### PR TITLE
ref(rules): Remove inner lock and add logging on exception

### DIFF
--- a/src/sentry/buffer/redis.py
+++ b/src/sentry/buffer/redis.py
@@ -315,7 +315,7 @@ class RedisBuffer(Buffer):
         try:
             redis_buffer_registry.callback(BufferHookEvent.FLUSH, self)
         except Exception as e:
-            logger.info("process_batch.error", extra={"exception": e})
+            logger.exception("process_batch.error", extra={"exception": e})
 
     def incr(
         self,

--- a/src/sentry/buffer/redis.py
+++ b/src/sentry/buffer/redis.py
@@ -314,8 +314,8 @@ class RedisBuffer(Buffer):
     def process_batch(self) -> None:
         try:
             redis_buffer_registry.callback(BufferHookEvent.FLUSH, self)
-        except Exception as e:
-            logger.exception("process_batch.error", extra={"exception": e})
+        except Exception:
+            logger.exception("process_batch.error")
 
     def incr(
         self,

--- a/src/sentry/buffer/redis.py
+++ b/src/sentry/buffer/redis.py
@@ -312,15 +312,10 @@ class RedisBuffer(Buffer):
         return decoded_hash
 
     def process_batch(self) -> None:
-        client = get_cluster_routing_client(self.cluster, self.is_redis_cluster)
-        lock_key = self._lock_key(client, self.pending_key, ex=10)
-        if not lock_key:
-            return
-
         try:
             redis_buffer_registry.callback(BufferHookEvent.FLUSH, self)
-        finally:
-            client.delete(lock_key)
+        except Exception as e:
+            logger.info("process_batch.error", extra={"exception": e})
 
     def incr(
         self,


### PR DESCRIPTION
Part of debugging the delayed rule processor lead here, we don't need the inner lock (it's locked [here](https://github.com/getsentry/sentry/blob/370e78ca10dddc2b018d1e9b6e41e501386cc0d2/src/sentry/buffer/redis.py#L316-L318) before `process_batch` is called). 