### PR TITLE
ref: fix usage of legacy event data key in suggested fix

### DIFF
--- a/src/sentry/api/endpoints/event_ai_suggested_fix.py
+++ b/src/sentry/api/endpoints/event_ai_suggested_fix.py
@@ -191,7 +191,7 @@ def describe_event_for_ai(event, model):
     detailed = model.startswith("gpt-4")
     data = {}
 
-    msg = event.get("message")
+    msg = event.get("logentry")
     if msg:
         data["message"] = msg
 


### PR DESCRIPTION
I'm attempting to kill CanonicalKeyDict and this code uses the legacy name instead of the normalized name

<!-- Describe your PR here. -->