### PR TITLE
feat(chartcuterie): Updated Function Regression Chart Styling

### DIFF
--- a/static/app/chartcuterie/performance.tsx
+++ b/static/app/chartcuterie/performance.tsx
@@ -1,3 +1,4 @@
+import Grid from 'sentry/components/charts/components/grid';
 import type {LineChartProps} from 'sentry/components/charts/lineChart';
 import {transformToLineSeries} from 'sentry/components/charts/lineChart';
 import getBreakpointChartOptionsFromData, {
@@ -18,6 +19,11 @@ export type FunctionRegressionPercentileData = {
   data: EventsStatsSeries<'p95()'>;
 };
 
+const performanceChartDefaults = {
+  ...slackChartDefaults,
+  grid: Grid({left: 10, right: 5, bottom: 5}),
+};
+
 function modifyOptionsForSlack(options: Omit<LineChartProps, 'series'>) {
   options.legend = options.legend || {};
   options.legend.icon = 'none';
@@ -27,16 +33,19 @@ function modifyOptionsForSlack(options: Omit<LineChartProps, 'series'>) {
 
   options.yAxis = options.yAxis || {};
   options.yAxis.axisLabel = options.yAxis.axisLabel || {};
+  options.yAxis.axisLabel.fontSize = 11;
   options.yAxis.axisLabel.fontFamily = DEFAULT_FONT_FAMILY;
 
   options.xAxis = options.xAxis || {};
   options.xAxis.axisLabel = options.xAxis.axisLabel || {};
+  options.xAxis.axisLabel.fontSize = 11;
   options.xAxis.axisLabel.fontFamily = DEFAULT_FONT_FAMILY;
 
   return {
     ...options,
-    grid: slackChartDefaults.grid,
+    grid: performanceChartDefaults.grid,
     visualMap: options.options?.visualMap,
+    backgroundColor: theme.background,
   };
 }
 type FunctionRegressionChartData = {
@@ -57,11 +66,7 @@ performanceCharts.push({
 
     return {
       ...modifiedOptions,
-
-      backgroundColor: theme.background,
       series: transformedSeries,
-      grid: slackChartDefaults.grid,
-      visualMap: modifiedOptions.options?.visualMap,
     };
   },
   ...slackChartSize,
@@ -95,11 +100,7 @@ performanceCharts.push({
 
     return {
       ...modifiedOptions,
-
-      backgroundColor: theme.background,
       series: transformedSeries,
-      grid: slackChartDefaults.grid,
-      visualMap: modifiedOptions.options?.visualMap,
     };
   },
   ...slackChartSize,

--- a/static/app/views/performance/utils/getIntervalLine.tsx
+++ b/static/app/views/performance/utils/getIntervalLine.tsx
@@ -161,7 +161,7 @@ export function getIntervalLine(
       formatter: `Baseline ${getPerformanceDuration(
         transformedTransaction.aggregate_range_1
       )}`,
-      position: 'insideStartBottom',
+      position: 'insideStartTop',
     };
 
     periodDividingLine.markLine.lineStyle = {
@@ -179,7 +179,7 @@ export function getIntervalLine(
       formatter: `Regressed ${getPerformanceDuration(
         transformedTransaction.aggregate_range_2
       )}`,
-      position: 'insideEndBottom',
+      position: 'insideEndTop',
       color: theme.gray400,
     };
 


### PR DESCRIPTION
I am updating the Chart Styling for Function Regression issues. I made two changes:

First thing is I am moving the labels so they start above the line so they don't fall over the x-axis:

Before:
<img width="1196" alt="image" src="https://github.com/getsentry/sentry/assets/33237075/f54d334f-0f86-492e-b39c-106623915797">

After:
<img width="1196" alt="image" src="https://github.com/getsentry/sentry/assets/33237075/6fdcd578-f9f4-419a-9746-7b698f81f065">


Second is for Charcuterie, I am thinking that the default font size is too large, which is making the y-axis spill over to the edge of the image. I also increased the margin we leave for the grid on the left side to see if that helps.

How it looks locally:
![example5](https://github.com/getsentry/sentry/assets/33237075/6f0249c3-76d4-4e5f-b9e7-7f529a7a855e)

