### PR TITLE
fix(ui): Revert to using project release commmit API

### DIFF
--- a/static/app/views/releases/detail/commitsAndFiles/commits.spec.tsx
+++ b/static/app/views/releases/detail/commitsAndFiles/commits.spec.tsx
@@ -68,7 +68,7 @@ describe('Commits', () => {
       body: repos,
     });
     MockApiClient.addMockResponse({
-      url: `/organizations/org-slug/releases/${encodeURIComponent(
+      url: `/projects/org-slug/project-slug/releases/${encodeURIComponent(
         release.version
       )}/commits/`,
       body: [],
@@ -85,7 +85,7 @@ describe('Commits', () => {
       body: repos,
     });
     MockApiClient.addMockResponse({
-      url: `/organizations/org-slug/releases/${encodeURIComponent(
+      url: `/projects/org-slug/project-slug/releases/${encodeURIComponent(
         release.version
       )}/commits/`,
       body: [CommitFixture()],
@@ -112,7 +112,7 @@ describe('Commits', () => {
       ],
     });
     MockApiClient.addMockResponse({
-      url: `/organizations/org-slug/releases/${encodeURIComponent(
+      url: `/projects/org-slug/project-slug/releases/${encodeURIComponent(
         release.version
       )}/commits/`,
       body: [CommitFixture()],
@@ -146,7 +146,7 @@ describe('Commits', () => {
       body: [repos[0]!, otherRepo],
     });
     MockApiClient.addMockResponse({
-      url: `/organizations/org-slug/releases/${encodeURIComponent(
+      url: `/projects/org-slug/project-slug/releases/${encodeURIComponent(
         release.version
       )}/commits/`,
       body: [

--- a/static/app/views/releases/detail/commitsAndFiles/commits.tsx
+++ b/static/app/views/releases/detail/commitsAndFiles/commits.tsx
@@ -49,7 +49,7 @@ function Commits({activeReleaseRepo, releaseRepos, projectSlug}: CommitsProps) {
     getResponseHeader,
   } = useApiQuery<Commit[]>(
     [
-      `/organizations/${organization.slug}/releases/${encodeURIComponent(
+      `/projects/${organization.slug}/${projectSlug}/releases/${encodeURIComponent(
         params.release
       )}/commits/`,
       {query},
@@ -58,7 +58,6 @@ function Commits({activeReleaseRepo, releaseRepos, projectSlug}: CommitsProps) {
       staleTime: Infinity,
     }
   );
-
   const commitsByRepository = getCommitsByRepository(commitList);
   const reposToRender = getReposToRender(Object.keys(commitsByRepository));
   const activeRepoName: string | undefined = activeReleaseRepo


### PR DESCRIPTION
In https://github.com/getsentry/sentry/pull/63860 we switched from a class component to a FC and also switched from hitting `ProjectReleaseCommitsEndpoint` to `OrganizationReleaseCommitsEndpoint`.

The latter doesn't respect repo name or id in the query param, which makes it so selecting a repo in the dropdown will show you commits from other repos (and also messes up pagination as well, not showing you all commits).

Related to https://github.com/getsentry/sentry/issues/70411