### PR TITLE
feat(performance): adds trace error rate function

### DIFF
--- a/src/sentry/search/events/constants.py
+++ b/src/sentry/search/events/constants.py
@@ -194,8 +194,6 @@ HTTP_SERVER_ERROR_STATUS = {
 
 CACHE_HIT_STATUS = {"true", "false"}
 
-TRACE_SUCCESS_STATUS = {"ok", "cancelled", "unknown"}
-
 CONFIGURABLE_AGGREGATES = {
     "apdex()": "apdex({threshold}) as apdex",
     "user_misery()": "user_misery({threshold}) as user_misery",

--- a/src/sentry/search/events/constants.py
+++ b/src/sentry/search/events/constants.py
@@ -194,6 +194,8 @@ HTTP_SERVER_ERROR_STATUS = {
 
 CACHE_HIT_STATUS = {"true", "false"}
 
+TRACE_SUCCESS_STATUS = {"ok", "cancelled", "unknown"}
+
 CONFIGURABLE_AGGREGATES = {
     "apdex()": "apdex({threshold}) as apdex",
     "user_misery()": "user_misery({threshold}) as user_misery",

--- a/src/sentry/search/events/datasets/spans_metrics.py
+++ b/src/sentry/search/events/datasets/spans_metrics.py
@@ -1214,7 +1214,7 @@ class SpansMetricsDatasetConfig(DatasetConfig):
         alias: str | None = None,
     ) -> SelectType:
         success_statuses = [
-            self.builder.resolve_tag_value(status) for status in constants.TRACE_SUCCESS_STATUS
+            self.builder.resolve_tag_value(status) for status in constants.NON_FAILURE_STATUS
         ]
         return self._resolve_count_if(
             Function(

--- a/src/sentry/search/events/datasets/spans_metrics.py
+++ b/src/sentry/search/events/datasets/spans_metrics.py
@@ -590,6 +590,27 @@ class SpansMetricsDatasetConfig(DatasetConfig):
                     ),
                     default_result_type="percentage",
                 ),
+                fields.MetricsFunction(
+                    "trace_error_rate",
+                    snql_distribution=lambda args, alias: function_aliases.resolve_division(
+                        self._resolve_trace_error_count(args),
+                        Function(
+                            "countIf",
+                            [
+                                Column("value"),
+                                Function(
+                                    "equals",
+                                    [
+                                        Column("metric_id"),
+                                        self.resolve_metric("span.self_time"),
+                                    ],
+                                ),
+                            ],
+                        ),
+                        alias,
+                    ),
+                    default_result_type="percentage",
+                ),
             ]
         }
 
@@ -1184,6 +1205,37 @@ class SpansMetricsDatasetConfig(DatasetConfig):
                 ],
             ),
             condition,
+            alias,
+        )
+
+    def _resolve_trace_error_count(
+        self,
+        _: Mapping[str, str | Column | SelectType | int | float],
+        alias: str | None = None,
+    ) -> SelectType:
+        success_statuses = [
+            self.builder.resolve_tag_value(status) for status in constants.TRACE_SUCCESS_STATUS
+        ]
+        return self._resolve_count_if(
+            Function(
+                "equals",
+                [
+                    Column("metric_id"),
+                    self.resolve_metric("span.self_time"),
+                ],
+            ),
+            Function(
+                "not",
+                [
+                    Function(
+                        "in",
+                        [
+                            self.builder.column("trace.status"),
+                            list(status for status in success_statuses if status is not None),
+                        ],
+                    )
+                ],
+            ),
             alias,
         )
 

--- a/tests/snuba/api/endpoints/test_organization_events_span_metrics.py
+++ b/tests/snuba/api/endpoints/test_organization_events_span_metrics.py
@@ -1731,6 +1731,62 @@ class OrganizationEventsMetricsEnhancedPerformanceEndpointTest(MetricsEnhancedPe
         assert meta["fields"]["trace_status_rate(internal_error)"] == "percentage"
         assert meta["fields"]["trace_status_rate(unauthenticated)"] == "percentage"
 
+    def test_trace_error_rate(self):
+        self.store_span_metric(
+            1,
+            internal_metric=constants.SELF_TIME_LIGHT,
+            timestamp=self.min_ago,
+            tags={"trace.status": "unknown"},
+        )
+
+        self.store_span_metric(
+            3,
+            internal_metric=constants.SELF_TIME_LIGHT,
+            timestamp=self.min_ago,
+            tags={"trace.status": "internal_error"},
+        )
+
+        self.store_span_metric(
+            3,
+            internal_metric=constants.SELF_TIME_LIGHT,
+            timestamp=self.min_ago,
+            tags={"trace.status": "unauthenticated"},
+        )
+
+        self.store_span_metric(
+            4,
+            internal_metric=constants.SELF_TIME_LIGHT,
+            timestamp=self.min_ago,
+            tags={"trace.status": "ok"},
+        )
+
+        self.store_span_metric(
+            5,
+            internal_metric=constants.SELF_TIME_LIGHT,
+            timestamp=self.min_ago,
+            tags={"trace.status": "ok"},
+        )
+
+        response = self.do_request(
+            {
+                "field": [
+                    "trace_error_rate()",
+                ],
+                "query": "",
+                "project": self.project.id,
+                "dataset": "spansMetrics",
+            }
+        )
+
+        assert response.status_code == 200, response.content
+        data = response.data["data"]
+        assert len(data) == 1
+        assert data[0]["trace_error_rate()"] == 0.4
+
+        meta = response.data["meta"]
+        assert meta["dataset"] == "spansMetrics"
+        assert meta["fields"]["trace_error_rate()"] == "percentage"
+
 
 class OrganizationEventsMetricsEnhancedPerformanceEndpointTestWithMetricLayer(
     OrganizationEventsMetricsEnhancedPerformanceEndpointTest


### PR DESCRIPTION
Adds a `trace_error_rate` function on the span metrics dataset that returns the rate of spans with `trace.status` not set to `ok` or `unknown` or `cancelled`