### PR TITLE
ref(relay): Bump librelay to version 0.8.58

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -66,7 +66,7 @@ sentry-arroyo>=2.16.5
 sentry-kafka-schemas>=0.1.74
 sentry-ophio==0.2.7
 sentry-redis-tools>=0.1.7
-sentry-relay>=0.8.57
+sentry-relay>=0.8.58
 sentry-sdk==2.0.0
 snuba-sdk>=2.0.32
 simplejson>=3.17.6

--- a/requirements-dev-frozen.txt
+++ b/requirements-dev-frozen.txt
@@ -183,7 +183,7 @@ sentry-forked-djangorestframework-stubs==3.14.5.post1
 sentry-kafka-schemas==0.1.74
 sentry-ophio==0.2.7
 sentry-redis-tools==0.1.7
-sentry-relay==0.8.57
+sentry-relay==0.8.58
 sentry-sdk==2.0.0
 sentry-usage-accountant==0.0.10
 simplejson==3.17.6

--- a/requirements-frozen.txt
+++ b/requirements-frozen.txt
@@ -123,7 +123,7 @@ sentry-arroyo==2.16.5
 sentry-kafka-schemas==0.1.74
 sentry-ophio==0.2.7
 sentry-redis-tools==0.1.7
-sentry-relay==0.8.57
+sentry-relay==0.8.58
 sentry-sdk==2.0.0
 sentry-usage-accountant==0.0.10
 simplejson==3.17.6

--- a/src/sentry/relay/config/__init__.py
+++ b/src/sentry/relay/config/__init__.py
@@ -62,7 +62,6 @@ EXPOSABLE_FEATURES = [
     "organizations:profiling",
     "organizations:session-replay-combined-envelope-items",
     "organizations:session-replay-recording-scrubbing",
-    "organizations:session-replay-video",
     "organizations:session-replay",
     "organizations:standalone-span-ingestion",
     "organizations:transaction-name-mark-scrubbed-as-sanitized",

--- a/tests/sentry/relay/snapshots/test_config/test_get_project_config/full_config/REGION.pysnap
+++ b/tests/sentry/relay/snapshots/test_config/test_get_project_config/full_config/REGION.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-04-30T11:46:28.288534+00:00'
+created: '2024-05-02T21:08:26.482609+00:00'
 creator: sentry
 source: tests/sentry/relay/test_config.py
 ---
@@ -21,7 +21,6 @@ config:
     scrubDefaults: true
     sensitiveFields: []
   features:
-  - organizations:session-replay-video
   - organizations:transaction-name-mark-scrubbed-as-sanitized
   - organizations:transaction-name-normalize
   filterSettings:

--- a/tests/sentry/relay/snapshots/test_config/test_get_project_config/slim_config/REGION.pysnap
+++ b/tests/sentry/relay/snapshots/test_config/test_get_project_config/slim_config/REGION.pysnap
@@ -1,4 +1,6 @@
 ---
+created: '2024-05-02T21:08:26.067868+00:00'
+creator: sentry
 source: tests/sentry/relay/test_config.py
 ---
 config:
@@ -10,7 +12,6 @@ config:
     scrubDefaults: true
     sensitiveFields: []
   features:
-  - organizations:session-replay-video
   - organizations:transaction-name-mark-scrubbed-as-sanitized
   - organizations:transaction-name-normalize
   piiConfig:


### PR DESCRIPTION
Bumps librelay, the Replay feature flag was reverted from Relay again, without cleaning up the feature flag in Sentry.