### PR TITLE
feat(related_issues): Include project=-1 when opening links

### DIFF
--- a/static/app/views/issueDetails/groupRelatedIssues/index.spec.tsx
+++ b/static/app/views/issueDetails/groupRelatedIssues/index.spec.tsx
@@ -158,7 +158,7 @@ describe('Related Issues View', function () {
     expect(linkButton).toHaveAttribute(
       'href',
       // Opening in Issues needs to include the group we are currently viewing
-      `/organizations/org-slug/issues/?query=issue.id:[${groupId},${group1},${group2}]`
+      `/organizations/org-slug/issues/?project=-1&query=issue.id:[${groupId},${group1},${group2}]`
     );
   });
 
@@ -200,7 +200,7 @@ describe('Related Issues View', function () {
     // The Issue search supports using `trace` as a parameter
     expect(linkButton).toHaveAttribute(
       'href',
-      `/organizations/org-slug/issues/?query=trace:1234`
+      `/organizations/org-slug/issues/?project=-1&query=trace:1234`
     );
   });
 });

--- a/static/app/views/issueDetails/groupRelatedIssues/index.tsx
+++ b/static/app/views/issueDetails/groupRelatedIssues/index.tsx
@@ -66,6 +66,10 @@ function GroupRelatedIssues({params}: Props) {
     {same_root_cause: [], trace_connected: []}
   );
 
+  // project=-1 allows ensuring that the query will show issues from any projects for the org
+  // This is important for traces since issues can be for any project in the org
+  const baseUrl = `/organizations/${orgSlug}/issues/?project=-1`;
+
   return (
     <Fragment>
       {isLoading ? (
@@ -85,7 +89,7 @@ function GroupRelatedIssues({params}: Props) {
                   <TextButtonWrapper>
                     <div />
                     <LinkButton
-                      to={`/organizations/${orgSlug}/issues/?query=issue.id:[${groupId},${sameRootCauseIssues}]`}
+                      to={`${baseUrl}&query=issue.id:[${groupId},${sameRootCauseIssues}]`}
                       size="xs"
                       analyticsEventName="Clicked Open Issues from same-root related issues"
                       analyticsEventKey="similar_issues.same_root_cause_clicked_open_issues"
@@ -122,7 +126,7 @@ function GroupRelatedIssues({params}: Props) {
                       .
                     </small>
                     <LinkButton
-                      to={`/organizations/${orgSlug}/issues/?query=trace:${traceMeta.trace_id}`}
+                      to={`${baseUrl}&query=trace:${traceMeta.trace_id}`}
                       size="xs"
                       analyticsEventName="Clicked Open Issues from trace-connected related issues"
                       analyticsEventKey="similar_issues.trace_connected_issues_clicked_open_issues"


### PR DESCRIPTION
This will ensure that a trace containing issues from multiple projects will be shown to the developer.