### PR TITLE
fix(spans): Filtering indexed spans on project should work

### DIFF
--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -116,6 +116,7 @@ SPAN_COLUMN_MAP = {
     "parent_span": "parent_span_id",
     "platform": "platform",
     "project": "project_id",
+    "project.id": "project_id",
     "span.action": "action",
     "span.description": "description",
     "span.domain": "domain",

--- a/tests/sentry/search/events/builder/test_spans_indexed.py
+++ b/tests/sentry/search/events/builder/test_spans_indexed.py
@@ -108,7 +108,7 @@ def test_where(params, condition, expected):
 
 @django_db_all
 def test_where_project(params):
-    project = next(params["project_objects"])
+    project = next(iter(params["project_objects"]))
 
     for query in [f"project:{project.slug}", f"project.id:{project.id}"]:
         builder = SpansIndexedQueryBuilder(

--- a/tests/sentry/search/events/builder/test_spans_indexed.py
+++ b/tests/sentry/search/events/builder/test_spans_indexed.py
@@ -73,24 +73,52 @@ def test_field_alias(params, field, expected):
 
 
 @pytest.mark.parametrize(
-    ["condition", "op", "value"],
+    ["condition", "expected"],
     [
-        pytest.param("1s", Op.EQ, 1000, id="=1s"),
-        pytest.param(">1s", Op.GT, 1000, id=">1s"),
-        pytest.param("<1s", Op.LT, 1000, id="<1s"),
-        pytest.param(">=1s", Op.GTE, 1000, id=">=1s"),
-        pytest.param("<=1s", Op.LTE, 1000, id="<=1s"),
+        pytest.param(
+            "span.duration:1s", Condition(span_duration, Op.EQ, 1000), id="span.duration:1s"
+        ),
+        pytest.param(
+            "span.duration:>1s", Condition(span_duration, Op.GT, 1000), id="span.duration:>1s"
+        ),
+        pytest.param(
+            "span.duration:<1s", Condition(span_duration, Op.LT, 1000), id="span.duration:<1s"
+        ),
+        pytest.param(
+            "span.duration:>=1s", Condition(span_duration, Op.GTE, 1000), id="span.duration:>=1s"
+        ),
+        pytest.param(
+            "span.duration:<=1s", Condition(span_duration, Op.LTE, 1000), id="span.duration:<=1s"
+        ),
+        pytest.param(
+            "span.duration:<=1s", Condition(span_duration, Op.LTE, 1000), id="span.duration:<=1s"
+        ),
     ],
 )
 @django_db_all
-def test_span_duration_where(params, condition, op, value):
+def test_where(params, condition, expected):
     builder = SpansIndexedQueryBuilder(
         Dataset.SpansIndexed,
         params,
-        query=f"span.duration:{condition}",
+        query=condition,
         selected_columns=["count"],
     )
-    assert Condition(span_duration, op, value) in builder.where
+    assert expected in builder.where
+
+
+@django_db_all
+def test_where_project(params):
+    project = next(params["project_objects"])
+
+    for query in [f"project:{project.slug}", f"project.id:{project.id}"]:
+        builder = SpansIndexedQueryBuilder(
+            Dataset.SpansIndexed,
+            params,
+            query=query,
+            selected_columns=["count"],
+        )
+
+        assert Condition(Column("project_id"), Op.EQ, project.id) in builder.where
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This was remapping the query to project.id but that was not defined on indexed spans.