### PR TITLE
fix(trace-explorer): Apply splitByChar optimization to trace ids

### DIFF
--- a/src/sentry/api/endpoints/organization_traces.py
+++ b/src/sentry/api/endpoints/organization_traces.py
@@ -398,7 +398,15 @@ class TraceSamplesExecutor:
                 )
 
                 # restrict the query to just this subset of trace ids
-                query.add_conditions([Condition(Column("trace_id"), Op.IN, chunk)])
+                query.add_conditions(
+                    [
+                        Condition(
+                            Column("trace_id"),
+                            Op.IN,
+                            Function("splitByChar", [",", ",".join(chunk)]),
+                        )
+                    ]
+                )
 
                 all_queries.append(query)
         else:


### PR DESCRIPTION
This list of trace ids was hitting a max recursion depth error in snuba. Use the splitByChar trick to get around this and speed up the parsing.