### PR TITLE
chore(events): Move `PLACEHOLDER_EVENT_TITLES` to a neutral location

### DIFF
--- a/src/sentry/constants.py
+++ b/src/sentry/constants.py
@@ -228,6 +228,8 @@ DEFAULT_LOG_LEVEL = "error"
 DEFAULT_LOGGER_NAME = ""
 LOG_LEVELS_MAP = {v: k for k, v in LOG_LEVELS.items()}
 
+PLACEHOLDER_EVENT_TITLES = frozenset(["<untitled>", "<unknown>", "<unlabeled event>", "Error"])
+
 # Default alerting threshold values
 DEFAULT_ALERT_PROJECT_THRESHOLD = (500, 25)  # 500%, 25 events
 DEFAULT_ALERT_GROUP_THRESHOLD = (1000, 25)  # 1000%, 25 events

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -35,6 +35,7 @@ from sentry.constants import (
     DEFAULT_STORE_NORMALIZER_ARGS,
     LOG_LEVELS_MAP,
     MAX_TAG_VALUE_LENGTH,
+    PLACEHOLDER_EVENT_TITLES,
     DataCategory,
 )
 from sentry.culprit import generate_culprit
@@ -146,7 +147,6 @@ SECURITY_REPORT_INTERFACES = ("csp", "hpkp", "expectct", "expectstaple", "nel")
 # Timeout for cached group crash report counts
 CRASH_REPORT_TIMEOUT = 24 * 3600  # one day
 
-PLACEHOLDER_EVENT_TITLES = frozenset(["<untitled>", "<unknown>", "<unlabeled event>", "Error"])
 
 HIGH_SEVERITY_THRESHOLD = 0.1
 

--- a/tests/sentry/event_manager/test_severity.py
+++ b/tests/sentry/event_manager/test_severity.py
@@ -9,8 +9,8 @@ from urllib3 import HTTPResponse
 from urllib3.exceptions import MaxRetryError
 
 from sentry import options
+from sentry.constants import PLACEHOLDER_EVENT_TITLES
 from sentry.event_manager import (
-    PLACEHOLDER_EVENT_TITLES,
     SEER_ERROR_COUNT_KEY,
     EventManager,
     _get_severity_score,


### PR DESCRIPTION
I tried to use `PLACEHOLDER_EVENT_TITLES` in an upcoming PR, and landed in a circular dependency with `event_manager.py`, where it currently lives. This moves it to `constants.py`, which solves the problem.