### PR TITLE
fix(replays): Remove project-id as an aggregation key

### DIFF
--- a/src/sentry/replays/endpoints/organization_replay_details.py
+++ b/src/sentry/replays/endpoints/organization_replay_details.py
@@ -67,8 +67,11 @@ class OrganizationReplayDetailsEndpoint(OrganizationEndpoint):
         except ValueError:
             return Response(status=404)
 
+        projects = self.get_projects(request, organization, include_all_accessible=True)
+        project_ids = [project.id for project in projects]
+
         snuba_response = query_replay_instance(
-            project_id=filter_params["project_id"],
+            project_id=project_ids,
             replay_id=replay_id,
             start=filter_params["start"],
             end=filter_params["end"],

--- a/src/sentry/replays/post_process.py
+++ b/src/sentry/replays/post_process.py
@@ -108,11 +108,11 @@ def generate_normalized_output(
     for item in response:
         ret_item: ReplayDetailsResponse = {}
         if item["isArchived"]:
-            yield _archived_row(item["replay_id"], item["project_id"])  # type: ignore[misc]
+            yield _archived_row(item["replay_id"], item["agg_project_id"])  # type: ignore[misc]
             continue
 
         ret_item["id"] = _strip_dashes(item.pop("replay_id", None))
-        ret_item["project_id"] = str(item["project_id"])
+        ret_item["project_id"] = str(item["agg_project_id"])
         ret_item["trace_ids"] = item.pop("traceIds", [])
         ret_item["error_ids"] = item.pop("errorIds", [])
         ret_item["environment"] = item.pop("agg_environment", None)

--- a/src/sentry/replays/query.py
+++ b/src/sentry/replays/query.py
@@ -502,7 +502,7 @@ def _filter_empty_uuids(column_name):
 FIELD_QUERY_ALIAS_MAP: dict[str, list[str]] = {
     "id": ["replay_id"],
     "replay_type": ["replay_type"],
-    "project_id": ["project_id"],
+    "project_id": ["agg_project_id"],
     "project": ["project_id"],
     "platform": ["platform"],
     "environment": ["agg_environment"],
@@ -597,7 +597,11 @@ FIELD_QUERY_ALIAS_MAP: dict[str, list[str]] = {
 
 QUERY_ALIAS_COLUMN_MAP = {
     "replay_id": Column("replay_id"),
-    "project_id": Column("project_id"),
+    "agg_project_id": Function(
+        "anyIf",
+        parameters=[Column("project_id"), Function("equals", parameters=[Column("segment_id"), 0])],
+        alias="agg_project_id",
+    ),
     "trace_ids": Function(
         "arrayMap",
         parameters=[
@@ -777,7 +781,7 @@ TAG_QUERY_ALIAS_COLUMN_MAP = {
 def collect_aliases(fields: list[str]) -> list[str]:
     """Return a unique list of aliases required to satisfy the fields."""
     # Required fields.
-    result = {"is_archived", "finished_at", "agg_environment"}
+    result = {"is_archived", "finished_at", "agg_environment", "agg_project_id"}
 
     saw_tags = False
     for field in fields:

--- a/src/sentry/replays/usecases/query/__init__.py
+++ b/src/sentry/replays/usecases/query/__init__.py
@@ -320,7 +320,7 @@ def make_full_aggregation_query(
         #
         # This condition ensures that every replay shown to the user is valid.
         having=[Condition(Function("min", parameters=[Column("segment_id")]), Op.EQ, 0)],
-        groupby=[Column("project_id"), Column("replay_id")],
+        groupby=[Column("replay_id")],
         granularity=Granularity(3600),
     )
 

--- a/tests/sentry/replays/test_organization_replay_details.py
+++ b/tests/sentry/replays/test_organization_replay_details.py
@@ -163,3 +163,90 @@ class OrganizationReplayDetailsTest(APITestCase, ReplaysSnubaTestCase):
                 count_errors=1,
             )
             assert_expected_response(response_data["data"], expected_response)
+
+    def test_get_replay_varying_projects(self):
+        """Test replay with varying project-ids returns its whole self."""
+        project2 = self.create_project()
+
+        replay1_id = self.replay_id
+        replay2_id = uuid4().hex
+        seq1_timestamp = datetime.datetime.now() - datetime.timedelta(seconds=25)
+        seq2_timestamp = datetime.datetime.now() - datetime.timedelta(seconds=7)
+        seq3_timestamp = datetime.datetime.now() - datetime.timedelta(seconds=4)
+
+        trace_id_1 = uuid4().hex
+        trace_id_2 = uuid4().hex
+        # Assert values from this non-returned replay do not pollute the returned
+        # replay.
+        self.store_replays(mock_replay(seq1_timestamp, self.project.id, replay2_id))
+        self.store_replays(mock_replay(seq3_timestamp, self.project.id, replay2_id))
+
+        self.store_replays(
+            mock_replay(
+                seq1_timestamp,
+                self.project.id,
+                replay1_id,
+                trace_ids=[trace_id_1],
+                urls=["http://localhost:3000/"],
+            )
+        )
+        # The initial segment's project-id is different from the following segments. This
+        # difference does not influence the response.
+        self.store_replays(
+            self.mock_event_links(
+                seq1_timestamp,
+                project2.id,
+                "error",
+                replay1_id,
+                "a3a62ef6ac86415b83c2416fc2f76db1",
+            )
+        )
+        self.store_replays(
+            mock_replay(
+                seq2_timestamp,
+                project2.id,
+                replay1_id,
+                segment_id=1,
+                trace_ids=[trace_id_2],
+                urls=["http://www.sentry.io/"],
+                error_ids=[],
+            )
+        )
+        self.store_replays(
+            mock_replay(
+                seq3_timestamp,
+                project2.id,
+                replay1_id,
+                segment_id=2,
+                trace_ids=[trace_id_2],
+                urls=["http://localhost:3000/"],
+                error_ids=[],
+            )
+        )
+
+        with self.feature(REPLAYS_FEATURES):
+            response = self.client.get(self.url)
+            assert response.status_code == 200
+
+            response_data = response.json()
+            assert "data" in response_data
+
+            expected_response = mock_expected_response(
+                self.project.id,
+                replay1_id,
+                seq1_timestamp,
+                seq3_timestamp,
+                trace_ids=[
+                    trace_id_1,
+                    trace_id_2,
+                ],
+                urls=[
+                    "http://localhost:3000/",
+                    "http://www.sentry.io/",
+                    "http://localhost:3000/",
+                ],
+                count_segments=3,
+                activity=4,
+                count_errors=1,
+            )
+            assert_expected_response(response_data["data"], expected_response)


### PR DESCRIPTION
This fixes a bug where the details page would show errors for project's associated with the replay but not other projects (e.g. back-end errors).  This pull does not fix the index page which suffers from a similar problem.