### PR TITLE
fix(issue_stream): Fallback to title if customTitle is null

### DIFF
--- a/static/app/utils/events.tsx
+++ b/static/app/utils/events.tsx
@@ -126,7 +126,7 @@ export function getTitle(
   grouping = false
 ) {
   const {metadata, type, culprit, title} = event;
-  const customTitle = metadata?.title;
+  const customTitle = metadata?.title || title;
 
   switch (type) {
     case EventOrGroupType.ERROR: {

--- a/static/app/utils/events.tsx
+++ b/static/app/utils/events.tsx
@@ -126,7 +126,7 @@ export function getTitle(
   grouping = false
 ) {
   const {metadata, type, culprit, title} = event;
-  const customTitle = metadata?.title || title;
+  const customTitle = metadata?.title;
 
   switch (type) {
     case EventOrGroupType.ERROR: {
@@ -178,7 +178,7 @@ export function getTitle(
       };
     case EventOrGroupType.DEFAULT:
       return {
-        title: customTitle ?? metadata.title ?? '',
+        title: customTitle ?? title,
         subtitle: '',
         treeLabel: undefined,
       };


### PR DESCRIPTION
When an event has a `title` inside of metadata set as `null` the UI would try to use it. In such a case, the UI would not let developers view an Issue from the Issue Stream as it would not be hyperlinked.

This is what it would look like (not clickable issues)
<img width="91" alt="image" src="https://github.com/getsentry/sentry/assets/44410/38ec80dd-fceb-4522-ad90-6d33b84e2fa5">


In this change, we fall back to the standard title value rather than `metadata.title` which can be `null`.

This happened because of a Relay deployment (https://github.com/getsentry/sentry-options-automator/pull/1367).