### PR TITLE
fix(perf): Span summary transaction throughput chart

### DIFF
--- a/static/app/views/performance/transactionSummary/transactionSpans/spanSummary/spanSummaryCharts.tsx
+++ b/static/app/views/performance/transactionSummary/transactionSpans/spanSummary/spanSummaryCharts.tsx
@@ -126,7 +126,6 @@ function SpanSummaryCharts() {
             type={ChartType.LINE}
             definedAxisTicks={4}
             aggregateOutputFormat="duration"
-            stacked
             error={avgDurationError}
             chartColors={[AVG_COLOR]}
           />
@@ -143,7 +142,6 @@ function SpanSummaryCharts() {
             definedAxisTicks={4}
             aggregateOutputFormat="rate"
             rateUnit={RateUnit.PER_MINUTE}
-            stacked
             error={throughputError}
             chartColors={[THROUGHPUT_COLOR]}
             tooltipFormatterOptions={{
@@ -163,7 +161,6 @@ function SpanSummaryCharts() {
             definedAxisTicks={4}
             aggregateOutputFormat="rate"
             rateUnit={RateUnit.PER_MINUTE}
-            stacked
             error={txnThroughputError}
             chartColors={[TXN_THROUGHPUT_COLOR]}
             tooltipFormatterOptions={{

--- a/static/app/views/performance/transactionSummary/transactionSpans/spanSummary/spanSummaryCharts.tsx
+++ b/static/app/views/performance/transactionSummary/transactionSpans/spanSummary/spanSummaryCharts.tsx
@@ -94,10 +94,6 @@ function SpanSummaryCharts() {
     getRequestPayload: () => ({
       ...eventView.getEventsAPIPayload(location),
       yAxis: eventView.yAxis,
-      topEvents: eventView.topEvents,
-      excludeOther: 0,
-      partial: 1,
-      orderby: undefined,
       interval: eventView.interval,
     }),
     options: {
@@ -111,7 +107,7 @@ function SpanSummaryCharts() {
     data:
       txnThroughputData?.data.map(datum => ({
         value: datum[1][0].count,
-        name: datum[0],
+        name: datum[0] * 1000,
       })) ?? [],
   };
 


### PR DESCRIPTION
Fixes an issue with the timestamps in the transaction throughput chart, on the new span summary page. This was caused by the timestamp values not being converted to milliseconds, which resulted in the x-axis of the chart, and the timestamps shown in the tooltip to be inaccurate. This also allows the cursor in the charts to be synchronized