### PR TITLE
fix(<AssigneeBadge/>): Fix broken hover state on assignee badge

### DIFF
--- a/static/app/components/assigneeBadge.tsx
+++ b/static/app/components/assigneeBadge.tsx
@@ -91,6 +91,7 @@ export function AssigneeBadge({
     <StyledTag icon={loadingIcon} />
   ) : assignedTo ? (
     <Tooltip
+      isHoverable
       title={
         <TooltipWrapper>
           {t('Assigned to ')}
@@ -105,6 +106,7 @@ export function AssigneeBadge({
     </Tooltip>
   ) : (
     <Tooltip
+      isHoverable
       title={
         <TooltipWrapper>
           <div>{t('Unassigned')}</div>


### PR DESCRIPTION
This PR fixes the error where the hover tooltip on the assignee badge did not persist long enough for users to click on the links. 