### PR TITLE
feat(chartcuterie): Change Chart Stylings

### DIFF
--- a/static/app/chartcuterie/performance.tsx
+++ b/static/app/chartcuterie/performance.tsx
@@ -14,6 +14,8 @@ export const performanceCharts: RenderDescriptor<ChartType>[] = [];
 function modifyOptionsForSlack(options: Omit<LineChartProps, 'series'>) {
   options.legend = options.legend || {};
   options.legend.icon = 'none';
+  options.legend.left = '25';
+  options.legend.top = '20';
 
   return {
     ...options,

--- a/static/app/views/performance/utils/getIntervalLine.tsx
+++ b/static/app/views/performance/utils/getIntervalLine.tsx
@@ -180,7 +180,7 @@ export function getIntervalLine(
         transformedTransaction.aggregate_range_2
       )}`,
       position: 'insideEndBottom',
-      color: theme.red300,
+      color: theme.gray400,
     };
 
     additionalLineSeries.push({


### PR DESCRIPTION
two quick updates:

1. Changes the label for regressed to a darker color so we can read it better
![image](https://github.com/getsentry/sentry/assets/33237075/80cd09dd-3619-4d58-abd3-65795de248c0)

2. Updated some chart styling for slack so the legend is on the left 
![image](https://github.com/getsentry/sentry/assets/33237075/de5a048a-cad5-4e9a-b152-15cbf9bc254e)
