### PR TITLE
feat(metrics): remove percentiles from meta endpoint in Metrics API

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -2506,7 +2506,8 @@ register(
 register(
     "api.organization-activity.brownout-duration", default="PT1M", flags=FLAG_AUTOMATOR_MODIFIABLE
 )
-# Disable
+# Hide percentile operations from appearing in the metrics/meta endpoint in the Metrics API, thereby also hiding those
+# operations from view in the Metrics UI.
 register(
     "sentry-metrics.metrics-api.hide-percentile-operations",
     type=Bool,

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -2506,3 +2506,10 @@ register(
 register(
     "api.organization-activity.brownout-duration", default="PT1M", flags=FLAG_AUTOMATOR_MODIFIABLE
 )
+# Disable
+register(
+    "sentry-metrics.metrics-api.hide-percentile-operations",
+    type=Bool,
+    default=False,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -2506,11 +2506,12 @@ register(
 register(
     "api.organization-activity.brownout-duration", default="PT1M", flags=FLAG_AUTOMATOR_MODIFIABLE
 )
-# Hide percentile operations from appearing in the metrics/meta endpoint in the Metrics API, thereby also hiding those
-# operations from view in the Metrics UI.
+
+# Enable percentile operations in the metrics/meta endpoint in the Metrics API for the orgs in the list. This is used to
+# also hide those expensive operations from view in the Metrics UI for everyone except the whitelist.
 register(
-    "sentry-metrics.metrics-api.hide-percentile-operations",
-    type=Bool,
-    default=False,
-    flags=FLAG_AUTOMATOR_MODIFIABLE,
+    "sentry-metrics.metrics-api.enable-percentile-operations-for-orgs",
+    type=Sequence,
+    default=[],
+    flags=FLAG_ALLOW_EMPTY | FLAG_AUTOMATOR_MODIFIABLE,
 )

--- a/src/sentry/sentry_metrics/querying/metadata/metrics.py
+++ b/src/sentry/sentry_metrics/querying/metadata/metrics.py
@@ -56,7 +56,9 @@ def get_metrics_meta(
                 # not stored.
                 del metrics_blocking_state[metric_mri]
 
-            metrics_metas.append(_build_metric_meta(parsed_mri, project_ids, blocking_status))
+            metrics_metas.append(
+                _build_metric_meta(organization, parsed_mri, project_ids, blocking_status)
+            )
 
         for metric_mri, metric_blocking in metrics_blocking_state.items():
             parsed_mri = parse_mri(metric_mri)
@@ -65,6 +67,7 @@ def get_metrics_meta(
 
             metrics_metas.append(
                 _build_metric_meta(
+                    organization,
                     parsed_mri,
                     [],
                     [
@@ -105,11 +108,16 @@ def _convert_to_mris_to_project_ids_mapping(project_id_to_mris: dict[int, list[s
 
 
 def _build_metric_meta(
-    parsed_mri: ParsedMRI, project_ids: Sequence[int], blocking_status: Sequence[BlockedMetric]
+    organization: Organization,
+    parsed_mri: ParsedMRI,
+    project_ids: Sequence[int],
+    blocking_status: Sequence[BlockedMetric],
 ) -> MetricMeta:
     available_operations = get_available_operations(parsed_mri)
 
-    if options.get("sentry-metrics.metrics-api.hide-percentile-operations"):
+    if organization.id not in options.get(
+        "sentry-metrics.metrics-api.enable-percentile-operations-for-orgs"
+    ):
         available_operations = [
             operation
             for operation in available_operations

--- a/src/sentry/sentry_metrics/querying/metadata/metrics.py
+++ b/src/sentry/sentry_metrics/querying/metadata/metrics.py
@@ -10,7 +10,13 @@ from sentry.sentry_metrics.use_case_id_registry import UseCaseID
 from sentry.snuba.metrics import parse_mri
 from sentry.snuba.metrics.datasource import get_metrics_blocking_state_of_projects
 from sentry.snuba.metrics.naming_layer.mri import ParsedMRI, get_available_operations
-from sentry.snuba.metrics.utils import BlockedMetric, MetricMeta, MetricOperationType, MetricUnit
+from sentry.snuba.metrics.utils import (
+    BlockedMetric,
+    MetricMeta,
+    MetricOperationType,
+    MetricType,
+    MetricUnit,
+)
 from sentry.snuba.metrics_layer.query import fetch_metric_mris
 
 
@@ -111,7 +117,7 @@ def _build_metric_meta(
         ]
 
     return MetricMeta(
-        type=parsed_mri.entity,
+        type=cast(MetricType, parsed_mri.entity),
         name=parsed_mri.name,
         unit=cast(MetricUnit, parsed_mri.unit),
         mri=parsed_mri.mri_string,

--- a/src/sentry/sentry_metrics/querying/metadata/metrics.py
+++ b/src/sentry/sentry_metrics/querying/metadata/metrics.py
@@ -2,6 +2,7 @@ from collections import defaultdict
 from collections.abc import Sequence
 from typing import cast
 
+from sentry import options
 from sentry.models.organization import Organization
 from sentry.models.project import Project
 from sentry.sentry_metrics.querying.metadata.utils import METRICS_API_HIDDEN_OPERATIONS
@@ -102,7 +103,7 @@ def _build_metric_meta(
 ) -> MetricMeta:
     available_operations = get_available_operations(parsed_mri)
 
-    if parsed_mri.namespace == "custom":
+    if options.get("sentry-metrics.metrics-api.hide-percentile-operations"):
         available_operations = [
             operation
             for operation in available_operations

--- a/src/sentry/sentry_metrics/querying/metadata/utils.py
+++ b/src/sentry/sentry_metrics/querying/metadata/utils.py
@@ -1,6 +1,8 @@
 from sentry.snuba.metrics import get_mri
 from sentry.snuba.metrics.naming_layer.mri import is_mri
 
+METRICS_API_HIDDEN_OPERATIONS = ["p50", "p75", "p90", "p95", "p99"]
+
 
 def convert_metric_names_to_mris(metric_names: list[str]) -> list[str]:
     mris: list[str] = []

--- a/src/sentry/snuba/metrics/datasource.py
+++ b/src/sentry/snuba/metrics/datasource.py
@@ -312,12 +312,19 @@ def get_metrics_blocking_state_of_projects(
 def _build_metric_meta(
     parsed_mri: ParsedMRI, project_ids: Sequence[int], blocking_status: Sequence[BlockedMetric]
 ) -> MetricMeta:
+    available_operations = get_available_operations(parsed_mri)
+    blocked_operations = ["p50", "p75", "p90", "p95", "p99"]
+    if parsed_mri.namespace == "custom":
+        available_operations = [
+            operation for operation in available_operations if operation not in blocked_operations
+        ]
+
     return MetricMeta(
         type=parsed_mri.entity,
         name=parsed_mri.name,
         unit=cast(MetricUnit, parsed_mri.unit),
         mri=parsed_mri.mri_string,
-        operations=cast(Sequence[MetricOperationType], get_available_operations(parsed_mri)),
+        operations=cast(Sequence[MetricOperationType], available_operations),
         projectIds=project_ids,
         blockingStatus=blocking_status,
     )

--- a/tests/sentry/api/endpoints/test_organization_metrics_details.py
+++ b/tests/sentry/api/endpoints/test_organization_metrics_details.py
@@ -9,6 +9,7 @@ from sentry.sentry_metrics.use_case_id_registry import (
 )
 from sentry.sentry_metrics.visibility import block_metric, block_tags_of_metric
 from sentry.testutils.cases import MetricsAPIBaseTestCase, OrganizationMetricsIntegrationTestCase
+from sentry.testutils.helpers import override_options
 from sentry.testutils.skips import requires_snuba
 
 pytestmark = [pytest.mark.sentry_metrics, requires_snuba]
@@ -228,5 +229,28 @@ class OrganizationMetricsDetailsTest(OrganizationMetricsIntegrationTestCase):
             "max_timestamp",
             "min",
             "min_timestamp",
+            "p50",
+            "p75",
+            "p90",
+            "p95",
+            "p99",
             "sum",
         ]
+
+        with override_options(
+            {"sentry-metrics.metrics-api.hide-percentile-operations": True},
+        ):
+            response = self.get_success_response(
+                self.organization.slug, project=[project_1.id, project_2.id], useCase="custom"
+            )
+            data = sorted(response.data, key=lambda d: d["mri"])
+            assert sorted(data[1]["operations"]) == [
+                "avg",
+                "count",
+                "histogram",
+                "max",
+                "max_timestamp",
+                "min",
+                "min_timestamp",
+                "sum",
+            ]

--- a/tests/sentry/api/endpoints/test_organization_metrics_details.py
+++ b/tests/sentry/api/endpoints/test_organization_metrics_details.py
@@ -229,16 +229,15 @@ class OrganizationMetricsDetailsTest(OrganizationMetricsIntegrationTestCase):
             "max_timestamp",
             "min",
             "min_timestamp",
-            "p50",
-            "p75",
-            "p90",
-            "p95",
-            "p99",
             "sum",
         ]
 
         with override_options(
-            {"sentry-metrics.metrics-api.hide-percentile-operations": True},
+            {
+                "sentry-metrics.metrics-api.enable-percentile-operations-for-orgs": [
+                    self.organization.id
+                ]
+            },
         ):
             response = self.get_success_response(
                 self.organization.slug, project=[project_1.id, project_2.id], useCase="custom"
@@ -252,5 +251,10 @@ class OrganizationMetricsDetailsTest(OrganizationMetricsIntegrationTestCase):
                 "max_timestamp",
                 "min",
                 "min_timestamp",
+                "p50",
+                "p75",
+                "p90",
+                "p95",
+                "p99",
                 "sum",
             ]

--- a/tests/sentry/api/endpoints/test_organization_metrics_details.py
+++ b/tests/sentry/api/endpoints/test_organization_metrics_details.py
@@ -220,3 +220,13 @@ class OrganizationMetricsDetailsTest(OrganizationMetricsIntegrationTestCase):
         assert data[2]["blockingStatus"] == [
             {"isBlocked": True, "blockedTags": [], "projectId": project_1.id}
         ]
+        assert sorted(data[1]["operations"]) == [
+            "avg",
+            "count",
+            "histogram",
+            "max",
+            "max_timestamp",
+            "min",
+            "min_timestamp",
+            "sum",
+        ]


### PR DESCRIPTION
- Add an empty Sequence option to defaults to remove percentiles from being return from metrics/meta as queryable operations in the Metrics API.
- If in the future, we want to turn on percentiles on a per-org-basis, this option can then be used to do that. 