### PR TITLE
chore(issues): Improve metrics emitted by severity

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -17,7 +17,7 @@ from django.db import IntegrityError, OperationalError, connection, router, tran
 from django.db.models import Func, Max
 from django.db.models.signals import post_save
 from django.utils.encoding import force_str
-from urllib3.exceptions import MaxRetryError
+from urllib3.exceptions import MaxRetryError, TimeoutError
 from usageaccountant import UsageUnit
 
 from sentry import (
@@ -31,7 +31,6 @@ from sentry import (
     tsdb,
 )
 from sentry.attachments import CachedAttachment, MissingAttachmentChunks, attachment_cache
-from sentry.conf.server import SEER_SEVERITY_RETRIES
 from sentry.constants import (
     DEFAULT_STORE_NORMALIZER_ARGS,
     LOG_LEVELS_MAP,
@@ -2443,33 +2442,20 @@ def _get_severity_score(event: Event) -> tuple[float, str]:
                 )
                 severity = orjson.loads(response.data).get("severity")
                 reason = "ml"
-        except MaxRetryError as e:
-            logger.warning(
-                "Unable to get severity score from microservice after %s retr%s. Got MaxRetryError caused by: %s.",
-                SEER_SEVERITY_RETRIES,
-                "ies" if SEER_SEVERITY_RETRIES > 1 else "y",
-                repr(e.reason),
-                extra=logger_data,
-            )
+        except MaxRetryError:
             reason = "microservice_max_retry"
             update_severity_error_count()
-            metrics.incr("issues.severity.max_retry_error")
-        except Exception as e:
-            logger.warning(
-                "Unable to get severity score from microservice. Got: %s.",
-                repr(e),
-                extra=logger_data,
-            )
+            metrics.incr("issues.severity.error", tags={"reason": "max_retries"})
+        except TimeoutError:
+            reason = "microservice_timeout"
+            update_severity_error_count()
+            metrics.incr("issues.severity.error", tags={"reason": "timeout"})
+        except Exception:
             reason = "microservice_error"
             update_severity_error_count()
-            metrics.incr("issues.severity.error")
+            metrics.incr("issues.severity.error", tags={"reason": "unknown"})
+            sentry_sdk.capture_exception()
         else:
-            logger.info(
-                "Got severity score of %s for event %s",
-                severity,
-                event.data["event_id"],
-                extra=logger_data,
-            )
             update_severity_error_count(reset=True)
 
     return severity, reason

--- a/tests/sentry/event_manager/test_severity.py
+++ b/tests/sentry/event_manager/test_severity.py
@@ -7,7 +7,7 @@ from unittest.mock import MagicMock, patch
 import orjson
 from django.core.cache import cache
 from urllib3 import HTTPResponse
-from urllib3.exceptions import MaxRetryError
+from urllib3.exceptions import ConnectTimeoutError, MaxRetryError
 
 from sentry import options
 from sentry.constants import PLACEHOLDER_EVENT_TITLES
@@ -39,12 +39,7 @@ class TestGetEventSeverity(TestCase):
         "sentry.event_manager.severity_connection_pool.urlopen",
         return_value=HTTPResponse(body=orjson.dumps({"severity": 0.1231})),
     )
-    @patch("sentry.event_manager.logger.info")
-    def test_error_event_simple(
-        self,
-        mock_logger_info: MagicMock,
-        mock_urlopen: MagicMock,
-    ) -> None:
+    def test_error_event_simple(self, mock_urlopen: MagicMock) -> None:
         manager = EventManager(
             make_event(
                 exception={
@@ -76,16 +71,6 @@ class TestGetEventSeverity(TestCase):
             headers={"content-type": "application/json;charset=utf-8"},
             timeout=0.2,
         )
-        mock_logger_info.assert_called_with(
-            "Got severity score of %s for event %s",
-            severity,
-            event.event_id,
-            extra={
-                "event_id": event.event_id,
-                "op": "event_manager._get_severity_score",
-                "payload": payload,
-            },
-        )
         assert severity == 0.1231
         assert reason == "ml"
         assert cache.get(SEER_ERROR_COUNT_KEY) == 0
@@ -94,10 +79,8 @@ class TestGetEventSeverity(TestCase):
         "sentry.event_manager.severity_connection_pool.urlopen",
         return_value=HTTPResponse(body=orjson.dumps({"severity": 0.1231})),
     )
-    @patch("sentry.event_manager.logger.info")
     def test_message_event_simple(
         self,
-        mock_logger_info: MagicMock,
         mock_urlopen: MagicMock,
     ) -> None:
         cases: list[dict[str, Any]] = [
@@ -123,16 +106,6 @@ class TestGetEventSeverity(TestCase):
                 body=orjson.dumps(payload),
                 headers={"content-type": "application/json;charset=utf-8"},
                 timeout=0.2,
-            )
-            mock_logger_info.assert_called_with(
-                "Got severity score of %s for event %s",
-                severity,
-                event.event_id,
-                extra={
-                    "event_id": event.event_id,
-                    "op": "event_manager._get_severity_score",
-                    "payload": payload,
-                },
             )
             assert severity == 0.1231
             assert reason == "ml"
@@ -232,10 +205,10 @@ class TestGetEventSeverity(TestCase):
             severity_connection_pool, "/issues/severity-score", Exception("It broke")
         ),
     )
-    @patch("sentry.event_manager.logger.warning")
+    @patch("sentry.event_manager.metrics.incr")
     def test_max_retry_exception(
         self,
-        mock_logger_warning: MagicMock,
+        mock_metrics_incr: MagicMock,
         _mock_urlopen: MagicMock,
     ) -> None:
         manager = EventManager(
@@ -256,20 +229,8 @@ class TestGetEventSeverity(TestCase):
 
         severity, reason = _get_severity_score(event)
 
-        mock_logger_warning.assert_called_with(
-            "Unable to get severity score from microservice after %s retr%s. Got MaxRetryError caused by: %s.",
-            1,
-            "y",
-            "Exception('It broke')",
-            extra={
-                "event_id": event.event_id,
-                "op": "event_manager._get_severity_score",
-                "payload": {
-                    "message": "NopeError: Nopey McNopeface",
-                    "has_stacktrace": 0,
-                    "handled": True,
-                },
-            },
+        mock_metrics_incr.assert_called_with(
+            "issues.severity.error", tags={"reason": "max_retries"}
         )
         assert severity == 1.0
         assert reason == "microservice_max_retry"
@@ -277,12 +238,47 @@ class TestGetEventSeverity(TestCase):
 
     @patch(
         "sentry.event_manager.severity_connection_pool.urlopen",
+        side_effect=ConnectTimeoutError(),
+    )
+    @patch("sentry.event_manager.metrics.incr")
+    def test_timeout_error(
+        self,
+        mock_metrics_incr: MagicMock,
+        _mock_urlopen: MagicMock,
+    ) -> None:
+        manager = EventManager(
+            make_event(
+                exception={
+                    "values": [
+                        {
+                            "type": "NopeError",
+                            "value": "Nopey McNopeface",
+                            "mechanism": {"type": "generic", "handled": True},
+                        }
+                    ]
+                },
+                platform="python",
+            )
+        )
+        event = manager.save(self.project.id)
+
+        severity, reason = _get_severity_score(event)
+
+        mock_metrics_incr.assert_called_with("issues.severity.error", tags={"reason": "timeout"})
+        assert severity == 1.0
+        assert reason == "microservice_timeout"
+        assert cache.get(SEER_ERROR_COUNT_KEY) == 1
+
+    @patch(
+        "sentry.event_manager.severity_connection_pool.urlopen",
         side_effect=Exception("It broke"),
     )
-    @patch("sentry.event_manager.logger.warning")
+    @patch("sentry.event_manager.sentry_sdk.capture_exception")
+    @patch("sentry.event_manager.metrics.incr")
     def test_other_exception(
         self,
-        mock_logger_warning: MagicMock,
+        mock_metrics_incr: MagicMock,
+        mock_capture_exception: MagicMock,
         _mock_urlopen: MagicMock,
     ) -> None:
         manager = EventManager(
@@ -303,19 +299,8 @@ class TestGetEventSeverity(TestCase):
 
         severity, reason = _get_severity_score(event)
 
-        mock_logger_warning.assert_called_with(
-            "Unable to get severity score from microservice. Got: %s.",
-            "Exception('It broke')",
-            extra={
-                "event_id": event.event_id,
-                "op": "event_manager._get_severity_score",
-                "payload": {
-                    "message": "NopeError: Nopey McNopeface",
-                    "has_stacktrace": 0,
-                    "handled": True,
-                },
-            },
-        )
+        mock_capture_exception.assert_called_once_with()
+        mock_metrics_incr.assert_called_with("issues.severity.error", tags={"reason": "unknown"})
         assert severity == 1.0
         assert reason == "microservice_error"
         assert cache.get(SEER_ERROR_COUNT_KEY) == 1


### PR DESCRIPTION
A few small changes to improve monitoring:
- Combine all error metrics into a single metric with tags indicating the error reason to make it easier to graph/monitor
- Remove most logging, these aren't particularly actionable since we have metrics
- Add handling for timeout errors (includes both connect and read), these are the only prior unknown errors I've seen
- Send unknown errors to Sentry