### PR TITLE
fix(insights): Fetch trace in mobile span sample panels

### DIFF
--- a/static/app/views/starfish/views/spanSummaryPage/sampleList/sampleTable/sampleTable.tsx
+++ b/static/app/views/starfish/views/spanSummaryPage/sampleList/sampleTable/sampleTable.tsx
@@ -17,7 +17,7 @@ import type {SpanSample} from 'sentry/views/starfish/queries/useSpanSamples';
 import {useSpanSamples} from 'sentry/views/starfish/queries/useSpanSamples';
 import {useTransactions} from 'sentry/views/starfish/queries/useTransactions';
 import type {ModuleName, SpanMetricsQueryFilters} from 'sentry/views/starfish/types';
-import {SpanMetricsField} from 'sentry/views/starfish/types';
+import {SpanIndexedField, SpanMetricsField} from 'sentry/views/starfish/types';
 
 const {SPAN_SELF_TIME, SPAN_OP} = SpanMetricsField;
 
@@ -96,7 +96,7 @@ function SampleTable({
     transactionMethod,
     release,
     query,
-    additionalFields,
+    additionalFields: [...(additionalFields ?? []), SpanIndexedField.TRACE],
   });
 
   const {


### PR DESCRIPTION
This query for sample data wasn't fetching the trade ID so it was undefined when linked out. Patching this by adding `trace` to the additional fields for now but in the future we should rework this component to use the `useSpanSamples` hook used in other modules.