### PR TITLE
feat(insights): add search bar to cache and queue sample panels

### DIFF
--- a/static/app/views/performance/cache/samplePanel/samplePanel.tsx
+++ b/static/app/views/performance/cache/samplePanel/samplePanel.tsx
@@ -384,8 +384,8 @@ export function CacheSamplePanel() {
             />
           </ModuleLayout.Half>
 
-          <ModuleLayout.Full>
-            <Feature features="performance-sample-panel-search">
+          <Feature features="performance-sample-panel-search">
+            <ModuleLayout.Full>
               <SearchBar
                 searchSource={`${ModuleName.CACHE}-sample-panel`}
                 query={query.spanSearchQuery}
@@ -397,8 +397,8 @@ export function CacheSamplePanel() {
                 dataset={DiscoverDatasets.SPANS_INDEXED}
                 projectIds={selection.projects}
               />
-            </Feature>
-          </ModuleLayout.Full>
+            </ModuleLayout.Full>
+          </Feature>
 
           <Fragment>
             <ModuleLayout.Full>

--- a/static/app/views/performance/queues/destinationSummary/destinationSummaryPage.spec.tsx
+++ b/static/app/views/performance/queues/destinationSummary/destinationSummaryPage.spec.tsx
@@ -51,7 +51,7 @@ describe('destinationSummaryPage', () => {
     initiallyLoaded: false,
   });
 
-  let eventsMock, eventsStatsMock;
+  let eventsMock, eventsStatsMock, spanFieldTagsMock;
 
   beforeEach(() => {
     eventsMock = MockApiClient.addMockResponse({
@@ -65,6 +65,21 @@ describe('destinationSummaryPage', () => {
       method: 'GET',
       body: {data: []},
     });
+
+    spanFieldTagsMock = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/spans/fields/`,
+      method: 'GET',
+      body: [
+        {
+          key: 'api_key',
+          name: 'Api Key',
+        },
+        {
+          key: 'bytes.size',
+          name: 'Bytes.Size',
+        },
+      ],
+    });
   });
 
   it('renders', async () => {
@@ -75,5 +90,16 @@ describe('destinationSummaryPage', () => {
     screen.getByText('Published vs Processed');
     expect(eventsStatsMock).toHaveBeenCalled();
     expect(eventsMock).toHaveBeenCalled();
+    expect(spanFieldTagsMock).toHaveBeenCalledWith(
+      `/organizations/${organization.slug}/spans/fields/`,
+      expect.objectContaining({
+        method: 'GET',
+        query: {
+          project: [],
+          environment: [],
+          statsPeriod: '1h',
+        },
+      })
+    );
   });
 });

--- a/static/app/views/performance/queues/destinationSummary/messageSpanSamplesPanel.spec.tsx
+++ b/static/app/views/performance/queues/destinationSummary/messageSpanSamplesPanel.spec.tsx
@@ -12,7 +12,7 @@ jest.mock('sentry/utils/usePageFilters');
 describe('messageSpanSamplesPanel', () => {
   const organization = OrganizationFixture();
 
-  let eventsRequestMock, eventsStatsRequestMock, samplesRequestMock;
+  let eventsRequestMock, eventsStatsRequestMock, samplesRequestMock, spanFieldTagsMock;
 
   jest.mocked(usePageFilters).mockReturnValue({
     isReady: true,
@@ -110,6 +110,21 @@ describe('messageSpanSamplesPanel', () => {
         ],
       },
     });
+
+    spanFieldTagsMock = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/spans/fields/`,
+      method: 'GET',
+      body: [
+        {
+          key: 'api_key',
+          name: 'Api Key',
+        },
+        {
+          key: 'bytes.size',
+          name: 'Bytes.Size',
+        },
+      ],
+    });
   });
 
   afterAll(() => {
@@ -185,6 +200,18 @@ describe('messageSpanSamplesPanel', () => {
           statsPeriod: '10d',
           upperBound: 8000,
         }),
+      })
+    );
+    expect(spanFieldTagsMock).toHaveBeenNthCalledWith(
+      1,
+      `/organizations/${organization.slug}/spans/fields/`,
+      expect.objectContaining({
+        method: 'GET',
+        query: {
+          project: [],
+          environment: [],
+          statsPeriod: '1h',
+        },
       })
     );
     expect(screen.getByRole('table', {name: 'Span Samples'})).toBeInTheDocument();
@@ -269,6 +296,17 @@ describe('messageSpanSamplesPanel', () => {
           statsPeriod: '10d',
           upperBound: 8000,
         }),
+      })
+    );
+    expect(spanFieldTagsMock).toHaveBeenCalledWith(
+      `/organizations/${organization.slug}/spans/fields/`,
+      expect.objectContaining({
+        method: 'GET',
+        query: {
+          project: [],
+          environment: [],
+          statsPeriod: '1h',
+        },
       })
     );
     expect(screen.getByRole('table', {name: 'Span Samples'})).toBeInTheDocument();

--- a/static/app/views/performance/queues/destinationSummary/messageSpanSamplesPanel.tsx
+++ b/static/app/views/performance/queues/destinationSummary/messageSpanSamplesPanel.tsx
@@ -362,7 +362,7 @@ export function MessageSpanSamplesPanel() {
           <ModuleLayout.Full>
             <Feature features="performance-sample-panel-search">
               <SearchBar
-                searchSource={`queue-sample-panel`}
+                searchSource={`${ModuleName.QUEUE}-sample-panel`}
                 query={query.spanSearchQuery}
                 onSearch={handleSearch}
                 placeholder={t('Search for span attributes')}

--- a/static/app/views/performance/queues/destinationSummary/messageSpanSamplesPanel.tsx
+++ b/static/app/views/performance/queues/destinationSummary/messageSpanSamplesPanel.tsx
@@ -359,8 +359,8 @@ export function MessageSpanSamplesPanel() {
             />
           </ModuleLayout.Full>
 
-          <ModuleLayout.Full>
-            <Feature features="performance-sample-panel-search">
+          <Feature features="performance-sample-panel-search">
+            <ModuleLayout.Full>
               <SearchBar
                 searchSource={`${ModuleName.QUEUE}-sample-panel`}
                 query={query.spanSearchQuery}
@@ -372,8 +372,8 @@ export function MessageSpanSamplesPanel() {
                 dataset={DiscoverDatasets.SPANS_INDEXED}
                 projectIds={selection.projects}
               />
-            </Feature>
-          </ModuleLayout.Full>
+            </ModuleLayout.Full>
+          </Feature>
 
           <ModuleLayout.Full>
             <MessageSpanSamplesTable

--- a/static/app/views/starfish/views/spanSummaryPage/sampleList/index.tsx
+++ b/static/app/views/starfish/views/spanSummaryPage/sampleList/index.tsx
@@ -211,7 +211,7 @@ export function SampleList({
 
         <Feature features="performance-sample-panel-search">
           <StyledSearchBar
-            searchSource="queries-sample-panel"
+            searchSource={`${moduleName}-sample-panel`}
             query={spanSearchQuery}
             onSearch={handleSearch}
             placeholder={t('Search for span attributes')}


### PR DESCRIPTION
Adds a span search bar to cache and queue sample panels.

Cache:
![image](https://github.com/getsentry/sentry/assets/58920989/a7ba2028-c72c-4d83-bd6b-9a6583e89986)

Queues:
![image](https://github.com/getsentry/sentry/assets/58920989/c6054c2d-7d51-4951-a011-49b58c8f2695)
