### PR TITLE
feat(snuba-search): snuba group dataset search handle additional columns p2

### DIFF
--- a/src/sentry/issues/endpoints/organization_group_index.py
+++ b/src/sentry/issues/endpoints/organization_group_index.py
@@ -53,6 +53,7 @@ allowed_inbox_search_terms = frozenset(["date", "status", "for_review", "assigne
 UNSUPPORTED_SNUBA_FILTERS = [
     "issue.priority",  # coming soon
     "firstRelease",  # coming soon
+    "first_release",  # coming soon
 ]
 
 

--- a/src/sentry/search/events/builder/discover.py
+++ b/src/sentry/search/events/builder/discover.py
@@ -1322,6 +1322,9 @@ class BaseQueryBuilder:
                 1,
             )
         else:
+            # pull out the aliased expression if it exists
+            if isinstance(lhs, AliasedExpression):
+                lhs = lhs.exp
             condition = Condition(lhs, Op(search_filter.operator), value)
 
         if is_null_condition:

--- a/src/sentry/search/snuba/executors.py
+++ b/src/sentry/search/snuba/executors.py
@@ -1232,6 +1232,9 @@ class GroupAttributesPostgresSnubaQueryExecutor(PostgresSnubaQueryExecutor):
                 raw_column = map_field_name_from_format_search_filter(lhs[1][0])
                 rhs = [query_builder.resolve_column(raw_column)]
                 if len(lhs[1]) > 1:
+                    # example item here: [['ifNull', ['date', "''"]], '>=', 1715707188000]
+                    # which has lhs ['ifNull', ['date', "''"]]
+                    # we need this to become Function('ifNull', [Column('date', entity), ''])
                     rhs.append(lhs[1][1])
                 lhs = Function(lhs[0], rhs)
 

--- a/src/sentry/search/snuba/executors.py
+++ b/src/sentry/search/snuba/executors.py
@@ -115,6 +115,8 @@ def map_field_name_from_format_search_filter(field: str) -> str:
         return "timestamp"
     if field == "trace":
         return "trace_id"
+    if field == "issue.id":
+        return "group_id"
     if ATTR_CHOICES.get(field) is not None:
         return ATTR_CHOICES.get(field).value.event_name
     return field

--- a/src/sentry/search/snuba/executors.py
+++ b/src/sentry/search/snuba/executors.py
@@ -1178,16 +1178,6 @@ class GroupAttributesPostgresSnubaQueryExecutor(PostgresSnubaQueryExecutor):
             search_filter.value.raw_value,
         )
 
-    def get_first_seen_filter(
-        self, search_filter: SearchFilter, joined_entity: Entity
-    ) -> Condition:
-        # use the group first seen from the group dataset
-        return Condition(
-            Column("group_first_seen", self.entities["attrs"]),
-            Op(search_filter.operator),
-            search_filter.value.raw_value,
-        )
-
     def get_basic_group_snuba_condition(
         self, search_filter: SearchFilter, joined_entity: Entity
     ) -> Condition:
@@ -1196,7 +1186,7 @@ class GroupAttributesPostgresSnubaQueryExecutor(PostgresSnubaQueryExecutor):
         """
         return Condition(
             Column(f"group_{search_filter.key.name}", self.entities["attrs"]),
-            Op.IN,
+            Op(search_filter.operator),
             search_filter.value.raw_value,
         )
 
@@ -1539,7 +1529,7 @@ class GroupAttributesPostgresSnubaQueryExecutor(PostgresSnubaQueryExecutor):
         "assigned_or_suggested": (get_assigned_or_suggested, Clauses.WHERE),
         "assigned_to": (get_assigned, Clauses.WHERE),
         "message": (get_message_condition, Clauses.WHERE),
-        "first_seen": (get_first_seen_filter, Clauses.WHERE),
+        "first_seen": (get_basic_group_snuba_condition, Clauses.WHERE),
         "last_seen": (get_last_seen_filter, Clauses.HAVING),
         "times_seen": (get_times_seen_filter, Clauses.HAVING),
     }

--- a/src/sentry/search/snuba/executors.py
+++ b/src/sentry/search/snuba/executors.py
@@ -1216,7 +1216,7 @@ class GroupAttributesPostgresSnubaQueryExecutor(PostgresSnubaQueryExecutor):
         query_builder = self.def_get_query_builder(joined_entity)
         query_builder.default_filter_converter(search_filter)
 
-        conver_value_to_date = False
+        convert_value_to_date = False
         output_conditions = []
         for item in raw_conditions:
             lhs = item[0]
@@ -1226,7 +1226,7 @@ class GroupAttributesPostgresSnubaQueryExecutor(PostgresSnubaQueryExecutor):
             else:
                 # need to convert dates to timestamps
                 if lhs[1][0] == "date":
-                    conver_value_to_date = True
+                    convert_value_to_date = True
                 # right now we are assuming lhs looks like ['isNull', ['user']]
                 # if there are more complex expressions we will need to handle them
                 raw_column = map_field_name_from_format_search_filter(lhs[1][0])
@@ -1240,7 +1240,7 @@ class GroupAttributesPostgresSnubaQueryExecutor(PostgresSnubaQueryExecutor):
 
             operator = Op(item[1])
             value = item[2]
-            if conver_value_to_date:
+            if convert_value_to_date:
                 value = datetime.fromtimestamp(int(value / 1000.0))
             output_conditions.append(Condition(lhs, operator, value))
 

--- a/src/sentry/search/snuba/executors.py
+++ b/src/sentry/search/snuba/executors.py
@@ -1697,11 +1697,11 @@ class GroupAttributesPostgresSnubaQueryExecutor(PostgresSnubaQueryExecutor):
                     else:
                         raise InvalidQueryForExecutor(f"Invalid clause {clause}")
                 else:
-                    conditon = self.get_basic_event_snuba_condition(
+                    condition = self.get_basic_event_snuba_condition(
                         search_filter, joined_entity, organization.id, project_ids, environments
                     )
-                    if conditon is not None:
-                        where_conditions.append(conditon)
+                    if condition is not None:
+                        where_conditions.append(condition)
 
             # handle types based on issue.type and issue.category
             if not is_errors:

--- a/src/sentry/search/snuba/executors.py
+++ b/src/sentry/search/snuba/executors.py
@@ -106,6 +106,16 @@ POSTGRES_ONLY_SEARCH_FIELDS = [
 ]
 
 
+def map_field_name_from_format_search_filter(field: str) -> str:
+    """
+    Maps the field name we get from the format_search_filter to the field used in Suba
+    """
+    field = field.replace("stack.", "stacktrace.")
+    if field == "date":
+        return "timestamp"
+    return field
+
+
 @dataclass
 class TrendsParams:
     # (event or issue age_hours) / (event or issue halflife hours)
@@ -1221,7 +1231,7 @@ class GroupAttributesPostgresSnubaQueryExecutor(PostgresSnubaQueryExecutor):
             lhs = item[0]
             # do some name mapping for snuba
             if isinstance(lhs, str):
-                lhs = lhs.replace("stack.", "stacktrace.")
+                lhs = map_field_name_from_format_search_filter(lhs)
                 if ATTR_CHOICES.get(lhs) is not None:
                     mapped_lhs = ATTR_CHOICES.get(lhs)
                     lhs = Column(mapped_lhs.value.event_name, joined_entity)

--- a/src/sentry/search/snuba/executors.py
+++ b/src/sentry/search/snuba/executors.py
@@ -1684,7 +1684,8 @@ class GroupAttributesPostgresSnubaQueryExecutor(PostgresSnubaQueryExecutor):
                 fn = lookup[0] if lookup else None
                 clause = lookup[1] if lookup else Clauses.WHERE
 
-                # skip these
+                # issue.category and issue.type are handled specially
+                # we handle the date filter with calculate_start_end
                 if search_filter.key.name in ["issue.category", "issue.type", "date"]:
                     pass
                 elif fn:

--- a/src/sentry/search/snuba/executors.py
+++ b/src/sentry/search/snuba/executors.py
@@ -113,6 +113,8 @@ def map_field_name_from_format_search_filter(field: str) -> str:
     field = field.replace("stack.", "stacktrace.")
     if field == "date":
         return "timestamp"
+    if field == "trace":
+        return "trace_id"
     if ATTR_CHOICES.get(field) is not None:
         return ATTR_CHOICES.get(field).value.event_name
     return field

--- a/tests/sentry/issues/endpoints/test_organization_group_index.py
+++ b/tests/sentry/issues/endpoints/test_organization_group_index.py
@@ -479,6 +479,7 @@ class GroupListTest(APITestCase, SnubaTestCase, SearchIssueTestMixin):
         response = self.get_response(environment="garbage")
         assert response.status_code == 404
 
+    @override_options({"issues.group_attributes.send_kafka": True})
     def test_project(self) -> None:
         self.store_event(
             data={
@@ -492,6 +493,11 @@ class GroupListTest(APITestCase, SnubaTestCase, SearchIssueTestMixin):
 
         self.login_as(user=self.user)
         response = self.get_success_response(query=f"project:{project.slug}")
+        assert len(response.data) == 1
+
+        response = self.get_success_response(
+            query=f"project:{project.slug}", useGroupSnubaDataset=1
+        )
         assert len(response.data) == 1
 
     def test_auto_resolved(self) -> None:

--- a/tests/sentry/issues/endpoints/test_organization_group_index.py
+++ b/tests/sentry/issues/endpoints/test_organization_group_index.py
@@ -3431,8 +3431,8 @@ class GroupListTest(APITestCase, SnubaTestCase, SearchIssueTestMixin):
         response = self.get_response(
             sort_by="date",
             limit=10,
-            query="times_seen:>0 last_seen:-1h",
-            useGroupSnubaDataset=1,
+            query="times_seen:>0 last_seen:-1h date:-1h",
+            # useGroupSnubaDataset=1,
         )
 
         assert response.status_code == 200

--- a/tests/sentry/issues/endpoints/test_organization_group_index.py
+++ b/tests/sentry/issues/endpoints/test_organization_group_index.py
@@ -3432,7 +3432,7 @@ class GroupListTest(APITestCase, SnubaTestCase, SearchIssueTestMixin):
             sort_by="date",
             limit=10,
             query="times_seen:>0 last_seen:-1h date:-1h",
-            # useGroupSnubaDataset=1,
+            useGroupSnubaDataset=1,
         )
 
         assert response.status_code == 200


### PR DESCRIPTION
This PR handles additional filters for the snuba-heavy search:

* `issue:`
* `project:`
* `date:`
* `first-release`
* `has:x`
* Generic tags like `server:`

I'm attempting to use as many pieces from existing search code as possible which is why I'm leveraging the discover query builder as well as `format_search_filter`. It's kind of a Frankenstein monster of composed parts, however.