### PR TITLE
feat(hybridcloud) Align RPC schema generation with other api schema

### DIFF
--- a/.github/workflows/openapi.yml
+++ b/.github/workflows/openapi.yml
@@ -57,15 +57,17 @@ jobs:
         run: |
           yarn add ts-node && make build-api-docs
 
-      - name: Copy artifact into getsentry/sentry-api-schema
+      - name: Build RPC method schema
+        if: steps.changes.outputs.api_docs == 'true'
+        run: |
+          sentry rpcschema --partial > rpc_method_schema.json
+
+      - name: Copy artifacts into getsentry/sentry-api-schema
         if: steps.changes.outputs.api_docs == 'true'
         run: |
           cp tests/apidocs/openapi-derefed.json sentry-api-schema
-
-      - name: Copy publish status into getsentry/sentry-api-schema
-        if: steps.changes.outputs.api_docs == 'true'
-        run: |
           cp src/sentry/apidocs/api_ownership_stats_dont_modify.json sentry-api-schema
+          cp rpc_method_schema.json sentry-api-schema
 
       - name: Git Commit & Push
         uses: stefanzweifel/git-auto-commit-action@0049e3fa4059ca715255fbbcb7dea4516f02ce0a # v4.15.3


### PR DESCRIPTION
Generate the baseline RPC schema during master builds like we do for the public API schema. This will allow us to simplify the pull request workflow and remove a few steps.
