### PR TITLE
perf: use orjson on bin, fixtures and scripts

### DIFF
--- a/bin/mock-outcomes
+++ b/bin/mock-outcomes
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+import orjson
+
 from sentry.runner import configure
 
 configure()
@@ -10,7 +12,6 @@ import requests
 from django.conf import settings
 
 from sentry.constants import DataCategory
-from sentry.utils import json
 from sentry.utils.outcomes import Outcome
 
 # import random
@@ -24,7 +25,7 @@ def store_outcomes(outcome, num_times=1):
         outcomes.append(outcome_copy)
 
     req = requests.post(
-        settings.SENTRY_SNUBA + "/tests/entities/outcomes/insert", data=json.dumps(outcomes)
+        settings.SENTRY_SNUBA + "/tests/entities/outcomes/insert", data=orjson.dumps(outcomes)
     )
     req.raise_for_status()
 

--- a/bin/run-model-tests
+++ b/bin/run-model-tests
@@ -3,12 +3,11 @@ import os
 import os.path
 
 import click
-
-from sentry.utils import json
+import orjson
 
 
 def find_test_cases_matching(model_name: str):
-    manifest = json.loads(open(os.environ["SENTRY_MODEL_MANIFEST_FILE_PATH"]).read())
+    manifest = orjson.loads(open(os.environ["SENTRY_MODEL_MANIFEST_FILE_PATH"], "rb").read())
     for test_node_id, hits in manifest.items():
         if model_name in hits:
             yield test_node_id.split("::")[1]

--- a/fixtures/apidocs_test_case.py
+++ b/fixtures/apidocs_test_case.py
@@ -1,6 +1,7 @@
 import functools
 import os
 
+import orjson
 from django.conf import settings
 from openapi_core.contrib.django import DjangoOpenAPIRequest, DjangoOpenAPIResponse
 from openapi_core.spec import Spec
@@ -9,7 +10,6 @@ from openapi_core.validation.response.validators import V30ResponseDataValidator
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.helpers.datetime import before_now, iso_format
 from sentry.testutils.skips import requires_snuba
-from sentry.utils import json
 
 
 @requires_snuba
@@ -17,8 +17,8 @@ class APIDocsTestCase(APITestCase):
     @functools.cached_property
     def cached_schema(self):
         path = os.path.join(os.path.dirname(__file__), "../tests/apidocs/openapi-derefed.json")
-        with open(path) as json_file:
-            data = json.load(json_file)
+        with open(path, "rb") as json_file:
+            data = orjson.loads(json_file.read())
             data["servers"][0]["url"] = settings.SENTRY_OPTIONS["system.url-prefix"]
             del data["components"]
 

--- a/fixtures/integrations/mock_service.py
+++ b/fixtures/integrations/mock_service.py
@@ -5,9 +5,10 @@ import shutil
 from collections import defaultdict
 from typing import Any
 
+import orjson
+
 from fixtures.integrations import FIXTURE_DIRECTORY
 from fixtures.integrations.stub_service import StubService
-from sentry.utils import json
 from sentry.utils.numbers import base32_encode
 
 
@@ -99,8 +100,8 @@ class MockService(StubService):
             return
 
         path = os.path.join(self._get_project_path(project), f"{name}.json")
-        with open(path, "w") as f:
-            f.write(json.dumps(data))
+        with open(path, "wb") as f:
+            f.write(orjson.dumps(data))
 
     def _get_data(self, project, name):
         if self.mode == "memory":
@@ -112,5 +113,5 @@ class MockService(StubService):
         if not os.path.exists(path):
             return None
 
-        with open(path) as f:
-            return json.loads(f.read())
+        with open(path, "rb") as f:
+            return orjson.loads(f.read())

--- a/fixtures/integrations/stub_service.py
+++ b/fixtures/integrations/stub_service.py
@@ -4,8 +4,9 @@ import os
 from copy import deepcopy
 from typing import Any
 
+import orjson
+
 from fixtures.integrations import FIXTURE_DIRECTORY
-from sentry.utils import json
 
 
 class StubService:
@@ -48,7 +49,7 @@ class StubService:
         if cached:
             data = cached
         else:
-            data = json.loads(StubService.get_stub_json(service_name, name))
+            data = orjson.loads(StubService.get_stub_json(service_name, name))
             StubService.stub_data_cache[cache_key] = data
         return deepcopy(data)
 

--- a/scripts/appconnect_cli.py
+++ b/scripts/appconnect_cli.py
@@ -10,11 +10,12 @@ first one found.
 import sys
 from pprint import pprint
 
+import orjson
+
 from sentry.lang.native.appconnect import SYMBOL_SOURCES_PROP_NAME
 from sentry.models.appconnectbuilds import AppConnectBuild
 from sentry.models.project import Project
 from sentry.tasks import app_store_connect
-from sentry.utils import json
 
 PROJECT_ID = 2
 
@@ -24,7 +25,7 @@ def main(argv):
         # Dumps the symbolSource configuration as stored in the project option.
         project = Project.objects.get(pk=PROJECT_ID)
         raw_config = project.get_option(SYMBOL_SOURCES_PROP_NAME, default="[]")
-        config = json.loads(raw_config)
+        config = orjson.loads(raw_config)
         pprint(config)
 
     elif argv[0] == "dsyms":
@@ -65,7 +66,7 @@ def main(argv):
 def appconnect_config():
     project = Project.objects.get(pk=PROJECT_ID)
     raw_config = project.get_option(SYMBOL_SOURCES_PROP_NAME, default="[]")
-    symbol_sources = json.loads(raw_config)
+    symbol_sources = orjson.loads(raw_config)
     for config in symbol_sources:
         if config["type"] == "appStoreConnect":
             return config


### PR DESCRIPTION
The goal is to get rid of all `sentry.utils.json` usages, and this is a step towards that goal.