### PR TITLE
chore(relay): Enable cardinality limiter by default

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1047,9 +1047,6 @@ register("relay.span-usage-metric", default=False, flags=FLAG_AUTOMATOR_MODIFIAB
 
 # Killswitch for the Relay cardinality limiter, one of `enabled`, `disabled`, `passive`.
 # In `passive` mode Relay's cardinality limiter is active but it does not enforce the limits.
-#
-# Note: To fully enable the cardinality limiter the feature `organizations:relay-cardinality-limiter`
-# needs to be rolled out as well.
 register("relay.cardinality-limiter.mode", default="enabled", flags=FLAG_AUTOMATOR_MODIFIABLE)
 # Override to set a list of limits into passive mode by organization.
 #

--- a/src/sentry/relay/config/__init__.py
+++ b/src/sentry/relay/config/__init__.py
@@ -259,66 +259,63 @@ class CardinalityLimitOption(TypedDict):
 def get_metrics_config(timeout: TimeChecker, project: Project) -> Mapping[str, Any] | None:
     metrics_config = {}
 
-    if features.has("organizations:relay-cardinality-limiter", project.organization):
-        passive_limits = options.get("relay.cardinality-limiter.passive-limits-by-org").get(
-            str(project.organization.id), []
-        )
+    passive_limits = options.get("relay.cardinality-limiter.passive-limits-by-org").get(
+        str(project.organization.id), []
+    )
 
-        existing_ids: set[str] = set()
-        cardinality_limits: list[CardinalityLimit] = []
-        for namespace in CARDINALITY_LIMIT_USE_CASES:
-            timeout.check()
-            option = options.get(
-                f"sentry-metrics.cardinality-limiter.limits.{namespace.value}.per-org"
-            )
-            if not option or not len(option) == 1:
-                # Multiple quotas are not supported
+    existing_ids: set[str] = set()
+    cardinality_limits: list[CardinalityLimit] = []
+    for namespace in CARDINALITY_LIMIT_USE_CASES:
+        timeout.check()
+        option = options.get(f"sentry-metrics.cardinality-limiter.limits.{namespace.value}.per-org")
+        if not option or not len(option) == 1:
+            # Multiple quotas are not supported
+            continue
+
+        quota = option[0]
+        id = namespace.value
+
+        limit: CardinalityLimit = {
+            "id": id,
+            "window": {
+                "windowSeconds": quota["window_seconds"],
+                "granularitySeconds": quota["granularity_seconds"],
+            },
+            "limit": quota["limit"],
+            "scope": "organization",
+            "namespace": namespace.value,
+        }
+        if id in passive_limits:
+            limit["passive"] = True
+        cardinality_limits.append(limit)
+        existing_ids.add(id)
+
+    project_limit_options: list[CardinalityLimitOption] = project.get_option(
+        "relay.cardinality-limiter.limits", []
+    )
+    organization_limit_options: list[CardinalityLimitOption] = project.organization.get_option(
+        "relay.cardinality-limiter.limits", []
+    )
+    option_limit_options: list[CardinalityLimitOption] = options.get(
+        "relay.cardinality-limiter.limits", []
+    )
+
+    for clo in project_limit_options + organization_limit_options + option_limit_options:
+        rollout_rate = clo.get("rollout_rate", 1.0)
+        if (project.organization.id % 100000) / 100000 >= rollout_rate:
+            continue
+
+        try:
+            limit = clo["limit"]
+            if clo["limit"]["id"] in existing_ids:
+                # skip if a limit with the same id already exists
                 continue
-
-            quota = option[0]
-            id = namespace.value
-
-            limit: CardinalityLimit = {
-                "id": id,
-                "window": {
-                    "windowSeconds": quota["window_seconds"],
-                    "granularitySeconds": quota["granularity_seconds"],
-                },
-                "limit": quota["limit"],
-                "scope": "organization",
-                "namespace": namespace.value,
-            }
-            if id in passive_limits:
-                limit["passive"] = True
             cardinality_limits.append(limit)
-            existing_ids.add(id)
+            existing_ids.add(clo["limit"]["id"])
+        except KeyError:
+            pass
 
-        project_limit_options: list[CardinalityLimitOption] = project.get_option(
-            "relay.cardinality-limiter.limits", []
-        )
-        organization_limit_options: list[CardinalityLimitOption] = project.organization.get_option(
-            "relay.cardinality-limiter.limits", []
-        )
-        option_limit_options: list[CardinalityLimitOption] = options.get(
-            "relay.cardinality-limiter.limits", []
-        )
-
-        for clo in project_limit_options + organization_limit_options + option_limit_options:
-            rollout_rate = clo.get("rollout_rate", 1.0)
-            if (project.organization.id % 100000) / 100000 >= rollout_rate:
-                continue
-
-            try:
-                limit = clo["limit"]
-                if clo["limit"]["id"] in existing_ids:
-                    # skip if a limit with the same id already exists
-                    continue
-                cardinality_limits.append(limit)
-                existing_ids.add(clo["limit"]["id"])
-            except KeyError:
-                pass
-
-        metrics_config["cardinalityLimits"] = cardinality_limits
+    metrics_config["cardinalityLimits"] = cardinality_limits
 
     if features.has("organizations:metrics-blocking", project.organization):
         metrics_blocking_state = get_metrics_blocking_state_for_relay_config(project)

--- a/tests/sentry/relay/snapshots/test_config/test_get_project_config/full_config/REGION.pysnap
+++ b/tests/sentry/relay/snapshots/test_config/test_get_project_config/full_config/REGION.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-05-02T21:08:26.482609+00:00'
+created: '2024-05-24T11:29:34.942206+00:00'
 creator: sentry
 source: tests/sentry/relay/test_config.py
 ---
@@ -103,6 +103,43 @@ config:
   groupingConfig:
     enhancements: KLUv_SAYwQAAkwKRs25ld3N0eWxlOjIwMjMtMDEtMTGQ
     id: newstyle:2023-01-11
+  metrics:
+    cardinalityLimits:
+    - id: transactions
+      limit: 10000
+      namespace: transactions
+      scope: organization
+      window:
+        granularitySeconds: 600
+        windowSeconds: 3600
+    - id: sessions
+      limit: 10000
+      namespace: sessions
+      scope: organization
+      window:
+        granularitySeconds: 600
+        windowSeconds: 3600
+    - id: spans
+      limit: 10000
+      namespace: spans
+      scope: organization
+      window:
+        granularitySeconds: 600
+        windowSeconds: 3600
+    - id: custom
+      limit: 10000
+      namespace: custom
+      scope: organization
+      window:
+        granularitySeconds: 600
+        windowSeconds: 3600
+    - id: profiles
+      limit: 10000
+      namespace: profiles
+      scope: organization
+      window:
+        granularitySeconds: 600
+        windowSeconds: 3600
   performanceScore:
     profiles:
     - condition:

--- a/tests/sentry/relay/test_config.py
+++ b/tests/sentry/relay/test_config.py
@@ -967,9 +967,7 @@ def test_project_config_cardinality_limits(default_project, insta_snapshot, pass
         ],
     )
 
-    features = Feature({"organizations:relay-cardinality-limiter": True})
-
-    with override_options(options), features:
+    with override_options(options):
         project_cfg = get_project_config(default_project, full_config=True)
 
         cfg = project_cfg.to_dict()
@@ -1029,9 +1027,7 @@ def test_project_config_cardinality_limits_project_options_override_other_option
         ],
     )
 
-    features = Feature({"organizations:relay-cardinality-limiter": True})
-
-    with override_options(options), features:
+    with override_options(options):
         project_cfg = get_project_config(default_project, full_config=True)
 
         cfg = project_cfg.to_dict()
@@ -1084,9 +1080,7 @@ def test_project_config_cardinality_limits_organization_options_override_options
         ],
     )
 
-    features = Feature({"organizations:relay-cardinality-limiter": True})
-
-    with override_options(options), features:
+    with override_options(options):
         project_cfg = get_project_config(default_project, full_config=True)
 
         cfg = project_cfg.to_dict()

--- a/tests/sentry/relay/test_config.py
+++ b/tests/sentry/relay/test_config.py
@@ -689,10 +689,11 @@ def test_with_blocked_metrics(default_project, feature_flag):
         config = project_config.to_dict()["config"]
         _validate_project_config(config)
 
+        config = config["metrics"]
         if not feature_flag:
-            assert "metrics" not in config
+            assert "deniedNames" not in config
+            assert "deniedTags" not in config
         else:
-            config = config["metrics"]
             assert len(config["deniedNames"]) == 1
             assert len(config["deniedTags"]) == 1
 


### PR DESCRIPTION
Enables Relay's cardinality limiter independent of the feature flag.

The flag is still declared since it is referenced in getsentry. Once this PR is
merged, both can be cleaned up.
