### PR TITLE
chore(pr-comments): metric for possible suspect issue comments on open PRs

### DIFF
--- a/src/sentry/tasks/commit_context.py
+++ b/src/sentry/tasks/commit_context.py
@@ -88,14 +88,6 @@ def queue_comment_task_if_needed(
             "github_pr_comment.queue_comment_check.open_pr",
             sample_rate=1.0,
         )
-        logger.info(
-            "github.pr_comment.queue_comment_check.open_pr",
-            extra={
-                "organization_id": commit.organization_id,
-                "repository_id": repo.id,
-                "commit_sha": commit.key,
-            },
-        )
         return
 
     merge_commit_sha = response[0]["merge_commit_sha"]

--- a/src/sentry/tasks/commit_context.py
+++ b/src/sentry/tasks/commit_context.py
@@ -83,6 +83,21 @@ def queue_comment_task_if_needed(
             )
         return
 
+    if response[0]["state"] == "open":
+        metrics.incr(
+            "github_pr_comment.queue_comment_check.open_pr",
+            sample_rate=1.0,
+        )
+        logger.info(
+            "github.pr_comment.queue_comment_check.open_pr",
+            extra={
+                "organization_id": commit.organization_id,
+                "repository_id": repo.id,
+                "commit_sha": commit.key,
+            },
+        )
+        return
+
     merge_commit_sha = response[0]["merge_commit_sha"]
 
     pr_query = PullRequest.objects.filter(

--- a/tests/sentry/tasks/test_commit_context.py
+++ b/tests/sentry/tasks/test_commit_context.py
@@ -854,7 +854,7 @@ class TestGHCommentQueuing(IntegrationTestCase, TestCommitContextMixin):
             responses.GET,
             self.base_url + f"/repos/example/commits/{self.commit.key}/pulls",
             status=200,
-            json=[{"merge_commit_sha": self.pull_request.merge_commit_sha}],
+            json=[{"merge_commit_sha": self.pull_request.merge_commit_sha, "state": "closed"}],
         )
 
     def test_gh_comment_not_github(self, mock_comment_workflow, mock_get_commit_context):


### PR DESCRIPTION
https://docs.github.com/en/rest/commits/commits#list-pull-requests-associated-with-a-commit

> Returns the merged pull request that introduced the commit to the repository. If the commit is not present in the default branch, will only return open pull requests associated with the commit.

Adding a metric so we can see if we could be making more suspect issue comments on open PRs