### PR TITLE
feat(crons): Improve occurance evidence Failure reason

### DIFF
--- a/src/sentry/monitors/logic/mark_failed.py
+++ b/src/sentry/monitors/logic/mark_failed.py
@@ -3,8 +3,9 @@ from __future__ import annotations
 import logging
 import uuid
 from collections import Counter
+from collections.abc import Mapping, Sequence
 from datetime import datetime, timezone
-from typing import TYPE_CHECKING, Mapping, Sequence, TypedDict, cast
+from typing import TYPE_CHECKING, TypedDict, cast
 
 from django.db.models import Q
 from django.utils.text import get_text_list

--- a/src/sentry/monitors/logic/mark_failed.py
+++ b/src/sentry/monitors/logic/mark_failed.py
@@ -2,9 +2,13 @@ from __future__ import annotations
 
 import logging
 import uuid
+from collections import Counter
 from datetime import datetime, timezone
+from typing import TYPE_CHECKING, Mapping, Sequence, TypedDict, cast
 
 from django.db.models import Q
+from django.utils.text import get_text_list
+from django.utils.translation import gettext_lazy as _
 
 from sentry import features
 from sentry.issues.grouptype import MonitorIncidentType
@@ -18,6 +22,9 @@ from sentry.monitors.models import (
 )
 
 logger = logging.getLogger(__name__)
+
+if TYPE_CHECKING:
+    from django.utils.functional import _StrPromise
 
 
 def mark_failed(
@@ -93,8 +100,16 @@ def mark_failed(
         return mark_failed_no_threshold(failed_checkin)
 
 
+class SimpleCheckIn(TypedDict):
+    id: int
+    date_added: datetime
+    status: int
+
+
 def mark_failed_threshold(
-    failed_checkin: MonitorCheckIn, failure_issue_threshold: int, received: datetime | None
+    failed_checkin: MonitorCheckIn,
+    failure_issue_threshold: int,
+    received: datetime | None,
 ):
     from sentry.signals import monitor_environment_failed
 
@@ -103,7 +118,7 @@ def mark_failed_threshold(
     # check to see if we need to update the status
     if monitor_env.status in [MonitorStatus.OK, MonitorStatus.ACTIVE]:
         if failure_issue_threshold == 1:
-            previous_checkins = [
+            previous_checkins: list[SimpleCheckIn] = [
                 {
                     "id": failed_checkin.id,
                     "date_added": failed_checkin.date_added,
@@ -111,13 +126,14 @@ def mark_failed_threshold(
                 }
             ]
         else:
-            previous_checkins = (
+            previous_checkins = cast(
+                list[SimpleCheckIn],
                 # Using .values for performance reasons
                 MonitorCheckIn.objects.filter(
                     monitor_environment=monitor_env, date_added__lte=failed_checkin.date_added
                 )
                 .order_by("-date_added")
-                .values("id", "date_added", "status")
+                .values("id", "date_added", "status"),
             )
 
             # reverse the list after slicing in order to start with oldest check-in
@@ -166,8 +182,13 @@ def mark_failed_threshold(
     # - The monitor and env are not muted
     if not monitor_env.monitor.is_muted and not monitor_env.is_muted and incident:
         checkins = MonitorCheckIn.objects.filter(id__in=[c["id"] for c in previous_checkins])
-        for previous_checkin in checkins:
-            create_issue_platform_occurrence(previous_checkin, incident, received=received)
+        for checkin in checkins:
+            create_issue_platform_occurrence(
+                previous_checkins,
+                checkin,
+                incident,
+                received=received,
+            )
 
     monitor_environment_failed.send(monitor_environment=monitor_env, sender=type(monitor_env))
 
@@ -228,6 +249,7 @@ def create_legacy_event(failed_checkin: MonitorCheckIn):
 
 
 def create_issue_platform_occurrence(
+    failed_checkins: Sequence[SimpleCheckIn],
     failed_checkin: MonitorCheckIn,
     incident: MonitorIncident,
     received: datetime | None,
@@ -254,7 +276,9 @@ def create_issue_platform_occurrence(
         issue_title=f"Monitor failure: {monitor_env.monitor.name}",
         subtitle="Your monitor has reached its failure threshold.",
         evidence_display=[
-            IssueEvidence(name="Failure reason", value="incident", important=True),
+            IssueEvidence(
+                name="Failure reason", value=get_failure_reason(failed_checkins), important=True
+            ),
             IssueEvidence(
                 name="Environment", value=monitor_env.get_environment().name, important=False
             ),
@@ -302,6 +326,48 @@ def create_issue_platform_occurrence(
         occurrence=occurrence,
         event_data=event_data,
     )
+
+
+HUMAN_FAILURE_STATUS_MAP: Mapping[int, _StrPromise] = {
+    CheckInStatus.ERROR: _("error"),
+    CheckInStatus.MISSED: _("missed"),
+    CheckInStatus.TIMEOUT: _("timeout"),
+}
+
+# Exists due to the vowel differences (A vs An) in the statuses
+SINGULAR_HUMAN_FAILURE_MAP: Mapping[int, _StrPromise] = {
+    CheckInStatus.ERROR: _("An error check-in was detected"),
+    CheckInStatus.MISSED: _("A missed check-in was detected"),
+    CheckInStatus.TIMEOUT: _("A timeout check-in was detected"),
+}
+
+
+def get_failure_reason(failed_checkins: Sequence[SimpleCheckIn]):
+    """
+    Builds a humam readible strong from a list of failed check-ins.
+
+    "3 missed check-ins detected"
+    "2 missed check-ins, 1 timeout check-in and 1 error check-in were detected"
+    "A failed check-in was detected"
+    """
+    status_counts = Counter(
+        checkin["status"]
+        for checkin in failed_checkins
+        if checkin["status"] in HUMAN_FAILURE_STATUS_MAP.keys()
+    )
+
+    if sum(status_counts.values()) == 1:
+        return SINGULAR_HUMAN_FAILURE_MAP[list(status_counts.keys())[0]]
+
+    human_status = get_text_list(
+        [
+            "%(count)d %(status)s" % {"count": count, "status": HUMAN_FAILURE_STATUS_MAP[status]}
+            for status, count in status_counts.items()
+        ],
+        last_word=_("and"),
+    )
+
+    return _("%(problem_checkins)s check-ins detected") % {"problem_checkins": human_status}
 
 
 def get_monitor_environment_context(monitor_environment: MonitorEnvironment):

--- a/tests/sentry/monitors/logic/test_mark_failed.py
+++ b/tests/sentry/monitors/logic/test_mark_failed.py
@@ -282,7 +282,11 @@ class MarkFailedTestCase(TestCase):
                 "resource_id": None,
                 "evidence_data": {},
                 "evidence_display": [
-                    {"name": "Failure reason", "value": "incident", "important": True},
+                    {
+                        "name": "Failure reason",
+                        "value": "An error check-in was detected",
+                        "important": True,
+                    },
                     {
                         "name": "Environment",
                         "value": monitor_environment.get_environment().name,
@@ -501,6 +505,12 @@ class MarkFailedTestCase(TestCase):
         occurrence = occurrence.to_dict()
         assert occurrence["fingerprint"][0] == monitor_incident.grouphash
 
+        # Human readible failure reason
+        assert (
+            occurrence["evidence_display"][0]["value"]
+            == "3 timeout, 3 missed and 2 error check-ins detected"
+        )
+
         # send another check-in to make sure the incident does not change
         status = next(failure_statuses)
         checkin = MonitorCheckIn.objects.create(
@@ -632,6 +642,9 @@ class MarkFailedTestCase(TestCase):
         occurrence = kwargs["occurrence"]
         occurrence = occurrence.to_dict()
         assert occurrence["fingerprint"][0] == monitor_incident.grouphash
+
+        # Human readible failure reason
+        assert occurrence["evidence_display"][0]["value"] == "8 timeout check-ins detected"
 
     # we are duplicating this test as the code paths are different, for now
     @with_feature("organizations:issue-platform")


### PR DESCRIPTION
The failure reason of "incident" isn't super helpful

We can instead say something like

> 3 missed check-ins detected
> 2 missed check-ins, 1 timeout check-in and 1 error check-in were detected
> A failed check-in was detected


This implements that