### PR TITLE
chore(api) Log incorrect cors method header

### DIFF
--- a/src/sentry/api/base.py
+++ b/src/sentry/api/base.py
@@ -131,6 +131,16 @@ def apply_cors_headers(
     if allowed_methods is None:
         allowed_methods = []
     allow = ", ".join(allowed_methods)
+    if not allow or "*" in allow:
+        logger.info(
+            "api.cors.no_methods",
+            extra={
+                "url": request.path,
+                "method": request.method,
+                "origin": request.META.get("HTTP_ORIGIN", ""),
+                "allow": allow,
+            },
+        )
     response["Allow"] = allow
     response["Access-Control-Allow-Methods"] = allow
     response["Access-Control-Allow-Headers"] = (
@@ -138,9 +148,9 @@ def apply_cors_headers(
         "Content-Type, Authentication, Authorization, Content-Encoding, "
         "sentry-trace, baggage, X-CSRFToken"
     )
-    response["Access-Control-Expose-Headers"] = (
-        "X-Sentry-Error, X-Sentry-Direct-Hit, X-Hits, X-Max-Hits, " "Endpoint, Retry-After, Link"
-    )
+    response[
+        "Access-Control-Expose-Headers"
+    ] = "X-Sentry-Error, X-Sentry-Direct-Hit, X-Hits, X-Max-Hits, Endpoint, Retry-After, Link"
 
     if request.META.get("HTTP_ORIGIN") == "null":
         # if ORIGIN header is explicitly specified as 'null' leave it alone


### PR DESCRIPTION
We have had a few reports of CORS responses that prevent actions from being taken. Based on a sample, we're including `Access-Control-Allow-Methods: *` in a response with credentials which is not compliant with CORS spec.

Refs #70859
