### PR TITLE
fix(similarity): allow single_org sentry users to not be superuser to call backfill

### DIFF
--- a/src/sentry/api/endpoints/project_backfill_similar_issues_embeddings_records.py
+++ b/src/sentry/api/endpoints/project_backfill_similar_issues_embeddings_records.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from rest_framework.request import Request
 from rest_framework.response import Response
 
@@ -18,9 +19,9 @@ class ProjectBackfillSimilarIssuesEmbeddingsRecords(ProjectEndpoint):
     }
 
     def post(self, request: Request, project) -> Response:
-        if not features.has(
-            "projects:similarity-embeddings-backfill", project
-        ) or not is_active_superuser(request):
+        if not features.has("projects:similarity-embeddings-backfill", project) or (
+            not is_active_superuser(request) and not settings.SENTRY_SINGLE_ORGANIZATION
+        ):
             return Response(status=404)
 
         last_processed_id = None

--- a/src/sentry/api/endpoints/project_backfill_similar_issues_embeddings_records.py
+++ b/src/sentry/api/endpoints/project_backfill_similar_issues_embeddings_records.py
@@ -19,10 +19,15 @@ class ProjectBackfillSimilarIssuesEmbeddingsRecords(ProjectEndpoint):
     }
 
     def post(self, request: Request, project) -> Response:
-        if not features.has("projects:similarity-embeddings-backfill", project) or (
-            not is_active_superuser(request) and not settings.SENTRY_SINGLE_ORGANIZATION
-        ):
+        if not features.has("projects:similarity-embeddings-backfill", project):
             return Response(status=404)
+
+        # needs to have the flag to run
+
+        if not (is_active_superuser(request) or settings.SENTRY_SINGLE_ORGANIZATION):
+            return Response(status=404)
+
+        # needs to either be a superuser or be in single org mode
 
         last_processed_id = None
         dry_run = False

--- a/tests/sentry/api/endpoints/test_project_backfill_similar_issues_embeddings_records.py
+++ b/tests/sentry/api/endpoints/test_project_backfill_similar_issues_embeddings_records.py
@@ -1,5 +1,6 @@
 from unittest.mock import patch
 
+from django.test import override_settings
 from django.urls import reverse
 
 from sentry.testutils.cases import APITestCase
@@ -42,6 +43,18 @@ class ProjectBackfillSimilarIssuesEmbeddingsRecordsTest(APITestCase):
     @with_feature("projects:similarity-embeddings-backfill")
     def test_post_success_no_last_processed_id(
         self, mock_backfill_seer_grouping_records, mock_is_active_superuser
+    ):
+        response = self.client.post(self.url, data={})
+        assert response.status_code == 204, response.content
+        mock_backfill_seer_grouping_records.assert_called_with(self.project.id, None, False)
+
+    @patch(
+        "sentry.api.endpoints.project_backfill_similar_issues_embeddings_records.backfill_seer_grouping_records.delay"
+    )
+    @with_feature("projects:similarity-embeddings-backfill")
+    @override_settings(SENTRY_SINGLE_ORGANIZATION=True)
+    def test_post_success_no_last_processed_id_single_org(
+        self, mock_backfill_seer_grouping_records
     ):
         response = self.client.post(self.url, data={})
         assert response.status_code == 204, response.content


### PR DESCRIPTION
still enforces org / project permissions