### PR TITLE
ref: fix nodestore related BytesWarnings

### DIFF
--- a/src/sentry/db/models/fields/node.py
+++ b/src/sentry/db/models/fields/node.py
@@ -169,7 +169,7 @@ class NodeField(GzippedDictField):
         self.ref_func = kwargs.pop("ref_func", None)
         self.ref_version = kwargs.pop("ref_version", None)
         self.wrapper = kwargs.pop("wrapper", None)
-        self.id_func = kwargs.pop("id_func", lambda: b64encode(uuid4().bytes))
+        self.id_func = kwargs.pop("id_func", lambda: b64encode(uuid4().bytes).decode())
         super().__init__(*args, **kwargs)
 
     def contribute_to_class(self, cls, name):

--- a/tests/sentry/nodestore/django/test_backend.py
+++ b/tests/sentry/nodestore/django/test_backend.py
@@ -53,13 +53,13 @@ class TestDjangoNodeStorage:
         )
 
     def test_delete(self):
-        node = Node.objects.create(id="d2502ebbd7df41ceba8d3275595cac33", data=b'{"foo": "bar"}')
+        node = Node.objects.create(id="d2502ebbd7df41ceba8d3275595cac33", data='{"foo": "bar"}')
 
         self.ns.delete(node.id)
         assert not Node.objects.filter(id=node.id).exists()
 
     def test_delete_multi(self):
-        node = Node.objects.create(id="d2502ebbd7df41ceba8d3275595cac33", data=b'{"foo": "bar"}')
+        node = Node.objects.create(id="d2502ebbd7df41ceba8d3275595cac33", data='{"foo": "bar"}')
 
         self.ns.delete_multi([node.id])
         assert not Node.objects.filter(id=node.id).exists()
@@ -69,11 +69,11 @@ class TestDjangoNodeStorage:
         cutoff = now - timedelta(days=1)
 
         node = Node.objects.create(
-            id="d2502ebbd7df41ceba8d3275595cac33", timestamp=now, data=b'{"foo": "bar"}'
+            id="d2502ebbd7df41ceba8d3275595cac33", timestamp=now, data='{"foo": "bar"}'
         )
 
         node2 = Node.objects.create(
-            id="d2502ebbd7df41ceba8d3275595cac34", timestamp=cutoff, data=b'{"foo": "bar"}'
+            id="d2502ebbd7df41ceba8d3275595cac34", timestamp=cutoff, data='{"foo": "bar"}'
         )
 
         self.ns.cleanup(cutoff)


### PR DESCRIPTION
failing with `-b` with:

```
_____ ProcessingIssueTest.test_with_release_dist_pair_and_previous_issue_without_release_dist ______
tests/sentry/models/test_processingissue.py:112: in test_with_release_dist_pair_and_previous_issue_without_release_dist
    raw_event = RawEvent.objects.create(
src/sentry/silo/base.py:146: in override
    return original_method(*args, **kwargs)
.venv/lib/python3.11/site-packages/django/db/models/manager.py:87: in manager_method
    return getattr(self.get_queryset(), name)(*args, **kwargs)
src/sentry/silo/base.py:146: in override
    return original_method(*args, **kwargs)
.venv/lib/python3.11/site-packages/django/db/models/query.py:679: in create
    obj.save(force_insert=True, using=self.db)
src/sentry/silo/base.py:146: in override
    return original_method(*args, **kwargs)
.venv/lib/python3.11/site-packages/django/db/models/base.py:822: in save
    self.save_base(
src/sentry/silo/base.py:146: in override
    return original_method(*args, **kwargs)
.venv/lib/python3.11/site-packages/django/db/models/base.py:909: in save_base
    updated = self._save_table(
.venv/lib/python3.11/site-packages/django/db/models/base.py:1067: in _save_table
    results = self._do_insert(
.venv/lib/python3.11/site-packages/django/db/models/base.py:1108: in _do_insert
    return manager._insert(
.venv/lib/python3.11/site-packages/django/db/models/manager.py:87: in manager_method
    return getattr(self.get_queryset(), name)(*args, **kwargs)
.venv/lib/python3.11/site-packages/django/db/models/query.py:1847: in _insert
    return query.get_compiler(using=using).execute_sql(returning_fields)
.venv/lib/python3.11/site-packages/django/db/models/sql/compiler.py:1822: in execute_sql
    for sql, params in self.as_sql():
.venv/lib/python3.11/site-packages/django/db/models/sql/compiler.py:1745: in as_sql
    value_rows = [
.venv/lib/python3.11/site-packages/django/db/models/sql/compiler.py:1746: in <listcomp>
    [
.venv/lib/python3.11/site-packages/django/db/models/sql/compiler.py:1747: in <listcomp>
    self.prepare_value(field, self.pre_save_val(field, obj))
.venv/lib/python3.11/site-packages/django/db/models/sql/compiler.py:1686: in prepare_value
    return field.get_db_prep_save(value, connection=self.connection)
.venv/lib/python3.11/site-packages/django/db/models/fields/__init__.py:1013: in get_db_prep_save
    return self.get_db_prep_value(value, connection=connection, prepared=False)
.venv/lib/python3.11/site-packages/django/db/models/fields/__init__.py:1006: in get_db_prep_value
    value = self.get_prep_value(value)
src/sentry/db/models/fields/node.py:245: in get_prep_value
    value.save()
src/sentry/db/models/fields/node.py:159: in save
    nodestore.backend.set_subkeys(self.id, subkeys)
src/sentry/utils/metrics.py:229: in inner
    return f(*args, **kwargs)
.venv/lib/python3.11/site-packages/sentry_sdk/tracing_utils.py:669: in func_with_tracing
    return func(*args, **kwargs)
src/sentry/nodestore/base.py:262: in set_subkeys
    self.set_bytes(item_id, bytes_data, ttl=ttl)
src/sentry/nodestore/base.py:229: in set_bytes
    return self._set_bytes(item_id, data, ttl)
src/sentry/nodestore/django/backend.py:56: in _set_bytes
    create_or_update(Node, id=id, values={"data": compress(data), "timestamp": timezone.now()})
src/sentry/db/models/query.py:151: in create_or_update
    affected = objects.filter(**kwargs).update(**values)
.venv/lib/python3.11/site-packages/django/db/models/query.py:1476: in filter
    return self._filter_or_exclude(False, args, kwargs)
.venv/lib/python3.11/site-packages/django/db/models/query.py:1494: in _filter_or_exclude
    clone._filter_or_exclude_inplace(negate, args, kwargs)
.venv/lib/python3.11/site-packages/django/db/models/query.py:1501: in _filter_or_exclude_inplace
    self._query.add_q(Q(*args, **kwargs))
.venv/lib/python3.11/site-packages/django/db/models/sql/query.py:1613: in add_q
    clause, _ = self._add_q(q_object, self.used_aliases)
.venv/lib/python3.11/site-packages/django/db/models/sql/query.py:1645: in _add_q
    child_clause, needed_inner = self.build_filter(
.venv/lib/python3.11/site-packages/django/db/models/sql/query.py:1559: in build_filter
    condition = self.build_lookup(lookups, col, value)
.venv/lib/python3.11/site-packages/django/db/models/sql/query.py:1389: in build_lookup
    lookup = lookup_class(lhs, rhs)
.venv/lib/python3.11/site-packages/django/db/models/lookups.py:30: in __init__
    self.rhs = self.get_prep_lookup()
.venv/lib/python3.11/site-packages/django/db/models/lookups.py:364: in get_prep_lookup
    return super().get_prep_lookup()
.venv/lib/python3.11/site-packages/django/db/models/lookups.py:88: in get_prep_lookup
    return self.lhs.output_field.get_prep_value(self.rhs)
.venv/lib/python3.11/site-packages/django/db/models/fields/__init__.py:1292: in get_prep_value
    return self.to_python(value)
.venv/lib/python3.11/site-packages/django/db/models/fields/__init__.py:1288: in to_python
    return str(value)
E   BytesWarning: str() on a bytes instance
```

<!-- Describe your PR here. -->