### PR TITLE
chore(issues): custom brownout for OrganizationActivityEndpoint

### DIFF
--- a/src/sentry/issues/endpoints/organization_activity.py
+++ b/src/sentry/issues/endpoints/organization_activity.py
@@ -26,6 +26,7 @@ class OrganizationActivityEndpoint(OrganizationMemberEndpoint, EnvironmentMixin)
     @deprecated(
         datetime.fromisoformat("2024-05-01T00:00:00Z"),
         "Activities for each issue at 'GET /api/0/organizations/{organization_slug}/issues/{issue_id}/activities/'",
+        "api.organization-activity.brownout",
     )
     def get(self, request: Request, organization, member) -> Response:
         # There is an activity record created for both sides of the unmerge


### PR DESCRIPTION
Standard brownout is once a day for a minute, with API as low a traffic as /activity/ that is not even remotely aggressive enough. Adding custom brownout schedule of 1 minute every third minute.

See also: https://github.com/getsentry/sentry-options-automator/pull/1318