### PR TITLE
feat(spans): Track complete segments

### DIFF
--- a/src/sentry/spans/consumers/process/factory.py
+++ b/src/sentry/spans/consumers/process/factory.py
@@ -190,7 +190,7 @@ def _batch_write_to_redis(message: Message[ValuesBatch[SpanMessageWithMetadata]]
 
         client = RedisSpansBuffer()
 
-        for key, num_spans in expected_num_spans:
+        for key, num_spans in expected_num_spans.items():
             if num_spans == len(spans_map[key]):
                 metrics.incr("spans.consumers.process.full_segment_detected.count")
 


### PR DESCRIPTION
Track two metrics:
1. I want to see if we get full segments in a batch on process spans, if we do enough times, we could make a performance improvement where we produce the segment right away instead of sending to redis
2. Track if we have missing spans in a segment during perf issue detection (also a good indicator of the pipeline health)