### PR TITLE
fix(trace-explorer): Breakdown by project and sdk

### DIFF
--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -1487,6 +1487,7 @@ class BaseSpansTestCase(SnubaTestCase):
         measurements: Mapping[str, int | float] | None = None,
         timestamp: datetime | None = None,
         store_metrics_summary: Mapping[str, Sequence[Mapping[str, Any]]] | None = None,
+        sdk_name: str | None = None,
     ):
         if span_id is None:
             span_id = self._random_span_id()
@@ -1520,6 +1521,8 @@ class BaseSpansTestCase(SnubaTestCase):
             payload["_metrics_summary"] = store_metrics_summary
         if parent_span_id:
             payload["parent_span_id"] = parent_span_id
+        if sdk_name is not None:
+            payload["sentry_tags"]["sdk.name"] = sdk_name
 
         self.store_span(payload)
 

--- a/tests/sentry/api/endpoints/test_organization_traces.py
+++ b/tests/sentry/api/endpoints/test_organization_traces.py
@@ -76,7 +76,7 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
         project_2 = self.create_project()
 
         # Hack: ensure that no span ids with leading 0s are generated for the test
-        span_ids = ["1" + uuid4().hex[:15] for _ in range(11)]
+        span_ids = ["1" + uuid4().hex[:15] for _ in range(12)]
         tags = ["", "bar", "bar", "baz", "", "bar", "baz"]
         timestamps = []
 
@@ -91,6 +91,7 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
             transaction="foo",
             duration=60_100,
             exclusive_time=60_100,
+            sdk_name="sentry.javascript.node",
         )
         for i in range(1, 4):
             timestamps.append(before_now(days=0, minutes=9, seconds=45 - i).replace(microsecond=0))
@@ -105,6 +106,7 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
                 duration=30_000 + i,
                 exclusive_time=30_000 + i,
                 tags={"foo": tags[i]},
+                sdk_name="sentry.javascript.node",
             )
 
         trace_id_2 = uuid4().hex
@@ -119,6 +121,7 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
             transaction="bar",
             duration=90_123,
             exclusive_time=90_123,
+            sdk_name="sentry.javascript.node",
         )
         for i in range(5, 7):
             timestamps.append(before_now(days=0, minutes=19, seconds=55 - i).replace(microsecond=0))
@@ -133,6 +136,7 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
                 duration=20_000 + i,
                 exclusive_time=20_000 + i,
                 tags={"foo": tags[i]},
+                sdk_name="sentry.javascript.node",
             )
 
         timestamps.append(before_now(days=0, minutes=19, seconds=59).replace(microsecond=0))
@@ -215,6 +219,21 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
                     }
                 ]
             },
+            sdk_name="sentry.javascript.remix",
+        )
+
+        timestamps.append(before_now(days=0, minutes=19, seconds=50).replace(microsecond=0))
+        self.double_write_segment(
+            project_id=project_1.id,
+            trace_id=trace_id_3,
+            transaction_id=uuid4().hex,
+            span_id=span_ids[11],
+            parent_span_id=span_ids[10],
+            timestamp=timestamps[-1],
+            transaction="quz",
+            duration=10_000,
+            tags={"foo": "quz"},
+            sdk_name="sentry.javascript.node",
         )
 
         error_data = load_data("javascript", timestamp=timestamps[0])
@@ -438,6 +457,7 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
                             {
                                 "project": project_1.slug,
                                 "opCategory": None,
+                                "sdkName": "sentry.javascript.node",
                                 "start": int(timestamps[0].timestamp() * 1000),
                                 "end": int(timestamps[0].timestamp() * 1000) + 60_100,
                                 "kind": "project",
@@ -445,6 +465,7 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
                             {
                                 "project": project_2.slug,
                                 "opCategory": None,
+                                "sdkName": "sentry.javascript.node",
                                 "start": int(timestamps[1].timestamp() * 1000),
                                 "end": int(timestamps[3].timestamp() * 1000) + 30_003,
                                 "kind": "project",
@@ -489,6 +510,7 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
                             {
                                 "project": project_1.slug,
                                 "opCategory": None,
+                                "sdkName": "sentry.javascript.node",
                                 "start": int(timestamps[4].timestamp() * 1000),
                                 "end": int(timestamps[4].timestamp() * 1000) + 90_123,
                                 "kind": "project",
@@ -496,6 +518,7 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
                             {
                                 "project": project_2.slug,
                                 "opCategory": None,
+                                "sdkName": "sentry.javascript.node",
                                 "start": int(timestamps[5].timestamp() * 1000),
                                 "end": int(timestamps[6].timestamp() * 1000) + 20_006,
                                 "kind": "project",
@@ -583,6 +606,7 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
                     {
                         "project": project_1.slug,
                         "opCategory": None,
+                        "sdkName": "sentry.javascript.node",
                         "start": int(timestamps[4].timestamp() * 1000),
                         "end": int(timestamps[4].timestamp() * 1000) + 90_123,
                         "kind": "project",
@@ -590,6 +614,7 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
                     {
                         "project": project_1.slug,
                         "opCategory": "http",
+                        "sdkName": "",
                         "start": int(timestamps[7].timestamp() * 1000),
                         "end": int(timestamps[7].timestamp() * 1000) + 1_000,
                         "kind": "project",
@@ -597,6 +622,7 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
                     {
                         "project": project_2.slug,
                         "opCategory": None,
+                        "sdkName": "sentry.javascript.node",
                         "start": int(timestamps[5].timestamp() * 1000),
                         "end": int(timestamps[6].timestamp() * 1000) + 20_006,
                         "kind": "project",
@@ -604,6 +630,7 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
                     {
                         "project": project_1.slug,
                         "opCategory": "db",
+                        "sdkName": "",
                         "start": int(timestamps[8].timestamp() * 1000),
                         "end": int(timestamps[8].timestamp() * 1000) + 3_000,
                         "kind": "project",
@@ -677,7 +704,7 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
                         "trace": trace_id_3,
                         "numErrors": 0,
                         "numOccurrences": 0,
-                        "numSpans": 1,
+                        "numSpans": 2,
                         "project": project_1.slug,
                         "name": "qux",
                         "duration": 40_000,
@@ -687,8 +714,17 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
                             {
                                 "project": project_1.slug,
                                 "opCategory": None,
+                                "sdkName": "sentry.javascript.remix",
                                 "start": int(timestamps[10].timestamp() * 1000),
                                 "end": int(timestamps[10].timestamp() * 1000) + 40_000,
+                                "kind": "project",
+                            },
+                            {
+                                "project": project_1.slug,
+                                "opCategory": None,
+                                "sdkName": "sentry.javascript.node",
+                                "start": int(timestamps[11].timestamp() * 1000),
+                                "end": int(timestamps[11].timestamp() * 1000) + 10_000,
                                 "kind": "project",
                             },
                         ],
@@ -761,6 +797,7 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
                 {
                     "trace": "a" * 32,
                     "project": "foo",
+                    "sdk.name": "sentry.javascript.node",
                     "transaction": "foo1",
                     "precise.start_ts": 0,
                     "precise.finish_ts": 0.1,
@@ -773,6 +810,7 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
                     {
                         "project": "foo",
                         "opCategory": None,
+                        "sdkName": "sentry.javascript.node",
                         "start": 0,
                         "end": 100,
                         "kind": "project",
@@ -786,6 +824,7 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
                 {
                     "trace": "a" * 32,
                     "project": "foo",
+                    "sdk.name": "sentry.javascript.node",
                     "transaction": "foo1",
                     "precise.start_ts": 0,
                     "precise.finish_ts": 0.1,
@@ -793,6 +832,7 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
                 {
                     "trace": "a" * 32,
                     "project": "bar",
+                    "sdk.name": "sentry.javascript.node",
                     "transaction": "bar1",
                     "precise.start_ts": 0.025,
                     "precise.finish_ts": 0.075,
@@ -805,6 +845,7 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
                     {
                         "project": "foo",
                         "opCategory": None,
+                        "sdkName": "sentry.javascript.node",
                         "start": 0,
                         "end": 100,
                         "kind": "project",
@@ -812,6 +853,7 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
                     {
                         "project": "bar",
                         "opCategory": None,
+                        "sdkName": "sentry.javascript.node",
                         "start": 25,
                         "end": 75,
                         "kind": "project",
@@ -825,6 +867,7 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
                 {
                     "trace": "a" * 32,
                     "project": "foo",
+                    "sdk.name": "sentry.javascript.node",
                     "transaction": "foo1",
                     "precise.start_ts": 0,
                     "precise.finish_ts": 0.05,
@@ -832,6 +875,7 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
                 {
                     "trace": "a" * 32,
                     "project": "bar",
+                    "sdk.name": "sentry.javascript.node",
                     "transaction": "bar1",
                     "precise.start_ts": 0.025,
                     "precise.finish_ts": 0.075,
@@ -839,6 +883,7 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
                 {
                     "trace": "a" * 32,
                     "project": "baz",
+                    "sdk.name": "sentry.javascript.node",
                     "transaction": "baz1",
                     "precise.start_ts": 0.05,
                     "precise.finish_ts": 0.1,
@@ -851,6 +896,7 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
                     {
                         "project": "foo",
                         "opCategory": None,
+                        "sdkName": "sentry.javascript.node",
                         "start": 0,
                         "end": 50,
                         "kind": "project",
@@ -858,6 +904,7 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
                     {
                         "project": "bar",
                         "opCategory": None,
+                        "sdkName": "sentry.javascript.node",
                         "start": 25,
                         "end": 75,
                         "kind": "project",
@@ -865,6 +912,7 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
                     {
                         "project": "baz",
                         "opCategory": None,
+                        "sdkName": "sentry.javascript.node",
                         "start": 50,
                         "end": 100,
                         "kind": "project",
@@ -878,6 +926,7 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
                 {
                     "trace": "a" * 32,
                     "project": "foo",
+                    "sdk.name": "sentry.javascript.node",
                     "transaction": "foo1",
                     "precise.start_ts": 0,
                     "precise.finish_ts": 0.025,
@@ -885,6 +934,7 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
                 {
                     "trace": "a" * 32,
                     "project": "bar",
+                    "sdk.name": "sentry.javascript.node",
                     "transaction": "bar1",
                     "precise.start_ts": 0.05,
                     "precise.finish_ts": 0.075,
@@ -897,6 +947,7 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
                     {
                         "project": "foo",
                         "opCategory": None,
+                        "sdkName": "sentry.javascript.node",
                         "start": 0,
                         "end": 25,
                         "kind": "project",
@@ -904,6 +955,7 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
                     {
                         "project": None,
                         "opCategory": None,
+                        "sdkName": None,
                         "start": 25,
                         "end": 50,
                         "kind": "missing",
@@ -911,6 +963,7 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
                     {
                         "project": "bar",
                         "opCategory": None,
+                        "sdkName": "sentry.javascript.node",
                         "start": 50,
                         "end": 75,
                         "kind": "project",
@@ -924,6 +977,7 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
                 {
                     "trace": "a" * 32,
                     "project": "foo",
+                    "sdk.name": "sentry.javascript.node",
                     "transaction": "foo1",
                     "precise.start_ts": 0,
                     "precise.finish_ts": 0.1,
@@ -931,6 +985,7 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
                 {
                     "trace": "a" * 32,
                     "project": "foo",
+                    "sdk.name": "sentry.javascript.node",
                     "transaction": "foo2",
                     "precise.start_ts": 0.025,
                     "precise.finish_ts": 0.075,
@@ -943,6 +998,7 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
                     {
                         "project": "foo",
                         "opCategory": None,
+                        "sdkName": "sentry.javascript.node",
                         "start": 0,
                         "end": 100,
                         "kind": "project",
@@ -956,6 +1012,7 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
                 {
                     "trace": "a" * 32,
                     "project": "foo",
+                    "sdk.name": "sentry.javascript.node",
                     "transaction": "foo1",
                     "precise.start_ts": 0,
                     "precise.finish_ts": 0.075,
@@ -963,6 +1020,7 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
                 {
                     "trace": "a" * 32,
                     "project": "foo",
+                    "sdk.name": "sentry.javascript.node",
                     "transaction": "foo2",
                     "precise.start_ts": 0.025,
                     "precise.finish_ts": 0.1,
@@ -975,6 +1033,7 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
                     {
                         "project": "foo",
                         "opCategory": None,
+                        "sdkName": "sentry.javascript.node",
                         "start": 0,
                         "end": 100,
                         "kind": "project",
@@ -988,6 +1047,7 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
                 {
                     "trace": "a" * 32,
                     "project": "foo",
+                    "sdk.name": "sentry.javascript.node",
                     "transaction": "foo1",
                     "precise.start_ts": 0,
                     "precise.finish_ts": 0.025,
@@ -995,6 +1055,7 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
                 {
                     "trace": "a" * 32,
                     "project": "foo",
+                    "sdk.name": "sentry.javascript.node",
                     "transaction": "foo2",
                     "precise.start_ts": 0.05,
                     "precise.finish_ts": 0.075,
@@ -1007,6 +1068,7 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
                     {
                         "project": "foo",
                         "opCategory": None,
+                        "sdkName": "sentry.javascript.node",
                         "start": 0,
                         "end": 25,
                         "kind": "project",
@@ -1014,6 +1076,7 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
                     {
                         "project": None,
                         "opCategory": None,
+                        "sdkName": None,
                         "start": 25,
                         "end": 50,
                         "kind": "missing",
@@ -1021,6 +1084,7 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
                     {
                         "project": "foo",
                         "opCategory": None,
+                        "sdkName": "sentry.javascript.node",
                         "start": 50,
                         "end": 75,
                         "kind": "project",
@@ -1034,6 +1098,7 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
                 {
                     "trace": "a" * 32,
                     "project": "foo",
+                    "sdk.name": "sentry.javascript.node",
                     "transaction": "foo1",
                     "precise.start_ts": 0,
                     "precise.finish_ts": 0.1,
@@ -1041,6 +1106,7 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
                 {
                     "trace": "a" * 32,
                     "project": "bar",
+                    "sdk.name": "sentry.javascript.node",
                     "transaction": "bar1",
                     "precise.start_ts": 0.02,
                     "precise.finish_ts": 0.08,
@@ -1048,6 +1114,7 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
                 {
                     "trace": "a" * 32,
                     "project": "baz",
+                    "sdk.name": "sentry.javascript.node",
                     "transaction": "baz1",
                     "precise.start_ts": 0.04,
                     "precise.finish_ts": 0.06,
@@ -1060,6 +1127,7 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
                     {
                         "project": "foo",
                         "opCategory": None,
+                        "sdkName": "sentry.javascript.node",
                         "start": 0,
                         "end": 100,
                         "kind": "project",
@@ -1067,6 +1135,7 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
                     {
                         "project": "bar",
                         "opCategory": None,
+                        "sdkName": "sentry.javascript.node",
                         "start": 20,
                         "end": 80,
                         "kind": "project",
@@ -1074,6 +1143,7 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
                     {
                         "project": "baz",
                         "opCategory": None,
+                        "sdkName": "sentry.javascript.node",
                         "start": 40,
                         "end": 60,
                         "kind": "project",
@@ -1087,6 +1157,7 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
                 {
                     "trace": "a" * 32,
                     "project": "foo",
+                    "sdk.name": "sentry.javascript.node",
                     "transaction": "foo1",
                     "precise.start_ts": 0,
                     "precise.finish_ts": 0.1,
@@ -1094,12 +1165,14 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
                 {
                     "trace": "a" * 32,
                     "project": "bar",
+                    "sdk.name": "sentry.javascript.node",
                     "transaction": "bar1",
                     "precise.start_ts": 0.025,
                     "precise.finish_ts": 0.05,
                 },
                 {
                     "trace": "a" * 32,
+                    "sdk.name": "sentry.javascript.node",
                     "project": "baz",
                     "transaction": "baz1",
                     "precise.start_ts": 0.05,
@@ -1113,6 +1186,7 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
                     {
                         "project": "foo",
                         "opCategory": None,
+                        "sdkName": "sentry.javascript.node",
                         "start": 0,
                         "end": 100,
                         "kind": "project",
@@ -1120,6 +1194,7 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
                     {
                         "project": "bar",
                         "opCategory": None,
+                        "sdkName": "sentry.javascript.node",
                         "start": 25,
                         "end": 50,
                         "kind": "project",
@@ -1127,6 +1202,7 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
                     {
                         "project": "baz",
                         "opCategory": None,
+                        "sdkName": "sentry.javascript.node",
                         "start": 50,
                         "end": 75,
                         "kind": "project",
@@ -1140,6 +1216,7 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
                 {
                     "trace": "a" * 32,
                     "project": "foo",
+                    "sdk.name": "sentry.javascript.node",
                     "transaction": "foo1",
                     "precise.start_ts": 0,
                     "precise.finish_ts": 0.05,
@@ -1147,6 +1224,7 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
                 {
                     "trace": "a" * 32,
                     "project": "bar",
+                    "sdk.name": "sentry.javascript.node",
                     "transaction": "bar1",
                     "precise.start_ts": 0.02,
                     "precise.finish_ts": 0.03,
@@ -1154,6 +1232,7 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
                 {
                     "trace": "a" * 32,
                     "project": "baz",
+                    "sdk.name": "sentry.javascript.node",
                     "transaction": "baz1",
                     "precise.start_ts": 0.05,
                     "precise.finish_ts": 0.075,
@@ -1166,6 +1245,7 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
                     {
                         "project": "foo",
                         "opCategory": None,
+                        "sdkName": "sentry.javascript.node",
                         "start": 0,
                         "end": 50,
                         "kind": "project",
@@ -1173,6 +1253,7 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
                     {
                         "project": "bar",
                         "opCategory": None,
+                        "sdkName": "sentry.javascript.node",
                         "start": 20,
                         "end": 30,
                         "kind": "project",
@@ -1180,6 +1261,7 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
                     {
                         "project": "baz",
                         "opCategory": None,
+                        "sdkName": "sentry.javascript.node",
                         "start": 50,
                         "end": 75,
                         "kind": "project",
@@ -1193,6 +1275,7 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
                 {
                     "trace": "a" * 32,
                     "project": "foo",
+                    "sdk.name": "sentry.javascript.node",
                     "transaction": "foo1",
                     "precise.start_ts": 0,
                     "precise.finish_ts": 0.05,
@@ -1200,6 +1283,7 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
                 {
                     "trace": "a" * 32,
                     "project": "bar",
+                    "sdk.name": "sentry.javascript.node",
                     "transaction": "bar1",
                     "precise.start_ts": 0.02,
                     "precise.finish_ts": 0.03,
@@ -1207,6 +1291,7 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
                 {
                     "trace": "a" * 32,
                     "project": "baz",
+                    "sdk.name": "sentry.javascript.node",
                     "transaction": "baz1",
                     "precise.start_ts": 0.04,
                     "precise.finish_ts": 0.06,
@@ -1219,6 +1304,7 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
                     {
                         "project": "foo",
                         "opCategory": None,
+                        "sdkName": "sentry.javascript.node",
                         "start": 0,
                         "end": 50,
                         "kind": "project",
@@ -1226,6 +1312,7 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
                     {
                         "project": "bar",
                         "opCategory": None,
+                        "sdkName": "sentry.javascript.node",
                         "start": 20,
                         "end": 30,
                         "kind": "project",
@@ -1233,6 +1320,7 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
                     {
                         "project": "baz",
                         "opCategory": None,
+                        "sdkName": "sentry.javascript.node",
                         "start": 40,
                         "end": 60,
                         "kind": "project",
@@ -1246,6 +1334,7 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
                 {
                     "trace": "a" * 32,
                     "project": "foo",
+                    "sdk.name": "sentry.javascript.node",
                     "transaction": "foo1",
                     "precise.start_ts": 0,
                     "precise.finish_ts": 0.05,
@@ -1253,6 +1342,7 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
                 {
                     "trace": "a" * 32,
                     "project": "bar",
+                    "sdk.name": "sentry.javascript.node",
                     "transaction": "bar1",
                     "precise.start_ts": 0.01,
                     "precise.finish_ts": 0.02,
@@ -1260,6 +1350,7 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
                 {
                     "trace": "a" * 32,
                     "project": "foo",
+                    "sdk.name": "sentry.javascript.node",
                     "transaction": "foo1",
                     "precise.start_ts": 0.03,
                     "precise.finish_ts": 0.04,
@@ -1272,6 +1363,7 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
                     {
                         "project": "foo",
                         "opCategory": None,
+                        "sdkName": "sentry.javascript.node",
                         "start": 0,
                         "end": 50,
                         "kind": "project",
@@ -1279,6 +1371,7 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
                     {
                         "project": "bar",
                         "opCategory": None,
+                        "sdkName": "sentry.javascript.node",
                         "start": 10,
                         "end": 20,
                         "kind": "project",
@@ -1292,6 +1385,7 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
                 {
                     "trace": "a" * 32,
                     "project": "foo",
+                    "sdk.name": "sentry.javascript.node",
                     "transaction": "foo1",
                     "precise.start_ts": 0,
                     "precise.finish_ts": 0.1,
@@ -1304,6 +1398,7 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
                     {
                         "project": "foo",
                         "opCategory": None,
+                        "sdkName": "sentry.javascript.node",
                         "start": 0,
                         "end": 50,
                         "kind": "project",
@@ -1317,6 +1412,7 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
                 {
                     "trace": "a" * 32,
                     "project": "foo",
+                    "sdk.name": "sentry.javascript.node",
                     "transaction": "foo1",
                     "precise.start_ts": 0,
                     "precise.finish_ts": 0.05,
@@ -1329,6 +1425,7 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
                     {
                         "project": "foo",
                         "opCategory": None,
+                        "sdkName": "sentry.javascript.node",
                         "start": 0,
                         "end": 50,
                         "kind": "project",
@@ -1336,6 +1433,7 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
                     {
                         "project": None,
                         "opCategory": None,
+                        "sdkName": None,
                         "start": 50,
                         "end": 100,
                         "kind": "other",
@@ -1349,6 +1447,7 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
                 {
                     "trace": "a" * 32,
                     "project": "foo",
+                    "sdk.name": "sentry.javascript.node",
                     "transaction": "foo1",
                     "precise.start_ts": 0,
                     "precise.finish_ts": 0.012,
@@ -1356,6 +1455,7 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
                 {
                     "trace": "a" * 32,
                     "project": "foo",
+                    "sdk.name": "sentry.javascript.node",
                     "transaction": "foo1",
                     "precise.start_ts": 0.013,
                     "precise.finish_ts": 0.024,
@@ -1363,6 +1463,7 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
                 {
                     "trace": "a" * 32,
                     "project": "foo",
+                    "sdk.name": "sentry.javascript.node",
                     "transaction": "foo1",
                     "precise.start_ts": 0.032,
                     "precise.finish_ts": 0.040,
@@ -1375,6 +1476,7 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
                     {
                         "project": "foo",
                         "opCategory": None,
+                        "sdkName": "sentry.javascript.node",
                         "start": 0,
                         "end": 21,
                         "kind": "project",
@@ -1382,6 +1484,7 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
                     {
                         "project": None,
                         "opCategory": None,
+                        "sdkName": None,
                         "start": 21,
                         "end": 30,
                         "kind": "missing",
@@ -1389,6 +1492,7 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
                     {
                         "project": "foo",
                         "opCategory": None,
+                        "sdkName": "sentry.javascript.node",
                         "start": 30,
                         "end": 40,
                         "kind": "project",


### PR DESCRIPTION
For full stack projects that use a single project for all the data, we need to break it down further using sdk.