### PR TITLE
ref(insights): Create sidebar links using `useModuleURL`

### DIFF
--- a/static/app/components/sidebar/index.tsx
+++ b/static/app/components/sidebar/index.tsx
@@ -245,7 +245,7 @@ function Sidebar() {
     </Feature>
   );
 
-  const moduleURLBuilder = useModuleURLBuilder();
+  const moduleURLBuilder = useModuleURLBuilder(true);
 
   const performance = hasOrganization && (
     <Feature
@@ -277,7 +277,7 @@ function Sidebar() {
                       {t('Queries')}
                     </GuideAnchor>
                   }
-                  to={`/organizations/${organization.slug}/${moduleURLBuilder('db', true)}/`}
+                  to={`/organizations/${organization.slug}/${moduleURLBuilder('db')}/`}
                   id="performance-database"
                   // collapsed controls whether the dot is visible or not.
                   // We always want it visible for these sidebar items so force it to true.
@@ -292,7 +292,7 @@ function Sidebar() {
                       {HTTP_MODULE_TITLE}
                     </GuideAnchor>
                   }
-                  to={`/organizations/${organization.slug}/${moduleURLBuilder('http', true)}/`}
+                  to={`/organizations/${organization.slug}/${moduleURLBuilder('http')}/`}
                   id="performance-http"
                   icon={<SubitemDot collapsed />}
                   {...HTTPModuleBadgeProps}
@@ -306,7 +306,7 @@ function Sidebar() {
                       {CACHE_MODULE_TITLE}
                     </GuideAnchor>
                   }
-                  to={`/organizations/${organization.slug}/${moduleURLBuilder('cache', true)}/`}
+                  to={`/organizations/${organization.slug}/${moduleURLBuilder('cache')}/`}
                   id="performance-cache"
                   icon={<SubitemDot collapsed />}
                   {...CacheModuleBadgeProps}
@@ -320,7 +320,7 @@ function Sidebar() {
                       {t('Web Vitals')}
                     </GuideAnchor>
                   }
-                  to={`/organizations/${organization.slug}/${moduleURLBuilder('vital', true)}/`}
+                  to={`/organizations/${organization.slug}/${moduleURLBuilder('vital')}/`}
                   id="performance-webvitals"
                   icon={<SubitemDot collapsed />}
                 />
@@ -334,7 +334,7 @@ function Sidebar() {
                     </GuideAnchor>
                   }
                   {...QueuesModuleBadgeProps}
-                  to={`/organizations/${organization.slug}/${moduleURLBuilder('queue', true)}/`}
+                  to={`/organizations/${organization.slug}/${moduleURLBuilder('queue')}/`}
                   id="performance-queues"
                   icon={<SubitemDot collapsed />}
                 />
@@ -343,7 +343,7 @@ function Sidebar() {
                 <SidebarItem
                   {...sidebarItemProps}
                   label={t('Screen Loads')}
-                  to={`/organizations/${organization.slug}/${moduleURLBuilder('screen_load', true)}/`}
+                  to={`/organizations/${organization.slug}/${moduleURLBuilder('screen_load')}/`}
                   id="performance-mobile-screens"
                   icon={<SubitemDot collapsed />}
                 />
@@ -352,7 +352,7 @@ function Sidebar() {
                 <SidebarItem
                   {...sidebarItemProps}
                   label={t('App Starts')}
-                  to={`/organizations/${organization.slug}/${moduleURLBuilder('app_start', true)}/`}
+                  to={`/organizations/${organization.slug}/${moduleURLBuilder('app_start')}/`}
                   id="performance-mobile-app-startup"
                   icon={<SubitemDot collapsed />}
                 />
@@ -364,7 +364,7 @@ function Sidebar() {
                 <SidebarItem
                   {...sidebarItemProps}
                   label={t('Mobile UI')}
-                  to={`/organizations/${organization.slug}/${moduleURLBuilder('mobile-ui', true)}/`}
+                  to={`/organizations/${organization.slug}/${moduleURLBuilder('mobile-ui')}/`}
                   id="performance-mobile-ui"
                   icon={<SubitemDot collapsed />}
                   isAlpha
@@ -374,7 +374,7 @@ function Sidebar() {
                 <SidebarItem
                   {...sidebarItemProps}
                   label={<GuideAnchor target="starfish">{t('Resources')}</GuideAnchor>}
-                  to={`/organizations/${organization.slug}/${moduleURLBuilder('resource', true)}/`}
+                  to={`/organizations/${organization.slug}/${moduleURLBuilder('resource')}/`}
                   id="performance-browser-resources"
                   icon={<SubitemDot collapsed />}
                 />
@@ -425,7 +425,7 @@ function Sidebar() {
         label={t('LLM Monitoring')}
         isAlpha
         variant="short"
-        to={`/organizations/${organization.slug}/${moduleURLBuilder('ai', true)}/`}
+        to={`/organizations/${organization.slug}/${moduleURLBuilder('ai')}/`}
         id="llm-monitoring"
       />
     </Feature>

--- a/static/app/components/sidebar/index.tsx
+++ b/static/app/components/sidebar/index.tsx
@@ -67,8 +67,7 @@ import {
   MODULE_TITLE as QUEUES_MODULE_TITLE,
   releaseLevelAsBadgeProps as QueuesModuleBadgeProps,
 } from 'sentry/views/performance/queues/settings';
-import {MODULE_BASE_URLS} from 'sentry/views/performance/utils/useModuleURL';
-import {ModuleName} from 'sentry/views/starfish/types';
+import {useModuleURLBuilder} from 'sentry/views/performance/utils/useModuleURL';
 
 import {ProfilingOnboardingSidebar} from '../profiling/ProfilingOnboarding/profilingOnboardingSidebar';
 
@@ -246,6 +245,8 @@ function Sidebar() {
     </Feature>
   );
 
+  const moduleURLBuilder = useModuleURLBuilder();
+
   const performance = hasOrganization && (
     <Feature
       hookName="feature-disabled:performance-sidebar-item"
@@ -276,7 +277,7 @@ function Sidebar() {
                       {t('Queries')}
                     </GuideAnchor>
                   }
-                  to={`/organizations/${organization.slug}/performance/${MODULE_BASE_URLS[ModuleName.DB]}/`}
+                  to={`/organizations/${organization.slug}/${moduleURLBuilder('db', true)}/`}
                   id="performance-database"
                   // collapsed controls whether the dot is visible or not.
                   // We always want it visible for these sidebar items so force it to true.
@@ -291,7 +292,7 @@ function Sidebar() {
                       {HTTP_MODULE_TITLE}
                     </GuideAnchor>
                   }
-                  to={`/organizations/${organization.slug}/performance/${MODULE_BASE_URLS[ModuleName.HTTP]}/`}
+                  to={`/organizations/${organization.slug}/${moduleURLBuilder('http', true)}/`}
                   id="performance-http"
                   icon={<SubitemDot collapsed />}
                   {...HTTPModuleBadgeProps}
@@ -305,7 +306,7 @@ function Sidebar() {
                       {CACHE_MODULE_TITLE}
                     </GuideAnchor>
                   }
-                  to={`/organizations/${organization.slug}/performance/${MODULE_BASE_URLS[ModuleName.CACHE]}/`}
+                  to={`/organizations/${organization.slug}/${moduleURLBuilder('cache', true)}/`}
                   id="performance-cache"
                   icon={<SubitemDot collapsed />}
                   {...CacheModuleBadgeProps}
@@ -319,7 +320,7 @@ function Sidebar() {
                       {t('Web Vitals')}
                     </GuideAnchor>
                   }
-                  to={`/organizations/${organization.slug}/performance/${MODULE_BASE_URLS[ModuleName.VITAL]}/`}
+                  to={`/organizations/${organization.slug}/${moduleURLBuilder('vital', true)}/`}
                   id="performance-webvitals"
                   icon={<SubitemDot collapsed />}
                 />
@@ -333,7 +334,7 @@ function Sidebar() {
                     </GuideAnchor>
                   }
                   {...QueuesModuleBadgeProps}
-                  to={`/organizations/${organization.slug}/performance/${MODULE_BASE_URLS[ModuleName.QUEUE]}/`}
+                  to={`/organizations/${organization.slug}/${moduleURLBuilder('queue', true)}/`}
                   id="performance-queues"
                   icon={<SubitemDot collapsed />}
                 />
@@ -342,7 +343,7 @@ function Sidebar() {
                 <SidebarItem
                   {...sidebarItemProps}
                   label={t('Screen Loads')}
-                  to={`/organizations/${organization.slug}/performance/${MODULE_BASE_URLS[ModuleName.SCREEN_LOAD]}/`}
+                  to={`/organizations/${organization.slug}/${moduleURLBuilder('screen_load', true)}/`}
                   id="performance-mobile-screens"
                   icon={<SubitemDot collapsed />}
                 />
@@ -351,7 +352,7 @@ function Sidebar() {
                 <SidebarItem
                   {...sidebarItemProps}
                   label={t('App Starts')}
-                  to={`/organizations/${organization.slug}/performance/${MODULE_BASE_URLS[ModuleName.APP_START]}/`}
+                  to={`/organizations/${organization.slug}/${moduleURLBuilder('app_start', true)}/`}
                   id="performance-mobile-app-startup"
                   icon={<SubitemDot collapsed />}
                 />
@@ -363,7 +364,7 @@ function Sidebar() {
                 <SidebarItem
                   {...sidebarItemProps}
                   label={t('Mobile UI')}
-                  to={`/organizations/${organization.slug}/performance/${MODULE_BASE_URLS[ModuleName.MOBILE_UI]}/`}
+                  to={`/organizations/${organization.slug}/${moduleURLBuilder('mobile-ui', true)}/`}
                   id="performance-mobile-ui"
                   icon={<SubitemDot collapsed />}
                   isAlpha
@@ -373,7 +374,7 @@ function Sidebar() {
                 <SidebarItem
                   {...sidebarItemProps}
                   label={<GuideAnchor target="starfish">{t('Resources')}</GuideAnchor>}
-                  to={`/organizations/${organization.slug}/performance/${MODULE_BASE_URLS[ModuleName.RESOURCE]}/`}
+                  to={`/organizations/${organization.slug}/${moduleURLBuilder('resource', true)}/`}
                   id="performance-browser-resources"
                   icon={<SubitemDot collapsed />}
                 />
@@ -424,8 +425,7 @@ function Sidebar() {
         label={t('LLM Monitoring')}
         isAlpha
         variant="short"
-        // NOTE: This doesn't include the insights base bath because LLM monitoring lives at `/llm-monitoring`
-        to={`/organizations/${organization.slug}/${MODULE_BASE_URLS[ModuleName.AI]}/`}
+        to={`/organizations/${organization.slug}/${moduleURLBuilder('ai', true)}/`}
         id="llm-monitoring"
       />
     </Feature>

--- a/static/app/views/performance/settings.ts
+++ b/static/app/views/performance/settings.ts
@@ -1,4 +1,4 @@
 import {t} from 'sentry/locale';
 
 export const INSIGHTS_LABEL = t('Performance');
-export const INSIGHTS_BASE_URL = '/performance';
+export const INSIGHTS_BASE_URL = 'performance';

--- a/static/app/views/performance/utils/useModuleBreadcrumbs.tsx
+++ b/static/app/views/performance/utils/useModuleBreadcrumbs.tsx
@@ -29,7 +29,7 @@ export function useModuleBreadcrumbs(moduleName: RoutableModuleNames): Crumb[] {
   return [
     {
       label: INSIGHTS_LABEL,
-      to: normalizeUrl(`/organizations/${organization.slug}${INSIGHTS_BASE_URL}/`),
+      to: normalizeUrl(`/organizations/${organization.slug}/${INSIGHTS_BASE_URL}/`),
       preservePageFilters: true,
     },
     {

--- a/static/app/views/performance/utils/useModuleURL.tsx
+++ b/static/app/views/performance/utils/useModuleURL.tsx
@@ -31,15 +31,20 @@ export const MODULE_BASE_URLS: Record<ModuleName, string> = {
 type ModuleNameStrings = `${ModuleName}`;
 type RoutableModuleNames = Exclude<ModuleNameStrings, '' | 'other'>;
 
-export const useModuleURL = (moduleName: RoutableModuleNames): string => {
+export const useModuleURL = (
+  moduleName: RoutableModuleNames,
+  bare: boolean = false
+): string => {
   const {slug} = useOrganization();
 
   if (moduleName === ModuleName.AI) {
     // AI Doesn't live under "/performance"
-    return normalizeUrl(`/organizations/${slug}/${AI_BASE_URL}`);
+    return bare
+      ? `${slug}${AI_BASE_URL}`
+      : normalizeUrl(`/organizations/${slug}/${AI_BASE_URL}`);
   }
 
-  return normalizeUrl(
-    `/organizations/${slug}${INSIGHTS_BASE_URL}/${MODULE_BASE_URLS[moduleName]}`
-  );
+  return bare
+    ? `/organizations/${slug}${INSIGHTS_BASE_URL}/${MODULE_BASE_URLS[moduleName]}`
+    : normalizeUrl(`${INSIGHTS_BASE_URL}/${MODULE_BASE_URLS[moduleName]}`);
 };

--- a/static/app/views/performance/utils/useModuleURL.tsx
+++ b/static/app/views/performance/utils/useModuleURL.tsx
@@ -35,13 +35,13 @@ export const useModuleURL = (
   moduleName: RoutableModuleNames,
   bare: boolean = false
 ): string => {
-  const builder = useModuleURLBuilder();
-  return builder(moduleName, bare);
+  const builder = useModuleURLBuilder(bare);
+  return builder(moduleName);
 };
 
-type URLBuilder = (moduleName: RoutableModuleNames, bare?: boolean) => string;
+type URLBuilder = (moduleName: RoutableModuleNames) => string;
 
-export function useModuleURLBuilder(): URLBuilder {
+export function useModuleURLBuilder(bare: boolean = false): URLBuilder {
   const organization = useOrganization({allowNull: true}); // Some parts of the app, like the main sidebar, render even if the organization isn't available (during loading, or at all).
 
   if (!organization) {
@@ -51,7 +51,7 @@ export function useModuleURLBuilder(): URLBuilder {
 
   const {slug} = organization;
 
-  return function (moduleName: RoutableModuleNames, bare: boolean = false) {
+  return function (moduleName: RoutableModuleNames) {
     if (moduleName === ModuleName.AI) {
       // AI Doesn't live under "/performance"
       return bare

--- a/static/app/views/performance/utils/useModuleURL.tsx
+++ b/static/app/views/performance/utils/useModuleURL.tsx
@@ -55,7 +55,7 @@ export function useModuleURLBuilder(): URLBuilder {
     return bare
       ? `${INSIGHTS_BASE_URL}/${MODULE_BASE_URLS[moduleName]}`
       : normalizeUrl(
-          `/organizations/${slug}${INSIGHTS_BASE_URL}/${MODULE_BASE_URLS[moduleName]}`
+          `/organizations/${slug}/${INSIGHTS_BASE_URL}/${MODULE_BASE_URLS[moduleName]}`
         );
   };
 }

--- a/static/app/views/performance/utils/useModuleURL.tsx
+++ b/static/app/views/performance/utils/useModuleURL.tsx
@@ -35,16 +35,27 @@ export const useModuleURL = (
   moduleName: RoutableModuleNames,
   bare: boolean = false
 ): string => {
+  const builder = useModuleURLBuilder();
+  return builder(moduleName, bare);
+};
+
+type URLBuilder = (moduleName: RoutableModuleNames, bare?: boolean) => string;
+
+export function useModuleURLBuilder(): URLBuilder {
   const {slug} = useOrganization();
 
-  if (moduleName === ModuleName.AI) {
-    // AI Doesn't live under "/performance"
-    return bare
-      ? `${slug}${AI_BASE_URL}`
-      : normalizeUrl(`/organizations/${slug}/${AI_BASE_URL}`);
-  }
+  return function (moduleName: RoutableModuleNames, bare: boolean = false) {
+    if (moduleName === ModuleName.AI) {
+      // AI Doesn't live under "/performance"
+      return bare
+        ? `${AI_BASE_URL}`
+        : normalizeUrl(`/organizations/${slug}/${AI_BASE_URL}`);
+    }
 
-  return bare
-    ? `/organizations/${slug}${INSIGHTS_BASE_URL}/${MODULE_BASE_URLS[moduleName]}`
-    : normalizeUrl(`${INSIGHTS_BASE_URL}/${MODULE_BASE_URLS[moduleName]}`);
-};
+    return bare
+      ? `${INSIGHTS_BASE_URL}/${MODULE_BASE_URLS[moduleName]}`
+      : normalizeUrl(
+          `/organizations/${slug}${INSIGHTS_BASE_URL}/${MODULE_BASE_URLS[moduleName]}`
+        );
+  };
+}

--- a/static/app/views/performance/utils/useModuleURL.tsx
+++ b/static/app/views/performance/utils/useModuleURL.tsx
@@ -42,7 +42,14 @@ export const useModuleURL = (
 type URLBuilder = (moduleName: RoutableModuleNames, bare?: boolean) => string;
 
 export function useModuleURLBuilder(): URLBuilder {
-  const {slug} = useOrganization();
+  const organization = useOrganization({allowNull: true}); // Some parts of the app, like the main sidebar, render even if the organization isn't available (during loading, or at all).
+
+  if (!organization) {
+    // If there isn't an organization, items that link to modules won't be visible, so this is a fallback just-in-case, and isn't trying too hard to be useful
+    return () => INSIGHTS_BASE_URL;
+  }
+
+  const {slug} = organization;
 
   return function (moduleName: RoutableModuleNames, bare: boolean = false) {
     if (moduleName === ModuleName.AI) {


### PR DESCRIPTION
Doesn't make sense to have a `useModuleURL` helper if I can't use it to generate links to the modules in the sidebar. This adds a _slightly lower level_ helper, so that the same function makes _all_ links to module. Which, you guessed it, will make it easier to change all the URLs behind a feature flag.

## Changes

- **Allow creating bare module URLs**
- **Split `useModuleURL` into a builder and a wrapper**
- **Remove leading slash from insights base URL**
- **Link sidebar items using `useModuleURLBuilder`**
