### PR TITLE
update: remove timebox from query_extra

### DIFF
--- a/src/sentry/incidents/models/alert_rule.py
+++ b/src/sentry/incidents/models/alert_rule.py
@@ -320,7 +320,7 @@ class AlertRule(Model):
                 projects,
                 INCIDENTS_SNUBA_SUBSCRIPTION_TYPE,
                 self.snuba_query,
-                query_extra,
+                query_extra=query_extra,
             )
             if self.monitor_type == AlertRuleMonitorType.ACTIVATED.value:
                 # NOTE: Activated Alert Rules are conditionally subscribed

--- a/src/sentry/models/releases/release_project.py
+++ b/src/sentry/models/releases/release_project.py
@@ -40,7 +40,7 @@ class ReleaseProjectModelManager(BaseManager["ReleaseProject"]):
             schedule_invalidate_project_config(project_id=project.id, trigger=trigger)
 
     @staticmethod
-    def _subscribe_project_to_alert_rule(
+    def subscribe_project_to_alert_rule(
         project: Project, release: Release, trigger: str
     ) -> list[QuerySubscription]:
         """
@@ -62,7 +62,7 @@ class ReleaseProjectModelManager(BaseManager["ReleaseProject"]):
     def post_save(self, instance, created, **kwargs):
         self._on_post(project=instance.project, trigger="releaseproject.post_save")
         if created:
-            self._subscribe_project_to_alert_rule(
+            self.subscribe_project_to_alert_rule(
                 project=instance.project,
                 release=instance.release,
                 trigger="releaseproject.post_save",

--- a/src/sentry/models/releases/release_project.py
+++ b/src/sentry/models/releases/release_project.py
@@ -4,7 +4,6 @@ import logging
 from typing import TYPE_CHECKING, ClassVar
 
 from django.db import models
-from django.utils import timezone
 
 from sentry import features
 from sentry.backup.scopes import RelocationScope
@@ -51,7 +50,7 @@ class ReleaseProjectModelManager(BaseManager["ReleaseProject"]):
         """
         from sentry.incidents.models.alert_rule import AlertRule
 
-        query_extra = f"release:{release.version} AND event.timestamp:>{timezone.now().isoformat()}"
+        query_extra = f"release:{release.version}"
         return AlertRule.objects.conditionally_subscribe_project_to_alert_rules(
             project=project,
             activation_condition=AlertRuleActivationConditionType.RELEASE_CREATION,

--- a/src/sentry/snuba/models.py
+++ b/src/sentry/snuba/models.py
@@ -117,6 +117,7 @@ class QuerySubscription(Model):
     query_extra = models.TextField(
         null=True
     )  # additional query filters to attach to the query created in Snuba such as datetime filters, or release/deploy tags
+    # TODO: timebox is not utilized. Subscription queries do not support timestamp restrictions
     # timebox_start/end is optional timebox restrictions to apply to the snuba query
     timebox_start = models.DateTimeField(null=True)
     timebox_end = models.DateTimeField(null=True)

--- a/src/sentry/snuba/tasks.py
+++ b/src/sentry/snuba/tasks.py
@@ -218,7 +218,6 @@ def _create_in_snuba(subscription: QuerySubscription) -> str:
             snuba_query,
             subscription.project.organization_id,
         )
-        # TODO: determine whether concatenating query_extra is proper
         snql_query = build_query_builder(
             entity_subscription=entity_subscription,
             query=f'{snuba_query.query}{f" and {subscription.query_extra}" if subscription.query_extra else ""}',

--- a/tests/sentry/models/releases/test_release_project.py
+++ b/tests/sentry/models/releases/test_release_project.py
@@ -17,7 +17,7 @@ class ReleaseProjectManagerTestCase(TransactionTestCase):
         self.assertIsInstance(ReleaseProject.objects, ReleaseProjectModelManager)
 
     @receivers_raise_on_send()
-    @patch.object(ReleaseProjectModelManager, "_subscribe_project_to_alert_rule")
+    @patch.object(ReleaseProjectModelManager, "subscribe_project_to_alert_rule")
     def test_post_save_signal_runs_if_dynamic_sampling_is_disabled(self, _):
         project = self.create_project(name="foo")
         release = Release.objects.create(organization_id=project.organization_id, version="42")
@@ -29,7 +29,7 @@ class ReleaseProjectManagerTestCase(TransactionTestCase):
             assert mock_task.mock_calls == []
 
     @receivers_raise_on_send()
-    @patch.object(ReleaseProjectModelManager, "_subscribe_project_to_alert_rule")
+    @patch.object(ReleaseProjectModelManager, "subscribe_project_to_alert_rule")
     def test_post_save_signal_runs_if_dynamic_sampling_is_enabled_and_latest_release_rule_does_not_exist(
         self,
         _,
@@ -49,7 +49,7 @@ class ReleaseProjectManagerTestCase(TransactionTestCase):
                 assert mock_task.mock_calls == []
 
     @receivers_raise_on_send()
-    @patch.object(ReleaseProjectModelManager, "_subscribe_project_to_alert_rule")
+    @patch.object(ReleaseProjectModelManager, "subscribe_project_to_alert_rule")
     def test_post_save_signal_runs_if_dynamic_sampling_is_enabled_and_latest_release_rule_exists(
         self,
         _,
@@ -76,7 +76,7 @@ class ReleaseProjectManagerTestCase(TransactionTestCase):
 
     @receivers_raise_on_send()
     @patch("sentry.models.releases.release_project.schedule_invalidate_project_config")
-    @patch.object(ReleaseProjectModelManager, "_subscribe_project_to_alert_rule")
+    @patch.object(ReleaseProjectModelManager, "subscribe_project_to_alert_rule")
     def test_post_save_subscribes_project_to_alert_rule_if_created(
         self, mock_subscribe_project_to_alert_rule, _
     ):


### PR DESCRIPTION
PR to remove the time restrictions from the activated snuba subscription queries

See: https://github.com/getsentry/sentry/pull/70486

Initially we had wanted to introduce a timebox to our subscriptions to ensure we do not receive any events outside of our timebox.
snuba subscriptions do _not_ support timestamp restrictions though as this could cause zombied queries that just eat memory.

Since we're already restricting on the Release versions and we do not have any use cases currently where this would become an issue, we're rolling forwards with simply removing the timeboxed restrictions.

IF other activation triggers emerge that might be problematic with this set up, then we can reach out to the SNS team to update their apis to enable timestamps for subscriptions