### PR TITLE
ref: fix settings import cycle for sentry.logging.handlers

### DIFF
--- a/src/sentry/logging/handlers.py
+++ b/src/sentry/logging/handlers.py
@@ -53,15 +53,12 @@ _json_encoder_no_skipkeys = _json_encoder(skipkeys=False)
 
 class JSONRenderer:
     def __call__(self, logger, name, event_dict):
-        # importing inside of the function to avoid circular imports
-        from django.conf import settings
-
         try:
             return _json_encoder_no_skipkeys.encode(event_dict)
         except Exception:
             logging.warning("Failed to serialize event", exc_info=True)
             # in Production, we want to skip non-serializable keys, rather than raise an exception
-            if settings.DEBUG:
+            if logging.raiseExceptions:
                 raise
             else:
                 return _json_encoder_skipkeys.encode(event_dict)

--- a/tests/sentry/logging/test_handler.py
+++ b/tests/sentry/logging/test_handler.py
@@ -93,14 +93,14 @@ def test_emit_invalid_keys_prod(handler):
     handler.emit(make_logrecord(), logger=logger)
 
 
-@mock.patch("django.conf.settings.DEBUG", True)
+@mock.patch("logging.raiseExceptions", True)
 def test_JSONRenderer_nonprod():
     renderer = JSONRenderer()
     with pytest.raises(TypeError):
         renderer(None, None, {"foo": {mock.Mock(): "foo"}})
 
 
-@mock.patch("django.conf.settings.DEBUG", False)
+@mock.patch("logging.raiseExceptions", False)
 def test_JSONRenderer_prod():
     renderer = JSONRenderer()
     renderer(None, None, {"foo": {mock.Mock(): "foo"}})


### PR DESCRIPTION
fixes this typing cycle with django-stubs 5.x:

```
src/sentry/logging/handlers.py:64: error: Import cycle from Django settings module prevents type inference for 'DEBUG'  [misc]
```

<!-- Describe your PR here. -->