### PR TITLE
chore(sdk): Turn off interactions experiment

### DIFF
--- a/static/app/bootstrap/initializeSdk.tsx
+++ b/static/app/bootstrap/initializeSdk.tsx
@@ -59,7 +59,7 @@ function getSentryIntegrations(routes?: Function) {
       routes: typeof routes === 'function' ? createRoutes(routes()) : [],
       match,
       _experiments: {
-        enableInteractions: true,
+        enableInteractions: false,
       },
     }),
     Sentry.browserProfilingIntegration(),


### PR DESCRIPTION
We think this is interacting poorly the trace IDs and causing a lot of `http.client` transactions with incorrect durations.
