### PR TITLE
fix(metrics): Allow searching namespace and type only in mri mode

### DIFF
--- a/static/app/views/metrics/queryBuilder.tsx
+++ b/static/app/views/metrics/queryBuilder.tsx
@@ -224,8 +224,11 @@ export const QueryBuilder = memo(function QueryBuilder({
         label: mriMode
           ? metric.mri
           : middleEllipsis(formatMRI(metric.mri) ?? '', 46, /\.|-|_/),
-        // enable search by mri, name, unit (millisecond), type (c:), and readable type (counter)
-        textValue: `${metric.mri}${getReadableMetricType(metric.type)}`,
+        textValue: mriMode
+          ? // enable search by mri, name, unit (millisecond), type (c:), and readable type (counter)
+            `${metric.mri}${getReadableMetricType(metric.type)}`
+          : // enable search in the full formatted string
+            formatMRI(metric.mri),
         value: metric.mri,
         details:
           metric.projectIds.length > 0 ? (


### PR DESCRIPTION
Allow searching for metric type and namespace only in MRI mode as it is confusing otherwise.

- Closes https://github.com/getsentry/sentry/issues/71211