### PR TITLE
fix(autofix): Properly check for existing installation and code mappings

### DIFF
--- a/src/sentry/api/endpoints/group_autofix_setup_check.py
+++ b/src/sentry/api/endpoints/group_autofix_setup_check.py
@@ -12,15 +12,13 @@ from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.group import GroupEndpoint
-from sentry.api.endpoints.event_ai_suggested_fix import get_openai_policy
 from sentry.api.helpers.autofix import (
     AutofixCodebaseIndexingStatus,
     get_project_codebase_indexing_status,
 )
 from sentry.api.helpers.repos import get_repos_from_project_code_mappings
-from sentry.constants import ObjectStatus
+from sentry.integrations.utils.code_mapping import get_sorted_code_mapping_configs
 from sentry.models.group import Group
-from sentry.models.integrations.repository_project_path_config import RepositoryProjectPathConfig
 from sentry.models.organization import Organization
 from sentry.models.project import Project
 from sentry.services.hybrid_cloud.integration import integration_service
@@ -30,28 +28,31 @@ logger = logging.getLogger(__name__)
 from rest_framework.request import Request
 
 
-def get_autofix_integration_setup_problems(organization: Organization) -> str | None:
+def get_autofix_integration_setup_problems(
+    organization: Organization, project: Project
+) -> str | None:
     """
     Runs through the checks to see if we can use the GitHub integration for Autofix.
 
     If there are no issues, returns None.
     If there is an issue, returns the reason.
     """
-    integrations = integration_service.get_organization_integrations(
+    organization_integrations = integration_service.get_organization_integrations(
         organization_id=organization.id, providers=["github"], limit=1
     )
 
-    integration = integrations[0] if integrations else None
+    organization_integration = organization_integrations[0] if organization_integrations else None
+    integration = organization_integration and integration_service.get_integration(
+        organization_integration_id=organization_integration.id
+    )
+    installation = integration and integration.get_installation(organization_id=organization.id)
 
-    if not integration:
+    if not installation:
         return "integration_missing"
 
-    if integration.status != ObjectStatus.ACTIVE:
-        return "integration_inactive"
+    code_mappings = get_sorted_code_mapping_configs(project)
 
-    if not RepositoryProjectPathConfig.objects.filter(
-        organization_integration_id=integration.id
-    ).exists():
+    if not code_mappings:
         return "integration_no_code_mappings"
 
     return None
@@ -99,18 +100,12 @@ class GroupAutofixSetupCheck(GroupEndpoint):
         if not features.has("projects:ai-autofix", group.project):
             return Response({"detail": "Feature not enabled for project"}, status=403)
 
-        policy = get_openai_policy(
-            request.organization,
-            request.user,
-            pii_certified=True,
-        )
-
-        requires_subprocessor_consent = policy == "subprocessor"
-
         org: Organization = request.organization
         has_gen_ai_consent = org.get_option("sentry:gen_ai_consent", False)
 
-        integration_check = get_autofix_integration_setup_problems(organization=org)
+        integration_check = get_autofix_integration_setup_problems(
+            organization=org, project=group.project
+        )
 
         repos = get_repos_and_access(group.project)
         write_access_ok = all(repo["ok"] for repo in repos)
@@ -119,10 +114,6 @@ class GroupAutofixSetupCheck(GroupEndpoint):
 
         return Response(
             {
-                "subprocessorConsent": {
-                    "ok": not requires_subprocessor_consent,
-                    "reason": None,
-                },
                 "genAIConsent": {
                     "ok": has_gen_ai_consent,
                     "reason": None,

--- a/tests/sentry/api/endpoints/test_group_autofix_setup_check.py
+++ b/tests/sentry/api/endpoints/test_group_autofix_setup_check.py
@@ -1,7 +1,6 @@
 from unittest.mock import patch
 
 from sentry.api.helpers.autofix import AutofixCodebaseIndexingStatus
-from sentry.constants import ObjectStatus
 from sentry.models.integrations.repository_project_path_config import RepositoryProjectPathConfig
 from sentry.models.repository import Repository
 from sentry.silo.base import SiloMode
@@ -106,23 +105,6 @@ class GroupAIAutofixEndpointFailureTest(APITestCase, SnubaTestCase):
             "reason": None,
         }
 
-    @patch(
-        "sentry.api.endpoints.group_autofix_setup_check.get_openai_policy",
-        return_value="subprocessor",
-    )
-    def test_needs_subprocessor_consent(self, mock):
-        group = self.create_group()
-        self.login_as(user=self.user)
-        url = f"/api/0/issues/{group.id}/autofix/setup/"
-
-        response = self.client.get(url, format="json")
-
-        assert response.status_code == 200
-        assert response.data["subprocessorConsent"] == {
-            "ok": False,
-            "reason": None,
-        }
-
     def test_no_code_mappings(self):
         RepositoryProjectPathConfig.objects.filter(
             organization_integration_id=self.organization_integration.id
@@ -137,21 +119,6 @@ class GroupAIAutofixEndpointFailureTest(APITestCase, SnubaTestCase):
         assert response.data["integration"] == {
             "ok": False,
             "reason": "integration_no_code_mappings",
-        }
-
-    def test_disabled_integration(self):
-        with assume_test_silo_mode(SiloMode.CONTROL):
-            self.organization_integration.update(status=ObjectStatus.DISABLED)
-
-        group = self.create_group()
-        self.login_as(user=self.user)
-        url = f"/api/0/issues/{group.id}/autofix/setup/"
-        response = self.client.get(url, format="json")
-
-        assert response.status_code == 200
-        assert response.data["integration"] == {
-            "ok": False,
-            "reason": "integration_inactive",
         }
 
     def test_missing_integration(self):

--- a/tests/sentry/api/endpoints/test_group_autofix_setup_check.py
+++ b/tests/sentry/api/endpoints/test_group_autofix_setup_check.py
@@ -59,10 +59,6 @@ class GroupAIAutofixEndpointSuccessTest(APITestCase, SnubaTestCase):
 
         assert response.status_code == 200
         assert response.data == {
-            "subprocessorConsent": {
-                "ok": True,
-                "reason": None,
-            },
             "genAIConsent": {
                 "ok": True,
                 "reason": None,


### PR DESCRIPTION
While running through this, I found an issue with how the setup check is looking at the integration, so made a couple changes:

1. Pass `project` in to the integration check so we can find code mappings for that project and error if not there
2. Checks for the integration's installation instead of the organization integration, which I think is more correct
3. Stop checking for whether it is disabled since Autofix only really needs the code mappings