### PR TITLE
chore(apis): Update ownership from issues to alerts & notifications

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -174,7 +174,19 @@ yarn.lock                                                @getsentry/owners-js-de
 /tests/snuba/incidents/                                   @getsentry/alerts-notifications
 /tests/sentry/snuba/test_query_subscription_consumer.py   @getsentry/alerts-notifications
 /tests/sentry/snuba/test_subscriptions.py                 @getsentry/alerts-notifications
+<<<<<<< HEAD
 /tests/sentry/snuba/test_tasks.py                         @getsentry/alerts-notifications
+=======
+/src/sentry/api/endpoints/notification_defaults.py                          @getsentry/alerts-notifications
+/src/sentry/api/endpoints/broadcast_details.py                              @getsentry/alerts-notifications
+/src/sentry/api/endpoints/broadcast_index.py                                @getsentry/alerts-notifications
+/src/sentry/api/endpoints/user_notification_email.py                        @getsentry/alerts-notifications
+/src/sentry/api/endpoints/user_notification_settings_options_detail.py      @getsentry/alerts-notifications
+/src/sentry/api/endpoints/user_notification_settings_options.py             @getsentry/alerts-notifications
+/src/sentry/api/endpoints/user_notification_settings_providers.py           @getsentry/alerts-notifications
+/src/sentry/api/endpoints/user_notification_details.py                      @getsentry/alerts-notifications
+/src/sentry/api/endpoints/user_subscriptions.py                             @getsentry/alerts-notifications
+>>>>>>> 14d24115b48 (chore(apis): Update ownership from issues to alerts & notifications)
 ## Endof Alerts & Notifications
 
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -181,7 +181,6 @@ yarn.lock                                                @getsentry/owners-js-de
 /src/sentry/api/endpoints/user_notification_settings_options.py             @getsentry/alerts-notifications
 /src/sentry/api/endpoints/user_notification_settings_providers.py           @getsentry/alerts-notifications
 /src/sentry/api/endpoints/user_notification_details.py                      @getsentry/alerts-notifications
-/src/sentry/api/endpoints/user_subscriptions.py                             @getsentry/alerts-notifications
 ## Endof Alerts & Notifications
 
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -174,19 +174,14 @@ yarn.lock                                                @getsentry/owners-js-de
 /tests/snuba/incidents/                                   @getsentry/alerts-notifications
 /tests/sentry/snuba/test_query_subscription_consumer.py   @getsentry/alerts-notifications
 /tests/sentry/snuba/test_subscriptions.py                 @getsentry/alerts-notifications
-<<<<<<< HEAD
 /tests/sentry/snuba/test_tasks.py                         @getsentry/alerts-notifications
-=======
 /src/sentry/api/endpoints/notification_defaults.py                          @getsentry/alerts-notifications
-/src/sentry/api/endpoints/broadcast_details.py                              @getsentry/alerts-notifications
-/src/sentry/api/endpoints/broadcast_index.py                                @getsentry/alerts-notifications
 /src/sentry/api/endpoints/user_notification_email.py                        @getsentry/alerts-notifications
 /src/sentry/api/endpoints/user_notification_settings_options_detail.py      @getsentry/alerts-notifications
 /src/sentry/api/endpoints/user_notification_settings_options.py             @getsentry/alerts-notifications
 /src/sentry/api/endpoints/user_notification_settings_providers.py           @getsentry/alerts-notifications
 /src/sentry/api/endpoints/user_notification_details.py                      @getsentry/alerts-notifications
 /src/sentry/api/endpoints/user_subscriptions.py                             @getsentry/alerts-notifications
->>>>>>> 14d24115b48 (chore(apis): Update ownership from issues to alerts & notifications)
 ## Endof Alerts & Notifications
 
 

--- a/src/sentry/api/api_owners.py
+++ b/src/sentry/api/api_owners.py
@@ -7,6 +7,7 @@ class ApiOwner(Enum):
     Value should map to team's github group
     """
 
+    ALERTS_NOTIFICATIONS = "alerts-notifications"
     BILLING = "revenue"
     CRONS = "crons"
     ECOSYSTEM = "ecosystem"

--- a/src/sentry/api/endpoints/broadcast_details.py
+++ b/src/sentry/api/endpoints/broadcast_details.py
@@ -22,7 +22,7 @@ from rest_framework.response import Response
 
 @control_silo_endpoint
 class BroadcastDetailsEndpoint(Endpoint):
-    owner = ApiOwner.ALERTS_NOTIFICATIONS
+    owner = ApiOwner.UNOWNED
     publish_status = {
         "GET": ApiPublishStatus.PRIVATE,
         "PUT": ApiPublishStatus.PRIVATE,

--- a/src/sentry/api/endpoints/broadcast_details.py
+++ b/src/sentry/api/endpoints/broadcast_details.py
@@ -22,7 +22,7 @@ from rest_framework.response import Response
 
 @control_silo_endpoint
 class BroadcastDetailsEndpoint(Endpoint):
-    owner = ApiOwner.ISSUES
+    owner = ApiOwner.ALERTS_NOTIFICATIONS
     publish_status = {
         "GET": ApiPublishStatus.PRIVATE,
         "PUT": ApiPublishStatus.PRIVATE,

--- a/src/sentry/api/endpoints/broadcast_index.py
+++ b/src/sentry/api/endpoints/broadcast_index.py
@@ -29,7 +29,7 @@ from rest_framework.response import Response
 
 @control_silo_endpoint
 class BroadcastIndexEndpoint(ControlSiloOrganizationEndpoint):
-    owner = ApiOwner.ISSUES
+    owner = ApiOwner.ALERTS_NOTIFICATIONS
     publish_status = {
         "GET": ApiPublishStatus.PRIVATE,
         "PUT": ApiPublishStatus.PRIVATE,

--- a/src/sentry/api/endpoints/broadcast_index.py
+++ b/src/sentry/api/endpoints/broadcast_index.py
@@ -29,7 +29,7 @@ from rest_framework.response import Response
 
 @control_silo_endpoint
 class BroadcastIndexEndpoint(ControlSiloOrganizationEndpoint):
-    owner = ApiOwner.ALERTS_NOTIFICATIONS
+    owner = ApiOwner.UNOWNED
     publish_status = {
         "GET": ApiPublishStatus.PRIVATE,
         "PUT": ApiPublishStatus.PRIVATE,

--- a/src/sentry/api/endpoints/notification_defaults.py
+++ b/src/sentry/api/endpoints/notification_defaults.py
@@ -15,7 +15,7 @@ class NotificationDefaultsEndpoints(Endpoint):
     publish_status = {
         "GET": ApiPublishStatus.PRIVATE,
     }
-    owner = ApiOwner.ISSUES
+    owner = ApiOwner.ALERTS_NOTIFICATIONS
     permission_classes = ()
     private = True
 

--- a/src/sentry/api/endpoints/user_notification_details.py
+++ b/src/sentry/api/endpoints/user_notification_details.py
@@ -55,7 +55,7 @@ class UserNotificationDetailsSerializer(serializers.Serializer):
 
 @control_silo_endpoint
 class UserNotificationDetailsEndpoint(UserEndpoint):
-    owner = ApiOwner.ISSUES
+    owner = ApiOwner.ALERTS_NOTIFICATIONS
     publish_status = {
         "GET": ApiPublishStatus.UNKNOWN,
         "PUT": ApiPublishStatus.UNKNOWN,

--- a/src/sentry/api/endpoints/user_notification_details.py
+++ b/src/sentry/api/endpoints/user_notification_details.py
@@ -57,8 +57,8 @@ class UserNotificationDetailsSerializer(serializers.Serializer):
 class UserNotificationDetailsEndpoint(UserEndpoint):
     owner = ApiOwner.ALERTS_NOTIFICATIONS
     publish_status = {
-        "GET": ApiPublishStatus.UNKNOWN,
-        "PUT": ApiPublishStatus.UNKNOWN,
+        "GET": ApiPublishStatus.PRIVATE,
+        "PUT": ApiPublishStatus.PRIVATE,
     }
 
     def get(self, request: Request, user) -> Response:

--- a/src/sentry/api/endpoints/user_notification_email.py
+++ b/src/sentry/api/endpoints/user_notification_email.py
@@ -21,7 +21,7 @@ class UserNotificationEmailEndpoint(UserEndpoint):
         "GET": ApiPublishStatus.PRIVATE,
         "PUT": ApiPublishStatus.PRIVATE,
     }
-    owner = ApiOwner.ISSUES
+    owner = ApiOwner.ALERTS_NOTIFICATIONS
 
     def get(self, request: Request, user) -> Response:
         """

--- a/src/sentry/api/endpoints/user_notification_settings_options.py
+++ b/src/sentry/api/endpoints/user_notification_settings_options.py
@@ -21,7 +21,7 @@ class UserNotificationSettingsOptionsEndpoint(UserEndpoint):
         "GET": ApiPublishStatus.PRIVATE,
         "PUT": ApiPublishStatus.PRIVATE,
     }
-    owner = ApiOwner.ISSUES
+    owner = ApiOwner.ALERTS_NOTIFICATIONS
     # TODO(Steve): Make not private when we launch new system
     private = True
 

--- a/src/sentry/api/endpoints/user_notification_settings_options_detail.py
+++ b/src/sentry/api/endpoints/user_notification_settings_options_detail.py
@@ -15,7 +15,7 @@ class UserNotificationSettingsOptionsDetailEndpoint(UserEndpoint):
     publish_status = {
         "DELETE": ApiPublishStatus.PRIVATE,
     }
-    owner = ApiOwner.ISSUES
+    owner = ApiOwner.ALERTS_NOTIFICATIONS
     # TODO(Steve): Make not private when we launch new system
     private = True
 

--- a/src/sentry/api/endpoints/user_notification_settings_providers.py
+++ b/src/sentry/api/endpoints/user_notification_settings_providers.py
@@ -24,7 +24,7 @@ class UserNotificationSettingsProvidersEndpoint(UserEndpoint):
         "GET": ApiPublishStatus.PRIVATE,
         "PUT": ApiPublishStatus.PRIVATE,
     }
-    owner = ApiOwner.ISSUES
+    owner = ApiOwner.ALERTS_NOTIFICATIONS
     # TODO(Steve): Make not private when we launch new system
     private = True
 

--- a/src/sentry/api/endpoints/user_subscriptions.py
+++ b/src/sentry/api/endpoints/user_subscriptions.py
@@ -26,7 +26,7 @@ from rest_framework.response import Response
 
 @control_silo_endpoint
 class UserSubscriptionsEndpoint(UserEndpoint):
-    owner = ApiOwner.ISSUES
+    owner = ApiOwner.ALERTS_NOTIFICATIONS
     publish_status = {
         "GET": ApiPublishStatus.UNKNOWN,
         "PUT": ApiPublishStatus.UNKNOWN,

--- a/src/sentry/api/endpoints/user_subscriptions.py
+++ b/src/sentry/api/endpoints/user_subscriptions.py
@@ -26,7 +26,7 @@ from rest_framework.response import Response
 
 @control_silo_endpoint
 class UserSubscriptionsEndpoint(UserEndpoint):
-    owner = ApiOwner.ALERTS_NOTIFICATIONS
+    owner = ApiOwner.UNOWNED
     publish_status = {
         "GET": ApiPublishStatus.PRIVATE,
         "PUT": ApiPublishStatus.PRIVATE,

--- a/src/sentry/api/endpoints/user_subscriptions.py
+++ b/src/sentry/api/endpoints/user_subscriptions.py
@@ -28,9 +28,9 @@ from rest_framework.response import Response
 class UserSubscriptionsEndpoint(UserEndpoint):
     owner = ApiOwner.ALERTS_NOTIFICATIONS
     publish_status = {
-        "GET": ApiPublishStatus.UNKNOWN,
-        "PUT": ApiPublishStatus.UNKNOWN,
-        "POST": ApiPublishStatus.UNKNOWN,
+        "GET": ApiPublishStatus.PRIVATE,
+        "PUT": ApiPublishStatus.PRIVATE,
+        "POST": ApiPublishStatus.PRIVATE,
     }
 
     def get(self, request: Request, user) -> Response:


### PR DESCRIPTION
After re-orgs some endpoints are better owned by alerts & notifications vs. issues. I'm not sure if the ownership I'm assigning in this PR is correct so will get help from both teams.
