### PR TITLE
feat(insights): render full span description in cache samples

### DIFF
--- a/static/app/views/performance/cache/tables/spanSamplesTable.tsx
+++ b/static/app/views/performance/cache/tables/spanSamplesTable.tsx
@@ -49,12 +49,12 @@ const COLUMN_ORDER: Column[] = [
   },
   {
     key: SpanIndexedField.SPAN_DESCRIPTION,
-    name: t('Key'),
+    name: t('Span Description'),
     width: COL_WIDTH_UNDEFINED,
   },
   {
     key: 'transaction.duration',
-    name: t('Txn Duration'),
+    name: t('Transaction Duration'),
     width: COL_WIDTH_UNDEFINED,
   },
   {
@@ -137,8 +137,9 @@ function renderBodyCell(
   }
 
   if (column.key === SpanIndexedField.SPAN_DESCRIPTION) {
-    const cacheKey = row[column.key].split(' ')[1]; // TODO - test with multiple keys
-    return <SpanDescriptionCell>{cacheKey}</SpanDescriptionCell>;
+    return (
+      <SpanDescriptionCell>{row[SpanIndexedField.SPAN_DESCRIPTION]}</SpanDescriptionCell>
+    );
   }
 
   if (column.key === SpanIndexedField.CACHE_HIT) {

--- a/static/app/views/starfish/views/spans/types.tsx
+++ b/static/app/views/starfish/views/spans/types.tsx
@@ -25,8 +25,7 @@ export type DataKey =
   | 'httpCodeBreakdown'
   | 'cacheMissRate'
   | 'avg(cache.item_size)'
-  | 'transaction.duration'
-  | 'cache.item_size';
+  | 'transaction.duration';
 
 export const DataTitles: Record<DataKey, string> = {
   change: t('Change'),
@@ -52,7 +51,6 @@ export const DataTitles: Record<DataKey, string> = {
   httpCodeBreakdown: t('Response Code Breakdown'),
   cacheMissRate: t('Miss Rate'),
   'transaction.duration': t('Transaction Duration'),
-  'cache.item_size': t('Value Size'),
 };
 
 export const getThroughputTitle = (

--- a/static/app/views/starfish/views/spans/types.tsx
+++ b/static/app/views/starfish/views/spans/types.tsx
@@ -25,7 +25,8 @@ export type DataKey =
   | 'httpCodeBreakdown'
   | 'cacheMissRate'
   | 'avg(cache.item_size)'
-  | 'transaction.duration';
+  | 'transaction.duration'
+  | 'cache.item_size';
 
 export const DataTitles: Record<DataKey, string> = {
   change: t('Change'),
@@ -51,6 +52,7 @@ export const DataTitles: Record<DataKey, string> = {
   httpCodeBreakdown: t('Response Code Breakdown'),
   cacheMissRate: t('Miss Rate'),
   'transaction.duration': t('Transaction Duration'),
+  'cache.item_size': t('Value Size'),
 };
 
 export const getThroughputTitle = (


### PR DESCRIPTION
We're thinking we should just render the entire span description instead of the key. Reason being
1. In most cases, the span description is the key anyways
2. In manually instrumented cases, you might set your span description to something that has more meaning, like `User auth cache`, which in this case it would be a lot more interesting to know the auth cache is missing vs the key itself!