### PR TITLE
feat(relay): Restore passive limits

### DIFF
--- a/src/sentry/relay/config/__init__.py
+++ b/src/sentry/relay/config/__init__.py
@@ -290,8 +290,7 @@ def get_metrics_config(timeout: TimeChecker, project: Project) -> Mapping[str, A
                 "namespace": namespace.value,
             }
             if id in passive_limits:
-                # HACK inc-730: reduce pressure on memory by disabling limits for passive projects
-                continue
+                limit["passive"] = True
             cardinality_limits.append(limit)
             existing_ids.add(id)
 

--- a/tests/sentry/relay/snapshots/test_config/test_project_config_cardinality_limits/True/REGION.pysnap
+++ b/tests/sentry/relay/snapshots/test_config/test_project_config_cardinality_limits/True/REGION.pysnap
@@ -1,9 +1,49 @@
 ---
-created: '2024-04-24T14:41:12.052529+00:00'
+created: '2024-05-03T06:37:35.696243+00:00'
 creator: sentry
 source: tests/sentry/relay/test_config.py
 ---
 cardinalityLimits:
+- id: transactions
+  limit: 10
+  namespace: transactions
+  passive: true
+  scope: organization
+  window:
+    granularitySeconds: 100
+    windowSeconds: 1000
+- id: sessions
+  limit: 20
+  namespace: sessions
+  passive: true
+  scope: organization
+  window:
+    granularitySeconds: 200
+    windowSeconds: 2000
+- id: spans
+  limit: 30
+  namespace: spans
+  passive: true
+  scope: organization
+  window:
+    granularitySeconds: 300
+    windowSeconds: 3000
+- id: custom
+  limit: 40
+  namespace: custom
+  passive: true
+  scope: organization
+  window:
+    granularitySeconds: 400
+    windowSeconds: 4000
+- id: profiles
+  limit: 60
+  namespace: profiles
+  passive: true
+  scope: organization
+  window:
+    granularitySeconds: 600
+    windowSeconds: 3600
 - id: test3
   limit: 90
   scope: name


### PR DESCRIPTION
This reverts https://github.com/getsentry/sentry/pull/69564.

The hack only had a minimal effect on redis memory pressure, and we've since increased redis memory.