### PR TITLE
fix(middleware): Integration Fetching Logic for Gitlab Parser

### DIFF
--- a/src/sentry/middleware/integrations/parsers/gitlab.py
+++ b/src/sentry/middleware/integrations/parsers/gitlab.py
@@ -66,7 +66,7 @@ class GitlabRequestParser(BaseRequestParser, GitlabWebhookMixin):
         except Exception as e:
             metrics.incr(
                 self._METRIC_CONTROL_PATH_FAILURE_KEY,
-                tags={"integration": self.provider, "error": e},
+                tags={"integration": self.provider, "error": str(e)},
             )
             logger.exception("Failed to get integration from request")
 

--- a/src/sentry/middleware/integrations/parsers/gitlab.py
+++ b/src/sentry/middleware/integrations/parsers/gitlab.py
@@ -5,7 +5,6 @@ from collections.abc import Mapping
 from typing import Any
 
 from django.http.response import HttpResponseBase
-from django.urls import resolve
 
 from sentry.integrations.gitlab.webhooks import GitlabWebhookEndpoint, GitlabWebhookMixin
 from sentry.integrations.utils.scope import clear_tags_and_context
@@ -43,14 +42,14 @@ class GitlabRequestParser(BaseRequestParser, GitlabWebhookMixin):
         if not self.is_json_request():
             return None
         try:
-            _view, _args, kwargs = resolve(self.request.path)
-            # Non-webhook endpoints
-            if "integration_id" in kwargs and "organization_slug" in kwargs:
-                self._integration = Integration.objects.filter(
-                    id=kwargs["integration_id"],
-                    organization_slug=kwargs["organization_slug"],
-                ).first()
-                return self._integration
+            # _view, _args, kwargs = resolve(self.request.path)
+            # # Non-webhook endpoints
+            # if "integration_id" in kwargs and "organization_slug" in kwargs:
+            #     self._integration = Integration.objects.filter(
+            #         id=kwargs["integration_id"],
+            #         organization_slug=kwargs["organization_slug"],
+            #     ).first()
+            #     return self._integration
 
             # Webhook endpoints
             result = self._resolve_external_id()

--- a/src/sentry/middleware/integrations/parsers/gitlab.py
+++ b/src/sentry/middleware/integrations/parsers/gitlab.py
@@ -42,14 +42,6 @@ class GitlabRequestParser(BaseRequestParser, GitlabWebhookMixin):
         if not self.is_json_request():
             return None
         try:
-            # _view, _args, kwargs = resolve(self.request.path)
-            # # Non-webhook endpoints
-            # if "integration_id" in kwargs and "organization_slug" in kwargs:
-            #     self._integration = Integration.objects.filter(
-            #         id=kwargs["integration_id"],
-            #         organization_slug=kwargs["organization_slug"],
-            #     ).first()
-            #     return self._integration
 
             # Webhook endpoints
             result = self._resolve_external_id()

--- a/src/sentry/middleware/integrations/parsers/gitlab.py
+++ b/src/sentry/middleware/integrations/parsers/gitlab.py
@@ -63,8 +63,11 @@ class GitlabRequestParser(BaseRequestParser, GitlabWebhookMixin):
                     external_id=external_id, provider=self.provider
                 ).first()
                 return self._integration
-        except Exception:
-            metrics.incr(self._METRIC_CONTROL_PATH_FAILURE_KEY)
+        except Exception as e:
+            metrics.incr(
+                self._METRIC_CONTROL_PATH_FAILURE_KEY,
+                tags={"integration": self.provider, "error": e},
+            )
             logger.exception("Failed to get integration from request")
 
         return None

--- a/src/sentry/middleware/integrations/parsers/gitlab.py
+++ b/src/sentry/middleware/integrations/parsers/gitlab.py
@@ -5,7 +5,9 @@ from collections.abc import Mapping
 from typing import Any
 
 from django.http.response import HttpResponseBase
+from django.urls import resolve
 
+from sentry import options
 from sentry.integrations.gitlab.webhooks import GitlabWebhookEndpoint, GitlabWebhookMixin
 from sentry.integrations.utils.scope import clear_tags_and_context
 from sentry.middleware.integrations.parsers.base import BaseRequestParser
@@ -14,7 +16,7 @@ from sentry.models.integrations.organization_integration import OrganizationInte
 from sentry.models.outbox import WebhookProviderIdentifier
 from sentry.services.hybrid_cloud.util import control_silo_function
 from sentry.types.integrations import EXTERNAL_PROVIDERS, ExternalProviders
-from sentry.utils import json
+from sentry.utils import json, metrics
 
 logger = logging.getLogger(__name__)
 
@@ -23,6 +25,7 @@ class GitlabRequestParser(BaseRequestParser, GitlabWebhookMixin):
     provider = EXTERNAL_PROVIDERS[ExternalProviders.GITLAB]
     webhook_identifier = WebhookProviderIdentifier.GITLAB
     _integration: Integration | None = None
+    _METRIC_CONTROL_PATH_FAILURE_KEY = "integrations.gitlab.get_integration_from_request.failure"
 
     def _resolve_external_id(self) -> tuple[str, str] | HttpResponseBase:
         clear_tags_and_context()
@@ -42,6 +45,15 @@ class GitlabRequestParser(BaseRequestParser, GitlabWebhookMixin):
         if not self.is_json_request():
             return None
         try:
+            if not options.get("api.remove-non-webhook-control-path-gitlab-parser"):
+                _view, _args, kwargs = resolve(self.request.path)
+                # Non-webhook endpoints
+                if "integration_id" in kwargs and "organization_slug" in kwargs:
+                    self._integration = Integration.objects.filter(
+                        id=kwargs["integration_id"],
+                        organization_slug=kwargs["organization_slug"],
+                    ).first()
+                    return self._integration
 
             # Webhook endpoints
             result = self._resolve_external_id()
@@ -52,7 +64,8 @@ class GitlabRequestParser(BaseRequestParser, GitlabWebhookMixin):
                 ).first()
                 return self._integration
         except Exception:
-            pass
+            metrics.incr(self._METRIC_CONTROL_PATH_FAILURE_KEY)
+            logger.exception("Failed to get integration from request")
 
         return None
 

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -320,6 +320,13 @@ register(
     flags=FLAG_ALLOW_EMPTY | FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
 )
 
+register(
+    "api.remove-non-webhook-control-path-gitlab-parser",
+    type=Bool,
+    default=False,
+    flags=FLAG_MODIFIABLE_BOOL | FLAG_AUTOMATOR_MODIFIABLE,
+)
+
 # Controls the rate of using the hashed value of User API tokens for lookups when logging in
 # and also updates tokens which are not hashed
 register(


### PR DESCRIPTION
The logic inside  `get_integration_from_request` is flawed. 

The check for "organization_slug" and "integration_id" will never return True because the function is only called when `get_response_from_gitlab_webhook` is called.

`get_response_from_gitlab_webhook` is [called](https://github.com/getsentry/sentry/blob/master/src/sentry/middleware/integrations/parsers/gitlab.py#L104-L107) only when the Endpoint is `GitlabWebhookEndpoint`. This endpoint is a webhook endpoint which will never have the above path params.

I have put this change behind an option so we can toggle it quickly. We will monitor the metric and if it is safe to do so, we will remove the option and the logic.