### PR TITLE
feat(ui): display full resource name on hover

### DIFF
--- a/static/app/views/starfish/components/tableCells/filenameCell.tsx
+++ b/static/app/views/starfish/components/tableCells/filenameCell.tsx
@@ -1,3 +1,4 @@
+import {WiderHovercard} from 'sentry/views/starfish/components/tableCells/spanDescriptionCell';
 import {OverflowEllipsisTextContainer} from 'sentry/views/starfish/components/textAlign';
 
 type Props = {
@@ -7,7 +8,11 @@ type Props = {
 function FilenameCell(props: Props) {
   const {url} = props;
   const filename = url?.split('/').pop()?.split('?')[0];
-  return <OverflowEllipsisTextContainer>{filename}</OverflowEllipsisTextContainer>;
+  return (
+    <WiderHovercard position="right" body={filename}>
+      <OverflowEllipsisTextContainer>{filename}</OverflowEllipsisTextContainer>
+    </WiderHovercard>
+  );
 }
 
 export default FilenameCell;


### PR DESCRIPTION
Displays full resource name on hover.

<img width="734" alt="image" src="https://github.com/getsentry/sentry/assets/58920989/abe97efc-7806-4ed2-a74f-016a7036337c">
