### PR TITLE
ref(insights): remove outdated starfish.panel.open in favor of new analytics

### DIFF
--- a/static/app/utils/analytics/starfishAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/starfishAnalyticsEvents.tsx
@@ -12,7 +12,6 @@ export type StarfishEventParameters = {
   'starfish.pageview': {
     route: string;
   };
-  'starfish.panel.open': {};
   'starfish.request': {
     duration: number;
     statusCode?: string;
@@ -44,7 +43,6 @@ export type StarfishEventKey = keyof StarfishEventParameters;
 export const starfishEventMap: Record<keyof StarfishEventParameters, string> = {
   'starfish.chart.zoom': 'Starfish: Chart Zoomed',
   'starfish.pageview': 'Starfish: Page Viewed',
-  'starfish.panel.open': 'Starfish: Slide Over Panel Opened',
   'starfish.request': 'Starfish: API Request Completed',
   'starfish.samples.loaded': 'Starfish: Samples Loaded',
   'starfish.web_service_view.endpoint_list.endpoint.clicked':

--- a/static/app/views/performance/mobile/components/spanSamplesPanel.tsx
+++ b/static/app/views/performance/mobile/components/spanSamplesPanel.tsx
@@ -63,7 +63,6 @@ export function SpanSamplesPanel({
 
   const onOpenDetailPanel = useCallback(() => {
     if (query.transaction) {
-      trackAnalytics('starfish.panel.open', {organization});
       trackAnalytics('performance_views.sample_spans.opened', {
         organization,
         source: moduleName,

--- a/static/app/views/starfish/views/spanSummaryPage/sampleList/index.tsx
+++ b/static/app/views/starfish/views/spanSummaryPage/sampleList/index.tsx
@@ -78,7 +78,6 @@ export function SampleList({
 
   const onOpenDetailPanel = useCallback(() => {
     if (query.transaction) {
-      trackAnalytics('starfish.panel.open', {organization});
       trackAnalytics('performance_views.sample_spans.opened', {
         organization,
         source: moduleName,


### PR DESCRIPTION
Removes `starfish.panel.open` which we no longer use in favor of `performance_views.sample_spans.opened`.