### PR TITLE
fix(span-samples-query) Adding trace as column for samples query.

### DIFF
--- a/src/sentry/api/endpoints/organization_events_meta.py
+++ b/src/sentry/api/endpoints/organization_events_meta.py
@@ -134,6 +134,7 @@ class OrganizationSpansSamplesEndpoint(OrganizationEventsEndpointBase):
             "timestamp",
             "span_id",
             "profile_id",
+            "trace",
         ]
 
         if lower_bound is None or upper_bound is None:


### PR DESCRIPTION
Frontend already expects `trace` in the response. 