### PR TITLE
feat(performance):Adds discover spans metrics support for queue module mertics and tags

### DIFF
--- a/src/sentry/search/events/constants.py
+++ b/src/sentry/search/events/constants.py
@@ -322,6 +322,8 @@ DEFAULT_METRIC_TAGS = {
     "transaction.op",
     "transaction.status",
     "span.op",
+    "trace.status",
+    "messaging.destination.name",
 }
 SPAN_METRICS_MAP = {
     "user": "s:spans/user@none",
@@ -335,6 +337,7 @@ SPAN_METRICS_MAP = {
     "mobile.frozen_frames": "g:spans/mobile.frozen_frames@none",
     "mobile.total_frames": "g:spans/mobile.total_frames@none",
     "mobile.frames_delay": "g:spans/mobile.frames_delay@second",
+    "messaging.message.receive.latency": "g:spans/messaging.message.receive.latency@millisecond",
 }
 SELF_TIME_LIGHT = "d:spans/exclusive_time_light@millisecond"
 # 50 to match the size of tables in the UI + 1 for pagination reasons
@@ -352,6 +355,11 @@ METRIC_DURATION_COLUMNS = {
     key
     for key, value in METRICS_MAP.items()
     if value.endswith("@millisecond") and value.startswith("d:")
+}
+SPAN_METRIC_GAUGE_DURATION_COLUMNS = {
+    key
+    for key, value in SPAN_METRICS_MAP.items()
+    if value.endswith("@millisecond") and value.startswith("g:")
 }
 SPAN_METRIC_DURATION_COLUMNS = {
     key

--- a/src/sentry/search/events/constants.py
+++ b/src/sentry/search/events/constants.py
@@ -356,11 +356,6 @@ METRIC_DURATION_COLUMNS = {
     for key, value in METRICS_MAP.items()
     if value.endswith("@millisecond") and value.startswith("d:")
 }
-SPAN_METRIC_GAUGE_DURATION_COLUMNS = {
-    key
-    for key, value in SPAN_METRICS_MAP.items()
-    if value.endswith("@millisecond") and value.startswith("g:")
-}
 SPAN_METRIC_DURATION_COLUMNS = {
     key
     for key, value in SPAN_METRICS_MAP.items()

--- a/src/sentry/search/events/datasets/spans_metrics.py
+++ b/src/sentry/search/events/datasets/spans_metrics.py
@@ -155,9 +155,9 @@ class SpansMetricsDatasetConfig(DatasetConfig):
                             "span.self_time",
                             fields.MetricArg(
                                 "column",
-                                allowed_columns=constants.SPAN_METRIC_DURATION_COLUMNS
-                                | constants.SPAN_METRIC_BYTES_COLUMNS
-                                | constants.SPAN_METRIC_GAUGE_DURATION_COLUMNS,
+                                allowed_columns=constants.SPAN_METRIC_DURATION_COLUMNS.union(
+                                    constants.SPAN_METRIC_BYTES_COLUMNS
+                                ),
                             ),
                         ),
                     ],

--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -155,6 +155,8 @@ SPAN_COLUMN_MAP = {
     "origin.transaction": "sentry_tags[transaction]",
     "is_transaction": "is_segment",
     "sdk.name": "sentry_tags[sdk.name]",
+    "trace.status": "sentry_tags[trace.status]",
+    "messaging.destination.name": "sentry_tags[messaging.destination.name]",
 }
 
 METRICS_SUMMARIES_COLUMN_MAP = {

--- a/tests/snuba/api/endpoints/test_organization_events_stats_span_metrics.py
+++ b/tests/snuba/api/endpoints/test_organization_events_stats_span_metrics.py
@@ -298,6 +298,40 @@ class OrganizationEventsStatsSpansMetricsEndpointTest(MetricsEnhancedPerformance
         assert not data[0][1][0]["count"]
         assert data[1][1][0]["count"] == 4.0
 
+    def test_messaging_receive_latency(self):
+        self.store_span_metric(
+            {
+                "min": 10,
+                "max": 10,
+                "sum": 10,
+                "count": 1,
+                "last": 10,
+            },
+            entity="metrics_gauges",
+            metric="messaging.message.receive.latency",
+            timestamp=self.day_ago + timedelta(minutes=1),
+            tags={"messaging.destination.name": "foo", "trace.status": "ok"},
+        )
+
+        response = self.do_request(
+            data={
+                "start": iso_format(self.day_ago),
+                "end": iso_format(self.day_ago + timedelta(minutes=2)),
+                "interval": "1m",
+                "query": "messaging.destination.name:foo",
+                "yAxis": "avg(messaging.message.receive.latency)",
+                "project": self.project.id,
+                "dataset": "spansMetrics",
+                "excludeOther": 0,
+            },
+        )
+
+        data = response.data["data"]
+        assert response.status_code == 200
+        assert len(data) == 2
+        assert not data[0][1][0]["count"]
+        assert data[1][1][0]["count"] == 10.0
+
 
 class OrganizationEventsStatsSpansMetricsEndpointTestWithMetricLayer(
     OrganizationEventsStatsSpansMetricsEndpointTest


### PR DESCRIPTION
Adds `trace.status` and `messaging.destination.name` as tags to spans metrics dataset.
Adds `messaging.message.receive.latency` as a gauge metric and add gauge resolver to `avg` in the spans metrics dataset.