### PR TITLE
fix(trace): display unique issues

### DIFF
--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/issues/issues.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/issues/issues.tsx
@@ -118,6 +118,21 @@ type IssueListProps = {
 };
 
 export function IssueList({issues, node, organization}: IssueListProps) {
+  const uniqueIssues = useMemo(() => {
+    const unique: TraceErrorOrIssue[] = [];
+    const seenIssues: Set<number> = new Set();
+
+    for (const issue of issues) {
+      if (seenIssues.has(issue.issue_id)) {
+        continue;
+      }
+      seenIssues.add(issue.issue_id);
+      unique.push(issue);
+    }
+
+    return unique;
+  }, [issues]);
+
   if (!issues.length) {
     return null;
   }
@@ -125,7 +140,7 @@ export function IssueList({issues, node, organization}: IssueListProps) {
   return (
     <StyledPanel>
       <IssueListHeader node={node} />
-      {issues.slice(0, MAX_DISPLAYED_ISSUES_COUNT).map((issue, index) => (
+      {uniqueIssues.slice(0, MAX_DISPLAYED_ISSUES_COUNT).map((issue, index) => (
         <Issue key={index} issue={issue} organization={organization} />
       ))}
     </StyledPanel>

--- a/static/app/views/performance/newTraceDetails/traceHeader.tsx
+++ b/static/app/views/performance/newTraceDetails/traceHeader.tsx
@@ -97,7 +97,12 @@ export function TraceHeader({
     metaResults.isLoading;
 
   const uniqueErrorIssues = useMemo(() => {
+    if (!traceNode) {
+      return [];
+    }
+
     const unique: TraceErrorOrIssue[] = [];
+
     const seenIssues: Set<number> = new Set();
 
     for (const issue of traceNode.errors) {
@@ -112,6 +117,10 @@ export function TraceHeader({
   }, [traceNode]);
 
   const uniquePerformanceIssues = useMemo(() => {
+    if (!traceNode) {
+      return [];
+    }
+
     const unique: TraceErrorOrIssue[] = [];
     const seenIssues: Set<number> = new Set();
 

--- a/static/app/views/performance/newTraceDetails/traceHeader.tsx
+++ b/static/app/views/performance/newTraceDetails/traceHeader.tsx
@@ -1,4 +1,4 @@
-import {Fragment} from 'react';
+import {Fragment, useMemo} from 'react';
 import styled from '@emotion/styled';
 
 import GuideAnchor from 'sentry/components/assistant/guideAnchor';
@@ -13,6 +13,7 @@ import type {EventTransaction, Organization} from 'sentry/types';
 import {getShortEventId} from 'sentry/utils/events';
 import {getDuration} from 'sentry/utils/formatters';
 import type {
+  TraceErrorOrIssue,
   TraceFullDetailed,
   TraceMeta,
   TraceSplitResults,
@@ -88,25 +89,52 @@ export function TraceHeader({
   tree,
   traceID,
 }: TraceHeaderProps) {
-  if (traces?.transactions.length === 0 && traces.orphan_errors.length === 0) {
-    return <TraceHeaderEmptyTrace />;
-  }
-
   const traceNode = tree.root.children[0];
-
-  if (!(traceNode && isTraceNode(traceNode))) {
-    throw new Error('Expected a trace node');
-  }
-
-  const errors = traceNode.errors.size || metaResults.data?.errors || 0;
-  const performanceIssues =
-    traceNode.performance_issues.size || metaResults.data?.performance_issues || 0;
-  const errorsAndIssuesCount = errors + performanceIssues;
 
   const replay_id = rootEventResults?.data?.contexts?.replay?.replay_id;
   const showLoadingIndicator =
     (rootEventResults.isLoading && rootEventResults.fetchStatus !== 'idle') ||
     metaResults.isLoading;
+
+  const uniqueErrorIssues = useMemo(() => {
+    const unique: TraceErrorOrIssue[] = [];
+    const seenIssues: Set<number> = new Set();
+
+    for (const issue of traceNode.errors) {
+      if (seenIssues.has(issue.issue_id)) {
+        continue;
+      }
+      seenIssues.add(issue.issue_id);
+      unique.push(issue);
+    }
+
+    return unique;
+  }, [traceNode]);
+
+  const uniquePerformanceIssues = useMemo(() => {
+    const unique: TraceErrorOrIssue[] = [];
+    const seenIssues: Set<number> = new Set();
+
+    for (const issue of traceNode.performance_issues) {
+      if (seenIssues.has(issue.issue_id)) {
+        continue;
+      }
+      seenIssues.add(issue.issue_id);
+      unique.push(issue);
+    }
+
+    return unique;
+  }, [traceNode]);
+
+  const uniqueIssuesCount = uniqueErrorIssues.length + uniquePerformanceIssues.length;
+
+  if (traces?.transactions.length === 0 && traces.orphan_errors.length === 0) {
+    return <TraceHeaderEmptyTrace />;
+  }
+
+  if (!(traceNode && isTraceNode(traceNode))) {
+    throw new Error('Expected a trace node');
+  }
 
   return (
     <TraceHeaderContainer>
@@ -204,14 +232,16 @@ export function TraceHeader({
           bodyText={
             <Tooltip
               title={
-                errorsAndIssuesCount > 0 ? (
+                uniqueIssuesCount > 0 ? (
                   <Fragment>
-                    <div>{tn('%s error issue', '%s error issues', errors)}</div>
+                    <div>
+                      {tn('%s error issue', '%s error issues', uniqueErrorIssues.length)}
+                    </div>
                     <div>
                       {tn(
                         '%s performance issue',
                         '%s performance issues',
-                        performanceIssues
+                        uniquePerformanceIssues.length
                       )}
                     </div>
                   </Fragment>
@@ -222,9 +252,9 @@ export function TraceHeader({
             >
               {metaResults.isLoading ? (
                 <LoadingIndicator size={20} mini />
-              ) : errorsAndIssuesCount > 0 ? (
+              ) : uniqueIssuesCount > 0 ? (
                 <TraceDrawerComponents.IssuesLink>
-                  {errorsAndIssuesCount}
+                  {uniqueIssuesCount}
                 </TraceDrawerComponents.IssuesLink>
               ) : (
                 '\u2014'


### PR DESCRIPTION
We were previously displaying multiple instances of the same issue which is noisy and not very valuable as we only show a max of 3 issues. Additionally, this change brings us in line with what users see when they open the issues page for this trace.