### PR TITLE
chore(feedback): show mark as spam buttons & spam mailbox for everyone

### DIFF
--- a/static/app/components/feedback/feedbackItem/feedbackActions.tsx
+++ b/static/app/components/feedback/feedbackItem/feedbackActions.tsx
@@ -47,28 +47,17 @@ export default function FeedbackActions({
 }
 
 function LargeWidth({feedbackItem}: {feedbackItem: FeedbackIssue}) {
-  const {
-    isResolved,
-    onResolveClick,
-    hasSpamFeature,
-    isSpam,
-    onSpamClick,
-    hasSeen,
-    onMarkAsReadClick,
-  } = useFeedbackActions({feedbackItem});
+  const {isResolved, onResolveClick, isSpam, onSpamClick, hasSeen, onMarkAsReadClick} =
+    useFeedbackActions({feedbackItem});
 
   return (
     <Fragment>
       <Button priority={isResolved ? 'danger' : 'primary'} onClick={onResolveClick}>
         {isResolved ? t('Unresolve') : t('Resolve')}
       </Button>
-
-      {hasSpamFeature && (
-        <Button priority="default" onClick={onSpamClick}>
-          {isSpam ? t('Move to Inbox') : t('Mark as Spam')}
-        </Button>
-      )}
-
+      <Button priority="default" onClick={onSpamClick}>
+        {isSpam ? t('Move to Inbox') : t('Mark as Spam')}
+      </Button>
       <Button onClick={onMarkAsReadClick}>
         {hasSeen ? t('Mark Unread') : t('Mark Read')}
       </Button>
@@ -77,15 +66,8 @@ function LargeWidth({feedbackItem}: {feedbackItem: FeedbackIssue}) {
 }
 
 function MediumWidth({feedbackItem}: {feedbackItem: FeedbackIssue}) {
-  const {
-    isResolved,
-    onResolveClick,
-    hasSpamFeature,
-    isSpam,
-    onSpamClick,
-    hasSeen,
-    onMarkAsReadClick,
-  } = useFeedbackActions({feedbackItem});
+  const {isResolved, onResolveClick, isSpam, onSpamClick, hasSeen, onMarkAsReadClick} =
+    useFeedbackActions({feedbackItem});
 
   return (
     <Fragment>
@@ -102,13 +84,11 @@ function MediumWidth({feedbackItem}: {feedbackItem: FeedbackIssue}) {
           size: 'xs',
         }}
         items={[
-          hasSpamFeature
-            ? {
-                key: 'spam',
-                label: isSpam ? t('Move to Inbox') : t('Mark as Spam'),
-                onAction: onSpamClick,
-              }
-            : null,
+          {
+            key: 'spam',
+            label: isSpam ? t('Move to Inbox') : t('Mark as Spam'),
+            onAction: onSpamClick,
+          },
           {
             key: 'read',
             label: hasSeen ? t('Mark Unread') : t('Mark Read'),

--- a/static/app/components/feedback/feedbackItem/feedbackActions.tsx
+++ b/static/app/components/feedback/feedbackItem/feedbackActions.tsx
@@ -101,15 +101,8 @@ function MediumWidth({feedbackItem}: {feedbackItem: FeedbackIssue}) {
 }
 
 function SmallWidth({feedbackItem}: {feedbackItem: FeedbackIssue}) {
-  const {
-    isResolved,
-    onResolveClick,
-    hasSpamFeature,
-    isSpam,
-    onSpamClick,
-    hasSeen,
-    onMarkAsReadClick,
-  } = useFeedbackActions({feedbackItem});
+  const {isResolved, onResolveClick, isSpam, onSpamClick, hasSeen, onMarkAsReadClick} =
+    useFeedbackActions({feedbackItem});
 
   return (
     <DropdownMenu
@@ -126,13 +119,11 @@ function SmallWidth({feedbackItem}: {feedbackItem: FeedbackIssue}) {
           label: isResolved ? t('Unresolve') : t('Resolve'),
           onAction: onResolveClick,
         },
-        hasSpamFeature
-          ? {
-              key: 'spam',
-              label: isSpam ? t('Move to Inbox') : t('Mark as Spam'),
-              onAction: onSpamClick,
-            }
-          : null,
+        {
+          key: 'spam',
+          label: isSpam ? t('Move to Inbox') : t('Mark as Spam'),
+          onAction: onSpamClick,
+        },
         {
           key: 'read',
           label: hasSeen ? t('Mark Unread') : t('Mark Read'),

--- a/static/app/components/feedback/feedbackItem/useFeedbackActions.ts
+++ b/static/app/components/feedback/feedbackItem/useFeedbackActions.ts
@@ -42,7 +42,6 @@ export default function useActions({feedbackItem}: Props) {
     resolve(newStatus, mutationOptions);
   }, [isResolved, resolve]);
 
-  const hasSpamFeature = organization.features.includes('user-feedback-spam-filter-ui');
   const isSpam = feedbackItem.status === GroupStatus.IGNORED;
   const onSpamClick = useCallback(() => {
     addLoadingMessage(t('Updating feedback...'));
@@ -66,7 +65,6 @@ export default function useActions({feedbackItem}: Props) {
   return {
     isResolved,
     onResolveClick,
-    hasSpamFeature,
     isSpam,
     onSpamClick,
     hasSeen,

--- a/static/app/components/feedback/list/feedbackListBulkSelection.tsx
+++ b/static/app/components/feedback/list/feedbackListBulkSelection.tsx
@@ -9,7 +9,6 @@ import {IconEllipsis} from 'sentry/icons/iconEllipsis';
 import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {GroupStatus} from 'sentry/types/group';
-import useOrganization from 'sentry/utils/useOrganization';
 
 interface Props
   extends Pick<
@@ -25,9 +24,6 @@ export default function FeedbackListBulkSelection({
   selectedIds,
   deselectAll,
 }: Props) {
-  const organization = useOrganization();
-  const hasSpamFeature = organization.features.includes('user-feedback-spam-filter-ui');
-
   const {onToggleResovled, onMarkAsRead, onMarkUnread} = useBulkEditFeedbacks({
     selectedIds,
     deselectAll,
@@ -55,20 +51,18 @@ export default function FeedbackListBulkSelection({
             {mailbox === 'resolved' ? t('Unresolve') : t('Resolve')}
           </Button>
         </ErrorBoundary>
-        {hasSpamFeature && (
-          <ErrorBoundary mini>
-            <Button
-              onClick={() =>
-                onToggleResovled({
-                  newMailbox: newMailboxSpam,
-                  moveToInbox: mailbox === 'ignored',
-                })
-              }
-            >
-              {mailbox === 'ignored' ? t('Move to inbox') : t('Mark as Spam')}
-            </Button>
-          </ErrorBoundary>
-        )}
+        <ErrorBoundary mini>
+          <Button
+            onClick={() =>
+              onToggleResovled({
+                newMailbox: newMailboxSpam,
+                moveToInbox: mailbox === 'ignored',
+              })
+            }
+          >
+            {mailbox === 'ignored' ? t('Move to inbox') : t('Mark as Spam')}
+          </Button>
+        </ErrorBoundary>
         <ErrorBoundary mini>
           <DropdownMenu
             position="bottom-end"

--- a/static/app/components/feedback/list/mailboxPicker.tsx
+++ b/static/app/components/feedback/list/mailboxPicker.tsx
@@ -24,10 +24,7 @@ export default function MailboxPicker({onChange, value}: Props) {
   const organization = useOrganization();
   const {data} = useMailboxCounts({organization});
 
-  const hasSpamFeature = organization.features.includes('user-feedback-spam-filter-ui');
-  const filteredMailboxes = hasSpamFeature
-    ? MAILBOXES
-    : MAILBOXES.filter(i => i.key !== 'ignored');
+  const filteredMailboxes = MAILBOXES;
 
   return (
     <Flex justify="flex-end" flex="1 0 auto">


### PR DESCRIPTION
relates to https://github.com/getsentry/sentry/issues/70346

shows the manual spam feature in these spots:

mailbox:
<img width="392" alt="SCR-20240506-kuku" src="https://github.com/getsentry/sentry/assets/56095982/30bca700-6cfa-4b12-8e93-b544aa646111">

bulk action:
<img width="395" alt="SCR-20240506-kumo" src="https://github.com/getsentry/sentry/assets/56095982/a1ea5a4b-2499-42ec-8fd9-f636afc6a3e8">

single feedback action:
<img width="323" alt="SCR-20240506-kuom" src="https://github.com/getsentry/sentry/assets/56095982/22d9f8a6-38c3-4e8e-89ec-78f5f7c7d7c7">
