### PR TITLE
test(onboarding): Check for error handler and profiling import

### DIFF
--- a/static/app/gettingStartedDocs/node/connect.spec.tsx
+++ b/static/app/gettingStartedDocs/node/connect.spec.tsx
@@ -24,6 +24,14 @@ describe('connect onboarding docs', function () {
     });
   });
 
+  it('includes error handler', () => {
+    renderWithOnboardingLayout(docs);
+
+    expect(
+      screen.getByText(textWithMarkupMatcher(/Sentry\.setupConnectErrorHandler\(app\)/))
+    ).toBeInTheDocument();
+  });
+
   it('displays sample rates by default', () => {
     renderWithOnboardingLayout(docs, {
       selectedProducts: [
@@ -59,6 +67,13 @@ describe('connect onboarding docs', function () {
       selectedProducts: [ProductSolution.ERROR_MONITORING, ProductSolution.PROFILING],
     });
 
+    expect(
+      screen.getByText(
+        textWithMarkupMatcher(
+          /import \{ nodeProfilingIntegration } from "@sentry\/profiling-node"/
+        )
+      )
+    ).toBeInTheDocument();
     expect(
       screen.getByText(textWithMarkupMatcher(/profilesSampleRate: 1\.0/))
     ).toBeInTheDocument();

--- a/static/app/gettingStartedDocs/node/express.spec.tsx
+++ b/static/app/gettingStartedDocs/node/express.spec.tsx
@@ -25,6 +25,14 @@ describe('express onboarding docs', function () {
     });
   });
 
+  it('includes error handler', () => {
+    renderWithOnboardingLayout(docs);
+
+    expect(
+      screen.getByText(textWithMarkupMatcher(/Sentry\.setupExpressErrorHandler\(app\)/))
+    ).toBeInTheDocument();
+  });
+
   it('displays sample rates by default', () => {
     renderWithOnboardingLayout(docs, {
       selectedProducts: [
@@ -60,6 +68,13 @@ describe('express onboarding docs', function () {
       selectedProducts: [ProductSolution.ERROR_MONITORING, ProductSolution.PROFILING],
     });
 
+    expect(
+      screen.getByText(
+        textWithMarkupMatcher(
+          /import \{ nodeProfilingIntegration } from "@sentry\/profiling-node"/
+        )
+      )
+    ).toBeInTheDocument();
     expect(
       screen.getByText(textWithMarkupMatcher(/profilesSampleRate: 1\.0/))
     ).toBeInTheDocument();

--- a/static/app/gettingStartedDocs/node/fastify.spec.tsx
+++ b/static/app/gettingStartedDocs/node/fastify.spec.tsx
@@ -25,6 +25,14 @@ describe('fastify onboarding docs', function () {
     });
   });
 
+  it('includes error handler', () => {
+    renderWithOnboardingLayout(docs);
+
+    expect(
+      screen.getByText(textWithMarkupMatcher(/Sentry\.setupFastifyErrorHandler\(app\)/))
+    ).toBeInTheDocument();
+  });
+
   it('displays sample rates by default', () => {
     renderWithOnboardingLayout(docs, {
       selectedProducts: [
@@ -60,6 +68,13 @@ describe('fastify onboarding docs', function () {
       selectedProducts: [ProductSolution.ERROR_MONITORING, ProductSolution.PROFILING],
     });
 
+    expect(
+      screen.getByText(
+        textWithMarkupMatcher(
+          /import \{ nodeProfilingIntegration } from "@sentry\/profiling-node"/
+        )
+      )
+    ).toBeInTheDocument();
     expect(
       screen.getByText(textWithMarkupMatcher(/profilesSampleRate: 1\.0/))
     ).toBeInTheDocument();

--- a/static/app/gettingStartedDocs/node/hapi.spec.tsx
+++ b/static/app/gettingStartedDocs/node/hapi.spec.tsx
@@ -25,6 +25,14 @@ describe('hapi onboarding docs', function () {
     });
   });
 
+  it('includes error handler', () => {
+    renderWithOnboardingLayout(docs);
+
+    expect(
+      screen.getByText(textWithMarkupMatcher(/Sentry\.setupHapiErrorHandler\(server\)/))
+    ).toBeInTheDocument();
+  });
+
   it('displays sample rates by default', () => {
     renderWithOnboardingLayout(docs, {
       selectedProducts: [
@@ -60,6 +68,13 @@ describe('hapi onboarding docs', function () {
       selectedProducts: [ProductSolution.ERROR_MONITORING, ProductSolution.PROFILING],
     });
 
+    expect(
+      screen.getByText(
+        textWithMarkupMatcher(
+          /import \{ nodeProfilingIntegration } from "@sentry\/profiling-node"/
+        )
+      )
+    ).toBeInTheDocument();
     expect(
       screen.getByText(textWithMarkupMatcher(/profilesSampleRate: 1\.0/))
     ).toBeInTheDocument();

--- a/static/app/gettingStartedDocs/node/koa.spec.tsx
+++ b/static/app/gettingStartedDocs/node/koa.spec.tsx
@@ -25,6 +25,14 @@ describe('koa onboarding docs', function () {
     });
   });
 
+  it('includes error handler', () => {
+    renderWithOnboardingLayout(docs);
+
+    expect(
+      screen.getByText(textWithMarkupMatcher(/Sentry\.setupKoaErrorHandler\(app\)/))
+    ).toBeInTheDocument();
+  });
+
   it('displays sample rates by default', () => {
     renderWithOnboardingLayout(docs, {
       selectedProducts: [
@@ -60,6 +68,13 @@ describe('koa onboarding docs', function () {
       selectedProducts: [ProductSolution.ERROR_MONITORING, ProductSolution.PROFILING],
     });
 
+    expect(
+      screen.getByText(
+        textWithMarkupMatcher(
+          /import \{ nodeProfilingIntegration } from "@sentry\/profiling-node"/
+        )
+      )
+    ).toBeInTheDocument();
     expect(
       screen.getByText(textWithMarkupMatcher(/profilesSampleRate: 1\.0/))
     ).toBeInTheDocument();

--- a/static/app/gettingStartedDocs/node/nestjs.spec.tsx
+++ b/static/app/gettingStartedDocs/node/nestjs.spec.tsx
@@ -25,6 +25,18 @@ describe('Nest.js onboarding docs', function () {
     });
   });
 
+  it('includes error handler', () => {
+    renderWithOnboardingLayout(docs);
+
+    expect(
+      screen.getByText(
+        textWithMarkupMatcher(
+          /Sentry\.setupNestErrorHandler\(app, new BaseExceptionFilter\(httpAdapter\)\)/
+        )
+      )
+    ).toBeInTheDocument();
+  });
+
   it('displays sample rates by default', () => {
     renderWithOnboardingLayout(docs, {
       selectedProducts: [
@@ -60,6 +72,13 @@ describe('Nest.js onboarding docs', function () {
       selectedProducts: [ProductSolution.ERROR_MONITORING, ProductSolution.PROFILING],
     });
 
+    expect(
+      screen.getByText(
+        textWithMarkupMatcher(
+          /import \{ nodeProfilingIntegration } from "@sentry\/profiling-node"/
+        )
+      )
+    ).toBeInTheDocument();
     expect(
       screen.getByText(textWithMarkupMatcher(/profilesSampleRate: 1\.0/))
     ).toBeInTheDocument();

--- a/static/app/gettingStartedDocs/node/nestjs.tsx
+++ b/static/app/gettingStartedDocs/node/nestjs.tsx
@@ -23,7 +23,7 @@ import {
 type Params = DocsParams;
 
 const getSdkSetupSnippet = (params: Params) => `
-${getSentryImportsSnippet('node')}
+${getSentryImportsSnippet('node')}${params.isProfilingSelected ? `\nimport { nodeProfilingIntegration } from "@sentry/profiling-node";` : ''}
 import { BaseExceptionFilter, HttpAdapterHost, NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
 

--- a/static/app/gettingStartedDocs/node/node.spec.tsx
+++ b/static/app/gettingStartedDocs/node/node.spec.tsx
@@ -61,6 +61,13 @@ describe('node onboarding docs', function () {
     });
 
     expect(
+      screen.getByText(
+        textWithMarkupMatcher(
+          /import \{ nodeProfilingIntegration } from "@sentry\/profiling-node"/
+        )
+      )
+    ).toBeInTheDocument();
+    expect(
       screen.getByText(textWithMarkupMatcher(/profilesSampleRate: 1\.0/))
     ).toBeInTheDocument();
   });


### PR DESCRIPTION
Improve tests for onboarding pages to make sure the profiling import is present and the correct error handler is used.
