### PR TITLE
ref(feedback): remove 'view event' link from feedback events

### DIFF
--- a/static/app/components/events/userFeedback.tsx
+++ b/static/app/components/events/userFeedback.tsx
@@ -16,9 +16,16 @@ type Props = {
   orgSlug: string;
   report: UserReport;
   className?: string;
+  showLink?: boolean;
 };
 
-export function EventUserFeedback({className, report, orgSlug, issueId}: Props) {
+export function EventUserFeedback({
+  className,
+  report,
+  orgSlug,
+  issueId,
+  showLink = true,
+}: Props) {
   const user = report.user || {
     name: report.name,
     email: report.email,
@@ -50,7 +57,7 @@ export function EventUserFeedback({className, report, orgSlug, issueId}: Props) 
               {report.email}
             </CopyButton>
 
-            {report.eventID && (
+            {report.eventID && showLink && (
               <ViewEventLink
                 to={`/organizations/${orgSlug}/issues/${issueId}/events/${report.eventID}/?referrer=user-feedback`}
               >

--- a/static/app/components/events/userFeedback.tsx
+++ b/static/app/components/events/userFeedback.tsx
@@ -16,7 +16,7 @@ type Props = {
   orgSlug: string;
   report: UserReport;
   className?: string;
-  showLink?: boolean;
+  showEventLink?: boolean;
 };
 
 export function EventUserFeedback({
@@ -24,7 +24,7 @@ export function EventUserFeedback({
   report,
   orgSlug,
   issueId,
-  showLink = true,
+  showEventLink = true,
 }: Props) {
   const user = report.user || {
     name: report.name,
@@ -57,7 +57,7 @@ export function EventUserFeedback({
               {report.email}
             </CopyButton>
 
-            {report.eventID && showLink && (
+            {report.eventID && showEventLink && (
               <ViewEventLink
                 to={`/organizations/${orgSlug}/issues/${issueId}/events/${report.eventID}/?referrer=user-feedback`}
               >

--- a/static/app/views/issueDetails/groupEventDetails/groupEventDetailsContent.tsx
+++ b/static/app/views/issueDetails/groupEventDetails/groupEventDetailsContent.tsx
@@ -133,6 +133,7 @@ function DefaultGroupEventDetailsContent({
             report={event.userReport}
             orgSlug={organization.slug}
             issueId={group.id}
+            showLink={false}
           />
         </EventDataSection>
       )}

--- a/static/app/views/issueDetails/groupEventDetails/groupEventDetailsContent.tsx
+++ b/static/app/views/issueDetails/groupEventDetails/groupEventDetailsContent.tsx
@@ -133,7 +133,7 @@ function DefaultGroupEventDetailsContent({
             report={event.userReport}
             orgSlug={organization.slug}
             issueId={group.id}
-            showLink={false}
+            showEventLink={false}
           />
         </EventDataSection>
       )}


### PR DESCRIPTION
fixes https://github.com/getsentry/sentry/issues/70035

remove the 'view event' link from the user feedback component if it's the same event. this link doesn't route to a new page, and we also don't want to route to the user feedback index since this page already gives the full context we need.

<img width="514" alt="SCR-20240501-krse" src="https://github.com/getsentry/sentry/assets/56095982/69aaa46d-16d2-4136-b9f7-1f334e2cd3da">


the link is still there everywhere else the component is used in the product:

user feedback index:
<img width="591" alt="SCR-20240501-krxg" src="https://github.com/getsentry/sentry/assets/56095982/f265dc12-d397-4d0d-8c42-e0f3d1be0492">

user feedback tab on issues:
<img width="644" alt="SCR-20240501-krun" src="https://github.com/getsentry/sentry/assets/56095982/9f069a44-f5ae-457e-a8d1-3e1e092517da">


