### PR TITLE
feat(charcuterie): Move Baseline Label Back to Bottom

### DIFF
--- a/static/app/views/performance/utils/getIntervalLine.tsx
+++ b/static/app/views/performance/utils/getIntervalLine.tsx
@@ -161,7 +161,7 @@ export function getIntervalLine(
       formatter: `Baseline ${getPerformanceDuration(
         transformedTransaction.aggregate_range_1
       )}`,
-      position: 'insideStartTop',
+      position: 'insideStartBottom',
     };
 
     periodDividingLine.markLine.lineStyle = {


### PR DESCRIPTION
I am moving the label back to the bottom here, it will collide with the line less than if its on the top! The actual rendered chart also looks better than below, but that is an example of what we are working with. Notice how the baseline text isn't hidden by the line.

![image](https://github.com/getsentry/sentry/assets/33237075/59a94710-2feb-4415-a3f4-d017ef86365a)
