### PR TITLE
fix(replay): if a video replay has no gestures, hide the rrweb canvas

### DIFF
--- a/static/app/components/replays/replayContext.tsx
+++ b/static/app/components/replays/replayContext.tsx
@@ -15,7 +15,6 @@ import type {
   ReplayPrefs,
 } from 'sentry/components/replays/preferences/replayPreferences';
 import useReplayHighlighting from 'sentry/components/replays/useReplayHighlighting';
-import {VideoReplayer} from 'sentry/components/replays/videoReplayer';
 import {VideoReplayerWithInteractions} from 'sentry/components/replays/videoReplayerWithInteractions';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import clamp from 'sentry/utils/number/clamp';
@@ -480,64 +479,37 @@ function ProviderNonMemo({
         return null;
       }
 
-      const hasGestures = events?.some(e => e.type === 3);
-
       // This is a wrapper class that wraps both the VideoReplayer
       // and the rrweb Replayer
-      const inst = hasGestures
-        ? new VideoReplayerWithInteractions({
-            // video specific
-            videoEvents,
-            videoApiPrefix: `/api/0/projects/${
-              organization.slug
-            }/${projectSlug}/replays/${replay?.getReplay().id}/videos/`,
-            start: startTimestampMs,
-            onFinished: setReplayFinished,
-            onLoaded: event => {
-              const {videoHeight, videoWidth} = event.target;
-              if (!videoHeight || !videoWidth) {
-                return;
-              }
-              setDimensions({
-                height: videoHeight,
-                width: videoWidth,
-              });
-            },
-            onBuffer: buffering => {
-              setVideoBuffering(buffering);
-            },
-            clipWindow,
-            durationMs,
-            // rrweb specific
-            theme,
-            events: events ?? [],
-            // common to both
-            root,
-          })
-        : // If the replay has no gestures, we should hide the rrweb canvas
-          new VideoReplayer(videoEvents, {
-            videoApiPrefix: `/api/0/projects/${
-              organization.slug
-            }/${projectSlug}/replays/${replay?.getReplay().id}/videos/`,
-            root,
-            start: startTimestampMs,
-            onFinished: setReplayFinished,
-            onLoaded: event => {
-              const {videoHeight, videoWidth} = event.target;
-              if (!videoHeight || !videoWidth) {
-                return;
-              }
-              setDimensions({
-                height: videoHeight,
-                width: videoWidth,
-              });
-            },
-            onBuffer: buffering => {
-              setVideoBuffering(buffering);
-            },
-            clipWindow,
-            durationMs,
+      const inst = new VideoReplayerWithInteractions({
+        // video specific
+        videoEvents,
+        videoApiPrefix: `/api/0/projects/${
+          organization.slug
+        }/${projectSlug}/replays/${replay?.getReplay().id}/videos/`,
+        start: startTimestampMs,
+        onFinished: setReplayFinished,
+        onLoaded: event => {
+          const {videoHeight, videoWidth} = event.target;
+          if (!videoHeight || !videoWidth) {
+            return;
+          }
+          setDimensions({
+            height: videoHeight,
+            width: videoWidth,
           });
+        },
+        onBuffer: buffering => {
+          setVideoBuffering(buffering);
+        },
+        clipWindow,
+        durationMs,
+        // rrweb specific
+        theme,
+        events: events ?? [],
+        // common to both
+        root,
+      });
       // `.current` is marked as readonly, but it's safe to set the value from
       // inside a `useEffect` hook.
       // See: https://reactjs.org/docs/hooks-faq.html#is-there-something-like-instance-variables

--- a/static/app/components/replays/replayContext.tsx
+++ b/static/app/components/replays/replayContext.tsx
@@ -514,7 +514,8 @@ function ProviderNonMemo({
             // common to both
             root,
           })
-        : new VideoReplayer(videoEvents, {
+        : // If the replay has no gestures, we should hide the rrweb canvas
+          new VideoReplayer(videoEvents, {
             videoApiPrefix: `/api/0/projects/${
               organization.slug
             }/${projectSlug}/replays/${replay?.getReplay().id}/videos/`,

--- a/static/app/components/replays/videoReplayerWithInteractions.tsx
+++ b/static/app/components/replays/videoReplayerWithInteractions.tsx
@@ -99,6 +99,8 @@ export class VideoReplayerWithInteractions {
       }
     });
 
+    const hasGestures = events?.some(e => e.type === 3);
+
     this.replayer = new Replayer(eventsWithSnapshots, {
       root: root as Element,
       blockClass: 'sentry-block',
@@ -112,6 +114,12 @@ export class VideoReplayerWithInteractions {
       skipInactive: false,
       speed: this.config.speed,
     });
+
+    if (!hasGestures) {
+      // If the replay has no gestures, we should hide the mouse
+      // @ts-expect-error private
+      this.replayer.mouse.classList.remove('replayer-mouse');
+    }
   }
 
   public destroy() {


### PR DESCRIPTION
This should probably get removed eventually once all mobile replays have gestures

Before:
<img width="972" alt="SCR-20240510-lgxp" src="https://github.com/getsentry/sentry/assets/56095982/44874c2b-5a62-4566-acaf-3578de3c3ba1">

After:
<img width="669" alt="SCR-20240510-lgvh" src="https://github.com/getsentry/sentry/assets/56095982/ae4f640a-8443-41f4-ae9e-40817be79bf0">
