### PR TITLE
modify helpSource to return results from all indices

### DIFF
--- a/static/app/components/search/sources/helpSource.tsx
+++ b/static/app/components/search/sources/helpSource.tsx
@@ -68,6 +68,7 @@ class HelpSource extends Component<Props, State> {
     const searchResults = await this.search.query(
       query,
       {
+        searchAllIndexes: true,
         platforms: platforms.map(platform => standardSDKSlug(platform)?.slug!),
       },
       {

--- a/static/app/components/search/sources/types.tsx
+++ b/static/app/components/search/sources/types.tsx
@@ -20,7 +20,8 @@ export type ResultItem = {
     | 'help-docs'
     | 'help-develop'
     | 'help-help-center'
-    | 'help-blog';
+    | 'help-blog'
+    | 'help-zendesk_sentry_articles';
   /**
    * The source that created the result.
    */


### PR DESCRIPTION
this PR allows the Search Support, Docs and More to search multiple indices - not just docs

<img width="624" alt="image" src="https://github.com/getsentry/sentry/assets/76002357/af2a49b8-a669-4d63-badd-12bce65e16a9">

At some point a regression was introduced that prevented this component from searching all indices in the config

This also adds a type for the new help center index
