### PR TITLE
fix(ui): Remove unused expression in 'highlightsDataSection.spec.tsx'

### DIFF
--- a/static/app/components/events/highlights/highlightsDataSection.spec.tsx
+++ b/static/app/components/events/highlights/highlightsDataSection.spec.tsx
@@ -7,15 +7,12 @@ import {render, screen, within} from 'sentry-test/reactTestingLibrary';
 
 import * as modal from 'sentry/actionCreators/modal';
 import HighlightsDataSection from 'sentry/components/events/highlights/highlightsDataSection';
-import * as analytics from 'sentry/utils/analytics';
-
-HighlightsDataSection;
-
 import {EMPTY_HIGHLIGHT_DEFAULT} from 'sentry/components/events/highlights/util';
 import {
   TEST_EVENT_CONTEXTS,
   TEST_EVENT_TAGS,
 } from 'sentry/components/events/highlights/util.spec';
+import * as analytics from 'sentry/utils/analytics';
 
 describe('HighlightsDataSection', function () {
   const organization = OrganizationFixture({features: ['event-tags-tree-ui']});


### PR DESCRIPTION
# Goal

The goal of this PR is to remove an unused expression at the top of file `static/app/components/ events/highlights/highlightsDataSection.spec.tsx`:

https://github.com/getsentry/sentry/blob/3b17f232c2c704a660bfcdaec0e6daa11195228e/static/app/components/events/highlights/highlightsDataSection.spec.tsx#L1-L18

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
