### PR TITLE
build(js): Update @sentry/status-page-list to 0.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "@sentry/node": "^8.0.0",
     "@sentry/react": "^8.0.0",
     "@sentry/release-parser": "^1.3.1",
-    "@sentry/status-page-list": "^0.1.0",
+    "@sentry/status-page-list": "^0.2.0",
     "@sentry/types": "^8.0.0",
     "@sentry/utils": "^8.0.0",
     "@spotlightjs/spotlight": "^2.0.0-alpha.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3204,10 +3204,10 @@
   resolved "https://registry.yarnpkg.com/@sentry/release-parser/-/release-parser-1.3.1.tgz#0ab8be23fd494d80dd0e4ec8ae5f3d13f805b13d"
   integrity sha512-/dGpCq+j3sJhqQ14RNEEL45Ot/rgq3jAlZDD/8ufeqq+W8p4gUhSrbGWCRL82NEIWY9SYwxYXGXjRcVPSHiA1Q==
 
-"@sentry/status-page-list@^0.1.0":
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/@sentry/status-page-list/-/status-page-list-0.1.0.tgz#49e8683091de0531aba96fc95f19891970929701"
-  integrity sha512-wXWu3IihxFO0l5WQkr6V138ZJKHpL8G7fw/9l0Dl6Nl1ggWcJZOaBN/o5sXasS1e0Atvy2dL9DiPsKmBq8D4MA==
+"@sentry/status-page-list@^0.2.0":
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/@sentry/status-page-list/-/status-page-list-0.2.0.tgz#f82dec256ccf412cc97d71245bd87300ec56deca"
+  integrity sha512-Ulu7dhQrkB8zDA1f6nDPGOB4nIQj7QBI3Mk3fHn9W9KMVYeY7wi+0u01aV2aO7JnCkXHihzRnuLyTgulVJuQWg==
 
 "@sentry/types@8.0.0", "@sentry/types@^8.0.0":
   version "8.0.0"


### PR DESCRIPTION
https://github.com/getsentry/status-page-list/releases/tag/0.2.0

> This release adds entries for AirGateway, Algolia, Appveyor, Automattic/Wordpress, Braze, Contentstack, CircleCI, ClearBit, ClickUp, Fly.io, Fullstory, Google Play, Incident.io, Klarna, LaunchDarkly, Linear, LinkedIn, Mapbox, Mixpanel, New Relic, NextRoll, Optimizely, PagerDuty, Pendo, Plausible, Qualtrics, Sanity, Segment, Shortcut, and Travis CI.
>
> This release improves the entries for Atlassian, Codecov, Dropbox, GitHub, Google Ads, Google Cloud, PayPal, Sentry, and Zendesk.