### PR TITLE
feat(billing): Add `spans-usage-tracking` org feature

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1877,8 +1877,8 @@ SENTRY_FEATURES: dict[str, bool | None] = {
     "organizations:standalone-span-ingestion": False,
     # A single flag for all the new performance UI that relies on span ingestion
     "organizations:spans-first-ui": False,
-    # Hide transactions and display spans
-    "organizations:spans-only": False,
+    # Measure usage by spans instead of transactions
+    "organizations:spans-usage-tracking": False,
     # Enable the aggregate span waterfall view
     "organizations:starfish-aggregate-span-waterfall": False,
     # Enables the resource module ui

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1877,6 +1877,8 @@ SENTRY_FEATURES: dict[str, bool | None] = {
     "organizations:standalone-span-ingestion": False,
     # A single flag for all the new performance UI that relies on span ingestion
     "organizations:spans-first-ui": False,
+    # Hide transactions and display spans
+    "organizations:spans-only": False,
     # Enable the aggregate span waterfall view
     "organizations:starfish-aggregate-span-waterfall": False,
     # Enables the resource module ui

--- a/src/sentry/features/permanent.py
+++ b/src/sentry/features/permanent.py
@@ -45,6 +45,7 @@ def register_permanent_features(manager: FeatureManager):
         "organizations:profiling-view",
         "organizations:relay",
         "organizations:session-replay",
+        "organizations:spans-only",
         "organizations:sso-basic",
         "organizations:sso-saml2",
         "organizations:team-insights",

--- a/src/sentry/features/permanent.py
+++ b/src/sentry/features/permanent.py
@@ -45,7 +45,7 @@ def register_permanent_features(manager: FeatureManager):
         "organizations:profiling-view",
         "organizations:relay",
         "organizations:session-replay",
-        "organizations:spans-only",
+        "organizations:spans-usage-tracking",
         "organizations:sso-basic",
         "organizations:sso-saml2",
         "organizations:team-insights",


### PR DESCRIPTION
This flag will be attached to the am3 billing plan since they'll measure only spans and not transactions.

part of https://getsentry.atlassian.net/browse/RV-1648
blocks https://github.com/getsentry/sentry/pull/71145