### PR TITLE
chore(seer grouping): Add/fix various types

### DIFF
--- a/src/sentry/testutils/helpers/eventprocessing.py
+++ b/src/sentry/testutils/helpers/eventprocessing.py
@@ -1,10 +1,12 @@
-from typing import Any
+from typing import Any, cast
 
 from sentry.event_manager import EventManager
-from sentry.eventstore.models import Event
+from sentry.eventstore.models import Event as _Event
 from sentry.eventstore.processing import event_processing_store
+from sentry.models.group import Group
 from sentry.models.project import Project
 from sentry.testutils.helpers.task_runner import TaskRunner
+from sentry.utils.types import NonNone
 
 
 def write_event_to_cache(event):
@@ -12,6 +14,18 @@ def write_event_to_cache(event):
     cache_data["event_id"] = event.event_id
     cache_data["project"] = event.project_id
     return event_processing_store.store(cache_data)
+
+
+# Wrap the real `Event` type in order to let mypy know that certain attributes are guaranteed
+# to be defined
+class Event(_Event):
+    group: Group
+    group_id: int
+
+    # Note: This function never gets called , but writing it out this way is necessary to change the
+    # return type in mypy's eyes
+    def get_primary_hash(self) -> str:
+        return NonNone(super().get_primary_hash())
 
 
 def save_new_event(event_data: dict[str, Any], project: Project) -> Event:
@@ -25,4 +39,4 @@ def save_new_event(event_data: dict[str, Any], project: Project) -> Event:
     with TaskRunner():
         event = EventManager(event_data).save(project.id)
 
-    return event
+    return cast(Event, event)

--- a/tests/sentry/api/endpoints/test_group_similar_issues_embeddings.py
+++ b/tests/sentry/api/endpoints/test_group_similar_issues_embeddings.py
@@ -18,7 +18,6 @@ from sentry.seer.utils import SeerSimilarIssueData, SimilarIssuesEmbeddingsRespo
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.helpers.eventprocessing import save_new_event
 from sentry.testutils.helpers.features import with_feature
-from sentry.utils.types import NonNone
 
 EXPECTED_STACKTRACE_STRING = 'ZeroDivisionError: division by zero\n  File "python_onboarding.py", function divide_by_zero\n    divide = 1/0'
 BASE_APP_DATA: dict[str, Any] = {
@@ -664,15 +663,15 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
 
         similar_issue_data_1 = SeerSimilarIssueData(
             message_distance=0.05,
-            parent_group_id=NonNone(self.similar_event.group_id),
-            parent_hash=NonNone(self.similar_event.get_primary_hash()),
+            parent_group_id=self.similar_event.group_id,
+            parent_hash=self.similar_event.get_primary_hash(),
             should_group=True,
             stacktrace_distance=0.01,
         )
         similar_issue_data_2 = SeerSimilarIssueData(
             message_distance=0.49,
-            parent_group_id=NonNone(event_from_second_similar_group.group_id),
-            parent_hash=NonNone(event_from_second_similar_group.get_primary_hash()),
+            parent_group_id=event_from_second_similar_group.group_id,
+            parent_hash=event_from_second_similar_group.get_primary_hash(),
             should_group=False,
             stacktrace_distance=0.23,
         )
@@ -682,8 +681,8 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
         )
         assert formatted_results == self.get_expected_response(
             [
-                NonNone(self.similar_event.group_id),
-                NonNone(event_from_second_similar_group.group_id),
+                self.similar_event.group_id,
+                event_from_second_similar_group.group_id,
             ],
             [0.95, 0.51],
             [0.99, 0.77],
@@ -706,7 +705,7 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
             "responses": [
                 {
                     "message_distance": 0.05,
-                    "parent_hash": NonNone(self.similar_event.get_primary_hash()),
+                    "parent_hash": self.similar_event.get_primary_hash(),
                     "should_group": True,
                     "stacktrace_distance": 0.01,
                 }
@@ -720,12 +719,12 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
         )
 
         assert response.data == self.get_expected_response(
-            [NonNone(self.similar_event.group_id)], [0.95], [0.99], ["Yes"]
+            [self.similar_event.group_id], [0.95], [0.99], ["Yes"]
         )
 
         expected_seer_request_params = {
             "threshold": 0.01,
-            "hash": NonNone(self.event.get_primary_hash()),
+            "hash": self.event.get_primary_hash(),
             "project_id": self.project.id,
             "stacktrace": EXPECTED_STACKTRACE_STRING,
             "message": self.group.message,
@@ -758,19 +757,19 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
             "responses": [
                 {
                     "message_distance": 0.05,
-                    "parent_hash": NonNone(self.similar_event.get_primary_hash()),
+                    "parent_hash": self.similar_event.get_primary_hash(),
                     "should_group": True,
                     "stacktrace_distance": 0.002,  # Over threshold
                 },
                 {
                     "message_distance": 0.05,
-                    "parent_hash": NonNone(over_threshold_group_event.get_primary_hash()),
+                    "parent_hash": over_threshold_group_event.get_primary_hash(),
                     "should_group": True,
                     "stacktrace_distance": 0.002,  # Over threshold
                 },
                 {
                     "message_distance": 0.05,
-                    "parent_hash": NonNone(under_threshold_group_event.get_primary_hash()),
+                    "parent_hash": under_threshold_group_event.get_primary_hash(),
                     "should_group": False,
                     "stacktrace_distance": 0.05,  # Under threshold
                 },
@@ -785,9 +784,9 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
 
         assert response.data == self.get_expected_response(
             [
-                NonNone(self.similar_event.group_id),
-                NonNone(over_threshold_group_event.group_id),
-                NonNone(under_threshold_group_event.group_id),
+                self.similar_event.group_id,
+                over_threshold_group_event.group_id,
+                under_threshold_group_event.group_id,
             ],
             [0.95, 0.95, 0.95],
             [0.998, 0.998, 0.95],
@@ -799,7 +798,7 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
             organization_id=self.org.id,
             project_id=self.project.id,
             group_id=self.group.id,
-            hash=NonNone(self.event.get_primary_hash()),
+            hash=self.event.get_primary_hash(),
             count_over_threshold=2,
             user_id=self.user.id,
         )
@@ -817,7 +816,7 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
             "responses": [
                 {
                     "message_distance": 0.05,
-                    "parent_hash": NonNone(self.similar_event.get_primary_hash()),
+                    "parent_hash": self.similar_event.get_primary_hash(),
                     "should_group": True,
                     "stacktrace_distance": 0.01,
                 },
@@ -836,7 +835,7 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
             "Seer similar issues response entry missing key 'parent_hash'",
             extra={
                 "request_params": {
-                    "hash": NonNone(self.event.get_primary_hash()),
+                    "hash": self.event.get_primary_hash(),
                     "project_id": self.project.id,
                     "stacktrace": EXPECTED_STACKTRACE_STRING,
                     "message": self.group.message,
@@ -856,7 +855,7 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
         )
 
         assert response.data == self.get_expected_response(
-            [NonNone(self.similar_event.group_id)], [0.95], [0.99], ["Yes"]
+            [self.similar_event.group_id], [0.95], [0.99], ["Yes"]
         )
 
     @with_feature("projects:similarity-embeddings")
@@ -873,7 +872,7 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
             "responses": [
                 {
                     "message_distance": 0.05,
-                    "parent_hash": NonNone(self.similar_event.get_primary_hash()),
+                    "parent_hash": self.similar_event.get_primary_hash(),
                     "should_group": True,
                     "stacktrace_distance": 0.01,
                 },
@@ -892,7 +891,7 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
             "seer.similar_issue_request.parent_issue", tags={"outcome": "not_found"}
         )
         assert response.data == self.get_expected_response(
-            [NonNone(self.similar_event.group_id)], [0.95], [0.99], ["Yes"]
+            [self.similar_event.group_id], [0.95], [0.99], ["Yes"]
         )
 
     @with_feature("projects:similarity-embeddings")
@@ -908,7 +907,7 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
             organization_id=self.org.id,
             project_id=self.project.id,
             group_id=self.group.id,
-            hash=NonNone(self.event.get_primary_hash()),
+            hash=self.event.get_primary_hash(),
             count_over_threshold=0,
             user_id=self.user.id,
         )
@@ -976,7 +975,7 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
             "responses": [
                 {
                     "message_distance": 0.05,
-                    "parent_hash": NonNone(self.similar_event.get_primary_hash()),
+                    "parent_hash": self.similar_event.get_primary_hash(),
                     "should_group": True,
                     "stacktrace_distance": 0.01,
                 }
@@ -988,7 +987,7 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
         # Include no optional parameters
         response = self.client.get(self.path)
         assert response.data == self.get_expected_response(
-            [NonNone(self.similar_event.group_id)], [0.95], [0.99], ["Yes"]
+            [self.similar_event.group_id], [0.95], [0.99], ["Yes"]
         )
 
         mock_seer_request.assert_called_with(
@@ -997,7 +996,7 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
             body=orjson.dumps(
                 {
                     "threshold": 0.01,
-                    "hash": NonNone(self.event.get_primary_hash()),
+                    "hash": self.event.get_primary_hash(),
                     "project_id": self.project.id,
                     "stacktrace": EXPECTED_STACKTRACE_STRING,
                     "message": self.group.message,
@@ -1012,7 +1011,7 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
             data={"k": 1},
         )
         assert response.data == self.get_expected_response(
-            [NonNone(self.similar_event.group_id)], [0.95], [0.99], ["Yes"]
+            [self.similar_event.group_id], [0.95], [0.99], ["Yes"]
         )
 
         mock_seer_request.assert_called_with(
@@ -1021,7 +1020,7 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
             body=orjson.dumps(
                 {
                     "threshold": 0.01,
-                    "hash": NonNone(self.event.get_primary_hash()),
+                    "hash": self.event.get_primary_hash(),
                     "project_id": self.project.id,
                     "stacktrace": EXPECTED_STACKTRACE_STRING,
                     "message": self.group.message,
@@ -1037,7 +1036,7 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
             data={"threshold": "0.01"},
         )
         assert response.data == self.get_expected_response(
-            [NonNone(self.similar_event.group_id)], [0.95], [0.99], ["Yes"]
+            [self.similar_event.group_id], [0.95], [0.99], ["Yes"]
         )
 
         mock_seer_request.assert_called_with(
@@ -1046,7 +1045,7 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
             body=orjson.dumps(
                 {
                     "threshold": 0.01,
-                    "hash": NonNone(self.event.get_primary_hash()),
+                    "hash": self.event.get_primary_hash(),
                     "project_id": self.project.id,
                     "stacktrace": EXPECTED_STACKTRACE_STRING,
                     "message": self.group.message,

--- a/tests/sentry/api/endpoints/test_group_similar_issues_embeddings.py
+++ b/tests/sentry/api/endpoints/test_group_similar_issues_embeddings.py
@@ -1,7 +1,8 @@
 import copy
-from collections.abc import Mapping, Sequence
+from collections.abc import Callable, Mapping, Sequence
 from typing import Any
 from unittest import mock
+from unittest.mock import MagicMock
 
 import orjson
 from urllib3.response import HTTPResponse
@@ -397,8 +398,11 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
         )
 
     def create_exception(
-        self, exception_type_str="Exception", exception_value="it broke", frames=None
-    ):
+        self,
+        exception_type_str: str = "Exception",
+        exception_value: str = "it broke",
+        frames: list[dict[str, Any]] | None = None,
+    ) -> dict[str, Any]:
         frames = frames or []
         return {
             "id": "exception",
@@ -432,11 +436,11 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
 
     def create_frames(
         self,
-        num_frames,
-        contributes=True,
-        start_index=1,
-        context_line_factory=lambda i: f"test = {i}!",
-    ):
+        num_frames: int,
+        contributes: bool = True,
+        start_index: int = 1,
+        context_line_factory: Callable[[int], str] = lambda i: f"test = {i}!",
+    ) -> list[dict[str, Any]]:
         frames = []
         for i in range(start_index, start_index + num_frames):
             frames.append(
@@ -697,7 +701,9 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
     @mock.patch("sentry.seer.utils.metrics")
     @mock.patch("sentry.seer.utils.seer_grouping_connection_pool.urlopen")
     @mock.patch("sentry.api.endpoints.group_similar_issues_embeddings.logger")
-    def test_simple(self, mock_logger, mock_seer_request, mock_metrics):
+    def test_simple(
+        self, mock_logger: MagicMock, mock_seer_request: MagicMock, mock_metrics: MagicMock
+    ):
         seer_return_value: SimilarIssuesEmbeddingsResponse = {
             "responses": [
                 {
@@ -746,7 +752,7 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
     @with_feature("projects:similarity-embeddings")
     @mock.patch("sentry.analytics.record")
     @mock.patch("sentry.seer.utils.seer_grouping_connection_pool.urlopen")
-    def test_multiple(self, mock_seer_request, mock_record):
+    def test_multiple(self, mock_seer_request: MagicMock, mock_record: MagicMock):
         over_threshold_group_event = save_new_event({"message": "Maisey is silly"}, self.project)
         under_threshold_group_event = save_new_event({"message": "Charlie is goofy"}, self.project)
 
@@ -804,7 +810,9 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
     @mock.patch("sentry.seer.utils.metrics")
     @mock.patch("sentry.seer.utils.logger")
     @mock.patch("sentry.seer.utils.seer_grouping_connection_pool.urlopen")
-    def test_incomplete_return_data(self, mock_seer_request, mock_logger, mock_metrics):
+    def test_incomplete_return_data(
+        self, mock_seer_request: MagicMock, mock_logger: MagicMock, mock_metrics: MagicMock
+    ):
         # Two suggested groups, one with valid data, one missing parent hash. We should log the
         # second and return the first.
         seer_return_value: Any = {
@@ -856,7 +864,7 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
     @with_feature("projects:similarity-embeddings")
     @mock.patch("sentry.seer.utils.metrics")
     @mock.patch("sentry.seer.utils.seer_grouping_connection_pool.urlopen")
-    def test_nonexistent_group(self, mock_seer_request, mock_metrics):
+    def test_nonexistent_group(self, mock_seer_request: MagicMock, mock_metrics: MagicMock):
         """
         The seer API can return groups that do not exist if they have been deleted/merged.
         Test that these groups are not returned.
@@ -892,7 +900,7 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
     @with_feature("projects:similarity-embeddings")
     @mock.patch("sentry.analytics.record")
     @mock.patch("sentry.seer.utils.seer_grouping_connection_pool.urlopen")
-    def test_empty_seer_return(self, mock_seer_request, mock_record):
+    def test_empty_seer_return(self, mock_seer_request: MagicMock, mock_record: MagicMock):
         mock_seer_request.return_value = HTTPResponse([])
         response = self.client.get(self.path)
         assert response.data == []
@@ -962,7 +970,7 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
 
     @with_feature("projects:similarity-embeddings")
     @mock.patch("sentry.seer.utils.seer_grouping_connection_pool.urlopen")
-    def test_no_optional_params(self, mock_seer_request):
+    def test_no_optional_params(self, mock_seer_request: MagicMock):
         """
         Test that optional parameters, k and threshold, can not be included.
         """

--- a/tests/sentry/api/endpoints/test_group_similar_issues_embeddings.py
+++ b/tests/sentry/api/endpoints/test_group_similar_issues_embeddings.py
@@ -389,13 +389,11 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
             },
             "platform": "python",
         }
-        self.event = self.store_event(data=self.base_error_trace, project_id=self.project)
+        self.event = save_new_event(self.base_error_trace, self.project)
         self.group = self.event.group
         assert self.group
         self.path = f"/api/0/issues/{self.group.id}/similar-issues-embeddings/"
-        self.similar_event = self.store_event(
-            data={"message": "Dogs are great!"}, project_id=self.project
-        )
+        self.similar_event = save_new_event({"message": "Dogs are great!"}, self.project)
 
     def create_exception(
         self,

--- a/tests/sentry/event_manager/grouping/test_seer_grouping.py
+++ b/tests/sentry/event_manager/grouping/test_seer_grouping.py
@@ -10,7 +10,6 @@ from sentry.testutils.helpers import Feature
 from sentry.testutils.helpers.eventprocessing import save_new_event
 from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.pytest.mocking import capture_results
-from sentry.utils.types import NonNone
 
 
 class SeerEventManagerGroupingTest(TestCase):
@@ -19,8 +18,8 @@ class SeerEventManagerGroupingTest(TestCase):
     def test_obeys_seer_similarity_flags(self):
         existing_event = save_new_event({"message": "Dogs are great!"}, self.project)
         seer_result_data = SeerSimilarIssueData(
-            parent_hash=NonNone(existing_event.get_primary_hash()),
-            parent_group_id=NonNone(existing_event.group_id),
+            parent_hash=existing_event.get_primary_hash(),
+            parent_group_id=existing_event.group_id,
             stacktrace_distance=0.01,
             message_distance=0.05,
             should_group=True,
@@ -62,7 +61,7 @@ class SeerEventManagerGroupingTest(TestCase):
                 assert get_seer_similar_issues_spy.call_count == 0
 
                 # No metadata stored, parent group not used (even though `should_group` is True)
-                assert "seer_similarity" not in NonNone(new_event.group).data["metadata"]
+                assert "seer_similarity" not in new_event.group.data["metadata"]
                 assert "seer_similarity" not in new_event.data
                 assert new_event.group_id != existing_event.group_id
 
@@ -84,10 +83,7 @@ class SeerEventManagerGroupingTest(TestCase):
 
                 # Metadata returned and stored
                 assert get_seer_similar_issues_return_values[0][0] == expected_metadata
-                assert (
-                    NonNone(new_event.group).data["metadata"]["seer_similarity"]
-                    == expected_metadata
-                )
+                assert new_event.group.data["metadata"]["seer_similarity"] == expected_metadata
                 assert new_event.data["seer_similarity"] == expected_metadata
 
                 # No parent group returned or used (even though `should_group` is True)
@@ -168,8 +164,8 @@ class SeerEventManagerGroupingTest(TestCase):
         existing_event = save_new_event({"message": "Dogs are great!"}, self.project)
 
         seer_result_data = SeerSimilarIssueData(
-            parent_hash=NonNone(existing_event.get_primary_hash()),
-            parent_group_id=NonNone(existing_event.group_id),
+            parent_hash=existing_event.get_primary_hash(),
+            parent_group_id=existing_event.group_id,
             stacktrace_distance=0.01,
             message_distance=0.05,
             should_group=True,
@@ -186,7 +182,7 @@ class SeerEventManagerGroupingTest(TestCase):
                 "results": [asdict(seer_result_data)],
             }
 
-        assert NonNone(new_event.group).data["metadata"]["seer_similarity"] == expected_metadata
+        assert new_event.group.data["metadata"]["seer_similarity"] == expected_metadata
         assert new_event.data["seer_similarity"] == expected_metadata
 
     @with_feature("projects:similarity-embeddings-grouping")
@@ -194,8 +190,8 @@ class SeerEventManagerGroupingTest(TestCase):
         existing_event = save_new_event({"message": "Dogs are great!"}, self.project)
 
         seer_result_data = SeerSimilarIssueData(
-            parent_hash=NonNone(existing_event.get_primary_hash()),
-            parent_group_id=NonNone(existing_event.group_id),
+            parent_hash=existing_event.get_primary_hash(),
+            parent_group_id=existing_event.group_id,
             stacktrace_distance=0.01,
             message_distance=0.05,
             should_group=True,
@@ -223,8 +219,8 @@ class SeerEventManagerGroupingTest(TestCase):
         existing_event = save_new_event({"message": "Dogs are great!"}, self.project)
 
         no_cigar_data = SeerSimilarIssueData(
-            parent_hash=NonNone(existing_event.get_primary_hash()),
-            parent_group_id=NonNone(existing_event.group_id),
+            parent_hash=existing_event.get_primary_hash(),
+            parent_group_id=existing_event.group_id,
             stacktrace_distance=0.10,
             message_distance=0.05,
             should_group=False,

--- a/tests/sentry/grouping/test_seer.py
+++ b/tests/sentry/grouping/test_seer.py
@@ -10,7 +10,6 @@ from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers import Feature
 from sentry.testutils.helpers.eventprocessing import save_new_event
 from sentry.testutils.helpers.features import with_feature
-from sentry.utils.types import NonNone
 
 
 class ShouldCallSeerTest(TestCase):
@@ -74,8 +73,8 @@ class GetSeerSimilarIssuesTest(TestCase):
     @with_feature({"projects:similarity-embeddings-grouping": False})
     def test_returns_metadata_but_no_group_if_seer_grouping_flag_off(self):
         seer_result_data = SeerSimilarIssueData(
-            parent_hash=NonNone(self.existing_event.get_primary_hash()),
-            parent_group_id=NonNone(self.existing_event.group_id),
+            parent_hash=self.existing_event.get_primary_hash(),
+            parent_group_id=self.existing_event.group_id,
             stacktrace_distance=0.01,
             message_distance=0.05,
             should_group=True,
@@ -98,8 +97,8 @@ class GetSeerSimilarIssuesTest(TestCase):
     @with_feature("projects:similarity-embeddings-grouping")
     def test_returns_metadata_and_group_if_sufficiently_close_group_found(self):
         seer_result_data = SeerSimilarIssueData(
-            parent_hash=NonNone(self.existing_event.get_primary_hash()),
-            parent_group_id=NonNone(self.existing_event.group_id),
+            parent_hash=self.existing_event.get_primary_hash(),
+            parent_group_id=self.existing_event.group_id,
             stacktrace_distance=0.01,
             message_distance=0.05,
             should_group=True,
@@ -122,8 +121,8 @@ class GetSeerSimilarIssuesTest(TestCase):
     @with_feature("projects:similarity-embeddings-grouping")
     def test_returns_metadata_but_no_group_if_similar_group_insufficiently_close(self):
         seer_result_data = SeerSimilarIssueData(
-            parent_hash=NonNone(self.existing_event.get_primary_hash()),
-            parent_group_id=NonNone(self.existing_event.group_id),
+            parent_hash=self.existing_event.get_primary_hash(),
+            parent_group_id=self.existing_event.group_id,
             stacktrace_distance=0.08,
             message_distance=0.12,
             should_group=False,

--- a/tests/sentry/seer/test_utils.py
+++ b/tests/sentry/seer/test_utils.py
@@ -25,7 +25,6 @@ from sentry.seer.utils import (
 from sentry.testutils.helpers.eventprocessing import save_new_event
 from sentry.testutils.pytest.fixtures import django_db_all
 from sentry.utils import json
-from sentry.utils.types import NonNone
 
 DUMMY_POOL = ConnectionPool("dummy")
 CREATE_GROUPING_RECORDS_REQUEST_PARAMS: CreateGroupingRecordsRequest = {
@@ -89,7 +88,7 @@ def test_similar_issues_embeddings_simple(mock_seer_request: MagicMock, default_
 
     raw_similar_issue_data: RawSeerSimilarIssueData = {
         "message_distance": 0.05,
-        "parent_hash": NonNone(similar_event.get_primary_hash()),
+        "parent_hash": similar_event.get_primary_hash(),
         "should_group": True,
         "stacktrace_distance": 0.01,
     }
@@ -98,7 +97,7 @@ def test_similar_issues_embeddings_simple(mock_seer_request: MagicMock, default_
     mock_seer_request.return_value = HTTPResponse(json.dumps(seer_return_value).encode("utf-8"))
 
     params: SimilarIssuesEmbeddingsRequest = {
-        "hash": NonNone(event.get_primary_hash()),
+        "hash": event.get_primary_hash(),
         "project_id": default_project.id,
         "stacktrace": "string",
         "message": "message",
@@ -121,7 +120,7 @@ def test_empty_similar_issues_embeddings(mock_seer_request: MagicMock, default_p
     mock_seer_request.return_value = HTTPResponse([])
 
     params: SimilarIssuesEmbeddingsRequest = {
-        "hash": NonNone(event.get_primary_hash()),
+        "hash": event.get_primary_hash(),
         "project_id": default_project.id,
         "stacktrace": "string",
         "message": "message",
@@ -138,13 +137,13 @@ def test_returns_sorted_similarity_results(mock_seer_request: MagicMock, default
 
     raw_similar_issue_data: RawSeerSimilarIssueData = {
         "message_distance": 0.05,
-        "parent_hash": NonNone(similar_event.get_primary_hash()),
+        "parent_hash": similar_event.get_primary_hash(),
         "should_group": True,
         "stacktrace_distance": 0.01,
     }
     raw_less_similar_issue_data: RawSeerSimilarIssueData = {
         "message_distance": 0.10,
-        "parent_hash": NonNone(less_similar_event.get_primary_hash()),
+        "parent_hash": less_similar_event.get_primary_hash(),
         "should_group": False,
         "stacktrace_distance": 0.05,
     }
@@ -154,7 +153,7 @@ def test_returns_sorted_similarity_results(mock_seer_request: MagicMock, default
     mock_seer_request.return_value = HTTPResponse(json.dumps(seer_return_value).encode("utf-8"))
 
     params: SimilarIssuesEmbeddingsRequest = {
-        "hash": NonNone(event.get_primary_hash()),
+        "hash": event.get_primary_hash(),
         "project_id": default_project.id,
         "stacktrace": "string",
         "message": "message",
@@ -181,14 +180,14 @@ def test_from_raw_simple(default_project: Project):
     similar_event = save_new_event({"message": "Dogs are great!"}, default_project)
     raw_similar_issue_data: RawSeerSimilarIssueData = {
         "message_distance": 0.05,
-        "parent_hash": NonNone(similar_event.get_primary_hash()),
+        "parent_hash": similar_event.get_primary_hash(),
         "should_group": True,
         "stacktrace_distance": 0.01,
     }
 
     similar_issue_data = {
         **raw_similar_issue_data,
-        "parent_group_id": NonNone(similar_event.group_id),
+        "parent_group_id": similar_event.group_id,
     }
 
     assert SeerSimilarIssueData.from_raw(
@@ -203,7 +202,7 @@ def test_from_raw_unexpected_data(default_project: Project):
     similar_event = save_new_event({"message": "Dogs are great!"}, default_project)
     raw_similar_issue_data = {
         "message_distance": 0.05,
-        "parent_hash": NonNone(similar_event.get_primary_hash()),
+        "parent_hash": similar_event.get_primary_hash(),
         "should_group": True,
         "stacktrace_distance": 0.01,
         "something": "unexpected",
@@ -211,10 +210,10 @@ def test_from_raw_unexpected_data(default_project: Project):
 
     expected_similar_issue_data = {
         "message_distance": 0.05,
-        "parent_hash": NonNone(similar_event.get_primary_hash()),
+        "parent_hash": similar_event.get_primary_hash(),
         "should_group": True,
         "stacktrace_distance": 0.01,
-        "parent_group_id": NonNone(similar_event.group_id),
+        "parent_group_id": similar_event.group_id,
     }
 
     # Everything worked fine, in spite of the extra data
@@ -247,7 +246,7 @@ def test_from_raw_missing_data(default_project: Project):
         match="Seer similar issues response entry missing key 'message_distance'",
     ):
         raw_similar_issue_data = {
-            "parent_hash": NonNone(similar_event.get_primary_hash()),
+            "parent_hash": similar_event.get_primary_hash(),
             # missing `message_distance`
             "should_group": True,
             "stacktrace_distance": 0.01,
@@ -260,7 +259,7 @@ def test_from_raw_missing_data(default_project: Project):
         match="Seer similar issues response entry missing keys 'message_distance', 'stacktrace_distance'",
     ):
         raw_similar_issue_data = {
-            "parent_hash": NonNone(similar_event.get_primary_hash()),
+            "parent_hash": similar_event.get_primary_hash(),
             # missing `message_distance`
             "should_group": True,
             # missing `stacktrace_distance`


### PR DESCRIPTION
This fixes and improves types in various places in the Seer similar issues code.

- Add types to tests.

- Add type to the `group` parameter in `GroupSimilarIssuesEmbeddingsEndpoint.get`. This in turn gave a type to `latest_event`, which necessitated two other changes:
  - A cast from `GroupEvent` to `Event`. The differences between the two, which have to do with issue platform `occurrence`s and the way that the `group` and `group_id` attributes are stored under the hood, aren't relevant here, and everything downstream expects an `Event`.
  - A non-null assertion on the hash. (Someday we should figure out when, if ever, the hash actually can be `None`, and clean up the typing here.)

- Handle the potential `None`-ness of various event attributes in tests better, by eliminating the `None` option in the `save_new_event` helper rather than being forced to do so on every instance of a value it returns. This works by having it return a subclass of `Event` in which the relevant attributes are guaranteed to have real values.