### PR TITLE
feat(cache): plot and highlight transaction samples

### DIFF
--- a/static/app/views/performance/cache/samplePanel/charts/transactionDurationChart.tsx
+++ b/static/app/views/performance/cache/samplePanel/charts/transactionDurationChart.tsx
@@ -1,16 +1,31 @@
+import type {EChartHighlightHandler} from 'sentry/types/echarts';
 import {decodeScalar} from 'sentry/utils/queryString';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import useLocationQuery from 'sentry/utils/url/useLocationQuery';
 import {Referrer} from 'sentry/views/performance/cache/referrers';
 import {CHART_HEIGHT} from 'sentry/views/performance/cache/settings';
+import type {DataRow} from 'sentry/views/performance/cache/tables/spanSamplesTable';
 import {AVG_COLOR} from 'sentry/views/starfish/colors';
 import Chart, {ChartType} from 'sentry/views/starfish/components/chart';
 import ChartPanel from 'sentry/views/starfish/components/chartPanel';
 import {useMetricsSeries} from 'sentry/views/starfish/queries/useDiscoverSeries';
 import type {MetricsQueryFilters} from 'sentry/views/starfish/types';
 import {DataTitles} from 'sentry/views/starfish/views/spans/types';
+import {useSampleScatterPlotSeries} from 'sentry/views/starfish/views/spanSummaryPage/sampleList/durationChart/useSampleScatterPlotSeries';
 
-export function TransactionDurationChart() {
+type Props = {
+  averageTransactionDuration: number;
+  onHighlight: EChartHighlightHandler;
+  samples: DataRow[];
+  highlightedSpanId?: string;
+};
+
+export function TransactionDurationChart({
+  samples,
+  averageTransactionDuration,
+  onHighlight,
+  highlightedSpanId,
+}: Props) {
   const {transaction} = useLocationQuery({
     fields: {
       project: decodeScalar,
@@ -28,6 +43,33 @@ export function TransactionDurationChart() {
     referrer: Referrer.SAMPLES_CACHE_TRANSACTION_DURATION,
   });
 
+  const sampledSpanDataSeries = useSampleScatterPlotSeries(
+    samples,
+    averageTransactionDuration,
+    highlightedSpanId,
+    'transaction.duration'
+  );
+
+  // TODO: This is duplicated from `DurationChart` in `SampleList`. Resolve the duplication
+  const handleChartHighlight: EChartHighlightHandler = function (event) {
+    // TODO: Gross hack. Even though `scatterPlot` is a separate prop, it's just an array of `Series` that gets appended to the main series. To find the point that was hovered, we re-construct the correct series order. It would have been cleaner to just pass the scatter plot as its own, single series
+    const allSeries = [
+      data['avg(transaction.duration)'],
+      ...(sampledSpanDataSeries ?? []),
+    ];
+
+    const highlightedDataPoints = event.batch.map(batch => {
+      const {seriesIndex, dataIndex} = batch;
+
+      const highlightedSeries = allSeries?.[seriesIndex];
+      const highlightedDataPoint = highlightedSeries.data?.[dataIndex];
+
+      return {series: highlightedSeries, dataPoint: highlightedDataPoint};
+    });
+
+    onHighlight?.(highlightedDataPoints, event);
+  };
+
   return (
     <ChartPanel title={DataTitles.transactionDuration}>
       <Chart
@@ -38,8 +80,10 @@ export function TransactionDurationChart() {
           top: '8px',
           bottom: '0',
         }}
+        scatterPlot={sampledSpanDataSeries}
         data={[data['avg(transaction.duration)']]}
         loading={isLoading}
+        onHighlight={handleChartHighlight}
         chartColors={[AVG_COLOR]}
         type={ChartType.LINE}
       />

--- a/static/app/views/performance/cache/samplePanel/samplePanel.tsx
+++ b/static/app/views/performance/cache/samplePanel/samplePanel.tsx
@@ -287,6 +287,8 @@ export function CacheSamplePanel() {
                 }}
                 isLoading={isCacheSpanSamplesFetching || isFetchingTransactions}
                 highlightedSpanId={highlightedSpanId}
+                onSampleMouseOver={sample => setHighlightedSpanId(sample.span_id)}
+                onSampleMouseOut={() => setHighlightedSpanId(undefined)}
                 error={transactionError}
               />
             </ModuleLayout.Full>

--- a/static/app/views/performance/cache/tables/spanSamplesTable.tsx
+++ b/static/app/views/performance/cache/tables/spanSamplesTable.tsx
@@ -35,7 +35,9 @@ type ColumnKeys =
   | SpanIndexedField.CACHE_ITEM_SIZE
   | 'transaction.duration';
 
-type DataRow = Pick<IndexedResponse, DataRowKeys> & {'transaction.duration': number};
+export type DataRow = Pick<IndexedResponse, DataRowKeys> & {
+  'transaction.duration': number;
+};
 
 type Column = GridColumnHeader<ColumnKeys>;
 

--- a/static/app/views/performance/http/data/useSpanSamples.tsx
+++ b/static/app/views/performance/http/data/useSpanSamples.tsx
@@ -58,6 +58,7 @@ export const useSpanSamples = <Fields extends IndexedProperty[]>(
           | SpanIndexedField.TIMESTAMP
           | SpanIndexedField.ID
           | SpanIndexedField.PROFILE_ID
+          | SpanIndexedField.SPAN_SELF_TIME
         >[]
       // This type is a little awkward but it explicitly states that the response could be empty. This doesn't enable unchecked access errors, but it at least indicates that it's possible that there's no data
       // eslint-disable-next-line @typescript-eslint/ban-types

--- a/static/app/views/performance/http/httpSamplesPanel.tsx
+++ b/static/app/views/performance/http/httpSamplesPanel.tsx
@@ -49,6 +49,7 @@ import {
   SpanMetricsField,
   type SpanMetricsQueryFilters,
 } from 'sentry/views/starfish/types';
+import {findSampleFromDataPoint} from 'sentry/views/starfish/utils/chart/findDataPoint';
 import {DataTitles, getThroughputTitle} from 'sentry/views/starfish/views/spans/types';
 import {useSampleScatterPlotSeries} from 'sentry/views/starfish/views/spanSummaryPage/sampleList/durationChart/useSampleScatterPlotSeries';
 
@@ -242,12 +243,6 @@ export function HTTPSamplesPanel() {
     highlightedSpanId
   );
 
-  const findSampleFromDataPoint = (dataPoint: {name: string | number; value: number}) => {
-    return durationSamplesData.find(
-      s => s.timestamp === dataPoint.name && s['span.self_time'] === dataPoint.value
-    );
-  };
-
   const handleClose = () => {
     router.replace({
       pathname: router.location.pathname,
@@ -402,7 +397,14 @@ export function HTTPSamplesPanel() {
                       return;
                     }
 
-                    const sample = findSampleFromDataPoint(firstHighlight.dataPoint);
+                    const sample = findSampleFromDataPoint<
+                      (typeof durationSamplesData)[0]
+                    >(
+                      firstHighlight.dataPoint,
+                      durationSamplesData,
+                      SpanIndexedField.SPAN_SELF_TIME
+                    );
+
                     setHighlightedSpanId(sample?.span_id);
                   }}
                   isLoading={isDurationDataFetching}

--- a/static/app/views/starfish/utils/chart/findDataPoint.ts
+++ b/static/app/views/starfish/utils/chart/findDataPoint.ts
@@ -1,0 +1,9 @@
+export function findSampleFromDataPoint<T extends {timestamp: string}>(
+  dataPoint: {name: string | number; value: number},
+  data: T[],
+  matchKey: keyof T
+) {
+  return data?.find(
+    s => s.timestamp === dataPoint.name && s[matchKey] === dataPoint.value
+  );
+}

--- a/static/app/views/starfish/views/spanSummaryPage/sampleList/durationChart/useSampleScatterPlotSeries.tsx
+++ b/static/app/views/starfish/views/spanSummaryPage/sampleList/durationChart/useSampleScatterPlotSeries.tsx
@@ -12,15 +12,16 @@ import {getSampleChartSymbol} from 'sentry/views/starfish/views/spanSummaryPage/
 export function useSampleScatterPlotSeries(
   spans: Partial<IndexedResponse>[],
   average?: number,
-  highlightedSpanId?: string
+  highlightedSpanId?: string,
+  key: string = 'span.self_time'
 ): Series[] {
   const theme = useTheme();
 
   return spans.map(span => {
     let symbol, color;
 
-    if (span['span.self_time'] && defined(average)) {
-      ({symbol, color} = getSampleChartSymbol(span['span.self_time'], average, theme));
+    if (span[key] && defined(average)) {
+      ({symbol, color} = getSampleChartSymbol(span[key], average, theme));
     } else {
       symbol = 'circle';
       color = AVG_COLOR;
@@ -30,7 +31,7 @@ export function useSampleScatterPlotSeries(
       data: [
         {
           name: span?.timestamp ?? span.span_id ?? t('Span'),
-          value: span?.['span.self_time'] ?? 0,
+          value: span?.[key] ?? 0,
         },
       ],
       symbol,


### PR DESCRIPTION
1. plots the transaction samples on the cache sidebar
2. Allows samples to be highlighted (similar to other starfish modules)

<img width="611" alt="image" src="https://github.com/getsentry/sentry/assets/44422760/5195ce1d-800e-4b69-bd75-708707ff666a">
