### PR TITLE
chore(hybridcloud) Add service methods to integration service

### DIFF
--- a/src/sentry/services/hybrid_cloud/integration/service.py
+++ b/src/sentry/services/hybrid_cloud/integration/service.py
@@ -11,6 +11,8 @@ from sentry.services.hybrid_cloud.integration import RpcIntegration, RpcOrganiza
 from sentry.services.hybrid_cloud.integration.model import (
     RpcIntegrationExternalProject,
     RpcIntegrationIdentityContext,
+    RpcOrganizationContext,
+    RpcOrganizationContextList,
 )
 from sentry.services.hybrid_cloud.pagination import RpcPaginationArgs, RpcPaginationResult
 from sentry.services.hybrid_cloud.rpc import RpcService, rpc_method
@@ -147,19 +149,32 @@ class IntegrationService(RpcService):
 
     @rpc_method
     @abstractmethod
-    def get_organization_contexts(
+    def organization_context(
+        self,
+        *,
+        organization_id: int,
+        integration_id: int | None = None,
+        provider: str | None = None,
+        external_id: str | None = None,
+    ) -> RpcOrganizationContext:
+        """
+        Returns a tuple of RpcIntegration and RpcOrganizationIntegration. The integration is selected
+        by either integration_id, or a combination of provider and external_id.
+        """
+
+    @rpc_method
+    @abstractmethod
+    def organization_contexts(
         self,
         *,
         organization_id: int | None = None,
         integration_id: int | None = None,
         provider: str | None = None,
         external_id: str | None = None,
-    ) -> tuple[RpcIntegration | None, list[RpcOrganizationIntegration]]:
+    ) -> RpcOrganizationContextList:
         """
         Returns a tuple of RpcIntegration and RpcOrganizationIntegrations. The integrations are selected
         by either integration_id, or a combination of provider and external_id.
-
-        :deprecated: Use organization_contexts() instead.
         """
 
     @rpc_method

--- a/src/sentry/services/hybrid_cloud/integration/service.py
+++ b/src/sentry/services/hybrid_cloud/integration/service.py
@@ -149,6 +149,20 @@ class IntegrationService(RpcService):
 
     @rpc_method
     @abstractmethod
+    def get_organization_contexts(
+        self,
+        *,
+        organization_id: int | None = None,
+        integration_id: int | None = None,
+        provider: str | None = None,
+        external_id: str | None = None,
+    ) -> tuple[RpcIntegration | None, list[RpcOrganizationIntegration]]:
+        """
+        :deprecated: Use organization_contexts() instead.
+        """
+
+    @rpc_method
+    @abstractmethod
     def organization_context(
         self,
         *,


### PR DESCRIPTION
In #71257 I forgot to include the service method stubs. This means the new methods can't be called in a non-local silo mode.

Refs HC-1190