### PR TITLE
fix(ui): Only show unresolved service incidents in sidebar

### DIFF
--- a/static/app/components/sidebar/serviceIncidents.tsx
+++ b/static/app/components/sidebar/serviceIncidents.tsx
@@ -22,7 +22,7 @@ function ServiceIncidents({
   collapsed,
   orientation,
 }: Props) {
-  const {data: incidents} = useServiceIncidents({statusFilter: 'resolved'});
+  const {data: incidents} = useServiceIncidents({statusFilter: 'unresolved'});
 
   if (!incidents) {
     return null;


### PR DESCRIPTION
This regressed in https://github.com/getsentry/sentry/pull/71060