### PR TITLE
feat(metrics): Add metricSecond to allowed category

### DIFF
--- a/src/sentry/api/endpoints/organization_stats_v2.py
+++ b/src/sentry/api/endpoints/organization_stats_v2.py
@@ -168,7 +168,10 @@ class OrganizationStatsEndpointV2(OrganizationEndpoint):
         with self.handle_query_errors():
 
             if features.has("organizations:metrics-stats", organization):
-                if request.GET.get("category") == "metrics":
+                if (
+                    request.GET.get("category") == "metrics"
+                    or request.GET.get("category") == "metricSecond"
+                ):
                     # TODO(metrics): align project resolution
                     result = run_metrics_outcomes_query(
                         request.GET,


### PR DESCRIPTION
We're planning on changing data category "metrics" to "metricSecond" to have the data categories line up with billing https://github.com/getsentry/getsentry/pull/13880/files

this change allows the stats_v2 endpoint to respond to both the "metrics" and "metricSecond"
