### PR TITLE
fix: Bottom margin for Wizard page

### DIFF
--- a/static/app/views/setupWizard/index.tsx
+++ b/static/app/views/setupWizard/index.tsx
@@ -132,6 +132,7 @@ function SetupWizard({hash = false, organizations}: Props) {
 const MinWidthButtonBar = styled(ButtonBar)`
   width: min-content;
   margin-top: 20px;
+  margin-bottom: 20px;
 `;
 
 export default SetupWizard;


### PR DESCRIPTION
Adds a bottom margin to this
![image (44)](https://github.com/getsentry/sentry/assets/363802/c1f0abf2-1fd9-4112-b505-7238e6c79f40)
