### PR TITLE
fix(metric-alerts): Pass environment when getting entity key from snuba query

### DIFF
--- a/src/sentry/snuba/entity_subscription.py
+++ b/src/sentry/snuba/entity_subscription.py
@@ -626,7 +626,7 @@ def get_entity_key_from_snuba_query(
     query_builder = entity_subscription.build_query_builder(
         snuba_query.query,
         [project_id],
-        None,
+        snuba_query.environment,
         {"organization_id": organization_id},
         skip_field_validation_for_entity_subscription_deletion=skip_field_validation_for_entity_subscription_deletion,
     )


### PR DESCRIPTION
Looks like this was an oversight and we should have been passing env here. This can make certain conditions fail.
