### PR TITLE
Update traceUXChangeBanner.tsx

### DIFF
--- a/static/app/views/performance/newTraceDetails/traceUXChangeBanner.tsx
+++ b/static/app/views/performance/newTraceDetails/traceUXChangeBanner.tsx
@@ -29,9 +29,7 @@ export function TraceUXChangeAlert() {
         {
           why: (
             <a
-              href="https://docs.sentry.io/product/sentry-basics/concepts/tracing/trace-view/"
-              target="_blank"
-              rel="noreferrer"
+              href="https://docs.sentry.io/product/sentry-basics/concepts/tracing/trace-view/" target="_blank"
             >
               {t('why')}
             </a>

--- a/static/app/views/performance/newTraceDetails/traceUXChangeBanner.tsx
+++ b/static/app/views/performance/newTraceDetails/traceUXChangeBanner.tsx
@@ -29,7 +29,9 @@ export function TraceUXChangeAlert() {
         {
           why: (
             <a
-              href="https://docs.sentry.io/product/sentry-basics/concepts/tracing/trace-view/" target="_blank"
+              href="https://docs.sentry.io/product/sentry-basics/concepts/tracing/trace-view/"
+              target="_blank"
+              rel="noreferrer"
             >
               {t('why')}
             </a>

--- a/static/app/views/performance/newTraceDetails/traceUXChangeBanner.tsx
+++ b/static/app/views/performance/newTraceDetails/traceUXChangeBanner.tsx
@@ -28,7 +28,11 @@ export function TraceUXChangeAlert() {
         'Get deeper context with the new trace view, which links events directly inside traces. Read [why] we are doing this and how it helps you.',
         {
           why: (
-            <a href="https://docs.sentry.io/product/sentry-basics/concepts/tracing/trace-view/" target="_blank">
+            <a
+              href="https://docs.sentry.io/product/sentry-basics/concepts/tracing/trace-view/"
+              target="_blank"
+              rel="noreferrer"
+            >
               {t('why')}
             </a>
           ),

--- a/static/app/views/performance/newTraceDetails/traceUXChangeBanner.tsx
+++ b/static/app/views/performance/newTraceDetails/traceUXChangeBanner.tsx
@@ -25,10 +25,10 @@ export function TraceUXChangeAlert() {
       }
     >
       {tct(
-        'Get deeper context with the new trace view, which links events directly inside traces. Read [why] we are doing this and how it helps you',
+        'Get deeper context with the new trace view, which links events directly inside traces. Read [why] we are doing this and how it helps you.',
         {
           why: (
-            <a href="https://docs.sentry.io/product/sentry-basics/concepts/tracing/trace-view/">
+            <a href="https://docs.sentry.io/product/sentry-basics/concepts/tracing/trace-view/" target="_blank">
               {t('why')}
             </a>
           ),

--- a/static/app/views/performance/newTraceDetails/traceUXChangeBanner.tsx
+++ b/static/app/views/performance/newTraceDetails/traceUXChangeBanner.tsx
@@ -1,5 +1,6 @@
 import Alert from 'sentry/components/alert';
 import {Button} from 'sentry/components/button';
+import ExternalLink from 'sentry/components/links/externalLink';
 import {IconClose} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
 import {useLocalStorageState} from 'sentry/utils/useLocalStorageState';
@@ -28,13 +29,9 @@ export function TraceUXChangeAlert() {
         'Get deeper context with the new trace view, which links events directly inside traces. Read [why] we are doing this and how it helps you.',
         {
           why: (
-            <a
-              href="https://docs.sentry.io/product/sentry-basics/concepts/tracing/trace-view/"
-              target="_blank"
-              rel="noreferrer"
-            >
+            <ExternalLink href="https://docs.sentry.io/product/sentry-basics/concepts/tracing/trace-view/">
               {t('why')}
-            </a>
+            </ExternalLink>
           ),
         }
       )}


### PR DESCRIPTION
set target to open a new tab and added a period.

<!-- Describe your PR here. -->

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
