### PR TITLE
chore(seer grouping): Move Seer similarity call to separate module

### DIFF
--- a/src/sentry/api/endpoints/group_similar_issues_embeddings.py
+++ b/src/sentry/api/endpoints/group_similar_issues_embeddings.py
@@ -15,8 +15,8 @@ from sentry.api.serializers import serialize
 from sentry.grouping.grouping_info import get_grouping_info
 from sentry.models.group import Group
 from sentry.models.user import User
+from sentry.seer.similarity.similar_issues import get_similarity_data_from_seer
 from sentry.seer.similarity.types import SeerSimilarIssueData, SimilarIssuesEmbeddingsRequest
-from sentry.seer.utils import get_similarity_data_from_seer
 from sentry.utils.safe import get_path
 
 logger = logging.getLogger(__name__)

--- a/src/sentry/grouping/ingest/seer.py
+++ b/src/sentry/grouping/ingest/seer.py
@@ -9,8 +9,8 @@ from sentry.grouping.grouping_info import get_grouping_info_from_variants
 from sentry.grouping.result import CalculatedHashes
 from sentry.models.group import Group
 from sentry.models.project import Project
+from sentry.seer.similarity.similar_issues import get_similarity_data_from_seer
 from sentry.seer.similarity.types import SeerSimilarIssuesMetadata, SimilarIssuesEmbeddingsRequest
-from sentry.seer.utils import get_similarity_data_from_seer
 from sentry.utils.safe import get_path
 
 logger = logging.getLogger("sentry.events.grouping")

--- a/src/sentry/seer/similarity/similar_issues.py
+++ b/src/sentry/seer/similarity/similar_issues.py
@@ -1,0 +1,84 @@
+import logging
+
+from django.conf import settings
+
+from sentry.conf.server import SEER_MAX_GROUPING_DISTANCE, SEER_SIMILAR_ISSUES_URL
+from sentry.net.http import connection_from_url
+from sentry.seer.similarity.types import (
+    IncompleteSeerDataError,
+    SeerSimilarIssueData,
+    SimilarGroupNotFoundError,
+    SimilarIssuesEmbeddingsRequest,
+)
+from sentry.utils import json, metrics
+from sentry.utils.json import JSONDecodeError
+
+logger = logging.getLogger(__name__)
+
+
+seer_grouping_connection_pool = connection_from_url(
+    settings.SEER_GROUPING_URL,
+    timeout=settings.SEER_GROUPING_TIMEOUT,
+)
+
+
+# TODO: Handle non-200 responses
+def get_similarity_data_from_seer(
+    similar_issues_request: SimilarIssuesEmbeddingsRequest,
+) -> list[SeerSimilarIssueData]:
+    """
+    Request similar issues data from seer and normalize the results. Returns similar groups
+    sorted in order of descending similarity.
+    """
+
+    response = seer_grouping_connection_pool.urlopen(
+        "POST",
+        SEER_SIMILAR_ISSUES_URL,
+        body=json.dumps({"threshold": SEER_MAX_GROUPING_DISTANCE, **similar_issues_request}),
+        headers={"Content-Type": "application/json;charset=utf-8"},
+    )
+
+    try:
+        response_data = json.loads(response.data.decode("utf-8"))
+    except (
+        AttributeError,  # caused by a response with no data and therefore no `.decode` method
+        UnicodeError,
+        JSONDecodeError,
+    ):
+        logger.exception(
+            "Failed to parse seer similar issues response",
+            extra={
+                "request_params": similar_issues_request,
+                "response_data": response.data,
+            },
+        )
+        return []
+
+    normalized = []
+
+    for raw_similar_issue_data in response_data.get("responses") or []:
+        try:
+            normalized.append(
+                SeerSimilarIssueData.from_raw(
+                    similar_issues_request["project_id"], raw_similar_issue_data
+                )
+            )
+            metrics.incr("seer.similar_issue_request.parent_issue", tags={"outcome": "found"})
+        except IncompleteSeerDataError as err:
+            metrics.incr(
+                "seer.similar_issue_request.parent_issue", tags={"outcome": "incomplete_data"}
+            )
+            logger.exception(
+                str(err),
+                extra={
+                    "request_params": similar_issues_request,
+                    "raw_similar_issue_data": raw_similar_issue_data,
+                },
+            )
+        except SimilarGroupNotFoundError:
+            metrics.incr("seer.similar_issue_request.parent_issue", tags={"outcome": "not_found"})
+
+    return sorted(
+        normalized,
+        key=lambda issue_data: issue_data.stacktrace_distance,
+    )

--- a/src/sentry/seer/utils.py
+++ b/src/sentry/seer/utils.py
@@ -5,19 +5,8 @@ import sentry_sdk
 from django.conf import settings
 from urllib3 import Retry
 
-from sentry.conf.server import SEER_MAX_GROUPING_DISTANCE, SEER_SIMILAR_ISSUES_URL
 from sentry.net.http import connection_from_url
-from sentry.seer.similarity.types import (
-    IncompleteSeerDataError,
-    SeerSimilarIssueData,
-    SimilarGroupNotFoundError,
-    SimilarIssuesEmbeddingsRequest,
-)
-from sentry.utils import json, metrics
-from sentry.utils.json import JSONDecodeError
-
-logger = logging.getLogger(__name__)
-
+from sentry.utils import json
 
 logger = logging.getLogger(__name__)
 
@@ -44,11 +33,6 @@ class BreakpointData(TypedDict):
 class BreakpointResponse(TypedDict):
     data: list[BreakpointData]
 
-
-seer_grouping_connection_pool = connection_from_url(
-    settings.SEER_GROUPING_URL,
-    timeout=settings.SEER_GROUPING_TIMEOUT,
-)
 
 seer_breakpoint_connection_pool = connection_from_url(
     settings.SEER_BREAKPOINT_DETECTION_URL,
@@ -88,65 +72,3 @@ def detect_breakpoints(breakpoint_request) -> BreakpointResponse:
 
     # assume no breakpoints if an error was returned from seer
     return {"data": []}
-
-
-# TODO: Handle non-200 responses
-def get_similarity_data_from_seer(
-    similar_issues_request: SimilarIssuesEmbeddingsRequest,
-) -> list[SeerSimilarIssueData]:
-    """
-    Request similar issues data from seer and normalize the results. Returns similar groups
-    sorted in order of descending similarity.
-    """
-
-    response = seer_grouping_connection_pool.urlopen(
-        "POST",
-        SEER_SIMILAR_ISSUES_URL,
-        body=json.dumps({"threshold": SEER_MAX_GROUPING_DISTANCE, **similar_issues_request}),
-        headers={"Content-Type": "application/json;charset=utf-8"},
-    )
-
-    try:
-        response_data = json.loads(response.data.decode("utf-8"))
-    except (
-        AttributeError,  # caused by a response with no data and therefore no `.decode` method
-        UnicodeError,
-        JSONDecodeError,
-    ):
-        logger.exception(
-            "Failed to parse seer similar issues response",
-            extra={
-                "request_params": similar_issues_request,
-                "response_data": response.data,
-            },
-        )
-        return []
-
-    normalized = []
-
-    for raw_similar_issue_data in response_data.get("responses") or []:
-        try:
-            normalized.append(
-                SeerSimilarIssueData.from_raw(
-                    similar_issues_request["project_id"], raw_similar_issue_data
-                )
-            )
-            metrics.incr("seer.similar_issue_request.parent_issue", tags={"outcome": "found"})
-        except IncompleteSeerDataError as err:
-            metrics.incr(
-                "seer.similar_issue_request.parent_issue", tags={"outcome": "incomplete_data"}
-            )
-            logger.exception(
-                str(err),
-                extra={
-                    "request_params": similar_issues_request,
-                    "raw_similar_issue_data": raw_similar_issue_data,
-                },
-            )
-        except SimilarGroupNotFoundError:
-            metrics.incr("seer.similar_issue_request.parent_issue", tags={"outcome": "not_found"})
-
-    return sorted(
-        normalized,
-        key=lambda issue_data: issue_data.stacktrace_distance,
-    )

--- a/tests/sentry/api/endpoints/test_group_similar_issues_embeddings.py
+++ b/tests/sentry/api/endpoints/test_group_similar_issues_embeddings.py
@@ -687,8 +687,8 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
             ["Yes", "No"],
         )
 
-    @mock.patch("sentry.seer.utils.metrics")
-    @mock.patch("sentry.seer.utils.seer_grouping_connection_pool.urlopen")
+    @mock.patch("sentry.seer.similarity.similar_issues.metrics")
+    @mock.patch("sentry.seer.similarity.similar_issues.seer_grouping_connection_pool.urlopen")
     @mock.patch("sentry.api.endpoints.group_similar_issues_embeddings.logger")
     def test_simple(self, mock_logger, mock_seer_request, mock_metrics):
         seer_return_value: SimilarIssuesEmbeddingsResponse = {
@@ -737,7 +737,7 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
         )
 
     @mock.patch("sentry.analytics.record")
-    @mock.patch("sentry.seer.utils.seer_grouping_connection_pool.urlopen")
+    @mock.patch("sentry.seer.similarity.similar_issues.seer_grouping_connection_pool.urlopen")
     def test_multiple(self, mock_seer_request, mock_record):
         over_threshold_group_event = save_new_event({"message": "Maisey is silly"}, self.project)
         under_threshold_group_event = save_new_event({"message": "Charlie is goofy"}, self.project)
@@ -792,9 +792,9 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
             user_id=self.user.id,
         )
 
-    @mock.patch("sentry.seer.utils.metrics")
-    @mock.patch("sentry.seer.utils.logger")
-    @mock.patch("sentry.seer.utils.seer_grouping_connection_pool.urlopen")
+    @mock.patch("sentry.seer.similarity.similar_issues.metrics")
+    @mock.patch("sentry.seer.similarity.similar_issues.logger")
+    @mock.patch("sentry.seer.similarity.similar_issues.seer_grouping_connection_pool.urlopen")
     def test_incomplete_return_data(self, mock_seer_request, mock_logger, mock_metrics):
         # Two suggested groups, one with valid data, one missing parent hash. We should log the
         # second and return the first.
@@ -844,8 +844,8 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
             [NonNone(self.similar_event.group_id)], [0.95], [0.99], ["Yes"]
         )
 
-    @mock.patch("sentry.seer.utils.metrics")
-    @mock.patch("sentry.seer.utils.seer_grouping_connection_pool.urlopen")
+    @mock.patch("sentry.seer.similarity.similar_issues.metrics")
+    @mock.patch("sentry.seer.similarity.similar_issues.seer_grouping_connection_pool.urlopen")
     def test_nonexistent_group(self, mock_seer_request, mock_metrics):
         """
         The seer API can return groups that do not exist if they have been deleted/merged.
@@ -880,7 +880,7 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
         )
 
     @mock.patch("sentry.analytics.record")
-    @mock.patch("sentry.seer.utils.seer_grouping_connection_pool.urlopen")
+    @mock.patch("sentry.seer.similarity.similar_issues.seer_grouping_connection_pool.urlopen")
     def test_empty_seer_return(self, mock_seer_request, mock_record):
         mock_seer_request.return_value = HTTPResponse([])
         response = self.client.get(self.path)
@@ -947,7 +947,7 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
 
         assert response.data == []
 
-    @mock.patch("sentry.seer.utils.seer_grouping_connection_pool.urlopen")
+    @mock.patch("sentry.seer.similarity.similar_issues.seer_grouping_connection_pool.urlopen")
     def test_no_optional_params(self, mock_seer_request):
         """
         Test that optional parameters, k and threshold, can not be included.

--- a/tests/sentry/seer/similarity/test_similar_issues.py
+++ b/tests/sentry/seer/similarity/test_similar_issues.py
@@ -1,0 +1,108 @@
+from typing import Any
+from unittest import mock
+from unittest.mock import MagicMock
+
+from urllib3.response import HTTPResponse
+
+from sentry.seer.similarity.similar_issues import get_similarity_data_from_seer
+from sentry.seer.similarity.types import (
+    RawSeerSimilarIssueData,
+    SeerSimilarIssueData,
+    SimilarIssuesEmbeddingsRequest,
+)
+from sentry.testutils.cases import TestCase
+from sentry.testutils.helpers.eventprocessing import save_new_event
+from sentry.utils import json
+from sentry.utils.types import NonNone
+
+
+class GetSimilarityDataFromSeerTest(TestCase):
+    @mock.patch("sentry.seer.similarity.similar_issues.seer_grouping_connection_pool.urlopen")
+    def test_similar_issues_embeddings_simple(self, mock_seer_request: MagicMock):
+        """Test that valid responses are decoded and returned."""
+        event = save_new_event({"message": "Dogs are great!"}, self.project)
+        similar_event = save_new_event({"message": "Adopt don't shop"}, self.project)
+
+        raw_similar_issue_data: RawSeerSimilarIssueData = {
+            "message_distance": 0.05,
+            "parent_hash": NonNone(similar_event.get_primary_hash()),
+            "should_group": True,
+            "stacktrace_distance": 0.01,
+        }
+
+        seer_return_value = {"responses": [raw_similar_issue_data]}
+        mock_seer_request.return_value = HTTPResponse(json.dumps(seer_return_value).encode("utf-8"))
+
+        params: SimilarIssuesEmbeddingsRequest = {
+            "hash": NonNone(event.get_primary_hash()),
+            "project_id": self.project.id,
+            "stacktrace": "string",
+            "message": "message",
+        }
+
+        similar_issue_data: Any = {
+            **raw_similar_issue_data,
+            "parent_group_id": similar_event.group_id,
+        }
+
+        assert get_similarity_data_from_seer(params) == [SeerSimilarIssueData(**similar_issue_data)]
+
+    @mock.patch("sentry.seer.similarity.similar_issues.seer_grouping_connection_pool.urlopen")
+    def test_empty_similar_issues_embeddings(self, mock_seer_request: MagicMock):
+        """Test that empty responses are returned."""
+        event = save_new_event({"message": "Dogs are great!"}, self.project)
+
+        mock_seer_request.return_value = HTTPResponse([])
+
+        params: SimilarIssuesEmbeddingsRequest = {
+            "hash": NonNone(event.get_primary_hash()),
+            "project_id": self.project.id,
+            "stacktrace": "string",
+            "message": "message",
+        }
+        assert get_similarity_data_from_seer(params) == []
+
+    @mock.patch("sentry.seer.similarity.similar_issues.seer_grouping_connection_pool.urlopen")
+    def test_returns_sorted_similarity_results(self, mock_seer_request: MagicMock):
+        event = save_new_event({"message": "Dogs are great!"}, self.project)
+        similar_event = save_new_event({"message": "Adopt don't shop"}, self.project)
+        less_similar_event = save_new_event({"message": "Charlie is goofy"}, self.project)
+
+        raw_similar_issue_data: RawSeerSimilarIssueData = {
+            "message_distance": 0.05,
+            "parent_hash": NonNone(similar_event.get_primary_hash()),
+            "should_group": True,
+            "stacktrace_distance": 0.01,
+        }
+        raw_less_similar_issue_data: RawSeerSimilarIssueData = {
+            "message_distance": 0.10,
+            "parent_hash": NonNone(less_similar_event.get_primary_hash()),
+            "should_group": False,
+            "stacktrace_distance": 0.05,
+        }
+
+        # Note that the less similar issue is first in the list as it comes back from Seer
+        seer_return_value = {"responses": [raw_less_similar_issue_data, raw_similar_issue_data]}
+        mock_seer_request.return_value = HTTPResponse(json.dumps(seer_return_value).encode("utf-8"))
+
+        params: SimilarIssuesEmbeddingsRequest = {
+            "hash": NonNone(event.get_primary_hash()),
+            "project_id": self.project.id,
+            "stacktrace": "string",
+            "message": "message",
+        }
+
+        similar_issue_data: Any = {
+            **raw_similar_issue_data,
+            "parent_group_id": similar_event.group_id,
+        }
+        less_similar_issue_data: Any = {
+            **raw_less_similar_issue_data,
+            "parent_group_id": less_similar_event.group_id,
+        }
+
+        # The results have been reordered so that the more similar issue comes first
+        assert get_similarity_data_from_seer(params) == [
+            SeerSimilarIssueData(**similar_issue_data),
+            SeerSimilarIssueData(**less_similar_issue_data),
+        ]

--- a/tests/sentry/seer/test_utils.py
+++ b/tests/sentry/seer/test_utils.py
@@ -1,20 +1,10 @@
-from typing import Any
 from unittest import mock
 
 import pytest
 from urllib3.response import HTTPResponse
 
-from sentry.seer.similarity.similar_issues import get_similarity_data_from_seer
-from sentry.seer.similarity.types import (
-    RawSeerSimilarIssueData,
-    SeerSimilarIssueData,
-    SimilarIssuesEmbeddingsRequest,
-)
 from sentry.seer.utils import detect_breakpoints
-from sentry.testutils.helpers.eventprocessing import save_new_event
-from sentry.testutils.pytest.fixtures import django_db_all
 from sentry.utils import json
-from sentry.utils.types import NonNone
 
 
 @mock.patch("sentry.seer.utils.seer_breakpoint_connection_pool.urlopen")
@@ -55,99 +45,3 @@ def test_detect_breakpoints_errors(mock_urlopen, mock_capture_exception, body, s
 
     assert detect_breakpoints({}) == {"data": []}
     assert mock_capture_exception.called
-
-
-@django_db_all
-@mock.patch("sentry.seer.similarity.similar_issues.seer_grouping_connection_pool.urlopen")
-def test_similar_issues_embeddings_simple(mock_seer_request, default_project):
-    """Test that valid responses are decoded and returned."""
-    event = save_new_event({"message": "Dogs are great!"}, default_project)
-    similar_event = save_new_event({"message": "Adopt don't shop"}, default_project)
-
-    raw_similar_issue_data: RawSeerSimilarIssueData = {
-        "message_distance": 0.05,
-        "parent_hash": NonNone(similar_event.get_primary_hash()),
-        "should_group": True,
-        "stacktrace_distance": 0.01,
-    }
-
-    seer_return_value = {"responses": [raw_similar_issue_data]}
-    mock_seer_request.return_value = HTTPResponse(json.dumps(seer_return_value).encode("utf-8"))
-
-    params: SimilarIssuesEmbeddingsRequest = {
-        "hash": NonNone(event.get_primary_hash()),
-        "project_id": default_project.id,
-        "stacktrace": "string",
-        "message": "message",
-    }
-
-    similar_issue_data: Any = {
-        **raw_similar_issue_data,
-        "parent_group_id": similar_event.group_id,
-    }
-
-    assert get_similarity_data_from_seer(params) == [SeerSimilarIssueData(**similar_issue_data)]
-
-
-@django_db_all
-@mock.patch("sentry.seer.similarity.similar_issues.seer_grouping_connection_pool.urlopen")
-def test_empty_similar_issues_embeddings(mock_seer_request, default_project):
-    """Test that empty responses are returned."""
-    event = save_new_event({"message": "Dogs are great!"}, default_project)
-
-    mock_seer_request.return_value = HTTPResponse([])
-
-    params: SimilarIssuesEmbeddingsRequest = {
-        "hash": NonNone(event.get_primary_hash()),
-        "project_id": default_project.id,
-        "stacktrace": "string",
-        "message": "message",
-    }
-    assert get_similarity_data_from_seer(params) == []
-
-
-@django_db_all
-@mock.patch("sentry.seer.similarity.similar_issues.seer_grouping_connection_pool.urlopen")
-def test_returns_sorted_similarity_results(mock_seer_request, default_project):
-    event = save_new_event({"message": "Dogs are great!"}, default_project)
-    similar_event = save_new_event({"message": "Adopt don't shop"}, default_project)
-    less_similar_event = save_new_event({"message": "Charlie is goofy"}, default_project)
-
-    raw_similar_issue_data: RawSeerSimilarIssueData = {
-        "message_distance": 0.05,
-        "parent_hash": NonNone(similar_event.get_primary_hash()),
-        "should_group": True,
-        "stacktrace_distance": 0.01,
-    }
-    raw_less_similar_issue_data: RawSeerSimilarIssueData = {
-        "message_distance": 0.10,
-        "parent_hash": NonNone(less_similar_event.get_primary_hash()),
-        "should_group": False,
-        "stacktrace_distance": 0.05,
-    }
-
-    # Note that the less similar issue is first in the list as it comes back from Seer
-    seer_return_value = {"responses": [raw_less_similar_issue_data, raw_similar_issue_data]}
-    mock_seer_request.return_value = HTTPResponse(json.dumps(seer_return_value).encode("utf-8"))
-
-    params: SimilarIssuesEmbeddingsRequest = {
-        "hash": NonNone(event.get_primary_hash()),
-        "project_id": default_project.id,
-        "stacktrace": "string",
-        "message": "message",
-    }
-
-    similar_issue_data: Any = {
-        **raw_similar_issue_data,
-        "parent_group_id": similar_event.group_id,
-    }
-    less_similar_issue_data: Any = {
-        **raw_less_similar_issue_data,
-        "parent_group_id": less_similar_event.group_id,
-    }
-
-    # The results have been reordered so that the more similar issue comes first
-    assert get_similarity_data_from_seer(params) == [
-        SeerSimilarIssueData(**similar_issue_data),
-        SeerSimilarIssueData(**less_similar_issue_data),
-    ]

--- a/tests/sentry/seer/test_utils.py
+++ b/tests/sentry/seer/test_utils.py
@@ -4,12 +4,13 @@ from unittest import mock
 import pytest
 from urllib3.response import HTTPResponse
 
+from sentry.seer.similarity.similar_issues import get_similarity_data_from_seer
 from sentry.seer.similarity.types import (
     RawSeerSimilarIssueData,
     SeerSimilarIssueData,
     SimilarIssuesEmbeddingsRequest,
 )
-from sentry.seer.utils import detect_breakpoints, get_similarity_data_from_seer
+from sentry.seer.utils import detect_breakpoints
 from sentry.testutils.helpers.eventprocessing import save_new_event
 from sentry.testutils.pytest.fixtures import django_db_all
 from sentry.utils import json
@@ -57,7 +58,7 @@ def test_detect_breakpoints_errors(mock_urlopen, mock_capture_exception, body, s
 
 
 @django_db_all
-@mock.patch("sentry.seer.utils.seer_grouping_connection_pool.urlopen")
+@mock.patch("sentry.seer.similarity.similar_issues.seer_grouping_connection_pool.urlopen")
 def test_similar_issues_embeddings_simple(mock_seer_request, default_project):
     """Test that valid responses are decoded and returned."""
     event = save_new_event({"message": "Dogs are great!"}, default_project)
@@ -89,7 +90,7 @@ def test_similar_issues_embeddings_simple(mock_seer_request, default_project):
 
 
 @django_db_all
-@mock.patch("sentry.seer.utils.seer_grouping_connection_pool.urlopen")
+@mock.patch("sentry.seer.similarity.similar_issues.seer_grouping_connection_pool.urlopen")
 def test_empty_similar_issues_embeddings(mock_seer_request, default_project):
     """Test that empty responses are returned."""
     event = save_new_event({"message": "Dogs are great!"}, default_project)
@@ -106,7 +107,7 @@ def test_empty_similar_issues_embeddings(mock_seer_request, default_project):
 
 
 @django_db_all
-@mock.patch("sentry.seer.utils.seer_grouping_connection_pool.urlopen")
+@mock.patch("sentry.seer.similarity.similar_issues.seer_grouping_connection_pool.urlopen")
 def test_returns_sorted_similarity_results(mock_seer_request, default_project):
     event = save_new_event({"message": "Dogs are great!"}, default_project)
     similar_event = save_new_event({"message": "Adopt don't shop"}, default_project)


### PR DESCRIPTION
This PR is the third in a series reorganizing the Seer grouping code a bit, primarily to split up what have become some unwieldily-long files. Here, the code in `seer.utils.py` getting similar issues from Seer is split into its own module.