### PR TITLE
fix(new-trace): Missing instrumentation span durations not visible.

### DIFF
--- a/static/app/views/performance/newTraceDetails/trace.tsx
+++ b/static/app/views/performance/newTraceDetails/trace.tsx
@@ -1325,16 +1325,18 @@ function MissingInstrumentationTraceBar(props: MissingInstrumentationTraceBarPro
     },
     [props.manager, props.node_space, props.virtualized_index, duration]
   );
+
   return (
-    <div ref={registerSpanBarRef} className="TraceBar">
+    <Fragment>
+      <div ref={registerSpanBarRef} className="TraceBar">
+        <div className="TracePatternContainer">
+          <div className="TracePattern missing_instrumentation" />
+        </div>
+      </div>
       <div ref={registerSpanBarTextRef} className="TraceBarDuration">
         {duration}
       </div>
-
-      <div className="TracePatternContainer">
-        <div className="TracePattern missing_instrumentation" />
-      </div>
-    </div>
+    </Fragment>
   );
 }
 


### PR DESCRIPTION
<img width="608" alt="Screenshot 2024-05-12 at 8 54 37 PM" src="https://github.com/getsentry/sentry/assets/60121741/40818adf-594f-4378-9617-c6714fab7737">
