### PR TITLE
fix(typo): Fix minor typo on replays tooltip

### DIFF
--- a/static/app/components/group/issueReplayCount.tsx
+++ b/static/app/components/group/issueReplayCount.tsx
@@ -27,7 +27,7 @@ function IssueReplayCount({group}: Props) {
   }
 
   const countDisplay = count > 50 ? '50+' : count;
-  const titleOver50 = t('This issue has 50+ replay available to view');
+  const titleOver50 = t('This issue has 50+ replays available to view');
   const title50OrLess = tn(
     'This issue has %s replay available to view',
     'This issue has %s replays available to view',


### PR DESCRIPTION
Fixes a minor typo on this tooltip in the issue stream:

![image](https://github.com/getsentry/sentry/assets/55160142/dbcaee59-e248-417e-9012-74bfee5caf54)

