### PR TITLE
fix(issues): Fix missing retries configuration

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -2221,6 +2221,7 @@ def _process_existing_aggregate(
 
 severity_connection_pool = connection_from_url(
     settings.SEER_SEVERITY_URL,
+    retries=settings.SEER_SEVERITY_RETRIES,
     timeout=settings.SEER_SEVERITY_TIMEOUT,  # Defaults to 300 milliseconds
 )
 


### PR DESCRIPTION
This previously was being logged (see also #70892) but not actually configured anywhere.

There is no change in behavior since this value is configured to 1 and the default urllib3 behavior is also 1 for POST methods, despite the docs stating 3 it isn't applied to all methods: https://github.com/urllib3/urllib3/blob/main/src/urllib3/util/retry.py#L184