### PR TITLE
fix(issue-stream): Ensure that empty state is shown correctly when all projects are selected

### DIFF
--- a/static/app/views/issueList/noGroupsHandler/index.spec.tsx
+++ b/static/app/views/issueList/noGroupsHandler/index.spec.tsx
@@ -1,0 +1,59 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import NoGroupsHandler from 'sentry/views/issueList/noGroupsHandler';
+
+describe('NoGroupsHandler', function () {
+  const defaultProps = {
+    api: new MockApiClient(),
+    query: '',
+    organization: OrganizationFixture(),
+    groupIds: [],
+  };
+
+  it('displays default empty state when first event has been sent', async function () {
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/projects/',
+      body: [],
+    });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/sent-first-event/',
+      body: {sentFirstEvent: true},
+    });
+
+    render(<NoGroupsHandler {...defaultProps} />);
+
+    expect(await screen.findByText('No issues match your search')).toBeInTheDocument();
+  });
+
+  it('displays default empty state when an error occurs', async function () {
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/projects/',
+      statusCode: 500,
+    });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/sent-first-event/',
+      statusCode: 500,
+    });
+
+    render(<NoGroupsHandler {...defaultProps} />);
+
+    expect(await screen.findByText('No issues match your search')).toBeInTheDocument();
+  });
+
+  it('displays waiting for events state when first event has not been sent', async function () {
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/projects/',
+      body: [],
+    });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/sent-first-event/',
+      body: {sentFirstEvent: false},
+    });
+
+    render(<NoGroupsHandler {...defaultProps} />);
+
+    expect(await screen.findByText(/Waiting for events/i)).toBeInTheDocument();
+  });
+});

--- a/static/app/views/issueList/noGroupsHandler/index.tsx
+++ b/static/app/views/issueList/noGroupsHandler/index.tsx
@@ -86,21 +86,30 @@ class NoGroupsHandler extends Component<Props, State> {
     let firstEventQuery: {project?: number[]} = {};
     const projectsQuery: {per_page: number; query?: string} = {per_page: 1};
 
-    if (selectedProjectIds?.length) {
+    if (selectedProjectIds?.length && !selectedProjectIds.includes(-1)) {
       firstEventQuery = {project: selectedProjectIds};
       projectsQuery.query = selectedProjectIds.map(id => `id:${id}`).join(' ');
     }
 
-    [{sentFirstEvent}, projects] = await Promise.all([
-      // checks to see if selection has sent a first event
-      api.requestPromise(`/organizations/${organization.slug}/sent-first-event/`, {
-        query: firstEventQuery,
-      }),
-      // retrieves a single project to feed to WaitingForEvents from renderStreamBody
-      api.requestPromise(`/organizations/${organization.slug}/projects/`, {
-        query: projectsQuery,
-      }),
-    ]);
+    try {
+      [{sentFirstEvent}, projects] = await Promise.all([
+        // checks to see if selection has sent a first event
+        api.requestPromise(`/organizations/${organization.slug}/sent-first-event/`, {
+          query: firstEventQuery,
+        }),
+        // retrieves a single project to feed to WaitingForEvents from renderStreamBody
+        api.requestPromise(`/organizations/${organization.slug}/projects/`, {
+          query: projectsQuery,
+        }),
+      ]);
+    } catch {
+      this.setState({
+        fetchingSentFirstEvent: false,
+        sentFirstEvent: true,
+        firstEventProjects: undefined,
+      });
+      return;
+    }
 
     // See comment where this property is initialized
     // FIXME


### PR DESCRIPTION
With `project="-1"`, the projects endpoint was failing. And because the component was not handling errors, it landed in a forever loading state. This fixes the endpoint so that it no longer fails with `project="-1"` and handles errors correctly to prevent this from happening again. 