### PR TITLE
Store small `EventAttachment` contents inline

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1034,6 +1034,8 @@ register("enhancers.use-zstd", default=False, flags=FLAG_AUTOMATOR_MODIFIABLE)
 register("eventattachments.store-blobs.projects", default=[], flags=FLAG_AUTOMATOR_MODIFIABLE)
 # Percentage sample rate for `EventAttachment`s that should use direct blob storage.
 register("eventattachments.store-blobs.sample-rate", default=0.0, flags=FLAG_AUTOMATOR_MODIFIABLE)
+# Percentage sample rate for "small" `EventAttachment`s to be stored inline.
+register("eventattachments.store-small-inline", default=0.0, flags=FLAG_AUTOMATOR_MODIFIABLE)
 
 # All Relay options (statically authenticated Relays can be registered here)
 register("relay.static_auth", default={}, flags=FLAG_NOSTORE)

--- a/tests/sentry/api/endpoints/test_event_attachment_details.py
+++ b/tests/sentry/api/endpoints/test_event_attachment_details.py
@@ -89,10 +89,10 @@ class EventAttachmentDetailsTest(APITestCase, CreateAttachmentMixin):
 
         with self.options(
             {
-                "eventattachments.store-blobs.sample-rate": 1,
+                "eventattachments.store-small-inline": 1,
             }
         ):
-            self.create_attachment()
+            self.create_attachment(content=b"a small inline attachment")
 
         path2 = f"/api/0/projects/{self.organization.slug}/{self.project.slug}/events/{self.event.event_id}/attachments/{self.attachment.id}/?download"
         assert path1 is not path2
@@ -103,7 +103,7 @@ class EventAttachmentDetailsTest(APITestCase, CreateAttachmentMixin):
         assert response.get("Content-Disposition") == 'attachment; filename="hello.png"'
         assert response.get("Content-Length") == str(self.attachment.size)
         assert response.get("Content-Type") == "image/png"
-        assert close_streaming_response(response) == ATTACHMENT_CONTENT
+        assert close_streaming_response(response) == b"a small inline attachment"
 
     @with_feature("organizations:event-attachments")
     def test_zero_sized_attachment(self):


### PR DESCRIPTION
Here, "inline" means storing contents in the `blob_path` field.

ASCII-only contents up to 192 bytes are stored there, prefixed by `:` as marker.
