### PR TITLE
ref(rules): Remove logger and break

### DIFF
--- a/src/sentry/buffer/redis.py
+++ b/src/sentry/buffer/redis.py
@@ -252,10 +252,6 @@ class RedisBuffer(Buffer):
     def push_to_sorted_set(self, key: str, value: list[int] | int) -> None:
         value_dict = {value: time()}
         self._execute_redis_operation(key, RedisOperation.SORTED_SET_ADD, value_dict)
-        logger.info(
-            "redis_buffer.push_to_sorted_set",
-            extra={"key_name": key, "value": json.dumps(value_dict)},
-        )
 
     def get_sorted_set(self, key: str, min: float, max: float) -> list[tuple[int, datetime]]:
         redis_set = self._execute_redis_operation(

--- a/src/sentry/rules/processing/delayed_processing.py
+++ b/src/sentry/rules/processing/delayed_processing.py
@@ -380,7 +380,7 @@ def apply_delayed(project_id: int, *args: Any, **kwargs: Any) -> None:
                         "delayed_processing.last_active",
                         extra={"last_active": status.last_active, "freq_offset": freq_offset},
                     )
-                    return
+                    break
 
                 updated = (
                     GroupRuleStatus.objects.filter(id=status.id)
@@ -390,7 +390,7 @@ def apply_delayed(project_id: int, *args: Any, **kwargs: Any) -> None:
 
                 if not updated:
                     logger.info("delayed_processing.not_updated", extra={"status_id": status.id})
-                    return
+                    break
 
                 notification_uuid = str(uuid.uuid4())
                 groupevent = group_to_groupevent[group]


### PR DESCRIPTION
Remove a logger we no longer use, and explicitly break instead of returning to be sure we're deleting the data from Redis if we don't fire the alert.