### PR TITLE
fix(feedback): Check to verify that feedback has project, ts is a lie

### DIFF
--- a/static/app/components/feedback/useFetchFeedbackData.tsx
+++ b/static/app/components/feedback/useFetchFeedbackData.tsx
@@ -40,7 +40,9 @@ export default function useFetchFeedbackData({feedbackId}: Props) {
   const {markAsRead} = useMutateFeedback({
     feedbackIds: [feedbackId],
     organization,
-    projectIds: issueData ? [issueData?.project.id] : [],
+    // Typescript is a lie. `project` might be missing if feedback didn't go
+    // through the new ingest pipeline. This can happen in new self-hosted upgrades.
+    projectIds: issueData?.project ? [issueData.project.id] : [],
   });
 
   // TODO: it would be excellent if `PUT /issues/` could return the same data


### PR DESCRIPTION
self-hosted users who recently upgraded noticed that some feedback items were not processed fully, and didn't have the expected project field in the response. This adds an extra check so we don't throw on that line of code.

Typescript in this case, is incorrect. It suggests that project is always present.

Self-hosted users, after the retention period, shouldn't need this line anymore... but we'll have to keep it in the codebase forever because folks can upgrade from an old to new version at anytime.

Fixes https://github.com/getsentry/sentry/issues/69258
Fixes https://github.com/getsentry/sentry/issues/70136