### PR TITLE
feat(query-builder): Add sections and descriptions to search key flyout

### DIFF
--- a/static/app/components/searchQueryBuilder/combobox.tsx
+++ b/static/app/components/searchQueryBuilder/combobox.tsx
@@ -29,6 +29,7 @@ type SearchQueryBuilderComboboxProps = {
   token: TokenResult<Token>;
   autoFocus?: boolean;
   filterValue?: string;
+  maxOptions?: number;
   onExit?: () => void;
   onInputChange?: React.ChangeEventHandler<HTMLInputElement>;
   onKeyDown?: (e: React.KeyboardEvent<HTMLInputElement>) => void;
@@ -50,6 +51,7 @@ export function SearchQueryBuilderCombobox({
   onInputChange,
   autoFocus,
   tabIndex = -1,
+  maxOptions,
 }: SearchQueryBuilderComboboxProps) {
   const theme = useTheme();
   const listBoxRef = useRef<HTMLUListElement>(null);
@@ -57,8 +59,8 @@ export function SearchQueryBuilderCombobox({
   const popoverRef = useRef<HTMLDivElement>(null);
 
   const hiddenOptions = useMemo(() => {
-    return getHiddenOptions(items, filterValue, 10);
-  }, [items, filterValue]);
+    return getHiddenOptions(items, filterValue, maxOptions);
+  }, [items, filterValue, maxOptions]);
 
   const disabledKeys = useMemo(
     () => [...getDisabledOptions(items), ...hiddenOptions].map(getEscapedKey),
@@ -171,7 +173,7 @@ export function SearchQueryBuilderCombobox({
         zIndex={theme.zIndex?.tooltip}
         visible={isOpen}
       >
-        <Overlay ref={popoverRef}>
+        <StyledOverlay ref={popoverRef}>
           <ListBox
             {...listBoxProps}
             ref={listBoxRef}
@@ -182,7 +184,7 @@ export function SearchQueryBuilderCombobox({
             overlayIsOpen={isOpen}
             size="md"
           />
-        </Overlay>
+        </StyledOverlay>
       </StyledPositionWrapper>
     </Wrapper>
   );
@@ -219,4 +221,9 @@ const StyledPositionWrapper = styled(PositionWrapper, {
 })<{visible?: boolean}>`
   min-width: 100%;
   display: ${p => (p.visible ? 'block' : 'none')};
+`;
+
+const StyledOverlay = styled(Overlay)`
+  max-height: 400px;
+  overflow-y: auto;
 `;

--- a/static/app/components/searchQueryBuilder/index.spec.tsx
+++ b/static/app/components/searchQueryBuilder/index.spec.tsx
@@ -150,11 +150,34 @@ describe('SearchQueryBuilder', function () {
   });
 
   describe('new search tokens', function () {
+    it('breaks keys into sections', async function () {
+      render(<SearchQueryBuilder {...defaultProps} />);
+      await userEvent.click(screen.getByRole('combobox', {name: 'Add a search term'}));
+
+      const menu = screen.getByRole('listbox');
+      const groups = within(menu).getAllByRole('group');
+      expect(groups).toHaveLength(2);
+
+      // First group (Field) should have age, assigned, browser.name
+      const group1 = groups[0];
+      expect(within(group1).getByRole('option', {name: 'age'})).toBeInTheDocument();
+      expect(within(group1).getByRole('option', {name: 'assigned'})).toBeInTheDocument();
+      expect(
+        within(group1).getByRole('option', {name: 'browser.name'})
+      ).toBeInTheDocument();
+
+      // Second group (Tag) should have custom_tag_name
+      const group2 = groups[1];
+      expect(
+        within(group2).getByRole('option', {name: 'custom_tag_name'})
+      ).toBeInTheDocument();
+    });
+
     it('can add a new token by clicking a key suggestion', async function () {
       render(<SearchQueryBuilder {...defaultProps} />);
 
       await userEvent.click(screen.getByRole('combobox', {name: 'Add a search term'}));
-      await userEvent.click(screen.getByRole('option', {name: 'Browser Name'}));
+      await userEvent.click(screen.getByRole('option', {name: 'browser.name'}));
 
       // New token should be added with the correct key
       expect(screen.getByRole('row', {name: 'browser.name:'})).toBeInTheDocument();
@@ -187,7 +210,7 @@ describe('SearchQueryBuilder', function () {
       // function which causes an act warning despite using userEvent.click.
       // Cannot find a way to avoid this warning.
       jest.spyOn(console, 'error').mockImplementation(jest.fn());
-      await userEvent.click(screen.getByRole('option', {name: 'Browser Name'}));
+      await userEvent.click(screen.getByRole('option', {name: 'browser.name'}));
       jest.restoreAllMocks();
 
       // Should have a free text token "some free text"

--- a/static/app/components/searchQueryBuilder/input.tsx
+++ b/static/app/components/searchQueryBuilder/input.tsx
@@ -1,4 +1,4 @@
-import {useCallback, useMemo, useRef, useState} from 'react';
+import {Fragment, useCallback, useMemo, useRef, useState} from 'react';
 import styled from '@emotion/styled';
 import {getFocusableTreeWalker} from '@react-aria/focus';
 import {mergeProps} from '@react-aria/utils';
@@ -6,7 +6,8 @@ import {Item, Section} from '@react-stately/collections';
 import type {ListState} from '@react-stately/list';
 import type {Node} from '@react-types/shared';
 
-import {getItemsWithKeys} from 'sentry/components/compactSelect/utils';
+import type {SelectOptionWithKey} from 'sentry/components/compactSelect/types';
+import {getEscapedKey} from 'sentry/components/compactSelect/utils';
 import {SearchQueryBuilderCombobox} from 'sentry/components/searchQueryBuilder/combobox';
 import {useSearchQueryBuilder} from 'sentry/components/searchQueryBuilder/context';
 import {useQueryBuilderGridItem} from 'sentry/components/searchQueryBuilder/useQueryBuilderGridItem';
@@ -17,6 +18,8 @@ import type {
 } from 'sentry/components/searchSyntax/parser';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
+import type {Tag} from 'sentry/types';
+import {toTitleCase} from 'sentry/utils';
 import {FieldKind, getFieldDefinition} from 'sentry/utils/fields';
 
 type SearchQueryBuilderInputProps = {
@@ -29,6 +32,8 @@ type SearchQueryBuilderInputInternalProps = {
   tabIndex: number;
   token: TokenResult<Token.FREE_TEXT> | TokenResult<Token.SPACES>;
 };
+
+const PROMOTED_SECTIONS = [FieldKind.FIELD];
 
 function getWordAtCursorPosition(value: string, cursorPosition: number) {
   const words = value.split(' ');
@@ -72,6 +77,70 @@ function replaceFocusedWordWithFilter(
   return value;
 }
 
+function getItemsBySection(allKeys: Tag[]) {
+  const itemsBySection = allKeys.reduce<{
+    [section: string]: Array<SelectOptionWithKey<string>>;
+  }>((acc, tag) => {
+    const fieldDefinition = getFieldDefinition(tag.key);
+
+    const section = tag.kind ?? fieldDefinition?.kind ?? t('other');
+    const item = {
+      label: tag.key,
+      key: getEscapedKey(tag.key),
+      value: tag.key,
+      textValue: tag.key,
+      hideCheck: true,
+      showDetailsInOverlay: true,
+      details: fieldDefinition?.desc ? <KeyDescription tag={tag} /> : null,
+    };
+
+    if (acc[section]) {
+      acc[section].push(item);
+    } else {
+      acc[section] = [item];
+    }
+
+    return acc;
+  }, {});
+
+  return [
+    ...PROMOTED_SECTIONS.filter(section => section in itemsBySection).map(section => {
+      return {
+        title: section,
+        children: itemsBySection[section],
+      };
+    }),
+    ...Object.entries(itemsBySection)
+      .filter(([section]) => !PROMOTED_SECTIONS.includes(section as FieldKind))
+      .map(([section, children]) => {
+        return {title: section, children};
+      }),
+  ];
+}
+
+function KeyDescription({tag}: {tag: Tag}) {
+  const fieldDefinition = getFieldDefinition(tag.key);
+
+  if (!fieldDefinition || !fieldDefinition.desc) {
+    return null;
+  }
+
+  return (
+    <DescriptionWrapper>
+      <div>{fieldDefinition.desc}</div>
+      <Separator />
+      <DescriptionList>
+        {fieldDefinition.valueType ? (
+          <Fragment>
+            <Term>{t('Type')}</Term>
+            <Details>{toTitleCase(fieldDefinition.valueType)}</Details>
+          </Fragment>
+        ) : null}
+      </DescriptionList>
+    </DescriptionWrapper>
+  );
+}
+
 function SearchQueryBuilderInputInternal({
   token,
   tabIndex,
@@ -91,23 +160,10 @@ function SearchQueryBuilderInputInternal({
   const {keys, dispatch} = useSearchQueryBuilder();
 
   const allKeys = useMemo(() => {
-    return Object.values(keys);
+    return Object.values(keys).sort((a, b) => a.key.localeCompare(b.key));
   }, [keys]);
-
-  const items = useMemo(() => {
-    return getItemsWithKeys(
-      allKeys.map(tag => {
-        const fieldDefinition = getFieldDefinition(tag.key);
-
-        return {
-          label: fieldDefinition?.kind === FieldKind.FIELD ? tag.name : tag.key,
-          value: tag.key,
-          textValue: tag.key,
-          hideCheck: true,
-        };
-      })
-    );
-  }, [allKeys]);
+  const sections = useMemo(() => getItemsBySection(allKeys), [allKeys]);
+  const items = useMemo(() => sections.flatMap(section => section.children), [sections]);
 
   // When token value changes, reset the input value
   const [prevValue, setPrevValue] = useState(inputValue);
@@ -149,14 +205,17 @@ function SearchQueryBuilderInputInternal({
         }
       }}
       tabIndex={tabIndex}
+      maxOptions={100}
     >
-      <Section>
-        {items.map(item => (
-          <Item {...item} key={item.key}>
-            {item.label}
-          </Item>
-        ))}
-      </Section>
+      {sections.map(({title, children}) => (
+        <Section title={title} key={title}>
+          {children.map(item => (
+            <Item {...item} key={item.key}>
+              {item.label}
+            </Item>
+          ))}
+        </Section>
+      ))}
     </SearchQueryBuilderCombobox>
   );
 }
@@ -212,3 +271,27 @@ const GridCell = styled('div')`
     min-width: 9px;
   }
 `;
+
+const DescriptionWrapper = styled('div')`
+  padding: ${space(1)} ${space(1.5)};
+  max-width: 220px;
+`;
+
+const Separator = styled('hr')`
+  border-top: 1px solid ${p => p.theme.border};
+  margin: ${space(1)} 0;
+`;
+
+const DescriptionList = styled('dl')`
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  gap: ${space(1.5)};
+  margin: 0;
+`;
+
+const Term = styled('dt')`
+  color: ${p => p.theme.subText};
+  font-weight: normal;
+`;
+
+const Details = styled('dd')``;


### PR DESCRIPTION
- Breaks keys into sections based on the FieldKind. In the future we will want more descriptive sections.
- Adds description overlay to the keys when highlighted
- Uses the raw key value instead of the formatted name
 
Before:

![CleanShot 2024-05-16 at 08 04 33](https://github.com/getsentry/sentry/assets/10888943/d15f189f-729f-4715-a786-ba238ad8ca2b)

After:

![CleanShot 2024-05-16 at 08 05 01](https://github.com/getsentry/sentry/assets/10888943/10395669-944b-475d-9750-aeeec35cc5ac)
