### PR TITLE
chore(actor) Add methods to RpcActor to match ActorTuple

### DIFF
--- a/src/sentry/services/hybrid_cloud/actor.py
+++ b/src/sentry/services/hybrid_cloud/actor.py
@@ -46,9 +46,35 @@ class RpcActor(RpcModel):
         return hash((self.id, self.actor_type))
 
     @classmethod
+    def resolve_many(cls, actors: Iterable["RpcActor"]) -> list["Team | RpcUser"]:
+        """
+        Resolve a list of actors in a batch to the Team/User the Actor references.
+
+        Will generate more efficient queries to load actors than calling
+        RpcActor.resolve() individually will.
+        """
+        from sentry.models.team import Team
+
+        if not actors:
+            return []
+        actors_by_type: dict[ActorType, list[RpcActor]] = defaultdict(list)
+        for actor in actors:
+            actors_by_type[actor.actor_type].append(actor)
+        results: dict[tuple[ActorType, int], Team | RpcUser] = {}
+        for actor_type, actor_list in actors_by_type.items():
+            if actor_type == ActorType.USER:
+                for user in user_service.get_many(filter={"user_ids": [u.id for u in actor_list]}):
+                    results[(actor_type, user.id)] = user
+            if actor_type == ActorType.TEAM:
+                for team in Team.objects.filter(id__in=[t.id for t in actor_list]):
+                    results[(actor_type, team.id)] = team
+
+        return list(filter(None, [results.get((actor.actor_type, actor.id)) for actor in actors]))
+
+    @classmethod
     def many_from_object(cls, objects: Iterable[ActorTarget]) -> list["RpcActor"]:
         """
-        Create a list of RpcActor instaces based on a collection of 'objects'
+        Create a list of RpcActor instances based on a collection of 'objects'
 
         Objects will be grouped by the kind of actor they would be related to.
         Queries for actors are batched to increase efficiency. Users that are
@@ -129,6 +155,52 @@ class RpcActor(RpcModel):
     def from_rpc_team(cls, team: RpcTeam) -> "RpcActor":
         return cls(id=team.id, actor_type=ActorType.TEAM, slug=team.slug)
 
+    @classmethod
+    def from_identifier(cls, id: str | int | None) -> "RpcActor | None":
+        """
+        Parse an actor identifier into an RpcActor
+
+        Forms `id` can take:
+            1231 -> look up User by id
+            "1231" -> look up User by id
+            "user:1231" -> look up User by id
+            "team:1231" -> look up Team by id
+            "maiseythedog" -> look up User by username
+            "maisey@dogsrule.com" -> look up User by primary email
+        """
+        if not id:
+            return None
+        # If we have an integer, fall back to assuming it's a User
+        if isinstance(id, int):
+            return cls(id=id, actor_type=ActorType.USER)
+
+        # If the actor_identifier is a simple integer as a string,
+        # we're also a User
+        if id.isdigit():
+            return cls(id=int(id), actor_type=ActorType.USER)
+
+        if id.startswith("user:"):
+            return cls(id=int(id[5:]), actor_type=ActorType.USER)
+
+        if id.startswith("team:"):
+            return cls(id=int(id[5:]), actor_type=ActorType.TEAM)
+
+        try:
+            user = user_service.get_by_username(username=id)[0]
+            return cls(id=user.id, actor_type=ActorType.USER)
+        except IndexError as e:
+            raise ValueError(f"Unable to resolve actor identifier: {e}")
+
+    @classmethod
+    def from_id(cls, user_id: int | None = None, team_id: int | None = None) -> "RpcActor":
+        if user_id and team_id:
+            raise ValueError("You can only provide one of user_id and team_id")
+        if user_id:
+            return cls(id=user_id, actor_type=ActorType.USER)
+        if team_id:
+            return cls(id=team_id, actor_type=ActorType.TEAM)
+        raise ValueError("You must provide one of user_id and team_id")
+
     def __eq__(self, other: Any) -> bool:
         return (
             isinstance(other, self.__class__)
@@ -143,3 +215,7 @@ class RpcActor(RpcModel):
             return Team.objects.filter(id=self.id).first()
         if self.actor_type == ActorType.USER:
             return user_service.get_user(user_id=self.id)
+
+    @property
+    def identifier(self) -> str:
+        return f"{self.actor_type.lower()}:{self.id}"

--- a/src/sentry/utils/actor.py
+++ b/src/sentry/utils/actor.py
@@ -45,8 +45,9 @@ class ActorTuple(namedtuple("Actor", "id type")):
             "team:1231" -> look up Team by id
             "maiseythedog" -> look up User by username
             "maisey@dogsrule.com" -> look up User by primary email
-        """
 
+        Deprecated: Use RpcActor.from_identifier instead.
+        """
         if not actor_identifier:
             return None
 
@@ -73,6 +74,9 @@ class ActorTuple(namedtuple("Actor", "id type")):
 
     @classmethod
     def from_id(cls, user_id: int | None, team_id: int | None) -> ActorTuple | None:
+        """
+        Deprecated: Use RpcActor.from_id() instead.
+        """
         from sentry.models.team import Team
         from sentry.models.user import User
 
@@ -105,6 +109,8 @@ class ActorTuple(namedtuple("Actor", "id type")):
         as the input, minus any actors we couldn't resolve.
         :param actors:
         :return:
+
+        Deprecated: Replace with RpcActor.from_many_object()
         """
         from sentry.models.user import User
         from sentry.services.hybrid_cloud.user.service import user_service

--- a/tests/sentry/hybridcloud/test_actor.py
+++ b/tests/sentry/hybridcloud/test_actor.py
@@ -1,4 +1,8 @@
+import pytest
+
+from sentry.models.team import Team
 from sentry.services.hybrid_cloud.actor import ActorType, RpcActor
+from sentry.services.hybrid_cloud.user.model import RpcUser
 from sentry.services.hybrid_cloud.user.service import user_service
 from sentry.testutils.factories import Factories
 from sentry.testutils.pytest.fixtures import django_db_all
@@ -15,6 +19,62 @@ def test_many_from_object_users():
 
     assert actors[1].id == users[1].id
     assert actors[1].actor_type == ActorType.USER
+
+
+@django_db_all(transaction=True)
+def test_from_identifier():
+    user = Factories.create_user()
+    org = Factories.create_organization(owner=user)
+    team = Factories.create_team(organization=org)
+
+    actor = RpcActor.from_identifier(user.id)
+    assert actor
+    assert actor.id == user.id
+    assert actor.actor_type == ActorType.USER
+
+    actor = RpcActor.from_identifier(str(user.id))
+    assert actor
+    assert actor.id == user.id
+    assert actor.actor_type == ActorType.USER
+
+    actor = RpcActor.from_identifier(f"user:{user.id}")
+    assert actor
+    assert actor.id == user.id
+    assert actor.actor_type == ActorType.USER
+
+    actor = RpcActor.from_identifier(user.username)
+    assert actor
+    assert actor.id == user.id
+    assert actor.actor_type == ActorType.USER
+
+    actor = RpcActor.from_identifier(user.email)
+    assert actor
+    assert actor.id == user.id
+    assert actor.actor_type == ActorType.USER
+    assert actor.identifier == f"user:{user.id}"
+
+    actor = RpcActor.from_identifier(f"team:{team.id}")
+    assert actor
+    assert actor.id == team.id
+    assert actor.actor_type == ActorType.TEAM
+    assert actor.identifier == f"team:{team.id}"
+
+
+def test_from_id():
+    actor = RpcActor.from_id(team_id=1)
+    assert actor
+    assert actor.id == 1
+    assert actor.actor_type == ActorType.TEAM
+
+    actor = RpcActor.from_id(user_id=11)
+    assert actor
+    assert actor.id == 11
+    assert actor.actor_type == ActorType.USER
+
+    with pytest.raises(ValueError):
+        RpcActor.from_id(user_id=11, team_id=99)
+    with pytest.raises(ValueError):
+        RpcActor.from_id(user_id=None)
 
 
 @django_db_all(transaction=True)
@@ -71,3 +131,29 @@ def test_many_from_object_mixed():
     assert actors[1].id == teams[1].id
     assert actors[1].actor_type == ActorType.TEAM
     assert actors[1].slug
+
+
+@django_db_all(transaction=True)
+def test_resolve_many():
+    organization = Factories.create_organization()
+    team_one = Factories.create_team(organization=organization)
+    team_two = Factories.create_team(organization=organization)
+    user_one = Factories.create_user()
+    user_two = Factories.create_user()
+
+    members = [user_one, user_two, team_two, team_one]
+    actors = [RpcActor.from_object(m) for m in members]
+    resolved = RpcActor.resolve_many(actors)
+    assert len(resolved) == len(actors)
+
+    assert isinstance(resolved[0], RpcUser)
+    assert resolved[0].id == user_one.id
+
+    assert isinstance(resolved[1], RpcUser)
+    assert resolved[1].id == user_two.id
+
+    assert isinstance(resolved[2], Team)
+    assert resolved[2].id == team_two.id
+
+    assert isinstance(resolved[3], Team)
+    assert resolved[3].id == team_one.id


### PR DESCRIPTION
As we remove the Actor model, I'd also like to streamline the Actor concept internally in the app. We currently have both `ActorTuple` and `RpcActor`. These changes add methods to `RpcActor` to ease callsites into using `RpcActor`.

My plan is to replace usage of `ActorTuple` with `RpcActor` and then rename `RpcActor` to `Actor` so that we have fewer similarly named objects in the application.