### PR TITLE
ref(seer grouping): Stop sending/receiving group id when communicating with Seer

### DIFF
--- a/src/sentry/api/endpoints/group_similar_issues_embeddings.py
+++ b/src/sentry/api/endpoints/group_similar_issues_embeddings.py
@@ -147,7 +147,6 @@ class GroupSimilarIssuesEmbeddingsEndpoint(GroupEndpoint):
             return Response([])  # No exception, stacktrace or in-app frames
 
         similar_issues_params: SimilarIssuesEmbeddingsRequest = {
-            "group_id": group.id,
             "hash": latest_event.get_primary_hash(),
             "project_id": group.project.id,
             "stacktrace": stacktrace_string,

--- a/src/sentry/seer/utils.py
+++ b/src/sentry/seer/utils.py
@@ -15,7 +15,6 @@ from sentry.conf.server import (
     SEER_SIMILAR_ISSUES_URL,
     SEER_SIMILARITY_MODEL_VERSION,
 )
-from sentry.models.group import Group
 from sentry.models.grouphash import GroupHash
 from sentry.net.http import connection_from_url
 from sentry.utils import json, metrics
@@ -151,10 +150,10 @@ class SeerSimilarIssueData:
         using the parent hash to look up the parent group id. Needs to be run individually on each
         similar issue in the Seer response.
 
-        Throws an `IncompleteSeerDataError` if given data with both parent group id and parent hash
-        missing, and a `SimilarGroupNotFoundError` if the data points to a group which no longer
-        exists. Thus if this successfully returns, the parent group id it contains is guaranteed to
-        point to an existing group.
+        Throws an `IncompleteSeerDataError` if given data with any required keys missing, and a
+        `SimilarGroupNotFoundError` if the data points to a group which no longer exists. The latter
+        guarantees that if this successfully returns, the parent group id in the return value points
+        to an existing group.
 
         """
 
@@ -170,36 +169,25 @@ class SeerSimilarIssueData:
                 + ", ".join(map(lambda key: f"'{key}'", sorted(missing_keys)))
             )
 
-        parent_hash = raw_similar_issue_data.get("parent_hash")
-        parent_group_id = raw_similar_issue_data.get("parent_group_id")
-
-        if not parent_group_id and not parent_hash:
-            raise IncompleteSeerDataError(
-                "Seer similar issues response missing both `parent_group_id` and `parent_hash`"
+        # Now that we know we have all the right data, use the parent group's hash to look up its id
+        parent_grouphash = (
+            GroupHash.objects.filter(
+                project_id=project_id, hash=raw_similar_issue_data["parent_hash"]
             )
+            .exclude(state=GroupHash.State.LOCKED_IN_MIGRATION)
+            .first()
+        )
 
-        if parent_group_id:
-            if not Group.objects.filter(id=parent_group_id).first():
-                raise SimilarGroupNotFoundError("Similar group suggested by Seer does not exist")
+        if not parent_grouphash:
+            # TODO: Report back to seer that the hash has been deleted.
+            raise SimilarGroupNotFoundError("Similar group suggested by Seer does not exist")
 
-            similar_issue_data = raw_similar_issue_data
-
-        # If we don't have a parent group id, try looking one up using the parent hash
-        else:
-            parent_grouphash = (
-                GroupHash.objects.filter(project_id=project_id, hash=parent_hash)
-                .exclude(state=GroupHash.State.LOCKED_IN_MIGRATION)
-                .first()
-            )
-
-            if not parent_grouphash:
-                # TODO: Report back to seer that the hash has been deleted.
-                raise SimilarGroupNotFoundError("Similar group suggested by Seer does not exist")
-
-            similar_issue_data = {
-                **raw_similar_issue_data,
-                "parent_group_id": parent_grouphash.group_id,
-            }
+        # TODO: The `Any` casting here isn't great, but Python currently has no way to
+        # relate typeddict keys to dataclass properties
+        similar_issue_data: Any = {
+            **raw_similar_issue_data,
+            "parent_group_id": parent_grouphash.group_id,
+        }
 
         return cls(**similar_issue_data)
 

--- a/src/sentry/seer/utils.py
+++ b/src/sentry/seer/utils.py
@@ -108,16 +108,16 @@ class SimilarIssuesEmbeddingsRequest(TypedDict):
     project_id: int
     stacktrace: str
     message: str
+    hash: str
     k: NotRequired[int]  # how many neighbors to find
     threshold: NotRequired[float]
-    hash: NotRequired[str]  # TODO: Make this required once id -> hash change is done
 
 
 class RawSeerSimilarIssueData(TypedDict):
+    parent_hash: str
     stacktrace_distance: float
     message_distance: float
     should_group: bool
-    parent_hash: NotRequired[str]  # TODO: Make this required once id -> hash change is done
 
 
 class SimilarIssuesEmbeddingsResponse(TypedDict):
@@ -131,13 +131,17 @@ class SeerSimilarIssueData:
     message_distance: float
     should_group: bool
     parent_group_id: int
-    # TODO: See if we end up needing the hash here
-    parent_hash: str | None = None
+    parent_hash: str
 
     # Unfortunately, we have to hardcode this separately from the `RawSeerSimilarIssueData` type
     # definition because Python has no way to derive it from the type (nor vice-versa)
-    required_incoming_keys: ClassVar = {"stacktrace_distance", "message_distance", "should_group"}
-    optional_incoming_keys: ClassVar = {"parent_hash"}
+    required_incoming_keys: ClassVar = {
+        "stacktrace_distance",
+        "message_distance",
+        "should_group",
+        "parent_hash",
+    }
+    optional_incoming_keys: ClassVar = {}
     expected_incoming_keys: ClassVar = {*required_incoming_keys, *optional_incoming_keys}
 
     @classmethod

--- a/src/sentry/seer/utils.py
+++ b/src/sentry/seer/utils.py
@@ -110,7 +110,6 @@ class SimilarIssuesEmbeddingsRequest(TypedDict):
     message: str
     k: NotRequired[int]  # how many neighbors to find
     threshold: NotRequired[float]
-    group_id: NotRequired[int]  # TODO: Remove this once we stop sending it to seer
     hash: NotRequired[str]  # TODO: Make this required once id -> hash change is done
 
 
@@ -118,7 +117,6 @@ class RawSeerSimilarIssueData(TypedDict):
     stacktrace_distance: float
     message_distance: float
     should_group: bool
-    parent_group_id: NotRequired[int]  # TODO: Remove this once seer stops sending it
     parent_hash: NotRequired[str]  # TODO: Make this required once id -> hash change is done
 
 
@@ -139,7 +137,7 @@ class SeerSimilarIssueData:
     # Unfortunately, we have to hardcode this separately from the `RawSeerSimilarIssueData` type
     # definition because Python has no way to derive it from the type (nor vice-versa)
     required_incoming_keys: ClassVar = {"stacktrace_distance", "message_distance", "should_group"}
-    optional_incoming_keys: ClassVar = {"parent_hash", "parent_group_id"}
+    optional_incoming_keys: ClassVar = {"parent_hash"}
     expected_incoming_keys: ClassVar = {*required_incoming_keys, *optional_incoming_keys}
 
     @classmethod

--- a/tests/sentry/api/endpoints/test_group_similar_issues_embeddings.py
+++ b/tests/sentry/api/endpoints/test_group_similar_issues_embeddings.py
@@ -832,7 +832,7 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
         response = self.client.get(self.path)
 
         mock_logger.exception.assert_called_with(
-            "Seer similar issues response missing both `parent_group_id` and `parent_hash`",
+            "Seer similar issues response entry missing key 'parent_hash'",
             extra={
                 "request_params": {
                     "group_id": NonNone(self.event.group_id),

--- a/tests/sentry/api/endpoints/test_group_similar_issues_embeddings.py
+++ b/tests/sentry/api/endpoints/test_group_similar_issues_embeddings.py
@@ -697,7 +697,7 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
     @mock.patch("sentry.seer.utils.metrics")
     @mock.patch("sentry.seer.utils.seer_grouping_connection_pool.urlopen")
     @mock.patch("sentry.api.endpoints.group_similar_issues_embeddings.logger")
-    def test_simple_only_hash_returned(self, mock_logger, mock_seer_request, mock_metrics):
+    def test_simple(self, mock_logger, mock_seer_request, mock_metrics):
         seer_return_value: SimilarIssuesEmbeddingsResponse = {
             "responses": [
                 {

--- a/tests/sentry/api/endpoints/test_group_similar_issues_embeddings.py
+++ b/tests/sentry/api/endpoints/test_group_similar_issues_embeddings.py
@@ -721,7 +721,6 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
 
         expected_seer_request_params = {
             "threshold": 0.01,
-            "group_id": self.group.id,
             "hash": NonNone(self.event.get_primary_hash()),
             "project_id": self.project.id,
             "stacktrace": EXPECTED_STACKTRACE_STRING,
@@ -835,7 +834,6 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
             "Seer similar issues response entry missing key 'parent_hash'",
             extra={
                 "request_params": {
-                    "group_id": NonNone(self.event.group_id),
                     "hash": NonNone(self.event.get_primary_hash()),
                     "project_id": self.project.id,
                     "stacktrace": EXPECTED_STACKTRACE_STRING,
@@ -1000,7 +998,6 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
             body=orjson.dumps(
                 {
                     "threshold": 0.01,
-                    "group_id": self.group.id,
                     "hash": NonNone(self.event.get_primary_hash()),
                     "project_id": self.project.id,
                     "stacktrace": EXPECTED_STACKTRACE_STRING,
@@ -1025,7 +1022,6 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
             body=orjson.dumps(
                 {
                     "threshold": 0.01,
-                    "group_id": self.group.id,
                     "hash": NonNone(self.event.get_primary_hash()),
                     "project_id": self.project.id,
                     "stacktrace": EXPECTED_STACKTRACE_STRING,
@@ -1051,7 +1047,6 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
             body=orjson.dumps(
                 {
                     "threshold": 0.01,
-                    "group_id": self.group.id,
                     "hash": NonNone(self.event.get_primary_hash()),
                     "project_id": self.project.id,
                     "stacktrace": EXPECTED_STACKTRACE_STRING,

--- a/tests/sentry/api/endpoints/test_group_similar_issues_embeddings.py
+++ b/tests/sentry/api/endpoints/test_group_similar_issues_embeddings.py
@@ -754,21 +754,18 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
             "responses": [
                 {
                     "message_distance": 0.05,
-                    "parent_group_id": NonNone(self.similar_event.group_id),
                     "parent_hash": NonNone(self.similar_event.get_primary_hash()),
                     "should_group": True,
                     "stacktrace_distance": 0.002,  # Over threshold
                 },
                 {
                     "message_distance": 0.05,
-                    "parent_group_id": NonNone(over_threshold_group_event.group_id),
                     "parent_hash": NonNone(over_threshold_group_event.get_primary_hash()),
                     "should_group": True,
                     "stacktrace_distance": 0.002,  # Over threshold
                 },
                 {
                     "message_distance": 0.05,
-                    "parent_group_id": NonNone(under_threshold_group_event.group_id),
                     "parent_hash": NonNone(under_threshold_group_event.get_primary_hash()),
                     "should_group": False,
                     "stacktrace_distance": 0.05,  # Under threshold
@@ -808,20 +805,19 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
     @mock.patch("sentry.seer.utils.logger")
     @mock.patch("sentry.seer.utils.seer_grouping_connection_pool.urlopen")
     def test_incomplete_return_data(self, mock_seer_request, mock_logger, mock_metrics):
-        # Two suggested groups, one with valid data, one missing both parent group id and parent hash.
-        # We should log the second and return the first.
+        # Two suggested groups, one with valid data, one missing parent hash. We should log the
+        # second and return the first.
         seer_return_value: SimilarIssuesEmbeddingsResponse = {
             "responses": [
                 {
                     "message_distance": 0.05,
-                    "parent_group_id": NonNone(self.similar_event.group_id),
                     "parent_hash": NonNone(self.similar_event.get_primary_hash()),
                     "should_group": True,
                     "stacktrace_distance": 0.01,
                 },
                 {
                     "message_distance": 0.05,
-                    # missing both parent group id and parent hash
+                    # missing parent hash
                     "should_group": True,
                     "stacktrace_distance": 0.01,
                 },
@@ -871,14 +867,12 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
             "responses": [
                 {
                     "message_distance": 0.05,
-                    "parent_group_id": NonNone(self.similar_event.group_id),
                     "parent_hash": NonNone(self.similar_event.get_primary_hash()),
                     "should_group": True,
                     "stacktrace_distance": 0.01,
                 },
                 {
                     "message_distance": 0.05,
-                    "parent_group_id": 1121201212312012,  # too high to be real
                     "parent_hash": "not a real hash",
                     "should_group": True,
                     "stacktrace_distance": 0.01,
@@ -976,7 +970,6 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
             "responses": [
                 {
                     "message_distance": 0.05,
-                    "parent_group_id": NonNone(self.similar_event.group_id),
                     "parent_hash": NonNone(self.similar_event.get_primary_hash()),
                     "should_group": True,
                     "stacktrace_distance": 0.01,

--- a/tests/sentry/api/endpoints/test_group_similar_issues_embeddings.py
+++ b/tests/sentry/api/endpoints/test_group_similar_issues_embeddings.py
@@ -807,7 +807,7 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
     def test_incomplete_return_data(self, mock_seer_request, mock_logger, mock_metrics):
         # Two suggested groups, one with valid data, one missing parent hash. We should log the
         # second and return the first.
-        seer_return_value: SimilarIssuesEmbeddingsResponse = {
+        seer_return_value: Any = {
             "responses": [
                 {
                     "message_distance": 0.05,

--- a/tests/sentry/event_manager/grouping/test_seer_grouping.py
+++ b/tests/sentry/event_manager/grouping/test_seer_grouping.py
@@ -19,7 +19,7 @@ class SeerEventManagerGroupingTest(TestCase):
     def test_obeys_seer_similarity_flags(self):
         existing_event = save_new_event({"message": "Dogs are great!"}, self.project)
         seer_result_data = SeerSimilarIssueData(
-            parent_hash=existing_event.get_primary_hash(),
+            parent_hash=NonNone(existing_event.get_primary_hash()),
             parent_group_id=NonNone(existing_event.group_id),
             stacktrace_distance=0.01,
             message_distance=0.05,
@@ -168,7 +168,7 @@ class SeerEventManagerGroupingTest(TestCase):
         existing_event = save_new_event({"message": "Dogs are great!"}, self.project)
 
         seer_result_data = SeerSimilarIssueData(
-            parent_hash=existing_event.get_primary_hash(),
+            parent_hash=NonNone(existing_event.get_primary_hash()),
             parent_group_id=NonNone(existing_event.group_id),
             stacktrace_distance=0.01,
             message_distance=0.05,
@@ -194,7 +194,7 @@ class SeerEventManagerGroupingTest(TestCase):
         existing_event = save_new_event({"message": "Dogs are great!"}, self.project)
 
         seer_result_data = SeerSimilarIssueData(
-            parent_hash=existing_event.get_primary_hash(),
+            parent_hash=NonNone(existing_event.get_primary_hash()),
             parent_group_id=NonNone(existing_event.group_id),
             stacktrace_distance=0.01,
             message_distance=0.05,
@@ -223,7 +223,7 @@ class SeerEventManagerGroupingTest(TestCase):
         existing_event = save_new_event({"message": "Dogs are great!"}, self.project)
 
         no_cigar_data = SeerSimilarIssueData(
-            parent_hash=existing_event.get_primary_hash(),
+            parent_hash=NonNone(existing_event.get_primary_hash()),
             parent_group_id=NonNone(existing_event.group_id),
             stacktrace_distance=0.10,
             message_distance=0.05,

--- a/tests/sentry/grouping/test_seer.py
+++ b/tests/sentry/grouping/test_seer.py
@@ -74,7 +74,7 @@ class GetSeerSimilarIssuesTest(TestCase):
     @with_feature({"projects:similarity-embeddings-grouping": False})
     def test_returns_metadata_but_no_group_if_seer_grouping_flag_off(self):
         seer_result_data = SeerSimilarIssueData(
-            parent_hash=self.existing_event.get_primary_hash(),
+            parent_hash=NonNone(self.existing_event.get_primary_hash()),
             parent_group_id=NonNone(self.existing_event.group_id),
             stacktrace_distance=0.01,
             message_distance=0.05,
@@ -98,7 +98,7 @@ class GetSeerSimilarIssuesTest(TestCase):
     @with_feature("projects:similarity-embeddings-grouping")
     def test_returns_metadata_and_group_if_sufficiently_close_group_found(self):
         seer_result_data = SeerSimilarIssueData(
-            parent_hash=self.existing_event.get_primary_hash(),
+            parent_hash=NonNone(self.existing_event.get_primary_hash()),
             parent_group_id=NonNone(self.existing_event.group_id),
             stacktrace_distance=0.01,
             message_distance=0.05,
@@ -122,7 +122,7 @@ class GetSeerSimilarIssuesTest(TestCase):
     @with_feature("projects:similarity-embeddings-grouping")
     def test_returns_metadata_but_no_group_if_similar_group_insufficiently_close(self):
         seer_result_data = SeerSimilarIssueData(
-            parent_hash=self.existing_event.get_primary_hash(),
+            parent_hash=NonNone(self.existing_event.get_primary_hash()),
             parent_group_id=NonNone(self.existing_event.group_id),
             stacktrace_distance=0.08,
             message_distance=0.12,

--- a/tests/sentry/seer/test_utils.py
+++ b/tests/sentry/seer/test_utils.py
@@ -100,14 +100,12 @@ def test_similar_issues_embeddings_simple(mock_seer_request, default_project):
         "message": "message",
     }
 
-    similar_issue_data = {
+    similar_issue_data: Any = {
         **raw_similar_issue_data,
         "parent_group_id": similar_event.group_id,
     }
 
-    assert get_similarity_data_from_seer(params) == [
-        SeerSimilarIssueData(**similar_issue_data)  # type: ignore[arg-type]
-    ]
+    assert get_similarity_data_from_seer(params) == [SeerSimilarIssueData(**similar_issue_data)]
 
 
 @django_db_all

--- a/tests/sentry/seer/test_utils.py
+++ b/tests/sentry/seer/test_utils.py
@@ -232,7 +232,7 @@ def test_from_raw_missing_data(default_project):
         match="Seer similar issues response entry missing key 'parent_hash'",
     ):
         raw_similar_issue_data: Any = {
-            # missing both `parent_group_id` and `parent_hash`
+            # missing `parent_hash`
             "message_distance": 0.05,
             "should_group": True,
             "stacktrace_distance": 0.01,
@@ -245,7 +245,6 @@ def test_from_raw_missing_data(default_project):
         match="Seer similar issues response entry missing key 'message_distance'",
     ):
         raw_similar_issue_data = {
-            "parent_group_id": NonNone(similar_event.group_id),
             "parent_hash": NonNone(similar_event.get_primary_hash()),
             # missing `message_distance`
             "should_group": True,
@@ -259,7 +258,6 @@ def test_from_raw_missing_data(default_project):
         match="Seer similar issues response entry missing keys 'message_distance', 'stacktrace_distance'",
     ):
         raw_similar_issue_data = {
-            "parent_group_id": NonNone(similar_event.group_id),
             "parent_hash": NonNone(similar_event.get_primary_hash()),
             # missing `message_distance`
             "should_group": True,
@@ -273,7 +271,6 @@ def test_from_raw_missing_data(default_project):
 def test_from_raw_nonexistent_group(default_project):
     with pytest.raises(SimilarGroupNotFoundError):
         raw_similar_issue_data = {
-            "parent_group_id": 1121201212312012,  # too high to be real
             "parent_hash": "not a real hash",
             "message_distance": 0.05,
             "should_group": True,

--- a/tests/sentry/seer/test_utils.py
+++ b/tests/sentry/seer/test_utils.py
@@ -231,7 +231,7 @@ def test_from_raw_missing_data(default_project):
 
     with pytest.raises(
         IncompleteSeerDataError,
-        match="Seer similar issues response missing both `parent_group_id` and `parent_hash`",
+        match="Seer similar issues response entry missing key 'parent_hash'",
     ):
         raw_similar_issue_data: Any = {
             # missing both `parent_group_id` and `parent_hash`

--- a/tests/sentry/seer/test_utils.py
+++ b/tests/sentry/seer/test_utils.py
@@ -94,7 +94,6 @@ def test_similar_issues_embeddings_simple(mock_seer_request, default_project):
     mock_seer_request.return_value = HTTPResponse(json.dumps(seer_return_value).encode("utf-8"))
 
     params: SimilarIssuesEmbeddingsRequest = {
-        "group_id": NonNone(event.group_id),
         "hash": NonNone(event.get_primary_hash()),
         "project_id": default_project.id,
         "stacktrace": "string",
@@ -120,7 +119,6 @@ def test_empty_similar_issues_embeddings(mock_seer_request, default_project):
     mock_seer_request.return_value = HTTPResponse([])
 
     params: SimilarIssuesEmbeddingsRequest = {
-        "group_id": NonNone(event.group_id),
         "hash": NonNone(event.get_primary_hash()),
         "project_id": default_project.id,
         "stacktrace": "string",

--- a/tests/sentry/seer/test_utils.py
+++ b/tests/sentry/seer/test_utils.py
@@ -76,36 +76,6 @@ def test_detect_breakpoints_errors(mock_urlopen, mock_capture_exception, body, s
     assert mock_capture_exception.called
 
 
-# TODO: Remove once switch is complete
-@django_db_all
-@mock.patch("sentry.seer.utils.seer_grouping_connection_pool.urlopen")
-def test_simple_similar_issues_embeddings_only_group_id_returned(
-    mock_seer_request, default_project
-):
-    """Test that valid responses are decoded and returned."""
-    event = save_new_event({"message": "Dogs are great!"}, default_project)
-    similar_event = save_new_event({"message": "Adopt don't shop"}, default_project)
-
-    raw_similar_issue_data: RawSeerSimilarIssueData = {
-        "message_distance": 0.05,
-        "parent_group_id": NonNone(similar_event.group_id),
-        "should_group": True,
-        "stacktrace_distance": 0.01,
-    }
-
-    seer_return_value = {"responses": [raw_similar_issue_data]}
-    mock_seer_request.return_value = HTTPResponse(json.dumps(seer_return_value).encode("utf-8"))
-
-    params: SimilarIssuesEmbeddingsRequest = {
-        "group_id": NonNone(event.group_id),
-        "hash": NonNone(event.get_primary_hash()),
-        "project_id": default_project.id,
-        "stacktrace": "string",
-        "message": "message",
-    }
-    assert get_similarity_data_from_seer(params) == [SeerSimilarIssueData(**raw_similar_issue_data)]
-
-
 @django_db_all
 @mock.patch("sentry.seer.utils.seer_grouping_connection_pool.urlopen")
 def test_simple_similar_issues_embeddings_only_hash_returned(mock_seer_request, default_project):
@@ -139,36 +109,6 @@ def test_simple_similar_issues_embeddings_only_hash_returned(mock_seer_request, 
     assert get_similarity_data_from_seer(params) == [
         SeerSimilarIssueData(**similar_issue_data)  # type: ignore[arg-type]
     ]
-
-
-# TODO: Remove once switch is complete
-@django_db_all
-@mock.patch("sentry.seer.utils.seer_grouping_connection_pool.urlopen")
-def test_simple_similar_issues_embeddings_both_returned(mock_seer_request, default_project):
-    """Test that valid responses are decoded and returned."""
-    event = save_new_event({"message": "Dogs are great!"}, default_project)
-    similar_event = save_new_event({"message": "Adopt don't shop"}, default_project)
-
-    raw_similar_issue_data: RawSeerSimilarIssueData = {
-        "message_distance": 0.05,
-        "parent_group_id": NonNone(similar_event.group_id),
-        "parent_hash": NonNone(similar_event.get_primary_hash()),
-        "should_group": True,
-        "stacktrace_distance": 0.01,
-    }
-
-    seer_return_value = {"responses": [raw_similar_issue_data]}
-    mock_seer_request.return_value = HTTPResponse(json.dumps(seer_return_value).encode("utf-8"))
-
-    params: SimilarIssuesEmbeddingsRequest = {
-        "group_id": NonNone(event.group_id),
-        "hash": NonNone(event.get_primary_hash()),
-        "project_id": default_project.id,
-        "stacktrace": "string",
-        "message": "message",
-    }
-
-    assert get_similarity_data_from_seer(params) == [SeerSimilarIssueData(**raw_similar_issue_data)]
 
 
 @django_db_all
@@ -236,22 +176,6 @@ def test_returns_sorted_similarity_results(mock_seer_request, default_project):
     ]
 
 
-# TODO: Remove once switch is complete
-@django_db_all
-def test_from_raw_only_parent_group_id(default_project):
-    similar_event = save_new_event({"message": "Dogs are great!"}, default_project)
-    raw_similar_issue_data: RawSeerSimilarIssueData = {
-        "message_distance": 0.05,
-        "parent_group_id": NonNone(similar_event.group_id),
-        "should_group": True,
-        "stacktrace_distance": 0.01,
-    }
-
-    assert SeerSimilarIssueData.from_raw(
-        default_project.id, raw_similar_issue_data
-    ) == SeerSimilarIssueData(**raw_similar_issue_data)
-
-
 @django_db_all
 def test_from_raw_only_parent_hash(default_project):
     similar_event = save_new_event({"message": "Dogs are great!"}, default_project)
@@ -272,23 +196,6 @@ def test_from_raw_only_parent_hash(default_project):
     ) == SeerSimilarIssueData(
         **similar_issue_data  # type:ignore[arg-type]
     )
-
-
-# TODO: Remove once switch is complete
-@django_db_all
-def test_from_raw_parent_group_id_and_parent_hash(default_project):
-    similar_event = save_new_event({"message": "Dogs are great!"}, default_project)
-    raw_similar_issue_data: RawSeerSimilarIssueData = {
-        "message_distance": 0.05,
-        "parent_group_id": NonNone(similar_event.group_id),
-        "parent_hash": NonNone(similar_event.get_primary_hash()),
-        "should_group": True,
-        "stacktrace_distance": 0.01,
-    }
-
-    assert SeerSimilarIssueData.from_raw(
-        default_project.id, raw_similar_issue_data
-    ) == SeerSimilarIssueData(**raw_similar_issue_data)
 
 
 @django_db_all

--- a/tests/sentry/seer/test_utils.py
+++ b/tests/sentry/seer/test_utils.py
@@ -78,7 +78,7 @@ def test_detect_breakpoints_errors(mock_urlopen, mock_capture_exception, body, s
 
 @django_db_all
 @mock.patch("sentry.seer.utils.seer_grouping_connection_pool.urlopen")
-def test_simple_similar_issues_embeddings_only_hash_returned(mock_seer_request, default_project):
+def test_similar_issues_embeddings_simple(mock_seer_request, default_project):
     """Test that valid responses are decoded and returned."""
     event = save_new_event({"message": "Dogs are great!"}, default_project)
     similar_event = save_new_event({"message": "Adopt don't shop"}, default_project)
@@ -177,7 +177,7 @@ def test_returns_sorted_similarity_results(mock_seer_request, default_project):
 
 
 @django_db_all
-def test_from_raw_only_parent_hash(default_project):
+def test_from_raw_simple(default_project):
     similar_event = save_new_event({"message": "Dogs are great!"}, default_project)
     raw_similar_issue_data: RawSeerSimilarIssueData = {
         "message_distance": 0.05,


### PR DESCRIPTION
Now that Seer has stopped expecting group ids (we started sending the hash in addition to group id in https://github.com/getsentry/sentry/pull/70244, and seer switched to handling hash rather than group id in https://github.com/getsentry/seer/pull/625), and has stopped sending them back (also changed in https://github.com/getsentry/seer/pull/625), we can close the loop and stop sending or expecting them on the Sentry side, too.

This PR makes that change, which allows for some simplification in three places:

- In the `SimilarIssuesEmbeddingsRequest` and `RawSeerSimilarIssueData` types, `group_id` and `parent_group_id` (respectively) are  removed and `hash` and `parent_hash` (respectively) are no longer optional.

- In `SeerSimilarIssueData.from_raw`, we no longer have to play the "Did Seer send back parent hash or parent group id?" game, and can instead just trust that the parent hash will be there and process it.

- In `GroupSimilarIssuesEmbeddingsEndpoint.get_formatted_results`, we no longer have to handle the case of there being parent group ids in the passed data which correspond to non-existent groups, since the group ids there are no longer coming from Seer but from us, which gives us the opportunity to make sure they're real before passing them on. (Technically this could/should have happened in https://github.com/getsentry/sentry/pull/70240, but better late than never.)