### PR TITLE
feat(traces): Use span search hints and values

### DIFF
--- a/static/app/actionCreators/tags.tsx
+++ b/static/app/actionCreators/tags.tsx
@@ -150,3 +150,45 @@ export function fetchTagValues({
     query,
   });
 }
+
+export function fetchSpanFieldValues({
+  api,
+  orgSlug,
+  fieldKey,
+  endpointParams,
+  projectIds,
+  search,
+}: {
+  api: Client;
+  fieldKey: string;
+  orgSlug: string;
+  endpointParams?: Query;
+  projectIds?: string[];
+  search?: string;
+}): Promise<TagValue[]> {
+  const url = `/organizations/${orgSlug}/spans/fields/${fieldKey}/values/`;
+
+  const query: Query = {};
+  if (search) {
+    query.query = search;
+  }
+  if (projectIds) {
+    query.project = projectIds;
+  }
+  if (endpointParams) {
+    if (endpointParams.start) {
+      query.start = endpointParams.start;
+    }
+    if (endpointParams.end) {
+      query.end = endpointParams.end;
+    }
+    if (endpointParams.statsPeriod) {
+      query.statsPeriod = endpointParams.statsPeriod;
+    }
+  }
+
+  return api.requestPromise(url, {
+    method: 'GET',
+    query,
+  });
+}


### PR DESCRIPTION
### Summary
This adds span-specific search hints to the traces explorer search boxes. It (will) use the new span/fields endpoint to get example fields back for the span op in question. Also included is an example of omitting a span op when it doesn't make sense (eg. it's internal span only)

#### Screenshot
![Screenshot 2024-05-02 at 3 35 30 PM](https://github.com/getsentry/sentry/assets/6111995/0c063f93-251f-498e-807e-9c232a3aa7fa)
