### PR TITLE
fix(issue-stream): Reduce font size of event status

### DIFF
--- a/static/app/components/charts/groupStatusChart.tsx
+++ b/static/app/components/charts/groupStatusChart.tsx
@@ -155,5 +155,6 @@ const ChartWrapper = styled('div')`
 `;
 
 const GraphText = styled('div')`
+  font-size: ${p => p.theme.fontSizeSmall};
   color: ${p => p.theme.gray300};
 `;


### PR DESCRIPTION
This PR reduces the font size of the status under the new `<EventStatusChart/>` component to 12px (`theme.fontSizeSmall`), from 14px

Before:
<img width="607" alt="image" src="https://github.com/getsentry/sentry/assets/55160142/8db8eb04-dd97-411b-849b-489c7e444c8e">

After:
<img width="610" alt="image" src="https://github.com/getsentry/sentry/assets/55160142/1f23bb16-f004-4f9d-84e1-860d518cdce9">
