### PR TITLE
feat(node): add external `instrument.js` file in onboarding

### DIFF
--- a/static/app/components/onboarding/gettingStartedDoc/step.tsx
+++ b/static/app/components/onboarding/gettingStartedDoc/step.tsx
@@ -25,6 +25,7 @@ interface CodeSnippetTab {
   label: string;
   language: string;
   value: string;
+  filename?: string;
 }
 
 interface TabbedCodeSnippetProps {
@@ -54,7 +55,7 @@ function TabbedCodeSnippet({
 }: TabbedCodeSnippetProps) {
   const [selectedTabValue, setSelectedTabValue] = useState(tabs[0].value);
   const selectedTab = tabs.find(tab => tab.value === selectedTabValue) ?? tabs[0];
-  const {code, language} = selectedTab;
+  const {code, language, filename} = selectedTab;
 
   return (
     <OnboardingCodeSnippet
@@ -67,6 +68,7 @@ function TabbedCodeSnippet({
       tabs={tabs}
       selectedTab={selectedTabValue}
       onTabClick={value => setSelectedTabValue(value)}
+      filename={filename}
     >
       {language === 'javascript'
         ? beautify.js(code, {

--- a/static/app/gettingStartedDocs/node/awslambda.spec.tsx
+++ b/static/app/gettingStartedDocs/node/awslambda.spec.tsx
@@ -17,11 +17,10 @@ describe('awslambda onboarding docs', function () {
     expect(screen.getByRole('heading', {name: 'Verify'})).toBeInTheDocument();
 
     // Includes import statement
-    expect(
-      screen.getByText(
-        textWithMarkupMatcher(/const Sentry = require\("@sentry\/aws-serverless"\);/)
-      )
-    ).toBeInTheDocument();
+    const allMatches = screen.getAllByText(textWithMarkupMatcher(/const Sentry = require\("@sentry\/aws-serverless"\);/));
+    allMatches.forEach(match => {
+      expect(match).toBeInTheDocument();
+    });
   });
 
   it('displays sample rates by default', () => {

--- a/static/app/gettingStartedDocs/node/awslambda.spec.tsx
+++ b/static/app/gettingStartedDocs/node/awslambda.spec.tsx
@@ -17,7 +17,9 @@ describe('awslambda onboarding docs', function () {
     expect(screen.getByRole('heading', {name: 'Verify'})).toBeInTheDocument();
 
     // Includes import statement
-    const allMatches = screen.getAllByText(textWithMarkupMatcher(/const Sentry = require\("@sentry\/aws-serverless"\);/));
+    const allMatches = screen.getAllByText(
+      textWithMarkupMatcher(/const Sentry = require\("@sentry\/aws-serverless"\);/)
+    );
     allMatches.forEach(match => {
       expect(match).toBeInTheDocument();
     });

--- a/static/app/gettingStartedDocs/node/awslambda.tsx
+++ b/static/app/gettingStartedDocs/node/awslambda.tsx
@@ -14,15 +14,13 @@ import {getJSServerMetricsOnboarding} from 'sentry/components/onboarding/getting
 import {t, tct} from 'sentry/locale';
 import {
   getInstallConfig,
-  getNodeRunCommandSnippet,
   getSdkInitSnippet,
-  getSentryImportsSnippet,
 } from 'sentry/utils/gettingStartedDocs/node';
 
 type Params = DocsParams;
 
-const getSdkSetupSnippet = () => `
-${getSentryImportsSnippet('aws-serverless')}
+const getSdkSetupSnippet = (params: Params) => `
+${getSdkInitSnippet(params, 'aws')}
 
 exports.handler = Sentry.wrapHandler(async (event, context) => {
   // Your handler code
@@ -54,52 +52,16 @@ const onboarding: OnboardingConfig = {
   configure: params => [
     {
       type: StepType.CONFIGURE,
-      description: t(
-        "Initialize Sentry as early as possible in your application's lifecycle. Otherwise, auto-instrumentation will not work."
+      description: tct(
+        "Wrap your lambda handler with Sentry's [code:wraphandler] function:",
+        {
+          code: <code />,
+        }
       ),
       configurations: [
         {
-          description: tct(
-            'To initialize the SDK before everything else, create an external file called [code:instrument.js/mjs].',
-            {code: <code />}
-          ),
-          code: [
-            {
-              label: 'JavaScript',
-              value: 'javascript',
-              language: 'javascript',
-              filename: 'instrument.(js|mjs)',
-              code: getSdkInitSnippet(params, 'aws'),
-            },
-          ],
-        },
-        {
-          description: tct(
-            'Modify the Node.js command to include the [code1:--require] option. This preloads [code2:instrument.(js|mjs)] at startup.',
-            {code1: <code />, code2: <code />}
-          ),
-          code: [
-            {
-              label: 'Bash',
-              value: 'bash',
-              language: 'bash',
-              code: getNodeRunCommandSnippet(),
-            },
-          ],
-        },
-        {
-          description: tct(
-            "Wrap your lambda handler with Sentry's [code:wraphandler] function:",
-            {code: <code />}
-          ),
-          code: [
-            {
-              label: 'JavaScript',
-              value: 'javascript',
-              language: 'javascript',
-              code: getSdkSetupSnippet(),
-            },
-          ],
+          language: 'javascript',
+          code: getSdkSetupSnippet(params),
         },
       ],
     },

--- a/static/app/gettingStartedDocs/node/awslambda.tsx
+++ b/static/app/gettingStartedDocs/node/awslambda.tsx
@@ -12,10 +12,7 @@ import {
 } from 'sentry/components/onboarding/gettingStartedDoc/utils/feedbackOnboarding';
 import {getJSServerMetricsOnboarding} from 'sentry/components/onboarding/gettingStartedDoc/utils/metricsOnboarding';
 import {t, tct} from 'sentry/locale';
-import {
-  getInstallConfig,
-  getSdkInitSnippet,
-} from 'sentry/utils/gettingStartedDocs/node';
+import {getInstallConfig, getSdkInitSnippet} from 'sentry/utils/gettingStartedDocs/node';
 
 type Params = DocsParams;
 

--- a/static/app/gettingStartedDocs/node/awslambda.tsx
+++ b/static/app/gettingStartedDocs/node/awslambda.tsx
@@ -60,7 +60,7 @@ const onboarding: OnboardingConfig = {
       configurations: [
         {
           description: tct(
-            'To initialize the SDK before everything else, create an external file called [code:instrument.ts/js].',
+            'To initialize the SDK before everything else, create an external file called [code:instrument.js/mjs].',
             {code: <code />}
           ),
           code: [
@@ -68,14 +68,14 @@ const onboarding: OnboardingConfig = {
               label: 'JavaScript',
               value: 'javascript',
               language: 'javascript',
-              filename: 'instrument.(js|mjs|ts)',
+              filename: 'instrument.(js|mjs)',
               code: getSdkInitSnippet(params, 'aws'),
             },
           ],
         },
         {
           description: tct(
-            'Modify the Node.js command to include the [code1:--require] option. This preloads [code2:instrument.(js|mjs|ts)] at startup.',
+            'Modify the Node.js command to include the [code1:--require] option. This preloads [code2:instrument.(js|mjs)] at startup.',
             {code1: <code />, code2: <code />}
           ),
           code: [

--- a/static/app/gettingStartedDocs/node/awslambda.tsx
+++ b/static/app/gettingStartedDocs/node/awslambda.tsx
@@ -11,50 +11,18 @@ import {
   getCrashReportModalIntroduction,
 } from 'sentry/components/onboarding/gettingStartedDoc/utils/feedbackOnboarding';
 import {getJSServerMetricsOnboarding} from 'sentry/components/onboarding/gettingStartedDoc/utils/metricsOnboarding';
-import {ProductSolution} from 'sentry/components/onboarding/productSelection';
 import {t, tct} from 'sentry/locale';
-import type {ProductSelectionMap} from 'sentry/utils/gettingStartedDocs/node';
 import {
-  getDefaulServerlessImports,
   getInstallConfig,
+  getNodeRunCommandSnippet,
+  getSdkInitSnippet,
+  getSentryImportsSnippet,
 } from 'sentry/utils/gettingStartedDocs/node';
 
 type Params = DocsParams;
 
-const productSelection = (params: Params): ProductSelectionMap => {
-  return {
-    [ProductSolution.ERROR_MONITORING]: true,
-    [ProductSolution.PROFILING]: params.isProfilingSelected,
-    [ProductSolution.PERFORMANCE_MONITORING]: params.isPerformanceSelected,
-    [ProductSolution.SESSION_REPLAY]: params.isReplaySelected,
-  };
-};
-
-const getSdkSetupSnippet = (params: Params) => `
-${getDefaulServerlessImports({productSelection: productSelection(params), library: 'aws-serverless'}).join('\n')}
-
-Sentry.init({
-  dsn: "${params.dsn}",
-  integrations: [${
-    params.isProfilingSelected
-      ? `
-      nodeProfilingIntegration(),`
-      : ''
-  }
-],${
-  params.isPerformanceSelected
-    ? `
-      // Performance Monitoring
-      tracesSampleRate: 1.0, //  Capture 100% of the transactions`
-    : ''
-}${
-  params.isProfilingSelected
-    ? `
-    // Set sampling rate for profiling - this is relative to tracesSampleRate
-    profilesSampleRate: 1.0,`
-    : ''
-}
-});
+const getSdkSetupSnippet = () => `
+${getSentryImportsSnippet('aws-serverless')}
 
 exports.handler = Sentry.wrapHandler(async (event, context) => {
   // Your handler code
@@ -86,16 +54,52 @@ const onboarding: OnboardingConfig = {
   configure: params => [
     {
       type: StepType.CONFIGURE,
-      description: tct(
-        "Wrap your lambda handler with Sentry's [code:wraphandler] function:",
-        {
-          code: <code />,
-        }
+      description: t(
+        "Initialize Sentry as early as possible in your application's lifecycle. Otherwise, auto-instrumentation will not work."
       ),
       configurations: [
         {
-          language: 'javascript',
-          code: getSdkSetupSnippet(params),
+          description: tct(
+            'To initialize the SDK before everything else, create an external file called [code:instrument.ts/js].',
+            {code: <code />}
+          ),
+          code: [
+            {
+              label: 'JavaScript',
+              value: 'javascript',
+              language: 'javascript',
+              filename: 'instrument.(js|mjs|ts)',
+              code: getSdkInitSnippet(params, 'aws'),
+            },
+          ],
+        },
+        {
+          description: tct(
+            'Modify the Node.js command to include the [code1:--require] option. This preloads [code2:instrument.(js|mjs|ts)] at startup.',
+            {code1: <code />, code2: <code />}
+          ),
+          code: [
+            {
+              label: 'Bash',
+              value: 'bash',
+              language: 'bash',
+              code: getNodeRunCommandSnippet(),
+            },
+          ],
+        },
+        {
+          description: tct(
+            "Wrap your lambda handler with Sentry's [code:wraphandler] function:",
+            {code: <code />}
+          ),
+          code: [
+            {
+              label: 'JavaScript',
+              value: 'javascript',
+              language: 'javascript',
+              code: getSdkSetupSnippet(),
+            },
+          ],
         },
       ],
     },

--- a/static/app/gettingStartedDocs/node/azurefunctions.spec.tsx
+++ b/static/app/gettingStartedDocs/node/azurefunctions.spec.tsx
@@ -16,9 +16,10 @@ describe('express onboarding docs', function () {
     expect(screen.getByRole('heading', {name: 'Upload Source Maps'})).toBeInTheDocument();
 
     // Includes import statement
-    expect(
-      screen.getByText(textWithMarkupMatcher(/import \* as Sentry from "@sentry\/node"/))
-    ).toBeInTheDocument();
+    const allMatches = screen.getAllByText(textWithMarkupMatcher(/import \* as Sentry from "@sentry\/node"/));
+    allMatches.forEach(match => {
+      expect(match).toBeInTheDocument();
+    });
   });
 
   it('displays sample rates by default', () => {

--- a/static/app/gettingStartedDocs/node/azurefunctions.spec.tsx
+++ b/static/app/gettingStartedDocs/node/azurefunctions.spec.tsx
@@ -16,7 +16,9 @@ describe('express onboarding docs', function () {
     expect(screen.getByRole('heading', {name: 'Upload Source Maps'})).toBeInTheDocument();
 
     // Includes import statement
-    const allMatches = screen.getAllByText(textWithMarkupMatcher(/import \* as Sentry from "@sentry\/node"/));
+    const allMatches = screen.getAllByText(
+      textWithMarkupMatcher(/import \* as Sentry from "@sentry\/node"/)
+    );
     allMatches.forEach(match => {
       expect(match).toBeInTheDocument();
     });

--- a/static/app/gettingStartedDocs/node/azurefunctions.tsx
+++ b/static/app/gettingStartedDocs/node/azurefunctions.tsx
@@ -12,7 +12,7 @@ import {
 } from 'sentry/components/onboarding/gettingStartedDoc/utils/feedbackOnboarding';
 import {getJSServerMetricsOnboarding} from 'sentry/components/onboarding/gettingStartedDoc/utils/metricsOnboarding';
 import {t, tct} from 'sentry/locale';
-import {getInstallConfig,getSdkInitSnippet} from 'sentry/utils/gettingStartedDocs/node';
+import {getInstallConfig, getSdkInitSnippet} from 'sentry/utils/gettingStartedDocs/node';
 
 type Params = DocsParams;
 
@@ -58,7 +58,7 @@ const onboarding: OnboardingConfig = {
         {
           language: 'javascript',
           code: getSdkSetupSnippet(params),
-        }
+        },
       ],
     },
     getUploadSourceMapsStep({

--- a/static/app/gettingStartedDocs/node/azurefunctions.tsx
+++ b/static/app/gettingStartedDocs/node/azurefunctions.tsx
@@ -58,7 +58,7 @@ const onboarding: OnboardingConfig = {
       configurations: [
         {
           description: tct(
-            'To initialize the SDK before everything else, create an external file called [code:instrument.ts/js].',
+            'To initialize the SDK before everything else, create an external file called [code:instrument.js/mjs].',
             {code: <code />}
           ),
           code: [
@@ -66,14 +66,14 @@ const onboarding: OnboardingConfig = {
               label: 'JavaScript',
               value: 'javascript',
               language: 'javascript',
-              filename: 'instrument.(js|mjs|ts)',
+              filename: 'instrument.(js|mjs)',
               code: getSdkInitSnippet(params, 'node'),
             },
           ],
         },
         {
           description: tct(
-            'Modify the Node.js command to include the [code1:--require] option. This preloads [code2:instrument.(js|mjs|ts)] at startup.',
+            'Modify the Node.js command to include the [code1:--require] option. This preloads [code2:instrument.(js|mjs)] at startup.',
             {code1: <code />, code2: <code />}
           ),
           code: [

--- a/static/app/gettingStartedDocs/node/azurefunctions.tsx
+++ b/static/app/gettingStartedDocs/node/azurefunctions.tsx
@@ -12,19 +12,13 @@ import {
 } from 'sentry/components/onboarding/gettingStartedDoc/utils/feedbackOnboarding';
 import {getJSServerMetricsOnboarding} from 'sentry/components/onboarding/gettingStartedDoc/utils/metricsOnboarding';
 import {t, tct} from 'sentry/locale';
-import {
-  getInstallConfig,
-  getNodeRunCommandSnippet,
-  getSdkInitSnippet,
-  getSentryImportsSnippet,
-} from 'sentry/utils/gettingStartedDocs/node';
+import {getInstallConfig,getSdkInitSnippet} from 'sentry/utils/gettingStartedDocs/node';
 
 type Params = DocsParams;
 
-const getSdkSetupSnippet = () => `
+const getSdkSetupSnippet = (params: Params) => `
 "use strict";
-
-${getSentryImportsSnippet('node')}
+${getSdkInitSnippet(params, 'node')}
 
 module.exports = async function (context, req) {
   try {
@@ -52,47 +46,19 @@ const onboarding: OnboardingConfig = {
   configure: params => [
     {
       type: StepType.CONFIGURE,
-      description: t(
-        "Initialize Sentry as early as possible in your application's lifecycle. Otherwise, auto-instrumentation will not work."
-      ),
+      description: t('To set up Sentry error logging for an Azure Function:'),
       configurations: [
         {
-          description: tct(
-            'To initialize the SDK before everything else, create an external file called [code:instrument.js/mjs].',
-            {code: <code />}
-          ),
-          code: [
-            {
-              label: 'JavaScript',
-              value: 'javascript',
-              language: 'javascript',
-              filename: 'instrument.(js|mjs)',
-              code: getSdkInitSnippet(params, 'node'),
-            },
-          ],
-        },
-        {
-          description: tct(
-            'Modify the Node.js command to include the [code1:--require] option. This preloads [code2:instrument.(js|mjs)] at startup.',
-            {code1: <code />, code2: <code />}
-          ),
-          code: [
-            {
-              label: 'Bash',
-              value: 'bash',
-              language: 'bash',
-              code: getNodeRunCommandSnippet(),
-            },
-          ],
-        },
-        {
+          language: 'javascript',
           description: tct(
             'Note: You need to call both [captureExceptionCode:captureException] and [flushCode:flush] for captured events to be successfully delivered to Sentry.',
             {captureExceptionCode: <code />, flushCode: <code />}
           ),
-          language: 'javascript',
-          code: getSdkSetupSnippet(),
         },
+        {
+          language: 'javascript',
+          code: getSdkSetupSnippet(params),
+        }
       ],
     },
     getUploadSourceMapsStep({

--- a/static/app/gettingStartedDocs/node/connect.spec.tsx
+++ b/static/app/gettingStartedDocs/node/connect.spec.tsx
@@ -16,7 +16,9 @@ describe('connect onboarding docs', function () {
     expect(screen.getByRole('heading', {name: 'Upload Source Maps'})).toBeInTheDocument();
 
     // Includes import statement
-    const allMatches = screen.getAllByText(textWithMarkupMatcher(/import \* as Sentry from "@sentry\/node"/));
+    const allMatches = screen.getAllByText(
+      textWithMarkupMatcher(/import \* as Sentry from "@sentry\/node"/)
+    );
     allMatches.forEach(match => {
       expect(match).toBeInTheDocument();
     });

--- a/static/app/gettingStartedDocs/node/connect.spec.tsx
+++ b/static/app/gettingStartedDocs/node/connect.spec.tsx
@@ -16,9 +16,10 @@ describe('connect onboarding docs', function () {
     expect(screen.getByRole('heading', {name: 'Upload Source Maps'})).toBeInTheDocument();
 
     // Includes import statement
-    expect(
-      screen.getByText(textWithMarkupMatcher(/import \* as Sentry from "@sentry\/node"/))
-    ).toBeInTheDocument();
+    const allMatches = screen.getAllByText(textWithMarkupMatcher(/import \* as Sentry from "@sentry\/node"/));
+    allMatches.forEach(match => {
+      expect(match).toBeInTheDocument();
+    });
   });
 
   it('displays sample rates by default', () => {

--- a/static/app/gettingStartedDocs/node/connect.tsx
+++ b/static/app/gettingStartedDocs/node/connect.tsx
@@ -11,52 +11,18 @@ import {
   getCrashReportModalIntroduction,
 } from 'sentry/components/onboarding/gettingStartedDoc/utils/feedbackOnboarding';
 import {getJSServerMetricsOnboarding} from 'sentry/components/onboarding/gettingStartedDoc/utils/metricsOnboarding';
-import {ProductSolution} from 'sentry/components/onboarding/productSelection';
-import {t} from 'sentry/locale';
-import type {ProductSelectionMap} from 'sentry/utils/gettingStartedDocs/node';
+import {t, tct} from 'sentry/locale';
 import {
-  getDefaultNodeImports,
   getInstallConfig,
+  getNodeRunCommandSnippet,
+  getSdkInitSnippet,
+  getSentryImportsSnippet,
 } from 'sentry/utils/gettingStartedDocs/node';
 
 type Params = DocsParams;
 
-const productSelection = (params: Params): ProductSelectionMap => {
-  return {
-    [ProductSolution.ERROR_MONITORING]: true,
-    [ProductSolution.PROFILING]: params.isProfilingSelected,
-    [ProductSolution.PERFORMANCE_MONITORING]: params.isPerformanceSelected,
-    [ProductSolution.SESSION_REPLAY]: params.isReplaySelected,
-  };
-};
-
-const getSdkSetupSnippet = (params: Params) => `
-${getDefaultNodeImports({productSelection: productSelection(params)}).join('\n')} d
-
-Sentry.init({
-  dsn: "${params.dsn}",
-  integrations: [${
-    params.isProfilingSelected
-      ? `
-      nodeProfilingIntegration(),`
-      : ''
-  }
-],${
-  params.isPerformanceSelected
-    ? `
-      // Performance Monitoring
-      tracesSampleRate: 1.0, //  Capture 100% of the transactions`
-    : ''
-}${
-  params.isProfilingSelected
-    ? `
-    // Set sampling rate for profiling - this is relative to tracesSampleRate
-    profilesSampleRate: 1.0,`
-    : ''
-}
-});
-
-// Make sure to require/import this _after_ calling Sentry.init()!
+const getSdkSetupSnippet = () => `
+${getSentryImportsSnippet('node')}
 const connect = require("connect");
 
 const app = connect();
@@ -79,11 +45,52 @@ const onboarding: OnboardingConfig = {
   configure: params => [
     {
       type: StepType.CONFIGURE,
-      description: t('Configure Sentry as a middleware:'),
+      description: t(
+        "Initialize Sentry as early as possible in your application's lifecycle. Otherwise, auto-instrumentation will not work."
+      ),
       configurations: [
         {
-          language: 'javascript',
-          code: getSdkSetupSnippet(params),
+          description: tct(
+            'To initialize the SDK before everything else, create an external file called [code:instrument.ts/js].',
+            {code: <code />}
+          ),
+          code: [
+            {
+              label: 'JavaScript',
+              value: 'javascript',
+              language: 'javascript',
+              filename: 'instrument.(js|mjs|ts)',
+              code: getSdkInitSnippet(params, 'node'),
+            },
+          ],
+        },
+        {
+          description: tct(
+            'Modify the Node.js command to include the [code1:--require] option. This preloads [code2:instrument.(js|mjs|ts)] at startup.',
+            {code1: <code />, code2: <code />}
+          ),
+          code: [
+            {
+              label: 'Bash',
+              value: 'bash',
+              language: 'bash',
+              code: getNodeRunCommandSnippet(),
+            },
+          ],
+        },
+        {
+          description: tct(
+            "Set up the error handler after all controllers and before any other error middleware. This setup is typically done in your application's entry point file, which is usually [code:index.(js|ts)].",
+            {code: <code />}
+          ),
+          code: [
+            {
+              label: 'JavaScript',
+              value: 'javascript',
+              language: 'javascript',
+              code: getSdkSetupSnippet(),
+            },
+          ],
         },
       ],
     },

--- a/static/app/gettingStartedDocs/node/connect.tsx
+++ b/static/app/gettingStartedDocs/node/connect.tsx
@@ -51,7 +51,7 @@ const onboarding: OnboardingConfig = {
       configurations: [
         {
           description: tct(
-            'To initialize the SDK before everything else, create an external file called [code:instrument.ts/js].',
+            'To initialize the SDK before everything else, create an external file called [code:instrument.js/mjs].',
             {code: <code />}
           ),
           code: [
@@ -59,14 +59,14 @@ const onboarding: OnboardingConfig = {
               label: 'JavaScript',
               value: 'javascript',
               language: 'javascript',
-              filename: 'instrument.(js|mjs|ts)',
+              filename: 'instrument.(js|mjs)',
               code: getSdkInitSnippet(params, 'node'),
             },
           ],
         },
         {
           description: tct(
-            'Modify the Node.js command to include the [code1:--require] option. This preloads [code2:instrument.(js|mjs|ts)] at startup.',
+            'Modify the Node.js command to include the [code1:--require] option. This preloads [code2:instrument.(js|mjs)] at startup.',
             {code1: <code />, code2: <code />}
           ),
           code: [

--- a/static/app/gettingStartedDocs/node/express.spec.tsx
+++ b/static/app/gettingStartedDocs/node/express.spec.tsx
@@ -17,9 +17,10 @@ describe('express onboarding docs', function () {
     expect(screen.getByRole('heading', {name: 'Verify'})).toBeInTheDocument();
 
     // Includes import statement
-    expect(
-      screen.getByText(textWithMarkupMatcher(/import \* as Sentry from "@sentry\/node"/))
-    ).toBeInTheDocument();
+    const allMatches = screen.getAllByText(textWithMarkupMatcher(/import \* as Sentry from "@sentry\/node"/));
+    allMatches.forEach(match => {
+      expect(match).toBeInTheDocument();
+    });
   });
 
   it('displays sample rates by default', () => {

--- a/static/app/gettingStartedDocs/node/express.spec.tsx
+++ b/static/app/gettingStartedDocs/node/express.spec.tsx
@@ -17,7 +17,9 @@ describe('express onboarding docs', function () {
     expect(screen.getByRole('heading', {name: 'Verify'})).toBeInTheDocument();
 
     // Includes import statement
-    const allMatches = screen.getAllByText(textWithMarkupMatcher(/import \* as Sentry from "@sentry\/node"/));
+    const allMatches = screen.getAllByText(
+      textWithMarkupMatcher(/import \* as Sentry from "@sentry\/node"/)
+    );
     allMatches.forEach(match => {
       expect(match).toBeInTheDocument();
     });

--- a/static/app/gettingStartedDocs/node/express.tsx
+++ b/static/app/gettingStartedDocs/node/express.tsx
@@ -11,58 +11,25 @@ import {
   getCrashReportModalIntroduction,
 } from 'sentry/components/onboarding/gettingStartedDoc/utils/feedbackOnboarding';
 import {getJSServerMetricsOnboarding} from 'sentry/components/onboarding/gettingStartedDoc/utils/metricsOnboarding';
-import {ProductSolution} from 'sentry/components/onboarding/productSelection';
 import replayOnboardingJsLoader from 'sentry/gettingStartedDocs/javascript/jsLoader/jsLoader';
 import {t, tct} from 'sentry/locale';
-import type {ProductSelectionMap} from 'sentry/utils/gettingStartedDocs/node';
 import {
-  getDefaultNodeImports,
   getInstallConfig,
+  getNodeRunCommandSnippet,
+  getSdkInitSnippet,
+  getSentryImportsSnippet,
 } from 'sentry/utils/gettingStartedDocs/node';
 
 type Params = DocsParams;
 
-const productSelection = (params: Params): ProductSelectionMap => {
-  return {
-    [ProductSolution.ERROR_MONITORING]: true,
-    [ProductSolution.PROFILING]: params.isProfilingSelected,
-    [ProductSolution.PERFORMANCE_MONITORING]: params.isPerformanceSelected,
-    [ProductSolution.SESSION_REPLAY]: params.isReplaySelected,
-  };
-};
-
-const getSdkSetupSnippet = (params: Params) => `
-${getDefaultNodeImports({productSelection: productSelection(params)}).join('\n')}
-
-Sentry.init({
-  dsn: "${params.dsn}",
-  integrations: [${
-    params.isProfilingSelected
-      ? `
-      nodeProfilingIntegration(),`
-      : ''
-  }
-],${
-  params.isPerformanceSelected
-    ? `
-      // Performance Monitoring
-      tracesSampleRate: 1.0, //  Capture 100% of the transactions`
-    : ''
-}${
-  params.isProfilingSelected
-    ? `
-    // Set sampling rate for profiling - this is relative to tracesSampleRate
-    profilesSampleRate: 1.0,`
-    : ''
-}
-});
-
-// Make sure to require/import this _after_ calling Sentry.init()!
+const getSdkSetupSnippet = () => `
+${getSentryImportsSnippet('node')}
 const express = require("express");
 
 const app = express();
 
 // All your controllers should live here
+
 app.get("/", function rootHandler(req, res) {
   res.end("Hello world!");
 });
@@ -92,18 +59,50 @@ const onboarding: OnboardingConfig = {
   configure: (params: Params) => [
     {
       type: StepType.CONFIGURE,
-      description: tct(
-        "Initialize Sentry as early as possible in your application's lifecycle, for example in your [code:index.ts/js] entry point. Make sure to initialize it before importing any other package:",
-        {code: <code />}
+      description: t(
+        "Initialize Sentry as early as possible in your application's lifecycle. Otherwise, auto-instrumentation will not work."
       ),
       configurations: [
         {
+          description: tct(
+            'To initialize the SDK before everything else, create an external file called [code:instrument.ts/js].',
+            {code: <code />}
+          ),
           code: [
             {
               label: 'JavaScript',
               value: 'javascript',
               language: 'javascript',
-              code: getSdkSetupSnippet(params),
+              filename: 'instrument.(js|mjs|ts)',
+              code: getSdkInitSnippet(params, 'node'),
+            },
+          ],
+        },
+        {
+          description: tct(
+            'Modify the Node.js command to include the [code1:--require] option. This preloads [code2:instrument.(js|mjs|ts)] at startup.',
+            {code1: <code />, code2: <code />}
+          ),
+          code: [
+            {
+              label: 'Bash',
+              value: 'bash',
+              language: 'bash',
+              code: getNodeRunCommandSnippet(),
+            },
+          ],
+        },
+        {
+          description: tct(
+            "Set up the error handler after all controllers and before any other error middleware. This setup is typically done in your application's entry point file, which is usually [code:index.(js|ts)].",
+            {code: <code />}
+          ),
+          code: [
+            {
+              label: 'JavaScript',
+              value: 'javascript',
+              language: 'javascript',
+              code: getSdkSetupSnippet(),
             },
           ],
         },

--- a/static/app/gettingStartedDocs/node/express.tsx
+++ b/static/app/gettingStartedDocs/node/express.tsx
@@ -65,7 +65,7 @@ const onboarding: OnboardingConfig = {
       configurations: [
         {
           description: tct(
-            'To initialize the SDK before everything else, create an external file called [code:instrument.ts/js].',
+            'To initialize the SDK before everything else, create an external file called [code:instrument.js/mjs].',
             {code: <code />}
           ),
           code: [
@@ -73,14 +73,14 @@ const onboarding: OnboardingConfig = {
               label: 'JavaScript',
               value: 'javascript',
               language: 'javascript',
-              filename: 'instrument.(js|mjs|ts)',
+              filename: 'instrument.(js|mjs)',
               code: getSdkInitSnippet(params, 'node'),
             },
           ],
         },
         {
           description: tct(
-            'Modify the Node.js command to include the [code1:--require] option. This preloads [code2:instrument.(js|mjs|ts)] at startup.',
+            'Modify the Node.js command to include the [code1:--require] option. This preloads [code2:instrument.(js|mjs)] at startup.',
             {code1: <code />, code2: <code />}
           ),
           code: [

--- a/static/app/gettingStartedDocs/node/gcpfunctions.spec.tsx
+++ b/static/app/gettingStartedDocs/node/gcpfunctions.spec.tsx
@@ -17,13 +17,10 @@ describe('gcpfunctions onboarding docs', function () {
     expect(screen.getByRole('heading', {name: 'Verify'})).toBeInTheDocument();
 
     // Includes import statement
-    expect(
-      screen.getByText(
-        textWithMarkupMatcher(
-          /const Sentry = require\("@sentry\/google-cloud-serverless"\);/
-        )
-      )
-    ).toBeInTheDocument();
+    const allMatches = screen.getAllByText(textWithMarkupMatcher(/const Sentry = require\("@sentry\/google-cloud-serverless"\);/));
+    allMatches.forEach(match => {
+      expect(match).toBeInTheDocument();
+    });
   });
 
   it('displays sample rates by default', () => {

--- a/static/app/gettingStartedDocs/node/gcpfunctions.spec.tsx
+++ b/static/app/gettingStartedDocs/node/gcpfunctions.spec.tsx
@@ -17,7 +17,11 @@ describe('gcpfunctions onboarding docs', function () {
     expect(screen.getByRole('heading', {name: 'Verify'})).toBeInTheDocument();
 
     // Includes import statement
-    const allMatches = screen.getAllByText(textWithMarkupMatcher(/const Sentry = require\("@sentry\/google-cloud-serverless"\);/));
+    const allMatches = screen.getAllByText(
+      textWithMarkupMatcher(
+        /const Sentry = require\("@sentry\/google-cloud-serverless"\);/
+      )
+    );
     allMatches.forEach(match => {
       expect(match).toBeInTheDocument();
     });

--- a/static/app/gettingStartedDocs/node/gcpfunctions.tsx
+++ b/static/app/gettingStartedDocs/node/gcpfunctions.tsx
@@ -11,59 +11,13 @@ import {
   getCrashReportModalIntroduction,
 } from 'sentry/components/onboarding/gettingStartedDoc/utils/feedbackOnboarding';
 import {getJSServerMetricsOnboarding} from 'sentry/components/onboarding/gettingStartedDoc/utils/metricsOnboarding';
-import {ProductSolution} from 'sentry/components/onboarding/productSelection';
 import {t, tct} from 'sentry/locale';
-import type {ProductSelectionMap} from 'sentry/utils/gettingStartedDocs/node';
-import {getDefaultServerlessImports} from 'sentry/utils/gettingStartedDocs/node';
+import {getInstallConfig, getSdkInitSnippet} from 'sentry/utils/gettingStartedDocs/node';
 
 type Params = DocsParams;
 
-const productSelection = (params: Params): ProductSelectionMap => {
-  return {
-    [ProductSolution.ERROR_MONITORING]: true,
-    [ProductSolution.PROFILING]: params.isProfilingSelected,
-    [ProductSolution.PERFORMANCE_MONITORING]: params.isPerformanceSelected,
-    [ProductSolution.SESSION_REPLAY]: params.isReplaySelected,
-  };
-};
-
-const getInstallSnippet = (params: Params) => `
-dependencies: {
-  //...
-  "@sentry/serverless": "^8",${
-    params.isProfilingSelected
-      ? `
-  "@sentry/profiling-node": "^1",`
-      : ''
-  }
-  //...
-}`;
-
 const getSdkSetupSnippet = (params: Params) => `
-${getDefaultServerlessImports({productSelection: productSelection(params), library: 'google-cloud-serverless'}).join('\n')}
-
-Sentry.init({
-  dsn: "${params.dsn}",
-  integrations: [${
-    params.isProfilingSelected
-      ? `
-      nodeProfilingIntegration(),`
-      : ''
-  }
-],${
-  params.isPerformanceSelected
-    ? `
-      // Performance Monitoring
-      tracesSampleRate: 1.0, //  Capture 100% of the transactions`
-    : ''
-}${
-  params.isProfilingSelected
-    ? `
-    // Set sampling rate for profiling - this is relative to tracesSampleRate
-    profilesSampleRate: 1.0,`
-    : ''
-}
-});
+${getSdkInitSnippet(params, 'gpc')}
 
 // Use wrapHttpFunction to instrument your http functions
 exports.helloHttp = Sentry.wrapHttpFunction((req, res) => {
@@ -108,7 +62,7 @@ const onboarding: OnboardingConfig = {
       configurations: [
         {
           language: 'json',
-          code: getInstallSnippet(params),
+          configurations: getInstallConfig(params, {basePackage: '@sentry/google-cloud-functions'})
         },
       ],
     },
@@ -159,7 +113,7 @@ const customMetricsOnboarding: OnboardingConfig = {
           codePackage: <code />,
         }
       ),
-      configurations: [{language: 'json', code: getInstallSnippet(params)}],
+      configurations: getInstallConfig(params, {basePackage: '@sentry/google-cloud-functions'}),
     },
   ],
   configure: params => [

--- a/static/app/gettingStartedDocs/node/gcpfunctions.tsx
+++ b/static/app/gettingStartedDocs/node/gcpfunctions.tsx
@@ -62,7 +62,9 @@ const onboarding: OnboardingConfig = {
       configurations: [
         {
           language: 'json',
-          configurations: getInstallConfig(params, {basePackage: '@sentry/google-cloud-functions'})
+          configurations: getInstallConfig(params, {
+            basePackage: '@sentry/google-cloud-functions',
+          }),
         },
       ],
     },
@@ -113,7 +115,9 @@ const customMetricsOnboarding: OnboardingConfig = {
           codePackage: <code />,
         }
       ),
-      configurations: getInstallConfig(params, {basePackage: '@sentry/google-cloud-functions'}),
+      configurations: getInstallConfig(params, {
+        basePackage: '@sentry/google-cloud-functions',
+      }),
     },
   ],
   configure: params => [

--- a/static/app/gettingStartedDocs/node/gcpfunctions.tsx
+++ b/static/app/gettingStartedDocs/node/gcpfunctions.tsx
@@ -14,7 +14,7 @@ import {getJSServerMetricsOnboarding} from 'sentry/components/onboarding/getting
 import {ProductSolution} from 'sentry/components/onboarding/productSelection';
 import {t, tct} from 'sentry/locale';
 import type {ProductSelectionMap} from 'sentry/utils/gettingStartedDocs/node';
-import {getDefaulServerlessImports} from 'sentry/utils/gettingStartedDocs/node';
+import {getDefaultServerlessImports} from 'sentry/utils/gettingStartedDocs/node';
 
 type Params = DocsParams;
 
@@ -40,7 +40,7 @@ dependencies: {
 }`;
 
 const getSdkSetupSnippet = (params: Params) => `
-${getDefaulServerlessImports({productSelection: productSelection(params), library: 'google-cloud-serverless'}).join('\n')}
+${getDefaultServerlessImports({productSelection: productSelection(params), library: 'google-cloud-serverless'}).join('\n')}
 
 Sentry.init({
   dsn: "${params.dsn}",

--- a/static/app/gettingStartedDocs/node/koa.spec.tsx
+++ b/static/app/gettingStartedDocs/node/koa.spec.tsx
@@ -17,9 +17,10 @@ describe('koa onboarding docs', function () {
     expect(screen.getByRole('heading', {name: 'Verify'})).toBeInTheDocument();
 
     // Includes import statement
-    expect(
-      screen.getByText(textWithMarkupMatcher(/import \* as Sentry from "@sentry\/node"/))
-    ).toBeInTheDocument();
+    const allMatches = screen.getAllByText(textWithMarkupMatcher(/import \* as Sentry from "@sentry\/node"/));
+    allMatches.forEach(match => {
+      expect(match).toBeInTheDocument();
+    });
   });
 
   it('displays sample rates by default', () => {

--- a/static/app/gettingStartedDocs/node/koa.spec.tsx
+++ b/static/app/gettingStartedDocs/node/koa.spec.tsx
@@ -17,7 +17,9 @@ describe('koa onboarding docs', function () {
     expect(screen.getByRole('heading', {name: 'Verify'})).toBeInTheDocument();
 
     // Includes import statement
-    const allMatches = screen.getAllByText(textWithMarkupMatcher(/import \* as Sentry from "@sentry\/node"/));
+    const allMatches = screen.getAllByText(
+      textWithMarkupMatcher(/import \* as Sentry from "@sentry\/node"/)
+    );
     allMatches.forEach(match => {
       expect(match).toBeInTheDocument();
     });

--- a/static/app/gettingStartedDocs/node/koa.tsx
+++ b/static/app/gettingStartedDocs/node/koa.tsx
@@ -60,7 +60,7 @@ const onboarding: OnboardingConfig = {
       configurations: [
         {
           description: tct(
-            'To initialize the SDK before everything else, create an external file called [code:instrument.ts/js].',
+            'To initialize the SDK before everything else, create an external file called [code:instrument.js/mjs].',
             {code: <code />}
           ),
           code: [
@@ -68,14 +68,14 @@ const onboarding: OnboardingConfig = {
               label: 'JavaScript',
               value: 'javascript',
               language: 'javascript',
-              filename: 'instrument.(js|mjs|ts)',
+              filename: 'instrument.(js|mjs)',
               code: getSdkInitSnippet(params, 'node'),
             },
           ],
         },
         {
           description: tct(
-            'Modify the Node.js command to include the [code1:--require] option. This preloads [code2:instrument.(js|mjs|ts)] at startup.',
+            'Modify the Node.js command to include the [code1:--require] option. This preloads [code2:instrument.(js|mjs)] at startup.',
             {code1: <code />, code2: <code />}
           ),
           code: [

--- a/static/app/gettingStartedDocs/node/koa.tsx
+++ b/static/app/gettingStartedDocs/node/koa.tsx
@@ -13,52 +13,18 @@ import {
   getCrashReportModalIntroduction,
 } from 'sentry/components/onboarding/gettingStartedDoc/utils/feedbackOnboarding';
 import {getJSServerMetricsOnboarding} from 'sentry/components/onboarding/gettingStartedDoc/utils/metricsOnboarding';
-import {ProductSolution} from 'sentry/components/onboarding/productSelection';
 import {t, tct} from 'sentry/locale';
-import type {ProductSelectionMap} from 'sentry/utils/gettingStartedDocs/node';
 import {
-  getDefaultNodeImports,
   getInstallConfig,
+  getNodeRunCommandSnippet,
+  getSdkInitSnippet,
+  getSentryImportsSnippet,
 } from 'sentry/utils/gettingStartedDocs/node';
 
 type Params = DocsParams;
 
-const productSelection = (params: Params): ProductSelectionMap => {
-  return {
-    [ProductSolution.ERROR_MONITORING]: true,
-    [ProductSolution.PROFILING]: params.isProfilingSelected,
-    [ProductSolution.PERFORMANCE_MONITORING]: params.isPerformanceSelected,
-    [ProductSolution.SESSION_REPLAY]: params.isReplaySelected,
-  };
-};
-
-const getSdkSetupSnippet = (params: Params) => `
-${getDefaultNodeImports({productSelection: productSelection(params)}).join('\n')}
-
-Sentry.init({
-  dsn: "${params.dsn}",
-  integrations: [${
-    params.isProfilingSelected
-      ? `
-      nodeProfilingIntegration(),`
-      : ''
-  }
-],${
-  params.isPerformanceSelected
-    ? `
-      // Performance Monitoring
-      tracesSampleRate: 1.0, //  Capture 100% of the transactions`
-    : ''
-}${
-  params.isProfilingSelected
-    ? `
-    // Set sampling rate for profiling - this is relative to tracesSampleRate
-    profilesSampleRate: 1.0,`
-    : ''
-}
-});
-
-// Make sure to require/import this _after_ calling Sentry.init()!
+const getSdkSetupSnippet = () => `
+${getSentryImportsSnippet('node')}
 const Koa = require("koa");
 
 const app = new Koa();
@@ -88,14 +54,52 @@ const onboarding: OnboardingConfig = {
   configure: params => [
     {
       type: StepType.CONFIGURE,
-      description: tct(
-        "Initialize Sentry as early as possible in your application's lifecycle, for example in your [code:index.ts/js] entry point:",
-        {code: <code />}
+      description: t(
+        "Initialize Sentry as early as possible in your application's lifecycle. Otherwise, auto-instrumentation will not work."
       ),
       configurations: [
         {
-          language: 'javascript',
-          code: getSdkSetupSnippet(params),
+          description: tct(
+            'To initialize the SDK before everything else, create an external file called [code:instrument.ts/js].',
+            {code: <code />}
+          ),
+          code: [
+            {
+              label: 'JavaScript',
+              value: 'javascript',
+              language: 'javascript',
+              filename: 'instrument.(js|mjs|ts)',
+              code: getSdkInitSnippet(params, 'node'),
+            },
+          ],
+        },
+        {
+          description: tct(
+            'Modify the Node.js command to include the [code1:--require] option. This preloads [code2:instrument.(js|mjs|ts)] at startup.',
+            {code1: <code />, code2: <code />}
+          ),
+          code: [
+            {
+              label: 'Bash',
+              value: 'bash',
+              language: 'bash',
+              code: getNodeRunCommandSnippet(),
+            },
+          ],
+        },
+        {
+          description: tct(
+            "Set up the error handler after all controllers and before any other error middleware. This setup is typically done in your application's entry point file, which is usually [code:index.(js|ts)].",
+            {code: <code />}
+          ),
+          code: [
+            {
+              label: 'JavaScript',
+              value: 'javascript',
+              language: 'javascript',
+              code: getSdkSetupSnippet(),
+            },
+          ],
         },
       ],
     },

--- a/static/app/gettingStartedDocs/node/node.spec.tsx
+++ b/static/app/gettingStartedDocs/node/node.spec.tsx
@@ -17,9 +17,10 @@ describe('node onboarding docs', function () {
     expect(screen.getByRole('heading', {name: 'Verify'})).toBeInTheDocument();
 
     // Includes import statement
-    expect(
-      screen.getByText(textWithMarkupMatcher(/import \* as Sentry from "@sentry\/node"/))
-    ).toBeInTheDocument();
+    const allMatches = screen.getAllByText(textWithMarkupMatcher(/import \* as Sentry from "@sentry\/node"/));
+    allMatches.forEach(match => {
+      expect(match).toBeInTheDocument();
+    });
   });
 
   it('displays sample rates by default', () => {

--- a/static/app/gettingStartedDocs/node/node.spec.tsx
+++ b/static/app/gettingStartedDocs/node/node.spec.tsx
@@ -17,7 +17,9 @@ describe('node onboarding docs', function () {
     expect(screen.getByRole('heading', {name: 'Verify'})).toBeInTheDocument();
 
     // Includes import statement
-    const allMatches = screen.getAllByText(textWithMarkupMatcher(/import \* as Sentry from "@sentry\/node"/));
+    const allMatches = screen.getAllByText(
+      textWithMarkupMatcher(/import \* as Sentry from "@sentry\/node"/)
+    );
     allMatches.forEach(match => {
       expect(match).toBeInTheDocument();
     });

--- a/static/app/gettingStartedDocs/node/node.tsx
+++ b/static/app/gettingStartedDocs/node/node.tsx
@@ -38,7 +38,7 @@ const onboarding: OnboardingConfig = {
       configurations: [
         {
           description: tct(
-            'To initialize the SDK before everything else, create an external file called [code:instrument.ts/js].',
+            'To initialize the SDK before everything else, create an external file called [code:instrument.js/mjs].',
             {code: <code />}
           ),
           code: [
@@ -46,14 +46,14 @@ const onboarding: OnboardingConfig = {
               label: 'JavaScript',
               value: 'javascript',
               language: 'javascript',
-              filename: 'instrument.(js|mjs|ts)',
+              filename: 'instrument.(js|mjs)',
               code: getSdkInitSnippet(params, 'node'),
             },
           ],
         },
         {
           description: tct(
-            'Modify the Node.js command to include the [code1:--require] option. This preloads [code2:instrument.(js|mjs|ts)] at startup.',
+            'Modify the Node.js command to include the [code1:--require] option. This preloads [code2:instrument.(js|mjs)] at startup.',
             {code1: <code />, code2: <code />}
           ),
           code: [

--- a/static/app/gettingStartedDocs/node/node.tsx
+++ b/static/app/gettingStartedDocs/node/node.tsx
@@ -11,52 +11,15 @@ import {
   getCrashReportModalIntroduction,
 } from 'sentry/components/onboarding/gettingStartedDoc/utils/feedbackOnboarding';
 import {getJSServerMetricsOnboarding} from 'sentry/components/onboarding/gettingStartedDoc/utils/metricsOnboarding';
-import {ProductSolution} from 'sentry/components/onboarding/productSelection';
 import replayOnboardingJsLoader from 'sentry/gettingStartedDocs/javascript/jsLoader/jsLoader';
 import {t, tct} from 'sentry/locale';
-import type {ProductSelectionMap} from 'sentry/utils/gettingStartedDocs/node';
 import {
-  getDefaultNodeImports,
   getInstallConfig,
+  getNodeRunCommandSnippet,
+  getSdkInitSnippet,
 } from 'sentry/utils/gettingStartedDocs/node';
 
 type Params = DocsParams;
-
-const productSelection = (params: Params): ProductSelectionMap => {
-  return {
-    [ProductSolution.ERROR_MONITORING]: true,
-    [ProductSolution.PROFILING]: params.isProfilingSelected,
-    [ProductSolution.PERFORMANCE_MONITORING]: params.isPerformanceSelected,
-    [ProductSolution.SESSION_REPLAY]: params.isReplaySelected,
-  };
-};
-
-const getSdkSetupSnippet = (params: Params) => `
-${getDefaultNodeImports({productSelection: productSelection(params)}).join('\n')}
-
-Sentry.init({
-  dsn: "${params.dsn}",
-  ${
-    params.isProfilingSelected
-      ? `integrations: [
-    nodeProfilingIntegration(),
-  ],`
-      : ''
-  }${
-    params.isPerformanceSelected
-      ? `
-      // Performance Monitoring
-      tracesSampleRate: 1.0, //  Capture 100% of the transactions`
-      : ''
-  }${
-    params.isProfilingSelected
-      ? `
-    // Set sampling rate for profiling - this is relative to tracesSampleRate
-    profilesSampleRate: 1.0,`
-      : ''
-  }
-});
-`;
 
 const onboarding: OnboardingConfig = {
   install: (params: Params) => [
@@ -69,18 +32,36 @@ const onboarding: OnboardingConfig = {
   configure: (params: Params) => [
     {
       type: StepType.CONFIGURE,
-      description: tct(
-        "Initialize Sentry as early as possible in your application's lifecycle, for example in your [code:index.ts/js] entry point:",
-        {code: <code />}
+      description: t(
+        "Initialize Sentry as early as possible in your application's lifecycle. Otherwise, auto-instrumentation will not work."
       ),
       configurations: [
         {
+          description: tct(
+            'To initialize the SDK before everything else, create an external file called [code:instrument.ts/js].',
+            {code: <code />}
+          ),
           code: [
             {
               label: 'JavaScript',
               value: 'javascript',
               language: 'javascript',
-              code: getSdkSetupSnippet(params),
+              filename: 'instrument.(js|mjs|ts)',
+              code: getSdkInitSnippet(params, 'node'),
+            },
+          ],
+        },
+        {
+          description: tct(
+            'Modify the Node.js command to include the [code1:--require] option. This preloads [code2:instrument.(js|mjs|ts)] at startup.',
+            {code1: <code />, code2: <code />}
+          ),
+          code: [
+            {
+              label: 'Bash',
+              value: 'bash',
+              language: 'bash',
+              code: getNodeRunCommandSnippet(),
             },
           ],
         },

--- a/static/app/utils/gettingStartedDocs/node.ts
+++ b/static/app/utils/gettingStartedDocs/node.ts
@@ -89,7 +89,7 @@ function getImports(
   sdkPackage: 'node' | 'google-cloud-serverless' | 'aws-serverless'
 ): string[] {
   return [
-    `// You can also use ESM \`import * as Sentry from "@sentry/${sdkPackage}"\` instead of \`require\``,
+    `// Import with \`import * as Sentry from "@sentry/${sdkPackage}"\` if you are using ESM`,
     `const Sentry = require("@sentry/${sdkPackage}");`,
   ];
 }
@@ -138,7 +138,7 @@ export function getDefaultServerlessImports({
 
 export function getNodeRunCommandSnippet(): string {
   return `# If you are using CommonJS (CJS)
-node --require ./instrumentation.js app.js
+node --require ./instrument.js app.js
 
 # If you are using ECMAScript Modules (ESM) - Note that this is only available from Node 18.19.0 onwards.
 node --import ./instrument.mjs app.mjs`;

--- a/static/app/utils/gettingStartedDocs/node.ts
+++ b/static/app/utils/gettingStartedDocs/node.ts
@@ -6,7 +6,7 @@ export type ProductSelectionMap = Record<ProductSolution, boolean>;
 /**
  * Transforms the product selection array into a map of booleans for each product for easier access.
  */
-const productSelectionMap = (params: DocsParams): ProductSelectionMap => {
+const getProductSelectionMap = (params: DocsParams): ProductSelectionMap => {
   return {
     [ProductSolution.ERROR_MONITORING]: true,
     [ProductSolution.PROFILING]: params.isProfilingSelected,
@@ -150,15 +150,15 @@ export const getSdkInitSnippet = (
 ) => `
 ${
   sdkImport === 'node'
-    ? getDefaultNodeImports({productSelection: productSelectionMap(params)}).join('\n')
+    ? getDefaultNodeImports({productSelection: getProductSelectionMap(params)}).join('\n')
     : sdkImport === 'aws'
       ? getDefaultServerlessImports({
-          productSelection: productSelectionMap(params),
+          productSelection: getProductSelectionMap(params),
           library: 'aws-serverless',
         }).join('\n')
       : sdkImport === 'gpc'
         ? getDefaultServerlessImports({
-            productSelection: productSelectionMap(params),
+            productSelection: getProductSelectionMap(params),
             library: 'google-cloud-serverless',
           }).join('\n')
         : ''

--- a/static/app/utils/gettingStartedDocs/node.ts
+++ b/static/app/utils/gettingStartedDocs/node.ts
@@ -6,20 +6,13 @@ export type ProductSelectionMap = Record<ProductSolution, boolean>;
 /**
  * Transforms the product selection array into a map of booleans for each product for easier access.
  */
-export const getProductSelectionMap = (
-  activeProductSelection: ProductSolution[]
-): ProductSelectionMap => {
-  const productSelectionMap: ProductSelectionMap = {
-    [ProductSolution.ERROR_MONITORING]: false,
-    [ProductSolution.PROFILING]: false,
-    [ProductSolution.PERFORMANCE_MONITORING]: false,
-    [ProductSolution.SESSION_REPLAY]: false,
+const productSelectionMap = (params: DocsParams): ProductSelectionMap => {
+  return {
+    [ProductSolution.ERROR_MONITORING]: true,
+    [ProductSolution.PROFILING]: params.isProfilingSelected,
+    [ProductSolution.PERFORMANCE_MONITORING]: params.isPerformanceSelected,
+    [ProductSolution.SESSION_REPLAY]: params.isReplaySelected,
   };
-
-  activeProductSelection.forEach(product => {
-    productSelectionMap[product] = true;
-  });
-  return productSelectionMap;
 };
 
 /**
@@ -92,32 +85,49 @@ export function getInstallConfig(
   ];
 }
 
+function getImports(
+  sdkPackage: 'node' | 'google-cloud-serverless' | 'aws-serverless'
+): string[] {
+  return [
+    `// You can also use ESM \`import * as Sentry from "@sentry/${sdkPackage}"\` instead of \`require\``,
+    `const Sentry = require("@sentry/${sdkPackage}");`,
+  ];
+}
+
+/**
+ * Import Snippet for the Node and Serverless SDKs without other packages (like profiling).
+ */
+export function getSentryImportsSnippet(
+  sdkPackage: 'node' | 'google-cloud-serverless' | 'aws-serverless'
+): string {
+  return getImports(sdkPackage).join('\n');
+}
+
+/**
+ * Import Snippet for the Node SDK with other selected packages (like profiling).
+ */
 export function getDefaultNodeImports({
   productSelection,
 }: {
   productSelection: ProductSelectionMap;
 }) {
-  const imports: string[] = [
-    `// You can also use ESM \`import * as Sentry from "@sentry/node"\` instead of \`require\``,
-    `const Sentry = require("@sentry/node");`,
-  ];
+  const imports: string[] = getImports('node');
+
   if (productSelection.profiling) {
     imports.push(`import { nodeProfilingIntegration } from "@sentry/profiling-node";`);
   }
   return imports;
 }
 
-export function getDefaulServerlessImports({
+export function getDefaultServerlessImports({
   productSelection,
   library,
 }: {
   library: `google-cloud-serverless` | `aws-serverless`;
   productSelection: ProductSelectionMap;
 }) {
-  const imports: string[] = [
-    `// You can also use ESM \`import * as Sentry from "@sentry/${library}"\` instead of \`require\``,
-    `const Sentry = require("@sentry/${library}");`,
-  ];
+  const imports: string[] = getImports(library);
+
   if (productSelection.profiling) {
     imports.push(
       `const { nodeProfilingIntegration } = require("@sentry/profiling-node");`
@@ -125,6 +135,58 @@ export function getDefaulServerlessImports({
   }
   return imports;
 }
+
+export function getNodeRunCommandSnippet(): string {
+  return `# If you are using CommonJS (CJS)
+node --require ./instrumentation.js app.js
+
+# If you are using ECMAScript Modules (ESM) - Note that this is only available from Node 18.19.0 onwards.
+node --import ./instrument.mjs app.mjs`;
+}
+
+export const getSdkInitSnippet = (
+  params: DocsParams,
+  sdkImport: 'node' | 'aws' | 'gpc'
+) => `
+${
+  sdkImport === 'node'
+    ? getDefaultNodeImports({productSelection: productSelectionMap(params)}).join('\n')
+    : sdkImport === 'aws'
+      ? getDefaultServerlessImports({
+          productSelection: productSelectionMap(params),
+          library: 'aws-serverless',
+        }).join('\n')
+      : sdkImport === 'gpc'
+        ? getDefaultServerlessImports({
+            productSelection: productSelectionMap(params),
+            library: 'google-cloud-serverless',
+          }).join('\n')
+        : ''
+}
+
+Sentry.init({
+  dsn: "${params.dsn}",
+  ${
+    params.isProfilingSelected
+      ? `integrations: [
+    nodeProfilingIntegration(),
+  ],`
+      : ''
+  }${
+    params.isPerformanceSelected
+      ? `
+      // Performance Monitoring
+      tracesSampleRate: 1.0, //  Capture 100% of the transactions`
+      : ''
+  }${
+    params.isProfilingSelected
+      ? `
+    // Set sampling rate for profiling - this is relative to tracesSampleRate
+    profilesSampleRate: 1.0,`
+      : ''
+  }
+});
+`;
 
 export function getProductIntegrations({
   productSelection,


### PR DESCRIPTION
For JS SDK v8 an external file is needed to initialize the SDK right at the start of the application. The existing node guides are updated.
