### PR TITLE
fix(issue-stream): Show event sub status before event chart, fix placeholders

### DIFF
--- a/static/app/components/charts/groupStatusChart.tsx
+++ b/static/app/components/charts/groupStatusChart.tsx
@@ -4,6 +4,7 @@ import styled from '@emotion/styled';
 import MarkLine from 'sentry/components/charts/components/markLine';
 import MiniBarChart from 'sentry/components/charts/miniBarChart';
 import {LazyRender} from 'sentry/components/lazyRender';
+import Placeholder from 'sentry/components/placeholder';
 import {t} from 'sentry/locale';
 import type {TimeseriesValue} from 'sentry/types';
 import type {Series} from 'sentry/types/echarts';
@@ -24,6 +25,7 @@ type Props = {
   groupStatus?: string;
   height?: number;
   hideZeros?: boolean;
+  loading?: boolean;
   secondaryStats?: ReadonlyArray<TimeseriesValue>;
   showMarkLine?: boolean;
   showSecondaryPoints?: boolean;
@@ -33,6 +35,7 @@ function GroupStatusChart({
   stats,
   groupStatus,
   height = 24,
+  loading = false,
   hideZeros = false,
   secondaryStats = EMPTY_STATS,
   showMarkLine = false,
@@ -104,21 +107,25 @@ function GroupStatusChart({
   return (
     <LazyRender containerHeight={showMarkLine ? 26 : height}>
       <ChartWrapper>
-        <MiniBarChart
-          animateBars
-          showXAxisLine
-          hideZeros={hideZeros}
-          markLineLabelSide="right"
-          barOpacity={0.4}
-          height={showMarkLine ? 36 : height}
-          isGroupedByDate
-          showTimeInTooltip
-          series={graphOptions.series}
-          colors={graphOptions.colors}
-          emphasisColors={graphOptions.emphasisColors}
-          hideDelay={50}
-          showMarkLineLabel={showMarkLine}
-        />
+        {loading ? (
+          <Placeholder height={`36px`} />
+        ) : (
+          <MiniBarChart
+            animateBars
+            showXAxisLine
+            hideZeros={hideZeros}
+            markLineLabelSide="right"
+            barOpacity={0.4}
+            height={showMarkLine ? 36 : height}
+            isGroupedByDate
+            showTimeInTooltip
+            series={graphOptions.series}
+            colors={graphOptions.colors}
+            emphasisColors={graphOptions.emphasisColors}
+            hideDelay={50}
+            showMarkLineLabel={showMarkLine}
+          />
+        )}
         <GraphText>{groupStatus}</GraphText>
       </ChartWrapper>
     </LazyRender>

--- a/static/app/components/charts/groupStatusChart.tsx
+++ b/static/app/components/charts/groupStatusChart.tsx
@@ -108,7 +108,7 @@ function GroupStatusChart({
     <LazyRender containerHeight={showMarkLine ? 26 : height}>
       <ChartWrapper>
         {loading ? (
-          <Placeholder height={`36px`} />
+          <Placeholder height={'36px'} />
         ) : (
           <MiniBarChart
             animateBars

--- a/static/app/components/eventOrGroupExtraDetails.tsx
+++ b/static/app/components/eventOrGroupExtraDetails.tsx
@@ -65,7 +65,7 @@ function EventOrGroupExtraDetails({data, showAssignee, organization}: Props) {
       )}
       {isUnhandled && <UnhandledTag />}
       {!lifetime && !firstSeen && !lastSeen ? (
-        <Placeholder height="14px" width="100px" />
+        <Placeholder height="12px" width="100px" />
       ) : (
         <TimesTag
           lastSeen={lifetime?.lastSeen || lastSeen}

--- a/static/app/components/stream/group.tsx
+++ b/static/app/components/stream/group.tsx
@@ -363,7 +363,7 @@ function BaseGroupRow({
   };
 
   const groupCount = !defined(primaryCount) ? (
-    <Placeholder height="18px" width="50px" />
+    <Placeholder height="18px" width="40px" />
   ) : (
     <GuideAnchor target="dynamic_counts" disabled={!hasGuideAnchor}>
       <Tooltip
@@ -404,7 +404,7 @@ function BaseGroupRow({
   );
 
   const groupUsersCount = !defined(primaryUserCount) ? (
-    <Placeholder height="18px" width="50px" />
+    <Placeholder height="18px" width="40px" />
   ) : (
     <Tooltip
       isHoverable
@@ -498,18 +498,15 @@ function BaseGroupRow({
       {withChart && !displayReprocessingLayout && issueTypeConfig.stats.enabled && (
         <ChartWrapper narrowGroups={narrowGroups}>
           {organization.features.includes('issue-stream-new-events-graph') ? (
-            !defined(groupStats) ? (
-              <Placeholder height="36px" />
-            ) : (
-              <GroupStatusChart
-                hideZeros
-                stats={groupStats}
-                secondaryStats={groupSecondaryStats}
-                showSecondaryPoints={showSecondaryPoints}
-                groupStatus={getBadgeProperties(group.status, group.substatus)?.status}
-                showMarkLine
-              />
-            )
+            <GroupStatusChart
+              hideZeros
+              loading={!defined(groupStats)}
+              stats={groupStats}
+              secondaryStats={groupSecondaryStats}
+              showSecondaryPoints={showSecondaryPoints}
+              groupStatus={getBadgeProperties(group.status, group.substatus)?.status}
+              showMarkLine
+            />
           ) : (
             <GroupChart
               stats={groupStats}


### PR DESCRIPTION
This PR makes a couple follow up improvements to the new `<EventStatsChart/>` component, as well as the Issue stream in which it appears. These improvements include:

1. **Reduces the height of the "Last Seen" placeholder.** Previously, the height of this placeholder was larger than the value itself. This caused all rows in the issue stream to suddenly contract upon initial load. Reducing the height of the placeholder solves this problem. 
2. **Reduces the width of the "Count" and "Users" placeholders.** The extra width made it seem like the number "jumped" into its position, which looked choppy. Now that the placeholder's width is closer to the width of the value itself, the "jump" effect seems reduced (to my eye at least) 
3. **Renders the group sub-status (escalating, ongoing, etc.) before the chart.** Previously, the group sub status wouldn't be loaded until the graph itself was loaded. 

At a glance:
<img width="611" alt="image" src="https://github.com/getsentry/sentry/assets/55160142/c2edfbbc-3a4a-435a-a043-2ab9b7579926">
