### PR TITLE
fix(metrics): Remove byte format within JSON

### DIFF
--- a/tests/sentry/sentry_metrics/test_gen_metrics_multiprocess_steps.py
+++ b/tests/sentry/sentry_metrics/test_gen_metrics_multiprocess_steps.py
@@ -66,6 +66,7 @@ def compare_messages_ignoring_mapping_metadata(actual: Message, expected: Messag
     actual_deserialized = json.loads(actual_payload.value)
     expected_deserialized = json.loads(expected_payload.value)
     del actual_deserialized["mapping_meta"]
+    actual_deserialized.pop("aggregation_option", None)
     assert actual_deserialized == expected_deserialized
 
 
@@ -241,7 +242,7 @@ counter_payloads: list[dict[str, Any]] = [
             "session.status": "init",
         },
         "timestamp": ts,
-        "type": b"c",
+        "type": "c",
         "value": 1.0,
         "org_id": 1,
         "project_id": 3,
@@ -258,7 +259,7 @@ distribution_payloads: list[dict[str, Any]] = [
             "session.status": "healthy",
         },
         "timestamp": ts,
-        "type": b"d",
+        "type": "d",
         "value": [4, 5, 6],
         "org_id": 1,
         "project_id": 3,
@@ -276,7 +277,7 @@ set_payloads: list[dict[str, Any]] = [
             "session.status": "errored",
         },
         "timestamp": ts,
-        "type": b"s",
+        "type": "s",
         "value": [3],
         "org_id": 1,
         "project_id": 3,
@@ -358,7 +359,7 @@ def test_process_messages() -> None:
                         None,
                         json.dumps(__translated_payload(message_payloads[i])).encode("utf-8"),
                         [
-                            ("metric_type", message_payloads[i]["type"]),
+                            ("metric_type", str.encode(message_payloads[i]["type"])),
                         ],
                     ),
                     m.value.partition,

--- a/tests/sentry/sentry_metrics/test_gen_metrics_multiprocess_steps.py
+++ b/tests/sentry/sentry_metrics/test_gen_metrics_multiprocess_steps.py
@@ -66,6 +66,9 @@ def compare_messages_ignoring_mapping_metadata(actual: Message, expected: Messag
     actual_deserialized = json.loads(actual_payload.value)
     expected_deserialized = json.loads(expected_payload.value)
     del actual_deserialized["mapping_meta"]
+    # The custom use case metrics payload adds the aggregation option to the transformed payload.
+    # Others don't. Since the tests are generic over different payload types, removed the checking
+    # of fields which are specific to a payload.
     actual_deserialized.pop("aggregation_option", None)
     assert actual_deserialized == expected_deserialized
 
@@ -359,7 +362,7 @@ def test_process_messages() -> None:
                         None,
                         json.dumps(__translated_payload(message_payloads[i])).encode("utf-8"),
                         [
-                            ("metric_type", str.encode(message_payloads[i]["type"])),
+                            ("metric_type", message_payloads[i]["type"].encode()),
                         ],
                     ),
                     m.value.partition,


### PR DESCRIPTION
We need the bytes of metric type only in the kafka headers. Not in the actual payload. Made the change so that the JSON payload gets a string while the kafka header gets a byte.