### PR TITLE
ref: remove impossible checks for Event from post_process

### DIFF
--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -593,6 +593,7 @@ def post_process_group(
             # instead.
 
             def get_event_raise_exception() -> Event:
+                assert occurrence is not None
                 retrieved = eventstore.backend.get_event_by_id(
                     project_id,
                     occurrence.event_id,
@@ -658,15 +659,16 @@ def post_process_group(
 
             group_event.occurrence = occurrence
 
-            group_job: PostProcessJob = {
-                "event": group_event,
-                "group_state": group_state,
-                "is_reprocessed": is_reprocessed,
-                "has_reappeared": bool(not group_state["is_new"]),
-                "has_alert": False,
-                "has_escalated": False,
-            }
-            run_post_process_job(group_job)
+            run_post_process_job(
+                {
+                    "event": group_event,
+                    "group_state": group_state,
+                    "is_reprocessed": is_reprocessed,
+                    "has_reappeared": bool(not group_state["is_new"]),
+                    "has_alert": False,
+                    "has_escalated": False,
+                }
+            )
             metric_tags["occurrence_type"] = group_event.group.issue_type.slug
 
         if not is_reprocessed and event.data.get("received"):
@@ -700,7 +702,7 @@ def post_process_group(
                 )
 
 
-def run_post_process_job(job: PostProcessJob):
+def run_post_process_job(job: PostProcessJob) -> None:
     group_event = job["event"]
     issue_category = group_event.group.issue_category if group_event.group else None
     issue_category_metric = issue_category.name.lower() if issue_category else None
@@ -851,7 +853,6 @@ def process_snoozes(job: PostProcessJob) -> None:
     if job["is_reprocessed"] or not job["has_reappeared"]:
         return
 
-    from sentry.eventstore.models import Event, GroupEvent
     from sentry.issues.escalating import is_escalating, manage_issue_states
     from sentry.models.group import GroupStatus
     from sentry.models.groupinbox import GroupInboxReason
@@ -865,8 +866,6 @@ def process_snoozes(job: PostProcessJob) -> None:
             "Group not found on event while processing snoozes", extra={"event_id": event.event_id}
         )
         return
-    if isinstance(event, Event):
-        event = GroupEvent.from_event(event, group)
 
     if not group.issue_type.should_detect_escalation(group.organization):
         return
@@ -999,23 +998,12 @@ def process_replay_link(job: PostProcessJob) -> None:
 
 
 def process_rules(job: PostProcessJob) -> None:
-    from sentry.eventstore.models import Event, GroupEvent
-
     if job["is_reprocessed"]:
         return
 
     from sentry.rules.processing.processor import RuleProcessor
 
     group_event = job["event"]
-    if isinstance(group_event, Event):
-        if group_event.group:
-            group_event = GroupEvent.from_event(group_event, group_event.group)
-        else:
-            logger.error(
-                "Group not found on event while processing rules",
-                extra={"event_id": group_event.event_id},
-            )
-            return
     is_new = job["group_state"]["is_new"]
     is_regression = job["group_state"]["is_regression"]
     is_new_group_environment = job["group_state"]["is_new_group_environment"]


### PR DESCRIPTION
after upgrading django-stubs, the type checker helpfully points out that `job['event']` is always `GroupEvent` and so an `isinstance(job['event'], Event)` check will always fail

<!-- Describe your PR here. -->