### PR TITLE
chore(integrations): better IntegrationFormError error message

### DIFF
--- a/src/sentry/shared_integrations/exceptions/__init__.py
+++ b/src/sentry/shared_integrations/exceptions/__init__.py
@@ -171,8 +171,11 @@ class DuplicateDisplayNameError(IntegrationError):
 
 class IntegrationFormError(IntegrationError):
     def __init__(self, field_errors: Mapping[str, Any]) -> None:
-        super().__init__("Invalid integration action")
-        self.field_errors = field_errors
+        error = "Invalid integration action"
+        if field_errors:
+            error = str(field_errors)
+
+        super().__init__(error)
 
 
 class ClientError(RequestException):


### PR DESCRIPTION
Initialize `super()` with `field_errors` so when we call `str(e)` it actually outputs a helpful error message.