### PR TITLE
feat(ui): Introduce useSyncLegacyStore

### DIFF
--- a/static/app/components/themeAndStyleProvider.tsx
+++ b/static/app/components/themeAndStyleProvider.tsx
@@ -5,7 +5,7 @@ import {CacheProvider, ThemeProvider} from '@emotion/react';
 
 import {loadPreferencesState} from 'sentry/actionCreators/preferences';
 import ConfigStore from 'sentry/stores/configStore';
-import {useLegacyStore} from 'sentry/stores/useLegacyStore';
+import {useSyncLegacyStore} from 'sentry/stores/useSyncLegacyStore';
 import GlobalStyles from 'sentry/styles/global';
 import {darkTheme, lightTheme} from 'sentry/utils/theme';
 
@@ -30,7 +30,7 @@ cache.compat = true;
 export function ThemeAndStyleProvider({children}: Props) {
   useEffect(() => void loadPreferencesState(), []);
 
-  const config = useLegacyStore(ConfigStore);
+  const config = useSyncLegacyStore(ConfigStore);
   const theme = config.theme === 'dark' ? darkTheme : lightTheme;
 
   return (

--- a/static/app/stores/useLegacyStore.tsx
+++ b/static/app/stores/useLegacyStore.tsx
@@ -3,7 +3,7 @@ import type {Store} from 'reflux';
 
 import type {CommonStoreDefinition} from './types';
 
-interface LegacyStoreShape extends Store, CommonStoreDefinition<any> {}
+export interface LegacyStoreShape extends Store, CommonStoreDefinition<any> {}
 
 /**
  * Returns the state of a reflux store. Automatically unsubscribes when destroyed

--- a/static/app/stores/useSyncLegacyStore.spec.tsx
+++ b/static/app/stores/useSyncLegacyStore.spec.tsx
@@ -1,0 +1,22 @@
+import {TeamFixture} from 'sentry-fixture/team';
+
+import {act, renderHook} from 'sentry-test/reactTestingLibrary';
+
+import TeamStore from 'sentry/stores/teamStore';
+import {useLegacyStore} from 'sentry/stores/useLegacyStore';
+
+describe('useSyncLegacyStore', () => {
+  const team = TeamFixture();
+
+  beforeEach(() => void TeamStore.reset());
+
+  it('should update on change to store', () => {
+    const {result} = renderHook(useLegacyStore, {initialProps: TeamStore});
+
+    expect(result.current.teams).toEqual([]);
+
+    act(() => TeamStore.loadInitialData([team]));
+
+    expect(result.current.teams).toEqual([team]);
+  });
+});

--- a/static/app/stores/useSyncLegacyStore.tsx
+++ b/static/app/stores/useSyncLegacyStore.tsx
@@ -1,0 +1,20 @@
+import {useSyncExternalStore} from 'react';
+
+import type {LegacyStoreShape} from './useLegacyStore';
+
+/**
+ * A more efficent version of `useLegacyStore` that uses `useSyncExternalStore`
+ * Caveats:
+ * - getState must keep a reference to the same object if the state hasn't changed
+ */
+export function useSyncLegacyStore<T extends LegacyStoreShape>(
+  store: T
+): ReturnType<T['getState']> {
+  // https://react.dev/reference/react/useSyncExternalStore
+  const state = useSyncExternalStore(
+    // Pass undefined to 2nd listen argument using bind
+    store.listen.bind(store, undefined, undefined) as () => () => void,
+    store.getState
+  );
+  return state;
+}


### PR DESCRIPTION
introduces a useSyncLegacyStore that wraps useSyncExternalStore. Can only be used with legacy redux stores that keep a reference to the current state. Avoids warnings with calling setState before the component has mounted and potential issues with updating state during render. This is similar to what zustand does in its hooks, except it can pass a selector. Might be worth looking into [supporting selectors](https://github.com/facebook/react/blob/e7d213dfb0760dc9f6506fca6d6cfbac708a40e2/packages/use-sync-external-store/src/useSyncExternalStoreWithSelector.js#L19)

https://react.dev/reference/react/useSyncExternalStore

good store
```
getState() {
	return this.state;
}
```

bad store - returns a new object every time
```
getState() {
 	return { thing: this.thing }
}
```