### PR TITLE
ref(replay): update details tab title to be display name

### DIFF
--- a/static/app/views/replays/detail/page.tsx
+++ b/static/app/views/replays/detail/page.tsx
@@ -40,7 +40,7 @@ export default function Page({
   isVideoReplay,
 }: Props) {
   const title = replayRecord
-    ? `${replayRecord.user.display_name} — Session Replay — ${orgSlug}`
+    ? `${replayRecord.user.display_name ?? t('Anonymous User')} — Session Replay — ${orgSlug}`
     : `Session Replay — ${orgSlug}`;
 
   const onShareReplay = useShareReplayAtTimestamp();

--- a/static/app/views/replays/detail/page.tsx
+++ b/static/app/views/replays/detail/page.tsx
@@ -40,7 +40,7 @@ export default function Page({
   isVideoReplay,
 }: Props) {
   const title = replayRecord
-    ? `${replayRecord.id} — Session Replay — ${orgSlug}`
+    ? `${replayRecord.user.display_name} — Session Replay — ${orgSlug}`
     : `Session Replay — ${orgSlug}`;
 
   const onShareReplay = useShareReplayAtTimestamp();


### PR DESCRIPTION
fixes https://github.com/getsentry/sentry/issues/70275

replaces the tab title (previously the replay ID) to be the display name instead

https://github.com/getsentry/sentry/assets/56095982/92edbe3e-fdd2-4d73-b6c6-d2ddeb7e561b

