### PR TITLE
fix(highlights): Hide edit scroll bar

### DIFF
--- a/static/app/components/events/highlights/editHighlightsModal.tsx
+++ b/static/app/components/events/highlights/editHighlightsModal.tsx
@@ -458,7 +458,7 @@ const modalBodyCss = css`
   margin: 0 -${space(4)};
   padding: 0 ${space(4)};
   max-height: 75vh;
-  overflow-y: scroll;
+  overflow-y: auto;
 `;
 
 const Title = styled('h3')`


### PR DESCRIPTION
We only want to display the scrollbar when content is hidden. Hides the scrollbar until content is clipped. macbook w/ trackpad hides the scrollbar for both.

![image](https://github.com/getsentry/sentry/assets/1400464/7c218e07-27c7-41f4-91ad-dcf9a5fff3dc)
