### PR TITLE
fix(trace-explorer): Should pass chunks not all trace ids

### DIFF
--- a/src/sentry/api/endpoints/organization_traces.py
+++ b/src/sentry/api/endpoints/organization_traces.py
@@ -344,7 +344,7 @@ class TraceSamplesExecutor:
                 )
 
                 # restrict the query to just this subset of trace ids
-                query.add_conditions([Condition(Column("trace_id"), Op.IN, trace_ids)])
+                query.add_conditions([Condition(Column("trace_id"), Op.IN, chunk)])
 
                 all_queries.append(query)
         else:

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1710,7 +1710,7 @@ register(
     type=Int,
     default=2500,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
-)  # hours
+)
 register(
     "performance.traces.span_query_minimum_spans",
     type=Int,


### PR DESCRIPTION
This was accidentally passing all 10k trace ids to the query which exceeded the max query size.