### PR TITLE
ref(browser-starfish): remove new badge resource image view

### DIFF
--- a/static/app/views/performance/browser/resources/resourceView/index.tsx
+++ b/static/app/views/performance/browser/resources/resourceView/index.tsx
@@ -2,7 +2,6 @@ import {Fragment, useCallback, useEffect, useState} from 'react';
 import styled from '@emotion/styled';
 import debounce from 'lodash/debounce';
 
-import FeatureBadge from 'sentry/components/badge/featureBadge';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {browserHistory} from 'sentry/utils/browserHistory';
@@ -100,12 +99,7 @@ function ResourceTypeSelector({value}: {value?: string}) {
       ? [
           {
             value: ResourceSpanOps.IMAGE,
-            label: (
-              <span>
-                {`${t('Image')} (${IMAGE_FILE_EXTENSIONS.map(e => `.${e}`).join(', ')})`}
-                <FeatureBadge type="new"> </FeatureBadge>
-              </span>
-            ),
+            label: `${t('Image')} (${IMAGE_FILE_EXTENSIONS.map(e => `.${e}`).join(', ')})`,
           },
         ]
       : []),


### PR DESCRIPTION
Image capability has been out for sometime, se we can remove the following `New` badge
<img width="443" alt="image" src="https://github.com/getsentry/sentry/assets/44422760/4562c85d-ce18-4f74-97c5-2fcff573faff">
