### PR TITLE
ref(groupChart): Refactor GroupChart for readability, typing, and scoping

### DIFF
--- a/static/app/components/stream/group.tsx
+++ b/static/app/components/stream/group.tsx
@@ -38,6 +38,7 @@ import type {
   NewQuery,
   Organization,
   PriorityLevel,
+  TimeseriesValue,
   User,
 } from 'sentry/types';
 import {IssueCategory} from 'sentry/types/group';
@@ -438,6 +439,14 @@ function BaseGroupRow({
     <GuideAnchor target="issue_stream" />
   );
 
+  const groupStats: ReadonlyArray<TimeseriesValue> = group.filtered
+    ? group.filtered.stats?.[statsPeriod]
+    : group.stats?.[statsPeriod];
+
+  const groupSecondaryStats: ReadonlyArray<TimeseriesValue> = group.filtered
+    ? group.stats?.[statsPeriod]
+    : [];
+
   return (
     <Wrapper
       data-test-id="group"
@@ -472,8 +481,8 @@ function BaseGroupRow({
       {withChart && !displayReprocessingLayout && issueTypeConfig.stats.enabled && (
         <ChartWrapper narrowGroups={narrowGroups}>
           <GroupChart
-            statsPeriod={statsPeriod!}
-            data={group}
+            stats={groupStats}
+            secondaryStats={groupSecondaryStats}
             showSecondaryPoints={showSecondaryPoints}
             showMarkLine
           />

--- a/static/app/views/discover/eventDetails/linkedIssue.tsx
+++ b/static/app/views/discover/eventDetails/linkedIssue.tsx
@@ -12,6 +12,7 @@ import ShortId from 'sentry/components/shortId';
 import GroupChart from 'sentry/components/stream/groupChart';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
+import type {TimeseriesValue} from 'sentry/types';
 import type {Group} from 'sentry/types/group';
 import {useApiQuery} from 'sentry/utils/queryClient';
 
@@ -50,6 +51,14 @@ function LinkedIssue({eventId, groupId}: Props) {
 
   const issueUrl = `${group.permalink}events/${eventId}/`;
 
+  const groupStats: ReadonlyArray<TimeseriesValue> = group.filtered
+    ? group.filtered.stats?.['30d']
+    : group.stats?.['30d'];
+
+  const groupSecondaryStats: ReadonlyArray<TimeseriesValue> = group.filtered
+    ? group.stats?.['30d']
+    : [];
+
   return (
     <Section>
       <SectionHeading>{t('Event Issue')}</SectionHeading>
@@ -71,7 +80,11 @@ function LinkedIssue({eventId, groupId}: Props) {
           <SeenByList seenBy={group.seenBy} maxVisibleAvatars={5} />
         </IssueCardHeader>
         <IssueCardBody>
-          <GroupChart statsPeriod="30d" data={group} height={56} />
+          <GroupChart
+            stats={groupStats}
+            secondaryStats={groupSecondaryStats}
+            height={56}
+          />
         </IssueCardBody>
         <IssueCardFooter>
           <Times lastSeen={group.lastSeen} firstSeen={group.firstSeen} />

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/issues/issues.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/issues/issues.tsx
@@ -80,8 +80,12 @@ function Issue(props: IssueProps) {
       </IssueSummaryWrapper>
       <ChartWrapper>
         <GroupChart
-          statsPeriod={'24h'}
-          data={fetchedIssue}
+          stats={
+            fetchedIssue.filtered
+              ? fetchedIssue.filtered.stats?.['24h']
+              : fetchedIssue.stats?.['24h']
+          }
+          secondaryStats={fetchedIssue.filtered ? fetchedIssue.stats?.['24h'] : []}
           showSecondaryPoints
           showMarkLine
         />


### PR DESCRIPTION
This PR refactors the `<GroupChart>` component to have better typing, and to be more readable. It also removes the `group` prop, since the scope of the entire `group` object is beyond what the component needs. Specific details are included the comments. 

**No design or visual changes should be included in this PR. If you browse the preview and see any visual changes to the events graph, please comment about it and I will rectify.**

High level changes:

- Updates all instances of `groupChart` to reflect refactor
- Replaces `group` and `statsPeriod` props in favor of stats and secondary stats data itself
- Removes all uses of `let` in groupChart
- Better typing 