### PR TITLE
chore(api) Update API docs for region limitations

### DIFF
--- a/src/sentry/api/endpoints/organization_index.py
+++ b/src/sentry/api/endpoints/organization_index.py
@@ -84,7 +84,8 @@ class OrganizationIndexEndpoint(Endpoint):
     )
     def get(self, request: Request) -> Response:
         """
-        Return a list of organizations available to the authenticated session. This is particularly useful for requests with a user bound context. For API key-based requests this will only return the organization that belongs to the key.
+        Return a list of organizations available to the authenticated session in a region.
+        This is particularly useful for requests with a user bound context. For API key-based requests this will only return the organization that belongs to the key.
         """
         owner_only = request.GET.get("owner") in ("1", "true")
 

--- a/src/sentry/api/endpoints/project_index.py
+++ b/src/sentry/api/endpoints/project_index.py
@@ -21,7 +21,7 @@ from sentry.search.utils import tokenize_query
 @region_silo_endpoint
 class ProjectIndexEndpoint(Endpoint):
     publish_status = {
-        "GET": ApiPublishStatus.UNKNOWN,
+        "GET": ApiPublishStatus.PRIVATE,
     }
     permission_classes = (ProjectPermission,)
 
@@ -31,7 +31,7 @@ class ProjectIndexEndpoint(Endpoint):
         ``````````````````
 
         Return a list of projects available to the authenticated
-        session.
+        session in a region.
 
         :auth: required
         """


### PR DESCRIPTION
The unprefixed /projects and /organizations endpoints are region bound. I've also tried to remove the `/projects` endpoint from the docs as we should be encouraging use of organization scoped endpoints.