### PR TITLE
fix(performance): Fix queues module empty state always displaying when an environment is selected

### DIFF
--- a/static/app/views/performance/onboarding/useHasData.tsx
+++ b/static/app/views/performance/onboarding/useHasData.tsx
@@ -17,7 +17,7 @@ export function useHasData(mutableSearch: MutableSearch, referrer: string) {
   const {data, isLoading, error} = useSpanMetrics(
     {
       search: mutableSearch,
-      fields: ['count()'],
+      fields: ['count()', 'transaction'],
       pageFilters: ninetyDayPageFilters,
     },
     referrer


### PR DESCRIPTION
Updates the `useHasData` to also query for `transaction` in order to force discover to use the non light `exclusive_time` metric. `exclusive_time_light` doesn't have an `environment` tag on the queues module, so this is a work around.