### PR TITLE
ref(insights): Wrap AI module in `ModulePageProviders`

### DIFF
--- a/static/app/views/aiMonitoring/PipelinesTable.tsx
+++ b/static/app/views/aiMonitoring/PipelinesTable.tsx
@@ -1,5 +1,6 @@
 import styled from '@emotion/styled';
 import type {Location} from 'history';
+import * as qs from 'query-string';
 
 import GridEditable, {
   COL_WIDTH_UNDEFINED,
@@ -228,10 +229,16 @@ function renderBodyCell(
     if (!row['span.group']) {
       return <span>{row['span.description']}</span>;
     }
+
+    const queryString = {
+      ...location.query,
+      'span.description': row['span.description'],
+    };
+
     return (
       <Link
         to={normalizeUrl(
-          `/organizations/${organization.slug}/ai-monitoring/pipeline-type/${row['span.group']}`
+          `/organizations/${organization.slug}/ai-monitoring/pipeline-type/${row['span.group']}?${qs.stringify(queryString)}`
         )}
       >
         {row['span.description']}

--- a/static/app/views/aiMonitoring/aiMonitoringDetailsPage.tsx
+++ b/static/app/views/aiMonitoring/aiMonitoringDetailsPage.tsx
@@ -1,16 +1,12 @@
 import styled from '@emotion/styled';
 
-import Feature from 'sentry/components/acl/feature';
-import {Alert} from 'sentry/components/alert';
 import {Breadcrumbs} from 'sentry/components/breadcrumbs';
 import * as Layout from 'sentry/components/layouts/thirds';
 import NoProjectMessage from 'sentry/components/noProjectMessage';
 import {DatePageFilter} from 'sentry/components/organizations/datePageFilter';
 import {EnvironmentPageFilter} from 'sentry/components/organizations/environmentPageFilter';
 import PageFilterBar from 'sentry/components/organizations/pageFilterBar';
-import PageFiltersContainer from 'sentry/components/organizations/pageFilters/container';
 import {ProjectPageFilter} from 'sentry/components/organizations/projectPageFilter';
-import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {CurrencyUnit, DurationUnit, RateUnit} from 'sentry/utils/discover/fields';
@@ -25,6 +21,7 @@ import {
 import {PipelineSpansTable} from 'sentry/views/aiMonitoring/pipelineSpansTable';
 import {MetricReadout} from 'sentry/views/performance/metricReadout';
 import * as ModuleLayout from 'sentry/views/performance/moduleLayout';
+import {ModulePageProviders} from 'sentry/views/performance/modulePageProviders';
 import {useSpanMetrics} from 'sentry/views/starfish/queries/useDiscover';
 import {
   SpanFunction,
@@ -32,20 +29,13 @@ import {
   type SpanMetricsQueryFilters,
 } from 'sentry/views/starfish/types';
 
-function NoAccessComponent() {
-  return (
-    <Layout.Page withPadding>
-      <Alert type="warning">{t("You don't have access to this feature")}</Alert>
-    </Layout.Page>
-  );
-}
 interface Props {
   params: {
     groupId: string;
   };
 }
 
-export default function AiMonitoringPage({params}: Props) {
+export function AiMonitoringPage({params}: Props) {
   const organization = useOrganization();
   const {groupId} = params;
 
@@ -87,107 +77,103 @@ export default function AiMonitoringPage({params}: Props) {
   const tokenUsedMetric = totalTokenData[0] ?? {};
 
   return (
-    <PageFiltersContainer>
-      <SentryDocumentTitle
-        title={`AI Monitoring — ${spanMetrics['span.description'] ?? t('(no name)')}`}
-      >
-        <Layout.Page>
-          <Feature
-            features="ai-analytics"
-            organization={organization}
-            renderDisabled={NoAccessComponent}
-          >
-            <NoProjectMessage organization={organization}>
-              <Layout.Header>
-                <Layout.HeaderContent>
-                  <Breadcrumbs
-                    crumbs={[
-                      {
-                        label: t('Dashboard'),
-                      },
-                      {
-                        label: t('AI Monitoring'),
-                      },
-                      {
-                        label: spanMetrics['span.description'] ?? t('(no name)'),
-                        to: normalizeUrl(
-                          `/organizations/${organization.slug}/ai-monitoring`
-                        ),
-                      },
-                    ]}
-                  />
-                  <Layout.Title>{t('AI Monitoring')}</Layout.Title>
-                </Layout.HeaderContent>
-              </Layout.Header>
-              <Layout.Body>
-                <Layout.Main fullWidth>
-                  <ModuleLayout.Layout>
-                    <ModuleLayout.Full>
-                      <SpaceBetweenWrap>
-                        <PageFilterBar condensed>
-                          <ProjectPageFilter />
-                          <EnvironmentPageFilter />
-                          <DatePageFilter />
-                        </PageFilterBar>
-                        <MetricsRibbon>
-                          <MetricReadout
-                            title={t('Total Tokens Used')}
-                            value={tokenUsedMetric['ai_total_tokens_used()']}
-                            unit={'count'}
-                            isLoading={isTotalTokenDataLoading}
-                          />
+    <Layout.Page>
+      <NoProjectMessage organization={organization}>
+        <Layout.Header>
+          <Layout.HeaderContent>
+            <Breadcrumbs
+              crumbs={[
+                {
+                  label: t('Dashboard'),
+                },
+                {
+                  label: t('AI Monitoring'),
+                },
+                {
+                  label: spanMetrics['span.description'] ?? t('(no name)'),
+                  to: normalizeUrl(`/organizations/${organization.slug}/ai-monitoring`),
+                },
+              ]}
+            />
+            <Layout.Title>{t('AI Monitoring')}</Layout.Title>
+          </Layout.HeaderContent>
+        </Layout.Header>
+        <Layout.Body>
+          <Layout.Main fullWidth>
+            <ModuleLayout.Layout>
+              <ModuleLayout.Full>
+                <SpaceBetweenWrap>
+                  <PageFilterBar condensed>
+                    <ProjectPageFilter />
+                    <EnvironmentPageFilter />
+                    <DatePageFilter />
+                  </PageFilterBar>
+                  <MetricsRibbon>
+                    <MetricReadout
+                      title={t('Total Tokens Used')}
+                      value={tokenUsedMetric['ai_total_tokens_used()']}
+                      unit={'count'}
+                      isLoading={isTotalTokenDataLoading}
+                    />
 
-                          <MetricReadout
-                            title={t('Total Cost')}
-                            value={
-                              tokenUsedMetric[
-                                'ai_total_tokens_used(c:spans/ai.total_cost@usd)'
-                              ]
-                            }
-                            unit={CurrencyUnit.USD}
-                            isLoading={isTotalTokenDataLoading}
-                          />
+                    <MetricReadout
+                      title={t('Total Cost')}
+                      value={
+                        tokenUsedMetric['ai_total_tokens_used(c:spans/ai.total_cost@usd)']
+                      }
+                      unit={CurrencyUnit.USD}
+                      isLoading={isTotalTokenDataLoading}
+                    />
 
-                          <MetricReadout
-                            title={t('Pipeline Duration')}
-                            value={
-                              spanMetrics?.[`avg(${SpanMetricsField.SPAN_DURATION})`]
-                            }
-                            unit={DurationUnit.MILLISECOND}
-                            isLoading={areSpanMetricsLoading}
-                          />
+                    <MetricReadout
+                      title={t('Pipeline Duration')}
+                      value={spanMetrics?.[`avg(${SpanMetricsField.SPAN_DURATION})`]}
+                      unit={DurationUnit.MILLISECOND}
+                      isLoading={areSpanMetricsLoading}
+                    />
 
-                          <MetricReadout
-                            title={t('Pipeline Runs Per Minute')}
-                            value={spanMetrics?.[`${SpanFunction.SPM}()`]}
-                            unit={RateUnit.PER_MINUTE}
-                            isLoading={areSpanMetricsLoading}
-                          />
-                        </MetricsRibbon>
-                      </SpaceBetweenWrap>
-                    </ModuleLayout.Full>
-                    <ModuleLayout.Third>
-                      <TotalTokensUsedChart groupId={groupId} />
-                    </ModuleLayout.Third>
-                    <ModuleLayout.Third>
-                      <NumberOfPipelinesChart groupId={groupId} />
-                    </ModuleLayout.Third>
-                    <ModuleLayout.Third>
-                      <PipelineDurationChart groupId={groupId} />
-                    </ModuleLayout.Third>
-                    <ModuleLayout.Full>
-                      <PipelineSpansTable groupId={groupId} />
-                    </ModuleLayout.Full>
-                  </ModuleLayout.Layout>
-                </Layout.Main>
-              </Layout.Body>
-            </NoProjectMessage>
-          </Feature>
-        </Layout.Page>
-      </SentryDocumentTitle>
-    </PageFiltersContainer>
+                    <MetricReadout
+                      title={t('Pipeline Runs Per Minute')}
+                      value={spanMetrics?.[`${SpanFunction.SPM}()`]}
+                      unit={RateUnit.PER_MINUTE}
+                      isLoading={areSpanMetricsLoading}
+                    />
+                  </MetricsRibbon>
+                </SpaceBetweenWrap>
+              </ModuleLayout.Full>
+              <ModuleLayout.Third>
+                <TotalTokensUsedChart groupId={groupId} />
+              </ModuleLayout.Third>
+              <ModuleLayout.Third>
+                <NumberOfPipelinesChart groupId={groupId} />
+              </ModuleLayout.Third>
+              <ModuleLayout.Third>
+                <PipelineDurationChart groupId={groupId} />
+              </ModuleLayout.Third>
+              <ModuleLayout.Full>
+                <PipelineSpansTable groupId={groupId} />
+              </ModuleLayout.Full>
+            </ModuleLayout.Layout>
+          </Layout.Main>
+        </Layout.Body>
+      </NoProjectMessage>
+    </Layout.Page>
   );
 }
+
+function PageWithProviders({params}: Props) {
+  return (
+    <ModulePageProviders
+      title={[t('AI Monitoring'), t('Pipeline Details')].join(' — ')}
+      baseURL="/ai-monitoring/"
+      features="ai-analytics"
+    >
+      <AiMonitoringPage params={params} />
+    </ModulePageProviders>
+  );
+}
+
+export default PageWithProviders;
 
 const SpaceBetweenWrap = styled('div')`
   display: flex;

--- a/static/app/views/aiMonitoring/aiMonitoringDetailsPage.tsx
+++ b/static/app/views/aiMonitoring/aiMonitoringDetailsPage.tsx
@@ -10,6 +10,7 @@ import {ProjectPageFilter} from 'sentry/components/organizations/projectPageFilt
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {CurrencyUnit, DurationUnit, RateUnit} from 'sentry/utils/discover/fields';
+import {decodeScalar} from 'sentry/utils/queryString';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
@@ -33,13 +34,20 @@ import {
 interface Props {
   params: {
     groupId: string;
-    'span.description'?: string;
   };
 }
 
+type Query = {
+  'span.description'?: string;
+};
+
 export function AiMonitoringPage({params}: Props) {
+  const location = useLocation<Query>();
+
   const organization = useOrganization();
-  const {groupId, 'span.description': spanDescription} = params;
+  const {groupId} = params;
+
+  const spanDescription = decodeScalar(location.query?.['span.description']);
 
   const filters: SpanMetricsQueryFilters = {
     'span.group': groupId,
@@ -163,7 +171,7 @@ export function AiMonitoringPage({params}: Props) {
 }
 
 function PageWithProviders({params}: Props) {
-  const location = useLocation<Props['params']>();
+  const location = useLocation<Query>();
 
   const {'span.description': spanDescription} = location.query;
 

--- a/static/app/views/aiMonitoring/aiMonitoringDetailsPage.tsx
+++ b/static/app/views/aiMonitoring/aiMonitoringDetailsPage.tsx
@@ -11,6 +11,7 @@ import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {CurrencyUnit, DurationUnit, RateUnit} from 'sentry/utils/discover/fields';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
+import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import {normalizeUrl} from 'sentry/utils/withDomainRequired';
 import {
@@ -32,12 +33,13 @@ import {
 interface Props {
   params: {
     groupId: string;
+    'span.description'?: string;
   };
 }
 
 export function AiMonitoringPage({params}: Props) {
   const organization = useOrganization();
-  const {groupId} = params;
+  const {groupId, 'span.description': spanDescription} = params;
 
   const filters: SpanMetricsQueryFilters = {
     'span.group': groupId,
@@ -49,7 +51,6 @@ export function AiMonitoringPage({params}: Props) {
       search: MutableSearch.fromQueryObject(filters),
       fields: [
         SpanMetricsField.SPAN_OP,
-        SpanMetricsField.SPAN_DESCRIPTION,
         'count()',
         `${SpanFunction.SPM}()`,
         `avg(${SpanMetricsField.SPAN_DURATION})`,
@@ -90,7 +91,7 @@ export function AiMonitoringPage({params}: Props) {
                   label: t('AI Monitoring'),
                 },
                 {
-                  label: spanMetrics['span.description'] ?? t('(no name)'),
+                  label: spanDescription ?? t('(no name)'),
                   to: normalizeUrl(`/organizations/${organization.slug}/ai-monitoring`),
                 },
               ]}
@@ -162,9 +163,13 @@ export function AiMonitoringPage({params}: Props) {
 }
 
 function PageWithProviders({params}: Props) {
+  const location = useLocation<Props['params']>();
+
+  const {'span.description': spanDescription} = location.query;
+
   return (
     <ModulePageProviders
-      title={[t('AI Monitoring'), t('Pipeline Details')].join(' — ')}
+      title={[spanDescription ?? t('(no name)'), t('Pipeline Details')].join(' — ')}
       baseURL="/ai-monitoring/"
       features="ai-analytics"
     >

--- a/static/app/views/aiMonitoring/landing.tsx
+++ b/static/app/views/aiMonitoring/landing.tsx
@@ -1,17 +1,13 @@
 import {Fragment} from 'react';
 
-import Feature from 'sentry/components/acl/feature';
-import {Alert} from 'sentry/components/alert';
 import {Breadcrumbs} from 'sentry/components/breadcrumbs';
 import * as Layout from 'sentry/components/layouts/thirds';
 import NoProjectMessage from 'sentry/components/noProjectMessage';
 import {DatePageFilter} from 'sentry/components/organizations/datePageFilter';
 import {EnvironmentPageFilter} from 'sentry/components/organizations/environmentPageFilter';
 import PageFilterBar from 'sentry/components/organizations/pageFilterBar';
-import PageFiltersContainer from 'sentry/components/organizations/pageFilters/container';
 import {ProjectPageFilter} from 'sentry/components/organizations/projectPageFilter';
 import {PageHeadingQuestionTooltip} from 'sentry/components/pageHeadingQuestionTooltip';
-import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import {t} from 'sentry/locale';
 import useOrganization from 'sentry/utils/useOrganization';
 import {
@@ -23,88 +19,85 @@ import {AIMonitoringOnboarding} from 'sentry/views/aiMonitoring/onboarding';
 import {PipelinesTable} from 'sentry/views/aiMonitoring/PipelinesTable';
 import {useOnboardingProject} from 'sentry/views/performance/browser/webVitals/utils/useOnboardingProject';
 import * as ModuleLayout from 'sentry/views/performance/moduleLayout';
+import {ModulePageProviders} from 'sentry/views/performance/modulePageProviders';
 
-function NoAccessComponent() {
-  return (
-    <Layout.Page withPadding>
-      <Alert type="warning">{t("You don't have access to this feature")}</Alert>
-    </Layout.Page>
-  );
-}
-
-export default function AiMonitoringPage() {
+export function AiMonitoringPage() {
   const organization = useOrganization();
   const onboardingProject = useOnboardingProject();
   const isOnboarding = !!onboardingProject;
 
   return (
-    <PageFiltersContainer>
-      <SentryDocumentTitle title={`AI Monitoring — ${organization.slug}`}>
-        <Layout.Page>
-          <Feature
-            features="ai-analytics"
-            organization={organization}
-            renderDisabled={NoAccessComponent}
-          >
-            <NoProjectMessage organization={organization}>
-              <Layout.Header>
-                <Layout.HeaderContent>
-                  <Breadcrumbs
-                    crumbs={[
-                      {
-                        label: t('Dashboard'),
-                      },
-                      {
-                        label: t('AI Monitoring'),
-                      },
-                    ]}
-                  />
-                  <Layout.Title>
-                    {t('AI Monitoring')}
-                    <PageHeadingQuestionTooltip
-                      title={t('View analytics and information about your AI pipelines')}
-                      docsUrl="https://docs.sentry.io/product/ai-monitoring/"
-                    />
-                  </Layout.Title>
-                </Layout.HeaderContent>
-              </Layout.Header>
-              <Layout.Body>
-                <Layout.Main fullWidth>
-                  <ModuleLayout.Layout>
-                    <ModuleLayout.Full>
-                      <PageFilterBar condensed>
-                        <ProjectPageFilter />
-                        <EnvironmentPageFilter />
-                        <DatePageFilter />
-                      </PageFilterBar>
-                    </ModuleLayout.Full>
-                    {isOnboarding ? (
-                      <ModuleLayout.Full>
-                        <AIMonitoringOnboarding />
-                      </ModuleLayout.Full>
-                    ) : (
-                      <Fragment>
-                        <ModuleLayout.Third>
-                          <TotalTokensUsedChart />
-                        </ModuleLayout.Third>
-                        <ModuleLayout.Third>
-                          <NumberOfPipelinesChart />
-                        </ModuleLayout.Third>
-                        <ModuleLayout.Third>
-                          <PipelineDurationChart />
-                        </ModuleLayout.Third>
-                        <ModuleLayout.Full>
-                          <PipelinesTable />
-                        </ModuleLayout.Full>
-                      </Fragment>
-                    )}
-                  </ModuleLayout.Layout>
-                </Layout.Main>
-              </Layout.Body>
-            </NoProjectMessage>
-          </Feature>
-        </Layout.Page>
-      </SentryDocumentTitle>
-    </PageFiltersContainer>
+    <Layout.Page>
+      <NoProjectMessage organization={organization}>
+        <Layout.Header>
+          <Layout.HeaderContent>
+            <Breadcrumbs
+              crumbs={[
+                {
+                  label: t('Dashboard'),
+                },
+                {
+                  label: t('AI Monitoring'),
+                },
+              ]}
+            />
+            <Layout.Title>
+              {t('AI Monitoring')}
+              <PageHeadingQuestionTooltip
+                title={t('View analytics and information about your AI pipelines')}
+                docsUrl="https://docs.sentry.io/product/ai-monitoring/"
+              />
+            </Layout.Title>
+          </Layout.HeaderContent>
+        </Layout.Header>
+        <Layout.Body>
+          <Layout.Main fullWidth>
+            <ModuleLayout.Layout>
+              <ModuleLayout.Full>
+                <PageFilterBar condensed>
+                  <ProjectPageFilter />
+                  <EnvironmentPageFilter />
+                  <DatePageFilter />
+                </PageFilterBar>
+              </ModuleLayout.Full>
+              {isOnboarding ? (
+                <ModuleLayout.Full>
+                  <AIMonitoringOnboarding />
+                </ModuleLayout.Full>
+              ) : (
+                <Fragment>
+                  <ModuleLayout.Third>
+                    <TotalTokensUsedChart />
+                  </ModuleLayout.Third>
+                  <ModuleLayout.Third>
+                    <NumberOfPipelinesChart />
+                  </ModuleLayout.Third>
+                  <ModuleLayout.Third>
+                    <PipelineDurationChart />
+                  </ModuleLayout.Third>
+                  <ModuleLayout.Full>
+                    <PipelinesTable />
+                  </ModuleLayout.Full>
+                </Fragment>
+              )}
+            </ModuleLayout.Layout>
+          </Layout.Main>
+        </Layout.Body>
+      </NoProjectMessage>
+    </Layout.Page>
   );
 }
+
+function PageWithProviders() {
+  return (
+    <ModulePageProviders
+      title={t('AI Monitoring')}
+      baseURL="/ai-monitoring/"
+      features="ai-analytics"
+    >
+      <AiMonitoringPage />
+    </ModulePageProviders>
+  );
+}
+
+export default PageWithProviders;


### PR DESCRIPTION
Preparation for URL and breadcrumb changes. The IA module doesn't wrap pages in `ModulePageProviders`. I need the wrapper so that I can wholesale change the base URL for all modules at once without doing awkward search-and-replace.

Best enjoyed with whitespace off.

## Changes

- Wrap IA module in `ModulePageProviders`
    
    `ModulePageProviders` includes `Feature`, `SentryDocumentTitle`, and
    `PageFiltersContainer`, so it's not necessary to wrap in those
    components manually.

- Pass pipeline name through URL
    
    Makes sure the name is available at page load, and is consistent with
    what the user clicked on _and_ saves a loaded column.
