### PR TITLE
feat(trace-explorer): Allow optional breakdown on category

### DIFF
--- a/src/sentry/api/endpoints/organization_traces.py
+++ b/src/sentry/api/endpoints/organization_traces.py
@@ -37,6 +37,7 @@ class TraceInterval(TypedDict):
     start: int
     end: int
     kind: Literal["project", "missing", "other"]
+    opCategory: str | None
 
 
 class TraceResult(TypedDict):
@@ -55,6 +56,9 @@ class TraceResult(TypedDict):
 
 
 class OrganizationTracesSerializer(serializers.Serializer):
+    breakdownCategory = serializers.ListField(
+        required=False, allow_empty=True, child=serializers.CharField()
+    )
     field = serializers.ListField(required=True, allow_empty=False, child=serializers.CharField())
     sort = serializers.ListField(required=False, allow_empty=True, child=serializers.CharField())
     metricsQuery = serializers.CharField(required=False)
@@ -63,6 +67,7 @@ class OrganizationTracesSerializer(serializers.Serializer):
         required=False, allow_empty=True, child=serializers.CharField(allow_blank=True)
     )
     suggestedQuery = serializers.CharField(required=False)
+    minBreakdownDuration = serializers.IntegerField(default=0, min_value=0)
     maxSpansPerTrace = serializers.IntegerField(default=1, min_value=1, max_value=100)
 
 
@@ -101,6 +106,8 @@ class OrganizationTracesEndpoint(OrganizationEventsV2EndpointBase):
             sort=serialized.get("sort"),
             limit=self.get_per_page(request),
             max_spans_per_trace=serialized["maxSpansPerTrace"],
+            breakdown_categories=serialized.get("breakdownCategory", []),
+            min_breakdown_duration=serialized["minBreakdownDuration"],
             get_all_projects=lambda: self.get_projects(
                 request,
                 organization,
@@ -139,6 +146,8 @@ class TraceSamplesExecutor:
         sort: str | None,
         limit: int,
         max_spans_per_trace: int,
+        breakdown_categories: list[str],
+        min_breakdown_duration: int,
         get_all_projects: Callable[[], list[Project]],
     ):
         self.params = params
@@ -151,6 +160,8 @@ class TraceSamplesExecutor:
         self.sort = sort
         self.limit = limit
         self.max_spans_per_trace = max_spans_per_trace
+        self.breakdown_categories = breakdown_categories
+        self.min_breakdown_duration = min_breakdown_duration
         self.get_all_projects = get_all_projects
         self._all_projects: list[Project] | None = None
 
@@ -202,8 +213,45 @@ class TraceSamplesExecutor:
                 query.process_results(result) for query, result in zip(all_queries, all_raw_results)
             ]
 
-            meta = self.process_meta_results(all_results)
-            data = self.process_final_results(all_results)
+            # the order of these results is defined by the order
+            # of the queries in `get_all_meta_data_queries`
+
+            idx = 0
+
+            traces_metas_results = all_results[idx]
+            idx += 1
+
+            traces_errors_results = all_results[idx]
+            idx += 1
+
+            traces_occurrences_results = all_results[idx]
+            idx += 1
+
+            traces_breakdown_projects_results = all_results[idx]
+            idx += 1
+
+            if self.breakdown_categories:
+                traces_breakdown_categories_results = all_results[idx]
+                idx += 1
+            else:
+                traces_breakdown_categories_results = {"data": []}
+
+            user_spans_results = all_results[idx]
+            idx += 1
+
+            suggested_spans_results = all_results[idx] if len(all_results) > idx else None
+            idx += 1
+
+            meta = self.process_meta_results(user_spans_results)
+            data = self.process_final_results(
+                traces_metas_results=traces_metas_results,
+                traces_errors_results=traces_errors_results,
+                traces_occurrences_results=traces_occurrences_results,
+                traces_breakdown_projects_results=traces_breakdown_projects_results,
+                traces_breakdown_categories_results=traces_breakdown_categories_results,
+                user_spans_results=user_spans_results,
+                suggested_spans_results=suggested_spans_results,
+            )
 
         return {"data": data, "meta": meta}
 
@@ -465,12 +513,6 @@ class TraceSamplesExecutor:
         snuba_params: SnubaParams,
         trace_ids: list[str],
     ) -> list[QueryBuilder]:
-        traces_breakdowns_query = self.get_traces_breakdowns_query(
-            params,
-            snuba_params,
-            trace_ids,
-        )
-
         traces_metas_query = self.get_traces_metas_query(
             params,
             snuba_params,
@@ -489,12 +531,28 @@ class TraceSamplesExecutor:
             trace_ids,
         )
 
-        return [
-            traces_breakdowns_query,
+        traces_breakdown_projects_query = self.get_traces_breakdown_projects_query(
+            params,
+            snuba_params,
+            trace_ids,
+        )
+
+        queries = [
             traces_metas_query,
             traces_errors_query,
             traces_occurrences_query,
+            traces_breakdown_projects_query,
         ]
+
+        if self.breakdown_categories:
+            traces_breakdown_categories_query = self.get_traces_breakdown_categories_query(
+                params,
+                snuba_params,
+                trace_ids,
+            )
+            queries.append(traces_breakdown_categories_query)
+
+        return queries
 
     def get_all_span_samples_queries(
         self,
@@ -523,30 +581,34 @@ class TraceSamplesExecutor:
 
         return span_samples_queries
 
-    def process_final_results(self, results) -> list[TraceResult]:
-        # the order of these results is defined by the order
-        # of the queries in `get_all_meta_data_queries`
-        traces_breakdowns_results = results[0]
-        traces_metas_results = results[1]
-        traces_errors_results = results[2]
-        traces_occurrences_results = results[3]
-        user_spans_results = results[4]
-        suggested_spans_results = results[5] if len(results) > 5 else None
-
+    def process_final_results(
+        self,
+        *,
+        traces_metas_results,
+        traces_errors_results,
+        traces_occurrences_results,
+        traces_breakdown_projects_results,
+        traces_breakdown_categories_results,
+        user_spans_results,
+        suggested_spans_results,
+    ) -> list[TraceResult]:
         # mapping of trace id to a tuple of start/finish times
         traces_range = {
             row["trace"]: (row["first_seen()"], row["last_seen()"])
             for row in traces_metas_results["data"]
         }
 
-        traces_breakdowns = process_breakdowns(
-            traces_breakdowns_results["data"],
-            traces_range,
-        )
+        spans = [
+            *traces_breakdown_projects_results["data"],
+            *traces_breakdown_categories_results["data"],
+        ]
+        spans.sort(key=lambda span: (span["precise.start_ts"], span["precise.finish_ts"]))
+
+        traces_breakdowns = process_breakdowns(spans, traces_range)
 
         # mapping of trace id to a tuple of project slug + transaction name
         traces_names: MutableMapping[str, tuple[str, str]] = {}
-        for row in traces_breakdowns_results["data"]:
+        for row in traces_breakdown_projects_results["data"]:
             # The underlying column is a Nullable(UInt64) but we write a default of 0 to it.
             # So make sure to handle both in case something changes.
             if not row["parent_span"] or int(row["parent_span"], 16) == 0:
@@ -594,14 +656,13 @@ class TraceSamplesExecutor:
         ]
 
     def process_meta_results(self, results):
-        user_spans_results = results[4]
-        fields = user_spans_results["meta"].get("fields", {})
+        fields = results["meta"].get("fields", {})
         return {
-            **user_spans_results["meta"],
+            **results["meta"],
             "fields": {field: fields[field] for field in self.fields},
         }
 
-    def get_traces_breakdowns_query(
+    def get_traces_breakdown_projects_query(
         self,
         params: ParamsType,
         snuba_params: SnubaParams,
@@ -619,6 +680,46 @@ class TraceSamplesExecutor:
                 "project",
                 "parent_span",
                 "transaction",
+                "precise.start_ts",
+                "precise.finish_ts",
+            ],
+            orderby=["precise.start_ts", "precise.finish_ts"],
+            # limit the number of segments we fetch per trace so a single
+            # large trace does not result in the rest being blank
+            limitby=("trace", int(MAX_SNUBA_RESULTS / len(trace_ids))),
+            limit=MAX_SNUBA_RESULTS,
+            config=QueryBuilderConfig(
+                transform_alias_to_input_format=True,
+            ),
+        )
+
+    def get_traces_breakdown_categories_query(
+        self,
+        params: ParamsType,
+        snuba_params: SnubaParams,
+        trace_ids: list[str],
+    ) -> QueryBuilder:
+        conditions = []
+
+        span_categories_str = ",".join(self.breakdown_categories)
+        conditions.append(f"span.category:[{span_categories_str}]")
+
+        trace_ids_str = ",".join(trace_ids)
+        conditions.append(f"trace:[{trace_ids_str}]")
+
+        if self.min_breakdown_duration > 0:
+            conditions.append(f"span.duration:>={self.min_breakdown_duration}")
+
+        return SpansIndexedQueryBuilder(
+            Dataset.SpansIndexed,
+            params,
+            snuba_params=snuba_params,
+            query=" ".join(conditions),
+            selected_columns=[
+                "trace",
+                "project",
+                "transaction",
+                "span.category",
                 "precise.start_ts",
                 "precise.finish_ts",
             ],
@@ -829,6 +930,13 @@ def process_breakdowns(data, traces_range):
     breakdowns: Mapping[str, list[TraceInterval]] = defaultdict(list)
     stacks: Mapping[str, list[TraceInterval]] = defaultdict(list)
 
+    def should_merge(interval_a, interval_b):
+        return (
+            interval_a["end"] >= interval_b["start"]
+            and interval_a["project"] == interval_b["project"]
+            and interval_a["opCategory"] == interval_b["opCategory"]
+        )
+
     def breakdown_push(trace, interval):
         # Clip the intervals os that it is within range of the trace
         if trace_range := traces_range.get(trace):
@@ -851,10 +959,11 @@ def process_breakdowns(data, traces_range):
             # A gap in the breakdown was found, fill it with a missing interval
             breakdown.append(
                 {
+                    "kind": "missing",
                     "project": None,
+                    "opCategory": None,
                     "start": last_interval["end"],
                     "end": interval["start"],
-                    "kind": "missing",
                 }
             )
 
@@ -862,11 +971,7 @@ def process_breakdowns(data, traces_range):
 
     def stack_push(trace, interval):
         last_interval = stack_peek(trace)
-        if (
-            last_interval
-            and last_interval["project"] == interval["project"]
-            and last_interval["end"] >= interval["start"]
-        ):
+        if last_interval and should_merge(last_interval, interval):
             # update the end of this interval and it will
             # be updated in the breakdown as well
             last_interval["end"] = max(interval["end"], last_interval["end"])
@@ -902,6 +1007,7 @@ def process_breakdowns(data, traces_range):
         cur: TraceInterval = {
             "kind": "project",
             "project": row["project"],
+            "opCategory": row.get("span.category"),
             "start": int(row["precise.start_ts"] * 1000),
             "end": int(row["precise.finish_ts"] * 1000),
         }
@@ -921,8 +1027,9 @@ def process_breakdowns(data, traces_range):
         # Check to see if there is still a gap before the trace ends and fill it
         # with an other interval.
 
-        other = {
+        other: TraceInterval = {
             "project": None,
+            "opCategory": None,
             "start": trace_start,
             "end": trace_end,
             "kind": "other",

--- a/src/sentry/api/endpoints/organization_traces.py
+++ b/src/sentry/api/endpoints/organization_traces.py
@@ -234,7 +234,13 @@ class TraceSamplesExecutor:
                 traces_breakdown_categories_results = all_results[idx]
                 idx += 1
             else:
-                traces_breakdown_categories_results = {"data": []}
+                traces_breakdown_categories_results = {
+                    "data": [],
+                    "meta": {
+                        "fields": {},
+                        "tips": {},
+                    },
+                }
 
             user_spans_results = all_results[idx]
             idx += 1

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -1544,6 +1544,7 @@ class BaseSpansTestCase(SnubaTestCase):
         store_only_summary: bool = False,
         store_metrics_summary: Mapping[str, Sequence[Mapping[str, Any]]] | None = None,
         group: str = "00",
+        category: str | None = None,
     ):
         if span_id is None:
             span_id = self._random_span_id()
@@ -1581,6 +1582,8 @@ class BaseSpansTestCase(SnubaTestCase):
             payload["_metrics_summary"] = store_metrics_summary
         if parent_span_id:
             payload["parent_span_id"] = parent_span_id
+        if category is not None:
+            payload["sentry_tags"]["category"] = category
 
         # We want to give the caller the possibility to store only a summary since the database does not deduplicate
         # on the span_id which makes the assumptions of a unique span_id in the database invalid.

--- a/tests/sentry/api/endpoints/test_organization_traces.py
+++ b/tests/sentry/api/endpoints/test_organization_traces.py
@@ -76,7 +76,7 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
         project_2 = self.create_project()
 
         # Hack: ensure that no span ids with leading 0s are generated for the test
-        span_ids = ["1" + uuid4().hex[:15] for _ in range(8)]
+        span_ids = ["1" + uuid4().hex[:15] for _ in range(11)]
         tags = ["", "bar", "bar", "baz", "", "bar", "baz"]
         timestamps = []
 
@@ -134,14 +134,59 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
                 exclusive_time=20_000 + i,
                 tags={"foo": tags[i]},
             )
-        timestamps.append(before_now(days=0, minutes=20).replace(microsecond=0))
 
+        timestamps.append(before_now(days=0, minutes=19, seconds=59).replace(microsecond=0))
+        self.store_indexed_span(
+            project_id=project_1.id,
+            trace_id=trace_id_2,
+            transaction_id=txn_id_2,
+            span_id=span_ids[7],
+            parent_span_id=span_ids[4],
+            timestamp=timestamps[-1],
+            transaction="foo",
+            duration=1_000,
+            exclusive_time=1_000,
+            op="http.client",
+            category="http",
+        )
+
+        timestamps.append(before_now(days=0, minutes=19, seconds=40).replace(microsecond=0))
+        self.store_indexed_span(
+            project_id=project_1.id,
+            trace_id=trace_id_2,
+            transaction_id=txn_id_2,
+            span_id=span_ids[8],
+            parent_span_id=span_ids[4],
+            timestamp=timestamps[-1],
+            transaction="foo",
+            duration=3_000,
+            exclusive_time=3_000,
+            op="db.sql",
+            category="db",
+        )
+
+        timestamps.append(before_now(days=0, minutes=19, seconds=45).replace(microsecond=0))
+        self.store_indexed_span(
+            project_id=project_1.id,
+            trace_id=trace_id_2,
+            transaction_id=txn_id_2,
+            span_id=span_ids[9],
+            parent_span_id=span_ids[4],
+            timestamp=timestamps[-1],
+            transaction="foo",
+            duration=3,
+            exclusive_time=3,
+            op="db.sql",
+            category="db",
+        )
+
+        timestamps.append(before_now(days=0, minutes=20).replace(microsecond=0))
         trace_id_3 = uuid4().hex
         self.double_write_segment(
             project_id=project_1.id,
             trace_id=trace_id_3,
             transaction_id=uuid4().hex,
-            span_id=span_ids[7],
+            span_id=span_ids[10],
             timestamp=timestamps[-1],
             transaction="qux",
             duration=40_000,
@@ -392,12 +437,14 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
                         "breakdowns": [
                             {
                                 "project": project_1.slug,
+                                "opCategory": None,
                                 "start": int(timestamps[0].timestamp() * 1000),
                                 "end": int(timestamps[0].timestamp() * 1000) + 60_100,
                                 "kind": "project",
                             },
                             {
                                 "project": project_2.slug,
+                                "opCategory": None,
                                 "start": int(timestamps[1].timestamp() * 1000),
                                 "end": int(timestamps[3].timestamp() * 1000) + 30_003,
                                 "kind": "project",
@@ -432,7 +479,7 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
                         "trace": trace_id_2,
                         "numErrors": 0,
                         "numOccurrences": 0,
-                        "numSpans": 3,
+                        "numSpans": 6,
                         "project": project_1.slug,
                         "name": "bar",
                         "duration": 90_123,
@@ -441,12 +488,14 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
                         "breakdowns": [
                             {
                                 "project": project_1.slug,
+                                "opCategory": None,
                                 "start": int(timestamps[4].timestamp() * 1000),
                                 "end": int(timestamps[4].timestamp() * 1000) + 90_123,
                                 "kind": "project",
                             },
                             {
                                 "project": project_2.slug,
+                                "opCategory": None,
                                 "start": int(timestamps[5].timestamp() * 1000),
                                 "end": int(timestamps[6].timestamp() * 1000) + 20_006,
                                 "kind": "project",
@@ -475,6 +524,111 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
                 ],
                 key=lambda trace: trace["trace"],
             )
+
+    def test_matching_tag_breakdown_with_category(self):
+        (
+            project_1,
+            project_2,
+            _,
+            trace_id_2,
+            _,
+            timestamps,
+            span_ids,
+        ) = self.create_mock_traces()
+
+        query = {
+            "project": [project_1.id],
+            "field": ["id", "parent_span", "span.duration"],
+            "query": "span.category:[db,http]",
+            "suggestedQuery": "span.category:[db,http]",
+            "maxSpansPerTrace": 3,
+            "sort": ["-span.duration"],
+            "breakdownCategory": ["db", "http"],
+            "minBreakdownDuration": 10,
+        }
+
+        response = self.do_request(query)
+        assert response.status_code == 200, response.data
+
+        assert response.data["meta"] == {
+            "dataset": "unknown",
+            "datasetReason": "unchanged",
+            "fields": {
+                "id": "string",
+                "parent_span": "string",
+                "span.duration": "duration",
+            },
+            "isMetricsData": False,
+            "isMetricsExtractedData": False,
+            "tips": {},
+            "units": {
+                "id": None,
+                "parent_span": None,
+                "span.duration": "millisecond",
+            },
+        }
+
+        assert response.data["data"] == [
+            {
+                "trace": trace_id_2,
+                "numErrors": 0,
+                "numOccurrences": 0,
+                "numSpans": 6,
+                "project": project_1.slug,
+                "name": "bar",
+                "duration": 90_123,
+                "start": int(timestamps[4].timestamp() * 1000),
+                "end": int(timestamps[4].timestamp() * 1000) + 90_123,
+                "breakdowns": [
+                    {
+                        "project": project_1.slug,
+                        "opCategory": None,
+                        "start": int(timestamps[4].timestamp() * 1000),
+                        "end": int(timestamps[4].timestamp() * 1000) + 90_123,
+                        "kind": "project",
+                    },
+                    {
+                        "project": project_1.slug,
+                        "opCategory": "http",
+                        "start": int(timestamps[7].timestamp() * 1000),
+                        "end": int(timestamps[7].timestamp() * 1000) + 1_000,
+                        "kind": "project",
+                    },
+                    {
+                        "project": project_2.slug,
+                        "opCategory": None,
+                        "start": int(timestamps[5].timestamp() * 1000),
+                        "end": int(timestamps[6].timestamp() * 1000) + 20_006,
+                        "kind": "project",
+                    },
+                    {
+                        "project": project_1.slug,
+                        "opCategory": "db",
+                        "start": int(timestamps[8].timestamp() * 1000),
+                        "end": int(timestamps[8].timestamp() * 1000) + 3_000,
+                        "kind": "project",
+                    },
+                ],
+                "spans": [
+                    {
+                        "id": span_ids[8],
+                        "parent_span": span_ids[4],
+                        "span.duration": 3_000.0,
+                    },
+                    {
+                        "id": span_ids[7],
+                        "parent_span": span_ids[4],
+                        "span.duration": 1_000.0,
+                    },
+                    {
+                        "id": span_ids[9],
+                        "parent_span": span_ids[4],
+                        "span.duration": 3.0,
+                    },
+                ],
+                "suggestedSpans": [],
+            },
+        ]
 
     def test_matching_tag_metrics(self):
         (
@@ -527,19 +681,20 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
                         "project": project_1.slug,
                         "name": "qux",
                         "duration": 40_000,
-                        "start": int(timestamps[7].timestamp() * 1000),
-                        "end": int(timestamps[7].timestamp() * 1000) + 40_000,
+                        "start": int(timestamps[10].timestamp() * 1000),
+                        "end": int(timestamps[10].timestamp() * 1000) + 40_000,
                         "breakdowns": [
                             {
                                 "project": project_1.slug,
-                                "start": int(timestamps[7].timestamp() * 1000),
-                                "end": int(timestamps[7].timestamp() * 1000) + 40_000,
+                                "opCategory": None,
+                                "start": int(timestamps[10].timestamp() * 1000),
+                                "end": int(timestamps[10].timestamp() * 1000) + 40_000,
                                 "kind": "project",
                             },
                         ],
                         "spans": [
                             {
-                                "id": span_ids[7],
+                                "id": span_ids[10],
                                 "parent_span": "00",
                                 "span.duration": 40_000.0,
                             },
@@ -548,7 +703,7 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
                         if user_query
                         else [
                             {
-                                "id": span_ids[7],
+                                "id": span_ids[10],
                                 "parent_span": "00",
                                 "span.duration": 40_000.0,
                             },
@@ -617,6 +772,7 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
                 * 32: [
                     {
                         "project": "foo",
+                        "opCategory": None,
                         "start": 0,
                         "end": 100,
                         "kind": "project",
@@ -648,12 +804,14 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
                 * 32: [
                     {
                         "project": "foo",
+                        "opCategory": None,
                         "start": 0,
                         "end": 100,
                         "kind": "project",
                     },
                     {
                         "project": "bar",
+                        "opCategory": None,
                         "start": 25,
                         "end": 75,
                         "kind": "project",
@@ -692,18 +850,21 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
                 * 32: [
                     {
                         "project": "foo",
+                        "opCategory": None,
                         "start": 0,
                         "end": 50,
                         "kind": "project",
                     },
                     {
                         "project": "bar",
+                        "opCategory": None,
                         "start": 25,
                         "end": 75,
                         "kind": "project",
                     },
                     {
                         "project": "baz",
+                        "opCategory": None,
                         "start": 50,
                         "end": 100,
                         "kind": "project",
@@ -735,18 +896,21 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
                 * 32: [
                     {
                         "project": "foo",
+                        "opCategory": None,
                         "start": 0,
                         "end": 25,
                         "kind": "project",
                     },
                     {
                         "project": None,
+                        "opCategory": None,
                         "start": 25,
                         "end": 50,
                         "kind": "missing",
                     },
                     {
                         "project": "bar",
+                        "opCategory": None,
                         "start": 50,
                         "end": 75,
                         "kind": "project",
@@ -778,6 +942,7 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
                 * 32: [
                     {
                         "project": "foo",
+                        "opCategory": None,
                         "start": 0,
                         "end": 100,
                         "kind": "project",
@@ -809,6 +974,7 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
                 * 32: [
                     {
                         "project": "foo",
+                        "opCategory": None,
                         "start": 0,
                         "end": 100,
                         "kind": "project",
@@ -840,18 +1006,21 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
                 * 32: [
                     {
                         "project": "foo",
+                        "opCategory": None,
                         "start": 0,
                         "end": 25,
                         "kind": "project",
                     },
                     {
                         "project": None,
+                        "opCategory": None,
                         "start": 25,
                         "end": 50,
                         "kind": "missing",
                     },
                     {
                         "project": "foo",
+                        "opCategory": None,
                         "start": 50,
                         "end": 75,
                         "kind": "project",
@@ -890,18 +1059,21 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
                 * 32: [
                     {
                         "project": "foo",
+                        "opCategory": None,
                         "start": 0,
                         "end": 100,
                         "kind": "project",
                     },
                     {
                         "project": "bar",
+                        "opCategory": None,
                         "start": 20,
                         "end": 80,
                         "kind": "project",
                     },
                     {
                         "project": "baz",
+                        "opCategory": None,
                         "start": 40,
                         "end": 60,
                         "kind": "project",
@@ -940,18 +1112,21 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
                 * 32: [
                     {
                         "project": "foo",
+                        "opCategory": None,
                         "start": 0,
                         "end": 100,
                         "kind": "project",
                     },
                     {
                         "project": "bar",
+                        "opCategory": None,
                         "start": 25,
                         "end": 50,
                         "kind": "project",
                     },
                     {
                         "project": "baz",
+                        "opCategory": None,
                         "start": 50,
                         "end": 75,
                         "kind": "project",
@@ -990,18 +1165,21 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
                 * 32: [
                     {
                         "project": "foo",
+                        "opCategory": None,
                         "start": 0,
                         "end": 50,
                         "kind": "project",
                     },
                     {
                         "project": "bar",
+                        "opCategory": None,
                         "start": 20,
                         "end": 30,
                         "kind": "project",
                     },
                     {
                         "project": "baz",
+                        "opCategory": None,
                         "start": 50,
                         "end": 75,
                         "kind": "project",
@@ -1040,18 +1218,21 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
                 * 32: [
                     {
                         "project": "foo",
+                        "opCategory": None,
                         "start": 0,
                         "end": 50,
                         "kind": "project",
                     },
                     {
                         "project": "bar",
+                        "opCategory": None,
                         "start": 20,
                         "end": 30,
                         "kind": "project",
                     },
                     {
                         "project": "baz",
+                        "opCategory": None,
                         "start": 40,
                         "end": 60,
                         "kind": "project",
@@ -1090,12 +1271,14 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
                 * 32: [
                     {
                         "project": "foo",
+                        "opCategory": None,
                         "start": 0,
                         "end": 50,
                         "kind": "project",
                     },
                     {
                         "project": "bar",
+                        "opCategory": None,
                         "start": 10,
                         "end": 20,
                         "kind": "project",
@@ -1120,6 +1303,7 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
                 * 32: [
                     {
                         "project": "foo",
+                        "opCategory": None,
                         "start": 0,
                         "end": 50,
                         "kind": "project",
@@ -1144,12 +1328,14 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
                 * 32: [
                     {
                         "project": "foo",
+                        "opCategory": None,
                         "start": 0,
                         "end": 50,
                         "kind": "project",
                     },
                     {
                         "project": None,
+                        "opCategory": None,
                         "start": 50,
                         "end": 100,
                         "kind": "other",


### PR DESCRIPTION
Sometimes the per project breakdown is insufficient, so allow enhancing it with more details on some span categories.