### PR TITLE
feat(insights): add analytics to database sample panel

### DIFF
--- a/static/app/utils/analytics/performanceAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/performanceAnalyticsEvents.tsx
@@ -1,3 +1,4 @@
+import type {FieldValue} from 'sentry/components/forms/model';
 import type {Organization, PlatformKey} from 'sentry/types';
 
 type SampleTransactionParam = {
@@ -127,6 +128,24 @@ export type PerformanceEventParameters = {
   'performance_views.relative_breakdown.selection': {
     action: string;
   };
+  'performance_views.sample_spans.filter_updated': {
+    filter: string;
+    new_state: FieldValue;
+    organization: Organization;
+    source: string;
+  };
+  'performance_views.sample_spans.opened': {
+    organization: Organization;
+    source: string;
+  };
+  'performance_views.sample_spans.span_clicked': {
+    organization: Organization;
+    source: string;
+  };
+  'performance_views.sample_spans.try_different_samples_clicked': {
+    organization: Organization;
+    source: string;
+  };
   'performance_views.span_summary.change_chart': {
     change_to_display: string;
   };
@@ -253,6 +272,12 @@ export const performanceEventMap: Record<PerformanceEventKey, string | null> = {
   'performance_views.landingv3.table_pagination':
     'Performance Views: Landing Page Transactions Table Page Changed',
   'performance_views.overview.change_chart': 'Performance Views: Change Overview Chart',
+  'performance_views.sample_spans.opened': 'Performance Views: Sample spans panel opened',
+  'performance_views.sample_spans.span_clicked': 'Performance Views: Sample span clicked',
+  'performance_views.sample_spans.try_different_samples_clicked':
+    'Performance Views: Try Different Samples clicked',
+  'performance_views.sample_spans.filter_updated':
+    'Performance Views: Sample spans panel filter updated',
   'performance_views.span_summary.change_chart':
     'Performance Views: Span Summary displayed chart changed',
   'performance_views.spans.change_op': 'Performance Views: Change span operation name',

--- a/static/app/views/performance/browser/resources/resourceSummaryPage/index.tsx
+++ b/static/app/views/performance/browser/resources/resourceSummaryPage/index.tsx
@@ -26,7 +26,7 @@ import {ResourceSpanOps} from 'sentry/views/performance/browser/resources/shared
 import {useResourceModuleFilters} from 'sentry/views/performance/browser/resources/utils/useResourceFilters';
 import {ModulePageProviders} from 'sentry/views/performance/modulePageProviders';
 import {useSpanMetrics} from 'sentry/views/starfish/queries/useDiscover';
-import {SpanMetricsField} from 'sentry/views/starfish/types';
+import {ModuleName, SpanMetricsField} from 'sentry/views/starfish/types';
 import {SampleList} from 'sentry/views/starfish/views/spanSummaryPage/sampleList';
 
 const {
@@ -149,7 +149,7 @@ function ResourceSummary() {
           <SampleList
             transactionRoute="/performance/browser/pageloads/"
             groupId={groupId}
-            moduleName="resources"
+            moduleName={ModuleName.RESOURCE}
             transactionName={transaction as string}
             additionalFields={[HTTP_RESPONSE_CONTENT_LENGTH]}
           />

--- a/static/app/views/performance/browser/resources/resourceSummaryPage/index.tsx
+++ b/static/app/views/performance/browser/resources/resourceSummaryPage/index.tsx
@@ -149,6 +149,7 @@ function ResourceSummary() {
           <SampleList
             transactionRoute="/performance/browser/pageloads/"
             groupId={groupId}
+            moduleName="resources"
             transactionName={transaction as string}
             additionalFields={[HTTP_RESPONSE_CONTENT_LENGTH]}
           />

--- a/static/app/views/performance/database/databaseSpanSummaryPage.tsx
+++ b/static/app/views/performance/database/databaseSpanSummaryPage.tsx
@@ -266,6 +266,7 @@ export function DatabaseSpanSummaryPage({params}: Props) {
 
           <SampleList
             groupId={span[SpanMetricsField.SPAN_GROUP]}
+            moduleName="database"
             transactionName={transaction}
             transactionMethod={transactionMethod}
           />

--- a/static/app/views/performance/database/databaseSpanSummaryPage.tsx
+++ b/static/app/views/performance/database/databaseSpanSummaryPage.tsx
@@ -31,7 +31,7 @@ import {getTimeSpentExplanation} from 'sentry/views/starfish/components/tableCel
 import {useSpanMetrics} from 'sentry/views/starfish/queries/useDiscover';
 import {useSpanMetricsSeries} from 'sentry/views/starfish/queries/useDiscoverSeries';
 import type {SpanMetricsQueryFilters} from 'sentry/views/starfish/types';
-import {SpanFunction, SpanMetricsField} from 'sentry/views/starfish/types';
+import {ModuleName, SpanFunction, SpanMetricsField} from 'sentry/views/starfish/types';
 import {QueryParameterNames} from 'sentry/views/starfish/views/queryParameters';
 import {DataTitles, getThroughputTitle} from 'sentry/views/starfish/views/spans/types';
 import {SampleList} from 'sentry/views/starfish/views/spanSummaryPage/sampleList';
@@ -266,7 +266,7 @@ export function DatabaseSpanSummaryPage({params}: Props) {
 
           <SampleList
             groupId={span[SpanMetricsField.SPAN_GROUP]}
-            moduleName="database"
+            moduleName={ModuleName.DB}
             transactionName={transaction}
             transactionMethod={transactionMethod}
           />

--- a/static/app/views/performance/database/queryTransactionsTable.tsx
+++ b/static/app/views/performance/database/queryTransactionsTable.tsx
@@ -10,6 +10,7 @@ import type {CursorHandler} from 'sentry/components/pagination';
 import Pagination from 'sentry/components/pagination';
 import {t} from 'sentry/locale';
 import type {Organization} from 'sentry/types';
+import {trackAnalytics} from 'sentry/utils/analytics';
 import type {EventsMetaType} from 'sentry/utils/discover/eventView';
 import {getFieldRenderer} from 'sentry/utils/discover/fieldRenderers';
 import type {Sort} from 'sentry/utils/discover/fields';
@@ -161,7 +162,17 @@ function renderBodyCell(
 
     return (
       <OverflowEllipsisTextContainer>
-        <Link to={`${pathname}?${qs.stringify(query)}`}>{label}</Link>
+        <Link
+          onClick={() =>
+            trackAnalytics('performance_views.sample_spans.opened', {
+              organization,
+              source: 'database',
+            })
+          }
+          to={`${pathname}?${qs.stringify(query)}`}
+        >
+          {label}
+        </Link>
       </OverflowEllipsisTextContainer>
     );
   }

--- a/static/app/views/performance/mobile/screenload/screenLoadSpans/samples/samplesContainer.tsx
+++ b/static/app/views/performance/mobile/screenload/screenLoadSpans/samples/samplesContainer.tsx
@@ -24,7 +24,7 @@ import {
 import {isCrossPlatform} from 'sentry/views/performance/mobile/screenload/screens/utils';
 import {useSpanMetrics} from 'sentry/views/starfish/queries/useDiscover';
 import type {SpanMetricsQueryFilters} from 'sentry/views/starfish/types';
-import {SpanMetricsField} from 'sentry/views/starfish/types';
+import {ModuleName, SpanMetricsField} from 'sentry/views/starfish/types';
 import {formatVersionAndCenterTruncate} from 'sentry/views/starfish/utils/centerTruncate';
 import {DataTitles} from 'sentry/views/starfish/views/spans/types';
 import DurationChart from 'sentry/views/starfish/views/spanSummaryPage/sampleList/durationChart';
@@ -182,7 +182,7 @@ export function ScreenLoadSampleContainer({
         onMouseOverSample={sample => setHighlightedSpanId(sample.span_id)}
         groupId={groupId}
         transactionName={transactionName}
-        moduleName="screenLoad"
+        moduleName={ModuleName.SCREEN}
         release={release}
         columnOrder={[
           {

--- a/static/app/views/performance/mobile/screenload/screenLoadSpans/samples/samplesContainer.tsx
+++ b/static/app/views/performance/mobile/screenload/screenLoadSpans/samples/samplesContainer.tsx
@@ -182,6 +182,7 @@ export function ScreenLoadSampleContainer({
         onMouseOverSample={sample => setHighlightedSpanId(sample.span_id)}
         groupId={groupId}
         transactionName={transactionName}
+        moduleName="screenLoad"
         release={release}
         columnOrder={[
           {

--- a/static/app/views/starfish/components/samplesTable/spanSamplesTable.tsx
+++ b/static/app/views/starfish/components/samplesTable/spanSamplesTable.tsx
@@ -7,6 +7,7 @@ import Link from 'sentry/components/links/link';
 import {Tooltip} from 'sentry/components/tooltip';
 import {IconProfiling} from 'sentry/icons/iconProfiling';
 import {t} from 'sentry/locale';
+import {trackAnalytics} from 'sentry/utils/analytics';
 import {generateLinkToEventInTraceView} from 'sentry/utils/discover/urls';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
@@ -67,6 +68,7 @@ type Props = {
   avg: number;
   data: SpanTableRow[];
   isLoading: boolean;
+  moduleName: string;
   columnOrder?: SamplesTableColumnHeader[];
   highlightedSpanId?: string;
   onMouseLeaveSample?: () => void;
@@ -77,6 +79,7 @@ export function SpanSamplesTable({
   isLoading,
   data,
   avg,
+  moduleName,
   highlightedSpanId,
   onMouseLeaveSample,
   onMouseOverSample,
@@ -123,6 +126,12 @@ export function SpanSamplesTable({
     if (column.key === 'span_id') {
       return (
         <Link
+          onClick={() =>
+            trackAnalytics('performance_views.sample_spans.span_clicked', {
+              organization,
+              source: moduleName,
+            })
+          }
           to={generateLinkToEventInTraceView({
             eventId: row['transaction.id'],
             timestamp: row.timestamp,

--- a/static/app/views/starfish/components/samplesTable/spanSamplesTable.tsx
+++ b/static/app/views/starfish/components/samplesTable/spanSamplesTable.tsx
@@ -20,7 +20,7 @@ import {
   TextAlignRight,
 } from 'sentry/views/starfish/components/textAlign';
 import type {SpanSample} from 'sentry/views/starfish/queries/useSpanSamples';
-import {SpanMetricsField} from 'sentry/views/starfish/types';
+import {type ModuleName, SpanMetricsField} from 'sentry/views/starfish/types';
 
 const {HTTP_RESPONSE_CONTENT_LENGTH} = SpanMetricsField;
 
@@ -68,7 +68,7 @@ type Props = {
   avg: number;
   data: SpanTableRow[];
   isLoading: boolean;
-  moduleName: string;
+  moduleName: ModuleName;
   columnOrder?: SamplesTableColumnHeader[];
   highlightedSpanId?: string;
   onMouseLeaveSample?: () => void;

--- a/static/app/views/starfish/types.tsx
+++ b/static/app/views/starfish/types.tsx
@@ -13,6 +13,11 @@ export enum StarfishType {
 export enum ModuleName {
   HTTP = 'http',
   DB = 'db',
+  CACHE = 'cache',
+  VITAL = 'vital',
+  QUEUE = 'queue',
+  SCREEN = 'screen',
+  STARTUP = 'startup',
   RESOURCE = 'resource',
   ALL = '',
   OTHER = 'other',

--- a/static/app/views/starfish/views/spanSummaryPage/sampleList/index.tsx
+++ b/static/app/views/starfish/views/spanSummaryPage/sampleList/index.tsx
@@ -18,7 +18,7 @@ import useRouter from 'sentry/utils/useRouter';
 import {normalizeUrl} from 'sentry/utils/withDomainRequired';
 import DetailPanel from 'sentry/views/starfish/components/detailPanel';
 import {DEFAULT_COLUMN_ORDER} from 'sentry/views/starfish/components/samplesTable/spanSamplesTable';
-import {SpanMetricsField} from 'sentry/views/starfish/types';
+import {type ModuleName, SpanMetricsField} from 'sentry/views/starfish/types';
 import DurationChart from 'sentry/views/starfish/views/spanSummaryPage/sampleList/durationChart';
 import SampleInfo from 'sentry/views/starfish/views/spanSummaryPage/sampleList/sampleInfo';
 import SampleTable from 'sentry/views/starfish/views/spanSummaryPage/sampleList/sampleTable/sampleTable';
@@ -27,7 +27,7 @@ const {HTTP_RESPONSE_CONTENT_LENGTH} = SpanMetricsField;
 
 type Props = {
   groupId: string;
-  moduleName: string;
+  moduleName: ModuleName;
   transactionName: string;
   additionalFields?: string[];
   onClose?: () => void;

--- a/static/app/views/starfish/views/spanSummaryPage/sampleList/index.tsx
+++ b/static/app/views/starfish/views/spanSummaryPage/sampleList/index.tsx
@@ -27,6 +27,7 @@ const {HTTP_RESPONSE_CONTENT_LENGTH} = SpanMetricsField;
 
 type Props = {
   groupId: string;
+  moduleName: string;
   transactionName: string;
   additionalFields?: string[];
   onClose?: () => void;
@@ -37,6 +38,7 @@ type Props = {
 
 export function SampleList({
   groupId,
+  moduleName,
   transactionName,
   transactionMethod,
   spanDescription,
@@ -171,6 +173,7 @@ export function SampleList({
           onMouseLeaveSample={() => setHighlightedSpanId(undefined)}
           onMouseOverSample={sample => setHighlightedSpanId(sample.span_id)}
           groupId={groupId}
+          moduleName={moduleName}
           transactionName={transactionName}
           query={extraQuery}
           columnOrder={columnOrder}

--- a/static/app/views/starfish/views/spanSummaryPage/sampleList/sampleTable/sampleTable.spec.tsx
+++ b/static/app/views/starfish/views/spanSummaryPage/sampleList/sampleTable/sampleTable.spec.tsx
@@ -43,6 +43,7 @@ describe('SampleTable', function () {
       const container = render(
         <SampleTable
           groupId="groupId123"
+          moduleName="sampleModule"
           transactionMethod="GET"
           transactionName="/endpoint"
         />
@@ -55,6 +56,7 @@ describe('SampleTable', function () {
       const container = render(
         <SampleTable
           groupId="groupId123"
+          moduleName="sampleModule"
           transactionMethod="GET"
           transactionName="/endpoint"
         />
@@ -68,6 +70,7 @@ describe('SampleTable', function () {
       const container = render(
         <SampleTable
           groupId="groupId123"
+          moduleName="sampleModule"
           transactionMethod="GET"
           transactionName="/endpoint"
         />
@@ -89,6 +92,7 @@ describe('SampleTable', function () {
       const container = render(
         <SampleTable
           groupId="groupId123"
+          moduleName="sampleModule"
           transactionMethod="GET"
           transactionName="/endpoint"
           columnOrder={[
@@ -137,6 +141,7 @@ describe('SampleTable', function () {
       const container = render(
         <SampleTable
           groupId="groupId123"
+          moduleName="sampleModule"
           transactionMethod="GET"
           transactionName="/endpoint"
         />

--- a/static/app/views/starfish/views/spanSummaryPage/sampleList/sampleTable/sampleTable.spec.tsx
+++ b/static/app/views/starfish/views/spanSummaryPage/sampleList/sampleTable/sampleTable.spec.tsx
@@ -7,7 +7,7 @@ import {
 import {COL_WIDTH_UNDEFINED} from 'sentry/components/gridEditable';
 import {t} from 'sentry/locale';
 import type {PageFilters} from 'sentry/types/core';
-import {SpanMetricsField} from 'sentry/views/starfish/types';
+import {ModuleName, SpanMetricsField} from 'sentry/views/starfish/types';
 
 import SampleTable from './sampleTable';
 
@@ -43,7 +43,7 @@ describe('SampleTable', function () {
       const container = render(
         <SampleTable
           groupId="groupId123"
-          moduleName="sampleModule"
+          moduleName={ModuleName.OTHER}
           transactionMethod="GET"
           transactionName="/endpoint"
         />
@@ -56,7 +56,7 @@ describe('SampleTable', function () {
       const container = render(
         <SampleTable
           groupId="groupId123"
-          moduleName="sampleModule"
+          moduleName={ModuleName.OTHER}
           transactionMethod="GET"
           transactionName="/endpoint"
         />
@@ -70,7 +70,7 @@ describe('SampleTable', function () {
       const container = render(
         <SampleTable
           groupId="groupId123"
-          moduleName="sampleModule"
+          moduleName={ModuleName.OTHER}
           transactionMethod="GET"
           transactionName="/endpoint"
         />
@@ -92,7 +92,7 @@ describe('SampleTable', function () {
       const container = render(
         <SampleTable
           groupId="groupId123"
-          moduleName="sampleModule"
+          moduleName={ModuleName.OTHER}
           transactionMethod="GET"
           transactionName="/endpoint"
           columnOrder={[
@@ -141,7 +141,7 @@ describe('SampleTable', function () {
       const container = render(
         <SampleTable
           groupId="groupId123"
-          moduleName="sampleModule"
+          moduleName={ModuleName.OTHER}
           transactionMethod="GET"
           transactionName="/endpoint"
         />

--- a/static/app/views/starfish/views/spanSummaryPage/sampleList/sampleTable/sampleTable.tsx
+++ b/static/app/views/starfish/views/spanSummaryPage/sampleList/sampleTable/sampleTable.tsx
@@ -27,6 +27,7 @@ const SpanSamplesTableContainer = styled('div')`
 
 type Props = {
   groupId: string;
+  moduleName: string;
   transactionName: string;
   additionalFields?: string[];
   additionalFilters?: Record<string, string>;
@@ -41,6 +42,7 @@ type Props = {
 
 function SampleTable({
   groupId,
+  moduleName,
   transactionName,
   highlightedSpanId,
   onMouseLeaveSample,
@@ -152,6 +154,7 @@ function SampleTable({
         hasData={spans.length > 0}
       >
         <SpanSamplesTable
+          moduleName={moduleName}
           onMouseLeaveSample={onMouseLeaveSample}
           onMouseOverSample={onMouseOverSample}
           highlightedSpanId={highlightedSpanId}
@@ -167,7 +170,17 @@ function SampleTable({
           avg={spanMetrics?.[`avg(${SPAN_SELF_TIME})`]}
         />
       </VisuallyCompleteWithData>
-      <Button onClick={() => refetch()}>{t('Try Different Samples')}</Button>
+      <Button
+        onClick={() => {
+          trackAnalytics('performance_views.sample_spans.try_different_samples_clicked', {
+            organization,
+            source: moduleName,
+          });
+          refetch();
+        }}
+      >
+        {t('Try Different Samples')}
+      </Button>
     </SpanSamplesTableContainer>
   );
 }

--- a/static/app/views/starfish/views/spanSummaryPage/sampleList/sampleTable/sampleTable.tsx
+++ b/static/app/views/starfish/views/spanSummaryPage/sampleList/sampleTable/sampleTable.tsx
@@ -16,7 +16,7 @@ import {useSpanMetrics} from 'sentry/views/starfish/queries/useDiscover';
 import type {SpanSample} from 'sentry/views/starfish/queries/useSpanSamples';
 import {useSpanSamples} from 'sentry/views/starfish/queries/useSpanSamples';
 import {useTransactions} from 'sentry/views/starfish/queries/useTransactions';
-import type {SpanMetricsQueryFilters} from 'sentry/views/starfish/types';
+import type {ModuleName, SpanMetricsQueryFilters} from 'sentry/views/starfish/types';
 import {SpanMetricsField} from 'sentry/views/starfish/types';
 
 const {SPAN_SELF_TIME, SPAN_OP} = SpanMetricsField;
@@ -27,7 +27,7 @@ const SpanSamplesTableContainer = styled('div')`
 
 type Props = {
   groupId: string;
-  moduleName: string;
+  moduleName: ModuleName;
   transactionName: string;
   additionalFields?: string[];
   additionalFilters?: Record<string, string>;

--- a/static/app/views/starfish/views/spans/selectors/actionSelector.tsx
+++ b/static/app/views/starfish/views/spans/selectors/actionSelector.tsx
@@ -102,6 +102,11 @@ const HTTP_ACTION_OPTIONS = [
 const LABEL_FOR_MODULE_NAME: {[key in ModuleName]: ReactNode} = {
   http: t('HTTP Method'),
   db: t('SQL Command'),
+  cache: t('Action'),
+  vital: t('Action'),
+  queue: t('Action'),
+  screen: t('Action'),
+  startup: t('Action'),
   resource: t('Resource'),
   other: t('Action'),
   '': t('Action'),

--- a/static/app/views/starfish/views/spans/selectors/domainSelector.tsx
+++ b/static/app/views/starfish/views/spans/selectors/domainSelector.tsx
@@ -170,6 +170,11 @@ const LIMIT = 100;
 const LABEL_FOR_MODULE_NAME: {[key in ModuleName]: ReactNode} = {
   http: t('Host'),
   db: t('Table'),
+  cache: t('Domain'),
+  vital: t('Domain'),
+  queue: t('Domain'),
+  screen: t('Domain'),
+  startup: t('Domain'),
   resource: t('Resource'),
   other: t('Domain'),
   '': t('Domain'),

--- a/static/app/views/starfish/views/spans/spanTimeCharts.tsx
+++ b/static/app/views/starfish/views/spans/spanTimeCharts.tsx
@@ -87,6 +87,11 @@ export function SpanTimeCharts({
       {title: getDurationChartTitle(moduleName), Comp: DurationChart},
     ],
     [ModuleName.DB]: [],
+    [ModuleName.CACHE]: [],
+    [ModuleName.VITAL]: [],
+    [ModuleName.QUEUE]: [],
+    [ModuleName.SCREEN]: [],
+    [ModuleName.STARTUP]: [],
     [ModuleName.RESOURCE]: features.includes(
       'starfish-browser-resource-module-bundle-analysis'
     )


### PR DESCRIPTION
Adds analytics to the span sample panel to track:
- How often the panels are opened
- How often spans are clicked
- How often “Try different samples” is clicked
- How often filters are interacted with

This PR adds analytics to database only as a first step. I'll be adding analytics to the remaining modules in the next PR.