### PR TITLE
fix(autofix): Return false for write integration when there are no repos

### DIFF
--- a/src/sentry/api/endpoints/group_autofix_setup_check.py
+++ b/src/sentry/api/endpoints/group_autofix_setup_check.py
@@ -113,7 +113,7 @@ class GroupAutofixSetupCheck(GroupEndpoint):
         integration_check = get_autofix_integration_setup_problems(organization=org)
 
         repos = get_repos_and_access(group.project)
-        write_access_ok = all(repo["ok"] for repo in repos)
+        write_access_ok = len(repos) > 0 and all(repo["ok"] for repo in repos)
 
         codebase_indexing_status = get_project_codebase_indexing_status(group.project)
 

--- a/tests/sentry/api/endpoints/test_group_autofix_setup_check.py
+++ b/tests/sentry/api/endpoints/test_group_autofix_setup_check.py
@@ -216,6 +216,22 @@ class GroupAIAutofixEndpointFailureTest(APITestCase, SnubaTestCase):
         }
 
     @patch(
+        "sentry.api.endpoints.group_autofix_setup_check.get_repos_and_access",
+        return_value=[],
+    )
+    def test_repo_write_access_no_repos(self, mock_get_repos_and_access):
+        group = self.create_group()
+        self.login_as(user=self.user)
+        url = f"/api/0/issues/{group.id}/autofix/setup/"
+        response = self.client.get(url, format="json")
+
+        assert response.status_code == 200
+        assert response.data["githubWriteIntegration"] == {
+            "ok": False,
+            "repos": [],
+        }
+
+    @patch(
         "sentry.api.endpoints.group_autofix_setup_check.get_project_codebase_indexing_status",
         return_value=AutofixCodebaseIndexingStatus.NOT_INDEXED,
     )


### PR DESCRIPTION
Small fix, this was returning true if there weren't any code mappings.