### PR TITLE
fix(metrics-extraction): Fix release selection with on-demand

### DIFF
--- a/static/app/utils/performance/contexts/onDemandControl.tsx
+++ b/static/app/utils/performance/contexts/onDemandControl.tsx
@@ -93,6 +93,12 @@ export function isOnDemandMetricWidget(widget: Widget): boolean {
   return true;
 }
 
+/**
+ * On-demand doesn't include 'release'
+ */
+const doesWidgetHaveReleaseConditions = (widget: Widget) =>
+  widget.queries.some(q => q.conditions.includes('release:'));
+
 export const shouldUseOnDemandMetrics = (
   organization: Organization,
   widget: Widget,
@@ -104,6 +110,10 @@ export const shouldUseOnDemandMetrics = (
 
   if (onDemandControlContext?.isControlEnabled) {
     return onDemandControlContext.forceOnDemand;
+  }
+
+  if (doesWidgetHaveReleaseConditions(widget)) {
+    return false;
   }
 
   return isOnDemandMetricWidget(widget);


### PR DESCRIPTION
### Summary
Releases are high cardinality and aren't currently emitted into the tags in on-demand. For now if we detect release selection via conditions we'll opt the widget out. Release conditions should be a provider on the page similar to PageFilters in the future, to disambiguate between conditions saved into the query and conditions coming from controls.
