### PR TITLE
chore(hybrid-cloud): Globally enables multi-region selector

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1661,7 +1661,7 @@ SENTRY_FEATURES: dict[str, bool | None] = {
     # Enables higher limit for alert rules
     "organizations:more-slow-alerts": False,
     # Enables region provisioning for individual users
-    "organizations:multi-region-selector": False,
+    "organizations:multi-region-selector": True,
     # Enable new page filter UI
     "organizations:new-page-filter": True,
     # Display warning banner for every event issue alerts

--- a/src/sentry/web/client_config.py
+++ b/src/sentry/web/client_config.py
@@ -221,11 +221,8 @@ class _ClientConfig:
             self.last_org and features.has("organizations:customer-domains", self.last_org)
         ):
             yield "organizations:customer-domains"
-        # TODO (Gabe): Remove selector option check once GetSentry side lands
-        if options.get("hybrid_cloud.multi-region-selector") or features.has(
-            "organizations:multi-region-selector", actor=self.user
-        ):
-            yield "organizations:multi-region-selector"
+
+        yield "organizations:multi-region-selector"
 
     @property
     def needs_upgrade(self) -> bool:

--- a/static/app/utils/regions/index.tsx
+++ b/static/app/utils/regions/index.tsx
@@ -69,9 +69,5 @@ export function getRegionChoices(): [string, string][] {
 }
 
 export function shouldDisplayRegions(): boolean {
-  const regionCount = getRegions().length;
-  return (
-    ConfigStore.get('features').has('organizations:multi-region-selector') &&
-    regionCount > 1
-  );
+  return getRegions().length > 1;
 }

--- a/static/app/views/organizationCreate/index.spec.tsx
+++ b/static/app/views/organizationCreate/index.spec.tsx
@@ -136,7 +136,6 @@ describe('OrganizationCreate', function () {
       }),
     });
 
-    ConfigStore.set('features', new Set(['organizations:multi-region-selector']));
     ConfigStore.set('regions', [
       {url: 'https://us.example.com', name: 'us'},
       {
@@ -200,30 +199,6 @@ describe('OrganizationCreate', function () {
         error: expect.any(Function),
         method: 'POST',
         host: expectedHost,
-        data: {defaultTeam: true, name: 'Good Burger'},
-      });
-    });
-
-    expect(window.location.assign).toHaveBeenCalledTimes(1);
-    expect(window.location.assign).toHaveBeenCalledWith(
-      'https://org-slug.sentry.io/projects/new/'
-    );
-  });
-
-  it('renders without region data and submits without host when the feature flag is not enabled', async function () {
-    const orgCreateMock = multiRegionSetup();
-    ConfigStore.set('features', new Set());
-    render(<OrganizationCreate />);
-    expect(screen.queryByLabelText('Data Storage Location')).not.toBeInTheDocument();
-    await userEvent.type(screen.getByPlaceholderText('e.g. My Company'), 'Good Burger');
-    await userEvent.click(screen.getByText('Create Organization'));
-
-    await waitFor(() => {
-      expect(orgCreateMock).toHaveBeenCalledWith('/organizations/', {
-        success: expect.any(Function),
-        error: expect.any(Function),
-        method: 'POST',
-        host: undefined,
         data: {defaultTeam: true, name: 'Good Burger'},
       });
     });

--- a/tests/sentry/web/test_api.py
+++ b/tests/sentry/web/test_api.py
@@ -106,14 +106,21 @@ class ClientConfigViewTest(TestCase):
             assert resp.status_code == 200
             assert resp["Content-Type"] == "application/json"
             data = json.loads(resp.content)
-            assert data["features"] == ["organizations:create", "auth:register"]
+            assert data["features"] == [
+                "organizations:create",
+                "auth:register",
+                "organizations:multi-region-selector",
+            ]
 
         with self.options({"auth.allow-registration": False}):
             resp = self.client.get(self.path)
             assert resp.status_code == 200
             assert resp["Content-Type"] == "application/json"
             data = json.loads(resp.content)
-            assert data["features"] == ["organizations:create"]
+            assert data["features"] == [
+                "organizations:create",
+                "organizations:multi-region-selector",
+            ]
 
     def test_org_create_feature(self):
         with self.feature({"organizations:create": True}):
@@ -121,14 +128,17 @@ class ClientConfigViewTest(TestCase):
             assert resp.status_code == 200
             assert resp["Content-Type"] == "application/json"
             data = json.loads(resp.content)
-            assert data["features"] == ["organizations:create"]
+            assert data["features"] == [
+                "organizations:create",
+                "organizations:multi-region-selector",
+            ]
 
         with self.feature({"organizations:create": False}):
             resp = self.client.get(self.path)
             assert resp.status_code == 200
             assert resp["Content-Type"] == "application/json"
             data = json.loads(resp.content)
-            assert data["features"] == []
+            assert data["features"] == ["organizations:multi-region-selector"]
 
     def test_customer_domain_feature(self):
         self.login_as(self.user)
@@ -146,21 +156,32 @@ class ClientConfigViewTest(TestCase):
             assert resp["Content-Type"] == "application/json"
             data = json.loads(resp.content)
             assert data["lastOrganization"] == self.organization.slug
-            assert data["features"] == ["organizations:create", "organizations:customer-domains"]
+            assert data["features"] == [
+                "organizations:create",
+                "organizations:customer-domains",
+                "organizations:multi-region-selector",
+            ]
 
         with self.feature({"organizations:customer-domains": False}):
             resp = self.client.get(self.path)
             assert resp.status_code == 200
             assert resp["Content-Type"] == "application/json"
             data = json.loads(resp.content)
-            assert data["features"] == ["organizations:create"]
+            assert data["features"] == [
+                "organizations:create",
+                "organizations:multi-region-selector",
+            ]
 
             # Customer domain feature is injected if a customer domain is used.
             resp = self.client.get(self.path, HTTP_HOST="albertos-apples.testserver")
             assert resp.status_code == 200
             assert resp["Content-Type"] == "application/json"
             data = json.loads(resp.content)
-            assert data["features"] == ["organizations:create", "organizations:customer-domains"]
+            assert data["features"] == [
+                "organizations:create",
+                "organizations:customer-domains",
+                "organizations:multi-region-selector",
+            ]
 
     def test_unauthenticated(self):
         resp = self.client.get(self.path)
@@ -170,7 +191,7 @@ class ClientConfigViewTest(TestCase):
         data = json.loads(resp.content)
         assert not data["isAuthenticated"]
         assert data["user"] is None
-        assert data["features"] == ["organizations:create"]
+        assert data["features"] == ["organizations:create", "organizations:multi-region-selector"]
         assert data["customerDomain"] is None
 
     def test_authenticated(self):
@@ -185,7 +206,7 @@ class ClientConfigViewTest(TestCase):
         assert data["isAuthenticated"]
         assert data["user"]
         assert data["user"]["email"] == user.email
-        assert data["features"] == ["organizations:create"]
+        assert data["features"] == ["organizations:create", "organizations:multi-region-selector"]
         assert data["customerDomain"] is None
 
     def _run_test_with_privileges(self, is_superuser: bool, is_staff: bool):


### PR DESCRIPTION
<!-- Describe your PR here. -->
Globally enables the multi-region selector in SaaS when there are 1 or more regions registered. Updates the backing option to be True by default. Next PR will delete the option entirely, pending removal from options automator.


