### PR TITLE
chore(trace-explorer): Start passing breakdown slices to traces endpoint

### DIFF
--- a/static/app/views/performance/traces/content.tsx
+++ b/static/app/views/performance/traces/content.tsx
@@ -441,6 +441,7 @@ function useTraces<F extends string>({
       suggestedQuery,
       sort,
       per_page: limit,
+      breakdownSlices: 40,
       minBreakdownPercentage: 1 / 40,
       maxSpansPerTrace: 5,
       mri,


### PR DESCRIPTION
Trying to refactor this endpoint. Going to be passing an integer number of slices instead of a floating point percentage of the trace for simplicity. The backend will quietly move to using this integer.