### PR TITLE
feat(profiling): enable profiling measurement charts if measurements are sent

### DIFF
--- a/static/app/components/profiling/flamegraph/flamegraph.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraph.tsx
@@ -240,18 +240,28 @@ function Flamegraph(): ReactElement {
 
   const hasBatteryChart = useMemo(() => {
     const platform = profileGroup.metadata.platform;
-    return platform === 'cocoa';
-  }, [profileGroup.metadata.platform]);
+    return platform === 'cocoa' || profileGroup.measurements?.cpu_energy_usage;
+  }, [profileGroup.metadata.platform, profileGroup.measurements]);
 
   const hasCPUChart = useMemo(() => {
     const platform = profileGroup.metadata.platform;
-    return platform === 'cocoa' || platform === 'android' || platform === 'node';
-  }, [profileGroup.metadata.platform]);
+    return (
+      platform === 'cocoa' ||
+      platform === 'android' ||
+      platform === 'node' ||
+      profileGroup.measurements?.cpu_usage
+    );
+  }, [profileGroup.metadata.platform, profileGroup.measurements]);
 
   const hasMemoryChart = useMemo(() => {
     const platform = profileGroup.metadata.platform;
-    return platform === 'cocoa' || platform === 'android' || platform === 'node';
-  }, [profileGroup.metadata.platform]);
+    return (
+      platform === 'cocoa' ||
+      platform === 'android' ||
+      platform === 'node' ||
+      profileGroup.measurements?.memory_footprint
+    );
+  }, [profileGroup.metadata.platform, profileGroup.measurements]);
 
   const profile = useMemo(() => {
     return profileGroup.profiles.find(p => p.threadId === threadId);


### PR DESCRIPTION
React native uses javascript as the platform value which is used both by browser sdk which doesnt report cpu and memory measures. This means we cant know ahead of time if we expect the measurements and simply enable the charts (this toggles loading and the various no measurement states). 

In order to not enable these charts for browser SDKs and confuse users, we take a different approach and enable the charts on demand, once the data has loaded. We miss out on some of the loading states, but this all happens pretty fast as the profile loads, so I dont think it's a big deal in terms of UX.

Fixes https://github.com/getsentry/sentry/issues/59989