### PR TITLE
fix(slack): title emoji typeerror

### DIFF
--- a/src/sentry/integrations/slack/message_builder/issues.py
+++ b/src/sentry/integrations/slack/message_builder/issues.py
@@ -522,7 +522,8 @@ class SlackIssuesMessageBuilder(BlockSlackMessageBuilder):
         else:
             title_emoji = CATEGORY_TO_EMOJI.get(self.group.issue_category)
 
-        title_text = (title_emoji + " " or "") + f"<{title_link}|*{escape_slack_text(title)}*>"
+        title_emoji = title_emoji + " " if title_emoji else ""
+        title_text = title_emoji + f"<{title_link}|*{escape_slack_text(title)}*>"
 
         return self.get_markdown_block(title_text)
 


### PR DESCRIPTION
Fixes SENTRY-38WB

The logic should be (title_emoji + " ") only if the title emoji exists but I'm concatenating it even if title_emoji is None, oops