### PR TITLE
ref(autofix): Use code mappings util and move helper to autofix folder

### DIFF
--- a/src/sentry/api/endpoints/group_ai_autofix.py
+++ b/src/sentry/api/endpoints/group_ai_autofix.py
@@ -15,8 +15,8 @@ from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.group import GroupEndpoint
-from sentry.api.helpers.repos import get_repos_from_project_code_mappings
 from sentry.api.serializers import EventSerializer, serialize
+from sentry.autofix.utils import get_autofix_repos_from_project_code_mappings
 from sentry.models.group import Group
 from sentry.models.user import User
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
@@ -169,7 +169,7 @@ class GroupAutofixEndpoint(GroupEndpoint):
         if not any([entry.get("type") == "exception" for entry in serialized_event["entries"]]):
             return self._respond_with_error("Cannot fix issues without a stacktrace.", 400)
 
-        repos = get_repos_from_project_code_mappings(group.project)
+        repos = get_autofix_repos_from_project_code_mappings(group.project)
 
         if not repos:
             return self._respond_with_error(

--- a/src/sentry/api/endpoints/group_autofix_setup_check.py
+++ b/src/sentry/api/endpoints/group_autofix_setup_check.py
@@ -17,7 +17,6 @@ from sentry.api.helpers.autofix import (
     get_project_codebase_indexing_status,
 )
 from sentry.autofix.utils import get_autofix_repos_from_project_code_mappings
-from sentry.constants import ObjectStatus
 from sentry.integrations.utils.code_mapping import get_sorted_code_mapping_configs
 from sentry.models.group import Group
 from sentry.models.organization import Organization

--- a/src/sentry/api/endpoints/group_autofix_setup_check.py
+++ b/src/sentry/api/endpoints/group_autofix_setup_check.py
@@ -17,7 +17,7 @@ from sentry.api.helpers.autofix import (
     AutofixCodebaseIndexingStatus,
     get_project_codebase_indexing_status,
 )
-from sentry.api.helpers.repos import get_repos_from_project_code_mappings
+from sentry.autofix.utils import get_autofix_repos_from_project_code_mappings
 from sentry.constants import ObjectStatus
 from sentry.models.group import Group
 from sentry.models.integrations.repository_project_path_config import RepositoryProjectPathConfig
@@ -63,7 +63,7 @@ def get_repos_and_access(project: Project) -> list[dict]:
 
     Returns a list of repos with the "ok" key set to True if we have write access, False otherwise.
     """
-    repos = get_repos_from_project_code_mappings(project)
+    repos = get_autofix_repos_from_project_code_mappings(project)
 
     repos_and_access: list[dict] = []
     for repo in repos:

--- a/src/sentry/api/endpoints/project_autofix_create_codebase_index.py
+++ b/src/sentry/api/endpoints/project_autofix_create_codebase_index.py
@@ -11,7 +11,7 @@ from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.project import ProjectEndpoint, ProjectPermission
-from sentry.api.helpers.repos import get_repos_from_project_code_mappings
+from sentry.autofix.utils import get_autofix_repos_from_project_code_mappings
 from sentry.models.project import Project
 
 logger = logging.getLogger(__name__)
@@ -40,7 +40,7 @@ class ProjectAutofixCreateCodebaseIndexEndpoint(ProjectEndpoint):
         """
         Create a codebase index for for a project's repositories, uses the code mapping to determine which repositories to index
         """
-        repos = get_repos_from_project_code_mappings(project)
+        repos = get_autofix_repos_from_project_code_mappings(project)
 
         for repo in repos:
             response = requests.post(

--- a/src/sentry/api/helpers/autofix.py
+++ b/src/sentry/api/helpers/autofix.py
@@ -4,7 +4,7 @@ import orjson
 import requests
 from django.conf import settings
 
-from sentry.api.helpers.repos import get_repos_from_project_code_mappings
+from sentry.autofix.utils import get_autofix_repos_from_project_code_mappings
 
 
 class AutofixCodebaseIndexingStatus(str, enum.Enum):
@@ -14,7 +14,7 @@ class AutofixCodebaseIndexingStatus(str, enum.Enum):
 
 
 def get_project_codebase_indexing_status(project):
-    repos = get_repos_from_project_code_mappings(project)
+    repos = get_autofix_repos_from_project_code_mappings(project)
 
     if not repos:
         return None

--- a/src/sentry/autofix/utils.py
+++ b/src/sentry/autofix/utils.py
@@ -1,16 +1,14 @@
-from sentry.models.integrations.repository_project_path_config import RepositoryProjectPathConfig
+from sentry.integrations.utils.code_mapping import get_sorted_code_mapping_configs
 from sentry.models.project import Project
 from sentry.models.repository import Repository
 
 
-def get_repos_from_project_code_mappings(project: Project) -> list[dict]:
-    repo_configs: list[RepositoryProjectPathConfig] = RepositoryProjectPathConfig.objects.filter(
-        project__in=[project]
-    )
+def get_autofix_repos_from_project_code_mappings(project: Project) -> list[dict]:
+    code_mappings = get_sorted_code_mapping_configs(project)
 
     repos: dict[tuple, dict] = {}
-    for repo_config in repo_configs:
-        repo: Repository = repo_config.repository
+    for code_mapping in code_mappings:
+        repo: Repository = code_mapping.repository
         repo_name_sections = repo.name.split("/")
 
         # We expect a repository name to be in the format of "owner/name" for now.

--- a/tests/sentry/autofix/test_utils.py
+++ b/tests/sentry/autofix/test_utils.py
@@ -1,18 +1,18 @@
-from sentry.api.helpers.repos import get_repos_from_project_code_mappings
+from sentry.autofix.utils import get_autofix_repos_from_project_code_mappings
 from sentry.testutils.cases import TestCase
 
 
 class TestGetRepoFromCodeMappings(TestCase):
-    def test_get_repos_from_project_code_mappings_empty(self):
+    def test_code_mappings_empty(self):
         project = self.create_project()
-        repos = get_repos_from_project_code_mappings(project)
-        self.assertEqual(repos, [])
+        repos = get_autofix_repos_from_project_code_mappings(project)
+        assert repos == []
 
     def test_get_repos_from_project_code_mappings_with_data(self):
         project = self.create_project()
         repo = self.create_repo(name="getsentry/sentry", provider="github", external_id="123")
         self.create_code_mapping(project=project, repo=repo)
-        repos = get_repos_from_project_code_mappings(project)
+        repos = get_autofix_repos_from_project_code_mappings(project)
         expected_repos = [
             {
                 "provider": repo.provider,
@@ -21,4 +21,4 @@ class TestGetRepoFromCodeMappings(TestCase):
                 "external_id": "123",
             }
         ]
-        self.assertEqual(repos, expected_repos)
+        assert repos == expected_repos


### PR DESCRIPTION
Uses `get_sorted_code_mapping_configs` for autofix to align with the setup check