### PR TITLE
fix: Tag tests with missing db fixture

### DIFF
--- a/tests/sentry/event_manager/interfaces/test_breadcrumbs.py
+++ b/tests/sentry/event_manager/interfaces/test_breadcrumbs.py
@@ -2,6 +2,7 @@ import pytest
 
 from sentry import eventstore
 from sentry.event_manager import EventManager
+from sentry.testutils.pytest.fixtures import django_db_all
 
 
 @pytest.fixture
@@ -33,6 +34,7 @@ def test_simple(make_breadcrumbs_snapshot):
     )
 
 
+@django_db_all
 @pytest.mark.parametrize(
     "input",
     [
@@ -48,6 +50,7 @@ def test_null_values(make_breadcrumbs_snapshot, input):
     make_breadcrumbs_snapshot(input)
 
 
+@django_db_all
 def test_non_string_keys(make_breadcrumbs_snapshot):
     make_breadcrumbs_snapshot(
         dict(

--- a/tests/sentry/event_manager/interfaces/test_frame.py
+++ b/tests/sentry/event_manager/interfaces/test_frame.py
@@ -2,6 +2,7 @@ import pytest
 
 from sentry import eventstore
 from sentry.event_manager import EventManager
+from sentry.testutils.pytest.fixtures import django_db_all
 
 
 @pytest.fixture
@@ -17,6 +18,7 @@ def make_frames_snapshot(insta_snapshot):
     return inner
 
 
+@django_db_all
 @pytest.mark.parametrize(
     "input",
     [
@@ -31,6 +33,7 @@ def test_bad_input(make_frames_snapshot, input):
     make_frames_snapshot(input)
 
 
+@django_db_all
 @pytest.mark.parametrize(
     "x", [float("inf"), float("-inf"), float("nan")], ids=["inf", "neginf", "nan"]
 )

--- a/tests/sentry/event_manager/interfaces/test_http.py
+++ b/tests/sentry/event_manager/interfaces/test_http.py
@@ -2,6 +2,7 @@ import pytest
 
 from sentry import eventstore
 from sentry.event_manager import EventManager
+from sentry.testutils.pytest.fixtures import django_db_all
 
 
 @pytest.fixture
@@ -22,6 +23,7 @@ def test_basic(make_http_snapshot):
     make_http_snapshot(dict(url="http://example.com"))
 
 
+@django_db_all
 def test_full(make_http_snapshot):
     make_http_snapshot(
         dict(
@@ -50,6 +52,7 @@ def test_data_as_dict(make_http_snapshot):
     make_http_snapshot(dict(url="http://example.com", data={"foo": "bar"}))
 
 
+@django_db_all
 def test_urlencoded_data(make_http_snapshot):
     make_http_snapshot(
         dict(
@@ -78,6 +81,7 @@ def test_infer_json_content_type(make_http_snapshot):
     make_http_snapshot(dict(url="http://example.com", data='{"foo":"bar"}'))
 
 
+@django_db_all
 def test_cookies_as_string(make_http_snapshot):
     make_http_snapshot(dict(url="http://example.com", cookies="a=b;c=d"))
     make_http_snapshot(dict(url="http://example.com", cookies="a=b;c=d"))
@@ -99,6 +103,7 @@ def test_query_string_and_fragment_as_params(make_http_snapshot):
     )
 
 
+@django_db_all
 def test_query_string_and_fragment_in_url(make_http_snapshot):
     make_http_snapshot(dict(url="http://example.com?foo\ufffd=bar#fragment\u2026"))
 
@@ -115,10 +120,12 @@ def test_invalid_method(make_http_snapshot):
     make_http_snapshot(dict(url="http://example.com", method="1234"))
 
 
+@django_db_all
 def test_invalid_method2(make_http_snapshot):
     make_http_snapshot(dict(url="http://example.com", method="A" * 33))
 
 
+@django_db_all
 def test_invalid_method3(make_http_snapshot):
     make_http_snapshot(dict(url="http://example.com", method="A"))
 

--- a/tests/sentry/event_manager/interfaces/test_single_exception.py
+++ b/tests/sentry/event_manager/interfaces/test_single_exception.py
@@ -2,6 +2,7 @@ import pytest
 
 from sentry import eventstore
 from sentry.event_manager import EventManager
+from sentry.testutils.pytest.fixtures import django_db_all
 
 
 @pytest.fixture
@@ -22,6 +23,7 @@ def make_single_exception_snapshot(insta_snapshot):
     return inner
 
 
+@django_db_all
 def test_basic(make_single_exception_snapshot):
     make_single_exception_snapshot(dict(type="ValueError", value="hello world", module="foo.bar"))
 
@@ -38,6 +40,7 @@ def test_coerces_object_value_to_string(make_single_exception_snapshot):
     make_single_exception_snapshot({"type": "ValueError", "value": {"unauthorized": True}})
 
 
+@django_db_all
 def test_handles_type_in_value(make_single_exception_snapshot):
     make_single_exception_snapshot(dict(value="ValueError: unauthorized"))
 

--- a/tests/sentry/event_manager/test_ensure_has_ip.py
+++ b/tests/sentry/event_manager/test_ensure_has_ip.py
@@ -1,4 +1,5 @@
 from sentry.event_manager import EventManager
+from sentry.testutils.pytest.fixtures import django_db_all
 
 
 def validate_and_normalize(report, client_ip=None):
@@ -29,6 +30,7 @@ def test_with_user_auto_ip():
     assert out["user"]["ip_address"] == "127.0.0.1"
 
 
+@django_db_all
 def test_without_ip_values():
     inp = {
         "platform": "javascript",


### PR DESCRIPTION
These tests fail when run on their own (in the Snuba CI) with errors about
missing this fixture.