### PR TITLE
fix(highlights): Fix crashing on null tag keys

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -495,6 +495,9 @@ static/app/components/events/eventStatisticalDetector/                    @getse
 /src/sentry/tasks/post_process.py                           @getsentry/issues
 /src/sentry/tasks/unmerge.py                                @getsentry/issues
 /src/sentry/search/snuba/                                   @getsentry/issues
+/static/app/components/events/contexts/                     @getsentry/issues
+/static/app/components/events/eventTags/                    @getsentry/issues
+/static/app/components/events/highlights/                   @getsentry/issues
 /static/app/views/issueList                                 @getsentry/issues
 /static/app/views/issueDetails/                             @getsentry/issues
 /static/app/views/organizationStats/teamInsights/           @getsentry/issues

--- a/static/app/components/events/eventTags/eventTagsTree.spec.tsx
+++ b/static/app/components/events/eventTags/eventTagsTree.spec.tsx
@@ -230,4 +230,23 @@ describe('EventTagsTree', function () {
     const errorRows = screen.queryAllByTestId('tag-tree-row-errors');
     expect(errorRows.length).toBe(2);
   });
+
+  it('avoids rendering nullish tags', function () {
+    const featuredOrganization = OrganizationFixture({features: ['event-tags-tree-ui']});
+    const uniqueTagsEvent = EventFixture({
+      tags: [
+        {key: null, value: 'null tag'},
+        {key: undefined, value: 'undefined tag'},
+        {key: 'boring-tag', value: 'boring tag'},
+      ],
+    });
+    render(<EventTags projectSlug={project.slug} event={uniqueTagsEvent} />, {
+      organization: featuredOrganization,
+    });
+
+    expect(screen.getByText('boring-tag', {selector: 'div'})).toBeInTheDocument();
+    expect(screen.getByText('boring tag')).toBeInTheDocument();
+    expect(screen.queryByText('null tag')).not.toBeInTheDocument();
+    expect(screen.queryByText('undefined tag')).not.toBeInTheDocument();
+  });
 });

--- a/static/app/components/events/eventTags/eventTagsTree.tsx
+++ b/static/app/components/events/eventTags/eventTagsTree.tsx
@@ -7,6 +7,7 @@ import EventTagsTreeRow, {
 import {useIssueDetailsColumnCount} from 'sentry/components/events/eventTags/util';
 import {space} from 'sentry/styles/space';
 import type {Event, EventTag} from 'sentry/types/event';
+import {defined} from 'sentry/utils';
 
 const MAX_TREE_DEPTH = 4;
 const INVALID_BRANCH_REGEX = /\.{2,}/;
@@ -43,6 +44,10 @@ function addToTagTree(
   originalTag: EventTag
 ): TagTree {
   const BRANCH_MATCHES_REGEX = /\./g;
+  if (!defined(tag.key)) {
+    return tree;
+  }
+
   const branchMatches = tag.key.match(BRANCH_MATCHES_REGEX) ?? [];
 
   const hasInvalidBranchCount =


### PR DESCRIPTION
Resolves https://sentry.sentry.io/issues/5243747663/?project=11276

Not sure why tags are coming in with `null` or `undefined` keys, but we can't display those so they will be omitted, letting the rest of the component render as per usual.

Also adding the team as a codeowner to help assignment for this stuff.