### PR TITLE
ref(js): Avoid direct usage of useRouteContext

### DIFF
--- a/static/app/components/feedback/feedbackOnboarding/sidebar.tsx
+++ b/static/app/components/feedback/feedbackOnboarding/sidebar.tsx
@@ -35,8 +35,8 @@ import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {PlatformKey, Project, SelectValue} from 'sentry/types';
 import {trackAnalytics} from 'sentry/utils/analytics';
+import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
-import {useRouteContext} from 'sentry/utils/useRouteContext';
 import useUrlParams from 'sentry/utils/useUrlParams';
 
 function FeedbackOnboardingSidebar(props: CommonSidebarProps) {
@@ -165,7 +165,7 @@ function OnboardingContent({currentProject}: {currentProject: Project}) {
   }>(jsFrameworkSelectOptions[0]);
 
   const defaultTab = 'npm';
-  const {location} = useRouteContext();
+  const location = useLocation();
   const crashReportOnboarding = location.hash === CRASH_REPORT_HASH;
 
   const {getParamValue: setupMode, setParamValue: setSetupMode} = useUrlParams(

--- a/static/app/components/feedback/useFeedbackOnboarding.tsx
+++ b/static/app/components/feedback/useFeedbackOnboarding.tsx
@@ -3,8 +3,8 @@ import {useCallback, useEffect} from 'react';
 import {SidebarPanelKey} from 'sentry/components/sidebar/types';
 import SidebarPanelStore from 'sentry/stores/sidebarPanelStore';
 import useSelectedProjectsHaveField from 'sentry/utils/project/useSelectedProjectsHaveField';
+import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
-import {useRouteContext} from 'sentry/utils/useRouteContext';
 
 export const CRASH_REPORT_HASH = '#crashreport-sidequest';
 export const FEEDBACK_HASH = '#feedback-sidequest';
@@ -22,7 +22,7 @@ export function useHaveSelectedProjectsSetupNewFeedback() {
 }
 
 export function useFeedbackOnboardingSidebarPanel() {
-  const {location} = useRouteContext();
+  const location = useLocation();
   const organization = useOrganization();
 
   useEffect(() => {

--- a/static/app/components/onboardingWizard/task.tsx
+++ b/static/app/components/onboardingWizard/task.tsx
@@ -22,7 +22,7 @@ import type {
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {isDemoWalkthrough} from 'sentry/utils/demoMode';
 import testableTransition from 'sentry/utils/testableTransition';
-import {useRouteContext} from 'sentry/utils/useRouteContext';
+import useRouter from 'sentry/utils/useRouter';
 import withOrganization from 'sentry/utils/withOrganization';
 
 import SkipConfirm from './skipConfirm';
@@ -63,8 +63,7 @@ type Props = {
 
 function Task(props: Props) {
   const {task, onSkip, onMarkComplete, forwardedRef, organization, hidePanel} = props;
-  const routeContext = useRouteContext();
-  const {router} = routeContext;
+  const router = useRouter();
   const handleSkip = () => {
     recordAnalytics(task, organization, 'skipped');
     onSkip(task.task);
@@ -83,7 +82,7 @@ function Task(props: Props) {
     }
 
     if (task.actionType === 'action') {
-      task.action(routeContext);
+      task.action(router);
     }
 
     if (task.actionType === 'app') {

--- a/static/app/components/onboardingWizard/taskConfig.tsx
+++ b/static/app/components/onboardingWizard/taskConfig.tsx
@@ -243,7 +243,7 @@ export function getOnboardingTasks({
       skippable: true,
       requisites: [OnboardingTaskKey.FIRST_PROJECT],
       actionType: 'action',
-      action: ({router}) => {
+      action: router => {
         // Use `features?.` because getsentry has a different `Organization` type/payload
         if (!organization.features?.includes('performance-onboarding-checklist')) {
           window.open(

--- a/static/app/types/onboarding.tsx
+++ b/static/app/types/onboarding.tsx
@@ -1,4 +1,4 @@
-import type {RouteContextInterface} from 'react-router';
+import type {InjectedRouter} from 'react-router';
 
 import type {OnboardingContextProps} from 'sentry/components/onboarding/onboardingContext';
 import type {Category} from 'sentry/components/platformPicker';
@@ -89,7 +89,7 @@ interface OnboardingTaskDescriptorBase {
 }
 
 interface OnboardingTypeDescriptorWithAction extends OnboardingTaskDescriptorBase {
-  action: (props: RouteContextInterface) => void;
+  action: (props: InjectedRouter) => void;
   actionType: 'action';
 }
 

--- a/static/app/utils/replays/hooks/useReplayOnboarding.tsx
+++ b/static/app/utils/replays/hooks/useReplayOnboarding.tsx
@@ -4,9 +4,9 @@ import {SidebarPanelKey} from 'sentry/components/sidebar/types';
 import SidebarPanelStore from 'sentry/stores/sidebarPanelStore';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import useSelectedProjectsHaveField from 'sentry/utils/project/useSelectedProjectsHaveField';
+import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import useProjects from 'sentry/utils/useProjects';
-import {useRouteContext} from 'sentry/utils/useRouteContext';
 
 export function useHasOrganizationSentAnyReplayEvents() {
   const {projects, fetching} = useProjects();
@@ -21,7 +21,7 @@ export function useHaveSelectedProjectsSentAnyReplayEvents() {
 }
 
 export function useReplayOnboardingSidebarPanel() {
-  const {location} = useRouteContext();
+  const location = useLocation();
   const organization = useOrganization();
 
   useEffect(() => {


### PR DESCRIPTION
This is to help ease the transition to react-router 6