### PR TITLE
fix(screenloads): Add sentry.dart to supported platforms

### DIFF
--- a/static/app/views/performance/mobile/screenload/index.tsx
+++ b/static/app/views/performance/mobile/screenload/index.tsx
@@ -92,6 +92,7 @@ export default function PageloadModule() {
                       'sentry.cocoa',
                       'sentry.javascript.react-native',
                       'sentry.dart.flutter',
+                      'sentry.dart',
                     ]}
                     docsUrl="https://docs.sentry.io/product/performance/mobile-vitals/screen-loads/#minimum-sdk-requirements"
                   >


### PR DESCRIPTION
It looks like `sentry.dart` is a possible platform name from SDKs. Add it to the supported list.