### PR TITLE
feat(traces): Show error message on traces

### DIFF
--- a/static/app/views/performance/traces/content.tsx
+++ b/static/app/views/performance/traces/content.tsx
@@ -135,6 +135,11 @@ export function Content() {
           })}
         </StyledAlert>
       )}
+      {isError && typeof traces.error?.responseJSON?.detail === 'string' ? (
+        <StyledAlert type="error" showIcon>
+          {traces.error?.responseJSON?.detail}
+        </StyledAlert>
+      ) : null}
       <TracesSearchBar
         queries={queries}
         handleSearch={handleSearch}

--- a/static/app/views/performance/traces/fieldRenderers.tsx
+++ b/static/app/views/performance/traces/fieldRenderers.tsx
@@ -59,7 +59,6 @@ export const TraceBreakdownContainer = styled('div')<{hoveredIndex?: number}>`
   min-width: 200px;
   height: 15px;
   background-color: ${p => p.theme.gray100};
-  overflow-x: hidden;
   ${p => `--hoveredSlice-${p.hoveredIndex ?? -1}-translateY: translateY(-3px)`};
 `;
 

--- a/static/app/views/performance/traces/fieldRenderers.tsx
+++ b/static/app/views/performance/traces/fieldRenderers.tsx
@@ -59,6 +59,7 @@ export const TraceBreakdownContainer = styled('div')<{hoveredIndex?: number}>`
   min-width: 200px;
   height: 15px;
   background-color: ${p => p.theme.gray100};
+  overflow-x: hidden;
   ${p => `--hoveredSlice-${p.hoveredIndex ?? -1}-translateY: translateY(-3px)`};
 `;
 


### PR DESCRIPTION
#### Summary
This shows an error message banner, which is helpful for timeouts.

#### Screenshots
![Screenshot 2024-05-09 at 2 54 37 PM](https://github.com/getsentry/sentry/assets/6111995/8ea24c53-0b7d-4a35-bef8-2dc9b02aa13b)
