### PR TITLE
feat(traces): Add slight shift for breakdowns

### DIFF
--- a/static/app/views/performance/traces/content.tsx
+++ b/static/app/views/performance/traces/content.tsx
@@ -483,12 +483,20 @@ const SpanTablePanelItem = styled(StyledPanelItem)`
 const BreakdownPanelItem = styled(StyledPanelItem)<{highlightedSliceName: string}>`
   ${p =>
     p.highlightedSliceName
-      ? `--highlightedSlice-${p.highlightedSliceName}-opacity: 1.0;`
+      ? `--highlightedSlice-${p.highlightedSliceName}-opacity: 1.0;
+         --highlightedSlice-${p.highlightedSliceName}-transform: translateY(-1px);
+       `
       : null}
   ${p =>
     p.highlightedSliceName
-      ? `--defaultSlice-opacity: 0.3;`
-      : `--defaultSlice-opacity: 1.0;`}
+      ? `
+        --defaultSlice-opacity: 0.3;
+        --defaultSlice-transform: translateY(1px);
+        `
+      : `
+        --defaultSlice-opacity: 1.0;
+        --defaultSlice-transform: translateY(0px);
+        `}
 `;
 
 const EmptyValueContainer = styled('span')`

--- a/static/app/views/performance/traces/fieldRenderers.tsx
+++ b/static/app/views/performance/traces/fieldRenderers.tsx
@@ -58,7 +58,6 @@ export const TraceBreakdownContainer = styled('div')`
   min-width: 150px;
   height: ${ROW_HEIGHT - 2 * ROW_PADDING}px;
   background-color: ${p => p.theme.gray100};
-  overflow: hidden;
 `;
 
 const RectangleTraceBreakdown = styled(RowRectangle)<{
@@ -71,7 +70,10 @@ const RectangleTraceBreakdown = styled(RowRectangle)<{
   ${p => `
     opacity: var(--highlightedSlice-${p.sliceName ?? ''}-opacity, var(--defaultSlice-opacity, 1.0));
   `}
-  transition: opacity 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+  ${p => `
+    transform: var(--highlightedSlice-${p.sliceName ?? ''}-transform, var(--defaultSlice-transform, 1.0));
+  `}
+  transition: opacity,transform 0.2s cubic-bezier(0.4, 0, 0.2, 1);
 `;
 
 export function TraceBreakdownRenderer({


### PR DESCRIPTION
### Summary
This let's you see breakdown bars when they are stacked a bit better, since opacity gives hints as to depth, it can also make it unclear for the base breakdown bar (eg. frontend).

#### Screenshot

![Screenshot 2024-05-02 at 1 57 34 PM](https://github.com/getsentry/sentry/assets/6111995/7450b1cf-3b1a-4cca-82f2-b5986f313a5a)
