### PR TITLE
fix(api): Update Endpoint so it Returns 404 as a `status_code`

### DIFF
--- a/src/sentry/api/endpoints/project_profiling_profile.py
+++ b/src/sentry/api/endpoints/project_profiling_profile.py
@@ -56,7 +56,7 @@ class ProjectProfilingPaginatedBaseEndpoint(ProjectProfilingBaseEndpoint, ABC):
 
     def get(self, request: Request, project: Project) -> Response:
         if not features.has("organizations:profiling", project.organization, actor=request.user):
-            return Response(404)
+            return Response(status=404)
 
         params = self.get_profiling_params(request, project)
 


### PR DESCRIPTION
Found a typo where endpoint returns 404 in the data field instead of status. I caught this when the test was failing when I was updating the ProjectEndpoint `convert_args`. A 404 was correctly being returned (in the data field), but the test was checking the  status_code, which was 200.