### PR TITLE
fix: Added `name` and `platform` to projects for the Setup Wizard

### DIFF
--- a/src/sentry/web/frontend/setup_wizard.py
+++ b/src/sentry/web/frontend/setup_wizard.py
@@ -123,6 +123,8 @@ class SetupWizardView(BaseView):
                 enriched_project = {
                     "slug": project.slug,
                     "id": project.id,
+                    "name": project.name,
+                    "platform": project.platform,
                     "status": STATUS_LABELS.get(project.status, "unknown"),
                 }
                 # The wizard only reads the a few fields so serializing the mapping should work fine


### PR DESCRIPTION
Before https://github.com/getsentry/sentry/pull/59153/ the `project` got serialized "as is" via `enriched_project = serialize(project)`.
The current construction of `enriched_project` leaves out `platform` and `name` which the Unity SDK setup wizard relies on.