### PR TITLE
fix(billing): Remove explicit reserved legend

### DIFF
--- a/static/app/views/organizationStats/usageChart/index.tsx
+++ b/static/app/views/organizationStats/usageChart/index.tsx
@@ -118,7 +118,6 @@ const enum SeriesTypes {
   ACCEPTED = 'Accepted',
   DROPPED = 'Dropped',
   PROJECTED = 'Projected',
-  RESERVED = 'Reserved',
   FILTERED = 'Filtered',
 }
 
@@ -413,13 +412,13 @@ function UsageChartBody({
 
   function chartLegendData() {
     const legend: LegendComponentOption['data'] = [
-      chartData.reserved && chartData.reserved.length > 0
-        ? {
-            name: SeriesTypes.RESERVED,
-          }
-        : {
-            name: SeriesTypes.ACCEPTED,
-          },
+      ...(chartData.reserved && chartData.reserved.length > 0
+        ? []
+        : [
+            {
+              name: SeriesTypes.ACCEPTED,
+            },
+          ]),
     ];
 
     if (chartData.filtered && chartData.filtered.length > 0) {


### PR DESCRIPTION
We want to rename reserved to "included in subscription". This will hit the for loop at the bottom of this function instead and let us pass the name via getsentry.

this for loop 
https://github.com/getsentry/sentry/blob/scttcper/remove-reserved-series/static/app/views/organizationStats/usageChart/index.tsx#L442-L446