### PR TITLE
feat(hybridcloud) Add user_service.get_or_create_by_email

### DIFF
--- a/src/sentry/services/hybrid_cloud/user/model.py
+++ b/src/sentry/services/hybrid_cloud/user/model.py
@@ -123,6 +123,11 @@ class RpcUser(RpcUserProfile):
         return len(self.authenticators) > 0
 
 
+class UserCreateResult(RpcModel):
+    user: RpcUser
+    created: bool
+
+
 class UserSerializeType(IntEnum):  # annoying
     SIMPLE = 0
     DETAILED = 1

--- a/src/sentry/services/hybrid_cloud/user/service.py
+++ b/src/sentry/services/hybrid_cloud/user/service.py
@@ -21,6 +21,7 @@ from sentry.services.hybrid_cloud.user.model import (
     RpcAvatar,
     RpcUserProfile,
     RpcVerifyUserEmail,
+    UserCreateResult,
     UserIdEmailArgs,
 )
 from sentry.silo.base import SiloMode
@@ -228,6 +229,25 @@ class UserService(RpcService):
         ident: str | None = None,
         referrer: str | None = None,
     ) -> tuple[RpcUser, bool]:
+        """
+        Get or create a user with a matching email address or AuthIdentity
+
+        :param email: The email to search by.
+        :param ident: If provided, and multiple users are found with a matching email, the ident
+          is used to narrow down results.
+        :deprecated: Use get_or_create_by_email instead.
+        """
+        pass
+
+    @rpc_method
+    @abstractmethod
+    def get_or_create_by_email(
+        self,
+        *,
+        email: str,
+        ident: str | None = None,
+        referrer: str | None = None,
+    ) -> UserCreateResult:
         """
         Get or create a user with a matching email address or AuthIdentity
 


### PR DESCRIPTION
Our schema generation and validation tooling doesn't work well with tuples. Add a new RPC method that uses a model instead of a tuple.

Once this is deployed callsites will be updated.

Refs HC-1190