### PR TITLE
feat(similar-grouping): dry run option for backfill

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -3958,6 +3958,9 @@ SEER_MAX_SIMILARITY_DISTANCE = 0.15  # Not yet in use - Seer doesn't obey this r
 SEER_GROUPING_RECORDS_URL = (
     f"/{SEER_SIMILARITY_MODEL_VERSION}/issues/similar-issues/grouping-record"
 )
+SEER_GROUPING_RECORDS_DELETE_URL = (
+    f"/{SEER_SIMILARITY_MODEL_VERSION}/issues/similar-issues/grouping-record/delete/"
+)
 
 # Devserver configuration overrides.
 ngrok_host = os.environ.get("SENTRY_DEVSERVER_NGROK")

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -3959,7 +3959,7 @@ SEER_GROUPING_RECORDS_URL = (
     f"/{SEER_SIMILARITY_MODEL_VERSION}/issues/similar-issues/grouping-record"
 )
 SEER_GROUPING_RECORDS_DELETE_URL = (
-    f"/{SEER_SIMILARITY_MODEL_VERSION}/issues/similar-issues/grouping-record/delete/"
+    f"/{SEER_SIMILARITY_MODEL_VERSION}/issues/similar-issues/grouping-record/delete"
 )
 
 # Devserver configuration overrides.

--- a/src/sentry/seer/utils.py
+++ b/src/sentry/seer/utils.py
@@ -8,6 +8,7 @@ from urllib3 import Retry
 from urllib3.exceptions import ReadTimeoutError
 
 from sentry.conf.server import (
+    SEER_GROUPING_RECORDS_DELETE_URL,
     SEER_GROUPING_RECORDS_URL,
     SEER_MAX_GROUPING_DISTANCE,
     SEER_SIMILAR_ISSUES_URL,
@@ -290,3 +291,29 @@ def post_bulk_grouping_records(
         extra.update({"reason": response.reason})
         logger.info("seer.post_bulk_grouping_records.failure", extra=extra)
         return {"success": False}
+
+
+def delete_grouping_records(
+    project_id: int,
+) -> bool:
+    try:
+        response = seer_grouping_connection_pool.urlopen(
+            "GET",
+            SEER_GROUPING_RECORDS_DELETE_URL + f"/{project_id}",
+            headers={"Content-Type": "application/json;charset=utf-8"},
+            timeout=POST_BULK_GROUPING_RECORDS_TIMEOUT,
+        )
+    except ReadTimeoutError:
+        logger.exception(
+            "seer.delete_grouping_records.timeout",
+            extra={"reason": "ReadTimeoutError", "timeout": POST_BULK_GROUPING_RECORDS_TIMEOUT},
+        )
+        return False
+
+    if response.status >= 200 and response.status < 300:
+        return True
+    else:
+        logger.error(
+            "seer.delete_grouping_records.failure",
+        )
+        return False

--- a/src/sentry/seer/utils.py
+++ b/src/sentry/seer/utils.py
@@ -299,7 +299,7 @@ def delete_grouping_records(
     try:
         response = seer_grouping_connection_pool.urlopen(
             "GET",
-            SEER_GROUPING_RECORDS_DELETE_URL + f"/{project_id}",
+            f"{SEER_GROUPING_RECORDS_DELETE_URL}/{project_id}",
             headers={"Content-Type": "application/json;charset=utf-8"},
             timeout=POST_BULK_GROUPING_RECORDS_TIMEOUT,
         )

--- a/tests/sentry/tasks/test_backfill_seer_grouping_records.py
+++ b/tests/sentry/tasks/test_backfill_seer_grouping_records.py
@@ -617,3 +617,27 @@ class TestBackfillSeerGroupingRecords(BaseMetricsTestCase, TestCase):
 
         for group in Group.objects.filter(project_id=self.project.id):
             assert not group.data["metadata"].get("embeddings_info")
+
+    @django_db_all
+    @with_feature("projects:similarity-embeddings-backfill")
+    @patch("sentry.tasks.backfill_seer_grouping_records.post_bulk_grouping_records")
+    @patch("sentry.tasks.backfill_seer_grouping_records.delete_grouping_records")
+    def test_backfill_seer_grouping_records_dry_run(
+        self, mock_delete_grouping_records, mock_post_bulk_grouping_records
+    ):
+        """
+        Test that the metadata is set for all groups showing that the record has been created.
+        """
+        mock_post_bulk_grouping_records.return_value = {"success": True}
+        mock_delete_grouping_records.return_value = True
+        with TaskRunner():
+            backfill_seer_grouping_records(self.project.id, 0, dry_run=True)
+
+        for group in Group.objects.filter(project_id=self.project.id):
+            assert not group.data["metadata"].get("embeddings_info") == {
+                "nn_model_version": 0,
+                "group_hash": json.dumps([self.group_hashes[group.id]]),
+            }
+        redis_client = redis.redis_clusters.get(settings.SENTRY_MONITORS_REDIS_CLUSTER)
+        last_processed_id = int(redis_client.get(LAST_PROCESSED_REDIS_KEY) or 0)
+        assert last_processed_id != 0


### PR DESCRIPTION
calls the endpoint that will delete the embeddings records in seer, which was added here: https://github.com/getsentry/seer/pull/713/

note that this will delete the records at the _beginning_ of the backfill, so we have a moment to analyze the state of the seer database between runs.