### PR TITLE
fix(ts): Fix TypeScript issue in integration configuration view

### DIFF
--- a/static/app/types/integrations.tsx
+++ b/static/app/types/integrations.tsx
@@ -383,7 +383,7 @@ type ConfigData = {
   installationType?: string;
 };
 
-export interface OrganizationIntegration extends CommonIntegration {
+export interface OrganizationIntegration extends Integration {
   configData: ConfigData | null;
   configOrganization: Field[];
   externalId: string;

--- a/static/app/views/settings/organizationIntegrations/configureIntegration.tsx
+++ b/static/app/views/settings/organizationIntegrations/configureIntegration.tsx
@@ -20,8 +20,8 @@ import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {
   IntegrationProvider,
-  IntegrationWithConfig,
   Organization,
+  OrganizationIntegration,
   PluginWithProjectList,
 } from 'sentry/types';
 import {singleLineRenderer} from 'sentry/utils/marked';
@@ -95,7 +95,7 @@ function ConfigureIntegration({params, router, routes, location}: Props) {
     isError: isErrorIntegration,
     refetch: refetchIntegration,
     remove: removeIntegration,
-  } = useApiQuery<IntegrationWithConfig>(
+  } = useApiQuery<OrganizationIntegration>(
     makeIntegrationQuery(organization, integrationId),
     {staleTime: 0}
   );
@@ -254,7 +254,6 @@ function ConfigureIntegration({params, router, routes, location}: Props) {
         <LinkButton
           aria-label={t('Open this server in the Discord app')}
           size="sm"
-          // @ts-ignore - the type of integration here is weird.
           href={`discord://discord.com/channels/${integration.externalId}`}
         >
           {t('Open in Discord')}

--- a/static/app/views/settings/organizationIntegrations/integrationServerlessFunctions.tsx
+++ b/static/app/views/settings/organizationIntegrations/integrationServerlessFunctions.tsx
@@ -3,7 +3,11 @@ import {Fragment} from 'react';
 import styled from '@emotion/styled';
 
 import DeprecatedAsyncComponent from 'sentry/components/deprecatedAsyncComponent';
-import type {IntegrationWithConfig, Organization, ServerlessFunction} from 'sentry/types';
+import type {
+  Organization,
+  OrganizationIntegration,
+  ServerlessFunction,
+} from 'sentry/types';
 import Panel from 'sentry/components/panels/panel';
 import PanelBody from 'sentry/components/panels/panelBody';
 import PanelHeader from 'sentry/components/panels/panelHeader';
@@ -16,7 +20,7 @@ import {trackIntegrationAnalytics} from 'sentry/utils/integrationUtil';
 import IntegrationServerlessRow from './integrationServerlessRow';
 
 type Props = DeprecatedAsyncComponent['props'] & {
-  integration: IntegrationWithConfig;
+  integration: OrganizationIntegration;
   organization: Organization;
 };
 

--- a/static/app/views/settings/organizationIntegrations/integrationServerlessRow.tsx
+++ b/static/app/views/settings/organizationIntegrations/integrationServerlessRow.tsx
@@ -11,13 +11,17 @@ import {Button} from 'sentry/components/button';
 import Switch from 'sentry/components/switchButton';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
-import type {IntegrationWithConfig, Organization, ServerlessFunction} from 'sentry/types';
+import type {
+  Organization,
+  OrganizationIntegration,
+  ServerlessFunction,
+} from 'sentry/types';
 import {trackIntegrationAnalytics} from 'sentry/utils/integrationUtil';
 import withApi from 'sentry/utils/withApi';
 
 type Props = {
   api: Client;
-  integration: IntegrationWithConfig;
+  integration: OrganizationIntegration;
   onUpdateFunction: (serverlessFunctionUpdate: Partial<ServerlessFunction>) => void;
   organization: Organization;
   serverlessFunction: ServerlessFunction;


### PR DESCRIPTION
# Goal

The goal of this PR is to fix a TypeScript error currently ignored with a `@ts-ignore` statement in `static/app/views/settings/organizationIntegrations/configureIntegration.tsx`:

https://github.com/getsentry/sentry/blob/3e90887a3632585b048f607668e20927321a39a0/static/app/views/settings/organizationIntegrations/configureIntegration.tsx#L253-L262

# Approach

There is indeed a type called `OrganizationIntegration` that has an `externalId` property:

https://github.com/getsentry/sentry/blob/3e90887a3632585b048f607668e20927321a39a0/static/app/types/integrations.tsx#L386-L391

but it needs to extend `Integration` instead of `CommonIntegration`:

https://github.com/getsentry/sentry/blob/3e90887a3632585b048f607668e20927321a39a0/static/app/types/integrations.tsx#L358-L380

Indeed, when we look at the API's `integration` model serializers (`src/sentry/api/serializers/models/integration.py`), the only place where we (may) have an `externalId` property is also one where we have `dynamicDisplayInformation` and `scopes`.

After making this change in `static/app/views/settings/organizationIntegrations/configureIntegration.tsx`, we need to also adapt type declarations in `static/app/views/settings/organizationIntegrations/integrationServerlessFunctions.tsx` and `static/app/views/settings/organizationIntegrations/integrationServerlessRow.tsx` for consistency.

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.