### PR TITLE
feat(seer grouping): Add `SeerSimilarIssuesMetadata` class

### DIFF
--- a/src/sentry/seer/utils.py
+++ b/src/sentry/seer/utils.py
@@ -133,7 +133,6 @@ class SeerSimilarIssueData:
     message_distance: float
     should_group: bool
     parent_group_id: int
-    similarity_model_version: str = SEER_SIMILARITY_MODEL_VERSION
     # TODO: See if we end up needing the hash here
     parent_hash: str | None = None
 
@@ -201,6 +200,13 @@ class SeerSimilarIssueData:
             }
 
         return cls(**similar_issue_data)
+
+
+@dataclass
+class SeerSimilarIssuesMetadata:
+    request_hash: str
+    results: list[SeerSimilarIssueData]
+    similarity_model_version: str = SEER_SIMILARITY_MODEL_VERSION
 
 
 class CreateGroupingRecordData(TypedDict):


### PR DESCRIPTION
This adds a new dataclass, `SeerSimilarIssuesMetadata`, to represent the metadata we're going to store on events and groups when we get results back from Seer. I considered making it a typeddict (and converting the `SeerSimilarIssueData` class to one while I was at it, so that everything would just be dicts), but it ended up being simpler to stick with dataclasses for now, as it turns out that `asdict` works recursively - calling it on a `SeerSimilarIssuesMetadata` instance runs it on the `SeerSimilarIssueData` instances it wraps as well.