### PR TITLE
feat(issue-search): implements x-hits and cursor logic for snuba only search

### DIFF
--- a/src/sentry/issues/endpoints/organization_group_index.py
+++ b/src/sentry/issues/endpoints/organization_group_index.py
@@ -56,6 +56,12 @@ UNSUPPORTED_SNUBA_FILTERS = [
     "subscribed_by",
     "regressed_in_release",
     "issue.priority",
+    "firstRelease",
+    "firstSeen",
+    "lastSeen",
+    "release.build",
+    "release.package",
+    "release.dist",
 ]
 
 


### PR DESCRIPTION
This PR makes sure we properly set the `X-Hits` and pagination logic for the new snuba only search. One thing I want to call out is that there might be issues when issues are pending deletion or being merged. We may return less than a full page of results in that case. This problem is likely worse than the postgres only search because we aren't checking PG for issue state before hitting Snuba.

Note that I am not sure about some of the logic overriding the default behavior for `has_results`. The existing logic is somewhat convoluted and I'm not sure we actually need it.

I also added more filters that we currently don't support for snuba only search. Some of them like `firstSeen` should be easy to support while others are harder.