### PR TITLE
fix(search): fixes short id lookup logic

### DIFF
--- a/src/sentry/models/group.py
+++ b/src/sentry/models/group.py
@@ -67,7 +67,7 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-_short_id_re = re.compile(r"^(?:[^:]+:)?(.*?)(?:[\s_-])([A-Za-z0-9]+)$")
+_short_id_re = re.compile(r"^(?:issue+:)?(.*?)(?:[\s_-])([A-Za-z0-9]+)$")
 ShortId = namedtuple("ShortId", ["project_slug", "short_id"])
 
 

--- a/src/sentry/models/group.py
+++ b/src/sentry/models/group.py
@@ -67,8 +67,7 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-_short_id_re = re.compile(r"^(.*?)(?:[\s_-])([A-Za-z0-9]+)$")
-
+_short_id_re = re.compile(r"^(?:[^:]+:)?(.*?)(?:[\s_-])([A-Za-z0-9]+)$")
 ShortId = namedtuple("ShortId", ["project_slug", "short_id"])
 
 

--- a/tests/sentry/issues/endpoints/test_organization_group_index.py
+++ b/tests/sentry/issues/endpoints/test_organization_group_index.py
@@ -664,7 +664,6 @@ class GroupListTest(APITestCase, SnubaTestCase, SearchIssueTestMixin):
         group_2 = self.create_group()
         response = self.get_success_response(group=[self.group.id, group_2.id])
         assert {g["id"] for g in response.data} == {str(self.group.id), str(group_2.id)}
-        assert response["X-Sentry-Direct-Hit"] == "1"
 
     def test_lookup_by_group_id_no_perms(self):
         organization = self.create_organization()


### PR DESCRIPTION
This PR fixes a bug where putting a short id as part of a query like `issue:SENTRY-38VM` actually fails the postgres direct hit search and doesn't redirect the user even though it limits the results to the single result. However, just searching `SENTRY-38VM` works as expected. The problem is the regex for the project slug matches `issue:SENTRY` instead of `SENTRY`.