### PR TITLE
ref: move settings creation to sentry init command

### DIFF
--- a/src/sentry/runner/commands/config.py
+++ b/src/sentry/runner/commands/config.py
@@ -1,5 +1,6 @@
 import click
 
+from sentry.runner.commands.init import generate_secret_key as _generate_secret_key
 from sentry.runner.decorators import configuration
 
 
@@ -160,9 +161,7 @@ def dump(flags: int, only_set: bool, pretty_print: bool) -> None:
 @config.command(name="generate-secret-key")
 def generate_secret_key() -> None:
     "Generate a new cryptographically secure secret key value."
-    from sentry.runner.settings import generate_secret_key
-
-    click.echo(generate_secret_key())
+    click.echo(_generate_secret_key())
 
 
 @config.command()

--- a/src/sentry/runner/settings.py
+++ b/src/sentry/runner/settings.py
@@ -1,4 +1,3 @@
-import importlib.resources
 import os
 import warnings
 
@@ -8,34 +7,6 @@ from sentry.runner import importer
 
 DEFAULT_SETTINGS_CONF = "config.yml"
 DEFAULT_SETTINGS_OVERRIDE = "sentry.conf.py"
-
-
-def generate_secret_key() -> str:
-    from django.utils.crypto import get_random_string
-
-    chars = "abcdefghijklmnopqrstuvwxyz0123456789!@#%^&*(-_=+)"
-    return get_random_string(50, chars)
-
-
-def load_config_template(path: str, version: str = "default") -> str:
-    return importlib.resources.files("sentry").joinpath(f"data/config/{path}.{version}").read_text()
-
-
-def generate_settings(dev: bool = False) -> tuple[str, str]:
-    """
-    This command is run when ``default_path`` doesn't exist, or ``init`` is
-    run and returns a string representing the default data to put into their
-    settings file.
-    """
-    context = {
-        "secret_key": generate_secret_key(),
-        "debug_flag": dev,
-        "mail.backend": "console" if dev else "smtp",
-    }
-
-    py = load_config_template(DEFAULT_SETTINGS_OVERRIDE, "default") % context
-    yaml = load_config_template(DEFAULT_SETTINGS_CONF, "default") % context
-    return py, yaml
 
 
 def get_sentry_conf() -> str:


### PR DESCRIPTION
this is very far down the rabbit hole but the first part of a larger refactor to make application initialization simpler such that I can unbreak a bunch of import cycles to upgrade django-stubs

<!-- Describe your PR here. -->