### PR TITLE
fix(autofix): Show setup modal when generative AI consent has not been enabled

### DIFF
--- a/static/app/components/events/autofix/useAutofixSetup.tsx
+++ b/static/app/components/events/autofix/useAutofixSetup.tsx
@@ -50,7 +50,7 @@ export function useAutofixSetup(
     hasSuccessfulSetup: Boolean(
       queryData.data?.integration.ok &&
         queryData.data?.githubWriteIntegration.ok &&
-        // queryData.data?.genAIConsent.ok &&
+        queryData.data?.genAIConsent.ok &&
         queryData.data?.codebaseIndexing.ok
     ),
   };

--- a/static/app/components/modals/autofixSetupModal.tsx
+++ b/static/app/components/modals/autofixSetupModal.tsx
@@ -217,8 +217,9 @@ function AutofixCodebaseIndexingStep({
   const {startIndexing} = useAutofixCodebaseIndexing({projectId, groupId});
 
   const canIndex =
-    // autofixSetup.genAIConsent.ok &&
-    autofixSetup.integration.ok && autofixSetup.githubWriteIntegration.ok;
+    autofixSetup.genAIConsent.ok &&
+    autofixSetup.integration.ok &&
+    autofixSetup.githubWriteIntegration.ok;
 
   return (
     <Fragment>


### PR DESCRIPTION
This has been enabled in the Sentry org so enabling it shouldn't break everything this time.