### PR TITLE
fix(escalating-issues): Cleanup query for escalating forecasts

### DIFF
--- a/src/sentry/issues/escalating.py
+++ b/src/sentry/issues/escalating.py
@@ -104,7 +104,7 @@ def query_groups_past_counts(groups: Sequence[Group]) -> list[GroupsCountRespons
     for g in groups:
         if g.issue_category == GroupCategory.ERROR:
             error_groups.append(g)
-        elif g.issue_type.should_detect_escalation(g.organization):
+        elif g.issue_type.should_detect_escalation():
             other_groups.append(g)
 
     all_results += _process_groups(error_groups, start_date, end_date, GroupCategory.ERROR)

--- a/src/sentry/issues/escalating_group_forecast.py
+++ b/src/sentry/issues/escalating_group_forecast.py
@@ -13,7 +13,6 @@ from typing import TypedDict, cast
 
 from sentry import nodestore
 from sentry.models.group import Group
-from sentry.models.organization import Organization
 from sentry.utils.dates import parse_timestamp
 
 GROUP_FORECAST_TTL = 14
@@ -53,8 +52,7 @@ class EscalatingGroupForecast:
     def _should_fetch_escalating(cls, group_id: int) -> bool:
         group = Group.objects.get(id=group_id)
 
-        organization = Organization.objects.get(project__group__id=group_id)
-        return group.issue_type.should_detect_escalation(organization)
+        return group.issue_type.should_detect_escalation()
 
     @classmethod
     def fetch(cls, project_id: int, group_id: int) -> EscalatingGroupForecast | None:

--- a/src/sentry/issues/forecasts.py
+++ b/src/sentry/issues/forecasts.py
@@ -55,6 +55,7 @@ def generate_and_save_forecasts(groups: Sequence[Group]) -> None:
     Generates and saves a list of forecasted values for each group.
     `groups`: Sequence of groups to be forecasted
     """
+    groups = [group for group in groups if group.issue_type.should_detect_escalation()]
     past_counts = query_groups_past_counts(groups)
     group_counts = parse_groups_past_counts(past_counts)
     save_forecast_per_group(groups, group_counts)

--- a/src/sentry/issues/grouptype.py
+++ b/src/sentry/issues/grouptype.py
@@ -183,11 +183,9 @@ class GroupType:
         return features.has(cls.build_post_process_group_feature_name(), organization)
 
     @classmethod
-    def should_detect_escalation(cls, organization: Organization) -> bool:
+    def should_detect_escalation(cls) -> bool:
         """
-        If the feature is enabled and enable_escalation_detection=True, then escalation detection is enabled.
-
-        When the feature flag is removed, we can remove the organization parameter from this method.
+        If enable_escalation_detection=True, then escalation detection is enabled.
         """
         return cls.enable_escalation_detection
 

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -503,7 +503,7 @@ def should_update_escalating_metrics(event: Event, is_transaction_event: bool) -
         features.has("organizations:escalating-metrics-backend", event.project.organization)
         and not is_transaction_event
         and event.group is not None
-        and event.group.issue_type.should_detect_escalation(event.project.organization)
+        and event.group.issue_type.should_detect_escalation()
     )
 
 
@@ -867,7 +867,7 @@ def process_snoozes(job: PostProcessJob) -> None:
         )
         return
 
-    if not group.issue_type.should_detect_escalation(group.organization):
+    if not group.issue_type.should_detect_escalation():
         return
 
     # groups less than a day old should use the new -> escalating logic

--- a/src/sentry/tasks/weekly_escalating_forecast.py
+++ b/src/sentry/tasks/weekly_escalating_forecast.py
@@ -68,12 +68,10 @@ def generate_forecasts_for_projects(project_ids: list[int]) -> None:
                 substatus=GroupSubStatus.UNTIL_ESCALATING,
                 project_id__in=project_ids,
                 last_seen__gte=datetime.now(UTC) - timedelta(days=7),
-            ).select_related(
-                "project", "project__organization"
-            ),  # TODO: Remove this once the feature flag is removed
+            ),
             step=ITERATOR_CHUNK,
         )
-        if group.issue_type.should_detect_escalation(group.project.organization)
+        if group.issue_type.should_detect_escalation()
     )
 
     for until_escalating_groups in chunked(

--- a/tests/sentry/tasks/test_auto_resolve_issues.py
+++ b/tests/sentry/tasks/test_auto_resolve_issues.py
@@ -11,7 +11,6 @@ from sentry.issues.grouptype import (
 from sentry.models.group import Group, GroupStatus
 from sentry.tasks.auto_resolve_issues import schedule_auto_resolution
 from sentry.testutils.cases import TestCase
-from sentry.testutils.helpers.features import with_feature
 
 
 class ScheduleAutoResolutionTest(TestCase):
@@ -83,7 +82,6 @@ class ScheduleAutoResolutionTest(TestCase):
 
     @patch("sentry.tasks.auto_ongoing_issues.backend")
     @patch("sentry.tasks.auto_resolve_issues.kick_off_status_syncs")
-    @with_feature("organizations:issue-platform-crons-sd")
     def test_single_event_performance(self, mock_kick_off_status_syncs, mock_backend):
         project = self.create_project()
 
@@ -112,7 +110,6 @@ class ScheduleAutoResolutionTest(TestCase):
         assert project.get_option("sentry:_last_auto_resolve") > current_ts
 
     @patch("sentry.tasks.auto_ongoing_issues.backend")
-    @with_feature("organizations:issue-platform-crons-sd")
     def test_aggregate_performance(self, mock_backend):
         project = self.create_project()
 

--- a/tests/sentry/tasks/test_post_process.py
+++ b/tests/sentry/tasks/test_post_process.py
@@ -1578,9 +1578,7 @@ class SnoozeTestSkipSnoozeMixin(BasePostProgressGroupMixin):
     def test_invalidates_snooze_issue_platform(self, mock_processor, mock_send_unignored_robust):
         event = self.create_event(data={"message": "testing"}, project_id=self.project.id)
         group = event.group
-        should_detect_escalation = group.issue_type.should_detect_escalation(
-            self.project.organization
-        )
+        should_detect_escalation = group.issue_type.should_detect_escalation()
 
         # Check for has_reappeared=False if is_new=True
         self.call_post_process_group(


### PR DESCRIPTION
Cleans up some cruft left behind by feature flags and pushes the escalation check out of the query to help with timeouts.

Fixes SENTRY-18AS