### PR TITLE
fix(slack): prevent falling back to token verification if slack headers are not set

### DIFF
--- a/src/sentry/integrations/slack/requests/base.py
+++ b/src/sentry/integrations/slack/requests/base.py
@@ -209,9 +209,6 @@ class SlackRequest:
     def _check_signing_secret(self, signing_secret: str) -> bool:
         signature = self.request.META.get("HTTP_X_SLACK_SIGNATURE")
         timestamp = self.request.META.get("HTTP_X_SLACK_REQUEST_TIMESTAMP")
-        if not (signature and timestamp):
-            return False
-
         return check_signing_secret(signing_secret, self.request.body, timestamp, signature)
 
     def _check_verification_token(self, verification_token: str) -> bool:


### PR DESCRIPTION
This PR adds ensures that if `slack.signing-secret` is set, we always using secret verification instead of token verification which is less safe. As it is currently implemented, if you have both `slack.signing-secret` and `slack.verification-token` set, it would fall back to token verification if the request didn't have slack HTTP headers.