### PR TITLE
fix(grouping): Store variant dict rather than items on `CalculatedHashes`

### DIFF
--- a/src/sentry/eventstore/models.py
+++ b/src/sentry/eventstore/models.py
@@ -368,7 +368,10 @@ class BaseEvent(metaclass=abc.ABCMeta):
                 return rv
 
         # Create fresh hashes
-        flat_variants, hierarchical_variants = self.get_sorted_grouping_variants(force_config)
+        from sentry.grouping.api import sort_grouping_variants
+
+        variants = self.get_grouping_variants(force_config)
+        flat_variants, hierarchical_variants = sort_grouping_variants(variants)
         flat_hashes, _ = self._hashes_from_sorted_grouping_variants(flat_variants)
         hierarchical_hashes, tree_labels = self._hashes_from_sorted_grouping_variants(
             hierarchical_variants
@@ -388,15 +391,6 @@ class BaseEvent(metaclass=abc.ABCMeta):
             tree_labels=tree_labels,
             variants=[*flat_variants, *hierarchical_variants],
         )
-
-    def get_sorted_grouping_variants(
-        self, force_config: StrategyConfiguration | None = None
-    ) -> tuple[KeyedVariants, KeyedVariants]:
-        """Get grouping variants sorted into flat and hierarchical variants"""
-        from sentry.grouping.api import sort_grouping_variants
-
-        variants = self.get_grouping_variants(force_config)
-        return sort_grouping_variants(variants)
 
     @staticmethod
     def _hashes_from_sorted_grouping_variants(

--- a/src/sentry/eventstore/models.py
+++ b/src/sentry/eventstore/models.py
@@ -389,7 +389,7 @@ class BaseEvent(metaclass=abc.ABCMeta):
             hashes=flat_hashes,
             hierarchical_hashes=hierarchical_hashes,
             tree_labels=tree_labels,
-            variants=[*flat_variants, *hierarchical_variants],
+            variants=variants,
         )
 
     @staticmethod

--- a/src/sentry/grouping/result.py
+++ b/src/sentry/grouping/result.py
@@ -100,6 +100,14 @@ class CalculatedHashes:
     hashes: list[str]
     hierarchical_hashes: list[str]
     tree_labels: list[TreeLabel | None]
+    # `variants` will never be `None` when the `CalculatedHashes` instance is created as part of
+    # event grouping, but it has to be typed including `None` because we use the `CalculatedHashes`
+    # container in other places where we don't have the variants data
+    #
+    # TODO: Once we get rid of hierarchical hashing, those other places will just be using
+    # `CalculatedHashes` to wrap `hashes` - meaning we don't need a wrapper at all, and can save use
+    # of `CalculatedHashes` for times when we know the variants are there (so we can make them
+    # required in the type)
     variants: dict[str, BaseVariant] | None = None
 
     def write_to_event(self, event_data: NodeData) -> None:

--- a/src/sentry/grouping/result.py
+++ b/src/sentry/grouping/result.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass
 from typing import Any, Optional, TypedDict
 
 from sentry.db.models import NodeData
-from sentry.grouping.variants import KeyedVariants
+from sentry.grouping.variants import BaseVariant
 from sentry.utils.safe import get_path, safe_execute, set_path
 
 EventMetadata = dict[str, Any]
@@ -100,7 +100,7 @@ class CalculatedHashes:
     hashes: list[str]
     hierarchical_hashes: list[str]
     tree_labels: list[TreeLabel | None]
-    variants: KeyedVariants | None = None
+    variants: dict[str, BaseVariant] | None = None
 
     def write_to_event(self, event_data: NodeData) -> None:
         event_data["hashes"] = self.hashes

--- a/src/sentry/grouping/variants.py
+++ b/src/sentry/grouping/variants.py
@@ -29,6 +29,11 @@ class BaseVariant:
     def __repr__(self):
         return f"<{self.__class__.__name__} {self.get_hash()!r} ({self.type})>"
 
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, BaseVariant):
+            return NotImplemented
+        return self.as_dict() == other.as_dict()
+
 
 KeyedVariants = KeyedList[BaseVariant]
 


### PR DESCRIPTION
In https://github.com/getsentry/sentry/pull/68360, I added `variants` data to the `CalculatedHashes` dataclass, so that we'd have access to them later in the ingest process. In https://github.com/getsentry/sentry/pull/68579, I split up the function getting grouping info for an event so that the part of the work getting variant data was separate from the part acting on that variant data, with the specific intention of being able to use the latter on the variant data now being stored on `CalculatedHashes`. All good, except that I mistakenly ended up with data stored as dict items containing dictified variant data, when the function I wanted to pass that data to wants a dict itself, filled with legit variant objects. Whoops.

This fixes the problem, by switching to storing the `variants` dictionary itself on `CalculatedHashes`. In order to do this, I had to pull the contents of a helper function, `get_sorted_grouping_variants`, up into the one place it's called, because inside of that function is currently the only place the variants data exists in dictionary form. Also, for ease of doing recursive checks in tests now that we're not pre-dictifying `CalculatedHashes.variants`, I added a `__eq__` method to the `BaseVariant` class which does the dictifying automatically before comparison. 