### PR TITLE
fix(release-alert): Update Query to use Org & Project Filtering for Release Health

### DIFF
--- a/src/sentry/release_health/release_monitor/metrics.py
+++ b/src/sentry/release_health/release_monitor/metrics.py
@@ -223,8 +223,14 @@ class MetricReleaseMonitorBackend(BaseReleaseMonitorBackend):
                                 UseCaseID.SESSIONS, org_id, SessionMRI.RAW_SESSION.value
                             ),
                         ),
-                        Condition(Column("org_id"), Op.GTE, prev_org_id),
-                        Condition(Column("project_id"), Op.GT, prev_project_id),
+                        # Either org_id > prev_org_id or (org_id == prev_org_id and project_id > prev_project_id)
+                        Condition(
+                            Condition(Column("org_id"), Op.GT, prev_org_id)
+                            | (
+                                Condition(Column("org_id"), Op.EQ, prev_org_id)
+                                & Condition(Column("project_id"), Op.GT, prev_project_id)
+                            )
+                        ),
                     ],
                     granularity=Granularity(21600),
                     orderby=[

--- a/src/sentry/release_health/release_monitor/metrics.py
+++ b/src/sentry/release_health/release_monitor/metrics.py
@@ -203,6 +203,7 @@ class MetricReleaseMonitorBackend(BaseReleaseMonitorBackend):
                         env_col,
                     ],
                     groupby=[
+                        Column("org_id"),
                         Column("project_id"),
                         release_col,
                         env_col,
@@ -224,12 +225,18 @@ class MetricReleaseMonitorBackend(BaseReleaseMonitorBackend):
                             ),
                         ),
                         # Either org_id > prev_org_id or (org_id == prev_org_id and project_id > prev_project_id)
-                        Condition(
-                            Condition(Column("org_id"), Op.GT, prev_org_id)
-                            | (
-                                Condition(Column("org_id"), Op.EQ, prev_org_id)
-                                & Condition(Column("project_id"), Op.GT, prev_project_id)
-                            )
+                        BooleanCondition(
+                            BooleanOp.OR,
+                            [
+                                Condition(Column("org_id"), Op.GT, prev_org_id),
+                                BooleanCondition(
+                                    BooleanOp.AND,
+                                    [
+                                        Condition(Column("org_id"), Op.EQ, prev_org_id),
+                                        Condition(Column("project_id"), Op.GT, prev_project_id),
+                                    ],
+                                ),
+                            ],
                         ),
                     ],
                     granularity=Granularity(21600),

--- a/tests/sentry/release_health/release_monitor/__init__.py
+++ b/tests/sentry/release_health/release_monitor/__init__.py
@@ -19,7 +19,35 @@ class BaseFetchProjectsWithRecentSessionsTest(TestCase, BaseMetricsTestCase):
         self.environment = self.create_environment(project=self.project2)
         self.backend = self.backend_class()
 
-    def test_monitor_release_adoption(self):
+    def test_monitor_release_adoption_with_offset(self):
+        self.org2 = self.create_organization()
+        self.org2_project = self.create_project(organization=self.org2)
+        self.org2_release = self.create_release(project=self.org2_project, version="org@2.0.0")
+        self.org2_environment = self.create_environment(project=self.org2_project)
+        self.bulk_store_sessions(
+            [
+                self.build_session(
+                    org_id=self.org2,
+                    project_id=self.org2_project,
+                    release=self.org2_release,
+                    environment=self.org2_environment,
+                )
+                for _ in range(2)
+            ]
+            + [self.build_session(project_id=self.project1) for _ in range(3)]
+            + [
+                self.build_session(project_id=self.project2, environment=self.environment)
+                for _ in range(1)
+            ]
+        )
+        results = self.backend.fetch_projects_with_recent_sessions()
+        assert results == {
+            self.organization.id: [self.project1.id, self.project2.id],
+            self.org2.id: [self.org2_project.id],
+        }
+
+    @override_options({"release-health.use-org-and-project-filter": True})
+    def test_monitor_release_adoption_with_filter(self):
         self.org2 = self.create_organization()
         self.org2_project = self.create_project(organization=self.org2)
         self.org2_release = self.create_release(project=self.org2_project, version="org@2.0.0")

--- a/tests/sentry/release_health/release_monitor/__init__.py
+++ b/tests/sentry/release_health/release_monitor/__init__.py
@@ -19,35 +19,7 @@ class BaseFetchProjectsWithRecentSessionsTest(TestCase, BaseMetricsTestCase):
         self.environment = self.create_environment(project=self.project2)
         self.backend = self.backend_class()
 
-    def test_monitor_release_adoption_with_offset(self):
-        self.org2 = self.create_organization()
-        self.org2_project = self.create_project(organization=self.org2)
-        self.org2_release = self.create_release(project=self.org2_project, version="org@2.0.0")
-        self.org2_environment = self.create_environment(project=self.org2_project)
-        self.bulk_store_sessions(
-            [
-                self.build_session(
-                    org_id=self.org2,
-                    project_id=self.org2_project,
-                    release=self.org2_release,
-                    environment=self.org2_environment,
-                )
-                for _ in range(2)
-            ]
-            + [self.build_session(project_id=self.project1) for _ in range(3)]
-            + [
-                self.build_session(project_id=self.project2, environment=self.environment)
-                for _ in range(1)
-            ]
-        )
-        results = self.backend.fetch_projects_with_recent_sessions()
-        assert results == {
-            self.organization.id: [self.project1.id, self.project2.id],
-            self.org2.id: [self.org2_project.id],
-        }
-
-    @override_options({"release-health.use-org-and-project-filter": True})
-    def test_monitor_release_adoption_with_filter(self):
+    def test_monitor_release_adoption(self):
         self.org2 = self.create_organization()
         self.org2_project = self.create_project(organization=self.org2)
         self.org2_release = self.create_release(project=self.org2_project, version="org@2.0.0")
@@ -89,7 +61,46 @@ class BaseFetchProjectReleaseHealthTotalsTest(TestCase, BaseMetricsTestCase):
         self.release2 = self.create_release(project=self.project2)
         self.backend = self.backend_class()
 
-    def test(self):
+    def test_with_offset(self):
+        self.bulk_store_sessions(
+            [
+                self.build_session(
+                    project_id=self.project1,
+                    environment=self.environment1.name,
+                    release=self.release1.version,
+                )
+                for _ in range(5)
+            ]
+            + [
+                self.build_session(
+                    project_id=self.project2,
+                    environment=self.environment2.name,
+                    release=self.release2.version,
+                )
+            ]
+        )
+
+        totals = self.backend.fetch_project_release_health_totals(
+            self.organization.id,
+            [self.project.id, self.project1.id, self.project2.id],
+        )
+        assert totals == {
+            self.project1.id: {
+                self.environment1.name: {
+                    "total_sessions": 5,
+                    "releases": {self.release1.version: 5},
+                }
+            },
+            self.project2.id: {
+                self.environment2.name: {
+                    "total_sessions": 1,
+                    "releases": {self.release2.version: 1},
+                }
+            },
+        }, totals
+
+    @override_options({"release-health.use-org-and-project-filter": True})
+    def test_with_filter(self):
         self.bulk_store_sessions(
             [
                 self.build_session(


### PR DESCRIPTION
Helps mitigate https://getsentry.atlassian.net/browse/ISSUE-1702

I create an option to query switch between the old query and the new query.

The new query is the same as old query p much, but with few differences. we sort by `org_id` and `project_id` and use the last one as the filter for the next query. 