### PR TITLE
test(ui): Set locale in tests

### DIFF
--- a/static/app/utils/silence-react-unsafe-warnings.ts
+++ b/static/app/utils/silence-react-unsafe-warnings.ts
@@ -8,8 +8,6 @@ const ignoredWarnings = [
   /componentWill.* has been renamed, and is not recommended for use.*/,
   // Moment failures. Why is this happening?
   /moment construction falls back/,
-  // Locale not set during tests
-  /Locale not set, defaulting to English/,
 ];
 
 window.console.warn = (message: any, ...args: any[]) => {

--- a/static/app/utils/silence-react-unsafe-warnings.ts
+++ b/static/app/utils/silence-react-unsafe-warnings.ts
@@ -8,6 +8,8 @@ const ignoredWarnings = [
   /componentWill.* has been renamed, and is not recommended for use.*/,
   // Moment failures. Why is this happening?
   /moment construction falls back/,
+  // Locale not set during tests
+  /Locale not set, defaulting to English/,
 ];
 
 window.console.warn = (message: any, ...args: any[]) => {

--- a/tests/js/setup.ts
+++ b/tests/js/setup.ts
@@ -16,7 +16,7 @@ import ConfigStore from 'sentry/stores/configStore';
 import * as performanceForSentry from 'sentry/utils/performanceForSentry';
 
 /**
- * Set locale to english
+ * Set locale to English
  */
 setLocale(DEFAULT_LOCALE_DATA);
 

--- a/tests/js/setup.ts
+++ b/tests/js/setup.ts
@@ -16,7 +16,7 @@ import ConfigStore from 'sentry/stores/configStore';
 import * as performanceForSentry from 'sentry/utils/performanceForSentry';
 
 /**
- * Set locale to english like we do in bootstrap
+ * Set locale to english
  */
 setLocale(DEFAULT_LOCALE_DATA);
 

--- a/tests/js/setup.ts
+++ b/tests/js/setup.ts
@@ -11,8 +11,14 @@ import {resetMockDate} from 'sentry-test/utils';
 
 // eslint-disable-next-line jest/no-mocks-import
 import type {Client} from 'sentry/__mocks__/api';
+import {DEFAULT_LOCALE_DATA, setLocale} from 'sentry/locale';
 import ConfigStore from 'sentry/stores/configStore';
 import * as performanceForSentry from 'sentry/utils/performanceForSentry';
+
+/**
+ * Set locale to english like we do in bootstrap
+ */
+setLocale(DEFAULT_LOCALE_DATA);
 
 /**
  * XXX(epurkhiser): Gross hack to fix a bug in jsdom which makes testing of


### PR DESCRIPTION
i guess it was probably hitting the captureMessage in every test before, now its an annoying warning.
![image](https://github.com/getsentry/sentry/assets/1400464/c23dde7b-f94c-4fb8-80f9-727a1ccf225a)
