### PR TITLE
feat(onboarding): Import/init Sentry on top

### DIFF
--- a/static/app/gettingStartedDocs/node/awslambda.tsx
+++ b/static/app/gettingStartedDocs/node/awslambda.tsx
@@ -17,7 +17,9 @@ import {getInstallConfig, getSdkInitSnippet} from 'sentry/utils/gettingStartedDo
 type Params = DocsParams;
 
 const getSdkSetupSnippet = (params: Params) => `
+// IMPORTANT: Make sure to import Sentry at the top of your file.
 ${getSdkInitSnippet(params, 'aws')}
+// Place any other require/import statements here
 
 exports.handler = Sentry.wrapHandler(async (event, context) => {
   // Your handler code
@@ -50,8 +52,10 @@ const onboarding: OnboardingConfig = {
     {
       type: StepType.CONFIGURE,
       description: tct(
-        "Wrap your lambda handler with Sentry's [code:wraphandler] function:",
+        "Ensure that Sentry is imported and initialized at the beginning of your file, prior to any other [require:require] or [import:import] statements. Then, wrap your lambda handler with Sentry's [code:wraphandler] function:",
         {
+          import: <code />,
+          require: <code />,
           code: <code />,
         }
       ),

--- a/static/app/gettingStartedDocs/node/awslambda.tsx
+++ b/static/app/gettingStartedDocs/node/awslambda.tsx
@@ -17,7 +17,7 @@ import {getInstallConfig, getSdkInitSnippet} from 'sentry/utils/gettingStartedDo
 type Params = DocsParams;
 
 const getSdkSetupSnippet = (params: Params) => `
-// IMPORTANT: Make sure to import Sentry at the top of your file.
+// IMPORTANT: Make sure to import and initialize Sentry at the top of your file.
 ${getSdkInitSnippet(params, 'aws')}
 // Place any other require/import statements here
 

--- a/static/app/gettingStartedDocs/node/azurefunctions.tsx
+++ b/static/app/gettingStartedDocs/node/azurefunctions.tsx
@@ -18,7 +18,7 @@ type Params = DocsParams;
 
 const getSdkSetupSnippet = (params: Params) => `
 "use strict";
-// IMPORTANT: Make sure to import Sentry at the top of your file.
+// IMPORTANT: Make sure to import and initialize Sentry at the top of your file.
 ${getSdkInitSnippet(params, 'node')}
 // Place any other require/import statements here
 

--- a/static/app/gettingStartedDocs/node/azurefunctions.tsx
+++ b/static/app/gettingStartedDocs/node/azurefunctions.tsx
@@ -18,7 +18,9 @@ type Params = DocsParams;
 
 const getSdkSetupSnippet = (params: Params) => `
 "use strict";
+// IMPORTANT: Make sure to import Sentry at the top of your file.
 ${getSdkInitSnippet(params, 'node')}
+// Place any other require/import statements here
 
 module.exports = async function (context, req) {
   try {
@@ -46,7 +48,10 @@ const onboarding: OnboardingConfig = {
   configure: params => [
     {
       type: StepType.CONFIGURE,
-      description: t('To set up Sentry error logging for an Azure Function:'),
+      description: tct(
+        'Ensure that Sentry is imported and initialized at the beginning of your file, prior to any other [require:require] or [import:import] statements.',
+        {import: <code />, require: <code />}
+      ),
       configurations: [
         {
           language: 'javascript',

--- a/static/app/gettingStartedDocs/node/gcpfunctions.tsx
+++ b/static/app/gettingStartedDocs/node/gcpfunctions.tsx
@@ -17,7 +17,9 @@ import {getInstallConfig, getSdkInitSnippet} from 'sentry/utils/gettingStartedDo
 type Params = DocsParams;
 
 const getSdkSetupSnippet = (params: Params) => `
+// IMPORTANT: Make sure to import Sentry at the top of your file.
 ${getSdkInitSnippet(params, 'gpc')}
+// Place any other require/import statements here
 
 // Use wrapHttpFunction to instrument your http functions
 exports.helloHttp = Sentry.wrapHttpFunction((req, res) => {
@@ -72,9 +74,13 @@ const onboarding: OnboardingConfig = {
   configure: params => [
     {
       type: StepType.CONFIGURE,
-      description: tct('Use the Sentry SDK to wrap your functions:', {
-        code: <code />,
-      }),
+      description: tct(
+        'Ensure that Sentry is imported and initialized at the beginning of your file, prior to any other [require:require] or [import:import] statements. Then, use the Sentry SDK to wrap your functions:',
+        {
+          import: <code />,
+          require: <code />,
+        }
+      ),
       configurations: [
         {
           language: 'javascript',

--- a/static/app/gettingStartedDocs/node/gcpfunctions.tsx
+++ b/static/app/gettingStartedDocs/node/gcpfunctions.tsx
@@ -17,7 +17,7 @@ import {getInstallConfig, getSdkInitSnippet} from 'sentry/utils/gettingStartedDo
 type Params = DocsParams;
 
 const getSdkSetupSnippet = (params: Params) => `
-// IMPORTANT: Make sure to import Sentry at the top of your file.
+// IMPORTANT: Make sure to import and initialize Sentry at the top of your file.
 ${getSdkInitSnippet(params, 'gpc')}
 // Place any other require/import statements here
 

--- a/static/app/utils/gettingStartedDocs/node.ts
+++ b/static/app/utils/gettingStartedDocs/node.ts
@@ -153,22 +153,24 @@ export function getImportInstrumentSnippet(): string {
 export const getSdkInitSnippet = (
   params: DocsParams,
   sdkImport: 'node' | 'aws' | 'gpc'
-) => `
-${
-  sdkImport === 'node'
-    ? getDefaultNodeImports({productSelection: getProductSelectionMap(params)}).join('\n')
-    : sdkImport === 'aws'
-      ? getDefaultServerlessImports({
-          productSelection: getProductSelectionMap(params),
-          library: 'aws-serverless',
-        }).join('\n')
-      : sdkImport === 'gpc'
+) =>
+  `${
+    sdkImport === 'node'
+      ? getDefaultNodeImports({productSelection: getProductSelectionMap(params)}).join(
+          '\n'
+        )
+      : sdkImport === 'aws'
         ? getDefaultServerlessImports({
             productSelection: getProductSelectionMap(params),
-            library: 'google-cloud-serverless',
+            library: 'aws-serverless',
           }).join('\n')
-        : ''
-}
+        : sdkImport === 'gpc'
+          ? getDefaultServerlessImports({
+              productSelection: getProductSelectionMap(params),
+              library: 'google-cloud-serverless',
+            }).join('\n')
+          : ''
+  }
 
 Sentry.init({
   dsn: "${params.dsn}",


### PR DESCRIPTION
Updates the serverless snippets to make the top-import of Sentry more clear.
