### PR TITLE
perf: remove jsondata usages

### DIFF
--- a/src/sentry/api/bases/doc_integrations.py
+++ b/src/sentry/api/bases/doc_integrations.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Any
+
 from django.http import Http404
 from rest_framework.request import Request
 
@@ -10,7 +12,6 @@ from sentry.api.utils import id_or_slug_path_params_enabled
 from sentry.api.validators.doc_integration import METADATA_PROPERTIES
 from sentry.auth.superuser import is_active_superuser
 from sentry.models.integrations.doc_integration import DocIntegration
-from sentry.utils.json import JSONData
 from sentry.utils.sdk import configure_scope
 
 
@@ -67,7 +68,7 @@ class DocIntegrationsBaseEndpoint(Endpoint):
 
     permission_classes = (DocIntegrationsAndStaffPermission,)
 
-    def generate_incoming_metadata(self, request: Request) -> JSONData:
+    def generate_incoming_metadata(self, request: Request) -> Any:
         return {k: v for k, v in request.json_body.items() if k in METADATA_PROPERTIES}
 
 

--- a/src/sentry/api/endpoints/group_integration_details.py
+++ b/src/sentry/api/endpoints/group_integration_details.py
@@ -21,7 +21,6 @@ from sentry.services.hybrid_cloud.integration import RpcIntegration, integration
 from sentry.shared_integrations.exceptions import IntegrationError, IntegrationFormError
 from sentry.signals import integration_issue_created, integration_issue_linked
 from sentry.types.activity import ActivityType
-from sentry.utils.json import JSONData
 
 MISSING_FEATURE_MESSAGE = "Your organization does not have access to this feature."
 
@@ -39,7 +38,7 @@ class IntegrationIssueConfigSerializer(IntegrationSerializer):
 
     def serialize(
         self, obj: RpcIntegration, attrs: Mapping[str, Any], user: User, **kwargs: Any
-    ) -> MutableMapping[str, JSONData]:
+    ) -> MutableMapping[str, Any]:
         data = super().serialize(obj, attrs, user)
 
         if self.action == "link":

--- a/src/sentry/api/endpoints/group_integrations.py
+++ b/src/sentry/api/endpoints/group_integrations.py
@@ -19,7 +19,6 @@ from sentry.models.integrations.external_issue import ExternalIssue
 from sentry.models.user import User
 from sentry.services.hybrid_cloud.integration import RpcIntegration, integration_service
 from sentry.services.hybrid_cloud.pagination import RpcPaginationArgs
-from sentry.utils.json import JSONData
 
 
 class IntegrationIssueSerializer(IntegrationSerializer):
@@ -63,7 +62,7 @@ class IntegrationIssueSerializer(IntegrationSerializer):
 
     def serialize(
         self, obj: RpcIntegration, attrs: Mapping[str, Any], user: User, **kwargs: Any
-    ) -> MutableMapping[str, JSONData]:
+    ) -> MutableMapping[str, Any]:
         data = super().serialize(obj, attrs, user)
         data["externalIssues"] = attrs.get("external_issues", [])
         return data

--- a/src/sentry/api/endpoints/notifications/notification_actions.md
+++ b/src/sentry/api/endpoints/notifications/notification_actions.md
@@ -58,6 +58,6 @@ class SentryAuditLogRegistration(ActionRegistration):
     @classmethod
     def serialize_available(
         cls, organization: Organization, integrations: List[RpcIntegration] = None
-    ) -> List[JSONData]:
+    ) -> List[Any]:
         return []
 ```

--- a/src/sentry/api/endpoints/organization_member/team_details.py
+++ b/src/sentry/api/endpoints/organization_member/team_details.py
@@ -36,7 +36,6 @@ from sentry.models.team import Team
 from sentry.roles import organization_roles, team_roles
 from sentry.roles.manager import TeamRole
 from sentry.utils import metrics
-from sentry.utils.json import JSONData
 
 from . import can_admin_team, can_set_team_role
 
@@ -51,7 +50,7 @@ class OrganizationMemberTeamSerializer(serializers.Serializer):
 class OrganizationMemberTeamDetailsSerializer(Serializer):
     def serialize(
         self, obj: OrganizationMemberTeam, attrs: Mapping[Any, Any], user: Any, **kwargs: Any
-    ) -> MutableMapping[str, JSONData]:
+    ) -> MutableMapping[str, Any]:
         return {
             "isActive": obj.is_active,
             "teamRole": obj.role,

--- a/src/sentry/api/serializers/base.py
+++ b/src/sentry/api/serializers/base.py
@@ -7,8 +7,6 @@ from typing import Any, TypeVar
 import sentry_sdk
 from django.contrib.auth.models import AnonymousUser
 
-from sentry.utils.json import JSONData
-
 logger = logging.getLogger(__name__)
 
 K = TypeVar("K")
@@ -105,7 +103,7 @@ class Serializer:
 
     def _serialize(
         self, obj: Any, attrs: Mapping[Any, Any], user: Any, **kwargs: Any
-    ) -> Mapping[str, JSONData] | None:
+    ) -> Mapping[str, Any] | None:
         try:
             return self.serialize(obj, attrs, user, **kwargs)
         except Exception:
@@ -114,7 +112,7 @@ class Serializer:
 
     def serialize(
         self, obj: Any, attrs: Mapping[Any, Any], user: Any, **kwargs: Any
-    ) -> Mapping[str, JSONData]:
+    ) -> Mapping[str, Any]:
         """
         Convert an arbitrary python object `obj` to an object that only contains primitives.
 

--- a/src/sentry/api/serializers/models/doc_integration.py
+++ b/src/sentry/api/serializers/models/doc_integration.py
@@ -6,7 +6,6 @@ from sentry.models.avatars.doc_integration_avatar import DocIntegrationAvatar
 from sentry.models.integrations.doc_integration import DocIntegration
 from sentry.models.integrations.integration_feature import IntegrationFeature, IntegrationTypes
 from sentry.models.user import User
-from sentry.utils.json import JSONData
 
 
 @register(DocIntegration)
@@ -36,7 +35,7 @@ class DocIntegrationSerializer(Serializer):
         attrs: Mapping[str, Any],
         user: User,
         **kwargs: Any,
-    ) -> JSONData:
+    ) -> Any:
         data = {
             "name": obj.name,
             "slug": obj.slug,

--- a/src/sentry/api/serializers/models/doc_integration_avatar.py
+++ b/src/sentry/api/serializers/models/doc_integration_avatar.py
@@ -1,15 +1,15 @@
 from collections.abc import MutableMapping
+from typing import Any
 
 from sentry.api.serializers import Serializer, register
 from sentry.models.avatars.doc_integration_avatar import DocIntegrationAvatar
-from sentry.utils.json import JSONData
 
 
 @register(DocIntegrationAvatar)
 class DocIntegrationAvatarSerializer(Serializer):
     def serialize(
         self, obj: DocIntegrationAvatar, attrs, user, **kwargs
-    ) -> MutableMapping[str, JSONData]:
+    ) -> MutableMapping[str, Any]:
         return {
             "avatarType": obj.get_avatar_type_display(),
             "avatarUuid": obj.ident,

--- a/src/sentry/api/serializers/models/group.py
+++ b/src/sentry/api/serializers/models/group.py
@@ -55,7 +55,6 @@ from sentry.tagstore.types import GroupTagValue
 from sentry.tsdb.snuba import SnubaTSDB
 from sentry.types.group import SUBSTATUS_TO_STR, PriorityLevel
 from sentry.utils.cache import cache
-from sentry.utils.json import JSONData
 from sentry.utils.safe import safe_execute
 from sentry.utils.snuba import aliased_query, raw_query
 
@@ -85,7 +84,7 @@ class GroupStatusDetailsResponseOptional(TypedDict, total=False):
     inRelease: str
     inCommit: str
     pendingEvents: int
-    info: JSONData
+    info: Any
 
 
 class GroupStatusDetailsResponse(GroupStatusDetailsResponseOptional):

--- a/src/sentry/api/serializers/models/integration.py
+++ b/src/sentry/api/serializers/models/integration.py
@@ -15,7 +15,6 @@ from sentry.services.hybrid_cloud.integration import (
     integration_service,
 )
 from sentry.shared_integrations.exceptions import ApiError
-from sentry.utils.json import JSONData
 
 logger = logging.getLogger(__name__)
 
@@ -54,7 +53,7 @@ def serialize_provider(provider: IntegrationProvider) -> Mapping[str, Any]:
 class IntegrationSerializer(Serializer):
     def serialize(
         self, obj: Integration | RpcIntegration, attrs: Mapping[str, Any], user: User, **kwargs: Any
-    ) -> MutableMapping[str, JSONData]:
+    ) -> MutableMapping[str, Any]:
         provider = obj.get_provider()
         return {
             "id": str(obj.id),
@@ -82,7 +81,7 @@ class IntegrationConfigSerializer(IntegrationSerializer):
         user: User,
         include_config: bool = True,
         **kwargs: Any,
-    ) -> MutableMapping[str, JSONData]:
+    ) -> MutableMapping[str, Any]:
         data = super().serialize(obj, attrs, user)
 
         if not include_config:
@@ -137,7 +136,7 @@ class OrganizationIntegrationSerializer(Serializer):
         attrs: Mapping[str, Any],
         user: User,
         include_config: bool = True,
-    ) -> MutableMapping[str, JSONData]:
+    ) -> MutableMapping[str, Any]:
         # XXX(epurkhiser): This is O(n) for integrations, especially since
         # we're using the IntegrationConfigSerializer which pulls in the
         # integration installation config object which very well may be making
@@ -197,7 +196,7 @@ class OrganizationIntegrationSerializer(Serializer):
 class IntegrationProviderSerializer(Serializer):
     def serialize(
         self, obj: IntegrationProvider, attrs: Mapping[str, Any], user: User, **kwargs: Any
-    ) -> MutableMapping[str, JSONData]:
+    ) -> MutableMapping[str, Any]:
         org_slug = kwargs.pop("organization").slug
         metadata = obj.metadata
         metadata = metadata and metadata._asdict() or None

--- a/src/sentry/api/serializers/models/relocation.py
+++ b/src/sentry/api/serializers/models/relocation.py
@@ -9,7 +9,6 @@ from sentry.models.relocation import Relocation
 from sentry.models.user import User
 from sentry.services.hybrid_cloud.user.model import RpcUser
 from sentry.services.hybrid_cloud.user.service import user_service
-from sentry.utils.json import JSONData
 
 
 @dataclasses.dataclass(frozen=True)
@@ -48,7 +47,7 @@ class RelocationSerializer(Serializer):
         attrs: Any,
         user: User,
         **kwargs: Any,
-    ) -> Mapping[str, JSONData]:
+    ) -> Mapping[str, Any]:
         scheduled_at_pause_step = (
             Relocation.Step(obj.scheduled_pause_at_step).name
             if obj.scheduled_pause_at_step is not None

--- a/src/sentry/api/serializers/models/sentry_app_avatar.py
+++ b/src/sentry/api/serializers/models/sentry_app_avatar.py
@@ -1,15 +1,13 @@
 from collections.abc import MutableMapping
+from typing import Any
 
 from sentry.api.serializers import Serializer, register
 from sentry.models.avatars.sentry_app_avatar import SentryAppAvatar
-from sentry.utils.json import JSONData
 
 
 @register(SentryAppAvatar)
 class SentryAppAvatarSerializer(Serializer):
-    def serialize(
-        self, obj: SentryAppAvatar, attrs, user, **kwargs
-    ) -> MutableMapping[str, JSONData]:
+    def serialize(self, obj: SentryAppAvatar, attrs, user, **kwargs) -> MutableMapping[str, Any]:
         return {
             "avatarType": obj.get_avatar_type_display(),
             "avatarUuid": obj.ident,

--- a/src/sentry/api/validators/doc_integration.py
+++ b/src/sentry/api/validators/doc_integration.py
@@ -6,8 +6,6 @@ from typing import Any
 from jsonschema import Draft7Validator
 from jsonschema.exceptions import best_match
 
-from sentry.utils.json import JSONData
-
 logger = logging.getLogger(__name__)
 
 METADATA_SCHEMA: dict[str, Any] = {
@@ -27,7 +25,7 @@ METADATA_SCHEMA: dict[str, Any] = {
 METADATA_PROPERTIES = list(METADATA_SCHEMA["properties"].keys())
 
 
-def validate_metadata_schema(instance: JSONData):
+def validate_metadata_schema(instance: Any):
     v = Draft7Validator(METADATA_SCHEMA)
     if not v.is_valid(instance):
         raise best_match(v.iter_errors(instance))

--- a/src/sentry/apidocs/build.py
+++ b/src/sentry/apidocs/build.py
@@ -1,7 +1,9 @@
+from typing import Any
+
 from sentry.utils import json
 
 
-def get_old_json_paths(filename: str) -> json.JSONData:
+def get_old_json_paths(filename: str) -> Any:
     try:
         with open(filename) as f:
             old_raw_paths = json.load(f)["paths"]
@@ -12,7 +14,7 @@ def get_old_json_paths(filename: str) -> json.JSONData:
     return old_raw_paths
 
 
-def get_old_json_components(filename: str) -> json.JSONData:
+def get_old_json_components(filename: str) -> Any:
     try:
         with open(filename) as f:
             old_raw_components = json.load(f)["components"]

--- a/src/sentry/backup/comparators.py
+++ b/src/sentry/backup/comparators.py
@@ -6,6 +6,7 @@ from collections import defaultdict
 from collections.abc import Callable
 from datetime import datetime, timezone
 from functools import lru_cache
+from typing import Any
 
 from dateutil import parser
 from django.db import models
@@ -18,7 +19,6 @@ from sentry.backup.dependencies import (
 )
 from sentry.backup.findings import ComparatorFinding, ComparatorFindingKind, InstanceID
 from sentry.backup.helpers import Side
-from sentry.utils.json import JSONData
 
 UNIX_EPOCH = unix_zero_date = datetime.fromtimestamp(0, timezone.utc).isoformat()
 
@@ -53,7 +53,7 @@ class JSONScrubbingComparator(ABC):
     def __init__(self, *fields: str):
         self.fields = set(fields)
 
-    def check(self, side: Side, data: JSONData) -> None:
+    def check(self, side: Side, data: Any) -> None:
         """Ensure that we have received valid JSON data at runtime."""
 
         if "model" not in data or not isinstance(data["model"], str):
@@ -64,12 +64,12 @@ class JSONScrubbingComparator(ABC):
             raise RuntimeError(f"The {side.name} input must have a `fields` dictionary.")
 
     @abstractmethod
-    def compare(self, on: InstanceID, left: JSONData, right: JSONData) -> list[ComparatorFinding]:
+    def compare(self, on: InstanceID, left: Any, right: Any) -> list[ComparatorFinding]:
         """An abstract method signature, to be implemented by inheriting classes with their own
         comparison logic. Implementations of this method MUST take care not to mutate the method's
         inputs!"""
 
-    def existence(self, on: InstanceID, left: JSONData, right: JSONData) -> list[ComparatorFinding]:
+    def existence(self, on: InstanceID, left: Any, right: Any) -> list[ComparatorFinding]:
         """Ensure that all tracked fields on either both models or neither."""
 
         findings = []
@@ -102,8 +102,8 @@ class JSONScrubbingComparator(ABC):
 
     def __scrub__(
         self,
-        left: JSONData,
-        right: JSONData,
+        left: Any,
+        right: Any,
         f: (
             Callable[[list[str]], list[str]] | Callable[[list[str]], ScrubbedData]
         ) = lambda _: ScrubbedData(),
@@ -142,8 +142,8 @@ class JSONScrubbingComparator(ABC):
 
     def scrub(
         self,
-        left: JSONData,
-        right: JSONData,
+        left: Any,
+        right: Any,
     ) -> None:
         self.__scrub__(left, right)
 
@@ -168,7 +168,7 @@ class AutoSuffixComparator(JSONScrubbingComparator):
     becomes "my-org-1k1j"). This comparator is robust to such fields, and ensures that the left
     field entry is a strict prefix of the right."""
 
-    def compare(self, on: InstanceID, left: JSONData, right: JSONData) -> list[ComparatorFinding]:
+    def compare(self, on: InstanceID, left: Any, right: Any) -> list[ComparatorFinding]:
         findings = []
         fields = sorted(self.fields)
         for f in fields:
@@ -196,7 +196,7 @@ class DateUpdatedComparator(JSONScrubbingComparator):
     """Comparator that ensures that the specified fields' value on the right input is an ISO-8601
     date that is greater than (ie, occurs after) or equal to the specified field's left input."""
 
-    def compare(self, on: InstanceID, left: JSONData, right: JSONData) -> list[ComparatorFinding]:
+    def compare(self, on: InstanceID, left: Any, right: Any) -> list[ComparatorFinding]:
         findings = []
         fields = sorted(self.fields)
         for f in fields:
@@ -223,7 +223,7 @@ class DatetimeEqualityComparator(JSONScrubbingComparator):
     exactly `.000` (ie, not milliseconds at all - what are the odds!). Because comparisons may fail
     in this case, we use a special comparator for these cases."""
 
-    def compare(self, on: InstanceID, left: JSONData, right: JSONData) -> list[ComparatorFinding]:
+    def compare(self, on: InstanceID, left: Any, right: Any) -> list[ComparatorFinding]:
         findings = []
         fields = sorted(self.fields)
         for f in fields:
@@ -263,7 +263,7 @@ class ForeignKeyComparator(JSONScrubbingComparator):
         self.left_pk_map = left_pk_map
         self.right_pk_map = right_pk_map
 
-    def compare(self, on: InstanceID, left: JSONData, right: JSONData) -> list[ComparatorFinding]:
+    def compare(self, on: InstanceID, left: Any, right: Any) -> list[ComparatorFinding]:
         findings = []
         fields = sorted(self.fields)
         for f in fields:
@@ -319,7 +319,7 @@ class ObfuscatingComparator(JSONScrubbingComparator, ABC):
     def __init__(self, *fields: str):
         super().__init__(*fields)
 
-    def compare(self, on: InstanceID, left: JSONData, right: JSONData) -> list[ComparatorFinding]:
+    def compare(self, on: InstanceID, left: Any, right: Any) -> list[ComparatorFinding]:
         findings = []
         fields = sorted(self.fields)
         for f in fields:
@@ -344,8 +344,8 @@ class ObfuscatingComparator(JSONScrubbingComparator, ABC):
 
     def scrub(
         self,
-        left: JSONData,
-        right: JSONData,
+        left: Any,
+        right: Any,
     ) -> None:
         super().__scrub__(left, right, self.truncate)
 
@@ -403,7 +403,7 @@ class UserPasswordObfuscatingComparator(ObfuscatingComparator):
     def __init__(self):
         super().__init__("password")
 
-    def compare(self, on: InstanceID, left: JSONData, right: JSONData) -> list[ComparatorFinding]:
+    def compare(self, on: InstanceID, left: Any, right: Any) -> list[ComparatorFinding]:
         findings = []
 
         # Error case: there is no importing action that can "claim" a user.
@@ -496,12 +496,12 @@ class IgnoredComparator(JSONScrubbingComparator):
     sure you are validating them some other way!
     """
 
-    def compare(self, _o: InstanceID, _l: JSONData, _r: JSONData) -> list[ComparatorFinding]:
+    def compare(self, _o: InstanceID, _l: Any, _r: Any) -> list[ComparatorFinding]:
         """Noop - there is nothing to compare once we've checked for existence."""
 
         return []
 
-    def existence(self, _o: InstanceID, _l: JSONData, _r: JSONData) -> list[ComparatorFinding]:
+    def existence(self, _o: InstanceID, _l: Any, _r: Any) -> list[ComparatorFinding]:
         """Noop - never compare existence for ignored fields, they're ignored after all."""
 
         return []
@@ -514,7 +514,7 @@ class RegexComparator(JSONScrubbingComparator, ABC):
         self.regex = regex
         super().__init__(*fields)
 
-    def compare(self, on: InstanceID, left: JSONData, right: JSONData) -> list[ComparatorFinding]:
+    def compare(self, on: InstanceID, left: Any, right: Any) -> list[ComparatorFinding]:
         findings = []
         fields = sorted(self.fields)
         for f in fields:
@@ -553,7 +553,7 @@ class EqualOrRemovedComparator(JSONScrubbingComparator):
     missing.
     """
 
-    def compare(self, on: InstanceID, left: JSONData, right: JSONData) -> list[ComparatorFinding]:
+    def compare(self, on: InstanceID, left: Any, right: Any) -> list[ComparatorFinding]:
         findings = []
         fields = sorted(self.fields)
         for f in fields:
@@ -577,7 +577,7 @@ class EqualOrRemovedComparator(JSONScrubbingComparator):
 
         return findings
 
-    def existence(self, on: InstanceID, left: JSONData, right: JSONData) -> list[ComparatorFinding]:
+    def existence(self, on: InstanceID, left: Any, right: Any) -> list[ComparatorFinding]:
         """Ensure that all tracked fields on either both models or neither."""
 
         findings = []
@@ -613,7 +613,7 @@ class SubscriptionIDComparator(RegexComparator):
     def __init__(self, *fields: str):
         super().__init__(re.compile("^\\d+/[0-9a-f]{32}$"), *fields)
 
-    def compare(self, on: InstanceID, left: JSONData, right: JSONData) -> list[ComparatorFinding]:
+    def compare(self, on: InstanceID, left: Any, right: Any) -> list[ComparatorFinding]:
         # First, ensure that the two sides are not equivalent.
         findings = []
         fields = sorted(self.fields)
@@ -644,7 +644,7 @@ class UnorderedListComparator(JSONScrubbingComparator):
     """Comparator for fields that are lists of unordered elements, which simply orders them before
     doing the comparison."""
 
-    def compare(self, on: InstanceID, left: JSONData, right: JSONData) -> list[ComparatorFinding]:
+    def compare(self, on: InstanceID, left: Any, right: Any) -> list[ComparatorFinding]:
         findings = []
         fields = sorted(self.fields)
         for f in fields:
@@ -681,7 +681,7 @@ class UUID4Comparator(RegexComparator):
             *fields,
         )
 
-    def compare(self, on: InstanceID, left: JSONData, right: JSONData) -> list[ComparatorFinding]:
+    def compare(self, on: InstanceID, left: Any, right: Any) -> list[ComparatorFinding]:
         # First, ensure that the two sides are not equivalent.
         findings = []
         fields = sorted(self.fields)

--- a/src/sentry/backup/crypto.py
+++ b/src/sentry/backup/crypto.py
@@ -4,7 +4,7 @@ import io
 import tarfile
 from abc import ABC, abstractmethod
 from functools import lru_cache
-from typing import IO, NamedTuple
+from typing import IO, Any, NamedTuple
 
 from cryptography.fernet import Fernet
 from cryptography.hazmat.backends import default_backend
@@ -115,7 +115,7 @@ class GCPKMSEncryptor(Encryptor):
         return public_key.pem.encode("utf-8")
 
 
-def create_encrypted_export_tarball(json_export: json.JSONData, encryptor: Encryptor) -> io.BytesIO:
+def create_encrypted_export_tarball(json_export: Any, encryptor: Encryptor) -> io.BytesIO:
     """
     Generate a tarball with 3 files:
 

--- a/src/sentry/backup/imports.py
+++ b/src/sentry/backup/imports.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 from collections.abc import Iterator
 from dataclasses import dataclass
-from typing import IO
+from typing import IO, Any
 from uuid import uuid4
 
 from django.core import serializers
@@ -315,7 +315,7 @@ def _import(
         import_write_context: ImportWriteContext,
         pk_map: PrimaryKeyMap,
         model_name: NormalizedModelName,
-        json_data: json.JSONData,
+        json_data: Any,
         offset: int,
     ) -> None:
         model_relations = import_write_context.dependencies.get(model_name)

--- a/src/sentry/backup/sanitize.py
+++ b/src/sentry/backup/sanitize.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta, timezone
 from ipaddress import IPv4Address, IPv6Address, ip_address
 from random import choice, randint
+from typing import Any
 from urllib.parse import urlparse, urlunparse
 from uuid import UUID, uuid4
 
@@ -13,7 +14,6 @@ from dateutil.parser import parse as parse_datetime
 from django.utils.text import slugify
 
 from sentry.utils import json
-from sentry.utils.json import JSONData
 
 UPPER_CASE_HEX = {"A", "B", "C", "D", "E", "F"}
 UPPER_CASE_NON_HEX = {
@@ -89,7 +89,7 @@ class SanitizableField:
     model: NormalizedModelName
     field: str
 
-    def validate_json_model(self, json: JSONData) -> None:
+    def validate_json_model(self, json: Any) -> None:
         """
         Validates the JSON model is shaped the way we expect a serialized Django model to be,
         and that we have the right kind of model for this `SanitizableField`. Raises errors if there
@@ -106,11 +106,11 @@ class SanitizableField:
         return None
 
 
-def _get_field_value(json: JSONData, field: SanitizableField) -> JSONData | None:
+def _get_field_value(json: Any, field: SanitizableField) -> Any | None:
     return json.get("fields", {}).get(field.field, None)
 
 
-def _set_field_value(json: JSONData, field: SanitizableField, value: JSONData) -> JSONData:
+def _set_field_value(json: Any, field: SanitizableField, value: Any) -> Any:
     json.get("fields", {})[field.field] = value
     return value
 
@@ -186,11 +186,11 @@ class Sanitizer:
     `set_name()`, etc), but all of these ultimately call into `set_string()` and `set_datetime()`.
     """
 
-    json: JSONData
+    json: Any
     interned_strings: dict[str, str]
     interned_datetimes: dict[datetime, datetime]
 
-    def __init__(self, export: JSONData, datetime_offset: timedelta | None = None):
+    def __init__(self, export: Any, datetime_offset: timedelta | None = None):
         self.json = export
         self.interned_strings = {"": ""}  # Always map empty string to itself.
         self.interned_datetimes = dict()
@@ -280,7 +280,7 @@ class Sanitizer:
                 self.interned_strings[old] = random_ipv6()
             return self.interned_strings[old]
 
-    def map_json(self, old_json: JSONData, new_json: JSONData) -> JSONData:
+    def map_json(self, old_json: Any, new_json: Any) -> Any:
         """
         Maps a JSON object. If the `old` JSON object has already been seen, the already-generated
         value for that existing key will be used instead. If it has not, we'll generate a new one.
@@ -399,7 +399,7 @@ class Sanitizer:
 
         return self.map_string(old, lambda _: str(uuid4()))
 
-    def set_datetime(self, json: JSONData, field: SanitizableField) -> datetime | None:
+    def set_datetime(self, json: Any, field: SanitizableField) -> datetime | None:
         """
         Replaces a datetime by replacing it with a different, but still correctly ordered,
         alternative.
@@ -425,7 +425,7 @@ class Sanitizer:
 
         return None if parsed is None else _set_field_value(json, field, self.map_datetime(parsed))
 
-    def set_email(self, json: JSONData, field: SanitizableField) -> str | None:
+    def set_email(self, json: Any, field: SanitizableField) -> str | None:
         """
         Replaces an email in a manner that retains domain relationships - ie, all sanitized emails
         from domain `@foo` will now be from `@bar`. If the `old` string is not a valid email (ie,
@@ -450,7 +450,7 @@ class Sanitizer:
 
     def set_ip(
         self,
-        json: JSONData,
+        json: Any,
         field: SanitizableField,
     ) -> str | None:
         """
@@ -478,10 +478,10 @@ class Sanitizer:
 
     def set_json(
         self,
-        json: JSONData,
+        json: Any,
         field: SanitizableField,
-        replace_with: JSONData,
-    ) -> JSONData | None:
+        replace_with: Any,
+    ) -> Any | None:
         """
         Replaces a JSON object with a randomly generated value. If the existing value of the JSON
         object has already been seen, the already-generated value for that existing key will be used
@@ -505,7 +505,7 @@ class Sanitizer:
 
     def set_name(
         self,
-        json: JSONData,
+        json: Any,
         field: SanitizableField,
     ) -> str | None:
         """
@@ -533,7 +533,7 @@ class Sanitizer:
         return _set_field_value(json, field, self.map_name(old))
 
     def set_name_and_slug_pair(
-        self, json: JSONData, name_field: SanitizableField, slug_field: SanitizableField
+        self, json: Any, name_field: SanitizableField, slug_field: SanitizableField
     ) -> tuple[str | None, str | None]:
         """
         Replaces a pair of a proper noun name and its matching slug with some randomly generated
@@ -574,7 +574,7 @@ class Sanitizer:
 
     def set_string(
         self,
-        json: JSONData,
+        json: Any,
         field: SanitizableField,
         generate: Callable[[str], str] = default_string_sanitizer,
     ) -> str | None:
@@ -603,7 +603,7 @@ class Sanitizer:
 
     def set_url(
         self,
-        json: JSONData,
+        json: Any,
         field: SanitizableField,
     ) -> str | None:
         """
@@ -634,7 +634,7 @@ class Sanitizer:
 
     def set_uuid(
         self,
-        json: JSONData,
+        json: Any,
         field: SanitizableField,
     ) -> str | None:
         """
@@ -664,7 +664,7 @@ class Sanitizer:
         return _set_field_value(json, field, self.map_uuid(old))
 
 
-def sanitize(export: JSONData, datetime_offset: timedelta | None = None) -> JSONData:
+def sanitize(export: Any, datetime_offset: timedelta | None = None) -> Any:
     """
     Sanitize an entire export JSON.
     """
@@ -673,7 +673,7 @@ def sanitize(export: JSONData, datetime_offset: timedelta | None = None) -> JSON
     from sentry.backup.dependencies import NormalizedModelName, get_model
 
     sanitizer = Sanitizer(export, datetime_offset)
-    sanitized: list[JSONData] = []
+    sanitized: list[Any] = []
     for item in sanitizer.json:
         clone = deepcopy(item)
         model_name = NormalizedModelName(clone["model"])

--- a/src/sentry/backup/validate.py
+++ b/src/sentry/backup/validate.py
@@ -5,6 +5,7 @@ from collections import OrderedDict as ordereddict
 from collections import defaultdict
 from copy import deepcopy
 from difflib import unified_diff
+from typing import Any
 
 from sentry.backup.comparators import ComparatorMap, ForeignKeyComparator, get_default_comparators
 from sentry.backup.dependencies import ImportKind, NormalizedModelName, PrimaryKeyMap, get_model
@@ -15,7 +16,7 @@ from sentry.backup.findings import (
     InstanceID,
 )
 from sentry.backup.helpers import Side
-from sentry.utils.json import JSONData, JSONEncoder, better_default_encoder
+from sentry.utils.json import JSONEncoder, better_default_encoder
 
 JSON_PRETTY_PRINTER = JSONEncoder(
     default=better_default_encoder, indent=2, ignore_nan=True, sort_keys=True
@@ -23,8 +24,8 @@ JSON_PRETTY_PRINTER = JSONEncoder(
 
 
 def validate(
-    expect: JSONData,
-    actual: JSONData,
+    expect: Any,
+    actual: Any,
     comparators: ComparatorMap | None = None,
 ) -> ComparatorFindings:
     """Ensures that originally imported data correctly matches actual outputted data, and produces a
@@ -43,7 +44,7 @@ def validate(
             self.next_ordinal = 1
 
         def assign(
-            self, obj: JSONData, ordinal_value: int | tuple, side: Side
+            self, obj: Any, ordinal_value: int | tuple, side: Side
         ) -> tuple[InstanceID, list[ComparatorFinding]]:
             """Assigns the next available ordinal to the supplied `obj` model."""
 
@@ -76,10 +77,10 @@ def validate(
             return (InstanceID(str(model_name), obj["ordinal"]), findings if findings else [])
 
     OrdinalCounters = dict[NormalizedModelName, OrdinalCounter]
-    ModelMap = dict[NormalizedModelName, OrderedDict[InstanceID, JSONData]]
+    ModelMap = dict[NormalizedModelName, OrderedDict[InstanceID, Any]]
 
     def build_model_map(
-        models: JSONData, side: Side, findings: ComparatorFindings
+        models: Any, side: Side, findings: ComparatorFindings
     ) -> tuple[ModelMap, OrdinalCounters]:
         """Does two things in tandem: builds a map of InstanceID -> JSON model, and simultaneously builds a map of model name -> number of ordinals assigned."""
 
@@ -88,7 +89,7 @@ def validate(
 
         model_map: ModelMap = defaultdict(ordereddict)
         ordinal_counters: OrdinalCounters = defaultdict(OrdinalCounter)
-        need_ordering: dict[NormalizedModelName, dict[tuple, JSONData]] = defaultdict(dict)
+        need_ordering: dict[NormalizedModelName, dict[tuple, Any]] = defaultdict(dict)
         pks_to_usernames: dict[int, str] = dict()
 
         for model in models:
@@ -156,8 +157,8 @@ def validate(
 
         return (model_map, ordinal_counters)
 
-    def json_lines(obj: JSONData) -> list[str]:
-        """Take a JSONData object and pretty-print it as JSON."""
+    def json_lines(obj: Any) -> list[str]:
+        """Take an object and pretty-print it as JSON."""
 
         return JSON_PRETTY_PRINTER.encode(obj).splitlines()
 

--- a/src/sentry/db/models/base.py
+++ b/src/sentry/db/models/base.py
@@ -20,7 +20,6 @@ from sentry.backup.sanitize import SanitizableField, Sanitizer
 from sentry.backup.scopes import ImportScope, RelocationScope
 from sentry.db.models.fields.uuid import UUIDField
 from sentry.silo.base import SiloLimit, SiloMode
-from sentry.utils.json import JSONData
 
 from .fields.bounded import BoundedBigAutoField
 from .manager import BaseManager
@@ -138,7 +137,7 @@ class BaseModel(models.Model):
         return self.__relocation_scope__
 
     @classmethod
-    def get_relocation_ordinal_fields(self, _json_model: JSONData) -> list[str] | None:
+    def get_relocation_ordinal_fields(self, _json_model: Any) -> list[str] | None:
         """
         Retrieves the custom ordinal fields for models that may be re-used at import time (that is,
         the `write_relocation_import()` method may return an `ImportKind` besides
@@ -196,7 +195,7 @@ class BaseModel(models.Model):
 
     @classmethod
     def sanitize_relocation_json(
-        cls, json: JSONData, sanitizer: Sanitizer, model_name: NormalizedModelName | None = None
+        cls, json: Any, sanitizer: Sanitizer, model_name: NormalizedModelName | None = None
     ) -> None:
         """
         Takes the export JSON representation of this model, and "sanitizes" any data that might be

--- a/src/sentry/integrations/github/client.py
+++ b/src/sentry/integrations/github/client.py
@@ -34,7 +34,6 @@ from sentry.shared_integrations.response.mapping import MappingApiResponse
 from sentry.types.integrations import EXTERNAL_PROVIDERS, ExternalProviders
 from sentry.utils import metrics
 from sentry.utils.cache import cache
-from sentry.utils.json import JSONData
 
 logger = logging.getLogger("sentry.integrations.github")
 
@@ -192,7 +191,7 @@ class GitHubClientMixin(GithubProxyClient):
     # Github gives us links to navigate, however, let's be safe in case we're fed garbage
     page_number_limit = 50  # With a default of 100 per page -> 5,000 items
 
-    def get_last_commits(self, repo: str, end_sha: str) -> Sequence[JSONData]:
+    def get_last_commits(self, repo: str, end_sha: str) -> Sequence[Any]:
         """
         Return API request that fetches last ~30 commits
         see https://docs.github.com/en/rest/commits/commits#list-commits-on-a-repository
@@ -200,32 +199,32 @@ class GitHubClientMixin(GithubProxyClient):
         """
         return self.get_cached(f"/repos/{repo}/commits", params={"sha": end_sha})
 
-    def compare_commits(self, repo: str, start_sha: str, end_sha: str) -> JSONData:
+    def compare_commits(self, repo: str, start_sha: str, end_sha: str) -> Any:
         """
         See https://docs.github.com/en/rest/commits/commits#compare-two-commits
         where start sha is oldest and end is most recent.
         """
         return self.get_cached(f"/repos/{repo}/compare/{start_sha}...{end_sha}")
 
-    def repo_hooks(self, repo: str) -> Sequence[JSONData]:
+    def repo_hooks(self, repo: str) -> Sequence[Any]:
         """
         https://docs.github.com/en/rest/webhooks/repos#list-repository-webhooks
         """
         return self.get(f"/repos/{repo}/hooks")
 
-    def get_commits(self, repo: str) -> Sequence[JSONData]:
+    def get_commits(self, repo: str) -> Sequence[Any]:
         """
         https://docs.github.com/en/rest/commits/commits#list-commits
         """
         return self.get(f"/repos/{repo}/commits")
 
-    def get_commit(self, repo: str, sha: str) -> JSONData:
+    def get_commit(self, repo: str, sha: str) -> Any:
         """
         https://docs.github.com/en/rest/commits/commits#get-a-commit
         """
         return self.get_cached(f"/repos/{repo}/commits/{sha}")
 
-    def get_pullrequest_from_commit(self, repo: str, sha: str) -> JSONData:
+    def get_pullrequest_from_commit(self, repo: str, sha: str) -> Any:
         """
         https://docs.github.com/en/rest/commits/commits#list-pull-requests-associated-with-a-commit
 
@@ -233,7 +232,7 @@ class GitHubClientMixin(GithubProxyClient):
         """
         return self.get(f"/repos/{repo}/commits/{sha}/pulls")
 
-    def get_pullrequest(self, repo: str, pull_number: str) -> JSONData:
+    def get_pullrequest(self, repo: str, pull_number: str) -> Any:
         """
         https://docs.github.com/en/rest/pulls/pulls#get-a-pull-request
 
@@ -241,7 +240,7 @@ class GitHubClientMixin(GithubProxyClient):
         """
         return self.get(f"/repos/{repo}/pulls/{pull_number}")
 
-    def get_pullrequest_files(self, repo: str, pull_number: str) -> JSONData:
+    def get_pullrequest_files(self, repo: str, pull_number: str) -> Any:
         """
         https://docs.github.com/en/rest/pulls/pulls#list-pull-requests-files
 
@@ -249,7 +248,7 @@ class GitHubClientMixin(GithubProxyClient):
         """
         return self.get(f"/repos/{repo}/pulls/{pull_number}/files")
 
-    def get_repo(self, repo: str) -> JSONData:
+    def get_repo(self, repo: str) -> Any:
         """
         https://docs.github.com/en/rest/repos/repos#get-a-repository
         """
@@ -263,8 +262,8 @@ class GitHubClientMixin(GithubProxyClient):
         return GithubRateLimitInfo(self.get("/rate_limit")["resources"][specific_resource])
 
     # https://docs.github.com/en/rest/git/trees#get-a-tree
-    def get_tree(self, repo_full_name: str, tree_sha: str) -> JSONData:
-        tree: JSONData = {}
+    def get_tree(self, repo_full_name: str, tree_sha: str) -> Any:
+        tree: Any = {}
         # We do not cache this call since it is a rather large object
         contents: dict[str, Any] = self.get(
             f"/repos/{repo_full_name}/git/trees/{tree_sha}",
@@ -370,7 +369,7 @@ class GitHubClientMixin(GithubProxyClient):
         should_count_error = False
         txt = error.text
         if error.json:
-            json_data: JSONData = error.json
+            json_data: Any = error.json
             txt = json_data.get("message")
 
         # TODO: Add condition for  getsentry/DataForThePeople
@@ -473,7 +472,7 @@ class GitHubClientMixin(GithubProxyClient):
         )
         return RepoTree(Repo(full_name, branch), repo_files)
 
-    def get_repositories(self, fetch_max_pages: bool = False) -> Sequence[JSONData]:
+    def get_repositories(self, fetch_max_pages: bool = False) -> Sequence[Any]:
         """
         args:
          * fetch_max_pages - fetch as many repos as possible using pagination (slow)
@@ -494,7 +493,7 @@ class GitHubClientMixin(GithubProxyClient):
         return [repo for repo in repos if not repo.get("archived")]
 
     # XXX: Find alternative approach
-    def search_repositories(self, query: bytes) -> Mapping[str, Sequence[JSONData]]:
+    def search_repositories(self, query: bytes) -> Mapping[str, Sequence[Any]]:
         """
         Find repositories matching a query.
         NOTE: All search APIs share a rate limit of 30 requests/minute
@@ -503,7 +502,7 @@ class GitHubClientMixin(GithubProxyClient):
         """
         return self.get("/search/repositories", params={"q": query})
 
-    def get_assignees(self, repo: str) -> Sequence[JSONData]:
+    def get_assignees(self, repo: str) -> Sequence[Any]:
         """
         https://docs.github.com/en/rest/issues/assignees#list-assignees
         """
@@ -511,7 +510,7 @@ class GitHubClientMixin(GithubProxyClient):
 
     def get_with_pagination(
         self, path: str, response_key: str | None = None, page_number_limit: int | None = None
-    ) -> Sequence[JSONData]:
+    ) -> Sequence[Any]:
         """
         Github uses the Link header to provide pagination links. Github
         recommends using the provided link relations and not constructing our
@@ -559,8 +558,8 @@ class GitHubClientMixin(GithubProxyClient):
                 page_number += 1
             return output
 
-    def get_issues(self, repo: str) -> Sequence[JSONData]:
-        issues: Sequence[JSONData] = self.get(f"/repos/{repo}/issues")
+    def get_issues(self, repo: str) -> Sequence[Any]:
+        issues: Sequence[Any] = self.get(f"/repos/{repo}/issues")
         return issues
 
     def search_issues(self, query: str) -> Mapping[str, Sequence[Mapping[str, Any]]]:
@@ -570,44 +569,44 @@ class GitHubClientMixin(GithubProxyClient):
         """
         return self.get("/search/issues", params={"q": query})
 
-    def get_issue(self, repo: str, number: str) -> JSONData:
+    def get_issue(self, repo: str, number: str) -> Any:
         """
         https://docs.github.com/en/rest/issues/issues#get-an-issue
         """
         return self.get(f"/repos/{repo}/issues/{number}")
 
-    def create_issue(self, repo: str, data: Mapping[str, Any]) -> JSONData:
+    def create_issue(self, repo: str, data: Mapping[str, Any]) -> Any:
         """
         https://docs.github.com/en/rest/issues/issues#create-an-issue
         """
         endpoint = f"/repos/{repo}/issues"
         return self.post(endpoint, data=data)
 
-    def create_comment(self, repo: str, issue_id: str, data: Mapping[str, Any]) -> JSONData:
+    def create_comment(self, repo: str, issue_id: str, data: Mapping[str, Any]) -> Any:
         """
         https://docs.github.com/en/rest/issues/comments#create-an-issue-comment
         """
         endpoint = f"/repos/{repo}/issues/{issue_id}/comments"
         return self.post(endpoint, data=data)
 
-    def update_comment(self, repo: str, comment_id: str, data: Mapping[str, Any]) -> JSONData:
+    def update_comment(self, repo: str, comment_id: str, data: Mapping[str, Any]) -> Any:
         endpoint = f"/repos/{repo}/issues/comments/{comment_id}"
         return self.patch(endpoint, data=data)
 
-    def get_comment_reactions(self, repo: str, comment_id: str) -> JSONData:
+    def get_comment_reactions(self, repo: str, comment_id: str) -> Any:
         endpoint = f"/repos/{repo}/issues/comments/{comment_id}"
         response = self.get(endpoint)
         reactions = response["reactions"]
         del reactions["url"]
         return reactions
 
-    def get_user(self, gh_username: str) -> JSONData:
+    def get_user(self, gh_username: str) -> Any:
         """
         https://docs.github.com/en/rest/users/users#get-a-user
         """
         return self.get(f"/users/{gh_username}")
 
-    def get_labels(self, repo: str) -> Sequence[JSONData]:
+    def get_labels(self, repo: str) -> Sequence[Any]:
         """
         Fetches up to the first 100 labels for a repository.
         https://docs.github.com/en/rest/issues/labels#list-labels-for-a-repository

--- a/src/sentry/integrations/github/repository.py
+++ b/src/sentry/integrations/github/repository.py
@@ -11,7 +11,6 @@ from sentry.plugins.providers import IntegrationRepositoryProvider
 from sentry.services.hybrid_cloud.integration import integration_service
 from sentry.services.hybrid_cloud.organization.model import RpcOrganization
 from sentry.shared_integrations.exceptions import ApiError, IntegrationError
-from sentry.utils.json import JSONData
 
 WEBHOOK_EVENTS = ["push", "pull_request"]
 
@@ -20,9 +19,7 @@ class GitHubRepositoryProvider(IntegrationRepositoryProvider):
     name = "GitHub"
     repo_provider = "github"
 
-    def _validate_repo(
-        self, client: Any, installation: IntegrationInstallation, repo: str
-    ) -> JSONData:
+    def _validate_repo(self, client: Any, installation: IntegrationInstallation, repo: str) -> Any:
         try:
             repo_data = client.get_repo(repo)
         except Exception as e:
@@ -92,7 +89,7 @@ class GitHubRepositoryProvider(IntegrationRepositoryProvider):
         self,
         client: Any,
         repo_name: str,
-        commit_list: JSONData,
+        commit_list: Any,
     ) -> Sequence[Mapping[str, Any]]:
         """Convert GitHub commits into our internal format
 

--- a/src/sentry/integrations/github/webhook.py
+++ b/src/sentry/integrations/github/webhook.py
@@ -46,7 +46,6 @@ from sentry.services.hybrid_cloud.user.service import user_service
 from sentry.shared_integrations.exceptions import ApiError
 from sentry.tasks.integrations.github.open_pr_comment import open_pr_comment_workflow
 from sentry.utils import metrics
-from sentry.utils.json import JSONData
 
 from .integration import GitHubIntegrationProvider
 from .repository import GitHubRepositoryProvider
@@ -574,8 +573,8 @@ class GitHubIntegrationsWebhookEndpoint(Endpoint):
         "installation": InstallationEventWebhook,
     }
 
-    def get_handler(self, event_type: str) -> Callable[[], Callable[[JSONData], Any]] | None:
-        handler: Callable[[], Callable[[JSONData], Any]] | None = self._handlers.get(event_type)
+    def get_handler(self, event_type: str) -> Callable[[], Callable[[Any], Any]] | None:
+        handler: Callable[[], Callable[[Any], Any]] | None = self._handlers.get(event_type)
         return handler
 
     def is_valid_signature(self, method: str, body: bytes, secret: str, signature: str) -> bool:

--- a/src/sentry/integrations/jira/client.py
+++ b/src/sentry/integrations/jira/client.py
@@ -1,6 +1,7 @@
 import datetime
 import logging
 import re
+from typing import Any
 from urllib.parse import parse_qs, urlparse, urlsplit
 
 from requests import PreparedRequest
@@ -11,7 +12,6 @@ from sentry.services.hybrid_cloud.integration.model import RpcIntegration
 from sentry.shared_integrations.exceptions import ApiError
 from sentry.utils import jwt
 from sentry.utils.http import absolute_uri
-from sentry.utils.json import JSONData
 
 logger = logging.getLogger("sentry.integrations.jira")
 
@@ -52,7 +52,7 @@ class JiraCloudClient(ApiClient):
         self,
         integration: RpcIntegration,
         verify_ssl: bool,
-        logging_context: JSONData | None = None,
+        logging_context: Any | None = None,
     ):
         self.base_url = integration.metadata.get("base_url")
         self.shared_secret = integration.metadata.get("shared_secret")

--- a/src/sentry/integrations/jira_server/client.py
+++ b/src/sentry/integrations/jira_server/client.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 import re
+from typing import Any
 from urllib.parse import parse_qsl, urlparse
 
 from django.urls import reverse
@@ -17,7 +18,6 @@ from sentry.services.hybrid_cloud.util import control_silo_function
 from sentry.shared_integrations.exceptions import ApiError
 from sentry.utils import jwt
 from sentry.utils.http import absolute_uri
-from sentry.utils.json import JSONData
 
 logger = logging.getLogger(__name__)
 
@@ -57,7 +57,7 @@ class JiraServerClient(ApiClient):
         self,
         integration: RpcIntegration | Integration,
         identity: RpcIdentity,
-        logging_context: JSONData | None = None,
+        logging_context: Any | None = None,
     ):
         self.base_url = integration.metadata["base_url"]
         self.identity = identity

--- a/src/sentry/integrations/slack/integration.py
+++ b/src/sentry/integrations/slack/integration.py
@@ -21,7 +21,6 @@ from sentry.services.hybrid_cloud.organization import RpcOrganizationSummary
 from sentry.shared_integrations.exceptions import ApiError, IntegrationError
 from sentry.tasks.integrations.slack import link_slack_user_identities
 from sentry.utils.http import absolute_uri
-from sentry.utils.json import JSONData
 
 from .client import SlackClient
 from .notifications import SlackNotifyBasicMixin
@@ -132,7 +131,7 @@ class SlackIntegrationProvider(IntegrationProvider):
 
         return [identity_pipeline_view]
 
-    def _get_team_info(self, access_token: str) -> JSONData:
+    def _get_team_info(self, access_token: str) -> Any:
         # Manually add authorization since this method is part of slack installation
         headers = {"Authorization": f"Bearer {access_token}"}
         try:

--- a/src/sentry/integrations/slack/requests/action.py
+++ b/src/sentry/integrations/slack/requests/action.py
@@ -8,7 +8,6 @@ from rest_framework import status
 from sentry.integrations.slack.requests.base import SlackRequest, SlackRequestError
 from sentry.models.group import Group
 from sentry.utils import json
-from sentry.utils.json import JSONData
 
 
 class SlackActionRequest(SlackRequest):
@@ -25,7 +24,7 @@ class SlackActionRequest(SlackRequest):
         return str(self.data.get("type"))
 
     @cached_property
-    def callback_data(self) -> JSONData:
+    def callback_data(self) -> Any:
         """
         We store certain data in ``callback_id`` as JSON. It's a bit hacky, but
         it's the simplest way to store state without saving it on the Sentry

--- a/src/sentry/integrations/slack/utils/rule_status.py
+++ b/src/sentry/integrations/slack/utils/rule_status.py
@@ -1,12 +1,11 @@
 from __future__ import annotations
 
-from typing import Union, cast
+from typing import Any, Union, cast
 from uuid import uuid4
 
 from django.conf import settings
 
 from sentry.utils import json
-from sentry.utils.json import JSONData
 from sentry.utils.redis import redis_clusters
 
 SLACK_FAILED_MESSAGE = (
@@ -35,7 +34,7 @@ class RedisRuleStatus:
         value = self._format_value(status, rule_id, error_message)
         self.client.set(self._get_redis_key(), f"{value}", ex=60 * 60)
 
-    def get_value(self) -> JSONData:
+    def get_value(self) -> Any:
         key = self._get_redis_key()
         value = self.client.get(key)
         return json.loads_experimental(

--- a/src/sentry/integrations/vsts/integration.py
+++ b/src/sentry/integrations/vsts/integration.py
@@ -44,7 +44,6 @@ from sentry.shared_integrations.exceptions import (
 from sentry.silo.base import SiloMode
 from sentry.tasks.integrations import migrate_repo
 from sentry.utils.http import absolute_uri
-from sentry.utils.json import JSONData
 from sentry.web.helpers import render_to_response
 
 from .client import VstsApiClient, VstsSetupApiClient
@@ -610,7 +609,7 @@ class AccountConfigView(PipelineView):
                 return account
         return None
 
-    def get_accounts(self, access_token: str, user_id: int) -> JSONData | None:
+    def get_accounts(self, access_token: str, user_id: int) -> Any | None:
         url = (
             f"https://app.vssps.visualstudio.com/_apis/accounts?memberId={user_id}&api-version=4.1"
         )

--- a/src/sentry/lang/native/sources.py
+++ b/src/sentry/lang/native/sources.py
@@ -434,7 +434,7 @@ def backfill_source(source, original_sources_by_id):
 
 def redact_source_secrets(config_sources: Any) -> Any:
     """
-    Returns a JSONData with all of the secrets redacted from every source.
+    Returns a json data with all of the secrets redacted from every source.
 
     The original value is not mutated in the process; A clone is created
     and returned by this function.

--- a/src/sentry/models/apiapplication.py
+++ b/src/sentry/models/apiapplication.py
@@ -1,5 +1,5 @@
 import secrets
-from typing import ClassVar, Self
+from typing import Any, ClassVar, Self
 from urllib.parse import urlparse
 
 import petname
@@ -20,7 +20,6 @@ from sentry.db.models import (
 )
 from sentry.models.outbox import ControlOutbox, OutboxCategory, OutboxScope, outbox_context
 from sentry.types.region import find_all_region_names
-from sentry.utils.json import JSONData
 
 
 def generate_name():
@@ -134,7 +133,7 @@ class ApiApplication(Model):
 
     @classmethod
     def sanitize_relocation_json(
-        cls, json: JSONData, sanitizer: Sanitizer, model_name: NormalizedModelName | None = None
+        cls, json: Any, sanitizer: Sanitizer, model_name: NormalizedModelName | None = None
     ) -> None:
         model_name = get_model_name(cls) if model_name is None else model_name
         super().sanitize_relocation_json(json, sanitizer, model_name)

--- a/src/sentry/models/apigrant.py
+++ b/src/sentry/models/apigrant.py
@@ -1,6 +1,6 @@
 import secrets
 from datetime import timedelta
-from typing import TypedDict
+from typing import Any, TypedDict
 
 from django.db import models
 from django.utils import timezone
@@ -10,7 +10,6 @@ from sentry.backup.dependencies import NormalizedModelName, get_model_name
 from sentry.backup.sanitize import SanitizableField, Sanitizer
 from sentry.backup.scopes import RelocationScope
 from sentry.db.models import ArrayField, FlexibleForeignKey, Model, control_silo_model
-from sentry.utils.json import JSONData
 
 DEFAULT_EXPIRATION = timedelta(minutes=10)
 
@@ -86,7 +85,7 @@ class ApiGrant(Model):
 
     @classmethod
     def sanitize_relocation_json(
-        cls, json: JSONData, sanitizer: Sanitizer, model_name: NormalizedModelName | None = None
+        cls, json: Any, sanitizer: Sanitizer, model_name: NormalizedModelName | None = None
     ) -> None:
         model_name = get_model_name(cls) if model_name is None else model_name
         super().sanitize_relocation_json(json, sanitizer, model_name)

--- a/src/sentry/models/apikey.py
+++ b/src/sentry/models/apikey.py
@@ -1,5 +1,5 @@
 import secrets
-from typing import ClassVar, Self
+from typing import Any, ClassVar, Self
 
 from django.db import models
 from django.utils import timezone
@@ -14,7 +14,6 @@ from sentry.db.models.outboxes import ReplicatedControlModel
 from sentry.models.apiscopes import HasApiScopes
 from sentry.models.outbox import OutboxCategory
 from sentry.services.hybrid_cloud.replica import region_replica_service
-from sentry.utils.json import JSONData
 
 
 # TODO(dcramer): pull in enum library
@@ -86,7 +85,7 @@ class ApiKey(ReplicatedControlModel, HasApiScopes):
 
     @classmethod
     def sanitize_relocation_json(
-        cls, json: JSONData, sanitizer: Sanitizer, model_name: NormalizedModelName | None = None
+        cls, json: Any, sanitizer: Sanitizer, model_name: NormalizedModelName | None = None
     ) -> None:
         model_name = get_model_name(cls) if model_name is None else model_name
         super().sanitize_relocation_json(json, sanitizer, model_name)

--- a/src/sentry/models/apitoken.py
+++ b/src/sentry/models/apitoken.py
@@ -23,7 +23,6 @@ from sentry.models.apiscopes import HasApiScopes
 from sentry.models.outbox import OutboxCategory
 from sentry.types.region import find_all_region_names
 from sentry.types.token import AuthTokenType
-from sentry.utils.json import JSONData
 
 DEFAULT_EXPIRATION = timedelta(days=30)
 TOKEN_REDACTED = "***REDACTED***"
@@ -322,7 +321,7 @@ class ApiToken(ReplicatedControlModel, HasApiScopes):
 
     @classmethod
     def sanitize_relocation_json(
-        cls, json: JSONData, sanitizer: Sanitizer, model_name: NormalizedModelName | None = None
+        cls, json: Any, sanitizer: Sanitizer, model_name: NormalizedModelName | None = None
     ) -> None:
         model_name = get_model_name(cls) if model_name is None else model_name
         super().sanitize_relocation_json(json, sanitizer, model_name)

--- a/src/sentry/models/authenticator.py
+++ b/src/sentry/models/authenticator.py
@@ -31,7 +31,6 @@ from sentry.db.models.fields.picklefield import PickledObjectField
 from sentry.db.models.outboxes import ControlOutboxProducingModel
 from sentry.models.outbox import ControlOutboxBase, OutboxCategory
 from sentry.types.region import find_regions_for_user
-from sentry.utils.json import JSONData
 
 
 class AuthenticatorManager(BaseManager["Authenticator"]):
@@ -197,7 +196,7 @@ class Authenticator(ControlOutboxProducingModel):
 
     @classmethod
     def sanitize_relocation_json(
-        cls, json: JSONData, sanitizer: Sanitizer, model_name: NormalizedModelName | None = None
+        cls, json: Any, sanitizer: Sanitizer, model_name: NormalizedModelName | None = None
     ) -> None:
         model_name = get_model_name(cls) if model_name is None else model_name
         super().sanitize_relocation_json(json, sanitizer, model_name)

--- a/src/sentry/models/authidentity.py
+++ b/src/sentry/models/authidentity.py
@@ -1,4 +1,5 @@
 from collections.abc import Collection
+from typing import Any
 
 from django.conf import settings
 from django.db import models
@@ -12,7 +13,6 @@ from sentry.db.models.fields.jsonfield import JSONField
 from sentry.db.models.outboxes import ReplicatedControlModel
 from sentry.models.outbox import OutboxCategory
 from sentry.types.region import find_regions_for_orgs
-from sentry.utils.json import JSONData
 
 
 @control_silo_model
@@ -44,7 +44,7 @@ class AuthIdentity(ReplicatedControlModel):
 
     @classmethod
     def sanitize_relocation_json(
-        cls, json: JSONData, sanitizer: Sanitizer, model_name: NormalizedModelName | None = None
+        cls, json: Any, sanitizer: Sanitizer, model_name: NormalizedModelName | None = None
     ) -> None:
         model_name = get_model_name(cls) if model_name is None else model_name
         super().sanitize_relocation_json(json, sanitizer, model_name)

--- a/src/sentry/models/authprovider.py
+++ b/src/sentry/models/authprovider.py
@@ -23,7 +23,6 @@ from sentry.db.models.fields.jsonfield import JSONField
 from sentry.db.models.outboxes import ReplicatedControlModel
 from sentry.models.outbox import ControlOutbox, OutboxCategory, OutboxScope
 from sentry.types.region import find_regions_for_orgs
-from sentry.utils.json import JSONData
 
 logger = logging.getLogger("sentry.authprovider")
 
@@ -228,7 +227,7 @@ class AuthProvider(ReplicatedControlModel):
 
     @classmethod
     def sanitize_relocation_json(
-        cls, json: JSONData, sanitizer: Sanitizer, model_name: NormalizedModelName | None = None
+        cls, json: Any, sanitizer: Sanitizer, model_name: NormalizedModelName | None = None
     ) -> None:
         model_name = get_model_name(cls) if model_name is None else model_name
         super().sanitize_relocation_json(json, sanitizer, model_name)

--- a/src/sentry/models/integrations/integration.py
+++ b/src/sentry/models/integrations/integration.py
@@ -17,7 +17,6 @@ from sentry.models.outbox import ControlOutbox, OutboxCategory, OutboxScope, out
 from sentry.services.hybrid_cloud.organization import RpcOrganization, organization_service
 from sentry.signals import integration_added
 from sentry.types.region import find_regions_for_orgs
-from sentry.utils.json import JSONData
 
 if TYPE_CHECKING:
     from sentry.integrations import (
@@ -164,7 +163,7 @@ class Integration(DefaultFieldsModel):
 
     @classmethod
     def sanitize_relocation_json(
-        cls, json: JSONData, sanitizer: Sanitizer, model_name: NormalizedModelName | None = None
+        cls, json: Any, sanitizer: Sanitizer, model_name: NormalizedModelName | None = None
     ) -> None:
         model_name = get_model_name(cls) if model_name is None else model_name
         super().sanitize_relocation_json(json, sanitizer, model_name)

--- a/src/sentry/models/integrations/organization_integration.py
+++ b/src/sentry/models/integrations/organization_integration.py
@@ -15,7 +15,6 @@ from sentry.db.models.fields.hybrid_cloud_foreign_key import HybridCloudForeignK
 from sentry.db.models.fields.jsonfield import JSONField
 from sentry.db.models.outboxes import ControlOutboxProducingManager, ReplicatedControlModel
 from sentry.models.outbox import OutboxCategory
-from sentry.utils.json import JSONData
 
 
 @control_silo_model
@@ -62,7 +61,7 @@ class OrganizationIntegration(ReplicatedControlModel):
 
     @classmethod
     def sanitize_relocation_json(
-        cls, json: JSONData, sanitizer: Sanitizer, model_name: NormalizedModelName | None = None
+        cls, json: Any, sanitizer: Sanitizer, model_name: NormalizedModelName | None = None
     ) -> None:
         model_name = get_model_name(cls) if model_name is None else model_name
         super().sanitize_relocation_json(json, sanitizer, model_name)

--- a/src/sentry/models/integrations/project_integration.py
+++ b/src/sentry/models/integrations/project_integration.py
@@ -1,10 +1,11 @@
+from typing import Any
+
 from sentry.backup.dependencies import NormalizedModelName, get_model_name
 from sentry.backup.sanitize import SanitizableField, Sanitizer
 from sentry.backup.scopes import RelocationScope
 from sentry.db.models import FlexibleForeignKey, Model, region_silo_model
 from sentry.db.models.fields.hybrid_cloud_foreign_key import HybridCloudForeignKey
 from sentry.db.models.fields.jsonfield import JSONField
-from sentry.utils.json import JSONData
 
 
 @region_silo_model
@@ -27,7 +28,7 @@ class ProjectIntegration(Model):
 
     @classmethod
     def sanitize_relocation_json(
-        cls, json: JSONData, sanitizer: Sanitizer, model_name: NormalizedModelName | None = None
+        cls, json: Any, sanitizer: Sanitizer, model_name: NormalizedModelName | None = None
     ) -> None:
         model_name = get_model_name(cls) if model_name is None else model_name
         super().sanitize_relocation_json(json, sanitizer, model_name)

--- a/src/sentry/models/integrations/sentry_app.py
+++ b/src/sentry/models/integrations/sentry_app.py
@@ -2,7 +2,7 @@ import hmac
 import itertools
 import uuid
 from hashlib import sha256
-from typing import ClassVar
+from typing import Any, ClassVar
 
 from django.db import models, router, transaction
 from django.db.models import QuerySet
@@ -33,7 +33,6 @@ from sentry.models.apiscopes import HasApiScopes
 from sentry.models.outbox import ControlOutbox, OutboxCategory, OutboxScope, outbox_context
 from sentry.types.region import find_all_region_names
 from sentry.utils import metrics
-from sentry.utils.json import JSONData
 
 # When a developer selects to receive "<Resource> Webhooks" it really means
 # listening to a list of specific events. This is a mapping of what those
@@ -240,7 +239,7 @@ class SentryApp(ParanoidModel, HasApiScopes, Model):
 
     @classmethod
     def sanitize_relocation_json(
-        cls, json: JSONData, sanitizer: Sanitizer, model_name: NormalizedModelName | None = None
+        cls, json: Any, sanitizer: Sanitizer, model_name: NormalizedModelName | None = None
     ) -> None:
         model_name = get_model_name(cls) if model_name is None else model_name
         super().sanitize_relocation_json(json, sanitizer, model_name)

--- a/src/sentry/models/integrations/sentry_app_component.py
+++ b/src/sentry/models/integrations/sentry_app_component.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from django.db import models
 
 from sentry.backup.dependencies import NormalizedModelName, get_model_name
@@ -5,7 +7,6 @@ from sentry.backup.sanitize import SanitizableField, Sanitizer
 from sentry.backup.scopes import RelocationScope
 from sentry.db.models import FlexibleForeignKey, Model, UUIDField, control_silo_model
 from sentry.db.models.fields.jsonfield import JSONField
-from sentry.utils.json import JSONData
 
 
 @control_silo_model
@@ -23,7 +24,7 @@ class SentryAppComponent(Model):
 
     @classmethod
     def sanitize_relocation_json(
-        cls, json: JSONData, sanitizer: Sanitizer, model_name: NormalizedModelName | None = None
+        cls, json: Any, sanitizer: Sanitizer, model_name: NormalizedModelName | None = None
     ) -> None:
         model_name = get_model_name(cls) if model_name is None else model_name
         super().sanitize_relocation_json(json, sanitizer, model_name)

--- a/src/sentry/models/notificationaction.py
+++ b/src/sentry/models/notificationaction.py
@@ -15,7 +15,6 @@ from sentry.db.models.fields.hybrid_cloud_foreign_key import HybridCloudForeignK
 from sentry.models.organization import Organization
 from sentry.services.hybrid_cloud.integration import RpcIntegration
 from sentry.types.integrations import ExternalProviders
-from sentry.utils.json import JSONData
 
 logger = logging.getLogger(__name__)
 
@@ -137,7 +136,7 @@ class ActionRegistration(metaclass=ABCMeta):
     @classmethod
     def serialize_available(
         cls, organization: Organization, integrations: list[RpcIntegration] | None = None
-    ) -> list[JSONData]:
+    ) -> list[Any]:
         """
         Optional class method to serialize this registration's available actions to an organization. See NotificationActionsAvailableEndpoint.
 

--- a/src/sentry/models/options/user_option.py
+++ b/src/sentry/models/options/user_option.py
@@ -13,7 +13,6 @@ from sentry.db.models import FlexibleForeignKey, Model, control_silo_model, sane
 from sentry.db.models.fields import PickledObjectField
 from sentry.db.models.fields.hybrid_cloud_foreign_key import HybridCloudForeignKey
 from sentry.db.models.manager import OptionManager, Value
-from sentry.utils.json import JSONData
 
 if TYPE_CHECKING:
     from sentry.models.organization import Organization
@@ -212,7 +211,7 @@ class UserOption(Model):
     __repr__ = sane_repr("user_id", "project_id", "organization_id", "key", "value")
 
     @classmethod
-    def get_relocation_ordinal_fields(self, json_model: JSONData) -> list[str] | None:
+    def get_relocation_ordinal_fields(self, json_model: Any) -> list[str] | None:
         # "global" user options (those with no organization and/or project scope) get a custom
         # ordinal; non-global ones use the default ordering.
         org_id = json_model["fields"].get("organization_id", None)

--- a/src/sentry/models/relay.py
+++ b/src/sentry/models/relay.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from django.db import models
 from django.utils import timezone
 from django.utils.functional import cached_property
@@ -8,7 +10,6 @@ from sentry.backup.mixins import OverwritableConfigMixin
 from sentry.backup.sanitize import SanitizableField, Sanitizer
 from sentry.backup.scopes import RelocationScope
 from sentry.db.models import Model, region_silo_model
-from sentry.utils.json import JSONData
 
 
 @region_silo_model
@@ -29,7 +30,7 @@ class RelayUsage(OverwritableConfigMixin, Model):
 
     @classmethod
     def sanitize_relocation_json(
-        cls, json: JSONData, sanitizer: Sanitizer, model_name: NormalizedModelName | None = None
+        cls, json: Any, sanitizer: Sanitizer, model_name: NormalizedModelName | None = None
     ) -> None:
         model_name = get_model_name(cls) if model_name is None else model_name
         super().sanitize_relocation_json(json, sanitizer, model_name)
@@ -82,7 +83,7 @@ class Relay(OverwritableConfigMixin, Model):
 
     @classmethod
     def sanitize_relocation_json(
-        cls, json: JSONData, sanitizer: Sanitizer, model_name: NormalizedModelName | None = None
+        cls, json: Any, sanitizer: Sanitizer, model_name: NormalizedModelName | None = None
     ) -> None:
         model_name = get_model_name(cls) if model_name is None else model_name
         super().sanitize_relocation_json(json, sanitizer, model_name)

--- a/src/sentry/models/repository.py
+++ b/src/sentry/models/repository.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Any
+
 from django.db import models
 from django.db.models.signals import pre_delete
 from django.utils import timezone
@@ -20,7 +22,6 @@ from sentry.db.models import (
 from sentry.db.models.fields.array import ArrayField
 from sentry.services.hybrid_cloud.user import RpcUser
 from sentry.signals import pending_delete
-from sentry.utils.json import JSONData
 
 
 @region_silo_model
@@ -99,7 +100,7 @@ class Repository(Model, PendingDeletionMixin):
 
     @classmethod
     def sanitize_relocation_json(
-        cls, json: JSONData, sanitizer: Sanitizer, model_name: NormalizedModelName | None = None
+        cls, json: Any, sanitizer: Sanitizer, model_name: NormalizedModelName | None = None
     ) -> None:
         model_name = get_model_name(cls) if model_name is None else model_name
         super().sanitize_relocation_json(json, sanitizer, model_name)

--- a/src/sentry/models/servicehook.py
+++ b/src/sentry/models/servicehook.py
@@ -2,7 +2,7 @@ import hmac
 import secrets
 from functools import cached_property
 from hashlib import sha256
-from typing import ClassVar, Self
+from typing import Any, ClassVar, Self
 from uuid import uuid4
 
 from django.db import models
@@ -24,7 +24,6 @@ from sentry.db.models import (
 from sentry.db.models.fields.bounded import BoundedBigIntegerField
 from sentry.db.models.fields.hybrid_cloud_foreign_key import HybridCloudForeignKey
 from sentry.services.hybrid_cloud.app import app_service
-from sentry.utils.json import JSONData
 
 SERVICE_HOOK_EVENTS = [
     "event.alert",
@@ -122,7 +121,7 @@ class ServiceHook(Model):
 
     @classmethod
     def sanitize_relocation_json(
-        cls, json: JSONData, sanitizer: Sanitizer, model_name: NormalizedModelName | None = None
+        cls, json: Any, sanitizer: Sanitizer, model_name: NormalizedModelName | None = None
     ) -> None:
         model_name = get_model_name(cls) if model_name is None else model_name
         super().sanitize_relocation_json(json, sanitizer, model_name)

--- a/src/sentry/models/user.py
+++ b/src/sentry/models/user.py
@@ -50,7 +50,6 @@ from sentry.services.hybrid_cloud.user import RpcUser
 from sentry.types.integrations import EXTERNAL_PROVIDERS, ExternalProviders
 from sentry.types.region import find_all_region_names, find_regions_for_user
 from sentry.utils.http import absolute_uri
-from sentry.utils.json import JSONData
 from sentry.utils.retries import TimedRetryPolicy
 
 audit_logger = logging.getLogger("sentry.audit.user")
@@ -513,7 +512,7 @@ class User(BaseModel, AbstractBaseUser):
 
     @classmethod
     def sanitize_relocation_json(
-        cls, json: JSONData, sanitizer: Sanitizer, model_name: NormalizedModelName | None = None
+        cls, json: Any, sanitizer: Sanitizer, model_name: NormalizedModelName | None = None
     ) -> None:
         model_name = get_model_name(cls) if model_name is None else model_name
         super().sanitize_relocation_json(json, sanitizer, model_name)

--- a/src/sentry/models/useremail.py
+++ b/src/sentry/models/useremail.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from collections import defaultdict
 from collections.abc import Iterable, Mapping
 from datetime import timedelta
-from typing import TYPE_CHECKING, ClassVar
+from typing import TYPE_CHECKING, Any, ClassVar
 
 from django.conf import settings
 from django.db import models
@@ -25,7 +25,6 @@ from sentry.models.outbox import ControlOutboxBase, OutboxCategory
 from sentry.services.hybrid_cloud.organization.model import RpcOrganization
 from sentry.services.hybrid_cloud.user.model import RpcUser
 from sentry.types.region import find_regions_for_user
-from sentry.utils.json import JSONData
 from sentry.utils.security import get_secure_token
 
 if TYPE_CHECKING:
@@ -152,7 +151,7 @@ class UserEmail(ControlOutboxProducingModel):
 
     @classmethod
     def sanitize_relocation_json(
-        cls, json: JSONData, sanitizer: Sanitizer, model_name: NormalizedModelName | None = None
+        cls, json: Any, sanitizer: Sanitizer, model_name: NormalizedModelName | None = None
     ) -> None:
         model_name = get_model_name(cls) if model_name is None else model_name
         super().sanitize_relocation_json(json, sanitizer, model_name)

--- a/src/sentry/models/userip.py
+++ b/src/sentry/models/userip.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Any
+
 from django.conf import settings
 from django.core.cache import cache
 from django.db import models
@@ -19,7 +21,6 @@ from sentry.models.user import User
 from sentry.services.hybrid_cloud.log import UserIpEvent, log_service
 from sentry.services.hybrid_cloud.user import RpcUser
 from sentry.utils.geo import geo_by_addr
-from sentry.utils.json import JSONData
 
 
 @control_silo_model
@@ -112,7 +113,7 @@ class UserIP(Model):
 
     @classmethod
     def sanitize_relocation_json(
-        cls, json: JSONData, sanitizer: Sanitizer, model_name: NormalizedModelName | None = None
+        cls, json: Any, sanitizer: Sanitizer, model_name: NormalizedModelName | None = None
     ) -> None:
         model_name = get_model_name(cls) if model_name is None else model_name
         super().sanitize_relocation_json(json, sanitizer, model_name)

--- a/src/sentry/runner/commands/backup.py
+++ b/src/sentry/runner/commands/backup.py
@@ -414,7 +414,7 @@ def compare(
         else:
             input = src
 
-        # Now read the input string into memory as JSONData.
+        # Now read the input string into memory as json data.
         try:
             data = json.load(input)
         except json.JSONDecodeError:
@@ -591,7 +591,7 @@ def sanitize_(
     else:
         input = src
 
-    # Now read the input string into memory as JSONData.
+    # Now read the input string into memory as json data.
     try:
         unsanitized_json = json.load(input)
     except json.JSONDecodeError:

--- a/src/sentry/tasks/derive_code_mappings.py
+++ b/src/sentry/tasks/derive_code_mappings.py
@@ -18,7 +18,6 @@ from sentry.models.repository import Repository
 from sentry.services.hybrid_cloud.integration import RpcOrganizationIntegration, integration_service
 from sentry.shared_integrations.exceptions import ApiError
 from sentry.tasks.base import instrumented_task
-from sentry.utils.json import JSONData
 from sentry.utils.locking import UnableToAcquireLock
 from sentry.utils.safe import get_path
 
@@ -33,7 +32,7 @@ if TYPE_CHECKING:
 def process_error(error: ApiError, extra: dict[str, str]) -> None:
     """Log known issues and report unknown ones"""
     if error.json:
-        json_data: JSONData = error.json
+        json_data: Any = error.json
         msg = json_data.get("message")
     else:
         msg = error.text

--- a/src/sentry/testutils/helpers/backups.py
+++ b/src/sentry/testutils/helpers/backups.py
@@ -6,6 +6,7 @@ from copy import deepcopy
 from datetime import UTC, datetime, timedelta
 from functools import cached_property, cmp_to_key
 from pathlib import Path
+from typing import Any
 from unittest.mock import MagicMock
 from uuid import uuid4
 
@@ -100,7 +101,6 @@ from sentry.testutils.factories import get_fixture_path
 from sentry.testutils.silo import assume_test_silo_mode
 from sentry.types.token import AuthTokenType
 from sentry.utils import json
-from sentry.utils.json import JSONData
 
 __all__ = [
     "export_to_file",
@@ -131,7 +131,7 @@ class ValidationError(Exception):
         self.info = info
 
 
-def export_to_file(path: Path, scope: ExportScope, filter_by: set[str] | None = None) -> JSONData:
+def export_to_file(path: Path, scope: ExportScope, filter_by: set[str] | None = None) -> Any:
     """
     Helper function that exports the current state of the database to the specified file.
     """
@@ -178,7 +178,7 @@ def export_to_encrypted_tarball(
     scope: ExportScope,
     *,
     filter_by: set[str] | None = None,
-) -> JSONData:
+) -> Any:
     """
     Helper function that exports the current state of the database to the specified encrypted
     tarball.
@@ -276,7 +276,7 @@ def clear_database(*, reset_pks: bool = False):
             pass
 
 
-def import_export_then_validate(method_name: str, *, reset_pks: bool = True) -> JSONData:
+def import_export_then_validate(method_name: str, *, reset_pks: bool = True) -> Any:
     """
     Test helper that validates that data imported from an export of the current state of the test
     database correctly matches the actual outputted export data.
@@ -669,49 +669,49 @@ class BackupTestCase(TransactionTestCase):
         self.create_exhaustive_sentry_app("test app", owner, org)
         self.create_exhaustive_global_configs(owner)
 
-    def import_export_then_validate(self, out_name, *, reset_pks: bool = True) -> JSONData:
+    def import_export_then_validate(self, out_name, *, reset_pks: bool = True) -> Any:
         return import_export_then_validate(out_name, reset_pks=reset_pks)
 
     @cached_property
-    def _json_of_exhaustive_user_with_maximum_privileges(self) -> JSONData:
+    def _json_of_exhaustive_user_with_maximum_privileges(self) -> Any:
         with open(get_fixture_path("backup", "user-with-maximum-privileges.json")) as backup_file:
             return json.load(backup_file)
 
-    def json_of_exhaustive_user_with_maximum_privileges(self) -> JSONData:
+    def json_of_exhaustive_user_with_maximum_privileges(self) -> Any:
         return deepcopy(self._json_of_exhaustive_user_with_maximum_privileges)
 
     @cached_property
-    def _json_of_exhaustive_user_with_minimum_privileges(self) -> JSONData:
+    def _json_of_exhaustive_user_with_minimum_privileges(self) -> Any:
         with open(get_fixture_path("backup", "user-with-minimum-privileges.json")) as backup_file:
             return json.load(backup_file)
 
-    def json_of_exhaustive_user_with_minimum_privileges(self) -> JSONData:
+    def json_of_exhaustive_user_with_minimum_privileges(self) -> Any:
         return deepcopy(self._json_of_exhaustive_user_with_minimum_privileges)
 
     @cached_property
-    def _json_of_exhaustive_user_with_roles_no_superadmin(self) -> JSONData:
+    def _json_of_exhaustive_user_with_roles_no_superadmin(self) -> Any:
         with open(get_fixture_path("backup", "user-with-roles-no-superadmin.json")) as backup_file:
             return json.load(backup_file)
 
-    def json_of_exhaustive_user_with_roles_no_superadmin(self) -> JSONData:
+    def json_of_exhaustive_user_with_roles_no_superadmin(self) -> Any:
         return deepcopy(self._json_of_exhaustive_user_with_roles_no_superadmin)
 
     @cached_property
-    def _json_of_exhaustive_user_with_superadmin_no_roles(self) -> JSONData:
+    def _json_of_exhaustive_user_with_superadmin_no_roles(self) -> Any:
         with open(get_fixture_path("backup", "user-with-superadmin-no-roles.json")) as backup_file:
             return json.load(backup_file)
 
-    def json_of_exhaustive_user_with_superadmin_no_roles(self) -> JSONData:
+    def json_of_exhaustive_user_with_superadmin_no_roles(self) -> Any:
         return deepcopy(self._json_of_exhaustive_user_with_superadmin_no_roles)
 
     @staticmethod
-    def sort_in_memory_json(json_data: JSONData) -> JSONData:
+    def sort_in_memory_json(json_data: Any) -> Any:
         """
         Helper function that takes an unordered set of JSON models and sorts them first in
         dependency order, and then, within each model, by ascending pk number.
         """
 
-        def sort_by_model_then_pk(a: JSONData, b: JSONData) -> int:
+        def sort_by_model_then_pk(a: Any, b: Any) -> int:
             sorted_deps = sorted_dependencies()
             a_model = get_model(NormalizedModelName(a["model"]))
             b_model = get_model(NormalizedModelName(b["model"]))
@@ -726,7 +726,7 @@ class BackupTestCase(TransactionTestCase):
             key=cmp_to_key(sort_by_model_then_pk),
         )
 
-    def generate_tmp_users_json(self) -> JSONData:
+    def generate_tmp_users_json(self) -> Any:
         """
         Generates an in-memory JSON array of users with different combinations of admin privileges.
         """
@@ -745,7 +745,7 @@ class BackupTestCase(TransactionTestCase):
 
         return self.sort_in_memory_json(max_user + min_user + roles_user + superadmin_user)
 
-    def generate_tmp_users_json_file(self, tmp_path: Path) -> JSONData:
+    def generate_tmp_users_json_file(self, tmp_path: Path) -> Any:
         """
         Generates a file filled with users with different combinations of admin privileges.
         """

--- a/src/sentry/utils/appleconnect/appstore_connect.py
+++ b/src/sentry/utils/appleconnect/appstore_connect.py
@@ -15,7 +15,6 @@ from dateutil.parser import parse as parse_date
 from requests import Session, Timeout
 
 from sentry.utils import jwt, safe, sdk
-from sentry.utils.json import JSONData
 
 logger = logging.getLogger(__name__)
 
@@ -167,7 +166,7 @@ def _get_next_page(response_json: Mapping[str, Any]) -> str | None:
 
 def _get_appstore_info_paged(
     session: Session, credentials: AppConnectCredentials, url: str
-) -> Generator[JSONData, None, None]:
+) -> Generator[Any, None, None]:
     """Iterates through all the pages from a paged response.
 
     App Store Connect responses shares the general format:
@@ -208,14 +207,14 @@ class _IncludedRelations:
        from this.
     """
 
-    def __init__(self, page_data: JSONData):
-        self._items: dict[tuple[_RelType, _RelId], JSONData] = {}
+    def __init__(self, page_data: Any):
+        self._items: dict[tuple[_RelType, _RelId], Any] = {}
         for relation in page_data.get("included", []):
             rel_type = _RelType(relation["type"])
             rel_id = _RelId(relation["id"])
             self._items[(rel_type, rel_id)] = relation
 
-    def get_related(self, data: JSONData, relation: str) -> JSONData | None:
+    def get_related(self, data: Any, relation: str) -> Any | None:
         """Returns the named relation of the object.
 
         ``data`` must be a JSON object which has a ``relationships`` object and
@@ -236,7 +235,7 @@ class _IncludedRelations:
         rel_id = _RelId(rel_ptr_data["id"])
         return self._items[(rel_type, rel_id)]
 
-    def get_multiple_related(self, data: JSONData, relation: str) -> list[JSONData] | None:
+    def get_multiple_related(self, data: Any, relation: str) -> list[Any] | None:
         """Returns a list of all the related objects of the named relation type.
 
         This is like :meth:`get_related` but is for relation types which have a list of
@@ -355,7 +354,7 @@ def get_build_info(
         return build_info
 
 
-def _get_dsym_url(bundles: list[JSONData] | None) -> NoDsymUrl | str:
+def _get_dsym_url(bundles: list[Any] | None) -> NoDsymUrl | str:
     """Returns the dSYMs URL from the extracted from the build bundles."""
     # https://developer.apple.com/documentation/appstoreconnectapi/build/relationships/buildbundles
     # https://developer.apple.com/documentation/appstoreconnectapi/buildbundle/attributes
@@ -372,7 +371,7 @@ def _get_dsym_url(bundles: list[JSONData] | None) -> NoDsymUrl | str:
     if not bundles:
         return NoDsymUrl.NOT_NEEDED
 
-    get_bundle_url: Callable[[JSONData], Any] = lambda bundle: safe.get_path(
+    get_bundle_url: Callable[[Any], Any] = lambda bundle: safe.get_path(
         bundle, "attributes", "dSYMUrl", default=NoDsymUrl.NOT_NEEDED
     )
 

--- a/src/sentry/utils/codecs.py
+++ b/src/sentry/utils/codecs.py
@@ -1,11 +1,10 @@
 import zlib
 from abc import ABC, abstractmethod
-from typing import Generic, TypeVar
+from typing import Any, Generic, TypeVar
 
 import zstandard
 
 from sentry.utils import json
-from sentry.utils.json import JSONData
 
 T = TypeVar("T")
 
@@ -66,15 +65,15 @@ class BytesCodec(Codec[str, bytes]):
         return value.decode(self.encoding)
 
 
-class JSONCodec(Codec[JSONData, str]):
+class JSONCodec(Codec[Any, str]):
     """
     Encode/decode Python data structures to/from JSON-encoded strings.
     """
 
-    def encode(self, value: JSONData) -> str:
+    def encode(self, value: Any) -> str:
         return str(json.dumps(value))
 
-    def decode(self, value: str) -> JSONData:
+    def decode(self, value: str) -> Any:
         return json.loads(value, skip_trace=True)
 
 

--- a/src/sentry/utils/cursors.py
+++ b/src/sentry/utils/cursors.py
@@ -3,8 +3,6 @@ from __future__ import annotations
 from collections.abc import Callable, Iterator, Sequence
 from typing import Any, Protocol, TypeVar, Union
 
-from sentry.utils.json import JSONData
-
 T = TypeVar("T")
 CursorValue = Union[float, int, str]
 
@@ -14,7 +12,7 @@ class KeyCallable(Protocol):
         ...
 
 
-OnResultCallable = Callable[[Sequence[T]], JSONData]
+OnResultCallable = Callable[[Sequence[T]], Any]
 
 
 class Cursor:
@@ -251,7 +249,7 @@ def build_cursor(
     hits: int | None = None,
     max_hits: int | None = None,
     on_results: OnResultCallable[T] | None = None,
-) -> CursorResult[T | JSONData]:
+) -> CursorResult[T | Any]:
     if cursor is None:
         cursor = Cursor(0, 0, 0)
 

--- a/src/sentry/utils/json.py
+++ b/src/sentry/utils/json.py
@@ -110,17 +110,14 @@ _default_escaped_encoder = JSONEncoderForHTML(
 )
 
 
-JSONData = Any  # https://github.com/python/typing/issues/182
-
-
 # NoReturn here is to make this a mypy error to pass kwargs, since they are currently silently dropped
-def dump(value: JSONData, fp: IO[str], **kwargs: NoReturn) -> None:
+def dump(value: Any, fp: IO[str], **kwargs: NoReturn) -> None:
     for chunk in _default_encoder.iterencode(value):
         fp.write(chunk)
 
 
 # NoReturn here is to make this a mypy error to pass kwargs, since they are currently silently dropped
-def dumps(value: JSONData, escape: bool = False, **kwargs: NoReturn) -> str:
+def dumps(value: Any, escape: bool = False, **kwargs: NoReturn) -> str:
     # Legacy use. Do not use. Use dumps_htmlsafe
     if escape:
         return _default_escaped_encoder.encode(value)
@@ -128,14 +125,14 @@ def dumps(value: JSONData, escape: bool = False, **kwargs: NoReturn) -> str:
 
 
 # NoReturn here is to make this a mypy error to pass kwargs, since they are currently silently dropped
-def load(fp: IO[str] | IO[bytes], **kwargs: NoReturn) -> JSONData:
+def load(fp: IO[str] | IO[bytes], **kwargs: NoReturn) -> Any:
     return loads(fp.read())
 
 
 # NoReturn here is to make this a mypy error to pass kwargs, since they are currently silently dropped
 def loads(
     value: str | bytes, use_rapid_json: bool = False, skip_trace: bool = False, **kwargs: NoReturn
-) -> JSONData:
+) -> Any:
     with contextlib.ExitStack() as ctx:
         if not skip_trace:
             ctx.enter_context(sentry_sdk.start_span(op="sentry.utils.json.loads"))
@@ -147,7 +144,7 @@ def loads(
 
 # loads JSON with `orjson` or the default function depending on `option_name`
 # TODO: remove this once we're confident that orjson is working as expected
-def loads_experimental(option_name: str, data: str | bytes, skip_trace: bool = False) -> JSONData:
+def loads_experimental(option_name: str, data: str | bytes, skip_trace: bool = False) -> Any:
     from sentry.features.rollout import in_random_rollout
 
     if in_random_rollout(option_name):
@@ -161,7 +158,7 @@ def loads_experimental(option_name: str, data: str | bytes, skip_trace: bool = F
 
 # dumps JSON with `orjson` or the default function depending on `option_name`
 # TODO: remove this when orjson experiment is successful
-def dumps_experimental(option_name: str, data: JSONData) -> str:
+def dumps_experimental(option_name: str, data: Any) -> str:
     from sentry.features.rollout import in_random_rollout
 
     if in_random_rollout(option_name):
@@ -202,7 +199,6 @@ def prune_empty_keys(obj: Mapping[TKey, TValue | None] | None) -> dict[TKey, TVa
 
 
 __all__ = (
-    "JSONData",
     "JSONDecodeError",
     "JSONEncoder",
     "dump",

--- a/src/sentry/utils/jwt.py
+++ b/src/sentry/utils/jwt.py
@@ -6,6 +6,7 @@ central place which handles JWT in a uniform way.
 from __future__ import annotations
 
 from collections.abc import Mapping
+from typing import Any
 
 import jwt as pyjwt
 from cryptography.hazmat.primitives.asymmetric.rsa import RSAPrivateKey, RSAPublicKey
@@ -17,12 +18,10 @@ from cryptography.hazmat.primitives.serialization import (
 )
 from jwt import DecodeError
 
-from sentry.utils.json import JSONData
-
 __all__ = ["peek_claims", "decode", "encode", "authorization_header", "DecodeError"]
 
 
-def peek_header(token: str) -> JSONData:
+def peek_header(token: str) -> Any:
     """Returns the headers in the JWT token without validation.
 
     Headers are not signed and can thus be spoofed.  You can use these to decide on what
@@ -34,7 +33,7 @@ def peek_header(token: str) -> JSONData:
     return pyjwt.get_unverified_header(token.encode("UTF-8"))
 
 
-def peek_claims(token: str) -> JSONData:
+def peek_claims(token: str) -> Any:
     """Returns the claims (payload) in the JWT token without validation.
 
     These claims can be used to look up the correct key to use in :func:`decode`.
@@ -50,7 +49,7 @@ def decode(
     *,  # Force passing optional arguments by keyword
     audience: str | bool | None = None,
     algorithms: list[str] | None = None,
-) -> dict[str, JSONData]:
+) -> dict[str, Any]:
     """Returns the claims (payload) in the JWT token.
 
     This will raise an exception if the claims can not be validated with the provided key.
@@ -84,11 +83,11 @@ def decode(
 
 
 def encode(
-    payload: JSONData,
+    payload: Any,
     key: str,
     *,  # Force passing optional arguments by keyword
     algorithm: str = "HS256",
-    headers: JSONData | None = None,
+    headers: Any | None = None,
 ) -> str:
     """Encode a JWT token containing the provided payload/claims.
 

--- a/tests/sentry/api/endpoints/test_doc_integrations.py
+++ b/tests/sentry/api/endpoints/test_doc_integrations.py
@@ -11,7 +11,6 @@ from sentry.models.integrations.integration_feature import IntegrationFeature, I
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.helpers.options import override_options
 from sentry.testutils.silo import control_silo_test
-from sentry.utils.json import JSONData
 
 
 class DocIntegrationsTest(APITestCase):
@@ -30,7 +29,7 @@ class DocIntegrationsTest(APITestCase):
             features=[2, 3, 4],
         )
 
-    def get_avatars(self, response: Response) -> list[JSONData]:
+    def get_avatars(self, response: Response) -> list[Any]:
         return [doc.get("avatar") for doc in response.data]
 
 

--- a/tests/sentry/backup/__init__.py
+++ b/tests/sentry/backup/__init__.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from functools import wraps
-from typing import Literal
+from typing import Any, Literal
 
 from django.db import models
 
@@ -15,12 +15,9 @@ from sentry.backup.dependencies import (
     sorted_dependencies,
 )
 from sentry.backup.helpers import DatetimeSafeDjangoJSONEncoder
-from sentry.utils.json import JSONData
 
 
-def verify_models_in_output(
-    expected_models: list[type[models.Model]], actual_json: JSONData
-) -> None:
+def verify_models_in_output(expected_models: list[type[models.Model]], actual_json: Any) -> None:
     """
     A helper context manager that checks that every model that a test "targeted" was actually seen
     in the output, ensuring that we're actually testing the thing we think we are. Additionally,

--- a/tests/sentry/backup/test_comparators.py
+++ b/tests/sentry/backup/test_comparators.py
@@ -1,4 +1,5 @@
 from copy import deepcopy
+from typing import Any
 
 import pytest
 
@@ -21,13 +22,12 @@ from sentry.backup.comparators import (
 )
 from sentry.backup.dependencies import ImportKind, NormalizedModelName, PrimaryKeyMap, dependencies
 from sentry.backup.findings import ComparatorFindingKind, InstanceID
-from sentry.utils.json import JSONData
 
 
 def test_good_comparator_both_sides_existing():
     cmp = DateUpdatedComparator("my_date_field")
     id = InstanceID("sentry.test", 0)
-    present: JSONData = {
+    present: Any = {
         "model": "test",
         "ordinal": 1,
         "pk": 1,
@@ -41,7 +41,7 @@ def test_good_comparator_both_sides_existing():
 def test_good_comparator_neither_side_existing():
     cmp = DateUpdatedComparator("my_date_field")
     id = InstanceID("sentry.test", 0)
-    missing: JSONData = {
+    missing: Any = {
         "model": "test",
         "ordinal": 1,
         "pk": 1,
@@ -53,7 +53,7 @@ def test_good_comparator_neither_side_existing():
 def test_bad_comparator_only_one_side_existing():
     cmp = DateUpdatedComparator("my_date_field")
     id = InstanceID("sentry.test", 0)
-    present: JSONData = {
+    present: Any = {
         "model": "test",
         "ordinal": 1,
         "pk": 1,
@@ -61,7 +61,7 @@ def test_bad_comparator_only_one_side_existing():
             "my_date_field": "2023-06-22T23:12:34.567Z",
         },
     }
-    missing: JSONData = {
+    missing: Any = {
         "model": "test",
         "ordinal": 1,
         "pk": 1,
@@ -95,7 +95,7 @@ def test_bad_comparator_only_one_side_existing():
 def test_good_comparator_both_sides_null():
     cmp = DateUpdatedComparator("my_date_field")
     id = InstanceID("sentry.test", 0)
-    nulled: JSONData = {
+    nulled: Any = {
         "model": "test",
         "ordinal": 1,
         "pk": 1,
@@ -109,7 +109,7 @@ def test_good_comparator_both_sides_null():
 def test_bad_comparator_only_one_side_null():
     cmp = DateUpdatedComparator("my_date_field")
     id = InstanceID("sentry.test", 0)
-    present: JSONData = {
+    present: Any = {
         "model": "test",
         "ordinal": 1,
         "pk": 1,
@@ -117,7 +117,7 @@ def test_bad_comparator_only_one_side_null():
             "my_date_field": "2023-06-22T23:12:34.567Z",
         },
     }
-    nulled: JSONData = {
+    nulled: Any = {
         "model": "test",
         "ordinal": 1,
         "pk": 1,
@@ -153,7 +153,7 @@ def test_bad_comparator_only_one_side_null():
 def test_good_comparator_one_side_null_other_side_missing():
     cmp = DateUpdatedComparator("my_date_field")
     id = InstanceID("sentry.test", 0)
-    nulled: JSONData = {
+    nulled: Any = {
         "model": "test",
         "ordinal": 1,
         "pk": 1,
@@ -161,7 +161,7 @@ def test_good_comparator_one_side_null_other_side_missing():
             "my_date_field": None,
         },
     }
-    missing: JSONData = {
+    missing: Any = {
         "model": "test",
         "ordinal": 1,
         "pk": 1,
@@ -177,7 +177,7 @@ def test_good_comparator_one_side_null_other_side_missing():
 def test_good_auto_suffix_comparator():
     cmp = AutoSuffixComparator("same", "suffixed")
     id = InstanceID("sentry.test", 0)
-    left: JSONData = {
+    left: Any = {
         "model": "test",
         "ordinal": 1,
         "pk": 1,
@@ -186,7 +186,7 @@ def test_good_auto_suffix_comparator():
             "suffixed": "foo-bar",
         },
     }
-    right: JSONData = {
+    right: Any = {
         "model": "test",
         "ordinal": 1,
         "pk": 1,
@@ -201,7 +201,7 @@ def test_good_auto_suffix_comparator():
 def test_bad_auto_suffix_comparator():
     cmp = AutoSuffixComparator("same", "suffixed")
     id = InstanceID("sentry.test", 0)
-    left: JSONData = {
+    left: Any = {
         "model": "test",
         "ordinal": 1,
         "pk": 1,
@@ -210,7 +210,7 @@ def test_bad_auto_suffix_comparator():
             "suffixed": "foo-bar",
         },
     }
-    right: JSONData = {
+    right: Any = {
         "model": "test",
         "ordinal": 1,
         "pk": 1,
@@ -243,7 +243,7 @@ def test_bad_auto_suffix_comparator():
 def test_good_auto_suffix_comparator_existence():
     cmp = AutoSuffixComparator("auto_suffix_field")
     id = InstanceID("sentry.test", 0)
-    present: JSONData = {
+    present: Any = {
         "model": "test",
         "ordinal": 1,
         "pk": 1,
@@ -251,7 +251,7 @@ def test_good_auto_suffix_comparator_existence():
             "auto_suffix_field": "foo-bar",
         },
     }
-    missing: JSONData = {
+    missing: Any = {
         "model": "test",
         "ordinal": 1,
         "pk": 1,
@@ -272,7 +272,7 @@ def test_good_auto_suffix_comparator_existence():
 
 def test_good_auto_suffix_comparator_scrubbed():
     cmp = AutoSuffixComparator("same", "suffixed")
-    left: JSONData = {
+    left: Any = {
         "model": "test",
         "ordinal": 1,
         "pk": 1,
@@ -281,7 +281,7 @@ def test_good_auto_suffix_comparator_scrubbed():
             "suffixed": "foo-bar",
         },
     }
-    right: JSONData = {
+    right: Any = {
         "model": "test",
         "ordinal": 1,
         "pk": 1,
@@ -303,7 +303,7 @@ def test_good_auto_suffix_comparator_scrubbed():
 def test_good_datetime_equality_comparator():
     cmp = DatetimeEqualityComparator("my_date_field")
     id = InstanceID("sentry.test", 0)
-    left: JSONData = {
+    left: Any = {
         "model": "test",
         "ordinal": 1,
         "pk": 1,
@@ -311,7 +311,7 @@ def test_good_datetime_equality_comparator():
             "my_date_field": "2023-06-22T23:00:00.123Z",
         },
     }
-    right: JSONData = {
+    right: Any = {
         "model": "test",
         "ordinal": 1,
         "pk": 1,
@@ -325,7 +325,7 @@ def test_good_datetime_equality_comparator():
 def test_bad_datetime_equality_comparator():
     cmp = DatetimeEqualityComparator("my_date_field")
     id = InstanceID("sentry.test", 0)
-    left: JSONData = {
+    left: Any = {
         "model": "test",
         "ordinal": 1,
         "pk": 1,
@@ -333,7 +333,7 @@ def test_bad_datetime_equality_comparator():
             "my_date_field": "2023-06-22T00:00:00.000Z",
         },
     }
-    right: JSONData = {
+    right: Any = {
         "model": "test",
         "ordinal": 1,
         "pk": 1,
@@ -358,7 +358,7 @@ def test_bad_datetime_equality_comparator():
 def test_good_date_updated_comparator():
     cmp = DateUpdatedComparator("my_date_field")
     id = InstanceID("sentry.test", 0)
-    left: JSONData = {
+    left: Any = {
         "model": "test",
         "ordinal": 1,
         "pk": 1,
@@ -366,7 +366,7 @@ def test_good_date_updated_comparator():
             "my_date_field": "2023-06-22T23:00:00.123Z",
         },
     }
-    right: JSONData = {
+    right: Any = {
         "model": "test",
         "ordinal": 1,
         "pk": 1,
@@ -380,7 +380,7 @@ def test_good_date_updated_comparator():
 def test_bad_date_updated_comparator():
     cmp = DateUpdatedComparator("my_date_field")
     id = InstanceID("sentry.test", 0)
-    left: JSONData = {
+    left: Any = {
         "model": "test",
         "ordinal": 1,
         "pk": 1,
@@ -388,7 +388,7 @@ def test_bad_date_updated_comparator():
             "my_date_field": "2023-06-22T23:12:34.567Z",
         },
     }
-    right: JSONData = {
+    right: Any = {
         "model": "test",
         "ordinal": 1,
         "pk": 1,
@@ -431,7 +431,7 @@ def test_good_email_obfuscating_comparator():
 def test_bad_email_obfuscating_comparator():
     cmp = EmailObfuscatingComparator("one_email", "many_emails")
     id = InstanceID("sentry.test", 0)
-    left: JSONData = {
+    left: Any = {
         "model": "test",
         "ordinal": 1,
         "pk": 1,
@@ -443,7 +443,7 @@ def test_bad_email_obfuscating_comparator():
             ],
         },
     }
-    right: JSONData = {
+    right: Any = {
         "model": "test",
         "ordinal": 1,
         "pk": 1,
@@ -479,7 +479,7 @@ def test_bad_email_obfuscating_comparator():
 def test_good_email_obfuscating_comparator_existence():
     cmp = EmailObfuscatingComparator("email_obfuscating_field")
     id = InstanceID("sentry.test", 0)
-    present: JSONData = {
+    present: Any = {
         "model": "test",
         "ordinal": 1,
         "pk": 1,
@@ -487,7 +487,7 @@ def test_good_email_obfuscating_comparator_existence():
             "email_obfuscating_field": "brian@testing.com",
         },
     }
-    missing: JSONData = {
+    missing: Any = {
         "model": "test",
         "ordinal": 1,
         "pk": 1,
@@ -508,7 +508,7 @@ def test_good_email_obfuscating_comparator_existence():
 
 def test_good_email_obfuscating_comparator_scrubbed():
     cmp = EmailObfuscatingComparator("one_email", "many_emails")
-    left: JSONData = {
+    left: Any = {
         "model": "test",
         "ordinal": 1,
         "pk": 1,
@@ -520,7 +520,7 @@ def test_good_email_obfuscating_comparator_scrubbed():
             ],
         },
     }
-    right: JSONData = {
+    right: Any = {
         "model": "test",
         "ordinal": 1,
         "pk": 1,
@@ -551,7 +551,7 @@ def test_good_email_obfuscating_comparator_scrubbed():
 def test_good_equal_or_removed_comparator_equal():
     cmp = EqualOrRemovedComparator("my_field")
     id = InstanceID("sentry.test", 0)
-    present: JSONData = {
+    present: Any = {
         "model": "test",
         "ordinal": 1,
         "pk": 1,
@@ -567,7 +567,7 @@ def test_good_equal_or_removed_comparator_equal():
 def test_good_equal_or_removed_comparator_not_equal():
     cmp = EqualOrRemovedComparator("my_field")
     id = InstanceID("sentry.test", 0)
-    left: JSONData = {
+    left: Any = {
         "model": "test",
         "ordinal": 1,
         "pk": 1,
@@ -575,7 +575,7 @@ def test_good_equal_or_removed_comparator_not_equal():
             "my_field": "foo",
         },
     }
-    right: JSONData = {
+    right: Any = {
         "model": "test",
         "ordinal": 1,
         "pk": 1,
@@ -603,7 +603,7 @@ def test_good_equal_or_removed_comparator_not_equal():
 def test_good_equal_or_removed_comparator_neither_side_existing():
     cmp = EqualOrRemovedComparator("my_field")
     id = InstanceID("sentry.test", 0)
-    missing: JSONData = {
+    missing: Any = {
         "model": "test",
         "ordinal": 1,
         "pk": 1,
@@ -615,7 +615,7 @@ def test_good_equal_or_removed_comparator_neither_side_existing():
 def test_good_equal_or_removed_comparator_only_right_side_missing():
     cmp = EqualOrRemovedComparator("my_field")
     id = InstanceID("sentry.test", 0)
-    present: JSONData = {
+    present: Any = {
         "model": "test",
         "ordinal": 1,
         "pk": 1,
@@ -623,7 +623,7 @@ def test_good_equal_or_removed_comparator_only_right_side_missing():
             "my_field": "foo",
         },
     }
-    missing: JSONData = {
+    missing: Any = {
         "model": "test",
         "ordinal": 1,
         "pk": 1,
@@ -636,7 +636,7 @@ def test_good_equal_or_removed_comparator_only_right_side_missing():
 def test_bad_equal_or_removed_comparator_only_left_side_missing():
     cmp = EqualOrRemovedComparator("my_field")
     id = InstanceID("sentry.test", 0)
-    present: JSONData = {
+    present: Any = {
         "model": "test",
         "ordinal": 1,
         "pk": 1,
@@ -644,7 +644,7 @@ def test_bad_equal_or_removed_comparator_only_left_side_missing():
             "my_field": "foo",
         },
     }
-    missing: JSONData = {
+    missing: Any = {
         "model": "test",
         "ordinal": 1,
         "pk": 1,
@@ -666,7 +666,7 @@ def test_bad_equal_or_removed_comparator_only_left_side_missing():
 def test_good_equal_or_removed_comparator_both_sides_nulled():
     cmp = EqualOrRemovedComparator("my_field")
     id = InstanceID("sentry.test", 0)
-    nulled: JSONData = {
+    nulled: Any = {
         "model": "test",
         "ordinal": 1,
         "pk": 1,
@@ -680,7 +680,7 @@ def test_good_equal_or_removed_comparator_both_sides_nulled():
 def test_good_equal_or_removed_comparator_only_right_side_nulled():
     cmp = EqualOrRemovedComparator("my_field")
     id = InstanceID("sentry.test", 0)
-    present: JSONData = {
+    present: Any = {
         "model": "test",
         "ordinal": 1,
         "pk": 1,
@@ -688,7 +688,7 @@ def test_good_equal_or_removed_comparator_only_right_side_nulled():
             "my_field": "foo",
         },
     }
-    missing: JSONData = {
+    missing: Any = {
         "model": "test",
         "ordinal": 1,
         "pk": 1,
@@ -703,7 +703,7 @@ def test_good_equal_or_removed_comparator_only_right_side_nulled():
 def test_bad_equal_or_removed_comparator_only_left_side_nulled():
     cmp = EqualOrRemovedComparator("my_field")
     id = InstanceID("sentry.test", 0)
-    present: JSONData = {
+    present: Any = {
         "model": "test",
         "ordinal": 1,
         "pk": 1,
@@ -711,7 +711,7 @@ def test_bad_equal_or_removed_comparator_only_left_side_nulled():
             "my_field": "foo",
         },
     }
-    missing: JSONData = {
+    missing: Any = {
         "model": "test",
         "ordinal": 1,
         "pk": 1,
@@ -735,7 +735,7 @@ def test_bad_equal_or_removed_comparator_only_left_side_nulled():
 def test_good_hash_obfuscating_comparator():
     cmp = HashObfuscatingComparator("one_hash", "many_hashes")
     id = InstanceID("sentry.test", 0)
-    model: JSONData = {
+    model: Any = {
         "model": "test",
         "ordinal": 1,
         "pk": 1,
@@ -753,7 +753,7 @@ def test_good_hash_obfuscating_comparator():
 def test_bad_hash_obfuscating_comparator():
     cmp = HashObfuscatingComparator("one_hash", "many_hashes")
     id = InstanceID("sentry.test", 0)
-    left: JSONData = {
+    left: Any = {
         "model": "test",
         "ordinal": 1,
         "pk": 1,
@@ -765,7 +765,7 @@ def test_bad_hash_obfuscating_comparator():
             ],
         },
     }
-    right: JSONData = {
+    right: Any = {
         "model": "test",
         "ordinal": 1,
         "pk": 1,
@@ -801,7 +801,7 @@ def test_bad_hash_obfuscating_comparator():
 def test_good_hash_obfuscating_comparator_existence():
     cmp = HashObfuscatingComparator("hash_obfuscating_field")
     id = InstanceID("sentry.test", 0)
-    present: JSONData = {
+    present: Any = {
         "model": "test",
         "ordinal": 1,
         "pk": 1,
@@ -809,7 +809,7 @@ def test_good_hash_obfuscating_comparator_existence():
             "hash_obfuscating_field": "foo",
         },
     }
-    missing: JSONData = {
+    missing: Any = {
         "model": "test",
         "ordinal": 1,
         "pk": 1,
@@ -830,7 +830,7 @@ def test_good_hash_obfuscating_comparator_existence():
 
 def test_good_hash_obfuscating_comparator_scrubbed():
     cmp = HashObfuscatingComparator("one_hash", "many_hashes")
-    left: JSONData = {
+    left: Any = {
         "model": "test",
         "ordinal": 1,
         "pk": 1,
@@ -842,7 +842,7 @@ def test_good_hash_obfuscating_comparator_scrubbed():
             ],
         },
     }
-    right: JSONData = {
+    right: Any = {
         "model": "test",
         "ordinal": 1,
         "pk": 1,
@@ -880,7 +880,7 @@ def test_good_foreign_key_comparator():
     left_pk_map.insert(NormalizedModelName("sentry.user"), 12, 1, ImportKind.Inserted)
     right_pk_map = PrimaryKeyMap()
     right_pk_map.insert(NormalizedModelName("sentry.user"), 34, 1, ImportKind.Inserted)
-    left: JSONData = {
+    left: Any = {
         "model": "test",
         "ordinal": 1,
         "pk": 1,
@@ -892,7 +892,7 @@ def test_good_foreign_key_comparator():
             "is_verified": True,
         },
     }
-    right: JSONData = {
+    right: Any = {
         "model": "test",
         "ordinal": 1,
         "pk": 1,
@@ -915,7 +915,7 @@ def test_good_foreign_key_comparator_existence():
         {k: v.model for k, v in deps[NormalizedModelName("sentry.UserEmail")].foreign_keys.items()}
     )
     id = InstanceID("sentry.test", 0)
-    present: JSONData = {
+    present: Any = {
         "model": "test",
         "ordinal": 1,
         "pk": 1,
@@ -927,7 +927,7 @@ def test_good_foreign_key_comparator_existence():
             "is_verified": True,
         },
     }
-    missing: JSONData = {
+    missing: Any = {
         "model": "test",
         "ordinal": 1,
         "pk": 1,
@@ -956,7 +956,7 @@ def test_good_foreign_key_comparator_scrubbed():
     cmp = ForeignKeyComparator(
         {k: v.model for k, v in deps[NormalizedModelName("sentry.UserEmail")].foreign_keys.items()}
     )
-    left: JSONData = {
+    left: Any = {
         "model": "test",
         "ordinal": 1,
         "pk": 1,
@@ -987,7 +987,7 @@ def test_bad_foreign_key_comparator_set_primary_key_maps_not_called():
     left_pk_map.insert(NormalizedModelName("sentry.user"), 12, 1, ImportKind.Inserted)
     right_pk_map = PrimaryKeyMap()
     right_pk_map.insert(NormalizedModelName("sentry.user"), 34, 1, ImportKind.Inserted)
-    left: JSONData = {
+    left: Any = {
         "model": "test",
         "ordinal": 1,
         "pk": 1,
@@ -999,7 +999,7 @@ def test_bad_foreign_key_comparator_set_primary_key_maps_not_called():
             "is_verified": True,
         },
     }
-    right: JSONData = {
+    right: Any = {
         "model": "test",
         "ordinal": 1,
         "pk": 1,
@@ -1026,7 +1026,7 @@ def test_bad_foreign_key_comparator_unequal_mapping():
     left_pk_map.insert(NormalizedModelName("sentry.user"), 12, 1, ImportKind.Inserted)
     right_pk_map = PrimaryKeyMap()
     right_pk_map.insert(NormalizedModelName("sentry.user"), 34, 2, ImportKind.Inserted)
-    left: JSONData = {
+    left: Any = {
         "model": "test",
         "ordinal": 1,
         "pk": 1,
@@ -1038,7 +1038,7 @@ def test_bad_foreign_key_comparator_unequal_mapping():
             "is_verified": True,
         },
     }
-    right: JSONData = {
+    right: Any = {
         "model": "test",
         "ordinal": 1,
         "pk": 1,
@@ -1074,7 +1074,7 @@ def test_bad_foreign_key_comparator_missing_mapping():
     id = InstanceID("sentry.useremail", 0)
     left_pk_map = PrimaryKeyMap()
     right_pk_map = PrimaryKeyMap()
-    left: JSONData = {
+    left: Any = {
         "model": "test",
         "ordinal": 1,
         "pk": 1,
@@ -1086,7 +1086,7 @@ def test_bad_foreign_key_comparator_missing_mapping():
             "is_verified": True,
         },
     }
-    right: JSONData = {
+    right: Any = {
         "model": "test",
         "ordinal": 1,
         "pk": 1,
@@ -1125,7 +1125,7 @@ def test_bad_foreign_key_comparator_missing_mapping():
 def test_good_ignored_comparator():
     cmp = IgnoredComparator("ignored_field")
     id = InstanceID("sentry.test", 0)
-    model: JSONData = {
+    model: Any = {
         "model": "test",
         "ordinal": 1,
         "pk": 1,
@@ -1140,7 +1140,7 @@ def test_good_ignored_comparator():
 def test_good_ignored_comparator_existence():
     cmp = IgnoredComparator("ignored_field")
     id = InstanceID("sentry.test", 0)
-    present: JSONData = {
+    present: Any = {
         "model": "test",
         "ordinal": 1,
         "pk": 1,
@@ -1148,7 +1148,7 @@ def test_good_ignored_comparator_existence():
             "ignored_field": "foo",
         },
     }
-    missing: JSONData = {
+    missing: Any = {
         "model": "test",
         "ordinal": 1,
         "pk": 1,
@@ -1160,7 +1160,7 @@ def test_good_ignored_comparator_existence():
 
 def test_good_ignored_comparator_scrubbed():
     cmp = IgnoredComparator("ignored_field")
-    left: JSONData = {
+    left: Any = {
         "model": "test",
         "ordinal": 1,
         "pk": 1,
@@ -1183,7 +1183,7 @@ def test_good_ignored_comparator_scrubbed():
 def test_good_secret_hex_comparator():
     cmp = SecretHexComparator(8, "equal", "unequal")
     id = InstanceID("sentry.test", 0)
-    left: JSONData = {
+    left: Any = {
         "model": "test",
         "ordinal": 1,
         "pk": 1,
@@ -1192,7 +1192,7 @@ def test_good_secret_hex_comparator():
             "unequal": "3e04f551c7219550",
         },
     }
-    right: JSONData = {
+    right: Any = {
         "model": "test",
         "ordinal": 1,
         "pk": 1,
@@ -1207,7 +1207,7 @@ def test_good_secret_hex_comparator():
 def test_bad_secret_hex_comparator():
     cmp = SecretHexComparator(8, "same", "invalid_left", "invalid_right")
     id = InstanceID("sentry.test", 0)
-    left: JSONData = {
+    left: Any = {
         "model": "test",
         "ordinal": 1,
         "pk": 1,
@@ -1217,7 +1217,7 @@ def test_bad_secret_hex_comparator():
             "invalid_right": "50a7e2c7e3ca35fc",
         },
     }
-    right: JSONData = {
+    right: Any = {
         "model": "test",
         "ordinal": 1,
         "pk": 1,
@@ -1254,7 +1254,7 @@ def test_bad_secret_hex_comparator():
 
 def test_good_secret_hex_comparator_scrubbed():
     cmp = SecretHexComparator(8, "secret_hex_field")
-    left: JSONData = {
+    left: Any = {
         "model": "test",
         "ordinal": 1,
         "pk": 1,
@@ -1262,7 +1262,7 @@ def test_good_secret_hex_comparator_scrubbed():
             "secret_hex_field": "3e04f551c7219550",
         },
     }
-    right: JSONData = {
+    right: Any = {
         "model": "test",
         "ordinal": 1,
         "pk": 1,
@@ -1281,7 +1281,7 @@ def test_good_secret_hex_comparator_scrubbed():
 def test_good_subscription_id_comparator():
     cmp = SubscriptionIDComparator("subscription_id_field")
     id = InstanceID("sentry.test", 0)
-    left: JSONData = {
+    left: Any = {
         "model": "test",
         "ordinal": 1,
         "pk": 1,
@@ -1289,7 +1289,7 @@ def test_good_subscription_id_comparator():
             "subscription_id_field": "0/12363aae153911eeac590242ac130004",
         },
     }
-    right: JSONData = {
+    right: Any = {
         "model": "test",
         "ordinal": 1,
         "pk": 1,
@@ -1303,7 +1303,7 @@ def test_good_subscription_id_comparator():
 def test_bad_subscription_id_comparator():
     cmp = SubscriptionIDComparator("same", "invalid_left", "invalid_right")
     id = InstanceID("sentry.test", 0)
-    left: JSONData = {
+    left: Any = {
         "model": "test",
         "ordinal": 1,
         "pk": 1,
@@ -1313,7 +1313,7 @@ def test_bad_subscription_id_comparator():
             "invalid_right": "0/12363aae153911eeac590242ac130004",
         },
     }
-    right: JSONData = {
+    right: Any = {
         "model": "test",
         "ordinal": 1,
         "pk": 1,
@@ -1360,7 +1360,7 @@ def test_bad_subscription_id_comparator():
 def test_good_subscription_id_comparator_existence():
     cmp = SubscriptionIDComparator("subscription_id_field")
     id = InstanceID("sentry.test", 0)
-    present: JSONData = {
+    present: Any = {
         "model": "test",
         "ordinal": 1,
         "pk": 1,
@@ -1368,7 +1368,7 @@ def test_good_subscription_id_comparator_existence():
             "subscription_id_field": "0/45663aae153911eeac590242acabc123",
         },
     }
-    missing: JSONData = {
+    missing: Any = {
         "model": "test",
         "ordinal": 1,
         "pk": 1,
@@ -1389,7 +1389,7 @@ def test_good_subscription_id_comparator_existence():
 
 def test_good_subscription_id_comparator_scrubbed():
     cmp = SubscriptionIDComparator("subscription_id_field")
-    left: JSONData = {
+    left: Any = {
         "model": "test",
         "ordinal": 1,
         "pk": 1,
@@ -1397,7 +1397,7 @@ def test_good_subscription_id_comparator_scrubbed():
             "subscription_id_field": "0/12363aae153911eeac590242ac130004",
         },
     }
-    right: JSONData = {
+    right: Any = {
         "model": "test",
         "ordinal": 1,
         "pk": 1,
@@ -1416,7 +1416,7 @@ def test_good_subscription_id_comparator_scrubbed():
 def test_good_unordered_list_comparator():
     cmp = UnorderedListComparator("ordered", "unordered")
     id = InstanceID("sentry.test", 0)
-    left: JSONData = {
+    left: Any = {
         "model": "test",
         "ordinal": 1,
         "pk": 1,
@@ -1425,7 +1425,7 @@ def test_good_unordered_list_comparator():
             "unordered": ["b", "a", "c"],
         },
     }
-    right: JSONData = {
+    right: Any = {
         "model": "test",
         "ordinal": 1,
         "pk": 1,
@@ -1440,7 +1440,7 @@ def test_good_unordered_list_comparator():
 def test_bad_unordered_list_comparator():
     cmp = UnorderedListComparator("unequal")
     id = InstanceID("sentry.test", 0)
-    left: JSONData = {
+    left: Any = {
         "model": "test",
         "ordinal": 1,
         "pk": 1,
@@ -1448,7 +1448,7 @@ def test_bad_unordered_list_comparator():
             "unequal": ["b", "a"],
         },
     }
-    right: JSONData = {
+    right: Any = {
         "model": "test",
         "ordinal": 1,
         "pk": 1,
@@ -1474,7 +1474,7 @@ def test_bad_unordered_list_comparator():
 def test_good_unordered_list_comparator_existence():
     cmp = UnorderedListComparator("unordered_list_field")
     id = InstanceID("sentry.test", 0)
-    present: JSONData = {
+    present: Any = {
         "model": "test",
         "ordinal": 1,
         "pk": 1,
@@ -1482,7 +1482,7 @@ def test_good_unordered_list_comparator_existence():
             "unordered_list_field": ["a", "b", "c"],
         },
     }
-    missing: JSONData = {
+    missing: Any = {
         "model": "test",
         "ordinal": 1,
         "pk": 1,
@@ -1503,7 +1503,7 @@ def test_good_unordered_list_comparator_existence():
 
 def test_good_unordered_list_comparator_scrubbed():
     cmp = UnorderedListComparator("unordered_list_field")
-    left: JSONData = {
+    left: Any = {
         "model": "test",
         "ordinal": 1,
         "pk": 1,
@@ -1511,7 +1511,7 @@ def test_good_unordered_list_comparator_scrubbed():
             "unordered_list_field": ["a", "b", "c"],
         },
     }
-    right: JSONData = {
+    right: Any = {
         "model": "test",
         "ordinal": 1,
         "pk": 1,
@@ -1530,7 +1530,7 @@ def test_good_unordered_list_comparator_scrubbed():
 def test_good_uuid4_comparator():
     cmp = UUID4Comparator("guid_field")
     id = InstanceID("sentry.test", 0)
-    left: JSONData = {
+    left: Any = {
         "model": "test",
         "ordinal": 1,
         "pk": 1,
@@ -1538,7 +1538,7 @@ def test_good_uuid4_comparator():
             "guid_field": "4c79eea3-8a71-4b99-b291-1f6a906fbb47",
         },
     }
-    right: JSONData = {
+    right: Any = {
         "model": "test",
         "ordinal": 1,
         "pk": 1,
@@ -1552,7 +1552,7 @@ def test_good_uuid4_comparator():
 def test_bad_uuid4_comparator():
     cmp = UUID4Comparator("same", "invalid_left", "invalid_right")
     id = InstanceID("sentry.test", 0)
-    left: JSONData = {
+    left: Any = {
         "model": "test",
         "ordinal": 1,
         "pk": 1,
@@ -1562,7 +1562,7 @@ def test_bad_uuid4_comparator():
             "invalid_right": "bb41a040-b413-4b89-aa03-179470d9ee05",
         },
     }
-    right: JSONData = {
+    right: Any = {
         "model": "test",
         "ordinal": 1,
         "pk": 1,
@@ -1608,7 +1608,7 @@ def test_bad_uuid4_comparator():
 
 def test_good_uuid4_comparator_scrubbed():
     cmp = UUID4Comparator("guid_field")
-    left: JSONData = {
+    left: Any = {
         "model": "test",
         "ordinal": 1,
         "pk": 1,
@@ -1616,7 +1616,7 @@ def test_good_uuid4_comparator_scrubbed():
             "guid_field": "4c79eea3-8a71-4b99-b291-1f6a906fbb47",
         },
     }
-    right: JSONData = {
+    right: Any = {
         "model": "test",
         "ordinal": 1,
         "pk": 1,
@@ -1635,7 +1635,7 @@ def test_good_uuid4_comparator_scrubbed():
 def test_good_user_password_obfuscating_comparator_claimed_user():
     cmp = UserPasswordObfuscatingComparator()
     id = InstanceID("sentry.test", 0)
-    model: JSONData = {
+    model: Any = {
         "model": "test",
         "ordinal": 1,
         "pk": 1,
@@ -1652,7 +1652,7 @@ def test_good_user_password_obfuscating_comparator_claimed_user():
 def test_good_user_password_obfuscating_comparator_claimed_user_never_changed_password():
     cmp = UserPasswordObfuscatingComparator()
     id = InstanceID("sentry.test", 0)
-    missing: JSONData = {
+    missing: Any = {
         "model": "test",
         "ordinal": 1,
         "pk": 1,
@@ -1663,7 +1663,7 @@ def test_good_user_password_obfuscating_comparator_claimed_user_never_changed_pa
             "is_password_expired": True,
         },
     }
-    nulled: JSONData = {
+    nulled: Any = {
         "model": "test",
         "ordinal": 1,
         "pk": 1,
@@ -1681,7 +1681,7 @@ def test_good_user_password_obfuscating_comparator_claimed_user_never_changed_pa
 def test_good_user_password_obfuscating_comparator_newly_unclaimed_user():
     cmp = UserPasswordObfuscatingComparator()
     id = InstanceID("sentry.test", 0)
-    left: JSONData = {
+    left: Any = {
         "model": "test",
         "ordinal": 1,
         "pk": 1,
@@ -1692,7 +1692,7 @@ def test_good_user_password_obfuscating_comparator_newly_unclaimed_user():
             "is_password_expired": True,
         },
     }
-    right: JSONData = {
+    right: Any = {
         "model": "test",
         "ordinal": 1,
         "pk": 1,
@@ -1709,7 +1709,7 @@ def test_good_user_password_obfuscating_comparator_newly_unclaimed_user():
 def test_good_user_password_obfuscating_comparator_newly_unclaimed_user_never_changed_password():
     cmp = UserPasswordObfuscatingComparator()
     id = InstanceID("sentry.test", 0)
-    left: JSONData = {
+    left: Any = {
         "model": "test",
         "ordinal": 1,
         "pk": 1,
@@ -1720,7 +1720,7 @@ def test_good_user_password_obfuscating_comparator_newly_unclaimed_user_never_ch
             "is_password_expired": False,
         },
     }
-    right: JSONData = {
+    right: Any = {
         "model": "test",
         "ordinal": 1,
         "pk": 1,
@@ -1737,7 +1737,7 @@ def test_good_user_password_obfuscating_comparator_newly_unclaimed_user_never_ch
 def test_good_user_password_obfuscating_comparator_already_unclaimed_user():
     cmp = UserPasswordObfuscatingComparator()
     id = InstanceID("sentry.test", 0)
-    left: JSONData = {
+    left: Any = {
         "model": "test",
         "ordinal": 1,
         "pk": 1,
@@ -1748,7 +1748,7 @@ def test_good_user_password_obfuscating_comparator_already_unclaimed_user():
             "is_password_expired": False,
         },
     }
-    right: JSONData = {
+    right: Any = {
         "model": "test",
         "ordinal": 1,
         "pk": 1,
@@ -1765,7 +1765,7 @@ def test_good_user_password_obfuscating_comparator_already_unclaimed_user():
 def test_bad_user_password_obfuscating_comparator_claimed_user_password_changed():
     cmp = UserPasswordObfuscatingComparator()
     id = InstanceID("sentry.test", 0)
-    left: JSONData = {
+    left: Any = {
         "model": "test",
         "ordinal": 1,
         "pk": 1,
@@ -1776,7 +1776,7 @@ def test_bad_user_password_obfuscating_comparator_claimed_user_password_changed(
             "is_password_expired": False,
         },
     }
-    right: JSONData = {
+    right: Any = {
         "model": "test",
         "ordinal": 1,
         "pk": 1,
@@ -1804,7 +1804,7 @@ def test_bad_user_password_obfuscating_comparator_claimed_user_password_changed(
 def test_bad_user_password_obfuscating_comparator_newly_unclaimed_user_password_unchanged():
     cmp = UserPasswordObfuscatingComparator()
     id = InstanceID("sentry.test", 0)
-    left: JSONData = {
+    left: Any = {
         "model": "test",
         "ordinal": 1,
         "pk": 1,
@@ -1815,7 +1815,7 @@ def test_bad_user_password_obfuscating_comparator_newly_unclaimed_user_password_
             "is_password_expired": False,
         },
     }
-    right: JSONData = {
+    right: Any = {
         "model": "test",
         "ordinal": 1,
         "pk": 1,
@@ -1842,7 +1842,7 @@ def test_bad_user_password_obfuscating_comparator_newly_unclaimed_user_password_
 def test_bad_user_password_obfuscating_comparator_already_unclaimed_user_password_unchanged():
     cmp = UserPasswordObfuscatingComparator()
     id = InstanceID("sentry.test", 0)
-    left: JSONData = {
+    left: Any = {
         "model": "test",
         "ordinal": 1,
         "pk": 1,
@@ -1853,7 +1853,7 @@ def test_bad_user_password_obfuscating_comparator_already_unclaimed_user_passwor
             "is_password_expired": False,
         },
     }
-    right: JSONData = {
+    right: Any = {
         "model": "test",
         "ordinal": 1,
         "pk": 1,
@@ -1880,7 +1880,7 @@ def test_bad_user_password_obfuscating_comparator_already_unclaimed_user_passwor
 def test_bad_user_password_obfuscating_comparator_impossible_newly_claimed_user():
     cmp = UserPasswordObfuscatingComparator()
     id = InstanceID("sentry.test", 0)
-    left: JSONData = {
+    left: Any = {
         "model": "test",
         "ordinal": 1,
         "pk": 1,
@@ -1891,7 +1891,7 @@ def test_bad_user_password_obfuscating_comparator_impossible_newly_claimed_user(
             "is_password_expired": False,
         },
     }
-    right: JSONData = {
+    right: Any = {
         "model": "test",
         "ordinal": 1,
         "pk": 1,
@@ -1918,7 +1918,7 @@ def test_bad_user_password_obfuscating_comparator_impossible_newly_claimed_user(
 def test_bad_user_password_obfuscating_comparator_unclaimed_user_last_password_change_nulled():
     cmp = UserPasswordObfuscatingComparator()
     id = InstanceID("sentry.test", 0)
-    left: JSONData = {
+    left: Any = {
         "model": "test",
         "ordinal": 1,
         "pk": 1,
@@ -1929,7 +1929,7 @@ def test_bad_user_password_obfuscating_comparator_unclaimed_user_last_password_c
             "is_password_expired": False,
         },
     }
-    right: JSONData = {
+    right: Any = {
         "model": "test",
         "ordinal": 1,
         "pk": 1,
@@ -1956,7 +1956,7 @@ def test_bad_user_password_obfuscating_comparator_unclaimed_user_last_password_c
 def test_bad_user_password_obfuscating_comparator_already_unclaimed_user_password_unexpired():
     cmp = UserPasswordObfuscatingComparator()
     id = InstanceID("sentry.test", 0)
-    left: JSONData = {
+    left: Any = {
         "model": "test",
         "ordinal": 1,
         "pk": 1,
@@ -1967,7 +1967,7 @@ def test_bad_user_password_obfuscating_comparator_already_unclaimed_user_passwor
             "is_password_expired": False,
         },
     }
-    right: JSONData = {
+    right: Any = {
         "model": "test",
         "ordinal": 1,
         "pk": 1,
@@ -1993,7 +1993,7 @@ def test_bad_user_password_obfuscating_comparator_already_unclaimed_user_passwor
 def test_bad_user_password_obfuscating_comparator_newly_unclaimed_user_password_still_expired():
     cmp = UserPasswordObfuscatingComparator()
     id = InstanceID("sentry.test", 0)
-    left: JSONData = {
+    left: Any = {
         "model": "test",
         "ordinal": 1,
         "pk": 1,
@@ -2004,7 +2004,7 @@ def test_bad_user_password_obfuscating_comparator_newly_unclaimed_user_password_
             "is_password_expired": True,
         },
     }
-    right: JSONData = {
+    right: Any = {
         "model": "test",
         "ordinal": 1,
         "pk": 1,
@@ -2031,7 +2031,7 @@ def test_bad_user_password_obfuscating_comparator_newly_unclaimed_user_password_
 def test_good_user_password_obfuscating_comparator_existence():
     cmp = UserPasswordObfuscatingComparator()
     id = InstanceID("sentry.test", 0)
-    present: JSONData = {
+    present: Any = {
         "model": "test",
         "ordinal": 1,
         "pk": 1,
@@ -2039,7 +2039,7 @@ def test_good_user_password_obfuscating_comparator_existence():
             "password": "pbkdf2_sha256$260000$3v4Cyy3TAhp14YCB8Zh7Gq$SjB35BELrwwfOCaiz8O/SdbvhXq+l02BRpKtwxOCTiw=",
         },
     }
-    missing: JSONData = {
+    missing: Any = {
         "model": "test",
         "ordinal": 1,
         "pk": 1,
@@ -2060,7 +2060,7 @@ def test_good_user_password_obfuscating_comparator_existence():
 
 def test_good_user_password_obfuscating_comparator_scrubbed_long():
     cmp = UserPasswordObfuscatingComparator()
-    left: JSONData = {
+    left: Any = {
         "model": "test",
         "ordinal": 1,
         "pk": 1,
@@ -2069,7 +2069,7 @@ def test_good_user_password_obfuscating_comparator_scrubbed_long():
             "password": "pbkdf2_sha256$260000$3v4Cyy3TAhp14YCB8Zh7Gq$SjB35BELrwwfOCaiz8O/SdbvhXq+l02BRpKtwxOCTiw=",
         },
     }
-    right: JSONData = {
+    right: Any = {
         "model": "test",
         "ordinal": 1,
         "pk": 1,
@@ -2092,7 +2092,7 @@ def test_good_user_password_obfuscating_comparator_scrubbed_long():
 
 def test_good_user_password_obfuscating_comparator_scrubbed_medium():
     cmp = UserPasswordObfuscatingComparator()
-    left: JSONData = {
+    left: Any = {
         "model": "test",
         "ordinal": 1,
         "pk": 1,
@@ -2101,7 +2101,7 @@ def test_good_user_password_obfuscating_comparator_scrubbed_medium():
             "password": "sha1$abc123$a0aac0d9559f1e7f4b6931f3918e72ad8ec01c04",
         },
     }
-    right: JSONData = {
+    right: Any = {
         "model": "test",
         "ordinal": 1,
         "pk": 1,
@@ -2120,7 +2120,7 @@ def test_good_user_password_obfuscating_comparator_scrubbed_medium():
 
 def test_good_user_password_obfuscating_comparator_scrubbed_short():
     cmp = UserPasswordObfuscatingComparator()
-    left: JSONData = {
+    left: Any = {
         "model": "test",
         "ordinal": 1,
         "pk": 1,
@@ -2129,7 +2129,7 @@ def test_good_user_password_obfuscating_comparator_scrubbed_short():
             "password": "md5$abc$d2315d2c3883695e40598e56792847ab",
         },
     }
-    right: JSONData = {
+    right: Any = {
         "model": "test",
         "ordinal": 1,
         "pk": 1,

--- a/tests/sentry/backup/test_exports.py
+++ b/tests/sentry/backup/test_exports.py
@@ -25,18 +25,17 @@ from sentry.testutils.helpers.backups import (
     export_to_file,
 )
 from sentry.testutils.helpers.datetime import freeze_time
-from sentry.utils.json import JSONData
 from tests.sentry.backup import get_matching_exportable_models
 
 
 class ExportTestCase(BackupTestCase):
     @staticmethod
-    def count(data: JSONData, model: type[models.base.BaseModel]) -> int:
+    def count(data: Any, model: type[models.base.BaseModel]) -> int:
         return len(list(filter(lambda d: d["model"] == str(get_model_name(model)), data)))
 
     @staticmethod
     def exists(
-        data: JSONData, model: type[models.base.BaseModel], key: str, value: Any | None = None
+        data: Any, model: type[models.base.BaseModel], key: str, value: Any | None = None
     ) -> bool:
         for d in data:
             if d["model"] == str(get_model_name(model)):
@@ -55,7 +54,7 @@ class ExportTestCase(BackupTestCase):
         *,
         scope: ExportScope,
         filter_by: set[str] | None = None,
-    ) -> JSONData:
+    ) -> Any:
         tmp_path = Path(tmp_dir).joinpath(f"{self._testMethodName}.json")
         return export_to_file(tmp_path, scope=scope, filter_by=filter_by)
 
@@ -65,7 +64,7 @@ class ExportTestCase(BackupTestCase):
         *,
         scope: ExportScope,
         filter_by: set[str] | None = None,
-    ) -> JSONData:
+    ) -> Any:
         tmp_path = Path(tmp_dir).joinpath(f"{self._testMethodName}.enc.tar")
         return export_to_encrypted_tarball(tmp_path, scope=scope, filter_by=filter_by)
 
@@ -76,7 +75,7 @@ class ScopingTests(ExportTestCase):
     """
 
     @staticmethod
-    def verify_model_inclusion(data: JSONData, scope: ExportScope) -> None:
+    def verify_model_inclusion(data: Any, scope: ExportScope) -> None:
         """
         Ensure all in-scope models are included, and that no out-of-scope models are included.
         """
@@ -101,7 +100,7 @@ class ScopingTests(ExportTestCase):
             )
 
     def verify_encryption_equality(
-        self, tmp_dir: str, unencrypted: JSONData, scope: ExportScope
+        self, tmp_dir: str, unencrypted: Any, scope: ExportScope
     ) -> None:
         res = validate(
             unencrypted,

--- a/tests/sentry/backup/test_models.py
+++ b/tests/sentry/backup/test_models.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import tempfile
 from pathlib import Path
+from typing import Any
 
 from django.db.models import Model
 
@@ -15,7 +16,6 @@ from sentry.silo.base import SiloMode
 from sentry.testutils.cases import TransactionTestCase
 from sentry.testutils.helpers.backups import export_to_file
 from sentry.testutils.silo import assume_test_silo_mode
-from sentry.utils.json import JSONData
 from tests.sentry.backup import expect_models, verify_models_in_output
 
 DYNAMIC_RELOCATION_SCOPE_TESTED: set[NormalizedModelName] = set()
@@ -28,7 +28,7 @@ class DynamicRelocationScopeTests(TransactionTestCase):
     For models that support different relocation scopes depending on properties of the model instance itself (ie, they have a set for their `__relocation_scope__`, rather than a single value), make sure that this dynamic deduction works correctly.
     """
 
-    def export(self) -> JSONData:
+    def export(self) -> Any:
         with tempfile.TemporaryDirectory() as tmp_dir:
             tmp_path = Path(tmp_dir).joinpath(f"{self._testMethodName}.expect.json")
             return export_to_file(tmp_path, ExportScope.Global)

--- a/tests/sentry/backup/test_rpc.py
+++ b/tests/sentry/backup/test_rpc.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from copy import deepcopy
 from functools import cached_property
+from typing import Any
 from unittest.mock import MagicMock, patch
 from uuid import uuid4
 
@@ -306,15 +307,15 @@ class RpcImportErrorTests(TestCase):
     """
 
     @staticmethod
-    def is_user_model(model: json.JSONData) -> bool:
+    def is_user_model(model: Any) -> bool:
         return NormalizedModelName(model["model"]) == USER_MODEL_NAME
 
     @cached_property
-    def _json_of_exhaustive_user_with_minimum_privileges(self) -> json.JSONData:
+    def _json_of_exhaustive_user_with_minimum_privileges(self) -> Any:
         with open(get_fixture_path("backup", "user-with-minimum-privileges.json")) as backup_file:
             return json.load(backup_file)
 
-    def json_of_exhaustive_user_with_minimum_privileges(self) -> json.JSONData:
+    def json_of_exhaustive_user_with_minimum_privileges(self) -> Any:
         return deepcopy(self._json_of_exhaustive_user_with_minimum_privileges)
 
     def test_bad_invalid_min_ordinal(self):

--- a/tests/sentry/backup/test_sanitize.py
+++ b/tests/sentry/backup/test_sanitize.py
@@ -2,6 +2,7 @@ import os
 from collections import defaultdict
 from collections.abc import Sequence
 from datetime import datetime, timedelta
+from typing import Any
 from unittest.mock import Mock, patch
 
 import pytest
@@ -31,7 +32,6 @@ from sentry.testutils.factories import get_fixture_path
 from sentry.testutils.helpers.backups import BackupTestCase
 from sentry.testutils.silo import strip_silo_mode_test_suffix
 from sentry.utils import json
-from sentry.utils.json import JSONData
 from tests.sentry.backup import expect_models, verify_models_in_output
 
 FAKE_EMAIL = "test@fake.com"
@@ -76,7 +76,7 @@ class FakeSanitizableModel(DefaultFieldsModel):
 
     @classmethod
     def sanitize_relocation_json(
-        cls, json: JSONData, sanitizer: Sanitizer, model_name: NormalizedModelName | None = None
+        cls, json: Any, sanitizer: Sanitizer, model_name: NormalizedModelName | None = None
     ) -> None:
         model_name = get_model_name(cls) if model_name is None else model_name
         super().sanitize_relocation_json(json, sanitizer, model_name)
@@ -89,7 +89,7 @@ class FakeSanitizableModel(DefaultFieldsModel):
 
 @patch("sentry.backup.dependencies.get_model", Mock(return_value=FakeSanitizableModel))
 class SanitizationUnitTests(TestCase):
-    def serialize_to_json_data(self, models: Sequence[FakeSanitizableModel]) -> JSONData:
+    def serialize_to_json_data(self, models: Sequence[FakeSanitizableModel]) -> Any:
         json_string = serialize(
             "json",
             models,
@@ -427,7 +427,7 @@ class SanitizationUnitTests(TestCase):
 
 
 class IntegrationTestCase(TestCase):
-    def sanitize_and_compare(self, unsanitized_json: JSONData) -> JSONData:
+    def sanitize_and_compare(self, unsanitized_json: Any) -> Any:
         root_dir = os.path.dirname(os.path.realpath(__file__))
 
         # Use the same data for monolith and region mode.

--- a/tests/sentry/backup/test_snapshots.py
+++ b/tests/sentry/backup/test_snapshots.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 from tempfile import TemporaryDirectory
+from typing import Any
 
 import pytest
 
@@ -30,7 +31,7 @@ class SnapshotTests(BackupTestCase):
 
     def import_export_fixture_then_validate(
         self, *, tmp_out_path: Path, fixture_file_name: str
-    ) -> json.JSONData:
+    ) -> Any:
         """
         Test helper that validates that data imported from a fixture `.json` file correctly matches
         the actual outputted export data.

--- a/tests/sentry/backup/test_validate.py
+++ b/tests/sentry/backup/test_validate.py
@@ -1,4 +1,5 @@
 from copy import deepcopy
+from typing import Any
 
 from sentry.backup.comparators import get_default_comparators
 from sentry.backup.findings import ComparatorFindingKind, InstanceID
@@ -7,7 +8,7 @@ from sentry.testutils.factories import get_fixture_path
 from sentry.utils import json
 
 
-def copy_model(model: json.JSONData, new_pk: int) -> json.JSONData:
+def copy_model(model: Any, new_pk: int) -> Any:
     new_model = deepcopy(model)
     new_model["pk"] = new_pk
     return new_model

--- a/tests/sentry/tasks/integrations/github/test_open_pr_comment.py
+++ b/tests/sentry/tasks/integrations/github/test_open_pr_comment.py
@@ -1,3 +1,4 @@
+from typing import Any
 from unittest.mock import patch
 
 import pytest
@@ -23,7 +24,6 @@ from sentry.tasks.integrations.github.utils import PullRequestFile, PullRequestI
 from sentry.testutils.cases import IntegrationTestCase, TestCase
 from sentry.testutils.helpers.datetime import before_now, iso_format
 from sentry.testutils.skips import requires_snuba
-from sentry.utils.json import JSONData
 from tests.sentry.tasks.integrations.github.test_pr_comment import GithubCommentTestCase
 
 pytestmark = [requires_snuba]
@@ -240,7 +240,7 @@ class TestGetFilenames(GithubCommentTestCase):
 
     @responses.activate
     def test_get_pr_files(self):
-        data: JSONData = [
+        data: Any = [
             {"filename": "bar.py", "status": "modified", "patch": "b"},
             {"filename": "baz.py", "status": "modified"},
         ]


### PR DESCRIPTION
By default JSONData is defined as Any. With `orjson`, we don't need `utils/json.py` and can slowly remove it.

Reduces cyclic dependencies.