### PR TITLE
 feat(autofix): Repo access & indexing steps + loading state for setup

### DIFF
--- a/static/app/components/events/autofix/autofixBanner.spec.tsx
+++ b/static/app/components/events/autofix/autofixBanner.spec.tsx
@@ -27,7 +27,7 @@ describe('AutofixBanner', () => {
   it('shows PII check for sentry employee users', () => {
     mockIsSentryEmployee(true);
 
-    render(<AutofixBanner {...defaultProps} />);
+    render(<AutofixBanner {...defaultProps} projectId="1" />);
     expect(
       screen.getByText(
         'By clicking the button above, you confirm that there is no PII in this event.'
@@ -38,7 +38,7 @@ describe('AutofixBanner', () => {
   it('does not show PII check for non sentry employee users', () => {
     mockIsSentryEmployee(false);
 
-    render(<AutofixBanner {...defaultProps} />);
+    render(<AutofixBanner {...defaultProps} projectId="1" />);
     expect(
       screen.queryByText(
         'By clicking the button above, you confirm that there is no PII in this event.'
@@ -49,7 +49,13 @@ describe('AutofixBanner', () => {
   it('can run without instructions', async () => {
     const mockTriggerAutofix = jest.fn();
 
-    render(<AutofixBanner {...defaultProps} triggerAutofix={mockTriggerAutofix} />);
+    render(
+      <AutofixBanner
+        {...defaultProps}
+        triggerAutofix={mockTriggerAutofix}
+        projectId="1"
+      />
+    );
     renderGlobalModal();
 
     await userEvent.click(screen.getByRole('button', {name: 'Gimme Fix'}));
@@ -59,7 +65,13 @@ describe('AutofixBanner', () => {
   it('can provide instructions', async () => {
     const mockTriggerAutofix = jest.fn();
 
-    render(<AutofixBanner {...defaultProps} triggerAutofix={mockTriggerAutofix} />);
+    render(
+      <AutofixBanner
+        {...defaultProps}
+        triggerAutofix={mockTriggerAutofix}
+        projectId="1"
+      />
+    );
     renderGlobalModal();
 
     await userEvent.click(screen.getByRole('button', {name: 'Give Instructions'}));

--- a/static/app/components/events/autofix/autofixBanner.tsx
+++ b/static/app/components/events/autofix/autofixBanner.tsx
@@ -8,6 +8,7 @@ import bannerStars from 'sentry-images/spot/ai-suggestion-banner-stars.svg';
 import {openModal} from 'sentry/actionCreators/modal';
 import {Button} from 'sentry/components/button';
 import {AutofixInstructionsModal} from 'sentry/components/events/autofix/autofixInstructionsModal';
+import {AutofixCodebaseIndexingStatus} from 'sentry/components/events/autofix/types';
 import {useAutofixCodebaseIndexing} from 'sentry/components/events/autofix/useAutofixCodebaseIndexing';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {AutofixSetupModal} from 'sentry/components/modals/autofixSetupModal';
@@ -76,7 +77,7 @@ export function AutofixBanner({
                 {t('Give Instructions')}
               </Button>
             </Fragment>
-          ) : indexingStatus === 'indexing' ? (
+          ) : indexingStatus === AutofixCodebaseIndexingStatus.INDEXING ? (
             <RowStack>
               <LoadingIndicator mini />
               <LoadingMessage>

--- a/static/app/components/events/autofix/autofixBanner.tsx
+++ b/static/app/components/events/autofix/autofixBanner.tsx
@@ -8,6 +8,8 @@ import bannerStars from 'sentry-images/spot/ai-suggestion-banner-stars.svg';
 import {openModal} from 'sentry/actionCreators/modal';
 import {Button} from 'sentry/components/button';
 import {AutofixInstructionsModal} from 'sentry/components/events/autofix/autofixInstructionsModal';
+import {useAutofixCodebaseIndexing} from 'sentry/components/events/autofix/useAutofixCodebaseIndexing';
+import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {AutofixSetupModal} from 'sentry/components/modals/autofixSetupModal';
 import Panel from 'sentry/components/panels/panel';
 import PanelBody from 'sentry/components/panels/panelBody';
@@ -18,10 +20,16 @@ import {useIsSentryEmployee} from 'sentry/utils/useIsSentryEmployee';
 type Props = {
   groupId: string;
   hasSuccessfulSetup: boolean;
+  projectId: string;
   triggerAutofix: (value: string) => void;
 };
 
-export function AutofixBanner({groupId, triggerAutofix, hasSuccessfulSetup}: Props) {
+export function AutofixBanner({
+  groupId,
+  projectId,
+  triggerAutofix,
+  hasSuccessfulSetup,
+}: Props) {
   const isSentryEmployee = useIsSentryEmployee();
   const onClickGiveInstructions = () => {
     openModal(deps => (
@@ -32,6 +40,7 @@ export function AutofixBanner({groupId, triggerAutofix, hasSuccessfulSetup}: Pro
       />
     ));
   };
+  const {status: indexingStatus} = useAutofixCodebaseIndexing({projectId, groupId});
 
   return (
     <Wrapper>
@@ -67,13 +76,22 @@ export function AutofixBanner({groupId, triggerAutofix, hasSuccessfulSetup}: Pro
                 {t('Give Instructions')}
               </Button>
             </Fragment>
+          ) : indexingStatus === 'indexing' ? (
+            <RowStack>
+              <LoadingIndicator mini />
+              <LoadingMessage>
+                Indexing your repositories, hold tight this may take up to 30 minutes...
+              </LoadingMessage>
+            </RowStack>
           ) : (
             <Button
               analyticsEventKey="autofix.setup_clicked"
               analyticsEventName="Autofix: Setup Clicked"
               analyticsParams={{group_id: groupId}}
               onClick={() => {
-                openModal(deps => <AutofixSetupModal {...deps} groupId={groupId} />);
+                openModal(deps => (
+                  <AutofixSetupModal {...deps} groupId={groupId} projectId={projectId} />
+                ));
               }}
               size="sm"
             >
@@ -175,6 +193,17 @@ const Separator = styled('hr')`
 `;
 
 const PiiMessage = styled('p')`
+  font-size: ${p => p.theme.fontSizeSmall};
+  color: ${p => p.theme.subText};
+`;
+
+const RowStack = styled('div')`
+  display: flex;
+  align-items: center;
+  gap: ${space(0.25)};
+`;
+
+const LoadingMessage = styled('div')`
   font-size: ${p => p.theme.fontSizeSmall};
   color: ${p => p.theme.subText};
 `;

--- a/static/app/components/events/autofix/index.spec.tsx
+++ b/static/app/components/events/autofix/index.spec.tsx
@@ -21,6 +21,18 @@ describe('Autofix', () => {
       body: {
         genAIConsent: {ok: true},
         integration: {ok: true},
+        githubWriteIntegration: {
+          ok: true,
+          repos: [
+            {
+              provider: 'integrations:github',
+              owner: 'getsentry',
+              name: 'sentry',
+              external_id: '123',
+            },
+          ],
+        },
+        codebaseIndexing: {ok: true},
       },
     });
   });

--- a/static/app/components/events/autofix/index.tsx
+++ b/static/app/components/events/autofix/index.tsx
@@ -31,6 +31,7 @@ export function Autofix({event, group}: Props) {
         ) : (
           <AutofixBanner
             groupId={group.id}
+            projectId={group.project.id}
             triggerAutofix={triggerAutofix}
             hasSuccessfulSetup={hasSuccessfulSetup}
           />

--- a/static/app/components/events/autofix/types.ts
+++ b/static/app/components/events/autofix/types.ts
@@ -19,6 +19,12 @@ export enum AutofixStepType {
   CHANGES = 'changes',
 }
 
+export enum AutofixCodebaseIndexingStatus {
+  UP_TO_DATE = 'up_to_date',
+  INDEXING = 'indexing',
+  NOT_INDEXED = 'not_indexed',
+}
+
 export type AutofixPullRequestDetails = {
   pr_number: number;
   pr_url: string;
@@ -150,3 +156,9 @@ export type DiffLine = {
   target_line_no: number | null;
   value: string;
 };
+
+export interface AutofixRepoDefinition {
+  name: string;
+  owner: string;
+  provider: string;
+}

--- a/static/app/components/events/autofix/useAutofixCodebaseIndexing.tsx
+++ b/static/app/components/events/autofix/useAutofixCodebaseIndexing.tsx
@@ -1,0 +1,95 @@
+import {useCallback, useEffect} from 'react';
+
+import {AutofixCodebaseIndexingStatus} from 'sentry/components/events/autofix/types';
+import {makeAutofixSetupQueryKey} from 'sentry/components/events/autofix/useAutofixSetup';
+import {
+  type ApiQueryKey,
+  setApiQueryData,
+  useApiQuery,
+  useQueryClient,
+} from 'sentry/utils/queryClient';
+import useApi from 'sentry/utils/useApi';
+import useOrganization from 'sentry/utils/useOrganization';
+import usePrevious from 'sentry/utils/usePrevious';
+import useProjectFromId from 'sentry/utils/useProjectFromId';
+
+const POLL_INTERVAL = 2500;
+
+const makeCodebaseIndexCreateUrl = (orgSlug: string, projectIdOrSlug: string): string =>
+  `/projects/${orgSlug}/${projectIdOrSlug}/autofix/codebase-index/create/`;
+
+const makeCodebaseIndexStatusQueryKey = (
+  orgSlug: string,
+  projectIdOrSlug: string
+): ApiQueryKey => [
+  `/projects/${orgSlug}/${projectIdOrSlug}/autofix/codebase-index/status/`,
+];
+
+const isPolling = (status: AutofixCodebaseIndexingStatus | undefined) =>
+  status === AutofixCodebaseIndexingStatus.INDEXING;
+
+export interface CodebaseIndexingStatusResponse {
+  status: AutofixCodebaseIndexingStatus;
+}
+
+export function useAutofixCodebaseIndexing({
+  projectId,
+  groupId,
+}: {
+  groupId: string;
+  projectId: string;
+}) {
+  const organization = useOrganization();
+  const projectSlug = useProjectFromId({project_id: projectId})?.slug;
+  const api = useApi();
+  const queryClient = useQueryClient();
+
+  const {data: apiData} = useApiQuery<CodebaseIndexingStatusResponse>(
+    makeCodebaseIndexStatusQueryKey(organization.slug, projectSlug ?? ''),
+    {
+      staleTime: 0,
+      retry: false,
+      enabled: projectSlug !== undefined,
+      refetchInterval: data => {
+        if (isPolling(data?.[0]?.status)) {
+          return POLL_INTERVAL;
+        }
+        return false;
+      },
+    }
+  );
+
+  const status = apiData?.status ?? null;
+  const prevStatus = usePrevious(status);
+
+  const startIndexing = useCallback(() => {
+    if (!projectSlug) {
+      return;
+    }
+
+    // Triggering the create endpoint on the seer side should make it start return indexing status...
+    api.requestPromise(makeCodebaseIndexCreateUrl(organization.slug, projectSlug), {
+      method: 'POST',
+    });
+
+    // We set it anyways to trigger the polling
+    setApiQueryData<CodebaseIndexingStatusResponse>(
+      queryClient,
+      makeCodebaseIndexStatusQueryKey(organization.slug, projectSlug),
+      {
+        status: AutofixCodebaseIndexingStatus.INDEXING,
+      }
+    );
+  }, [api, queryClient, organization.slug, projectSlug]);
+
+  useEffect(() => {
+    if (
+      prevStatus === AutofixCodebaseIndexingStatus.INDEXING &&
+      status === AutofixCodebaseIndexingStatus.UP_TO_DATE
+    ) {
+      queryClient.refetchQueries(makeAutofixSetupQueryKey(groupId));
+    }
+  }, [queryClient, groupId, prevStatus, status]);
+
+  return {status, startIndexing};
+}

--- a/static/app/components/events/autofix/useAutofixSetup.tsx
+++ b/static/app/components/events/autofix/useAutofixSetup.tsx
@@ -1,9 +1,25 @@
-import {useApiQuery, type UseApiQueryOptions} from 'sentry/utils/queryClient';
+import type {AutofixRepoDefinition} from 'sentry/components/events/autofix/types';
+import {
+  type ApiQueryKey,
+  useApiQuery,
+  type UseApiQueryOptions,
+} from 'sentry/utils/queryClient';
 import type RequestError from 'sentry/utils/requestError/requestError';
 
+export interface AutofixSetupRepoDefinition extends AutofixRepoDefinition {
+  ok: boolean;
+}
+
 export type AutofixSetupResponse = {
+  codebaseIndexing: {
+    ok: boolean;
+  };
   genAIConsent: {
     ok: boolean;
+  };
+  githubWriteIntegration: {
+    ok: boolean;
+    repos: AutofixSetupRepoDefinition[];
   };
   integration: {
     ok: boolean;
@@ -14,20 +30,28 @@ export type AutofixSetupResponse = {
   };
 };
 
+export function makeAutofixSetupQueryKey(groupId: string): ApiQueryKey {
+  return [`/issues/${groupId}/autofix/setup/`];
+}
+
 export function useAutofixSetup(
   {groupId}: {groupId: string},
   options: Omit<UseApiQueryOptions<AutofixSetupResponse, RequestError>, 'staleTime'> = {}
 ) {
-  const queryData = useApiQuery<AutofixSetupResponse>(
-    [`/issues/${groupId}/autofix/setup/`],
-    {enabled: Boolean(groupId), staleTime: 0, retry: false, ...options}
-  );
+  const queryData = useApiQuery<AutofixSetupResponse>(makeAutofixSetupQueryKey(groupId), {
+    enabled: Boolean(groupId),
+    staleTime: 0,
+    retry: false,
+    ...options,
+  });
 
   return {
     ...queryData,
     hasSuccessfulSetup: Boolean(
-      // TODO: Add other checks here when we can actually configure them
-      queryData.data?.integration.ok
+      queryData.data?.integration.ok &&
+        queryData.data?.githubWriteIntegration.ok &&
+        queryData.data?.genAIConsent.ok &&
+        queryData.data?.codebaseIndexing.ok
     ),
   };
 }

--- a/static/app/components/guidedSteps/guidedSteps.tsx
+++ b/static/app/components/guidedSteps/guidedSteps.tsx
@@ -161,11 +161,12 @@ function NextButton({children, ...props}: BaseButtonProps) {
   );
 }
 
-function StepButtons() {
+function StepButtons({children}: {children?: React.ReactNode}) {
   return (
     <StepButtonsWrapper>
       <BackButton />
       <NextButton />
+      {children}
     </StepButtonsWrapper>
   );
 }

--- a/static/app/components/modals/autofixSetupModal.tsx
+++ b/static/app/components/modals/autofixSetupModal.tsx
@@ -123,13 +123,13 @@ function GitRepoLink({repo}: {repo: AutofixSetupRepoDefinition}) {
       <RepoLinkItem>
         <GithubLink>
           <ExternalLink href={`https://github.com/${repo.owner}/${repo.name}`}>
-            <IconGithub color="gray500" size="sm" />
+            <IconGithub color="linkColor" size="sm" />
             <span>
               {repo.owner}/{repo.name}
             </span>
           </ExternalLink>
         </GithubLink>
-        {repo.ok ? <RepoCheckIcon isCircled /> : null}
+        {repo.ok ? <IconCheckmark color="success" isCircled /> : null}
       </RepoLinkItem>
     );
   }
@@ -315,7 +315,7 @@ function AutofixSetupContent({
   if (hasSuccessfulSetup) {
     return (
       <AutofixSetupDone>
-        <DoneIcon size="xxl" isCircled />
+        <DoneIcon color="success" size="xxl" isCircled />
         <p>{t("You've successfully configured Autofix!")}</p>
         <Button onClick={closeModal} priority="primary">
           {t("Let's go")}
@@ -368,7 +368,6 @@ const AutofixSetupDone = styled('div')`
 `;
 
 const DoneIcon = styled(IconCheckmark)`
-  color: ${p => p.theme.success};
   margin-bottom: ${space(4)};
 `;
 
@@ -384,10 +383,6 @@ const RepoLinkItem = styled('li')`
   gap: ${space(0.5)};
 `;
 
-const RepoCheckIcon = styled(IconCheckmark)`
-  fill: ${p => p.theme.success};
-`;
-
 const GithubLink = styled('div')`
   display: flex;
   align-items: center;
@@ -399,6 +394,5 @@ const GithubLink = styled('div')`
 
   svg {
     margin-right: ${space(0.5)};
-    fill: ${p => p.theme.linkColor};
   }
 `;

--- a/static/app/components/modals/autofixSetupModal.tsx
+++ b/static/app/components/modals/autofixSetupModal.tsx
@@ -275,7 +275,7 @@ function AutofixSetupSteps({
       </GuidedSteps.Step>
       <GuidedSteps.Step
         stepKey="codebaseIndexing"
-        title={t('Index your repositories')}
+        title={t('Enable Autofix')}
         isCompleted={autofixSetup.codebaseIndexing.ok}
       >
         <AutofixCodebaseIndexingStep

--- a/static/app/components/modals/autofixSetupModal.tsx
+++ b/static/app/components/modals/autofixSetupModal.tsx
@@ -1,9 +1,11 @@
-import {Fragment} from 'react';
+import {Fragment, useMemo} from 'react';
 import styled from '@emotion/styled';
 
 import type {ModalRenderProps} from 'sentry/actionCreators/modal';
 import {Button} from 'sentry/components/button';
+import {useAutofixCodebaseIndexing} from 'sentry/components/events/autofix/useAutofixCodebaseIndexing';
 import {
+  type AutofixSetupRepoDefinition,
   type AutofixSetupResponse,
   useAutofixSetup,
 } from 'sentry/components/events/autofix/useAutofixSetup';
@@ -12,12 +14,13 @@ import HookOrDefault from 'sentry/components/hookOrDefault';
 import ExternalLink from 'sentry/components/links/externalLink';
 import LoadingError from 'sentry/components/loadingError';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
-import {IconCheckmark} from 'sentry/icons';
+import {IconCheckmark, IconGithub} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 
 interface AutofixSetupModalProps extends ModalRenderProps {
   groupId: string;
+  projectId: string;
 }
 
 const ConsentStep = HookOrDefault({
@@ -114,7 +117,145 @@ function AutofixIntegrationStep({autofixSetup}: {autofixSetup: AutofixSetupRespo
   );
 }
 
-function AutofixSetupSteps({autofixSetup}: {autofixSetup: AutofixSetupResponse}) {
+function GitRepoLink({repo}: {repo: AutofixSetupRepoDefinition}) {
+  if (repo.provider === 'github' || repo.provider.split(':')[1] === 'github') {
+    return (
+      <RepoLinkItem>
+        <GithubLink>
+          <ExternalLink href={`https://github.com/${repo.owner}/${repo.name}`}>
+            <IconGithub color="gray500" size="sm" />
+            <span>
+              {repo.owner}/{repo.name}
+            </span>
+          </ExternalLink>
+        </GithubLink>
+        {repo.ok ? <RepoCheckIcon isCircled /> : null}
+      </RepoLinkItem>
+    );
+  }
+
+  return (
+    <li>
+      {repo.owner}/{repo.name}
+    </li>
+  );
+}
+
+function AutofixGithubIntegrationStep({
+  autofixSetup,
+}: {
+  autofixSetup: AutofixSetupResponse;
+}) {
+  const sortedRepos = useMemo(
+    () =>
+      autofixSetup.githubWriteIntegration.repos.toSorted((a, b) => {
+        if (a.ok === b.ok) {
+          return `${a.owner}/${a.name}`.localeCompare(`${b.owner}/${b.name}`);
+        }
+        return a.ok ? -1 : 1;
+      }),
+    [autofixSetup.githubWriteIntegration.repos]
+  );
+
+  if (autofixSetup.githubWriteIntegration.ok) {
+    return (
+      <Fragment>
+        <p>
+          {tct(
+            'The [link:Sentry Autofix Github App] has been installed on all required repositories:',
+            {
+              link: (
+                <ExternalLink href="https://github.com/apps/sentry-autofix-experimental" />
+              ),
+            }
+          )}
+        </p>
+        <RepoLinkUl>
+          {sortedRepos.map(repo => (
+            <GitRepoLink key={`${repo.owner}/${repo.name}`} repo={repo} />
+          ))}
+        </RepoLinkUl>
+        <GuidedSteps.StepButtons />
+      </Fragment>
+    );
+  }
+
+  return (
+    <Fragment>
+      <p>
+        {tct(
+          'Install the [link:Sentry Autofix Github App] on your Github organization or each individual repository with write permissions to enable Autofix.',
+          {
+            link: (
+              <ExternalLink href="https://github.com/apps/sentry-autofix-experimental" />
+            ),
+          }
+        )}
+      </p>
+      <p>{t(`To run Autofix on this issue, you will need to install the app on:`)}</p>
+      <RepoLinkUl>
+        {sortedRepos.map(repo => (
+          <GitRepoLink key={`${repo.owner}/${repo.name}`} repo={repo} />
+        ))}
+      </RepoLinkUl>
+      <GuidedSteps.StepButtons />
+    </Fragment>
+  );
+}
+
+function AutofixCodebaseIndexingStep({
+  autofixSetup,
+  projectId,
+  groupId,
+  closeModal,
+}: {
+  autofixSetup: AutofixSetupResponse;
+  closeModal: () => void;
+  groupId: string;
+  projectId: string;
+}) {
+  const {startIndexing} = useAutofixCodebaseIndexing({projectId, groupId});
+
+  const canIndex =
+    autofixSetup.genAIConsent.ok &&
+    autofixSetup.integration.ok &&
+    autofixSetup.githubWriteIntegration.ok;
+
+  return (
+    <Fragment>
+      <p>
+        {t(
+          'Sentry will index your repositories to enable Autofix. This process may take a few minutes.'
+        )}
+      </p>
+      <GuidedSteps.StepButtons>
+        <Button
+          priority="primary"
+          size="sm"
+          disabled={!canIndex}
+          onClick={() => {
+            startIndexing();
+            closeModal();
+          }}
+        >
+          {t('Index Repositories & Enable Autofix')}
+        </Button>
+      </GuidedSteps.StepButtons>
+    </Fragment>
+  );
+}
+
+function AutofixSetupSteps({
+  projectId,
+  groupId,
+  autofixSetup,
+  closeModal,
+}: {
+  autofixSetup: AutofixSetupResponse;
+  closeModal: () => void;
+  groupId: string;
+  projectId: string;
+}) {
   return (
     <GuidedSteps>
       <ConsentStep hasConsented={autofixSetup.genAIConsent.ok} />
@@ -125,18 +266,39 @@ function AutofixSetupSteps({autofixSetup}: {autofixSetup: AutofixSetupResponse})
       >
         <AutofixIntegrationStep autofixSetup={autofixSetup} />
       </GuidedSteps.Step>
+      <GuidedSteps.Step
+        stepKey="repoWriteAccess"
+        title={t('Install the Sentry Autofix App on Github')}
+        isCompleted={autofixSetup.githubWriteIntegration.ok}
+      >
+        <AutofixGithubIntegrationStep autofixSetup={autofixSetup} />
+      </GuidedSteps.Step>
+      <GuidedSteps.Step
+        stepKey="codebaseIndexing"
+        title={t('Index your repositories')}
+        isCompleted={autofixSetup.codebaseIndexing.ok}
+      >
+        <AutofixCodebaseIndexingStep
+          groupId={groupId}
+          projectId={projectId}
+          autofixSetup={autofixSetup}
+          closeModal={closeModal}
+        />
+      </GuidedSteps.Step>
     </GuidedSteps>
   );
 }
 
 function AutofixSetupContent({
+  projectId,
   groupId,
   closeModal,
 }: {
   closeModal: () => void;
   groupId: string;
+  projectId: string;
 }) {
-  const {data, isLoading, isError} = useAutofixSetup(
+  const {data, hasSuccessfulSetup, isLoading, isError} = useAutofixSetup(
     {groupId},
     // Want to check setup status whenever the user comes back to the tab
     {refetchOnWindowFocus: true}
@@ -150,7 +312,7 @@ function AutofixSetupContent({
     return <LoadingError message={t('Failed to fetch Autofix setup progress.')} />;
   }
 
-  if (data.genAIConsent.ok && data.integration.ok) {
+  if (hasSuccessfulSetup) {
     return (
       <AutofixSetupDone>
         <DoneIcon size="xxl" isCircled />
@@ -162,13 +324,21 @@ function AutofixSetupContent({
     );
   }
 
-  return <AutofixSetupSteps autofixSetup={data} />;
+  return (
+    <AutofixSetupSteps
+      groupId={groupId}
+      projectId={projectId}
+      autofixSetup={data}
+      closeModal={closeModal}
+    />
+  );
 }
 
 export function AutofixSetupModal({
   Header,
   Body,
   groupId,
+  projectId,
   closeModal,
 }: AutofixSetupModalProps) {
   return (
@@ -177,7 +347,11 @@ export function AutofixSetupModal({
         <h3>{t('Configure Autofix')}</h3>
       </Header>
       <Body>
-        <AutofixSetupContent groupId={groupId} closeModal={closeModal} />
+        <AutofixSetupContent
+          projectId={projectId}
+          groupId={groupId}
+          closeModal={closeModal}
+        />
       </Body>
     </Fragment>
   );
@@ -196,4 +370,35 @@ const AutofixSetupDone = styled('div')`
 const DoneIcon = styled(IconCheckmark)`
   color: ${p => p.theme.success};
   margin-bottom: ${space(4)};
+`;
+
+const RepoLinkUl = styled('ul')`
+  display: flex;
+  flex-direction: column;
+  gap: ${space(0.5)};
+`;
+
+const RepoLinkItem = styled('li')`
+  display: flex;
+  align-items: center;
+  gap: ${space(0.5)};
+`;
+
+const RepoCheckIcon = styled(IconCheckmark)`
+  fill: ${p => p.theme.success};
+`;
+
+const GithubLink = styled('div')`
+  display: flex;
+  align-items: center;
+
+  a {
+    display: flex;
+    align-items: center;
+  }
+
+  svg {
+    margin-right: ${space(0.5)};
+    fill: ${p => p.theme.linkColor};
+  }
 `;


### PR DESCRIPTION
Adds a repo check & codebase indexing start step to the Autofix setup modal


![Screenshot 2024-04-30 at 10 32 45 AM](https://github.com/getsentry/sentry/assets/30991498/8e395e5f-06fd-4921-afbe-d34313dfe103)
![Screenshot 2024-05-01 at 1 19 31 PM](https://github.com/getsentry/sentry/assets/30991498/7fc08cf2-447c-42ec-bcb7-b6fee3b1c22d)

Also adds a loading state to the autofix banner when a codebase is indexing
![Screenshot 2024-05-01 at 1 19 37 PM](https://github.com/getsentry/sentry/assets/30991498/ed1bf547-687f-4a45-8471-8ed447794827)
