### PR TITLE
chore(ui): Update Codecov bundler plugin

### DIFF
--- a/.github/actions/artifacts/action.yml
+++ b/.github/actions/artifacts/action.yml
@@ -13,6 +13,9 @@ inputs:
   token:
     description: 'The codecov token'
     required: true
+  commit_sha:
+    description: 'The commit sha'
+    required: true
 
 runs:
   using: 'composite'
@@ -23,6 +26,7 @@ runs:
         token: ${{ inputs.token }}
         flags: ${{ inputs.type }}
         files: ${{ inputs.files }}
+        override_commit: ${{ inputs.commit_sha}}
         plugin: noop
         verbose: true
       continue-on-error: true

--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -137,6 +137,7 @@ jobs:
         if: ${{ always() && needs.files-changed.outputs.backend_all == 'true' }}
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          commit_sha: ${{ github.event.pull_request.head.sha }}
 
   acceptance-required-checks:
     # this is a required check so we need this job to always run and report a status.

--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -65,6 +65,8 @@ jobs:
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         name: Checkout sentry
+        with:
+          fetch-depth: 2
 
       - uses: getsentry/action-setup-volta@e4939d337b83760d13a9d7030a6f68c9d0ee7581 # v2.0.0
 

--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -65,8 +65,6 @@ jobs:
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         name: Checkout sentry
-        with:
-          fetch-depth: 2
 
       - uses: getsentry/action-setup-volta@e4939d337b83760d13a9d7030a6f68c9d0ee7581 # v2.0.0
 
@@ -100,6 +98,7 @@ jobs:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
           # should set value either as `true` or `false`
           CODECOV_ENABLE_BA: ${{ needs.files-changed.outputs.frontend_all == 'true'}}
+          GH_COMMIT_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           yarn build-acceptance
 

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -86,10 +86,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-        with:
-          # Avoid codecov error message related to SHA resolution:
-          # https://github.com/codecov/codecov-bash/blob/7100762afbc822b91806a6574658129fe0d23a7d/codecov#L891
-          fetch-depth: '2'
 
       - name: Setup sentry env
         uses: ./.github/actions/setup-sentry
@@ -128,6 +124,7 @@ jobs:
         uses: ./.github/actions/artifacts
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          commit_sha: ${{ github.event.pull_request.head.sha }}
 
   backend-migration-tests:
     if: needs.files-changed.outputs.backend == 'true'
@@ -141,10 +138,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-        with:
-          # Avoid codecov error message related to SHA resolution:
-          # https://github.com/codecov/codecov-bash/blob/7100762afbc822b91806a6574658129fe0d23a7d/codecov#L891
-          fetch-depth: '2'
 
       - name: Setup sentry env
         uses: ./.github/actions/setup-sentry
@@ -164,6 +157,7 @@ jobs:
         uses: ./.github/actions/artifacts
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          commit_sha: ${{ github.event.pull_request.head.sha }}
 
   cli:
     if: needs.files-changed.outputs.backend == 'true'
@@ -194,6 +188,7 @@ jobs:
         uses: ./.github/actions/artifacts
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          commit_sha: ${{ github.event.pull_request.head.sha }}
 
   requirements:
     if: needs.files-changed.outputs.backend_dependencies == 'true'
@@ -265,10 +260,6 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-        with:
-          # Avoid codecov error message related to SHA resolution:
-          # https://github.com/codecov/codecov-bash/blob/7100762afbc822b91806a6574658129fe0d23a7d/codecov#L891
-          fetch-depth: '2'
 
       - name: Setup sentry env
         uses: ./.github/actions/setup-sentry
@@ -295,6 +286,7 @@ jobs:
         uses: ./.github/actions/artifacts
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          commit_sha: ${{ github.event.pull_request.head.sha }}
 
   typing:
     if: needs.files-changed.outputs.backend == 'true'

--- a/.github/workflows/codecov_per_test_coverage.yml
+++ b/.github/workflows/codecov_per_test_coverage.yml
@@ -31,10 +31,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-        with:
-          # Avoid codecov error message related to SHA resolution:
-          # https://github.com/codecov/codecov-bash/blob/7100762afbc822b91806a6574658129fe0d23a7d/codecov#L891
-          fetch-depth: '2'
 
       - name: Setup sentry env
         uses: ./.github/actions/setup-sentry
@@ -71,5 +67,6 @@ jobs:
         with:
           files: .artifacts/python.coverage.codecov.json
           flags: smart-tests
+          override_commit: ${{ github.event.pull_request.head.sha }}
           plugins: compress-pycoverage
         continue-on-error: true

--- a/.github/workflows/development-environment.yml
+++ b/.github/workflows/development-environment.yml
@@ -44,6 +44,7 @@ jobs:
         uses: ./.github/actions/artifacts
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          commit_sha: ${{ github.event.pull_request.head.sha }}
   devenv:
     runs-on: ubuntu-22.04
     timeout-minutes: 5

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -151,11 +151,6 @@ jobs:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         name: Checkout sentry
 
-        with:
-          # Avoid codecov error message related to SHA resolution:
-          # https://github.com/codecov/codecov-bash/blob/7100762afbc822b91806a6574658129fe0d23a7d/codecov#L891
-          fetch-depth: '2'
-
       - uses: getsentry/action-setup-volta@e4939d337b83760d13a9d7030a6f68c9d0ee7581 # v2.0.0
 
       - name: node_modules cache
@@ -199,6 +194,7 @@ jobs:
           files: .artifacts/coverage/*
           type: frontend
           token: ${{ secrets.CODECOV_TOKEN }}
+          commit_sha: ${{ github.event.pull_request.head.sha }}
 
   # This check runs once all dependant jobs have passed
   # It symbolizes that all required Frontend checks have succesfully passed (Or skipped)

--- a/.github/workflows/openapi.yml
+++ b/.github/workflows/openapi.yml
@@ -21,10 +21,6 @@ jobs:
           private_key: ${{ secrets.SENTRY_INTERNAL_APP_PRIVATE_KEY }}
 
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-        with:
-          # Avoid codecov error message related to SHA resolution:
-          # https://github.com/codecov/codecov-bash/blob/7100762afbc822b91806a6574658129fe0d23a7d/codecov#L891
-          fetch-depth: '2'
 
       - name: Check for python file changes
         uses: dorny/paths-filter@0bc4621a3135347011ad047f9ecf449bf72ce2bd # v3.0.0

--- a/.github/workflows/shuffle-tests.yml
+++ b/.github/workflows/shuffle-tests.yml
@@ -43,10 +43,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-        with:
-          # Avoid codecov error message related to SHA resolution:
-          # https://github.com/codecov/codecov-bash/blob/7100762afbc822b91806a6574658129fe0d23a7d/codecov#L891
-          fetch-depth: '2'
 
       - name: Setup sentry env
         uses: ./.github/actions/setup-sentry

--- a/package.json
+++ b/package.json
@@ -175,7 +175,7 @@
   },
   "devDependencies": {
     "@biomejs/biome": "^1.7.3",
-    "@codecov/webpack-plugin": "^0.0.1-beta.6",
+    "@codecov/webpack-plugin": "^0.0.1-beta.8",
     "@pmmmwh/react-refresh-webpack-plugin": "0.5.11",
     "@sentry/jest-environment": "6.0.0",
     "@sentry/profiling-node": "^8.0.0",

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -789,7 +789,7 @@ if (CODECOV_TOKEN && ENABLE_CODECOV_BA) {
   const {codecovWebpackPlugin} = require('@codecov/webpack-plugin');
   // defaulting to an empty string which in turn will fallback to env var or
   // determine merge commit sha from git
-  const GH_COMMIT_SHA = env.GH_COMMIT_SHA ?? "";
+  const GH_COMMIT_SHA = env.GH_COMMIT_SHA ?? '';
 
   appConfig.plugins?.push(
     codecovWebpackPlugin({

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -787,6 +787,9 @@ if (IS_PRODUCTION) {
 
 if (CODECOV_TOKEN && ENABLE_CODECOV_BA) {
   const {codecovWebpackPlugin} = require('@codecov/webpack-plugin');
+  // defaulting to an empty string which in turn will fallback to env var or
+  // determine merge commit sha from git
+  const GH_COMMIT_SHA = env.GH_COMMIT_SHA ?? "";
 
   appConfig.plugins?.push(
     codecovWebpackPlugin({
@@ -794,6 +797,9 @@ if (CODECOV_TOKEN && ENABLE_CODECOV_BA) {
       bundleName: 'app-webpack-bundle',
       uploadToken: CODECOV_TOKEN,
       debug: true,
+      uploadOverrides: {
+        sha: GH_COMMIT_SHA,
+      },
     })
   );
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1242,22 +1242,23 @@
   resolved "https://registry.yarnpkg.com/@biomejs/cli-win32-x64/-/cli-win32-x64-1.7.3.tgz#41b65a940a360abb4a3205949370153ffe30c7de"
   integrity sha512-ZmByhbrnmz/UUFYB622CECwhKIPjJLLPr5zr3edhu04LzbfcOrz16VYeNq5dpO1ADG70FORhAJkaIGdaVBG00w==
 
-"@codecov/bundler-plugin-core@^0.0.1-beta.6":
-  version "0.0.1-beta.6"
-  resolved "https://registry.yarnpkg.com/@codecov/bundler-plugin-core/-/bundler-plugin-core-0.0.1-beta.6.tgz#50ada40c16251ce7ffa0c66292401c8f45383e3f"
-  integrity sha512-dGk/s90fZm7D1O00gRtuE2gqM/CW9nglaPzcIT0v10VOV2tj+aHRrdB+yjas+RW8QP8Qf/sMqSmjkufP1iqggw==
+"@codecov/bundler-plugin-core@^0.0.1-beta.8":
+  version "0.0.1-beta.8"
+  resolved "https://registry.yarnpkg.com/@codecov/bundler-plugin-core/-/bundler-plugin-core-0.0.1-beta.8.tgz#4a9fe40c1976bde62cb29e4f060daa08640ca1db"
+  integrity sha512-3yxNa4N+pZxqU60XQxJ10sDKUWcDf/YaQSvODrgxLfKG/peZhSdbd92uRc7PYi73szu7lr1CVZIvVerod9C4Uw==
   dependencies:
     chalk "4.1.2"
     semver "^7.5.4"
-    unplugin "^1.6.0"
+    unplugin "^1.10.1"
     zod "^3.22.4"
 
-"@codecov/webpack-plugin@^0.0.1-beta.6":
-  version "0.0.1-beta.6"
-  resolved "https://registry.yarnpkg.com/@codecov/webpack-plugin/-/webpack-plugin-0.0.1-beta.6.tgz#9a82c7810c2463f4a6ee579e6d0d05fc58ac536a"
-  integrity sha512-3dyq8XmSxD4/92XFWkkukbSugb6kBsRZ3VpgR6ykKZ003fTLqOIzMEs15IQw3eHku/7b2awM9MvofvstaQdijA==
+"@codecov/webpack-plugin@^0.0.1-beta.8":
+  version "0.0.1-beta.8"
+  resolved "https://registry.yarnpkg.com/@codecov/webpack-plugin/-/webpack-plugin-0.0.1-beta.8.tgz#afd2c84fbf6b151d3316fc30592bd5974107e1bc"
+  integrity sha512-2fVEmEXn7Om8VnC1e0ntBpNYcQaP+Aw9fh/tjLjzH8q2sgGfYOU5oRCuBlzZqsElpsYVm5jbr7xM/3He0Tkj5w==
   dependencies:
-    "@codecov/bundler-plugin-core" "^0.0.1-beta.6"
+    "@codecov/bundler-plugin-core" "^0.0.1-beta.8"
+    unplugin "^1.10.1"
 
 "@cspotcode/source-map-support@^0.8.0":
   version "0.8.1"
@@ -11796,7 +11797,17 @@ unpipe@1.0.0, unpipe@~1.0.0:
   resolved "https://registry.yarnpkg.com/unpipe/-/unpipe-1.0.0.tgz#b2bf4ee8514aae6165b4817829d21b2ef49904ec"
   integrity sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=
 
-unplugin@^1.4.0, unplugin@^1.6.0:
+unplugin@^1.10.1:
+  version "1.10.1"
+  resolved "https://registry.yarnpkg.com/unplugin/-/unplugin-1.10.1.tgz#8ceda065dc71bc67d923dea0920f05c67f2cd68c"
+  integrity sha512-d6Mhq8RJeGA8UfKCu54Um4lFA0eSaRa3XxdAJg8tIdxbu1ubW0hBCZUL7yI2uGyYCRndvbK8FLHzqy2XKfeMsg==
+  dependencies:
+    acorn "^8.11.3"
+    chokidar "^3.6.0"
+    webpack-sources "^3.2.3"
+    webpack-virtual-modules "^0.6.1"
+
+unplugin@^1.4.0:
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/unplugin/-/unplugin-1.9.0.tgz#d1805188dc54b9b693f97b9c17e3714b38b2b47f"
   integrity sha512-14PslvMY3gNbXnQtNIRB566Q057L5Fe7f5LDEamxVi0QQVxoz5hrveBwwZLcKyHtZ09ysmipxRRj5Lv+BGz2Iw==


### PR DESCRIPTION
This PR updates the Codecov bundler plugin version to the latest version `beta-8`, in this latest version we've enhanced the debugging of commit sha's so we can better investigate a suspect issue with merge commits in GH and how we're determining what sha to choose.

Also I've modified the build env vars slightly to grab the head commit sha from the pull request event payload, and pass along through to the webpack config as an upload override to Codecov.
