### PR TITLE
fix(trace-explorer): Nullable fields can return None

### DIFF
--- a/src/sentry/api/endpoints/organization_spans_fields.py
+++ b/src/sentry/api/endpoints/organization_spans_fields.py
@@ -136,6 +136,7 @@ class OrganizationSpansFieldValuesEndpoint(OrganizationEventsV2EndpointBase):
                     ),
                 )
                 for row in results["data"]
+                if row[key] is not None
             ]
         )
 


### PR DESCRIPTION
Nullable fields can return None so make sure to handle them or the paginator will not work correctly.

Fixes SENTRY-38VB