### PR TITLE
build(ui): Speed up hot reloading file resolution in getsentry

### DIFF
--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -463,8 +463,12 @@ const appConfig: Configuration = {
       'process/browser': require.resolve('process/browser'),
     },
 
+    // Might be an issue if changing file extensions during development
+    cache: true,
+    // Prefers local modules over node_modules
+    preferAbsolute: true,
     modules: ['node_modules'],
-    extensions: ['.js', '.json', '.ts', '.tsx', '.less'],
+    extensions: ['.js', '.tsx', '.ts', '.json', '.less'],
     symlinks: false,
   },
   output: {


### PR DESCRIPTION
enable [resolve.cache](https://webpack.js.org/configuration/resolve/#resolvecache) and resolve.preferAbsolute in webpack and arrange the extensions so we try .js and .tsx first. This seems to mostly affect getsentry, possibly because it has two node_modules folders to look in.

When updating a file there's this huge "watch" process that seems to iterate all of the files and try to resolve them again (couldn't figure out how to get it to not do that).

before watch is 12s
<img width="1674" alt="image" src="https://github.com/getsentry/sentry/assets/1400464/a1955b00-dc0f-4e53-8d26-68406e83e9aa">

after watch is a normal 170ms
<img width="954" alt="image" src="https://github.com/getsentry/sentry/assets/1400464/b0ee6b7a-1b23-477a-b064-4646a4c1b1a2">

preferAbsolute seems to reduce the files that are attempted during resolution and the cache does the rest of the work

without preferAbsolute
![Screenshot 2024-05-22 at 10 22 15 PM](https://github.com/getsentry/sentry/assets/1400464/80dc1ec7-fc0a-4058-a850-3b6a55e4ef2b)

with preferAbsolute and the new file extension ordering
![Screenshot 2024-05-22 at 10 18 30 PM](https://github.com/getsentry/sentry/assets/1400464/98c67ad7-2698-4bb2-b5b2-7331b024099e)

Measured using this command and waiting for the page to fully load, then changing some text in a file.

```
SENTRY_UI_DEV_ONLY=1 SENTRY_WEBPACK_PROXY_PORT=7999 node --inspect-brk ./node_modules/.bin/webpack serve
```
