### PR TITLE
fix(ui): Fix incorrect search dynamic in 'Search Support' modal

### DIFF
--- a/static/app/components/helpSearch.spec.tsx
+++ b/static/app/components/helpSearch.spec.tsx
@@ -1,3 +1,5 @@
+import {SentryGlobalSearch} from '@sentry-internal/global-search';
+
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
 import HelpSearch from 'sentry/components/helpSearch';
@@ -60,11 +62,15 @@ const mockResults = [
   },
 ];
 
-jest.mock('@sentry-internal/global-search', () => ({
-  SentryGlobalSearch: jest
-    .fn()
-    .mockImplementation(() => ({query: () => Promise.resolve(mockResults)})),
-}));
+jest.mock('@sentry-internal/global-search', () => {
+  const mockQuery = jest.fn(() => Promise.resolve(mockResults));
+
+  return {
+    SentryGlobalSearch: jest.fn().mockImplementation(() => ({
+      query: mockQuery,
+    })),
+  };
+});
 
 describe('HelpSearch', function () {
   it('produces search results', async function () {
@@ -78,6 +84,14 @@ describe('HelpSearch', function () {
     );
 
     await userEvent.type(screen.getByTestId('search'), 'dummy');
+
+    const mockSentryGlobalSearch = new SentryGlobalSearch();
+
+    expect(mockSentryGlobalSearch.query).toHaveBeenLastCalledWith(
+      'dummy',
+      {platforms: []},
+      {analyticsTags: ['source:dashboard']}
+    );
 
     await screen.findByText('From Documentation');
 

--- a/static/app/components/search/sources/helpSource.tsx
+++ b/static/app/components/search/sources/helpSource.tsx
@@ -53,9 +53,9 @@ class HelpSource extends Component<Props, State> {
     }
   }
 
-  componentDidUpdate(nextProps: Props) {
-    if (nextProps.query !== this.props.query) {
-      this.doSearch(nextProps.query);
+  componentDidUpdate(prevProps: Props) {
+    if (prevProps.query !== this.props.query) {
+      this.doSearch(this.props.query);
     }
   }
 


### PR DESCRIPTION
# Goal

The goal of this PR is to fix a bug in the "Search Support, Docs and More" search bar. When typing into this search bar, the search query sent to the backend in the search request is the previous input value instead of the current one:

<img width="1512" alt="Screenshot 2024-05-05 at 20 54 43" src="https://github.com/getsentry/sentry/assets/79283128/77cae6dc-4f94-48a2-8da9-f2721d8e37d9">

See #70305 for more details, including reproduction steps.

# Approach

The bug is caused by an incorrect use of  `componentDidUpdate` in `static/app/components/helpSearch.tsx`:

https://github.com/getsentry/sentry/blob/3e90887a3632585b048f607668e20927321a39a0/static/app/components/search/sources/helpSource.tsx#L56-L60

The first argument of `componentDidUpdate` is the previous props' value, not the new ones', as documented [here](https://legacy.reactjs.org/docs/react-component.html#componentdidupdate).

The fix is straightforward (compare the current props with the previous props, and if they are different call `doSearch` on `this.props.query`, which indeed has the new query value).

We also add an assertion to the relevant test in `sentry/static/app/components/helpSearch.spec.tsx`. You can check that the test now fails if you remove the fix:

<img width="895" alt="Screenshot 2024-05-05 at 21 33 06" src="https://github.com/getsentry/sentry/assets/79283128/0d61c425-0dfd-4f0e-806c-4ab1d5d7b2d9">

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.