### PR TITLE
Ownership change for sentry.snuba.tasks

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -170,9 +170,11 @@ yarn.lock                                                @getsentry/owners-js-de
 /src/sentry/snuba/models.py                               @getsentry/alerts-notifications
 /src/sentry/snuba/query_subscriptions/                    @getsentry/alerts-notifications
 /src/sentry/snuba/subscriptions.py                        @getsentry/alerts-notifications
+/src/sentry/snuba/tasks.py                                @getsentry/alerts-notifications
 /tests/snuba/incidents/                                   @getsentry/alerts-notifications
 /tests/sentry/snuba/test_query_subscription_consumer.py   @getsentry/alerts-notifications
 /tests/sentry/snuba/test_subscriptions.py                 @getsentry/alerts-notifications
+/tests/sentry/snuba/test_tasks.py                         @getsentry/alerts-notifications
 ## Endof Alerts & Notifications
 
 
@@ -514,7 +516,6 @@ static/app/components/events/eventStatisticalDetector/                    @getse
 /tests/sentry/event_manager/                                @getsentry/issues
 /tests/sentry/grouping/                                     @getsentry/issues
 /tests/sentry/search/                                       @getsentry/issues
-/tests/sentry/snuba/test_tasks.py                           @getsentry/issues
 /tests/sentry/tasks/test_post_process.py                    @getsentry/issues
 /tests/snuba/search/                                        @getsentry/issues
 ## End of Issues


### PR DESCRIPTION
This file is now owned by the Alerts and Notifications team.