### PR TITLE
ref(feedback): add associated_event_id to the issue evidence

### DIFF
--- a/src/sentry/feedback/usecases/create_feedback.py
+++ b/src/sentry/feedback/usecases/create_feedback.py
@@ -61,6 +61,13 @@ class FeedbackCreationSource(Enum):
 def make_evidence(feedback, source: FeedbackCreationSource, is_message_spam: bool | None):
     evidence_data = {}
     evidence_display = []
+    if feedback.get("associated_event_id"):
+        evidence_data["associated_event_id"] = feedback["associated_event_id"]
+        evidence_display.append(
+            IssueEvidence(
+                name="associated_event_id", value=feedback["associated_event_id"], important=False
+            )
+        )
     if feedback.get("contact_email"):
         evidence_data["contact_email"] = feedback["contact_email"]
         evidence_display.append(
@@ -173,7 +180,7 @@ def should_filter_feedback(event, project_id, source: FeedbackCreationSource):
     return False
 
 
-def create_feedback_issue(event, project_id, source: FeedbackCreationSource):
+def create_feedback_issue(event, project_id: int, source: FeedbackCreationSource):
     metrics.incr("feedback.create_feedback_issue.entered")
 
     if should_filter_feedback(event, project_id, source):

--- a/tests/sentry/feedback/usecases/test_create_feedback.py
+++ b/tests/sentry/feedback/usecases/test_create_feedback.py
@@ -268,7 +268,7 @@ def test_create_feedback_filters_unreal(default_project, mock_produce_occurrence
         "breadcrumbs": [],
         "platform": "javascript",
     }
-    create_feedback_issue(event, default_project, FeedbackCreationSource.NEW_FEEDBACK_ENVELOPE)
+    create_feedback_issue(event, default_project.id, FeedbackCreationSource.NEW_FEEDBACK_ENVELOPE)
 
     assert mock_produce_occurrence_to_kafka.call_count == 0
 
@@ -340,8 +340,8 @@ def test_create_feedback_filters_empty(default_project, mock_produce_occurrence_
         "breadcrumbs": [],
         "platform": "javascript",
     }
-    create_feedback_issue(event, default_project, FeedbackCreationSource.NEW_FEEDBACK_ENVELOPE)
-    create_feedback_issue(event_2, default_project, FeedbackCreationSource.NEW_FEEDBACK_ENVELOPE)
+    create_feedback_issue(event, default_project.id, FeedbackCreationSource.NEW_FEEDBACK_ENVELOPE)
+    create_feedback_issue(event_2, default_project.id, FeedbackCreationSource.NEW_FEEDBACK_ENVELOPE)
 
     assert mock_produce_occurrence_to_kafka.call_count == 0
 
@@ -432,13 +432,13 @@ def test_create_feedback_filters_no_contexts_or_message(
     }
 
     create_feedback_issue(
-        event_no_context, default_project, FeedbackCreationSource.NEW_FEEDBACK_ENVELOPE
+        event_no_context, default_project.id, FeedbackCreationSource.NEW_FEEDBACK_ENVELOPE
     )
     create_feedback_issue(
-        event_no_message, default_project, FeedbackCreationSource.NEW_FEEDBACK_ENVELOPE
+        event_no_message, default_project.id, FeedbackCreationSource.NEW_FEEDBACK_ENVELOPE
     )
     create_feedback_issue(
-        event_no_feedback, default_project, FeedbackCreationSource.NEW_FEEDBACK_ENVELOPE
+        event_no_feedback, default_project.id, FeedbackCreationSource.NEW_FEEDBACK_ENVELOPE
     )
 
     assert mock_produce_occurrence_to_kafka.call_count == 0
@@ -635,3 +635,55 @@ def test_create_feedback_spam_detection_option_false(
         ]
         found_is_spam = is_spam_evidence[0] if is_spam_evidence else None
         assert found_is_spam is None
+
+
+@django_db_all
+def test_create_feedback_adds_associated_event_id(
+    default_project, mock_produce_occurrence_to_kafka
+):
+    event = {
+        "project_id": default_project.id,
+        "request": {
+            "url": "https://sentry.sentry.io/feedback/?statsPeriod=14d",
+            "headers": {
+                "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/118.0.0.0 Safari/537.36"
+            },
+        },
+        "event_id": "56b08cf7852c42cbb95e4a6998c66ad6",
+        "timestamp": 1698255009.574,
+        "received": "2021-10-24T22:23:29.574000+00:00",
+        "environment": "prod",
+        "release": "frontend@daf1316f209d961443664cd6eb4231ca154db502",
+        "user": {
+            "ip_address": "72.164.175.154",
+            "email": "josh.ferge@sentry.io",
+            "id": 880461,
+            "isStaff": False,
+            "name": "Josh Ferge",
+        },
+        "contexts": {
+            "feedback": {
+                "contact_email": "josh.ferge@sentry.io",
+                "name": "Josh Ferge",
+                "message": "great website",
+                "replay_id": "3d621c61593c4ff9b43f8490a78ae18e",
+                "url": "https://sentry.sentry.io/feedback/?statsPeriod=14d",
+                "associated_event_id": "56b08cf7852c42cbb95e4a6998c66ad6",
+            },
+        },
+        "breadcrumbs": [],
+        "platform": "javascript",
+    }
+    create_feedback_issue(event, default_project.id, FeedbackCreationSource.NEW_FEEDBACK_ENVELOPE)
+
+    assert mock_produce_occurrence_to_kafka.call_count == 1
+
+    associated_event_id_evidence = [
+        evidence.value
+        for evidence in mock_produce_occurrence_to_kafka.call_args.kwargs[
+            "occurrence"
+        ].evidence_display
+        if evidence.name == "associated_event_id"
+    ]
+    associated_event_id = associated_event_id_evidence[0] if associated_event_id_evidence else None
+    assert associated_event_id == "56b08cf7852c42cbb95e4a6998c66ad6"


### PR DESCRIPTION
- add `associated_event_id` to the feedback issue evidence
- also fix some bugs in existing tests where we were passing in `Project` instead of `int` for a `project_id` param