### PR TITLE
fix(api): Update Path Params for ProjectBackfillSimilarIssuesEmbeddingsRecords

### DIFF
--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -2545,7 +2545,7 @@ PROJECT_URLS: list[URLPattern | URLResolver] = [
         name="sentry-api-0-project-rule-task-details",
     ),
     re_path(
-        r"^(?P<organization_slug>[^\/]+)/(?P<project_slug>[^\/]+)/backfill-similar-embeddings-records/$",
+        r"^(?P<organization_id_or_slug>[^\/]+)/(?P<project_id_or_slug>[^\/]+)/backfill-similar-embeddings-records/$",
         ProjectBackfillSimilarIssuesEmbeddingsRecords.as_view(),
         name="sentry-api-0-project-backfill-similar-embeddings-records",
     ),

--- a/tests/sentry/api/endpoints/test_project_backfill_similar_issues_embeddings_records.py
+++ b/tests/sentry/api/endpoints/test_project_backfill_similar_issues_embeddings_records.py
@@ -16,8 +16,8 @@ class ProjectBackfillSimilarIssuesEmbeddingsRecordsTest(APITestCase):
         self.url = reverse(
             "sentry-api-0-project-backfill-similar-embeddings-records",
             kwargs={
-                "organization_slug": self.project.organization.slug,
-                "project_slug": self.project.slug,
+                "organization_id_or_slug": self.project.organization.slug,
+                "project_id_or_slug": self.project.slug,
             },
         )
 


### PR DESCRIPTION
Not have `id_or_slug` as path params for this endpoint is blocking me from merging my test to enforce having _id_or_slug as path params here: https://github.com/getsentry/sentry/pull/70909