### PR TITLE
chore(hybridcloud) Add non-tuple returns to notification methods

### DIFF
--- a/src/sentry/services/hybrid_cloud/integration/model.py
+++ b/src/sentry/services/hybrid_cloud/integration/model.py
@@ -83,3 +83,13 @@ class RpcIntegrationIdentityContext(RpcModel):
     identity_provider: RpcIdentityProvider | None
     identity: RpcIdentity | None
     user: RpcUser | None
+
+
+class RpcOrganizationContext(RpcModel):
+    integration: RpcIntegration | None
+    organization_integration: RpcOrganizationIntegration | None
+
+
+class RpcOrganizationContextList(RpcModel):
+    integration: RpcIntegration | None
+    organization_integrations: list[RpcOrganizationIntegration]

--- a/src/sentry/services/hybrid_cloud/integration/service.py
+++ b/src/sentry/services/hybrid_cloud/integration/service.py
@@ -141,6 +141,8 @@ class IntegrationService(RpcService):
         """
         Returns a tuple of RpcIntegration and RpcOrganizationIntegration. The integration is selected
         by either integration_id, or a combination of provider and external_id.
+
+        :deprecated: Use organization_context() instead.
         """
 
     @rpc_method
@@ -156,6 +158,8 @@ class IntegrationService(RpcService):
         """
         Returns a tuple of RpcIntegration and RpcOrganizationIntegrations. The integrations are selected
         by either integration_id, or a combination of provider and external_id.
+
+        :deprecated: Use organization_contexts() instead.
         """
 
     @rpc_method


### PR DESCRIPTION
Add new RPC methods that don't return tuples. Methods with tuple returns are not compatible with our RPC schema validation and need to be phased out.

Refs HC-1190