### PR TITLE
build(sdk): Bump Python SDK to 2.2.0

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -67,7 +67,7 @@ sentry-kafka-schemas>=0.1.81
 sentry-ophio==0.2.7
 sentry-redis-tools>=0.1.7
 sentry-relay>=0.8.64
-sentry-sdk==2.1.1
+sentry-sdk>=2.2.0
 snuba-sdk>=2.0.33
 simplejson>=3.17.6
 sqlparse>=0.4.4

--- a/requirements-dev-frozen.txt
+++ b/requirements-dev-frozen.txt
@@ -184,7 +184,7 @@ sentry-kafka-schemas==0.1.81
 sentry-ophio==0.2.7
 sentry-redis-tools==0.1.7
 sentry-relay==0.8.64
-sentry-sdk==2.1.1
+sentry-sdk==2.2.0
 sentry-usage-accountant==0.0.10
 simplejson==3.17.6
 six==1.16.0

--- a/requirements-frozen.txt
+++ b/requirements-frozen.txt
@@ -124,7 +124,7 @@ sentry-kafka-schemas==0.1.81
 sentry-ophio==0.2.7
 sentry-redis-tools==0.1.7
 sentry-relay==0.8.64
-sentry-sdk==2.1.1
+sentry-sdk==2.2.0
 sentry-usage-accountant==0.0.10
 simplejson==3.17.6
 six==1.16.0


### PR DESCRIPTION
2.2.0 introduces a fix that may help fix some broken traces we have been noticing in Sentry.
