### PR TITLE
refactor: use UTC_Z for several orjson.dumps usages

### DIFF
--- a/src/sentry/api/client.py
+++ b/src/sentry/api/client.py
@@ -56,7 +56,7 @@ class ApiClient:
         if data:
             # TODO(@anonrig): Investigate why we are doing this?
             # we encode to ensure compatibility
-            data = orjson.loads(orjson.dumps(data))
+            data = orjson.loads(orjson.dumps(data, option=orjson.OPT_UTC_Z))
 
         rf = APIRequestFactory()
         mock_request = getattr(rf, method.lower())(full_path, data or {})

--- a/src/sentry/api/endpoints/event_grouping_info.py
+++ b/src/sentry/api/endpoints/event_grouping_info.py
@@ -31,4 +31,6 @@ class EventGroupingInfoEndpoint(ProjectEndpoint):
 
         grouping_info = get_grouping_info(request.GET.get("config", None), project, event)
 
-        return HttpResponse(orjson.dumps(grouping_info), content_type="application/json")
+        return HttpResponse(
+            orjson.dumps(grouping_info, option=orjson.OPT_UTC_Z), content_type="application/json"
+        )

--- a/src/sentry/api/endpoints/organization_transaction_anomaly_detection.py
+++ b/src/sentry/api/endpoints/organization_transaction_anomaly_detection.py
@@ -31,7 +31,7 @@ def get_anomalies(snuba_io):
     response = ads_connection_pool.urlopen(
         "POST",
         "/anomaly/predict",
-        body=orjson.dumps(snuba_io),
+        body=orjson.dumps(snuba_io, option=orjson.OPT_UTC_Z),
         headers={"content-type": "application/json;charset=utf-8"},
     )
     return Response(orjson.loads(response.data), status=200)

--- a/src/sentry/api/helpers/autofix.py
+++ b/src/sentry/api/helpers/autofix.py
@@ -28,7 +28,8 @@ def get_project_codebase_indexing_status(project):
                     "organization_id": project.organization.id,
                     "project_id": project.id,
                     "repo": repo,
-                }
+                },
+                option=orjson.OPT_UTC_Z,
             ),
             headers={"content-type": "application/json;charset=utf-8"},
         )

--- a/src/sentry/api/serializers/models/project.py
+++ b/src/sentry/api/serializers/models/project.py
@@ -1011,7 +1011,7 @@ class DetailedProjectSerializer(ProjectWithTeamSerializer):
             serialized_sources = "[]"
         else:
             redacted_sources = redact_source_secrets(sources)
-            serialized_sources = orjson.dumps(redacted_sources).decode()
+            serialized_sources = orjson.dumps(redacted_sources, option=orjson.OPT_UTC_Z).decode()
 
         data.update(
             {


### PR DESCRIPTION
This is in par with the `json.dumps()` behavior. There is no downside of this change, but only safety. As far as I know we don't have any issues but just to make it a little bit more safe, let's use OPT_UTC_Z for dates.