### PR TITLE
chore(perf): Add specs for `SpanSummaryPage`

### DIFF
--- a/static/app/views/performance/database/databaseSpanSummaryPage.spec.tsx
+++ b/static/app/views/performance/database/databaseSpanSummaryPage.spec.tsx
@@ -1,0 +1,338 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+import {RouteComponentPropsFixture} from 'sentry-fixture/routeComponentPropsFixture';
+
+import {render, screen, waitForElementToBeRemoved} from 'sentry-test/reactTestingLibrary';
+
+import {useLocation} from 'sentry/utils/useLocation';
+import useOrganization from 'sentry/utils/useOrganization';
+import usePageFilters from 'sentry/utils/usePageFilters';
+import {DatabaseSpanSummaryPage} from 'sentry/views/performance/database/databaseSpanSummaryPage';
+
+jest.mock('sentry/utils/useLocation');
+jest.mock('sentry/utils/usePageFilters');
+jest.mock('sentry/utils/useOrganization');
+
+describe('DatabaseSpanSummaryPage', function () {
+  const organization = OrganizationFixture();
+
+  jest.mocked(usePageFilters).mockReturnValue({
+    isReady: true,
+    desyncedFilters: new Set(),
+    pinnedFilters: new Set(),
+    shouldPersist: true,
+    selection: {
+      datetime: {
+        period: '10d',
+        start: null,
+        end: null,
+        utc: false,
+      },
+      environments: [],
+      projects: [],
+    },
+  });
+
+  jest.mocked(useLocation).mockReturnValue({
+    pathname: '',
+    search: '',
+    query: {statsPeriod: '10d', transactionsCursor: '0:20:0'},
+    hash: '',
+    state: undefined,
+    action: 'PUSH',
+    key: '',
+  });
+
+  jest.mocked(useOrganization).mockReturnValue(organization);
+
+  beforeEach(function () {
+    jest.clearAllMocks();
+  });
+
+  afterAll(function () {
+    jest.resetAllMocks();
+  });
+
+  it('renders', async function () {
+    const eventsRequestMock = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/events/`,
+      method: 'GET',
+      body: {
+        data: [
+          {
+            'span.op': 'db',
+          },
+        ],
+      },
+    });
+
+    const eventsStatsRequestMock = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/events-stats/`,
+      method: 'GET',
+      body: {
+        'spm()': {
+          data: [],
+        },
+        'avg(span.self_time)': {
+          data: [],
+        },
+      },
+    });
+
+    const spanDescriptionRequestMock = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/events/`,
+      match: [
+        MockApiClient.matchQuery({
+          referrer: 'api.starfish.span-description',
+        }),
+      ],
+      method: 'GET',
+      body: {
+        data: [
+          {
+            'span.group': '1756baf8fd19c116',
+          },
+        ],
+      },
+    });
+
+    const transactionListMock = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/events/`,
+      method: 'GET',
+      match: [
+        MockApiClient.matchQuery({
+          referrer: 'api.starfish.span-transaction-metrics',
+        }),
+      ],
+      body: {
+        data: [
+          {
+            transaction: '/api/users',
+            'transaction.method': 'GET',
+            'span.op': 'db',
+            'spm()': 17.88,
+            'avg(span.self_time)': 204.5,
+            'sum(span.self_time)': 177238,
+            'time_spent_percentage()': 0.00341,
+          },
+        ],
+        meta: {
+          fields: {
+            'spm()': 'rate',
+            'avg(span.self_time)': 'duration',
+            'sum(span.self_time)': 'duration',
+            'time_spent_percentage()': 'percentage',
+          },
+        },
+      },
+    });
+
+    render(
+      <DatabaseSpanSummaryPage
+        {...RouteComponentPropsFixture({})}
+        params={{
+          groupId: '1756baf8fd19c116',
+          endpoint: '',
+          endpointMethod: '',
+          transaction: '',
+          transactionMethod: '',
+          spansSort: '',
+        }}
+      />
+    );
+
+    // Metrics ribbon
+    expect(eventsRequestMock).toHaveBeenNthCalledWith(
+      1,
+      `/organizations/${organization.slug}/events/`,
+      expect.objectContaining({
+        method: 'GET',
+        query: {
+          dataset: 'spansMetrics',
+          environment: [],
+          field: [
+            'span.op',
+            'span.description',
+            'span.action',
+            'span.domain',
+            'count()',
+            'spm()',
+            'sum(span.self_time)',
+            'avg(span.self_time)',
+            'time_spent_percentage()',
+            'http_error_count()',
+          ],
+          per_page: 50,
+          project: [],
+          query: 'span.group:1756baf8fd19c116',
+          referrer: 'api.starfish.span-summary-page-metrics',
+          statsPeriod: '10d',
+        },
+      })
+    );
+
+    // Full span description
+    expect(spanDescriptionRequestMock).toHaveBeenNthCalledWith(
+      1,
+      `/organizations/${organization.slug}/events/`,
+      expect.objectContaining({
+        method: 'GET',
+        query: {
+          dataset: 'spansIndexed',
+          environment: [],
+          field: ['project_id', 'transaction.id', 'span.description'],
+          per_page: 1,
+          project: [],
+          query: 'span.group:1756baf8fd19c116',
+          referrer: 'api.starfish.span-description',
+          statsPeriod: '10d',
+        },
+      })
+    );
+
+    // SPM Chart
+    expect(eventsStatsRequestMock).toHaveBeenNthCalledWith(
+      1,
+      `/organizations/${organization.slug}/events-stats/`,
+      expect.objectContaining({
+        method: 'GET',
+        query: {
+          cursor: undefined,
+          dataset: 'spansMetrics',
+          environment: [],
+          excludeOther: 0,
+          field: [],
+          interval: '30m',
+          orderby: undefined,
+          partial: 1,
+          per_page: 50,
+          project: [],
+          query: 'span.group:1756baf8fd19c116',
+          referrer: 'api.starfish.span-summary-page-metrics-chart',
+          statsPeriod: '10d',
+          topEvents: undefined,
+          yAxis: 'spm()',
+        },
+      })
+    );
+
+    // Duration Chart
+    expect(eventsStatsRequestMock).toHaveBeenNthCalledWith(
+      2,
+      `/organizations/${organization.slug}/events-stats/`,
+      expect.objectContaining({
+        method: 'GET',
+        query: {
+          cursor: undefined,
+          dataset: 'spansMetrics',
+          environment: [],
+          excludeOther: 0,
+          field: [],
+          interval: '30m',
+          orderby: undefined,
+          partial: 1,
+          per_page: 50,
+          project: [],
+          query: 'span.group:1756baf8fd19c116',
+          referrer: 'api.starfish.span-summary-page-metrics-chart',
+          statsPeriod: '10d',
+          topEvents: undefined,
+          yAxis: 'avg(span.self_time)',
+        },
+      })
+    );
+
+    // Transactions table
+    expect(transactionListMock).toHaveBeenNthCalledWith(
+      1,
+      `/organizations/${organization.slug}/events/`,
+      expect.objectContaining({
+        method: 'GET',
+        query: {
+          dataset: 'spansMetrics',
+          environment: [],
+          field: [
+            'transaction',
+            'transaction.method',
+            'spm()',
+            'sum(span.self_time)',
+            'avg(span.self_time)',
+            'time_spent_percentage()',
+            'http_error_count()',
+          ],
+          per_page: 25,
+          project: [],
+          query: 'span.group:1756baf8fd19c116',
+          sort: '-time_spent_percentage()',
+          referrer: 'api.starfish.span-transaction-metrics',
+          statsPeriod: '10d',
+        },
+      })
+    );
+
+    expect(spanDescriptionRequestMock).toHaveBeenCalledTimes(1);
+    expect(eventsRequestMock).toHaveBeenCalledTimes(1);
+    expect(eventsStatsRequestMock).toHaveBeenCalledTimes(2);
+    expect(transactionListMock).toHaveBeenCalledTimes(1);
+
+    await waitForElementToBeRemoved(() => screen.queryAllByTestId('loading-indicator'));
+
+    // Span details for query source. This runs after the indexed span has loaded
+    expect(eventsRequestMock).toHaveBeenNthCalledWith(
+      2,
+      `/organizations/${organization.slug}/events/`,
+      expect.objectContaining({
+        method: 'GET',
+        query: {
+          dataset: 'spansIndexed',
+          environment: [],
+          field: [
+            'resource.render_blocking_status',
+            'http.response_content_length',
+            'span.duration',
+            'span.self_time',
+            'span.group',
+            'span.module',
+            'span.description',
+            'span.op',
+            'span_id',
+            'span.action',
+            'span.ai.pipeline.group',
+            'trace',
+            'transaction.id',
+            'transaction.method',
+            'transaction.op',
+            'span.domain',
+            'timestamp',
+            'raw_domain',
+            'project',
+            'project_id',
+          ],
+          per_page: 1,
+          project: [],
+          query: 'span.group:1756baf8fd19c116',
+          sort: '-span.self_time',
+          referrer: 'api.starfish.full-span-from-trace',
+          statsPeriod: '10d',
+        },
+      })
+    );
+
+    expect(screen.getByRole('table', {name: 'Transactions'})).toBeInTheDocument();
+
+    expect(screen.getByRole('columnheader', {name: 'Found In'})).toBeInTheDocument();
+    expect(
+      screen.getByRole('columnheader', {name: 'Queries Per Minute'})
+    ).toBeInTheDocument();
+    expect(screen.getByRole('columnheader', {name: 'Avg Duration'})).toBeInTheDocument();
+    expect(screen.getByRole('columnheader', {name: 'Time Spent'})).toBeInTheDocument();
+
+    expect(screen.getByRole('cell', {name: 'GET /api/users'})).toBeInTheDocument();
+    expect(screen.getByRole('link', {name: 'GET /api/users'})).toHaveAttribute(
+      'href',
+      '/organizations/org-slug/starfish/spans/span/1756baf8fd19c116?statsPeriod=10d&transaction=%2Fapi%2Fusers&transactionMethod=GET&transactionsCursor=0%3A20%3A0'
+    );
+    expect(screen.getByRole('cell', {name: '17.9/s'})).toBeInTheDocument();
+    expect(screen.getByRole('cell', {name: '204.50ms'})).toBeInTheDocument();
+    expect(screen.getByRole('cell', {name: '2.95min'})).toBeInTheDocument();
+  });
+});

--- a/static/app/views/performance/database/databaseSpanSummaryPage.tsx
+++ b/static/app/views/performance/database/databaseSpanSummaryPage.tsx
@@ -1,7 +1,6 @@
 import {Fragment} from 'react';
 import type {RouteComponentProps} from 'react-router';
 import styled from '@emotion/styled';
-import type {Location} from 'history';
 
 import {Breadcrumbs} from 'sentry/components/breadcrumbs';
 import ButtonBar from 'sentry/components/buttonBar';
@@ -45,9 +44,7 @@ type Query = {
   aggregate?: string;
 };
 
-type Props = {
-  location: Location<Query>;
-} & RouteComponentProps<Query, {groupId: string}>;
+type Props = RouteComponentProps<Query, {groupId: string}>;
 
 export function DatabaseSpanSummaryPage({params}: Props) {
   const organization = useOrganization();

--- a/static/app/views/performance/database/databaseSpanSummaryPage.tsx
+++ b/static/app/views/performance/database/databaseSpanSummaryPage.tsx
@@ -1,3 +1,4 @@
+import {Fragment} from 'react';
 import type {RouteComponentProps} from 'react-router';
 import styled from '@emotion/styled';
 import type {Location} from 'history';
@@ -48,7 +49,7 @@ type Props = {
   location: Location<Query>;
 } & RouteComponentProps<Query, {groupId: string}>;
 
-function SpanSummaryPage({params}: Props) {
+export function DatabaseSpanSummaryPage({params}: Props) {
   const organization = useOrganization();
   const location = useLocation<Query>();
 
@@ -127,11 +128,7 @@ function SpanSummaryPage({params}: Props) {
   useSynchronizeCharts([!isThroughputDataLoading && !isDurationDataLoading]);
 
   return (
-    <ModulePageProviders
-      title={[t('Performance'), t('Database'), t('Query Summary')].join(' — ')}
-      baseURL="/performance/database"
-      features="spans-first-ui"
-    >
+    <Fragment>
       <Layout.Header>
         <Layout.HeaderContent>
           <Breadcrumbs
@@ -247,7 +244,7 @@ function SpanSummaryPage({params}: Props) {
           />
         </Layout.Main>
       </Layout.Body>
-    </ModulePageProviders>
+    </Fragment>
   );
 }
 
@@ -283,4 +280,16 @@ const MetricsRibbon = styled('div')`
   gap: ${space(4)};
 `;
 
-export default SpanSummaryPage;
+function PageWithProviders(props) {
+  return (
+    <ModulePageProviders
+      title={[t('Performance'), t('Database'), t('Query Summary')].join(' — ')}
+      baseURL="/performance/database"
+      features="spans-first-ui"
+    >
+      <DatabaseSpanSummaryPage {...props} />
+    </ModulePageProviders>
+  );
+}
+
+export default PageWithProviders;

--- a/static/app/views/starfish/views/spanSummaryPage/spanTransactionsTable.tsx
+++ b/static/app/views/starfish/views/spanSummaryPage/spanTransactionsTable.tsx
@@ -158,6 +158,7 @@ export function SpanTransactionsTable({span, endpoint, endpointMethod, sort}: Pr
         hasData={spanTransactionMetrics.length > 0}
       >
         <GridEditable
+          aria-label={t('Transactions')}
           isLoading={isLoading}
           error={error}
           data={spanTransactionsWithMetrics}


### PR DESCRIPTION
I'm about to do some refactoring here, and I didn't want to until some tests exist.

- Export testable component
- Add table ARIA lable
- Fix incorrect prop typing
- Add spec
