### PR TITLE
feat(new-trace): Fixing trace issue table header

### DIFF
--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/issues/issues.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/issues/issues.tsx
@@ -207,7 +207,7 @@ function IssueListHeader({
                 count: errorIssues.length,
                 text: errorIssues.length > 1 ? plural : singular,
               })
-            : performanceIssues.length > 0 && performanceIssues.length === 0
+            : performanceIssues.length > 0 && errorIssues.length === 0
               ? tct('[count] [text]', {
                   count: performanceIssues.length,
                   text: tn(


### PR DESCRIPTION
This table in the trace drawer should just say '1 Performance Issue': 
<img width="640" alt="Screenshot 2024-05-06 at 3 55 00 PM" src="https://github.com/getsentry/sentry/assets/60121741/efe3dbd0-9ba4-4d7c-9956-b73be0f11a3e">
