### PR TITLE
feat(traces): Improve breakdown UI

### DIFF
--- a/static/app/views/performance/traces/content.tsx
+++ b/static/app/views/performance/traces/content.tsx
@@ -1,6 +1,7 @@
 import {Fragment, useCallback, useMemo, useState} from 'react';
 import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
+import debounce from 'lodash/debounce';
 
 import {Button} from 'sentry/components/button';
 import Count from 'sentry/components/count';
@@ -167,6 +168,15 @@ export function Content() {
 
 function TraceRow({trace}: {trace: TraceResult<Field>}) {
   const [expanded, setExpanded] = useState<boolean>(false);
+  const [highlightedSliceName, _setHighlightedSliceName] = useState('');
+
+  const setHighlightedSliceName = useMemo(
+    () =>
+      debounce(sliceName => _setHighlightedSliceName(sliceName), 100, {
+        leading: true,
+      }),
+    [_setHighlightedSliceName]
+  );
   return (
     <Fragment>
       <StyledPanelItem align="center" center>
@@ -195,9 +205,16 @@ function TraceRow({trace}: {trace: TraceResult<Field>}) {
       <StyledPanelItem align="right">
         <Count value={trace.numSpans} />
       </StyledPanelItem>
-      <StyledPanelItem align="right">
-        <TraceBreakdownRenderer trace={trace} />
-      </StyledPanelItem>
+      <BreakdownPanelItem
+        align="right"
+        highlightedSliceName={highlightedSliceName}
+        onMouseLeave={() => setHighlightedSliceName('')}
+      >
+        <TraceBreakdownRenderer
+          trace={trace}
+          setHighlightedSliceName={setHighlightedSliceName}
+        />
+      </BreakdownPanelItem>
       <StyledPanelItem align="right">
         <PerformanceDuration milliseconds={trace.duration} abbreviation />
       </StyledPanelItem>
@@ -205,7 +222,13 @@ function TraceRow({trace}: {trace: TraceResult<Field>}) {
         <TraceIssuesRenderer trace={trace} />
       </StyledPanelItem>
       <StyledPanelItem style={{padding: '5px'}} />
-      {expanded && <SpanTable spans={trace.spans} trace={trace} />}
+      {expanded && (
+        <SpanTable
+          spans={trace.spans}
+          trace={trace}
+          setHighlightedSliceName={setHighlightedSliceName}
+        />
+      )}
     </Fragment>
   );
 }
@@ -213,7 +236,9 @@ function TraceRow({trace}: {trace: TraceResult<Field>}) {
 function SpanTable({
   spans,
   trace,
+  setHighlightedSliceName,
 }: {
+  setHighlightedSliceName: (sliceName: string) => void;
   spans: SpanResult<Field>[];
   trace: TraceResult<Field>;
 }) {
@@ -236,7 +261,12 @@ function SpanTable({
           </StyledPanelHeader>
 
           {spans.map(span => (
-            <SpanRow key={span.id} span={span} trace={trace} />
+            <SpanRow
+              key={span.id}
+              span={span}
+              trace={trace}
+              setHighlightedSliceName={setHighlightedSliceName}
+            />
           ))}
         </SpanPanelContent>
       </StyledPanel>
@@ -244,7 +274,16 @@ function SpanTable({
   );
 }
 
-function SpanRow({span, trace}: {span: SpanResult<Field>; trace: TraceResult<Field>}) {
+function SpanRow({
+  span,
+  trace,
+  setHighlightedSliceName,
+}: {
+  setHighlightedSliceName: (sliceName: string) => void;
+  span: SpanResult<Field>;
+
+  trace: TraceResult<Field>;
+}) {
   const theme = useTheme();
   return (
     <Fragment>
@@ -265,7 +304,7 @@ function SpanRow({span, trace}: {span: SpanResult<Field>; trace: TraceResult<Fie
           {span['span.description']}
         </Description>
       </StyledSpanPanelItem>
-      <StyledSpanPanelItem align="right">
+      <StyledSpanPanelItem align="right" onMouseLeave={() => setHighlightedSliceName('')}>
         <TraceBreakdownContainer>
           <SpanBreakdownSliceRenderer
             sliceName={span.project}
@@ -273,6 +312,7 @@ function SpanRow({span, trace}: {span: SpanResult<Field>; trace: TraceResult<Fie
             sliceEnd={Math.floor(span['precise.finish_ts'] * 1000)}
             trace={trace}
             theme={theme}
+            onMouseEnter={() => setHighlightedSliceName(span.project)}
           />
         </TraceBreakdownContainer>
       </StyledSpanPanelItem>
@@ -438,6 +478,17 @@ const StyledSpanPanelItem = styled(StyledPanelItem)`
 
 const SpanTablePanelItem = styled(StyledPanelItem)`
   background-color: ${p => p.theme.gray100};
+`;
+
+const BreakdownPanelItem = styled(StyledPanelItem)<{highlightedSliceName: string}>`
+  ${p =>
+    p.highlightedSliceName
+      ? `--highlightedSlice-${p.highlightedSliceName}-opacity: 1.0;`
+      : null}
+  ${p =>
+    p.highlightedSliceName
+      ? `--defaultSlice-opacity: 0.3;`
+      : `--defaultSlice-opacity: 1.0;`}
 `;
 
 const EmptyValueContainer = styled('span')`

--- a/static/app/views/performance/traces/fieldRenderers.tsx
+++ b/static/app/views/performance/traces/fieldRenderers.tsx
@@ -12,10 +12,10 @@ import PerformanceDuration from 'sentry/components/performanceDuration';
 import {Tooltip} from 'sentry/components/tooltip';
 import {IconIssues} from 'sentry/icons';
 import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
 import type {DateString} from 'sentry/types/core';
 import {generateLinkToEventInTraceView} from 'sentry/utils/discover/urls';
 import {getShortEventId} from 'sentry/utils/events';
-import toPercent from 'sentry/utils/number/toPercent';
 import Projects from 'sentry/utils/projects';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
@@ -58,14 +58,30 @@ export const TraceBreakdownContainer = styled('div')`
   min-width: 150px;
   height: ${ROW_HEIGHT - 2 * ROW_PADDING}px;
   background-color: ${p => p.theme.gray100};
+  overflow: hidden;
 `;
 
-const RectangleTraceBreakdown = styled(RowRectangle)`
+const RectangleTraceBreakdown = styled(RowRectangle)<{
+  sliceColor: string;
+  sliceName: string | null;
+}>`
+  background-color: ${p => p.sliceColor};
   position: relative;
   width: 100%;
+  ${p => `
+    opacity: var(--highlightedSlice-${p.sliceName ?? ''}-opacity, var(--defaultSlice-opacity, 1.0));
+  `}
+  transition: opacity 0.3s cubic-bezier(0.4, 0, 0.2, 1);
 `;
 
-export function TraceBreakdownRenderer({trace}: {trace: TraceResult<Field>}) {
+export function TraceBreakdownRenderer({
+  trace,
+  setHighlightedSliceName,
+}: {
+  setHighlightedSliceName: (sliceName: string) => void;
+
+  trace: TraceResult<Field>;
+}) {
   const theme = useTheme();
 
   return (
@@ -79,6 +95,9 @@ export function TraceBreakdownRenderer({trace}: {trace: TraceResult<Field>}) {
             sliceEnd={breakdown.end}
             trace={trace}
             theme={theme}
+            onMouseEnter={() =>
+              breakdown.project ? setHighlightedSliceName(breakdown.project) : null
+            }
           />
         );
       })}
@@ -86,13 +105,17 @@ export function TraceBreakdownRenderer({trace}: {trace: TraceResult<Field>}) {
   );
 }
 
+const BREAKDOWN_BAR_SIZE = 150;
+const BREAKDOWN_QUANTIZE_STEP = 3;
 export function SpanBreakdownSliceRenderer({
   trace,
   theme,
   sliceName,
   sliceStart,
   sliceEnd,
+  onMouseEnter,
 }: {
+  onMouseEnter: () => void;
   sliceEnd: number;
   sliceName: string | null;
   sliceStart: number;
@@ -107,22 +130,32 @@ export function SpanBreakdownSliceRenderer({
     return null;
   }
   const sliceColor = sliceName ? pickBarColor(sliceName) : theme.gray100;
-  const slicePercent = toPercent(sliceDuration / traceDuration);
+  const sliceWidth =
+    BREAKDOWN_QUANTIZE_STEP *
+    Math.ceil(
+      (BREAKDOWN_BAR_SIZE / BREAKDOWN_QUANTIZE_STEP) * (sliceDuration / traceDuration)
+    );
   const relativeSliceStart = sliceStart - trace.start;
-  const sliceOffset = toPercent(relativeSliceStart / traceDuration);
+  const sliceOffset =
+    BREAKDOWN_QUANTIZE_STEP *
+    Math.floor(
+      ((BREAKDOWN_BAR_SIZE / BREAKDOWN_QUANTIZE_STEP) * relativeSliceStart) /
+        traceDuration
+    ); // 150px wide breakdown.
   return (
-    <div
-      style={{
-        width: `max(2px, ${slicePercent})`,
-        left: sliceOffset,
-        position: 'absolute',
-        ...(sliceName ? {} : {zIndex: -1}),
-      }}
+    <BreakdownSlice
+      sliceName={sliceName}
+      sliceOffset={sliceOffset}
+      sliceWidth={sliceWidth}
+      onMouseEnter={onMouseEnter}
     >
       <Tooltip
         title={
           <div>
-            <div>{sliceName}</div>
+            <FlexContainer>
+              {sliceName ? <ProjectRenderer projectSlug={sliceName} hideName /> : null}
+              <div>{sliceName}</div>
+            </FlexContainer>
             <div>
               <PerformanceDuration milliseconds={sliceDuration} abbreviation />
             </div>
@@ -130,16 +163,30 @@ export function SpanBreakdownSliceRenderer({
         }
         containerDisplayMode="block"
       >
-        <RectangleTraceBreakdown
-          style={{
-            backgroundColor: sliceColor,
-          }}
-          onClick={_ => {}}
-        />
+        <RectangleTraceBreakdown sliceColor={sliceColor} sliceName={sliceName} />
       </Tooltip>
-    </div>
+    </BreakdownSlice>
   );
 }
+
+const FlexContainer = styled('div')`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: ${space(0.5)};
+  padding-bottom: ${space(0.5)};
+`;
+
+const BreakdownSlice = styled('div')<{
+  sliceName: string | null;
+  sliceOffset: number;
+  sliceWidth: number;
+}>`
+  position: absolute;
+  width: max(3px, ${p => p.sliceWidth}px);
+  left: ${p => p.sliceOffset}px;
+  ${p => (p.sliceName ? null : 'z-index: -1;')}
+`;
 
 interface SpanIdRendererProps {
   projectSlug: string;


### PR DESCRIPTION
### Summary
This adds highlights to the breakdown and improves the ux experience on hover. Sets a minimum width that each slice can be in the breakdown to improve targetting.
