### PR TITLE
chore(trace): Skip flaky suite

### DIFF
--- a/static/app/views/performance/newTraceDetails/trace.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/trace.spec.tsx
@@ -531,7 +531,8 @@ describe('trace view', () => {
     ).toBeInTheDocument();
   });
 
-  describe('pageload', () => {
+  // biome-ignore lint/suspicious/noSkippedTests: Flaky suite times out waiting for `pageloadTestSetup()`
+  describe.skip('pageload', () => {
     it('highlights row at load and sets it as focused', async () => {
       Object.defineProperty(window, 'location', {
         value: {


### PR DESCRIPTION
A few tests in the pageload suite are flaking while waiting for loading state to finish: https://sentry.sentry.io/issues/?project=4857230&query=%22%2Ftransaction-op-%2Fi%22&referrer=issue-list&sort=trends&statsPeriod=30d

Skipping for now.
