### PR TITLE
Add limit to API for Alert Rules

### DIFF
--- a/src/sentry/api/helpers/constants.py
+++ b/src/sentry/api/helpers/constants.py
@@ -1,2 +1,2 @@
-MAX_QUERY_SUBSCTIPTIONS_HEADER = "X-Sentry-Rule-Limit"
+MAX_QUERY_SUBSCRIPTIONS_HEADER = "X-Sentry-Alert-Rule-Limit"
 ALERT_RULES_COUNT_HEADER = "X-Sentry-Alert-Rule-Hits"

--- a/src/sentry/api/helpers/constants.py
+++ b/src/sentry/api/helpers/constants.py
@@ -1,0 +1,2 @@
+MAX_QUERY_SUBSCTIPTIONS_HEADER = "X-Sentry-Rule-Limit"
+ALERT_RULES_COUNT_HEADER = "X-Sentry-Alert-Rule-Hits"

--- a/src/sentry/incidents/endpoints/organization_alert_rule_index.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_index.py
@@ -16,7 +16,7 @@ from sentry.api.base import Endpoint, region_silo_endpoint
 from sentry.api.bases.organization import OrganizationAlertRulePermission, OrganizationEndpoint
 from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.api.fields.actor import ActorField
-from sentry.api.helpers.constants import ALERT_RULES_COUNT_HEADER, MAX_QUERY_SUBSCTIPTIONS_HEADER
+from sentry.api.helpers.constants import ALERT_RULES_COUNT_HEADER, MAX_QUERY_SUBSCRIPTIONS_HEADER
 from sentry.api.paginator import (
     CombinedQuerysetIntermediary,
     CombinedQuerysetPaginator,
@@ -82,7 +82,7 @@ class AlertRuleIndexMixin(Endpoint):
         )
 
         response[ALERT_RULES_COUNT_HEADER] = len(alert_rules)
-        response[MAX_QUERY_SUBSCTIPTIONS_HEADER] = settings.MAX_QUERY_SUBSCRIPTIONS_PER_ORG
+        response[MAX_QUERY_SUBSCRIPTIONS_HEADER] = settings.MAX_QUERY_SUBSCRIPTIONS_PER_ORG
         return response
 
     def create_metric_alert(self, request, organization, project=None):
@@ -285,7 +285,7 @@ class OrganizationCombinedRuleIndexEndpoint(OrganizationEndpoint):
         )
         response["X-Sentry-Issue-Rule-Hits"] = issue_rules_count
         response[ALERT_RULES_COUNT_HEADER] = alert_rules_count
-        response[MAX_QUERY_SUBSCTIPTIONS_HEADER] = settings.MAX_QUERY_SUBSCRIPTIONS_PER_ORG
+        response[MAX_QUERY_SUBSCRIPTIONS_HEADER] = settings.MAX_QUERY_SUBSCRIPTIONS_PER_ORG
         return response
 
 

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
@@ -9,7 +9,7 @@ from django.test.utils import override_settings
 from rest_framework import status
 
 from sentry import audit_log
-from sentry.api.helpers.constants import ALERT_RULES_COUNT_HEADER, MAX_QUERY_SUBSCTIPTIONS_HEADER
+from sentry.api.helpers.constants import ALERT_RULES_COUNT_HEADER, MAX_QUERY_SUBSCRIPTIONS_HEADER
 from sentry.api.serializers import serialize
 from sentry.incidents.models.alert_rule import (
     AlertRule,
@@ -133,7 +133,7 @@ class AlertRuleListEndpointTest(AlertRuleIndexBase):
             resp = self.get_response(self.organization.slug)
 
         assert resp[ALERT_RULES_COUNT_HEADER] == "2"
-        assert resp[MAX_QUERY_SUBSCTIPTIONS_HEADER] == "1000"
+        assert resp[MAX_QUERY_SUBSCRIPTIONS_HEADER] == "1000"
 
     def test_simple_with_activation(self):
         self.create_team(organization=self.organization, members=[self.user])


### PR DESCRIPTION
## Description
Fixes: https://github.com/getsentry/sentry/issues/67195

Adds the `x-sentry-rule-limit` header to the list views for alert rules (both the combined-rules and metric alert api).

I tried adding an indicator to the UI, but it was pretty difficult to tell which page we're on in the UI, since we're handling it on the backend with a `Link`. Rather than blocking the API fix on trying to figure out the UI, i figure it's better to get this out and we can add to the UI later.

![Screenshot 2024-05-09 at 11 39 43 AM](https://github.com/getsentry/sentry/assets/1569818/3cb0d796-95ad-4f87-8344-88d9599b6c79)