### PR TITLE
feat(insights): Render modules under `/insights` URL tree

### DIFF
--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -1448,7 +1448,7 @@ function buildRoutes() {
     </Route>
   );
 
-  const insightsRoutes = (
+  const insightsSubRoutes = (
     <Fragment>
       <Route path="database/">
         <IndexRoute
@@ -1658,7 +1658,7 @@ function buildRoutes() {
         path="trace/:traceSlug/"
         component={make(() => import('sentry/views/performance/traceDetails'))}
       />
-      {insightsRoutes}
+      {insightsSubRoutes}
       <Route
         path=":eventSlug/"
         component={make(() => import('sentry/views/performance/transactionDetails'))}

--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -1567,6 +1567,12 @@ function buildRoutes() {
     </Fragment>
   );
 
+  const insightsRoutes = (
+    <Route path="/insights/" withOrgPath>
+      {insightsSubRoutes}
+    </Route>
+  );
+
   const performanceRoutes = (
     <Route
       path="/performance/"
@@ -2072,6 +2078,7 @@ function buildRoutes() {
       {statsRoutes}
       {discoverRoutes}
       {performanceRoutes}
+      {insightsRoutes}
       {llmMonitoringRoutes}
       {profilingRoutes}
       {metricsRoutes}


### PR DESCRIPTION
As we transition the modules from `/performance/x` to `/insights/x` I'm adding an `/insights` URL tree here. The modules will be rendered under _both_ URLs during the transition. Once the transition is complete, I'll remove `insightsSubRoutes` from `performanceRoutes` and replace them with redirects. For now, the `/insights` URL is already available so URLs like `/insights/http` will work. No harm no foul.
