### PR TITLE
perf: add import warning to sentry/types

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -36,7 +36,15 @@
       },
       "nursery": {
         "noDuplicateJsonKeys": "error",
-        "noNodejsModules": "error"
+        "noNodejsModules": "error",
+        "noRestrictedImports": {
+          "level": "warn",
+          "options": {
+            "paths": {
+              "sentry/types":  "Please import directly. For example: import type {Organization} from 'sentry/types/organization'"
+            }
+          }
+        }
       },
       "performance": {
         "noBarrelFile": "error"


### PR DESCRIPTION
Adds an import warning for `sentry/types`. For example:

```
./static/app/stores/demoWalkthroughStore.tsx:4:33 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━

  ⚠ Please import directly. For example: import type {Organization} from 'sentry/types/organization'

    2 │ import {createStore} from 'reflux';
    3 │
  > 4 │ import {OnboardingTaskKey} from 'sentry/types';
      │                                 ^^^^^^^^^^^^^^
    5 │
    6 │ interface DemoWalkthroughStoreDefinition extends StoreDefinition {
```