### PR TITLE
perf: use orjson in endpoints

### DIFF
--- a/src/sentry/api/base.py
+++ b/src/sentry/api/base.py
@@ -9,6 +9,7 @@ from datetime import datetime, timedelta, timezone
 from typing import Any
 from urllib.parse import quote as urlquote
 
+import orjson
 import sentry_sdk
 from django.conf import settings
 from django.http import HttpResponse
@@ -34,7 +35,6 @@ from sentry.models.environment import Environment
 from sentry.ratelimits.config import DEFAULT_RATE_LIMIT_CONFIG, RateLimitConfig
 from sentry.silo.base import SiloLimit, SiloMode
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
-from sentry.utils import json
 from sentry.utils.audit import create_audit_entry
 from sentry.utils.cursors import Cursor
 from sentry.utils.dates import to_datetime
@@ -343,8 +343,8 @@ class Endpoint(APIView):
             return
 
         try:
-            request.json_body = json.loads(request.body)
-        except json.JSONDecodeError:
+            request.json_body = orjson.loads(request.body)
+        except orjson.JSONDecodeError:
             return
 
     def initialize_request(self, request: HttpRequest, *args: Any, **kwargs: Any) -> Request:

--- a/src/sentry/api/client.py
+++ b/src/sentry/api/client.py
@@ -2,12 +2,12 @@ from __future__ import annotations
 
 from typing import TypeAlias
 
+import orjson
 from django.conf import settings
 from django.urls import resolve
 from rest_framework.test import APIRequestFactory, force_authenticate
 
 from sentry.auth.superuser import Superuser
-from sentry.utils import json
 
 __all__ = ("ApiClient",)
 
@@ -54,8 +54,9 @@ class ApiClient:
         callback, callback_args, callback_kwargs = resolver_match
 
         if data:
+            # TODO(@anonrig): Investigate why we are doing this?
             # we encode to ensure compatibility
-            data = json.loads(json.dumps(data))
+            data = orjson.loads(orjson.dumps(data))
 
         rf = APIRequestFactory()
         mock_request = getattr(rf, method.lower())(full_path, data or {})

--- a/src/sentry/api/endpoints/custom_rules.py
+++ b/src/sentry/api/endpoints/custom_rules.py
@@ -1,6 +1,7 @@
 from datetime import datetime, timedelta, timezone
 from enum import Enum
 
+import orjson
 import sentry_sdk
 from django.db import DatabaseError
 from rest_framework import serializers
@@ -23,7 +24,6 @@ from sentry.models.organization import Organization
 from sentry.models.project import Project
 from sentry.snuba.metrics.extraction import RuleCondition, SearchQueryConverter, parse_search_query
 from sentry.tasks.relay import schedule_invalidate_project_config
-from sentry.utils import json
 from sentry.utils.dates import parse_stats_period
 
 MAX_RULE_PERIOD_STRING = "6h"
@@ -248,7 +248,7 @@ class CustomRulesEndpoint(OrganizationEndpoint):
 def _rule_to_response(rule: CustomDynamicSamplingRule) -> Response:
     response_data = {
         "ruleId": rule.external_rule_id,
-        "condition": json.loads(rule.condition),
+        "condition": orjson.loads(rule.condition),
         "startDate": rule.start_date.strftime(CUSTOM_RULE_DATE_FORMAT),
         "endDate": rule.end_date.strftime(CUSTOM_RULE_DATE_FORMAT),
         "numSamples": rule.num_samples,

--- a/src/sentry/api/endpoints/debug_files.py
+++ b/src/sentry/api/endpoints/debug_files.py
@@ -5,6 +5,7 @@ import uuid
 from collections.abc import Sequence
 
 import jsonschema
+import orjson
 from django.db import IntegrityError, router
 from django.db.models import Q
 from django.http import Http404, HttpResponse, StreamingHttpResponse
@@ -44,7 +45,6 @@ from sentry.tasks.assemble import (
     get_assemble_status,
     set_assemble_status,
 )
-from sentry.utils import json
 from sentry.utils.db import atomic_transaction
 
 logger = logging.getLogger("sentry.api")
@@ -419,7 +419,7 @@ class DifAssembleEndpoint(ProjectEndpoint):
         }
 
         try:
-            files = json.loads(request.body)
+            files = orjson.loads(request.body)
             jsonschema.validate(files, schema)
         except jsonschema.ValidationError as e:
             return Response({"error": str(e).splitlines()[0]}, status=400)

--- a/src/sentry/api/endpoints/event_grouping_info.py
+++ b/src/sentry/api/endpoints/event_grouping_info.py
@@ -1,3 +1,4 @@
+import orjson
 from django.http import HttpRequest, HttpResponse
 
 from sentry import eventstore
@@ -7,7 +8,6 @@ from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.project import ProjectEndpoint
 from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.grouping.grouping_info import get_grouping_info
-from sentry.utils import json
 
 
 @region_silo_endpoint
@@ -31,4 +31,4 @@ class EventGroupingInfoEndpoint(ProjectEndpoint):
 
         grouping_info = get_grouping_info(request.GET.get("config", None), project, event)
 
-        return HttpResponse(json.dumps(grouping_info), content_type="application/json")
+        return HttpResponse(orjson.dumps(grouping_info), content_type="application/json")

--- a/src/sentry/api/endpoints/group_ai_autofix.py
+++ b/src/sentry/api/endpoints/group_ai_autofix.py
@@ -4,6 +4,7 @@ import logging
 from datetime import datetime
 from typing import Any
 
+import orjson
 import requests
 from django.conf import settings
 from django.contrib.auth.models import AbstractBaseUser, AnonymousUser
@@ -19,7 +20,6 @@ from sentry.api.serializers import EventSerializer, serialize
 from sentry.models.group import Group
 from sentry.models.user import User
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
-from sentry.utils import json
 
 logger = logging.getLogger(__name__)
 
@@ -86,7 +86,7 @@ class GroupAutofixEndpoint(GroupEndpoint):
     ):
         response = requests.post(
             f"{settings.SEER_AUTOFIX_URL}/v1/automation/autofix/start",
-            data=json.dumps(
+            data=orjson.dumps(
                 {
                     "organization_id": group.organization.id,
                     "project_id": group.project.id,
@@ -118,7 +118,7 @@ class GroupAutofixEndpoint(GroupEndpoint):
     def _call_get_autofix_state(self, group_id: int) -> dict[str, Any] | None:
         response = requests.post(
             f"{settings.SEER_AUTOFIX_URL}/v1/automation/autofix/state",
-            data=json.dumps(
+            data=orjson.dumps(
                 {
                     "group_id": group_id,
                 }
@@ -136,7 +136,7 @@ class GroupAutofixEndpoint(GroupEndpoint):
         return None
 
     def post(self, request: Request, group: Group) -> Response:
-        data = json.loads(request.body)
+        data = orjson.loads(request.body)
 
         # This event_id is the event that the user is looking at when they click the "Fix" button
         event_id = data.get("event_id", None)

--- a/src/sentry/api/endpoints/group_autofix_setup_check.py
+++ b/src/sentry/api/endpoints/group_autofix_setup_check.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 
+import orjson
 import requests
 from django.conf import settings
 from rest_framework.response import Response
@@ -23,7 +24,6 @@ from sentry.models.integrations.repository_project_path_config import Repository
 from sentry.models.organization import Organization
 from sentry.models.project import Project
 from sentry.services.hybrid_cloud.integration import integration_service
-from sentry.utils import json
 
 logger = logging.getLogger(__name__)
 
@@ -69,7 +69,7 @@ def get_repos_and_access(project: Project) -> list[dict]:
     for repo in repos:
         response = requests.post(
             f"{settings.SEER_AUTOFIX_URL}/v1/automation/codebase/repo/check-access",
-            data=json.dumps(
+            data=orjson.dumps(
                 {
                     "repo": repo,
                 }

--- a/src/sentry/api/endpoints/integrations/sentry_apps/details.py
+++ b/src/sentry/api/endpoints/integrations/sentry_apps/details.py
@@ -1,5 +1,6 @@
 import logging
 
+import orjson
 import sentry_sdk
 from django.db import router, transaction
 from requests import RequestException
@@ -24,7 +25,6 @@ from sentry.models.integrations.sentry_app import SentryApp
 from sentry.models.integrations.sentry_app_installation import SentryAppInstallation
 from sentry.sentry_apps.apps import SentryAppUpdater
 from sentry.services.hybrid_cloud.organization import organization_service
-from sentry.utils import json
 from sentry.utils.audit import create_audit_entry
 
 logger = logging.getLogger(__name__)
@@ -116,7 +116,7 @@ class SentryAppDetailsEndpoint(SentryAppBaseEndpoint):
             for error_message in serializer.errors["schema"]:
                 name = "sentry_app.schema_validation_error"
                 log_info = {
-                    "schema": json.dumps(request.data["schema"]),
+                    "schema": orjson.dumps(request.data["schema"]).decode(),
                     "user_id": request.user.id,
                     "sentry_app_id": sentry_app.id,
                     "sentry_app_name": sentry_app.name,

--- a/src/sentry/api/endpoints/integrations/sentry_apps/index.py
+++ b/src/sentry/api/endpoints/integrations/sentry_apps/index.py
@@ -1,5 +1,6 @@
 import logging
 
+import orjson
 from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.serializers import ValidationError
@@ -18,7 +19,6 @@ from sentry.constants import SentryAppStatus
 from sentry.models.integrations.sentry_app import SentryApp
 from sentry.sentry_apps.apps import SentryAppCreator
 from sentry.services.hybrid_cloud.user.service import user_service
-from sentry.utils import json
 
 logger = logging.getLogger(__name__)
 
@@ -143,7 +143,7 @@ class SentryAppsEndpoint(SentryAppsBaseEndpoint):
             for error_message in serializer.errors["schema"]:
                 name = "sentry_app.schema_validation_error"
                 log_info = {
-                    "schema": json.dumps(data["schema"]),
+                    "schema": orjson.dumps(data["schema"]).decode(),
                     "user_id": request.user.id,
                     "sentry_app_name": data["name"],
                     "organization_id": organization.id,

--- a/src/sentry/api/endpoints/organization_artifactbundle_assemble.py
+++ b/src/sentry/api/endpoints/organization_artifactbundle_assemble.py
@@ -1,4 +1,5 @@
 import jsonschema
+import orjson
 from rest_framework.request import Request
 from rest_framework.response import Response
 
@@ -17,7 +18,6 @@ from sentry.tasks.assemble import (
     get_assemble_status,
     set_assemble_status,
 )
-from sentry.utils import json
 
 
 @region_silo_endpoint
@@ -49,7 +49,7 @@ class OrganizationArtifactBundleAssembleEndpoint(OrganizationReleasesBaseEndpoin
         }
 
         try:
-            data = json.loads(request.body)
+            data = orjson.loads(request.body)
             jsonschema.validate(data, schema)
         except jsonschema.ValidationError as e:
             return Response({"error": str(e).splitlines()[0]}, status=400)

--- a/src/sentry/api/endpoints/organization_release_assemble.py
+++ b/src/sentry/api/endpoints/organization_release_assemble.py
@@ -1,4 +1,5 @@
 import jsonschema
+import orjson
 from rest_framework.request import Request
 from rest_framework.response import Response
 
@@ -13,7 +14,7 @@ from sentry.tasks.assemble import (
     get_assemble_status,
     set_assemble_status,
 )
-from sentry.utils import json, metrics
+from sentry.utils import metrics
 
 
 @region_silo_endpoint
@@ -52,7 +53,7 @@ class OrganizationReleaseAssembleEndpoint(OrganizationReleasesBaseEndpoint):
         }
 
         try:
-            data = json.loads(request.body)
+            data = orjson.loads(request.body)
             jsonschema.validate(data, schema)
         except jsonschema.ValidationError as e:
             return Response({"error": str(e).splitlines()[0]}, status=400)

--- a/src/sentry/api/endpoints/organization_transaction_anomaly_detection.py
+++ b/src/sentry/api/endpoints/organization_transaction_anomaly_detection.py
@@ -1,6 +1,7 @@
 from collections import namedtuple
 from datetime import datetime, timedelta, timezone
 
+import orjson
 from django.conf import settings
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -13,7 +14,6 @@ from sentry.api.bases import OrganizationEventsEndpointBase
 from sentry.api.utils import get_date_range_from_params, handle_query_errors
 from sentry.net.http import connection_from_url
 from sentry.snuba.metrics_enhanced_performance import timeseries_query
-from sentry.utils import json
 
 ads_connection_pool = connection_from_url(
     settings.ANOMALY_DETECTION_URL,
@@ -31,10 +31,10 @@ def get_anomalies(snuba_io):
     response = ads_connection_pool.urlopen(
         "POST",
         "/anomaly/predict",
-        body=json.dumps(snuba_io),
+        body=orjson.dumps(snuba_io),
         headers={"content-type": "application/json;charset=utf-8"},
     )
-    return Response(json.loads(response.data), status=200)
+    return Response(orjson.loads(response.data), status=200)
 
 
 def get_time_params(start: datetime, end: datetime) -> MappedParams:

--- a/src/sentry/api/endpoints/project_app_store_connect_credentials.py
+++ b/src/sentry/api/endpoints/project_app_store_connect_credentials.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
@@ -59,7 +61,6 @@ from sentry.models.project import Project
 from sentry.ratelimits.config import RateLimitConfig
 from sentry.tasks.app_store_connect import dsym_download
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
-from sentry.utils import json
 from sentry.utils.appleconnect import appstore_connect
 
 logger = logging.getLogger(__name__)
@@ -275,7 +276,7 @@ class AppStoreUpdateCredentialsSerializer(serializers.Serializer):
 
     def validate_appconnectPrivateKey(
         self, private_key_json: str | dict[str, bool] | None
-    ) -> json.JSONData | None:
+    ) -> Any | None:
         return validate_secret(private_key_json)
 
 

--- a/src/sentry/api/endpoints/project_autofix_create_codebase_index.py
+++ b/src/sentry/api/endpoints/project_autofix_create_codebase_index.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 
+import orjson
 import requests
 from django.conf import settings
 from rest_framework.response import Response
@@ -12,7 +13,6 @@ from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.project import ProjectEndpoint, ProjectPermission
 from sentry.api.helpers.repos import get_repos_from_project_code_mappings
 from sentry.models.project import Project
-from sentry.utils import json
 
 logger = logging.getLogger(__name__)
 
@@ -45,7 +45,7 @@ class ProjectAutofixCreateCodebaseIndexEndpoint(ProjectEndpoint):
         for repo in repos:
             response = requests.post(
                 f"{settings.SEER_AUTOFIX_URL}/v1/automation/codebase/index/create",
-                data=json.dumps(
+                data=orjson.dumps(
                     {
                         "organization_id": project.organization.id,
                         "project_id": project.id,

--- a/src/sentry/api/endpoints/project_create_sample_transaction.py
+++ b/src/sentry/api/endpoints/project_create_sample_transaction.py
@@ -2,6 +2,7 @@ import os
 from datetime import datetime, timedelta, timezone
 from uuid import uuid4
 
+import orjson
 from rest_framework import status
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -12,7 +13,6 @@ from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.project import ProjectEndpoint, ProjectEventPermission
 from sentry.api.serializers import serialize
 from sentry.constants import DATA_ROOT
-from sentry.utils import json
 from sentry.utils.samples import create_sample_event_basic
 
 base_platforms_with_transactions = ["javascript", "python", "apple-ios"]
@@ -84,8 +84,8 @@ class ProjectCreateSampleTransactionEndpoint(ProjectEndpoint):
         if expected_commonpath != os.path.commonpath([expected_commonpath, json_real_path]):
             return Response(status=status.HTTP_400_BAD_REQUEST)
 
-        with open(json_path) as fp:
-            data = json.load(fp)
+        with open(json_path, "rb") as fp:
+            data = orjson.loads(fp.read())
 
         data = fix_event_data(data)
         event = create_sample_event_basic(

--- a/src/sentry/api/endpoints/project_details.py
+++ b/src/sentry/api/endpoints/project_details.py
@@ -4,6 +4,7 @@ import time
 from datetime import timedelta
 from uuid import uuid4
 
+import orjson
 from django.db import IntegrityError, router, transaction
 from django.utils import timezone
 from drf_spectacular.utils import extend_schema, extend_schema_serializer
@@ -48,7 +49,6 @@ from sentry.models.projectbookmark import ProjectBookmark
 from sentry.models.projectredirect import ProjectRedirect
 from sentry.models.scheduledeletion import RegionScheduledDeletion
 from sentry.notifications.utils import has_alert_integration
-from sentry.utils import json
 
 logger = logging.getLogger(__name__)
 
@@ -284,7 +284,7 @@ class ProjectAdminSerializer(ProjectMemberSerializer):
 
         return value
 
-    def validate_symbolSources(self, sources_json):
+    def validate_symbolSources(self, sources_json) -> str:
         if not sources_json:
             return sources_json
 
@@ -307,7 +307,7 @@ class ProjectAdminSerializer(ProjectMemberSerializer):
         # This is always allowed.
         added_or_modified_sources = [s for s in sources if s not in orig_sources]
         if not added_or_modified_sources:
-            return json.dumps(sources) if sources else ""
+            return orjson.dumps(sources).decode() if sources else ""
 
         # All modified sources should get a new UUID, as a way to invalidate caches.
         # Downstream symbolicator uses this ID as part of a cache key, so assigning
@@ -321,7 +321,7 @@ class ProjectAdminSerializer(ProjectMemberSerializer):
             if source["type"] != "appStoreConnect":
                 source["id"] = str(uuid4())
 
-        sources_json = json.dumps(sources) if sources else ""
+        sources_json = orjson.dumps(sources).decode() if sources else ""
 
         # Adding sources is only allowed if custom symbol sources are enabled.
         has_sources = features.has(

--- a/src/sentry/api/endpoints/project_profiling_profile.py
+++ b/src/sentry/api/endpoints/project_profiling_profile.py
@@ -1,6 +1,7 @@
 from abc import ABC, abstractmethod
 from typing import Any
 
+import orjson
 from django.http import HttpResponse, HttpResponseRedirect
 from rest_framework import serializers
 from rest_framework.exceptions import ParseError
@@ -23,7 +24,6 @@ from sentry.profiles.utils import (
     parse_profile_filters,
     proxy_profiling_service,
 )
-from sentry.utils import json
 
 
 class ProjectProfilingBaseEndpoint(ProjectEndpoint):
@@ -96,7 +96,7 @@ class ProjectProfilingProfileEndpoint(ProjectProfilingBaseEndpoint):
         )
 
         if response.status == 200:
-            profile = json.loads(response.data)
+            profile = orjson.loads(response.data)
 
             if "release" in profile:
                 profile["release"] = get_release(project, profile["release"])
@@ -186,7 +186,7 @@ class ProjectProfilingFunctionsEndpoint(ProjectProfilingPaginatedBaseEndpoint):
                 **kwargs,
             )
 
-            data = json.loads(response.data)
+            data = orjson.loads(response.data)
 
             return data.get("functions", [])
 

--- a/src/sentry/api/endpoints/project_symbol_sources.py
+++ b/src/sentry/api/endpoints/project_symbol_sources.py
@@ -1,5 +1,6 @@
 from uuid import uuid4
 
+import orjson
 from drf_spectacular.utils import extend_schema
 from rest_framework import serializers
 from rest_framework.request import Request
@@ -29,7 +30,6 @@ from sentry.lang.native.sources import (
     validate_sources,
 )
 from sentry.models.project import Project
-from sentry.utils import json
 
 
 class LayoutSerializer(serializers.Serializer):
@@ -302,7 +302,7 @@ class ProjectSymbolSourcesEndpoint(ProjectEndpoint):
             if len(filtered_sources) == len(sources):
                 return Response(data={"error": f"Unknown source id: {id}"}, status=404)
 
-            serialized = json.dumps(filtered_sources)
+            serialized = orjson.dumps(filtered_sources).decode()
             project.update_option("sentry:symbol_sources", serialized)
             return Response(status=204)
 
@@ -341,7 +341,7 @@ class ProjectSymbolSourcesEndpoint(ProjectEndpoint):
         except InvalidSourcesError:
             return Response(status=400)
 
-        serialized = json.dumps(sources)
+        serialized = orjson.dumps(sources).decode()
         project.update_option("sentry:symbol_sources", serialized)
 
         redacted = redact_source_secrets([source])
@@ -402,7 +402,7 @@ class ProjectSymbolSourcesEndpoint(ProjectEndpoint):
         except InvalidSourcesError as e:
             return Response(data={"error": str(e)}, status=400)
 
-        serialized = json.dumps(sources)
+        serialized = orjson.dumps(sources).decode()
         project.update_option("sentry:symbol_sources", serialized)
 
         redacted = redact_source_secrets([source])

--- a/src/sentry/api/endpoints/relay/register_challenge.py
+++ b/src/sentry/api/endpoints/relay/register_challenge.py
@@ -1,3 +1,4 @@
+import orjson
 from django.conf import settings
 from rest_framework import serializers, status
 from rest_framework.request import Request
@@ -12,7 +13,6 @@ from sentry.api.base import Endpoint, region_silo_endpoint
 from sentry.api.endpoints.relay.constants import RELAY_AUTH_RATE_LIMITS
 from sentry.api.serializers import serialize
 from sentry.relay.utils import get_header_relay_id, get_header_relay_signature
-from sentry.utils import json
 
 from . import RelayIdSerializer
 
@@ -42,8 +42,8 @@ class RelayRegisterChallengeEndpoint(Endpoint):
         it will always attempt to invoke this endpoint.
         """
         try:
-            json_data = json.loads(request.body)
-        except ValueError:
+            json_data = orjson.loads(request.body)
+        except orjson.JSONDecodeError:
             return Response({"detail": "No valid json body"}, status=status.HTTP_400_BAD_REQUEST)
 
         serializer = RelayRegisterChallengeSerializer(data=json_data)

--- a/src/sentry/api/endpoints/relay/register_response.py
+++ b/src/sentry/api/endpoints/relay/register_response.py
@@ -1,3 +1,4 @@
+import orjson
 from django.utils import timezone
 from rest_framework import serializers, status
 from rest_framework.request import Request
@@ -14,7 +15,6 @@ from sentry.api.endpoints.relay.constants import RELAY_AUTH_RATE_LIMITS
 from sentry.api.serializers import serialize
 from sentry.models.relay import Relay, RelayUsage
 from sentry.relay.utils import get_header_relay_id, get_header_relay_signature
-from sentry.utils import json
 
 from . import RelayIdSerializer
 
@@ -45,8 +45,8 @@ class RelayRegisterResponseEndpoint(Endpoint):
         """
 
         try:
-            json_data = json.loads(request.body)
-        except ValueError:
+            json_data = orjson.loads(request.body)
+        except orjson.JSONDecodeError:
             return Response({"detail": "No valid json body"}, status=status.HTTP_400_BAD_REQUEST)
 
         serializer = RelayRegisterResponseSerializer(data=json_data)

--- a/src/sentry/api/fields/secret.py
+++ b/src/sentry/api/fields/secret.py
@@ -1,7 +1,5 @@
 from rest_framework import serializers
 
-from sentry.utils import json
-
 
 class SecretField(serializers.Field):
     """
@@ -30,7 +28,7 @@ class SecretField(serializers.Field):
         return self.string_field.to_internal_value(data)
 
 
-def validate_secret(secret: str | dict[str, bool] | None) -> json.JSONData | None:
+def validate_secret(secret: str | dict[str, bool] | None) -> str | dict[str, bool] | None:
     """
     Validates the contents of a field containing a secret that may have a magic object representing
     some existing value already stored on the server.

--- a/src/sentry/api/helpers/autofix.py
+++ b/src/sentry/api/helpers/autofix.py
@@ -1,10 +1,10 @@
 import enum
 
+import orjson
 import requests
 from django.conf import settings
 
 from sentry.api.helpers.repos import get_repos_from_project_code_mappings
-from sentry.utils import json
 
 
 class AutofixCodebaseIndexingStatus(str, enum.Enum):
@@ -23,7 +23,7 @@ def get_project_codebase_indexing_status(project):
     for repo in repos:
         response = requests.post(
             f"{settings.SEER_AUTOFIX_URL}/v1/automation/codebase/index/status",
-            data=json.dumps(
+            data=orjson.dumps(
                 {
                     "organization_id": project.organization.id,
                     "project_id": project.id,

--- a/src/sentry/api/serializers/models/app_platform_event.py
+++ b/src/sentry/api/serializers/models/app_platform_event.py
@@ -1,7 +1,7 @@
 from time import time
 from uuid import uuid4
 
-from sentry.utils import json
+import orjson
 
 
 class AppPlatformEvent:
@@ -33,14 +33,14 @@ class AppPlatformEvent:
 
     @property
     def body(self):
-        return json.dumps(
+        return orjson.dumps(
             {
                 "action": self.action,
                 "installation": {"uuid": self.install.uuid},
                 "data": self.data,
                 "actor": self.get_actor(),
             }
-        )
+        ).decode()
 
     @property
     def headers(self):

--- a/src/sentry/api/serializers/models/dashboard.py
+++ b/src/sentry/api/serializers/models/dashboard.py
@@ -1,5 +1,7 @@
 from collections import defaultdict
 
+import orjson
+
 from sentry.api.serializers import Serializer, register, serialize
 from sentry.constants import ALL_ACCESS_PROJECTS
 from sentry.models.dashboard import Dashboard
@@ -12,7 +14,6 @@ from sentry.models.dashboard_widget import (
 )
 from sentry.services.hybrid_cloud.user.service import user_service
 from sentry.snuba.metrics.extraction import OnDemandMetricSpecVersioning
-from sentry.utils import json
 from sentry.utils.dates import outside_retention_with_modified_start, parse_timestamp
 
 
@@ -128,7 +129,7 @@ class DashboardListSerializer(Serializer):
                 "layout": None,
             }
             if widget.get("detail"):
-                detail = json.loads(widget["detail"])
+                detail = orjson.loads(widget["detail"])
                 if detail.get("layout"):
                     widget_preview["layout"] = detail["layout"]
 

--- a/src/sentry/api/serializers/models/project.py
+++ b/src/sentry/api/serializers/models/project.py
@@ -5,6 +5,7 @@ from collections.abc import Iterable, Mapping, MutableMapping, Sequence
 from datetime import datetime, timedelta
 from typing import Any, Final, TypedDict, cast
 
+import orjson
 import sentry_sdk
 from django.db import connection
 from django.db.models import prefetch_related_objects
@@ -41,7 +42,6 @@ from sentry.processing import realtime_metrics
 from sentry.roles import organization_roles
 from sentry.snuba import discover
 from sentry.tasks.symbolication import should_demote_symbolication
-from sentry.utils import json
 
 STATUS_LABELS = {
     ObjectStatus.ACTIVE: "active",
@@ -1013,7 +1013,7 @@ class DetailedProjectSerializer(ProjectWithTeamSerializer):
             serialized_sources = "[]"
         else:
             redacted_sources = redact_source_secrets(sources)
-            serialized_sources = json.dumps(redacted_sources)
+            serialized_sources = orjson.dumps(redacted_sources).decode()
 
         data.update(
             {

--- a/src/sentry/api/serializers/rest_framework/json.py
+++ b/src/sentry/api/serializers/rest_framework/json.py
@@ -1,7 +1,6 @@
+import orjson
 from django.utils.translation import gettext_lazy as _
 from rest_framework.serializers import Field, ValidationError
-
-from sentry.utils import json
 
 # JSONField taken from Django rest framework version 3.9.0
 # See https://github.com/encode/django-rest-framework/blob/0eb2dc1137189027cc8d638630fb1754b02d6cfa/rest_framework/fields.py
@@ -14,7 +13,7 @@ class JSONField(Field):
 
     def to_internal_value(self, data):
         try:
-            json.dumps(data)
-        except (TypeError, ValueError):
+            orjson.dumps(data)
+        except (TypeError, ValueError, orjson.JSONEncodeError):
             raise ValidationError(self.default_error_messages["invalid"])
         return data

--- a/src/sentry/api/serializers/rest_framework/rule.py
+++ b/src/sentry/api/serializers/rest_framework/rule.py
@@ -1,6 +1,7 @@
 from typing import Any
 from uuid import UUID, uuid4
 
+import orjson
 from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import extend_schema_field
 from rest_framework import serializers
@@ -10,7 +11,6 @@ from sentry.api.fields.actor import ActorField
 from sentry.constants import MIGRATED_CONDITIONS, SENTRY_APP_ACTIONS, TICKET_ACTIONS
 from sentry.models.environment import Environment
 from sentry.rules import rules
-from sentry.utils import json
 
 ValidationError = serializers.ValidationError
 
@@ -27,7 +27,7 @@ class RuleNodeField(serializers.Field):
     def to_internal_value(self, data):
         if isinstance(data, str):
             try:
-                data = json.loads(data.replace("'", '"'))
+                data = orjson.loads(data.replace("'", '"'))
             except Exception:
                 raise ValidationError("Failed trying to parse dict from string")
         elif not isinstance(data, dict):

--- a/src/sentry/api/validators/sentry_apps/schema.py
+++ b/src/sentry/api/validators/sentry_apps/schema.py
@@ -1,10 +1,9 @@
 import logging
 
+import orjson
 from jsonschema import Draft7Validator
 from jsonschema.exceptions import ValidationError as SchemaValidationError
 from jsonschema.exceptions import best_match
-
-from sentry.utils import json
 
 logger = logging.getLogger(__name__)
 
@@ -277,7 +276,7 @@ def validate_ui_element_schema(instance):
             "Unexpected error validating schema: %s",
             e,
             exc_info=True,
-            extra={"schema": json.dumps(instance)},
+            extra={"schema": orjson.dumps(instance).decode()},
         )
         # pre-validators might have unexpected errors if the format is not what they expect in the check
         # if that happens, we should eat the error and let the main validator find the schema error

--- a/tests/sentry/api/endpoints/notifications/test_notification_actions_details.py
+++ b/tests/sentry/api/endpoints/notifications/test_notification_actions_details.py
@@ -1,5 +1,6 @@
 from unittest.mock import MagicMock, patch
 
+import orjson
 import responses
 from rest_framework import serializers, status
 
@@ -18,7 +19,6 @@ from sentry.silo.base import SiloMode
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.helpers.slack import install_slack
 from sentry.testutils.silo import assume_test_silo_mode
-from sentry.utils import json
 
 
 class NotificationActionsDetailsEndpointTest(APITestCase):
@@ -238,7 +238,7 @@ class NotificationActionsDetailsEndpointTest(APITestCase):
             url="https://slack.com/api/chat.scheduleMessage",
             status=200,
             content_type="application/json",
-            body=json.dumps(
+            body=orjson.dumps(
                 {"ok": "true", "channel": channel_id, "scheduled_message_id": "Q1298393284"}
             ),
         )
@@ -247,7 +247,7 @@ class NotificationActionsDetailsEndpointTest(APITestCase):
             url="https://slack.com/api/chat.deleteScheduledMessage",
             status=200,
             content_type="application/json",
-            body=json.dumps({"ok": True}),
+            body=orjson.dumps({"ok": True}),
         )
 
         response = self.get_success_response(

--- a/tests/sentry/api/endpoints/notifications/test_notification_actions_index.py
+++ b/tests/sentry/api/endpoints/notifications/test_notification_actions_index.py
@@ -1,5 +1,6 @@
 from unittest.mock import MagicMock, patch
 
+import orjson
 import responses
 from rest_framework import serializers, status
 
@@ -18,7 +19,6 @@ from sentry.silo.base import SiloMode
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.helpers.slack import install_slack
 from sentry.testutils.silo import assume_test_silo_mode
-from sentry.utils import json
 
 
 class NotificationActionsIndexEndpointTest(APITestCase):
@@ -286,7 +286,7 @@ class NotificationActionsIndexEndpointTest(APITestCase):
             url="https://slack.com/api/chat.scheduleMessage",
             status=200,
             content_type="application/json",
-            body=json.dumps(
+            body=orjson.dumps(
                 {"ok": "true", "channel": channel_id, "scheduled_message_id": "Q1298393284"}
             ),
         )
@@ -295,7 +295,7 @@ class NotificationActionsIndexEndpointTest(APITestCase):
             url="https://slack.com/api/chat.deleteScheduledMessage",
             status=200,
             content_type="application/json",
-            body=json.dumps({"ok": True}),
+            body=orjson.dumps({"ok": True}),
         )
         response = self.get_success_response(
             self.organization.slug,

--- a/tests/sentry/api/endpoints/relocations/test_index.py
+++ b/tests/sentry/api/endpoints/relocations/test_index.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from unittest.mock import Mock, call, patch
 from uuid import UUID
 
+import orjson
 from django.core.files.uploadedfile import SimpleUploadedFile
 from rest_framework import status
 
@@ -23,7 +24,6 @@ from sentry.testutils.factories import get_fixture_path
 from sentry.testutils.helpers.backups import generate_rsa_key_pair
 from sentry.testutils.helpers.datetime import freeze_time
 from sentry.testutils.helpers.options import override_options
-from sentry.utils import json
 from sentry.utils.relocation import OrderedTask
 
 FRESH_INSTALL_PATH = get_fixture_path("backup", "fresh-install.json")
@@ -310,8 +310,8 @@ class PostRelocationsTest(APITestCase):
 
         with tempfile.TemporaryDirectory() as tmp_dir:
             (_, tmp_pub_key_path) = self.tmp_keys(tmp_dir)
-            with open(FRESH_INSTALL_PATH) as f:
-                data = json.load(f)
+            with open(FRESH_INSTALL_PATH, "rb") as f:
+                data = orjson.loads(f.read())
                 with open(tmp_pub_key_path, "rb") as p:
                     response = self.get_success_response(
                         owner=self.owner.username,
@@ -372,8 +372,8 @@ class PostRelocationsTest(APITestCase):
 
         with tempfile.TemporaryDirectory() as tmp_dir:
             (_, tmp_pub_key_path) = self.tmp_keys(tmp_dir)
-            with open(FRESH_INSTALL_PATH) as f:
-                data = json.load(f)
+            with open(FRESH_INSTALL_PATH, "rb") as f:
+                data = orjson.loads(f.read())
                 with open(tmp_pub_key_path, "rb") as p:
                     response = self.get_success_response(
                         owner=self.owner.username,
@@ -439,8 +439,8 @@ class PostRelocationsTest(APITestCase):
 
         with tempfile.TemporaryDirectory() as tmp_dir:
             (_, tmp_pub_key_path) = self.tmp_keys(tmp_dir)
-            with open(FRESH_INSTALL_PATH) as f:
-                data = json.load(f)
+            with open(FRESH_INSTALL_PATH, "rb") as f:
+                data = orjson.loads(f.read())
                 with open(tmp_pub_key_path, "rb") as p:
                     response = self.get_success_response(
                         owner=self.owner.username,
@@ -493,8 +493,8 @@ class PostRelocationsTest(APITestCase):
 
         with tempfile.TemporaryDirectory() as tmp_dir:
             (_, tmp_pub_key_path) = self.tmp_keys(tmp_dir)
-            with open(FRESH_INSTALL_PATH) as f:
-                data = json.load(f)
+            with open(FRESH_INSTALL_PATH, "rb") as f:
+                data = orjson.loads(f.read())
                 with open(tmp_pub_key_path, "rb") as p:
                     response = self.get_success_response(
                         owner=self.owner.username,
@@ -544,8 +544,8 @@ class PostRelocationsTest(APITestCase):
 
         with tempfile.TemporaryDirectory() as tmp_dir:
             (_, tmp_pub_key_path) = self.tmp_keys(tmp_dir)
-            with open(FRESH_INSTALL_PATH) as f:
-                data = json.load(f)
+            with open(FRESH_INSTALL_PATH, "rb") as f:
+                data = orjson.loads(f.read())
                 with open(tmp_pub_key_path, "rb") as p:
                     response = self.get_success_response(
                         owner=self.owner.username,
@@ -605,8 +605,8 @@ class PostRelocationsTest(APITestCase):
 
         with tempfile.TemporaryDirectory() as tmp_dir:
             (_, tmp_pub_key_path) = self.tmp_keys(tmp_dir)
-            with open(FRESH_INSTALL_PATH) as f:
-                data = json.load(f)
+            with open(FRESH_INSTALL_PATH, "rb") as f:
+                data = orjson.loads(f.read())
                 with open(tmp_pub_key_path, "rb") as p:
                     response = self.get_success_response(
                         owner=self.owner.username,
@@ -658,8 +658,8 @@ class PostRelocationsTest(APITestCase):
         self.login_as(user=self.owner, superuser=False)
         with tempfile.TemporaryDirectory() as tmp_dir:
             (_, tmp_pub_key_path) = self.tmp_keys(tmp_dir)
-            with open(FRESH_INSTALL_PATH) as f:
-                data = json.load(f)
+            with open(FRESH_INSTALL_PATH, "rb") as f:
+                data = orjson.loads(f.read())
                 with open(tmp_pub_key_path, "rb") as p:
                     response = self.get_error_response(
                         owner=self.owner.username,
@@ -684,8 +684,8 @@ class PostRelocationsTest(APITestCase):
         self.login_as(user=self.owner, superuser=True)
         with tempfile.TemporaryDirectory() as tmp_dir:
             (_, tmp_pub_key_path) = self.tmp_keys(tmp_dir)
-            with open(FRESH_INSTALL_PATH) as f:
-                data = json.load(f)
+            with open(FRESH_INSTALL_PATH, "rb") as f:
+                data = orjson.loads(f.read())
                 with open(tmp_pub_key_path, "rb") as p:
                     response = self.get_error_response(
                         owner=self.owner.username,
@@ -730,8 +730,8 @@ class PostRelocationsTest(APITestCase):
 
             with tempfile.TemporaryDirectory() as tmp_dir:
                 (_, tmp_pub_key_path) = self.tmp_keys(tmp_dir)
-                with open(FRESH_INSTALL_PATH) as f:
-                    data = json.load(f)
+                with open(FRESH_INSTALL_PATH, "rb") as f:
+                    data = orjson.loads(f.read())
                     with open(tmp_pub_key_path, "rb") as p:
                         response = self.get_success_response(
                             owner=self.owner.username,
@@ -790,8 +790,8 @@ class PostRelocationsTest(APITestCase):
 
             with tempfile.TemporaryDirectory() as tmp_dir:
                 (_, tmp_pub_key_path) = self.tmp_keys(tmp_dir)
-                with open(FRESH_INSTALL_PATH) as f:
-                    data = json.load(f)
+                with open(FRESH_INSTALL_PATH, "rb") as f:
+                    data = orjson.loads(f.read())
                     with open(tmp_pub_key_path, "rb") as p:
                         response = self.get_error_response(
                             owner=self.owner.username,
@@ -841,8 +841,8 @@ class PostRelocationsTest(APITestCase):
 
         with tempfile.TemporaryDirectory() as tmp_dir:
             (_, tmp_pub_key_path) = self.tmp_keys(tmp_dir)
-            with open(FRESH_INSTALL_PATH) as f:
-                data = json.load(f)
+            with open(FRESH_INSTALL_PATH, "rb") as f:
+                data = orjson.loads(f.read())
                 with open(tmp_pub_key_path, "rb") as p:
                     response = self.get_success_response(
                         owner=self.owner.username,
@@ -899,8 +899,8 @@ class PostRelocationsTest(APITestCase):
         self.login_as(user=self.owner, superuser=False)
         with tempfile.TemporaryDirectory() as tmp_dir:
             (_, tmp_pub_key_path) = self.tmp_keys(tmp_dir)
-            with open(FRESH_INSTALL_PATH) as f:
-                data = json.load(f)
+            with open(FRESH_INSTALL_PATH, "rb") as f:
+                data = orjson.loads(f.read())
                 with open(tmp_pub_key_path, "rb") as p:
                     response = self.get_error_response(
                         owner=self.owner.username,
@@ -927,8 +927,8 @@ class PostRelocationsTest(APITestCase):
         self.login_as(user=self.owner, superuser=False)
         with tempfile.TemporaryDirectory() as tmp_dir:
             (_, tmp_pub_key_path) = self.tmp_keys(tmp_dir)
-            with open(FRESH_INSTALL_PATH) as f:
-                data = json.load(f)
+            with open(FRESH_INSTALL_PATH, "rb") as f:
+                data = orjson.loads(f.read())
                 with open(tmp_pub_key_path, "rb") as p:
                     response = self.get_error_response(
                         file=SimpleUploadedFile(
@@ -957,8 +957,8 @@ class PostRelocationsTest(APITestCase):
         self.login_as(user=self.staff_user, staff=True)
         with tempfile.TemporaryDirectory() as tmp_dir:
             (_, tmp_pub_key_path) = self.tmp_keys(tmp_dir)
-            with open(FRESH_INSTALL_PATH) as f:
-                data = json.load(f)
+            with open(FRESH_INSTALL_PATH, "rb") as f:
+                data = orjson.loads(f.read())
                 with open(tmp_pub_key_path, "rb") as p:
                     response = self.get_error_response(
                         owner="doesnotexist",
@@ -988,8 +988,8 @@ class PostRelocationsTest(APITestCase):
         self.login_as(user=self.superuser, superuser=True)
         with tempfile.TemporaryDirectory() as tmp_dir:
             (_, tmp_pub_key_path) = self.tmp_keys(tmp_dir)
-            with open(FRESH_INSTALL_PATH) as f:
-                data = json.load(f)
+            with open(FRESH_INSTALL_PATH, "rb") as f:
+                data = orjson.loads(f.read())
                 with open(tmp_pub_key_path, "rb") as p:
                     response = self.get_error_response(
                         owner="doesnotexist",
@@ -1019,8 +1019,8 @@ class PostRelocationsTest(APITestCase):
         self.login_as(user=self.owner, superuser=False)
         with tempfile.TemporaryDirectory() as tmp_dir:
             (_, tmp_pub_key_path) = self.tmp_keys(tmp_dir)
-            with open(FRESH_INSTALL_PATH) as f:
-                data = json.load(f)
+            with open(FRESH_INSTALL_PATH, "rb") as f:
+                data = orjson.loads(f.read())
                 with open(tmp_pub_key_path, "rb") as p:
                     response = self.get_error_response(
                         owner="other",
@@ -1064,8 +1064,8 @@ class PostRelocationsTest(APITestCase):
 
             with tempfile.TemporaryDirectory() as tmp_dir:
                 (_, tmp_pub_key_path) = self.tmp_keys(tmp_dir)
-                with open(FRESH_INSTALL_PATH) as f:
-                    data = json.load(f)
+                with open(FRESH_INSTALL_PATH, "rb") as f:
+                    data = orjson.loads(f.read())
                     with open(tmp_pub_key_path, "rb") as p:
                         simple_file = SimpleUploadedFile(
                             "export.tar",
@@ -1095,8 +1095,8 @@ class PostRelocationsTest(APITestCase):
 
         with tempfile.TemporaryDirectory() as tmp_dir:
             (_, tmp_pub_key_path) = self.tmp_keys(tmp_dir)
-            with open(FRESH_INSTALL_PATH) as f:
-                data = json.load(f)
+            with open(FRESH_INSTALL_PATH, "rb") as f:
+                data = orjson.loads(f.read())
                 with open(tmp_pub_key_path, "rb") as p:
                     initial_response = self.get_success_response(
                         owner=self.owner.username,
@@ -1163,8 +1163,8 @@ class PostRelocationsTest(APITestCase):
 
         with tempfile.TemporaryDirectory() as tmp_dir:
             (_, tmp_pub_key_path) = self.tmp_keys(tmp_dir)
-            with open(FRESH_INSTALL_PATH) as f:
-                data = json.load(f)
+            with open(FRESH_INSTALL_PATH, "rb") as f:
+                data = orjson.loads(f.read())
                 with open(tmp_pub_key_path, "rb") as p:
                     initial_response = self.get_success_response(
                         owner=self.owner.username,
@@ -1246,8 +1246,8 @@ class PostRelocationsTest(APITestCase):
 
         with tempfile.TemporaryDirectory() as tmp_dir:
             (_, tmp_pub_key_path) = self.tmp_keys(tmp_dir)
-            with open(FRESH_INSTALL_PATH) as f:
-                data = json.load(f)
+            with open(FRESH_INSTALL_PATH, "rb") as f:
+                data = orjson.loads(f.read())
                 with open(tmp_pub_key_path, "rb") as p:
                     initial_response = self.get_success_response(
                         owner=self.owner.username,
@@ -1335,8 +1335,8 @@ class PostRelocationsTest(APITestCase):
 
         with tempfile.TemporaryDirectory() as tmp_dir:
             (_, tmp_pub_key_path) = self.tmp_keys(tmp_dir)
-            with open(FRESH_INSTALL_PATH) as f:
-                data = json.load(f)
+            with open(FRESH_INSTALL_PATH, "rb") as f:
+                data = orjson.loads(f.read())
                 with open(tmp_pub_key_path, "rb") as p:
                     initial_response = self.get_success_response(
                         owner=self.owner.username,
@@ -1420,7 +1420,7 @@ class PostRelocationsTest(APITestCase):
         with tempfile.TemporaryDirectory() as tmp_dir:
             (_, tmp_pub_key_path) = self.tmp_keys(tmp_dir)
             with open(FRESH_INSTALL_PATH) as f, freeze_time("2023-11-28 00:00:00") as frozen_time:
-                data = json.load(f)
+                data = orjson.loads(f.read())
                 with open(tmp_pub_key_path, "rb") as p:
                     initial_response = self.get_success_response(
                         owner=self.owner.username,
@@ -1506,8 +1506,8 @@ class PostRelocationsTest(APITestCase):
 
         with tempfile.TemporaryDirectory() as tmp_dir:
             (_, tmp_pub_key_path) = self.tmp_keys(tmp_dir)
-            with open(FRESH_INSTALL_PATH) as f:
-                data = json.load(f)
+            with open(FRESH_INSTALL_PATH, "rb") as f:
+                data = orjson.loads(f.read())
                 with open(tmp_pub_key_path, "rb") as p:
                     self.get_error_response(
                         owner=self.owner.username,

--- a/tests/sentry/api/endpoints/relocations/test_retry.py
+++ b/tests/sentry/api/endpoints/relocations/test_retry.py
@@ -4,6 +4,8 @@ from io import BytesIO
 from unittest.mock import Mock, patch
 from uuid import uuid4
 
+import orjson
+
 from sentry.api.endpoints.relocations import ERR_FEATURE_DISABLED
 from sentry.api.endpoints.relocations.index import (
     ERR_DUPLICATE_RELOCATION,
@@ -24,7 +26,6 @@ from sentry.testutils.factories import get_fixture_path
 from sentry.testutils.helpers.backups import generate_rsa_key_pair
 from sentry.testutils.helpers.options import override_options
 from sentry.testutils.silo import assume_test_silo_mode
-from sentry.utils import json
 from sentry.utils.relocation import RELOCATION_FILE_TYPE, OrderedTask
 
 FRESH_INSTALL_PATH = get_fixture_path("backup", "fresh-install.json")
@@ -35,8 +36,8 @@ TEST_DATE_ADDED = datetime(2023, 1, 23, 1, 23, 45, tzinfo=timezone.utc)
 @lru_cache(maxsize=1)
 def get_test_tarball() -> BytesIO:
     (_, pub_key_pem) = generate_rsa_key_pair()
-    with open(FRESH_INSTALL_PATH) as f:
-        data = json.load(f)
+    with open(FRESH_INSTALL_PATH, "rb") as f:
+        data = orjson.loads(f.read())
         return create_encrypted_export_tarball(data, LocalFileEncryptor(BytesIO(pub_key_pem)))
 
 

--- a/tests/sentry/api/endpoints/test_event_grouping_info.py
+++ b/tests/sentry/api/endpoints/test_event_grouping_info.py
@@ -1,5 +1,6 @@
 from unittest import mock
 
+import orjson
 import pytest
 from django.urls import reverse
 
@@ -7,7 +8,6 @@ from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.grouping.grouping_info import get_grouping_info
 from sentry.testutils.cases import APITestCase, PerformanceIssueTestCase
 from sentry.testutils.skips import requires_snuba
-from sentry.utils import json
 from sentry.utils.samples import load_data
 
 pytestmark = [requires_snuba]
@@ -39,7 +39,7 @@ class EventGroupingInfoEndpointTestCase(APITestCase, PerformanceIssueTestCase):
         )
 
         response = self.client.get(url, format="json")
-        content = json.loads(response.content)
+        content = orjson.loads(response.content)
 
         assert response.status_code == 200
         assert content["system"]["type"] == "component"
@@ -58,7 +58,7 @@ class EventGroupingInfoEndpointTestCase(APITestCase, PerformanceIssueTestCase):
         )
 
         response = self.client.get(url, format="json")
-        content = json.loads(response.content)
+        content = orjson.loads(response.content)
 
         assert response.status_code == 200
         assert content == {}
@@ -76,7 +76,7 @@ class EventGroupingInfoEndpointTestCase(APITestCase, PerformanceIssueTestCase):
         )
 
         response = self.client.get(url, format="json")
-        content = json.loads(response.content)
+        content = orjson.loads(response.content)
 
         assert response.status_code == 200
         assert content["performance_n_plus_one_db_queries"]["type"] == "performance-problem"

--- a/tests/sentry/api/endpoints/test_group_autofix_update.py
+++ b/tests/sentry/api/endpoints/test_group_autofix_update.py
@@ -1,10 +1,10 @@
 from unittest.mock import patch
 
+import orjson
 from django.conf import settings
 from rest_framework import status
 
 from sentry.testutils.cases import APITestCase
-from sentry.utils import json
 
 
 class TestGroupAutofixUpdate(APITestCase):
@@ -35,7 +35,7 @@ class TestGroupAutofixUpdate(APITestCase):
         assert response.status_code == status.HTTP_202_ACCEPTED
         mock_post.assert_called_once_with(
             f"{settings.SEER_AUTOFIX_URL}/v1/automation/autofix/update",
-            data=json.dumps(
+            data=orjson.dumps(
                 {
                     "run_id": 123,
                     "payload": {
@@ -44,7 +44,7 @@ class TestGroupAutofixUpdate(APITestCase):
                         "fix_id": 789,
                     },
                 }
-            ).encode("utf-8"),
+            ),
             headers={"content-type": "application/json;charset=utf-8"},
         )
 
@@ -54,7 +54,7 @@ class TestGroupAutofixUpdate(APITestCase):
 
         response = self.client.post(
             self.url,
-            data=json.dumps(
+            data=orjson.dumps(
                 {
                     "run_id": 123,
                     "payload": {
@@ -63,7 +63,7 @@ class TestGroupAutofixUpdate(APITestCase):
                         "fix_id": 789,
                     },
                 }
-            ).encode("utf-8"),
+            ),
             format="json",
         )
 

--- a/tests/sentry/api/endpoints/test_group_similar_issues_embeddings.py
+++ b/tests/sentry/api/endpoints/test_group_similar_issues_embeddings.py
@@ -3,6 +3,7 @@ from collections.abc import Mapping, Sequence
 from typing import Any
 from unittest import mock
 
+import orjson
 from urllib3.response import HTTPResponse
 
 from sentry.api.endpoints.group_similar_issues_embeddings import (
@@ -15,7 +16,6 @@ from sentry.seer.utils import SeerSimilarIssueData, SimilarIssuesEmbeddingsRespo
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.helpers.eventprocessing import save_new_event
 from sentry.testutils.helpers.features import with_feature
-from sentry.utils import json
 from sentry.utils.types import NonNone
 
 EXPECTED_STACKTRACE_STRING = 'ZeroDivisionError: division by zero\n  File "python_onboarding.py", function divide_by_zero\n    divide = 1/0'
@@ -707,7 +707,7 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
                 }
             ]
         }
-        mock_seer_request.return_value = HTTPResponse(json.dumps(seer_return_value).encode("utf-8"))
+        mock_seer_request.return_value = HTTPResponse(orjson.dumps(seer_return_value))
 
         response = self.client.get(
             self.path,
@@ -731,7 +731,7 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
         mock_seer_request.assert_called_with(
             "POST",
             "/v0/issues/similar-issues",
-            body=json.dumps(expected_seer_request_params),
+            body=orjson.dumps(expected_seer_request_params).decode(),
             headers={"Content-Type": "application/json;charset=utf-8"},
         )
 
@@ -754,7 +754,7 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
                 }
             ]
         }
-        mock_seer_request.return_value = HTTPResponse(json.dumps(seer_return_value).encode("utf-8"))
+        mock_seer_request.return_value = HTTPResponse(orjson.dumps(seer_return_value))
 
         response = self.client.get(
             self.path,
@@ -778,7 +778,7 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
         mock_seer_request.assert_called_with(
             "POST",
             "/v0/issues/similar-issues",
-            body=json.dumps(expected_seer_request_params),
+            body=orjson.dumps(expected_seer_request_params).decode(),
             headers={"Content-Type": "application/json;charset=utf-8"},
         )
 
@@ -803,7 +803,7 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
                 }
             ]
         }
-        mock_seer_request.return_value = HTTPResponse(json.dumps(seer_return_value).encode("utf-8"))
+        mock_seer_request.return_value = HTTPResponse(orjson.dumps(seer_return_value))
 
         response = self.client.get(
             self.path,
@@ -827,7 +827,7 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
         mock_seer_request.assert_called_with(
             "POST",
             "/v0/issues/similar-issues",
-            body=json.dumps(expected_seer_request_params),
+            body=orjson.dumps(expected_seer_request_params).decode(),
             headers={"Content-Type": "application/json;charset=utf-8"},
         )
 
@@ -868,7 +868,7 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
                 },
             ]
         }
-        mock_seer_request.return_value = HTTPResponse(json.dumps(seer_return_value).encode("utf-8"))
+        mock_seer_request.return_value = HTTPResponse(orjson.dumps(seer_return_value))
 
         response = self.client.get(
             self.path,
@@ -919,7 +919,7 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
                 },
             ]
         }
-        mock_seer_request.return_value = HTTPResponse(json.dumps(seer_return_value).encode("utf-8"))
+        mock_seer_request.return_value = HTTPResponse(orjson.dumps(seer_return_value))
         response = self.client.get(self.path)
 
         mock_logger.exception.assert_called_with(
@@ -971,7 +971,7 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
                 },
             ]
         }
-        mock_seer_request.return_value = HTTPResponse(json.dumps(seer_return_value).encode("utf-8"))
+        mock_seer_request.return_value = HTTPResponse(orjson.dumps(seer_return_value))
         response = self.client.get(self.path)
 
         mock_logger.exception.assert_called_with(
@@ -1086,7 +1086,7 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
             ]
         }
 
-        mock_seer_request.return_value = HTTPResponse(json.dumps(seer_return_value).encode("utf-8"))
+        mock_seer_request.return_value = HTTPResponse(orjson.dumps(seer_return_value))
 
         # Include no optional parameters
         response = self.client.get(self.path)
@@ -1097,7 +1097,7 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
         mock_seer_request.assert_called_with(
             "POST",
             "/v0/issues/similar-issues",
-            body=json.dumps(
+            body=orjson.dumps(
                 {
                     "group_id": self.group.id,
                     "hash": NonNone(self.event.get_primary_hash()),
@@ -1105,7 +1105,7 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
                     "stacktrace": EXPECTED_STACKTRACE_STRING,
                     "message": self.group.message,
                 },
-            ),
+            ).decode(),
             headers={"Content-Type": "application/json;charset=utf-8"},
         )
 
@@ -1121,7 +1121,7 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
         mock_seer_request.assert_called_with(
             "POST",
             "/v0/issues/similar-issues",
-            body=json.dumps(
+            body=orjson.dumps(
                 {
                     "group_id": self.group.id,
                     "hash": NonNone(self.event.get_primary_hash()),
@@ -1130,7 +1130,7 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
                     "message": self.group.message,
                     "k": 1,
                 },
-            ),
+            ).decode(),
             headers={"Content-Type": "application/json;charset=utf-8"},
         )
 
@@ -1146,7 +1146,7 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
         mock_seer_request.assert_called_with(
             "POST",
             "/v0/issues/similar-issues",
-            body=json.dumps(
+            body=orjson.dumps(
                 {
                     "group_id": self.group.id,
                     "hash": NonNone(self.event.get_primary_hash()),
@@ -1155,6 +1155,6 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
                     "message": self.group.message,
                     "threshold": 0.98,
                 },
-            ),
+            ).decode(),
             headers={"Content-Type": "application/json;charset=utf-8"},
         )

--- a/tests/sentry/api/endpoints/test_organization_details.py
+++ b/tests/sentry/api/endpoints/test_organization_details.py
@@ -6,6 +6,7 @@ from datetime import timedelta
 from typing import Any
 from unittest.mock import patch
 
+import orjson
 import pytest
 import responses
 from dateutil.parser import parse as parse_date
@@ -40,7 +41,6 @@ from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.outbox import outbox_runner
 from sentry.testutils.silo import assume_test_silo_mode_of, create_test_regions, region_silo_test
 from sentry.testutils.skips import requires_snuba
-from sentry.utils import json
 
 pytestmark = [requires_snuba]
 
@@ -556,7 +556,7 @@ class OrganizationUpdateTest(OrganizationDetailsTestBase):
 
         response_data = response.data.get("trustedRelays")
         assert response_data is not None
-        resp_str = json.dumps(response_data)
+        resp_str = orjson.dumps(response_data).decode()
         # check that we have the duplicate key specified somewhere in the error message
         assert resp_str.find(_VALID_RELAY_KEYS[0]) >= 0
 

--- a/tests/sentry/api/endpoints/test_organization_invite_request_index.py
+++ b/tests/sentry/api/endpoints/test_organization_invite_request_index.py
@@ -1,6 +1,7 @@
 from functools import cached_property
 from urllib.parse import parse_qs, urlparse
 
+import orjson
 import responses
 from django.core import mail
 from django.urls import reverse
@@ -12,7 +13,6 @@ from sentry.testutils.cases import APITestCase, SlackActivityNotificationTest
 from sentry.testutils.helpers.slack import get_blocks_and_fallback_text
 from sentry.testutils.hybrid_cloud import HybridCloudTestMixin
 from sentry.testutils.outbox import outbox_runner
-from sentry.utils import json
 
 
 class OrganizationInviteRequestListTest(APITestCase):
@@ -234,7 +234,7 @@ class OrganizationInviteRequestCreateTest(
         )
         member = OrganizationMember.objects.get(email="eric@localhost")
         data = parse_qs(responses.calls[0].request.body)
-        assert json.loads(data["callback_id"][0]) == {
+        assert orjson.loads(data["callback_id"][0]) == {
             "member_id": member.id,
             "member_email": "eric@localhost",
         }

--- a/tests/sentry/api/endpoints/test_organization_join_request.py
+++ b/tests/sentry/api/endpoints/test_organization_join_request.py
@@ -2,6 +2,7 @@ from functools import cached_property
 from unittest.mock import patch
 from urllib.parse import parse_qs, urlparse
 
+import orjson
 import responses
 from django.core import mail
 
@@ -15,7 +16,6 @@ from sentry.testutils.helpers.slack import get_blocks_and_fallback_text
 from sentry.testutils.hybrid_cloud import HybridCloudTestMixin
 from sentry.testutils.outbox import outbox_runner
 from sentry.testutils.silo import assume_test_silo_mode
-from sentry.utils import json
 
 
 class OrganizationJoinRequestTest(APITestCase, SlackActivityNotificationTest, HybridCloudTestMixin):
@@ -212,7 +212,7 @@ class OrganizationJoinRequestTest(APITestCase, SlackActivityNotificationTest, Hy
 
         with outbox_runner():
             member = OrganizationMember.objects.get(email=self.email)
-        assert json.loads(data["callback_id"][0]) == {
+        assert orjson.loads(data["callback_id"][0]) == {
             "member_id": member.id,
             "member_email": self.email,
         }

--- a/tests/sentry/api/endpoints/test_organization_metrics_code_locations.py
+++ b/tests/sentry/api/endpoints/test_organization_metrics_code_locations.py
@@ -2,6 +2,7 @@ from collections.abc import Sequence
 from datetime import datetime, timedelta
 from unittest.mock import patch
 
+import orjson
 import pytest
 from django.utils import timezone
 
@@ -13,7 +14,6 @@ from sentry.sentry_metrics.querying.metadata.metrics_code_locations import (
 from sentry.sentry_metrics.querying.utils import get_redis_client_for_metrics_meta
 from sentry.testutils.cases import APITestCase, BaseSpansTestCase
 from sentry.testutils.helpers.datetime import freeze_time
-from sentry.utils import json
 
 pytestmark = pytest.mark.sentry_metrics
 
@@ -48,7 +48,7 @@ class OrganizationMetricsCodeLocationsTest(APITestCase, BaseSpansTestCase):
         if post_context is not None:
             code_location["post_context"] = post_context
 
-        return json.dumps(code_location)
+        return orjson.dumps(code_location).decode()
 
     def _store_code_location(
         self, organization_id: int, project_id: int, metric_mri: str, timestamp: int, value: str

--- a/tests/sentry/api/endpoints/test_organization_release_meta.py
+++ b/tests/sentry/api/endpoints/test_organization_release_meta.py
@@ -1,3 +1,4 @@
+import orjson
 from django.urls import reverse
 
 from sentry.models.artifactbundle import ProjectArtifactBundle, ReleaseArtifactBundle
@@ -9,7 +10,6 @@ from sentry.models.releasecommit import ReleaseCommit
 from sentry.models.releasefile import ReleaseFile
 from sentry.models.repository import Repository
 from sentry.testutils.cases import APITestCase
-from sentry.utils import json
 
 
 class ReleaseMetaTest(APITestCase):
@@ -76,7 +76,7 @@ class ReleaseMetaTest(APITestCase):
 
         assert response.status_code == 200, response.content
 
-        data = json.loads(response.content)
+        data = orjson.loads(response.content)
         assert data["deployCount"] == 1
         assert data["commitCount"] == 2
         assert data["newGroups"] == 42
@@ -110,7 +110,7 @@ class ReleaseMetaTest(APITestCase):
 
         assert response.status_code == 200, response.content
 
-        data = json.loads(response.content)
+        data = orjson.loads(response.content)
         assert data["releaseFileCount"] == 2
         assert not data["isArtifactBundle"]
 
@@ -148,7 +148,7 @@ class ReleaseMetaTest(APITestCase):
 
         assert response.status_code == 200, response.content
 
-        data = json.loads(response.content)
+        data = orjson.loads(response.content)
         assert data["releaseFileCount"] == 10
         assert data["isArtifactBundle"]
 
@@ -199,6 +199,6 @@ class ReleaseMetaTest(APITestCase):
 
         assert response.status_code == 200, response.content
 
-        data = json.loads(response.content)
+        data = orjson.loads(response.content)
         assert data["releaseFileCount"] == 40
         assert data["isArtifactBundle"]

--- a/tests/sentry/api/endpoints/test_organization_sentry_apps.py
+++ b/tests/sentry/api/endpoints/test_organization_sentry_apps.py
@@ -1,16 +1,16 @@
+import orjson
 from django.urls import reverse
 
 from sentry.models.integrations.sentry_app import SentryApp
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.silo import control_silo_test
-from sentry.utils import json
 
 
 def assert_response_json(response, data):
     """
     Normalizes unicode strings by encoding/decoding expected output
     """
-    assert json.loads(response.content) == json.loads(json.dumps(data))
+    assert orjson.loads(response.content) == orjson.loads(orjson.dumps(data))
 
 
 class OrganizationSentryAppsTest(APITestCase):

--- a/tests/sentry/api/endpoints/test_project_app_store_connect_credentials.py
+++ b/tests/sentry/api/endpoints/test_project_app_store_connect_credentials.py
@@ -1,5 +1,6 @@
 from unittest.mock import patch
 
+import orjson
 from django.test import override_settings
 from django.urls import reverse
 
@@ -8,14 +9,13 @@ from sentry.api.endpoints.project_app_store_connect_credentials import (
 )
 from sentry.lang.native.appconnect import AppStoreConnectConfig
 from sentry.testutils.cases import TestCase
-from sentry.utils import json
 
 
 class TestAppStoreUpdateCredentialsSerializer:
     def test_validate_secrets_magic_object_true(self):
         payload_json = """{"appconnectPrivateKey": {"hidden-secret": true}}"""
 
-        payload = json.loads(payload_json)
+        payload = orjson.loads(payload_json)
         serializer = AppStoreUpdateCredentialsSerializer(data=payload)
         assert serializer.is_valid(), serializer.errors
 
@@ -26,7 +26,7 @@ class TestAppStoreUpdateCredentialsSerializer:
     def test_validate_secrets_magic_object_false(self):
         payload_json = """{"appconnectPrivateKey": {"hidden-secret": false}}"""
 
-        payload = json.loads(payload_json)
+        payload = orjson.loads(payload_json)
         serializer = AppStoreUpdateCredentialsSerializer(data=payload)
         assert not serializer.is_valid()
 
@@ -35,7 +35,7 @@ class TestAppStoreUpdateCredentialsSerializer:
     def test_validate_secrets_null(self):
         payload_json = """{"appconnectPrivateKey": null}"""
 
-        payload = json.loads(payload_json)
+        payload = orjson.loads(payload_json)
         serializer = AppStoreUpdateCredentialsSerializer(data=payload)
         assert not serializer.is_valid()
 
@@ -48,7 +48,7 @@ class TestAppStoreUpdateCredentialsSerializer:
     def test_validate_secrets_absent(self):
         payload_json = """{"appId": "honk"}"""
 
-        payload = json.loads(payload_json)
+        payload = orjson.loads(payload_json)
         serializer = AppStoreUpdateCredentialsSerializer(data=payload)
         assert serializer.is_valid(), serializer.errors
 
@@ -60,7 +60,7 @@ class TestAppStoreUpdateCredentialsSerializer:
     def test_validate_secrets_empty_string(self):
         payload_json = """{"appconnectPrivateKey": ""}"""
 
-        payload = json.loads(payload_json)
+        payload = orjson.loads(payload_json)
         serializer = AppStoreUpdateCredentialsSerializer(data=payload)
         assert not serializer.is_valid()
 
@@ -71,7 +71,7 @@ class TestAppStoreUpdateCredentialsSerializer:
     def test_validate_secrets_string(self):
         payload_json = """{"appconnectPrivateKey": "honk"}"""
 
-        payload = json.loads(payload_json)
+        payload = orjson.loads(payload_json)
         serializer = AppStoreUpdateCredentialsSerializer(data=payload)
         assert serializer.is_valid(), serializer.errors
 

--- a/tests/sentry/api/endpoints/test_project_artifact_bundle_file_details.py
+++ b/tests/sentry/api/endpoints/test_project_artifact_bundle_file_details.py
@@ -3,13 +3,13 @@ import io
 import zipfile
 from uuid import uuid4
 
+import orjson
 from django.urls import reverse
 
 from sentry.models.artifactbundle import ArtifactBundle, ProjectArtifactBundle
 from sentry.models.files.file import File
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.helpers.response import close_streaming_response
-from sentry.utils import json
 
 
 class ProjectArtifactBundleFileDetailsEndpointTest(APITestCase):
@@ -26,7 +26,7 @@ class ProjectArtifactBundleFileDetailsEndpointTest(APITestCase):
 
             zip_file.writestr(
                 "manifest.json",
-                json.dumps(
+                orjson.dumps(
                     {
                         # We remove the "content" key in the original dict, thus no subsequent calls should be made.
                         "files": {
@@ -34,7 +34,7 @@ class ProjectArtifactBundleFileDetailsEndpointTest(APITestCase):
                             for file_path, info in files.items()
                         }
                     }
-                ),
+                ).decode(),
             )
         compressed.seek(0)
 

--- a/tests/sentry/api/endpoints/test_project_autofix_create_codebase_index.py
+++ b/tests/sentry/api/endpoints/test_project_autofix_create_codebase_index.py
@@ -1,11 +1,11 @@
 from unittest.mock import call, patch
 
+import orjson
 from django.conf import settings
 from django.urls import reverse
 from rest_framework import status
 
 from sentry.testutils.cases import APITestCase
-from sentry.utils import json
 
 
 class TestProjectAutofixCodebaseIndexCreate(APITestCase):
@@ -41,7 +41,7 @@ class TestProjectAutofixCodebaseIndexCreate(APITestCase):
         assert response.status_code == status.HTTP_202_ACCEPTED
         mock_post.assert_called_once_with(
             f"{settings.SEER_AUTOFIX_URL}/v1/automation/codebase/index/create",
-            data=json.dumps(
+            data=orjson.dumps(
                 {
                     "organization_id": self.project.organization.id,
                     "project_id": self.project.id,
@@ -86,7 +86,7 @@ class TestProjectAutofixCodebaseIndexCreate(APITestCase):
         calls = [
             call(
                 f"{settings.SEER_AUTOFIX_URL}/v1/automation/codebase/index/create",
-                data=json.dumps(
+                data=orjson.dumps(
                     {
                         "organization_id": self.project.organization.id,
                         "project_id": self.project.id,
@@ -102,7 +102,7 @@ class TestProjectAutofixCodebaseIndexCreate(APITestCase):
             ),
             call(
                 f"{settings.SEER_AUTOFIX_URL}/v1/automation/codebase/index/create",
-                data=json.dumps(
+                data=orjson.dumps(
                     {
                         "organization_id": self.project.organization.id,
                         "project_id": self.project.id,

--- a/tests/sentry/api/endpoints/test_project_create_sample.py
+++ b/tests/sentry/api/endpoints/test_project_create_sample.py
@@ -1,9 +1,9 @@
+import orjson
 from django.urls import reverse
 
 from sentry.models.groupinbox import GroupInbox
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.skips import requires_snuba
-from sentry.utils import json
 
 pytestmark = [requires_snuba]
 
@@ -26,7 +26,7 @@ class ProjectCreateSampleTest(APITestCase):
         response = self.client.post(url, format="json")
 
         assert response.status_code == 200, response.content
-        assert "groupID" in json.loads(response.content)
+        assert "groupID" in orjson.loads(response.content)
         assert GroupInbox.objects.filter(group=response.data["groupID"]).exists()
 
     def test_project_platform(self):
@@ -42,7 +42,7 @@ class ProjectCreateSampleTest(APITestCase):
         response = self.client.post(url, format="json")
 
         assert response.status_code == 200, response.content
-        assert "groupID" in json.loads(response.content)
+        assert "groupID" in orjson.loads(response.content)
 
     def test_cocoa(self):
         project = self.create_project(teams=[self.team], name="foo", platform="cocoa")
@@ -57,7 +57,7 @@ class ProjectCreateSampleTest(APITestCase):
         response = self.client.post(url, format="json")
 
         assert response.status_code == 200, response.content
-        assert "groupID" in json.loads(response.content)
+        assert "groupID" in orjson.loads(response.content)
 
     def test_java(self):
         project = self.create_project(teams=[self.team], name="foo", platform="java")
@@ -72,7 +72,7 @@ class ProjectCreateSampleTest(APITestCase):
         response = self.client.post(url, format="json")
 
         assert response.status_code == 200, response.content
-        assert "groupID" in json.loads(response.content)
+        assert "groupID" in orjson.loads(response.content)
 
     def test_javascript(self):
         project = self.create_project(teams=[self.team], name="foo", platform="javascript")
@@ -87,7 +87,7 @@ class ProjectCreateSampleTest(APITestCase):
         response = self.client.post(url, format="json")
 
         assert response.status_code == 200, response.content
-        assert "groupID" in json.loads(response.content)
+        assert "groupID" in orjson.loads(response.content)
 
     def test_php(self):
         project = self.create_project(teams=[self.team], name="foo", platform="php")
@@ -102,7 +102,7 @@ class ProjectCreateSampleTest(APITestCase):
         response = self.client.post(url, format="json")
 
         assert response.status_code == 200, response.content
-        assert "groupID" in json.loads(response.content)
+        assert "groupID" in orjson.loads(response.content)
 
     def test_python(self):
         project = self.create_project(teams=[self.team], name="foo", platform="python")
@@ -117,7 +117,7 @@ class ProjectCreateSampleTest(APITestCase):
         response = self.client.post(url, format="json")
 
         assert response.status_code == 200, response.content
-        assert "groupID" in json.loads(response.content)
+        assert "groupID" in orjson.loads(response.content)
 
     def test_reactnative(self):
         project = self.create_project(teams=[self.team], name="foo", platform="react-native")
@@ -132,7 +132,7 @@ class ProjectCreateSampleTest(APITestCase):
         response = self.client.post(url, format="json")
 
         assert response.status_code == 200, response.content
-        assert "groupID" in json.loads(response.content)
+        assert "groupID" in orjson.loads(response.content)
 
     def test_ruby(self):
         project = self.create_project(teams=[self.team], name="foo", platform="ruby")
@@ -147,7 +147,7 @@ class ProjectCreateSampleTest(APITestCase):
         response = self.client.post(url, format="json")
 
         assert response.status_code == 200, response.content
-        assert "groupID" in json.loads(response.content)
+        assert "groupID" in orjson.loads(response.content)
 
     def test_attempted_path_traversal_returns_400(self):
         project = self.create_project(teams=[self.team], name="foo", platform="../../../etc/passwd")

--- a/tests/sentry/api/endpoints/test_project_details.py
+++ b/tests/sentry/api/endpoints/test_project_details.py
@@ -6,6 +6,7 @@ from time import time
 from typing import Any
 from unittest import mock
 
+import orjson
 from django.db import router
 from django.urls import reverse
 
@@ -34,7 +35,6 @@ from sentry.testutils.cases import APITestCase
 from sentry.testutils.helpers import Feature, with_feature
 from sentry.testutils.outbox import outbox_runner
 from sentry.testutils.silo import assume_test_silo_mode
-from sentry.utils import json
 
 
 def _dyn_sampling_data(multiple_uniform_rules=False, uniform_rule_last_position=True):
@@ -104,7 +104,7 @@ def _remove_ids_from_dynamic_rules(dynamic_rules):
 
 
 def first_symbol_source_id(sources_json):
-    sources = json.loads(sources_json)
+    sources = orjson.loads(sources_json)
     return sources[0]["id"]
 
 
@@ -1180,11 +1180,13 @@ class ProjectUpdateTest(APITestCase):
                 "password": "beepbeep",
             }
             self.get_success_response(
-                self.org_slug, self.proj_slug, symbolSources=json.dumps([config])
+                self.org_slug, self.proj_slug, symbolSources=orjson.dumps([config]).decode()
             )
             config["id"] = first_symbol_source_id(self.project.get_option("sentry:symbol_sources"))
 
-            assert self.project.get_option("sentry:symbol_sources") == json.dumps([config])
+            assert (
+                self.project.get_option("sentry:symbol_sources") == orjson.dumps([config]).decode()
+            )
 
             # redact password
             redacted_source = config.copy()
@@ -1204,10 +1206,14 @@ class ProjectUpdateTest(APITestCase):
             }
 
             self.get_success_response(
-                self.org_slug, self.proj_slug, symbolSources=json.dumps([redacted_source])
+                self.org_slug,
+                self.proj_slug,
+                symbolSources=orjson.dumps([redacted_source]).decode(),
             )
             # on save the magic object should be replaced with the previously set password
-            assert self.project.get_option("sentry:symbol_sources") == json.dumps([config])
+            assert (
+                self.project.get_option("sentry:symbol_sources") == orjson.dumps([config]).decode()
+            )
 
     @mock.patch("sentry.api.base.create_audit_entry")
     def test_redacted_symbol_source_secrets_unknown_secret(self, create_audit_entry):
@@ -1227,21 +1233,23 @@ class ProjectUpdateTest(APITestCase):
                 "password": "beepbeep",
             }
             self.get_success_response(
-                self.org_slug, self.proj_slug, symbolSources=json.dumps([config])
+                self.org_slug, self.proj_slug, symbolSources=orjson.dumps([config]).decode()
             )
             config["id"] = first_symbol_source_id(self.project.get_option("sentry:symbol_sources"))
 
-            assert self.project.get_option("sentry:symbol_sources") == json.dumps([config])
+            assert (
+                self.project.get_option("sentry:symbol_sources") == orjson.dumps([config]).decode()
+            )
 
             # prepare new call, this secret is not known
             new_source = config.copy()
             new_source["password"] = {"hidden-secret": True}
             new_source["id"] = "oops"
             response = self.get_response(
-                self.org_slug, self.proj_slug, symbolSources=json.dumps([new_source])
+                self.org_slug, self.proj_slug, symbolSources=orjson.dumps([new_source]).decode()
             )
             assert response.status_code == 400
-            assert json.loads(response.content) == {
+            assert orjson.loads(response.content) == {
                 "symbolSources": ["Hidden symbol source secret is missing a value"]
             }
 
@@ -1273,7 +1281,7 @@ class ProjectUpdateTest(APITestCase):
             "password": "beepbeep",
         }
 
-        project.update_option("sentry:symbol_sources", json.dumps([source1, source2]))
+        project.update_option("sentry:symbol_sources", orjson.dumps([source1, source2]).decode())
         return [source1, source2]
 
     def test_symbol_sources_no_modification(self):
@@ -1281,22 +1289,26 @@ class ProjectUpdateTest(APITestCase):
         project = Project.objects.get(id=self.project.id)
         with Feature({"organizations:custom-symbol-sources": False}):
             resp = self.get_response(
-                self.org_slug, self.proj_slug, symbolSources=json.dumps([source1, source2])
+                self.org_slug,
+                self.proj_slug,
+                symbolSources=orjson.dumps([source1, source2]).decode(),
             )
 
             assert resp.status_code == 200
-            assert project.get_option("sentry:symbol_sources", json.dumps([source1, source2]))
+            assert project.get_option(
+                "sentry:symbol_sources", orjson.dumps([source1, source2]).decode()
+            )
 
     def test_symbol_sources_deletion(self):
         source1, source2 = self.symbol_sources()
         project = Project.objects.get(id=self.project.id)
         with Feature({"organizations:custom-symbol-sources": False}):
             resp = self.get_response(
-                self.org_slug, self.proj_slug, symbolSources=json.dumps([source1])
+                self.org_slug, self.proj_slug, symbolSources=orjson.dumps([source1]).decode()
             )
 
             assert resp.status_code == 200
-            assert project.get_option("sentry:symbol_sources", json.dumps([source1]))
+            assert project.get_option("sentry:symbol_sources", orjson.dumps([source1]).decode())
 
 
 class CopyProjectSettingsTest(APITestCase):

--- a/tests/sentry/api/endpoints/test_project_profiling_profile.py
+++ b/tests/sentry/api/endpoints/test_project_profiling_profile.py
@@ -1,11 +1,11 @@
 from unittest.mock import MagicMock, patch
 from uuid import uuid4
 
+import orjson
 from django.urls import reverse
 from rest_framework.exceptions import ErrorDetail
 
 from sentry.testutils.cases import APITestCase
-from sentry.utils import json
 
 PROFILING_FEATURES = {"organizations:profiling": True}
 
@@ -50,7 +50,7 @@ class ProjectProfilingFunctionsEndpoint(APITestCase):
     def test_basic(self, mock_proxy):
         mock_response = MagicMock()
         mock_response.status = 200
-        mock_response.data = json.dumps({"functions": []})
+        mock_response.data = orjson.dumps({"functions": []}).decode()
         mock_proxy.return_value = mock_response
         with self.feature(PROFILING_FEATURES):
             response = self.client.get(self.url, {"sort": "count"})
@@ -75,7 +75,7 @@ class ProjectProfilingFunctionsEndpoint(APITestCase):
     def test_is_application_true(self, mock_proxy):
         mock_response = MagicMock()
         mock_response.status = 200
-        mock_response.data = json.dumps({"functions": []})
+        mock_response.data = orjson.dumps({"functions": []}).decode()
         mock_proxy.return_value = mock_response
         with self.feature(PROFILING_FEATURES):
             response = self.client.get(self.url, {"is_application": "1", "sort": "count"})
@@ -88,7 +88,7 @@ class ProjectProfilingFunctionsEndpoint(APITestCase):
     def test_is_application_false(self, mock_proxy):
         mock_response = MagicMock()
         mock_response.status = 200
-        mock_response.data = json.dumps({"functions": []})
+        mock_response.data = orjson.dumps({"functions": []}).decode()
         mock_proxy.return_value = mock_response
         with self.feature(PROFILING_FEATURES):
             response = self.client.get(self.url, {"is_application": "0", "sort": "count"})

--- a/tests/sentry/api/endpoints/test_project_rule_details.py
+++ b/tests/sentry/api/endpoints/test_project_rule_details.py
@@ -6,6 +6,7 @@ from typing import Any
 from unittest.mock import patch
 from urllib.parse import parse_qs
 
+import orjson
 import responses
 from rest_framework import status
 
@@ -25,7 +26,6 @@ from sentry.testutils.helpers import install_slack
 from sentry.testutils.helpers.datetime import freeze_time
 from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.silo import assume_test_silo_mode
-from sentry.utils import json
 
 
 def assert_rule_from_payload(rule: Rule, payload: Mapping[str, Any]) -> None:
@@ -1017,14 +1017,14 @@ class UpdateProjectRuleTest(ProjectRuleDetailsBaseTestCase):
             url="https://slack.com/api/conversations.list",
             status=200,
             content_type="application/json",
-            body=json.dumps(channels),
+            body=orjson.dumps(channels),
         )
         responses.add(
             method=responses.GET,
             url="https://slack.com/api/conversations.info",
             status=200,
             content_type="application/json",
-            body=json.dumps({"ok": channels["ok"], "channel": channels["channels"][1]}),
+            body=orjson.dumps({"ok": channels["ok"], "channel": channels["channels"][1]}),
         )
 
         payload = {
@@ -1081,19 +1081,19 @@ class UpdateProjectRuleTest(ProjectRuleDetailsBaseTestCase):
             url="https://slack.com/api/conversations.list",
             status=200,
             content_type="application/json",
-            body=json.dumps(channels),
+            body=orjson.dumps(channels),
         )
         responses.add(
             method=responses.GET,
             url="https://slack.com/api/conversations.info",
             status=200,
             content_type="application/json",
-            body=json.dumps({"ok": channels["ok"], "channel": channels["channels"][1]}),
+            body=orjson.dumps({"ok": channels["ok"], "channel": channels["channels"][1]}),
         )
         blocks = SlackRuleSaveEditMessageBuilder(rule=self.rule, new=False).build()
         payload = {
             "text": blocks.get("text"),
-            "blocks": json.dumps(blocks.get("blocks")),
+            "blocks": orjson.dumps(blocks.get("blocks")).decode(),
             "channel": "new_channel_id",
             "unfurl_links": False,
             "unfurl_media": False,
@@ -1103,7 +1103,7 @@ class UpdateProjectRuleTest(ProjectRuleDetailsBaseTestCase):
             url="https://slack.com/api/chat.postMessage",
             status=200,
             content_type="application/json",
-            body=json.dumps(payload),
+            body=orjson.dumps(payload),
         )
         staging_env = self.create_environment(
             self.project, name="staging", organization=self.organization
@@ -1128,7 +1128,7 @@ class UpdateProjectRuleTest(ProjectRuleDetailsBaseTestCase):
         data = parse_qs(responses.calls[1].request.body)
         message = f"Alert rule <http://testserver/organizations/{self.organization.slug}/alerts/rules/{self.project.slug}/{rule_id}/details/|*{rule_label}*> in the *{self.project.slug}* project was updated."
         assert data["text"][0] == message
-        rendered_blocks = json.loads(data["blocks"][0])
+        rendered_blocks = orjson.loads(data["blocks"][0])
         assert rendered_blocks[0]["text"]["text"] == message
         changes = "*Changes*\n"
         changes += "• Added condition 'The issue's category is equal to Performance'\n"
@@ -1170,14 +1170,14 @@ class UpdateProjectRuleTest(ProjectRuleDetailsBaseTestCase):
             url="https://slack.com/api/conversations.list",
             status=200,
             content_type="application/json",
-            body=json.dumps(channels),
+            body=orjson.dumps(channels),
         )
         responses.add(
             method=responses.GET,
             url="https://slack.com/api/conversations.info",
             status=200,
             content_type="application/json",
-            body=json.dumps({"ok": channels["ok"], "channel": channels["channels"][0]}),
+            body=orjson.dumps({"ok": channels["ok"], "channel": channels["channels"][0]}),
         )
 
         actions[0]["channel"] = "#new_channel_name"
@@ -1201,7 +1201,7 @@ class UpdateProjectRuleTest(ProjectRuleDetailsBaseTestCase):
             url="https://slack.com/api/conversations.info",
             status=200,
             content_type="application/json",
-            body=json.dumps(
+            body=orjson.dumps(
                 {"ok": "true", "channel": {"name": "team-team-team", "id": channel_id}}
             ),
         )

--- a/tests/sentry/api/endpoints/test_project_rules.py
+++ b/tests/sentry/api/endpoints/test_project_rules.py
@@ -7,6 +7,7 @@ from unittest.mock import patch
 from urllib.parse import parse_qs
 from uuid import uuid4
 
+import orjson
 import responses
 from django.test import override_settings
 from rest_framework import status
@@ -23,7 +24,6 @@ from sentry.tasks.integrations.slack.find_channel_id_for_rule import find_channe
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.helpers import install_slack, with_feature
 from sentry.testutils.silo import assume_test_silo_mode
-from sentry.utils import json
 
 
 class ProjectRuleBaseTestCase(APITestCase):
@@ -358,7 +358,7 @@ class CreateProjectRuleTest(ProjectRuleBaseTestCase):
             url="https://slack.com/api/conversations.info",
             status=200,
             content_type="application/json",
-            body=json.dumps(
+            body=orjson.dumps(
                 {"ok": "true", "channel": {"name": "team-team-team", "id": self.channel_id}}
             ),
         )
@@ -385,7 +385,7 @@ class CreateProjectRuleTest(ProjectRuleBaseTestCase):
             url="https://slack.com/api/conversations.info",
             status=200,
             content_type="application/json",
-            body=json.dumps(
+            body=orjson.dumps(
                 {"ok": "true", "channel": {"name": "team-team-team", "id": self.channel_id}}
             ),
         )
@@ -393,7 +393,7 @@ class CreateProjectRuleTest(ProjectRuleBaseTestCase):
         blocks = SlackRuleSaveEditMessageBuilder(rule=self.rule, new=True).build()
         payload = {
             "text": blocks.get("text"),
-            "blocks": json.dumps(blocks.get("blocks")),
+            "blocks": orjson.dumps(blocks.get("blocks")).decode(),
             "channel": self.channel_id,
             "unfurl_links": False,
             "unfurl_media": False,
@@ -403,7 +403,7 @@ class CreateProjectRuleTest(ProjectRuleBaseTestCase):
             url="https://slack.com/api/chat.postMessage",
             status=200,
             content_type="application/json",
-            body=json.dumps(payload),
+            body=orjson.dumps(payload),
         )
         response = self.get_success_response(
             self.organization.slug,
@@ -423,7 +423,7 @@ class CreateProjectRuleTest(ProjectRuleBaseTestCase):
         data = parse_qs(responses.calls[1].request.body)
         message = f"Alert rule <http://testserver/organizations/{self.organization.slug}/alerts/rules/{self.project.slug}/{rule_id}/details/|*{rule_label}*> was created in the *{self.project.slug}* project and will send notifications here."
         assert data["text"][0] == message
-        rendered_blocks = json.loads(data["blocks"][0])
+        rendered_blocks = orjson.loads(data["blocks"][0])
         assert rendered_blocks[0]["text"]["text"] == message
         assert (
             rendered_blocks[1]["elements"][0]["text"]

--- a/tests/sentry/api/endpoints/test_project_symbol_sources.py
+++ b/tests/sentry/api/endpoints/test_project_symbol_sources.py
@@ -1,6 +1,7 @@
+import orjson
+
 from sentry.lang.native.sources import redact_source_secrets
 from sentry.testutils.cases import APITestCase
-from sentry.utils import json
 
 
 class ProjectSymbolSourcesTest(APITestCase):
@@ -19,7 +20,7 @@ class ProjectSymbolSourcesTest(APITestCase):
             "password": "beepbeep",
         }
         project = self.project  # force creation
-        project.update_option("sentry:symbol_sources", json.dumps([config]))
+        project.update_option("sentry:symbol_sources", orjson.dumps([config]).decode())
         self.login_as(user=self.user)
 
         expected = redact_source_secrets([config])
@@ -45,7 +46,7 @@ class ProjectSymbolSourcesTest(APITestCase):
             "password": "beepbeep",
         }
         project = self.project  # force creation
-        project.update_option("sentry:symbol_sources", json.dumps([config]))
+        project.update_option("sentry:symbol_sources", orjson.dumps([config]).decode())
         self.login_as(user=self.user)
 
         self.get_error_response(
@@ -71,7 +72,7 @@ class ProjectSymbolSourcesDeleteTest(APITestCase):
         }
 
         project = self.project  # force creation
-        project.update_option("sentry:symbol_sources", json.dumps([config]))
+        project.update_option("sentry:symbol_sources", orjson.dumps([config]).decode())
         self.login_as(user=self.user)
 
         self.get_success_response(
@@ -94,7 +95,7 @@ class ProjectSymbolSourcesDeleteTest(APITestCase):
         }
 
         project = self.project  # force creation
-        project.update_option("sentry:symbol_sources", json.dumps([config]))
+        project.update_option("sentry:symbol_sources", orjson.dumps([config]).decode())
         self.login_as(user=self.user)
 
         self.get_error_response(project.organization.slug, project.slug, status=404)
@@ -152,7 +153,7 @@ class ProjectSymbolSourcesPostTest(APITestCase):
         }
 
         project = self.project  # force creation
-        project.update_option("sentry:symbol_sources", json.dumps([config]))
+        project.update_option("sentry:symbol_sources", orjson.dumps([config]).decode())
         self.login_as(user=self.user)
 
         self.get_error_response(project.organization.slug, project.slug, raw_data=config)
@@ -224,7 +225,7 @@ class ProjectSymbolSourcesPutTest(APITestCase):
         ]
 
         project = self.project  # force creation
-        project.update_option("sentry:symbol_sources", json.dumps(config))
+        project.update_option("sentry:symbol_sources", orjson.dumps(config).decode())
         self.login_as(user=self.user)
 
         update_config = {
@@ -269,7 +270,9 @@ class ProjectSymbolSourcesPutTest(APITestCase):
         del response.data["id"]
         assert response.data == redact_source_secrets([update_config])[0]
 
-        source_ids = {src["id"] for src in json.loads(project.get_option("sentry:symbol_sources"))}
+        source_ids = {
+            src["id"] for src in orjson.loads(project.get_option("sentry:symbol_sources"))
+        }
 
         assert "hank" in source_ids
         assert "beep" not in source_ids
@@ -301,7 +304,7 @@ class ProjectSymbolSourcesPutTest(APITestCase):
         ]
 
         project = self.project  # force creation
-        project.update_option("sentry:symbol_sources", json.dumps(config))
+        project.update_option("sentry:symbol_sources", orjson.dumps(config).decode())
         self.login_as(user=self.user)
 
         update_config = {

--- a/tests/sentry/api/endpoints/test_relay_globalconfig_v3.py
+++ b/tests/sentry/api/endpoints/test_relay_globalconfig_v3.py
@@ -1,5 +1,6 @@
 from unittest.mock import patch
 
+import orjson
 import pytest
 from django.urls import reverse
 from sentry_relay.processing import normalize_global_config
@@ -7,7 +8,6 @@ from sentry_relay.processing import normalize_global_config
 from sentry.relay.globalconfig import get_global_config
 from sentry.testutils.helpers.options import override_options
 from sentry.testutils.pytest.fixtures import django_db_all
-from sentry.utils import json
 
 
 @pytest.fixture
@@ -26,7 +26,7 @@ def call_endpoint(client, relay, private_key):
             HTTP_X_SENTRY_RELAY_SIGNATURE=signature,
         )
 
-        return json.loads(resp.content), resp.status_code
+        return orjson.loads(resp.content), resp.status_code
 
     return inner
 

--- a/tests/sentry/api/endpoints/test_relay_projectconfigs.py
+++ b/tests/sentry/api/endpoints/test_relay_projectconfigs.py
@@ -4,6 +4,7 @@ import re
 from typing import Any
 from uuid import uuid4
 
+import orjson
 import pytest
 from django.urls import reverse
 from sentry_relay.auth import generate_key_pair
@@ -14,7 +15,7 @@ from sentry.models.project import Project
 from sentry.models.relay import Relay
 from sentry.testutils.helpers import Feature
 from sentry.testutils.pytest.fixtures import django_db_all
-from sentry.utils import json, safe
+from sentry.utils import safe
 
 _date_regex = re.compile(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d+Z$")
 
@@ -84,7 +85,7 @@ def call_endpoint(client, relay, private_key, default_project):
             HTTP_X_SENTRY_RELAY_SIGNATURE=signature,
         )
 
-        return json.loads(resp.content), resp.status_code
+        return orjson.loads(resp.content), resp.status_code
 
     return inner
 

--- a/tests/sentry/api/endpoints/test_relay_projectconfigs_v2.py
+++ b/tests/sentry/api/endpoints/test_relay_projectconfigs_v2.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import re
 from typing import Any
 
+import orjson
 import pytest
 from django.urls import reverse
 
@@ -11,7 +12,7 @@ from sentry.constants import ObjectStatus
 from sentry.models.projectkey import ProjectKey, ProjectKeyStatus
 from sentry.testutils.helpers import Feature
 from sentry.testutils.pytest.fixtures import django_db_all
-from sentry.utils import json, safe
+from sentry.utils import safe
 
 _date_regex = re.compile(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d+Z$")
 
@@ -56,7 +57,7 @@ def call_endpoint(client, relay, private_key, default_projectkey):
             HTTP_X_SENTRY_RELAY_SIGNATURE=signature,
         )
 
-        return json.loads(resp.content), resp.status_code
+        return orjson.loads(resp.content), resp.status_code
 
     return inner
 

--- a/tests/sentry/api/endpoints/test_relay_projectconfigs_v3.py
+++ b/tests/sentry/api/endpoints/test_relay_projectconfigs_v3.py
@@ -1,5 +1,6 @@
 from unittest.mock import patch, sentinel
 
+import orjson
 import pytest
 from django.urls import reverse
 
@@ -8,7 +9,6 @@ from sentry.relay.config import ProjectConfig
 from sentry.tasks.relay import build_project_config
 from sentry.testutils.hybrid_cloud import simulated_transaction_watermarks
 from sentry.testutils.pytest.fixtures import django_db_all
-from sentry.utils import json
 
 
 @pytest.fixture(autouse=True)
@@ -41,7 +41,7 @@ def call_endpoint(client, relay, private_key, default_projectkey):
             HTTP_X_SENTRY_RELAY_SIGNATURE=signature,
         )
 
-        return json.loads(resp.content), resp.status_code
+        return orjson.loads(resp.content), resp.status_code
 
     return inner
 

--- a/tests/sentry/api/endpoints/test_relay_projectids.py
+++ b/tests/sentry/api/endpoints/test_relay_projectids.py
@@ -2,6 +2,7 @@ import re
 import uuid
 from unittest import mock
 
+import orjson
 from django.test import override_settings
 from django.urls import reverse
 from sentry_relay.auth import generate_key_pair
@@ -10,7 +11,7 @@ from sentry.auth import system
 from sentry.models.relay import Relay
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.helpers.options import override_options
-from sentry.utils import json, safe
+from sentry.utils import safe
 
 
 # Note this is duplicated in test_relay_publickeys (maybe put in a common utils)
@@ -71,7 +72,7 @@ class RelayProjectIdsEndpointTest(APITestCase):
                     HTTP_X_SENTRY_RELAY_SIGNATURE=signature,
                 )
 
-        return json.loads(resp.content), resp.status_code
+        return orjson.loads(resp.content), resp.status_code
 
     def _call_endpoint_static_relay(self, internal):
         raw_json, signature = self.private_key.pack({"publicKeys": [str(self.public_key)]})
@@ -85,7 +86,7 @@ class RelayProjectIdsEndpointTest(APITestCase):
                 HTTP_X_SENTRY_RELAY_ID=self.relay_id,
                 HTTP_X_SENTRY_RELAY_SIGNATURE=signature,
             )
-        return json.loads(resp.content), resp.status_code
+        return orjson.loads(resp.content), resp.status_code
 
     def test_internal_relay(self):
         self._setup_relay(add_org_key=True)

--- a/tests/sentry/api/endpoints/test_relay_publickeys.py
+++ b/tests/sentry/api/endpoints/test_relay_publickeys.py
@@ -1,13 +1,13 @@
 from unittest import mock
 from uuid import uuid4
 
+import orjson
 from django.urls import reverse
 from sentry_relay.auth import generate_key_pair
 
 from sentry.auth import system
 from sentry.models.relay import Relay
 from sentry.testutils.cases import APITestCase
-from sentry.utils import json
 
 
 def disable_internal_networks():
@@ -115,5 +115,4 @@ class RelayPublicKeysConfigTest(APITestCase):
             HTTP_X_SENTRY_RELAY_SIGNATURE=signature,
         )
 
-        result = json.loads(resp.content)
-        return result
+        return orjson.loads(resp.content)

--- a/tests/sentry/api/endpoints/test_relay_register.py
+++ b/tests/sentry/api/endpoints/test_relay_register.py
@@ -1,5 +1,6 @@
 from uuid import uuid4
 
+import orjson
 from django.conf import settings
 from django.urls import reverse
 from django.utils import timezone
@@ -8,7 +9,6 @@ from sentry_relay.auth import generate_key_pair
 from sentry.models.relay import Relay, RelayUsage
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.helpers.options import override_options
-from sentry.utils import json
 
 
 class RelayRegisterTest(APITestCase):
@@ -47,7 +47,7 @@ class RelayRegisterTest(APITestCase):
         )
 
         assert resp.status_code == 200, resp.content
-        result = json.loads(resp.content)
+        result = orjson.loads(resp.content)
 
         data = {
             "token": str(result.get("token")),
@@ -179,7 +179,7 @@ class RelayRegisterTest(APITestCase):
         )
 
         assert resp.status_code == 200, resp.content
-        result = json.loads(resp.content)
+        result = orjson.loads(resp.content)
 
         raw_json, signature = self.private_key.pack(result)
 
@@ -210,7 +210,7 @@ class RelayRegisterTest(APITestCase):
         )
 
         assert resp.status_code == 200, resp.content
-        result = json.loads(resp.content)
+        result = orjson.loads(resp.content)
 
         raw_json, signature = self.private_key.pack(result)
 
@@ -254,7 +254,7 @@ class RelayRegisterTest(APITestCase):
         )
 
         assert resp.status_code == 200, resp.content
-        result = json.loads(resp.content)
+        result = orjson.loads(resp.content)
 
         raw_json, signature = self.private_key.pack(result)
 
@@ -295,7 +295,7 @@ class RelayRegisterTest(APITestCase):
             HTTP_X_SENTRY_RELAY_SIGNATURE=signature,
         )
 
-        result = json.loads(resp.content)
+        result = orjson.loads(resp.content)
 
         resp = self.client.post(
             self.path,
@@ -337,7 +337,7 @@ class RelayRegisterTest(APITestCase):
         )
 
         assert resp.status_code == 200, resp.content
-        result = json.loads(resp.content)
+        result = orjson.loads(resp.content)
 
         _, signature = self.private_key.pack(result)
 
@@ -365,7 +365,7 @@ class RelayRegisterTest(APITestCase):
         )
 
         assert resp.status_code == 200, resp.content
-        result = json.loads(resp.content)
+        result = orjson.loads(resp.content)
 
         del result["token"]
 
@@ -395,7 +395,7 @@ class RelayRegisterTest(APITestCase):
         )
 
         assert resp.status_code == 200, resp.content
-        result = json.loads(resp.content)
+        result = orjson.loads(resp.content)
 
         raw_json, signature = self.private_key.pack(result)
 
@@ -422,7 +422,7 @@ class RelayRegisterTest(APITestCase):
         )
 
         assert resp.status_code == 200, resp.content
-        result = json.loads(resp.content)
+        result = orjson.loads(resp.content)
 
         raw_json, signature = self.private_key.pack(result)
 
@@ -462,7 +462,7 @@ class RelayRegisterTest(APITestCase):
         )
 
         assert resp.status_code == 200, resp.content
-        result = json.loads(resp.content)
+        result = orjson.loads(resp.content)
 
         raw_json, signature = self.private_key.pack(result)
 

--- a/tests/sentry/api/endpoints/test_rpc.py
+++ b/tests/sentry/api/endpoints/test_rpc.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Any
 
+import orjson
 from django.test import override_settings
 from django.urls import reverse
 from rest_framework.exceptions import ErrorDetail
@@ -9,7 +10,6 @@ from rest_framework.exceptions import ErrorDetail
 from sentry.services.hybrid_cloud.organization import RpcUserOrganizationContext
 from sentry.services.hybrid_cloud.rpc import generate_request_signature
 from sentry.testutils.cases import APITestCase
-from sentry.utils import json
 
 
 @override_settings(RPC_SHARED_SECRET=["a-long-value-that-is-hard-to-guess"])
@@ -27,8 +27,8 @@ class RpcServiceEndpointTest(APITestCase):
 
     def auth_header(self, path: str, data: dict | str) -> str:
         if isinstance(data, dict):
-            data = json.dumps(data)
-        signature = generate_request_signature(path, data.encode("utf8"))
+            data = orjson.dumps(data).decode()
+        signature = generate_request_signature(path, data.encode())
 
         return f"rpcsignature {signature}"
 

--- a/tests/sentry/api/endpoints/test_seer_rpc.py
+++ b/tests/sentry/api/endpoints/test_seer_rpc.py
@@ -1,11 +1,11 @@
 from typing import Any
 
+import orjson
 from django.test import override_settings
 from django.urls import reverse
 
 from sentry.api.endpoints.seer_rpc import generate_request_signature
 from sentry.testutils.cases import APITestCase
-from sentry.utils import json
 
 
 @override_settings(SEER_RPC_SHARED_SECRET=["a-long-value-that-is-hard-to-guess"])
@@ -19,8 +19,8 @@ class TestSeerRpc(APITestCase):
 
     def auth_header(self, path: str, data: dict | str) -> str:
         if isinstance(data, dict):
-            data = json.dumps(data)
-        signature = generate_request_signature(path, data.encode("utf8"))
+            data = orjson.dumps(data).decode()
+        signature = generate_request_signature(path, data.encode())
 
         return f"rpcsignature {signature}"
 

--- a/tests/sentry/api/endpoints/test_sentry_app_details.py
+++ b/tests/sentry/api/endpoints/test_sentry_app_details.py
@@ -1,5 +1,7 @@
 from unittest.mock import patch
 
+import orjson
+
 from sentry import audit_log, deletions
 from sentry.api.endpoints.integrations.sentry_apps.details import (
     PARTNERSHIP_RESTRICTED_ERROR_MESSAGE,
@@ -14,7 +16,6 @@ from sentry.testutils.cases import APITestCase
 from sentry.testutils.helpers import with_feature
 from sentry.testutils.helpers.options import override_options
 from sentry.testutils.silo import assume_test_silo_mode, control_silo_test
-from sentry.utils import json
 
 
 class SentryAppDetailsTest(APITestCase):
@@ -419,7 +420,7 @@ class UpdateSentryAppDetailsTest(SentryAppDetailsTest):
             sentry_app_id=app.id,
             sentry_app_name="SampleApp",
             error_message="'elements' is a required property",
-            schema=json.dumps(schema),
+            schema=orjson.dumps(schema).decode(),
         )
 
     def test_no_webhook_public_integration(self):

--- a/tests/sentry/api/endpoints/test_sentry_app_installation_external_requests.py
+++ b/tests/sentry/api/endpoints/test_sentry_app_installation_external_requests.py
@@ -1,10 +1,10 @@
+import orjson
 import responses
 from django.urls import reverse
 from django.utils.http import urlencode
 from responses.matchers import query_string_matcher
 
 from sentry.testutils.cases import APITestCase
-from sentry.utils import json
 
 
 class SentryAppInstallationExternalRequestsEndpointTest(APITestCase):
@@ -55,7 +55,7 @@ class SentryAppInstallationExternalRequestsEndpointTest(APITestCase):
                 "projectSlug": self.project.slug,
                 "installationId": self.install.uuid,
                 "query": "proj",
-                "dependentData": json.dumps({"org_id": "A"}),
+                "dependentData": orjson.dumps({"org_id": "A"}).decode(),
             }
         )
         responses.add(
@@ -71,7 +71,7 @@ class SentryAppInstallationExternalRequestsEndpointTest(APITestCase):
                 "projectId": self.project.id,
                 "uri": "/get-projects",
                 "query": "proj",
-                "dependentData": json.dumps({"org_id": "A"}),
+                "dependentData": orjson.dumps({"org_id": "A"}).decode(),
             }
         )
         url = f"{self.url}?{qs}"

--- a/tests/sentry/api/endpoints/test_sentry_apps.py
+++ b/tests/sentry/api/endpoints/test_sentry_apps.py
@@ -5,6 +5,7 @@ from collections.abc import Mapping
 from typing import Any
 from unittest.mock import patch
 
+import orjson
 import pytest
 from django.test import override_settings
 from django.urls import reverse
@@ -23,7 +24,6 @@ from sentry.testutils.cases import APITestCase
 from sentry.testutils.helpers import Feature, with_feature
 from sentry.testutils.helpers.options import override_options
 from sentry.testutils.silo import assume_test_silo_mode, control_silo_test
-from sentry.utils import json
 
 POPULARITY = 27
 EXPECTED = {
@@ -116,7 +116,7 @@ class SentryAppsTest(APITestCase):
                 }
             ]
 
-        assert data in json.loads(response.content)
+        assert data in orjson.loads(response.content)
 
     def get_data(self, **kwargs: Any) -> Mapping[str, Any]:
         return {
@@ -373,7 +373,7 @@ class SuperuserStaffPostSentryAppsTest(SentryAppsTest):
         response = self.get_success_response(
             **self.get_data(popularity=POPULARITY), status_code=201
         )
-        assert {"popularity": POPULARITY}.items() <= json.loads(response.content).items()
+        assert {"popularity": POPULARITY}.items() <= orjson.loads(response.content).items()
 
         with self.settings(SENTRY_SELF_HOSTED=False):
             self.get_success_response(
@@ -465,7 +465,7 @@ class PostSentryAppsTest(SentryAppsTest):
 
     def test_creates_sentry_app(self):
         response = self.get_success_response(**self.get_data(), status_code=201)
-        content = json.loads(response.content)
+        content = orjson.loads(response.content)
         for key, value in EXPECTED.items():
             assert key in content
             if isinstance(value, list):
@@ -523,7 +523,7 @@ class PostSentryAppsTest(SentryAppsTest):
         response = self.get_success_response(
             **self.get_data(popularity=POPULARITY), status_code=201
         )
-        assert {"popularity": self.default_popularity}.items() <= json.loads(
+        assert {"popularity": self.default_popularity}.items() <= orjson.loads(
             response.content
         ).items()
 
@@ -548,7 +548,7 @@ class PostSentryAppsTest(SentryAppsTest):
 
         data = self.get_data(schema={"elements": [self.create_alert_rule_action_schema()]})
         response = self.get_success_response(**data, status_code=201)
-        content = json.loads(response.content)
+        content = orjson.loads(response.content)
         for key, value in expected.items():
             assert key in content
             if isinstance(value, list):
@@ -591,7 +591,7 @@ class PostSentryAppsTest(SentryAppsTest):
         }
 
         # XXX: Compare schema as an object instead of json to avoid key ordering issues
-        record.call_args.kwargs["schema"] = json.loads(record.call_args.kwargs["schema"])
+        record.call_args.kwargs["schema"] = orjson.loads(record.call_args.kwargs["schema"])
 
         record.assert_called_with(
             "sentry_app.schema_validation_error",
@@ -606,7 +606,7 @@ class PostSentryAppsTest(SentryAppsTest):
     def test_can_create_with_error_created_hook_with_flag(self):
         expected = {**EXPECTED, "events": ["error"]}
         response = self.get_success_response(**self.get_data(events=("error",)), status_code=201)
-        content = json.loads(response.content)
+        content = orjson.loads(response.content)
         for key, value in expected.items():
             assert key in content
             if isinstance(value, list):

--- a/tests/sentry/api/endpoints/test_sentry_apps_stats.py
+++ b/tests/sentry/api/endpoints/test_sentry_apps_stats.py
@@ -1,8 +1,9 @@
+import orjson
+
 from sentry.api.serializers.base import serialize
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.helpers.options import override_options
 from sentry.testutils.silo import control_silo_test
-from sentry.utils import json
 
 
 @control_silo_test
@@ -33,7 +34,7 @@ class SentryAppsStatsTest(APITestCase):
             "name": self.app_two.name,
             "installs": 1,
             "avatars": [],
-        } in json.loads(response.content)
+        } in orjson.loads(response.content)
         assert {
             "id": self.app_one.id,
             "uuid": self.app_one.uuid,
@@ -41,7 +42,7 @@ class SentryAppsStatsTest(APITestCase):
             "name": self.app_one.name,
             "installs": 1,
             "avatars": [serialize(self.app_one_avatar)],
-        } in json.loads(response.content)
+        } in orjson.loads(response.content)
 
     def test_superuser_has_access(self):
         self.login_as(user=self.superuser, superuser=True)

--- a/tests/sentry/api/endpoints/test_source_map_debug_blue_thunder_edition.py
+++ b/tests/sentry/api/endpoints/test_source_map_debug_blue_thunder_edition.py
@@ -1,6 +1,7 @@
 import zipfile
 from io import BytesIO
 
+import orjson
 from django.core.files.base import ContentFile
 from rest_framework import status
 
@@ -21,7 +22,6 @@ from sentry.models.release import Release
 from sentry.models.releasefile import ARTIFACT_INDEX_FILENAME, ARTIFACT_INDEX_TYPE, ReleaseFile
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.skips import requires_snuba
-from sentry.utils import json
 
 pytestmark = [requires_snuba]
 
@@ -864,7 +864,7 @@ class SourceMapDebugBlueThunderEditionEndpointTestCase(APITestCase):
             zip_file.writestr("files/_/_/bundle.min.js", b'console.log("hello world");')
             zip_file.writestr(
                 "manifest.json",
-                json.dumps(
+                orjson.dumps(
                     {
                         "files": {
                             "files/_/_/bundle.min.js": {
@@ -877,7 +877,7 @@ class SourceMapDebugBlueThunderEditionEndpointTestCase(APITestCase):
                             },
                         },
                     }
-                ),
+                ).decode(),
             )
         compressed.seek(0)
 
@@ -940,7 +940,7 @@ class SourceMapDebugBlueThunderEditionEndpointTestCase(APITestCase):
             )
             zip_file.writestr(
                 "manifest.json",
-                json.dumps(
+                orjson.dumps(
                     {
                         "files": {
                             "files/_/_/bundle.min.js": {
@@ -952,7 +952,7 @@ class SourceMapDebugBlueThunderEditionEndpointTestCase(APITestCase):
                             },
                         },
                     }
-                ),
+                ).decode(),
             )
         compressed.seek(0)
 
@@ -1013,7 +1013,7 @@ class SourceMapDebugBlueThunderEditionEndpointTestCase(APITestCase):
             )
             zip_file.writestr(
                 "manifest.json",
-                json.dumps(
+                orjson.dumps(
                     {
                         "files": {
                             "files/_/_/bundle.min.js": {
@@ -1025,7 +1025,7 @@ class SourceMapDebugBlueThunderEditionEndpointTestCase(APITestCase):
                             },
                         },
                     }
-                ),
+                ).decode(),
             )
         compressed.seek(0)
 
@@ -1086,7 +1086,7 @@ class SourceMapDebugBlueThunderEditionEndpointTestCase(APITestCase):
             zip_file.writestr("files/_/_/bundle.min.js.map", b"")
             zip_file.writestr(
                 "manifest.json",
-                json.dumps(
+                orjson.dumps(
                     {
                         "files": {
                             "files/_/_/bundle.min.js": {
@@ -1105,7 +1105,7 @@ class SourceMapDebugBlueThunderEditionEndpointTestCase(APITestCase):
                             },
                         },
                     }
-                ),
+                ).decode(),
             )
         compressed.seek(0)
 
@@ -1175,7 +1175,7 @@ class SourceMapDebugBlueThunderEditionEndpointTestCase(APITestCase):
             zip_file.writestr("files/_/_/bundle.min.js.map", b"")
             zip_file.writestr(
                 "manifest.json",
-                json.dumps(
+                orjson.dumps(
                     {
                         "files": {
                             "files/_/_/bundle.min.js": {
@@ -1194,7 +1194,7 @@ class SourceMapDebugBlueThunderEditionEndpointTestCase(APITestCase):
                             },
                         },
                     }
-                ),
+                ).decode(),
             )
         compressed.seek(0)
 
@@ -1291,7 +1291,7 @@ class SourceMapDebugBlueThunderEditionEndpointTestCase(APITestCase):
             zip_file.writestr("files/_/_/bundle.min.js.map", b"")
             zip_file.writestr(
                 "manifest.json",
-                json.dumps(
+                orjson.dumps(
                     {
                         "files": {
                             "files/_/_/bundle.min.js": {
@@ -1310,7 +1310,7 @@ class SourceMapDebugBlueThunderEditionEndpointTestCase(APITestCase):
                             },
                         },
                     }
-                ),
+                ).decode(),
             )
         compressed.seek(0)
 
@@ -1392,7 +1392,7 @@ class SourceMapDebugBlueThunderEditionEndpointTestCase(APITestCase):
 
         artifact_index.putfile(
             ContentFile(
-                json.dumps(
+                orjson.dumps(
                     {
                         "files": {
                             "~/bundle.min.js": {
@@ -1415,7 +1415,7 @@ class SourceMapDebugBlueThunderEditionEndpointTestCase(APITestCase):
                             },
                         },
                     }
-                ).encode()
+                )
             )
         )
 
@@ -1438,7 +1438,7 @@ class SourceMapDebugBlueThunderEditionEndpointTestCase(APITestCase):
             zip_file.writestr("files/_/_/bundle.min.js.map", b"")
             zip_file.writestr(
                 "manifest.json",
-                json.dumps(
+                orjson.dumps(
                     {
                         "files": {
                             "files/_/_/bundle.min.js": {
@@ -1457,7 +1457,7 @@ class SourceMapDebugBlueThunderEditionEndpointTestCase(APITestCase):
                             },
                         },
                     }
-                ),
+                ).decode(),
             )
         compressed.seek(0)
         release_artifact_bundle = File.objects.create(
@@ -1509,7 +1509,7 @@ class SourceMapDebugBlueThunderEditionEndpointTestCase(APITestCase):
 
         artifact_index.putfile(
             ContentFile(
-                json.dumps(
+                orjson.dumps(
                     {
                         "files": {
                             "~/bundle.min.js": {
@@ -1528,7 +1528,7 @@ class SourceMapDebugBlueThunderEditionEndpointTestCase(APITestCase):
                             },
                         },
                     }
-                ).encode()
+                )
             )
         )
 
@@ -1550,7 +1550,7 @@ class SourceMapDebugBlueThunderEditionEndpointTestCase(APITestCase):
             zip_file.writestr("files/_/_/bundle.min.js.map", b"")
             zip_file.writestr(
                 "manifest.json",
-                json.dumps(
+                orjson.dumps(
                     {
                         "files": {
                             "files/_/_/bundle.min.js": {
@@ -1569,7 +1569,7 @@ class SourceMapDebugBlueThunderEditionEndpointTestCase(APITestCase):
                             },
                         },
                     }
-                ),
+                ).decode(),
             )
         compressed.seek(0)
         release_artifact_bundle = File.objects.create(

--- a/tests/sentry/api/helpers/test_autofix.py
+++ b/tests/sentry/api/helpers/test_autofix.py
@@ -1,11 +1,11 @@
 from unittest import mock
 from unittest.mock import call, patch
 
+import orjson
 from django.conf import settings
 
 from sentry.api.helpers.autofix import get_project_codebase_indexing_status
 from sentry.testutils.cases import TestCase
-from sentry.utils import json
 
 
 class TestGetProjectCodebaseIndexingStatus(TestCase):
@@ -28,7 +28,7 @@ class TestGetProjectCodebaseIndexingStatus(TestCase):
         assert status == "up_to_date"
         mock_post.assert_called_once_with(
             f"{settings.SEER_AUTOFIX_URL}/v1/automation/codebase/index/status",
-            data=json.dumps(
+            data=orjson.dumps(
                 {
                     "organization_id": self.project.organization.id,
                     "project_id": self.project.id,
@@ -71,7 +71,7 @@ class TestGetProjectCodebaseIndexingStatus(TestCase):
         calls = [
             call(
                 f"{settings.SEER_AUTOFIX_URL}/v1/automation/codebase/index/status",
-                data=json.dumps(
+                data=orjson.dumps(
                     {
                         "organization_id": self.project.organization.id,
                         "project_id": self.project.id,
@@ -87,7 +87,7 @@ class TestGetProjectCodebaseIndexingStatus(TestCase):
             ),
             call(
                 f"{settings.SEER_AUTOFIX_URL}/v1/automation/codebase/index/status",
-                data=json.dumps(
+                data=orjson.dumps(
                     {
                         "organization_id": self.project.organization.id,
                         "project_id": self.project.id,
@@ -132,7 +132,7 @@ class TestGetProjectCodebaseIndexingStatus(TestCase):
         calls = [
             call(
                 f"{settings.SEER_AUTOFIX_URL}/v1/automation/codebase/index/status",
-                data=json.dumps(
+                data=orjson.dumps(
                     {
                         "organization_id": self.project.organization.id,
                         "project_id": self.project.id,
@@ -148,7 +148,7 @@ class TestGetProjectCodebaseIndexingStatus(TestCase):
             ),
             call(
                 f"{settings.SEER_AUTOFIX_URL}/v1/automation/codebase/index/status",
-                data=json.dumps(
+                data=orjson.dumps(
                     {
                         "organization_id": self.project.organization.id,
                         "project_id": self.project.id,
@@ -194,7 +194,7 @@ class TestGetProjectCodebaseIndexingStatus(TestCase):
         calls = [
             call(
                 f"{settings.SEER_AUTOFIX_URL}/v1/automation/codebase/index/status",
-                data=json.dumps(
+                data=orjson.dumps(
                     {
                         "organization_id": self.project.organization.id,
                         "project_id": self.project.id,
@@ -210,7 +210,7 @@ class TestGetProjectCodebaseIndexingStatus(TestCase):
             ),
             call(
                 f"{settings.SEER_AUTOFIX_URL}/v1/automation/codebase/index/status",
-                data=json.dumps(
+                data=orjson.dumps(
                     {
                         "organization_id": self.project.organization.id,
                         "project_id": self.project.id,

--- a/tests/sentry/api/serializers/test_app_platform_event.py
+++ b/tests/sentry/api/serializers/test_app_platform_event.py
@@ -1,6 +1,7 @@
+import orjson
+
 from sentry.api.serializers import AppPlatformEvent
 from sentry.testutils.cases import TestCase
-from sentry.utils import json
 
 
 class AppPlatformEventSerializerTest(TestCase):
@@ -17,13 +18,16 @@ class AppPlatformEventSerializerTest(TestCase):
             resource="event_alert", action="triggered", install=self.install, data={}
         )
 
-        assert result.body == json.dumps(
-            {
-                "action": "triggered",
-                "installation": {"uuid": self.install.uuid},
-                "data": {},
-                "actor": {"type": "application", "id": "sentry", "name": "Sentry"},
-            }
+        assert (
+            result.body
+            == orjson.dumps(
+                {
+                    "action": "triggered",
+                    "installation": {"uuid": self.install.uuid},
+                    "data": {},
+                    "actor": {"type": "application", "id": "sentry", "name": "Sentry"},
+                }
+            ).decode()
         )
 
         signature = self.sentry_app.build_signature(result.body)
@@ -41,7 +45,7 @@ class AppPlatformEventSerializerTest(TestCase):
             actor=self.sentry_app.proxy_user,
         )
 
-        assert json.loads(result.body)["actor"] == {
+        assert orjson.loads(result.body)["actor"] == {
             "type": "application",
             "id": self.sentry_app.uuid,
             "name": self.sentry_app.name,
@@ -62,7 +66,7 @@ class AppPlatformEventSerializerTest(TestCase):
             actor=self.user,
         )
 
-        assert json.loads(result.body)["actor"] == {
+        assert orjson.loads(result.body)["actor"] == {
             "type": "user",
             "id": self.user.id,
             "name": self.user.name,


### PR DESCRIPTION
We have enough confidence to say that `orjson` doesn't cause any errors/issues. We can now safely get rid of `json` and `rapidjson` in our repository.

Ref: https://github.com/getsentry/sentry/issues/68903