### PR TITLE
fix: allow JSON keys with non-string attributes

### DIFF
--- a/src/sentry/notifications/utils/participants.py
+++ b/src/sentry/notifications/utils/participants.py
@@ -617,7 +617,10 @@ def _get_recipients_by_provider(
             "teams": orjson.dumps([team.id for team in teams]).decode(),
             "teams_by_provider": orjson.dumps(teams_by_provider_dict).decode(),
             "users": orjson.dumps([user.id for user in users]).decode(),
-            "users_by_provider": orjson.dumps(users_by_provider_dict).decode(),
+            # TODO(@anonrig): Remove support for non-string JSON keys.
+            "users_by_provider": orjson.dumps(
+                users_by_provider_dict, option=orjson.OPT_NON_STR_KEYS
+            ).decode(),
         }
         logger.info("sentry.notifications.recipients_by_provider", extra=extra)
     except Exception as e:


### PR DESCRIPTION
It seems we have a missing test coverage for this.

Ref https://github.com/getsentry/sentry/pull/71155#issuecomment-2120783149
Fixes https://sentry-st.sentry.io/issues/5380029738/?project=1513938
Fixes https://sentry.sentry.io/issues/5380113426/?project=1&referrer=github-pr-bot