### PR TITLE
ref(test): Remove b64 padding from send_metrics.py

### DIFF
--- a/bin/send_metrics.py
+++ b/bin/send_metrics.py
@@ -49,7 +49,9 @@ def make_dist_payload(use_case, org_id, rand_str, value_len, b64_encode):
         "value": (
             {
                 "format": "base64",
-                "data": base64.b64encode(struct.pack(f"<{len(nums)}d", *nums)).decode("ascii"),
+                "data": base64.b64encode(struct.pack(f"<{len(nums)}d", *nums))
+                .replace(b"=", b"")
+                .decode("ascii"),
             }
             if b64_encode
             else {
@@ -80,7 +82,9 @@ def make_set_payload(use_case, org_id, rand_str, value_len, b64_encode):
                 "format": "base64",
                 "data": base64.b64encode(
                     b"".join([num.to_bytes(INT_WIDTH, byteorder="little") for num in nums])
-                ).decode("ascii"),
+                )
+                .replace(b"=", b"")
+                .decode("ascii"),
             }
             if b64_encode
             else {


### PR DESCRIPTION
### Overview

Remove b64 padding so send_metrics.py is on parity with relay