### PR TITLE
feat(snuba-search): adds logic to handle first and last seen filters for snuba only search

### DIFF
--- a/src/sentry/issues/endpoints/organization_group_index.py
+++ b/src/sentry/issues/endpoints/organization_group_index.py
@@ -57,8 +57,6 @@ UNSUPPORTED_SNUBA_FILTERS = [
     "regressed_in_release",
     "issue.priority",
     "firstRelease",
-    "firstSeen",
-    "lastSeen",
     "release.build",
     "release.package",
     "release.dist",

--- a/src/sentry/search/snuba/executors.py
+++ b/src/sentry/search/snuba/executors.py
@@ -1130,6 +1130,24 @@ class InvalidQueryForExecutor(Exception):
 
 
 class GroupAttributesPostgresSnubaQueryExecutor(PostgresSnubaQueryExecutor):
+    def get_last_seen_filter(self, search_filter: SearchFilter, joined_entity: Entity) -> Condition:
+        # get the max timestamp of the error/search_issue event
+        return Condition(
+            Column("timestamp", joined_entity),
+            Op(search_filter.operator),
+            search_filter.value.raw_value,
+        )
+
+    def get_first_seen_filter(
+        self, search_filter: SearchFilter, joined_entity: Entity
+    ) -> Condition:
+        # use the group first seen from the group dataset
+        return Condition(
+            Column("group_first_seen", self.entities["attrs"]),
+            Op(search_filter.operator),
+            search_filter.value.raw_value,
+        )
+
     def get_basic_group_snuba_condition(
         self, search_filter: SearchFilter, joined_entity: Entity
     ) -> Condition:
@@ -1431,6 +1449,8 @@ class GroupAttributesPostgresSnubaQueryExecutor(PostgresSnubaQueryExecutor):
         "assigned_or_suggested": get_assigned_or_suggested,
         "assigned_to": get_assigned,
         "message": get_message_condition,
+        "first_seen": get_first_seen_filter,
+        "last_seen": get_last_seen_filter,
     }
 
     first_seen = Column("group_first_seen", entities["attrs"])

--- a/src/sentry/search/snuba/executors.py
+++ b/src/sentry/search/snuba/executors.py
@@ -7,6 +7,7 @@ from abc import ABCMeta, abstractmethod
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from datetime import datetime, timedelta
+from enum import Enum, auto
 from hashlib import md5
 from math import floor
 from typing import Any, TypedDict, cast
@@ -85,6 +86,11 @@ DEFAULT_TRENDS_WEIGHTS: TrendsSortWeights = {
     "v2": True,
     "norm": False,
 }
+
+
+class Clauses(Enum):
+    HAVING = auto()
+    WHERE = auto()
 
 
 @dataclass
@@ -1444,13 +1450,13 @@ class GroupAttributesPostgresSnubaQueryExecutor(PostgresSnubaQueryExecutor):
     }
 
     group_conditions_lookup = {
-        "status": get_basic_group_snuba_condition,
-        "substatus": get_basic_group_snuba_condition,
-        "assigned_or_suggested": get_assigned_or_suggested,
-        "assigned_to": get_assigned,
-        "message": get_message_condition,
-        "first_seen": get_first_seen_filter,
-        # "last_seen": get_last_seen_filter,
+        "status": [get_basic_group_snuba_condition, Clauses.WHERE],
+        "substatus": [get_basic_group_snuba_condition, Clauses.WHERE],
+        "assigned_or_suggested": [get_assigned_or_suggested, Clauses.WHERE],
+        "assigned_to": [get_assigned, Clauses.WHERE],
+        "message": [get_message_condition, Clauses.WHERE],
+        "first_seen": [get_first_seen_filter, Clauses.WHERE],
+        "last_seen": [get_last_seen_filter, Clauses.HAVING],
     }
 
     first_seen = Column("group_first_seen", entities["attrs"])
@@ -1561,15 +1567,21 @@ class GroupAttributesPostgresSnubaQueryExecutor(PostgresSnubaQueryExecutor):
             having = []
             for search_filter in search_filters or ():
                 # use the stored function if it exists in our mapping, otherwise use the basic lookup
-                fn = self.group_conditions_lookup.get(search_filter.key.name)
-                if fn:
-                    where_conditions.append(fn(self, search_filter, joined_entity))
-                elif search_filter.key.name == "last_seen":
-                    # last seen modifies the having clause because its an aggregation
-                    having.append(self.get_last_seen_filter(search_filter, joined_entity))
-                elif search_filter.key.name in ["issue.category", "issue.type"]:
-                    # handle this separately since it's a special case that combines both issue.type and issue.category to determine the type
+                lookup = self.group_conditions_lookup.get(search_filter.key.name)
+                fn = lookup[0] if lookup else None
+                clause = lookup[1] if lookup else Clauses.WHERE
+
+                # skip these
+                if search_filter.key.name in ["issue.category", "issue.type"]:
                     pass
+                elif fn:
+                    # dynamic lookup of what clause to use
+                    if clause == Clauses.WHERE:
+                        where_conditions.append(fn(self, search_filter, joined_entity))
+                    elif clause == Clauses.HAVING:
+                        having.append(fn(self, search_filter, joined_entity))
+                    else:
+                        raise InvalidQueryForExecutor(f"Invalid clause {clause}")
                 else:
                     where_conditions.append(
                         self.get_basic_event_snuba_condition(search_filter, joined_entity)
@@ -1602,6 +1614,7 @@ class GroupAttributesPostgresSnubaQueryExecutor(PostgresSnubaQueryExecutor):
                         Column("environment", joined_entity), Op.IN, [e.name for e in environments]
                     )
                 )
+
             if cursor is not None:
                 op = Op.GTE if cursor.is_prev else Op.LTE
                 having.append(Condition(sort_func, op, cursor.value))

--- a/src/sentry/search/snuba/executors.py
+++ b/src/sentry/search/snuba/executors.py
@@ -1450,15 +1450,14 @@ class GroupAttributesPostgresSnubaQueryExecutor(PostgresSnubaQueryExecutor):
     }
 
     group_conditions_lookup = {
-        "status": [get_basic_group_snuba_condition, Clauses.WHERE],
-        "substatus": [get_basic_group_snuba_condition, Clauses.WHERE],
-        "assigned_or_suggested": [get_assigned_or_suggested, Clauses.WHERE],
-        "assigned_to": [get_assigned, Clauses.WHERE],
-        "message": [get_message_condition, Clauses.WHERE],
-        "first_seen": [get_first_seen_filter, Clauses.WHERE],
-        "last_seen": [get_last_seen_filter, Clauses.HAVING],
+        "status": (get_basic_group_snuba_condition, Clauses.WHERE),
+        "substatus": (get_basic_group_snuba_condition, Clauses.WHERE),
+        "assigned_or_suggested": (get_assigned_or_suggested, Clauses.WHERE),
+        "assigned_to": (get_assigned, Clauses.WHERE),
+        "message": (get_message_condition, Clauses.WHERE),
+        "first_seen": (get_first_seen_filter, Clauses.WHERE),
+        "last_seen": (get_last_seen_filter, Clauses.HAVING),
     }
-
     first_seen = Column("group_first_seen", entities["attrs"])
     times_seen_aggregation = Function("count", [], alias="times_seen")
 


### PR DESCRIPTION
This PR adds logic to support filters on the first seen and the last seen of on an issue for the snuba only search.