### PR TITLE
ref(onboarding): Remove unsupported serverlesscloud (backend)

### DIFF
--- a/src/sentry/dynamic_sampling/rules/helpers/time_to_adoptions.py
+++ b/src/sentry/dynamic_sampling/rules/helpers/time_to_adoptions.py
@@ -85,7 +85,6 @@ LATEST_RELEASE_TTAS = {
     "node-gcpfunctions": 3728,
     "node-koa": 4214,
     "node-nodeawslambda": 3639,
-    "node-serverlesscloud": 11155,
     "objc": 4000209,
     "other": 12019,
     "php": 12112,

--- a/src/sentry/models/project.py
+++ b/src/sentry/models/project.py
@@ -122,7 +122,6 @@ GETTING_STARTED_DOCS_PLATFORMS = [
     "node-hapi",
     "node-koa",
     "node-nestjs",
-    "node-serverlesscloud",
     "php",
     "php-laravel",
     "php-symfony",


### PR DESCRIPTION
Remove already hidden onboarding guide for Serverless Cloud. This package does not exist anymore:  https://www.serverless.com/blog/serverless-cloud-spins-off-as-ampt

ref https://github.com/getsentry/sentry-docs/issues/7718

Merge frontend PR before: https://github.com/getsentry/sentry/pull/70719