### PR TITLE
feat(replay): show screen name in url bar for mobile replays

### DIFF
--- a/static/app/components/events/eventReplay/replayPreviewPlayer.tsx
+++ b/static/app/components/events/eventReplay/replayPreviewPlayer.tsx
@@ -6,6 +6,7 @@ import {Button, LinkButton} from 'sentry/components/button';
 import ErrorBoundary from 'sentry/components/errorBoundary';
 import Panel from 'sentry/components/panels/panel';
 import {useReplayContext} from 'sentry/components/replays/replayContext';
+import ReplayCurrentScreen from 'sentry/components/replays/replayCurrentScreen';
 import ReplayCurrentUrl from 'sentry/components/replays/replayCurrentUrl';
 import {ReplayFullscreenButton} from 'sentry/components/replays/replayFullscreenButton';
 import ReplayPlayer from 'sentry/components/replays/replayPlayer';
@@ -54,7 +55,8 @@ function ReplayPreviewPlayer({
   const location = useLocation();
   const organization = useOrganization();
   const [isSidebarOpen, setIsSidebarOpen] = useState(true);
-  const {replay, currentTime, isFetching, isFinished, isPlaying} = useReplayContext();
+  const {replay, currentTime, isFetching, isFinished, isPlaying, isVideoReplay} =
+    useReplayContext();
   const eventView = EventView.fromLocation(location);
 
   const fullscreenRef = useRef(null);
@@ -103,7 +105,7 @@ function ReplayPreviewPlayer({
           <PlayerContextContainer>
             {isFullscreen ? (
               <ContextContainer>
-                <ReplayCurrentUrl />
+                {isVideoReplay ? <ReplayCurrentScreen /> : <ReplayCurrentUrl />}
                 <BrowserOSIcons />
                 <ReplaySidebarToggleButton
                   isOpen={isSidebarOpen}

--- a/static/app/components/replays/replayCurrentScreen.tsx
+++ b/static/app/components/replays/replayCurrentScreen.tsx
@@ -1,0 +1,38 @@
+import {useMemo} from 'react';
+import * as Sentry from '@sentry/react';
+
+import {useReplayContext} from 'sentry/components/replays/replayContext';
+import TextCopyInput from 'sentry/components/textCopyInput';
+import {t} from 'sentry/locale';
+import getCurrentScreenName from 'sentry/utils/replays/getCurrentScreenName';
+
+// Screen name component for video/mobile replays - mirrors replayCurrentUrl.tsx
+function ReplayCurrentScreen() {
+  const {currentTime, replay} = useReplayContext();
+  const frames = replay?.getMobileNavigationFrames();
+
+  const screenName = useMemo(() => {
+    try {
+      return getCurrentScreenName(frames, currentTime);
+    } catch (err) {
+      Sentry.captureException(err);
+      return '';
+    }
+  }, [frames, currentTime]);
+
+  if (!replay || !screenName) {
+    return (
+      <TextCopyInput aria-label={t('Current Screen Name')} size="sm" disabled>
+        {''}
+      </TextCopyInput>
+    );
+  }
+
+  return (
+    <TextCopyInput aria-label={t('Current Screen Name')} size="sm">
+      {screenName}
+    </TextCopyInput>
+  );
+}
+
+export default ReplayCurrentScreen;

--- a/static/app/components/replays/replayView.tsx
+++ b/static/app/components/replays/replayView.tsx
@@ -3,6 +3,7 @@ import styled from '@emotion/styled';
 
 import {useReplayContext} from 'sentry/components/replays/replayContext';
 import ReplayController from 'sentry/components/replays/replayController';
+import ReplayCurrentScreen from 'sentry/components/replays/replayCurrentScreen';
 import ReplayCurrentUrl from 'sentry/components/replays/replayCurrentUrl';
 import ReplayPlayer from 'sentry/components/replays/replayPlayer';
 import ReplayProcessingError from 'sentry/components/replays/replayProcessingError';
@@ -30,7 +31,7 @@ function ReplayView({toggleFullscreen}: Props) {
       <PlayerBreadcrumbContainer>
         <PlayerContainer>
           <ContextContainer>
-            <ReplayCurrentUrl />
+            {isVideoReplay ? <ReplayCurrentScreen /> : <ReplayCurrentUrl />}
             <BrowserOSIcons showBrowser={!isVideoReplay} />
             {isFullscreen ? (
               <ReplaySidebarToggleButton

--- a/static/app/utils/replays/getCurrentScreenName.spec.tsx
+++ b/static/app/utils/replays/getCurrentScreenName.spec.tsx
@@ -1,0 +1,47 @@
+import {ReplayNavFrameFixture} from 'sentry-fixture/replay/replayBreadcrumbFrameData';
+import {ReplayRecordFixture} from 'sentry-fixture/replayRecord';
+
+import getCurrentScreenName from 'sentry/utils/replays/getCurrentScreenName';
+import hydrateBreadcrumbs, {
+  replayInitBreadcrumb,
+} from 'sentry/utils/replays/hydrateBreadcrumbs';
+
+const START_DATE = new Date('2022-06-15T00:40:00.111Z');
+const NAVIGATION_DATE_1 = new Date('2022-06-15T00:46:00.333Z');
+const NAVIGATION_DATE_2 = new Date('2022-06-15T00:48:00.444Z');
+const END_DATE = new Date('2022-06-15T00:50:00.555Z');
+
+const replayRecord = ReplayRecordFixture({
+  started_at: START_DATE,
+  finished_at: END_DATE,
+});
+
+const PAGELOAD_FRAME = replayInitBreadcrumb(replayRecord);
+
+const [NAV_FRAME_1, NAV_FRAME_2] = hydrateBreadcrumbs(
+  replayRecord,
+  [
+    ReplayNavFrameFixture({
+      data: {to: 'MainActivityScreen'},
+      timestamp: NAVIGATION_DATE_1,
+    }),
+    ReplayNavFrameFixture({
+      data: {to: 'ConfirmPayment'},
+      timestamp: NAVIGATION_DATE_2,
+    }),
+  ],
+  []
+);
+
+describe('getCurrentScreenName', () => {
+  it('should return the screen name based on the closest navigation crumb', () => {
+    const frames = [PAGELOAD_FRAME, NAV_FRAME_1, NAV_FRAME_2];
+    const offsetMS = Number(NAVIGATION_DATE_1) - Number(START_DATE) + 3;
+    const screenName = getCurrentScreenName(frames, offsetMS);
+    expect(screenName).toBe('MainActivityScreen');
+
+    const offsetMS2 = Number(NAVIGATION_DATE_2) - Number(START_DATE) + 1;
+    const screenName2 = getCurrentScreenName(frames, offsetMS2);
+    expect(screenName2).toBe('ConfirmPayment');
+  });
+});

--- a/static/app/utils/replays/getCurrentScreenName.tsx
+++ b/static/app/utils/replays/getCurrentScreenName.tsx
@@ -1,0 +1,20 @@
+import type {BreadcrumbFrame} from 'sentry/utils/replays/types';
+
+// Gets the current screen name for video/mobile replays - mirrors getCurrentUrl.tsx
+function getCurrentScreenName(
+  frames: undefined | BreadcrumbFrame[],
+  currentOffsetMS: number
+) {
+  const framesBeforeCurrentOffset = frames?.filter(
+    frame => frame.offsetMs < currentOffsetMS
+  );
+
+  const mostRecentFrame = framesBeforeCurrentOffset?.at(-1) ?? frames?.at(0);
+  if (!mostRecentFrame) {
+    return '';
+  }
+
+  return mostRecentFrame.data.to;
+}
+
+export default getCurrentScreenName;

--- a/static/app/utils/replays/replayReader.tsx
+++ b/static/app/utils/replays/replayReader.tsx
@@ -429,6 +429,14 @@ export default class ReplayReader {
     ].sort(sortFrames)
   );
 
+  getMobileNavigationFrames = memoize(() =>
+    [
+      ...this._sortedBreadcrumbFrames.filter(frame =>
+        ['replay.init', 'navigation'].includes(frame.category)
+      ),
+    ].sort(sortFrames)
+  );
+
   getNetworkFrames = memoize(() =>
     this._sortedSpanFrames.filter(
       frame => frame.op.startsWith('navigation.') || frame.op.startsWith('resource.')

--- a/static/app/utils/replays/types.tsx
+++ b/static/app/utils/replays/types.tsx
@@ -57,8 +57,8 @@ type ExtraBreadcrumbTypes =
   | {
       category: 'navigation';
       data: {
-        from: string;
         to: string;
+        from?: string;
       };
       message: string;
       timestamp: number;


### PR DESCRIPTION
- closes https://github.com/getsentry/sentry/issues/67697
- mirroring the web replay url functions -- show screen name (1 per navigation crumb) in the url bar
- (the replay below has 3 nav frames in a second so it picks the last one)

https://github.com/getsentry/sentry/assets/56095982/24791fd6-ad4b-455e-a1b0-a7a3c483865b

