### PR TITLE
fix(metrics): emptry description fallback

### DIFF
--- a/static/app/components/metrics/metricSamplesTable.tsx
+++ b/static/app/components/metrics/metricSamplesTable.tsx
@@ -593,10 +593,19 @@ function SpanId({
 }
 
 function SpanDescription({description, project}: {description: string; project: string}) {
+  if (!description) {
+    return (
+      <Flex gap={space(0.75)} align="center">
+        <ProjectRenderer projectSlug={project} />
+        <EmptyValueContainer>{t('(none)')}</EmptyValueContainer>
+      </Flex>
+    );
+  }
+
   return (
     <Flex gap={space(0.75)} align="center">
       <ProjectRenderer projectSlug={project} />
-      <Container>{description} </Container>
+      <Container>{description}</Container>
     </Flex>
   );
 }


### PR DESCRIPTION
Before:
<img width="619" alt="image" src="https://github.com/getsentry/sentry/assets/86684834/43dbeb68-8594-43cc-8e03-48843bebaccd">


After:
<img width="619" alt="image" src="https://github.com/getsentry/sentry/assets/86684834/dc982c49-60c6-412e-8b7b-6a5001429ec5">
