### PR TITLE
ref(insights): Use module URLs from constants for routing

### DIFF
--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -1481,37 +1481,35 @@ function buildRoutes() {
           )}
         />
       </Route>
-      <Route path="browser/">
-        <Route path="pageloads/">
-          <IndexRoute
-            component={make(
-              () =>
-                import('sentry/views/performance/browser/webVitals/webVitalsLandingPage')
-            )}
-          />
-          <Route
-            path="overview/"
-            component={make(
-              () => import('sentry/views/performance/browser/webVitals/pageOverview')
-            )}
-          />
-        </Route>
-        <Route path="resources/">
-          <IndexRoute
-            component={make(
-              () => import('sentry/views/performance/browser/resources/index')
-            )}
-          />
-          <Route
-            path="spans/span/:groupId/"
-            component={make(
-              () =>
-                import(
-                  'sentry/views/performance/browser/resources/resourceSummaryPage/index'
-                )
-            )}
-          />
-        </Route>
+      <Route path="browser/pageloads/">
+        <IndexRoute
+          component={make(
+            () =>
+              import('sentry/views/performance/browser/webVitals/webVitalsLandingPage')
+          )}
+        />
+        <Route
+          path="overview/"
+          component={make(
+            () => import('sentry/views/performance/browser/webVitals/pageOverview')
+          )}
+        />
+      </Route>
+      <Route path="browser/resources/">
+        <IndexRoute
+          component={make(
+            () => import('sentry/views/performance/browser/resources/index')
+          )}
+        />
+        <Route
+          path="spans/span/:groupId/"
+          component={make(
+            () =>
+              import(
+                'sentry/views/performance/browser/resources/resourceSummaryPage/index'
+              )
+          )}
+        />
       </Route>
       <Route path="queues/">
         <IndexRoute
@@ -1529,40 +1527,38 @@ function buildRoutes() {
           )}
         />
       </Route>
-      <Route path="mobile/">
-        <Route path="screens/">
-          <IndexRoute
-            component={make(() => import('sentry/views/performance/mobile/screenload'))}
-          />
-          <Route
-            path="spans/"
-            component={make(
-              () => import('sentry/views/performance/mobile/screenload/screenLoadSpans')
-            )}
-          />
-        </Route>
-        <Route path="app-startup/">
-          <IndexRoute
-            component={make(() => import('sentry/views/performance/mobile/appStarts'))}
-          />
-          <Route
-            path="spans/"
-            component={make(
-              () => import('sentry/views/performance/mobile/appStarts/screenSummary')
-            )}
-          />
-        </Route>
-        <Route path="ui/">
-          <IndexRoute
-            component={make(() => import('sentry/views/performance/mobile/ui'))}
-          />
-          <Route
-            path="spans/"
-            component={make(
-              () => import('sentry/views/performance/mobile/ui/screenSummary')
-            )}
-          />
-        </Route>
+      <Route path="mobile/screens/">
+        <IndexRoute
+          component={make(() => import('sentry/views/performance/mobile/screenload'))}
+        />
+        <Route
+          path="spans/"
+          component={make(
+            () => import('sentry/views/performance/mobile/screenload/screenLoadSpans')
+          )}
+        />
+      </Route>
+      <Route path="mobile/app-startup/">
+        <IndexRoute
+          component={make(() => import('sentry/views/performance/mobile/appStarts'))}
+        />
+        <Route
+          path="spans/"
+          component={make(
+            () => import('sentry/views/performance/mobile/appStarts/screenSummary')
+          )}
+        />
+      </Route>
+      <Route path="mobile/ui/">
+        <IndexRoute
+          component={make(() => import('sentry/views/performance/mobile/ui'))}
+        />
+        <Route
+          path="spans/"
+          component={make(
+            () => import('sentry/views/performance/mobile/ui/screenSummary')
+          )}
+        />
       </Route>
     </Fragment>
   );

--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -19,11 +19,12 @@ import IssueListOverview from 'sentry/views/issueList/overview';
 import OrganizationContainer from 'sentry/views/organizationContainer';
 import OrganizationLayout from 'sentry/views/organizationLayout';
 import OrganizationRoot from 'sentry/views/organizationRoot';
-import {BASE_URL as CACHE_BASE_URL} from 'sentry/views/performance/cache/settings';
+import {MODULE_BASE_URLS} from 'sentry/views/performance/utils/useModuleURL';
 import ProjectEventRedirect from 'sentry/views/projectEventRedirect';
 import redirectDeprecatedProjectRoute from 'sentry/views/projects/redirectDeprecatedProjectRoute';
 import RouteNotFound from 'sentry/views/routeNotFound';
 import SettingsWrapper from 'sentry/views/settings/components/settingsWrapper';
+import {ModuleName} from 'sentry/views/starfish/types';
 
 import {IndexRoute, Route} from './components/route';
 
@@ -1437,7 +1438,7 @@ function buildRoutes() {
   );
 
   const llmMonitoringRoutes = (
-    <Route path="/llm-monitoring/" withOrgPath>
+    <Route path={`${MODULE_BASE_URLS[ModuleName.AI]}/`} withOrgPath>
       <IndexRoute component={make(() => import('sentry/views/llmMonitoring/landing'))} />
       <Route
         path="pipeline-type/:groupId/"
@@ -1450,7 +1451,7 @@ function buildRoutes() {
 
   const insightsRoutes = (
     <Fragment>
-      <Route path="database/">
+      <Route path={`${MODULE_BASE_URLS[ModuleName.DB]}/`}>
         <IndexRoute
           component={make(
             () => import('sentry/views/performance/database/databaseLandingPage')
@@ -1463,7 +1464,7 @@ function buildRoutes() {
           )}
         />
       </Route>
-      <Route path="http/">
+      <Route path={`${MODULE_BASE_URLS[ModuleName.HTTP]}/`}>
         <IndexRoute
           component={make(() => import('sentry/views/performance/http/httpLandingPage'))}
         />
@@ -1474,14 +1475,14 @@ function buildRoutes() {
           )}
         />
       </Route>
-      <Route path={`${CACHE_BASE_URL}/`}>
+      <Route path={`${MODULE_BASE_URLS[ModuleName.CACHE]}/`}>
         <IndexRoute
           component={make(
             () => import('sentry/views/performance/cache/cacheLandingPage')
           )}
         />
       </Route>
-      <Route path="browser/pageloads/">
+      <Route path={`${MODULE_BASE_URLS[ModuleName.VITAL]}/`}>
         <IndexRoute
           component={make(
             () =>
@@ -1495,7 +1496,7 @@ function buildRoutes() {
           )}
         />
       </Route>
-      <Route path="browser/resources/">
+      <Route path={`${MODULE_BASE_URLS[ModuleName.RESOURCE]}/`}>
         <IndexRoute
           component={make(
             () => import('sentry/views/performance/browser/resources/index')
@@ -1511,7 +1512,7 @@ function buildRoutes() {
           )}
         />
       </Route>
-      <Route path="queues/">
+      <Route path={`${MODULE_BASE_URLS[ModuleName.QUEUE]}/`}>
         <IndexRoute
           component={make(
             () => import('sentry/views/performance/queues/queuesLandingPage')
@@ -1527,7 +1528,7 @@ function buildRoutes() {
           )}
         />
       </Route>
-      <Route path="mobile/screens/">
+      <Route path={`${MODULE_BASE_URLS[ModuleName.SCREEN_LOAD]}/`}>
         <IndexRoute
           component={make(() => import('sentry/views/performance/mobile/screenload'))}
         />
@@ -1538,7 +1539,7 @@ function buildRoutes() {
           )}
         />
       </Route>
-      <Route path="mobile/app-startup/">
+      <Route path={`${MODULE_BASE_URLS[ModuleName.APP_START]}/`}>
         <IndexRoute
           component={make(() => import('sentry/views/performance/mobile/appStarts'))}
         />
@@ -1549,7 +1550,7 @@ function buildRoutes() {
           )}
         />
       </Route>
-      <Route path="mobile/ui/">
+      <Route path={`${MODULE_BASE_URLS[ModuleName.MOBILE_UI]}/`}>
         <IndexRoute
           component={make(() => import('sentry/views/performance/mobile/ui'))}
         />

--- a/static/app/views/performance/utils/useModuleURL.tsx
+++ b/static/app/views/performance/utils/useModuleURL.tsx
@@ -13,7 +13,7 @@ import {BASE_URL as QUEUE_BASE_URL} from 'sentry/views/performance/queues/settin
 import {INSIGHTS_BASE_URL} from 'sentry/views/performance/settings';
 import {ModuleName} from 'sentry/views/starfish/types';
 
-const MODULE_BASE_URLS: Record<ModuleName, string> = {
+export const MODULE_BASE_URLS: Record<ModuleName, string> = {
   [ModuleName.DB]: DB_BASE_URL,
   [ModuleName.HTTP]: HTTP_BASE_URL,
   [ModuleName.CACHE]: CACHE_BASE_URL,


### PR DESCRIPTION
We're moving all the Starfish modules from `/performance` URLs to `/insights` URLs. As part of this whole thing, I also want to clean up how the routes are generated. We define the base URLs for the modules in constants files, and the routes file should respect those! That way, everything is in sync.

- Flatten Insights URL structure
    
    The nesting is fine, but it's easier to use configured URL prefixes if
    they're unrolled. React Router supports slashes in routes, so the routing
    works correctly.

- Use module settings for routing

