### PR TITLE
ref: Change grouping record backfill batch size

### DIFF
--- a/src/sentry/tasks/backfill_seer_grouping_records.py
+++ b/src/sentry/tasks/backfill_seer_grouping_records.py
@@ -172,9 +172,7 @@ def backfill_seer_grouping_records(
             Condition(
                 Column("timestamp", entity=events_entity), Op.GTE, time_now - timedelta(days=90)
             ),
-            Condition(
-                Column("timestamp", entity=events_entity), Op.LT, time_now + timedelta(days=1)
-            ),
+            Condition(Column("timestamp", entity=events_entity), Op.LT, time_now),
         ],
         orderby=[OrderBy(Column("group_id"), Direction.ASC)],
     )

--- a/src/sentry/tasks/backfill_seer_grouping_records.py
+++ b/src/sentry/tasks/backfill_seer_grouping_records.py
@@ -37,7 +37,7 @@ from sentry.utils import json, metrics, redis
 from sentry.utils.safe import get_path
 from sentry.utils.snuba import bulk_snuba_queries
 
-BATCH_SIZE = 20
+BATCH_SIZE = 10
 BACKFILL_NAME = "backfill_grouping_records"
 
 logger = logging.getLogger(__name__)

--- a/src/sentry/tasks/backfill_seer_grouping_records.py
+++ b/src/sentry/tasks/backfill_seer_grouping_records.py
@@ -172,7 +172,9 @@ def backfill_seer_grouping_records(
             Condition(
                 Column("timestamp", entity=events_entity), Op.GTE, time_now - timedelta(days=90)
             ),
-            Condition(Column("timestamp", entity=events_entity), Op.LT, time_now),
+            Condition(
+                Column("timestamp", entity=events_entity), Op.LT, time_now + timedelta(days=1)
+            ),
         ],
         orderby=[OrderBy(Column("group_id"), Direction.ASC)],
     )

--- a/tests/sentry/tasks/test_backfill_seer_grouping_records.py
+++ b/tests/sentry/tasks/test_backfill_seer_grouping_records.py
@@ -114,7 +114,6 @@ class TestBackfillSeerGroupingRecords(SnubaTestCase, TestCase):
                 group_id=event.group.id,
                 hash="".join(choice(ascii_uppercase) for i in range(32)),
             )
-        self.wait_for_event_count(self.project.id, 5)
 
         return {"rows": rows, "events": events, "messages": messages}
 
@@ -133,6 +132,9 @@ class TestBackfillSeerGroupingRecords(SnubaTestCase, TestCase):
         )
         self.event.group.times_seen = 5
         self.event.group.save()
+
+        self.wait_for_event_count(self.project.id, 6)
+
         group_hashes = GroupHash.objects.all().distinct("group_id")
         self.group_hashes = {group_hash.group_id: group_hash.hash for group_hash in group_hashes}
 


### PR DESCRIPTION
Change record backfill batch size from 20 to 10
Fix flaky tests by setting event timestamp in the past