### PR TITLE
fix: use date parser to parse timestamps

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -97,7 +97,12 @@ register(
 )
 # The region that this instance is currently running in.
 register("system.region", flags=FLAG_ALLOW_EMPTY | FLAG_PRIORITIZE_DISK | FLAG_NOSTORE)
-
+# Enable date-util parsing for timestamps
+register(
+    "system.use-date-util-timestamps",
+    default=False,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
 # Redis
 register(
     "redis.clusters",

--- a/tests/sentry/utils/test_dates.py
+++ b/tests/sentry/utils/test_dates.py
@@ -1,5 +1,6 @@
 import datetime
 
+from sentry.testutils.helpers import override_options
 from sentry.utils.dates import date_to_utc_datetime, parse_stats_period, parse_timestamp
 
 
@@ -20,7 +21,19 @@ def test_date_to_utc_datetime():
     assert dt == datetime.datetime(2024, 7, 5, tzinfo=datetime.UTC)
 
 
+@override_options({"system.use-date-util-timestamps": False})
 def test_parse_timestamp():
+    assert parse_timestamp("2024-05-20T17:29:00+00:00") == datetime.datetime(
+        2024, 5, 20, 17, 29, tzinfo=datetime.UTC
+    )
+    assert parse_timestamp("2024-05-20T17:29:00") == datetime.datetime(
+        2024, 5, 20, 17, 29, tzinfo=datetime.UTC
+    )
+    assert parse_timestamp("2024-05-20T17:29:00gu") is None
+
+
+@override_options({"system.use-date-util-timestamps": True})
+def test_parse_timestamp_with_date_util():
     assert parse_timestamp("2024-05-20T17:29:00+00:00") == datetime.datetime(
         2024, 5, 20, 17, 29, tzinfo=datetime.UTC
     )


### PR DESCRIPTION
Recently merged https://github.com/getsentry/sentry/commit/68f2dfc6b73efc374b293c84137d11db8d314d62 can be improved by using the `dateutil.parser`