### PR TITLE
ref(router): Remove ability to pass `to` as a function

### DIFF
--- a/static/app/components/feedback/list/feedbackListItem.tsx
+++ b/static/app/components/feedback/list/feedbackListItem.tsx
@@ -65,15 +65,13 @@ const FeedbackListItem = forwardRef<HTMLDivElement, Props>(
         <ThemeProvider theme={theme}>
           <LinkedFeedbackCard
             data-selected={isOpen}
-            to={() => {
-              return {
-                pathname: normalizeUrl(`/organizations/${organization.slug}/feedback/`),
-                query: {
-                  ...location.query,
-                  referrer: 'feedback_list_page',
-                  feedbackSlug: `${feedbackItem.project.slug}:${feedbackItem.id}`,
-                },
-              };
+            to={{
+              pathname: normalizeUrl(`/organizations/${organization.slug}/feedback/`),
+              query: {
+                ...location.query,
+                referrer: 'feedback_list_page',
+                feedbackSlug: `${feedbackItem.project.slug}:${feedbackItem.id}`,
+              },
             }}
             onClick={() => {
               trackAnalytics('feedback.list-item-selected', {organization});

--- a/static/app/components/links/link.tsx
+++ b/static/app/components/links/link.tsx
@@ -1,7 +1,7 @@
 import {forwardRef} from 'react';
 import {Link as RouterLink} from 'react-router';
 import styled from '@emotion/styled';
-import type {Location, LocationDescriptor} from 'history';
+import type {LocationDescriptor} from 'history';
 
 import {useLocation} from 'sentry/utils/useLocation';
 import {normalizeUrl} from 'sentry/utils/withDomainRequired';
@@ -22,7 +22,7 @@ export interface LinkProps
    * work in environments that do have customer-domains (saas) and those without
    * customer-domains (single-tenant).
    */
-  to: ((location: Location) => LocationDescriptor) | LocationDescriptor;
+  to: LocationDescriptor;
   /**
    * Style applied to the component's root
    */

--- a/static/app/utils/withDomainRequired.spec.tsx
+++ b/static/app/utils/withDomainRequired.spec.tsx
@@ -1,5 +1,4 @@
 import type {RouteComponentProps} from 'react-router';
-import type {Location, LocationDescriptor, LocationDescriptorObject} from 'history';
 import {LocationFixture} from 'sentry-fixture/locationFixture';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 
@@ -181,43 +180,6 @@ describe('normalizeUrl', function () {
       }
     );
     expect(result.pathname).toEqual('/issues');
-  });
-
-  it('replaces pathname in function callback', function () {
-    const location = LocationFixture();
-    function objectCallback(_loc: Location): LocationDescriptorObject {
-      return {pathname: '/settings/'};
-    }
-    result = normalizeUrl(objectCallback, location);
-    expect(result.pathname).toEqual('/settings/');
-
-    function stringCallback(_loc: Location): LocationDescriptor {
-      return '/organizations/a-long-slug/discover/';
-    }
-    result = normalizeUrl(stringCallback, location);
-    expect(result).toEqual('/discover/');
-
-    // Normalizes urls if options.customerDomain is true and orgslug.sentry.io isn't being used
-    window.__initialData.customerDomain = null;
-
-    function objectCallback2(_loc: Location): LocationDescriptorObject {
-      return {pathname: '/settings/'};
-    }
-    result = normalizeUrl(objectCallback2, location, {forceCustomerDomain: true});
-    expect(result.pathname).toEqual('/settings/');
-
-    function stringCallback2(_loc: Location): LocationDescriptor {
-      return '/organizations/a-long-slug/discover/';
-    }
-    result = normalizeUrl(stringCallback2, location, {forceCustomerDomain: true});
-    expect(result).toEqual('/discover/');
-  });
-
-  it('errors on functions without location', function () {
-    function objectCallback(_loc: Location): LocationDescriptorObject {
-      return {pathname: '/settings/organization'};
-    }
-    expect(() => normalizeUrl(objectCallback)).toThrow();
   });
 });
 

--- a/static/app/utils/withDomainRequired.tsx
+++ b/static/app/utils/withDomainRequired.tsx
@@ -25,8 +25,6 @@ const NORMALIZE_PATTERNS: Array<[pattern: RegExp, replacement: string]> = [
   [/^\/?accept-terms\/[^\/]*\/?$/, '/accept-terms/'],
 ];
 
-type LocationTarget = ((location: Location) => LocationDescriptor) | LocationDescriptor;
-
 type NormalizeUrlOptions = {
   forceCustomerDomain: boolean;
 };
@@ -43,16 +41,16 @@ export function normalizeUrl(
 ): LocationDescriptor;
 
 export function normalizeUrl(
-  path: LocationTarget,
+  path: LocationDescriptor,
   location?: Location,
   options?: NormalizeUrlOptions
-): LocationTarget;
+): LocationDescriptor;
 
 export function normalizeUrl(
-  path: LocationTarget,
+  path: LocationDescriptor,
   location?: Location | NormalizeUrlOptions,
   options?: NormalizeUrlOptions
-): LocationTarget {
+): LocationDescriptor {
   if (location && 'forceCustomerDomain' in location) {
     options = location;
     location = undefined;
@@ -62,15 +60,7 @@ export function normalizeUrl(
     return path;
   }
 
-  let resolved: LocationDescriptor;
-  if (typeof path === 'function') {
-    if (!location) {
-      throw new Error('Cannot resolve function URL without a location');
-    }
-    resolved = path(location);
-  } else {
-    resolved = path;
-  }
+  let resolved = path;
 
   if (typeof resolved === 'string') {
     for (const patternData of NORMALIZE_PATTERNS) {

--- a/static/app/views/replays/replayTable/tableCell.tsx
+++ b/static/app/views/replays/replayTable/tableCell.tsx
@@ -360,7 +360,7 @@ export function ReplayCell({
           {/* Avatar is used instead of ProjectBadge because using ProjectBadge increases spacing, which doesn't look as good */}
           {project ? <Avatar size={12} project={project} /> : null}
           {project ? project.slug : null}
-          <Link to={detailsTab} onClick={trackNavigationEvent}>
+          <Link to={detailsTab()} onClick={trackNavigationEvent}>
             {getShortEventId(replay.id)}
           </Link>
           <Row gap={0.5}>
@@ -382,7 +382,7 @@ export function ReplayCell({
               replay.user.display_name || t('Anonymous User')
             ) : (
               <MainLink
-                to={detailsTab}
+                to={detailsTab()}
                 onClick={trackNavigationEvent}
                 data-has-viewed={replay.has_viewed}
               >


### PR DESCRIPTION
We don't use this and it's not supported in react-router 6