### PR TITLE
perf(tagstore): sample if timerange longer than 14 days

### DIFF
--- a/src/sentry/tagstore/snuba/backend.py
+++ b/src/sentry/tagstore/snuba/backend.py
@@ -3,7 +3,7 @@ import os
 import re
 from collections import defaultdict
 from collections.abc import Iterable, Sequence
-from datetime import timezone
+from datetime import timedelta, timezone
 from typing import Any
 
 from dateutil.parser import parse as parse_datetime
@@ -440,7 +440,9 @@ class SnubaTagStorage(TagStorage):
         # the sampling that turbo enables so that we get more accurate results.
         # We only want sampling when we have a large number of projects, so
         # that we don't cause performance issues for Snuba.
-        if len(projects) <= max_unsampled_projects:
+        # We also see issues with long timeranges in large projects,
+        # So only disable sampling if the timerange is short enough.
+        if len(projects) <= max_unsampled_projects and end - start > timedelta(days=14):
             optimize_kwargs["sample"] = 1
         return self.__get_tag_keys_for_projects(
             projects,

--- a/src/sentry/tagstore/snuba/backend.py
+++ b/src/sentry/tagstore/snuba/backend.py
@@ -442,7 +442,7 @@ class SnubaTagStorage(TagStorage):
         # that we don't cause performance issues for Snuba.
         # We also see issues with long timeranges in large projects,
         # So only disable sampling if the timerange is short enough.
-        if len(projects) <= max_unsampled_projects and end - start > timedelta(days=14):
+        if len(projects) <= max_unsampled_projects and end - start <= timedelta(days=14):
             optimize_kwargs["sample"] = 1
         return self.__get_tag_keys_for_projects(
             projects,

--- a/tests/snuba/api/endpoints/test_organization_tags.py
+++ b/tests/snuba/api/endpoints/test_organization_tags.py
@@ -43,7 +43,7 @@ class OrganizationTagsTest(APITestCase, SnubaTestCase):
 
         url = reverse("sentry-api-0-organization-tags", kwargs={"organization_slug": org.slug})
 
-        response = self.client.get(url, format="json")
+        response = self.client.get(url, {"statsPeriod": "14d"}, format="json")
         assert response.status_code == 200, response.content
         data = response.data
         data.sort(key=lambda val: val["totalValues"], reverse=True)


### PR DESCRIPTION
- allow sampling to run on tagkey queries if the timerange is greater than 14 days on the query. We frequently see errors on the tagstore endpoint with 30 and 90 day queries on certain projects