### PR TITLE
ref(seer grouping): Add constants for Seer model version and URL

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -3950,6 +3950,9 @@ COGS_EVENT_STORE_LABEL = "bigtable_nodestore"
 # Disable DDM entirely
 SENTRY_DDM_DISABLE = os.getenv("SENTRY_DDM_DISABLE", "0") in ("1", "true", "True")
 
+SEER_SIMILARITY_MODEL_VERSION = "v0"
+SEER_SIMILAR_ISSUES_URL = f"/{SEER_SIMILARITY_MODEL_VERSION}/issues/similar-issues"
+
 # Devserver configuration overrides.
 ngrok_host = os.environ.get("SENTRY_DEVSERVER_NGROK")
 if ngrok_host:

--- a/src/sentry/seer/utils.py
+++ b/src/sentry/seer/utils.py
@@ -177,7 +177,7 @@ class SeerSimilarIssueData:
 def get_similar_issues_embeddings(
     similar_issues_request: SimilarIssuesEmbeddingsRequest,
 ) -> list[SeerSimilarIssueData]:
-    """Call /v0/issues/similar-issues endpoint from seer."""
+    """Request similar issues data from seer and normalize the results."""
     response = seer_staging_connection_pool.urlopen(
         "POST",
         SEER_SIMILAR_ISSUES_URL,

--- a/src/sentry/seer/utils.py
+++ b/src/sentry/seer/utils.py
@@ -6,7 +6,7 @@ import sentry_sdk
 from django.conf import settings
 from urllib3 import Retry
 
-from sentry.conf.server import SEER_SIMILAR_ISSUES_URL
+from sentry.conf.server import SEER_SIMILAR_ISSUES_URL, SEER_SIMILARITY_MODEL_VERSION
 from sentry.models.group import Group
 from sentry.models.grouphash import GroupHash
 from sentry.net.http import connection_from_url
@@ -125,6 +125,7 @@ class SeerSimilarIssueData:
     message_distance: float
     should_group: bool
     parent_group_id: int
+    similarity_model_version: str = SEER_SIMILARITY_MODEL_VERSION
     # TODO: See if we end up needing the hash here
     parent_hash: str | None = None
 

--- a/src/sentry/seer/utils.py
+++ b/src/sentry/seer/utils.py
@@ -6,6 +6,7 @@ import sentry_sdk
 from django.conf import settings
 from urllib3 import Retry
 
+from sentry.conf.server import SEER_SIMILAR_ISSUES_URL
 from sentry.models.group import Group
 from sentry.models.grouphash import GroupHash
 from sentry.net.http import connection_from_url
@@ -178,7 +179,7 @@ def get_similar_issues_embeddings(
     """Call /v0/issues/similar-issues endpoint from seer."""
     response = seer_staging_connection_pool.urlopen(
         "POST",
-        "/v0/issues/similar-issues",
+        SEER_SIMILAR_ISSUES_URL,
         body=json.dumps(similar_issues_request),
         headers={"Content-Type": "application/json;charset=utf-8"},
     )

--- a/tests/sentry/api/endpoints/test_group_similar_issues_embeddings.py
+++ b/tests/sentry/api/endpoints/test_group_similar_issues_embeddings.py
@@ -11,6 +11,7 @@ from sentry.api.endpoints.group_similar_issues_embeddings import (
     get_stacktrace_string,
 )
 from sentry.api.serializers.base import serialize
+from sentry.conf.server import SEER_SIMILAR_ISSUES_URL
 from sentry.models.group import Group
 from sentry.seer.utils import SeerSimilarIssueData, SimilarIssuesEmbeddingsResponse
 from sentry.testutils.cases import APITestCase
@@ -730,7 +731,7 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
 
         mock_seer_request.assert_called_with(
             "POST",
-            "/v0/issues/similar-issues",
+            SEER_SIMILAR_ISSUES_URL,
             body=orjson.dumps(expected_seer_request_params).decode(),
             headers={"Content-Type": "application/json;charset=utf-8"},
         )
@@ -777,7 +778,7 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
 
         mock_seer_request.assert_called_with(
             "POST",
-            "/v0/issues/similar-issues",
+            SEER_SIMILAR_ISSUES_URL,
             body=orjson.dumps(expected_seer_request_params).decode(),
             headers={"Content-Type": "application/json;charset=utf-8"},
         )
@@ -826,7 +827,7 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
 
         mock_seer_request.assert_called_with(
             "POST",
-            "/v0/issues/similar-issues",
+            SEER_SIMILAR_ISSUES_URL,
             body=orjson.dumps(expected_seer_request_params).decode(),
             headers={"Content-Type": "application/json;charset=utf-8"},
         )
@@ -1096,7 +1097,7 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
 
         mock_seer_request.assert_called_with(
             "POST",
-            "/v0/issues/similar-issues",
+            SEER_SIMILAR_ISSUES_URL,
             body=orjson.dumps(
                 {
                     "group_id": self.group.id,
@@ -1120,7 +1121,7 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
 
         mock_seer_request.assert_called_with(
             "POST",
-            "/v0/issues/similar-issues",
+            SEER_SIMILAR_ISSUES_URL,
             body=orjson.dumps(
                 {
                     "group_id": self.group.id,
@@ -1145,7 +1146,7 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
 
         mock_seer_request.assert_called_with(
             "POST",
-            "/v0/issues/similar-issues",
+            SEER_SIMILAR_ISSUES_URL,
             body=orjson.dumps(
                 {
                     "group_id": self.group.id,


### PR DESCRIPTION
This adds two constants, `SEER_SIMILARITY_MODEL_VERSION` and `SEER_SIMILAR_ISSUES_URL`, and uses them in places where we've previously been hardcoding values. it also adds model version to the `SeerSimilarIssueData` dataclass, defaulted to the constant's value.