### PR TITLE
test(ui): Remove `babel-plugin-dynamic-import-node`

### DIFF
--- a/babel.config.ts
+++ b/babel.config.ts
@@ -41,8 +41,6 @@ const config: TransformOptions = {
     test: {
       sourceMaps: process.env.CI ? false : true,
       plugins: [
-        // Required, see https://github.com/facebook/jest/issues/9430
-        'dynamic-import-node',
         // Disable emotion sourcemaps in tests
         // Since emotion spends lots of time parsing and inserting sourcemaps
         [

--- a/package.json
+++ b/package.json
@@ -186,7 +186,6 @@
     "@types/node": "^20.11.7",
     "babel-gettext-extractor": "^4.1.3",
     "babel-jest": "^29.6.2",
-    "babel-plugin-dynamic-import-node": "^2.3.3",
     "benchmark": "^2.1.4",
     "eslint": "8.57.0",
     "eslint-config-sentry-app": "2.7.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4954,13 +4954,6 @@ babel-plugin-add-react-displayname@^0.0.5:
   resolved "https://registry.yarnpkg.com/babel-plugin-add-react-displayname/-/babel-plugin-add-react-displayname-0.0.5.tgz#339d4cddb7b65fd62d1df9db9fe04de134122bd5"
   integrity sha1-M51M3be2X9YtHfnbn+BN4TQSK9U=
 
-babel-plugin-dynamic-import-node@^2.3.3:
-  version "2.3.3"
-  resolved "https://registry.yarnpkg.com/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.3.3.tgz#84fda19c976ec5c6defef57f9427b3def66e17a3"
-  integrity sha512-jZVI+s9Zg3IqA/kdi0i6UDCybUI3aSBLnglhYbSSjKlV7yF1F/5LWv8MakQmvYpnbJDS6fcBL2KzHSxNCMtWSQ==
-  dependencies:
-    object.assign "^4.1.0"
-
 babel-plugin-istanbul@^6.1.1:
   version "6.1.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-istanbul/-/babel-plugin-istanbul-6.1.1.tgz#fa88ec59232fd9b4e36dbbc540a8ec9a9b47da73"
@@ -9490,7 +9483,7 @@ object-keys@^1.1.1:
   resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.1.1.tgz#1c47f272df277f3b1daf061677d9c82e2322c60e"
   integrity sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==
 
-object.assign@^4.1.0, object.assign@^4.1.2, object.assign@^4.1.4, object.assign@^4.1.5:
+object.assign@^4.1.2, object.assign@^4.1.4, object.assign@^4.1.5:
   version "4.1.5"
   resolved "https://registry.yarnpkg.com/object.assign/-/object.assign-4.1.5.tgz#3a833f9ab7fdb80fc9e8d2300c803d216d8fdbb0"
   integrity sha512-byy+U7gp+FVwmyzKPYhW2h5l3crpmGsxl7X2s8y43IgxvG4g3QZ6CffDtsNQy1WsmZpQbO+ybo0AlW7TY6DcBQ==


### PR DESCRIPTION
I believe this was a temporary fix or is no longer required now that we're fully on typescript? https://www.npmjs.com/package/babel-plugin-dynamic-import-node
