### PR TITLE
ref: move integration docs / sdk registry building to sentry.build

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -556,6 +556,7 @@ module = [
     "sentry.api.helpers.source_map_helper",
     "sentry.buffer.base",
     "sentry.buffer.redis",
+    "sentry.build.*",
     "sentry.eventstore.reprocessing.redis",
     "sentry.issues",
     "sentry.issues.analytics",

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -191,7 +191,7 @@ create-superuser() {
 
 build-platform-assets() {
     echo "--> Building platform assets"
-    echo "from sentry.utils.integrationdocs import sync_docs; sync_docs(quiet=True)" | sentry exec
+    python3 -m sentry.build._integration_docs
     # make sure this didn't silently do nothing
     test -f src/sentry/integration-docs/android.json
 }

--- a/setup.cfg
+++ b/setup.cfg
@@ -97,9 +97,10 @@ extend-ignore = E203,E501,E402,E731,B007,B009,B010,B011,B020,B023,B024,B026,B027
 
 per-file-ignores =
     # these scripts must have minimal dependencies so opt out of the usual sentry rules
-    tools/*: S
     .github/*: S
     devenv/sync.py: S
+    src/sentry/build/*: S
+    tools/*: S
     # testing the options manager itself
     src/sentry/testutils/helpers/options.py, tests/sentry/options/test_manager.py: S011
 

--- a/src/sentry/build/_download.py
+++ b/src/sentry/build/_download.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+import time
+import urllib.request
+from typing import IO
+
+
+def urlopen_with_retries(url: str, timeout: int = 5, retries: int = 10) -> IO[bytes]:
+    for i in range(retries):
+        try:
+            return urllib.request.urlopen(url, timeout=timeout)
+        except Exception:
+            if i == retries - 1:
+                raise
+            time.sleep(i * 0.01)
+    else:
+        raise AssertionError("unreachable")

--- a/src/sentry/build/_integration_docs.py
+++ b/src/sentry/build/_integration_docs.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+import argparse
+import concurrent.futures
+import json
+import multiprocessing
+import os.path
+
+from sentry.build._download import urlopen_with_retries
+
+_INTEGRATION_DOCS_URL = os.environ.get("INTEGRATION_DOCS_URL", "https://docs.sentry.io/_platforms/")
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_TARGET = os.path.join(_HERE, "..", "integration-docs")
+
+
+def _integration_id(platform_id: str, integration_id: str) -> str:
+    if integration_id == "_self":
+        return platform_id
+    return f"{platform_id}-{integration_id}"
+
+
+def _dump_doc(dest: str, path: str, data: object) -> None:
+    expected_commonpath = os.path.realpath(dest)
+    doc_path = os.path.join(dest, f"{path}.json")
+    doc_real_path = os.path.realpath(doc_path)
+
+    if expected_commonpath != os.path.commonpath([expected_commonpath, doc_real_path]):
+        raise AssertionError("illegal path access")
+
+    directory = os.path.dirname(doc_path)
+    os.makedirs(directory, exist_ok=True)
+    with open(doc_path, "w", encoding="utf-8") as f:
+        f.write(json.dumps(data, indent=2))
+        f.write("\n")
+
+
+def _sync_one(
+    dest: str, platform_id: str, integration_id: str, path: str, quiet: bool = False
+) -> None:
+    if not quiet:
+        print(f"  syncing documentation for {platform_id}.{integration_id} integration")
+
+    data = json.load(urlopen_with_retries(f"{_INTEGRATION_DOCS_URL}{path}"))
+
+    key = _integration_id(platform_id, integration_id)
+
+    _dump_doc(
+        dest,
+        key,
+        {
+            "id": key,
+            "name": data["name"],
+            "html": data["body"],
+            "link": data["doc_link"],
+            "wizard_setup": data.get("wizard_setup", None),
+        },
+    )
+
+
+def _sync_docs(dest: str, *, quiet: bool = False) -> None:
+    if not quiet:
+        print("syncing documentation (platform index)")
+    data = json.load(urlopen_with_retries(f"{_INTEGRATION_DOCS_URL}_index.json"))
+    platform_list = []
+    for platform_id, integrations in data["platforms"].items():
+        platform_list.append(
+            {
+                "id": platform_id,
+                "name": integrations["_self"]["name"],
+                "integrations": [
+                    {
+                        "id": _integration_id(platform_id, i_id),
+                        "name": i_data["name"],
+                        "type": i_data["type"],
+                        "link": i_data["doc_link"],
+                    }
+                    for i_id, i_data in sorted(integrations.items(), key=lambda x: x[1]["name"])
+                ],
+            }
+        )
+
+    platform_list.sort(key=lambda x: x["name"])
+
+    _dump_doc(dest, "_platforms", {"platforms": platform_list})
+
+    # This value is derived from https://docs.python.org/3/library/concurrent.futures.html#threadpoolexecutor
+    MAX_THREADS = 32
+    thread_count = min(len(data["platforms"]), multiprocessing.cpu_count() * 5, MAX_THREADS)
+    with concurrent.futures.ThreadPoolExecutor(thread_count) as exe:
+        for future in concurrent.futures.as_completed(
+            exe.submit(
+                _sync_one,
+                dest,
+                platform_id,
+                integration_id,
+                integration["details"],
+                quiet=quiet,
+            )
+            for platform_id, platform_data in data["platforms"].items()
+            for integration_id, integration in platform_data.items()
+        ):
+            future.result()  # needed to trigger exceptions
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--dest", default=_TARGET)
+    parser.add_argument("--quiet", action="store_true")
+    args = parser.parse_args()
+
+    _sync_docs(args.dest, quiet=args.quiet)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/sentry/build/_js_sdk_registry.py
+++ b/src/sentry/build/_js_sdk_registry.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os.path
+
+from sentry.build._download import urlopen_with_retries
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_TARGET = os.path.join(_HERE, "..", "loader")
+
+
+def _download(dest: str) -> None:
+    resp = urlopen_with_retries(
+        "https://release-registry.services.sentry.io/sdks/sentry.javascript.browser/versions"
+    )
+    data = json.load(resp)
+    with open(os.path.join(dest, "_registry.json"), "w", encoding="UTF-8") as f:
+        json.dump(data, f, indent=2)
+
+
+def main() -> int:  # convenience to debug with `python -m ...`
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--dest", default=_TARGET)
+    args = parser.parse_args()
+
+    _download(args.dest)
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/sentry/runner/commands/repair.py
+++ b/src/sentry/runner/commands/repair.py
@@ -1,4 +1,3 @@
-import os
 from collections.abc import Generator
 from contextlib import contextmanager
 
@@ -22,21 +21,6 @@ def catchable_atomic() -> Generator[None, None, None]:
             yield
     except RollbackLocally:
         pass
-
-
-def sync_docs() -> None:
-    click.echo("Forcing documentation sync")
-    from sentry.utils.integrationdocs import DOC_FOLDER, sync_docs
-
-    if os.access(DOC_FOLDER, os.W_OK):
-        try:
-            sync_docs()
-        except Exception as e:
-            click.echo(" - skipping, failure: %s" % e)
-    elif os.path.isdir(DOC_FOLDER):
-        click.echo(" - skipping, path cannot be written to: %r" % DOC_FOLDER)
-    else:
-        click.echo(" - skipping, path does not exist: %r" % DOC_FOLDER)
 
 
 @region_silo_function
@@ -71,23 +55,13 @@ def fix_group_counters() -> None:
 
 
 @click.command()
-@click.option(
-    "--with-docs/--without-docs",
-    default=False,
-    help="Synchronize and repair embedded documentation. This " "is disabled by default.",
-)
 @configuration
-def repair(with_docs: bool) -> None:
+def repair() -> None:
     """Attempt to repair any invalid data.
 
     This by default will correct some common issues like projects missing
-    DSNs or counters desynchronizing.  Optionally it can also synchronize
-    the current client documentation from the Sentry documentation server
-    (--with-docs).
+    DSNs or counters desynchronizing.
     """
-
-    if with_docs:
-        sync_docs()
 
     try:
         create_missing_dsns()

--- a/src/sentry/utils/distutils/commands/build_integration_docs.py
+++ b/src/sentry/utils/distutils/commands/build_integration_docs.py
@@ -1,7 +1,8 @@
 import logging
-import os.path
 
-from .base import ROOT, BaseBuildCommand
+from sentry.build._integration_docs import _TARGET, _sync_docs
+
+from .base import BaseBuildCommand
 
 log = logging.getLogger(__name__)
 
@@ -10,13 +11,9 @@ class BuildIntegrationDocsCommand(BaseBuildCommand):
     description = "build integration docs"
 
     def get_dist_paths(self):
-        return [
-            # Also see sentry.utils.integrationdocs.DOC_FOLDER
-            os.path.join(ROOT, "src", "sentry", "integration-docs")
-        ]
+        # Also see sentry.utils.integrationdocs.DOC_FOLDER
+        return [_TARGET]
 
     def _build(self):
-        from sentry.utils.integrationdocs import sync_docs
-
         log.info("downloading integration docs")
-        sync_docs()
+        _sync_docs(_TARGET)

--- a/src/sentry/utils/distutils/commands/build_js_sdk_registry.py
+++ b/src/sentry/utils/distutils/commands/build_js_sdk_registry.py
@@ -1,39 +1,10 @@
-# NOTE: This is run external to sentry as well as part of the setup
-# process.  Thus we do not want to import non stdlib things here.
-
-import json  # NOQA
-
-# Import the stdlib json instead of sentry.utils.json, since this command is
-# run in setup.py
 import logging
-import os
-from urllib.request import urlopen
 
-import sentry
+from sentry.build._js_sdk_registry import _TARGET, _download
 
 from .base import BaseBuildCommand
 
 log = logging.getLogger(__name__)
-
-JS_SDK_REGISTRY_URL = (
-    "https://release-registry.services.sentry.io/sdks/sentry.javascript.browser/versions"
-)
-LOADER_FOLDER = os.path.abspath(os.path.join(os.path.dirname(sentry.__file__), "loader"))
-
-
-def dump_registry(path, data):
-    fn = os.path.join(LOADER_FOLDER, path + ".json")
-    directory = os.path.dirname(fn)
-    os.makedirs(directory, exist_ok=True)
-    with open(fn, "w", encoding="utf-8") as f:
-        f.write(json.dumps(data, indent=2))
-        f.write("\n")
-
-
-def sync_registry():
-    body = urlopen(JS_SDK_REGISTRY_URL).read().decode("utf-8")
-    data = json.loads(body)
-    dump_registry("_registry", data)
 
 
 class BuildJsSdkRegistryCommand(BaseBuildCommand):
@@ -41,9 +12,4 @@ class BuildJsSdkRegistryCommand(BaseBuildCommand):
 
     def run(self):
         log.info("downloading js sdk information from the release registry")
-        try:
-            sync_registry()
-        except Exception:
-            log.exception(
-                "error occurred while trying to fetch js sdk information from the registry"
-            )
+        _download(_TARGET)

--- a/src/sentry/utils/integrationdocs.py
+++ b/src/sentry/utils/integrationdocs.py
@@ -1,42 +1,11 @@
 from __future__ import annotations
 
-import concurrent.futures
-
-# Import the stdlib json instead of sentry.utils.json, since this command is
-# run at build time
-import json  # noqa: S003
-import logging
-import multiprocessing
 import os
-import sys
-import time
-from typing import IO, Any, TypedDict
-from urllib.request import urlopen
+from typing import Any
+
+import orjson
 
 import sentry
-
-# NOTE: This is run external to sentry as well as part of the setup
-# process.  Thus we do not want to import non stdlib things here.
-
-
-class Integration(TypedDict):
-    key: str
-    type: str
-    details: str
-    doc_link: str
-    name: str
-    aliases: list[str]
-    categories: list[str]
-
-
-class Platform(TypedDict):
-    id: str
-    name: str
-    integrations: list[dict[str, str]]
-
-
-INTEGRATION_DOCS_URL = os.environ.get("INTEGRATION_DOCS_URL", "https://docs.sentry.io/_platforms/")
-BASE_URL = INTEGRATION_DOCS_URL + "{}"
 
 DOC_FOLDER = os.path.abspath(os.path.join(os.path.dirname(sentry.__file__), "integration-docs"))
 
@@ -53,31 +22,9 @@ Add the new language/framework.
 
 Example: https://github.com/getsentry/raven-js/blob/master/docs/sentry-doc-config.json
 
-Once the docs have been deployed, you can run `sentry repair --with-docs` to pull down
+Once the docs have been deployed, you can run `make build-platform-assets` to pull down
 the latest list of integrations and serve them in your local Sentry install.
 """
-
-logger = logging.getLogger("sentry")
-
-
-def echo(what: str) -> None:
-    sys.stdout.write(what + "\n")
-    sys.stdout.flush()
-
-
-def dump_doc(path: str, data: dict[str, Any]) -> None:
-    expected_commonpath = os.path.realpath(DOC_FOLDER)
-    doc_path = os.path.join(DOC_FOLDER, f"{path}.json")
-    doc_real_path = os.path.realpath(doc_path)
-
-    if expected_commonpath != os.path.commonpath([expected_commonpath, doc_real_path]):
-        raise SuspiciousDocPathOperation("illegal path access")
-
-    directory = os.path.dirname(doc_path)
-    os.makedirs(directory, exist_ok=True)
-    with open(doc_path, "w", encoding="utf-8") as f:
-        f.write(json.dumps(data, indent=2))
-        f.write("\n")
 
 
 def load_doc(path: str) -> dict[str, Any] | None:
@@ -90,91 +37,6 @@ def load_doc(path: str) -> dict[str, Any] | None:
 
     try:
         with open(doc_path, encoding="utf-8") as f:
-            return json.load(f)
+            return orjson.loads(f.read())
     except OSError:
         return None
-
-
-def get_integration_id(platform_id: str, integration_id: str) -> str:
-    if integration_id == "_self":
-        return platform_id
-    return f"{platform_id}-{integration_id}"
-
-
-def urlopen_with_retries(url: str, timeout: int = 5, retries: int = 10) -> IO[bytes]:
-    for i in range(retries):
-        try:
-            return urlopen(url, timeout=timeout)
-        except Exception:
-            if i == retries - 1:
-                raise
-            time.sleep(i * 0.01)
-    else:
-        raise AssertionError("unreachable")
-
-
-def sync_docs(quiet: bool = False) -> None:
-    if not quiet:
-        echo("syncing documentation (platform index)")
-    data: dict[str, dict[str, dict[str, Integration]]]
-    data = json.load(urlopen_with_retries(BASE_URL.format("_index.json")))
-    platform_list: list[Platform] = []
-    for platform_id, integrations in data["platforms"].items():
-        platform_list.append(
-            {
-                "id": platform_id,
-                "name": integrations["_self"]["name"],
-                "integrations": [
-                    {
-                        "id": get_integration_id(platform_id, i_id),
-                        "name": i_data["name"],
-                        "type": i_data["type"],
-                        "link": i_data["doc_link"],
-                    }
-                    for i_id, i_data in sorted(integrations.items(), key=lambda x: x[1]["name"])
-                ],
-            }
-        )
-
-    platform_list.sort(key=lambda x: x["name"])
-
-    dump_doc("_platforms", {"platforms": platform_list})
-
-    # This value is derived from https://docs.python.org/3/library/concurrent.futures.html#threadpoolexecutor
-    MAX_THREADS = 32
-    thread_count = min(len(data["platforms"]), multiprocessing.cpu_count() * 5, MAX_THREADS)
-    with concurrent.futures.ThreadPoolExecutor(thread_count) as exe:
-        for future in concurrent.futures.as_completed(
-            exe.submit(
-                sync_integration_docs,
-                platform_id,
-                integration_id,
-                integration["details"],
-                quiet,
-            )
-            for platform_id, platform_data in data["platforms"].items()
-            for integration_id, integration in platform_data.items()
-        ):
-            future.result()  # needed to trigger exceptions
-
-
-def sync_integration_docs(
-    platform_id: str, integration_id: str, path: str, quiet: bool = False
-) -> None:
-    if not quiet:
-        echo(f"  syncing documentation for {platform_id}.{integration_id} integration")
-
-    data = json.load(urlopen_with_retries(BASE_URL.format(path)))
-
-    key = get_integration_id(platform_id, integration_id)
-
-    dump_doc(
-        key,
-        {
-            "id": key,
-            "name": data["name"],
-            "html": data["body"],
-            "link": data["doc_link"],
-            "wizard_setup": data.get("wizard_setup", None),
-        },
-    )

--- a/tests/sentry/utils/test_integrationdocs.py
+++ b/tests/sentry/utils/test_integrationdocs.py
@@ -1,6 +1,6 @@
 import pytest
 
-from sentry.utils.integrationdocs import SuspiciousDocPathOperation, dump_doc, load_doc
+from sentry.utils.integrationdocs import SuspiciousDocPathOperation, load_doc
 
 
 @pytest.mark.parametrize(
@@ -18,28 +18,6 @@ from sentry.utils.integrationdocs import SuspiciousDocPathOperation, dump_doc, l
 def test_path_traversal_attempt_on_load_doc_raises_exception(path):
     with pytest.raises(SuspiciousDocPathOperation) as excinfo:
         load_doc(path)
-
-    (msg,) = excinfo.value.args
-    assert msg == "illegal path access"
-
-
-@pytest.mark.parametrize(
-    "path",
-    [
-        "/",
-        "/..",
-        "//....",
-        "/%5c..",
-        "../",
-        "../../",
-        "../../../etc/passwd",
-    ],
-)
-def test_path_traversal_attempt_on_dump_doc_raises_exception(path):
-    data = {"foo": "bar", "baz": 1234}
-
-    with pytest.raises(SuspiciousDocPathOperation) as excinfo:
-        dump_doc(path, data)
 
     (msg,) = excinfo.value.args
     assert msg == "illegal path access"


### PR DESCRIPTION
I'm planning to kill the setuptools-based build which is blocking our upgrade to python 3.12 -- this is the first step

<!-- Describe your PR here. -->