### PR TITLE
feat(insights): Render LLM routes under `/insights/`

### DIFF
--- a/static/app/components/sidebar/index.tsx
+++ b/static/app/components/sidebar/index.tsx
@@ -418,8 +418,8 @@ function Sidebar() {
         label={t('LLM Monitoring')}
         isAlpha
         variant="short"
-        // NOTE: This is missing a slash, since the base URL for the AI module has a slash
-        to={`/organizations/${organization.slug}${MODULE_BASE_URLS[ModuleName.AI]}/`}
+        // NOTE: This doesn't include the insights base bath because LLM monitoring lives at `/llm-monitoring`
+        to={`/organizations/${organization.slug}/${MODULE_BASE_URLS[ModuleName.AI]}/`}
         id="llm-monitoring"
       />
     </Feature>

--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -1561,6 +1561,17 @@ function buildRoutes() {
           )}
         />
       </Route>
+      <Route path={`${MODULE_BASE_URLS[ModuleName.AI]}/`}>
+        <IndexRoute
+          component={make(() => import('sentry/views/llmMonitoring/landing'))}
+        />
+        <Route
+          path="pipeline-type/:groupId/"
+          component={make(
+            () => import('sentry/views/llmMonitoring/llmMonitoringDetailsPage')
+          )}
+        />
+      </Route>
     </Fragment>
   );
 

--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -1438,7 +1438,7 @@ function buildRoutes() {
   );
 
   const llmMonitoringRoutes = (
-    <Route path={`${MODULE_BASE_URLS[ModuleName.AI]}/`} withOrgPath>
+    <Route path={`/${MODULE_BASE_URLS[ModuleName.AI]}/`} withOrgPath>
       <IndexRoute component={make(() => import('sentry/views/llmMonitoring/landing'))} />
       <Route
         path="pipeline-type/:groupId/"

--- a/static/app/views/llmMonitoring/settings.ts
+++ b/static/app/views/llmMonitoring/settings.ts
@@ -1,4 +1,4 @@
 import {t} from 'sentry/locale';
 
 export const MODULE_TITLE = t('LLM Monitoring');
-export const BASE_URL = '/llm-monitoring';
+export const BASE_URL = 'llm-monitoring';

--- a/static/app/views/performance/utils/useModuleURL.tsx
+++ b/static/app/views/performance/utils/useModuleURL.tsx
@@ -36,7 +36,7 @@ export const useModuleURL = (moduleName: RoutableModuleNames): string => {
 
   if (moduleName === ModuleName.AI) {
     // AI Doesn't live under "/performance"
-    return normalizeUrl(`/organizations/${slug}${AI_BASE_URL}`);
+    return normalizeUrl(`/organizations/${slug}/${AI_BASE_URL}`);
   }
 
   return normalizeUrl(


### PR DESCRIPTION
Follow-up to https://github.com/getsentry/sentry/pull/71293. In short, makes the LLM module available at `/insights/llm-monitoring`. This is preparation for when all insights modules are under `/insights/`. I'm adding the routes early, so when the cutoff happens all I need to update is where the button in the UI go, and I don't need to feature flag the routes.

I had to make some small code changes, so this PR is separate.

Note: Technically, it's now always available at `/performance/llm-monitoring` but nothing leads there, and this is just a temporary state.
