### PR TITLE
feat(dashboards): metric widget legend

### DIFF
--- a/static/app/views/dashboards/metrics/chart.tsx
+++ b/static/app/views/dashboards/metrics/chart.tsx
@@ -3,8 +3,8 @@ import styled from '@emotion/styled';
 
 import TransitionChart from 'sentry/components/charts/transitionChart';
 import {space} from 'sentry/styles/space';
-import type {MetricsQueryApiResponse} from 'sentry/types';
 import type {ReactEchartsRef} from 'sentry/types/echarts';
+import type {MetricsQueryApiResponse} from 'sentry/types/metrics';
 import type {MetricDisplayType} from 'sentry/utils/metrics/types';
 import type {MetricsQueryApiQueryParams} from 'sentry/utils/metrics/useMetricsQuery';
 import {LoadingScreen} from 'sentry/views/dashboards/widgetCard/widgetCardChartContainer';
@@ -19,6 +19,7 @@ type MetricChartContainerProps = {
   isLoading: boolean;
   metricQueries: MetricsQueryApiQueryParams[];
   chartHeight?: number;
+  showLegend?: boolean;
   timeseriesData?: MetricsQueryApiResponse;
 };
 
@@ -28,6 +29,7 @@ export function MetricChartContainer({
   metricQueries,
   chartHeight,
   displayType,
+  showLegend,
 }: MetricChartContainerProps) {
   const chartRef = useRef<ReactEchartsRef>(null);
 
@@ -50,6 +52,7 @@ export function MetricChartContainer({
           group={DASHBOARD_CHART_GROUP}
           height={chartHeight}
           enableZoom
+          showLegend={showLegend}
         />
       </TransitionChart>
     </MetricWidgetChartWrapper>
@@ -60,5 +63,5 @@ const MetricWidgetChartWrapper = styled('div')`
   height: 100%;
   width: 100%;
   padding: ${space(3)};
-  padding-top: ${space(2)};
+  padding-top: ${space(0.25)};
 `;

--- a/static/app/views/dashboards/metrics/widgetCard.tsx
+++ b/static/app/views/dashboards/metrics/widgetCard.tsx
@@ -10,7 +10,8 @@ import TextOverflow from 'sentry/components/textOverflow';
 import {IconWarning} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
-import type {Organization, PageFilters} from 'sentry/types';
+import type {PageFilters} from 'sentry/types/core';
+import type {Organization} from 'sentry/types/organization';
 import {useMetricsQuery} from 'sentry/utils/metrics/useMetricsQuery';
 import {MetricBigNumberContainer} from 'sentry/views/dashboards/metrics/bigNumber';
 import {MetricChartContainer} from 'sentry/views/dashboards/metrics/chart';
@@ -97,6 +98,7 @@ export function MetricWidgetCard({
         metricQueries={metricQueries}
         displayType={toMetricDisplayType(widget.displayType)}
         chartHeight={!showContextMenu ? 200 : undefined}
+        showLegend
       />
     );
   }, [widget.displayType, metricQueries, timeseriesData, isLoading, showContextMenu]);

--- a/static/app/views/metrics/chart/chart.tsx
+++ b/static/app/views/metrics/chart/chart.tsx
@@ -9,7 +9,7 @@ import omitBy from 'lodash/omitBy';
 
 import {transformToAreaSeries} from 'sentry/components/charts/areaChart';
 import {transformToBarSeries} from 'sentry/components/charts/barChart';
-import BaseChart from 'sentry/components/charts/baseChart';
+import BaseChart, {type BaseChartProps} from 'sentry/components/charts/baseChart';
 import {
   defaultFormatAxisLabel,
   getFormatter,
@@ -41,7 +41,35 @@ type ChartProps = {
   height?: number;
   releases?: UseMetricReleasesResult;
   samples?: UseMetricSamplesResult;
+  showLegend?: boolean;
 };
+
+function getLegendProps(showLegend?: boolean): Pick<BaseChartProps, 'legend' | 'grid'> {
+  if (showLegend) {
+    return {
+      legend: {
+        show: true,
+        left: 0,
+        top: 0,
+      },
+      grid: {
+        top: 40,
+        bottom: 0,
+        left: 0,
+        right: 0,
+      },
+    };
+  }
+
+  return {
+    grid: {
+      top: 5,
+      bottom: 0,
+      left: 0,
+      right: 0,
+    },
+  };
+}
 
 // We need to enable canvas renderer for echarts before we use it here.
 // Once we use it in more places, this should probably move to a more global place
@@ -87,6 +115,7 @@ export const MetricChart = memo(
         enableZoom,
         releases,
         additionalSeries,
+        showLegend,
       },
       forwardedRef
     ) => {
@@ -178,6 +207,7 @@ export const MetricChart = memo(
         let baseChartProps: CombinedMetricChartProps = {
           ...heightOptions,
           ...dateTimeOptions,
+          ...getLegendProps(showLegend),
           displayType,
           forwardedRef: mergeRefs([forwardedRef, chartRef]),
           series: seriesToShow,
@@ -185,12 +215,6 @@ export const MetricChart = memo(
           renderer: 'canvas' as const,
           isGroupedByDate: true,
           colors: seriesToShow.map(s => s.color),
-          grid: {
-            top: 5,
-            bottom: 0,
-            left: 0,
-            right: 0,
-          },
           additionalSeries,
           tooltip: {
             formatter: (params, asyncTicket) => {
@@ -338,6 +362,7 @@ export const MetricChart = memo(
         releases,
         firstUnit,
         additionalSeries,
+        showLegend,
       ]);
 
       if (!enableZoom) {


### PR DESCRIPTION
- closes: #71230 

Adds a `showLegend` prop that is used to toggle Echarts legend in metrics chart

Before: 
![image](https://github.com/getsentry/sentry/assets/86684834/a872d34d-7f92-41c3-a5eb-497a01c9d95a)

After:
![image](https://github.com/getsentry/sentry/assets/86684834/0cec9e70-2eb0-4248-94fb-258f614941d1)
