### PR TITLE
feat(assignee-dropdown): Swap out old assignee dropdown trigger for <AssigneeBadge/>

### DIFF
--- a/static/app/components/assigneeBadge.tsx
+++ b/static/app/components/assigneeBadge.tsx
@@ -145,7 +145,6 @@ const StyledTag = styled(Tag)`
     padding: ${space(0.5)};
   }
   color: ${p => p.theme.subText};
-  cursor: pointer;
 `;
 
 const TooltipSubtext = styled('div')`

--- a/static/app/components/assigneeBadge.tsx
+++ b/static/app/components/assigneeBadge.tsx
@@ -143,6 +143,7 @@ const StyledTag = styled(Tag)`
   & > div {
     height: 24px;
     padding: ${space(0.5)};
+    padding-right: ${space(0.25)};
   }
   color: ${p => p.theme.subText};
 `;

--- a/static/app/components/badge/groupPriority.tsx
+++ b/static/app/components/badge/groupPriority.tsx
@@ -1,5 +1,6 @@
 import {Fragment, useMemo, useRef} from 'react';
 import type {Theme} from '@emotion/react';
+import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import bannerStar from 'sentry-images/spot/banner-star.svg';
@@ -102,9 +103,13 @@ export function GroupPriorityBadge({priority, children}: GroupPriorityBadgeProps
   return (
     <StyledTag
       type={getTagTypeForPriority(priority)}
-      bigtag={organization.features.includes(
-        'organizations:issue-stream-new-assignee-dropdown-trigger'
-      )}
+      css={css`
+        --tagHeight: ${organization.features.includes(
+          'organizations:issue-stream-new-assignee-dropdown-trigger'
+        )
+          ? '24px'
+          : '18px'};
+      `}
     >
       {PRIORITY_KEY_TO_LABEL[priority] ?? t('Unknown')}
       {children}
@@ -272,7 +277,7 @@ const DropdownButton = styled(Button)`
   box-shadow: none;
 `;
 
-const StyledTag = styled(Tag)<{bigtag: boolean}>`
+const StyledTag = styled(Tag)`
   span {
     display: flex;
     align-items: center;
@@ -280,7 +285,7 @@ const StyledTag = styled(Tag)<{bigtag: boolean}>`
   }
 
   & > div {
-    height: ${p => (p.bigtag ? '24px' : '18px')};
+    height: var(--tagHeight, 18px);
   }
 `;
 

--- a/static/app/components/badge/groupPriority.tsx
+++ b/static/app/components/badge/groupPriority.tsx
@@ -1,6 +1,6 @@
 import {Fragment, useMemo, useRef} from 'react';
+import isPropValid from '@emotion/is-prop-valid';
 import type {Theme} from '@emotion/react';
-import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import bannerStar from 'sentry-images/spot/banner-star.svg';
@@ -103,13 +103,9 @@ export function GroupPriorityBadge({priority, children}: GroupPriorityBadgeProps
   return (
     <StyledTag
       type={getTagTypeForPriority(priority)}
-      css={css`
-        --tagHeight: ${organization.features.includes(
-          'organizations:issue-stream-new-assignee-dropdown-trigger'
-        )
-          ? '24px'
-          : '18px'};
-      `}
+      isBigtag={organization.features.includes(
+        'organizations:issue-stream-new-assignee-dropdown-trigger'
+      )}
     >
       {PRIORITY_KEY_TO_LABEL[priority] ?? t('Unknown')}
       {children}
@@ -277,7 +273,9 @@ const DropdownButton = styled(Button)`
   box-shadow: none;
 `;
 
-const StyledTag = styled(Tag)`
+const StyledTag = styled(Tag, {
+  shouldForwardProp: prop => typeof prop === 'string' && isPropValid(prop),
+})<{isBigtag: boolean}>`
   span {
     display: flex;
     align-items: center;
@@ -285,7 +283,7 @@ const StyledTag = styled(Tag)`
   }
 
   & > div {
-    height: var(--tagHeight, 18px);
+    height: ${p => (p.isBigtag ? '24px' : '18px')};
   }
 `;
 

--- a/static/app/components/badge/groupPriority.tsx
+++ b/static/app/components/badge/groupPriority.tsx
@@ -104,7 +104,7 @@ export function GroupPriorityBadge({priority, children}: GroupPriorityBadgeProps
     <StyledTag
       type={getTagTypeForPriority(priority)}
       isBigtag={organization.features.includes(
-        'organizations:issue-stream-new-assignee-dropdown-trigger'
+        'issue-stream-new-assignee-dropdown-trigger'
       )}
     >
       {PRIORITY_KEY_TO_LABEL[priority] ?? t('Unknown')}

--- a/static/app/components/badge/groupPriority.tsx
+++ b/static/app/components/badge/groupPriority.tsx
@@ -98,8 +98,14 @@ export function makeGroupPriorityDropdownOptions({
 }
 
 export function GroupPriorityBadge({priority, children}: GroupPriorityBadgeProps) {
+  const organization = useOrganization();
   return (
-    <StyledTag type={getTagTypeForPriority(priority)}>
+    <StyledTag
+      type={getTagTypeForPriority(priority)}
+      bigTag={organization.features.includes(
+        'organizations:issue-stream-new-assignee-dropdown-trigger'
+      )}
+    >
       {PRIORITY_KEY_TO_LABEL[priority] ?? t('Unknown')}
       {children}
     </StyledTag>
@@ -266,11 +272,15 @@ const DropdownButton = styled(Button)`
   box-shadow: none;
 `;
 
-const StyledTag = styled(Tag)`
+const StyledTag = styled(Tag)<{bigTag: boolean}>`
   span {
     display: flex;
     align-items: center;
     gap: ${space(0.25)};
+  }
+
+  & > div {
+    height: ${p => (p.bigTag ? '24px' : '18px')};
   }
 `;
 

--- a/static/app/components/badge/groupPriority.tsx
+++ b/static/app/components/badge/groupPriority.tsx
@@ -102,7 +102,7 @@ export function GroupPriorityBadge({priority, children}: GroupPriorityBadgeProps
   return (
     <StyledTag
       type={getTagTypeForPriority(priority)}
-      bigTag={organization.features.includes(
+      bigtag={organization.features.includes(
         'organizations:issue-stream-new-assignee-dropdown-trigger'
       )}
     >
@@ -272,7 +272,7 @@ const DropdownButton = styled(Button)`
   box-shadow: none;
 `;
 
-const StyledTag = styled(Tag)<{bigTag: boolean}>`
+const StyledTag = styled(Tag)<{bigtag: boolean}>`
   span {
     display: flex;
     align-items: center;
@@ -280,7 +280,7 @@ const StyledTag = styled(Tag)<{bigTag: boolean}>`
   }
 
   & > div {
-    height: ${p => (p.bigTag ? '24px' : '18px')};
+    height: ${p => (p.bigtag ? '24px' : '18px')};
   }
 `;
 

--- a/static/app/components/stream/group.tsx
+++ b/static/app/components/stream/group.tsx
@@ -11,9 +11,9 @@ import AssigneeSelectorDropdown, {
   type AssignableEntity,
 } from 'sentry/components/assigneeSelectorDropdown';
 import GuideAnchor from 'sentry/components/assistant/guideAnchor';
-import {Button} from 'sentry/components/button';
 import Checkbox from 'sentry/components/checkbox';
 import Count from 'sentry/components/count';
+import DropdownButton from 'sentry/components/dropdownButton';
 import EventOrGroupExtraDetails from 'sentry/components/eventOrGroupExtraDetails';
 import EventOrGroupHeader from 'sentry/components/eventOrGroupHeader';
 import type {GroupListColumn} from 'sentry/components/issues/groupList';
@@ -509,8 +509,10 @@ function BaseGroupRow({
                     'issue-stream-new-assignee-dropdown-trigger'
                   )
                     ? (props, isOpen) => (
-                        <DropdownButton
+                        <StyledDropdownButton
                           {...props}
+                          borderless
+                          showChevron={false}
                           aria-label={t('Modify issue assignee')}
                           size="zero"
                         >
@@ -525,7 +527,7 @@ function BaseGroupRow({
                             loading={assigneeLoading}
                             chevronDirection={isOpen ? 'up' : 'down'}
                           />
-                        </DropdownButton>
+                        </StyledDropdownButton>
                       )
                     : undefined
                 }
@@ -543,7 +545,7 @@ const StreamGroup = withOrganization(BaseGroupRow);
 
 export default StreamGroup;
 
-const DropdownButton = styled(Button)`
+const StyledDropdownButton = styled(DropdownButton)`
   font-weight: normal;
   border: none;
   padding: 0;

--- a/static/app/components/stream/group.tsx
+++ b/static/app/components/stream/group.tsx
@@ -512,7 +512,6 @@ function BaseGroupRow({
                         <StyledDropdownButton
                           {...props}
                           borderless
-                          showChevron={false}
                           aria-label={t('Modify issue assignee')}
                           size="zero"
                         >

--- a/static/app/components/stream/group.tsx
+++ b/static/app/components/stream/group.tsx
@@ -506,7 +506,7 @@ function BaseGroupRow({
                 onClear={() => handleAssigneeChange(null)}
                 trigger={
                   organization.features.includes(
-                    'organizations:issue-stream-new-assignee-dropdown-trigger'
+                    'issue-stream-new-assignee-dropdown-trigger'
                   )
                     ? (props, isOpen) => (
                         <DropdownButton

--- a/static/app/components/stream/group.tsx
+++ b/static/app/components/stream/group.tsx
@@ -11,9 +11,9 @@ import AssigneeSelectorDropdown, {
   type AssignableEntity,
 } from 'sentry/components/assigneeSelectorDropdown';
 import GuideAnchor from 'sentry/components/assistant/guideAnchor';
+import {Button} from 'sentry/components/button';
 import Checkbox from 'sentry/components/checkbox';
 import Count from 'sentry/components/count';
-import DropdownButton from 'sentry/components/dropdownButton';
 import EventOrGroupExtraDetails from 'sentry/components/eventOrGroupExtraDetails';
 import EventOrGroupHeader from 'sentry/components/eventOrGroupHeader';
 import type {GroupListColumn} from 'sentry/components/issues/groupList';
@@ -545,8 +545,7 @@ const StreamGroup = withOrganization(BaseGroupRow);
 
 export default StreamGroup;
 
-const StyledDropdownButton = styled(DropdownButton)`
-  z-index: 0;
+const StyledDropdownButton = styled(Button)`
   font-weight: normal;
   border: none;
   padding: 0;

--- a/static/app/components/stream/group.tsx
+++ b/static/app/components/stream/group.tsx
@@ -546,6 +546,7 @@ const StreamGroup = withOrganization(BaseGroupRow);
 export default StreamGroup;
 
 const StyledDropdownButton = styled(DropdownButton)`
+  z-index: 0;
   font-weight: normal;
   border: none;
   padding: 0;


### PR DESCRIPTION
This PR swaps the current assignee dropdown trigger out for a new component, `<AssigneeBadge/>` under the feature flag,`organizations:issue-stream-new-assignee-dropdown-trigger`. This feature flag is set to release only in LA currently (although if you're reading this, I have not merged my PR to options automator just yet. I will do that before merging this.)

Before:
![image](https://github.com/getsentry/sentry/assets/55160142/26ac2098-268d-4d1b-9688-702aecf1db95)

After:
![image](https://github.com/getsentry/sentry/assets/55160142/e6f9fae5-4148-46fa-95c8-bd764df76186)

Notice how the height of the issue priority dropdown trigger also increases a bit to match the height of the assignee badge. If the organization does not have the feature enabled, this height change will not be applied. 

This PR will also remove the appearance of the suggested assignees in the issue stream, aka this state:
![image](https://github.com/getsentry/sentry/assets/55160142/f4f3417e-2ccb-4f26-a681-52ff67f23c26)

If an issue does have suggested assignees, this new trigger will now just show up as Unassigned, but the suggested assignees and reasons will still be surfaced in the assignee dropdown menu. 