### PR TITLE
ref(delayed rules): Add instrumentation

### DIFF
--- a/src/sentry/rules/processing/delayed_processing.py
+++ b/src/sentry/rules/processing/delayed_processing.py
@@ -333,12 +333,6 @@ def apply_delayed(project_id: int, *args: Any, **kwargs: Any) -> None:
     )
     # STEP 2: Map each rule to the groups that must be checked for that rule.
     rules_to_groups = get_rules_to_groups(rulegroup_to_event_data)
-    logger.info("delayed_processing.num_rules", extra={"rules": len(rules_to_groups.keys())})
-
-    num_groups = 0
-    for groups in rules_to_groups.values():
-        num_groups += len(groups)
-    logger.info("delayed_processing.num_groups", extra={"groups": num_groups})
 
     # STEP 3: Fetch the Rule models we need to check
     alert_rules = Rule.objects.filter(id__in=list(rules_to_groups.keys()))

--- a/src/sentry/rules/processing/processor.py
+++ b/src/sentry/rules/processing/processor.py
@@ -26,7 +26,7 @@ from sentry.rules.conditions.base import EventCondition
 from sentry.rules.conditions.event_frequency import EventFrequencyConditionData
 from sentry.rules.filters.base import EventFilter
 from sentry.types.rules import RuleFuture
-from sentry.utils import json
+from sentry.utils import json, metrics
 from sentry.utils.hashlib import hash_values
 from sentry.utils.safe import safe_execute
 
@@ -275,6 +275,7 @@ class RuleProcessor:
             field=f"{rule.id}:{self.group.id}",
             value=value,
         )
+        metrics.incr("delayed_rule.group_added")
 
     def apply_rule(self, rule: Rule, status: GroupRuleStatus) -> None:
         """


### PR DESCRIPTION
Add instrumentation and logging to the delayed rule processor to measure how long the bulkier functions are taking and how many rules and groups we're processing. 

Closes https://getsentry.atlassian.net/browse/ALRT-19 and https://github.com/getsentry/team-core-product-foundations/issues/308 (a dupe) as a follow up to https://github.com/getsentry/sentry/pull/69830#pullrequestreview-2036397916