### PR TITLE
ref(seer grouping): `SeerSimilarIssueData.from_raw` improvements

### DIFF
--- a/src/sentry/seer/utils.py
+++ b/src/sentry/seer/utils.py
@@ -1,6 +1,7 @@
 import logging
+from collections.abc import Mapping
 from dataclasses import dataclass
-from typing import NotRequired, Self, TypedDict
+from typing import Any, NotRequired, Self, TypedDict
 
 import sentry_sdk
 from django.conf import settings
@@ -136,7 +137,7 @@ class SeerSimilarIssueData:
     parent_hash: str | None = None
 
     @classmethod
-    def from_raw(cls, project_id: int, raw_similar_issue_data: RawSeerSimilarIssueData) -> Self:
+    def from_raw(cls, project_id: int, raw_similar_issue_data: Mapping[str, Any]) -> Self:
         """
         Create an instance of `SeerSimilarIssueData` from the raw data that comes back from Seer,
         using the parent hash to look up the parent group id. Needs to be run individually on each

--- a/src/sentry/seer/utils.py
+++ b/src/sentry/seer/utils.py
@@ -181,6 +181,7 @@ class SeerSimilarIssueData:
             if not Group.objects.filter(id=parent_group_id).first():
                 raise SimilarGroupNotFoundError("Similar group suggested by Seer does not exist")
 
+        # If we don't have a parent group id, try looking one up using the parent hash
         else:
             parent_grouphash = (
                 GroupHash.objects.filter(project_id=project_id, hash=parent_hash)

--- a/src/sentry/seer/utils.py
+++ b/src/sentry/seer/utils.py
@@ -168,7 +168,6 @@ class SeerSimilarIssueData:
                 + ", ".join(map(lambda key: f"'{key}'", sorted(missing_keys)))
             )
 
-        similar_issue_data = raw_similar_issue_data
         parent_hash = raw_similar_issue_data.get("parent_hash")
         parent_group_id = raw_similar_issue_data.get("parent_group_id")
 
@@ -180,6 +179,8 @@ class SeerSimilarIssueData:
         if parent_group_id:
             if not Group.objects.filter(id=parent_group_id).first():
                 raise SimilarGroupNotFoundError("Similar group suggested by Seer does not exist")
+
+            similar_issue_data = raw_similar_issue_data
 
         # If we don't have a parent group id, try looking one up using the parent hash
         else:


### PR DESCRIPTION
This makes a number of improvements to the `from_raw1 factory method in the `SeerSimilarIssueData` dataclass, all related to the fact that the data being fed to it comes straight from the JSON returned by Seer and so we can't actually guarantee what's in it.

Included changes: 

- Loosen the typing of the `raw_similar_issue_data` parameter, from `RawSeerSimilarIssueData` (implying we know exactly what's in it) to `Mapping[str, Any]` (acknowledging that we don't).
- Add check to ensure all required keys are present.
- Filter out any data with unknown keys, to prevent the `SeerSimilarIssueData` constructor from crashing with an 'unknown keyword argument' error in the case of unexpected data. 