### PR TITLE
feat(integrations): add state param to oauth redirect flow

### DIFF
--- a/static/app/views/sentryAppExternalInstallation/index.tsx
+++ b/static/app/views/sentryAppExternalInstallation/index.tsx
@@ -176,16 +176,20 @@ function SentryAppExternalInstallationContent({params, ...props}: Props) {
     }
 
     if (sentryApp.redirectUrl) {
-      const queryParams = {
+      const queryParams: Record<string, string | undefined> = {
         installationId: install.uuid,
         code: install.code,
         orgSlug: organization.slug,
       };
+      const state = props.location.query.state;
+      if (state) {
+        queryParams.state = state;
+      }
       const redirectUrl = addQueryParamsToExistingUrl(sentryApp.redirectUrl, queryParams);
       return window.location.assign(redirectUrl);
     }
     return onClose();
-  }, [api, organization, sentryApp, onClose]);
+  }, [api, organization, sentryApp, onClose, props.location.query.state]);
 
   if (sentryAppLoading || orgsLoading || !sentryApp) {
     return <LoadingIndicator />;


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry/issues/55794

- [x] allows the query param `state` to be passed to the `sentry-apps/<integration>/external-install/` frontend webpage, allowing for integrations initiated externally to utilize this.
- [x] we'll pass this state to the integration oauth redirect, if provided
- [x] test added
- [x] tested locally, looks good

https://datatracker.ietf.org/doc/html/rfc6749#section-4.1.1

- Note that this does not add the state parameter for integration setups initiated on the sentry side.