### PR TITLE
ref: add metric when canonical key falls back

### DIFF
--- a/src/sentry/utils/canonical.py
+++ b/src/sentry/utils/canonical.py
@@ -43,7 +43,14 @@ CANONICAL_KEY_MAPPING = {
 
 
 def get_canonical_name(key: str) -> str:
-    return CANONICAL_KEY_MAPPING.get(key, (key,))[0]
+    rv = CANONICAL_KEY_MAPPING.get(key)
+    if rv is None:
+        return key
+    else:
+        from sentry.utils import metrics
+
+        metrics.incr("canonical-legacy-key")
+        return rv[0]
 
 
 class CanonicalKeyView(Mapping[str, V]):


### PR DESCRIPTION
want to make sure this isn't happening before I clean up all of this -- I'm told this is handled by relay now

<!-- Describe your PR here. -->