### PR TITLE
feat(performance): Update cache and queues module badge setting to beta

### DIFF
--- a/static/app/components/sidebar/index.tsx
+++ b/static/app/components/sidebar/index.tsx
@@ -63,6 +63,10 @@ import {
   MODULE_TITLE as HTTP_MODULE_TITLE,
   releaseLevelAsBadgeProps as HTTPModuleBadgeProps,
 } from 'sentry/views/performance/http/settings';
+import {
+  MODULE_TITLE as QUEUES_MODULE_TITLE,
+  releaseLevelAsBadgeProps as QueuesModuleBadgeProps,
+} from 'sentry/views/performance/queues/settings';
 import {MODULE_BASE_URLS} from 'sentry/views/performance/utils/useModuleURL';
 import {ModuleName} from 'sentry/views/starfish/types';
 
@@ -324,9 +328,11 @@ function Sidebar() {
                 <SidebarItem
                   {...sidebarItemProps}
                   label={
-                    <GuideAnchor target="performance-queues">{t('Queues')}</GuideAnchor>
+                    <GuideAnchor target="performance-queues">
+                      {QUEUES_MODULE_TITLE}
+                    </GuideAnchor>
                   }
-                  isAlpha
+                  {...QueuesModuleBadgeProps}
                   to={`/organizations/${organization.slug}/performance/${MODULE_BASE_URLS[ModuleName.QUEUE]}/`}
                   id="performance-queues"
                   icon={<SubitemDot collapsed />}

--- a/static/app/views/performance/cache/settings.ts
+++ b/static/app/views/performance/cache/settings.ts
@@ -5,7 +5,7 @@ import type {SpanMetricsQueryFilters} from 'sentry/views/starfish/types';
 export const MODULE_TITLE = t('Caches');
 export const BASE_URL = 'caches';
 
-export const RELEASE_LEVEL: BadgeType = 'alpha';
+export const RELEASE_LEVEL: BadgeType = 'beta';
 
 // NOTE: Awkward typing, but without it `RELEASE_LEVEL` is narrowed and the comparison is not allowed
 export const releaseLevelAsBadgeProps = {

--- a/static/app/views/performance/queues/settings.ts
+++ b/static/app/views/performance/queues/settings.ts
@@ -6,7 +6,7 @@ export const BASE_URL = 'queues';
 
 export const DESTINATION_TITLE = t('Destination Summary');
 
-export const RELEASE_LEVEL: BadgeType = 'alpha';
+export const RELEASE_LEVEL: BadgeType = 'beta';
 
 export const releaseLevelAsBadgeProps = {
   isAlpha: (RELEASE_LEVEL as BadgeType) === 'alpha',


### PR DESCRIPTION
Bumps cache and queues module to beta
![image](https://github.com/getsentry/sentry/assets/83961295/c429d2c4-4978-423c-bf0a-a163d7fa2a3d)