### PR TITLE
ref(insights): Dynamically generate page titles

### DIFF
--- a/static/app/views/llmMonitoring/landing.tsx
+++ b/static/app/views/llmMonitoring/landing.tsx
@@ -86,7 +86,7 @@ export function LLMMonitoringPage() {
 
 function PageWithProviders() {
   return (
-    <ModulePageProviders title={t('LLM Monitoring')} features="ai-analytics">
+    <ModulePageProviders moduleName="ai" features="ai-analytics">
       <LLMMonitoringPage />
     </ModulePageProviders>
   );

--- a/static/app/views/llmMonitoring/llmMonitoringDetailsPage.tsx
+++ b/static/app/views/llmMonitoring/llmMonitoringDetailsPage.tsx
@@ -173,7 +173,8 @@ function PageWithProviders({params}: Props) {
 
   return (
     <ModulePageProviders
-      title={[spanDescription ?? t('(no name)'), t('Pipeline Details')].join(' — ')}
+      moduleName="ai"
+      pageTitle={spanDescription ?? t('(no name)')}
       features="ai-analytics"
     >
       <LLMMonitoringPage params={params} />

--- a/static/app/views/performance/browser/resources/index.tsx
+++ b/static/app/views/performance/browser/resources/index.tsx
@@ -89,10 +89,7 @@ function ResourcesLandingPage() {
 
 function PageWithProviders() {
   return (
-    <ModulePageProviders
-      title={[t('Performance'), t('Resources')].join(' — ')}
-      features="spans-first-ui"
-    >
+    <ModulePageProviders moduleName="resource" features="spans-first-ui">
       <ResourcesLandingPage />
     </ModulePageProviders>
   );

--- a/static/app/views/performance/browser/resources/resourceSummaryPage/index.tsx
+++ b/static/app/views/performance/browser/resources/resourceSummaryPage/index.tsx
@@ -150,7 +150,8 @@ function ResourceSummary() {
 function PageWithProviders() {
   return (
     <ModulePageProviders
-      title={[t('Performance'), t('Resources'), t('Resource Summary')].join(' — ')}
+      moduleName="resource"
+      pageTitle={t('Resource Summary')}
       features="spans-first-ui"
     >
       <ResourceSummary />

--- a/static/app/views/performance/browser/webVitals/pageOverview.tsx
+++ b/static/app/views/performance/browser/webVitals/pageOverview.tsx
@@ -293,10 +293,7 @@ export function PageOverview() {
 
 function PageWithProviders() {
   return (
-    <ModulePageProviders
-      title={[t('Performance'), t('Web Vitals')].join(' — ')}
-      features="spans-first-ui"
-    >
+    <ModulePageProviders moduleName="vital" features="spans-first-ui">
       <PageOverview />
     </ModulePageProviders>
   );

--- a/static/app/views/performance/browser/webVitals/webVitalsLandingPage.tsx
+++ b/static/app/views/performance/browser/webVitals/webVitalsLandingPage.tsx
@@ -182,10 +182,7 @@ export function WebVitalsLandingPage() {
 
 function PageWithProviders() {
   return (
-    <ModulePageProviders
-      title={[t('Performance'), t('Web Vitals')].join(' — ')}
-      features="spans-first-ui"
-    >
+    <ModulePageProviders moduleName="vital" features="spans-first-ui">
       <WebVitalsLandingPage />
     </ModulePageProviders>
   );

--- a/static/app/views/performance/cache/cacheLandingPage.tsx
+++ b/static/app/views/performance/cache/cacheLandingPage.tsx
@@ -11,7 +11,6 @@ import {EnvironmentPageFilter} from 'sentry/components/organizations/environment
 import PageFilterBar from 'sentry/components/organizations/pageFilterBar';
 import {ProjectPageFilter} from 'sentry/components/organizations/projectPageFilter';
 import {PageHeadingQuestionTooltip} from 'sentry/components/pageHeadingQuestionTooltip';
-import {t} from 'sentry/locale';
 import type {EventsMetaType} from 'sentry/utils/discover/eventView';
 import {decodeScalar, decodeSorts} from 'sentry/utils/queryString';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
@@ -208,10 +207,7 @@ export function CacheLandingPage() {
 
 function PageWithProviders() {
   return (
-    <ModulePageProviders
-      title={[t('Performance'), MODULE_TITLE].join(' — ')}
-      features="performance-cache-view"
-    >
+    <ModulePageProviders moduleName="cache" features="performance-cache-view">
       <CacheLandingPage />
     </ModulePageProviders>
   );

--- a/static/app/views/performance/database/databaseLandingPage.tsx
+++ b/static/app/views/performance/database/databaseLandingPage.tsx
@@ -269,10 +269,7 @@ const LIMIT: number = 25;
 
 function PageWithProviders() {
   return (
-    <ModulePageProviders
-      title={[t('Performance'), t('Database')].join(' — ')}
-      features="spans-first-ui"
-    >
+    <ModulePageProviders moduleName="db" features="spans-first-ui">
       <DatabaseLandingPage />
     </ModulePageProviders>
   );

--- a/static/app/views/performance/database/databaseSpanSummaryPage.tsx
+++ b/static/app/views/performance/database/databaseSpanSummaryPage.tsx
@@ -302,7 +302,8 @@ const MetricsRibbon = styled('div')`
 function PageWithProviders(props) {
   return (
     <ModulePageProviders
-      title={[t('Performance'), t('Database'), t('Query Summary')].join(' — ')}
+      moduleName="db"
+      pageTitle={t('Query Summary')}
       features="spans-first-ui"
     >
       <DatabaseSpanSummaryPage {...props} />

--- a/static/app/views/performance/http/httpDomainSummaryPage.tsx
+++ b/static/app/views/performance/http/httpDomainSummaryPage.tsx
@@ -33,7 +33,6 @@ import {Referrer} from 'sentry/views/performance/http/referrers';
 import {
   BASE_FILTERS,
   MODULE_DOC_LINK,
-  MODULE_TITLE,
   NULL_DOMAIN_DESCRIPTION,
   RELEASE_LEVEL,
 } from 'sentry/views/performance/http/settings';
@@ -345,7 +344,8 @@ const MetricsRibbon = styled('div')`
 function PageWithProviders() {
   return (
     <ModulePageProviders
-      title={[t('Performance'), MODULE_TITLE, t('Domain Summary')].join(' — ')}
+      moduleName="http"
+      pageTitle={t('Domain Summary')}
       features="spans-first-ui"
     >
       <HTTPDomainSummaryPage />

--- a/static/app/views/performance/http/httpLandingPage.tsx
+++ b/static/app/views/performance/http/httpLandingPage.tsx
@@ -250,10 +250,7 @@ const DOMAIN_TABLE_ROW_COUNT = 10;
 
 function PageWithProviders() {
   return (
-    <ModulePageProviders
-      title={[t('Performance'), MODULE_TITLE].join(' — ')}
-      features="spans-first-ui"
-    >
+    <ModulePageProviders moduleName="http" features="spans-first-ui">
       <HTTPLandingPage />
     </ModulePageProviders>
   );

--- a/static/app/views/performance/mobile/appStarts/index.tsx
+++ b/static/app/views/performance/mobile/appStarts/index.tsx
@@ -18,7 +18,7 @@ export function InitializationModule() {
 
 function PageWithProviders() {
   return (
-    <ModulePageProviders title={ROUTE_NAMES['app-startup']} features="spans-first-ui">
+    <ModulePageProviders moduleName="app_start" features="spans-first-ui">
       <InitializationModule />
     </ModulePageProviders>
   );

--- a/static/app/views/performance/mobile/appStarts/screenSummary/index.tsx
+++ b/static/app/views/performance/mobile/appStarts/screenSummary/index.tsx
@@ -30,7 +30,6 @@ import {
   SECONDARY_RELEASE_ALIAS,
 } from 'sentry/views/starfish/components/releaseSelector';
 import {ModuleName, SpanMetricsField} from 'sentry/views/starfish/types';
-import {ROUTE_NAMES} from 'sentry/views/starfish/utils/routeNames';
 
 import AppStartWidgets from './widgets';
 
@@ -199,7 +198,8 @@ function PageWithProviders() {
 
   return (
     <ModulePageProviders
-      title={[transaction, ROUTE_NAMES['app-startup']].join(' — ')}
+      moduleName="app_start"
+      pageTitle={transaction}
       features="spans-first-ui"
     >
       <ScreenSummary />

--- a/static/app/views/performance/mobile/screenload/index.tsx
+++ b/static/app/views/performance/mobile/screenload/index.tsx
@@ -103,7 +103,7 @@ export function PageloadModule() {
 
 function PageWithProviders() {
   return (
-    <ModulePageProviders title={t('Screen Loads')} features="spans-first-ui">
+    <ModulePageProviders moduleName="screen_load" features="spans-first-ui">
       <PageloadModule />
     </ModulePageProviders>
   );

--- a/static/app/views/performance/mobile/screenload/screenLoadSpans/index.tsx
+++ b/static/app/views/performance/mobile/screenload/screenLoadSpans/index.tsx
@@ -219,7 +219,8 @@ function PageWithProviders() {
 
   return (
     <ModulePageProviders
-      title={[transaction, t('Screen Loads')].join(' — ')}
+      moduleName="screen_load"
+      pageTitle={transaction}
       features="spans-first-ui"
     >
       <ScreenLoadSpans />

--- a/static/app/views/performance/mobile/ui/index.tsx
+++ b/static/app/views/performance/mobile/ui/index.tsx
@@ -17,7 +17,7 @@ export function ResponsivenessModule() {
 function PageWithProviders() {
   return (
     <ModulePageProviders
-      title={ROUTE_NAMES.mobileUI}
+      moduleName="mobile-ui"
       features={['spans-first-ui', 'starfish-mobile-ui-module']}
     >
       <ResponsivenessModule />

--- a/static/app/views/performance/mobile/ui/screenSummary/index.tsx
+++ b/static/app/views/performance/mobile/ui/screenSummary/index.tsx
@@ -118,7 +118,8 @@ function PageWithProviders() {
 
   return (
     <ModulePageProviders
-      title={[transaction, t('Screen Loads')].join(' — ')}
+      moduleName="mobile-ui"
+      pageTitle={transaction}
       features={['spans-first-ui', 'starfish-mobile-ui-module']}
     >
       <ScreenSummary />

--- a/static/app/views/performance/modulePageProviders.tsx
+++ b/static/app/views/performance/modulePageProviders.tsx
@@ -6,19 +6,33 @@ import PageFiltersContainer from 'sentry/components/organizations/pageFilters/co
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import useOrganization from 'sentry/utils/useOrganization';
 import {NoAccess} from 'sentry/views/performance/database/noAccess';
+import {useInsightsTitle} from 'sentry/views/performance/utils/useInsightsTitle';
+import {useModuleTitle} from 'sentry/views/performance/utils/useModuleTitle';
+import type {ModuleName} from 'sentry/views/starfish/types';
+
+type ModuleNameStrings = `${ModuleName}`;
+type TitleableModuleNames = Exclude<ModuleNameStrings, '' | 'other'>;
 
 interface Props {
   children: React.ReactNode;
   features: ComponentProps<typeof Feature>['features'];
-  title: string;
+  moduleName: TitleableModuleNames;
+  pageTitle?: string;
 }
 
-export function ModulePageProviders({title, children, features}: Props) {
+export function ModulePageProviders({moduleName, pageTitle, children, features}: Props) {
   const organization = useOrganization();
+
+  const insightsTitle = useInsightsTitle(moduleName);
+  const moduleTitle = useModuleTitle(moduleName);
+
+  const fullPageTitle = [pageTitle, moduleTitle, insightsTitle]
+    .filter(Boolean)
+    .join(' — ');
 
   return (
     <PageFiltersContainer>
-      <SentryDocumentTitle title={title} orgSlug={organization.slug}>
+      <SentryDocumentTitle title={fullPageTitle} orgSlug={organization.slug}>
         <Layout.Page>
           <Feature
             features={features}

--- a/static/app/views/performance/queues/destinationSummary/destinationSummaryPage.tsx
+++ b/static/app/views/performance/queues/destinationSummary/destinationSummaryPage.tsx
@@ -27,11 +27,7 @@ import {MessageSpanSamplesPanel} from 'sentry/views/performance/queues/destinati
 import {TransactionsTable} from 'sentry/views/performance/queues/destinationSummary/transactionsTable';
 import {useQueuesMetricsQuery} from 'sentry/views/performance/queues/queries/useQueuesMetricsQuery';
 import {Referrer} from 'sentry/views/performance/queues/referrers';
-import {
-  DESTINATION_TITLE,
-  MODULE_TITLE,
-  RELEASE_LEVEL,
-} from 'sentry/views/performance/queues/settings';
+import {DESTINATION_TITLE, RELEASE_LEVEL} from 'sentry/views/performance/queues/settings';
 import {useModuleBreadcrumbs} from 'sentry/views/performance/utils/useModuleBreadcrumbs';
 import {getTimeSpentExplanation} from 'sentry/views/starfish/components/tableCells/timeSpentCell';
 
@@ -170,7 +166,8 @@ function DestinationSummaryPage() {
 function PageWithProviders() {
   return (
     <ModulePageProviders
-      title={[t('Performance'), MODULE_TITLE].join(' — ')}
+      moduleName="queue"
+      pageTitle={t('Destination Summary')}
       features="performance-queues-view"
     >
       <DestinationSummaryPage />

--- a/static/app/views/performance/queues/queuesLandingPage.tsx
+++ b/static/app/views/performance/queues/queuesLandingPage.tsx
@@ -142,10 +142,7 @@ function QueuesLandingPage() {
 
 function PageWithProviders() {
   return (
-    <ModulePageProviders
-      title={[t('Performance'), MODULE_TITLE].join(' — ')}
-      features="performance-queues-view"
-    >
+    <ModulePageProviders moduleName="queue" features="performance-queues-view">
       <QueuesLandingPage />
     </ModulePageProviders>
   );

--- a/static/app/views/performance/utils/useInsightsTitle.tsx
+++ b/static/app/views/performance/utils/useInsightsTitle.tsx
@@ -1,0 +1,14 @@
+import {INSIGHTS_LABEL} from 'sentry/views/performance/settings';
+import {ModuleName} from 'sentry/views/starfish/types';
+
+type ModuleNameStrings = `${ModuleName}`;
+type TitleableModuleNames = Exclude<ModuleNameStrings, '' | 'other'>;
+
+export function useInsightsTitle(moduleName: TitleableModuleNames) {
+  if (moduleName === ModuleName.AI) {
+    // AI doesn't live under Performance
+    return undefined;
+  }
+
+  return INSIGHTS_LABEL;
+}


### PR DESCRIPTION
Pass the module name to the providers, and let them generate a correct page title for you.

1. Enforces consistent page title order! The most specific entity _first_! Makes for friendlier titles
2. Same crumb logic everywhere


`useInsightsTitle` is a weird hook, but don't fret, it's about to start checking a feature flag, so we'll need it to be a hook