### PR TITLE
fix(insights): Left-align response status code column

### DIFF
--- a/static/app/utils/discover/fieldRenderers.tsx
+++ b/static/app/utils/discover/fieldRenderers.tsx
@@ -698,13 +698,13 @@ const SPECIAL_FIELDS: SpecialFields = {
   'span.status_code': {
     sortField: 'span.status_code',
     renderFunc: data => (
-      <NumberContainer>
+      <Container>
         {data['span.status_code'] ? (
           <ResponseStatusCodeCell code={parseInt(data['span.status_code'], 10)} />
         ) : (
           t('Unknown')
         )}
-      </NumberContainer>
+      </Container>
     ),
   },
 };

--- a/static/app/views/starfish/components/tableCells/renderHeadCell.tsx
+++ b/static/app/views/starfish/components/tableCells/renderHeadCell.tsx
@@ -67,7 +67,6 @@ export const SORTABLE_FIELDS = new Set([
 const NUMERIC_FIELDS = new Set([
   'transaction.duration',
   SpanMetricsField.CACHE_ITEM_SIZE,
-  SpanIndexedField.RESPONSE_CODE,
   SpanIndexedField.SPAN_SELF_TIME,
   SpanIndexedField.SPAN_DURATION,
   SpanIndexedField.CACHE_ITEM_SIZE,


### PR DESCRIPTION
Do not treat that column as numeric! It's only numeric -ish since because

1. Sometimes it's "Unknown" which is literally not a number
2. The actual numbers have specific significance, unlike a count
3. All the numbers are always 3 digits anyway

Left-alignment is a better fit here.

**e.g.,**
<img width="216" alt="Screenshot 2024-05-17 at 2 36 42 PM" src="https://github.com/getsentry/sentry/assets/989898/931648d2-8e2e-4d7f-8fa6-70625ad7b54d">
<img width="138" alt="Screenshot 2024-05-17 at 2 37 08 PM" src="https://github.com/getsentry/sentry/assets/989898/8daded80-c2ee-45c4-97d4-86fb01814a08">
