### PR TITLE
chore(similarity-embeddings): Skip flakey test for now

### DIFF
--- a/tests/sentry/tasks/test_backfill_seer_grouping_records.py
+++ b/tests/sentry/tasks/test_backfill_seer_grouping_records.py
@@ -1,4 +1,5 @@
 import copy
+import unittest
 from collections.abc import Mapping
 from random import choice
 from string import ascii_uppercase
@@ -851,6 +852,9 @@ class TestBackfillSeerGroupingRecords(SnubaTestCase, TestCase):
         last_processed_index = int(redis_client.get(make_backfill_redis_key(self.project.id)) or 0)
         assert last_processed_index == len(groups)
 
+    @unittest.skip(
+        "this test is flakey in production; trying to replicate locally and skipping it for now"
+    )
     @django_db_all
     @with_feature("projects:similarity-embeddings-backfill")
     @patch("sentry.tasks.backfill_seer_grouping_records.post_bulk_grouping_records")


### PR DESCRIPTION
This [test is flakey](https://sentry.sentry.io/issues/5366231364/events/d62113fc00514b07b25494db890803ca/?project=2423079) in production; trying to replicate locally and skipping it for now
The code that this test is testing will not be run in production unless it's manually triggered by us, thus it's safe to keep it in