### PR TITLE
fix: Add a metric for non-success Snuba requests

### DIFF
--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -1020,7 +1020,10 @@ def _bulk_snuba_query(
 
         if response.status != 200:
             _log_request_query(snuba_param_list[index][0])
-
+            metrics.incr(
+                "snuba.client.api.error",
+                tags={"status_code": response.status, "referrer": query_referrer},
+            )
             if body.get("error"):
                 error = body["error"]
                 if response.status == 429:


### PR DESCRIPTION
Tracking this on the Sentry side allows alerts to be created that are separate
from the Snuba API itself, in case the API is in a broken state and can't
accurately report what is happening.