### PR TITLE
feat(trace-explorer): Add better error handling

### DIFF
--- a/src/sentry/api/endpoints/organization_traces.py
+++ b/src/sentry/api/endpoints/organization_traces.py
@@ -697,12 +697,6 @@ class TraceSamplesExecutor:
                     "trace": row["trace"],
                     "start": row["first_seen()"],
                     "end": row["last_seen()"],
-                    "params": self.params,
-                    "user_query": self.user_queries,
-                    "mri": self.mri,
-                    "metrics_query": self.metrics_query,
-                    "metrics_min": self.metrics_min,
-                    "metrics_max": self.metrics_max,
                 }
                 sentry_sdk.capture_message(
                     "trace missing spans", contexts={"trace_missing_spans": context}

--- a/src/sentry/api/endpoints/organization_traces.py
+++ b/src/sentry/api/endpoints/organization_traces.py
@@ -656,7 +656,13 @@ class TraceSamplesExecutor:
         ]
         spans.sort(key=lambda span: (span["precise.start_ts"], span["precise.finish_ts"]))
 
-        traces_breakdowns = process_breakdowns(spans, traces_range)
+        try:
+            traces_breakdowns = process_breakdowns(spans, traces_range)
+        except Exception as e:
+            traces_breakdowns = defaultdict(list)
+
+            context = {"traces": list(sorted(traces_range.keys()))}
+            sentry_sdk.capture_exception(e, contexts={"bad_traces": context})
 
         # mapping of trace id to a tuple of project slug + transaction name
         traces_names: MutableMapping[str, tuple[str, str]] = {}
@@ -1034,6 +1040,20 @@ def quantize_range(span_start, span_end, trace_range):
     return int(rounded_start), int(rounded_end)
 
 
+def new_trace_interval(row) -> TraceInterval:
+    return {
+        "kind": "project",
+        "project": row["project"],
+        "sdkName": row["sdk.name"],
+        "opCategory": row.get("span.category"),
+        "start": row["quantized.start_ts"],
+        "end": row["quantized.finish_ts"],
+        "duration": 0,
+        "components": [(row["precise.start_ts"], row["precise.finish_ts"])],
+        "isRoot": not bool(row.get("parent_span")),
+    }
+
+
 def process_breakdowns(data, traces_range):
     breakdowns: Mapping[str, list[TraceInterval]] = defaultdict(list)
     stacks: Mapping[str, list[TraceInterval]] = defaultdict(list)
@@ -1131,31 +1151,42 @@ def process_breakdowns(data, traces_range):
                 break
             stack_pop(trace)
 
+    quantized_data = []
+
     for row in data:
-        trace = row["trace"]
-        precise_start = int(row["precise.start_ts"] * 1000)
-        precise_end = int(row["precise.finish_ts"] * 1000)
+        try:
+            trace = row["trace"]
+            precise_start = int(row["precise.start_ts"] * 1000)
+            precise_end = int(row["precise.finish_ts"] * 1000)
 
-        trace_range = traces_range[trace]
-        trace_start = trace_range["start"]
-        trace_end = trace_range["end"]
+            trace_range = traces_range[trace]
+            trace_start = trace_range["start"]
+            trace_end = trace_range["end"]
 
-        # Clip the intervals os that it is within range of the trace
-        precise_start = clip(precise_start, trace_start, trace_end)
-        precise_end = clip(precise_end, trace_start, trace_end)
+            # Clip the intervals os that it is within range of the trace
+            precise_start = clip(precise_start, trace_start, trace_end)
+            precise_end = clip(precise_end, trace_start, trace_end)
 
-        quantized_start, quantized_end = quantize_range(
-            precise_start,
-            precise_end,
-            traces_range[trace],
-        )
+            quantized_start, quantized_end = quantize_range(
+                precise_start,
+                precise_end,
+                traces_range[trace],
+            )
 
-        row["precise.start_ts"] = precise_start
-        row["precise.finish_ts"] = precise_end
-        row["quantized.start_ts"] = quantized_start
-        row["quantized.finish_ts"] = quantized_end
+            quantized_data.append(
+                {
+                    **row,
+                    "precise.start_ts": precise_start,
+                    "precise.finish_ts": precise_end,
+                    "quantized.start_ts": quantized_start,
+                    "quantized.finish_ts": quantized_end,
+                }
+            )
+        except Exception as e:
+            context = {"trace": row["trace"]}
+            sentry_sdk.capture_exception(e, contexts={"bad_trace": context})
 
-    data.sort(
+    quantized_data.sort(
         key=lambda row: (
             row["quantized.start_ts"],
             row["precise.start_ts"],
@@ -1166,34 +1197,28 @@ def process_breakdowns(data, traces_range):
 
     last_timestamp_per_trace: dict[str, int] = defaultdict(int)
 
-    for row in data:
-        trace = row["trace"]
+    for row in quantized_data:
+        try:
+            trace = row["trace"]
 
-        last_timestamp_per_trace["trace"] = max(
-            row["precise.finish_ts"], last_timestamp_per_trace["trace"]
-        )
+            last_timestamp_per_trace["trace"] = max(
+                row["precise.finish_ts"], last_timestamp_per_trace["trace"]
+            )
 
-        if row["quantized.start_ts"] == row["quantized.finish_ts"]:
-            # after quantizing, this span is far too small to render, so remove it
-            continue
+            if row["quantized.start_ts"] == row["quantized.finish_ts"]:
+                # after quantizing, this span is far too small to render, so remove it
+                continue
 
-        cur: TraceInterval = {
-            "kind": "project",
-            "project": row["project"],
-            "sdkName": row["sdk.name"],
-            "opCategory": row.get("span.category"),
-            "start": row["quantized.start_ts"],
-            "end": row["quantized.finish_ts"],
-            "duration": 0,
-            "components": [(row["precise.start_ts"], row["precise.finish_ts"])],
-            "isRoot": not bool(row.get("parent_span")),
-        }
+            cur = new_trace_interval(row)
 
-        # Clear the stack of any intervals that end before the current interval
-        # starts while pushing them to the breakdowns.
-        stack_clear(trace, until=cur["start"])
+            # Clear the stack of any intervals that end before the current interval
+            # starts while pushing them to the breakdowns.
+            stack_clear(trace, until=cur["start"])
 
-        stack_push(trace, cur)
+            stack_push(trace, cur)
+        except Exception as e:
+            context = {"trace": row["trace"]}
+            sentry_sdk.capture_exception(e, contexts={"bad_trace": context})
 
     for trace, trace_range in traces_range.items():
         # Check to see if there is still a gap before the trace ends and fill it

--- a/tests/sentry/api/endpoints/test_organization_traces.py
+++ b/tests/sentry/api/endpoints/test_organization_traces.py
@@ -1,4 +1,5 @@
 from datetime import timedelta
+from unittest.mock import patch
 from uuid import uuid4
 
 import pytest
@@ -267,7 +268,7 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
             trace_id_1,
             trace_id_2,
             trace_id_3,
-            timestamps,
+            [int(ts.timestamp() * 1000) for ts in timestamps],
             span_ids,
         )
 
@@ -407,6 +408,132 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
         response = self.do_request(query)
         assert response.status_code == 200, response.data
 
+    @patch("sentry_sdk.capture_exception")
+    @patch("sentry.api.endpoints.organization_traces.process_breakdowns")
+    def test_process_breakdown_error(self, mock_process_breakdowns, mock_capture_exception):
+        exception = Exception()
+
+        mock_process_breakdowns.side_effect = exception
+
+        (
+            project_1,
+            project_2,
+            trace_id_1,
+            trace_id_2,
+            _,
+            timestamps,
+            span_ids,
+        ) = self.create_mock_traces()
+
+        query = {
+            "project": [project_2.id],
+            "field": ["id", "parent_span", "span.duration"],
+            "query": "foo:[bar, baz]",
+            "suggestedQuery": "foo:baz span.duration:>0s",
+            "maxSpansPerTrace": 3,
+            "sort": ["-span.duration"],
+        }
+
+        response = self.do_request(query)
+        assert response.status_code == 200, response.data
+
+        assert response.data["meta"] == {
+            "dataset": "unknown",
+            "datasetReason": "unchanged",
+            "fields": {
+                "id": "string",
+                "parent_span": "string",
+                "span.duration": "duration",
+            },
+            "isMetricsData": False,
+            "isMetricsExtractedData": False,
+            "tips": {},
+            "units": {
+                "id": None,
+                "parent_span": None,
+                "span.duration": "millisecond",
+            },
+        }
+
+        result_data = sorted(response.data["data"], key=lambda trace: trace["trace"])
+
+        assert result_data == sorted(
+            [
+                {
+                    "trace": trace_id_1,
+                    "numErrors": 1,
+                    "numOccurrences": 0,
+                    "numSpans": 4,
+                    "project": project_1.slug,
+                    "name": "foo",
+                    "duration": 60_100,
+                    "start": timestamps[0],
+                    "end": timestamps[0] + 60_100,
+                    "breakdowns": [],
+                    "spans": [
+                        {
+                            "id": span_ids[3],
+                            "parent_span": span_ids[0],
+                            "span.duration": 30_003.0,
+                        },
+                        {
+                            "id": span_ids[2],
+                            "parent_span": span_ids[0],
+                            "span.duration": 30_002.0,
+                        },
+                        {
+                            "id": span_ids[1],
+                            "parent_span": span_ids[0],
+                            "span.duration": 30_001.0,
+                        },
+                    ],
+                    "suggestedSpans": [
+                        {
+                            "id": span_ids[3],
+                            "parent_span": span_ids[0],
+                            "span.duration": 30_003.0,
+                        },
+                    ],
+                },
+                {
+                    "trace": trace_id_2,
+                    "numErrors": 0,
+                    "numOccurrences": 0,
+                    "numSpans": 6,
+                    "project": project_1.slug,
+                    "name": "bar",
+                    "duration": 90_123,
+                    "start": timestamps[4],
+                    "end": timestamps[4] + 90_123,
+                    "breakdowns": [],
+                    "spans": [
+                        {
+                            "id": span_ids[6],
+                            "parent_span": span_ids[4],
+                            "span.duration": 20_006.0,
+                        },
+                        {
+                            "id": span_ids[5],
+                            "parent_span": span_ids[4],
+                            "span.duration": 20_005.0,
+                        },
+                    ],
+                    "suggestedSpans": [
+                        {
+                            "id": span_ids[6],
+                            "parent_span": span_ids[4],
+                            "span.duration": 20_006.0,
+                        },
+                    ],
+                },
+            ],
+            key=lambda trace: trace["trace"],
+        )
+
+        mock_capture_exception.assert_called_with(
+            exception, contexts={"bad_traces": {"traces": list(sorted([trace_id_1, trace_id_2]))}}
+        )
+
     def test_matching_tag(self):
         (
             project_1,
@@ -467,16 +594,16 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
                         "project": project_1.slug,
                         "name": "foo",
                         "duration": 60_100,
-                        "start": int(timestamps[0].timestamp() * 1000),
-                        "end": int(timestamps[0].timestamp() * 1000) + 60_100,
+                        "start": timestamps[0],
+                        "end": timestamps[0] + 60_100,
                         "breakdowns": [
                             {
                                 "project": project_1.slug,
                                 "opCategory": None,
                                 "sdkName": "sentry.javascript.node",
                                 "isRoot": False,
-                                "start": int(timestamps[0].timestamp() * 1000),
-                                "end": int(timestamps[0].timestamp() * 1000) + 60_100,
+                                "start": timestamps[0],
+                                "end": timestamps[0] + 60_100,
                                 "kind": "project",
                                 "duration": 60_100,
                             },
@@ -485,10 +612,10 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
                                 "opCategory": None,
                                 "sdkName": "sentry.javascript.node",
                                 "isRoot": False,
-                                "start": int(timestamps[1].timestamp() * 1000),
-                                "end": int(timestamps[3].timestamp() * 1000) + 30_003,
+                                "start": timestamps[1],
+                                "end": timestamps[3] + 30_003,
                                 "kind": "project",
-                                "duration": 32_003,
+                                "duration": timestamps[3] - timestamps[1] + 30_003,
                             },
                         ],
                         "spans": [
@@ -524,16 +651,16 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
                         "project": project_1.slug,
                         "name": "bar",
                         "duration": 90_123,
-                        "start": int(timestamps[4].timestamp() * 1000),
-                        "end": int(timestamps[4].timestamp() * 1000) + 90_123,
+                        "start": timestamps[4],
+                        "end": timestamps[4] + 90_123,
                         "breakdowns": [
                             {
                                 "project": project_1.slug,
                                 "opCategory": None,
                                 "sdkName": "sentry.javascript.node",
                                 "isRoot": False,
-                                "start": int(timestamps[4].timestamp() * 1000),
-                                "end": int(timestamps[4].timestamp() * 1000) + 90_123,
+                                "start": timestamps[4],
+                                "end": timestamps[4] + 90_123,
                                 "kind": "project",
                                 "duration": 90_123,
                             },
@@ -542,10 +669,10 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
                                 "opCategory": None,
                                 "sdkName": "sentry.javascript.node",
                                 "isRoot": False,
-                                "start": int(timestamps[5].timestamp() * 1000),
-                                "end": int(timestamps[6].timestamp() * 1000) + 20_006,
+                                "start": timestamps[5],
+                                "end": timestamps[6] + 20_006,
                                 "kind": "project",
-                                "duration": 21_006,
+                                "duration": timestamps[6] - timestamps[5] + 20_006,
                             },
                         ],
                         "spans": [
@@ -624,16 +751,16 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
                 "project": project_1.slug,
                 "name": "bar",
                 "duration": 90_123,
-                "start": int(timestamps[4].timestamp() * 1000),
-                "end": int(timestamps[4].timestamp() * 1000) + 90_123,
+                "start": timestamps[4],
+                "end": timestamps[4] + 90_123,
                 "breakdowns": [
                     {
                         "project": project_1.slug,
                         "opCategory": None,
                         "sdkName": "sentry.javascript.node",
                         "isRoot": False,
-                        "start": int(timestamps[4].timestamp() * 1000),
-                        "end": int(timestamps[4].timestamp() * 1000) + 90_123,
+                        "start": timestamps[4],
+                        "end": timestamps[4] + 90_123,
                         "kind": "project",
                         "duration": 90_123,
                     },
@@ -642,8 +769,8 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
                         "opCategory": "http",
                         "sdkName": "",
                         "isRoot": False,
-                        "start": int(timestamps[7].timestamp() * 1000),
-                        "end": int(timestamps[7].timestamp() * 1000) + 1_000,
+                        "start": timestamps[7],
+                        "end": timestamps[7] + 1_000,
                         "kind": "project",
                         "duration": 1_000,
                     },
@@ -652,18 +779,18 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
                         "opCategory": None,
                         "sdkName": "sentry.javascript.node",
                         "isRoot": False,
-                        "start": int(timestamps[5].timestamp() * 1000),
-                        "end": int(timestamps[6].timestamp() * 1000) + 20_006,
+                        "start": timestamps[5],
+                        "end": timestamps[6] + 20_006,
                         "kind": "project",
-                        "duration": 21_006,
+                        "duration": timestamps[6] - timestamps[5] + 20_006,
                     },
                     {
                         "project": project_1.slug,
                         "opCategory": "db",
                         "sdkName": "",
                         "isRoot": False,
-                        "start": int(timestamps[8].timestamp() * 1000),
-                        "end": int(timestamps[8].timestamp() * 1000) + 3_000,
+                        "start": timestamps[8],
+                        "end": timestamps[8] + 3_000,
                         "kind": "project",
                         "duration": 3_000,
                     },
@@ -742,16 +869,16 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
                         "project": project_1.slug,
                         "name": "qux",
                         "duration": 40_000,
-                        "start": int(timestamps[10].timestamp() * 1000),
-                        "end": int(timestamps[10].timestamp() * 1000) + 40_000,
+                        "start": timestamps[10],
+                        "end": timestamps[10] + 40_000,
                         "breakdowns": [
                             {
                                 "project": project_1.slug,
                                 "opCategory": None,
                                 "sdkName": "sentry.javascript.remix",
                                 "isRoot": False,
-                                "start": int(timestamps[10].timestamp() * 1000),
-                                "end": int(timestamps[10].timestamp() * 1000) + 40_000,
+                                "start": timestamps[10],
+                                "end": timestamps[10] + 40_000,
                                 "kind": "project",
                                 "duration": 40_000,
                             },
@@ -760,8 +887,8 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
                                 "opCategory": None,
                                 "sdkName": "sentry.javascript.node",
                                 "isRoot": False,
-                                "start": int(timestamps[11].timestamp() * 1000),
-                                "end": int(timestamps[11].timestamp() * 1000) + 10_000,
+                                "start": timestamps[11],
+                                "end": timestamps[11] + 10_000,
                                 "kind": "project",
                                 "duration": 10_000,
                             },
@@ -1885,3 +2012,99 @@ def test_process_breakdowns(data, traces_range, expected):
     }
     result = process_breakdowns(data, traces_range)
     assert result == expected
+
+
+@patch("sentry_sdk.capture_exception")
+@patch("sentry.api.endpoints.organization_traces.quantize_range")
+def test_quantize_range_error(mock_quantize_range, mock_capture_exception):
+    exception = Exception()
+
+    mock_quantize_range.side_effect = exception
+
+    data = [
+        {
+            "trace": "a" * 32,
+            "project": "foo",
+            "sdk.name": "sentry.javascript.node",
+            "parent_span": "a" * 16,
+            "transaction": "foo1",
+            "precise.start_ts": 0,
+            "precise.finish_ts": 0.1,
+        },
+    ]
+    traces_range = {
+        "a"
+        * 32: {
+            "start": 0,
+            "end": 100,
+            "min": 0,
+        }
+    }
+    result = process_breakdowns(data, traces_range)
+    assert result == {
+        "a"
+        * 32: [
+            {
+                "project": None,
+                "opCategory": None,
+                "sdkName": None,
+                "start": 0,
+                "end": 100,
+                "kind": "other",
+                "duration": 100,
+                "isRoot": False,
+            }
+        ]
+    }
+
+    mock_capture_exception.assert_called_with(
+        exception, contexts={"bad_trace": {"trace": "a" * 32}}
+    )
+
+
+@patch("sentry_sdk.capture_exception")
+@patch("sentry.api.endpoints.organization_traces.new_trace_interval")
+def test_build_breakdown_error(mock_new_trace_interval, mock_capture_exception):
+    exception = Exception()
+
+    mock_new_trace_interval.side_effect = exception
+
+    data = [
+        {
+            "trace": "a" * 32,
+            "project": "foo",
+            "sdk.name": "sentry.javascript.node",
+            "parent_span": "a" * 16,
+            "transaction": "foo1",
+            "precise.start_ts": 0,
+            "precise.finish_ts": 0.1,
+        },
+    ]
+    traces_range = {
+        "a"
+        * 32: {
+            "start": 0,
+            "end": 100,
+            "min": 0,
+        }
+    }
+    result = process_breakdowns(data, traces_range)
+    assert result == {
+        "a"
+        * 32: [
+            {
+                "project": None,
+                "opCategory": None,
+                "sdkName": None,
+                "start": 0,
+                "end": 100,
+                "kind": "other",
+                "duration": 100,
+                "isRoot": False,
+            }
+        ]
+    }
+
+    mock_capture_exception.assert_called_with(
+        exception, contexts={"bad_trace": {"trace": "a" * 32}}
+    )


### PR DESCRIPTION
Modifying the breakdown generation can be error prone so wrap it in some `try ... except ...` to avoid crashing the entire endpoint.