### PR TITLE
ref(crons): Accept children for monitor processing errors alert

### DIFF
--- a/static/app/views/monitors/components/processingErrors/monitorProcessingErrors.tsx
+++ b/static/app/views/monitors/components/processingErrors/monitorProcessingErrors.tsx
@@ -19,8 +19,10 @@ import {ProcessingErrorTitle} from './processingErrorTitle';
 
 export default function MonitorProcessingErrors({
   checkinErrors,
+  children,
 }: {
   checkinErrors: CheckinProcessingError[];
+  children: React.ReactNode;
 }) {
   const flattenedErrors = checkinErrors.flatMap(({errors, checkin}) =>
     errors.map(error => ({error, checkin}))
@@ -78,7 +80,7 @@ export default function MonitorProcessingErrors({
 
   return (
     <ScrollableAlert type="error" showIcon expand={accordionErrors}>
-      {t('Errors were encountered while ingesting check-ins for this monitor')}
+      {children}
     </ScrollableAlert>
   );
 }

--- a/static/app/views/monitors/details.tsx
+++ b/static/app/views/monitors/details.tsx
@@ -145,7 +145,9 @@ function MonitorDetails({params, location}: Props) {
               </Alert>
             )}
             {!!checkinErrors?.length && (
-              <MonitorProcessingErrors checkinErrors={checkinErrors} />
+              <MonitorProcessingErrors checkinErrors={checkinErrors}>
+                {t('Errors were encountered while ingesting check-ins for this monitor')}
+              </MonitorProcessingErrors>
             )}
             {!hasLastCheckIn(monitor) ? (
               <MonitorOnboarding monitor={monitor} />


### PR DESCRIPTION
Lets accept children here so we can customize the error text, this will be useful when we add the error component on the monitor listing page and we want to display something different like:
`Errors were encountered while ingesting check-ins for the selected projects` 
or 
`for the current organization`, etc...