### PR TITLE
feat(hybridcloud) Use published rpc schema in comparison workflow

### DIFF
--- a/.github/workflows/openapi-diff.yml
+++ b/.github/workflows/openapi-diff.yml
@@ -55,28 +55,18 @@ jobs:
         run: |
           npx json-diff@0.5.4 --color sentry-api-schema/openapi-derefed.json tests/apidocs/openapi-derefed.json
 
-      # Do RPC compatibility checks. Combined with public API audits
-      # to avoid workflow/job setup overhead.
       - name: Dump RPC schema for new version
         id: newschema
         if: steps.changes.outputs.api_docs == 'true'
         run: |
           mkdir schemas
-          sentry rpcschema --partial > schemas/new_schema.json
+          sentry rpcschema --partial > rpc_method_schema.json
 
-      - name: Dump RPC schema for master
-        id: oldschema
-        if: steps.changes.outputs.api_docs == 'true'
-        run: |
-          git fetch origin
-          git switch master
-          sentry rpcschema --partial > schemas/old_schema.json
-
-      - name: Invoke oasdiff on RPC schemas
+      - name: Compare RPC schema with oasdiff
         uses: oasdiff/oasdiff-action/breaking@fc826b9f0d21b85b085842521c7a8cc445412c08 # v0.0.19
         if: steps.changes.outputs.api_docs == 'true'
         with:
-          base: ./schemas/old_schema.json
-          revision: ./schemas/new_schema.json
+          base: sentry-api-schema/rpc_method_schema.json
+          revision: ./rpc_method_schema.json
           format: 'text'
           fail-on-diff: true


### PR DESCRIPTION
Update the rpc schema breaking change workflow to use the schema files published by master builds.

Requires #71107
