### PR TITLE
test(feedback): make sure empty event tags still adds tags onto the feedback event

### DIFF
--- a/tests/sentry/feedback/usecases/test_create_feedback.py
+++ b/tests/sentry/feedback/usecases/test_create_feedback.py
@@ -692,6 +692,72 @@ def test_create_feedback_adds_associated_event_id(
 
 
 @django_db_all
+def test_create_feedback_adds_empty_tags(default_project, mock_produce_occurrence_to_kafka):
+    event: dict[str, Any] = {
+        "project_id": 1,
+        "request": {
+            "url": "https://sentry.sentry.io/feedback/?statsPeriod=14d",
+            "headers": {
+                "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/118.0.0.0 Safari/537.36"
+            },
+        },
+        "event_id": "56b08cf7852c42cbb95e4a6998c66ad6",
+        "timestamp": 1698255009.574,
+        "received": "2021-10-24T22:23:29.574000+00:00",
+        "environment": "prod",
+        "release": "frontend@daf1316f209d961443664cd6eb4231ca154db502",
+        "sdk": {
+            "integrations": [
+                "InboundFilters",
+                "FunctionToString",
+                "TryCatch",
+                "Breadcrumbs",
+                "GlobalHandlers",
+                "LinkedErrors",
+                "Dedupe",
+                "HttpContext",
+                "ExtraErrorData",
+                "BrowserTracing",
+                "BrowserProfilingIntegration",
+            ],
+            "name": "sentry.javascript.react",
+            "version": "7.75.0",
+        },
+        "user": {
+            "ip_address": "72.164.175.154",
+            "email": "josh.ferge@sentry.io",
+            "id": 880461,
+            "isStaff": False,
+            "name": "Josh Ferge",
+        },
+        "contexts": {
+            "trace": {
+                "op": "navigation",
+                "span_id": "9ffadde1100e4d55",
+                "trace_id": "8e51f44000d34b8d871cea7f0c3e394c",
+            },
+            "organization": {"id": "1", "slug": "sentry"},
+            "feedback": {
+                "contact_email": "josh.ferge@sentry.io",
+                "name": "Josh Ferge",
+                "message": "josh ferge testing again!",
+                "replay_id": "3d621c61593c4ff9b43f8490a78ae18e",
+                "url": "https://sentry.sentry.io/feedback/?statsPeriod=14d",
+            },
+            "replay": {
+                "replay_id": "3d621c61593c4ff9b43f8490a78ae18e",
+            },
+        },
+        "breadcrumbs": [],
+        "platform": "javascript",
+    }
+
+    fixed_event = fix_for_issue_platform(event)
+    validate_issue_platform_event_schema(fixed_event)
+    assert fixed_event["tags"] == []
+
+
+@django_db_all
 def test_create_feedback_spam_detection_adds_field_calls(
     default_project,
     monkeypatch,


### PR DESCRIPTION
relates to https://github.com/getsentry/sentry/pull/71003#issuecomment-2118043797. testing that a feedback event created from an issue event w/ no tags still adds an empty `tags` onto the feedback event.