### PR TITLE
chore(seer grouping): Move backfill seer utils to separate module

### DIFF
--- a/src/sentry/seer/similarity/backfill.py
+++ b/src/sentry/seer/similarity/backfill.py
@@ -1,0 +1,105 @@
+import logging
+from typing import NotRequired, TypedDict
+
+from django.conf import settings
+from urllib3.exceptions import ReadTimeoutError
+
+from sentry.conf.server import SEER_GROUPING_RECORDS_DELETE_URL, SEER_GROUPING_RECORDS_URL
+from sentry.net.http import connection_from_url
+from sentry.seer.utils import RawSeerSimilarIssueData
+from sentry.utils import json
+
+logger = logging.getLogger(__name__)
+
+POST_BULK_GROUPING_RECORDS_TIMEOUT = 10000
+
+
+class CreateGroupingRecordData(TypedDict):
+    group_id: int
+    hash: str
+    project_id: int
+    message: str
+
+
+class CreateGroupingRecordsRequest(TypedDict):
+    group_id_list: list[int]
+    data: list[CreateGroupingRecordData]
+    stacktrace_list: list[str]
+
+
+class BulkCreateGroupingRecordsResponse(TypedDict):
+    success: bool
+    groups_with_neighbor: NotRequired[dict[str, RawSeerSimilarIssueData]]
+
+
+seer_grouping_connection_pool = connection_from_url(
+    settings.SEER_GROUPING_URL,
+    timeout=settings.SEER_GROUPING_TIMEOUT,
+)
+
+
+def post_bulk_grouping_records(
+    grouping_records_request: CreateGroupingRecordsRequest,
+) -> BulkCreateGroupingRecordsResponse:
+    """Call /v0/issues/similar-issues/grouping-record endpoint from seer."""
+    if not grouping_records_request.get("data"):
+        return {"success": True}
+
+    extra = {
+        "group_ids": json.dumps(grouping_records_request["group_id_list"]),
+        "project_id": grouping_records_request["data"][0]["project_id"],
+        "stacktrace_length_sum": sum(
+            [len(stacktrace) for stacktrace in grouping_records_request["stacktrace_list"]]
+        ),
+    }
+
+    try:
+        response = seer_grouping_connection_pool.urlopen(
+            "POST",
+            SEER_GROUPING_RECORDS_URL,
+            body=json.dumps(grouping_records_request),
+            headers={"Content-Type": "application/json;charset=utf-8"},
+            timeout=POST_BULK_GROUPING_RECORDS_TIMEOUT,
+        )
+    except ReadTimeoutError:
+        extra.update({"reason": "ReadTimeoutError", "timeout": POST_BULK_GROUPING_RECORDS_TIMEOUT})
+        logger.info("seer.post_bulk_grouping_records.failure", extra=extra)
+        return {"success": False}
+
+    if response.status >= 200 and response.status < 300:
+        logger.info("seer.post_bulk_grouping_records.success", extra=extra)
+        return json.loads(response.data.decode("utf-8"))
+    else:
+        extra.update({"reason": response.reason})
+        logger.info("seer.post_bulk_grouping_records.failure", extra=extra)
+        return {"success": False}
+
+
+def delete_grouping_records(
+    project_id: int,
+) -> bool:
+    try:
+        response = seer_grouping_connection_pool.urlopen(
+            "GET",
+            f"{SEER_GROUPING_RECORDS_DELETE_URL}/{project_id}",
+            headers={"Content-Type": "application/json;charset=utf-8"},
+            timeout=POST_BULK_GROUPING_RECORDS_TIMEOUT,
+        )
+    except ReadTimeoutError:
+        logger.exception(
+            "seer.delete_grouping_records.timeout",
+            extra={"reason": "ReadTimeoutError", "timeout": POST_BULK_GROUPING_RECORDS_TIMEOUT},
+        )
+        return False
+
+    if response.status >= 200 and response.status < 300:
+        logger.info(
+            "seer.delete_grouping_records.success",
+            extra={"project_id": project_id},
+        )
+        return True
+    else:
+        logger.error(
+            "seer.delete_grouping_records.failure",
+        )
+        return False

--- a/src/sentry/tasks/backfill_seer_grouping_records.py
+++ b/src/sentry/tasks/backfill_seer_grouping_records.py
@@ -22,14 +22,16 @@ from sentry.issues.occurrence_consumer import EventLookupError
 from sentry.models.group import Group
 from sentry.models.grouphash import GroupHash
 from sentry.models.project import Project
-from sentry.seer.utils import (
+from sentry.seer.similarity.backfill import (
     CreateGroupingRecordData,
     CreateGroupingRecordsRequest,
+    delete_grouping_records,
+    post_bulk_grouping_records,
+)
+from sentry.seer.utils import (
     IncompleteSeerDataError,
     SeerSimilarIssueData,
     SimilarGroupNotFoundError,
-    delete_grouping_records,
-    post_bulk_grouping_records,
 )
 from sentry.silo.base import SiloMode
 from sentry.snuba.dataset import Dataset

--- a/tests/sentry/seer/similarity/test_backfill.py
+++ b/tests/sentry/seer/similarity/test_backfill.py
@@ -1,0 +1,106 @@
+import copy
+from unittest import mock
+from unittest.mock import MagicMock
+
+from django.conf import settings
+from urllib3.connectionpool import ConnectionPool
+from urllib3.exceptions import ReadTimeoutError
+from urllib3.response import HTTPResponse
+
+from sentry.seer.similarity.backfill import (
+    POST_BULK_GROUPING_RECORDS_TIMEOUT,
+    CreateGroupingRecordsRequest,
+    post_bulk_grouping_records,
+)
+from sentry.utils import json
+
+DUMMY_POOL = ConnectionPool("dummy")
+CREATE_GROUPING_RECORDS_REQUEST_PARAMS: CreateGroupingRecordsRequest = {
+    "group_id_list": [1, 2],
+    "data": [
+        {"group_id": 1, "hash": "hash-1", "project_id": 1, "message": "message"},
+        {"group_id": 2, "hash": "hash-2", "project_id": 1, "message": "message 2"},
+    ],
+    "stacktrace_list": ["stacktrace 1", "stacktrace 2"],
+}
+
+
+@mock.patch("sentry.seer.similarity.backfill.logger")
+@mock.patch("sentry.seer.similarity.backfill.seer_grouping_connection_pool.urlopen")
+def test_post_bulk_grouping_records_success(mock_seer_request: MagicMock, mock_logger: MagicMock):
+    expected_return_value = {
+        "success": True,
+        "groups_with_neighbor": {"1": "00000000000000000000000000000000"},
+    }
+    mock_seer_request.return_value = HTTPResponse(
+        json.dumps(expected_return_value).encode("utf-8"), status=200
+    )
+
+    response = post_bulk_grouping_records(CREATE_GROUPING_RECORDS_REQUEST_PARAMS)
+    assert response == expected_return_value
+    mock_logger.info.assert_called_with(
+        "seer.post_bulk_grouping_records.success",
+        extra={
+            "group_ids": json.dumps(CREATE_GROUPING_RECORDS_REQUEST_PARAMS["group_id_list"]),
+            "project_id": 1,
+            "stacktrace_length_sum": 24,
+        },
+    )
+
+
+@mock.patch("sentry.seer.similarity.backfill.logger")
+@mock.patch("sentry.seer.similarity.backfill.seer_grouping_connection_pool.urlopen")
+def test_post_bulk_grouping_records_timeout(mock_seer_request: MagicMock, mock_logger: MagicMock):
+    expected_return_value = {"success": False}
+    mock_seer_request.side_effect = ReadTimeoutError(
+        DUMMY_POOL, settings.SEER_AUTOFIX_URL, "read timed out"
+    )
+
+    response = post_bulk_grouping_records(CREATE_GROUPING_RECORDS_REQUEST_PARAMS)
+    assert response == expected_return_value
+    mock_logger.info.assert_called_with(
+        "seer.post_bulk_grouping_records.failure",
+        extra={
+            "group_ids": json.dumps(CREATE_GROUPING_RECORDS_REQUEST_PARAMS["group_id_list"]),
+            "project_id": 1,
+            "reason": "ReadTimeoutError",
+            "timeout": POST_BULK_GROUPING_RECORDS_TIMEOUT,
+            "stacktrace_length_sum": 24,
+        },
+    )
+
+
+@mock.patch("sentry.seer.similarity.backfill.logger")
+@mock.patch("sentry.seer.similarity.backfill.seer_grouping_connection_pool.urlopen")
+def test_post_bulk_grouping_records_failure(mock_seer_request: MagicMock, mock_logger: MagicMock):
+    expected_return_value = {"success": False}
+    mock_seer_request.return_value = HTTPResponse(
+        b"<!doctype html>\n<html lang=en>\n<title>500 Internal Server Error</title>\n<h1>Internal Server Error</h1>\n<p>The server encountered an internal error and was unable to complete your request. Either the server is overloaded or there is an error in the application.</p>\n",
+        reason="INTERNAL SERVER ERROR",
+        status=500,
+    )
+
+    response = post_bulk_grouping_records(CREATE_GROUPING_RECORDS_REQUEST_PARAMS)
+    assert response == expected_return_value
+    mock_logger.info.assert_called_with(
+        "seer.post_bulk_grouping_records.failure",
+        extra={
+            "group_ids": json.dumps(CREATE_GROUPING_RECORDS_REQUEST_PARAMS["group_id_list"]),
+            "project_id": 1,
+            "reason": "INTERNAL SERVER ERROR",
+            "stacktrace_length_sum": 24,
+        },
+    )
+
+
+@mock.patch("sentry.seer.similarity.backfill.seer_grouping_connection_pool.urlopen")
+def test_post_bulk_grouping_records_empty_data(mock_seer_request: MagicMock):
+    """Test that function handles empty data. This should not happen, but we do not want to error if it does."""
+    expected_return_value = {"success": True}
+    mock_seer_request.return_value = HTTPResponse(
+        json.dumps(expected_return_value).encode("utf-8"), status=200
+    )
+    empty_data = copy.deepcopy(CREATE_GROUPING_RECORDS_REQUEST_PARAMS)
+    empty_data["data"] = []
+    response = post_bulk_grouping_records(empty_data)
+    assert response == expected_return_value

--- a/tests/sentry/seer/test_utils.py
+++ b/tests/sentry/seer/test_utils.py
@@ -1,18 +1,9 @@
-import copy
 from typing import Any
 from unittest import mock
 
 import pytest
-from django.conf import settings
-from urllib3.connectionpool import ConnectionPool
-from urllib3.exceptions import ReadTimeoutError
 from urllib3.response import HTTPResponse
 
-from sentry.seer.similarity.backfill import (
-    POST_BULK_GROUPING_RECORDS_TIMEOUT,
-    CreateGroupingRecordsRequest,
-    post_bulk_grouping_records,
-)
 from sentry.seer.utils import (
     IncompleteSeerDataError,
     RawSeerSimilarIssueData,
@@ -26,16 +17,6 @@ from sentry.testutils.helpers.eventprocessing import save_new_event
 from sentry.testutils.pytest.fixtures import django_db_all
 from sentry.utils import json
 from sentry.utils.types import NonNone
-
-DUMMY_POOL = ConnectionPool("dummy")
-CREATE_GROUPING_RECORDS_REQUEST_PARAMS: CreateGroupingRecordsRequest = {
-    "group_id_list": [1, 2],
-    "data": [
-        {"group_id": 1, "hash": "hash-1", "project_id": 1, "message": "message"},
-        {"group_id": 2, "hash": "hash-2", "project_id": 1, "message": "message 2"},
-    ],
-    "stacktrace_list": ["stacktrace 1", "stacktrace 2"],
-}
 
 
 @mock.patch("sentry.seer.utils.seer_breakpoint_connection_pool.urlopen")
@@ -278,84 +259,3 @@ def test_from_raw_nonexistent_group(default_project):
         }
 
         SeerSimilarIssueData.from_raw(default_project.id, raw_similar_issue_data)
-
-
-@mock.patch("sentry.seer.similarity.backfill.logger")
-@mock.patch("sentry.seer.similarity.backfill.seer_grouping_connection_pool.urlopen")
-def test_post_bulk_grouping_records_success(mock_seer_request, mock_logger):
-    expected_return_value = {
-        "success": True,
-        "groups_with_neighbor": {"1": "00000000000000000000000000000000"},
-    }
-    mock_seer_request.return_value = HTTPResponse(
-        json.dumps(expected_return_value).encode("utf-8"), status=200
-    )
-
-    response = post_bulk_grouping_records(CREATE_GROUPING_RECORDS_REQUEST_PARAMS)
-    assert response == expected_return_value
-    mock_logger.info.assert_called_with(
-        "seer.post_bulk_grouping_records.success",
-        extra={
-            "group_ids": json.dumps(CREATE_GROUPING_RECORDS_REQUEST_PARAMS["group_id_list"]),
-            "project_id": 1,
-            "stacktrace_length_sum": 24,
-        },
-    )
-
-
-@mock.patch("sentry.seer.similarity.backfill.logger")
-@mock.patch("sentry.seer.similarity.backfill.seer_grouping_connection_pool.urlopen")
-def test_post_bulk_grouping_records_timeout(mock_seer_request, mock_logger):
-    expected_return_value = {"success": False}
-    mock_seer_request.side_effect = ReadTimeoutError(
-        DUMMY_POOL, settings.SEER_AUTOFIX_URL, "read timed out"
-    )
-
-    response = post_bulk_grouping_records(CREATE_GROUPING_RECORDS_REQUEST_PARAMS)
-    assert response == expected_return_value
-    mock_logger.info.assert_called_with(
-        "seer.post_bulk_grouping_records.failure",
-        extra={
-            "group_ids": json.dumps(CREATE_GROUPING_RECORDS_REQUEST_PARAMS["group_id_list"]),
-            "project_id": 1,
-            "reason": "ReadTimeoutError",
-            "timeout": POST_BULK_GROUPING_RECORDS_TIMEOUT,
-            "stacktrace_length_sum": 24,
-        },
-    )
-
-
-@mock.patch("sentry.seer.similarity.backfill.logger")
-@mock.patch("sentry.seer.similarity.backfill.seer_grouping_connection_pool.urlopen")
-def test_post_bulk_grouping_records_failure(mock_seer_request, mock_logger):
-    expected_return_value = {"success": False}
-    mock_seer_request.return_value = HTTPResponse(
-        b"<!doctype html>\n<html lang=en>\n<title>500 Internal Server Error</title>\n<h1>Internal Server Error</h1>\n<p>The server encountered an internal error and was unable to complete your request. Either the server is overloaded or there is an error in the application.</p>\n",
-        reason="INTERNAL SERVER ERROR",
-        status=500,
-    )
-
-    response = post_bulk_grouping_records(CREATE_GROUPING_RECORDS_REQUEST_PARAMS)
-    assert response == expected_return_value
-    mock_logger.info.assert_called_with(
-        "seer.post_bulk_grouping_records.failure",
-        extra={
-            "group_ids": json.dumps(CREATE_GROUPING_RECORDS_REQUEST_PARAMS["group_id_list"]),
-            "project_id": 1,
-            "reason": "INTERNAL SERVER ERROR",
-            "stacktrace_length_sum": 24,
-        },
-    )
-
-
-@mock.patch("sentry.seer.similarity.backfill.seer_grouping_connection_pool.urlopen")
-def test_post_bulk_grouping_records_empty_data(mock_seer_request):
-    """Test that function handles empty data. This should not happen, but we do not want to error if it does."""
-    expected_return_value = {"success": True}
-    mock_seer_request.return_value = HTTPResponse(
-        json.dumps(expected_return_value).encode("utf-8"), status=200
-    )
-    empty_data = copy.deepcopy(CREATE_GROUPING_RECORDS_REQUEST_PARAMS)
-    empty_data["data"] = []
-    response = post_bulk_grouping_records(empty_data)
-    assert response == expected_return_value

--- a/tests/sentry/seer/test_utils.py
+++ b/tests/sentry/seer/test_utils.py
@@ -8,9 +8,12 @@ from urllib3.connectionpool import ConnectionPool
 from urllib3.exceptions import ReadTimeoutError
 from urllib3.response import HTTPResponse
 
-from sentry.seer.utils import (
+from sentry.seer.similarity.backfill import (
     POST_BULK_GROUPING_RECORDS_TIMEOUT,
     CreateGroupingRecordsRequest,
+    post_bulk_grouping_records,
+)
+from sentry.seer.utils import (
     IncompleteSeerDataError,
     RawSeerSimilarIssueData,
     SeerSimilarIssueData,
@@ -18,7 +21,6 @@ from sentry.seer.utils import (
     SimilarIssuesEmbeddingsRequest,
     detect_breakpoints,
     get_similarity_data_from_seer,
-    post_bulk_grouping_records,
 )
 from sentry.testutils.helpers.eventprocessing import save_new_event
 from sentry.testutils.pytest.fixtures import django_db_all
@@ -278,8 +280,8 @@ def test_from_raw_nonexistent_group(default_project):
         SeerSimilarIssueData.from_raw(default_project.id, raw_similar_issue_data)
 
 
-@mock.patch("sentry.seer.utils.logger")
-@mock.patch("sentry.seer.utils.seer_grouping_connection_pool.urlopen")
+@mock.patch("sentry.seer.similarity.backfill.logger")
+@mock.patch("sentry.seer.similarity.backfill.seer_grouping_connection_pool.urlopen")
 def test_post_bulk_grouping_records_success(mock_seer_request, mock_logger):
     expected_return_value = {
         "success": True,
@@ -301,8 +303,8 @@ def test_post_bulk_grouping_records_success(mock_seer_request, mock_logger):
     )
 
 
-@mock.patch("sentry.seer.utils.logger")
-@mock.patch("sentry.seer.utils.seer_grouping_connection_pool.urlopen")
+@mock.patch("sentry.seer.similarity.backfill.logger")
+@mock.patch("sentry.seer.similarity.backfill.seer_grouping_connection_pool.urlopen")
 def test_post_bulk_grouping_records_timeout(mock_seer_request, mock_logger):
     expected_return_value = {"success": False}
     mock_seer_request.side_effect = ReadTimeoutError(
@@ -323,8 +325,8 @@ def test_post_bulk_grouping_records_timeout(mock_seer_request, mock_logger):
     )
 
 
-@mock.patch("sentry.seer.utils.logger")
-@mock.patch("sentry.seer.utils.seer_grouping_connection_pool.urlopen")
+@mock.patch("sentry.seer.similarity.backfill.logger")
+@mock.patch("sentry.seer.similarity.backfill.seer_grouping_connection_pool.urlopen")
 def test_post_bulk_grouping_records_failure(mock_seer_request, mock_logger):
     expected_return_value = {"success": False}
     mock_seer_request.return_value = HTTPResponse(
@@ -346,7 +348,7 @@ def test_post_bulk_grouping_records_failure(mock_seer_request, mock_logger):
     )
 
 
-@mock.patch("sentry.seer.utils.seer_grouping_connection_pool.urlopen")
+@mock.patch("sentry.seer.similarity.backfill.seer_grouping_connection_pool.urlopen")
 def test_post_bulk_grouping_records_empty_data(mock_seer_request):
     """Test that function handles empty data. This should not happen, but we do not want to error if it does."""
     expected_return_value = {"success": True}

--- a/tests/sentry/tasks/test_backfill_seer_grouping_records.py
+++ b/tests/sentry/tasks/test_backfill_seer_grouping_records.py
@@ -15,7 +15,8 @@ from sentry.grouping.grouping_info import get_grouping_info
 from sentry.issues.occurrence_consumer import EventLookupError
 from sentry.models.group import Group
 from sentry.models.grouphash import GroupHash
-from sentry.seer.utils import CreateGroupingRecordData, RawSeerSimilarIssueData
+from sentry.seer.similarity.backfill import CreateGroupingRecordData
+from sentry.seer.utils import RawSeerSimilarIssueData
 from sentry.tasks.backfill_seer_grouping_records import (
     GroupStacktraceData,
     backfill_seer_grouping_records,


### PR DESCRIPTION
This PR is the first in a series reorganizing the Seer grouping code a bit, primarily to split up what have become some unwieldily-long files. Here, the backfill code from `seer.utils.py` is split into its own module.