### PR TITLE
feat(snuba-search): adds handling for additional filters for useGroupSnubaDataset=1

### DIFF
--- a/src/sentry/issues/endpoints/organization_group_index.py
+++ b/src/sentry/issues/endpoints/organization_group_index.py
@@ -51,12 +51,8 @@ allowed_inbox_search_terms = frozenset(["date", "status", "for_review", "assigne
 # these filters are currently not supported in the snuba only search
 # and will use PostgresSnubaQueryExecutor instead of GroupAttributesPostgresSnubaQueryExecutor
 UNSUPPORTED_SNUBA_FILTERS = [
-    "regressed_in_release",
-    "issue.priority",
-    "firstRelease",
-    "release.build",
-    "release.package",
-    "release.dist",
+    "issue.priority",  # coming soon
+    "firstRelease",  # coming soon
 ]
 
 

--- a/src/sentry/search/snuba/backend.py
+++ b/src/sentry/search/snuba/backend.py
@@ -496,7 +496,7 @@ class SnubaSearchBackendBase(SearchBackend, metaclass=ABCMeta):
         if use_group_snuba_dataset:
             # we need to handle two cases fo the group queryset:
             # 1. Limit results to groups that are not pending deletion or merge
-            # 2. Handle queries snuba doesn't support such as bookmarked_by, linked, subscribed_by
+            # 2. Handle queries snuba doesn't support such as bookmarked_by, linked, subscribed_by, etc
             # For the second case, we hit postgres before Snuba to get the group ids
             group_queryset = self._build_limited_group_queryset(projects, search_filters)
 

--- a/src/sentry/search/snuba/executors.py
+++ b/src/sentry/search/snuba/executors.py
@@ -57,6 +57,7 @@ from sentry.models.organization import Organization
 from sentry.models.project import Project
 from sentry.models.team import Team
 from sentry.models.user import User
+from sentry.rules.conditions.event_attribute import ATTR_CHOICES
 from sentry.search.events.builder.discover import UnresolvedQuery
 from sentry.search.events.datasets.discover import DiscoverDatasetConfig
 from sentry.search.events.filter import convert_search_filter_to_snuba_query, format_search_filter
@@ -95,7 +96,13 @@ class Clauses(Enum):
 
 # we cannot use snuba for these fields because they require a join with tables that don't exist there
 # if we ever see these fields, we will use postgres to get the group_ids before sending back to ClickHouse
-POSTGRES_ONLY_SEARCH_FIELDS = ["bookmarked_by", "linked", "subscribed_by"]
+# note that we could eventually migrate the releases table to ClickHouse and handle those with a join in ClickHouse
+POSTGRES_ONLY_SEARCH_FIELDS = [
+    "bookmarked_by",
+    "linked",
+    "subscribed_by",
+    "regressed_in_release",
+]
 
 
 @dataclass
@@ -1172,13 +1179,48 @@ class GroupAttributesPostgresSnubaQueryExecutor(PostgresSnubaQueryExecutor):
         )
 
     def get_basic_event_snuba_condition(
-        self, search_filter: SearchFilter, joined_entity: Entity
+        self,
+        search_filter: SearchFilter,
+        joined_entity: Entity,
+        organization_id: int,
+        project_ids: Sequence[int],
+        environments: Sequence[str],
     ) -> Condition:
         """
         Returns the basic lookup for a search filter.
         """
-        query_builder = self.def_get_query_builder(joined_entity)
-        return query_builder.default_filter_converter(search_filter)
+        # note this might hit postgres to do queries on releases
+        raw_conditions = convert_search_filter_to_snuba_query(
+            search_filter,
+            params={
+                "organization_id": organization_id,
+                "project_id": project_ids,
+                "environment": environments,
+            },
+        )
+        if not raw_conditions:
+            return None
+
+        item = raw_conditions[0]
+        if not isinstance(item, list):
+            raw_conditions = [raw_conditions]
+
+        output_conditions = []
+        for item in raw_conditions:
+            column_name = item[0]
+            # do some name mapping for snuba
+            column_name = column_name.replace("stack.", "stacktrace.")
+            if ATTR_CHOICES.get(column_name) is not None:
+                raw_column = ATTR_CHOICES.get(column_name)
+                column_name = raw_column.value.event_name
+
+            column = Column(column_name, joined_entity)
+            operator = Op(item[1])
+            value = item[2]
+            output_conditions.append(Condition(column, operator, value))
+        if len(output_conditions) == 1:
+            return output_conditions[0]
+        return BooleanCondition(op=BooleanOp.AND, conditions=output_conditions)
 
     def get_assigned(
         self, search_filter: SearchFilter, joined_entity: Entity, check_none=True
@@ -1481,6 +1523,19 @@ class GroupAttributesPostgresSnubaQueryExecutor(PostgresSnubaQueryExecutor):
         "user": "user_count",
     }
 
+    def should_check_search_issues(
+        self, group_categories: Sequence[str], search_filters: Sequence[SearchFilter]
+    ) -> bool:
+        # not in the group categories we are looking for
+        if not any([GroupCategory.ERROR.value != gc for gc in group_categories]):
+            return False
+        # error/stacktrace info doesn't exist exist in search_issues so we shouldn't it at all
+        bad_prefix_list = ["error.", "stack."]
+        for filter in search_filters:
+            if any(filter.key.name.startswith(bad_prefix) for bad_prefix in bad_prefix_list):
+                return False
+        return True
+
     def calculate_start_end(
         self,
         retention_window_start: datetime | None,
@@ -1555,6 +1610,7 @@ class GroupAttributesPostgresSnubaQueryExecutor(PostgresSnubaQueryExecutor):
         ]
 
         organization = projects[0].organization
+        project_ids = [p.id for p in projects]
 
         event_entity = self.entities["event"]
         attr_entity = self.entities["attrs"]
@@ -1568,7 +1624,7 @@ class GroupAttributesPostgresSnubaQueryExecutor(PostgresSnubaQueryExecutor):
             entities_to_check.append(event_entity)
 
         # check we have non-error categories to search for
-        if any([GroupCategory.ERROR.value != gc for gc in group_categories]):
+        if self.should_check_search_issues(group_categories, search_filters):
             entities_to_check.append(search_issues_entity)
 
         for joined_entity in entities_to_check:
@@ -1615,7 +1671,9 @@ class GroupAttributesPostgresSnubaQueryExecutor(PostgresSnubaQueryExecutor):
                         raise InvalidQueryForExecutor(f"Invalid clause {clause}")
                 else:
                     where_conditions.append(
-                        self.get_basic_event_snuba_condition(search_filter, joined_entity)
+                        self.get_basic_event_snuba_condition(
+                            search_filter, joined_entity, organization.id, project_ids, environments
+                        )
                     )
 
             # handle types based on issue.type and issue.category
@@ -1639,7 +1697,6 @@ class GroupAttributesPostgresSnubaQueryExecutor(PostgresSnubaQueryExecutor):
             sort_func = self.get_sort_defs(joined_entity)[sort_by]
 
             if environments:
-                # TODO: Should this be handled via filter_keys, once we have a snql compatible version?
                 where_conditions.append(
                     Condition(
                         Column("environment", joined_entity), Op.IN, [e.name for e in environments]

--- a/src/sentry/search/snuba/executors.py
+++ b/src/sentry/search/snuba/executors.py
@@ -1148,6 +1148,15 @@ class InvalidQueryForExecutor(Exception):
 
 
 class GroupAttributesPostgresSnubaQueryExecutor(PostgresSnubaQueryExecutor):
+    def get_times_seen_filter(
+        self, search_filter: SearchFilter, joined_entity: Entity
+    ) -> Condition:
+        return Condition(
+            Function("count", []),
+            Op(search_filter.operator),
+            search_filter.value.raw_value,
+        )
+
     def get_last_seen_filter(self, search_filter: SearchFilter, joined_entity: Entity) -> Condition:
         # get the max timestamp of the error/search_issue event
         return Condition(
@@ -1504,6 +1513,7 @@ class GroupAttributesPostgresSnubaQueryExecutor(PostgresSnubaQueryExecutor):
         "message": (get_message_condition, Clauses.WHERE),
         "first_seen": (get_first_seen_filter, Clauses.WHERE),
         "last_seen": (get_last_seen_filter, Clauses.HAVING),
+        "times_seen": (get_times_seen_filter, Clauses.HAVING),
     }
     first_seen = Column("group_first_seen", entities["attrs"])
     times_seen_aggregation = Function("count", [], alias="times_seen")

--- a/src/sentry/search/snuba/executors.py
+++ b/src/sentry/search/snuba/executors.py
@@ -102,6 +102,7 @@ POSTGRES_ONLY_SEARCH_FIELDS = [
     "linked",
     "subscribed_by",
     "regressed_in_release",
+    "for_review",
 ]
 
 

--- a/tests/sentry/issues/endpoints/test_organization_group_index.py
+++ b/tests/sentry/issues/endpoints/test_organization_group_index.py
@@ -2777,7 +2777,6 @@ class GroupListTest(APITestCase, SnubaTestCase, SearchIssueTestMixin):
     def test_snuba_unsupported_filters(self):
         self.login_as(user=self.user)
         for query in [
-            "regressed_in_release:latest",
             "issue.priority:high",
         ]:
             with patch(
@@ -3254,6 +3253,172 @@ class GroupListTest(APITestCase, SnubaTestCase, SearchIssueTestMixin):
             query="subscribed:fake@fake.com", useGroupSnubaDataset=1
         )
         assert len(response.data) == 0
+
+    @override_options({"issues.group_attributes.send_kafka": True})
+    def test_snuba_search_lookup_by_regressed_in_release(self):
+        self.login_as(self.user)
+        project = self.project
+        release = self.create_release()
+        event = self.store_event(
+            data={
+                "timestamp": iso_format(before_now(seconds=1)),
+                "tags": {"sentry:release": release.version},
+            },
+            project_id=project.id,
+        )
+        record_group_history(event.group, GroupHistoryStatus.REGRESSED, release=release)
+        response = self.get_success_response(
+            query=f"regressed_in_release:{release.version}", useGroupSnubaDataset=1
+        )
+        issues = json.loads(response.content)
+        assert [int(issue["id"]) for issue in issues] == [event.group.id]
+
+    @override_options({"issues.group_attributes.send_kafka": True})
+    def test_lookup_by_release_build(self):
+
+        for i in range(3):
+            j = 119 + i
+            self.create_release(version=f"steve@1.2.{i}+{j}")
+
+        self.login_as(self.user)
+        project = self.project
+        release = self.create_release(version="steve@1.2.7+123")
+        event = self.store_event(
+            data={
+                "timestamp": iso_format(before_now(seconds=1)),
+                "tags": {"sentry:release": release.version},
+            },
+            project_id=project.id,
+        )
+
+        response = self.get_success_response(query="release.build:123", useGroupSnubaDataset=1)
+        issues = json.loads(response.content)
+        assert len(issues) == 1
+        assert int(issues[0]["id"]) == event.group.id
+
+        response = self.get_success_response(query="release.build:122", useGroupSnubaDataset=1)
+        issues = json.loads(response.content)
+        assert len(issues) == 0
+
+    @override_options({"issues.group_attributes.send_kafka": True})
+    def test_snuba_search_lookup_by_stack_filename(self):
+        self.login_as(self.user)
+        project = self.project
+        event = self.store_event(
+            data={
+                "timestamp": iso_format(before_now(seconds=1)),
+                "fingerprint": ["unique-fingerprint-1"],
+                "exception": {
+                    "values": [
+                        {
+                            "type": "Error",
+                            "stacktrace": {
+                                "frames": [
+                                    {
+                                        "filename": "example.py",
+                                        "lineno": 29,
+                                        "colno": 10,
+                                        "function": "test_function",
+                                    }
+                                ]
+                            },
+                        }
+                    ]
+                },
+            },
+            project_id=project.id,
+        )
+        self.store_event(
+            data={
+                "timestamp": iso_format(before_now(seconds=2)),
+                "fingerprint": ["unique-fingerprint-2"],
+                "exception": {
+                    "values": [
+                        {
+                            "type": "Error",
+                            "stacktrace": {
+                                "frames": [
+                                    {
+                                        "filename": "different_example.py",
+                                        "lineno": 45,
+                                        "colno": 10,
+                                        "function": "another_test_function",
+                                    }
+                                ]
+                            },
+                        }
+                    ]
+                },
+            },
+            project_id=project.id,
+        )
+
+        response = self.get_success_response(
+            query="stack.filename:example.py", useGroupSnubaDataset=1
+        )
+        issues = json.loads(response.content)
+        assert len(issues) == 1
+        assert int(issues[0]["id"]) == event.group.id
+        response = self.get_success_response(
+            query="stack.filename:nonexistent.py", useGroupSnubaDataset=1
+        )
+        issues = json.loads(response.content)
+        assert len(issues) == 0
+
+    @override_options({"issues.group_attributes.send_kafka": True})
+    def test_error_main_thread_condition(self):
+        self.login_as(user=self.user)
+        project = self.project
+        # Simulate sending an event with main_thread set to true
+        event1 = self.store_event(
+            data={
+                "timestamp": iso_format(before_now(seconds=1)),
+                "message": "MainThreadError",
+                "exception": {
+                    "values": [
+                        {
+                            "type": "Error",
+                            "value": "Error in main thread",
+                            "thread_id": 1,
+                        }
+                    ]
+                },
+                "threads": {"values": [{"id": 1, "main": True}]},
+            },
+            project_id=project.id,
+        )
+        # Simulate sending an event with main_thread set to false
+        event2 = self.store_event(
+            data={
+                "timestamp": iso_format(before_now(seconds=2)),
+                "message": "WorkerThreadError",
+                "exception": {
+                    "values": [
+                        {
+                            "type": "Error",
+                            "value": "Error in worker thread",
+                            "thread_id": 2,
+                        }
+                    ]
+                },
+                "threads": {"values": [{"id": 2, "main": False}]},
+            },
+            project_id=project.id,
+        )
+
+        # Query for events where main_thread is true
+        response = self.get_success_response(query="error.main_thread:true", useGroupSnubaDataset=1)
+        issues = json.loads(response.content)
+        assert len(issues) == 1
+        assert int(issues[0]["id"]) == event1.group.id
+
+        # Query for events where main_thread is false
+        response = self.get_success_response(
+            query="error.main_thread:false", useGroupSnubaDataset=1
+        )
+        issues = json.loads(response.content)
+        assert len(issues) == 1
+        assert int(issues[0]["id"]) == event2.group.id
 
 
 class GroupUpdateTest(APITestCase, SnubaTestCase):


### PR DESCRIPTION
This PR adds the capability to filter on the following new attributes:
* regressed_in_release
* release.build
* release.package
* release.dist

All of them require Postgres queries but handle it differently. For `regressed_in_release`, use the query to generate a list of IDs where we have a group history for regression that matches the versions we check for. For the other three, we get the release versions from Postgres and use that in a snuba query checking events of particular release versions.

Note I am leveraging `convert_search_filter_to_snuba_query` to generate the filters which requires some name mapping that I've added. And it adds logic to skip checking `search_issues` for columns that don't appear in it.

Also added `for_review` which is used in the standard way of generating group_ids. And also added support for `times_seen`.