### PR TITLE
fix(issues): Check that group is defined

### DIFF
--- a/static/app/views/issueDetails/groupEventDetails/groupEventDetails.tsx
+++ b/static/app/views/issueDetails/groupEventDetails/groupEventDetails.tsx
@@ -70,11 +70,8 @@ function GroupEventDetails(props: GroupEventDetailsProps) {
     eventError,
     params,
   } = props;
-  const eventWithMeta = withMeta(event);
   // Reprocessing
   const hasReprocessingV2Feature = organization.features?.includes('reprocessing-v2');
-  const {activity: activities} = group;
-  const mostRecentActivity = getGroupMostRecentActivity(activities);
   const projectId = project.id;
   const environments = useEnvironmentsFromUrl();
   const prevEnvironment = usePrevious(environments);
@@ -162,6 +159,12 @@ function GroupEventDetails(props: GroupEventDetailsProps) {
     );
   };
 
+  // TODO(scttcper): In some cases it seems like the event is not loaded yet
+  if (!group) {
+    return <LoadingIndicator />;
+  }
+
+  const eventWithMeta = withMeta(event);
   const issueTypeConfig = getConfigForIssueType(group, project);
 
   return (
@@ -179,7 +182,10 @@ function GroupEventDetails(props: GroupEventDetailsProps) {
           {hasReprocessingV2Feature &&
           groupReprocessingStatus === ReprocessingStatus.REPROCESSING ? (
             <ReprocessingProgress
-              totalEvents={(mostRecentActivity as GroupActivityReprocess).data.eventCount}
+              totalEvents={
+                (getGroupMostRecentActivity(group.activity) as GroupActivityReprocess)
+                  .data.eventCount
+              }
               pendingEvents={
                 (group.statusDetails as GroupReprocessing['statusDetails']).pendingEvents
               }


### PR DESCRIPTION
I'm not sure how this is happening yet, and there's checks in the parent component that group is defined. https://github.com/getsentry/sentry/blob/cb6e611d874d07f37a3dc0dd0743887e74c4c6b8/static/app/views/issueDetails/groupDetails.tsx#L803-L811

fixes JAVASCRIPT-2SY0