### PR TITLE
ref: Create new queue for seer record backfill

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -838,6 +838,7 @@ CELERY_QUEUES_REGION = [
     Queue("app_platform", routing_key="app_platform"),
     Queue("appstoreconnect", routing_key="sentry.tasks.app_store_connect.#"),
     Queue("assemble", routing_key="assemble"),
+    Queue("backfill_seer_grouping_records", routing_key="backfill_seer_grouping_records"),
     Queue("buffers.process_pending", routing_key="buffers.process_pending"),
     Queue("buffers.process_pending_batch", routing_key="buffers.process_pending_batch"),
     Queue("buffers.incr", routing_key="buffers.incr"),


### PR DESCRIPTION
Create new queue to be used by the [backfill_seer_grouping_records script](https://github.com/getsentry/sentry/blob/2c2362b81ef5bc089dda852c5a99e0d8983b05e3/src/sentry/tasks/backfill_seer_grouping_records.py#L65)