### PR TITLE
ref: produce a sentry error (behind an option) on canonical key fallback

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -2339,6 +2339,13 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 
+# temporary option for logging canonical key fallback stacktraces
+register(
+    "canonical-fallback.send-error-to-sentry",
+    default=0.0,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+
 # Standalone spans
 register(
     "standalone-spans.process-spans-consumer.enable",


### PR DESCRIPTION
🤞 this'll hopefully show us the remaining (if any) callers -- though I may have already fixed them when I fixed plugins

<!-- Describe your PR here. -->