### PR TITLE
fix(platform): Using the correct name

### DIFF
--- a/static/app/components/events/contextSummary/contextIcon.tsx
+++ b/static/app/components/events/contextSummary/contextIcon.tsx
@@ -61,7 +61,7 @@ const LOGO_MAPPING = {
   'net-core': logoNetcore,
   'net-framework': logoNetframework,
   'qq-browser': logoQq,
-  nintendo: logoNintendo,
+  'nintendo-os': logoNintendo,
   amazon: logoAmazon,
   amd: logoAmd,
   android: logoAndroid,


### PR DESCRIPTION
sdk developers recommended to use `OS` in the name.
