### PR TITLE
chore(slack): Remove block kit flag code

### DIFF
--- a/src/sentry/integrations/slack/webhooks/action.py
+++ b/src/sentry/integrations/slack/webhooks/action.py
@@ -11,7 +11,7 @@ from rest_framework import serializers
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from sentry import analytics, features
+from sentry import analytics
 from sentry.api import client
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
@@ -36,7 +36,6 @@ from sentry.models.rule import Rule
 from sentry.notifications.utils.actions import BlockKitMessageAction, MessageAction
 from sentry.services.hybrid_cloud.integration import integration_service
 from sentry.services.hybrid_cloud.notifications import notifications_service
-from sentry.services.hybrid_cloud.organization import organization_service
 from sentry.services.hybrid_cloud.user import RpcUser
 from sentry.shared_integrations.exceptions import ApiError
 
@@ -500,10 +499,8 @@ class SlackActionEndpoint(Endpoint):
         if not group:
             return self.respond(status=403)
 
-        use_block_kit = features.has("organizations:slack-block-kit", group.project.organization)
         rule = None
-        if use_block_kit:
-            rule = get_rule(slack_request)
+        rule = get_rule(slack_request)
 
         identity = slack_request.get_identity()
         # Determine the acting user by Slack identity.
@@ -520,7 +517,7 @@ class SlackActionEndpoint(Endpoint):
 
         original_tags_from_request = slack_request.get_tags()
 
-        if use_block_kit and slack_request.type == "view_submission":
+        if slack_request.type == "view_submission":
             # TODO: if we use modals for something other than resolve and archive, this will need to be more specific
 
             # Masquerade a status action
@@ -617,22 +614,21 @@ class SlackActionEndpoint(Endpoint):
         # Handle interaction actions
         for action in action_list:
             try:
-                if action.name == "status" or (
-                    use_block_kit
-                    and action.name
-                    in (
-                        "ignored:forever",
-                        "ignored:until_escalating",
-                        "unresolved:ongoing",
-                    )  # TODO: delete the first two names when block kit is GA
+                if action.name in (
+                    "status",
+                    "ignored:forever",
+                    "ignored:until_escalating",
+                    "unresolved:ongoing",
                 ):
+                    # check to see which action names are in use
+                    logger.info("slack.action.name", extra={"name": action.name})
                     self.on_status(request, identity_user, group, action)
                 elif action.name == "assign":
                     self.on_assign(request, identity_user, group, action)
                 elif action.name == "resolve_dialog":
                     self.open_resolve_dialog(slack_request, group)
                     defer_attachment_update = True
-                elif action.name == "archive_dialog" and use_block_kit:
+                elif action.name == "archive_dialog":
                     self.open_archive_dialog(slack_request, group)
                     defer_attachment_update = True
             except client.ApiError as error:
@@ -646,44 +642,32 @@ class SlackActionEndpoint(Endpoint):
         # Reload group as it may have been mutated by the action
         group = Group.objects.get(id=group.id)
 
-        if use_block_kit:
-            response = SlackIssuesMessageBuilder(
-                group,
-                identity=identity,
-                actions=action_list,
-                tags=original_tags_from_request,
-                rules=[rule] if rule else None,
-            ).build()
-            # XXX(isabella): for actions on link unfurls, we omit the fallback text from the
-            # response so the unfurling endpoint understands the payload
-            if (
-                slack_request.data.get("container")
-                and slack_request.data["container"].get("is_app_unfurl")
-                and "text" in response
-            ):
-                del response["text"]
-            slack_client = SlackClient(integration_id=slack_request.integration.id)
-
-            if not slack_request.data.get("response_url"):
-                # XXX: when you click an option in a modal dropdown it submits the request even though "Submit" has not been clicked
-                return self.respond()
-            try:
-                slack_client.post(slack_request.data["response_url"], data=response, json=True)
-            except ApiError as e:
-                logger.error("slack.action.response-error", extra={"error": str(e)})
-
-            return self.respond(response)
-
-        attachment = SlackIssuesMessageBuilder(
+        response = SlackIssuesMessageBuilder(
             group,
             identity=identity,
             actions=action_list,
             tags=original_tags_from_request,
             rules=[rule] if rule else None,
         ).build()
-        body = self.construct_reply(attachment, is_message=_is_message(slack_request.data))
+        # XXX(isabella): for actions on link unfurls, we omit the fallback text from the
+        # response so the unfurling endpoint understands the payload
+        if (
+            slack_request.data.get("container")
+            and slack_request.data["container"].get("is_app_unfurl")
+            and "text" in response
+        ):
+            del response["text"]
+        slack_client = SlackClient(integration_id=slack_request.integration.id)
 
-        return self.respond(body)
+        if not slack_request.data.get("response_url"):
+            # XXX: when you click an option in a modal dropdown it submits the request even though "Submit" has not been clicked
+            return self.respond()
+        try:
+            slack_client.post(slack_request.data["response_url"], data=response, json=True)
+        except ApiError as e:
+            logger.error("slack.action.response-error", extra={"error": str(e)})
+
+        return self.respond(response)
 
     def handle_unfurl(self, slack_request: SlackActionRequest, action: str) -> Response:
         organization_integrations = integration_service.get_organization_integrations(
@@ -715,11 +699,9 @@ class SlackActionEndpoint(Endpoint):
         return action_option
 
     @classmethod
-    def get_action_list(
-        cls, slack_request: SlackActionRequest, use_block_kit: bool
-    ) -> list[MessageAction]:
+    def get_action_list(cls, slack_request: SlackActionRequest) -> list[MessageAction]:
         action_data = slack_request.data.get("actions")
-        if use_block_kit and action_data:
+        if action_data:
             # XXX(CEO): this is here for backwards compatibility - if a user performs an action with an "older"
             # style issue alert but the block kit flag is enabled, we don't want to fall into this code path
             if action_data[0].get("action_id"):
@@ -806,27 +788,8 @@ class SlackActionEndpoint(Endpoint):
         result = integration_service.organization_contexts(
             integration_id=slack_request.integration.id
         )
-        org_integrations = result.organization_integrations
-        use_block_kit = False
-        if len(org_integrations):
-            org_context = organization_service.get_organization_by_id(
-                id=org_integrations[0].organization_id, include_projects=False, include_teams=False
-            )
-            if org_context:
-                use_block_kit = any(
-                    [
-                        (
-                            True
-                            if features.has(
-                                "organizations:slack-block-kit", org_context.organization
-                            )
-                            else False
-                        )
-                        for oi in org_integrations
-                    ]
-                )
 
-        action_list = self.get_action_list(slack_request=slack_request, use_block_kit=use_block_kit)
+        action_list = self.get_action_list(slack_request=slack_request)
         return self._handle_group_actions(slack_request, request, action_list)
 
     def handle_enable_notifications(self, slack_request: SlackActionRequest) -> Response:

--- a/src/sentry/integrations/slack/webhooks/action.py
+++ b/src/sentry/integrations/slack/webhooks/action.py
@@ -785,10 +785,6 @@ class SlackActionEndpoint(Endpoint):
         if action_option in NOTIFICATION_SETTINGS_ACTION_OPTIONS:
             return self.handle_enable_notifications(slack_request)
 
-        result = integration_service.organization_contexts(
-            integration_id=slack_request.integration.id
-        )
-
         action_list = self.get_action_list(slack_request=slack_request)
         return self._handle_group_actions(slack_request, request, action_list)
 

--- a/src/sentry/integrations/slack/webhooks/action.py
+++ b/src/sentry/integrations/slack/webhooks/action.py
@@ -458,7 +458,7 @@ class SlackActionEndpoint(Endpoint):
             headers = {"content-type": "application/json; charset=utf-8"}
             slack_client.post(
                 "/views.open",
-                data=orjson.dumps(payload),
+                data=orjson.dumps(payload).decode(),
                 headers=headers,
             )
         except ApiError as e:

--- a/src/sentry/integrations/slack/webhooks/event.py
+++ b/src/sentry/integrations/slack/webhooks/event.py
@@ -184,10 +184,9 @@ class SlackEventEndpoint(SlackDMEndpoint):
         # XXX(isabella): we use our message builders to create the blocks for each link to be
         # unfurled, so the original result will include the fallback text string, however, the
         # unfurl endpoint does not accept fallback text.
-        if features.has("organizations:slack-block-kit", organization):
-            for link_info in results.values():
-                if "text" in link_info:
-                    del link_info["text"]
+        for link_info in results.values():
+            if "text" in link_info:
+                del link_info["text"]
 
         payload = {
             "channel": data["channel"],

--- a/src/sentry/integrations/slack/webhooks/options_load.py
+++ b/src/sentry/integrations/slack/webhooks/options_load.py
@@ -9,7 +9,6 @@ from rest_framework import status
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from sentry import features
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import Endpoint, region_silo_endpoint
@@ -91,9 +90,7 @@ class SlackOptionsLoadEndpoint(Endpoint):
             .first()
         )
 
-        if not group or not features.has(
-            "organizations:slack-block-kit", group.project.organization
-        ):
+        if not group:
             logger.exception(
                 "slack.options_load.request-error",
                 extra={

--- a/tests/sentry/integrations/slack/test_unfurl.py
+++ b/tests/sentry/integrations/slack/test_unfurl.py
@@ -18,7 +18,6 @@ from sentry.snuba.dataset import Dataset
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers import install_slack
 from sentry.testutils.helpers.datetime import before_now, freeze_time, iso_format
-from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.skips import requires_snuba
 
 pytestmark = [requires_snuba, pytest.mark.sentry_metrics]
@@ -245,7 +244,6 @@ class UnfurlTest(TestCase):
             ).build()
         )
 
-    @with_feature({"organizations:slack-block-kit": False})
     def test_escape_issue(self):
         # wraps text in markdown code block
         escape_text = "<https://example.com/|*Click Here*>"

--- a/tests/sentry/integrations/slack/webhooks/actions/test_enable_notifications.py
+++ b/tests/sentry/integrations/slack/webhooks/actions/test_enable_notifications.py
@@ -100,12 +100,11 @@ class EnableNotificationsActionTest(BaseEventTest):
                 },
             ]
         }
-        with self.feature("organizations:slack-block-kit"):
-            response = self.post_webhook_block_kit(
-                action_data=[{"name": "enable_notifications", "value": "all_slack"}],
-                original_message=original_message,
-                data={"callback_id": orjson.dumps({"enable_notifications": True}).decode()},
-            )
+        response = self.post_webhook_block_kit(
+            action_data=[{"name": "enable_notifications", "value": "all_slack"}],
+            original_message=original_message,
+            data={"callback_id": orjson.dumps({"enable_notifications": True})},
+        )
         self.user.refresh_from_db()  # Reload to fetch actor
         assert response.status_code == 200, response.content
         assert response.data["text"] == ENABLE_SLACK_SUCCESS_MESSAGE

--- a/tests/sentry/integrations/slack/webhooks/actions/test_enable_notifications.py
+++ b/tests/sentry/integrations/slack/webhooks/actions/test_enable_notifications.py
@@ -103,7 +103,7 @@ class EnableNotificationsActionTest(BaseEventTest):
         response = self.post_webhook_block_kit(
             action_data=[{"name": "enable_notifications", "value": "all_slack"}],
             original_message=original_message,
-            data={"callback_id": orjson.dumps({"enable_notifications": True})},
+            data={"callback_id": orjson.dumps({"enable_notifications": True}).decode()},
         )
         self.user.refresh_from_db()  # Reload to fetch actor
         assert response.status_code == 200, response.content

--- a/tests/sentry/integrations/slack/webhooks/actions/test_status.py
+++ b/tests/sentry/integrations/slack/webhooks/actions/test_status.py
@@ -81,7 +81,7 @@ class StatusActionTest(BaseEventTest, PerformanceIssueTestCase, HybridCloudTestM
         assert event.group
         self.group = Group.objects.get(id=event.group.id)
 
-    def get_original_message_block_kit(self, group_id):
+    def get_original_message(self, group_id):
         return {
             "blocks": [
                 {
@@ -92,7 +92,7 @@ class StatusActionTest(BaseEventTest, PerformanceIssueTestCase, HybridCloudTestM
             ],
         }
 
-    def get_block_kit_unfurl_data(self, blocks):
+    def get_unfurl_data(self, blocks):
         return {
             "container": {
                 "type": "message_attachment",
@@ -150,7 +150,7 @@ class StatusActionTest(BaseEventTest, PerformanceIssueTestCase, HybridCloudTestM
             "action_ts": "1702502122.304116",
         }
 
-    def archive_issue_block_kit(self, original_message, selected_option, payload_data=None):
+    def archive_issue(self, original_message, selected_option, payload_data=None):
         assert selected_option in ARCHIVE_OPTIONS.values()
         status_action = self.get_archive_status_action()
 
@@ -163,10 +163,9 @@ class StatusActionTest(BaseEventTest, PerformanceIssueTestCase, HybridCloudTestM
             content_type="application/json",
         )
 
-        with self.feature("organizations:slack-block-kit"):
-            resp = self.post_webhook_block_kit(
-                action_data=[status_action], original_message=original_message, data=payload_data
-            )
+        resp = self.post_webhook_block_kit(
+            action_data=[status_action], original_message=original_message, data=payload_data
+        )
         assert resp.status_code == 200, resp.content
 
         # Opening dialog should *not* cause the current message to be updated
@@ -189,17 +188,15 @@ class StatusActionTest(BaseEventTest, PerformanceIssueTestCase, HybridCloudTestM
             status=200,
             content_type="application/json",
         )
-        with self.feature("organizations:slack-block-kit"):
-            resp = self.post_webhook_block_kit(
-                type="view_submission",
-                private_metadata=orjson.dumps(private_metadata).decode(),
-                selected_option=selected_option,
-            )
-
+        resp = self.post_webhook_block_kit(
+            type="view_submission",
+            private_metadata=orjson.dumps(private_metadata),
+            selected_option=selected_option,
+        )
         assert resp.status_code == 200, resp.content
         return resp
 
-    def assign_issue_block_kit(self, original_message, selected_option, payload_data=None):
+    def assign_issue(self, original_message, selected_option, payload_data=None):
         if isinstance(selected_option, Team):
             status_action = self.get_assign_status_action(
                 "team", selected_option.slug, selected_option.id
@@ -208,10 +205,9 @@ class StatusActionTest(BaseEventTest, PerformanceIssueTestCase, HybridCloudTestM
             status_action = self.get_assign_status_action(
                 "user", selected_option.get_display_name(), selected_option.id
             )
-        with self.feature("organizations:slack-block-kit"):
-            resp = self.post_webhook_block_kit(
-                action_data=[status_action], original_message=original_message
-            )
+        resp = self.post_webhook_block_kit(
+            action_data=[status_action], original_message=original_message
+        )
 
         assert resp.status_code == 200, resp.content
         # Unlike the other action helper functions, this doesn't involve opening and submitting a
@@ -219,7 +215,7 @@ class StatusActionTest(BaseEventTest, PerformanceIssueTestCase, HybridCloudTestM
         # resp so that the tests can assert the response blocks looked as expected
         return resp
 
-    def resolve_issue_block_kit(self, original_message, selected_option, payload_data=None):
+    def resolve_issue(self, original_message, selected_option, payload_data=None):
         status_action = self.get_resolve_status_action()
         # Expect request to open dialog on slack
         responses.add(
@@ -229,10 +225,9 @@ class StatusActionTest(BaseEventTest, PerformanceIssueTestCase, HybridCloudTestM
             status=200,
             content_type="application/json",
         )
-        with self.feature("organizations:slack-block-kit"):
-            resp = self.post_webhook_block_kit(
-                action_data=[status_action], original_message=original_message, data=payload_data
-            )
+        resp = self.post_webhook_block_kit(
+            action_data=[status_action], original_message=original_message, data=payload_data
+        )
         assert resp.status_code == 200, resp.content
 
         # Opening dialog should *not* cause the current message to be updated
@@ -255,13 +250,11 @@ class StatusActionTest(BaseEventTest, PerformanceIssueTestCase, HybridCloudTestM
             status=200,
             content_type="application/json",
         )
-        with self.feature("organizations:slack-block-kit"):
-            resp = self.post_webhook_block_kit(
-                type="view_submission",
-                private_metadata=orjson.dumps(private_metadata).decode(),
-                selected_option=selected_option,
-            )
-
+        resp = self.post_webhook_block_kit(
+            type="view_submission",
+            private_metadata=orjson.dumps(private_metadata),
+            selected_option=selected_option,
+        )
         assert resp.status_code == 200, resp.content
 
     @freeze_time("2021-01-14T12:27:28.303Z")
@@ -277,63 +270,28 @@ class StatusActionTest(BaseEventTest, PerformanceIssueTestCase, HybridCloudTestM
         assert resp.data["response_type"] == "ephemeral"
         assert resp.data["text"] == LINK_IDENTITY_MESSAGE.format(associate_url=associate_url)
 
-    @with_feature({"organizations:slack-block-kit": False})
-    def test_archive_issue(self):
-        status_action = {
-            "name": "status",
-            "value": "ignored:archived_until_escalating",
-            "type": "button",
-        }
+    @responses.activate
+    def test_archive_issue_until_escalating(self):
+        original_message = self.get_original_message(self.group.id)
+        self.archive_issue(original_message, "ignored:archived_until_escalating")
 
-        expect_status = f"Identity not found.\n*Issue archived by <@{self.external_id}>*"
+        self.group = Group.objects.get(id=self.group.id)
+        assert self.group.get_status() == GroupStatus.IGNORED
+        assert self.group.substatus == GroupSubStatus.UNTIL_ESCALATING
 
-        with self.feature("organizations:slack-block-kit"):
-            # test backwards compatibility
-            resp = self.post_webhook(
-                action_data=[status_action],
-                original_message=self.original_message,
-                type="interactive_message",
-                callback_id=orjson.dumps({"issue": self.group.id}).decode(),
-            )
-            self.group = Group.objects.get(id=self.group.id)
+        update_data = orjson.loads(responses.calls[1].request.body)
 
-            assert resp.status_code == 200, resp.content
-            assert self.group.get_status() == GroupStatus.IGNORED
-            assert self.group.substatus == GroupSubStatus.UNTIL_ESCALATING
-            expect_status = f"*Issue archived by <@{self.external_id}>*"
-            assert self.notification_text in resp.data["blocks"][1]["text"]["text"]
-            assert resp.data["blocks"][2]["text"]["text"].endswith(expect_status)
+        expect_status = f"*Issue archived by <@{self.external_id}>*"
+        assert self.notification_text in update_data["blocks"][1]["text"]["text"]
+        assert update_data["blocks"][2]["text"]["text"].endswith(expect_status)
+        assert "via" not in update_data["blocks"][4]["elements"][0]["text"]
+        assert ":red_circle:" in update_data["blocks"][0]["text"]["text"]
 
     @responses.activate
-    def test_archive_issue_backwards_compat_block_kit(self):
-        """Test backwards compatibility of archiving an issue from a legacy Slack notification
-        with the block kit feature flag enabled"""
-        status_action = {
-            "name": "status",
-            "value": "ignored:archived_until_escalating",
-            "type": "button",
-        }
-        with self.feature("organizations:slack-block-kit"):
-            resp = self.post_webhook(
-                action_data=[status_action],
-                original_message=self.original_message,
-                type="interactive_message",
-                callback_id=orjson.dumps({"issue": self.group.id}).decode(),
-            )
-            self.group = Group.objects.get(id=self.group.id)
-
-            assert resp.status_code == 200, resp.content
-            assert self.group.get_status() == GroupStatus.IGNORED
-            assert self.group.substatus == GroupSubStatus.UNTIL_ESCALATING
-
-            expect_status = f"*Issue archived by <@{self.external_id}>*"
-            assert self.notification_text in resp.data["blocks"][1]["text"]["text"]
-            assert resp.data["blocks"][2]["text"]["text"].endswith(expect_status)
-
-    @responses.activate
-    def test_archive_issue_until_escalating_block_kit(self):
-        original_message = self.get_original_message_block_kit(self.group.id)
-        self.archive_issue_block_kit(original_message, "ignored:archived_until_escalating")
+    @with_feature("organizations:slack-improvements")
+    def test_archive_issue_until_escalating_block_kit_improvements(self):
+        original_message = self.get_original_message(self.group.id)
+        self.archive_issue(original_message, "ignored:archived_until_escalating")
 
         self.group = Group.objects.get(id=self.group.id)
         assert self.group.get_status() == GroupStatus.IGNORED
@@ -348,12 +306,10 @@ class StatusActionTest(BaseEventTest, PerformanceIssueTestCase, HybridCloudTestM
         assert ":white_circle:" in update_data["blocks"][0]["text"]["text"]
 
     @responses.activate
-    def test_archive_issue_until_escalating_block_kit_through_unfurl(self):
-        original_message = self.get_original_message_block_kit(self.group.id)
-        payload_data = self.get_block_kit_unfurl_data(original_message["blocks"])
-        self.archive_issue_block_kit(
-            original_message, "ignored:archived_until_escalating", payload_data
-        )
+    def test_archive_issue_until_escalating_through_unfurl(self):
+        original_message = self.get_original_message(self.group.id)
+        payload_data = self.get_unfurl_data(original_message["blocks"])
+        self.archive_issue(original_message, "ignored:archived_until_escalating", payload_data)
 
         self.group = Group.objects.get(id=self.group.id)
         assert self.group.get_status() == GroupStatus.IGNORED
@@ -366,9 +322,9 @@ class StatusActionTest(BaseEventTest, PerformanceIssueTestCase, HybridCloudTestM
         assert update_data["blocks"][2]["text"]["text"].endswith(expect_status)
 
     @responses.activate
-    def test_archive_issue_until_condition_met_block_kit(self):
-        original_message = self.get_original_message_block_kit(self.group.id)
-        self.archive_issue_block_kit(original_message, "ignored:archived_until_condition_met:10")
+    def test_archive_issue_until_condition_met(self):
+        original_message = self.get_original_message(self.group.id)
+        self.archive_issue(original_message, "ignored:archived_until_condition_met:10")
 
         self.group = Group.objects.get(id=self.group.id)
         assert self.group.get_status() == GroupStatus.IGNORED
@@ -383,10 +339,10 @@ class StatusActionTest(BaseEventTest, PerformanceIssueTestCase, HybridCloudTestM
         assert update_data["blocks"][2]["text"]["text"].endswith(expect_status)
 
     @responses.activate
-    def test_archive_issue_until_condition_met_block_kit_through_unfurl(self):
-        original_message = self.get_original_message_block_kit(self.group.id)
-        payload_data = self.get_block_kit_unfurl_data(original_message["blocks"])
-        self.archive_issue_block_kit(
+    def test_archive_issue_until_condition_met_through_unfurl(self):
+        original_message = self.get_original_message(self.group.id)
+        payload_data = self.get_unfurl_data(original_message["blocks"])
+        self.archive_issue(
             original_message, "ignored:archived_until_condition_met:100", payload_data
         )
 
@@ -403,7 +359,7 @@ class StatusActionTest(BaseEventTest, PerformanceIssueTestCase, HybridCloudTestM
         assert update_data["blocks"][2]["text"]["text"].endswith(expect_status)
 
     @responses.activate
-    def test_archive_issue_forever_(self):
+    def test_archive_issue_forever(self):
         original_message = self.get_original_message_block_kit(self.group.id)
         self.archive_issue_block_kit(original_message, "ignored:archived_forever")
 
@@ -448,7 +404,7 @@ class StatusActionTest(BaseEventTest, PerformanceIssueTestCase, HybridCloudTestM
         assert self.notification_text in update_data["blocks"][1]["text"]["text"]
         assert update_data["blocks"][2]["text"]["text"].endswith(expect_status)
 
-    @with_feature({"organizations:slack-block-kit": False})
+    @responses.activate
     def test_archive_issue_with_additional_user_auth(self):
         """
         Ensure that we can act as a user even when the organization has SSO enabled
@@ -459,34 +415,8 @@ class StatusActionTest(BaseEventTest, PerformanceIssueTestCase, HybridCloudTestM
             )
             AuthIdentity.objects.create(auth_provider=auth_idp, user=self.user)
 
-        status_action = {"name": "status", "value": "ignored:archived_forever", "type": "button"}
-
-        expect_status = f"*Issue archived by <@{self.external_id}>*"
-
-        with self.feature("organizations:slack-block-kit"):
-            # test backwards compatibility
-            resp = self.post_webhook(action_data=[status_action])
-            self.group = Group.objects.get(id=self.group.id)
-
-            assert resp.status_code == 200, resp.content
-            assert self.group.get_status() == GroupStatus.IGNORED
-            assert self.group.substatus == GroupSubStatus.FOREVER
-            assert self.notification_text in resp.data["blocks"][1]["text"]["text"]
-            assert resp.data["blocks"][2]["text"]["text"].endswith(expect_status)
-
-    @responses.activate
-    def test_archive_issue_with_additional_user_auth_block_kit(self):
-        """
-        Ensure that we can act as a user even when the organization has SSO enabled
-        """
-        with assume_test_silo_mode(SiloMode.CONTROL):
-            auth_idp = AuthProvider.objects.create(
-                organization_id=self.organization.id, provider="dummy"
-            )
-            AuthIdentity.objects.create(auth_provider=auth_idp, user=self.user)
-
-        original_message = self.get_original_message_block_kit(self.group.id)
-        self.archive_issue_block_kit(original_message, "ignored:archived_forever")
+        original_message = self.get_original_message(self.group.id)
+        self.archive_issue(original_message, "ignored:archived_forever")
 
         self.group = Group.objects.get(id=self.group.id)
         assert self.group.get_status() == GroupStatus.IGNORED
@@ -499,7 +429,7 @@ class StatusActionTest(BaseEventTest, PerformanceIssueTestCase, HybridCloudTestM
         assert update_data["blocks"][2]["text"]["text"].endswith(expect_status)
 
     @responses.activate
-    def test_archive_issue_with_additional_user_auth_block_kit_through_unfurl(self):
+    def test_archive_issue_with_additional_user_auth_through_unfurl(self):
         """
         Ensure that we can act as a user even when the organization has SSO enabled
         """
@@ -508,9 +438,9 @@ class StatusActionTest(BaseEventTest, PerformanceIssueTestCase, HybridCloudTestM
                 organization_id=self.organization.id, provider="dummy"
             )
             AuthIdentity.objects.create(auth_provider=auth_idp, user=self.user)
-        original_message = self.get_original_message_block_kit(self.group.id)
-        payload_data = self.get_block_kit_unfurl_data(original_message["blocks"])
-        self.archive_issue_block_kit(original_message, "ignored:archived_forever", payload_data)
+        original_message = self.get_original_message(self.group.id)
+        payload_data = self.get_unfurl_data(original_message["blocks"])
+        self.archive_issue(original_message, "ignored:archived_forever", payload_data)
 
         self.group = Group.objects.get(id=self.group.id)
         assert self.group.get_status() == GroupStatus.IGNORED
@@ -522,18 +452,17 @@ class StatusActionTest(BaseEventTest, PerformanceIssueTestCase, HybridCloudTestM
         assert self.notification_text in update_data["blocks"][1]["text"]["text"]
         assert update_data["blocks"][2]["text"]["text"].endswith(expect_status)
 
-    def test_unarchive_issue_block_kit(self):
+    def test_unarchive_issue(self):
         self.group.status = GroupStatus.IGNORED
         self.group.substatus = GroupSubStatus.UNTIL_ESCALATING
         self.group.save(update_fields=["status", "substatus"])
 
         status_action = self.get_mark_ongoing_action()
-        original_message = self.get_original_message_block_kit(self.group.id)
+        original_message = self.get_original_message(self.group.id)
 
-        with self.feature("organizations:slack-block-kit"):
-            resp = self.post_webhook_block_kit(
-                action_data=[status_action], original_message=original_message
-            )
+        resp = self.post_webhook_block_kit(
+            action_data=[status_action], original_message=original_message
+        )
         assert resp.status_code == 200, resp.content
 
         self.group = Group.objects.get(id=self.group.id)
@@ -544,19 +473,18 @@ class StatusActionTest(BaseEventTest, PerformanceIssueTestCase, HybridCloudTestM
         assert self.notification_text in resp.data["blocks"][1]["text"]["text"]
         assert resp.data["blocks"][2]["text"]["text"].endswith(expect_status)
 
-    def test_unarchive_issue_block_kit_through_unfurl(self):
+    def test_unarchive_issue_through_unfurl(self):
         self.group.status = GroupStatus.IGNORED
         self.group.substatus = GroupSubStatus.UNTIL_ESCALATING
         self.group.save(update_fields=["status", "substatus"])
 
         status_action = self.get_mark_ongoing_action()
-        original_message = self.get_original_message_block_kit(self.group.id)
-        payload_data = self.get_block_kit_unfurl_data(original_message["blocks"])
+        original_message = self.get_original_message(self.group.id)
+        payload_data = self.get_unfurl_data(original_message["blocks"])
 
-        with self.feature("organizations:slack-block-kit"):
-            resp = self.post_webhook_block_kit(
-                action_data=[status_action], original_message=original_message, data=payload_data
-            )
+        resp = self.post_webhook_block_kit(
+            action_data=[status_action], original_message=original_message, data=payload_data
+        )
         assert resp.status_code == 200, resp.content
 
         self.group = Group.objects.get(id=self.group.id)
@@ -570,53 +498,47 @@ class StatusActionTest(BaseEventTest, PerformanceIssueTestCase, HybridCloudTestM
     def test_assign_issue(self):
         user2 = self.create_user(is_superuser=False)
         self.create_member(user=user2, organization=self.organization, teams=[self.team])
-
-        with self.feature("organizations:slack-block-kit"):
-            # Assign to user
-            status_action = {
-                "name": "assign",
-                "selected_options": [{"value": f"user:{user2.id}"}],
-            }
-
-            resp = self.post_webhook(action_data=[status_action])
-
-            assert resp.status_code == 200, resp.content
-            assert GroupAssignee.objects.filter(group=self.group, user_id=user2.id).exists()
-
-            expect_status = (
-                f"*Issue assigned to {user2.get_display_name()} by <@{self.external_id}>*"
-            )
-
-            # Assign to team
-            status_action = {
-                "name": "assign",
-                "selected_options": [{"value": f"team:{self.team.id}"}],
-            }
-
-            resp = self.post_webhook(action_data=[status_action])
-
-            assert resp.status_code == 200, resp.content
-            assert GroupAssignee.objects.filter(group=self.group, team=self.team).exists()
-            activity = Activity.objects.filter(group=self.group)[0]
-            assert activity.data == {
-                "assignee": str(user2.id),
-                "assigneeEmail": user2.email,
-                "assigneeType": "user",
-                "integration": ActivityIntegration.SLACK.value,
-            }
-
-            expect_status = f"*Issue assigned to #{self.team.slug} by <@{self.external_id}>*"
-
-            assert self.notification_text in resp.data["blocks"][1]["text"]["text"]
-            assert resp.data["blocks"][2]["text"]["text"].endswith(expect_status), resp.data["text"]
-
-    def test_assign_issue_block_kit(self):
-        user2 = self.create_user(is_superuser=False)
-        self.create_member(user=user2, organization=self.organization, teams=[self.team])
-        original_message = self.get_original_message_block_kit(self.group.id)
+        original_message = self.get_original_message(self.group.id)
 
         # Assign to user
-        resp = self.assign_issue_block_kit(original_message, user2)
+        resp = self.assign_issue(original_message, user2)
+        assert GroupAssignee.objects.filter(group=self.group, user_id=user2.id).exists()
+        expect_status = f"*Issue assigned to {user2.get_display_name()} by <@{self.external_id}>*"
+        assert self.notification_text in resp.data["blocks"][1]["text"]["text"]
+        assert resp.data["blocks"][2]["text"]["text"].endswith(expect_status), resp.data["text"]
+        assert ":red_circle:" in resp.data["blocks"][0]["text"]["text"]
+
+        # Assign to team
+        resp = self.assign_issue(original_message, self.team)
+        assert GroupAssignee.objects.filter(group=self.group, team=self.team).exists()
+        expect_status = f"*Issue assigned to #{self.team.slug} by <@{self.external_id}>*"
+        assert self.notification_text in resp.data["blocks"][1]["text"]["text"]
+        assert resp.data["blocks"][2]["text"]["text"].endswith(expect_status), resp.data["text"]
+        assert ":red_circle:" in resp.data["blocks"][0]["text"]["text"]
+
+        # Assert group assignment activity recorded
+        group_activity = Activity.objects.filter(group=self.group)
+        assert group_activity.first().data == {
+            "assignee": str(user2.id),
+            "assigneeEmail": user2.email,
+            "assigneeType": "user",
+            "integration": ActivityIntegration.SLACK.value,
+        }
+        assert group_activity.last().data == {
+            "assignee": str(self.team.id),
+            "assigneeEmail": None,
+            "assigneeType": "team",
+            "integration": ActivityIntegration.SLACK.value,
+        }
+
+    @with_feature("organizations:slack-improvements")
+    def test_assign_issue_block_kit_improvements(self):
+        user2 = self.create_user(is_superuser=False)
+        self.create_member(user=user2, organization=self.organization, teams=[self.team])
+        original_message = self.get_original_message(self.group.id)
+
+        # Assign to user
+        resp = self.assign_issue(original_message, user2)
         assert GroupAssignee.objects.filter(group=self.group, user_id=user2.id).exists()
         expect_status = f"*Issue assigned to {user2.get_display_name()} by <@{self.external_id}>*"
         assert self.notification_text in resp.data["blocks"][1]["text"]["text"]
@@ -624,7 +546,7 @@ class StatusActionTest(BaseEventTest, PerformanceIssueTestCase, HybridCloudTestM
         assert ":white_circle:" in resp.data["blocks"][0]["text"]["text"]
 
         # Assign to team
-        resp = self.assign_issue_block_kit(original_message, self.team)
+        resp = self.assign_issue(original_message, self.team)
         assert GroupAssignee.objects.filter(group=self.group, team=self.team).exists()
         expect_status = f"*Issue assigned to #{self.team.slug} by <@{self.external_id}>*"
         assert self.notification_text in resp.data["blocks"][1]["text"]["text"]
@@ -646,21 +568,21 @@ class StatusActionTest(BaseEventTest, PerformanceIssueTestCase, HybridCloudTestM
             "integration": ActivityIntegration.SLACK.value,
         }
 
-    def test_assign_issue_block_kit_through_unfurl(self):
+    def test_assign_issue_through_unfurl(self):
         user2 = self.create_user(is_superuser=False)
         self.create_member(user=user2, organization=self.organization, teams=[self.team])
-        original_message = self.get_original_message_block_kit(self.group.id)
-        payload_data = self.get_block_kit_unfurl_data(original_message["blocks"])
+        original_message = self.get_original_message(self.group.id)
+        payload_data = self.get_unfurl_data(original_message["blocks"])
 
         # Assign to user
-        resp = self.assign_issue_block_kit(original_message, user2, payload_data)
+        resp = self.assign_issue(original_message, user2, payload_data)
         assert GroupAssignee.objects.filter(group=self.group, user_id=user2.id).exists()
         expect_status = f"*Issue assigned to {user2.get_display_name()} by <@{self.external_id}>*"
         assert self.notification_text in resp.data["blocks"][1]["text"]["text"]
         assert resp.data["blocks"][2]["text"]["text"].endswith(expect_status), resp.data["text"]
 
         # Assign to team
-        resp = self.assign_issue_block_kit(original_message, self.team, payload_data)
+        resp = self.assign_issue(original_message, self.team, payload_data)
         assert GroupAssignee.objects.filter(group=self.group, team=self.team).exists()
         expect_status = f"*Issue assigned to #{self.team.slug} by <@{self.external_id}>*"
         assert self.notification_text in resp.data["blocks"][1]["text"]["text"]
@@ -683,47 +605,18 @@ class StatusActionTest(BaseEventTest, PerformanceIssueTestCase, HybridCloudTestM
 
     def test_assign_issue_where_team_not_in_project(self):
         user2 = self.create_user(is_superuser=False)
-
         team2 = self.create_team(
             organization=self.organization, members=[self.user], name="Ecosystem"
         )
         self.create_member(user=user2, organization=self.organization, teams=[team2])
         self.create_project(name="hellboy", organization=self.organization, teams=[team2])
         # Assign to team
-        status_action = {
-            "name": "assign",
-            "selected_options": [{"value": f"team:{team2.id}"}],
-        }
-
-        resp = self.post_webhook(action_data=[status_action])
-
-        assert resp.status_code == 200, resp.content
-        assert resp.data["text"] == "Cannot assign to a team without access to the project"
-        assert not GroupAssignee.objects.filter(group=self.group).exists()
-        with self.feature("organizations:slack-block-kit"):
-            # test backwards compatibility
-            resp = self.post_webhook(action_data=[status_action])
-
-            assert resp.status_code == 200, resp.content
-            assert resp.data["text"].endswith(
-                "Cannot assign to a team without access to the project"
-            )
-            assert not GroupAssignee.objects.filter(group=self.group).exists()
-
-    def test_assign_issue_where_team_not_in_project_block_kit(self):
-        user2 = self.create_user(is_superuser=False)
-        team2 = self.create_team(
-            organization=self.organization, members=[self.user], name="Ecosystem"
-        )
-        self.create_member(user=user2, organization=self.organization, teams=[team2])
-        self.create_project(name="hellboy", organization=self.organization, teams=[team2])
-        # Assign to team
-        original_message = self.get_original_message_block_kit(self.group.id)
-        resp = self.assign_issue_block_kit(original_message, team2)
+        original_message = self.get_original_message(self.group.id)
+        resp = self.assign_issue(original_message, team2)
         assert resp.data["text"].endswith("Cannot assign to a team without access to the project")
         assert not GroupAssignee.objects.filter(group=self.group).exists()
 
-    def test_assign_issue_where_team_not_in_project_block_kit_through_unfurl(self):
+    def test_assign_issue_where_team_not_in_project_through_unfurl(self):
         user2 = self.create_user(is_superuser=False)
         team2 = self.create_team(
             organization=self.organization, members=[self.user], name="Ecosystem"
@@ -731,49 +624,22 @@ class StatusActionTest(BaseEventTest, PerformanceIssueTestCase, HybridCloudTestM
         self.create_member(user=user2, organization=self.organization, teams=[team2])
         self.create_project(name="hellboy", organization=self.organization, teams=[team2])
         # Assign to team
-        original_message = self.get_original_message_block_kit(self.group.id)
-        payload_data = self.get_block_kit_unfurl_data(original_message["blocks"])
-        resp = self.assign_issue_block_kit(original_message, team2, payload_data)
+        original_message = self.get_original_message(self.group.id)
+        payload_data = self.get_unfurl_data(original_message["blocks"])
+        resp = self.assign_issue(original_message, team2, payload_data)
         assert resp.data["text"].endswith("Cannot assign to a team without access to the project")
         assert not GroupAssignee.objects.filter(group=self.group).exists()
 
     def test_assign_issue_user_has_identity(self):
         user2 = self.create_user(is_superuser=False)
         self.create_member(user=user2, organization=self.organization, teams=[self.team])
-
         user2_identity = self.create_identity(
             external_id="slack_id2",
             identity_provider=self.idp,
             user=user2,
         )
-
-        status_action = {
-            "name": "assign",
-            "selected_options": [{"value": f"user:{user2.id}"}],
-        }
-
-        expect_status = (
-            f"*Issue assigned to <@{user2_identity.external_id}> by <@{self.external_id}>*"
-        )
-
-        with self.feature("organizations:slack-block-kit"):
-            # test backwards compatibility
-            resp = self.post_webhook(action_data=[status_action])
-            assert resp.status_code == 200, resp.content
-            assert GroupAssignee.objects.filter(group=self.group, user_id=user2.id).exists()
-            assert self.notification_text in resp.data["blocks"][1]["text"]["text"]
-            assert resp.data["blocks"][2]["text"]["text"].endswith(expect_status), resp.data["text"]
-
-    def test_assign_issue_user_has_identity_block_kit(self):
-        user2 = self.create_user(is_superuser=False)
-        self.create_member(user=user2, organization=self.organization, teams=[self.team])
-        user2_identity = self.create_identity(
-            external_id="slack_id2",
-            identity_provider=self.idp,
-            user=user2,
-        )
-        original_message = self.get_original_message_block_kit(self.group.id)
-        resp = self.assign_issue_block_kit(original_message, user2)
+        original_message = self.get_original_message(self.group.id)
+        resp = self.assign_issue(original_message, user2)
         assert GroupAssignee.objects.filter(group=self.group, user_id=user2.id).exists()
 
         expect_status = (
@@ -782,7 +648,7 @@ class StatusActionTest(BaseEventTest, PerformanceIssueTestCase, HybridCloudTestM
         assert self.notification_text in resp.data["blocks"][1]["text"]["text"]
         assert resp.data["blocks"][2]["text"]["text"].endswith(expect_status), resp.data["text"]
 
-    def test_assign_issue_user_has_identity_block_kit_through_unfurl(self):
+    def test_assign_issue_user_has_identity_through_unfurl(self):
         user2 = self.create_user(is_superuser=False)
         self.create_member(user=user2, organization=self.organization, teams=[self.team])
 
@@ -791,9 +657,9 @@ class StatusActionTest(BaseEventTest, PerformanceIssueTestCase, HybridCloudTestM
             identity_provider=self.idp,
             user=user2,
         )
-        original_message = self.get_original_message_block_kit(self.group.id)
-        payload_data = self.get_block_kit_unfurl_data(original_message["blocks"])
-        resp = self.assign_issue_block_kit(original_message, user2, payload_data)
+        original_message = self.get_original_message(self.group.id)
+        payload_data = self.get_unfurl_data(original_message["blocks"])
+        resp = self.assign_issue(original_message, user2, payload_data)
         assert GroupAssignee.objects.filter(group=self.group, user_id=user2.id).exists()
 
         expect_status = (
@@ -816,39 +682,8 @@ class StatusActionTest(BaseEventTest, PerformanceIssueTestCase, HybridCloudTestM
             identity_provider=idp2,
             user=self.user,
         )
-
-        status_action = {
-            "name": "assign",
-            "selected_options": [{"value": f"user:{self.user.id}"}],
-        }
-
-        expect_status = "*Issue assigned to <@{assignee}> by <@{assignee}>*".format(
-            assignee=self.external_id
-        )
-        with self.feature("organizations:slack-block-kit"):
-            # test backwards compatibility
-            resp = self.post_webhook(action_data=[status_action])
-            assert resp.status_code == 200, resp.content
-            assert GroupAssignee.objects.filter(group=self.group, user_id=self.user.id).exists()
-            assert self.notification_text in resp.data["blocks"][1]["text"]["text"]
-            assert resp.data["blocks"][2]["text"]["text"].endswith(expect_status), resp.data["text"]
-
-    def test_assign_user_with_multiple_identities_block_kit(self):
-        org2 = self.create_organization(owner=None)
-
-        integration2 = self.create_integration(
-            organization=org2,
-            provider="slack",
-            external_id="TXXXXXXX2",
-        )
-        idp2 = self.create_identity_provider(integration=integration2)
-        self.create_identity(
-            external_id="slack_id2",
-            identity_provider=idp2,
-            user=self.user,
-        )
-        original_message = self.get_original_message_block_kit(self.group.id)
-        resp = self.assign_issue_block_kit(original_message, self.user)
+        original_message = self.get_original_message(self.group.id)
+        resp = self.assign_issue(original_message, self.user)
         assert GroupAssignee.objects.filter(group=self.group, user_id=self.user.id).exists()
 
         expect_status = "*Issue assigned to <@{assignee}> by <@{assignee}>*".format(
@@ -857,7 +692,7 @@ class StatusActionTest(BaseEventTest, PerformanceIssueTestCase, HybridCloudTestM
         assert self.notification_text in resp.data["blocks"][1]["text"]["text"]
         assert resp.data["blocks"][2]["text"]["text"].endswith(expect_status), resp.data["text"]
 
-    def test_assign_user_with_multiple_identities_block_kit_through_unfurl(self):
+    def test_assign_user_with_multiple_identities_through_unfurl(self):
         org2 = self.create_organization(owner=None)
 
         integration2 = self.create_integration(
@@ -871,9 +706,9 @@ class StatusActionTest(BaseEventTest, PerformanceIssueTestCase, HybridCloudTestM
             identity_provider=idp2,
             user=self.user,
         )
-        original_message = self.get_original_message_block_kit(self.group.id)
-        payload_data = self.get_block_kit_unfurl_data(original_message["blocks"])
-        resp = self.assign_issue_block_kit(original_message, self.user, payload_data)
+        original_message = self.get_original_message(self.group.id)
+        payload_data = self.get_unfurl_data(original_message["blocks"])
+        resp = self.assign_issue(original_message, self.user, payload_data)
         assert GroupAssignee.objects.filter(group=self.group, user_id=self.user.id).exists()
 
         expect_status = "*Issue assigned to <@{assignee}> by <@{assignee}>*".format(
@@ -913,8 +748,8 @@ class StatusActionTest(BaseEventTest, PerformanceIssueTestCase, HybridCloudTestM
         self.group = perf_issue.group
         assert self.group
 
-        original_message = self.get_original_message_block_kit(self.group.id)
-        self.resolve_issue_block_kit(original_message, "resolved")
+        original_message = self.get_original_message(self.group.id)
+        self.resolve_issue(original_message, "resolved")
 
         self.group.refresh_from_db()
         assert self.group.get_status() == GroupStatus.RESOLVED
@@ -933,10 +768,10 @@ class StatusActionTest(BaseEventTest, PerformanceIssueTestCase, HybridCloudTestM
         )
 
     @responses.activate
-    def test_resolve_issue_block_kit_through_unfurl(self):
-        original_message = self.get_original_message_block_kit(self.group.id)
-        payload_data = self.get_block_kit_unfurl_data(original_message["blocks"])
-        self.resolve_issue_block_kit(original_message, "resolved", payload_data)
+    def test_resolve_issue_through_unfurl(self):
+        original_message = self.get_original_message(self.group.id)
+        payload_data = self.get_unfurl_data(original_message["blocks"])
+        self.resolve_issue(original_message, "resolved", payload_data)
 
         self.group = Group.objects.get(id=self.group.id)
         assert self.group.get_status() == GroupStatus.RESOLVED
@@ -972,16 +807,16 @@ class StatusActionTest(BaseEventTest, PerformanceIssueTestCase, HybridCloudTestM
         assert update_data["blocks"][2]["text"]["text"].endswith(expect_status)
 
     @responses.activate
-    def test_resolve_issue_in_current_release_block_kit_through_unfurl(self):
+    def test_resolve_issue_in_current_release_through_unfurl(self):
         release = Release.objects.create(
             organization_id=self.organization.id,
             version="1.0",
         )
         release.add_project(self.project)
 
-        original_message = self.get_original_message_block_kit(self.group.id)
-        payload_data = self.get_block_kit_unfurl_data(original_message["blocks"])
-        self.resolve_issue_block_kit(original_message, "resolved:inCurrentRelease", payload_data)
+        original_message = self.get_original_message(self.group.id)
+        payload_data = self.get_unfurl_data(original_message["blocks"])
+        self.resolve_issue(original_message, "resolved:inCurrentRelease", payload_data)
 
         self.group = Group.objects.get(id=self.group.id)
         assert self.group.get_status() == GroupStatus.RESOLVED
@@ -996,14 +831,14 @@ class StatusActionTest(BaseEventTest, PerformanceIssueTestCase, HybridCloudTestM
         assert update_data["blocks"][2]["text"]["text"].endswith(expect_status)
 
     @responses.activate
-    def test_resolve_in_next_release_block_kit(self):
+    def test_resolve_in_next_release(self):
         release = Release.objects.create(
             organization_id=self.organization.id,
             version="1.0",
         )
         release.add_project(self.project)
-        original_message = self.get_original_message_block_kit(self.group.id)
-        self.resolve_issue_block_kit(original_message, "resolved:inNextRelease")
+        original_message = self.get_original_message(self.group.id)
+        self.resolve_issue(original_message, "resolved:inNextRelease")
 
         self.group = Group.objects.get(id=self.group.id)
         assert self.group.get_status() == GroupStatus.RESOLVED
@@ -1018,15 +853,15 @@ class StatusActionTest(BaseEventTest, PerformanceIssueTestCase, HybridCloudTestM
         assert update_data["blocks"][2]["text"]["text"].endswith(expect_status)
 
     @responses.activate
-    def test_resolve_in_next_release_block_kit_through_unfurl(self):
+    def test_resolve_in_next_release_through_unfurl(self):
         release = Release.objects.create(
             organization_id=self.organization.id,
             version="1.0",
         )
         release.add_project(self.project)
-        original_message = self.get_original_message_block_kit(self.group.id)
-        payload_data = self.get_block_kit_unfurl_data(original_message["blocks"])
-        self.resolve_issue_block_kit(original_message, "resolved:inNextRelease", payload_data)
+        original_message = self.get_original_message(self.group.id)
+        payload_data = self.get_unfurl_data(original_message["blocks"])
+        self.resolve_issue(original_message, "resolved:inNextRelease", payload_data)
 
         self.group = Group.objects.get(id=self.group.id)
         assert self.group.get_status() == GroupStatus.RESOLVED
@@ -1040,24 +875,10 @@ class StatusActionTest(BaseEventTest, PerformanceIssueTestCase, HybridCloudTestM
         assert self.notification_text in update_data["blocks"][1]["text"]["text"]
         assert update_data["blocks"][2]["text"]["text"].endswith(expect_status)
 
+    @responses.activate
     def test_response_differs_on_bot_message(self):
-        status_action = {"name": "status", "value": "ignored:archived_forever", "type": "button"}
-        original_message = {"type": "message"}
-
-        with self.feature("organizations:slack-block-kit"):
-            # test backwards compatibility
-            resp = self.post_webhook(action_data=[status_action], original_message=original_message)
-            self.group = Group.objects.get(id=self.group.id)
-            assert self.group.get_status() == GroupStatus.IGNORED
-            assert self.group.substatus == GroupSubStatus.FOREVER
-            assert resp.status_code == 200, resp.content
-            assert "blocks" in resp.data
-            assert resp.data["blocks"][1]["text"]["text"][3:-3] in self.group.title
-
-    @responses.activate
-    def test_response_differs_on_bot_message_block_kit(self):
         status_action = self.get_archive_status_action()
-        original_message = self.get_original_message_block_kit(self.group.id)
+        original_message = self.get_original_message(self.group.id)
 
         # Expect request to open dialog on slack
         responses.add(
@@ -1068,11 +889,10 @@ class StatusActionTest(BaseEventTest, PerformanceIssueTestCase, HybridCloudTestM
             content_type="application/json",
         )
 
-        with self.feature("organizations:slack-block-kit"):
-            resp = self.post_webhook_block_kit(
-                action_data=[status_action],
-                original_message=original_message,
-            )
+        resp = self.post_webhook_block_kit(
+            action_data=[status_action],
+            original_message=original_message,
+        )
         assert resp.status_code == 200, resp.content
 
         # Opening dialog should *not* cause the current message to be updated
@@ -1096,12 +916,11 @@ class StatusActionTest(BaseEventTest, PerformanceIssueTestCase, HybridCloudTestM
             content_type="application/json",
         )
 
-        with self.feature("organizations:slack-block-kit"):
-            resp = self.post_webhook_block_kit(
-                type="view_submission",
-                private_metadata=orjson.dumps(private_metadata).decode(),
-                selected_option="ignored:archived_forever",
-            )
+        resp = self.post_webhook_block_kit(
+            type="view_submission",
+            private_metadata=orjson.dumps(private_metadata),
+            selected_option="ignored:archived_forever",
+        )
         assert resp.status_code == 200, resp.content
         self.group = Group.objects.get(id=self.group.id)
 
@@ -1114,49 +933,8 @@ class StatusActionTest(BaseEventTest, PerformanceIssueTestCase, HybridCloudTestM
         assert self.notification_text in update_data["blocks"][1]["text"]["text"]
         assert update_data["blocks"][2]["text"]["text"].endswith(expect_status)
 
-    def test_permission_denied(self):
-        user2 = self.create_user(is_superuser=False)
-
-        user2_identity = self.create_identity(
-            external_id="slack_id2",
-            identity_provider=self.idp,
-            user=user2,
-        )
-
-        status_action = {"name": "status", "value": "ignored:archived_forever", "type": "button"}
-
-        with self.feature({"organizations:slack-block-kit": False}):
-            resp = self.post_webhook(
-                action_data=[status_action], slack_user={"id": user2_identity.external_id}
-            )
-            self.group = Group.objects.get(id=self.group.id)
-
-            associate_url = build_unlinking_url(
-                self.integration.id, "slack_id2", "C065W1189", self.response_url
-            )
-
-            assert resp.status_code == 200, resp.content
-            assert resp.data["response_type"] == "ephemeral"
-            assert not resp.data["replace_original"]
-            assert resp.data["text"] == UNLINK_IDENTITY_MESSAGE.format(
-                associate_url=associate_url, user_email=user2.email, org_name=self.organization.name
-            )
-
-        with self.feature("organizations:slack-block-kit"):
-            # test backwards compatibility
-            resp = self.post_webhook(
-                action_data=[status_action], slack_user={"id": user2_identity.external_id}
-            )
-
-            assert resp.status_code == 200, resp.content
-            assert resp.data["response_type"] == "ephemeral"
-            assert not resp.data["replace_original"]
-            assert resp.data["text"] == UNLINK_IDENTITY_MESSAGE.format(
-                associate_url=associate_url, user_email=user2.email, org_name=self.organization.name
-            )
-
     @responses.activate
-    def test_permission_denied_block_kit(self):
+    def test_permission_denied(self):
         user2 = self.create_user(is_superuser=False)
         user2_identity = self.create_identity(
             external_id="slack_id2",
@@ -1164,7 +942,7 @@ class StatusActionTest(BaseEventTest, PerformanceIssueTestCase, HybridCloudTestM
             user=user2,
         )
         status_action = self.get_archive_status_action()
-        original_message = self.get_original_message_block_kit(self.group.id)
+        original_message = self.get_original_message(self.group.id)
         assert self.group.get_status() == GroupStatus.UNRESOLVED
 
         # Expect request to open dialog on slack; will only get permission denied when trying to complete an action
@@ -1176,12 +954,11 @@ class StatusActionTest(BaseEventTest, PerformanceIssueTestCase, HybridCloudTestM
             content_type="application/json",
         )
 
-        with self.feature("organizations:slack-block-kit"):
-            resp = self.post_webhook_block_kit(
-                action_data=[status_action],
-                original_message=original_message,
-                slack_user={"id": user2_identity.external_id},
-            )
+        resp = self.post_webhook_block_kit(
+            action_data=[status_action],
+            original_message=original_message,
+            slack_user={"id": user2_identity.external_id},
+        )
         assert resp.status_code == 200, resp.content
 
         # Opening dialog should *not* cause the current message to be updated
@@ -1204,14 +981,12 @@ class StatusActionTest(BaseEventTest, PerformanceIssueTestCase, HybridCloudTestM
             status=200,
             content_type="application/json",
         )
-        with self.feature("organizations:slack-block-kit"):
-            resp = self.post_webhook_block_kit(
-                type="view_submission",
-                private_metadata=orjson.dumps(private_metadata).decode(),
-                selected_option="ignored:archived_forever",
-                slack_user={"id": user2_identity.external_id},
-            )
-
+        resp = self.post_webhook_block_kit(
+            type="view_submission",
+            private_metadata=orjson.dumps(private_metadata),
+            selected_option="ignored:archived_forever",
+            slack_user={"id": user2_identity.external_id},
+        )
         assert resp.status_code == 200, resp.content
         self.group = Group.objects.get(id=self.group.id)
         assert self.group.get_status() == GroupStatus.UNRESOLVED
@@ -1227,7 +1002,7 @@ class StatusActionTest(BaseEventTest, PerformanceIssueTestCase, HybridCloudTestM
         )
 
     @responses.activate
-    def test_permission_denied_block_kit_through_unfurl(self):
+    def test_permission_denied_through_unfurl(self):
         user2 = self.create_user(is_superuser=False)
         user2_identity = self.create_identity(
             external_id="slack_id2",
@@ -1235,7 +1010,7 @@ class StatusActionTest(BaseEventTest, PerformanceIssueTestCase, HybridCloudTestM
             user=user2,
         )
         status_action = self.get_archive_status_action()
-        original_message = self.get_original_message_block_kit(self.group.id)
+        original_message = self.get_original_message(self.group.id)
 
         # Expect request to open dialog on slack
         responses.add(
@@ -1246,13 +1021,12 @@ class StatusActionTest(BaseEventTest, PerformanceIssueTestCase, HybridCloudTestM
             content_type="application/json",
         )
 
-        data = self.get_block_kit_unfurl_data(original_message["blocks"])
-        with self.feature("organizations:slack-block-kit"):
-            resp = self.post_webhook_block_kit(
-                action_data=[status_action],
-                data=data,
-                slack_user={"id": user2_identity.external_id},
-            )
+        data = self.get_unfurl_data(original_message["blocks"])
+        resp = self.post_webhook_block_kit(
+            action_data=[status_action],
+            data=data,
+            slack_user={"id": user2_identity.external_id},
+        )
         assert resp.status_code == 200, resp.content
 
         # Opening dialog should *not* cause the current message to be updated
@@ -1276,13 +1050,12 @@ class StatusActionTest(BaseEventTest, PerformanceIssueTestCase, HybridCloudTestM
             content_type="application/json",
         )
 
-        with self.feature("organizations:slack-block-kit"):
-            resp = self.post_webhook_block_kit(
-                type="view_submission",
-                private_metadata=orjson.dumps(private_metadata).decode(),
-                selected_option="ignored:archived_until_escalating",
-                slack_user={"id": user2_identity.external_id},
-            )
+        resp = self.post_webhook_block_kit(
+            type="view_submission",
+            private_metadata=orjson.dumps(private_metadata),
+            selected_option="ignored:archived_until_escalating",
+            slack_user={"id": user2_identity.external_id},
+        )
         assert resp.status_code == 200, resp.content
         self.group = Group.objects.get(id=self.group.id)
 
@@ -1312,7 +1085,7 @@ class StatusActionTest(BaseEventTest, PerformanceIssueTestCase, HybridCloudTestM
     @responses.activate
     def test_handle_submission_fail_block_kit(self, mock_open_view):
         status_action = self.get_resolve_status_action()
-        original_message = self.get_original_message_block_kit(self.group.id)
+        original_message = self.get_original_message(self.group.id)
         # Expect request to open dialog on slack
         responses.add(
             method=responses.POST,
@@ -1321,10 +1094,9 @@ class StatusActionTest(BaseEventTest, PerformanceIssueTestCase, HybridCloudTestM
             status=200,
             content_type="application/json",
         )
-        with self.feature("organizations:slack-block-kit"):
-            resp = self.post_webhook_block_kit(
-                action_data=[status_action], original_message=original_message
-            )
+        resp = self.post_webhook_block_kit(
+            action_data=[status_action], original_message=original_message
+        )
         assert resp.status_code == 200, resp.content
 
         # Opening dialog should *not* cause the current message to be updated
@@ -1388,8 +1160,8 @@ class StatusActionTest(BaseEventTest, PerformanceIssueTestCase, HybridCloudTestM
     @responses.activate
     def test_handle_submission_fail_through_unfurl(self, mock_open_view):
         status_action = self.get_resolve_status_action()
-        original_message = self.get_original_message_block_kit(self.group.id)
-        payload_data = self.get_block_kit_unfurl_data(original_message["blocks"])
+        original_message = self.get_original_message(self.group.id)
+        payload_data = self.get_unfurl_data(original_message["blocks"])
         # Expect request to open dialog on slack
         responses.add(
             method=responses.POST,
@@ -1398,8 +1170,7 @@ class StatusActionTest(BaseEventTest, PerformanceIssueTestCase, HybridCloudTestM
             status=200,
             content_type="application/json",
         )
-        with self.feature("organizations:slack-block-kit"):
-            resp = self.post_webhook_block_kit(action_data=[status_action], data=payload_data)
+        resp = self.post_webhook_block_kit(action_data=[status_action], data=payload_data)
         assert resp.status_code == 200, resp.content
 
         # Opening dialog should *not* cause the current message to be updated

--- a/tests/sentry/integrations/slack/webhooks/options_load/test_dynamic_assignment_dropdown.py
+++ b/tests/sentry/integrations/slack/webhooks/options_load/test_dynamic_assignment_dropdown.py
@@ -1,7 +1,6 @@
 import orjson
 
 from sentry.testutils.helpers.datetime import freeze_time
-from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.skips import requires_snuba
 
 from . import BaseEventTest
@@ -64,7 +63,6 @@ class DynamicAssignmentDropdownTest(BaseEventTest):
         }
 
     @freeze_time("2021-01-14T12:27:28.303Z")
-    @with_feature("organizations:slack-block-kit")
     def test_simple(self):
         self.team1 = self.create_team(name="aaaa", slug="aaaa")
         self.team2 = self.create_team(name="aaab", slug="eeee")
@@ -103,17 +101,6 @@ class DynamicAssignmentDropdownTest(BaseEventTest):
         assert len(resp.data["option_groups"][0]["options"]) == 3
         assert len(resp.data["option_groups"][1]["options"]) == 3
 
-    @with_feature({"organizations:slack-block-kit": False})
-    def test_no_flag(self):
-        self.group = self.create_group(project=self.project)
-        self.original_message["blocks"][0]["block_id"] = orjson.dumps(
-            {"issue": self.group.id}
-        ).decode()
-        resp = self.post_webhook(substring="bbb", original_message=self.original_message)
-
-        assert resp.status_code == 400
-
-    @with_feature("organizations:slack-block-kit")
     def test_non_existent_group(self):
         self.original_message["blocks"][0]["block_id"] = orjson.dumps({"issue": 1}).decode()
         resp = self.post_webhook(substring="bbb", original_message=self.original_message)


### PR DESCRIPTION
Remove usages of the "organizations:slack-block-kit" flag - this doesn't completely remove the flag because we still need to update some getsentry tests. 