### PR TITLE
fix(self-hosted): Ensure sentry help does not silently fail

### DIFF
--- a/self-hosted/Dockerfile
+++ b/self-hosted/Dockerfile
@@ -17,68 +17,69 @@ ARG TINI_VERSION=0.19.0
 ARG TINI_SHA256=93dcc18adc78c65a028a84799ecf8ad40c936fdfc5f2a57b1acda5a8117fa82c
 
 RUN set -x \
-  && buildDeps=" \
-  wget \
-  " \
-  && apt-get update && apt-get install -y --no-install-recommends $buildDeps \
-  && rm -rf /var/lib/apt/lists/* \
-  # grab gosu for easy step-down from root
-  && wget --quiet -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-amd64" \
-  && echo "$GOSU_SHA256 /usr/local/bin/gosu" | sha256sum --check --status \
-  && chmod +x /usr/local/bin/gosu \
-  # grab tini for signal processing and zombie killing
-  && wget --quiet -O /usr/local/bin/tini "https://github.com/krallin/tini/releases/download/v$TINI_VERSION/tini-amd64" \
-  && echo "$TINI_SHA256 /usr/local/bin/tini" | sha256sum --check --status \
-  && chmod +x /usr/local/bin/tini \
-  && apt-get purge -y --auto-remove $buildDeps
+    && buildDeps=" \
+    wget \
+    " \
+    && apt-get update && apt-get install -y --no-install-recommends $buildDeps \
+    && rm -rf /var/lib/apt/lists/* \
+    # grab gosu for easy step-down from root
+    && wget --quiet -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-amd64" \
+    && echo "$GOSU_SHA256 /usr/local/bin/gosu" | sha256sum --check --status \
+    && chmod +x /usr/local/bin/gosu \
+    # grab tini for signal processing and zombie killing
+    && wget --quiet -O /usr/local/bin/tini "https://github.com/krallin/tini/releases/download/v$TINI_VERSION/tini-amd64" \
+    && echo "$TINI_SHA256 /usr/local/bin/tini" | sha256sum --check --status \
+    && chmod +x /usr/local/bin/tini \
+    && apt-get purge -y --auto-remove $buildDeps
 
 # Sane defaults for pip
 ENV \
-  PIP_NO_CACHE_DIR=1 \
-  PIP_DISABLE_PIP_VERSION_CHECK=1 \
-  # Sentry config params
-  SENTRY_CONF=/etc/sentry \
-  # Disable some unused uWSGI features, saving dependencies
-  # Thank to https://stackoverflow.com/a/25260588/90297
-  UWSGI_PROFILE_OVERRIDE=ssl=false;xml=false;routing=false \
-  # UWSGI dogstatsd plugin
-  UWSGI_NEED_PLUGIN=/var/lib/uwsgi/dogstatsd \
-  # grpcio>1.30.0 requires this, see requirements.txt for more detail.
-  GRPC_POLL_STRATEGY=epoll1
+    PIP_NO_CACHE_DIR=1 \
+    PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    # Sentry config params
+    SENTRY_CONF=/etc/sentry \
+    # Disable some unused uWSGI features, saving dependencies
+    # Thank to https://stackoverflow.com/a/25260588/90297
+    UWSGI_PROFILE_OVERRIDE=ssl=false;xml=false;routing=false \
+    # UWSGI dogstatsd plugin
+    UWSGI_NEED_PLUGIN=/var/lib/uwsgi/dogstatsd \
+    # grpcio>1.30.0 requires this, see requirements.txt for more detail.
+    GRPC_POLL_STRATEGY=epoll1
 
 # Install dependencies first to leverage Docker layer caching.
 COPY /dist/requirements-frozen.txt /tmp/requirements-frozen.txt
 RUN set -x \
-  && buildDeps="" \
-  # uwsgi-dogstatsd
-  && buildDeps="$buildDeps \
-  gcc \
-  libpcre3-dev \
-  wget \
-  zlib1g-dev \
-  " \
-  && apt-get update \
-  && apt-get install -y --no-install-recommends $buildDeps \
-  && pip install -r /tmp/requirements-frozen.txt \
-  && mkdir /tmp/uwsgi-dogstatsd \
-  # pinned the same as in getsentry
-  && wget -O - https://github.com/DataDog/uwsgi-dogstatsd/archive/1a04f784491ab0270b4e94feb94686b65d8d2db1.tar.gz | \
-  tar -xzf - -C /tmp/uwsgi-dogstatsd --strip-components=1 \
-  && UWSGI_NEED_PLUGIN="" uwsgi --build-plugin /tmp/uwsgi-dogstatsd \
-  && mkdir -p /var/lib/uwsgi \
-  && mv dogstatsd_plugin.so /var/lib/uwsgi/ \
-  && rm -rf /tmp/requirements-frozen.txt /tmp/uwsgi-dogstatsd .uwsgi_plugins_builder \
-  && apt-get purge -y --auto-remove $buildDeps \
-  && apt-get clean \
-  && rm -rf /var/lib/apt/lists/* \
-  # Fully verify that the C extension is correctly installed, it unfortunately
-  # requires a full check into maxminddb.extension.Reader
-  && python -c 'import maxminddb.extension; maxminddb.extension.Reader' \
-  && mkdir -p $SENTRY_CONF
+    && buildDeps="" \
+    # uwsgi-dogstatsd
+    && buildDeps="$buildDeps \
+    gcc \
+    libpcre3-dev \
+    wget \
+    zlib1g-dev \
+    " \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends $buildDeps \
+    && pip install -r /tmp/requirements-frozen.txt \
+    && mkdir /tmp/uwsgi-dogstatsd \
+    # pinned the same as in getsentry
+    && wget -O - https://github.com/DataDog/uwsgi-dogstatsd/archive/1a04f784491ab0270b4e94feb94686b65d8d2db1.tar.gz | \
+    tar -xzf - -C /tmp/uwsgi-dogstatsd --strip-components=1 \
+    && UWSGI_NEED_PLUGIN="" uwsgi --build-plugin /tmp/uwsgi-dogstatsd \
+    && mkdir -p /var/lib/uwsgi \
+    && mv dogstatsd_plugin.so /var/lib/uwsgi/ \
+    && rm -rf /tmp/requirements-frozen.txt /tmp/uwsgi-dogstatsd .uwsgi_plugins_builder \
+    && apt-get purge -y --auto-remove $buildDeps \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* \
+    # Fully verify that the C extension is correctly installed, it unfortunately
+    # requires a full check into maxminddb.extension.Reader
+    && python -c 'import maxminddb.extension; maxminddb.extension.Reader' \
+    && mkdir -p $SENTRY_CONF
 
 COPY /dist/*.whl /tmp/dist/
 RUN pip install /tmp/dist/*.whl --no-deps && pip check && rm -rf /tmp/dist
-RUN sentry help | sed '1,/Commands:/d' | awk '{print $1}' >  /sentry-commands.txt
+RUN set -o pipefail \
+    && sentry help | sed '1,/Commands:/d' | awk '{print $1}' >  /sentry-commands.txt
 
 COPY ./self-hosted/sentry.conf.py ./self-hosted/config.yml $SENTRY_CONF/
 COPY ./self-hosted/docker-entrypoint.sh /

--- a/self-hosted/Dockerfile
+++ b/self-hosted/Dockerfile
@@ -17,64 +17,64 @@ ARG TINI_VERSION=0.19.0
 ARG TINI_SHA256=93dcc18adc78c65a028a84799ecf8ad40c936fdfc5f2a57b1acda5a8117fa82c
 
 RUN set -x \
-    && buildDeps=" \
-    wget \
-    " \
-    && apt-get update && apt-get install -y --no-install-recommends $buildDeps \
-    && rm -rf /var/lib/apt/lists/* \
-    # grab gosu for easy step-down from root
-    && wget --quiet -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-amd64" \
-    && echo "$GOSU_SHA256 /usr/local/bin/gosu" | sha256sum --check --status \
-    && chmod +x /usr/local/bin/gosu \
-    # grab tini for signal processing and zombie killing
-    && wget --quiet -O /usr/local/bin/tini "https://github.com/krallin/tini/releases/download/v$TINI_VERSION/tini-amd64" \
-    && echo "$TINI_SHA256 /usr/local/bin/tini" | sha256sum --check --status \
-    && chmod +x /usr/local/bin/tini \
-    && apt-get purge -y --auto-remove $buildDeps
+  && buildDeps=" \
+  wget \
+  " \
+  && apt-get update && apt-get install -y --no-install-recommends $buildDeps \
+  && rm -rf /var/lib/apt/lists/* \
+  # grab gosu for easy step-down from root
+  && wget --quiet -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-amd64" \
+  && echo "$GOSU_SHA256 /usr/local/bin/gosu" | sha256sum --check --status \
+  && chmod +x /usr/local/bin/gosu \
+  # grab tini for signal processing and zombie killing
+  && wget --quiet -O /usr/local/bin/tini "https://github.com/krallin/tini/releases/download/v$TINI_VERSION/tini-amd64" \
+  && echo "$TINI_SHA256 /usr/local/bin/tini" | sha256sum --check --status \
+  && chmod +x /usr/local/bin/tini \
+  && apt-get purge -y --auto-remove $buildDeps
 
 # Sane defaults for pip
 ENV \
-    PIP_NO_CACHE_DIR=1 \
-    PIP_DISABLE_PIP_VERSION_CHECK=1 \
-    # Sentry config params
-    SENTRY_CONF=/etc/sentry \
-    # Disable some unused uWSGI features, saving dependencies
-    # Thank to https://stackoverflow.com/a/25260588/90297
-    UWSGI_PROFILE_OVERRIDE=ssl=false;xml=false;routing=false \
-    # UWSGI dogstatsd plugin
-    UWSGI_NEED_PLUGIN=/var/lib/uwsgi/dogstatsd \
-    # grpcio>1.30.0 requires this, see requirements.txt for more detail.
-    GRPC_POLL_STRATEGY=epoll1
+  PIP_NO_CACHE_DIR=1 \
+  PIP_DISABLE_PIP_VERSION_CHECK=1 \
+  # Sentry config params
+  SENTRY_CONF=/etc/sentry \
+  # Disable some unused uWSGI features, saving dependencies
+  # Thank to https://stackoverflow.com/a/25260588/90297
+  UWSGI_PROFILE_OVERRIDE=ssl=false;xml=false;routing=false \
+  # UWSGI dogstatsd plugin
+  UWSGI_NEED_PLUGIN=/var/lib/uwsgi/dogstatsd \
+  # grpcio>1.30.0 requires this, see requirements.txt for more detail.
+  GRPC_POLL_STRATEGY=epoll1
 
 # Install dependencies first to leverage Docker layer caching.
 COPY /dist/requirements-frozen.txt /tmp/requirements-frozen.txt
 RUN set -x \
-    && buildDeps="" \
-    # uwsgi-dogstatsd
-    && buildDeps="$buildDeps \
-    gcc \
-    libpcre3-dev \
-    wget \
-    zlib1g-dev \
-    " \
-    && apt-get update \
-    && apt-get install -y --no-install-recommends $buildDeps \
-    && pip install -r /tmp/requirements-frozen.txt \
-    && mkdir /tmp/uwsgi-dogstatsd \
-    # pinned the same as in getsentry
-    && wget -O - https://github.com/DataDog/uwsgi-dogstatsd/archive/1a04f784491ab0270b4e94feb94686b65d8d2db1.tar.gz | \
-    tar -xzf - -C /tmp/uwsgi-dogstatsd --strip-components=1 \
-    && UWSGI_NEED_PLUGIN="" uwsgi --build-plugin /tmp/uwsgi-dogstatsd \
-    && mkdir -p /var/lib/uwsgi \
-    && mv dogstatsd_plugin.so /var/lib/uwsgi/ \
-    && rm -rf /tmp/requirements-frozen.txt /tmp/uwsgi-dogstatsd .uwsgi_plugins_builder \
-    && apt-get purge -y --auto-remove $buildDeps \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/* \
-    # Fully verify that the C extension is correctly installed, it unfortunately
-    # requires a full check into maxminddb.extension.Reader
-    && python -c 'import maxminddb.extension; maxminddb.extension.Reader' \
-    && mkdir -p $SENTRY_CONF
+  && buildDeps="" \
+  # uwsgi-dogstatsd
+  && buildDeps="$buildDeps \
+  gcc \
+  libpcre3-dev \
+  wget \
+  zlib1g-dev \
+  " \
+  && apt-get update \
+  && apt-get install -y --no-install-recommends $buildDeps \
+  && pip install -r /tmp/requirements-frozen.txt \
+  && mkdir /tmp/uwsgi-dogstatsd \
+  # pinned the same as in getsentry
+  && wget -O - https://github.com/DataDog/uwsgi-dogstatsd/archive/1a04f784491ab0270b4e94feb94686b65d8d2db1.tar.gz | \
+  tar -xzf - -C /tmp/uwsgi-dogstatsd --strip-components=1 \
+  && UWSGI_NEED_PLUGIN="" uwsgi --build-plugin /tmp/uwsgi-dogstatsd \
+  && mkdir -p /var/lib/uwsgi \
+  && mv dogstatsd_plugin.so /var/lib/uwsgi/ \
+  && rm -rf /tmp/requirements-frozen.txt /tmp/uwsgi-dogstatsd .uwsgi_plugins_builder \
+  && apt-get purge -y --auto-remove $buildDeps \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/* \
+  # Fully verify that the C extension is correctly installed, it unfortunately
+  # requires a full check into maxminddb.extension.Reader
+  && python -c 'import maxminddb.extension; maxminddb.extension.Reader' \
+  && mkdir -p $SENTRY_CONF
 
 COPY /dist/*.whl /tmp/dist/
 RUN pip install /tmp/dist/*.whl --no-deps && pip check && rm -rf /tmp/dist

--- a/self-hosted/Dockerfile
+++ b/self-hosted/Dockerfile
@@ -78,8 +78,8 @@ RUN set -x \
 
 COPY /dist/*.whl /tmp/dist/
 RUN pip install /tmp/dist/*.whl --no-deps && pip check && rm -rf /tmp/dist
-RUN set -o pipefail \
-    && sentry help | sed '1,/Commands:/d' | awk '{print $1}' >  /sentry-commands.txt
+RUN set -e \
+    && sentry helpp | sed '1,/Commands:/d' | awk '{print $1}' >  /sentry-commands.txt
 
 COPY ./self-hosted/sentry.conf.py ./self-hosted/config.yml $SENTRY_CONF/
 COPY ./self-hosted/docker-entrypoint.sh /

--- a/self-hosted/Dockerfile
+++ b/self-hosted/Dockerfile
@@ -78,8 +78,7 @@ RUN set -x \
 
 COPY /dist/*.whl /tmp/dist/
 RUN pip install /tmp/dist/*.whl --no-deps && pip check && rm -rf /tmp/dist
-RUN set -e \
-    && sentry helpp | sed '1,/Commands:/d' | awk '{print $1}' >  /sentry-commands.txt
+RUN sentry helpp && sentry help | sed '1,/Commands:/d' | awk '{print $1}' >  /sentry-commands.txt
 
 COPY ./self-hosted/sentry.conf.py ./self-hosted/config.yml $SENTRY_CONF/
 COPY ./self-hosted/docker-entrypoint.sh /

--- a/self-hosted/Dockerfile
+++ b/self-hosted/Dockerfile
@@ -78,7 +78,7 @@ RUN set -x \
 
 COPY /dist/*.whl /tmp/dist/
 RUN pip install /tmp/dist/*.whl --no-deps && pip check && rm -rf /tmp/dist
-RUN sentry helpp && sentry help | sed '1,/Commands:/d' | awk '{print $1}' >  /sentry-commands.txt
+RUN sentry help && sentry help | sed '1,/Commands:/d' | awk '{print $1}' >  /sentry-commands.txt
 
 COPY ./self-hosted/sentry.conf.py ./self-hosted/config.yml $SENTRY_CONF/
 COPY ./self-hosted/docker-entrypoint.sh /


### PR DESCRIPTION
This was silently failing, allowing an image to be built even though `sentry help` returned an error. 