### PR TITLE
fix(files): close mmap in abstract file _prefetch

### DIFF
--- a/src/sentry/models/files/abstractfile.py
+++ b/src/sentry/models/files/abstractfile.py
@@ -107,6 +107,7 @@ class ChunkedFileBlobIndexWrapper:
                 exe.submit(fetch_file, idx.offset, idx.blob.getfile)
 
         mem.flush()
+        mem.close()
         self._curfile = f
 
     def close(self):


### PR DESCRIPTION
we seem to have a lot of warnings about this function and unclosed sockets. reading python docs, it seems like we should close this mmap. I'm not quite sure if this is the source of the log.

https://cloudlogging.app.goo.gl/Yu321395kTNxZFiWA