### PR TITLE
ref(slack): :white_circle: for actions

### DIFF
--- a/src/sentry/integrations/slack/message_builder/__init__.py
+++ b/src/sentry/integrations/slack/message_builder/__init__.py
@@ -28,7 +28,6 @@ INCIDENT_COLOR_MAPPING = {
 SLACK_URL_FORMAT = "<{url}|{text}>"
 
 LEVEL_TO_EMOJI = {
-    "_actioned_issue": ":white_circle:",
     "_incident_resolved": ":green_circle:",
     "debug": ":bug:",
     "error": ":red_circle:",
@@ -37,6 +36,8 @@ LEVEL_TO_EMOJI = {
     "warning": ":large_yellow_circle:",
 }
 
+ACTION_EMOJI = ":white_circle:"
+
 CATEGORY_TO_EMOJI = {
     GroupCategory.PERFORMANCE: ":large_blue_circle: :chart_with_upwards_trend:",
     GroupCategory.FEEDBACK: ":large_blue_circle: :busts_in_silhouette:",
@@ -44,7 +45,7 @@ CATEGORY_TO_EMOJI = {
 }
 
 ACTIONED_CATEGORY_TO_EMOJI = {
-    GroupCategory.PERFORMANCE: ":white_circle: :chart_with_upwards_trend:",
-    GroupCategory.FEEDBACK: ":white_circle: :busts_in_silhouette:",
-    GroupCategory.CRON: ":white_circle: :spiral_calendar_pad:",
+    GroupCategory.PERFORMANCE: ACTION_EMOJI + " :chart_with_upwards_trend:",
+    GroupCategory.FEEDBACK: ACTION_EMOJI + " :busts_in_silhouette:",
+    GroupCategory.CRON: ACTION_EMOJI + " :spiral_calendar_pad:",
 }

--- a/src/sentry/integrations/slack/message_builder/__init__.py
+++ b/src/sentry/integrations/slack/message_builder/__init__.py
@@ -28,7 +28,7 @@ INCIDENT_COLOR_MAPPING = {
 SLACK_URL_FORMAT = "<{url}|{text}>"
 
 LEVEL_TO_EMOJI = {
-    "_actioned_issue": ":white_check_mark:",
+    "_actioned_issue": ":white_circle:",
     "_incident_resolved": ":green_circle:",
     "debug": ":bug:",
     "error": ":red_circle:",
@@ -38,7 +38,7 @@ LEVEL_TO_EMOJI = {
 }
 
 CATEGORY_TO_EMOJI = {
-    GroupCategory.PERFORMANCE: ":large_blue_circle: :chart_with_upwards_trend:",
-    GroupCategory.FEEDBACK: ":large_blue_circle: :busts_in_silhouette:",
-    GroupCategory.CRON: ":large_yellow_circle: :spiral_calendar_pad:",
+    GroupCategory.PERFORMANCE: [":large_blue_circle:", ":chart_with_upwards_trend:"],
+    GroupCategory.FEEDBACK: [":large_blue_circle:", ":busts_in_silhouette:"],
+    GroupCategory.CRON: [":large_yellow_circle:", ":spiral_calendar_pad:"],
 }

--- a/src/sentry/integrations/slack/message_builder/__init__.py
+++ b/src/sentry/integrations/slack/message_builder/__init__.py
@@ -38,7 +38,13 @@ LEVEL_TO_EMOJI = {
 }
 
 CATEGORY_TO_EMOJI = {
-    GroupCategory.PERFORMANCE: [":large_blue_circle:", ":chart_with_upwards_trend:"],
-    GroupCategory.FEEDBACK: [":large_blue_circle:", ":busts_in_silhouette:"],
-    GroupCategory.CRON: [":large_yellow_circle:", ":spiral_calendar_pad:"],
+    GroupCategory.PERFORMANCE: ":large_blue_circle: :chart_with_upwards_trend:",
+    GroupCategory.FEEDBACK: ":large_blue_circle: :busts_in_silhouette:",
+    GroupCategory.CRON: ":large_yellow_circle: :spiral_calendar_pad:",
+}
+
+ACTIONED_CATEGORY_TO_EMOJI = {
+    GroupCategory.PERFORMANCE: ":white_circle: :chart_with_upwards_trend:",
+    GroupCategory.FEEDBACK: ":white_circle: :busts_in_silhouette:",
+    GroupCategory.CRON: ":white_circle: :spiral_calendar_pad:",
 }

--- a/src/sentry/integrations/slack/message_builder/issues.py
+++ b/src/sentry/integrations/slack/message_builder/issues.py
@@ -382,7 +382,10 @@ def build_actions(
     """Having actions means a button will be shown on the Slack message e.g. ignore, resolve, assign."""
     if actions and identity:
         text = get_action_text(text, actions, identity)
-        return [], text, True
+        if features.has("organizations:slack-improvements", project.organization):
+            # if actions are taken, return True at the end to show the white circle emoji
+            return [], text, True
+        return [], text, False
 
     status = group.get_status()
 
@@ -504,9 +507,6 @@ class SlackIssuesMessageBuilder(BlockSlackMessageBuilder):
             )
         else:
             payload_actions = []
-            has_action = False
-
-        if not features.has("organizations:slack-improvements", self.group.project.organization):
             has_action = False
 
         rule_id = None

--- a/tests/sentry/integrations/slack/test_message_builder.py
+++ b/tests/sentry/integrations/slack/test_message_builder.py
@@ -1151,7 +1151,7 @@ class ActionsTest(TestCase):
 
         assert build_actions(
             group, self.project, "test txt", [MessageAction(name="TEST")], MOCKIDENTITY
-        ) == ([], "", "_actioned_issue")
+        ) == ([], "", True)
 
     def _assert_message_actions_list(self, actions, expected):
         actions_dict = [

--- a/tests/sentry/integrations/slack/test_message_builder.py
+++ b/tests/sentry/integrations/slack/test_message_builder.py
@@ -1150,7 +1150,7 @@ class ActionsTest(TestCase):
         MOCKIDENTITY = Mock()
 
         assert build_actions(
-            group, self.project, "test txt", "red", [MessageAction(name="TEST")], MOCKIDENTITY
+            group, self.project, "test txt", [MessageAction(name="TEST")], MOCKIDENTITY
         ) == ([], "", "_actioned_issue")
 
     def _assert_message_actions_list(self, actions, expected):
@@ -1171,9 +1171,7 @@ class ActionsTest(TestCase):
             "value": "unresolved:ongoing",
         }
 
-        res = build_actions(
-            group, self.project, "test txt", "red", [MessageAction(name="TEST")], None
-        )
+        res = build_actions(group, self.project, "test txt", [MessageAction(name="TEST")], None)
         self._assert_message_actions_list(
             res[0],
             expected,
@@ -1190,9 +1188,7 @@ class ActionsTest(TestCase):
             "type": "button",
             "value": "unresolved:ongoing",
         }
-        res = build_actions(
-            group, self.project, "test txt", "red", [MessageAction(name="TEST")], None
-        )
+        res = build_actions(group, self.project, "test txt", [MessageAction(name="TEST")], None)
         self._assert_message_actions_list(
             res[0],
             expected,
@@ -1209,9 +1205,7 @@ class ActionsTest(TestCase):
             "type": "button",
             "value": "archive_dialog",
         }
-        res = build_actions(
-            group, self.project, "test txt", "red", [MessageAction(name="TEST")], None
-        )
+        res = build_actions(group, self.project, "test txt", [MessageAction(name="TEST")], None)
         self._assert_message_actions_list(
             res[0],
             expected,
@@ -1228,9 +1222,7 @@ class ActionsTest(TestCase):
             "type": "button",
             "value": "archive_dialog",
         }
-        res = build_actions(
-            group, self.project, "test txt", "red", [MessageAction(name="TEST")], None
-        )
+        res = build_actions(group, self.project, "test txt", [MessageAction(name="TEST")], None)
         self._assert_message_actions_list(
             res[0],
             expected,
@@ -1238,9 +1230,7 @@ class ActionsTest(TestCase):
 
     def test_no_ignore_if_feedback(self):
         group = self.create_group(project=self.project, type=FeedbackGroup.type_id)
-        res = build_actions(
-            group, self.project, "test txt", "red", [MessageAction(name="TEST")], None
-        )
+        res = build_actions(group, self.project, "test txt", [MessageAction(name="TEST")], None)
         # no ignore action if feedback issue, so only assign and resolve
         assert len(res[0]) == 2
 
@@ -1249,9 +1239,7 @@ class ActionsTest(TestCase):
         group.status = GroupStatus.RESOLVED
         group.save()
 
-        res = build_actions(
-            group, self.project, "test txt", "red", [MessageAction(name="TEST")], None
-        )
+        res = build_actions(group, self.project, "test txt", [MessageAction(name="TEST")], None)
 
         self._assert_message_actions_list(
             res[0],
@@ -1270,9 +1258,7 @@ class ActionsTest(TestCase):
         self.project.flags.has_releases = False
         self.project.save()
 
-        res = build_actions(
-            group, self.project, "test txt", "red", [MessageAction(name="TEST")], None
-        )
+        res = build_actions(group, self.project, "test txt", [MessageAction(name="TEST")], None)
         self._assert_message_actions_list(
             res[0],
             {
@@ -1290,9 +1276,7 @@ class ActionsTest(TestCase):
         self.project.flags.has_releases = True
         self.project.save()
 
-        res = build_actions(
-            group, self.project, "test txt", "red", [MessageAction(name="TEST")], None
-        )
+        res = build_actions(group, self.project, "test txt", [MessageAction(name="TEST")], None)
         self._assert_message_actions_list(
             res[0],
             {
@@ -1310,9 +1294,7 @@ class ActionsTest(TestCase):
         self.project.flags.has_releases = True
         self.project.save()
 
-        res = build_actions(
-            group, self.project, "test txt", "red", [MessageAction(name="TEST")], None
-        )
+        res = build_actions(group, self.project, "test txt", [MessageAction(name="TEST")], None)
 
         self._assert_message_actions_list(
             res[0],

--- a/tests/sentry/integrations/slack/test_message_builder.py
+++ b/tests/sentry/integrations/slack/test_message_builder.py
@@ -46,6 +46,7 @@ from sentry.silo.base import SiloMode
 from sentry.testutils.cases import PerformanceIssueTestCase, TestCase
 from sentry.testutils.factories import DEFAULT_EVENT_DATA
 from sentry.testutils.helpers.datetime import before_now, freeze_time, iso_format
+from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.silo import assume_test_silo_mode
 from sentry.testutils.skips import requires_snuba
 from sentry.types.group import GroupSubStatus
@@ -1146,6 +1147,16 @@ class BuildMetricAlertAttachmentTest(TestCase):
 
 class ActionsTest(TestCase):
     def test_identity_and_action(self):
+        group = self.create_group(project=self.project)
+        MOCKIDENTITY = Mock()
+
+        assert build_actions(
+            group, self.project, "test txt", [MessageAction(name="TEST")], MOCKIDENTITY
+        ) == ([], "", False)
+
+    @with_feature("organizations:slack-improvements")
+    def test_identity_and_action_has_action(self):
+        # returns True to indicate to use the white circle emoji
         group = self.create_group(project=self.project)
         MOCKIDENTITY = Mock()
 

--- a/tests/sentry/integrations/slack/webhooks/actions/test_status.py
+++ b/tests/sentry/integrations/slack/webhooks/actions/test_status.py
@@ -194,8 +194,6 @@ class StatusActionTest(BaseEventTest, HybridCloudTestMixin):
             )
 
         assert resp.status_code == 200, resp.content
-        updated_blocks = json.loads(responses.calls[-1].request.body.decode())["blocks"]
-        assert ":white_circle:" in updated_blocks[0]["text"]["text"]
 
     def assign_issue_block_kit(self, original_message, selected_option, payload_data=None):
         if isinstance(selected_option, Team):

--- a/tests/sentry/integrations/slack/webhooks/actions/test_status.py
+++ b/tests/sentry/integrations/slack/webhooks/actions/test_status.py
@@ -341,6 +341,25 @@ class StatusActionTest(BaseEventTest, HybridCloudTestMixin):
         assert self.notification_text in update_data["blocks"][1]["text"]["text"]
         assert update_data["blocks"][2]["text"]["text"].endswith(expect_status)
         assert "via" not in update_data["blocks"][4]["elements"][0]["text"]
+        assert ":red_circle:" in update_data["blocks"][0]["text"]["text"]
+
+    @responses.activate
+    @with_feature("organizations:slack-improvements")
+    def test_archive_issue_until_escalating_block_kit_improvements(self):
+        original_message = self.get_original_message_block_kit(self.group.id)
+        self.archive_issue_block_kit(original_message, "ignored:archived_until_escalating")
+
+        self.group = Group.objects.get(id=self.group.id)
+        assert self.group.get_status() == GroupStatus.IGNORED
+        assert self.group.substatus == GroupSubStatus.UNTIL_ESCALATING
+
+        update_data = json.loads(responses.calls[1].request.body)
+
+        expect_status = f"*Issue archived by <@{self.external_id}>*"
+        assert self.notification_text in update_data["blocks"][1]["text"]["text"]
+        assert update_data["blocks"][2]["text"]["text"].endswith(expect_status)
+        assert "via" not in update_data["blocks"][4]["elements"][0]["text"]
+        assert ":white_circle:" in update_data["blocks"][0]["text"]["text"]
 
     @responses.activate
     def test_archive_issue_until_escalating_block_kit_through_unfurl(self):
@@ -601,6 +620,7 @@ class StatusActionTest(BaseEventTest, HybridCloudTestMixin):
         expect_status = f"*Issue assigned to {user2.get_display_name()} by <@{self.external_id}>*"
         assert self.notification_text in resp.data["blocks"][1]["text"]["text"]
         assert resp.data["blocks"][2]["text"]["text"].endswith(expect_status), resp.data["text"]
+        assert ":red_circle:" in resp.data["blocks"][0]["text"]["text"]
 
         # Assign to team
         resp = self.assign_issue_block_kit(original_message, self.team)
@@ -608,6 +628,44 @@ class StatusActionTest(BaseEventTest, HybridCloudTestMixin):
         expect_status = f"*Issue assigned to #{self.team.slug} by <@{self.external_id}>*"
         assert self.notification_text in resp.data["blocks"][1]["text"]["text"]
         assert resp.data["blocks"][2]["text"]["text"].endswith(expect_status), resp.data["text"]
+        assert ":red_circle:" in resp.data["blocks"][0]["text"]["text"]
+
+        # Assert group assignment activity recorded
+        group_activity = Activity.objects.filter(group=self.group)
+        assert group_activity.first().data == {
+            "assignee": str(user2.id),
+            "assigneeEmail": user2.email,
+            "assigneeType": "user",
+            "integration": ActivityIntegration.SLACK.value,
+        }
+        assert group_activity.last().data == {
+            "assignee": str(self.team.id),
+            "assigneeEmail": None,
+            "assigneeType": "team",
+            "integration": ActivityIntegration.SLACK.value,
+        }
+
+    @with_feature("organizations:slack-improvements")
+    def test_assign_issue_block_kit_improvements(self):
+        user2 = self.create_user(is_superuser=False)
+        self.create_member(user=user2, organization=self.organization, teams=[self.team])
+        original_message = self.get_original_message_block_kit(self.group.id)
+
+        # Assign to user
+        resp = self.assign_issue_block_kit(original_message, user2)
+        assert GroupAssignee.objects.filter(group=self.group, user_id=user2.id).exists()
+        expect_status = f"*Issue assigned to {user2.get_display_name()} by <@{self.external_id}>*"
+        assert self.notification_text in resp.data["blocks"][1]["text"]["text"]
+        assert resp.data["blocks"][2]["text"]["text"].endswith(expect_status), resp.data["text"]
+        assert ":white_circle:" in resp.data["blocks"][0]["text"]["text"]
+
+        # Assign to team
+        resp = self.assign_issue_block_kit(original_message, self.team)
+        assert GroupAssignee.objects.filter(group=self.group, team=self.team).exists()
+        expect_status = f"*Issue assigned to #{self.team.slug} by <@{self.external_id}>*"
+        assert self.notification_text in resp.data["blocks"][1]["text"]["text"]
+        assert resp.data["blocks"][2]["text"]["text"].endswith(expect_status), resp.data["text"]
+        assert ":white_circle:" in resp.data["blocks"][0]["text"]["text"]
 
         # Assert group assignment activity recorded
         group_activity = Activity.objects.filter(group=self.group)
@@ -931,6 +989,24 @@ class StatusActionTest(BaseEventTest, HybridCloudTestMixin):
         expect_status = f"*Issue resolved by <@{self.external_id}>*"
         assert self.notification_text in update_data["blocks"][1]["text"]["text"]
         assert update_data["blocks"][2]["text"]["text"] == expect_status
+        assert ":red_circle:" in update_data["blocks"][0]["text"]["text"]
+
+    @responses.activate
+    @with_feature("organizations:slack-improvements")
+    def test_resolve_issue_block_kit_improvements(self):
+        original_message = self.get_original_message_block_kit(self.group.id)
+        self.resolve_issue_block_kit(original_message, "resolved")
+
+        self.group = Group.objects.get(id=self.group.id)
+        assert self.group.get_status() == GroupStatus.RESOLVED
+        assert not GroupResolution.objects.filter(group=self.group)
+
+        update_data = json.loads(responses.calls[1].request.body)
+
+        expect_status = f"*Issue resolved by <@{self.external_id}>*"
+        assert self.notification_text in update_data["blocks"][1]["text"]["text"]
+        assert update_data["blocks"][2]["text"]["text"] == expect_status
+        assert ":white_circle:" in update_data["blocks"][0]["text"]["text"]
 
     @responses.activate
     def test_resolve_issue_block_kit_through_unfurl(self):

--- a/tests/sentry/integrations/slack/webhooks/actions/test_status.py
+++ b/tests/sentry/integrations/slack/webhooks/actions/test_status.py
@@ -194,6 +194,8 @@ class StatusActionTest(BaseEventTest, HybridCloudTestMixin):
             )
 
         assert resp.status_code == 200, resp.content
+        updated_blocks = json.loads(responses.calls[-1].request.body.decode())["blocks"]
+        assert ":white_circle:" in updated_blocks[0]["text"]["text"]
 
     def assign_issue_block_kit(self, original_message, selected_option, payload_data=None):
         if isinstance(selected_option, Team):


### PR DESCRIPTION
When somebody takes an action on an issue (resolves, archives, assigns) we used to change the bar color to white. Block kit doesn't have this functionality, but we can replace the circle emojis with a ⚪ instead.