### PR TITLE
ref(js): Remove usage of browserHistory.getCurrentLocation

### DIFF
--- a/static/app/utils/replays/hooks/useActiveReplayTab.spec.tsx
+++ b/static/app/utils/replays/hooks/useActiveReplayTab.spec.tsx
@@ -1,26 +1,16 @@
-import type {Location} from 'history';
+import * as qs from 'query-string';
 
 import {renderHook} from 'sentry-test/reactTestingLibrary';
 
 import {browserHistory} from 'sentry/utils/browserHistory';
 import useActiveReplayTab, {TabKey} from 'sentry/utils/replays/hooks/useActiveReplayTab';
-import {useLocation} from 'sentry/utils/useLocation';
 
 jest.mock('react-router');
-jest.mock('sentry/utils/useLocation');
 
 const mockPush = jest.mocked(browserHistory.push);
 
 function mockLocation(query: string = '') {
-  jest.mocked(useLocation).mockReturnValue({
-    action: 'PUSH',
-    hash: '',
-    key: '',
-    pathname: '',
-    query: {query},
-    search: '',
-    state: undefined,
-  } as Location);
+  window.location.search = qs.stringify({query});
 }
 
 describe('useActiveReplayTab', () => {
@@ -55,8 +45,9 @@ describe('useActiveReplayTab', () => {
 
     result.current.setActiveTab('nEtWoRk');
     expect(mockPush).toHaveBeenLastCalledWith({
-      pathname: '',
-      query: {t_main: TabKey.NETWORK},
+      pathname: '/',
+      state: undefined,
+      query: {query: '', t_main: TabKey.NETWORK},
     });
   });
 
@@ -68,8 +59,8 @@ describe('useActiveReplayTab', () => {
 
     result.current.setActiveTab('foo bar');
     expect(mockPush).toHaveBeenLastCalledWith({
-      pathname: '',
-      query: {t_main: TabKey.BREADCRUMBS},
+      pathname: '/',
+      query: {query: '', t_main: TabKey.BREADCRUMBS},
     });
   });
 });

--- a/static/app/utils/useUrlParams.spec.tsx
+++ b/static/app/utils/useUrlParams.spec.tsx
@@ -1,4 +1,4 @@
-import type {Location} from 'history';
+import * as qs from 'query-string';
 
 import {renderHook} from 'sentry-test/reactTestingLibrary';
 
@@ -7,19 +7,14 @@ import {browserHistory} from 'sentry/utils/browserHistory';
 import useUrlParams from './useUrlParams';
 
 jest.mock('react-router');
-jest.mock('sentry/utils/useLocation');
-
-type Query = {array: string[]; limit: string; page: string};
 
 describe('useUrlParams', () => {
   beforeEach(() => {
-    jest.mocked(browserHistory.getCurrentLocation).mockReturnValue({
-      query: {
-        page: '3',
-        limit: '50',
-        array: ['first', 'second'],
-      },
-    } as Location<Query>);
+    window.location.search = qs.stringify({
+      page: '3',
+      limit: '50',
+      array: ['first', 'second'],
+    });
   });
 
   it('should read query values from the url', () => {
@@ -56,6 +51,7 @@ describe('useUrlParams', () => {
     result.current.setParamValue('page', '4');
 
     expect(browserHistory.push).toHaveBeenCalledWith({
+      pathname: '/',
       query: {
         array: ['first', 'second'],
         page: '4',
@@ -72,6 +68,7 @@ describe('useUrlParams', () => {
     result.current.setParamValue('4');
 
     expect(browserHistory.push).toHaveBeenCalledWith({
+      pathname: '/',
       query: {
         array: ['first', 'second'],
         page: '4',

--- a/static/app/utils/useUrlParams.tsx
+++ b/static/app/utils/useUrlParams.tsx
@@ -1,6 +1,10 @@
 import {useCallback} from 'react';
+import * as qs from 'query-string';
 
 import {browserHistory} from 'sentry/utils/browserHistory';
+
+// TODO(epurkhiser): Once we're on react-router 6 we should replace this with
+// their useSearchParams hook
 
 function useUrlParams(
   defaultKey: string,
@@ -20,24 +24,22 @@ function useUrlParams(): {
 function useUrlParams(defaultKey?: string, defaultValue?: string) {
   const getParamValue = useCallback(
     (key: string) => {
-      const location = browserHistory.getCurrentLocation();
-      // location.query.key can return string[] but we expect a singular value from this function, so we return the first string (this is picked arbitrarily) if it's string[]
-      return Array.isArray(location.query[key])
-        ? location.query[key]?.at(0) ?? defaultValue
-        : location.query[key] ?? defaultValue;
+      const currentQuery = qs.parse(window.location.search);
+
+      // location.query.key can return string[] but we expect a singular value
+      // from this function, so we return the first string (this is picked
+      // arbitrarily) if it's string[]
+      return Array.isArray(currentQuery[key])
+        ? currentQuery[key]?.at(0) ?? defaultValue
+        : currentQuery[key] ?? defaultValue;
     },
     [defaultValue]
   );
 
   const setParamValue = useCallback((key: string, value: string) => {
-    const location = browserHistory.getCurrentLocation();
-    browserHistory.push({
-      ...location,
-      query: {
-        ...location.query,
-        [key]: value,
-      },
-    });
+    const currentQuery = qs.parse(window.location.search);
+    const query = {...currentQuery, [key]: value};
+    browserHistory.push({pathname: location.pathname, query});
   }, []);
 
   const getWithDefault = useCallback(


### PR DESCRIPTION
Newer versions of the history library do not support this function [0].
Use `useLocation` in this case instead.

[0]: https://github.com/remix-run/history/blob/485ebc177c1f3f8eef93b0d654fffd1d321c2ecd/packages/history/index.ts#L188