### PR TITLE
temporary(dynamic-sampling): Log outgoing envelopes that belong to boost low volume projects

### DIFF
--- a/src/sentry/utils/sdk.py
+++ b/src/sentry/utils/sdk.py
@@ -226,6 +226,13 @@ def before_send_transaction(event: Event, _: Hint) -> Event | None:
     ):
         return None
 
+    # This code is added only for debugging purposes, as such, it should be removed once the investigation is done.
+    if event.get("transaction") in {
+        "sentry.dynamic_sampling.boost_low_volume_projects_of_org",
+        "sentry.dynamic_sampling.tasks.boost_low_volume_projects",
+    }:
+        logger.info("transaction_logged", extra=event)
+
     # Occasionally the span limit is hit and we drop spans from transactions, this helps find transactions where this occurs.
     num_of_spans = len(event["spans"])
     event["tags"]["spans_over_limit"] = str(num_of_spans >= 1000)


### PR DESCRIPTION
This PR adds logging to outgoing envelopes for specific transactions because we are investigating problems with trace headers.