### PR TITLE
fix(spans): Format span status before returning

### DIFF
--- a/src/sentry/search/events/builder/spans_indexed.py
+++ b/src/sentry/search/events/builder/spans_indexed.py
@@ -1,5 +1,7 @@
+from sentry_relay.consts import SPAN_STATUS_CODE_TO_NAME
 from snuba_sdk import Column, Function
 
+from sentry.search.events import constants
 from sentry.search.events.builder import QueryBuilder, TimeseriesQueryBuilder, TopEventsQueryBuilder
 from sentry.search.events.types import SelectType
 
@@ -8,6 +10,12 @@ class SpansIndexedQueryBuilder(QueryBuilder):
     requires_organization_condition = False
     free_text_key = "span.description"
     uuid_fields = {"transaction.id", "replay.id", "profile.id", "trace"}
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.value_resolver_map[
+            constants.SPAN_STATUS
+        ] = lambda status: SPAN_STATUS_CODE_TO_NAME.get(status)
 
     def get_field_type(self, field: str) -> str | None:
         if field in self.meta_resolver_map:


### PR DESCRIPTION
Span statuses are sent as strings and queried as strings but transformed into ints before being stored. This maps it back it back into a string before returning the result.