### PR TITLE
perf: remove unecessary spans for json

### DIFF
--- a/src/sentry/ingest/consumer/processors.py
+++ b/src/sentry/ingest/consumer/processors.py
@@ -304,8 +304,7 @@ def process_individual_attachment(message: IngestMessage, project: Project) -> N
 @metrics.wraps("ingest_consumer.process_userreport")
 def process_userreport(message: IngestMessage, project: Project) -> bool:
     start_time = to_datetime(message["start_time"])
-    with sentry_sdk.start_span(op="sentry.utils.json.loads"):
-        feedback = orjson.loads(message["payload"])
+    feedback = orjson.loads(message["payload"])
 
     try:
         save_userreport(

--- a/src/sentry/sentry_metrics/consumers/indexer/batch.py
+++ b/src/sentry/sentry_metrics/consumers/indexer/batch.py
@@ -168,8 +168,7 @@ class IndexerBatch:
     ) -> ParsedMessage:
         assert isinstance(msg.value, BrokerValue)
         try:
-            with sentry_sdk.start_span(op="sentry.utils.json.loads"):
-                parsed_payload: ParsedMessage = orjson.loads(msg.payload.value.decode())
+            parsed_payload: ParsedMessage = orjson.loads(msg.payload.value)
         except orjson.JSONDecodeError:
             logger.exception(
                 "process_messages.invalid_json",

--- a/src/sentry/snuba/tasks.py
+++ b/src/sentry/snuba/tasks.py
@@ -262,8 +262,7 @@ def _create_snql_in_snuba(subscription, snuba_query, snql_query, entity_subscrip
         metrics.incr("snuba.snql.subscription.http.error", tags={"dataset": snuba_query.dataset})
         raise SnubaError("HTTP %s response from Snuba!" % response.status)
 
-    with sentry_sdk.start_span(op="sentry.utils.json.loads"):
-        return orjson.loads(response.data)["subscription_id"]
+    return orjson.loads(response.data)["subscription_id"]
 
 
 def _delete_from_snuba(dataset: Dataset, subscription_id: str, entity_key: EntityKey) -> None:


### PR DESCRIPTION
We don't need to trace JSON deserialization cost since creating spans has a cost as well.