### PR TITLE
fix(span-summary): Fetch transaction durations only when IDs available

### DIFF
--- a/static/app/views/performance/transactionSummary/transactionSpans/spanSummary/spanSummaryTable.tsx
+++ b/static/app/views/performance/transactionSummary/transactionSpans/spanSummary/spanSummaryTable.tsx
@@ -161,7 +161,7 @@ export default function SpanSummaryTable(props: Props) {
     limit: LIMIT,
     options: {
       refetchOnWindowFocus: false,
-      enabled: Boolean(rowData),
+      enabled: Boolean(rowData && rowData.length > 0),
     },
     referrer: SpanSummaryReferrer.SPAN_SUMMARY_TABLE,
   });


### PR DESCRIPTION
The span summary page was attempting to fetch transaction durations even when `rowData` was empty, because an empty array resolves to `true`