### PR TITLE
feat(metrics): enable querying of metric tag values with multiple project ids when using new meta tables

### DIFF
--- a/src/sentry/snuba/metrics_layer/query.py
+++ b/src/sentry/snuba/metrics_layer/query.py
@@ -634,7 +634,7 @@ def _query_meta_table(
 
 def fetch_metric_tag_values(
     org_id: int,
-    project_id: int,
+    project_ids: list[int],
     use_case_id: UseCaseID,
     mri: str,
     tag_key: str,
@@ -662,7 +662,7 @@ def fetch_metric_tag_values(
     metric_id, tag_key_id = resolved
 
     conditions = [
-        Condition(Column("project_id"), Op.EQ, project_id),
+        Condition(Column("project_id"), Op.IN, project_ids),
         Condition(Column("metric_id"), Op.EQ, metric_id),
         Condition(Column("tag_key"), Op.EQ, tag_key_id),
         Condition(Column("timestamp"), Op.GTE, datetime.now(UTC) - timedelta(days=90)),
@@ -687,7 +687,6 @@ def fetch_metric_tag_values(
         query=tag_values_query,
         tenant_ids={
             "organization_id": org_id,
-            "project_id": project_id,
             "referrer": "generic_metrics_meta_tag_values",
         },
     )

--- a/tests/snuba/test_metrics_layer.py
+++ b/tests/snuba/test_metrics_layer.py
@@ -947,7 +947,7 @@ class MQLMetaTest(TestCase, BaseMetricsTestCase):
     def test_fetch_metric_tag_values(self) -> None:
         tag_values = fetch_metric_tag_values(
             self.org_id,
-            self.project.id,
+            [self.project.id],
             UseCaseID.TRANSACTIONS,
             "g:transactions/test_gauge@none",
             "transaction",
@@ -958,7 +958,7 @@ class MQLMetaTest(TestCase, BaseMetricsTestCase):
     def test_fetch_metric_tag_values_with_prefix(self) -> None:
         tag_values = fetch_metric_tag_values(
             self.org_id,
-            self.project.id,
+            [self.project.id],
             UseCaseID.TRANSACTIONS,
             "g:transactions/test_gauge@none",
             "status_code",
@@ -966,3 +966,27 @@ class MQLMetaTest(TestCase, BaseMetricsTestCase):
         )
         assert len(tag_values) == 1
         assert tag_values == ["500"]
+
+    def test_fetch_metric_tag_values_for_multiple_projects(self) -> None:
+        new_project = self.create_project(name="New Project")
+        self.store_metric(
+            self.org_id,
+            new_project.id,
+            "gauge",
+            "g:transactions/test_gauge@none",
+            {"status_code": "524"},
+            self.ts(self.hour_ago + timedelta(minutes=10)),
+            10,
+            UseCaseID.TRANSACTIONS,
+        )
+
+        tag_values = fetch_metric_tag_values(
+            self.org_id,
+            [self.project.id, new_project.id],
+            UseCaseID.TRANSACTIONS,
+            "g:transactions/test_gauge@none",
+            "status_code",
+            "5",
+        )
+        assert len(tag_values) == 2
+        assert tag_values == ["500", "524"]


### PR DESCRIPTION
The initial implementation of fetch_metric_tag_values that enables us to query the new metrics meta tables only allows for querying tag values for a single project id. This PR is intended to make it possible to provide a list that is then used in an IN statement in the query to prevent us having to make one request per queried project. 