### PR TITLE
fix(onboarding): Fix Next.js and serverless tests

### DIFF
--- a/static/app/gettingStartedDocs/javascript/nextjs.spec.tsx
+++ b/static/app/gettingStartedDocs/javascript/nextjs.spec.tsx
@@ -32,6 +32,7 @@ describe('javascript-nextjs onboarding docs', function () {
       screen.queryByText(textWithMarkupMatcher(/sentry.client.config.js/))
     ).toBeInTheDocument();
     expect(screen.queryByText(textWithMarkupMatcher(/Sentry.init/))).toBeInTheDocument();
-    expect(screen.queryByText(textWithMarkupMatcher(/.sentryclirc/))).toBeInTheDocument();
+    expect(screen.queryByText(textWithMarkupMatcher(/.env.sentry-build-plugin/))).toBeInTheDocument();
+    expect(screen.queryByText(textWithMarkupMatcher(/instrumentation.ts/))).toBeInTheDocument();
   });
 });

--- a/static/app/gettingStartedDocs/javascript/nextjs.spec.tsx
+++ b/static/app/gettingStartedDocs/javascript/nextjs.spec.tsx
@@ -32,7 +32,11 @@ describe('javascript-nextjs onboarding docs', function () {
       screen.queryByText(textWithMarkupMatcher(/sentry.client.config.js/))
     ).toBeInTheDocument();
     expect(screen.queryByText(textWithMarkupMatcher(/Sentry.init/))).toBeInTheDocument();
-    expect(screen.queryByText(textWithMarkupMatcher(/.env.sentry-build-plugin/))).toBeInTheDocument();
-    expect(screen.queryByText(textWithMarkupMatcher(/instrumentation.ts/))).toBeInTheDocument();
+    expect(
+      screen.queryByText(textWithMarkupMatcher(/.env.sentry-build-plugin/))
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText(textWithMarkupMatcher(/instrumentation.ts/))
+    ).toBeInTheDocument();
   });
 });

--- a/static/app/gettingStartedDocs/node/awslambda.spec.tsx
+++ b/static/app/gettingStartedDocs/node/awslambda.spec.tsx
@@ -19,7 +19,7 @@ describe('awslambda onboarding docs', function () {
     // Includes import statement
     expect(
       screen.getByText(
-        textWithMarkupMatcher(/const Sentry = require\("@sentry\/serverless"\);/)
+        textWithMarkupMatcher(/const Sentry = require\("@sentry\/aws-serverless"\);/)
       )
     ).toBeInTheDocument();
   });

--- a/static/app/gettingStartedDocs/node/gcpfunctions.spec.tsx
+++ b/static/app/gettingStartedDocs/node/gcpfunctions.spec.tsx
@@ -19,7 +19,7 @@ describe('gcpfunctions onboarding docs', function () {
     // Includes import statement
     expect(
       screen.getByText(
-        textWithMarkupMatcher(/const Sentry = require\("@sentry\/serverless"\);/)
+        textWithMarkupMatcher(/const Sentry = require\("@sentry\/google-cloud-serverless"\);/)
       )
     ).toBeInTheDocument();
   });


### PR DESCRIPTION
The steps were changed, and `.sentryclirc` is not part of it anymore.
