### PR TITLE
ref(js): Relative imports in settingsBreadcrumb

### DIFF
--- a/static/app/views/settings/components/settingsBreadcrumb/breadcrumbDropdown.spec.tsx
+++ b/static/app/views/settings/components/settingsBreadcrumb/breadcrumbDropdown.spec.tsx
@@ -1,6 +1,6 @@
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
-import BreadcrumbDropdown from 'sentry/views/settings/components/settingsBreadcrumb/breadcrumbDropdown';
+import BreadcrumbDropdown from './breadcrumbDropdown';
 
 describe('Settings Breadcrumb Dropdown', () => {
   const selectMock = jest.fn();

--- a/static/app/views/settings/components/settingsBreadcrumb/breadcrumbDropdown.tsx
+++ b/static/app/views/settings/components/settingsBreadcrumb/breadcrumbDropdown.tsx
@@ -2,9 +2,9 @@ import {useState} from 'react';
 
 import DropdownAutoCompleteMenu from 'sentry/components/dropdownAutoComplete/menu';
 import type {Item} from 'sentry/components/dropdownAutoComplete/types';
-import Crumb from 'sentry/views/settings/components/settingsBreadcrumb/crumb';
-import Divider from 'sentry/views/settings/components/settingsBreadcrumb/divider';
 
+import Crumb from './crumb';
+import Divider from './divider';
 import type {RouteWithName} from './types';
 
 interface AdditionalDropdownProps

--- a/static/app/views/settings/components/settingsBreadcrumb/breadcrumbTitle.spec.tsx
+++ b/static/app/views/settings/components/settingsBreadcrumb/breadcrumbTitle.spec.tsx
@@ -2,8 +2,8 @@ import {initializeOrg} from 'sentry-test/initializeOrg';
 import {BreadcrumbContextProvider} from 'sentry-test/providers/breadcrumbContextProvider';
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
-import SettingsBreadcrumb from 'sentry/views/settings/components/settingsBreadcrumb';
-import BreadcrumbTitle from 'sentry/views/settings/components/settingsBreadcrumb/breadcrumbTitle';
+import BreadcrumbTitle from './breadcrumbTitle';
+import SettingsBreadcrumb from '.';
 
 jest.unmock('sentry/utils/recreateRoute');
 

--- a/static/app/views/settings/components/settingsBreadcrumb/findFirstRouteWithoutRouteParam.spec.tsx
+++ b/static/app/views/settings/components/settingsBreadcrumb/findFirstRouteWithoutRouteParam.spec.tsx
@@ -1,5 +1,4 @@
-import findFirstRouteWithoutRouteParam from 'sentry/views/settings/components/settingsBreadcrumb/findFirstRouteWithoutRouteParam';
-
+import findFirstRouteWithoutRouteParam from './findFirstRouteWithoutRouteParam';
 import type {RouteWithName} from './types';
 
 describe('findFirstRouteWithoutRouteParam', function () {

--- a/static/app/views/settings/components/settingsBreadcrumb/index.tsx
+++ b/static/app/views/settings/components/settingsBreadcrumb/index.tsx
@@ -4,13 +4,13 @@ import Link from 'sentry/components/links/link';
 import {t} from 'sentry/locale';
 import getRouteStringFromRoutes from 'sentry/utils/getRouteStringFromRoutes';
 import recreateRoute from 'sentry/utils/recreateRoute';
-import Crumb from 'sentry/views/settings/components/settingsBreadcrumb/crumb';
-import Divider from 'sentry/views/settings/components/settingsBreadcrumb/divider';
-import {OrganizationCrumb} from 'sentry/views/settings/components/settingsBreadcrumb/organizationCrumb';
-import ProjectCrumb from 'sentry/views/settings/components/settingsBreadcrumb/projectCrumb';
-import TeamCrumb from 'sentry/views/settings/components/settingsBreadcrumb/teamCrumb';
 
 import {useBreadcrumbsPathmap} from './context';
+import Crumb from './crumb';
+import Divider from './divider';
+import {OrganizationCrumb} from './organizationCrumb';
+import ProjectCrumb from './projectCrumb';
+import TeamCrumb from './teamCrumb';
 import type {RouteWithName} from './types';
 
 const MENUS = {

--- a/static/app/views/settings/components/settingsBreadcrumb/organizationCrumb.spec.tsx
+++ b/static/app/views/settings/components/settingsBreadcrumb/organizationCrumb.spec.tsx
@@ -6,8 +6,8 @@ import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 import OrganizationsStore from 'sentry/stores/organizationsStore';
 import type {Config} from 'sentry/types/system';
 import {browserHistory} from 'sentry/utils/browserHistory';
-import {OrganizationCrumb} from 'sentry/views/settings/components/settingsBreadcrumb/organizationCrumb';
 
+import {OrganizationCrumb} from './organizationCrumb';
 import type {RouteWithName} from './types';
 
 jest.unmock('sentry/utils/recreateRoute');

--- a/static/app/views/settings/components/settingsBreadcrumb/organizationCrumb.tsx
+++ b/static/app/views/settings/components/settingsBreadcrumb/organizationCrumb.tsx
@@ -10,10 +10,10 @@ import {browserHistory} from 'sentry/utils/browserHistory';
 import recreateRoute from 'sentry/utils/recreateRoute';
 import {resolveRoute} from 'sentry/utils/resolveRoute';
 import useOrganization from 'sentry/utils/useOrganization';
-import BreadcrumbDropdown from 'sentry/views/settings/components/settingsBreadcrumb/breadcrumbDropdown';
-import findFirstRouteWithoutRouteParam from 'sentry/views/settings/components/settingsBreadcrumb/findFirstRouteWithoutRouteParam';
-import MenuItem from 'sentry/views/settings/components/settingsBreadcrumb/menuItem';
 
+import BreadcrumbDropdown from './breadcrumbDropdown';
+import findFirstRouteWithoutRouteParam from './findFirstRouteWithoutRouteParam';
+import MenuItem from './menuItem';
 import {CrumbLink} from '.';
 
 type Props = RouteComponentProps<{projectId?: string}, {}>;

--- a/static/app/views/settings/components/settingsBreadcrumb/projectCrumb.tsx
+++ b/static/app/views/settings/components/settingsBreadcrumb/projectCrumb.tsx
@@ -11,10 +11,10 @@ import recreateRoute from 'sentry/utils/recreateRoute';
 import replaceRouterParams from 'sentry/utils/replaceRouterParams';
 import useProjects from 'sentry/utils/useProjects';
 import withLatestContext from 'sentry/utils/withLatestContext';
-import BreadcrumbDropdown from 'sentry/views/settings/components/settingsBreadcrumb/breadcrumbDropdown';
-import findFirstRouteWithoutRouteParam from 'sentry/views/settings/components/settingsBreadcrumb/findFirstRouteWithoutRouteParam';
-import MenuItem from 'sentry/views/settings/components/settingsBreadcrumb/menuItem';
 
+import BreadcrumbDropdown from './breadcrumbDropdown';
+import findFirstRouteWithoutRouteParam from './findFirstRouteWithoutRouteParam';
+import MenuItem from './menuItem';
 import {CrumbLink} from '.';
 
 type Props = RouteComponentProps<{projectId?: string}, {}> & {

--- a/static/app/views/settings/components/settingsBreadcrumb/teamCrumb.tsx
+++ b/static/app/views/settings/components/settingsBreadcrumb/teamCrumb.tsx
@@ -7,9 +7,9 @@ import {browserHistory} from 'sentry/utils/browserHistory';
 import recreateRoute from 'sentry/utils/recreateRoute';
 import {useParams} from 'sentry/utils/useParams';
 import {useTeams} from 'sentry/utils/useTeams';
-import BreadcrumbDropdown from 'sentry/views/settings/components/settingsBreadcrumb/breadcrumbDropdown';
-import MenuItem from 'sentry/views/settings/components/settingsBreadcrumb/menuItem';
 
+import BreadcrumbDropdown from './breadcrumbDropdown';
+import MenuItem from './menuItem';
 import {CrumbLink} from '.';
 
 type Props = RouteComponentProps<{teamId: string}, {}>;


### PR DESCRIPTION
These are just so deeply nested, it's kinda nicer this way