### PR TITLE
ref(rules): Fix task name for delayed rule processing

### DIFF
--- a/src/sentry/buffer/redis.py
+++ b/src/sentry/buffer/redis.py
@@ -73,6 +73,7 @@ class BufferHookRegistry:
         try:
             callback = self._registry[buffer_hook_event]
         except KeyError:
+            logger.info("buffer_hook_event.missing", extra={"key_name": buffer_hook_event.value})
             return False
 
         return callback(data)

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -781,6 +781,7 @@ CELERY_IMPORTS = (
     "sentry.tasks.user_report",
     "sentry.profiles.task",
     "sentry.release_health.tasks",
+    "sentry.rules.processing.delayed_processing",
     "sentry.dynamic_sampling.tasks.boost_low_volume_projects",
     "sentry.dynamic_sampling.tasks.boost_low_volume_transactions",
     "sentry.dynamic_sampling.tasks.recalibrate_orgs",

--- a/src/sentry/rules/processing/delayed_processing.py
+++ b/src/sentry/rules/processing/delayed_processing.py
@@ -310,7 +310,7 @@ def process_delayed_alert_conditions(buffer: RedisBuffer) -> None:
 
 
 @instrumented_task(
-    name="sentry.delayed_processing.tasks.apply_delayed",
+    name="sentry.rules.processing.delayed_processing",
     queue="delayed_rules",
     default_retry_delay=5,
     max_retries=5,


### PR DESCRIPTION
The task for processing delayed rules wasn't imported into `CELERY_IMPORTS` and the name was incorrect - this fixes both and adds a log message if the buffer hook registry isn't working as expected.