### PR TITLE
ref(ui): Slightly better spacing on incident component icons

### DIFF
--- a/static/app/components/serviceIncidentDetails.tsx
+++ b/static/app/components/serviceIncidentDetails.tsx
@@ -66,7 +66,7 @@ export function ServiceIncidentDetails({incident}: Props) {
         <ComponentList>
           {sortBy(incident.components, i => COMPONENT_STATUS_SORT.indexOf(i.status)).map(
             ({name, status}, key) => (
-              <ComponentStatus key={key} padding="24px" symbol={getStatusSymbol(status)}>
+              <ComponentStatus key={key} padding="20px" symbol={getStatusSymbol(status)}>
                 {name}
               </ComponentStatus>
             )


### PR DESCRIPTION
before
<img width="368" alt="image" src="https://github.com/getsentry/sentry/assets/1421724/d821b130-5ae5-477c-a76c-c89b52d5cb4e">

after
<img width="354" alt="image" src="https://github.com/getsentry/sentry/assets/1421724/b3a99362-b918-4e18-9ff5-fbb207f20a3e">
