### PR TITLE
perf: move tests/sentry_plugins to use orjson

### DIFF
--- a/tests/sentry_plugins/asana/test_plugin.py
+++ b/tests/sentry_plugins/asana/test_plugin.py
@@ -1,5 +1,6 @@
 from functools import cached_property
 
+import orjson
 import pytest
 import responses
 from django.contrib.auth.models import AnonymousUser
@@ -7,7 +8,6 @@ from django.test import RequestFactory
 
 from sentry.exceptions import PluginError
 from sentry.testutils.cases import PluginTestCase
-from sentry.utils import json
 from sentry_plugins.asana.plugin import AsanaPlugin
 
 
@@ -65,7 +65,7 @@ class AsanaPluginTest(PluginTestCase):
 
         assert self.plugin.create_issue(request, group, form_data) == 1
         request = responses.calls[0].request
-        payload = json.loads(request.body)
+        payload = orjson.loads(request.body)
         assert payload == {"data": {"notes": "Fix this.", "name": "Hello", "workspace": "12345678"}}
 
     @responses.activate
@@ -119,5 +119,5 @@ class AsanaPluginTest(PluginTestCase):
 
         assert self.plugin.link_issue(request, group, form_data) == {"title": "Hello"}
         request = responses.calls[-1].request
-        payload = json.loads(request.body)
+        payload = orjson.loads(request.body)
         assert payload == {"data": {"text": "please fix this"}}

--- a/tests/sentry_plugins/github/test_plugin.py
+++ b/tests/sentry_plugins/github/test_plugin.py
@@ -1,5 +1,6 @@
 from functools import cached_property
 
+import orjson
 import pytest
 import responses
 from django.contrib.auth.models import AnonymousUser
@@ -7,7 +8,6 @@ from django.test import RequestFactory
 
 from sentry.exceptions import PluginError
 from sentry.testutils.cases import PluginTestCase
-from sentry.utils import json
 from sentry_plugins.github.plugin import GitHubPlugin
 
 
@@ -66,7 +66,7 @@ class GitHubPluginTest(PluginTestCase):
         assert self.plugin.create_issue(request, group, form_data) == 1
         request = responses.calls[0].request
         assert request.headers["Authorization"] == "Bearer foo"
-        payload = json.loads(request.body)
+        payload = orjson.loads(request.body)
         assert payload == {"title": "Hello", "body": "Fix this.", "assignee": None}
 
     @responses.activate
@@ -100,5 +100,5 @@ class GitHubPluginTest(PluginTestCase):
         assert self.plugin.link_issue(request, group, form_data) == {"title": "Hello world"}
         request = responses.calls[-1].request
         assert request.headers["Authorization"] == "Bearer foo"
-        payload = json.loads(request.body)
+        payload = orjson.loads(request.body)
         assert payload == {"body": "Hello"}

--- a/tests/sentry_plugins/github/test_provider.py
+++ b/tests/sentry_plugins/github/test_provider.py
@@ -1,6 +1,7 @@
 from functools import cached_property
 from unittest.mock import patch
 
+import orjson
 import responses
 
 from sentry.models.integrations.organization_integration import OrganizationIntegration
@@ -8,7 +9,6 @@ from sentry.models.repository import Repository
 from sentry.silo.base import SiloMode
 from sentry.testutils.cases import TestCase
 from sentry.testutils.silo import assume_test_silo_mode
-from sentry.utils import json
 from sentry_plugins.github.client import GithubPluginAppsClient, GithubPluginClient
 from sentry_plugins.github.plugin import GitHubAppsRepositoryProvider, GitHubRepositoryProvider
 from sentry_plugins.github.testutils import (
@@ -27,7 +27,7 @@ class GitHubPluginTest(TestCase):
     def test_compare_commits(self):
         repo = Repository.objects.create(provider="github", name="example", organization_id=1)
 
-        res = self.provider._format_commits(repo, json.loads(COMPARE_COMMITS_EXAMPLE)["commits"])
+        res = self.provider._format_commits(repo, orjson.loads(COMPARE_COMMITS_EXAMPLE)["commits"])
 
         assert res == [
             {
@@ -42,7 +42,7 @@ class GitHubPluginTest(TestCase):
     def test_get_last_commits(self):
         repo = Repository.objects.create(provider="github", name="example", organization_id=1)
 
-        res = self.provider._format_commits(repo, json.loads(GET_LAST_COMMITS_EXAMPLE)[:10])
+        res = self.provider._format_commits(repo, orjson.loads(GET_LAST_COMMITS_EXAMPLE)[:10])
 
         assert res == [
             {
@@ -80,7 +80,7 @@ class GitHubPluginTest(TestCase):
         }
 
         request = responses.calls[-1].request
-        req_json = json.loads(request.body)
+        req_json = orjson.loads(request.body)
         assert req_json == {
             "active": True,
             "config": {
@@ -178,12 +178,12 @@ class GitHubAppsProviderTest(TestCase):
     @patch.object(
         GithubPluginAppsClient,
         "get_repositories",
-        return_value=json.loads(INSTALLATION_REPOSITORIES_API_RESPONSE),
+        return_value=orjson.loads(INSTALLATION_REPOSITORIES_API_RESPONSE),
     )
     @patch.object(
         GithubPluginClient,
         "get_installations",
-        return_value=json.loads(LIST_INSTALLATION_API_RESPONSE),
+        return_value=orjson.loads(LIST_INSTALLATION_API_RESPONSE),
     )
     def test_link_auth(self, *args):
         user = self.create_user()

--- a/tests/sentry_plugins/gitlab/test_plugin.py
+++ b/tests/sentry_plugins/gitlab/test_plugin.py
@@ -1,11 +1,11 @@
 from functools import cached_property
 
+import orjson
 import responses
 from django.test import RequestFactory
 from django.urls import reverse
 
 from sentry.testutils.cases import PluginTestCase
-from sentry.utils import json
 from sentry_plugins.gitlab.plugin import GitLabPlugin
 
 
@@ -67,7 +67,7 @@ class GitLabPluginTest(PluginTestCase):
 
         assert self.plugin.create_issue(request, group, form_data) == 1
         request = responses.calls[0].request
-        payload = json.loads(request.body)
+        payload = orjson.loads(request.body)
         assert payload == {
             "title": "Hello",
             "description": "Fix this.",
@@ -101,7 +101,7 @@ class GitLabPluginTest(PluginTestCase):
 
         assert self.plugin.link_issue(request, group, form_data) == {"title": "Hello world"}
         request = responses.calls[-1].request
-        payload = json.loads(request.body)
+        payload = orjson.loads(request.body)
         assert payload == {"body": "Hello"}
 
     def test_no_secrets(self):
@@ -117,7 +117,7 @@ class GitLabPluginTest(PluginTestCase):
             "sentry-api-0-project-plugin-details", args=[self.org.slug, self.project.slug, "gitlab"]
         )
         res = self.client.get(url)
-        config = json.loads(res.content)["config"]
+        config = orjson.loads(res.content)["config"]
         token_config = [item for item in config if item["name"] == "gitlab_token"][0]
         assert token_config.get("type") == "secret"
         assert token_config.get("value") is None

--- a/tests/sentry_plugins/heroku/test_plugin.py
+++ b/tests/sentry_plugins/heroku/test_plugin.py
@@ -4,6 +4,7 @@ from datetime import timedelta
 from typing import Any
 from unittest.mock import Mock, patch
 
+import orjson
 import pytest
 from django.utils import timezone
 
@@ -17,7 +18,6 @@ from sentry.models.releasecommit import ReleaseCommit
 from sentry.models.releaseheadcommit import ReleaseHeadCommit
 from sentry.models.repository import Repository
 from sentry.testutils.cases import TestCase
-from sentry.utils import json
 from sentry_plugins.heroku.plugin import HerokuReleaseHook
 
 
@@ -146,7 +146,7 @@ class HookHandleTest(TestCase):
             },
             "action": "update",
         }
-        req.body = json.dumps(body).encode()
+        req.body = orjson.dumps(body)
         hook.handle(req)
         assert Release.objects.filter(version=body["data"]["slug"]["commit"]).exists()
         assert set_refs_mock.call_count == 1
@@ -167,7 +167,7 @@ class HookHandleTest(TestCase):
             },
             "action": "create",
         }
-        req.body = json.dumps(body).encode()
+        req.body = orjson.dumps(body)
         hook.handle(req)
         assert not Release.objects.filter(version=body["data"]["slug"]["commit"]).exists()
         assert set_refs_mock.call_count == 0
@@ -188,7 +188,7 @@ class HookHandleTest(TestCase):
             },
             "action": "update",
         }
-        req.body = json.dumps(body).encode()
+        req.body = orjson.dumps(body)
         hook.handle(req)
         assert Release.objects.filter(version=body["data"]["slug"]["commit"]).exists()
         assert set_refs_mock.call_count == 1
@@ -208,7 +208,7 @@ class HookHandleTest(TestCase):
             },
             "action": "update",
         }
-        req.body = json.dumps(body).encode()
+        req.body = orjson.dumps(body)
         hook.handle(req)
         assert Release.objects.filter(version=body["data"]["slug"]["commit"]).exists()
 
@@ -226,6 +226,6 @@ class HookHandleTest(TestCase):
             },
             "action": "update",
         }
-        req.body = json.dumps(body).encode()
+        req.body = orjson.dumps(body)
         with pytest.raises(HookValidationError):
             hook.handle(req)

--- a/tests/sentry_plugins/jira/test_plugin.py
+++ b/tests/sentry_plugins/jira/test_plugin.py
@@ -3,13 +3,13 @@ from __future__ import annotations
 from functools import cached_property
 from typing import Any
 
+import orjson
 import responses
 from django.contrib.auth.models import AnonymousUser
 from django.test import RequestFactory
 from django.urls import reverse
 
 from sentry.testutils.cases import TestCase
-from sentry.utils import json
 from sentry_plugins.jira.plugin import JiraPlugin
 
 create_meta_response = {
@@ -273,7 +273,7 @@ class JiraPluginTest(TestCase):
             "sentry-api-0-project-plugin-details", args=[self.org.slug, self.project.slug, "jira"]
         )
         res = self.client.get(url)
-        config = json.loads(res.content)["config"]
+        config = orjson.loads(res.content)["config"]
         password_config = [item for item in config if item["name"] == "password"][0]
         assert password_config.get("type") == "secret"
         assert password_config.get("value") is None

--- a/tests/sentry_plugins/opgsenie/test_plugin.py
+++ b/tests/sentry_plugins/opgsenie/test_plugin.py
@@ -1,11 +1,11 @@
 from functools import cached_property
 
+import orjson
 import responses
 
 from sentry.models.rule import Rule
 from sentry.plugins.base import Notification
 from sentry.testutils.cases import PluginTestCase
-from sentry.utils import json
 from sentry_plugins.opsgenie.plugin import OpsGeniePlugin
 
 
@@ -54,7 +54,7 @@ class OpsGeniePluginTest(PluginTestCase):
             self.plugin.notify(notification)
 
         request = responses.calls[0].request
-        payload = json.loads(request.body)
+        payload = orjson.loads(request.body)
         group_id = str(group.id)
         assert payload == {
             "recipients": "me",

--- a/tests/sentry_plugins/pagerduty/test_plugin.py
+++ b/tests/sentry_plugins/pagerduty/test_plugin.py
@@ -1,12 +1,12 @@
 from functools import cached_property
 
+import orjson
 import responses
 from django.urls import reverse
 
 from sentry.models.rule import Rule
 from sentry.plugins.base import Notification
 from sentry.testutils.cases import PluginTestCase
-from sentry.utils import json
 from sentry_plugins.pagerduty.plugin import PagerDutyPlugin
 
 INVALID_METHOD = (
@@ -70,7 +70,7 @@ class PagerDutyPluginTest(PluginTestCase):
             self.plugin.notify(notification)
 
         request = responses.calls[0].request
-        payload = json.loads(request.body)
+        payload = orjson.loads(request.body)
         assert payload == {
             "client_url": "http://example.com",
             "event_type": "trigger",
@@ -109,7 +109,7 @@ class PagerDutyPluginTest(PluginTestCase):
             args=[self.org.slug, self.project.slug, "pagerduty"],
         )
         res = self.client.get(url)
-        config = json.loads(res.content)["config"]
+        config = orjson.loads(res.content)["config"]
         key_config = [item for item in config if item["name"] == "service_key"][0]
         assert key_config.get("type") == "secret"
         assert key_config.get("value") is None

--- a/tests/sentry_plugins/pivotal/test_pivotal_plugin.py
+++ b/tests/sentry_plugins/pivotal/test_pivotal_plugin.py
@@ -1,9 +1,9 @@
 from functools import cached_property
 
+import orjson
 from django.urls import reverse
 
 from sentry.testutils.cases import PluginTestCase
-from sentry.utils import json
 from sentry_plugins.pivotal.plugin import PivotalPlugin
 
 
@@ -44,7 +44,7 @@ class PivotalPluginTest(PluginTestCase):
             args=[self.org.slug, self.project.slug, "pivotal"],
         )
         res = self.client.get(url)
-        config = json.loads(res.content)["config"]
+        config = orjson.loads(res.content)["config"]
         token_config = [item for item in config if item["name"] == "token"][0]
         assert token_config.get("type") == "secret"
         assert token_config.get("value") is None

--- a/tests/sentry_plugins/pushover/test_plugin.py
+++ b/tests/sentry_plugins/pushover/test_plugin.py
@@ -1,13 +1,13 @@
 from functools import cached_property
 from urllib.parse import parse_qs
 
+import orjson
 import responses
 from django.urls import reverse
 
 from sentry.models.rule import Rule
 from sentry.plugins.base import Notification
 from sentry.testutils.cases import PluginTestCase
-from sentry.utils import json
 from sentry_plugins.pushover.plugin import PushoverPlugin
 
 SUCCESS = """{"status":1,"request":"e460545a8b333d0da2f3602aff3133d6"}"""
@@ -117,7 +117,7 @@ class PushoverPluginTest(PluginTestCase):
             args=[self.org.slug, self.project.slug, "pushover"],
         )
         res = self.client.get(url)
-        config = json.loads(res.content)["config"]
+        config = orjson.loads(res.content)["config"]
         userkey_config = [item for item in config if item["name"] == "userkey"][0]
         apikey_config = [item for item in config if item["name"] == "apikey"][0]
         assert userkey_config.get("type") == "secret"

--- a/tests/sentry_plugins/segment/test_plugin.py
+++ b/tests/sentry_plugins/segment/test_plugin.py
@@ -1,9 +1,9 @@
 from functools import cached_property
 
+import orjson
 import responses
 
 from sentry.testutils.cases import PluginTestCase
-from sentry.utils import json
 from sentry_plugins.segment.plugin import SegmentPlugin
 
 
@@ -39,7 +39,7 @@ class SegmentPluginTest(PluginTestCase):
             self.plugin.post_process(event)
 
         request = responses.calls[0].request
-        payload = json.loads(request.body)
+        payload = orjson.loads(request.body)
         assert {
             "userId": "1",
             "event": "Error Captured",

--- a/tests/sentry_plugins/slack/test_plugin.py
+++ b/tests/sentry_plugins/slack/test_plugin.py
@@ -1,6 +1,7 @@
 from functools import cached_property
 from urllib.parse import parse_qs
 
+import orjson
 import pytest
 import responses
 
@@ -9,7 +10,6 @@ from sentry.models.rule import Rule
 from sentry.plugins.base import Notification
 from sentry.shared_integrations.exceptions import ApiError
 from sentry.testutils.cases import PluginTestCase
-from sentry.utils import json
 from sentry_plugins.slack.plugin import SlackPlugin
 
 
@@ -43,7 +43,7 @@ class SlackPluginTest(PluginTestCase):
         self.plugin.notify(notification)
 
         request = responses.calls[0].request
-        payload = json.loads(parse_qs(request.body)["payload"][0])
+        payload = orjson.loads(parse_qs(request.body)["payload"][0])
         assert payload == {
             "username": "Sentry",
             "attachments": [
@@ -79,7 +79,7 @@ class SlackPluginTest(PluginTestCase):
         self.plugin.notify(notification)
 
         request = responses.calls[0].request
-        payload = json.loads(parse_qs(request.body)["payload"][0])
+        payload = orjson.loads(parse_qs(request.body)["payload"][0])
         assert payload == {
             "username": "Sentry",
             "attachments": [
@@ -113,7 +113,7 @@ class SlackPluginTest(PluginTestCase):
         self.plugin.notify(notification)
 
         request = responses.calls[0].request
-        payload = json.loads(parse_qs(request.body)["payload"][0])
+        payload = orjson.loads(parse_qs(request.body)["payload"][0])
         assert payload == {
             "username": "Sentry",
             "attachments": [

--- a/tests/sentry_plugins/splunk/test_plugin.py
+++ b/tests/sentry_plugins/splunk/test_plugin.py
@@ -1,11 +1,11 @@
 from functools import cached_property
 
+import orjson
 import pytest
 import responses
 
 from sentry.shared_integrations.exceptions import ApiError
 from sentry.testutils.cases import PluginTestCase
-from sentry.utils import json
 from sentry_plugins.splunk.plugin import SplunkPlugin
 
 
@@ -35,7 +35,7 @@ class SplunkPluginTest(PluginTestCase):
             self.plugin.post_process(event)
 
         request = responses.calls[0].request
-        payload = json.loads(request.body)
+        payload = orjson.loads(request.body)
         assert payload == self.plugin.get_event_payload(event)
         headers = request.headers
         assert headers["Authorization"] == "Splunk 12345678-1234-1234-1234-1234567890AB"

--- a/tests/sentry_plugins/trello/test_plugin.py
+++ b/tests/sentry_plugins/trello/test_plugin.py
@@ -1,11 +1,11 @@
 from functools import cached_property
 from urllib.parse import parse_qsl, urlparse
 
+import orjson
 import responses
 from django.test import RequestFactory
 
 from sentry.testutils.cases import PluginTestCase
-from sentry.utils import json
 from sentry_plugins.trello.plugin import TrelloPlugin
 
 
@@ -136,7 +136,7 @@ class TrelloPluginApiTests(TrelloPluginTestBase):
         assert self.plugin.create_issue(request, self.group, form_data) == "rds43"
         responses_request = responses.calls[0].request
         assert responses_request.url == "https://api.trello.com/1/cards?token=7c8951d1&key=39g"
-        payload = json.loads(responses_request.body)
+        payload = orjson.loads(responses_request.body)
         assert payload == {"name": "Hello", "desc": "Fix this.", "idList": "23tds"}
 
     @responses.activate

--- a/tests/sentry_plugins/victorops/test_plugin.py
+++ b/tests/sentry_plugins/victorops/test_plugin.py
@@ -1,12 +1,12 @@
 from functools import cached_property
 
+import orjson
 import responses
 
 from sentry.interfaces.base import Interface
 from sentry.models.rule import Rule
 from sentry.plugins.base import Notification
 from sentry.testutils.cases import PluginTestCase
-from sentry.utils import json
 from sentry_plugins.victorops.plugin import VictorOpsPlugin
 
 SUCCESS = """{
@@ -78,7 +78,7 @@ class VictorOpsPluginTest(PluginTestCase):
         self.plugin.notify(notification)
 
         request = responses.calls[0].request
-        payload = json.loads(request.body)
+        payload = orjson.loads(request.body)
         assert {
             "message_type": "WARNING",
             "entity_id": group.id,


### PR DESCRIPTION
Part of `orjson` move to get rid of `sentry.utils.json`