### PR TITLE
feat(crons): Pass request to quota APIs

### DIFF
--- a/src/sentry/monitors/endpoints/base_monitor_details.py
+++ b/src/sentry/monitors/endpoints/base_monitor_details.py
@@ -122,7 +122,7 @@ class MonitorDetailsMixin(BaseEndpointMixin):
 
         # Attempt to assign a monitor seat
         if params["status"] == ObjectStatus.ACTIVE and monitor.status != ObjectStatus.ACTIVE:
-            outcome = quotas.backend.assign_monitor_seat(monitor)
+            outcome = quotas.backend.assign_monitor_seat(monitor, request)
             # The MonitorValidator checks if a seat assignment is available.
             # This protects against a race condition
             if outcome != Outcome.ACCEPTED:
@@ -130,7 +130,7 @@ class MonitorDetailsMixin(BaseEndpointMixin):
 
         # Attempt to unassign the monitor seat
         if params["status"] == ObjectStatus.DISABLED and monitor.status != ObjectStatus.DISABLED:
-            quotas.backend.disable_monitor_seat(monitor)
+            quotas.backend.disable_monitor_seat(monitor, request)
 
         # Update monitor slug in billing
         if "slug" in result:

--- a/src/sentry/monitors/endpoints/organization_monitor_index.py
+++ b/src/sentry/monitors/endpoints/organization_monitor_index.py
@@ -316,7 +316,7 @@ class OrganizationMonitorIndexEndpoint(OrganizationEndpoint):
             return self.respond({type(e).__name__: str(e)}, status=403)
 
         # Attempt to assign a seat for this monitor
-        seat_outcome = quotas.backend.assign_monitor_seat(monitor)
+        seat_outcome = quotas.backend.assign_monitor_seat(monitor, request)
         if seat_outcome != Outcome.ACCEPTED:
             monitor.update(status=ObjectStatus.DISABLED)
 
@@ -390,14 +390,14 @@ class OrganizationMonitorIndexEndpoint(OrganizationEndpoint):
             with transaction.atomic(router.db_for_write(Monitor)):
                 # Attempt to assign a monitor seat
                 if status == ObjectStatus.ACTIVE:
-                    outcome = quotas.backend.assign_monitor_seat(monitor)
+                    outcome = quotas.backend.assign_monitor_seat(monitor, request)
                     if outcome != Outcome.ACCEPTED:
                         errored.append(monitor)
                         continue
 
                 # Attempt to unassign the monitor seat
                 if status == ObjectStatus.DISABLED:
-                    quotas.backend.disable_monitor_seat(monitor)
+                    quotas.backend.disable_monitor_seat(monitor, request)
 
                 monitor.update(**result)
                 updated.append(monitor)

--- a/src/sentry/quotas/base.py
+++ b/src/sentry/quotas/base.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING, Any, Literal
 
 from django.conf import settings
 from django.core.cache import cache
+from django.http import HttpRequest
 
 from sentry import features, options
 from sentry.constants import DataCategory
@@ -609,7 +610,11 @@ class Quota(Service):
         """
         return SeatAssignmentResult(assignable=True)
 
-    def assign_monitor_seat(self, monitor: Monitor) -> int:
+    def assign_monitor_seat(
+        self,
+        monitor: Monitor,
+        request: HttpRequest | None = None,
+    ) -> int:
         """
         Assigns a monitor a seat if possible, resulting in a Outcome.ACCEPTED.
         If the monitor cannot be assigned a seat it will be
@@ -619,7 +624,11 @@ class Quota(Service):
 
         return Outcome.ACCEPTED
 
-    def disable_monitor_seat(self, monitor: Monitor) -> None:
+    def disable_monitor_seat(
+        self,
+        monitor: Monitor,
+        request: HttpRequest | None = None,
+    ) -> None:
         """
         Removes a monitor from it's assigned seat.
         """

--- a/tests/sentry/monitors/endpoints/test_base_monitor_details.py
+++ b/tests/sentry/monitors/endpoints/test_base_monitor_details.py
@@ -827,7 +827,7 @@ class BaseUpdateMonitorTest(MonitorTestCase):
     ):
         check_assign_monitor_seat.return_value = SeatAssignmentResult(assignable=True)
 
-        def dummy_assign(monitor):
+        def dummy_assign(monitor, request=None):
             assert monitor.slug == old_slug
             return Outcome.ACCEPTED
 

--- a/tests/sentry/monitors/endpoints/test_organization_monitor_index.py
+++ b/tests/sentry/monitors/endpoints/test_organization_monitor_index.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from datetime import UTC, datetime, timedelta
-from unittest.mock import patch
+from unittest.mock import ANY, patch
 
 from django.conf import settings
 from django.test.utils import override_settings
@@ -480,7 +480,7 @@ class CreateOrganizationMonitorTest(MonitorTestCase):
 
         monitor = Monitor.objects.get(slug=response.data["slug"])
 
-        assign_monitor_seat.assert_called_with(monitor)
+        assign_monitor_seat.assert_called_with(monitor, ANY)
         assert monitor.status == ObjectStatus.ACTIVE
 
     @patch("sentry.quotas.backend.assign_monitor_seat")


### PR DESCRIPTION
This will allow getsentry to generate audit log entries with information
about the originating user causing seat allocation

This is part of https://github.com/getsentry/getsentry/issues/14009 (but it looks like we're not going to do this)

Proably still worth merging this for now if we do decide to add some kind of audit logs later.