### PR TITLE
feat(integrations): Toggle features at organization integration level

### DIFF
--- a/src/sentry/integrations/slack/integration.py
+++ b/src/sentry/integrations/slack/integration.py
@@ -121,7 +121,7 @@ class SlackIntegration(SlackNotifyBasicMixin, IntegrationInstallation):
 
         cleaned_flags_data = data.get(self._FLAGS_KEY, {})
         # ensure we add the default supported flags if they don't already exist
-        for flag_name, default_flag_value in self._SUPPORTED_FLAGS_WITH_DEFAULTS:
+        for flag_name, default_flag_value in self._SUPPORTED_FLAGS_WITH_DEFAULTS.items():
             flag_value = cleaned_flags_data.get(flag_name, None)
             if flag_value is None:
                 cleaned_flags_data[flag_name] = default_flag_value

--- a/src/sentry/integrations/slack/integration.py
+++ b/src/sentry/integrations/slack/integration.py
@@ -92,52 +92,6 @@ class SlackIntegration(SlackNotifyBasicMixin, IntegrationInstallation):
         default_installation = (
             "classic_bot" if "user_access_token" in metadata_ else "workspace_app"
         )
-
-    def get_organization_config(self) -> Sequence[tuple[str, bool]]:
-        """
-        Not sure why the base class is restricted to a sequence type, doesn't really make sense, however, it is
-        sufficient to our needs for now, and we can utilize it to return toggleable flags/feature on the integration
-        """
-
-        # Specifically using the parent method because the overwritten method on current class is hacked for another
-        # purpose at the integration/provider wide level, which is wrong/incorrect
-        base_data = super().get_config_data()
-
-        # Add missing toggleable feature flags
-        stored_flag_data = base_data.get(self._FLAGS_KEY, {})
-        for flag_name, default_flag_value in self._SUPPORTED_FLAGS_WITH_DEFAULTS.items():
-            if flag_name not in stored_flag_data:
-                stored_flag_data[flag_name] = default_flag_value
-
-        base_data[self._FLAGS_KEY] = stored_flag_data
-        return base_data
-
-    def _update_and_clean_flags_in_organization_config(
-        self, data: MutableMapping[str, Any]
-    ) -> None:
-        """
-        Checks the new provided data for the flags key.
-        If the key does not exist, uses the default set values.
-        """
-
-        cleaned_flags_data = data.get(self._FLAGS_KEY, {})
-        # ensure we add the default supported flags if they don't already exist
-        for flag_name, default_flag_value in self._SUPPORTED_FLAGS_WITH_DEFAULTS.items():
-            flag_value = cleaned_flags_data.get(flag_name, None)
-            if flag_value is None:
-                cleaned_flags_data[flag_name] = default_flag_value
-            else:
-                # if the type for the flag is not the same as the default, use the default value as an override
-                if type(flag_value) is not type(default_flag_value):
-                    _default_logger.info(
-                        "Flag value was not correct, overriding with default",
-                        extra={
-                            "flag_name": flag_name,
-                            "flag_value": flag_value,
-                            "default_flag_value": default_flag_value,
-                        },
-                    )
-                    cleaned_flags_data[flag_name] = default_flag_value
         base_data["installationType"] = metadata_.get("installation_type", default_installation)
 
         # Add missing toggleable feature flags
@@ -175,16 +129,6 @@ class SlackIntegration(SlackNotifyBasicMixin, IntegrationInstallation):
                         },
                     )
                     cleaned_flags_data[flag_name] = default_flag_value
-
-        data[self._FLAGS_KEY] = cleaned_flags_data
-
-    def update_organization_config(self, data: MutableMapping[str, Any]) -> None:
-        """
-        Update the organization's configuration, but make sure to properly handle specific things for Slack installation
-        before passing it off to the parent method
-        """
-        self._update_and_clean_flags_in_organization_config(data=data)
-        super().update_organization_config(data=data)
 
         data[self._FLAGS_KEY] = cleaned_flags_data
 

--- a/src/sentry/integrations/slack/integration.py
+++ b/src/sentry/integrations/slack/integration.py
@@ -103,13 +103,14 @@ class SlackIntegration(SlackNotifyBasicMixin, IntegrationInstallation):
         # purpose at the integration/provider wide level, which is wrong/incorrect
         base_data = super().get_config_data()
 
+        # Add missing toggleable feature flags
         stored_flag_data = base_data.get(self._FLAGS_KEY, {})
-        flag_statuses = []
         for flag_name, default_flag_value in self._SUPPORTED_FLAGS_WITH_DEFAULTS.items():
-            flag_value = stored_flag_data.get(flag_name, default_flag_value)
-            flag_statuses.append((flag_name, flag_value))
+            if flag_name not in stored_flag_data:
+                stored_flag_data[flag_name] = default_flag_value
 
-        return flag_statuses
+        base_data[self._FLAGS_KEY] = stored_flag_data
+        return base_data
 
     def _update_and_clean_flags_in_organization_config(
         self, data: MutableMapping[str, Any]

--- a/static/app/types/integrations.tsx
+++ b/static/app/types/integrations.tsx
@@ -380,8 +380,8 @@ export interface Integration extends CommonIntegration {
 }
 
 type ConfigData = {
-  toggleableFlags: Record<string, boolean>;
   installationType?: string;
+  toggleableFlags?: Record<string, boolean>;
 };
 
 export interface OrganizationIntegration extends CommonIntegration {

--- a/static/app/types/integrations.tsx
+++ b/static/app/types/integrations.tsx
@@ -380,6 +380,7 @@ export interface Integration extends CommonIntegration {
 }
 
 type ConfigData = {
+  toggleableFlags: Record<string, boolean>;
   installationType?: string;
 };
 

--- a/static/app/views/settings/organizationIntegrations/featureToggle.tsx
+++ b/static/app/views/settings/organizationIntegrations/featureToggle.tsx
@@ -1,0 +1,119 @@
+import {useEffect, useState} from 'react';
+import styled from '@emotion/styled';
+
+import {Client} from 'sentry/api';
+import Switch from 'sentry/components/switchButton';
+import type {IntegrationWithConfig, Organization} from 'sentry/types';
+
+export interface ToggleableFeature {
+  disabledReason: string;
+  help: string;
+  initialState: boolean;
+  label: string;
+  name: string;
+}
+
+interface Props {
+  configurations: IntegrationWithConfig[];
+  features: ToggleableFeature[];
+  onUpdate: (updatedConfigs: IntegrationWithConfig[]) => void;
+  organization: Organization;
+}
+
+export default function FeatureToggleUpdater({
+  configurations,
+  organization,
+  features,
+  onUpdate,
+}: Props) {
+  const [featureToggles, setFeatureToggles] = useState<{[key: string]: boolean}>(
+    features.reduce((acc, feature) => {
+      acc[feature.name] = feature.initialState;
+      return acc;
+    }, {})
+  );
+
+  useEffect(() => {
+    const baseEndpoint = `/organizations/${organization.slug}/integrations/`;
+    const api = new Client();
+    const updatedConfigs: IntegrationWithConfig[] = [];
+    configurations.forEach(config => {
+      if (!config.configData) {
+        return;
+      }
+
+      const integrationConfigEndpoint = `${baseEndpoint}${config.id}/`;
+      const updatedConfigData = {
+        ...config.configData,
+        toggleableFlags: featureToggles,
+      };
+
+      try {
+        api.request(integrationConfigEndpoint, {
+          method: 'POST',
+          data: updatedConfigData,
+        });
+      } catch (error) {
+        // Nothing to do here
+      }
+      updatedConfigs.push({
+        ...config,
+        configData: updatedConfigData,
+      });
+    });
+
+    onUpdate(updatedConfigs);
+    // eslint-disable-next-line
+  }, [featureToggles]);
+
+  const handleToggle = (featureName: string) => {
+    setFeatureToggles(prevToggles => ({
+      ...prevToggles,
+      [featureName]: !prevToggles[featureName],
+    }));
+  };
+
+  const renderSwitches = () => {
+    const hasOrgWrite = organization.access.includes('org:write');
+    return features.map(feature => (
+      <ListItem key={feature.name}>
+        <RightSwitch
+          toggle={() => handleToggle(feature.name)}
+          isActive={featureToggles[feature.name]}
+          isDisabled={!hasOrgWrite}
+          size="sm"
+        />
+        <Label>{feature.label}</Label>
+        <HelpLabel text-muted>{feature.help}</HelpLabel>
+      </ListItem>
+    ));
+  };
+
+  return <List>{renderSwitches()}</List>;
+}
+
+const List = styled('ul')`
+  list-style: none;
+  padding: 0;
+`;
+
+const ListItem = styled('li')`
+  margin-bottom: 10px;
+  display: block;
+`;
+
+const Label = styled('div')`
+  display: block;
+  padding-bottom: 5px;
+`;
+
+const HelpLabel = styled('div')`
+  display: block;
+  padding-bottom: 5px;
+  color: #80708f;
+`;
+
+const RightSwitch = styled(Switch)`
+  padding-top: 3px;
+  float: right;
+`;

--- a/static/app/views/settings/organizationIntegrations/integrationDetailedView.spec.tsx
+++ b/static/app/views/settings/organizationIntegrations/integrationDetailedView.spec.tsx
@@ -54,7 +54,7 @@ describe('IntegrationDetailedView', function () {
     });
 
     MockApiClient.addMockResponse({
-      url: `/organizations/${org.slug}/integrations/?provider_key=bitbucket&includeConfig=0`,
+      url: `/organizations/${org.slug}/integrations/?provider_key=bitbucket&includeConfig=1`,
       body: [
         {
           accountType: null,
@@ -128,7 +128,7 @@ describe('IntegrationDetailedView', function () {
       },
     });
     MockApiClient.addMockResponse({
-      url: `/organizations/${org.slug}/integrations/?provider_key=github&includeConfig=0`,
+      url: `/organizations/${org.slug}/integrations/?provider_key=github&includeConfig=1`,
       body: [
         {
           accountType: null,
@@ -172,7 +172,7 @@ describe('IntegrationDetailedView', function () {
       },
     });
     MockApiClient.addMockResponse({
-      url: `/organizations/${org.slug}/integrations/?provider_key=github&includeConfig=0`,
+      url: `/organizations/${org.slug}/integrations/?provider_key=github&includeConfig=1`,
       body: [
         {
           accountType: null,
@@ -215,7 +215,7 @@ describe('IntegrationDetailedView', function () {
       },
     });
     MockApiClient.addMockResponse({
-      url: `/organizations/${org.slug}/integrations/?provider_key=github&includeConfig=0`,
+      url: `/organizations/${org.slug}/integrations/?provider_key=github&includeConfig=1`,
       body: [],
     });
 
@@ -248,7 +248,7 @@ describe('IntegrationDetailedView', function () {
     });
 
     MockApiClient.addMockResponse({
-      url: `/organizations/${org.slug}/integrations/?provider_key=github&includeConfig=0`,
+      url: `/organizations/${org.slug}/integrations/?provider_key=github&includeConfig=1`,
       body: [GitHubIntegrationFixture()],
     });
     render(

--- a/static/app/views/settings/organizationIntegrations/integrationDetailedView.tsx
+++ b/static/app/views/settings/organizationIntegrations/integrationDetailedView.tsx
@@ -425,6 +425,11 @@ class IntegrationDetailedView extends AbstractIntegrationDetailedView<
     }
 
     const flags = configurations[0].configData.toggleableFlags;
+
+    if (!flags) {
+      return null;
+    }
+
     const features: ToggleableFeature[] = [
       {
         name: 'issueAlertsThreadFlag',


### PR DESCRIPTION
We need to allow users to be able to toggle features for integrations at their organization integration level. If users do not like or want the features, they should have the power to turn them on or off at their disposal. 

The previous FE implementation was doing this at the organization model level, but we can leverage the organization integration model/object to hold and control these settings. Added a custom component that will handle doing this toggling across the integration, and made it integration agnostic to be used across all the other integrations as well.

We can slowly migrate the github piece to this functionality. There is more work to be done on the FE side to help improve this code area, but it would require a lot of effort and changes that we can follow up with after better planning.



https://github.com/getsentry/sentry/assets/5581484/1213ca25-19d7-417e-89f2-166aada6b7ec


Requires: https://github.com/getsentry/sentry/pull/70620