### PR TITLE
fix(billing): Rename span to spans, metric second to metricSeconds

### DIFF
--- a/static/app/types/core.tsx
+++ b/static/app/types/core.tsx
@@ -81,7 +81,7 @@ export enum DataCategory {
   MONITOR_SEATS = 'monitorSeats',
   PROFILE_DURATION = 'profileDuration',
   SPANS = 'spans',
-  METRIC_SECOND = 'metricSecond',
+  METRIC_SECOND = 'metricSeconds',
 }
 
 /**

--- a/static/app/types/core.tsx
+++ b/static/app/types/core.tsx
@@ -80,7 +80,7 @@ export enum DataCategory {
   REPLAYS = 'replays',
   MONITOR_SEATS = 'monitorSeats',
   PROFILE_DURATION = 'profileDuration',
-  SPAN = 'span',
+  SPANS = 'spans',
   METRIC_SECOND = 'metricSecond',
 }
 


### PR DESCRIPTION
The data category is spans
![image](https://github.com/getsentry/sentry/assets/1400464/32e92a2f-461a-4180-82c2-31b8cb09fae8)
