### PR TITLE
ref(seer-grouping): More pre-group-id-to-hash-switch fixes

### DIFF
--- a/src/sentry/api/endpoints/group_similar_issues_embeddings.py
+++ b/src/sentry/api/endpoints/group_similar_issues_embeddings.py
@@ -186,15 +186,15 @@ class GroupSimilarIssuesEmbeddingsEndpoint(GroupEndpoint):
             count_over_threshold=len(
                 [
                     result["stacktrace_distance"]
-                    for result in (results.get("responses") or [])
+                    for result in results
                     if result["stacktrace_distance"] <= 0.01
                 ]
             ),
             user_id=request.user.id,
         )
 
-        if not results["responses"]:
+        if not results:
             return Response([])
-        formatted_results = self.get_formatted_results(results["responses"], request.user)
+        formatted_results = self.get_formatted_results(results, request.user)
 
         return Response(formatted_results)

--- a/src/sentry/seer/utils.py
+++ b/src/sentry/seer/utils.py
@@ -120,7 +120,7 @@ class SeerSimilarIssueData:
 
 def get_similar_issues_embeddings(
     similar_issues_request: SimilarIssuesEmbeddingsRequest,
-) -> SimilarIssuesEmbeddingsResponse:
+) -> list[RawSeerSimilarIssueData]:
     """Call /v0/issues/similar-issues endpoint from seer."""
     response = seer_staging_connection_pool.urlopen(
         "POST",
@@ -130,7 +130,7 @@ def get_similar_issues_embeddings(
     )
 
     try:
-        return json.loads(response.data.decode("utf-8"))
+        response_data = json.loads(response.data.decode("utf-8"))
     except (
         AttributeError,  # caused by a response with no data and therefore no `.decode` method
         UnicodeError,
@@ -143,4 +143,6 @@ def get_similar_issues_embeddings(
                 "response_data": response.data,
             },
         )
-        return {"responses": []}
+        return []
+
+    return response_data.get("responses") or []

--- a/tests/sentry/api/endpoints/test_group_similar_issues_embeddings.py
+++ b/tests/sentry/api/endpoints/test_group_similar_issues_embeddings.py
@@ -13,8 +13,10 @@ from sentry.api.serializers.base import serialize
 from sentry.models.group import Group
 from sentry.seer.utils import RawSeerSimilarIssueData, SimilarIssuesEmbeddingsResponse
 from sentry.testutils.cases import APITestCase
+from sentry.testutils.helpers.eventprocessing import save_new_event
 from sentry.testutils.helpers.features import with_feature
 from sentry.utils import json
+from sentry.utils.types import NonNone
 
 EXPECTED_STACKTRACE_STRING = 'ZeroDivisionError: division by zero\n  File "python_onboarding.py", function divide_by_zero\n    divide = 1/0'
 BASE_APP_DATA: dict[str, Any] = {
@@ -389,7 +391,9 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
         self.group = self.event.group
         assert self.group
         self.path = f"/api/0/issues/{self.group.id}/similar-issues-embeddings/"
-        self.similar_group = self.create_group(project=self.project)
+        self.similar_event = self.store_event(
+            data={"message": "Dogs are great!"}, project_id=self.project
+        )
 
     def create_exception(
         self, exception_type_str="Exception", exception_value="it broke", frames=None
@@ -651,16 +655,19 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
         assert stacktrace_str == ""
 
     def test_get_formatted_results(self):
-        new_group = self.create_group(project=self.project)
+        event_from_second_similar_group = save_new_event(
+            {"message": "Adopt don't shop"}, self.project
+        )
+
         response_1: RawSeerSimilarIssueData = {
             "message_distance": 0.05,
-            "parent_group_id": self.similar_group.id,
+            "parent_group_id": NonNone(self.similar_event.group_id),
             "should_group": True,
             "stacktrace_distance": 0.01,
         }
         response_2: RawSeerSimilarIssueData = {
             "message_distance": 0.49,
-            "parent_group_id": new_group.id,
+            "parent_group_id": NonNone(event_from_second_similar_group.group_id),
             "should_group": False,
             "stacktrace_distance": 0.23,
         }
@@ -669,7 +676,13 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
             similar_issues_data=[response_1, response_2], user=self.user
         )
         assert formatted_results == self.get_expected_response(
-            [self.similar_group.id, new_group.id], [0.95, 0.51], [0.99, 0.77], ["Yes", "No"]
+            [
+                NonNone(self.similar_event.group_id),
+                NonNone(event_from_second_similar_group.group_id),
+            ],
+            [0.95, 0.51],
+            [0.99, 0.77],
+            ["Yes", "No"],
         )
 
     def test_no_feature_flag(self):
@@ -685,7 +698,7 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
             "responses": [
                 {
                     "message_distance": 0.05,
-                    "parent_group_id": self.similar_group.id,
+                    "parent_group_id": NonNone(self.similar_event.group_id),
                     "should_group": True,
                     "stacktrace_distance": 0.01,
                 }
@@ -699,7 +712,7 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
         )
 
         assert response.data == self.get_expected_response(
-            [self.similar_group.id], [0.95], [0.99], ["Yes"]
+            [NonNone(self.similar_event.group_id)], [0.95], [0.99], ["Yes"]
         )
 
         expected_seer_request_params = {
@@ -727,25 +740,26 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
     @mock.patch("sentry.analytics.record")
     @mock.patch("sentry.seer.utils.seer_staging_connection_pool.urlopen")
     def test_multiple(self, mock_seer_request, mock_record):
-        similar_group_over_threshold = self.create_group(project=self.project)
-        similar_group_under_threshold = self.create_group(project=self.project)
+        over_threshold_group_event = save_new_event({"message": "Maisey is silly"}, self.project)
+        under_threshold_group_event = save_new_event({"message": "Charlie is goofy"}, self.project)
+
         seer_return_value: SimilarIssuesEmbeddingsResponse = {
             "responses": [
                 {
                     "message_distance": 0.05,
-                    "parent_group_id": self.similar_group.id,
+                    "parent_group_id": NonNone(self.similar_event.group_id),
                     "should_group": True,
                     "stacktrace_distance": 0.002,  # Over threshold
                 },
                 {
                     "message_distance": 0.05,
-                    "parent_group_id": similar_group_over_threshold.id,
+                    "parent_group_id": NonNone(over_threshold_group_event.group_id),
                     "should_group": True,
                     "stacktrace_distance": 0.002,  # Over threshold
                 },
                 {
                     "message_distance": 0.05,
-                    "parent_group_id": similar_group_under_threshold.id,
+                    "parent_group_id": NonNone(under_threshold_group_event.group_id),
                     "should_group": False,
                     "stacktrace_distance": 0.05,  # Under threshold
                 },
@@ -760,9 +774,9 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
 
         assert response.data == self.get_expected_response(
             [
-                self.similar_group.id,
-                similar_group_over_threshold.id,
-                similar_group_under_threshold.id,
+                NonNone(self.similar_event.group_id),
+                NonNone(over_threshold_group_event.group_id),
+                NonNone(under_threshold_group_event.group_id),
             ],
             [0.95, 0.95, 0.95],
             [0.998, 0.998, 0.95],
@@ -789,7 +803,7 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
             "responses": [
                 {
                     "message_distance": 0.05,
-                    "parent_group_id": self.similar_group.id,
+                    "parent_group_id": NonNone(self.similar_event.group_id),
                     "should_group": True,
                     "stacktrace_distance": 0.01,
                 },
@@ -804,7 +818,7 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
         mock_seer_request.return_value = HTTPResponse(json.dumps(seer_return_value).encode("utf-8"))
         response = self.client.get(self.path)
         assert response.data == self.get_expected_response(
-            [self.similar_group.id], [0.95], [0.99], ["Yes"]
+            [NonNone(self.similar_event.group_id)], [0.95], [0.99], ["Yes"]
         )
 
     @with_feature("projects:similarity-embeddings")
@@ -887,7 +901,7 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
             "responses": [
                 {
                     "message_distance": 0.05,
-                    "parent_group_id": self.similar_group.id,
+                    "parent_group_id": NonNone(self.similar_event.group_id),
                     "should_group": True,
                     "stacktrace_distance": 0.01,
                 }
@@ -899,7 +913,7 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
         # Include no optional parameters
         response = self.client.get(self.path)
         assert response.data == self.get_expected_response(
-            [self.similar_group.id], [0.95], [0.99], ["Yes"]
+            [NonNone(self.similar_event.group_id)], [0.95], [0.99], ["Yes"]
         )
 
         mock_seer_request.assert_called_with(
@@ -922,7 +936,7 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
             data={"k": 1},
         )
         assert response.data == self.get_expected_response(
-            [self.similar_group.id], [0.95], [0.99], ["Yes"]
+            [NonNone(self.similar_event.group_id)], [0.95], [0.99], ["Yes"]
         )
 
         mock_seer_request.assert_called_with(
@@ -946,7 +960,7 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
             data={"threshold": "0.98"},
         )
         assert response.data == self.get_expected_response(
-            [self.similar_group.id], [0.95], [0.99], ["Yes"]
+            [NonNone(self.similar_event.group_id)], [0.95], [0.99], ["Yes"]
         )
 
         mock_seer_request.assert_called_with(

--- a/tests/sentry/seer/test_utils.py
+++ b/tests/sentry/seer/test_utils.py
@@ -55,17 +55,15 @@ def test_detect_breakpoints_errors(mock_urlopen, mock_capture_exception, body, s
 def test_simple_similar_issues_embeddings(mock_seer_request):
     """Test that valid responses are decoded and returned."""
 
-    expected_return_value = {
-        "responses": [
-            {
-                "message_distance": 0.05,
-                "parent_group_id": 6,
-                "should_group": True,
-                "stacktrace_distance": 0.01,
-            }
-        ]
+    raw_similar_issue_data = {
+        "message_distance": 0.05,
+        "parent_group_id": 6,
+        "should_group": True,
+        "stacktrace_distance": 0.01,
     }
-    mock_seer_request.return_value = HTTPResponse(json.dumps(expected_return_value).encode("utf-8"))
+
+    seer_return_value = {"responses": [raw_similar_issue_data]}
+    mock_seer_request.return_value = HTTPResponse(json.dumps(seer_return_value).encode("utf-8"))
 
     params: SimilarIssuesEmbeddingsRequest = {
         "group_id": 1,
@@ -74,7 +72,7 @@ def test_simple_similar_issues_embeddings(mock_seer_request):
         "message": "message",
     }
     response = get_similar_issues_embeddings(params)
-    assert response == expected_return_value
+    assert response == [raw_similar_issue_data]
 
 
 @mock.patch("sentry.seer.utils.seer_staging_connection_pool.urlopen")
@@ -90,4 +88,4 @@ def test_empty_similar_issues_embeddings(mock_seer_request):
         "message": "message",
     }
     response = get_similar_issues_embeddings(params)
-    assert response == {"responses": []}
+    assert response == []


### PR DESCRIPTION
This is a few more small fixes and tweaks pulled from upcoming PRs making the switch from using group ids to hashes when communicating with Seer, in order to make them more manageable.

Changes:

- For simplicity, switch `get_similar_issues_embeddings` from returning `{"responses": <list of results>}` to just `<list of results>`.

- In both `test_utils.py` and `test_group_similar_issues_embeddings.py`, switch from creating groups directly to creating them by way of event creation. Bonus (and the reason for doing it): When we switch to using hash rather than group id, we'll be able to get that hash from the event, which we can't do from a bare group. Drawback: When you create a group directly, it's obviously non-null, but when you do it via event creation, it (that is to say, `event.group`) is typed as `Group | None`, so it requires a bunch of non-null assertions everywhere. (Oh, to have TS's `!` in Python! Alas, my hacky and decidedly clunkier `NonNull` helper will have to do.)
