### PR TITLE
ref(seer grouping): Pull event content filtering into helper

### DIFF
--- a/src/sentry/grouping/ingest/seer.py
+++ b/src/sentry/grouping/ingest/seer.py
@@ -2,7 +2,6 @@ import logging
 from dataclasses import asdict
 
 from sentry import features
-from sentry.constants import PLACEHOLDER_EVENT_TITLES
 from sentry.eventstore.models import Event
 from sentry.grouping.grouping_info import get_grouping_info_from_variants
 from sentry.grouping.result import CalculatedHashes
@@ -10,8 +9,7 @@ from sentry.models.group import Group
 from sentry.models.project import Project
 from sentry.seer.similarity.similar_issues import get_similarity_data_from_seer
 from sentry.seer.similarity.types import SeerSimilarIssuesMetadata, SimilarIssuesEmbeddingsRequest
-from sentry.seer.similarity.utils import get_stacktrace_string
-from sentry.utils.safe import get_path
+from sentry.seer.similarity.utils import event_content_is_seer_eligible, get_stacktrace_string
 
 logger = logging.getLogger("sentry.events.grouping")
 
@@ -24,13 +22,7 @@ def should_call_seer_for_grouping(event: Event, project: Project) -> bool:
     # TODO: Implement rate limits, kill switches, other flags, etc
     # TODO: Return False if the event has a custom fingerprint (check for both client- and server-side fingerprints)
 
-    # If an event has no stacktrace, and only one of our placeholder titles ("<untitled>",
-    # "<unknown>", etc.), there's no data for Seer to analyze, so no point in making the API call.
-    if (
-        event.title in PLACEHOLDER_EVENT_TITLES
-        and not get_path(event.data, "exception", "values", -1, "stacktrace", "frames")
-        and not get_path(event.data, "threads", "values", -1, "stacktrace", "frames")
-    ):
+    if not event_content_is_seer_eligible(event):
         return False
 
     return features.has("projects:similarity-embeddings-metadata", project) or features.has(

--- a/tests/sentry/event_manager/grouping/test_seer_grouping.py
+++ b/tests/sentry/event_manager/grouping/test_seer_grouping.py
@@ -47,6 +47,10 @@ class SeerEventManagerGroupingTest(TestCase):
                 "sentry.grouping.ingest.seer.get_similarity_data_from_seer",
                 return_value=[seer_result_data],
             ),
+            patch(
+                "sentry.grouping.ingest.seer.event_content_is_seer_eligible",
+                return_value=True,
+            ),
         ):
 
             with Feature(
@@ -148,14 +152,16 @@ class SeerEventManagerGroupingTest(TestCase):
                 assert new_event.group_id == existing_event.group_id
 
     @with_feature("projects:similarity-embeddings-metadata")
+    @patch("sentry.grouping.ingest.seer.event_content_is_seer_eligible", return_value=True)
     @patch("sentry.event_manager.get_seer_similar_issues", return_value=({}, None))
-    def test_calls_seer_if_no_group_found(self, mock_get_seer_similar_issues: MagicMock):
+    def test_calls_seer_if_no_group_found(self, mock_get_seer_similar_issues: MagicMock, _):
         save_new_event({"message": "Dogs are great!"}, self.project)
         assert mock_get_seer_similar_issues.call_count == 1
 
     @with_feature("projects:similarity-embeddings-metadata")
+    @patch("sentry.grouping.ingest.seer.event_content_is_seer_eligible", return_value=True)
     @patch("sentry.event_manager.get_seer_similar_issues", return_value=({}, None))
-    def test_bypasses_seer_if_group_found(self, mock_get_seer_similar_issues: MagicMock):
+    def test_bypasses_seer_if_group_found(self, mock_get_seer_similar_issues: MagicMock, _):
         existing_event = save_new_event({"message": "Dogs are great!"}, self.project)
         assert mock_get_seer_similar_issues.call_count == 1
 
@@ -164,7 +170,8 @@ class SeerEventManagerGroupingTest(TestCase):
         assert mock_get_seer_similar_issues.call_count == 1  # didn't get called again
 
     @with_feature("projects:similarity-embeddings-metadata")
-    def test_stores_seer_results_in_metadata(self):
+    @patch("sentry.grouping.ingest.seer.event_content_is_seer_eligible", return_value=True)
+    def test_stores_seer_results_in_metadata(self, _):
         existing_event = save_new_event({"message": "Dogs are great!"}, self.project)
 
         seer_result_data = SeerSimilarIssueData(
@@ -190,7 +197,8 @@ class SeerEventManagerGroupingTest(TestCase):
         assert new_event.data["seer_similarity"] == expected_metadata
 
     @with_feature("projects:similarity-embeddings-grouping")
-    def test_assigns_event_to_neighbor_group_if_found(self):
+    @patch("sentry.grouping.ingest.seer.event_content_is_seer_eligible", return_value=True)
+    def test_assigns_event_to_neighbor_group_if_found(self, _):
         existing_event = save_new_event({"message": "Dogs are great!"}, self.project)
 
         seer_result_data = SeerSimilarIssueData(


### PR DESCRIPTION
Some of the criteria we use to decide whether or not to make a call to Seer before creating a new group are based on the contents of the event. (For example, does it have a stacktrace and a usable title?) We want to be able to run these event-contents-based checks when doing the backfill also, though, so this splits them into a separate function, so it can be used in both spots. 

It also adds platform to the filtering criteria. For now, we're only letting Python and JS events through, because those are the only platforms for which we've validated the similarity model.