### PR TITLE
feat(metrics): use new meta tables for metrics meta queries in metrics API

### DIFF
--- a/src/sentry/api/endpoints/organization_metrics.py
+++ b/src/sentry/api/endpoints/organization_metrics.py
@@ -37,6 +37,7 @@ from sentry.sentry_metrics.querying.errors import (
     MetricsQueryExecutionError,
 )
 from sentry.sentry_metrics.querying.metadata import MetricCodeLocations, get_metric_code_locations
+from sentry.sentry_metrics.querying.metadata.metrics import get_metrics_meta
 from sentry.sentry_metrics.querying.metadata.tags import get_tag_values
 from sentry.sentry_metrics.querying.metadata.utils import convert_metric_names_to_mris
 from sentry.sentry_metrics.querying.samples_list import get_sample_list_executor_cls
@@ -47,13 +48,7 @@ from sentry.sentry_metrics.use_case_id_registry import (
     get_use_case_id_api_access,
 )
 from sentry.sentry_metrics.utils import string_to_use_case_id
-from sentry.snuba.metrics import (
-    QueryDefinition,
-    get_all_tags,
-    get_metrics_meta,
-    get_series,
-    get_single_metric_info,
-)
+from sentry.snuba.metrics import QueryDefinition, get_all_tags, get_series, get_single_metric_info
 from sentry.snuba.metrics.naming_layer.mri import is_mri
 from sentry.snuba.metrics.utils import DerivedMetricException, DerivedMetricParseException
 from sentry.snuba.referrer import Referrer
@@ -156,10 +151,8 @@ class OrganizationMetricsDetailsEndpoint(OrganizationEndpoint):
         if not projects:
             raise InvalidParams("You must supply at least one project to see its metrics")
 
-        start, end = get_date_range_from_params(request.GET)
-
         metrics = get_metrics_meta(
-            projects=projects, use_case_ids=get_use_case_ids(request), start=start, end=end
+            organization=organization, projects=projects, use_case_ids=get_use_case_ids(request)
         )
 
         return Response(metrics, status=200)

--- a/src/sentry/api/endpoints/organization_metrics.py
+++ b/src/sentry/api/endpoints/organization_metrics.py
@@ -36,10 +36,13 @@ from sentry.sentry_metrics.querying.errors import (
     LatestReleaseNotFoundError,
     MetricsQueryExecutionError,
 )
-from sentry.sentry_metrics.querying.metadata import MetricCodeLocations, get_metric_code_locations
-from sentry.sentry_metrics.querying.metadata.metrics import get_metrics_meta
-from sentry.sentry_metrics.querying.metadata.tags import get_tag_values
-from sentry.sentry_metrics.querying.metadata.utils import convert_metric_names_to_mris
+from sentry.sentry_metrics.querying.metadata import (
+    MetricCodeLocations,
+    convert_metric_names_to_mris,
+    get_metric_code_locations,
+    get_metrics_meta,
+    get_tag_values,
+)
 from sentry.sentry_metrics.querying.samples_list import get_sample_list_executor_cls
 from sentry.sentry_metrics.querying.types import QueryOrder, QueryType
 from sentry.sentry_metrics.use_case_id_registry import (

--- a/src/sentry/api/endpoints/organization_metrics.py
+++ b/src/sentry/api/endpoints/organization_metrics.py
@@ -243,6 +243,10 @@ class OrganizationMetricsTagDetailsEndpoint(OrganizationEndpoint):
 
     def get(self, request: Request, organization, tag_name) -> Response:
         metric_names = request.GET.getlist("metric") or []
+        if len(metric_names) > 1:
+            raise InvalidParams(
+                "Please supply only a single metric name. More than one metric name is not supported for this endpoint."
+            )
         projects = self.get_projects(request, organization)
         if not projects:
             raise InvalidParams("You must supply at least one project to see the tag values")

--- a/src/sentry/sentry_metrics/querying/metadata/__init__.py
+++ b/src/sentry/sentry_metrics/querying/metadata/__init__.py
@@ -1,3 +1,12 @@
+from .metrics import get_metrics_meta
 from .metrics_code_locations import MetricCodeLocations, get_metric_code_locations
+from .tags import get_tag_values
+from .utils import convert_metric_names_to_mris
 
-__all__ = ["MetricCodeLocations", "get_metric_code_locations"]
+__all__ = [
+    "MetricCodeLocations",
+    "convert_metric_names_to_mris",
+    "get_metric_code_locations",
+    "get_metrics_meta",
+    "get_tag_values",
+]

--- a/src/sentry/sentry_metrics/querying/metadata/metrics.py
+++ b/src/sentry/sentry_metrics/querying/metadata/metrics.py
@@ -35,6 +35,9 @@ def get_metrics_meta(
         for metric_mri, project_ids in stored_metrics.items():
             parsed_mri = parse_mri(metric_mri)
 
+            if parsed_mri is None:
+                continue
+
             blocking_status = []
             if (metric_blocking := metrics_blocking_state.get(metric_mri)) is not None:
                 blocking_status = [

--- a/src/sentry/sentry_metrics/querying/metadata/metrics.py
+++ b/src/sentry/sentry_metrics/querying/metadata/metrics.py
@@ -1,0 +1,94 @@
+from collections import defaultdict
+from collections.abc import Sequence
+from typing import Any
+
+from sentry.models.organization import Organization
+from sentry.models.project import Project
+from sentry.sentry_metrics.use_case_id_registry import UseCaseID
+from sentry.snuba.metrics import parse_mri
+from sentry.snuba.metrics.datasource import (
+    _build_metric_meta,
+    get_metrics_blocking_state_of_projects,
+)
+from sentry.snuba.metrics.utils import BlockedMetric, MetricMeta
+from sentry.snuba.metrics_layer.query import fetch_metric_mris
+
+
+def get_metrics_meta(
+    organization: Organization,
+    projects: Sequence[Project],
+    use_case_ids: Sequence[UseCaseID],
+) -> Sequence[MetricMeta]:
+    if not projects:
+        return []
+
+    stored_metrics = get_available_mris(organization, projects, use_case_ids)
+    metrics_blocking_state = (
+        get_metrics_blocking_state_of_projects(projects) if UseCaseID.CUSTOM in use_case_ids else {}
+    )
+
+    metrics_metas = []
+    for metric_mri, project_ids in stored_metrics.items():
+        parsed_mri = parse_mri(metric_mri)
+
+        blocking_status = []
+        if (metric_blocking := metrics_blocking_state.get(metric_mri)) is not None:
+            blocking_status = [
+                BlockedMetric(isBlocked=is_blocked, blockedTags=blocked_tags, projectId=project_id)
+                for is_blocked, blocked_tags, project_id in metric_blocking
+            ]
+            # We delete the metric so that in the next steps we can just merge the remaining blocked metrics that are
+            # not stored.
+            del metrics_blocking_state[metric_mri]
+
+        metrics_metas.append(_build_metric_meta(parsed_mri, project_ids, blocking_status))
+
+    for metric_mri, metric_blocking in metrics_blocking_state.items():
+        parsed_mri = parse_mri(metric_mri)
+        if parsed_mri is None:
+            continue
+
+        metrics_metas.append(
+            _build_metric_meta(
+                parsed_mri,
+                [],
+                [
+                    BlockedMetric(
+                        isBlocked=is_blocked, blockedTags=blocked_tags, projectId=project_id
+                    )
+                    for is_blocked, blocked_tags, project_id in metric_blocking
+                ],
+            )
+        )
+
+    return metrics_metas
+
+
+def get_available_mris(
+    organization: Organization, projects: Sequence[Project], use_case_id: UseCaseID
+) -> dict[str, list[int]]:
+    """
+    Returns a dictionary containing the Metrics MRIs available as keys, and the corresponding
+    list of project_ids in which the MRI is available as values.
+    """
+    project_ids = [project.id for project in projects]
+    project_id_to_mris = fetch_metric_mris(organization.id, project_ids, use_case_id)
+    mris_to_project_ids = _reverse_mapping(project_id_to_mris)
+
+    return mris_to_project_ids
+
+
+def _reverse_mapping(project_id_to_mris: dict[int, list[str]]):
+    mris_to_project_ids: dict[str, list[int]] = defaultdict(list)
+
+    mris = set(_flatten([mri for mri in project_id_to_mris.values()]))
+    for mri in mris:
+        for project_id in project_id_to_mris.keys():
+            if mri in project_id_to_mris[project_id]:
+                mris_to_project_ids[mri].append(project_id)
+
+    return mris_to_project_ids
+
+
+def _flatten(list_of_lists: list[list[Any]]) -> list[Any]:
+    return [element for sublist in list_of_lists for element in sublist]

--- a/src/sentry/sentry_metrics/querying/metadata/metrics.py
+++ b/src/sentry/sentry_metrics/querying/metadata/metrics.py
@@ -1,6 +1,5 @@
 from collections import defaultdict
 from collections.abc import Sequence
-from typing import Any
 
 from sentry.models.organization import Organization
 from sentry.models.project import Project
@@ -82,22 +81,17 @@ def get_available_mris(
     """
     project_ids = [project.id for project in projects]
     project_id_to_mris = fetch_metric_mris(organization.id, project_ids, use_case_id)
-    mris_to_project_ids = _reverse_mapping(project_id_to_mris)
+    mris_to_project_ids = _convert_to_mris_to_project_ids_mapping(project_id_to_mris)
 
     return mris_to_project_ids
 
 
-def _reverse_mapping(project_id_to_mris: dict[int, list[str]]):
+def _convert_to_mris_to_project_ids_mapping(project_id_to_mris: dict[int, list[str]]):
     mris_to_project_ids: dict[str, list[int]] = defaultdict(list)
 
-    mris = set(_flatten([mri for mri in project_id_to_mris.values()]))
-    for mri in mris:
-        for project_id in project_id_to_mris.keys():
-            if mri in project_id_to_mris[project_id]:
-                mris_to_project_ids[mri].append(project_id)
+    mris_to_project_ids = {}
+    for project_id, mris in project_id_to_mris.items():
+        for mri in mris:
+            mris_to_project_ids.setdefault(mri, []).append(project_id)
 
     return mris_to_project_ids
-
-
-def _flatten(list_of_lists: list[list[Any]]) -> list[Any]:
-    return [element for sublist in list_of_lists for element in sublist]

--- a/src/sentry/sentry_metrics/querying/metadata/tags.py
+++ b/src/sentry/sentry_metrics/querying/metadata/tags.py
@@ -49,12 +49,12 @@ def get_tag_values(
     """
     Get all available tag values for an MRI and tag key from metrics.
     """
+    project_ids = [project.id for project in projects]
     tag_values: set[str] = set()
-    for project in projects:
-        for use_case_id in use_case_ids:
-            use_case_tag_values = fetch_metric_tag_values(
-                organization.id, project.id, use_case_id, mri, tag_key
-            )
-            tag_values = tag_values.union(use_case_tag_values)
+    for use_case_id in use_case_ids:
+        use_case_tag_values = fetch_metric_tag_values(
+            organization.id, project_ids, use_case_id, mri, tag_key
+        )
+        tag_values = tag_values.union(use_case_tag_values)
 
     return list(tag_values)

--- a/src/sentry/sentry_metrics/querying/metadata/tags.py
+++ b/src/sentry/sentry_metrics/querying/metadata/tags.py
@@ -1,0 +1,59 @@
+from collections.abc import Sequence
+from dataclasses import dataclass
+
+from sentry.models.organization import Organization
+from sentry.models.project import Project
+from sentry.sentry_metrics.use_case_id_registry import UseCaseID
+from sentry.snuba.metrics_layer.query import fetch_metric_tag_keys, fetch_metric_tag_values
+
+
+@dataclass
+class TagValue:
+    key: str
+    value: str
+
+    def __hash__(self):
+        return hash((self.key, self.value))
+
+
+def get_tag_keys(
+    organization: Organization,
+    projects: Sequence[Project],
+    use_case_ids: Sequence[UseCaseID],
+    mris: list[str],
+) -> list[str]:
+    """
+    Get all available tag keys for a given MRI, specified projects and use_case_ids.
+    Returns list of strings representing tag keys for a list of MRIs
+    """
+    all_tag_keys: set[str] = set()
+    for mri in mris:
+        for use_case_id in use_case_ids:
+            project_ids = [project.id for project in projects]
+            tag_keys_per_project = fetch_metric_tag_keys(
+                organization.id, project_ids, use_case_id, mri
+            )
+            for tag_keys in tag_keys_per_project.values():
+                all_tag_keys = all_tag_keys.union(tag_keys)
+
+    return sorted(list(all_tag_keys))
+
+
+def get_tag_values(
+    organization: Organization,
+    projects: Sequence[Project],
+    use_case_ids: Sequence[UseCaseID],
+    mri: str,
+    tag_key: str,
+) -> list[TagValue]:
+    """
+    Get all available tag values for an MRI and tag key from metrics.
+    """
+    tag_values: set[TagValue] = set()
+    for project in projects:
+        for use_case_id in use_case_ids:
+            tag_values = tag_values.union(
+                fetch_metric_tag_values(organization.id, project.id, use_case_id, mri, tag_key)
+            )
+
+    return list(tag_values)

--- a/src/sentry/sentry_metrics/querying/metadata/tags.py
+++ b/src/sentry/sentry_metrics/querying/metadata/tags.py
@@ -27,9 +27,9 @@ def get_tag_keys(
     Returns list of strings representing tag keys for a list of MRIs
     """
     all_tag_keys: set[str] = set()
+    project_ids = [project.id for project in projects]
     for mri in mris:
         for use_case_id in use_case_ids:
-            project_ids = [project.id for project in projects]
             tag_keys_per_project = fetch_metric_tag_keys(
                 organization.id, project_ids, use_case_id, mri
             )

--- a/src/sentry/sentry_metrics/querying/metadata/tags.py
+++ b/src/sentry/sentry_metrics/querying/metadata/tags.py
@@ -45,15 +45,16 @@ def get_tag_values(
     use_case_ids: Sequence[UseCaseID],
     mri: str,
     tag_key: str,
-) -> list[TagValue]:
+) -> list[str]:
     """
     Get all available tag values for an MRI and tag key from metrics.
     """
-    tag_values: set[TagValue] = set()
+    tag_values: set[str] = set()
     for project in projects:
         for use_case_id in use_case_ids:
-            tag_values = tag_values.union(
-                fetch_metric_tag_values(organization.id, project.id, use_case_id, mri, tag_key)
+            use_case_tag_values = fetch_metric_tag_values(
+                organization.id, project.id, use_case_id, mri, tag_key
             )
+            tag_values = tag_values.union(use_case_tag_values)
 
     return list(tag_values)

--- a/src/sentry/sentry_metrics/querying/metadata/utils.py
+++ b/src/sentry/sentry_metrics/querying/metadata/utils.py
@@ -1,0 +1,13 @@
+from sentry.snuba.metrics import get_mri
+from sentry.snuba.metrics.naming_layer.mri import is_mri
+
+
+def convert_metric_names_to_mris(metric_names: list[str]) -> list[str]:
+    mris: list[str] = []
+    for metric_name in metric_names or ():
+        if is_mri(metric_name):
+            mris.append(metric_name)
+        else:
+            mris.append(get_mri(metric_name))
+
+    return mris

--- a/tests/sentry/api/endpoints/test_organization_metrics_metadata.py
+++ b/tests/sentry/api/endpoints/test_organization_metrics_metadata.py
@@ -126,7 +126,11 @@ class OrganizationMetricsTagValues(MetricsAPIBaseTestCase):
             project=[self.project.id],
             useCase="transactions",
         )
-        assert response.content == b'{"detail":"Unknown metric or tag key"}'
+        assert response.status_code == 404
+        assert (
+            response.json()["detail"]
+            == "No data found for metric: d:transactions/duration@millisecond and tag: my_non_existent_tag"
+        )
 
     def test_non_existing_tag_for_custom_use_case(self):
         response = self.get_error_response(
@@ -136,7 +140,11 @@ class OrganizationMetricsTagValues(MetricsAPIBaseTestCase):
             project=[self.project.id],
             useCase="custom",
         )
-        assert response.content == b'{"detail":"Unknown metric or tag key"}'
+        assert response.status_code == 404
+        assert (
+            response.json()["detail"]
+            == "No data found for metric: d:custom/my_test_metric@percent and tag: my_non_existent_tag"
+        )
 
     def test_tag_details_for_non_existent_metric(self):
         response = self.get_error_response(
@@ -146,7 +154,11 @@ class OrganizationMetricsTagValues(MetricsAPIBaseTestCase):
             project=[self.project.id],
             useCase="custom",
         )
-        assert response.content == b'{"detail":"Unknown metric or tag key"}'
+        assert response.status_code == 404
+        assert (
+            response.json()["detail"]
+            == "No data found for metric: d:custom/my_non_existent_test_metric@percent and tag: my_non_existent_tag"
+        )
 
     # fix this
     def test_tag_details_for_multiple_supplied_metrics(self):
@@ -162,6 +174,6 @@ class OrganizationMetricsTagValues(MetricsAPIBaseTestCase):
         )
 
         assert (
-            response.content
-            == b'{"detail":"Please supply only a single metric name. More than one metric name is not supported for this endpoint."}'
+            response.json()["detail"]
+            == "Please supply only a single metric name. Specifying multiple metric names is not supported for this endpoint."
         )

--- a/tests/sentry/api/endpoints/test_organization_metrics_metadata.py
+++ b/tests/sentry/api/endpoints/test_organization_metrics_metadata.py
@@ -98,7 +98,7 @@ class OrganizationMetricsTagValues(MetricsAPIBaseTestCase):
             project=[self.project.id],
             useCase="transactions",
         )
-        assert response.data == [
+        assert sorted(response.data, key=lambda x: x["value"]) == [
             {"key": "transaction", "value": "/hello"},
             {"key": "transaction", "value": "/world"},
         ]
@@ -148,6 +148,7 @@ class OrganizationMetricsTagValues(MetricsAPIBaseTestCase):
         )
         assert response.content == b'{"detail":"Unknown metric or tag key"}'
 
+    # fix this
     def test_tag_details_for_multiple_supplied_metrics(self):
         response = self.get_error_response(
             self.project.organization.slug,
@@ -159,4 +160,8 @@ class OrganizationMetricsTagValues(MetricsAPIBaseTestCase):
             project=[self.project.id],
             useCase="custom",
         )
-        assert response.content == b'{"detail":"Unknown metric or tag key"}'
+
+        assert (
+            response.content
+            == b'{"detail":"Please supply only a single metric name. More than one metric name is not supported for this endpoint."}'
+        )

--- a/tests/sentry/api/endpoints/test_organization_metrics_metadata.py
+++ b/tests/sentry/api/endpoints/test_organization_metrics_metadata.py
@@ -1,0 +1,162 @@
+from datetime import timedelta
+
+import pytest
+
+from sentry.sentry_metrics.use_case_id_registry import UseCaseID
+from sentry.snuba.metrics.naming_layer import TransactionMRI
+from sentry.testutils.cases import MetricsAPIBaseTestCase
+from sentry.testutils.helpers.datetime import freeze_time
+
+pytestmark = pytest.mark.sentry_metrics
+
+
+@freeze_time(MetricsAPIBaseTestCase.MOCK_DATETIME)
+class OrganizationMetricsTagValues(MetricsAPIBaseTestCase):
+    method = "get"
+    endpoint = "sentry-api-0-organization-metrics-tag-details"
+
+    def setUp(self):
+        super().setUp()
+        self.login_as(self.user)
+
+        release_1 = self.create_release(
+            project=self.project, version="1.0", date_added=MetricsAPIBaseTestCase.MOCK_DATETIME
+        )
+        release_2 = self.create_release(
+            project=self.project,
+            version="2.0",
+            date_added=MetricsAPIBaseTestCase.MOCK_DATETIME + timedelta(minutes=5),
+        )
+
+        # Use Case: TRANSACTIONS
+        for value, transaction, platform, env, release, time in (
+            (1, "/hello", "android", "prod", release_1.version, self.now()),
+            (6, "/hello", "ios", "dev", release_2.version, self.now()),
+            (5, "/world", "windows", "prod", release_1.version, self.now() + timedelta(minutes=30)),
+            (3, "/hello", "ios", "dev", release_2.version, self.now() + timedelta(hours=1)),
+            (2, "/hello", "android", "dev", release_1.version, self.now() + timedelta(hours=1)),
+            (
+                4,
+                "/world",
+                "windows",
+                "prod",
+                release_2.version,
+                self.now() + timedelta(hours=1, minutes=30),
+            ),
+        ):
+            self.store_metric(
+                self.project.organization.id,
+                self.project.id,
+                "distribution",
+                TransactionMRI.DURATION.value,
+                {
+                    "transaction": transaction,
+                    "platform": platform,
+                    "environment": env,
+                    "release": release,
+                },
+                self.now().timestamp(),
+                value,
+                UseCaseID.TRANSACTIONS,
+            )
+        # Use Case: CUSTOM
+        for value, release, tag_value, time in (
+            (1, release_1.version, "tag_value_1", self.now()),
+            (1, release_1.version, "tag_value_1", self.now()),
+            (1, release_1.version, "tag_value_2", self.now() - timedelta(days=40)),
+            (1, release_2.version, "tag_value_3", self.now() - timedelta(days=50)),
+            (1, release_2.version, "tag_value_4", self.now() - timedelta(days=60)),
+        ):
+            self.store_metric(
+                self.project.organization.id,
+                self.project.id,
+                "distribution",
+                "d:custom/my_test_metric@percent",
+                {
+                    "transaction": "/hello",
+                    "platform": "platform",
+                    "environment": "prod",
+                    "release": release,
+                    "mytag": tag_value,
+                },
+                self.now().timestamp(),
+                value,
+                UseCaseID.CUSTOM,
+            )
+
+        self.prod_env = self.create_environment(name="prod", project=self.project)
+        self.dev_env = self.create_environment(name="dev", project=self.project)
+
+    def now(self):
+        return MetricsAPIBaseTestCase.MOCK_DATETIME
+
+    def test_tag_details_for_transactions_use_case(self):
+        response = self.get_success_response(
+            self.project.organization.slug,
+            "transaction",
+            metric=["d:transactions/duration@millisecond"],
+            project=[self.project.id],
+            useCase="transactions",
+        )
+        assert response.data == [
+            {"key": "transaction", "value": "/hello"},
+            {"key": "transaction", "value": "/world"},
+        ]
+
+    def test_tag_details_for_custom_use_case(self):
+        response = self.get_success_response(
+            self.project.organization.slug,
+            "mytag",
+            metric=["d:custom/my_test_metric@percent"],
+            project=[self.project.id],
+            useCase="custom",
+        )
+        assert sorted(response.data, key=lambda x: x["value"]) == [
+            {"key": "mytag", "value": "tag_value_1"},
+            {"key": "mytag", "value": "tag_value_2"},
+            {"key": "mytag", "value": "tag_value_3"},
+            {"key": "mytag", "value": "tag_value_4"},
+        ]
+
+    def test_non_existing_tag_for_transactions_use_case(self):
+        response = self.get_error_response(
+            self.project.organization.slug,
+            "my_non_existent_tag",
+            metric=["d:transactions/duration@millisecond"],
+            project=[self.project.id],
+            useCase="transactions",
+        )
+        assert response.content == b'{"detail":"Unknown metric or tag key"}'
+
+    def test_non_existing_tag_for_custom_use_case(self):
+        response = self.get_error_response(
+            self.project.organization.slug,
+            "my_non_existent_tag",
+            metric=["d:custom/my_test_metric@percent"],
+            project=[self.project.id],
+            useCase="custom",
+        )
+        assert response.content == b'{"detail":"Unknown metric or tag key"}'
+
+    def test_tag_details_for_non_existent_metric(self):
+        response = self.get_error_response(
+            self.project.organization.slug,
+            "my_non_existent_tag",
+            metric=["d:custom/my_non_existent_test_metric@percent"],
+            project=[self.project.id],
+            useCase="custom",
+        )
+        assert response.content == b'{"detail":"Unknown metric or tag key"}'
+
+    def test_tag_details_for_multiple_supplied_metrics(self):
+        response = self.get_error_response(
+            self.project.organization.slug,
+            "my_non_existent_tag",
+            metric=[
+                "d:custom/my_test_metric@percent",
+                "d:transactions/duration@millisecond",
+            ],
+            project=[self.project.id],
+            useCase="custom",
+        )
+        assert response.content == b'{"detail":"Unknown metric or tag key"}'

--- a/tests/sentry/api/endpoints/test_organization_metrics_tag_details.py
+++ b/tests/sentry/api/endpoints/test_organization_metrics_tag_details.py
@@ -1,19 +1,10 @@
 import time
-from datetime import datetime, timedelta
-from unittest.mock import patch
 
 import pytest
 
 from sentry.sentry_metrics import indexer
 from sentry.sentry_metrics.use_case_id_registry import UseCaseID
-from sentry.snuba.metrics.naming_layer import get_mri
-from sentry.snuba.metrics.naming_layer.public import SessionMetricKey
 from sentry.testutils.cases import MetricsAPIBaseTestCase, OrganizationMetricsIntegrationTestCase
-from sentry.testutils.helpers.datetime import freeze_time
-from tests.sentry.api.endpoints.test_organization_metrics import (
-    MOCKED_DERIVED_METRICS,
-    mocked_mri_resolver,
-)
 
 pytestmark = pytest.mark.sentry_metrics
 
@@ -32,98 +23,20 @@ class OrganizationMetricsTagDetailsTest(OrganizationMetricsIntegrationTestCase):
 
     def test_unknown_tag(self):
         _indexer_record(self.organization.id, "bar")
-        response = self.get_success_response(self.project.organization.slug, "bar")
-        assert response.data == []
+        response = self.get_response(self.project.organization.slug, "bar")
+        assert response.status_code == 404
+        assert response.json()["detail"] == "No data found for tag: bar"
 
     def test_non_existing_tag(self):
         response = self.get_response(self.project.organization.slug, "bar")
-        assert response.status_code == 400
+        assert response.status_code == 404
+        assert response.json()["detail"] == "No data found for tag: bar"
 
-    @patch("sentry.snuba.metrics.datasource.get_mri", mocked_mri_resolver(["bad"], get_mri))
-    def test_non_existing_filter(self):
+    def test_non_existing_metric_name(self):
         _indexer_record(self.organization.id, "bar")
         response = self.get_response(self.project.organization.slug, "bar", metric="bad")
-        assert response.status_code == 200
-        assert response.data == []
-
-    @patch(
-        "sentry.snuba.metrics.datasource.get_mri",
-        mocked_mri_resolver(["metric1", "metric2", "metric3", "random_tag"], get_mri),
-    )
-    def test_metric_tag_details(self):
-        response = self.get_success_response(
-            self.organization.slug,
-            "tag1",
-        )
-        assert response.data == [
-            {"key": "tag1", "value": "value1"},
-            {"key": "tag1", "value": "value2"},
-        ]
-
-        # When single metric_name is supplied, get only tag values for that metric:
-        response = self.get_success_response(
-            self.organization.slug,
-            "tag1",
-            metric=["metric1"],
-        )
-        assert response.data == [
-            {"key": "tag1", "value": "value1"},
-        ]
-
-        # When metric names are supplied, get intersection of tags:
-        response = self.get_success_response(
-            self.organization.slug,
-            "tag1",
-            metric=["metric1", "metric2"],
-        )
-        assert response.data == []
-
-        # We need to ensure that if the tag is present in the indexer but has no values in the
-        # dataset, the intersection of it and other tags should not yield any results
-        _indexer_record(self.organization.id, "random_tag")
-        response = self.get_success_response(
-            self.organization.slug,
-            "tag1",
-            metric=["metric1", "random_tag"],
-        )
-        assert response.data == []
-
-    def test_tag_values_for_session_status_tag(self):
-        self.store_session(
-            self.build_session(
-                project_id=self.project.id,
-                started=(time.time() // 60) * 60,
-                status="ok",
-                release="foobar",
-                errors=2,
-            )
-        )
-        response = self.get_response(
-            self.organization.slug,
-            "session.status",
-        )
-        assert response.data["detail"] == "Tag name session.status is an unallowed tag"
-
-    @freeze_time((datetime.now() - timedelta(hours=1)).replace(minute=30))
-    def test_tag_values_for_derived_metrics(self):
-        self.store_session(
-            self.build_session(
-                project_id=self.project.id,
-                started=(time.time() // 60) * 60,
-                status="ok",
-                release="foobar",
-                errors=2,
-            )
-        )
-        response = self.get_response(
-            self.organization.slug,
-            "release",
-            metric=[
-                SessionMetricKey.CRASH_FREE_RATE.value,
-                SessionMetricKey.ALL.value,
-            ],
-        )
-        assert response.data == [{"key": "release", "value": "foobar"}]
+        assert response.status_code == 404
+        assert response.json()["detail"] == "No data found for metric: bad and tag: bar"
 
     def test_metric_not_in_naming_layer(self):
         self.store_session(
@@ -141,87 +54,8 @@ class OrganizationMetricsTagDetailsTest(OrganizationMetricsIntegrationTestCase):
             "release",
             metric=["session.abnormal_and_crashed"],
         )
-        assert response.data == []
-
-    @freeze_time((datetime.now() - timedelta(hours=1)).replace(minute=30))
-    def test_tag_values_for_composite_derived_metrics(self):
-        self.store_session(
-            self.build_session(
-                project_id=self.project.id,
-                started=(time.time() // 60) * 60,
-                status="ok",
-                release="foobar@2.0",
-                errors=2,
-            )
+        assert response.status_code == 404
+        assert (
+            response.json()["detail"]
+            == "No data found for metric: session.abnormal_and_crashed and tag: release"
         )
-        response = self.get_success_response(
-            self.organization.slug,
-            "release",
-            metric=[SessionMetricKey.HEALTHY.value],
-        )
-        assert response.data == [{"key": "release", "value": "foobar@2.0"}]
-
-    def test_tag_not_available_in_the_indexer(self):
-        response = self.get_response(
-            self.organization.slug,
-            "random_foo_tag",
-            metric=[SessionMetricKey.HEALTHY.value],
-        )
-        assert response.status_code == 400
-        assert response.json()["detail"] == "Tag random_foo_tag is not available in the indexer"
-
-    @freeze_time((datetime.now() - timedelta(hours=1)).replace(minute=30))
-    @patch("sentry.snuba.metrics.fields.base.DERIVED_METRICS", MOCKED_DERIVED_METRICS)
-    @patch("sentry.snuba.metrics.datasource.get_mri")
-    @patch("sentry.snuba.metrics.datasource.get_derived_metrics")
-    def test_incorrectly_setup_derived_metric(self, mocked_derived_metrics, mocked_mri):
-        mocked_derived_metrics.return_value = MOCKED_DERIVED_METRICS
-        mocked_mri.return_value = "crash_free_fake"
-        self.store_session(
-            self.build_session(
-                project_id=self.project.id,
-                started=(time.time() // 60) * 60,
-                status="ok",
-                release="foobar",
-                errors=2,
-            )
-        )
-        response = self.get_response(
-            self.organization.slug,
-            "release",
-            metric=["crash_free_fake"],
-        )
-        assert response.json()["detail"] == (
-            "The following metrics {'crash_free_fake'} cannot be computed from single entities. "
-            "Please revise the definition of these singular entity derived metrics"
-        )
-
-    def test_metric_tag_details_with_date_range(self):
-        mri = "c:custom/clicks@none"
-        transactions = (
-            ("/hello", 0),
-            ("/world", 1),
-            ("/foo", 7),
-        )
-        for transaction, days in transactions:
-            self.store_metric(
-                self.project.organization.id,
-                self.project.id,
-                "counter",
-                mri,
-                {"transaction": transaction},
-                int((self.now - timedelta(days=days)).timestamp()),
-                10,
-                UseCaseID.CUSTOM,
-            )
-
-        for stats_period, expected_count in (("1d", 1), ("2d", 2), ("2w", 3)):
-            response = self.get_success_response(
-                self.organization.slug,
-                "transaction",
-                metric=[mri],
-                project=self.project.id,
-                useCase="custom",
-                statsPeriod=stats_period,
-            )
-            assert len(response.data) == expected_count

--- a/tests/sentry/api/endpoints/test_organization_metrics_tag_details_v2.py
+++ b/tests/sentry/api/endpoints/test_organization_metrics_tag_details_v2.py
@@ -126,7 +126,11 @@ class OrganizationMetricsTagValues(MetricsAPIBaseTestCase):
             project=[self.project.id],
             useCase="transactions",
         )
-        assert response.content == b'{"detail":"Unknown metric or tag key"}'
+        assert response.status_code == 404
+        assert (
+            response.json()["detail"]
+            == "No data found for metric: d:transactions/duration@millisecond and tag: my_non_existent_tag"
+        )
 
     def test_non_existing_tag_for_custom_use_case(self):
         response = self.get_error_response(
@@ -136,7 +140,11 @@ class OrganizationMetricsTagValues(MetricsAPIBaseTestCase):
             project=[self.project.id],
             useCase="custom",
         )
-        assert response.content == b'{"detail":"Unknown metric or tag key"}'
+        assert response.status_code == 404
+        assert (
+            response.json()["detail"]
+            == "No data found for metric: d:custom/my_test_metric@percent and tag: my_non_existent_tag"
+        )
 
     def test_tag_details_for_non_existent_metric(self):
         response = self.get_error_response(
@@ -146,7 +154,11 @@ class OrganizationMetricsTagValues(MetricsAPIBaseTestCase):
             project=[self.project.id],
             useCase="custom",
         )
-        assert response.content == b'{"detail":"Unknown metric or tag key"}'
+        assert response.status_code == 404
+        assert (
+            response.json()["detail"]
+            == "No data found for metric: d:custom/my_non_existent_test_metric@percent and tag: my_non_existent_tag"
+        )
 
     def test_tag_details_for_multiple_supplied_metrics(self):
         response = self.get_error_response(
@@ -159,4 +171,8 @@ class OrganizationMetricsTagValues(MetricsAPIBaseTestCase):
             project=[self.project.id],
             useCase="custom",
         )
-        assert response.content == b'{"detail":"Unknown metric or tag key"}'
+        assert response.status_code == 400
+        assert (
+            response.json()["detail"]
+            == "Please supply only a single metric name. Specifying multiple metric names is not supported for this endpoint."
+        )

--- a/tests/sentry/api/endpoints/test_organization_metrics_tag_details_v2.py
+++ b/tests/sentry/api/endpoints/test_organization_metrics_tag_details_v2.py
@@ -11,7 +11,7 @@ pytestmark = pytest.mark.sentry_metrics
 
 
 @freeze_time(MetricsAPIBaseTestCase.MOCK_DATETIME)
-class OrganizationMetricsTagDetailsTestV2(MetricsAPIBaseTestCase):
+class OrganizationMetricsTagValues(MetricsAPIBaseTestCase):
     method = "get"
     endpoint = "sentry-api-0-organization-metrics-tag-details"
 
@@ -143,6 +143,19 @@ class OrganizationMetricsTagDetailsTestV2(MetricsAPIBaseTestCase):
             self.project.organization.slug,
             "my_non_existent_tag",
             metric=["d:custom/my_non_existent_test_metric@percent"],
+            project=[self.project.id],
+            useCase="custom",
+        )
+        assert response.content == b'{"detail":"Unknown metric or tag key"}'
+
+    def test_tag_details_for_multiple_supplied_metrics(self):
+        response = self.get_error_response(
+            self.project.organization.slug,
+            "my_non_existent_tag",
+            metric=[
+                "d:custom/my_test_metric@percent",
+                "d:transactions/duration@millisecond",
+            ],
             project=[self.project.id],
             useCase="custom",
         )

--- a/tests/sentry/api/endpoints/test_organization_metrics_tag_details_v2.py
+++ b/tests/sentry/api/endpoints/test_organization_metrics_tag_details_v2.py
@@ -1,0 +1,114 @@
+from datetime import datetime, timedelta
+
+import pytest
+from django.utils import timezone
+
+from sentry.sentry_metrics import indexer
+from sentry.sentry_metrics.use_case_id_registry import UseCaseID
+from sentry.snuba.metrics.naming_layer import TransactionMRI
+from sentry.testutils.cases import MetricsAPIBaseTestCase
+from sentry.testutils.helpers.datetime import freeze_time
+
+pytestmark = pytest.mark.sentry_metrics
+
+MOCK_DATETIME = (timezone.now() - timedelta(days=1)).replace(
+    hour=10, minute=0, second=0, microsecond=0
+)
+
+
+def _indexer_record(org_id: int, string: str) -> None:
+    indexer.record(use_case_id=UseCaseID.SESSIONS, org_id=org_id, string=string)
+
+
+@freeze_time(MOCK_DATETIME)
+class OrganizationMetricsTagDetailsTestV2(MetricsAPIBaseTestCase):
+    method = "get"
+    endpoint = "sentry-api-0-organization-metrics-tag-details"
+
+    def setUp(self):
+        super().setUp()
+        self.login_as(user=self.user)
+
+        release_1 = self.create_release(
+            project=self.project, version="1.0", date_added=MOCK_DATETIME
+        )
+        release_2 = self.create_release(
+            project=self.project, version="2.0", date_added=MOCK_DATETIME + timedelta(minutes=5)
+        )
+
+        for value, transaction, platform, env, release, time in (
+            (1, "/hello", "android", "prod", release_1.version, self.now()),
+            (6, "/hello", "ios", "dev", release_2.version, self.now()),
+            (5, "/world", "windows", "prod", release_1.version, self.now() + timedelta(minutes=30)),
+            (3, "/hello", "ios", "dev", release_2.version, self.now() + timedelta(hours=1)),
+            (2, "/hello", "android", "dev", release_1.version, self.now() + timedelta(hours=1)),
+            (
+                4,
+                "/world",
+                "windows",
+                "prod",
+                release_2.version,
+                self.now() + timedelta(hours=1, minutes=30),
+            ),
+        ):
+            self.store_metric(
+                self.project.organization.id,
+                self.project.id,
+                "distribution",
+                TransactionMRI.DURATION.value,
+                {
+                    "transaction": transaction,
+                    "platform": platform,
+                    "environment": env,
+                    "release": release,
+                },
+                self.ts(time),
+                value,
+                UseCaseID.TRANSACTIONS,
+            )
+
+        self.prod_env = self.create_environment(name="prod", project=self.project)
+        self.dev_env = self.create_environment(name="dev", project=self.project)
+
+    def now(self):
+        return MetricsAPIBaseTestCase.MOCK_DATETIME
+
+    def ts(self, dt: datetime) -> int:
+        return int(dt.timestamp())
+
+    def test_unknown_tag(self):
+        qs_params = {
+            "metric": "d:transactions/duration@millisecond",
+            "project": "1",
+            "useCase": "transactions",
+        }
+
+        response = self.get_success_response(self.organization.slug, "transaction", **qs_params)
+        assert response
+        assert False
+
+    def test_non_existing_tag(self):
+        assert False
+
+    def test_non_existing_filter(self):
+        assert False
+
+    def test_metric_tag_details(self):
+        assert False
+
+    def test_tag_values_for_session_status_tag(self):
+        assert False
+
+    @freeze_time((datetime.now() - timedelta(hours=1)).replace(minute=30))
+    def test_tag_values_for_derived_metrics(self):
+        assert False
+
+    def test_metric_not_in_naming_layer(self):
+        assert False
+
+    @freeze_time((datetime.now() - timedelta(hours=1)).replace(minute=30))
+    def test_tag_values_for_composite_derived_metrics(self):
+        assert False
+
+    def test_metric_tag_details_with_date_range(self):
+        assert False

--- a/tests/sentry/api/endpoints/test_organization_metrics_tag_details_v2.py
+++ b/tests/sentry/api/endpoints/test_organization_metrics_tag_details_v2.py
@@ -98,7 +98,7 @@ class OrganizationMetricsTagValues(MetricsAPIBaseTestCase):
             project=[self.project.id],
             useCase="transactions",
         )
-        assert response.data == [
+        assert sorted(response.data, key=lambda x: x["value"]) == [
             {"key": "transaction", "value": "/hello"},
             {"key": "transaction", "value": "/world"},
         ]

--- a/tests/sentry/sentry_metrics/querying/metadata/test_metrics.py
+++ b/tests/sentry/sentry_metrics/querying/metadata/test_metrics.py
@@ -1,14 +1,6 @@
 from sentry.sentry_metrics.querying.metadata.metrics import _flatten, _reverse_mapping
 
 
-def test_get_metrics_meta():
-    assert False
-
-
-def test_get_available_mris():
-    assert False
-
-
 def test_reverse_mapping():
     project_id_to_mris = {
         1: ["metric1", "metric2", "metric3"],

--- a/tests/sentry/sentry_metrics/querying/metadata/test_metrics.py
+++ b/tests/sentry/sentry_metrics/querying/metadata/test_metrics.py
@@ -1,0 +1,33 @@
+from sentry.sentry_metrics.querying.metadata.metrics import _flatten, _reverse_mapping
+
+
+def test_get_metrics_meta():
+    assert False
+
+
+def test_get_available_mris():
+    assert False
+
+
+def test_reverse_mapping():
+    project_id_to_mris = {
+        1: ["metric1", "metric2", "metric3"],
+        2: ["metric1", "metric4", "metric5", "metric6"],
+        3: ["metric1", "metric6"],
+    }
+    expected = {
+        "metric1": [1, 2, 3],
+        "metric2": [1],
+        "metric3": [1],
+        "metric4": [2],
+        "metric5": [2],
+        "metric6": [2, 3],
+    }
+
+    assert _reverse_mapping(project_id_to_mris) == expected
+
+
+def test_flatten():
+    list_of_lists = [[1, 2, 3], [4, 5, 6], [3, 6, 8]]
+    expected = [1, 2, 3, 4, 5, 6, 3, 6, 8]
+    assert _flatten(list_of_lists) == expected

--- a/tests/sentry/sentry_metrics/querying/metadata/test_metrics.py
+++ b/tests/sentry/sentry_metrics/querying/metadata/test_metrics.py
@@ -1,7 +1,7 @@
-from sentry.sentry_metrics.querying.metadata.metrics import _flatten, _reverse_mapping
+from sentry.sentry_metrics.querying.metadata.metrics import _convert_to_mris_to_project_ids_mapping
 
 
-def test_reverse_mapping():
+def test_convert_to_mris_to_project_ids_mapping():
     project_id_to_mris = {
         1: ["metric1", "metric2", "metric3"],
         2: ["metric1", "metric4", "metric5", "metric6"],
@@ -16,10 +16,4 @@ def test_reverse_mapping():
         "metric6": [2, 3],
     }
 
-    assert _reverse_mapping(project_id_to_mris) == expected
-
-
-def test_flatten():
-    list_of_lists = [[1, 2, 3], [4, 5, 6], [3, 6, 8]]
-    expected = [1, 2, 3, 4, 5, 6, 3, 6, 8]
-    assert _flatten(list_of_lists) == expected
+    assert _convert_to_mris_to_project_ids_mapping(project_id_to_mris) == expected


### PR DESCRIPTION
- Create new functionality in sentry_metrics/querying/metadata that uses new meta tables in Snuba to query metadata about metrics. This should increase query speed considerably.
- Replace calls to sentry.snuba.metrics with calls to sentry_metrics.querying.metadata in the Organization Metrics endpoints to make use of these faster queries in the respective UIs. 