### PR TITLE
feat(slack): Add support for external issue creation

### DIFF
--- a/src/sentry/integrations/slack/service.py
+++ b/src/sentry/integrations/slack/service.py
@@ -8,7 +8,10 @@ from sentry.integrations.repository.issue_alert import (
     IssueAlertNotificationMessageRepository,
 )
 from sentry.integrations.slack import BlockSlackMessageBuilder, SlackClient
-from sentry.integrations.slack.threads.activity_notifications import AssignedActivityNotification
+from sentry.integrations.slack.threads.activity_notifications import (
+    AssignedActivityNotification,
+    ExternalIssueCreatedActivityNotification,
+)
 from sentry.integrations.utils.common import get_active_integration_for_organization
 from sentry.models.activity import Activity
 from sentry.models.rule import Rule
@@ -45,6 +48,7 @@ DEFAULT_SUPPORTED_ACTIVITY_THREAD_NOTIFICATION_HANDLERS: dict[
     ActivityType.SET_ESCALATING: EscalatingActivityNotification,
     ActivityType.SET_IGNORED: ArchiveActivityNotification,
     ActivityType.SET_UNRESOLVED: UnresolvedActivityNotification,
+    ActivityType.CREATE_ISSUE: ExternalIssueCreatedActivityNotification,
 }
 
 

--- a/src/sentry/integrations/slack/threads/activity_notifications.py
+++ b/src/sentry/integrations/slack/threads/activity_notifications.py
@@ -1,9 +1,16 @@
+import logging
 from collections.abc import Mapping
 from typing import Any
 
+from sentry.models.activity import Activity
 from sentry.notifications.notifications.activity.assigned import (
     AssignedActivityNotification as BaseAssignedActivityNotification,
 )
+from sentry.notifications.notifications.activity.base import GroupActivityNotification
+from sentry.types.activity import ActivityType
+from sentry.utils import metrics
+
+_default_logger = logging.getLogger(__name__)
 
 
 class AssignedActivityNotification(BaseAssignedActivityNotification):
@@ -15,3 +22,185 @@ class AssignedActivityNotification(BaseAssignedActivityNotification):
 
     def get_description(self) -> tuple[str, str | None, Mapping[str, Any]]:
         return "{author} assigned this issue to {assignee}", None, {"assignee": self.get_assignee()}
+
+
+class _ExternalIssueCreatedActivity:
+    """
+    Class responsible for helping derive data from a specific activity type
+    """
+
+    _NO_PROVIDER_KEY_METRICS = "sentry.integrations.slack.tasks.activity_notifications.external_issue_created_activity.missing_provider"
+    _NO_LINK_KEY_METRICS = "sentry.integrations.slack.tasks.activity_notifications.external_issue_created_activity.missing_link"
+    _NO_LABEL_KEY_METRICS = "sentry.integrations.slack.tasks.activity_notifications.external_issue_created_activity.missing_label"
+
+    DEFAULT_PROVIDER_FALLBACK_TEXT = "external provider"
+    _PROVIDER_KEY = "provider"
+    _TICKET_KEY = "label"
+    _URL_KEY = "location"
+
+    def __init__(self, activity: Activity) -> None:
+        try:
+            activity_type: ActivityType = ActivityType(activity.type)
+        except ValueError as err:
+            _default_logger.info(
+                "there was an error trying to get activity type, assuming activity is unsupported",
+                exc_info=err,
+                extra={
+                    "error": str(err),
+                    "activity_id": activity.id,
+                    "activity_type_raw": activity.type,
+                },
+            )
+            raise
+
+        if activity_type != ActivityType.CREATE_ISSUE:
+            _default_logger.info(
+                "tried to use external issue creator for an improper activity type",
+                extra={
+                    "activity_id": activity.id,
+                    "activity_type_raw": activity.type,
+                    "activity_type": activity_type,
+                },
+            )
+
+            raise Exception(f"Activity type {activity_type} is incorrect")
+        self._activity: Activity = activity
+
+    def get_link(self) -> str:
+        """
+        Returns the link to where the issue was created in the external provider.
+        """
+        link = self._activity.data.get(self._URL_KEY, None)
+        if not link:
+            metrics.incr(
+                self._NO_LINK_KEY_METRICS,
+                sample_rate=1.0,
+            )
+
+            _default_logger.info(
+                "Activity does not have a url key, using fallback",
+                extra={
+                    "activity_id": self._activity.id,
+                },
+            )
+            link = ""
+        return link
+
+    def get_provider(self) -> str:
+        """
+        Returns the provider of the activity for where the issue was created.
+        Returns the value in lowercase to provider consistent value.
+        If key is not found, or value is empty, uses the fallback value.
+        """
+        provider = self._activity.data.get(self._PROVIDER_KEY, None)
+        if not provider:
+            metrics.incr(
+                self._NO_PROVIDER_KEY_METRICS,
+                sample_rate=1.0,
+            )
+            _default_logger.info(
+                "Activity does not have a provider key, using fallback",
+                extra={
+                    "activity_id": self._activity.id,
+                },
+            )
+            provider = self.DEFAULT_PROVIDER_FALLBACK_TEXT
+
+        return provider.lower()
+
+    def get_ticket_number(self) -> str:
+        """
+        Returns the ticket number for the issue that was created on the external provider.
+        """
+        ticket_number = self._activity.data.get(self._TICKET_KEY, None)
+        if not ticket_number:
+            metrics.incr(
+                self._NO_LABEL_KEY_METRICS,
+                sample_rate=1.0,
+            )
+            _default_logger.info(
+                "Activity does not have a label key, using fallback",
+                extra={
+                    "activity_id": self._activity.id,
+                },
+            )
+            ticket_number = ""
+
+        return ticket_number
+
+
+class _AsanaExternalIssueCreatedActivity(_ExternalIssueCreatedActivity):
+    """
+    Override class for Asana as, at this time, the label, or ticket number, does not exist and has to be derived.
+    If plausible, this could be removed if the activity object itself properly has the correct data, but side effects
+    for that change are not yet known.
+    """
+
+    _DEFAULT_ASANA_LABEL_VALUE = "Asana Issue"
+
+    def get_ticket_number(self) -> str:
+        # Try to use the base logic if it works as a just in-case
+        stored_value = super().get_ticket_number()
+        if stored_value != "" and stored_value != self._DEFAULT_ASANA_LABEL_VALUE:
+            return stored_value
+
+        link = self.get_link()
+        if not link:
+            return ""
+
+        # Remove any trailing slashes
+        if link.endswith("/"):
+            link = link[:-1]
+
+        # Split the URL by "/"
+        parts = link.split("/")
+
+        # Get the last part
+        last_part = parts[-1]
+
+        return last_part
+
+
+def _external_issue_activity_factory(activity: Activity) -> _ExternalIssueCreatedActivity:
+    """
+    Returns the correct ExternalIssueCreatedActivity class based on the provider.
+    All classes have the same interface, the method for one is simply modified for its use case.
+    """
+    base_activity = _ExternalIssueCreatedActivity(activity=activity)
+    provider = base_activity.get_provider()
+    if provider == "asana":
+        return _AsanaExternalIssueCreatedActivity(activity=activity)
+
+    return base_activity
+
+
+class ExternalIssueCreatedActivityNotification(GroupActivityNotification):
+    metrics_key = "create_issue"
+    title = "External Issue Created"
+
+    def get_description(self) -> tuple[str, str | None, Mapping[str, Any]]:
+        external_issue = _external_issue_activity_factory(activity=self.activity)
+
+        provider = external_issue.get_provider()
+        # Use proper grammar, so use "an" if it's "external provider" and "a" if it's a regular name
+        if provider == external_issue.DEFAULT_PROVIDER_FALLBACK_TEXT:
+            base_template = "an "
+        else:
+            base_template = "a "
+            # Make sure to make the proper noun have correct capitalization
+            # I.e. github -> Github, jira -> Jira
+            provider = provider.capitalize()
+        base_template += "{provider} issue"
+
+        ticket_number = external_issue.get_ticket_number()
+        if ticket_number:
+            base_template += " {ticket}"
+
+        link = external_issue.get_link()
+        if link:
+            base_template = "<{link}|" + base_template + ">"
+
+        # Template should look something like "{author} created <{link}| a/an {provider} issue {ticket}>"
+        base_template = "{author} created " + base_template
+
+        return base_template, None, {"provider": provider, "ticket": ticket_number, "link": link}

--- a/tests/sentry/integrations/slack/threads/activity_notifications/__init__.py
+++ b/tests/sentry/integrations/slack/threads/activity_notifications/__init__.py
@@ -1,0 +1,7 @@
+from sentry.testutils.cases import TestCase
+from sentry.types.activity import ActivityType
+
+
+class BaseTestCase(TestCase):
+    def setUp(self) -> None:
+        self.activity.type = ActivityType.CREATE_ISSUE

--- a/tests/sentry/integrations/slack/threads/activity_notifications/test_asana_external_issue_created_activity.py
+++ b/tests/sentry/integrations/slack/threads/activity_notifications/test_asana_external_issue_created_activity.py
@@ -1,0 +1,49 @@
+from sentry.integrations.slack.threads.activity_notifications import (
+    _AsanaExternalIssueCreatedActivity,
+)
+from tests.sentry.integrations.slack.threads.activity_notifications import BaseTestCase
+
+
+class TestGetTicketNumber(BaseTestCase):
+    def test_returns_base_value_when_exists(self) -> None:
+        ticket_number_value = "ABC-123"
+        self.activity.data = {"label": ticket_number_value}
+
+        create_issue_activity = _AsanaExternalIssueCreatedActivity(self.activity)
+        ret = create_issue_activity.get_ticket_number()
+
+        assert ret == ticket_number_value
+
+    def test_returns_empty_with_no_link(self) -> None:
+        self.activity.data = {"label": "Asana Issue"}
+        create_issue_activity = _AsanaExternalIssueCreatedActivity(self.activity)
+
+        ret = create_issue_activity.get_ticket_number()
+        assert ret == ""
+
+    def test_returns_last_part_of_link(self) -> None:
+        last_part = "ABC-123"
+        self.activity.data = {"location": f"www.example.com/{last_part}"}
+
+        create_issue_activity = _AsanaExternalIssueCreatedActivity(self.activity)
+        ret = create_issue_activity.get_ticket_number()
+
+        assert ret == last_part
+
+    def test_returns_last_part_of_link_with_multiple_slashes(self) -> None:
+        last_part = "ABC-123"
+        self.activity.data = {"location": f"www.example.com/abc/something/whatever/{last_part}"}
+
+        create_issue_activity = _AsanaExternalIssueCreatedActivity(self.activity)
+        ret = create_issue_activity.get_ticket_number()
+
+        assert ret == last_part
+
+    def test_accounts_for_trailing_slash(self) -> None:
+        last_part = "ABC-123"
+        self.activity.data = {"location": f"www.example.com/{last_part}/"}
+
+        create_issue_activity = _AsanaExternalIssueCreatedActivity(self.activity)
+        ret = create_issue_activity.get_ticket_number()
+
+        assert ret == last_part

--- a/tests/sentry/integrations/slack/threads/activity_notifications/test_external_issue_created_activity.py
+++ b/tests/sentry/integrations/slack/threads/activity_notifications/test_external_issue_created_activity.py
@@ -1,0 +1,107 @@
+import pytest
+
+from sentry.integrations.slack.threads.activity_notifications import _ExternalIssueCreatedActivity
+from sentry.testutils.cases import TestCase
+from sentry.types.activity import ActivityType
+from tests.sentry.integrations.slack.threads.activity_notifications import BaseTestCase
+
+
+class TestInit(TestCase):
+    def test_throws_error_on_invalid_activity_type(self) -> None:
+        with pytest.raises(Exception):
+            self.activity.type = 500
+            _ExternalIssueCreatedActivity(self.activity)
+
+    def test_throws_error_on_unsupported_activity_type(self) -> None:
+        with pytest.raises(Exception):
+            self.activity.type = ActivityType.ASSIGNED
+            _ExternalIssueCreatedActivity(self.activity)
+
+    def test_success(self) -> None:
+        self.activity.type = ActivityType.CREATE_ISSUE
+        obj = _ExternalIssueCreatedActivity(self.activity)
+        assert obj is not None
+
+
+class TestGetLink(BaseTestCase):
+    def test_when_link_key_is_not_in_map(self) -> None:
+        self.activity.data = {}
+        create_issue_activity = _ExternalIssueCreatedActivity(self.activity)
+
+        ret = create_issue_activity.get_link()
+        assert ret == ""
+
+    def test_when_link_key_is_empty(self) -> None:
+        self.activity.data = {"location": None}
+        create_issue_activity = _ExternalIssueCreatedActivity(self.activity)
+
+        ret = create_issue_activity.get_link()
+        assert ret == ""
+
+    def test_returns_correct_value(self) -> None:
+        link_value = "www.example.com"
+        self.activity.data = {"location": link_value}
+
+        create_issue_activity = _ExternalIssueCreatedActivity(self.activity)
+        ret = create_issue_activity.get_link()
+
+        assert ret == link_value
+
+
+class TestGetProvider(BaseTestCase):
+    def test_returns_fallback_when_provider_key_is_not_in_map(self) -> None:
+        self.activity.data = {}
+        create_issue_activity = _ExternalIssueCreatedActivity(self.activity)
+
+        ret = create_issue_activity.get_provider()
+        assert ret == create_issue_activity.DEFAULT_PROVIDER_FALLBACK_TEXT
+
+    def test_returns_fallback_when_provider_key_is_empty(self) -> None:
+        self.activity.data = {"provider": None}
+        create_issue_activity = _ExternalIssueCreatedActivity(self.activity)
+
+        ret = create_issue_activity.get_provider()
+        assert ret == create_issue_activity.DEFAULT_PROVIDER_FALLBACK_TEXT
+
+    def test_returns_correct_value(self) -> None:
+        provider_value = "whatever"
+        self.activity.data = {"provider": provider_value}
+
+        create_issue_activity = _ExternalIssueCreatedActivity(self.activity)
+        ret = create_issue_activity.get_provider()
+
+        assert ret == provider_value
+
+    def test_returns_lowercase_value(self) -> None:
+        provider_value = "WHATEVER"
+        self.activity.data = {"provider": provider_value}
+
+        create_issue_activity = _ExternalIssueCreatedActivity(self.activity)
+        ret = create_issue_activity.get_provider()
+
+        assert ret == provider_value.lower()
+
+
+class TestGetTicketNumber(BaseTestCase):
+    def test_when_ticket_number_key_is_not_in_map(self) -> None:
+        self.activity.data = {}
+        create_issue_activity = _ExternalIssueCreatedActivity(self.activity)
+
+        ret = create_issue_activity.get_ticket_number()
+        assert ret == ""
+
+    def test_when_ticket_number_key_is_empty(self) -> None:
+        self.activity.data = {"label": None}
+        create_issue_activity = _ExternalIssueCreatedActivity(self.activity)
+
+        ret = create_issue_activity.get_ticket_number()
+        assert ret == ""
+
+    def test_returns_correct_value(self) -> None:
+        ticket_number_value = "ABC-123"
+        self.activity.data = {"label": ticket_number_value}
+
+        create_issue_activity = _ExternalIssueCreatedActivity(self.activity)
+        ret = create_issue_activity.get_ticket_number()
+
+        assert ret == ticket_number_value

--- a/tests/sentry/integrations/slack/threads/activity_notifications/test_external_issue_created_activity_notification.py
+++ b/tests/sentry/integrations/slack/threads/activity_notifications/test_external_issue_created_activity_notification.py
@@ -1,0 +1,62 @@
+from sentry.integrations.slack.threads.activity_notifications import (
+    ExternalIssueCreatedActivityNotification,
+)
+from tests.sentry.integrations.slack.threads.activity_notifications import BaseTestCase
+
+
+class TestGetDescription(BaseTestCase):
+    def test_basic_case(self) -> None:
+        provider = "Github"
+        label = "ABC-123"
+        location = "www.example.com"
+        self.activity.data = {"provider": provider, "label": label, "location": location}
+
+        notification = ExternalIssueCreatedActivityNotification(self.activity)
+        template, _, metadata = notification.get_description()
+
+        assert template == "{author} created <{link}|a {provider} issue {ticket}>"
+        assert metadata["provider"] == provider
+        assert metadata["ticket"] == label
+        assert metadata["link"] == location
+
+    def test_with_default_provider(self) -> None:
+        provider = ""
+        label = "ABC-123"
+        location = "www.example.com"
+        self.activity.data = {"provider": provider, "label": label, "location": location}
+
+        notification = ExternalIssueCreatedActivityNotification(self.activity)
+        template, _, metadata = notification.get_description()
+
+        assert template == "{author} created <{link}|an {provider} issue {ticket}>"
+        assert metadata["provider"] == "external provider"
+        assert metadata["ticket"] == label
+        assert metadata["link"] == location
+
+    def test_without_ticket_number(self) -> None:
+        provider = "Jira"
+        label = ""
+        location = "www.example.com"
+        self.activity.data = {"provider": provider, "label": label, "location": location}
+
+        notification = ExternalIssueCreatedActivityNotification(self.activity)
+        template, _, metadata = notification.get_description()
+
+        assert template == "{author} created <{link}|a {provider} issue>"
+        assert metadata["provider"] == provider
+        assert metadata["ticket"] == label
+        assert metadata["link"] == location
+
+    def test_without_link(self) -> None:
+        provider = "Jira"
+        label = "ABC-123"
+        location = ""
+        self.activity.data = {"provider": provider, "label": label, "location": location}
+
+        notification = ExternalIssueCreatedActivityNotification(self.activity)
+        template, _, metadata = notification.get_description()
+
+        assert template == "{author} created a {provider} issue {ticket}"
+        assert metadata["provider"] == provider
+        assert metadata["ticket"] == label
+        assert metadata["link"] == location


### PR DESCRIPTION
Add support for an external issue created activity event notification for Slack threads. To do this, we added a few classes that will parse the specific pieces of information we need, and added logging and metrics to track "bad state" activities, as we assume some data to always be there as a form of contract. Also added test cases to help validate logic and keep it consistent from breaking changes.

With the changes, we should now be able to create a slack notification that looks like the following:
```
<Author> created a (<Provider> issue <Ticket Number>)[Link]
```

Special consideration had to be done for Asana for now, and we might be able to remove that special consideration if we can update the activity data object when an asana issue is created, but the changes would need to be verified that it does not affect other assumptions/contracts.