### PR TITLE
ref(assignee-dropdown): Add size limit to assignee dropdown

### DIFF
--- a/static/app/components/assigneeSelectorDropdown.tsx
+++ b/static/app/components/assigneeSelectorDropdown.tsx
@@ -550,6 +550,8 @@ export default function AssigneeSelectorDropdown({
         options={makeAllOptions()}
         trigger={trigger ?? makeTrigger}
         menuFooter={footerInviteButton}
+        sizeLimit={150}
+        sizeLimitMessage="Use search to find more users and teams..."
       />
     </AssigneeWrapper>
   );


### PR DESCRIPTION
This PR adds a limit to the number of options that can be displayed in the assignee dropdown. This is so that issues with a massive number of assignable options do not take forever to load. 

The current limit is set to 150, if you believe a different limit would be better feel free to start a discussion in the comments. 

New Design:
![image](https://github.com/getsentry/sentry/assets/55160142/9b9574dd-7122-4337-933f-911280708891)
