### PR TITLE
test(ui): Remove mock useOrganization

### DIFF
--- a/static/app/components/modals/inviteMembersModal/index.spec.tsx
+++ b/static/app/components/modals/inviteMembersModal/index.spec.tsx
@@ -12,9 +12,6 @@ import InviteMembersModal from 'sentry/components/modals/inviteMembersModal';
 import {ORG_ROLES} from 'sentry/constants';
 import TeamStore from 'sentry/stores/teamStore';
 import type {DetailedTeam, Scope} from 'sentry/types';
-import useOrganization from 'sentry/utils/useOrganization';
-
-jest.mock('sentry/utils/useOrganization');
 
 describe('InviteMembersModal', function () {
   const styledWrapper = styled(c => c.children);
@@ -84,9 +81,11 @@ describe('InviteMembersModal', function () {
     mockApiResponses.forEach(mockApiResponse => {
       mocks.push(mockApiResponse(MockApiClient, org.slug, roles));
     });
-    jest.mocked(useOrganization).mockReturnValue(org);
 
-    return {...render(<InviteMembersModal {...modalProps} />), mocks};
+    return {
+      ...render(<InviteMembersModal {...modalProps} />, {organization: org}),
+      mocks,
+    };
   };
 
   const setupMemberInviteState = async () => {

--- a/static/app/utils/replays/hooks/useActiveReplayTab.spec.tsx
+++ b/static/app/utils/replays/hooks/useActiveReplayTab.spec.tsx
@@ -1,16 +1,13 @@
 import type {Location} from 'history';
-import {OrganizationFixture} from 'sentry-fixture/organization';
 
 import {renderHook} from 'sentry-test/reactTestingLibrary';
 
 import {browserHistory} from 'sentry/utils/browserHistory';
 import useActiveReplayTab, {TabKey} from 'sentry/utils/replays/hooks/useActiveReplayTab';
 import {useLocation} from 'sentry/utils/useLocation';
-import useOrganization from 'sentry/utils/useOrganization';
 
 jest.mock('react-router');
 jest.mock('sentry/utils/useLocation');
-jest.mock('sentry/utils/useOrganization');
 
 const mockPush = jest.mocked(browserHistory.push);
 
@@ -26,15 +23,9 @@ function mockLocation(query: string = '') {
   } as Location);
 }
 
-function mockOrganizationFixture(props?: {features: string[]}) {
-  const features = props?.features ?? [];
-  jest.mocked(useOrganization).mockReturnValue(OrganizationFixture({features}));
-}
-
 describe('useActiveReplayTab', () => {
   beforeEach(() => {
     mockLocation();
-    mockOrganizationFixture();
     mockPush.mockReset();
   });
 

--- a/static/app/views/issueDetails/groupActivity.spec.tsx
+++ b/static/app/views/issueDetails/groupActivity.spec.tsx
@@ -23,10 +23,7 @@ import ProjectsStore from 'sentry/stores/projectsStore';
 import TeamStore from 'sentry/stores/teamStore';
 import type {Group, Organization as TOrganization, Project} from 'sentry/types';
 import {GroupActivityType, PriorityLevel} from 'sentry/types';
-import useOrganization from 'sentry/utils/useOrganization';
 import GroupActivity from 'sentry/views/issueDetails/groupActivity';
-
-jest.mock('sentry/utils/useOrganization');
 
 describe('GroupActivity', function () {
   let project!: Project;
@@ -69,13 +66,12 @@ describe('GroupActivity', function () {
     const {organization, routerContext, routerProps} = initializeOrg({
       organization: additionalOrg,
     });
-    jest.mocked(useOrganization).mockReturnValue(organization);
     GroupStore.add([group]);
     TeamStore.loadInitialData([TeamFixture({id: '999', slug: 'no-team'})]);
     OrganizationStore.onUpdate(organization, {replace: true});
     return render(
       <GroupActivity {...routerProps} params={{orgId: 'org-slug'}} group={group} />,
-      {context: routerContext}
+      {context: routerContext, organization}
     );
   }
 

--- a/static/app/views/performance/browser/resources/index.spec.tsx
+++ b/static/app/views/performance/browser/resources/index.spec.tsx
@@ -4,7 +4,6 @@ import {render, screen, waitForElementToBeRemoved} from 'sentry-test/reactTestin
 
 import type {DetailedOrganization} from 'sentry/types';
 import {useLocation} from 'sentry/utils/useLocation';
-import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import ResourcesLandingPage from 'sentry/views/performance/browser/resources';
 import {SpanFunction, SpanMetricsField} from 'sentry/views/starfish/types';
@@ -23,7 +22,6 @@ const {SPM, TIME_SPENT_PERCENTAGE} = SpanFunction;
 
 jest.mock('sentry/utils/useLocation');
 jest.mock('sentry/utils/usePageFilters');
-jest.mock('sentry/utils/useOrganization');
 
 const requestMocks: Record<string, jest.Mock> = {};
 
@@ -33,7 +31,7 @@ describe('ResourcesLandingPage', function () {
   });
 
   beforeEach(() => {
-    setupMocks(organization);
+    setupMocks();
     setupMockRequests(organization);
   });
 
@@ -42,7 +40,7 @@ describe('ResourcesLandingPage', function () {
   });
 
   it('renders a list of resources', async () => {
-    render(<ResourcesLandingPage />);
+    render(<ResourcesLandingPage />, {organization});
     await waitForElementToBeRemoved(() => screen.queryAllByTestId('loading-indicator'));
 
     expect(
@@ -55,7 +53,7 @@ describe('ResourcesLandingPage', function () {
   });
 
   it('contains correct query in charts', async () => {
-    render(<ResourcesLandingPage />);
+    render(<ResourcesLandingPage />, {organization});
     await waitForElementToBeRemoved(() => screen.queryAllByTestId('loading-indicator'));
 
     expect(requestMocks.mainTable.mock.calls).toMatchInlineSnapshot(`
@@ -96,7 +94,7 @@ describe('ResourcesLandingPage', function () {
   });
 });
 
-const setupMocks = (organization: DetailedOrganization) => {
+const setupMocks = () => {
   jest.mocked(usePageFilters).mockReturnValue({
     isReady: true,
     desyncedFilters: new Set(),
@@ -123,8 +121,6 @@ const setupMocks = (organization: DetailedOrganization) => {
     action: 'PUSH',
     key: '',
   });
-
-  jest.mocked(useOrganization).mockReturnValue(organization);
 };
 
 const setupMockRequests = (organization: DetailedOrganization) => {

--- a/static/app/views/performance/browser/resources/resourceSummaryPage/sampleImages.spec.tsx
+++ b/static/app/views/performance/browser/resources/resourceSummaryPage/sampleImages.spec.tsx
@@ -6,7 +6,6 @@ import {render, screen, waitForElementToBeRemoved} from 'sentry-test/reactTestin
 import ProjectsStore from 'sentry/stores/projectsStore';
 import type {DetailedOrganization} from 'sentry/types';
 import {useLocation} from 'sentry/utils/useLocation';
-import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import SampleImages from 'sentry/views/performance/browser/resources/resourceSummaryPage/sampleImages';
 import {SpanIndexedField} from 'sentry/views/starfish/types';
@@ -16,7 +15,6 @@ const {SPAN_GROUP, HTTP_RESPONSE_CONTENT_LENGTH, RAW_DOMAIN, SPAN_DESCRIPTION} =
 
 jest.mock('sentry/utils/useLocation');
 jest.mock('sentry/utils/usePageFilters');
-jest.mock('sentry/utils/useOrganization');
 
 describe('SampleImages', function () {
   const organization = OrganizationFixture({
@@ -24,7 +22,7 @@ describe('SampleImages', function () {
   });
 
   beforeEach(() => {
-    setupMocks(organization);
+    setupMocks();
   });
 
   afterEach(function () {
@@ -36,7 +34,7 @@ describe('SampleImages', function () {
       setupMockRequests(organization, {enableImages: true});
     });
     it('should render images', async () => {
-      render(<SampleImages groupId="group123" projectId={2} />);
+      render(<SampleImages groupId="group123" projectId={2} />, {organization});
       await waitForElementToBeRemoved(() => screen.queryAllByTestId('loading-indicator'));
 
       const sampleImages = screen.queryAllByTestId('sample-image');
@@ -52,7 +50,7 @@ describe('SampleImages', function () {
     });
 
     it('should ask to enable images', async () => {
-      render(<SampleImages groupId="group123" projectId={2} />);
+      render(<SampleImages groupId="group123" projectId={2} />, {organization});
       await waitForElementToBeRemoved(() => screen.queryAllByTestId('loading-indicator'));
       expect(screen.queryByTestId('sample-image')).not.toBeInTheDocument();
       expect(screen.queryByTestId('enable-sample-images-button')).toBeInTheDocument();
@@ -60,7 +58,7 @@ describe('SampleImages', function () {
   });
 });
 
-const setupMocks = (organization: DetailedOrganization) => {
+const setupMocks = () => {
   const mockProjects = [ProjectFixture()];
   ProjectsStore.loadInitialData(mockProjects);
 
@@ -90,8 +88,6 @@ const setupMocks = (organization: DetailedOrganization) => {
     action: 'PUSH',
     key: '',
   });
-
-  jest.mocked(useOrganization).mockReturnValue(organization);
 };
 
 const setupMockRequests = (

--- a/static/app/views/performance/browser/webVitals/components/performanceScoreBreakdownChart.spec.tsx
+++ b/static/app/views/performance/browser/webVitals/components/performanceScoreBreakdownChart.spec.tsx
@@ -3,7 +3,6 @@ import {OrganizationFixture} from 'sentry-fixture/organization';
 import {render, screen, waitForElementToBeRemoved} from 'sentry-test/reactTestingLibrary';
 
 import {useLocation} from 'sentry/utils/useLocation';
-import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import {
   formatTimeSeriesResultsToChartData,
@@ -12,7 +11,6 @@ import {
 
 jest.mock('sentry/utils/useLocation');
 jest.mock('sentry/utils/usePageFilters');
-jest.mock('sentry/utils/useOrganization');
 
 describe('PerformanceScoreBreakdownChart', function () {
   const organization = OrganizationFixture();
@@ -44,7 +42,6 @@ describe('PerformanceScoreBreakdownChart', function () {
         projects: [],
       },
     });
-    jest.mocked(useOrganization).mockReturnValue(organization);
 
     eventsMock = MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/events/`,
@@ -63,7 +60,7 @@ describe('PerformanceScoreBreakdownChart', function () {
   });
 
   it('renders using frontend score calculation', async () => {
-    render(<PerformanceScoreBreakdownChart />);
+    render(<PerformanceScoreBreakdownChart />, {organization});
     await waitForElementToBeRemoved(() => screen.getByTestId('loading-indicator'));
     expect(eventsStatsMock).toHaveBeenCalledWith(
       '/organizations/org-slug/events-stats/',
@@ -95,7 +92,7 @@ describe('PerformanceScoreBreakdownChart', function () {
       action: 'PUSH',
       key: '',
     });
-    render(<PerformanceScoreBreakdownChart />);
+    render(<PerformanceScoreBreakdownChart />, {organization});
     await waitForElementToBeRemoved(() => screen.getByTestId('loading-indicator'));
     expect(eventsMock).toHaveBeenCalledTimes(1);
     expect(eventsMock).toHaveBeenCalledWith(
@@ -178,7 +175,7 @@ describe('PerformanceScoreBreakdownChart', function () {
         projects: [],
       },
     });
-    render(<PerformanceScoreBreakdownChart />);
+    render(<PerformanceScoreBreakdownChart />, {organization});
     await waitForElementToBeRemoved(() => screen.getByTestId('loading-indicator'));
     expect(eventsMock).toHaveBeenCalledTimes(1);
     expect(eventsStatsMock).toHaveBeenCalledTimes(2);

--- a/static/app/views/performance/browser/webVitals/components/performanceScoreRingWithTooltips.spec.tsx
+++ b/static/app/views/performance/browser/webVitals/components/performanceScoreRingWithTooltips.spec.tsx
@@ -2,12 +2,9 @@ import {OrganizationFixture} from 'sentry-fixture/organization';
 
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
-import useOrganization from 'sentry/utils/useOrganization';
 import PerformanceScoreRingWithTooltips from 'sentry/views/performance/browser/webVitals/components/performanceScoreRingWithTooltips';
 
-jest.mock('sentry/utils/useOrganization');
 describe('PerformanceScoreRingWithTooltips', function () {
-  const organization = OrganizationFixture();
   const projectScore = {
     lcpScore: 74,
     fcpScore: 92,
@@ -23,14 +20,6 @@ describe('PerformanceScoreRingWithTooltips', function () {
     fidWeight: 5,
     inpWeight: 5,
   };
-
-  beforeEach(function () {
-    jest.mocked(useOrganization).mockReturnValue(organization);
-  });
-
-  afterEach(function () {
-    jest.resetAllMocks();
-  });
 
   it('renders segment labels', async () => {
     render(
@@ -53,7 +42,6 @@ describe('PerformanceScoreRingWithTooltips', function () {
 
   it('renders inp', async () => {
     const organizationWithInp = OrganizationFixture();
-    jest.mocked(useOrganization).mockReturnValue(organizationWithInp);
     render(
       <PerformanceScoreRingWithTooltips
         weights={{lcp: 38, fcp: 23, cls: 18, ttfb: 16, fid: 0, inp: 10}}
@@ -63,7 +51,8 @@ describe('PerformanceScoreRingWithTooltips', function () {
         ringBackgroundColors={['#444674', '#895289', '#d6567f', '#f38150', '#f2b712']}
         ringSegmentColors={['#444674', '#895289', '#d6567f', '#f38150', '#f2b712']}
         text={undefined}
-      />
+      />,
+      {organization: organizationWithInp}
     );
     await screen.findByText('inp');
     screen.getByText('fcp');

--- a/static/app/views/performance/browser/webVitals/components/webVitalMeters.spec.tsx
+++ b/static/app/views/performance/browser/webVitals/components/webVitalMeters.spec.tsx
@@ -4,14 +4,12 @@ import {render, screen} from 'sentry-test/reactTestingLibrary';
 
 import type {TableData} from 'sentry/utils/discover/discoverQuery';
 import {useLocation} from 'sentry/utils/useLocation';
-import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import WebVitalMeters from 'sentry/views/performance/browser/webVitals/components/webVitalMeters';
 import type {ProjectScore} from 'sentry/views/performance/browser/webVitals/utils/types';
 
 jest.mock('sentry/utils/useLocation');
 jest.mock('sentry/utils/usePageFilters');
-jest.mock('sentry/utils/useOrganization');
 
 describe('WebVitalMeters', function () {
   const organization = OrganizationFixture();
@@ -53,11 +51,12 @@ describe('WebVitalMeters', function () {
         projects: [],
       },
     });
-    jest.mocked(useOrganization).mockReturnValue(organization);
   });
 
   it('renders web vital meters with interaction to next paint', async () => {
-    render(<WebVitalMeters projectData={projectData} projectScore={projectScore} />);
+    render(<WebVitalMeters projectData={projectData} projectScore={projectScore} />, {
+      organization,
+    });
     await screen.findByText('Largest Contentful Paint');
     screen.getByText('First Contentful Paint');
     screen.getByText('Cumulative Layout Shift');

--- a/static/app/views/performance/browser/webVitals/pageOverview.spec.tsx
+++ b/static/app/views/performance/browser/webVitals/pageOverview.spec.tsx
@@ -3,13 +3,11 @@ import {OrganizationFixture} from 'sentry-fixture/organization';
 import {render, screen, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import {useLocation} from 'sentry/utils/useLocation';
-import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import PageOverview from 'sentry/views/performance/browser/webVitals/pageOverview';
 
 jest.mock('sentry/utils/useLocation');
 jest.mock('sentry/utils/usePageFilters');
-jest.mock('sentry/utils/useOrganization');
 
 describe('PageOverview', function () {
   const organization = OrganizationFixture({
@@ -44,8 +42,6 @@ describe('PageOverview', function () {
         projects: [],
       },
     });
-    jest.mocked(useOrganization).mockReturnValue(organization);
-
     eventsMock = MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/events/`,
       body: {
@@ -76,7 +72,7 @@ describe('PageOverview', function () {
       action: 'PUSH',
       key: '',
     });
-    render(<PageOverview />);
+    render(<PageOverview />, {organization});
     await screen.findByText(/\(Interaction to Next Paint\) will replace/);
     await screen.findByText(
       /\(First Input Delay\) in our performance score calculation./
@@ -87,7 +83,6 @@ describe('PageOverview', function () {
     const organizationWithInp = OrganizationFixture({
       features: ['spans-first-ui'],
     });
-    jest.mocked(useOrganization).mockReturnValue(organizationWithInp);
     jest.mocked(useLocation).mockReturnValue({
       pathname: '',
       search: '',
@@ -97,7 +92,7 @@ describe('PageOverview', function () {
       action: 'PUSH',
       key: '',
     });
-    render(<PageOverview />);
+    render(<PageOverview />, {organization: organizationWithInp});
     await waitFor(() =>
       expect(eventsMock).toHaveBeenCalledWith(
         '/organizations/org-slug/events/',
@@ -132,7 +127,6 @@ describe('PageOverview', function () {
     const organizationWithInp = OrganizationFixture({
       features: ['spans-first-ui'],
     });
-    jest.mocked(useOrganization).mockReturnValue(organizationWithInp);
     jest.mocked(useLocation).mockReturnValue({
       pathname: '',
       search: '',
@@ -146,7 +140,7 @@ describe('PageOverview', function () {
       action: 'PUSH',
       key: '',
     });
-    render(<PageOverview />);
+    render(<PageOverview />, {organization: organizationWithInp});
     await waitFor(() =>
       expect(eventsMock).toHaveBeenCalledWith(
         '/organizations/org-slug/events/',

--- a/static/app/views/performance/browser/webVitals/pagePerformanceTable.spec.tsx
+++ b/static/app/views/performance/browser/webVitals/pagePerformanceTable.spec.tsx
@@ -3,13 +3,11 @@ import {OrganizationFixture} from 'sentry-fixture/organization';
 import {render, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import {useLocation} from 'sentry/utils/useLocation';
-import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import {PagePerformanceTable} from 'sentry/views/performance/browser/webVitals/pagePerformanceTable';
 
 jest.mock('sentry/utils/useLocation');
 jest.mock('sentry/utils/usePageFilters');
-jest.mock('sentry/utils/useOrganization');
 
 describe('PagePerformanceTable', function () {
   const organization = OrganizationFixture();
@@ -42,7 +40,6 @@ describe('PagePerformanceTable', function () {
         projects: [],
       },
     });
-    jest.mocked(useOrganization).mockReturnValue(organization);
     eventsMock = MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/events/`,
       body: {
@@ -65,7 +62,7 @@ describe('PagePerformanceTable', function () {
       action: 'PUSH',
       key: '',
     });
-    render(<PagePerformanceTable />);
+    render(<PagePerformanceTable />, {organization});
     await waitFor(() => {
       expect(eventsMock).toHaveBeenCalledTimes(2);
       expect(eventsMock).toHaveBeenLastCalledWith(

--- a/static/app/views/performance/browser/webVitals/webVitalsDetailPanel.spec.tsx
+++ b/static/app/views/performance/browser/webVitals/webVitalsDetailPanel.spec.tsx
@@ -3,13 +3,11 @@ import {OrganizationFixture} from 'sentry-fixture/organization';
 import {render, screen, waitForElementToBeRemoved} from 'sentry-test/reactTestingLibrary';
 
 import {useLocation} from 'sentry/utils/useLocation';
-import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import {WebVitalsDetailPanel} from 'sentry/views/performance/browser/webVitals/webVitalsDetailPanel';
 
 jest.mock('sentry/utils/useLocation');
 jest.mock('sentry/utils/usePageFilters');
-jest.mock('sentry/utils/useOrganization');
 
 describe('WebVitalsDetailPanel', function () {
   const organization = OrganizationFixture();
@@ -41,7 +39,6 @@ describe('WebVitalsDetailPanel', function () {
         projects: [],
       },
     });
-    jest.mocked(useOrganization).mockReturnValue(organization);
 
     eventsMock = MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/events/`,
@@ -60,7 +57,9 @@ describe('WebVitalsDetailPanel', function () {
   });
 
   it('renders correctly with empty results', async () => {
-    render(<WebVitalsDetailPanel onClose={() => undefined} webVital="lcp" />);
+    render(<WebVitalsDetailPanel onClose={() => undefined} webVital="lcp" />, {
+      organization,
+    });
     await waitForElementToBeRemoved(() => screen.getByTestId('loading-indicator'));
     // Once for project web vitals and once for samples
     expect(eventsMock).toHaveBeenCalledTimes(3);

--- a/static/app/views/performance/browser/webVitals/webVitalsLandingPage.spec.tsx
+++ b/static/app/views/performance/browser/webVitals/webVitalsLandingPage.spec.tsx
@@ -3,13 +3,11 @@ import {OrganizationFixture} from 'sentry-fixture/organization';
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
 import {useLocation} from 'sentry/utils/useLocation';
-import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import WebVitalsLandingPage from 'sentry/views/performance/browser/webVitals/webVitalsLandingPage';
 
 jest.mock('sentry/utils/useLocation');
 jest.mock('sentry/utils/usePageFilters');
-jest.mock('sentry/utils/useOrganization');
 
 describe('WebVitalsLandingPage', function () {
   const organization = OrganizationFixture({
@@ -42,7 +40,6 @@ describe('WebVitalsLandingPage', function () {
         projects: [],
       },
     });
-    jest.mocked(useOrganization).mockReturnValue(organization);
 
     MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/events/`,
@@ -70,7 +67,7 @@ describe('WebVitalsLandingPage', function () {
       action: 'PUSH',
       key: '',
     });
-    render(<WebVitalsLandingPage />);
+    render(<WebVitalsLandingPage />, {organization});
     await screen.findByText(/\(Interaction to Next Paint\) will replace/);
     await screen.findByText(
       /\(First Input Delay\) in our performance score calculation./

--- a/static/app/views/performance/database/databaseLandingPage.spec.tsx
+++ b/static/app/views/performance/database/databaseLandingPage.spec.tsx
@@ -3,13 +3,11 @@ import {OrganizationFixture} from 'sentry-fixture/organization';
 import {render, screen, waitForElementToBeRemoved} from 'sentry-test/reactTestingLibrary';
 
 import {useLocation} from 'sentry/utils/useLocation';
-import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import {DatabaseLandingPage} from 'sentry/views/performance/database/databaseLandingPage';
 
 jest.mock('sentry/utils/useLocation');
 jest.mock('sentry/utils/usePageFilters');
-jest.mock('sentry/utils/useOrganization');
 
 describe('DatabaseLandingPage', function () {
   const organization = OrganizationFixture();
@@ -42,8 +40,6 @@ describe('DatabaseLandingPage', function () {
     action: 'PUSH',
     key: '',
   });
-
-  jest.mocked(useOrganization).mockReturnValue(organization);
 
   beforeEach(function () {
     MockApiClient.addMockResponse({
@@ -117,7 +113,7 @@ describe('DatabaseLandingPage', function () {
   it('fetches module data', async function () {
     jest.spyOn(console, 'error').mockImplementation(jest.fn()); // This silences pointless unique key errors that React throws because of the tokenized query descriptions
 
-    render(<DatabaseLandingPage />);
+    render(<DatabaseLandingPage />, {organization});
 
     expect(spanChartsRequestMock).toHaveBeenNthCalledWith(
       1,
@@ -202,7 +198,7 @@ describe('DatabaseLandingPage', function () {
     // eslint-disable-next-line no-console
     jest.spyOn(console, 'error').mockImplementation(jest.fn()); // This silences pointless unique key errors that React throws because of the tokenized query descriptions
 
-    render(<DatabaseLandingPage />);
+    render(<DatabaseLandingPage />, {organization});
 
     await waitForElementToBeRemoved(() => screen.queryAllByTestId('loading-indicator'));
 

--- a/static/app/views/performance/database/databaseSpanSummaryPage.spec.tsx
+++ b/static/app/views/performance/database/databaseSpanSummaryPage.spec.tsx
@@ -4,13 +4,11 @@ import {RouteComponentPropsFixture} from 'sentry-fixture/routeComponentPropsFixt
 import {render, screen, waitForElementToBeRemoved} from 'sentry-test/reactTestingLibrary';
 
 import {useLocation} from 'sentry/utils/useLocation';
-import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import {DatabaseSpanSummaryPage} from 'sentry/views/performance/database/databaseSpanSummaryPage';
 
 jest.mock('sentry/utils/useLocation');
 jest.mock('sentry/utils/usePageFilters');
-jest.mock('sentry/utils/useOrganization');
 
 describe('DatabaseSpanSummaryPage', function () {
   const organization = OrganizationFixture();
@@ -41,8 +39,6 @@ describe('DatabaseSpanSummaryPage', function () {
     action: 'PUSH',
     key: '',
   });
-
-  jest.mocked(useOrganization).mockReturnValue(organization);
 
   beforeEach(function () {
     jest.clearAllMocks();
@@ -135,7 +131,8 @@ describe('DatabaseSpanSummaryPage', function () {
           transactionMethod: '',
           transactionsSort: '',
         }}
-      />
+      />,
+      {organization}
     );
 
     // Metrics ribbon

--- a/static/app/views/performance/http/data/useSpanSamples.spec.tsx
+++ b/static/app/views/performance/http/data/useSpanSamples.spec.tsx
@@ -6,23 +6,26 @@ import {renderHook, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import {QueryClientProvider} from 'sentry/utils/queryClient';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
-import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
+import {OrganizationContext} from 'sentry/views/organizationContext';
 import {useSpanSamples} from 'sentry/views/performance/http/data/useSpanSamples';
 import type {IndexedProperty} from 'sentry/views/starfish/types';
 import {SpanIndexedField} from 'sentry/views/starfish/types';
 
 jest.mock('sentry/utils/usePageFilters');
-jest.mock('sentry/utils/useOrganization');
-
-function Wrapper({children}: {children?: ReactNode}) {
-  return (
-    <QueryClientProvider client={makeTestQueryClient()}>{children}</QueryClientProvider>
-  );
-}
 
 describe('useSpanSamples', () => {
   const organization = OrganizationFixture();
+
+  function Wrapper({children}: {children?: ReactNode}) {
+    return (
+      <QueryClientProvider client={makeTestQueryClient()}>
+        <OrganizationContext.Provider value={organization}>
+          {children}
+        </OrganizationContext.Provider>
+      </QueryClientProvider>
+    );
+  }
 
   jest.mocked(usePageFilters).mockReturnValue({
     isReady: true,
@@ -40,8 +43,6 @@ describe('useSpanSamples', () => {
       projects: [],
     },
   });
-
-  jest.mocked(useOrganization).mockReturnValue(organization);
 
   beforeEach(() => {
     jest.clearAllMocks();

--- a/static/app/views/performance/http/httpDomainSummaryPage.spec.tsx
+++ b/static/app/views/performance/http/httpDomainSummaryPage.spec.tsx
@@ -3,13 +3,11 @@ import {OrganizationFixture} from 'sentry-fixture/organization';
 import {render, screen, waitForElementToBeRemoved} from 'sentry-test/reactTestingLibrary';
 
 import {useLocation} from 'sentry/utils/useLocation';
-import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import {HTTPDomainSummaryPage} from 'sentry/views/performance/http/httpDomainSummaryPage';
 
 jest.mock('sentry/utils/useLocation');
 jest.mock('sentry/utils/usePageFilters');
-jest.mock('sentry/utils/useOrganization');
 
 describe('HTTPSummaryPage', function () {
   const organization = OrganizationFixture();
@@ -43,8 +41,6 @@ describe('HTTPSummaryPage', function () {
     key: '',
   });
 
-  jest.mocked(useOrganization).mockReturnValue(organization);
-
   beforeEach(function () {
     jest.clearAllMocks();
 
@@ -75,7 +71,7 @@ describe('HTTPSummaryPage', function () {
   });
 
   it('fetches module data', async function () {
-    render(<HTTPDomainSummaryPage />);
+    render(<HTTPDomainSummaryPage />, {organization});
 
     expect(domainChartsRequestMock).toHaveBeenNthCalledWith(
       1,
@@ -253,7 +249,7 @@ describe('HTTPSummaryPage', function () {
       },
     });
 
-    render(<HTTPDomainSummaryPage />);
+    render(<HTTPDomainSummaryPage />, {organization});
 
     await waitForElementToBeRemoved(() => screen.queryAllByTestId('loading-indicator'));
 

--- a/static/app/views/performance/http/httpLandingPage.spec.tsx
+++ b/static/app/views/performance/http/httpLandingPage.spec.tsx
@@ -4,14 +4,12 @@ import {ProjectFixture} from 'sentry-fixture/project';
 import {render, screen, waitForElementToBeRemoved} from 'sentry-test/reactTestingLibrary';
 
 import {useLocation} from 'sentry/utils/useLocation';
-import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import useProjects from 'sentry/utils/useProjects';
 import {HTTPLandingPage} from 'sentry/views/performance/http/httpLandingPage';
 
 jest.mock('sentry/utils/useLocation');
 jest.mock('sentry/utils/usePageFilters');
-jest.mock('sentry/utils/useOrganization');
 jest.mock('sentry/utils/useProjects');
 
 describe('HTTPLandingPage', function () {
@@ -45,8 +43,6 @@ describe('HTTPLandingPage', function () {
     action: 'PUSH',
     key: '',
   });
-
-  jest.mocked(useOrganization).mockReturnValue(organization);
 
   jest.mocked(useProjects).mockReturnValue({
     projects: [
@@ -144,7 +140,7 @@ describe('HTTPLandingPage', function () {
   });
 
   it('fetches module data', async function () {
-    render(<HTTPLandingPage />);
+    render(<HTTPLandingPage />, {organization});
 
     expect(spanChartsRequestMock).toHaveBeenNthCalledWith(
       1,
@@ -258,7 +254,7 @@ describe('HTTPLandingPage', function () {
   });
 
   it('renders a list of domains', async function () {
-    render(<HTTPLandingPage />);
+    render(<HTTPLandingPage />, {organization});
 
     await waitForElementToBeRemoved(() => screen.queryAllByTestId('loading-indicator'));
 

--- a/static/app/views/performance/http/httpSamplesPanel.spec.tsx
+++ b/static/app/views/performance/http/httpSamplesPanel.spec.tsx
@@ -8,13 +8,11 @@ import {
 } from 'sentry-test/reactTestingLibrary';
 
 import {useLocation} from 'sentry/utils/useLocation';
-import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import {HTTPSamplesPanel} from 'sentry/views/performance/http/httpSamplesPanel';
 
 jest.mock('sentry/utils/useLocation');
 jest.mock('sentry/utils/usePageFilters');
-jest.mock('sentry/utils/useOrganization');
 
 describe('HTTPSamplesPanel', () => {
   const organization = OrganizationFixture();
@@ -53,8 +51,6 @@ describe('HTTPSamplesPanel', () => {
     action: 'PUSH',
     key: '',
   });
-
-  jest.mocked(useOrganization).mockReturnValue(organization);
 
   beforeEach(() => {
     jest.clearAllMocks();

--- a/static/app/views/performance/mobile/screenload/index.spec.tsx
+++ b/static/app/views/performance/mobile/screenload/index.spec.tsx
@@ -7,14 +7,12 @@ import {render, screen, waitFor} from 'sentry-test/reactTestingLibrary';
 import {browserHistory} from 'sentry/utils/browserHistory';
 import localStorage from 'sentry/utils/localStorage';
 import {useLocation} from 'sentry/utils/useLocation';
-import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import useProjects from 'sentry/utils/useProjects';
 import {useOnboardingProject} from 'sentry/views/performance/browser/webVitals/utils/useOnboardingProject';
 import PageloadModule from 'sentry/views/performance/mobile/screenload';
 import {PLATFORM_LOCAL_STORAGE_KEY} from 'sentry/views/performance/mobile/screenload/screens/platformSelector';
 
-jest.mock('sentry/utils/useOrganization');
 jest.mock('sentry/views/performance/browser/webVitals/utils/useOnboardingProject');
 jest.mock('sentry/utils/useLocation');
 jest.mock('sentry/utils/usePageFilters');
@@ -26,7 +24,6 @@ describe('PageloadModule', function () {
     features: ['spans-first-ui'],
     projects: [project],
   });
-  jest.mocked(useOrganization).mockReturnValue(organization);
   jest.mocked(useOnboardingProject).mockReturnValue(undefined);
 
   jest.mocked(useProjects).mockReturnValue({

--- a/static/app/views/performance/mobile/screenload/screenLoadSpans/index.spec.tsx
+++ b/static/app/views/performance/mobile/screenload/screenLoadSpans/index.spec.tsx
@@ -7,20 +7,17 @@ import {render, screen, waitFor, within} from 'sentry-test/reactTestingLibrary';
 import {browserHistory} from 'sentry/utils/browserHistory';
 import localStorage from 'sentry/utils/localStorage';
 import {useLocation} from 'sentry/utils/useLocation';
-import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import useProjects from 'sentry/utils/useProjects';
 import {useOnboardingProject} from 'sentry/views/performance/browser/webVitals/utils/useOnboardingProject';
 import ScreenLoadSpans from 'sentry/views/performance/mobile/screenload/screenLoadSpans';
 
-jest.mock('sentry/utils/useOrganization');
 jest.mock('sentry/views/performance/browser/webVitals/utils/useOnboardingProject');
 jest.mock('sentry/utils/useLocation');
 jest.mock('sentry/utils/usePageFilters');
 jest.mock('sentry/utils/useProjects');
 
 function mockResponses(organization, project) {
-  jest.mocked(useOrganization).mockReturnValue(organization);
   jest.mocked(useOnboardingProject).mockReturnValue(undefined);
 
   jest.mocked(useProjects).mockReturnValue({

--- a/static/app/views/performance/mobile/screenload/screenLoadSpans/table.spec.tsx
+++ b/static/app/views/performance/mobile/screenload/screenLoadSpans/table.spec.tsx
@@ -5,11 +5,9 @@ import {render, screen, within} from 'sentry-test/reactTestingLibrary';
 
 import {browserHistory} from 'sentry/utils/browserHistory';
 import {useLocation} from 'sentry/utils/useLocation';
-import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import {ScreenLoadSpansTable} from 'sentry/views/performance/mobile/screenload/screenLoadSpans/table';
 
-jest.mock('sentry/utils/useOrganization');
 jest.mock('sentry/utils/useLocation');
 jest.mock('sentry/utils/usePageFilters');
 
@@ -17,7 +15,6 @@ describe('ScreenLoadSpansTable', function () {
   const organization = OrganizationFixture({
     features: ['spans-first-ui'],
   });
-  jest.mocked(useOrganization).mockReturnValue(organization);
 
   jest.mocked(useLocation).mockReturnValue({
     action: 'PUSH',

--- a/static/app/views/performance/queues/charts/latencyChart.spec.tsx
+++ b/static/app/views/performance/queues/charts/latencyChart.spec.tsx
@@ -2,15 +2,11 @@ import {OrganizationFixture} from 'sentry-fixture/organization';
 
 import {render, screen, waitForElementToBeRemoved} from 'sentry-test/reactTestingLibrary';
 
-import useOrganization from 'sentry/utils/useOrganization';
 import {LatencyChart} from 'sentry/views/performance/queues/charts/latencyChart';
 import {Referrer} from 'sentry/views/performance/queues/referrers';
 
-jest.mock('sentry/utils/useOrganization');
-
 describe('latencyChart', () => {
   const organization = OrganizationFixture();
-  jest.mocked(useOrganization).mockReturnValue(organization);
 
   let eventsStatsMock;
 
@@ -25,7 +21,8 @@ describe('latencyChart', () => {
   });
   it('renders', async () => {
     render(
-      <LatencyChart destination="events" referrer={Referrer.QUEUES_SUMMARY_CHARTS} />
+      <LatencyChart destination="events" referrer={Referrer.QUEUES_SUMMARY_CHARTS} />,
+      {organization}
     );
     screen.getByText('Avg Latency');
     expect(eventsStatsMock).toHaveBeenCalledWith(

--- a/static/app/views/performance/queues/charts/throughputChart.spec.tsx
+++ b/static/app/views/performance/queues/charts/throughputChart.spec.tsx
@@ -2,15 +2,11 @@ import {OrganizationFixture} from 'sentry-fixture/organization';
 
 import {render, screen, waitForElementToBeRemoved} from 'sentry-test/reactTestingLibrary';
 
-import useOrganization from 'sentry/utils/useOrganization';
 import {ThroughputChart} from 'sentry/views/performance/queues/charts/throughputChart';
 import {Referrer} from 'sentry/views/performance/queues/referrers';
 
-jest.mock('sentry/utils/useOrganization');
-
 describe('throughputChart', () => {
   const organization = OrganizationFixture();
-  jest.mocked(useOrganization).mockReturnValue(organization);
 
   let eventsStatsMock;
 
@@ -24,7 +20,7 @@ describe('throughputChart', () => {
     });
   });
   it('renders', async () => {
-    render(<ThroughputChart referrer={Referrer.QUEUES_SUMMARY_CHARTS} />);
+    render(<ThroughputChart referrer={Referrer.QUEUES_SUMMARY_CHARTS} />, {organization});
     screen.getByText('Published vs Processed');
     expect(eventsStatsMock).toHaveBeenCalledWith(
       '/organizations/org-slug/events-stats/',

--- a/static/app/views/performance/queues/destinationSummary/destinationSummaryPage.spec.tsx
+++ b/static/app/views/performance/queues/destinationSummary/destinationSummaryPage.spec.tsx
@@ -3,14 +3,12 @@ import {OrganizationFixture} from 'sentry-fixture/organization';
 import {render, screen, waitForElementToBeRemoved} from 'sentry-test/reactTestingLibrary';
 
 import {useLocation} from 'sentry/utils/useLocation';
-import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import useProjects from 'sentry/utils/useProjects';
 import PageWithProviders from 'sentry/views/performance/queues/destinationSummary/destinationSummaryPage';
 
 jest.mock('sentry/utils/useLocation');
 jest.mock('sentry/utils/usePageFilters');
-jest.mock('sentry/utils/useOrganization');
 jest.mock('sentry/utils/useProjects');
 
 describe('destinationSummaryPage', () => {
@@ -43,8 +41,6 @@ describe('destinationSummaryPage', () => {
     key: '',
   });
 
-  jest.mocked(useOrganization).mockReturnValue(organization);
-
   jest.mocked(useProjects).mockReturnValue({
     projects: [],
     onSearch: jest.fn(),
@@ -72,7 +68,7 @@ describe('destinationSummaryPage', () => {
   });
 
   it('renders', async () => {
-    render(<PageWithProviders />);
+    render(<PageWithProviders />, {organization});
     await screen.findByRole('table', {name: 'Transactions'});
     await waitForElementToBeRemoved(() => screen.queryAllByTestId('loading-indicator'));
     screen.getByText('Avg Latency');

--- a/static/app/views/performance/queues/destinationSummary/messageSpanSamplesPanel.spec.tsx
+++ b/static/app/views/performance/queues/destinationSummary/messageSpanSamplesPanel.spec.tsx
@@ -3,13 +3,11 @@ import {OrganizationFixture} from 'sentry-fixture/organization';
 import {render, screen, waitForElementToBeRemoved} from 'sentry-test/reactTestingLibrary';
 
 import {useLocation} from 'sentry/utils/useLocation';
-import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import {MessageSpanSamplesPanel} from 'sentry/views/performance/queues/destinationSummary/messageSpanSamplesPanel';
 
 jest.mock('sentry/utils/useLocation');
 jest.mock('sentry/utils/usePageFilters');
-jest.mock('sentry/utils/useOrganization');
 
 describe('messageSpanSamplesPanel', () => {
   const organization = OrganizationFixture();
@@ -42,8 +40,6 @@ describe('messageSpanSamplesPanel', () => {
     action: 'PUSH',
     key: '',
   });
-
-  jest.mocked(useOrganization).mockReturnValue(organization);
 
   beforeEach(() => {
     eventsStatsRequestMock = MockApiClient.addMockResponse({
@@ -134,7 +130,7 @@ describe('messageSpanSamplesPanel', () => {
       action: 'PUSH',
       key: '',
     });
-    render(<MessageSpanSamplesPanel />);
+    render(<MessageSpanSamplesPanel />, {organization});
     await waitForElementToBeRemoved(() => screen.queryAllByTestId('loading-indicator'));
     expect(eventsStatsRequestMock).toHaveBeenCalled();
     expect(eventsRequestMock).toHaveBeenCalledWith(
@@ -218,7 +214,7 @@ describe('messageSpanSamplesPanel', () => {
       action: 'PUSH',
       key: '',
     });
-    render(<MessageSpanSamplesPanel />);
+    render(<MessageSpanSamplesPanel />, {organization});
     await waitForElementToBeRemoved(() => screen.queryAllByTestId('loading-indicator'));
     expect(eventsStatsRequestMock).toHaveBeenCalled();
     expect(eventsRequestMock).toHaveBeenCalledWith(

--- a/static/app/views/performance/queues/destinationSummary/messageSpanSamplesTable.spec.tsx
+++ b/static/app/views/performance/queues/destinationSummary/messageSpanSamplesTable.spec.tsx
@@ -1,18 +1,9 @@
-import {OrganizationFixture} from 'sentry-fixture/organization';
-
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
-import useOrganization from 'sentry/utils/useOrganization';
 import {MessageSpanSamplesTable} from 'sentry/views/performance/queues/destinationSummary/messageSpanSamplesTable';
 import {MessageActorType} from 'sentry/views/performance/queues/settings';
 
-jest.mock('sentry/utils/useOrganization');
-
 describe('messageSpanSamplesTable', () => {
-  const organization = OrganizationFixture();
-  jest.mocked(useOrganization).mockReturnValue(organization);
-
-  beforeEach(() => {});
   it('renders consumer samples table', () => {
     render(
       <MessageSpanSamplesTable

--- a/static/app/views/performance/queues/destinationSummary/transactionsTable.spec.tsx
+++ b/static/app/views/performance/queues/destinationSummary/transactionsTable.spec.tsx
@@ -3,16 +3,13 @@ import {OrganizationFixture} from 'sentry-fixture/organization';
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
 import {useLocation} from 'sentry/utils/useLocation';
-import useOrganization from 'sentry/utils/useOrganization';
 import {TransactionsTable} from 'sentry/views/performance/queues/destinationSummary/transactionsTable';
 import {QueryParameterNames} from 'sentry/views/starfish/views/queryParameters';
 
-jest.mock('sentry/utils/useOrganization');
 jest.mock('sentry/utils/useLocation');
 
 describe('transactionsTable', () => {
   const organization = OrganizationFixture();
-  jest.mocked(useOrganization).mockReturnValue(organization);
 
   let eventsMock;
 
@@ -70,7 +67,7 @@ describe('transactionsTable', () => {
     });
   });
   it('renders', async () => {
-    render(<TransactionsTable />);
+    render(<TransactionsTable />, {organization});
     expect(screen.getByRole('table', {name: 'Transactions'})).toBeInTheDocument();
 
     expect(screen.getByRole('columnheader', {name: 'Transactions'})).toBeInTheDocument();
@@ -133,7 +130,7 @@ describe('transactionsTable', () => {
       key: '',
     });
 
-    render(<TransactionsTable />);
+    render(<TransactionsTable />, {organization});
 
     expect(eventsMock).toHaveBeenCalledWith(
       '/organizations/org-slug/events/',

--- a/static/app/views/performance/queues/queuesLandingPage.spec.tsx
+++ b/static/app/views/performance/queues/queuesLandingPage.spec.tsx
@@ -3,14 +3,12 @@ import {OrganizationFixture} from 'sentry-fixture/organization';
 import {render, screen, waitForElementToBeRemoved} from 'sentry-test/reactTestingLibrary';
 
 import {useLocation} from 'sentry/utils/useLocation';
-import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import useProjects from 'sentry/utils/useProjects';
 import QueuesLandingPage from 'sentry/views/performance/queues/queuesLandingPage';
 
 jest.mock('sentry/utils/useLocation');
 jest.mock('sentry/utils/usePageFilters');
-jest.mock('sentry/utils/useOrganization');
 jest.mock('sentry/utils/useProjects');
 
 describe('queuesLandingPage', () => {
@@ -43,8 +41,6 @@ describe('queuesLandingPage', () => {
     key: '',
   });
 
-  jest.mocked(useOrganization).mockReturnValue(organization);
-
   jest.mocked(useProjects).mockReturnValue({
     projects: [],
     onSearch: jest.fn(),
@@ -72,7 +68,7 @@ describe('queuesLandingPage', () => {
   });
 
   it('renders', async () => {
-    render(<QueuesLandingPage />);
+    render(<QueuesLandingPage />, {organization});
     await screen.findByRole('table', {name: 'Queues'});
     await waitForElementToBeRemoved(() => screen.queryAllByTestId('loading-indicator'));
     screen.getByPlaceholderText('Search for more destinations');

--- a/static/app/views/performance/queues/queuesTable.spec.tsx
+++ b/static/app/views/performance/queues/queuesTable.spec.tsx
@@ -2,15 +2,11 @@ import {OrganizationFixture} from 'sentry-fixture/organization';
 
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
-import useOrganization from 'sentry/utils/useOrganization';
 import {QueuesTable} from 'sentry/views/performance/queues/queuesTable';
 import {SpanIndexedField} from 'sentry/views/starfish/types';
 
-jest.mock('sentry/utils/useOrganization');
-
 describe('queuesTable', () => {
   const organization = OrganizationFixture();
-  jest.mocked(useOrganization).mockReturnValue(organization);
 
   let eventsMock;
 
@@ -60,7 +56,8 @@ describe('queuesTable', () => {
     render(
       <QueuesTable
         sort={{field: 'time_spent_percentage(app,span.duration)', kind: 'desc'}}
-      />
+      />,
+      {organization}
     );
     expect(screen.getByRole('table', {name: 'Queues'})).toBeInTheDocument();
     expect(screen.getByRole('columnheader', {name: 'Destination'})).toBeInTheDocument();
@@ -108,7 +105,8 @@ describe('queuesTable', () => {
       <QueuesTable
         destination="*events*"
         sort={{field: SpanIndexedField.MESSAGING_MESSAGE_DESTINATION_NAME, kind: 'desc'}}
-      />
+      />,
+      {organization}
     );
     expect(eventsMock).toHaveBeenCalledWith(
       '/organizations/org-slug/events/',

--- a/static/app/views/replays/list/listContent.spec.tsx
+++ b/static/app/views/replays/list/listContent.spec.tsx
@@ -9,14 +9,12 @@ import {
   useHaveSelectedProjectsSentAnyReplayEvents,
   useReplayOnboardingSidebarPanel,
 } from 'sentry/utils/replays/hooks/useReplayOnboarding';
-import useOrganization from 'sentry/utils/useOrganization';
 import useProjectSdkNeedsUpdate from 'sentry/utils/useProjectSdkNeedsUpdate';
 import ListPage from 'sentry/views/replays/list/listContent';
 
 jest.mock('sentry/utils/replays/hooks/useDeadRageSelectors');
 jest.mock('sentry/utils/replays/hooks/useReplayOnboarding');
 jest.mock('sentry/utils/replays/hooks/useReplayPageview');
-jest.mock('sentry/utils/useOrganization');
 jest.mock('sentry/utils/useProjectSdkNeedsUpdate');
 
 const mockUseDeadRageSelectors = jest.mocked(useDeadRageSelectors);
@@ -37,8 +35,6 @@ function getMockOrganizationFixture({features}: {features: string[]}) {
     features,
     access: [],
   });
-
-  jest.mocked(useOrganization).mockReturnValue(mockOrg);
 
   return mockOrg;
 }
@@ -78,6 +74,7 @@ describe('ReplayList', () => {
 
     render(<ListPage />, {
       context: getMockContext(mockOrg),
+      organization: mockOrg,
     });
 
     await waitFor(() =>
@@ -100,6 +97,7 @@ describe('ReplayList', () => {
 
     render(<ListPage />, {
       context: getMockContext(mockOrg),
+      organization: mockOrg,
     });
 
     await waitFor(() =>
@@ -122,6 +120,7 @@ describe('ReplayList', () => {
 
     render(<ListPage />, {
       context: getMockContext(mockOrg),
+      organization: mockOrg,
     });
 
     await waitFor(() =>
@@ -144,6 +143,7 @@ describe('ReplayList', () => {
 
     render(<ListPage />, {
       context: getMockContext(mockOrg),
+      organization: mockOrg,
     });
 
     await waitFor(() => {
@@ -173,6 +173,7 @@ describe('ReplayList', () => {
 
     render(<ListPage />, {
       context: getMockContext(mockOrg),
+      organization: mockOrg,
     });
 
     await waitFor(() => expect(screen.queryAllByTestId('replay-table')).toHaveLength(1));

--- a/static/app/views/starfish/components/spanDescription.spec.tsx
+++ b/static/app/views/starfish/components/spanDescription.spec.tsx
@@ -5,16 +5,13 @@ import {render, screen, waitForElementToBeRemoved} from 'sentry-test/reactTestin
 import {textWithMarkupMatcher} from 'sentry-test/utils';
 
 import {EntryType} from 'sentry/types/event';
-import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import {DatabaseSpanDescription} from 'sentry/views/starfish/components/spanDescription';
 
-jest.mock('sentry/utils/useOrganization');
 jest.mock('sentry/utils/usePageFilters');
 
 describe('DatabaseSpanDescription', function () {
   const organization = OrganizationFixture();
-  jest.mocked(useOrganization).mockReturnValue(organization);
 
   const project = ProjectFixture();
 
@@ -49,7 +46,8 @@ describe('DatabaseSpanDescription', function () {
       <DatabaseSpanDescription
         groupId={groupId}
         preliminaryDescription="SELECT USERS FRO*"
-      />
+      />,
+      {organization}
     );
 
     await waitForElementToBeRemoved(() => screen.getByTestId('loading-indicator'));
@@ -93,7 +91,8 @@ describe('DatabaseSpanDescription', function () {
       <DatabaseSpanDescription
         groupId={groupId}
         preliminaryDescription="SELECT USERS FRO*"
-      />
+      />,
+      {organization}
     );
 
     await waitForElementToBeRemoved(() => screen.getByTestId('loading-indicator'));

--- a/static/app/views/starfish/queries/useDiscover.spec.tsx
+++ b/static/app/views/starfish/queries/useDiscover.spec.tsx
@@ -8,23 +8,26 @@ import {renderHook, waitFor} from 'sentry-test/reactTestingLibrary';
 import {QueryClientProvider} from 'sentry/utils/queryClient';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {useLocation} from 'sentry/utils/useLocation';
-import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
+import {OrganizationContext} from 'sentry/views/organizationContext';
 import {useSpanMetrics} from 'sentry/views/starfish/queries/useDiscover';
 import type {SpanMetricsProperty} from 'sentry/views/starfish/types';
 
 jest.mock('sentry/utils/useLocation');
 jest.mock('sentry/utils/usePageFilters');
-jest.mock('sentry/utils/useOrganization');
-
-function Wrapper({children}: {children?: ReactNode}) {
-  return (
-    <QueryClientProvider client={makeTestQueryClient()}>{children}</QueryClientProvider>
-  );
-}
 
 describe('useSpanMetrics', () => {
   const organization = OrganizationFixture();
+
+  function Wrapper({children}: {children?: ReactNode}) {
+    return (
+      <QueryClientProvider client={makeTestQueryClient()}>
+        <OrganizationContext.Provider value={organization}>
+          {children}
+        </OrganizationContext.Provider>
+      </QueryClientProvider>
+    );
+  }
 
   jest.mocked(usePageFilters).mockReturnValue({
     isReady: true,
@@ -48,8 +51,6 @@ describe('useSpanMetrics', () => {
       query: {statsPeriod: '10d'},
     })
   );
-
-  jest.mocked(useOrganization).mockReturnValue(organization);
 
   it('respects the `enabled` prop', () => {
     const eventsRequest = MockApiClient.addMockResponse({

--- a/static/app/views/starfish/queries/useDiscoverSeries.spec.tsx
+++ b/static/app/views/starfish/queries/useDiscoverSeries.spec.tsx
@@ -7,23 +7,26 @@ import {renderHook, waitFor} from 'sentry-test/reactTestingLibrary';
 import {QueryClientProvider} from 'sentry/utils/queryClient';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {useLocation} from 'sentry/utils/useLocation';
-import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
+import {OrganizationContext} from 'sentry/views/organizationContext';
 import {useSpanMetricsSeries} from 'sentry/views/starfish/queries/useDiscoverSeries';
 import type {SpanMetricsProperty} from 'sentry/views/starfish/types';
 
 jest.mock('sentry/utils/useLocation');
 jest.mock('sentry/utils/usePageFilters');
-jest.mock('sentry/utils/useOrganization');
-
-function Wrapper({children}: {children?: ReactNode}) {
-  return (
-    <QueryClientProvider client={makeTestQueryClient()}>{children}</QueryClientProvider>
-  );
-}
 
 describe('useSpanMetricsSeries', () => {
   const organization = OrganizationFixture();
+
+  function Wrapper({children}: {children?: ReactNode}) {
+    return (
+      <QueryClientProvider client={makeTestQueryClient()}>
+        <OrganizationContext.Provider value={organization}>
+          {children}
+        </OrganizationContext.Provider>
+      </QueryClientProvider>
+    );
+  }
 
   jest.mocked(usePageFilters).mockReturnValue({
     isReady: true,
@@ -51,8 +54,6 @@ describe('useSpanMetricsSeries', () => {
     action: 'PUSH',
     key: '',
   });
-
-  jest.mocked(useOrganization).mockReturnValue(organization);
 
   it('respects the `enabled` prop', () => {
     const eventsRequest = MockApiClient.addMockResponse({

--- a/static/app/views/starfish/queries/useIndexedSpans.spec.tsx
+++ b/static/app/views/starfish/queries/useIndexedSpans.spec.tsx
@@ -8,18 +8,21 @@ import {renderHook, waitFor} from 'sentry-test/reactTestingLibrary';
 import {QueryClientProvider} from 'sentry/utils/queryClient';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {useLocation} from 'sentry/utils/useLocation';
-import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
+import {OrganizationContext} from 'sentry/views/organizationContext';
 import {useIndexedSpans} from 'sentry/views/starfish/queries/useIndexedSpans';
 import type {IndexedProperty} from 'sentry/views/starfish/types';
 
 jest.mock('sentry/utils/useLocation');
 jest.mock('sentry/utils/usePageFilters');
-jest.mock('sentry/utils/useOrganization');
 
 function Wrapper({children}: {children?: ReactNode}) {
   return (
-    <QueryClientProvider client={makeTestQueryClient()}>{children}</QueryClientProvider>
+    <QueryClientProvider client={makeTestQueryClient()}>
+      <OrganizationContext.Provider value={OrganizationFixture()}>
+        {children}
+      </OrganizationContext.Provider>
+    </QueryClientProvider>
   );
 }
 
@@ -48,8 +51,6 @@ describe('useIndexedSpans', () => {
       query: {statsPeriod: '10d'},
     })
   );
-
-  jest.mocked(useOrganization).mockReturnValue(organization);
 
   beforeEach(() => {
     jest.clearAllMocks();

--- a/static/app/views/starfish/queries/useSpanMetricsTopNSeries.spec.tsx
+++ b/static/app/views/starfish/queries/useSpanMetricsTopNSeries.spec.tsx
@@ -7,23 +7,26 @@ import {renderHook, waitFor} from 'sentry-test/reactTestingLibrary';
 import {QueryClientProvider} from 'sentry/utils/queryClient';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {useLocation} from 'sentry/utils/useLocation';
-import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
+import {OrganizationContext} from 'sentry/views/organizationContext';
 import {useSpanMetricsTopNSeries} from 'sentry/views/starfish/queries/useSpanMetricsTopNSeries';
 import type {SpanMetricsProperty} from 'sentry/views/starfish/types';
 
 jest.mock('sentry/utils/useLocation');
 jest.mock('sentry/utils/usePageFilters');
-jest.mock('sentry/utils/useOrganization');
-
-function Wrapper({children}: {children?: ReactNode}) {
-  return (
-    <QueryClientProvider client={makeTestQueryClient()}>{children}</QueryClientProvider>
-  );
-}
 
 describe('useSpanMetricsTopNSeries', () => {
   const organization = OrganizationFixture();
+
+  function Wrapper({children}: {children?: ReactNode}) {
+    return (
+      <QueryClientProvider client={makeTestQueryClient()}>
+        <OrganizationContext.Provider value={organization}>
+          {children}
+        </OrganizationContext.Provider>
+      </QueryClientProvider>
+    );
+  }
 
   jest.mocked(usePageFilters).mockReturnValue({
     isReady: true,
@@ -51,8 +54,6 @@ describe('useSpanMetricsTopNSeries', () => {
     action: 'PUSH',
     key: '',
   });
-
-  jest.mocked(useOrganization).mockReturnValue(organization);
 
   it('rolls multi-axis top-n responses up into multiple series', async () => {
     const eventsRequest = MockApiClient.addMockResponse({

--- a/static/app/views/starfish/views/spans/selectors/domainSelector.spec.tsx
+++ b/static/app/views/starfish/views/spans/selectors/domainSelector.spec.tsx
@@ -9,17 +9,14 @@ import {
 } from 'sentry-test/reactTestingLibrary';
 import selectEvent from 'sentry-test/selectEvent';
 
-import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import {ModuleName} from 'sentry/views/starfish/types';
 import {DomainSelector} from 'sentry/views/starfish/views/spans/selectors/domainSelector';
 
-jest.mock('sentry/utils/useOrganization');
 jest.mock('sentry/utils/usePageFilters');
 
 describe('DomainSelector', function () {
   const organization = OrganizationFixture();
-  jest.mocked(useOrganization).mockReturnValue(organization);
 
   jest.mocked(usePageFilters).mockReturnValue({
     isReady: true,


### PR DESCRIPTION
`render(<Component />, {organization})` will add an organization context for you, no need to mock our hooks which can hide other issues, like hooks being used outside components/hooks.
