### PR TITLE
chore: reapply reverted orjson changes

### DIFF
--- a/src/sentry/api/endpoints/source_map_debug_blue_thunder_edition.py
+++ b/src/sentry/api/endpoints/source_map_debug_blue_thunder_edition.py
@@ -1,5 +1,6 @@
 from typing import Literal, TypedDict
 
+import orjson
 import sentry_sdk
 from django.db.models import QuerySet
 from django.utils.encoding import force_bytes, force_str
@@ -33,7 +34,6 @@ from sentry.models.releasefile import (
     ReleaseFile,
 )
 from sentry.sdk_updates import get_sdk_index
-from sentry.utils import json
 from sentry.utils.javascript import find_sourcemap
 from sentry.utils.safe import get_path
 from sentry.utils.urls import non_standard_url_join
@@ -416,7 +416,7 @@ class ReleaseLookupData:
             self._get_dist_matched_artifact_index_release_file()
         )
         if dist_matched_artifact_index_release_file is not None:
-            raw_data = json.load(dist_matched_artifact_index_release_file.file.getfile())
+            raw_data = orjson.loads(dist_matched_artifact_index_release_file.file.getfile().read())
             files = raw_data.get("files")
             for potential_source_file_name in self.matching_source_file_names:
                 matching_file = files.get(potential_source_file_name)
@@ -453,7 +453,7 @@ class ReleaseLookupData:
                     return
 
         for artifact_index_file in self._get_artifact_index_release_files():
-            raw_data = json.load(artifact_index_file.file.getfile())
+            raw_data = orjson.loads(artifact_index_file.file.getfile().read())
             files = raw_data.get("files")
             for potential_source_file_name in self.matching_source_file_names:
                 if files.get(potential_source_file_name) is not None:
@@ -534,14 +534,14 @@ class ReleaseLookupData:
             self._get_dist_matched_artifact_index_release_file()
         )
         if dist_matched_artifact_index_release_file is not None:
-            raw_data = json.load(dist_matched_artifact_index_release_file.file.getfile())
+            raw_data = orjson.loads(dist_matched_artifact_index_release_file.file.getfile().read())
             files = raw_data.get("files")
             if files.get(matching_source_map_name) is not None:
                 self.source_map_lookup_result = "found"
                 return
 
         for artifact_index_file in self._get_artifact_index_release_files():
-            raw_data = json.load(artifact_index_file.file.getfile())
+            raw_data = orjson.loads(artifact_index_file.file.getfile().read())
             files = raw_data.get("files")
             if files.get(matching_source_map_name) is not None:
                 self.source_map_lookup_result = "wrong-dist"

--- a/src/sentry/backup/crypto.py
+++ b/src/sentry/backup/crypto.py
@@ -14,7 +14,6 @@ from cryptography.hazmat.primitives.asymmetric import padding
 from google.cloud.kms import KeyManagementServiceClient as KeyManagementServiceClient
 from google_crc32c import value as crc32c
 
-from sentry.utils import json
 from sentry.utils.env import gcp_project_id
 
 
@@ -94,7 +93,7 @@ class GCPKMSEncryptor(Encryptor):
     def get_public_key_pem(self) -> bytes:
         if self.crypto_key_version is None:
             # Read the user supplied configuration into the proper format.
-            gcp_kms_config_json = json.load(self.__fp)
+            gcp_kms_config_json = orjson.loads(self.__fp.read())
             try:
                 self.crypto_key_version = CryptoKeyVersion(**gcp_kms_config_json)
             except TypeError:

--- a/src/sentry/backup/imports.py
+++ b/src/sentry/backup/imports.py
@@ -188,7 +188,7 @@ def _import(
                 del content_as_json[i]
 
         # Return the content to byte form, as that is what the Django deserializer expects.
-        content = orjson.dumps(content_as_json)
+        content = orjson.dumps(content_as_json, option=orjson.OPT_UTC_Z)
 
     filters = []
     if filter_by is not None:

--- a/src/sentry/backup/imports.py
+++ b/src/sentry/backup/imports.py
@@ -38,7 +38,6 @@ from sentry.services.hybrid_cloud.import_export.model import (
 from sentry.services.hybrid_cloud.import_export.service import ImportExportService
 from sentry.silo.base import SiloMode
 from sentry.silo.safety import unguarded_write
-from sentry.utils import json
 from sentry.utils.env import is_split_db
 
 __all__ = (
@@ -289,7 +288,11 @@ def _import(
                 batch = []
                 last_seen_model_name = model_name
             if len(batch) >= MAX_BATCH_SIZE:
-                yield (last_seen_model_name, json.dumps(batch), num_current_model_instances_yielded)
+                yield (
+                    last_seen_model_name,
+                    orjson.dumps(batch).decode(),
+                    num_current_model_instances_yielded,
+                )
                 num_current_model_instances_yielded += len(batch)
                 batch = []
 

--- a/src/sentry/backup/sanitize.py
+++ b/src/sentry/backup/sanitize.py
@@ -295,7 +295,7 @@ class Sanitizer:
         if interned is not None:
             return orjson.loads(interned)
 
-        new_serialized = orjson.dumps(new_json).decode()
+        new_serialized = orjson.dumps(new_json, option=orjson.OPT_UTC_Z).decode()
         self.interned_strings[old_serialized] = new_serialized
         return new_json
 

--- a/src/sentry/backup/sanitize.py
+++ b/src/sentry/backup/sanitize.py
@@ -9,11 +9,10 @@ from typing import Any
 from urllib.parse import urlparse, urlunparse
 from uuid import UUID, uuid4
 
+import orjson
 import petname
 from dateutil.parser import parse as parse_datetime
 from django.utils.text import slugify
-
-from sentry.utils import json
 
 UPPER_CASE_HEX = {"A", "B", "C", "D", "E", "F"}
 UPPER_CASE_NON_HEX = {
@@ -89,14 +88,14 @@ class SanitizableField:
     model: NormalizedModelName
     field: str
 
-    def validate_json_model(self, json: Any) -> None:
+    def validate_json_model(self, obj: Any) -> None:
         """
         Validates the JSON model is shaped the way we expect a serialized Django model to be,
         and that we have the right kind of model for this `SanitizableField`. Raises errors if there
         is a validation failure.
         """
 
-        model_name = json.get("model", None)
+        model_name = obj.get("model", None)
         if model_name is None:
             raise InvalidJSONError(
                 "JSON is not properly formatted, must be a serialized Django model"
@@ -106,12 +105,12 @@ class SanitizableField:
         return None
 
 
-def _get_field_value(json: Any, field: SanitizableField) -> Any | None:
-    return json.get("fields", {}).get(field.field, None)
+def _get_field_value(obj: Any, field: SanitizableField) -> Any | None:
+    return obj.get("fields", {}).get(field.field, None)
 
 
-def _set_field_value(json: Any, field: SanitizableField, value: Any) -> Any:
-    json.get("fields", {})[field.field] = value
+def _set_field_value(obj: Any, field: SanitizableField, value: Any) -> Any:
+    obj.get("fields", {})[field.field] = value
     return value
 
 
@@ -291,12 +290,12 @@ class Sanitizer:
         `set_json()` is the preferred method for doing so.
         """
 
-        old_serialized = json.dumps(old_json)
+        old_serialized = orjson.dumps(old_json).decode()
         interned = self.interned_strings.get(old_serialized)
         if interned is not None:
-            return json.loads(interned)
+            return orjson.loads(interned)
 
-        new_serialized = json.dumps(new_json)
+        new_serialized = orjson.dumps(new_json).decode()
         self.interned_strings[old_serialized] = new_serialized
         return new_json
 

--- a/src/sentry/buffer/redis.py
+++ b/src/sentry/buffer/redis.py
@@ -9,6 +9,7 @@ from enum import Enum
 from time import time
 from typing import Any, TypeVar
 
+import orjson
 import rb
 from django.utils.encoding import force_bytes, force_str
 from rediscluster import RedisCluster
@@ -16,7 +17,7 @@ from rediscluster import RedisCluster
 from sentry.buffer.base import Buffer
 from sentry.db import models
 from sentry.tasks.process_buffer import process_incr
-from sentry.utils import json, metrics
+from sentry.utils import metrics
 from sentry.utils.hashlib import md5_text
 from sentry.utils.imports import import_string
 from sentry.utils.redis import (
@@ -47,7 +48,9 @@ def _validate_json_roundtrip(value: dict[str, Any], model: type[models.Model]) -
         _last_validation_log = time()
         try:
             if (
-                RedisBuffer._load_values(json.loads(json.dumps(RedisBuffer._dump_values(value))))
+                RedisBuffer._load_values(
+                    orjson.loads(orjson.dumps(RedisBuffer._dump_values(value)))
+                )
                 != value
             ):
                 logger.error("buffer.corrupted_value", extra={"value": value, "model": model})
@@ -252,10 +255,6 @@ class RedisBuffer(Buffer):
     def push_to_sorted_set(self, key: str, value: list[int] | int) -> None:
         value_dict = {value: time()}
         self._execute_redis_operation(key, RedisOperation.SORTED_SET_ADD, value_dict)
-        logger.info(
-            "redis_buffer.push_to_sorted_set",
-            extra={"key_name": key, "value": json.dumps(value_dict)},
-        )
 
     def get_sorted_set(self, key: str, min: float, max: float) -> list[tuple[int, datetime]]:
         redis_set = self._execute_redis_operation(
@@ -347,7 +346,7 @@ class RedisBuffer(Buffer):
         _validate_json_roundtrip(filters, model)
 
         if is_instance_redis_cluster(self.cluster, self.is_redis_cluster):
-            pipe.hsetnx(key, "f", json.dumps(self._dump_values(filters)))
+            pipe.hsetnx(key, "f", orjson.dumps(self._dump_values(filters)).decode())
         else:
             pipe.hsetnx(key, "f", pickle.dumps(filters))
 
@@ -361,7 +360,7 @@ class RedisBuffer(Buffer):
             _validate_json_roundtrip(extra, model)
             for column, value in extra.items():
                 if is_instance_redis_cluster(self.cluster, self.is_redis_cluster):
-                    pipe.hset(key, "e+" + column, json.dumps(self._dump_value(value)))
+                    pipe.hset(key, "e+" + column, orjson.dumps(self._dump_value(value)).decode())
                 else:
                     pipe.hset(key, "e+" + column, pickle.dumps(value))
 
@@ -474,7 +473,7 @@ class RedisBuffer(Buffer):
             model = import_string(force_str(values.pop("m")))
 
             if values["f"].startswith(b"{" if not self.is_redis_cluster else "{"):
-                filters = self._load_values(json.loads(force_str(values.pop("f"))))
+                filters = self._load_values(orjson.loads(force_str(values.pop("f"))))
             else:
                 # TODO(dcramer): legacy pickle support - remove in Sentry 9.1
                 filters = pickle.loads(force_bytes(values.pop("f")))
@@ -487,7 +486,7 @@ class RedisBuffer(Buffer):
                     incr_values[k[2:]] = int(v)
                 elif k.startswith("e+"):
                     if v.startswith(b"[" if not self.is_redis_cluster else "["):
-                        extra_values[k[2:]] = self._load_value(json.loads(force_str(v)))
+                        extra_values[k[2:]] = self._load_value(orjson.loads(force_str(v)))
                     else:
                         # TODO(dcramer): legacy pickle support - remove in Sentry 9.1
                         extra_values[k[2:]] = pickle.loads(force_bytes(v))

--- a/src/sentry/buffer/redis.py
+++ b/src/sentry/buffer/redis.py
@@ -49,7 +49,9 @@ def _validate_json_roundtrip(value: dict[str, Any], model: type[models.Model]) -
         try:
             if (
                 RedisBuffer._load_values(
-                    orjson.loads(orjson.dumps(RedisBuffer._dump_values(value)))
+                    orjson.loads(
+                        orjson.dumps(RedisBuffer._dump_values(value), option=orjson.OPT_UTC_Z)
+                    )
                 )
                 != value
             ):
@@ -346,7 +348,9 @@ class RedisBuffer(Buffer):
         _validate_json_roundtrip(filters, model)
 
         if is_instance_redis_cluster(self.cluster, self.is_redis_cluster):
-            pipe.hsetnx(key, "f", orjson.dumps(self._dump_values(filters)).decode())
+            pipe.hsetnx(
+                key, "f", orjson.dumps(self._dump_values(filters), option=orjson.OPT_UTC_Z).decode()
+            )
         else:
             pipe.hsetnx(key, "f", pickle.dumps(filters))
 
@@ -360,7 +364,11 @@ class RedisBuffer(Buffer):
             _validate_json_roundtrip(extra, model)
             for column, value in extra.items():
                 if is_instance_redis_cluster(self.cluster, self.is_redis_cluster):
-                    pipe.hset(key, "e+" + column, orjson.dumps(self._dump_value(value)).decode())
+                    pipe.hset(
+                        key,
+                        "e+" + column,
+                        orjson.dumps(self._dump_value(value), option=orjson.OPT_UTC_Z).decode(),
+                    )
                 else:
                     pipe.hset(key, "e+" + column, pickle.dumps(value))
 

--- a/src/sentry/cache/redis.py
+++ b/src/sentry/cache/redis.py
@@ -26,7 +26,7 @@ class CommonRedisCache(BaseCache):
 
     def set(self, key, value, timeout, version=None, raw=False):
         key = self.make_key(key, version=version)
-        v = orjson.dumps(value).decode() if not raw else value
+        v = orjson.dumps(value, option=orjson.OPT_UTC_Z).decode() if not raw else value
         if len(v) > self.max_size:
             raise ValueTooLarge(f"Cache key too large: {key!r} {len(v)!r}")
         if timeout:

--- a/src/sentry/cache/redis.py
+++ b/src/sentry/cache/redis.py
@@ -1,4 +1,5 @@
-from sentry.utils import json
+import orjson
+
 from sentry.utils.redis import get_cluster_from_options, get_cluster_routing_client, redis_clusters
 
 from .base import BaseCache
@@ -25,7 +26,7 @@ class CommonRedisCache(BaseCache):
 
     def set(self, key, value, timeout, version=None, raw=False):
         key = self.make_key(key, version=version)
-        v = json.dumps(value) if not raw else value
+        v = orjson.dumps(value).decode() if not raw else value
         if len(v) > self.max_size:
             raise ValueTooLarge(f"Cache key too large: {key!r} {len(v)!r}")
         if timeout:
@@ -45,7 +46,7 @@ class CommonRedisCache(BaseCache):
         key = self.make_key(key, version=version)
         result = self._client(raw=raw).get(key)
         if result is not None and not raw:
-            result = json.loads(result)
+            result = orjson.loads(result)
 
         self._mark_transaction("get")
 

--- a/src/sentry/charts/chartcuterie.py
+++ b/src/sentry/charts/chartcuterie.py
@@ -76,7 +76,7 @@ class Chartcuterie(ChartRenderer):
             assert self.service_url is not None
             resp = requests.post(
                 url=urljoin(self.service_url, "render"),
-                data=orjson.dumps(payload),
+                data=orjson.dumps(payload, option=orjson.OPT_UTC_Z),
                 headers={"Content-Type": "application/json"},
             )
 

--- a/src/sentry/charts/chartcuterie.py
+++ b/src/sentry/charts/chartcuterie.py
@@ -3,6 +3,7 @@ from typing import Any
 from urllib.parse import urljoin
 from uuid import uuid4
 
+import orjson
 import requests
 import sentry_sdk
 from django.conf import settings
@@ -10,7 +11,6 @@ from django.conf import settings
 from sentry import options
 from sentry.exceptions import InvalidConfiguration
 from sentry.models.file import get_storage
-from sentry.utils import json
 from sentry.utils.http import absolute_uri
 
 from .base import ChartRenderer, logger
@@ -76,7 +76,7 @@ class Chartcuterie(ChartRenderer):
             assert self.service_url is not None
             resp = requests.post(
                 url=urljoin(self.service_url, "render"),
-                data=json.dumps(payload),
+                data=orjson.dumps(payload),
                 headers={"Content-Type": "application/json"},
             )
 

--- a/src/sentry/db/models/fields/array.py
+++ b/src/sentry/db/models/fields/array.py
@@ -1,9 +1,9 @@
 import ast
 
+import orjson
 from django.db import models
 
 from sentry.db.models.utils import Creator
-from sentry.utils import json
 
 
 # Adapted from django-pgfields
@@ -54,8 +54,8 @@ class ArrayField(models.Field):
             value = []
         if isinstance(value, str):
             try:
-                value = json.loads(value)
-            except json.JSONDecodeError:
+                value = orjson.loads(value)
+            except orjson.JSONDecodeError:
                 # This is to accommodate the erroneous exports pre 21.4.0
                 # See getsentry/sentry#23843 for more details
                 try:

--- a/src/sentry/db/models/fields/gzippeddict.py
+++ b/src/sentry/db/models/fields/gzippeddict.py
@@ -3,10 +3,10 @@ from __future__ import annotations
 import logging
 import pickle
 
+import orjson
 from django.db.models import TextField
 
 from sentry.db.models.utils import Creator
-from sentry.utils import json
 from sentry.utils.strings import decompress
 
 __all__ = ("GzippedDictField",)
@@ -32,7 +32,7 @@ class GzippedDictField(TextField):
         try:
             if not value:
                 return {}
-            return json.loads(value)
+            return orjson.loads(value)
         except (ValueError, TypeError):
             if isinstance(value, str) and value:
                 try:
@@ -47,7 +47,7 @@ class GzippedDictField(TextField):
     def from_db_value(self, value, expression, connection):
         return self.to_python(value)
 
-    def get_prep_value(self, value):
+    def get_prep_value(self, value) -> str | None:
         if not value and self.null:
             # save ourselves some storage
             return None
@@ -55,7 +55,7 @@ class GzippedDictField(TextField):
             value = value.decode("utf-8")
         if value is None and self.null:
             return None
-        return json.dumps(value)
+        return orjson.dumps(value).decode()
 
     def value_to_string(self, obj):
         return self.get_prep_value(self.value_from_object(obj))

--- a/src/sentry/db/models/fields/jsonfield.py
+++ b/src/sentry/db/models/fields/jsonfield.py
@@ -117,7 +117,7 @@ class JSONField(models.TextField):
                 return ""
             return None
         # TODO(@anonrig): Remove support for non-string keys.
-        return orjson.dumps(value, option=orjson.OPT_NON_STR_KEYS).decode()
+        return orjson.dumps(value, option=orjson.OPT_NON_STR_KEYS | orjson.OPT_UTC_Z).decode()
 
     def value_to_string(self, obj):
         return self.value_from_object(obj)

--- a/src/sentry/db/models/fields/jsonfield.py
+++ b/src/sentry/db/models/fields/jsonfield.py
@@ -25,13 +25,13 @@ LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
 OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
 ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 """
+import orjson
 from django.core.exceptions import ValidationError
 from django.db import models
 from django.db.models.lookups import Contains, Exact, IContains, IExact, In, Lookup
 from django.utils.translation import gettext_lazy as _
 
 from sentry.db.models.utils import Creator
-from sentry.utils import json
 
 
 class JSONField(models.TextField):
@@ -83,8 +83,8 @@ class JSONField(models.TextField):
             if callable(default):
                 default = default()
             if isinstance(default, str):
-                return json.loads(default)
-            return json.loads(json.dumps(default))
+                return orjson.loads(default)
+            return orjson.loads(orjson.dumps(default))
         return super().get_default()
 
     def get_internal_type(self):
@@ -101,7 +101,7 @@ class JSONField(models.TextField):
                 if self.blank:
                     return ""
             try:
-                value = json.loads(value)
+                value = orjson.loads(value)
             except ValueError:
                 msg = self.error_messages["invalid"] % value
                 raise ValidationError(msg)
@@ -111,12 +111,13 @@ class JSONField(models.TextField):
     def get_db_prep_value(self, value, connection=None, prepared=None):
         return self.get_prep_value(value)
 
-    def get_prep_value(self, value):
+    def get_prep_value(self, value) -> str | None:
         if value is None:
             if not self.null and self.blank:
                 return ""
             return None
-        return json.dumps(value)
+        # TODO(@anonrig): Remove support for non-string keys.
+        return orjson.dumps(value, option=orjson.OPT_NON_STR_KEYS).decode()
 
     def value_to_string(self, obj):
         return self.value_from_object(obj)

--- a/src/sentry/db/models/fields/node.py
+++ b/src/sentry/db/models/fields/node.py
@@ -7,12 +7,12 @@ from collections.abc import MutableMapping
 from typing import Any
 from uuid import uuid4
 
+import orjson
 from django.db.models.signals import post_delete
 from django.utils.functional import cached_property
 
 from sentry import nodestore
 from sentry.db.models.utils import Creator
-from sentry.utils import json
 from sentry.utils.canonical import CANONICAL_TYPES, CanonicalKeyDict
 from sentry.utils.strings import decompress
 
@@ -191,7 +191,7 @@ class NodeField(GzippedDictField):
         # with a dict.
         if value and isinstance(value, str):
             try:
-                value = json.loads(value)
+                value = orjson.loads(value)
             except (ValueError, TypeError):
                 try:
                     value = pickle.loads(decompress(value))
@@ -228,7 +228,7 @@ class NodeField(GzippedDictField):
             ref_func=self.ref_func,
         )
 
-    def get_prep_value(self, value):
+    def get_prep_value(self, value) -> str | None:
         """
         Prepares the NodeData to be written in a Model.save() call.
 
@@ -244,4 +244,4 @@ class NodeField(GzippedDictField):
 
         value.save()
 
-        return json.dumps({"node_id": value.id})
+        return orjson.dumps({"node_id": value.id}).decode()

--- a/src/sentry/db/models/fields/picklefield.py
+++ b/src/sentry/db/models/fields/picklefield.py
@@ -34,7 +34,7 @@ class PickledObjectField(django_picklefield.PickledObjectField):
             return None
         # TODO(@anonrig): Remove support for non-string keys.
         return orjson.dumps(
-            value, option=orjson.OPT_NON_STR_KEYS, default=_orjson_defaults
+            value, option=orjson.OPT_NON_STR_KEYS | orjson.OPT_UTC_Z, default=_orjson_defaults
         ).decode()
 
     def to_python(self, value):

--- a/src/sentry/db/models/fields/picklefield.py
+++ b/src/sentry/db/models/fields/picklefield.py
@@ -1,5 +1,17 @@
+from typing import Any
+
+import orjson
+
 import django_picklefield
-from sentry.utils import json
+
+
+# TODO(@anonrig): Remove support for `bytes` as a JSON value
+def _orjson_defaults(obj: Any) -> Any:
+    if isinstance(obj, bytes):
+        return obj.decode()
+    elif isinstance(obj, set):
+        return list(obj)
+    raise TypeError
 
 
 class PickledObjectField(django_picklefield.PickledObjectField):
@@ -17,16 +29,19 @@ class PickledObjectField(django_picklefield.PickledObjectField):
 
     def get_db_prep_value(self, value, *args, **kwargs):
         if isinstance(value, bytes):
-            value = value.decode("utf-8")
+            value = value.decode()
         if value is None and self.null:
             return None
-        return json.dumps(value)
+        # TODO(@anonrig): Remove support for non-string keys.
+        return orjson.dumps(
+            value, option=orjson.OPT_NON_STR_KEYS, default=_orjson_defaults
+        ).decode()
 
     def to_python(self, value):
         if value is None:
             return None
         try:
-            return json.loads(value)
+            return orjson.loads(value)
         except (ValueError, TypeError):
             from sentry.utils import metrics
 

--- a/src/sentry/eventstream/snuba.py
+++ b/src/sentry/eventstream/snuba.py
@@ -6,6 +6,7 @@ from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any
 from uuid import uuid4
 
+import orjson
 import urllib3
 
 from sentry import quotas
@@ -418,7 +419,7 @@ class SnubaEventStream(SnubaProtocolEventStream):
         if event_type == EventStreamEventType.Generic:
             entity = "search_issues"
 
-        serialized_data = json.dumps(data)
+        serialized_data = orjson.dumps(data, option=orjson.OPT_UTC_Z).decode()
 
         topic_mapping: Mapping[str, Topic] = {
             "events": Topic.EVENTS,
@@ -427,7 +428,7 @@ class SnubaEventStream(SnubaProtocolEventStream):
         }
 
         codec = get_topic_codec(topic_mapping[entity])
-        codec.decode(serialized_data.encode("utf-8"), validate=True)
+        codec.decode(serialized_data.encode(), validate=True)
 
         try:
             resp = snuba._snuba_pool.urlopen(
@@ -438,7 +439,7 @@ class SnubaEventStream(SnubaProtocolEventStream):
             )
             if resp.status != 200:
                 raise snuba.SnubaError(
-                    f"HTTP {resp.status} response from Snuba! {json.loads(resp.data)}"
+                    f"HTTP {resp.status} response from Snuba! {orjson.loads(resp.data)}"
                 )
             return None
         except urllib3.exceptions.HTTPError as err:

--- a/src/sentry/interfaces/message.py
+++ b/src/sentry/interfaces/message.py
@@ -1,17 +1,19 @@
 __all__ = ("Message",)
 
+from typing import Any
+
+import orjson
 
 from sentry.interfaces.base import Interface
-from sentry.utils import json
 from sentry.utils.json import prune_empty_keys
 
 
-def stringify(value):
+def stringify(value: Any) -> str | None:
     if isinstance(value, str):
         return value
 
     if isinstance(value, (int, float, bool)):
-        return json.dumps(value)
+        return orjson.dumps(value).decode()
 
     return None
 

--- a/src/sentry/interfaces/security.py
+++ b/src/sentry/interfaces/security.py
@@ -1,8 +1,8 @@
+import orjson
 from django.utils.functional import cached_property
 
 from sentry.interfaces.base import Interface
 from sentry.security import csp
-from sentry.utils import json
 from sentry.web.helpers import render_to_string
 
 __all__ = ("Csp", "Hpkp", "ExpectCT", "ExpectStaple")
@@ -173,7 +173,7 @@ class Csp(SecurityReport):
         return super().to_python(data, **kwargs)
 
     def to_string(self, is_public=False, **kwargs):
-        return json.dumps({"csp-report": self.get_api_context()})
+        return orjson.dumps({"csp-report": self.get_api_context()}).decode()
 
     def to_email_html(self, event, **kwargs):
         return render_to_string(

--- a/src/sentry/interfaces/security.py
+++ b/src/sentry/interfaces/security.py
@@ -173,7 +173,9 @@ class Csp(SecurityReport):
         return super().to_python(data, **kwargs)
 
     def to_string(self, is_public=False, **kwargs):
-        return orjson.dumps({"csp-report": self.get_api_context()}).decode()
+        return orjson.dumps(
+            {"csp-report": self.get_api_context()}, option=orjson.OPT_UTC_Z
+        ).decode()
 
     def to_email_html(self, event, **kwargs):
         return render_to_string(

--- a/src/sentry/monitors/consumers/monitor_consumer.py
+++ b/src/sentry/monitors/consumers/monitor_consumer.py
@@ -10,6 +10,7 @@ from datetime import datetime, timedelta
 from functools import partial
 from typing import Literal
 
+import orjson
 import sentry_sdk
 from arroyo.backends.kafka.consumer import KafkaPayload
 from arroyo.processing.strategies.abstract import ProcessingStrategy, ProcessingStrategyFactory
@@ -74,7 +75,7 @@ from sentry.monitors.utils import (
 )
 from sentry.monitors.validators import ConfigValidator, MonitorCheckInValidator
 from sentry.types.actor import parse_and_validate_actor
-from sentry.utils import json, metrics
+from sentry.utils import metrics
 from sentry.utils.dates import to_datetime
 from sentry.utils.outcomes import Outcome, track_outcome
 
@@ -968,7 +969,7 @@ def process_batch(executor: ThreadPoolExecutor, message: Message[ValuesBatch[Kaf
             ts=item.timestamp,
             partition=item.partition.index,
             message=wrapper,
-            payload=json.loads(wrapper["payload"]),
+            payload=orjson.loads(wrapper["payload"]),
         )
         checkin_mapping[item.processing_key].append(item)
 
@@ -1015,7 +1016,7 @@ def process_single(message: Message[KafkaPayload | FilteredPayload]):
             ts=ts,
             partition=partition,
             message=wrapper,
-            payload=json.loads(wrapper["payload"]),
+            payload=orjson.loads(wrapper["payload"]),
         )
         process_checkin(item)
     except Exception:

--- a/src/sentry/notifications/utils/participants.py
+++ b/src/sentry/notifications/utils/participants.py
@@ -5,6 +5,7 @@ from collections import defaultdict
 from collections.abc import Iterable, Mapping, MutableMapping, Sequence
 from typing import TYPE_CHECKING, Any
 
+import orjson
 from django.db.models import Q
 
 from sentry import features
@@ -35,7 +36,7 @@ from sentry.services.hybrid_cloud.user.service import user_service
 from sentry.services.hybrid_cloud.user_option import get_option_from_list, user_option_service
 from sentry.types.actor import Actor, ActorType
 from sentry.types.integrations import ExternalProviders, get_provider_enum_from_string
-from sentry.utils import json, metrics
+from sentry.utils import metrics
 from sentry.utils.committers import AuthorCommitsSerialized, get_serialized_event_file_committers
 
 if TYPE_CHECKING:
@@ -613,10 +614,10 @@ def _get_recipients_by_provider(
             "target_type": target_type,
             "target_identifier": target_identifier,
             "notification_uuid": notification_uuid,
-            "teams": json.dumps([team.id for team in teams]),
-            "teams_by_provider": json.dumps(teams_by_provider_dict),
-            "users": json.dumps([user.id for user in users]),
-            "users_by_provider": json.dumps(users_by_provider_dict),
+            "teams": orjson.dumps([team.id for team in teams]).decode(),
+            "teams_by_provider": orjson.dumps(teams_by_provider_dict).decode(),
+            "users": orjson.dumps([user.id for user in users]).decode(),
+            "users_by_provider": orjson.dumps(users_by_provider_dict).decode(),
         }
         logger.info("sentry.notifications.recipients_by_provider", extra=extra)
     except Exception as e:

--- a/src/sentry/notifications/utils/participants.py
+++ b/src/sentry/notifications/utils/participants.py
@@ -617,7 +617,10 @@ def _get_recipients_by_provider(
             "teams": orjson.dumps([team.id for team in teams]).decode(),
             "teams_by_provider": orjson.dumps(teams_by_provider_dict).decode(),
             "users": orjson.dumps([user.id for user in users]).decode(),
-            "users_by_provider": orjson.dumps(users_by_provider_dict).decode(),
+            # TODO(@anonrig): Remove support for non-string JSON keys.
+            "users_by_provider": orjson.dumps(
+                users_by_provider_dict, option=orjson.OPT_NON_STR_KEYS
+            ).decode(),
         }
         logger.info("sentry.notifications.recipients_by_provider", extra=extra)
     except Exception as e:

--- a/src/sentry/pipeline/views/base.py
+++ b/src/sentry/pipeline/views/base.py
@@ -2,10 +2,10 @@ import abc
 from collections.abc import Mapping
 from typing import TYPE_CHECKING, Any
 
+import orjson
 from django.http.response import HttpResponseBase
 from rest_framework.request import Request
 
-from sentry.utils import json
 from sentry.web.frontend.base import BaseView
 from sentry.web.helpers import render_to_response
 
@@ -35,5 +35,5 @@ class PipelineView(BaseView, abc.ABC):
         return render_to_response(
             template="sentry/bases/react_pipeline.html",
             request=request,
-            context={"pipelineName": pipeline_name, "props": json.dumps(props)},
+            context={"pipelineName": pipeline_name, "props": orjson.dumps(props).decode()},
         )

--- a/src/sentry/pipeline/views/base.py
+++ b/src/sentry/pipeline/views/base.py
@@ -35,5 +35,8 @@ class PipelineView(BaseView, abc.ABC):
         return render_to_response(
             template="sentry/bases/react_pipeline.html",
             request=request,
-            context={"pipelineName": pipeline_name, "props": orjson.dumps(props).decode()},
+            context={
+                "pipelineName": pipeline_name,
+                "props": orjson.dumps(props, option=orjson.OPT_UTC_Z).decode(),
+            },
         )

--- a/src/sentry/plugins/base/response.py
+++ b/src/sentry/plugins/base/response.py
@@ -34,5 +34,7 @@ class JSONResponse(Response):
 
     def respond(self, request, context=None):
         return HttpResponse(
-            orjson.dumps(self.context).decode(), content_type="application/json", status=self.status
+            orjson.dumps(self.context, option=orjson.OPT_UTC_Z).decode(),
+            content_type="application/json",
+            status=self.status,
         )

--- a/src/sentry/plugins/base/response.py
+++ b/src/sentry/plugins/base/response.py
@@ -1,9 +1,8 @@
 __all__ = ("Response", "JSONResponse")
 
+import orjson
 from django.http import HttpResponse
 from django.template.context_processors import csrf
-
-from sentry.utils import json
 
 
 class Response:
@@ -35,5 +34,5 @@ class JSONResponse(Response):
 
     def respond(self, request, context=None):
         return HttpResponse(
-            json.dumps(self.context), content_type="application/json", status=self.status
+            orjson.dumps(self.context).decode(), content_type="application/json", status=self.status
         )

--- a/src/sentry/shared_integrations/client/base.py
+++ b/src/sentry/shared_integrations/client/base.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from collections.abc import Callable, Mapping, Sequence
 from typing import Any, Literal, Self, Union, overload
 
+import orjson
 import sentry_sdk
 from django.core.cache import cache
 from requests import PreparedRequest, Request, Response
@@ -19,7 +20,7 @@ from sentry.models.integrations.utils import is_response_error, is_response_succ
 from sentry.net.http import SafeSession
 from sentry.services.hybrid_cloud.integration import integration_service
 from sentry.services.hybrid_cloud.organization import organization_service
-from sentry.utils import json, metrics
+from sentry.utils import metrics
 from sentry.utils.audit import create_system_audit_entry
 from sentry.utils.hashlib import md5_text
 
@@ -332,7 +333,7 @@ class BaseApiClient(TrackResponseMixin):
         data = kwargs.get("data", None)
         query = ""
         if kwargs.get("params", None):
-            query = json.dumps(kwargs.get("params"))
+            query = orjson.dumps(kwargs.get("params")).decode()
 
         key = self.get_cache_key(path, query, data)
         result: BaseApiResponseX | None = self.check_cache(key)

--- a/src/sentry/shared_integrations/client/base.py
+++ b/src/sentry/shared_integrations/client/base.py
@@ -333,7 +333,7 @@ class BaseApiClient(TrackResponseMixin):
         data = kwargs.get("data", None)
         query = ""
         if kwargs.get("params", None):
-            query = orjson.dumps(kwargs.get("params")).decode()
+            query = orjson.dumps(kwargs.get("params"), option=orjson.OPT_UTC_Z).decode()
 
         key = self.get_cache_key(path, query, data)
         result: BaseApiResponseX | None = self.check_cache(key)

--- a/src/sentry/shared_integrations/exceptions/__init__.py
+++ b/src/sentry/shared_integrations/exceptions/__init__.py
@@ -5,12 +5,11 @@ from collections.abc import Mapping
 from typing import Any, Protocol
 from urllib.parse import urlparse
 
+import orjson
 from bs4 import BeautifulSoup
 from requests import Response
 from requests.adapters import RetryError
 from requests.exceptions import RequestException
-
-from sentry.utils import json
 
 __all__ = (
     "ApiConnectionResetError",
@@ -53,8 +52,8 @@ class ApiError(Exception):
         # TODO(dcramer): pull in XML support from Jira
         if text:
             try:
-                self.json = json.loads(text)
-            except (json.JSONDecodeError, ValueError):
+                self.json = orjson.loads(text)
+            except orjson.JSONDecodeError:
                 if self.text[:5] == "<?xml":
                     # perhaps it's XML?
                     self.xml = BeautifulSoup(self.text, "xml")

--- a/src/sentry/shared_integrations/response/base.py
+++ b/src/sentry/shared_integrations/response/base.py
@@ -3,12 +3,12 @@ from __future__ import annotations
 from collections.abc import Mapping
 from typing import Any
 
+import orjson
 import requests
 from django.utils.functional import cached_property
 from requests import Response
 
 from sentry.shared_integrations.exceptions import UnsupportedResponseType
-from sentry.utils import json
 
 
 class BaseApiResponse:
@@ -77,8 +77,8 @@ class BaseApiResponse:
         # to decode it anyways
         if "application/json" not in response.headers.get("Content-Type", ""):
             try:
-                data = json.loads(response.text)
-            except (TypeError, ValueError):
+                data = orjson.loads(response.text)
+            except orjson.JSONDecodeError:
                 if allow_text:
                     return TextApiResponse(response.text, response.headers, response.status_code)
                 raise UnsupportedResponseType(
@@ -87,7 +87,7 @@ class BaseApiResponse:
         elif response.text == "":
             return TextApiResponse(response.text, response.headers, response.status_code)
         else:
-            data = json.loads(response.text)
+            data = orjson.loads(response.text)
 
         if isinstance(data, dict):
             return MappingApiResponse(data, response.headers, response.status_code)

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -1245,7 +1245,9 @@ class SnubaTestCase(BaseTestCase):
 
     @classmethod
     def snuba_update_config(cls, config_vals):
-        return _snuba_pool.request("POST", "/config.json", body=orjson.dumps(config_vals).decode())
+        return _snuba_pool.request(
+            "POST", "/config.json", body=orjson.dumps(config_vals, option=orjson.OPT_UTC_Z)
+        )
 
     def init_snuba(self):
         self.snuba_eventstream = SnubaEventStream()
@@ -1335,7 +1337,7 @@ class SnubaTestCase(BaseTestCase):
             _snuba_pool.urlopen(
                 "POST",
                 "/tests/entities/groupedmessage/insert",
-                body=orjson.dumps(data).decode(),
+                body=orjson.dumps(data, option=orjson.OPT_UTC_Z),
                 headers={},
             ).status
             == 200
@@ -1346,7 +1348,7 @@ class SnubaTestCase(BaseTestCase):
         assert (
             requests.post(
                 settings.SENTRY_SNUBA + "/tests/entities/outcomes/insert",
-                data=orjson.dumps(data),
+                data=orjson.dumps(data, option=orjson.OPT_UTC_Z),
             ).status_code
             == 200
         )
@@ -1355,7 +1357,7 @@ class SnubaTestCase(BaseTestCase):
         assert (
             requests.post(
                 settings.SENTRY_SNUBA + "/tests/entities/spans/insert",
-                data=orjson.dumps([span]),
+                data=orjson.dumps([span], option=orjson.OPT_UTC_Z),
             ).status_code
             == 200
         )
@@ -1364,7 +1366,7 @@ class SnubaTestCase(BaseTestCase):
         assert (
             requests.post(
                 settings.SENTRY_SNUBA + "/tests/entities/spans/insert",
-                data=orjson.dumps(spans),
+                data=orjson.dumps(spans, option=orjson.OPT_UTC_Z),
             ).status_code
             == 200
         )
@@ -1401,7 +1403,7 @@ class SnubaTestCase(BaseTestCase):
         assert (
             requests.post(
                 settings.SENTRY_SNUBA + "/tests/entities/metrics_summaries/insert",
-                data=orjson.dumps(rows),
+                data=orjson.dumps(rows, option=orjson.OPT_UTC_Z),
             ).status_code
             == 200
         )
@@ -1470,7 +1472,7 @@ class SnubaTestCase(BaseTestCase):
         assert (
             requests.post(
                 settings.SENTRY_SNUBA + "/tests/entities/events/insert",
-                data=orjson.dumps(events),
+                data=orjson.dumps(events, option=orjson.OPT_UTC_Z),
             ).status_code
             == 200
         )
@@ -1792,7 +1794,7 @@ class BaseMetricsTestCase(SnubaTestCase):
         assert (
             requests.post(
                 settings.SENTRY_SNUBA + cls.snuba_endpoint.format(entity=entity),
-                data=orjson.dumps(buckets),
+                data=orjson.dumps(buckets, option=orjson.OPT_UTC_Z),
             ).status_code
             == 200
         )
@@ -2314,7 +2316,7 @@ class OutcomesSnubaTest(TestCase):
         assert (
             requests.post(
                 settings.SENTRY_SNUBA + "/tests/entities/outcomes/insert",
-                data=orjson.dumps(outcomes),
+                data=orjson.dumps(outcomes, option=orjson.OPT_UTC_Z),
             ).status_code
             == 200
         )

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -17,6 +17,7 @@ from urllib.parse import urlencode
 from uuid import uuid4
 from zlib import compress
 
+import orjson
 import pytest
 import requests
 import responses
@@ -135,7 +136,6 @@ from sentry.testutils.helpers.notifications import TEST_ISSUE_OCCURRENCE
 from sentry.testutils.helpers.slack import install_slack
 from sentry.testutils.pytest.selenium import Browser
 from sentry.types.condition_activity import ConditionActivity, ConditionActivityType
-from sentry.utils import json
 from sentry.utils.auth import SsoSession
 from sentry.utils.json import dumps_htmlsafe
 from sentry.utils.performance_issues.performance_detection import detect_performance_problems
@@ -726,7 +726,7 @@ class APITestCase(BaseTestCase, BaseAPITestCase):
         if raw_data and isinstance(raw_data, bytes):
             raw_data = raw_data.decode("utf-8")
         if raw_data and isinstance(raw_data, str):
-            raw_data = json.loads(raw_data)
+            raw_data = orjson.loads(raw_data)
         data = raw_data or params
         method = params.pop("method", self.method).lower()
 
@@ -1167,7 +1167,7 @@ class AcceptanceTestCase(TransactionTestCase):
             res = self.client.put(
                 "/api/0/assistant/",
                 content_type="application/json",
-                data=json.dumps({"guide": item, "status": "viewed", "useful": True}),
+                data=orjson.dumps({"guide": item, "status": "viewed", "useful": True}).decode(),
             )
             assert res.status_code == 201, res.content
 
@@ -1245,7 +1245,7 @@ class SnubaTestCase(BaseTestCase):
 
     @classmethod
     def snuba_update_config(cls, config_vals):
-        return _snuba_pool.request("POST", "/config.json", body=json.dumps(config_vals))
+        return _snuba_pool.request("POST", "/config.json", body=orjson.dumps(config_vals).decode())
 
     def init_snuba(self):
         self.snuba_eventstream = SnubaEventStream()
@@ -1335,7 +1335,7 @@ class SnubaTestCase(BaseTestCase):
             _snuba_pool.urlopen(
                 "POST",
                 "/tests/entities/groupedmessage/insert",
-                body=json.dumps(data),
+                body=orjson.dumps(data).decode(),
                 headers={},
             ).status
             == 200
@@ -1345,7 +1345,8 @@ class SnubaTestCase(BaseTestCase):
         data = [self.__wrap_group(group)]
         assert (
             requests.post(
-                settings.SENTRY_SNUBA + "/tests/entities/outcomes/insert", data=json.dumps(data)
+                settings.SENTRY_SNUBA + "/tests/entities/outcomes/insert",
+                data=orjson.dumps(data),
             ).status_code
             == 200
         )
@@ -1353,7 +1354,8 @@ class SnubaTestCase(BaseTestCase):
     def store_span(self, span):
         assert (
             requests.post(
-                settings.SENTRY_SNUBA + "/tests/entities/spans/insert", data=json.dumps([span])
+                settings.SENTRY_SNUBA + "/tests/entities/spans/insert",
+                data=orjson.dumps([span]),
             ).status_code
             == 200
         )
@@ -1361,7 +1363,8 @@ class SnubaTestCase(BaseTestCase):
     def store_spans(self, spans):
         assert (
             requests.post(
-                settings.SENTRY_SNUBA + "/tests/entities/spans/insert", data=json.dumps(spans)
+                settings.SENTRY_SNUBA + "/tests/entities/spans/insert",
+                data=orjson.dumps(spans),
             ).status_code
             == 200
         )
@@ -1398,7 +1401,7 @@ class SnubaTestCase(BaseTestCase):
         assert (
             requests.post(
                 settings.SENTRY_SNUBA + "/tests/entities/metrics_summaries/insert",
-                data=json.dumps(rows),
+                data=orjson.dumps(rows),
             ).status_code
             == 200
         )
@@ -1466,7 +1469,8 @@ class SnubaTestCase(BaseTestCase):
 
         assert (
             requests.post(
-                settings.SENTRY_SNUBA + "/tests/entities/events/insert", data=json.dumps(events)
+                settings.SENTRY_SNUBA + "/tests/entities/events/insert",
+                data=orjson.dumps(events),
             ).status_code
             == 200
         )
@@ -1788,7 +1792,7 @@ class BaseMetricsTestCase(SnubaTestCase):
         assert (
             requests.post(
                 settings.SENTRY_SNUBA + cls.snuba_endpoint.format(entity=entity),
-                data=json.dumps(buckets),
+                data=orjson.dumps(buckets),
             ).status_code
             == 200
         )
@@ -2309,7 +2313,8 @@ class OutcomesSnubaTest(TestCase):
 
         assert (
             requests.post(
-                settings.SENTRY_SNUBA + "/tests/entities/outcomes/insert", data=json.dumps(outcomes)
+                settings.SENTRY_SNUBA + "/tests/entities/outcomes/insert",
+                data=orjson.dumps(outcomes),
             ).status_code
             == 200
         )

--- a/src/sentry/testutils/helpers/backups.py
+++ b/src/sentry/testutils/helpers/backups.py
@@ -10,6 +10,7 @@ from typing import Any
 from unittest.mock import MagicMock
 from uuid import uuid4
 
+import orjson
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
@@ -102,7 +103,6 @@ from sentry.testutils.cases import TransactionTestCase
 from sentry.testutils.factories import get_fixture_path
 from sentry.testutils.silo import assume_test_silo_mode
 from sentry.types.token import AuthTokenType
-from sentry.utils import json
 
 __all__ = [
     "export_to_file",
@@ -153,8 +153,8 @@ def export_to_file(path: Path, scope: ExportScope, filter_by: set[str] | None = 
         else:
             raise AssertionError(f"Unknown `ExportScope`: `{scope.name}`")
 
-    with open(json_file_path) as tmp_file:
-        output = json.load(tmp_file)
+    with open(json_file_path, "rb") as tmp_file:
+        output = orjson.loads(tmp_file.read())
     return output
 
 
@@ -224,7 +224,7 @@ def export_to_encrypted_tarball(
     # part of the encrypt/decrypt tar-ing API, so we need to ensure that these exact names are
     # present and contain the data we expect.
     with open(tar_file_path, "rb") as f:
-        return json.loads(
+        return orjson.loads(
             decrypt_encrypted_tarball(f, LocalFileDecryptor.from_bytes(private_key_pem))
         )
 
@@ -682,32 +682,40 @@ class BackupTestCase(TransactionTestCase):
 
     @cached_property
     def _json_of_exhaustive_user_with_maximum_privileges(self) -> Any:
-        with open(get_fixture_path("backup", "user-with-maximum-privileges.json")) as backup_file:
-            return json.load(backup_file)
+        with open(
+            get_fixture_path("backup", "user-with-maximum-privileges.json"), "rb"
+        ) as backup_file:
+            return orjson.loads(backup_file.read())
 
     def json_of_exhaustive_user_with_maximum_privileges(self) -> Any:
         return deepcopy(self._json_of_exhaustive_user_with_maximum_privileges)
 
     @cached_property
     def _json_of_exhaustive_user_with_minimum_privileges(self) -> Any:
-        with open(get_fixture_path("backup", "user-with-minimum-privileges.json")) as backup_file:
-            return json.load(backup_file)
+        with open(
+            get_fixture_path("backup", "user-with-minimum-privileges.json"), "rb"
+        ) as backup_file:
+            return orjson.loads(backup_file.read())
 
     def json_of_exhaustive_user_with_minimum_privileges(self) -> Any:
         return deepcopy(self._json_of_exhaustive_user_with_minimum_privileges)
 
     @cached_property
     def _json_of_exhaustive_user_with_roles_no_superadmin(self) -> Any:
-        with open(get_fixture_path("backup", "user-with-roles-no-superadmin.json")) as backup_file:
-            return json.load(backup_file)
+        with open(
+            get_fixture_path("backup", "user-with-roles-no-superadmin.json"), "rb"
+        ) as backup_file:
+            return orjson.loads(backup_file.read())
 
     def json_of_exhaustive_user_with_roles_no_superadmin(self) -> Any:
         return deepcopy(self._json_of_exhaustive_user_with_roles_no_superadmin)
 
     @cached_property
     def _json_of_exhaustive_user_with_superadmin_no_roles(self) -> Any:
-        with open(get_fixture_path("backup", "user-with-superadmin-no-roles.json")) as backup_file:
-            return json.load(backup_file)
+        with open(
+            get_fixture_path("backup", "user-with-superadmin-no-roles.json"), "rb"
+        ) as backup_file:
+            return orjson.loads(backup_file.read())
 
     def json_of_exhaustive_user_with_superadmin_no_roles(self) -> Any:
         return deepcopy(self._json_of_exhaustive_user_with_superadmin_no_roles)
@@ -759,5 +767,5 @@ class BackupTestCase(TransactionTestCase):
         """
 
         data = self.generate_tmp_users_json()
-        with open(tmp_path, "w+") as tmp_file:
-            json.dump(data, tmp_file)
+        with open(tmp_path, "wb+") as tmp_file:
+            tmp_file.write(orjson.dumps(data))

--- a/src/sentry/testutils/helpers/slack.py
+++ b/src/sentry/testutils/helpers/slack.py
@@ -1,5 +1,6 @@
 from urllib.parse import parse_qs, quote
 
+import orjson
 import responses
 
 from sentry.integrations.slack.message_builder import SlackBody
@@ -13,7 +14,6 @@ from sentry.models.user import User
 from sentry.silo.base import SiloMode
 from sentry.testutils.silo import assume_test_silo_mode
 from sentry.types.integrations import EXTERNAL_PROVIDERS, ExternalProviders
-from sentry.utils import json
 
 
 def get_response_text(data: SlackBody) -> str:
@@ -95,7 +95,7 @@ def get_channel(index=0):
     assert len(responses.calls) >= 1
     data = parse_qs(responses.calls[index].request.body)
     assert "channel" in data
-    channel = json.loads(data["channel"][0])
+    channel = orjson.loads(data["channel"][0])
 
     return channel
 
@@ -105,7 +105,7 @@ def get_attachment(index=0):
     data = parse_qs(responses.calls[index].request.body)
     assert "text" in data
     assert "attachments" in data
-    attachments = json.loads(data["attachments"][0])
+    attachments = orjson.loads(data["attachments"][0])
 
     assert len(attachments) == 1
     return attachments[0], data["text"][0]
@@ -115,7 +115,7 @@ def get_attachment_no_text():
     assert len(responses.calls) >= 1
     data = parse_qs(responses.calls[0].request.body)
     assert "attachments" in data
-    attachments = json.loads(data["attachments"][0])
+    attachments = orjson.loads(data["attachments"][0])
     assert len(attachments) == 1
     return attachments[0]
 
@@ -125,7 +125,7 @@ def get_blocks_and_fallback_text(index=0):
     data = parse_qs(responses.calls[index].request.body)
     assert "blocks" in data
     assert "text" in data
-    blocks = json.loads(data["blocks"][0])
+    blocks = orjson.loads(data["blocks"][0])
     fallback_text = data["text"][0]
     return blocks, fallback_text
 
@@ -137,8 +137,8 @@ def get_block_kit_preview_url(index=0) -> str:
     assert data["blocks"][0]
 
     stringified_blocks = data["blocks"][0]
-    blocks = json.loads(data["blocks"][0])
-    stringified_blocks = json.dumps({"blocks": blocks})
+    blocks = orjson.loads(data["blocks"][0])
+    stringified_blocks = orjson.dumps({"blocks": blocks}).decode()
 
     encoded_blocks = quote(stringified_blocks)
     base_url = "https://app.slack.com/block-kit-builder/#"

--- a/src/sentry/testutils/performance_issues/event_generators.py
+++ b/src/sentry/testutils/performance_issues/event_generators.py
@@ -4,8 +4,9 @@ import os
 from copy import deepcopy
 from typing import Any
 
+import orjson
+
 from sentry.testutils.factories import get_fixture_path
-from sentry.utils import json
 
 from .span_builder import SpanBuilder
 
@@ -27,8 +28,8 @@ for (dirpath, dirnames, filenames) in os.walk(_fixture_path):
 
         [full_event_name, _] = relative_path.split(".")
 
-        with open(filepath) as f:
-            event = json.load(f)
+        with open(filepath, "rb") as f:
+            event = orjson.loads(f.read())
             event["project"] = PROJECT_ID
 
         EVENTS[full_event_name] = event

--- a/src/sentry/utils/assets.py
+++ b/src/sentry/utils/assets.py
@@ -2,19 +2,18 @@ from __future__ import annotations
 
 import os.path
 
+import orjson
 from cachetools.func import ttl_cache
 from django.conf import settings
-
-from sentry.utils import json
 
 
 @ttl_cache(ttl=60)
 def _frontend_versions() -> dict[str, str]:
     try:
         with open(
-            os.path.join(settings.CONF_DIR, "settings", "frontend", "frontend-versions.json")
+            os.path.join(settings.CONF_DIR, "settings", "frontend", "frontend-versions.json"), "rb"
         ) as f:
-            return json.load(f)  # getsentry path
+            return orjson.loads(f.read())  # getsentry path
     except OSError:
         return {}  # common case for self-hosted
 

--- a/src/sentry/utils/codecs.py
+++ b/src/sentry/utils/codecs.py
@@ -70,7 +70,7 @@ class JSONCodec(Codec[Any, str]):
     """
 
     def encode(self, value: Any) -> str:
-        return orjson.dumps(value).decode()
+        return orjson.dumps(value, option=orjson.OPT_UTC_Z).decode()
 
     def decode(self, value: str) -> Any:
         return orjson.loads(value)

--- a/src/sentry/utils/codecs.py
+++ b/src/sentry/utils/codecs.py
@@ -2,9 +2,8 @@ import zlib
 from abc import ABC, abstractmethod
 from typing import Any, Generic, TypeVar
 
+import orjson
 import zstandard
-
-from sentry.utils import json
 
 T = TypeVar("T")
 
@@ -71,10 +70,10 @@ class JSONCodec(Codec[Any, str]):
     """
 
     def encode(self, value: Any) -> str:
-        return str(json.dumps(value))
+        return orjson.dumps(value).decode()
 
     def decode(self, value: str) -> Any:
-        return json.loads(value)
+        return orjson.loads(value)
 
 
 class ZlibCodec(Codec[bytes, bytes]):

--- a/src/sentry/utils/email/message_builder.py
+++ b/src/sentry/utils/email/message_builder.py
@@ -10,6 +10,7 @@ from random import randrange
 from typing import Any
 
 import lxml.html
+import orjson
 import toronado
 from django.core.mail import EmailMultiAlternatives
 from django.utils.encoding import force_str
@@ -22,7 +23,7 @@ from sentry.models.group import Group
 from sentry.models.groupemailthread import GroupEmailThread
 from sentry.models.project import Project
 from sentry.silo.base import SiloMode
-from sentry.utils import json, metrics
+from sentry.utils import metrics
 from sentry.utils.safe import safe_execute
 from sentry.web.helpers import render_to_string
 
@@ -116,7 +117,7 @@ class MessageBuilder:
         # If a "type" is specified, add it to the headers to categorize the emails if not already set
         if type is not None and "X-SMTPAPI" not in self.headers:
             self.headers = {
-                "X-SMTPAPI": json.dumps({"category": type}),
+                "X-SMTPAPI": orjson.dumps({"category": type}).decode(),
                 **(self.headers),
             }
 

--- a/src/sentry/utils/env.py
+++ b/src/sentry/utils/env.py
@@ -2,11 +2,10 @@ import logging
 import os
 import sys
 
+import orjson
 import requests
 from django.conf import settings
 from google.auth import default
-
-from sentry.utils import json
 
 
 def in_test_environment() -> bool:
@@ -34,8 +33,8 @@ def gcp_project_id() -> str:
     except requests.exceptions.RequestException:
         adc_path = os.environ.get("GOOGLE_APPLICATION_CREDENTIALS", "")
         if adc_path:
-            with open(adc_path) as fp:
-                adc = json.load(fp)
+            with open(adc_path, "rb") as fp:
+                adc = orjson.loads(fp.read())
                 if adc.get("quota_project_id") is not None:
                     return adc.get("quota_project_id")
 
@@ -50,8 +49,8 @@ def log_gcp_credentials_details(logger: logging.Logger) -> None:
     # Checking GOOGLE_APPLICATION_CREDENTIALS environment variable
     adc_path = os.environ.get("GOOGLE_APPLICATION_CREDENTIALS", "")
     if adc_path:
-        with open(adc_path) as fp:
-            adc = json.load(fp)
+        with open(adc_path, "rb") as fp:
+            adc = orjson.loads(fp.read())
 
             logger.info(
                 "gcp.credentials.file_found",

--- a/src/sentry/utils/outcomes.py
+++ b/src/sentry/utils/outcomes.py
@@ -118,7 +118,8 @@ def track_outcome(
                 "event_id": event_id,
                 "category": category,
                 "quantity": quantity,
-            }
+            },
+            option=orjson.OPT_UTC_Z,
         ).decode(),
     )
 

--- a/src/sentry/utils/outcomes.py
+++ b/src/sentry/utils/outcomes.py
@@ -4,9 +4,11 @@ import time
 from datetime import datetime
 from enum import IntEnum
 
+import orjson
+
 from sentry.conf.types.kafka_definition import Topic
 from sentry.constants import DataCategory
-from sentry.utils import json, kafka_config, metrics
+from sentry.utils import kafka_config, metrics
 from sentry.utils.dates import to_datetime
 from sentry.utils.pubsub import KafkaPublisher
 
@@ -105,7 +107,7 @@ def track_outcome(
     # Send a snuba metrics payload.
     publisher.publish(
         topic_name,
-        json.dumps(
+        orjson.dumps(
             {
                 "timestamp": timestamp,
                 "org_id": org_id,
@@ -117,7 +119,7 @@ def track_outcome(
                 "category": category,
                 "quantity": quantity,
             }
-        ),
+        ).decode(),
     )
 
     metrics.incr(

--- a/src/sentry/utils/safe.py
+++ b/src/sentry/utils/safe.py
@@ -68,7 +68,7 @@ def trim(
 
     if _depth > max_depth:
         if not isinstance(value, str):
-            value = orjson.dumps(value).decode()
+            value = orjson.dumps(value, option=orjson.OPT_UTC_Z).decode()
         return trim(value, _size=_size, max_size=max_size)
 
     elif isinstance(value, dict):
@@ -125,7 +125,7 @@ def get_path(data: PathSearchable, *path, should_log=False, **kwargs):
     logger_data = {}
     if should_log:
         logger_data = {
-            "path_searchable": orjson.dumps(data).decode(),
+            "path_searchable": orjson.dumps(data, option=orjson.OPT_UTC_Z).decode(),
             "path_arg": orjson.dumps(path).decode(),
         }
 
@@ -136,7 +136,7 @@ def get_path(data: PathSearchable, *path, should_log=False, **kwargs):
             data = data[p]
         else:
             if should_log:
-                logger_data["invalid_path"] = orjson.dumps(p).decode()
+                logger_data["invalid_path"] = orjson.dumps(p, option=orjson.OPT_UTC_Z).decode()
                 logger.info("sentry.safe.get_path.invalid_path_section", extra=logger_data)
             return default
 
@@ -144,7 +144,7 @@ def get_path(data: PathSearchable, *path, should_log=False, **kwargs):
         if data is None:
             logger.info("sentry.safe.get_path.iterated_path_is_none", extra=logger_data)
         else:
-            logger_data["iterated_path"] = orjson.dumps(data).decode()
+            logger_data["iterated_path"] = orjson.dumps(data, option=orjson.OPT_UTC_Z).decode()
 
     if f and data and isinstance(data, (list, tuple)):
         data = list(filter((lambda x: x is not None) if f is True else f, data))

--- a/src/sentry/utils/samples.py
+++ b/src/sentry/utils/samples.py
@@ -5,13 +5,13 @@ import time
 from datetime import datetime, timedelta, timezone
 from uuid import uuid4
 
+import orjson
 from django.core.exceptions import SuspiciousFileOperation
 
 from sentry.constants import DATA_ROOT, INTEGRATION_ID_TO_PLATFORM_DATA
 from sentry.event_manager import EventManager, set_tag
 from sentry.interfaces.user import User as UserInterface
 from sentry.spans.grouping.utils import hash_values
-from sentry.utils import json
 from sentry.utils.canonical import CanonicalKeyDict
 
 logger = logging.getLogger(__name__)
@@ -170,8 +170,8 @@ def load_data(
         # XXX: At this point, it's assumed that `json_path` was safely found
         # within `samples_root` due to the checks above and cannot traverse
         # into paths.
-        with open(json_path) as fp:
-            data = json.load(fp)
+        with open(json_path, "rb") as fp:
+            data = orjson.loads(fp.read())
             break
 
     if data is None:

--- a/src/social_auth/backends/__init__.py
+++ b/src/social_auth/backends/__init__.py
@@ -18,6 +18,7 @@ from urllib.error import HTTPError
 from urllib.parse import urlencode
 from urllib.request import Request
 
+import orjson
 import requests
 from django.conf import settings
 from django.contrib.auth import authenticate, load_backend
@@ -25,7 +26,6 @@ from django.utils.crypto import constant_time_compare, get_random_string
 from requests_oauthlib import OAuth1
 
 from sentry.services.hybrid_cloud.user.service import user_service
-from sentry.utils import json
 from sentry.utils.http import absolute_uri
 from social_auth.exceptions import (
     AuthCanceled,
@@ -631,7 +631,7 @@ class BaseOAuth2(OAuthAuth):
         )
 
         try:
-            response = json.loads(dsa_urlopen(request).read())
+            response = orjson.loads(dsa_urlopen(request).read())
         except HTTPError as e:
             logger.exception(
                 "plugins.auth.error",

--- a/src/social_auth/backends/bitbucket.py
+++ b/src/social_auth/backends/bitbucket.py
@@ -10,8 +10,8 @@ By default username, email, token expiration time, first name and last name are
 stored in extra_data field, check OAuthBackend class for details on how to
 extend it.
 """
+import orjson
 
-from sentry.utils import json
 from social_auth.backends import BaseOAuth1, OAuthBackend
 from social_auth.utils import dsa_urlopen
 
@@ -88,7 +88,7 @@ class BitbucketAuth(BaseOAuth1):
             email = None
 
             # Then retrieve the user's primary email address or the top email
-            email_addresses = json.loads(response)
+            email_addresses = orjson.loads(response)
             for email_address in reversed(email_addresses):
                 if email_address["active"]:
                     email = email_address["email"]
@@ -101,7 +101,7 @@ class BitbucketAuth(BaseOAuth1):
             # Then return the user data using a normal GET with the
             # BITBUCKET_USER_DATA_URL and the user's email
             response = dsa_urlopen(BITBUCKET_USER_DATA_URL + email)
-            user_details = json.load(response)["user"]
+            user_details = orjson.loads(response.read())["user"]
             user_details["email"] = email
             return user_details
         except ValueError:

--- a/src/social_auth/backends/github.py
+++ b/src/social_auth/backends/github.py
@@ -14,9 +14,9 @@ field, check OAuthBackend class for details on how to extend it.
 from urllib.error import HTTPError
 from urllib.request import Request
 
+import orjson
 from django.conf import settings
 
-from sentry.utils import json
 from social_auth.backends import BaseOAuth2, OAuthBackend
 from social_auth.exceptions import AuthFailed
 from social_auth.utils import dsa_urlopen
@@ -46,7 +46,7 @@ class GithubBackend(OAuthBackend):
         )
 
         try:
-            data = json.load(dsa_urlopen(req))
+            data = orjson.loads(dsa_urlopen(req).read())
         except (ValueError, HTTPError):
             data = []
         return data
@@ -93,7 +93,7 @@ class GithubAuth(BaseOAuth2):
         req = Request(GITHUB_USER_DATA_URL, headers={"Authorization": "token %s" % access_token})
 
         try:
-            data = json.load(dsa_urlopen(req))
+            data = orjson.loads(dsa_urlopen(req).read())
         except ValueError:
             data = None
 

--- a/src/social_auth/fields.py
+++ b/src/social_auth/fields.py
@@ -1,9 +1,9 @@
+import orjson
 from django.core.exceptions import ValidationError
 from django.db.models import TextField
 from django.utils.encoding import smart_str
 
 from sentry.db.models.utils import Creator
-from sentry.utils import json
 
 
 class JSONField(TextField):
@@ -28,8 +28,8 @@ class JSONField(TextField):
             return None
         if isinstance(value, str):
             try:
-                return json.loads(value)
-            except Exception as e:
+                return orjson.loads(value)
+            except orjson.JSONDecodeError as e:
                 raise ValidationError(str(e))
         else:
             return value
@@ -40,15 +40,15 @@ class JSONField(TextField):
         if isinstance(value, str):
             super().validate(value, model_instance)
             try:
-                json.loads(value)
-            except Exception as e:
+                orjson.loads(value)
+            except orjson.JSONDecodeError as e:
                 raise ValidationError(str(e))
 
-    def get_prep_value(self, value):
+    def get_prep_value(self, value) -> str:
         """Convert value to JSON string before save"""
         try:
-            return json.dumps(value)
-        except Exception as e:
+            return orjson.dumps(value).decode()
+        except orjson.JSONEncodeError as e:
             raise ValidationError(str(e))
 
     def value_to_string(self, obj):

--- a/src/social_auth/fields.py
+++ b/src/social_auth/fields.py
@@ -47,7 +47,7 @@ class JSONField(TextField):
     def get_prep_value(self, value) -> str:
         """Convert value to JSON string before save"""
         try:
-            return orjson.dumps(value).decode()
+            return orjson.dumps(value, option=orjson.OPT_UTC_Z).decode()
         except orjson.JSONEncodeError as e:
             raise ValidationError(str(e))
 

--- a/tests/acceptance/conftest.py
+++ b/tests/acceptance/conftest.py
@@ -3,7 +3,7 @@ import subprocess
 import sys
 import time
 
-from sentry.utils import json
+import orjson
 
 
 def pytest_configure(config):
@@ -21,8 +21,8 @@ def pytest_configure(config):
         return
 
     try:
-        with open("./.webpack.meta") as f:
-            data = json.load(f)
+        with open("./.webpack.meta", "rb") as f:
+            data = orjson.loads(f.read())
 
             # If built within last hour, do not build again
             last_built = int(time.time()) - data["built"]

--- a/tests/acceptance/test_organization_security_privacy.py
+++ b/tests/acceptance/test_organization_security_privacy.py
@@ -1,6 +1,7 @@
+import orjson
+
 from sentry.testutils.cases import AcceptanceTestCase
 from sentry.testutils.silo import no_silo_test
-from sentry.utils import json
 
 
 @no_silo_test
@@ -54,7 +55,7 @@ class OrganizationSecurityAndPrivacyTest(AcceptanceTestCase):
         self.load_organization_helper()
 
     def test_renders_advanced_data_scrubbing_with_rules(self):
-        relayPiiConfig = json.dumps(
+        relayPiiConfig = orjson.dumps(
             {
                 "rules": {
                     "0": {
@@ -65,7 +66,7 @@ class OrganizationSecurityAndPrivacyTest(AcceptanceTestCase):
                 },
                 "applications": {"password": ["0"], "$message": ["1"]},
             }
-        )
+        ).decode()
         self.org.update_option("sentry:relay_pii_config", relayPiiConfig)
         self.browser.get(self.path)
         self.browser.wait_until_not('[data-test-id="loading-indicator"]')

--- a/tests/acceptance/test_performance_issues.py
+++ b/tests/acceptance/test_performance_issues.py
@@ -4,6 +4,8 @@ from datetime import timedelta
 from unittest import mock
 from unittest.mock import patch
 
+import orjson
+
 from fixtures.page_objects.issue_details import IssueDetailsPage
 from sentry import options
 from sentry.issues.grouptype import (
@@ -16,7 +18,6 @@ from sentry.models.group import Group
 from sentry.testutils.cases import AcceptanceTestCase, PerformanceIssueTestCase, SnubaTestCase
 from sentry.testutils.helpers.datetime import before_now
 from sentry.testutils.silo import no_silo_test
-from sentry.utils import json
 
 
 @no_silo_test
@@ -38,7 +39,7 @@ class PerformanceIssuesTest(AcceptanceTestCase, SnubaTestCase, PerformanceIssueT
         self.dismiss_assistant()
 
     def create_sample_event(self, fixture, start_timestamp):
-        event = json.loads(self.load_fixture(f"events/performance_problems/{fixture}.json"))
+        event = orjson.loads(self.load_fixture(f"events/performance_problems/{fixture}.json"))
 
         for key in ["datetime", "location", "title"]:
             del event[key]

--- a/tests/acceptance/test_proxy.py
+++ b/tests/acceptance/test_proxy.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from dataclasses import asdict
 
+import orjson
 import pytest
 from django.urls import reverse
 from pytest_django.live_server_helper import LiveServer
@@ -17,7 +18,6 @@ from sentry.testutils.factories import Factories
 from sentry.testutils.region import override_regions
 from sentry.testutils.silo import region_silo_test
 from sentry.types.region import Region
-from sentry.utils import json
 from tests.sentry.middleware.test_proxy import test_region
 
 
@@ -67,6 +67,6 @@ class EndToEndAPIProxyTest(TransactionTestCase):
                 )
 
         assert_status_code(resp, 201)
-        result = json.loads(resp.getvalue())
+        result = orjson.loads(resp.getvalue())
         team = Team.objects.get(id=result["id"])
         assert team.idp_provisioned

--- a/tests/flagpole/test_conditions.py
+++ b/tests/flagpole/test_conditions.py
@@ -1,5 +1,6 @@
 from typing import Any
 
+import orjson
 import pytest
 from pydantic import ValidationError
 
@@ -16,7 +17,6 @@ from flagpole.conditions import (
     create_case_insensitive_set_from_list,
 )
 from sentry.testutils.cases import TestCase
-from sentry.utils import json
 
 
 class TestCreateCaseInsensitiveSetFromList(TestCase):
@@ -36,7 +36,7 @@ class TestCreateCaseInsensitiveSetFromList(TestCase):
 def assert_valid_types(condition: type[ConditionBase], expected_types: list[Any]):
     for value in expected_types:
         condition_dict = dict(property="test", value=value)
-        json_condition = json.dumps(condition_dict)
+        json_condition = orjson.dumps(condition_dict).decode()
         try:
             parsed_condition = condition.parse_raw(json_condition)
         except ValidationError as exc:
@@ -49,7 +49,7 @@ def assert_valid_types(condition: type[ConditionBase], expected_types: list[Any]
 def assert_invalid_types(condition: type[ConditionBase], invalid_types: list[Any]):
     for value in invalid_types:
         json_dict = dict(value=value)
-        condition_json = json.dumps(json_dict)
+        condition_json = orjson.dumps(json_dict).decode()
         try:
             condition.parse_raw(condition_json)
         except ValidationError:

--- a/tests/relay_integration/lang/java/test_plugin.py
+++ b/tests/relay_integration/lang/java/test_plugin.py
@@ -2,6 +2,7 @@ import zipfile
 from io import BytesIO
 from uuid import uuid4
 
+import orjson
 import pytest
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.urls import reverse
@@ -13,7 +14,6 @@ from sentry.testutils.helpers.datetime import before_now, iso_format
 from sentry.testutils.helpers.options import override_options
 from sentry.testutils.relay import RelayStoreHelper
 from sentry.testutils.skips import requires_symbolicator
-from sentry.utils import json
 
 PROGUARD_UUID = "6dc7fdb0-d2fb-4c8e-9d6b-bb1aa98929b1"
 PROGUARD_SOURCE = b"""\
@@ -1026,7 +1026,7 @@ class BasicResolvingIntegrationTest(RelayStoreHelper, TransactionTestCase):
         with zipfile.ZipFile(file_like, "a") as zip:
             for path, contents in source_files.items():
                 zip.writestr(f"files/_/_/{path}", contents)
-            zip.writestr("manifest.json", json.dumps(manifest))
+            zip.writestr("manifest.json", orjson.dumps(manifest).decode())
         file_like.seek(0)
 
         file = File.objects.create(

--- a/tests/relay_integration/lang/javascript/test_plugin.py
+++ b/tests/relay_integration/lang/javascript/test_plugin.py
@@ -5,6 +5,7 @@ from hashlib import sha1
 from io import BytesIO
 from uuid import uuid4
 
+import orjson
 import pytest
 import responses
 from django.conf import settings
@@ -26,7 +27,6 @@ from sentry.testutils.helpers.datetime import before_now, iso_format
 from sentry.testutils.pytest.fixtures import django_db_all
 from sentry.testutils.relay import RelayStoreHelper
 from sentry.testutils.skips import requires_kafka, requires_symbolicator
-from sentry.utils import json
 from sentry.utils.safe import get_path
 
 # IMPORTANT:
@@ -74,7 +74,7 @@ def make_compressed_zip_file(files):
 
         zip_file.writestr(
             "manifest.json",
-            json.dumps(
+            orjson.dumps(
                 {
                     # We remove the "content" key in the original dict, thus no subsequent calls should be made.
                     "files": {
@@ -82,7 +82,7 @@ def make_compressed_zip_file(files):
                         for file_path, info in files.items()
                     }
                 }
-            ),
+            ).decode(),
         )
     compressed.seek(0)
 
@@ -1125,7 +1125,7 @@ class TestJavascriptIntegration(RelayStoreHelper):
                     content = content.replace(b"//@ sourceMappingURL=file.sourcemap.js", b"")
                     entry["headers"] = {"Sourcemap": "file.sourcemap.js"}
                 zip_file.writestr(rel_path, content)
-            zip_file.writestr("manifest.json", json.dumps(manifest))
+            zip_file.writestr("manifest.json", orjson.dumps(manifest).decode())
         compressed.seek(0)
 
         file = File.objects.create(name="doesnt_matter", type="release.bundle")
@@ -1473,7 +1473,7 @@ class TestJavascriptIntegration(RelayStoreHelper):
 
             zip_file.writestr(
                 "manifest.json",
-                json.dumps(
+                orjson.dumps(
                     {
                         "org": self.organization.slug,
                         "release": release.version,
@@ -1518,7 +1518,7 @@ class TestJavascriptIntegration(RelayStoreHelper):
                             },
                         },
                     }
-                ),
+                ).decode(),
             )
         compressed.seek(0)
         file = File.objects.create(name="bundle.zip", type="artifact.bundle")
@@ -1648,7 +1648,7 @@ class TestJavascriptIntegration(RelayStoreHelper):
 
             zip_file.writestr(
                 "manifest.json",
-                json.dumps(
+                orjson.dumps(
                     {
                         "files": {
                             "files/_/_/file.min.js": {
@@ -1691,7 +1691,7 @@ class TestJavascriptIntegration(RelayStoreHelper):
                             },
                         }
                     }
-                ),
+                ).decode(),
             )
         compressed.seek(0)
 
@@ -1804,7 +1804,7 @@ class TestJavascriptIntegration(RelayStoreHelper):
 
             zip_file.writestr(
                 "manifest.json",
-                json.dumps(
+                orjson.dumps(
                     {
                         "files": {
                             "files/_/_/file.min.js": {
@@ -1847,7 +1847,7 @@ class TestJavascriptIntegration(RelayStoreHelper):
                             },
                         }
                     }
-                ),
+                ).decode(),
             )
         compressed.seek(0)
 
@@ -1964,7 +1964,7 @@ class TestJavascriptIntegration(RelayStoreHelper):
                     content = content.replace(b"//@ sourceMappingURL=file.sourcemap.js", b"")
                     entry["headers"] = {"Sourcemap": "file.sourcemap.js"}
                 zip_file.writestr(rel_path, content)
-            zip_file.writestr("manifest.json", json.dumps(manifest))
+            zip_file.writestr("manifest.json", orjson.dumps(manifest).decode())
         compressed.seek(0)
 
         file = File.objects.create(name="release_bundle.zip", type="release.bundle")
@@ -2067,7 +2067,7 @@ class TestJavascriptIntegration(RelayStoreHelper):
             )
             zip_file.writestr(
                 "manifest.json",
-                json.dumps(
+                orjson.dumps(
                     {
                         "files": {
                             "files/_/_/file.min.js": {
@@ -2110,7 +2110,7 @@ class TestJavascriptIntegration(RelayStoreHelper):
                             },
                         },
                     }
-                ),
+                ).decode(),
             )
         compressed.seek(0)
 
@@ -2222,7 +2222,7 @@ class TestJavascriptIntegration(RelayStoreHelper):
 
             zip_file.writestr(
                 "manifest.json",
-                json.dumps(
+                orjson.dumps(
                     {
                         "files": {
                             "files/_/_/file.min.js": {
@@ -2263,7 +2263,7 @@ class TestJavascriptIntegration(RelayStoreHelper):
                             },
                         }
                     }
-                ),
+                ).decode(),
             )
         compressed.seek(0)
 
@@ -2364,7 +2364,7 @@ class TestJavascriptIntegration(RelayStoreHelper):
 
             zip_file.writestr(
                 "manifest.json",
-                json.dumps(
+                orjson.dumps(
                     {
                         "files": {
                             "files/_/_/file.min.js": {
@@ -2405,7 +2405,7 @@ class TestJavascriptIntegration(RelayStoreHelper):
                             },
                         }
                     }
-                ),
+                ).decode(),
             )
         compressed.seek(0)
 

--- a/tests/relay_integration/test_metrics_extraction.py
+++ b/tests/relay_integration/test_metrics_extraction.py
@@ -1,6 +1,7 @@
 import uuid
 
 import confluent_kafka as kafka
+import orjson
 import pytest
 
 from sentry.sentry_metrics.indexer.strings import SHARED_STRINGS
@@ -10,7 +11,6 @@ from sentry.testutils.helpers.features import Feature
 from sentry.testutils.helpers.options import override_options
 from sentry.testutils.relay import RelayStoreHelper
 from sentry.testutils.skips import requires_kafka
-from sentry.utils import json
 
 pytestmark = [requires_kafka]
 
@@ -85,7 +85,7 @@ class MetricsExtractionTest(RelayStoreHelper, TransactionTestCase):
                 message = consumer.poll(timeout=1.0)
                 if message is None:
                     break
-                message = json.loads(message.value())
+                message = orjson.loads(message.value())
                 if message["project_id"] == self.project.id:
                     strings_emitted.add(message["name"])
                     for key, value in message["tags"].items():

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_details.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_details.py
@@ -6,6 +6,7 @@ from typing import Any
 from unittest import mock
 from unittest.mock import patch
 
+import orjson
 import responses
 from django.conf import settings
 from django.test import override_settings
@@ -40,7 +41,6 @@ from sentry.testutils.abstract import Abstract
 from sentry.testutils.outbox import outbox_runner
 from sentry.testutils.silo import assume_test_silo_mode
 from sentry.testutils.skips import requires_snuba
-from sentry.utils import json
 from tests.sentry.incidents.endpoints.test_organization_alert_rule_index import AlertRuleBase
 
 pytestmark = [requires_snuba]
@@ -785,7 +785,7 @@ class AlertRuleDetailsSlackPutEndpointTest(AlertRuleDetailsBase):
             url=url,
             status=status,
             content_type="application/json",
-            body=json.dumps(body),
+            body=orjson.dumps(body).decode(),
         )
 
     def _organization_alert_rule_api_call(

--- a/tests/sentry/mediators/external_requests/test_alert_rule_action_requester.py
+++ b/tests/sentry/mediators/external_requests/test_alert_rule_action_requester.py
@@ -1,3 +1,4 @@
+import orjson
 import responses
 
 from sentry.mediators.external_requests.alert_rule_action_requester import (
@@ -7,7 +8,6 @@ from sentry.mediators.external_requests.alert_rule_action_requester import (
 )
 from sentry.testutils.cases import TestCase
 from sentry.testutils.silo import control_silo_test
-from sentry.utils import json
 from sentry.utils.sentry_apps import SentryAppWebhookRequestsBuffer
 
 
@@ -71,11 +71,11 @@ class TestAlertRuleActionRequester(TestCase):
             ],
             "installationId": self.install.uuid,
         }
-        payload = json.loads(request.body)
+        payload = orjson.loads(request.body)
         assert payload == data
 
         assert request.headers["Sentry-App-Signature"] == self.sentry_app.build_signature(
-            json.dumps(payload)
+            orjson.dumps(payload).decode()
         )
 
         buffer = SentryAppWebhookRequestsBuffer(self.sentry_app)
@@ -147,11 +147,11 @@ class TestAlertRuleActionRequester(TestCase):
             ],
             "installationId": self.install.uuid,
         }
-        payload = json.loads(request.body)
+        payload = orjson.loads(request.body)
         assert payload == data
 
         assert request.headers["Sentry-App-Signature"] == self.sentry_app.build_signature(
-            json.dumps(payload)
+            orjson.dumps(payload).decode()
         )
 
         buffer = SentryAppWebhookRequestsBuffer(self.sentry_app)

--- a/tests/sentry/mediators/external_requests/test_issue_link_requester.py
+++ b/tests/sentry/mediators/external_requests/test_issue_link_requester.py
@@ -1,3 +1,4 @@
+import orjson
 import pytest
 import responses
 
@@ -6,7 +7,6 @@ from sentry.mediators.external_requests.issue_link_requester import IssueLinkReq
 from sentry.services.hybrid_cloud.app import app_service
 from sentry.services.hybrid_cloud.user.serial import serialize_rpc_user
 from sentry.testutils.cases import TestCase
-from sentry.utils import json
 from sentry.utils.sentry_apps import SentryAppWebhookRequestsBuffer
 
 
@@ -69,10 +69,10 @@ class TestIssueLinkRequester(TestCase):
             "project": {"id": self.project.id, "slug": self.project.slug},
             "actor": {"type": "user", "id": self.user.id, "name": self.user.name},
         }
-        payload = json.loads(request.body)
+        payload = orjson.loads(request.body)
         assert payload == data
         assert request.headers["Sentry-App-Signature"] == self.sentry_app.build_signature(
-            json.dumps(payload)
+            orjson.dumps(payload).decode()
         )
         buffer = SentryAppWebhookRequestsBuffer(self.sentry_app)
         requests = buffer.get_requests()

--- a/tests/sentry/middleware/integrations/parsers/test_discord.py
+++ b/tests/sentry/middleware/integrations/parsers/test_discord.py
@@ -4,6 +4,7 @@ from collections.abc import Mapping
 from typing import Any
 from unittest.mock import patch
 
+import orjson
 import responses
 from django.http import HttpRequest, HttpResponse
 from django.test import RequestFactory, override_settings
@@ -17,7 +18,6 @@ from sentry.silo.base import SiloMode
 from sentry.testutils.cases import APITestCase, TestCase
 from sentry.testutils.outbox import assert_no_webhook_payloads
 from sentry.testutils.silo import control_silo_test, create_test_regions
-from sentry.utils import json
 from sentry.utils.signing import sign
 
 
@@ -59,7 +59,7 @@ class DiscordRequestParserTest(TestCase):
 
         response = parser.get_response()
         assert response.status_code == 200
-        data = json.loads(response.content)
+        data = orjson.loads(response.content)
         assert data == {"type": 1}
         assert len(responses.calls) == 0
         assert_no_webhook_payloads()
@@ -89,7 +89,7 @@ class DiscordRequestParserTest(TestCase):
 
         response = parser.get_response()
         assert response.status_code == 200
-        data = json.loads(response.content)
+        data = orjson.loads(response.content)
         assert data == {"type": 1}
         assert_no_webhook_payloads()
         assert len(responses.calls) == 0
@@ -208,7 +208,7 @@ class DiscordRequestParserTest(TestCase):
             }
         )
         assert response.status_code == status.HTTP_202_ACCEPTED
-        assert json.loads(response.content) == parser.async_response_data
+        assert orjson.loads(response.content) == parser.async_response_data
 
 
 @control_silo_test
@@ -232,6 +232,6 @@ class End2EndTest(APITestCase):
             HTTP_X_SIGNATURE_TIMESTAMP="timestamp",
         )
         assert response.status_code == 200
-        data = json.loads(response.content)
+        data = orjson.loads(response.content)
         assert data == {"type": 1}
         assert mock_verify_signature.call_count == 1

--- a/tests/sentry/middleware/integrations/test_tasks.py
+++ b/tests/sentry/middleware/integrations/test_tasks.py
@@ -1,5 +1,6 @@
 from unittest.mock import patch
 
+import orjson
 import responses
 from django.test import RequestFactory
 from django.urls import reverse
@@ -15,7 +16,6 @@ from sentry.testutils.cases import TestCase
 from sentry.testutils.region import override_regions
 from sentry.testutils.silo import control_silo_test
 from sentry.types.region import Region, RegionCategory
-from sentry.utils import json
 
 
 @control_silo_test
@@ -29,7 +29,7 @@ class AsyncSlackResponseTest(TestCase):
         super().setUp()
         self.response_url = "https://hooks.slack.com/commands/TXXXXXXX1/1234567890123/something"
         slack_payload = {"team_id": "TXXXXXXX1", "response_url": self.response_url}
-        data = {"payload": json.dumps(slack_payload)}
+        data = {"payload": orjson.dumps(slack_payload).decode()}
         action_request = self.factory.post(reverse("sentry-integration-slack-action"), data=data)
         self.payload = create_async_request_payload(action_request)
 

--- a/tests/sentry/middleware/test_health.py
+++ b/tests/sentry/middleware/test_health.py
@@ -1,12 +1,12 @@
 from functools import cached_property
 from unittest.mock import patch
 
+import orjson
 from django.test import RequestFactory
 
 from sentry.middleware.health import HealthCheck
 from sentry.status_checks import Problem
 from sentry.testutils.cases import TestCase
-from sentry.utils import json
 
 
 class HealthCheckTest(TestCase):
@@ -36,7 +36,7 @@ class HealthCheckTest(TestCase):
         req = self.factory.get("/_health/?full")
         resp = self.middleware.process_request(req)
         assert resp.status_code == 200, resp
-        body = json.loads(resp.content)
+        body = orjson.loads(resp.content)
         assert "problems" in body
         assert "healthy" in body
         assert check_all.call_count == 1
@@ -47,7 +47,7 @@ class HealthCheckTest(TestCase):
         req = self.factory.get("/_health/?full")
         resp = self.middleware.process_request(req)
         assert resp.status_code == 500, resp
-        body = json.loads(resp.content)
+        body = orjson.loads(resp.content)
         assert "problems" in body
         assert "healthy" in body
         assert check_all.call_count == 1

--- a/tests/sentry/rules/processing/test_delayed_processing.py
+++ b/tests/sentry/rules/processing/test_delayed_processing.py
@@ -3,6 +3,7 @@ from datetime import UTC, datetime
 from unittest.mock import patch
 from uuid import uuid4
 
+import orjson
 import pytest
 
 from sentry import buffer
@@ -18,7 +19,6 @@ from sentry.testutils.cases import APITestCase, PerformanceIssueTestCase, TestCa
 from sentry.testutils.factories import DEFAULT_EVENT_DATA
 from sentry.testutils.helpers.datetime import iso_format
 from sentry.testutils.helpers.redis import mock_redis_buffer
-from sentry.utils import json
 from tests.snuba.rules.conditions.test_event_frequency import BaseEventFrequencyPercentTest
 
 pytestmark = pytest.mark.sentry_metrics
@@ -62,7 +62,7 @@ class ProcessDelayedAlertConditionsTest(
         return {"interval": interval, "id": condition_id, "value": value}
 
     def push_to_hash(self, project_id, rule_id, group_id, event_id=None, occurrence_id=None):
-        value = json.dumps({"event_id": event_id, "occurrence_id": occurrence_id})
+        value = orjson.dumps({"event_id": event_id, "occurrence_id": occurrence_id})
         buffer.backend.push_to_hash(
             model=Project,
             filters={"project_id": project_id},

--- a/tests/sentry/rules/processing/test_processor.py
+++ b/tests/sentry/rules/processing/test_processor.py
@@ -3,6 +3,7 @@ from typing import cast
 from unittest import mock
 from unittest.mock import patch
 
+import orjson
 from django.core.cache import cache
 from django.db import DEFAULT_DB_ALIAS, connections
 from django.test.utils import CaptureQueriesContext
@@ -26,7 +27,6 @@ from sentry.testutils.helpers import install_slack
 from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.helpers.redis import mock_redis_buffer
 from sentry.testutils.skips import requires_snuba
-from sentry.utils import json
 from sentry.utils.safe import safe_execute
 
 pytestmark = [requires_snuba]
@@ -145,9 +145,9 @@ class RuleProcessorTest(TestCase, PerformanceIssueTestCase):
             model=Project, field={"project_id": self.project.id}
         )
         assert rulegroup_to_events == {
-            f"{self.rule.id}:{self.group_event.group.id}": json.dumps(
+            f"{self.rule.id}:{self.group_event.group.id}": orjson.dumps(
                 {"event_id": self.group_event.event_id, "occurrence_id": None}
-            )
+            ).decode()
         }
 
     @with_feature("organizations:process-slow-alerts")
@@ -190,9 +190,9 @@ class RuleProcessorTest(TestCase, PerformanceIssueTestCase):
             model=Project, field={"project_id": self.project.id}
         )
         assert rulegroup_to_events == {
-            f"{self.rule.id}:{perf_event.group.id}": json.dumps(
+            f"{self.rule.id}:{perf_event.group.id}": orjson.dumps(
                 {"event_id": perf_event.event_id, "occurrence_id": perf_event.occurrence_id}
-            )
+            ).decode()
         }
 
     @with_feature("organizations:process-slow-alerts")
@@ -228,9 +228,9 @@ class RuleProcessorTest(TestCase, PerformanceIssueTestCase):
             model=Project, field={"project_id": self.project.id}
         )
         assert rulegroup_to_events == {
-            f"{self.rule.id}:{self.group_event.group.id}": json.dumps(
+            f"{self.rule.id}:{self.group_event.group.id}": orjson.dumps(
                 {"event_id": self.group_event.event_id, "occurrence_id": None}
-            )
+            ).decode()
         }
 
     @with_feature("organizations:process-slow-alerts")
@@ -317,9 +317,9 @@ class RuleProcessorTest(TestCase, PerformanceIssueTestCase):
             model=Project, field={"project_id": self.project.id}
         )
         assert rulegroup_to_events == {
-            f"{self.rule.id}:{self.group_event.group.id}": json.dumps(
+            f"{self.rule.id}:{self.group_event.group.id}": orjson.dumps(
                 {"event_id": self.group_event.event_id, "occurrence_id": None}
-            )
+            ).decode()
         }
 
     def test_ignored_issue(self):
@@ -921,7 +921,7 @@ class RuleProcessorTestFilters(TestCase):
         mock_post.assert_called_once()
         assert (
             "notification_uuid"
-            in json.loads(mock_post.call_args[1]["data"]["blocks"])[0]["text"]["text"]
+            in orjson.loads(mock_post.call_args[1]["data"]["blocks"])[0]["text"]["text"]
         )
 
     @patch("sentry.shared_integrations.client.base.BaseApiClient.post")

--- a/tests/sentry/web/frontend/test_auth_login.py
+++ b/tests/sentry/web/frontend/test_auth_login.py
@@ -4,6 +4,7 @@ from unittest import mock
 from urllib.parse import quote as urlquote
 from urllib.parse import urlencode
 
+import orjson
 import pytest
 from django.conf import settings
 from django.test import override_settings
@@ -24,7 +25,6 @@ from sentry.testutils.helpers.datetime import freeze_time
 from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.hybrid_cloud import HybridCloudTestMixin
 from sentry.testutils.silo import assume_test_silo_mode, control_silo_test
-from sentry.utils import json
 
 
 # TODO(dcramer): need tests for SSO behavior and single org behavior
@@ -196,7 +196,7 @@ class AuthLoginTest(TestCase, HybridCloudTestMixin):
             resp.context["register_form"].errors if resp.status_code == 200 else None
         )
         frontend_events = {"event_name": "Sign Up"}
-        marketing_query = urlencode({"frontend_events": json.dumps(frontend_events)})
+        marketing_query = urlencode({"frontend_events": orjson.dumps(frontend_events).decode()})
         assert marketing_query in resp.headers["Location"]
 
         user = User.objects.get(username="test-a-really-long-email-address@example.com")

--- a/tests/sentry/web/frontend/test_auth_organization_login.py
+++ b/tests/sentry/web/frontend/test_auth_organization_login.py
@@ -3,6 +3,7 @@ from unittest import mock
 from urllib.parse import quote as urlquote
 from urllib.parse import urlencode
 
+import orjson
 from django.test import override_settings
 from django.urls import reverse
 
@@ -20,7 +21,6 @@ from sentry.silo.base import SiloMode
 from sentry.testutils.cases import AuthProviderTestCase
 from sentry.testutils.helpers import with_feature
 from sentry.testutils.silo import assume_test_silo_mode, control_silo_test
-from sentry.utils import json
 
 
 # TODO(dcramer): this is an integration test and repeats tests from
@@ -85,7 +85,7 @@ class OrganizationAuthLoginTest(AuthProviderTestCase):
         assert resp.status_code == 200
 
         frontend_events = {"event_name": "Sign Up", "event_label": "dummy"}
-        marketing_query = urlencode({"frontend_events": json.dumps(frontend_events)})
+        marketing_query = urlencode({"frontend_events": orjson.dumps(frontend_events).decode()})
 
         with self.settings(
             TERMS_URL="https://example.com/terms", PRIVACY_URL="https://example.com/privacy"
@@ -288,7 +288,7 @@ class OrganizationAuthLoginTest(AuthProviderTestCase):
         assert resp.context["login_form"]
 
         frontend_events = {"event_name": "Sign Up", "event_label": "dummy"}
-        marketing_query = urlencode({"frontend_events": json.dumps(frontend_events)})
+        marketing_query = urlencode({"frontend_events": orjson.dumps(frontend_events).decode()})
 
         resp = self.client.post(path, {"op": "newuser"}, follow=True)
         assert resp.redirect_chain == [
@@ -559,7 +559,7 @@ class OrganizationAuthLoginTest(AuthProviderTestCase):
         assert resp.context["login_form"]
 
         frontend_events = {"event_name": "Sign Up", "event_label": "dummy"}
-        marketing_query = urlencode({"frontend_events": json.dumps(frontend_events)})
+        marketing_query = urlencode({"frontend_events": orjson.dumps(frontend_events).decode()})
 
         resp = self.client.post(path, {"op": "newuser"}, follow=True)
         assert resp.redirect_chain == [

--- a/tests/symbolicator/test_payload_full.py
+++ b/tests/symbolicator/test_payload_full.py
@@ -4,6 +4,7 @@ from io import BytesIO
 from unittest.mock import patch
 from uuid import uuid4
 
+import orjson
 import pytest
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.urls import reverse
@@ -22,7 +23,6 @@ from sentry.testutils.factories import get_fixture_path
 from sentry.testutils.helpers.datetime import before_now, iso_format
 from sentry.testutils.relay import RelayStoreHelper
 from sentry.testutils.skips import requires_kafka, requires_symbolicator
-from sentry.utils import json
 from tests.symbolicator import insta_snapshot_native_stacktrace_data, redact_location
 
 # IMPORTANT:
@@ -287,7 +287,7 @@ class SymbolicatorResolvingIntegrationTest(RelayStoreHelper, TransactionTestCase
 
             zip_file.writestr(
                 "manifest.json",
-                json.dumps(
+                orjson.dumps(
                     {
                         "files": {
                             "files/_/_/test.min.js": {
@@ -307,7 +307,7 @@ class SymbolicatorResolvingIntegrationTest(RelayStoreHelper, TransactionTestCase
                             },
                         },
                     }
-                ),
+                ).decode(),
             )
         compressed.seek(0)
         bundle_file = File.objects.create(name="bundle.zip", type="artifact.bundle")


### PR DESCRIPTION
Reapplies `orjson` changes and squashes them into single PR.

> No rush to merge this. Opening now to keep track of changes.