### PR TITLE
chore(seer grouping): Move Seer similarity utils types to separate module

### DIFF
--- a/src/sentry/api/endpoints/group_similar_issues_embeddings.py
+++ b/src/sentry/api/endpoints/group_similar_issues_embeddings.py
@@ -15,11 +15,8 @@ from sentry.api.serializers import serialize
 from sentry.grouping.grouping_info import get_grouping_info
 from sentry.models.group import Group
 from sentry.models.user import User
-from sentry.seer.utils import (
-    SeerSimilarIssueData,
-    SimilarIssuesEmbeddingsRequest,
-    get_similarity_data_from_seer,
-)
+from sentry.seer.similarity.types import SeerSimilarIssueData, SimilarIssuesEmbeddingsRequest
+from sentry.seer.utils import get_similarity_data_from_seer
 from sentry.utils.safe import get_path
 
 logger = logging.getLogger(__name__)

--- a/src/sentry/grouping/ingest/seer.py
+++ b/src/sentry/grouping/ingest/seer.py
@@ -9,11 +9,8 @@ from sentry.grouping.grouping_info import get_grouping_info_from_variants
 from sentry.grouping.result import CalculatedHashes
 from sentry.models.group import Group
 from sentry.models.project import Project
-from sentry.seer.utils import (
-    SeerSimilarIssuesMetadata,
-    SimilarIssuesEmbeddingsRequest,
-    get_similarity_data_from_seer,
-)
+from sentry.seer.similarity.types import SeerSimilarIssuesMetadata, SimilarIssuesEmbeddingsRequest
+from sentry.seer.utils import get_similarity_data_from_seer
 from sentry.utils.safe import get_path
 
 logger = logging.getLogger("sentry.events.grouping")

--- a/src/sentry/seer/similarity/backfill.py
+++ b/src/sentry/seer/similarity/backfill.py
@@ -6,7 +6,7 @@ from urllib3.exceptions import ReadTimeoutError
 
 from sentry.conf.server import SEER_GROUPING_RECORDS_DELETE_URL, SEER_GROUPING_RECORDS_URL
 from sentry.net.http import connection_from_url
-from sentry.seer.utils import RawSeerSimilarIssueData
+from sentry.seer.similarity.types import RawSeerSimilarIssueData
 from sentry.utils import json
 
 logger = logging.getLogger(__name__)

--- a/src/sentry/seer/similarity/types.py
+++ b/src/sentry/seer/similarity/types.py
@@ -1,0 +1,114 @@
+import logging
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any, ClassVar, NotRequired, Self, TypedDict
+
+from sentry.conf.server import SEER_SIMILARITY_MODEL_VERSION
+from sentry.models.grouphash import GroupHash
+from sentry.utils.json import apply_key_filter
+
+logger = logging.getLogger(__name__)
+
+
+class IncompleteSeerDataError(Exception):
+    pass
+
+
+class SimilarGroupNotFoundError(Exception):
+    pass
+
+
+class SimilarIssuesEmbeddingsRequest(TypedDict):
+    project_id: int
+    stacktrace: str
+    message: str
+    hash: str
+    k: NotRequired[int]  # how many neighbors to find
+    threshold: NotRequired[float]
+
+
+class RawSeerSimilarIssueData(TypedDict):
+    parent_hash: str
+    stacktrace_distance: float
+    message_distance: float
+    should_group: bool
+
+
+class SimilarIssuesEmbeddingsResponse(TypedDict):
+    responses: list[RawSeerSimilarIssueData]
+
+
+# Like the data that comes back from seer, but guaranteed to have a parent group id
+@dataclass
+class SeerSimilarIssueData:
+    stacktrace_distance: float
+    message_distance: float
+    should_group: bool
+    parent_group_id: int
+    parent_hash: str
+
+    # Unfortunately, we have to hardcode this separately from the `RawSeerSimilarIssueData` type
+    # definition because Python has no way to derive it from the type (nor vice-versa)
+    required_incoming_keys: ClassVar = {
+        "stacktrace_distance",
+        "message_distance",
+        "should_group",
+        "parent_hash",
+    }
+    optional_incoming_keys: ClassVar = {}
+    expected_incoming_keys: ClassVar = {*required_incoming_keys, *optional_incoming_keys}
+
+    @classmethod
+    def from_raw(cls, project_id: int, raw_similar_issue_data: Mapping[str, Any]) -> Self:
+        """
+        Create an instance of `SeerSimilarIssueData` from the raw data that comes back from Seer,
+        using the parent hash to look up the parent group id. Needs to be run individually on each
+        similar issue in the Seer response.
+
+        Throws an `IncompleteSeerDataError` if given data with any required keys missing, and a
+        `SimilarGroupNotFoundError` if the data points to a group which no longer exists. The latter
+        guarantees that if this successfully returns, the parent group id in the return value points
+        to an existing group.
+
+        """
+
+        # Filter out any data we're not expecting, and then make sure what's left isn't missing anything
+        raw_similar_issue_data = apply_key_filter(
+            raw_similar_issue_data, keep_keys=cls.expected_incoming_keys
+        )
+        missing_keys = cls.required_incoming_keys - raw_similar_issue_data.keys()
+        if missing_keys:
+            raise IncompleteSeerDataError(
+                "Seer similar issues response entry missing "
+                + ("keys " if len(missing_keys) > 1 else "key ")
+                + ", ".join(map(lambda key: f"'{key}'", sorted(missing_keys)))
+            )
+
+        # Now that we know we have all the right data, use the parent group's hash to look up its id
+        parent_grouphash = (
+            GroupHash.objects.filter(
+                project_id=project_id, hash=raw_similar_issue_data["parent_hash"]
+            )
+            .exclude(state=GroupHash.State.LOCKED_IN_MIGRATION)
+            .first()
+        )
+
+        if not parent_grouphash:
+            # TODO: Report back to seer that the hash has been deleted.
+            raise SimilarGroupNotFoundError("Similar group suggested by Seer does not exist")
+
+        # TODO: The `Any` casting here isn't great, but Python currently has no way to
+        # relate typeddict keys to dataclass properties
+        similar_issue_data: Any = {
+            **raw_similar_issue_data,
+            "parent_group_id": parent_grouphash.group_id,
+        }
+
+        return cls(**similar_issue_data)
+
+
+@dataclass
+class SeerSimilarIssuesMetadata:
+    request_hash: str
+    results: list[SeerSimilarIssueData]
+    similarity_model_version: str = SEER_SIMILARITY_MODEL_VERSION

--- a/src/sentry/tasks/backfill_seer_grouping_records.py
+++ b/src/sentry/tasks/backfill_seer_grouping_records.py
@@ -28,7 +28,7 @@ from sentry.seer.similarity.backfill import (
     delete_grouping_records,
     post_bulk_grouping_records,
 )
-from sentry.seer.utils import (
+from sentry.seer.similarity.types import (
     IncompleteSeerDataError,
     SeerSimilarIssueData,
     SimilarGroupNotFoundError,

--- a/tests/sentry/api/endpoints/test_group_similar_issues_embeddings.py
+++ b/tests/sentry/api/endpoints/test_group_similar_issues_embeddings.py
@@ -13,7 +13,7 @@ from sentry.api.endpoints.group_similar_issues_embeddings import (
 from sentry.api.serializers.base import serialize
 from sentry.conf.server import SEER_SIMILAR_ISSUES_URL
 from sentry.models.group import Group
-from sentry.seer.utils import SeerSimilarIssueData, SimilarIssuesEmbeddingsResponse
+from sentry.seer.similarity.types import SeerSimilarIssueData, SimilarIssuesEmbeddingsResponse
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.helpers.eventprocessing import save_new_event
 from sentry.utils.types import NonNone

--- a/tests/sentry/event_manager/grouping/test_seer_grouping.py
+++ b/tests/sentry/event_manager/grouping/test_seer_grouping.py
@@ -4,7 +4,7 @@ from unittest.mock import MagicMock, patch
 
 from sentry.conf.server import SEER_SIMILARITY_MODEL_VERSION
 from sentry.grouping.ingest.seer import get_seer_similar_issues, should_call_seer_for_grouping
-from sentry.seer.utils import SeerSimilarIssueData
+from sentry.seer.similarity.types import SeerSimilarIssueData
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers import Feature
 from sentry.testutils.helpers.eventprocessing import save_new_event

--- a/tests/sentry/grouping/test_seer.py
+++ b/tests/sentry/grouping/test_seer.py
@@ -5,7 +5,7 @@ from sentry.conf.server import SEER_SIMILARITY_MODEL_VERSION
 from sentry.eventstore.models import Event
 from sentry.grouping.ingest.seer import get_seer_similar_issues, should_call_seer_for_grouping
 from sentry.grouping.result import CalculatedHashes
-from sentry.seer.utils import SeerSimilarIssueData
+from sentry.seer.similarity.types import SeerSimilarIssueData
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers import Feature
 from sentry.testutils.helpers.eventprocessing import save_new_event

--- a/tests/sentry/seer/similarity/test_types.py
+++ b/tests/sentry/seer/similarity/test_types.py
@@ -1,0 +1,113 @@
+from typing import Any
+
+import pytest
+
+from sentry.seer.similarity.types import (
+    IncompleteSeerDataError,
+    RawSeerSimilarIssueData,
+    SeerSimilarIssueData,
+    SimilarGroupNotFoundError,
+)
+from sentry.testutils.cases import TestCase
+from sentry.testutils.helpers.eventprocessing import save_new_event
+from sentry.utils.types import NonNone
+
+
+class SeerSimilarIssueDataTest(TestCase):
+    def test_from_raw_simple(self):
+        similar_event = save_new_event({"message": "Dogs are great!"}, self.project)
+        raw_similar_issue_data: RawSeerSimilarIssueData = {
+            "message_distance": 0.05,
+            "parent_hash": NonNone(similar_event.get_primary_hash()),
+            "should_group": True,
+            "stacktrace_distance": 0.01,
+        }
+
+        similar_issue_data = {
+            **raw_similar_issue_data,
+            "parent_group_id": similar_event.group_id,
+        }
+
+        assert SeerSimilarIssueData.from_raw(
+            self.project.id, raw_similar_issue_data
+        ) == SeerSimilarIssueData(
+            **similar_issue_data  # type:ignore[arg-type]
+        )
+
+    def test_from_raw_unexpected_data(self):
+        similar_event = save_new_event({"message": "Dogs are great!"}, self.project)
+        raw_similar_issue_data = {
+            "message_distance": 0.05,
+            "parent_hash": NonNone(similar_event.get_primary_hash()),
+            "should_group": True,
+            "stacktrace_distance": 0.01,
+            "something": "unexpected",
+        }
+
+        expected_similar_issue_data = {
+            "message_distance": 0.05,
+            "parent_hash": NonNone(similar_event.get_primary_hash()),
+            "should_group": True,
+            "stacktrace_distance": 0.01,
+            "parent_group_id": NonNone(similar_event.group_id),
+        }
+
+        # Everything worked fine, in spite of the extra data
+        assert SeerSimilarIssueData.from_raw(
+            self.project.id, raw_similar_issue_data
+        ) == SeerSimilarIssueData(
+            **expected_similar_issue_data  # type:ignore[arg-type]
+        )
+
+    def test_from_raw_missing_data(self):
+        similar_event = save_new_event({"message": "Dogs are great!"}, self.project)
+
+        with pytest.raises(
+            IncompleteSeerDataError,
+            match="Seer similar issues response entry missing key 'parent_hash'",
+        ):
+            raw_similar_issue_data: Any = {
+                # missing `parent_hash`
+                "message_distance": 0.05,
+                "should_group": True,
+                "stacktrace_distance": 0.01,
+            }
+
+            SeerSimilarIssueData.from_raw(self.project.id, raw_similar_issue_data)
+
+        with pytest.raises(
+            IncompleteSeerDataError,
+            match="Seer similar issues response entry missing key 'message_distance'",
+        ):
+            raw_similar_issue_data = {
+                "parent_hash": NonNone(similar_event.get_primary_hash()),
+                # missing `message_distance`
+                "should_group": True,
+                "stacktrace_distance": 0.01,
+            }
+
+            SeerSimilarIssueData.from_raw(self.project.id, raw_similar_issue_data)
+
+        with pytest.raises(
+            IncompleteSeerDataError,
+            match="Seer similar issues response entry missing keys 'message_distance', 'stacktrace_distance'",
+        ):
+            raw_similar_issue_data = {
+                "parent_hash": NonNone(similar_event.get_primary_hash()),
+                # missing `message_distance`
+                "should_group": True,
+                # missing `stacktrace_distance`
+            }
+
+            SeerSimilarIssueData.from_raw(self.project.id, raw_similar_issue_data)
+
+    def test_from_raw_nonexistent_group(self):
+        with pytest.raises(SimilarGroupNotFoundError):
+            raw_similar_issue_data = {
+                "parent_hash": "not a real hash",
+                "message_distance": 0.05,
+                "should_group": True,
+                "stacktrace_distance": 0.01,
+            }
+
+            SeerSimilarIssueData.from_raw(self.project.id, raw_similar_issue_data)

--- a/tests/sentry/seer/test_utils.py
+++ b/tests/sentry/seer/test_utils.py
@@ -4,15 +4,14 @@ from unittest import mock
 import pytest
 from urllib3.response import HTTPResponse
 
-from sentry.seer.utils import (
+from sentry.seer.similarity.types import (
     IncompleteSeerDataError,
     RawSeerSimilarIssueData,
     SeerSimilarIssueData,
     SimilarGroupNotFoundError,
     SimilarIssuesEmbeddingsRequest,
-    detect_breakpoints,
-    get_similarity_data_from_seer,
 )
+from sentry.seer.utils import detect_breakpoints, get_similarity_data_from_seer
 from sentry.testutils.helpers.eventprocessing import save_new_event
 from sentry.testutils.pytest.fixtures import django_db_all
 from sentry.utils import json

--- a/tests/sentry/seer/test_utils.py
+++ b/tests/sentry/seer/test_utils.py
@@ -5,10 +5,8 @@ import pytest
 from urllib3.response import HTTPResponse
 
 from sentry.seer.similarity.types import (
-    IncompleteSeerDataError,
     RawSeerSimilarIssueData,
     SeerSimilarIssueData,
-    SimilarGroupNotFoundError,
     SimilarIssuesEmbeddingsRequest,
 )
 from sentry.seer.utils import detect_breakpoints, get_similarity_data_from_seer
@@ -152,109 +150,3 @@ def test_returns_sorted_similarity_results(mock_seer_request, default_project):
         SeerSimilarIssueData(**similar_issue_data),
         SeerSimilarIssueData(**less_similar_issue_data),
     ]
-
-
-@django_db_all
-def test_from_raw_simple(default_project):
-    similar_event = save_new_event({"message": "Dogs are great!"}, default_project)
-    raw_similar_issue_data: RawSeerSimilarIssueData = {
-        "message_distance": 0.05,
-        "parent_hash": NonNone(similar_event.get_primary_hash()),
-        "should_group": True,
-        "stacktrace_distance": 0.01,
-    }
-
-    similar_issue_data = {
-        **raw_similar_issue_data,
-        "parent_group_id": NonNone(similar_event.group_id),
-    }
-
-    assert SeerSimilarIssueData.from_raw(
-        default_project.id, raw_similar_issue_data
-    ) == SeerSimilarIssueData(
-        **similar_issue_data  # type:ignore[arg-type]
-    )
-
-
-@django_db_all
-def test_from_raw_unexpected_data(default_project):
-    similar_event = save_new_event({"message": "Dogs are great!"}, default_project)
-    raw_similar_issue_data = {
-        "message_distance": 0.05,
-        "parent_hash": NonNone(similar_event.get_primary_hash()),
-        "should_group": True,
-        "stacktrace_distance": 0.01,
-        "something": "unexpected",
-    }
-
-    expected_similar_issue_data = {
-        "message_distance": 0.05,
-        "parent_hash": NonNone(similar_event.get_primary_hash()),
-        "should_group": True,
-        "stacktrace_distance": 0.01,
-        "parent_group_id": NonNone(similar_event.group_id),
-    }
-
-    # Everything worked fine, in spite of the extra data
-    assert SeerSimilarIssueData.from_raw(
-        default_project.id, raw_similar_issue_data
-    ) == SeerSimilarIssueData(
-        **expected_similar_issue_data  # type:ignore[arg-type]
-    )
-
-
-@django_db_all
-def test_from_raw_missing_data(default_project):
-    similar_event = save_new_event({"message": "Dogs are great!"}, default_project)
-
-    with pytest.raises(
-        IncompleteSeerDataError,
-        match="Seer similar issues response entry missing key 'parent_hash'",
-    ):
-        raw_similar_issue_data: Any = {
-            # missing `parent_hash`
-            "message_distance": 0.05,
-            "should_group": True,
-            "stacktrace_distance": 0.01,
-        }
-
-        SeerSimilarIssueData.from_raw(default_project.id, raw_similar_issue_data)
-
-    with pytest.raises(
-        IncompleteSeerDataError,
-        match="Seer similar issues response entry missing key 'message_distance'",
-    ):
-        raw_similar_issue_data = {
-            "parent_hash": NonNone(similar_event.get_primary_hash()),
-            # missing `message_distance`
-            "should_group": True,
-            "stacktrace_distance": 0.01,
-        }
-
-        SeerSimilarIssueData.from_raw(default_project.id, raw_similar_issue_data)
-
-    with pytest.raises(
-        IncompleteSeerDataError,
-        match="Seer similar issues response entry missing keys 'message_distance', 'stacktrace_distance'",
-    ):
-        raw_similar_issue_data = {
-            "parent_hash": NonNone(similar_event.get_primary_hash()),
-            # missing `message_distance`
-            "should_group": True,
-            # missing `stacktrace_distance`
-        }
-
-        SeerSimilarIssueData.from_raw(default_project.id, raw_similar_issue_data)
-
-
-@django_db_all
-def test_from_raw_nonexistent_group(default_project):
-    with pytest.raises(SimilarGroupNotFoundError):
-        raw_similar_issue_data = {
-            "parent_hash": "not a real hash",
-            "message_distance": 0.05,
-            "should_group": True,
-            "stacktrace_distance": 0.01,
-        }
-
-        SeerSimilarIssueData.from_raw(default_project.id, raw_similar_issue_data)

--- a/tests/sentry/tasks/test_backfill_seer_grouping_records.py
+++ b/tests/sentry/tasks/test_backfill_seer_grouping_records.py
@@ -16,7 +16,7 @@ from sentry.issues.occurrence_consumer import EventLookupError
 from sentry.models.group import Group
 from sentry.models.grouphash import GroupHash
 from sentry.seer.similarity.backfill import CreateGroupingRecordData
-from sentry.seer.utils import RawSeerSimilarIssueData
+from sentry.seer.similarity.types import RawSeerSimilarIssueData
 from sentry.tasks.backfill_seer_grouping_records import (
     GroupStacktraceData,
     backfill_seer_grouping_records,


### PR DESCRIPTION
This PR is the second in a series reorganizing the Seer grouping code a bit, primarily to split up what have become some unwieldily-long files. Here, the error and data types from `seer.utils.py` are split into their own module.