### PR TITLE
feat(assignee-selector): Create storybook component for new assignee selector trigger

### DIFF
--- a/static/app/components/assigneeBadge.stories.tsx
+++ b/static/app/components/assigneeBadge.stories.tsx
@@ -4,7 +4,7 @@ import type {Actor} from 'sentry/types';
 import {useUser} from 'sentry/utils/useUser';
 
 export default storyBook(AssigneeBadge, story => {
-  story('Assignee Exists', () => {
+  story('Assignee Exists (no label)', () => {
     const user = useUser();
 
     const userActor: Actor = {
@@ -17,7 +17,24 @@ export default storyBook(AssigneeBadge, story => {
     return <AssigneeBadge assignedTo={userActor} />;
   });
 
-  story('Assignee Does Not Exist', () => {
-    return <AssigneeBadge assignedTo={null} />;
+  story('Assignee Exists (with label)', () => {
+    const user = useUser();
+
+    const userActor: Actor = {
+      type: 'user',
+      id: user.id,
+      name: user.name,
+      email: user.email,
+    };
+
+    return <AssigneeBadge assignedTo={userActor} showLabel />;
+  });
+
+  story('Assignee Does Not Exist (no label)', () => {
+    return <AssigneeBadge assignedTo={undefined} />;
+  });
+
+  story('Assignee Does Not Exist (with label)', () => {
+    return <AssigneeBadge assignedTo={undefined} showLabel />;
   });
 });

--- a/static/app/components/assigneeBadge.stories.tsx
+++ b/static/app/components/assigneeBadge.stories.tsx
@@ -7,9 +7,10 @@ import {useUser} from 'sentry/utils/useUser';
 import {useUserTeams} from 'sentry/utils/useUserTeams';
 
 export default storyBook(AssigneeBadge, story => {
-  story('User Assignee Exists (no label)', () => {
+  story('User Assignee', () => {
     const user = useUser();
-    const [chevronToggle, setChevronToggle] = useState<'up' | 'down'>('down');
+    const [chevron1Toggle, setChevron1Toggle] = useState<'up' | 'down'>('down');
+    const [chevron2Toggle, setChevron2Toggle] = useState<'up' | 'down'>('down');
     const userActor: Actor = {
       type: 'user',
       id: user.id,
@@ -18,32 +19,18 @@ export default storyBook(AssigneeBadge, story => {
     };
 
     return (
-      <div onClick={() => setChevronToggle(chevronToggle === 'up' ? 'down' : 'up')}>
-        <AssigneeBadge assignedTo={userActor} chevronDirection={chevronToggle} />
-      </div>
-    );
-  });
-
-  story('User Assignee Exists (with label)', () => {
-    const user = useUser();
-    const [chevronToggle, setChevronToggle] = useState<'up' | 'down'>('down');
-
-    const userActor: Actor = {
-      type: 'user',
-      id: user.id,
-      name: user.name,
-      email: user.email,
-    };
-
-    return (
-      <div onClick={() => setChevronToggle(chevronToggle === 'up' ? 'down' : 'up')}>
-        {' '}
-        <AssigneeBadge
-          assignedTo={userActor}
-          showLabel
-          chevronDirection={chevronToggle}
-        />
-      </div>
+      <Fragment>
+        <p onClick={() => setChevron1Toggle(chevron1Toggle === 'up' ? 'down' : 'up')}>
+          <AssigneeBadge assignedTo={userActor} chevronDirection={chevron1Toggle} />
+        </p>
+        <p onClick={() => setChevron2Toggle(chevron2Toggle === 'up' ? 'down' : 'up')}>
+          <AssigneeBadge
+            showLabel
+            assignedTo={userActor}
+            chevronDirection={chevron2Toggle}
+          />
+        </p>
+      </Fragment>
     );
   });
 
@@ -74,26 +61,36 @@ export default storyBook(AssigneeBadge, story => {
     );
   });
 
-  story('Assignee Does Not Exist (no label)', () => {
-    const [chevronToggle, setChevronToggle] = useState<'up' | 'down'>('down');
+  story('Unassigned', () => {
+    const [chevron1Toggle, setChevron1Toggle] = useState<'up' | 'down'>('down');
+    const [chevron2Toggle, setChevron2Toggle] = useState<'up' | 'down'>('down');
 
     return (
-      <div onClick={() => setChevronToggle(chevronToggle === 'up' ? 'down' : 'up')}>
-        <AssigneeBadge assignedTo={undefined} chevronDirection={chevronToggle} />
-      </div>
+      <Fragment>
+        <p onClick={() => setChevron1Toggle(chevron1Toggle === 'up' ? 'down' : 'up')}>
+          <AssigneeBadge assignedTo={undefined} chevronDirection={chevron1Toggle} />
+        </p>
+        <p onClick={() => setChevron2Toggle(chevron2Toggle === 'up' ? 'down' : 'up')}>
+          <AssigneeBadge
+            showLabel
+            assignedTo={undefined}
+            chevronDirection={chevron2Toggle}
+          />
+        </p>
+      </Fragment>
     );
   });
 
-  story('Assignee Does Not Exist (with label)', () => {
-    const [chevronToggle, setChevronToggle] = useState<'up' | 'down'>('down');
+  story('Loading', () => {
     return (
-      <div onClick={() => setChevronToggle(chevronToggle === 'up' ? 'down' : 'up')}>
-        <AssigneeBadge
-          assignedTo={undefined}
-          showLabel
-          chevronDirection={chevronToggle}
-        />
-      </div>
+      <Fragment>
+        <p>
+          <AssigneeBadge loading />
+        </p>
+        <p>
+          <AssigneeBadge showLabel loading />
+        </p>
+      </Fragment>
     );
   });
 });

--- a/static/app/components/assigneeBadge.stories.tsx
+++ b/static/app/components/assigneeBadge.stories.tsx
@@ -48,7 +48,11 @@ export default storyBook(AssigneeBadge, story => {
     return (
       <Fragment>
         <p onClick={() => setChevron1Toggle(chevron1Toggle === 'up' ? 'down' : 'up')}>
-          <AssigneeBadge assignedTo={teamActor} chevronDirection={chevron1Toggle} />
+          <AssigneeBadge
+            assignmentReason="suspectCommit"
+            assignedTo={teamActor}
+            chevronDirection={chevron1Toggle}
+          />
         </p>
         <p onClick={() => setChevron2Toggle(chevron2Toggle === 'up' ? 'down' : 'up')}>
           <AssigneeBadge

--- a/static/app/components/assigneeBadge.stories.tsx
+++ b/static/app/components/assigneeBadge.stories.tsx
@@ -1,10 +1,13 @@
+import {Fragment} from 'react';
+
 import {AssigneeBadge} from 'sentry/components/assigneeBadge';
 import storyBook from 'sentry/stories/storyBook';
 import type {Actor} from 'sentry/types';
 import {useUser} from 'sentry/utils/useUser';
+import {useUserTeams} from 'sentry/utils/useUserTeams';
 
 export default storyBook(AssigneeBadge, story => {
-  story('Assignee Exists (no label)', () => {
+  story('User Assignee Exists (no label)', () => {
     const user = useUser();
 
     const userActor: Actor = {
@@ -14,10 +17,10 @@ export default storyBook(AssigneeBadge, story => {
       email: user.email,
     };
 
-    return <AssigneeBadge assignedTo={userActor} />;
+    return <AssigneeBadge assignedTo={userActor} chevronDirection="down" />;
   });
 
-  story('Assignee Exists (with label)', () => {
+  story('User Assignee Exists (with label)', () => {
     const user = useUser();
 
     const userActor: Actor = {
@@ -27,14 +30,35 @@ export default storyBook(AssigneeBadge, story => {
       email: user.email,
     };
 
-    return <AssigneeBadge assignedTo={userActor} showLabel />;
+    return <AssigneeBadge assignedTo={userActor} showLabel chevronDirection="down" />;
+  });
+
+  story('Team Assignee', () => {
+    const {teams} = useUserTeams();
+
+    const teamActor: Actor = {
+      type: 'team',
+      id: teams[0].id,
+      name: teams[0].name,
+    };
+
+    return (
+      <Fragment>
+        <p>
+          <AssigneeBadge assignedTo={teamActor} chevronDirection="down" />
+        </p>
+        <p>
+          <AssigneeBadge assignedTo={teamActor} showLabel chevronDirection="down" />
+        </p>
+      </Fragment>
+    );
   });
 
   story('Assignee Does Not Exist (no label)', () => {
-    return <AssigneeBadge assignedTo={undefined} />;
+    return <AssigneeBadge assignedTo={undefined} chevronDirection="down" />;
   });
 
   story('Assignee Does Not Exist (with label)', () => {
-    return <AssigneeBadge assignedTo={undefined} showLabel />;
+    return <AssigneeBadge assignedTo={undefined} showLabel chevronDirection="down" />;
   });
 });

--- a/static/app/components/assigneeBadge.stories.tsx
+++ b/static/app/components/assigneeBadge.stories.tsx
@@ -1,4 +1,4 @@
-import {Fragment} from 'react';
+import {Fragment, useState} from 'react';
 
 import {AssigneeBadge} from 'sentry/components/assigneeBadge';
 import storyBook from 'sentry/stories/storyBook';
@@ -9,7 +9,7 @@ import {useUserTeams} from 'sentry/utils/useUserTeams';
 export default storyBook(AssigneeBadge, story => {
   story('User Assignee Exists (no label)', () => {
     const user = useUser();
-
+    const [chevronToggle, setChevronToggle] = useState<'up' | 'down'>('down');
     const userActor: Actor = {
       type: 'user',
       id: user.id,
@@ -17,11 +17,16 @@ export default storyBook(AssigneeBadge, story => {
       email: user.email,
     };
 
-    return <AssigneeBadge assignedTo={userActor} chevronDirection="down" />;
+    return (
+      <div onClick={() => setChevronToggle(chevronToggle === 'up' ? 'down' : 'up')}>
+        <AssigneeBadge assignedTo={userActor} chevronDirection={chevronToggle} />
+      </div>
+    );
   });
 
   story('User Assignee Exists (with label)', () => {
     const user = useUser();
+    const [chevronToggle, setChevronToggle] = useState<'up' | 'down'>('down');
 
     const userActor: Actor = {
       type: 'user',
@@ -30,11 +35,22 @@ export default storyBook(AssigneeBadge, story => {
       email: user.email,
     };
 
-    return <AssigneeBadge assignedTo={userActor} showLabel chevronDirection="down" />;
+    return (
+      <div onClick={() => setChevronToggle(chevronToggle === 'up' ? 'down' : 'up')}>
+        {' '}
+        <AssigneeBadge
+          assignedTo={userActor}
+          showLabel
+          chevronDirection={chevronToggle}
+        />
+      </div>
+    );
   });
 
   story('Team Assignee', () => {
     const {teams} = useUserTeams();
+    const [chevron1Toggle, setChevron1Toggle] = useState<'up' | 'down'>('down');
+    const [chevron2Toggle, setChevron2Toggle] = useState<'up' | 'down'>('down');
 
     const teamActor: Actor = {
       type: 'team',
@@ -44,21 +60,40 @@ export default storyBook(AssigneeBadge, story => {
 
     return (
       <Fragment>
-        <p>
-          <AssigneeBadge assignedTo={teamActor} chevronDirection="down" />
+        <p onClick={() => setChevron1Toggle(chevron1Toggle === 'up' ? 'down' : 'up')}>
+          <AssigneeBadge assignedTo={teamActor} chevronDirection={chevron1Toggle} />
         </p>
-        <p>
-          <AssigneeBadge assignedTo={teamActor} showLabel chevronDirection="down" />
+        <p onClick={() => setChevron2Toggle(chevron2Toggle === 'up' ? 'down' : 'up')}>
+          <AssigneeBadge
+            assignedTo={teamActor}
+            showLabel
+            chevronDirection={chevron2Toggle}
+          />
         </p>
       </Fragment>
     );
   });
 
   story('Assignee Does Not Exist (no label)', () => {
-    return <AssigneeBadge assignedTo={undefined} chevronDirection="down" />;
+    const [chevronToggle, setChevronToggle] = useState<'up' | 'down'>('down');
+
+    return (
+      <div onClick={() => setChevronToggle(chevronToggle === 'up' ? 'down' : 'up')}>
+        <AssigneeBadge assignedTo={undefined} chevronDirection={chevronToggle} />
+      </div>
+    );
   });
 
   story('Assignee Does Not Exist (with label)', () => {
-    return <AssigneeBadge assignedTo={undefined} showLabel chevronDirection="down" />;
+    const [chevronToggle, setChevronToggle] = useState<'up' | 'down'>('down');
+    return (
+      <div onClick={() => setChevronToggle(chevronToggle === 'up' ? 'down' : 'up')}>
+        <AssigneeBadge
+          assignedTo={undefined}
+          showLabel
+          chevronDirection={chevronToggle}
+        />
+      </div>
+    );
   });
 });

--- a/static/app/components/assigneeBadge.stories.tsx
+++ b/static/app/components/assigneeBadge.stories.tsx
@@ -1,0 +1,23 @@
+import {AssigneeBadge} from 'sentry/components/assigneeBadge';
+import storyBook from 'sentry/stories/storyBook';
+import type {Actor} from 'sentry/types';
+import {useUser} from 'sentry/utils/useUser';
+
+export default storyBook(AssigneeBadge, story => {
+  story('Assignee Exists', () => {
+    const user = useUser();
+
+    const userActor: Actor = {
+      type: 'user',
+      id: user.id,
+      name: user.name,
+      email: user.email,
+    };
+
+    return <AssigneeBadge assignedTo={userActor} />;
+  });
+
+  story('Assignee Does Not Exist', () => {
+    return <AssigneeBadge assignedTo={null} />;
+  });
+});

--- a/static/app/components/assigneeBadge.tsx
+++ b/static/app/components/assigneeBadge.tsx
@@ -1,5 +1,6 @@
 // import {Fragment} from 'react';
 import {Fragment} from 'react';
+import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import ActorAvatar from 'sentry/components/avatar/actorAvatar';
@@ -86,7 +87,14 @@ export function AssigneeBadge({
 
   return assignedTo ? (
     <Tooltip title={makeAssignedTooltipText(assignedTo)}>
-      <StyledTag icon={makeAssignedIcon(assignedTo)} />
+      <StyledTag
+        data-is-team={assignedTo.type === 'team'}
+        css={css`
+          --avatar-spacing: ${space(0.5)} ${space(0.25)} ${space(0.5)}
+            ${assignedTo.type === 'team' ? space(0.75) : space(0.5)};
+        `}
+        icon={makeAssignedIcon(assignedTo)}
+      />
     </Tooltip>
   ) : (
     <Tooltip title={makeUnAssignedTooltipText()}>
@@ -107,8 +115,9 @@ const StyledTag = styled(Tag)`
   }
   & > div {
     height: 24px;
-    padding: ${space(0.5)};
+    padding: var(--avatar-spacing, ${space(0.5)});
   }
+  cursor: pointer;
 `;
 
 const TooltipSubtext = styled('div')`

--- a/static/app/components/assigneeBadge.tsx
+++ b/static/app/components/assigneeBadge.tsx
@@ -89,6 +89,8 @@ export function AssigneeBadge({
     <Tooltip title={makeAssignedTooltipText(assignedTo)}>
       <StyledTag
         data-is-team={assignedTo.type === 'team'}
+        // Team avatars need extra left padding since the square avatar
+        // is being fit into a rounded edge
         css={css`
           --avatar-spacing: ${space(0.5)} ${space(0.25)} ${space(0.5)}
             ${assignedTo.type === 'team' ? space(0.75) : space(0.5)};

--- a/static/app/components/assigneeBadge.tsx
+++ b/static/app/components/assigneeBadge.tsx
@@ -42,7 +42,9 @@ export function AssigneeBadge({
             margin-left: ${actor.type === 'team' ? space(0.5) : space(0)};
           `}
         />
-        {showLabel && <Fragment>{actor.name}</Fragment>}
+        {showLabel && (
+          <Fragment>{`${actor.type === 'team' ? '#' : ''}${actor.name}`}</Fragment>
+        )}
         <Chevron direction={chevronDirection} size="small" />
       </Fragment>
     );

--- a/static/app/components/assigneeBadge.tsx
+++ b/static/app/components/assigneeBadge.tsx
@@ -1,0 +1,109 @@
+import {Fragment} from 'react';
+import styled from '@emotion/styled';
+
+import ActorAvatar from 'sentry/components/avatar/actorAvatar';
+import {Chevron} from 'sentry/components/chevron';
+import ExternalLink from 'sentry/components/links/externalLink';
+import {Tooltip} from 'sentry/components/tooltip';
+import {IconUser} from 'sentry/icons';
+import {t, tct} from 'sentry/locale';
+import type {Actor} from 'sentry/types';
+
+export function AssigneeBadge({
+  assignedTo,
+  assignmentReason,
+  showName = false,
+}: {
+  assignedTo?: Actor | null;
+  assignmentReason?: string;
+  showName?: boolean;
+}) {
+  // const suggestedReasons: Record<SuggestedOwnerReason, React.ReactNode> = {
+  //   suspectCommit: tct('Based on [commit:commit data]', {
+  //     commit: (
+  //       <TooltipSubExternalLink href="https://docs.sentry.io/product/sentry-basics/integrate-frontend/configure-scms/" />
+  //     ),
+  //   }),
+  //   ownershipRule: t('Matching Issue Owners Rule'),
+  //   projectOwnership: t('Matching Issue Owners Rule'),
+  //   codeowners: t('Matching Codeowners Rule'),
+  // };
+
+  if (assignedTo) {
+    return (
+      <PillOutline assigneeExists={!!assignedTo}>
+        <ActorAvatar
+          actor={assignedTo}
+          className="avatar"
+          size={16}
+          tooltip={
+            <TooltipWrapper>
+              {tct('Assigned to [name]', {
+                name:
+                  assignedTo.type === 'team' ? `#${assignedTo.name}` : assignedTo.name,
+              })}
+              {assignmentReason && <TooltipSubtext>{assignmentReason}</TooltipSubtext>}
+            </TooltipWrapper>
+          }
+        />
+        {assignedTo && showName && <Fragment>{assignedTo.name}</Fragment>}
+        <Chevron direction="down" size="small" />
+      </PillOutline>
+    );
+  }
+
+  return (
+    <Tooltip
+      isHoverable
+      skipWrapper
+      title={
+        <TooltipWrapper>
+          <div>{t('Unassigned')}</div>
+          <TooltipSubtext>
+            {tct(
+              'You can auto-assign issues by adding [issueOwners:Issue Owner rules].',
+              {
+                issueOwners: (
+                  <TooltipSubExternalLink href="https://docs.sentry.io/product/error-monitoring/issue-owners/" />
+                ),
+              }
+            )}
+          </TooltipSubtext>
+        </TooltipWrapper>
+      }
+    >
+      <StyledIconUser data-test-id="unassigned" size="md" color="gray400" />
+    </Tooltip>
+  );
+}
+
+const StyledIconUser = styled(IconUser)`
+  /* We need this to center with Avatar */
+  margin-right: 2px;
+`;
+
+const TooltipWrapper = styled('div')`
+  text-align: left;
+`;
+
+const TooltipSubExternalLink = styled(ExternalLink)`
+  color: ${p => p.theme.subText};
+  text-decoration: underline;
+
+  :hover {
+    color: ${p => p.theme.subText};
+  }
+`;
+
+const TooltipSubtext = styled('div')`
+  color: ${p => p.theme.subText};
+`;
+
+const PillOutline = styled('div')<{assigneeExists: boolean}>`
+  display: inline-flex;
+  padding: 2px 4px 4px 4px;
+  border: 1px ${p => (p.assigneeExists ? 'solid' : 'dotted')} ${p => p.theme.border};
+  border-radius: 16px;
+  align-items: center;
+  align-self: flex-start;
+`;

--- a/static/app/components/assigneeBadge.tsx
+++ b/static/app/components/assigneeBadge.tsx
@@ -29,6 +29,7 @@ export function AssigneeBadge({
   //   projectOwnership: t('Matching Issue Owners Rule'),
   //   codeowners: t('Matching Codeowners Rule'),
   // };
+  const AVATAR_SIZE = 16;
 
   const makeAssignedIcon = (actor: Actor) => {
     return (
@@ -36,7 +37,7 @@ export function AssigneeBadge({
         <ActorAvatar
           actor={actor}
           className="avatar"
-          size={16}
+          size={AVATAR_SIZE}
           tooltip={
             <TooltipWrapper>
               {tct('Assigned to [name]', {
@@ -55,7 +56,11 @@ export function AssigneeBadge({
   const makeUnassignedIcon = () => {
     return (
       <Fragment>
-        <Placeholder shape="circle" width={'16px'} height={'16px'} />
+        <Placeholder
+          shape="circle"
+          width={`${AVATAR_SIZE}px`}
+          height={`${AVATAR_SIZE}px`}
+        />
         {showLabel && <Fragment>Unassigned</Fragment>}
         <Chevron direction="down" size="small" />
       </Fragment>
@@ -91,7 +96,11 @@ const StyledTag = styled(Tag)`
   span {
     display: flex;
     align-items: center;
-    gap: ${space(0.5)};
+    gap: ${space(0.25)};
+  }
+  & > div {
+    height: 24px;
+    padding: ${space(0.5)};
   }
 `;
 

--- a/static/app/components/assigneeBadge.tsx
+++ b/static/app/components/assigneeBadge.tsx
@@ -44,7 +44,11 @@ export function AssigneeBadge({
             marginLeft: actor.type === 'team' ? space(0.5) : space(0),
           }}
         />
-        {showLabel && <div>{`${actor.type === 'team' ? '#' : ''}${actor.name}`}</div>}
+        {showLabel && (
+          <div
+            style={{color: theme.textColor}}
+          >{`${actor.type === 'team' ? '#' : ''}${actor.name}`}</div>
+        )}
         <Chevron direction={chevronDirection} size="small" />
       </Fragment>
     );
@@ -82,7 +86,7 @@ export function AssigneeBadge({
         </TooltipWrapper>
       }
     >
-      <StyledTag icon={makeAssignedIcon(assignedTo)} style={{color: theme.textColor}} />
+      <StyledTag icon={makeAssignedIcon(assignedTo)} />
     </Tooltip>
   ) : (
     <Tooltip

--- a/static/app/components/assigneeBadge.tsx
+++ b/static/app/components/assigneeBadge.tsx
@@ -110,7 +110,6 @@ const StyledTag = styled(Tag)`
   & > div {
     height: 24px;
     padding: ${space(0.5)};
-    padding-right: ${space(0.25)};
   }
   cursor: pointer;
 `;

--- a/static/app/components/assigneeBadge.tsx
+++ b/static/app/components/assigneeBadge.tsx
@@ -12,27 +12,21 @@ import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {Actor} from 'sentry/types';
 
+type AssigneeBadgeProps = {
+  chevronDirection: 'up' | 'down';
+  assignedTo?: Actor | undefined;
+  assignmentReason?: string;
+  showLabel?: boolean;
+};
+
+const AVATAR_SIZE = 16;
+
 export function AssigneeBadge({
   assignedTo,
   assignmentReason,
   showLabel = false,
-}: {
-  assignedTo?: Actor | undefined;
-  assignmentReason?: string;
-  showLabel?: boolean;
-}) {
-  // const suggestedReasons: Record<SuggestedOwnerReason, React.ReactNode> = {
-  //   suspectCommit: tct('Based on [commit:commit data]', {
-  //     commit: (
-  //       <TooltipSubExternalLink href="https://docs.sentry.io/product/sentry-basics/integrate-frontend/configure-scms/" />
-  //     ),
-  //   }),
-  //   ownershipRule: t('Matching Issue Owners Rule'),
-  //   projectOwnership: t('Matching Issue Owners Rule'),
-  //   codeowners: t('Matching Codeowners Rule'),
-  // };
-  const AVATAR_SIZE = 16;
-
+  chevronDirection = 'down',
+}: AssigneeBadgeProps) {
   const makeAssignedIcon = (actor: Actor) => {
     return (
       <Fragment>
@@ -43,7 +37,7 @@ export function AssigneeBadge({
           hasTooltip={false}
         />
         {showLabel && <Fragment>{actor.name}</Fragment>}
-        <Chevron direction="down" size="small" />
+        <Chevron direction={chevronDirection} size="small" />
       </Fragment>
     );
   };
@@ -57,7 +51,7 @@ export function AssigneeBadge({
           height={`${AVATAR_SIZE}px`}
         />
         {showLabel && <Fragment>Unassigned</Fragment>}
-        <Chevron direction="down" size="small" />
+        <Chevron direction={chevronDirection} size="small" />
       </Fragment>
     );
   };
@@ -100,11 +94,6 @@ export function AssigneeBadge({
     </Tooltip>
   );
 }
-
-// const StyledIconUser = styled(IconUser)`
-//   /* We need this to center with Avatar */
-//   margin-right: 2px;
-// `;
 
 const TooltipWrapper = styled('div')`
   text-align: left;

--- a/static/app/components/assigneeBadge.tsx
+++ b/static/app/components/assigneeBadge.tsx
@@ -1,22 +1,23 @@
+// import {Fragment} from 'react';
 import {Fragment} from 'react';
 import styled from '@emotion/styled';
 
 import ActorAvatar from 'sentry/components/avatar/actorAvatar';
+import Tag from 'sentry/components/badge/tag';
 import {Chevron} from 'sentry/components/chevron';
-import ExternalLink from 'sentry/components/links/externalLink';
-import {Tooltip} from 'sentry/components/tooltip';
-import {IconUser} from 'sentry/icons';
-import {t, tct} from 'sentry/locale';
+import Placeholder from 'sentry/components/placeholder';
+import {tct} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
 import type {Actor} from 'sentry/types';
 
 export function AssigneeBadge({
   assignedTo,
   assignmentReason,
-  showName = false,
+  showLabel = false,
 }: {
-  assignedTo?: Actor | null;
+  assignedTo?: Actor | undefined;
   assignmentReason?: string;
-  showName?: boolean;
+  showLabel?: boolean;
 }) {
   // const suggestedReasons: Record<SuggestedOwnerReason, React.ReactNode> = {
   //   suspectCommit: tct('Based on [commit:commit data]', {
@@ -29,69 +30,140 @@ export function AssigneeBadge({
   //   codeowners: t('Matching Codeowners Rule'),
   // };
 
-  if (assignedTo) {
+  const makeAssignedIcon = actor => {
     return (
-      <PillOutline assigneeExists={!!assignedTo}>
+      <Fragment>
         <ActorAvatar
-          actor={assignedTo}
+          actor={actor}
           className="avatar"
           size={16}
           tooltip={
             <TooltipWrapper>
               {tct('Assigned to [name]', {
-                name:
-                  assignedTo.type === 'team' ? `#${assignedTo.name}` : assignedTo.name,
+                name: actor.type === 'team' ? `#${actor.name}` : actor.name,
               })}
               {assignmentReason && <TooltipSubtext>{assignmentReason}</TooltipSubtext>}
             </TooltipWrapper>
           }
         />
-        {assignedTo && showName && <Fragment>{assignedTo.name}</Fragment>}
+        {showLabel && <Fragment>{actor.name}</Fragment>}
         <Chevron direction="down" size="small" />
-      </PillOutline>
+      </Fragment>
     );
-  }
+  };
 
-  return (
-    <Tooltip
-      isHoverable
-      skipWrapper
-      title={
-        <TooltipWrapper>
-          <div>{t('Unassigned')}</div>
-          <TooltipSubtext>
-            {tct(
-              'You can auto-assign issues by adding [issueOwners:Issue Owner rules].',
-              {
-                issueOwners: (
-                  <TooltipSubExternalLink href="https://docs.sentry.io/product/error-monitoring/issue-owners/" />
-                ),
-              }
-            )}
-          </TooltipSubtext>
-        </TooltipWrapper>
-      }
-    >
-      <StyledIconUser data-test-id="unassigned" size="md" color="gray400" />
-    </Tooltip>
+  const makeUnassignedIcon = () => {
+    return (
+      <Fragment>
+        <Placeholder shape="circle" width={'16px'} height={'16px'} />
+        {showLabel && <Fragment>Unassigned</Fragment>}
+        <Chevron direction="down" size="small" />
+      </Fragment>
+    );
+  };
+
+  return assignedTo ? (
+    <StyledTag icon={makeAssignedIcon(assignedTo)} />
+  ) : (
+    // How to override border here?
+    <StyledTag icon={makeUnassignedIcon()} borderStyle="dashed" />
   );
+
+  // {assignedTo ? (
+  //   <Tag icon={makeAvatar(assignedTo)}/>
+  // ) : (
+  //   <Tag icon={makeAvatar(assignedTo)}/>
+  // )
+  // }
+
+  // <PillOutline assigneeExists={!!assignedTo}>
+  //   {assignedTo ? (
+  //     <ActorAvatar
+  //       actor={assignedTo}
+  //       className="avatar"
+  //       size={16}
+  //       tooltip={
+  //         <TooltipWrapper>
+  //           {tct('Assigned to [name]', {
+  //             name:
+  //               assignedTo.type === 'team' ? `#${assignedTo.name}` : assignedTo.name,
+  //           })}
+  //           {assignmentReason && <TooltipSubtext>{assignmentReason}</TooltipSubtext>}
+  //         </TooltipWrapper>
+  //       }
+  //     />
+  //   ) : (
+  //     <Placeholder shape="circle" width={'16px'} height={'16px'} />
+  //   )}
+  //   {assignedTo && showName && <Fragment>{assignedTo.name}</Fragment>}
+  //   <Chevron direction="down" size="small" />
+  // </PillOutline>
+
+  // return (
+  //   <PillOutline assigneeExists={!!assignedTo}>
+  //     <ActorAvatar
+  //       actor={actor}
+  //       className="avatar"
+  //       size={16}
+  //       tooltip={
+  //         <TooltipWrapper>
+  //           {tct('Assigned to [name]', {
+  //             name: actor.type === 'team' ? `#${actor.name}` : actor.name,
+  //           })}
+  //           {assignmentReason && <TooltipSubtext>{assignmentReason}</TooltipSubtext>}
+  //         </TooltipWrapper>
+  //       }
+  //     />
+  //     {assignedTo && showName && <Fragment>{assignedTo.name}</Fragment>}
+  //     <Chevron direction="down" size="small" />
+  //   </PillOutline>
+  //   // <Tooltip
+  //   //   isHoverable
+  //   //   skipWrapper
+  //   //   title={
+  //   //     <TooltipWrapper>
+  //   //       <div>{t('Unassigned')}</div>
+  //   //       <TooltipSubtext>
+  //   //         {tct(
+  //   //           'You can auto-assign issues by adding [issueOwners:Issue Owner rules].',
+  //   //           {
+  //   //             issueOwners: (
+  //   //               <TooltipSubExternalLink href="https://docs.sentry.io/product/error-monitoring/issue-owners/" />
+  //   //             ),
+  //   //           }
+  //   //         )}
+  //   //       </TooltipSubtext>
+  //   //     </TooltipWrapper>
+  //   //   }
+  //   // >
+  //   //   <StyledIconUser data-test-id="unassigned" size="md" color="gray400" />
+  //   // </Tooltip>
+  // );
 }
 
-const StyledIconUser = styled(IconUser)`
-  /* We need this to center with Avatar */
-  margin-right: 2px;
-`;
+// const StyledIconUser = styled(IconUser)`
+//   /* We need this to center with Avatar */
+//   margin-right: 2px;
+// `;
 
 const TooltipWrapper = styled('div')`
   text-align: left;
 `;
 
-const TooltipSubExternalLink = styled(ExternalLink)`
-  color: ${p => p.theme.subText};
-  text-decoration: underline;
+// const TooltipSubExternalLink = styled(ExternalLink)`
+//   color: ${p => p.theme.subText};
+//   text-decoration: underline;
 
-  :hover {
-    color: ${p => p.theme.subText};
+//   :hover {
+//     color: ${p => p.theme.subText};
+//   }
+// `;
+
+const StyledTag = styled(Tag)`
+  span {
+    display: flex;
+    align-items: center;
+    gap: ${space(0.5)};
   }
 `;
 
@@ -99,11 +171,11 @@ const TooltipSubtext = styled('div')`
   color: ${p => p.theme.subText};
 `;
 
-const PillOutline = styled('div')<{assigneeExists: boolean}>`
-  display: inline-flex;
-  padding: 2px 4px 4px 4px;
-  border: 1px ${p => (p.assigneeExists ? 'solid' : 'dotted')} ${p => p.theme.border};
-  border-radius: 16px;
-  align-items: center;
-  align-self: flex-start;
-`;
+// const PillOutline = styled('div')<{assigneeExists: boolean}>`
+//   display: inline-flex;
+//   padding: 2px 4px 4px 4px;
+//   border: 1px ${p => (p.assigneeExists ? 'solid' : 'dashed')} ${p => p.theme.border};
+//   border-radius: 16px;
+//   align-items: center;
+//   align-self: flex-start;
+// `;

--- a/static/app/components/assigneeBadge.tsx
+++ b/static/app/components/assigneeBadge.tsx
@@ -30,7 +30,7 @@ export function AssigneeBadge({
   //   codeowners: t('Matching Codeowners Rule'),
   // };
 
-  const makeAssignedIcon = actor => {
+  const makeAssignedIcon = (actor: Actor) => {
     return (
       <Fragment>
         <ActorAvatar
@@ -65,80 +65,8 @@ export function AssigneeBadge({
   return assignedTo ? (
     <StyledTag icon={makeAssignedIcon(assignedTo)} />
   ) : (
-    // How to override border here?
     <StyledTag icon={makeUnassignedIcon()} borderStyle="dashed" />
   );
-
-  // {assignedTo ? (
-  //   <Tag icon={makeAvatar(assignedTo)}/>
-  // ) : (
-  //   <Tag icon={makeAvatar(assignedTo)}/>
-  // )
-  // }
-
-  // <PillOutline assigneeExists={!!assignedTo}>
-  //   {assignedTo ? (
-  //     <ActorAvatar
-  //       actor={assignedTo}
-  //       className="avatar"
-  //       size={16}
-  //       tooltip={
-  //         <TooltipWrapper>
-  //           {tct('Assigned to [name]', {
-  //             name:
-  //               assignedTo.type === 'team' ? `#${assignedTo.name}` : assignedTo.name,
-  //           })}
-  //           {assignmentReason && <TooltipSubtext>{assignmentReason}</TooltipSubtext>}
-  //         </TooltipWrapper>
-  //       }
-  //     />
-  //   ) : (
-  //     <Placeholder shape="circle" width={'16px'} height={'16px'} />
-  //   )}
-  //   {assignedTo && showName && <Fragment>{assignedTo.name}</Fragment>}
-  //   <Chevron direction="down" size="small" />
-  // </PillOutline>
-
-  // return (
-  //   <PillOutline assigneeExists={!!assignedTo}>
-  //     <ActorAvatar
-  //       actor={actor}
-  //       className="avatar"
-  //       size={16}
-  //       tooltip={
-  //         <TooltipWrapper>
-  //           {tct('Assigned to [name]', {
-  //             name: actor.type === 'team' ? `#${actor.name}` : actor.name,
-  //           })}
-  //           {assignmentReason && <TooltipSubtext>{assignmentReason}</TooltipSubtext>}
-  //         </TooltipWrapper>
-  //       }
-  //     />
-  //     {assignedTo && showName && <Fragment>{assignedTo.name}</Fragment>}
-  //     <Chevron direction="down" size="small" />
-  //   </PillOutline>
-  //   // <Tooltip
-  //   //   isHoverable
-  //   //   skipWrapper
-  //   //   title={
-  //   //     <TooltipWrapper>
-  //   //       <div>{t('Unassigned')}</div>
-  //   //       <TooltipSubtext>
-  //   //         {tct(
-  //   //           'You can auto-assign issues by adding [issueOwners:Issue Owner rules].',
-  //   //           {
-  //   //             issueOwners: (
-  //   //               <TooltipSubExternalLink href="https://docs.sentry.io/product/error-monitoring/issue-owners/" />
-  //   //             ),
-  //   //           }
-  //   //         )}
-  //   //       </TooltipSubtext>
-  //   //     </TooltipWrapper>
-  //   //   }
-  //   // >
-  //   //   <StyledIconUser data-test-id="unassigned" size="md" color="gray400" />
-  //   // </Tooltip>
-  // );
 }
 
 // const StyledIconUser = styled(IconUser)`

--- a/static/app/components/assigneeBadge.tsx
+++ b/static/app/components/assigneeBadge.tsx
@@ -113,7 +113,7 @@ const StyledTag = styled(Tag)`
   span {
     display: flex;
     align-items: center;
-    gap: ${space(0.25)};
+    gap: ${space(0.5)};
   }
   & > div {
     height: 24px;

--- a/static/app/components/assigneeBadge.tsx
+++ b/static/app/components/assigneeBadge.tsx
@@ -36,6 +36,7 @@ export function AssigneeBadge({
           className="avatar"
           size={AVATAR_SIZE}
           hasTooltip={false}
+          style={{paddingLeft: space(1)}}
         />
         {showLabel && <Fragment>{actor.name}</Fragment>}
         <Chevron direction={chevronDirection} size="small" />
@@ -59,12 +60,10 @@ export function AssigneeBadge({
 
   const makeAssignedTooltipText = (actor: Actor) => {
     // Cant use StyledTag's tooltipText prop because
-    // it screws with the nested div style ()
+    // it screws with the nested div style
     return (
       <TooltipWrapper>
-        {tct('Assigned to [name]', {
-          name: actor.type === 'team' ? `#${actor.name}` : actor.name,
-        })}
+        {t('Assigned to')} {actor.type === 'team' ? `#${actor.name}` : actor.name}
         {assignmentReason && <TooltipSubtext>{assignmentReason}</TooltipSubtext>}
       </TooltipWrapper>
     );

--- a/static/app/components/assigneeBadge.tsx
+++ b/static/app/components/assigneeBadge.tsx
@@ -5,8 +5,10 @@ import styled from '@emotion/styled';
 import ActorAvatar from 'sentry/components/avatar/actorAvatar';
 import Tag from 'sentry/components/badge/tag';
 import {Chevron} from 'sentry/components/chevron';
+import ExternalLink from 'sentry/components/links/externalLink';
 import Placeholder from 'sentry/components/placeholder';
-import {tct} from 'sentry/locale';
+import {Tooltip} from 'sentry/components/tooltip';
+import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {Actor} from 'sentry/types';
 
@@ -38,14 +40,7 @@ export function AssigneeBadge({
           actor={actor}
           className="avatar"
           size={AVATAR_SIZE}
-          tooltip={
-            <TooltipWrapper>
-              {tct('Assigned to [name]', {
-                name: actor.type === 'team' ? `#${actor.name}` : actor.name,
-              })}
-              {assignmentReason && <TooltipSubtext>{assignmentReason}</TooltipSubtext>}
-            </TooltipWrapper>
-          }
+          hasTooltip={false}
         />
         {showLabel && <Fragment>{actor.name}</Fragment>}
         <Chevron direction="down" size="small" />
@@ -67,10 +62,42 @@ export function AssigneeBadge({
     );
   };
 
+  const makeAssignedTooltipText = (actor: Actor) => {
+    // Cant use StyledTag's tooltipText prop because
+    // it screws with the nested div style ()
+    return (
+      <TooltipWrapper>
+        {tct('Assigned to [name]', {
+          name: actor.type === 'team' ? `#${actor.name}` : actor.name,
+        })}
+        {assignmentReason && <TooltipSubtext>{assignmentReason}</TooltipSubtext>}
+      </TooltipWrapper>
+    );
+  };
+
+  const makeUnAssignedTooltipText = () => {
+    return (
+      <TooltipWrapper>
+        <div>{t('Unassigned')}</div>
+        <TooltipSubtext>
+          {tct('You can auto-assign issues by adding [issueOwners:Issue Owner rules].', {
+            issueOwners: (
+              <TooltipSubExternalLink href="https://docs.sentry.io/product/error-monitoring/issue-owners/" />
+            ),
+          })}
+        </TooltipSubtext>
+      </TooltipWrapper>
+    );
+  };
+
   return assignedTo ? (
-    <StyledTag icon={makeAssignedIcon(assignedTo)} />
+    <Tooltip title={makeAssignedTooltipText(assignedTo)}>
+      <StyledTag icon={makeAssignedIcon(assignedTo)} />
+    </Tooltip>
   ) : (
-    <StyledTag icon={makeUnassignedIcon()} borderStyle="dashed" />
+    <Tooltip title={makeUnAssignedTooltipText()}>
+      <StyledTag icon={makeUnassignedIcon()} borderStyle="dashed" />
+    </Tooltip>
   );
 }
 
@@ -82,15 +109,6 @@ export function AssigneeBadge({
 const TooltipWrapper = styled('div')`
   text-align: left;
 `;
-
-// const TooltipSubExternalLink = styled(ExternalLink)`
-//   color: ${p => p.theme.subText};
-//   text-decoration: underline;
-
-//   :hover {
-//     color: ${p => p.theme.subText};
-//   }
-// `;
 
 const StyledTag = styled(Tag)`
   span {
@@ -108,11 +126,11 @@ const TooltipSubtext = styled('div')`
   color: ${p => p.theme.subText};
 `;
 
-// const PillOutline = styled('div')<{assigneeExists: boolean}>`
-//   display: inline-flex;
-//   padding: 2px 4px 4px 4px;
-//   border: 1px ${p => (p.assigneeExists ? 'solid' : 'dashed')} ${p => p.theme.border};
-//   border-radius: 16px;
-//   align-items: center;
-//   align-self: flex-start;
-// `;
+const TooltipSubExternalLink = styled(ExternalLink)`
+  color: ${p => p.theme.subText};
+  text-decoration: underline;
+
+  :hover {
+    color: ${p => p.theme.subText};
+  }
+`;

--- a/static/app/components/assigneeBadge.tsx
+++ b/static/app/components/assigneeBadge.tsx
@@ -36,7 +36,11 @@ export function AssigneeBadge({
           className="avatar"
           size={AVATAR_SIZE}
           hasTooltip={false}
-          style={{paddingLeft: space(1)}}
+          // Team avatars need extra left margin since the
+          // square team avatar is being fit into a rounded borders
+          css={css`
+            margin-left: ${actor.type === 'team' ? space(0.5) : space(0)};
+          `}
         />
         {showLabel && <Fragment>{actor.name}</Fragment>}
         <Chevron direction={chevronDirection} size="small" />
@@ -60,22 +64,13 @@ export function AssigneeBadge({
     <Tooltip
       title={
         <TooltipWrapper>
-          {t('Assigned to')}{' '}
+          {t('Assigned to ')}
           {assignedTo.type === 'team' ? `#${assignedTo.name}` : assignedTo.name}
           {assignmentReason && <TooltipSubtext>{assignmentReason}</TooltipSubtext>}
         </TooltipWrapper>
       }
     >
-      <StyledTag
-        data-is-team={assignedTo.type === 'team'}
-        // Team avatars need extra left padding since the square avatar
-        // is being fit into a rounded edge
-        css={css`
-          --avatar-spacing: ${space(0.5)} ${space(0.25)} ${space(0.5)}
-            ${assignedTo.type === 'team' ? space(0.75) : space(0.5)};
-        `}
-        icon={makeAssignedIcon(assignedTo)}
-      />
+      <StyledTag icon={makeAssignedIcon(assignedTo)} />
     </Tooltip>
   ) : (
     <Tooltip
@@ -112,7 +107,8 @@ const StyledTag = styled(Tag)`
   }
   & > div {
     height: 24px;
-    padding: var(--avatar-spacing, ${space(0.5)});
+    padding: ${space(0.5)};
+    padding-right: ${space(0.25)};
   }
   cursor: pointer;
 `;

--- a/static/app/components/assigneeBadge.tsx
+++ b/static/app/components/assigneeBadge.tsx
@@ -12,9 +12,9 @@ import {space} from 'sentry/styles/space';
 import type {Actor} from 'sentry/types';
 
 type AssigneeBadgeProps = {
-  chevronDirection: 'up' | 'down';
   assignedTo?: Actor | undefined;
   assignmentReason?: string;
+  chevronDirection?: 'up' | 'down';
   showLabel?: boolean;
 };
 

--- a/static/app/components/assigneeBadge.tsx
+++ b/static/app/components/assigneeBadge.tsx
@@ -10,12 +10,12 @@ import Placeholder from 'sentry/components/placeholder';
 import {Tooltip} from 'sentry/components/tooltip';
 import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
-import type {Actor} from 'sentry/types';
+import type {Actor, SuggestedOwnerReason} from 'sentry/types';
 import {lightTheme as theme} from 'sentry/utils/theme';
 
 type AssigneeBadgeProps = {
   assignedTo?: Actor | undefined;
-  assignmentReason?: string;
+  assignmentReason?: SuggestedOwnerReason;
   chevronDirection?: 'up' | 'down';
   loading?: boolean;
   showLabel?: boolean;
@@ -30,6 +30,17 @@ export function AssigneeBadge({
   chevronDirection = 'down',
   loading = false,
 }: AssigneeBadgeProps) {
+  const suggestedReasons: Record<SuggestedOwnerReason, React.ReactNode> = {
+    suspectCommit: tct('Based on [commit:commit data]', {
+      commit: (
+        <TooltipSubExternalLink href="https://docs.sentry.io/product/sentry-basics/integrate-frontend/configure-scms/" />
+      ),
+    }),
+    ownershipRule: t('Matching Issue Owners Rule'),
+    projectOwnership: t('Matching Issue Owners Rule'),
+    codeowners: t('Matching Codeowners Rule'),
+  };
+
   const makeAssignedIcon = (actor: Actor) => {
     return (
       <Fragment>
@@ -38,6 +49,7 @@ export function AssigneeBadge({
           className="avatar"
           size={AVATAR_SIZE}
           hasTooltip={false}
+          data-test-id="assigned-avatar"
           // Team avatars need extra left margin since the
           // square team avatar is being fit into a rounded borders
           style={{
@@ -82,7 +94,9 @@ export function AssigneeBadge({
         <TooltipWrapper>
           {t('Assigned to ')}
           {assignedTo.type === 'team' ? `#${assignedTo.name}` : assignedTo.name}
-          {assignmentReason && <TooltipSubtext>{assignmentReason}</TooltipSubtext>}
+          {assignmentReason && (
+            <TooltipSubtext>{suggestedReasons[assignmentReason]}</TooltipSubtext>
+          )}
         </TooltipWrapper>
       }
     >

--- a/static/app/components/assigneeBadge.tsx
+++ b/static/app/components/assigneeBadge.tsx
@@ -1,6 +1,4 @@
-// import {Fragment} from 'react';
 import {Fragment} from 'react';
-import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import ActorAvatar from 'sentry/components/avatar/actorAvatar';
@@ -38,9 +36,7 @@ export function AssigneeBadge({
           hasTooltip={false}
           // Team avatars need extra left margin since the
           // square team avatar is being fit into a rounded borders
-          css={css`
-            margin-left: ${actor.type === 'team' ? space(0.5) : space(0)};
-          `}
+          style={{marginLeft: actor.type === 'team' ? space(0.5) : space(0)}}
         />
         {showLabel && (
           <Fragment>{`${actor.type === 'team' ? '#' : ''}${actor.name}`}</Fragment>

--- a/static/app/components/assigneeBadge.tsx
+++ b/static/app/components/assigneeBadge.tsx
@@ -5,16 +5,19 @@ import ActorAvatar from 'sentry/components/avatar/actorAvatar';
 import Tag from 'sentry/components/badge/tag';
 import {Chevron} from 'sentry/components/chevron';
 import ExternalLink from 'sentry/components/links/externalLink';
+import LoadingIndicator from 'sentry/components/loadingIndicator';
 import Placeholder from 'sentry/components/placeholder';
 import {Tooltip} from 'sentry/components/tooltip';
 import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {Actor} from 'sentry/types';
+import {lightTheme as theme} from 'sentry/utils/theme';
 
 type AssigneeBadgeProps = {
   assignedTo?: Actor | undefined;
   assignmentReason?: string;
   chevronDirection?: 'up' | 'down';
+  loading?: boolean;
   showLabel?: boolean;
 };
 
@@ -25,6 +28,7 @@ export function AssigneeBadge({
   assignmentReason,
   showLabel = false,
   chevronDirection = 'down',
+  loading = false,
 }: AssigneeBadgeProps) {
   const makeAssignedIcon = (actor: Actor) => {
     return (
@@ -36,15 +40,23 @@ export function AssigneeBadge({
           hasTooltip={false}
           // Team avatars need extra left margin since the
           // square team avatar is being fit into a rounded borders
-          style={{marginLeft: actor.type === 'team' ? space(0.5) : space(0)}}
+          style={{
+            marginLeft: actor.type === 'team' ? space(0.5) : space(0),
+          }}
         />
-        {showLabel && (
-          <Fragment>{`${actor.type === 'team' ? '#' : ''}${actor.name}`}</Fragment>
-        )}
+        {showLabel && <div>{`${actor.type === 'team' ? '#' : ''}${actor.name}`}</div>}
         <Chevron direction={chevronDirection} size="small" />
       </Fragment>
     );
   };
+
+  const loadingIcon = (
+    <Fragment>
+      <StyledLoadingIndicator mini hideMessage relative size={AVATAR_SIZE} />
+      {showLabel && 'Loading...'}
+      <Chevron direction={chevronDirection} size="small" />
+    </Fragment>
+  );
 
   const unassignedIcon = (
     <Fragment>
@@ -58,7 +70,9 @@ export function AssigneeBadge({
     </Fragment>
   );
 
-  return assignedTo ? (
+  return loading ? (
+    <StyledTag icon={loadingIcon} />
+  ) : assignedTo ? (
     <Tooltip
       title={
         <TooltipWrapper>
@@ -68,7 +82,7 @@ export function AssigneeBadge({
         </TooltipWrapper>
       }
     >
-      <StyledTag icon={makeAssignedIcon(assignedTo)} />
+      <StyledTag icon={makeAssignedIcon(assignedTo)} style={{color: theme.textColor}} />
     </Tooltip>
   ) : (
     <Tooltip
@@ -93,6 +107,11 @@ export function AssigneeBadge({
   );
 }
 
+const StyledLoadingIndicator = styled(LoadingIndicator)`
+  display: inline-flex;
+  align-items: center;
+`;
+
 const TooltipWrapper = styled('div')`
   text-align: left;
 `;
@@ -107,6 +126,7 @@ const StyledTag = styled(Tag)`
     height: 24px;
     padding: ${space(0.5)};
   }
+  color: ${p => p.theme.subText};
   cursor: pointer;
 `;
 

--- a/static/app/components/assigneeBadge.tsx
+++ b/static/app/components/assigneeBadge.tsx
@@ -44,48 +44,28 @@ export function AssigneeBadge({
     );
   };
 
-  const makeUnassignedIcon = () => {
-    return (
-      <Fragment>
-        <Placeholder
-          shape="circle"
-          width={`${AVATAR_SIZE}px`}
-          height={`${AVATAR_SIZE}px`}
-        />
-        {showLabel && <Fragment>Unassigned</Fragment>}
-        <Chevron direction={chevronDirection} size="small" />
-      </Fragment>
-    );
-  };
-
-  const makeAssignedTooltipText = (actor: Actor) => {
-    // Cant use StyledTag's tooltipText prop because
-    // it screws with the nested div style
-    return (
-      <TooltipWrapper>
-        {t('Assigned to')} {actor.type === 'team' ? `#${actor.name}` : actor.name}
-        {assignmentReason && <TooltipSubtext>{assignmentReason}</TooltipSubtext>}
-      </TooltipWrapper>
-    );
-  };
-
-  const makeUnAssignedTooltipText = () => {
-    return (
-      <TooltipWrapper>
-        <div>{t('Unassigned')}</div>
-        <TooltipSubtext>
-          {tct('You can auto-assign issues by adding [issueOwners:Issue Owner rules].', {
-            issueOwners: (
-              <TooltipSubExternalLink href="https://docs.sentry.io/product/error-monitoring/issue-owners/" />
-            ),
-          })}
-        </TooltipSubtext>
-      </TooltipWrapper>
-    );
-  };
+  const unassignedIcon = (
+    <Fragment>
+      <Placeholder
+        shape="circle"
+        width={`${AVATAR_SIZE}px`}
+        height={`${AVATAR_SIZE}px`}
+      />
+      {showLabel && <Fragment>Unassigned</Fragment>}
+      <Chevron direction={chevronDirection} size="small" />
+    </Fragment>
+  );
 
   return assignedTo ? (
-    <Tooltip title={makeAssignedTooltipText(assignedTo)}>
+    <Tooltip
+      title={
+        <TooltipWrapper>
+          {t('Assigned to')}{' '}
+          {assignedTo.type === 'team' ? `#${assignedTo.name}` : assignedTo.name}
+          {assignmentReason && <TooltipSubtext>{assignmentReason}</TooltipSubtext>}
+        </TooltipWrapper>
+      }
+    >
       <StyledTag
         data-is-team={assignedTo.type === 'team'}
         // Team avatars need extra left padding since the square avatar
@@ -98,8 +78,24 @@ export function AssigneeBadge({
       />
     </Tooltip>
   ) : (
-    <Tooltip title={makeUnAssignedTooltipText()}>
-      <StyledTag icon={makeUnassignedIcon()} borderStyle="dashed" />
+    <Tooltip
+      title={
+        <TooltipWrapper>
+          <div>{t('Unassigned')}</div>
+          <TooltipSubtext>
+            {tct(
+              'You can auto-assign issues by adding [issueOwners:Issue Owner rules].',
+              {
+                issueOwners: (
+                  <TooltipSubExternalLink href="https://docs.sentry.io/product/error-monitoring/issue-owners/" />
+                ),
+              }
+            )}
+          </TooltipSubtext>
+        </TooltipWrapper>
+      }
+    >
+      <StyledTag icon={unassignedIcon} borderStyle="dashed" />
     </Tooltip>
   );
 }


### PR DESCRIPTION
This PR creates a new component `<AssigneeBadge/>` which will eventually replace  the current assignee selector trigger in the issue stream. This PR does **not** make any changes to the selector, it merely creates the component and a corresponding storybook entry so it can be iterated on independent of any changes made to the issue stream. 

More details of the project can be found [here](https://github.com/getsentry/sentry/issues/69827) (#69827)

At a glance (as of 5/9):
<img width="206" alt="image" src="https://github.com/getsentry/sentry/assets/55160142/9da5fa59-4cc0-4dcf-be27-b7fcc5c686e3">

Note that unlike the previous assignee selector, there is no longer a "Suggested Assignee" state for this new assignee selector, there is only an Assigned and Unassigned state. 

TODO:
- [x] Figure out what the loading state looks like
- [x] Chevron weight and style match border
- [x] Add tests