### PR TITLE
ref: fix BytesWarnings in data_export tests

### DIFF
--- a/src/sentry/data_export/models.py
+++ b/src/sentry/data_export/models.py
@@ -4,7 +4,6 @@ from django.conf import settings
 from django.db import models, router, transaction
 from django.urls import reverse
 from django.utils import timezone
-from django.utils.encoding import force_str
 
 from sentry.backup.scopes import RelocationScope
 from sentry.db.models import (
@@ -43,7 +42,7 @@ class ExportedData(Model):
     query_info = JSONField()
 
     @property
-    def status(self):
+    def status(self) -> ExportStatus:
         if self.date_finished is None:
             return ExportStatus.Early
         elif self.date_expired is not None and self.date_expired < timezone.now():
@@ -58,16 +57,16 @@ class ExportedData(Model):
         return payload
 
     @property
-    def file_name(self):
+    def file_name(self) -> str:
         date = self.date_added.strftime("%Y-%B-%d")
         export_type = ExportQueryType.as_str(self.query_type)
         # Example: Discover_2020-July-21_27.csv
         return f"{export_type}_{date}_{self.id}.csv"
 
     @staticmethod
-    def format_date(date):
+    def format_date(date) -> str | None:
         # Example: 12:21 PM on July 21, 2020 (UTC)
-        return None if date is None else force_str(date.strftime("%-I:%M %p on %B %d, %Y (%Z)"))
+        return None if date is None else date.strftime("%-I:%M %p on %B %d, %Y (%Z)")
 
     def delete_file(self):
         file = self._get_file()
@@ -85,7 +84,7 @@ class ExportedData(Model):
         self.update(file_id=file.id, date_finished=current_time, date_expired=expire_time)
         transaction.on_commit(lambda: self.email_success(), router.db_for_write(ExportedData))
 
-    def email_success(self):
+    def email_success(self) -> None:
         from sentry.utils.email import MessageBuilder
 
         user_email = None
@@ -113,7 +112,7 @@ class ExportedData(Model):
         if user_email is not None:
             msg.send_async([user_email])
 
-    def email_failure(self, message):
+    def email_failure(self, message: str) -> None:
         from sentry.utils.email import MessageBuilder
 
         user = user_service.get_user(user_id=self.user_id)

--- a/tests/sentry/data_export/test_models.py
+++ b/tests/sentry/data_export/test_models.py
@@ -154,19 +154,19 @@ class ExportedDataTest(TestCase):
 
     def test_email_failure(self):
         with self.tasks():
-            self.data_export.email_failure(self.TEST_STRING)
+            self.data_export.email_failure("failed to export data!")
         assert len(mail.outbox) == 1
         assert not ExportedData.objects.filter(id=self.data_export.id).exists()
 
     @patch("sentry.utils.email.MessageBuilder")
     def test_email_failure_content(self, builder):
         with self.tasks():
-            self.data_export.email_failure(self.TEST_STRING)
+            self.data_export.email_failure("failed to export data!")
         expected_email_args = {
             "subject": "We couldn't export your data.",
             "context": {
                 "creation": ExportedData.format_date(date=self.data_export.date_added),
-                "error_message": self.TEST_STRING,
+                "error_message": "failed to export data!",
                 "payload": json.dumps(self.data_export.payload),
             },
             "type": "organization.export-data",


### PR DESCRIPTION
previously failing (`-b`) with:
```
_______________________________ ExportedDataTest.test_email_failure ________________________________
tests/sentry/data_export/test_models.py:157: in test_email_failure
    self.data_export.email_failure(self.TEST_STRING)
src/sentry/data_export/models.py:134: in email_failure
    msg.send_async([user.email])
src/sentry/utils/email/message_builder.py:241: in send_async
    messages = self.get_built_messages(to, cc=cc, bcc=bcc)
src/sentry/utils/email/message_builder.py:207: in get_built_messages
    results = [
src/sentry/utils/email/message_builder.py:208: in <listcomp>
    self.build(to=email, reply_to=send_to, cc=cc, bcc=bcc) for email in send_to if email
src/sentry/utils/email/message_builder.py:185: in build
    body=self.__render_text_body(),
src/sentry/utils/email/message_builder.py:136: in __render_text_body
    body: str = render_to_string(self.template, self.context)
src/sentry/web/helpers.py:29: in render_to_string
    rendered = loader.render_to_string(template, context=context, request=request)
.venv/lib/python3.11/site-packages/django/template/loader.py:62: in render_to_string
    return template.render(context, request)
.venv/lib/python3.11/site-packages/django/template/backends/django.py:61: in render
    return self.template.render(context)
.venv/lib/python3.11/site-packages/django/template/base.py:171: in render
    return self._render(context)
.venv/lib/python3.11/site-packages/django/test/utils.py:111: in instrumented_test_render
    return self.nodelist.render(context)
.venv/lib/python3.11/site-packages/django/template/base.py:1000: in render
    return SafeString("".join([node.render_annotated(context) for node in self]))
.venv/lib/python3.11/site-packages/django/template/base.py:1000: in <listcomp>
    return SafeString("".join([node.render_annotated(context) for node in self]))
.venv/lib/python3.11/site-packages/django/template/base.py:961: in render_annotated
    return self.render(context)
.venv/lib/python3.11/site-packages/django/template/base.py:1065: in render
    return render_value_in_context(output, context)
.venv/lib/python3.11/site-packages/django/template/base.py:1042: in render_value_in_context
    value = str(value)
E   BytesWarning: str() on a bytes instance
```

<!-- Describe your PR here. -->