### PR TITLE
perf: use orjson in dynamic sampling

### DIFF
--- a/src/sentry/dynamic_sampling/rules/biases/custom_rule_bias.py
+++ b/src/sentry/dynamic_sampling/rules/biases/custom_rule_bias.py
@@ -1,14 +1,13 @@
 import logging
 from typing import cast
 
+import orjson
 from sentry_relay.processing import validate_rule_condition
 
 from sentry.dynamic_sampling.rules.biases.base import Bias
 from sentry.dynamic_sampling.rules.utils import Condition, PolymorphicRule
 from sentry.models.dynamicsampling import CUSTOM_RULE_DATE_FORMAT, CustomDynamicSamplingRule
 from sentry.models.project import Project
-from sentry.utils import json
-from sentry.utils.json import JSONDecodeError
 
 logger = logging.getLogger(__name__)
 
@@ -34,7 +33,7 @@ class CustomRuleBias(Bias):
                 continue
 
             try:
-                condition = cast(Condition, json.loads(rule.condition))
+                condition = cast(Condition, orjson.loads(rule.condition))
                 ret_val.append(
                     {
                         "samplingValue": {"type": "reservoir", "limit": rule.num_samples},
@@ -47,7 +46,7 @@ class CustomRuleBias(Bias):
                         },
                     }
                 )
-            except JSONDecodeError:
+            except orjson.JSONDecodeError:
                 logger.exception(
                     "Custom rule with invalid json found",
                     extra={"rule_id": rule.rule_id, "condition": rule.condition},

--- a/src/sentry/dynamic_sampling/tasks/helpers/boost_low_volume_transactions.py
+++ b/src/sentry/dynamic_sampling/tasks/helpers/boost_low_volume_transactions.py
@@ -1,10 +1,10 @@
 from collections.abc import Mapping
 
+import orjson
 import sentry_sdk
 
 from sentry.dynamic_sampling.models.common import RebalancedItem
 from sentry.dynamic_sampling.rules.utils import get_redis_client_for_ds
-from sentry.utils import json
 
 
 def _get_cache_key(org_id: int, proj_id: int) -> str:
@@ -19,7 +19,7 @@ def get_transactions_resampling_rates(
     try:
         serialised_val = redis_client.get(cache_key)
         if serialised_val:
-            return json.loads(serialised_val)
+            return orjson.loads(serialised_val)
     except (TypeError, ValueError) as e:
         sentry_sdk.capture_exception(e)
 
@@ -33,6 +33,6 @@ def set_transactions_resampling_rates(
     cache_key = _get_cache_key(org_id=org_id, proj_id=proj_id)
     named_rates_dict = {rate.id: rate.new_sample_rate for rate in named_rates}
     val = [named_rates_dict, default_rate]
-    val_str = json.dumps(val)
+    val_str = orjson.dumps(val).decode()
     redis_client.set(cache_key, val_str)
     redis_client.pexpire(cache_key, ttl_ms)


### PR DESCRIPTION
Replaces `json` calls with `orjson` and includes a small optimization to avoid sorting of keys.

Ref: https://github.com/getsentry/sentry/issues/68903