### PR TITLE
cogs(access-logs): dont log internal methods

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -3703,6 +3703,10 @@ DEVSERVER_REQUEST_LOG_EXCLUDES: list[str] = []
 
 LOG_API_ACCESS = not IS_DEV or os.environ.get("SENTRY_LOG_API_ACCESS")
 
+# We should not run access logging middleware on some endpoints as
+# it is very noisy, and these views are hit by internal services.
+ACCESS_LOGS_EXCLUDE_PATHS = ("/api/0/internal/",)
+
 VALIDATE_SUPERUSER_ACCESS_CATEGORY_AND_REASON = True
 DISABLE_SU_FORM_U2F_CHECK_FOR_LOCAL = False
 

--- a/src/sentry/middleware/access_log.py
+++ b/src/sentry/middleware/access_log.py
@@ -19,6 +19,8 @@ from . import is_frontend_request
 
 api_access_logger = logging.getLogger("sentry.access.api")
 
+EXCLUSION_PATHS = settings.ACCESS_LOGS_EXCLUDE_PATHS + settings.ANONYMOUS_STATIC_PREFIXES
+
 
 @dataclass
 class _AccessLogMetaData:
@@ -125,8 +127,9 @@ def access_log_middleware(
         if not settings.LOG_API_ACCESS:
             return get_response(request)
 
-        if request.path_info.startswith(settings.ANONYMOUS_STATIC_PREFIXES):
+        if request.path_info.startswith(EXCLUSION_PATHS):
             return get_response(request)
+
         access_log_metadata = _AccessLogMetaData(request_start_time=time.time())
         response = get_response(request)
         _create_api_access_log(request, response, access_log_metadata)


### PR DESCRIPTION
The purpose of access logs is to monitor how our API is used externally. We shouldn't log access info for internal API calls. volume wise, this is mainly RPC methods taking up the bulk of the logs. https://cloudlogging.app.goo.gl/qzdQHVAyBtPtAPk49

