### PR TITLE
ref: inline SENTRY_ANALYTICS_ALIASES to remove import cycle

### DIFF
--- a/src/sentry/analytics/__init__.py
+++ b/src/sentry/analytics/__init__.py
@@ -6,7 +6,6 @@ from .base import Analytics
 from .event import Event
 from .event_manager import default_manager
 from .map import Map
-from .utils import get_backend_path
 
 __all__ = (
     "Analytics",
@@ -18,9 +17,19 @@ __all__ = (
     "setup",
 )
 
+_SENTRY_ANALYTICS_ALIASES = {
+    "noop": "sentry.analytics.Analytics",
+    "pubsub": "sentry.analytics.pubsub.PubSubAnalytics",
+}
+
+
+def _get_backend_path(path: str) -> str:
+    return _SENTRY_ANALYTICS_ALIASES.get(path, path)
+
+
 backend = LazyServiceWrapper(
     backend_base=Analytics,
-    backend_path=get_backend_path(options.get("analytics.backend")),
+    backend_path=_get_backend_path(options.get("analytics.backend")),
     options=options.get("analytics.options"),
 )
 

--- a/src/sentry/analytics/utils.py
+++ b/src/sentry/analytics/utils.py
@@ -3,17 +3,7 @@ from __future__ import annotations
 from collections.abc import Mapping, Sequence
 from typing import Any
 
-from django.conf import settings
-
 from sentry.analytics.attribute import Attribute
-
-
-def get_backend_path(backend_: str) -> str:
-    try:
-        backend_ = settings.SENTRY_ANALYTICS_ALIASES[backend_]
-    except KeyError:
-        pass
-    return backend_
 
 
 def get_data(attributes: Sequence[Attribute], items: dict[str, Any]) -> Mapping[str, Any | None]:

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -2151,11 +2151,6 @@ SENTRY_FILESTORE_ALIASES = {
     "gcs": "sentry.filestore.gcs.GoogleCloudStorage",
 }
 
-SENTRY_ANALYTICS_ALIASES = {
-    "noop": "sentry.analytics.Analytics",
-    "pubsub": "sentry.analytics.pubsub.PubSubAnalytics",
-}
-
 # set of backends that do not support needing SMTP mail.* settings
 # This list is a bit fragile and hardcoded, but it's unlikely that
 # a user will be using a different backend that also mandates SMTP


### PR DESCRIPTION
this setting is not overridden in any environment and has not changed since introduction

resolves this cycle with latest `django-stubs`:

```
src/sentry/analytics/utils.py:13: error: Import cycle from Django settings module prevents type inference for 'SENTRY_ANALYTICS_ALIASES'  [misc]
```

<!-- Describe your PR here. -->