### PR TITLE
cogs(ownership): remove logs in project ownership

### DIFF
--- a/src/sentry/models/projectownership.py
+++ b/src/sentry/models/projectownership.py
@@ -270,7 +270,6 @@ class ProjectOwnership(Model):
 
             autoassignment_types = cls._get_autoassignment_types(ownership)
             if not len(autoassignment_types):
-                logger.info("handle_auto_assignment.autoassignment_disabled", extra=logging_extra)
                 return
             logging_extra["autoassignment_types"] = autoassignment_types
 
@@ -280,13 +279,11 @@ class ProjectOwnership(Model):
             )
 
             if issue_owner is False:
-                logger.info("handle_auto_assignment.no_issue_owner", extra=logging_extra)
                 return
             logging_extra["issue_owner"] = issue_owner
 
             owner = issue_owner.owner()
             if not owner:
-                logger.info("handle_auto_assignment.no_owner", extra=logging_extra)
                 return
 
             logging_extra["owner"] = owner
@@ -315,7 +312,6 @@ class ProjectOwnership(Model):
             if activity:
                 auto_assigned = activity[0].data.get("integration")
                 if not auto_assigned and not force_autoassign:
-                    logger.info("autoassignment.post_manual_assignment", extra=logging_extra)
                     return
 
             if not isinstance(owner, Team) and not isinstance(owner, RpcUser):
@@ -327,14 +323,12 @@ class ProjectOwnership(Model):
                 isinstance(owner, Team)
                 and GroupAssignee.objects.filter(group=group, team=owner.id).exists()
             ):
-                logger.info("handle_auto_assignment.team_already_assigned", extra=logging_extra)
                 return
 
             if (
                 isinstance(owner, RpcUser)
                 and GroupAssignee.objects.filter(group=group, user_id=owner.id).exists()
             ):
-                logger.info("handle_auto_assignment.user_already_assigned", extra=logging_extra)
                 return
 
             assignment = GroupAssignee.objects.assign(
@@ -356,15 +350,6 @@ class ProjectOwnership(Model):
                     organization_id=organization_id or ownership.project.organization_id,
                     project_id=project_id,
                     group_id=group.id,
-                )
-                logger.info(
-                    "handle_auto_assignment.success",
-                    extra={
-                        **logging_extra,
-                        # owner_id returns a string including the owner type (user or team) and id
-                        "assignee": issue_owner.owner_id(),
-                        "reason": "created" if assignment["new_assignment"] else "updated",
-                    },
                 )
 
     @classmethod


### PR DESCRIPTION
these logs are too noisy and expensive, removing them. if we want high level info about this flow, we should add metrics. If we want to debug a small subset, we should add spans and relay on tracing in order to debug them.