### PR TITLE
ref(crons): Tighten check_{missed,timeout} queries

### DIFF
--- a/src/sentry/monitors/clock_tasks/check_missed.py
+++ b/src/sentry/monitors/clock_tasks/check_missed.py
@@ -55,25 +55,32 @@ def dispatch_check_missing(ts: datetime):
 
     This will dispatch MarkMissing messages into monitors-clock-tasks.
     """
-    qs = MonitorEnvironment.objects.filter(
-        IGNORE_MONITORS,
-        monitor__type__in=[MonitorType.CRON_JOB],
-        next_checkin_latest__lte=ts,
-    )[:MONITOR_LIMIT]
+    missed_envs = list(
+        MonitorEnvironment.objects.filter(
+            IGNORE_MONITORS,
+            monitor__type__in=[MonitorType.CRON_JOB],
+            next_checkin_latest__lte=ts,
+        ).values("id")[:MONITOR_LIMIT]
+    )
 
-    metrics.gauge("sentry.monitors.tasks.check_missing.count", qs.count(), sample_rate=1.0)
-    for monitor_environment in qs:
+    metrics.gauge(
+        "sentry.monitors.tasks.check_missing.count",
+        len(missed_envs),
+        sample_rate=1.0,
+    )
+
+    for monitor_environment in missed_envs:
         message: MarkMissing = {
             "type": "mark_missing",
             "ts": ts.timestamp(),
-            "monitor_environment_id": monitor_environment.id,
+            "monitor_environment_id": monitor_environment["id"],
         }
         # XXX(epurkhiser): Partitioning by monitor_environment.id is important
         # here as these task messages will be consumed in a multi-consumer
         # setup. If we backlogged clock-ticks we may produce multiple missed
         # tasks for the same monitor_environment. These MUST happen in-order.
         payload = KafkaPayload(
-            str(monitor_environment.id).encode(),
+            str(monitor_environment["id"]).encode(),
             MONITORS_CLOCK_TASKS_CODEC.encode(message),
             [],
         )

--- a/src/sentry/monitors/clock_tasks/check_timeout.py
+++ b/src/sentry/monitors/clock_tasks/check_timeout.py
@@ -29,24 +29,32 @@ def dispatch_check_timeout(ts: datetime):
 
     This will dispatch MarkTimeout messages into monitors-clock-tasks.
     """
-    qs = MonitorCheckIn.objects.filter(status=CheckInStatus.IN_PROGRESS, timeout_at__lte=ts)[
-        :CHECKINS_LIMIT
-    ]
-    metrics.gauge("sentry.monitors.tasks.check_timeout.count", qs.count(), sample_rate=1.0)
+    missed_checkins = list(
+        MonitorCheckIn.objects.filter(status=CheckInStatus.IN_PROGRESS, timeout_at__lte=ts,).values(
+            "id", "monitor_environment_id"
+        )[:CHECKINS_LIMIT]
+    )
+
+    metrics.gauge(
+        "sentry.monitors.tasks.check_timeout.count",
+        len(missed_checkins),
+        sample_rate=1.0,
+    )
+
     # check for any monitors which are still running and have exceeded their maximum runtime
-    for checkin in qs:
+    for checkin in missed_checkins:
         message: MarkTimeout = {
             "type": "mark_timeout",
             "ts": ts.timestamp(),
-            "monitor_environment_id": checkin.monitor_environment_id,
-            "checkin_id": checkin.id,
+            "monitor_environment_id": checkin["monitor_environment_id"],
+            "checkin_id": checkin["id"],
         }
         # XXX(epurkhiser): Partitioning by monitor_environment.id is important
         # here as these task messages will be consumed in a multi-consumer
         # setup. If we backlogged clock-ticks we may produce multiple timeout
         # tasks for the same monitor_environment. These MUST happen in-order.
         payload = KafkaPayload(
-            str(checkin.monitor_environment_id).encode(),
+            str(checkin["monitor_environment_id"]).encode(),
             MONITORS_CLOCK_TASKS_CODEC.encode(message),
             [],
         )


### PR DESCRIPTION
We don't need to select everything. We can potentially improve query
performance here by allowing a Index Only scan [^0], where the data comes
straight from the index

[^0]: https://pganalyze.com/docs/explain/scan-nodes/index-only-scan