### PR TITLE
fix: increase timeout duration of appstore connect

### DIFF
--- a/src/sentry/utils/appleconnect/appstore_connect.py
+++ b/src/sentry/utils/appleconnect/appstore_connect.py
@@ -21,7 +21,7 @@ logger = logging.getLogger(__name__)
 
 AppConnectCredentials = namedtuple("AppConnectCredentials", ["key_id", "key", "issuer_id"])
 
-REQUEST_TIMEOUT = 30.0
+REQUEST_TIMEOUT = 60.0
 
 
 class RequestError(Exception):


### PR DESCRIPTION
Increases the timeout duration of AppStore Connect events.

Ref: [https://sentry.sentry.io/issues/4741836679/?environment=prod&environment=production&p[…]ry=json&referrer=issue-stream&statsPeriod=12h&stream_index=1](https://sentry.sentry.io/issues/4741836679/?environment=prod&environment=production&project=1&query=json&referrer=issue-stream&statsPeriod=12h&stream_index=1)