### PR TITLE
feat(trace-explorer): Support coming from a metric

### DIFF
--- a/src/sentry/api/endpoints/organization_metrics.py
+++ b/src/sentry/api/endpoints/organization_metrics.py
@@ -563,23 +563,23 @@ class OrganizationMetricsSamplesEndpoint(OrganizationEventsV2EndpointBase):
                 raise ParseError(f"Unsupported sort: {sort} for MRI")
 
         executor = executor_cls(
-            serialized["mri"],
-            params,
-            snuba_params,
-            serialized["field"],
-            serialized.get("operation"),
-            serialized.get("query", ""),
-            serialized.get("min"),
-            serialized.get("max"),
-            serialized.get("sort"),
-            rollup,
-            Referrer.API_ORGANIZATION_METRICS_SAMPLES,
+            mri=serialized["mri"],
+            params=params,
+            snuba_params=snuba_params,
+            fields=serialized["field"],
+            operation=serialized.get("operation"),
+            query=serialized.get("query", ""),
+            min=serialized.get("min"),
+            max=serialized.get("max"),
+            sort=serialized.get("sort"),
+            rollup=rollup,
+            referrer=Referrer.API_ORGANIZATION_METRICS_SAMPLES,
         )
 
         with handle_query_errors():
             return self.paginate(
                 request=request,
-                paginator=GenericOffsetPaginator(data_fn=executor.execute),
+                paginator=GenericOffsetPaginator(data_fn=executor.get_matching_spans),
                 on_results=lambda results: self.handle_results_with_meta(
                     request,
                     organization,

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1700,6 +1700,12 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )  # hours
 register(
+    "performance.traces.trace-explorer-max-trace-ids-per-chunk",
+    type=Int,
+    default=2500,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)  # hours
+register(
     "performance.traces.span_query_minimum_spans",
     type=Int,
     default=10000,

--- a/src/sentry/snuba/referrer.py
+++ b/src/sentry/snuba/referrer.py
@@ -437,6 +437,7 @@ class Referrer(Enum):
     API_STARFISH_MOBILE_STARTUP_SPAN_TABLE = "api.starfish.mobile-spartup-span-table"
     API_STARFISH_MOBILE_STARTUP_LOADED_LIBRARIES = "api.starfish.mobile-startup-loaded-libraries"
     API_STARFISH_MOBILE_STARTUP_TOTALS = "api.starfish.mobile-startup-totals"
+    API_TRACE_EXPLORER_METRICS_SPANS_LIST = "api.trace-explorer.metrics-spans-list"
     API_TRACE_EXPLORER_SPANS_LIST = "api.trace-explorer.spans-list"
     API_TRACE_EXPLORER_TRACES_META = "api.trace-explorer.traces-meta"
 

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -1484,6 +1484,7 @@ class BaseSpansTestCase(SnubaTestCase):
         tags: Mapping[str, Any] | None = None,
         measurements: Mapping[str, int | float] | None = None,
         timestamp: datetime | None = None,
+        store_metrics_summary: Mapping[str, Sequence[Mapping[str, Any]]] | None = None,
     ):
         if span_id is None:
             span_id = self._random_span_id()
@@ -1513,10 +1514,15 @@ class BaseSpansTestCase(SnubaTestCase):
             payload["measurements"] = {
                 measurement: {"value": value} for measurement, value in measurements.items()
             }
+        if store_metrics_summary:
+            payload["_metrics_summary"] = store_metrics_summary
         if parent_span_id:
             payload["parent_span_id"] = parent_span_id
 
         self.store_span(payload)
+
+        if "_metrics_summary" in payload:
+            self.store_metrics_summary(payload)
 
     def store_indexed_span(
         self,

--- a/tests/sentry/api/endpoints/test_organization_traces.py
+++ b/tests/sentry/api/endpoints/test_organization_traces.py
@@ -1,3 +1,4 @@
+from datetime import timedelta
 from uuid import uuid4
 
 import pytest
@@ -5,6 +6,7 @@ from django.urls import reverse
 from rest_framework.exceptions import ErrorDetail
 
 from sentry.api.endpoints.organization_traces import process_breakdowns
+from sentry.snuba.metrics.naming_layer.mri import SpanMRI, TransactionMRI
 from sentry.testutils.cases import APITestCase, BaseSpansTestCase
 from sentry.testutils.helpers.datetime import before_now
 from sentry.utils.samples import load_data
@@ -27,6 +29,167 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
                 format="json",
                 **kwargs,
             )
+
+    def double_write_segment(
+        self,
+        *,
+        project_id,
+        trace_id,
+        transaction_id,
+        span_id,
+        timestamp,
+        duration,
+        **kwargs,
+    ):
+        # first write to the transactions dataset
+        end_timestamp = timestamp + timedelta(microseconds=duration * 1000)
+        data = load_data(
+            "transaction",
+            start_timestamp=timestamp,
+            timestamp=end_timestamp,
+            trace=trace_id,
+            span_id=span_id,
+            spans=[],
+            event_id=transaction_id,
+        )
+        data["measurements"] = {"lcp": {"value": duration}}
+        if tags := kwargs.get("tags", {}):
+            data["tags"] = [[key, val] for key, val in tags.items()]
+
+        self.store_event(
+            data=data,
+            project_id=project_id,
+        )
+
+        self.store_segment(
+            project_id=project_id,
+            trace_id=trace_id,
+            transaction_id=transaction_id,
+            span_id=span_id,
+            timestamp=timestamp,
+            duration=duration,
+            **kwargs,
+        )
+
+    def create_mock_traces(self):
+        project_1 = self.create_project()
+        project_2 = self.create_project()
+
+        # Hack: ensure that no span ids with leading 0s are generated for the test
+        span_ids = ["1" + uuid4().hex[:15] for _ in range(8)]
+        tags = ["", "bar", "bar", "baz", "", "bar", "baz"]
+        timestamps = []
+
+        trace_id_1 = uuid4().hex
+        timestamps.append(before_now(days=0, minutes=10).replace(microsecond=0))
+        self.double_write_segment(
+            project_id=project_1.id,
+            trace_id=trace_id_1,
+            transaction_id=uuid4().hex,
+            span_id=span_ids[0],
+            timestamp=timestamps[-1],
+            transaction="foo",
+            duration=60_100,
+            exclusive_time=60_100,
+        )
+        for i in range(1, 4):
+            timestamps.append(before_now(days=0, minutes=9, seconds=45 - i).replace(microsecond=0))
+            self.double_write_segment(
+                project_id=project_2.id,
+                trace_id=trace_id_1,
+                transaction_id=uuid4().hex,
+                span_id=span_ids[i],
+                parent_span_id=span_ids[0],
+                timestamp=timestamps[-1],
+                transaction="bar",
+                duration=30_000 + i,
+                exclusive_time=30_000 + i,
+                tags={"foo": tags[i]},
+            )
+
+        trace_id_2 = uuid4().hex
+        txn_id_2 = uuid4().hex
+        timestamps.append(before_now(days=0, minutes=20).replace(microsecond=0))
+        self.double_write_segment(
+            project_id=project_1.id,
+            trace_id=trace_id_2,
+            transaction_id=txn_id_2,
+            span_id=span_ids[4],
+            timestamp=timestamps[-1],
+            transaction="bar",
+            duration=90_123,
+            exclusive_time=90_123,
+        )
+        for i in range(5, 7):
+            timestamps.append(before_now(days=0, minutes=19, seconds=55 - i).replace(microsecond=0))
+            self.double_write_segment(
+                project_id=project_2.id,
+                trace_id=trace_id_2,
+                transaction_id=uuid4().hex,
+                span_id=span_ids[i],
+                parent_span_id=span_ids[4],
+                timestamp=timestamps[-1],
+                transaction="baz",
+                duration=20_000 + i,
+                exclusive_time=20_000 + i,
+                tags={"foo": tags[i]},
+            )
+        timestamps.append(before_now(days=0, minutes=20).replace(microsecond=0))
+
+        trace_id_3 = uuid4().hex
+        self.double_write_segment(
+            project_id=project_1.id,
+            trace_id=trace_id_3,
+            transaction_id=uuid4().hex,
+            span_id=span_ids[7],
+            timestamp=timestamps[-1],
+            transaction="qux",
+            duration=40_000,
+            tags={"foo": "qux"},
+            measurements={
+                measurement: 40_000
+                for i, measurement in enumerate(
+                    [
+                        "score.total",
+                        "score.inp",
+                        "score.weight.inp",
+                        "http.response_content_length",
+                        "http.decoded_response_content_length",
+                        "http.response_transfer_size",
+                    ]
+                )
+            },
+            store_metrics_summary={
+                "d:custom/value@millisecond": [
+                    {
+                        "min": 40_000,
+                        "max": 40_000,
+                        "sum": 40_000,
+                        "count": 1,
+                        "tags": {"foo": "qux"},
+                    }
+                ]
+            },
+        )
+
+        error_data = load_data("javascript", timestamp=timestamps[0])
+        error_data["contexts"]["trace"] = {
+            "type": "trace",
+            "trace_id": trace_id_1,
+            "span_id": span_ids[0],
+        }
+        error_data["tags"] = [["transaction", "foo"]]
+        self.store_event(error_data, project_id=project_1.id)
+
+        return (
+            project_1,
+            project_2,
+            trace_id_1,
+            trace_id_2,
+            trace_id_3,
+            timestamps,
+            span_ids,
+        )
 
     def test_no_feature(self):
         query = {
@@ -115,6 +278,22 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
             ),
         }
 
+    def test_unsupported_mri(self):
+        query = {
+            "project": [self.project.id],
+            "field": ["id"],
+            "maxSpansPerTrace": 1,
+            "mri": "d:spans/made_up@none",
+        }
+
+        response = self.do_request(query)
+        assert response.status_code == 400, response.data
+        assert response.data == {
+            "detail": ErrorDetail(
+                string="Unsupported MRI: d:spans/made_up@none", code="parse_error"
+            ),
+        }
+
     def test_no_traces(self):
         query = {
             "project": [self.project.id],
@@ -149,76 +328,15 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
         assert response.status_code == 200, response.data
 
     def test_matching_tag(self):
-        project_1 = self.create_project()
-        project_2 = self.create_project()
-
-        # Hack: ensure that no span ids with leading 0s are generated for the test
-        span_ids = ["1" + uuid4().hex[:15] for _ in range(7)]
-        tags = ["", "bar", "bar", "baz", "", "bar", "baz"]
-        timestamps = []
-
-        trace_id_1 = uuid4().hex
-        timestamps.append(before_now(days=0, minutes=10).replace(microsecond=0))
-        self.store_segment(
-            project_1.id,
+        (
+            project_1,
+            project_2,
             trace_id_1,
-            uuid4().hex,
-            span_id=span_ids[0],
-            timestamp=timestamps[-1],
-            transaction="foo",
-            duration=60_100,
-            exclusive_time=60_100,
-        )
-        for i in range(1, 4):
-            timestamps.append(before_now(days=0, minutes=9, seconds=45 - i).replace(microsecond=0))
-            self.store_segment(
-                project_2.id,
-                trace_id_1,
-                uuid4().hex,
-                span_id=span_ids[i],
-                parent_span_id=span_ids[0],
-                timestamp=timestamps[-1],
-                transaction="bar",
-                duration=30_000 + i,
-                exclusive_time=30_000 + i,
-                tags={"foo": tags[i]},
-            )
-
-        trace_id_2 = uuid4().hex
-        timestamps.append(before_now(days=0, minutes=20).replace(microsecond=0))
-        self.store_segment(
-            project_1.id,
             trace_id_2,
-            uuid4().hex,
-            span_id=span_ids[4],
-            timestamp=timestamps[-1],
-            transaction="bar",
-            duration=90_123,
-            exclusive_time=90_123,
-        )
-        for i in range(5, 7):
-            timestamps.append(before_now(days=0, minutes=19, seconds=55 - i).replace(microsecond=0))
-            self.store_segment(
-                project_2.id,
-                trace_id_2,
-                uuid4().hex,
-                span_id=span_ids[i],
-                parent_span_id=span_ids[4],
-                timestamp=timestamps[-1],
-                transaction="baz",
-                duration=20_000 + i,
-                exclusive_time=20_000 + i,
-                tags={"foo": tags[i]},
-            )
-
-        error_data = load_data("javascript", timestamp=timestamps[0])
-        error_data["contexts"]["trace"] = {
-            "type": "trace",
-            "trace_id": trace_id_1,
-            "span_id": span_ids[0],
-        }
-        error_data["tags"] = [["transaction", "foo"]]
-        self.store_event(error_data, project_id=project_1.id)
+            _,
+            timestamps,
+            span_ids,
+        ) = self.create_mock_traces()
 
         for q in [
             [
@@ -357,6 +475,76 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
                 ],
                 key=lambda trace: trace["trace"],
             )
+
+    def test_matching_tag_metrics(self):
+        (
+            project_1,
+            _,
+            _,
+            _,
+            trace_id_3,
+            timestamps,
+            span_ids,
+        ) = self.create_mock_traces()
+
+        for mri in [
+            TransactionMRI.DURATION.value,
+            "d:transactions/measurements.lcp@millisecond",
+            SpanMRI.DURATION.value,
+            SpanMRI.SELF_TIME.value,
+            "d:spans/webvital.score.total@ratio",
+            "d:spans/webvital.score.inp@ratio",
+            "d:spans/webvital.score.weight.inp@ratio",
+            "d:spans/http.response_content_length@byte",
+            "d:spans/http.decoded_response_content_length@byte",
+            "d:spans/http.response_transfer_size@byte",
+            "d:custom/value@millisecond",
+        ]:
+            query = {
+                "mri": mri,
+                "metricsQuery": ["foo:qux"],
+                "project": [project_1.id],
+                "field": ["id", "parent_span", "span.duration"],
+                "query": ["foo:qux"],
+                "suggestedQuery": ["foo:qux"],
+                "maxSpansPerTrace": 3,
+                "sort": ["-span.duration"],
+            }
+
+            response = self.do_request(query)
+            assert response.status_code == 200, (mri, response.data)
+
+            result_data = sorted(response.data["data"], key=lambda trace: trace["trace"])
+
+            assert result_data == [
+                {
+                    "trace": trace_id_3,
+                    "numErrors": 0,
+                    "numOccurrences": 0,
+                    "numSpans": 1,
+                    "project": project_1.slug,
+                    "name": "qux",
+                    "duration": 40_000,
+                    "start": int(timestamps[7].timestamp() * 1000),
+                    "end": int(timestamps[7].timestamp() * 1000) + 40_000,
+                    "breakdowns": [
+                        {
+                            "project": project_1.slug,
+                            "start": int(timestamps[7].timestamp() * 1000),
+                            "end": int(timestamps[7].timestamp() * 1000) + 40_000,
+                            "kind": "project",
+                        },
+                    ],
+                    "spans": [
+                        {
+                            "id": span_ids[7],
+                            "parent_span": "00",
+                            "span.duration": 40_000.0,
+                        },
+                    ],
+                    "suggestedSpans": [],
+                },
+            ], mri
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This supports querying for traces when coming from a metric.

Note: This performs an application-level join and is not performant at all as it requires going back and forth between querying on the metric and spans.