### PR TITLE
chore(superuser): use option for read-write instead of FF

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -275,6 +275,13 @@ register(
     default=[],
     flags=FLAG_ALLOW_EMPTY | FLAG_AUTOMATOR_MODIFIABLE,
 )
+# Superuser read/write
+register(
+    "superuser.read-write.ga-rollout",
+    type=Bool,
+    default=False,
+    flags=FLAG_MODIFIABLE_BOOL | FLAG_AUTOMATOR_MODIFIABLE,
+)
 
 # API
 # GA Option for endpoints to work with id or slug as path parameters

--- a/tests/sentry/api/bases/test_sentryapps.py
+++ b/tests/sentry/api/bases/test_sentryapps.py
@@ -14,7 +14,7 @@ from sentry.api.bases.sentryapps import (
     add_integration_platform_metric_tag,
 )
 from sentry.testutils.cases import TestCase
-from sentry.testutils.helpers.features import with_feature
+from sentry.testutils.helpers.options import override_options
 from sentry.testutils.silo import control_silo_test
 
 
@@ -51,7 +51,7 @@ class SentryAppPermissionTest(TestCase):
         request.method = "POST"
         assert self.permission.has_object_permission(request, None, self.sentry_app)
 
-    @with_feature("auth:enterprise-superuser-read-write")
+    @override_options({"superuser.read-write.ga-rollout": True})
     @override_settings(SENTRY_SELF_HOSTED=False)
     def test_superuser_has_permission_read_only(self):
         request = self.make_request(user=self.superuser, method="GET", is_superuser=True)
@@ -63,7 +63,7 @@ class SentryAppPermissionTest(TestCase):
         with pytest.raises(Http404):
             self.permission.has_object_permission(request, None, self.sentry_app)
 
-    @with_feature("auth:enterprise-superuser-read-write")
+    @override_options({"superuser.read-write.ga-rollout": True})
     @override_settings(SENTRY_SELF_HOSTED=False)
     def test_superuser_has_permission_write(self):
         self.add_user_permission(self.superuser, "superuser.write")
@@ -152,7 +152,7 @@ class SentryAppInstallationPermissionTest(TestCase):
         request.method = "POST"
         assert self.permission.has_object_permission(request, None, self.installation)
 
-    @with_feature("auth:enterprise-superuser-read-write")
+    @override_options({"superuser.read-write.ga-rollout": True})
     @override_settings(SENTRY_SELF_HOSTED=False)
     def test_superuser_has_permission_read_only(self):
         request = self.make_request(user=self.superuser, method="GET", is_superuser=True)
@@ -163,7 +163,7 @@ class SentryAppInstallationPermissionTest(TestCase):
         with pytest.raises(Http404):
             self.permission.has_object_permission(request, None, self.installation)
 
-    @with_feature("auth:enterprise-superuser-read-write")
+    @override_options({"superuser.read-write.ga-rollout": True})
     @override_settings(SENTRY_SELF_HOSTED=False)
     def test_superuser_has_permission_write(self):
         self.add_user_permission(self.superuser, "superuser.write")

--- a/tests/sentry/api/bases/test_user.py
+++ b/tests/sentry/api/bases/test_user.py
@@ -11,7 +11,7 @@ from sentry.api.bases.user import (
 )
 from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.testutils.cases import DRFPermissionTestCase
-from sentry.testutils.helpers.features import with_feature
+from sentry.testutils.helpers.options import override_options
 from sentry.testutils.silo import all_silo_test, control_silo_test, no_silo_test
 
 
@@ -46,7 +46,7 @@ class UserPermissionTest(DRFPermissionTestCase):
             )
 
     @override_settings(SENTRY_SELF_HOSTED=False, SUPERUSER_ORG_ID=1000)
-    @with_feature("auth:enterprise-superuser-read-write")
+    @override_options({"superuser.read-write.ga-rollout": True})
     def test_active_superuser_read(self):
         # superuser read can hit GET
         request = self.make_request(user=self.superuser, is_superuser=True, method="GET")
@@ -58,7 +58,7 @@ class UserPermissionTest(DRFPermissionTestCase):
         assert not self.user_permission.has_object_permission(request, None, self.normal_user)
 
     @override_settings(SENTRY_SELF_HOSTED=False, SUPERUSER_ORG_ID=1000)
-    @with_feature("auth:enterprise-superuser-read-write")
+    @override_options({"superuser.read-write.ga-rollout": True})
     def test_active_superuser_write(self):
         # superuser write can hit GET
         self.add_user_permission(self.superuser, "superuser.write")

--- a/tests/sentry/api/endpoints/test_event_attachment_details.py
+++ b/tests/sentry/api/endpoints/test_event_attachment_details.py
@@ -7,6 +7,7 @@ from sentry.models.eventattachment import EventAttachment
 from sentry.testutils.cases import APITestCase, PermissionTestCase
 from sentry.testutils.helpers.datetime import before_now, iso_format
 from sentry.testutils.helpers.features import with_feature
+from sentry.testutils.helpers.options import override_options
 from sentry.testutils.helpers.response import close_streaming_response
 from sentry.testutils.skips import requires_snuba
 from sentry.types.activity import ActivityType
@@ -206,9 +207,8 @@ class EventAttachmentDetailsPermissionTest(PermissionTestCase, CreateAttachmentM
             self.assert_can_access(superuser, self.path)
             self.assert_can_access(superuser, self.path, method="DELETE")
 
-    @with_feature(
-        {"organizations:event-attachments": True, "auth:enterprise-superuser-read-write": True}
-    )
+    @with_feature("organizations:event-attachments")
+    @override_options({"superuser.read-write.ga-rollout": True})
     @override_settings(SENTRY_SELF_HOSTED=False)
     def test_superuser_read_access(self):
         self.organization.update_option("sentry:attachments_role", "owner")
@@ -218,9 +218,8 @@ class EventAttachmentDetailsPermissionTest(PermissionTestCase, CreateAttachmentM
 
         self.assert_cannot_access(superuser, self.path, method="DELETE")
 
-    @with_feature(
-        {"organizations:event-attachments": True, "auth:enterprise-superuser-read-write": True}
-    )
+    @with_feature("organizations:event-attachments")
+    @override_options({"superuser.read-write.ga-rollout": True})
     @override_settings(SENTRY_SELF_HOSTED=False)
     def test_superuser_write_can_access(self):
         self.organization.update_option("sentry:attachments_role", "owner")

--- a/tests/sentry/api/endpoints/test_organization_auditlogs.py
+++ b/tests/sentry/api/endpoints/test_organization_auditlogs.py
@@ -7,7 +7,7 @@ from rest_framework.exceptions import ErrorDetail
 from sentry import audit_log
 from sentry.models.auditlogentry import AuditLogEntry
 from sentry.testutils.cases import APITestCase
-from sentry.testutils.helpers.features import with_feature
+from sentry.testutils.helpers.options import override_options
 from sentry.testutils.silo import control_silo_test
 
 
@@ -181,7 +181,7 @@ class OrganizationAuditLogsTest(APITestCase):
         assert set(response.data["options"]) == audit_log_api_names
 
     @override_settings(SENTRY_SELF_HOSTED=False)
-    @with_feature("auth:enterprise-superuser-read-write")
+    @override_options({"superuser.read-write.ga-rollout": True})
     def test_superuser_read_write_can_see_audit_logs(self):
         superuser = self.create_user(is_superuser=True)
         self.login_as(superuser, superuser=True)

--- a/tests/sentry/api/endpoints/test_organization_member_details.py
+++ b/tests/sentry/api/endpoints/test_organization_member_details.py
@@ -17,6 +17,7 @@ from sentry.roles import organization_roles
 from sentry.silo.base import SiloMode
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.helpers import with_feature
+from sentry.testutils.helpers.options import override_options
 from sentry.testutils.hybrid_cloud import HybridCloudTestMixin
 from sentry.testutils.outbox import outbox_runner
 from sentry.testutils.silo import assume_test_silo_mode
@@ -820,7 +821,7 @@ class DeleteOrganizationMemberTest(OrganizationMemberTestBase):
         self.get_error_response(self.organization.slug, member_om.id, status_code=403)
 
     @override_settings(SENTRY_SELF_HOSTED=False)
-    @with_feature("auth:enterprise-superuser-read-write")
+    @override_options({"superuser.read-write.ga-rollout": True})
     def test_cannot_delete_as_superuser_read(self):
         superuser = self.create_user(is_superuser=True)
         self.login_as(superuser, superuser=True)
@@ -835,7 +836,7 @@ class DeleteOrganizationMemberTest(OrganizationMemberTestBase):
         self.get_error_response(self.organization.slug, member_om.id, status_code=400)
 
     @override_settings(SENTRY_SELF_HOSTED=False)
-    @with_feature("auth:enterprise-superuser-read-write")
+    @override_options({"superuser.read-write.ga-rollout": True})
     def test_can_delete_as_superuser_write(self):
         superuser = self.create_user(is_superuser=True)
         self.add_user_permission(superuser, "superuser.write")

--- a/tests/sentry/api/endpoints/test_organization_member_team_details.py
+++ b/tests/sentry/api/endpoints/test_organization_member_team_details.py
@@ -13,6 +13,7 @@ from sentry.models.organizationmemberteam import OrganizationMemberTeam
 from sentry.roles import organization_roles
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.helpers import with_feature
+from sentry.testutils.helpers.options import override_options
 from tests.sentry.api.endpoints.test_organization_member_index import (
     mock_organization_roles_get_factory,
 )
@@ -583,7 +584,7 @@ class DeleteOrganizationMemberTeamTest(OrganizationMemberTeamTestBase):
         ).exists()
 
     @override_settings(SENTRY_SELF_HOSTED=False)
-    @with_feature("auth:enterprise-superuser-read-write")
+    @override_options({"superuser.read-write.ga-rollout": True})
     def test_superuser_read_cannot_remove_member(self):
         superuser = self.create_user(is_superuser=True)
         self.login_as(superuser, superuser=True)
@@ -597,7 +598,7 @@ class DeleteOrganizationMemberTeamTest(OrganizationMemberTeamTestBase):
         ).exists()
 
     @override_settings(SENTRY_SELF_HOSTED=False)
-    @with_feature("auth:enterprise-superuser-read-write")
+    @override_options({"superuser.read-write.ga-rollout": True})
     def test_superuser_write_can_remove_member(self):
         superuser = self.create_user(is_superuser=True)
         self.add_user_permission(superuser, "superuser.write")
@@ -858,7 +859,8 @@ class UpdateOrganizationMemberTeamTest(OrganizationMemberTeamTestBase):
             )
             assert updated_omt.role == "admin"
 
-    @with_feature({"organizations:team-roles": True, "auth:enterprise-superuser-read-write": True})
+    @with_feature("organizations:team-roles")
+    @override_options({"superuser.read-write.ga-rollout": True})
     @override_settings(SENTRY_SELF_HOSTED=False)
     def test_superuser_read_cannot_promote_member(self):
         superuser = self.create_user(is_superuser=True)
@@ -870,7 +872,8 @@ class UpdateOrganizationMemberTeamTest(OrganizationMemberTeamTestBase):
         assert resp.status_code == 400
         assert resp.data["detail"] == ERR_INSUFFICIENT_ROLE
 
-    @with_feature({"organizations:team-roles": True, "auth:enterprise-superuser-read-write": True})
+    @with_feature("organizations:team-roles")
+    @override_options({"superuser.read-write.ga-rollout": True})
     @override_settings(SENTRY_SELF_HOSTED=False)
     def test_superuser_write_can_promote_member(self):
         superuser = self.create_user(is_superuser=True)
@@ -914,4 +917,5 @@ class UpdateOrganizationMemberTeamTest(OrganizationMemberTeamTestBase):
         target_omt = OrganizationMemberTeam.objects.get(
             team=self.team, organizationmember=other_member
         )
+        assert target_omt.role is None
         assert target_omt.role is None

--- a/tests/sentry/api/endpoints/test_organization_sentry_app_installations.py
+++ b/tests/sentry/api/endpoints/test_organization_sentry_app_installations.py
@@ -7,6 +7,7 @@ from sentry.sentry_apps.apps import SentryAppUpdater
 from sentry.slug.errors import DEFAULT_SLUG_ERROR_MESSAGE
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.helpers.features import with_feature
+from sentry.testutils.helpers.options import override_options
 from sentry.testutils.silo import control_silo_test
 
 
@@ -74,7 +75,7 @@ class GetSentryAppInstallationsTest(SentryAppInstallationsTest):
             response = self.get_success_response(self.super_org.slug, status_code=200)
 
     @override_settings(SENTRY_SELF_HOSTED=False)
-    @with_feature("auth:enterprise-superuser-read-write")
+    @override_options({"superuser.read-write.ga-rollout": True})
     def test_superuser_read_and_write_sees_all_installs(self):
         # test SaaS only
         self.login_as(user=self.superuser, superuser=True)
@@ -165,7 +166,7 @@ class PostSentryAppInstallationsTest(SentryAppInstallationsTest):
         self.get_success_response(self.org.slug, slug=app2.slug, status_code=200)
 
     @override_settings(SENTRY_SELF_HOSTED=False)
-    @with_feature("auth:enterprise-superuser-read-write")
+    @override_options({"superuser.read-write.ga-rollout": True})
     def test_install_superuser_read(self):
         self.login_as(user=self.superuser, superuser=True)
 
@@ -173,7 +174,7 @@ class PostSentryAppInstallationsTest(SentryAppInstallationsTest):
         self.get_error_response(self.org.slug, slug=app.slug, status_code=404)
 
     @override_settings(SENTRY_SELF_HOSTED=False)
-    @with_feature("auth:enterprise-superuser-read-write")
+    @override_options({"superuser.read-write.ga-rollout": True})
     def test_install_superuser_write(self):
         self.login_as(user=self.superuser, superuser=True)
         self.add_user_permission(self.superuser, "superuser.write")

--- a/tests/sentry/api/endpoints/test_project_performance_issue_settings.py
+++ b/tests/sentry/api/endpoints/test_project_performance_issue_settings.py
@@ -176,9 +176,8 @@ class ProjectPerformanceIssueSettingsTest(APITestCase):
         assert not get_response.data["n_plus_one_db_queries_detection_enabled"]
 
     @override_settings(SENTRY_SELF_HOSTED=False)
-    @with_feature(
-        {"organizations:performance-view": True, "auth:enterprise-superuser-read-write": True}
-    )
+    @with_feature("organizations:performance-view")
+    @override_options({"superuser.read-write.ga-rollout": True})
     def test_put_superuser_read_write_updates_detection_setting(self):
         # superuser read-only cannot hit put
         self.get_error_response(

--- a/tests/sentry/api/endpoints/test_sentry_apps.py
+++ b/tests/sentry/api/endpoints/test_sentry_apps.py
@@ -21,6 +21,7 @@ from sentry.models.organizationmember import OrganizationMember
 from sentry.silo.base import SiloMode
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.helpers import Feature, with_feature
+from sentry.testutils.helpers.options import override_options
 from sentry.testutils.silo import assume_test_silo_mode, control_silo_test
 from sentry.utils import json
 
@@ -191,7 +192,7 @@ class SuperuserStaffGetSentryAppsTest(SentryAppsTest):
             self.get_success_response(status_code=200)
 
     @override_settings(SENTRY_SELF_HOSTED=False)
-    @with_feature("auth:enterprise-superuser-read-write")
+    @override_options({"superuser.read-write.ga-rollout": True})
     def test_superuser_read_write_sees_all_apps(self):
         self.get_success_response(status_code=200)
 
@@ -380,12 +381,12 @@ class SuperuserStaffPostSentryAppsTest(SentryAppsTest):
             )
 
     @override_settings(SENTRY_SELF_HOSTED=False)
-    @with_feature("auth:enterprise-superuser-read-write")
+    @override_options({"superuser.read-write.ga-rollout": True})
     def test_superuser_read_cannot_create(self):
         self.get_error_response(**self.get_data(name="POPULARITY"))
 
     @override_settings(SENTRY_SELF_HOSTED=False)
-    @with_feature("auth:enterprise-superuser-read-write")
+    @override_options({"superuser.read-write.ga-rollout": True})
     def test_superuser_read_can_create(self):
         self.add_user_permission(self.superuser, "superuser.write")
         self.get_success_response(**self.get_data(popularity=POPULARITY), status_code=201)

--- a/tests/sentry/api/endpoints/test_sentry_internal_app_token_details.py
+++ b/tests/sentry/api/endpoints/test_sentry_internal_app_token_details.py
@@ -3,7 +3,7 @@ from rest_framework import status
 
 from sentry.models.apitoken import ApiToken
 from sentry.testutils.cases import APITestCase
-from sentry.testutils.helpers.features import with_feature
+from sentry.testutils.helpers.options import override_options
 from sentry.testutils.silo import control_silo_test
 
 
@@ -101,7 +101,7 @@ class SentryInternalAppTokenCreationTest(APITestCase):
         assert not ApiToken.objects.filter(pk=self.api_token.id).exists()
 
     @override_settings(SENTRY_SELF_HOSTED=False)
-    @with_feature("auth:enterprise-superuser-read-write")
+    @override_options({"superuser.read-write.ga-rollout": True})
     def test_superuser_read_write_delete(self):
         self.login_as(self.superuser, superuser=True)
 

--- a/tests/sentry/api/endpoints/test_sentry_internal_app_tokens.py
+++ b/tests/sentry/api/endpoints/test_sentry_internal_app_tokens.py
@@ -4,7 +4,7 @@ from rest_framework import status
 from sentry.models.apitoken import ApiToken
 from sentry.models.integrations.sentry_app import MASKED_VALUE
 from sentry.testutils.cases import APITestCase
-from sentry.testutils.helpers.features import with_feature
+from sentry.testutils.helpers.options import override_options
 from sentry.testutils.silo import control_silo_test
 
 
@@ -78,7 +78,7 @@ class PostSentryInternalAppTokenTest(SentryInternalAppTokenTest):
         )
 
     @override_settings(SENTRY_SELF_HOSTED=False)
-    @with_feature("auth:enterprise-superuser-read-write")
+    @override_options({"superuser.read-write.ga-rollout": True})
     def test_superuser_read_write_post(self):
         # only superuser write can hit post
         self.login_as(self.superuser, superuser=True)
@@ -155,7 +155,7 @@ class GetSentryInternalAppTokenTest(SentryInternalAppTokenTest):
         self.get_success_response(self.internal_sentry_app.slug)
 
     @override_settings(SENTRY_SELF_HOSTED=False)
-    @with_feature("auth:enterprise-superuser-read-write")
+    @override_options({"superuser.read-write.ga-rollout": True})
     def test_superuser_read_write_get(self):
         self.login_as(self.superuser, superuser=True)
         self.get_success_response(self.internal_sentry_app.slug)

--- a/tests/sentry/api/endpoints/test_user_details.py
+++ b/tests/sentry/api/endpoints/test_user_details.py
@@ -11,7 +11,6 @@ from sentry.models.userrole import UserRole
 from sentry.silo.base import SiloMode
 from sentry.tasks.deletion.hybrid_cloud import schedule_hybrid_cloud_foreign_key_jobs
 from sentry.testutils.cases import APITestCase
-from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.helpers.options import override_options
 from sentry.testutils.hybrid_cloud import HybridCloudTestMixin
 from sentry.testutils.outbox import outbox_runner
@@ -234,7 +233,7 @@ class UserDetailsSuperuserUpdateTest(UserDetailsTest):
         assert not user.is_active
 
     @override_settings(SENTRY_SELF_HOSTED=False)
-    @with_feature("auth:enterprise-superuser-read-write")
+    @override_options({"superuser.read-write.ga-rollout": True})
     def test_superuser_read_cannot_change_is_active(self):
         self.user.update(is_active=True)
         superuser = self.create_user(email="b@example.com", is_superuser=True)
@@ -250,7 +249,7 @@ class UserDetailsSuperuserUpdateTest(UserDetailsTest):
         assert self.user.is_active
 
     @override_settings(SENTRY_SELF_HOSTED=False)
-    @with_feature("auth:enterprise-superuser-read-write")
+    @override_options({"superuser.read-write.ga-rollout": True})
     def test_superuser_write_can_change_is_active(self):
         self.user.update(is_active=True)
         superuser = self.create_user(email="b@example.com", is_superuser=True)

--- a/tests/sentry/auth/test_access.py
+++ b/tests/sentry/auth/test_access.py
@@ -22,6 +22,7 @@ from sentry.services.hybrid_cloud.organization import organization_service
 from sentry.silo.base import SiloMode
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers import with_feature
+from sentry.testutils.helpers.options import override_options
 from sentry.testutils.silo import all_silo_test, assume_test_silo_mode, no_silo_test
 
 
@@ -574,7 +575,7 @@ class FromRequestTest(AccessFactoryTestCase):
         result = self.from_request(request, self.org)
         assert result.scopes == SUPERUSER_SCOPES
 
-    @with_feature("auth:enterprise-superuser-read-write")
+    @override_options({"superuser.read-write.ga-rollout": True})
     @override_settings(SENTRY_SELF_HOSTED=False)
     def test_superuser_readonly_scopes(self):
         # superuser not in organization
@@ -596,7 +597,7 @@ class FromRequestTest(AccessFactoryTestCase):
         result = self.from_request(request, self.org, scopes=member.get_scopes())
         assert result.scopes == set(member.get_scopes()).union({"org:superuser"})
 
-    @with_feature("auth:enterprise-superuser-read-write")
+    @override_options({"superuser.read-write.ga-rollout": True})
     @override_settings(SENTRY_SELF_HOSTED=False)
     def test_superuser_write_scopes(self):
         self.add_user_permission(self.superuser, "superuser.write")
@@ -613,7 +614,7 @@ class FromRequestTest(AccessFactoryTestCase):
         result = self.from_request(request, self.org)
         assert result.scopes == SUPERUSER_SCOPES
 
-    @with_feature("auth:enterprise-superuser-read-write")
+    @override_options({"superuser.read-write.ga-rollout": True})
     @override_settings(SENTRY_SELF_HOSTED=False)
     def test_superuser_in_organization_write_scopes(self):
         self.add_user_permission(self.superuser, "superuser.write")

--- a/tests/sentry/auth/test_superuser.py
+++ b/tests/sentry/auth/test_superuser.py
@@ -34,7 +34,7 @@ from sentry.middleware.superuser import SuperuserMiddleware
 from sentry.services.hybrid_cloud.auth.model import RpcAuthState, RpcMemberSsoState
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.datetime import freeze_time
-from sentry.testutils.helpers.features import with_feature
+from sentry.testutils.helpers.options import override_options
 from sentry.testutils.silo import control_silo_test
 from sentry.utils import json
 from sentry.utils.auth import mark_sso_complete
@@ -476,7 +476,7 @@ class SuperuserTestCase(TestCase):
         assert get_superuser_scopes(auth_state_with_write, user) == SUPERUSER_SCOPES
 
         # test scope separation
-        with self.feature("auth:enterprise-superuser-read-write"):
+        with self.options({"superuser.read-write.ga-rollout": True}):
             assert get_superuser_scopes(auth_state, user) == SUPERUSER_READONLY_SCOPES
             assert get_superuser_scopes(auth_state_with_write, user) == SUPERUSER_SCOPES
 
@@ -493,7 +493,7 @@ class SuperuserTestCase(TestCase):
         assert get_superuser_scopes(auth_state, user) == SUPERUSER_SCOPES
         assert get_superuser_scopes(auth_state_with_write, user) == SUPERUSER_SCOPES
 
-        with self.feature("auth:enterprise-superuser-read-write"):
+        with self.feature({"superuser.read-write.ga-rollout": True}):
             assert get_superuser_scopes(auth_state, user) == SUPERUSER_SCOPES
             assert get_superuser_scopes(auth_state_with_write, user) == SUPERUSER_SCOPES
 
@@ -517,7 +517,7 @@ class SuperuserTestCase(TestCase):
         assert superuser_has_permission(request)
 
     @override_settings(SENTRY_SELF_HOSTED=False)
-    @with_feature("auth:enterprise-superuser-read-write")
+    @override_options({"superuser.read-write.ga-rollout": True})
     def test_superuser_has_permission_read_write_get(self):
         request = self.build_request(method="GET")
 
@@ -532,7 +532,7 @@ class SuperuserTestCase(TestCase):
         assert superuser_has_permission(request)
 
     @override_settings(SENTRY_SELF_HOSTED=False)
-    @with_feature("auth:enterprise-superuser-read-write")
+    @override_options({"superuser.read-write.ga-rollout": True})
     def test_superuser_has_permission_read_write_post(self):
         request = self.build_request(method="POST")
 
@@ -548,7 +548,7 @@ class SuperuserTestCase(TestCase):
         assert superuser_has_permission(request)
 
     @override_settings(SENTRY_SELF_HOSTED=False)
-    @with_feature("auth:enterprise-superuser-read-write")
+    @override_options({"superuser.read-write.ga-rollout": True})
     def test_superuser_has_permission_read_write_no_request_access(self):
         request = self.build_request(method="GET")
 


### PR DESCRIPTION
Part 1 of replacing the superuser read-write feature flag with an option. There's code in getsentry that is using the flag, so we can't completely remove it yet.

The flag is not currently turned on, so using an OR for either the option or the flag for the logic is fine. This will be temporary.