### PR TITLE
perf: use orjson in metrics

### DIFF
--- a/src/sentry/sentry_metrics/client/kafka.py
+++ b/src/sentry/sentry_metrics/client/kafka.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from datetime import datetime
 
+import orjson
 from arroyo import Topic as ArroyoTopic
 from arroyo.backends.abstract import Producer
 from arroyo.backends.kafka import KafkaPayload, KafkaProducer, build_kafka_configuration
@@ -13,7 +14,6 @@ from sentry import quotas
 from sentry.conf.types.kafka_definition import Topic, get_topic_codec
 from sentry.sentry_metrics.client.base import GenericMetricsBackend
 from sentry.sentry_metrics.use_case_id_registry import UseCaseID
-from sentry.utils import json
 from sentry.utils.kafka_config import get_kafka_producer_cluster_options, get_topic_definition
 
 INGEST_CODEC: Codec[IngestMetric] = get_topic_codec(Topic.INGEST_METRICS)
@@ -91,7 +91,7 @@ class KafkaMetricsBackend(GenericMetricsBackend):
         INGEST_CODEC.validate(metric)
         payload = KafkaPayload(
             None,
-            json.dumps(metric).encode("utf-8"),
+            orjson.dumps(metric),
             [
                 ("namespace", use_case_id.value.encode()),
             ],

--- a/src/sentry/sentry_metrics/querying/metadata/metrics_code_locations.py
+++ b/src/sentry/sentry_metrics/querying/metadata/metrics_code_locations.py
@@ -2,10 +2,12 @@ from collections.abc import Generator, Sequence
 from dataclasses import dataclass
 from datetime import datetime
 
+import orjson
+
 from sentry.models.organization import Organization
 from sentry.models.project import Project
 from sentry.sentry_metrics.querying.utils import get_redis_client_for_metrics_meta
-from sentry.utils import json, metrics
+from sentry.utils import metrics
 from sentry.utils.hashlib import fnv1a_32
 
 DAY_IN_SECONDS = 86400
@@ -127,7 +129,7 @@ class CodeLocationsFetcher:
                     index += 1
 
     def _parse_code_location_payload(self, encoded_location: str) -> CodeLocationPayload:
-        decoded_location = json.loads(encoded_location)
+        decoded_location = orjson.loads(encoded_location)
         return CodeLocationPayload(
             function=decoded_location.get("function"),
             module=decoded_location.get("module"),

--- a/tests/sentry/sentry_metrics/test_kafka.py
+++ b/tests/sentry/sentry_metrics/test_kafka.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 from unittest import TestCase
 
+import orjson
 import pytest
 from arroyo.backends.kafka import KafkaPayload
 from arroyo.backends.local.backend import LocalBroker, LocalProducer
@@ -10,7 +11,6 @@ from arroyo.utils.clock import TestingClock as Clock
 
 from sentry.sentry_metrics.client.kafka import KafkaMetricsBackend
 from sentry.testutils.metrics_backend import GenericMetricsTestMixIn
-from sentry.utils import json
 
 
 class KafkaMetricsInterfaceTest(GenericMetricsTestMixIn, TestCase):
@@ -55,7 +55,7 @@ class KafkaMetricsInterfaceTest(GenericMetricsTestMixIn, TestCase):
             "type": "c",
         }
 
-        counter_value = json.dumps(counter_metric).encode("utf-8")
+        counter_value = orjson.dumps(counter_metric)
 
         produced_message = broker_storage.consume(Partition(my_topic, 0), 0)
         assert produced_message is not None

--- a/tests/sentry/sentry_metrics/test_parallel_indexer.py
+++ b/tests/sentry/sentry_metrics/test_parallel_indexer.py
@@ -1,5 +1,6 @@
 from datetime import datetime, timezone
 
+import orjson
 import pytest
 from arroyo.backends.kafka import KafkaPayload
 from arroyo.types import BrokerValue, Message, Partition, Topic
@@ -7,7 +8,6 @@ from arroyo.types import BrokerValue, Message, Partition, Topic
 from sentry.metrics.middleware import global_tags
 from sentry.sentry_metrics.consumers.indexer.parallel import MetricsConsumerStrategyFactory
 from sentry.snuba.metrics.naming_layer.mri import SessionMRI
-from sentry.utils import json
 
 ts = int(datetime.now(tz=timezone.utc).timestamp())
 counter_payload = {
@@ -65,7 +65,7 @@ def test_basic(request, settings, force_disable_multiprocessing):
 
     message = Message(
         BrokerValue(
-            KafkaPayload(None, json.dumps(counter_payload).encode("utf-8"), []),
+            KafkaPayload(None, orjson.dumps(counter_payload), []),
             Partition(Topic("topic"), 0),
             0,
             datetime.now(),

--- a/tests/sentry/sentry_metrics/test_rh_metrics_multiprocess_steps.py
+++ b/tests/sentry/sentry_metrics/test_rh_metrics_multiprocess_steps.py
@@ -447,7 +447,7 @@ def test_process_messages_invalid_messages(
                     orjson.dumps(
                         __translated_payload(counter_payload), option=orjson.OPT_NON_STR_KEYS
                     ),
-                    [("metric_type", "c")],
+                    [("metric_type", b"c")],
                 ),
                 expected_msg.committable,
             )
@@ -520,7 +520,7 @@ def test_process_messages_rate_limited(caplog, settings) -> None:
                     orjson.dumps(
                         __translated_payload(counter_payload), option=orjson.OPT_NON_STR_KEYS
                     ),
-                    [("metric_type", "c")],
+                    [("metric_type", b"c")],
                 ),
                 expected_msg.value.partition,
                 expected_msg.value.offset,

--- a/tests/sentry/sentry_metrics/visibility/test_metrics_blocking.py
+++ b/tests/sentry/sentry_metrics/visibility/test_metrics_blocking.py
@@ -1,5 +1,6 @@
 from unittest import mock
 
+import orjson
 import pytest
 
 from sentry.sentry_metrics.visibility import (
@@ -16,7 +17,6 @@ from sentry.sentry_metrics.visibility.metrics_blocking import (
     unblock_tags_of_metric,
 )
 from sentry.testutils.pytest.fixtures import django_db_all
-from sentry.utils import json
 
 
 @mock.patch("sentry.sentry_metrics.visibility.metrics_blocking.metrics")
@@ -29,7 +29,7 @@ def test_apply_multiple_operations(mock_metrics, default_project):
     block_metric(mri_1, [default_project])
 
     metrics_blocking_state = sorted(
-        json.loads(default_project.get_option(METRICS_BLOCKING_STATE_PROJECT_OPTION_KEY)),
+        orjson.loads(default_project.get_option(METRICS_BLOCKING_STATE_PROJECT_OPTION_KEY)),
         key=lambda v: v["metric_mri"],
     )
     assert len(metrics_blocking_state) == 1
@@ -41,7 +41,7 @@ def test_apply_multiple_operations(mock_metrics, default_project):
     # We block tags of a blocked metric.
     block_tags_of_metric(mri_1, {"release", "transaction", "release"}, [default_project])
 
-    metrics_blocking_state = json.loads(
+    metrics_blocking_state = orjson.loads(
         default_project.get_option(METRICS_BLOCKING_STATE_PROJECT_OPTION_KEY)
     )
     assert len(metrics_blocking_state) == 1
@@ -53,7 +53,7 @@ def test_apply_multiple_operations(mock_metrics, default_project):
     # We unblock a tag of a blocked metric.
     unblock_tags_of_metric(mri_1, {"transaction"}, [default_project])
 
-    metrics_blocking_state = json.loads(
+    metrics_blocking_state = orjson.loads(
         default_project.get_option(METRICS_BLOCKING_STATE_PROJECT_OPTION_KEY)
     )
     assert len(metrics_blocking_state) == 1
@@ -65,7 +65,7 @@ def test_apply_multiple_operations(mock_metrics, default_project):
     # We block tags of an unblocked metric.
     block_tags_of_metric(mri_2, {"environment", "transaction"}, [default_project])
 
-    metrics_blocking_state = json.loads(
+    metrics_blocking_state = orjson.loads(
         default_project.get_option(METRICS_BLOCKING_STATE_PROJECT_OPTION_KEY)
     )
     assert len(metrics_blocking_state) == 2
@@ -79,7 +79,7 @@ def test_apply_multiple_operations(mock_metrics, default_project):
     # We unblock all the tags of an unblocked metric.
     unblock_tags_of_metric(mri_2, {"environment", "transaction"}, [default_project])
 
-    metrics_blocking_state = json.loads(
+    metrics_blocking_state = orjson.loads(
         default_project.get_option(METRICS_BLOCKING_STATE_PROJECT_OPTION_KEY)
     )
     assert len(metrics_blocking_state) == 1
@@ -90,7 +90,7 @@ def test_apply_multiple_operations(mock_metrics, default_project):
     # We unblock a blocked metric with blocked tags.
     unblock_metric(mri_1, [default_project])
 
-    metrics_blocking_state = json.loads(
+    metrics_blocking_state = orjson.loads(
         default_project.get_option(METRICS_BLOCKING_STATE_PROJECT_OPTION_KEY)
     )
     assert len(metrics_blocking_state) == 1
@@ -102,7 +102,7 @@ def test_apply_multiple_operations(mock_metrics, default_project):
     # We unblock all the tags of an unblocked metric.
     unblock_tags_of_metric(mri_1, {"release", "transaction"}, [default_project])
 
-    metrics_blocking_state = json.loads(
+    metrics_blocking_state = orjson.loads(
         default_project.get_option(METRICS_BLOCKING_STATE_PROJECT_OPTION_KEY)
     )
     assert len(metrics_blocking_state) == 0


### PR DESCRIPTION
We have enough confidence to say that `orjson` doesn't cause any errors/issues. We can now safely get rid of `json` and `rapidjson` in our repository.

Ref: https://github.com/getsentry/sentry/issues/68903