### PR TITLE
feat(insights): Move Insights modules to `/insights/` URL

### DIFF
--- a/static/app/views/performance/settings.ts
+++ b/static/app/views/performance/settings.ts
@@ -1,4 +1,0 @@
-import {t} from 'sentry/locale';
-
-export const INSIGHTS_LABEL = t('Performance');
-export const INSIGHTS_BASE_URL = 'performance';

--- a/static/app/views/performance/utils/useInsightsTitle.tsx
+++ b/static/app/views/performance/utils/useInsightsTitle.tsx
@@ -1,14 +1,17 @@
-import {INSIGHTS_LABEL} from 'sentry/views/performance/settings';
+import {t} from 'sentry/locale';
+import useOrganization from 'sentry/utils/useOrganization';
 import {ModuleName} from 'sentry/views/starfish/types';
 
 type ModuleNameStrings = `${ModuleName}`;
 type TitleableModuleNames = Exclude<ModuleNameStrings, '' | 'other'>;
 
 export function useInsightsTitle(moduleName: TitleableModuleNames) {
-  if (moduleName === ModuleName.AI) {
-    // AI doesn't live under Performance
-    return undefined;
-  }
+  const organization = useOrganization();
 
-  return INSIGHTS_LABEL;
+  // If `insights` flag is present, the top-most title is "Insights". If it's absent, for LLM the topmost title is missing, and for other Insights modules it's "Performance"
+  return organization?.features?.includes('performance-insights')
+    ? t('Insights')
+    : moduleName === ModuleName.AI
+      ? ''
+      : t('Performance');
 }

--- a/static/app/views/performance/utils/useInsightsURL.tsx
+++ b/static/app/views/performance/utils/useInsightsURL.tsx
@@ -1,0 +1,25 @@
+import useOrganization from 'sentry/utils/useOrganization';
+import {ModuleName} from 'sentry/views/starfish/types';
+
+type ModuleNameStrings = `${ModuleName}`;
+type RoutableModuleNames = Exclude<ModuleNameStrings, '' | 'other'>;
+
+export function useInsightsURL(moduleName: RoutableModuleName) {
+  const builder = useInsightsURLBuilder();
+  return builder(moduleName);
+}
+
+type URLBuilder = (moduleName: RoutableModuleNames) => string;
+
+export function useInsightsURLBuilder(): URLBuilder {
+  const organization = useOrganization();
+
+  return function (moduleName: RoutableModuleNames) {
+    // If `insights` flag is present, all Insights modules are routed from `/insights`. If the flag is absent, LLM is routed from `/` and other insights modules are routed of `/performance`
+    return organization?.features?.includes('performance-insights')
+      ? 'insights'
+      : moduleName === ModuleName.AI
+        ? ''
+        : 'performance';
+  };
+}

--- a/static/app/views/performance/utils/useInsightsURL.tsx
+++ b/static/app/views/performance/utils/useInsightsURL.tsx
@@ -12,7 +12,12 @@ export function useInsightsURL(moduleName: RoutableModuleNames) {
 type URLBuilder = (moduleName: RoutableModuleNames) => string;
 
 export function useInsightsURLBuilder(): URLBuilder {
-  const organization = useOrganization();
+  const organization = useOrganization({allowNull: true}); // Some parts of the app, like the main sidebar, render even if the organization isn't available (during loading, or at all).
+
+  if (!organization) {
+    // If there isn't an organization, items that link to modules won't be visible, so this is a fallback just-in-case, and isn't trying too hard to be useful
+    return () => '';
+  }
 
   return function (moduleName: RoutableModuleNames) {
     // If `insights` flag is present, all Insights modules are routed from `/insights`. If the flag is absent, LLM is routed from `/` and other insights modules are routed of `/performance`

--- a/static/app/views/performance/utils/useInsightsURL.tsx
+++ b/static/app/views/performance/utils/useInsightsURL.tsx
@@ -14,11 +14,6 @@ type URLBuilder = (moduleName: RoutableModuleNames) => string;
 export function useInsightsURLBuilder(): URLBuilder {
   const organization = useOrganization({allowNull: true}); // Some parts of the app, like the main sidebar, render even if the organization isn't available (during loading, or at all).
 
-  if (!organization) {
-    // If there isn't an organization, items that link to modules won't be visible, so this is a fallback just-in-case, and isn't trying too hard to be useful
-    return () => '';
-  }
-
   return function (moduleName: RoutableModuleNames) {
     // If `insights` flag is present, all Insights modules are routed from `/insights`. If the flag is absent, LLM is routed from `/` and other insights modules are routed of `/performance`
     return organization?.features?.includes('performance-insights')

--- a/static/app/views/performance/utils/useInsightsURL.tsx
+++ b/static/app/views/performance/utils/useInsightsURL.tsx
@@ -4,7 +4,7 @@ import {ModuleName} from 'sentry/views/starfish/types';
 type ModuleNameStrings = `${ModuleName}`;
 type RoutableModuleNames = Exclude<ModuleNameStrings, '' | 'other'>;
 
-export function useInsightsURL(moduleName: RoutableModuleName) {
+export function useInsightsURL(moduleName: RoutableModuleNames) {
   const builder = useInsightsURLBuilder();
   return builder(moduleName);
 }

--- a/static/app/views/performance/utils/useModuleBreadcrumbs.tsx
+++ b/static/app/views/performance/utils/useModuleBreadcrumbs.tsx
@@ -1,7 +1,8 @@
 import type {Crumb} from 'sentry/components/breadcrumbs';
 import useOrganization from 'sentry/utils/useOrganization';
 import {normalizeUrl} from 'sentry/utils/withDomainRequired';
-import {INSIGHTS_BASE_URL, INSIGHTS_LABEL} from 'sentry/views/performance/settings';
+import {useInsightsTitle} from 'sentry/views/performance/utils/useInsightsTitle';
+import {useInsightsURL} from 'sentry/views/performance/utils/useInsightsURL';
 import {useModuleTitle} from 'sentry/views/performance/utils/useModuleTitle';
 import {useModuleURL} from 'sentry/views/performance/utils/useModuleURL';
 import {ModuleName} from 'sentry/views/starfish/types';
@@ -12,30 +13,44 @@ type RoutableModuleNames = Exclude<ModuleNameStrings, '' | 'other'>;
 export function useModuleBreadcrumbs(moduleName: RoutableModuleNames): Crumb[] {
   const organization = useOrganization();
 
+  const insightsURL = useInsightsURL(moduleName);
+  const insightsTitle = useInsightsTitle(moduleName);
+
   const moduleLabel = useModuleTitle(moduleName);
   const moduleTo = useModuleURL(moduleName);
 
-  // AI Modules lives outside of Performance right now
-  if (moduleName === ModuleName.AI) {
-    return [
-      {
-        label: moduleLabel,
-        to: moduleTo,
-        preservePageFilters: true,
-      },
-    ];
-  }
-
-  return [
-    {
-      label: INSIGHTS_LABEL,
-      to: normalizeUrl(`/organizations/${organization.slug}/${INSIGHTS_BASE_URL}/`),
-      preservePageFilters: true,
-    },
-    {
-      label: moduleLabel,
-      to: moduleTo,
-      preservePageFilters: true,
-    },
-  ];
+  // If `insights` flag is present, the root crumb is "Insights". If it's absent, LLMs base crumb is nothing, and other Insights modules base breadcrumb is "Performance"
+  return organization?.features?.includes('performance-insights')
+    ? [
+        {
+          label: insightsTitle,
+          to: normalizeUrl(`/organizations/${organization.slug}/${insightsURL}/`),
+          preservePageFilters: true,
+        },
+        {
+          label: moduleLabel,
+          to: moduleTo,
+          preservePageFilters: true,
+        },
+      ]
+    : moduleName === ModuleName.AI
+      ? [
+          {
+            label: moduleLabel,
+            to: moduleTo,
+            preservePageFilters: true,
+          },
+        ]
+      : [
+          {
+            label: insightsTitle,
+            to: normalizeUrl(`/organizations/${organization.slug}/${insightsURL}/`),
+            preservePageFilters: true,
+          },
+          {
+            label: moduleLabel,
+            to: moduleTo,
+            preservePageFilters: true,
+          },
+        ];
 }

--- a/static/app/views/performance/utils/useModuleURL.tsx
+++ b/static/app/views/performance/utils/useModuleURL.tsx
@@ -57,10 +57,12 @@ export function useModuleURLBuilder(bare: boolean = false): URLBuilder {
     const insightsURL = insightsURLBuilder(moduleName);
 
     if (moduleName === ModuleName.AI) {
-      // AI Doesn't live under "/performance"
+      // AI Doesn't live under "/performance", which means `insightsURL` might be an empty string, so we need to account for that
+      const moduleURLSegment = [insightsURL, AI_BASE_URL].filter(Boolean).join('/');
+
       return bare
-        ? `${AI_BASE_URL}`
-        : normalizeUrl(`/organizations/${slug}/${AI_BASE_URL}`);
+        ? moduleURLSegment
+        : normalizeUrl(`/organizations/${slug}/${moduleURLSegment}`);
     }
 
     return bare

--- a/static/app/views/performance/utils/useModuleURL.tsx
+++ b/static/app/views/performance/utils/useModuleURL.tsx
@@ -10,7 +10,7 @@ import {BASE_URL as APP_STARTS_BASE_URL} from 'sentry/views/performance/mobile/a
 import {BASE_URL as SCREEN_LOADS_BASE_URL} from 'sentry/views/performance/mobile/screenload/settings';
 import {BASE_URL as MOBILE_UI_BASE_URL} from 'sentry/views/performance/mobile/ui/settings';
 import {BASE_URL as QUEUE_BASE_URL} from 'sentry/views/performance/queues/settings';
-import {INSIGHTS_BASE_URL} from 'sentry/views/performance/settings';
+import {useInsightsURLBuilder} from 'sentry/views/performance/utils/useInsightsURL';
 import {ModuleName} from 'sentry/views/starfish/types';
 
 export const MODULE_BASE_URLS: Record<ModuleName, string> = {
@@ -44,14 +44,18 @@ type URLBuilder = (moduleName: RoutableModuleNames) => string;
 export function useModuleURLBuilder(bare: boolean = false): URLBuilder {
   const organization = useOrganization({allowNull: true}); // Some parts of the app, like the main sidebar, render even if the organization isn't available (during loading, or at all).
 
+  const insightsURLBuilder = useInsightsURLBuilder();
+
   if (!organization) {
     // If there isn't an organization, items that link to modules won't be visible, so this is a fallback just-in-case, and isn't trying too hard to be useful
-    return () => INSIGHTS_BASE_URL;
+    return () => '';
   }
 
   const {slug} = organization;
 
   return function (moduleName: RoutableModuleNames) {
+    const insightsURL = insightsURLBuilder(moduleName);
+
     if (moduleName === ModuleName.AI) {
       // AI Doesn't live under "/performance"
       return bare
@@ -60,9 +64,9 @@ export function useModuleURLBuilder(bare: boolean = false): URLBuilder {
     }
 
     return bare
-      ? `${INSIGHTS_BASE_URL}/${MODULE_BASE_URLS[moduleName]}`
+      ? `${insightsURL}/${MODULE_BASE_URLS[moduleName]}`
       : normalizeUrl(
-          `/organizations/${slug}/${INSIGHTS_BASE_URL}/${MODULE_BASE_URLS[moduleName]}`
+          `/organizations/${slug}/${insightsURL}/${MODULE_BASE_URLS[moduleName]}`
         );
   };
 }


### PR DESCRIPTION
If the `performance-insights` flag is present, direct all links to Insights modules to `/insights/`, and update the page titles and breadcrumbs accordingly.

**e.g.,**
![Screenshot 2024-05-23 at 10 36 05 AM](https://github.com/getsentry/sentry/assets/989898/6d9d456f-3ae3-45c5-b4d6-81cdd262179a)

The complicated logic creates a _somewhat_ uncomfortable intermediate state, so I'll need to remove this shortly after rollout.