### PR TITLE
ci: reduce time running codecov

### DIFF
--- a/.github/actions/artifacts/action.yml
+++ b/.github/actions/artifacts/action.yml
@@ -23,5 +23,6 @@ runs:
         token: ${{ inputs.token }}
         flags: ${{ inputs.type }}
         files: ${{ inputs.files }}
+        plugin: noop
         verbose: true
       continue-on-error: true


### PR DESCRIPTION
`plugin: noop` prevents default plugins from running. These create a new version of the coverage file and that is unnecessary work being done.

Example run showing that it handle airtifact in 5s: https://github.com/giovanni-guidini/sentry/actions/runs/9084832844/job/24966726208
