### PR TITLE
ref(insights): Simplify `useModuleURL`

### DIFF
--- a/static/app/components/events/interfaces/llm-monitoring/llmMonitoringSection.tsx
+++ b/static/app/components/events/interfaces/llm-monitoring/llmMonitoringSection.tsx
@@ -12,7 +12,7 @@ import {
   TotalTokensUsedChart,
 } from 'sentry/views/llmMonitoring/llmMonitoringCharts';
 import * as ModuleLayout from 'sentry/views/performance/moduleLayout';
-import {useAIModuleURL} from 'sentry/views/performance/utils/useModuleURL';
+import {useModuleURL} from 'sentry/views/performance/utils/useModuleURL';
 import {useIndexedSpans} from 'sentry/views/starfish/queries/useIndexedSpans';
 import {type IndexedResponse, SpanIndexedField} from 'sentry/views/starfish/types';
 
@@ -30,7 +30,7 @@ export default function LLMMonitoringSection({event}: Props) {
     referrer: 'api.ai-pipelines.view',
     search: new MutableSearch(`trace:${traceId} id:"${spanId}"`),
   });
-  const moduleUrl = useAIModuleURL();
+  const moduleUrl = useModuleURL('ai');
   const aiPipelineGroup =
     data && (data[0] as IndexedResponse)?.[SpanIndexedField.SPAN_AI_PIPELINE_GROUP];
 

--- a/static/app/views/llmMonitoring/llmMonitoringDetailsPage.tsx
+++ b/static/app/views/llmMonitoring/llmMonitoringDetailsPage.tsx
@@ -24,7 +24,7 @@ import {BASE_URL} from 'sentry/views/llmMonitoring/settings';
 import {MetricReadout} from 'sentry/views/performance/metricReadout';
 import * as ModuleLayout from 'sentry/views/performance/moduleLayout';
 import {ModulePageProviders} from 'sentry/views/performance/modulePageProviders';
-import {useAIModuleURL} from 'sentry/views/performance/utils/useModuleURL';
+import {useModuleURL} from 'sentry/views/performance/utils/useModuleURL';
 import {useSpanMetrics} from 'sentry/views/starfish/queries/useDiscover';
 import {
   SpanFunction,
@@ -43,7 +43,7 @@ type Query = {
 };
 
 export function LLMMonitoringPage({params}: Props) {
-  const moduleURL = useAIModuleURL();
+  const moduleURL = useModuleURL('ai');
   const location = useLocation<Query>();
 
   const organization = useOrganization();

--- a/static/app/views/llmMonitoring/pipelinesTable.tsx
+++ b/static/app/views/llmMonitoring/pipelinesTable.tsx
@@ -25,7 +25,7 @@ import {decodeScalar, decodeSorts} from 'sentry/utils/queryString';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
-import {useAIModuleURL} from 'sentry/views/performance/utils/useModuleURL';
+import {useModuleURL} from 'sentry/views/performance/utils/useModuleURL';
 import {renderHeadCell} from 'sentry/views/starfish/components/tableCells/renderHeadCell';
 import {useSpanMetrics} from 'sentry/views/starfish/queries/useDiscover';
 import type {SpanMetricsResponse} from 'sentry/views/starfish/types';
@@ -91,7 +91,7 @@ export function isAValidSort(sort: Sort): sort is ValidSort {
 
 export function PipelinesTable() {
   const location = useLocation();
-  const moduleURL = useAIModuleURL();
+  const moduleURL = useModuleURL('ai');
 
   const organization = useOrganization();
   const cursor = decodeScalar(location.query?.[QueryParameterNames.SPANS_CURSOR]);

--- a/static/app/views/performance/browser/resources/resourceSummaryPage/index.tsx
+++ b/static/app/views/performance/browser/resources/resourceSummaryPage/index.tsx
@@ -27,10 +27,7 @@ import RenderBlockingSelector from 'sentry/views/performance/browser/resources/s
 import {ResourceSpanOps} from 'sentry/views/performance/browser/resources/shared/types';
 import {useResourceModuleFilters} from 'sentry/views/performance/browser/resources/utils/useResourceFilters';
 import {ModulePageProviders} from 'sentry/views/performance/modulePageProviders';
-import {
-  useResourceModuleURL,
-  useWebVitalsModuleURL,
-} from 'sentry/views/performance/utils/useModuleURL';
+import {useModuleURL} from 'sentry/views/performance/utils/useModuleURL';
 import {useSpanMetrics} from 'sentry/views/starfish/queries/useDiscover';
 import {ModuleName, SpanMetricsField} from 'sentry/views/starfish/types';
 import {SampleList} from 'sentry/views/starfish/views/spanSummaryPage/sampleList';
@@ -46,8 +43,8 @@ const {
 } = SpanMetricsField;
 
 function ResourceSummary() {
-  const resourcesModuleURL = useResourceModuleURL();
-  const webVitalsModuleURL = useWebVitalsModuleURL();
+  const resourcesModuleURL = useModuleURL('resource');
+  const webVitalsModuleURL = useModuleURL('vital');
   const organization = useOrganization();
   const {groupId} = useParams();
   const filters = useResourceModuleFilters();

--- a/static/app/views/performance/browser/webVitals/components/performanceScoreRingWithTooltips.tsx
+++ b/static/app/views/performance/browser/webVitals/components/performanceScoreRingWithTooltips.tsx
@@ -16,7 +16,7 @@ import type {
   ProjectScore,
   WebVitals,
 } from 'sentry/views/performance/browser/webVitals/utils/types';
-import {useWebVitalsModuleURL} from 'sentry/views/performance/utils/useModuleURL';
+import {useModuleURL} from 'sentry/views/performance/utils/useModuleURL';
 
 import {ORDER_WITH_INP} from '../performanceScoreChart';
 
@@ -84,7 +84,7 @@ function WebVitalLabel({
   inPerformanceWidget,
   projectData,
 }: WebVitalLabelProps) {
-  const moduleURL = useWebVitalsModuleURL();
+  const moduleURL = useModuleURL('vital');
   const xOffset = webVitalLabelCoordinates?.[webVital]?.x ?? 0;
   const yOffset = webVitalLabelCoordinates?.[webVital]?.y ?? 0;
   const webvitalInfo =

--- a/static/app/views/performance/browser/webVitals/pageOverview.tsx
+++ b/static/app/views/performance/browser/webVitals/pageOverview.tsx
@@ -48,7 +48,7 @@ import {
   StyledAlert,
 } from 'sentry/views/performance/browser/webVitals/webVitalsLandingPage';
 import {ModulePageProviders} from 'sentry/views/performance/modulePageProviders';
-import {useWebVitalsModuleURL} from 'sentry/views/performance/utils/useModuleURL';
+import {useModuleURL} from 'sentry/views/performance/utils/useModuleURL';
 
 import {transactionSummaryRouteWithQuery} from '../../transactionSummary/utils';
 
@@ -77,7 +77,7 @@ function getCurrentTabSelection(selectedTab) {
 }
 
 export function PageOverview() {
-  const moduleURL = useWebVitalsModuleURL();
+  const moduleURL = useModuleURL('vital');
   const organization = useOrganization();
   const location = useLocation();
   const {projects} = useProjects();

--- a/static/app/views/performance/cache/tables/transactionCell.tsx
+++ b/static/app/views/performance/cache/tables/transactionCell.tsx
@@ -2,7 +2,7 @@ import * as qs from 'query-string';
 
 import Link from 'sentry/components/links/link';
 import {useLocation} from 'sentry/utils/useLocation';
-import {useCacheModuleURL} from 'sentry/views/performance/utils/useModuleURL';
+import {useModuleURL} from 'sentry/views/performance/utils/useModuleURL';
 import {OverflowEllipsisTextContainer} from 'sentry/views/starfish/components/textAlign';
 
 interface Props {
@@ -12,7 +12,7 @@ interface Props {
 }
 
 export function TransactionCell({project, transaction}: Props) {
-  const moduleURL = useCacheModuleURL();
+  const moduleURL = useModuleURL('cache');
   const location = useLocation();
 
   if (!transaction) {

--- a/static/app/views/performance/database/databaseSpanSummaryPage.tsx
+++ b/static/app/views/performance/database/databaseSpanSummaryPage.tsx
@@ -26,7 +26,7 @@ import {useSelectedDurationAggregate} from 'sentry/views/performance/database/us
 import {MetricReadout} from 'sentry/views/performance/metricReadout';
 import * as ModuleLayout from 'sentry/views/performance/moduleLayout';
 import {ModulePageProviders} from 'sentry/views/performance/modulePageProviders';
-import {useDatabaseModuleURL} from 'sentry/views/performance/utils/useModuleURL';
+import {useModuleURL} from 'sentry/views/performance/utils/useModuleURL';
 import {useSynchronizeCharts} from 'sentry/views/starfish/components/chart';
 import {DatabaseSpanDescription} from 'sentry/views/starfish/components/spanDescription';
 import {getTimeSpentExplanation} from 'sentry/views/starfish/components/tableCells/timeSpentCell';
@@ -48,7 +48,7 @@ type Query = {
 type Props = RouteComponentProps<Query, {groupId: string}>;
 
 export function DatabaseSpanSummaryPage({params}: Props) {
-  const moduleURL = useDatabaseModuleURL();
+  const moduleURL = useModuleURL('db');
   const organization = useOrganization();
   const location = useLocation<Query>();
 

--- a/static/app/views/performance/database/queryTransactionsTable.tsx
+++ b/static/app/views/performance/database/queryTransactionsTable.tsx
@@ -15,7 +15,7 @@ import {getFieldRenderer} from 'sentry/utils/discover/fieldRenderers';
 import type {Sort} from 'sentry/utils/discover/fields';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
-import {useDatabaseModuleURL} from 'sentry/views/performance/utils/useModuleURL';
+import {useModuleURL} from 'sentry/views/performance/utils/useModuleURL';
 import {renderHeadCell} from 'sentry/views/starfish/components/tableCells/renderHeadCell';
 import {OverflowEllipsisTextContainer} from 'sentry/views/starfish/components/textAlign';
 import type {SpanMetricsResponse} from 'sentry/views/starfish/types';
@@ -93,7 +93,7 @@ export function QueryTransactionsTable({
   sort,
   span,
 }: Props) {
-  const moduleURL = useDatabaseModuleURL();
+  const moduleURL = useModuleURL('db');
   const location = useLocation();
   const organization = useOrganization();
 

--- a/static/app/views/performance/http/httpDomainSummaryPage.tsx
+++ b/static/app/views/performance/http/httpDomainSummaryPage.tsx
@@ -46,7 +46,7 @@ import {
 import {MetricReadout} from 'sentry/views/performance/metricReadout';
 import * as ModuleLayout from 'sentry/views/performance/moduleLayout';
 import {ModulePageProviders} from 'sentry/views/performance/modulePageProviders';
-import {useRequestsModuleURL} from 'sentry/views/performance/utils/useModuleURL';
+import {useModuleURL} from 'sentry/views/performance/utils/useModuleURL';
 import {useSynchronizeCharts} from 'sentry/views/starfish/components/chart';
 import {getTimeSpentExplanation} from 'sentry/views/starfish/components/tableCells/timeSpentCell';
 import {useSpanMetrics} from 'sentry/views/starfish/queries/useDiscover';
@@ -62,7 +62,7 @@ type Query = {
 };
 
 export function HTTPDomainSummaryPage() {
-  const moduleURL = useRequestsModuleURL();
+  const moduleURL = useModuleURL('http');
   const location = useLocation<Query>();
   const organization = useOrganization();
   const {projects} = useProjects();

--- a/static/app/views/performance/http/tables/domainCell.tsx
+++ b/static/app/views/performance/http/tables/domainCell.tsx
@@ -5,7 +5,7 @@ import Link from 'sentry/components/links/link';
 import {space} from 'sentry/styles/space';
 import {useLocation} from 'sentry/utils/useLocation';
 import {NULL_DOMAIN_DESCRIPTION} from 'sentry/views/performance/http/settings';
-import {useRequestsModuleURL} from 'sentry/views/performance/utils/useModuleURL';
+import {useModuleURL} from 'sentry/views/performance/utils/useModuleURL';
 import {OverflowEllipsisTextContainer} from 'sentry/views/starfish/components/textAlign';
 
 interface Props {
@@ -14,7 +14,7 @@ interface Props {
 }
 
 export function DomainCell({projectId, domain}: Props) {
-  const moduleURL = useRequestsModuleURL();
+  const moduleURL = useModuleURL('http');
   const location = useLocation();
 
   const queryString = {

--- a/static/app/views/performance/http/tables/transactionCell.tsx
+++ b/static/app/views/performance/http/tables/transactionCell.tsx
@@ -2,7 +2,7 @@ import * as qs from 'query-string';
 
 import Link from 'sentry/components/links/link';
 import {useLocation} from 'sentry/utils/useLocation';
-import {useRequestsModuleURL} from 'sentry/views/performance/utils/useModuleURL';
+import {useModuleURL} from 'sentry/views/performance/utils/useModuleURL';
 import {OverflowEllipsisTextContainer} from 'sentry/views/starfish/components/textAlign';
 
 interface Props {
@@ -18,7 +18,7 @@ export function TransactionCell({
   transaction,
   transactionMethod,
 }: Props) {
-  const moduleURL = useRequestsModuleURL();
+  const moduleURL = useModuleURL('http');
   const location = useLocation();
 
   if (!transaction) {

--- a/static/app/views/performance/mobile/appStarts/screenSummary/index.tsx
+++ b/static/app/views/performance/mobile/appStarts/screenSummary/index.tsx
@@ -28,7 +28,7 @@ import {BASE_URL} from 'sentry/views/performance/mobile/appStarts/settings';
 import {SpanSamplesPanel} from 'sentry/views/performance/mobile/components/spanSamplesPanel';
 import {MetricsRibbon} from 'sentry/views/performance/mobile/screenload/screenLoadSpans/metricsRibbon';
 import {ModulePageProviders} from 'sentry/views/performance/modulePageProviders';
-import {useAppStartupsModuleURL} from 'sentry/views/performance/utils/useModuleURL';
+import {useModuleURL} from 'sentry/views/performance/utils/useModuleURL';
 import {
   PRIMARY_RELEASE_ALIAS,
   ReleaseComparisonSelector,
@@ -53,7 +53,7 @@ type Query = {
 };
 
 export function ScreenSummary() {
-  const moduleURL = useAppStartupsModuleURL();
+  const moduleURL = useModuleURL('app_start');
   const organization = useOrganization();
   const location = useLocation<Query>();
   const router = useRouter();

--- a/static/app/views/performance/mobile/appStarts/screenSummary/spanOperationTable.tsx
+++ b/static/app/views/performance/mobile/appStarts/screenSummary/spanOperationTable.tsx
@@ -30,7 +30,7 @@ import {
 } from 'sentry/views/performance/mobile/appStarts/screenSummary/startTypeSelector';
 import {MobileCursors} from 'sentry/views/performance/mobile/screenload/screens/constants';
 import {useTableQuery} from 'sentry/views/performance/mobile/screenload/screens/screensTable';
-import {useAppStartupsModuleURL} from 'sentry/views/performance/utils/useModuleURL';
+import {useModuleURL} from 'sentry/views/performance/utils/useModuleURL';
 import {
   PRIMARY_RELEASE_ALIAS,
   SECONDARY_RELEASE_ALIAS,
@@ -56,7 +56,7 @@ export function SpanOperationTable({
   primaryRelease,
   secondaryRelease,
 }: Props) {
-  const moduleURL = useAppStartupsModuleURL();
+  const moduleURL = useModuleURL('app_start');
   const location = useLocation();
   const {selection} = usePageFilters();
   const organization = useOrganization();

--- a/static/app/views/performance/mobile/appStarts/screens/screensTable.tsx
+++ b/static/app/views/performance/mobile/appStarts/screens/screensTable.tsx
@@ -12,7 +12,7 @@ import Breakdown from 'sentry/views/performance/mobile/appStarts/screens/breakdo
 import {COLD_START_TYPE} from 'sentry/views/performance/mobile/appStarts/screenSummary/startTypeSelector';
 import {ScreensTable} from 'sentry/views/performance/mobile/components/screensTable';
 import {TOP_SCREENS} from 'sentry/views/performance/mobile/constants';
-import {useAppStartupsModuleURL} from 'sentry/views/performance/utils/useModuleURL';
+import {useModuleURL} from 'sentry/views/performance/utils/useModuleURL';
 import {COLD_START_COLOR, WARM_START_COLOR} from 'sentry/views/starfish/colors';
 import {
   PRIMARY_RELEASE_ALIAS,
@@ -29,7 +29,7 @@ type Props = {
 };
 
 export function AppStartScreens({data, eventView, isLoading, pageLinks}: Props) {
-  const moduleURL = useAppStartupsModuleURL();
+  const moduleURL = useModuleURL('app_start');
   const location = useLocation();
   const {primaryRelease, secondaryRelease} = useReleaseSelection();
 

--- a/static/app/views/performance/mobile/screenload/screenLoadSpans/index.tsx
+++ b/static/app/views/performance/mobile/screenload/screenLoadSpans/index.tsx
@@ -37,7 +37,7 @@ import {PlatformSelector} from 'sentry/views/performance/mobile/screenload/scree
 import {isCrossPlatform} from 'sentry/views/performance/mobile/screenload/screens/utils';
 import {BASE_URL} from 'sentry/views/performance/mobile/screenload/settings';
 import {ModulePageProviders} from 'sentry/views/performance/modulePageProviders';
-import {useScreenLoadsModuleURL} from 'sentry/views/performance/utils/useModuleURL';
+import {useModuleURL} from 'sentry/views/performance/utils/useModuleURL';
 import {
   PRIMARY_RELEASE_ALIAS,
   ReleaseComparisonSelector,
@@ -57,7 +57,7 @@ type Query = {
 };
 
 function ScreenLoadSpans() {
-  const moduleURL = useScreenLoadsModuleURL();
+  const moduleURL = useModuleURL('screen_load');
   const location = useLocation<Query>();
   const organization = useOrganization();
   const router = useRouter();

--- a/static/app/views/performance/mobile/screenload/screenLoadSpans/table.tsx
+++ b/static/app/views/performance/mobile/screenload/screenLoadSpans/table.tsx
@@ -39,7 +39,7 @@ import {
 } from 'sentry/views/performance/mobile/screenload/screens/platformSelector';
 import {useTableQuery} from 'sentry/views/performance/mobile/screenload/screens/screensTable';
 import {isCrossPlatform} from 'sentry/views/performance/mobile/screenload/screens/utils';
-import {useScreenLoadsModuleURL} from 'sentry/views/performance/utils/useModuleURL';
+import {useModuleURL} from 'sentry/views/performance/utils/useModuleURL';
 import {
   PRIMARY_RELEASE_ALIAS,
   SECONDARY_RELEASE_ALIAS,
@@ -67,7 +67,7 @@ export function ScreenLoadSpansTable({
   secondaryRelease,
   project,
 }: Props) {
-  const moduleURL = useScreenLoadsModuleURL();
+  const moduleURL = useModuleURL('screen_load');
   const location = useLocation();
   const {selection} = usePageFilters();
   const organization = useOrganization();

--- a/static/app/views/performance/mobile/screenload/screens/screensTable.tsx
+++ b/static/app/views/performance/mobile/screenload/screens/screensTable.tsx
@@ -24,7 +24,7 @@ import usePageFilters from 'sentry/utils/usePageFilters';
 import TopResultsIndicator from 'sentry/views/discover/table/topResultsIndicator';
 import type {TableColumn} from 'sentry/views/discover/table/types';
 import {TOP_SCREENS} from 'sentry/views/performance/mobile/constants';
-import {useScreenLoadsModuleURL} from 'sentry/views/performance/utils/useModuleURL';
+import {useModuleURL} from 'sentry/views/performance/utils/useModuleURL';
 import {
   PRIMARY_RELEASE_ALIAS,
   SECONDARY_RELEASE_ALIAS,
@@ -49,7 +49,7 @@ export function ScreensTable({
   onCursor,
   project,
 }: Props) {
-  const moduleURL = useScreenLoadsModuleURL();
+  const moduleURL = useModuleURL('screen_load');
   const location = useLocation();
   const organization = useOrganization();
   const {primaryRelease, secondaryRelease} = useReleaseSelection();

--- a/static/app/views/performance/mobile/ui/screenSummary/index.tsx
+++ b/static/app/views/performance/mobile/ui/screenSummary/index.tsx
@@ -18,7 +18,7 @@ import {SpanSamplesPanel} from 'sentry/views/performance/mobile/components/spanS
 import {SpanOperationTable} from 'sentry/views/performance/mobile/ui/screenSummary/spanOperationTable';
 import {BASE_URL} from 'sentry/views/performance/mobile/ui/settings';
 import {ModulePageProviders} from 'sentry/views/performance/modulePageProviders';
-import {useMobileUIModuleURL} from 'sentry/views/performance/utils/useModuleURL';
+import {useModuleURL} from 'sentry/views/performance/utils/useModuleURL';
 import {ReleaseComparisonSelector} from 'sentry/views/starfish/components/releaseSelector';
 import {ModuleName, SpanMetricsField} from 'sentry/views/starfish/types';
 import {QueryParameterNames} from 'sentry/views/starfish/views/queryParameters';
@@ -35,7 +35,7 @@ type Query = {
 };
 
 function ScreenSummary() {
-  const moduleURL = useMobileUIModuleURL();
+  const moduleURL = useModuleURL('mobile-ui');
   const organization = useOrganization();
   const location = useLocation<Query>();
   const router = useRouter();

--- a/static/app/views/performance/mobile/ui/screenSummary/spanOperationTable.tsx
+++ b/static/app/views/performance/mobile/ui/screenSummary/spanOperationTable.tsx
@@ -18,7 +18,7 @@ import {ScreensTable} from 'sentry/views/performance/mobile/components/screensTa
 import {MobileCursors} from 'sentry/views/performance/mobile/screenload/screens/constants';
 import {useTableQuery} from 'sentry/views/performance/mobile/screenload/screens/screensTable';
 import {Referrer} from 'sentry/views/performance/mobile/ui/referrers';
-import {useMobileUIModuleURL} from 'sentry/views/performance/utils/useModuleURL';
+import {useModuleURL} from 'sentry/views/performance/utils/useModuleURL';
 import {
   PRIMARY_RELEASE_ALIAS,
   SECONDARY_RELEASE_ALIAS,
@@ -37,7 +37,7 @@ export function SpanOperationTable({
   primaryRelease,
   secondaryRelease,
 }: SpanOperationTableProps) {
-  const moduleURL = useMobileUIModuleURL();
+  const moduleURL = useModuleURL('mobile-ui');
   const location = useLocation();
   const {selection} = usePageFilters();
   const cursor = decodeScalar(location.query?.[MobileCursors.SPANS_TABLE]);

--- a/static/app/views/performance/mobile/ui/screens/table.tsx
+++ b/static/app/views/performance/mobile/ui/screens/table.tsx
@@ -11,7 +11,7 @@ import {useLocation} from 'sentry/utils/useLocation';
 import TopResultsIndicator from 'sentry/views/discover/table/topResultsIndicator';
 import {ScreensTable} from 'sentry/views/performance/mobile/components/screensTable';
 import {TOP_SCREENS} from 'sentry/views/performance/mobile/constants';
-import {useMobileUIModuleURL} from 'sentry/views/performance/utils/useModuleURL';
+import {useModuleURL} from 'sentry/views/performance/utils/useModuleURL';
 import {
   PRIMARY_RELEASE_ALIAS,
   SECONDARY_RELEASE_ALIAS,
@@ -26,7 +26,7 @@ type Props = {
 };
 
 export function UIScreensTable({data, eventView, isLoading, pageLinks}: Props) {
-  const moduleURL = useMobileUIModuleURL();
+  const moduleURL = useModuleURL('mobile-ui');
   const location = useLocation();
   const {primaryRelease, secondaryRelease} = useReleaseSelection();
 

--- a/static/app/views/performance/queues/destinationSummary/destinationSummaryPage.tsx
+++ b/static/app/views/performance/queues/destinationSummary/destinationSummaryPage.tsx
@@ -33,11 +33,11 @@ import {
   MODULE_TITLE,
   RELEASE_LEVEL,
 } from 'sentry/views/performance/queues/settings';
-import {useQueueModuleURL} from 'sentry/views/performance/utils/useModuleURL';
+import {useModuleURL} from 'sentry/views/performance/utils/useModuleURL';
 import {getTimeSpentExplanation} from 'sentry/views/starfish/components/tableCells/timeSpentCell';
 
 function DestinationSummaryPage() {
-  const moduleURL = useQueueModuleURL();
+  const moduleURL = useModuleURL('queue');
   const organization = useOrganization();
   const onboardingProject = useOnboardingProject();
 

--- a/static/app/views/performance/queues/destinationSummary/transactionsTable.tsx
+++ b/static/app/views/performance/queues/destinationSummary/transactionsTable.tsx
@@ -21,7 +21,7 @@ import useLocationQuery from 'sentry/utils/url/useLocationQuery';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import {useQueuesByTransactionQuery} from 'sentry/views/performance/queues/queries/useQueuesByTransactionQuery';
-import {useQueueModuleURL} from 'sentry/views/performance/utils/useModuleURL';
+import {useModuleURL} from 'sentry/views/performance/utils/useModuleURL';
 import {renderHeadCell} from 'sentry/views/starfish/components/tableCells/renderHeadCell';
 import {SpanFunction, type SpanMetricsResponse} from 'sentry/views/starfish/types';
 import {QueryParameterNames} from 'sentry/views/starfish/views/queryParameters';
@@ -232,7 +232,7 @@ function renderBodyCell(
 }
 
 function TransactionCell({transaction, op}: {op: string; transaction: string}) {
-  const moduleURL = useQueueModuleURL();
+  const moduleURL = useModuleURL('queue');
   const {query} = useLocation();
   const queryString = {
     ...query,

--- a/static/app/views/performance/queues/queuesTable.tsx
+++ b/static/app/views/performance/queues/queuesTable.tsx
@@ -20,7 +20,7 @@ import {formatAbbreviatedNumber} from 'sentry/utils/formatters';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import {useQueuesByDestinationQuery} from 'sentry/views/performance/queues/queries/useQueuesByDestinationQuery';
-import {useQueueModuleURL} from 'sentry/views/performance/utils/useModuleURL';
+import {useModuleURL} from 'sentry/views/performance/utils/useModuleURL';
 import {renderHeadCell} from 'sentry/views/starfish/components/tableCells/renderHeadCell';
 import {
   SpanFunction,
@@ -203,7 +203,7 @@ function renderBodyCell(
 }
 
 function DestinationCell({destination}: {destination: string}) {
-  const moduleURL = useQueueModuleURL();
+  const moduleURL = useModuleURL('queue');
   const {query} = useLocation();
   const queryString = {
     ...query,

--- a/static/app/views/performance/utils/useModuleURL.tsx
+++ b/static/app/views/performance/utils/useModuleURL.tsx
@@ -1,5 +1,3 @@
-import partial from 'lodash/partial';
-
 import useOrganization from 'sentry/utils/useOrganization';
 import {normalizeUrl} from 'sentry/utils/withDomainRequired';
 import {BASE_URL as AI_BASE_URL} from 'sentry/views/llmMonitoring/settings';
@@ -30,7 +28,10 @@ const MODULE_BASE_URLS: Record<ModuleName, string> = {
   [ModuleName.ALL]: '',
 };
 
-export const useModuleURL = (moduleName: ModuleName): string => {
+type ModuleNameStrings = `${ModuleName}`;
+type RoutableModuleNames = Exclude<ModuleNameStrings, '' | 'other'>;
+
+export const useModuleURL = (moduleName: RoutableModuleNames): string => {
   const {slug} = useOrganization();
 
   if (moduleName === ModuleName.AI) {
@@ -42,14 +43,3 @@ export const useModuleURL = (moduleName: ModuleName): string => {
     `/organizations/${slug}${INSIGHTS_BASE_URL}/${MODULE_BASE_URLS[moduleName]}`
   );
 };
-
-export const useDatabaseModuleURL = partial(useModuleURL, ModuleName.DB);
-export const useRequestsModuleURL = partial(useModuleURL, ModuleName.HTTP);
-export const useCacheModuleURL = partial(useModuleURL, ModuleName.CACHE);
-export const useQueueModuleURL = partial(useModuleURL, ModuleName.QUEUE);
-export const useScreenLoadsModuleURL = partial(useModuleURL, ModuleName.SCREEN_LOAD);
-export const useAppStartupsModuleURL = partial(useModuleURL, ModuleName.APP_START);
-export const useWebVitalsModuleURL = partial(useModuleURL, ModuleName.VITAL);
-export const useResourceModuleURL = partial(useModuleURL, ModuleName.RESOURCE);
-export const useAIModuleURL = partial(useModuleURL, ModuleName.AI);
-export const useMobileUIModuleURL = partial(useModuleURL, ModuleName.MOBILE_UI);

--- a/static/app/views/starfish/components/spanGroupDetailsLink.tsx
+++ b/static/app/views/starfish/components/spanGroupDetailsLink.tsx
@@ -11,7 +11,7 @@ const {SPAN_OP} = SpanMetricsField;
 
 interface Props {
   description: React.ReactNode;
-  moduleName: ModuleName;
+  moduleName: ModuleName.DB | ModuleName.RESOURCE;
   projectId: number;
   group?: string;
   spanOp?: string;

--- a/static/app/views/starfish/components/tableCells/spanDescriptionCell.tsx
+++ b/static/app/views/starfish/components/tableCells/spanDescriptionCell.tsx
@@ -15,7 +15,7 @@ const {SPAN_OP} = SpanMetricsField;
 
 interface Props {
   description: string;
-  moduleName: ModuleName;
+  moduleName: ModuleName.DB | ModuleName.RESOURCE;
   projectId: number;
   group?: string;
   spanOp?: string;


### PR DESCRIPTION
Keep it simple with a single `useModuleURL` hook that accepts a string. This is a departure from our usual approach of using `ModuleName`, but I'm going to replace `ModuleName` with a string union type soon anyway.
