### PR TITLE
ref(grouping): Change hash calculation metric tag value

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -1496,7 +1496,7 @@ def _save_aggregate(
                 record_calculation_metric_with_result(
                     project=project,
                     has_secondary_hashes=has_secondary_hashes,
-                    result="new_group",
+                    result="no_match",
                 )
 
                 metrics.incr(
@@ -1639,7 +1639,7 @@ def _save_aggregate_new(
             group_info = create_group_with_grouphashes(
                 job, all_grouphashes, group_processing_kwargs
             )
-            result = "new_group"
+            result = "no_match"
 
     # From here on out, we're just doing housekeeping
 

--- a/tests/sentry/event_manager/grouping/test_assign_to_group.py
+++ b/tests/sentry/event_manager/grouping/test_assign_to_group.py
@@ -297,7 +297,7 @@ def test_new_group(
             "secondary_grouphash_existed_already": False,
             "primary_grouphash_exists_now": True,
             "secondary_grouphash_exists_now": True,
-            "result_tag_value_for_metrics": "new_group",
+            "result_tag_value_for_metrics": "no_match",
             # Moot since no existing group was passed
             "event_assigned_to_given_existing_group": None,
         }
@@ -309,7 +309,7 @@ def test_new_group(
             "new_group_created": True,
             "primary_grouphash_existed_already": False,
             "primary_grouphash_exists_now": True,
-            "result_tag_value_for_metrics": "new_group",
+            "result_tag_value_for_metrics": "no_match",
             # The rest are moot since no existing group was passed and no secondary hash was
             # calculated.
             "event_assigned_to_given_existing_group": None,
@@ -375,7 +375,7 @@ def test_existing_group_no_new_hash(
             "event_assigned_to_given_existing_group": False,
             "primary_grouphash_existed_already": False,
             "primary_grouphash_exists_now": True,
-            "result_tag_value_for_metrics": "new_group",
+            "result_tag_value_for_metrics": "no_match",
             # The rest are moot since no secondary hash was calculated.
             "hashes_different": None,
             "secondary_hash_found": None,


### PR DESCRIPTION
We record two metrics during ingest, `grouping.event_hashes_calculated` and `grouping.total_calculations`, in order to be able to track the average number of hash calculations done per event and how that relates to whether or not we find one or both of the primary and secondary hashes. (This is relevant to the project of updating our grouping config transition logic.) The current choices for the `result` tag are `found_primary`, `found_secondary`, and `new_group`, because until now, those have been the only possibilities.

Now that we're going to be using Seer for grouping, though, there's another possibility, namely that Seer might find a group similar enough that we don't in fact create a new one. For the purposes of the metrics in question, this is no different than the case where we do in fact create a new group - either way, we didn't find a matching hash in the `GroupHash` table - and so we want to use the same tag option for both. This therefore changes the value for that option to `no_match`, to better reflect what it's actually trying to indicate (and so it won't sometimes be a lie once we turn on Seer grouping).