### PR TITLE
perf: use orjson for all relay operations

### DIFF
--- a/src/sentry/datascrubbing.py
+++ b/src/sentry/datascrubbing.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import copy
 from typing import Any
 
+import orjson
 import sentry_sdk
 from rest_framework import serializers
 from sentry_relay.processing import (
@@ -80,8 +81,7 @@ def get_all_pii_configs(project):
 
     settings = get_datascrubbing_settings(project)
 
-    json_loads, json_dumps = json.methods_for_experiment("relay.enable-orjson")
-    yield convert_datascrubbing_config(settings, json_dumps=json_dumps, json_loads=json_loads)
+    yield convert_datascrubbing_config(settings, json_dumps=orjson.dumps, json_loads=orjson.loads)
 
 
 @sentry_sdk.tracing.trace
@@ -98,8 +98,7 @@ def scrub_data(project, event):
 
         metrics.distribution("datascrubbing.config.rules.size", total_rules)
 
-        json_loads, json_dumps = json.methods_for_experiment("relay.enable-orjson")
-        event = pii_strip_event(config, event, json_loads=json_loads, json_dumps=json_dumps)
+        event = pii_strip_event(config, event, json_loads=orjson.loads, json_dumps=orjson.dumps)
 
     return event
 

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from typing import TYPE_CHECKING, Any, TypedDict, cast
 
+import orjson
 import sentry_sdk
 from django.conf import settings
 from django.core.cache import cache
@@ -375,8 +376,6 @@ class EventManager:
 
         from sentry_relay.processing import StoreNormalizer
 
-        json_loads, json_dumps = json.methods_for_experiment("relay.enable-orjson")
-
         rust_normalizer = StoreNormalizer(
             project_id=self._project.id if self._project else project_id,
             client_ip=self._client_ip,
@@ -388,13 +387,13 @@ class EventManager:
             remove_other=self._remove_other,
             normalize_user_agent=True,
             sent_at=self.sent_at.isoformat() if self.sent_at is not None else None,
-            json_dumps=json_dumps,
+            json_dumps=orjson.dumps,
             **DEFAULT_STORE_NORMALIZER_ARGS,
         )
 
         pre_normalize_type = self._data.get("type")
         self._data = CanonicalKeyDict(
-            rust_normalizer.normalize_event(dict(self._data), json_loads=json_loads)
+            rust_normalizer.normalize_event(dict(self._data), json_loads=orjson.loads)
         )
         # XXX: This is a hack to make generic events work (for now?). I'm not sure whether we should
         # include this in the rust normalizer, since we don't want people sending us these via the

--- a/src/sentry/integrations/slack/message_builder/issues.py
+++ b/src/sentry/integrations/slack/message_builder/issues.py
@@ -5,6 +5,7 @@ from collections.abc import Mapping, Sequence
 from datetime import datetime
 from typing import Any
 
+import orjson
 from django.core.exceptions import ObjectDoesNotExist
 from sentry_relay.processing import parse_release
 
@@ -172,8 +173,7 @@ def format_release_tag(value: str, event: GroupEvent | Group):
     """Format the release tag using the short version and make it a link"""
     path = f"/releases/{value}/"
     url = event.project.organization.absolute_url(path)
-    json_loads, _ = json.methods_for_experiment("relay.enable-orjson")
-    release_description = parse_release(value, json_loads=json_loads).get("description")
+    release_description = parse_release(value, json_loads=orjson.loads).get("description")
     return f"<{url}|{release_description}>"
 
 

--- a/src/sentry/integrations/slack/message_builder/notifications/daily_summary.py
+++ b/src/sentry/integrations/slack/message_builder/notifications/daily_summary.py
@@ -4,6 +4,7 @@ from collections.abc import Mapping
 from typing import Any
 from urllib.parse import urlencode
 
+import orjson
 from sentry_relay.processing import parse_release
 
 from sentry import features
@@ -52,8 +53,7 @@ class SlackDailySummaryMessageBuilder(SlackNotificationsMessageBuilder):
     def linkify_release(self, release, organization):
         path = f"/releases/{release.version}/"
         url = organization.absolute_url(path)
-        json_loads, _ = json.methods_for_experiment("relay.enable-orjson")
-        release_description = parse_release(release.version, json_loads=json_loads).get(
+        release_description = parse_release(release.version, json_loads=orjson.loads).get(
             "description"
         )
         return f":rocket: *<{url}|Release {release_description}>*\n"

--- a/src/sentry/models/event.py
+++ b/src/sentry/models/event.py
@@ -1,7 +1,7 @@
+import orjson
 from sentry_relay.processing import StoreNormalizer
 
 from sentry.db.models import NodeData
-from sentry.utils import json
 from sentry.utils.canonical import CanonicalKeyDict
 
 
@@ -23,11 +23,10 @@ class EventDict(CanonicalKeyDict):
         if not skip_renormalization and not is_renormalized:
             data = dict(data)
             pre_normalize_type = data.get("type")
-            json_loads, json_dumps = json.methods_for_experiment("relay.enable-orjson")
             normalizer = StoreNormalizer(
-                is_renormalize=True, enable_trimming=False, json_dumps=json_dumps
+                is_renormalize=True, enable_trimming=False, json_dumps=orjson.dumps
             )
-            data = normalizer.normalize_event(data, json_loads=json_loads)
+            data = normalizer.normalize_event(data, json_loads=orjson.loads)
             # XXX: This is a hack to make generic events work (for now?). I'm not sure whether we
             # should include this in the rust normalizer, since we don't want people sending us
             # these via the sdk.

--- a/src/sentry/models/groupresolution.py
+++ b/src/sentry/models/groupresolution.py
@@ -1,3 +1,4 @@
+import orjson
 from django.db import models
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
@@ -15,7 +16,7 @@ from sentry.db.models import (
 )
 from sentry.models.release import Release, follows_semver_versioning_scheme
 from sentry.models.releases.constants import DB_VERSION_LENGTH
-from sentry.utils import json, metrics
+from sentry.utils import metrics
 
 
 @region_silo_model
@@ -116,11 +117,10 @@ class GroupResolution(Model):
                     # If current_release_version == release.version => 0
                     # If current_release_version < release.version => -1
                     # If current_release_version > release.version => 1
-                    json_loads, _ = json.methods_for_experiment("relay.enable-orjson")
                     current_release_raw = parse_release(
-                        current_release_version, json_loads=json_loads
+                        current_release_version, json_loads=orjson.loads
                     ).get("version_raw")
-                    release_raw = parse_release(release.version, json_loads=json_loads).get(
+                    release_raw = parse_release(release.version, json_loads=orjson.loads).get(
                         "version_raw"
                     )
                     return compare_version_relay(current_release_raw, release_raw) >= 0
@@ -162,11 +162,10 @@ class GroupResolution(Model):
                 try:
                     # A resolution only exists if the resolved release is greater (in semver
                     # terms) than the provided release
-                    json_loads, _ = json.methods_for_experiment("relay.enable-orjson")
-                    res_release_raw = parse_release(res_release_version, json_loads=json_loads).get(
-                        "version_raw"
-                    )
-                    release_raw = parse_release(release.version, json_loads=json_loads).get(
+                    res_release_raw = parse_release(
+                        res_release_version, json_loads=orjson.loads
+                    ).get("version_raw")
+                    release_raw = parse_release(release.version, json_loads=orjson.loads).get(
                         "version_raw"
                     )
                     return compare_version_relay(res_release_raw, release_raw) == 1

--- a/src/sentry/notifications/notifications/activity/regression.py
+++ b/src/sentry/notifications/notifications/activity/regression.py
@@ -4,11 +4,11 @@ from collections.abc import Mapping
 from typing import Any
 from urllib.parse import urlencode
 
+import orjson
 from sentry_relay.processing import parse_release
 
 from sentry.models.activity import Activity
 from sentry.types.integrations import ExternalProviders
-from sentry.utils.json import methods_for_experiment
 
 from .base import GroupActivityNotification
 
@@ -20,8 +20,7 @@ class RegressionActivityNotification(GroupActivityNotification):
     def __init__(self, activity: Activity) -> None:
         super().__init__(activity)
         self.version = self.activity.data.get("version", "")
-        json_loads, _ = methods_for_experiment("relay.enable-orjson")
-        self.version_parsed = parse_release(self.version, json_loads=json_loads)["description"]
+        self.version_parsed = parse_release(self.version, json_loads=orjson.loads)["description"]
 
     def get_description(self) -> tuple[str, str | None, Mapping[str, Any]]:
         text_message, html_message, params = "{author} marked {an issue} as a regression", None, {}

--- a/src/sentry/notifications/notifications/activity/release.py
+++ b/src/sentry/notifications/notifications/activity/release.py
@@ -4,6 +4,7 @@ from collections.abc import Iterable, Mapping, MutableMapping, Sequence
 from typing import Any
 from urllib.parse import urlencode
 
+import orjson
 from sentry_relay.processing import parse_release
 
 from sentry.models.activity import Activity
@@ -24,7 +25,6 @@ from sentry.notifications.utils.participants import ParticipantMap, get_particip
 from sentry.services.hybrid_cloud.actor import ActorType, RpcActor
 from sentry.services.hybrid_cloud.user.service import user_service
 from sentry.types.integrations import ExternalProviders
-from sentry.utils.json import methods_for_experiment
 
 from .base import ActivityNotification
 
@@ -64,8 +64,7 @@ class ReleaseActivityNotification(ActivityNotification):
         self.group_counts_by_project = get_group_counts_by_project(self.release, self.projects)
 
         self.version = self.release.version
-        json_loads, _ = methods_for_experiment("relay.enable-orjson")
-        self.version_parsed = parse_release(self.version, json_loads=json_loads)["description"]
+        self.version_parsed = parse_release(self.version, json_loads=orjson.loads)["description"]
 
     def get_participants_with_group_subscription_reason(self) -> ParticipantMap:
         return get_participants_for_release(self.projects, self.organization, self.user_ids)

--- a/src/sentry/notifications/notifications/activity/resolved_in_release.py
+++ b/src/sentry/notifications/notifications/activity/resolved_in_release.py
@@ -4,11 +4,11 @@ from collections.abc import Mapping
 from typing import Any
 from urllib.parse import urlencode
 
+import orjson
 from sentry_relay.processing import parse_release
 
 from sentry.models.activity import Activity
 from sentry.types.integrations import ExternalProviders
-from sentry.utils.json import methods_for_experiment
 
 from .base import GroupActivityNotification
 
@@ -20,8 +20,7 @@ class ResolvedInReleaseActivityNotification(GroupActivityNotification):
     def __init__(self, activity: Activity) -> None:
         super().__init__(activity)
         self.version = self.activity.data.get("version", "")
-        json_loads, _ = methods_for_experiment("relay.enable-orjson")
-        self.version_parsed = parse_release(self.version, json_loads=json_loads)["description"]
+        self.version_parsed = parse_release(self.version, json_loads=orjson.loads)["description"]
 
     def get_description(self) -> tuple[str, str | None, Mapping[str, Any]]:
         if self.version:

--- a/src/sentry/search/events/filter.py
+++ b/src/sentry/search/events/filter.py
@@ -5,6 +5,7 @@ from datetime import datetime
 from functools import reduce
 from typing import Any, Union
 
+import orjson
 from sentry_relay.consts import SPAN_STATUS_NAME_TO_CODE
 from sentry_relay.processing import parse_release as parse_release_relay
 
@@ -48,7 +49,6 @@ from sentry.search.events.constants import (
 )
 from sentry.search.events.fields import FIELD_ALIASES, FUNCTIONS, resolve_field
 from sentry.search.utils import parse_release
-from sentry.utils.json import methods_for_experiment
 from sentry.utils.snuba import FUNCTION_TO_OPERATOR, OPERATOR_TO_FUNCTION, SNUBA_AND, SNUBA_OR
 from sentry.utils.strings import oxfordize_list
 from sentry.utils.validators import INVALID_ID_DETAILS, INVALID_SPAN_ID, WILDCARD_NOT_ALLOWED
@@ -524,8 +524,7 @@ def parse_semver(version, operator) -> SemverFilter:
         raise InvalidSearchQuery("Invalid operation 'IN' for semantic version filter.")
 
     version = version if "@" in version else f"{SEMVER_FAKE_PACKAGE}@{version}"
-    json_loads, _ = methods_for_experiment("relay.enable-orjson")
-    parsed = parse_release_relay(version, json_loads=json_loads)
+    parsed = parse_release_relay(version, json_loads=orjson.loads)
     parsed_version = parsed.get("version_parsed")
     if parsed_version:
         # Convert `pre` to always be a string

--- a/src/sentry/utils/json.py
+++ b/src/sentry/utils/json.py
@@ -5,9 +5,8 @@ from __future__ import annotations
 import contextlib
 import datetime
 import decimal
-import json  # noqa: S003
 import uuid
-from collections.abc import Callable, Generator, Mapping
+from collections.abc import Generator, Mapping
 from enum import Enum
 from typing import IO, TYPE_CHECKING, Any, NoReturn, TypeVar, overload
 
@@ -175,18 +174,6 @@ def dumps_htmlsafe(value: object) -> SafeString:
     return mark_safe(_default_escaped_encoder.encode(value))
 
 
-# TODO: remove this when orjson experiment is successful
-def methods_for_experiment(
-    option_name: str,
-) -> tuple[Callable[[str | bytes], Any], Callable[[Any], Any]]:
-    from sentry.features.rollout import in_random_rollout
-
-    if in_random_rollout(option_name):
-        return orjson.loads, orjson.dumps
-    else:
-        return json.loads, json.dumps
-
-
 @overload
 def prune_empty_keys(obj: None) -> None:
     ...
@@ -224,7 +211,6 @@ __all__ = (
     "load",
     "loads",
     "prune_empty_keys",
-    "methods_for_experiment",
     "loads_experimental",
     "dumps_experimental",
 )

--- a/tests/sentry/event_manager/interfaces/test_contexts.py
+++ b/tests/sentry/event_manager/interfaces/test_contexts.py
@@ -2,13 +2,6 @@ import pytest
 
 from sentry import eventstore
 from sentry.event_manager import EventManager
-from sentry.testutils.helpers import override_options
-
-
-@pytest.fixture(autouse=True)
-def run_before_each():
-    with override_options({"relay.enable-orjson": 0.0}):
-        yield
 
 
 @pytest.fixture

--- a/tests/sentry/event_manager/interfaces/test_csp.py
+++ b/tests/sentry/event_manager/interfaces/test_csp.py
@@ -2,13 +2,6 @@ import pytest
 
 from sentry import eventstore
 from sentry.event_manager import EventManager, get_event_type, materialize_metadata
-from sentry.testutils.helpers import override_options
-
-
-@pytest.fixture(autouse=True)
-def run_before_each():
-    with override_options({"relay.enable-orjson": 0.0}):
-        yield
 
 
 @pytest.fixture

--- a/tests/sentry/event_manager/interfaces/test_debug_meta.py
+++ b/tests/sentry/event_manager/interfaces/test_debug_meta.py
@@ -2,13 +2,6 @@ import pytest
 
 from sentry import eventstore
 from sentry.event_manager import EventManager
-from sentry.testutils.helpers import override_options
-
-
-@pytest.fixture(autouse=True)
-def run_before_each():
-    with override_options({"relay.enable-orjson": 0.0}):
-        yield
 
 
 @pytest.fixture

--- a/tests/sentry/event_manager/interfaces/test_exception.py
+++ b/tests/sentry/event_manager/interfaces/test_exception.py
@@ -4,13 +4,6 @@ from sentry import eventstore
 from sentry.event_manager import EventManager
 from sentry.interfaces.exception import Exception
 from sentry.stacktraces.processing import normalize_stacktraces_for_grouping
-from sentry.testutils.helpers import override_options
-
-
-@pytest.fixture(autouse=True)
-def run_before_each():
-    with override_options({"relay.enable-orjson": 0.0}):
-        yield
 
 
 @pytest.fixture

--- a/tests/sentry/event_manager/interfaces/test_expectstaple.py
+++ b/tests/sentry/event_manager/interfaces/test_expectstaple.py
@@ -2,13 +2,6 @@ import pytest
 
 from sentry import eventstore
 from sentry.event_manager import EventManager, get_event_type, materialize_metadata
-from sentry.testutils.helpers import override_options
-
-
-@pytest.fixture(autouse=True)
-def run_before_each():
-    with override_options({"relay.enable-orjson": 0.0}):
-        yield
 
 
 @pytest.fixture

--- a/tests/sentry/event_manager/interfaces/test_geo.py
+++ b/tests/sentry/event_manager/interfaces/test_geo.py
@@ -2,13 +2,6 @@ import pytest
 
 from sentry import eventstore
 from sentry.event_manager import EventManager
-from sentry.testutils.helpers import override_options
-
-
-@pytest.fixture(autouse=True)
-def run_before_each():
-    with override_options({"relay.enable-orjson": 0.0}):
-        yield
 
 
 @pytest.fixture

--- a/tests/sentry/event_manager/interfaces/test_mechanism.py
+++ b/tests/sentry/event_manager/interfaces/test_mechanism.py
@@ -3,13 +3,6 @@ import pytest
 from sentry import eventstore
 from sentry.event_manager import EventManager
 from sentry.interfaces.exception import upgrade_legacy_mechanism
-from sentry.testutils.helpers import override_options
-
-
-@pytest.fixture(autouse=True)
-def run_before_each():
-    with override_options({"relay.enable-orjson": 0.0}):
-        yield
 
 
 @pytest.fixture

--- a/tests/sentry/event_manager/interfaces/test_message.py
+++ b/tests/sentry/event_manager/interfaces/test_message.py
@@ -2,13 +2,6 @@ import pytest
 
 from sentry import eventstore
 from sentry.event_manager import EventManager
-from sentry.testutils.helpers import override_options
-
-
-@pytest.fixture(autouse=True)
-def run_before_each():
-    with override_options({"relay.enable-orjson": 0.0}):
-        yield
 
 
 @pytest.fixture

--- a/tests/sentry/event_manager/interfaces/test_sdk.py
+++ b/tests/sentry/event_manager/interfaces/test_sdk.py
@@ -2,13 +2,6 @@ import pytest
 
 from sentry import eventstore
 from sentry.event_manager import EventManager
-from sentry.testutils.helpers import override_options
-
-
-@pytest.fixture(autouse=True)
-def run_before_each():
-    with override_options({"relay.enable-orjson": 0.0}):
-        yield
 
 
 @pytest.fixture

--- a/tests/sentry/event_manager/interfaces/test_spans.py
+++ b/tests/sentry/event_manager/interfaces/test_spans.py
@@ -2,16 +2,9 @@ import pytest
 
 from sentry import eventstore
 from sentry.event_manager import EventManager
-from sentry.testutils.helpers import override_options
 
 START_TIME = 1562873192.624
 END_TIME = 1562873194.624
-
-
-@pytest.fixture(autouse=True)
-def run_before_each():
-    with override_options({"relay.enable-orjson": 0.0}):
-        yield
 
 
 @pytest.fixture

--- a/tests/sentry/event_manager/interfaces/test_stacktrace.py
+++ b/tests/sentry/event_manager/interfaces/test_stacktrace.py
@@ -5,13 +5,6 @@ import pytest
 from sentry import eventstore
 from sentry.event_manager import EventManager
 from sentry.interfaces.stacktrace import get_context, is_url
-from sentry.testutils.helpers import override_options
-
-
-@pytest.fixture(autouse=True)
-def run_before_each():
-    with override_options({"relay.enable-orjson": 0.0}):
-        yield
 
 
 def test_is_url():

--- a/tests/sentry/event_manager/interfaces/test_template.py
+++ b/tests/sentry/event_manager/interfaces/test_template.py
@@ -2,13 +2,6 @@ import pytest
 
 from sentry import eventstore
 from sentry.event_manager import EventManager
-from sentry.testutils.helpers import override_options
-
-
-@pytest.fixture(autouse=True)
-def run_before_each():
-    with override_options({"relay.enable-orjson": 0.0}):
-        yield
 
 
 @pytest.fixture

--- a/tests/sentry/event_manager/interfaces/test_threads.py
+++ b/tests/sentry/event_manager/interfaces/test_threads.py
@@ -2,13 +2,6 @@ import pytest
 
 from sentry import eventstore
 from sentry.event_manager import EventManager
-from sentry.testutils.helpers import override_options
-
-
-@pytest.fixture(autouse=True)
-def run_before_each():
-    with override_options({"relay.enable-orjson": 0.0}):
-        yield
 
 
 @pytest.fixture

--- a/tests/sentry/event_manager/interfaces/test_user.py
+++ b/tests/sentry/event_manager/interfaces/test_user.py
@@ -2,13 +2,6 @@ import pytest
 
 from sentry import eventstore
 from sentry.event_manager import EventManager
-from sentry.testutils.helpers import override_options
-
-
-@pytest.fixture(autouse=True)
-def run_before_each():
-    with override_options({"relay.enable-orjson": 0.0}):
-        yield
 
 
 @pytest.fixture

--- a/tests/sentry/event_manager/test_normalization.py
+++ b/tests/sentry/event_manager/test_normalization.py
@@ -6,13 +6,6 @@ from django.conf import settings
 
 from sentry.constants import DEFAULT_LOGGER_NAME, MAX_CULPRIT_LENGTH
 from sentry.event_manager import EventManager
-from sentry.testutils.helpers import override_options
-
-
-@pytest.fixture(autouse=True)
-def run_before_each():
-    with override_options({"relay.enable-orjson": 0.0}):
-        yield
 
 
 def make_event(**kwargs):

--- a/tests/sentry/event_manager/test_validate_data.py
+++ b/tests/sentry/event_manager/test_validate_data.py
@@ -5,13 +5,6 @@ from django.utils import timezone
 
 from sentry.constants import MAX_CULPRIT_LENGTH, MAX_VERSION_LENGTH
 from sentry.event_manager import EventManager
-from sentry.testutils.helpers import override_options
-
-
-@pytest.fixture(autouse=True)
-def run_before_each():
-    with override_options({"relay.enable-orjson": 0.0}):
-        yield
 
 
 def validate_and_normalize(data):

--- a/tests/sentry/search/events/test_filter.py
+++ b/tests/sentry/search/events/test_filter.py
@@ -28,14 +28,7 @@ from sentry.search.events.filter import (
 from sentry.search.events.types import ParamsType, QueryBuilderConfig
 from sentry.snuba.dataset import Dataset
 from sentry.testutils.cases import TestCase
-from sentry.testutils.helpers import override_options
 from sentry.utils.snuba import OPERATOR_TO_FUNCTION
-
-
-@pytest.fixture(autouse=True)
-def run_before_each():
-    with override_options({"relay.enable-orjson": 0.0}):
-        yield
 
 
 # Helper functions to make reading the expected output from the boolean tests easier to read. #

--- a/tests/sentry/test_culprit.py
+++ b/tests/sentry/test_culprit.py
@@ -1,14 +1,5 @@
-import pytest
-
 from sentry.event_manager import EventManager
 from sentry.event_manager import get_culprit as get_culprit_impl
-from sentry.testutils.helpers import override_options
-
-
-@pytest.fixture(autouse=True)
-def run_before_each():
-    with override_options({"relay.enable-orjson": 0.0}):
-        yield
 
 
 def get_culprit(data):


### PR DESCRIPTION
Follow up after https://github.com/getsentry/sentry/pull/69613, since the experiment is a success and no-new errors are introduced.