### PR TITLE
ref: get_jwt returns a str not bytes

### DIFF
--- a/src/sentry_plugins/github/client.py
+++ b/src/sentry_plugins/github/client.py
@@ -94,7 +94,7 @@ class GithubPluginAppsClient(GithubPluginClientMixin, ApiClient):
 
         return self.token
 
-    def get_jwt(self):
+    def get_jwt(self) -> str:
         exp_dt = datetime.datetime.utcnow() + datetime.timedelta(minutes=10)
         exp = calendar.timegm(exp_dt.timetuple())
         # Generate the JWT

--- a/tests/sentry/integrations/github/test_client.py
+++ b/tests/sentry/integrations/github/test_client.py
@@ -38,7 +38,7 @@ GITHUB_CODEOWNERS = {
 
 
 class GitHubAppsClientTest(TestCase):
-    @mock.patch("sentry.integrations.github.client.get_jwt", return_value=b"jwt_token_1")
+    @mock.patch("sentry.integrations.github.client.get_jwt", return_value="jwt_token_1")
     def setUp(self, get_jwt):
         ten_days = timezone.now() + timedelta(days=10)
         self.integration = self.create_integration(
@@ -77,7 +77,7 @@ class GitHubAppsClientTest(TestCase):
                 },
             },
         )
-        with mock.patch("sentry.integrations.github.client.get_jwt", return_value=b"jwt_token_1"):
+        with mock.patch("sentry.integrations.github.client.get_jwt", return_value="jwt_token_1"):
             gh_rate_limit = self.github_client.get_rate_limit()
             assert gh_rate_limit.limit == 5000
             assert gh_rate_limit.remaining == 4999
@@ -101,7 +101,7 @@ class GitHubAppsClientTest(TestCase):
         with pytest.raises(AssertionError):
             self.github_client.get_rate_limit("foo")
 
-    @mock.patch("sentry.integrations.github.client.get_jwt", return_value=b"jwt_token_1")
+    @mock.patch("sentry.integrations.github.client.get_jwt", return_value="jwt_token_1")
     @responses.activate
     def test_check_file(self, get_jwt):
         path = "src/sentry/integrations/github/client.py"
@@ -118,7 +118,7 @@ class GitHubAppsClientTest(TestCase):
         assert isinstance(resp, BaseApiResponse)
         assert resp.status_code == 200
 
-    @mock.patch("sentry.integrations.github.client.get_jwt", return_value=b"jwt_token_1")
+    @mock.patch("sentry.integrations.github.client.get_jwt", return_value="jwt_token_1")
     @responses.activate
     def test_check_no_file(self, get_jwt):
         path = "src/santry/integrations/github/client.py"
@@ -131,7 +131,7 @@ class GitHubAppsClientTest(TestCase):
             self.github_client.check_file(self.repo, path, version)
         assert responses.calls[0].response.status_code == 404
 
-    @mock.patch("sentry.integrations.github.client.get_jwt", return_value=b"jwt_token_1")
+    @mock.patch("sentry.integrations.github.client.get_jwt", return_value="jwt_token_1")
     @responses.activate
     def test_get_stacktrace_link(self, get_jwt):
         path = "/src/sentry/integrations/github/client.py"
@@ -152,7 +152,7 @@ class GitHubAppsClientTest(TestCase):
             == "https://github.com/Test-Organization/foo/blob/master/src/sentry/integrations/github/client.py"
         )
 
-    @mock.patch("sentry.integrations.github.client.get_jwt", return_value=b"jwt_token_1")
+    @mock.patch("sentry.integrations.github.client.get_jwt", return_value="jwt_token_1")
     @responses.activate
     def test_get_with_pagination(self, get_jwt):
         url = f"https://api.github.com/repos/{self.repo.name}/assignees?per_page={self.github_client.page_size}"
@@ -188,7 +188,7 @@ class GitHubAppsClientTest(TestCase):
         assert len(responses.calls) == 4
         assert responses.calls[0].response.status_code == 200
 
-    @mock.patch("sentry.integrations.github.client.get_jwt", return_value=b"jwt_token_1")
+    @mock.patch("sentry.integrations.github.client.get_jwt", return_value="jwt_token_1")
     @responses.activate
     def test_get_with_pagination_only_one_page(self, get_jwt):
         url = f"https://api.github.com/repos/{self.repo.name}/assignees?per_page={self.github_client.page_size}"
@@ -203,7 +203,7 @@ class GitHubAppsClientTest(TestCase):
         "sentry.integrations.github.integration.GitHubIntegration.check_file",
         return_value=GITHUB_CODEOWNERS["html_url"],
     )
-    @mock.patch("sentry.integrations.github.client.get_jwt", return_value=b"jwt_token_1")
+    @mock.patch("sentry.integrations.github.client.get_jwt", return_value="jwt_token_1")
     @responses.activate
     def test_get_codeowner_file(self, mock_jwt, mock_check_file):
         self.config = self.create_code_mapping(
@@ -235,7 +235,7 @@ class GitHubAppsClientTest(TestCase):
         )
         repo_key = f"github:repo:{self.repo.name}:source-code"
         assert cache.get(repo_key) is None
-        with mock.patch("sentry.integrations.github.client.get_jwt", return_value=b"jwt_token_1"):
+        with mock.patch("sentry.integrations.github.client.get_jwt", return_value="jwt_token_1"):
             files = self.github_client.get_cached_repo_files(self.repo.name, "master")
             assert cache.get(repo_key) == files
             # Calling a second time should work
@@ -262,11 +262,11 @@ class GitHubAppsClientTest(TestCase):
         )
         repo_key = f"github:repo:{self.repo.name}:all"
         assert cache.get(repo_key) is None
-        with mock.patch("sentry.integrations.github.client.get_jwt", return_value=b"jwt_token_1"):
+        with mock.patch("sentry.integrations.github.client.get_jwt", return_value="jwt_token_1"):
             files = self.github_client.get_cached_repo_files(self.repo.name, "master")
             assert files == ["src/foo.py"]
 
-    @mock.patch("sentry.integrations.github.client.get_jwt", return_value=b"jwt_token_1")
+    @mock.patch("sentry.integrations.github.client.get_jwt", return_value="jwt_token_1")
     @responses.activate
     def test_update_comment(self, get_jwt):
         responses.add(
@@ -309,7 +309,7 @@ class GitHubAppsClientTest(TestCase):
         assert responses.calls[1].response.status_code == 200
         assert responses.calls[1].request.body == b'{"body": "world"}'
 
-    @mock.patch("sentry.integrations.github.client.get_jwt", return_value=b"jwt_token_1")
+    @mock.patch("sentry.integrations.github.client.get_jwt", return_value="jwt_token_1")
     @responses.activate
     def test_get_comment_reactions(self, get_jwt):
         comment_reactions = {
@@ -549,7 +549,7 @@ class GithubProxyClientTest(TestCase):
 
 
 class GitHubClientFileBlameBase(TestCase):
-    @mock.patch("sentry.integrations.github.client.get_jwt", return_value=b"jwt_token_1")
+    @mock.patch("sentry.integrations.github.client.get_jwt", return_value="jwt_token_1")
     def setUp(self, get_jwt):
         integration = self.create_integration(
             organization=self.organization,
@@ -614,7 +614,7 @@ class GitHubClientFileBlameBase(TestCase):
 
 
 class GitHubClientFileBlameIntegrationDisableTest(TestCase):
-    @mock.patch("sentry.integrations.github.client.get_jwt", return_value=b"jwt_token_1")
+    @mock.patch("sentry.integrations.github.client.get_jwt", return_value="jwt_token_1")
     def setUp(self, get_jwt):
         ten_days = timezone.now() + timedelta(days=10)
         self.integration = self.create_integration(
@@ -787,7 +787,7 @@ class GitHubClientFileBlameQueryBuilderTest(GitHubClientFileBlameBase):
     def setUp(self):
         super().setUp()
 
-    @mock.patch("sentry.integrations.github.client.get_jwt", return_value=b"jwt_token_1")
+    @mock.patch("sentry.integrations.github.client.get_jwt", return_value="jwt_token_1")
     @responses.activate
     def test_get_blame_for_files_same_repo(self, get_jwt):
         """
@@ -877,7 +877,7 @@ class GitHubClientFileBlameQueryBuilderTest(GitHubClientFileBlameBase):
             "path_0_0_1": "src/sentry/integrations/github/client_2.py",
         }
 
-    @mock.patch("sentry.integrations.github.client.get_jwt", return_value=b"jwt_token_1")
+    @mock.patch("sentry.integrations.github.client.get_jwt", return_value="jwt_token_1")
     @responses.activate
     def test_get_blame_for_files_different_repos(self, get_jwt):
         """
@@ -995,7 +995,7 @@ class GitHubClientFileBlameQueryBuilderTest(GitHubClientFileBlameBase):
             "path_1_0_0": "src/getsentry/file.py",
         }
 
-    @mock.patch("sentry.integrations.github.client.get_jwt", return_value=b"jwt_token_1")
+    @mock.patch("sentry.integrations.github.client.get_jwt", return_value="jwt_token_1")
     @responses.activate
     def test_get_blame_for_files_different_refs(self, get_jwt):
         """
@@ -1092,7 +1092,7 @@ class GitHubClientFileBlameQueryBuilderTest(GitHubClientFileBlameBase):
             "path_0_1_0": "src/sentry/integrations/github/client.py",
         }
 
-    @mock.patch("sentry.integrations.github.client.get_jwt", return_value=b"jwt_token_1")
+    @mock.patch("sentry.integrations.github.client.get_jwt", return_value="jwt_token_1")
     @responses.activate
     def test_trim_file_path_for_query(self, get_jwt):
         """
@@ -1247,7 +1247,7 @@ class GitHubClientFileBlameResponseTest(GitHubClientFileBlameBase):
             }
         }
 
-    @mock.patch("sentry.integrations.github.client.get_jwt", return_value=b"jwt_token_1")
+    @mock.patch("sentry.integrations.github.client.get_jwt", return_value="jwt_token_1")
     @responses.activate
     def test_get_blame_for_files_full_response(self, get_jwt):
         """
@@ -1302,7 +1302,7 @@ class GitHubClientFileBlameResponseTest(GitHubClientFileBlameBase):
             ],
         )
 
-    @mock.patch("sentry.integrations.github.client.get_jwt", return_value=b"jwt_token_1")
+    @mock.patch("sentry.integrations.github.client.get_jwt", return_value="jwt_token_1")
     @responses.activate
     def test_get_cached_blame_for_files_full_response(self, get_jwt):
         """
@@ -1379,7 +1379,7 @@ class GitHubClientFileBlameResponseTest(GitHubClientFileBlameBase):
             self.github_client.get_blame_for_files([self.file1, self.file2], extra={}) != response
         )
 
-    @mock.patch("sentry.integrations.github.client.get_jwt", return_value=b"jwt_token_1")
+    @mock.patch("sentry.integrations.github.client.get_jwt", return_value="jwt_token_1")
     @responses.activate
     def test_get_blame_for_files_response_partial_data(self, get_jwt):
         """
@@ -1467,7 +1467,7 @@ class GitHubClientFileBlameResponseTest(GitHubClientFileBlameBase):
         )
 
     @mock.patch("sentry.integrations.github.client.logger.error")
-    @mock.patch("sentry.integrations.github.client.get_jwt", return_value=b"jwt_token_1")
+    @mock.patch("sentry.integrations.github.client.get_jwt", return_value="jwt_token_1")
     @responses.activate
     def test_get_blame_for_files_invalid_commit(self, get_jwt, mock_logger_error):
         """
@@ -1611,7 +1611,7 @@ class GitHubClientFileBlameRateLimitTest(GitHubClientFileBlameBase):
         )
 
     @mock.patch("sentry.integrations.github.client.logger.error")
-    @mock.patch("sentry.integrations.github.client.get_jwt", return_value=b"jwt_token_1")
+    @mock.patch("sentry.integrations.github.client.get_jwt", return_value="jwt_token_1")
     @responses.activate
     def test_rate_limit_exceeded(self, get_jwt, mock_logger_error):
         with pytest.raises(ApiRateLimitedError):
@@ -1627,7 +1627,7 @@ class GitHubClientFileBlameRateLimitTest(GitHubClientFileBlameBase):
             },
         )
 
-    @mock.patch("sentry.integrations.github.client.get_jwt", return_value=b"jwt_token_1")
+    @mock.patch("sentry.integrations.github.client.get_jwt", return_value="jwt_token_1")
     @responses.activate
     def test_no_rate_limiting(self, get_jwt):
         """

--- a/tests/sentry/integrations/github/test_installation.py
+++ b/tests/sentry/integrations/github/test_installation.py
@@ -23,7 +23,7 @@ class InstallationEndpointTest(APITestCase):
         options.set("github-app.webhook-secret", self.secret)
 
     @responses.activate
-    @patch("sentry.integrations.github.client.get_jwt", return_value=b"jwt_token_1")
+    @patch("sentry.integrations.github.client.get_jwt", return_value="jwt_token_1")
     def test_installation_endpoint(self, get_jwt):
         # add installation via GitHub webhook
         responses.add(

--- a/tests/sentry/integrations/github/test_repository.py
+++ b/tests/sentry/integrations/github/test_repository.py
@@ -74,7 +74,7 @@ class GitHubAppsProviderTest(TestCase):
             "url": "https://github.com/getsentry/example-repo",
         }
 
-    @mock.patch("sentry.integrations.github.client.get_jwt", return_value=b"jwt_token_1")
+    @mock.patch("sentry.integrations.github.client.get_jwt", return_value="jwt_token_1")
     @responses.activate
     def test_compare_commits_no_start(self, get_jwt):
         responses.add(
@@ -101,7 +101,7 @@ class GitHubAppsProviderTest(TestCase):
         with pytest.raises(IntegrationError):
             self.provider.compare_commits(self.repository, None, "abcdef")
 
-    @mock.patch("sentry.integrations.github.client.get_jwt", return_value=b"jwt_token_1")
+    @mock.patch("sentry.integrations.github.client.get_jwt", return_value="jwt_token_1")
     @responses.activate
     def test_compare_commits(self, get_jwt):
         responses.add(
@@ -118,7 +118,7 @@ class GitHubAppsProviderTest(TestCase):
         for commit in result:
             assert_commit_shape(commit)
 
-    @mock.patch("sentry.integrations.github.client.get_jwt", return_value=b"jwt_token_1")
+    @mock.patch("sentry.integrations.github.client.get_jwt", return_value="jwt_token_1")
     @responses.activate
     def test_compare_commits_patchset_handling(self, get_jwt):
         responses.add(
@@ -140,7 +140,7 @@ class GitHubAppsProviderTest(TestCase):
         assert patchset[3] == {"path": "old_name.txt", "type": "D"}
         assert patchset[4] == {"path": "renamed.txt", "type": "A"}
 
-    @mock.patch("sentry.integrations.github.client.get_jwt", return_value=b"jwt_token_1")
+    @mock.patch("sentry.integrations.github.client.get_jwt", return_value="jwt_token_1")
     @responses.activate
     def test_patchset_caching(self, get_jwt):
         responses.add(

--- a/tests/sentry/integrations/github/test_webhooks.py
+++ b/tests/sentry/integrations/github/test_webhooks.py
@@ -78,7 +78,7 @@ class InstallationEventWebhookTest(APITestCase):
         options.set("github-app.webhook-secret", self.secret)
 
     @responses.activate
-    @patch("sentry.integrations.github.client.get_jwt", return_value=b"jwt_token_1")
+    @patch("sentry.integrations.github.client.get_jwt", return_value="jwt_token_1")
     def test_installation_created(self, get_jwt):
         responses.add(
             method=responses.GET,
@@ -115,7 +115,7 @@ class InstallationDeleteEventWebhookTest(APITestCase):
         self.secret = "b3002c3e321d4b7880360d397db2ccfd"
         options.set("github-app.webhook-secret", self.secret)
 
-    @patch("sentry.integrations.github.client.get_jwt", return_value=b"jwt_token_1")
+    @patch("sentry.integrations.github.client.get_jwt", return_value="jwt_token_1")
     def test_installation_deleted(self, get_jwt):
         project = self.project  # force creation
 
@@ -156,7 +156,7 @@ class InstallationDeleteEventWebhookTest(APITestCase):
             repo.refresh_from_db()
             assert repo.status == ObjectStatus.DISABLED
 
-    @patch("sentry.integrations.github.client.get_jwt", return_value=b"jwt_token_1")
+    @patch("sentry.integrations.github.client.get_jwt", return_value="jwt_token_1")
     def test_installation_deleted_no_org_integration(self, get_jwt):
         project = self.project  # force creation
 
@@ -221,6 +221,7 @@ class PushEventWebhookTest(APITestCase):
 
         assert response.status_code == 204
 
+    @responses.activate
     def test_simple(self):
         project = self.project  # force creation
 
@@ -267,6 +268,7 @@ class PushEventWebhookTest(APITestCase):
         repo.refresh_from_db()
         assert set(repo.languages) == {"python", "javascript"}
 
+    @responses.activate
     @patch("sentry.integrations.github.webhook.metrics")
     def test_creates_missing_repo(self, mock_metrics):
         project = self.project  # force creation
@@ -349,6 +351,7 @@ class PushEventWebhookTest(APITestCase):
         repo.refresh_from_db()
         assert set(repo.languages) == {"python", "javascript"}
 
+    @responses.activate
     def test_multiple_orgs(self):
         project = self.project  # force creation
 
@@ -414,6 +417,7 @@ class PushEventWebhookTest(APITestCase):
         )
         assert len(commit_list) == 0
 
+    @responses.activate
     @patch("sentry.integrations.github.webhook.metrics")
     def test_multiple_orgs_creates_missing_repos(self, mock_metrics):
         project = self.project  # force creation

--- a/tests/sentry/integrations/github_enterprise/test_webhooks.py
+++ b/tests/sentry/integrations/github_enterprise/test_webhooks.py
@@ -117,7 +117,7 @@ class PushEventWebhookTest(APITestCase):
             status=204,
         )
 
-        mock_get_jwt.return_value = b""
+        mock_get_jwt.return_value = ""
         mock_get_installation_metadata.return_value = self.metadata
 
         self.create_integration(
@@ -240,7 +240,7 @@ class PushEventWebhookTest(APITestCase):
             status=204,
         )
 
-        mock_get_jwt.return_value = b""
+        mock_get_jwt.return_value = ""
         mock_get_installation_metadata.return_value = self.metadata
 
         self.create_integration(

--- a/tests/sentry/plugins/test_integration_repository.py
+++ b/tests/sentry/plugins/test_integration_repository.py
@@ -13,7 +13,7 @@ from sentry.shared_integrations.exceptions import IntegrationError
 from sentry.testutils.cases import TestCase
 
 
-@patch("sentry.integrations.github.client.get_jwt", return_value=b"jwt_token_1")
+@patch("sentry.integrations.github.client.get_jwt", return_value="jwt_token_1")
 class IntegrationRepositoryTestCase(TestCase):
     @responses.activate
     def setUp(self):

--- a/tests/sentry/tasks/integrations/github/test_pr_comment.py
+++ b/tests/sentry/tasks/integrations/github/test_pr_comment.py
@@ -88,7 +88,7 @@ class GithubCommentTestCase(IntegrationTestCase):
         self.pr_key = 1
         self.commit_sha = 1
         self.fingerprint = 1
-        patch("sentry.integrations.github.client.get_jwt", return_value=b"jwt_token_1").start()
+        patch("sentry.integrations.github.client.get_jwt", return_value="jwt_token_1").start()
 
     def add_commit_to_repo(self, repo, user, project):
         if user not in self.user_to_commit_author_map:

--- a/tests/sentry/tasks/integrations/test_link_all_repos.py
+++ b/tests/sentry/tasks/integrations/test_link_all_repos.py
@@ -14,7 +14,7 @@ from sentry.testutils.silo import assume_test_silo_mode, control_silo_test
 
 
 @control_silo_test
-@patch("sentry.integrations.github.client.get_jwt", return_value=b"jwt_token_1")
+@patch("sentry.integrations.github.client.get_jwt", return_value="jwt_token_1")
 class LinkAllReposTestCase(IntegrationTestCase):
     provider = GitHubIntegrationProvider
     base_url = "https://api.github.com"

--- a/tests/sentry/tasks/test_commit_context.py
+++ b/tests/sentry/tasks/test_commit_context.py
@@ -891,7 +891,7 @@ class TestGHCommentQueuing(IntegrationTestCase, TestCommitContextMixin):
             )
             assert not mock_comment_workflow.called
 
-    @patch("sentry.integrations.github.client.get_jwt", return_value=b"jwt_token_1")
+    @patch("sentry.integrations.github.client.get_jwt", return_value="jwt_token_1")
     @responses.activate
     def test_gh_comment_no_pr_from_api(
         self, get_jwt, mock_comment_workflow, mock_get_commit_context
@@ -918,7 +918,7 @@ class TestGHCommentQueuing(IntegrationTestCase, TestCommitContextMixin):
             )
             assert not mock_comment_workflow.called
 
-    @patch("sentry.integrations.github.client.get_jwt", return_value=b"jwt_token_1")
+    @patch("sentry.integrations.github.client.get_jwt", return_value="jwt_token_1")
     @patch("sentry_sdk.capture_exception")
     @responses.activate
     def test_gh_comment_api_error(
@@ -945,7 +945,7 @@ class TestGHCommentQueuing(IntegrationTestCase, TestCommitContextMixin):
             assert mock_capture_exception.called
             assert not mock_comment_workflow.called
 
-    @patch("sentry.integrations.github.client.get_jwt", return_value=b"jwt_token_1")
+    @patch("sentry.integrations.github.client.get_jwt", return_value="jwt_token_1")
     @responses.activate
     def test_gh_comment_commit_not_in_default_branch(
         self, get_jwt, mock_comment_workflow, mock_get_commit_context
@@ -970,7 +970,7 @@ class TestGHCommentQueuing(IntegrationTestCase, TestCommitContextMixin):
             )
             assert not mock_comment_workflow.called
 
-    @patch("sentry.integrations.github.client.get_jwt", return_value=b"jwt_token_1")
+    @patch("sentry.integrations.github.client.get_jwt", return_value="jwt_token_1")
     @responses.activate
     def test_gh_comment_no_pr_from_query(
         self, get_jwt, mock_comment_workflow, mock_get_commit_context
@@ -992,7 +992,7 @@ class TestGHCommentQueuing(IntegrationTestCase, TestCommitContextMixin):
             )
             assert not mock_comment_workflow.called
 
-    @patch("sentry.integrations.github.client.get_jwt", return_value=b"jwt_token_1")
+    @patch("sentry.integrations.github.client.get_jwt", return_value="jwt_token_1")
     @responses.activate
     def test_gh_comment_pr_too_old(self, get_jwt, mock_comment_workflow, mock_get_commit_context):
         """No comment on pr that's older than PR_COMMENT_WINDOW"""
@@ -1014,7 +1014,7 @@ class TestGHCommentQueuing(IntegrationTestCase, TestCommitContextMixin):
             assert not mock_comment_workflow.called
             assert len(PullRequestCommit.objects.all()) == 0
 
-    @patch("sentry.integrations.github.client.get_jwt", return_value=b"jwt_token_1")
+    @patch("sentry.integrations.github.client.get_jwt", return_value="jwt_token_1")
     @responses.activate
     def test_gh_comment_pr_info_level_issue(
         self, get_jwt, mock_comment_workflow, mock_get_commit_context
@@ -1039,7 +1039,7 @@ class TestGHCommentQueuing(IntegrationTestCase, TestCommitContextMixin):
             assert not mock_comment_workflow.called
             assert len(PullRequestCommit.objects.all()) == 0
 
-    @patch("sentry.integrations.github.client.get_jwt", return_value=b"jwt_token_1")
+    @patch("sentry.integrations.github.client.get_jwt", return_value="jwt_token_1")
     @responses.activate
     def test_gh_comment_repeat_issue(self, get_jwt, mock_comment_workflow, mock_get_commit_context):
         """No comment on a pr that has a comment with the issue in the same pr list"""
@@ -1061,7 +1061,7 @@ class TestGHCommentQueuing(IntegrationTestCase, TestCommitContextMixin):
             assert not mock_comment_workflow.called
             assert len(PullRequestCommit.objects.all()) == 0
 
-    @patch("sentry.integrations.github.client.get_jwt", return_value=b"jwt_token_1")
+    @patch("sentry.integrations.github.client.get_jwt", return_value="jwt_token_1")
     @responses.activate
     def test_gh_comment_create_queued(
         self, get_jwt, mock_comment_workflow, mock_get_commit_context
@@ -1087,7 +1087,7 @@ class TestGHCommentQueuing(IntegrationTestCase, TestCommitContextMixin):
             assert len(pr_commits) == 1
             assert pr_commits[0].commit == self.commit
 
-    @patch("sentry.integrations.github.client.get_jwt", return_value=b"jwt_token_1")
+    @patch("sentry.integrations.github.client.get_jwt", return_value="jwt_token_1")
     @responses.activate
     def test_gh_comment_create_queued_existing_pr_commit(
         self, get_jwt, mock_comment_workflow, mock_get_commit_context
@@ -1116,7 +1116,7 @@ class TestGHCommentQueuing(IntegrationTestCase, TestCommitContextMixin):
             assert len(pr_commits) == 1
             assert pr_commits[0] == pr_commit
 
-    @patch("sentry.integrations.github.client.get_jwt", return_value=b"jwt_token_1")
+    @patch("sentry.integrations.github.client.get_jwt", return_value="jwt_token_1")
     @responses.activate
     def test_gh_comment_update_queue(self, get_jwt, mock_comment_workflow, mock_get_commit_context):
         """Task queued if new issue for prior comment"""
@@ -1155,7 +1155,7 @@ class TestGHCommentQueuing(IntegrationTestCase, TestCommitContextMixin):
             assert not mock_comment_workflow.called
             assert len(PullRequestCommit.objects.all()) == 0
 
-    @patch("sentry.integrations.github.client.get_jwt", return_value=b"jwt_token_1")
+    @patch("sentry.integrations.github.client.get_jwt", return_value="jwt_token_1")
     @responses.activate
     def test_gh_comment_debounces(self, get_jwt, mock_comment_workflow, mock_get_commit_context):
         mock_get_commit_context.return_value = [self.blame]
@@ -1188,7 +1188,7 @@ class TestGHCommentQueuing(IntegrationTestCase, TestCommitContextMixin):
             )
             assert mock_comment_workflow.call_count == 1
 
-    @patch("sentry.integrations.github.client.get_jwt", return_value=b"jwt_token_1")
+    @patch("sentry.integrations.github.client.get_jwt", return_value="jwt_token_1")
     @responses.activate
     def test_gh_comment_multiple_comments(
         self, get_jwt, mock_comment_workflow, mock_get_commit_context


### PR DESCRIPTION
split out from my "enable bytes warnings" branch

I also needed to add some `responses` mocks as these tests were hitting public github (!!!)

<!-- Describe your PR here. -->