### PR TITLE
feat(mobile-ui): Render screen charts

### DIFF
--- a/static/app/views/performance/mobile/appStarts/screens/averageComparisonChart.tsx
+++ b/static/app/views/performance/mobile/appStarts/screens/averageComparisonChart.tsx
@@ -11,15 +11,14 @@ import {decodeScalar} from 'sentry/utils/queryString';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {useLocation} from 'sentry/utils/useLocation';
 import usePageFilters from 'sentry/utils/usePageFilters';
-import {MAX_CHART_RELEASE_CHARS} from 'sentry/views/performance/mobile/appStarts/screens';
 import {COLD_START_TYPE} from 'sentry/views/performance/mobile/appStarts/screenSummary/startTypeSelector';
 import {YAxis, YAXIS_COLUMNS} from 'sentry/views/performance/mobile/screenload/screens';
 import {ScreensBarChart} from 'sentry/views/performance/mobile/screenload/screens/screenBarChart';
 import {useTableQuery} from 'sentry/views/performance/mobile/screenload/screens/screensTable';
+import useTruncatedReleaseNames from 'sentry/views/performance/mobile/useTruncatedRelease';
 import {PRIMARY_RELEASE_COLOR} from 'sentry/views/starfish/colors';
 import {useReleaseSelection} from 'sentry/views/starfish/queries/useReleases';
 import {SpanMetricsField} from 'sentry/views/starfish/types';
-import {formatVersionAndCenterTruncate} from 'sentry/views/starfish/utils/centerTruncate';
 import {appendReleaseFilters} from 'sentry/views/starfish/utils/releaseComparison';
 
 interface Props {
@@ -90,14 +89,7 @@ export function AverageComparisonChart({chartHeight}: Props) {
     return transformData(data?.data, appStartType);
   }, [data, appStartType]);
 
-  const truncatedPrimaryChart = formatVersionAndCenterTruncate(
-    primaryRelease ?? '',
-    MAX_CHART_RELEASE_CHARS
-  );
-  const truncatedSecondaryChart = formatVersionAndCenterTruncate(
-    secondaryRelease ?? '',
-    MAX_CHART_RELEASE_CHARS
-  );
+  const {truncatedPrimaryRelease, truncatedSecondaryRelease} = useTruncatedReleaseNames();
 
   return (
     <ScreensBarChart
@@ -116,8 +108,8 @@ export function AverageComparisonChart({chartHeight}: Props) {
           subtitle: primaryRelease
             ? t(
                 '%s v. %s',
-                truncatedPrimaryChart,
-                secondaryRelease ? truncatedSecondaryChart : ''
+                truncatedPrimaryRelease,
+                secondaryRelease ? truncatedSecondaryRelease : ''
               )
             : '',
         },

--- a/static/app/views/performance/mobile/appStarts/screens/countChart.tsx
+++ b/static/app/views/performance/mobile/appStarts/screens/countChart.tsx
@@ -12,9 +12,9 @@ import {decodeScalar} from 'sentry/utils/queryString';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {useLocation} from 'sentry/utils/useLocation';
 import usePageFilters from 'sentry/utils/usePageFilters';
-import {MAX_CHART_RELEASE_CHARS} from 'sentry/views/performance/mobile/appStarts/screens';
 import {COLD_START_TYPE} from 'sentry/views/performance/mobile/appStarts/screenSummary/startTypeSelector';
 import {OUTPUT_TYPE, YAxis} from 'sentry/views/performance/mobile/screenload/screens';
+import useTruncatedReleaseNames from 'sentry/views/performance/mobile/useTruncatedRelease';
 import {
   PRIMARY_RELEASE_COLOR,
   SECONDARY_RELEASE_COLOR,
@@ -23,7 +23,6 @@ import Chart, {ChartType} from 'sentry/views/starfish/components/chart';
 import MiniChartPanel from 'sentry/views/starfish/components/miniChartPanel';
 import {useReleaseSelection} from 'sentry/views/starfish/queries/useReleases';
 import {SpanMetricsField} from 'sentry/views/starfish/types';
-import {formatVersionAndCenterTruncate} from 'sentry/views/starfish/utils/centerTruncate';
 import {STARFISH_CHART_INTERVAL_FIDELITY} from 'sentry/views/starfish/utils/constants';
 import {appendReleaseFilters} from 'sentry/views/starfish/utils/releaseComparison';
 import {useEventsStatsQuery} from 'sentry/views/starfish/utils/useEventsStatsQuery';
@@ -107,14 +106,7 @@ export function CountChart({chartHeight}: Props) {
     }
   );
 
-  const truncatedPrimaryChart = formatVersionAndCenterTruncate(
-    primaryRelease ?? '',
-    MAX_CHART_RELEASE_CHARS
-  );
-  const truncatedSecondaryChart = formatVersionAndCenterTruncate(
-    secondaryRelease ?? '',
-    MAX_CHART_RELEASE_CHARS
-  );
+  const {truncatedPrimaryRelease, truncatedSecondaryRelease} = useTruncatedReleaseNames();
 
   return (
     <MiniChartPanel
@@ -123,8 +115,8 @@ export function CountChart({chartHeight}: Props) {
         primaryRelease
           ? t(
               '%s v. %s',
-              truncatedPrimaryChart,
-              secondaryRelease ? truncatedSecondaryChart : ''
+              truncatedPrimaryRelease,
+              secondaryRelease ? truncatedSecondaryRelease : ''
             )
           : ''
       }

--- a/static/app/views/performance/mobile/appStarts/screens/index.tsx
+++ b/static/app/views/performance/mobile/appStarts/screens/index.tsx
@@ -20,22 +20,21 @@ import {AverageComparisonChart} from 'sentry/views/performance/mobile/appStarts/
 import {CountChart} from 'sentry/views/performance/mobile/appStarts/screens/countChart';
 import {AppStartScreens} from 'sentry/views/performance/mobile/appStarts/screens/screensTable';
 import {COLD_START_TYPE} from 'sentry/views/performance/mobile/appStarts/screenSummary/startTypeSelector';
+import {TOP_SCREENS} from 'sentry/views/performance/mobile/constants';
 import {
   getFreeTextFromQuery,
-  TOP_SCREENS,
   YAxis,
   YAXIS_COLUMNS,
 } from 'sentry/views/performance/mobile/screenload/screens';
 import {ScreensBarChart} from 'sentry/views/performance/mobile/screenload/screens/screenBarChart';
 import {useTableQuery} from 'sentry/views/performance/mobile/screenload/screens/screensTable';
 import {transformReleaseEvents} from 'sentry/views/performance/mobile/screenload/screens/utils';
+import useTruncatedReleaseNames from 'sentry/views/performance/mobile/useTruncatedRelease';
 import {getTransactionSearchQuery} from 'sentry/views/performance/utils';
 import {useReleaseSelection} from 'sentry/views/starfish/queries/useReleases';
 import {SpanMetricsField} from 'sentry/views/starfish/types';
-import {formatVersionAndCenterTruncate} from 'sentry/views/starfish/utils/centerTruncate';
 import {appendReleaseFilters} from 'sentry/views/starfish/utils/releaseComparison';
 
-export const MAX_CHART_RELEASE_CHARS = 12;
 const Y_AXES = [YAxis.COLD_START, YAxis.WARM_START];
 const Y_AXIS_COLS = [YAXIS_COLUMNS[YAxis.COLD_START], YAXIS_COLUMNS[YAxis.WARM_START]];
 
@@ -57,6 +56,7 @@ function AppStartup({additionalFilters, chartHeight}: Props) {
     secondaryRelease,
     isLoading: isReleasesLoading,
   } = useReleaseSelection();
+  const {truncatedPrimaryRelease, truncatedSecondaryRelease} = useTruncatedReleaseNames();
 
   const router = useRouter();
 
@@ -173,15 +173,6 @@ function AppStartup({additionalFilters, chartHeight}: Props) {
     topTransactions,
   });
 
-  const truncatedPrimaryChart = formatVersionAndCenterTruncate(
-    primaryRelease ?? '',
-    MAX_CHART_RELEASE_CHARS
-  );
-  const truncatedSecondaryChart = formatVersionAndCenterTruncate(
-    secondaryRelease ?? '',
-    MAX_CHART_RELEASE_CHARS
-  );
-
   const countTopScreens = Math.min(TOP_SCREENS, topTransactions.length);
   const [singularTopScreenTitle, pluralTopScreenTitle] =
     appStartType === COLD_START_TYPE
@@ -204,8 +195,8 @@ function AppStartup({additionalFilters, chartHeight}: Props) {
               subtitle: primaryRelease
                 ? t(
                     '%s v. %s',
-                    truncatedPrimaryChart,
-                    secondaryRelease ? truncatedSecondaryChart : ''
+                    truncatedPrimaryRelease,
+                    secondaryRelease ? truncatedSecondaryRelease : ''
                   )
                 : '',
             },

--- a/static/app/views/performance/mobile/appStarts/screens/screensTable.tsx
+++ b/static/app/views/performance/mobile/appStarts/screens/screensTable.tsx
@@ -13,7 +13,7 @@ import TopResultsIndicator from 'sentry/views/discover/table/topResultsIndicator
 import Breakdown from 'sentry/views/performance/mobile/appStarts/screens/breakdown';
 import {COLD_START_TYPE} from 'sentry/views/performance/mobile/appStarts/screenSummary/startTypeSelector';
 import {ScreensTable} from 'sentry/views/performance/mobile/components/screensTable';
-import {TOP_SCREENS} from 'sentry/views/performance/mobile/screenload/screens';
+import {TOP_SCREENS} from 'sentry/views/performance/mobile/constants';
 import {COLD_START_COLOR, WARM_START_COLOR} from 'sentry/views/starfish/colors';
 import {
   PRIMARY_RELEASE_ALIAS,

--- a/static/app/views/performance/mobile/constants.tsx
+++ b/static/app/views/performance/mobile/constants.tsx
@@ -1,0 +1,2 @@
+export const TOP_SCREENS = 5;
+export const MAX_CHART_RELEASE_CHARS = 12;

--- a/static/app/views/performance/mobile/screenload/screens/screensTable.tsx
+++ b/static/app/views/performance/mobile/screenload/screens/screensTable.tsx
@@ -24,7 +24,7 @@ import usePageFilters from 'sentry/utils/usePageFilters';
 import {normalizeUrl} from 'sentry/utils/withDomainRequired';
 import TopResultsIndicator from 'sentry/views/discover/table/topResultsIndicator';
 import type {TableColumn} from 'sentry/views/discover/table/types';
-import {TOP_SCREENS} from 'sentry/views/performance/mobile/screenload/screens';
+import {TOP_SCREENS} from 'sentry/views/performance/mobile/constants';
 import {
   PRIMARY_RELEASE_ALIAS,
   SECONDARY_RELEASE_ALIAS,

--- a/static/app/views/performance/mobile/ui/referrers.tsx
+++ b/static/app/views/performance/mobile/ui/referrers.tsx
@@ -1,3 +1,4 @@
 export enum Referrer {
   OVERVIEW_SCREENS_TABLE = 'api.performance.module.ui.screen-table',
+  MOBILE_UI_BAR_CHART = 'api.performance.mobile.ui.bar-chart',
 }

--- a/static/app/views/performance/mobile/ui/screens/chart.tsx
+++ b/static/app/views/performance/mobile/ui/screens/chart.tsx
@@ -1,0 +1,47 @@
+import {t} from 'sentry/locale';
+import {TOP_SCREENS} from 'sentry/views/performance/mobile/constants';
+import {ScreensBarChart} from 'sentry/views/performance/mobile/screenload/screens/screenBarChart';
+import useTruncatedReleaseNames from 'sentry/views/performance/mobile/useTruncatedRelease';
+import {useReleaseSelection} from 'sentry/views/starfish/queries/useReleases';
+
+export function Chart({
+  yAxis,
+  topTransactions,
+  transformedReleaseEvents,
+  chartHeight,
+  isLoading,
+}) {
+  const {primaryRelease, secondaryRelease} = useReleaseSelection();
+  const {truncatedPrimaryRelease, truncatedSecondaryRelease} = useTruncatedReleaseNames();
+
+  const countTopScreens = Math.min(TOP_SCREENS, topTransactions.length);
+
+  // TODO
+  const [singularTopScreenTitle, pluralTopScreenTitle] = [
+    t('Top Screen Data'),
+    t('Top %s Screen Data', countTopScreens),
+  ];
+
+  return (
+    <ScreensBarChart
+      chartOptions={[
+        {
+          title: countTopScreens > 1 ? pluralTopScreenTitle : singularTopScreenTitle,
+          yAxis,
+          xAxisLabel: topTransactions,
+          series: Object.values(transformedReleaseEvents[yAxis]),
+          subtitle: primaryRelease
+            ? t(
+                '%s v. %s',
+                truncatedPrimaryRelease,
+                secondaryRelease ? truncatedSecondaryRelease : ''
+              )
+            : '',
+        },
+      ]}
+      chartHeight={chartHeight}
+      isLoading={isLoading}
+      chartKey={`${yAxis}-screen-chart`}
+    />
+  );
+}

--- a/static/app/views/performance/mobile/ui/screens/index.tsx
+++ b/static/app/views/performance/mobile/ui/screens/index.tsx
@@ -1,28 +1,46 @@
+import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 
+import Alert from 'sentry/components/alert';
 import SearchBar from 'sentry/components/performance/searchBar';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {NewQuery} from 'sentry/types';
+import {defined} from 'sentry/utils';
 import EventView from 'sentry/utils/discover/eventView';
 import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import {decodeScalar} from 'sentry/utils/queryString';
-import {MutableSearch} from 'sentry/utils/tokenizeSearch';
+import {escapeFilterValue, MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import useRouter from 'sentry/utils/useRouter';
 import {prepareQueryForLandingPage} from 'sentry/views/performance/data';
-import {getFreeTextFromQuery} from 'sentry/views/performance/mobile/screenload/screens';
+import {TOP_SCREENS} from 'sentry/views/performance/mobile/constants';
+import {
+  getFreeTextFromQuery,
+  YAxis,
+  YAXIS_COLUMNS,
+} from 'sentry/views/performance/mobile/screenload/screens';
 import {useTableQuery} from 'sentry/views/performance/mobile/screenload/screens/screensTable';
+import {transformReleaseEvents} from 'sentry/views/performance/mobile/screenload/screens/utils';
 import {Referrer} from 'sentry/views/performance/mobile/ui/referrers';
+import {Chart} from 'sentry/views/performance/mobile/ui/screens/chart';
 import {UIScreensTable} from 'sentry/views/performance/mobile/ui/screens/table';
 import {getTransactionSearchQuery} from 'sentry/views/performance/utils';
 import {useReleaseSelection} from 'sentry/views/starfish/queries/useReleases';
 import {SpanMetricsField} from 'sentry/views/starfish/types';
 import {appendReleaseFilters} from 'sentry/views/starfish/utils/releaseComparison';
 
+const Y_AXES = [YAxis.SLOW_FRAMES, YAxis.FROZEN_FRAMES, YAxis.FRAMES_DELAY];
+const Y_AXIS_COLUMNS = [
+  'avg(mobile.slow_frames)',
+  'avg(mobile.frozen_frames)',
+  'avg(mobile.frames_delay)',
+];
+
 export function UIScreens() {
+  const theme = useTheme();
   const router = useRouter();
   const {selection} = usePageFilters();
   const location = useLocation();
@@ -80,14 +98,91 @@ export function UIScreens() {
     referrer: Referrer.OVERVIEW_SCREENS_TABLE,
   });
 
+  const topTransactions =
+    topTransactionsData?.data?.slice(0, 5).map(datum => datum.transaction as string) ??
+    [];
+
+  // TODO: Fill with transaction.op filter
+  const topEventsQuery = new MutableSearch([]);
+
+  const topEventsQueryString = `${appendReleaseFilters(
+    topEventsQuery,
+    primaryRelease,
+    secondaryRelease
+  )} ${
+    topTransactions.length > 0
+      ? escapeFilterValue(
+          `transaction:[${topTransactions.map(name => `"${name}"`).join()}]`
+        )
+      : ''
+  }`.trim();
+
+  const {data: releaseEvents, isLoading: isReleaseEventsLoading} = useTableQuery({
+    eventView: EventView.fromNewQueryWithPageFilters(
+      {
+        name: '',
+        fields: ['transaction', 'release', ...Y_AXIS_COLUMNS],
+        yAxis: Y_AXIS_COLUMNS,
+        query: topEventsQueryString,
+        dataset: DiscoverDatasets.SPANS_METRICS,
+        version: 2,
+      },
+      selection
+    ),
+    enabled: !topTransactionsLoading,
+    referrer: Referrer.MOBILE_UI_BAR_CHART,
+  });
+
+  if (!defined(primaryRelease) && !isReleasesLoading) {
+    return (
+      <Alert type="warning" showIcon>
+        {t(
+          'No screens found on recent releases. Please try a single iOS or Android project, a single environment or a smaller date range.'
+        )}
+      </Alert>
+    );
+  }
+
   // TODO: Add transaction.op:ui.load when collecting begins
   const tableSearchFilters = new MutableSearch([]);
 
   const derivedQuery = getTransactionSearchQuery(location, tableEventView.query);
 
+  const transformedReleaseEvents = transformReleaseEvents({
+    yAxes: Y_AXES,
+    primaryRelease,
+    secondaryRelease,
+    colorPalette: theme.charts.getColorPalette(TOP_SCREENS - 2),
+    releaseEvents,
+    topTransactions,
+  });
+
   return (
-    <div>
-      <StyledSearchBar
+    <Layout>
+      <ChartContainer>
+        <Chart
+          yAxis={YAXIS_COLUMNS[YAxis.SLOW_FRAMES]}
+          isLoading={isReleaseEventsLoading}
+          chartHeight={200}
+          topTransactions={topTransactions}
+          transformedReleaseEvents={transformedReleaseEvents}
+        />
+        <Chart
+          yAxis={YAXIS_COLUMNS[YAxis.FROZEN_FRAMES]}
+          isLoading={isReleaseEventsLoading}
+          chartHeight={200}
+          topTransactions={topTransactions}
+          transformedReleaseEvents={transformedReleaseEvents}
+        />
+        <Chart
+          yAxis={YAXIS_COLUMNS[YAxis.FRAMES_DELAY]}
+          isLoading={isReleaseEventsLoading}
+          chartHeight={200}
+          topTransactions={topTransactions}
+          transformedReleaseEvents={transformedReleaseEvents}
+        />
+      </ChartContainer>
+      <SearchBar
         eventView={tableEventView}
         onSearch={search => {
           router.push({
@@ -114,10 +209,18 @@ export function UIScreens() {
         isLoading={topTransactionsLoading}
         pageLinks={pageLinks}
       />
-    </div>
+    </Layout>
   );
 }
 
-const StyledSearchBar = styled(SearchBar)`
-  margin-bottom: ${space(1)};
+const Layout = styled('div')`
+  display: flex;
+  flex-direction: column;
+  gap: ${space(1)};
+`;
+
+const ChartContainer = styled('div')`
+  display: grid;
+  grid-template-columns: 33% 33% 33%;
+  gap: ${space(1)};
 `;

--- a/static/app/views/performance/mobile/ui/screens/index.tsx
+++ b/static/app/views/performance/mobile/ui/screens/index.tsx
@@ -25,8 +25,8 @@ import {
 import {useTableQuery} from 'sentry/views/performance/mobile/screenload/screens/screensTable';
 import {transformReleaseEvents} from 'sentry/views/performance/mobile/screenload/screens/utils';
 import {Referrer} from 'sentry/views/performance/mobile/ui/referrers';
-import {Chart} from 'sentry/views/performance/mobile/ui/screens/chart';
 import {UIScreensTable} from 'sentry/views/performance/mobile/ui/screens/table';
+import {TopScreensChart} from 'sentry/views/performance/mobile/ui/screens/topScreensChart';
 import {getTransactionSearchQuery} from 'sentry/views/performance/utils';
 import {useReleaseSelection} from 'sentry/views/starfish/queries/useReleases';
 import {SpanMetricsField} from 'sentry/views/starfish/types';
@@ -160,21 +160,21 @@ export function UIScreens() {
   return (
     <Layout>
       <ChartContainer>
-        <Chart
+        <TopScreensChart
           yAxis={YAXIS_COLUMNS[YAxis.SLOW_FRAMES]}
           isLoading={isReleaseEventsLoading}
           chartHeight={200}
           topTransactions={topTransactions}
           transformedReleaseEvents={transformedReleaseEvents}
         />
-        <Chart
+        <TopScreensChart
           yAxis={YAXIS_COLUMNS[YAxis.FROZEN_FRAMES]}
           isLoading={isReleaseEventsLoading}
           chartHeight={200}
           topTransactions={topTransactions}
           transformedReleaseEvents={transformedReleaseEvents}
         />
-        <Chart
+        <TopScreensChart
           yAxis={YAXIS_COLUMNS[YAxis.FRAMES_DELAY]}
           isLoading={isReleaseEventsLoading}
           chartHeight={200}

--- a/static/app/views/performance/mobile/ui/screens/table.tsx
+++ b/static/app/views/performance/mobile/ui/screens/table.tsx
@@ -12,7 +12,7 @@ import useOrganization from 'sentry/utils/useOrganization';
 import {normalizeUrl} from 'sentry/utils/withDomainRequired';
 import TopResultsIndicator from 'sentry/views/discover/table/topResultsIndicator';
 import {ScreensTable} from 'sentry/views/performance/mobile/components/screensTable';
-import {TOP_SCREENS} from 'sentry/views/performance/mobile/screenload/screens';
+import {TOP_SCREENS} from 'sentry/views/performance/mobile/constants';
 import {
   PRIMARY_RELEASE_ALIAS,
   SECONDARY_RELEASE_ALIAS,

--- a/static/app/views/performance/mobile/ui/screens/topScreensChart.tsx
+++ b/static/app/views/performance/mobile/ui/screens/topScreensChart.tsx
@@ -4,7 +4,28 @@ import {ScreensBarChart} from 'sentry/views/performance/mobile/screenload/screen
 import useTruncatedReleaseNames from 'sentry/views/performance/mobile/useTruncatedRelease';
 import {useReleaseSelection} from 'sentry/views/starfish/queries/useReleases';
 
-export function Chart({
+function getChartTitle(yAxis: string, countTopScreens: number) {
+  const TITLES = {
+    ['avg(mobile.slow_frames)']: [
+      t('Top Screen Slow Frames'),
+      t('Top %s Screen Slow Frames', countTopScreens),
+    ],
+    ['avg(mobile.frozen_frames)']: [
+      t('Top Screen Frozen Frames'),
+      t('Top %s Screen Frozen Frames', countTopScreens),
+    ],
+    ['avg(mobile.frames_delay)']: [
+      t('Top Screen Frames Delay'),
+      t('Top %s Screen Frames Delay', countTopScreens),
+    ],
+  };
+
+  const [singularTopScreenTitle, pluralTopScreenTitle] = TITLES[yAxis];
+
+  return countTopScreens > 1 ? pluralTopScreenTitle : singularTopScreenTitle;
+}
+
+export function TopScreensChart({
   yAxis,
   topTransactions,
   transformedReleaseEvents,
@@ -16,17 +37,11 @@ export function Chart({
 
   const countTopScreens = Math.min(TOP_SCREENS, topTransactions.length);
 
-  // TODO
-  const [singularTopScreenTitle, pluralTopScreenTitle] = [
-    t('Top Screen Data'),
-    t('Top %s Screen Data', countTopScreens),
-  ];
-
   return (
     <ScreensBarChart
       chartOptions={[
         {
-          title: countTopScreens > 1 ? pluralTopScreenTitle : singularTopScreenTitle,
+          title: getChartTitle(yAxis, countTopScreens),
           yAxis,
           xAxisLabel: topTransactions,
           series: Object.values(transformedReleaseEvents[yAxis]),

--- a/static/app/views/performance/mobile/useTruncatedRelease.spec.tsx
+++ b/static/app/views/performance/mobile/useTruncatedRelease.spec.tsx
@@ -1,0 +1,26 @@
+import {renderHook} from 'sentry-test/reactTestingLibrary';
+
+import useTruncatedReleaseNames from 'sentry/views/performance/mobile/useTruncatedRelease';
+import {useReleaseSelection} from 'sentry/views/starfish/queries/useReleases';
+
+jest.mock('sentry/views/starfish/queries/useReleases');
+
+jest.mocked(useReleaseSelection).mockReturnValue({
+  primaryRelease: 'com.example.vu.android@2.10.5-alpha.1+42',
+  isLoading: false,
+  secondaryRelease: 'com.example.vu.android@2.10.3+42',
+});
+
+describe('useTruncatedRelease', () => {
+  it('truncates long release names to 12 characters by default', () => {
+    const {result} = renderHook(useTruncatedReleaseNames);
+    expect(result.current.truncatedPrimaryRelease).toBe('2.10.5…1 (42)');
+    expect(result.current.truncatedSecondaryRelease).toBe('2.10.3 (42)');
+  });
+
+  it('truncates long release names to provided length limit', () => {
+    const {result} = renderHook(useTruncatedReleaseNames, {truncation: 5});
+    expect(result.current.truncatedPrimaryRelease).toBe('2.10.5…1 (42)');
+    expect(result.current.truncatedSecondaryRelease).toBe('2.10.3 (42)');
+  });
+});

--- a/static/app/views/performance/mobile/useTruncatedRelease.spec.tsx
+++ b/static/app/views/performance/mobile/useTruncatedRelease.spec.tsx
@@ -1,8 +1,8 @@
 import {renderHook} from 'sentry-test/reactTestingLibrary';
 
-import {ELLIPSIS} from 'sentry/utils/profiling/gl/utils';
 import useTruncatedReleaseNames from 'sentry/views/performance/mobile/useTruncatedRelease';
 import {useReleaseSelection} from 'sentry/views/starfish/queries/useReleases';
+import {ELLIPSIS} from 'sentry/views/starfish/utils/centerTruncate';
 
 jest.mock('sentry/views/starfish/queries/useReleases');
 

--- a/static/app/views/performance/mobile/useTruncatedRelease.spec.tsx
+++ b/static/app/views/performance/mobile/useTruncatedRelease.spec.tsx
@@ -1,5 +1,6 @@
 import {renderHook} from 'sentry-test/reactTestingLibrary';
 
+import {ELLIPSIS} from 'sentry/utils/profiling/gl/utils';
 import useTruncatedReleaseNames from 'sentry/views/performance/mobile/useTruncatedRelease';
 import {useReleaseSelection} from 'sentry/views/starfish/queries/useReleases';
 
@@ -14,13 +15,25 @@ jest.mocked(useReleaseSelection).mockReturnValue({
 describe('useTruncatedRelease', () => {
   it('truncates long release names to 12 characters by default', () => {
     const {result} = renderHook(useTruncatedReleaseNames);
+
+    expect(
+      [...result.current.truncatedPrimaryRelease].filter(char => char !== ELLIPSIS)
+    ).toHaveLength(12);
+
     expect(result.current.truncatedPrimaryRelease).toBe('2.10.5…1 (42)');
     expect(result.current.truncatedSecondaryRelease).toBe('2.10.3 (42)');
   });
 
   it('truncates long release names to provided length limit', () => {
-    const {result} = renderHook(useTruncatedReleaseNames, {truncation: 5});
-    expect(result.current.truncatedPrimaryRelease).toBe('2.10.5…1 (42)');
-    expect(result.current.truncatedSecondaryRelease).toBe('2.10.3 (42)');
+    const {result} = renderHook(useTruncatedReleaseNames, {
+      initialProps: 5,
+    });
+
+    expect(
+      [...result.current.truncatedPrimaryRelease].filter(char => char !== ELLIPSIS).length
+    ).toBeLessThanOrEqual(5);
+
+    expect(result.current.truncatedPrimaryRelease).toBe('2.…2)');
+    expect(result.current.truncatedSecondaryRelease).toBe('2.…2)');
   });
 });

--- a/static/app/views/performance/mobile/useTruncatedRelease.tsx
+++ b/static/app/views/performance/mobile/useTruncatedRelease.tsx
@@ -1,0 +1,20 @@
+import {MAX_CHART_RELEASE_CHARS} from 'sentry/views/performance/mobile/constants';
+import {useReleaseSelection} from 'sentry/views/starfish/queries/useReleases';
+import {formatVersionAndCenterTruncate} from 'sentry/views/starfish/utils/centerTruncate';
+
+function useTruncatedReleaseNames(truncation?: number) {
+  const {primaryRelease, secondaryRelease} = useReleaseSelection();
+
+  const truncatedPrimaryRelease = formatVersionAndCenterTruncate(
+    primaryRelease ?? '',
+    truncation ?? MAX_CHART_RELEASE_CHARS
+  );
+  const truncatedSecondaryRelease = formatVersionAndCenterTruncate(
+    secondaryRelease ?? '',
+    truncation ?? MAX_CHART_RELEASE_CHARS
+  );
+
+  return {truncatedPrimaryRelease, truncatedSecondaryRelease};
+}
+
+export default useTruncatedReleaseNames;

--- a/static/app/views/starfish/utils/centerTruncate.ts
+++ b/static/app/views/starfish/utils/centerTruncate.ts
@@ -1,9 +1,11 @@
 import {formatVersion} from 'sentry/utils/formatters';
 
+export const ELLIPSIS = '\u2026';
+
 export function centerTruncate(value: string, maxLength: number = 20) {
   const divider = Math.floor(maxLength / 2);
   if (value?.length > maxLength) {
-    return `${value.slice(0, divider)}\u2026${value.slice(value.length - divider)}`;
+    return `${value.slice(0, divider)}${ELLIPSIS}${value.slice(value.length - divider)}`;
   }
   return value;
 }


### PR DESCRIPTION
Adds support for charts based off of top results in the screens table.

This PR touches a number of files because I did a simple refactor to move some constants into a separate file and created a hook for truncating the release names we use in chart subtitles.

![Screenshot 2024-05-06 at 10 37 16 AM](https://github.com/getsentry/sentry/assets/22846452/3a51ae35-88a1-4af2-b708-a34ededabfc0)

⚠️ I noticed the frames delay tooltips aren't rendered as seconds currently, but I will handle those in a separate PR.
