### PR TITLE
ref(crons): Fix usage of monitor_environment_id as partition key

### DIFF
--- a/src/sentry/monitors/clock_tasks/check_missed.py
+++ b/src/sentry/monitors/clock_tasks/check_missed.py
@@ -90,7 +90,7 @@ def dispatch_check_missing(ts: datetime):
         # setup. If we backlogged clock-ticks we may produce multiple missed
         # tasks for the same monitor_environment. These MUST happen in-order.
         payload = KafkaPayload(
-            monitor_environment.id.to_bytes(),
+            str(monitor_environment.id).encode(),
             MONITORS_CLOCK_TASKS_CODEC.encode(message),
             [],
         )

--- a/src/sentry/monitors/clock_tasks/check_timeout.py
+++ b/src/sentry/monitors/clock_tasks/check_timeout.py
@@ -46,7 +46,7 @@ def dispatch_check_timeout(ts: datetime):
         # setup. If we backlogged clock-ticks we may produce multiple timeout
         # tasks for the same monitor_environment. These MUST happen in-order.
         payload = KafkaPayload(
-            checkin.monitor_environment_id.to_bytes(),
+            str(checkin.monitor_environment_id).encode(),
             MONITORS_CLOCK_TASKS_CODEC.encode(message),
             [],
         )

--- a/tests/sentry/monitors/clock_tasks/test_check_missed.py
+++ b/tests/sentry/monitors/clock_tasks/test_check_missed.py
@@ -47,6 +47,9 @@ class MonitorClockTasksCheckMissingTest(TestCase):
 
         # Expected check-in was a full minute ago.
         monitor_environment = MonitorEnvironment.objects.create(
+            # XXX(epurkhiser): Arbitrarily large id to make sure we can
+            # correctly use the monitor_environment.id as the partition key
+            id=62702371781194950,
             monitor=monitor,
             environment_id=self.environment.id,
             last_checkin=ts - timedelta(minutes=2),
@@ -63,7 +66,7 @@ class MonitorClockTasksCheckMissingTest(TestCase):
             "monitor_environment_id": monitor_environment.id,
         }
         payload = KafkaPayload(
-            monitor_environment.id.to_bytes(),
+            str(monitor_environment.id).encode(),
             MONITORS_CLOCK_TASKS_CODEC.encode(message),
             [],
         )
@@ -224,7 +227,7 @@ class MonitorClockTasksCheckMissingTest(TestCase):
             "monitor_environment_id": monitor_environment.id,
         }
         payload = KafkaPayload(
-            monitor_environment.id.to_bytes(),
+            str(monitor_environment.id).encode(),
             MONITORS_CLOCK_TASKS_CODEC.encode(message),
             [],
         )
@@ -332,7 +335,7 @@ class MonitorClockTasksCheckMissingTest(TestCase):
             "monitor_environment_id": monitor_environment.id,
         }
         payload = KafkaPayload(
-            monitor_environment.id.to_bytes(),
+            str(monitor_environment.id).encode(),
             MONITORS_CLOCK_TASKS_CODEC.encode(message),
             [],
         )

--- a/tests/sentry/monitors/clock_tasks/test_check_timeout.py
+++ b/tests/sentry/monitors/clock_tasks/test_check_timeout.py
@@ -49,6 +49,9 @@ class MonitorClockTasksCheckTimeoutTest(TestCase):
         )
         # Checkin will timeout in 30 minutes
         checkin = MonitorCheckIn.objects.create(
+            # XXX(epurkhiser): Arbitrarily large id to make sure we can
+            # correctly use the monitor_environment.id as the partition key
+            id=62702371781194950,
             monitor=monitor,
             monitor_environment=monitor_environment,
             project_id=project.id,
@@ -76,7 +79,7 @@ class MonitorClockTasksCheckTimeoutTest(TestCase):
             "checkin_id": checkin.id,
         }
         payload = KafkaPayload(
-            monitor_environment.id.to_bytes(),
+            str(monitor_environment.id).encode(),
             MONITORS_CLOCK_TASKS_CODEC.encode(message),
             [],
         )
@@ -178,7 +181,7 @@ class MonitorClockTasksCheckTimeoutTest(TestCase):
             "checkin_id": checkin1.id,
         }
         payload = KafkaPayload(
-            monitor_environment.id.to_bytes(),
+            str(monitor_environment.id).encode(),
             MONITORS_CLOCK_TASKS_CODEC.encode(message),
             [],
         )
@@ -262,7 +265,7 @@ class MonitorClockTasksCheckTimeoutTest(TestCase):
             "checkin_id": checkin.id,
         }
         payload = KafkaPayload(
-            monitor_environment.id.to_bytes(),
+            str(monitor_environment.id).encode(),
             MONITORS_CLOCK_TASKS_CODEC.encode(message),
             [],
         )
@@ -330,7 +333,7 @@ class MonitorClockTasksCheckTimeoutTest(TestCase):
             "checkin_id": checkin.id,
         }
         payload = KafkaPayload(
-            monitor_environment.id.to_bytes(),
+            str(monitor_environment.id).encode(),
             MONITORS_CLOCK_TASKS_CODEC.encode(message),
             [],
         )
@@ -419,7 +422,7 @@ class MonitorClockTasksCheckTimeoutTest(TestCase):
             "checkin_id": checkin1.id,
         }
         payload = KafkaPayload(
-            monitor_environment.id.to_bytes(),
+            str(monitor_environment.id).encode(),
             MONITORS_CLOCK_TASKS_CODEC.encode(message),
             [],
         )


### PR DESCRIPTION
Fixes SENTRY-FOR-SENTRY-955