### PR TITLE
fix(slack): Link alert setting pages with correct org

### DIFF
--- a/src/sentry/notifications/notifications/base.py
+++ b/src/sentry/notifications/notifications/base.py
@@ -11,7 +11,7 @@ import sentry_sdk
 from sentry import analytics
 from sentry.db.models import Model
 from sentry.models.environment import Environment
-from sentry.notifications.types import NotificationSettingEnum, UnsubscribeContext
+from sentry.notifications.types import FineTuningAPIKey, NotificationSettingEnum, UnsubscribeContext
 from sentry.notifications.utils.actions import MessageAction
 from sentry.services.hybrid_cloud.actor import ActorType, RpcActor
 from sentry.types.integrations import EXTERNAL_PROVIDERS, ExternalProviders
@@ -20,6 +20,16 @@ from sentry.utils.safe import safe_execute
 if TYPE_CHECKING:
     from sentry.models.organization import Organization
     from sentry.models.project import Project
+
+
+def alert_page_needs_org_id(fine_tuning_key: FineTuningAPIKey) -> bool:
+    """Determines if the alert setting page needs the organization id in the query params."""
+    return fine_tuning_key in (
+        FineTuningAPIKey.ALERTS,
+        FineTuningAPIKey.WORKFLOW,
+        FineTuningAPIKey.EMAIL,
+        FineTuningAPIKey.SPIKE_PROTECTION,
+    )
 
 
 # TODO: add abstractmethod decorators
@@ -31,7 +41,7 @@ class BaseNotification(abc.ABC):
     }
     message_builder = "SlackNotificationsMessageBuilder"
     # some notifications have no settings for it which is why it is optional
-    notification_setting_type_enum: NotificationSettingEnum | None = None
+    notification_setting_type_enum: NotificationSettingEnum | FineTuningAPIKey | None = None
     analytics_event: str = ""
 
     def __init__(self, organization: Organization, notification_uuid: str | None = None):
@@ -178,35 +188,47 @@ class BaseNotification(abc.ABC):
         return referrer
 
     def get_sentry_query_params(
-        self, provider: ExternalProviders, recipient: RpcActor | None = None
+        self,
+        provider: ExternalProviders,
+        recipient: RpcActor | None = None,
+        set_organization_id: bool = False,
     ) -> str:
         """
         Returns the query params that allow us to track clicks into Sentry links.
         If the recipient is not necessarily a user (ex: sending to an email address associated with an account),
         The recipient may be omitted.
+
+        Also set the organization id query param as needed for specific setting pages, e.g. workflow
         """
-        query = urlencode(
-            {
-                "referrer": self.get_referrer(provider, recipient),
-                "notification_uuid": self.notification_uuid,
-            }
-        )
+        q_params = {
+            "referrer": self.get_referrer(provider, recipient),
+            "notification_uuid": self.notification_uuid,
+        }
+        if set_organization_id:
+            q_params["organizationId"] = self.organization.id
+
+        query = urlencode(q_params)
         return f"?{query}"
 
     def get_settings_url(self, recipient: RpcActor, provider: ExternalProviders) -> str:
+        set_organization_id = False
         # Settings url is dependant on the provider so we know which provider is sending them into Sentry.
         if recipient.actor_type == ActorType.TEAM:
             url_str = f"/settings/{self.organization.slug}/teams/{recipient.slug}/notifications/"
         else:
             url_str = "/settings/account/notifications/"
+
             if self.notification_setting_type_enum:
-                fine_tuning_key = self.notification_setting_type_enum.value
+                fine_tuning_key = self.notification_setting_type_enum
                 if fine_tuning_key:
-                    url_str += f"{fine_tuning_key}/"
+                    url_str += f"{fine_tuning_key.value}/"
+
+                set_organization_id = alert_page_needs_org_id(fine_tuning_key)
 
         return str(
             self.organization.absolute_url(
-                url_str, query=self.get_sentry_query_params(provider, recipient)
+                url_str,
+                query=self.get_sentry_query_params(provider, recipient, set_organization_id),
             )
         )
 

--- a/src/sentry/notifications/notifications/base.py
+++ b/src/sentry/notifications/notifications/base.py
@@ -22,7 +22,7 @@ if TYPE_CHECKING:
     from sentry.models.project import Project
 
 
-def alert_page_needs_org_id(fine_tuning_key: FineTuningAPIKey) -> bool:
+def alert_page_needs_org_id(fine_tuning_key: NotificationSettingEnum | FineTuningAPIKey) -> bool:
     """Determines if the alert setting page needs the organization id in the query params."""
     return fine_tuning_key in (
         FineTuningAPIKey.ALERTS,
@@ -41,7 +41,7 @@ class BaseNotification(abc.ABC):
     }
     message_builder = "SlackNotificationsMessageBuilder"
     # some notifications have no settings for it which is why it is optional
-    notification_setting_type_enum: NotificationSettingEnum | FineTuningAPIKey | None = None
+    notification_setting_type_enum: NotificationSettingEnum | None = None
     analytics_event: str = ""
 
     def __init__(self, organization: Organization, notification_uuid: str | None = None):
@@ -200,7 +200,7 @@ class BaseNotification(abc.ABC):
 
         Also set the organization id query param as needed for specific setting pages, e.g. workflow
         """
-        q_params = {
+        q_params: dict[str, str | int] = {
             "referrer": self.get_referrer(provider, recipient),
             "notification_uuid": self.notification_uuid,
         }

--- a/src/sentry/notifications/types.py
+++ b/src/sentry/notifications/types.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from enum import Enum
+from enum import Enum, StrEnum
 from typing import TYPE_CHECKING
 
 from sentry.services.hybrid_cloud import ValueEqualityEnum
@@ -57,7 +57,7 @@ class NotificationScopeEnum(ValueEqualityEnum):
     TEAM = "team"
 
 
-class FineTuningAPIKey(Enum):
+class FineTuningAPIKey(StrEnum):
     ALERTS = "alerts"
     APPROVAL = "approval"
     DEPLOY = "deploy"

--- a/tests/sentry/integrations/msteams/notifications/test_assigned.py
+++ b/tests/sentry/integrations/msteams/notifications/test_assigned.py
@@ -47,7 +47,7 @@ class MSTeamsAssignedNotificationTest(MSTeamsActivityNotificationTest):
             in body[1]["text"]
         )
         assert (
-            f"{self.project.slug} | [Notification Settings](http://testserver/settings/account/notifications/workflow/?referrer=assigned\\_activity-msteams-user&amp;notification\\_uuid={notification_uuid})"
+            f"{self.project.slug} | [Notification Settings](http://testserver/settings/account/notifications/workflow/?referrer=assigned\\_activity-msteams-user&amp;notification\\_uuid={notification_uuid}&amp;organizationId={self.organization.id})"
             == body[3]["columns"][1]["items"][0]["text"]
         )
 
@@ -82,6 +82,6 @@ class MSTeamsAssignedNotificationTest(MSTeamsActivityNotificationTest):
             in body[1]["text"]
         )
         assert (
-            f"{self.project.slug} | [Notification Settings](http://testserver/settings/account/notifications/workflow/?referrer=assigned\\_activity-msteams-user&amp;notification\\_uuid={notification_uuid})"
+            f"{self.project.slug} | [Notification Settings](http://testserver/settings/account/notifications/workflow/?referrer=assigned\\_activity-msteams-user&amp;notification\\_uuid={notification_uuid}&amp;organizationId={self.organization.id})"
             == body[3]["columns"][1]["items"][0]["text"]
         )

--- a/tests/sentry/integrations/msteams/notifications/test_escalating.py
+++ b/tests/sentry/integrations/msteams/notifications/test_escalating.py
@@ -52,5 +52,5 @@ class MSTeamsEscalatingNotificationTest(MSTeamsActivityNotificationTest):
         notification_uuid = self.get_notification_uuid(body[3]["columns"][1]["items"][0]["text"])
         assert (
             body[3]["columns"][1]["items"][0]["text"]
-            == f"{self.project.slug} | [Notification Settings](http://testserver/settings/account/notifications/workflow/?referrer=escalating\\_activity-msteams-user&amp;notification\\_uuid={notification_uuid})"
+            == f"{self.project.slug} | [Notification Settings](http://testserver/settings/account/notifications/workflow/?referrer=escalating\\_activity-msteams-user&amp;notification\\_uuid={notification_uuid}&amp;organizationId={self.organization.id})"
         )

--- a/tests/sentry/integrations/msteams/notifications/test_issue_alert.py
+++ b/tests/sentry/integrations/msteams/notifications/test_issue_alert.py
@@ -67,7 +67,7 @@ class MSTeamsIssueAlertNotificationTest(MSTeamsActivityNotificationTest):
             == body[1]["text"]
         )
         assert (
-            f"{self.project.slug} | [Notification Settings](http://testserver/settings/account/notifications/alerts/?referrer=issue\\_alert-msteams-user&amp;notification\\_uuid={notification_uuid})"
+            f"{self.project.slug} | [Notification Settings](http://testserver/settings/account/notifications/alerts/?referrer=issue\\_alert-msteams-user&amp;notification\\_uuid={notification_uuid}&amp;organizationId={self.organization.id})"
             == body[3]["columns"][1]["items"][0]["text"]
         )
 
@@ -120,6 +120,6 @@ class MSTeamsIssueAlertNotificationTest(MSTeamsActivityNotificationTest):
             == body[1]["text"]
         )
         assert (
-            f"{self.project.slug} | [Notification Settings](http://testserver/settings/account/notifications/alerts/?referrer=issue\\_alert-msteams-user&amp;notification\\_uuid={notification_uuid})"
+            f"{self.project.slug} | [Notification Settings](http://testserver/settings/account/notifications/alerts/?referrer=issue\\_alert-msteams-user&amp;notification\\_uuid={notification_uuid}&amp;organizationId={self.organization.id})"
             == body[3]["columns"][1]["items"][0]["text"]
         )

--- a/tests/sentry/integrations/msteams/notifications/test_note.py
+++ b/tests/sentry/integrations/msteams/notifications/test_note.py
@@ -48,6 +48,6 @@ class MSTeamsNoteNotificationTest(MSTeamsActivityNotificationTest):
         assert notification.activity.data["text"] == body[2]["text"]
         notification_uuid = self.get_notification_uuid(body[3]["columns"][1]["items"][0]["text"])
         assert (
-            f"{self.project.slug} | [Notification Settings](http://testserver/settings/account/notifications/workflow/?referrer=note\\_activity-msteams-user&amp;notification\\_uuid={notification_uuid})"
+            f"{self.project.slug} | [Notification Settings](http://testserver/settings/account/notifications/workflow/?referrer=note\\_activity-msteams-user&amp;notification\\_uuid={notification_uuid}&amp;organizationId={self.organization.id})"
             == body[3]["columns"][1]["items"][0]["text"]
         )

--- a/tests/sentry/integrations/msteams/notifications/test_regression.py
+++ b/tests/sentry/integrations/msteams/notifications/test_regression.py
@@ -47,6 +47,6 @@ class MSTeamsRegressionNotificationTest(MSTeamsActivityNotificationTest):
         )
         notification_uuid = self.get_notification_uuid(body[3]["columns"][1]["items"][0]["text"])
         assert (
-            f"{self.project.slug} | [Notification Settings](http://testserver/settings/account/notifications/workflow/?referrer=regression\\_activity-msteams-user&amp;notification\\_uuid={notification_uuid})"
+            f"{self.project.slug} | [Notification Settings](http://testserver/settings/account/notifications/workflow/?referrer=regression\\_activity-msteams-user&amp;notification\\_uuid={notification_uuid}&amp;organizationId={self.organization.id})"
             == body[3]["columns"][1]["items"][0]["text"]
         )

--- a/tests/sentry/integrations/msteams/notifications/test_resolved.py
+++ b/tests/sentry/integrations/msteams/notifications/test_resolved.py
@@ -53,7 +53,7 @@ class MSTeamsResolvedNotificationTest(MSTeamsActivityNotificationTest):
             in body[1]["text"]
         )
         assert (
-            f"{self.project.slug} | [Notification Settings](http://testserver/settings/account/notifications/workflow/?referrer=resolved\\_activity-msteams-user&amp;notification\\_uuid={notification_uuid})"
+            f"{self.project.slug} | [Notification Settings](http://testserver/settings/account/notifications/workflow/?referrer=resolved\\_activity-msteams-user&amp;notification\\_uuid={notification_uuid}&amp;organizationId={self.organization.id})"
             == body[3]["columns"][1]["items"][0]["text"]
         )
 
@@ -93,6 +93,6 @@ class MSTeamsResolvedNotificationTest(MSTeamsActivityNotificationTest):
         )
         notification_uuid = self.get_notification_uuid(body[3]["columns"][1]["items"][0]["text"])
         assert (
-            f"{self.project.slug} | [Notification Settings](http://testserver/settings/account/notifications/workflow/?referrer=resolved\\_in\\_release\\_activity-msteams-user&amp;notification\\_uuid={notification_uuid})"
+            f"{self.project.slug} | [Notification Settings](http://testserver/settings/account/notifications/workflow/?referrer=resolved\\_in\\_release\\_activity-msteams-user&amp;notification\\_uuid={notification_uuid}&amp;organizationId={self.organization.id})"
             == body[3]["columns"][1]["items"][0]["text"]
         )

--- a/tests/sentry/integrations/msteams/notifications/test_unassigned.py
+++ b/tests/sentry/integrations/msteams/notifications/test_unassigned.py
@@ -47,7 +47,7 @@ class MSTeamsUnassignedNotificationTest(MSTeamsActivityNotificationTest):
             in body[1]["text"]
         )
         assert (
-            f"{self.project.slug} | [Notification Settings](http://testserver/settings/account/notifications/workflow/?referrer=unassigned\\_activity-msteams-user&amp;notification\\_uuid={notification_uuid})"
+            f"{self.project.slug} | [Notification Settings](http://testserver/settings/account/notifications/workflow/?referrer=unassigned\\_activity-msteams-user&amp;notification\\_uuid={notification_uuid}&amp;organizationId={self.organization.id})"
             == body[3]["columns"][1]["items"][0]["text"]
         )
 
@@ -82,6 +82,6 @@ class MSTeamsUnassignedNotificationTest(MSTeamsActivityNotificationTest):
             in body[1]["text"]
         )
         assert (
-            f"{self.project.slug} | [Notification Settings](http://testserver/settings/account/notifications/workflow/?referrer=unassigned\\_activity-msteams-user&amp;notification\\_uuid={notification_uuid})"
+            f"{self.project.slug} | [Notification Settings](http://testserver/settings/account/notifications/workflow/?referrer=unassigned\\_activity-msteams-user&amp;notification\\_uuid={notification_uuid}&amp;organizationId={self.organization.id})"
             == body[3]["columns"][1]["items"][0]["text"]
         )

--- a/tests/sentry/integrations/slack/notifications/test_assigned.py
+++ b/tests/sentry/integrations/slack/notifications/test_assigned.py
@@ -128,7 +128,7 @@ class SlackAssignedNotificationTest(SlackActivityNotificationTest, PerformanceIs
         )
         assert (
             blocks[3]["elements"][0]["text"]
-            == f"{self.project.slug} | <http://testserver/settings/account/notifications/workflow/?referrer=assigned_activity-slack-user&notification_uuid={notification_uuid}|Notification Settings>"
+            == f"{self.project.slug} | <http://testserver/settings/account/notifications/workflow/?referrer=assigned_activity-slack-user&notification_uuid={notification_uuid}&organizationId={self.organization.id}|Notification Settings>"
         )
 
     @responses.activate
@@ -154,7 +154,7 @@ class SlackAssignedNotificationTest(SlackActivityNotificationTest, PerformanceIs
         assert blocks[0]["text"]["text"] == fallback_text
         self.assert_generic_issue_blocks(
             blocks,
-            group_event.organization.slug,
+            group_event.organization,
             group_event.project.slug,
             group_event.group,
             "assigned_activity-slack",
@@ -180,7 +180,7 @@ class SlackAssignedNotificationTest(SlackActivityNotificationTest, PerformanceIs
         assert blocks[0]["text"]["text"] == fallback_text
         self.assert_performance_issue_blocks(
             blocks,
-            event.organization.slug,
+            event.organization,
             event.project.slug,
             event.group,
             "assigned_activity-slack",

--- a/tests/sentry/integrations/slack/notifications/test_escalating.py
+++ b/tests/sentry/integrations/slack/notifications/test_escalating.py
@@ -44,7 +44,7 @@ class SlackRegressionNotificationTest(SlackActivityNotificationTest, Performance
         )
         assert (
             blocks[2]["elements"][0]["text"]
-            == f"{self.project.slug} | <http://testserver/settings/account/notifications/workflow/?referrer=escalating_activity-slack-user&notification_uuid={notification_uuid}|Notification Settings>"
+            == f"{self.project.slug} | <http://testserver/settings/account/notifications/workflow/?referrer=escalating_activity-slack-user&notification_uuid={notification_uuid}&organizationId={self.organization.id}|Notification Settings>"
         )
 
     @responses.activate
@@ -72,7 +72,7 @@ class SlackRegressionNotificationTest(SlackActivityNotificationTest, Performance
         )
         assert (
             blocks[2]["elements"][0]["text"]
-            == f"{self.project.slug} | production | <http://testserver/settings/account/notifications/workflow/?referrer=escalating_activity-slack-user&notification_uuid={notification_uuid}|Notification Settings>"
+            == f"{self.project.slug} | production | <http://testserver/settings/account/notifications/workflow/?referrer=escalating_activity-slack-user&notification_uuid={notification_uuid}&organizationId={self.organization.id}|Notification Settings>"
         )
 
     @responses.activate
@@ -104,5 +104,5 @@ class SlackRegressionNotificationTest(SlackActivityNotificationTest, Performance
         )
         assert (
             blocks[2]["elements"][0]["text"]
-            == f"{self.project.slug} | <http://testserver/settings/account/notifications/workflow/?referrer=escalating_activity-slack-user&notification_uuid={notification_uuid}|Notification Settings>"
+            == f"{self.project.slug} | <http://testserver/settings/account/notifications/workflow/?referrer=escalating_activity-slack-user&notification_uuid={notification_uuid}&organizationId={self.organization.id}|Notification Settings>"
         )

--- a/tests/sentry/integrations/slack/notifications/test_issue_alert.py
+++ b/tests/sentry/integrations/slack/notifications/test_issue_alert.py
@@ -21,7 +21,7 @@ from sentry.models.notificationsettingprovider import NotificationSettingProvide
 from sentry.models.projectownership import ProjectOwnership
 from sentry.models.rule import Rule
 from sentry.notifications.notifications.rules import AlertRuleNotification
-from sentry.notifications.types import ActionTargetType, FallthroughChoiceType
+from sentry.notifications.types import ActionTargetType, FallthroughChoiceType, FineTuningAPIKey
 from sentry.ownership.grammar import Matcher, Owner
 from sentry.ownership.grammar import Rule as GrammarRule
 from sentry.ownership.grammar import dump_schema
@@ -132,7 +132,7 @@ class SlackIssueAlertNotificationTest(SlackActivityNotificationTest, Performance
             event.project.slug,
             event.group,
             "issue_alert-slack",
-            alert_type="alerts",
+            alert_type=FineTuningAPIKey.ALERTS,
             issue_link_extra_params=f"&alert_rule_id={self.rule.id}&alert_type=issue",
         )
 

--- a/tests/sentry/integrations/slack/notifications/test_issue_alert.py
+++ b/tests/sentry/integrations/slack/notifications/test_issue_alert.py
@@ -96,7 +96,7 @@ class SlackIssueAlertNotificationTest(SlackActivityNotificationTest, Performance
         )
         assert (
             blocks[4]["elements"][0]["text"]
-            == f"{event.project.slug} | <http://testserver/settings/account/notifications/alerts/?referrer=issue_alert-slack-user&notification_uuid={notification_uuid}|Notification Settings>"
+            == f"{event.project.slug} | <http://testserver/settings/account/notifications/alerts/?referrer=issue_alert-slack-user&notification_uuid={notification_uuid}&organizationId={event.organization.id}|Notification Settings>"
         )
 
     @responses.activate
@@ -128,7 +128,7 @@ class SlackIssueAlertNotificationTest(SlackActivityNotificationTest, Performance
         assert blocks[0]["text"]["text"] == fallback_text
         self.assert_performance_issue_blocks(
             blocks,
-            event.organization.slug,
+            event.organization,
             event.project.slug,
             event.group,
             "issue_alert-slack",
@@ -210,7 +210,7 @@ class SlackIssueAlertNotificationTest(SlackActivityNotificationTest, Performance
 
         self.assert_generic_issue_blocks(
             blocks,
-            event.organization.slug,
+            group_event.organization,
             event.project.slug,
             event.group,
             "issue_alert-slack",
@@ -287,7 +287,7 @@ class SlackIssueAlertNotificationTest(SlackActivityNotificationTest, Performance
         )
         assert (
             blocks[4]["elements"][0]["text"]
-            == f"{event.project.slug} | <http://testserver/settings/account/notifications/alerts/?referrer=issue_alert-slack-user&notification_uuid={notification_uuid}|Notification Settings>"
+            == f"{event.project.slug} | <http://testserver/settings/account/notifications/alerts/?referrer=issue_alert-slack-user&notification_uuid={notification_uuid}&organizationId={event.organization.id}|Notification Settings>"
         )
 
     @responses.activate
@@ -347,7 +347,7 @@ class SlackIssueAlertNotificationTest(SlackActivityNotificationTest, Performance
         )
         assert (
             blocks[4]["elements"][0]["text"]
-            == f"{event.project.slug} | {environment.name} | <http://testserver/settings/account/notifications/alerts/?referrer=issue_alert-slack-user&notification_uuid={notification_uuid}|Notification Settings>"
+            == f"{event.project.slug} | {environment.name} | <http://testserver/settings/account/notifications/alerts/?referrer=issue_alert-slack-user&notification_uuid={notification_uuid}&organizationId={event.organization.id}|Notification Settings>"
         )
 
     @responses.activate
@@ -878,7 +878,7 @@ class SlackIssueAlertNotificationTest(SlackActivityNotificationTest, Performance
         notification_uuid = self.get_notification_uuid(title_link)
         assert (
             blocks[-2]["elements"][0]["text"]
-            == f"{self.project.slug} | <http://example.com/settings/account/notifications/alerts/?referrer=issue_alert-slack-user&notification_uuid={notification_uuid}|Notification Settings>"
+            == f"{self.project.slug} | <http://example.com/settings/account/notifications/alerts/?referrer=issue_alert-slack-user&notification_uuid={notification_uuid}&organizationId={event.organization.id}|Notification Settings>"
         )
 
         # check that user2 got a notification as well
@@ -888,7 +888,7 @@ class SlackIssueAlertNotificationTest(SlackActivityNotificationTest, Performance
         assert "Hello world" in blocks[1]["text"]["text"]
         assert (
             blocks[-2]["elements"][0]["text"]
-            == f"{self.project.slug} | <http://example.com/settings/account/notifications/alerts/?referrer=issue_alert-slack-user&notification_uuid={notification_uuid}|Notification Settings>"
+            == f"{self.project.slug} | <http://example.com/settings/account/notifications/alerts/?referrer=issue_alert-slack-user&notification_uuid={notification_uuid}&organizationId={event.organization.id}|Notification Settings>"
         )
 
     @responses.activate
@@ -929,5 +929,5 @@ class SlackIssueAlertNotificationTest(SlackActivityNotificationTest, Performance
         )
         assert (
             blocks[4]["elements"][0]["text"]
-            == f"{event.project.slug} | <http://testserver/settings/account/notifications/alerts/?referrer=issue_alert-slack-user&notification_uuid={notification_uuid}|Notification Settings>"
+            == f"{event.project.slug} | <http://testserver/settings/account/notifications/alerts/?referrer=issue_alert-slack-user&notification_uuid={notification_uuid}&organizationId={event.organization.id}|Notification Settings>"
         )

--- a/tests/sentry/integrations/slack/notifications/test_new_processing_issues.py
+++ b/tests/sentry/integrations/slack/notifications/test_new_processing_issues.py
@@ -46,7 +46,7 @@ class SlackNewProcessingIssuesNotificationTest(SlackActivityNotificationTest):
         )
         assert (
             blocks[2]["elements"][0]["text"]
-            == f"{self.project.slug} | <http://testserver/settings/account/notifications/workflow/?referrer=new_processing_issues_activity-slack-user&notification_uuid={notification_uuid}|Notification Settings>"
+            == f"{self.project.slug} | <http://testserver/settings/account/notifications/workflow/?referrer=new_processing_issues_activity-slack-user&notification_uuid={notification_uuid}&organizationId={self.organization.id}|Notification Settings>"
         )
 
     @responses.activate
@@ -80,5 +80,5 @@ class SlackNewProcessingIssuesNotificationTest(SlackActivityNotificationTest):
         )
         assert (
             blocks[2]["elements"][0]["text"]
-            == f"{self.project.slug} | <http://{self.organization.slug}.testserver/settings/account/notifications/workflow/?referrer=new_processing_issues_activity-slack-user&notification_uuid={notification_uuid}|Notification Settings>"
+            == f"{self.project.slug} | <http://{self.organization.slug}.testserver/settings/account/notifications/workflow/?referrer=new_processing_issues_activity-slack-user&notification_uuid={notification_uuid}&organizationId={self.organization.id}|Notification Settings>"
         )

--- a/tests/sentry/integrations/slack/notifications/test_note.py
+++ b/tests/sentry/integrations/slack/notifications/test_note.py
@@ -47,7 +47,7 @@ class SlackNoteNotificationTest(SlackActivityNotificationTest, PerformanceIssueT
         )
         assert (
             blocks[2]["elements"][0]["text"]
-            == f"{self.project.slug} | <http://testserver/settings/account/notifications/workflow/?referrer=note_activity-slack-user&notification_uuid={notification_uuid}|Notification Settings>"
+            == f"{self.project.slug} | <http://testserver/settings/account/notifications/workflow/?referrer=note_activity-slack-user&notification_uuid={notification_uuid}&organizationId={self.organization.id}|Notification Settings>"
         )
 
     @responses.activate
@@ -73,7 +73,7 @@ class SlackNoteNotificationTest(SlackActivityNotificationTest, PerformanceIssueT
         )
         assert (
             blocks[2]["elements"][0]["text"]
-            == f"{self.project.slug} | production | <http://testserver/settings/account/notifications/workflow/?referrer=note_activity-slack-user&notification_uuid={notification_uuid}|Notification Settings>"
+            == f"{self.project.slug} | production | <http://testserver/settings/account/notifications/workflow/?referrer=note_activity-slack-user&notification_uuid={notification_uuid}&organizationId={self.organization.id}|Notification Settings>"
         )
 
     @responses.activate
@@ -107,5 +107,5 @@ class SlackNoteNotificationTest(SlackActivityNotificationTest, PerformanceIssueT
         )
         assert (
             blocks[2]["elements"][0]["text"]
-            == f"{self.project.slug} | <http://testserver/settings/account/notifications/workflow/?referrer=note_activity-slack-user&notification_uuid={notification_uuid}|Notification Settings>"
+            == f"{self.project.slug} | <http://testserver/settings/account/notifications/workflow/?referrer=note_activity-slack-user&notification_uuid={notification_uuid}&organizationId={self.organization.id}|Notification Settings>"
         )

--- a/tests/sentry/integrations/slack/notifications/test_regression.py
+++ b/tests/sentry/integrations/slack/notifications/test_regression.py
@@ -42,7 +42,7 @@ class SlackRegressionNotificationTest(SlackActivityNotificationTest, Performance
             f":red_circle: <http://testserver/organizations/{self.organization.slug}/issues/{self.group.id}/?referrer=regression_activity-slack&notification_uuid={notification_uuid}|*{self.group.title}*>"
         )
         assert blocks[3]["elements"][0]["text"] == (
-            f"{self.project.slug} | <http://testserver/settings/account/notifications/workflow/?referrer=regression_activity-slack-user&notification_uuid={notification_uuid}|Notification Settings>"
+            f"{self.project.slug} | <http://testserver/settings/account/notifications/workflow/?referrer=regression_activity-slack-user&notification_uuid={notification_uuid}&organizationId={self.organization.id}|Notification Settings>"
         )
 
     @responses.activate
@@ -65,7 +65,7 @@ class SlackRegressionNotificationTest(SlackActivityNotificationTest, Performance
             f":red_circle: <http://testserver/organizations/{self.organization.slug}/issues/{self.group.id}/?referrer=regression_activity-slack&notification_uuid={notification_uuid}|*{self.group.title}*>"
         )
         assert blocks[3]["elements"][0]["text"] == (
-            f"{self.project.slug} | <http://testserver/settings/account/notifications/workflow/?referrer=regression_activity-slack-user&notification_uuid={notification_uuid}|Notification Settings>"
+            f"{self.project.slug} | <http://testserver/settings/account/notifications/workflow/?referrer=regression_activity-slack-user&notification_uuid={notification_uuid}&organizationId={self.organization.id}|Notification Settings>"
         )
 
     @responses.activate
@@ -88,7 +88,7 @@ class SlackRegressionNotificationTest(SlackActivityNotificationTest, Performance
         assert blocks[0]["text"]["text"] == fallback_text
         self.assert_performance_issue_blocks(
             blocks,
-            event.organization.slug,
+            event.organization,
             event.project.slug,
             event.group,
             "regression_activity-slack",
@@ -118,7 +118,7 @@ class SlackRegressionNotificationTest(SlackActivityNotificationTest, Performance
         assert blocks[0]["text"]["text"] == fallback_text
         self.assert_generic_issue_blocks(
             blocks,
-            group_event.organization.slug,
+            group_event.organization,
             group_event.project.slug,
             group_event.group,
             "regression_activity-slack",

--- a/tests/sentry/integrations/slack/notifications/test_resolved.py
+++ b/tests/sentry/integrations/slack/notifications/test_resolved.py
@@ -50,7 +50,7 @@ class SlackResolvedNotificationTest(SlackActivityNotificationTest, PerformanceIs
         )
         assert (
             blocks[3]["elements"][0]["text"]
-            == f"{self.project.slug} | <http://testserver/settings/account/notifications/workflow/?referrer=resolved_activity-slack-user&notification_uuid={notification_uuid}|Notification Settings>"
+            == f"{self.project.slug} | <http://testserver/settings/account/notifications/workflow/?referrer=resolved_activity-slack-user&notification_uuid={notification_uuid}&organizationId={self.organization.id}|Notification Settings>"
         )
 
     @responses.activate
@@ -77,7 +77,7 @@ class SlackResolvedNotificationTest(SlackActivityNotificationTest, PerformanceIs
         assert blocks[0]["text"]["text"] == fallback_text
         self.assert_performance_issue_blocks(
             blocks,
-            event.organization.slug,
+            event.organization,
             event.project.slug,
             event.group,
             "resolved_activity-slack",
@@ -111,7 +111,7 @@ class SlackResolvedNotificationTest(SlackActivityNotificationTest, PerformanceIs
         assert blocks[0]["text"]["text"] == fallback_text
         self.assert_generic_issue_blocks(
             blocks,
-            group_event.organization.slug,
+            group_event.organization,
             group_event.project.slug,
             group_event.group,
             "resolved_activity-slack",

--- a/tests/sentry/integrations/slack/notifications/test_resolved_in_release.py
+++ b/tests/sentry/integrations/slack/notifications/test_resolved_in_release.py
@@ -46,7 +46,7 @@ class SlackResolvedInReleaseNotificationTest(
         )
         assert (
             blocks[3]["elements"][0]["text"]
-            == f"{self.project.slug} | <http://testserver/settings/account/notifications/workflow/?referrer=resolved_in_release_activity-slack-user&notification_uuid={notification_uuid}|Notification Settings>"
+            == f"{self.project.slug} | <http://testserver/settings/account/notifications/workflow/?referrer=resolved_in_release_activity-slack-user&notification_uuid={notification_uuid}&organizationId={self.organization.id}|Notification Settings>"
         )
 
     @responses.activate
@@ -71,7 +71,7 @@ class SlackResolvedInReleaseNotificationTest(
         assert blocks[0]["text"]["text"] == fallback_text
         self.assert_performance_issue_blocks(
             blocks,
-            event.organization.slug,
+            event.organization,
             event.project.slug,
             event.group,
             "resolved_in_release_activity-slack",
@@ -102,7 +102,7 @@ class SlackResolvedInReleaseNotificationTest(
         assert blocks[0]["text"]["text"] == fallback_text
         self.assert_generic_issue_blocks(
             blocks,
-            group_event.organization.slug,
+            group_event.organization,
             group_event.project.slug,
             group_event.group,
             "resolved_in_release_activity-slack",
@@ -123,5 +123,5 @@ class SlackResolvedInReleaseNotificationTest(
         notification_uuid = self.get_notification_uuid(blocks[1]["text"]["text"])
         assert (
             blocks[3]["elements"][0]["text"]
-            == f"{self.project.slug} | <http://testserver/settings/account/notifications/workflow/?referrer=resolved_in_release_activity-slack-user&notification_uuid={notification_uuid}|Notification Settings>"
+            == f"{self.project.slug} | <http://testserver/settings/account/notifications/workflow/?referrer=resolved_in_release_activity-slack-user&notification_uuid={notification_uuid}&organizationId={self.organization.id}|Notification Settings>"
         )

--- a/tests/sentry/integrations/slack/notifications/test_unassigned.py
+++ b/tests/sentry/integrations/slack/notifications/test_unassigned.py
@@ -43,7 +43,7 @@ class SlackUnassignedNotificationTest(SlackActivityNotificationTest, Performance
         )
         assert (
             blocks[3]["elements"][0]["text"]
-            == f"{self.project.slug} | <http://testserver/settings/account/notifications/workflow/?referrer=unassigned_activity-slack-user&notification_uuid={notification_uuid}|Notification Settings>"
+            == f"{self.project.slug} | <http://testserver/settings/account/notifications/workflow/?referrer=unassigned_activity-slack-user&notification_uuid={notification_uuid}&organizationId={self.organization.id}|Notification Settings>"
         )
 
     @responses.activate
@@ -66,7 +66,7 @@ class SlackUnassignedNotificationTest(SlackActivityNotificationTest, Performance
         assert blocks[0]["text"]["text"] == fallback_text
         self.assert_performance_issue_blocks(
             blocks,
-            event.organization.slug,
+            event.organization,
             event.project.slug,
             event.group,
             "unassigned_activity-slack",
@@ -95,7 +95,7 @@ class SlackUnassignedNotificationTest(SlackActivityNotificationTest, Performance
         assert blocks[0]["text"]["text"] == fallback_text
         self.assert_generic_issue_blocks(
             blocks,
-            group_event.organization.slug,
+            group_event.organization,
             group_event.project.slug,
             group_event.group,
             "unassigned_activity-slack",

--- a/tests/sentry/notifications/test_notifications.py
+++ b/tests/sentry/notifications/test_notifications.py
@@ -178,7 +178,7 @@ class ActivityNotificationTest(APITestCase):
         assert title_link.split("\n")[-1] == "blah blah"
         assert (
             footer
-            == f"{self.project.slug} | <http://testserver/settings/account/notifications/workflow/?referrer=note_activity-slack-user&notification_uuid={notification_uuid}|Notification Settings>"
+            == f"{self.project.slug} | <http://testserver/settings/account/notifications/workflow/?referrer=note_activity-slack-user&notification_uuid={notification_uuid}&organizationId={self.organization.id}|Notification Settings>"
         )
 
     @responses.activate
@@ -215,7 +215,7 @@ class ActivityNotificationTest(APITestCase):
         notification_uuid = get_notification_uuid(title_link)
         assert (
             footer
-            == f"{self.project.slug} | <http://testserver/settings/account/notifications/workflow/?referrer=unassigned_activity-slack-user&notification_uuid={notification_uuid}|Notification Settings>"
+            == f"{self.project.slug} | <http://testserver/settings/account/notifications/workflow/?referrer=unassigned_activity-slack-user&notification_uuid={notification_uuid}&organizationId={self.organization.id}|Notification Settings>"
         )
 
     @responses.activate
@@ -279,7 +279,7 @@ class ActivityNotificationTest(APITestCase):
         )
         assert (
             footer
-            == f"{self.project.slug} | <http://testserver/settings/account/notifications/workflow/?referrer=resolved_activity-slack-user&notification_uuid={notification_uuid}|Notification Settings>"
+            == f"{self.project.slug} | <http://testserver/settings/account/notifications/workflow/?referrer=resolved_activity-slack-user&notification_uuid={notification_uuid}&organizationId={self.organization.id}|Notification Settings>"
         )
 
         assert self.analytics_called_with_args(
@@ -409,7 +409,7 @@ class ActivityNotificationTest(APITestCase):
         notification_uuid = get_notification_uuid(title_link)
         assert (
             footer
-            == f"{self.project.slug} | <http://testserver/settings/account/notifications/workflow/?referrer=regression_activity-slack-user&notification_uuid={notification_uuid}|Notification Settings>"
+            == f"{self.project.slug} | <http://testserver/settings/account/notifications/workflow/?referrer=regression_activity-slack-user&notification_uuid={notification_uuid}&organizationId={self.organization.id}|Notification Settings>"
         )
         assert self.analytics_called_with_args(
             record_analytics,
@@ -469,7 +469,7 @@ class ActivityNotificationTest(APITestCase):
         notification_uuid = get_notification_uuid(title_link)
         assert (
             footer
-            == f"{self.project.slug} | <http://testserver/settings/account/notifications/workflow/?referrer=resolved_in_release_activity-slack-user&notification_uuid={notification_uuid}|Notification Settings>"
+            == f"{self.project.slug} | <http://testserver/settings/account/notifications/workflow/?referrer=resolved_in_release_activity-slack-user&notification_uuid={notification_uuid}&organizationId={self.organization.id}|Notification Settings>"
         )
         assert self.analytics_called_with_args(
             record_analytics,
@@ -551,7 +551,7 @@ class ActivityNotificationTest(APITestCase):
         notification_uuid = get_notification_uuid(title_link)
         assert (
             footer
-            == f"{self.project.slug} | <http://testserver/settings/account/notifications/alerts/?referrer=issue_alert-slack-user&notification_uuid={notification_uuid}|Notification Settings>"
+            == f"{self.project.slug} | <http://testserver/settings/account/notifications/alerts/?referrer=issue_alert-slack-user&notification_uuid={notification_uuid}&organizationId={self.organization.id}|Notification Settings>"
         )
         assert self.analytics_called_with_args(
             record_analytics,


### PR DESCRIPTION
Use a query param to have the org dropdown populated with the correct org

Fixes https://github.com/getsentry/sentry/issues/58601