### PR TITLE
feat(forms): Add function option for `disabledReason`

### DIFF
--- a/static/app/components/forms/fieldGroup/types.tsx
+++ b/static/app/components/forms/fieldGroup/types.tsx
@@ -30,7 +30,7 @@ export interface FieldGroupProps {
   /**
    * Produces a question tooltip on the field, explaining why it is disabled
    */
-  disabledReason?: React.ReactNode;
+  disabledReason?: React.ReactNode | ((props: FieldGroupProps) => React.ReactNode);
   /**
    * Display the  error indicator
    */

--- a/static/app/components/forms/fields/booleanField.tsx
+++ b/static/app/components/forms/fields/booleanField.tsx
@@ -33,7 +33,7 @@ export default class BooleanField extends Component<BooleanFieldProps> {
   };
 
   render() {
-    const {confirm, disabledReason, ...fieldProps} = this.props;
+    const {confirm, ...fieldProps} = this.props;
 
     return (
       <FormField {...fieldProps} resetOnError>
@@ -43,9 +43,11 @@ export default class BooleanField extends Component<BooleanFieldProps> {
           onBlur,
           value,
           disabled,
+          disabledReason,
           ...props
         }: {
           disabled: boolean;
+          disabledReason: boolean;
           onBlur: OnEvent;
           onChange: OnEvent;
           type: string;

--- a/static/app/components/forms/fields/selectField.tsx
+++ b/static/app/components/forms/fields/selectField.tsx
@@ -99,14 +99,7 @@ export default class SelectField<OptionType extends SelectValue<any>> extends Co
   };
 
   render() {
-    const {
-      allowClear,
-      confirm,
-      multiple,
-      disabledReason,
-      hideControlState,
-      ...otherProps
-    } = this.props;
+    const {allowClear, confirm, multiple, hideControlState, ...otherProps} = this.props;
 
     return (
       <FormField {...otherProps} hideControlState flexibleControlStateSize>
@@ -117,6 +110,7 @@ export default class SelectField<OptionType extends SelectValue<any>> extends Co
           required: _required,
           children: _children,
           disabled,
+          disabledReason,
           model,
           name,
           ...props

--- a/static/app/components/forms/formField/index.tsx
+++ b/static/app/components/forms/formField/index.tsx
@@ -54,6 +54,7 @@ const propsToObserve = [
   'inline',
   'visible',
   'disabled',
+  'disabledReason',
 ] satisfies Array<keyof FormFieldProps>;
 
 interface FormFieldPropModel extends FormFieldProps {
@@ -75,6 +76,7 @@ type ObservedPropResolver = [
  */
 interface ObservableProps {
   disabled?: ObservedFnOrValue<{}, FieldGroupProps['disabled']>;
+  disabledReason?: ObservedFnOrValue<{}, FieldGroupProps['disabledReason']>;
   help?: ObservedFnOrValue<{}, FieldGroupProps['help']>;
   highlighted?: ObservedFnOrValue<{}, FieldGroupProps['highlighted']>;
   inline?: ObservedFnOrValue<{}, FieldGroupProps['inline']>;
@@ -86,6 +88,7 @@ interface ObservableProps {
  */
 interface ResolvedObservableProps {
   disabled?: FieldGroupProps['disabled'];
+  disabledReason?: FieldGroupProps['disabledReason'];
   help?: FieldGroupProps['help'];
   highlighted?: FieldGroupProps['highlighted'];
   inline?: FieldGroupProps['inline'];

--- a/static/app/components/forms/types.tsx
+++ b/static/app/components/forms/types.tsx
@@ -46,7 +46,7 @@ interface BaseField {
   confirm?: {[key: string]: React.ReactNode};
   defaultValue?: FieldValue;
   disabled?: boolean | ((props: any) => boolean);
-  disabledReason?: React.ReactNode;
+  disabledReason?: React.ReactNode | ((props: any) => React.ReactNode);
   extraHelp?: string;
   flexibleControlStateSize?: boolean;
   formatLabel?: (value: number | '') => React.ReactNode;


### PR DESCRIPTION
this pr adds the option to have `disabledReason` be a function. this will help align it with `disabled` which already allows for functions, which means that the tooltip we display can differ, depending on why it is disabled. Right now, you can check a variety of conditions to see if it should be disabled or not, but can only show one reason. 