### PR TITLE
fix(github-comments): use bigint for commitId

### DIFF
--- a/src/sentry/tasks/integrations/github/pr_comment.py
+++ b/src/sentry/tasks/integrations/github/pr_comment.py
@@ -83,7 +83,7 @@ def pr_to_issue_query(pr_id: int):
                 pr.organization_id org_id,
                 array_agg(go.group_id ORDER BY go.date_added) issues
             FROM sentry_groupowner go
-            JOIN sentry_pullrequest_commit c ON c.commit_id = (go.context::jsonb->>'commitId')::int
+            JOIN sentry_pullrequest_commit c ON c.commit_id = (go.context::jsonb->>'commitId')::bigint
             JOIN sentry_pull_request pr ON c.pull_request_id = pr.id
             WHERE go.type=0
             AND pr.id={pr_id}


### PR DESCRIPTION
Fixes SENTRY-38VN

The request is erroring out because we're casting what should be a `bigint` into an `int`, using `bigint` fixes this (tested on Redash).