### PR TITLE
ref(routes): Avoid usage of optional route params

### DIFF
--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -1705,12 +1705,9 @@ function buildRoutes() {
   );
 
   const issueListRoutes = (
-    <Route
-      path="/issues/(searches/:searchId/)"
-      component={errorHandler(IssueListContainer)}
-      withOrgPath
-    >
+    <Route path="/issues" component={errorHandler(IssueListContainer)} withOrgPath>
       <IndexRoute component={errorHandler(IssueListOverview)} />
+      <Route path="searches/:searchId/" component={errorHandler(IssueListOverview)} />
     </Route>
   );
 


### PR DESCRIPTION
The syntax has changed in react-router 6. Instead of trying to build
compatability we can just remove the one optional route we have.