### PR TITLE
chore(grouping): Add grouping threshold constants

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -3952,6 +3952,8 @@ SENTRY_DDM_DISABLE = os.getenv("SENTRY_DDM_DISABLE", "0") in ("1", "true", "True
 
 SEER_SIMILARITY_MODEL_VERSION = "v0"
 SEER_SIMILAR_ISSUES_URL = f"/{SEER_SIMILARITY_MODEL_VERSION}/issues/similar-issues"
+SEER_MAX_GROUPING_DISTANCE = 0.01
+SEER_MAX_SIMILARITY_DISTANCE = 0.15  # Not yet in use - Seer doesn't obey this right now
 
 # Devserver configuration overrides.
 ngrok_host = os.environ.get("SENTRY_DEVSERVER_NGROK")


### PR DESCRIPTION
This adds to constants, `SEER_MAX_GROUPING_DISTANCE` and `SEER_MAX_SIMILARITY_DISTANCE` to `server.py`, along with their default values. The former is usable now, as Seer accepts a `threshold` request parameter and will use that to determine whether a similar issue falls into the `should_group: True` or `should_group: False` category. The latter we can't yet use, because Seer does not yet accept a parameter for the threshold which determines whether a `should_group: False` neighbor issue should  be returned as similar at all, but it'll be there to use once we make that Seer change.