### PR TITLE
ref(seer-grouping): Automatically convert `RawSeerSimilarIssueData` into `SeerSimilarIssueData`

### DIFF
--- a/src/sentry/api/endpoints/group_similar_issues_embeddings.py
+++ b/src/sentry/api/endpoints/group_similar_issues_embeddings.py
@@ -16,7 +16,7 @@ from sentry.grouping.grouping_info import get_grouping_info
 from sentry.models.group import Group
 from sentry.models.user import User
 from sentry.seer.utils import (
-    RawSeerSimilarIssueData,
+    SeerSimilarIssueData,
     SimilarIssuesEmbeddingsRequest,
     get_similar_issues_embeddings,
 )
@@ -108,7 +108,7 @@ class GroupSimilarIssuesEmbeddingsEndpoint(GroupEndpoint):
 
     def get_formatted_results(
         self,
-        similar_issues_data: Sequence[RawSeerSimilarIssueData],
+        similar_issues_data: Sequence[SeerSimilarIssueData],
         user: User | AnonymousUser,
     ) -> Sequence[tuple[Mapping[str, Any], Mapping[str, Any]] | None]:
         """
@@ -118,11 +118,11 @@ class GroupSimilarIssuesEmbeddingsEndpoint(GroupEndpoint):
         group_data = {}
         for similar_issue_data in similar_issues_data:
             formatted_response: FormattedSimilarIssuesEmbeddingsData = {
-                "message": 1 - similar_issue_data["message_distance"],
-                "exception": 1 - similar_issue_data["stacktrace_distance"],
-                "shouldBeGrouped": "Yes" if similar_issue_data["should_group"] else "No",
+                "message": 1 - similar_issue_data.message_distance,
+                "exception": 1 - similar_issue_data.stacktrace_distance,
+                "shouldBeGrouped": "Yes" if similar_issue_data.should_group else "No",
             }
-            group_data[similar_issue_data["parent_group_id"]] = formatted_response
+            group_data[similar_issue_data.parent_group_id] = formatted_response
 
         serialized_groups = {
             int(g["id"]): g
@@ -185,9 +185,9 @@ class GroupSimilarIssuesEmbeddingsEndpoint(GroupEndpoint):
             group_id=group.id,
             count_over_threshold=len(
                 [
-                    result["stacktrace_distance"]
+                    result.stacktrace_distance
                     for result in results
-                    if result["stacktrace_distance"] <= 0.01
+                    if result.stacktrace_distance <= 0.01
                 ]
             ),
             user_id=request.user.id,

--- a/tests/sentry/api/endpoints/test_group_similar_issues_embeddings.py
+++ b/tests/sentry/api/endpoints/test_group_similar_issues_embeddings.py
@@ -11,7 +11,7 @@ from sentry.api.endpoints.group_similar_issues_embeddings import (
 )
 from sentry.api.serializers.base import serialize
 from sentry.models.group import Group
-from sentry.seer.utils import RawSeerSimilarIssueData, SimilarIssuesEmbeddingsResponse
+from sentry.seer.utils import SeerSimilarIssueData, SimilarIssuesEmbeddingsResponse
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.helpers.eventprocessing import save_new_event
 from sentry.testutils.helpers.features import with_feature
@@ -659,21 +659,21 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
             {"message": "Adopt don't shop"}, self.project
         )
 
-        response_1: RawSeerSimilarIssueData = {
-            "message_distance": 0.05,
-            "parent_group_id": NonNone(self.similar_event.group_id),
-            "should_group": True,
-            "stacktrace_distance": 0.01,
-        }
-        response_2: RawSeerSimilarIssueData = {
-            "message_distance": 0.49,
-            "parent_group_id": NonNone(event_from_second_similar_group.group_id),
-            "should_group": False,
-            "stacktrace_distance": 0.23,
-        }
+        similar_issue_data_1 = SeerSimilarIssueData(
+            message_distance=0.05,
+            parent_group_id=NonNone(self.similar_event.group_id),
+            should_group=True,
+            stacktrace_distance=0.01,
+        )
+        similar_issue_data_2 = SeerSimilarIssueData(
+            message_distance=0.49,
+            parent_group_id=NonNone(event_from_second_similar_group.group_id),
+            should_group=False,
+            stacktrace_distance=0.23,
+        )
         group_similar_endpoint = GroupSimilarIssuesEmbeddingsEndpoint()
         formatted_results = group_similar_endpoint.get_formatted_results(
-            similar_issues_data=[response_1, response_2], user=self.user
+            similar_issues_data=[similar_issue_data_1, similar_issue_data_2], user=self.user
         )
         assert formatted_results == self.get_expected_response(
             [
@@ -793,12 +793,11 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
         )
 
     @with_feature("projects:similarity-embeddings")
+    @mock.patch("sentry.seer.utils.logger")
     @mock.patch("sentry.seer.utils.seer_staging_connection_pool.urlopen")
-    def test_invalid_return(self, mock_seer_request):
-        """
-        The seer API can return groups that do not exist if they have been deleted/merged.
-        Test that these groups are not returned.
-        """
+    def test_incomplete_return_data(self, mock_seer_request, mock_logger):
+        # Two suggested groups, one with valid data, one missing both parent group id and parent group hash.
+        # We should log the second and return the first.
         seer_return_value: SimilarIssuesEmbeddingsResponse = {
             "responses": [
                 {
@@ -809,7 +808,7 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
                 },
                 {
                     "message_distance": 0.05,
-                    "parent_group_id": 10000000,  # An arbitrarily large group ID that will not exist
+                    # missing both parent group id and parent hash
                     "should_group": True,
                     "stacktrace_distance": 0.01,
                 },
@@ -817,6 +816,73 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
         }
         mock_seer_request.return_value = HTTPResponse(json.dumps(seer_return_value).encode("utf-8"))
         response = self.client.get(self.path)
+
+        mock_logger.exception.assert_called_with(
+            "Seer similar issues response missing both `parent_group_id` and `parent_group_hash`",
+            extra={
+                "request_params": {
+                    "group_id": NonNone(self.event.group_id),
+                    "project_id": self.project.id,
+                    "stacktrace": EXPECTED_STACKTRACE_STRING,
+                    "message": self.group.message,
+                },
+                "raw_similar_issue_data": {
+                    "message_distance": 0.05,
+                    "should_group": True,
+                    "stacktrace_distance": 0.01,
+                },
+            },
+        )
+        assert response.data == self.get_expected_response(
+            [NonNone(self.similar_event.group_id)], [0.95], [0.99], ["Yes"]
+        )
+
+    @with_feature("projects:similarity-embeddings")
+    @mock.patch("sentry.seer.utils.logger")
+    @mock.patch("sentry.seer.utils.seer_staging_connection_pool.urlopen")
+    def test_nonexistent_group(self, mock_seer_request, mock_logger):
+        """
+        The seer API can return groups that do not exist if they have been deleted/merged.
+        Test that these groups are not returned.
+        """
+        seer_return_value: SimilarIssuesEmbeddingsResponse = {
+            # Two suggested groups, one with valid data, one pointing to a group that doesn't exist.
+            # We should log the second and return the first.
+            "responses": [
+                {
+                    "message_distance": 0.05,
+                    "parent_group_id": NonNone(self.similar_event.group_id),
+                    "should_group": True,
+                    "stacktrace_distance": 0.01,
+                },
+                {
+                    "message_distance": 0.05,
+                    "parent_group_id": 1121201212312012,  # too high to be real
+                    "should_group": True,
+                    "stacktrace_distance": 0.01,
+                },
+            ]
+        }
+        mock_seer_request.return_value = HTTPResponse(json.dumps(seer_return_value).encode("utf-8"))
+        response = self.client.get(self.path)
+
+        mock_logger.exception.assert_called_with(
+            "Similar group suggested by Seer does not exist",
+            extra={
+                "request_params": {
+                    "group_id": NonNone(self.event.group_id),
+                    "project_id": self.project.id,
+                    "stacktrace": EXPECTED_STACKTRACE_STRING,
+                    "message": self.group.message,
+                },
+                "raw_similar_issue_data": {
+                    "message_distance": 0.05,
+                    "parent_group_id": 1121201212312012,
+                    "should_group": True,
+                    "stacktrace_distance": 0.01,
+                },
+            },
+        )
         assert response.data == self.get_expected_response(
             [NonNone(self.similar_event.group_id)], [0.95], [0.99], ["Yes"]
         )

--- a/tests/sentry/seer/test_utils.py
+++ b/tests/sentry/seer/test_utils.py
@@ -65,7 +65,7 @@ def test_simple_similar_issues_embeddings(mock_seer_request, default_project):
     event = save_new_event({"message": "Dogs are great!"}, default_project)
     similar_event = save_new_event({"message": "Adopt don't shop"}, default_project)
 
-    raw_similar_issue_data = {
+    raw_similar_issue_data: RawSeerSimilarIssueData = {
         "message_distance": 0.05,
         "parent_group_id": NonNone(similar_event.group_id),
         "should_group": True,
@@ -81,8 +81,7 @@ def test_simple_similar_issues_embeddings(mock_seer_request, default_project):
         "stacktrace": "string",
         "message": "message",
     }
-    response = get_similar_issues_embeddings(params)
-    assert response == [raw_similar_issue_data]
+    assert get_similar_issues_embeddings(params) == [SeerSimilarIssueData(**raw_similar_issue_data)]
 
 
 @django_db_all
@@ -99,8 +98,7 @@ def test_empty_similar_issues_embeddings(mock_seer_request, default_project):
         "stacktrace": "string",
         "message": "message",
     }
-    response = get_similar_issues_embeddings(params)
-    assert response == []
+    assert get_similar_issues_embeddings(params) == []
 
 
 # TODO: Remove once switch is complete

--- a/tests/sentry/seer/test_utils.py
+++ b/tests/sentry/seer/test_utils.py
@@ -58,9 +58,12 @@ def test_detect_breakpoints_errors(mock_urlopen, mock_capture_exception, body, s
     assert mock_capture_exception.called
 
 
+# TODO: Remove once switch is complete
 @django_db_all
 @mock.patch("sentry.seer.utils.seer_staging_connection_pool.urlopen")
-def test_simple_similar_issues_embeddings(mock_seer_request, default_project):
+def test_simple_similar_issues_embeddings_only_group_id_returned(
+    mock_seer_request, default_project
+):
     """Test that valid responses are decoded and returned."""
     event = save_new_event({"message": "Dogs are great!"}, default_project)
     similar_event = save_new_event({"message": "Adopt don't shop"}, default_project)
@@ -81,6 +84,69 @@ def test_simple_similar_issues_embeddings(mock_seer_request, default_project):
         "stacktrace": "string",
         "message": "message",
     }
+    assert get_similar_issues_embeddings(params) == [SeerSimilarIssueData(**raw_similar_issue_data)]
+
+
+@django_db_all
+@mock.patch("sentry.seer.utils.seer_staging_connection_pool.urlopen")
+def test_simple_similar_issues_embeddings_only_hash_returned(mock_seer_request, default_project):
+    """Test that valid responses are decoded and returned."""
+    event = save_new_event({"message": "Dogs are great!"}, default_project)
+    similar_event = save_new_event({"message": "Adopt don't shop"}, default_project)
+
+    raw_similar_issue_data: RawSeerSimilarIssueData = {
+        "message_distance": 0.05,
+        "parent_group_hash": NonNone(similar_event.get_primary_hash()),
+        "should_group": True,
+        "stacktrace_distance": 0.01,
+    }
+
+    seer_return_value = {"responses": [raw_similar_issue_data]}
+    mock_seer_request.return_value = HTTPResponse(json.dumps(seer_return_value).encode("utf-8"))
+
+    params: SimilarIssuesEmbeddingsRequest = {
+        "group_id": NonNone(event.group_id),
+        "project_id": default_project.id,
+        "stacktrace": "string",
+        "message": "message",
+    }
+
+    similar_issue_data = {
+        **raw_similar_issue_data,
+        "parent_group_id": similar_event.group_id,
+    }
+
+    assert get_similar_issues_embeddings(params) == [
+        SeerSimilarIssueData(**similar_issue_data)  # type: ignore[arg-type]
+    ]
+
+
+# TODO: Remove once switch is complete
+@django_db_all
+@mock.patch("sentry.seer.utils.seer_staging_connection_pool.urlopen")
+def test_simple_similar_issues_embeddings_both_returned(mock_seer_request, default_project):
+    """Test that valid responses are decoded and returned."""
+    event = save_new_event({"message": "Dogs are great!"}, default_project)
+    similar_event = save_new_event({"message": "Adopt don't shop"}, default_project)
+
+    raw_similar_issue_data: RawSeerSimilarIssueData = {
+        "message_distance": 0.05,
+        "parent_group_id": NonNone(similar_event.group_id),
+        "parent_group_hash": NonNone(similar_event.get_primary_hash()),
+        "should_group": True,
+        "stacktrace_distance": 0.01,
+    }
+
+    seer_return_value = {"responses": [raw_similar_issue_data]}
+    mock_seer_request.return_value = HTTPResponse(json.dumps(seer_return_value).encode("utf-8"))
+
+    params: SimilarIssuesEmbeddingsRequest = {
+        "group_id": NonNone(event.group_id),
+        "project_id": default_project.id,
+        "stacktrace": "string",
+        "message": "message",
+    }
+
     assert get_similar_issues_embeddings(params) == [SeerSimilarIssueData(**raw_similar_issue_data)]
 
 


### PR DESCRIPTION
This switches `get_similar_issues_embeddings` from returning a list of `RawSeerSimilarIssueData` instances to returning a list of `SeerSimilarIssueData` instances, automatically converting the former to the latter along the way.

The primary difference between the two types is that while the raw version might include the parent group hash rather than the parent group id, the non-raw version is guaranteed to have the parent group id, looked up from the parent group hash if that's all that's sent back from Seer. This means that once this merges, we'll be safe to only send the parent group hash back from Seer, knowing the the parent group id will get filled in in the process of turning the `RawSeerSimilarIssueData` instances into `SeerSimilarIssueData` instances.

Note that this change required switching the code calling `get_similar_issues_embeddings` from using dictionary syntax to using class syntax (because `RawSeerSimilarIssueData` is a typeddict and `SeerSimilarIssueData` is a dataclass). 

To test this change, the "test simple" version of both the similar issues endpoint and `get_similar_issues_embeddings` tests have been replicated so that they now test all three of the possible return options from Seer - only parent group id, only parent group hash, and both - to show that in all cases, the logic which follows gets the data it needs.