### PR TITLE
fix(similarity): add extra log to backfill

### DIFF
--- a/src/sentry/tasks/backfill_seer_grouping_records.py
+++ b/src/sentry/tasks/backfill_seer_grouping_records.py
@@ -302,7 +302,11 @@ def backfill_seer_grouping_records(
     else:
         logger.info(
             "backfill_seer_snuba_returned_empty_result",
-            extra={"project_id": project.id},
+            extra={
+                "project_id": project.id,
+                "snuba_result": result,
+                "group_id_batch": group_id_batch,
+            },
         )
 
 


### PR DESCRIPTION
in cases where snuba returns an empty result set, add some more logs so we can see what's going on.