### PR TITLE
ref(rules): Only fetch project ids from small time period

### DIFF
--- a/src/sentry/rules/processing/delayed_processing.py
+++ b/src/sentry/rules/processing/delayed_processing.py
@@ -296,7 +296,7 @@ def process_delayed_alert_conditions() -> None:
     with metrics.timer("delayed_processing.process_all_conditions.duration"):
         fetch_time = datetime.now(tz=timezone.utc)
         project_ids = buffer.backend.get_sorted_set(
-            PROJECT_ID_BUFFER_LIST_KEY, min=float("-inf"), max=float("+inf")
+            PROJECT_ID_BUFFER_LIST_KEY, min=0, max=fetch_time.timestamp()
         )
         log_str = ""
         for project_id, timestamp in project_ids:


### PR DESCRIPTION
Undoing https://github.com/getsentry/sentry/pull/70986 since we're seeing data in the buffer now - that PR was kind of a desperate debugging attempt.