### PR TITLE
ref(hybrid-cloud): Remove success logs on integration proxying

### DIFF
--- a/src/sentry/api/endpoints/internal/integration_proxy.py
+++ b/src/sentry/api/endpoints/internal/integration_proxy.py
@@ -161,8 +161,6 @@ class InternalIntegrationProxyEndpoint(Endpoint):
             logger.info("integration_proxy.failure.invalid_request", extra=self.log_extra)
             metrics.incr("hybrid_cloud.integration_proxy.failure.invalid_request", sample_rate=1.0)
             return False
-
-        logger.info("integration_proxy.valid_request", extra=self.log_extra)
         return True
 
     def _call_third_party_api(self, request, full_url: str, headers) -> HttpResponse:
@@ -218,7 +216,6 @@ class InternalIntegrationProxyEndpoint(Endpoint):
             tags={"status": response.status_code},
             sample_rate=1.0,
         )
-        logger.info("proxy_success", extra=self.log_extra)
         return response
 
     def handle_exception(  # type: ignore[override]

--- a/src/sentry/middleware/integrations/classifications.py
+++ b/src/sentry/middleware/integrations/classifications.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import abc
-import logging
 import re
 from collections.abc import Mapping
 from typing import TYPE_CHECKING, cast
@@ -39,7 +38,6 @@ class BaseClassification(abc.ABC):
 class PluginClassification(BaseClassification):
     plugin_prefix = "/plugins/"
     """Prefix for plugin requests."""
-    logger = logging.getLogger(f"{__name__}.plugin")
 
     def should_operate(self, request: HttpRequest) -> bool:
         from .parsers import PluginRequestParser
@@ -54,14 +52,12 @@ class PluginClassification(BaseClassification):
         from .parsers import PluginRequestParser
 
         rp = PluginRequestParser(request=request, response_handler=self.response_handler)
-        self.logger.info("routing_request.plugin", extra={"path": request.path})
         return rp.get_response()
 
 
 class IntegrationClassification(BaseClassification):
     integration_prefix = "/extensions/"
     """Prefix for all integration requests. See `src/sentry/web/urls.py`"""
-    logger = logging.getLogger(f"{__name__}.integration")
 
     @property
     def integration_parsers(self) -> Mapping[str, type[BaseRequestParser]]:
@@ -153,14 +149,5 @@ class IntegrationClassification(BaseClassification):
             f"hybrid_cloud.integration_control.integration.{parser.provider}",
             tags={"url_name": parser.match.url_name, "status_code": response.status_code},
             sample_rate=1.0,
-        )
-        self.logger.info(
-            f"integration_control.routing_request.{parser.provider}.response",
-            extra={
-                "request.path": request.path,
-                "request.method": request.method,
-                "url_name": parser.match.url_name,
-                "response.status_code": response.status_code,
-            },
         )
         return response


### PR DESCRIPTION
Inspired by @JoshFerge, removing some more logs that are too large in volume to be useful. The useful data is already tracked in metrics so we can just retain logging for failure states and debugging instead.