### PR TITLE
remove SUPPORTED_KAFKA_CONFIGURATION

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -3392,6 +3392,8 @@ SENTRY_USER_PERMISSIONS = ("broadcasts.admin", "users.admin", "options.admin")
 # Reading items from this default configuration directly might break deploys.
 # To correctly read items from this dictionary and not worry about the format,
 # see `sentry.utils.kafka_config.get_kafka_consumer_cluster_options`.
+# Check https://github.com/edenhill/librdkafka/blob/master/CONFIGURATION.md
+# for the full list of available options
 KAFKA_CLUSTERS: dict[str, dict[str, Any]] = {
     "default": {
         "common": {"bootstrap.servers": "127.0.0.1:9092"},

--- a/src/sentry/utils/kafka_config.py
+++ b/src/sentry/utils/kafka_config.py
@@ -6,32 +6,6 @@ from django.conf import settings
 from sentry.conf.types.kafka_definition import Topic
 from sentry.conf.types.topic_definition import TopicDefinition
 
-SUPPORTED_KAFKA_CONFIGURATION = (
-    # Check https://github.com/edenhill/librdkafka/blob/master/CONFIGURATION.md
-    # for the full list of available options
-    "bootstrap.servers",
-    "compression.type",
-    "message.max.bytes",
-    "sasl.mechanism",
-    "sasl.username",
-    "sasl.password",
-    "security.protocol",
-    "socket.timeout.ms",
-    "ssl.ca.location",
-    "ssl.ca.certificate.stores",
-    "ssl.certificate.location",
-    "ssl.certificate.pem",
-    "ssl.cipher.suites",
-    "ssl.crl.location",
-    "ssl.curves.list",
-    "ssl.endpoint.identification.algorithm",
-    "ssl.key.location",
-    "ssl.key.password",
-    "ssl.key.pem",
-    "ssl.keystore.location",
-    "ssl.keystore.password",
-    "ssl.sigalgs.list",
-)
 COMMON_SECTION = "common"
 PRODUCERS_SECTION = "producers"
 CONSUMERS_SECTION = "consumers"
@@ -66,10 +40,6 @@ def _get_kafka_cluster_options(
     else:
         options.update(common_options)
         options.update(custom_options)
-        # check key validity
-        for configuration_key in options:
-            if configuration_key not in SUPPORTED_KAFKA_CONFIGURATION:
-                raise ValueError(f"The `{configuration_key}` configuration key is not supported.")
     if not isinstance(options["bootstrap.servers"], str):
         raise ValueError("bootstrap.servers must be a comma separated string")
     if override_params:


### PR DESCRIPTION
<!-- Describe your PR here. -->

This PR removes `SUPPORTED_KAFKA_CONFIGURATION`.
There are a lot of configurations in [rdkafka](https://github.com/confluentinc/librdkafka/blob/master/CONFIGURATION.md), but they are blocked by the `SUPPORTED_KAFKA_CONFIGURATION`.

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
