### PR TITLE
feat(crons): Add processing error display to monitor details page

### DIFF
--- a/static/app/views/monitors/components/processingErrors/monitorProcessingErrors.tsx
+++ b/static/app/views/monitors/components/processingErrors/monitorProcessingErrors.tsx
@@ -1,0 +1,61 @@
+import styled from '@emotion/styled';
+
+import Alert from 'sentry/components/alert';
+import {DateTime} from 'sentry/components/dateTime';
+import List from 'sentry/components/list';
+import ListItem from 'sentry/components/list/listItem';
+import {Tooltip} from 'sentry/components/tooltip';
+import {t, tct} from 'sentry/locale';
+import {ProcessingErrorItem} from 'sentry/views/monitors/components/processingErrors/processingErrorItem';
+import type {CheckInPayload, CheckinProcessingError} from 'sentry/views/monitors/types';
+
+export default function MonitorProcessingErrors({
+  checkinErrors,
+}: {
+  checkinErrors: CheckinProcessingError[];
+}) {
+  const flattenedErrors = checkinErrors.flatMap(({errors, checkin}) =>
+    errors.map(error => ({error, checkin}))
+  );
+
+  const renderCheckinTooltip = (checkin: CheckInPayload) => (
+    <Tooltip
+      skipWrapper
+      title={
+        <div>
+          {tct('[status] check-in sent on [date]', {
+            status: checkin.payload.status,
+            date: <DateTime timeZone date={checkin.message.start_time * 1000} />,
+          })}
+        </div>
+      }
+      showUnderline
+    />
+  );
+
+  return (
+    <ScrollableAlert
+      type="error"
+      showIcon
+      expand={
+        <List symbol="bullet">
+          {flattenedErrors.map(({error, checkin}, i) => (
+            <ListItem key={i}>
+              <ProcessingErrorItem
+                error={error}
+                checkinTooltip={renderCheckinTooltip(checkin)}
+              />
+            </ListItem>
+          ))}
+        </List>
+      }
+    >
+      {t('Errors were encountered while ingesting check-ins for this monitor')}
+    </ScrollableAlert>
+  );
+}
+
+const ScrollableAlert = styled(Alert)`
+  max-height: 400px;
+  overflow-y: auto;
+`;

--- a/static/app/views/monitors/components/processingErrors/processingErrorItem.tsx
+++ b/static/app/views/monitors/components/processingErrors/processingErrorItem.tsx
@@ -1,0 +1,117 @@
+import ExternalLink from 'sentry/components/links/externalLink';
+import Link from 'sentry/components/links/link';
+import {tct} from 'sentry/locale';
+import {type ProcessingError, ProcessingErrorType} from 'sentry/views/monitors/types';
+
+interface Props {
+  checkinTooltip: React.ReactNode;
+  error: ProcessingError;
+}
+
+export function ProcessingErrorItem({error, checkinTooltip}: Props) {
+  switch (error.type) {
+    case ProcessingErrorType.CHECKIN_ENVIRONMENT_MISMATCH:
+      return tct(
+        'The environment of the second [checkinTooltip:check-in] does not match the original "[env]" environment. Ensure both check-ins have the same environment.',
+        {checkinTooltip, env: error.existingEnvironment}
+      );
+    case ProcessingErrorType.CHECKIN_FINISHED:
+      return tct(
+        'A [checkinTooltip:check-in] update was sent to a check-in that has already succeeded or failed. Only in-progress check-ins can be updated.',
+        {checkinTooltip}
+      );
+    case ProcessingErrorType.CHECKIN_GUID_PROJECT_MISMATCH:
+      return tct(
+        'The [checkinTooltip:check-in] GUID provided matched a project different than the associated DSN project. Use the correct project DSN to successfully process check-ins',
+        {checkinTooltip}
+      );
+    case ProcessingErrorType.CHECKIN_INVALID_DURATION:
+      return tct(
+        'A [checkinTooltip:check-in] was sent with an invalid duration of "[duration]".',
+        {
+          checkinTooltip,
+          duration: error.duration,
+        }
+      );
+    case ProcessingErrorType.CHECKIN_INVALID_GUID:
+      return tct('A [checkinTooltip:check-in] was sent with an invalid GUID.', {
+        checkinTooltip,
+      });
+    case ProcessingErrorType.CHECKIN_VALIDATION_FAILED:
+      return tct(
+        'A [checkinTooltip:check-in] was sent with an invalid payload. Learn more about the check-in payload in our [link:documentation]',
+        {
+          checkinTooltip,
+          link: (
+            <ExternalLink href="https://docs.sentry.io/product/crons/getting-started/http/" />
+          ),
+        }
+      );
+    case ProcessingErrorType.MONITOR_DISABLED:
+      return tct(
+        'A [checkinTooltip:check-in] was sent but was discarded because the monitor is disabled.',
+        {checkinTooltip}
+      );
+    case ProcessingErrorType.MONITOR_DISABLED_NO_QUOTA:
+      return tct(
+        'A [checkinTooltip:check-in] upsert was sent but dropped due to insufficient quota. To create new monitors, increase your Crons on-demand budget in your [link: subscription settings].',
+        {checkinTooltip, link: <Link to="/settings/billing/overview/" />}
+      );
+    case ProcessingErrorType.MONITOR_INVALID_CONFIG:
+      return tct(
+        'A monitor failed to upsert due to an invalid [checkinTooltip:check-in] payload provided. Learn more about the check-in payload in our [link:documentation].',
+        {
+          checkinTooltip,
+          link: (
+            <ExternalLink href="https://docs.sentry.io/product/crons/getting-started/http/" />
+          ),
+        }
+      );
+    case ProcessingErrorType.MONITOR_INVALID_ENVIRONMENT:
+      return tct(
+        'A [checkinTooltip:check-in] was sent with an invalid environment due to: [reason].',
+        {
+          checkinTooltip,
+          reason: error.reason,
+        }
+      );
+    case ProcessingErrorType.MONITOR_LIMIT_EXCEEDED:
+      return tct(
+        'The maximum monitor limit for this project has been reached. Please reach out to our [link:sales team] to create additional monitors.',
+        {link: <ExternalLink href="https://sentry.io/contact/enterprise/" />}
+      );
+    case ProcessingErrorType.MONITOR_NOT_FOUND:
+      return tct(
+        'A [checkinTooltip:check-in] was sent for a monitor that does not exist. If you meant to create a new monitor via upsert, please provide a valid monitor configuration in the check-in payload.',
+        {checkinTooltip}
+      );
+    case ProcessingErrorType.MONITOR_OVER_QUOTA:
+      return tct(
+        'A [checkinTooltip:check-in] was sent but dropped due to the monitor being over quota. Please increase your on-demand budget in your [link:subscription settings] to resume processing check-ins.',
+        {
+          checkinTooltip,
+          link: <Link to="/settings/billing/overview/" />,
+        }
+      );
+    case ProcessingErrorType.MONITOR_ENVIRONMENT_LIMIT_EXCEEDED:
+      return tct(
+        'A [checkinTooltip:check-in] was sent but dropped because the monitor has already reached the limit of allowed environments. Remove an existing environment to create new ones.',
+        {checkinTooltip}
+      );
+    case ProcessingErrorType.MONITOR_ENVIRONMENT_RATELIMITED:
+      return tct(
+        'A sent [checkinTooltip:check-in] was dropped due to being rate limited. Reivew our rate limits for more information.',
+        {checkinTooltip}
+      );
+    case ProcessingErrorType.ORGANIZATION_KILLSWITCH_ENABLED:
+      return tct(
+        'We have detected a problem with your organization and disabled check-in ingestion. Contact [link:support] for details.',
+        {link: <ExternalLink href="https://sentry.zendesk.com/hc/en-us/requests/new/" />}
+      );
+    default:
+      return tct(
+        'Unknown problem occurred while processing this [checkinTooltip:check-in]',
+        {checkinTooltip}
+      );
+  }
+}

--- a/static/app/views/monitors/components/processingErrors/utils.tsx
+++ b/static/app/views/monitors/components/processingErrors/utils.tsx
@@ -1,0 +1,12 @@
+import type {Organization} from 'sentry/types';
+
+export function makeMonitorErrorsQueryKey(
+  organization: Organization,
+  projectId: string,
+  monitorSlug: string
+) {
+  return [
+    `/projects/${organization.slug}/${projectId}/monitors/${monitorSlug}/processing-errors/`,
+    {},
+  ] as const;
+}

--- a/static/app/views/monitors/details.tsx
+++ b/static/app/views/monitors/details.tsx
@@ -19,6 +19,8 @@ import useApi from 'sentry/utils/useApi';
 import useOrganization from 'sentry/utils/useOrganization';
 import DetailsSidebar from 'sentry/views/monitors/components/detailsSidebar';
 import {DetailsTimeline} from 'sentry/views/monitors/components/detailsTimeline';
+import MonitorProcessingErrors from 'sentry/views/monitors/components/processingErrors/monitorProcessingErrors';
+import {makeMonitorErrorsQueryKey} from 'sentry/views/monitors/components/processingErrors/utils';
 import {makeMonitorDetailsQueryKey} from 'sentry/views/monitors/utils';
 
 import MonitorCheckIns from './components/monitorCheckIns';
@@ -27,7 +29,7 @@ import MonitorIssues from './components/monitorIssues';
 import MonitorStats from './components/monitorStats';
 import MonitorOnboarding from './components/onboarding';
 import {StatusToggleButton} from './components/statusToggleButton';
-import type {Monitor} from './types';
+import type {CheckinProcessingError, Monitor} from './types';
 
 const DEFAULT_POLL_INTERVAL_MS = 5000;
 
@@ -64,6 +66,14 @@ function MonitorDetails({params, location}: Props) {
       return hasLastCheckIn(monitorData) ? false : DEFAULT_POLL_INTERVAL_MS;
     },
   });
+
+  const {data: checkinErrors} = useApiQuery<CheckinProcessingError[]>(
+    makeMonitorErrorsQueryKey(organization, params.projectId, params.monitorSlug),
+    {
+      staleTime: 0,
+      refetchOnWindowFocus: true,
+    }
+  );
 
   function onUpdate(data: Monitor) {
     const updatedMonitor = {
@@ -133,6 +143,9 @@ function MonitorDetails({params, location}: Props) {
               >
                 {t('This monitor is disabled and is not accepting check-ins.')}
               </Alert>
+            )}
+            {!!checkinErrors?.length && (
+              <MonitorProcessingErrors checkinErrors={checkinErrors} />
             )}
             {!hasLastCheckIn(monitor) ? (
               <MonitorOnboarding monitor={monitor} />


### PR DESCRIPTION
Shows errors that occurred while processing check-ins specific to a monitor

<img width="917" alt="image" src="https://github.com/getsentry/sentry/assets/9372512/bbf782c2-054e-4383-8e26-c3b9d5d0a29b">

<img width="917" alt="image" src="https://github.com/getsentry/sentry/assets/9372512/55b5c9d3-3ffe-4f8a-81f3-1a823d2bf584">
<img width="920" alt="image" src="https://github.com/getsentry/sentry/assets/9372512/4a0f9574-ad80-451d-a70a-e8af13382137">
