### PR TITLE
ref: add iso3166 (to replace pycountry)

### DIFF
--- a/requirements-dev-frozen.txt
+++ b/requirements-dev-frozen.txt
@@ -79,6 +79,7 @@ identify==2.5.24
 idna==2.10
 inflection==0.5.1
 iniconfig==1.1.1
+iso3166==2.1.1
 isodate==0.6.1
 isort==5.10.1
 jmespath==0.10.0

--- a/requirements-frozen.txt
+++ b/requirements-frozen.txt
@@ -63,6 +63,7 @@ httpcore==1.0.2
 httpx==0.25.2
 idna==2.10
 inflection==0.5.1
+iso3166==2.1.1
 isodate==0.6.1
 jmespath==0.10.0
 jsonschema==4.20.0

--- a/requirements-getsentry.txt
+++ b/requirements-getsentry.txt
@@ -7,6 +7,7 @@
 # requirements synchronization across the two repositories
 
 Avalara==20.9.0
+iso3166
 pycountry==17.5.14
 pyvat==1.3.15
 reportlab==4.0.7


### PR DESCRIPTION
for analysis of the country code differences see https://github.com/getsentry/pypi/pull/832

this dependency is unused, but will be used in place of `pycountry` in getsentry in a followup PR

<!-- Describe your PR here. -->