### PR TITLE
feat(highlights): Variety of fixes/changes to highlights work

### DIFF
--- a/static/app/components/events/eventTags/eventTagsTree.spec.tsx
+++ b/static/app/components/events/eventTags/eventTagsTree.spec.tsx
@@ -167,7 +167,7 @@ describe('EventTagsTree', function () {
       tag: {key: 'transaction', value: 'abc123'},
       labelText: 'View this transaction',
       validateLink: () => {
-        const linkElement = screen.getByText('abc123', {selector: 'a'});
+        const linkElement = screen.getByRole('link', {name: 'abc123'});
         const href = linkElement.attributes.getNamedItem('href');
         expect(href?.value).toContain(
           `/organizations/${organization.slug}/performance/summary/`
@@ -181,7 +181,7 @@ describe('EventTagsTree', function () {
       tag: {key: 'replay_id', value: 'def456'},
       labelText: 'View this replay',
       validateLink: () => {
-        const linkElement = screen.getByText('def456', {selector: 'a'});
+        const linkElement = screen.getByRole('link', {name: 'def456'});
         expect(linkElement).toHaveAttribute(
           'href',
           `/organizations/${organization.slug}/replays/def456/?referrer=${referrer}`
@@ -192,7 +192,7 @@ describe('EventTagsTree', function () {
       tag: {key: 'replayId', value: 'ghi789'},
       labelText: 'View this replay',
       validateLink: () => {
-        const linkElement = screen.getByText('ghi789', {selector: 'a'});
+        const linkElement = screen.getByRole('link', {name: 'ghi789'});
         expect(linkElement).toHaveAttribute(
           'href',
           `/organizations/${organization.slug}/replays/ghi789/?referrer=${referrer}`
@@ -204,7 +204,7 @@ describe('EventTagsTree', function () {
       labelText: 'Visit this external link',
       validateLink: async () => {
         renderGlobalModal();
-        const linkElement = screen.getByText('https://example.com', {selector: 'a'});
+        const linkElement = screen.getByText('https://example.com');
         await userEvent.click(linkElement);
         expect(screen.getByTestId('external-link-warning')).toBeInTheDocument();
       },

--- a/static/app/components/events/eventTags/eventTagsTree.spec.tsx
+++ b/static/app/components/events/eventTags/eventTagsTree.spec.tsx
@@ -2,7 +2,12 @@ import {EventFixture} from 'sentry-fixture/event';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
-import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+import {
+  render,
+  renderGlobalModal,
+  screen,
+  userEvent,
+} from 'sentry-test/reactTestingLibrary';
 
 import {EventTags} from 'sentry/components/events/eventTags';
 
@@ -54,6 +59,7 @@ describe('EventTagsTree', function () {
   ].concat(emptyBranchTags);
 
   const event = EventFixture({tags});
+  const referrer = 'event-tags-table';
 
   it('avoids tag tree without query param or flag', function () {
     render(<EventTags projectSlug={project.slug} event={event} />, {organization});
@@ -160,29 +166,65 @@ describe('EventTagsTree', function () {
     {
       tag: {key: 'transaction', value: 'abc123'},
       labelText: 'View this transaction',
+      validateLink: () => {
+        const linkElement = screen.getByText('abc123', {selector: 'a'});
+        const href = linkElement.attributes.getNamedItem('href');
+        expect(href?.value).toContain(
+          `/organizations/${organization.slug}/performance/summary/`
+        );
+        expect(href?.value).toContain(`project=${project.id}`);
+        expect(href?.value).toContain('transaction=abc123');
+        expect(href?.value).toContain(`referrer=${referrer}`);
+      },
     },
     {
       tag: {key: 'replay_id', value: 'def456'},
       labelText: 'View this replay',
+      validateLink: () => {
+        const linkElement = screen.getByText('def456', {selector: 'a'});
+        expect(linkElement).toHaveAttribute(
+          'href',
+          `/organizations/${organization.slug}/replays/def456/?referrer=${referrer}`
+        );
+      },
     },
     {
       tag: {key: 'replayId', value: 'ghi789'},
       labelText: 'View this replay',
+      validateLink: () => {
+        const linkElement = screen.getByText('ghi789', {selector: 'a'});
+        expect(linkElement).toHaveAttribute(
+          'href',
+          `/organizations/${organization.slug}/replays/ghi789/?referrer=${referrer}`
+        );
+      },
     },
     {
       tag: {key: 'external-link', value: 'https://example.com'},
       labelText: 'Visit this external link',
+      validateLink: async () => {
+        renderGlobalModal();
+        const linkElement = screen.getByText('https://example.com', {selector: 'a'});
+        await userEvent.click(linkElement);
+        expect(screen.getByTestId('external-link-warning')).toBeInTheDocument();
+      },
     },
-  ])("renders unique links for '$tag.key' tag", async ({tag, labelText}) => {
-    const featuredOrganization = OrganizationFixture({features: ['event-tags-tree-ui']});
-    const uniqueTagsEvent = EventFixture({tags: [tag]});
-    render(<EventTags projectSlug={project.slug} event={uniqueTagsEvent} />, {
-      organization: featuredOrganization,
-    });
-    const dropdown = screen.getByLabelText('Tag Actions Menu');
-    await userEvent.click(dropdown);
-    expect(screen.getByLabelText(labelText)).toBeInTheDocument();
-  });
+  ])(
+    "renders unique links for '$tag.key' tag",
+    async ({tag, labelText, validateLink}) => {
+      const featuredOrganization = OrganizationFixture({
+        features: ['event-tags-tree-ui'],
+      });
+      const uniqueTagsEvent = EventFixture({tags: [tag], projectID: project.id});
+      render(<EventTags projectSlug={project.slug} event={uniqueTagsEvent} />, {
+        organization: featuredOrganization,
+      });
+      const dropdown = screen.getByLabelText('Tag Actions Menu');
+      await userEvent.click(dropdown);
+      expect(screen.getByLabelText(labelText)).toBeInTheDocument();
+      await validateLink();
+    }
+  );
 
   it('renders error message tooltips instead of dropdowns', function () {
     const featuredOrganization = OrganizationFixture({features: ['event-tags-tree-ui']});

--- a/static/app/components/events/highlights/editHighlightsModal.spec.tsx
+++ b/static/app/components/events/highlights/editHighlightsModal.spec.tsx
@@ -266,7 +266,7 @@ describe('EditHighlightsModal', function () {
     );
     await Promise.all(ctxTestPromises);
 
-    // These come from the event, and existing highlights
+    // Combine existing highlight context titles, with new ones that were selected above
     const allHighlightCtxTitles = highlightContextTitles.concat([
       'Keyboard: switches',
       'Client Os: Version',
@@ -299,5 +299,26 @@ describe('EditHighlightsModal', function () {
       })
     );
     expect(closeModal).toHaveBeenCalled();
+  });
+
+  it('should update sections from search input', async function () {
+    renderModal();
+    const tagCount = TEST_EVENT_TAGS.length;
+    expect(screen.getAllByTestId('highlight-tag-option')).toHaveLength(tagCount);
+    const tagInput = screen.getByTestId('highlights-tag-search');
+    await userEvent.type(tagInput, 'le');
+    expect(screen.getAllByTestId('highlight-tag-option')).toHaveLength(3); // handled, level, release
+    await userEvent.clear(tagInput);
+    expect(screen.getAllByTestId('highlight-tag-option')).toHaveLength(tagCount);
+
+    const ctxCount = Object.values(TEST_EVENT_CONTEXTS)
+      .flatMap(Object.keys)
+      .filter(k => k !== 'type').length;
+    expect(screen.getAllByTestId('highlight-context-option')).toHaveLength(ctxCount);
+    const contextInput = screen.getByTestId('highlights-context-search');
+    await userEvent.type(contextInput, 'name'); // client_os.name, runtime.name
+    expect(screen.getAllByTestId('highlight-context-option')).toHaveLength(2);
+    await userEvent.clear(contextInput);
+    expect(screen.getAllByTestId('highlight-context-option')).toHaveLength(ctxCount);
   });
 });

--- a/static/app/components/events/highlights/editHighlightsModal.spec.tsx
+++ b/static/app/components/events/highlights/editHighlightsModal.spec.tsx
@@ -20,6 +20,7 @@ import {
 } from 'sentry/components/events/highlights/util.spec';
 import ModalStore from 'sentry/stores/modalStore';
 import type {Project} from 'sentry/types';
+import * as analytics from 'sentry/utils/analytics';
 
 describe('EditHighlightsModal', function () {
   const organization = OrganizationFixture();
@@ -54,6 +55,7 @@ describe('EditHighlightsModal', function () {
     tags: ['presetTag'],
   };
   const closeModal = jest.fn();
+  const analyticsSpy = jest.spyOn(analytics, 'trackAnalytics');
 
   function renderModal(editHighlightModalProps?: Partial<EditHighlightsModalProps>) {
     act(() => {
@@ -92,6 +94,10 @@ describe('EditHighlightsModal', function () {
 
     const defaultButton = screen.getByRole('button', {name: 'Use Defaults'});
     await userEvent.click(defaultButton);
+    expect(analyticsSpy).toHaveBeenCalledWith(
+      'highlights.edit_modal.use_default_clicked',
+      expect.anything()
+    );
     expect(screen.queryByTestId('highlights-empty-message')).not.toBeInTheDocument();
 
     const updateProjectMock = MockApiClient.addMockResponse({
@@ -101,6 +107,10 @@ describe('EditHighlightsModal', function () {
     });
     const cancelButton = screen.getByRole('button', {name: 'Cancel'});
     await userEvent.click(cancelButton);
+    expect(analyticsSpy).toHaveBeenCalledWith(
+      'highlights.edit_modal.cancel_clicked',
+      expect.anything()
+    );
     expect(updateProjectMock).not.toHaveBeenCalled();
     expect(closeModal).toHaveBeenCalled();
 
@@ -109,6 +119,10 @@ describe('EditHighlightsModal', function () {
     renderModal({highlightContext: {}, highlightTags: []});
     const saveButton = screen.getByRole('button', {name: 'Apply to Project'});
     await userEvent.click(saveButton);
+    expect(analyticsSpy).toHaveBeenCalledWith(
+      'highlights.edit_modal.save_clicked',
+      expect.anything()
+    );
     expect(updateProjectMock).toHaveBeenCalled();
     expect(closeModal).toHaveBeenCalled();
   });
@@ -124,7 +138,6 @@ describe('EditHighlightsModal', function () {
     // Existing Tags and Context Keys should be highlighted
     const previewSection = screen.getByTestId('highlights-preview-section');
     expect(screen.queryByTestId('highlights-empty-message')).not.toBeInTheDocument();
-
     highlightTags.forEach(tag => {
       const tagItem = within(previewSection).getByText(tag, {selector: 'div'});
       expect(tagItem).toBeInTheDocument();
@@ -136,8 +149,27 @@ describe('EditHighlightsModal', function () {
       const contextItem = within(previewSection).getByText(titleString);
       expect(contextItem).toBeInTheDocument();
     });
+
     const previewCtxButtons = screen.queryAllByTestId('highlights-remove-ctx');
     expect(previewCtxButtons).toHaveLength(highlightContextTitles.length);
+
+    await userEvent.click(previewTagButtons[0]);
+    expect(analyticsSpy).toHaveBeenCalledWith(
+      'highlights.edit_modal.remove_tag',
+      expect.anything()
+    );
+    expect(screen.queryAllByTestId('highlights-remove-tag')).toHaveLength(
+      previewTagButtons.length - 1
+    );
+
+    await userEvent.click(previewCtxButtons[0]);
+    expect(analyticsSpy).toHaveBeenCalledWith(
+      'highlights.edit_modal.remove_context_key',
+      expect.anything()
+    );
+    expect(screen.queryAllByTestId('highlights-remove-ctx')).toHaveLength(
+      previewCtxButtons.length - 1
+    );
 
     // Default should unselect the current values
     const defaultButton = screen.getByRole('button', {name: 'Use Defaults'});
@@ -204,6 +236,11 @@ describe('EditHighlightsModal', function () {
       expect(removeButton).toBeEnabled();
     });
     await Promise.all(tagTestPromises);
+    expect(analyticsSpy).toHaveBeenCalledTimes(8);
+    expect(analyticsSpy).toHaveBeenCalledWith(
+      'highlights.edit_modal.add_tag',
+      expect.anything()
+    );
 
     // All event tags should be present now
     await userEvent.click(screen.getByRole('button', {name: 'Apply to Project'}));
@@ -265,7 +302,11 @@ describe('EditHighlightsModal', function () {
       }
     );
     await Promise.all(ctxTestPromises);
-
+    expect(analyticsSpy).toHaveBeenCalledTimes(5);
+    expect(analyticsSpy).toHaveBeenCalledWith(
+      'highlights.edit_modal.add_context_key',
+      expect.anything()
+    );
     // Combine existing highlight context titles, with new ones that were selected above
     const allHighlightCtxTitles = highlightContextTitles.concat([
       'Keyboard: switches',

--- a/static/app/components/events/highlights/editHighlightsModal.tsx
+++ b/static/app/components/events/highlights/editHighlightsModal.tsx
@@ -176,7 +176,11 @@ function EditTagHighlightSection({
                 title={isDisabled && t('Already highlighted')}
                 tooltipProps={{delay: 500}}
               />
-              <HighlightKey disabled={isDisabled} aria-disabled={isDisabled}>
+              <HighlightKey
+                disabled={isDisabled}
+                aria-disabled={isDisabled}
+                data-test-id="highlight-tag-option"
+              >
                 {tagKey}
               </HighlightKey>
             </EditTagContainer>
@@ -193,6 +197,7 @@ function EditTagHighlightSection({
           placeholder={t('Search Tags')}
           value={tagFilter}
           onChange={e => setTagFilter(e.target.value)}
+          data-test-id="highlights-tag-search"
         />
       </Subtitle>
       <EditHighlightSectionContent columnCount={columnCount}>
@@ -266,7 +271,11 @@ function EditContextHighlightSection({
                         title={isDisabled && t('Already highlighted')}
                         tooltipProps={{delay: 500}}
                       />
-                      <HighlightKey disabled={isDisabled} aria-disabled={isDisabled}>
+                      <HighlightKey
+                        disabled={isDisabled}
+                        aria-disabled={isDisabled}
+                        data-test-id="highlight-context-option"
+                      >
                         {contextKey}
                       </HighlightKey>
                     </Fragment>
@@ -287,6 +296,7 @@ function EditContextHighlightSection({
           placeholder={t('Search Context')}
           value={ctxFilter}
           onChange={e => setCtxFilter(e.target.value)}
+          data-test-id="highlights-context-search"
         />
       </Subtitle>
       <EditHighlightSectionContent columnCount={columnCount}>

--- a/static/app/components/events/highlights/editHighlightsModal.tsx
+++ b/static/app/components/events/highlights/editHighlightsModal.tsx
@@ -66,10 +66,10 @@ function EditPreviewHighlightSection({
     highlightContext,
   });
   const highlightContextRows = highlightContextDataItems.reduce<React.ReactNode[]>(
-    (rowList, {alias, data}, i) => {
+    (rowList, {alias, data}) => {
       const meta = getContextMeta(event, alias);
-      const newRows = data.map((item, j) => (
-        <Fragment key={`edit-highlight-ctx-${i}-${j}`}>
+      const newRows = data.map(item => (
+        <Fragment key={`edit-highlight-ctx-${alias}-${item.key}`}>
           <EditButton
             aria-label={`Remove from highlights`}
             icon={<IconSubtract />}
@@ -92,8 +92,8 @@ function EditPreviewHighlightSection({
   );
 
   const highlightTagItems = getHighlightTagData({event, highlightTags});
-  const highlightTagRows = highlightTagItems.map((content, i) => (
-    <Fragment key={`edit-highlight-tag-${i}`}>
+  const highlightTagRows = highlightTagItems.map(content => (
+    <Fragment key={`edit-highlight-tag-${content.originalTag.key}`}>
       <EditButton
         aria-label={`Remove from highlights`}
         icon={<IconSubtract />}
@@ -154,7 +154,7 @@ function EditTagHighlightSection({
 }: EditTagHighlightSectionProps) {
   const [tagFilter, setTagFilter] = useState('');
   const tagData = event.tags
-    .filter(tag => tag?.key.includes(tagFilter))
+    .filter(tag => tag.key?.includes(tagFilter))
     .map(tag => tag.key);
   const tagColumnSize = Math.ceil(tagData.length / columnCount);
   const tagColumns: React.ReactNode[] = [];
@@ -377,12 +377,12 @@ export default function EditHighlightsModal({
           highlightTags={highlightTags}
           highlightContext={highlightContext}
           onRemoveTag={tagKey => {
-            trackAnalytics('edit_highlights.remove_tag_key', {organization});
+            trackAnalytics('highlights.edit_modal.remove_tag', {organization});
             setHighlightTags(highlightTags.filter(tag => tag !== tagKey));
           }}
-          onRemoveContextKey={(contextType, contextKey) =>
+          onRemoveContextKey={(contextType, contextKey) => {
+            trackAnalytics('highlights.edit_modal.remove_context_key', {organization});
             setHighlightContext(() => {
-              trackAnalytics('edit_highlights.remove_context_key', {organization});
               const {[contextType]: highlightContextKeys, ...newHighlightContext} =
                 highlightContext;
               const newHighlightContextKeys = (highlightContextKeys ?? []).filter(
@@ -394,8 +394,8 @@ export default function EditHighlightsModal({
                     ...newHighlightContext,
                     [contextType]: newHighlightContextKeys,
                   };
-            })
-          }
+            });
+          }}
           project={project}
           data-test-id="highlights-preview-section"
         />
@@ -404,7 +404,7 @@ export default function EditHighlightsModal({
           columnCount={columnCount}
           highlightTags={highlightTags}
           onAddTag={tagKey => {
-            trackAnalytics('edit_highlights.add_tag_key', {organization});
+            trackAnalytics('highlights.edit_modal.add_tag', {organization});
             setHighlightTags([...highlightTags, tagKey]);
           }}
           data-test-id="highlights-tag-section"
@@ -414,7 +414,7 @@ export default function EditHighlightsModal({
           columnCount={columnCount}
           highlightContext={highlightContext}
           onAddContextKey={(contextType, contextKey) => {
-            trackAnalytics('edit_highlights.add_context_key', {organization});
+            trackAnalytics('highlights.edit_modal.add_context_key', {organization});
             setHighlightContext({
               ...highlightContext,
               [contextType]: [...(highlightContext[contextType] ?? []), contextKey],
@@ -431,7 +431,7 @@ export default function EditHighlightsModal({
         <ButtonBar gap={1}>
           <Button
             onClick={() => {
-              trackAnalytics('edit_highlights.cancel_clicked', {organization});
+              trackAnalytics('highlights.edit_modal.cancel_clicked', {organization});
               closeModal();
             }}
             size="sm"
@@ -441,7 +441,9 @@ export default function EditHighlightsModal({
           {highlightPreset && (
             <Button
               onClick={() => {
-                trackAnalytics('edit_highlights.use_default_clicked', {organization});
+                trackAnalytics('highlights.edit_modal.use_default_clicked', {
+                  organization,
+                });
                 setHighlightContext(highlightPreset.context);
                 setHighlightTags(highlightPreset.tags);
               }}
@@ -453,7 +455,7 @@ export default function EditHighlightsModal({
           <Button
             disabled={isLoading}
             onClick={() => {
-              trackAnalytics('edit_highlights.save_clicked', {organization});
+              trackAnalytics('highlights.edit_modal.save_clicked', {organization});
               saveHighlights({highlightContext, highlightTags});
             }}
             priority="primary"

--- a/static/app/components/events/highlights/editHighlightsModal.tsx
+++ b/static/app/components/events/highlights/editHighlightsModal.tsx
@@ -154,7 +154,7 @@ function EditTagHighlightSection({
 }: EditTagHighlightSectionProps) {
   const [tagFilter, setTagFilter] = useState('');
   const tagData = event.tags
-    .filter(tag => tag.key.includes(tagFilter))
+    .filter(tag => tag?.key.includes(tagFilter))
     .map(tag => tag.key);
   const tagColumnSize = Math.ceil(tagData.length / columnCount);
   const tagColumns: React.ReactNode[] = [];

--- a/static/app/components/events/highlights/highlightsDataSection.tsx
+++ b/static/app/components/events/highlights/highlightsDataSection.tsx
@@ -69,7 +69,7 @@ export default function HighlightsDataSection({
   const viewAllButton = viewAllRef ? (
     <Button
       onClick={() => {
-        trackAnalytics('highlights_section.view_all_clicked', {organization});
+        trackAnalytics('highlights.issue_details.view_all_clicked', {organization});
         viewAllRef?.current?.scrollIntoView({behavior: 'smooth'});
       }}
       size="xs"
@@ -131,7 +131,7 @@ export default function HighlightsDataSection({
   });
 
   function openEditHighlightsModal() {
-    trackAnalytics('highlights_section.edit_clicked', {organization});
+    trackAnalytics('highlights.issue_details.edit_clicked', {organization});
     openModal(
       deps => (
         <EditHighlightsModal

--- a/static/app/components/events/highlights/highlightsDataSection.tsx
+++ b/static/app/components/events/highlights/highlightsDataSection.tsx
@@ -23,8 +23,9 @@ import {
   getHighlightContextData,
   getHighlightTagData,
 } from 'sentry/components/events/highlights/util';
+import useFeedbackWidget from 'sentry/components/feedback/widget/useFeedbackWidget';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
-import {IconEdit} from 'sentry/icons';
+import {IconEdit, IconMegaphone} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {Event, Group, Project} from 'sentry/types';
@@ -158,6 +159,7 @@ export default function HighlightsDataSection({
       type="event-highlights"
       actions={
         <ButtonBar gap={1}>
+          <HighlightsFeedback />
           {viewAllButton}
           <Button
             size="xs"
@@ -193,6 +195,31 @@ export default function HighlightsDataSection({
         )}
       </HighlightContainer>
     </EventDataSection>
+  );
+}
+
+function HighlightsFeedback() {
+  const buttonRef = useRef<HTMLButtonElement>(null);
+  const feedback = useFeedbackWidget({
+    buttonRef,
+    messagePlaceholder: t(
+      'How can we make tags, context or highlights more useful to you?'
+    ),
+  });
+
+  if (!feedback) {
+    return null;
+  }
+
+  return (
+    <Button
+      ref={buttonRef}
+      aria-label={t('Give Feedback')}
+      icon={<IconMegaphone />}
+      size={'xs'}
+    >
+      {t('Feedback')}
+    </Button>
   );
 }
 

--- a/static/app/components/events/highlights/highlightsSettingsForm.spec.tsx
+++ b/static/app/components/events/highlights/highlightsSettingsForm.spec.tsx
@@ -4,6 +4,7 @@ import {ProjectFixture} from 'sentry-fixture/project';
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
 import HighlightsSettingsForm from 'sentry/components/events/highlights/highlightsSettingsForm';
+import * as analytics from 'sentry/utils/analytics';
 
 describe('HighlightsSettingForm', function () {
   const organization = OrganizationFixture({features: ['event-tags-tree-ui']});
@@ -13,6 +14,7 @@ describe('HighlightsSettingForm', function () {
     browser: ['name', 'version'],
   };
   const project = ProjectFixture({highlightContext, highlightTags});
+  const analyticsSpy = jest.spyOn(analytics, 'trackAnalytics');
 
   beforeEach(async function () {
     MockApiClient.addMockResponse({
@@ -52,6 +54,10 @@ describe('HighlightsSettingForm', function () {
       expect.objectContaining({
         data: {highlightTags: [...highlightTags, newTag]},
       })
+    );
+    expect(analyticsSpy).toHaveBeenCalledWith(
+      'highlights.project_settings.updated_manually',
+      expect.anything()
     );
   });
 

--- a/static/app/components/events/highlights/highlightsSettingsForm.tsx
+++ b/static/app/components/events/highlights/highlightsSettingsForm.tsx
@@ -51,7 +51,7 @@ export default function HighlightsSettingsForm({
         }),
         data => (updatedProject ? updatedProject : data)
       );
-      trackAnalytics('project_settings.updated_highlights', {organization});
+      trackAnalytics('highlights.project_settings.updated_manually', {organization});
       addSuccessMessage(`Successfully updated highlights for '${project.name}'`);
     },
   };

--- a/static/app/components/modals/navigateToExternalLinkModal.tsx
+++ b/static/app/components/modals/navigateToExternalLinkModal.tsx
@@ -18,7 +18,7 @@ function NavigateToExternalLinkModal({Body, closeModal, Header, linkText}: Props
         <h2>{t('Heads up')}</h2>
       </Header>
       <Body>
-        <p>
+        <p data-test-id="external-link-warning">
           {t(
             "You're leaving Sentry and will be redirected to the following external website:"
           )}

--- a/static/app/utils/analytics/issueAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/issueAnalyticsEvents.tsx
@@ -63,6 +63,16 @@ export type IssueEventParameters = {
     platform?: string;
     project_id?: string;
   };
+  'highlights.edit_modal.add_context_key': {};
+  'highlights.edit_modal.add_tag': {};
+  'highlights.edit_modal.cancel_clicked': {};
+  'highlights.edit_modal.remove_context_key': {};
+  'highlights.edit_modal.remove_tag': {};
+  'highlights.edit_modal.save_clicked': {};
+  'highlights.edit_modal.use_default_clicked': {};
+  'highlights.issue_details.edit_clicked': {};
+  'highlights.issue_details.view_all_clicked': {};
+  'highlights.project_settings.updated_manually': {};
   'integrations.integration_reinstall_clicked': {
     provider: string;
   };
@@ -275,6 +285,18 @@ export const issueEventMap: Record<IssueEventKey, string | null> = {
   'event_cause.docs_clicked': 'Event Cause Docs Clicked',
   'event_cause.snoozed': 'Event Cause Snoozed',
   'event_cause.dismissed': 'Event Cause Dismissed',
+  'highlights.edit_modal.add_context_key': 'Highlights: Add Context in Edit Modal',
+  'highlights.edit_modal.add_tag': 'Highlights: Add Tag in Edit Modal',
+  'highlights.edit_modal.cancel_clicked': 'Highlights: Cancel from Edit Modal',
+  'highlights.edit_modal.remove_context_key': 'Highlights: Remove Context in Edit Modal',
+  'highlights.edit_modal.remove_tag': 'Highlights: Remove Tag in Edit Modal',
+  'highlights.edit_modal.save_clicked': 'Highlights: Save from Edit Modal',
+  'highlights.edit_modal.use_default_clicked':
+    'Highlights: Defaults Applied from Edit Modal',
+  'highlights.issue_details.edit_clicked': 'Highlights: Open Edit Modal',
+  'highlights.issue_details.view_all_clicked': 'Highlights: View All Clicked',
+  'highlights.project_settings.updated_manually':
+    'Highlights: Updated Manually from Settings',
   'issue_details.escalating_feedback_received':
     'Issue Details: Escalating Feedback Received',
   'issue_details.escalating_issues_banner_feedback_received':


### PR DESCRIPTION
This PR makes a variety of changes to the highlights/tags areas:
- [x] Add tests for analytics and user friendly names

- [x] Add search to the highlights modal
![image](https://github.com/getsentry/sentry/assets/35509934/75beb7c9-90c3-40a3-84d9-f4b585297de5)

- [x] Allow `replayId`, `transaction` and tags with URLs to be clickable
![image](https://github.com/getsentry/sentry/assets/35509934/bc0f4ac6-a2c2-496a-bcfa-6e14c811d151)

- [x] Adds a feedback button on Highlight section
![image](https://github.com/getsentry/sentry/assets/35509934/064edd41-1a83-48a9-ad12-b0de8102db4c)

**todo**
- [x] Add tests for search
- [x] Add tests for new tag links
- [x] Add screenshots of changes