### PR TITLE
ref(seer grouping): Small improvements to code calling Seer

### DIFF
--- a/src/sentry/api/endpoints/group_similar_issues_embeddings.py
+++ b/src/sentry/api/endpoints/group_similar_issues_embeddings.py
@@ -18,7 +18,7 @@ from sentry.models.user import User
 from sentry.seer.utils import (
     SeerSimilarIssueData,
     SimilarIssuesEmbeddingsRequest,
-    get_similar_issues_embeddings,
+    get_similarity_data_from_seer,
 )
 from sentry.utils.safe import get_path
 
@@ -177,7 +177,7 @@ class GroupSimilarIssuesEmbeddingsEndpoint(GroupEndpoint):
         extra["group_message"] = extra.pop("message")
         logger.info("Similar issues embeddings parameters", extra=extra)
 
-        results = get_similar_issues_embeddings(similar_issues_params)
+        results = get_similarity_data_from_seer(similar_issues_params)
 
         analytics.record(
             "group_similar_issues_embeddings.count",

--- a/src/sentry/seer/utils.py
+++ b/src/sentry/seer/utils.py
@@ -178,6 +178,7 @@ class SeerSimilarIssueData:
         return cls(**similar_issue_data)
 
 
+# TODO: Handle non-200 responses
 def get_similarity_data_from_seer(
     similar_issues_request: SimilarIssuesEmbeddingsRequest,
 ) -> list[SeerSimilarIssueData]:

--- a/src/sentry/seer/utils.py
+++ b/src/sentry/seer/utils.py
@@ -6,7 +6,11 @@ import sentry_sdk
 from django.conf import settings
 from urllib3 import Retry
 
-from sentry.conf.server import SEER_SIMILAR_ISSUES_URL, SEER_SIMILARITY_MODEL_VERSION
+from sentry.conf.server import (
+    SEER_MAX_GROUPING_DISTANCE,
+    SEER_SIMILAR_ISSUES_URL,
+    SEER_SIMILARITY_MODEL_VERSION,
+)
 from sentry.models.group import Group
 from sentry.models.grouphash import GroupHash
 from sentry.net.http import connection_from_url
@@ -181,7 +185,7 @@ def get_similarity_data_from_seer(
     response = seer_grouping_connection_pool.urlopen(
         "POST",
         SEER_SIMILAR_ISSUES_URL,
-        body=json.dumps(similar_issues_request),
+        body=json.dumps({"threshold": SEER_MAX_GROUPING_DISTANCE, **similar_issues_request}),
         headers={"Content-Type": "application/json;charset=utf-8"},
     )
 

--- a/src/sentry/seer/utils.py
+++ b/src/sentry/seer/utils.py
@@ -174,7 +174,7 @@ class SeerSimilarIssueData:
         return cls(**similar_issue_data)
 
 
-def get_similar_issues_embeddings(
+def get_similarity_data_from_seer(
     similar_issues_request: SimilarIssuesEmbeddingsRequest,
 ) -> list[SeerSimilarIssueData]:
     """Request similar issues data from seer and normalize the results."""

--- a/src/sentry/seer/utils.py
+++ b/src/sentry/seer/utils.py
@@ -182,7 +182,11 @@ class SeerSimilarIssueData:
 def get_similarity_data_from_seer(
     similar_issues_request: SimilarIssuesEmbeddingsRequest,
 ) -> list[SeerSimilarIssueData]:
-    """Request similar issues data from seer and normalize the results."""
+    """
+    Request similar issues data from seer and normalize the results. Returns similar groups
+    sorted in order of descending similarity.
+    """
+
     response = seer_grouping_connection_pool.urlopen(
         "POST",
         SEER_SIMILAR_ISSUES_URL,
@@ -230,4 +234,7 @@ def get_similarity_data_from_seer(
         except SimilarGroupNotFoundError:
             metrics.incr("seer.similar_issue_request.parent_issue", tags={"outcome": "not_found"})
 
-    return normalized
+    return sorted(
+        normalized,
+        key=lambda issue_data: issue_data.stacktrace_distance,
+    )

--- a/tests/sentry/api/endpoints/test_group_similar_issues_embeddings.py
+++ b/tests/sentry/api/endpoints/test_group_similar_issues_embeddings.py
@@ -713,7 +713,7 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
 
         response = self.client.get(
             self.path,
-            data={"k": "1", "threshold": "0.98"},
+            data={"k": "1", "threshold": "0.01"},
         )
 
         assert response.data == self.get_expected_response(
@@ -721,13 +721,13 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
         )
 
         expected_seer_request_params = {
+            "threshold": 0.01,
             "group_id": self.group.id,
             "hash": NonNone(self.event.get_primary_hash()),
             "project_id": self.project.id,
             "stacktrace": EXPECTED_STACKTRACE_STRING,
             "message": self.group.message,
             "k": 1,
-            "threshold": 0.98,
         }
 
         mock_seer_request.assert_called_with(
@@ -764,7 +764,7 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
 
         response = self.client.get(
             self.path,
-            data={"k": "1", "threshold": "0.98"},
+            data={"k": "1", "threshold": "0.01"},
         )
 
         assert response.data == self.get_expected_response(
@@ -772,13 +772,13 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
         )
 
         expected_seer_request_params = {
+            "threshold": 0.01,
             "group_id": self.group.id,
             "hash": NonNone(self.event.get_primary_hash()),
             "project_id": self.project.id,
             "stacktrace": EXPECTED_STACKTRACE_STRING,
             "message": self.group.message,
             "k": 1,
-            "threshold": 0.98,
         }
 
         mock_seer_request.assert_called_with(
@@ -817,7 +817,7 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
 
         response = self.client.get(
             self.path,
-            data={"k": "1", "threshold": "0.98"},
+            data={"k": "1", "threshold": "0.01"},
         )
 
         assert response.data == self.get_expected_response(
@@ -825,13 +825,13 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
         )
 
         expected_seer_request_params = {
+            "threshold": 0.01,
             "group_id": self.group.id,
             "hash": NonNone(self.event.get_primary_hash()),
             "project_id": self.project.id,
             "stacktrace": EXPECTED_STACKTRACE_STRING,
             "message": self.group.message,
             "k": 1,
-            "threshold": 0.98,
         }
 
         mock_seer_request.assert_called_with(
@@ -1104,6 +1104,7 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
             SEER_SIMILAR_ISSUES_URL,
             body=orjson.dumps(
                 {
+                    "threshold": 0.01,
                     "group_id": self.group.id,
                     "hash": NonNone(self.event.get_primary_hash()),
                     "project_id": self.project.id,
@@ -1128,6 +1129,7 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
             SEER_SIMILAR_ISSUES_URL,
             body=orjson.dumps(
                 {
+                    "threshold": 0.01,
                     "group_id": self.group.id,
                     "hash": NonNone(self.event.get_primary_hash()),
                     "project_id": self.project.id,
@@ -1142,7 +1144,7 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
         # Include threshold
         response = self.client.get(
             self.path,
-            data={"threshold": "0.98"},
+            data={"threshold": "0.01"},
         )
         assert response.data == self.get_expected_response(
             [NonNone(self.similar_event.group_id)], [0.95], [0.99], ["Yes"]
@@ -1153,12 +1155,12 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
             SEER_SIMILAR_ISSUES_URL,
             body=orjson.dumps(
                 {
+                    "threshold": 0.01,
                     "group_id": self.group.id,
                     "hash": NonNone(self.event.get_primary_hash()),
                     "project_id": self.project.id,
                     "stacktrace": EXPECTED_STACKTRACE_STRING,
                     "message": self.group.message,
-                    "threshold": 0.98,
                 },
             ).decode(),
             headers={"Content-Type": "application/json;charset=utf-8"},

--- a/tests/sentry/seer/test_utils.py
+++ b/tests/sentry/seer/test_utils.py
@@ -1,3 +1,4 @@
+from typing import Any
 from unittest import mock
 
 import pytest
@@ -169,6 +170,53 @@ def test_empty_similar_issues_embeddings(mock_seer_request, default_project):
         "message": "message",
     }
     assert get_similarity_data_from_seer(params) == []
+
+
+@django_db_all
+@mock.patch("sentry.seer.utils.seer_grouping_connection_pool.urlopen")
+def test_returns_sorted_similarity_results(mock_seer_request, default_project):
+    event = save_new_event({"message": "Dogs are great!"}, default_project)
+    similar_event = save_new_event({"message": "Adopt don't shop"}, default_project)
+    less_similar_event = save_new_event({"message": "Charlie is goofy"}, default_project)
+
+    raw_similar_issue_data: RawSeerSimilarIssueData = {
+        "message_distance": 0.05,
+        "parent_hash": NonNone(similar_event.get_primary_hash()),
+        "should_group": True,
+        "stacktrace_distance": 0.01,
+    }
+    raw_less_similar_issue_data: RawSeerSimilarIssueData = {
+        "message_distance": 0.10,
+        "parent_hash": NonNone(less_similar_event.get_primary_hash()),
+        "should_group": False,
+        "stacktrace_distance": 0.05,
+    }
+
+    # Note that the less similar issue is first in the list as it comes back from Seer
+    seer_return_value = {"responses": [raw_less_similar_issue_data, raw_similar_issue_data]}
+    mock_seer_request.return_value = HTTPResponse(json.dumps(seer_return_value).encode("utf-8"))
+
+    params: SimilarIssuesEmbeddingsRequest = {
+        "hash": NonNone(event.get_primary_hash()),
+        "project_id": default_project.id,
+        "stacktrace": "string",
+        "message": "message",
+    }
+
+    similar_issue_data: Any = {
+        **raw_similar_issue_data,
+        "parent_group_id": similar_event.group_id,
+    }
+    less_similar_issue_data: Any = {
+        **raw_less_similar_issue_data,
+        "parent_group_id": less_similar_event.group_id,
+    }
+
+    # The results have been reordered so that the more similar issue comes first
+    assert get_similarity_data_from_seer(params) == [
+        SeerSimilarIssueData(**similar_issue_data),
+        SeerSimilarIssueData(**less_similar_issue_data),
+    ]
 
 
 # TODO: Remove once switch is complete

--- a/tests/sentry/seer/test_utils.py
+++ b/tests/sentry/seer/test_utils.py
@@ -10,7 +10,7 @@ from sentry.seer.utils import (
     SimilarGroupNotFoundError,
     SimilarIssuesEmbeddingsRequest,
     detect_breakpoints,
-    get_similar_issues_embeddings,
+    get_similarity_data_from_seer,
 )
 from sentry.testutils.helpers.eventprocessing import save_new_event
 from sentry.testutils.pytest.fixtures import django_db_all
@@ -85,7 +85,7 @@ def test_simple_similar_issues_embeddings_only_group_id_returned(
         "stacktrace": "string",
         "message": "message",
     }
-    assert get_similar_issues_embeddings(params) == [SeerSimilarIssueData(**raw_similar_issue_data)]
+    assert get_similarity_data_from_seer(params) == [SeerSimilarIssueData(**raw_similar_issue_data)]
 
 
 @django_db_all
@@ -118,7 +118,7 @@ def test_simple_similar_issues_embeddings_only_hash_returned(mock_seer_request, 
         "parent_group_id": similar_event.group_id,
     }
 
-    assert get_similar_issues_embeddings(params) == [
+    assert get_similarity_data_from_seer(params) == [
         SeerSimilarIssueData(**similar_issue_data)  # type: ignore[arg-type]
     ]
 
@@ -150,7 +150,7 @@ def test_simple_similar_issues_embeddings_both_returned(mock_seer_request, defau
         "message": "message",
     }
 
-    assert get_similar_issues_embeddings(params) == [SeerSimilarIssueData(**raw_similar_issue_data)]
+    assert get_similarity_data_from_seer(params) == [SeerSimilarIssueData(**raw_similar_issue_data)]
 
 
 @django_db_all
@@ -168,7 +168,7 @@ def test_empty_similar_issues_embeddings(mock_seer_request, default_project):
         "stacktrace": "string",
         "message": "message",
     }
-    assert get_similar_issues_embeddings(params) == []
+    assert get_similarity_data_from_seer(params) == []
 
 
 # TODO: Remove once switch is complete


### PR DESCRIPTION
This makes a few small improvements to our code calling Seer for similar issues.

Changes:

- Rename the function that makes the API call from `get_similar_issues_embeddings` to `get_similarity_data_from_seer`. As I've been working on adding a call to Seer during ingest, I've kept confusing myself, losing track of which of the multiple functions whose names involve the words "get," "seer," "similarity," and "issues" was the one actually talking to Seer. Hopefully the rename makes it clear that the function in question is the one actually calling the Seer endpoint.

- Stop raising a full-blown error when Seer suggests an issue which no longer exists in the Sentry database and instead just increment a metric. For the sake of completeness, I also added calls to the same metric tracking the times when a similar issue suggested by Seer _is_ found, and those where Seer sends back incomplete data. That way, all of the possible outcomes of the call to `SeerSimilarIssueData.from_raw` are covered.

- Now that we have [a constant](https://github.com/getsentry/sentry/pull/70459) for the default threshold for considering one issue similar to another, use it as the default value of the `threshold` request parameter.

- Sort the results from Seer in order from most to least similar, so that when we're using this data for grouping, we know we can always just take the first group in the list (provided it has `should_group: True`, of course).

- Add a TODO so we remember to add handling for non-200 responses from Seer.