### PR TITLE
ref(seer grouping): Check rate limits before seer ingestion grouping call

### DIFF
--- a/src/sentry/grouping/ingest/seer.py
+++ b/src/sentry/grouping/ingest/seer.py
@@ -2,6 +2,7 @@ import logging
 from dataclasses import asdict
 
 from sentry import features, options
+from sentry import ratelimits as ratelimiter
 from sentry.eventstore.models import Event
 from sentry.grouping.grouping_info import get_grouping_info_from_variants
 from sentry.grouping.result import CalculatedHashes
@@ -23,7 +24,7 @@ def should_call_seer_for_grouping(event: Event, project: Project) -> bool:
     # TODO: Implement rate limits, kill switches, other flags, etc
     # TODO: Return False if the event has a custom fingerprint (check for both client- and server-side fingerprints)
 
-    if _killswitch_enabled(event, project):
+    if _killswitch_enabled(event, project) or _ratelimiting_enabled(event, project):
         return False
 
     if not event_content_is_seer_eligible(event):
@@ -55,6 +56,46 @@ def _killswitch_enabled(event: Event, project: Project) -> bool:
             extra=logger_extra,
         )
         metrics.incr("grouping.similarity.seer_similarity_killswitch_enabled")
+        return True
+
+    return False
+
+
+def _ratelimiting_enabled(event: Event, project: Project) -> bool:
+    """
+    Check both the global and project-based Seer similarity ratelimits.
+    """
+
+    global_ratelimit = options.get("seer.similarity.global-rate-limit")
+    per_project_ratelimit = options.get("seer.similarity.per-project-rate-limit")
+
+    global_limit_per_sec = global_ratelimit["limit"] / global_ratelimit["window"]
+    project_limit_per_sec = per_project_ratelimit["limit"] / per_project_ratelimit["window"]
+
+    logger_extra = {"event_id": event.event_id, "project_id": project.id}
+
+    if ratelimiter.backend.is_limited("seer:similarity:global-limit", **global_ratelimit):
+        logger_extra["limit_per_sec"] = global_limit_per_sec
+        logger.warning("should_call_seer_for_grouping.global_ratelimit_hit", extra=logger_extra)
+
+        metrics.incr(
+            "grouping.similarity.global_ratelimit_hit",
+            tags={"limit_per_sec": global_limit_per_sec},
+        )
+
+        return True
+
+    if ratelimiter.backend.is_limited(
+        f"seer:similarity:project-{project.id}-limit", **per_project_ratelimit
+    ):
+        logger_extra["limit_per_sec"] = project_limit_per_sec
+        logger.warning("should_call_seer_for_grouping.project_ratelimit_hit", extra=logger_extra)
+
+        metrics.incr(
+            "grouping.similarity.project_ratelimit_hit",
+            tags={"limit_per_sec": project_limit_per_sec},
+        )
+
         return True
 
     return False

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -893,6 +893,19 @@ register(
     flags=FLAG_MODIFIABLE_BOOL | FLAG_AUTOMATOR_MODIFIABLE,
 )
 
+register(
+    "seer.similarity.global-rate-limit",
+    type=Dict,
+    default={"limit": 20, "window": 1},
+    flags=FLAG_ALLOW_EMPTY | FLAG_AUTOMATOR_MODIFIABLE,
+)
+register(
+    "seer.similarity.per-project-rate-limit",
+    type=Dict,
+    default={"limit": 5, "window": 1},
+    flags=FLAG_ALLOW_EMPTY | FLAG_AUTOMATOR_MODIFIABLE,
+)
+
 
 register(
     "issues.similarity-embeddings.projects-allowlist",


### PR DESCRIPTION
This adds both a similarity-service-wide rate limit check and a per-project rate limit check before calling the Seer similarity service during ingestion. The rate limits are based on two new options, `seer.similarity.global-rate-limit` and `seer.similarity.per-project-rate-limit`. 

Note to reviewers: Lacking good intuition about what would make for a reasonable limit, I copied the default values from the Seer severity rate limits. Happy to adjust them, though.