### PR TITLE
ref: skip event pre-normalize through CanonicalKeyDict

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -338,7 +338,7 @@ class EventManager:
         project_config: Any | None = None,
         sent_at: datetime | None = None,
     ):
-        self._data = CanonicalKeyDict(data)
+        self._data: MutableMapping[str, Any] = data
         self.version = version
         self._project = project
         # if not explicitly specified try to get the grouping from project_config
@@ -401,7 +401,7 @@ class EventManager:
         if pre_normalize_type in ("generic", "feedback"):
             self._data["type"] = pre_normalize_type
 
-    def get_data(self) -> CanonicalKeyDict:
+    def get_data(self) -> MutableMapping[str, Any]:
         return self._data
 
     @sentry_sdk.tracing.trace

--- a/src/sentry/web/frontend/debug/mail.py
+++ b/src/sentry/web/frontend/debug/mail.py
@@ -431,7 +431,7 @@ class ActivityMailDebugView(View):
         event_type = get_event_type(data)
 
         event = eventstore.backend.create_event(
-            event_id="a" * 32, group_id=group.id, project_id=project.id, data=data.data
+            event_id="a" * 32, group_id=group.id, project_id=project.id, data=data
         )
 
         group.message = event.search_message
@@ -532,7 +532,7 @@ def digest(request):
             )
 
             event = eventstore.backend.create_event(
-                event_id=uuid.uuid4().hex, group_id=group.id, project_id=project.id, data=data.data
+                event_id=uuid.uuid4().hex, group_id=group.id, project_id=project.id, data=data
             )
             records.append(
                 Record(

--- a/tests/sentry/event_manager/test_normalization.py
+++ b/tests/sentry/event_manager/test_normalization.py
@@ -199,13 +199,13 @@ def test_deprecated_attrs(key):
     assert not data.get("errors")
 
 
-def test_returns_canonical_dict():
+def test_returns_canonical_dict_after_normalization():
     from sentry.utils.canonical import CanonicalKeyDict
 
     event = make_event()
 
     manager = EventManager(event)
-    assert isinstance(manager.get_data(), CanonicalKeyDict)
+    assert not isinstance(manager.get_data(), CanonicalKeyDict)
     manager.normalize()
     assert isinstance(manager.get_data(), CanonicalKeyDict)
 


### PR DESCRIPTION
keys get normalized through the relay normalization

this gets the rest of the tests passing when changing CanonicalKeyDict to raise when legacy keys are passed -- the testsuite passes lots of `{"message": ...}` similar to current sdks!

<!-- Describe your PR here. -->