### PR TITLE
ref(router): Remove search params from discover table links

### DIFF
--- a/static/app/views/discover/results.spec.tsx
+++ b/static/app/views/discover/results.spec.tsx
@@ -656,7 +656,7 @@ describe('Results', function () {
       // NOTE: This uses a legacy redirect for project event to the issue group event link
       expect(screen.getByRole('link', {name: 'deadbeef'})).toHaveAttribute(
         'href',
-        '/org-slug/project-slug/events/deadbeef/?referrer=discover-events-table?id=1&statsPeriod=24h'
+        '/org-slug/project-slug/events/deadbeef/?id=1&referrer=discover-events-table&statsPeriod=24h'
       );
 
       expect(screen.getByRole('link', {name: 'user.display'})).toHaveAttribute(

--- a/static/app/views/discover/table/tableView.tsx
+++ b/static/app/views/discover/table/tableView.tsx
@@ -210,8 +210,8 @@ function TableView(props: TableViewProps) {
 
         target = {
           // NOTE: This uses a legacy redirect for project event to the issue group event link
-          pathname: `/${organization.slug}/${project}/events/${dataRow.id}/?referrer=discover-events-table`,
-          query: location.query,
+          pathname: `/${organization.slug}/${project}/events/${dataRow.id}/`,
+          query: {...location.query, referrer: 'discover-events-table'},
         };
       }
 
@@ -338,8 +338,8 @@ function TableView(props: TableViewProps) {
 
         target = {
           // NOTE: This uses a legacy redirect for project event to the issue group event link
-          pathname: `/${organization.slug}/${project}/events/${dataRow.id}/?referrer=discover-events-table`,
-          query: location.query,
+          pathname: `/${organization.slug}/${project}/events/${dataRow.id}/`,
+          query: {...location.query, referrer: 'discover-events-table'},
         };
       }
 


### PR DESCRIPTION
React router 6 doesn't let you put query parameters into the pathname