### PR TITLE
Remove small insignificant spans

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -831,7 +831,6 @@ def _derive_plugin_tags_many(jobs: Sequence[Job], projects: ProjectsMapping) -> 
                         set_tag(data, key, value)
 
 
-@sentry_sdk.tracing.trace
 def _derive_interface_tags_many(jobs: Sequence[Job]) -> None:
     # XXX: We ought to inline or remove this one for sure
     for job in jobs:
@@ -845,7 +844,6 @@ def _derive_interface_tags_many(jobs: Sequence[Job]) -> None:
                 data.pop(iface.path, None)
 
 
-@sentry_sdk.tracing.trace
 def _materialize_metadata_many(jobs: Sequence[Job]) -> None:
     for job in jobs:
         # we want to freeze not just the metadata and type in but also the

--- a/src/sentry/grouping/strategies/newstyle.py
+++ b/src/sentry/grouping/strategies/newstyle.py
@@ -692,18 +692,14 @@ def chained_exception(
     }
 
     # Filter the exceptions according to rules for handling exception groups.
-    with sentry_sdk.start_span(
-        op="grouping.strategies.newstyle.filter_exceptions_for_exception_groups"
-    ) as span:
-        try:
-            exceptions = filter_exceptions_for_exception_groups(
-                all_exceptions, exception_components, event
-            )
-        except Exception:
-            # We shouldn't have exceptions here. But if we do, just record it and continue with the original list.
-            sentry_sdk.capture_exception()
-            span.set_status("internal_error")
-            exceptions = all_exceptions
+    try:
+        exceptions = filter_exceptions_for_exception_groups(
+            all_exceptions, exception_components, event
+        )
+    except Exception:
+        # We shouldn't have exceptions here. But if we do, just record it and continue with the original list.
+        sentry_sdk.capture_exception()
+        exceptions = all_exceptions
 
     # Case 1: we have a single exception, use the single exception
     # component directly to avoid a level of nesting

--- a/src/sentry/killswitches.py
+++ b/src/sentry/killswitches.py
@@ -13,7 +13,6 @@ from dataclasses import dataclass
 from typing import Any, Optional, Union
 
 import click
-import sentry_sdk
 
 from sentry import options
 from sentry.utils import metrics
@@ -274,7 +273,6 @@ def normalize_value(
     return rv
 
 
-@sentry_sdk.tracing.trace
 def killswitch_matches_context(killswitch_name: str, context: Context, emit_metrics=True) -> bool:
     assert killswitch_name in ALL_KILLSWITCH_OPTIONS
     assert set(ALL_KILLSWITCH_OPTIONS[killswitch_name].fields) == set(context)

--- a/src/sentry/stacktraces/processing.py
+++ b/src/sentry/stacktraces/processing.py
@@ -304,14 +304,13 @@ def normalize_stacktraces_for_grouping(
     stacktrace_frames = []
     stacktrace_containers = []
 
-    with sentry_sdk.start_span(op=op, description="find_stacktraces_in_data"):
-        for stacktrace_info in find_stacktraces_in_data(data, include_raw=True):
-            frames = stacktrace_info.get_frames()
-            if frames:
-                stacktrace_frames.append(frames)
-                stacktrace_containers.append(
-                    stacktrace_info.container if stacktrace_info.is_exception else {}
-                )
+    for stacktrace_info in find_stacktraces_in_data(data, include_raw=True):
+        frames = stacktrace_info.get_frames()
+        if frames:
+            stacktrace_frames.append(frames)
+            stacktrace_containers.append(
+                stacktrace_info.container if stacktrace_info.is_exception else {}
+            )
 
     if not stacktrace_frames:
         return
@@ -339,22 +338,21 @@ def normalize_stacktraces_for_grouping(
 
     # normalize `in_app` values, noting and storing the event's mix of in-app and system frames, so
     # we can track the mix with a metric in cases where this event creates a new group
-    with sentry_sdk.start_span(op=op, description="normalize_in_app_stacktraces"):
-        frame_mixes = {"mixed": 0, "in-app-only": 0, "system-only": 0}
+    frame_mixes = {"mixed": 0, "in-app-only": 0, "system-only": 0}
 
-        for frames in stacktrace_frames:
-            stacktrace_frame_mix = _normalize_in_app(frames)
-            frame_mixes[stacktrace_frame_mix] += 1
+    for frames in stacktrace_frames:
+        stacktrace_frame_mix = _normalize_in_app(frames)
+        frame_mixes[stacktrace_frame_mix] += 1
 
-        event_metadata = data.get("metadata") or {}
-        event_metadata["in_app_frame_mix"] = (
-            "in-app-only"
-            if frame_mixes["in-app-only"] == len(stacktrace_frames)
-            else "system-only"
-            if frame_mixes["system-only"] == len(stacktrace_frames)
-            else "mixed"
-        )
-        data["metadata"] = event_metadata
+    event_metadata = data.get("metadata") or {}
+    event_metadata["in_app_frame_mix"] = (
+        "in-app-only"
+        if frame_mixes["in-app-only"] == len(stacktrace_frames)
+        else "system-only"
+        if frame_mixes["system-only"] == len(stacktrace_frames)
+        else "mixed"
+    )
+    data["metadata"] = event_metadata
 
 
 def _update_frame(frame: dict[str, Any], platform: str | None) -> None:

--- a/src/sentry/tasks/symbolication.py
+++ b/src/sentry/tasks/symbolication.py
@@ -157,19 +157,6 @@ def _do_symbolicate_event(
     project_id = data["project"]
     has_changed = False
 
-    stacktraces = find_stacktraces_in_data(data)
-
-    # Backwards compatibility: If the current platform is JS, we may need to do
-    # native afterwards. Otherwise we don't do anything.
-    if symbolicate_platforms is None:
-        if (
-            task_kind.platform == SymbolicatorPlatform.js
-            and get_native_symbolication_function(data, stacktraces) is not None
-        ):
-            symbolicate_platforms = [SymbolicatorPlatform.native]
-        else:
-            symbolicate_platforms = []
-
     set_current_event_project(project_id)
 
     # check whether the event is in the wrong queue and if so, move it to the other one.
@@ -218,6 +205,7 @@ def _do_symbolicate_event(
         )
 
     try:
+        stacktraces = find_stacktraces_in_data(data)
         symbolication_function = get_symbolication_function_for_platform(
             task_kind.platform, data, stacktraces
         )


### PR DESCRIPTION
Most of the removed spans are well below `1ms`, and they are polluting the trace view without adding any value.