### PR TITLE
perf(assignees): Reduce render time of assignee dropdown

### DIFF
--- a/static/app/components/assigneeSelectorDropdown.tsx
+++ b/static/app/components/assigneeSelectorDropdown.tsx
@@ -492,6 +492,7 @@ export default function AssigneeSelectorDropdown({
       <CompactSelect
         searchable
         clearable
+        menuWidth={275}
         disallowEmptySelection={false}
         onClick={e => e.stopPropagation()}
         value={

--- a/static/app/components/assigneeSelectorDropdown.tsx
+++ b/static/app/components/assigneeSelectorDropdown.tsx
@@ -314,9 +314,7 @@ export default function AssigneeSelectorDropdown({
           data-test-id="assignee-option"
           displayName={`${userDisplay}${isCurrentUser ? ' (You)' : ''}`}
           hideEmail
-          user={{
-            ...user,
-          }}
+          user={user}
         />
       ),
       // Jank way to pass assignee type (team or user) into each row
@@ -342,9 +340,7 @@ export default function AssigneeSelectorDropdown({
             hideEmail
             data-test-id="assignee-option"
             displayName={`${assignee.name}${isCurrentUser ? ' (You)' : ''}`}
-            user={{
-              ...(assignee.assignee as User),
-            }}
+            user={assignee.assignee as User}
             description={suggestedReasonTable[assignee.suggestedReason]}
           />
         ),

--- a/static/app/components/assigneeSelectorDropdown.tsx
+++ b/static/app/components/assigneeSelectorDropdown.tsx
@@ -387,7 +387,7 @@ export default function AssigneeSelectorDropdown({
         assignedUser = currentMemberList.find(user => user.id === group.assignedTo?.id);
         if (assignedUser) {
           options.push(makeMemberOption(assignedUser));
-          memList = memList?.filter(member => member.id !== group.assignedTo?.id);
+          memList = memList.filter(member => member.id !== group.assignedTo?.id);
           suggestedAssignees = suggestedAssignees?.filter(suggestedAssignee => {
             return suggestedAssignee.id !== group.assignedTo?.id;
           });
@@ -402,19 +402,19 @@ export default function AssigneeSelectorDropdown({
         suggestedAssignee => suggestedAssignee.id === sessionUser.id
       );
     if (!isUserAssignedOrSuggested) {
-      const currentUser = memList?.find(user => user.id === sessionUser.id);
+      const currentUser = memList.find(user => user.id === sessionUser.id);
       if (currentUser) {
-        memList = memList?.filter(user => user.id !== sessionUser.id);
+        memList = memList.filter(user => user.id !== sessionUser.id);
         // This can't be sessionUser even though they're the same thing
         // because it would bork the tests
-        memList?.unshift(currentUser);
+        memList.unshift(currentUser);
       }
     }
 
     const memberOptions = {
       value: '_members',
       label: t('Members'),
-      options: memList?.map(member => makeMemberOption(member)) ?? [],
+      options: memList.map(member => makeMemberOption(member)) ?? [],
     };
 
     const teamOptions = {

--- a/static/app/components/assigneeSelectorDropdown.tsx
+++ b/static/app/components/assigneeSelectorDropdown.tsx
@@ -171,20 +171,17 @@ export default function AssigneeSelectorDropdown({
   const memberLists = useLegacyStore(MemberListStore);
   const sessionUser = ConfigStore.get('user');
 
-  const currentMemberList = (): User[] | undefined => {
-    return memberList ?? memberLists?.members;
-  };
+  const currentMemberList = memberList ?? memberLists?.members ?? [];
 
   const getSuggestedAssignees = (): SuggestedAssignee[] => {
     const currAssignableTeams = getAssignableTeams();
-    const currMembers = currentMemberList() ?? [];
 
     if (owners !== undefined) {
       // Add team or user from store
       return owners
         .map<SuggestedAssignee | null>(owner => {
           if (owner.type === 'user') {
-            const member = currMembers.find(user => user.id === owner.id);
+            const member = currentMemberList.find(user => user.id === owner.id);
             if (member) {
               return {
                 ...owner,
@@ -220,7 +217,7 @@ export default function AssigneeSelectorDropdown({
         const [suggestionType, suggestionId] = suggestion.owner.split(':');
         const suggestedReasonText = suggestedReasonTable[suggestion.type];
         if (suggestionType === 'user') {
-          const member = currMembers.find(user => user.id === suggestionId);
+          const member = currentMemberList.find(user => user.id === suggestionId);
           if (member) {
             return {
               id: suggestionId,
@@ -278,7 +275,7 @@ export default function AssigneeSelectorDropdown({
     let assignee: User | Actor;
 
     if (type === 'user') {
-      assignee = currentMemberList()?.find(member => member.id === assigneeId) as User;
+      assignee = currentMemberList.find(member => member.id === assigneeId) as User;
     } else {
       const assignedTeam = getAssignableTeams().find(
         assignableTeam => assignableTeam.team.id === assigneeId
@@ -365,7 +362,7 @@ export default function AssigneeSelectorDropdown({
   const makeAllOptions = (): SelectOptionOrSection<string>[] => {
     const options: SelectOptionOrSection<string>[] = [];
 
-    let memList = currentMemberList();
+    let memList = currentMemberList;
     let assignableTeamList = getAssignableTeams();
     let suggestedAssignees = getSuggestedAssignees();
     let assignedUser: User | undefined;
@@ -387,7 +384,7 @@ export default function AssigneeSelectorDropdown({
           });
         }
       } else {
-        assignedUser = memList?.find(user => user.id === group.assignedTo?.id);
+        assignedUser = currentMemberList.find(user => user.id === group.assignedTo?.id);
         if (assignedUser) {
           options.push(makeMemberOption(assignedUser));
           memList = memList?.filter(member => member.id !== group.assignedTo?.id);

--- a/static/app/components/avatar/baseAvatar.tsx
+++ b/static/app/components/avatar/baseAvatar.tsx
@@ -122,21 +122,27 @@ function BaseAvatar({
         width: size,
       };
 
-  return (
-    <Tooltip title={tooltip} disabled={!hasTooltip} {...tooltipOptions}>
-      <StyledBaseAvatar
-        data-test-id={`${type}-avatar`}
-        ref={forwardedRef}
-        className={classNames('avatar', className)}
-        round={!!round}
-        suggested={!!suggested}
-        style={{...sizeStyle, ...style}}
-        title={title}
-        {...props}
-      >
-        {hasError ? backup : imageAvatar}
-      </StyledBaseAvatar>
+  const avatarComponent = (
+    <StyledBaseAvatar
+      data-test-id={`${type}-avatar`}
+      ref={forwardedRef}
+      className={classNames('avatar', className)}
+      round={!!round}
+      suggested={!!suggested}
+      style={{...sizeStyle, ...style}}
+      title={title}
+      {...props}
+    >
+      {hasError ? backup : imageAvatar}
+    </StyledBaseAvatar>
+  );
+
+  return hasTooltip ? (
+    <Tooltip title={tooltip} {...tooltipOptions}>
+      {avatarComponent}
     </Tooltip>
+  ) : (
+    avatarComponent
   );
 }
 

--- a/static/app/components/idBadge/baseBadge.tsx
+++ b/static/app/components/idBadge/baseBadge.tsx
@@ -1,5 +1,4 @@
 import {memo} from 'react';
-import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import Avatar from 'sentry/components/avatar';
@@ -44,12 +43,7 @@ export const BaseBadge = memo(
     const wrapperGap: ValidSize = avatarSize <= 14 ? 0.5 : avatarSize <= 20 ? 0.75 : 1;
 
     return (
-      <Wrapper
-        className={className}
-        css={css`
-          --wrapper-gap: ${space(wrapperGap)};
-        `}
-      >
+      <Wrapper className={className} style={{gap: space(wrapperGap)}}>
         {!hideAvatar && (
           <Avatar
             {...avatarProps}
@@ -77,7 +71,6 @@ export const BaseBadge = memo(
 
 const Wrapper = styled('div')`
   display: flex;
-  gap: var(--wrapper-gap, 0);
   align-items: center;
   flex-shrink: 0;
 `;

--- a/static/app/components/idBadge/baseBadge.tsx
+++ b/static/app/components/idBadge/baseBadge.tsx
@@ -1,4 +1,5 @@
 import {memo} from 'react';
+import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import Avatar from 'sentry/components/avatar';
@@ -43,7 +44,12 @@ export const BaseBadge = memo(
     const wrapperGap: ValidSize = avatarSize <= 14 ? 0.5 : avatarSize <= 20 ? 0.75 : 1;
 
     return (
-      <Wrapper className={className} gap={wrapperGap}>
+      <Wrapper
+        className={className}
+        css={css`
+          --wrapper-gap: ${space(wrapperGap)};
+        `}
+      >
         {!hideAvatar && (
           <Avatar
             {...avatarProps}
@@ -69,9 +75,9 @@ export const BaseBadge = memo(
   }
 );
 
-const Wrapper = styled('div')<{gap: ValidSize}>`
+const Wrapper = styled('div')`
   display: flex;
-  gap: ${p => space(p.gap)};
+  gap: var(--wrapper-gap, 0);
   align-items: center;
   flex-shrink: 0;
 `;


### PR DESCRIPTION
This PR gets rid of a usage of dynamic props in styled components in <baseBadge/> since this is [bad for performance](https://develop.sentry.dev/frontend/using-styled-components/#use-style--css-attributes). It also gets rid of any usages of replaces any usage of idBadge in <assigneeSelectorDropdown/> with userBadge or teamBadge, since idBadge might re-fetch the avatar when we already have it. 

I'm seeing ~~20-30~~ 40-50% faster initial render speeds on local dev. 