### PR TITLE
fix(highlights): Set column count after ref defined

### DIFF
--- a/static/app/components/events/eventTags/util.tsx
+++ b/static/app/components/events/eventTags/util.tsx
@@ -1,4 +1,4 @@
-import {type RefObject, useCallback, useState} from 'react';
+import {type RefObject, useCallback, useLayoutEffect, useState} from 'react';
 import {useResizeObserver} from '@react-aria/utils';
 
 import {useLocation} from 'sentry/utils/useLocation';
@@ -188,6 +188,13 @@ export function useIssueDetailsColumnCount(elementRef: RefObject<HTMLElement>): 
   }, [elementRef]);
 
   const [columnCount, setColumnCount] = useState(calculateColumnCount());
+
+  // If the ref was undefined, calculate the column count again
+  useLayoutEffect(() => {
+    if (elementRef.current) {
+      setColumnCount(calculateColumnCount());
+    }
+  }, [calculateColumnCount, elementRef]);
 
   const onResize = useCallback(() => {
     const count = calculateColumnCount();


### PR DESCRIPTION
Fixes the number of columns from changing when going between the issues stream and an issue.

can kinda see it going from 1 to 2 columns when the resize observer callback is finally hit

https://github.com/getsentry/sentry/assets/1400464/fc022952-9407-427f-a493-528684bdcbbf

