### PR TITLE
feat(new-trace): Removing location query from being passed to traceview.

### DIFF
--- a/static/app/components/events/interfaces/spans/utils.tsx
+++ b/static/app/components/events/interfaces/spans/utils.tsx
@@ -482,7 +482,6 @@ export function handleTraceDetailsRouting(
       organization,
       traceId,
       event.title,
-      location.query,
       getEventTimestamp(event),
       event.eventID
     );

--- a/static/app/components/metrics/metricSamplesTable.tsx
+++ b/static/app/components/metrics/metricSamplesTable.tsx
@@ -669,7 +669,6 @@ function TraceId({
       end: selection.datetime.end,
       statsPeriod: selection.datetime.period,
     },
-    {},
     stringOrNumberTimestamp,
     eventId
   );

--- a/static/app/components/profiling/profileEventsTable.tsx
+++ b/static/app/components/profiling/profileEventsTable.tsx
@@ -175,7 +175,6 @@ function ProfileEventsCell<F extends FieldType>(props: ProfileEventsCellProps<F>
             props.baggage.organization,
             props.dataRow[key] ?? '',
             dataSelection,
-            {},
             timestamp
           )}
         >

--- a/static/app/components/quickTrace/utils.tsx
+++ b/static/app/components/quickTrace/utils.tsx
@@ -146,7 +146,6 @@ export function generateTraceTarget(
       organization,
       traceId,
       dateSelection,
-      {},
       getEventTimestamp(event),
       event.eventID
     );

--- a/static/app/utils/discover/urls.tsx
+++ b/static/app/utils/discover/urls.tsx
@@ -75,7 +75,6 @@ export function generateLinkToEventInTraceView({
       organization,
       String(traceSlug),
       dateSelection,
-      location.query,
       normalizedTimestamp,
       eventId,
       spanId

--- a/static/app/views/dashboards/datasetConfig/errorsAndTransactions.tsx
+++ b/static/app/views/dashboards/datasetConfig/errorsAndTransactions.tsx
@@ -428,7 +428,6 @@ function renderTraceAsLinkable(
     organization,
     String(data.trace),
     dateSelection,
-    {},
     getTimeStampFromTableDateField(data.timestamp),
     data.id || data.eventID
   );

--- a/static/app/views/discover/table/tableView.tsx
+++ b/static/app/views/discover/table/tableView.tsx
@@ -385,7 +385,6 @@ function TableView(props: TableViewProps) {
           organization,
           String(dataRow.trace),
           dateSelection,
-          {},
           timestamp
         );
 

--- a/static/app/views/performance/traceDetails/TraceDetailsRouting.tsx
+++ b/static/app/views/performance/traceDetails/TraceDetailsRouting.tsx
@@ -36,7 +36,6 @@ function TraceDetailsRouting(props: Props) {
         organization,
         traceId,
         datetimeSelection,
-        location.query,
         getEventTimestamp(event),
         event.eventID
       );

--- a/static/app/views/performance/traceDetails/utils.tsx
+++ b/static/app/views/performance/traceDetails/utils.tsx
@@ -1,4 +1,4 @@
-import type {LocationDescriptorObject, Query} from 'history';
+import type {LocationDescriptorObject} from 'history';
 
 import {PAGE_URL_PARAM} from 'sentry/constants/pageFilters';
 import type {Organization, OrganizationSummary} from 'sentry/types';
@@ -19,7 +19,6 @@ export function getTraceDetailsUrl(
   organization: Pick<OrganizationSummary, 'slug' | 'features'>,
   traceSlug: string,
   dateSelection,
-  query: Query,
   timestamp?: string | number,
   eventId?: string,
   spanId?: string
@@ -27,7 +26,6 @@ export function getTraceDetailsUrl(
   const {start, end, statsPeriod} = dateSelection;
 
   const queryParams = {
-    ...query,
     statsPeriod,
     [PAGE_URL_PARAM.PAGE_START]: start,
     [PAGE_URL_PARAM.PAGE_END]: end,

--- a/static/app/views/performance/traces/fieldRenderers.tsx
+++ b/static/app/views/performance/traces/fieldRenderers.tsx
@@ -245,7 +245,6 @@ export function TraceIdRenderer({
       end: selection.datetime.end,
       statsPeriod: selection.datetime.period,
     },
-    {},
     stringOrNumberTimestamp,
     transactionId
   );

--- a/static/app/views/performance/transactionSummary/utils.tsx
+++ b/static/app/views/performance/transactionSummary/utils.tsx
@@ -131,13 +131,7 @@ export function generateTraceLink(dateSelection) {
       return {};
     }
 
-    return getTraceDetailsUrl(
-      organization,
-      traceId,
-      dateSelection,
-      {},
-      tableRow.timestamp
-    );
+    return getTraceDetailsUrl(organization, traceId, dateSelection, tableRow.timestamp);
   };
 }
 


### PR DESCRIPTION
We already pass all the query params we need as destructured props to `getTraceDetailsUrl`, to load the trace view. Channeling the rest of the `location.query` params leads to unwanted filtering in when naving out of the traceview to ex: transaction summary. 