### PR TITLE
ref(ui): Extract Accordion specific to performance widgets

### DIFF
--- a/static/app/views/performance/landing/widgets/components/accordion.tsx
+++ b/static/app/views/performance/landing/widgets/components/accordion.tsx
@@ -1,0 +1,72 @@
+import styled from '@emotion/styled';
+
+import {Button} from 'sentry/components/button';
+import {IconChevron} from 'sentry/icons';
+import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
+
+interface AccordionItemContent {
+  content: React.ReactNode;
+  header: React.ReactNode;
+}
+
+interface Props {
+  expandedIndex: number;
+  items: AccordionItemContent[];
+  setExpandedIndex: (index: number) => void;
+}
+
+/**
+ * Accordion used in performance widgets
+ */
+function Accordion({expandedIndex, setExpandedIndex, items}: Props) {
+  return (
+    <AccordionContainer>
+      {items.map((item, index) => (
+        <AccordionItem key={index}>
+          <AccordionHeader>
+            {item.header}
+            <Button
+              icon={
+                <IconChevron
+                  size="xs"
+                  direction={index === expandedIndex ? 'up' : 'down'}
+                />
+              }
+              aria-label={t('Expand')}
+              aria-expanded={index === expandedIndex}
+              disabled={index === expandedIndex}
+              size="zero"
+              borderless
+              onClick={() => setExpandedIndex(index)}
+            />
+          </AccordionHeader>
+          <AccordionContent>{index === expandedIndex && item.content}</AccordionContent>
+        </AccordionItem>
+      ))}
+    </AccordionContainer>
+  );
+}
+
+const AccordionItem = styled('li')`
+  line-height: ${p => p.theme.text.lineHeightBody};
+`;
+
+const AccordionContainer = styled('ul')`
+  padding: ${space(1)} 0 0 0;
+  margin: 0;
+  list-style-type: none;
+`;
+
+const AccordionHeader = styled('div')`
+  display: flex;
+  border-top: 1px solid ${p => p.theme.border};
+  padding: ${space(1)} ${space(2)};
+  font-size: ${p => p.theme.fontSizeMedium};
+`;
+
+const AccordionContent = styled('div')`
+  padding: ${space(0)} ${space(2)};
+`;
+
+export {Accordion};

--- a/static/app/views/performance/landing/widgets/widgets/lineChartListWidget.tsx
+++ b/static/app/views/performance/landing/widgets/widgets/lineChartListWidget.tsx
@@ -3,7 +3,6 @@ import styled from '@emotion/styled';
 import pick from 'lodash/pick';
 import * as qs from 'query-string';
 
-import Accordion from 'sentry/components/accordion/accordion';
 import {LinkButton} from 'sentry/components/button';
 import _EventsRequest from 'sentry/components/charts/eventsRequest';
 import {getInterval} from 'sentry/components/charts/utils';
@@ -42,6 +41,7 @@ import {ModuleName, SpanFunction, SpanMetricsField} from 'sentry/views/starfish/
 import {STARFISH_CHART_INTERVAL_FIDELITY} from 'sentry/views/starfish/utils/constants';
 
 import {excludeTransaction} from '../../utils';
+import {Accordion} from '../components/accordion';
 import {GenericPerformanceWidget} from '../components/performanceWidget';
 import SelectableList, {
   GrowLink,

--- a/static/app/views/performance/landing/widgets/widgets/mobileReleaseComparisonListWidget.tsx
+++ b/static/app/views/performance/landing/widgets/widgets/mobileReleaseComparisonListWidget.tsx
@@ -2,7 +2,6 @@ import {Fragment, useMemo, useState} from 'react';
 import styled from '@emotion/styled';
 import pick from 'lodash/pick';
 
-import Accordion from 'sentry/components/accordion/accordion';
 import {LinkButton} from 'sentry/components/button';
 import type {RenderProps} from 'sentry/components/charts/eventsRequest';
 import EventsRequest from 'sentry/components/charts/eventsRequest';
@@ -27,13 +26,18 @@ import useApi from 'sentry/utils/useApi';
 import {useLocation} from 'sentry/utils/useLocation';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import {normalizeUrl} from 'sentry/utils/withDomainRequired';
-import {GenericPerformanceWidget} from 'sentry/views/performance/landing/widgets/components/performanceWidget';
-import {
-  GrowLink,
-  WidgetEmptyStateWarning,
-} from 'sentry/views/performance/landing/widgets/components/selectableList';
-import {transformDiscoverToList} from 'sentry/views/performance/landing/widgets/transforms/transformDiscoverToList';
-import type {transformEventsRequestToArea} from 'sentry/views/performance/landing/widgets/transforms/transformEventsToArea';
+import {Subtitle} from 'sentry/views/profiling/landing/styles';
+import {RightAlignedCell} from 'sentry/views/replays/deadRageClick/deadRageSelectorCards';
+import Chart, {ChartType} from 'sentry/views/starfish/components/chart';
+import {useReleaseSelection} from 'sentry/views/starfish/queries/useReleases';
+import {STARFISH_CHART_INTERVAL_FIDELITY} from 'sentry/views/starfish/utils/constants';
+import {appendReleaseFilters} from 'sentry/views/starfish/utils/releaseComparison';
+
+import {Accordion} from '../components/accordion';
+import {GenericPerformanceWidget} from '../components/performanceWidget';
+import {GrowLink, WidgetEmptyStateWarning} from '../components/selectableList';
+import {transformDiscoverToList} from '../transforms/transformDiscoverToList';
+import type {transformEventsRequestToArea} from '../transforms/transformEventsToArea';
 import type {
   PerformanceWidgetProps,
   QueryDefinition,
@@ -41,20 +45,14 @@ import type {
   WidgetDataConstraint,
   WidgetDataResult,
   WidgetPropUnion,
-} from 'sentry/views/performance/landing/widgets/types';
+} from '../types';
 import {
   eventsRequestQueryProps,
   getMEPParamsIfApplicable,
   QUERY_LIMIT_PARAM,
   TOTAL_EXPANDABLE_ROWS_HEIGHT,
-} from 'sentry/views/performance/landing/widgets/utils';
-import {PerformanceWidgetSetting} from 'sentry/views/performance/landing/widgets/widgetDefinitions';
-import {Subtitle} from 'sentry/views/profiling/landing/styles';
-import {RightAlignedCell} from 'sentry/views/replays/deadRageClick/deadRageSelectorCards';
-import Chart, {ChartType} from 'sentry/views/starfish/components/chart';
-import {useReleaseSelection} from 'sentry/views/starfish/queries/useReleases';
-import {STARFISH_CHART_INTERVAL_FIDELITY} from 'sentry/views/starfish/utils/constants';
-import {appendReleaseFilters} from 'sentry/views/starfish/utils/releaseComparison';
+} from '../utils';
+import {PerformanceWidgetSetting} from '../widgetDefinitions';
 
 type DataType = {
   chart: WidgetDataResult & ReturnType<typeof transformEventsRequestToArea>;

--- a/static/app/views/performance/landing/widgets/widgets/performanceScoreListWidget.tsx
+++ b/static/app/views/performance/landing/widgets/widgets/performanceScoreListWidget.tsx
@@ -3,7 +3,6 @@ import {Fragment, useState} from 'react';
 import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 
-import Accordion from 'sentry/components/accordion/accordion';
 import {LinkButton} from 'sentry/components/button';
 import _EventsRequest from 'sentry/components/charts/eventsRequest';
 import ExternalLink from 'sentry/components/links/externalLink';
@@ -25,6 +24,7 @@ import {useTransactionWebVitalsQuery} from 'sentry/views/performance/browser/web
 import type {RowWithScoreAndOpportunity} from 'sentry/views/performance/browser/webVitals/utils/types';
 import Chart, {ChartType} from 'sentry/views/starfish/components/chart';
 
+import {Accordion} from '../components/accordion';
 import {GenericPerformanceWidget} from '../components/performanceWidget';
 import {
   GrowLink,

--- a/static/app/views/performance/landing/widgets/widgets/stackedAreaChartListWidget.tsx
+++ b/static/app/views/performance/landing/widgets/widgets/stackedAreaChartListWidget.tsx
@@ -2,7 +2,6 @@ import {Fragment, useMemo, useState} from 'react';
 import {useTheme} from '@emotion/react';
 import pick from 'lodash/pick';
 
-import Accordion from 'sentry/components/accordion/accordion';
 import _EventsRequest from 'sentry/components/charts/eventsRequest';
 import StackedAreaChart from 'sentry/components/charts/stackedAreaChart';
 import {getInterval} from 'sentry/components/charts/utils';
@@ -30,6 +29,7 @@ import {
   UNPARAMETERIZED_TRANSACTION,
 } from 'sentry/views/performance/utils';
 
+import {Accordion} from '../components/accordion';
 import {GenericPerformanceWidget} from '../components/performanceWidget';
 import {
   GrowLink,

--- a/static/app/views/performance/landing/widgets/widgets/trendsWidget.tsx
+++ b/static/app/views/performance/landing/widgets/widgets/trendsWidget.tsx
@@ -1,6 +1,5 @@
 import {Fragment, useMemo, useState} from 'react';
 
-import Accordion from 'sentry/components/accordion/accordion';
 import {Button} from 'sentry/components/button';
 import Truncate from 'sentry/components/truncate';
 import {DEFAULT_STATS_PERIOD} from 'sentry/constants';
@@ -26,6 +25,7 @@ import {
 import {Chart} from '../../../trends/chart';
 import {TrendChangeType, TrendFunctionField} from '../../../trends/types';
 import {excludeTransaction} from '../../utils';
+import {Accordion} from '../components/accordion';
 import {GenericPerformanceWidget} from '../components/performanceWidget';
 import SelectableList, {
   GrowLink,

--- a/static/app/views/performance/landing/widgets/widgets/vitalWidget.tsx
+++ b/static/app/views/performance/landing/widgets/widgets/vitalWidget.tsx
@@ -2,7 +2,6 @@ import {Fragment, useMemo, useState} from 'react';
 import styled from '@emotion/styled';
 import pick from 'lodash/pick';
 
-import Accordion from 'sentry/components/accordion/accordion';
 import {Button} from 'sentry/components/button';
 import _EventsRequest from 'sentry/components/charts/eventsRequest';
 import {getInterval} from 'sentry/components/charts/utils';
@@ -37,6 +36,7 @@ import {_VitalChart} from 'sentry/views/performance/vitalDetail/vitalChart';
 
 import {excludeTransaction} from '../../utils';
 import {VitalBar} from '../../vitalsCards';
+import {Accordion} from '../components/accordion';
 import {GenericPerformanceWidget} from '../components/performanceWidget';
 import SelectableList, {
   GrowLink,


### PR DESCRIPTION
This component was never suitable to be made reusable. It has only gotten cruftier as things were bolted on.

Instead let's just keep this simple component specific to the performance widgets separate from a more reusable one (if we have one at all after this refactor)

I'll be following up with adding one for replays