### PR TITLE
feat(trace): add searching by entity duration

### DIFF
--- a/static/app/views/performance/newTraceDetails/traceSearch/traceSearchEvaluator.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceSearch/traceSearchEvaluator.spec.tsx
@@ -1,5 +1,7 @@
 import {waitFor} from 'sentry-test/reactTestingLibrary';
 
+import type {RawSpanType} from 'sentry/components/events/interfaces/spans/types';
+import type {EventTransaction} from 'sentry/types';
 import {
   type TraceTree,
   TraceTreeNode,
@@ -23,6 +25,20 @@ function makeTransaction(
   } as TraceTree.Transaction;
 }
 
+function makeSpan(overrides: Partial<RawSpanType> = {}): TraceTree.Span {
+  return {
+    span_id: '',
+    op: '',
+    description: '',
+    start_timestamp: 0,
+    timestamp: 10,
+    data: {},
+    trace_id: '',
+    childTransactions: [],
+    event: undefined as unknown as EventTransaction,
+    ...overrides,
+  };
+}
 const makeTree = (list: TraceTree.NodeValue[]): TraceTree => {
   return {
     list: list.map(
@@ -31,10 +47,10 @@ const makeTree = (list: TraceTree.NodeValue[]): TraceTree => {
   } as unknown as TraceTree;
 };
 
-const search = (query: string, list: TraceTree.NodeValue[], cb: any) => {
+const search = (query: string, tree: TraceTree, cb: any) => {
   searchInTraceTreeTokens(
-    makeTree(list),
-    // @ts-expect-error test failed parse
+    tree,
+    // @ts-expect-error dont care if this fails
     parseTraceSearch(query),
     null,
     cb
@@ -43,10 +59,10 @@ const search = (query: string, list: TraceTree.NodeValue[], cb: any) => {
 
 describe('TraceSearchEvaluator', () => {
   it('empty string', async () => {
-    const list = [
+    const list = makeTree([
       makeTransaction({'transaction.op': 'operation'}),
       makeTransaction({'transaction.op': 'other'}),
-    ];
+    ]);
 
     const cb = jest.fn();
     search('', list, cb);
@@ -68,10 +84,10 @@ describe('TraceSearchEvaluator', () => {
     ['()'],
     ['(invalid_query)'],
   ])('invalid grammar %s', async query => {
-    const list = [
+    const list = makeTree([
       makeTransaction({'transaction.op': 'operation'}),
       makeTransaction({'transaction.op': 'other'}),
-    ];
+    ]);
 
     const cb = jest.fn();
     search(query, list, cb);
@@ -81,5 +97,216 @@ describe('TraceSearchEvaluator', () => {
     expect(cb.mock.calls[0][0][0]).toEqual([]);
     expect(cb.mock.calls[0][0][1].size).toBe(0);
     expect(cb.mock.calls[0][0][2]).toBe(null);
+  });
+
+  it('AND query', async () => {
+    const tree = makeTree([
+      makeTransaction({'transaction.op': 'operation', transaction: 'something'}),
+      makeTransaction({'transaction.op': 'other'}),
+    ]);
+
+    const cb = jest.fn();
+    search('transaction.op:operation AND transaction:something', tree, cb);
+    await waitFor(() => {
+      expect(cb).toHaveBeenCalled();
+    });
+    expect(cb.mock.calls[0][0][1].size).toBe(1);
+    expect(cb.mock.calls[0][0][0]).toEqual([{index: 0, value: tree.list[0]}]);
+    expect(cb.mock.calls[0][0][2]).toBe(null);
+  });
+
+  it('OR query', async () => {
+    const tree = makeTree([
+      makeTransaction({'transaction.op': 'operation'}),
+      makeTransaction({'transaction.op': 'other'}),
+    ]);
+
+    const cb = jest.fn();
+    search('transaction.op:operation OR transaction.op:other', tree, cb);
+    await waitFor(() => {
+      expect(cb).toHaveBeenCalled();
+    });
+    expect(cb.mock.calls[0][0][0]).toEqual([
+      {index: 0, value: tree.list[0]},
+      {index: 1, value: tree.list[1]},
+    ]);
+    expect(cb.mock.calls[0][0][1].size).toBe(2);
+    expect(cb.mock.calls[0][0][2]).toBe(null);
+  });
+
+  it('OR with AND respects precedence', async () => {
+    const tree = makeTree([
+      makeTransaction({'transaction.op': 'operation', transaction: 'something'}),
+      makeTransaction({'transaction.op': 'other', transaction: ''}),
+    ]);
+
+    const cb = jest.fn();
+    // (transaction.op:operation AND transaction:something) OR transaction.op:other
+    search(
+      'transaction.op:operation AND transaction:something OR transaction.op:other',
+      tree,
+      cb
+    );
+    await waitFor(() => {
+      expect(cb).toHaveBeenCalled();
+    });
+    expect(cb.mock.calls[0][0][1].size).toBe(1);
+    expect(cb.mock.calls[0][0][0]).toEqual([{index: 0, value: tree.list[0]}]);
+    expect(cb.mock.calls[0][0][2]).toBe(null);
+  });
+
+  describe('transaction', () => {
+    it('text filter', async () => {
+      const tree = makeTree([
+        makeTransaction({'transaction.op': 'operation'}),
+        makeTransaction({'transaction.op': 'other'}),
+      ]);
+
+      const cb = jest.fn();
+      search('transaction.op:operation', tree, cb);
+      await waitFor(() => expect(cb).toHaveBeenCalled());
+      expect(cb.mock.calls[0][0][1].size).toBe(1);
+      expect(cb.mock.calls[0][0][0]).toEqual([{index: 0, value: tree.list[0]}]);
+      expect(cb.mock.calls[0][0][2]).toBe(null);
+    });
+
+    it('transaction.duration (milliseconds)', async () => {
+      const tree = makeTree([
+        makeTransaction({'transaction.duration': 1000}),
+        makeTransaction({'transaction.duration': 500}),
+      ]);
+
+      const cb = jest.fn();
+      search('transaction.duration:>500ms', tree, cb);
+      await waitFor(() => expect(cb).toHaveBeenCalled());
+      expect(cb.mock.calls[0][0][1].size).toBe(1);
+      expect(cb.mock.calls[0][0][0]).toEqual([{index: 0, value: tree.list[0]}]);
+      expect(cb.mock.calls[0][0][2]).toBe(null);
+    });
+
+    it('transaction.duration (seconds)', async () => {
+      const tree = makeTree([
+        makeTransaction({'transaction.duration': 1000}),
+        makeTransaction({'transaction.duration': 500}),
+      ]);
+
+      const cb = jest.fn();
+      search('transaction.duration:>0.5s', tree, cb);
+      await waitFor(() => expect(cb).toHaveBeenCalled());
+      expect(cb.mock.calls[0][0][1].size).toBe(1);
+      expect(cb.mock.calls[0][0][0]).toEqual([{index: 0, value: tree.list[0]}]);
+      expect(cb.mock.calls[0][0][2]).toBe(null);
+    });
+
+    it('transaction.total_time', async () => {
+      const tree = makeTree([
+        makeTransaction({start_timestamp: 0, timestamp: 1}),
+        makeTransaction({start_timestamp: 0, timestamp: 0.5}),
+      ]);
+
+      const cb = jest.fn();
+      search('transaction.total_time:>0.5s', tree, cb);
+      await waitFor(() => expect(cb).toHaveBeenCalled());
+      expect(cb.mock.calls[0][0][1].size).toBe(1);
+      expect(cb.mock.calls[0][0][0]).toEqual([{index: 0, value: tree.list[0]}]);
+      expect(cb.mock.calls[0][0][2]).toBe(null);
+    });
+
+    // For consistency between spans and txns, should should be implemented
+    // it('transaction.self_time', () => {});
+  });
+
+  describe('span', () => {
+    it('text filter', async () => {
+      const tree = makeTree([makeSpan({op: 'db'}), makeSpan({op: 'http'})]);
+
+      const cb = jest.fn();
+      search('op:db', tree, cb);
+      await waitFor(() => expect(cb).toHaveBeenCalled());
+      expect(cb.mock.calls[0][0][1].size).toBe(1);
+      expect(cb.mock.calls[0][0][0]).toEqual([{index: 0, value: tree.list[0]}]);
+      expect(cb.mock.calls[0][0][2]).toBe(null);
+    });
+
+    it('span.duration (milliseconds)', async () => {
+      const tree = makeTree([
+        makeSpan({start_timestamp: 0, timestamp: 1}),
+        makeSpan({start_timestamp: 0, timestamp: 0.5}),
+      ]);
+
+      const cb = jest.fn();
+      search('span.duration:>500ms', tree, cb);
+      await waitFor(() => expect(cb).toHaveBeenCalled());
+      expect(cb.mock.calls[0][0][1].size).toBe(1);
+      expect(cb.mock.calls[0][0][0]).toEqual([{index: 0, value: tree.list[0]}]);
+      expect(cb.mock.calls[0][0][2]).toBe(null);
+    });
+
+    it('span.duration (seconds)', async () => {
+      const tree = makeTree([
+        makeSpan({start_timestamp: 0, timestamp: 1}),
+        makeSpan({start_timestamp: 0, timestamp: 0.5}),
+      ]);
+
+      const cb = jest.fn();
+      search('span.duration:>0.5s', tree, cb);
+      await waitFor(() => expect(cb).toHaveBeenCalled());
+      expect(cb.mock.calls[0][0][1].size).toBe(1);
+      expect(cb.mock.calls[0][0][0]).toEqual([{index: 0, value: tree.list[0]}]);
+      expect(cb.mock.calls[0][0][2]).toBe(null);
+    });
+
+    it('span.total_time', async () => {
+      const tree = makeTree([
+        makeSpan({start_timestamp: 0, timestamp: 1}),
+        makeSpan({start_timestamp: 0, timestamp: 0.5}),
+      ]);
+
+      const cb = jest.fn();
+      search('span.total_time:>0.5s', tree, cb);
+      await waitFor(() => expect(cb).toHaveBeenCalled());
+      expect(cb.mock.calls[0][0][1].size).toBe(1);
+      expect(cb.mock.calls[0][0][0]).toEqual([{index: 0, value: tree.list[0]}]);
+      expect(cb.mock.calls[0][0][2]).toBe(null);
+    });
+    it('span.self_time', async () => {
+      const tree = makeTree([
+        makeSpan({exclusive_time: 1000}),
+        makeSpan({exclusive_time: 500}),
+      ]);
+
+      const cb = jest.fn();
+      search('span.self_time:>0.5s', tree, cb);
+      await waitFor(() => expect(cb).toHaveBeenCalled());
+      expect(cb.mock.calls[0][0][1].size).toBe(1);
+      expect(cb.mock.calls[0][0][0]).toEqual([{index: 0, value: tree.list[0]}]);
+      expect(cb.mock.calls[0][0][2]).toBe(null);
+    });
+    it('span.exclusive_time', async () => {
+      const tree = makeTree([
+        makeSpan({exclusive_time: 1000}),
+        makeSpan({exclusive_time: 500}),
+      ]);
+
+      const cb = jest.fn();
+      search('span.exclusive_time:>0.5s', tree, cb);
+      await waitFor(() => expect(cb).toHaveBeenCalled());
+      expect(cb.mock.calls[0][0][1].size).toBe(1);
+      expect(cb.mock.calls[0][0][0]).toEqual([{index: 0, value: tree.list[0]}]);
+      expect(cb.mock.calls[0][0][2]).toBe(null);
+    });
+    it('exclusive_time', async () => {
+      const tree = makeTree([
+        makeSpan({exclusive_time: 1000}),
+        makeSpan({exclusive_time: 500}),
+      ]);
+
+      const cb = jest.fn();
+      search('exclusive_time:>0.5s', tree, cb);
+      await waitFor(() => expect(cb).toHaveBeenCalled());
+      expect(cb.mock.calls[0][0][1].size).toBe(1);
+      expect(cb.mock.calls[0][0][0]).toEqual([{index: 0, value: tree.list[0]}]);
+      expect(cb.mock.calls[0][0][2]).toBe(null);
+    });
   });
 });

--- a/static/app/views/performance/newTraceDetails/traceSearch/traceSearchEvaluator.tsx
+++ b/static/app/views/performance/newTraceDetails/traceSearch/traceSearchEvaluator.tsx
@@ -414,8 +414,14 @@ function evaluateValueNumber<T extends Token.VALUE_DURATION | Token.VALUE_NUMBER
   }
 }
 
-// @TODO Alias self time, total time.
-const DURATION_ALIASES = new Set(['duration']);
+const TRANSACTION_DURATION_ALIASES = new Set([
+  'duration',
+  // 'transaction.duration', <-- this is an actual key
+  'transaction.total_time',
+]);
+const SPAN_DURATION_ALIASES = new Set(['duration', 'span.duration', 'span.total_time']);
+const SPAN_SELF_TIME_ALIASES = new Set(['span.self_time', 'span.exclusive_time']);
+
 // Pulls the value from the node based on the key in the token
 function resolveValueFromKey(
   node: TraceTreeNode<TraceTree.NodeValue>,
@@ -431,9 +437,30 @@ function resolveValueFromKey(
     let key: string | null = null;
     switch (token.key.type) {
       case Token.KEY_SIMPLE: {
-        if (DURATION_ALIASES.has(token.key.value) && node.space) {
+        if (
+          TRANSACTION_DURATION_ALIASES.has(token.key.value) &&
+          isTransactionNode(node) &&
+          node.space
+        ) {
           return node.space[1];
         }
+
+        if (
+          SPAN_DURATION_ALIASES.has(token.key.value) &&
+          isSpanNode(node) &&
+          node.space
+        ) {
+          return node.space[1];
+        }
+
+        if (
+          SPAN_SELF_TIME_ALIASES.has(token.key.value) &&
+          isSpanNode(node) &&
+          node.space
+        ) {
+          return node.value.exclusive_time;
+        }
+
         key = token.key.value;
         break;
       }

--- a/static/app/views/performance/newTraceDetails/traceSearch/traceTokenConverter.tsx
+++ b/static/app/views/performance/newTraceDetails/traceSearch/traceTokenConverter.tsx
@@ -23,6 +23,12 @@ const TRANSACTION_NUMERIC_KEYS: (keyof TraceTree.Transaction)[] = [
 ];
 const TRANSACTION_DURATION_KEYS: (keyof TraceTree.Transaction)[] = [
   'transaction.duration',
+  // The keys below are not real keys returned by the API, but are instead
+  // mapped by the frontend to the correct keys for convenience and UX reasons
+  // @ts-expect-error
+  'transaction.total_time',
+  // @TODO for consistency with spans, this should be implemented
+  // 'transaction.self_time'
 ];
 
 // @TODO the current date parsing does not support timestamps, so we
@@ -48,7 +54,18 @@ const SPAN_NUMERIC_KEYS: (keyof TraceTree.Span)[] = ['timestamp', 'start_timesta
 const SPAN_DURATION_KEYS: (keyof TraceTree.Span)[] = [
   // @TODO create aliases for self_time total_time and duration.
   'exclusive_time',
+  // The keys below are not real keys returned by the API, but are instead
+  // mapped by the frontend to the correct keys for convenience and UX reasons
+  // @ts-expect-error
+  'span.duration',
+  // @ts-expect-error
+  'span.total_time',
+  // @ts-expect-error
+  'span.self_time',
+  // @ts-expect-error
+  'span.exclusive_time',
 ];
+
 // @TODO the current date parsing does not support timestamps, so we
 // exclude these keys for now and parse them as numeric keys
 const SPAN_DATE_KEYS: (keyof TraceTree.Span)[] = [


### PR DESCRIPTION
Implements search support for span.total_time, span.self_time, span.exclusive_time and transaction.total_time