### PR TITLE
fix(autofix-setup): Ignore genAI consent for now

### DIFF
--- a/static/app/components/events/autofix/useAutofixSetup.tsx
+++ b/static/app/components/events/autofix/useAutofixSetup.tsx
@@ -50,7 +50,7 @@ export function useAutofixSetup(
     hasSuccessfulSetup: Boolean(
       queryData.data?.integration.ok &&
         queryData.data?.githubWriteIntegration.ok &&
-        queryData.data?.genAIConsent.ok &&
+        // queryData.data?.genAIConsent.ok &&
         queryData.data?.codebaseIndexing.ok
     ),
   };

--- a/static/app/components/modals/autofixSetupModal.tsx
+++ b/static/app/components/modals/autofixSetupModal.tsx
@@ -217,9 +217,8 @@ function AutofixCodebaseIndexingStep({
   const {startIndexing} = useAutofixCodebaseIndexing({projectId, groupId});
 
   const canIndex =
-    autofixSetup.genAIConsent.ok &&
-    autofixSetup.integration.ok &&
-    autofixSetup.githubWriteIntegration.ok;
+    // autofixSetup.genAIConsent.ok &&
+    autofixSetup.integration.ok && autofixSetup.githubWriteIntegration.ok;
 
   return (
     <Fragment>


### PR DESCRIPTION
As per discussed with @rachrwang we disable this for now for Autofix. Will re-enable for LA