### PR TITLE
fix(slack): remove backticks from tag values

### DIFF
--- a/src/sentry/integrations/slack/message_builder/base/block.py
+++ b/src/sentry/integrations/slack/message_builder/base/block.py
@@ -52,6 +52,8 @@ class BlockSlackMessageBuilder(SlackMessageBuilder, ABC):
         for tag in tags:
             title = tag["title"]
             value = tag["value"]
+            # remove backticks from value, otherwise it will break the markdown
+            value = value.replace("`", "")
             text += f"{title}: `{value}`  "
         return {
             "type": "section",

--- a/tests/sentry/integrations/slack/test_message_builder.py
+++ b/tests/sentry/integrations/slack/test_message_builder.py
@@ -101,6 +101,7 @@ def build_test_message_blocks(
         for k, v in tags.items():
             if k == "release":
                 v = format_release_tag(v, group)
+            v = v.replace("`", "")
             tags_text += f"{k}: `{v}`  "
 
         tags_section = {"type": "section", "text": {"type": "mrkdwn", "text": tags_text}}
@@ -271,7 +272,7 @@ class BuildGroupAttachmentTest(TestCase, PerformanceIssueTestCase, OccurrenceTes
         event = self.store_event(
             data={
                 "event_id": "a" * 32,
-                "tags": {"foo": "bar"},
+                "tags": {"escape": "`room`", "foo": "bar"},
                 "timestamp": iso_format(before_now(minutes=1)),
                 "logentry": {"formatted": "bar"},
                 "_meta": {"logentry": {"formatted": {"": {"err": ["some error"]}}}},
@@ -284,7 +285,7 @@ class BuildGroupAttachmentTest(TestCase, PerformanceIssueTestCase, OccurrenceTes
         assert group
         self.project.flags.has_releases = True
         self.project.save(update_fields=["flags"])
-        more_tags = {"foo": "bar"}
+        more_tags = {"escape": "`room`", "foo": "bar"}
         notes = "hey @colleen fix it"
 
         assert SlackIssuesMessageBuilder(group).build() == build_test_message_blocks(
@@ -294,7 +295,7 @@ class BuildGroupAttachmentTest(TestCase, PerformanceIssueTestCase, OccurrenceTes
         )
         # add extra tag to message
         assert SlackIssuesMessageBuilder(
-            group, event.for_group(group), tags={"foo"}
+            group, event.for_group(group), tags={"foo", "escape"}
         ).build() == build_test_message_blocks(
             teams={self.team},
             users={self.user},
@@ -315,7 +316,7 @@ class BuildGroupAttachmentTest(TestCase, PerformanceIssueTestCase, OccurrenceTes
         )
         # add extra tag and notes to message
         assert SlackIssuesMessageBuilder(
-            group, event.for_group(group), tags={"foo"}, notes=notes
+            group, event.for_group(group), tags={"foo", "escape"}, notes=notes
         ).build() == build_test_message_blocks(
             teams={self.team},
             users={self.user},


### PR DESCRIPTION
Tag values are wrapped in backticks to make them show up as markdown `code`. If the tag value itself has backticks then it will break the markdown code formatting.

To fix this we can remove the backticks from the tag in the message. It shouldn't be too much of a disturbance.