### PR TITLE
fix(mobile-ui): Add transaction.op:ui.load filter

### DIFF
--- a/static/app/views/performance/mobile/ui/screens/index.tsx
+++ b/static/app/views/performance/mobile/ui/screens/index.tsx
@@ -53,8 +53,7 @@ export function UIScreens() {
     isLoading: isReleasesLoading,
   } = useReleaseSelection();
 
-  // TODO: Add transaction.op:ui.load when collecting begins
-  const query = new MutableSearch([]);
+  const query = new MutableSearch(['transaction.op:ui.load']);
 
   const searchQuery = decodeScalar(locationQuery.query, '');
   if (searchQuery) {
@@ -143,8 +142,7 @@ export function UIScreens() {
     );
   }
 
-  // TODO: Add transaction.op:ui.load when collecting begins
-  const tableSearchFilters = new MutableSearch([]);
+  const tableSearchFilters = new MutableSearch(['transaction.op:ui.load']);
 
   const derivedQuery = getTransactionSearchQuery(location, tableEventView.query);
 


### PR DESCRIPTION
We added the transaction op filter (see [here](https://github.com/getsentry/relay/pull/3512)) so I can update these filters to look for `ui.load` data.