### PR TITLE
perf: use orjson in most integrations

### DIFF
--- a/src/sentry/integrations/aws_lambda/client.py
+++ b/src/sentry/integrations/aws_lambda/client.py
@@ -3,9 +3,9 @@ from __future__ import annotations
 import logging
 
 import boto3
+import orjson
 
 from sentry import options
-from sentry.utils import json
 
 
 class ConfigurationError(Exception):
@@ -45,7 +45,7 @@ def gen_aws_client(account_number, region, aws_external_id, service_name="lambda
         RoleSessionName="Sentry",
         RoleArn=role_arn,
         ExternalId=aws_external_id,
-        Policy=json.dumps(
+        Policy=orjson.dumps(
             {
                 "Version": "2012-10-17",
                 "Statement": [
@@ -66,7 +66,7 @@ def gen_aws_client(account_number, region, aws_external_id, service_name="lambda
                     },
                 ],
             }
-        ),
+        ).decode(),
     )
 
     credentials = assumed_role_object["Credentials"]

--- a/src/sentry/integrations/bitbucket/webhook.py
+++ b/src/sentry/integrations/bitbucket/webhook.py
@@ -2,6 +2,7 @@ import ipaddress
 import logging
 from datetime import timezone
 
+import orjson
 from dateutil.parser import parse as parse_date
 from django.db import IntegrityError, router, transaction
 from django.http import Http404, HttpResponse
@@ -18,7 +19,6 @@ from sentry.models.commitauthor import CommitAuthor
 from sentry.models.organization import Organization
 from sentry.models.repository import Repository
 from sentry.plugins.providers import IntegrationRepositoryProvider
-from sentry.utils import json
 from sentry.utils.email import parse_email
 
 logger = logging.getLogger("sentry.webhooks")
@@ -176,8 +176,8 @@ class BitbucketWebhookEndpoint(Endpoint):
             return HttpResponse(status=401)
 
         try:
-            event = json.loads(body.decode("utf-8"))
-        except json.JSONDecodeError:
+            event = orjson.loads(body)
+        except orjson.JSONDecodeError:
             logger.exception(
                 "%s.webhook.invalid-json",
                 PROVIDER_NAME,

--- a/src/sentry/integrations/bitbucket_server/webhook.py
+++ b/src/sentry/integrations/bitbucket_server/webhook.py
@@ -1,6 +1,7 @@
 import logging
 from datetime import datetime, timezone
 
+import orjson
 import sentry_sdk
 from django.db import IntegrityError, router, transaction
 from django.http import HttpResponse
@@ -17,7 +18,6 @@ from sentry.models.organization import Organization
 from sentry.models.repository import Repository
 from sentry.plugins.providers import IntegrationRepositoryProvider
 from sentry.shared_integrations.exceptions import ApiHostError, ApiUnauthorized, IntegrationError
-from sentry.utils import json
 from sentry.web.frontend.base import region_silo_view
 
 logger = logging.getLogger("sentry.webhooks")
@@ -164,8 +164,8 @@ class BitbucketServerWebhookEndpoint(View):
             return HttpResponse(status=204)
 
         try:
-            event = json.loads(body.decode("utf-8"))
-        except json.JSONDecodeError:
+            event = orjson.loads(body)
+        except orjson.JSONDecodeError:
             logger.exception(
                 "%s.webhook.invalid-json",
                 PROVIDER_NAME,

--- a/src/sentry/integrations/discord/client.py
+++ b/src/sentry/integrations/discord/client.py
@@ -5,6 +5,7 @@ from collections.abc import Mapping
 from typing import Any
 from urllib.parse import urlencode
 
+import orjson
 from rest_framework import status
 from rest_framework.response import Response
 
@@ -14,7 +15,7 @@ from sentry.integrations.discord.message_builder.base.base import DiscordMessage
 from sentry.integrations.discord.utils.consts import DISCORD_ERROR_CODES, DISCORD_USER_ERRORS
 
 # to avoid a circular import
-from sentry.utils import json, metrics
+from sentry.utils import metrics
 
 logger = logging.getLogger("sentry.integrations.discord")
 
@@ -167,7 +168,7 @@ class DiscordClient(ApiClient):
         if resp is not None:
             # Try to get the additional error code that Discord sent us to help determine what specific error happened
             try:
-                discord_error_response = json.loads(resp.content.decode("utf-8"))
+                discord_error_response = orjson.loads(resp.content)
                 log_params["discord_error_response"] = discord_error_response
             except Exception as err:
                 self.logger.info(

--- a/src/sentry/integrations/discord/requests/base.py
+++ b/src/sentry/integrations/discord/requests/base.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import dataclasses
 from collections.abc import Mapping
 
+import orjson
 from cryptography.exceptions import InvalidSignature
 from rest_framework import status
 from rest_framework.request import Request
@@ -14,7 +15,6 @@ from sentry.services.hybrid_cloud.identity.service import identity_service
 from sentry.services.hybrid_cloud.integration import RpcIntegration, integration_service
 from sentry.services.hybrid_cloud.user.model import RpcUser
 from sentry.services.hybrid_cloud.user.service import user_service
-from sentry.utils import json
 
 from ..utils import logger, verify_signature
 
@@ -55,8 +55,8 @@ class DiscordRequest:
 
     def __init__(self, request: Request):
         self.request = request
-        self._body = self.request.body.decode("utf-8")
-        self._data: Mapping[str, object] = json.loads(self._body)
+        self._body = self.request.body.decode()
+        self._data: Mapping[str, object] = orjson.loads(self.request.body)
         self._integration: RpcIntegration | None = None
         self._provider: RpcIdentityProvider | None = None
         self._identity: RpcIdentity | None = None

--- a/src/sentry/integrations/github/client.py
+++ b/src/sentry/integrations/github/client.py
@@ -5,6 +5,7 @@ from collections.abc import Mapping, Sequence
 from datetime import datetime
 from typing import Any, cast
 
+import orjson
 import sentry_sdk
 from requests import PreparedRequest
 
@@ -31,7 +32,7 @@ from sentry.shared_integrations.client.proxy import IntegrationProxyClient
 from sentry.shared_integrations.exceptions import ApiError, ApiRateLimitedError
 from sentry.shared_integrations.response.mapping import MappingApiResponse
 from sentry.types.integrations import EXTERNAL_PROVIDERS, ExternalProviders
-from sentry.utils import json, metrics
+from sentry.utils import metrics
 from sentry.utils.cache import cache
 from sentry.utils.json import JSONData
 
@@ -672,7 +673,7 @@ class GitHubClientMixin(GithubProxyClient):
         file_path_mapping = generate_file_path_mapping(files)
         query, variables = create_blame_query(file_path_mapping, extra=log_info)
         data = {"query": query, "variables": variables}
-        cache_key = self.get_cache_key("/graphql", "", json.dumps(data))
+        cache_key = self.get_cache_key("/graphql", "", orjson.dumps(data).decode())
         response = self.check_cache(cache_key)
         if response:
             metrics.incr("integrations.github.get_blame_for_files.got_cached")

--- a/src/sentry/integrations/github/installation.py
+++ b/src/sentry/integrations/github/installation.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 import time
 
+import orjson
 from django.http import HttpResponse
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.request import Request
@@ -13,7 +14,6 @@ from sentry.api.base import Endpoint, control_silo_endpoint
 from sentry.constants import ObjectStatus
 from sentry.models.integrations.integration import Integration
 from sentry.models.integrations.organization_integration import OrganizationIntegration
-from sentry.utils import json
 
 logger = logging.getLogger("sentry.webhooks")
 
@@ -56,4 +56,4 @@ class GitHubIntegrationsInstallationEndpoint(Endpoint):
             "sender": integration.metadata["sender"],
         }
 
-        return HttpResponse(json.dumps(result), status=200, content_type="application/json")
+        return HttpResponse(orjson.dumps(result), status=200, content_type="application/json")

--- a/src/sentry/integrations/github/webhook.py
+++ b/src/sentry/integrations/github/webhook.py
@@ -7,6 +7,7 @@ from collections.abc import Callable, Mapping, MutableMapping
 from datetime import timezone
 from typing import Any
 
+import orjson
 from dateutil.parser import parse as parse_date
 from django.db import IntegrityError, router, transaction
 from django.http import HttpResponse
@@ -44,7 +45,7 @@ from sentry.services.hybrid_cloud.repository.service import repository_service
 from sentry.services.hybrid_cloud.user.service import user_service
 from sentry.shared_integrations.exceptions import ApiError
 from sentry.tasks.integrations.github.open_pr_comment import open_pr_comment_workflow
-from sentry.utils import json, metrics
+from sentry.utils import metrics
 from sentry.utils.json import JSONData
 
 from .integration import GitHubIntegrationProvider
@@ -644,8 +645,8 @@ class GitHubIntegrationsWebhookEndpoint(Endpoint):
             return HttpResponse(status=401)
 
         try:
-            event = json.loads(body.decode("utf-8"))
-        except json.JSONDecodeError:
+            event = orjson.loads(body)
+        except orjson.JSONDecodeError:
             logger.exception("github.webhook.invalid-json", extra=self.get_logging_data())
             logger.exception("Invalid JSON.")
             return HttpResponse(status=400)

--- a/src/sentry/integrations/github_enterprise/webhook.py
+++ b/src/sentry/integrations/github_enterprise/webhook.py
@@ -4,6 +4,7 @@ import hashlib
 import hmac
 import logging
 
+import orjson
 from django.http import HttpRequest, HttpResponse
 from django.utils.crypto import constant_time_compare
 from django.utils.decorators import method_decorator
@@ -19,7 +20,7 @@ from sentry.integrations.github.webhook import (
     get_github_external_id,
 )
 from sentry.integrations.utils.scope import clear_tags_and_context
-from sentry.utils import json, metrics
+from sentry.utils import metrics
 from sentry.utils.sdk import configure_scope
 
 from .repository import GitHubEnterpriseRepositoryProvider
@@ -147,8 +148,8 @@ class GitHubEnterpriseWebhookBase(Endpoint):
             try:
                 # XXX: Sometimes they send us this b'payload=%7B%22ref%22 Support this
                 # See https://sentry.io/organizations/sentry/issues/2565421410
-                event = json.loads(body.decode("utf-8"))
-            except json.JSONDecodeError:
+                event = orjson.loads(body)
+            except orjson.JSONDecodeError:
                 logger.warning(
                     "github_enterprise.webhook.invalid-json",
                     extra=extra,

--- a/src/sentry/integrations/gitlab/blame.py
+++ b/src/sentry/integrations/gitlab/blame.py
@@ -7,6 +7,7 @@ from datetime import timezone
 from typing import Any, TypedDict
 from urllib.parse import quote
 
+import orjson
 from isodate import parse_datetime
 
 from sentry.integrations.gitlab.utils import (
@@ -18,7 +19,7 @@ from sentry.integrations.mixins.commit_context import CommitInfo, FileBlameInfo,
 from sentry.shared_integrations.client.base import BaseApiClient
 from sentry.shared_integrations.exceptions import ApiError, ApiRateLimitedError
 from sentry.shared_integrations.response.sequence import SequenceApiResponse
-from sentry.utils import json, metrics
+from sentry.utils import metrics
 
 logger = logging.getLogger("sentry.integrations.gitlab")
 
@@ -87,7 +88,7 @@ def _fetch_file_blame(
     request_path = GitLabApiClientPath.blame.format(project=project_id, path=encoded_path)
     params = {"ref": file.ref, "range[start]": file.lineno, "range[end]": file.lineno}
 
-    cache_key = client.get_cache_key(request_path, json.dumps(params))
+    cache_key = client.get_cache_key(request_path, orjson.dumps(params).decode())
     response = client.check_cache(cache_key)
     if response:
         metrics.incr("integrations.gitlab.get_blame_for_files.got_cached")

--- a/src/sentry/integrations/gitlab/webhooks.py
+++ b/src/sentry/integrations/gitlab/webhooks.py
@@ -5,6 +5,7 @@ from collections.abc import Mapping
 from datetime import timezone
 from typing import Any
 
+import orjson
 from dateutil.parser import parse as parse_date
 from django.db import IntegrityError, router, transaction
 from django.http import Http404, HttpResponse
@@ -26,7 +27,6 @@ from sentry.plugins.providers import IntegrationRepositoryProvider
 from sentry.services.hybrid_cloud.integration import integration_service
 from sentry.services.hybrid_cloud.integration.model import RpcIntegration
 from sentry.services.hybrid_cloud.organization import organization_service
-from sentry.utils import json
 
 logger = logging.getLogger("sentry.webhooks")
 
@@ -309,8 +309,8 @@ class GitlabWebhookEndpoint(Endpoint, GitlabWebhookMixin):
             return HttpResponse(status=409, reason=extra["reason"])
 
         try:
-            event = json.loads(request.body.decode("utf-8"))
-        except json.JSONDecodeError:
+            event = orjson.loads(request.body)
+        except orjson.JSONDecodeError:
             logger.info("gitlab.webhook.invalid-json", extra=extra)
             extra["reason"] = "Data received is not JSON."
             logger.exception(extra["reason"])

--- a/src/sentry/integrations/jira/views/extension_configuration.py
+++ b/src/sentry/integrations/jira/views/extension_configuration.py
@@ -1,4 +1,5 @@
-from sentry.utils import json
+import orjson
+
 from sentry.utils.signing import unsign
 from sentry.web.frontend.base import control_silo_view
 from sentry.web.frontend.integration_extension_configuration import (
@@ -28,5 +29,5 @@ class JiraExtensionConfigurationView(IntegrationExtensionConfigurationView):
                 max_age=INSTALL_EXPIRATION_TIME,
             )
         )
-        params["metadata"] = json.loads(params["metadata"])
+        params["metadata"] = orjson.loads(params["metadata"])
         return params

--- a/src/sentry/integrations/jira/views/sentry_installation.py
+++ b/src/sentry/integrations/jira/views/sentry_installation.py
@@ -1,9 +1,9 @@
+import orjson
 from jwt import ExpiredSignatureError
 from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry.integrations.utils import AtlassianConnectValidationError, get_integration_from_request
-from sentry.utils import json
 from sentry.utils.assets import get_asset_url
 from sentry.utils.http import absolute_uri
 from sentry.utils.signing import sign
@@ -32,7 +32,7 @@ class JiraSentryInstallationView(JiraSentryUIBaseView):
         # expose a link to the configuration view
         signed_data = {
             "external_id": integration.external_id,
-            "metadata": json.dumps(integration.metadata),
+            "metadata": orjson.dumps(integration.metadata).decode(),
         }
         finish_link = "{}.?signed_params={}".format(
             absolute_uri("/extensions/jira/configure/"), sign(**signed_data)

--- a/src/sentry/integrations/msteams/webhook.py
+++ b/src/sentry/integrations/msteams/webhook.py
@@ -6,6 +6,7 @@ from collections.abc import Callable, Mapping
 from enum import Enum
 from typing import Any
 
+import orjson
 from django.http import HttpRequest, HttpResponse
 from django.views.decorators.csrf import csrf_exempt
 from rest_framework.exceptions import AuthenticationFailed, NotAuthenticated
@@ -25,7 +26,7 @@ from sentry.services.hybrid_cloud.integration import integration_service
 from sentry.services.hybrid_cloud.integration.model import RpcIntegration
 from sentry.services.hybrid_cloud.user.service import user_service
 from sentry.silo.base import SiloMode
-from sentry.utils import json, jwt
+from sentry.utils import jwt
 from sentry.utils.audit import create_audit_entry
 from sentry.utils.signing import sign
 
@@ -108,7 +109,7 @@ def verify_signature(request):
     public_keys = {}
     for jwk in jwks["keys"]:
         kid = jwk["kid"]
-        public_keys[kid] = jwt.rsa_key_from_jwk(json.dumps(jwk))
+        public_keys[kid] = jwt.rsa_key_from_jwk(orjson.dumps(jwk).decode())
 
     kid = jwt.peek_header(token)["kid"]
     key = public_keys[kid]

--- a/src/sentry/integrations/pagerduty/integration.py
+++ b/src/sentry/integrations/pagerduty/integration.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 from typing import Any
 
+import orjson
 from django.db import router, transaction
 from django.http import HttpResponse
 from django.utils.translation import gettext_lazy as _
@@ -21,7 +22,6 @@ from sentry.models.integrations.organization_integration import OrganizationInte
 from sentry.pipeline import PipelineView
 from sentry.services.hybrid_cloud.organization import RpcOrganizationSummary
 from sentry.shared_integrations.exceptions import IntegrationError
-from sentry.utils import json
 from sentry.utils.http import absolute_uri
 
 from .client import PagerDutyClient
@@ -197,7 +197,7 @@ class PagerDutyIntegrationProvider(IntegrationProvider):
                 )
 
     def build_integration(self, state):
-        config = json.loads(state.get("config"))
+        config = orjson.loads(state.get("config"))
         account = config["account"]
         # PagerDuty gives us integration keys for various things, some of which
         # are not services. For now we only care about services.

--- a/tests/sentry/integrations/aws_lambda/test_client.py
+++ b/tests/sentry/integrations/aws_lambda/test_client.py
@@ -1,11 +1,11 @@
 from unittest.mock import MagicMock, patch
 
 import boto3
+import orjson
 
 from sentry.integrations.aws_lambda.client import gen_aws_client
 from sentry.testutils.cases import TestCase
 from sentry.testutils.silo import all_silo_test
-from sentry.utils import json
 
 
 @all_silo_test
@@ -43,7 +43,7 @@ class AwsLambdaClientTest(TestCase):
             RoleSessionName="Sentry",
             RoleArn=role_arn,
             ExternalId=aws_external_id,
-            Policy=json.dumps(
+            Policy=orjson.dumps(
                 {
                     "Version": "2012-10-17",
                     "Statement": [
@@ -64,7 +64,7 @@ class AwsLambdaClientTest(TestCase):
                         },
                     ],
                 }
-            ),
+            ).decode(),
         )
 
         mock_get_session.assert_called_once_with(

--- a/tests/sentry/integrations/bitbucket/test_issues.py
+++ b/tests/sentry/integrations/bitbucket/test_issues.py
@@ -1,5 +1,6 @@
 import copy
 
+import orjson
 import responses
 
 from sentry.integrations.bitbucket.issues import ISSUE_TYPES, PRIORITIES
@@ -9,7 +10,6 @@ from sentry.testutils.cases import APITestCase
 from sentry.testutils.factories import DEFAULT_EVENT_DATA
 from sentry.testutils.helpers.datetime import before_now, iso_format
 from sentry.testutils.skips import requires_snuba
-from sentry.utils import json
 
 pytestmark = [requires_snuba]
 
@@ -99,7 +99,7 @@ class BitbucketIssueTest(APITestCase):
 
         request = responses.calls[0].request
         assert responses.calls[0].response.status_code == 201
-        payload = json.loads(request.body)
+        payload = orjson.loads(request.body)
         assert payload == {"content": {"raw": comment["comment"]}}
 
     @responses.activate

--- a/tests/sentry/integrations/bitbucket_server/test_client.py
+++ b/tests/sentry/integrations/bitbucket_server/test_client.py
@@ -1,3 +1,4 @@
+import orjson
 import responses
 from django.test import override_settings
 from requests import Request
@@ -9,7 +10,6 @@ from sentry.integrations.bitbucket_server.client import (
 )
 from sentry.testutils.cases import BaseTestCase, TestCase
 from sentry.testutils.silo import control_silo_test
-from sentry.utils import json
 from tests.sentry.integrations.jira_server import EXAMPLE_PRIVATE_KEY
 
 control_address = "http://controlserver"
@@ -71,7 +71,7 @@ class BitbucketServerClientTest(TestCase, BaseTestCase):
         responses.add(
             responses.GET,
             f"{self.bb_server_client.base_url}{BitbucketServerAPIPath.repository.format(project='laurynsentry', repo='helloworld')}",
-            body=json.dumps(REPO),
+            body=orjson.dumps(REPO),
         )
 
         res = self.bb_server_client.get_repo("laurynsentry", "helloworld")

--- a/tests/sentry/integrations/bitbucket_server/test_webhook.py
+++ b/tests/sentry/integrations/bitbucket_server/test_webhook.py
@@ -1,6 +1,7 @@
 from time import time
 from typing import Any
 
+import orjson
 import responses
 from requests.exceptions import ConnectionError
 
@@ -11,7 +12,6 @@ from sentry.models.repository import Repository
 from sentry.silo.base import SiloMode
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.silo import assume_test_silo_mode
-from sentry.utils import json
 from sentry_plugins.bitbucket.testutils import REFS_CHANGED_EXAMPLE
 
 PROVIDER = "bitbucket_server"
@@ -162,7 +162,7 @@ class RefsChangedWebhookTest(WebhookTestBase):
         self.get_error_response(
             self.organization.id,
             self.integration.id,
-            raw_data=json.dumps(payload),
+            raw_data=orjson.dumps(payload),
             extra_headers=dict(HTTP_X_EVENT_KEY="repo:refs_changed"),
             status_code=400,
         )
@@ -204,7 +204,7 @@ class RefsChangedWebhookTest(WebhookTestBase):
         self.get_error_response(
             self.organization.id,
             self.integration.id,
-            raw_data=json.dumps(payload),
+            raw_data=orjson.dumps(payload),
             extra_headers=dict(HTTP_X_EVENT_KEY="repo:refs_changed"),
             status_code=409,
         )

--- a/tests/sentry/integrations/discord/test_issue_alert.py
+++ b/tests/sentry/integrations/discord/test_issue_alert.py
@@ -1,6 +1,7 @@
 from unittest import mock
 from uuid import uuid4
 
+import orjson
 import responses
 from django.core.exceptions import ValidationError
 
@@ -18,7 +19,6 @@ from sentry.testutils.cases import RuleTestCase, TestCase
 from sentry.testutils.helpers.datetime import before_now, iso_format
 from sentry.testutils.skips import requires_snuba
 from sentry.types.integrations import ExternalProviders
-from sentry.utils import json
 
 pytestmark = [requires_snuba]
 
@@ -73,7 +73,7 @@ class DiscordIssueAlertTest(RuleTestCase):
         results[0].callback(self.event, futures=[])
 
         body = responses.calls[0].request.body
-        data = json.loads(bytes.decode(body, "utf-8"))
+        data = orjson.loads(body)
 
         embed = data["embeds"][0]
         assert embed == {
@@ -138,7 +138,7 @@ class DiscordIssueAlertTest(RuleTestCase):
         results[0].callback(self.event, futures=[])
 
         body = responses.calls[0].request.body
-        data = json.loads(bytes.decode(body, "utf-8"))
+        data = orjson.loads(body)
 
         buttons = data["components"][0]["components"]
         assert (
@@ -165,7 +165,7 @@ class DiscordIssueAlertTest(RuleTestCase):
         results[0].callback(self.event, futures=[])
 
         body = responses.calls[0].request.body
-        data = json.loads(bytes.decode(body, "utf-8"))
+        data = orjson.loads(body)
 
         buttons = data["components"][0]["components"]
         assert (
@@ -192,7 +192,7 @@ class DiscordIssueAlertTest(RuleTestCase):
         results[0].callback(self.event, futures=[])
 
         body = responses.calls[0].request.body
-        data = json.loads(bytes.decode(body, "utf-8"))
+        data = orjson.loads(body)
 
         buttons = data["components"][0]["components"]
         assert (

--- a/tests/sentry/integrations/discord/test_requests.py
+++ b/tests/sentry/integrations/discord/test_requests.py
@@ -2,11 +2,12 @@ from __future__ import annotations
 
 from unittest import mock
 
+import orjson
+
 from sentry.integrations.discord.requests.base import DiscordRequest
 from sentry.services.hybrid_cloud.integration.model import RpcIntegration
 from sentry.testutils.cases import TestCase
 from sentry.testutils.silo import control_silo_test
-from sentry.utils import json
 
 
 @control_silo_test
@@ -27,7 +28,7 @@ class DiscordRequestTest(TestCase):
             if request_data is None
             else request_data
         )
-        self.request.body = json.dumps(self.request.data).encode()
+        self.request.body = orjson.dumps(self.request.data)
         self.request.META = {
             "HTTP_X_SIGNATURE_ED25519": "signature",
             "HTTP_X_SIGNATURE_TIMESTAMP": "timestamp",

--- a/tests/sentry/integrations/github/test_client.py
+++ b/tests/sentry/integrations/github/test_client.py
@@ -3,6 +3,7 @@ from dataclasses import asdict
 from datetime import UTC, datetime, timedelta
 from unittest import mock
 
+import orjson
 import pytest
 import responses
 from django.core import mail
@@ -26,7 +27,6 @@ from sentry.silo.util import PROXY_BASE_PATH, PROXY_OI_HEADER, PROXY_SIGNATURE_H
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.datetime import freeze_time
 from sentry.testutils.silo import control_silo_test
-from sentry.utils import json
 from sentry.utils.cache import cache
 from tests.sentry.integrations.test_helpers import add_control_silo_proxy_response
 
@@ -596,7 +596,7 @@ class GitHubClientFileBlameBase(TestCase):
         responses.add(
             method=responses.GET,
             url="https://api.github.com/rate_limit",
-            body=json.dumps(
+            body=orjson.dumps(
                 {
                     "resources": {
                         "graphql": {
@@ -607,7 +607,7 @@ class GitHubClientFileBlameBase(TestCase):
                         }
                     }
                 }
-            ),
+            ).decode(),
             status=200,
             content_type="application/json",
         )
@@ -681,7 +681,7 @@ class GitHubClientFileBlameIntegrationDisableTest(TestCase):
         responses.add(
             method=responses.GET,
             url="https://api.github.com/rate_limit",
-            body=json.dumps(
+            body=orjson.dumps(
                 {
                     "resources": {
                         "graphql": {
@@ -692,7 +692,7 @@ class GitHubClientFileBlameIntegrationDisableTest(TestCase):
                         }
                     }
                 }
-            ),
+            ).decode(),
             status=200,
             content_type="application/json",
         )
@@ -868,8 +868,8 @@ class GitHubClientFileBlameQueryBuilderTest(GitHubClientFileBlameBase):
         )
 
         self.github_client.get_blame_for_files([file1, file2, file3], extra={})
-        assert json.loads(responses.calls[1].request.body)["query"] == query
-        assert json.loads(responses.calls[1].request.body)["variables"] == {
+        assert orjson.loads(responses.calls[1].request.body)["query"] == query
+        assert orjson.loads(responses.calls[1].request.body)["variables"] == {
             "repo_name_0": "foo",
             "repo_owner_0": "Test-Organization",
             "ref_0_0": "master",
@@ -982,8 +982,8 @@ class GitHubClientFileBlameQueryBuilderTest(GitHubClientFileBlameBase):
         )
 
         self.github_client.get_blame_for_files([file1, file2, file3], extra={})
-        assert json.loads(responses.calls[1].request.body)["query"] == query
-        assert json.loads(responses.calls[1].request.body)["variables"] == {
+        assert orjson.loads(responses.calls[1].request.body)["query"] == query
+        assert orjson.loads(responses.calls[1].request.body)["variables"] == {
             "repo_name_0": "foo",
             "repo_owner_0": "Test-Organization",
             "ref_0_0": "master",
@@ -1082,8 +1082,8 @@ class GitHubClientFileBlameQueryBuilderTest(GitHubClientFileBlameBase):
         )
 
         self.github_client.get_blame_for_files([file1, file2, file3], extra={})
-        assert json.loads(responses.calls[1].request.body)["query"] == query
-        assert json.loads(responses.calls[1].request.body)["variables"] == {
+        assert orjson.loads(responses.calls[1].request.body)["query"] == query
+        assert orjson.loads(responses.calls[1].request.body)["variables"] == {
             "repo_name_0": "foo",
             "repo_owner_0": "Test-Organization",
             "ref_0_0": "master",
@@ -1144,8 +1144,8 @@ class GitHubClientFileBlameQueryBuilderTest(GitHubClientFileBlameBase):
         )
 
         self.github_client.get_blame_for_files([file1], extra={})
-        assert json.loads(responses.calls[1].request.body)["query"] == query
-        assert json.loads(responses.calls[1].request.body)["variables"] == {
+        assert orjson.loads(responses.calls[1].request.body)["query"] == query
+        assert orjson.loads(responses.calls[1].request.body)["variables"] == {
             "repo_name_0": "foo",
             "repo_owner_0": "Test-Organization",
             "ref_0_0": "master",
@@ -1321,7 +1321,7 @@ class GitHubClientFileBlameResponseTest(GitHubClientFileBlameBase):
             generate_file_path_mapping([self.file1, self.file2, self.file3]), extra={}
         )
         cache_key = self.github_client.get_cache_key(
-            "/graphql", json.dumps({"query": query, "variables": variables})
+            "/graphql", orjson.dumps({"query": query, "variables": variables}).decode()
         )
         assert self.github_client.check_cache(cache_key) is None
         response = self.github_client.get_blame_for_files(
@@ -1594,7 +1594,7 @@ class GitHubClientFileBlameRateLimitTest(GitHubClientFileBlameBase):
         responses.add(
             method=responses.GET,
             url="https://api.github.com/rate_limit",
-            body=json.dumps(
+            body=orjson.dumps(
                 {
                     "resources": {
                         "graphql": {
@@ -1605,7 +1605,7 @@ class GitHubClientFileBlameRateLimitTest(GitHubClientFileBlameBase):
                         }
                     }
                 }
-            ),
+            ).decode(),
             status=200,
             content_type="application/json",
         )

--- a/tests/sentry/integrations/github/test_integration.py
+++ b/tests/sentry/integrations/github/test_integration.py
@@ -7,6 +7,7 @@ from unittest import mock
 from unittest.mock import patch
 from urllib.parse import urlencode, urlparse
 
+import orjson
 import pytest
 import responses
 from django.urls import reverse
@@ -33,7 +34,6 @@ from sentry.shared_integrations.exceptions import ApiError
 from sentry.silo.base import SiloMode
 from sentry.testutils.cases import IntegrationTestCase
 from sentry.testutils.silo import assume_test_silo_mode, control_silo_test
-from sentry.utils import json
 from sentry.utils.cache import cache
 
 TREE_RESPONSES = {
@@ -412,12 +412,12 @@ class GitHubIntegrationTest(IntegrationTestCase):
         )
         self.client.get(init_path_1)
 
-        webhook_event = json.loads(INSTALLATION_EVENT_EXAMPLE)
+        webhook_event = orjson.loads(INSTALLATION_EVENT_EXAMPLE)
         webhook_event["installation"]["id"] = self.installation_id
         webhook_event["sender"]["login"] = "attacker"
         resp = self.client.post(
             path="/extensions/github/webhook/",
-            data=json.dumps(webhook_event),
+            data=orjson.dumps(webhook_event),
             content_type="application/json",
             HTTP_X_GITHUB_EVENT="installation",
             HTTP_X_HUB_SIGNATURE="sha1=d184e6717f8bfbcc291ebc8c0756ee446c6c9486",

--- a/tests/sentry/integrations/github/test_issues.py
+++ b/tests/sentry/integrations/github/test_issues.py
@@ -3,6 +3,7 @@ from functools import cached_property
 from typing import cast
 from unittest.mock import patch
 
+import orjson
 import responses
 from django.test import RequestFactory
 from django.utils import timezone
@@ -20,7 +21,6 @@ from sentry.testutils.helpers.datetime import before_now, iso_format
 from sentry.testutils.helpers.notifications import TEST_ISSUE_OCCURRENCE
 from sentry.testutils.silo import all_silo_test
 from sentry.testutils.skips import requires_snuba
-from sentry.utils import json
 
 pytestmark = [requires_snuba]
 
@@ -226,7 +226,7 @@ class GitHubIssueBasicTest(TestCase, PerformanceIssueTestCase, IntegratedApiTest
 
             request = responses.calls[1].request
             assert request.headers["Authorization"] == "Bearer token_1"
-            payload = json.loads(request.body)
+            payload = orjson.loads(request.body)
             assert payload == {
                 "body": "This is the description",
                 "assignee": None,
@@ -455,7 +455,7 @@ class GitHubIssueBasicTest(TestCase, PerformanceIssueTestCase, IntegratedApiTest
 
         request = responses.calls[1].request
         assert request.headers["Authorization"] == "Bearer token_1"
-        payload = json.loads(request.body)
+        payload = orjson.loads(request.body)
         assert payload == {"body": "hello"}
 
     @responses.activate

--- a/tests/sentry/integrations/github/test_repository.py
+++ b/tests/sentry/integrations/github/test_repository.py
@@ -2,6 +2,7 @@ import datetime
 from functools import cached_property
 from unittest import mock
 
+import orjson
 import pytest
 import responses
 from django.utils import timezone
@@ -15,7 +16,6 @@ from sentry.silo.base import SiloMode
 from sentry.testutils.asserts import assert_commit_shape
 from sentry.testutils.cases import TestCase
 from sentry.testutils.silo import assume_test_silo_mode, control_silo_test
-from sentry.utils import json
 
 
 @control_silo_test
@@ -80,12 +80,12 @@ class GitHubAppsProviderTest(TestCase):
         responses.add(
             responses.GET,
             "https://api.github.com/repos/getsentry/example-repo/commits?sha=abcdef",
-            json=json.loads(GET_LAST_COMMITS_EXAMPLE),
+            json=orjson.loads(GET_LAST_COMMITS_EXAMPLE),
         )
         responses.add(
             responses.GET,
             "https://api.github.com/repos/getsentry/example-repo/commits/6dcb09b5b57875f334f61aebed695e2e4193db5e",
-            json=json.loads(GET_COMMIT_EXAMPLE),
+            json=orjson.loads(GET_COMMIT_EXAMPLE),
         )
         result = self.provider.compare_commits(self.repository, None, "abcdef")
         for commit in result:
@@ -107,12 +107,12 @@ class GitHubAppsProviderTest(TestCase):
         responses.add(
             responses.GET,
             "https://api.github.com/repos/getsentry/example-repo/compare/xyz123...abcdef",
-            json=json.loads(COMPARE_COMMITS_EXAMPLE),
+            json=orjson.loads(COMPARE_COMMITS_EXAMPLE),
         )
         responses.add(
             responses.GET,
             "https://api.github.com/repos/getsentry/example-repo/commits/6dcb09b5b57875f334f61aebed695e2e4193db5e",
-            json=json.loads(GET_COMMIT_EXAMPLE),
+            json=orjson.loads(GET_COMMIT_EXAMPLE),
         )
         result = self.provider.compare_commits(self.repository, "xyz123", "abcdef")
         for commit in result:
@@ -124,12 +124,12 @@ class GitHubAppsProviderTest(TestCase):
         responses.add(
             responses.GET,
             "https://api.github.com/repos/getsentry/example-repo/compare/xyz123...abcdef",
-            json=json.loads(COMPARE_COMMITS_EXAMPLE),
+            json=orjson.loads(COMPARE_COMMITS_EXAMPLE),
         )
         responses.add(
             responses.GET,
             "https://api.github.com/repos/getsentry/example-repo/commits/6dcb09b5b57875f334f61aebed695e2e4193db5e",
-            json=json.loads(GET_COMMIT_EXAMPLE),
+            json=orjson.loads(GET_COMMIT_EXAMPLE),
         )
         result = self.provider.compare_commits(self.repository, "xyz123", "abcdef")
 
@@ -146,7 +146,7 @@ class GitHubAppsProviderTest(TestCase):
         responses.add(
             responses.GET,
             "https://api.github.com/repos/getsentry/example-repo/commits/abcdef",
-            json=json.loads(GET_COMMIT_EXAMPLE),
+            json=orjson.loads(GET_COMMIT_EXAMPLE),
         )
         client = self.integration.get_installation(self.repository.organization_id).get_client()
 

--- a/tests/sentry/integrations/github_enterprise/test_issues.py
+++ b/tests/sentry/integrations/github_enterprise/test_issues.py
@@ -2,6 +2,7 @@ from functools import cached_property
 from typing import cast
 from unittest.mock import patch
 
+import orjson
 import responses
 from django.test import RequestFactory
 
@@ -11,7 +12,6 @@ from sentry.silo.base import SiloMode
 from sentry.silo.util import PROXY_BASE_URL_HEADER, PROXY_OI_HEADER, PROXY_SIGNATURE_HEADER
 from sentry.testutils.cases import IntegratedApiTestCase, TestCase
 from sentry.testutils.silo import assume_test_silo_mode
-from sentry.utils import json
 
 
 class GitHubEnterpriseIssueBasicTest(TestCase, IntegratedApiTestCase):
@@ -155,7 +155,7 @@ class GitHubEnterpriseIssueBasicTest(TestCase, IntegratedApiTestCase):
 
             request = responses.calls[1].request
             assert request.headers["Authorization"] == "Bearer token_1"
-            payload = json.loads(request.body)
+            payload = orjson.loads(request.body)
             assert payload == {
                 "body": "This is the description",
                 "assignee": None,
@@ -265,7 +265,7 @@ class GitHubEnterpriseIssueBasicTest(TestCase, IntegratedApiTestCase):
 
             request = responses.calls[1].request
             assert request.headers["Authorization"] == "Bearer token_1"
-            payload = json.loads(request.body)
+            payload = orjson.loads(request.body)
             assert payload == {"body": "hello"}
         else:
             self._check_proxying()

--- a/tests/sentry/integrations/gitlab/test_client.py
+++ b/tests/sentry/integrations/gitlab/test_client.py
@@ -6,6 +6,7 @@ from unittest import mock
 from unittest.mock import patch
 from urllib.parse import quote
 
+import orjson
 import pytest
 import responses
 from requests.exceptions import ConnectionError
@@ -22,7 +23,6 @@ from sentry.models.integrations import Integration
 from sentry.shared_integrations.exceptions import ApiError, ApiHostError, ApiRateLimitedError
 from sentry.testutils.outbox import outbox_runner
 from sentry.testutils.silo import control_silo_test
-from sentry.utils import json
 from sentry.utils.cache import cache
 
 GITLAB_CODEOWNERS = {
@@ -105,7 +105,7 @@ class GitlabRefreshAuthTest(GitLabClientTest):
         self.assert_response_call(responses_calls[1], self.refresh_url, 200)
         self.assert_response_call(responses_calls[2], self.request_url, 200)
 
-        assert json.loads(responses_calls[2].response.text) == self.request_data
+        assert orjson.loads(responses_calls[2].response.text) == self.request_data
 
     def assert_identity_was_refreshed(self):
         data = self.gitlab_client.identity.data
@@ -226,11 +226,11 @@ class GitlabRefreshAuthTest(GitLabClientTest):
         responses.add(
             method=responses.GET,
             url=f"https://example.gitlab.com/api/v4/projects/{self.gitlab_id}/repository/commits/{commit}",
-            json=json.loads(GET_COMMIT_RESPONSE),
+            json=orjson.loads(GET_COMMIT_RESPONSE),
         )
 
         resp = self.gitlab_client.get_commit(self.gitlab_id, commit)
-        assert resp == json.loads(GET_COMMIT_RESPONSE)
+        assert resp == orjson.loads(GET_COMMIT_RESPONSE)
 
     @responses.activate
     def test_get_rate_limit_info_from_response(self):

--- a/tests/sentry/integrations/gitlab/test_integration.py
+++ b/tests/sentry/integrations/gitlab/test_integration.py
@@ -3,6 +3,7 @@ from datetime import datetime, timezone
 from unittest.mock import Mock, patch
 from urllib.parse import parse_qs, quote, urlencode, urlparse
 
+import orjson
 import pytest
 import responses
 from django.core.cache import cache
@@ -22,7 +23,6 @@ from sentry.silo.base import SiloMode
 from sentry.silo.util import PROXY_BASE_PATH, PROXY_OI_HEADER, PROXY_SIGNATURE_HEADER
 from sentry.testutils.cases import IntegrationTestCase
 from sentry.testutils.silo import assume_test_silo_mode, control_silo_test
-from sentry.utils import json
 from tests.sentry.integrations.test_helpers import add_control_silo_proxy_response
 
 
@@ -695,13 +695,13 @@ class GitlabProxyApiClientTest(GitLabTestCase):
         gitlab_response = responses.add(
             method=responses.GET,
             url=f"https://example.gitlab.com/api/v4/projects/{gitlab_id}/repository/commits/{commit}",
-            json=json.loads(GET_COMMIT_RESPONSE),
+            json=orjson.loads(GET_COMMIT_RESPONSE),
         )
 
         control_proxy_response = add_control_silo_proxy_response(
             method=responses.GET,
             path=f"api/v4/projects/{gitlab_id}/repository/commits/{commit}",
-            json=json.loads(GET_COMMIT_RESPONSE),
+            json=orjson.loads(GET_COMMIT_RESPONSE),
         )
 
         class GitlabProxyApiTestClient(GitLabProxyApiClient):

--- a/tests/sentry/integrations/gitlab/test_repository.py
+++ b/tests/sentry/integrations/gitlab/test_repository.py
@@ -1,5 +1,6 @@
 from functools import cached_property
 
+import orjson
 import pytest
 import responses
 
@@ -13,7 +14,6 @@ from sentry.silo.base import SiloMode
 from sentry.testutils.asserts import assert_commit_shape
 from sentry.testutils.cases import IntegrationRepositoryTestCase
 from sentry.testutils.silo import assume_test_silo_mode
-from sentry.utils import json
 
 
 class GitLabRepositoryProviderTest(IntegrationRepositoryTestCase):
@@ -106,7 +106,7 @@ class GitLabRepositoryProviderTest(IntegrationRepositoryTestCase):
     @responses.activate
     def test_create_repository_verify_payload(self):
         def request_callback(request):
-            payload = json.loads(request.body)
+            payload = orjson.loads(request.body)
             assert "url" in payload
             assert payload["push_events"]
             assert payload["merge_requests_events"]
@@ -115,7 +115,7 @@ class GitLabRepositoryProviderTest(IntegrationRepositoryTestCase):
             )
             assert payload["token"] == expected_token
 
-            return (201, {}, json.dumps({"id": 99}))
+            return 201, {}, orjson.dumps({"id": 99}).decode()
 
         responses.add_callback(
             responses.POST,
@@ -234,19 +234,19 @@ class GitLabRepositoryProviderTest(IntegrationRepositoryTestCase):
             responses.GET,
             "https://example.gitlab.com/api/v4/projects/%s/repository/compare?from=abc&to=xyz"
             % self.gitlab_id,
-            json=json.loads(COMPARE_RESPONSE),
+            json=orjson.loads(COMPARE_RESPONSE),
         )
         responses.add(
             responses.GET,
             "https://example.gitlab.com/api/v4/projects/%s/repository/commits/12d65c8dd2b2676fa3ac47d955accc085a37a9c1/diff"
             % self.gitlab_id,
-            json=json.loads(COMMIT_DIFF_RESPONSE),
+            json=orjson.loads(COMMIT_DIFF_RESPONSE),
         )
         responses.add(
             responses.GET,
             "https://example.gitlab.com/api/v4/projects/%s/repository/commits/8b090c1b79a14f2bd9e8a738f717824ff53aebad/diff"
             % self.gitlab_id,
-            json=json.loads(COMMIT_DIFF_RESPONSE),
+            json=orjson.loads(COMMIT_DIFF_RESPONSE),
         )
         response = self.create_repository(self.default_repository_config, self.integration.id)
         repo = self.get_repository(pk=response.data["id"])
@@ -279,19 +279,19 @@ class GitLabRepositoryProviderTest(IntegrationRepositoryTestCase):
             responses.GET,
             "https://example.gitlab.com/api/v4/projects/%s/repository/commits?until=2018-09-19T13:14:15Z"
             % self.gitlab_id,
-            json=json.loads(COMMIT_LIST_RESPONSE),
+            json=orjson.loads(COMMIT_LIST_RESPONSE),
         )
         responses.add(
             responses.GET,
             "https://example.gitlab.com/api/v4/projects/%s/repository/commits/ed899a2f4b50b4370feeea94676502b42383c746/diff"
             % self.gitlab_id,
-            json=json.loads(COMMIT_DIFF_RESPONSE),
+            json=orjson.loads(COMMIT_DIFF_RESPONSE),
         )
         responses.add(
             responses.GET,
             "https://example.gitlab.com/api/v4/projects/%s/repository/commits/6104942438c14ec7bd21c6cd5bd995272b3faff6/diff"
             % self.gitlab_id,
-            json=json.loads(COMMIT_DIFF_RESPONSE),
+            json=orjson.loads(COMMIT_DIFF_RESPONSE),
         )
 
         response = self.create_repository(self.default_repository_config, self.integration.id)

--- a/tests/sentry/integrations/gitlab/test_search.py
+++ b/tests/sentry/integrations/gitlab/test_search.py
@@ -1,12 +1,12 @@
 from urllib.parse import parse_qs
 
+import orjson
 import responses
 from django.urls import reverse
 
 from fixtures.gitlab import GitLabTestCase
 from sentry.models.integrations.organization_integration import OrganizationIntegration
 from sentry.testutils.silo import control_silo_test
-from sentry.utils import json
 
 
 @control_silo_test
@@ -104,7 +104,7 @@ class GitlabSearchTest(GitLabTestCase):
                 projects = [project_a, project_b] * 10
             else:
                 projects = [project_a, project_b] * 50
-            return (200, {}, json.dumps(projects))
+            return 200, {}, orjson.dumps(projects).decode()
 
         responses.add_callback(
             responses.GET,

--- a/tests/sentry/integrations/gitlab/test_webhook.py
+++ b/tests/sentry/integrations/gitlab/test_webhook.py
@@ -1,3 +1,5 @@
+import orjson
+
 from fixtures.gitlab import (
     EXTERNAL_ID,
     MERGE_REQUEST_OPENED_EVENT,
@@ -13,7 +15,6 @@ from sentry.models.integrations import Integration
 from sentry.models.pullrequest import PullRequest
 from sentry.silo.base import SiloMode
 from sentry.testutils.silo import assume_test_silo_mode, assume_test_silo_mode_of
-from sentry.utils import json
 
 
 class WebhookTest(GitLabTestCase):
@@ -204,12 +205,12 @@ class WebhookTest(GitLabTestCase):
 
     def test_push_event_create_commits_with_no_author_email(self):
         repo = self.create_repo("getsentry/sentry")
-        push_event = json.loads(PUSH_EVENT)
+        push_event = orjson.loads(PUSH_EVENT)
         push_event["commits"][0]["author"]["email"] = None
 
         response = self.client.post(
             self.url,
-            data=json.dumps(push_event),
+            data=orjson.dumps(push_event),
             content_type="application/json",
             HTTP_X_GITLAB_TOKEN=WEBHOOK_TOKEN,
             HTTP_X_GITLAB_EVENT="Push Hook",
@@ -276,7 +277,7 @@ class WebhookTest(GitLabTestCase):
         assert 0 == PullRequest.objects.count()
 
     def test_merge_event_no_last_commit(self):
-        payload = json.loads(MERGE_REQUEST_OPENED_EVENT)
+        payload = orjson.loads(MERGE_REQUEST_OPENED_EVENT)
 
         # Remove required keys. There have been events in prod that are missing
         # these important attributes. GitLab docs don't explain why though.
@@ -284,7 +285,7 @@ class WebhookTest(GitLabTestCase):
 
         response = self.client.post(
             self.url,
-            data=json.dumps(payload),
+            data=orjson.dumps(payload),
             content_type="application/json",
             HTTP_X_GITLAB_TOKEN=WEBHOOK_TOKEN,
             HTTP_X_GITLAB_EVENT="Merge Request Hook",

--- a/tests/sentry/integrations/jira_server/test_installation.py
+++ b/tests/sentry/integrations/jira_server/test_installation.py
@@ -1,3 +1,4 @@
+import orjson
 import responses
 from requests.exceptions import ReadTimeout
 
@@ -7,7 +8,7 @@ from sentry.models.integrations.integration import Integration
 from sentry.models.integrations.organization_integration import OrganizationIntegration
 from sentry.testutils.cases import IntegrationTestCase
 from sentry.testutils.silo import control_silo_test
-from sentry.utils import json, jwt
+from sentry.utils import jwt
 
 from . import EXAMPLE_PRIVATE_KEY
 
@@ -304,14 +305,14 @@ class JiraServerInstallationTest(IntegrationTestCase):
         def webhook_response(request):
             # Ensure the webhook token contains our integration
             # external id
-            data = json.loads(request.body)
+            data = orjson.loads(request.body)
             url = data["url"]
             token = url.split("/")[-2]
             token_data = jwt.peek_claims(token)
             assert "id" in token_data
             assert token_data["id"] == expected_id
 
-            return (204, {}, "")
+            return 204, {}, ""
 
         responses.add_callback(
             responses.POST,

--- a/tests/sentry/integrations/jira_server/test_integration.py
+++ b/tests/sentry/integrations/jira_server/test_integration.py
@@ -3,6 +3,7 @@ from functools import cached_property
 from unittest import mock
 from unittest.mock import patch
 
+import orjson
 import pytest
 import responses
 from django.db import router
@@ -26,7 +27,6 @@ from sentry.testutils.factories import DEFAULT_EVENT_DATA
 from sentry.testutils.helpers.datetime import before_now, iso_format
 from sentry.testutils.silo import assume_test_silo_mode, control_silo_test
 from sentry.testutils.skips import requires_snuba
-from sentry.utils import json
 from sentry.utils.http import absolute_uri
 from sentry_plugins.jira.plugin import JiraPlugin
 
@@ -502,10 +502,10 @@ class JiraServerRegionIntegrationTest(JiraServerIntegrationBaseTest):
         )
 
         with mock.patch.object(self.installation, "get_client", get_client):
-            mock_get_issue_fields_return_value = json.loads(
+            mock_get_issue_fields_return_value = orjson.loads(
                 StubService.get_stub_json("jira", "issue_fields_response.json")
             )
-            project_list_response = json.loads(
+            project_list_response = orjson.loads(
                 StubService.get_stub_json("jira", "project_list_response.json")
             )
             side_effect_values = [
@@ -699,7 +699,7 @@ class JiraServerRegionIntegrationTest(JiraServerIntegrationBaseTest):
         )
 
         def responder(request):
-            body = json.loads(request.body)
+            body = orjson.loads(request.body)
             assert body["fields"]["labels"] == ["fuzzy", "bunnies"]
             assert body["fields"]["customfield_10200"] == {"value": "sad"}
             assert body["fields"]["customfield_10201"] == [

--- a/tests/sentry/integrations/msteams/test_action_state_change.py
+++ b/tests/sentry/integrations/msteams/test_action_state_change.py
@@ -1,6 +1,7 @@
 import time
 from unittest.mock import patch
 
+import orjson
 import responses
 from django.http import HttpResponse
 from django.urls import reverse
@@ -20,7 +21,6 @@ from sentry.testutils.asserts import assert_mock_called_once_with_partial
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.silo import assume_test_silo_mode
 from sentry.testutils.skips import requires_snuba
-from sentry.utils import json
 
 pytestmark = [requires_snuba]
 
@@ -125,12 +125,12 @@ class StatusActionTest(APITestCase):
         sign.return_value = "signed_parameters"
 
         def user_conversation_id_callback(request):
-            payload = json.loads(request.body)
+            payload = orjson.loads(request.body)
             if payload["members"] == [{"id": "s4ur0n"}] and payload["channelData"] == {
                 "tenant": {"id": "7h3_gr347"}
             }:
-                return (200, {}, json.dumps({"id": "d4rk_l0rd"}))
-            return (404, {}, json.dumps({}))
+                return 200, {}, orjson.dumps({"id": "d4rk_l0rd"}).decode()
+            return 404, {}, orjson.dumps({}).decode()
 
         responses.add_callback(
             method=responses.POST,
@@ -159,7 +159,7 @@ class StatusActionTest(APITestCase):
             self.integration, self.org, "s4ur0n", "f3ll0wsh1p", "7h3_gr347"
         )
 
-        data = json.loads(responses.calls[1].request.body)
+        data = orjson.loads(responses.calls[1].request.body)
 
         assert resp.status_code == 201
         assert "attachments" in data

--- a/tests/sentry/integrations/msteams/test_link_identity.py
+++ b/tests/sentry/integrations/msteams/test_link_identity.py
@@ -1,13 +1,13 @@
 import time
 from unittest.mock import patch
 
+import orjson
 import responses
 
 from sentry.integrations.msteams.link_identity import build_linking_url
 from sentry.models.identity import Identity, IdentityStatus
 from sentry.testutils.cases import TestCase
 from sentry.testutils.silo import control_silo_test
-from sentry.utils import json
 
 
 @control_silo_test
@@ -64,11 +64,11 @@ class MsTeamsIntegrationLinkIdentityTest(TestCase):
         self.assertTemplateUsed(resp, "sentry/auth-link-identity.html")
 
         def user_conversation_id_callback(request):
-            payload = json.loads(request.body)
+            payload = orjson.loads(request.body)
             if payload["members"] == [{"id": "a_p_w_b_d"}] and payload["channelData"] == {
                 "tenant": {"id": "h0g5m34d3"}
             }:
-                return (200, {}, json.dumps({"id": "dumbl3d0r3"}))
+                return 200, {}, orjson.dumps({"id": "dumbl3d0r3"}).decode()
 
         responses.add_callback(
             method=responses.POST,
@@ -119,12 +119,12 @@ class MsTeamsIntegrationLinkIdentityTest(TestCase):
         )
 
         def user_conversation_id_callback(request):
-            payload = json.loads(request.body)
+            payload = orjson.loads(request.body)
             if payload["members"] == [{"id": "g_w"}] and payload["channelData"] == {
                 "tenant": {"id": "th3_burr0w"}
             }:
-                return (200, {}, json.dumps({"id": "g1nny_w345l3y"}))
-            return (404, {}, json.dumps({}))
+                return 200, {}, orjson.dumps({"id": "g1nny_w345l3y"}).decode()
+            return 404, {}, orjson.dumps({}).decode()
 
         responses.add_callback(
             method=responses.POST,

--- a/tests/sentry/integrations/msteams/test_message_builder.py
+++ b/tests/sentry/integrations/msteams/test_message_builder.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import re
 from typing import TypeGuard
 
+import orjson
+
 from sentry.integrations.msteams.card_builder.base import MSTeamsMessageBuilder
 from sentry.integrations.msteams.card_builder.block import (
     ActionSet,
@@ -53,7 +55,6 @@ from sentry.testutils.helpers.notifications import (
 )
 from sentry.testutils.skips import requires_snuba
 from sentry.types.group import GroupSubStatus
-from sentry.utils import json
 
 pytestmark = [requires_snuba]
 
@@ -387,7 +388,7 @@ class MSTeamsMessageBuilderTest(TestCase):
         assert "Assign" == assign_action["card"]["actions"][0]["title"]
 
         # Check if card is serializable to json
-        card_json = json.dumps(issue_card)
+        card_json = orjson.dumps(issue_card).decode()
         assert card_json[0] == "{" and card_json[-1] == "}"
 
     def test_issue_message_builder_with_escalating_issues(self):
@@ -482,7 +483,7 @@ class MSTeamsMessageBuilderTest(TestCase):
             assert "Assign" == assign_action["card"]["actions"][0]["title"]
 
             # Check if card is serializable to json
-            card_json = json.dumps(issue_card)
+            card_json = orjson.dumps(issue_card).decode()
             assert card_json[0] == "{" and card_json[-1] == "}"
 
     def test_issue_without_description(self):

--- a/tests/sentry/integrations/msteams/test_notifications.py
+++ b/tests/sentry/integrations/msteams/test_notifications.py
@@ -1,5 +1,6 @@
 from unittest.mock import MagicMock, Mock, call, patch
 
+import orjson
 import responses
 
 from sentry.integrations.msteams.notifications import send_notification_as_msteams
@@ -15,7 +16,6 @@ from sentry.testutils.helpers.notifications import (
 from sentry.testutils.silo import assume_test_silo_mode, control_silo_test
 from sentry.testutils.skips import requires_snuba
 from sentry.types.activity import ActivityType
-from sentry.utils import json
 
 pytestmark = [requires_snuba]
 
@@ -224,7 +224,7 @@ class MSTeamsNotificationIntegrationTest(MSTeamsActivityNotificationTest):
         with self.tasks():
             notification.send()
 
-        data = json.loads(responses.calls[-1].request.body)
+        data = orjson.loads(responses.calls[-1].request.body)
 
         attachment = data["attachments"][0]
         assert "AdaptiveCard" == attachment["content"]["type"]

--- a/tests/sentry/integrations/msteams/test_notify_action.py
+++ b/tests/sentry/integrations/msteams/test_notify_action.py
@@ -2,6 +2,7 @@ import re
 import time
 from unittest import mock
 
+import orjson
 import responses
 
 from sentry.integrations.msteams import MsTeamsNotifyServiceAction
@@ -10,7 +11,6 @@ from sentry.testutils.cases import PerformanceIssueTestCase, RuleTestCase
 from sentry.testutils.helpers.notifications import TEST_ISSUE_OCCURRENCE, TEST_PERF_ISSUE_OCCURRENCE
 from sentry.testutils.silo import assume_test_silo_mode_of
 from sentry.testutils.skips import requires_snuba
-from sentry.utils import json
 
 pytestmark = [requires_snuba]
 
@@ -60,7 +60,7 @@ class MsTeamsNotifyActionTest(RuleTestCase, PerformanceIssueTestCase):
         )
 
         results[0].callback(event, futures=[])
-        data = json.loads(responses.calls[0].request.body)
+        data = orjson.loads(responses.calls[0].request.body)
 
         assert "attachments" in data
         attachments = data["attachments"]
@@ -119,7 +119,7 @@ class MsTeamsNotifyActionTest(RuleTestCase, PerformanceIssueTestCase):
 
         results[0].callback(event, futures=[])
 
-        data = json.loads(responses.calls[0].request.body)
+        data = orjson.loads(responses.calls[0].request.body)
         assert "attachments" in data
         attachments = data["attachments"]
         assert len(attachments) == 1
@@ -157,7 +157,7 @@ class MsTeamsNotifyActionTest(RuleTestCase, PerformanceIssueTestCase):
 
         results[0].callback(event, futures=[])
 
-        data = json.loads(responses.calls[0].request.body)
+        data = orjson.loads(responses.calls[0].request.body)
         assert "attachments" in data
         attachments = data["attachments"]
         assert len(attachments) == 1

--- a/tests/sentry/integrations/msteams/test_utils.py
+++ b/tests/sentry/integrations/msteams/test_utils.py
@@ -1,11 +1,11 @@
 import time
 
+import orjson
 import responses
 
 from sentry.integrations.msteams.utils import get_channel_id
 from sentry.testutils.cases import TestCase
 from sentry.testutils.skips import requires_snuba
-from sentry.utils import json
 
 pytestmark = [requires_snuba]
 
@@ -52,19 +52,19 @@ class GetChannelIdTest(TestCase):
         )
 
         def user_conversation_id_callback(request):
-            payload = json.loads(request.body)
+            payload = orjson.loads(request.body)
             if payload["members"] == [{"id": "d_p_r"}] and payload["channelData"] == {
                 "tenant": {"id": "3141-5926-5358"}
             }:
-                return (200, {}, json.dumps({"id": "dread_pirate_roberts"}))
+                return 200, {}, orjson.dumps({"id": "dread_pirate_roberts"}).decode()
             elif payload["members"] == [{"id": "p_b"}] and payload["channelData"] == {
                 "tenant": {"id": "2718-2818-2845"}
             }:
-                return (200, {}, json.dumps({"id": "princess_bride"}))
+                return 200, {}, orjson.dumps({"id": "princess_bride"}).decode()
             elif payload["members"] == [{"id": "p_t_d"}] and payload["channelData"] == {
                 "tenant": {"id": "1618-0339-8874"}
             }:
-                return (200, {}, json.dumps({"id": "prepare_to_die"}))
+                return 200, {}, orjson.dumps({"id": "prepare_to_die"}).decode()
 
         responses.add_callback(
             responses.POST,

--- a/tests/sentry/integrations/opsgenie/test_client.py
+++ b/tests/sentry/integrations/opsgenie/test_client.py
@@ -1,10 +1,10 @@
+import orjson
 import pytest
 import responses
 
 from sentry.models.rule import Rule
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.skips import requires_snuba
-from sentry.utils import json
 
 pytestmark = [requires_snuba]
 
@@ -88,7 +88,7 @@ class OpsgenieClientTest(APITestCase):
             client.send_notification(event, "P2", [rule])
 
         request = responses.calls[0].request
-        payload = json.loads(request.body)
+        payload = orjson.loads(request.body)
         group_id = str(group.id)
         assert payload == {
             "tags": ["level:warning"],

--- a/tests/sentry/integrations/opsgenie/test_notify_action.py
+++ b/tests/sentry/integrations/opsgenie/test_notify_action.py
@@ -1,5 +1,6 @@
 from unittest.mock import MagicMock, patch
 
+import orjson
 import pytest
 import responses
 
@@ -10,7 +11,6 @@ from sentry.silo.base import SiloMode
 from sentry.testutils.cases import PerformanceIssueTestCase, RuleTestCase
 from sentry.testutils.silo import assume_test_silo_mode
 from sentry.testutils.skips import requires_snuba
-from sentry.utils import json
 
 pytestmark = [requires_snuba]
 
@@ -69,7 +69,7 @@ class OpsgenieNotifyTeamTest(RuleTestCase, PerformanceIssueTestCase):
         )
 
         results[0].callback(event, futures=[])
-        data = json.loads(responses.calls[0].request.body)
+        data = orjson.loads(responses.calls[0].request.body)
 
         assert event.group is not None
         assert data["message"] == event.message
@@ -203,7 +203,7 @@ class OpsgenieNotifyTeamTest(RuleTestCase, PerformanceIssueTestCase):
         )
 
         results[0].callback(event, futures=[])
-        data = json.loads(responses.calls[0].request.body)
+        data = orjson.loads(responses.calls[0].request.body)
 
         assert event.group is not None
         assert data["message"] == event.message

--- a/tests/sentry/integrations/pagerduty/test_integration.py
+++ b/tests/sentry/integrations/pagerduty/test_integration.py
@@ -1,5 +1,6 @@
 from urllib.parse import urlencode, urlparse
 
+import orjson
 import pytest
 import responses
 
@@ -11,7 +12,6 @@ from sentry.models.integrations.organization_integration import OrganizationInte
 from sentry.shared_integrations.exceptions import IntegrationError
 from sentry.testutils.cases import IntegrationTestCase
 from sentry.testutils.silo import control_silo_test
-from sentry.utils import json
 
 
 @control_silo_test
@@ -63,7 +63,7 @@ class PagerDutyIntegrationTest(IntegrationTestCase):
         }
 
         resp = self.client.get(
-            "{}?{}".format(self.setup_path, urlencode({"config": json.dumps(config)}))
+            "{}?{}".format(self.setup_path, urlencode({"config": orjson.dumps(config).decode()}))
         )
 
         self.assertDialogSuccess(resp)
@@ -92,7 +92,7 @@ class PagerDutyIntegrationTest(IntegrationTestCase):
         }
 
         resp = self.client.get(
-            "{}?{}".format(self.setup_path, urlencode({"config": json.dumps(config)}))
+            "{}?{}".format(self.setup_path, urlencode({"config": orjson.dumps(config).decode()}))
         )
 
         self.assertDialogSuccess(resp)

--- a/tests/sentry/integrations/pagerduty/test_notify_action.py
+++ b/tests/sentry/integrations/pagerduty/test_notify_action.py
@@ -1,5 +1,6 @@
 from unittest.mock import patch
 
+import orjson
 import responses
 
 from sentry.integrations.pagerduty.actions.notification import PagerDutyNotifyServiceAction
@@ -11,7 +12,6 @@ from sentry.testutils.helpers.datetime import before_now, iso_format
 from sentry.testutils.helpers.notifications import TEST_ISSUE_OCCURRENCE
 from sentry.testutils.silo import assume_test_silo_mode
 from sentry.testutils.skips import requires_snuba
-from sentry.utils import json
 
 pytestmark = [requires_snuba]
 
@@ -81,7 +81,7 @@ class PagerDutyNotifyActionTest(RuleTestCase, PerformanceIssueTestCase):
 
         # Trigger rule callback
         results[0].callback(event, futures=[])
-        data = json.loads(responses.calls[0].request.body)
+        data = orjson.loads(responses.calls[0].request.body)
 
         assert data["event_action"] == "trigger"
         assert data["payload"]["summary"] == event.message
@@ -128,7 +128,7 @@ class PagerDutyNotifyActionTest(RuleTestCase, PerformanceIssueTestCase):
 
         # Trigger rule callback
         results[0].callback(event, futures=[])
-        data = json.loads(responses.calls[0].request.body)
+        data = orjson.loads(responses.calls[0].request.body)
 
         perf_issue_title = "N+1 Query"
 
@@ -163,7 +163,7 @@ class PagerDutyNotifyActionTest(RuleTestCase, PerformanceIssueTestCase):
 
         # Trigger rule callback
         results[0].callback(group_event, futures=[])
-        data = json.loads(responses.calls[0].request.body)
+        data = orjson.loads(responses.calls[0].request.body)
 
         assert data["event_action"] == "trigger"
         assert data["payload"]["summary"] == group_event.occurrence.issue_title
@@ -291,7 +291,7 @@ class PagerDutyNotifyActionTest(RuleTestCase, PerformanceIssueTestCase):
 
         # Trigger rule callback
         results[0].callback(event, futures=[])
-        data = json.loads(responses.calls[0].request.body)
+        data = orjson.loads(responses.calls[0].request.body)
 
         assert data["event_action"] == "trigger"
 

--- a/tests/sentry/integrations/slack/notifications/test_issue_alert.py
+++ b/tests/sentry/integrations/slack/notifications/test_issue_alert.py
@@ -4,6 +4,7 @@ from unittest import mock
 from unittest.mock import patch
 from urllib.parse import parse_qs
 
+import orjson
 import responses
 
 import sentry
@@ -34,7 +35,6 @@ from sentry.testutils.helpers.slack import get_blocks_and_fallback_text
 from sentry.testutils.silo import assume_test_silo_mode
 from sentry.testutils.skips import requires_snuba
 from sentry.types.integrations import ExternalProviders
-from sentry.utils import json
 
 pytestmark = [requires_snuba]
 
@@ -432,7 +432,7 @@ class SlackIssueAlertNotificationTest(SlackActivityNotificationTest, Performance
         assert data["channel"] == ["CXXXXXXX2"]
         assert "blocks" in data
         assert "text" in data
-        blocks = json.loads(data["blocks"][0])
+        blocks = orjson.loads(data["blocks"][0])
         fallback_text = data["text"][0]
         notification_uuid = notification.notification_uuid
 
@@ -598,7 +598,7 @@ class SlackIssueAlertNotificationTest(SlackActivityNotificationTest, Performance
         data = parse_qs(responses.calls[0].request.body)
         assert data["channel"] == ["CXXXXXXX2"]
         assert "blocks" in data
-        blocks = json.loads(data["blocks"][0])
+        blocks = orjson.loads(data["blocks"][0])
         assert "Hello world" in blocks[1]["text"]["text"]
         title_link = blocks[1]["text"]["text"][13:][1:-1]
         notification_uuid = self.get_notification_uuid(title_link)
@@ -679,7 +679,7 @@ class SlackIssueAlertNotificationTest(SlackActivityNotificationTest, Performance
         assert data["channel"] == ["CXXXXXXX2"]
         assert "blocks" in data
         assert "text" in data
-        blocks = json.loads(data["blocks"][0])
+        blocks = orjson.loads(data["blocks"][0])
         fallback_text = data["text"][0]
         notification_uuid = self.get_notification_uuid(blocks[1]["text"]["text"])
 
@@ -767,7 +767,7 @@ class SlackIssueAlertNotificationTest(SlackActivityNotificationTest, Performance
         data = parse_qs(responses.calls[0].request.body)
         assert data["channel"] == ["CXXXXXXX2"]
         assert "blocks" in data
-        blocks = json.loads(data["blocks"][0])
+        blocks = orjson.loads(data["blocks"][0])
         assert "Hello world" in blocks[1]["text"]["text"]
         title_link = blocks[1]["text"]["text"][13:][1:-1]
         notification_uuid = self.get_notification_uuid(title_link)
@@ -872,7 +872,7 @@ class SlackIssueAlertNotificationTest(SlackActivityNotificationTest, Performance
 
         assert data["channel"] == ["UXXXXXXX1"]
         assert "blocks" in data
-        blocks = json.loads(data["blocks"][0])
+        blocks = orjson.loads(data["blocks"][0])
         assert "Hello world" in blocks[1]["text"]["text"]
         title_link = blocks[1]["text"]["text"]
         notification_uuid = self.get_notification_uuid(title_link)
@@ -884,7 +884,7 @@ class SlackIssueAlertNotificationTest(SlackActivityNotificationTest, Performance
         # check that user2 got a notification as well
         assert data2["channel"] == ["UXXXXXXX2"]
         assert "blocks" in data2
-        blocks = json.loads(data2["blocks"][0])
+        blocks = orjson.loads(data2["blocks"][0])
         assert "Hello world" in blocks[1]["text"]["text"]
         assert (
             blocks[-2]["elements"][0]["text"]

--- a/tests/sentry/integrations/slack/notifications/test_nudge.py
+++ b/tests/sentry/integrations/slack/notifications/test_nudge.py
@@ -1,5 +1,6 @@
 from urllib.parse import parse_qs
 
+import orjson
 import responses
 
 from sentry.notifications.notifications.integration_nudge import (
@@ -9,7 +10,6 @@ from sentry.notifications.notifications.integration_nudge import (
 from sentry.testutils.cases import SlackActivityNotificationTest
 from sentry.testutils.helpers.slack import get_blocks_and_fallback_text
 from sentry.types.integrations import ExternalProviders
-from sentry.utils import json
 
 SEED = 0
 
@@ -37,4 +37,4 @@ class SlackNudgeNotificationTest(SlackActivityNotificationTest):
 
         # Slack requires callback_id to handle enablement
         request_data = parse_qs(responses.calls[0].request.body)
-        assert json.loads(request_data["callback_id"][0]) == {"enable_notifications": True}
+        assert orjson.loads(request_data["callback_id"][0]) == {"enable_notifications": True}

--- a/tests/sentry/integrations/slack/test_disable.py
+++ b/tests/sentry/integrations/slack/test_disable.py
@@ -1,6 +1,7 @@
 import time
 from datetime import datetime, timedelta
 
+import orjson
 import pytest
 import responses
 from django.core import mail
@@ -19,7 +20,6 @@ from sentry.testutils.helpers.datetime import freeze_time
 from sentry.testutils.outbox import outbox_runner
 from sentry.testutils.silo import assume_test_silo_mode
 from sentry.testutils.skips import requires_snuba
-from sentry.utils import json
 
 pytestmark = [requires_snuba]
 
@@ -59,7 +59,7 @@ class SlackClientDisable(TestCase):
             url="https://slack.com/api/chat.postMessage",
             status=200,
             content_type="application/json",
-            body=json.dumps(bodydict),
+            body=orjson.dumps(bodydict),
         )
         client = SlackClient(integration_id=self.integration.id)
 
@@ -108,14 +108,14 @@ class SlackClientDisable(TestCase):
             url="https://slack.com/api/chat.postMessage",
             status=404,
             content_type="application/json",
-            body=json.dumps(bodydict),
+            body=orjson.dumps(bodydict),
         )
         self.resp.add(
             method=responses.POST,
             url="https://slack.com/api/chat.postMessage",
             status=404,
             content_type="application/json",
-            body=json.dumps(bodydict),
+            body=orjson.dumps(bodydict),
         )
         client = SlackClient(integration_id=self.integration.id)
         with pytest.raises(ApiError):
@@ -138,7 +138,7 @@ class SlackClientDisable(TestCase):
             url="https://slack.com/api/chat.postMessage",
             status=404,
             content_type="application/json",
-            body=json.dumps(bodydict),
+            body=orjson.dumps(bodydict),
         )
         client = SlackClient(integration_id=self.integration.id)
         buffer = IntegrationRequestBuffer(client._get_redis_key())
@@ -166,7 +166,7 @@ class SlackClientDisable(TestCase):
             url="https://slack.com/api/chat.postMessage",
             status=404,
             content_type="application/json",
-            body=json.dumps(bodydict),
+            body=orjson.dumps(bodydict),
         )
         client = SlackClient(integration_id=self.integration.id)
         buffer = IntegrationRequestBuffer(client._get_redis_key())
@@ -191,7 +191,7 @@ class SlackClientDisable(TestCase):
             url="https://slack.com/api/chat.postMessage",
             status=404,
             content_type="application/json",
-            body=json.dumps(bodydict),
+            body=orjson.dumps(bodydict),
         )
         client = SlackClient(integration_id=self.integration.id)
         buffer = IntegrationRequestBuffer(client._get_redis_key())

--- a/tests/sentry/integrations/slack/test_link_team.py
+++ b/tests/sentry/integrations/slack/test_link_team.py
@@ -2,6 +2,7 @@ from collections.abc import Mapping, Sequence
 from typing import Any, Optional
 from urllib.parse import urlencode
 
+import orjson
 import responses
 from django.db.models import QuerySet
 from django.http.response import HttpResponseBase
@@ -19,7 +20,6 @@ from sentry.testutils.helpers import add_identity, get_response_text, install_sl
 from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.silo import assume_test_silo_mode
 from sentry.types.integrations import ExternalProviders
-from sentry.utils import json
 
 
 class SlackIntegrationLinkTeamTestBase(TestCase):
@@ -140,7 +140,7 @@ class SlackIntegrationLinkTeamTest(SlackIntegrationLinkTeamTestBase):
         assert external_actors[0].team_id == self.team.id
 
         assert len(responses.calls) >= 1
-        data = json.loads(str(responses.calls[0].request.body.decode("utf-8")))
+        data = orjson.loads(responses.calls[0].request.body)
         assert (
             f"The {self.team.slug} team will now receive issue alert notifications in the {external_actors[0].external_name} channel."
             in get_response_text(data)
@@ -173,7 +173,7 @@ class SlackIntegrationLinkTeamTest(SlackIntegrationLinkTeamTestBase):
         response = self.get_success_response(data={"team": self.team.id})
         self.assertTemplateUsed(response, "sentry/integrations/slack/post-linked-team.html")
         assert len(responses.calls) >= 1
-        data = json.loads(str(responses.calls[0].request.body.decode("utf-8")))
+        data = orjson.loads(responses.calls[0].request.body)
         assert (
             f"The {self.team.slug} team has already been linked to a Slack channel."
             in get_response_text(data)
@@ -213,7 +213,7 @@ class SlackIntegrationLinkTeamTest(SlackIntegrationLinkTeamTestBase):
         external_actors = self.get_linked_teams()
 
         assert len(responses.calls) >= 1
-        data = json.loads(str(responses.calls[0].request.body.decode("utf-8")))
+        data = orjson.loads(responses.calls[0].request.body)
         assert (
             f"The {self.team.slug} team will now receive issue alert and workflow notifications in the {external_actors[0].external_name} channel."
             in get_response_text(data)
@@ -234,7 +234,7 @@ class SlackIntegrationLinkTeamTest(SlackIntegrationLinkTeamTestBase):
         assert external_actors[0].team_id == self.team.id
 
         assert len(responses.calls) >= 1
-        data = json.loads(str(responses.calls[0].request.body.decode("utf-8")))
+        data = orjson.loads(responses.calls[0].request.body)
         assert (
             f"The {self.team.slug} team will now receive issue alert and workflow notifications in the {external_actors[0].external_name} channel."
             in get_response_text(data)
@@ -276,7 +276,7 @@ class SlackIntegrationUnlinkTeamTest(SlackIntegrationLinkTeamTestBase):
         assert len(external_actors) == 0
 
         assert len(responses.calls) >= 1
-        data = json.loads(str(responses.calls[0].request.body.decode("utf-8")))
+        data = orjson.loads(responses.calls[0].request.body)
         assert (
             f"This channel will no longer receive issue alert notifications for the {self.team.slug} team."
             in get_response_text(data)
@@ -317,7 +317,7 @@ class SlackIntegrationUnlinkTeamTest(SlackIntegrationLinkTeamTestBase):
         assert len(external_actors) == 0
 
         assert len(responses.calls) >= 1
-        data = json.loads(str(responses.calls[0].request.body.decode("utf-8")))
+        data = orjson.loads(responses.calls[0].request.body)
         assert (
             f"This channel will no longer receive issue alert notifications for the {self.team.slug} team."
             in get_response_text(data)

--- a/tests/sentry/integrations/slack/test_notifications.py
+++ b/tests/sentry/integrations/slack/test_notifications.py
@@ -1,6 +1,7 @@
 from unittest import mock
 from urllib.parse import parse_qs
 
+import orjson
 import responses
 
 from sentry.integrations.slack.notifications import send_notification_as_slack
@@ -8,7 +9,6 @@ from sentry.notifications.additional_attachment_manager import manager
 from sentry.testutils.cases import SlackActivityNotificationTest
 from sentry.testutils.helpers.notifications import DummyNotification
 from sentry.types.integrations import ExternalProviders
-from sentry.utils import json
 
 
 def additional_attachment_generator_block_kit(integration, organization):
@@ -40,7 +40,7 @@ class SlackNotificationsTest(SlackActivityNotificationTest):
             assert "text" in data
             assert data["text"][0] == "Notification Title"
 
-            blocks = json.loads(data["blocks"][0])
+            blocks = orjson.loads(data["blocks"][0])
             assert len(blocks) == 5
 
             assert blocks[0]["text"]["text"] == "Notification Title"
@@ -77,7 +77,7 @@ class SlackNotificationsTest(SlackActivityNotificationTest):
         assert "text" in data
         assert data["text"][0] == "Notification Title"
 
-        blocks = json.loads(data["blocks"][0])
+        blocks = orjson.loads(data["blocks"][0])
         assert len(blocks) == 3
 
         assert blocks[0]["text"]["text"] == "Notification Title"

--- a/tests/sentry/integrations/slack/test_notify_action.py
+++ b/tests/sentry/integrations/slack/test_notify_action.py
@@ -1,6 +1,7 @@
 from unittest import mock
 from urllib.parse import parse_qs
 
+import orjson
 import responses
 
 from sentry.constants import ObjectStatus
@@ -12,7 +13,6 @@ from sentry.testutils.cases import RuleTestCase
 from sentry.testutils.silo import assume_test_silo_mode
 from sentry.testutils.skips import requires_snuba
 from sentry.types.integrations import ExternalProviders
-from sentry.utils import json
 from tests.sentry.integrations.slack.test_notifications import (
     additional_attachment_generator_block_kit,
 )
@@ -65,7 +65,7 @@ class SlackNotifyActionTest(RuleTestCase):
         data = parse_qs(responses.calls[0].request.body)
 
         assert "blocks" in data
-        blocks = json.loads(data["blocks"][0])
+        blocks = orjson.loads(data["blocks"][0])
 
         assert event.title in blocks[0]["text"]["text"]
 
@@ -127,7 +127,7 @@ class SlackNotifyActionTest(RuleTestCase):
             url="https://slack.com/api/chat.scheduleMessage",
             status=200,
             content_type="application/json",
-            body=json.dumps(
+            body=orjson.dumps(
                 {"ok": "true", "channel": "chan-id", "scheduled_message_id": "Q1298393284"}
             ),
         )
@@ -136,7 +136,7 @@ class SlackNotifyActionTest(RuleTestCase):
             url="https://slack.com/api/chat.deleteScheduledMessage",
             status=200,
             content_type="application/json",
-            body=json.dumps({"ok": True}),
+            body=orjson.dumps({"ok": True}),
         )
 
         form = rule.get_form_instance()
@@ -154,7 +154,7 @@ class SlackNotifyActionTest(RuleTestCase):
             url="https://slack.com/api/chat.scheduleMessage",
             status=200,
             content_type="application/json",
-            body=json.dumps({"ok": False, "error": "channel_not_found"}),
+            body=orjson.dumps({"ok": False, "error": "channel_not_found"}),
         )
 
         members = {
@@ -170,7 +170,7 @@ class SlackNotifyActionTest(RuleTestCase):
             url="https://slack.com/api/users.list",
             status=200,
             content_type="application/json",
-            body=json.dumps(members),
+            body=orjson.dumps(members),
         )
 
         form = rule.get_form_instance()
@@ -187,7 +187,7 @@ class SlackNotifyActionTest(RuleTestCase):
             url="https://slack.com/api/chat.scheduleMessage",
             status=200,
             content_type="application/json",
-            body=json.dumps({"ok": False, "error": "channel_not_found"}),
+            body=orjson.dumps({"ok": False, "error": "channel_not_found"}),
         )
 
         members = {"ok": "true", "members": [{"name": "other-member", "id": "member-id"}]}
@@ -197,7 +197,7 @@ class SlackNotifyActionTest(RuleTestCase):
             url="https://slack.com/api/users.list",
             status=200,
             content_type="application/json",
-            body=json.dumps(members),
+            body=orjson.dumps(members),
         )
 
         form = rule.get_form_instance()
@@ -213,7 +213,7 @@ class SlackNotifyActionTest(RuleTestCase):
             url="https://slack.com/api/chat.scheduleMessage",
             status=200,
             content_type="application/json",
-            body=json.dumps({"ok": False, "error": "channel_not_found"}),
+            body=orjson.dumps({"ok": False, "error": "channel_not_found"}),
         )
 
         responses.add(
@@ -221,7 +221,7 @@ class SlackNotifyActionTest(RuleTestCase):
             url="https://slack.com/api/users.list",
             status=429,
             content_type="application/json",
-            body=json.dumps({"ok": False, "error": "ratelimited"}),
+            body=orjson.dumps({"ok": False, "error": "ratelimited"}),
         )
         rule = self.get_rule(
             data={
@@ -243,7 +243,7 @@ class SlackNotifyActionTest(RuleTestCase):
             url="https://slack.com/api/conversations.info",
             status=200,
             content_type="application/json",
-            body=json.dumps({"ok": "true", "channel": {"name": "my-channel", "id": "C2349874"}}),
+            body=orjson.dumps({"ok": "true", "channel": {"name": "my-channel", "id": "C2349874"}}),
         )
         rule = self.get_rule(
             data={
@@ -264,7 +264,7 @@ class SlackNotifyActionTest(RuleTestCase):
             url="https://slack.com/api/conversations.info",
             status=200,
             content_type="application/json",
-            body=json.dumps({"ok": False, "error": "channel_not_found"}),
+            body=orjson.dumps({"ok": False, "error": "channel_not_found"}),
         )
         rule = self.get_rule(
             data={
@@ -286,7 +286,7 @@ class SlackNotifyActionTest(RuleTestCase):
             url="https://slack.com/api/conversations.info",
             status=200,
             content_type="application/json",
-            body=json.dumps({"ok": "true", "channel": {"name": "my-channel", "id": "C2349874"}}),
+            body=orjson.dumps({"ok": "true", "channel": {"name": "my-channel", "id": "C2349874"}}),
         )
         rule = self.get_rule(
             data={
@@ -324,7 +324,7 @@ class SlackNotifyActionTest(RuleTestCase):
             url="https://slack.com/api/chat.scheduleMessage",
             status=200,
             content_type="application/json",
-            body=json.dumps({"ok": False, "error": "channel_not_found"}),
+            body=orjson.dumps({"ok": False, "error": "channel_not_found"}),
         )
 
         members = {
@@ -340,7 +340,7 @@ class SlackNotifyActionTest(RuleTestCase):
             url="https://slack.com/api/users.list",
             status=200,
             content_type="application/json",
-            body=json.dumps(members),
+            body=orjson.dumps(members),
         )
 
         form = rule.get_form_instance()
@@ -397,7 +397,7 @@ class SlackNotifyActionTest(RuleTestCase):
             data = parse_qs(responses.calls[0].request.body)
 
             assert "blocks" in data
-            blocks = json.loads(data["blocks"][0])
+            blocks = orjson.loads(data["blocks"][0])
 
             assert event.title in blocks[0]["text"]["text"]
             assert blocks[-2]["text"]["text"] == self.organization.slug

--- a/tests/sentry/integrations/slack/test_tasks.py
+++ b/tests/sentry/integrations/slack/test_tasks.py
@@ -2,6 +2,7 @@ from unittest.mock import patch
 from urllib.parse import parse_qs
 from uuid import uuid4
 
+import orjson
 import pytest
 import responses
 
@@ -18,7 +19,6 @@ from sentry.tasks.integrations.slack import (
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers import install_slack
 from sentry.testutils.skips import requires_snuba
-from sentry.utils import json
 
 pytestmark = [requires_snuba]
 
@@ -35,7 +35,7 @@ class SlackTasksTest(TestCase):
             url="https://slack.com/api/chat.scheduleMessage",
             status=200,
             content_type="application/json",
-            body=json.dumps(
+            body=orjson.dumps(
                 {"ok": "true", "channel": "chan-id", "scheduled_message_id": "Q1298393284"}
             ),
         )
@@ -44,7 +44,7 @@ class SlackTasksTest(TestCase):
             url="https://slack.com/api/chat.deleteScheduledMessage",
             status=200,
             content_type="application/json",
-            body=json.dumps({"ok": True}),
+            body=orjson.dumps({"ok": True}),
         )
         with responses.mock:
             yield

--- a/tests/sentry/integrations/slack/test_utils.py
+++ b/tests/sentry/integrations/slack/test_utils.py
@@ -1,3 +1,4 @@
+import orjson
 import pytest
 import responses
 
@@ -7,7 +8,6 @@ from sentry.shared_integrations.exceptions import ApiRateLimitedError, Duplicate
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers import install_slack
 from sentry.testutils.skips import requires_snuba
-from sentry.utils import json
 
 pytestmark = [requires_snuba]
 
@@ -29,7 +29,7 @@ class GetChannelIdTest(TestCase):
             url="https://slack.com/api/%s.list" % list_type,
             status=200,
             content_type="application/json",
-            body=json.dumps({"ok": "true", result_name: channels}),
+            body=orjson.dumps({"ok": "true", result_name: channels}),
         )
 
     def add_msg_response(self, channel_id, result_name="channel"):
@@ -43,7 +43,7 @@ class GetChannelIdTest(TestCase):
             url="https://slack.com/api/chat.scheduleMessage",
             status=200,
             content_type="application/json",
-            body=json.dumps(bodydict),
+            body=orjson.dumps(bodydict),
         )
 
     def run_valid_test(self, channel, expected_prefix, expected_id, timed_out):
@@ -58,7 +58,7 @@ class GetChannelIdTest(TestCase):
             url="https://slack.com/api/chat.deleteScheduledMessage",
             status=200,
             content_type="application/json",
-            body=json.dumps({"ok": True}),
+            body=orjson.dumps({"ok": True}),
         )
         self.run_valid_test("#My-Channel", CHANNEL_PREFIX, "m-c", False)
 
@@ -69,7 +69,7 @@ class GetChannelIdTest(TestCase):
             url="https://slack.com/api/chat.deleteScheduledMessage",
             status=200,
             content_type="application/json",
-            body=json.dumps({"ok": True}),
+            body=orjson.dumps({"ok": True}),
         )
         self.run_valid_test("#my-private-channel", CHANNEL_PREFIX, "m-p-c", False)
 
@@ -126,7 +126,7 @@ class GetChannelIdTest(TestCase):
             url="https://slack.com/api/users.list",
             status=429,
             content_type="application/json",
-            body=json.dumps({"ok": False, "error": "ratelimited"}),
+            body=orjson.dumps({"ok": False, "error": "ratelimited"}),
         )
         with pytest.raises(ApiRateLimitedError):
             get_channel_id(self.organization, self.integration, "@user")

--- a/tests/sentry/integrations/slack/webhooks/actions/__init__.py
+++ b/tests/sentry/integrations/slack/webhooks/actions/__init__.py
@@ -1,8 +1,9 @@
 from unittest.mock import patch
 
+import orjson
+
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.helpers import add_identity, install_slack
-from sentry.utils import json
 
 
 class BaseEventTest(APITestCase):
@@ -39,7 +40,7 @@ class BaseEventTest(APITestCase):
             slack_user = {"id": self.external_id, "domain": "example"}
 
         if callback_id is None:
-            callback_id = json.dumps({"issue": self.group.id, "rule": self.rule.id})
+            callback_id = orjson.dumps({"issue": self.group.id, "rule": self.rule.id}).decode()
 
         if original_message is None:
             original_message = {}
@@ -61,7 +62,7 @@ class BaseEventTest(APITestCase):
         if data:
             payload.update(data)
 
-        payload = {"payload": json.dumps(payload)}
+        payload = {"payload": orjson.dumps(payload).decode()}
 
         return self.client.post("/extensions/slack/action/", data=payload)
 
@@ -222,5 +223,5 @@ class BaseEventTest(APITestCase):
         if data:
             payload.update(data)
 
-        payload = {"payload": json.dumps(payload)}
+        payload = {"payload": orjson.dumps(payload).decode()}
         return self.client.post("/extensions/slack/action/", data=payload)

--- a/tests/sentry/integrations/slack/webhooks/actions/test_enable_notifications.py
+++ b/tests/sentry/integrations/slack/webhooks/actions/test_enable_notifications.py
@@ -1,3 +1,5 @@
+import orjson
+
 from sentry.integrations.slack.webhooks.action import (
     ENABLE_SLACK_SUCCESS_MESSAGE,
     NO_IDENTITY_MESSAGE,
@@ -6,7 +8,6 @@ from sentry.models.identity import Identity
 from sentry.models.notificationsettingprovider import NotificationSettingProvider
 from sentry.silo.base import SiloMode
 from sentry.testutils.silo import assume_test_silo_mode
-from sentry.utils import json
 
 from . import BaseEventTest
 
@@ -103,7 +104,7 @@ class EnableNotificationsActionTest(BaseEventTest):
             response = self.post_webhook_block_kit(
                 action_data=[{"name": "enable_notifications", "value": "all_slack"}],
                 original_message=original_message,
-                data={"callback_id": json.dumps({"enable_notifications": True})},
+                data={"callback_id": orjson.dumps({"enable_notifications": True}).decode()},
             )
         self.user.refresh_from_db()  # Reload to fetch actor
         assert response.status_code == 200, response.content

--- a/tests/sentry/integrations/slack/webhooks/commands/__init__.py
+++ b/tests/sentry/integrations/slack/webhooks/commands/__init__.py
@@ -4,6 +4,7 @@ from collections.abc import Mapping
 from typing import Any
 from urllib.parse import urlencode
 
+import orjson
 from django.http.response import HttpResponse
 from django.urls import reverse
 from rest_framework import status
@@ -17,7 +18,6 @@ from sentry.testutils.cases import APITestCase, TestCase
 from sentry.testutils.helpers import find_identity, install_slack, link_team, link_user
 from sentry.testutils.silo import assume_test_silo_mode
 from sentry.types.integrations import EXTERNAL_PROVIDERS, ExternalProviders
-from sentry.utils import json
 
 
 class SlackCommandsTest(APITestCase, TestCase):
@@ -52,7 +52,7 @@ class SlackCommandsTest(APITestCase, TestCase):
                 **kwargs,
             }
         )
-        return json.loads(str(response.content.decode("utf-8")))
+        return orjson.loads(response.content)
 
     def find_identity(self) -> Identity | None:
         return find_identity(idp=self.idp, user=self.user)

--- a/tests/sentry/integrations/slack/webhooks/commands/test_link_team.py
+++ b/tests/sentry/integrations/slack/webhooks/commands/test_link_team.py
@@ -1,3 +1,4 @@
+import orjson
 import responses
 from rest_framework import status
 
@@ -11,7 +12,6 @@ from sentry.integrations.slack.webhooks.command import (
 from sentry.silo.base import SiloMode
 from sentry.testutils.helpers import get_response_text, link_user
 from sentry.testutils.silo import assume_test_silo_mode
-from sentry.utils import json
 from tests.sentry.integrations.slack.webhooks.commands import SlackCommandsTest
 
 OTHER_SLACK_ID = "UXXXXXXX2"
@@ -56,7 +56,7 @@ class SlackCommandsLinkTeamTest(SlackCommandsLinkTeamTestBase):
                 "channel_id": self.channel_id,
             }
         )
-        data = json.loads(str(response.content.decode("utf-8")))
+        data = orjson.loads(response.content)
         assert CHANNEL_ALREADY_LINKED_MESSAGE in get_response_text(data)
 
     @responses.activate
@@ -73,7 +73,7 @@ class SlackCommandsLinkTeamTest(SlackCommandsLinkTeamTestBase):
                 "channel_name": "directmessage",
             }
         )
-        data = json.loads(str(response.content.decode("utf-8")))
+        data = orjson.loads(response.content)
         assert LINK_FROM_CHANNEL_MESSAGE in get_response_text(data)
 
     @responses.activate

--- a/tests/sentry/integrations/slack/webhooks/commands/test_link_user.py
+++ b/tests/sentry/integrations/slack/webhooks/commands/test_link_user.py
@@ -1,3 +1,4 @@
+import orjson
 import responses
 
 from sentry.integrations.slack.views.link_identity import SUCCESS_LINKED_MESSAGE, build_linking_url
@@ -8,7 +9,6 @@ from sentry.integrations.slack.views.unlink_identity import (
 from sentry.integrations.slack.webhooks.base import NOT_LINKED_MESSAGE
 from sentry.testutils.helpers import get_response_text
 from sentry.testutils.silo import control_silo_test
-from sentry.utils import json
 from tests.sentry.integrations.slack.webhooks.commands import SlackCommandsTest
 
 
@@ -26,7 +26,7 @@ class SlackLinkIdentityViewTest(SlackCommandsTest):
         assert response.status_code == 200
 
         assert len(responses.calls) >= 1
-        data = json.loads(str(responses.calls[0].request.body.decode("utf-8")))
+        data = orjson.loads(responses.calls[0].request.body)
         assert SUCCESS_LINKED_MESSAGE in get_response_text(data)
 
 
@@ -63,7 +63,7 @@ class SlackUnlinkIdentityViewTest(SlackCommandsTest):
         assert response.status_code == 200
 
         assert len(responses.calls) >= 1
-        data = json.loads(str(responses.calls[0].request.body.decode("utf-8")))
+        data = orjson.loads(responses.calls[0].request.body)
         assert SUCCESS_UNLINKED_MESSAGE in get_response_text(data)
 
 

--- a/tests/sentry/integrations/slack/webhooks/events/__init__.py
+++ b/tests/sentry/integrations/slack/webhooks/events/__init__.py
@@ -1,8 +1,9 @@
 from unittest.mock import patch
 
+import orjson
+
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.helpers import install_slack
-from sentry.utils import json
 
 UNSET = object()
 
@@ -39,7 +40,7 @@ def build_test_block(link):
                     "type": "mrkdwn",
                     "text": f"<{link}/1|*wow an issue very cool*> \n",
                 },
-                "block_id": json.dumps({"issue": 1}),
+                "block_id": orjson.dumps({"issue": 1}).decode(),
             }
         ],
         "text": "[foo] wow an issue very cool",

--- a/tests/sentry/integrations/slack/webhooks/events/test_discover_link_shared.py
+++ b/tests/sentry/integrations/slack/webhooks/events/test_discover_link_shared.py
@@ -2,13 +2,13 @@ import re
 from unittest.mock import Mock, patch
 from urllib.parse import parse_qsl
 
+import orjson
 import responses
 
 from sentry.integrations.slack.unfurl import Handler, LinkType, make_type_coercer
 from sentry.models.identity import Identity, IdentityStatus
 from sentry.silo.base import SiloMode
 from sentry.testutils.silo import assume_test_silo_mode
-from sentry.utils import json
 
 from . import LINK_SHARED_EVENT, BaseEventTest
 
@@ -62,7 +62,7 @@ class DiscoverLinkSharedEvent(BaseEventTest):
         responses.add(responses.POST, "https://slack.com/api/chat.postEphemeral", json={"ok": True})
         responses.add(responses.POST, "https://slack.com/api/chat.unfurl", json={"ok": True})
 
-        resp = self.post_webhook(event_data=json.loads(LINK_SHARED_EVENT))
+        resp = self.post_webhook(event_data=orjson.loads(LINK_SHARED_EVENT))
         assert resp.status_code == 200, resp.content
 
         data = responses.calls[0].request.body
@@ -74,7 +74,7 @@ class DiscoverLinkSharedEvent(BaseEventTest):
         with self.feature("organizations:discover-basic"):
             data = self.share_discover_links()
 
-        blocks = json.loads(data["blocks"])
+        blocks = orjson.loads(data["blocks"])
 
         assert blocks[0]["type"] == "section"
         assert (
@@ -96,7 +96,7 @@ class DiscoverLinkSharedEvent(BaseEventTest):
             )
             responses.add(responses.POST, "https://slack.com/api/chat.unfurl", json={"ok": True})
 
-            resp = self.post_webhook(event_data=json.loads(LINK_SHARED_EVENT_NO_CHANNEL_NAME))
+            resp = self.post_webhook(event_data=orjson.loads(LINK_SHARED_EVENT_NO_CHANNEL_NAME))
             assert resp.status_code == 200, resp.content
             assert len(responses.calls) == 0
 
@@ -112,7 +112,7 @@ class DiscoverLinkSharedEvent(BaseEventTest):
             )
         data = self.share_discover_links()
 
-        unfurls = json.loads(data["unfurls"])
+        unfurls = orjson.loads(data["unfurls"])
 
         # We only have two unfurls since one link was duplicated
         assert len(unfurls) == 2

--- a/tests/sentry/integrations/slack/webhooks/events/test_link_shared.py
+++ b/tests/sentry/integrations/slack/webhooks/events/test_link_shared.py
@@ -2,11 +2,11 @@ import re
 from unittest.mock import Mock, patch
 from urllib.parse import parse_qsl
 
+import orjson
 import responses
 
 from sentry.integrations.slack.unfurl import Handler, make_type_coercer
 from sentry.testutils.helpers.features import with_feature
-from sentry.utils import json
 
 from . import LINK_SHARED_EVENT, BaseEventTest, build_test_block
 
@@ -36,12 +36,12 @@ class LinkSharedEventTest(BaseEventTest):
     def test_share_links(self, mock_match_link):
         responses.add(responses.POST, "https://slack.com/api/chat.unfurl", json={"ok": True})
 
-        resp = self.post_webhook(event_data=json.loads(LINK_SHARED_EVENT))
+        resp = self.post_webhook(event_data=orjson.loads(LINK_SHARED_EVENT))
         assert resp.status_code == 200, resp.content
         assert len(mock_match_link.mock_calls) == 3
 
         data = dict(parse_qsl(responses.calls[0].request.body))
-        unfurls = json.loads(data["unfurls"])
+        unfurls = orjson.loads(data["unfurls"])
 
         # We only have two unfurls since one link was duplicated
         assert len(unfurls) == 2
@@ -78,12 +78,12 @@ class LinkSharedEventTest(BaseEventTest):
     def test_share_links_block_kit(self, mock_match_link):
         responses.add(responses.POST, "https://slack.com/api/chat.unfurl", json={"ok": True})
 
-        resp = self.post_webhook(event_data=json.loads(LINK_SHARED_EVENT))
+        resp = self.post_webhook(event_data=orjson.loads(LINK_SHARED_EVENT))
         assert resp.status_code == 200, resp.content
         assert len(mock_match_link.mock_calls) == 3
 
         data = dict(parse_qsl(responses.calls[0].request.body))
-        unfurls = json.loads(data["unfurls"])
+        unfurls = orjson.loads(data["unfurls"])
 
         # We only have two unfurls since one link was duplicated
         assert len(unfurls) == 2

--- a/tests/sentry/integrations/slack/webhooks/events/test_message_im.py
+++ b/tests/sentry/integrations/slack/webhooks/events/test_message_im.py
@@ -1,3 +1,4 @@
+import orjson
 import responses
 
 from sentry.models.identity import Identity, IdentityStatus
@@ -5,7 +6,6 @@ from sentry.silo.base import SiloMode
 from sentry.testutils.cases import IntegratedApiTestCase
 from sentry.testutils.helpers import get_response_text
 from sentry.testutils.silo import assume_test_silo_mode
-from sentry.utils import json
 
 from . import BaseEventTest
 
@@ -58,22 +58,22 @@ class MessageIMEventTest(BaseEventTest, IntegratedApiTestCase):
     @responses.activate
     def test_identifying_channel_correctly(self):
         responses.add(responses.POST, "https://slack.com/api/chat.postMessage", json={"ok": True})
-        event_data = json.loads(MESSAGE_IM_EVENT)
+        event_data = orjson.loads(MESSAGE_IM_EVENT)
         self.post_webhook(event_data=event_data)
         request = responses.calls[0].request
-        data = json.loads(request.body)
+        data = orjson.loads(request.body)
         assert data.get("channel") == event_data["channel"]
 
     @responses.activate
     def test_user_message_im_notification_platform(self):
         responses.add(responses.POST, "https://slack.com/api/chat.postMessage", json={"ok": True})
-        resp = self.post_webhook(event_data=json.loads(MESSAGE_IM_EVENT))
+        resp = self.post_webhook(event_data=orjson.loads(MESSAGE_IM_EVENT))
         assert resp.status_code == 200, resp.content
 
         assert len(responses.calls) == 1
         request = responses.calls[0].request
         assert request.headers["Authorization"] == "Bearer xoxb-xxxxxxxxx-xxxxxxxxxx-xxxxxxxxxxxx"
-        data = json.loads(request.body)
+        data = orjson.loads(request.body)
         heading, contents = self.get_block_section_text(data)
         assert heading == "Unknown command: `helloo`"
         assert (
@@ -90,13 +90,13 @@ class MessageIMEventTest(BaseEventTest, IntegratedApiTestCase):
             self.create_identity_provider(type="slack", external_id="TXXXXXXX1")
 
         responses.add(responses.POST, "https://slack.com/api/chat.postMessage", json={"ok": True})
-        resp = self.post_webhook(event_data=json.loads(MESSAGE_IM_EVENT_LINK))
+        resp = self.post_webhook(event_data=orjson.loads(MESSAGE_IM_EVENT_LINK))
         assert resp.status_code == 200, resp.content
 
         assert len(responses.calls) == 1
         request = responses.calls[0].request
         assert request.headers["Authorization"] == "Bearer xoxb-xxxxxxxxx-xxxxxxxxxx-xxxxxxxxxxxx"
-        data = json.loads(request.body)
+        data = orjson.loads(request.body)
         assert "Link your Slack identity" in get_response_text(data)
 
     @responses.activate
@@ -116,13 +116,13 @@ class MessageIMEventTest(BaseEventTest, IntegratedApiTestCase):
             )
 
         responses.add(responses.POST, "https://slack.com/api/chat.postMessage", json={"ok": True})
-        resp = self.post_webhook(event_data=json.loads(MESSAGE_IM_EVENT_LINK))
+        resp = self.post_webhook(event_data=orjson.loads(MESSAGE_IM_EVENT_LINK))
         assert resp.status_code == 200, resp.content
 
         assert len(responses.calls) == 1
         request = responses.calls[0].request
         assert request.headers["Authorization"] == "Bearer xoxb-xxxxxxxxx-xxxxxxxxxx-xxxxxxxxxxxx"
-        data = json.loads(request.body)
+        data = orjson.loads(request.body)
         assert "You are already linked" in get_response_text(data)
 
     @responses.activate
@@ -141,13 +141,13 @@ class MessageIMEventTest(BaseEventTest, IntegratedApiTestCase):
             )
 
         responses.add(responses.POST, "https://slack.com/api/chat.postMessage", json={"ok": True})
-        resp = self.post_webhook(event_data=json.loads(MESSAGE_IM_EVENT_UNLINK))
+        resp = self.post_webhook(event_data=orjson.loads(MESSAGE_IM_EVENT_UNLINK))
         assert resp.status_code == 200, resp.content
 
         assert len(responses.calls) == 1
         request = responses.calls[0].request
         assert request.headers["Authorization"] == "Bearer xoxb-xxxxxxxxx-xxxxxxxxxx-xxxxxxxxxxxx"
-        data = json.loads(request.body)
+        data = orjson.loads(request.body)
         assert "Click here to unlink your identity" in get_response_text(data)
 
     @responses.activate
@@ -160,22 +160,22 @@ class MessageIMEventTest(BaseEventTest, IntegratedApiTestCase):
             self.create_identity_provider(type="slack", external_id="TXXXXXXX1")
 
         responses.add(responses.POST, "https://slack.com/api/chat.postMessage", json={"ok": True})
-        resp = self.post_webhook(event_data=json.loads(MESSAGE_IM_EVENT_UNLINK))
+        resp = self.post_webhook(event_data=orjson.loads(MESSAGE_IM_EVENT_UNLINK))
         assert resp.status_code == 200, resp.content
 
         assert len(responses.calls) == 1
         request = responses.calls[0].request
         assert request.headers["Authorization"] == "Bearer xoxb-xxxxxxxxx-xxxxxxxxxx-xxxxxxxxxxxx"
-        data = json.loads(request.body)
+        data = orjson.loads(request.body)
         assert "You do not have a linked identity to unlink" in get_response_text(data)
 
     def test_bot_message_im(self):
-        resp = self.post_webhook(event_data=json.loads(MESSAGE_IM_BOT_EVENT))
+        resp = self.post_webhook(event_data=orjson.loads(MESSAGE_IM_BOT_EVENT))
         assert resp.status_code == 200, resp.content
 
     @responses.activate
     def test_user_message_im_no_text(self):
         responses.add(responses.POST, "https://slack.com/api/chat.postMessage", json={"ok": True})
-        resp = self.post_webhook(event_data=json.loads(MESSAGE_IM_EVENT_NO_TEXT))
+        resp = self.post_webhook(event_data=orjson.loads(MESSAGE_IM_EVENT_NO_TEXT))
         assert resp.status_code == 200, resp.content
         assert len(responses.calls) == 0

--- a/tests/sentry/integrations/slack/webhooks/options_load/__init__.py
+++ b/tests/sentry/integrations/slack/webhooks/options_load/__init__.py
@@ -1,8 +1,9 @@
 from unittest.mock import patch
 
+import orjson
+
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.helpers.slack import install_slack
-from sentry.utils import json
 
 
 class BaseEventTest(APITestCase):
@@ -41,7 +42,7 @@ class BaseEventTest(APITestCase):
 
         if type == "block_suggestion":
             payload = {
-                "payload": json.dumps(
+                "payload": orjson.dumps(
                     {
                         "type": type,
                         "user": slack_user,
@@ -61,7 +62,7 @@ class BaseEventTest(APITestCase):
                         "channel": self.channel,
                         "message": original_message,
                     }
-                )
+                ).decode()
             }
         if data:
             payload.update(data)

--- a/tests/sentry/integrations/slack/webhooks/options_load/test_dynamic_assignment_dropdown.py
+++ b/tests/sentry/integrations/slack/webhooks/options_load/test_dynamic_assignment_dropdown.py
@@ -1,7 +1,8 @@
+import orjson
+
 from sentry.testutils.helpers.datetime import freeze_time
 from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.skips import requires_snuba
-from sentry.utils import json
 
 from . import BaseEventTest
 
@@ -75,7 +76,9 @@ class DynamicAssignmentDropdownTest(BaseEventTest):
 
         self.project = self.create_project(teams=[self.team1, self.team2, self.team3, self.team4])
         self.group = self.create_group(project=self.project)
-        self.original_message["blocks"][0]["block_id"] = json.dumps({"issue": self.group.id})
+        self.original_message["blocks"][0]["block_id"] = orjson.dumps(
+            {"issue": self.group.id}
+        ).decode()
 
         self.user1 = self.create_user(email="aaa@testing.com", name="Alice")
         self.create_member(organization=self.organization, user=self.user1, teams=[self.team4])
@@ -103,14 +106,16 @@ class DynamicAssignmentDropdownTest(BaseEventTest):
     @with_feature({"organizations:slack-block-kit": False})
     def test_no_flag(self):
         self.group = self.create_group(project=self.project)
-        self.original_message["blocks"][0]["block_id"] = json.dumps({"issue": self.group.id})
+        self.original_message["blocks"][0]["block_id"] = orjson.dumps(
+            {"issue": self.group.id}
+        ).decode()
         resp = self.post_webhook(substring="bbb", original_message=self.original_message)
 
         assert resp.status_code == 400
 
     @with_feature("organizations:slack-block-kit")
     def test_non_existent_group(self):
-        self.original_message["blocks"][0]["block_id"] = json.dumps({"issue": 1})
+        self.original_message["blocks"][0]["block_id"] = orjson.dumps({"issue": 1}).decode()
         resp = self.post_webhook(substring="bbb", original_message=self.original_message)
 
         assert resp.status_code == 400

--- a/tests/sentry/integrations/vercel/test_integration.py
+++ b/tests/sentry/integrations/vercel/test_integration.py
@@ -1,5 +1,6 @@
 from urllib.parse import parse_qs
 
+import orjson
 import pytest
 import responses
 from rest_framework.serializers import ValidationError
@@ -20,7 +21,6 @@ from sentry.models.scheduledeletion import ScheduledDeletion
 from sentry.silo.base import SiloMode
 from sentry.testutils.cases import IntegrationTestCase
 from sentry.testutils.silo import assume_test_silo_mode, control_silo_test
-from sentry.utils import json
 
 
 @control_silo_test
@@ -216,30 +216,30 @@ class VercelIntegrationTest(IntegrationTestCase):
         assert org_integration.config == {"project_mappings": [[project_id, self.project_id]]}
 
         # assert the env vars were created correctly
-        req_params = json.loads(responses.calls[5].request.body)
+        req_params = orjson.loads(responses.calls[5].request.body)
         assert req_params["key"] == "SENTRY_ORG"
         assert req_params["value"] == org.slug
         assert req_params["target"] == ["production", "preview"]
         assert req_params["type"] == "encrypted"
 
-        req_params = json.loads(responses.calls[6].request.body)
+        req_params = orjson.loads(responses.calls[6].request.body)
         assert req_params["key"] == "SENTRY_PROJECT"
         assert req_params["value"] == self.project.slug
         assert req_params["target"] == ["production", "preview"]
         assert req_params["type"] == "encrypted"
 
-        req_params = json.loads(responses.calls[7].request.body)
+        req_params = orjson.loads(responses.calls[7].request.body)
         assert req_params["key"] == "NEXT_PUBLIC_SENTRY_DSN"
         assert req_params["value"] == enabled_dsn
         assert req_params["target"] == ["production", "preview", "development"]
         assert req_params["type"] == "encrypted"
 
-        req_params = json.loads(responses.calls[8].request.body)
+        req_params = orjson.loads(responses.calls[8].request.body)
         assert req_params["key"] == "SENTRY_AUTH_TOKEN"
         assert req_params["target"] == ["production", "preview"]
         assert req_params["type"] == "encrypted"
 
-        req_params = json.loads(responses.calls[9].request.body)
+        req_params = orjson.loads(responses.calls[9].request.body)
         assert req_params["key"] == "VERCEL_GIT_COMMIT_SHA"
         assert req_params["value"] == "VERCEL_GIT_COMMIT_SHA"
         assert req_params["target"] == ["production", "preview"]
@@ -341,30 +341,30 @@ class VercelIntegrationTest(IntegrationTestCase):
         )
         assert org_integration.config == {"project_mappings": [[project_id, self.project_id]]}
 
-        req_params = json.loads(responses.calls[5].request.body)
+        req_params = orjson.loads(responses.calls[5].request.body)
         assert req_params["key"] == "SENTRY_ORG"
         assert req_params["value"] == org.slug
         assert req_params["target"] == ["production", "preview"]
         assert req_params["type"] == "encrypted"
 
-        req_params = json.loads(responses.calls[8].request.body)
+        req_params = orjson.loads(responses.calls[8].request.body)
         assert req_params["key"] == "SENTRY_PROJECT"
         assert req_params["value"] == self.project.slug
         assert req_params["target"] == ["production", "preview"]
         assert req_params["type"] == "encrypted"
 
-        req_params = json.loads(responses.calls[11].request.body)
+        req_params = orjson.loads(responses.calls[11].request.body)
         assert req_params["key"] == "SENTRY_DSN"
         assert req_params["value"] == enabled_dsn
         assert req_params["target"] == ["production", "preview", "development"]
         assert req_params["type"] == "encrypted"
 
-        req_params = json.loads(responses.calls[14].request.body)
+        req_params = orjson.loads(responses.calls[14].request.body)
         assert req_params["key"] == "SENTRY_AUTH_TOKEN"
         assert req_params["target"] == ["production", "preview"]
         assert req_params["type"] == "encrypted"
 
-        req_params = json.loads(responses.calls[17].request.body)
+        req_params = orjson.loads(responses.calls[17].request.body)
         assert req_params["key"] == "VERCEL_GIT_COMMIT_SHA"
         assert req_params["value"] == "VERCEL_GIT_COMMIT_SHA"
         assert req_params["target"] == ["production", "preview"]

--- a/tests/sentry/integrations/vercel/test_webhook.py
+++ b/tests/sentry/integrations/vercel/test_webhook.py
@@ -1,6 +1,7 @@
 import hashlib
 import hmac
 
+import orjson
 import responses
 from rest_framework.response import Response
 
@@ -17,7 +18,6 @@ from sentry.silo.base import SiloMode
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.helpers import override_options
 from sentry.testutils.silo import assume_test_silo_mode, control_silo_test
-from sentry.utils import json
 from sentry.utils.http import absolute_uri
 
 
@@ -111,8 +111,8 @@ class VercelReleasesTest(APITestCase):
 
             assert len(responses.calls) == 2
             release_request = responses.calls[0].request
-            release_body = json.loads(release_request.body)
-            set_refs_body = json.loads(responses.calls[1].request.body)
+            release_body = orjson.loads(release_request.body)
+            set_refs_body = orjson.loads(responses.calls[1].request.body)
             assert release_body == {
                 "projects": [self.project.slug],
                 "version": "7488658dfcf24d9b735e015992b316e2a8340d93",
@@ -231,9 +231,9 @@ class VercelReleasesTest(APITestCase):
     @responses.activate
     def test_set_refs_failed(self):
         def request_callback(request):
-            payload = json.loads(request.body)
+            payload = orjson.loads(request.body)
             status_code = 400 if payload.get("refs") else 200
-            return (status_code, {}, json.dumps({}))
+            return status_code, {}, orjson.dumps({}).decode()
 
         responses.add_callback(
             responses.POST,

--- a/tests/sentry/integrations/vsts/test_client.py
+++ b/tests/sentry/integrations/vsts/test_client.py
@@ -3,6 +3,7 @@ from unittest import mock
 from unittest.mock import call
 from urllib.parse import parse_qs, quote_plus
 
+import orjson
 import pytest
 import responses
 from django.test import override_settings
@@ -18,7 +19,6 @@ from sentry.shared_integrations.exceptions import ApiError
 from sentry.silo.base import SiloMode
 from sentry.silo.util import PROXY_BASE_PATH, PROXY_OI_HEADER, PROXY_PATH, PROXY_SIGNATURE_HEADER
 from sentry.testutils.silo import assume_test_silo_mode, control_silo_test
-from sentry.utils import json
 
 
 @control_silo_test
@@ -112,7 +112,7 @@ class VstsApiClientTest(VstsIntegrationTestCase):
             else:
                 projects = [self.project_a, self.project_b] * 50
             resp_body = {"value": projects, "count": len(projects)}
-            return (200, {}, json.dumps(resp_body))
+            return 200, {}, orjson.dumps(resp_body).decode()
 
         self.assert_installation()
         responses.reset()

--- a/tests/sentry/integrations/vsts/test_issues.py
+++ b/tests/sentry/integrations/vsts/test_issues.py
@@ -5,6 +5,7 @@ from time import time
 from typing import Any
 from unittest.mock import patch
 
+import orjson
 import pytest
 import responses
 from django.test import RequestFactory, override_settings
@@ -30,7 +31,6 @@ from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.datetime import before_now, iso_format
 from sentry.testutils.silo import assume_test_silo_mode, region_silo_test
 from sentry.testutils.skips import requires_snuba
-from sentry.utils import json
 
 pytestmark = [requires_snuba]
 
@@ -189,7 +189,7 @@ class VstsIssueSyncTest(VstsIssueBase):
         }
         request = responses.calls[-1].request
         assert request.headers["Content-Type"] == "application/json-patch+json"
-        payload = json.loads(request.body)
+        payload = orjson.loads(request.body)
         assert payload == [
             {"op": "add", "path": "/fields/System.Title", "value": "Hello"},
             # Adds both a comment and a description.
@@ -256,7 +256,7 @@ class VstsIssueSyncTest(VstsIssueBase):
             ],
         )
 
-        request_body = json.loads(responses.calls[1].request.body)
+        request_body = orjson.loads(responses.calls[1].request.body)
         assert len(request_body) == 1
         assert request_body[0]["path"] == "/fields/System.AssignedTo"
         assert request_body[0]["value"] == "ftotten@vscsi.us"
@@ -319,7 +319,7 @@ class VstsIssueSyncTest(VstsIssueBase):
             ],
         )
 
-        request_body = json.loads(responses.calls[2].request.body)
+        request_body = orjson.loads(responses.calls[2].request.body)
         assert len(request_body) == 1
         assert request_body[0]["path"] == "/fields/System.AssignedTo"
         assert request_body[0]["value"] == "ftotten@vscsi.us"
@@ -376,7 +376,7 @@ class VstsIssueSyncTest(VstsIssueBase):
             req.url
             == f"https://fabrikam-fiber-inc.visualstudio.com/_apis/wit/workitems/{vsts_work_item_id}"
         )
-        assert json.loads(req.body) == [
+        assert orjson.loads(req.body) == [
             {"path": "/fields/System.State", "value": "Resolved", "op": "replace"}
         ]
         assert responses.calls[2].response.status_code == 200

--- a/tests/sentry/integrations/vsts/test_notify_action.py
+++ b/tests/sentry/integrations/vsts/test_notify_action.py
@@ -1,5 +1,6 @@
 from time import time
 
+import orjson
 import responses
 
 from fixtures.vsts import GET_PROJECTS_RESPONSE, WORK_ITEM_RESPONSE
@@ -14,7 +15,6 @@ from sentry.testutils.helpers.datetime import freeze_time
 from sentry.testutils.silo import assume_test_silo_mode
 from sentry.testutils.skips import requires_snuba
 from sentry.types.rules import RuleFuture
-from sentry.utils import json
 
 from .test_issues import VstsIssueBase
 
@@ -74,7 +74,7 @@ class AzureDevopsCreateTicketActionTest(RuleTestCase, VstsIssueBase):
         # Trigger rule callback
         rule_future = RuleFuture(rule=azuredevops_rule, kwargs=results[0].kwargs)
         results[0].callback(event, futures=[rule_future])
-        data = json.loads(responses.calls[0].response.text)
+        data = orjson.loads(responses.calls[0].response.text)
 
         assert data["fields"]["System.Title"] == "Hello"
         assert data["fields"]["System.Description"] == "Fix this."


### PR DESCRIPTION
We have enough confidence to say that `orjson` doesn't cause any errors/issues. We can now safely get rid of `json` and `rapidjson` in our repository.

Ref: https://github.com/getsentry/sentry/issues/68903