### PR TITLE
chore: change powershell tag

### DIFF
--- a/src/sentry/utils/tag_normalization.py
+++ b/src/sentry/utils/tag_normalization.py
@@ -10,6 +10,7 @@ _KNOWN_TAGS = {
     "sentry.cocoa",
     "sentry.dart",
     "sentry.dotnet",
+    "sentry.dotnet.powershell",
     "sentry.elixir",
     "sentry.go",
     "sentry.java",
@@ -38,7 +39,6 @@ _KNOWN_TAGS = {
     "sentry.objc",
     "sentry.perl",
     "sentry.php",
-    "sentry.powershell",
     "sentry.python",
     "sentry.ruby",
     "sentry.rust",
@@ -57,6 +57,7 @@ _SYNONYMOUS_TAGS = {
     "sentry.react": "sentry.javascript.react",
     "sentry.symfony": "sentry.php.symfony",
     "sentry.unity": "sentry.native.unity",
+    "sentry.powershell": "sentry.dotnet.powershell",
 }
 
 # TODO: Should we be grouping by origin SDK instead? (For example, should we be


### PR DESCRIPTION
<!-- Describe your PR here. -->

The tag has been changed in the SDK to `sentry.dotnet.powershell`

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
