### PR TITLE
fix(new-trace): Adding trace data section to drawer.

### DIFF
--- a/static/app/components/events/interfaces/spans/types.tsx
+++ b/static/app/components/events/interfaces/spans/types.tsx
@@ -216,6 +216,7 @@ export enum TickAlignment {
 export type TraceContextType = {
   client_sample_rate?: number;
   count?: number;
+  data?: Record<string, any>;
   description?: string;
   exclusive_time?: number;
   frequency?: number;

--- a/static/app/components/keyValueData/card.tsx
+++ b/static/app/components/keyValueData/card.tsx
@@ -141,7 +141,7 @@ const isReactComponent = (type): type is ReactFCWithProps => {
   );
 };
 
-// Returns an array of children where null/undefind children and children returning null are filtered out.
+// Returns an array of children where null/undefined children and children returning null are filtered out.
 // For example:
 // <Component1/> --> returns a <Card/>
 // {null}

--- a/static/app/components/keyValueData/card.tsx
+++ b/static/app/components/keyValueData/card.tsx
@@ -155,7 +155,7 @@ const filterChildren = (children: ReactNode): ReactNode[] => {
       return renderedChild !== null;
     }
 
-    return child !== null && child !== undefined;
+    return child != null
   });
 };
 

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/styles.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/styles.tsx
@@ -18,8 +18,8 @@ import {Tooltip} from 'sentry/components/tooltip';
 import {IconChevron, IconOpen} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
-import type {KeyValueListData} from 'sentry/types';
-import type {Event} from 'sentry/types/event';
+import type {Event, EventTransaction} from 'sentry/types/event';
+import type {KeyValueListData} from 'sentry/types/group';
 import type {Organization} from 'sentry/types/organization';
 import {formatBytesBase10} from 'sentry/utils';
 import getDuration from 'sentry/utils/duration/getDuration';
@@ -572,6 +572,25 @@ function CopyableCardValueWithLink({
   );
 }
 
+function TraceDataSection({event}: {event: EventTransaction}) {
+  const traceData = event.contexts.trace?.data;
+
+  if (!traceData) {
+    return null;
+  }
+
+  return (
+    <SectionCard
+      items={Object.entries(traceData).map(([key, value]) => ({
+        key,
+        subject: key,
+        value,
+      }))}
+      title={t('Trace Data')}
+    />
+  );
+}
+
 const StyledCopyToClipboardButton = styled(CopyToClipboardButton)`
   transform: translateY(2px);
 `;
@@ -614,6 +633,7 @@ const TraceDrawerComponents = {
   SectionCard,
   CopyableCardValueWithLink,
   EventTags,
+  TraceDataSection,
   SectionCardGroup,
 };
 

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/transaction/index.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/transaction/index.tsx
@@ -11,7 +11,9 @@ import LoadingError from 'sentry/components/loadingError';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {Tooltip} from 'sentry/components/tooltip';
 import {t} from 'sentry/locale';
-import type {EventTransaction, Organization, Project} from 'sentry/types';
+import type {EventTransaction} from 'sentry/types/event';
+import type {Organization} from 'sentry/types/organization';
+import type {Project} from 'sentry/types/project';
 import {useLocation} from 'sentry/utils/useLocation';
 import useProjects from 'sentry/utils/useProjects';
 import {CustomMetricsEventData} from 'sentry/views/metrics/customMetricsEventData';
@@ -142,6 +144,7 @@ export function TransactionNodeDetails({
             projectId={event.projectID}
           />
         ) : null}
+        <TraceDrawerComponents.TraceDataSection event={event} />
       </TraceDrawerComponents.SectionCardGroup>
 
       <Request event={event} />


### PR DESCRIPTION
Adding a trace data section to the trace drawer if `event.contexts.trace.data` exists:
<img width="1298" alt="Screenshot 2024-05-24 at 1 31 56 PM" src="https://github.com/getsentry/sentry/assets/60121741/f1a5c5c8-87a1-479a-9c1e-b46a2878c8af">
