### PR TITLE
feat(replay): add foreground/background breadcrumbs

### DIFF
--- a/static/app/utils/replays/getFrameDetails.tsx
+++ b/static/app/utils/replays/getFrameDetails.tsx
@@ -224,6 +224,20 @@ const MAPPER_FOR_FRAME: Record<string, (frame) => Details> = {
     title: 'User Focus',
     icon: <IconUser size="xs" />,
   }),
+  'app.foreground': () => ({
+    color: 'blue300',
+    description: 'Video started recording',
+    tabKey: TabKey.BREADCRUMBS,
+    title: 'App in Foreground',
+    icon: <IconUser size="xs" />,
+  }),
+  'app.background': () => ({
+    color: 'blue300',
+    description: 'Video stopped recording',
+    tabKey: TabKey.BREADCRUMBS,
+    title: 'App in Background',
+    icon: <IconUser size="xs" />,
+  }),
   console: frame => ({
     color: 'gray300',
     description: frame.message ?? '',

--- a/static/app/utils/replays/getFrameDetails.tsx
+++ b/static/app/utils/replays/getFrameDetails.tsx
@@ -226,14 +226,14 @@ const MAPPER_FOR_FRAME: Record<string, (frame) => Details> = {
   }),
   'app.foreground': () => ({
     color: 'blue300',
-    description: 'Video started recording',
+    description: 'Replay started',
     tabKey: TabKey.BREADCRUMBS,
     title: 'App in Foreground',
     icon: <IconUser size="xs" />,
   }),
   'app.background': () => ({
     color: 'blue300',
-    description: 'Video stopped recording',
+    description: 'Replay paused',
     tabKey: TabKey.BREADCRUMBS,
     title: 'App in Background',
     icon: <IconUser size="xs" />,

--- a/static/app/utils/replays/replayReader.tsx
+++ b/static/app/utils/replays/replayReader.tsx
@@ -470,6 +470,8 @@ export default class ReplayReader {
             'device.battery',
             'device.connectivity',
             'device.orientation',
+            'app.foreground',
+            'app.background',
           ].includes(frame.category)
         ),
         ...this._errors,

--- a/static/app/utils/replays/types.tsx
+++ b/static/app/utils/replays/types.tsx
@@ -242,6 +242,8 @@ export type FeedbackFrame = {
   type: string;
 };
 
+export type ForegroundFrame = HydratedBreadcrumb<'app.foreground'>;
+export type BackgroundFrame = HydratedBreadcrumb<'app.background'>;
 export type BlurFrame = HydratedBreadcrumb<'ui.blur'>;
 export type ClickFrame = HydratedBreadcrumb<'ui.click'>;
 export type TapFrame = HydratedBreadcrumb<'ui.tap'>;
@@ -276,6 +278,8 @@ export const BreadcrumbCategories = [
   'ui.keyDown',
   'ui.multiClick',
   'ui.slowClickDetected',
+  'app.foreground',
+  'app.background',
 ];
 
 // Spans

--- a/static/app/views/replays/detail/breadcrumbs/useBreadcrumbFilters.tsx
+++ b/static/app/views/replays/detail/breadcrumbs/useBreadcrumbFilters.tsx
@@ -51,6 +51,7 @@ const TYPE_TO_LABEL: Record<string, string> = {
   input: 'Input',
   tap: 'User Tap',
   device: 'Device',
+  app: 'App',
 };
 
 const OPORCATEGORY_TO_TYPE: Record<string, keyof typeof TYPE_TO_LABEL> = {
@@ -79,6 +80,8 @@ const OPORCATEGORY_TO_TYPE: Record<string, keyof typeof TYPE_TO_LABEL> = {
   'device.battery': 'device',
   'device.connectivity': 'device',
   'device.orientation': 'device',
+  'app.foreground': 'app',
+  'app.background': 'app',
 };
 
 function typeToLabel(val: string): string {


### PR DESCRIPTION


<img width="625" alt="SCR-20240506-omtl" src="https://github.com/getsentry/sentry/assets/56095982/3d72c609-f300-443a-80c7-51b77a832859">

relates to https://github.com/getsentry/sentry/issues/69249
