### PR TITLE
meta: Autofix codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -517,8 +517,12 @@ static/app/components/events/eventStatisticalDetector/                    @getse
 /src/sentry/api/endpoints/check_am2_compatibility.py    @getsentry/revenue
 
 ## ML & AI
-/static/app/components/events/aiSuggestedSolution/      @getsentry/machine-learning-ai
-/src/sentry/api/endpoints/event_ai_suggested_fix.py     @getsentry/machine-learning-ai
+*autofix*.py                                                @getsentry/machine-learning-ai
+/src/sentry/api/endpoints/event_ai_suggested_fix.py         @getsentry/machine-learning-ai
+/static/app/components/events/aiSuggestedSolution/          @getsentry/machine-learning-ai
+/static/app/components/events/autofix/                      @getsentry/machine-learning-ai
+/static/app/components/modals/autofixSetupModal.spec.tsx    @getsentry/machine-learning-ai
+/static/app/components/modals/autofixSetupModal.tsx         @getsentry/machine-learning-ai
 ## End of ML & AI
 
 ## Processing


### PR DESCRIPTION
Adds @getsentry/machine-learning-ai as codeowners, this should cover all autofix related files both backend and frontend.

As postmortem of https://getsentry.atlassian.net/browse/INC-743