### PR TITLE
(fix): Sentry-16D3 - Issue accessing the project on a query subscription

### DIFF
--- a/src/sentry/incidents/endpoints/organization_alert_rule_details.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_details.py
@@ -319,11 +319,6 @@ class OrganizationAlertRuleDetailsEndpoint(OrganizationAlertRuleEndpoint):
             except Exception:
                 pass
 
-            # TODO - Cleanup Subscription Project Mapping
-            # if not, check to see if there's a project associated with the snuba query
-            if project is None:
-                project = alert_rule.snuba_query.subscriptions.get().project
-
             if not request.access.has_project_access(project):
                 return Response(status=status.HTTP_403_FORBIDDEN)
 


### PR DESCRIPTION
## Description
Error report: https://sentry.sentry.io/issues/4527458007/?project=1

Looks like this was missed after [we migrated](https://github.com/getsentry/sentry/pull/67563/files) from projects being stored on the alert_rule. This can now be removed because all projects should exist at the alert_rule level.