### PR TITLE
fix(pr-comment): don't make an empty comment

### DIFF
--- a/src/sentry/tasks/integrations/github/pr_comment.py
+++ b/src/sentry/tasks/integrations/github/pr_comment.py
@@ -167,15 +167,15 @@ def github_comment_workflow(pullrequest_id: int, project_id: int):
         return
 
     top_5_issues = get_top_5_issues_by_count(issue_list, project)
+    if not top_5_issues:
+        logger.info(
+            "github.pr_comment.no_issues",
+            extra={"organization_id": org_id, "pr_id": pullrequest_id},
+        )
+        cache.delete(cache_key)
+        return
+
     top_5_issue_ids = [issue["group_id"] for issue in top_5_issues]
-    logger.info(
-        "github.pr_comment.top_5_issues",
-        extra={
-            "top_5_issue_ids": top_5_issue_ids,
-            "issue_list": issue_list,
-            "pr_id": pullrequest_id,
-        },
-    )
 
     issue_comment_contents = get_comment_contents(top_5_issue_ids)
 

--- a/tests/sentry/tasks/integrations/github/test_pr_comment.py
+++ b/tests/sentry/tasks/integrations/github/test_pr_comment.py
@@ -637,6 +637,17 @@ class TestCommentWorkflow(GithubCommentTestCase):
             "github_pr_comment.error", tags={"type": "missing_integration"}
         )
 
+    @patch("sentry.tasks.integrations.github.pr_comment.get_top_5_issues_by_count")
+    @patch("sentry.tasks.integrations.github.pr_comment.format_comment")
+    @responses.activate
+    def test_comment_workflow_no_issues(self, mock_format_comment, mock_issues):
+        mock_issues.return_value = []
+
+        github_comment_workflow(self.pr.id, self.project.id)
+
+        assert mock_issues.called
+        assert not mock_format_comment.called
+
 
 class TestCommentReactionsTask(GithubCommentTestCase):
     base_url = "https://api.github.com"


### PR DESCRIPTION
The suspect PR comment is only triggered from the suspect commit flow. However, if for some reason we don't find any issue associated with the suspect PR, we shouldn't be commenting.