### PR TITLE
fix(insights): fix infinite spinner cache module landing

### DIFF
--- a/static/app/views/performance/cache/cacheLandingPage.tsx
+++ b/static/app/views/performance/cache/cacheLandingPage.tsx
@@ -103,6 +103,9 @@ export function CacheLandingPage() {
     Referrer.LANDING_CACHE_TRANSACTION_LIST
   );
 
+  const enableTransactionDuration =
+    !isTransactionsListLoading && transactionsList.length > 0;
+
   const {
     data: transactionDurationData,
     error: transactionDurationError,
@@ -112,7 +115,7 @@ export function CacheLandingPage() {
     {
       search: `transaction:[${transactionsList.map(({transaction}) => `"${transaction}"`).join(',')}]`,
       fields: [`avg(transaction.duration)`, 'transaction'],
-      enabled: !isTransactionsListLoading && transactionsList.length > 0,
+      enabled: enableTransactionDuration,
     },
     Referrer.LANDING_CACHE_TRANSACTION_DURATION
   );
@@ -194,7 +197,10 @@ export function CacheLandingPage() {
               <ModuleLayout.Full>
                 <TransactionsTable
                   data={transactionsListWithDuration}
-                  isLoading={isTransactionsListLoading || isTransactionDurationLoading}
+                  isLoading={
+                    isTransactionsListLoading ||
+                    (enableTransactionDuration && isTransactionDurationLoading)
+                  }
                   sort={sort}
                   error={transactionsListError || transactionDurationError}
                   meta={meta}

--- a/static/app/views/performance/cache/cacheLandingPage.tsx
+++ b/static/app/views/performance/cache/cacheLandingPage.tsx
@@ -78,7 +78,7 @@ export function CacheLandingPage() {
   );
 
   const {
-    isLoading: isTransactionsListLoading,
+    isFetching: isTransactionsListFetching,
     data: transactionsList,
     meta: transactionsListMeta,
     error: transactionsListError,
@@ -103,19 +103,16 @@ export function CacheLandingPage() {
     Referrer.LANDING_CACHE_TRANSACTION_LIST
   );
 
-  const enableTransactionDuration =
-    !isTransactionsListLoading && transactionsList.length > 0;
-
   const {
     data: transactionDurationData,
     error: transactionDurationError,
     meta: transactionDurationMeta,
-    isLoading: isTransactionDurationLoading,
+    isFetching: isTransactionDurationFetching,
   } = useMetrics(
     {
       search: `transaction:[${transactionsList.map(({transaction}) => `"${transaction}"`).join(',')}]`,
       fields: [`avg(transaction.duration)`, 'transaction'],
-      enabled: enableTransactionDuration,
+      enabled: !isTransactionsListFetching && transactionsList.length > 0,
     },
     Referrer.LANDING_CACHE_TRANSACTION_DURATION
   );
@@ -197,10 +194,7 @@ export function CacheLandingPage() {
               <ModuleLayout.Full>
                 <TransactionsTable
                   data={transactionsListWithDuration}
-                  isLoading={
-                    isTransactionsListLoading ||
-                    (enableTransactionDuration && isTransactionDurationLoading)
-                  }
+                  isLoading={isTransactionsListFetching || isTransactionDurationFetching}
                   sort={sort}
                   error={transactionsListError || transactionDurationError}
                   meta={meta}


### PR DESCRIPTION
The cache landing page table would contain an infinite spinner if no data is available.
This is because the table requires two requests to populate, if the first request has no data, the second requests would still be in the `loading` state.

~~Also, if anybody remembers a more elegant way to do this, lmk! I feel like this is came up a few times~~