### PR TITLE
fix(trace): adjust timeline for ns precision

### DIFF
--- a/static/app/views/performance/newTraceDetails/index.tsx
+++ b/static/app/views/performance/newTraceDetails/index.tsx
@@ -652,6 +652,7 @@ function TraceViewContent(props: TraceViewContentProps) {
       nodeToScrollTo: TraceTreeNode<TraceTree.NodeValue> | null,
       indexOfNodeToScrollTo: number | null
     ) => {
+      scrollQueueRef.current = null;
       const query = qs.parse(location.search);
 
       if (query.fov && typeof query.fov === 'string') {

--- a/static/app/views/performance/newTraceDetails/index.tsx
+++ b/static/app/views/performance/newTraceDetails/index.tsx
@@ -819,7 +819,7 @@ function TraceViewContent(props: TraceViewContentProps) {
   }, [tree, shape, organization]);
 
   useLayoutEffect(() => {
-    if (!tree.root?.space) {
+    if (!tree.root?.space || tree.type !== 'trace') {
       return undefined;
     }
 

--- a/static/app/views/performance/newTraceDetails/trace.tsx
+++ b/static/app/views/performance/newTraceDetails/trace.tsx
@@ -207,24 +207,28 @@ export function Trace({
   const traceStateRef = useRef<TraceReducerState>(trace_state);
   traceStateRef.current = trace_state;
 
-  if (
-    trace.root.space &&
-    (trace.root.space[0] !== manager.to_origin ||
-      trace.root.space[1] !== manager.trace_space.width)
-  ) {
-    manager.initializeTraceSpace([trace.root.space[0], 0, trace.root.space[1], 1]);
-    const queryParams = qs.parse(location.search);
-    const maybeQueue = decodeScrollQueue(queryParams.node);
-
-    if (maybeQueue || queryParams.eventId) {
-      scrollQueueRef.current = {
-        eventId: queryParams.eventId as string,
-        path: maybeQueue as TraceTreeNode<TraceTree.NodeValue>['path'],
-      };
-    }
-  }
-
   const loadedRef = useRef(false);
+
+  useLayoutEffect(() => {
+    if (
+      !loadedRef.current &&
+      trace.root.space &&
+      (trace.root.space[0] !== manager.to_origin ||
+        trace.root.space[1] !== manager.trace_space.width)
+    ) {
+      manager.initializeTraceSpace([trace.root.space[0], 0, trace.root.space[1], 1]);
+      const queryParams = qs.parse(location.search);
+      const maybeQueue = decodeScrollQueue(queryParams.node);
+
+      if (maybeQueue || queryParams.eventId) {
+        scrollQueueRef.current = {
+          eventId: queryParams.eventId as string,
+          path: maybeQueue as TraceTreeNode<TraceTree.NodeValue>['path'],
+        };
+      }
+    }
+  }, [manager, trace, scrollQueueRef]);
+
   useLayoutEffect(() => {
     if (loadedRef.current) {
       return;

--- a/static/app/views/performance/newTraceDetails/trace.tsx
+++ b/static/app/views/performance/newTraceDetails/trace.tsx
@@ -4,7 +4,6 @@ import {type Theme, useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 import * as Sentry from '@sentry/react';
 import {PlatformIcon} from 'platformicons';
-import * as qs from 'query-string';
 
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import Placeholder from 'sentry/components/placeholder';
@@ -52,18 +51,6 @@ import {
   isTransactionNode,
 } from './guards';
 import {TraceIcons} from './icons';
-
-function decodeScrollQueue(maybePath: unknown): TraceTree.NodePath[] | null {
-  if (Array.isArray(maybePath)) {
-    return maybePath;
-  }
-
-  if (typeof maybePath === 'string') {
-    return [maybePath as TraceTree.NodePath];
-  }
-
-  return null;
-}
 
 const COUNT_FORMATTER = Intl.NumberFormat(undefined, {notation: 'compact'});
 const NO_ERRORS = new Set<TraceError>();
@@ -144,6 +131,7 @@ function maybeFocusRow(
 
 interface TraceProps {
   forceRerender: number;
+  initializedRef: React.MutableRefObject<boolean>;
   manager: VirtualizedViewManager;
   onRowClick: (
     node: TraceTreeNode<TraceTree.NodeValue>,
@@ -183,6 +171,7 @@ export function Trace({
   onTraceLoad,
   rerender,
   trace_state,
+  initializedRef,
   trace_dispatch,
   forceRerender,
 }: TraceProps) {
@@ -207,37 +196,15 @@ export function Trace({
   const traceStateRef = useRef<TraceReducerState>(trace_state);
   traceStateRef.current = trace_state;
 
-  const loadedRef = useRef(false);
-
   useLayoutEffect(() => {
-    if (
-      !loadedRef.current &&
-      trace.root.space &&
-      (trace.root.space[0] !== manager.to_origin ||
-        trace.root.space[1] !== manager.trace_space.width)
-    ) {
-      manager.initializeTraceSpace([trace.root.space[0], 0, trace.root.space[1], 1]);
-      const queryParams = qs.parse(location.search);
-      const maybeQueue = decodeScrollQueue(queryParams.node);
-
-      if (maybeQueue || queryParams.eventId) {
-        scrollQueueRef.current = {
-          eventId: queryParams.eventId as string,
-          path: maybeQueue as TraceTreeNode<TraceTree.NodeValue>['path'],
-        };
-      }
-    }
-  }, [manager, trace, scrollQueueRef]);
-
-  useLayoutEffect(() => {
-    if (loadedRef.current) {
+    if (initializedRef.current) {
       return;
     }
     if (trace.type !== 'trace' || !manager) {
       return;
     }
 
-    loadedRef.current = true;
+    initializedRef.current = true;
 
     if (!scrollQueueRef.current) {
       onTraceLoad(trace, null, null);
@@ -286,6 +253,7 @@ export function Trace({
     onTraceLoad,
     trace_dispatch,
     scrollQueueRef,
+    initializedRef,
     organization,
   ]);
 

--- a/static/app/views/performance/newTraceDetails/traceModels/traceTree.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/traceTree.spec.tsx
@@ -603,6 +603,31 @@ describe('TreeNode', () => {
       });
     });
 
+    it('adjusts trace space when spans exceed the bounds of a trace', () => {
+      const adjusted = TraceTree.FromTrace(
+        makeTrace({
+          transactions: [
+            makeTransaction({
+              start_timestamp: 1,
+              timestamp: 3,
+            }),
+          ],
+          orphan_errors: [],
+        })
+      );
+
+      expect(adjusted.root.space).toEqual([1000, 2000]);
+
+      const [_, adjusted_space] = TraceTree.FromSpans(
+        adjusted.root,
+        makeEvent(),
+        [makeSpan({start_timestamp: 0.5, timestamp: 3.5})],
+        {sdk: undefined}
+      );
+
+      expect(adjusted_space).toEqual([0.5, 3.5]);
+    });
+
     it('inserts no data node when txn has no span children', async () => {
       const tree = TraceTree.FromTrace(
         makeTrace({
@@ -977,7 +1002,7 @@ describe('TraceTree', () => {
       {project_slug: '', event_id: ''}
     );
 
-    const node = TraceTree.FromSpans(
+    const [node] = TraceTree.FromSpans(
       root,
       makeEvent(),
       [
@@ -1029,7 +1054,7 @@ describe('TraceTree', () => {
       )
     );
 
-    const node = TraceTree.FromSpans(
+    const [node] = TraceTree.FromSpans(
       root,
       makeEvent(),
       [
@@ -1079,7 +1104,7 @@ describe('TraceTree', () => {
       start = node;
     }
 
-    const node = TraceTree.FromSpans(
+    const [node] = TraceTree.FromSpans(
       root,
       makeEvent(),
       [
@@ -1109,7 +1134,7 @@ describe('TraceTree', () => {
     );
 
     const date = new Date().getTime();
-    const node = TraceTree.FromSpans(
+    const [node] = TraceTree.FromSpans(
       root,
       makeEvent(),
       [
@@ -1149,7 +1174,7 @@ describe('TraceTree', () => {
     );
 
     const date = new Date().getTime();
-    const node = TraceTree.FromSpans(
+    const [node] = TraceTree.FromSpans(
       root,
       makeEvent(),
       [

--- a/static/app/views/performance/newTraceDetails/traceModels/traceTree.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/traceTree.tsx
@@ -1369,10 +1369,25 @@ export class TraceTree {
           const new_start = view[0];
           const new_end = view[1];
 
+          // Update the space of the tree and the trace root node
           this.root.space = [
             Math.min(new_start * node.multiplier, this.root.space[0]),
             Math.max(new_end * node.multiplier - prev_start, this.root.space[1]),
           ];
+          this.root.children[0].space = [...this.root.space];
+
+          // If the parent is a transaction node, we need to update its space as well
+          if (isTransactionNode(node)) {
+            node.space = [...this.root.space];
+            // If the parent is not a transaction node, then we'll find the first one
+            // in the parent chain and update its space.
+          } else {
+            const parentTransaction = node.parent_transaction;
+            if (parentTransaction) {
+              parentTransaction.space = [...this.root.space];
+            }
+          }
+
           if (prev_start !== this.root.space[0] || prev_end !== this.root.space[1]) {
             this.dispatch('trace timeline change', this.root.space);
           }

--- a/static/app/views/performance/newTraceDetails/traceModels/traceTree.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/traceTree.tsx
@@ -1377,14 +1377,22 @@ export class TraceTree {
           this.root.children[0].space = [...this.root.space];
 
           // If the parent is a transaction node, we need to update its space as well
-          if (isTransactionNode(node)) {
-            node.space = [...this.root.space];
-            // If the parent is not a transaction node, then we'll find the first one
-            // in the parent chain and update its space.
-          } else {
-            const parentTransaction = node.parent_transaction;
-            if (parentTransaction) {
-              parentTransaction.space = [...this.root.space];
+          if (node.space) {
+            if (isTransactionNode(node)) {
+              node.space = [
+                Math.min(view[0] * node.multiplier, node.space[0]),
+                Math.max(view[1] * node.multiplier - node.space[0], node.space[1]),
+              ];
+              // If the parent is not a transaction node, then we'll find the first one
+              // in the parent chain and update its space.
+            } else {
+              const parentTransaction = node.parent_transaction;
+              if (parentTransaction) {
+                parentTransaction.space = [
+                  view[0] * node.multiplier,
+                  (view[1] - view[0]) * node.multiplier,
+                ];
+              }
             }
           }
 

--- a/static/app/views/performance/newTraceDetails/traceModels/traceTree.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/traceTree.tsx
@@ -109,6 +109,8 @@ import {TraceType} from '../traceType';
  * - instead of storing span children separately, we should have meta tree nodes that handle pointing to the correct children
  */
 
+type ArgumentTypes<F> = F extends (...args: infer A) => any ? A : never;
+
 export declare namespace TraceTree {
   type Transaction = TraceFullDetailed;
   interface Span extends RawSpanType {
@@ -172,6 +174,12 @@ export declare namespace TraceTree {
   };
 
   type CollectedVital = {key: string; measurement: Measurement};
+
+  interface TraceTreeEvents {
+    ['trace timeline change']: (view: [number, number]) => void;
+  }
+
+  type EventStore = {[K in keyof TraceTreeEvents]: Set<TraceTreeEvents[K]>};
 }
 
 export type ViewManagerScrollToOptions = {
@@ -508,6 +516,8 @@ export class TraceTree {
     const tLen = transactionQueue.length;
     const oLen = orphanErrorsQueue.length;
 
+    // Items in each queue are sorted by timestamp, so we just take
+    // from the queue with the earliest timestamp which means the final list will be ordered.
     while (tIdx < tLen || oIdx < oLen) {
       const transaction = transactionQueue[tIdx];
       const orphan = orphanErrorsQueue[oIdx];
@@ -612,9 +622,12 @@ export class TraceTree {
     data: Event,
     spans: RawSpanType[],
     options: {sdk: string | undefined} | undefined
-  ): TraceTreeNode<TraceTree.NodeValue> {
+  ): [TraceTreeNode<TraceTree.NodeValue>, [number, number] | null] {
     parent.invalidate(parent);
     const platformHasMissingSpans = shouldAddMissingInstrumentationSpan(options?.sdk);
+
+    let min_span_start = Number.POSITIVE_INFINITY;
+    let min_span_end = Number.NEGATIVE_INFINITY;
 
     const parentIsSpan = isSpanNode(parent);
     const lookuptable: Record<
@@ -625,14 +638,14 @@ export class TraceTree {
     // If we've already fetched children, the tree is already assembled
     if (parent.spanChildren.length > 0) {
       parent.zoomedIn = true;
-      return parent;
+      return [parent, null];
     }
 
     // If we have no spans, insert an empty node to indicate that there is no data
     if (!spans.length && !parent.children.length) {
       parent.zoomedIn = true;
       parent.spanChildren.push(new NoDataNode(parent));
-      return parent;
+      return [parent, null];
     }
 
     if (parentIsSpan) {
@@ -675,6 +688,16 @@ export class TraceTree {
         event_id: undefined,
         project_slug: undefined,
       });
+
+      if (
+        typeof span.start_timestamp === 'number' &&
+        span.start_timestamp < min_span_start
+      ) {
+        min_span_start = span.start_timestamp;
+      }
+      if (typeof span.timestamp === 'number' && span.timestamp > min_span_end) {
+        min_span_end = span.timestamp;
+      }
 
       for (const error of getRelatedSpanErrorsFromTransaction(span, parent)) {
         node.errors.add(error);
@@ -748,7 +771,8 @@ export class TraceTree {
     parent.zoomedIn = true;
     TraceTree.AutogroupSiblingSpanNodes(parent);
     TraceTree.AutogroupDirectChildrenSpanNodes(parent);
-    return parent;
+
+    return [parent, [min_span_start, min_span_end]];
   }
 
   static AutogroupDirectChildrenSpanNodes(
@@ -1326,7 +1350,33 @@ export class TraceTree {
         // Api response is not sorted
         spans.data.sort((a, b) => a.start_timestamp - b.start_timestamp);
 
-        TraceTree.FromSpans(node, data, spans.data, {sdk: data.sdk?.name});
+        const [_, view] = TraceTree.FromSpans(node, data, spans.data, {
+          sdk: data.sdk?.name,
+        });
+
+        // Spans contain millisecond precision, which means that it is possible for the
+        // children spans of a transaction to extend beyond the start and end of the transaction
+        // through ns precision. To account for this, we need to adjust the space of the transaction node and the space
+        // of our trace so that all of the span children are visible and can be rendered inside the view.
+        if (
+          view &&
+          Number.isFinite(view[0]) &&
+          Number.isFinite(view[1]) &&
+          this.root.space
+        ) {
+          const prev_start = this.root.space[0];
+          const prev_end = this.root.space[1];
+          const new_start = view[0];
+          const new_end = view[1];
+
+          this.root.space = [
+            Math.min(new_start * node.multiplier, this.root.space[0]),
+            Math.max(new_end * node.multiplier - prev_start, this.root.space[1]),
+          ];
+          if (prev_start !== this.root.space[0] || prev_end !== this.root.space[1]) {
+            this.dispatch('trace timeline change', this.root.space);
+          }
+        }
 
         const spanChildren = node.getVisibleChildren();
         this._list.splice(index + 1, 0, ...spanChildren);
@@ -1364,6 +1414,38 @@ export class TraceTree {
 
   get list(): ReadonlyArray<TraceTreeNode<TraceTree.NodeValue>> {
     return this._list;
+  }
+
+  listeners: TraceTree.EventStore = {
+    'trace timeline change': new Set(),
+  };
+
+  on<K extends keyof TraceTree.TraceTreeEvents>(
+    event: K,
+    cb: TraceTree.TraceTreeEvents[K]
+  ): void {
+    this.listeners[event].add(cb);
+  }
+
+  off<K extends keyof TraceTree.TraceTreeEvents>(
+    event: K,
+    cb: TraceTree.TraceTreeEvents[K]
+  ): void {
+    this.listeners[event].delete(cb);
+  }
+
+  dispatch<K extends keyof TraceTree.TraceTreeEvents>(
+    event: K,
+    ...args: ArgumentTypes<TraceTree.TraceTreeEvents[K]>
+  ): void {
+    if (!this.listeners[event]) {
+      return;
+    }
+
+    for (const handler of this.listeners[event]) {
+      // @ts-expect-error
+      handler(...args);
+    }
   }
 
   /**

--- a/static/app/views/performance/newTraceDetails/traceModels/traceTree.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/traceTree.tsx
@@ -1376,26 +1376,6 @@ export class TraceTree {
           ];
           this.root.children[0].space = [...this.root.space];
 
-          // If the parent is a transaction node, we need to update its space as well
-          if (node.space) {
-            if (isTransactionNode(node)) {
-              node.space = [
-                Math.min(view[0] * node.multiplier, node.space[0]),
-                Math.max(view[1] * node.multiplier - node.space[0], node.space[1]),
-              ];
-              // If the parent is not a transaction node, then we'll find the first one
-              // in the parent chain and update its space.
-            } else {
-              const parentTransaction = node.parent_transaction;
-              if (parentTransaction) {
-                parentTransaction.space = [
-                  view[0] * node.multiplier,
-                  (view[1] - view[0]) * node.multiplier,
-                ];
-              }
-            }
-          }
-
           if (prev_start !== this.root.space[0] || prev_end !== this.root.space[1]) {
             this.dispatch('trace timeline change', this.root.space);
           }

--- a/static/app/views/performance/newTraceDetails/traceRenderers/virtualizedViewManager.tsx
+++ b/static/app/views/performance/newTraceDetails/traceRenderers/virtualizedViewManager.tsx
@@ -216,6 +216,18 @@ export class VirtualizedViewManager {
     }
   }
 
+  updateTraceSpace(start: number, width: number) {
+    if (this.trace_space.width === width && this.to_origin === start) {
+      return;
+    }
+
+    this.to_origin = start;
+    this.trace_space = new TraceView(0, 0, width, 1);
+
+    this.recomputeTimelineIntervals();
+    this.recomputeSpanToPxMatrix();
+  }
+
   initializeTraceSpace(space: [x: number, y: number, width: number, height: number]) {
     this.to_origin = space[0];
 

--- a/static/app/views/performance/newTraceDetails/traceRenderers/virtualizedViewManager.tsx
+++ b/static/app/views/performance/newTraceDetails/traceRenderers/virtualizedViewManager.tsx
@@ -222,7 +222,14 @@ export class VirtualizedViewManager {
     }
 
     this.to_origin = start;
+
+    // If view is scaled all the way out, then lets update it to match the new space, else
+    // we are implicitly zooming in, which may be even more confusing.
+    const preventImplicitZoom = this.trace_view.width === this.trace_space.width;
     this.trace_space = new TraceView(0, 0, width, 1);
+    if (preventImplicitZoom) {
+      this.setTraceView({x: 0, width});
+    }
 
     this.recomputeTimelineIntervals();
     this.recomputeSpanToPxMatrix();


### PR DESCRIPTION
Spans have ns precision while transactions only include ms precision. This means that it is possible for spans to render outside of their "container" if their duration is sub ms and the txn duration is rounded down. 
