### PR TITLE
chore(api-idorslug0: Update Open API Param to `ORG_ID_OR_SLUG`

### DIFF
--- a/src/sentry/api/endpoints/codeowners/external_actor/team_details.py
+++ b/src/sentry/api/endpoints/codeowners/external_actor/team_details.py
@@ -28,14 +28,14 @@ class ExternalTeamDetailsEndpoint(TeamEndpoint, ExternalActorEndpointMixin):
     def convert_args(
         self,
         request: Request,
-        organization_id_or_slug: int | str,
+        organization_slug: str,
         team_id_or_slug: int | str,
         external_team_id: int,
         *args: Any,
         **kwargs: Any,
     ) -> tuple[Any, Any]:
         args, kwargs = super().convert_args(
-            request, organization_id_or_slug, team_id_or_slug, *args, **kwargs
+            request, organization_slug, team_id_or_slug, *args, **kwargs
         )
         kwargs["external_team"] = self.get_external_actor_or_404(
             external_team_id, kwargs["team"].organization
@@ -47,7 +47,7 @@ class ExternalTeamDetailsEndpoint(TeamEndpoint, ExternalActorEndpointMixin):
         Update an External Team
         `````````````
 
-        :pparam string organization_id_or_slug: the id or slug of the organization the
+        :pparam string organization_slug: the slug of the organization the
                                           team belongs to.
         :pparam string team_id_or_slug: the id or slug of the team to get.
         :pparam string external_team_id: id of external_team object

--- a/src/sentry/api/endpoints/codeowners/external_actor/team_details.py
+++ b/src/sentry/api/endpoints/codeowners/external_actor/team_details.py
@@ -28,14 +28,14 @@ class ExternalTeamDetailsEndpoint(TeamEndpoint, ExternalActorEndpointMixin):
     def convert_args(
         self,
         request: Request,
-        organization_slug: str,
+        organization_id_or_slug: int | str,
         team_id_or_slug: int | str,
         external_team_id: int,
         *args: Any,
         **kwargs: Any,
     ) -> tuple[Any, Any]:
         args, kwargs = super().convert_args(
-            request, organization_slug, team_id_or_slug, *args, **kwargs
+            request, organization_id_or_slug, team_id_or_slug, *args, **kwargs
         )
         kwargs["external_team"] = self.get_external_actor_or_404(
             external_team_id, kwargs["team"].organization
@@ -47,7 +47,7 @@ class ExternalTeamDetailsEndpoint(TeamEndpoint, ExternalActorEndpointMixin):
         Update an External Team
         `````````````
 
-        :pparam string organization_slug: the slug of the organization the
+        :pparam string organization_id_or_slug: the id or slug of the organization the
                                           team belongs to.
         :pparam string team_id_or_slug: the id or slug of the team to get.
         :pparam string external_team_id: id of external_team object

--- a/src/sentry/api/endpoints/codeowners/external_actor/team_index.py
+++ b/src/sentry/api/endpoints/codeowners/external_actor/team_index.py
@@ -27,7 +27,7 @@ class ExternalTeamEndpoint(TeamEndpoint, ExternalActorEndpointMixin):
         Create an External Team
         `````````````
 
-        :pparam string organization_id_or_slug: the id or slug of the organization the
+        :pparam string organization_slug: the slug of the organization the
                                           team belongs to.
         :pparam string team_id_or_slug: the team_id_or_slug of the team to get.
         :param required string provider: enum("github", "gitlab")

--- a/src/sentry/api/endpoints/codeowners/external_actor/team_index.py
+++ b/src/sentry/api/endpoints/codeowners/external_actor/team_index.py
@@ -27,7 +27,7 @@ class ExternalTeamEndpoint(TeamEndpoint, ExternalActorEndpointMixin):
         Create an External Team
         `````````````
 
-        :pparam string organization_slug: the slug of the organization the
+        :pparam string organization_id_or_slug: the id or slug of the organization the
                                           team belongs to.
         :pparam string team_id_or_slug: the team_id_or_slug of the team to get.
         :param required string provider: enum("github", "gitlab")

--- a/src/sentry/api/endpoints/integrations/organization_integrations/index.py
+++ b/src/sentry/api/endpoints/integrations/organization_integrations/index.py
@@ -64,7 +64,7 @@ class OrganizationIntegrationsEndpoint(OrganizationIntegrationBaseEndpoint):
     @extend_schema(
         operation_id="List an Organization's Available Integrations",
         parameters=[
-            GlobalParams.ORG_SLUG,
+            GlobalParams.ORG_ID_OR_SLUG,
             IntegrationParams.PROVIDER_KEY,
             IntegrationParams.FEATURES,
             IntegrationParams.INCLUDE_CONFIG,

--- a/src/sentry/api/endpoints/notifications/notification_actions_details.py
+++ b/src/sentry/api/endpoints/notifications/notification_actions_details.py
@@ -87,7 +87,7 @@ class NotificationActionsDetailsEndpoint(OrganizationEndpoint):
     @extend_schema(
         operation_id="Retrieve a Spike Protection Notification Action",
         parameters=[
-            GlobalParams.ORG_SLUG,
+            GlobalParams.ORG_ID_OR_SLUG,
             NotificationParams.ACTION_ID,
         ],
         responses={200: OutgoingNotificationActionSerializer},
@@ -111,7 +111,7 @@ class NotificationActionsDetailsEndpoint(OrganizationEndpoint):
     @extend_schema(
         operation_id="Update a Spike Protection Notification Action",
         parameters=[
-            GlobalParams.ORG_SLUG,
+            GlobalParams.ORG_ID_OR_SLUG,
             NotificationParams.ACTION_ID,
         ],
         request=NotificationActionSerializer,
@@ -159,7 +159,7 @@ class NotificationActionsDetailsEndpoint(OrganizationEndpoint):
     @extend_schema(
         operation_id="Delete a Spike Protection Notification Action",
         parameters=[
-            GlobalParams.ORG_SLUG,
+            GlobalParams.ORG_ID_OR_SLUG,
             NotificationParams.ACTION_ID,
         ],
         responses={

--- a/src/sentry/api/endpoints/notifications/notification_actions_index.py
+++ b/src/sentry/api/endpoints/notifications/notification_actions_index.py
@@ -66,7 +66,7 @@ class NotificationActionsIndexEndpoint(OrganizationEndpoint):
     @extend_schema(
         operation_id="List Spike Protection Notifications",
         parameters=[
-            GlobalParams.ORG_SLUG,
+            GlobalParams.ORG_ID_OR_SLUG,
             OrganizationParams.PROJECT,
             OrganizationParams.PROJECT_ID_OR_SLUG,
             NotificationParams.TRIGGER_TYPE,
@@ -119,7 +119,7 @@ class NotificationActionsIndexEndpoint(OrganizationEndpoint):
     @extend_schema(
         operation_id="Create a Spike Protection Notification Action",
         parameters=[
-            GlobalParams.ORG_SLUG,
+            GlobalParams.ORG_ID_OR_SLUG,
         ],
         request=NotificationActionSerializer,
         responses={

--- a/src/sentry/api/endpoints/organization_events.py
+++ b/src/sentry/api/endpoints/organization_events.py
@@ -230,7 +230,7 @@ class OrganizationEventsEndpoint(OrganizationEventsV2EndpointBase):
         parameters=[
             GlobalParams.END,
             GlobalParams.ENVIRONMENT,
-            GlobalParams.ORG_SLUG,
+            GlobalParams.ORG_ID_OR_SLUG,
             OrganizationParams.PROJECT,
             GlobalParams.START,
             GlobalParams.STATS_PERIOD,

--- a/src/sentry/api/endpoints/organization_member/details.py
+++ b/src/sentry/api/endpoints/organization_member/details.py
@@ -113,7 +113,7 @@ class OrganizationMemberDetailsEndpoint(OrganizationMemberEndpoint):
     @extend_schema(
         operation_id="Retrieve an Organization Member",
         parameters=[
-            GlobalParams.ORG_SLUG,
+            GlobalParams.ORG_ID_OR_SLUG,
             GlobalParams.member_id("The ID of the organization member."),
         ],
         responses={
@@ -146,7 +146,7 @@ class OrganizationMemberDetailsEndpoint(OrganizationMemberEndpoint):
     @extend_schema(
         operation_id="Update an Organization Member's Roles",
         parameters=[
-            GlobalParams.ORG_SLUG,
+            GlobalParams.ORG_ID_OR_SLUG,
             GlobalParams.member_id("The ID of the member to update."),
         ],
         request=inline_serializer(
@@ -357,7 +357,7 @@ class OrganizationMemberDetailsEndpoint(OrganizationMemberEndpoint):
     @extend_schema(
         operation_id="Delete an Organization Member",
         parameters=[
-            GlobalParams.ORG_SLUG,
+            GlobalParams.ORG_ID_OR_SLUG,
             GlobalParams.member_id("The ID of the member to delete."),
         ],
         responses={

--- a/src/sentry/api/endpoints/organization_member/index.py
+++ b/src/sentry/api/endpoints/organization_member/index.py
@@ -189,7 +189,7 @@ class OrganizationMemberIndexEndpoint(OrganizationEndpoint):
     @extend_schema(
         operation_id="List an Organization's Members",
         parameters=[
-            GlobalParams.ORG_SLUG,
+            GlobalParams.ORG_ID_OR_SLUG,
         ],
         responses={
             200: inline_sentry_response_serializer(
@@ -299,7 +299,7 @@ class OrganizationMemberIndexEndpoint(OrganizationEndpoint):
     @extend_schema(
         operation_id="Add a Member to an Organization",
         parameters=[
-            GlobalParams.ORG_SLUG,
+            GlobalParams.ORG_ID_OR_SLUG,
         ],
         request=OrganizationMemberRequestSerializer,
         responses={

--- a/src/sentry/api/endpoints/organization_member/team_details.py
+++ b/src/sentry/api/endpoints/organization_member/team_details.py
@@ -229,7 +229,7 @@ class OrganizationMemberTeamDetailsEndpoint(OrganizationMemberEndpoint):
     @extend_schema(
         operation_id="Add an Organization Member to a Team",
         parameters=[
-            GlobalParams.ORG_SLUG,
+            GlobalParams.ORG_ID_OR_SLUG,
             GlobalParams.member_id("The ID of the organization member to add to the team"),
             GlobalParams.TEAM_ID_OR_SLUG,
         ],
@@ -419,7 +419,7 @@ class OrganizationMemberTeamDetailsEndpoint(OrganizationMemberEndpoint):
     @extend_schema(
         operation_id="Delete an Organization Member from a Team",
         parameters=[
-            GlobalParams.ORG_SLUG,
+            GlobalParams.ORG_ID_OR_SLUG,
             GlobalParams.member_id("The ID of the organization member to delete from the team"),
             GlobalParams.TEAM_ID_OR_SLUG,
         ],

--- a/src/sentry/api/endpoints/organization_projects.py
+++ b/src/sentry/api/endpoints/organization_projects.py
@@ -51,7 +51,7 @@ class OrganizationProjectsEndpoint(OrganizationEndpoint, EnvironmentMixin):
 
     @extend_schema(
         operation_id="List an Organization's Projects",
-        parameters=[GlobalParams.ORG_SLUG, CursorQueryParam],
+        parameters=[GlobalParams.ORG_ID_OR_SLUG, CursorQueryParam],
         request=None,
         responses={
             200: inline_sentry_response_serializer(

--- a/src/sentry/api/endpoints/organization_relay_usage.py
+++ b/src/sentry/api/endpoints/organization_relay_usage.py
@@ -27,7 +27,7 @@ class OrganizationRelayUsage(OrganizationEndpoint):
 
     @extend_schema(
         operation_id="List an Organization's trusted Relays",
-        parameters=[GlobalParams.ORG_SLUG],
+        parameters=[GlobalParams.ORG_ID_OR_SLUG],
         request=None,
         responses={
             200: inline_sentry_response_serializer(

--- a/src/sentry/api/endpoints/organization_sessions.py
+++ b/src/sentry/api/endpoints/organization_sessions.py
@@ -45,7 +45,7 @@ class OrganizationSessionsEndpoint(OrganizationEndpoint):
             GlobalParams.START,
             GlobalParams.END,
             GlobalParams.ENVIRONMENT,
-            GlobalParams.ORG_SLUG,
+            GlobalParams.ORG_ID_OR_SLUG,
             GlobalParams.STATS_PERIOD,
             OrganizationParams.PROJECT,
             SessionsParams.FIELD,

--- a/src/sentry/api/endpoints/organization_stats_summary.py
+++ b/src/sentry/api/endpoints/organization_stats_summary.py
@@ -125,7 +125,7 @@ class OrganizationStatsSummaryEndpoint(OrganizationEndpoint):
 
     @extend_schema(
         operation_id="Retrieve an Organization's Events Count by Project",
-        parameters=[GlobalParams.ORG_SLUG, OrgStatsSummaryQueryParamsSerializer],
+        parameters=[GlobalParams.ORG_ID_OR_SLUG, OrgStatsSummaryQueryParamsSerializer],
         request=None,
         responses={
             200: inline_sentry_response_serializer(

--- a/src/sentry/api/endpoints/organization_stats_v2.py
+++ b/src/sentry/api/endpoints/organization_stats_v2.py
@@ -151,7 +151,7 @@ class OrganizationStatsEndpointV2(OrganizationEndpoint):
 
     @extend_schema(
         operation_id="Retrieve Event Counts for an Organization (v2)",
-        parameters=[GlobalParams.ORG_SLUG, OrgStatsQueryParamsSerializer],
+        parameters=[GlobalParams.ORG_ID_OR_SLUG, OrgStatsQueryParamsSerializer],
         request=None,
         responses={
             200: inline_sentry_response_serializer("OutcomesResponse", StatsApiResponse),

--- a/src/sentry/api/endpoints/organization_teams.py
+++ b/src/sentry/api/endpoints/organization_teams.py
@@ -80,7 +80,7 @@ class OrganizationTeamsEndpoint(OrganizationEndpoint):
     @extend_schema(
         operation_id="List an Organization's Teams",
         parameters=[
-            GlobalParams.ORG_SLUG,
+            GlobalParams.ORG_ID_OR_SLUG,
             TeamParams.DETAILED,
             CursorQueryParam,
         ],
@@ -161,7 +161,7 @@ class OrganizationTeamsEndpoint(OrganizationEndpoint):
     @extend_schema(
         operation_id="Create a New Team",
         parameters=[
-            GlobalParams.ORG_SLUG,
+            GlobalParams.ORG_ID_OR_SLUG,
         ],
         request=TeamPostSerializer,
         responses={

--- a/src/sentry/api/endpoints/project_details.py
+++ b/src/sentry/api/endpoints/project_details.py
@@ -456,7 +456,7 @@ class ProjectDetailsEndpoint(ProjectEndpoint):
 
     @extend_schema(
         operation_id="Retrieve a Project",
-        parameters=[GlobalParams.ORG_SLUG, GlobalParams.PROJECT_ID_OR_SLUG],
+        parameters=[GlobalParams.ORG_ID_OR_SLUG, GlobalParams.PROJECT_ID_OR_SLUG],
         request=None,
         responses={
             200: DetailedProjectSerializer,
@@ -500,7 +500,7 @@ class ProjectDetailsEndpoint(ProjectEndpoint):
     @extend_schema(
         operation_id="Update a Project",
         parameters=[
-            GlobalParams.ORG_SLUG,
+            GlobalParams.ORG_ID_OR_SLUG,
             GlobalParams.PROJECT_ID_OR_SLUG,
         ],
         request=ProjectAdminSerializer,
@@ -891,7 +891,7 @@ class ProjectDetailsEndpoint(ProjectEndpoint):
 
     @extend_schema(
         operation_id="Delete a Project",
-        parameters=[GlobalParams.ORG_SLUG, GlobalParams.PROJECT_ID_OR_SLUG],
+        parameters=[GlobalParams.ORG_ID_OR_SLUG, GlobalParams.PROJECT_ID_OR_SLUG],
         responses={
             204: RESPONSE_NO_CONTENT,
             403: RESPONSE_FORBIDDEN,

--- a/src/sentry/api/endpoints/project_filter_details.py
+++ b/src/sentry/api/endpoints/project_filter_details.py
@@ -30,7 +30,7 @@ class ProjectFilterDetailsEndpoint(ProjectEndpoint):
     @extend_schema(
         operation_id="Update an Inbound Data Filter",
         parameters=[
-            GlobalParams.ORG_SLUG,
+            GlobalParams.ORG_ID_OR_SLUG,
             GlobalParams.PROJECT_ID_OR_SLUG,
             ProjectParams.FILTER_ID,
         ],

--- a/src/sentry/api/endpoints/project_key_details.py
+++ b/src/sentry/api/endpoints/project_key_details.py
@@ -40,7 +40,7 @@ class ProjectKeyDetailsEndpoint(ProjectEndpoint):
     @extend_schema(
         operation_id="Retrieve a Client Key",
         parameters=[
-            GlobalParams.ORG_SLUG,
+            GlobalParams.ORG_ID_OR_SLUG,
             GlobalParams.PROJECT_ID_OR_SLUG,
             ProjectParams.key_id("The ID of the client key"),
         ],
@@ -68,7 +68,7 @@ class ProjectKeyDetailsEndpoint(ProjectEndpoint):
     @extend_schema(
         operation_id="Update a Client Key",
         parameters=[
-            GlobalParams.ORG_SLUG,
+            GlobalParams.ORG_ID_OR_SLUG,
             GlobalParams.PROJECT_ID_OR_SLUG,
             ProjectParams.key_id("The ID of the key to update."),
         ],
@@ -181,7 +181,7 @@ class ProjectKeyDetailsEndpoint(ProjectEndpoint):
     @extend_schema(
         operation_id="Delete a Client Key",
         parameters=[
-            GlobalParams.ORG_SLUG,
+            GlobalParams.ORG_ID_OR_SLUG,
             GlobalParams.PROJECT_ID_OR_SLUG,
             ProjectParams.key_id("The ID of the key to delete."),
         ],

--- a/src/sentry/api/endpoints/project_keys.py
+++ b/src/sentry/api/endpoints/project_keys.py
@@ -33,7 +33,7 @@ class ProjectKeysEndpoint(ProjectEndpoint):
     @extend_schema(
         operation_id="List a Project's Client Keys",
         parameters=[
-            GlobalParams.ORG_SLUG,
+            GlobalParams.ORG_ID_OR_SLUG,
             GlobalParams.PROJECT_ID_OR_SLUG,
             CursorQueryParam,
             ProjectParams.STATUS,
@@ -72,7 +72,7 @@ class ProjectKeysEndpoint(ProjectEndpoint):
     @extend_schema(
         operation_id="Create a New Client Key",
         parameters=[
-            GlobalParams.ORG_SLUG,
+            GlobalParams.ORG_ID_OR_SLUG,
             GlobalParams.PROJECT_ID_OR_SLUG,
         ],
         request=ProjectKeyPostSerializer,

--- a/src/sentry/api/endpoints/project_ownership.py
+++ b/src/sentry/api/endpoints/project_ownership.py
@@ -219,7 +219,7 @@ class ProjectOwnershipEndpoint(ProjectEndpoint):
     @extend_schema(
         operation_id="Retrieve Ownership Configuration for a Project",
         parameters=[
-            GlobalParams.ORG_SLUG,
+            GlobalParams.ORG_ID_OR_SLUG,
             GlobalParams.PROJECT_ID_OR_SLUG,
         ],
         request=None,
@@ -241,7 +241,7 @@ class ProjectOwnershipEndpoint(ProjectEndpoint):
     @extend_schema(
         operation_id="Update Ownership Configuration for a Project",
         parameters=[
-            GlobalParams.ORG_SLUG,
+            GlobalParams.ORG_ID_OR_SLUG,
             GlobalParams.PROJECT_ID_OR_SLUG,
         ],
         request=ProjectOwnershipRequestSerializer,

--- a/src/sentry/api/endpoints/project_rule_details.py
+++ b/src/sentry/api/endpoints/project_rule_details.py
@@ -108,7 +108,7 @@ class ProjectRuleDetailsEndpoint(RuleEndpoint):
     @extend_schema(
         operation_id="Retrieve an Issue Alert Rule for a Project",
         parameters=[
-            GlobalParams.ORG_SLUG,
+            GlobalParams.ORG_ID_OR_SLUG,
             GlobalParams.PROJECT_ID_OR_SLUG,
             IssueAlertParams.ISSUE_RULE_ID,
         ],
@@ -208,7 +208,7 @@ class ProjectRuleDetailsEndpoint(RuleEndpoint):
     @extend_schema(
         operation_id="Update an Issue Alert Rule",
         parameters=[
-            GlobalParams.ORG_SLUG,
+            GlobalParams.ORG_ID_OR_SLUG,
             GlobalParams.PROJECT_ID_OR_SLUG,
             IssueAlertParams.ISSUE_RULE_ID,
         ],
@@ -398,7 +398,7 @@ class ProjectRuleDetailsEndpoint(RuleEndpoint):
     @extend_schema(
         operation_id="Delete an Issue Alert Rule",
         parameters=[
-            GlobalParams.ORG_SLUG,
+            GlobalParams.ORG_ID_OR_SLUG,
             GlobalParams.PROJECT_ID_OR_SLUG,
             IssueAlertParams.ISSUE_RULE_ID,
         ],

--- a/src/sentry/api/endpoints/project_rules.py
+++ b/src/sentry/api/endpoints/project_rules.py
@@ -681,7 +681,7 @@ class ProjectRulesEndpoint(ProjectEndpoint):
 
     @extend_schema(
         operation_id="List a Project's Issue Alert Rules",
-        parameters=[GlobalParams.ORG_SLUG, GlobalParams.PROJECT_ID_OR_SLUG],
+        parameters=[GlobalParams.ORG_ID_OR_SLUG, GlobalParams.PROJECT_ID_OR_SLUG],
         request=None,
         responses={
             200: inline_sentry_response_serializer("ListRules", list[RuleSerializerResponse]),
@@ -715,7 +715,7 @@ class ProjectRulesEndpoint(ProjectEndpoint):
     @extend_schema(
         operation_id="Create an Issue Alert Rule for a Project",
         parameters=[
-            GlobalParams.ORG_SLUG,
+            GlobalParams.ORG_ID_OR_SLUG,
             GlobalParams.PROJECT_ID_OR_SLUG,
         ],
         request=ProjectRulesPostSerializer,

--- a/src/sentry/api/endpoints/project_symbol_sources.py
+++ b/src/sentry/api/endpoints/project_symbol_sources.py
@@ -243,7 +243,7 @@ class ProjectSymbolSourcesEndpoint(ProjectEndpoint):
     @extend_schema(
         operation_id="Retrieve a Project's Symbol Sources",
         parameters=[
-            GlobalParams.ORG_SLUG,
+            GlobalParams.ORG_ID_OR_SLUG,
             GlobalParams.PROJECT_ID_OR_SLUG,
             ProjectParams.source_id(
                 "The ID of the source to look up. If this is not provided, all sources are returned.",
@@ -277,7 +277,7 @@ class ProjectSymbolSourcesEndpoint(ProjectEndpoint):
     @extend_schema(
         operation_id="Delete a Symbol Source from a Project",
         parameters=[
-            GlobalParams.ORG_SLUG,
+            GlobalParams.ORG_ID_OR_SLUG,
             GlobalParams.PROJECT_ID_OR_SLUG,
             ProjectParams.source_id("The ID of the source to delete.", True),
         ],
@@ -310,7 +310,7 @@ class ProjectSymbolSourcesEndpoint(ProjectEndpoint):
 
     @extend_schema(
         operation_id="Add a Symbol Source to a Project",
-        parameters=[GlobalParams.ORG_SLUG, GlobalParams.PROJECT_ID_OR_SLUG],
+        parameters=[GlobalParams.ORG_ID_OR_SLUG, GlobalParams.PROJECT_ID_OR_SLUG],
         request=SourceSerializer,
         responses={
             201: REDACTED_SOURCE_SCHEMA,
@@ -350,7 +350,7 @@ class ProjectSymbolSourcesEndpoint(ProjectEndpoint):
     @extend_schema(
         operation_id="Update a Project's Symbol Source",
         parameters=[
-            GlobalParams.ORG_SLUG,
+            GlobalParams.ORG_ID_OR_SLUG,
             GlobalParams.PROJECT_ID_OR_SLUG,
             ProjectParams.source_id("The ID of the source to update.", True),
         ],

--- a/src/sentry/api/endpoints/project_team_details.py
+++ b/src/sentry/api/endpoints/project_team_details.py
@@ -72,7 +72,7 @@ class ProjectTeamDetailsEndpoint(ProjectEndpoint):
     @extend_schema(
         operation_id="Add a Team to a Project",
         parameters=[
-            GlobalParams.ORG_SLUG,
+            GlobalParams.ORG_ID_OR_SLUG,
             GlobalParams.PROJECT_ID_OR_SLUG,
             GlobalParams.TEAM_ID_OR_SLUG,
         ],
@@ -103,7 +103,7 @@ class ProjectTeamDetailsEndpoint(ProjectEndpoint):
     @extend_schema(
         operation_id="Delete a Team from a Project",
         parameters=[
-            GlobalParams.ORG_SLUG,
+            GlobalParams.ORG_ID_OR_SLUG,
             GlobalParams.PROJECT_ID_OR_SLUG,
             GlobalParams.TEAM_ID_OR_SLUG,
         ],

--- a/src/sentry/api/endpoints/release_thresholds/release_threshold_status_index.py
+++ b/src/sentry/api/endpoints/release_thresholds/release_threshold_status_index.py
@@ -97,7 +97,7 @@ class ReleaseThresholdStatusIndexEndpoint(OrganizationReleasesBaseEndpoint, Envi
 
     @extend_schema(
         operation_id="Retrieve Statuses of Release Thresholds (Alpha)",
-        parameters=[GlobalParams.ORG_SLUG, ReleaseThresholdStatusIndexSerializer],
+        parameters=[GlobalParams.ORG_ID_OR_SLUG, ReleaseThresholdStatusIndexSerializer],
         request=None,
         responses={
             200: inline_sentry_response_serializer(

--- a/src/sentry/api/endpoints/source_map_debug_blue_thunder_edition.py
+++ b/src/sentry/api/endpoints/source_map_debug_blue_thunder_edition.py
@@ -135,7 +135,7 @@ class SourceMapDebugBlueThunderEditionEndpoint(ProjectEndpoint):
     @extend_schema(
         operation_id="Get Debug Information Related to Source Maps for a Given Event",
         parameters=[
-            GlobalParams.ORG_SLUG,
+            GlobalParams.ORG_ID_OR_SLUG,
             GlobalParams.PROJECT_ID_OR_SLUG,
             EventParams.EVENT_ID,
         ],

--- a/src/sentry/api/endpoints/team_projects.py
+++ b/src/sentry/api/endpoints/team_projects.py
@@ -87,7 +87,7 @@ class TeamProjectsEndpoint(TeamEndpoint, EnvironmentMixin):
     @extend_schema(
         operation_id="List a Team's Projects",
         parameters=[
-            GlobalParams.ORG_SLUG,
+            GlobalParams.ORG_ID_OR_SLUG,
             GlobalParams.TEAM_ID_OR_SLUG,
             CursorQueryParam,
         ],
@@ -142,7 +142,7 @@ class TeamProjectsEndpoint(TeamEndpoint, EnvironmentMixin):
         tags=["Projects"],
         operation_id="Create a New Project",
         parameters=[
-            GlobalParams.ORG_SLUG,
+            GlobalParams.ORG_ID_OR_SLUG,
             GlobalParams.TEAM_ID_OR_SLUG,
         ],
         request=ProjectPostSerializer,

--- a/src/sentry/apidocs/parameters.py
+++ b/src/sentry/apidocs/parameters.py
@@ -18,9 +18,9 @@ def build_typed_list(type: Any):
 
 
 class GlobalParams:
-    ORG_SLUG = OpenApiParameter(
-        name="organization_slug",
-        description="The slug of the organization the resource belongs to.",
+    ORG_ID_OR_SLUG = OpenApiParameter(
+        name="organization_id_or_slug",
+        description="The id or slug of the organization the resource belongs to.",
         required=True,
         type=str,
         location="path",

--- a/src/sentry/incidents/endpoints/organization_alert_rule_activations.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_activations.py
@@ -28,7 +28,7 @@ class OrganizationAlertRuleActivationsEndpoint(OrganizationAlertRuleEndpoint):
 
     @extend_schema(
         operation_id="Retrieve activations for an AlertRule",
-        parameters=[GlobalParams.ORG_SLUG, MetricAlertParams.METRIC_RULE_ID],
+        parameters=[GlobalParams.ORG_ID_OR_SLUG, MetricAlertParams.METRIC_RULE_ID],
         responses={
             200: inline_sentry_response_serializer(
                 "ListAlertRuleActivations", list[AlertRuleActivationsResponse]

--- a/src/sentry/incidents/endpoints/organization_alert_rule_details.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_details.py
@@ -335,7 +335,7 @@ class OrganizationAlertRuleDetailsEndpoint(OrganizationAlertRuleEndpoint):
 
     @extend_schema(
         operation_id="Retrieve a Metric Alert Rule for an Organization",
-        parameters=[GlobalParams.ORG_SLUG, MetricAlertParams.METRIC_RULE_ID],
+        parameters=[GlobalParams.ORG_ID_OR_SLUG, MetricAlertParams.METRIC_RULE_ID],
         responses={
             200: AlertRuleSerializer,
             401: RESPONSE_UNAUTHORIZED,
@@ -360,7 +360,7 @@ class OrganizationAlertRuleDetailsEndpoint(OrganizationAlertRuleEndpoint):
 
     @extend_schema(
         operation_id="Update a Metric Alert Rule",
-        parameters=[GlobalParams.ORG_SLUG, MetricAlertParams.METRIC_RULE_ID],
+        parameters=[GlobalParams.ORG_ID_OR_SLUG, MetricAlertParams.METRIC_RULE_ID],
         request=OrganizationAlertRuleDetailsPutSerializer,
         responses={
             200: AlertRuleSerializer,
@@ -391,7 +391,7 @@ class OrganizationAlertRuleDetailsEndpoint(OrganizationAlertRuleEndpoint):
 
     @extend_schema(
         operation_id="Delete a Metric Alert Rule",
-        parameters=[GlobalParams.ORG_SLUG, MetricAlertParams.METRIC_RULE_ID],
+        parameters=[GlobalParams.ORG_ID_OR_SLUG, MetricAlertParams.METRIC_RULE_ID],
         responses={
             202: RESPONSE_ACCEPTED,
             401: RESPONSE_UNAUTHORIZED,

--- a/src/sentry/incidents/endpoints/organization_alert_rule_index.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_index.py
@@ -415,7 +415,7 @@ class OrganizationAlertRuleIndexEndpoint(OrganizationEndpoint, AlertRuleIndexMix
 
     @extend_schema(
         operation_id="List an Organization's Metric Alert Rules",
-        parameters=[GlobalParams.ORG_SLUG],
+        parameters=[GlobalParams.ORG_ID_OR_SLUG],
         request=None,
         responses={
             200: inline_sentry_response_serializer(
@@ -442,7 +442,7 @@ class OrganizationAlertRuleIndexEndpoint(OrganizationEndpoint, AlertRuleIndexMix
 
     @extend_schema(
         operation_id="Create a Metric Alert Rule for an Organization",
-        parameters=[GlobalParams.ORG_SLUG],
+        parameters=[GlobalParams.ORG_ID_OR_SLUG],
         request=OrganizationAlertRuleIndexPostSerializer,
         responses={
             201: AlertRuleSerializer,

--- a/src/sentry/issues/endpoints/source_map_debug.py
+++ b/src/sentry/issues/endpoints/source_map_debug.py
@@ -38,7 +38,7 @@ class SourceMapDebugEndpoint(ProjectEndpoint):
     @extend_schema(
         operation_id="Debug Issues Related to Source Maps for a Given Event",
         parameters=[
-            GlobalParams.ORG_SLUG,
+            GlobalParams.ORG_ID_OR_SLUG,
             GlobalParams.PROJECT_ID_OR_SLUG,
             EventParams.EVENT_ID,
             EventParams.FRAME_IDX,

--- a/src/sentry/monitors/endpoints/organization_monitor_checkin_index.py
+++ b/src/sentry/monitors/endpoints/organization_monitor_checkin_index.py
@@ -27,7 +27,7 @@ class OrganizationMonitorCheckInIndexEndpoint(MonitorEndpoint, MonitorCheckInMix
     @extend_schema(
         operation_id="Retrieve Check-Ins for a Monitor",
         parameters=[
-            GlobalParams.ORG_SLUG,
+            GlobalParams.ORG_ID_OR_SLUG,
             MonitorParams.MONITOR_ID_OR_SLUG,
         ],
         responses={

--- a/src/sentry/monitors/endpoints/organization_monitor_details.py
+++ b/src/sentry/monitors/endpoints/organization_monitor_details.py
@@ -35,7 +35,7 @@ class OrganizationMonitorDetailsEndpoint(MonitorEndpoint, MonitorDetailsMixin):
     @extend_schema(
         operation_id="Retrieve a Monitor",
         parameters=[
-            GlobalParams.ORG_SLUG,
+            GlobalParams.ORG_ID_OR_SLUG,
             MonitorParams.MONITOR_ID_OR_SLUG,
             GlobalParams.ENVIRONMENT,
         ],
@@ -55,7 +55,7 @@ class OrganizationMonitorDetailsEndpoint(MonitorEndpoint, MonitorDetailsMixin):
     @extend_schema(
         operation_id="Update a Monitor",
         parameters=[
-            GlobalParams.ORG_SLUG,
+            GlobalParams.ORG_ID_OR_SLUG,
             MonitorParams.MONITOR_ID_OR_SLUG,
         ],
         request=MonitorValidator,
@@ -76,7 +76,7 @@ class OrganizationMonitorDetailsEndpoint(MonitorEndpoint, MonitorDetailsMixin):
     @extend_schema(
         operation_id="Delete a Monitor or Monitor Environments",
         parameters=[
-            GlobalParams.ORG_SLUG,
+            GlobalParams.ORG_ID_OR_SLUG,
             MonitorParams.MONITOR_ID_OR_SLUG,
             GlobalParams.ENVIRONMENT,
         ],

--- a/src/sentry/monitors/endpoints/organization_monitor_environment_details.py
+++ b/src/sentry/monitors/endpoints/organization_monitor_environment_details.py
@@ -36,7 +36,7 @@ class OrganizationMonitorEnvironmentDetailsEndpoint(
     @extend_schema(
         operation_id="Update a Monitor Environment",
         parameters=[
-            GlobalParams.ORG_SLUG,
+            GlobalParams.ORG_ID_OR_SLUG,
             MonitorParams.MONITOR_ID_OR_SLUG,
             MonitorParams.ENVIRONMENT,
         ],
@@ -59,7 +59,7 @@ class OrganizationMonitorEnvironmentDetailsEndpoint(
     @extend_schema(
         operation_id="Delete a Monitor Environments",
         parameters=[
-            GlobalParams.ORG_SLUG,
+            GlobalParams.ORG_ID_OR_SLUG,
             MonitorParams.MONITOR_ID_OR_SLUG,
             MonitorParams.ENVIRONMENT,
         ],

--- a/src/sentry/monitors/endpoints/organization_monitor_index.py
+++ b/src/sentry/monitors/endpoints/organization_monitor_index.py
@@ -102,7 +102,7 @@ class OrganizationMonitorIndexEndpoint(OrganizationEndpoint):
     @extend_schema(
         operation_id="Retrieve Monitors for an Organization",
         parameters=[
-            GlobalParams.ORG_SLUG,
+            GlobalParams.ORG_ID_OR_SLUG,
             OrganizationParams.PROJECT,
             GlobalParams.ENVIRONMENT,
             MonitorParams.OWNER,
@@ -270,7 +270,7 @@ class OrganizationMonitorIndexEndpoint(OrganizationEndpoint):
 
     @extend_schema(
         operation_id="Create a Monitor",
-        parameters=[GlobalParams.ORG_SLUG],
+        parameters=[GlobalParams.ORG_ID_OR_SLUG],
         request=MonitorValidator,
         responses={
             201: MonitorSerializer,
@@ -346,7 +346,7 @@ class OrganizationMonitorIndexEndpoint(OrganizationEndpoint):
 
     @extend_schema(
         operation_id="Bulk Edit Monitors",
-        parameters=[GlobalParams.ORG_SLUG],
+        parameters=[GlobalParams.ORG_ID_OR_SLUG],
         request=MonitorBulkEditValidator,
         responses={
             200: inline_sentry_response_serializer(

--- a/src/sentry/monitors/endpoints/project_monitor_checkin_index.py
+++ b/src/sentry/monitors/endpoints/project_monitor_checkin_index.py
@@ -27,7 +27,7 @@ class ProjectMonitorCheckInIndexEndpoint(ProjectMonitorEndpoint, MonitorCheckInM
     @extend_schema(
         operation_id="Retrieve Check-Ins for a Monitor by Project",
         parameters=[
-            GlobalParams.ORG_SLUG,
+            GlobalParams.ORG_ID_OR_SLUG,
             GlobalParams.PROJECT_ID_OR_SLUG,
             MonitorParams.MONITOR_ID_OR_SLUG,
         ],

--- a/src/sentry/monitors/endpoints/project_monitor_details.py
+++ b/src/sentry/monitors/endpoints/project_monitor_details.py
@@ -35,7 +35,7 @@ class ProjectMonitorDetailsEndpoint(ProjectMonitorEndpoint, MonitorDetailsMixin)
     @extend_schema(
         operation_id="Retrieve a Monitor for a Project",
         parameters=[
-            GlobalParams.ORG_SLUG,
+            GlobalParams.ORG_ID_OR_SLUG,
             GlobalParams.PROJECT_ID_OR_SLUG,
             MonitorParams.MONITOR_ID_OR_SLUG,
         ],
@@ -55,7 +55,7 @@ class ProjectMonitorDetailsEndpoint(ProjectMonitorEndpoint, MonitorDetailsMixin)
     @extend_schema(
         operation_id="Update a Monitor for a Project",
         parameters=[
-            GlobalParams.ORG_SLUG,
+            GlobalParams.ORG_ID_OR_SLUG,
             GlobalParams.PROJECT_ID_OR_SLUG,
             MonitorParams.MONITOR_ID_OR_SLUG,
         ],
@@ -77,7 +77,7 @@ class ProjectMonitorDetailsEndpoint(ProjectMonitorEndpoint, MonitorDetailsMixin)
     @extend_schema(
         operation_id="Delete a Monitor or Monitor Environments for a Project",
         parameters=[
-            GlobalParams.ORG_SLUG,
+            GlobalParams.ORG_ID_OR_SLUG,
             GlobalParams.PROJECT_ID_OR_SLUG,
             MonitorParams.MONITOR_ID_OR_SLUG,
             GlobalParams.ENVIRONMENT,

--- a/src/sentry/monitors/endpoints/project_monitor_environment_details.py
+++ b/src/sentry/monitors/endpoints/project_monitor_environment_details.py
@@ -36,7 +36,7 @@ class ProjectMonitorEnvironmentDetailsEndpoint(
     @extend_schema(
         operation_id="Update a Monitor Environment for a Project",
         parameters=[
-            GlobalParams.ORG_SLUG,
+            GlobalParams.ORG_ID_OR_SLUG,
             GlobalParams.PROJECT_ID_OR_SLUG,
             MonitorParams.MONITOR_ID_OR_SLUG,
             MonitorParams.ENVIRONMENT,
@@ -58,7 +58,7 @@ class ProjectMonitorEnvironmentDetailsEndpoint(
     @extend_schema(
         operation_id="Delete a Monitor Environment for a Project",
         parameters=[
-            GlobalParams.ORG_SLUG,
+            GlobalParams.ORG_ID_OR_SLUG,
             GlobalParams.PROJECT_ID_OR_SLUG,
             MonitorParams.MONITOR_ID_OR_SLUG,
             MonitorParams.ENVIRONMENT,

--- a/src/sentry/replays/endpoints/organization_replay_count.py
+++ b/src/sentry/replays/endpoints/organization_replay_count.py
@@ -60,7 +60,7 @@ class OrganizationReplayCountEndpoint(OrganizationEventsV2EndpointBase):
         parameters=[
             GlobalParams.END,
             GlobalParams.ENVIRONMENT,
-            GlobalParams.ORG_SLUG,
+            GlobalParams.ORG_ID_OR_SLUG,
             GlobalParams.START,
             GlobalParams.STATS_PERIOD,
             OrganizationParams.PROJECT,

--- a/src/sentry/replays/endpoints/organization_replay_details.py
+++ b/src/sentry/replays/endpoints/organization_replay_details.py
@@ -36,7 +36,7 @@ class OrganizationReplayDetailsEndpoint(OrganizationEndpoint):
 
     @extend_schema(
         operation_id="Retrieve a Replay Instance",
-        parameters=[GlobalParams.ORG_SLUG, ReplayParams.REPLAY_ID, ReplayValidator],
+        parameters=[GlobalParams.ORG_ID_OR_SLUG, ReplayParams.REPLAY_ID, ReplayValidator],
         responses={
             200: inline_sentry_response_serializer("GetReplay", ReplayDetailsResponse),
             400: RESPONSE_BAD_REQUEST,

--- a/src/sentry/replays/endpoints/organization_replay_index.py
+++ b/src/sentry/replays/endpoints/organization_replay_index.py
@@ -34,7 +34,7 @@ class OrganizationReplayIndexEndpoint(OrganizationEndpoint):
 
     @extend_schema(
         operation_id="List an Organization's Replays",
-        parameters=[GlobalParams.ORG_SLUG, ReplayValidator],
+        parameters=[GlobalParams.ORG_ID_OR_SLUG, ReplayValidator],
         responses={
             200: inline_sentry_response_serializer("ListReplays", list[ReplayDetailsResponse]),
             400: RESPONSE_BAD_REQUEST,

--- a/src/sentry/replays/endpoints/organization_replay_selector_index.py
+++ b/src/sentry/replays/endpoints/organization_replay_selector_index.py
@@ -95,7 +95,7 @@ class OrganizationReplaySelectorIndexEndpoint(OrganizationEndpoint):
     @extend_schema(
         operation_id="List an Organization's Selectors",
         parameters=[
-            GlobalParams.ORG_SLUG,
+            GlobalParams.ORG_ID_OR_SLUG,
             GlobalParams.ENVIRONMENT,
             ReplaySelectorValidator,
             CursorQueryParam,

--- a/src/sentry/replays/endpoints/project_replay_clicks_index.py
+++ b/src/sentry/replays/endpoints/project_replay_clicks_index.py
@@ -68,7 +68,7 @@ class ProjectReplayClicksIndexEndpoint(ProjectEndpoint):
         operation_id="List Clicked Nodes",
         parameters=[
             CursorQueryParam,
-            GlobalParams.ORG_SLUG,
+            GlobalParams.ORG_ID_OR_SLUG,
             GlobalParams.PROJECT_ID_OR_SLUG,
             GlobalParams.ENVIRONMENT,
             ReplayParams.REPLAY_ID,

--- a/src/sentry/replays/endpoints/project_replay_details.py
+++ b/src/sentry/replays/endpoints/project_replay_details.py
@@ -73,7 +73,7 @@ class ProjectReplayDetailsEndpoint(ProjectEndpoint):
     @extend_schema(
         operation_id="Delete a Replay Instance",
         parameters=[
-            GlobalParams.ORG_SLUG,
+            GlobalParams.ORG_ID_OR_SLUG,
             GlobalParams.PROJECT_ID_OR_SLUG,
             ReplayParams.REPLAY_ID,
         ],

--- a/src/sentry/replays/endpoints/project_replay_recording_segment_details.py
+++ b/src/sentry/replays/endpoints/project_replay_recording_segment_details.py
@@ -34,7 +34,7 @@ class ProjectReplayRecordingSegmentDetailsEndpoint(ProjectEndpoint):
     @extend_schema(
         operation_id="Fetch Recording Segment",
         parameters=[
-            GlobalParams.ORG_SLUG,
+            GlobalParams.ORG_ID_OR_SLUG,
             GlobalParams.PROJECT_ID_OR_SLUG,
             ReplayParams.REPLAY_ID,
             ReplayParams.SEGMENT_ID,

--- a/src/sentry/replays/endpoints/project_replay_recording_segment_index.py
+++ b/src/sentry/replays/endpoints/project_replay_recording_segment_index.py
@@ -36,7 +36,7 @@ class ProjectReplayRecordingSegmentIndexEndpoint(ProjectEndpoint):
         operation_id="List Recording Segments",
         parameters=[
             CursorQueryParam,
-            GlobalParams.ORG_SLUG,
+            GlobalParams.ORG_ID_OR_SLUG,
             GlobalParams.PROJECT_ID_OR_SLUG,
             ReplayParams.REPLAY_ID,
             VisibilityParams.PER_PAGE,

--- a/src/sentry/replays/endpoints/project_replay_video_details.py
+++ b/src/sentry/replays/endpoints/project_replay_video_details.py
@@ -41,7 +41,7 @@ class ProjectReplayVideoDetailsEndpoint(ProjectEndpoint):
     @extend_schema(
         operation_id="Fetch Replay Video",
         parameters=[
-            GlobalParams.ORG_SLUG,
+            GlobalParams.ORG_ID_OR_SLUG,
             GlobalParams.PROJECT_ID_OR_SLUG,
             ReplayParams.REPLAY_ID,
             ReplayParams.SEGMENT_ID,

--- a/src/sentry/replays/endpoints/project_replay_viewed_by.py
+++ b/src/sentry/replays/endpoints/project_replay_viewed_by.py
@@ -41,7 +41,7 @@ class ProjectReplayViewedByEndpoint(ProjectEndpoint):
     @extend_schema(
         operation_id="Get list of user who have viewed a replay",
         parameters=[
-            GlobalParams.ORG_SLUG,
+            GlobalParams.ORG_ID_OR_SLUG,
             GlobalParams.PROJECT_ID_OR_SLUG,
             ReplayParams.REPLAY_ID,
         ],

--- a/src/sentry/rules/history/endpoints/project_rule_group_history.py
+++ b/src/sentry/rules/history/endpoints/project_rule_group_history.py
@@ -63,7 +63,7 @@ class ProjectRuleGroupHistoryIndexEndpoint(RuleEndpoint):
     @extend_schema(
         operation_id="Retrieve a Group Firing History for an Issue Alert",
         parameters=[
-            GlobalParams.ORG_SLUG,
+            GlobalParams.ORG_ID_OR_SLUG,
             GlobalParams.PROJECT_ID_OR_SLUG,
             IssueAlertParams.ISSUE_RULE_ID,
         ],

--- a/src/sentry/rules/history/endpoints/project_rule_stats.py
+++ b/src/sentry/rules/history/endpoints/project_rule_stats.py
@@ -46,7 +46,7 @@ class ProjectRuleStatsIndexEndpoint(RuleEndpoint):
     @extend_schema(
         operation_id="Retrieve Firing Starts for an Issue Alert Rule for a Given Time Range.",
         parameters=[
-            GlobalParams.ORG_SLUG,
+            GlobalParams.ORG_ID_OR_SLUG,
             GlobalParams.PROJECT_ID_OR_SLUG,
             IssueAlertParams.ISSUE_RULE_ID,
         ],

--- a/src/sentry/scim/endpoints/members.py
+++ b/src/sentry/scim/endpoints/members.py
@@ -226,7 +226,7 @@ class OrganizationSCIMMemberDetails(SCIMEndpoint, OrganizationMemberEndpoint):
     @extend_schema(
         operation_id="Query an Individual Organization Member",
         parameters=[
-            GlobalParams.ORG_SLUG,
+            GlobalParams.ORG_ID_OR_SLUG,
             GlobalParams.member_id("The ID of the member to query."),
         ],
         request=None,
@@ -253,7 +253,7 @@ class OrganizationSCIMMemberDetails(SCIMEndpoint, OrganizationMemberEndpoint):
     @extend_schema(
         operation_id="Update an Organization Member's Attributes",
         parameters=[
-            GlobalParams.ORG_SLUG,
+            GlobalParams.ORG_ID_OR_SLUG,
             GlobalParams.member_id("The ID of the member to update."),
         ],
         request=SCIMPatchRequestSerializer,
@@ -305,7 +305,7 @@ class OrganizationSCIMMemberDetails(SCIMEndpoint, OrganizationMemberEndpoint):
     @extend_schema(
         operation_id="Delete an Organization Member via SCIM",
         parameters=[
-            GlobalParams.ORG_SLUG,
+            GlobalParams.ORG_ID_OR_SLUG,
             GlobalParams.member_id("The ID of the member to delete."),
         ],
         responses={
@@ -334,7 +334,7 @@ class OrganizationSCIMMemberDetails(SCIMEndpoint, OrganizationMemberEndpoint):
     @extend_schema(
         operation_id="Update an Organization Member's Attributes",
         parameters=[
-            GlobalParams.ORG_SLUG,
+            GlobalParams.ORG_ID_OR_SLUG,
             GlobalParams.member_id("The ID of the member to update."),
         ],
         request=inline_serializer(
@@ -443,7 +443,7 @@ class OrganizationSCIMMemberIndex(SCIMEndpoint):
 
     @extend_schema(
         operation_id="List an Organization's SCIM Members",
-        parameters=[GlobalParams.ORG_SLUG, SCIMQueryParamSerializer],
+        parameters=[GlobalParams.ORG_ID_OR_SLUG, SCIMQueryParamSerializer],
         responses={
             200: inline_sentry_response_serializer(
                 "SCIMListResponseEnvelopeSCIMMemberIndexResponse", SCIMListMembersResponse
@@ -500,7 +500,7 @@ class OrganizationSCIMMemberIndex(SCIMEndpoint):
 
     @extend_schema(
         operation_id="Provision a New Organization Member",
-        parameters=[GlobalParams.ORG_SLUG],
+        parameters=[GlobalParams.ORG_ID_OR_SLUG],
         request=inline_serializer(
             name="SCIMMemberProvision",
             fields={

--- a/src/sentry/scim/endpoints/teams.py
+++ b/src/sentry/scim/endpoints/teams.py
@@ -165,7 +165,7 @@ class OrganizationSCIMTeamIndex(SCIMEndpoint):
 
     @extend_schema(
         operation_id="List an Organization's Paginated Teams",
-        parameters=[GlobalParams.ORG_SLUG, SCIMQueryParamSerializer],
+        parameters=[GlobalParams.ORG_ID_OR_SLUG, SCIMQueryParamSerializer],
         request=None,
         responses={
             200: inline_sentry_response_serializer(
@@ -212,7 +212,7 @@ class OrganizationSCIMTeamIndex(SCIMEndpoint):
 
     @extend_schema(
         operation_id="Provision a New Team",
-        parameters=[GlobalParams.ORG_SLUG],
+        parameters=[GlobalParams.ORG_ID_OR_SLUG],
         request=inline_serializer(
             name="SCIMTeamRequestBody",
             fields={
@@ -322,7 +322,7 @@ class OrganizationSCIMTeamDetails(SCIMEndpoint, TeamDetailsEndpoint):
 
     @extend_schema(
         operation_id="Query an Individual Team",
-        parameters=[SCIMParams.TEAM_ID, GlobalParams.ORG_SLUG],
+        parameters=[SCIMParams.TEAM_ID, GlobalParams.ORG_ID_OR_SLUG],
         request=None,
         responses={
             200: TeamSCIMSerializer,
@@ -403,7 +403,7 @@ class OrganizationSCIMTeamDetails(SCIMEndpoint, TeamDetailsEndpoint):
 
     @extend_schema(
         operation_id="Update a Team's Attributes",
-        parameters=[GlobalParams.ORG_SLUG, SCIMParams.TEAM_ID],
+        parameters=[GlobalParams.ORG_ID_OR_SLUG, SCIMParams.TEAM_ID],
         request=SCIMTeamPatchRequestSerializer,
         responses={
             204: RESPONSE_SUCCESS,
@@ -474,7 +474,7 @@ class OrganizationSCIMTeamDetails(SCIMEndpoint, TeamDetailsEndpoint):
 
     @extend_schema(
         operation_id="Delete an Individual Team",
-        parameters=[GlobalParams.ORG_SLUG, SCIMParams.TEAM_ID],
+        parameters=[GlobalParams.ORG_ID_OR_SLUG, SCIMParams.TEAM_ID],
         responses={
             204: RESPONSE_SUCCESS,
             401: RESPONSE_UNAUTHORIZED,


### PR DESCRIPTION
As I roll out the changes to support ids in our APIs, I need to update the OpenAPI Param from ORG_SLUG to ORG_ID_OR_SLUG. In this pr, I replace the param to reflect the changes on our docs.