### PR TITLE
perf: replace memcache with redis on assemble

### DIFF
--- a/tests/sentry/tasks/test_assemble.py
+++ b/tests/sentry/tasks/test_assemble.py
@@ -1053,7 +1053,7 @@ class ArtifactBundleIndexingTest(TestCase):
         )
 
 
-@use_redis_cluster(with_options={"assemble.read_from_redis": True})
+@use_redis_cluster()
 def test_redis_assemble_status():
     task = AssembleTask.DIF
     project_id = uuid.uuid4().hex


### PR DESCRIPTION
Once https://github.com/getsentry/sentry-options-automator/pull/1358 lands, we can land this pull-request since we're right now officially writing to both Memcache and Redis for assemble status.