### PR TITLE
feat(insights): add hit/miss cache filter to sample panel

### DIFF
--- a/static/app/views/performance/cache/samplePanel/samplePanel.tsx
+++ b/static/app/views/performance/cache/samplePanel/samplePanel.tsx
@@ -319,6 +319,16 @@ export function CacheSamplePanel() {
               />
             </MetricsRibbon>
           </ModuleLayout.Full>
+          <ModuleLayout.Full>
+            <CompactSelect
+              value={query.statusClass}
+              options={CACHE_STATUS_OPTIONS}
+              onChange={handleStatusClassChange}
+              triggerProps={{
+                prefix: t('Status'),
+              }}
+            />
+          </ModuleLayout.Full>
           <ModuleLayout.Half>
             <CacheHitMissChart
               isLoading={isCacheHitRateLoading}
@@ -351,17 +361,6 @@ export function CacheSamplePanel() {
               }}
             />
           </ModuleLayout.Half>
-
-          <ModuleLayout.Full>
-            <CompactSelect
-              value={query.statusClass}
-              options={CACHE_STATUS_OPTIONS}
-              onChange={handleStatusClassChange}
-              triggerProps={{
-                prefix: t('Status'),
-              }}
-            />
-          </ModuleLayout.Full>
 
           <Fragment>
             <ModuleLayout.Full>


### PR DESCRIPTION
Adds a hit/miss filter for the cache sample panel above the graphs and below the statistics.

Re discussion: we'll move the hit/miss filter above the statistics once the key prefix filter is finished. The ideal page will have both filters at the very top above statistics, and the search bar above the samples table. 

<img width="948" alt="image" src="https://github.com/getsentry/sentry/assets/58920989/bbbccab3-51aa-4081-b92b-f80916d01437">