### PR TITLE
fix(dashboards): Release filter should apply conditions over base query

### DIFF
--- a/static/app/components/modals/widgetViewerModal.spec.tsx
+++ b/static/app/components/modals/widgetViewerModal.spec.tsx
@@ -238,7 +238,7 @@ describe('Modals -> WidgetViewerModal', function () {
             query: expect.objectContaining({
               query:
                 // The release was injected into the discover query
-                'title:/organizations/:orgId/performance/summary/ release:"project-release@1.2.0" ',
+                '(title:/organizations/:orgId/performance/summary/) release:"project-release@1.2.0" ',
             }),
           })
         );

--- a/static/app/views/dashboards/detail.spec.tsx
+++ b/static/app/views/dashboards/detail.spec.tsx
@@ -453,7 +453,8 @@ describe('Dashboards > Detail', function () {
           '/organizations/org-slug/events-stats/',
           expect.objectContaining({
             query: expect.objectContaining({
-              query: 'event.type:transaction transaction:/api/cats release:"abc@1.2.0" ',
+              query:
+                '(event.type:transaction transaction:/api/cats) release:"abc@1.2.0" ',
             }),
           })
         )

--- a/static/app/views/dashboards/widgetCard/genericWidgetQueries.tsx
+++ b/static/app/views/dashboards/widgetCard/genericWidgetQueries.tsx
@@ -198,9 +198,13 @@ class GenericWidgetQueries<SeriesResponse, TableResponse> extends Component<
 
     const dashboardFilterConditions = dashboardFiltersToString(dashboardFilters);
     widget.queries.forEach(query => {
-      query.conditions =
-        query.conditions +
-        (dashboardFilterConditions === '' ? '' : ` ${dashboardFilterConditions}`);
+      if (dashboardFilterConditions) {
+        // If there is no base query, there's no need to add parens
+        if (query.conditions) {
+          query.conditions = `(${query.conditions})`;
+        }
+        query.conditions = query.conditions + ` ${dashboardFilterConditions}`;
+      }
     });
     return widget;
   }

--- a/static/app/views/dashboards/widgetCard/issueWidgetQueries.spec.tsx
+++ b/static/app/views/dashboards/widgetCard/issueWidgetQueries.spec.tsx
@@ -142,7 +142,7 @@ describe('IssueWidgetQueries', function () {
       expect.objectContaining({
         data: expect.objectContaining({
           query:
-            'assigned_or_suggested:#visibility timesSeen:>100 release:["abc@1.2.0","abc@1.3.0"] ',
+            '(assigned_or_suggested:#visibility timesSeen:>100) release:["abc@1.2.0","abc@1.3.0"] ',
         }),
       })
     );

--- a/static/app/views/dashboards/widgetCard/widgetQueries.spec.tsx
+++ b/static/app/views/dashboards/widgetCard/widgetQueries.spec.tsx
@@ -142,7 +142,7 @@ describe('Dashboards > WidgetQueries', function () {
       '/organizations/org-slug/events-stats/',
       expect.objectContaining({
         query: expect.objectContaining({
-          query: 'event.type:error release:["abc@1.2.0","abc@1.3.0"] ',
+          query: '(event.type:error) release:["abc@1.2.0","abc@1.3.0"] ',
         }),
       })
     );
@@ -170,7 +170,7 @@ describe('Dashboards > WidgetQueries', function () {
       '/organizations/org-slug/events/',
       expect.objectContaining({
         query: expect.objectContaining({
-          query: 'event.type:error release:"abc@1.3.0" ',
+          query: '(event.type:error) release:"abc@1.3.0" ',
         }),
       })
     );


### PR DESCRIPTION
When using OR filters, the previous application of filters would result in incorrect results. A OR B AND C is not the same as (A OR B) AND C, which is the proper way to apply the filter to the base query of a widget.