### PR TITLE
feat(analytics): adds analytics for issue search on the backend

### DIFF
--- a/src/sentry/analytics/events/__init__.py
+++ b/src/sentry/analytics/events/__init__.py
@@ -43,6 +43,7 @@ from .issue_ignored import *  # noqa: F401,F403
 from .issue_mark_reviewed import *  # noqa: F401,F403
 from .issue_priority import *  # noqa: F401,F403
 from .issue_resolved import *  # noqa: F401,F403
+from .issue_search_endpoint_queried import *  # noqa: F401,F403
 from .issue_tracker_used import *  # noqa: F401,F403
 from .issue_unignored import *  # noqa: F401,F403
 from .issue_unresolved import *  # noqa: F401,F403

--- a/src/sentry/analytics/events/issue_search_endpoint_queried.py
+++ b/src/sentry/analytics/events/issue_search_endpoint_queried.py
@@ -1,0 +1,16 @@
+from sentry import analytics
+
+
+class IssueSearchEndpointQueriedEvent(analytics.Event):
+    type = "issue_search.endpoint_queried"
+
+    attributes = (
+        analytics.Attribute("user_id"),
+        analytics.Attribute("organization_id"),
+        analytics.Attribute("project_ids"),  # This is a list of project ids
+        analytics.Attribute("full_query_params"),
+        analytics.Attribute("query"),
+    )
+
+
+analytics.register(IssueSearchEndpointQueriedEvent)


### PR DESCRIPTION
We want to have a better understanding what queries are being used on the backend for issue search. We have analytics on the FE for issue stream loading but it doesn't cover a lot of places that make searches such as the releases tab.