### PR TITLE
feat(api): Added `include_feature_flags` Query Param for Organization Details

### DIFF
--- a/src/sentry/api/endpoints/organization_details.py
+++ b/src/sentry/api/endpoints/organization_details.py
@@ -689,9 +689,6 @@ class OrganizationDetailsEndpoint(OrganizationEndpoint):
         """
         This method exists as a way for getsentry to override this endpoint with less duplication.
         """
-        # This param will be used to determine if we should include feature flags in the response
-        include_feature_flags = request.GET.get("include_feature_flags", "0") != "0"
-        (include_feature_flags)
 
         if not request.user.is_authenticated:
             return self.respond({"detail": ERR_NO_USER}, status=401)

--- a/src/sentry/api/endpoints/organization_details.py
+++ b/src/sentry/api/endpoints/organization_details.py
@@ -576,6 +576,10 @@ class OrganizationDetailsEndpoint(OrganizationEndpoint):
         :param string detailed: Specify '0' to retrieve details without projects and teams.
         :auth: required
         """
+        # This param will be used to determine if we should include feature flags in the response
+        include_feature_flags = request.GET.get("include_feature_flags", "0") != "0"
+        (include_feature_flags)
+
         serializer = org_serializers.OrganizationSerializer
 
         if request.access.has_scope("org:read") or is_active_staff(request):
@@ -605,6 +609,10 @@ class OrganizationDetailsEndpoint(OrganizationEndpoint):
         :auth: required
         """
         from sentry import features
+
+        # This param will be used to determine if we should include feature flags in the response
+        include_feature_flags = request.GET.get("include_feature_flags", "0") != "0"
+        (include_feature_flags)
 
         # We don't need to check for staff here b/c the _admin portal uses another endpoint to update orgs
         if request.access.has_scope("org:admin"):
@@ -681,6 +689,10 @@ class OrganizationDetailsEndpoint(OrganizationEndpoint):
         """
         This method exists as a way for getsentry to override this endpoint with less duplication.
         """
+        # This param will be used to determine if we should include feature flags in the response
+        include_feature_flags = request.GET.get("include_feature_flags", "0") != "0"
+        (include_feature_flags)
+
         if not request.user.is_authenticated:
             return self.respond({"detail": ERR_NO_USER}, status=401)
 

--- a/src/sentry/api/endpoints/organization_details.py
+++ b/src/sentry/api/endpoints/organization_details.py
@@ -689,7 +689,6 @@ class OrganizationDetailsEndpoint(OrganizationEndpoint):
         """
         This method exists as a way for getsentry to override this endpoint with less duplication.
         """
-
         if not request.user.is_authenticated:
             return self.respond({"detail": ERR_NO_USER}, status=401)
 

--- a/src/sentry/api/endpoints/organization_details.py
+++ b/src/sentry/api/endpoints/organization_details.py
@@ -578,7 +578,7 @@ class OrganizationDetailsEndpoint(OrganizationEndpoint):
         """
         # This param will be used to determine if we should include feature flags in the response
         include_feature_flags = request.GET.get("include_feature_flags", "0") != "0"
-        (include_feature_flags)
+        (include_feature_flags)  # TODO: Remove this once include_feature_flags is used
 
         serializer = org_serializers.OrganizationSerializer
 
@@ -612,7 +612,7 @@ class OrganizationDetailsEndpoint(OrganizationEndpoint):
 
         # This param will be used to determine if we should include feature flags in the response
         include_feature_flags = request.GET.get("include_feature_flags", "0") != "0"
-        (include_feature_flags)
+        (include_feature_flags)  # TODO: Remove this once include_feature_flags is used
 
         # We don't need to check for staff here b/c the _admin portal uses another endpoint to update orgs
         if request.access.has_scope("org:admin"):

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -325,13 +325,6 @@ register(
     flags=FLAG_ALLOW_EMPTY | FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
 )
 
-register(
-    "api.remove-non-webhook-control-path-gitlab-parser",
-    type=Bool,
-    default=False,
-    flags=FLAG_MODIFIABLE_BOOL | FLAG_AUTOMATOR_MODIFIABLE,
-)
-
 # Controls the rate of using the hashed value of User API tokens for lookups when logging in
 # and also updates tokens which are not hashed
 register(


### PR DESCRIPTION
In this pr I introduce a new query param `include_feature_flags`, which by default will be False. Eventually, api calls will have to pass `include_feature_flags=1` in order to get all the features of the org. 

There will be 2 follow-up prs, one to update the frontend to use this query param, and one to actually implement the logic to using the query param.

Additionally, the `DELETE` method will be updated so it never returns flags.

For: https://github.com/getsentry/team-core-product-foundations/issues/326