### PR TITLE
ref(crons): Include monitor name in audit log entries

### DIFF
--- a/src/sentry/audit_log/register.py
+++ b/src/sentry/audit_log/register.py
@@ -258,17 +258,20 @@ default_manager.add(
 )
 default_manager.add(
     AuditLogEvent(
-        event_id=120, name="MONITOR_ADD", api_name="monitor.add", template="Monitor added"
+        event_id=120, name="MONITOR_ADD", api_name="monitor.add", template="added monitor {name}"
     )
 )
 default_manager.add(
     AuditLogEvent(
-        event_id=121, name="MONITOR_EDIT", api_name="monitor.edit", template="Monitor edited"
+        event_id=121, name="MONITOR_EDIT", api_name="monitor.edit", template="edited monitor {name}"
     )
 )
 default_manager.add(
     AuditLogEvent(
-        event_id=122, name="MONITOR_REMOVE", api_name="monitor.remove", template="Monitor removed"
+        event_id=122,
+        name="MONITOR_REMOVE",
+        api_name="monitor.remove",
+        template="removed monitor {name}",
     )
 )
 default_manager.add(
@@ -276,7 +279,7 @@ default_manager.add(
         event_id=123,
         name="MONITOR_ENVIRONMENT_REMOVE",
         api_name="monitor.environment.remove",
-        template="Monitor environment removed",
+        template="removed an environment from monitor {name}",
     )
 )
 default_manager.add(
@@ -284,7 +287,7 @@ default_manager.add(
         event_id=124,
         name="MONITOR_ENVIRONMENT_EDIT",
         api_name="monitor.environment.edit",
-        template="Monitor environment edited",
+        template="edited an environment from monitor {name}",
     )
 )
 default_manager.add(events.InternalIntegrationAddAuditLogEvent())


### PR DESCRIPTION
At the very least, adds the monitor name to the audit log entry to indicate which monitor was removed, added, edited, etc... Also changes the language a bit here to match the structure

example:
<img width="937" alt="image" src="https://github.com/getsentry/sentry/assets/9372512/63220e4c-ec0e-4ab5-aa54-0a3b3a7fdd00">
