### PR TITLE
[POC] Use CSVish format for Seer similarity stacktrace string

### DIFF
--- a/src/sentry/api/endpoints/group_similar_issues_embeddings.py
+++ b/src/sentry/api/endpoints/group_similar_issues_embeddings.py
@@ -81,7 +81,7 @@ def get_stacktrace_string(data: dict[str, Any]) -> str:
                         if frame_values.get("id") in frame_dict:
                             frame_dict[frame_values["id"]] = _get_value_if_exists(frame_values)
 
-                    frame_str += f'  File "{frame_dict["filename"]}", function {frame_dict["function"]}\n    {frame_dict["context-line"]}\n'
+                    frame_str += f'"{frame_dict["filename"]}","{frame_dict["function"]}","{frame_dict["context-line"]}"\n'
 
         # Only exceptions have the type and value properties, so we don't need to handle the threads
         # case here


### PR DESCRIPTION
_NOTE: Opening this as a PR just to have a place to talk about the idea, so this should stay in draft and not be merged. If we ever end up doing this for real I'll need to rebase on other in-flight things, fix tests, etc._

_Relates to https://github.com/getsentry/sentry/issues/69696._

--------------

This switches the way we format the stacktrace strings we send to the Seer similarity service, so that they're much more reminiscent of a CSV, in hopes of slimming down the total length and allowing more of them to be be processed per batch. 

For example, here's a before and after of the expected result from the [`test_get_stacktrace_string_chained_too_many_frames` test](https://github.com/getsentry/sentry/blob/121fc88284771be1a75ffb38aa2f4c65807cf7ab/tests/sentry/api/endpoints/test_group_similar_issues_embeddings.py#L548) (selected because this is mostly relevant for long stacktraces, but truncated because I think you can get the idea). The change results in 28% fewer characters and words, and 49% fewer lines. (IIUC, how much of a difference this makes will depend in large part on how this affects the number of tokens, but IDK if we know how those numbers correspond without testing it.)

Current (2,875 characters, 357 words, 103 lines):
```
OuterException: no way
  File "hello.py", function hello_there
    outer line 1
  File "hello.py", function hello_there
    outer line 2
  File "hello.py", function hello_there
    outer line 3
  ...
  File "hello.py", function hello_there
    outer line 30
MiddleException: un-uh
  File "hello.py", function hello_there
    middle line 11
  File "hello.py", function hello_there
    middle line 12
  File "hello.py", function hello_there
    middle line 13
  ...
  File "hello.py", function hello_there
    middle line 30
InnerException: nope
```

With this change (2,075 characters, 257 words, 53 lines):
```
OuterException: no way
"hello.py","hello_there","outer line 1"
"hello.py","hello_there","outer line 2"
"hello.py","hello_there","outer line 3"
...
"hello.py","hello_there","outer line 30"
MiddleException: un-uh
"hello.py","hello_there","middle line 11"
"hello.py","hello_there","middle line 12"
"hello.py","hello_there","middle line 13"
...
"hello.py","hello_there","middle line 30"
InnerException: nope
```