### PR TITLE
feat(insights): Redirect module visitors to correct Insights URL

### DIFF
--- a/static/app/views/performance/modulePageProviders.tsx
+++ b/static/app/views/performance/modulePageProviders.tsx
@@ -11,7 +11,6 @@ import useOrganization from 'sentry/utils/useOrganization';
 import {NoAccess} from 'sentry/views/performance/database/noAccess';
 import {useInsightsTitle} from 'sentry/views/performance/utils/useInsightsTitle';
 import {useModuleTitle} from 'sentry/views/performance/utils/useModuleTitle';
-import {useModuleURL} from 'sentry/views/performance/utils/useModuleURL';
 import type {ModuleName} from 'sentry/views/starfish/types';
 
 type ModuleNameStrings = `${ModuleName}`;
@@ -28,7 +27,6 @@ export function ModulePageProviders({moduleName, pageTitle, children, features}:
   const organization = useOrganization();
   const location = useLocation();
   const navigate = useNavigate();
-  const moduleURL = useModuleURL(moduleName);
 
   const insightsTitle = useInsightsTitle(moduleName);
   const moduleTitle = useModuleTitle(moduleName);
@@ -42,13 +40,13 @@ export function ModulePageProviders({moduleName, pageTitle, children, features}:
   useEffect(() => {
     // If the Insights feature is enabled, redirect users to the `/insights/` equivalent URL!
     if (areInsightsEnabled && !isOnInsightsRoute) {
-      navigate(`${moduleURL}/?${qs.stringify(location.query)}`);
+      const newPathname = location.pathname.replace(/\/performance\//g, '/insights/');
+      navigate(`${newPathname}?${qs.stringify(location.query)}`);
     }
   }, [
     navigate,
+    location.pathname,
     location.query,
-    moduleURL,
-    organization.slug,
     areInsightsEnabled,
     isOnInsightsRoute,
   ]);

--- a/static/app/views/performance/modulePageProviders.tsx
+++ b/static/app/views/performance/modulePageProviders.tsx
@@ -42,7 +42,7 @@ export function ModulePageProviders({moduleName, pageTitle, children, features}:
   useEffect(() => {
     // If the Insights feature is enabled, redirect users to the `/insights/` equivalent URL!
     if (areInsightsEnabled && !isOnInsightsRoute) {
-      navigate(`${moduleURL}/${qs.stringify(location.query)}`);
+      navigate(`${moduleURL}/?${qs.stringify(location.query)}`);
     }
   }, [
     navigate,


### PR DESCRIPTION
If the Insight flag is enabled, redirect from `/performance/database` to `/insights/database` and so on. This can't be done with `<Redirect>` components in routes because they have to check a feature flag.
