### PR TITLE
fix(ui): Sort organization list by name

### DIFF
--- a/static/app/components/sidebar/sidebarDropdown/switchOrganization.tsx
+++ b/static/app/components/sidebar/sidebarDropdown/switchOrganization.tsx
@@ -112,7 +112,7 @@ function SwitchOrganization({canCreateOrganization}: Props) {
               {...getMenuProps({})}
             >
               <OrganizationList role="list">
-                {sortBy(organizations, ['status.id']).map(organization => {
+                {sortBy(organizations, ['status.id', 'name']).map(organization => {
                   return (
                     <OrganizationMenuItem
                       key={organization.slug}

--- a/static/app/views/settings/components/settingsBreadcrumb/organizationCrumb.tsx
+++ b/static/app/views/settings/components/settingsBreadcrumb/organizationCrumb.tsx
@@ -1,5 +1,6 @@
 import type {RouteComponentProps} from 'react-router';
 import styled from '@emotion/styled';
+import sortBy from 'lodash/sortBy';
 
 import IdBadge from 'sentry/components/idBadge';
 import OrganizationsStore from 'sentry/stores/organizationsStore';
@@ -75,7 +76,7 @@ function OrganizationCrumb({params, routes, route, ...props}: Props) {
       onSelect={handleSelect}
       hasMenu={hasMenu}
       route={route}
-      items={organizations.map((org, index) => ({
+      items={sortBy(organizations, ['name']).map((org, index) => ({
         index,
         value: org,
         label: (


### PR DESCRIPTION
Sorts the org switcher by name after by status

Also sorts the organization breadcrumbs in settings navigation