### PR TITLE
chore(pr-comments): generalization for triggering merged PR comments workflow

### DIFF
--- a/src/sentry/integrations/github/client.py
+++ b/src/sentry/integrations/github/client.py
@@ -224,6 +224,25 @@ class GitHubClientMixin(GithubProxyClient):
         """
         return self.get_cached(f"/repos/{repo}/commits/{sha}")
 
+    def get_merge_commit_sha_from_commit(self, repo: str, sha: str) -> str | None:
+        """
+        Get the merge commit sha from a commit sha.
+        """
+        response = self.get_pullrequest_from_commit(repo, sha)
+        if not isinstance(response, list) or len(response) != 1:
+            # the response should return a single merged PR, return if multiple
+            if len(response) > 1:
+                return None
+
+        if response[0]["state"] == "open":
+            metrics.incr(
+                "github_pr_comment.queue_comment_check.open_pr",
+                sample_rate=1.0,
+            )
+            return None
+
+        return response[0].get("merge_commit_sha")
+
     def get_pullrequest_from_commit(self, repo: str, sha: str) -> Any:
         """
         https://docs.github.com/en/rest/commits/commits#list-pull-requests-associated-with-a-commit

--- a/src/sentry/integrations/github/client.py
+++ b/src/sentry/integrations/github/client.py
@@ -233,7 +233,7 @@ class GitHubClientMixin(GithubProxyClient):
             # the response should return a single merged PR, return if multiple
             return None
 
-        pull_request = response[0]
+        (pull_request,) = response
         if pull_request["state"] == "open":
             metrics.incr(
                 "github_pr_comment.queue_comment_check.open_pr",

--- a/src/sentry/integrations/github/client.py
+++ b/src/sentry/integrations/github/client.py
@@ -229,19 +229,19 @@ class GitHubClientMixin(GithubProxyClient):
         Get the merge commit sha from a commit sha.
         """
         response = self.get_pullrequest_from_commit(repo, sha)
-        if not isinstance(response, list) or len(response) != 1:
+        if not response or isinstance(response, list) or len(response) != 1:
             # the response should return a single merged PR, return if multiple
-            if len(response) > 1:
-                return None
+            return None
 
-        if response[0]["state"] == "open":
+        pull_request = response[0]
+        if pull_request["state"] == "open":
             metrics.incr(
                 "github_pr_comment.queue_comment_check.open_pr",
                 sample_rate=1.0,
             )
             return None
 
-        return response[0].get("merge_commit_sha")
+        return pull_request.get("merge_commit_sha")
 
     def get_pullrequest_from_commit(self, repo: str, sha: str) -> Any:
         """

--- a/src/sentry/integrations/github/client.py
+++ b/src/sentry/integrations/github/client.py
@@ -229,7 +229,7 @@ class GitHubClientMixin(GithubProxyClient):
         Get the merge commit sha from a commit sha.
         """
         response = self.get_pullrequest_from_commit(repo, sha)
-        if not response or isinstance(response, list) or len(response) != 1:
+        if not response or (isinstance(response, list) and len(response) != 1):
             # the response should return a single merged PR, return if multiple
             return None
 


### PR DESCRIPTION
If we want to be able to have merged PR comments for SCMs other than GitHub, we'll need to generalize some of the flows. In this PR I generalize the flow to trigger the merged PR comments workflow.

1. Check if the repo for the suspect commit has a provider that supports merged PR comments
2. Move the custom logic needed to fetch the merge commit sha from the commit sha into the GitHub client, this can be repeated for other SCMs. We use this to find the PR associated with the merge commit sha in our db.

In a follow up PR, I will generalize the workflow itself.