### PR TITLE
feat(new-trace): Fixing routing to discover from trace view bug.

### DIFF
--- a/static/app/views/performance/traceDetails/utils.tsx
+++ b/static/app/views/performance/traceDetails/utils.tsx
@@ -2,6 +2,7 @@ import type {LocationDescriptorObject} from 'history';
 
 import {PAGE_URL_PARAM} from 'sentry/constants/pageFilters';
 import type {Organization, OrganizationSummary} from 'sentry/types';
+import {getTimeStampFromTableDateField} from 'sentry/utils/dates';
 import type {
   EventLite,
   TraceError,
@@ -41,7 +42,7 @@ export function getTraceDetailsUrl(
       ),
       query: {
         ...queryParams,
-        timestamp,
+        timestamp: getTimeStampFromTableDateField(timestamp),
         eventId,
       },
     };


### PR DESCRIPTION
When we have a timestamp in the url, we use `start: timestamp - 1.5days` and `end: timestamp + 1.5days` instead of statsPeriod, when routing to discover to review all events associated with trace id. 