### PR TITLE
fix(sidebar): fix quick start on mobile view

### DIFF
--- a/static/app/components/sidebar/onboardingStatus.tsx
+++ b/static/app/components/sidebar/onboardingStatus.tsx
@@ -11,6 +11,7 @@ import ProgressRing, {
   RingBar,
   RingText,
 } from 'sentry/components/progressRing';
+import {ExpandedContext} from 'sentry/components/sidebar/expandedContextProvider';
 import {isDone} from 'sentry/components/sidebar/utils';
 import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
@@ -46,6 +47,7 @@ export default function OnboardingStatus({
   };
   const onboardingContext = useContext(OnboardingContext);
   const {projects} = useProjects();
+  const {shouldAccordionFloat} = useContext(ExpandedContext);
 
   if (!org.features?.includes('onboarding')) {
     return null;
@@ -98,7 +100,7 @@ export default function OnboardingStatus({
           size={38}
           barWidth={6}
         />
-        {!collapsed && (
+        {!shouldAccordionFloat && (
           <div>
             <Heading>{label}</Heading>
             <Remaining>


### PR DESCRIPTION
The quick start was covering the icons in mobile view in the sidebar
![image](https://github.com/getsentry/sentry/assets/44422760/8c223ce2-5b5e-4d59-a7ab-2446567cbde2)

This is because the quick start would only collapse based on the sidebar being collapsed, and not based on if the sidebar is in mobile mode.

This updates the quickstart component to collapse if `shouldAccordionFloat` which equals `sidebarCollapsed || isInMobileView`

Now it looks like this
![image](https://github.com/getsentry/sentry/assets/44422760/6c382df6-86e0-4588-a2c0-bdfc07f30536)

This should fix it for the most part, but technically if its really narrow it also might have issues. I don't see this being an issue, not sure what screens are that narrow, but we can definitely look into it more down the road if it becomes a problem
