### PR TITLE
feat(billing): Add organizations:user-spend-notifications-settings feature

### DIFF
--- a/src/sentry/apidocs/examples/project_examples.py
+++ b/src/sentry/apidocs/examples/project_examples.py
@@ -223,7 +223,7 @@ DETAILED_PROJECT = {
             "session-replay",
             "sql-format",
             "performance-consecutive-db-queries-visible",
-            "slack-overage-notifications",
+            "user-spend-notifications-settings",
             "performance-m-n-plus-one-db-queries-post-process-group",
             "transaction-metrics-extraction",
             "performance-consecutive-db-queries-post-process-group",

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1860,6 +1860,8 @@ SENTRY_FEATURES: dict[str, bool | None] = {
     "organizations:settings-legal-tos-ui": False,
     # Enable the UI for the overage alert settings
     "organizations:slack-overage-notifications": False,
+    # Enable the UI for user spend notification settings
+    "organizations:user-spend-notifications-settings": False,
     # Enable Slack messages using Block Kit
     "organizations:slack-block-kit": True,
     # Send Slack notifications to threads for Issue Alerts

--- a/static/app/views/settings/account/notifications/constants.tsx
+++ b/static/app/views/settings/account/notifications/constants.tsx
@@ -90,8 +90,13 @@ export const CONFIRMATION_MESSAGE = (
   </div>
 );
 
-export const NOTIFICATION_FEATURE_MAP: Partial<Record<NotificationSettingsType, string>> =
-  {
-    quota: 'slack-overage-notifications',
-    spikeProtection: 'spike-projections',
-  };
+export const NOTIFICATION_FEATURE_MAP: Partial<
+  Record<NotificationSettingsType, string | Array<string>>
+> = {
+  quota: [
+    'slack-overage-notifications',
+    'spend-visibility-notifications',
+    'user-spend-notifications-settings',
+  ],
+  spikeProtection: 'spike-projections',
+};

--- a/static/app/views/settings/account/notifications/notificationSettings.spec.tsx
+++ b/static/app/views/settings/account/notifications/notificationSettings.spec.tsx
@@ -48,7 +48,7 @@ describe('NotificationSettings', function () {
   it('renders quota section with feature flag', async function () {
     const {routerContext, organization} = initializeOrg({
       organization: {
-        features: ['slack-overage-notifications'],
+        features: ['user-spend-notifications-settings'],
       },
     });
 
@@ -80,12 +80,12 @@ describe('NotificationSettings', function () {
   it('renders spend section instead of quota section with feature flag', async function () {
     const {routerContext, organization} = initializeOrg({
       organization: {
-        features: ['slack-overage-notifications', 'spend-visibility-notifications'],
+        features: ['user-spend-notifications-settings', 'spend-visibility-notifications'],
       },
     });
 
     const organizationNoFlag = OrganizationFixture();
-    organizationNoFlag.features.push('slack-overage-notifications');
+    organizationNoFlag.features.push('user-spend-notifications-settings');
 
     renderMockRequests({});
 

--- a/static/app/views/settings/account/notifications/notificationSettings.tsx
+++ b/static/app/views/settings/account/notifications/notificationSettings.tsx
@@ -38,6 +38,9 @@ function NotificationSettings({organizations}: NotificationSettingsProps) {
   };
   const notificationFields = NOTIFICATION_SETTINGS_TYPES.filter(type => {
     const notificationFlag = NOTIFICATION_FEATURE_MAP[type];
+    if (Array.isArray(notificationFlag)) {
+      return notificationFlag.some(flag => checkFeatureFlag(flag));
+    }
     if (notificationFlag) {
       return checkFeatureFlag(notificationFlag);
     }


### PR DESCRIPTION
This PR introduces `user-spend-notifications-settings` feature flag that will eventually replace `slack-overage-notifications`.

I will follow up with another pull request to delete `slack-overage-notifications`.