### PR TITLE
fix(metrics): Reset focused series

### DIFF
--- a/static/app/views/metrics/context.tsx
+++ b/static/app/views/metrics/context.tsx
@@ -17,7 +17,11 @@ import {
   emptyMetricsQueryWidget,
   NO_QUERY_ID,
 } from 'sentry/utils/metrics/constants';
-import {MetricExpressionType, type MetricsWidget} from 'sentry/utils/metrics/types';
+import {
+  isMetricsQueryWidget,
+  MetricExpressionType,
+  type MetricsWidget,
+} from 'sentry/utils/metrics/types';
 import {useMetricsMeta} from 'sentry/utils/metrics/useMetricsMeta';
 import type {MetricsSamplesResults} from 'sentry/utils/metrics/useMetricsSamples';
 import {decodeInteger, decodeScalar} from 'sentry/utils/queryString';
@@ -122,6 +126,19 @@ export function useMetricWidgets(mri: MRI) {
     (index: number, data: Partial<Omit<MetricsWidget, 'type'>>) => {
       setWidgets(currentWidgets => {
         const newWidgets = [...currentWidgets];
+        const oldWidget = currentWidgets[index];
+
+        if (isMetricsQueryWidget(oldWidget)) {
+          // Reset focused series if mri, query or groupBy changes
+          if (
+            ('mri' in data && data.mri !== oldWidget.mri) ||
+            ('query' in data && data.query !== oldWidget.query) ||
+            ('groupBy' in data && !isEqual(data.groupBy, oldWidget.groupBy))
+          ) {
+            data.focusedSeries = undefined;
+          }
+        }
+
         newWidgets[index] = {
           ...currentWidgets[index],
           ...data,

--- a/static/app/views/metrics/queries.tsx
+++ b/static/app/views/metrics/queries.tsx
@@ -186,11 +186,7 @@ function Query({
 
   const handleChange = useCallback(
     (data: Partial<MetricsQuery>) => {
-      const changes: Partial<MetricsQueryWidget> = {...data};
-      if (changes.mri || changes.groupBy) {
-        changes.focusedSeries = undefined;
-      }
-      onChange(index, changes);
+      onChange(index, data);
     },
     [index, onChange]
   );

--- a/static/app/views/metrics/utils/index.spec.tsx
+++ b/static/app/views/metrics/utils/index.spec.tsx
@@ -97,6 +97,24 @@ describe('updateQueryWithSeriesFilter', () => {
     expect(updatedQuery.query).toEqual('project:"1" release:"latest"');
     expect(updatedQuery.groupBy).toEqual(['environment']);
   });
+
+  it('should add an empty filter value', () => {
+    const query = {
+      mri: 'd:transactions/duration@milisecond' as MRI,
+      op: 'count',
+      groupBy: [],
+      query: '',
+    };
+
+    const updatedQuery = updateQueryWithSeriesFilter(
+      query,
+      {project: ''},
+      MetricSeriesFilterUpdateType.ADD
+    );
+
+    expect(updatedQuery.query).toEqual('project:""');
+    expect(updatedQuery.groupBy).toEqual([]);
+  });
 });
 
 describe('ensureQuotedTextFilters', () => {

--- a/static/app/views/metrics/utils/index.tsx
+++ b/static/app/views/metrics/utils/index.tsx
@@ -5,6 +5,7 @@ import {
   type SearchConfig,
   Token,
 } from 'sentry/components/searchSyntax/parser';
+import {defined} from 'sentry/utils';
 import {
   MetricSeriesFilterUpdateType,
   type MetricsQuery,
@@ -93,7 +94,7 @@ export function updateQueryWithSeriesFilter(
 
   const groupByEntries = Object.entries(groupBys);
   groupByEntries.forEach(([key, value]) => {
-    if (!value) {
+    if (!defined(value)) {
       return;
     }
     updateType === MetricSeriesFilterUpdateType.ADD


### PR DESCRIPTION
Centralize reset logic for focused series in the metrics context.
Fix adding empty / "none" values of groups to the filter.

Closes https://github.com/getsentry/sentry/issues/71242
Closes https://github.com/getsentry/sentry/issues/69851