### PR TITLE
fix(pr-comments): handle multiple sentry orgs associated with single GH org

### DIFF
--- a/src/sentry/tasks/commit_context.py
+++ b/src/sentry/tasks/commit_context.py
@@ -92,11 +92,12 @@ def queue_comment_task_if_needed(
 
     merge_commit_sha = response[0]["merge_commit_sha"]
 
+    # get first PR that merged the commit
     pr_query = PullRequest.objects.filter(
         organization_id=commit.organization_id,
         repository_id=commit.repository_id,
         merge_commit_sha=merge_commit_sha,
-    )
+    ).order_by("date_added")
     if not pr_query.exists():
         logger.info(
             "github.pr_comment.queue_comment_check.missing_pr",


### PR DESCRIPTION
At the moment, it's not possible to have multiple sentry orgs associated with a single GH org through the UI.

However, the `sentry` SaaS org and the `sentry` single tenant org are both associated with the `getsentry` GH organization. So there are two repos that exist in the DB that represent the `getsentry/sentry` repo, since we likely added all repos automatically.

In the webhook handler, we collect all the repos in the DB that are associated with the GH repo sending us the webhook, and invoke the handler for all of them
https://github.com/getsentry/sentry/blob/288017fd6d1df31ff26a020472e5610f7c715330/src/sentry/integrations/github/webhook.py#L155-L156
This includes created `PullRequest` objects in the DB for new PRs.

To fix this, I'm getting the oldest `PullRequest` object to create the comment on. We also create a `PullRequestComment` object to track the comments, and these will always be linked to the oldest `PullRequest` object out of the ones with the same `merge_commit_sha`, `repo_id`, and `org_id`.