### PR TITLE
ref(delayed rules): Don't use a decorator, call add_handler instead

### DIFF
--- a/src/sentry/buffer/redis.py
+++ b/src/sentry/buffer/redis.py
@@ -66,6 +66,9 @@ class BufferHookRegistry:
     def add_handler(self, key: BufferHookEvent, func: Callable[..., Any]) -> None:
         self._registry[key] = func
 
+    def has(self, key: BufferHookEvent):
+        return self._registry.get(key) is not None
+
     def callback(self, buffer_hook_event: BufferHookEvent, data: RedisBuffer) -> bool:
         try:
             callback = self._registry[buffer_hook_event]

--- a/src/sentry/buffer/redis.py
+++ b/src/sentry/buffer/redis.py
@@ -66,7 +66,7 @@ class BufferHookRegistry:
     def add_handler(self, key: BufferHookEvent, func: Callable[..., Any]) -> None:
         self._registry[key] = func
 
-    def has(self, key: BufferHookEvent):
+    def has(self, key: BufferHookEvent) -> bool:
         return self._registry.get(key) is not None
 
     def callback(self, buffer_hook_event: BufferHookEvent, data: RedisBuffer) -> bool:

--- a/src/sentry/buffer/redis.py
+++ b/src/sentry/buffer/redis.py
@@ -63,12 +63,8 @@ class BufferHookRegistry:
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         self._registry: dict[BufferHookEvent, Callable[..., Any]] = {}
 
-    def add_handler(self, key: BufferHookEvent) -> Callable[..., Any]:
-        def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
-            self._registry[key] = func
-            return func
-
-        return decorator
+    def add_handler(self, key: BufferHookEvent, func: Callable[..., Any]) -> None:
+        self._registry[key] = func
 
     def callback(self, buffer_hook_event: BufferHookEvent, data: RedisBuffer) -> bool:
         try:

--- a/src/sentry/rules/processing/delayed_processing.py
+++ b/src/sentry/rules/processing/delayed_processing.py
@@ -5,7 +5,7 @@ from datetime import datetime, timedelta, timezone
 from typing import Any, DefaultDict, NamedTuple
 
 from sentry import nodestore
-from sentry.buffer.redis import BufferHookEvent, RedisBuffer, redis_buffer_registry
+from sentry.buffer.redis import RedisBuffer
 from sentry.eventstore.models import Event, GroupEvent
 from sentry.issues.issue_occurrence import IssueOccurrence
 from sentry.models.group import Group
@@ -292,7 +292,6 @@ def get_group_to_groupevent(
     return group_to_groupevent
 
 
-@redis_buffer_registry.add_handler(BufferHookEvent.FLUSH)
 def process_delayed_alert_conditions(buffer: RedisBuffer) -> None:
     with metrics.timer("delayed_processing.process_all_conditions.duration"):
         fetch_time = datetime.now(tz=timezone.utc)

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -994,7 +994,7 @@ def process_rules(job: PostProcessJob) -> None:
     from sentry.rules.processing.delayed_processing import process_delayed_alert_conditions
 
     if not redis_buffer_registry.has(BufferHookEvent.FLUSH):
-        redis_buffer_registry.add_callback(BufferHookEvent.FLUSH, process_delayed_alert_conditions)
+        redis_buffer_registry.add_handler(BufferHookEvent.FLUSH, process_delayed_alert_conditions)
 
     if job["is_reprocessed"]:
         return

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -990,11 +990,11 @@ def process_replay_link(job: PostProcessJob) -> None:
 
 
 def process_rules(job: PostProcessJob) -> None:
-    from sentry.buffer.redis import BufferHookEvent, BufferHookRegistry
+    from sentry.buffer.redis import BufferHookEvent, redis_buffer_registry
     from sentry.rules.processing.delayed_processing import process_delayed_alert_conditions
 
-    if not BufferHookRegistry._registry.get(BufferHookEvent.FLUSH):
-        BufferHookRegistry.add_callback(BufferHookEvent.FLUSH, process_delayed_alert_conditions)
+    if not redis_buffer_registry.has(BufferHookEvent.FLUSH):
+        redis_buffer_registry.add_callback(BufferHookEvent.FLUSH, process_delayed_alert_conditions)
 
     if job["is_reprocessed"]:
         return

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -990,6 +990,12 @@ def process_replay_link(job: PostProcessJob) -> None:
 
 
 def process_rules(job: PostProcessJob) -> None:
+    from sentry.buffer.redis import BufferHookEvent, BufferHookRegistry
+    from sentry.rules.processing.delayed_processing import process_delayed_alert_conditions
+
+    if not BufferHookRegistry._registry.get(BufferHookEvent.FLUSH):
+        BufferHookRegistry.add_callback(BufferHookEvent.FLUSH, process_delayed_alert_conditions)
+
     if job["is_reprocessed"]:
         return
 


### PR DESCRIPTION
It doesn't seem like any of the delayed processing is being called since it's not imported by anything, so this PR changes the registry pattern a bit so that it does. 