### PR TITLE
feat(new-trace): Updating trace tags summary fetching logic and ui

### DIFF
--- a/static/app/views/performance/newTraceDetails/traceDrawer/tabs/trace/index.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/tabs/trace/index.tsx
@@ -1,0 +1,84 @@
+import {Fragment, useMemo} from 'react';
+
+import type {Tag} from 'sentry/actionCreators/events';
+import type {ApiResult} from 'sentry/api';
+import type {EventTransaction} from 'sentry/types/event';
+import type EventView from 'sentry/utils/discover/eventView';
+import type {
+  TraceFullDetailed,
+  TraceMeta,
+  TraceSplitResults,
+} from 'sentry/utils/performance/quickTrace/types';
+import type {UseApiQueryResult, UseInfiniteQueryResult} from 'sentry/utils/queryClient';
+import type RequestError from 'sentry/utils/requestError/requestError';
+import {useLocation} from 'sentry/utils/useLocation';
+import useOrganization from 'sentry/utils/useOrganization';
+import {TraceWarnings} from 'sentry/views/performance/newTraceDetails/traceWarnings';
+import type {TraceType} from 'sentry/views/performance/traceDetails/newTraceDetailsContent';
+
+import {isTraceNode} from '../../../guards';
+import type {TraceTree, TraceTreeNode} from '../../../traceModels/traceTree';
+import {IssueList} from '../../details/issues/issues';
+import {TraceDrawerComponents} from '../../details/styles';
+
+import {GeneralInfo} from './generalInfo';
+import {TagsSummary} from './tagsSummary';
+
+type TraceDetailsProps = {
+  metaResults: UseApiQueryResult<TraceMeta | null, any>;
+  node: TraceTreeNode<TraceTree.NodeValue> | null;
+  rootEventResults: UseApiQueryResult<EventTransaction, RequestError>;
+  tagsInfiniteQueryResults: UseInfiniteQueryResult<ApiResult<Tag[]>, unknown>;
+  traceEventView: EventView;
+  traceType: TraceType;
+  traces: TraceSplitResults<TraceFullDetailed> | null;
+  tree: TraceTree;
+};
+
+export function TraceDetails(props: TraceDetailsProps) {
+  const location = useLocation();
+  const organization = useOrganization();
+  const issues = useMemo(() => {
+    if (!props.node) {
+      return [];
+    }
+
+    return [...props.node.errors, ...props.node.performance_issues];
+  }, [props.node]);
+
+  if (!props.node) {
+    return null;
+  }
+
+  if (!(props.node && isTraceNode(props.node))) {
+    throw new Error('Expected a trace node');
+  }
+
+  const {data: rootEvent} = props.rootEventResults;
+
+  return (
+    <Fragment>
+      {props.tree.type === 'trace' ? <TraceWarnings type={props.traceType} /> : null}
+      <IssueList issues={issues} node={props.node} organization={organization} />
+      <TraceDrawerComponents.SectionCardGroup>
+        <GeneralInfo
+          organization={organization}
+          traces={props.traces}
+          tree={props.tree}
+          node={props.node}
+          rootEventResults={props.rootEventResults}
+          metaResults={props.metaResults}
+        />
+        {rootEvent ? (
+          <TagsSummary
+            tagsInfiniteQueryResults={props.tagsInfiniteQueryResults}
+            organization={organization}
+            location={location}
+            eventView={props.traceEventView}
+            totalValues={props.tree.eventsCount}
+          />
+        ) : null}
+      </TraceDrawerComponents.SectionCardGroup>
+    </Fragment>
+  );
+}

--- a/static/app/views/performance/newTraceDetails/traceDrawer/tabs/trace/tagsSummary.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/tabs/trace/tagsSummary.tsx
@@ -1,0 +1,172 @@
+import {Fragment, useMemo} from 'react';
+import styled from '@emotion/styled';
+import type {Location} from 'history';
+
+import type {Tag, TagSegment} from 'sentry/actionCreators/events';
+import type {ApiResult} from 'sentry/api';
+import {TagFacetsList} from 'sentry/components/group/tagFacets';
+import TagFacetsDistributionMeter from 'sentry/components/group/tagFacets/tagFacetsDistributionMeter';
+import Placeholder from 'sentry/components/placeholder';
+import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
+import type {Organization} from 'sentry/types';
+import {generateQueryWithTag} from 'sentry/utils';
+import type EventView from 'sentry/utils/discover/eventView';
+import {formatTagKey} from 'sentry/utils/discover/fields';
+import type {UseInfiniteQueryResult} from 'sentry/utils/queryClient';
+import StyledEmptyStateWarning from 'sentry/views/replays/detail/emptyState';
+
+import {TraceDrawerComponents} from '../../details/styles';
+
+const getTagTarget = (
+  tagKey: string,
+  tagValue: string,
+  eventView: EventView,
+  organization: Organization
+) => {
+  const url = eventView.getResultsViewUrlTarget(organization.slug, false);
+  url.query = generateQueryWithTag(url.query, {
+    key: formatTagKey(tagKey),
+    value: tagValue,
+  });
+  return url;
+};
+
+type TagSummaryProps = {
+  eventView: EventView;
+  location: Location;
+  organization: Organization;
+  tagsInfiniteQueryResults: UseInfiniteQueryResult<ApiResult<Tag[]>, unknown>;
+  totalValues: number | null;
+};
+
+function TagsSummaryPlaceholder() {
+  return (
+    <Fragment>
+      <StyledPlaceholderTitle key="title-1" />
+      <StyledPlaceholder key="bar-1" />
+      <StyledPlaceholderTitle key="title-2" />
+      <StyledPlaceholder key="bar-2" />
+      <StyledPlaceholderTitle key="title-3" />
+      <StyledPlaceholder key="bar-3" />
+    </Fragment>
+  );
+}
+
+const StyledPlaceholder = styled(Placeholder)`
+  border-radius: ${p => p.theme.borderRadius};
+  height: 16px;
+  margin-bottom: ${space(1.5)};
+`;
+
+const StyledPlaceholderTitle = styled(Placeholder)`
+  width: 100px;
+  height: 12px;
+  margin-bottom: ${space(0.5)};
+`;
+
+type TagProps = {
+  eventView: EventView;
+  index: number;
+  organization: Organization;
+  tag: Tag;
+  totalValues: number | null;
+};
+
+function TagRow(props: TagProps) {
+  const segments: TagSegment[] = props.tag.topValues.map(segment => {
+    segment.url = getTagTarget(
+      props.tag.key,
+      segment.value,
+      props.eventView,
+      props.organization
+    );
+
+    return segment;
+  });
+  // Ensure we don't show >100% if there's a slight mismatch between the facets
+  // endpoint and the totals endpoint
+  const maxTotalValues =
+    segments.length > 0
+      ? Math.max(Number(props.totalValues), segments[0].count)
+      : props.totalValues;
+  return (
+    <li key={props.tag.key} aria-label={props.tag.key}>
+      <TagFacetsDistributionMeter
+        title={props.tag.key}
+        segments={segments}
+        totalValues={Number(maxTotalValues)}
+        expandByDefault={props.index === 0}
+      />
+    </li>
+  );
+}
+
+export function TagsSummary(props: TagSummaryProps) {
+  const {
+    data,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+    isLoading, // If anything is loaded yet
+  } = props.tagsInfiniteQueryResults;
+
+  const tags: Tag[] = useMemo(() => {
+    if (!data) {
+      return [];
+    }
+    return data.pages.flatMap(([pageData]) => pageData);
+  }, [data]);
+
+  return (
+    <TraceDrawerComponents.SectionCard
+      items={[
+        {
+          key: 'tags',
+          subject: null,
+          value: (
+            <Fragment>
+              {tags.length > 0 ? (
+                <StyledTagFacetList id="tag-facet-list">
+                  {tags.map((tag, index) => (
+                    <TagRow
+                      key={tag.key}
+                      tag={tag}
+                      index={index}
+                      eventView={props.eventView}
+                      organization={props.organization}
+                      totalValues={props.totalValues}
+                    />
+                  ))}
+                </StyledTagFacetList>
+              ) : null}
+              {isLoading || isFetchingNextPage ? (
+                <TagsSummaryPlaceholder />
+              ) : tags.length === 0 ? (
+                <StyledEmptyStateWarning small>
+                  {t('No tags found')}
+                </StyledEmptyStateWarning>
+              ) : null}
+              {hasNextPage ? (
+                <ShowMoreWrapper>
+                  <a onClick={() => fetchNextPage()}>{t('Show more')}</a>
+                </ShowMoreWrapper>
+              ) : null}
+            </Fragment>
+          ),
+        },
+      ]}
+      title={t('Tags')}
+    />
+  );
+}
+
+const StyledTagFacetList = styled(TagFacetsList)`
+  margin-bottom: 0;
+  width: 100%;
+`;
+
+const ShowMoreWrapper = styled('div')`
+  display: flex;
+  justify-content: center;
+`;

--- a/static/app/views/performance/newTraceDetails/traceDrawer/traceDrawer.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/traceDrawer.tsx
@@ -21,7 +21,7 @@ import {
   requestAnimationTimeout,
 } from 'sentry/utils/profiling/hooks/useVirtualizedTree/virtualizedTreeUtils';
 import type {UseApiQueryResult} from 'sentry/utils/queryClient';
-import {useApiQuery} from 'sentry/utils/queryClient';
+import {useInfiniteApiQuery} from 'sentry/utils/queryClient';
 import type RequestError from 'sentry/utils/requestError/requestError';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
@@ -91,8 +91,8 @@ export function TraceDrawer(props: TraceDrawerProps) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  const tagsQueryResults = useApiQuery<Tag[]>(
-    [
+  const tagsInfiniteQueryResults = useInfiniteApiQuery<Tag[]>({
+    queryKey: [
       `/organizations/${organization.slug}/events-facets/`,
       {
         query: {
@@ -102,10 +102,7 @@ export function TraceDrawer(props: TraceDrawerProps) {
         },
       },
     ],
-    {
-      staleTime: Infinity,
-    }
-  );
+  });
 
   const traceStateRef = useRef(props.trace_state);
   traceStateRef.current = props.trace_state;
@@ -441,7 +438,7 @@ export function TraceDrawer(props: TraceDrawerProps) {
                   node={props.trace.root.children[0]}
                   rootEventResults={props.rootEventResults}
                   traces={props.traces}
-                  tagsQueryResults={tagsQueryResults}
+                  tagsInfiniteQueryResults={tagsInfiniteQueryResults}
                   traceEventView={props.traceEventView}
                 />
               ) : props.trace_state.tabs.current_tab.node === 'vitals' ? (


### PR DESCRIPTION
- Used `useInfiniteApiQuery` to load tags from paginated endpoint.
- Updated ui:
Before:
<img width="1288" alt="Screenshot 2024-05-13 at 1 17 59 PM" src="https://github.com/getsentry/sentry/assets/60121741/40186528-7620-4861-b436-11b60e12d18a">

After:
<img width="1283" alt="Screenshot 2024-05-13 at 1 18 32 PM" src="https://github.com/getsentry/sentry/assets/60121741/f6b0d27c-c6ee-4011-83fa-cebb892ce9c4">


