### PR TITLE
fix(staff): Prevent fetching authenticators before preloading

### DIFF
--- a/static/app/components/modals/sudoModal.tsx
+++ b/static/app/components/modals/sudoModal.tsx
@@ -200,6 +200,7 @@ class SudoModal extends Component<Props, State> {
     const {api} = this.props;
 
     try {
+      await Promise.all(Object.values(window.__sentry_preload));
       const authenticators = await api.requestPromise('/authenticators/');
       this.setState({authenticators: authenticators ?? []});
     } catch {


### PR DESCRIPTION
There may be one more place in projects where we preload, but I want to check if this will work first.