### PR TITLE
feat(api): Add `organization_id_or_slug` Support to Customer Domain Middleware

### DIFF
--- a/src/sentry/middleware/customer_domain.py
+++ b/src/sentry/middleware/customer_domain.py
@@ -52,11 +52,8 @@ def _resolve_redirect_url(request, activeorg):
     if redirect_subdomain:
         redirect_url = generate_organization_url(activeorg)
     result = resolve(request.path)
-    org_slug_path_mismatch = (
-        result.kwargs
-        and (
-            "organization_slug" in result.kwargs and result.kwargs["organization_slug"] != activeorg
-        )
+    org_slug_path_mismatch = result.kwargs and (
+        ("organization_slug" in result.kwargs and result.kwargs["organization_slug"] != activeorg)
         or (
             "organization_id_or_slug" in result.kwargs
             and result.kwargs["organization_id_or_slug"] != activeorg

--- a/src/sentry/middleware/customer_domain.py
+++ b/src/sentry/middleware/customer_domain.py
@@ -54,14 +54,26 @@ def _resolve_redirect_url(request, activeorg):
     result = resolve(request.path)
     org_slug_path_mismatch = (
         result.kwargs
-        and "organization_slug" in result.kwargs
-        and result.kwargs["organization_slug"] != activeorg
+        and (
+            "organization_slug" in result.kwargs and result.kwargs["organization_slug"] != activeorg
+        )
+        or (
+            "organization_id_or_slug" in result.kwargs
+            and result.kwargs["organization_id_or_slug"] != activeorg
+            and not str(result.kwargs["organization_id_or_slug"]).isdecimal()
+        )
     )
     if not redirect_subdomain and not org_slug_path_mismatch:
         return None
     kwargs = {**result.kwargs}
+
+    # Make sure if organization_id_or_slug is passed in, it is a slug
     if org_slug_path_mismatch:
-        kwargs["organization_slug"] = activeorg
+        if "organization_slug" in kwargs:
+            kwargs["organization_slug"] = activeorg
+        else:
+            kwargs["organization_id_or_slug"] = activeorg
+
     path = reverse(result.url_name or result.func, kwargs=kwargs)
     qs = _query_string(request)
     redirect_url = f"{redirect_url}{path}{qs}"

--- a/tests/sentry/middleware/test_customer_domain.py
+++ b/tests/sentry/middleware/test_customer_domain.py
@@ -188,6 +188,19 @@ class OrganizationTestEndpoint(Endpoint):
         )
 
 
+class OrganizationIdOrSlugTestEndpoint(Endpoint):
+    permission_classes = (AllowAny,)
+
+    def get(self, request, organization_id_or_slug):
+        return Response(
+            {
+                "organization_id_or_slug": organization_id_or_slug,
+                "subdomain": request.subdomain,
+                "activeorg": request.session.get("activeorg", None),
+            }
+        )
+
+
 urlpatterns = [
     re_path(
         r"^api/0/(?P<organization_slug>[^\/]+)/$",
@@ -197,6 +210,11 @@ urlpatterns = [
     re_path(
         r"^api/0/(?P<organization_slug>[^\/]+)/nameless/$",
         OrganizationTestEndpoint.as_view(),
+    ),
+    re_path(
+        r"^api/0/(?P<organization_id_or_slug>[^\/]+)/idorslug/$",
+        OrganizationIdOrSlugTestEndpoint.as_view(),
+        name="org-events-endpoint-id-or-slug",
     ),
     re_path(r"^logout/$", AuthLogoutView.as_view(), name="sentry-logout"),
 ]
@@ -259,6 +277,36 @@ class End2EndTest(APITestCase):
             assert response.redirect_chain == []
             assert response.data == {
                 "organization_slug": "some-org",
+                "subdomain": None,
+                "activeorg": "test",
+            }
+            assert "activeorg" in self.client.session
+            assert self.client.session["activeorg"] == "test"
+
+            response = self.client.get(
+                reverse("org-events-endpoint-id-or-slug", kwargs={"organization_id_or_slug": 1234}),
+                follow=True,
+            )
+            assert response.status_code == 200
+            assert response.redirect_chain == []
+            assert response.data == {
+                "organization_id_or_slug": "1234",
+                "subdomain": None,
+                "activeorg": "test",
+            }
+            assert "activeorg" in self.client.session
+            assert self.client.session["activeorg"] == "test"
+
+            response = self.client.get(
+                reverse(
+                    "org-events-endpoint-id-or-slug", kwargs={"organization_id_or_slug": "some-org"}
+                ),
+                follow=True,
+            )
+            assert response.status_code == 200
+            assert response.redirect_chain == []
+            assert response.data == {
+                "organization_id_or_slug": "some-org",
                 "subdomain": None,
                 "activeorg": "test",
             }
@@ -336,6 +384,37 @@ class End2EndTest(APITestCase):
             # No redirect for http methods that is not GET
             response = self.client.post(
                 reverse("org-events-endpoint", kwargs={"organization_slug": "some-org"}),
+                data={"querystring": "value"},
+                HTTP_HOST="albertos-apples.testserver",
+                follow=True,
+            )
+            assert response.status_code == 200
+            assert response.redirect_chain == []
+
+            # Redirect response for org id or slug path mismatch
+            response = self.client.get(
+                reverse(
+                    "org-events-endpoint-id-or-slug", kwargs={"organization_id_or_slug": "some-org"}
+                ),
+                data={"querystring": "value"},
+                HTTP_HOST="albertos-apples.testserver",
+                follow=True,
+            )
+            assert response.status_code == 200
+            assert response.redirect_chain == [
+                ("/api/0/albertos-apples/idorslug/?querystring=value", 302)
+            ]
+            assert response.data == {
+                "organization_id_or_slug": "albertos-apples",
+                "subdomain": "albertos-apples",
+                "activeorg": "albertos-apples",
+            }
+            assert "activeorg" in self.client.session
+            assert self.client.session["activeorg"] == "albertos-apples"
+
+            # No redirect for id
+            response = self.client.get(
+                reverse("org-events-endpoint-id-or-slug", kwargs={"organization_id_or_slug": 1234}),
                 data={"querystring": "value"},
                 HTTP_HOST="albertos-apples.testserver",
                 follow=True,


### PR DESCRIPTION
We are updating our APIs work with id and slug path params. We need to make sure that the middleware works with both type of path params. We need to make sure that if an orgid is passed, we don't redirect them.

For more context: https://sentry.slack.com/archives/C032E82D338/p1714605291155389

Example: `acme.sentry.io/organizations/12345/issues` to `http://12345.sentry.io/issues`.