### PR TITLE
fix(ts): Remove non-null assertion in integrationExternalUserMappings.tsx

### DIFF
--- a/static/app/views/settings/organizationIntegrations/integrationExternalMappingForm.tsx
+++ b/static/app/views/settings/organizationIntegrations/integrationExternalMappingForm.tsx
@@ -25,7 +25,7 @@ type Props = Pick<FormProps, 'onCancel' | 'onSubmitSuccess' | 'onSubmitError'> &
     dataEndpoint: string;
     getBaseFormEndpoint: (mapping?: ExternalActorMappingOrSuggestion) => string;
     integration: Integration;
-    sentryNamesMapper: (v: any) => {id: string; name: string}[];
+    sentryNamesMapper: (v: any) => {id: string | undefined; name: string}[];
     type: 'user' | 'team';
     isInline?: boolean;
     mapping?: ExternalActorMappingOrSuggestion;

--- a/static/app/views/settings/organizationIntegrations/integrationExternalUserMappings.tsx
+++ b/static/app/views/settings/organizationIntegrations/integrationExternalUserMappings.tsx
@@ -107,7 +107,7 @@ class IntegrationExternalUserMappings extends DeprecatedAsyncComponent<Props, St
       .filter(member => member.user)
       .map(({user, email, name}) => {
         const label = email !== name ? `${name} - ${email}` : `${email}`;
-        return {id: user?.id!, name: label};
+        return {id: user?.id, name: label};
       });
   }
 


### PR DESCRIPTION
# Goal

The goal of this PR is to get rid of a non-null assertion (`!`) following an optional chaining operator (`?.`):

https://github.com/getsentry/sentry/blob/3e90887a3632585b048f607668e20927321a39a0/static/app/views/settings/organizationIntegrations/integrationExternalUserMappings.tsx#L105-L112

Optional chain expressions are designed to return `undefined` if the optional property is nullish. Using a non-null assertion after an optional chain expression doesn't make logical sense and introduces a type safety hole into the code.

# Approach

We get rid of the non-null assertion and simply allow the `id` string to be `undefined` in the return value of the `sentryNamesMapper` prop passed down to the `<IntegrationExternalMappings />` child component.

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.