### PR TITLE
fix(metrics): Add missing 'return' statement in <WidgetDetails />

### DIFF
--- a/static/app/views/metrics/widgetDetails.tsx
+++ b/static/app/views/metrics/widgetDetails.tsx
@@ -52,7 +52,7 @@ export function WidgetDetails() {
 
   // TODO(aknaus): better fallback
   if (selectedWidget?.type === MetricExpressionType.EQUATION) {
-    <MetricDetails onRowHover={handleSampleRowHover} focusArea={focusArea} />;
+    return <MetricDetails onRowHover={handleSampleRowHover} focusArea={focusArea} />;
   }
 
   const {mri, op, query, focusedSeries} = selectedWidget as MetricsQueryWidget;


### PR DESCRIPTION
# Goal

The goal of this PR is to add a missing `return` statement in the rendering logic of the `<WidgetDetails />` component defined in `static/app/views/metrics`:

https://github.com/getsentry/sentry/blob/6b530ffab46d0b50512f0f4c9df8d084c1feb831/static/app/views/metrics/widgetDetails.tsx#L54-L56

This `return` was most likely forgotten when writing this piece of code. This probably doesn't result in any bug: by incorrectly continuing the rendering function, we end up also rendering a `<MetricDetails />` component with `undefined` `mri`, `op` and `query`.

The code makes more sense with the `return` statement though.

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
