### PR TITLE
ref: work around mypy bug with partially-typed namespace packages

### DIFF
--- a/src/sentry/analytics/pubsub.py
+++ b/src/sentry/analytics/pubsub.py
@@ -4,8 +4,8 @@ __all__ = ("PubSubAnalytics",)
 
 import logging
 
+import google.cloud.pubsub_v1 as pubsub_v1  # weird import for python/mypy#10360
 from google.auth.exceptions import GoogleAuthError
-from google.cloud import pubsub_v1
 
 from sentry.utils.json import dumps
 


### PR DESCRIPTION
https://github.com/python/mypy/issues/10360#issuecomment-1185082979

fixes:

```console
$ mypy src/sentry/utils/kvstore/bigtable.py  src/sentry/analytics/pubsub.py 
src/sentry/analytics/pubsub.py:8: error: Module "google.cloud" has no attribute "pubsub_v1"  [attr-defined]
Found 1 error in 1 file (checked 2 source files)
```

<!-- Describe your PR here. -->