### PR TITLE
feat(related_issues): Decouple endpoint

### DIFF
--- a/src/sentry/api/endpoints/issues/related_issues.py
+++ b/src/sentry/api/endpoints/issues/related_issues.py
@@ -6,7 +6,7 @@ from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.group import GroupEndpoint
 from sentry.issues.related import find_related_issues  # To be deprecated
-from sentry.issues.related import same_root_cause_analysis, trace_connected_analysis
+from sentry.issues.related import RELATED_ISSUES_ALGORITHMS
 from sentry.models.group import Group
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
 
@@ -40,8 +40,8 @@ class RelatedIssuesEndpoint(GroupEndpoint):
 
         if related_type in RELATED_ISSUES_ALGORITHMS:
             data, meta = RELATED_ISSUES_ALGORITHMS[related_type](group)
-            related_issues = [{"type": related_type, "data": data, "meta": meta}]
+            return Response({"type": related_type, "data": data, "meta": meta})
         else:
             # XXX: We will be deprecating this approach soon
             related_issues = find_related_issues(group)
-        return Response({"data": [related_set for related_set in related_issues]})
+            return Response({"data": [related_set for related_set in related_issues]})

--- a/src/sentry/api/endpoints/issues/related_issues.py
+++ b/src/sentry/api/endpoints/issues/related_issues.py
@@ -38,11 +38,8 @@ class RelatedIssuesEndpoint(GroupEndpoint):
         related_type = request.query_params.get("type")
         related_issues: list[dict[str, str | list[int] | dict[str, str]]] = []
 
-        if related_type == "same_root_cause":
-            data, meta = same_root_cause_analysis(group)
-            related_issues = [{"type": related_type, "data": data, "meta": meta}]
-        elif related_type == "trace_connected":
-            data, meta = trace_connected_analysis(group)
+        if related_type in RELATED_ISSUES_ALGORITHMS:
+            data, meta = RELATED_ISSUES_ALGORITHMS[related_type](group)
             related_issues = [{"type": related_type, "data": data, "meta": meta}]
         else:
             # XXX: We will be deprecating this approach soon

--- a/src/sentry/api/endpoints/issues/related_issues.py
+++ b/src/sentry/api/endpoints/issues/related_issues.py
@@ -5,7 +5,8 @@ from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.group import GroupEndpoint
-from sentry.issues.related import find_related_issues
+from sentry.issues.related import find_related_issues  # To be deprecated
+from sentry.issues.related import same_root_cause_analysis, trace_connected_analysis
 from sentry.models.group import Group
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
 
@@ -24,13 +25,26 @@ class RelatedIssuesEndpoint(GroupEndpoint):
     }
 
     # We get a Group object since the endpoint is /issues/{issue_id}/related-issues
-    def get(self, _: Request, group: Group) -> Response:
+    def get(self, request: Request, group: Group) -> Response:
         """
-        Retrieve related issues for an Issue
+        Retrieve related issues for a Group
         ````````````````````````````````````
         Related issues can be based on the same root cause or trace connected.
 
-        :pparam string group_id: the ID of the issue
+        :pparam Request request: the request object
+        :pparam Group group: the group object
         """
-        related_issues = find_related_issues(group)
+        # The type of related issues to retrieve. Can be either `same_root_cause` or `trace_connected`.
+        related_type = request.query_params.get("type")
+        related_issues: list[dict[str, str | list[int] | dict[str, str]]] = []
+
+        if related_type == "same_root_cause":
+            data, meta = same_root_cause_analysis(group)
+            related_issues = [{"type": related_type, "data": data, "meta": meta}]
+        elif related_type == "trace_connected":
+            data, meta = trace_connected_analysis(group)
+            related_issues = [{"type": related_type, "data": data, "meta": meta}]
+        else:
+            # XXX: We will be deprecating this approach soon
+            related_issues = find_related_issues(group)
         return Response({"data": [related_set for related_set in related_issues]})

--- a/src/sentry/issues/related/__init__.py
+++ b/src/sentry/issues/related/__init__.py
@@ -5,7 +5,7 @@ from sentry.models.group import Group
 from .same_root_cause import same_root_cause_analysis
 from .trace_connected import trace_connected_analysis
 
-__all__ = ["find_related_issues"]
+__all__ = ["find_related_issues", "same_root_cause_analysis", "trace_connected_analysis"]
 
 RELATED_ISSUES_ALGORITHMS = {
     "same_root_cause": same_root_cause_analysis,

--- a/tests/sentry/api/endpoints/issues/test_related_issues.py
+++ b/tests/sentry/api/endpoints/issues/test_related_issues.py
@@ -40,15 +40,12 @@ class RelatedIssuesTest(APITestCase, SnubaTestCase, TraceTestCase):
         for datum in groups_data:
             self.create_group(data=datum)
 
-        response = self.get_success_response()
+        response = self.get_success_response(qs_params={"type": "same_root_cause"})
         # The UI will then make normal calls to get issues-stats
         # For instance, this URL
         # https://us.sentry.io/api/0/organizations/sentry/issues-stats/?groups=4741828952&groups=4489703641&statsPeriod=24h
         assert response.json() == {
-            "data": [
-                {"type": "same_root_cause", "data": [5], "meta": {}},
-                {"type": "trace_connected", "data": [], "meta": {}},
-            ],
+            "data": [{"type": "same_root_cause", "data": [5], "meta": {}}],
         }
 
     def test_trace_connected_errors(self) -> None:
@@ -62,10 +59,9 @@ class RelatedIssuesTest(APITestCase, SnubaTestCase, TraceTestCase):
         assert error_event.project.id != another_proj_event.project.id
         assert error_event.trace_id == another_proj_event.trace_id
 
-        response = self.get_success_response()
+        response = self.get_success_response(qs_params={"type": "trace_connected"})
         assert response.json() == {
             "data": [
-                {"type": "same_root_cause", "data": [], "meta": {}},
                 {
                     "type": "trace_connected",
                     # This is the other issue in the trace that it is not itself

--- a/tests/sentry/api/endpoints/issues/test_related_issues.py
+++ b/tests/sentry/api/endpoints/issues/test_related_issues.py
@@ -44,9 +44,7 @@ class RelatedIssuesTest(APITestCase, SnubaTestCase, TraceTestCase):
         # The UI will then make normal calls to get issues-stats
         # For instance, this URL
         # https://us.sentry.io/api/0/organizations/sentry/issues-stats/?groups=4741828952&groups=4489703641&statsPeriod=24h
-        assert response.json() == {
-            "data": [{"type": "same_root_cause", "data": [5], "meta": {}}],
-        }
+        assert response.json() == {"type": "same_root_cause", "data": [5], "meta": {}}
 
     def test_trace_connected_errors(self) -> None:
         error_event, _, another_proj_event = self.load_errors(self.project, uuid4().hex[:16])
@@ -61,15 +59,8 @@ class RelatedIssuesTest(APITestCase, SnubaTestCase, TraceTestCase):
 
         response = self.get_success_response(qs_params={"type": "trace_connected"})
         assert response.json() == {
-            "data": [
-                {
-                    "type": "trace_connected",
-                    # This is the other issue in the trace that it is not itself
-                    "data": [another_proj_event.group_id],
-                    "meta": {
-                        "event_id": recommended_event.event_id,
-                        "trace_id": error_event.trace_id,
-                    },
-                },
-            ]
+            "type": "trace_connected",
+            # This is the other issue in the trace that it is not itself
+            "data": [another_proj_event.group_id],
+            "meta": {"event_id": recommended_event.event_id, "trace_id": error_event.trace_id},
         }


### PR DESCRIPTION
The API tries to find issues for both approaches sequentially (slower), making it harder to iterate on each approach independently.

This change allows using a `type` parameter with the endpoint to execute one approach or the other.

The UI will be changed to make two independent requests, thus, improving load time.

This is required to empower trace issues from the issues details page.