### PR TITLE
feat(snub-heavy-search): adds exceptions to pre-fetch groupids from postgres under certain conditions

### DIFF
--- a/src/sentry/issues/endpoints/organization_group_index.py
+++ b/src/sentry/issues/endpoints/organization_group_index.py
@@ -51,9 +51,6 @@ allowed_inbox_search_terms = frozenset(["date", "status", "for_review", "assigne
 # these filters are currently not supported in the snuba only search
 # and will use PostgresSnubaQueryExecutor instead of GroupAttributesPostgresSnubaQueryExecutor
 UNSUPPORTED_SNUBA_FILTERS = [
-    "bookmarked_by",
-    "linked",
-    "subscribed_by",
     "regressed_in_release",
     "issue.priority",
     "firstRelease",

--- a/src/sentry/search/snuba/backend.py
+++ b/src/sentry/search/snuba/backend.py
@@ -35,6 +35,7 @@ from sentry.models.user import User
 from sentry.search.base import SearchBackend
 from sentry.search.events.constants import EQUALITY_OPERATORS, OPERATOR_TO_DJANGO
 from sentry.search.snuba.executors import (
+    POSTGRES_ONLY_SEARCH_FIELDS,
     AbstractQueryExecutor,
     InvalidQueryForExecutor,
     PostgresSnubaQueryExecutor,
@@ -493,16 +494,11 @@ class SnubaSearchBackendBase(SearchBackend, metaclass=ABCMeta):
             retention_window_start = None
 
         if use_group_snuba_dataset:
-            # just use the basic group initialization query which prevents us from
-            # returning groups that are pending deletion or merge
-            # this query is only used after we query snuba to filter out groups we don't want
-            group_queryset = Group.objects.filter(project__in=projects).exclude(
-                status__in=[
-                    GroupStatus.PENDING_DELETION,
-                    GroupStatus.DELETION_IN_PROGRESS,
-                    GroupStatus.PENDING_MERGE,
-                ]
-            )
+            # we need to handle two cases fo the group queryset:
+            # 1. Limit results to groups that are not pending deletion or merge
+            # 2. Handle queries snuba doesn't support such as bookmarked_by, linked, subscribed_by
+            # For the second case, we hit postgres before Snuba to get the group ids
+            group_queryset = self._build_limited_group_queryset(projects, search_filters)
 
         else:
             group_queryset = self._build_group_queryset(
@@ -592,6 +588,24 @@ class SnubaSearchBackendBase(SearchBackend, metaclass=ABCMeta):
             )
 
         return query_results
+
+    def _build_limited_group_queryset(
+        self, projects: Sequence[Project], search_filters: Sequence[SearchFilter]
+    ) -> QuerySet:
+        """
+        Builds a group queryset to handle joins for data that doesn't exist in Clickhouse on the group_attributes dataset
+        """
+        # Filter search_filters to only include 'bookmarked_by', 'linked', 'subscribed_by'
+        filtered_search_filters = [
+            sf for sf in search_filters if sf.key.name in POSTGRES_ONLY_SEARCH_FIELDS
+        ]
+        # Use the filtered search filters for further processing
+        return self._build_group_queryset(
+            projects=projects,
+            environments=None,
+            search_filters=filtered_search_filters,
+            retention_window_start=None,
+        )
 
     def _build_group_queryset(
         self,

--- a/src/sentry/search/snuba/executors.py
+++ b/src/sentry/search/snuba/executors.py
@@ -1586,9 +1586,15 @@ class GroupAttributesPostgresSnubaQueryExecutor(PostgresSnubaQueryExecutor):
                 if len(group_ids_to_pass_to_snuba) == 0:
                     return self.empty_result
 
-                where_conditions.append(
-                    Condition(Column("group_id", attr_entity), Op.IN, group_ids_to_pass_to_snuba)
-                )
+                # limit groups and events to the group ids
+                for entity_with_group_id in [attr_entity, joined_entity]:
+                    where_conditions.append(
+                        Condition(
+                            Column("group_id", entity_with_group_id),
+                            Op.IN,
+                            group_ids_to_pass_to_snuba,
+                        )
+                    )
 
             for search_filter in search_filters or ():
                 # use the stored function if it exists in our mapping, otherwise use the basic lookup

--- a/tests/sentry/issues/endpoints/test_organization_group_index.py
+++ b/tests/sentry/issues/endpoints/test_organization_group_index.py
@@ -2777,10 +2777,6 @@ class GroupListTest(APITestCase, SnubaTestCase, SearchIssueTestMixin):
     def test_snuba_unsupported_filters(self):
         self.login_as(user=self.user)
         for query in [
-            "bookmarks:me",
-            "is:linked",
-            "is:unlinked",
-            "subscribed:me",
             "regressed_in_release:latest",
             "issue.priority:high",
         ]:


### PR DESCRIPTION
There are certain filters such as `bookmarked_by`, `linked`, `subscribed_by` that require us to do joins in Postgres to other tables. These tables do not exist in Snuba and likely never will because these queries are somewhat uncommon. As a result, this PR adds pre-fetching group_ids when users are trying to filter with one of these conditions with the new `GroupAttributesPostgresSnubaQueryExecutor`. The long term goal is to remove `UNSUPPORTED_SNUBA_FILTERS` so we can have all queries use `GroupAttributesPostgresSnubaQueryExecutor` instead of `PostgresSnubaQueryExecutor`.