### PR TITLE
fix(seer grouping): Stop checking for missing groups when handling processed results

### DIFF
--- a/src/sentry/api/endpoints/group_similar_issues_embeddings.py
+++ b/src/sentry/api/endpoints/group_similar_issues_embeddings.py
@@ -131,21 +131,7 @@ class GroupSimilarIssuesEmbeddingsEndpoint(GroupEndpoint):
             )
         }
 
-        result = []
-        for group_id in group_data:
-            try:
-                result.append((serialized_groups[group_id], group_data[group_id]))
-            except KeyError:
-                # KeyErrors may occur if seer API returns a deleted/merged group, which means it
-                # will be missing from `serialized_groups`
-                #
-                # TODO: This shouldn't be an issue for merged groups once we only use hashes (since
-                # merging leaves the hashes intact), but it will still be an error for deleted
-                # groups/hashes.
-                #
-                # TODO: Report back to seer that the hash has been deleted.
-                continue
-        return result
+        return [(serialized_groups[group_id], group_data[group_id]) for group_id in group_data]
 
     def get(self, request: Request, group) -> Response:
         if not features.has("projects:similarity-embeddings", group.project):


### PR DESCRIPTION
When Seer sends back information on similar groups, there's no guarantee that those groups still exist on the Sentry side. Therefore, in the similar issues endpoint, we surround our code which handles the Seer results with a `try-except`, in case we look for a group which isn't there. Now that the Seer data is first being processed by the `SeerSimilarIssueData.from_raw` factory method, though, we no longer have to worry about missing groups, because `from_raw` will error out and not create a `SeerSimilarIssueData` instance if the group doesn't exist.

This therefore removes the `try-except`, which then allows us to use a simple list comprehension to build the return value of the endpoint's `get_formatted_results` helper.