### PR TITLE
ref(insights): Put each Insights sidebar button into its own variable

### DIFF
--- a/static/app/components/sidebar/index.tsx
+++ b/static/app/components/sidebar/index.tsx
@@ -55,15 +55,9 @@ import useOrganization from 'sentry/utils/useOrganization';
 import useProjects from 'sentry/utils/useProjects';
 import {normalizeUrl} from 'sentry/utils/withDomainRequired';
 import MetricsOnboardingSidebar from 'sentry/views/metrics/ddmOnboarding/sidebar';
-import {
-  MODULE_TITLE as CACHE_MODULE_TITLE,
-  releaseLevelAsBadgeProps as CacheModuleBadgeProps,
-} from 'sentry/views/performance/cache/settings';
-import {MODULE_TITLE as HTTP_MODULE_TITLE} from 'sentry/views/performance/http/settings';
-import {
-  MODULE_TITLE as QUEUES_MODULE_TITLE,
-  releaseLevelAsBadgeProps as QueuesModuleBadgeProps,
-} from 'sentry/views/performance/queues/settings';
+import {releaseLevelAsBadgeProps as CacheModuleBadgeProps} from 'sentry/views/performance/cache/settings';
+import {releaseLevelAsBadgeProps as QueuesModuleBadgeProps} from 'sentry/views/performance/queues/settings';
+import {MODULE_TITLES} from 'sentry/views/performance/utils/useModuleTitle';
 import {useModuleURLBuilder} from 'sentry/views/performance/utils/useModuleURL';
 
 import {ProfilingOnboardingSidebar} from '../profiling/ProfilingOnboarding/profilingOnboardingSidebar';
@@ -248,7 +242,9 @@ function Sidebar() {
     <Feature key="db" features="spans-first-ui" organization={organization}>
       <SidebarItem
         {...sidebarItemProps}
-        label={<GuideAnchor target="performance-database">{t('Queries')}</GuideAnchor>}
+        label={
+          <GuideAnchor target="performance-database">{MODULE_TITLES.db}</GuideAnchor>
+        }
         to={`/organizations/${organization.slug}/${moduleURLBuilder('db')}/`}
         id="performance-database"
         icon={<SubitemDot collapsed />}
@@ -260,7 +256,7 @@ function Sidebar() {
     <Feature key="http" features="spans-first-ui" organization={organization}>
       <SidebarItem
         {...sidebarItemProps}
-        label={<GuideAnchor target="performance-http">{HTTP_MODULE_TITLE}</GuideAnchor>}
+        label={<GuideAnchor target="performance-http">{MODULE_TITLES.http}</GuideAnchor>}
         to={`/organizations/${organization.slug}/${moduleURLBuilder('http')}/`}
         id="performance-http"
         icon={<SubitemDot collapsed />}
@@ -272,7 +268,9 @@ function Sidebar() {
     <Feature key="cache" features="performance-cache-view" organization={organization}>
       <SidebarItem
         {...sidebarItemProps}
-        label={<GuideAnchor target="performance-cache">{CACHE_MODULE_TITLE}</GuideAnchor>}
+        label={
+          <GuideAnchor target="performance-cache">{MODULE_TITLES.cache}</GuideAnchor>
+        }
         to={`/organizations/${organization.slug}/${moduleURLBuilder('cache')}/`}
         id="performance-cache"
         icon={<SubitemDot collapsed />}
@@ -286,7 +284,7 @@ function Sidebar() {
       <SidebarItem
         {...sidebarItemProps}
         label={
-          <GuideAnchor target="performance-webvitals">{t('Web Vitals')}</GuideAnchor>
+          <GuideAnchor target="performance-webvitals">{MODULE_TITLES.vital}</GuideAnchor>
         }
         to={`/organizations/${organization.slug}/${moduleURLBuilder('vital')}/`}
         id="performance-webvitals"
@@ -300,7 +298,7 @@ function Sidebar() {
       <SidebarItem
         {...sidebarItemProps}
         label={
-          <GuideAnchor target="performance-queues">{QUEUES_MODULE_TITLE}</GuideAnchor>
+          <GuideAnchor target="performance-queues">{MODULE_TITLES.queue}</GuideAnchor>
         }
         {...QueuesModuleBadgeProps}
         to={`/organizations/${organization.slug}/${moduleURLBuilder('queue')}/`}
@@ -314,7 +312,7 @@ function Sidebar() {
     <Feature key="screen_load" features="spans-first-ui" organization={organization}>
       <SidebarItem
         {...sidebarItemProps}
-        label={t('Screen Loads')}
+        label={MODULE_TITLES.screen_load}
         to={`/organizations/${organization.slug}/${moduleURLBuilder('screen_load')}/`}
         id="performance-mobile-screens"
         icon={<SubitemDot collapsed />}
@@ -326,7 +324,7 @@ function Sidebar() {
     <Feature key="app_start" features="spans-first-ui" organization={organization}>
       <SidebarItem
         {...sidebarItemProps}
-        label={t('App Starts')}
+        label={MODULE_TITLES.app_start}
         to={`/organizations/${organization.slug}/${moduleURLBuilder('app_start')}/`}
         id="performance-mobile-app-startup"
         icon={<SubitemDot collapsed />}
@@ -342,7 +340,7 @@ function Sidebar() {
     >
       <SidebarItem
         {...sidebarItemProps}
-        label={t('Mobile UI')}
+        label={MODULE_TITLES['mobile-ui']}
         to={`/organizations/${organization.slug}/${moduleURLBuilder('mobile-ui')}/`}
         id="performance-mobile-ui"
         icon={<SubitemDot collapsed />}
@@ -355,7 +353,7 @@ function Sidebar() {
     <Feature key="resource" features="spans-first-ui">
       <SidebarItem
         {...sidebarItemProps}
-        label={<GuideAnchor target="starfish">{t('Resources')}</GuideAnchor>}
+        label={<GuideAnchor target="starfish">{MODULE_TITLES.resource}</GuideAnchor>}
         to={`/organizations/${organization.slug}/${moduleURLBuilder('resource')}/`}
         id="performance-browser-resources"
         icon={<SubitemDot collapsed />}
@@ -381,7 +379,7 @@ function Sidebar() {
       <SidebarItem
         {...sidebarItemProps}
         icon={<IconRobot />}
-        label={t('LLM Monitoring')}
+        label={MODULE_TITLES.ai}
         isAlpha
         variant="short"
         to={`/organizations/${organization.slug}/${moduleURLBuilder('ai')}/`}

--- a/static/app/components/sidebar/index.tsx
+++ b/static/app/components/sidebar/index.tsx
@@ -244,6 +244,154 @@ function Sidebar() {
 
   const moduleURLBuilder = useModuleURLBuilder(true);
 
+  const queries = hasOrganization && (
+    <Feature key="db" features="spans-first-ui" organization={organization}>
+      <SidebarItem
+        {...sidebarItemProps}
+        label={<GuideAnchor target="performance-database">{t('Queries')}</GuideAnchor>}
+        to={`/organizations/${organization.slug}/${moduleURLBuilder('db')}/`}
+        id="performance-database"
+        // collapsed controls whether the dot is visible or not.
+        // We always want it visible for these sidebar items so force it to true.
+        icon={<SubitemDot collapsed />}
+      />
+    </Feature>
+  );
+
+  const requests = hasOrganization && (
+    <Feature key="http" features="spans-first-ui" organization={organization}>
+      <SidebarItem
+        {...sidebarItemProps}
+        label={<GuideAnchor target="performance-http">{HTTP_MODULE_TITLE}</GuideAnchor>}
+        to={`/organizations/${organization.slug}/${moduleURLBuilder('http')}/`}
+        id="performance-http"
+        icon={<SubitemDot collapsed />}
+      />
+    </Feature>
+  );
+
+  const caches = hasOrganization && (
+    <Feature key="cache" features="performance-cache-view" organization={organization}>
+      <SidebarItem
+        {...sidebarItemProps}
+        label={<GuideAnchor target="performance-cache">{CACHE_MODULE_TITLE}</GuideAnchor>}
+        to={`/organizations/${organization.slug}/${moduleURLBuilder('cache')}/`}
+        id="performance-cache"
+        icon={<SubitemDot collapsed />}
+        {...CacheModuleBadgeProps}
+      />
+    </Feature>
+  );
+
+  const webVitals = hasOrganization && (
+    <Feature key="vital" features="spans-first-ui" organization={organization}>
+      <SidebarItem
+        {...sidebarItemProps}
+        label={
+          <GuideAnchor target="performance-webvitals">{t('Web Vitals')}</GuideAnchor>
+        }
+        to={`/organizations/${organization.slug}/${moduleURLBuilder('vital')}/`}
+        id="performance-webvitals"
+        icon={<SubitemDot collapsed />}
+      />
+    </Feature>
+  );
+
+  const queues = hasOrganization && (
+    <Feature key="queue" features="performance-queues-view" organization={organization}>
+      <SidebarItem
+        {...sidebarItemProps}
+        label={
+          <GuideAnchor target="performance-queues">{QUEUES_MODULE_TITLE}</GuideAnchor>
+        }
+        {...QueuesModuleBadgeProps}
+        to={`/organizations/${organization.slug}/${moduleURLBuilder('queue')}/`}
+        id="performance-queues"
+        icon={<SubitemDot collapsed />}
+      />
+    </Feature>
+  );
+
+  const screenLoads = hasOrganization && (
+    <Feature key="screen_load" features="spans-first-ui" organization={organization}>
+      <SidebarItem
+        {...sidebarItemProps}
+        label={t('Screen Loads')}
+        to={`/organizations/${organization.slug}/${moduleURLBuilder('screen_load')}/`}
+        id="performance-mobile-screens"
+        icon={<SubitemDot collapsed />}
+      />
+    </Feature>
+  );
+
+  const appStarts = hasOrganization && (
+    <Feature key="app_start" features="spans-first-ui" organization={organization}>
+      <SidebarItem
+        {...sidebarItemProps}
+        label={t('App Starts')}
+        to={`/organizations/${organization.slug}/${moduleURLBuilder('app_start')}/`}
+        id="performance-mobile-app-startup"
+        icon={<SubitemDot collapsed />}
+      />
+    </Feature>
+  );
+
+  const mobileUI = hasOrganization && (
+    <Feature
+      key="mobile-ui"
+      features={['spans-first-ui', 'starfish-mobile-ui-module']}
+      organization={organization}
+    >
+      <SidebarItem
+        {...sidebarItemProps}
+        label={t('Mobile UI')}
+        to={`/organizations/${organization.slug}/${moduleURLBuilder('mobile-ui')}/`}
+        id="performance-mobile-ui"
+        icon={<SubitemDot collapsed />}
+        isAlpha
+      />
+    </Feature>
+  );
+
+  const resources = hasOrganization && (
+    <Feature key="resource" features="spans-first-ui">
+      <SidebarItem
+        {...sidebarItemProps}
+        label={<GuideAnchor target="starfish">{t('Resources')}</GuideAnchor>}
+        to={`/organizations/${organization.slug}/${moduleURLBuilder('resource')}/`}
+        id="performance-browser-resources"
+        icon={<SubitemDot collapsed />}
+      />
+    </Feature>
+  );
+
+  const traces = hasOrganization && (
+    <Feature features="performance-trace-explorer">
+      <SidebarItem
+        {...sidebarItemProps}
+        label={<GuideAnchor target="traces">{t('Traces')}</GuideAnchor>}
+        to={`/organizations/${organization.slug}/performance/traces/`}
+        id="performance-trace-explorer"
+        icon={<SubitemDot collapsed />}
+        isAlpha
+      />
+    </Feature>
+  );
+
+  const llmMonitoring = hasOrganization && (
+    <Feature features="ai-analytics" organization={organization}>
+      <SidebarItem
+        {...sidebarItemProps}
+        icon={<IconRobot />}
+        label={t('LLM Monitoring')}
+        isAlpha
+        variant="short"
+        to={`/organizations/${organization.slug}/${moduleURLBuilder('ai')}/`}
+        id="llm-monitoring"
+      />
+    </Feature>
+  );
+
   const performance = hasOrganization && (
     <Feature
       hookName="feature-disabled:performance-sidebar-item"
@@ -266,125 +414,16 @@ function Sidebar() {
               id="performance"
               exact={!shouldAccordionFloat}
             >
-              <Feature features="spans-first-ui" organization={organization}>
-                <SidebarItem
-                  {...sidebarItemProps}
-                  label={
-                    <GuideAnchor target="performance-database">
-                      {t('Queries')}
-                    </GuideAnchor>
-                  }
-                  to={`/organizations/${organization.slug}/${moduleURLBuilder('db')}/`}
-                  id="performance-database"
-                  // collapsed controls whether the dot is visible or not.
-                  // We always want it visible for these sidebar items so force it to true.
-                  icon={<SubitemDot collapsed />}
-                />
-              </Feature>
-              <Feature features="spans-first-ui" organization={organization}>
-                <SidebarItem
-                  {...sidebarItemProps}
-                  label={
-                    <GuideAnchor target="performance-http">
-                      {HTTP_MODULE_TITLE}
-                    </GuideAnchor>
-                  }
-                  to={`/organizations/${organization.slug}/${moduleURLBuilder('http')}/`}
-                  id="performance-http"
-                  icon={<SubitemDot collapsed />}
-                />
-              </Feature>
-              <Feature features="performance-cache-view" organization={organization}>
-                <SidebarItem
-                  {...sidebarItemProps}
-                  label={
-                    <GuideAnchor target="performance-cache">
-                      {CACHE_MODULE_TITLE}
-                    </GuideAnchor>
-                  }
-                  to={`/organizations/${organization.slug}/${moduleURLBuilder('cache')}/`}
-                  id="performance-cache"
-                  icon={<SubitemDot collapsed />}
-                  {...CacheModuleBadgeProps}
-                />
-              </Feature>
-              <Feature features="spans-first-ui" organization={organization}>
-                <SidebarItem
-                  {...sidebarItemProps}
-                  label={
-                    <GuideAnchor target="performance-webvitals">
-                      {t('Web Vitals')}
-                    </GuideAnchor>
-                  }
-                  to={`/organizations/${organization.slug}/${moduleURLBuilder('vital')}/`}
-                  id="performance-webvitals"
-                  icon={<SubitemDot collapsed />}
-                />
-              </Feature>
-              <Feature features="performance-queues-view" organization={organization}>
-                <SidebarItem
-                  {...sidebarItemProps}
-                  label={
-                    <GuideAnchor target="performance-queues">
-                      {QUEUES_MODULE_TITLE}
-                    </GuideAnchor>
-                  }
-                  {...QueuesModuleBadgeProps}
-                  to={`/organizations/${organization.slug}/${moduleURLBuilder('queue')}/`}
-                  id="performance-queues"
-                  icon={<SubitemDot collapsed />}
-                />
-              </Feature>
-              <Feature features="spans-first-ui" organization={organization}>
-                <SidebarItem
-                  {...sidebarItemProps}
-                  label={t('Screen Loads')}
-                  to={`/organizations/${organization.slug}/${moduleURLBuilder('screen_load')}/`}
-                  id="performance-mobile-screens"
-                  icon={<SubitemDot collapsed />}
-                />
-              </Feature>
-              <Feature features="spans-first-ui" organization={organization}>
-                <SidebarItem
-                  {...sidebarItemProps}
-                  label={t('App Starts')}
-                  to={`/organizations/${organization.slug}/${moduleURLBuilder('app_start')}/`}
-                  id="performance-mobile-app-startup"
-                  icon={<SubitemDot collapsed />}
-                />
-              </Feature>
-              <Feature
-                features={['spans-first-ui', 'starfish-mobile-ui-module']}
-                organization={organization}
-              >
-                <SidebarItem
-                  {...sidebarItemProps}
-                  label={t('Mobile UI')}
-                  to={`/organizations/${organization.slug}/${moduleURLBuilder('mobile-ui')}/`}
-                  id="performance-mobile-ui"
-                  icon={<SubitemDot collapsed />}
-                  isAlpha
-                />
-              </Feature>
-              <Feature features="spans-first-ui">
-                <SidebarItem
-                  {...sidebarItemProps}
-                  label={<GuideAnchor target="starfish">{t('Resources')}</GuideAnchor>}
-                  to={`/organizations/${organization.slug}/${moduleURLBuilder('resource')}/`}
-                  id="performance-browser-resources"
-                  icon={<SubitemDot collapsed />}
-                />
-              </Feature>
-              <Feature features="performance-trace-explorer">
-                <SidebarItem
-                  {...sidebarItemProps}
-                  label={<GuideAnchor target="traces">{t('Traces')}</GuideAnchor>}
-                  to={`/organizations/${organization.slug}/performance/traces/`}
-                  id="performance-trace-explorer"
-                  icon={<SubitemDot collapsed />}
-                  isAlpha
-                />
-              </Feature>
+              {queries}
+              {requests}
+              {caches}
+              {webVitals}
+              {queues}
+              {screenLoads}
+              {appStarts}
+              {resources}
+              {mobileUI}
+              {traces}
             </SidebarAccordion>
           );
         }
@@ -411,20 +450,6 @@ function Sidebar() {
       to={`/organizations/${organization.slug}/releases/`}
       id="releases"
     />
-  );
-
-  const llmMonitoring = hasOrganization && (
-    <Feature features="ai-analytics" organization={organization}>
-      <SidebarItem
-        {...sidebarItemProps}
-        icon={<IconRobot />}
-        label={t('LLM Monitoring')}
-        isAlpha
-        variant="short"
-        to={`/organizations/${organization.slug}/${moduleURLBuilder('ai')}/`}
-        id="llm-monitoring"
-      />
-    </Feature>
   );
 
   const userFeedback = hasOrganization && (

--- a/static/app/components/sidebar/index.tsx
+++ b/static/app/components/sidebar/index.tsx
@@ -251,8 +251,6 @@ function Sidebar() {
         label={<GuideAnchor target="performance-database">{t('Queries')}</GuideAnchor>}
         to={`/organizations/${organization.slug}/${moduleURLBuilder('db')}/`}
         id="performance-database"
-        // collapsed controls whether the dot is visible or not.
-        // We always want it visible for these sidebar items so force it to true.
         icon={<SubitemDot collapsed />}
       />
     </Feature>

--- a/static/app/views/performance/utils/useModuleTitle.tsx
+++ b/static/app/views/performance/utils/useModuleTitle.tsx
@@ -10,7 +10,7 @@ import {MODULE_TITLE as MOBILE_UI_MODULE_TITLE} from 'sentry/views/performance/m
 import {MODULE_TITLE as QUEUE_MODULE_TITLE} from 'sentry/views/performance/queues/settings';
 import {ModuleName} from 'sentry/views/starfish/types';
 
-const MODULE_TITLES: Record<ModuleName, string> = {
+export const MODULE_TITLES: Record<ModuleName, string> = {
   [ModuleName.DB]: DB_MODULE_TITLE,
   [ModuleName.HTTP]: HTTP_MODULE_TITLE,
   [ModuleName.CACHE]: CACHE_MODULE_TITLE,


### PR DESCRIPTION
Small refactor with no behaviour changes. Getting ready to re-arrange all of these! If you're wondering why the `key` props on each `Feature` look weird, it's because they match the `ModuleName` enum definitions, something I'll clean up soon.