### PR TITLE
fix(perf): Adjust transaction name search period

### DIFF
--- a/static/app/components/performance/searchBar.tsx
+++ b/static/app/components/performance/searchBar.tsx
@@ -9,6 +9,7 @@ import {t} from 'sentry/locale';
 import type {Organization} from 'sentry/types/organization';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {browserHistory} from 'sentry/utils/browserHistory';
+import {parsePeriodToHours} from 'sentry/utils/dates';
 import type EventView from 'sentry/utils/discover/eventView';
 import {doDiscoverQuery} from 'sentry/utils/discover/genericDiscoverQuery';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
@@ -20,6 +21,8 @@ import {transactionSummaryRouteWithQuery} from 'sentry/views/performance/transac
 import SearchDropdown from '../smartSearchBar/searchDropdown';
 import type {SearchGroup} from '../smartSearchBar/types';
 import {ItemType} from '../smartSearchBar/types';
+
+const TRANSACTION_SEARCH_PERIOD = '14d';
 
 export type SearchBarProps = {
   eventView: EventView;
@@ -148,6 +151,15 @@ function SearchBar(props: SearchBarProps) {
           if (Object.keys(api.activeRequests).length) {
             api.clear();
           }
+          const parsedPeriodHours = eventView.statsPeriod
+            ? parsePeriodToHours(eventView.statsPeriod)
+            : 0;
+          const parsedDefaultHours = parsePeriodToHours(TRANSACTION_SEARCH_PERIOD);
+
+          const statsPeriod =
+            parsedDefaultHours > parsedPeriodHours
+              ? TRANSACTION_SEARCH_PERIOD
+              : eventView.statsPeriod;
 
           const [results] = await doDiscoverQuery<{
             data: DataItem[];
@@ -156,7 +168,7 @@ function SearchBar(props: SearchBarProps) {
             project: projectIdStrings,
             sort: '-count()',
             query: conditions.formatString(),
-            statsPeriod: eventView.statsPeriod,
+            statsPeriod,
             referrer: 'api.performance.transaction-name-search-bar',
           });
 


### PR DESCRIPTION
### Summary
This will set a minimum stats period so we don't have cases where you can find an intermittent transaction at low values (eg. 1h). This should eventually be replaced by a materialized view for unique transaction names across all times for faster lookup / completedness, but this is just a quick fix.
