### PR TITLE
fix(replay): Remove View Sample Replay button

### DIFF
--- a/static/app/components/events/eventReplay/replayInlineOnboardingPanel.tsx
+++ b/static/app/components/events/eventReplay/replayInlineOnboardingPanel.tsx
@@ -6,7 +6,6 @@ import {usePrompt} from 'sentry/actionCreators/prompts';
 import {Button} from 'sentry/components/button';
 import {DropdownMenu} from 'sentry/components/dropdownMenu';
 import {EventReplaySection} from 'sentry/components/events/eventReplay/eventReplaySection';
-import HookOrDefault from 'sentry/components/hookOrDefault';
 import platforms, {otherPlatform} from 'sentry/data/platforms';
 import {IconClose} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
@@ -22,11 +21,6 @@ type OnboardingCTAProps = {
   platform: PlatformKey;
   projectId: string;
 };
-
-const OnboardingCTAButton = HookOrDefault({
-  hookName: 'component:replay-onboarding-cta-button',
-  defaultComponent: null,
-});
 
 export default function ReplayInlineOnboardingPanel({
   platform,
@@ -64,7 +58,6 @@ export default function ReplayInlineOnboardingPanel({
             {t('Watch the errors and latency issues your users face')}
           </BannerDescription>
           <ActionButton>
-            {!isScreenSmall && <OnboardingCTAButton />}
             <Button
               analyticsEventName="Clicked Replay Onboarding CTA Set Up Button in Issue Details"
               analyticsEventKey="issue_details.replay-onboarding-cta-set-up-button-clicked"

--- a/static/app/components/feedback/feedbackItem/replayInlineCTAPanel.tsx
+++ b/static/app/components/feedback/feedbackItem/replayInlineCTAPanel.tsx
@@ -5,15 +5,9 @@ import replaysInlineOnboarding from 'sentry-images/spot/replay-onboarding-backen
 import PageBanner from 'sentry/components/alerts/pageBanner';
 import {Button} from 'sentry/components/button';
 import ButtonBar from 'sentry/components/buttonBar';
-import HookOrDefault from 'sentry/components/hookOrDefault';
 import {IconBroadcast} from 'sentry/icons/iconBroadcast';
 import {t} from 'sentry/locale';
 import {useReplayOnboardingSidebarPanel} from 'sentry/utils/replays/hooks/useReplayOnboarding';
-
-const OnboardingCTAButton = HookOrDefault({
-  hookName: 'component:replay-onboarding-cta-button',
-  defaultComponent: null,
-});
 
 export default function ReplayInlineCTAPanel() {
   const {activateSidebar} = useReplayOnboardingSidebarPanel();
@@ -22,7 +16,6 @@ export default function ReplayInlineCTAPanel() {
     <PageBanner
       button={
         <ButtonBar gap={1}>
-          <OnboardingCTAButton />
           <Button
             priority="primary"
             analyticsEventName="Clicked Replay Onboarding CTA Button in User Feedback"

--- a/static/app/types/hooks.tsx
+++ b/static/app/types/hooks.tsx
@@ -214,7 +214,6 @@ export type ComponentHooks = {
   'component:replay-list-page-header': () => React.ComponentType<ReplayListPageHeaderProps> | null;
   'component:replay-onboarding-alert': () => React.ComponentType<ReplayOnboardingAlertProps>;
   'component:replay-onboarding-cta': () => React.ComponentType<ReplayOnboardingCTAProps>;
-  'component:replay-onboarding-cta-button': () => React.ComponentType<{}> | null;
   'component:sentry-logo': () => React.ComponentType<SentryLogoProps>;
   'component:superuser-access-category': React.ComponentType<any>;
   'component:superuser-warning': React.ComponentType<any>;

--- a/static/app/views/replays/list/replayOnboardingPanel.tsx
+++ b/static/app/views/replays/list/replayOnboardingPanel.tsx
@@ -35,10 +35,6 @@ const OnboardingCTAHook = HookOrDefault({
   hookName: 'component:replay-onboarding-cta',
   defaultComponent: ({children}) => <Fragment>{children}</Fragment>,
 });
-const OnboardingCTAButton = HookOrDefault({
-  hookName: 'component:replay-onboarding-cta-button',
-  defaultComponent: null,
-});
 
 const OnboardingAlertHook = HookOrDefault({
   hookName: 'component:replay-onboarding-alert',
@@ -272,7 +268,6 @@ export function SetupReplaysCTA({
       </p>
       <ButtonList gap={1}>
         {renderCTA()}
-        <OnboardingCTAButton />
         <Button
           href="https://docs.sentry.io/product/session-replay/getting-started/"
           external


### PR DESCRIPTION
Removes view sample replay button from replay onboarding because we're not supposed to rely on Arcade inside Sentry.

Relates to https://github.com/getsentry/team-replay/issues/433 and https://github.com/getsentry/getsentry/pull/13875