### PR TITLE
fix(trace-explorer): Date range narrowing condition is backwards

### DIFF
--- a/src/sentry/api/endpoints/organization_traces.py
+++ b/src/sentry/api/endpoints/organization_traces.py
@@ -356,12 +356,17 @@ class TraceSamplesExecutor:
                 return min_timestamp, max_timestamp, [], []
         else:
             # No user queries so take the first N trace ids as our list
+            min_timestamp = snuba_params.end
+            max_timestamp = snuba_params.start
+            assert min_timestamp is not None
+            assert max_timestamp is not None
+
             trace_ids = trace_ids[: self.limit]
             timestamps = timestamps[: self.limit]
             for timestamp in timestamps:
                 if timestamp < min_timestamp:
                     min_timestamp = timestamp
-                if timestamp < max_timestamp:
+                if timestamp > max_timestamp:
                     max_timestamp = timestamp
 
         self.refine_params(min_timestamp, max_timestamp)

--- a/src/sentry/sentry_metrics/querying/samples_list.py
+++ b/src/sentry/sentry_metrics/querying/samples_list.py
@@ -258,7 +258,7 @@ class SegmentsSamplesListExecutor(AbstractSamplesListExecutor):
             # This also means we cannot order by any columns or paginate.
             orderby=None,
             limit=len(trace_ids) * max_spans_per_trace,
-            limitby=("trace", 1),
+            limitby=("trace", max_spans_per_trace),
         )
 
         trace_id_condition = Condition(Column("trace_id"), Op.IN, trace_ids)
@@ -609,7 +609,7 @@ class SpansSamplesListExecutor(AbstractSamplesListExecutor):
             # This also means we cannot order by any columns or paginate.
             orderby=None,
             limit=len(trace_ids) * max_spans_per_trace,
-            limitby=("trace", 1),
+            limitby=("trace", max_spans_per_trace),
         )
 
         trace_id_condition = Condition(Column("trace_id"), Op.IN, trace_ids)
@@ -943,7 +943,7 @@ class CustomSamplesListExecutor(AbstractSamplesListExecutor):
             # This also means we cannot order by any columns or paginate.
             orderby=None,
             limit=len(trace_ids) * max_spans_per_trace,
-            limitby=("trace", 1),
+            limitby=("trace", max_spans_per_trace),
         )
 
         trace_id_condition = Condition(Column("trace_id"), Op.IN, trace_ids)


### PR DESCRIPTION
This was changing the end timestamp to be too narrow and missing some spans.