### PR TITLE
feat(replay): add device breadcrumbs

### DIFF
--- a/static/app/utils/replays/getFrameDetails.tsx
+++ b/static/app/utils/replays/getFrameDetails.tsx
@@ -15,6 +15,7 @@ import {
   IconKeyDown,
   IconLocation,
   IconMegaphone,
+  IconMobile,
   IconSort,
   IconTerminal,
   IconUser,
@@ -24,6 +25,9 @@ import {t, tct} from 'sentry/locale';
 import {TabKey} from 'sentry/utils/replays/hooks/useActiveReplayTab';
 import type {
   BreadcrumbFrame,
+  DeviceBatteryFrame,
+  DeviceConnectivityFrame,
+  DeviceOrientationFrame,
   ErrorFrame,
   FeedbackFrame,
   LargestContentfulPaintFrame,
@@ -349,6 +353,30 @@ const MAPPER_FOR_FRAME: Record<string, (frame) => Details> = {
     tabKey: TabKey.NETWORK,
     title: frame.description,
     icon: <IconSort size="xs" rotated />,
+  }),
+  'device.connectivity': (frame: DeviceConnectivityFrame) => ({
+    color: 'pink300',
+    description: frame.data.state,
+    tabKey: TabKey.BREADCRUMBS,
+    title: 'Device Connectivity',
+    icon: <IconMobile size="xs" />,
+  }),
+  'device.battery': (frame: DeviceBatteryFrame) => ({
+    color: 'pink300',
+    description: tct('Device was at [percent]% battery and [charging]', {
+      percent: frame.data.level,
+      charging: frame.data.charging ? 'charging' : 'not charging',
+    }),
+    tabKey: TabKey.BREADCRUMBS,
+    title: 'Device Battery',
+    icon: <IconMobile size="xs" />,
+  }),
+  'device.orientation': (frame: DeviceOrientationFrame) => ({
+    color: 'pink300',
+    description: frame.data.position,
+    tabKey: TabKey.BREADCRUMBS,
+    title: 'Device Orientation',
+    icon: <IconMobile size="xs" />,
   }),
 };
 

--- a/static/app/utils/replays/replayReader.tsx
+++ b/static/app/utils/replays/replayReader.tsx
@@ -467,6 +467,9 @@ export default class ReplayReader {
             'replay.init',
             'replay.mutations',
             'feedback',
+            'device.battery',
+            'device.connectivity',
+            'device.orientation',
           ].includes(frame.category)
         ),
         ...this._errors,

--- a/static/app/utils/replays/types.tsx
+++ b/static/app/utils/replays/types.tsx
@@ -18,13 +18,35 @@ import invariant from 'invariant';
 import type {HydratedA11yFrame} from 'sentry/utils/replays/hydrateA11yFrame';
 
 // TODO: more types get added here
-type MobileBreadcrumbTypes = {
-  category: 'ui.tap';
-  data: any;
-  message: string;
-  timestamp: number;
-  type: string;
-};
+type MobileBreadcrumbTypes =
+  | {
+      category: 'ui.tap';
+      data: any;
+      message: string;
+      timestamp: number;
+      type: string;
+    }
+  | {
+      category: 'device.battery';
+      data: {charging: boolean; level: number};
+      timestamp: number;
+      type: string;
+      message?: string;
+    }
+  | {
+      category: 'device.connectivity';
+      data: {state: 'offline' | 'wifi' | 'cellular' | 'ethernet'};
+      timestamp: number;
+      type: string;
+      message?: string;
+    }
+  | {
+      category: 'device.orientation';
+      data: {position: 'landscape' | 'portrait'};
+      timestamp: number;
+      type: string;
+      message?: string;
+    };
 
 /**
  * Extra breadcrumb types not included in `@sentry/replay`
@@ -231,11 +253,17 @@ export type MultiClickFrame = HydratedBreadcrumb<'ui.multiClick'>;
 export type MutationFrame = HydratedBreadcrumb<'replay.mutations'>;
 export type NavFrame = HydratedBreadcrumb<'navigation'>;
 export type SlowClickFrame = HydratedBreadcrumb<'ui.slowClickDetected'>;
+export type DeviceBatteryFrame = HydratedBreadcrumb<'device.battery'>;
+export type DeviceConnectivityFrame = HydratedBreadcrumb<'device.connectivity'>;
+export type DeviceOrientationFrame = HydratedBreadcrumb<'device.orientation'>;
 
 // This list must match each of the categories used in `HydratedBreadcrumb` above
 // and any app-specific types that we hydrate (ie: replay.init).
 export const BreadcrumbCategories = [
   'console',
+  'device.battery',
+  'device.connectivity',
+  'device.orientation',
   'navigation',
   'replay.init',
   'replay.mutations',

--- a/static/app/views/replays/detail/breadcrumbs/useBreadcrumbFilters.tsx
+++ b/static/app/views/replays/detail/breadcrumbs/useBreadcrumbFilters.tsx
@@ -50,6 +50,7 @@ const TYPE_TO_LABEL: Record<string, string> = {
   keydown: 'KeyDown',
   input: 'Input',
   tap: 'User Tap',
+  device: 'Device',
 };
 
 const OPORCATEGORY_TO_TYPE: Record<string, keyof typeof TYPE_TO_LABEL> = {
@@ -75,6 +76,9 @@ const OPORCATEGORY_TO_TYPE: Record<string, keyof typeof TYPE_TO_LABEL> = {
   'ui.keyDown': 'keydown',
   'ui.input': 'input',
   feedback: 'feedback',
+  'device.battery': 'device',
+  'device.connectivity': 'device',
+  'device.orientation': 'device',
 };
 
 function typeToLabel(val: string): string {

--- a/static/app/views/replays/detail/breadcrumbs/useBreadcrumbFilters.tsx
+++ b/static/app/views/replays/detail/breadcrumbs/useBreadcrumbFilters.tsx
@@ -115,7 +115,9 @@ function useBreadcrumbFilters({frames}: Options): Return {
     // flips OPORCATERGORY_TO_TYPE and prevents overwriting nav entry, nav entry becomes nav: ['navigation','navigation.push']
     const TYPE_TO_OPORCATEGORY = Object.entries(OPORCATEGORY_TO_TYPE).reduce(
       (dict, [key, value]) =>
-        dict[value] ? {...dict, [value]: [dict[value], key]} : {...dict, [value]: key},
+        dict[value]
+          ? {...dict, [value]: [dict[value], key].flat()}
+          : {...dict, [value]: key},
       {}
     );
     const OpOrCategory = type.flatMap(theType => TYPE_TO_OPORCATEGORY[theType]);


### PR DESCRIPTION
- closes https://github.com/getsentry/sentry/issues/69226
- adds 3 new device related breadcrumbs: `connectivity`, `battery`, and `orientation`
- open to ideas on different logos / messages we could show in the breadcrumb -- I just kept it simple for now

<img width="429" alt="SCR-20240503-kmns" src="https://github.com/getsentry/sentry/assets/56095982/6f547d7f-22fd-41d2-8021-34c45025a013">
