### PR TITLE
fix(dashboards): Skip applying parens in Issue widgets

### DIFF
--- a/static/app/views/dashboards/widgetCard/genericWidgetQueries.tsx
+++ b/static/app/views/dashboards/widgetCard/genericWidgetQueries.tsx
@@ -80,6 +80,9 @@ export type GenericWidgetQueriesProps<SeriesResponse, TableResponse> = {
     timeseriesResultsTypes,
   }: OnDataFetchedProps) => void;
   onDemandControlContext?: OnDemandControlContext;
+  // Skips adding parens before applying dashboard filters
+  // Used for datasets that do not support parens/boolean logic
+  skipDashboardFilterParens?: boolean;
 };
 
 type State<SeriesResponse> = {
@@ -194,13 +197,13 @@ class GenericWidgetQueries<SeriesResponse, TableResponse> extends Component<
   private _isMounted: boolean = false;
 
   applyDashboardFilters(widget: Widget): Widget {
-    const {dashboardFilters} = this.props;
+    const {dashboardFilters, skipDashboardFilterParens} = this.props;
 
     const dashboardFilterConditions = dashboardFiltersToString(dashboardFilters);
     widget.queries.forEach(query => {
       if (dashboardFilterConditions) {
         // If there is no base query, there's no need to add parens
-        if (query.conditions) {
+        if (query.conditions && !skipDashboardFilterParens) {
           query.conditions = `(${query.conditions})`;
         }
         query.conditions = query.conditions + ` ${dashboardFilterConditions}`;

--- a/static/app/views/dashboards/widgetCard/issueWidgetQueries.spec.tsx
+++ b/static/app/views/dashboards/widgetCard/issueWidgetQueries.spec.tsx
@@ -142,7 +142,7 @@ describe('IssueWidgetQueries', function () {
       expect.objectContaining({
         data: expect.objectContaining({
           query:
-            '(assigned_or_suggested:#visibility timesSeen:>100) release:["abc@1.2.0","abc@1.3.0"] ',
+            'assigned_or_suggested:#visibility timesSeen:>100 release:["abc@1.2.0","abc@1.3.0"] ',
         }),
       })
     );

--- a/static/app/views/dashboards/widgetCard/issueWidgetQueries.tsx
+++ b/static/app/views/dashboards/widgetCard/issueWidgetQueries.tsx
@@ -66,6 +66,7 @@ function IssueWidgetQueries({
         dashboardFilters={dashboardFilters}
         onDataFetched={onDataFetched}
         afterFetchTableData={afterFetchTableData}
+        skipDashboardFilterParens // Issue widgets do not support parens in search
       >
         {({loading, ...rest}) =>
           children({


### PR DESCRIPTION
Issue search doesn't support parens currently. Any queries with parens will just return no results.