### PR TITLE
ref(rules): Don't pass buffer to callback

### DIFF
--- a/src/sentry/buffer/redis.py
+++ b/src/sentry/buffer/redis.py
@@ -69,13 +69,13 @@ class BufferHookRegistry:
     def has(self, key: BufferHookEvent) -> bool:
         return self._registry.get(key) is not None
 
-    def callback(self, buffer_hook_event: BufferHookEvent, data: RedisBuffer) -> bool:
+    def callback(self, buffer_hook_event: BufferHookEvent) -> bool:
         try:
             callback = self._registry[buffer_hook_event]
         except KeyError:
             logger.exception("buffer_hook_event.missing")
 
-        return callback(data)
+        return callback()
 
 
 redis_buffer_registry = BufferHookRegistry()
@@ -317,7 +317,7 @@ class RedisBuffer(Buffer):
 
     def process_batch(self) -> None:
         try:
-            redis_buffer_registry.callback(BufferHookEvent.FLUSH, self)
+            redis_buffer_registry.callback(BufferHookEvent.FLUSH)
         except Exception:
             logger.exception("process_batch.error")
 

--- a/tests/sentry/buffer/test_redis.py
+++ b/tests/sentry/buffer/test_redis.py
@@ -276,6 +276,14 @@ class TestRedisBuffer:
         redis_buffer_registry.callback(BufferHookEvent.FLUSH)
         assert mock.call_count == 1
 
+    @mock.patch("sentry.rules.processing.delayed_processing.metrics.timer")
+    def test_callback(self, mock_metrics_timer):
+        from sentry.rules.processing.delayed_processing import process_delayed_alert_conditions
+
+        redis_buffer_registry.add_handler(BufferHookEvent.FLUSH, process_delayed_alert_conditions)
+        self.buf.process_batch()
+        assert mock_metrics_timer.call_count == 1
+
     def test_process_batch(self):
         """Test that the registry's callbacks are invoked when we process a batch"""
         mock = Mock()

--- a/tests/sentry/buffer/test_redis.py
+++ b/tests/sentry/buffer/test_redis.py
@@ -11,6 +11,7 @@ from sentry import options
 from sentry.buffer.redis import BufferHookEvent, RedisBuffer, redis_buffer_registry
 from sentry.models.group import Group
 from sentry.models.project import Project
+from sentry.rules.processing.delayed_processing import process_delayed_alert_conditions
 from sentry.rules.processing.processor import PROJECT_ID_BUFFER_LIST_KEY
 from sentry.testutils.helpers.datetime import freeze_time
 from sentry.testutils.pytest.fixtures import django_db_all
@@ -278,8 +279,6 @@ class TestRedisBuffer:
 
     @mock.patch("sentry.rules.processing.delayed_processing.metrics.timer")
     def test_callback(self, mock_metrics_timer):
-        from sentry.rules.processing.delayed_processing import process_delayed_alert_conditions
-
         redis_buffer_registry.add_handler(BufferHookEvent.FLUSH, process_delayed_alert_conditions)
         self.buf.process_batch()
         assert mock_metrics_timer.call_count == 1

--- a/tests/sentry/buffer/test_redis.py
+++ b/tests/sentry/buffer/test_redis.py
@@ -273,9 +273,8 @@ class TestRedisBuffer:
         mock = Mock()
         redis_buffer_registry._registry[BufferHookEvent.FLUSH] = mock
 
-        redis_buffer_registry.callback(BufferHookEvent.FLUSH, self.buf)
+        redis_buffer_registry.callback(BufferHookEvent.FLUSH)
         assert mock.call_count == 1
-        assert mock.call_args[0][0] == self.buf
 
     def test_process_batch(self):
         """Test that the registry's callbacks are invoked when we process a batch"""
@@ -283,7 +282,6 @@ class TestRedisBuffer:
         redis_buffer_registry._registry[BufferHookEvent.FLUSH] = mock
         self.buf.process_batch()
         assert mock.call_count == 1
-        assert mock.call_args[0][0] == self.buf
 
     def test_delete_batch(self):
         """Test that after we add things to redis we can clean it up"""


### PR DESCRIPTION
Follow up to https://github.com/getsentry/sentry/pull/71181 - I missed not passing the buffer to the callback function (resulted in error logs [here](https://console.cloud.google.com/logs/query;query=resource.type%3D%22k8s_container%22%0Alabels.name%3D~%22sentry%22%0AjsonPayload.event%20%3D%20%22process_batch.error%22;summaryFields=:true:32:beginning;cursorTimestamp=2024-05-21T20:10:00.215761417Z;duration=PT3H?project=internal-sentry&rapt=AEjHL4OqiZAY0vR7lEVLYXWgo1lpciRDevanEaABYuH6DbCTIUdXbFge5vnJECK4V8dVLsjnf43-vKFyCvGCt0HNJSVrJXq1dAOtQcE5clmHzB35kAuAO1M)). This also adds a test that would fail if an arg is passed to it. 