### PR TITLE
feat(insights): support cache.get op in cache module

### DIFF
--- a/static/app/views/performance/cache/settings.ts
+++ b/static/app/views/performance/cache/settings.ts
@@ -19,7 +19,7 @@ export const CHART_HEIGHT = 160;
 export const CACHE_BASE_URL = `/performance/${BASE_URL}`;
 
 export const BASE_FILTERS: SpanMetricsQueryFilters = {
-  'span.op': 'cache.get_item', //  TODO - add more span ops as they become available, we can't use span.module because db.redis is also `cache`
+  'span.op': '[cache.get_item,cache.get]', //  TODO - add more span ops as they become available, we can't use span.module because db.redis is also `cache`
 };
 
 export const ONBOARDING_CONTENT = {

--- a/static/app/views/performance/cache/settings.ts
+++ b/static/app/views/performance/cache/settings.ts
@@ -20,7 +20,7 @@ export const CACHE_BASE_URL = `/performance/${BASE_URL}`;
 
 export const BASE_FILTERS: SpanMetricsQueryFilters = {
   'span.op': '[cache.get_item,cache.get]', //  TODO - add more span ops as they become available, we can't use span.module because db.redis is also `cache`
-};
+}; // TODO - Its akward to construct an array here, mutibleSearch should support array values
 
 export const ONBOARDING_CONTENT = {
   title: t('Start collecting Insights about your Caches!'),

--- a/static/app/views/performance/landing/widgets/components/widgetContainer.spec.tsx
+++ b/static/app/views/performance/landing/widgets/components/widgetContainer.spec.tsx
@@ -1007,7 +1007,7 @@ describe('Performance > Widgets > WidgetContainer', function () {
           noPagination: true,
           per_page: QUERY_LIMIT_PARAM,
           project: ['-42'],
-          query: 'span.op:cache.get_item',
+          query: 'span.op:[cache.get_item,cache.get]',
           statsPeriod: '7d',
           referrer:
             'api.performance.generic-widget-chart.highest-cache--miss-rate-transactions',


### PR DESCRIPTION
SDKs recently started sending `cache.get` span ops