### PR TITLE
ref(rules): Fetch all project ids in buffer

### DIFF
--- a/src/sentry/rules/processing/delayed_processing.py
+++ b/src/sentry/rules/processing/delayed_processing.py
@@ -295,7 +295,9 @@ def get_group_to_groupevent(
 def process_delayed_alert_conditions(buffer: RedisBuffer) -> None:
     with metrics.timer("delayed_processing.process_all_conditions.duration"):
         fetch_time = datetime.now(tz=timezone.utc)
-        project_ids = buffer.get_sorted_set(PROJECT_ID_BUFFER_LIST_KEY, min="-inf", max="+inf")
+        project_ids = buffer.get_sorted_set(
+            PROJECT_ID_BUFFER_LIST_KEY, min=float("-inf"), max=float("+inf")
+        )
         log_str = ""
         for project_id, timestamp in project_ids:
             log_str += f"{project_id}: {timestamp}"

--- a/src/sentry/rules/processing/delayed_processing.py
+++ b/src/sentry/rules/processing/delayed_processing.py
@@ -295,9 +295,7 @@ def get_group_to_groupevent(
 def process_delayed_alert_conditions(buffer: RedisBuffer) -> None:
     with metrics.timer("delayed_processing.process_all_conditions.duration"):
         fetch_time = datetime.now(tz=timezone.utc)
-        project_ids = buffer.get_sorted_set(
-            PROJECT_ID_BUFFER_LIST_KEY, min=0, max=fetch_time.timestamp()
-        )
+        project_ids = buffer.get_sorted_set(PROJECT_ID_BUFFER_LIST_KEY, min="-inf", max="+inf")
         log_str = ""
         for project_id, timestamp in project_ids:
             log_str += f"{project_id}: {timestamp}"


### PR DESCRIPTION
We're not seeing any project ids in the logs for `delayed_processing.project_id_list` and delayed alerts aren't firing (though it works locally) so maybe the time range is too narrow. To test, we'll just get all the project ids right now.