### PR TITLE
fix: use orjson.OPT_UTC_Z for dates

### DIFF
--- a/src/sentry/api/serializers/models/app_platform_event.py
+++ b/src/sentry/api/serializers/models/app_platform_event.py
@@ -39,7 +39,8 @@ class AppPlatformEvent:
                 "installation": {"uuid": self.install.uuid},
                 "data": self.data,
                 "actor": self.get_actor(),
-            }
+            },
+            option=orjson.OPT_UTC_Z,
         ).decode()
 
     @property


### PR DESCRIPTION
serializing dates differently might be the root cause of signature mismatch.