### PR TITLE
ref(metrics): Use type guards in widget details

### DIFF
--- a/static/app/views/metrics/widgetDetails.tsx
+++ b/static/app/views/metrics/widgetDetails.tsx
@@ -20,12 +20,8 @@ import type {MRI} from 'sentry/types/metrics';
 import {defined} from 'sentry/utils';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {isCustomMetric} from 'sentry/utils/metrics';
-import type {
-  FocusedMetricsSeries,
-  MetricsQueryWidget,
-  MetricsWidget,
-} from 'sentry/utils/metrics/types';
-import {MetricExpressionType} from 'sentry/utils/metrics/types';
+import type {FocusedMetricsSeries, MetricsWidget} from 'sentry/utils/metrics/types';
+import {isMetricsEquationWidget} from 'sentry/utils/metrics/types';
 import type {MetricsSamplesResults} from 'sentry/utils/metrics/useMetricsSamples';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
@@ -58,12 +54,11 @@ export function WidgetDetails() {
     [setHighlightedSampleId]
   );
 
-  // TODO(aknaus): better fallback
-  if (selectedWidget?.type === MetricExpressionType.EQUATION) {
+  if (!selectedWidget || isMetricsEquationWidget(selectedWidget)) {
     return <MetricDetails onRowHover={handleSampleRowHover} focusArea={focusArea} />;
   }
 
-  const {mri, op, query, focusedSeries} = selectedWidget as MetricsQueryWidget;
+  const {mri, op, query, focusedSeries} = selectedWidget;
 
   return (
     <MetricDetails


### PR DESCRIPTION
Use type guard and remove casting in widget details.

- follow-up of https://github.com/getsentry/sentry/pull/70512