### PR TITLE
fix(slack): Ensure notifications for same issue are seen

### DIFF
--- a/src/sentry/integrations/slack/actions/notification.py
+++ b/src/sentry/integrations/slack/actions/notification.py
@@ -93,19 +93,15 @@ class SlackNotifyServiceAction(IntegrationEventAction):
                 for block in additional_attachment:
                     blocks["blocks"].append(block)
 
+            payload = {
+                "text": blocks.get("text"),
+                "channel": channel,
+                "unfurl_links": False,
+                "unfurl_media": False,
+            }
             if payload_blocks := blocks.get("blocks"):
-                payload = {
-                    "text": blocks.get("text"),
-                    "blocks": json.dumps_experimental(
-                        "integrations.slack.enable-orjson", payload_blocks
-                    ),
-                    "channel": channel,
-                    "unfurl_links": False,
-                    "unfurl_media": False,
-                }
-                self.logger.info(
-                    "rule.slack_post.attachments",
-                    extra={"organization_id": event.group.project.organization_id},
+                payload["blocks"] = json.dumps_experimental(
+                    "integrations.slack.enable-orjson", payload_blocks
                 )
 
             rule = rules[0] if rules else None
@@ -158,6 +154,8 @@ class SlackNotifyServiceAction(IntegrationEventAction):
                     # To reply to a thread, use the specific key in the payload as referenced by the docs
                     # https://api.slack.com/methods/chat.postMessage#arg_thread_ts
                     payload["thread_ts"] = parent_notification_message.message_identifier
+                    # If this flow is triggered again for the same issue, we want it to be seen in the main channel
+                    payload["reply_broadcast"] = True
 
             client = SlackClient(integration_id=integration.id)
             try:


### PR DESCRIPTION
When the issue alert flow gets triggered for the same issue, we should ensure the notification gets seen in the main channel as well. Refactored some code a little to clean it up.

Resolves: https://github.com/getsentry/sentry/issues/70135#event-12684736214