### PR TITLE
fix(feedback): check latest event for attachment

### DIFF
--- a/src/sentry/api/endpoints/group_details.py
+++ b/src/sentry/api/endpoints/group_details.py
@@ -236,7 +236,7 @@ class GroupDetailsEndpoint(GroupEndpoint, EnvironmentMixin):
                 )
                 data.update({"sentryAppIssues": sentry_app_issues})
 
-            if "hasAttachments" in expand:
+            if "latestEventHasAttachments" in expand:
                 if not features.has(
                     "organizations:event-attachments",
                     group.project.organization,
@@ -244,8 +244,11 @@ class GroupDetailsEndpoint(GroupEndpoint, EnvironmentMixin):
                 ):
                     return self.respond(status=404)
 
-                num_attachments = EventAttachment.objects.filter(group_id=group.id).count()
-                data.update({"hasAttachments": num_attachments > 0})
+                latest_event = group.get_latest_event()
+                num_attachments = EventAttachment.objects.filter(
+                    project_id=latest_event.project_id, event_id=latest_event.event_id
+                ).count()
+                data.update({"latestEventHasAttachments": num_attachments > 0})
 
             data.update(
                 {

--- a/tests/sentry/issues/endpoints/test_organization_group_index.py
+++ b/tests/sentry/issues/endpoints/test_organization_group_index.py
@@ -1862,7 +1862,7 @@ class GroupListTest(APITestCase, SnubaTestCase, SearchIssueTestMixin):
         assert response.data[0]["sentryAppIssues"][1]["displayName"] == issue_2.display_name
 
     @with_feature("organizations:event-attachments")
-    def test_expand_has_attachments(self) -> None:
+    def test_expand_latest_event_has_attachments(self) -> None:
         event = self.store_event(
             data={"timestamp": iso_format(before_now(seconds=500)), "fingerprint": ["group-1"]},
             project_id=self.project.id,
@@ -1870,20 +1870,20 @@ class GroupListTest(APITestCase, SnubaTestCase, SearchIssueTestMixin):
         query = "status:unresolved"
         self.login_as(user=self.user)
         response = self.get_response(
-            sort_by="date", limit=10, query=query, expand=["hasAttachments"]
+            sort_by="date", limit=10, query=query, expand=["latestEventHasAttachments"]
         )
         assert response.status_code == 200
         assert len(response.data) == 1
         assert int(response.data[0]["id"]) == event.group.id
         # No attachments
-        assert response.data[0]["hasAttachments"] is False
+        assert response.data[0]["latestEventHasAttachments"] is False
 
         # Test with no expand
         response = self.get_response(sort_by="date", limit=10, query=query)
         assert response.status_code == 200
         assert len(response.data) == 1
         assert int(response.data[0]["id"]) == event.group.id
-        assert "hasAttachments" not in response.data[0]
+        assert "latestEventHasAttachments" not in response.data[0]
 
         # Add 1 attachment
         file_attachment = File.objects.create(name="hello.png", type="image/png")
@@ -1897,10 +1897,10 @@ class GroupListTest(APITestCase, SnubaTestCase, SearchIssueTestMixin):
         )
 
         response = self.get_response(
-            sort_by="date", limit=10, query=query, expand=["hasAttachments"]
+            sort_by="date", limit=10, query=query, expand=["latestEventHasAttachments"]
         )
         assert response.status_code == 200
-        assert response.data[0]["hasAttachments"] is True
+        assert response.data[0]["latestEventHasAttachments"] is True
 
     def test_expand_owners(self) -> None:
         event = self.store_event(


### PR DESCRIPTION
we send screenshots through the feedback event, so instead of checking the issue for attachments, we should check the latest event.

this should fix the issue where the `IconImage` isn't showing up when a feedback has a screenshot attached.

<img width="765" alt="SCR-20240513-jcau" src="https://github.com/getsentry/sentry/assets/56095982/f292f56d-14a3-4ba1-8f37-894fb2861a93">
