### PR TITLE
ref(seer-grouping): Send group hash to Seer

### DIFF
--- a/src/sentry/api/endpoints/group_similar_issues_embeddings.py
+++ b/src/sentry/api/endpoints/group_similar_issues_embeddings.py
@@ -162,6 +162,7 @@ class GroupSimilarIssuesEmbeddingsEndpoint(GroupEndpoint):
 
         similar_issues_params: SimilarIssuesEmbeddingsRequest = {
             "group_id": group.id,
+            "group_hash": latest_event.get_primary_hash(),
             "project_id": group.project.id,
             "stacktrace": stacktrace_string,
             "message": group.message,

--- a/src/sentry/api/endpoints/group_similar_issues_embeddings.py
+++ b/src/sentry/api/endpoints/group_similar_issues_embeddings.py
@@ -184,6 +184,7 @@ class GroupSimilarIssuesEmbeddingsEndpoint(GroupEndpoint):
             organization_id=group.organization.id,
             project_id=group.project.id,
             group_id=group.id,
+            group_hash=latest_event.get_primary_hash(),
             count_over_threshold=len(
                 [
                     result.stacktrace_distance

--- a/tests/sentry/api/endpoints/test_group_similar_issues_embeddings.py
+++ b/tests/sentry/api/endpoints/test_group_similar_issues_embeddings.py
@@ -662,12 +662,14 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
         similar_issue_data_1 = SeerSimilarIssueData(
             message_distance=0.05,
             parent_group_id=NonNone(self.similar_event.group_id),
+            parent_group_hash=NonNone(self.similar_event.get_primary_hash()),
             should_group=True,
             stacktrace_distance=0.01,
         )
         similar_issue_data_2 = SeerSimilarIssueData(
             message_distance=0.49,
             parent_group_id=NonNone(event_from_second_similar_group.group_id),
+            parent_group_hash=NonNone(event_from_second_similar_group.get_primary_hash()),
             should_group=False,
             stacktrace_distance=0.23,
         )
@@ -718,6 +720,7 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
 
         expected_seer_request_params = {
             "group_id": self.group.id,
+            "group_hash": NonNone(self.event.get_primary_hash()),
             "project_id": self.project.id,
             "stacktrace": EXPECTED_STACKTRACE_STRING,
             "message": self.group.message,
@@ -764,6 +767,7 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
 
         expected_seer_request_params = {
             "group_id": self.group.id,
+            "group_hash": NonNone(self.event.get_primary_hash()),
             "project_id": self.project.id,
             "stacktrace": EXPECTED_STACKTRACE_STRING,
             "message": self.group.message,
@@ -812,6 +816,7 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
 
         expected_seer_request_params = {
             "group_id": self.group.id,
+            "group_hash": NonNone(self.event.get_primary_hash()),
             "project_id": self.project.id,
             "stacktrace": EXPECTED_STACKTRACE_STRING,
             "message": self.group.message,
@@ -843,18 +848,21 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
                 {
                     "message_distance": 0.05,
                     "parent_group_id": NonNone(self.similar_event.group_id),
+                    "parent_group_hash": NonNone(self.similar_event.get_primary_hash()),
                     "should_group": True,
                     "stacktrace_distance": 0.002,  # Over threshold
                 },
                 {
                     "message_distance": 0.05,
                     "parent_group_id": NonNone(over_threshold_group_event.group_id),
+                    "parent_group_hash": NonNone(over_threshold_group_event.get_primary_hash()),
                     "should_group": True,
                     "stacktrace_distance": 0.002,  # Over threshold
                 },
                 {
                     "message_distance": 0.05,
                     "parent_group_id": NonNone(under_threshold_group_event.group_id),
+                    "parent_group_hash": NonNone(under_threshold_group_event.get_primary_hash()),
                     "should_group": False,
                     "stacktrace_distance": 0.05,  # Under threshold
                 },
@@ -883,6 +891,7 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
             organization_id=self.org.id,
             project_id=self.project.id,
             group_id=self.group.id,
+            group_hash=NonNone(self.event.get_primary_hash()),
             count_over_threshold=2,
             user_id=self.user.id,
         )
@@ -898,6 +907,7 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
                 {
                     "message_distance": 0.05,
                     "parent_group_id": NonNone(self.similar_event.group_id),
+                    "parent_group_hash": NonNone(self.similar_event.get_primary_hash()),
                     "should_group": True,
                     "stacktrace_distance": 0.01,
                 },
@@ -917,6 +927,7 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
             extra={
                 "request_params": {
                     "group_id": NonNone(self.event.group_id),
+                    "group_hash": NonNone(self.event.get_primary_hash()),
                     "project_id": self.project.id,
                     "stacktrace": EXPECTED_STACKTRACE_STRING,
                     "message": self.group.message,
@@ -947,12 +958,14 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
                 {
                     "message_distance": 0.05,
                     "parent_group_id": NonNone(self.similar_event.group_id),
+                    "parent_group_hash": NonNone(self.similar_event.get_primary_hash()),
                     "should_group": True,
                     "stacktrace_distance": 0.01,
                 },
                 {
                     "message_distance": 0.05,
                     "parent_group_id": 1121201212312012,  # too high to be real
+                    "parent_group_hash": "not a real hash",
                     "should_group": True,
                     "stacktrace_distance": 0.01,
                 },
@@ -966,6 +979,7 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
             extra={
                 "request_params": {
                     "group_id": NonNone(self.event.group_id),
+                    "group_hash": NonNone(self.event.get_primary_hash()),
                     "project_id": self.project.id,
                     "stacktrace": EXPECTED_STACKTRACE_STRING,
                     "message": self.group.message,
@@ -973,6 +987,7 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
                 "raw_similar_issue_data": {
                     "message_distance": 0.05,
                     "parent_group_id": 1121201212312012,
+                    "parent_group_hash": "not a real hash",
                     "should_group": True,
                     "stacktrace_distance": 0.01,
                 },
@@ -995,6 +1010,7 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
             organization_id=self.org.id,
             project_id=self.project.id,
             group_id=self.group.id,
+            group_hash=NonNone(self.event.get_primary_hash()),
             count_over_threshold=0,
             user_id=self.user.id,
         )
@@ -1063,6 +1079,7 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
                 {
                     "message_distance": 0.05,
                     "parent_group_id": NonNone(self.similar_event.group_id),
+                    "parent_group_hash": NonNone(self.similar_event.get_primary_hash()),
                     "should_group": True,
                     "stacktrace_distance": 0.01,
                 }
@@ -1083,6 +1100,7 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
             body=json.dumps(
                 {
                     "group_id": self.group.id,
+                    "group_hash": NonNone(self.event.get_primary_hash()),
                     "project_id": self.project.id,
                     "stacktrace": EXPECTED_STACKTRACE_STRING,
                     "message": self.group.message,
@@ -1106,6 +1124,7 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
             body=json.dumps(
                 {
                     "group_id": self.group.id,
+                    "group_hash": NonNone(self.event.get_primary_hash()),
                     "project_id": self.project.id,
                     "stacktrace": EXPECTED_STACKTRACE_STRING,
                     "message": self.group.message,
@@ -1130,6 +1149,7 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
             body=json.dumps(
                 {
                     "group_id": self.group.id,
+                    "group_hash": NonNone(self.event.get_primary_hash()),
                     "project_id": self.project.id,
                     "stacktrace": EXPECTED_STACKTRACE_STRING,
                     "message": self.group.message,

--- a/tests/sentry/seer/test_utils.py
+++ b/tests/sentry/seer/test_utils.py
@@ -80,6 +80,7 @@ def test_simple_similar_issues_embeddings_only_group_id_returned(
 
     params: SimilarIssuesEmbeddingsRequest = {
         "group_id": NonNone(event.group_id),
+        "group_hash": NonNone(event.get_primary_hash()),
         "project_id": default_project.id,
         "stacktrace": "string",
         "message": "message",
@@ -106,6 +107,7 @@ def test_simple_similar_issues_embeddings_only_hash_returned(mock_seer_request, 
 
     params: SimilarIssuesEmbeddingsRequest = {
         "group_id": NonNone(event.group_id),
+        "group_hash": NonNone(event.get_primary_hash()),
         "project_id": default_project.id,
         "stacktrace": "string",
         "message": "message",
@@ -142,6 +144,7 @@ def test_simple_similar_issues_embeddings_both_returned(mock_seer_request, defau
 
     params: SimilarIssuesEmbeddingsRequest = {
         "group_id": NonNone(event.group_id),
+        "group_hash": NonNone(event.get_primary_hash()),
         "project_id": default_project.id,
         "stacktrace": "string",
         "message": "message",
@@ -160,6 +163,7 @@ def test_empty_similar_issues_embeddings(mock_seer_request, default_project):
 
     params: SimilarIssuesEmbeddingsRequest = {
         "group_id": NonNone(event.group_id),
+        "group_hash": NonNone(event.get_primary_hash()),
         "project_id": default_project.id,
         "stacktrace": "string",
         "message": "message",


### PR DESCRIPTION
This adds the group hash to the outgoing payload sent to Seer. Once this is merged, it will be safe to remove the Seer logic handling an incoming group id, since we'll now be able to rely on the group hash being present. 

Taken together, this PR and the ones leading up to it (links below) mean will mean that on the Sentry side we'll be sending in the request and handling in the response both hash and group id (and transforming hashes in the response into group ids if hashes are all that's sent). Once Seer is adjusted to only deal in hashes, we can then remove the sending and handling of group ids from Sentry and the transition will be complete.

Other PRs which are part of the group-id-to-group-hash switch:
- https://github.com/getsentry/sentry/pull/70005, https://github.com/getsentry/sentry/pull/70236, and https://github.com/getsentry/sentry/pull/70237 - various small fixes and tweaks
- https://github.com/getsentry/sentry/pull/70070 and https://github.com/getsentry/sentry/pull/70238 - updates to associated types
- https://github.com/getsentry/sentry/pull/70240 - automatic conversion from hash to group id when handling Seer similar group data