### PR TITLE
chore(insights): Remove "New" from Requests

### DIFF
--- a/static/app/components/sidebar/index.tsx
+++ b/static/app/components/sidebar/index.tsx
@@ -59,10 +59,7 @@ import {
   MODULE_TITLE as CACHE_MODULE_TITLE,
   releaseLevelAsBadgeProps as CacheModuleBadgeProps,
 } from 'sentry/views/performance/cache/settings';
-import {
-  MODULE_TITLE as HTTP_MODULE_TITLE,
-  releaseLevelAsBadgeProps as HTTPModuleBadgeProps,
-} from 'sentry/views/performance/http/settings';
+import {MODULE_TITLE as HTTP_MODULE_TITLE} from 'sentry/views/performance/http/settings';
 import {
   MODULE_TITLE as QUEUES_MODULE_TITLE,
   releaseLevelAsBadgeProps as QueuesModuleBadgeProps,
@@ -295,7 +292,6 @@ function Sidebar() {
                   to={`/organizations/${organization.slug}/${moduleURLBuilder('http')}/`}
                   id="performance-http"
                   icon={<SubitemDot collapsed />}
-                  {...HTTPModuleBadgeProps}
                 />
               </Feature>
               <Feature features="performance-cache-view" organization={organization}>

--- a/static/app/views/performance/http/httpDomainSummaryPage.tsx
+++ b/static/app/views/performance/http/httpDomainSummaryPage.tsx
@@ -3,7 +3,6 @@ import styled from '@emotion/styled';
 
 import Alert from 'sentry/components/alert';
 import ProjectAvatar from 'sentry/components/avatar/projectAvatar';
-import FeatureBadge from 'sentry/components/badge/featureBadge';
 import {Breadcrumbs} from 'sentry/components/breadcrumbs';
 import ButtonBar from 'sentry/components/buttonBar';
 import FeedbackWidgetButton from 'sentry/components/feedback/widget/feedbackWidgetButton';
@@ -35,7 +34,6 @@ import {
   MODULE_DOC_LINK,
   MODULE_TITLE,
   NULL_DOMAIN_DESCRIPTION,
-  RELEASE_LEVEL,
 } from 'sentry/views/performance/http/settings';
 import {
   DomainTransactionsTable,
@@ -183,7 +181,6 @@ export function HTTPDomainSummaryPage() {
             {project && <ProjectAvatar project={project} size={36} />}
             {domain || NULL_DOMAIN_DESCRIPTION}
             <DomainStatusLink domain={domain} />
-            <FeatureBadge type={RELEASE_LEVEL} />
           </Layout.Title>
         </Layout.HeaderContent>
         <Layout.HeaderActions>

--- a/static/app/views/performance/http/httpLandingPage.tsx
+++ b/static/app/views/performance/http/httpLandingPage.tsx
@@ -1,6 +1,5 @@
 import React, {Fragment} from 'react';
 
-import FeatureBadge from 'sentry/components/badge/featureBadge';
 import {Breadcrumbs} from 'sentry/components/breadcrumbs';
 import ButtonBar from 'sentry/components/buttonBar';
 import FeedbackWidgetButton from 'sentry/components/feedback/widget/feedbackWidgetButton';
@@ -28,7 +27,6 @@ import {
   MODULE_DESCRIPTION,
   MODULE_DOC_LINK,
   MODULE_TITLE,
-  RELEASE_LEVEL,
 } from 'sentry/views/performance/http/settings';
 import {
   DomainsTable,
@@ -155,7 +153,6 @@ export function HTTPLandingPage() {
               docsUrl={MODULE_DOC_LINK}
               title={MODULE_DESCRIPTION}
             />
-            <FeatureBadge type={RELEASE_LEVEL} />
           </Layout.Title>
         </Layout.HeaderContent>
         <Layout.HeaderActions>

--- a/static/app/views/performance/http/settings.ts
+++ b/static/app/views/performance/http/settings.ts
@@ -1,4 +1,3 @@
-import type {BadgeType} from 'sentry/components/badge/featureBadge';
 import {t} from 'sentry/locale';
 import {ModuleName} from 'sentry/views/starfish/types';
 
@@ -6,15 +5,6 @@ export const MODULE_TITLE = t('Requests');
 export const BASE_URL = 'http';
 
 export const NULL_DOMAIN_DESCRIPTION = t('Unknown Domain');
-
-export const RELEASE_LEVEL: BadgeType = 'new';
-
-// NOTE: Awkward typing, but without it `RELEASE_LEVEL` is narrowed and the comparison is not allowed
-export const releaseLevelAsBadgeProps = {
-  isAlpha: (RELEASE_LEVEL as BadgeType) === 'alpha',
-  isBeta: (RELEASE_LEVEL as BadgeType) === 'beta',
-  isNew: (RELEASE_LEVEL as BadgeType) === 'new',
-};
 
 export const CHART_HEIGHT = 160;
 export const SPAN_ID_DISPLAY_LENGTH = 16;

--- a/static/app/views/performance/landing/widgets/components/widgetHeader.tsx
+++ b/static/app/views/performance/landing/widgets/components/widgetHeader.tsx
@@ -27,14 +27,11 @@ export function WidgetHeader<T extends WidgetDataConstraint>(
   const isResourcesWidget =
     chartSetting === PerformanceWidgetSetting.MOST_TIME_CONSUMING_RESOURCES;
 
-  const isRequestsWidget =
-    chartSetting === PerformanceWidgetSetting.MOST_TIME_CONSUMING_DOMAINS;
-
   const isCacheWidget =
     chartSetting === PerformanceWidgetSetting.HIGHEST_CACHE_MISS_RATE_TRANSACTIONS;
 
   const featureBadge =
-    isWebVitalsWidget || isResourcesWidget || isRequestsWidget || isCacheWidget ? (
+    isWebVitalsWidget || isResourcesWidget || isCacheWidget ? (
       <FeatureBadge type="new" />
     ) : null;
 


### PR DESCRIPTION
It's been about a month since release, so it seems like a decent time to remove the badge. There's a lot of "new" floating around right now, it's distracting.
