### PR TITLE
feat(feedback): show IconImage on feedback list if it has a screenshot

### DIFF
--- a/static/app/components/feedback/list/feedbackListItem.tsx
+++ b/static/app/components/feedback/list/feedbackListItem.tsx
@@ -13,7 +13,7 @@ import {Flex} from 'sentry/components/profiling/flex';
 import TextOverflow from 'sentry/components/textOverflow';
 import TimeSince from 'sentry/components/timeSince';
 import {Tooltip} from 'sentry/components/tooltip';
-import {IconChat, IconCircleFill, IconFatal, IconPlay} from 'sentry/icons';
+import {IconChat, IconCircleFill, IconFatal, IconImage, IconPlay} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import ConfigStore from 'sentry/stores/configStore';
 import {useLegacyStore} from 'sentry/stores/useLegacyStore';
@@ -55,6 +55,7 @@ const FeedbackListItem = forwardRef<HTMLDivElement, Props>(
 
     const isCrashReport = feedbackItem.metadata.source === 'crash_report_embed_form';
     const isUserReportWithError = feedbackItem.metadata.source === 'user_report_envelope';
+    const hasAttachments = feedbackItem.hasAttachments;
     const hasComments = feedbackItem.numComments > 0;
     const theme = isOpen || config.theme === 'dark' ? darkTheme : lightTheme;
 
@@ -146,6 +147,12 @@ const FeedbackListItem = forwardRef<HTMLDivElement, Props>(
                 {hasReplayId && (
                   <Tooltip title={t('Linked Replay')} containerDisplayMode="flex">
                     <IconPlay size="xs" />
+                  </Tooltip>
+                )}
+
+                {hasAttachments && (
+                  <Tooltip title={t('Has Screenshot')} containerDisplayMode="flex">
+                    <IconImage size="xs" />
                   </Tooltip>
                 )}
 

--- a/static/app/components/feedback/useFeedbackListQueryKey.tsx
+++ b/static/app/components/feedback/useFeedbackListQueryKey.tsx
@@ -94,6 +94,7 @@ export default function useFeedbackListQueryKey({
                 'pluginIssues', // Gives us plugin issues available
                 'integrationIssues', // Gives us integration issues available
                 'sentryAppIssues', // Gives us Sentry app issues available
+                'hasAttachments', // Gives us whether the feedback has screenshots
               ],
           shortIdLookup: 0,
           query: `issue.category:feedback status:${mailbox} ${fixedQueryView.query}`,

--- a/static/app/types/group.tsx
+++ b/static/app/types/group.tsx
@@ -804,6 +804,7 @@ export interface BaseGroup {
   title: string;
   type: EventOrGroupType;
   userReportCount: number;
+  hasAttachments?: boolean;
   inbox?: InboxDetails | null | false;
   integrationIssues?: ExternalIssue[];
   latestEvent?: Event;


### PR DESCRIPTION
closes https://github.com/getsentry/sentry/issues/67795
follow up to https://github.com/getsentry/sentry/pull/70102 (the backend changes)

<img width="672" alt="SCR-20240501-oexu" src="https://github.com/getsentry/sentry/assets/56095982/3984ab3d-c919-4891-b6c9-439066525907">
