### PR TITLE
fix(autofix): Allow project:read permission to make a codebase index

### DIFF
--- a/src/sentry/api/endpoints/project_autofix_create_codebase_index.py
+++ b/src/sentry/api/endpoints/project_autofix_create_codebase_index.py
@@ -9,7 +9,7 @@ from rest_framework.response import Response
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
-from sentry.api.bases.project import ProjectEndpoint
+from sentry.api.bases.project import ProjectEndpoint, ProjectPermission
 from sentry.api.helpers.repos import get_repos_from_project_code_mappings
 from sentry.models.project import Project
 from sentry.utils import json
@@ -19,6 +19,13 @@ logger = logging.getLogger(__name__)
 from rest_framework.request import Request
 
 
+class ProjectAutofixCreateCodebaseIndexPermission(ProjectPermission):
+    scope_map = {
+        # We might want to re-evaluate this for LA/EA whether a user needs to have write access to the project to create a codebase index (probably yes?)
+        "POST": ["project:read", "project:write", "project:admin"],
+    }
+
+
 @region_silo_endpoint
 class ProjectAutofixCreateCodebaseIndexEndpoint(ProjectEndpoint):
     publish_status = {
@@ -26,6 +33,8 @@ class ProjectAutofixCreateCodebaseIndexEndpoint(ProjectEndpoint):
     }
     owner = ApiOwner.ML_AI
     private = True
+
+    permission_classes = (ProjectAutofixCreateCodebaseIndexPermission,)
 
     def post(self, request: Request, project: Project) -> Response:
         """


### PR DESCRIPTION
Unlock autofix codebase creation for now for internal testing, we should re-consider after LA whether we should actually lock it to accounts with project write access