### PR TITLE
test(ui): Collect coverage from v8

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -211,6 +211,7 @@ const config: Config.InitialOptions = {
     'static/app/**/*.{js,jsx,ts,tsx}',
     '!static/app/**/*.spec.{js,jsx,ts,tsx}',
   ],
+  coverageProvider: 'v8',
   coverageReporters: ['html', 'cobertura'],
   coverageDirectory: '.artifacts/coverage',
   moduleNameMapper: {


### PR DESCRIPTION
https://jestjs.io/docs/configuration#coverageprovider-string uses v8 instead of babel's coverage via istanbul. Should use less memory?
