### PR TITLE
feat(flagpole): Adds bulk option lookup with flag filter

### DIFF
--- a/src/sentry/options/manager.py
+++ b/src/sentry/options/manager.py
@@ -514,7 +514,7 @@ class OptionsManager:
 
         return None
 
-    def bulk_retrieve_options(self, keys: list[str], flag: int | None = None) -> dict[str, any]:
+    def bulk_retrieve_options(self, keys: list[str], flag: int | None = None) -> dict[str, Any]:
         key_set = set(keys)
         keys = []
 

--- a/src/sentry/options/manager.py
+++ b/src/sentry/options/manager.py
@@ -514,7 +514,7 @@ class OptionsManager:
 
         return None
 
-    def bulk_retrieve_options(self, keys: list[str], flag: int | None = None) -> dict[str, Any]:
+    def bulk_retrieve_options(self, keys: list[str], flag: int | None = None):
         key_set = set(keys)
         keys = []
 
@@ -529,5 +529,5 @@ class OptionsManager:
 
         return self.bulk_retrieve_options_by_key(keys)
 
-    def bulk_retrieve_options_by_key(self, keys) -> dict[str, any]:
+    def bulk_retrieve_options_by_key(self, keys):
         return {key.name: self.get(key.name) for key in keys}

--- a/src/sentry/options/manager.py
+++ b/src/sentry/options/manager.py
@@ -108,6 +108,8 @@ FLAG_BOOL = 1 << 10
 FLAG_AUTOMATOR_MODIFIABLE = 1 << 11
 # Values that are scalar numeric integer values
 FLAG_SCALAR = 1 << 12
+# Values that are meant to be used by the flagpole feature handler
+FLAG_FLAGPOLE_FEATURE = 1 << 13
 
 FLAG_MODIFIABLE_RATE = FLAG_ADMIN_MODIFIABLE | FLAG_RATE
 FLAG_MODIFIABLE_BOOL = FLAG_ADMIN_MODIFIABLE | FLAG_BOOL
@@ -511,3 +513,21 @@ class OptionsManager:
             return NotWritableReason.DRIFTED
 
         return None
+
+    def bulk_retrieve_options(self, keys: list[str], flag: int | None = None) -> dict[str, any]:
+        key_set = set(keys)
+        keys = []
+
+        for key, value in self.registry.items():
+            flag_matches = flag is None or value.flags & flag
+            key_in_set = key in key_set
+
+            if not key_in_set or not flag_matches:
+                continue
+
+            keys.append(value)
+
+        return self.bulk_retrieve_options_by_key(keys)
+
+    def bulk_retrieve_options_by_key(self, keys) -> dict[str, any]:
+        return {key.name: self.get(key.name) for key in keys}


### PR DESCRIPTION
Adds a new `bulk_retrieve_options` method to OptionsManager to allow flagpole to bulk query matching feature options.

This isn't super optimized as it will invoke the `OptionsManager.get()` method for every registry key match, meaning this could result in multiple DB round trips depending on what lives in the options manager and store caches. If this becomes problematic, we can update the bulk retrieval method to bulk query the store and caches accordingly, but would require us to reimplement this complex get logic.
