### PR TITLE
fix(revenue): Add back metrics for stats page

### DIFF
--- a/static/app/constants/index.tsx
+++ b/static/app/constants/index.tsx
@@ -334,6 +334,18 @@ export const DATA_CATEGORY_INFO = {
     titleName: t('Profile Seconds'),
     uid: 17,
   },
+  /**
+   * Used to display metrics on the stats page
+   */
+  [DataCategoryExact.METRICS]: {
+    name: DataCategoryExact.METRICS,
+    apiName: 'metrics',
+    plural: 'metrics',
+    displayName: 'metrics',
+    titleName: t('Metrics'),
+    // Metrics has no uid, is only used on stats page
+    uid: -1,
+  },
   [DataCategoryExact.METRIC_SECOND]: {
     name: DataCategoryExact.METRIC_SECOND,
     apiName: 'metricSecond',

--- a/static/app/types/core.tsx
+++ b/static/app/types/core.tsx
@@ -101,6 +101,10 @@ export enum DataCategoryExact {
   MONITOR_SEAT = 'monitorSeat',
   PROFILE_DURATION = 'profileDuration',
   SPAN = 'span',
+  /**
+   * Metrics does not actually exist, placeholder until metricSecond is implemented
+   */
+  METRICS = 'metrics',
   METRIC_SECOND = 'metricSecond',
 }
 

--- a/static/app/types/core.tsx
+++ b/static/app/types/core.tsx
@@ -102,7 +102,8 @@ export enum DataCategoryExact {
   PROFILE_DURATION = 'profileDuration',
   SPAN = 'span',
   /**
-   * Metrics does not actually exist, placeholder until metricSecond is implemented
+   * Metrics does not actually exist as a data category, but is used on the stats page.
+   * See metricSecond instead.
    */
   METRICS = 'metrics',
   METRIC_SECOND = 'metricSecond',

--- a/static/app/views/organizationStats/index.tsx
+++ b/static/app/views/organizationStats/index.tsx
@@ -263,7 +263,7 @@ export class OrganizationStats extends Component<OrganizationStatsProps> {
       if (opt.value === DATA_CATEGORY_INFO.replay.plural) {
         return organization.features.includes('session-replay');
       }
-      if (opt.value === DATA_CATEGORY_INFO.metricSecond.plural) {
+      if (opt.value === DATA_CATEGORY_INFO.metrics.plural) {
         return hasMetricStats(organization);
       }
       return true;
@@ -321,7 +321,7 @@ export class OrganizationStats extends Component<OrganizationStatsProps> {
       if (opt.value === DATA_CATEGORY_INFO.replay.plural) {
         return organization.features.includes('session-replay');
       }
-      if (opt.value === DATA_CATEGORY_INFO.metricSecond.plural) {
+      if (opt.value === DATA_CATEGORY_INFO.metrics.plural) {
         return hasMetricStats(organization);
       }
       return true;

--- a/static/app/views/organizationStats/usageChart/index.tsx
+++ b/static/app/views/organizationStats/usageChart/index.tsx
@@ -89,8 +89,8 @@ export const CHART_OPTIONS_DATACATEGORY: CategoryOption[] = [
     yAxisMinInterval: 100,
   },
   {
-    label: DATA_CATEGORY_INFO.metricSecond.titleName,
-    value: DATA_CATEGORY_INFO.metricSecond.plural,
+    label: DATA_CATEGORY_INFO.metrics.titleName,
+    value: DATA_CATEGORY_INFO.metrics.plural,
     disabled: false,
     yAxisMinInterval: 100,
   },
@@ -360,7 +360,7 @@ function UsageChartBody({
 
   const filteredOptions = useMemo(() => {
     return categoryOptions.filter(option => {
-      if (option.value !== DATA_CATEGORY_INFO.metricSecond.plural) {
+      if (option.value !== DATA_CATEGORY_INFO.metrics.plural) {
         return true;
       }
       return (

--- a/static/app/views/organizationStats/usageStatsOrg.tsx
+++ b/static/app/views/organizationStats/usageStatsOrg.tsx
@@ -136,7 +136,7 @@ class UsageStatsOrganization<
           {
             query: {
               ...this.endpointQuery,
-              category: DATA_CATEGORY_INFO.metricSecond.apiName,
+              category: DATA_CATEGORY_INFO.metrics.apiName,
               groupBy: ['outcome'],
             },
           },
@@ -159,7 +159,7 @@ class UsageStatsOrganization<
         ...group,
         by: {
           ...group.by,
-          category: DATA_CATEGORY_INFO.metricSecond.apiName,
+          category: DATA_CATEGORY_INFO.metrics.apiName,
         },
       };
     });
@@ -345,7 +345,7 @@ class UsageStatsOrganization<
       filtered: {
         title: tct('Filtered [dataCategory]', {dataCategory: dataCategoryName}),
         help:
-          dataCategory === DATA_CATEGORY_INFO.metricSecond.plural
+          dataCategory === DATA_CATEGORY_INFO.metrics.plural
             ? tct(
                 'Filtered metrics were blocked due to your disabled metrics [settings: settings]',
                 {

--- a/static/app/views/organizationStats/usageStatsPerMin.tsx
+++ b/static/app/views/organizationStats/usageStatsPerMin.tsx
@@ -78,7 +78,7 @@ function UsageStatsPerMin({dataCategory, organization, projectIds}: Props) {
   };
 
   // Metrics stats ingestion is delayed, so we can't show this for metrics right now
-  if (dataCategory === DATA_CATEGORY_INFO.metricSecond.plural) {
+  if (dataCategory === DATA_CATEGORY_INFO.metrics.plural) {
     return null;
   }
 


### PR DESCRIPTION
instead of using metric hours, use metrics. The stats page and billing will likely not line up here

reverts the changes in https://github.com/getsentry/sentry/pull/70476