### PR TITLE
fix(issue-priority): Add Chevron-up state for when group priority dropdown is open

### DIFF
--- a/static/app/components/badge/groupPriority.tsx
+++ b/static/app/components/badge/groupPriority.tsx
@@ -1,4 +1,4 @@
-import {Fragment, useMemo, useRef} from 'react';
+import {Fragment, useMemo, useRef, useState} from 'react';
 import type {Theme} from '@emotion/react';
 import styled from '@emotion/styled';
 
@@ -211,6 +211,7 @@ export function GroupPriorityDropdown({
     () => makeGroupPriorityDropdownOptions({onChange}),
     [onChange]
   );
+  const [isDropdownOpen, setIsDropdownOpen] = useState(false);
 
   return (
     <DropdownMenu
@@ -229,11 +230,12 @@ export function GroupPriorityDropdown({
           size="zero"
         >
           <GroupPriorityBadge priority={value}>
-            <Chevron direction="down" size="small" />
+            <Chevron direction={isDropdownOpen ? 'up' : 'down'} size="small" />
           </GroupPriorityBadge>
         </DropdownButton>
       )}
       items={options}
+      onOpenChange={isOpen => setIsDropdownOpen(isOpen)}
       menuFooter={
         <Fragment>
           <StyledFooter>

--- a/static/app/components/badge/groupPriority.tsx
+++ b/static/app/components/badge/groupPriority.tsx
@@ -1,4 +1,4 @@
-import {Fragment, useMemo, useRef, useState} from 'react';
+import {Fragment, useMemo, useRef} from 'react';
 import type {Theme} from '@emotion/react';
 import styled from '@emotion/styled';
 
@@ -211,7 +211,6 @@ export function GroupPriorityDropdown({
     () => makeGroupPriorityDropdownOptions({onChange}),
     [onChange]
   );
-  const [isDropdownOpen, setIsDropdownOpen] = useState(false);
 
   return (
     <DropdownMenu
@@ -223,19 +222,18 @@ export function GroupPriorityDropdown({
         </MenuTitleContainer>
       }
       minMenuWidth={230}
-      trigger={triggerProps => (
+      trigger={(triggerProps, isOpen) => (
         <DropdownButton
           {...triggerProps}
           aria-label={t('Modify issue priority')}
           size="zero"
         >
           <GroupPriorityBadge priority={value}>
-            <Chevron direction={isDropdownOpen ? 'up' : 'down'} size="small" />
+            <Chevron direction={isOpen ? 'up' : 'down'} size="small" />
           </GroupPriorityBadge>
         </DropdownButton>
       )}
       items={options}
-      onOpenChange={isOpen => setIsDropdownOpen(isOpen)}
       menuFooter={
         <Fragment>
           <StyledFooter>


### PR DESCRIPTION
Currently, the chevron for the issue priority tag does not animate or flip up when the dropdown is toggled. This PR fixes that.

Before: 
![Mov to Gif conversion (1)](https://github.com/getsentry/sentry/assets/55160142/c892fc0e-d042-4e95-898f-e30f26c6feaf)

After:
![Mov to Gif conversion](https://github.com/getsentry/sentry/assets/55160142/729ce25c-de21-43a5-8d15-c969f93c5144)

