### PR TITLE
feat(metrics): remove percentiles from Metrics API

### DIFF
--- a/src/sentry/sentry_metrics/querying/operations/__init__.py
+++ b/src/sentry/sentry_metrics/querying/operations/__init__.py
@@ -1,0 +1,3 @@
+from .operations import MetricsOperationsConfig
+
+__all__ = ["MetricsOperationsConfig"]

--- a/src/sentry/sentry_metrics/querying/operations/available_operations.py
+++ b/src/sentry/sentry_metrics/querying/operations/available_operations.py
@@ -1,0 +1,57 @@
+from sentry.sentry_metrics.querying.operations.operation import MetricOp
+from sentry.snuba.dataset import EntityKey
+
+OP_COUNTERS_SUM = MetricOp(EntityKey.GenericMetricsCounters, "sum", "sumIf", "general", 0)
+OP_COUNTERS_MIN_TIMESTAMP = MetricOp(
+    EntityKey.GenericMetricsCounters, "min_timestamp", "minIf", "timestamp"
+)
+OP_COUNTERS_MAX_TIMESTAMP = MetricOp(
+    EntityKey.GenericMetricsCounters, "max_timestamp", "maxIf", "timestamp"
+)
+OP_DISTRIBUTIONS_AVG = MetricOp(EntityKey.GenericMetricsDistributions, "avg", "avgIf", "general")
+OP_DISTRIBUTIONS_COUNT = MetricOp(
+    EntityKey.GenericMetricsDistributions, "count", "countIf", "general"
+)
+OP_DISTRIBUTIONS_MAX = MetricOp(EntityKey.GenericMetricsDistributions, "max", "maxIf", "general")
+OP_DISTRIBUTIONS_MIN = MetricOp(EntityKey.GenericMetricsDistributions, "min", "minIf", "general")
+OP_DISTRIBUTIONS_HISTOGRAM = MetricOp(
+    EntityKey.GenericMetricsDistributions, "histogram", "histogramIf(250)", "general"
+)
+OP_DISTRIBUTIONS_SUM = MetricOp(EntityKey.GenericMetricsDistributions, "sum", "sumIf", "general")
+OP_DISTRIBUTIONS_MIN_TIMESTAMP = MetricOp(
+    EntityKey.GenericMetricsDistributions, "min_timestamp", "minIf", "timestamp"
+)
+OP_DISTRIBUTIONS_MAX_TIMESTAMP = MetricOp(
+    EntityKey.GenericMetricsDistributions, "max_timestamp", "maxIf", "timestamp"
+)
+OP_SETS_COUNT_UNIQUE = MetricOp(EntityKey.GenericMetricsSets, "count_unique", "uniqIf", "general")
+OP_SETS_MIN_TIMESTAMP = MetricOp(
+    EntityKey.GenericMetricsSets, "min_timestamp", "minIf", "timestamp"
+)
+OP_SETS_MAX_TIMESTAMP = MetricOp(
+    EntityKey.GenericMetricsSets, "max_timestamp", "maxIf", "timestamp"
+)
+OP_GAUGES_MIN = MetricOp(EntityKey.GenericMetricsGauges, "min", "minIf", "general")
+OP_GAUGES_MAX = MetricOp(EntityKey.GenericMetricsGauges, "max", "maxIf", "general")
+OP_GAUGES_SUM = MetricOp(EntityKey.GenericMetricsGauges, "sum", "sumIf", "general")
+OP_GAUGES_COUNT = MetricOp(EntityKey.GenericMetricsGauges, "count", "countIf", "general")
+OP_GAUGES_LAST = MetricOp(EntityKey.GenericMetricsGauges, "last", "lastIf", "general")
+OP_GAUGES_AVG = MetricOp(EntityKey.GenericMetricsGauges, "avg", "avg", "general")
+OP_DISTRIBUTIONS_P50 = MetricOp(
+    EntityKey.GenericMetricsDistributions, "p50", "quantilesIf(0.50)", "percentile"
+)
+OP_DISTRIBUTIONS_P75 = MetricOp(
+    EntityKey.GenericMetricsDistributions, "p75", "quantilesIf(0.75)", "percentile"
+)
+OP_DISTRIBUTIONS_P90 = MetricOp(
+    EntityKey.GenericMetricsDistributions, "p90", "quantilesIf(0.90)", "percentile"
+)
+OP_DISTRIBUTIONS_P95 = MetricOp(
+    EntityKey.GenericMetricsDistributions, "p95", "quantilesIf(0.95)", "percentile"
+)
+OP_DISTRIBUTIONS_P99 = MetricOp(
+    EntityKey.GenericMetricsDistributions, "p99", "quantilesIf(0.99)", "percentile"
+)
+OP_DISTRIBUTIONS_P100 = MetricOp(
+    EntityKey.GenericMetricsDistributions, "p100", "quantilesIf(01.100)", "percentile"
+)

--- a/src/sentry/sentry_metrics/querying/operations/operation.py
+++ b/src/sentry/sentry_metrics/querying/operations/operation.py
@@ -1,0 +1,17 @@
+from sentry.snuba.dataset import EntityKey
+
+
+class MetricOp:
+    def __init__(
+        self,
+        entity_key: EntityKey,
+        name: str,
+        snuba_fn: str,
+        operation_class: str = "",
+        default_aggregate: int | float | None = None,
+    ):
+        self.entity_key = entity_key
+        self.name = name
+        self.snuba_fn = snuba_fn
+        self.operation_class = operation_class
+        self.default_aggregate = default_aggregate

--- a/src/sentry/sentry_metrics/querying/operations/operations.py
+++ b/src/sentry/sentry_metrics/querying/operations/operations.py
@@ -1,0 +1,74 @@
+from dataclasses import dataclass, field
+
+from sentry.sentry_metrics.querying.operations.operation import MetricOp
+from sentry.snuba.dataset import EntityKey
+
+
+@dataclass
+class MetricsOperationsConfig:
+    """
+    Use as Singleton?
+        operations = operations_config[entity_type].as_list()
+        operations_config.enable(metric_operation)
+
+    Configure as
+        operations_config = MetricsOperationsConfig().enable_percentiles()
+    """
+
+    operations: list[MetricOp] = field(default_factory=list)
+    enabled_classes: list[str] = field(default_factory=lambda: ["general"])
+
+    def register(self, operation: MetricOp):
+        self.operations.append(operation)
+
+    def enable_class(self, operation_class: str):
+        if operation_class not in self.enabled_classes:
+            self.enabled_classes.append(operation_class)
+
+    def disable_class(self, operation_class: str):
+        if operation_class in self.enabled_classes:
+            self.enabled_classes.remove(operation_class)
+
+    def get_available_operations_for_entity_key(self, entity_key: EntityKey) -> list[MetricOp]:
+        operations = self._get_enabled_operations_for_entity_key(entity_key)
+        return [op for op in operations]
+
+    def get_operation_for_entity_key(self, entity_key: EntityKey, operation_name: str) -> MetricOp:
+
+        operations = [
+            x for x in self.operations if x.entity_key == entity_key and x.name == operation_name
+        ]
+        if len(operations) > 0:
+            return operations[0]
+
+    def get_available_operation_names_for_entity_key(self, entity_key: EntityKey) -> list[str]:
+        return [op.name for op in self._get_enabled_operations_for_entity_key(entity_key)]
+
+    def get_all_available_operation_names(self) -> list[str]:
+        return [
+            operation.name
+            for operation in self.operations
+            if operation.operation_class in self.enabled_classes
+        ]
+
+    def _get_enabled_operations_for_entity_key(self, entity_key: EntityKey) -> list[MetricOp]:
+        return [
+            operation
+            for operation in self.operations
+            if operation.entity_key == entity_key
+            and operation.operation_class in self.enabled_classes
+        ]
+
+    def get_operations_for_class(self, entity_key: EntityKey, operation_class: str) -> list[str]:
+        return [
+            operation.name
+            for operation in self._get_enabled_operations_for_entity_key(entity_key)
+            if operation.operation_class == operation_class
+        ]
+
+    def get_op_to_entity_mapping(self) -> dict[str, str]:
+        return {
+            operation.name: operation.entity_key.name
+            for operation in self.operations
+            if operation.operation_class in self.enabled_classes
+        }

--- a/src/sentry/snuba/metrics/datasource.py
+++ b/src/sentry/snuba/metrics/datasource.py
@@ -68,10 +68,10 @@ from sentry.snuba.metrics.query_builder import (
     translate_meta_results,
 )
 from sentry.snuba.metrics.utils import (
-    AVAILABLE_GENERIC_OPERATIONS,
     AVAILABLE_OPERATIONS,
     CUSTOM_MEASUREMENT_DATASETS,
     METRIC_TYPE_TO_ENTITY,
+    METRICS_OPERATIONS_CONFIG,
     UNALLOWED_TAGS,
     BlockedMetric,
     DerivedMetricParseException,
@@ -474,9 +474,9 @@ def get_custom_measurements(
                     MetricMeta(
                         name=parsed_mri.name,
                         type=metric_type,
-                        operations=AVAILABLE_GENERIC_OPERATIONS[
-                            METRIC_TYPE_TO_ENTITY[metric_type].value
-                        ],
+                        operations=METRICS_OPERATIONS_CONFIG.get_available_operations_for_entity_key(
+                            METRIC_TYPE_TO_ENTITY[metric_type]
+                        ),
                         unit=parsed_mri.unit,
                         metric_id=row["metric_id"],
                         mri=parsed_mri.mri_string,

--- a/src/sentry/snuba/metrics/fields/base.py
+++ b/src/sentry/snuba/metrics/fields/base.py
@@ -68,8 +68,8 @@ from sentry.snuba.metrics.naming_layer.mapping import get_public_name_from_mri
 from sentry.snuba.metrics.naming_layer.mri import SessionMRI, SpanMRI, TransactionMRI
 from sentry.snuba.metrics.utils import (
     DEFAULT_AGGREGATES,
-    GENERIC_OP_TO_SNUBA_FUNCTION,
     GRANULARITY,
+    METRICS_OPERATIONS_CONFIG,
     OP_TO_SNUBA_FUNCTION,
     OPERATIONS_PERCENTILES,
     UNIT_TO_TYPE,
@@ -481,7 +481,9 @@ class RawOp(MetricOperation):
             UseCaseID.CUSTOM,
             UseCaseID.ESCALATING_ISSUES,
         ]:
-            snuba_function = GENERIC_OP_TO_SNUBA_FUNCTION[entity][self.op]
+            snuba_function = METRICS_OPERATIONS_CONFIG.get_operation_for_entity_key(
+                EntityKey(entity), self.op
+            ).snuba_fn
         else:
             snuba_function = OP_TO_SNUBA_FUNCTION[entity][self.op]
 

--- a/src/sentry/snuba/metrics/naming_layer/mri.py
+++ b/src/sentry/snuba/metrics/naming_layer/mri.py
@@ -45,8 +45,8 @@ from sentry.sentry_metrics.use_case_id_registry import UseCaseID
 from sentry.snuba.dataset import EntityKey
 from sentry.snuba.metrics.units import format_value_using_unit_and_op
 from sentry.snuba.metrics.utils import (
-    AVAILABLE_GENERIC_OPERATIONS,
     AVAILABLE_OPERATIONS,
+    METRICS_OPERATIONS_CONFIG,
     OP_REGEX,
     MetricOperationType,
     MetricUnit,
@@ -338,7 +338,7 @@ def get_available_operations(parsed_mri: ParsedMRI) -> Sequence[str]:
         return AVAILABLE_OPERATIONS[entity_key]
     else:
         entity_key = get_entity_key_from_entity_type(parsed_mri.entity, True).value
-        return AVAILABLE_GENERIC_OPERATIONS[entity_key]
+        return METRICS_OPERATIONS_CONFIG.get_available_operations_for_entity_key(entity_key)
 
 
 def extract_use_case_id(mri: str) -> UseCaseID:

--- a/src/sentry/snuba/metrics/utils.py
+++ b/src/sentry/snuba/metrics/utils.py
@@ -29,7 +29,6 @@ __all__ = (
     "MetricMeta",
     "MetricMetaWithTagKeys",
     "OPERATIONS",
-    "OPERATIONS_PERCENTILES",
     "DEFAULT_AGGREGATES",
     "UNIT_TO_TYPE",
     "DerivedMetricException",
@@ -67,12 +66,6 @@ MetricOperationType = Literal[
     "sum",
     "max",
     "min",
-    "p50",
-    "p75",
-    "p90",
-    "p95",
-    "p99",
-    "p100",
     "percentage",
     "histogram",
     "rate",
@@ -151,12 +144,6 @@ OP_TO_SNUBA_FUNCTION = {
         "count": "countIf",
         "max": "maxIf",
         "min": "minIf",
-        "p50": "quantilesIf(0.50)",
-        # TODO: Would be nice to use `quantile(0.50)` (singular) here, but snuba responds with an error
-        "p75": "quantilesIf(0.75)",
-        "p90": "quantilesIf(0.90)",
-        "p95": "quantilesIf(0.95)",
-        "p99": "quantilesIf(0.99)",
         "histogram": "histogramIf(250)",
         "sum": "sumIf",
         "min_timestamp": "minIf",
@@ -350,14 +337,8 @@ class MetricMetaWithTagKeys(MetricMeta):
     tags: Sequence[Tag]
 
 
-OPERATIONS_PERCENTILES = (
-    "p50",
-    "p75",
-    "p90",
-    "p95",
-    "p99",
-    "p100",
-)
+OPERATIONS_PERCENTILES = ()
+
 DERIVED_OPERATIONS = (
     "histogram",
     "rate",
@@ -379,11 +360,7 @@ DERIVED_OPERATIONS = (
     "on_demand_count_web_vitals",
     "on_demand_user_misery",
 )
-OPERATIONS = (
-    ("avg", "count_unique", "count", "max", "min", "sum", "last")
-    + OPERATIONS_PERCENTILES
-    + DERIVED_OPERATIONS
-)
+OPERATIONS = ("avg", "count_unique", "count", "max", "min", "sum", "last") + DERIVED_OPERATIONS
 
 DEFAULT_AGGREGATES: dict[MetricOperationType, int | list[tuple[float]] | None] = {
     "avg": None,
@@ -391,11 +368,6 @@ DEFAULT_AGGREGATES: dict[MetricOperationType, int | list[tuple[float]] | None] =
     "count": 0,
     "min": None,
     "max": None,
-    "p50": None,
-    "p75": None,
-    "p90": None,
-    "p95": None,
-    "p99": None,
     "sum": 0,
     "percentage": None,
     "last": None,

--- a/tests/sentry/api/endpoints/test_organization_metrics_details.py
+++ b/tests/sentry/api/endpoints/test_organization_metrics_details.py
@@ -220,3 +220,13 @@ class OrganizationMetricsDetailsTest(OrganizationMetricsIntegrationTestCase):
         assert data[2]["blockingStatus"] == [
             {"isBlocked": True, "blockedTags": [], "projectId": project_1.id}
         ]
+        assert sorted(data[1]["operations"]) == [
+            "avg",
+            "count",
+            "histogram",
+            "max",
+            "max_timestamp",
+            "min",
+            "min_timestamp",
+            "sum",
+        ]

--- a/tests/sentry/sentry_metrics/querying/operations/test_metrics_operations_configuration.py
+++ b/tests/sentry/sentry_metrics/querying/operations/test_metrics_operations_configuration.py
@@ -1,0 +1,74 @@
+from sentry.sentry_metrics.querying.operations import MetricsOperationsConfig
+from sentry.sentry_metrics.querying.operations.available_operations import (
+    OP_COUNTERS_MIN_TIMESTAMP,
+    OP_COUNTERS_SUM,
+)
+from sentry.snuba.dataset import EntityKey
+
+
+def test_basic_setup() -> None:
+    config = MetricsOperationsConfig()
+    assert len(config.enabled_classes) == 1
+    assert config.enabled_classes[0] == "general"
+
+
+def test_add_enabled_classes() -> None:
+    config = MetricsOperationsConfig()
+    assert len(config.enabled_classes) == 1
+    assert config.enabled_classes[0] == "general"
+
+    config.enable_class("percentile")
+
+    assert len(config.enabled_classes) == 2
+    assert config.enabled_classes == ["general", "percentile"]
+
+
+def test_get_enabled_operations() -> None:
+    config = MetricsOperationsConfig()
+    config.register(OP_COUNTERS_SUM)
+    config.register(OP_COUNTERS_MIN_TIMESTAMP)
+
+    assert config[EntityKey.GenericMetricsDistributions] == []
+    assert config[EntityKey.GenericMetricsCounters] == [
+        OP_COUNTERS_SUM.name,
+    ]
+
+
+def test_get_enabled_operations_with_enabled_class() -> None:
+    config = MetricsOperationsConfig()
+    config.register(OP_COUNTERS_SUM)
+    config.register(OP_COUNTERS_MIN_TIMESTAMP)
+    config.enable_class("timestamp")
+
+    assert config[EntityKey.GenericMetricsDistributions] == []
+    assert config[EntityKey.GenericMetricsCounters] == [
+        OP_COUNTERS_SUM.name,
+        OP_COUNTERS_MIN_TIMESTAMP.name,
+    ]
+
+
+def test_enable_class_is_idempotent() -> None:
+    config = MetricsOperationsConfig()
+    config.register(OP_COUNTERS_SUM)
+    config.register(OP_COUNTERS_MIN_TIMESTAMP)
+    config.enable_class("timestamp")
+    config.enable_class("timestamp")
+
+    assert config[EntityKey.GenericMetricsDistributions] == []
+    assert config[EntityKey.GenericMetricsCounters] == [
+        OP_COUNTERS_SUM.name,
+        OP_COUNTERS_MIN_TIMESTAMP.name,
+    ]
+
+
+def test_get_enabled_operations_with_disabled_class() -> None:
+    config = MetricsOperationsConfig()
+    config.register(OP_COUNTERS_SUM)
+    config.register(OP_COUNTERS_MIN_TIMESTAMP)
+    config.enable_class("timestamp")
+    config.disable_class("general")
+
+    assert config[EntityKey.GenericMetricsDistributions] == []
+    assert config[EntityKey.GenericMetricsCounters] == [
+        OP_COUNTERS_MIN_TIMESTAMP.name,
+    ]

--- a/tests/sentry/snuba/metrics/test_mqb_query_transformer.py
+++ b/tests/sentry/snuba/metrics/test_mqb_query_transformer.py
@@ -194,9 +194,9 @@ VALID_QUERIES_INTEGRATION_TEST_CASES = [
             match=Entity("generic_metrics_distributions"),
             select=[
                 Function(
-                    function="p95",
+                    function="avg",
                     parameters=[Column("d:transactions/duration@millisecond")],
-                    alias="p95",
+                    alias="avg",
                 ),
                 Function(
                     function="rate",
@@ -283,9 +283,9 @@ VALID_QUERIES_INTEGRATION_TEST_CASES = [
             orderby=[
                 OrderBy(
                     exp=Function(
-                        function="p95",
+                        function="avg",
                         parameters=[Column("d:transactions/duration@millisecond")],
-                        alias="p95",
+                        alias="avg",
                     ),
                     direction=Direction.ASC,
                 ),
@@ -312,9 +312,9 @@ VALID_QUERIES_INTEGRATION_TEST_CASES = [
             project_ids=[13],
             select=[
                 MetricField(
-                    op="p95",
+                    op="avg",
                     metric_mri="d:transactions/duration@millisecond",
-                    alias="p95",
+                    alias="avg",
                 ),
                 MetricField(
                     op="rate",
@@ -366,9 +366,9 @@ VALID_QUERIES_INTEGRATION_TEST_CASES = [
             orderby=[
                 MetricOrderByField(
                     field=MetricField(
-                        op="p95",
+                        op="avg",
                         metric_mri="d:transactions/duration@millisecond",
-                        alias="p95",
+                        alias="avg",
                     ),
                     direction=Direction.ASC,
                 ),
@@ -393,9 +393,9 @@ VALID_QUERIES_INTEGRATION_TEST_CASES = [
             match=Entity("generic_metrics_distributions"),
             select=[
                 Function(
-                    function="p95",
+                    function="avg",
                     parameters=[Column("d:transactions/duration@millisecond")],
-                    alias="p95",
+                    alias="avg",
                 ),
                 Function(
                     function="team_key_transaction",
@@ -474,9 +474,9 @@ VALID_QUERIES_INTEGRATION_TEST_CASES = [
                 ),
                 OrderBy(
                     exp=Function(
-                        function="p95",
+                        function="avg",
                         parameters=[Column("d:transactions/duration@millisecond")],
-                        alias="p95",
+                        alias="avg",
                     ),
                     direction=Direction.ASC,
                 ),
@@ -492,9 +492,9 @@ VALID_QUERIES_INTEGRATION_TEST_CASES = [
             project_ids=[13],
             select=[
                 MetricField(
-                    op="p95",
+                    op="avg",
                     metric_mri="d:transactions/duration@millisecond",
-                    alias="p95",
+                    alias="avg",
                 ),
                 MetricField(
                     op="team_key_transaction",
@@ -541,9 +541,9 @@ VALID_QUERIES_INTEGRATION_TEST_CASES = [
                 ),
                 MetricOrderByField(
                     field=MetricField(
-                        op="p95",
+                        op="avg",
                         metric_mri="d:transactions/duration@millisecond",
-                        alias="p95",
+                        alias="avg",
                     ),
                     direction=Direction.ASC,
                 ),
@@ -552,7 +552,7 @@ VALID_QUERIES_INTEGRATION_TEST_CASES = [
             offset=Offset(offset=0),
             include_series=False,
         ),
-        id="team_key_transaction transformation with p95 in select",
+        id="team_key_transaction transformation with avg in select",
     ),
     pytest.param(
         Query(
@@ -712,11 +712,11 @@ VALID_QUERIES_INTEGRATION_TEST_CASES = [
                     alias="apdex",
                 ),
                 Function(
-                    function="p75",
+                    function="avg",
                     parameters=[
                         Column("d:transactions/measurements.cls@millisecond"),
                     ],
-                    alias="p75_measurements_cls",
+                    alias="avg_measurements_cls",
                 ),
                 Function(
                     function="rate",
@@ -728,19 +728,19 @@ VALID_QUERIES_INTEGRATION_TEST_CASES = [
                     alias="tpm",
                 ),
                 Function(
-                    function="p75",
+                    function="avg",
                     parameters=[Column("d:transactions/measurements.fid@millisecond")],
-                    alias="p75_measurements_fid",
+                    alias="avg_measurements_fid",
                 ),
                 Function(
-                    function="p75",
+                    function="avg",
                     parameters=[Column("d:transactions/measurements.fcp@millisecond")],
-                    alias="p75_measurements_fcp",
+                    alias="avg_measurements_fcp",
                 ),
                 Function(
-                    function="p75",
+                    function="avg",
                     parameters=[Column("d:transactions/measurements.lcp@millisecond")],
-                    alias="p75_measurements_lcp",
+                    alias="avg_measurements_lcp",
                 ),
             ],
             groupby=[
@@ -799,9 +799,9 @@ VALID_QUERIES_INTEGRATION_TEST_CASES = [
                     alias="apdex",
                 ),
                 MetricField(
-                    op="p75",
+                    op="avg",
                     metric_mri="d:transactions/measurements.cls@millisecond",
-                    alias="p75_measurements_cls",
+                    alias="avg_measurements_cls",
                 ),
                 MetricField(
                     op="rate",
@@ -810,19 +810,19 @@ VALID_QUERIES_INTEGRATION_TEST_CASES = [
                     alias="tpm",
                 ),
                 MetricField(
-                    op="p75",
+                    op="avg",
                     metric_mri="d:transactions/measurements.fid@millisecond",
-                    alias="p75_measurements_fid",
+                    alias="avg_measurements_fid",
                 ),
                 MetricField(
-                    op="p75",
+                    op="avg",
                     metric_mri="d:transactions/measurements.fcp@millisecond",
-                    alias="p75_measurements_fcp",
+                    alias="avg_measurements_fcp",
                 ),
                 MetricField(
-                    op="p75",
+                    op="avg",
                     metric_mri="d:transactions/measurements.lcp@millisecond",
-                    alias="p75_measurements_lcp",
+                    alias="avg_measurements_lcp",
                 ),
             ],
             start=datetime.datetime(2022, 3, 24, 11, 11, 37, 278535),
@@ -1732,7 +1732,7 @@ INVALID_QUERIES_INTEGRATION_TEST_CASES = [
         _construct_snuba_sdk_query(
             select=[
                 Function(
-                    function="p95",
+                    function="avg",
                     parameters=[],
                     alias="has_value_transaction_count",
                 ),
@@ -1904,16 +1904,16 @@ INVALID_QUERIES_INTEGRATION_TEST_CASES = [
             where=[
                 Condition(
                     lhs=Function(
-                        function="p95",
+                        function="avg",
                         parameters=[Column("d:transactions/duration@millisecond")],
-                        alias="p95",
+                        alias="avg",
                     ),
                     op=Op.EQ,
                     rhs=1,
                 )
             ],
         ),
-        "Unsupported function 'p95' in where",
+        "Unsupported function 'avg' in where",
         id="Unsupported function/operation in where clause",
     ),
     # Validate OrderBy statements


### PR DESCRIPTION
As it has been agreed upon that percentiles shall be removed from the product for now, this PR removes the percentile functions from the available operations for distributions.