### PR TITLE
feat(slack): Add flags to toggle features on organization integration

### DIFF
--- a/src/sentry/api/serializers/models/integration.py
+++ b/src/sentry/api/serializers/models/integration.py
@@ -155,13 +155,12 @@ class OrganizationIntegrationSerializer(Serializer):
         try:
             installation = integration.get_installation(organization_id=obj.organization_id)
         except NotImplementedError:
-            # slack doesn't have an installation implementation
             config_data = obj.config if include_config else None
         else:
             try:
                 # just doing this to avoid querying for an object we already have
                 installation._org_integration = obj
-                config_data = installation.get_config_data() if include_config else None  # type: ignore[assignment]
+                config_data = installation.get_config_data() if include_config else None
                 dynamic_display_information = installation.get_dynamic_display_information()
             except ApiError as e:
                 # If there is an ApiError from our 3rd party integration

--- a/src/sentry/integrations/base.py
+++ b/src/sentry/integrations/base.py
@@ -354,7 +354,7 @@ class IntegrationInstallation:
             config=config,
         )
 
-    def get_config_data(self) -> Mapping[str, str]:
+    def get_config_data(self) -> dict[str, Any]:
         if not self.org_integration:
             return {}
         return self.org_integration.config

--- a/src/sentry/integrations/slack/integration.py
+++ b/src/sentry/integrations/slack/integration.py
@@ -119,7 +119,7 @@ class SlackIntegration(SlackNotifyBasicMixin, IntegrationInstallation):
 
         cleaned_flags_data = data.get(self._FLAGS_KEY, {})
         # ensure we add the default supported flags if they don't already exist
-        for flag_name, default_flag_value in self._SUPPORTED_FLAGS_WITH_DEFAULTS:
+        for flag_name, default_flag_value in self._SUPPORTED_FLAGS_WITH_DEFAULTS.items():
             flag_value = cleaned_flags_data.get(flag_name, None)
             if flag_value is None:
                 cleaned_flags_data[flag_name] = default_flag_value

--- a/src/sentry/integrations/slack/integration.py
+++ b/src/sentry/integrations/slack/integration.py
@@ -72,9 +72,9 @@ _default_logger = logging.getLogger(__name__)
 
 
 class SlackIntegration(SlackNotifyBasicMixin, IntegrationInstallation):
-    _FLAGS_KEY: str = "TOGGLEABLE_FLAGS"
-    _ISSUE_ALERTS_THREAD_FLAG: str = "ISSUE_ALERTS_THREAD_FLAG"
-    _METRIC_ALERTS_THREAD_FLAG: str = "METRIC_ALERTS_THREAD_FLAG"
+    _FLAGS_KEY: str = "toggleableFlags"
+    _ISSUE_ALERTS_THREAD_FLAG: str = "issueAlertsThreadFlag"
+    _METRIC_ALERTS_THREAD_FLAG: str = "metricAlertsThreadFlag"
     _SUPPORTED_FLAGS_WITH_DEFAULTS: dict[str, bool] = {
         _ISSUE_ALERTS_THREAD_FLAG: True,
         _METRIC_ALERTS_THREAD_FLAG: True,

--- a/tests/sentry/integrations/slack/integration/test_slack_integration.py
+++ b/tests/sentry/integrations/slack/integration/test_slack_integration.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from sentry.integrations.slack import SlackIntegration
 from sentry.testutils.cases import TestCase
 from sentry.testutils.silo import control_silo_test
@@ -83,13 +85,13 @@ class TestGetOrganizationConfig(_BaseTestCase):
 @control_silo_test
 class TestUpdateAndCleanFlagsInOrganizationConfig(_BaseTestCase):
     def test_adds_flags_key_when_it_does_not_exist(self) -> None:
-        data = {}
+        data: dict[str, Any] = {}
         self.slack_installation._update_and_clean_flags_in_organization_config(data=data)
 
         assert "TOGGLEABLE_FLAGS" in data
 
     def test_adds_default_flags_key_when_it_does_not_exist(self) -> None:
-        data = {}
+        data: dict[str, Any] = {}
         self.slack_installation._update_and_clean_flags_in_organization_config(data=data)
 
         results = data["TOGGLEABLE_FLAGS"]
@@ -99,7 +101,7 @@ class TestUpdateAndCleanFlagsInOrganizationConfig(_BaseTestCase):
         }
 
     def test_adds_missing_flags(self) -> None:
-        data = {
+        data: dict[str, Any] = {
             "TOGGLEABLE_FLAGS": {
                 "ISSUE_ALERTS_THREAD_FLAG": False,
             }
@@ -113,7 +115,7 @@ class TestUpdateAndCleanFlagsInOrganizationConfig(_BaseTestCase):
         }
 
     def test_corrects_bad_flag_values(self) -> None:
-        data = {
+        data: dict[str, Any] = {
             "TOGGLEABLE_FLAGS": {
                 "ISSUE_ALERTS_THREAD_FLAG": False,
                 "METRIC_ALERTS_THREAD_FLAG": 0,
@@ -136,7 +138,7 @@ class TestUpdateOrganizationConfig(_BaseTestCase):
             integration=self.slack_provider_integration,
             config={},
         )
-        data = {
+        data: dict[str, Any] = {
             "TOGGLEABLE_FLAGS": {
                 "ISSUE_ALERTS_THREAD_FLAG": False,
                 "METRIC_ALERTS_THREAD_FLAG": True,

--- a/tests/sentry/integrations/slack/integration/test_slack_integration.py
+++ b/tests/sentry/integrations/slack/integration/test_slack_integration.py
@@ -16,18 +16,19 @@ class _BaseTestCase(TestCase):
 
 
 @control_silo_test
-class TestGetOrganizationConfig(_BaseTestCase):
+class TestGetConfigData(_BaseTestCase):
     def test_gets_default_flags_when_no_data_exists(self) -> None:
         self.create_organization_integration(
             organization_id=self.organization.id,
             integration=self.slack_provider_integration,
             config={},
         )
-        results = self.slack_installation.get_organization_config()
-        assert results == [
-            ("ISSUE_ALERTS_THREAD_FLAG", True),
-            ("METRIC_ALERTS_THREAD_FLAG", True),
-        ]
+        data = self.slack_installation.get_config_data()
+        results = data.get("TOGGLEABLE_FLAGS")
+        assert results == {
+            "ISSUE_ALERTS_THREAD_FLAG": True,
+            "METRIC_ALERTS_THREAD_FLAG": True,
+        }
 
     def test_gets_missing_flags(self) -> None:
         self.create_organization_integration(
@@ -39,11 +40,12 @@ class TestGetOrganizationConfig(_BaseTestCase):
                 }
             },
         )
-        results = self.slack_installation.get_organization_config()
-        assert results == [
-            ("ISSUE_ALERTS_THREAD_FLAG", False),
-            ("METRIC_ALERTS_THREAD_FLAG", True),
-        ]
+        data = self.slack_installation.get_config_data()
+        results = data.get("TOGGLEABLE_FLAGS")
+        assert results == {
+            "ISSUE_ALERTS_THREAD_FLAG": False,
+            "METRIC_ALERTS_THREAD_FLAG": True,
+        }
 
     def test_gets_correct_data(self) -> None:
         self.create_organization_integration(
@@ -56,30 +58,12 @@ class TestGetOrganizationConfig(_BaseTestCase):
                 }
             },
         )
-        results = self.slack_installation.get_organization_config()
-        assert results == [
-            ("ISSUE_ALERTS_THREAD_FLAG", False),
-            ("METRIC_ALERTS_THREAD_FLAG", False),
-        ]
-
-    def test_ignores_unsupported_flags(self) -> None:
-        self.create_organization_integration(
-            organization_id=self.organization.id,
-            integration=self.slack_provider_integration,
-            config={
-                "TOGGLEABLE_FLAGS": {
-                    "ISSUE_ALERTS_THREAD_FLAG": False,
-                    "METRIC_ALERTS_THREAD_FLAG": False,
-                    "SOME_OTHER_KEY": True,
-                    "KEY": True,
-                }
-            },
-        )
-        results = self.slack_installation.get_organization_config()
-        assert results == [
-            ("ISSUE_ALERTS_THREAD_FLAG", False),
-            ("METRIC_ALERTS_THREAD_FLAG", False),
-        ]
+        data = self.slack_installation.get_config_data()
+        results = data.get("TOGGLEABLE_FLAGS")
+        assert results == {
+            "ISSUE_ALERTS_THREAD_FLAG": False,
+            "METRIC_ALERTS_THREAD_FLAG": False,
+        }
 
 
 @control_silo_test

--- a/tests/sentry/integrations/slack/integration/test_slack_integration.py
+++ b/tests/sentry/integrations/slack/integration/test_slack_integration.py
@@ -1,0 +1,148 @@
+from sentry.integrations.slack import SlackIntegration
+from sentry.testutils.cases import TestCase
+from sentry.testutils.silo import control_silo_test
+
+
+class _BaseTestCase(TestCase):
+    def setUp(self) -> None:
+        self.slack_provider_integration = self.create_provider_integration(
+            provider="slack", name="Slack", metadata={}
+        )
+        self.slack_installation = SlackIntegration(
+            self.slack_provider_integration, self.organization.id
+        )
+
+
+@control_silo_test
+class TestGetOrganizationConfig(_BaseTestCase):
+    def test_gets_default_flags_when_no_data_exists(self) -> None:
+        self.create_organization_integration(
+            organization_id=self.organization.id,
+            integration=self.slack_provider_integration,
+            config={},
+        )
+        results = self.slack_installation.get_organization_config()
+        assert results == [
+            ("ISSUE_ALERTS_THREAD_FLAG", True),
+            ("METRIC_ALERTS_THREAD_FLAG", True),
+        ]
+
+    def test_gets_missing_flags(self) -> None:
+        self.create_organization_integration(
+            organization_id=self.organization.id,
+            integration=self.slack_provider_integration,
+            config={
+                "TOGGLEABLE_FLAGS": {
+                    "ISSUE_ALERTS_THREAD_FLAG": False,
+                }
+            },
+        )
+        results = self.slack_installation.get_organization_config()
+        assert results == [
+            ("ISSUE_ALERTS_THREAD_FLAG", False),
+            ("METRIC_ALERTS_THREAD_FLAG", True),
+        ]
+
+    def test_gets_correct_data(self) -> None:
+        self.create_organization_integration(
+            organization_id=self.organization.id,
+            integration=self.slack_provider_integration,
+            config={
+                "TOGGLEABLE_FLAGS": {
+                    "ISSUE_ALERTS_THREAD_FLAG": False,
+                    "METRIC_ALERTS_THREAD_FLAG": False,
+                }
+            },
+        )
+        results = self.slack_installation.get_organization_config()
+        assert results == [
+            ("ISSUE_ALERTS_THREAD_FLAG", False),
+            ("METRIC_ALERTS_THREAD_FLAG", False),
+        ]
+
+    def test_ignores_unsupported_flags(self) -> None:
+        self.create_organization_integration(
+            organization_id=self.organization.id,
+            integration=self.slack_provider_integration,
+            config={
+                "TOGGLEABLE_FLAGS": {
+                    "ISSUE_ALERTS_THREAD_FLAG": False,
+                    "METRIC_ALERTS_THREAD_FLAG": False,
+                    "SOME_OTHER_KEY": True,
+                    "KEY": True,
+                }
+            },
+        )
+        results = self.slack_installation.get_organization_config()
+        assert results == [
+            ("ISSUE_ALERTS_THREAD_FLAG", False),
+            ("METRIC_ALERTS_THREAD_FLAG", False),
+        ]
+
+
+@control_silo_test
+class TestUpdateAndCleanFlagsInOrganizationConfig(_BaseTestCase):
+    def test_adds_flags_key_when_it_does_not_exist(self) -> None:
+        data = {}
+        self.slack_installation._update_and_clean_flags_in_organization_config(data=data)
+
+        assert "TOGGLEABLE_FLAGS" in data
+
+    def test_adds_default_flags_key_when_it_does_not_exist(self) -> None:
+        data = {}
+        self.slack_installation._update_and_clean_flags_in_organization_config(data=data)
+
+        results = data["TOGGLEABLE_FLAGS"]
+        assert results == {
+            "ISSUE_ALERTS_THREAD_FLAG": True,
+            "METRIC_ALERTS_THREAD_FLAG": True,
+        }
+
+    def test_adds_missing_flags(self) -> None:
+        data = {
+            "TOGGLEABLE_FLAGS": {
+                "ISSUE_ALERTS_THREAD_FLAG": False,
+            }
+        }
+        self.slack_installation._update_and_clean_flags_in_organization_config(data=data)
+
+        results = data["TOGGLEABLE_FLAGS"]
+        assert results == {
+            "ISSUE_ALERTS_THREAD_FLAG": False,
+            "METRIC_ALERTS_THREAD_FLAG": True,
+        }
+
+    def test_corrects_bad_flag_values(self) -> None:
+        data = {
+            "TOGGLEABLE_FLAGS": {
+                "ISSUE_ALERTS_THREAD_FLAG": False,
+                "METRIC_ALERTS_THREAD_FLAG": 0,
+            }
+        }
+        self.slack_installation._update_and_clean_flags_in_organization_config(data=data)
+
+        results = data["TOGGLEABLE_FLAGS"]
+        assert results == {
+            "ISSUE_ALERTS_THREAD_FLAG": False,
+            "METRIC_ALERTS_THREAD_FLAG": True,
+        }
+
+
+@control_silo_test
+class TestUpdateOrganizationConfig(_BaseTestCase):
+    def test_saves_flags(self) -> None:
+        org_integration = self.create_organization_integration(
+            organization_id=self.organization.id,
+            integration=self.slack_provider_integration,
+            config={},
+        )
+        data = {
+            "TOGGLEABLE_FLAGS": {
+                "ISSUE_ALERTS_THREAD_FLAG": False,
+                "METRIC_ALERTS_THREAD_FLAG": True,
+            }
+        }
+        self.slack_installation.update_organization_config(data=data)
+
+        org_integration.refresh_from_db()
+        assert org_integration.config == data

--- a/tests/sentry/integrations/slack/integration/test_slack_integration.py
+++ b/tests/sentry/integrations/slack/integration/test_slack_integration.py
@@ -24,10 +24,10 @@ class TestGetConfigData(_BaseTestCase):
             config={},
         )
         data = self.slack_installation.get_config_data()
-        results = data.get("TOGGLEABLE_FLAGS")
+        results = data.get("toggleableFlags")
         assert results == {
-            "ISSUE_ALERTS_THREAD_FLAG": True,
-            "METRIC_ALERTS_THREAD_FLAG": True,
+            "issueAlertsThreadFlag": True,
+            "metricAlertsThreadFlag": True,
         }
 
     def test_gets_missing_flags(self) -> None:
@@ -35,16 +35,16 @@ class TestGetConfigData(_BaseTestCase):
             organization_id=self.organization.id,
             integration=self.slack_provider_integration,
             config={
-                "TOGGLEABLE_FLAGS": {
-                    "ISSUE_ALERTS_THREAD_FLAG": False,
+                "toggleableFlags": {
+                    "issueAlertsThreadFlag": False,
                 }
             },
         )
         data = self.slack_installation.get_config_data()
-        results = data.get("TOGGLEABLE_FLAGS")
+        results = data.get("toggleableFlags")
         assert results == {
-            "ISSUE_ALERTS_THREAD_FLAG": False,
-            "METRIC_ALERTS_THREAD_FLAG": True,
+            "issueAlertsThreadFlag": False,
+            "metricAlertsThreadFlag": True,
         }
 
     def test_gets_correct_data(self) -> None:
@@ -52,17 +52,17 @@ class TestGetConfigData(_BaseTestCase):
             organization_id=self.organization.id,
             integration=self.slack_provider_integration,
             config={
-                "TOGGLEABLE_FLAGS": {
-                    "ISSUE_ALERTS_THREAD_FLAG": False,
-                    "METRIC_ALERTS_THREAD_FLAG": False,
+                "toggleableFlags": {
+                    "issueAlertsThreadFlag": False,
+                    "metricAlertsThreadFlag": False,
                 }
             },
         )
         data = self.slack_installation.get_config_data()
-        results = data.get("TOGGLEABLE_FLAGS")
+        results = data.get("toggleableFlags")
         assert results == {
-            "ISSUE_ALERTS_THREAD_FLAG": False,
-            "METRIC_ALERTS_THREAD_FLAG": False,
+            "issueAlertsThreadFlag": False,
+            "metricAlertsThreadFlag": False,
         }
 
 
@@ -72,45 +72,45 @@ class TestUpdateAndCleanFlagsInOrganizationConfig(_BaseTestCase):
         data: dict[str, Any] = {}
         self.slack_installation._update_and_clean_flags_in_organization_config(data=data)
 
-        assert "TOGGLEABLE_FLAGS" in data
+        assert "toggleableFlags" in data
 
     def test_adds_default_flags_key_when_it_does_not_exist(self) -> None:
         data: dict[str, Any] = {}
         self.slack_installation._update_and_clean_flags_in_organization_config(data=data)
 
-        results = data["TOGGLEABLE_FLAGS"]
+        results = data["toggleableFlags"]
         assert results == {
-            "ISSUE_ALERTS_THREAD_FLAG": True,
-            "METRIC_ALERTS_THREAD_FLAG": True,
+            "issueAlertsThreadFlag": True,
+            "metricAlertsThreadFlag": True,
         }
 
     def test_adds_missing_flags(self) -> None:
         data: dict[str, Any] = {
-            "TOGGLEABLE_FLAGS": {
-                "ISSUE_ALERTS_THREAD_FLAG": False,
+            "toggleableFlags": {
+                "issueAlertsThreadFlag": False,
             }
         }
         self.slack_installation._update_and_clean_flags_in_organization_config(data=data)
 
-        results = data["TOGGLEABLE_FLAGS"]
+        results = data["toggleableFlags"]
         assert results == {
-            "ISSUE_ALERTS_THREAD_FLAG": False,
-            "METRIC_ALERTS_THREAD_FLAG": True,
+            "issueAlertsThreadFlag": False,
+            "metricAlertsThreadFlag": True,
         }
 
     def test_corrects_bad_flag_values(self) -> None:
         data: dict[str, Any] = {
-            "TOGGLEABLE_FLAGS": {
-                "ISSUE_ALERTS_THREAD_FLAG": False,
-                "METRIC_ALERTS_THREAD_FLAG": 0,
+            "toggleableFlags": {
+                "issueAlertsThreadFlag": False,
+                "metricAlertsThreadFlag": 0,
             }
         }
         self.slack_installation._update_and_clean_flags_in_organization_config(data=data)
 
-        results = data["TOGGLEABLE_FLAGS"]
+        results = data["toggleableFlags"]
         assert results == {
-            "ISSUE_ALERTS_THREAD_FLAG": False,
-            "METRIC_ALERTS_THREAD_FLAG": True,
+            "issueAlertsThreadFlag": False,
+            "metricAlertsThreadFlag": True,
         }
 
 
@@ -123,9 +123,9 @@ class TestUpdateOrganizationConfig(_BaseTestCase):
             config={},
         )
         data: dict[str, Any] = {
-            "TOGGLEABLE_FLAGS": {
-                "ISSUE_ALERTS_THREAD_FLAG": False,
-                "METRIC_ALERTS_THREAD_FLAG": True,
+            "toggleableFlags": {
+                "issueAlertsThreadFlag": False,
+                "metricAlertsThreadFlag": True,
             }
         }
         self.slack_installation.update_organization_config(data=data)


### PR DESCRIPTION
Features that we add to integrations should have the ability to be turned off by users. Use the Slack Threads feature as a stepping stone for this pattern to add feature toggle to organization integrations, allowing organizations to turn features on or off.

The features are turned on by default as we are about to GA the feature.