### PR TITLE
ref(routes): Prioritize customer domains route

### DIFF
--- a/static/app/components/route.tsx
+++ b/static/app/components/route.tsx
@@ -80,7 +80,7 @@ Route.createRouteFromReactElement = function (element: RouteElement): PlainRoute
   ];
 
   if (USING_CUSTOMER_DOMAIN) {
-    childRoutes.push({
+    childRoutes.unshift({
       ...createRouteFromReactElement(element),
       path,
       component: withDomainRequired(component ?? NoOp),


### PR DESCRIPTION
In a936fb00da922a79943d70d0272e1d6505d6ef95 we introduced a new withOrgPath prop to the Route component. This caused the route to have the same behaviour as doing

```tsx
<Framgnet>
  {USING_CUSTOMER_DOMAIN && (
    <Route
      path="/some-path/"
      component={withDomainRequired(make(() => import('sentry/views/someView')))}
    />
  )}
  <Route
    path="/organizations/:orgId/some-path/"
    component={withDomainRedirect(make(() => import('sentry/views/someView')))}
  />
</Framgnet>
```

However the introduced logic generated the routes in the opposite order, where the org slug version would get priority.

For some future changes this becomes important so I am bringing back this matching behaviour