### PR TITLE
fix(feedback): fix metric name emitted 

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -2857,7 +2857,7 @@ def _update_user_reports_with_event_link(job: Job, group_info: GroupInfo) -> Non
     )
 
     if user_reports_updated:
-        metrics.incr("event_manager.save._update_user_reports_with_event_link")
+        metrics.incr("event_manager.save._update_user_reports_with_event_link_updated")
 
 
 class PerformanceJob(TypedDict, total=False):


### PR DESCRIPTION
should be a different name compared to the one in the prev. part of the function