### PR TITLE
feat(insights): add view all button to cache widget

### DIFF
--- a/static/app/views/performance/landing/widgets/widgets/lineChartListWidget.tsx
+++ b/static/app/views/performance/landing/widgets/widgets/lineChartListWidget.tsx
@@ -804,7 +804,8 @@ export function LineChartListWidget(props: PerformanceWidgetProps) {
         [PerformanceWidgetSetting.MOST_TIME_CONSUMING_RESOURCES]:
           'performance/browser/resources/',
         [PerformanceWidgetSetting.MOST_TIME_CONSUMING_DOMAINS]: 'performance/http/',
-        [PerformanceWidgetSetting.HIGHEST_CACHE_MISS_RATE_TRANSACTIONS]: CACHE_BASE_URL,
+        [PerformanceWidgetSetting.HIGHEST_CACHE_MISS_RATE_TRANSACTIONS]:
+          CACHE_BASE_URL.slice(1),
       }[props.chartSetting] ?? '';
 
     return [

--- a/static/app/views/performance/landing/widgets/widgets/lineChartListWidget.tsx
+++ b/static/app/views/performance/landing/widgets/widgets/lineChartListWidget.tsx
@@ -687,7 +687,7 @@ export function LineChartListWidget(props: PerformanceWidgetProps) {
             case PerformanceWidgetSetting.HIGHEST_CACHE_MISS_RATE_TRANSACTIONS:
               const cacheMissRate = listItem[fieldString];
               const target = normalizeUrl(
-                `${CACHE_BASE_URL}/?${qs.stringify({transaction: transaction})}`
+                `${CACHE_BASE_URL}/?${qs.stringify({transaction: transaction, project: listItem['project.id']})}`
               );
               return (
                 <Fragment>
@@ -804,12 +804,14 @@ export function LineChartListWidget(props: PerformanceWidgetProps) {
         [PerformanceWidgetSetting.MOST_TIME_CONSUMING_RESOURCES]:
           'performance/browser/resources/',
         [PerformanceWidgetSetting.MOST_TIME_CONSUMING_DOMAINS]: 'performance/http/',
+        [PerformanceWidgetSetting.HIGHEST_CACHE_MISS_RATE_TRANSACTIONS]: CACHE_BASE_URL,
       }[props.chartSetting] ?? '';
 
     return [
       PerformanceWidgetSetting.MOST_TIME_SPENT_DB_QUERIES,
       PerformanceWidgetSetting.MOST_TIME_CONSUMING_RESOURCES,
       PerformanceWidgetSetting.MOST_TIME_CONSUMING_DOMAINS,
+      PerformanceWidgetSetting.HIGHEST_CACHE_MISS_RATE_TRANSACTIONS,
     ].includes(props.chartSetting) ? (
       <Fragment>
         <div>


### PR DESCRIPTION
1. Adds view all button to cache performance landing widget
<img width="628" alt="image" src="https://github.com/getsentry/sentry/assets/44422760/65899ba0-c362-4990-aa33-2a0a1179e620">

2. Fixes bug where the widget did not pass the project id when you click on a transaction