### PR TITLE
ref: skip checking legacy event key for eventstream

### DIFF
--- a/src/sentry/eventstream/snuba.py
+++ b/src/sentry/eventstream/snuba.py
@@ -166,7 +166,7 @@ class SnubaProtocolEventStream(EventStream):
             contexts = event_data.setdefault("contexts", {})
 
             # add user.geo to contexts if it exists
-            user_dict = event_data.get("user") or event_data.get("sentry.interfaces.User") or {}
+            user_dict = event_data.get("user") or {}
             geo = user_dict.get("geo", {})
             if "geo" not in contexts and isinstance(geo, dict):
                 contexts["geo"] = geo


### PR DESCRIPTION
relay normalizes these so they shouldn't appear here at all

I'm planning to kill CanonicalKeyDict as well and this is one of the references triggering failing tests

<!-- Describe your PR here. -->