### PR TITLE
fix: remove unnecessary list[int] type

### DIFF
--- a/src/sentry/replays/lib/event_linking.py
+++ b/src/sentry/replays/lib/event_linking.py
@@ -15,9 +15,7 @@ class EventLinkKafkaMessage(TypedDict):
     replay_id: str
     project_id: int
     segment_id: None
-    payload: list[
-        int
-    ] | EventLinkPayloadDebugId | EventLinkPayloadInfoId | EventLinkPayloadWarningId | EventLinkPayloadErrorId | EventLinkPayloadFatalId
+    payload: EventLinkPayloadDebugId | EventLinkPayloadInfoId | EventLinkPayloadWarningId | EventLinkPayloadErrorId | EventLinkPayloadFatalId
     retention_days: int
 
 


### PR DESCRIPTION
Follow up for https://github.com/getsentry/sentry/pull/69990

We already removed list of bytes from the type, and no longer need it as the Python type.