### PR TITLE
fix(metrics): Wrap onboarding panel buttons

### DIFF
--- a/static/app/views/metrics/layout.tsx
+++ b/static/app/views/metrics/layout.tsx
@@ -222,4 +222,5 @@ const EmptyStateImage = styled('img')`
 
 const ButtonList = styled(ButtonBar)`
   grid-template-columns: repeat(auto-fit, minmax(130px, max-content));
+  grid-auto-flow: row;
 `;

--- a/static/app/views/metrics/layout.tsx
+++ b/static/app/views/metrics/layout.tsx
@@ -223,4 +223,5 @@ const EmptyStateImage = styled('img')`
 const ButtonList = styled(ButtonBar)`
   grid-template-columns: repeat(auto-fit, minmax(130px, max-content));
   grid-auto-flow: row;
+  gap: ${space(1)};
 `;


### PR DESCRIPTION
Make the buttons wrap on smaller screens.

<img width="278" alt="Screenshot 2024-05-23 at 16 21 32" src="https://github.com/getsentry/sentry/assets/7033940/ca7ee964-549a-4cf4-ac38-d64e7a8dae16">

