### PR TITLE
fix(release-alert): Update Query to use Org & Project Filtering for `fetch_projects_with_recent_sessions`

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -945,6 +945,14 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 
+# Switch for new logic for release health metrics, based on filtering on org & project ids
+register(
+    "release-health.use-org-and-project-filter",
+    type=Bool,
+    default=False,
+    flags=FLAG_MODIFIABLE_BOOL | FLAG_AUTOMATOR_MODIFIABLE,
+)
+
 # Switch for more performant project counter incr
 register(
     "store.projectcounter-modern-upsert-sample-rate", default=0.0, flags=FLAG_AUTOMATOR_MODIFIABLE

--- a/src/sentry/release_health/release_monitor/metrics.py
+++ b/src/sentry/release_health/release_monitor/metrics.py
@@ -170,12 +170,10 @@ class MetricReleaseMonitorBackend(BaseReleaseMonitorBackend):
 
         return aggregated_projects
 
-    def fetch_projects_with_recent_sessions(
-        self, org_id: int, project_ids: Sequence[int]
-    ) -> Totals:
+    def fetch_projects_with_recent_sessions(self) -> Totals:
         if options.get("release-health.use-org-and-project-filter"):
-            return self.fetch_projects_with_recent_sessions_with_filter(org_id, project_ids)
-        return self.fetch_projects_with_recent_sessions_with_offset(org_id, project_ids)
+            return self.fetch_projects_with_recent_sessions_with_filter()
+        return self.fetch_projects_with_recent_sessions_with_offset()
 
     def fetch_project_release_health_totals(
         self, org_id: int, project_ids: Sequence[int]

--- a/src/sentry/release_health/release_monitor/metrics.py
+++ b/src/sentry/release_health/release_monitor/metrics.py
@@ -170,7 +170,7 @@ class MetricReleaseMonitorBackend(BaseReleaseMonitorBackend):
 
         return aggregated_projects
 
-    def fetch_projects_with_recent_sessions(self) -> Totals:
+    def fetch_projects_with_recent_sessions(self) -> Mapping[int, Sequence[int]]:
         if options.get("release-health.use-org-and-project-filter"):
             return self.fetch_projects_with_recent_sessions_with_filter()
         return self.fetch_projects_with_recent_sessions_with_offset()

--- a/src/sentry/release_health/release_monitor/metrics.py
+++ b/src/sentry/release_health/release_monitor/metrics.py
@@ -17,6 +17,7 @@ from snuba_sdk import (
     Request,
 )
 
+from sentry import options
 from sentry.release_health.release_monitor.base import BaseReleaseMonitorBackend, Totals
 from sentry.sentry_metrics import indexer
 from sentry.sentry_metrics.indexer.strings import SESSION_METRIC_NAMES
@@ -31,7 +32,7 @@ logger = logging.getLogger(__name__)
 
 
 class MetricReleaseMonitorBackend(BaseReleaseMonitorBackend):
-    def fetch_projects_with_recent_sessions(self) -> Mapping[int, Sequence[int]]:
+    def fetch_projects_with_recent_sessions_with_offset(self) -> Mapping[int, Sequence[int]]:
         with metrics.timer(
             "release_monitor.fetch_projects_with_recent_sessions.loop", sample_rate=1.0
         ):
@@ -93,6 +94,88 @@ class MetricReleaseMonitorBackend(BaseReleaseMonitorBackend):
                 )
 
         return aggregated_projects
+
+    def fetch_projects_with_recent_sessions_with_filter(self) -> Mapping[int, Sequence[int]]:
+        with metrics.timer(
+            "release_monitor.fetch_projects_with_recent_sessions.loop", sample_rate=1.0
+        ):
+            aggregated_projects = defaultdict(list)
+            start_time = time.time()
+            prev_org_id = 0
+            prev_project_id = 0
+
+            while (time.time() - start_time) < self.MAX_SECONDS:
+                query = Query(
+                    match=Entity(EntityKey.OrgMetricsCounters.value),
+                    select=[
+                        Column("org_id"),
+                        Column("project_id"),
+                    ],
+                    groupby=[Column("org_id"), Column("project_id")],
+                    where=[
+                        Condition(
+                            Column("timestamp"), Op.GTE, datetime.utcnow() - timedelta(hours=6)
+                        ),
+                        Condition(Column("timestamp"), Op.LT, datetime.utcnow()),
+                        Condition(
+                            Column("metric_id"),
+                            Op.EQ,
+                            SESSION_METRIC_NAMES[SessionMRI.RAW_SESSION.value],
+                        ),
+                        # Pagination conditions
+                        # Either org_id > prev_org_id or (org_id == prev_org_id and project_id > prev_project_id)
+                        Condition(
+                            Condition(Column("org_id"), Op.GT, prev_org_id)
+                            | (
+                                Condition(Column("org_id"), Op.EQ, prev_org_id)
+                                & Condition(Column("project_id"), Op.GT, prev_project_id)
+                            )
+                        ),
+                    ],
+                    granularity=Granularity(3600),
+                    orderby=[
+                        OrderBy(Column("org_id"), Direction.ASC),
+                        OrderBy(Column("project_id"), Direction.ASC),
+                    ],
+                ).set_limit(self.CHUNK_SIZE + 1)
+                request = Request(
+                    dataset=Dataset.Metrics.value, app_id="release_health", query=query
+                )
+                data = raw_snql_query(
+                    request, referrer="release_monitor.fetch_projects_with_recent_sessions"
+                )["data"]
+                count = len(data)
+                more_results = count > self.CHUNK_SIZE
+
+                if more_results:
+                    data = data[:-1]
+
+                for row in data:
+                    aggregated_projects[row["org_id"]].append(row["project_id"])
+
+                # Update prev_org_id and prev_project_id for the next iteration
+                if data:
+                    last_row = data[-1]
+                    prev_org_id = last_row["org_id"]
+                    prev_project_id = last_row["project_id"]
+
+                if not more_results:
+                    break
+
+            else:
+                logger.error(
+                    "release_monitor.fetch_projects_with_recent_sessions.loop_timeout",
+                    extra={"prev_org_id": prev_org_id, "prev_project_id": prev_project_id},
+                )
+
+        return aggregated_projects
+
+    def fetch_projects_with_recent_sessions(
+        self, org_id: int, project_ids: Sequence[int]
+    ) -> Totals:
+        if options.get("release-health.use-org-and-project-filter"):
+            return self.fetch_projects_with_recent_sessions_with_filter(org_id, project_ids)
+        return self.fetch_projects_with_recent_sessions_with_offset(org_id, project_ids)
 
     def fetch_project_release_health_totals(
         self, org_id: int, project_ids: Sequence[int]

--- a/tests/sentry/release_health/release_monitor/__init__.py
+++ b/tests/sentry/release_health/release_monitor/__init__.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from sentry.release_health.release_monitor.base import BaseReleaseMonitorBackend
 from sentry.testutils.abstract import Abstract
 from sentry.testutils.cases import BaseMetricsTestCase, TestCase
+from sentry.testutils.helpers import override_options
 
 
 class BaseFetchProjectsWithRecentSessionsTest(TestCase, BaseMetricsTestCase):
@@ -18,7 +19,35 @@ class BaseFetchProjectsWithRecentSessionsTest(TestCase, BaseMetricsTestCase):
         self.environment = self.create_environment(project=self.project2)
         self.backend = self.backend_class()
 
-    def test_monitor_release_adoption(self):
+    def test_monitor_release_adoption_with_offset(self):
+        self.org2 = self.create_organization()
+        self.org2_project = self.create_project(organization=self.org2)
+        self.org2_release = self.create_release(project=self.org2_project, version="org@2.0.0")
+        self.org2_environment = self.create_environment(project=self.org2_project)
+        self.bulk_store_sessions(
+            [
+                self.build_session(
+                    org_id=self.org2,
+                    project_id=self.org2_project,
+                    release=self.org2_release,
+                    environment=self.org2_environment,
+                )
+                for _ in range(2)
+            ]
+            + [self.build_session(project_id=self.project1) for _ in range(3)]
+            + [
+                self.build_session(project_id=self.project2, environment=self.environment)
+                for _ in range(1)
+            ]
+        )
+        results = self.backend.fetch_projects_with_recent_sessions()
+        assert results == {
+            self.organization.id: [self.project1.id, self.project2.id],
+            self.org2.id: [self.org2_project.id],
+        }
+
+    @override_options({"release-health.use-org-and-project-filter": True})
+    def test_monitor_release_adoption_with_filter(self):
         self.org2 = self.create_organization()
         self.org2_project = self.create_project(organization=self.org2)
         self.org2_release = self.create_release(project=self.org2_project, version="org@2.0.0")


### PR DESCRIPTION
Helps mitigate https://getsentry.atlassian.net/browse/ISSUE-1702, by updating the query in `fetch_projects_with_recent_sessions`.

I create an option to query switch between the old query and the new query.

The new query is the same as old query p much, but with few differences. we sort by org_id and project_id and use the last one as the filter for the next query.