### PR TITLE
perf: use orjson in billing metrics

### DIFF
--- a/tests/sentry/ingest/billing_metrics_consumer/test_billing_metrics_consumer_kafka.py
+++ b/tests/sentry/ingest/billing_metrics_consumer/test_billing_metrics_consumer_kafka.py
@@ -4,6 +4,7 @@ from datetime import datetime, timezone
 from typing import cast
 from unittest import mock
 
+import orjson
 from arroyo.backends.kafka import KafkaPayload
 from arroyo.types import BrokerValue, Message, Partition, Topic
 from django.core.cache import cache
@@ -23,7 +24,6 @@ from sentry.sentry_metrics.indexer.strings import (
 )
 from sentry.sentry_metrics.use_case_id_registry import UseCaseID
 from sentry.testutils.pytest.fixtures import django_db_all
-from sentry.utils import json
 from sentry.utils.outcomes import Outcome
 
 
@@ -206,7 +206,7 @@ def test_outcomes_consumed(track_outcome, factories):
     def generate_kafka_message(generic_metric: GenericMetric) -> Message[KafkaPayload]:
         nonlocal generate_kafka_message_counter
 
-        encoded = json.dumps(generic_metric).encode()
+        encoded = orjson.dumps(generic_metric)
         payload = KafkaPayload(key=None, value=encoded, headers=[])
         message = Message(
             BrokerValue(

--- a/tests/sentry/ingest/ingest_consumer/test_dlq.py
+++ b/tests/sentry/ingest/ingest_consumer/test_dlq.py
@@ -3,6 +3,7 @@ from datetime import datetime
 from unittest.mock import Mock
 
 import msgpack
+import orjson
 import pytest
 from arroyo.backends.kafka import KafkaPayload
 from arroyo.dlq import InvalidMessage
@@ -13,7 +14,6 @@ from sentry.event_manager import EventManager
 from sentry.ingest.consumer.factory import IngestStrategyFactory
 from sentry.ingest.types import ConsumerType
 from sentry.testutils.pytest.fixtures import django_db_all
-from sentry.utils import json
 
 
 def make_message(payload: bytes, partition: Partition, offset: int) -> Message:
@@ -60,7 +60,7 @@ def test_dlq_invalid_messages(factories, topic_name, consumer_type) -> None:
         {
             "type": "unsupported type",
             "project_id": project.id,
-            "payload": json.dumps(sample_event).encode("utf-8"),
+            "payload": orjson.dumps(sample_event),
             "start_time": int(time.time()),
             "event_id": "aaa",
         }

--- a/tests/sentry/ingest/ingest_consumer/test_ingest_consumer_kafka.py
+++ b/tests/sentry/ingest/ingest_consumer/test_ingest_consumer_kafka.py
@@ -5,6 +5,7 @@ import time
 import uuid
 
 import msgpack
+import orjson
 import pytest
 from django.conf import settings
 
@@ -15,7 +16,6 @@ from sentry.event_manager import EventManager
 from sentry.eventstore.processing import event_processing_store
 from sentry.testutils.pytest.fixtures import django_db_all
 from sentry.testutils.skips import requires_kafka, requires_snuba
-from sentry.utils import json
 from sentry.utils.batching_kafka_consumer import create_topics
 from sentry.utils.kafka_config import get_topic_definition
 
@@ -79,7 +79,7 @@ def get_test_message(default_project):
             "start_time": int(time.time()),
             "event_id": event_id,
             "project_id": int(project_id),
-            "payload": json.dumps(normalized_event),
+            "payload": orjson.dumps(normalized_event),
         }
 
         val = msgpack.packb(message)


### PR DESCRIPTION
We have enough confidence to say that `orjson` doesn't cause any errors/issues. We can now safely get rid of `json` and `rapidjson` in our repository.

Ref: https://github.com/getsentry/sentry/issues/68903