### PR TITLE
fix(similarity): more backfill fixes and a few more logs

### DIFF
--- a/src/sentry/seer/utils.py
+++ b/src/sentry/seer/utils.py
@@ -333,6 +333,10 @@ def delete_grouping_records(
         return False
 
     if response.status >= 200 and response.status < 300:
+        logger.info(
+            "seer.delete_grouping_records.success",
+            extra={"project_id": project_id},
+        )
         return True
     else:
         logger.error(

--- a/src/sentry/tasks/backfill_seer_grouping_records.py
+++ b/src/sentry/tasks/backfill_seer_grouping_records.py
@@ -107,6 +107,7 @@ def backfill_seer_grouping_records(
             "last_processed_id": last_processed_id,
         },
     )
+
     if len(group_id_message_data_batch) == 0:
         logger.info(
             "backfill_seer_grouping_records.no_more_groups",
@@ -117,9 +118,8 @@ def backfill_seer_grouping_records(
     group_id_message_batch_filtered = {
         group_id: message
         for (group_id, message, data) in group_id_message_data_batch
-        if get_path(data, "metadata", "embeddings_info", "nn_model_version") is not None
+        if get_path(data, "metadata", "embeddings_info", "nn_model_version") is None
     }
-
     if len(group_id_message_data_batch) != len(group_id_message_batch_filtered):
         logger.info(
             "backfill_seer_grouping_records.groups_already_had_embedding",
@@ -222,8 +222,6 @@ def backfill_seer_grouping_records(
         backfill_seer_grouping_records.apply_async(
             args=[project.id, last_processed_id, dry_run],
         )
-        return
-
     else:
         logger.info(
             "backfill_seer_snuba_returned_empty_result",

--- a/tests/sentry/tasks/test_backfill_seer_grouping_records.py
+++ b/tests/sentry/tasks/test_backfill_seer_grouping_records.py
@@ -3,7 +3,6 @@ from collections.abc import Mapping
 from random import choice
 from string import ascii_uppercase
 from typing import Any
-from unittest import TestCase
 from unittest.mock import patch
 
 import pytest
@@ -25,7 +24,7 @@ from sentry.tasks.backfill_seer_grouping_records import (
     lookup_group_data_stacktrace_single,
     make_backfill_redis_key,
 )
-from sentry.testutils.cases import BaseMetricsTestCase
+from sentry.testutils.cases import SnubaTestCase, TestCase
 from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.helpers.task_runner import TaskRunner
 from sentry.testutils.pytest.fixtures import django_db_all
@@ -57,7 +56,7 @@ EXCEPTION_STACKTRACE_STRING = (
 
 
 @django_db_all
-class TestBackfillSeerGroupingRecords(BaseMetricsTestCase, TestCase):
+class TestBackfillSeerGroupingRecords(SnubaTestCase, TestCase):
     def create_exception_values(self, function_name: str, type: str, value: str):
         return {
             "values": [


### PR DESCRIPTION
- will delete the redis key after no more groups are found
- adds a few more logs in other cases:
  - when we've already done embeddings for a group, we'll log the count of that
  - if snuba returns no results for whatever reason, we'll log that
  - we'll log the number of updated groups