### PR TITLE
feat(issues/feedback): allow hasAttachments to be expanded for feedback usecase

### DIFF
--- a/src/sentry/api/endpoints/group_details.py
+++ b/src/sentry/api/endpoints/group_details.py
@@ -244,8 +244,8 @@ class GroupDetailsEndpoint(GroupEndpoint, EnvironmentMixin):
                 ):
                     return self.respond(status=404)
 
-                attachments = EventAttachment.objects.filter(group_id=group.id)
-                data.update({"hasAttachments": len(attachments) > 0})
+                num_attachments = EventAttachment.objects.filter(group_id=group.id).count()
+                data.update({"hasAttachments": num_attachments > 0})
 
             data.update(
                 {

--- a/src/sentry/api/serializers/models/group_stream.py
+++ b/src/sentry/api/serializers/models/group_stream.py
@@ -406,8 +406,8 @@ class StreamGroupSerializerSnuba(GroupSerializerSnuba, GroupStatsMixin):
                 return self.respond(status=404)
 
             for item in item_list:
-                attachments = EventAttachment.objects.filter(group_id=item.id)
-                attrs[item].update({"hasAttachments": len(attachments) > 0})
+                num_attachments = EventAttachment.objects.filter(group_id=item.id).count()
+                attrs[item].update({"hasAttachments": num_attachments > 0})
 
         return attrs
 

--- a/src/sentry/api/serializers/models/group_stream.py
+++ b/src/sentry/api/serializers/models/group_stream.py
@@ -25,6 +25,7 @@ from sentry.api.serializers.models.plugin import is_plugin_deprecated
 from sentry.constants import StatsPeriod
 from sentry.issues.grouptype import GroupCategory
 from sentry.models.environment import Environment
+from sentry.models.eventattachment import EventAttachment
 from sentry.models.group import Group
 from sentry.models.groupinbox import get_inbox_details
 from sentry.models.grouplink import GroupLink
@@ -396,6 +397,18 @@ class StreamGroupSerializerSnuba(GroupSerializerSnuba, GroupStatsMixin):
                 )
                 attrs[item].update({"sentryAppIssues": sentry_app_issues})
 
+        if self._expand("hasAttachments"):
+            if not features.has(
+                "organizations:event-attachments",
+                item.project.organization,
+                actor=request.user,
+            ):
+                return self.respond(status=404)
+
+            for item in item_list:
+                attachments = EventAttachment.objects.filter(group_id=item.id)
+                attrs[item].update({"hasAttachments": len(attachments) > 0})
+
         return attrs
 
     def serialize(
@@ -453,6 +466,9 @@ class StreamGroupSerializerSnuba(GroupSerializerSnuba, GroupStatsMixin):
 
         if self._expand("sentryAppIssues"):
             result["sentryAppIssues"] = attrs["sentryAppIssues"]
+
+        if self._expand("hasAttachments"):
+            result["hasAttachments"] = attrs["hasAttachments"]
 
         return result
 


### PR DESCRIPTION
relates to https://github.com/getsentry/sentry/issues/67795

allow expansion of a new flag on an issue, `hasAttachments`, which will specify whether a group has any event attachments. we'll use this in user feedback to show a indicator when a feedback has an attachment (e.g. screenshot).

context: the user feedback list shows small icon indicators when certain properties are true (e.g. `hasReplay`, `hasLinkedError`) and we want to add another one to this list: `hasAttachments` (aka `hasScreenshots`). however, the list relies on having issue data only. we don't have access to the attachments list just from the issue (we'd have to do a separate api call on the frontend to get the list of attachments which is unideal), so instead i'm adding an option to expand and directly put the `hasAttachments` property onto the issue when requested.

frontend changes using this PR are here: https://github.com/getsentry/sentry/pull/70109