### PR TITLE
fix(hybridcloud) Fix loading project lists in notification settings

### DIFF
--- a/static/app/utils/queryClient.tsx
+++ b/static/app/utils/queryClient.tsx
@@ -47,6 +47,7 @@ export type QueryKeyEndpointOptions<
 > = {
   data?: Data;
   headers?: Headers;
+  host?: string;
   method?: APIRequestMethod;
   query?: Query;
 };
@@ -184,6 +185,7 @@ export function fetchDataQuery(api: Client) {
 
     return api.requestPromise(url, {
       includeAllArgs: true,
+      host: opts?.host,
       method: opts?.method ?? 'GET',
       data: opts?.data,
       query: opts?.query,

--- a/static/app/views/settings/account/notifications/notificationSettingsByEntity.spec.tsx
+++ b/static/app/views/settings/account/notifications/notificationSettingsByEntity.spec.tsx
@@ -1,4 +1,5 @@
 import {OrganizationFixture} from 'sentry-fixture/organization';
+import {ProjectFixture} from 'sentry-fixture/project';
 
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
@@ -40,6 +41,47 @@ describe('NotificationSettingsByEntity', function () {
       />
     );
     expect(await screen.findByText(otherOrganization.name)).toBeInTheDocument();
+    expect(projectsMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('should load from the organization region', async function () {
+    const organization = OrganizationFixture();
+    const deOrg = OrganizationFixture({
+      id: '2',
+      slug: 'de-org',
+      name: 'de org',
+      links: {
+        organizationUrl: 'https://de-org.sentry.io',
+        regionUrl: 'https://de.sentry.io',
+      },
+    });
+    ConfigStore.set('customerDomain', {
+      ...ConfigStore.get('customerDomain')!,
+      subdomain: deOrg.slug,
+    });
+    const projectsMock = MockApiClient.addMockResponse({
+      url: `/organizations/${deOrg.slug}/projects/`,
+      method: 'GET',
+      body: [ProjectFixture({organization: deOrg})],
+      match: [
+        function (_url: string, options: Record<string, any>) {
+          return options.host === 'https://de.sentry.io';
+        },
+      ],
+    });
+
+    render(
+      <NotificationSettingsByEntity
+        organizations={[organization, deOrg]}
+        notificationType="alerts"
+        notificationOptions={[]}
+        handleRemoveNotificationOption={jest.fn()}
+        handleAddNotificationOption={jest.fn()}
+        handleEditNotificationOption={jest.fn()}
+        entityType={'project' as const}
+      />
+    );
+    expect(await screen.findByText(deOrg.name)).toBeInTheDocument();
     expect(projectsMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/static/app/views/settings/account/notifications/notificationSettingsByEntity.tsx
+++ b/static/app/views/settings/account/notifications/notificationSettingsByEntity.tsx
@@ -57,8 +57,11 @@ function NotificationSettingsByEntity({
 
   const orgId =
     router.location?.query?.organizationId ?? orgFromSubdomain ?? organizations[0]?.id;
-  const orgSlug =
-    organizations.find(({id}) => id === orgId)?.slug || organizations[0]?.slug;
+  let organization = organizations.find(({id}) => id === orgId);
+  if (!organization) {
+    organization = organizations[0];
+  }
+  const orgSlug = organization.slug;
 
   // loads all the projects for an org
   const {
@@ -71,6 +74,7 @@ function NotificationSettingsByEntity({
     [
       `/organizations/${orgSlug}/projects/`,
       {
+        host: organization.links.regionUrl,
         query: {
           all_projects: '1',
           collapse: ['latestDeploys', 'unusedFeatures'],


### PR DESCRIPTION
We should apply the organization region URL to requests made for project list requests from notifications. Doing so avoids sending requests to the wrong region, as `Client` will implicitly use the region of the organization the HTML page was initially loaded if no `host` is provided.

Fixes HC-1187