### PR TITLE
fix(trace-explorer): Skip floating spans in traces

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1710,6 +1710,12 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 register(
+    "performance.traces.trace-explorer-skip-floating-spans",
+    type=Bool,
+    default=True,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+register(
     "performance.traces.span_query_minimum_spans",
     type=Int,
     default=10000,

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -1538,7 +1538,7 @@ class BaseSpansTestCase(SnubaTestCase):
         self,
         project_id: int,
         trace_id: str,
-        transaction_id: str,
+        transaction_id: str | None,  # Nones are permitted for INP spans
         span_id: str | None = None,
         parent_span_id: str | None = None,
         profile_id: str | None = None,

--- a/tests/sentry/api/endpoints/test_organization_traces.py
+++ b/tests/sentry/api/endpoints/test_organization_traces.py
@@ -76,7 +76,7 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
         project_2 = self.create_project()
 
         # Hack: ensure that no span ids with leading 0s are generated for the test
-        span_ids = ["1" + uuid4().hex[:15] for _ in range(12)]
+        span_ids = ["1" + uuid4().hex[:15] for _ in range(13)]
         tags = ["", "bar", "bar", "baz", "", "bar", "baz"]
         timestamps = []
 
@@ -244,6 +244,21 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
         }
         error_data["tags"] = [["transaction", "foo"]]
         self.store_event(error_data, project_id=project_1.id)
+
+        timestamps.append(before_now(days=0, minutes=21, seconds=0).replace(microsecond=0))
+        self.store_indexed_span(
+            project_id=project_1.id,
+            trace_id=trace_id_2,
+            transaction_id=None,  # mock an INP span
+            span_id=span_ids[12],
+            parent_span_id=span_ids[4],
+            timestamp=timestamps[-1],
+            transaction="",
+            duration=1_000,
+            exclusive_time=1_000,
+            op="ui.navigation.click",
+            category="ui",
+        )
 
         return (
             project_1,


### PR DESCRIPTION
There are some floating spans in a trace like INP spans. These spans are not associated with a transaction and can make the trace look longer. They also don't work in the trace view. So let's skip them for now until we have a clearer story around how it ties into the tracing experience.