### PR TITLE
fix(trace-explorer): Limit results per page

### DIFF
--- a/src/sentry/api/endpoints/organization_traces.py
+++ b/src/sentry/api/endpoints/organization_traces.py
@@ -470,6 +470,10 @@ class TraceSamplesExecutor:
                 if timestamp > max_timestamp:
                     max_timestamp = timestamp
 
+                # early escape once we have enough results
+                if len(matching_trace_ids) >= self.limit:
+                    return min_timestamp, max_timestamp, matching_trace_ids
+
         return min_timestamp, max_timestamp, matching_trace_ids
 
     def get_traces_matching_span_conditions_query(

--- a/tests/sentry/api/endpoints/test_organization_traces.py
+++ b/tests/sentry/api/endpoints/test_organization_traces.py
@@ -724,6 +724,7 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
                     "suggestedQuery": ["foo:qux"],
                     "maxSpansPerTrace": 3,
                     "sort": ["-span.duration"],
+                    "per_page": 1,
                 }
                 if user_query:
                     query["query"] = user_query


### PR DESCRIPTION
When coming from metrics, we use up to 10k trace ids and try to filter on that. The queries are split into `n` parallel queries each with a limit. But because of this, the total number of results can be `n * limit` instead of `limit`. So reduce the number of results further to fit within the limit.