### PR TITLE
feat(insights): add status and retry filtering to queue sample panel

### DIFF
--- a/static/app/views/performance/queues/destinationSummary/messageSpanSamplesPanel.tsx
+++ b/static/app/views/performance/queues/destinationSummary/messageSpanSamplesPanel.tsx
@@ -4,7 +4,7 @@ import * as qs from 'query-string';
 
 import ProjectAvatar from 'sentry/components/avatar/projectAvatar';
 import {Button} from 'sentry/components/button';
-import {CompactSelect} from 'sentry/components/compactSelect';
+import {CompactSelect, type SelectOption} from 'sentry/components/compactSelect';
 import Link from 'sentry/components/links/link';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
@@ -73,7 +73,7 @@ export function MessageSpanSamplesPanel() {
     ? [query.destination, query.transaction].filter(Boolean).join(':')
     : undefined;
 
-  const handleStatusChange = newStatus => {
+  const handleStatusChange = (newStatus: SelectOption<string>) => {
     trackAnalytics('performance_views.sample_spans.filter_updated', {
       filter: 'status',
       new_state: newStatus.value,
@@ -89,7 +89,7 @@ export function MessageSpanSamplesPanel() {
     });
   };
 
-  const handleRetriesChange = newRetries => {
+  const handleRetriesChange = (newRetries: SelectOption<string>) => {
     trackAnalytics('performance_views.sample_spans.filter_updated', {
       filter: 'retries',
       new_state: newRetries.value,
@@ -145,11 +145,13 @@ export function MessageSpanSamplesPanel() {
 
   const durationAxisMax = computeAxisMax([durationData?.[`avg(span.duration)`]]);
 
+  // Filter by trace status if status is set
+  // Note: filtering should only affect the sample spans in the table and not the timeseries graph
   if (query.status.length > 0) {
     search.addFilterValue('trace.status', query.status);
   }
 
-  // Note: only consumers should show the retry count filter
+  // Note: only consumer panels should allow filtering by retry count
   if (messageActorType === MessageActorType.CONSUMER) {
     if (query.retries === '0') {
       search.addFilterValue('measurements.messaging.message.retry.count', '0');

--- a/static/app/views/performance/queues/destinationSummary/messageSpanSamplesPanel.tsx
+++ b/static/app/views/performance/queues/destinationSummary/messageSpanSamplesPanel.tsx
@@ -181,7 +181,6 @@ export function MessageSpanSamplesPanel() {
       SpanIndexedField.MESSAGING_MESSAGE_RECEIVE_LATENCY,
       SpanIndexedField.MESSAGING_MESSAGE_RETRY_COUNT,
       SpanIndexedField.MESSAGING_MESSAGE_ID,
-      SpanIndexedField.MESSAGING_MESSAGE_DESTINATION_NAME,
       SpanIndexedField.TRACE_STATUS,
       SpanIndexedField.SPAN_DURATION,
     ],
@@ -280,6 +279,7 @@ export function MessageSpanSamplesPanel() {
           <ModuleLayout.Full>
             <PanelControls>
               <CompactSelect
+                searchable
                 value={query.status}
                 options={STATUS_OPTIONS}
                 onChange={handleStatusChange}

--- a/static/app/views/performance/queues/queryParameterDecoders/retryCount.tsx
+++ b/static/app/views/performance/queues/queryParameterDecoders/retryCount.tsx
@@ -1,0 +1,23 @@
+import {decodeScalar} from 'sentry/utils/queryString';
+import {RETRY_COUNT_OPTIONS} from 'sentry/views/performance/queues/settings';
+
+// Include default value of '' that represents all options
+const OPTIONS = ['', ...RETRY_COUNT_OPTIONS] as const;
+const DEFAULT = '';
+
+type RetryCount = (typeof OPTIONS)[number];
+
+export default function decode(value: string | string[] | undefined | null): RetryCount {
+  const decodedValue = decodeScalar(value, DEFAULT);
+
+  if (isAValidOption(decodedValue)) {
+    return decodedValue;
+  }
+
+  return DEFAULT;
+}
+
+function isAValidOption(maybeOption: string): maybeOption is RetryCount {
+  // Manually widen to allow the comparison to string
+  return (OPTIONS as unknown as string[]).includes(maybeOption as RetryCount);
+}

--- a/static/app/views/performance/queues/queryParameterDecoders/traceStatus.tsx
+++ b/static/app/views/performance/queues/queryParameterDecoders/traceStatus.tsx
@@ -1,0 +1,23 @@
+import {decodeScalar} from 'sentry/utils/queryString';
+import {TRACE_STATUS_OPTIONS} from 'sentry/views/performance/queues/settings';
+
+// Include default value of '' that represents all options
+const OPTIONS = ['', ...TRACE_STATUS_OPTIONS] as const;
+const DEFAULT = '';
+
+type TraceStatus = (typeof OPTIONS)[number];
+
+export default function decode(value: string | string[] | undefined | null): TraceStatus {
+  const decodedValue = decodeScalar(value, DEFAULT);
+
+  if (isAValidOption(decodedValue)) {
+    return decodedValue;
+  }
+
+  return DEFAULT;
+}
+
+function isAValidOption(maybeOption: string): maybeOption is TraceStatus {
+  // Manually widen to allow the comparison to string
+  return (OPTIONS as unknown as string[]).includes(maybeOption as TraceStatus);
+}

--- a/static/app/views/performance/queues/settings.ts
+++ b/static/app/views/performance/queues/settings.ts
@@ -18,6 +18,28 @@ export const DEFAULT_QUERY_FILTER = 'span.op:[queue.process,queue.publish]';
 export const CONSUMER_QUERY_FILTER = 'span.op:queue.process';
 export const PRODUCER_QUERY_FILTER = 'span.op:queue.publish';
 
+export const TRACE_STATUS_OPTIONS = [
+  'ok',
+  'cancelled',
+  'unknown',
+  'unknown_error',
+  'invalid_argument',
+  'deadline_exceeded',
+  'not_found',
+  'already_exists',
+  'permission_denied',
+  'resource_exhausted',
+  'failed_precondition',
+  'aborted',
+  'out_of_range',
+  'unimplemented',
+  'internal_error',
+  'unavailable',
+  'data_loss',
+  'unauthenticated',
+];
+export const RETRY_COUNT_OPTIONS = ['0', '1-3', '4+'];
+
 export enum MessageActorType {
   PRODUCER = 'producer',
   CONSUMER = 'consumer',


### PR DESCRIPTION
Adds status and retry filtering to the queue sample panel. Retry filters are only available for consumers.

<img width="949" alt="image" src="https://github.com/getsentry/sentry/assets/58920989/74708859-9357-4f43-b84f-6c85cdd32e13">

