### PR TITLE
fix(open-pr-comments): Limit `group_ids` to 5k to prevent clickhouse errors

### DIFF
--- a/src/sentry/tasks/integrations/github/open_pr_comment.py
+++ b/src/sentry/tasks/integrations/github/open_pr_comment.py
@@ -89,7 +89,7 @@ OPEN_PR_ISSUE_TABLE_TOGGLE_TEMPLATE = """\
 
 OPEN_PR_ISSUE_DESCRIPTION_LENGTH = 52
 
-MAX_RECENT_ISSUES = 10000
+MAX_RECENT_ISSUES = 5000
 
 
 def format_open_pr_comment(issue_tables: list[str]) -> str:


### PR DESCRIPTION
Making this temporary fix till Snuba supports aliasing in nested joins. Lets monitor and see if we also need to limit `project_id`