### PR TITLE
ref(rules): Handle improperly formatted rule

### DIFF
--- a/src/sentry/rules/conditions/event_frequency.py
+++ b/src/sentry/rules/conditions/event_frequency.py
@@ -166,6 +166,8 @@ class BaseEventFrequencyCondition(EventCondition, abc.ABC):
 
         comparison_type = self.get_option("comparisonType", ComparisonType.COUNT)
         comparison_interval_option = self.get_option("comparisonInterval", "5m")
+        if comparison_interval_option == "":
+            return False
         comparison_interval = COMPARISON_INTERVALS[comparison_interval_option][1]
         _, duration = self.intervals[interval]
         try:

--- a/tests/snuba/rules/conditions/test_event_frequency.py
+++ b/tests/snuba/rules/conditions/test_event_frequency.py
@@ -292,6 +292,15 @@ class StandardIntervalTestBase(SnubaTestCase, RuleTestCase, PerformanceIssueTest
             self.assertDoesNotPass(rule, event, is_new=False)
             self.assertDoesNotPass(environment_rule, event, is_new=False)
 
+    def test_comparison_interval_empty_string(self):
+        data = {
+            "interval": "1m",
+            "value": 16,
+            "comparisonType": "count",
+            "comparisonInterval": "",
+        }
+        self._run_test(data=data, minutes=1, passes=False)
+
     def test_one_minute_with_events(self):
         data = {"interval": "1m", "value": 6, "comparisonType": "count", "comparisonInterval": "5m"}
         self._run_test(data=data, minutes=1, passes=True, add_events=True)


### PR DESCRIPTION
One customer has a couple improperly formatted alert rules that are causing this error: https://sentry.sentry.io/issues/5245475486/. I've already edited the serializer so it's not possible to get into this state again (we don't save data with a value of "") and had support reach out to the customer to address this, but this issue keeps happening so we can just handle the empty string.