### PR TITLE
ref(replay): rename query_replays_collection_raw and remove compatibility fx

### DIFF
--- a/src/sentry/replays/endpoints/organization_replay_index.py
+++ b/src/sentry/replays/endpoints/organization_replay_index.py
@@ -18,7 +18,7 @@ from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.exceptions import InvalidSearchQuery
 from sentry.models.organization import Organization
 from sentry.replays.post_process import ReplayDetailsResponse, process_raw_response
-from sentry.replays.query import query_replays_collection_raw, replay_url_parser_config
+from sentry.replays.query import query_replays_collection_paginated, replay_url_parser_config
 from sentry.replays.usecases.errors import handled_snuba_exceptions
 from sentry.replays.validators import ReplayValidator
 from sentry.utils.cursors import Cursor, CursorResult
@@ -83,7 +83,7 @@ class OrganizationReplayIndexEndpoint(OrganizationEndpoint):
                 # to do this for completeness sake.
                 return Response({"detail": "Missing start or end period."}, status=400)
 
-            return query_replays_collection_raw(
+            return query_replays_collection_paginated(
                 project_ids=filter_params["project_id"],
                 start=start,
                 end=end,

--- a/src/sentry/replays/query.py
+++ b/src/sentry/replays/query.py
@@ -39,12 +39,7 @@ MAX_REPLAY_LENGTH_HOURS = 1
 ELIGIBLE_SUBQUERY_SORTS = {"started_at", "browser.name", "os.name"}
 
 
-# Compatibility function for getsentry code.
-def query_replays_collection(*args, **kwargs):
-    return query_replays_collection_raw(*args, **kwargs)[0]
-
-
-def query_replays_collection_raw(
+def query_replays_collection_paginated(
     project_ids: list[int],
     start: datetime,
     end: datetime,

--- a/tests/sentry/replays/test_organization_replay_index.py
+++ b/tests/sentry/replays/test_organization_replay_index.py
@@ -1392,7 +1392,7 @@ class OrganizationReplayIndexTest(APITestCase, ReplaysSnubaTestCase):
         with self.feature(REPLAYS_FEATURES):
             # Invalid field-names error regardless of ordering.
             with mock.patch(
-                "sentry.replays.endpoints.organization_replay_index.query_replays_collection_raw",
+                "sentry.replays.endpoints.organization_replay_index.query_replays_collection_paginated",
                 side_effect=QueryMemoryLimitExceeded("mocked error"),
             ):
                 response = self.client.get(self.url)


### PR DESCRIPTION
Suggesting a better name for this fx since limit and offset are required and, we no longer need the compatibility fx since delete_replays was moved from getsentry to sentry.

Did a grep to ensure there are no references in getsentry:
![Screenshot 2024-05-15 at 2 08 02 PM](https://github.com/getsentry/sentry/assets/159852527/54f8d2ee-ef26-4c16-9eb2-aa15fc90ce9a)
