### PR TITLE
fix(feedback): Prevent extra scrollbars from appearing for mouse users

### DIFF
--- a/static/app/components/feedback/feedbackItem/feedbackItem.tsx
+++ b/static/app/components/feedback/feedbackItem/feedbackItem.tsx
@@ -101,7 +101,7 @@ export default function FeedbackItem({feedbackItem, eventData, tags}: Props) {
 
 // 0 padding-bottom because <ActivitySection> has space(2) built-in.
 const OverflowPanelItem = styled(PanelItem)`
-  overflow: scroll;
+  overflow: auto;
 
   flex-direction: column;
   flex-grow: 1;

--- a/static/app/components/feedback/list/feedbackList.tsx
+++ b/static/app/components/feedback/list/feedbackList.tsx
@@ -15,7 +15,6 @@ import FeedbackListItem from 'sentry/components/feedback/list/feedbackListItem';
 import useListItemCheckboxState from 'sentry/components/feedback/list/useListItemCheckboxState';
 import useFeedbackQueryKeys from 'sentry/components/feedback/useFeedbackQueryKeys';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
-import PanelItem from 'sentry/components/panels/panelItem';
 import {Tooltip} from 'sentry/components/tooltip';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
@@ -99,7 +98,7 @@ export default function FeedbackList() {
   return (
     <Fragment>
       <FeedbackListHeader {...checkboxState} />
-      <OverflowPanelItem noPadding>
+      <FeedbackListItems>
         <InfiniteLoader
           isRowLoaded={isRowLoaded}
           loadMoreRows={loadMoreRows}
@@ -151,14 +150,13 @@ export default function FeedbackList() {
             </Tooltip>
           ) : null}
         </FloatingContainer>
-      </OverflowPanelItem>
+      </FeedbackListItems>
     </Fragment>
   );
 }
 
-const OverflowPanelItem = styled(PanelItem)`
+const FeedbackListItems = styled('div')`
   display: grid;
-  overflow: auto;
   flex-grow: 1;
   min-height: 300px;
 `;

--- a/static/app/components/feedback/list/feedbackList.tsx
+++ b/static/app/components/feedback/list/feedbackList.tsx
@@ -158,7 +158,7 @@ export default function FeedbackList() {
 
 const OverflowPanelItem = styled(PanelItem)`
   display: grid;
-  overflow: scroll;
+  overflow: auto;
   flex-grow: 1;
   min-height: 300px;
 `;


### PR DESCRIPTION
**Before:**
<img width="431" alt="SCR-20240520-oyor" src="https://github.com/getsentry/sentry/assets/187460/d09a5e5d-473e-4a30-aee1-a75522ce97dd">
<img width="804" alt="SCR-20240520-oywx" src="https://github.com/getsentry/sentry/assets/187460/4abbc7cb-1fec-410a-a36b-b305afe8b4be">


**After:**
<img width="824" alt="SCR-20240520-oxxf" src="https://github.com/getsentry/sentry/assets/187460/386ba816-346c-4a44-8f57-7908756e78c4">
<img width="427" alt="SCR-20240520-oxvg" src="https://github.com/getsentry/sentry/assets/187460/4c298bce-76a7-4cb9-9b83-86993e4df7f4">
