### PR TITLE
feat(new-trace): Fixing stack trace width.

### DIFF
--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/error.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/error.tsx
@@ -136,7 +136,7 @@ export function ErrorNodeDetails({
   ) : null;
 }
 
-const StackTraceWrapper = styled('td')`
+const StackTraceWrapper = styled('div')`
   .traceback {
     margin-bottom: 0;
     border: 0;


### PR DESCRIPTION
Before:
<img width="1292" alt="Screenshot 2024-05-16 at 1 24 54 PM" src="https://github.com/getsentry/sentry/assets/60121741/38e59c70-17f9-460f-b10a-c5bcfdd78832">

After:
<img width="1284" alt="Screenshot 2024-05-16 at 1 25 38 PM" src="https://github.com/getsentry/sentry/assets/60121741/86488ddb-f06e-4533-87e4-c08315709851">
