### PR TITLE
fix(metrics): no data time format

### DIFF
--- a/static/app/views/metrics/chart/chart.tsx
+++ b/static/app/views/metrics/chart/chart.tsx
@@ -235,9 +235,7 @@ export const MetricChart = memo(
                   return true;
                 });
 
-                const date = params[0].value[0];
-
-                defaultFormatAxisLabel(
+                const formattedDate = defaultFormatAxisLabel(
                   params[0].value[0] as number,
                   timeseriesFormatters.isGroupedByDate,
                   timeseriesFormatters.utc,
@@ -251,7 +249,7 @@ export const MetricChart = memo(
                     '<div class="tooltip-series">',
                     `<center>${t('No data available')}</center>`,
                     '</div>',
-                    `<div class="tooltip-footer">${date}</div>`,
+                    `<div class="tooltip-footer">${formattedDate}</div>`,
                   ].join('');
                 }
                 return getFormatter(timeseriesFormatters)(deDupedParams, asyncTicket);


### PR DESCRIPTION
- closes #69645

Before:
<img width="641" alt="image" src="https://github.com/getsentry/sentry/assets/86684834/e1160044-f484-443e-880d-3720edba30fd">

After:
<img width="641" alt="image" src="https://github.com/getsentry/sentry/assets/86684834/5cf234e4-158b-4f71-bf8a-8ab24edf2ca2">
