### PR TITLE
ref: use canonical names for referencing interfaces in plugins

### DIFF
--- a/src/sentry_plugins/jira/plugin.py
+++ b/src/sentry_plugins/jira/plugin.py
@@ -652,7 +652,7 @@ class JiraPlugin(CorePluginMixin, IssuePlugin2):
         ):
             return
 
-        interface = event.interfaces.get("sentry.interfaces.Exception")
+        interface = event.interfaces.get("exception")
 
         if interface:
             post_data["description"] += "\n{code}%s{code}" % interface.get_stacktrace(

--- a/src/sentry_plugins/segment/plugin.py
+++ b/src/sentry_plugins/segment/plugin.py
@@ -51,8 +51,8 @@ class SegmentPlugin(CorePluginMixin, DataForwardingPlugin):
             "level": event.get_tag("level") or "",
             "environment": event.get_tag("environment") or "",
         }
-        if "sentry.interfaces.Http" in event.interfaces:
-            http = event.interfaces["sentry.interfaces.Http"]
+        if "request" in event.interfaces:
+            http = event.interfaces["request"]
             headers = http.headers
             if not isinstance(headers, dict):
                 headers = dict(headers or ())
@@ -64,8 +64,8 @@ class SegmentPlugin(CorePluginMixin, DataForwardingPlugin):
                     "requestReferer": headers.get("Referer", ""),
                 }
             )
-        if "sentry.interfaces.Exception" in event.interfaces:
-            exc = event.interfaces["sentry.interfaces.Exception"].values[0]
+        if "exception" in event.interfaces:
+            exc = event.interfaces["exception"].values[0]
             props.update({"exceptionType": exc.type})
         return props
 
@@ -81,16 +81,16 @@ class SegmentPlugin(CorePluginMixin, DataForwardingPlugin):
             "environment": event.get_tag("environment") or "",
         }
 
-        if "sentry.interfaces.User" in event.interfaces:
-            user = event.interfaces["sentry.interfaces.User"]
+        if "user" in event.interfaces:
+            user = event.interfaces["user"]
             if user.ip_address:
                 context["ip"] = user.ip_address
             user_id = user.id
         else:
             user_id = None
 
-        if "sentry.interfaces.Http" in event.interfaces:
-            http = event.interfaces["sentry.interfaces.Http"]
+        if "request" in event.interfaces:
+            http = event.interfaces["request"]
             headers = http.headers
             if not isinstance(headers, dict):
                 headers = dict(headers or ())
@@ -107,8 +107,8 @@ class SegmentPlugin(CorePluginMixin, DataForwardingPlugin):
                 }
             )
 
-        if "sentry.interfaces.Exception" in event.interfaces:
-            exc = event.interfaces["sentry.interfaces.Exception"].values[0]
+        if "exception" in event.interfaces:
+            exc = event.interfaces["exception"].values[0]
             props.update({"exceptionType": exc.type})
 
         return {
@@ -131,7 +131,7 @@ class SegmentPlugin(CorePluginMixin, DataForwardingPlugin):
 
         # we avoid instantiating interfaces here as they're only going to be
         # used if there's a User present
-        user_interface = event.data.get("sentry.interfaces.User")
+        user_interface = event.data.get("user")
         if not user_interface:
             return
 

--- a/src/sentry_plugins/splunk/plugin.py
+++ b/src/sentry_plugins/splunk/plugin.py
@@ -102,7 +102,7 @@ class SplunkPlugin(CorePluginMixin, DataForwardingPlugin):
         if host:
             return host
 
-        user_interface = event.interfaces.get("sentry.interfaces.User")
+        user_interface = event.interfaces.get("user")
         if user_interface:
             host = user_interface.ip_address
             if host:


### PR DESCRIPTION
I'm planning to kill CanonicalKeyDict since relay handles all that normalization already for us -- these access the legacy names

<!-- Describe your PR here. -->