### PR TITLE
ref(seer-grouping): Switch to using `hash` and `parent_hash` from `group_hash` and `parent_group_hash`

### DIFF
--- a/src/sentry/api/endpoints/group_similar_issues_embeddings.py
+++ b/src/sentry/api/endpoints/group_similar_issues_embeddings.py
@@ -162,7 +162,7 @@ class GroupSimilarIssuesEmbeddingsEndpoint(GroupEndpoint):
 
         similar_issues_params: SimilarIssuesEmbeddingsRequest = {
             "group_id": group.id,
-            "group_hash": latest_event.get_primary_hash(),
+            "hash": latest_event.get_primary_hash(),
             "project_id": group.project.id,
             "stacktrace": stacktrace_string,
             "message": group.message,
@@ -184,7 +184,7 @@ class GroupSimilarIssuesEmbeddingsEndpoint(GroupEndpoint):
             organization_id=group.organization.id,
             project_id=group.project.id,
             group_id=group.id,
-            group_hash=latest_event.get_primary_hash(),
+            hash=latest_event.get_primary_hash(),
             count_over_threshold=len(
                 [
                     result.stacktrace_distance

--- a/src/sentry/seer/utils.py
+++ b/src/sentry/seer/utils.py
@@ -102,7 +102,7 @@ class SimilarIssuesEmbeddingsRequest(TypedDict):
     k: NotRequired[int]  # how many neighbors to find
     threshold: NotRequired[float]
     group_id: NotRequired[int]  # TODO: Remove this once we stop sending it to seer
-    group_hash: NotRequired[str]  # TODO: Make this required once id -> hash change is done
+    hash: NotRequired[str]  # TODO: Make this required once id -> hash change is done
 
 
 class RawSeerSimilarIssueData(TypedDict):
@@ -110,7 +110,7 @@ class RawSeerSimilarIssueData(TypedDict):
     message_distance: float
     should_group: bool
     parent_group_id: NotRequired[int]  # TODO: Remove this once seer stops sending it
-    parent_group_hash: NotRequired[str]  # TODO: Make this required once id -> hash change is done
+    parent_hash: NotRequired[str]  # TODO: Make this required once id -> hash change is done
 
 
 class SimilarIssuesEmbeddingsResponse(TypedDict):
@@ -125,7 +125,7 @@ class SeerSimilarIssueData:
     should_group: bool
     parent_group_id: int
     # TODO: See if we end up needing the hash here
-    parent_group_hash: str | None = None
+    parent_hash: str | None = None
 
     @classmethod
     def from_raw(cls, project_id: int, raw_similar_issue_data: RawSeerSimilarIssueData) -> Self:
@@ -141,12 +141,12 @@ class SeerSimilarIssueData:
 
         """
         similar_issue_data = raw_similar_issue_data
-        parent_group_hash = raw_similar_issue_data.get("parent_group_hash")
+        parent_hash = raw_similar_issue_data.get("parent_hash")
         parent_group_id = raw_similar_issue_data.get("parent_group_id")
 
-        if not parent_group_id and not parent_group_hash:
+        if not parent_group_id and not parent_hash:
             raise IncompleteSeerDataError(
-                "Seer similar issues response missing both `parent_group_id` and `parent_group_hash`"
+                "Seer similar issues response missing both `parent_group_id` and `parent_hash`"
             )
 
         if parent_group_id:
@@ -155,7 +155,7 @@ class SeerSimilarIssueData:
 
         else:
             parent_grouphash = (
-                GroupHash.objects.filter(project_id=project_id, hash=parent_group_hash)
+                GroupHash.objects.filter(project_id=project_id, hash=parent_hash)
                 .exclude(state=GroupHash.State.LOCKED_IN_MIGRATION)
                 .first()
             )

--- a/tests/sentry/api/endpoints/test_group_similar_issues_embeddings.py
+++ b/tests/sentry/api/endpoints/test_group_similar_issues_embeddings.py
@@ -662,14 +662,14 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
         similar_issue_data_1 = SeerSimilarIssueData(
             message_distance=0.05,
             parent_group_id=NonNone(self.similar_event.group_id),
-            parent_group_hash=NonNone(self.similar_event.get_primary_hash()),
+            parent_hash=NonNone(self.similar_event.get_primary_hash()),
             should_group=True,
             stacktrace_distance=0.01,
         )
         similar_issue_data_2 = SeerSimilarIssueData(
             message_distance=0.49,
             parent_group_id=NonNone(event_from_second_similar_group.group_id),
-            parent_group_hash=NonNone(event_from_second_similar_group.get_primary_hash()),
+            parent_hash=NonNone(event_from_second_similar_group.get_primary_hash()),
             should_group=False,
             stacktrace_distance=0.23,
         )
@@ -720,7 +720,7 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
 
         expected_seer_request_params = {
             "group_id": self.group.id,
-            "group_hash": NonNone(self.event.get_primary_hash()),
+            "hash": NonNone(self.event.get_primary_hash()),
             "project_id": self.project.id,
             "stacktrace": EXPECTED_STACKTRACE_STRING,
             "message": self.group.message,
@@ -748,7 +748,7 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
             "responses": [
                 {
                     "message_distance": 0.05,
-                    "parent_group_hash": NonNone(self.similar_event.get_primary_hash()),
+                    "parent_hash": NonNone(self.similar_event.get_primary_hash()),
                     "should_group": True,
                     "stacktrace_distance": 0.01,
                 }
@@ -767,7 +767,7 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
 
         expected_seer_request_params = {
             "group_id": self.group.id,
-            "group_hash": NonNone(self.event.get_primary_hash()),
+            "hash": NonNone(self.event.get_primary_hash()),
             "project_id": self.project.id,
             "stacktrace": EXPECTED_STACKTRACE_STRING,
             "message": self.group.message,
@@ -797,7 +797,7 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
                 {
                     "message_distance": 0.05,
                     "parent_group_id": NonNone(self.similar_event.group_id),
-                    "parent_group_hash": NonNone(self.similar_event.get_primary_hash()),
+                    "parent_hash": NonNone(self.similar_event.get_primary_hash()),
                     "should_group": True,
                     "stacktrace_distance": 0.01,
                 }
@@ -816,7 +816,7 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
 
         expected_seer_request_params = {
             "group_id": self.group.id,
-            "group_hash": NonNone(self.event.get_primary_hash()),
+            "hash": NonNone(self.event.get_primary_hash()),
             "project_id": self.project.id,
             "stacktrace": EXPECTED_STACKTRACE_STRING,
             "message": self.group.message,
@@ -848,21 +848,21 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
                 {
                     "message_distance": 0.05,
                     "parent_group_id": NonNone(self.similar_event.group_id),
-                    "parent_group_hash": NonNone(self.similar_event.get_primary_hash()),
+                    "parent_hash": NonNone(self.similar_event.get_primary_hash()),
                     "should_group": True,
                     "stacktrace_distance": 0.002,  # Over threshold
                 },
                 {
                     "message_distance": 0.05,
                     "parent_group_id": NonNone(over_threshold_group_event.group_id),
-                    "parent_group_hash": NonNone(over_threshold_group_event.get_primary_hash()),
+                    "parent_hash": NonNone(over_threshold_group_event.get_primary_hash()),
                     "should_group": True,
                     "stacktrace_distance": 0.002,  # Over threshold
                 },
                 {
                     "message_distance": 0.05,
                     "parent_group_id": NonNone(under_threshold_group_event.group_id),
-                    "parent_group_hash": NonNone(under_threshold_group_event.get_primary_hash()),
+                    "parent_hash": NonNone(under_threshold_group_event.get_primary_hash()),
                     "should_group": False,
                     "stacktrace_distance": 0.05,  # Under threshold
                 },
@@ -891,7 +891,7 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
             organization_id=self.org.id,
             project_id=self.project.id,
             group_id=self.group.id,
-            group_hash=NonNone(self.event.get_primary_hash()),
+            hash=NonNone(self.event.get_primary_hash()),
             count_over_threshold=2,
             user_id=self.user.id,
         )
@@ -900,14 +900,14 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
     @mock.patch("sentry.seer.utils.logger")
     @mock.patch("sentry.seer.utils.seer_staging_connection_pool.urlopen")
     def test_incomplete_return_data(self, mock_seer_request, mock_logger):
-        # Two suggested groups, one with valid data, one missing both parent group id and parent group hash.
+        # Two suggested groups, one with valid data, one missing both parent group id and parent hash.
         # We should log the second and return the first.
         seer_return_value: SimilarIssuesEmbeddingsResponse = {
             "responses": [
                 {
                     "message_distance": 0.05,
                     "parent_group_id": NonNone(self.similar_event.group_id),
-                    "parent_group_hash": NonNone(self.similar_event.get_primary_hash()),
+                    "parent_hash": NonNone(self.similar_event.get_primary_hash()),
                     "should_group": True,
                     "stacktrace_distance": 0.01,
                 },
@@ -923,11 +923,11 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
         response = self.client.get(self.path)
 
         mock_logger.exception.assert_called_with(
-            "Seer similar issues response missing both `parent_group_id` and `parent_group_hash`",
+            "Seer similar issues response missing both `parent_group_id` and `parent_hash`",
             extra={
                 "request_params": {
                     "group_id": NonNone(self.event.group_id),
-                    "group_hash": NonNone(self.event.get_primary_hash()),
+                    "hash": NonNone(self.event.get_primary_hash()),
                     "project_id": self.project.id,
                     "stacktrace": EXPECTED_STACKTRACE_STRING,
                     "message": self.group.message,
@@ -958,14 +958,14 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
                 {
                     "message_distance": 0.05,
                     "parent_group_id": NonNone(self.similar_event.group_id),
-                    "parent_group_hash": NonNone(self.similar_event.get_primary_hash()),
+                    "parent_hash": NonNone(self.similar_event.get_primary_hash()),
                     "should_group": True,
                     "stacktrace_distance": 0.01,
                 },
                 {
                     "message_distance": 0.05,
                     "parent_group_id": 1121201212312012,  # too high to be real
-                    "parent_group_hash": "not a real hash",
+                    "parent_hash": "not a real hash",
                     "should_group": True,
                     "stacktrace_distance": 0.01,
                 },
@@ -979,7 +979,7 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
             extra={
                 "request_params": {
                     "group_id": NonNone(self.event.group_id),
-                    "group_hash": NonNone(self.event.get_primary_hash()),
+                    "hash": NonNone(self.event.get_primary_hash()),
                     "project_id": self.project.id,
                     "stacktrace": EXPECTED_STACKTRACE_STRING,
                     "message": self.group.message,
@@ -987,7 +987,7 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
                 "raw_similar_issue_data": {
                     "message_distance": 0.05,
                     "parent_group_id": 1121201212312012,
-                    "parent_group_hash": "not a real hash",
+                    "parent_hash": "not a real hash",
                     "should_group": True,
                     "stacktrace_distance": 0.01,
                 },
@@ -1010,7 +1010,7 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
             organization_id=self.org.id,
             project_id=self.project.id,
             group_id=self.group.id,
-            group_hash=NonNone(self.event.get_primary_hash()),
+            hash=NonNone(self.event.get_primary_hash()),
             count_over_threshold=0,
             user_id=self.user.id,
         )
@@ -1079,7 +1079,7 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
                 {
                     "message_distance": 0.05,
                     "parent_group_id": NonNone(self.similar_event.group_id),
-                    "parent_group_hash": NonNone(self.similar_event.get_primary_hash()),
+                    "parent_hash": NonNone(self.similar_event.get_primary_hash()),
                     "should_group": True,
                     "stacktrace_distance": 0.01,
                 }
@@ -1100,7 +1100,7 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
             body=json.dumps(
                 {
                     "group_id": self.group.id,
-                    "group_hash": NonNone(self.event.get_primary_hash()),
+                    "hash": NonNone(self.event.get_primary_hash()),
                     "project_id": self.project.id,
                     "stacktrace": EXPECTED_STACKTRACE_STRING,
                     "message": self.group.message,
@@ -1124,7 +1124,7 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
             body=json.dumps(
                 {
                     "group_id": self.group.id,
-                    "group_hash": NonNone(self.event.get_primary_hash()),
+                    "hash": NonNone(self.event.get_primary_hash()),
                     "project_id": self.project.id,
                     "stacktrace": EXPECTED_STACKTRACE_STRING,
                     "message": self.group.message,
@@ -1149,7 +1149,7 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
             body=json.dumps(
                 {
                     "group_id": self.group.id,
-                    "group_hash": NonNone(self.event.get_primary_hash()),
+                    "hash": NonNone(self.event.get_primary_hash()),
                     "project_id": self.project.id,
                     "stacktrace": EXPECTED_STACKTRACE_STRING,
                     "message": self.group.message,

--- a/tests/sentry/seer/test_utils.py
+++ b/tests/sentry/seer/test_utils.py
@@ -80,7 +80,7 @@ def test_simple_similar_issues_embeddings_only_group_id_returned(
 
     params: SimilarIssuesEmbeddingsRequest = {
         "group_id": NonNone(event.group_id),
-        "group_hash": NonNone(event.get_primary_hash()),
+        "hash": NonNone(event.get_primary_hash()),
         "project_id": default_project.id,
         "stacktrace": "string",
         "message": "message",
@@ -97,7 +97,7 @@ def test_simple_similar_issues_embeddings_only_hash_returned(mock_seer_request, 
 
     raw_similar_issue_data: RawSeerSimilarIssueData = {
         "message_distance": 0.05,
-        "parent_group_hash": NonNone(similar_event.get_primary_hash()),
+        "parent_hash": NonNone(similar_event.get_primary_hash()),
         "should_group": True,
         "stacktrace_distance": 0.01,
     }
@@ -107,7 +107,7 @@ def test_simple_similar_issues_embeddings_only_hash_returned(mock_seer_request, 
 
     params: SimilarIssuesEmbeddingsRequest = {
         "group_id": NonNone(event.group_id),
-        "group_hash": NonNone(event.get_primary_hash()),
+        "hash": NonNone(event.get_primary_hash()),
         "project_id": default_project.id,
         "stacktrace": "string",
         "message": "message",
@@ -134,7 +134,7 @@ def test_simple_similar_issues_embeddings_both_returned(mock_seer_request, defau
     raw_similar_issue_data: RawSeerSimilarIssueData = {
         "message_distance": 0.05,
         "parent_group_id": NonNone(similar_event.group_id),
-        "parent_group_hash": NonNone(similar_event.get_primary_hash()),
+        "parent_hash": NonNone(similar_event.get_primary_hash()),
         "should_group": True,
         "stacktrace_distance": 0.01,
     }
@@ -144,7 +144,7 @@ def test_simple_similar_issues_embeddings_both_returned(mock_seer_request, defau
 
     params: SimilarIssuesEmbeddingsRequest = {
         "group_id": NonNone(event.group_id),
-        "group_hash": NonNone(event.get_primary_hash()),
+        "hash": NonNone(event.get_primary_hash()),
         "project_id": default_project.id,
         "stacktrace": "string",
         "message": "message",
@@ -163,7 +163,7 @@ def test_empty_similar_issues_embeddings(mock_seer_request, default_project):
 
     params: SimilarIssuesEmbeddingsRequest = {
         "group_id": NonNone(event.group_id),
-        "group_hash": NonNone(event.get_primary_hash()),
+        "hash": NonNone(event.get_primary_hash()),
         "project_id": default_project.id,
         "stacktrace": "string",
         "message": "message",
@@ -192,7 +192,7 @@ def test_from_raw_only_parent_hash(default_project):
     similar_event = save_new_event({"message": "Dogs are great!"}, default_project)
     raw_similar_issue_data: RawSeerSimilarIssueData = {
         "message_distance": 0.05,
-        "parent_group_hash": NonNone(similar_event.get_primary_hash()),
+        "parent_hash": NonNone(similar_event.get_primary_hash()),
         "should_group": True,
         "stacktrace_distance": 0.01,
     }
@@ -216,7 +216,7 @@ def test_from_raw_parent_group_id_and_parent_hash(default_project):
     raw_similar_issue_data: RawSeerSimilarIssueData = {
         "message_distance": 0.05,
         "parent_group_id": NonNone(similar_event.group_id),
-        "parent_group_hash": NonNone(similar_event.get_primary_hash()),
+        "parent_hash": NonNone(similar_event.get_primary_hash()),
         "should_group": True,
         "stacktrace_distance": 0.01,
     }
@@ -230,7 +230,7 @@ def test_from_raw_parent_group_id_and_parent_hash(default_project):
 def test_from_raw_missing_data(default_project):
     with pytest.raises(IncompleteSeerDataError):
         raw_similar_issue_data: RawSeerSimilarIssueData = {
-            # missing both `parent_group_id` and `parent_group_hash`
+            # missing both `parent_group_id` and `parent_hash`
             "message_distance": 0.05,
             "should_group": True,
             "stacktrace_distance": 0.01,
@@ -244,7 +244,7 @@ def test_from_raw_nonexistent_group(default_project):
     with pytest.raises(SimilarGroupNotFoundError):
         raw_similar_issue_data: RawSeerSimilarIssueData = {
             "parent_group_id": 1121201212312012,  # too high to be real
-            "parent_group_hash": "not a real hash",
+            "parent_hash": "not a real hash",
             "message_distance": 0.05,
             "should_group": True,
             "stacktrace_distance": 0.01,


### PR DESCRIPTION
As we've been thinking about the switch from sending and receiving group ids when communicating with Seer to doing so with hashes, all along we've been talking about those hashes as "group hashes." In truth, though, hash values are based on the data in a particular event (not the group overall), and indeed, that's how we're using them in Seer - pairing up hashes not with what group they're in but which event data they represent. There _is_ a pairing of groups and hashes - on the Sentry side, in the form of the `GroupHash` table - but entries from that table aren't what we're using with Seer. With Seer, we only care about the "hash" part of `GroupHash`.

So, both for accuracy and so as to be able to differentiate in Seer-related Sentry code between hashes (hex strings) and grouphashes (association table records), we're switching from using `group_hash` and `parent_group_hash` to using `hash` and `parent_hash`.

This PR makes the change on the Sentry side. Fortunately, nothing in Seer is yet relying on hashes, so as long as we wait for this to go live, we can then add hash support on the seer side using the new names from the get-go.