### PR TITLE
feat(tags): Adds border customizability to <Tag/>

### DIFF
--- a/static/app/components/badge/tag.stories.tsx
+++ b/static/app/components/badge/tag.stories.tsx
@@ -70,6 +70,27 @@ export default storyBook(Tag, story => {
     );
   });
 
+  story('borderStyle', () => {
+    return (
+      <Fragment>
+        <p>
+          The <JSXProperty name="borderStyle" value /> prop can be used to change the
+          border style of the tag to the following 3 options. By default, it is set to{' '}
+          <JSXProperty name="borderStyle" value="solid" />.
+        </p>
+        <Tag type="default" borderStyle="solid">
+          default
+        </Tag>
+        <Tag type="default" borderStyle="dashed">
+          dashed
+        </Tag>
+        <Tag type="default" borderStyle="dotted">
+          dotted
+        </Tag>
+      </Fragment>
+    );
+  });
+
   story('to vs href', () => {
     return (
       <Fragment>

--- a/static/app/components/badge/tag.tsx
+++ b/static/app/components/badge/tag.tsx
@@ -18,7 +18,7 @@ import type {Color} from 'sentry/utils/theme';
 import theme from 'sentry/utils/theme';
 
 export interface TagProps extends React.HTMLAttributes<HTMLSpanElement> {
-  borderStyle?: 'solid' | 'dashed' | 'dotted';
+  borderStyle?: 'solid' | 'dashed' | 'dotted' | 'double' | 'none';
   /**
    * Makes the tag clickable. Use for external links.
    * If no icon is passed, it defaults to IconOpen (can be removed by passing icon={null})

--- a/static/app/components/badge/tag.tsx
+++ b/static/app/components/badge/tag.tsx
@@ -18,7 +18,7 @@ import type {Color} from 'sentry/utils/theme';
 import theme from 'sentry/utils/theme';
 
 export interface TagProps extends React.HTMLAttributes<HTMLSpanElement> {
-  borderStyle?: 'solid' | 'dashed' | 'dotted' | 'double' | 'none';
+  borderStyle?: 'solid' | 'dashed' | 'dotted';
   /**
    * Makes the tag clickable. Use for external links.
    * If no icon is passed, it defaults to IconOpen (can be removed by passing icon={null})

--- a/static/app/components/badge/tag.tsx
+++ b/static/app/components/badge/tag.tsx
@@ -1,5 +1,5 @@
 import {useCallback} from 'react';
-import type {Theme} from '@emotion/react';
+import {css, type Theme} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import {Button} from 'sentry/components/button';
@@ -18,6 +18,7 @@ import type {Color} from 'sentry/utils/theme';
 import theme from 'sentry/utils/theme';
 
 export interface TagProps extends React.HTMLAttributes<HTMLSpanElement> {
+  borderStyle?: 'solid' | 'dashed' | 'dotted';
   /**
    * Makes the tag clickable. Use for external links.
    * If no icon is passed, it defaults to IconOpen (can be removed by passing icon={null})
@@ -59,6 +60,7 @@ export interface TagProps extends React.HTMLAttributes<HTMLSpanElement> {
 }
 
 function BaseTag({
+  borderStyle = 'solid',
   type = 'default',
   icon,
   tooltipText,
@@ -99,7 +101,13 @@ function BaseTag({
 
   const tag = (
     <Tooltip title={tooltipText} containerDisplayMode="inline-flex" {...tooltipProps}>
-      <Background type={type}>
+      <Background
+        type={type}
+        css={css`
+          --border-style: ${borderStyle};
+        `}
+        data-test-id="tag-background"
+      >
         {tagIcon && (
           <IconWrapper>
             <IconDefaultsProvider {...iconsProps}>{tagIcon}</IconDefaultsProvider>
@@ -154,7 +162,7 @@ export const Background = styled('div')<{type: keyof Theme['tag']}>`
   height: ${TAG_HEIGHT};
   border-radius: ${TAG_HEIGHT};
   background-color: ${p => p.theme.tag[p.type].background};
-  border: solid 1px ${p => p.theme.tag[p.type].border};
+  border: var(--border-style, solid) 1px ${p => p.theme.tag[p.type].border};
   padding: 0 ${space(1)};
 `;
 


### PR DESCRIPTION
This PR adds a `borderStyle` prop to the `<Tag/>` component. It is set to `solid` by default, since that is what was the only option before. 

This will be needed in upcoming changes to the Assignee dropdown trigger on the Issue details page, detailed [here](https://github.com/getsentry/sentry/issues/69827) 