### PR TITLE
fix(issues): Prevent loading group from groupstore

### DIFF
--- a/static/app/views/issueDetails/groupDetails.tsx
+++ b/static/app/views/issueDetails/groupDetails.tsx
@@ -4,7 +4,6 @@ import {
   isValidElement,
   useCallback,
   useEffect,
-  useRef,
   useState,
 } from 'react';
 import type {RouteComponentProps} from 'react-router';
@@ -45,6 +44,7 @@ import useDisableRouteAnalytics from 'sentry/utils/routeAnalytics/useDisableRout
 import useRouteAnalyticsEventNames from 'sentry/utils/routeAnalytics/useRouteAnalyticsEventNames';
 import useRouteAnalyticsParams from 'sentry/utils/routeAnalytics/useRouteAnalyticsParams';
 import useApi from 'sentry/utils/useApi';
+import {useEffectAfterFirstRender} from 'sentry/utils/useEffectAfterFirstRender';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useMemoWithPrevious} from 'sentry/utils/useMemoWithPrevious';
 import useOrganization from 'sentry/utils/useOrganization';
@@ -316,35 +316,28 @@ function makeFetchGroupQueryKey({
  * Once we remove all references to GroupStore in the issue details page we
  * should remove this.
  */
-function useSyncGroupStore(incomingEnvs: string[]) {
+function useSyncGroupStore(groupId: string, incomingEnvs: string[]) {
   const queryClient = useQueryClient();
   const organization = useOrganization();
 
-  const environmentsRef = useRef<string[]>(incomingEnvs);
-  environmentsRef.current = incomingEnvs;
-
-  const unlisten = useRef<Function>();
-  if (unlisten.current === undefined) {
-    unlisten.current = GroupStore.listen(() => {
+  // Start listening to GroupStore after the first render
+  // It's possible the overview page is still unloading the store
+  useEffectAfterFirstRender(() => {
+    return GroupStore.listen(() => {
       const [storeGroup] = GroupStore.getState();
-      const environments = environmentsRef.current;
-      if (defined(storeGroup)) {
+      if (defined(storeGroup) && storeGroup.id === groupId) {
         setApiQueryData(
           queryClient,
           makeFetchGroupQueryKey({
             groupId: storeGroup.id,
             organizationSlug: organization.slug,
-            environments,
+            environments: incomingEnvs,
           }),
           storeGroup
         );
       }
-    }, undefined);
-  }
-
-  useEffect(() => {
-    return () => unlisten.current?.();
-  }, []);
+    }, undefined) as () => void;
+  }, [groupId, incomingEnvs, organization.slug, queryClient]);
 }
 
 function useFetchGroupDetails(): FetchGroupDetailsState {
@@ -408,7 +401,7 @@ function useFetchGroupDetails(): FetchGroupDetailsState {
     }
   }, [groupId, group]);
 
-  useSyncGroupStore(environments);
+  useSyncGroupStore(groupId, environments);
 
   useEffect(() => {
     if (group && event) {

--- a/static/app/views/issueDetails/groupDetails.tsx
+++ b/static/app/views/issueDetails/groupDetails.tsx
@@ -323,7 +323,13 @@ function useSyncGroupStore(groupId: string, incomingEnvs: string[]) {
   useEffect(() => {
     return GroupStore.listen(() => {
       const [storeGroup] = GroupStore.getState();
-      if (defined(storeGroup) && storeGroup.id === groupId) {
+      if (
+        defined(storeGroup) &&
+        storeGroup.id === groupId &&
+        // Check for properties that are only set after the group has been loaded
+        defined(storeGroup.participants) &&
+        defined(storeGroup.activity)
+      ) {
         setApiQueryData(
           queryClient,
           makeFetchGroupQueryKey({

--- a/static/app/views/issueDetails/groupDetails.tsx
+++ b/static/app/views/issueDetails/groupDetails.tsx
@@ -44,7 +44,6 @@ import useDisableRouteAnalytics from 'sentry/utils/routeAnalytics/useDisableRout
 import useRouteAnalyticsEventNames from 'sentry/utils/routeAnalytics/useRouteAnalyticsEventNames';
 import useRouteAnalyticsParams from 'sentry/utils/routeAnalytics/useRouteAnalyticsParams';
 import useApi from 'sentry/utils/useApi';
-import {useEffectAfterFirstRender} from 'sentry/utils/useEffectAfterFirstRender';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useMemoWithPrevious} from 'sentry/utils/useMemoWithPrevious';
 import useOrganization from 'sentry/utils/useOrganization';
@@ -320,9 +319,8 @@ function useSyncGroupStore(groupId: string, incomingEnvs: string[]) {
   const queryClient = useQueryClient();
   const organization = useOrganization();
 
-  // Start listening to GroupStore after the first render
   // It's possible the overview page is still unloading the store
-  useEffectAfterFirstRender(() => {
+  useEffect(() => {
     return GroupStore.listen(() => {
       const [storeGroup] = GroupStore.getState();
       if (defined(storeGroup) && storeGroup.id === groupId) {

--- a/static/app/views/issueDetails/groupEventDetails/groupEventDetails.tsx
+++ b/static/app/views/issueDetails/groupEventDetails/groupEventDetails.tsx
@@ -159,11 +159,6 @@ function GroupEventDetails(props: GroupEventDetailsProps) {
     );
   };
 
-  // TODO(scttcper): In some cases it seems like the event is not loaded yet
-  if (!group) {
-    return <LoadingIndicator />;
-  }
-
   const eventWithMeta = withMeta(event);
   const issueTypeConfig = getConfigForIssueType(group, project);
 


### PR DESCRIPTION
I think we're getting groups from the issues stream in the query cache, attempt to start listening later once the group store is cleared. It's possible we'll need to check more properties exist.

this does two things:
- starts listening to store changes slightly later via useEffect
- checks that certain properties exist that are not defined in the issues stream

fixes JAVASCRIPT-2SY0