### PR TITLE
fix: accept non-str keys on autofix

### DIFF
--- a/src/sentry/api/endpoints/group_ai_autofix.py
+++ b/src/sentry/api/endpoints/group_ai_autofix.py
@@ -108,7 +108,8 @@ class GroupAutofixEndpoint(GroupEndpoint):
                         if not isinstance(user, AnonymousUser)
                         else None
                     ),
-                }
+                },
+                option=orjson.OPT_NON_STR_KEYS,
             ),
             headers={"content-type": "application/json;charset=utf-8"},
         )


### PR DESCRIPTION
Fixes https://sentry.sentry.io/issues/5326989067/?project=1&referrer=github-pr-bot