### PR TITLE
fix(replay): check for undefined property in init crumb

### DIFF
--- a/static/app/utils/replays/getCurrentScreenName.spec.tsx
+++ b/static/app/utils/replays/getCurrentScreenName.spec.tsx
@@ -36,12 +36,17 @@ const [NAV_FRAME_1, NAV_FRAME_2] = hydrateBreadcrumbs(
 describe('getCurrentScreenName', () => {
   it('should return the screen name based on the closest navigation crumb', () => {
     const frames = [PAGELOAD_FRAME, NAV_FRAME_1, NAV_FRAME_2];
-    const offsetMS = Number(NAVIGATION_DATE_1) - Number(START_DATE) + 3;
-    const screenName = getCurrentScreenName(frames, offsetMS);
-    expect(screenName).toBe('MainActivityScreen');
 
-    const offsetMS2 = Number(NAVIGATION_DATE_2) - Number(START_DATE) + 1;
+    const offsetMS = 1; // at the beginning
+    const screenName = getCurrentScreenName(frames, offsetMS);
+    expect(screenName).toBe('');
+
+    const offsetMS2 = Number(NAVIGATION_DATE_1) - Number(START_DATE) + 3;
     const screenName2 = getCurrentScreenName(frames, offsetMS2);
-    expect(screenName2).toBe('ConfirmPayment');
+    expect(screenName2).toBe('MainActivityScreen');
+
+    const offsetMS3 = Number(NAVIGATION_DATE_2) - Number(START_DATE) + 1;
+    const screenName3 = getCurrentScreenName(frames, offsetMS3);
+    expect(screenName3).toBe('ConfirmPayment');
   });
 });

--- a/static/app/utils/replays/getCurrentScreenName.tsx
+++ b/static/app/utils/replays/getCurrentScreenName.tsx
@@ -14,7 +14,9 @@ function getCurrentScreenName(
     return '';
   }
 
-  return mostRecentFrame.data.to;
+  return 'data' in mostRecentFrame && 'to' in mostRecentFrame.data
+    ? mostRecentFrame.data.to
+    : '';
 }
 
 export default getCurrentScreenName;


### PR DESCRIPTION
fixes JAVASCRIPT-2SZ9
fixes JAVASCRIPT-2T0N

check for undefined properties before we attempt to access them. the replay init breadcrumb doesn't have `data.to`:

https://github.com/getsentry/sentry/blob/257a223719efcfc4d77e4440e3f3e30e88fbbf88/static/app/utils/replays/hydrateBreadcrumbs.tsx#L59-L70