### PR TITLE
fix(billing): Avoid usage chart warning

### DIFF
--- a/static/app/views/dashboards/widgetBuilder/widgetBuilderSortBy.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/widgetBuilderSortBy.spec.tsx
@@ -241,7 +241,9 @@ describe('WidgetBuilder', function () {
       // Selector "sortDirection"
       expect(screen.getByText('High to low')).toBeInTheDocument();
       // Selector "sortBy"
-      expect(screen.getAllByText('count()')).toHaveLength(3);
+      await waitFor(() => {
+        expect(screen.getAllByText('count()')).toHaveLength(3);
+      });
     });
 
     it('sortBy defaults to the first field value when changing display type to table', async function () {

--- a/static/app/views/organizationStats/usageChart/index.tsx
+++ b/static/app/views/organizationStats/usageChart/index.tsx
@@ -442,7 +442,9 @@ function UsageChartBody({
 
     if (chartSeries) {
       chartSeries.forEach(chartOption => {
-        legend.push({name: `${chartOption.name}`});
+        if (chartOption.name) {
+          legend.push({name: `${chartOption.name}`});
+        }
       });
     }
 


### PR DESCRIPTION
Avoids a warning when displaying the billing usage chart. We add a series for the "plan quota" that has no name. Adding a legend with no matching series throws this warning

![image](https://github.com/getsentry/sentry/assets/1400464/0a9e0665-8d4b-46b5-bb92-5a96c0b1d2db)

the series with no name (it does not need a legend) https://github.com/getsentry/getsentry/blob/master/static/getsentry/gsApp/views/subscriptionPage/reservedUsageChart.tsx#L529-L551
