### PR TITLE
chore(api): Register api.organization-activity.brownout-* flags

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -2503,3 +2503,17 @@ register(
     default=False,
     flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
 )
+
+
+# default brownout crontab for Organiation Events API deprecations
+# TODO: remove once endpoint is removed
+register(
+    "api.organization-activity.brownout-cron",
+    default="*/3 * * * *",
+    type=String,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+# Brownout duration to be stored in ISO8601 format for durations (See https://en.wikipedia.org/wiki/ISO_8601#Durations)
+register(
+    "api.organization-activity.brownout-duration", default="PT1M", flags=FLAG_AUTOMATOR_MODIFIABLE
+)

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -2505,7 +2505,7 @@ register(
 )
 
 
-# default brownout crontab for Organiation Events API deprecations
+# default brownout crontab for Organization Events API deprecations
 # TODO: remove once endpoint is removed
 register(
     "api.organization-activity.brownout-cron",


### PR DESCRIPTION
I've added usage in https://github.com/getsentry/sentry/pull/70202 and values in https://github.com/getsentry/sentry-options-automator/pull/1318, but they also need to be registered. 🤦 