### PR TITLE
fix(highlights): Allow custom properties on user to be highlighted

### DIFF
--- a/static/app/components/events/contexts/index.tsx
+++ b/static/app/components/events/contexts/index.tsx
@@ -35,12 +35,13 @@ export interface ContextItem {
 
 export function getOrderedContextItems(event): ContextItem[] {
   const {user, contexts} = event;
+  const {data: customUserData, ...userContext} = user;
 
   const {feedback, response, ...otherContexts} = contexts ?? {};
   const orderedContext: [ContextItem['alias'], ContextValue][] = [
     ['response', response],
     ['feedback', feedback],
-    ['user', user],
+    ['user', {...userContext, ...customUserData}],
     ...Object.entries(otherContexts),
   ];
   // For these context aliases, use the alias as 'type' rather than 'value.type'

--- a/static/app/components/events/contexts/index.tsx
+++ b/static/app/components/events/contexts/index.tsx
@@ -35,7 +35,7 @@ export interface ContextItem {
 
 export function getOrderedContextItems(event): ContextItem[] {
   const {user, contexts} = event;
-  const {data: customUserData, ...userContext} = user;
+  const {data: customUserData, ...userContext} = user ?? {};
 
   const {feedback, response, ...otherContexts} = contexts ?? {};
   const orderedContext: [ContextItem['alias'], ContextValue][] = [

--- a/static/app/components/events/highlights/highlightsDataSection.spec.tsx
+++ b/static/app/components/events/highlights/highlightsDataSection.spec.tsx
@@ -3,7 +3,7 @@ import {GroupFixture} from 'sentry-fixture/group';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {ProjectFixture} from 'sentry-fixture/project';
 
-import {render, screen, within} from 'sentry-test/reactTestingLibrary';
+import {render, screen, userEvent, within} from 'sentry-test/reactTestingLibrary';
 
 import * as modal from 'sentry/actionCreators/modal';
 import HighlightsDataSection from 'sentry/components/events/highlights/highlightsDataSection';
@@ -86,7 +86,15 @@ describe('HighlightsDataSection', function () {
       // If highlight is present on the event...
       if (eventTagMap.hasOwnProperty(tagKey)) {
         expect(within(row).getByText(eventTagMap[tagKey])).toBeInTheDocument();
-        expect(within(row).getByLabelText('Tag Actions Menu')).toBeInTheDocument();
+        const highlightTagDropdown = within(row).getByLabelText('Tag Actions Menu');
+        expect(highlightTagDropdown).toBeInTheDocument();
+        await userEvent.click(highlightTagDropdown);
+        expect(
+          screen.getByLabelText('View issues with this tag value')
+        ).toBeInTheDocument();
+        expect(
+          screen.queryByLabelText('Add to event highlights')
+        ).not.toBeInTheDocument();
       } else {
         expect(within(row).getByText(EMPTY_HIGHLIGHT_DEFAULT)).toBeInTheDocument();
         expect(within(row).queryByLabelText('Tag Actions Menu')).not.toBeInTheDocument();

--- a/static/app/components/events/highlights/highlightsDataSection.tsx
+++ b/static/app/components/events/highlights/highlightsDataSection.tsx
@@ -102,7 +102,7 @@ function HighlightsData({
       content={content}
       event={event}
       tagKey={content.originalTag.key}
-      project={project}
+      project={detailedProject ?? project}
       config={{
         disableActions: content.value === EMPTY_HIGHLIGHT_DEFAULT,
         disableRichValue: content.value === EMPTY_HIGHLIGHT_DEFAULT,

--- a/static/app/components/events/highlights/highlightsSettingsForm.spec.tsx
+++ b/static/app/components/events/highlights/highlightsSettingsForm.spec.tsx
@@ -16,16 +16,17 @@ describe('HighlightsSettingForm', function () {
   const project = ProjectFixture({highlightContext, highlightTags});
   const analyticsSpy = jest.spyOn(analytics, 'trackAnalytics');
 
-  beforeEach(async function () {
+  beforeEach(function () {
     MockApiClient.addMockResponse({
       url: `/projects/${organization.slug}/${project.slug}/`,
       body: {...project, highlightTags, highlightContext},
     });
-    render(<HighlightsSettingsForm projectSlug={project.slug} />, {organization});
-    await screen.findByText('Highlights');
   });
 
-  it('should render with highlights from detailed project', function () {
+  it('should render with highlights from detailed project', async function () {
+    render(<HighlightsSettingsForm projectSlug={project.slug} />, {organization});
+    await screen.findByText('Highlights');
+
     expect(screen.getByText('Highlighted Tags')).toBeInTheDocument();
     const tagInput = screen.getByRole('textbox', {name: 'Highlighted Tags'});
     expect(tagInput).toHaveValue(highlightTags.join('\n'));
@@ -36,6 +37,9 @@ describe('HighlightsSettingForm', function () {
   });
 
   it('should allow the Highlight Tags field to mutate highlights', async function () {
+    render(<HighlightsSettingsForm projectSlug={project.slug} />, {organization});
+    await screen.findByText('Highlights');
+
     const newTag = 'orchid';
     const url = `/projects/${organization.slug}/${project.slug}/`;
     const updateProjectMock = MockApiClient.addMockResponse({
@@ -62,6 +66,9 @@ describe('HighlightsSettingForm', function () {
   });
 
   it('should allow the Highlight Context field to mutate highlights', async function () {
+    render(<HighlightsSettingsForm projectSlug={project.slug} />, {organization});
+    await screen.findByText('Highlights');
+
     const newContext = {flower: ['leafCount', 'petalCount']};
     const url = `/projects/${organization.slug}/${project.slug}/`;
     const updateProjectMock = MockApiClient.addMockResponse({


### PR DESCRIPTION
Resolves https://github.com/getsentry/sentry/issues/71246

Allows custom properties on User context to be highlighted as well as displayed on the context UI. In the screenshots, `location` and `other` are custom properties.

**context on issue**
![image](https://github.com/getsentry/sentry/assets/35509934/59643318-11ef-4f9a-b56f-22532089f457)

**highlights modal**
![image](https://github.com/getsentry/sentry/assets/35509934/64406271-7acd-4b02-ae4f-536e708d760c)

Added a bonus fix for hiding 'Add to Event Highlights' from the dropdowns in the highlights section.

![image](https://github.com/getsentry/sentry/assets/35509934/422e9bf6-2d29-450d-b7f2-b65fb4ff387d)
