### PR TITLE
Send additional data when logging metric alert query exceptions 

### DIFF
--- a/src/sentry/incidents/subscription_processor.py
+++ b/src/sentry/incidents/subscription_processor.py
@@ -228,7 +228,14 @@ class SubscriptionProcessor:
             comparison_aggregate = list(results["data"][0].values())[0]
 
         except Exception:
-            logger.exception("Failed to run comparison query")
+            logger.exception(
+                "Failed to run comparison query",
+                extra={
+                    "alert_rule_id": self.alert_rule.id,
+                    "subscription_id": subscription_update.get("subscription_id"),
+                    "organization_id": self.alert_rule.organization_id,
+                },
+            )
             return None
 
         if not comparison_aggregate:


### PR DESCRIPTION
## Description
Include extra information when logging the exception, this will help us find specific problems with specific alert issues.