### PR TITLE
feat(dashboards): Add remaining span metrics to metric samples endpoint

### DIFF
--- a/src/sentry/sentry_metrics/querying/samples_list.py
+++ b/src/sentry/sentry_metrics/querying/samples_list.py
@@ -826,6 +826,13 @@ class SpansMeasurementsSamplesListExecutor(SpansSamplesListExecutor):
         SpanMRI.RESPONSE_CONTENT_LENGTH.value: "http.response_content_length",
         SpanMRI.DECODED_RESPONSE_CONTENT_LENGTH.value: "http.decoded_response_content_length",
         SpanMRI.RESPONSE_TRANSFER_SIZE.value: "http.response_transfer_size",
+        SpanMRI.AI_TOTAL_TOKENS.value: "ai_total_tokens_used",
+        SpanMRI.CACHE_ITEM_SIZE.value: "cache.item_size",
+        SpanMRI.MOBILE_SLOW_FRAMES.value: "frames.slow",
+        SpanMRI.MOBILE_FROZEN_FRAMES.value: "frames.frozen",
+        SpanMRI.MOBILE_TOTAL_FRAMES.value: "frames.total",
+        SpanMRI.MOBILE_FRAMES_DELAY.value: "frames.delay",
+        SpanMRI.MESSAGE_RECEIVE_LATENCY.value: "messaging.message.receive.latency",
     }
 
     @classmethod

--- a/src/sentry/snuba/metrics/naming_layer/mri.py
+++ b/src/sentry/snuba/metrics/naming_layer/mri.py
@@ -165,10 +165,22 @@ class SpanMRI(Enum):
     DURATION = "d:spans/duration@millisecond"
     SELF_TIME = "d:spans/exclusive_time@millisecond"
     SELF_TIME_LIGHT = "d:spans/exclusive_time_light@millisecond"
-    RESPONSE_CONTENT_LENGTH = "d:spans/http.response_content_length@byte"
-    DECODED_RESPONSE_CONTENT_LENGTH = "d:spans/http.decoded_response_content_length@byte"
+
+    # Measurement-based metrics
+    AI_TOTAL_TOKENS = "c:spans/ai.total_tokens@none"
     CACHE_ITEM_SIZE = "d:spans/cache.item_size@byte"
+    DECODED_RESPONSE_CONTENT_LENGTH = "d:spans/http.decoded_response_content_length@byte"
+    MESSAGE_RECEIVE_LATENCY = "g:spans/messaging.message.receive.latency@millisecond"
+    MOBILE_FRAMES_DELAY = "g:spans/mobile.frames_delay@second"
+    MOBILE_FROZEN_FRAMES = "g:spans/mobile.frozen_frames@none"
+    MOBILE_SLOW_FRAMES = "g:spans/mobile.slow_frames@none"
+    MOBILE_TOTAL_FRAMES = "g:spans/mobile.total_frames@none"
+    RESPONSE_CONTENT_LENGTH = "d:spans/http.response_content_length@byte"
     RESPONSE_TRANSFER_SIZE = "d:spans/http.response_transfer_size@byte"
+    WEB_VITALS_INP = "d:spans/webvital.inp@millisecond"
+    WEB_VITALS_SCORE_INP = "d:spans/webvital.score.inp@ratio"
+    WEB_VITALS_SCORE_TOTAL = "d:spans/webvital.score.total@ratio"
+    WEB_VITALS_SCORE_WEIGHT = "d:spans/webvital.score.weight.inp@ratio"
 
     # Derived
     ALL = "e:spans/all@none"

--- a/tests/sentry/api/endpoints/test_organization_metrics.py
+++ b/tests/sentry/api/endpoints/test_organization_metrics.py
@@ -267,6 +267,7 @@ class OrganizationMetricsSamplesEndpointTest(BaseSpansTestCase, APITestCase):
                     measurement: duration + j + 1
                     for j, measurement in enumerate(
                         [
+                            "frames.slow",
                             "score.total",
                             "score.inp",
                             "score.weight.inp",
@@ -288,6 +289,7 @@ class OrganizationMetricsSamplesEndpointTest(BaseSpansTestCase, APITestCase):
 
         for i, mri in enumerate(
             [
+                "g:spans/mobile.slow_frames@none",
                 "d:spans/webvital.score.total@ratio",
                 "d:spans/webvital.score.inp@ratio",
                 "d:spans/webvital.score.weight.inp@ratio",


### PR DESCRIPTION
To display span metrics properly in dashboards we also need to expose the samples on the widget builder. This involves updating the span sample executor to accept the remaining span MRIs.