### PR TITLE
ref(replay/issues): show replay tab on issue details for mobile

### DIFF
--- a/static/app/utils/replays/projectSupportsReplay.spec.tsx
+++ b/static/app/utils/replays/projectSupportsReplay.spec.tsx
@@ -1,7 +1,12 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
 import type {MinimalProject, PlatformKey} from 'sentry/types';
 import projectSupportsReplay, {
   projectCanLinkToReplay,
 } from 'sentry/utils/replays/projectSupportsReplay';
+import useOrganization from 'sentry/utils/useOrganization';
+
+jest.mock('sentry/utils/useOrganization');
 
 function mockProjectFixture(platform: PlatformKey): MinimalProject {
   return {
@@ -12,6 +17,9 @@ function mockProjectFixture(platform: PlatformKey): MinimalProject {
 }
 
 describe('projectSupportsReplay & projectCanLinkToReplay', () => {
+  const organization = OrganizationFixture();
+  jest.mocked(useOrganization).mockReturnValue(organization);
+
   it.each([
     'javascript-angular' as PlatformKey,
     'javascript-nextjs' as PlatformKey,

--- a/static/app/utils/replays/projectSupportsReplay.tsx
+++ b/static/app/utils/replays/projectSupportsReplay.tsx
@@ -1,5 +1,6 @@
-import {backend, replayPlatforms} from 'sentry/data/platformCategories';
+import {backend, mobile, replayPlatforms} from 'sentry/data/platformCategories';
 import type {MinimalProject} from 'sentry/types';
+import useOrganization from 'sentry/utils/useOrganization';
 
 /**
  * Are you able to send a Replay into the project?
@@ -16,11 +17,20 @@ function projectSupportsReplay(project: MinimalProject) {
  * Basically: is this a backend or frontend project
  */
 export function projectCanLinkToReplay(project: undefined | MinimalProject) {
+  const organization = useOrganization();
+
   if (!project || !project.platform) {
     return false;
   }
 
-  return replayPlatforms.includes(project.platform) || backend.includes(project.platform);
+  const hasMobileReplay = organization.features.includes('session-replay-mobile-player');
+  const supportedPlatforms = hasMobileReplay
+    ? replayPlatforms.concat(mobile)
+    : replayPlatforms;
+
+  return (
+    supportedPlatforms.includes(project.platform) || backend.includes(project.platform)
+  );
 }
 
 export function projectCanUpsellReplay(project: undefined | MinimalProject) {


### PR DESCRIPTION
enable the replays tab for mobile issues (if the org is under the feature flag) -- while testing i noticed this tab was hidden and got confused why i could see a replay but no tab!

after:
<img width="682" alt="SCR-20240502-ofja" src="https://github.com/getsentry/sentry/assets/56095982/76f23708-3e9c-4e61-a3b0-e3b56edc9e1c">

before:
<img width="929" alt="SCR-20240502-ofnr" src="https://github.com/getsentry/sentry/assets/56095982/8d507efd-7bc7-44b6-99c9-ef4aa200ca51">
