### PR TITLE
fix(query-builder): Ensure that search bar only has a single tab stop

### DIFF
--- a/static/app/components/searchQueryBuilder/combobox.tsx
+++ b/static/app/components/searchQueryBuilder/combobox.tsx
@@ -33,6 +33,7 @@ type SearchQueryBuilderComboboxProps = {
   onInputChange?: React.ChangeEventHandler<HTMLInputElement>;
   onKeyDown?: (e: React.KeyboardEvent<HTMLInputElement>) => void;
   placeholder?: string;
+  tabIndex?: number;
 };
 
 export function SearchQueryBuilderCombobox({
@@ -48,6 +49,7 @@ export function SearchQueryBuilderCombobox({
   onKeyDown,
   onInputChange,
   autoFocus,
+  tabIndex = -1,
 }: SearchQueryBuilderComboboxProps) {
   const theme = useTheme();
   const listBoxRef = useRef<HTMLUListElement>(null);
@@ -162,6 +164,7 @@ export function SearchQueryBuilderCombobox({
         onClick={handleInputClick}
         value={inputValue}
         onChange={onInputChange}
+        tabIndex={tabIndex}
       />
       <StyledPositionWrapper
         {...overlayProps}

--- a/static/app/components/searchQueryBuilder/index.spec.tsx
+++ b/static/app/components/searchQueryBuilder/index.spec.tsx
@@ -287,5 +287,23 @@ describe('SearchQueryBuilder', function () {
         screen.getAllByRole('combobox', {name: 'Add a search term'}).at(-2)
       ).toHaveFocus();
     });
+
+    it('has a single tab stop', async function () {
+      render(
+        <SearchQueryBuilder {...defaultProps} initialQuery="browser.name:firefox" />
+      );
+
+      expect(document.body).toHaveFocus();
+
+      // Tabbing in should focus the last input
+      await userEvent.keyboard('{Tab}');
+      expect(
+        screen.getAllByRole('combobox', {name: 'Add a search term'}).at(-1)
+      ).toHaveFocus();
+
+      // Shift-tabbing should exit the component
+      await userEvent.keyboard('{Shift>}{Tab}{/Shift}');
+      expect(document.body).toHaveFocus();
+    });
   });
 });

--- a/static/app/components/searchQueryBuilder/index.tsx
+++ b/static/app/components/searchQueryBuilder/index.tsx
@@ -36,6 +36,7 @@ interface SearchQueryBuilderProps {
 
 interface GridProps extends AriaGridListOptions<ParseResultToken> {
   children: CollectionChildren<ParseResultToken>;
+  items: ParseResultToken[];
 }
 
 function Grid(props: GridProps) {

--- a/static/app/components/searchQueryBuilder/input.tsx
+++ b/static/app/components/searchQueryBuilder/input.tsx
@@ -25,6 +25,11 @@ type SearchQueryBuilderInputProps = {
   token: TokenResult<Token.FREE_TEXT> | TokenResult<Token.SPACES>;
 };
 
+type SearchQueryBuilderInputInternalProps = {
+  tabIndex: number;
+  token: TokenResult<Token.FREE_TEXT> | TokenResult<Token.SPACES>;
+};
+
 function getWordAtCursorPosition(value: string, cursorPosition: number) {
   const words = value.split(' ');
 
@@ -67,7 +72,10 @@ function replaceFocusedWordWithFilter(
   return value;
 }
 
-function SearchQueryBuilderInputInternal({token}: SearchQueryBuilderInputProps) {
+function SearchQueryBuilderInputInternal({
+  token,
+  tabIndex,
+}: SearchQueryBuilderInputInternalProps) {
   const [inputValue, setInputValue] = useState(token.value.trim());
   // TODO(malwilley): Use input ref to update cursor position on mount
   const [selectionIndex, setSelectionIndex] = useState(0);
@@ -139,6 +147,7 @@ function SearchQueryBuilderInputInternal({token}: SearchQueryBuilderInputProps) 
           setSelectionIndex(e.target.selectionStart ?? 0);
         }
       }}
+      tabIndex={tabIndex}
     >
       <Section>
         {items.map(item => (
@@ -175,14 +184,12 @@ export function SearchQueryBuilderInput({
     [item.key, state.selectionManager]
   );
 
+  const isFocused = item.key === state.selectionManager.focusedKey;
+
   return (
-    <Row
-      {...mergeProps(rowProps, {onFocus})}
-      ref={ref}
-      tabIndex={-1} // Input row should not be focused directly
-    >
+    <Row {...mergeProps(rowProps, {onFocus})} ref={ref} tabIndex={-1}>
       <GridCell {...gridCellProps} onClick={e => e.stopPropagation()}>
-        <SearchQueryBuilderInputInternal token={token} item={item} state={state} />
+        <SearchQueryBuilderInputInternal token={token} tabIndex={isFocused ? 0 : -1} />
       </GridCell>
     </Row>
   );

--- a/static/app/components/searchQueryBuilder/useQueryBuilderGrid.tsx
+++ b/static/app/components/searchQueryBuilder/useQueryBuilderGrid.tsx
@@ -49,6 +49,19 @@ export function useQueryBuilderGrid(
       // The default behavior will capture some keys such as Enter and Space, which
       // we want to handle ourselves.
       onKeyDownCapture: () => {},
+      onFocus: () => {
+        if (state.selectionManager.isFocused) {
+          return;
+        }
+
+        // Ensure that the state is updated correctly
+        state.selectionManager.setFocused(true);
+
+        // If nothing is has been focused yet , default to last item
+        if (!state.selectionManager.focusedKey) {
+          state.selectionManager.setFocusedKey(state.collection.getLastKey());
+        }
+      },
     },
   };
 }


### PR DESCRIPTION
Pressing tab from the element before the search bar should focus the last input inside the search bar. While focus is within the search bar, tabbing or shift tabbing should exit the search bar, not focus any of the other focusable elements within it.

- Adds `tabIndex="-1"` to all the focusable elements
- Ensures that the `selectionManager` focus state gets updated correctly when arrowing around the search bar. This ensures that when the search bar receives focus again, the correct element is focused.
- Adds an `onFocus` handler to the top level grid element that will set the focus to the last element if the user hasn't interacted with the search bar yet.