### PR TITLE
featchartcuterie): Update Chart Styling

### DIFF
--- a/static/app/chartcuterie/performance.tsx
+++ b/static/app/chartcuterie/performance.tsx
@@ -8,7 +8,7 @@ import {transformStatsResponse} from 'sentry/utils/profiling/hooks/utils';
 import {lightTheme as theme} from 'sentry/utils/theme';
 import type {NormalizedTrendsTransaction} from 'sentry/views/performance/trends/types';
 
-import {slackChartDefaults, slackChartSize} from './slack';
+import {DEFAULT_FONT_FAMILY, slackChartDefaults, slackChartSize} from './slack';
 import type {RenderDescriptor} from './types';
 import {ChartType} from './types';
 
@@ -23,6 +23,15 @@ function modifyOptionsForSlack(options: Omit<LineChartProps, 'series'>) {
   options.legend.icon = 'none';
   options.legend.left = '25';
   options.legend.top = '20';
+  options.grid = slackChartDefaults.grid;
+
+  options.yAxis = options.yAxis || {};
+  options.yAxis.axisLabel = options.yAxis.axisLabel || {};
+  options.yAxis.axisLabel.fontFamily = DEFAULT_FONT_FAMILY;
+
+  options.xAxis = options.xAxis || {};
+  options.xAxis.axisLabel = options.xAxis.axisLabel || {};
+  options.xAxis.axisLabel.fontFamily = DEFAULT_FONT_FAMILY;
 
   return {
     ...options,


### PR DESCRIPTION
The chart styling generated locally looks slightly different from in the container. Namely the font is different. I investigated and it seems to be because we don't pass the default font for the axis labels and the default font in the container is different. Issues team also had this issue when they generated these charts. I really can't test this locally because we need to look at the behavior of the prod container, but for what its worth, the chart still renders correctly locally. This should fix at least the styling of the axis labels.

Local:
![image](https://github.com/getsentry/sentry/assets/33237075/b8eabbfb-1729-4a6a-9303-2ff4febe20c4)

Container:
![image](https://github.com/getsentry/sentry/assets/33237075/3918bcb9-15e2-447f-9efa-36e19549c863)