### PR TITLE
fix(list-item-details): Hidden on Safari

### DIFF
--- a/static/app/components/comboBox/index.tsx
+++ b/static/app/components/comboBox/index.tsx
@@ -123,12 +123,8 @@ function ComboBox<Value extends string>({
     isOpen: state.isOpen,
     position: 'bottom-start',
     offset: [0, 8],
-    isDismissable: true,
-    onInteractOutside: () => {
-      state.close();
-      inputRef.current?.blur();
-    },
-    shouldCloseOnBlur: true,
+    // Open state is managed by useComboBoxState & useComboBox
+    isDismissable: false,
   });
 
   // The menu opens after selecting an item but the input stays focused
@@ -358,7 +354,7 @@ const StyledInput = styled(Input)`
   max-width: inherit;
   min-width: inherit;
   &:not(:focus) {
-    pointer-events: none;
+    cursor: pointer;
   }
 `;
 const StyledGrowingInput = styled(GrowingInput)`

--- a/static/app/components/menuListItem.tsx
+++ b/static/app/components/menuListItem.tsx
@@ -1,11 +1,5 @@
-import {
-  forwardRef as reactForwardRef,
-  memo,
-  type SyntheticEvent,
-  useMemo,
-  useRef,
-  useState,
-} from 'react';
+import {forwardRef as reactForwardRef, memo, useMemo, useRef, useState} from 'react';
+import {createPortal} from 'react-dom';
 import {usePopper} from 'react-popper';
 import isPropValid from '@emotion/is-prop-valid';
 import {type Theme, useTheme} from '@emotion/react';
@@ -237,10 +231,6 @@ const POPPER_OPTIONS = {
   ],
 };
 
-function stopPropagation(e: SyntheticEvent) {
-  e.stopPropagation();
-}
-
 function DetailsOverlay({
   children,
   size,
@@ -257,12 +247,8 @@ function DetailsOverlay({
 
   const popper = usePopper(itemRef.current, overlayElement, POPPER_OPTIONS);
 
-  return (
+  return createPortal(
     <StyledPositionWrapper
-      // Stop propagation so listeners on the menu-item are not triggered
-      onPointerDown={stopPropagation}
-      onMouseDown={stopPropagation}
-      onTouchStart={stopPropagation}
       {...popper.attributes.popper}
       ref={setOverlayElement}
       zIndex={theme.zIndex.tooltip}
@@ -271,7 +257,11 @@ function DetailsOverlay({
       <StyledOverlay id={id} role="tooltip" placement="right-start" size={size}>
         {children}
       </StyledOverlay>
-    </StyledPositionWrapper>
+    </StyledPositionWrapper>,
+    // Safari will clip the overlay if it is inside a scrollable container, even though it is positioned fixed.
+    // See https://bugs.webkit.org/show_bug.cgi?id=160953
+    // To work around this, we append the overlay to the body
+    document.body
   );
 }
 

--- a/static/app/views/metrics/metricListItemDetails.tsx
+++ b/static/app/views/metrics/metricListItemDetails.tsx
@@ -1,4 +1,11 @@
-import {Fragment, startTransition, useEffect, useMemo, useState} from 'react';
+import {
+  Fragment,
+  startTransition,
+  type SyntheticEvent,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react';
 import styled from '@emotion/styled';
 
 import {navigateTo} from 'sentry/actionCreators/navigation';
@@ -8,7 +15,8 @@ import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {IconSettings, IconWarning} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
-import type {MetricMeta, MRI, Project} from 'sentry/types';
+import type {MetricMeta, MRI} from 'sentry/types/metrics';
+import type {Project} from 'sentry/types/project';
 import {getReadableMetricType} from 'sentry/utils/metrics/formatters';
 import {formatMRI, parseMRI} from 'sentry/utils/metrics/mri';
 import {
@@ -23,6 +31,11 @@ const MAX_PROJECTS_TO_SHOW = 3;
 const MAX_TAGS_TO_SHOW = 5;
 
 const STANDARD_TAGS = ['release', 'environment', 'transaction', 'project'];
+
+function stopPropagationAndPreventDefault(e: SyntheticEvent) {
+  e.stopPropagation();
+  e.preventDefault();
+}
 
 export function MetricListItemDetails({
   metric,
@@ -101,7 +114,10 @@ export function MetricListItemDetails({
   const firstMetricProject = metricProjects[0];
 
   return (
-    <DetailsWrapper>
+    <DetailsWrapper
+      // Stop propagation and default behaviour to keep the focus in the combobox
+      onMouseDown={stopPropagationAndPreventDefault}
+    >
       <Header>
         <MetricName>
           {/* Add zero width spaces at delimiter characters for nice word breaks */}


### PR DESCRIPTION
### Problem
On Safari the details overlay is not visible once the menu list item is inside a scrollable menu that has a z-index set.
Basically, affecting all out current use cases where absolutely positioned menus float above the page content.

There is an open bug report for this on the webkit bug reporting platform:
https://bugs.webkit.org/show_bug.cgi?id=160953

### Solution
Use `createPortal` to mount the overlay directly in the body and adjust event handling for the combobox to keep interactive elements inside interactive. 

Closes https://github.com/getsentry/sentry/issues/69849