### PR TITLE
ref(crons): Move timezone to schedule text

### DIFF
--- a/static/app/views/monitors/components/detailsSidebar.tsx
+++ b/static/app/views/monitors/components/detailsSidebar.tsx
@@ -66,7 +66,10 @@ export default function DetailsSidebar({monitorEnv, monitor}: Props) {
       </CheckIns>
       <SectionHeading>{t('Schedule')}</SectionHeading>
       <Schedule>
-        <Text>{scheduleAsText(monitor.config)}</Text>
+        <Text>
+          {scheduleAsText(monitor.config)}{' '}
+          {schedule_type === ScheduleType.CRONTAB && `(${timezone})`}
+        </Text>
         {schedule_type === ScheduleType.CRONTAB && (
           <CrontabText>({schedule})</CrontabText>
         )}
@@ -93,9 +96,6 @@ export default function DetailsSidebar({monitorEnv, monitor}: Props) {
       <SectionHeading>{t('Cron Details')}</SectionHeading>
       <KeyValueTable>
         <KeyValueTableRow keyName={t('Monitor Slug')} value={slug} />
-        {schedule_type === ScheduleType.CRONTAB && (
-          <KeyValueTableRow keyName={t('Timezone')} value={timezone} />
-        )}
         <KeyValueTableRow
           keyName={t('Owner')}
           value={


### PR DESCRIPTION
<img width="295" alt="image" src="https://github.com/getsentry/sentry/assets/1421724/fd919e5b-0dd6-4b41-8e84-d3b99dfe6042">

It is now next to the schedule. This is more logical