### PR TITLE
chore(api-idorslug): Updating Comments to Reflect Support for `organization_id_or_slug`

### DIFF
--- a/src/sentry/api/endpoints/artifact_bundles.py
+++ b/src/sentry/api/endpoints/artifact_bundles.py
@@ -67,7 +67,7 @@ class ArtifactBundlesEndpoint(ProjectEndpoint, ArtifactBundlesMixin):
 
         Retrieve a list of artifact bundles for a given project.
 
-        :pparam string organization_slug: the slug of the organization the
+        :pparam string organization_slug: the id or slug of the organization the
                                           artifact bundle belongs to.
         :pparam string project_id_or_slug: the id or slug of the project to list the
                                      artifact bundles of.
@@ -121,7 +121,7 @@ class ArtifactBundlesEndpoint(ProjectEndpoint, ArtifactBundlesMixin):
 
         Delete all artifacts inside given archive.
 
-        :pparam string organization_slug: the slug of the organization the
+        :pparam string organization_slug: the id or slug of the organization the
                                             archive belongs to.
         :pparam string project_id_or_slug: the id or slug of the project to delete the
                                         archive of.

--- a/src/sentry/api/endpoints/artifact_lookup.py
+++ b/src/sentry/api/endpoints/artifact_lookup.py
@@ -104,7 +104,7 @@ class ProjectArtifactLookupEndpoint(ProjectEndpoint):
 
         Retrieve a list of individual artifacts or artifact bundles for a given project.
 
-        :pparam string organization_slug: the slug of the organization to query.
+        :pparam string organization_slug: the id or slug of the organization to query.
         :pparam string project_id_or_slug: the id or slug of the project to query.
         :qparam string debug_id: if set, will query and return the artifact
                                  bundle that matches the given `debug_id`.

--- a/src/sentry/api/endpoints/codeowners/details.py
+++ b/src/sentry/api/endpoints/codeowners/details.py
@@ -58,7 +58,7 @@ class ProjectCodeOwnersDetailsEndpoint(ProjectEndpoint, ProjectCodeOwnersMixin):
         Update a CodeOwners
         `````````````
 
-        :pparam string organization_slug: the slug of the organization.
+        :pparam string organization_slug: the id or slug of the organization.
         :pparam string project_id_or_slug: the id or slug of the project to get.
         :pparam string codeowners_id: id of codeowners object
         :param string raw: the raw CODEOWNERS text

--- a/src/sentry/api/endpoints/codeowners/external_actor/user_details.py
+++ b/src/sentry/api/endpoints/codeowners/external_actor/user_details.py
@@ -48,7 +48,7 @@ class ExternalUserDetailsEndpoint(OrganizationEndpoint, ExternalActorEndpointMix
         Update an External User
         `````````````
 
-        :pparam string organization_slug: the slug of the organization the
+        :pparam string organization_slug: the id or slug of the organization the
                                           user belongs to.
         :pparam int user_id: the User id.
         :pparam string external_user_id: id of external_user object

--- a/src/sentry/api/endpoints/codeowners/external_actor/user_index.py
+++ b/src/sentry/api/endpoints/codeowners/external_actor/user_index.py
@@ -27,7 +27,7 @@ class ExternalUserEndpoint(OrganizationEndpoint, ExternalActorEndpointMixin):
         Create an External User
         `````````````
 
-        :pparam string organization_slug: the slug of the organization the
+        :pparam string organization_slug: the id or slug of the organization the
                                           user belongs to.
         :param required string provider: enum("github", "gitlab", "slack")
         :param required string external_name: the associated username for this provider.

--- a/src/sentry/api/endpoints/codeowners/index.py
+++ b/src/sentry/api/endpoints/codeowners/index.py
@@ -88,7 +88,7 @@ class ProjectCodeOwnersEndpoint(ProjectEndpoint, ProjectCodeOwnersMixin):
         Upload a CODEOWNERS for project
         `````````````
 
-        :pparam string organization_slug: the slug of the organization.
+        :pparam string organization_slug: the id or slug of the organization.
         :pparam string project_id_or_slug: the id or slug of the project to get.
         :param string raw: the raw CODEOWNERS text
         :param string codeMappingId: id of the RepositoryProjectPathConfig object

--- a/src/sentry/api/endpoints/debug_files.py
+++ b/src/sentry/api/endpoints/debug_files.py
@@ -157,7 +157,7 @@ class ProguardArtifactReleasesEndpoint(ProjectEndpoint):
 
         Retrieve a list of associated releases for a given Proguard File.
 
-        :pparam string organization_slug: the slug of the organization the
+        :pparam string organization_slug: the id or slug of the organization the
                                           file belongs to.
         :pparam string project_id_or_slug: the id or slug of the project to list the
                                      DIFs of.
@@ -227,7 +227,7 @@ class DebugFilesEndpoint(ProjectEndpoint):
 
         Retrieve a list of debug information files for a given project.
 
-        :pparam string organization_slug: the slug of the organization the
+        :pparam string organization_slug: the id or slug of the organization the
                                           file belongs to.
         :pparam string project_id_or_slug: the id or slug of the project to list the
                                      DIFs of.
@@ -312,7 +312,7 @@ class DebugFilesEndpoint(ProjectEndpoint):
 
         Delete a debug information file for a given project.
 
-        :pparam string organization_slug: the slug of the organization the
+        :pparam string organization_slug: the id or slug of the organization the
                                           file belongs to.
         :pparam string project_id_or_slug: the id or slug of the project to delete the
                                      DIF.
@@ -346,7 +346,7 @@ class DebugFilesEndpoint(ProjectEndpoint):
         contains the individual debug images.  Uploading through this endpoint
         will create different files for the contained images.
 
-        :pparam string organization_slug: the slug of the organization the
+        :pparam string organization_slug: the id or slug of the organization the
                                           release belongs to.
         :pparam string project_id_or_slug: the id or slug of the project to change the
                                      release of.
@@ -521,7 +521,7 @@ class SourceMapsEndpoint(ProjectEndpoint):
 
         Retrieve a list of source map archives (releases, later bundles) for a given project.
 
-        :pparam string organization_slug: the slug of the organization the
+        :pparam string organization_slug: the id or slug of the organization the
                                           source map archive belongs to.
         :pparam string project_id_or_slug: the id or slug of the project to list the
                                      source map archives of.
@@ -585,7 +585,7 @@ class SourceMapsEndpoint(ProjectEndpoint):
 
         Delete all artifacts inside given archive.
 
-        :pparam string organization_slug: the slug of the organization the
+        :pparam string organization_slug: the id or slug of the organization the
                                             archive belongs to.
         :pparam string project_id_or_slug: the id or slug of the project to delete the
                                         archive of.

--- a/src/sentry/api/endpoints/event_attachment_details.py
+++ b/src/sentry/api/endpoints/event_attachment_details.py
@@ -78,7 +78,7 @@ class EventAttachmentDetailsEndpoint(ProjectEndpoint):
         Retrieve an Attachment
         ``````````````````````
 
-        :pparam string organization_slug: the slug of the organization the
+        :pparam string organization_slug: the id or slug of the organization the
                                           issues belong to.
         :pparam string project_id_or_slug: the id or slug of the project the event
                                      belongs to.

--- a/src/sentry/api/endpoints/event_attachments.py
+++ b/src/sentry/api/endpoints/event_attachments.py
@@ -24,7 +24,7 @@ class EventAttachmentsEndpoint(ProjectEndpoint):
         Retrieve attachments for an event
         `````````````````````````````````
 
-        :pparam string organization_slug: the slug of the organization the
+        :pparam string organization_slug: the id or slug of the organization the
                                           issues belong to.
         :pparam string project_id_or_slug: the id or slug of the project the event
                                      belongs to.

--- a/src/sentry/api/endpoints/event_reprocessable.py
+++ b/src/sentry/api/endpoints/event_reprocessable.py
@@ -48,7 +48,7 @@ class EventReprocessableEndpoint(ProjectEndpoint):
         * `attachment.not_found`: A required attachment, such as the original
           minidump, is missing.
 
-        :pparam string organization_slug: the slug of the organization the
+        :pparam string organization_slug: the id or slug of the organization the
                                           issues belong to.
         :pparam string project_id_or_slug: the id or slug of the project the event
                                      belongs to.

--- a/src/sentry/api/endpoints/filechange.py
+++ b/src/sentry/api/endpoints/filechange.py
@@ -29,7 +29,7 @@ class CommitFileChangeEndpoint(OrganizationReleasesBaseEndpoint):
 
         Retrieve a list of files that were changed in a given release's commits.
 
-        :pparam string organization_slug: the slug of the organization the
+        :pparam string organization_slug: the id or slug of the organization the
                                           release belongs to.
         :pparam string version: the version identifier of the release.
 

--- a/src/sentry/api/endpoints/group_tombstone_details.py
+++ b/src/sentry/api/endpoints/group_tombstone_details.py
@@ -25,7 +25,7 @@ class GroupTombstoneDetailsEndpoint(ProjectEndpoint):
         Undiscards a group such that new events in that group will be captured.
         This does not restore any previous data.
 
-        :pparam string organization_slug: the slug of the organization.
+        :pparam string organization_slug: the id or slug of the organization.
         :pparam string project_id_or_slug: the id or slug of the project to which this tombstone belongs.
         :pparam string tombstone_id: the ID of the tombstone to remove.
         :auth: required

--- a/src/sentry/api/endpoints/organization_api_key_details.py
+++ b/src/sentry/api/endpoints/organization_api_key_details.py
@@ -36,7 +36,7 @@ class OrganizationApiKeyDetailsEndpoint(ControlSiloOrganizationEndpoint):
         Retrieves API Key details
         `````````````````````````
 
-        :pparam string organization_slug: the slug of the organization the
+        :pparam string organization_slug: the id or slug of the organization the
                                           team belongs to.
         :pparam string api_key_id: the ID of the api key to delete
         :auth: required
@@ -53,7 +53,7 @@ class OrganizationApiKeyDetailsEndpoint(ControlSiloOrganizationEndpoint):
         Update an API Key
         `````````````````
 
-        :pparam string organization_slug: the slug of the organization the
+        :pparam string organization_slug: the id or slug of the organization the
                                           team belongs to.
         :pparam string api_key_id: the ID of the api key to delete
         :param string label: the new label for the api key
@@ -89,7 +89,7 @@ class OrganizationApiKeyDetailsEndpoint(ControlSiloOrganizationEndpoint):
         Deletes an API Key
         ``````````````````
 
-        :pparam string organization_slug: the slug of the organization the
+        :pparam string organization_slug: the id or slug of the organization the
                                           team belongs to.
         :pparam string api_key_id: the ID of the api key to delete
         :auth: required

--- a/src/sentry/api/endpoints/organization_code_mapping_details.py
+++ b/src/sentry/api/endpoints/organization_code_mapping_details.py
@@ -50,7 +50,7 @@ class OrganizationCodeMappingDetailsEndpoint(OrganizationEndpoint, OrganizationI
         Update a repository project path config
         ``````````````````
 
-        :pparam string organization_slug: the slug of the organization the
+        :pparam string organization_slug: the id or slug of the organization the
                                           team should be created for.
         :param int repository_id:
         :param int project_id:

--- a/src/sentry/api/endpoints/organization_code_mappings.py
+++ b/src/sentry/api/endpoints/organization_code_mappings.py
@@ -141,7 +141,7 @@ class OrganizationCodeMappingsEndpoint(OrganizationEndpoint, OrganizationIntegra
         """
         Get the list of repository project path configs
 
-        :pparam string organization_slug: the slug of the organization the
+        :pparam string organization_slug: the id or slug of the organization the
                                           team should be created for.
         :qparam int integrationId: the optional integration id.
         :qparam int project: Optional. Pass "-1" to filter to 'all projects user has access to'. Omit to filter for 'all projects user is a member of'.
@@ -175,7 +175,7 @@ class OrganizationCodeMappingsEndpoint(OrganizationEndpoint, OrganizationIntegra
         Create a new repository project path config
         ``````````````````
 
-        :pparam string organization_slug: the slug of the organization the
+        :pparam string organization_slug: the id or slug of the organization the
                                           team should be created for.
         :param int repositoryId:
         :param int projectId:

--- a/src/sentry/api/endpoints/organization_dashboards.py
+++ b/src/sentry/api/endpoints/organization_dashboards.py
@@ -49,7 +49,7 @@ class OrganizationDashboardsEndpoint(OrganizationEndpoint):
         If on the first page, this endpoint will also include any pre-built dashboards
         that haven't been replaced or removed.
 
-        :pparam string organization_slug: the slug of the organization the
+        :pparam string organization_slug: the id or slug of the organization the
                                           dashboards belongs to.
         :qparam string query: the title of the dashboard being searched for.
         :auth: required
@@ -142,7 +142,7 @@ class OrganizationDashboardsEndpoint(OrganizationEndpoint):
         ``````````````````````````````````````````
 
         Create a new dashboard for the given Organization
-        :pparam string organization_slug: the slug of the organization the
+        :pparam string organization_slug: the id or slug of the organization the
                                           dashboards belongs to.
         """
         if not features.has("organizations:dashboards-edit", organization, actor=request.user):

--- a/src/sentry/api/endpoints/organization_details.py
+++ b/src/sentry/api/endpoints/organization_details.py
@@ -555,7 +555,7 @@ class OrganizationDetailsEndpoint(OrganizationEndpoint):
         Return details on an individual organization including various details
         such as membership access, features, and teams.
 
-        :pparam string organization_slug: the slug of the organization the
+        :pparam string organization_slug: the id or slug of the organization the
                                           team should be created for.
         :param string detailed: Specify '0' to retrieve details without projects and teams.
         :auth: required
@@ -581,7 +581,7 @@ class OrganizationDetailsEndpoint(OrganizationEndpoint):
         Update various attributes and configurable settings for the given
         organization.
 
-        :pparam string organization_slug: the slug of the organization the
+        :pparam string organization_slug: the id or slug of the organization the
                                           team should be created for.
         :param string name: an optional new name for the organization.
         :param string slug: an optional new slug for the organization.  Needs
@@ -714,7 +714,7 @@ class OrganizationDetailsEndpoint(OrganizationEndpoint):
         However once deletion has begun the state of an organization changes and
         will be hidden from most public views.
 
-        :pparam string organization_slug: the slug of the organization the
+        :pparam string organization_slug: the id or slug of the organization the
                                           team should be created for.
         :auth: required, user-context-needed
         """

--- a/src/sentry/api/endpoints/organization_eventid.py
+++ b/src/sentry/api/endpoints/organization_eventid.py
@@ -35,7 +35,7 @@ class EventIdLookupEndpoint(OrganizationEndpoint):
 
         This resolves an event ID to the project slug and internal issue ID and internal event ID.
 
-        :pparam string organization_slug: the slug of the organization the
+        :pparam string organization_slug: the id or slug of the organization the
                                           event ID should be looked up in.
         :param string event_id: the event ID to look up. validated by a
                                 regex in the URL.

--- a/src/sentry/api/endpoints/organization_issues_resolved_in_release.py
+++ b/src/sentry/api/endpoints/organization_issues_resolved_in_release.py
@@ -26,7 +26,7 @@ class OrganizationIssuesResolvedInReleaseEndpoint(OrganizationEndpoint, Environm
 
         Retrieve a list of issues to be resolved in a given release.
 
-        :pparam string organization_slug: the slug of the organization the
+        :pparam string organization_slug: the id or slug of the organization the
                                           release belongs to.
         :pparam string version: the version identifier of the release.
         :auth: required

--- a/src/sentry/api/endpoints/organization_member/requests/invite/details.py
+++ b/src/sentry/api/endpoints/organization_member/requests/invite/details.py
@@ -90,7 +90,7 @@ class OrganizationInviteRequestDetailsEndpoint(OrganizationMemberEndpoint):
 
         Update and/or approve an invite request to an organization.
 
-        :pparam string organization_slug: the slug of the organization the member will belong to
+        :pparam string organization_slug: the id or slug of the organization the member will belong to
         :param string member_id: the member ID
         :param boolean approve: allows the member to be invited
         :param string role: the suggested role of the new member
@@ -171,7 +171,7 @@ class OrganizationInviteRequestDetailsEndpoint(OrganizationMemberEndpoint):
 
         Delete an invite request to an organization.
 
-        :pparam string organization_slug: the slug of the organization the member would belong to
+        :pparam string organization_slug: the id or slug of the organization the member would belong to
         :param string member_id: the member ID
 
         :auth: required

--- a/src/sentry/api/endpoints/organization_member/requests/invite/index.py
+++ b/src/sentry/api/endpoints/organization_member/requests/invite/index.py
@@ -61,7 +61,7 @@ class OrganizationInviteRequestIndexEndpoint(OrganizationEndpoint):
 
         Creates an invite request given an email and suggested role / teams.
 
-        :pparam string organization_slug: the slug of the organization the member will belong to
+        :pparam string organization_slug: the id or slug of the organization the member will belong to
         :param string email: the email address to invite
         :param string role: the suggested role of the new member
         :param string orgRole: the suggested org-role of the new member

--- a/src/sentry/api/endpoints/organization_processingissues.py
+++ b/src/sentry/api/endpoints/organization_processingissues.py
@@ -21,7 +21,7 @@ class OrganizationProcessingIssuesEndpoint(OrganizationEndpoint):
         For each Project in an Organization, list its processing issues. Can
         be passed `project` to filter down to specific projects.
 
-        :pparam string organization_slug: the slug of the organization.
+        :pparam string organization_slug: the id or slug of the organization.
         :qparam array[string] project: An optional list of project ids to filter
         to within the organization
         :auth: required

--- a/src/sentry/api/endpoints/organization_projects_experiment.py
+++ b/src/sentry/api/endpoints/organization_projects_experiment.py
@@ -71,7 +71,7 @@ class OrganizationProjectsExperimentEndpoint(OrganizationEndpoint):
         If this is taken, a random three letter suffix is added as needed
         (eg: ...-gnm, ...-zls). Then create a new project bound to this team
 
-        :pparam string organization_slug: the slug of the organization the
+        :pparam string organization_slug: the id or slug of the organization the
                                           team should be created for.
         :param string name: the name for the new project.
         :param string platform: the optional platform that this project is for.

--- a/src/sentry/api/endpoints/organization_projects_sent_first_event.py
+++ b/src/sentry/api/endpoints/organization_projects_sent_first_event.py
@@ -23,7 +23,7 @@ class OrganizationProjectsSentFirstEventEndpoint(OrganizationEndpoint):
         Returns true if any projects within the organization have received
         a first event, false otherwise.
 
-        :pparam string organization_slug: the slug of the organization
+        :pparam string organization_slug: the id or slug of the organization
                                           containing the projects to check
                                           for a first event from.
         :qparam array[string] project:    An optional list of project ids to filter

--- a/src/sentry/api/endpoints/organization_release_commits.py
+++ b/src/sentry/api/endpoints/organization_release_commits.py
@@ -23,7 +23,7 @@ class OrganizationReleaseCommitsEndpoint(OrganizationReleasesBaseEndpoint):
 
         Retrieve a list of commits for a given release.
 
-        :pparam string organization_slug: the slug of the organization the
+        :pparam string organization_slug: the id or slug of the organization the
                                           release belongs to.
         :pparam string version: the version identifier of the release.
         :auth: required

--- a/src/sentry/api/endpoints/organization_release_details.py
+++ b/src/sentry/api/endpoints/organization_release_details.py
@@ -288,7 +288,7 @@ class OrganizationReleaseDetailsEndpoint(
 
         Return details on an individual release.
 
-        :pparam string organization_slug: the slug of the organization the
+        :pparam string organization_slug: the id or slug of the organization the
                                           release belongs to.
         :pparam string version: the version identifier of the release.
         :auth: required
@@ -383,7 +383,7 @@ class OrganizationReleaseDetailsEndpoint(
         Update a release. This can change some metadata associated with
         the release (the ref, url, and dates).
 
-        :pparam string organization_slug: the slug of the organization the
+        :pparam string organization_slug: the id or slug of the organization the
                                           release belongs to.
         :pparam string version: the version identifier of the release.
         :param string ref: an optional commit reference.  This is useful if
@@ -510,7 +510,7 @@ class OrganizationReleaseDetailsEndpoint(
 
         Permanently remove a release and all of its files.
 
-        :pparam string organization_slug: the slug of the organization the
+        :pparam string organization_slug: the id or slug of the organization the
                                           release belongs to.
         :pparam string version: the version identifier of the release.
         :auth: required

--- a/src/sentry/api/endpoints/organization_release_file_details.py
+++ b/src/sentry/api/endpoints/organization_release_file_details.py
@@ -33,7 +33,7 @@ class OrganizationReleaseFileDetailsEndpoint(
         not actually return the contents of the file, just the associated
         metadata.
 
-        :pparam string organization_slug: the slug of the organization the
+        :pparam string organization_slug: the id or slug of the organization the
                                           release belongs to.
         :pparam string version: the version identifier of the release.
         :pparam string file_id: the ID of the file to retrieve.
@@ -62,7 +62,7 @@ class OrganizationReleaseFileDetailsEndpoint(
         Update metadata of an existing file.  Currently only the name of
         the file can be changed.
 
-        :pparam string organization_slug: the slug of the organization the
+        :pparam string organization_slug: the id or slug of the organization the
                                           release belongs to.
         :pparam string version: the version identifier of the release.
         :pparam string file_id: the ID of the file to update.
@@ -89,7 +89,7 @@ class OrganizationReleaseFileDetailsEndpoint(
 
         This will also remove the physical file from storage.
 
-        :pparam string organization_slug: the slug of the organization the
+        :pparam string organization_slug: the id or slug of the organization the
                                           release belongs to.
         :pparam string version: the version identifier of the release.
         :pparam string file_id: the ID of the file to delete.

--- a/src/sentry/api/endpoints/organization_release_files.py
+++ b/src/sentry/api/endpoints/organization_release_files.py
@@ -25,7 +25,7 @@ class OrganizationReleaseFilesEndpoint(OrganizationReleasesBaseEndpoint, Release
 
         Retrieve a list of files for a given release.
 
-        :pparam string organization_slug: the slug of the organization the
+        :pparam string organization_slug: the id or slug of the organization the
                                           release belongs to.
         :pparam string version: the version identifier of the release.
         :qparam string query: If set, only files with these partial names will be returned.
@@ -56,7 +56,7 @@ class OrganizationReleaseFilesEndpoint(OrganizationReleasesBaseEndpoint, Release
         that this file will be referenced as. For example, in the case of
         JavaScript you might specify the full web URI.
 
-        :pparam string organization_slug: the slug of the organization the
+        :pparam string organization_slug: the id or slug of the organization the
                                           release belongs to.
         :pparam string version: the version identifier of the release.
         :param string name: the name (full path) of the file.

--- a/src/sentry/api/endpoints/organization_release_meta.py
+++ b/src/sentry/api/endpoints/organization_release_meta.py
@@ -28,7 +28,7 @@ class OrganizationReleaseMetaEndpoint(OrganizationReleasesBaseEndpoint):
 
         The data returned from here is auxiliary meta data that the UI uses.
 
-        :pparam string organization_slug: the slug of the organization the
+        :pparam string organization_slug: the id or slug of the organization the
                                           release belongs to.
         :pparam string version: the version identifier of the release.
         :auth: required

--- a/src/sentry/api/endpoints/organization_releases.py
+++ b/src/sentry/api/endpoints/organization_releases.py
@@ -421,7 +421,7 @@ class OrganizationReleasesEndpoint(
         Releases are also necessary for sourcemaps and other debug features
         that require manual upload for functioning well.
 
-        :pparam string organization_slug: the slug of the organization the
+        :pparam string organization_slug: the id or slug of the organization the
                                           release belongs to.
         :param string version: a version identifier for this release.  Can
                                be a version number, a commit hash etc.

--- a/src/sentry/api/endpoints/organization_shortid.py
+++ b/src/sentry/api/endpoints/organization_shortid.py
@@ -24,7 +24,7 @@ class ShortIdLookupEndpoint(OrganizationEndpoint):
 
         This resolves a short ID to the project slug and internal issue ID.
 
-        :pparam string organization_slug: the slug of the organization the
+        :pparam string organization_slug: the id or slug of the organization the
                                           short ID should be looked up in.
         :pparam string short_id: the short ID to look up.
         :auth: required

--- a/src/sentry/api/endpoints/organization_slugs.py
+++ b/src/sentry/api/endpoints/organization_slugs.py
@@ -25,7 +25,7 @@ class SlugsUpdateEndpoint(OrganizationEndpoint):
 
         Updates the slugs of projects within the organization.
 
-        :pparam string organization_slug: the slug of the organization the
+        :pparam string organization_slug: the id or slug of the organization the
                                           short ID should be looked up in.
         :param slugs: a dictionary of project IDs to their intended slugs.
         :auth: required

--- a/src/sentry/api/endpoints/organization_stats.py
+++ b/src/sentry/api/endpoints/organization_stats.py
@@ -32,7 +32,7 @@ class OrganizationStatsEndpoint(OrganizationEndpoint, EnvironmentMixin, StatsMix
         Return a set of points representing a normalized timestamp and the
         number of events seen in the period.
 
-        :pparam string organization_slug: the slug of the organization for
+        :pparam string organization_slug: the id or slug of the organization for
                                           which the stats should be
                                           retrieved.
         :qparam string stat: the name of the stat to query (``"received"``,

--- a/src/sentry/api/endpoints/organization_user_reports.py
+++ b/src/sentry/api/endpoints/organization_user_reports.py
@@ -35,7 +35,7 @@ class OrganizationUserReportsEndpoint(OrganizationEndpoint):
         Return a list of user feedback items within this organization. Can be
         filtered by projects/environments/creation date.
 
-        :pparam string organization_slug: the slug of the organization.
+        :pparam string organization_slug: the id or slug of the organization.
         :pparam string project_id_or_slug: the id or slug of the project.
         :auth: required
         """

--- a/src/sentry/api/endpoints/organization_users.py
+++ b/src/sentry/api/endpoints/organization_users.py
@@ -27,7 +27,7 @@ class OrganizationUsersEndpoint(OrganizationEndpoint, EnvironmentMixin):
         Return a list of users that belong to a given organization and are part of a project.
 
         :qparam string project: restrict results to users who have access to a given project ID
-        :pparam string organization_slug: the slug of the organization for which the users
+        :pparam string organization_slug: the id or slug of the organization for which the users
                                           should be listed.
         :auth: required
         """

--- a/src/sentry/api/endpoints/project_artifact_bundle_file_details.py
+++ b/src/sentry/api/endpoints/project_artifact_bundle_file_details.py
@@ -63,7 +63,7 @@ class ProjectArtifactBundleFileDetailsEndpoint(
         not actually return the contents of the file, just the associated
         metadata.
 
-        :pparam string organization_slug: the slug of the organization the
+        :pparam string organization_slug: the id or slug of the organization the
                                           release belongs to.
         :pparam string project_id_or_slug: the id or slug of the project to retrieve the
                                      file of.

--- a/src/sentry/api/endpoints/project_artifact_bundle_files.py
+++ b/src/sentry/api/endpoints/project_artifact_bundle_files.py
@@ -69,7 +69,7 @@ class ProjectArtifactBundleFilesEndpoint(ProjectEndpoint):
 
         Retrieve a list of files for a given artifact bundle.
 
-        :pparam string organization_slug: the slug of the organization the
+        :pparam string organization_slug: the id or slug of the organization the
                                           artifact bundle belongs to.
         :pparam string project_id_or_slug: the id or slug of the project the
                                      artifact bundle belongs to.

--- a/src/sentry/api/endpoints/project_commits.py
+++ b/src/sentry/api/endpoints/project_commits.py
@@ -26,7 +26,7 @@ class ProjectCommitsEndpoint(ProjectEndpoint):
 
         Retrieve a list of commits for a given project.
 
-        :pparam string organization_slug: the slug of the organization the
+        :pparam string organization_slug: the id or slug of the organization the
                                           commit belongs to.
         :pparam string project_id_or_slug: the id or slug of the project to list the
                                      commits of.

--- a/src/sentry/api/endpoints/project_environments.py
+++ b/src/sentry/api/endpoints/project_environments.py
@@ -27,7 +27,7 @@ class ProjectEnvironmentsEndpoint(ProjectEndpoint):
                                    environments, or ``"all"`` for both hidden
                                    and visible environments.
 
-        :pparam string organization_slug: the slug of the organization the project
+        :pparam string organization_slug: the id or slug of the organization the project
                                           belongs to.
 
         :pparam string project_id_or_slug: the id or slug of the project.

--- a/src/sentry/api/endpoints/project_event_details.py
+++ b/src/sentry/api/endpoints/project_event_details.py
@@ -64,7 +64,7 @@ class ProjectEventDetailsEndpoint(ProjectEndpoint):
 
         Return details on an individual event.
 
-        :pparam string organization_slug: the slug of the organization the
+        :pparam string organization_slug: the id or slug of the organization the
                                           event belongs to.
         :pparam string project_id_or_slug: the id or slug of the project the event
                                      belongs to.

--- a/src/sentry/api/endpoints/project_events.py
+++ b/src/sentry/api/endpoints/project_events.py
@@ -46,7 +46,7 @@ class ProjectEventsEndpoint(ProjectEndpoint):
         :qparam bool sample: return events in pseudo-random order. This is deterministic,
                              same query will return the same events in the same order.
 
-        :pparam string organization_slug: the slug of the organization the
+        :pparam string organization_slug: the id or slug of the organization the
                                           groups belong to.
         :pparam string project_id_or_slug: the id or slug of the project the groups
                                      belong to.

--- a/src/sentry/api/endpoints/project_group_index.py
+++ b/src/sentry/api/endpoints/project_group_index.py
@@ -77,7 +77,7 @@ class ProjectGroupIndexEndpoint(ProjectEndpoint, EnvironmentMixin):
                                    ``"is:unresolved"`` is assumed.)
         :qparam string environment: this restricts the issues to ones containing
                                     events from this environment
-        :pparam string organization_slug: the slug of the organization the
+        :pparam string organization_slug: the id or slug of the organization the
                                           issues belong to.
         :pparam string project_id_or_slug: the id or slug of the project the issues
                                      belong to.
@@ -214,7 +214,7 @@ class ProjectGroupIndexEndpoint(ProjectEndpoint, EnvironmentMixin):
                                specified status.  Valid values are
                                ``"resolved"``, ``"unresolved"`` and
                                ``"ignored"``.
-        :pparam string organization_slug: the slug of the organization the
+        :pparam string organization_slug: the id or slug of the organization the
                                           issues belong to.
         :pparam string project_id_or_slug: the id or slug of the project the issues
                                      belong to.
@@ -271,7 +271,7 @@ class ProjectGroupIndexEndpoint(ProjectEndpoint, EnvironmentMixin):
 
         :qparam int id: a list of IDs of the issues to be removed.  This
                         parameter shall be repeated for each issue.
-        :pparam string organization_slug: the slug of the organization the
+        :pparam string organization_slug: the id or slug of the organization the
                                           issues belong to.
         :pparam string project_id_or_slug: the id or slug of the project the issues
                                      belong to.

--- a/src/sentry/api/endpoints/project_issues_resolved_in_release.py
+++ b/src/sentry/api/endpoints/project_issues_resolved_in_release.py
@@ -26,7 +26,7 @@ class ProjectIssuesResolvedInReleaseEndpoint(ProjectEndpoint, EnvironmentMixin):
 
         Retrieve a list of issues to be resolved in a given release.
 
-        :pparam string organization_slug: the slug of the organization the
+        :pparam string organization_slug: the id or slug of the organization the
                                           release belongs to.
         :pparam string project_id_or_slug: the id or slug of the project associated with the release.
         :pparam string version: the version identifier of the release.

--- a/src/sentry/api/endpoints/project_performance_issue_settings.py
+++ b/src/sentry/api/endpoints/project_performance_issue_settings.py
@@ -184,7 +184,7 @@ class ProjectPerformanceIssueSettingsEndpoint(ProjectEndpoint):
 
         Return settings for performance issues
 
-        :pparam string organization_slug: the slug of the organization the
+        :pparam string organization_slug: the id or slug of the organization the
                                           project belongs to.
         :pparam string project_id_or_slug: the id or slug of the project to configure.
         :auth: required

--- a/src/sentry/api/endpoints/project_release_commits.py
+++ b/src/sentry/api/endpoints/project_release_commits.py
@@ -26,7 +26,7 @@ class ProjectReleaseCommitsEndpoint(ProjectEndpoint):
 
         Retrieve a list of commits for a given release.
 
-        :pparam string organization_slug: the slug of the organization the
+        :pparam string organization_slug: the id or slug of the organization the
                                           release belongs to.
         :pparam string project_id_or_slug: the id or slug of the project to list the
                                      release files of.

--- a/src/sentry/api/endpoints/project_release_details.py
+++ b/src/sentry/api/endpoints/project_release_details.py
@@ -34,7 +34,7 @@ class ProjectReleaseDetailsEndpoint(ProjectEndpoint, ReleaseAnalyticsMixin):
 
         Return details on an individual release.
 
-        :pparam string organization_slug: the slug of the organization the
+        :pparam string organization_slug: the id or slug of the organization the
                                           release belongs to.
         :pparam string project_id_or_slug: the id or slug of the project to retrieve the
                                      release of.
@@ -78,7 +78,7 @@ class ProjectReleaseDetailsEndpoint(ProjectEndpoint, ReleaseAnalyticsMixin):
         Update a release.  This can change some metadata associated with
         the release (the ref, url, and dates).
 
-        :pparam string organization_slug: the slug of the organization the
+        :pparam string organization_slug: the id or slug of the organization the
                                           release belongs to.
         :pparam string project_id_or_slug: the id or slug of the project to change the
                                      release of.
@@ -154,7 +154,7 @@ class ProjectReleaseDetailsEndpoint(ProjectEndpoint, ReleaseAnalyticsMixin):
 
         Permanently remove a release and all of its files.
 
-        :pparam string organization_slug: the slug of the organization the
+        :pparam string organization_slug: the id or slug of the organization the
                                           release belongs to.
         :pparam string project_id_or_slug: the id or slug of the project to delete the
                                      release of.

--- a/src/sentry/api/endpoints/project_release_file_details.py
+++ b/src/sentry/api/endpoints/project_release_file_details.py
@@ -217,7 +217,7 @@ class ProjectReleaseFileDetailsEndpoint(ProjectEndpoint, ReleaseFileDetailsMixin
         not actually return the contents of the file, just the associated
         metadata.
 
-        :pparam string organization_slug: the slug of the organization the
+        :pparam string organization_slug: the id or slug of the organization the
                                           release belongs to.
         :pparam string project_id_or_slug: the id or slug of the project to retrieve the
                                      file of.
@@ -247,7 +247,7 @@ class ProjectReleaseFileDetailsEndpoint(ProjectEndpoint, ReleaseFileDetailsMixin
         Update metadata of an existing file.  Currently only the name of
         the file can be changed.
 
-        :pparam string organization_slug: the slug of the organization the
+        :pparam string organization_slug: the id or slug of the organization the
                                           release belongs to.
         :pparam string project_id_or_slug: the id or slug of the project to update the
                                      file of.
@@ -276,7 +276,7 @@ class ProjectReleaseFileDetailsEndpoint(ProjectEndpoint, ReleaseFileDetailsMixin
         This will also remove the physical file from storage, except if it is
         stored as part of an artifact bundle.
 
-        :pparam string organization_slug: the slug of the organization the
+        :pparam string organization_slug: the id or slug of the organization the
                                           release belongs to.
         :pparam string project_id_or_slug: the id or slug of the project to delete the
                                      file of.

--- a/src/sentry/api/endpoints/project_release_files.py
+++ b/src/sentry/api/endpoints/project_release_files.py
@@ -244,7 +244,7 @@ class ProjectReleaseFilesEndpoint(ProjectEndpoint, ReleaseFilesMixin):
 
         Retrieve a list of files for a given release.
 
-        :pparam string organization_slug: the slug of the organization the
+        :pparam string organization_slug: the id or slug of the organization the
                                           release belongs to.
         :pparam string project_id_or_slug: the id or slug of the project to list the
                                      release files of.
@@ -276,7 +276,7 @@ class ProjectReleaseFilesEndpoint(ProjectEndpoint, ReleaseFilesMixin):
         that this file will be referenced as. For example, in the case of
         JavaScript you might specify the full web URI.
 
-        :pparam string organization_slug: the slug of the organization the
+        :pparam string organization_slug: the id or slug of the organization the
                                           release belongs to.
         :pparam string project_id_or_slug: the id or slug of the project to change the
                                      release of.

--- a/src/sentry/api/endpoints/project_release_repositories.py
+++ b/src/sentry/api/endpoints/project_release_repositories.py
@@ -26,7 +26,7 @@ class ProjectReleaseRepositories(ProjectEndpoint):
 
         This endpoint is used in the commits and changed files tab of the release details page
 
-        :pparam string organization_slug: the slug of the organization the
+        :pparam string organization_slug: the id or slug of the organization the
                                           release belongs to.
         :pparam string project_id_or_slug: the id or slug of the project to retrieve the
                                      release of.

--- a/src/sentry/api/endpoints/project_release_stats.py
+++ b/src/sentry/api/endpoints/project_release_stats.py
@@ -39,7 +39,7 @@ class ProjectReleaseStatsEndpoint(ProjectEndpoint):
 
         Returns the stats of a given release under a project.
 
-        :pparam string organization_slug: the slug of the organization the
+        :pparam string organization_slug: the id or slug of the organization the
                                           release belongs to.
         :pparam string project_id_or_slug: the id or slug of the project to list the
                                      release files of.

--- a/src/sentry/api/endpoints/project_releases.py
+++ b/src/sentry/api/endpoints/project_releases.py
@@ -42,7 +42,7 @@ class ProjectReleasesEndpoint(ProjectEndpoint, EnvironmentMixin):
 
         Retrieve a list of releases for a given project.
 
-        :pparam string organization_slug: the slug of the organization the
+        :pparam string organization_slug: the id or slug of the organization the
                                           release belongs to.
         :pparam string project_id_or_slug: the id or slug of the project to list the
                                      releases of.
@@ -97,7 +97,7 @@ class ProjectReleasesEndpoint(ProjectEndpoint, EnvironmentMixin):
         Releases are also necessary for sourcemaps and other debug features
         that require manual upload for functioning well.
 
-        :pparam string organization_slug: the slug of the organization the
+        :pparam string organization_slug: the id or slug of the organization the
                                           release belongs to.
         :pparam string project_id_or_slug: the id or slug of the project to create a
                                      release for.

--- a/src/sentry/api/endpoints/project_servicehook_details.py
+++ b/src/sentry/api/endpoints/project_servicehook_details.py
@@ -31,7 +31,7 @@ class ProjectServiceHookDetailsEndpoint(ProjectEndpoint):
 
         Return a service hook bound to a project.
 
-        :pparam string organization_slug: the slug of the organization the
+        :pparam string organization_slug: the id or slug of the organization the
                                           client keys belong to.
         :pparam string project_id_or_slug: the id or slug of the project the client keys
                                      belong to.
@@ -49,7 +49,7 @@ class ProjectServiceHookDetailsEndpoint(ProjectEndpoint):
         Update a Service Hook
         `````````````````````
 
-        :pparam string organization_slug: the slug of the organization the
+        :pparam string organization_slug: the id or slug of the organization the
                                           client keys belong to.
         :pparam string project_id_or_slug: the id or slug of the project the client keys
                                      belong to.
@@ -102,7 +102,7 @@ class ProjectServiceHookDetailsEndpoint(ProjectEndpoint):
         Remove a Service Hook
         `````````````````````
 
-        :pparam string organization_slug: the slug of the organization the
+        :pparam string organization_slug: the id or slug of the organization the
                                           client keys belong to.
         :pparam string project_id_or_slug: the id or slug of the project the client keys
                                      belong to.

--- a/src/sentry/api/endpoints/project_servicehooks.py
+++ b/src/sentry/api/endpoints/project_servicehooks.py
@@ -37,7 +37,7 @@ class ProjectServiceHooksEndpoint(ProjectEndpoint):
         This endpoint requires the 'servicehooks' feature to
         be enabled for your project.
 
-        :pparam string organization_slug: the slug of the organization the
+        :pparam string organization_slug: the id or slug of the organization the
                                           client keys belong to.
         :pparam string project_id_or_slug: the id or slug of the project the client keys
                                      belong to.
@@ -83,7 +83,7 @@ class ProjectServiceHooksEndpoint(ProjectEndpoint):
         This endpoint requires the 'servicehooks' feature to
         be enabled for your project.
 
-        :pparam string organization_slug: the slug of the organization the
+        :pparam string organization_slug: the id or slug of the organization the
                                           client keys belong to.
         :pparam string project_id_or_slug: the id or slug of the project the client keys
                                      belong to.

--- a/src/sentry/api/endpoints/project_stats.py
+++ b/src/sentry/api/endpoints/project_stats.py
@@ -31,7 +31,7 @@ class ProjectStatsEndpoint(ProjectEndpoint, EnvironmentMixin, StatsMixin):
         Query ranges are limited to Sentry's configured time-series
         resolutions.
 
-        :pparam string organization_slug: the slug of the organization.
+        :pparam string organization_slug: the id or slug of the organization.
         :pparam string project_id_or_slug: the id or slug of the project.
         :qparam string stat: the name of the stat to query (``"received"``,
                              ``"rejected"``, ``"blacklisted"``, ``generated``)

--- a/src/sentry/api/endpoints/project_tagkey_values.py
+++ b/src/sentry/api/endpoints/project_tagkey_values.py
@@ -29,7 +29,7 @@ class ProjectTagKeyValuesEndpoint(ProjectEndpoint, EnvironmentMixin):
         values.
         When paginated can return at most 1000 values.
 
-        :pparam string organization_slug: the slug of the organization.
+        :pparam string organization_slug: the id or slug of the organization.
         :pparam string project_id_or_slug: the id or slug of the project.
         :pparam string key: the tag key to look up.
         :auth: required

--- a/src/sentry/api/endpoints/project_teams.py
+++ b/src/sentry/api/endpoints/project_teams.py
@@ -24,7 +24,7 @@ class ProjectTeamsEndpoint(ProjectEndpoint):
 
         Return a list of teams that have access to this project.
 
-        :pparam string organization_slug: the slug of the organization.
+        :pparam string organization_slug: the id or slug of the organization.
         :pparam string project_id_or_slug: the id or slug of the project.
         :auth: required
         """

--- a/src/sentry/api/endpoints/project_transfer.py
+++ b/src/sentry/api/endpoints/project_transfer.py
@@ -39,7 +39,7 @@ class ProjectTransferEndpoint(ProjectEndpoint):
 
         Schedules a project for transfer to a new organization.
 
-        :pparam string organization_slug: the slug of the organization the
+        :pparam string organization_slug: the id or slug of the organization the
                                           project belongs to.
         :pparam string project_id_or_slug: the id or slug of the project to delete.
         :param string email: email of new owner. must be an organization owner

--- a/src/sentry/api/endpoints/project_user_reports.py
+++ b/src/sentry/api/endpoints/project_user_reports.py
@@ -45,7 +45,7 @@ class ProjectUserReportsEndpoint(ProjectEndpoint, EnvironmentMixin):
 
         Return a list of user feedback items within this project.
 
-        :pparam string organization_slug: the slug of the organization.
+        :pparam string organization_slug: the id or slug of the organization.
         :pparam string project_id_or_slug: the id or slug of the project.
         :auth: required
         """
@@ -100,7 +100,7 @@ class ProjectUserReportsEndpoint(ProjectEndpoint, EnvironmentMixin):
 
         Note: Feedback may be submitted with DSN authentication (see auth documentation).
 
-        :pparam string organization_slug: the slug of the organization.
+        :pparam string organization_slug: the id or slug of the organization.
         :pparam string project_id_or_slug: the id or slug of the project.
         :auth: required
         :param string event_id: the event ID

--- a/src/sentry/api/endpoints/project_users.py
+++ b/src/sentry/api/endpoints/project_users.py
@@ -31,7 +31,7 @@ class ProjectUsersEndpoint(ProjectEndpoint):
 
         Return a list of users seen within this project.
 
-        :pparam string organization_slug: the slug of the organization.
+        :pparam string organization_slug: the id or slug of the organization.
         :pparam string project_id_or_slug: the id or slug of the project.
         :pparam string key: the tag key to look up.
         :auth: required

--- a/src/sentry/api/endpoints/team_details.py
+++ b/src/sentry/api/endpoints/team_details.py
@@ -51,7 +51,7 @@ class TeamDetailsEndpoint(TeamEndpoint):
 
         Return details on an individual team.
 
-        :pparam string organization_slug: the slug of the organization the
+        :pparam string organization_slug: the id or slug of the organization the
                                           team belongs to.
         :pparam string team_id_or_slug: the id or slug of the team to get.
         :qparam list expand: an optional list of strings to opt in to additional
@@ -81,7 +81,7 @@ class TeamDetailsEndpoint(TeamEndpoint):
         Update various attributes and configurable settings for the given
         team.
 
-        :pparam string organization_slug: the slug of the organization the
+        :pparam string organization_slug: the id or slug of the organization the
                                           team belongs to.
         :pparam string team_id_or_slug: the id or slug of the team to get.
         :param string name: the new name for the team.

--- a/src/sentry/issues/endpoints/organization_group_index.py
+++ b/src/sentry/issues/endpoints/organization_group_index.py
@@ -251,7 +251,7 @@ class OrganizationGroupIndexEndpoint(OrganizationEndpoint):
         :qparam bool savedSearch:  if this is set to False, then we are making the request without
                                    a saved search and will look for the default search from this endpoint.
         :qparam string searchId:   if passed in, this is the selected search
-        :pparam string organization_slug: the slug of the organization the
+        :pparam string organization_slug: the id or slug of the organization the
                                           issues belong to.
         :auth: required
         :qparam list expand: an optional list of strings to opt in to additional data. Supports `inbox`
@@ -445,7 +445,7 @@ class OrganizationGroupIndexEndpoint(OrganizationEndpoint):
                                specified status.  Valid values are
                                ``"resolved"``, ``"unresolved"`` and
                                ``"ignored"``.
-        :pparam string organization_slug: the slug of the organization the
+        :pparam string organization_slug: the id or slug of the organization the
                                           issues belong to.
         :param string status: the new status for the issues.  Valid values
                               are ``"resolved"``, ``"resolvedInNextRelease"``,
@@ -521,7 +521,7 @@ class OrganizationGroupIndexEndpoint(OrganizationEndpoint):
                         parameter shall be repeated for each issue, e.g.
                         `?id=1&id=2&id=3`. If this parameter is not provided,
                         it will attempt to remove the first 1000 issues.
-        :pparam string organization_slug: the slug of the organization the
+        :pparam string organization_slug: the id or slug of the organization the
                                           issues belong to.
         :auth: required
         """

--- a/src/sentry/issues/endpoints/organization_release_previous_commits.py
+++ b/src/sentry/issues/endpoints/organization_release_previous_commits.py
@@ -26,7 +26,7 @@ class OrganizationReleasePreviousCommitsEndpoint(OrganizationReleasesBaseEndpoin
         Retrieve an Organization's Most Recent Release with Commits
         ````````````````````````````````````````````````````````````
 
-        :pparam string organization_slug: the slug of the organization the
+        :pparam string organization_slug: the id or slug of the organization the
                                           release belongs to.
         :pparam string version: the version identifier of the release.
         :auth: required


### PR DESCRIPTION
I am breaking apart a large PR I had to rollout `organization_id_or_slug` changes, this pr just changes some comments en-masse.