### PR TITLE
ref: rework build to be reusable outside of setup.py

### DIFF
--- a/src/sentry/build/_static_assets.py
+++ b/src/sentry/build/_static_assets.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+
+
+def _build_static_assets() -> None:
+    node_options = os.environ.get("NODE_OPTIONS", "")
+    env = {
+        **os.environ,
+        # By setting NODE_ENV=production, a few things happen
+        #   * React optimizes out certain code paths
+        #   * Webpack will add version strings to built/referenced assets
+        "NODE_ENV": "production",
+        # TODO: Our JS builds should not require 4GB heap space
+        "NODE_OPTIONS": f"{node_options} --max-old-space-size=4096".lstrip(),
+    }
+
+    def _cmd(*cmd: str) -> None:
+        ret = subprocess.call(cmd, env=env)
+        if ret:
+            raise SystemExit(ret)
+
+    _cmd("yarn", "install", "--production", "--frozen-lockfile", "--quiet")
+    _cmd("yarn", "tsc", "-p", "config/tsconfig.build.json")
+    _cmd("yarn", "build-production", "--bail")
+    _cmd("yarn", "build-chartcuterie-config", "--bail")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.parse_args()
+
+    _build_static_assets()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/sentry/build/main.py
+++ b/src/sentry/build/main.py
@@ -1,0 +1,21 @@
+import argparse
+
+from sentry.build import _integration_docs, _js_sdk_registry, _static_assets
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.parse_args()
+
+    print("=> integration docs")
+    _integration_docs._sync_docs(_integration_docs._TARGET)
+    print("=> js sdk registry")
+    _js_sdk_registry._download(_js_sdk_registry._TARGET)
+    print("=> static assets")
+    _static_assets._build_static_assets()
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/sentry/utils/distutils/commands/build_assets.py
+++ b/src/sentry/utils/distutils/commands/build_assets.py
@@ -5,6 +5,8 @@ import logging
 import os
 import os.path
 
+from sentry.build._static_assets import _build_static_assets
+
 from .base import BaseBuildCommand
 
 log = logging.getLogger(__name__)
@@ -17,17 +19,7 @@ class BuildAssetsCommand(BaseBuildCommand):
         return ["src/sentry/static/sentry/dist"]
 
     def _build(self):
-        # By setting NODE_ENV=production, a few things happen
-        #   * React optimizes out certain code paths
-        #   * Webpack will add version strings to built/referenced assets
-        env = dict(os.environ)
-        env["SENTRY_STATIC_DIST_PATH"] = self.sentry_static_dist_path
-        env["NODE_ENV"] = "production"
-        # TODO: Our JS builds should not require 4GB heap space
-        env["NODE_OPTIONS"] = (env.get("NODE_OPTIONS", "") + " --max-old-space-size=4096").lstrip()
-        self._run_command(["yarn", "tsc", "-p", "config/tsconfig.build.json"], env=env)
-        self._run_command(["yarn", "build-production", "--bail"], env=env)
-        self._run_command(["yarn", "build-chartcuterie-config", "--bail"], env=env)
+        _build_static_assets()
 
     @property
     def sentry_static_dist_path(self):

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -113,7 +113,7 @@ const ENABLE_CODECOV_BA = env.CODECOV_ENABLE_BA === 'true' ?? false;
 // this is the path to the django "sentry" app, we output the webpack build here to `dist`
 // so that `django collectstatic` and so that we can serve the post-webpack bundles
 const sentryDjangoAppPath = path.join(__dirname, 'src/sentry/static/sentry');
-const distPath = env.SENTRY_STATIC_DIST_PATH || path.join(sentryDjangoAppPath, 'dist');
+const distPath = path.join(sentryDjangoAppPath, 'dist');
 const staticPrefix = path.join(__dirname, 'static');
 
 // Locale file extraction build step


### PR DESCRIPTION
need to get off setuptools so we can get to python 3.12 -- and so we can conditionally do the js build only for self-hosted (since we do it twice for getsentry for no reason!)

<!-- Describe your PR here. -->