### PR TITLE
fix(tags): Allow filtering by both IPv4 and IPv6 tags on EventUsers

### DIFF
--- a/src/sentry/utils/eventuser.py
+++ b/src/sentry/utils/eventuser.py
@@ -39,7 +39,7 @@ REFERRER = "sentry.utils.eventuser"
 
 SNUBA_KEYWORD_SET = {"id", "username", "email", "ip"}
 # Keyword 'ip' is a special case since we need to handle IPv4/IPv6 differently
-SNUBA_KEYWORD_COLUMN_MAP: Mapping[str, str | None] = {
+SNUBA_KEYWORD_COLUMN_MAP = {
     "id": "user_id",
     "username": "user_name",
     "email": "user_email",
@@ -56,10 +56,6 @@ KEYWORD_MAP = BidirectionalMapping(
         "ip_address": "ip",
     }
 )
-
-SNUBA_COLUMN_COALASCE = {"ip_address_v4": "toIPv4", "ip_address_v6": "toIPv6"}
-
-
 MAX_QUERY_TRIES = 5
 OVERFETCH_FACTOR = 10
 MAX_FETCH_SIZE = 10_000

--- a/src/sentry/utils/eventuser.py
+++ b/src/sentry/utils/eventuser.py
@@ -142,7 +142,7 @@ class EventUser:
             if not isinstance(filter_list, list):
                 raise ValueError(f"{keyword} filter must be a list of values")
             if keyword not in SNUBA_KEYWORD_SET:
-                raise ValueError(f"{keyword} must be one of {', '.join(SNUBA_KEYWORD_SET)}.")
+                continue
             if (snuba_column := SNUBA_KEYWORD_COLUMN_MAP.get(keyword)) is not None:
                 keyword_where_conditions.append(Condition(Column(snuba_column), Op.IN, filter_list))
             elif keyword == "ip":

--- a/src/sentry/utils/eventuser.py
+++ b/src/sentry/utils/eventuser.py
@@ -6,6 +6,7 @@ from collections.abc import Mapping
 from dataclasses import dataclass
 from datetime import datetime
 from functools import cached_property
+from ipaddress import IPv4Address, IPv6Address, ip_address
 from typing import Any
 
 from snuba_sdk import (
@@ -35,14 +36,14 @@ logger = logging.getLogger(__name__)
 
 REFERRER = "sentry.utils.eventuser"
 
-SNUBA_KEYWORD_MAP = BidirectionalMapping(
-    {
-        ("user_id"): "id",
-        ("user_name"): "username",
-        ("user_email"): "email",
-        ("ip_address_v4", "ip_address_v6"): "ip",
-    }
-)
+
+SNUBA_KEYWORD_SET = {"id", "username", "email", "ip"}
+# Keyword 'ip' is a special case since we need to handle IPv4/IPv6 differently
+SNUBA_KEYWORD_COLUMN_MAP: Mapping[str, str | None] = {
+    "id": "user_id",
+    "username": "user_name",
+    "email": "user_email",
+}
 
 # The order of these keys are significant to also indicate priority
 # when used in hashing and determining uniqueness. If you change the order
@@ -57,9 +58,36 @@ KEYWORD_MAP = BidirectionalMapping(
 )
 
 SNUBA_COLUMN_COALASCE = {"ip_address_v4": "toIPv4", "ip_address_v6": "toIPv6"}
+
+
 MAX_QUERY_TRIES = 5
 OVERFETCH_FACTOR = 10
 MAX_FETCH_SIZE = 10_000
+
+
+def get_ip_address_conditions(ip_addresses: list[str]) -> list[Condition]:
+    """
+    Returns a list of Snuba Conditions for filtering a list of mixed IPv4/IPv6 addresses.
+    Silently ignores invalid IP addresses, and applies `Op.IN` to the `ip_address_v4` and/or `ip_address_v6` columns.
+    """
+    ipv4_addresses = []
+    ipv6_addresses = []
+    for ip in ip_addresses:
+        try:
+            valid_ip = ip_address(ip)
+        except ValueError:
+            continue
+        if type(valid_ip) is IPv4Address:
+            ipv4_addresses.append(Function("toIPv4", parameters=[ip]))
+        elif type(valid_ip) is IPv6Address:
+            ipv6_addresses.append(Function("toIPv6", parameters=[ip]))
+
+    conditions = []
+    if len(ipv4_addresses) > 0:
+        conditions.append(Condition(Column("ip_address_v4"), Op.IN, ipv4_addresses))
+    if len(ipv6_addresses) > 0:
+        conditions.append(Condition(Column("ip_address_v6"), Op.IN, ipv6_addresses))
+    return conditions
 
 
 @dataclass
@@ -114,32 +142,15 @@ class EventUser:
         ]
 
         keyword_where_conditions = []
-        for keyword, value in keyword_filters.items():
-            if not isinstance(value, list):
+        for keyword, filter_list in keyword_filters.items():
+            if not isinstance(filter_list, list):
                 raise ValueError(f"{keyword} filter must be a list of values")
-
-            snuba_column = SNUBA_KEYWORD_MAP.get_key(keyword)
-            if isinstance(snuba_column, tuple):
-                for filter_value in value:
-                    keyword_where_conditions.append(
-                        BooleanCondition(
-                            BooleanOp.OR,
-                            [
-                                Condition(
-                                    Column(column),
-                                    Op.IN,
-                                    value
-                                    if SNUBA_COLUMN_COALASCE.get(column, None) is None
-                                    else Function(
-                                        SNUBA_COLUMN_COALASCE.get(column), parameters=[filter_value]
-                                    ),
-                                )
-                                for column in snuba_column
-                            ],
-                        )
-                    )
-            else:
-                keyword_where_conditions.append(Condition(Column(snuba_column), Op.IN, value))
+            if keyword not in SNUBA_KEYWORD_SET:
+                raise ValueError(f"{keyword} must be one of {', '.join(SNUBA_KEYWORD_SET)}.")
+            if (snuba_column := SNUBA_KEYWORD_COLUMN_MAP.get(keyword)) is not None:
+                keyword_where_conditions.append(Condition(Column(snuba_column), Op.IN, filter_list))
+            elif keyword == "ip":
+                keyword_where_conditions.extend(get_ip_address_conditions(filter_list))
 
         if len(keyword_where_conditions) > 1:
             where_conditions.append(

--- a/tests/sentry/utils/test_eventuser.py
+++ b/tests/sentry/utils/test_eventuser.py
@@ -161,7 +161,7 @@ class EventUserTestCase(APITestCase, SnubaTestCase):
         assert eusers[0].ip_address == self.event_2.data.get("user").get("ip_address")
 
     def test_for_projects_query_with_multiple_eventuser_entries_different_ips_query_by_ip(self):
-        for i in range(10):
+        for i in range(5):
             self.store_event(
                 data={
                     "user": {
@@ -186,19 +186,52 @@ class EventUserTestCase(APITestCase, SnubaTestCase):
                 },
                 project_id=self.project.id,
             )
+            self.store_event(
+                data={
+                    "user": {
+                        "id": "gru",
+                        "email": "gru@universal.com",
+                        "username": "gru",
+                        "ip_address": f"2001:0db8:0000:85a3:0000:0000:ac1f:800{i}",
+                    },
+                    "timestamp": iso_format(before_now(seconds=50 + i)),
+                },
+                project_id=self.project.id,
+            )
+            self.store_event(
+                data={
+                    "user": {
+                        "id": "scarlet",
+                        "email": "scarlet@universal.com",
+                        "username": "scarlet",
+                        "ip_address": f"2001:db8:0:85a3::ac1f:{i}008",
+                    },
+                    "timestamp": iso_format(before_now(seconds=60 + i)),
+                },
+                project_id=self.project.id,
+            )
 
         eusers = EventUser.for_projects(
             [self.project],
-            {"ip": ["8.8.8.8", "1.1.1.4"]},
+            {
+                "ip": [
+                    "2001:0db8:0000:85a3:0000:0000:ac1f:3008",
+                    "2001:db8:0:85a3::ac1f:8001",
+                    "8.8.8.4",
+                    "1.1.1.2",
+                ]
+            },
             filter_boolean=BooleanOp.OR,
         )
-        assert len(eusers) == 2
-        assert eusers[0].user_ident == self.event_3.data.get("user").get("id")
-        assert eusers[0].email == self.event_3.data.get("user").get("email")
-        assert eusers[0].ip_address == self.event_3.data.get("user").get("ip_address")
-        assert eusers[1].user_ident == self.event_2.data.get("user").get("id")
-        assert eusers[1].email == self.event_2.data.get("user").get("email")
-        assert eusers[1].ip_address == "1.1.1.4"
+        assert len(eusers) == 4
+        assert eusers[0].email == "nisanthan@sentry.io"
+        assert eusers[0].ip_address == "1.1.1.2"
+        assert eusers[1].email == "minion@universal.com"
+        assert eusers[1].ip_address == "8.8.8.4"
+        assert eusers[2].email == "gru@universal.com"
+        assert eusers[2].ip_address == "2001:db8:0:85a3::ac1f:8001"
+        assert eusers[3].email == "scarlet@universal.com"
+        assert eusers[3].ip_address == "2001:db8:0:85a3::ac1f:3008"
 
     @mock.patch("sentry.analytics.record")
     def test_for_projects_query_with_multiple_eventuser_entries_different_ips_query_by_username(
@@ -223,7 +256,7 @@ class EventUserTestCase(APITestCase, SnubaTestCase):
                         "id": "myminion",
                         "email": "minion@universal.com",
                         "username": "minion",
-                        "ip_address": f"8.8.8.{i}",
+                        "ip_address": f"2001:0db8:0000:85a3:0000:0000:ac1f:800{i}",
                     },
                     "timestamp": iso_format(before_now(seconds=40 + i)),
                 },
@@ -261,8 +294,8 @@ class EventUserTestCase(APITestCase, SnubaTestCase):
                     f"AND user_name IN array('nisanthan', 'minion')\n"
                     f"ORDER BY latest_timestamp DESC",
                     query_try=0,
-                    count_rows_returned=20,
-                    count_rows_filtered=18,
+                    count_rows_returned=21,
+                    count_rows_filtered=19,
                     query_time_ms=0,
                 ),
                 call(
@@ -302,7 +335,7 @@ class EventUserTestCase(APITestCase, SnubaTestCase):
                         "id": "test2",
                         "email": email_2,
                         "username": "test2",
-                        "ip_address": f"8.8.8.{i}",
+                        "ip_address": f"2001:0db8:0000:85a3:0000:0000:ac1f:800{i}",
                     },
                     "timestamp": iso_format(before_now(minutes=60 + i)),
                 },
@@ -326,7 +359,7 @@ class EventUserTestCase(APITestCase, SnubaTestCase):
         assert eusers[0].ip_address == "1.1.1.0"
         assert eusers[1].user_ident == id_2
         assert eusers[1].email == email_2
-        assert eusers[1].ip_address == "8.8.8.5"
+        assert eusers[1].ip_address == "2001:db8:0:85a3::ac1f:8005"
 
         mock_record.assert_has_calls(
             [


### PR DESCRIPTION
Resolves https://github.com/getsentry/sentry/issues/71461

Prior, when filtering by IP, regardless of which type the address was, we'd apply an IPv4 and IPv6 filter (`toIPv4` and `toIPv6`). For v4s this works fine since the `toIPv4` resolves and `toIPv6` allows for passing v4s. When passing in v6s though, `toIPv4` fails loudly and returns a 500 from the API.

Now, we'll just create two conditions (v4 and v6) and add in all the valid IPs for each form of address after validating them as one or the other. The code was also a bit confusing so it got a heavy refactor, and a few test changes.
