### PR TITLE
fix: Fix onboarding button to view npm instructions

### DIFF
--- a/static/app/components/onboarding/productSelection.spec.tsx
+++ b/static/app/components/onboarding/productSelection.spec.tsx
@@ -135,7 +135,7 @@ describe('Onboarding Product Selection', function () {
       )
     ).toBeInTheDocument();
 
-    await userEvent.click(screen.getByText('Go here'));
+    await userEvent.click(screen.getByText('View npm instructions'));
 
     expect(skipLazyLoader).toHaveBeenCalledTimes(1);
   });

--- a/static/app/components/onboarding/productSelection.tsx
+++ b/static/app/components/onboarding/productSelection.tsx
@@ -448,13 +448,13 @@ export function ProductSelection({
       </Products>
       {showPackageManagerInfo && lazyLoader && (
         <AlternativeInstallationAlert type="info" showIcon>
-          {tct('Prefer to set up Sentry using [npm:npm] or [yarn:yarn]? [goHere].', {
+          {tct('Prefer to set up Sentry using [npm:npm] or [yarn:yarn]? [goHere]', {
             npm: <strong />,
             yarn: <strong />,
             goHere: (
-              <Button onClick={skipLazyLoader} priority="link">
-                {t('Go here')}
-              </Button>
+              <SkipLazyLoaderButton onClick={skipLazyLoader} size="xs" priority="default">
+                {t('View npm instructions')}
+              </SkipLazyLoaderButton>
             ),
           })}
         </AlternativeInstallationAlert>
@@ -462,6 +462,10 @@ export function ProductSelection({
     </Fragment>
   );
 }
+
+const SkipLazyLoaderButton = styled(Button)`
+  margin-left: ${space(1)};
+`;
 
 const Products = styled('div')`
   display: flex;


### PR DESCRIPTION
This got visually broken with some update - it looks like this today:

![Screenshot 2024-05-03 at 13 00 20](https://github.com/getsentry/sentry/assets/2411343/24bedcdc-32cd-451a-bfcd-0014cbb64321)

This changes this to show a proper button with a better text content than "Go here":

![Screenshot 2024-05-03 at 12 54 28](https://github.com/getsentry/sentry/assets/2411343/911da6b2-75f8-45bf-bb3b-51bda64eb30c)
