### PR TITLE
feat(traces): Add span status to trace explorer

### DIFF
--- a/static/app/views/performance/traces/content.tsx
+++ b/static/app/views/performance/traces/content.tsx
@@ -37,6 +37,7 @@ import {type Field, FIELDS, SORTS} from './data';
 import {
   ProjectRenderer,
   SpanBreakdownSliceRenderer,
+  SpanDescriptionRenderer,
   SpanIdRenderer,
   SpanTimeRenderer,
   TraceBreakdownContainer,
@@ -354,12 +355,7 @@ function SpanRow({
         />
       </StyledSpanPanelItem>
       <StyledSpanPanelItem align="left" overflow>
-        <Description>
-          <ProjectRenderer projectSlug={span.project} hideName />
-          <strong>{span['span.op']}</strong>
-          <em>{'\u2014'}</em>
-          {span['span.description']}
-        </Description>
+        <SpanDescriptionRenderer span={span} />
       </StyledSpanPanelItem>
       <StyledSpanPanelItem align="right" onMouseLeave={() => setHighlightedSliceName('')}>
         <TraceBreakdownContainer>

--- a/static/app/views/performance/traces/data.tsx
+++ b/static/app/views/performance/traces/data.tsx
@@ -7,6 +7,7 @@ export const FIELDS = [
   'sdk.name',
   'span.description',
   'span.duration',
+  'span.status',
   'span.self_time',
   'precise.start_ts',
   'precise.finish_ts',

--- a/static/app/views/starfish/types.tsx
+++ b/static/app/views/starfish/types.tsx
@@ -174,6 +174,7 @@ export enum SpanIndexedField {
   SPAN_GROUP = 'span.group', // Span group computed from the normalized description. Matches the group in the metrics data set
   SPAN_MODULE = 'span.module',
   SPAN_DESCRIPTION = 'span.description',
+  SPAN_STATUS = 'span.status',
   SPAN_OP = 'span.op',
   ID = 'span_id',
   SPAN_ACTION = 'span.action',
@@ -222,6 +223,24 @@ export type IndexedResponse = {
   [SpanIndexedField.SPAN_DESCRIPTION]: string;
   [SpanIndexedField.SPAN_OP]: string;
   [SpanIndexedField.SPAN_AI_PIPELINE_GROUP]: string;
+  [SpanIndexedField.SPAN_STATUS]:
+    | 'ok'
+    | 'cancelled'
+    | 'unknown'
+    | 'invalid_argument'
+    | 'deadline_exceeded'
+    | 'not_found'
+    | 'already_exists'
+    | 'permission_denied'
+    | 'resource_exhausted'
+    | 'failed_precondition'
+    | 'aborted'
+    | 'out_of_range'
+    | 'unimplemented'
+    | 'internal_error'
+    | 'unavailable'
+    | 'data_loss'
+    | 'unauthenticated';
   [SpanIndexedField.ID]: string;
   [SpanIndexedField.SPAN_ACTION]: string;
   [SpanIndexedField.TRACE]: string;


### PR DESCRIPTION
### Summary
This adds a span.status to both the search and as a tag in trace explorer.

#### Screenshot
![Screenshot 2024-05-21 at 2 11 53 PM](https://github.com/getsentry/sentry/assets/6111995/33058d26-c763-45a6-a68d-693d5bdc6d46)
