### PR TITLE
feat: Add a helper script for Celery troubleshooting

### DIFF
--- a/bin/celery-helper.py
+++ b/bin/celery-helper.py
@@ -7,9 +7,10 @@
 import enum
 import inspect as insp
 import sys
+from typing import Any
 
-control = None
-inspect = None
+control: Any = None
+inspect: Any = None
 
 _initialized = False
 
@@ -25,6 +26,10 @@ Initialized objects:
 Functions:
 
 {functions_help}
+
+Additional documentation:
+  * https://docs.celeryq.dev/en/latest/userguide/workers.html#inspecting-workers
+
 """
 
 
@@ -81,17 +86,18 @@ def get_reserved_task_ids_by_name(task_name: str) -> list[str]:
     return _get_task_ids_by_name_and_status(task_name, TaskStatus.RESERVED)
 
 
-def revoke_active_tasks_by_name(task_name: str, dry_run: bool = False):
+def revoke_active_tasks_by_name(task_name: str, dry_run: bool = False) -> None:
     """Revoke and terminate all tasks with the given name. Dangerous!"""
     _ensure_initialized()
 
     task_ids = get_active_task_ids_by_name(task_name)
+    task_num = len(task_ids)
 
     if dry_run:
-        print(f"!!![dry-run] Would revoke tasks: {num}")  # NOQA
+        print(f"!!![dry-run] Would revoke tasks: {task_num}")  # NOQA
     else:
         control.revoke(task_ids, terminate=True)
-        print(f"Revoked tasks: {num}")  # NOQA
+        print(f"Revoked tasks: {task_num}")  # NOQA
 
 
 def generate_help() -> str:
@@ -103,7 +109,7 @@ def generate_help() -> str:
         revoke_active_tasks_by_name,
     ]:
         functions_help += f"    {func.__name__} - {func.__doc__}\n"
-        functions_help += f"        {insp.signature(func)}\n\n"
+        functions_help += f"        {insp.signature(func)}\n\n"  # type: ignore[arg-type]
     return HELP.format(functions_help=functions_help)
 
 

--- a/bin/celery-helper.py
+++ b/bin/celery-helper.py
@@ -1,11 +1,12 @@
 #!/usr/bin/env python -i
 #
-# NOTE: this script is meant to be used in "interactive" mode:
+# NOTE: when started with "python", this script is meant to be used in "interactive" mode:
 #   python -i SCRIPT
 #
+import enum
+import inspect as insp
 import sys
 from collections.abc import Generator
-from enum import Enum
 
 control = None
 inspect = None
@@ -13,16 +14,43 @@ inspect = None
 _initialized = False
 
 
-class TaskStatus(Enum):
-    ACTIVE = 0
-    SCHEDULED = 1
-    RESERVED = 2
+HELP = """
+Initialized objects:
+
+    control <celery.app.control.Control>
+        Docs: https://docs.celeryq.dev/en/stable/reference/celery.app.control.html#celery.app.control.Control
+    inspect <celery.app.control.Inspect>
+        Docs: https://docs.celeryq.dev/en/stable/reference/celery.app.control.html#celery.app.control.Inspect
+
+Functions:
+
+{functions_help}
+"""
+
+
+class TaskStatus(enum.Enum):
+    ACTIVE = enum.auto()
+    SCHEDULED = enum.auto()
+    RESERVED = enum.auto()
 
 
 def _ensure_initialized():
     if not _initialized:
-        print(">>> The app is not initialized! Run init_sentry() function.")  # NOQA
+        print("!!! The Sentry/Celery apps are not initialized! Run init_sentry() function.")  # NOQA
         sys.exit(1)
+
+
+def _get_tasks_by_status(status: TaskStatus) -> dict:
+    _ensure_initialized()
+
+    res = {}
+    if status == TaskStatus.ACTIVE:
+        res = inspect.active()
+    elif status == TaskStatus.SCHEDULED:
+        res = inspect.scheduled()
+    elif status == TaskStatus.RESERVED:
+        res = inspect.reserved()
+    return res or {}
 
 
 def _get_task_ids_by_name_and_status(
@@ -31,17 +59,7 @@ def _get_task_ids_by_name_and_status(
     if not task_name:
         raise ValueError("Invalid task_name: %f", task_name)
 
-    _ensure_initialized()
-
-    worker_to_task_map = {}
-    if status == TaskStatus.ACTIVE:
-        worker_to_task_map = inspect.active()
-    elif status == TaskStatus.SCHEDULED:
-        worker_to_task_map = inspect.scheduled()
-    elif status == TaskStatus.RESERVED:
-        worker_to_task_map = inspect.reserved()
-
-    worker_to_task_map = inspect.active() or {}
+    worker_to_task_map = _get_tasks_by_status(status)
     for worker_id, tasks in worker_to_task_map.items():
         for task in tasks:
             if task["name"] == task_name:
@@ -49,25 +67,47 @@ def _get_task_ids_by_name_and_status(
 
 
 def get_active_task_ids_by_name(task_name: str) -> Generator[str, None, None]:
+    """Get IDs of all active (running) tasks by a task name"""
     return _get_task_ids_by_name_and_status(task_name, TaskStatus.ACTIVE)
 
 
 def get_scheduled_task_ids_by_name(task_name: str) -> Generator[str, None, None]:
+    """Get IDs of all scheduled tasks by a task name"""
     return _get_task_ids_by_name_and_status(task_name, TaskStatus.SCHEDULED)
 
 
 def get_reserved_task_ids_by_name(task_name: str) -> Generator[str, None, None]:
+    """Get IDs of all reserved tasks by a task name"""
     return _get_task_ids_by_name_and_status(task_name, TaskStatus.RESERVED)
 
 
-def revoke_active_tasks_by_name(task_name: str):
+def revoke_active_tasks_by_name(task_name: str, dry_run: bool = False):
+    """Revoke all tasks with the given name. Dangerous!"""
+
+    _ensure_initialized()
+
     task_ids = get_active_task_ids_by_name(task_name)
 
     num = 0
     for task_id in task_ids:
-        control.revoke(task_ids)
+        if not dry_run:
+            # Technically, revoke() can accept a list of IDs
+            control.revoke(task_ids)
         num += 1
-    print(f">> Revoked tasks: {num}")  # NOQA
+    print(f"!!!{'[dry-run]' if dry_run else ''} Revoked tasks: {num}")  # NOQA
+
+
+def generate_help() -> str:
+    functions_help = ""
+    for func in [
+        get_active_task_ids_by_name,
+        get_scheduled_task_ids_by_name,
+        get_reserved_task_ids_by_name,
+        revoke_active_tasks_by_name,
+    ]:
+        functions_help += f"    {func.__name__} - {func.__doc__}\n"
+        functions_help += f"        {insp.signature(func)}\n\n"
+    return HELP.format(functions_help=functions_help)
 
 
 def init_sentry():
@@ -77,6 +117,7 @@ def init_sentry():
 
     from sentry.runner import configure
 
+    print("!!! Initializing Sentry app...")  # NOQA
     configure()
 
     from sentry.celery import app
@@ -89,6 +130,8 @@ def init_sentry():
 
 def main() -> None:
     init_sentry()
+    print("!!! Celery shell initialized!")  # NOQA
+    print(generate_help())  # NOQA
 
 
 if __name__ == "__main__":

--- a/bin/celery-helper.py
+++ b/bin/celery-helper.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python -i
+#
+# NOTE: this script is meant to be used in "interactive" mode:
+#   python -i SCRIPT
+#
+import sys
+from collections.abc import Generator
+from enum import Enum
+
+control = None
+inspect = None
+
+_initialized = False
+
+
+class TaskStatus(Enum):
+    ACTIVE = 0
+    SCHEDULED = 1
+    RESERVED = 2
+
+
+def _ensure_initialized():
+    if not _initialized:
+        print(">>> The app is not initialized! Run init_sentry() function.")  # NOQA
+        sys.exit(1)
+
+
+def _get_task_ids_by_name_and_status(
+    task_name: str, status: TaskStatus
+) -> Generator[str, None, None]:
+    if not task_name:
+        raise ValueError("Invalid task_name: %f", task_name)
+
+    _ensure_initialized()
+
+    worker_to_task_map = {}
+    if status == TaskStatus.ACTIVE:
+        worker_to_task_map = inspect.active()
+    elif status == TaskStatus.SCHEDULED:
+        worker_to_task_map = inspect.scheduled()
+    elif status == TaskStatus.RESERVED:
+        worker_to_task_map = inspect.reserved()
+
+    worker_to_task_map = inspect.active() or {}
+    for worker_id, tasks in worker_to_task_map.items():
+        for task in tasks:
+            if task["name"] == task_name:
+                yield task["id"]
+
+
+def get_active_task_ids_by_name(task_name: str) -> Generator[str, None, None]:
+    return _get_task_ids_by_name_and_status(task_name, TaskStatus.ACTIVE)
+
+
+def get_scheduled_task_ids_by_name(task_name: str) -> Generator[str, None, None]:
+    return _get_task_ids_by_name_and_status(task_name, TaskStatus.SCHEDULED)
+
+
+def get_reserved_task_ids_by_name(task_name: str) -> Generator[str, None, None]:
+    return _get_task_ids_by_name_and_status(task_name, TaskStatus.RESERVED)
+
+
+def revoke_active_tasks_by_name(task_name: str):
+    task_ids = get_active_task_ids_by_name(task_name)
+
+    num = 0
+    for task_id in task_ids:
+        control.revoke(task_ids)
+        num += 1
+    print(f">> Revoked tasks: {num}")  # NOQA
+
+
+def init_sentry():
+    global control
+    global inspect
+    global _initialized
+
+    from sentry.runner import configure
+
+    configure()
+
+    from sentry.celery import app
+
+    control = app.control
+    inspect = control.inspect()
+
+    _initialized = True
+
+
+def main() -> None:
+    init_sentry()
+
+
+if __name__ == "__main__":
+    main()

--- a/bin/celery-helper.py
+++ b/bin/celery-helper.py
@@ -86,18 +86,18 @@ def get_reserved_task_ids_by_name(task_name: str) -> list[str]:
     return _get_task_ids_by_name_and_status(task_name, TaskStatus.RESERVED)
 
 
-def revoke_active_tasks_by_name(task_name: str, dry_run: bool = False) -> None:
+def revoke_active_tasks_by_name(task_name: str, execute: bool = False) -> None:
     """Revoke and terminate all tasks with the given name. Dangerous!"""
     _ensure_initialized()
 
     task_ids = get_active_task_ids_by_name(task_name)
     task_num = len(task_ids)
 
-    if dry_run:
-        print(f"!!![dry-run] Would revoke tasks: {task_num}")  # NOQA
-    else:
+    if execute:
         control.revoke(task_ids, terminate=True)
         print(f"Revoked tasks: {task_num}")  # NOQA
+    else:
+        print(f"!!![dry-run] Would revoke tasks: {task_num}")  # NOQA
 
 
 def generate_help() -> str:


### PR DESCRIPTION
This is a helper script to aid in troubleshooting Celery-related activities.

Mostly for internal use right now, but if proved useful, we can make it a "sentry" subcommand.

The idea is that the script is started in interactive mode (either by calling "./bin/celery-helper.py" or via "python -i ./bin/celery-helper.py"), and then one can run commands in the interactive shell such as:
1. Listing all active tasks
2. Listing all task IDs for the given name
3. Revoking and terminating all tasks by name
...and others.

Additional docs around some basic operations: https://docs.celeryq.dev/en/latest/userguide/workers.html#inspecting-workers

