### PR TITLE
feat(spans): Filter to only required span fields

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -2417,16 +2417,6 @@ register(
     flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
 )
 register(
-    "standalone-spans.deserialize-spans-rapidjson.enable",
-    default=False,
-    flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
-)
-register(
-    "standalone-spans.deserialize-spans-orjson.enable",
-    default=False,
-    flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
-)
-register(
     "indexed-spans.agg-span-waterfall.enable",
     default=False,
     flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,

--- a/src/sentry/spans/consumers/detect_performance_issues/message.py
+++ b/src/sentry/spans/consumers/detect_performance_issues/message.py
@@ -143,6 +143,12 @@ def transform_spans_to_event_dict(spans):
     event["platform"] = sentry_tags.get("platform")
     event["tags"] = [["environment", sentry_tags.get("environment")]]
 
+    if "browser.name" in sentry_tags:
+        event["tags"].append(["browser.name", sentry_tags["browser.name"]])
+
+    if "sdk.name" in sentry_tags:
+        event["sdk"] = {"name": sentry_tags["sdk.name"]}
+
     event["contexts"]["trace"] = {
         "trace_id": span["trace_id"],
         "type": "trace",

--- a/src/sentry/spans/consumers/process/factory.py
+++ b/src/sentry/spans/consumers/process/factory.py
@@ -48,12 +48,15 @@ SPAN_DATA_KEYS = [
 
 SENTRY_TAG_KEYS = [
     "transaction",
+    "transaction.method",
+    "transaction.op",
     "release",
     "environment",
     "platform",
     "environment",
     "op",
     "sdk.name",
+    "browser.name",
 ]
 
 

--- a/tests/sentry/spans/consumers/detect_performance_issues/test_factory.py
+++ b/tests/sentry/spans/consumers/detect_performance_issues/test_factory.py
@@ -45,7 +45,7 @@ def test_segment_deserialized_correctly(mock_process_segment):
         partitions={},
     )
 
-    span_data = build_mock_span(project_id=1, is_segment=True)
+    _, span_data = build_mock_span(project_id=1, is_segment=True)
     segment_data = {"spans": [span_data]}
     message = build_mock_message(segment_data, topic)
 

--- a/tests/sentry/spans/consumers/detect_performance_issues/test_message.py
+++ b/tests/sentry/spans/consumers/detect_performance_issues/test_message.py
@@ -14,8 +14,8 @@ class TestSpansTask(TestCase):
         self.project = self.create_project()
 
     def generate_n_plus_one_spans(self):
-        segment_span = build_mock_span(project_id=self.project.id)
-        child_span = build_mock_span(
+        _, segment_span = build_mock_span(project_id=self.project.id)
+        _, child_span = build_mock_span(
             project_id=self.project.id,
             description="OrganizationNPlusOne.get",
             is_segment=False,
@@ -23,7 +23,7 @@ class TestSpansTask(TestCase):
             span_id="940ce942561548b5",
             start_timestamp_ms=1707953018867,
         )
-        cause_span = build_mock_span(
+        _, cause_span = build_mock_span(
             project_id=self.project.id,
             span_op="db",
             description='SELECT "sentry_project"."id", "sentry_project"."slug", "sentry_project"."name", "sentry_project"."forced_color", "sentry_project"."organization_id", "sentry_project"."public", "sentry_project"."date_added", "sentry_project"."status", "sentry_project"."first_event", "sentry_project"."flags", "sentry_project"."platform" FROM "sentry_project"',
@@ -35,7 +35,7 @@ class TestSpansTask(TestCase):
         repeating_span_description = 'SELECT "sentry_organization"."id", "sentry_organization"."name", "sentry_organization"."slug", "sentry_organization"."status", "sentry_organization"."date_added", "sentry_organization"."default_role", "sentry_organization"."is_test", "sentry_organization"."flags" FROM "sentry_organization" WHERE "sentry_organization"."id" = %s LIMIT 21'
 
         def repeating_span():
-            return build_mock_span(
+            _, s = build_mock_span(
                 project_id=self.project.id,
                 span_op="db",
                 description=repeating_span_description,
@@ -44,6 +44,7 @@ class TestSpansTask(TestCase):
                 span_id=uuid.uuid4().hex[:16],
                 start_timestamp_ms=1707953018869,
             )
+            return s
 
         repeating_spans = [repeating_span() for _ in range(7)]
         spans = [segment_span, child_span, cause_span] + repeating_spans
@@ -83,8 +84,8 @@ class TestSpansTask(TestCase):
         ]
 
     def test_n_plus_one_issue_detection_without_segment_span(self):
-        segment_span = build_mock_span(project_id=self.project.id, is_segment=False)
-        child_span = build_mock_span(
+        _, segment_span = build_mock_span(project_id=self.project.id, is_segment=False)
+        _, child_span = build_mock_span(
             project_id=self.project.id,
             description="OrganizationNPlusOne.get",
             is_segment=False,
@@ -92,7 +93,7 @@ class TestSpansTask(TestCase):
             span_id="940ce942561548b5",
             start_timestamp_ms=1707953018867,
         )
-        cause_span = build_mock_span(
+        _, cause_span = build_mock_span(
             project_id=self.project.id,
             span_op="db",
             description='SELECT "sentry_project"."id", "sentry_project"."slug", "sentry_project"."name", "sentry_project"."forced_color", "sentry_project"."organization_id", "sentry_project"."public", "sentry_project"."date_added", "sentry_project"."status", "sentry_project"."first_event", "sentry_project"."flags", "sentry_project"."platform" FROM "sentry_project"',
@@ -104,7 +105,7 @@ class TestSpansTask(TestCase):
         repeating_span_description = 'SELECT "sentry_organization"."id", "sentry_organization"."name", "sentry_organization"."slug", "sentry_organization"."status", "sentry_organization"."date_added", "sentry_organization"."default_role", "sentry_organization"."is_test", "sentry_organization"."flags" FROM "sentry_organization" WHERE "sentry_organization"."id" = %s LIMIT 21'
 
         def repeating_span():
-            return build_mock_span(
+            _, s = build_mock_span(
                 project_id=self.project.id,
                 span_op="db",
                 description=repeating_span_description,
@@ -113,6 +114,7 @@ class TestSpansTask(TestCase):
                 span_id=uuid.uuid4().hex[:16],
                 start_timestamp_ms=1707953018869,
             )
+            return s
 
         repeating_spans = [repeating_span() for _ in range(7)]
         spans = [segment_span, child_span, cause_span] + repeating_spans


### PR DESCRIPTION
Only store required `span.data` and `span.sentry_tag` keys in redis
Remove unused metrics and options