### PR TITLE
feat(Activated Alerts): implement deploy activator

### DIFF
--- a/src/sentry/models/deploy.py
+++ b/src/sentry/models/deploy.py
@@ -1,5 +1,3 @@
-from typing import TYPE_CHECKING, ClassVar
-
 from django.db import models
 from django.utils import timezone
 
@@ -11,52 +9,10 @@ from sentry.db.models import (
     Model,
     region_silo_model,
 )
-from sentry.db.models.manager import BaseManager
-from sentry.incidents.utils.types import AlertRuleActivationConditionType
 from sentry.locks import locks
 from sentry.models.environment import Environment
 from sentry.types.activity import ActivityType
 from sentry.utils.retries import TimedRetryPolicy
-
-if TYPE_CHECKING:
-    from sentry.models.project import Project
-    from sentry.models.release import Release
-    from sentry.snuba.models import QuerySubscription
-
-
-class DeployModelManager(BaseManager["Deploy"]):
-    @staticmethod
-    def subscribe_project_to_alert_rule(
-        project: Project, release: Release, env_id: int, activator: str, trigger: str
-    ) -> list[QuerySubscription]:
-        """
-        TODO: potentially enable custom query_extra to be passed on ReleaseProject creation (on release/deploy)
-
-        NOTE: import AlertRule model here to avoid circular dependency
-        """
-        from sentry.incidents.models.alert_rule import AlertRule
-
-        query_extra = f"release:{release.version} and env_id:{env_id}"
-        return AlertRule.objects.conditionally_subscribe_project_to_alert_rules(
-            project=project,
-            activation_condition=AlertRuleActivationConditionType.DEPLOY_CREATION,
-            query_extra=query_extra,
-            origin=trigger,
-            activator=activator,
-        )
-
-    def post_save(self, instance, created, **kwargs):
-        if created:
-            release = instance.release
-            projects = release.projects.all()
-            env_id = instance.environment_id
-            for project in projects:
-                self.subscribe_project_to_alert_rule(
-                    project=project,
-                    release=release,
-                    env_id=env_id,
-                    trigger="deploy.post_save",
-                )
 
 
 @region_silo_model
@@ -71,8 +27,6 @@ class Deploy(Model):
     name = models.CharField(max_length=64, null=True, blank=True)
     url = models.URLField(null=True, blank=True)
     notified = models.BooleanField(null=True, db_index=True, default=False)
-
-    objects: ClassVar[DeployModelManager] = DeployModelManager()
 
     class Meta:
         app_label = "sentry"

--- a/src/sentry/models/releaseprojectenvironment.py
+++ b/src/sentry/models/releaseprojectenvironment.py
@@ -34,7 +34,7 @@ class ReleaseStages(str, Enum):
 class ReleaseProjectEnvironmentManager(BaseManager["ReleaseProjectEnvironment"]):
     @staticmethod
     def subscribe_project_to_alert_rule(
-        project: Project, release: Release, environment: Environment, activator: str, trigger: str
+        project: Project, release: Release, environment: Environment, trigger: str
     ) -> list[QuerySubscription]:
         """
         TODO: potentially enable custom query_extra to be passed on ReleaseProject creation (on release/deploy)
@@ -44,6 +44,8 @@ class ReleaseProjectEnvironmentManager(BaseManager["ReleaseProjectEnvironment"])
         from sentry.incidents.models.alert_rule import AlertRule
 
         query_extra = f"release:{release.version} and environment:{environment.name}"
+        # TODO: parse activator on the client to derive release version / environment name
+        activator = f"release:{release.version} and environment:{environment.name}"
         return AlertRule.objects.conditionally_subscribe_project_to_alert_rules(
             project=project,
             activation_condition=AlertRuleActivationConditionType.DEPLOY_CREATION,

--- a/src/sentry/models/releaseprojectenvironment.py
+++ b/src/sentry/models/releaseprojectenvironment.py
@@ -59,15 +59,14 @@ class ReleaseProjectEnvironmentManager(BaseManager["ReleaseProjectEnvironment"])
     def post_save(self, instance, created, **kwargs):
         if created:
             release = instance.release
-            projects = instance.project
+            project = instance.project
             environment = instance.environment
-            for project in projects:
-                self.subscribe_project_to_alert_rule(
-                    project=project,
-                    release=release,
-                    environment=environment,
-                    trigger="releaseprojectenvironment.post_save",
-                )
+            self.subscribe_project_to_alert_rule(
+                project=project,
+                release=release,
+                environment=environment,
+                trigger="releaseprojectenvironment.post_save",
+            )
 
 
 @region_silo_model

--- a/src/sentry/models/releaseprojectenvironment.py
+++ b/src/sentry/models/releaseprojectenvironment.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from datetime import timedelta
 from enum import Enum
 from typing import TYPE_CHECKING, ClassVar

--- a/src/sentry/models/releaseprojectenvironment.py
+++ b/src/sentry/models/releaseprojectenvironment.py
@@ -1,5 +1,6 @@
 from datetime import timedelta
 from enum import Enum
+from typing import TYPE_CHECKING, ClassVar
 
 from django.db import models
 from django.utils import timezone
@@ -12,14 +13,57 @@ from sentry.db.models import (
     region_silo_model,
     sane_repr,
 )
+from sentry.db.models.manager import BaseManager
+from sentry.incidents.utils.types import AlertRuleActivationConditionType
 from sentry.utils import metrics
 from sentry.utils.cache import cache
+
+if TYPE_CHECKING:
+    from sentry.models.environment import Environment
+    from sentry.models.project import Project
+    from sentry.models.release import Release
+    from sentry.snuba.models import QuerySubscription
 
 
 class ReleaseStages(str, Enum):
     ADOPTED = "adopted"
     LOW_ADOPTION = "low_adoption"
     REPLACED = "replaced"
+
+
+class ReleaseProjectEnvironmentManager(BaseManager["ReleaseProjectEnvironment"]):
+    @staticmethod
+    def subscribe_project_to_alert_rule(
+        project: Project, release: Release, environment: Environment, activator: str, trigger: str
+    ) -> list[QuerySubscription]:
+        """
+        TODO: potentially enable custom query_extra to be passed on ReleaseProject creation (on release/deploy)
+
+        NOTE: import AlertRule model here to avoid circular dependency
+        """
+        from sentry.incidents.models.alert_rule import AlertRule
+
+        query_extra = f"release:{release.version} and environment:{environment.name}"
+        return AlertRule.objects.conditionally_subscribe_project_to_alert_rules(
+            project=project,
+            activation_condition=AlertRuleActivationConditionType.DEPLOY_CREATION,
+            query_extra=query_extra,
+            origin=trigger,
+            activator=activator,
+        )
+
+    def post_save(self, instance, created, **kwargs):
+        if created:
+            release = instance.release
+            projects = instance.project
+            environment = instance.environment
+            for project in projects:
+                self.subscribe_project_to_alert_rule(
+                    project=project,
+                    release=release,
+                    environment=environment,
+                    trigger="releaseprojectenvironment.post_save",
+                )
 
 
 @region_silo_model
@@ -36,6 +80,8 @@ class ReleaseProjectEnvironment(Model):
 
     adopted = models.DateTimeField(null=True, blank=True)
     unadopted = models.DateTimeField(null=True, blank=True)
+
+    objects: ClassVar[ReleaseProjectEnvironmentManager] = ReleaseProjectEnvironmentManager()
 
     class Meta:
         app_label = "sentry"

--- a/static/app/views/alerts/rules/metric/ruleConditionsForm.tsx
+++ b/static/app/views/alerts/rules/metric/ruleConditionsForm.tsx
@@ -462,6 +462,10 @@ class RuleConditionsForm extends PureComponent<Props, State> {
                         value: ActivationConditionType.RELEASE_CREATION,
                         label: t('New Release'),
                       },
+                      {
+                        value: ActivationConditionType.DEPLOY_CREATION,
+                        label: t('New Deploy'),
+                      },
                     ]}
                     required
                     value={activationCondition}

--- a/tests/sentry/models/test_releaseprojectenvironment.py
+++ b/tests/sentry/models/test_releaseprojectenvironment.py
@@ -1,10 +1,19 @@
 from datetime import timedelta
+from unittest.mock import call as mock_call
+from unittest.mock import patch
 
 from django.utils import timezone
 
+from sentry.incidents.models.alert_rule import AlertRule, AlertRuleMonitorType
+from sentry.incidents.utils.types import AlertRuleActivationConditionType
 from sentry.models.environment import Environment
 from sentry.models.release import Release
-from sentry.models.releaseprojectenvironment import ReleaseProjectEnvironment
+from sentry.models.releaseprojectenvironment import (
+    ReleaseProjectEnvironment,
+    ReleaseProjectEnvironmentManager,
+)
+from sentry.signals import receivers_raise_on_send
+from sentry.snuba.models import QuerySubscription
 from sentry.testutils.cases import TestCase
 
 
@@ -83,3 +92,68 @@ class GetOrCreateTest(TestCase):
         )
         assert release_project_env.first_seen == self.datetime_now
         assert release_project_env.last_seen == self.datetime_now
+
+    @receivers_raise_on_send()
+    @patch.object(ReleaseProjectEnvironmentManager, "subscribe_project_to_alert_rule")
+    def test_post_save_subscribes_project_to_alert_rule_if_created(
+        self, mock_subscribe_project_to_alert_rule
+    ):
+        ReleaseProjectEnvironment.get_or_create(
+            project=self.project,
+            release=self.release,
+            environment=self.environment,
+            datetime=self.datetime_now,
+        )
+
+        assert mock_subscribe_project_to_alert_rule.call_count == 1
+
+    @patch(
+        "sentry.incidents.models.alert_rule.AlertRule.objects.conditionally_subscribe_project_to_alert_rules"
+    )
+    def test_subscribe_project_to_alert_rule_constructs_query(self, mock_conditionally_subscribe):
+        ReleaseProjectEnvironmentManager.subscribe_project_to_alert_rule(
+            project=self.project, release=self.release, environment=self.environment, trigger="test"
+        )
+
+        assert mock_conditionally_subscribe.call_count == 1
+        assert mock_conditionally_subscribe.mock_calls == [
+            mock_call(
+                project=self.project,
+                activation_condition=AlertRuleActivationConditionType.DEPLOY_CREATION,
+                query_extra=f"release:{self.release.version} and environment:{self.environment.name}",
+                origin="test",
+                activator=f"release:{self.release.version} and environment:{self.environment.name}",
+            )
+        ]
+
+    def test_unmocked_subscribe_project_to_alert_rule_constructs_query(self):
+        # Let the logic flow through to snuba and see whether we properly construct the snuba query
+        # project = self.create_project(name="foo")
+        # release = Release.objects.create(organization_id=project.organization_id, version="42")
+        self.create_alert_rule(
+            projects=[self.project],
+            monitor_type=AlertRuleMonitorType.ACTIVATED,
+            activation_condition=AlertRuleActivationConditionType.DEPLOY_CREATION,
+        )
+
+        subscribe_project = AlertRule.objects.conditionally_subscribe_project_to_alert_rules
+        with patch(
+            "sentry.incidents.models.alert_rule.AlertRule.objects.conditionally_subscribe_project_to_alert_rules",
+            wraps=subscribe_project,
+        ) as wrapped_subscribe_project:
+            with self.tasks():
+                rpe = ReleaseProjectEnvironmentManager.subscribe_project_to_alert_rule(
+                    project=self.project,
+                    release=self.release,
+                    environment=self.environment,
+                    trigger="test",
+                )
+
+                assert rpe
+                assert wrapped_subscribe_project.call_count == 1
+
+                queryset = QuerySubscription.objects.filter(project=self.project)
+                assert queryset.exists()
+
+                sub = queryset.first()
+                assert sub.subscription_id is not None


### PR DESCRIPTION
Deploy reference a specific release being deployed to a specific environment

To activate a monitor for a deploy means to start monitoring per release AND environment for a specific Project.

This PR subscribes the monitor subscription to the creation of a `ReleaseProjectEnvironment` which for all intents and purposes is synonymous with "deploy"