### PR TITLE
fix(cache): right align value size header

### DIFF
--- a/static/app/views/starfish/components/tableCells/renderHeadCell.tsx
+++ b/static/app/views/starfish/components/tableCells/renderHeadCell.tsx
@@ -26,7 +26,6 @@ type Options = {
 const DEFAULT_SORT_PARAMETER_NAME = 'sort';
 
 const {SPAN_SELF_TIME, HTTP_RESPONSE_CONTENT_LENGTH, CACHE_ITEM_SIZE} = SpanMetricsField;
-const {RESPONSE_CODE, MESSAGING_MESSAGE_BODY_SIZE} = SpanIndexedField;
 const {
   TIME_SPENT_PERCENTAGE,
   SPS,
@@ -58,11 +57,12 @@ export const SORTABLE_FIELDS = new Set([
 ]);
 
 const NUMERIC_FIELDS = new Set([
-  `${RESPONSE_CODE}`,
-  CACHE_ITEM_SIZE,
   'transaction.duration',
+  SpanMetricsField.CACHE_ITEM_SIZE,
+  SpanIndexedField.RESPONSE_CODE,
   SpanIndexedField.SPAN_SELF_TIME,
-  MESSAGING_MESSAGE_BODY_SIZE,
+  SpanIndexedField.CACHE_ITEM_SIZE,
+  SpanIndexedField.MESSAGING_MESSAGE_BODY_SIZE,
 ]);
 
 export const renderHeadCell = ({column, location, sort, sortParameterName}: Options) => {


### PR DESCRIPTION
Right align value size in cache samples drawer and do a little bit of code consistency changes

<img width="598" alt="image" src="https://github.com/getsentry/sentry/assets/44422760/b7832a14-0060-4101-882c-71867aa891f3">
