### PR TITLE
fix: use `orjson.OPT_UTC_Z` for timestamps

### DIFF
--- a/src/sentry/utils/outcomes.py
+++ b/src/sentry/utils/outcomes.py
@@ -118,7 +118,8 @@ def track_outcome(
                 "event_id": event_id,
                 "category": category,
                 "quantity": quantity,
-            }
+            },
+            option=orjson.OPT_UTC_Z
         ).decode(),
     )
 

--- a/src/sentry/utils/outcomes.py
+++ b/src/sentry/utils/outcomes.py
@@ -119,7 +119,7 @@ def track_outcome(
                 "category": category,
                 "quantity": quantity,
             },
-            option=orjson.OPT_UTC_Z
+            option=orjson.OPT_UTC_Z,
         ).decode(),
     )
 


### PR DESCRIPTION
For timestamps, we should use `OPT_UTC_Z`