### PR TITLE
perf: use orjson in all middlewares

### DIFF
--- a/src/sentry/middleware/health.py
+++ b/src/sentry/middleware/health.py
@@ -1,5 +1,6 @@
 import itertools
 
+import orjson
 from django.http import HttpResponse
 from django.utils.deprecation import MiddlewareMixin
 from rest_framework.request import Request
@@ -20,7 +21,6 @@ class HealthCheck(MiddlewareMixin):
             return HttpResponse("ok", content_type="text/plain")
 
         from sentry.status_checks import Problem, check_all
-        from sentry.utils import json
 
         threshold = Problem.threshold(Problem.SEVERITY_CRITICAL)
         results = {
@@ -29,7 +29,7 @@ class HealthCheck(MiddlewareMixin):
         problems = list(itertools.chain.from_iterable(results.values()))
 
         return HttpResponse(
-            json.dumps(
+            orjson.dumps(
                 {
                     "problems": [str(p) for p in problems],
                     "healthy": {type(check).__name__: not p for check, p in results.items()},

--- a/src/sentry/middleware/integrations/parsers/github.py
+++ b/src/sentry/middleware/integrations/parsers/github.py
@@ -4,6 +4,7 @@ import logging
 from collections.abc import Mapping
 from typing import Any
 
+import orjson
 from django.http import HttpResponse
 
 from sentry.integrations.github.webhook import (
@@ -16,7 +17,6 @@ from sentry.models.integrations.organization_integration import OrganizationInte
 from sentry.models.outbox import WebhookProviderIdentifier
 from sentry.services.hybrid_cloud.util import control_silo_function
 from sentry.types.integrations import EXTERNAL_PROVIDERS, ExternalProviders
-from sentry.utils import json
 
 logger = logging.getLogger(__name__)
 
@@ -36,8 +36,8 @@ class GithubRequestParser(BaseRequestParser):
         if not self.is_json_request():
             return None
         try:
-            event = json.loads(self.request.body.decode(encoding="utf-8"))
-        except json.JSONDecodeError:
+            event = orjson.loads(self.request.body)
+        except orjson.JSONDecodeError:
             return None
         external_id = self._get_external_id(event=event)
         if not external_id:
@@ -49,8 +49,8 @@ class GithubRequestParser(BaseRequestParser):
             return self.get_response_from_control_silo()
 
         try:
-            event = json.loads(self.request.body.decode(encoding="utf-8"))
-        except json.JSONDecodeError:
+            event = orjson.loads(self.request.body)
+        except orjson.JSONDecodeError:
             return HttpResponse(status=400)
 
         if event.get("installation") and event.get("action") in {"created", "deleted"}:

--- a/src/sentry/middleware/integrations/parsers/gitlab.py
+++ b/src/sentry/middleware/integrations/parsers/gitlab.py
@@ -4,6 +4,7 @@ import logging
 from collections.abc import Mapping
 from typing import Any
 
+import orjson
 from django.http.response import HttpResponseBase
 from django.urls import resolve
 
@@ -16,7 +17,7 @@ from sentry.models.integrations.organization_integration import OrganizationInte
 from sentry.models.outbox import WebhookProviderIdentifier
 from sentry.services.hybrid_cloud.util import control_silo_function
 from sentry.types.integrations import EXTERNAL_PROVIDERS, ExternalProviders
-from sentry.utils import json, metrics
+from sentry.utils import metrics
 
 logger = logging.getLogger(__name__)
 
@@ -87,8 +88,8 @@ class GitlabRequestParser(BaseRequestParser, GitlabWebhookMixin):
             return self.get_default_missing_integration_response()
 
         try:
-            data = json.loads(self.request.body)
-        except ValueError:
+            data = orjson.loads(self.request.body)
+        except orjson.JSONDecodeError:
             data = {}
 
         return self.get_response_from_webhookpayload(

--- a/src/sentry/middleware/integrations/parsers/jira_server.py
+++ b/src/sentry/middleware/integrations/parsers/jira_server.py
@@ -4,6 +4,7 @@ import logging
 from collections.abc import Mapping
 from typing import Any
 
+import orjson
 from django.http import HttpResponse
 
 from sentry.integrations.jira_server.webhooks import (
@@ -12,7 +13,6 @@ from sentry.integrations.jira_server.webhooks import (
 )
 from sentry.middleware.integrations.parsers.base import BaseRequestParser
 from sentry.models.outbox import WebhookProviderIdentifier
-from sentry.utils import json
 
 logger = logging.getLogger(__name__)
 
@@ -33,8 +33,8 @@ class JiraServerRequestParser(BaseRequestParser):
         regions = self.get_regions_from_organizations(organizations=organizations)
 
         try:
-            data = json.loads(self.request.body)
-        except ValueError:
+            data = orjson.loads(self.request.body)
+        except orjson.JSONDecodeError:
             data = {}
 
         # We only process webhooks with changelogs

--- a/src/sentry/middleware/integrations/parsers/msteams.py
+++ b/src/sentry/middleware/integrations/parsers/msteams.py
@@ -5,6 +5,7 @@ from collections.abc import Mapping, Sequence
 from functools import cached_property
 from typing import Any
 
+import orjson
 import sentry_sdk
 from django.http.response import HttpResponseBase
 
@@ -20,7 +21,6 @@ from sentry.models.outbox import WebhookProviderIdentifier
 from sentry.services.hybrid_cloud.util import control_silo_function
 from sentry.types.integrations import EXTERNAL_PROVIDERS, ExternalProviders
 from sentry.types.region import Region, RegionResolutionError
-from sentry.utils import json
 
 logger = logging.getLogger(__name__)
 
@@ -37,8 +37,8 @@ class MsTeamsRequestParser(BaseRequestParser, MsTeamsWebhookMixin):
     def request_data(self):
         data = {}
         try:
-            data = json.loads(self.request.body.decode(encoding="utf-8"))
-        except Exception as err:
+            data = orjson.loads(self.request.body)
+        except orjson.JSONDecodeError as err:
             sentry_sdk.capture_exception(err)
         return data
 

--- a/src/sentry/middleware/integrations/parsers/slack.py
+++ b/src/sentry/middleware/integrations/parsers/slack.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 from collections.abc import Sequence
 
+import orjson
 import sentry_sdk
 from django.http.response import HttpResponse, HttpResponseBase
 from rest_framework import status
@@ -29,7 +30,6 @@ from sentry.models.integrations.organization_integration import OrganizationInte
 from sentry.models.outbox import WebhookProviderIdentifier
 from sentry.types.integrations import EXTERNAL_PROVIDERS, ExternalProviders
 from sentry.types.region import Region
-from sentry.utils import json
 from sentry.utils.signing import unsign
 
 from .base import BaseRequestParser, create_async_request_payload
@@ -127,8 +127,8 @@ class SlackRequestParser(BaseRequestParser):
         # Handle event interactions challenge request
         data = None
         try:
-            data = json.loads(self.request.body.decode(encoding="utf-8"))
-        except Exception:
+            data = orjson.loads(self.request.body)
+        except orjson.JSONDecodeError:
             pass
         if data and is_event_challenge(data):
             return self.get_response_from_control_silo()

--- a/src/sentry/middleware/integrations/parsers/vsts.py
+++ b/src/sentry/middleware/integrations/parsers/vsts.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 
+import orjson
 import sentry_sdk
 from django.http.response import HttpResponseBase
 
@@ -11,7 +12,6 @@ from sentry.models.integrations.integration import Integration
 from sentry.models.integrations.organization_integration import OrganizationIntegration
 from sentry.models.outbox import WebhookProviderIdentifier
 from sentry.services.hybrid_cloud.util import control_silo_function
-from sentry.utils import json
 
 logger = logging.getLogger(__name__)
 
@@ -25,7 +25,7 @@ class VstsRequestParser(BaseRequestParser):
     @control_silo_function
     def get_integration_from_request(self) -> Integration | None:
         try:
-            data = json.loads(self.request.body.decode(encoding="utf-8"))
+            data = orjson.loads(self.request.body)
             external_id = get_vsts_external_id(data=data)
         except Exception as e:
             sentry_sdk.capture_exception(e)

--- a/src/sentry/middleware/integrations/tasks.py
+++ b/src/sentry/middleware/integrations/tasks.py
@@ -2,6 +2,7 @@ import logging
 from collections.abc import MutableMapping
 from typing import Any, cast
 
+import orjson
 import requests
 import sentry_sdk
 from requests import Response
@@ -11,7 +12,6 @@ from sentry.silo.base import SiloMode
 from sentry.silo.client import RegionSiloClient
 from sentry.tasks.base import instrumented_task
 from sentry.types.region import get_region_by_name
-from sentry.utils import json
 
 logger = logging.getLogger(__name__)
 
@@ -73,7 +73,7 @@ def convert_to_async_slack_response(
 
     response_payload = {}
     try:
-        response_payload = json.loads(response_body.decode(encoding="utf-8"))
+        response_payload = orjson.loads(response_body)
     except Exception as exc:
         sentry_sdk.capture_exception(exc)
 
@@ -145,9 +145,7 @@ def convert_to_async_discord_response(
         # handling the request asynchronously, we extract only the data, and post it to the webhook
         # that discord provides.
         # https://discord.com/developers/docs/interactions/receiving-and-responding#followup-messages
-        response_payload = json.loads(result["response"].content.decode(encoding="utf-8")).get(
-            "data"
-        )
+        response_payload = orjson.loads(result["response"].content).get("data")
     except Exception as e:
         sentry_sdk.capture_exception(e)
     integration_response = requests.post(response_url, json=response_payload)

--- a/src/sentry/middleware/ratelimit.py
+++ b/src/sentry/middleware/ratelimit.py
@@ -4,6 +4,7 @@ import logging
 import uuid
 from collections.abc import Callable
 
+import orjson
 from django.conf import settings
 from django.http.request import HttpRequest
 from django.http.response import HttpResponse, HttpResponseBase
@@ -18,7 +19,7 @@ from sentry.ratelimits import (
 )
 from sentry.ratelimits.config import RateLimitConfig
 from sentry.types.ratelimit import RateLimitCategory, RateLimitMeta, RateLimitType
-from sentry.utils import json, metrics
+from sentry.utils import metrics
 
 DEFAULT_ERROR_MESSAGE = (
     "You are attempting to use this endpoint too frequently. Limit is "
@@ -106,7 +107,7 @@ class RatelimitMiddleware:
                         },
                     )
                     response = HttpResponse(
-                        json.dumps(
+                        orjson.dumps(
                             DEFAULT_ERROR_MESSAGE.format(
                                 limit=request.rate_limit_metadata.limit,
                                 window=request.rate_limit_metadata.window,


### PR DESCRIPTION
We have enough confidence to say that `orjson` doesn't cause any errors/issues. We can now safely get rid of `json` and `rapidjson` in our repository.

Ref: https://github.com/getsentry/sentry/issues/68903