### PR TITLE
Revert "ref(perf): Hide user misery chart in transaction summary page"

### DIFF
--- a/static/app/views/performance/transactionSummary/transactionOverview/charts.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/charts.tsx
@@ -174,16 +174,6 @@ function TransactionSummaryCharts({
     organization
   );
 
-  const hasTransactionSummaryCleanupFlag = organization.features.includes(
-    'performance-transaction-summary-cleanup'
-  );
-
-  const displayOptions = generateDisplayOptions(currentFilter).filter(
-    option =>
-      (hasTransactionSummaryCleanupFlag && option.value !== DisplayModes.USER_MISERY) ||
-      !hasTransactionSummaryCleanupFlag
-  );
-
   return (
     <Panel>
       <ChartContainer data-test-id="transaction-summary-charts">
@@ -301,7 +291,7 @@ function TransactionSummaryCharts({
           <OptionSelector
             title={t('Display')}
             selected={display}
-            options={displayOptions}
+            options={generateDisplayOptions(currentFilter)}
             onChange={handleDisplayChange}
           />
         </InlineContainer>

--- a/static/app/views/performance/transactionSummary/transactionOverview/userStats.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/userStats.tsx
@@ -44,10 +44,6 @@ function UserStats({
   transactionName,
   eventView,
 }: Props) {
-  const hasTransactionSummaryCleanupFlag = organization.features.includes(
-    'performance-transaction-summary-cleanup'
-  );
-
   let userMisery = error !== null ? <div>{'\u2014'}</div> : <Placeholder height="34px" />;
 
   if (!isLoading && error === null && totals) {
@@ -121,22 +117,17 @@ function UserStats({
           <SidebarSpacer />
         </Fragment>
       )}
-      {!hasTransactionSummaryCleanupFlag && (
-        <Fragment>
-          <GuideAnchor target="user_misery" position="left">
-            <SectionHeading>
-              {t('User Misery')}
-              <QuestionTooltip
-                position="top"
-                title={getTermHelp(organization, PerformanceTerm.USER_MISERY)}
-                size="sm"
-              />
-            </SectionHeading>
-          </GuideAnchor>
-          {userMisery}
-        </Fragment>
-      )}
-
+      <GuideAnchor target="user_misery" position="left">
+        <SectionHeading>
+          {t('User Misery')}
+          <QuestionTooltip
+            position="top"
+            title={getTermHelp(organization, PerformanceTerm.USER_MISERY)}
+            size="sm"
+          />
+        </SectionHeading>
+      </GuideAnchor>
+      {userMisery}
       <SidebarSpacer />
     </Fragment>
   );


### PR DESCRIPTION
Reverts getsentry/sentry#68210

We no longer need to hide this