### PR TITLE
fix(search-query-builder): Move logic for handling focus setting on backspace/delete to the child elements

### DIFF
--- a/static/app/components/searchQueryBuilder/useQueryBuilderGridItem.tsx
+++ b/static/app/components/searchQueryBuilder/useQueryBuilderGridItem.tsx
@@ -36,12 +36,6 @@ export function useQueryBuilderGridItem(
         if (e.key === 'ArrowLeft') {
           return true;
         }
-        // At start and pressing backspace, focus the next full token
-        if (e.key === 'Backspace') {
-          if (state.collection.getKeyBefore(item.key)) {
-            state.selectionManager.setFocusedKey(state.collection.getKeyBefore(item.key));
-          }
-        }
       }
 
       if (
@@ -52,17 +46,12 @@ export function useQueryBuilderGridItem(
         if (e.key === 'ArrowRight') {
           return true;
         }
-        // At end and pressing delete, focus the previous full token
-        if (e.key === 'Delete') {
-          if (state.collection.getKeyAfter(item.key)) {
-            state.selectionManager.setFocusedKey(state.collection.getKeyAfter(item.key));
-          }
-        }
       }
 
+      // Otherwise, let the input handle the event
       return false;
     },
-    [item.key, state.collection, state.selectionManager]
+    []
   );
 
   const onKeyDownCapture = useCallback(


### PR DESCRIPTION
The handler for backspace/delete events was on the common hook that is used for all tokens, which caused some unexpected behavior for token value inputs. I've moved that logic to the text input token type so that the value inputs can use the default behavior.

Before:

https://github.com/getsentry/sentry/assets/10888943/89c73f43-6d75-4017-bfc7-089849e068a2


After:

https://github.com/getsentry/sentry/assets/10888943/55fa1c90-bf4e-4a96-a014-86f0f14bf0ed

