### PR TITLE
perf: remove trace from sentry.utils.json

### DIFF
--- a/src/sentry/db/models/fields/gzippeddict.py
+++ b/src/sentry/db/models/fields/gzippeddict.py
@@ -32,7 +32,7 @@ class GzippedDictField(TextField):
         try:
             if not value:
                 return {}
-            return json.loads(value, skip_trace=True)
+            return json.loads(value)
         except (ValueError, TypeError):
             if isinstance(value, str) and value:
                 try:

--- a/src/sentry/db/models/fields/jsonfield.py
+++ b/src/sentry/db/models/fields/jsonfield.py
@@ -83,8 +83,8 @@ class JSONField(models.TextField):
             if callable(default):
                 default = default()
             if isinstance(default, str):
-                return json.loads(default, skip_trace=True)
-            return json.loads(json.dumps(default), skip_trace=True)
+                return json.loads(default)
+            return json.loads(json.dumps(default))
         return super().get_default()
 
     def get_internal_type(self):
@@ -101,7 +101,7 @@ class JSONField(models.TextField):
                 if self.blank:
                     return ""
             try:
-                value = json.loads(value, skip_trace=True)
+                value = json.loads(value)
             except ValueError:
                 msg = self.error_messages["invalid"] % value
                 raise ValidationError(msg)

--- a/src/sentry/db/models/fields/picklefield.py
+++ b/src/sentry/db/models/fields/picklefield.py
@@ -26,7 +26,7 @@ class PickledObjectField(django_picklefield.PickledObjectField):
         if value is None:
             return None
         try:
-            return json.loads(value, skip_trace=True)
+            return json.loads(value)
         except (ValueError, TypeError):
             from sentry.utils import metrics
 

--- a/src/sentry/utils/codecs.py
+++ b/src/sentry/utils/codecs.py
@@ -74,7 +74,7 @@ class JSONCodec(Codec[Any, str]):
         return str(json.dumps(value))
 
     def decode(self, value: str) -> Any:
-        return json.loads(value, skip_trace=True)
+        return json.loads(value)
 
 
 class ZlibCodec(Codec[bytes, bytes]):

--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -999,7 +999,7 @@ def _bulk_snuba_query(
     for index, item in enumerate(query_results):
         response, _, reverse = item
         try:
-            body = json.loads(response.data, skip_trace=True)
+            body = json.loads(response.data)
             if SNUBA_INFO:
                 if "sql" in body:
                     log_snuba_info(

--- a/tests/sentry/utils/test_json.py
+++ b/tests/sentry/utils/test_json.py
@@ -2,7 +2,6 @@ import datetime
 import uuid
 from enum import Enum
 from unittest import TestCase
-from unittest.mock import patch
 
 from django.utils.translation import gettext_lazy as _
 
@@ -49,13 +48,3 @@ class JSONTest(TestCase):
 
     def test_translation(self):
         self.assertEqual(json.dumps(_("word")), '"word"')
-
-    @patch("sentry_sdk.start_span")
-    def test_loads_with_sdk_trace(self, start_span_mock):
-        json.loads('{"test": "message"}')
-        start_span_mock.assert_called_once()
-
-    @patch("sentry_sdk.start_span")
-    def test_loads_without_sdk_trace(self, start_span_mock):
-        json.loads('{"test": "message"}', skip_trace=True)
-        start_span_mock.assert_not_called()


### PR DESCRIPTION
Starting a trace has a cost, and for micro-optimizations we should avoid it.

cc @ayirr7 