### PR TITLE
feat(metrics): Open metrics explorer in traces explorer

### DIFF
--- a/static/app/views/performance/traces/content.tsx
+++ b/static/app/views/performance/traces/content.tsx
@@ -3,6 +3,7 @@ import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 import debounce from 'lodash/debounce';
 
+import {Alert} from 'sentry/components/alert';
 import {Button} from 'sentry/components/button';
 import Count from 'sentry/components/count';
 import EmptyStateWarning from 'sentry/components/emptyStateWarning';
@@ -18,12 +19,12 @@ import PanelHeader from 'sentry/components/panels/panelHeader';
 import PanelItem from 'sentry/components/panels/panelItem';
 import PerformanceDuration from 'sentry/components/performanceDuration';
 import {IconChevron} from 'sentry/icons/iconChevron';
-import {t} from 'sentry/locale';
+import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {PageFilters} from 'sentry/types/core';
 import {browserHistory} from 'sentry/utils/browserHistory';
 import {useApiQuery} from 'sentry/utils/queryClient';
-import {decodeInteger, decodeList} from 'sentry/utils/queryString';
+import {decodeInteger, decodeList, decodeScalar} from 'sentry/utils/queryString';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
@@ -54,6 +55,10 @@ export function Content() {
   const limit = useMemo(() => {
     return decodeInteger(location.query.perPage, DEFAULT_PER_PAGE);
   }, [location.query.perPage]);
+
+  const metricsOp = decodeScalar(location.query.metricsOp);
+  const mri = decodeScalar(location.query.mri);
+  const metricsQuery = decodeScalar(location.query.metricsQuery);
 
   const handleSearch = useCallback(
     (searchIndex: number, searchQuery: string) => {
@@ -95,6 +100,8 @@ export function Content() {
     [location, queries]
   );
 
+  const hasMetric = metricsOp && mri;
+
   const traces = useTraces<Field>({
     fields: [
       ...FIELDS,
@@ -105,6 +112,8 @@ export function Content() {
     limit,
     query: queries,
     sort: SORTS,
+    mri: hasMetric ? mri : undefined,
+    metricsQuery: hasMetric ? metricsQuery : undefined,
   });
 
   const isLoading = traces.isFetching;
@@ -119,6 +128,13 @@ export function Content() {
         <EnvironmentPageFilter />
         <DatePageFilter defaultPeriod="2h" />
       </PageFilterBar>
+      {hasMetric && (
+        <StyledAlert type="info" showIcon>
+          {tct('The metric query [metricQuery] is filtering the results below.', {
+            metricQuery: <strong>{`${metricsOp}(${mri}){${metricsQuery || ''}}`}</strong>,
+          })}
+        </StyledAlert>
+      )}
       <TracesSearchBar
         queries={queries}
         handleSearch={handleSearch}
@@ -386,6 +402,8 @@ interface UseTracesOptions<F extends string> {
   datetime?: PageFilters['datetime'];
   enabled?: boolean;
   limit?: number;
+  metricsQuery?: string;
+  mri?: string;
   query?: string | string[];
   sort?: string[];
   suggestedQuery?: string;
@@ -396,6 +414,8 @@ function useTraces<F extends string>({
   datetime,
   enabled,
   limit,
+  mri,
+  metricsQuery,
   query,
   suggestedQuery,
   sort,
@@ -415,7 +435,9 @@ function useTraces<F extends string>({
       suggestedQuery,
       sort,
       per_page: limit,
-      maxSpansPerTrace: 10,
+      maxSpansPerTrace: 5,
+      mri,
+      metricsQuery,
     },
   };
 
@@ -518,4 +540,8 @@ const BreakdownPanelItem = styled(StyledPanelItem)<{highlightedSliceName: string
 
 const EmptyValueContainer = styled('span')`
   color: ${p => p.theme.gray300};
+`;
+
+const StyledAlert = styled(Alert)`
+  margin-bottom: 0;
 `;

--- a/static/app/views/performance/traces/utils.tsx
+++ b/static/app/views/performance/traces/utils.tsx
@@ -1,3 +1,7 @@
+import type {Location, LocationDescriptor} from 'history';
+
+import type {Organization} from 'sentry/types/organization';
+
 import type {SpanResult, TraceResult} from './content';
 import type {Field} from './data';
 
@@ -25,4 +29,36 @@ export function getStylingSliceName(
 
 export function getSecondaryNameFromSpan(span: SpanResult<Field>) {
   return span['sdk.name'];
+}
+
+export function generateTracesRoute({orgSlug}: {orgSlug: Organization['slug']}): string {
+  return `/organizations/${orgSlug}/performance/traces/`;
+}
+
+export function generateTracesRouteWithQuery({
+  orgSlug,
+  metric,
+  query,
+}: {
+  orgSlug: Organization['slug'];
+  metric?: {
+    metricsOp: string;
+    mri: string;
+    metricsQuery?: string;
+  };
+  query?: Location['query'];
+}): LocationDescriptor {
+  const {metricsOp, metricsQuery, mri} = metric || {};
+
+  const pathname = generateTracesRoute({orgSlug});
+
+  return {
+    pathname,
+    query: {
+      ...query,
+      metricsOp,
+      metricsQuery,
+      mri,
+    },
+  };
 }


### PR DESCRIPTION
This adds an open in trace explorer button in the metrics page. There's still a few bugs where the traces explorer errors in some cases but this button is behind a feature flag to test.