### PR TITLE
feat(backup): Remove `org_role` from `sentry.team` on import

### DIFF
--- a/fixtures/backup/fresh-install.json
+++ b/fixtures/backup/fresh-install.json
@@ -214,8 +214,7 @@
     "status": 0,
     "actor": 1,
     "idp_provisioned": false,
-    "date_added": "2023-06-22T22:54:28.821Z",
-    "org_role": null
+    "date_added": "2023-06-22T22:54:28.821Z"
   }
 },
 {

--- a/src/sentry/backup/imports.py
+++ b/src/sentry/backup/imports.py
@@ -64,7 +64,6 @@ logger = logging.getLogger(__name__)
 # each entry in this dict, please leave a TODO comment pointed to a github issue for removing
 # the shim, noting in the comment which self-hosted release will trigger the removal.
 DELETED_FIELDS: dict[str, set[str]] = {
-    # TODO(getsentry/sentry#66247): Remove once self-hosted 24.4.0 is released.
     # The actor field should be retained until 24.6.0
     "sentry.team": {"actor"},
     # TODO(mark): Safe to remove after july 2024 after self-hosted 24.6.0 is released

--- a/src/sentry/backup/imports.py
+++ b/src/sentry/backup/imports.py
@@ -66,7 +66,7 @@ logger = logging.getLogger(__name__)
 DELETED_FIELDS: dict[str, set[str]] = {
     # TODO(getsentry/sentry#66247): Remove once self-hosted 24.4.0 is released.
     # The actor field should be retained until 24.6.0
-    "sentry.team": {"org_role", "actor"},
+    "sentry.team": {"actor"},
     # TODO(mark): Safe to remove after july 2024 after self-hosted 24.6.0 is released
     "sentry.rule": {"owner"},
     # TODO(mark): Safe to remove after july 2024 after self-hosted 24.6.0 is released


### PR DESCRIPTION
This completes the too-early attempt from this PR: https://github.com/getsentry/sentry/pull/69003

Closes https://github.com/getsentry/sentry/issues/66247