### PR TITLE
fix(replays): Fix 'clearQueryCache' method in 'useReplayData' hook

### DIFF
--- a/static/app/utils/replays/hooks/useReplayData.tsx
+++ b/static/app/utils/replays/hooks/useReplayData.tsx
@@ -214,21 +214,19 @@ function useReplayData({
     });
 
   const clearQueryCache = useCallback(() => {
-    () => {
-      queryClient.invalidateQueries({
-        queryKey: [`/organizations/${orgSlug}/replays/${replayId}/`],
-      });
-      queryClient.invalidateQueries({
-        queryKey: [
-          `/projects/${orgSlug}/${projectSlug}/replays/${replayId}/recording-segments/`,
-        ],
-      });
-      // The next one isn't optimized
-      // This statement will invalidate the cache of fetched error events for all replayIds
-      queryClient.invalidateQueries({
-        queryKey: [`/organizations/${orgSlug}/replays-events-meta/`],
-      });
-    };
+    queryClient.invalidateQueries({
+      queryKey: [`/organizations/${orgSlug}/replays/${replayId}/`],
+    });
+    queryClient.invalidateQueries({
+      queryKey: [
+        `/projects/${orgSlug}/${projectSlug}/replays/${replayId}/recording-segments/`,
+      ],
+    });
+    // The next one isn't optimized
+    // This statement will invalidate the cache of fetched error events for all replayIds
+    queryClient.invalidateQueries({
+      queryKey: [`/organizations/${orgSlug}/replays-events-meta/`],
+    });
   }, [orgSlug, replayId, projectSlug, queryClient]);
 
   return useMemo(() => {


### PR DESCRIPTION
# Goal

The goal of this PR is to fix a bug currently causing the `clearQueryCache` method defined in `static/app/utils/replays/hooks/useReplayData.tsx` to have no effect (extra arrow function declaration).

# Approach

Remove the duplicated arrow function declaration syntax (`() => { ... }`).

We also add a unit test to cover this behavior of the custom hook. You can see that the test fails if you revert the fix in `useReplayData.tsx`.

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
