### PR TITLE
chore(superuser): replace read-write FF entirely with option

### DIFF
--- a/src/sentry/auth/superuser.py
+++ b/src/sentry/auth/superuser.py
@@ -24,7 +24,7 @@ from django.utils.crypto import constant_time_compare, get_random_string
 from rest_framework import serializers, status
 from rest_framework.request import Request
 
-from sentry import features, options
+from sentry import options
 from sentry.api.exceptions import SentryAPIException
 from sentry.auth.elevated_mode import ElevatedMode, InactiveReason
 from sentry.auth.system import is_system_auth
@@ -81,10 +81,7 @@ def get_superuser_scopes(auth_state: RpcAuthState, user: Any) -> set[str]:
     superuser_scopes = SUPERUSER_SCOPES
     if (
         not is_self_hosted()
-        and (
-            options.get("superuser.read-write.ga-rollout")
-            or features.has("auth:enterprise-superuser-read-write", actor=user)
-        )
+        and options.get("superuser.read-write.ga-rollout")
         and "superuser.write" not in auth_state.permissions
     ):
         superuser_scopes = SUPERUSER_READONLY_SCOPES
@@ -111,10 +108,7 @@ def superuser_has_permission(
         return True
 
     # if we aren't enforcing superuser read-write, then superuser always has access
-    if not (
-        features.has("auth:enterprise-superuser-read-write", actor=request.user)
-        or options.get("superuser.read-write.ga-rollout")
-    ):
+    if not options.get("superuser.read-write.ga-rollout"):
         return True
 
     # either request.access or permissions must exist

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1455,8 +1455,6 @@ SENTRY_EARLY_FEATURES = {
 
 # NOTE: Please maintain alphabetical order when adding new feature flags
 SENTRY_FEATURES: dict[str, bool | None] = {
-    # Enables superuser read vs. write separation
-    "auth:enterprise-superuser-read-write": False,
     # Enables user registration.
     "auth:register": True,
     # Enables activated alert rules

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -30,7 +30,6 @@ def register_temporary_features(manager: FeatureManager):
     # NOTE: Please maintain alphabetical order when adding new feature flags
 
     # Features that don't use resource scoping
-    manager.add("auth:enterprise-superuser-read-write", SystemFeature, FeatureHandlerStrategy.INTERNAL)
     manager.add("auth:register", SystemFeature, FeatureHandlerStrategy.INTERNAL)
     manager.add("organizations:create", SystemFeature, FeatureHandlerStrategy.INTERNAL)
     manager.add("organizations:multi-region-selector", SystemFeature, FeatureHandlerStrategy.INTERNAL)


### PR DESCRIPTION
Replaces the temporary OR with the option and the feature flag introduced in https://github.com/getsentry/sentry/pull/70083 with just the option. Usage of the FF has been removed from getsentry.