### PR TITLE
feat(insights): add search bar to mobile sample panels

### DIFF
--- a/static/app/views/performance/mobile/components/spanSamplesPanel.tsx
+++ b/static/app/views/performance/mobile/components/spanSamplesPanel.tsx
@@ -32,6 +32,9 @@ type Props = {
   transactionRoute?: string;
 };
 
+const PRIMARY_SPAN_QUERY_KEY = 'primarySpanSearchQuery';
+const SECONDARY_SPAN_QUERY_KEY = 'secondarySpanSearchQuery';
+
 export function SpanSamplesPanel({
   groupId,
   moduleName,
@@ -57,8 +60,8 @@ export function SpanSamplesPanel({
   const {query} = useLocation();
   const {projects} = useProjects();
 
-  const primarySpanSearchQuery = decodeScalar(query.primarySpanSearchQuery);
-  const secondarySpanSearchQuery = decodeScalar(query.secondarySpanSearchQuery);
+  const primarySpanSearchQuery = decodeScalar(query[PRIMARY_SPAN_QUERY_KEY]);
+  const secondarySpanSearchQuery = decodeScalar(query[SECONDARY_SPAN_QUERY_KEY]);
 
   const project = useMemo(
     () => projects.find(p => p.id === String(query.project)),
@@ -85,26 +88,6 @@ export function SpanSamplesPanel({
       transaction: transactionName,
     })}`
   );
-
-  const handlePrimarySearch = (newSpanSearchQuery: string) => {
-    router.replace({
-      pathname: location.pathname,
-      query: {
-        ...query,
-        primarySpanSearchQuery: newSpanSearchQuery,
-      },
-    });
-  };
-
-  const handleSecondarySearch = (newSpanSearchQuery: string) => {
-    router.replace({
-      pathname: location.pathname,
-      query: {
-        ...query,
-        secondarySpanSearchQuery: newSpanSearchQuery,
-      },
-    });
-  };
 
   function defaultOnClose() {
     router.replace({
@@ -151,7 +134,7 @@ export function SpanSamplesPanel({
               sectionTitle={t('Release 1')}
               project={project}
               searchQuery={primarySpanSearchQuery}
-              handleSearch={handlePrimarySearch}
+              searchQueryKey={PRIMARY_SPAN_QUERY_KEY}
               spanOp={spanOp}
               additionalFilters={additionalFilters}
             />
@@ -166,7 +149,7 @@ export function SpanSamplesPanel({
               sectionTitle={t('Release 2')}
               project={project}
               searchQuery={secondarySpanSearchQuery}
-              handleSearch={handleSecondarySearch}
+              searchQueryKey={SECONDARY_SPAN_QUERY_KEY}
               spanOp={spanOp}
               additionalFilters={additionalFilters}
             />

--- a/static/app/views/performance/mobile/components/spanSamplesPanel.tsx
+++ b/static/app/views/performance/mobile/components/spanSamplesPanel.tsx
@@ -9,7 +9,6 @@ import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {PageAlert, PageAlertProvider} from 'sentry/utils/performance/contexts/pageAlert';
-import {decodeScalar} from 'sentry/utils/queryString';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import useProjects from 'sentry/utils/useProjects';
@@ -59,9 +58,6 @@ export function SpanSamplesPanel({
   const organization = useOrganization();
   const {query} = useLocation();
   const {projects} = useProjects();
-
-  const primarySpanSearchQuery = decodeScalar(query[PRIMARY_SPAN_QUERY_KEY]);
-  const secondarySpanSearchQuery = decodeScalar(query[SECONDARY_SPAN_QUERY_KEY]);
 
   const project = useMemo(
     () => projects.find(p => p.id === String(query.project)),
@@ -133,7 +129,6 @@ export function SpanSamplesPanel({
               release={primaryRelease}
               sectionTitle={t('Release 1')}
               project={project}
-              searchQuery={primarySpanSearchQuery}
               searchQueryKey={PRIMARY_SPAN_QUERY_KEY}
               spanOp={spanOp}
               additionalFilters={additionalFilters}
@@ -148,7 +143,6 @@ export function SpanSamplesPanel({
               release={secondaryRelease}
               sectionTitle={t('Release 2')}
               project={project}
-              searchQuery={secondarySpanSearchQuery}
               searchQueryKey={SECONDARY_SPAN_QUERY_KEY}
               spanOp={spanOp}
               additionalFilters={additionalFilters}

--- a/static/app/views/performance/mobile/components/spanSamplesPanel.tsx
+++ b/static/app/views/performance/mobile/components/spanSamplesPanel.tsx
@@ -9,6 +9,7 @@ import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {PageAlert, PageAlertProvider} from 'sentry/utils/performance/contexts/pageAlert';
+import {decodeScalar} from 'sentry/utils/queryString';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import useProjects from 'sentry/utils/useProjects';
@@ -56,6 +57,9 @@ export function SpanSamplesPanel({
   const {query} = useLocation();
   const {projects} = useProjects();
 
+  const primarySpanSearchQuery = decodeScalar(query.primarySpanSearchQuery);
+  const secondarySpanSearchQuery = decodeScalar(query.secondarySpanSearchQuery);
+
   const project = useMemo(
     () => projects.find(p => p.id === String(query.project)),
     [projects, query.project]
@@ -81,6 +85,26 @@ export function SpanSamplesPanel({
       transaction: transactionName,
     })}`
   );
+
+  const handlePrimarySearch = (newSpanSearchQuery: string) => {
+    router.replace({
+      pathname: location.pathname,
+      query: {
+        ...query,
+        primarySpanSearchQuery: newSpanSearchQuery,
+      },
+    });
+  };
+
+  const handleSecondarySearch = (newSpanSearchQuery: string) => {
+    router.replace({
+      pathname: location.pathname,
+      query: {
+        ...query,
+        secondarySpanSearchQuery: newSpanSearchQuery,
+      },
+    });
+  };
 
   function defaultOnClose() {
     router.replace({
@@ -126,6 +150,8 @@ export function SpanSamplesPanel({
               release={primaryRelease}
               sectionTitle={t('Release 1')}
               project={project}
+              searchQuery={primarySpanSearchQuery}
+              handleSearch={handlePrimarySearch}
               spanOp={spanOp}
               additionalFilters={additionalFilters}
             />
@@ -139,6 +165,8 @@ export function SpanSamplesPanel({
               release={secondaryRelease}
               sectionTitle={t('Release 2')}
               project={project}
+              searchQuery={secondarySpanSearchQuery}
+              handleSearch={handleSecondarySearch}
               spanOp={spanOp}
               additionalFilters={additionalFilters}
             />

--- a/static/app/views/performance/mobile/components/spanSamplesPanelContainer.tsx
+++ b/static/app/views/performance/mobile/components/spanSamplesPanelContainer.tsx
@@ -130,19 +130,15 @@ export function SpanSamplesContainer({
 
   const spanMetrics = data[0] ?? {};
 
-  let handleSearch: ((query: string) => void) | undefined = undefined;
-
-  if (searchQueryKey) {
-    handleSearch = (newSearchQuery: string) => {
-      router.replace({
-        pathname: location.pathname,
-        query: {
-          ...location.query,
-          [searchQueryKey]: newSearchQuery,
-        },
-      });
-    };
-  }
+  const handleSearch = (newSearchQuery: string) => {
+    router.replace({
+      pathname: location.pathname,
+      query: {
+        ...location.query,
+        ...(searchQueryKey && {[searchQueryKey]: newSearchQuery}),
+      },
+    });
+  };
 
   return (
     <Fragment>

--- a/static/app/views/performance/mobile/components/spanSamplesPanelContainer.tsx
+++ b/static/app/views/performance/mobile/components/spanSamplesPanelContainer.tsx
@@ -2,6 +2,8 @@ import {Fragment, useCallback, useState} from 'react';
 import styled from '@emotion/styled';
 import debounce from 'lodash/debounce';
 
+import Feature from 'sentry/components/acl/feature';
+import SearchBar from 'sentry/components/events/searchBar';
 import {COL_WIDTH_UNDEFINED} from 'sentry/components/gridEditable';
 import Link from 'sentry/components/links/link';
 import {Tooltip} from 'sentry/components/tooltip';
@@ -9,10 +11,12 @@ import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {Project} from 'sentry/types/project';
 import {DurationUnit} from 'sentry/utils/discover/fields';
+import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import {decodeScalar} from 'sentry/utils/queryString';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
+import usePageFilters from 'sentry/utils/usePageFilters';
 import useRouter from 'sentry/utils/useRouter';
 import {normalizeUrl} from 'sentry/utils/withDomainRequired';
 import {MetricReadout} from 'sentry/views/performance/metricReadout';
@@ -22,6 +26,7 @@ import {
   PLATFORM_QUERY_PARAM,
 } from 'sentry/views/performance/mobile/screenload/screens/platformSelector';
 import {isCrossPlatform} from 'sentry/views/performance/mobile/screenload/screens/utils';
+import {useSpanFieldSupportedTags} from 'sentry/views/performance/utils/useSpanFieldSupportedTags';
 import {useSpanMetrics} from 'sentry/views/starfish/queries/useDiscover';
 import {
   type ModuleName,
@@ -65,8 +70,11 @@ export function SpanSamplesContainer({
   );
 
   const organization = useOrganization();
+  const {selection} = usePageFilters();
+  const supportedTags = useSpanFieldSupportedTags();
 
   const hasPlatformSelectFeature = organization.features.includes('spans-first-ui');
+  const spanSearchQuery = decodeScalar(location.query.spanSearchQuery);
   const platform =
     decodeScalar(location.query[PLATFORM_QUERY_PARAM]) ??
     localStorage.getItem(PLATFORM_LOCAL_STORAGE_KEY) ??
@@ -79,6 +87,23 @@ export function SpanSamplesContainer({
     }, 10),
     []
   );
+
+  const handleSearch = (newSpanSearchQuery: string) => {
+    router.replace({
+      pathname: location.pathname,
+      query: {
+        ...location.query,
+        spanSearchQuery: newSpanSearchQuery,
+      },
+    });
+  };
+
+  const spanSearch = new MutableSearch(spanSearchQuery ?? '');
+  if (additionalFilters) {
+    Object.entries(additionalFilters).forEach(([key, value]) => {
+      spanSearch.addFilterValue(key, value);
+    });
+  }
 
   const filters: SpanMetricsQueryFilters = {
     'span.group': groupId,
@@ -150,7 +175,7 @@ export function SpanSamplesContainer({
       </Container>
 
       <DurationChart
-        spanSearch={MutableSearch.fromQueryObject(additionalFilters ?? {})}
+        spanSearch={spanSearch}
         additionalFilters={additionalFilters}
         groupId={groupId}
         transactionName={transactionName}
@@ -170,8 +195,22 @@ export function SpanSamplesContainer({
             : undefined
         }
       />
+
+      <Feature features="performance-sample-panel-search">
+        <StyledSearchBar
+          searchSource="queries-sample-panel"
+          query={spanSearchQuery}
+          onSearch={handleSearch}
+          placeholder={t('Search for span attributes')}
+          organization={organization}
+          metricAlert={false}
+          supportedTags={supportedTags}
+          dataset={DiscoverDatasets.SPANS_INDEXED}
+          projectIds={selection.projects}
+        />
+      </Feature>
       <SampleTable
-        spanSearch={MutableSearch.fromQueryObject(additionalFilters ?? {})}
+        spanSearch={spanSearch}
         additionalFilters={additionalFilters}
         highlightedSpanId={highlightedSpanId}
         transactionMethod={transactionMethod}
@@ -213,4 +252,8 @@ const PaddedTitle = styled('div')`
 
 const Container = styled('div')`
   display: flex;
+`;
+
+const StyledSearchBar = styled(SearchBar)`
+  margin-top: ${space(2)};
 `;

--- a/static/app/views/performance/mobile/components/spanSamplesPanelContainer.tsx
+++ b/static/app/views/performance/mobile/components/spanSamplesPanelContainer.tsx
@@ -47,7 +47,6 @@ type Props = {
   additionalFilters?: Record<string, string>;
   project?: Project | null;
   release?: string;
-  searchQuery?: string;
   searchQueryKey?: string;
   sectionSubtitle?: string;
   sectionTitle?: string;
@@ -62,7 +61,6 @@ export function SpanSamplesContainer({
   transactionMethod,
   release,
   project,
-  searchQuery,
   searchQueryKey,
   spanOp,
   additionalFilters,
@@ -76,6 +74,11 @@ export function SpanSamplesContainer({
   const organization = useOrganization();
   const {selection} = usePageFilters();
   const supportedTags = useSpanFieldSupportedTags();
+
+  const searchQuery =
+    searchQueryKey !== undefined
+      ? decodeScalar(location.query[searchQueryKey])
+      : undefined;
 
   const hasPlatformSelectFeature = organization.features.includes('spans-first-ui');
   const platform =

--- a/static/app/views/performance/mobile/components/spanSamplesPanelContainer.tsx
+++ b/static/app/views/performance/mobile/components/spanSamplesPanelContainer.tsx
@@ -45,10 +45,10 @@ type Props = {
   moduleName: ModuleName;
   transactionName: string;
   additionalFilters?: Record<string, string>;
-  handleSearch?: (newSpanSearchQuery: string) => void;
   project?: Project | null;
   release?: string;
   searchQuery?: string;
+  searchQueryKey?: string;
   sectionSubtitle?: string;
   sectionTitle?: string;
   spanOp?: string;
@@ -63,7 +63,7 @@ export function SpanSamplesContainer({
   release,
   project,
   searchQuery,
-  handleSearch,
+  searchQueryKey,
   spanOp,
   additionalFilters,
 }: Props) {
@@ -129,6 +129,20 @@ export function SpanSamplesContainer({
   );
 
   const spanMetrics = data[0] ?? {};
+
+  let handleSearch: ((query: string) => void) | undefined = undefined;
+
+  if (searchQueryKey) {
+    handleSearch = (newSearchQuery: string) => {
+      router.replace({
+        pathname: location.pathname,
+        query: {
+          ...location.query,
+          [searchQueryKey]: newSearchQuery,
+        },
+      });
+    };
+  }
 
   return (
     <Fragment>

--- a/static/app/views/performance/mobile/components/spanSamplesPanelContainer.tsx
+++ b/static/app/views/performance/mobile/components/spanSamplesPanelContainer.tsx
@@ -45,8 +45,10 @@ type Props = {
   moduleName: ModuleName;
   transactionName: string;
   additionalFilters?: Record<string, string>;
+  handleSearch?: (newSpanSearchQuery: string) => void;
   project?: Project | null;
   release?: string;
+  searchQuery?: string;
   sectionSubtitle?: string;
   sectionTitle?: string;
   spanOp?: string;
@@ -60,6 +62,8 @@ export function SpanSamplesContainer({
   transactionMethod,
   release,
   project,
+  searchQuery,
+  handleSearch,
   spanOp,
   additionalFilters,
 }: Props) {
@@ -74,7 +78,6 @@ export function SpanSamplesContainer({
   const supportedTags = useSpanFieldSupportedTags();
 
   const hasPlatformSelectFeature = organization.features.includes('spans-first-ui');
-  const spanSearchQuery = decodeScalar(location.query.spanSearchQuery);
   const platform =
     decodeScalar(location.query[PLATFORM_QUERY_PARAM]) ??
     localStorage.getItem(PLATFORM_LOCAL_STORAGE_KEY) ??
@@ -88,17 +91,7 @@ export function SpanSamplesContainer({
     []
   );
 
-  const handleSearch = (newSpanSearchQuery: string) => {
-    router.replace({
-      pathname: location.pathname,
-      query: {
-        ...location.query,
-        spanSearchQuery: newSpanSearchQuery,
-      },
-    });
-  };
-
-  const spanSearch = new MutableSearch(spanSearchQuery ?? '');
+  const spanSearch = new MutableSearch(searchQuery ?? '');
   if (additionalFilters) {
     Object.entries(additionalFilters).forEach(([key, value]) => {
       spanSearch.addFilterValue(key, value);
@@ -199,7 +192,7 @@ export function SpanSamplesContainer({
       <Feature features="performance-sample-panel-search">
         <StyledSearchBar
           searchSource="queries-sample-panel"
-          query={spanSearchQuery}
+          query={searchQuery}
           onSearch={handleSearch}
           placeholder={t('Search for span attributes')}
           organization={organization}


### PR DESCRIPTION
Adds search bar to mobile sample panels.
![image](https://github.com/getsentry/sentry/assets/58920989/c0984988-98ea-44eb-8814-68c207b90add)

We have an independent search bar for each of the releases, so that users can narrow down on spans in one release without affecting the sample table of the other release.