### PR TITLE
fix(stories): Reduce scroll bars on stories

### DIFF
--- a/static/app/views/stories/index.tsx
+++ b/static/app/views/stories/index.tsx
@@ -104,7 +104,7 @@ const Main = styled(VerticalScroll)`
 
   padding: var(--stories-grid-space);
   overflow-x: hidden;
-  overflow-y: scroll;
+  overflow-y: auto;
 
   position: relative;
 `;

--- a/static/app/views/stories/storyFile.tsx
+++ b/static/app/views/stories/storyFile.tsx
@@ -78,7 +78,6 @@ const FlexColumn = styled('section')`
 `;
 
 const StoryArea = styled('div')`
-  overflow: scroll;
   display: flex;
   flex-direction: column;
   gap: ${space(4)};


### PR DESCRIPTION
hide scroll bars until content is clipped

before
![image](https://github.com/getsentry/sentry/assets/1400464/97106bcd-c741-406a-9987-d4a1f6017452)

after
![image](https://github.com/getsentry/sentry/assets/1400464/ae5af7da-f0d2-4b91-8560-0e1c0c4ff80d)
