### PR TITLE
feat(events-graph): Add storybook for new events graph component

### DIFF
--- a/static/app/components/charts/groupStatusChart.stories.tsx
+++ b/static/app/components/charts/groupStatusChart.stories.tsx
@@ -1,0 +1,51 @@
+import GroupStatusChart from 'sentry/components/charts/groupStatusChart';
+import storyBook from 'sentry/stories/storyBook';
+import type {Group, TimeseriesValue} from 'sentry/types';
+
+const stats: ReadonlyArray<TimeseriesValue> = [
+  // [1715554800, 126],
+  [1715558400, 112],
+  // [1715562000, 126],
+  [1715565600, 113],
+  // [1715569200, 118],
+  [1715572800, 87],
+  // [1715576400, 88],
+  [1715580000, 59],
+  // [1715583600, 54],
+  [1715587200, 55],
+  // [1715590800, 52],
+  [1715594400, 48],
+  // [1715598000, 62],
+  [1715601600, 86],
+  // [1715605200, 100],
+  [1715608800, 121],
+  // [1715612400, 124],
+  [1715616000, 129],
+  // [1715619600, 149],
+  [1715623200, 141],
+  // [1715626800, 132],
+  [1715630400, 133],
+  // [1715634000, 127],
+  [1715637600, 82],
+];
+
+const fakeGroup = {
+  stats: {
+    '24h': stats,
+  },
+} as unknown as Group;
+
+export default storyBook(GroupStatusChart, story => {
+  story('Default', () => {
+    return (
+      <div style={{display: 'flex', justifyContent: 'center', marginBottom: '20px'}}>
+        <GroupStatusChart
+          showMarkLine
+          data={fakeGroup}
+          groupStatus="Escalating"
+          statsPeriod="24h"
+        />
+      </div>
+    );
+  });
+});

--- a/static/app/components/charts/groupStatusChart.stories.tsx
+++ b/static/app/components/charts/groupStatusChart.stories.tsx
@@ -1,3 +1,5 @@
+import styled from '@emotion/styled';
+
 import GroupStatusChart from 'sentry/components/charts/groupStatusChart';
 import storyBook from 'sentry/stories/storyBook';
 import type {Group, TimeseriesValue} from 'sentry/types';
@@ -38,14 +40,20 @@ const fakeGroup = {
 export default storyBook(GroupStatusChart, story => {
   story('Default', () => {
     return (
-      <div style={{display: 'flex', justifyContent: 'center', marginBottom: '20px'}}>
+      <GraphContainer>
         <GroupStatusChart
           showMarkLine
           data={fakeGroup}
           groupStatus="Escalating"
           statsPeriod="24h"
         />
-      </div>
+      </GraphContainer>
     );
   });
 });
+
+const GraphContainer = styled('div')`
+  display: flex;
+  justify-content: center;
+  margin-bottom: 20px;
+`;

--- a/static/app/components/charts/groupStatusChart.stories.tsx
+++ b/static/app/components/charts/groupStatusChart.stories.tsx
@@ -2,7 +2,7 @@ import styled from '@emotion/styled';
 
 import GroupStatusChart from 'sentry/components/charts/groupStatusChart';
 import storyBook from 'sentry/stories/storyBook';
-import type {Group, TimeseriesValue} from 'sentry/types';
+import type {TimeseriesValue} from 'sentry/types';
 
 const stats: ReadonlyArray<TimeseriesValue> = [
   // [1715554800, 126],
@@ -31,22 +31,11 @@ const stats: ReadonlyArray<TimeseriesValue> = [
   [1715637600, 82],
 ];
 
-const fakeGroup = {
-  stats: {
-    '24h': stats,
-  },
-} as unknown as Group;
-
 export default storyBook(GroupStatusChart, story => {
   story('Default', () => {
     return (
       <GraphContainer>
-        <GroupStatusChart
-          showMarkLine
-          data={fakeGroup}
-          groupStatus="Escalating"
-          statsPeriod="24h"
-        />
+        <GroupStatusChart showMarkLine stats={stats} groupStatus="Escalating" />
       </GraphContainer>
     );
   });

--- a/static/app/components/charts/groupStatusChart.tsx
+++ b/static/app/components/charts/groupStatusChart.tsx
@@ -1,0 +1,150 @@
+import {useMemo} from 'react';
+import styled from '@emotion/styled';
+
+import MarkLine from 'sentry/components/charts/components/markLine';
+import MiniBarChart from 'sentry/components/charts/miniBarChart';
+import {LazyRender} from 'sentry/components/lazyRender';
+import {t} from 'sentry/locale';
+import type {Group, TimeseriesValue} from 'sentry/types';
+import type {Series} from 'sentry/types/echarts';
+import {formatAbbreviatedNumber} from 'sentry/utils/formatters';
+import theme from 'sentry/utils/theme';
+
+function asChartPoint(point: [number, number]): {name: number | string; value: number} {
+  return {
+    name: point[0] * 1000,
+    value: point[1],
+  };
+}
+
+const EMPTY_STATS: ReadonlyArray<TimeseriesValue> = [];
+
+type Props = {
+  data: Group;
+  statsPeriod: string;
+  groupStatus?: string;
+  height?: number;
+  showMarkLine?: boolean;
+  showSecondaryPoints?: boolean;
+};
+
+function GroupStatusChart({
+  statsPeriod,
+  data,
+  groupStatus,
+  height = 24,
+  showMarkLine = false,
+  showSecondaryPoints = false,
+}: Props) {
+  const stats: ReadonlyArray<TimeseriesValue> = statsPeriod
+    ? data.filtered
+      ? data.filtered.stats?.[statsPeriod]
+      : data.stats?.[statsPeriod]
+    : EMPTY_STATS;
+
+  const secondaryStats: TimeseriesValue[] | null =
+    statsPeriod && data.filtered ? data.stats[statsPeriod] : null;
+
+  const [series, colors, emphasisColors]: [
+    Series[],
+    [string] | undefined,
+    [string] | undefined,
+  ] = useMemo(() => {
+    if (!stats || !stats.length) {
+      return [[], undefined, undefined];
+    }
+
+    let max = 0;
+    const marklinePoints: number[] = [];
+
+    for (let i = 0; i < stats.length; i++) {
+      const point = stats[i];
+      if (point[1] > max) {
+        max = point[1];
+      }
+      marklinePoints.push(point[1]);
+    }
+
+    const formattedMarkLine = formatAbbreviatedNumber(max);
+
+    const chartSeries: Series[] = [];
+    let chartColors: [string] | undefined = undefined;
+    let chartEmphasisColors: [string] | undefined = undefined;
+
+    if (showSecondaryPoints && secondaryStats && secondaryStats.length) {
+      chartSeries.push({
+        seriesName: t('Total Events'),
+        data: secondaryStats.map(asChartPoint),
+      });
+      chartSeries.push({
+        seriesName: t('Matching Events'),
+        data: stats.map(asChartPoint),
+      });
+    } else {
+      // Colors are custom to preserve historical appearance where the single series is
+      // considerably darker than the two series results.
+      chartColors = [theme.gray300];
+      chartEmphasisColors = [theme.purple300];
+      secondaryStats;
+      showSecondaryPoints;
+      chartSeries.push({
+        seriesName: t('Events'),
+        data: stats.map(asChartPoint),
+        markLine:
+          showMarkLine && max > 0
+            ? MarkLine({
+                silent: true,
+                lineStyle: {color: theme.gray200, type: 'dashed', width: 1},
+                data: [
+                  {
+                    type: 'max',
+                  },
+                ],
+                label: {
+                  show: true,
+                  position: 'end',
+                  color: `${theme.gray300}`,
+                  fontFamily: 'Rubik',
+                  fontSize: 10,
+                  formatter: `${formattedMarkLine}`,
+                },
+              })
+            : undefined,
+      });
+    }
+    return [chartSeries, chartColors, chartEmphasisColors];
+  }, [showSecondaryPoints, secondaryStats, showMarkLine, stats]);
+
+  return (
+    <LazyRender containerHeight={showMarkLine ? 26 : height}>
+      <ChartWrapper>
+        <MiniBarChart
+          showXAxisLine
+          markLineLabelSide="right"
+          barOpacity={0.4}
+          height={showMarkLine ? 36 : height}
+          isGroupedByDate
+          showTimeInTooltip
+          series={series}
+          colors={colors}
+          emphasisColors={emphasisColors}
+          hideDelay={50}
+          showMarkLineLabel={showMarkLine}
+          width={136}
+        />
+        <GraphText>{groupStatus}</GraphText>
+      </ChartWrapper>
+    </LazyRender>
+  );
+}
+
+export default GroupStatusChart;
+
+const ChartWrapper = styled('div')`
+  display: flex;
+  flex-direction: column;
+`;
+// TODO: Call this something better
+const GraphText = styled('div')`
+  color: ${p => p.theme.gray300};
+`;

--- a/static/app/components/charts/groupStatusChart.tsx
+++ b/static/app/components/charts/groupStatusChart.tsx
@@ -70,12 +70,18 @@ function GroupStatusChart({
           showMarkLine && max > 0
             ? MarkLine({
                 silent: true,
-                lineStyle: {color: theme.gray200, type: 'dashed', width: 1},
+                lineStyle: {
+                  color: theme.gray200,
+                  type: [4, 3], // Sets line type to "dashed" with 4 length and 3 gap
+                  opacity: 0.6,
+                  cap: 'round', // Rounded edges for the dashes
+                },
                 data: [
                   {
                     type: 'max',
                   },
                 ],
+                animation: false,
                 label: {
                   show: true,
                   position: 'end',
@@ -95,6 +101,7 @@ function GroupStatusChart({
     <LazyRender containerHeight={showMarkLine ? 26 : height}>
       <ChartWrapper>
         <MiniBarChart
+          animateBars
           showXAxisLine
           markLineLabelSide="right"
           barOpacity={0.4}

--- a/static/app/components/charts/groupStatusChart.tsx
+++ b/static/app/components/charts/groupStatusChart.tsx
@@ -51,12 +51,12 @@ function GroupStatusChart({
     if (showSecondaryPoints && secondaryStats && secondaryStats.length) {
       const series: Series[] = [
         {
-          seriesName: t('Matching Events'),
-          data: stats.map(asChartPoint),
-        },
-        {
           seriesName: t('Total Events'),
           data: secondaryStats.map(asChartPoint),
+        },
+        {
+          seriesName: t('Matching Events'),
+          data: stats.map(asChartPoint),
         },
       ];
 

--- a/static/app/components/charts/groupStatusChart.tsx
+++ b/static/app/components/charts/groupStatusChart.tsx
@@ -29,7 +29,7 @@ type Props = {
 };
 
 function GroupStatusChart({
-  stats = EMPTY_STATS,
+  stats,
   groupStatus,
   height = 24,
   secondaryStats = EMPTY_STATS,

--- a/static/app/components/charts/miniBarChart.tsx
+++ b/static/app/components/charts/miniBarChart.tsx
@@ -13,6 +13,7 @@ import {BarChart} from './barChart';
 import type {BaseChartProps} from './baseChart';
 
 function makeBaseChartOptions({
+  animateBars,
   height,
   hideDelay,
   tooltipFormatter,
@@ -24,6 +25,7 @@ function makeBaseChartOptions({
   showXAxisLine,
   xAxisLineColor,
 }: {
+  animateBars: boolean;
   height: number;
   markLineLabelSide: 'right' | 'left';
   showXAxisLine: boolean;
@@ -84,9 +86,14 @@ function makeBaseChartOptions({
         },
       },
     },
-    options: {
-      animation: false,
-    },
+    options: animateBars
+      ? {
+          animation: true,
+          animationEasing: 'circularOut',
+        }
+      : {
+          animation: false,
+        },
   };
 }
 
@@ -117,6 +124,12 @@ interface Props extends Omit<BaseChartProps, 'css' | 'colors' | 'series' | 'heig
    * Chart height
    */
   height: number;
+
+  /**
+   * Whether to animate the bars on initial render.
+   * If true, bars will rise from the x-axis to their final height.
+   */
+  animateBars?: boolean;
 
   /**
    * Opacity of each bar in the graph (0-1)
@@ -205,6 +218,7 @@ export function getYAxisMaxFn(height: number) {
 }
 
 function MiniBarChart({
+  animateBars = false,
   barOpacity = 0.6,
   emphasisColors,
   series,
@@ -252,6 +266,7 @@ function MiniBarChart({
       }
       set(updated, 'itemStyle.color', colorList[i]);
       set(updated, 'itemStyle.opacity', barOpacity); // Opacity of each bar
+      set(updated, 'itemStyle.borderRadius', [1, 1, 0, 0]); // Rounded corners on top of the bar
       set(updated, 'emphasis.itemStyle.opacity', 1.0);
       set(updated, 'emphasis.itemStyle.color', emphasisColors?.[i] ?? colorList[i]);
       chartSeries.push(updated);
@@ -273,6 +288,7 @@ function MiniBarChart({
       : noLabelYAxisOptions;
 
     const options = makeBaseChartOptions({
+      animateBars,
       height,
       hideDelay,
       tooltipFormatter,
@@ -287,6 +303,7 @@ function MiniBarChart({
 
     return options;
   }, [
+    animateBars,
     grid,
     height,
     hideDelay,

--- a/static/app/components/charts/miniBarChart.tsx
+++ b/static/app/components/charts/miniBarChart.tsx
@@ -18,10 +18,16 @@ function makeBaseChartOptions({
   tooltipFormatter,
   labelYAxisExtents,
   showMarkLineLabel,
+  markLineLabelSide,
   grid,
   yAxisOptions,
+  showXAxisLine,
+  xAxisLineColor,
 }: {
   height: number;
+  markLineLabelSide: 'right' | 'left';
+  showXAxisLine: boolean;
+  xAxisLineColor: string;
   grid?: GridComponentOption;
   hideDelay?: number;
   labelYAxisExtents?: boolean;
@@ -49,13 +55,18 @@ function makeBaseChartOptions({
       // default size.
       top: labelYAxisExtents || showMarkLineLabel ? 6 : 0,
       bottom: labelYAxisExtents || showMarkLineLabel ? 4 : 0,
-      left: showMarkLineLabel ? 35 : 4,
-      right: 0,
+      left: markLineLabelSide === 'left' ? (showMarkLineLabel ? 35 : 4) : 0,
+      right: markLineLabelSide === 'right' ? (showMarkLineLabel ? 35 : 4) : 0,
     },
     xAxis: {
-      axisLine: {
-        show: false,
-      },
+      axisLine: showXAxisLine
+        ? {
+            show: true,
+            lineStyle: {
+              color: xAxisLineColor,
+            },
+          }
+        : {show: false},
       axisTick: {
         show: false,
         alignWithLabel: true,
@@ -106,6 +117,12 @@ interface Props extends Omit<BaseChartProps, 'css' | 'colors' | 'series' | 'heig
    * Chart height
    */
   height: number;
+
+  /**
+   * Opacity of each bar in the graph (0-1)
+   */
+  barOpacity?: number;
+
   /**
    * Colors to use on the chart.
    */
@@ -133,12 +150,26 @@ interface Props extends Omit<BaseChartProps, 'css' | 'colors' | 'series' | 'heig
    */
   labelYAxisExtents?: boolean;
 
+  /**
+   * Which side of the chart the mark line label shows on.
+   * Requires `showMarkLineLabel` to be true.
+   */
+  markLineLabelSide?: 'right' | 'left';
+
+  /**
+   * Series data to display
+   */
   series?: BarChartProps['series'];
 
   /**
    * Whether not we show a MarkLine label
    */
   showMarkLineLabel?: boolean;
+
+  /**
+   * Whether or not to show the x-axis line
+   */
+  showXAxisLine?: boolean;
 
   /**
    * Whether not the series should be stacked.
@@ -174,6 +205,7 @@ export function getYAxisMaxFn(height: number) {
 }
 
 function MiniBarChart({
+  barOpacity = 0.6,
   emphasisColors,
   series,
   hideDelay,
@@ -182,12 +214,14 @@ function MiniBarChart({
   stacked = false,
   labelYAxisExtents = false,
   showMarkLineLabel = false,
+  markLineLabelSide = 'left',
+  showXAxisLine = false,
   height,
   grid,
   ...props
 }: Props) {
   const theme = useTheme();
-
+  const xAxisLineColor: string = theme.gray200;
   const updatedSeries: BarChartSeries[] = useMemo(() => {
     if (!series?.length) {
       return [];
@@ -217,13 +251,21 @@ function MiniBarChart({
         updated.stack = 'stack1';
       }
       set(updated, 'itemStyle.color', colorList[i]);
-      set(updated, 'itemStyle.opacity', 0.6);
+      set(updated, 'itemStyle.opacity', barOpacity); // Opacity of each bar
       set(updated, 'emphasis.itemStyle.opacity', 1.0);
       set(updated, 'emphasis.itemStyle.color', emphasisColors?.[i] ?? colorList[i]);
       chartSeries.push(updated);
     }
     return chartSeries;
-  }, [series, emphasisColors, stacked, colors, theme.gray200, theme.purple300]);
+  }, [
+    barOpacity,
+    series,
+    emphasisColors,
+    stacked,
+    colors,
+    theme.gray200,
+    theme.purple300,
+  ]);
 
   const chartOptions = useMemo(() => {
     const yAxisOptions = labelYAxisExtents
@@ -236,12 +278,25 @@ function MiniBarChart({
       tooltipFormatter,
       labelYAxisExtents,
       showMarkLineLabel,
+      markLineLabelSide,
       grid,
       yAxisOptions,
+      showXAxisLine,
+      xAxisLineColor,
     });
 
     return options;
-  }, [grid, height, hideDelay, labelYAxisExtents, showMarkLineLabel, tooltipFormatter]);
+  }, [
+    grid,
+    height,
+    hideDelay,
+    labelYAxisExtents,
+    markLineLabelSide,
+    showMarkLineLabel,
+    showXAxisLine,
+    tooltipFormatter,
+    xAxisLineColor,
+  ]);
 
   return <BarChart series={updatedSeries} height={height} {...chartOptions} {...props} />;
 }


### PR DESCRIPTION
Related ticket: #69691

This PR creates the storybook and initial design for the new events stats graph component, `<GroupStatusChart/>`. **This PR does not change the existing events graph in the issue stream**. 

The only publicly used file that was modified is miniBarChart.tsx. The `<MiniBarChart/>` component is the underlying component of the existing events graph component, `<GroupChart/>`, and it needs to expose more parameters of the graph as props to allow for the modifications in the new `<GroupStatusChart/>` component to avoid creating an entirely new underlying component\. Prop defaults were set for all new props introduced to ensure that the existing event stats chart is visually unchanged. 

The new component in its current form: 
![image](https://github.com/getsentry/sentry/assets/55160142/ff1bbf2d-d3ef-49cf-9536-8302defb2ffd)


Remaining work to be done (probably in future PRs): 
- [ ] Add test file
- [ ] Add loading state
- [ ] **Swap old events graph with this one**

Open design questions:
- [ ] ~~What should the loading state look like?~~ Gray box (with rounded edges)