### PR TITLE
feat(metrics): Expose span.duration

### DIFF
--- a/static/app/utils/metrics/index.tsx
+++ b/static/app/utils/metrics/index.tsx
@@ -337,13 +337,6 @@ export function isSpanDuration({mri}: {mri: MRI}) {
   return mri === 'd:spans/duration@millisecond';
 }
 
-export function isSpanSelfTime({mri}: {mri: MRI}) {
-  return (
-    mri === 'd:spans/exclusive_time@millisecond' ||
-    mri === 'g:spans/self_time@millisecond'
-  );
-}
-
 export function isGaugeMetric({mri}: {mri: MRI}) {
   return parseMRI(mri)?.type === 'g';
 }

--- a/static/app/utils/metrics/index.tsx
+++ b/static/app/utils/metrics/index.tsx
@@ -333,6 +333,10 @@ export function isCustomMetric({mri}: {mri: MRI}) {
   return mri.includes(':custom/');
 }
 
+export function isSpanDuration({mri}: {mri: MRI}) {
+  return mri === 'd:spans/duration@millisecond';
+}
+
 export function isSpanSelfTime({mri}: {mri: MRI}) {
   return (
     mri === 'd:spans/exclusive_time@millisecond' ||

--- a/static/app/utils/metrics/useMetricsTags.tsx
+++ b/static/app/utils/metrics/useMetricsTags.tsx
@@ -82,7 +82,7 @@ export function useMetricsTags(
   if (mri === SPAN_DURATION_MRI) {
     tags = {
       ...tags,
-      data: tags.data?.filter(tag => ALLOWED_SPAN_DURATION_TAGS.includes(tag.key)),
+      data: tags.data?.filter(tag => ALLOWED_SPAN_DURATION_TAGS.includes(tag.key)) ?? [],
     };
   }
 

--- a/static/app/utils/metrics/useMetricsTags.tsx
+++ b/static/app/utils/metrics/useMetricsTags.tsx
@@ -80,7 +80,8 @@ export function useMetricsTags(
       tagsQuery.data?.filter(
         tag =>
           !blockedTagsData.includes(tag.key) ||
-          // The span duration metric will only expose certain tags to be used
+          // Span duration only exposes tags that are found on all/most spans to
+          // avoid tags that are only collected for specific Insights use cases
           (mri === SPAN_DURATION_MRI && ALLOWED_SPAN_DURATION_TAGS.includes(tag.key))
       ) ?? [],
   };

--- a/static/app/utils/metrics/useMetricsTags.tsx
+++ b/static/app/utils/metrics/useMetricsTags.tsx
@@ -8,7 +8,15 @@ import useOrganization from 'sentry/utils/useOrganization';
 import {getMetaDateTimeParams} from './index';
 
 const SPAN_DURATION_MRI = 'd:spans/duration@millisecond';
-const ALLOWED_SPAN_DURATION_TAGS = ['span.op', 'span.domain', 'span.action'];
+const ALLOWED_SPAN_DURATION_TAGS = [
+  'span.category',
+  'span.description',
+  'environment',
+  'project',
+  'span.action',
+  'span.domain',
+  'span.op',
+];
 
 export function getMetricsTagsQueryKey(
   organization: Organization,

--- a/static/app/utils/metrics/useMetricsTags.tsx
+++ b/static/app/utils/metrics/useMetricsTags.tsx
@@ -74,17 +74,14 @@ export function useMetricsTags(
     return tagsQuery;
   }
 
-  let tags = {
+  return {
     ...tagsQuery,
-    data: tagsQuery.data?.filter(tag => !blockedTagsData.includes(tag.key)) ?? [],
+    data:
+      tagsQuery.data?.filter(
+        tag =>
+          !blockedTagsData.includes(tag.key) ||
+          // The span duration metric will only expose certain tags to be used
+          (mri === SPAN_DURATION_MRI && ALLOWED_SPAN_DURATION_TAGS.includes(tag.key))
+      ) ?? [],
   };
-
-  if (mri === SPAN_DURATION_MRI) {
-    tags = {
-      ...tags,
-      data: tags.data?.filter(tag => ALLOWED_SPAN_DURATION_TAGS.includes(tag.key)) ?? [],
-    };
-  }
-
-  return tags;
 }

--- a/static/app/utils/metrics/useMetricsTags.tsx
+++ b/static/app/utils/metrics/useMetricsTags.tsx
@@ -7,6 +7,9 @@ import useOrganization from 'sentry/utils/useOrganization';
 
 import {getMetaDateTimeParams} from './index';
 
+const SPAN_DURATION_MRI = 'd:spans/duration@millisecond';
+const ALLOWED_SPAN_DURATION_TAGS = ['span.op', 'span.domain', 'span.action'];
+
 export function getMetricsTagsQueryKey(
   organization: Organization,
   mri: MRI | undefined,
@@ -63,8 +66,17 @@ export function useMetricsTags(
     return tagsQuery;
   }
 
-  return {
+  let tags = {
     ...tagsQuery,
     data: tagsQuery.data?.filter(tag => !blockedTagsData.includes(tag.key)) ?? [],
   };
+
+  if (mri === SPAN_DURATION_MRI) {
+    tags = {
+      ...tags,
+      data: tags.data?.filter(tag => ALLOWED_SPAN_DURATION_TAGS.includes(tag.key)),
+    };
+  }
+
+  return tags;
 }

--- a/static/app/views/metrics/queryBuilder.tsx
+++ b/static/app/views/metrics/queryBuilder.tsx
@@ -16,6 +16,7 @@ import {trackAnalytics} from 'sentry/utils/analytics';
 import {
   isAllowedOp,
   isCustomMetric,
+  isSpanDuration,
   isSpanMeasurement,
   isSpanSelfTime,
   isTransactionDuration,
@@ -46,7 +47,7 @@ const isVisibleTransactionMetric = (metric: MetricMeta) =>
   isTransactionDuration(metric) || isTransactionMeasurement(metric);
 
 const isVisibleSpanMetric = (metric: MetricMeta) =>
-  isSpanSelfTime(metric) || isSpanMeasurement(metric);
+  isSpanSelfTime(metric) || isSpanDuration(metric) || isSpanMeasurement(metric);
 
 const isShownByDefault = (metric: MetricMeta) =>
   isCustomMetric(metric) ||

--- a/static/app/views/metrics/queryBuilder.tsx
+++ b/static/app/views/metrics/queryBuilder.tsx
@@ -18,7 +18,6 @@ import {
   isCustomMetric,
   isSpanDuration,
   isSpanMeasurement,
-  isSpanSelfTime,
   isTransactionDuration,
   isTransactionMeasurement,
 } from 'sentry/utils/metrics';
@@ -47,7 +46,7 @@ const isVisibleTransactionMetric = (metric: MetricMeta) =>
   isTransactionDuration(metric) || isTransactionMeasurement(metric);
 
 const isVisibleSpanMetric = (metric: MetricMeta) =>
-  isSpanSelfTime(metric) || isSpanDuration(metric) || isSpanMeasurement(metric);
+  isSpanDuration(metric) || isSpanMeasurement(metric);
 
 const isShownByDefault = (metric: MetricMeta) =>
   isCustomMetric(metric) ||


### PR DESCRIPTION
Exposes span.duration in the metrics query builder with a very limited set of available tags and replaces the `self_time` and `exclusive_time` metrics. We've decided that we do not want to
show these anymore.

People who have built widgets using this dashboard will still work, but they won't be able to select the field in new widgets, or re-select it in modified widgets.