### PR TITLE
chore(replay): make mobile replay default tab breadcrumbs

### DIFF
--- a/static/app/utils/replays/hooks/useActiveReplayTab.spec.tsx
+++ b/static/app/utils/replays/hooks/useActiveReplayTab.spec.tsx
@@ -46,14 +46,6 @@ describe('useActiveReplayTab', () => {
     expect(result.current.getActiveTab()).toBe(TabKey.BREADCRUMBS);
   });
 
-  it('should use Tags as a default for video replays', () => {
-    const {result} = renderHook(useActiveReplayTab, {
-      initialProps: {isVideoReplay: true},
-    });
-
-    expect(result.current.getActiveTab()).toBe(TabKey.TAGS);
-  });
-
   it('should use Breadcrumbs as a default, when there is a click search in the url', () => {
     mockLocation('click.tag:button');
 
@@ -80,19 +72,6 @@ describe('useActiveReplayTab', () => {
   it('should set the default tab if the name is invalid', () => {
     const {result} = renderHook(useActiveReplayTab, {
       initialProps: {},
-    });
-    expect(result.current.getActiveTab()).toBe(TabKey.BREADCRUMBS);
-
-    result.current.setActiveTab('foo bar');
-    expect(mockPush).toHaveBeenLastCalledWith({
-      pathname: '',
-      query: {t_main: TabKey.BREADCRUMBS},
-    });
-  });
-
-  it('should set the default tab if the name is invalid for video replays', () => {
-    const {result} = renderHook(useActiveReplayTab, {
-      initialProps: {isVideoReplay: true},
     });
     expect(result.current.getActiveTab()).toBe(TabKey.BREADCRUMBS);
 

--- a/static/app/utils/replays/hooks/useActiveReplayTab.spec.tsx
+++ b/static/app/utils/replays/hooks/useActiveReplayTab.spec.tsx
@@ -94,12 +94,12 @@ describe('useActiveReplayTab', () => {
     const {result} = renderHook(useActiveReplayTab, {
       initialProps: {isVideoReplay: true},
     });
-    expect(result.current.getActiveTab()).toBe(TabKey.TAGS);
+    expect(result.current.getActiveTab()).toBe(TabKey.BREADCRUMBS);
 
     result.current.setActiveTab('foo bar');
     expect(mockPush).toHaveBeenLastCalledWith({
       pathname: '',
-      query: {t_main: TabKey.TAGS},
+      query: {t_main: TabKey.BREADCRUMBS},
     });
   });
 });

--- a/static/app/utils/replays/hooks/useActiveReplayTab.tsx
+++ b/static/app/utils/replays/hooks/useActiveReplayTab.tsx
@@ -30,7 +30,7 @@ function isReplayTab({tab, isVideoReplay}: {isVideoReplay: boolean; tab: string}
 }
 
 function useActiveReplayTab({isVideoReplay = false}: {isVideoReplay?: boolean}) {
-  const defaultTab = isVideoReplay ? TabKey.TAGS : TabKey.BREADCRUMBS;
+  const defaultTab = TabKey.BREADCRUMBS;
   const {getParamValue, setParamValue} = useUrlParams('t_main', defaultTab);
 
   const paramValue = getParamValue()?.toLowerCase() ?? '';


### PR DESCRIPTION
since we have interesting breadcrumbs now:
<img width="1112" alt="SCR-20240506-mggr" src="https://github.com/getsentry/sentry/assets/56095982/c78dc788-98ba-4196-8083-9b092b972e7b">
