### PR TITLE
ref(crons): Produce missed check-ins for muted monitors

### DIFF
--- a/src/sentry/monitors/clock_tasks/check_missed.py
+++ b/src/sentry/monitors/clock_tasks/check_missed.py
@@ -32,35 +32,18 @@ MONITOR_LIMIT = 10_000
 
 # re-use the monitor exclusion query node across dispatch_check_missing and
 # mark_environment_missing.
-IGNORE_MONITORS = (
-    ~Q(
-        status__in=[
-            MonitorStatus.DISABLED,
-            MonitorStatus.PENDING_DELETION,
-            MonitorStatus.DELETION_IN_PROGRESS,
-        ]
-    )
-    & ~Q(
-        monitor__status__in=[
-            ObjectStatus.DISABLED,
-            ObjectStatus.PENDING_DELETION,
-            ObjectStatus.DELETION_IN_PROGRESS,
-        ]
-    )
-    & ~Q(
-        # TODO(epurkhiser): This is a hold-over from when we were producing
-        # these tasks into celery. Removing this conditional will create many
-        # more monitors for us to mark as missed. We should be able to remove
-        # now that we're using a kafka consumer to process these
-        monitor__is_muted=True,
-    )
-    & ~Q(
-        # TODO(epurkhiser): This is a hold-over from when we were producing
-        # these tasks into celery. Removing this conditional will create many
-        # more monitors for us to mark as missed. We should be able to remove
-        # now that we're using a kafka consumer to process these
-        is_muted=True,
-    )
+IGNORE_MONITORS = ~Q(
+    status__in=[
+        MonitorStatus.DISABLED,
+        MonitorStatus.PENDING_DELETION,
+        MonitorStatus.DELETION_IN_PROGRESS,
+    ]
+) & ~Q(
+    monitor__status__in=[
+        ObjectStatus.DISABLED,
+        ObjectStatus.PENDING_DELETION,
+        ObjectStatus.DELETION_IN_PROGRESS,
+    ]
 )
 
 

--- a/tests/sentry/monitors/clock_tasks/test_check_missed.py
+++ b/tests/sentry/monitors/clock_tasks/test_check_missed.py
@@ -490,14 +490,6 @@ class MonitorClockTasksCheckMissingTest(TestCase):
     def test_missing_checkin_but_deletion_in_progress(self):
         self.assert_state_does_not_change_for_status(ObjectStatus.DELETION_IN_PROGRESS)
 
-    # Temporary test until we can move out of celery or reduce load
-    def test_missing_checkin_but_muted(self):
-        self.assert_state_does_not_change_for_status(ObjectStatus.ACTIVE, is_muted=True)
-
-    # Temporary test until we can move out of celery or reduce load
-    def test_missing_checkin_but_environment_muted(self):
-        self.assert_state_does_not_change_for_status(ObjectStatus.ACTIVE, environment_is_muted=True)
-
     @mock.patch("sentry.monitors.clock_tasks.check_missed.produce_task")
     def test_not_missing_checkin(self, mock_produce_task):
         """


### PR DESCRIPTION
With the completion of GH-58410 we should be able to support increasing
the task load for marking muted monitors as missing.