### PR TITLE
fix(mobile-ui): Frames delay rendering in table

### DIFF
--- a/static/app/views/performance/mobile/ui/screens/table.tsx
+++ b/static/app/views/performance/mobile/ui/screens/table.tsx
@@ -1,10 +1,12 @@
 import {Fragment} from 'react';
 import * as qs from 'query-string';
 
+import Duration from 'sentry/components/duration';
 import Link from 'sentry/components/links/link';
 import {t} from 'sentry/locale';
 import type {TableData} from 'sentry/utils/discover/discoverQuery';
 import type EventView from 'sentry/utils/discover/eventView';
+import {NumberContainer} from 'sentry/utils/discover/styles';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import {normalizeUrl} from 'sentry/utils/withDomainRequired';
@@ -94,6 +96,18 @@ export function UIScreensTable({data, eventView, isLoading, pageLinks}: Props) {
             {row.transaction}
           </Link>
         </Fragment>
+      );
+    }
+
+    if (field.startsWith('avg_if(mobile.frames_delay')) {
+      return (
+        <NumberContainer>
+          {row[field] ? (
+            <Duration seconds={row[field]} fixedDigits={2} abbreviation />
+          ) : (
+            '-'
+          )}
+        </NumberContainer>
       );
     }
 


### PR DESCRIPTION
Frame delay isn't self-reporting its units as seconds, so handle it in the frontend until we fix this.

Before:
<img width="1488" alt="Screenshot 2024-05-03 at 1 00 20 PM" src="https://github.com/getsentry/sentry/assets/22846452/1c0598c4-1e6f-4578-aeb0-c7cb34b59831">

After:
<img width="1495" alt="Screenshot 2024-05-03 at 12 59 49 PM" src="https://github.com/getsentry/sentry/assets/22846452/91087e35-beef-4f7f-9b0d-3a29e978556b">
