### PR TITLE
feat(utils): Add dictionary filtering helper

### DIFF
--- a/src/sentry/utils/json.py
+++ b/src/sentry/utils/json.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import datetime
 import decimal
 import uuid
-from collections.abc import Generator, Mapping
+from collections.abc import Callable, Collection, Generator, Mapping
 from enum import Enum
 from typing import IO, TYPE_CHECKING, Any, NoReturn, TypeVar, overload
 
@@ -177,6 +177,37 @@ def prune_empty_keys(obj: Mapping[TKey, TValue | None] | None) -> dict[TKey, TVa
     return {k: v for k, v in obj.items() if v is not None}
 
 
+def apply_key_filter(
+    obj: Mapping[TKey, TValue],
+    *,
+    keep_keys: Collection[TKey] | None = None,
+    key_filter: Callable[[TKey], bool] | None = None,
+) -> dict[TKey, TValue]:
+    """
+    A version of the built-in `filter` function which works on dictionaries, returning a (filtered)
+    shallow copy of the original.
+
+    If `keep_keys` is given, any key-value pair whose key isn't in `keep_keys` will be excluded from
+    the result.
+
+    If a `key_filter` function is given, any key-value pair for which `key_filter(key)` is False
+    will be excluded from the result.
+
+    If both are given, `keep_keys` takes precedence. If neither is given, an unfiltered shallow copy
+    of the original is returned.
+    """
+
+    if keep_keys:
+        key_filter = lambda key: key in keep_keys
+    elif not keep_keys and not key_filter:
+        key_filter = lambda _key: True
+
+    # `key_filter` can't be None by now, but mypy still thinks it might
+    assert key_filter
+
+    return {key: obj[key] for key in obj if key_filter(key)}
+
+
 __all__ = (
     "JSONDecodeError",
     "JSONEncoder",
@@ -186,4 +217,5 @@ __all__ = (
     "load",
     "loads",
     "prune_empty_keys",
+    "apply_key_filter",
 )

--- a/tests/sentry/utils/test_json.py
+++ b/tests/sentry/utils/test_json.py
@@ -89,3 +89,42 @@ class JSONHelpersTest(TestCase):
 
     def test_prune_empty_keys_none_input(self):
         assert json.prune_empty_keys(None) is None
+
+    def test_apply_key_filter_with_key_list(self):
+        dog_data = {
+            "dogs_are_great": True,
+            "good_dogs": "all",
+            "bad_dogs": None,
+        }
+        keep_keys = ["dogs_are_great", "good_dogs"]
+
+        assert json.apply_key_filter(dog_data, keep_keys=keep_keys,) == {
+            "dogs_are_great": True,
+            "good_dogs": "all",
+        }
+
+    def test_apply_key_filter_with_callback(self):
+        dog_data = {
+            "dogs_are_great": True,
+            "good_dogs": "all",
+            "bad_dogs": None,
+        }
+        keep_keys = ["dogs_are_great", "good_dogs"]
+
+        assert json.apply_key_filter(dog_data, key_filter=lambda key: key in keep_keys,) == {
+            "dogs_are_great": True,
+            "good_dogs": "all",
+        }
+
+    def test_apply_key_filter_no_filter(self):
+        dog_data = {
+            "dogs_are_great": True,
+            "good_dogs": "all",
+            "bad_dogs": None,
+        }
+
+        assert json.apply_key_filter(dog_data,) == {
+            "dogs_are_great": True,
+            "good_dogs": "all",
+            "bad_dogs": None,
+        }

--- a/tests/sentry/utils/test_json.py
+++ b/tests/sentry/utils/test_json.py
@@ -8,7 +8,7 @@ from django.utils.translation import gettext_lazy as _
 from sentry.utils import json
 
 
-class JSONTest(TestCase):
+class JSONSerializationTest(TestCase):
     def test_uuid(self):
         res = uuid.uuid4()
         self.assertEqual(json.dumps(res), '"%s"' % res.hex)
@@ -48,3 +48,44 @@ class JSONTest(TestCase):
 
     def test_translation(self):
         self.assertEqual(json.dumps(_("word")), '"word"')
+
+
+class JSONHelpersTest(TestCase):
+    def test_prune_empty_keys_simple(self):
+        assert json.prune_empty_keys(
+            {
+                "dogs_are_great": True,
+                "good_dogs": "all",
+                "bad_dogs": None,
+            }
+        ) == {
+            "dogs_are_great": True,
+            "good_dogs": "all",
+        }
+
+    def test_prune_empty_keys_keeps_falsy_values(self):
+        assert json.prune_empty_keys(
+            {
+                "empty_string": "",
+                "empty_list": [],
+                "empty_dict": {},
+                "empty_set": set(),
+                "empty_tuple": tuple(),
+                "false": False,
+                "zero": 0,
+                "zero_point_zero": 0.0,
+                "none": None,
+            }
+        ) == {
+            "empty_string": "",
+            "empty_list": [],
+            "empty_dict": {},
+            "empty_set": set(),
+            "empty_tuple": tuple(),
+            "false": False,
+            "zero": 0,
+            "zero_point_zero": 0.0,
+        }
+
+    def test_prune_empty_keys_none_input(self):
+        assert json.prune_empty_keys(None) is None


### PR DESCRIPTION
While working on an upcoming PR, I found myself wanting to be able to filter a dictionary by key. `filter` seemed promising, but, no, that only works on lists*. Set intersection? Nope, that'll only give you back the intersecting keys, not the full intersecting key-value pairs. And yeah, I could do it manually, but I figured if I were going to do that, I might as well wrap it in a function. 

So this adds an `apply_key_filter` helper, which takes a dictionary and either a list of keys to keep or a function to apply to each key, in order to decide whether to include the key and its corresponding value. (It's implemented both ways because I couldn't figure out which I liked better and ended up trying both.) 

(Maybe at some point [this guy](https://discuss.python.org/t/dictionaries-should-have-key-based-set-operations/28408) will get his way, and we won't have to do this anymore.)

While I was in the JSON utils test file, I also did a little cleanup work there (renamed some things and added missing tests for the already-existing and related `prune_empty_keys` helper).

*Yes, and tuples and sets and the like. But still, it's fundamentally about 1-dimensional objects, and I wanted it to work on a 2D(ish) one.