### PR TITLE
deprecate(related_issues): Drop support for doing all types of related issues

### DIFF
--- a/src/sentry/api/endpoints/issues/related_issues.py
+++ b/src/sentry/api/endpoints/issues/related_issues.py
@@ -34,8 +34,6 @@ class RelatedIssuesEndpoint(GroupEndpoint):
         :pparam Group group: the group object
         """
         # The type of related issues to retrieve. Can be either `same_root_cause` or `trace_connected`.
-        related_type = request.query_params.get("type")
-
-        if related_type in RELATED_ISSUES_ALGORITHMS:
-            data, meta = RELATED_ISSUES_ALGORITHMS[related_type](group)
-            return Response({"type": related_type, "data": data, "meta": meta})
+        related_type = request.query_params["type"]
+        data, meta = RELATED_ISSUES_ALGORITHMS[related_type](group)
+        return Response({"type": related_type, "data": data, "meta": meta})

--- a/src/sentry/api/endpoints/issues/related_issues.py
+++ b/src/sentry/api/endpoints/issues/related_issues.py
@@ -5,7 +5,6 @@ from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.group import GroupEndpoint
-from sentry.issues.related import find_related_issues  # To be deprecated
 from sentry.issues.related import RELATED_ISSUES_ALGORITHMS
 from sentry.models.group import Group
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
@@ -36,12 +35,7 @@ class RelatedIssuesEndpoint(GroupEndpoint):
         """
         # The type of related issues to retrieve. Can be either `same_root_cause` or `trace_connected`.
         related_type = request.query_params.get("type")
-        related_issues: list[dict[str, str | list[int] | dict[str, str]]] = []
 
         if related_type in RELATED_ISSUES_ALGORITHMS:
             data, meta = RELATED_ISSUES_ALGORITHMS[related_type](group)
             return Response({"type": related_type, "data": data, "meta": meta})
-        else:
-            # XXX: We will be deprecating this approach soon
-            related_issues = find_related_issues(group)
-            return Response({"data": [related_set for related_set in related_issues]})

--- a/src/sentry/issues/related/__init__.py
+++ b/src/sentry/issues/related/__init__.py
@@ -1,7 +1,5 @@
 """This module exports a function to find related issues. It groups them by type."""
 
-from sentry.models.group import Group
-
 from .same_root_cause import same_root_cause_analysis
 from .trace_connected import trace_connected_analysis
 
@@ -11,12 +9,3 @@ RELATED_ISSUES_ALGORITHMS = {
     "same_root_cause": same_root_cause_analysis,
     "trace_connected": trace_connected_analysis,
 }
-
-
-def find_related_issues(group: Group) -> list[dict[str, str | list[int] | dict[str, str]]]:
-    related_issues: list[dict[str, str | list[int] | dict[str, str]]] = []
-    for key, func in RELATED_ISSUES_ALGORITHMS.items():
-        data, meta = func(group)
-        related_issues.append({"type": key, "data": data, "meta": meta})
-
-    return related_issues


### PR DESCRIPTION
This is a follow-up to #70504. Once the UI stops using this approach we will merge this change.