### PR TITLE
feat(crons): Backfill missed clock-tick dispatches

### DIFF
--- a/tests/sentry/monitors/test_clock_dispatch.py
+++ b/tests/sentry/monitors/test_clock_dispatch.py
@@ -12,25 +12,26 @@ from sentry.utils import json
 
 
 @mock.patch("sentry.monitors.clock_dispatch._dispatch_tick")
-def test_monitor_task_trigger(dispatch_tick):
+@override_options({"crons.use_clock_pulse_consumer": False})
+def test_monitor_task_trigger_legacy(dispatch_tick):
     now = timezone.now().replace(second=0, microsecond=0)
 
     # Assumes a single partition for simplicitly. Multi-partition cases are
     # covered in further test cases.
 
-    # First checkin triggers tasks
+    # First checkin triggers dispatch
     try_monitor_clock_tick(ts=now, partition=0)
     assert dispatch_tick.call_count == 1
 
-    # 5 seconds later does NOT trigger the task
+    # 5 seconds later does NOT trigger the dispatch
     try_monitor_clock_tick(ts=now + timedelta(seconds=5), partition=0)
     assert dispatch_tick.call_count == 1
 
-    # a minute later DOES trigger the task
+    # a minute later DOES trigger the dispatch
     try_monitor_clock_tick(ts=now + timedelta(minutes=1), partition=0)
     assert dispatch_tick.call_count == 2
 
-    # Same time does NOT trigger the task
+    # Same time does NOT trigger the dispatch
     try_monitor_clock_tick(ts=now + timedelta(minutes=1), partition=0)
     assert dispatch_tick.call_count == 2
 
@@ -43,70 +44,8 @@ def test_monitor_task_trigger(dispatch_tick):
 
 
 @mock.patch("sentry.monitors.clock_dispatch._dispatch_tick")
-def test_monitor_task_trigger_partition_desync(dispatch_tick):
-    """
-    When consumer partitions are not completely synchronized we may read
-    timestamps in a non-monotonic order. In this scenario we want to make
-    sure we still only trigger once
-    """
-    now = timezone.now().replace(second=0, microsecond=0)
-
-    # First message in partition 0 with timestamp just after the minute
-    # boundary triggers the task
-    try_monitor_clock_tick(ts=now + timedelta(seconds=1), partition=0)
-    assert dispatch_tick.call_count == 1
-
-    # Second message in a partition 1 has a timestamp just before the minute
-    # boundary, should not trigger anything since we've already ticked ahead of
-    # this
-    try_monitor_clock_tick(ts=now - timedelta(seconds=1), partition=1)
-    assert dispatch_tick.call_count == 1
-
-    # Third message in partition 1 again just after the minute boundary does
-    # NOT trigger the task, we've already ticked at that time.
-    try_monitor_clock_tick(ts=now + timedelta(seconds=1), partition=1)
-    assert dispatch_tick.call_count == 1
-
-    # Next two messages in both partitions move the clock forward
-    try_monitor_clock_tick(ts=now + timedelta(minutes=1, seconds=1), partition=0)
-    try_monitor_clock_tick(ts=now + timedelta(minutes=1, seconds=1), partition=1)
-    assert dispatch_tick.call_count == 2
-
-
-@mock.patch("sentry.monitors.clock_dispatch._dispatch_tick")
-def test_monitor_task_trigger_partition_sync(dispatch_tick):
-    """
-    When the kafka topic has multiple partitions we want to only tick our clock
-    forward once all partitions have caught up. This test simulates that
-    """
-    now = timezone.now().replace(second=0, microsecond=0)
-
-    # Tick for 4 partitions
-    try_monitor_clock_tick(ts=now, partition=0)
-    try_monitor_clock_tick(ts=now, partition=1)
-    try_monitor_clock_tick(ts=now, partition=2)
-    try_monitor_clock_tick(ts=now, partition=3)
-    assert dispatch_tick.call_count == 1
-    assert dispatch_tick.mock_calls[0] == mock.call(now)
-
-    # Tick forward 3 of the partitions, global clock does not tick
-    try_monitor_clock_tick(ts=now + timedelta(minutes=1), partition=0)
-    try_monitor_clock_tick(ts=now + timedelta(minutes=1), partition=1)
-    try_monitor_clock_tick(ts=now + timedelta(minutes=1), partition=2)
-    assert dispatch_tick.call_count == 1
-
-    # Slowest partition ticks forward, global clock ticks
-    try_monitor_clock_tick(ts=now + timedelta(minutes=1), partition=3)
-    assert dispatch_tick.call_count == 2
-    assert dispatch_tick.mock_calls[1] == mock.call(now + timedelta(minutes=1))
-
-
-@mock.patch("sentry.monitors.clock_dispatch._dispatch_tick")
-def test_monitor_task_trigger_partition_tick_skip(dispatch_tick):
-    """
-    In a scenario where all partitions move multiple ticks past the slowest
-    partition we may end up skipping a tick.
-    """
+@override_options({"crons.use_clock_pulse_consumer": False})
+def test_monitor_task_trigger_partition_tick_skip_legacy(dispatch_tick):
     now = timezone.now().replace(second=0, microsecond=0)
 
     # Tick for 4 partitions
@@ -146,6 +85,130 @@ def test_monitor_task_trigger_partition_tick_skip(dispatch_tick):
 
     assert dispatch_tick.call_count == 2
     assert dispatch_tick.mock_calls[1] == mock.call(now + timedelta(minutes=2))
+
+
+@mock.patch("sentry.monitors.clock_dispatch._dispatch_tick")
+@override_options({"crons.use_clock_pulse_consumer": True})
+def test_monitor_task_trigger(dispatch_tick):
+    now = timezone.now().replace(second=0, microsecond=0)
+
+    # Assumes a single partition for simplicitly. Multi-partition cases are
+    # covered in further test cases.
+
+    # First checkin triggers dispatch
+    try_monitor_clock_tick(ts=now, partition=0)
+    assert dispatch_tick.call_count == 1
+
+    # 5 seconds later does NOT trigger the dispatch
+    try_monitor_clock_tick(ts=now + timedelta(seconds=5), partition=0)
+    assert dispatch_tick.call_count == 1
+
+    # a minute later DOES trigger the dispatch
+    try_monitor_clock_tick(ts=now + timedelta(minutes=1), partition=0)
+    assert dispatch_tick.call_count == 2
+
+    # Same time does NOT trigger the dispatch
+    try_monitor_clock_tick(ts=now + timedelta(minutes=1), partition=0)
+    assert dispatch_tick.call_count == 2
+
+    # A skipped minute triggers the dispatch multiple times
+    try_monitor_clock_tick(ts=now + timedelta(minutes=3, seconds=5), partition=0)
+    assert dispatch_tick.call_count == 4
+
+
+@mock.patch("sentry.monitors.clock_dispatch._dispatch_tick")
+def test_monitor_task_trigger_partition_desync(dispatch_tick):
+    """
+    When consumer partitions are not completely synchronized we may read
+    timestamps in a non-monotonic order. In this scenario we want to make
+    sure we still only trigger once
+    """
+    now = timezone.now().replace(second=0, microsecond=0)
+
+    # First message in partition 0 with timestamp just after the minute
+    # boundary triggers the dispatch
+    try_monitor_clock_tick(ts=now + timedelta(seconds=1), partition=0)
+    assert dispatch_tick.call_count == 1
+
+    # Second message in a partition 1 has a timestamp just before the minute
+    # boundary, should not trigger anything since we've already ticked ahead of
+    # this
+    try_monitor_clock_tick(ts=now - timedelta(seconds=1), partition=1)
+    assert dispatch_tick.call_count == 1
+
+    # Third message in partition 1 again just after the minute boundary does
+    # NOT trigger the dispatch, we've already ticked at that time.
+    try_monitor_clock_tick(ts=now + timedelta(seconds=1), partition=1)
+    assert dispatch_tick.call_count == 1
+
+    # Next two messages in both partitions move the clock forward
+    try_monitor_clock_tick(ts=now + timedelta(minutes=1, seconds=1), partition=0)
+    try_monitor_clock_tick(ts=now + timedelta(minutes=1, seconds=1), partition=1)
+    assert dispatch_tick.call_count == 2
+
+
+@mock.patch("sentry.monitors.clock_dispatch._dispatch_tick")
+def test_monitor_task_trigger_partition_sync(dispatch_tick):
+    """
+    When the kafka topic has multiple partitions we want to only tick our clock
+    forward once all partitions have caught up. This test simulates that
+    """
+    now = timezone.now().replace(second=0, microsecond=0)
+
+    # Tick for 4 partitions
+    try_monitor_clock_tick(ts=now, partition=0)
+    try_monitor_clock_tick(ts=now, partition=1)
+    try_monitor_clock_tick(ts=now, partition=2)
+    try_monitor_clock_tick(ts=now, partition=3)
+    assert dispatch_tick.call_count == 1
+    assert dispatch_tick.mock_calls[0] == mock.call(now)
+
+    # Tick forward 3 of the partitions, global clock does not tick
+    try_monitor_clock_tick(ts=now + timedelta(minutes=1), partition=0)
+    try_monitor_clock_tick(ts=now + timedelta(minutes=1), partition=1)
+    try_monitor_clock_tick(ts=now + timedelta(minutes=1), partition=2)
+    assert dispatch_tick.call_count == 1
+
+    # Slowest partition ticks forward, global clock ticks
+    try_monitor_clock_tick(ts=now + timedelta(minutes=1), partition=3)
+    assert dispatch_tick.call_count == 2
+    assert dispatch_tick.mock_calls[1] == mock.call(now + timedelta(minutes=1))
+
+
+@mock.patch("sentry.monitors.clock_dispatch._dispatch_tick")
+@override_options({"crons.use_clock_pulse_consumer": True})
+def test_monitor_task_trigger_partition_tick_skip(dispatch_tick):
+    """
+    In a scenario where all partitions move multiple ticks past the slowest
+    partition we may end up skipping a tick. In this scenario we will backfill
+    those ticks
+    """
+    now = timezone.now().replace(second=0, microsecond=0)
+
+    # Tick for 4 partitions
+    try_monitor_clock_tick(ts=now, partition=0)
+    try_monitor_clock_tick(ts=now, partition=1)
+    try_monitor_clock_tick(ts=now, partition=2)
+    try_monitor_clock_tick(ts=now, partition=3)
+    assert dispatch_tick.call_count == 1
+    assert dispatch_tick.mock_calls[0] == mock.call(now)
+
+    # Tick forward twice for 3 partitions
+    try_monitor_clock_tick(ts=now + timedelta(minutes=1), partition=0)
+    try_monitor_clock_tick(ts=now + timedelta(minutes=1), partition=1)
+    try_monitor_clock_tick(ts=now + timedelta(minutes=1), partition=2)
+
+    try_monitor_clock_tick(ts=now + timedelta(minutes=2), partition=0)
+    try_monitor_clock_tick(ts=now + timedelta(minutes=3), partition=1)
+    try_monitor_clock_tick(ts=now + timedelta(minutes=3), partition=2)
+    assert dispatch_tick.call_count == 1
+
+    # Slowest partition catches up, but has a timestamp gap
+    try_monitor_clock_tick(ts=now + timedelta(minutes=2), partition=3)
+
+    assert dispatch_tick.call_count == 3
+    assert dispatch_tick.mock_calls[1] == mock.call(now + timedelta(minutes=1))
+    assert dispatch_tick.mock_calls[2] == mock.call(now + timedelta(minutes=2))
 
 
 @override_settings(KAFKA_TOPIC_OVERRIDES={"monitors-clock-tick": "clock-tick-test-topic"})


### PR DESCRIPTION
When we detect a clock tick it is possible that we may have skipped a tick when a monitor ingest partition is very slow and does not contain a message for a entire minute (and other partitions have already moved multiple minutes forward).

Previously we would log this and avoid producing a clock tick for these skipped minute(s) as we were using celery to dispatch the check_missing and check_timeout tasks. Since the celery tasks would be produced back-to-back it wasn't unlikely they would be processed out of order

Since the completion of GH-58410 we are now guaranteed that clock tick tasks are processed in order.