### PR TITLE
feat(autofix): Add more autofix setup analytics

### DIFF
--- a/static/app/components/modals/autofixSetupModal.tsx
+++ b/static/app/components/modals/autofixSetupModal.tsx
@@ -1,4 +1,4 @@
-import {Fragment, useMemo} from 'react';
+import {Fragment, useEffect, useMemo} from 'react';
 import styled from '@emotion/styled';
 
 import type {ModalRenderProps} from 'sentry/actionCreators/modal';
@@ -18,6 +18,8 @@ import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {IconCheckmark, IconGithub} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
+import {trackAnalytics} from 'sentry/utils/analytics';
+import useOrganization from 'sentry/utils/useOrganization';
 
 interface AutofixSetupModalProps extends ModalRenderProps {
   groupId: string;
@@ -240,6 +242,8 @@ function AutofixCodebaseIndexingStep({
           priority="primary"
           size="sm"
           disabled={!canIndex}
+          analyticsEventKey="autofix.index_repositories_clicked"
+          analyticsEventName="Autofix: Index Repositories Clicked"
           onClick={() => {
             startIndexing();
             closeModal();
@@ -305,11 +309,28 @@ function AutofixSetupContent({
   groupId: string;
   projectId: string;
 }) {
+  const organization = useOrganization();
   const {data, hasSuccessfulSetup, isLoading, isError} = useAutofixSetup(
     {groupId},
     // Want to check setup status whenever the user comes back to the tab
     {refetchOnWindowFocus: true}
   );
+
+  useEffect(() => {
+    if (!data) {
+      return;
+    }
+
+    trackAnalytics('autofix.setup_modal_viewed', {
+      groupId,
+      projectId,
+      organization,
+      setup_codebase_index: data.codebaseIndexing.ok,
+      setup_gen_ai_consent: data.genAIConsent.ok,
+      setup_integration: data.integration.ok,
+      setup_write_integration: data.githubWriteIntegration.ok,
+    });
+  }, [data, groupId, organization, projectId]);
 
   if (isLoading) {
     return <LoadingIndicator />;

--- a/static/app/utils/analytics/issueAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/issueAnalyticsEvents.tsx
@@ -47,6 +47,14 @@ interface SetPriorityParams extends CommonGroupAnalyticsData {
 
 export type IssueEventParameters = {
   'actionable_items.expand_clicked': ActionableItemDebugParam;
+  'autofix.setup_modal_viewed': {
+    groupId: string;
+    projectId: string;
+    setup_codebase_index: boolean;
+    setup_gen_ai_consent: boolean;
+    setup_integration: boolean;
+    setup_write_integration: boolean;
+  };
   'device.classification.high.end.android.device': {
     processor_count: number;
     processor_frequency: number;
@@ -282,6 +290,7 @@ export type IssueEventParameters = {
 export type IssueEventKey = keyof IssueEventParameters;
 
 export const issueEventMap: Record<IssueEventKey, string | null> = {
+  'autofix.setup_modal_viewed': 'Autofix: Setup Modal Viewed',
   'event_cause.viewed': null,
   'event_cause.docs_clicked': 'Event Cause Docs Clicked',
   'event_cause.snoozed': 'Event Cause Snoozed',


### PR DESCRIPTION
Adds a setup modal viewed analytic event which will allow us to track more precisely which steps have been completed. Also adds an event to the the codebase index button.