### PR TITLE
fix(feedback): check event tags for replay ID

### DIFF
--- a/static/app/components/feedback/feedbackItem/feedbackReplay.tsx
+++ b/static/app/components/feedback/feedbackItem/feedbackReplay.tsx
@@ -21,7 +21,10 @@ export default function FeedbackReplay({eventData, feedbackItem, organization}: 
   const {feedbackHasReplay} = useReplayCountForFeedbacks();
   const hasReplayId = feedbackHasReplay(feedbackItem.id);
 
-  const replayId = eventData?.contexts?.feedback?.replay_id;
+  // replay ID can be found in two places
+  const replayId =
+    eventData?.contexts?.feedback?.replay_id ??
+    eventData?.tags?.find(({key}) => key === 'replayId')?.value;
   const {hasSentOneReplay, fetching: isFetchingSentOneReplay} =
     useHaveSelectedProjectsSentAnyReplayEvents();
   const platformSupported = replayPlatforms.includes(feedbackItem.platform);


### PR DESCRIPTION
need to check an extra spot for the replay ID - see https://github.com/getsentry/sentry/blob/1665fdf89d94e86554494d5443a35fcd8464927a/static/app/utils/replays/getReplayIdFromEvent.tsx#L4-L5