### PR TITLE
ref(assignee-selector): Get rid of old component for assignee selector in issue details 

### DIFF
--- a/fixtures/page_objects/issue_details.py
+++ b/fixtures/page_objects/issue_details.py
@@ -86,9 +86,7 @@ class IssueDetailsPage(BasePage):
         assignee.find_element(by=By.TAG_NAME, value="input").send_keys(user)
 
         # Click the member/team
-        options = assignee.find_elements(
-            by=By.CSS_SELECTOR, value='[data-test-id="assignee-option"]'
-        )
+        options = assignee.find_elements(by=By.CSS_SELECTOR, value='[role="option"]')
         assert len(options) > 0, "No assignees could be found."
         options[0].click()
 

--- a/static/app/components/assigneeSelectorDropdown.tsx
+++ b/static/app/components/assigneeSelectorDropdown.tsx
@@ -66,6 +66,10 @@ export interface AssigneeSelectorDropdownProps {
    */
   loading: boolean;
   /**
+   * Additional styles to apply to the dropdown
+   */
+  className?: string;
+  /**
    * Optional list of members to populate the dropdown with.
    */
   memberList?: User[];
@@ -87,10 +91,6 @@ export interface AssigneeSelectorDropdownProps {
    * Optional list of suggested owners of the group
    */
   owners?: Omit<SuggestedAssignee, 'assignee'>[];
-  /**
-   * Additional styles to apply to the dropdown
-   */
-  style?: React.CSSProperties;
   /**
    * Optional trigger for the assignee selector. If nothing passed in,
    * the default trigger will be used
@@ -196,6 +196,7 @@ export function AssigneeAvatar({
 }
 
 export default function AssigneeSelectorDropdown({
+  className,
   group,
   loading,
   memberList,
@@ -203,7 +204,6 @@ export default function AssigneeSelectorDropdown({
   onAssign,
   onClear,
   owners,
-  style,
   trigger,
 }: AssigneeSelectorDropdownProps) {
   const memberLists = useLegacyStore(MemberListStore);
@@ -535,6 +535,7 @@ export default function AssigneeSelectorDropdown({
       <CompactSelect
         searchable
         clearable
+        className={className}
         menuWidth={275}
         disallowEmptySelection={false}
         onClick={e => e.stopPropagation()}
@@ -549,7 +550,6 @@ export default function AssigneeSelectorDropdown({
         size="sm"
         onChange={handleSelect}
         options={makeAllOptions()}
-        style={style}
         trigger={trigger ?? makeTrigger}
         menuFooter={makeFooterInviteButton()}
       />

--- a/static/app/components/assigneeSelectorDropdown.tsx
+++ b/static/app/components/assigneeSelectorDropdown.tsx
@@ -88,6 +88,10 @@ export interface AssigneeSelectorDropdownProps {
    */
   owners?: Omit<SuggestedAssignee, 'assignee'>[];
   /**
+   * Additional styles to apply to the dropdown
+   */
+  style?: React.CSSProperties;
+  /**
    * Optional trigger for the assignee selector. If nothing passed in,
    * the default trigger will be used
    */
@@ -199,6 +203,7 @@ export default function AssigneeSelectorDropdown({
   onAssign,
   onClear,
   owners,
+  style,
   trigger,
 }: AssigneeSelectorDropdownProps) {
   const memberLists = useLegacyStore(MemberListStore);
@@ -539,6 +544,7 @@ export default function AssigneeSelectorDropdown({
         size="sm"
         onChange={handleSelect}
         options={makeAllOptions()}
+        style={style}
         trigger={trigger ?? makeTrigger}
         menuFooter={makeFooterInviteButton()}
       />

--- a/static/app/components/assigneeSelectorDropdown.tsx
+++ b/static/app/components/assigneeSelectorDropdown.tsx
@@ -376,7 +376,10 @@ export default function AssigneeSelectorDropdown({
             data-test-id="assignee-option"
             displayName={`${assignee.name}${isCurrentUser ? ' (You)' : ''}`}
             user={assignee.assignee as User}
-            description={suggestedReasonTable[assignee.suggestedReason]}
+            description={
+              assignee.suggestedReasonText ??
+              suggestedReasonTable[assignee.suggestedReason]
+            }
           />
         ),
         value: `user:${assignee.id}`,
@@ -389,7 +392,9 @@ export default function AssigneeSelectorDropdown({
         <TeamBadge
           data-test-id="assignee-option"
           team={assignedTeam.team}
-          description={suggestedReasonTable[assignee.suggestedReason]}
+          description={
+            assignee.suggestedReasonText ?? suggestedReasonTable[assignee.suggestedReason]
+          }
         />
       ),
       value: `team:${assignee.id}`,

--- a/static/app/components/assigneeSelectorDropdown.tsx
+++ b/static/app/components/assigneeSelectorDropdown.tsx
@@ -513,22 +513,20 @@ export default function AssigneeSelectorDropdown({
     );
   };
 
-  const makeFooterInviteButton = () => {
-    return (
-      <Button
-        size="xs"
-        aria-label={t('Invite Member')}
-        disabled={loading}
-        onClick={(event: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => {
-          event.preventDefault();
-          openInviteMembersModal({source: 'assignee_selector'});
-        }}
-        icon={<IconAdd isCircled />}
-      >
-        {t('Invite Member')}
-      </Button>
-    );
-  };
+  const footerInviteButton = (
+    <Button
+      size="xs"
+      aria-label={t('Invite Member')}
+      disabled={loading}
+      onClick={(event: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => {
+        event.preventDefault();
+        openInviteMembersModal({source: 'assignee_selector'});
+      }}
+      icon={<IconAdd isCircled />}
+    >
+      {t('Invite Member')}
+    </Button>
+  );
 
   return (
     <AssigneeWrapper>
@@ -551,7 +549,7 @@ export default function AssigneeSelectorDropdown({
         onChange={handleSelect}
         options={makeAllOptions()}
         trigger={trigger ?? makeTrigger}
-        menuFooter={makeFooterInviteButton()}
+        menuFooter={footerInviteButton}
       />
     </AssigneeWrapper>
   );

--- a/static/app/components/group/assignedTo.spec.tsx
+++ b/static/app/components/group/assignedTo.spec.tsx
@@ -146,7 +146,11 @@ describe('Group > AssignedTo', () => {
         })
       )
     );
-    expect(onAssign).toHaveBeenCalledWith('team', TEAM_1, undefined);
+    expect(onAssign).toHaveBeenCalledWith(
+      'team',
+      {id: `team:${TEAM_1.id}`, name: TEAM_1.slug, type: 'team'},
+      undefined
+    );
 
     // Group changes are passed down from parent component
     rerender(<AssignedTo project={project} group={assignedGroup} event={event} />);
@@ -189,7 +193,7 @@ describe('Group > AssignedTo', () => {
     // Group changes are passed down from parent component
     rerender(<AssignedTo project={project} group={assignedGroup} event={event} />);
     await openMenu();
-    await userEvent.click(screen.getByRole('button', {name: 'Clear Assignee'}));
+    await userEvent.click(screen.getByRole('button', {name: 'Clear'}));
 
     // api was called with empty string, clearing assignment
     await waitFor(() =>
@@ -255,7 +259,7 @@ describe('Group > AssignedTo', () => {
       )
     );
     expect(onAssign).toHaveBeenCalledWith(
-      'member',
+      'user',
       USER_2,
       expect.objectContaining({
         suggestedReason: 'suspectCommit',

--- a/static/app/components/group/assignedTo.tsx
+++ b/static/app/components/group/assignedTo.tsx
@@ -180,7 +180,6 @@ function AssignedTo({
   const organization = useOrganization();
   const api = useApi();
   const [eventOwners, setEventOwners] = useState<EventOwners | null>(null);
-  const [assigneeLoading, setAssigneeLoading] = useState<boolean>(false);
   const {data} = useCommitters(
     {
       eventId: event?.id ?? '',
@@ -192,7 +191,7 @@ function AssignedTo({
     }
   );
 
-  const {mutate: handleAssigneeChange} = useMutation<
+  const {mutate: handleAssigneeChange, isLoading: assigneeLoading} = useMutation<
     AssignableEntity | null,
     RequestError,
     AssignableEntity | null
@@ -200,7 +199,6 @@ function AssignedTo({
     mutationFn: async (
       newAssignee: AssignableEntity | null
     ): Promise<AssignableEntity | null> => {
-      setAssigneeLoading(true);
       if (newAssignee) {
         await assignToActor({
           id: group.id,
@@ -218,11 +216,9 @@ function AssignedTo({
       if (onAssign && newAssignee) {
         onAssign(newAssignee.type, newAssignee.assignee, newAssignee.suggestedAssignee);
       }
-      setAssigneeLoading(false);
     },
     onError: () => {
       addErrorMessage('Failed to update assignee');
-      setAssigneeLoading(false);
     },
   });
 

--- a/static/app/components/group/assignedTo.tsx
+++ b/static/app/components/group/assignedTo.tsx
@@ -331,9 +331,6 @@ function AssignedTo({
 export default AssignedTo;
 
 const DropdownButton = styled('div')`
-  appearance: none;
-  border: 0;
-  background: transparent;
   display: flex;
   align-items: center;
   gap: ${space(1)};

--- a/static/app/components/group/assignedTo.tsx
+++ b/static/app/components/group/assignedTo.tsx
@@ -308,13 +308,12 @@ function AssignedTo({
         </Access>
       </StyledSidebarTitle>
       <StyledSidebarSectionContent>
-        <AssigneeSelectorDropdown
+        <StyledAssigneeSelectorDropdown
           group={group}
           owners={owners}
           loading={assigneeLoading}
           onAssign={handleAssigneeChange}
           onClear={() => handleAssigneeChange(null)}
-          style={{width: '100%'}}
           trigger={makeTrigger}
         />
       </StyledSidebarSectionContent>
@@ -323,6 +322,10 @@ function AssignedTo({
 }
 
 export default AssignedTo;
+
+const StyledAssigneeSelectorDropdown = styled(AssigneeSelectorDropdown)`
+  width: 100%;
+`;
 
 const DropdownButton = styled('div')`
   display: flex;

--- a/static/app/components/group/assignedTo.tsx
+++ b/static/app/components/group/assignedTo.tsx
@@ -255,8 +255,6 @@ function AssignedTo({
     };
   }, [api, event, organization, project.slug]);
 
-  useEffect(() => {}, []);
-
   const owners = getOwnerList(data?.committers ?? [], eventOwners, group.assignedTo);
 
   const makeTrigger = (props: any, isOpen: boolean) => {

--- a/static/app/components/stream/group.tsx
+++ b/static/app/components/stream/group.tsx
@@ -178,7 +178,7 @@ function BaseGroupRow({
       setAssigneeLoading(false);
     },
     onError: () => {
-      addErrorMessage('Failed to updated assignee');
+      addErrorMessage('Failed to update assignee');
       setAssigneeLoading(false);
     },
   });


### PR DESCRIPTION
This PR swaps the old assignee selector dropdown in the issue details page for the new one that was recently introduced in the issue stream. The design of the trigger has not been changed with the exception of the chevron, which has been changed to use `<Chevron>` instead of `<IconChevron>`.

Closes #69829

Old: 
<img width="309" alt="image" src="https://github.com/getsentry/sentry/assets/55160142/0f3f13ac-f540-4d50-8fa3-e2f8870aa3db">

New:
<img width="307" alt="image" src="https://github.com/getsentry/sentry/assets/55160142/aef22afa-de26-4a50-9e26-7c3edefb752f">

TODOs:
- [x] Fix old tests 