### PR TITLE
fix(slack): correct suspect commit

### DIFF
--- a/src/sentry/api/serializers/models/pullrequest.py
+++ b/src/sentry/api/serializers/models/pullrequest.py
@@ -30,7 +30,7 @@ class PullRequestSerializer(Serializer):
             repository_id = str(item.repository_id)
             external_url = ""
             if item.repository_id in repository_map:
-                external_url = self._external_url(repository_map[item.repository_id], item)
+                external_url = item.get_external_url()
             result[item] = {
                 "repository": serialized_repos.get(repository_id, {}),
                 "external_url": external_url,
@@ -38,16 +38,6 @@ class PullRequestSerializer(Serializer):
             }
 
         return result
-
-    def _external_url(self, repository, pull):
-        from sentry.plugins.base import bindings
-
-        provider_id = repository.provider
-        if not provider_id or not provider_id.startswith("integrations:"):
-            return None
-        provider_cls = bindings.get("integration-repository.provider").get(provider_id)
-        provider = provider_cls(provider_id)
-        return provider.pull_request_url(repository, pull)
 
     def serialize(self, obj, attrs, user):
         return {

--- a/src/sentry/integrations/slack/message_builder/issues.py
+++ b/src/sentry/integrations/slack/message_builder/issues.py
@@ -328,8 +328,6 @@ def get_suspect_commit_text(group: Group) -> str | None:
     pull_request = PullRequest.objects.filter(
         merge_commit_sha=commit.key, organization_id=group.project.organization_id
     ).first()
-    if not pull_request:
-        return None
 
     author = commit.author
     commit_id = commit.key

--- a/src/sentry/integrations/slack/message_builder/issues.py
+++ b/src/sentry/integrations/slack/message_builder/issues.py
@@ -43,11 +43,12 @@ from sentry.models.commit import Commit
 from sentry.models.group import Group, GroupStatus
 from sentry.models.project import Project
 from sentry.models.projectownership import ProjectOwnership
+from sentry.models.pullrequest import PullRequest
 from sentry.models.release import Release
+from sentry.models.repository import Repository
 from sentry.models.rule import Rule
 from sentry.models.team import Team
 from sentry.notifications.notifications.base import ProjectNotification
-from sentry.notifications.utils import get_commits
 from sentry.notifications.utils.actions import MessageAction
 from sentry.notifications.utils.participants import (
     dedupe_suggested_assignees,
@@ -316,31 +317,30 @@ def get_suggested_assignees(
     return []
 
 
-def get_suspect_commit_text(
-    project: Project, event: GroupEvent, commits: Sequence[Mapping[str, Any]] | None = None
-) -> SlackBlock:
+def get_suspect_commit_text(group: Group) -> str | None:
     """Build up the suspect commit text for the given event"""
 
-    # commits is passed from context when the rule initially fires
-    # we may not have that data if the message is being built after an action is taken, for example
-    if not commits:
-        commits = get_commits(project, event)
-    if not commits:
+    commit = group.get_suspect_commit()
+    if not commit:
         return None
 
-    commit = commits[0]  # get the most recent commit
     suspect_commit_text = "Suspect Commit: "
-    pull_request = commit.get("pull_request")
-    author = commit.get("author")
-    commit_id = commit.get("id")
+    pull_request = PullRequest.objects.filter(
+        merge_commit_sha=commit.key, organization_id=group.project.organization_id
+    ).first()
+    if not pull_request:
+        return None
+
+    author = commit.author
+    commit_id = commit.key
     if not (author and commit_id):  # we need both the author and commit id to continue
         return None
 
-    author_display = author.get("name") if author.get("name") is not None else author.get("email")
+    author_display = author.name if author.name else author.email
     if pull_request:
-        repo = pull_request.get("repository", {})
-        repo_base = repo.get("url")
-        provider = repo.get("provider", {}).get("id")
+        repo = Repository.objects.get(id=pull_request.repository_id)
+        repo_base = repo.url
+        provider = repo.provider
         if repo_base and provider in SUPPORTED_COMMIT_PROVIDERS:
             if "bitbucket" in provider:
                 commit_link = f"<{repo_base}/commits/{commit_id}"
@@ -351,12 +351,12 @@ def get_suspect_commit_text(
         else:  # for unsupported providers
             suspect_commit_text += f"{commit_id[:6]} by {author_display}"
 
-        pr_date = pull_request.get("dateCreated")
+        pr_date = pull_request.date_added
         if pr_date:
             pr_date = time_since(pr_date)
-        pr_id = pull_request.get("id")
-        pr_title = pull_request.get("title")
-        pr_link = pull_request.get("externalUrl")
+        pr_id = pull_request.key
+        pr_title = pull_request.title
+        pr_link = pull_request.get_external_url()
         if pr_date and pr_id and pr_title and pr_link:
             suspect_commit_text += (
                 f" {pr_date} \n'{pr_title} (#{pr_id})' <{pr_link}|View Pull Request>"
@@ -458,7 +458,6 @@ class SlackIssuesMessageBuilder(BlockSlackMessageBuilder):
         is_unfurl: bool = False,
         skip_fallback: bool = False,
         notes: str | None = None,
-        commits: Sequence[Mapping[str, Any]] | None = None,
     ) -> None:
         super().__init__()
         self.group = group
@@ -474,7 +473,6 @@ class SlackIssuesMessageBuilder(BlockSlackMessageBuilder):
         self.is_unfurl = is_unfurl
         self.skip_fallback = skip_fallback
         self.notes = notes
-        self.commits = commits
 
     @property
     def escape_text(self) -> bool:
@@ -667,10 +665,9 @@ class SlackIssuesMessageBuilder(BlockSlackMessageBuilder):
             blocks.append(self.get_suggested_assignees_block(suggested_assignees))
 
         # add suspect commit info
-        if event_for_tags:
-            suspect_commit_text = get_suspect_commit_text(project, event_for_tags, self.commits)
-            if suspect_commit_text:
-                blocks.append(self.get_context_block(suspect_commit_text))
+        suspect_commit_text = get_suspect_commit_text(self.group)
+        if suspect_commit_text:
+            blocks.append(self.get_context_block(suspect_commit_text))
 
         # add notes
         if self.notes:

--- a/src/sentry/integrations/slack/message_builder/notifications/issues.py
+++ b/src/sentry/integrations/slack/message_builder/notifications/issues.py
@@ -31,5 +31,4 @@ class IssueNotificationMessageBuilder(SlackNotificationsMessageBuilder):
             issue_details=True,
             notification=self.notification,
             recipient=self.recipient,
-            commits=self.context.get("commits", None),
         ).build()

--- a/src/sentry/models/group.py
+++ b/src/sentry/models/group.py
@@ -43,6 +43,7 @@ from sentry.issues.priority import (
     PriorityChangeReason,
     get_priority_for_ongoing_group,
 )
+from sentry.models.commit import Commit
 from sentry.models.grouphistory import record_group_history, record_group_history_from_activity_type
 from sentry.models.organization import Organization
 from sentry.snuba.dataset import Dataset
@@ -802,6 +803,23 @@ class Group(Model):
             if maybe_event
             else self.get_latest_event_for_environments([env.name for env in environments])
         )
+
+    def get_suspect_commit(self) -> Commit | None:
+        from sentry.models.groupowner import GroupOwner, GroupOwnerType
+
+        suspect_commit_owner = GroupOwner.objects.filter(
+            group_id=self.id, project_id=self.project_id, type=GroupOwnerType.SUSPECT_COMMIT.value
+        )
+        if not suspect_commit_owner.exists():
+            return None
+
+        suspect_commit_owner = suspect_commit_owner.first()
+        commit_id = suspect_commit_owner.context.get("commitId")
+        if not commit_id:
+            return None
+
+        commit = Commit.objects.filter(id=commit_id)
+        return commit.first()
 
     def get_first_release(self) -> str | None:
         from sentry.models.release import Release

--- a/src/sentry/models/pullrequest.py
+++ b/src/sentry/models/pullrequest.py
@@ -86,7 +86,7 @@ class PullRequest(Model):
         text = f"{self.message} {self.title}"
         return find_referenced_groups(text, self.organization_id)
 
-    def get_external_url(self) -> str:
+    def get_external_url(self) -> str | None:
         from sentry.models.repository import Repository
         from sentry.plugins.base import bindings
 

--- a/src/sentry/notifications/notifications/rules.py
+++ b/src/sentry/notifications/notifications/rules.py
@@ -19,6 +19,7 @@ from sentry.notifications.types import (
     NotificationSettingEnum,
 )
 from sentry.notifications.utils import (
+    get_commits,
     get_generic_data,
     get_group_settings_link,
     get_integration_link,
@@ -169,6 +170,7 @@ class AlertRuleNotification(ProjectNotification):
             "rules": rule_details,
             "has_integrations": has_integrations(self.organization, self.project),
             "enhanced_privacy": enhanced_privacy,
+            "commits": get_commits(self.project, self.event),
             "environment": environment,
             "slack_link": get_integration_link(self.organization, "slack", self.notification_uuid),
             "notification_reason": notification_reason,

--- a/src/sentry/notifications/notifications/rules.py
+++ b/src/sentry/notifications/notifications/rules.py
@@ -19,7 +19,6 @@ from sentry.notifications.types import (
     NotificationSettingEnum,
 )
 from sentry.notifications.utils import (
-    get_commits,
     get_generic_data,
     get_group_settings_link,
     get_integration_link,
@@ -170,7 +169,6 @@ class AlertRuleNotification(ProjectNotification):
             "rules": rule_details,
             "has_integrations": has_integrations(self.organization, self.project),
             "enhanced_privacy": enhanced_privacy,
-            "commits": get_commits(self.project, self.event),
             "environment": environment,
             "slack_link": get_integration_link(self.organization, "slack", self.notification_uuid),
             "notification_reason": notification_reason,
@@ -267,9 +265,9 @@ class AlertRuleNotification(ProjectNotification):
                 "group": self.group.id,
                 "project_id": self.project.id,
                 "organization": self.organization.id,
-                "fallthrough_choice": self.fallthrough_choice.value
-                if self.fallthrough_choice
-                else None,
+                "fallthrough_choice": (
+                    self.fallthrough_choice.value if self.fallthrough_choice else None
+                ),
                 "notification_uuid": self.notification_uuid,
             },
         )


### PR DESCRIPTION
The suspect commit is stored via the GroupOwner model. We have been fetching the suspect commit using the old logic (the commit responsible for the first line in the stacktrace) but this is incorrect.

NOTE: This probably won't be the final state, as we are not guaranteed the suspect commit will exist at the time the Slack message is sent because suspect commits processing is async from the alert rule firing.