### PR TITLE
fix(insights): handle spaces in search query literals with MutableSearch

### DIFF
--- a/static/app/views/performance/mobile/components/spanSamplesPanelContainer.tsx
+++ b/static/app/views/performance/mobile/components/spanSamplesPanelContainer.tsx
@@ -150,11 +150,7 @@ export function SpanSamplesContainer({
       </Container>
 
       <DurationChart
-        query={
-          additionalFilters
-            ? Object.entries(additionalFilters).map(([key, value]) => `${key}:${value}`)
-            : undefined
-        }
+        spanSearch={MutableSearch.fromQueryObject(additionalFilters ?? {})}
         additionalFilters={additionalFilters}
         groupId={groupId}
         transactionName={transactionName}
@@ -175,11 +171,7 @@ export function SpanSamplesContainer({
         }
       />
       <SampleTable
-        query={
-          additionalFilters
-            ? Object.entries(additionalFilters).map(([key, value]) => `${key}:${value}`)
-            : undefined
-        }
+        spanSearch={MutableSearch.fromQueryObject(additionalFilters ?? {})}
         additionalFilters={additionalFilters}
         highlightedSpanId={highlightedSpanId}
         transactionMethod={transactionMethod}

--- a/static/app/views/starfish/queries/useSpanSamples.tsx
+++ b/static/app/views/starfish/queries/useSpanSamples.tsx
@@ -23,8 +23,8 @@ type Options = {
   groupId: string;
   transactionName: string;
   additionalFields?: string[];
-  query?: string[];
   release?: string;
+  spanSearch?: MutableSearch;
   transactionMethod?: string;
 };
 
@@ -50,16 +50,14 @@ export const useSpanSamples = (options: Options) => {
     transactionName,
     transactionMethod,
     release,
-    query: extraQuery = [],
+    spanSearch,
     additionalFields,
   } = options;
   const location = useLocation();
 
-  const query = new MutableSearch([
-    `${SPAN_GROUP}:${groupId}`,
-    `transaction:"${transactionName}"`,
-    ...extraQuery,
-  ]);
+  const query = spanSearch?.copy() ?? new MutableSearch([]);
+  query.addFilterValue(SPAN_GROUP, groupId);
+  query.addFilterValue('transaction', transactionName);
 
   const filters: SpanMetricsQueryFilters = {
     transaction: transactionName,

--- a/static/app/views/starfish/queries/useSpanSamples.tsx
+++ b/static/app/views/starfish/queries/useSpanSamples.tsx
@@ -55,7 +55,7 @@ export const useSpanSamples = (options: Options) => {
   } = options;
   const location = useLocation();
 
-  const query = spanSearch?.copy() ?? new MutableSearch([]);
+  const query = spanSearch !== undefined ? spanSearch.copy() : new MutableSearch([]);
   query.addFilterValue(SPAN_GROUP, groupId);
   query.addFilterValue('transaction', transactionName);
 

--- a/static/app/views/starfish/views/spanSummaryPage/sampleList/durationChart/index.tsx
+++ b/static/app/views/starfish/views/spanSummaryPage/sampleList/durationChart/index.tsx
@@ -31,9 +31,9 @@ type Props = {
   onMouseLeaveSample?: () => void;
   onMouseOverSample?: (sample: SpanSample) => void;
   platform?: string;
-  query?: string[];
   release?: string;
   spanDescription?: string;
+  spanSearch?: MutableSearch;
   transactionMethod?: string;
 };
 
@@ -47,7 +47,7 @@ function DurationChart({
   transactionMethod,
   additionalFields,
   release,
-  query,
+  spanSearch,
   platform,
   additionalFilters,
 }: Props) {
@@ -108,7 +108,7 @@ function DurationChart({
     transactionName,
     transactionMethod,
     release,
-    query,
+    spanSearch,
     additionalFields,
   });
 

--- a/static/app/views/starfish/views/spanSummaryPage/sampleList/index.tsx
+++ b/static/app/views/starfish/views/spanSummaryPage/sampleList/index.tsx
@@ -15,6 +15,7 @@ import {trackAnalytics} from 'sentry/utils/analytics';
 import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import {PageAlert, PageAlertProvider} from 'sentry/utils/performance/contexts/pageAlert';
 import {decodeScalar} from 'sentry/utils/queryString';
+import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
@@ -118,11 +119,11 @@ export function SampleList({
   );
 
   // set additional query filters from the span search bar and the `query` param
-  let extraQuery: string[] | undefined = spanSearchQuery?.split(' ');
+  const spanSearch = new MutableSearch(spanSearchQuery ?? '');
   if (query.query) {
-    extraQuery = extraQuery?.concat(
-      Array.isArray(query.query) ? query.query : [query.query]
-    );
+    (Array.isArray(query.query) ? query.query : [query.query]).forEach(filter => {
+      spanSearch.addStringFilter(filter);
+    });
   }
 
   function defaultOnClose() {
@@ -204,7 +205,7 @@ export function SampleList({
           }}
           onMouseOverSample={sample => debounceSetHighlightedSpanId(sample.span_id)}
           onMouseLeaveSample={() => debounceSetHighlightedSpanId(undefined)}
-          query={extraQuery}
+          spanSearch={spanSearch}
           highlightedSpanId={highlightedSpanId}
         />
 
@@ -230,7 +231,7 @@ export function SampleList({
           groupId={groupId}
           moduleName={moduleName}
           transactionName={transactionName}
-          query={extraQuery}
+          spanSearch={spanSearch}
           columnOrder={columnOrder}
           additionalFields={additionalFields}
         />

--- a/static/app/views/starfish/views/spanSummaryPage/sampleList/sampleTable/sampleTable.tsx
+++ b/static/app/views/starfish/views/spanSummaryPage/sampleList/sampleTable/sampleTable.tsx
@@ -35,8 +35,8 @@ type Props = {
   highlightedSpanId?: string;
   onMouseLeaveSample?: () => void;
   onMouseOverSample?: (sample: SpanSample) => void;
-  query?: string[];
   release?: string;
+  spanSearch?: MutableSearch;
   transactionMethod?: string;
 };
 
@@ -50,7 +50,7 @@ function SampleTable({
   transactionMethod,
   columnOrder,
   release,
-  query,
+  spanSearch,
   additionalFields,
   additionalFilters,
 }: Props) {
@@ -95,7 +95,7 @@ function SampleTable({
     transactionName,
     transactionMethod,
     release,
-    query,
+    spanSearch,
     additionalFields,
   });
 


### PR DESCRIPTION
Fixes an issue with handling empty spaces in the search query strings. Previously (https://github.com/getsentry/sentry/pull/71345), we naively split the search query into filters with `.split(' ')` - this does not handle the case where the user searches for a string containing a space, e.g. `browser.name:"Microsoft Edge"`.

![image](https://github.com/getsentry/sentry/assets/58920989/81a30a98-a6f7-4543-a884-74d7b70dda40)

We can easily verify that the spans are correctly filtered to `Microsoft Edge` in the example above.


