### PR TITLE
ref(insights): Create widget "View All" links using module URL helper

### DIFF
--- a/static/app/views/performance/landing/widgets/components/widgetContainer.spec.tsx
+++ b/static/app/views/performance/landing/widgets/components/widgetContainer.spec.tsx
@@ -867,6 +867,10 @@ describe('Performance > Widgets > WidgetContainer', function () {
     expect(await screen.findByTestId('performance-widget-title')).toHaveTextContent(
       'Most Time-Consuming Queries'
     );
+    expect(await screen.findByRole('button', {name: 'View All'})).toHaveAttribute(
+      'href',
+      '/organizations/org-slug/performance/database/'
+    );
     expect(eventsMock).toHaveBeenCalledTimes(1);
     expect(eventsMock).toHaveBeenNthCalledWith(
       1,
@@ -909,6 +913,10 @@ describe('Performance > Widgets > WidgetContainer', function () {
     expect(await screen.findByTestId('performance-widget-title')).toHaveTextContent(
       'Most Time-Consuming Domains'
     );
+    expect(await screen.findByRole('button', {name: 'View All'})).toHaveAttribute(
+      'href',
+      '/organizations/org-slug/performance/http/'
+    );
     expect(eventsMock).toHaveBeenCalledTimes(1);
     expect(eventsMock).toHaveBeenNthCalledWith(
       1,
@@ -948,6 +956,10 @@ describe('Performance > Widgets > WidgetContainer', function () {
 
     expect(await screen.findByTestId('performance-widget-title')).toHaveTextContent(
       'Most Time Consuming Resources'
+    );
+    expect(await screen.findByRole('button', {name: 'View All'})).toHaveAttribute(
+      'href',
+      '/organizations/org-slug/performance/browser/resources/'
     );
     expect(eventsMock).toHaveBeenCalledTimes(1);
     expect(eventsMock).toHaveBeenNthCalledWith(
@@ -993,6 +1005,10 @@ describe('Performance > Widgets > WidgetContainer', function () {
 
     expect(await screen.findByTestId('performance-widget-title')).toHaveTextContent(
       'Highest Cache Miss Rates'
+    );
+    expect(await screen.findByRole('button', {name: 'View All'})).toHaveAttribute(
+      'href',
+      '/organizations/org-slug/performance/caches'
     );
     expect(eventsMock).toHaveBeenCalledTimes(1);
     expect(eventsMock).toHaveBeenNthCalledWith(

--- a/static/app/views/performance/landing/widgets/components/widgetContainer.spec.tsx
+++ b/static/app/views/performance/landing/widgets/components/widgetContainer.spec.tsx
@@ -869,7 +869,7 @@ describe('Performance > Widgets > WidgetContainer', function () {
     );
     expect(await screen.findByRole('button', {name: 'View All'})).toHaveAttribute(
       'href',
-      '/organizations/org-slug/performance/database/'
+      '/performance/database/'
     );
     expect(eventsMock).toHaveBeenCalledTimes(1);
     expect(eventsMock).toHaveBeenNthCalledWith(
@@ -915,7 +915,7 @@ describe('Performance > Widgets > WidgetContainer', function () {
     );
     expect(await screen.findByRole('button', {name: 'View All'})).toHaveAttribute(
       'href',
-      '/organizations/org-slug/performance/http/'
+      '/performance/http/'
     );
     expect(eventsMock).toHaveBeenCalledTimes(1);
     expect(eventsMock).toHaveBeenNthCalledWith(
@@ -959,7 +959,7 @@ describe('Performance > Widgets > WidgetContainer', function () {
     );
     expect(await screen.findByRole('button', {name: 'View All'})).toHaveAttribute(
       'href',
-      '/organizations/org-slug/performance/browser/resources/'
+      '/performance/browser/resources/'
     );
     expect(eventsMock).toHaveBeenCalledTimes(1);
     expect(eventsMock).toHaveBeenNthCalledWith(
@@ -1008,7 +1008,7 @@ describe('Performance > Widgets > WidgetContainer', function () {
     );
     expect(await screen.findByRole('button', {name: 'View All'})).toHaveAttribute(
       'href',
-      '/organizations/org-slug/performance/caches'
+      '/performance/caches/'
     );
     expect(eventsMock).toHaveBeenCalledTimes(1);
     expect(eventsMock).toHaveBeenNthCalledWith(

--- a/static/app/views/performance/landing/widgets/widgets/lineChartListWidget.tsx
+++ b/static/app/views/performance/landing/widgets/widgets/lineChartListWidget.tsx
@@ -35,6 +35,7 @@ import {
   UNPARAMETERIZED_TRANSACTION,
 } from 'sentry/views/performance/utils';
 import {getPerformanceDuration} from 'sentry/views/performance/utils/getPerformanceDuration';
+import {useModuleURLBuilder} from 'sentry/views/performance/utils/useModuleURL';
 import {SpanDescriptionCell} from 'sentry/views/starfish/components/tableCells/spanDescriptionCell';
 import {TimeSpentCell} from 'sentry/views/starfish/components/tableCells/timeSpentCell';
 import {ModuleName, SpanFunction, SpanMetricsField} from 'sentry/views/starfish/types';
@@ -781,15 +782,17 @@ export function LineChartListWidget(props: PerformanceWidgetProps) {
         },
       ];
 
+  const moduleURLBuilder = useModuleURLBuilder(true);
+
   const getContainerActions = provided => {
     const route =
       {
-        [PerformanceWidgetSetting.MOST_TIME_SPENT_DB_QUERIES]: 'performance/database/',
+        [PerformanceWidgetSetting.MOST_TIME_SPENT_DB_QUERIES]: moduleURLBuilder('db'),
         [PerformanceWidgetSetting.MOST_TIME_CONSUMING_RESOURCES]:
-          'performance/browser/resources/',
-        [PerformanceWidgetSetting.MOST_TIME_CONSUMING_DOMAINS]: 'performance/http/',
+          moduleURLBuilder('resource'),
+        [PerformanceWidgetSetting.MOST_TIME_CONSUMING_DOMAINS]: moduleURLBuilder('http'),
         [PerformanceWidgetSetting.HIGHEST_CACHE_MISS_RATE_TRANSACTIONS]:
-          CACHE_BASE_URL.slice(1),
+          moduleURLBuilder('cache'),
       }[props.chartSetting] ?? '';
 
     return [
@@ -800,7 +803,7 @@ export function LineChartListWidget(props: PerformanceWidgetProps) {
     ].includes(props.chartSetting) ? (
       <Fragment>
         <div>
-          <LinkButton to={`/organizations/${organization.slug}/${route}`} size="sm">
+          <LinkButton to={`/${route}/`} size="sm">
             {t('View All')}
           </LinkButton>
         </div>


### PR DESCRIPTION
This is the last place I found, I think!

- **Add spec for "View All"**
- **Use route helper**

**e.g.,**
![Screenshot 2024-05-23 at 2 45 37 PM](https://github.com/getsentry/sentry/assets/989898/5b940630-7497-4102-bab6-8c3aaeeceb59)
