### PR TITLE
ref(rules): Import base buffer

### DIFF
--- a/src/sentry/buffer/__init__.py
+++ b/src/sentry/buffer/__init__.py
@@ -1,3 +1,5 @@
+from typing import TYPE_CHECKING
+
 from django.conf import settings
 
 from sentry.utils.services import LazyServiceWrapper
@@ -6,3 +8,18 @@ from .base import Buffer
 
 backend = LazyServiceWrapper(Buffer, settings.SENTRY_BUFFER, settings.SENTRY_BUFFER_OPTIONS)
 backend.expose(locals())
+
+if TYPE_CHECKING:
+    __buffer__ = Buffer()
+    get = __buffer__.get
+    incr = __buffer__.incr
+    process = __buffer__.process
+    process_pending = __buffer__.process_pending
+    process_batch = __buffer__.process_batch
+    validate = __buffer__.validate
+    push_to_sorted_set = __buffer__.push_to_sorted_set
+    push_to_hash = __buffer__.push_to_hash
+    get_sorted_set = __buffer__.get_sorted_set
+    get_hash = __buffer__.get_hash
+    delete_hash = __buffer__.delete_hash
+    delete_key = __buffer__.delete_key

--- a/src/sentry/buffer/__init__.py
+++ b/src/sentry/buffer/__init__.py
@@ -1,5 +1,3 @@
-from typing import TYPE_CHECKING
-
 from django.conf import settings
 
 from sentry.utils.services import LazyServiceWrapper
@@ -8,18 +6,3 @@ from .base import Buffer
 
 backend = LazyServiceWrapper(Buffer, settings.SENTRY_BUFFER, settings.SENTRY_BUFFER_OPTIONS)
 backend.expose(locals())
-
-if TYPE_CHECKING:
-    __buffer__ = Buffer()
-    get = __buffer__.get
-    incr = __buffer__.incr
-    process = __buffer__.process
-    process_pending = __buffer__.process_pending
-    process_batch = __buffer__.process_batch
-    validate = __buffer__.validate
-    push_to_sorted_set = __buffer__.push_to_sorted_set
-    push_to_hash = __buffer__.push_to_hash
-    get_sorted_set = __buffer__.get_sorted_set
-    get_hash = __buffer__.get_hash
-    delete_hash = __buffer__.delete_hash
-    delete_key = __buffer__.delete_key

--- a/src/sentry/buffer/base.py
+++ b/src/sentry/buffer/base.py
@@ -23,7 +23,19 @@ class Buffer(Service):
     keep up with the updates.
     """
 
-    __all__ = ("get", "incr", "process", "process_pending", "process_batch", "validate")
+    __all__ = (
+        "get",
+        "incr",
+        "process",
+        "process_pending",
+        "process_batch",
+        "validate",
+        "push_to_sorted_set",
+        "push_to_hash",
+        "get_sorted_set",
+        "get_hash",
+        "delete_hash",
+    )
 
     def get(
         self,
@@ -43,6 +55,26 @@ class Buffer(Service):
 
     def get_sorted_set(self, key: str, min: float, max: float) -> list[tuple[int, datetime]]:
         return []
+
+    def push_to_sorted_set(self, key: str, value: list[int] | int) -> None:
+        return None
+
+    def push_to_hash(
+        self,
+        model: type[models.Model],
+        filters: dict[str, models.Model | str | int],
+        field: str,
+        value: str,
+    ) -> None:
+        return None
+
+    def delete_hash(
+        self,
+        model: type[models.Model],
+        filters: dict[str, models.Model | str | int],
+        fields: list[str],
+    ) -> None:
+        return None
 
     def incr(
         self,

--- a/src/sentry/buffer/base.py
+++ b/src/sentry/buffer/base.py
@@ -35,6 +35,7 @@ class Buffer(Service):
         "get_sorted_set",
         "get_hash",
         "delete_hash",
+        "delete_key",
     )
 
     def get(
@@ -74,6 +75,9 @@ class Buffer(Service):
         filters: dict[str, models.Model | str | int],
         fields: list[str],
     ) -> None:
+        return None
+
+    def delete_key(self, key: str, min: float, max: float) -> None:
         return None
 
     def incr(

--- a/src/sentry/rules/processing/delayed_processing.py
+++ b/src/sentry/rules/processing/delayed_processing.py
@@ -295,7 +295,7 @@ def get_group_to_groupevent(
 def process_delayed_alert_conditions() -> None:
     with metrics.timer("delayed_processing.process_all_conditions.duration"):
         fetch_time = datetime.now(tz=timezone.utc)
-        project_ids = buffer.get_sorted_set(
+        project_ids = buffer.backend.get_sorted_set(
             PROJECT_ID_BUFFER_LIST_KEY, min=float("-inf"), max=float("+inf")
         )
         log_str = ""
@@ -306,7 +306,7 @@ def process_delayed_alert_conditions() -> None:
         for project_id, _ in project_ids:
             apply_delayed.delay(project_id)
 
-        buffer.delete_key(PROJECT_ID_BUFFER_LIST_KEY, min=0, max=fetch_time.timestamp())
+        buffer.backend.delete_key(PROJECT_ID_BUFFER_LIST_KEY, min=0, max=fetch_time.timestamp())
 
 
 @instrumented_task(
@@ -324,7 +324,9 @@ def apply_delayed(project_id: int, *args: Any, **kwargs: Any) -> None:
     """
     # STEP 1: Fetch the rulegroup_to_event_data mapping for the project from redis
     project = Project.objects.get_from_cache(id=project_id)
-    rulegroup_to_event_data = buffer.get_hash(model=Project, field={"project_id": project.id})
+    rulegroup_to_event_data = buffer.backend.get_hash(
+        model=Project, field={"project_id": project.id}
+    )
     logger.info(
         "delayed_processing.rulegroupeventdata",
         extra={"rulegroupdata": rulegroup_to_event_data},
@@ -404,7 +406,7 @@ def apply_delayed(project_id: int, *args: Any, **kwargs: Any) -> None:
     hashes_to_delete = [
         f"{rule}:{group}" for rule, groups in rules_to_groups.items() for group in groups
     ]
-    buffer.delete_hash(
+    buffer.backend.delete_hash(
         model=Project,
         filters={"project_id": project_id},
         fields=hashes_to_delete,

--- a/src/sentry/rules/processing/delayed_processing.py
+++ b/src/sentry/rules/processing/delayed_processing.py
@@ -4,7 +4,7 @@ from collections import defaultdict
 from datetime import datetime, timedelta, timezone
 from typing import Any, DefaultDict, NamedTuple
 
-from sentry import nodestore
+from sentry import buffer, nodestore
 from sentry.buffer.redis import BufferHookEvent, RedisBuffer, redis_buffer_registry
 from sentry.eventstore.models import Event, GroupEvent
 from sentry.issues.issue_occurrence import IssueOccurrence
@@ -324,7 +324,6 @@ def apply_delayed(project_id: int, *args: Any, **kwargs: Any) -> None:
     """
     # STEP 1: Fetch the rulegroup_to_event_data mapping for the project from redis
     project = Project.objects.get_from_cache(id=project_id)
-    buffer = RedisBuffer()
     rulegroup_to_event_data = buffer.get_hash(model=Project, field={"project_id": project.id})
     logger.info(
         "delayed_processing.rulegroupeventdata",

--- a/src/sentry/rules/processing/delayed_processing.py
+++ b/src/sentry/rules/processing/delayed_processing.py
@@ -5,7 +5,7 @@ from datetime import datetime, timedelta, timezone
 from typing import Any, DefaultDict, NamedTuple
 
 from sentry import buffer, nodestore
-from sentry.buffer.redis import BufferHookEvent, RedisBuffer, redis_buffer_registry
+from sentry.buffer.redis import BufferHookEvent, redis_buffer_registry
 from sentry.eventstore.models import Event, GroupEvent
 from sentry.issues.issue_occurrence import IssueOccurrence
 from sentry.models.group import Group
@@ -292,7 +292,7 @@ def get_group_to_groupevent(
     return group_to_groupevent
 
 
-def process_delayed_alert_conditions(buffer: RedisBuffer) -> None:
+def process_delayed_alert_conditions() -> None:
     with metrics.timer("delayed_processing.process_all_conditions.duration"):
         fetch_time = datetime.now(tz=timezone.utc)
         project_ids = buffer.get_sorted_set(

--- a/src/sentry/rules/processing/processor.py
+++ b/src/sentry/rules/processing/processor.py
@@ -10,8 +10,7 @@ from typing import Any
 from django.core.cache import cache
 from django.utils import timezone
 
-from sentry import analytics, features
-from sentry.buffer.redis import RedisBuffer
+from sentry import analytics, buffer, features
 from sentry.eventstore.models import GroupEvent
 from sentry.models.environment import Environment
 from sentry.models.group import Group
@@ -263,13 +262,12 @@ class RuleProcessor:
             "rule_processor.rule_enqueued",
             extra={"rule": rule.id, "group": self.group.id, "project": rule.project.id},
         )
-        self.buffer = RedisBuffer()
-        self.buffer.push_to_sorted_set(PROJECT_ID_BUFFER_LIST_KEY, rule.project.id)
+        buffer.push_to_sorted_set(PROJECT_ID_BUFFER_LIST_KEY, rule.project.id)
 
         value = json.dumps(
             {"event_id": self.event.event_id, "occurrence_id": self.event.occurrence_id}
         )
-        self.buffer.push_to_hash(
+        buffer.push_to_hash(
             model=Project,
             filters={"project_id": rule.project.id},
             field=f"{rule.id}:{self.group.id}",

--- a/src/sentry/rules/processing/processor.py
+++ b/src/sentry/rules/processing/processor.py
@@ -262,12 +262,12 @@ class RuleProcessor:
             "rule_processor.rule_enqueued",
             extra={"rule": rule.id, "group": self.group.id, "project": rule.project.id},
         )
-        buffer.push_to_sorted_set(PROJECT_ID_BUFFER_LIST_KEY, rule.project.id)
+        buffer.backend.push_to_sorted_set(PROJECT_ID_BUFFER_LIST_KEY, rule.project.id)
 
         value = json.dumps(
             {"event_id": self.event.event_id, "occurrence_id": self.event.occurrence_id}
         )
-        buffer.push_to_hash(
+        buffer.backend.push_to_hash(
             model=Project,
             filters={"project_id": rule.project.id},
             field=f"{rule.id}:{self.group.id}",

--- a/src/sentry/testutils/helpers/redis.py
+++ b/src/sentry/testutils/helpers/redis.py
@@ -22,6 +22,10 @@ def mock_redis_buffer():
         "sentry.buffer.get_sorted_set", new=buffer.get_sorted_set
     ), patch(
         "sentry.buffer.delete_key", new=buffer.delete_key
+    ), patch(
+        "sentry.buffer.get", new=buffer.get
+    ), patch(
+        "sentry.buffer.incr", new=buffer.incr
     ):
         yield buffer
 

--- a/src/sentry/testutils/helpers/redis.py
+++ b/src/sentry/testutils/helpers/redis.py
@@ -12,21 +12,7 @@ from sentry.testutils.helpers import override_options
 @contextmanager
 def mock_redis_buffer():
     buffer = RedisBuffer()
-    with patch("sentry.buffer.push_to_sorted_set", new=buffer.push_to_sorted_set), patch(
-        "sentry.buffer.push_to_hash", new=buffer.push_to_hash
-    ), patch("sentry.buffer.get_sorted_set", new=buffer.get_sorted_set), patch(
-        "sentry.buffer.get_hash", new=buffer.get_hash
-    ), patch(
-        "sentry.buffer.delete_hash", new=buffer.delete_hash
-    ), patch(
-        "sentry.buffer.get_sorted_set", new=buffer.get_sorted_set
-    ), patch(
-        "sentry.buffer.delete_key", new=buffer.delete_key
-    ), patch(
-        "sentry.buffer.get", new=buffer.get
-    ), patch(
-        "sentry.buffer.incr", new=buffer.incr
-    ):
+    with patch("sentry.buffer.backend", new=buffer):
         yield buffer
 
 

--- a/src/sentry/testutils/helpers/redis.py
+++ b/src/sentry/testutils/helpers/redis.py
@@ -20,6 +20,8 @@ def mock_redis_buffer():
         "sentry.buffer.delete_hash", new=buffer.delete_hash
     ), patch(
         "sentry.buffer.get_sorted_set", new=buffer.get_sorted_set
+    ), patch(
+        "sentry.buffer.delete_key", new=buffer.delete_key
     ):
         yield buffer
 

--- a/src/sentry/testutils/helpers/redis.py
+++ b/src/sentry/testutils/helpers/redis.py
@@ -1,10 +1,27 @@
 from collections.abc import Generator
 from contextlib import contextmanager
 from typing import Any
+from unittest.mock import patch
 
 from django.test.utils import override_settings
 
+from sentry.buffer.redis import RedisBuffer
 from sentry.testutils.helpers import override_options
+
+
+@contextmanager
+def mock_redis_buffer():
+    buffer = RedisBuffer()
+    with patch("sentry.buffer.push_to_sorted_set", new=buffer.push_to_sorted_set), patch(
+        "sentry.buffer.push_to_hash", new=buffer.push_to_hash
+    ), patch("sentry.buffer.get_sorted_set", new=buffer.get_sorted_set), patch(
+        "sentry.buffer.get_hash", new=buffer.get_hash
+    ), patch(
+        "sentry.buffer.delete_hash", new=buffer.delete_hash
+    ), patch(
+        "sentry.buffer.get_sorted_set", new=buffer.get_sorted_set
+    ):
+        yield buffer
 
 
 @contextmanager

--- a/tests/sentry/rules/processing/test_delayed_processing.py
+++ b/tests/sentry/rules/processing/test_delayed_processing.py
@@ -63,7 +63,7 @@ class ProcessDelayedAlertConditionsTest(
 
     def push_to_hash(self, project_id, rule_id, group_id, event_id=None, occurrence_id=None):
         value = json.dumps({"event_id": event_id, "occurrence_id": occurrence_id})
-        buffer.push_to_hash(
+        buffer.backend.push_to_hash(
             model=Project,
             filters={"project_id": project_id},
             field=f"{rule_id}:{group_id}",
@@ -151,8 +151,8 @@ class ProcessDelayedAlertConditionsTest(
             self.project.id: self.rulegroup_event_mapping_one,
             self.project_two.id: self.rulegroup_event_mapping_two,
         }
-        buffer.push_to_sorted_set(key=PROJECT_ID_BUFFER_LIST_KEY, value=self.project.id)
-        buffer.push_to_sorted_set(key=PROJECT_ID_BUFFER_LIST_KEY, value=self.project_two.id)
+        buffer.backend.push_to_sorted_set(key=PROJECT_ID_BUFFER_LIST_KEY, value=self.project.id)
+        buffer.backend.push_to_sorted_set(key=PROJECT_ID_BUFFER_LIST_KEY, value=self.project_two.id)
 
         self.push_to_hash(self.project.id, self.rule1.id, self.group1.id, self.event1.event_id)
         self.push_to_hash(self.project.id, self.rule2.id, self.group2.id, self.event2.event_id)
@@ -174,7 +174,7 @@ class ProcessDelayedAlertConditionsTest(
         ):
             assert mock_apply_delayed.delay.call_count == 2
 
-        project_ids = buffer.get_sorted_set(
+        project_ids = buffer.backend.get_sorted_set(
             PROJECT_ID_BUFFER_LIST_KEY, 0, datetime.now(UTC).timestamp()
         )
         assert project_ids == []
@@ -184,7 +184,7 @@ class ProcessDelayedAlertConditionsTest(
         """
         Test that rules of various event frequency conditions, projects, environments, etc. are properly fired
         """
-        project_ids = buffer.get_sorted_set(
+        project_ids = buffer.backend.get_sorted_set(
             PROJECT_ID_BUFFER_LIST_KEY, 0, datetime.now(UTC).timestamp()
         )
         apply_delayed(project_ids[0][0], project_ids[0][1])
@@ -214,7 +214,7 @@ class ProcessDelayedAlertConditionsTest(
         assert (self.rule3.id, self.group3.id) in rule_fire_histories
         assert (self.rule4.id, self.group4.id) in rule_fire_histories
 
-        rule_group_data = buffer.get_hash(Project, {"project_id": self.project_two.id})
+        rule_group_data = buffer.backend.get_hash(Project, {"project_id": self.project_two.id})
         assert rule_group_data == {}
 
     def test_apply_delayed_issue_platform_event(self):
@@ -244,7 +244,7 @@ class ProcessDelayedAlertConditionsTest(
             event5.event_id,
             occurrence_id=event5.occurrence_id,
         )
-        project_ids = buffer.get_sorted_set(
+        project_ids = buffer.backend.get_sorted_set(
             PROJECT_ID_BUFFER_LIST_KEY, 0, datetime.now(UTC).timestamp()
         )
         apply_delayed(project_ids[0][0], project_ids[0][1])
@@ -277,7 +277,7 @@ class ProcessDelayedAlertConditionsTest(
         assert self.group1
         self.push_to_hash(self.project.id, rule5.id, group5.id, event5.event_id)
 
-        project_ids = buffer.get_sorted_set(
+        project_ids = buffer.backend.get_sorted_set(
             PROJECT_ID_BUFFER_LIST_KEY, 0, datetime.now(UTC).timestamp()
         )
         apply_delayed(project_ids[0][0], project_ids[0][1])
@@ -307,7 +307,7 @@ class ProcessDelayedAlertConditionsTest(
         assert self.group1
         self.push_to_hash(self.project.id, rule5.id, group5.id, event5.event_id)
 
-        project_ids = buffer.get_sorted_set(
+        project_ids = buffer.backend.get_sorted_set(
             PROJECT_ID_BUFFER_LIST_KEY, 0, datetime.now(UTC).timestamp()
         )
         apply_delayed(project_ids[0][0], project_ids[0][1])
@@ -339,7 +339,7 @@ class ProcessDelayedAlertConditionsTest(
         assert self.group1
         self.push_to_hash(self.project.id, diff_interval_rule.id, group5.id, event5.event_id)
 
-        project_ids = buffer.get_sorted_set(
+        project_ids = buffer.backend.get_sorted_set(
             PROJECT_ID_BUFFER_LIST_KEY, 0, datetime.now(UTC).timestamp()
         )
         apply_delayed(project_ids[0][0], project_ids[0][1])
@@ -371,7 +371,7 @@ class ProcessDelayedAlertConditionsTest(
         assert self.group1
         self.push_to_hash(self.project.id, diff_env_rule.id, group5.id, event5.event_id)
 
-        project_ids = buffer.get_sorted_set(
+        project_ids = buffer.backend.get_sorted_set(
             PROJECT_ID_BUFFER_LIST_KEY, 0, datetime.now(UTC).timestamp()
         )
         apply_delayed(project_ids[0][0], project_ids[0][1])
@@ -408,7 +408,7 @@ class ProcessDelayedAlertConditionsTest(
         assert self.group1
         self.push_to_hash(self.project.id, no_fire_rule.id, group5.id, event5.event_id)
 
-        project_ids = buffer.get_sorted_set(
+        project_ids = buffer.backend.get_sorted_set(
             PROJECT_ID_BUFFER_LIST_KEY, 0, datetime.now(UTC).timestamp()
         )
         apply_delayed(project_ids[0][0], project_ids[0][1])
@@ -452,7 +452,7 @@ class ProcessDelayedAlertConditionsTest(
         self.push_to_hash(
             self.project.id, two_conditions_match_all_rule.id, group5.id, event5.event_id
         )
-        project_ids = buffer.get_sorted_set(
+        project_ids = buffer.backend.get_sorted_set(
             PROJECT_ID_BUFFER_LIST_KEY, 0, datetime.now(UTC).timestamp()
         )
         apply_delayed(project_ids[0][0])

--- a/tests/sentry/rules/processing/test_delayed_processing.py
+++ b/tests/sentry/rules/processing/test_delayed_processing.py
@@ -166,7 +166,7 @@ class ProcessDelayedAlertConditionsTest(
     def test_fetches_from_buffer_and_executes(self, mock_apply_delayed):
         # To get the correct mapping, we need to return the correct
         # rulegroup_event mapping based on the project_id input
-        process_delayed_alert_conditions(buffer)
+        process_delayed_alert_conditions()
 
         for project, rule_group_event_mapping in (
             (self.project, self.rulegroup_event_mapping_one),

--- a/tests/sentry/rules/processing/test_delayed_processing.py
+++ b/tests/sentry/rules/processing/test_delayed_processing.py
@@ -71,7 +71,7 @@ class ProcessDelayedAlertConditionsTest(
         )
 
     def assert_buffer_cleared(self, project_id):
-        rule_group_data = buffer.get_hash(Project, {"project_id": project_id})
+        rule_group_data = buffer.backend.get_hash(Project, {"project_id": project_id})
         assert rule_group_data == {}
 
     def setUp(self):

--- a/tests/sentry/rules/processing/test_delayed_processing.py
+++ b/tests/sentry/rules/processing/test_delayed_processing.py
@@ -1,13 +1,11 @@
 import copy
-from contextlib import contextmanager
 from datetime import UTC, datetime
 from unittest.mock import patch
 from uuid import uuid4
 
 import pytest
-
+import orjson
 from sentry import buffer
-from sentry.buffer.redis import RedisBuffer
 from sentry.eventstore.models import Event
 from sentry.models.project import Project
 from sentry.models.rulefirehistory import RuleFireHistory
@@ -19,25 +17,11 @@ from sentry.rules.processing.processor import PROJECT_ID_BUFFER_LIST_KEY
 from sentry.testutils.cases import APITestCase, PerformanceIssueTestCase, TestCase
 from sentry.testutils.factories import DEFAULT_EVENT_DATA
 from sentry.testutils.helpers.datetime import iso_format
-from sentry.utils import json
+
+from sentry.testutils.helpers.redis import mock_redis_buffer
 from tests.snuba.rules.conditions.test_event_frequency import BaseEventFrequencyPercentTest
 
 pytestmark = pytest.mark.sentry_metrics
-
-
-@contextmanager
-def mock_redis_buffer():
-    buffer = RedisBuffer()
-    with patch("sentry.buffer.push_to_sorted_set", new=buffer.push_to_sorted_set), patch(
-        "sentry.buffer.push_to_hash", new=buffer.push_to_hash
-    ), patch("sentry.buffer.get_sorted_set", new=buffer.get_sorted_set), patch(
-        "sentry.buffer.get_hash", new=buffer.get_hash
-    ), patch(
-        "sentry.buffer.delete_hash", new=buffer.delete_hash
-    ), patch(
-        "sentry.buffer.get_sorted_set", new=buffer.get_sorted_set
-    ):
-        yield buffer
 
 
 @mock_redis_buffer()

--- a/tests/sentry/rules/processing/test_processor.py
+++ b/tests/sentry/rules/processing/test_processor.py
@@ -1,4 +1,3 @@
-from contextlib import contextmanager
 from datetime import UTC, datetime, timedelta
 from typing import cast
 from unittest import mock
@@ -10,7 +9,6 @@ from django.test.utils import CaptureQueriesContext
 from django.utils import timezone
 
 from sentry import buffer
-from sentry.buffer.redis import RedisBuffer
 from sentry.constants import ObjectStatus
 from sentry.models.group import Group, GroupStatus
 from sentry.models.grouprulestatus import GroupRuleStatus
@@ -26,6 +24,7 @@ from sentry.rules.processing.processor import PROJECT_ID_BUFFER_LIST_KEY, RulePr
 from sentry.testutils.cases import PerformanceIssueTestCase, TestCase
 from sentry.testutils.helpers import install_slack
 from sentry.testutils.helpers.features import with_feature
+from sentry.testutils.helpers.redis import mock_redis_buffer
 from sentry.testutils.skips import requires_snuba
 from sentry.utils import json
 from sentry.utils.safe import safe_execute
@@ -47,15 +46,6 @@ class MockConditionTrue(EventCondition):
 
     def passes(self, event, state):
         return True
-
-
-@contextmanager
-def mock_redis_buffer():
-    buffer = RedisBuffer()
-    with patch("sentry.buffer.push_to_sorted_set", new=buffer.push_to_sorted_set), patch(
-        "sentry.buffer.push_to_hash", new=buffer.push_to_hash
-    ), patch("sentry.buffer.get_sorted_set", new=buffer.get_sorted_set):
-        yield buffer
 
 
 @mock_redis_buffer()

--- a/tests/sentry/rules/processing/test_processor.py
+++ b/tests/sentry/rules/processing/test_processor.py
@@ -136,12 +136,14 @@ class RuleProcessorTest(TestCase, PerformanceIssueTestCase):
         )
         results = list(rp.apply())
         assert len(results) == 0
-        project_ids = buffer.get_sorted_set(
+        project_ids = buffer.backend.get_sorted_set(
             PROJECT_ID_BUFFER_LIST_KEY, 0, timezone.now().timestamp()
         )
         assert len(project_ids) == 1
         assert project_ids[0][0] == self.project.id
-        rulegroup_to_events = buffer.get_hash(model=Project, field={"project_id": self.project.id})
+        rulegroup_to_events = buffer.backend.get_hash(
+            model=Project, field={"project_id": self.project.id}
+        )
         assert rulegroup_to_events == {
             f"{self.rule.id}:{self.group_event.group.id}": json.dumps(
                 {"event_id": self.group_event.event_id, "occurrence_id": None}
@@ -179,12 +181,14 @@ class RuleProcessorTest(TestCase, PerformanceIssueTestCase):
         )
         results = list(rp.apply())
         assert len(results) == 0
-        project_ids = buffer.get_sorted_set(
+        project_ids = buffer.backend.get_sorted_set(
             PROJECT_ID_BUFFER_LIST_KEY, 0, timezone.now().timestamp()
         )
         assert len(project_ids) == 1
         assert project_ids[0][0] == self.project.id
-        rulegroup_to_events = buffer.get_hash(model=Project, field={"project_id": self.project.id})
+        rulegroup_to_events = buffer.backend.get_hash(
+            model=Project, field={"project_id": self.project.id}
+        )
         assert rulegroup_to_events == {
             f"{self.rule.id}:{perf_event.group.id}": json.dumps(
                 {"event_id": perf_event.event_id, "occurrence_id": perf_event.occurrence_id}
@@ -215,12 +219,14 @@ class RuleProcessorTest(TestCase, PerformanceIssueTestCase):
         )
         results = list(rp.apply())
         assert len(results) == 0
-        project_ids = buffer.get_sorted_set(
+        project_ids = buffer.backend.get_sorted_set(
             PROJECT_ID_BUFFER_LIST_KEY, 0, timezone.now().timestamp()
         )
         assert len(project_ids) == 1
         assert project_ids[0][0] == self.project.id
-        rulegroup_to_events = buffer.get_hash(model=Project, field={"project_id": self.project.id})
+        rulegroup_to_events = buffer.backend.get_hash(
+            model=Project, field={"project_id": self.project.id}
+        )
         assert rulegroup_to_events == {
             f"{self.rule.id}:{self.group_event.group.id}": json.dumps(
                 {"event_id": self.group_event.event_id, "occurrence_id": None}
@@ -302,12 +308,14 @@ class RuleProcessorTest(TestCase, PerformanceIssueTestCase):
         )
         results = list(rp.apply())
         assert len(results) == 0
-        project_ids = buffer.get_sorted_set(
+        project_ids = buffer.backend.get_sorted_set(
             PROJECT_ID_BUFFER_LIST_KEY, 0, timezone.now().timestamp()
         )
         assert len(project_ids) == 1
         assert project_ids[0][0] == self.project.id
-        rulegroup_to_events = buffer.get_hash(model=Project, field={"project_id": self.project.id})
+        rulegroup_to_events = buffer.backend.get_hash(
+            model=Project, field={"project_id": self.project.id}
+        )
         assert rulegroup_to_events == {
             f"{self.rule.id}:{self.group_event.group.id}": json.dumps(
                 {"event_id": self.group_event.event_id, "occurrence_id": None}

--- a/tests/sentry/tasks/test_post_process.py
+++ b/tests/sentry/tasks/test_post_process.py
@@ -15,8 +15,6 @@ from django.test import override_settings
 from django.utils import timezone
 
 from sentry import buffer
-
-# from sentry.buffer.redis import RedisBuffer
 from sentry.eventstore.models import Event
 from sentry.eventstore.processing import event_processing_store
 from sentry.feedback.usecases.create_feedback import FeedbackCreationSource
@@ -427,8 +425,8 @@ class RuleProcessorTestMixin(BasePostProgressGroupMixin):
         MOCK_RULES = ("sentry.rules.filters.issue_occurrences.IssueOccurrencesFilter",)
 
         with (
-            mock.patch("sentry.buffer.backend.get", buffer.get),
-            mock.patch("sentry.buffer.backend.incr", buffer.incr),
+            mock.patch("sentry.buffer.backend.get", buffer.backend.get),
+            mock.patch("sentry.buffer.backend.incr", buffer.backend.incr),
             patch("sentry.constants._SENTRY_RULES", MOCK_RULES),
             patch("sentry.rules.rules", init_registry()) as rules,
         ):
@@ -1682,8 +1680,8 @@ class SnoozeTestMixin(BasePostProgressGroupMixin):
     @patch("sentry.rules.processing.processor.RuleProcessor")
     def test_invalidates_snooze_with_buffers(self, mock_processor, send_robust):
         with (
-            mock.patch("sentry.buffer.backend.get", buffer.get),
-            mock.patch("sentry.buffer.backend.incr", buffer.incr),
+            mock.patch("sentry.buffer.backend.get", buffer.backend.get),
+            mock.patch("sentry.buffer.backend.incr", buffer.backend.incr),
         ):
             event = self.create_event(
                 data={"message": "testing", "fingerprint": ["group-1"]}, project_id=self.project.id

--- a/tests/sentry/tasks/test_post_process.py
+++ b/tests/sentry/tasks/test_post_process.py
@@ -15,7 +15,8 @@ from django.test import override_settings
 from django.utils import timezone
 
 from sentry import buffer
-from sentry.buffer.redis import RedisBuffer
+
+# from sentry.buffer.redis import RedisBuffer
 from sentry.eventstore.models import Event
 from sentry.eventstore.processing import event_processing_store
 from sentry.feedback.usecases.create_feedback import FeedbackCreationSource
@@ -71,6 +72,7 @@ from sentry.testutils.helpers import with_feature
 from sentry.testutils.helpers.datetime import before_now, iso_format
 from sentry.testutils.helpers.eventprocessing import write_event_to_cache
 from sentry.testutils.helpers.options import override_options
+from sentry.testutils.helpers.redis import mock_redis_buffer
 from sentry.testutils.performance_issues.store_transaction import store_transaction
 from sentry.testutils.silo import assume_test_silo_mode
 from sentry.testutils.skips import requires_snuba
@@ -416,6 +418,7 @@ class RuleProcessorTestMixin(BasePostProgressGroupMixin):
 
         mock_callback.assert_called_once_with(EventMatcher(event), mock_futures)
 
+    @mock_redis_buffer()
     def test_rule_processor_buffer_values(self):
         # Test that pending buffer values for `times_seen` are applied to the group and that alerts
         # fire as expected
@@ -423,10 +426,9 @@ class RuleProcessorTestMixin(BasePostProgressGroupMixin):
 
         MOCK_RULES = ("sentry.rules.filters.issue_occurrences.IssueOccurrencesFilter",)
 
-        redis_buffer = RedisBuffer()
         with (
-            mock.patch("sentry.buffer.backend.get", redis_buffer.get),
-            mock.patch("sentry.buffer.backend.incr", redis_buffer.incr),
+            mock.patch("sentry.buffer.backend.get", buffer.get),
+            mock.patch("sentry.buffer.backend.incr", buffer.incr),
             patch("sentry.constants._SENTRY_RULES", MOCK_RULES),
             patch("sentry.rules.rules", init_registry()) as rules,
         ):
@@ -1674,14 +1676,14 @@ class SnoozeTestMixin(BasePostProgressGroupMixin):
         ).exists()
         assert mock_send_unignored_robust.called
 
+    @mock_redis_buffer()
     @override_settings(SENTRY_BUFFER="sentry.buffer.redis.RedisBuffer")
     @patch("sentry.signals.issue_unignored.send_robust")
     @patch("sentry.rules.processing.processor.RuleProcessor")
     def test_invalidates_snooze_with_buffers(self, mock_processor, send_robust):
-        redis_buffer = RedisBuffer()
         with (
-            mock.patch("sentry.buffer.backend.get", redis_buffer.get),
-            mock.patch("sentry.buffer.backend.incr", redis_buffer.incr),
+            mock.patch("sentry.buffer.backend.get", buffer.get),
+            mock.patch("sentry.buffer.backend.incr", buffer.incr),
         ):
             event = self.create_event(
                 data={"message": "testing", "fingerprint": ["group-1"]}, project_id=self.project.id


### PR DESCRIPTION
Use the base buffer instead of directly importing the `RedisBuffer` to hopefully fix the problem where this all works locally but in production we get an empty project ID list from Redis perhaps because we're writing to one cluster and reading from another.