### PR TITLE
Add support to ingest inline attachments

### DIFF
--- a/src/sentry/attachments/base.py
+++ b/src/sentry/attachments/base.py
@@ -51,6 +51,7 @@ class CachedAttachment:
         self._data = data
         self.chunks = chunks
         self._cache = cache
+        self._has_initial_data = data is not UNINITIALIZED_DATA
 
     @classmethod
     def from_upload(cls, file, **kwargs):
@@ -74,6 +75,9 @@ class CachedAttachment:
     def chunk_keys(self):
         assert self.key is not None
         assert self.id is not None
+
+        if self._has_initial_data:
+            return
 
         if self.chunks is None:
             yield ATTACHMENT_UNCHUNKED_DATA_KEY.format(key=self.key, id=self.id)

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -2785,42 +2785,43 @@ def save_attachment(
             project_id=project.id,
             key_id=key_id,
             outcome=Outcome.RATE_LIMITED,
-            reason="Too many attachments ({num_requests}} uploaded in a 5 minute window, will reset at {reset_time}",
+            reason=f"Too many attachments ({num_requests}) uploaded in a 5 minute window, will reset at {reset_time}",
             timestamp=timestamp,
             event_id=event_id,
             category=DataCategory.ATTACHMENT,
             quantity=attachment.size or 1,
         )
-    else:
-        file = EventAttachment.putfile(project.id, attachment)
+        return
 
-        EventAttachment.objects.create(
-            # lookup:
-            project_id=project.id,
-            group_id=group_id,
-            event_id=event_id,
-            # metadata:
-            type=attachment.type,
-            name=attachment.name,
-            content_type=file.content_type,
-            size=file.size,
-            sha1=file.sha1,
-            # storage:
-            file_id=file.file_id,
-            blob_path=file.blob_path,
-        )
+    file = EventAttachment.putfile(project.id, attachment)
 
-        track_outcome(
-            org_id=project.organization_id,
-            project_id=project.id,
-            key_id=key_id,
-            outcome=Outcome.ACCEPTED,
-            reason=None,
-            timestamp=timestamp,
-            event_id=event_id,
-            category=DataCategory.ATTACHMENT,
-            quantity=attachment.size or 1,
-        )
+    EventAttachment.objects.create(
+        # lookup:
+        project_id=project.id,
+        group_id=group_id,
+        event_id=event_id,
+        # metadata:
+        type=attachment.type,
+        name=attachment.name,
+        content_type=file.content_type,
+        size=file.size,
+        sha1=file.sha1,
+        # storage:
+        file_id=file.file_id,
+        blob_path=file.blob_path,
+    )
+
+    track_outcome(
+        org_id=project.organization_id,
+        project_id=project.id,
+        key_id=key_id,
+        outcome=Outcome.ACCEPTED,
+        reason=None,
+        timestamp=timestamp,
+        event_id=event_id,
+        category=DataCategory.ATTACHMENT,
+        quantity=attachment.size or 1,
+    )
 
 
 def save_attachments(cache_key: str | None, attachments: list[Attachment], job: Job) -> None:

--- a/src/sentry/ingest/consumer/processors.py
+++ b/src/sentry/ingest/consumer/processors.py
@@ -279,23 +279,26 @@ def process_individual_attachment(message: IngestMessage, project: Project) -> N
     if event is not None:
         group_id = event.group_id
 
-    attachment = message["attachment"]
-    attachment = attachment_cache.get_from_chunks(
-        key=cache_key, type=attachment.pop("attachment_type"), **attachment
-    )
-    if attachment.type not in ("event.attachment", "event.view_hierarchy"):
-        logger.error("invalid individual attachment type: %s", attachment.type)
-        return
+    attachment_msg = message["attachment"]
+    attachment_type = attachment_msg.pop("attachment_type")
 
-    save_attachment(
-        cache_key,
-        attachment,
-        project,
-        event_id,
-        key_id=None,  # TODO: Inject this from Relay
-        group_id=group_id,
-        start_time=None,  # TODO: Inject this from Relay
+    # NOTE: `get_from_chunks` will avoid the cache if `attachment_msg` contains `data` inline
+    attachment = attachment_cache.get_from_chunks(
+        key=cache_key, type=attachment_type, **attachment_msg
     )
+
+    if attachment_type in ("event.attachment", "event.view_hierarchy"):
+        save_attachment(
+            cache_key,
+            attachment,
+            project,
+            event_id,
+            key_id=None,  # TODO: Inject this from Relay
+            group_id=group_id,
+            start_time=None,  # TODO: Inject this from Relay
+        )
+    else:
+        logger.error("invalid individual attachment type: %s", attachment_type)
 
     attachment.delete()
 


### PR DESCRIPTION
For individual attachments, it is now possible to pass the contents within the `data` property directly instead of needing to do a processing attachments store roundtrip via `attachment_chunk` messages.