### PR TITLE
fix(assignees): Fix issue with suggested assignees not hoisting to top

### DIFF
--- a/static/app/components/assigneeSelectorDropdown.spec.tsx
+++ b/static/app/components/assigneeSelectorDropdown.spec.tsx
@@ -29,6 +29,7 @@ describe('AssigneeSelectorDropdown', () => {
   let PROJECT_1;
   let GROUP_1;
   let GROUP_2;
+  let GROUP_3;
 
   beforeEach(() => {
     USER_1 = UserFixture({
@@ -80,6 +81,18 @@ describe('AssigneeSelectorDropdown', () => {
         {
           type: 'suspectCommit',
           owner: `user:${USER_1.id}`,
+          date_added: '',
+        },
+      ],
+    });
+
+    GROUP_3 = GroupFixture({
+      id: '1339',
+      project: PROJECT_1,
+      owners: [
+        {
+          type: 'suspectCommit',
+          owner: `user:${USER_4.id}`,
           date_added: '',
         },
       ],
@@ -561,6 +574,34 @@ describe('AssigneeSelectorDropdown', () => {
       type: 'user',
       suggestedAssignee: expect.objectContaining({id: USER_1.id}),
     });
+  });
+
+  it('shows the suggested assignee even if they would be cut off by the size limit', async () => {
+    jest.spyOn(GroupStore, 'get').mockImplementation(() => GROUP_3);
+
+    MemberListStore.loadInitialData([USER_1, USER_2, USER_3, USER_4]);
+
+    render(
+      <AssigneeSelectorDropdown
+        group={GROUP_3}
+        loading={false}
+        onAssign={newAssignee => updateGroup(GROUP_3, newAssignee)}
+        sizeLimit={2}
+      />
+    );
+
+    expect(screen.getByTestId('suggested-avatar-stack')).toBeInTheDocument();
+    // Hover over avatar
+    await userEvent.hover(await screen.findByTestId('letter_avatar-avatar'));
+    expect(await screen.findByText('Suggestion: Git Hub')).toBeInTheDocument();
+    expect(await screen.findByText('commit data')).toBeInTheDocument();
+
+    await openMenu();
+    // User 4, Git Hub, would have normally been cut off by the the size limit since it is
+    // alphabetically last, but it should still be shown because it is a suggested assignee
+    const options = await screen.findAllByRole('option');
+    expect(options).toHaveLength(2);
+    expect(options[0]).toHaveTextContent('GH');
   });
 
   it('shows invite member button', async () => {

--- a/static/app/components/assigneeSelectorDropdown.tsx
+++ b/static/app/components/assigneeSelectorDropdown.tsx
@@ -92,6 +92,10 @@ export interface AssigneeSelectorDropdownProps {
    */
   owners?: Omit<SuggestedAssignee, 'assignee'>[];
   /**
+   * Maximum number of teams/users to display in the dropdown
+   */
+  sizeLimit?: number;
+  /**
    * Optional trigger for the assignee selector. If nothing passed in,
    * the default trigger will be used
    */
@@ -204,6 +208,7 @@ export default function AssigneeSelectorDropdown({
   onAssign,
   onClear,
   owners,
+  sizeLimit = 150,
   trigger,
 }: AssigneeSelectorDropdownProps) {
   const memberLists = useLegacyStore(MemberListStore);
@@ -438,18 +443,6 @@ export default function AssigneeSelectorDropdown({
       }
     }
 
-    // Remove suggested assignees from the member list and team list to avoid duplicates
-    for (let i = 0; i < suggestedAssignees.length; i++) {
-      const suggestedAssignee = suggestedAssignees[i];
-      if (suggestedAssignee.type === 'user') {
-        memList = memList.filter(user => user.id !== suggestedAssignee.id);
-      } else {
-        assignableTeamList = assignableTeamList.filter(
-          assignableTeam => assignableTeam.team.id !== suggestedAssignee.id
-        );
-      }
-    }
-
     // Only bubble the current user to the top if they are not already assigned or suggested
     const isUserAssignedOrSuggested =
       assignedUser?.id === sessionUser.id ||
@@ -466,6 +459,22 @@ export default function AssigneeSelectorDropdown({
       }
     }
 
+    const suggestedUsers = suggestedAssignees?.filter(
+      assignee => assignee.type === 'user'
+    );
+    const suggestedTeams = suggestedAssignees?.filter(
+      assignee => assignee.type === 'team'
+    );
+
+    // Remove suggested assignees from the member list and team list to avoid duplicates
+    memList = memList.filter(
+      user => !suggestedUsers.find(suggested => suggested.id === user.id)
+    );
+    assignableTeamList = assignableTeamList.filter(
+      assignableTeam =>
+        !suggestedTeams.find(suggested => suggested.id === assignableTeam.team.id)
+    );
+
     const memberOptions = {
       value: '_members',
       label: t('Members'),
@@ -477,13 +486,6 @@ export default function AssigneeSelectorDropdown({
       label: t('Teams'),
       options: assignableTeamList?.map(makeTeamOption) ?? [],
     };
-
-    const suggestedUsers = suggestedAssignees?.filter(
-      assignee => assignee.type === 'user'
-    );
-    const suggestedTeams = suggestedAssignees?.filter(
-      assignee => assignee.type === 'team'
-    );
 
     const suggestedOptions = {
       value: '_suggested_assignees',
@@ -562,7 +564,7 @@ export default function AssigneeSelectorDropdown({
         options={makeAllOptions()}
         trigger={trigger ?? makeTrigger}
         menuFooter={footerInviteButton}
-        sizeLimit={150}
+        sizeLimit={sizeLimit}
         sizeLimitMessage="Use search to find more users and teams..."
       />
     </AssigneeWrapper>

--- a/static/app/components/assigneeSelectorDropdown.tsx
+++ b/static/app/components/assigneeSelectorDropdown.tsx
@@ -438,6 +438,18 @@ export default function AssigneeSelectorDropdown({
       }
     }
 
+    // Remove suggested assignees from the member list and team list to avoid duplicates
+    for (let i = 0; i < suggestedAssignees.length; i++) {
+      const suggestedAssignee = suggestedAssignees[i];
+      if (suggestedAssignee.type === 'user') {
+        memList = memList.filter(user => user.id !== suggestedAssignee.id);
+      } else {
+        assignableTeamList = assignableTeamList.filter(
+          assignableTeam => assignableTeam.team.id !== suggestedAssignee.id
+        );
+      }
+    }
+
     // Only bubble the current user to the top if they are not already assigned or suggested
     const isUserAssignedOrSuggested =
       assignedUser?.id === sessionUser.id ||


### PR DESCRIPTION
This PR fixes an uncommon bug where suggested assignees were not being hoisted to the top of the dropdown menu. This was caused by a combination of two things:

1. A recent change where we limit the number of assignees shown in the menu to 150
2. Suggested assignees were being shown both in the top "suggested" section, and later in the "members" section 

If a suggested assignee was below the 150th option and was removed, it would also be removed from the top of the list as well. This is because both options had the same id (because they were for the same user), and CompactSelect hides the options whose ids appear below the 150th option. 

The solution is to filter out the duplicate from the members list and only show it in the top "suggested" section, thus preventing it from being removed if it's duplicate would have been below the 150th element 