### PR TITLE
perf(crons): Attempt to improve performance of `organization_monitor_index_stats` api.

### DIFF
--- a/src/sentry/monitors/endpoints/organization_monitor_index_stats.py
+++ b/src/sentry/monitors/endpoints/organization_monitor_index_stats.py
@@ -17,6 +17,14 @@ from sentry.api.helpers.environments import get_environments
 from sentry.models.environment import Environment
 from sentry.monitors.models import CheckInStatus, Monitor, MonitorCheckIn, MonitorEnvironment
 
+TRACKED_STATUSES = [
+    CheckInStatus.IN_PROGRESS,
+    CheckInStatus.OK,
+    CheckInStatus.ERROR,
+    CheckInStatus.MISSED,
+    CheckInStatus.TIMEOUT,
+]
+
 
 def normalize_to_epoch(timestamp: datetime, seconds: int):
     """
@@ -47,14 +55,6 @@ class OrganizationMonitorIndexStatsEndpoint(OrganizationEndpoint, StatsMixin):
         end = normalize_to_epoch(args["end"], args["rollup"])
 
         monitor_guids: list[str] = request.GET.getlist("monitor")
-
-        tracked_statuses = [
-            CheckInStatus.IN_PROGRESS,
-            CheckInStatus.OK,
-            CheckInStatus.ERROR,
-            CheckInStatus.MISSED,
-            CheckInStatus.TIMEOUT,
-        ]
 
         # Pre-fetch the monitor-ids and their guid. This is an
         # optimization to eliminate a join against the monitor table which
@@ -112,14 +112,14 @@ class OrganizationMonitorIndexStatsEndpoint(OrganizationEndpoint, StatsMixin):
                 environment_map = {env.id: env.name for env in environments}
 
         check_ins = MonitorCheckIn.objects.filter(
-            monitor_id__in=monitor_map.keys(),
-            status__in=tracked_statuses,
             date_added__gte=args["start"],
             date_added__lt=args["end"],
         )
 
         if monitor_environment_map:
             check_ins = check_ins.filter(monitor_environment_id__in=monitor_environment_map.keys())
+        else:
+            check_ins = check_ins.filter(monitor_id__in=monitor_map.keys())
 
         # Use postgres' `date_bin` to bucket rounded to our rollups
         bucket = Func(
@@ -158,7 +158,7 @@ class OrganizationMonitorIndexStatsEndpoint(OrganizationEndpoint, StatsMixin):
         StatusStats = MutableMapping[str, int]
 
         def status_obj_factory() -> StatusStats:
-            return {status_to_name[status]: 0 for status in tracked_statuses}
+            return {status_to_name[status]: 0 for status in TRACKED_STATUSES}
 
         # Mapping chain of monitor_id -> timestamp[] -> monitor_env_names -> StatusStats
         EnvToStatusMapping = MutableMapping[int, StatusStats]

--- a/tests/sentry/monitors/endpoints/test_organization_monitor_index_stats.py
+++ b/tests/sentry/monitors/endpoints/test_organization_monitor_index_stats.py
@@ -30,6 +30,7 @@ class OrganizationMonitorIndexStatsTest(MonitorTestCase):
         self.monitor2 = self._create_monitor()
         self.env_prod = self._create_monitor_environment(monitor=self.monitor1)
         self.env_debug = self._create_monitor_environment(monitor=self.monitor1, name="debug")
+        self.env_prod_2 = self._create_monitor_environment(monitor=self.monitor2)
 
         # Be sure to note the freeze time above
         self.since = self.monitor1.date_added
@@ -62,8 +63,8 @@ class OrganizationMonitorIndexStatsTest(MonitorTestCase):
             status=CheckInStatus.TIMEOUT,
         )
 
-        self.add_checkin(self.monitor2, offset={"minutes": 1})
-        self.add_checkin(self.monitor2, offset={"minutes": 2})
+        self.add_checkin(self.monitor2, env=self.env_prod_2, offset={"minutes": 1})
+        self.add_checkin(self.monitor2, env=self.env_prod_2, offset={"minutes": 2})
 
     def test_simple(self):
         resp = self.get_success_response(


### PR DESCRIPTION
At the moment we're filtering on `monitor_id` and `monitor_environment_id`. There's no specific index on both of these, and so postgres ends up scanning multiple indexes, rather than either `monitor_id, date_added` or `monitor_environment_id, date_added`.

I also dropped the filter on status, which is unnecessary since we're filtering to all statuses.

This should improve things, but if not we can see if a `UNION` helps at all.