### PR TITLE
fix(insights): Improve span sample trace data fetching

### DIFF
--- a/static/app/views/performance/browser/resources/resourceSummaryPage/index.tsx
+++ b/static/app/views/performance/browser/resources/resourceSummaryPage/index.tsx
@@ -148,7 +148,6 @@ function ResourceSummary() {
             groupId={groupId}
             moduleName={ModuleName.RESOURCE}
             transactionName={transaction as string}
-            additionalFields={[HTTP_RESPONSE_CONTENT_LENGTH]}
           />
         </Layout.Main>
       </Layout.Body>

--- a/static/app/views/starfish/components/samplesTable/spanSamplesTable.tsx
+++ b/static/app/views/starfish/components/samplesTable/spanSamplesTable.tsx
@@ -55,13 +55,13 @@ export const DEFAULT_COLUMN_ORDER: SamplesTableColumnHeader[] = [
 
 type SpanTableRow = {
   op: string;
+  trace: string;
   transaction: {
-    id: string;
     'project.name': string;
     timestamp: string;
-    trace: string;
     'transaction.duration': number;
   };
+  'transaction.id': string;
 } & SpanSample;
 
 type Props = {
@@ -111,7 +111,7 @@ export function SpanSamplesTable({
           to={generateLinkToEventInTraceView({
             eventId: row['transaction.id'],
             timestamp: row.timestamp,
-            traceSlug: row.transaction?.trace,
+            traceSlug: row.trace,
             projectSlug: row.project,
             organization,
             location,
@@ -135,7 +135,7 @@ export function SpanSamplesTable({
           to={generateLinkToEventInTraceView({
             eventId: row['transaction.id'],
             timestamp: row.timestamp,
-            traceSlug: row.transaction?.trace,
+            traceSlug: row.trace,
             projectSlug: row.project,
             organization,
             location,

--- a/static/app/views/starfish/views/spanSummaryPage/sampleList/index.tsx
+++ b/static/app/views/starfish/views/spanSummaryPage/sampleList/index.tsx
@@ -108,7 +108,10 @@ export function SampleList({
 
   let columnOrder = DEFAULT_COLUMN_ORDER;
 
-  const additionalFields: SpanIndexedField[] = [];
+  const additionalFields: SpanIndexedField[] = [
+    SpanIndexedField.TRACE,
+    SpanIndexedField.TRANSACTION_ID,
+  ];
 
   if (moduleName === ModuleName.RESOURCE) {
     additionalFields?.push(SpanIndexedField.HTTP_RESPONSE_CONTENT_LENGTH);

--- a/static/app/views/starfish/views/spanSummaryPage/sampleList/index.tsx
+++ b/static/app/views/starfish/views/spanSummaryPage/sampleList/index.tsx
@@ -18,7 +18,11 @@ import useRouter from 'sentry/utils/useRouter';
 import {normalizeUrl} from 'sentry/utils/withDomainRequired';
 import DetailPanel from 'sentry/views/starfish/components/detailPanel';
 import {DEFAULT_COLUMN_ORDER} from 'sentry/views/starfish/components/samplesTable/spanSamplesTable';
-import {type ModuleName, SpanMetricsField} from 'sentry/views/starfish/types';
+import {
+  ModuleName,
+  SpanIndexedField,
+  SpanMetricsField,
+} from 'sentry/views/starfish/types';
 import DurationChart from 'sentry/views/starfish/views/spanSummaryPage/sampleList/durationChart';
 import SampleInfo from 'sentry/views/starfish/views/spanSummaryPage/sampleList/sampleInfo';
 import SampleTable from 'sentry/views/starfish/views/spanSummaryPage/sampleList/sampleTable/sampleTable';
@@ -29,7 +33,6 @@ type Props = {
   groupId: string;
   moduleName: ModuleName;
   transactionName: string;
-  additionalFields?: string[];
   onClose?: () => void;
   spanDescription?: string;
   transactionMethod?: string;
@@ -42,7 +45,6 @@ export function SampleList({
   transactionName,
   transactionMethod,
   spanDescription,
-  additionalFields,
   onClose,
   transactionRoute = '/performance/summary/',
 }: Props) {
@@ -106,7 +108,11 @@ export function SampleList({
 
   let columnOrder = DEFAULT_COLUMN_ORDER;
 
-  if (additionalFields?.includes(HTTP_RESPONSE_CONTENT_LENGTH)) {
+  const additionalFields: SpanIndexedField[] = [];
+
+  if (moduleName === ModuleName.RESOURCE) {
+    additionalFields?.push(SpanIndexedField.HTTP_RESPONSE_CONTENT_LENGTH);
+
     columnOrder = [
       ...DEFAULT_COLUMN_ORDER,
       {


### PR DESCRIPTION
Colin spotted an issue where some span sample links were broken, the trace ID is missing from the URL. This happens because of our fetching strategy, which is:

1. Fetch a list of span samples
2. Find transactions for each of the span IDs in the sample list
3. Merge transaction information into the span information
4. Render the table
5. Construct URL from trace information that's in the transaction information

This doesn't work nicely because the call to fetch transactions for spans might fail or return incomplete information. Since the trace ID and transaction ID are in the spans dataset, too, fetch them from there instead.

I also snuck in a change to how `additionalFields` are declared, because otherwise it was _very_ awkward to mash the extra code in there.

P.S. I didn't see any actual use of the transaction data in any table, so we can probably completely rip that out later.