### PR TITLE
perf: move interfaces and integrations to orjson

### DIFF
--- a/src/sentry/shared_integrations/client/base.py
+++ b/src/sentry/shared_integrations/client/base.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from collections.abc import Callable, Mapping, Sequence
 from typing import Any, Literal, Self, Union, overload
 
+import orjson
 import sentry_sdk
 from django.core.cache import cache
 from requests import PreparedRequest, Request, Response
@@ -19,7 +20,7 @@ from sentry.models.integrations.utils import is_response_error, is_response_succ
 from sentry.net.http import SafeSession
 from sentry.services.hybrid_cloud.integration import integration_service
 from sentry.services.hybrid_cloud.organization import organization_service
-from sentry.utils import json, metrics
+from sentry.utils import metrics
 from sentry.utils.audit import create_system_audit_entry
 from sentry.utils.hashlib import md5_text
 
@@ -332,7 +333,7 @@ class BaseApiClient(TrackResponseMixin):
         data = kwargs.get("data", None)
         query = ""
         if kwargs.get("params", None):
-            query = json.dumps(kwargs.get("params"))
+            query = orjson.dumps(kwargs.get("params")).decode()
 
         key = self.get_cache_key(path, query, data)
         result: BaseApiResponseX | None = self.check_cache(key)

--- a/src/sentry/shared_integrations/exceptions/__init__.py
+++ b/src/sentry/shared_integrations/exceptions/__init__.py
@@ -5,12 +5,11 @@ from collections.abc import Mapping
 from typing import Any, Protocol
 from urllib.parse import urlparse
 
+import orjson
 from bs4 import BeautifulSoup
 from requests import Response
 from requests.adapters import RetryError
 from requests.exceptions import RequestException
-
-from sentry.utils import json
 
 __all__ = (
     "ApiConnectionResetError",
@@ -53,8 +52,8 @@ class ApiError(Exception):
         # TODO(dcramer): pull in XML support from Jira
         if text:
             try:
-                self.json = json.loads(text)
-            except (json.JSONDecodeError, ValueError):
+                self.json = orjson.loads(text)
+            except orjson.JSONDecodeError:
                 if self.text[:5] == "<?xml":
                     # perhaps it's XML?
                     self.xml = BeautifulSoup(self.text, "xml")

--- a/src/sentry/shared_integrations/response/base.py
+++ b/src/sentry/shared_integrations/response/base.py
@@ -3,12 +3,12 @@ from __future__ import annotations
 from collections.abc import Mapping
 from typing import Any
 
+import orjson
 import requests
 from django.utils.functional import cached_property
 from requests import Response
 
 from sentry.shared_integrations.exceptions import UnsupportedResponseType
-from sentry.utils import json
 
 
 class BaseApiResponse:
@@ -77,8 +77,8 @@ class BaseApiResponse:
         # to decode it anyways
         if "application/json" not in response.headers.get("Content-Type", ""):
             try:
-                data = json.loads(response.text)
-            except (TypeError, ValueError):
+                data = orjson.loads(response.text)
+            except orjson.JSONDecodeError:
                 if allow_text:
                     return TextApiResponse(response.text, response.headers, response.status_code)
                 raise UnsupportedResponseType(
@@ -87,7 +87,7 @@ class BaseApiResponse:
         elif response.text == "":
             return TextApiResponse(response.text, response.headers, response.status_code)
         else:
-            data = json.loads(response.text)
+            data = orjson.loads(response.text)
 
         if isinstance(data, dict):
             return MappingApiResponse(data, response.headers, response.status_code)

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -17,6 +17,7 @@ from urllib.parse import urlencode
 from uuid import uuid4
 from zlib import compress
 
+import orjson
 import pytest
 import requests
 import responses
@@ -135,7 +136,6 @@ from sentry.testutils.helpers.notifications import TEST_ISSUE_OCCURRENCE
 from sentry.testutils.helpers.slack import install_slack
 from sentry.testutils.pytest.selenium import Browser
 from sentry.types.condition_activity import ConditionActivity, ConditionActivityType
-from sentry.utils import json
 from sentry.utils.auth import SsoSession
 from sentry.utils.json import dumps_htmlsafe
 from sentry.utils.performance_issues.performance_detection import detect_performance_problems
@@ -726,7 +726,7 @@ class APITestCase(BaseTestCase, BaseAPITestCase):
         if raw_data and isinstance(raw_data, bytes):
             raw_data = raw_data.decode("utf-8")
         if raw_data and isinstance(raw_data, str):
-            raw_data = json.loads(raw_data)
+            raw_data = orjson.loads(raw_data)
         data = raw_data or params
         method = params.pop("method", self.method).lower()
 
@@ -1167,7 +1167,7 @@ class AcceptanceTestCase(TransactionTestCase):
             res = self.client.put(
                 "/api/0/assistant/",
                 content_type="application/json",
-                data=json.dumps({"guide": item, "status": "viewed", "useful": True}),
+                data=orjson.dumps({"guide": item, "status": "viewed", "useful": True}).decode(),
             )
             assert res.status_code == 201, res.content
 
@@ -1245,7 +1245,7 @@ class SnubaTestCase(BaseTestCase):
 
     @classmethod
     def snuba_update_config(cls, config_vals):
-        return _snuba_pool.request("POST", "/config.json", body=json.dumps(config_vals))
+        return _snuba_pool.request("POST", "/config.json", body=orjson.dumps(config_vals).decode())
 
     def init_snuba(self):
         self.snuba_eventstream = SnubaEventStream()
@@ -1335,7 +1335,7 @@ class SnubaTestCase(BaseTestCase):
             _snuba_pool.urlopen(
                 "POST",
                 "/tests/entities/groupedmessage/insert",
-                body=json.dumps(data),
+                body=orjson.dumps(data).decode(),
                 headers={},
             ).status
             == 200
@@ -1345,7 +1345,8 @@ class SnubaTestCase(BaseTestCase):
         data = [self.__wrap_group(group)]
         assert (
             requests.post(
-                settings.SENTRY_SNUBA + "/tests/entities/outcomes/insert", data=json.dumps(data)
+                settings.SENTRY_SNUBA + "/tests/entities/outcomes/insert",
+                data=orjson.dumps(data),
             ).status_code
             == 200
         )
@@ -1353,7 +1354,8 @@ class SnubaTestCase(BaseTestCase):
     def store_span(self, span):
         assert (
             requests.post(
-                settings.SENTRY_SNUBA + "/tests/entities/spans/insert", data=json.dumps([span])
+                settings.SENTRY_SNUBA + "/tests/entities/spans/insert",
+                data=orjson.dumps([span]),
             ).status_code
             == 200
         )
@@ -1361,7 +1363,8 @@ class SnubaTestCase(BaseTestCase):
     def store_spans(self, spans):
         assert (
             requests.post(
-                settings.SENTRY_SNUBA + "/tests/entities/spans/insert", data=json.dumps(spans)
+                settings.SENTRY_SNUBA + "/tests/entities/spans/insert",
+                data=orjson.dumps(spans),
             ).status_code
             == 200
         )
@@ -1398,7 +1401,7 @@ class SnubaTestCase(BaseTestCase):
         assert (
             requests.post(
                 settings.SENTRY_SNUBA + "/tests/entities/metrics_summaries/insert",
-                data=json.dumps(rows),
+                data=orjson.dumps(rows),
             ).status_code
             == 200
         )
@@ -1466,7 +1469,8 @@ class SnubaTestCase(BaseTestCase):
 
         assert (
             requests.post(
-                settings.SENTRY_SNUBA + "/tests/entities/events/insert", data=json.dumps(events)
+                settings.SENTRY_SNUBA + "/tests/entities/events/insert",
+                data=orjson.dumps(events),
             ).status_code
             == 200
         )
@@ -1788,7 +1792,7 @@ class BaseMetricsTestCase(SnubaTestCase):
         assert (
             requests.post(
                 settings.SENTRY_SNUBA + cls.snuba_endpoint.format(entity=entity),
-                data=json.dumps(buckets),
+                data=orjson.dumps(buckets),
             ).status_code
             == 200
         )
@@ -2309,7 +2313,8 @@ class OutcomesSnubaTest(TestCase):
 
         assert (
             requests.post(
-                settings.SENTRY_SNUBA + "/tests/entities/outcomes/insert", data=json.dumps(outcomes)
+                settings.SENTRY_SNUBA + "/tests/entities/outcomes/insert",
+                data=orjson.dumps(outcomes),
             ).status_code
             == 200
         )

--- a/src/sentry/testutils/helpers/backups.py
+++ b/src/sentry/testutils/helpers/backups.py
@@ -10,6 +10,7 @@ from typing import Any
 from unittest.mock import MagicMock
 from uuid import uuid4
 
+import orjson
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
@@ -102,7 +103,6 @@ from sentry.testutils.cases import TransactionTestCase
 from sentry.testutils.factories import get_fixture_path
 from sentry.testutils.silo import assume_test_silo_mode
 from sentry.types.token import AuthTokenType
-from sentry.utils import json
 
 __all__ = [
     "export_to_file",
@@ -153,8 +153,8 @@ def export_to_file(path: Path, scope: ExportScope, filter_by: set[str] | None = 
         else:
             raise AssertionError(f"Unknown `ExportScope`: `{scope.name}`")
 
-    with open(json_file_path) as tmp_file:
-        output = json.load(tmp_file)
+    with open(json_file_path, "rb") as tmp_file:
+        output = orjson.loads(tmp_file.read())
     return output
 
 
@@ -224,7 +224,7 @@ def export_to_encrypted_tarball(
     # part of the encrypt/decrypt tar-ing API, so we need to ensure that these exact names are
     # present and contain the data we expect.
     with open(tar_file_path, "rb") as f:
-        return json.loads(
+        return orjson.loads(
             decrypt_encrypted_tarball(f, LocalFileDecryptor.from_bytes(private_key_pem))
         )
 
@@ -682,32 +682,40 @@ class BackupTestCase(TransactionTestCase):
 
     @cached_property
     def _json_of_exhaustive_user_with_maximum_privileges(self) -> Any:
-        with open(get_fixture_path("backup", "user-with-maximum-privileges.json")) as backup_file:
-            return json.load(backup_file)
+        with open(
+            get_fixture_path("backup", "user-with-maximum-privileges.json"), "rb"
+        ) as backup_file:
+            return orjson.loads(backup_file.read())
 
     def json_of_exhaustive_user_with_maximum_privileges(self) -> Any:
         return deepcopy(self._json_of_exhaustive_user_with_maximum_privileges)
 
     @cached_property
     def _json_of_exhaustive_user_with_minimum_privileges(self) -> Any:
-        with open(get_fixture_path("backup", "user-with-minimum-privileges.json")) as backup_file:
-            return json.load(backup_file)
+        with open(
+            get_fixture_path("backup", "user-with-minimum-privileges.json"), "rb"
+        ) as backup_file:
+            return orjson.loads(backup_file.read())
 
     def json_of_exhaustive_user_with_minimum_privileges(self) -> Any:
         return deepcopy(self._json_of_exhaustive_user_with_minimum_privileges)
 
     @cached_property
     def _json_of_exhaustive_user_with_roles_no_superadmin(self) -> Any:
-        with open(get_fixture_path("backup", "user-with-roles-no-superadmin.json")) as backup_file:
-            return json.load(backup_file)
+        with open(
+            get_fixture_path("backup", "user-with-roles-no-superadmin.json"), "rb"
+        ) as backup_file:
+            return orjson.loads(backup_file.read())
 
     def json_of_exhaustive_user_with_roles_no_superadmin(self) -> Any:
         return deepcopy(self._json_of_exhaustive_user_with_roles_no_superadmin)
 
     @cached_property
     def _json_of_exhaustive_user_with_superadmin_no_roles(self) -> Any:
-        with open(get_fixture_path("backup", "user-with-superadmin-no-roles.json")) as backup_file:
-            return json.load(backup_file)
+        with open(
+            get_fixture_path("backup", "user-with-superadmin-no-roles.json"), "rb"
+        ) as backup_file:
+            return orjson.loads(backup_file.read())
 
     def json_of_exhaustive_user_with_superadmin_no_roles(self) -> Any:
         return deepcopy(self._json_of_exhaustive_user_with_superadmin_no_roles)
@@ -759,5 +767,5 @@ class BackupTestCase(TransactionTestCase):
         """
 
         data = self.generate_tmp_users_json()
-        with open(tmp_path, "w+") as tmp_file:
-            json.dump(data, tmp_file)
+        with open(tmp_path, "wb+") as tmp_file:
+            tmp_file.write(orjson.dumps(data))

--- a/src/sentry/testutils/helpers/slack.py
+++ b/src/sentry/testutils/helpers/slack.py
@@ -1,5 +1,6 @@
 from urllib.parse import parse_qs, quote
 
+import orjson
 import responses
 
 from sentry.integrations.slack.message_builder import SlackBody
@@ -13,7 +14,6 @@ from sentry.models.user import User
 from sentry.silo.base import SiloMode
 from sentry.testutils.silo import assume_test_silo_mode
 from sentry.types.integrations import EXTERNAL_PROVIDERS, ExternalProviders
-from sentry.utils import json
 
 
 def get_response_text(data: SlackBody) -> str:
@@ -95,7 +95,7 @@ def get_channel(index=0):
     assert len(responses.calls) >= 1
     data = parse_qs(responses.calls[index].request.body)
     assert "channel" in data
-    channel = json.loads(data["channel"][0])
+    channel = orjson.loads(data["channel"][0])
 
     return channel
 
@@ -105,7 +105,7 @@ def get_attachment(index=0):
     data = parse_qs(responses.calls[index].request.body)
     assert "text" in data
     assert "attachments" in data
-    attachments = json.loads(data["attachments"][0])
+    attachments = orjson.loads(data["attachments"][0])
 
     assert len(attachments) == 1
     return attachments[0], data["text"][0]
@@ -115,7 +115,7 @@ def get_attachment_no_text():
     assert len(responses.calls) >= 1
     data = parse_qs(responses.calls[0].request.body)
     assert "attachments" in data
-    attachments = json.loads(data["attachments"][0])
+    attachments = orjson.loads(data["attachments"][0])
     assert len(attachments) == 1
     return attachments[0]
 
@@ -125,7 +125,7 @@ def get_blocks_and_fallback_text(index=0):
     data = parse_qs(responses.calls[index].request.body)
     assert "blocks" in data
     assert "text" in data
-    blocks = json.loads(data["blocks"][0])
+    blocks = orjson.loads(data["blocks"][0])
     fallback_text = data["text"][0]
     return blocks, fallback_text
 
@@ -137,8 +137,8 @@ def get_block_kit_preview_url(index=0) -> str:
     assert data["blocks"][0]
 
     stringified_blocks = data["blocks"][0]
-    blocks = json.loads(data["blocks"][0])
-    stringified_blocks = json.dumps({"blocks": blocks})
+    blocks = orjson.loads(data["blocks"][0])
+    stringified_blocks = orjson.dumps({"blocks": blocks}).decode()
 
     encoded_blocks = quote(stringified_blocks)
     base_url = "https://app.slack.com/block-kit-builder/#"

--- a/src/sentry/testutils/performance_issues/event_generators.py
+++ b/src/sentry/testutils/performance_issues/event_generators.py
@@ -4,8 +4,9 @@ import os
 from copy import deepcopy
 from typing import Any
 
+import orjson
+
 from sentry.testutils.factories import get_fixture_path
-from sentry.utils import json
 
 from .span_builder import SpanBuilder
 
@@ -27,8 +28,8 @@ for (dirpath, dirnames, filenames) in os.walk(_fixture_path):
 
         [full_event_name, _] = relative_path.split(".")
 
-        with open(filepath) as f:
-            event = json.load(f)
+        with open(filepath, "rb") as f:
+            event = orjson.loads(f.read())
             event["project"] = PROJECT_ID
 
         EVENTS[full_event_name] = event

--- a/src/sentry/utils/assets.py
+++ b/src/sentry/utils/assets.py
@@ -2,19 +2,18 @@ from __future__ import annotations
 
 import os.path
 
+import orjson
 from cachetools.func import ttl_cache
 from django.conf import settings
-
-from sentry.utils import json
 
 
 @ttl_cache(ttl=60)
 def _frontend_versions() -> dict[str, str]:
     try:
         with open(
-            os.path.join(settings.CONF_DIR, "settings", "frontend", "frontend-versions.json")
+            os.path.join(settings.CONF_DIR, "settings", "frontend", "frontend-versions.json"), "rb"
         ) as f:
-            return json.load(f)  # getsentry path
+            return orjson.loads(f.read())  # getsentry path
     except OSError:
         return {}  # common case for self-hosted
 

--- a/src/sentry/utils/codecs.py
+++ b/src/sentry/utils/codecs.py
@@ -2,9 +2,8 @@ import zlib
 from abc import ABC, abstractmethod
 from typing import Any, Generic, TypeVar
 
+import orjson
 import zstandard
-
-from sentry.utils import json
 
 T = TypeVar("T")
 
@@ -71,10 +70,10 @@ class JSONCodec(Codec[Any, str]):
     """
 
     def encode(self, value: Any) -> str:
-        return str(json.dumps(value))
+        return orjson.dumps(value).decode()
 
     def decode(self, value: str) -> Any:
-        return json.loads(value)
+        return orjson.loads(value)
 
 
 class ZlibCodec(Codec[bytes, bytes]):

--- a/src/sentry/utils/email/message_builder.py
+++ b/src/sentry/utils/email/message_builder.py
@@ -10,6 +10,7 @@ from random import randrange
 from typing import Any
 
 import lxml.html
+import orjson
 import toronado
 from django.core.mail import EmailMultiAlternatives
 from django.utils.encoding import force_str
@@ -22,7 +23,7 @@ from sentry.models.group import Group
 from sentry.models.groupemailthread import GroupEmailThread
 from sentry.models.project import Project
 from sentry.silo.base import SiloMode
-from sentry.utils import json, metrics
+from sentry.utils import metrics
 from sentry.utils.safe import safe_execute
 from sentry.web.helpers import render_to_string
 
@@ -116,7 +117,7 @@ class MessageBuilder:
         # If a "type" is specified, add it to the headers to categorize the emails if not already set
         if type is not None and "X-SMTPAPI" not in self.headers:
             self.headers = {
-                "X-SMTPAPI": json.dumps({"category": type}),
+                "X-SMTPAPI": orjson.dumps({"category": type}).decode(),
                 **(self.headers),
             }
 

--- a/src/sentry/utils/env.py
+++ b/src/sentry/utils/env.py
@@ -2,11 +2,10 @@ import logging
 import os
 import sys
 
+import orjson
 import requests
 from django.conf import settings
 from google.auth import default
-
-from sentry.utils import json
 
 
 def in_test_environment() -> bool:
@@ -34,8 +33,8 @@ def gcp_project_id() -> str:
     except requests.exceptions.RequestException:
         adc_path = os.environ.get("GOOGLE_APPLICATION_CREDENTIALS", "")
         if adc_path:
-            with open(adc_path) as fp:
-                adc = json.load(fp)
+            with open(adc_path, "rb") as fp:
+                adc = orjson.loads(fp.read())
                 if adc.get("quota_project_id") is not None:
                     return adc.get("quota_project_id")
 
@@ -50,8 +49,8 @@ def log_gcp_credentials_details(logger: logging.Logger) -> None:
     # Checking GOOGLE_APPLICATION_CREDENTIALS environment variable
     adc_path = os.environ.get("GOOGLE_APPLICATION_CREDENTIALS", "")
     if adc_path:
-        with open(adc_path) as fp:
-            adc = json.load(fp)
+        with open(adc_path, "rb") as fp:
+            adc = orjson.loads(fp.read())
 
             logger.info(
                 "gcp.credentials.file_found",

--- a/src/sentry/utils/outcomes.py
+++ b/src/sentry/utils/outcomes.py
@@ -4,9 +4,11 @@ import time
 from datetime import datetime
 from enum import IntEnum
 
+import orjson
+
 from sentry.conf.types.kafka_definition import Topic
 from sentry.constants import DataCategory
-from sentry.utils import json, kafka_config, metrics
+from sentry.utils import kafka_config, metrics
 from sentry.utils.dates import to_datetime
 from sentry.utils.pubsub import KafkaPublisher
 
@@ -105,7 +107,7 @@ def track_outcome(
     # Send a snuba metrics payload.
     publisher.publish(
         topic_name,
-        json.dumps(
+        orjson.dumps(
             {
                 "timestamp": timestamp,
                 "org_id": org_id,
@@ -117,7 +119,7 @@ def track_outcome(
                 "category": category,
                 "quantity": quantity,
             }
-        ),
+        ).decode(),
     )
 
     metrics.incr(

--- a/src/sentry/utils/samples.py
+++ b/src/sentry/utils/samples.py
@@ -5,13 +5,13 @@ import time
 from datetime import datetime, timedelta, timezone
 from uuid import uuid4
 
+import orjson
 from django.core.exceptions import SuspiciousFileOperation
 
 from sentry.constants import DATA_ROOT, INTEGRATION_ID_TO_PLATFORM_DATA
 from sentry.event_manager import EventManager, set_tag
 from sentry.interfaces.user import User as UserInterface
 from sentry.spans.grouping.utils import hash_values
-from sentry.utils import json
 from sentry.utils.canonical import CanonicalKeyDict
 
 logger = logging.getLogger(__name__)
@@ -170,8 +170,8 @@ def load_data(
         # XXX: At this point, it's assumed that `json_path` was safely found
         # within `samples_root` due to the checks above and cannot traverse
         # into paths.
-        with open(json_path) as fp:
-            data = json.load(fp)
+        with open(json_path, "rb") as fp:
+            data = orjson.loads(fp.read())
             break
 
     if data is None:

--- a/src/social_auth/backends/__init__.py
+++ b/src/social_auth/backends/__init__.py
@@ -18,6 +18,7 @@ from urllib.error import HTTPError
 from urllib.parse import urlencode
 from urllib.request import Request
 
+import orjson
 import requests
 from django.conf import settings
 from django.contrib.auth import authenticate, load_backend
@@ -25,7 +26,6 @@ from django.utils.crypto import constant_time_compare, get_random_string
 from requests_oauthlib import OAuth1
 
 from sentry.services.hybrid_cloud.user.service import user_service
-from sentry.utils import json
 from sentry.utils.http import absolute_uri
 from social_auth.exceptions import (
     AuthCanceled,
@@ -631,7 +631,7 @@ class BaseOAuth2(OAuthAuth):
         )
 
         try:
-            response = json.loads(dsa_urlopen(request).read())
+            response = orjson.loads(dsa_urlopen(request).read())
         except HTTPError as e:
             logger.exception(
                 "plugins.auth.error",

--- a/src/social_auth/backends/bitbucket.py
+++ b/src/social_auth/backends/bitbucket.py
@@ -10,8 +10,8 @@ By default username, email, token expiration time, first name and last name are
 stored in extra_data field, check OAuthBackend class for details on how to
 extend it.
 """
+import orjson
 
-from sentry.utils import json
 from social_auth.backends import BaseOAuth1, OAuthBackend
 from social_auth.utils import dsa_urlopen
 
@@ -88,7 +88,7 @@ class BitbucketAuth(BaseOAuth1):
             email = None
 
             # Then retrieve the user's primary email address or the top email
-            email_addresses = json.loads(response)
+            email_addresses = orjson.loads(response)
             for email_address in reversed(email_addresses):
                 if email_address["active"]:
                     email = email_address["email"]
@@ -101,7 +101,7 @@ class BitbucketAuth(BaseOAuth1):
             # Then return the user data using a normal GET with the
             # BITBUCKET_USER_DATA_URL and the user's email
             response = dsa_urlopen(BITBUCKET_USER_DATA_URL + email)
-            user_details = json.load(response)["user"]
+            user_details = orjson.loads(response.read())["user"]
             user_details["email"] = email
             return user_details
         except ValueError:

--- a/src/social_auth/backends/github.py
+++ b/src/social_auth/backends/github.py
@@ -14,9 +14,9 @@ field, check OAuthBackend class for details on how to extend it.
 from urllib.error import HTTPError
 from urllib.request import Request
 
+import orjson
 from django.conf import settings
 
-from sentry.utils import json
 from social_auth.backends import BaseOAuth2, OAuthBackend
 from social_auth.exceptions import AuthFailed
 from social_auth.utils import dsa_urlopen
@@ -46,7 +46,7 @@ class GithubBackend(OAuthBackend):
         )
 
         try:
-            data = json.load(dsa_urlopen(req))
+            data = orjson.loads(dsa_urlopen(req).read())
         except (ValueError, HTTPError):
             data = []
         return data
@@ -93,7 +93,7 @@ class GithubAuth(BaseOAuth2):
         req = Request(GITHUB_USER_DATA_URL, headers={"Authorization": "token %s" % access_token})
 
         try:
-            data = json.load(dsa_urlopen(req))
+            data = orjson.loads(dsa_urlopen(req).read())
         except ValueError:
             data = None
 

--- a/src/social_auth/fields.py
+++ b/src/social_auth/fields.py
@@ -1,9 +1,9 @@
+import orjson
 from django.core.exceptions import ValidationError
 from django.db.models import TextField
 from django.utils.encoding import smart_str
 
 from sentry.db.models.utils import Creator
-from sentry.utils import json
 
 
 class JSONField(TextField):
@@ -28,8 +28,8 @@ class JSONField(TextField):
             return None
         if isinstance(value, str):
             try:
-                return json.loads(value)
-            except Exception as e:
+                return orjson.loads(value)
+            except orjson.JSONDecodeError as e:
                 raise ValidationError(str(e))
         else:
             return value
@@ -40,15 +40,15 @@ class JSONField(TextField):
         if isinstance(value, str):
             super().validate(value, model_instance)
             try:
-                json.loads(value)
-            except Exception as e:
+                orjson.loads(value)
+            except orjson.JSONDecodeError as e:
                 raise ValidationError(str(e))
 
-    def get_prep_value(self, value):
+    def get_prep_value(self, value) -> str:
         """Convert value to JSON string before save"""
         try:
-            return json.dumps(value)
-        except Exception as e:
+            return orjson.dumps(value).decode()
+        except orjson.JSONEncodeError as e:
             raise ValidationError(str(e))
 
     def value_to_string(self, obj):

--- a/tests/acceptance/conftest.py
+++ b/tests/acceptance/conftest.py
@@ -3,7 +3,7 @@ import subprocess
 import sys
 import time
 
-from sentry.utils import json
+import orjson
 
 
 def pytest_configure(config):
@@ -21,8 +21,8 @@ def pytest_configure(config):
         return
 
     try:
-        with open("./.webpack.meta") as f:
-            data = json.load(f)
+        with open("./.webpack.meta", "rb") as f:
+            data = orjson.loads(f.read())
 
             # If built within last hour, do not build again
             last_built = int(time.time()) - data["built"]

--- a/tests/acceptance/test_organization_security_privacy.py
+++ b/tests/acceptance/test_organization_security_privacy.py
@@ -1,6 +1,7 @@
+import orjson
+
 from sentry.testutils.cases import AcceptanceTestCase
 from sentry.testutils.silo import no_silo_test
-from sentry.utils import json
 
 
 @no_silo_test
@@ -54,7 +55,7 @@ class OrganizationSecurityAndPrivacyTest(AcceptanceTestCase):
         self.load_organization_helper()
 
     def test_renders_advanced_data_scrubbing_with_rules(self):
-        relayPiiConfig = json.dumps(
+        relayPiiConfig = orjson.dumps(
             {
                 "rules": {
                     "0": {
@@ -65,7 +66,7 @@ class OrganizationSecurityAndPrivacyTest(AcceptanceTestCase):
                 },
                 "applications": {"password": ["0"], "$message": ["1"]},
             }
-        )
+        ).decode()
         self.org.update_option("sentry:relay_pii_config", relayPiiConfig)
         self.browser.get(self.path)
         self.browser.wait_until_not('[data-test-id="loading-indicator"]')

--- a/tests/acceptance/test_performance_issues.py
+++ b/tests/acceptance/test_performance_issues.py
@@ -4,6 +4,8 @@ from datetime import timedelta
 from unittest import mock
 from unittest.mock import patch
 
+import orjson
+
 from fixtures.page_objects.issue_details import IssueDetailsPage
 from sentry import options
 from sentry.issues.grouptype import (
@@ -16,7 +18,6 @@ from sentry.models.group import Group
 from sentry.testutils.cases import AcceptanceTestCase, PerformanceIssueTestCase, SnubaTestCase
 from sentry.testutils.helpers.datetime import before_now
 from sentry.testutils.silo import no_silo_test
-from sentry.utils import json
 
 
 @no_silo_test
@@ -38,7 +39,7 @@ class PerformanceIssuesTest(AcceptanceTestCase, SnubaTestCase, PerformanceIssueT
         self.dismiss_assistant()
 
     def create_sample_event(self, fixture, start_timestamp):
-        event = json.loads(self.load_fixture(f"events/performance_problems/{fixture}.json"))
+        event = orjson.loads(self.load_fixture(f"events/performance_problems/{fixture}.json"))
 
         for key in ["datetime", "location", "title"]:
             del event[key]

--- a/tests/acceptance/test_proxy.py
+++ b/tests/acceptance/test_proxy.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from dataclasses import asdict
 
+import orjson
 import pytest
 from django.urls import reverse
 from pytest_django.live_server_helper import LiveServer
@@ -17,7 +18,6 @@ from sentry.testutils.factories import Factories
 from sentry.testutils.region import override_regions
 from sentry.testutils.silo import region_silo_test
 from sentry.types.region import Region
-from sentry.utils import json
 from tests.sentry.middleware.test_proxy import test_region
 
 
@@ -67,6 +67,6 @@ class EndToEndAPIProxyTest(TransactionTestCase):
                 )
 
         assert_status_code(resp, 201)
-        result = json.loads(resp.getvalue())
+        result = orjson.loads(resp.getvalue())
         team = Team.objects.get(id=result["id"])
         assert team.idp_provisioned

--- a/tests/flagpole/test_conditions.py
+++ b/tests/flagpole/test_conditions.py
@@ -1,5 +1,6 @@
 from typing import Any
 
+import orjson
 import pytest
 from pydantic import ValidationError
 
@@ -16,7 +17,6 @@ from flagpole.conditions import (
     create_case_insensitive_set_from_list,
 )
 from sentry.testutils.cases import TestCase
-from sentry.utils import json
 
 
 class TestCreateCaseInsensitiveSetFromList(TestCase):
@@ -36,7 +36,7 @@ class TestCreateCaseInsensitiveSetFromList(TestCase):
 def assert_valid_types(condition: type[ConditionBase], expected_types: list[Any]):
     for value in expected_types:
         condition_dict = dict(property="test", value=value)
-        json_condition = json.dumps(condition_dict)
+        json_condition = orjson.dumps(condition_dict).decode()
         try:
             parsed_condition = condition.parse_raw(json_condition)
         except ValidationError as exc:
@@ -49,7 +49,7 @@ def assert_valid_types(condition: type[ConditionBase], expected_types: list[Any]
 def assert_invalid_types(condition: type[ConditionBase], invalid_types: list[Any]):
     for value in invalid_types:
         json_dict = dict(value=value)
-        condition_json = json.dumps(json_dict)
+        condition_json = orjson.dumps(json_dict).decode()
         try:
             condition.parse_raw(condition_json)
         except ValidationError:

--- a/tests/relay_integration/lang/java/test_plugin.py
+++ b/tests/relay_integration/lang/java/test_plugin.py
@@ -2,6 +2,7 @@ import zipfile
 from io import BytesIO
 from uuid import uuid4
 
+import orjson
 import pytest
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.urls import reverse
@@ -13,7 +14,6 @@ from sentry.testutils.helpers.datetime import before_now, iso_format
 from sentry.testutils.helpers.options import override_options
 from sentry.testutils.relay import RelayStoreHelper
 from sentry.testutils.skips import requires_symbolicator
-from sentry.utils import json
 
 PROGUARD_UUID = "6dc7fdb0-d2fb-4c8e-9d6b-bb1aa98929b1"
 PROGUARD_SOURCE = b"""\
@@ -1026,7 +1026,7 @@ class BasicResolvingIntegrationTest(RelayStoreHelper, TransactionTestCase):
         with zipfile.ZipFile(file_like, "a") as zip:
             for path, contents in source_files.items():
                 zip.writestr(f"files/_/_/{path}", contents)
-            zip.writestr("manifest.json", json.dumps(manifest))
+            zip.writestr("manifest.json", orjson.dumps(manifest).decode())
         file_like.seek(0)
 
         file = File.objects.create(

--- a/tests/relay_integration/lang/javascript/test_plugin.py
+++ b/tests/relay_integration/lang/javascript/test_plugin.py
@@ -5,6 +5,7 @@ from hashlib import sha1
 from io import BytesIO
 from uuid import uuid4
 
+import orjson
 import pytest
 import responses
 from django.conf import settings
@@ -26,7 +27,6 @@ from sentry.testutils.helpers.datetime import before_now, iso_format
 from sentry.testutils.pytest.fixtures import django_db_all
 from sentry.testutils.relay import RelayStoreHelper
 from sentry.testutils.skips import requires_kafka, requires_symbolicator
-from sentry.utils import json
 from sentry.utils.safe import get_path
 
 # IMPORTANT:
@@ -74,7 +74,7 @@ def make_compressed_zip_file(files):
 
         zip_file.writestr(
             "manifest.json",
-            json.dumps(
+            orjson.dumps(
                 {
                     # We remove the "content" key in the original dict, thus no subsequent calls should be made.
                     "files": {
@@ -82,7 +82,7 @@ def make_compressed_zip_file(files):
                         for file_path, info in files.items()
                     }
                 }
-            ),
+            ).decode(),
         )
     compressed.seek(0)
 
@@ -1125,7 +1125,7 @@ class TestJavascriptIntegration(RelayStoreHelper):
                     content = content.replace(b"//@ sourceMappingURL=file.sourcemap.js", b"")
                     entry["headers"] = {"Sourcemap": "file.sourcemap.js"}
                 zip_file.writestr(rel_path, content)
-            zip_file.writestr("manifest.json", json.dumps(manifest))
+            zip_file.writestr("manifest.json", orjson.dumps(manifest).decode())
         compressed.seek(0)
 
         file = File.objects.create(name="doesnt_matter", type="release.bundle")
@@ -1473,7 +1473,7 @@ class TestJavascriptIntegration(RelayStoreHelper):
 
             zip_file.writestr(
                 "manifest.json",
-                json.dumps(
+                orjson.dumps(
                     {
                         "org": self.organization.slug,
                         "release": release.version,
@@ -1518,7 +1518,7 @@ class TestJavascriptIntegration(RelayStoreHelper):
                             },
                         },
                     }
-                ),
+                ).decode(),
             )
         compressed.seek(0)
         file = File.objects.create(name="bundle.zip", type="artifact.bundle")
@@ -1648,7 +1648,7 @@ class TestJavascriptIntegration(RelayStoreHelper):
 
             zip_file.writestr(
                 "manifest.json",
-                json.dumps(
+                orjson.dumps(
                     {
                         "files": {
                             "files/_/_/file.min.js": {
@@ -1691,7 +1691,7 @@ class TestJavascriptIntegration(RelayStoreHelper):
                             },
                         }
                     }
-                ),
+                ).decode(),
             )
         compressed.seek(0)
 
@@ -1804,7 +1804,7 @@ class TestJavascriptIntegration(RelayStoreHelper):
 
             zip_file.writestr(
                 "manifest.json",
-                json.dumps(
+                orjson.dumps(
                     {
                         "files": {
                             "files/_/_/file.min.js": {
@@ -1847,7 +1847,7 @@ class TestJavascriptIntegration(RelayStoreHelper):
                             },
                         }
                     }
-                ),
+                ).decode(),
             )
         compressed.seek(0)
 
@@ -1964,7 +1964,7 @@ class TestJavascriptIntegration(RelayStoreHelper):
                     content = content.replace(b"//@ sourceMappingURL=file.sourcemap.js", b"")
                     entry["headers"] = {"Sourcemap": "file.sourcemap.js"}
                 zip_file.writestr(rel_path, content)
-            zip_file.writestr("manifest.json", json.dumps(manifest))
+            zip_file.writestr("manifest.json", orjson.dumps(manifest).decode())
         compressed.seek(0)
 
         file = File.objects.create(name="release_bundle.zip", type="release.bundle")
@@ -2067,7 +2067,7 @@ class TestJavascriptIntegration(RelayStoreHelper):
             )
             zip_file.writestr(
                 "manifest.json",
-                json.dumps(
+                orjson.dumps(
                     {
                         "files": {
                             "files/_/_/file.min.js": {
@@ -2110,7 +2110,7 @@ class TestJavascriptIntegration(RelayStoreHelper):
                             },
                         },
                     }
-                ),
+                ).decode(),
             )
         compressed.seek(0)
 
@@ -2222,7 +2222,7 @@ class TestJavascriptIntegration(RelayStoreHelper):
 
             zip_file.writestr(
                 "manifest.json",
-                json.dumps(
+                orjson.dumps(
                     {
                         "files": {
                             "files/_/_/file.min.js": {
@@ -2263,7 +2263,7 @@ class TestJavascriptIntegration(RelayStoreHelper):
                             },
                         }
                     }
-                ),
+                ).decode(),
             )
         compressed.seek(0)
 
@@ -2364,7 +2364,7 @@ class TestJavascriptIntegration(RelayStoreHelper):
 
             zip_file.writestr(
                 "manifest.json",
-                json.dumps(
+                orjson.dumps(
                     {
                         "files": {
                             "files/_/_/file.min.js": {
@@ -2405,7 +2405,7 @@ class TestJavascriptIntegration(RelayStoreHelper):
                             },
                         }
                     }
-                ),
+                ).decode(),
             )
         compressed.seek(0)
 

--- a/tests/relay_integration/test_metrics_extraction.py
+++ b/tests/relay_integration/test_metrics_extraction.py
@@ -1,6 +1,7 @@
 import uuid
 
 import confluent_kafka as kafka
+import orjson
 import pytest
 
 from sentry.sentry_metrics.indexer.strings import SHARED_STRINGS
@@ -10,7 +11,6 @@ from sentry.testutils.helpers.features import Feature
 from sentry.testutils.helpers.options import override_options
 from sentry.testutils.relay import RelayStoreHelper
 from sentry.testutils.skips import requires_kafka
-from sentry.utils import json
 
 pytestmark = [requires_kafka]
 
@@ -85,7 +85,7 @@ class MetricsExtractionTest(RelayStoreHelper, TransactionTestCase):
                 message = consumer.poll(timeout=1.0)
                 if message is None:
                     break
-                message = json.loads(message.value())
+                message = orjson.loads(message.value())
                 if message["project_id"] == self.project.id:
                     strings_emitted.add(message["name"])
                     for key, value in message["tags"].items():

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_details.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_details.py
@@ -6,6 +6,7 @@ from typing import Any
 from unittest import mock
 from unittest.mock import patch
 
+import orjson
 import responses
 from django.conf import settings
 from django.test import override_settings
@@ -40,7 +41,6 @@ from sentry.testutils.abstract import Abstract
 from sentry.testutils.outbox import outbox_runner
 from sentry.testutils.silo import assume_test_silo_mode
 from sentry.testutils.skips import requires_snuba
-from sentry.utils import json
 from tests.sentry.incidents.endpoints.test_organization_alert_rule_index import AlertRuleBase
 
 pytestmark = [requires_snuba]
@@ -785,7 +785,7 @@ class AlertRuleDetailsSlackPutEndpointTest(AlertRuleDetailsBase):
             url=url,
             status=status,
             content_type="application/json",
-            body=json.dumps(body),
+            body=orjson.dumps(body).decode(),
         )
 
     def _organization_alert_rule_api_call(

--- a/tests/sentry/mediators/external_requests/test_alert_rule_action_requester.py
+++ b/tests/sentry/mediators/external_requests/test_alert_rule_action_requester.py
@@ -1,3 +1,4 @@
+import orjson
 import responses
 
 from sentry.mediators.external_requests.alert_rule_action_requester import (
@@ -7,7 +8,6 @@ from sentry.mediators.external_requests.alert_rule_action_requester import (
 )
 from sentry.testutils.cases import TestCase
 from sentry.testutils.silo import control_silo_test
-from sentry.utils import json
 from sentry.utils.sentry_apps import SentryAppWebhookRequestsBuffer
 
 
@@ -71,11 +71,11 @@ class TestAlertRuleActionRequester(TestCase):
             ],
             "installationId": self.install.uuid,
         }
-        payload = json.loads(request.body)
+        payload = orjson.loads(request.body)
         assert payload == data
 
         assert request.headers["Sentry-App-Signature"] == self.sentry_app.build_signature(
-            json.dumps(payload)
+            orjson.dumps(payload).decode()
         )
 
         buffer = SentryAppWebhookRequestsBuffer(self.sentry_app)
@@ -147,11 +147,11 @@ class TestAlertRuleActionRequester(TestCase):
             ],
             "installationId": self.install.uuid,
         }
-        payload = json.loads(request.body)
+        payload = orjson.loads(request.body)
         assert payload == data
 
         assert request.headers["Sentry-App-Signature"] == self.sentry_app.build_signature(
-            json.dumps(payload)
+            orjson.dumps(payload).decode()
         )
 
         buffer = SentryAppWebhookRequestsBuffer(self.sentry_app)

--- a/tests/sentry/mediators/external_requests/test_issue_link_requester.py
+++ b/tests/sentry/mediators/external_requests/test_issue_link_requester.py
@@ -1,3 +1,4 @@
+import orjson
 import pytest
 import responses
 
@@ -6,7 +7,6 @@ from sentry.mediators.external_requests.issue_link_requester import IssueLinkReq
 from sentry.services.hybrid_cloud.app import app_service
 from sentry.services.hybrid_cloud.user.serial import serialize_rpc_user
 from sentry.testutils.cases import TestCase
-from sentry.utils import json
 from sentry.utils.sentry_apps import SentryAppWebhookRequestsBuffer
 
 
@@ -69,10 +69,10 @@ class TestIssueLinkRequester(TestCase):
             "project": {"id": self.project.id, "slug": self.project.slug},
             "actor": {"type": "user", "id": self.user.id, "name": self.user.name},
         }
-        payload = json.loads(request.body)
+        payload = orjson.loads(request.body)
         assert payload == data
         assert request.headers["Sentry-App-Signature"] == self.sentry_app.build_signature(
-            json.dumps(payload)
+            orjson.dumps(payload).decode()
         )
         buffer = SentryAppWebhookRequestsBuffer(self.sentry_app)
         requests = buffer.get_requests()

--- a/tests/sentry/middleware/integrations/parsers/test_discord.py
+++ b/tests/sentry/middleware/integrations/parsers/test_discord.py
@@ -4,6 +4,7 @@ from collections.abc import Mapping
 from typing import Any
 from unittest.mock import patch
 
+import orjson
 import responses
 from django.http import HttpRequest, HttpResponse
 from django.test import RequestFactory, override_settings
@@ -17,7 +18,6 @@ from sentry.silo.base import SiloMode
 from sentry.testutils.cases import APITestCase, TestCase
 from sentry.testutils.outbox import assert_no_webhook_payloads
 from sentry.testutils.silo import control_silo_test, create_test_regions
-from sentry.utils import json
 from sentry.utils.signing import sign
 
 
@@ -59,7 +59,7 @@ class DiscordRequestParserTest(TestCase):
 
         response = parser.get_response()
         assert response.status_code == 200
-        data = json.loads(response.content)
+        data = orjson.loads(response.content)
         assert data == {"type": 1}
         assert len(responses.calls) == 0
         assert_no_webhook_payloads()
@@ -89,7 +89,7 @@ class DiscordRequestParserTest(TestCase):
 
         response = parser.get_response()
         assert response.status_code == 200
-        data = json.loads(response.content)
+        data = orjson.loads(response.content)
         assert data == {"type": 1}
         assert_no_webhook_payloads()
         assert len(responses.calls) == 0
@@ -208,7 +208,7 @@ class DiscordRequestParserTest(TestCase):
             }
         )
         assert response.status_code == status.HTTP_202_ACCEPTED
-        assert json.loads(response.content) == parser.async_response_data
+        assert orjson.loads(response.content) == parser.async_response_data
 
 
 @control_silo_test
@@ -232,6 +232,6 @@ class End2EndTest(APITestCase):
             HTTP_X_SIGNATURE_TIMESTAMP="timestamp",
         )
         assert response.status_code == 200
-        data = json.loads(response.content)
+        data = orjson.loads(response.content)
         assert data == {"type": 1}
         assert mock_verify_signature.call_count == 1

--- a/tests/sentry/middleware/integrations/test_tasks.py
+++ b/tests/sentry/middleware/integrations/test_tasks.py
@@ -1,5 +1,6 @@
 from unittest.mock import patch
 
+import orjson
 import responses
 from django.test import RequestFactory
 from django.urls import reverse
@@ -15,7 +16,6 @@ from sentry.testutils.cases import TestCase
 from sentry.testutils.region import override_regions
 from sentry.testutils.silo import control_silo_test
 from sentry.types.region import Region, RegionCategory
-from sentry.utils import json
 
 
 @control_silo_test
@@ -29,7 +29,7 @@ class AsyncSlackResponseTest(TestCase):
         super().setUp()
         self.response_url = "https://hooks.slack.com/commands/TXXXXXXX1/1234567890123/something"
         slack_payload = {"team_id": "TXXXXXXX1", "response_url": self.response_url}
-        data = {"payload": json.dumps(slack_payload)}
+        data = {"payload": orjson.dumps(slack_payload).decode()}
         action_request = self.factory.post(reverse("sentry-integration-slack-action"), data=data)
         self.payload = create_async_request_payload(action_request)
 

--- a/tests/sentry/middleware/test_health.py
+++ b/tests/sentry/middleware/test_health.py
@@ -1,12 +1,12 @@
 from functools import cached_property
 from unittest.mock import patch
 
+import orjson
 from django.test import RequestFactory
 
 from sentry.middleware.health import HealthCheck
 from sentry.status_checks import Problem
 from sentry.testutils.cases import TestCase
-from sentry.utils import json
 
 
 class HealthCheckTest(TestCase):
@@ -36,7 +36,7 @@ class HealthCheckTest(TestCase):
         req = self.factory.get("/_health/?full")
         resp = self.middleware.process_request(req)
         assert resp.status_code == 200, resp
-        body = json.loads(resp.content)
+        body = orjson.loads(resp.content)
         assert "problems" in body
         assert "healthy" in body
         assert check_all.call_count == 1
@@ -47,7 +47,7 @@ class HealthCheckTest(TestCase):
         req = self.factory.get("/_health/?full")
         resp = self.middleware.process_request(req)
         assert resp.status_code == 500, resp
-        body = json.loads(resp.content)
+        body = orjson.loads(resp.content)
         assert "problems" in body
         assert "healthy" in body
         assert check_all.call_count == 1

--- a/tests/symbolicator/test_payload_full.py
+++ b/tests/symbolicator/test_payload_full.py
@@ -4,6 +4,7 @@ from io import BytesIO
 from unittest.mock import patch
 from uuid import uuid4
 
+import orjson
 import pytest
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.urls import reverse
@@ -22,7 +23,6 @@ from sentry.testutils.factories import get_fixture_path
 from sentry.testutils.helpers.datetime import before_now, iso_format
 from sentry.testutils.relay import RelayStoreHelper
 from sentry.testutils.skips import requires_kafka, requires_symbolicator
-from sentry.utils import json
 from tests.symbolicator import insta_snapshot_native_stacktrace_data, redact_location
 
 # IMPORTANT:
@@ -287,7 +287,7 @@ class SymbolicatorResolvingIntegrationTest(RelayStoreHelper, TransactionTestCase
 
             zip_file.writestr(
                 "manifest.json",
-                json.dumps(
+                orjson.dumps(
                     {
                         "files": {
                             "files/_/_/test.min.js": {
@@ -307,7 +307,7 @@ class SymbolicatorResolvingIntegrationTest(RelayStoreHelper, TransactionTestCase
                             },
                         },
                     }
-                ),
+                ).decode(),
             )
         compressed.seek(0)
         bundle_file = File.objects.create(name="bundle.zip", type="artifact.bundle")


### PR DESCRIPTION
Part of `orjson` move to get rid of `sentry.utils.json`