### PR TITLE
ref(insights): update onboarding links for caches/queues

### DIFF
--- a/static/app/views/performance/cache/settings.ts
+++ b/static/app/views/performance/cache/settings.ts
@@ -22,13 +22,13 @@ export const BASE_FILTERS: SpanMetricsQueryFilters = {
   'span.op': '[cache.get_item,cache.get]', //  TODO - add more span ops as they become available, we can't use span.module because db.redis is also `cache`
 }; // TODO - Its akward to construct an array here, mutibleSearch should support array values
 
-export const ONBOARDING_CONTENT = {
-  title: t('Start collecting Insights about your Caches!'),
-  description: t('Our robot is waiting to collect your first cache hit.'),
-  link: 'https://develop.sentry.dev/sdk/performance/modules/caches/',
-};
-
 export const MODULE_DESCRIPTION = t(
   'Discover whether your application is utilizing caching effectively and understand the latency associated with cache misses.'
 );
 export const MODULE_DOC_LINK = 'https://docs.sentry.io/product/performance/caches/';
+
+export const ONBOARDING_CONTENT = {
+  title: t('Start collecting Insights about your Caches!'),
+  description: t('Our robot is waiting to collect your first cache hit.'),
+  link: MODULE_DOC_LINK,
+};

--- a/static/app/views/performance/queues/settings.ts
+++ b/static/app/views/performance/queues/settings.ts
@@ -45,14 +45,14 @@ export enum MessageActorType {
   CONSUMER = 'consumer',
 }
 
-export const ONBOARDING_CONTENT = {
-  title: t('Start collecting Insights about your Queues!'),
-  description: t('Our robot is waiting for your first background job to complete.'),
-  link: 'https://develop.sentry.dev/sdk/performance/modules/queues/',
-};
-
 export const MODULE_DESCRIPTION = t(
   'Understand the health and performance impact that queues have on your application and diagnose errors tied to jobs.'
 );
 export const MODULE_DOC_LINK =
   'https://docs.sentry.io/product/performance/queue-monitoring/';
+
+export const ONBOARDING_CONTENT = {
+  title: t('Start collecting Insights about your Queues!'),
+  description: t('Our robot is waiting for your first background job to complete.'),
+  link: MODULE_DOC_LINK,
+};


### PR DESCRIPTION
Use the product doc links for onboarding as it provides more context on what the module does, and it provides links to better and more detailed instrumentation instructions.