### PR TITLE
chore(hybridcloud) Move usage to tuple-free methods/parameters

### DIFF
--- a/src/sentry/hybridcloud/rpc_services/control_organization_provisioning/impl.py
+++ b/src/sentry/hybridcloud/rpc_services/control_organization_provisioning/impl.py
@@ -257,17 +257,9 @@ class DatabaseBackedControlOrganizationProvisioningService(
         self,
         *,
         region_name: str,
-        organization_ids_and_slugs: set[tuple[int, str]] | None = None,
-        slug_mapping: dict[int, str] | None = None,
+        slug_mapping: dict[int, str],
     ) -> None:
         slug_reservations_to_create: list[OrganizationSlugReservation] = []
-        assert not (
-            organization_ids_and_slugs is not None and slug_mapping is not None
-        ), "Cannot provide both slug_mapping and organization_ids_and_slugs"
-
-        if organization_ids_and_slugs:
-            slug_mapping = dict(organization_ids_and_slugs)
-        assert isinstance(slug_mapping, dict), "slug_mapping must be dict now"
 
         with outbox_context(transaction.atomic(router.db_for_write(OrganizationSlugReservation))):
             for org_id, slug in slug_mapping.items():

--- a/src/sentry/hybridcloud/rpc_services/control_organization_provisioning/service.py
+++ b/src/sentry/hybridcloud/rpc_services/control_organization_provisioning/service.py
@@ -80,8 +80,7 @@ class ControlOrganizationProvisioningRpcService(RpcService):
         self,
         *,
         region_name: str,
-        organization_ids_and_slugs: set[tuple[int, str]] | None = None,
-        slug_mapping: dict[int, str] | None = None,
+        slug_mapping: dict[int, str],
     ) -> None:
         """
         Only really intended for bulk organization import usage. Creates unique organization slug

--- a/src/sentry/receivers/outbox/region.py
+++ b/src/sentry/receivers/outbox/region.py
@@ -19,6 +19,7 @@ from sentry.receivers.outbox import maybe_process_tombstone
 from sentry.services.hybrid_cloud.auth import auth_service
 from sentry.services.hybrid_cloud.log import AuditLogEvent, UserIpEvent, log_rpc_service
 from sentry.services.hybrid_cloud.organization_mapping import organization_mapping_service
+from sentry.services.hybrid_cloud.organization_mapping.model import CustomerId
 from sentry.services.hybrid_cloud.organization_mapping.serial import (
     update_organization_mapping_from_instance,
 )
@@ -59,9 +60,8 @@ def process_organization_mapping_customer_id_update(
         return
 
     if payload and "customer_id" in payload:
-        # TODO(mark) Update this to use CustomerId
         update = update_organization_mapping_from_instance(
-            org, get_local_region(), customer_id=(payload["customer_id"],)
+            org, get_local_region(), customer_id=CustomerId(value=payload["customer_id"])
         )
         organization_mapping_service.upsert(organization_id=org.id, update=update)
 

--- a/src/sentry/services/hybrid_cloud/organization_mapping/model.py
+++ b/src/sentry/services/hybrid_cloud/organization_mapping/model.py
@@ -36,7 +36,7 @@ class RpcOrganizationMappingUpdate(RpcModel):
     # When not set, no change to customer id performed,
     # when set with a tuple, the customer_id set to either None or the string
     # that is the first element.
-    # Using a tuple is deprecated and will be removed.
+    # TODO(hybridcloud) Using a tuple is deprecated and will be removed.
     customer_id: tuple[str | None] | CustomerId | None = None
     requires_2fa: bool = False
     early_adopter: bool = False


### PR DESCRIPTION
Update the callsites for several RPC methods to use return values and parameters that don't rely on tuples. Part of the work to remove tuple usage from our RPC methods as we cannot generate schema for methods using tuples.

Refs HC-1190