### PR TITLE
ref(rules): Log after zadd

### DIFF
--- a/src/sentry/buffer/redis.py
+++ b/src/sentry/buffer/redis.py
@@ -250,7 +250,10 @@ class RedisBuffer(Buffer):
     def push_to_sorted_set(self, key: str, value: list[int] | int) -> None:
         value_dict = {value: time()}
         self._execute_redis_operation(key, RedisOperation.SORTED_SET_ADD, value_dict)
-        logger.info("redis_buffer.push_to_sorted_set", extra={"key_name": key, "value": value})
+        logger.info(
+            "redis_buffer.push_to_sorted_set",
+            extra={"key_name": key, "value": json.dumps(value_dict)},
+        )
 
     def get_sorted_set(self, key: str, min: float, max: float) -> list[tuple[int, datetime]]:
         redis_set = self._execute_redis_operation(

--- a/src/sentry/buffer/redis.py
+++ b/src/sentry/buffer/redis.py
@@ -248,7 +248,9 @@ class RedisBuffer(Buffer):
         return pipe.execute()[0]
 
     def push_to_sorted_set(self, key: str, value: list[int] | int) -> None:
-        self._execute_redis_operation(key, RedisOperation.SORTED_SET_ADD, {value: time()})
+        value_dict = {value: time()}
+        self._execute_redis_operation(key, RedisOperation.SORTED_SET_ADD, value_dict)
+        logger.info("redis_buffer.push_to_sorted_set", extra={"key_name": key, "value": value})
 
     def get_sorted_set(self, key: str, min: float, max: float) -> list[tuple[int, datetime]]:
         redis_set = self._execute_redis_operation(


### PR DESCRIPTION
Add a log to confirm we're writing project ids to Redis with the data we expect.