### PR TITLE
fix(spans): Free text search on spans should use globs

### DIFF
--- a/src/sentry/search/events/builder/discover.py
+++ b/src/sentry/search/events/builder/discover.py
@@ -90,7 +90,6 @@ from sentry.utils.validators import INVALID_ID_DETAILS, INVALID_SPAN_ID, WILDCAR
 class BaseQueryBuilder:
     requires_organization_condition: bool = False
     organization_column: str = "organization.id"
-    free_text_key = "message"
     uuid_fields = {"id", "trace", "profile.id", "replay.id"}
     function_alias_prefix: str | None = None
     spans_metrics_builder = False
@@ -207,7 +206,6 @@ class BaseQueryBuilder:
             self.builder_config = config
         if self.builder_config.parser_config_overrides is None:
             self.builder_config.parser_config_overrides = {}
-        self.builder_config.parser_config_overrides["free_text_key"] = self.free_text_key
 
         self.dataset = dataset
 

--- a/src/sentry/search/events/builder/metrics.py
+++ b/src/sentry/search/events/builder/metrics.py
@@ -663,6 +663,8 @@ class MetricsQueryBuilder(QueryBuilder):
         return self.resolve_metric_index(value)
 
     def resolve_tag_key(self, value: str) -> int | str | None:
+        # some tag keys needs to be remapped to a different column name
+        # prior to resolving it via the indexer
         value = self.column_remapping.get(value, value)
 
         if self.use_default_tags:

--- a/src/sentry/search/events/builder/metrics.py
+++ b/src/sentry/search/events/builder/metrics.py
@@ -81,6 +81,8 @@ class MetricsQueryBuilder(QueryBuilder):
 
     organization_column: str = "organization_id"
 
+    column_remapping = {}
+
     def __init__(
         self,
         *args: Any,
@@ -661,6 +663,8 @@ class MetricsQueryBuilder(QueryBuilder):
         return self.resolve_metric_index(value)
 
     def resolve_tag_key(self, value: str) -> int | str | None:
+        value = self.column_remapping.get(value, value)
+
         if self.use_default_tags:
             if value in constants.DEFAULT_METRIC_TAGS:
                 return self.resolve_metric_index(value)

--- a/src/sentry/search/events/builder/spans_indexed.py
+++ b/src/sentry/search/events/builder/spans_indexed.py
@@ -8,7 +8,6 @@ from sentry.search.events.types import SelectType
 
 class SpansIndexedQueryBuilder(QueryBuilder):
     requires_organization_condition = False
-    free_text_key = "span.description"
     uuid_fields = {"transaction.id", "replay.id", "profile.id", "trace"}
 
     def __init__(self, *args, **kwargs):

--- a/src/sentry/search/events/builder/spans_metrics.py
+++ b/src/sentry/search/events/builder/spans_metrics.py
@@ -14,7 +14,12 @@ class SpansMetricsQueryBuilder(MetricsQueryBuilder):
     spans_metrics_builder = True
     has_transaction = False
 
-    column_remapping = {"message": "span.description"}
+    column_remapping = {
+        # We want to remap `message` to `span.description` for the free
+        # text search use case so that it searches the `span.description`
+        # when the user performs a free text search
+        "message": "span.description",
+    }
 
     @property
     def use_default_tags(self) -> bool:

--- a/src/sentry/search/events/builder/spans_metrics.py
+++ b/src/sentry/search/events/builder/spans_metrics.py
@@ -13,7 +13,6 @@ class SpansMetricsQueryBuilder(MetricsQueryBuilder):
     requires_organization_condition = True
     spans_metrics_builder = True
     has_transaction = False
-    free_text_key = "span.description"
 
     @property
     def use_default_tags(self) -> bool:

--- a/src/sentry/search/events/builder/spans_metrics.py
+++ b/src/sentry/search/events/builder/spans_metrics.py
@@ -14,6 +14,8 @@ class SpansMetricsQueryBuilder(MetricsQueryBuilder):
     spans_metrics_builder = True
     has_transaction = False
 
+    column_remapping = {"message": "span.description"}
+
     @property
     def use_default_tags(self) -> bool:
         return False

--- a/src/sentry/search/events/datasets/discover.py
+++ b/src/sentry/search/events/datasets/discover.py
@@ -32,7 +32,6 @@ from sentry.search.events.constants import (
     DEFAULT_PROJECT_THRESHOLD,
     DEFAULT_PROJECT_THRESHOLD_METRIC,
     DEVICE_CLASS_ALIAS,
-    EQUALITY_OPERATORS,
     ERROR_HANDLED_ALIAS,
     ERROR_UNHANDLED_ALIAS,
     FUNCTION_ALIASES,
@@ -1891,36 +1890,7 @@ class DiscoverDatasetConfig(DatasetConfig):
         return None
 
     def _message_filter_converter(self, search_filter: SearchFilter) -> WhereType | None:
-        value = search_filter.value.value
-        if search_filter.value.is_wildcard():
-            # XXX: We don't want the '^$' values at the beginning and end of
-            # the regex since we want to find the pattern anywhere in the
-            # message. Strip off here
-            value = search_filter.value.value[1:-1]
-            return Condition(
-                Function("match", [self.builder.column("message"), f"(?i){value}"]),
-                Op(search_filter.operator),
-                1,
-            )
-        elif value == "":
-            operator = Op.EQ if search_filter.operator == "=" else Op.NEQ
-            return Condition(
-                Function("equals", [self.builder.column("message"), value]), operator, 1
-            )
-        else:
-            if search_filter.is_in_filter:
-                return Condition(
-                    self.builder.column("message"),
-                    Op(search_filter.operator),
-                    value,
-                )
-
-            # make message search case insensitive
-            return Condition(
-                Function("positionCaseInsensitive", [self.builder.column("message"), value]),
-                Op.NEQ if search_filter.operator in EQUALITY_OPERATORS else Op.EQ,
-                0,
-            )
+        return filter_aliases.message_filter_converter(self.builder, search_filter)
 
     def _trace_parent_span_converter(self, search_filter: SearchFilter) -> WhereType | None:
         if search_filter.operator in ("=", "!=") and search_filter.value.value == "":

--- a/src/sentry/search/events/datasets/profile_functions.py
+++ b/src/sentry/search/events/datasets/profile_functions.py
@@ -172,36 +172,7 @@ class ProfileFunctionsDatasetConfig(DatasetConfig):
             )
 
     def _message_filter_converter(self, search_filter: SearchFilter) -> WhereType | None:
-        value = search_filter.value.value
-        if search_filter.value.is_wildcard():
-            # XXX: We don't want the '^$' values at the beginning and end of
-            # the regex since we want to find the pattern anywhere in the
-            # message. Strip off here
-            value = search_filter.value.value[1:-1]
-            return Condition(
-                Function("match", [self.builder.column("message"), f"(?i){value}"]),
-                Op(search_filter.operator),
-                1,
-            )
-        elif value == "":
-            operator = Op.EQ if search_filter.operator == "=" else Op.NEQ
-            return Condition(
-                Function("equals", [self.builder.column("message"), value]), operator, 1
-            )
-        else:
-            if search_filter.is_in_filter:
-                return Condition(
-                    self.builder.column("message"),
-                    Op(search_filter.operator),
-                    value,
-                )
-
-            # make message search case insensitive
-            return Condition(
-                Function("positionCaseInsensitive", [self.builder.column("message"), value]),
-                Op.NEQ if search_filter.operator in EQUALITY_OPERATORS else Op.EQ,
-                0,
-            )
+        return filter_aliases.message_filter_converter(self.builder, search_filter)
 
     def _project_slug_filter_converter(self, search_filter: SearchFilter) -> WhereType | None:
         return filter_aliases.project_slug_converter(self.builder, search_filter)

--- a/src/sentry/search/events/datasets/profiles.py
+++ b/src/sentry/search/events/datasets/profiles.py
@@ -4,13 +4,13 @@ from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 from enum import Enum
 
-from snuba_sdk import Condition, Direction, Op, OrderBy
+from snuba_sdk import Direction, OrderBy
 from snuba_sdk.function import Function
 
 from sentry.api.event_search import SearchFilter
 from sentry.exceptions import InvalidSearchQuery
 from sentry.search.events import builder
-from sentry.search.events.constants import EQUALITY_OPERATORS, PROJECT_ALIAS, PROJECT_NAME_ALIAS
+from sentry.search.events.constants import PROJECT_ALIAS, PROJECT_NAME_ALIAS
 from sentry.search.events.datasets import field_aliases, filter_aliases
 from sentry.search.events.datasets.base import DatasetConfig
 from sentry.search.events.fields import (
@@ -178,36 +178,7 @@ class ProfilesDatasetConfig(DatasetConfig):
         }
 
     def _message_filter_converter(self, search_filter: SearchFilter) -> WhereType | None:
-        value = search_filter.value.value
-        if search_filter.value.is_wildcard():
-            # XXX: We don't want the '^$' values at the beginning and end of
-            # the regex since we want to find the pattern anywhere in the
-            # message. Strip off here
-            value = search_filter.value.value[1:-1]
-            return Condition(
-                Function("match", [self.builder.column("message"), f"(?i){value}"]),
-                Op(search_filter.operator),
-                1,
-            )
-        elif value == "":
-            operator = Op.EQ if search_filter.operator == "=" else Op.NEQ
-            return Condition(
-                Function("equals", [self.builder.column("message"), value]), operator, 1
-            )
-        else:
-            if search_filter.is_in_filter:
-                return Condition(
-                    self.builder.column("message"),
-                    Op(search_filter.operator),
-                    value,
-                )
-
-            # make message search case insensitive
-            return Condition(
-                Function("positionCaseInsensitive", [self.builder.column("message"), value]),
-                Op.NEQ if search_filter.operator in EQUALITY_OPERATORS else Op.EQ,
-                0,
-            )
+        return filter_aliases.message_filter_converter(self.builder, search_filter)
 
     def _project_slug_filter_converter(self, search_filter: SearchFilter) -> WhereType | None:
         return filter_aliases.project_slug_converter(self.builder, search_filter)

--- a/src/sentry/search/events/datasets/spans_indexed.py
+++ b/src/sentry/search/events/datasets/spans_indexed.py
@@ -36,6 +36,7 @@ class SpansIndexedDatasetConfig(DatasetConfig):
         self,
     ) -> Mapping[str, Callable[[SearchFilter], WhereType | None]]:
         return {
+            "message": self._message_filter_converter,
             constants.PROJECT_ALIAS: self._project_slug_filter_converter,
             constants.PROJECT_NAME_ALIAS: self._project_slug_filter_converter,
             constants.DEVICE_CLASS_ALIAS: self._device_class_filter_converter,
@@ -344,6 +345,9 @@ class SpansIndexedDatasetConfig(DatasetConfig):
     @property
     def orderby_converter(self) -> Mapping[str, Callable[[Direction], OrderBy]]:
         return {}
+
+    def _message_filter_converter(self, search_filter: SearchFilter) -> WhereType | None:
+        return filter_aliases.message_filter_converter(self.builder, search_filter)
 
     def _project_slug_filter_converter(self, search_filter: SearchFilter) -> WhereType | None:
         return filter_aliases.project_slug_converter(self.builder, search_filter)

--- a/src/sentry/search/events/datasets/spans_metrics.py
+++ b/src/sentry/search/events/datasets/spans_metrics.py
@@ -31,6 +31,7 @@ class SpansMetricsDatasetConfig(DatasetConfig):
         self,
     ) -> Mapping[str, Callable[[SearchFilter], WhereType | None]]:
         return {
+            "message": self._message_filter_converter,
             constants.SPAN_DOMAIN_ALIAS: self._span_domain_filter_converter,
             constants.DEVICE_CLASS_ALIAS: self._device_class_filter_converter,
         }
@@ -624,6 +625,9 @@ class SpansMetricsDatasetConfig(DatasetConfig):
                 function_converter[alias] = function_converter[name].alias_as(alias)
 
         return function_converter
+
+    def _message_filter_converter(self, search_filter: SearchFilter) -> WhereType | None:
+        return filter_aliases.message_filter_converter(self.builder, search_filter)
 
     def _span_domain_filter_converter(self, search_filter: SearchFilter) -> WhereType | None:
         value = search_filter.value.value

--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -119,6 +119,9 @@ SPAN_COLUMN_MAP = {
     "project.id": "project_id",
     "span.action": "action",
     "span.description": "description",
+    # message also maps to span description but gets special handling
+    # to support wild card searching by default
+    "message": "description",
     "span.domain": "domain",
     # DO NOT directly expose span.duration, we should always use the alias
     # "span.duration": "duration",

--- a/tests/sentry/search/events/builder/test_discover.py
+++ b/tests/sentry/search/events/builder/test_discover.py
@@ -68,6 +68,26 @@ class QueryBuilderTest(TestCase):
         )
         query.get_snql_query().validate()
 
+    def test_free_text_search(self):
+        query = QueryBuilder(
+            Dataset.Discover,
+            self.params,
+            query="foo",
+            selected_columns=["count()"],
+        )
+
+        self.assertCountEqual(
+            query.where,
+            [
+                Condition(
+                    Function("positionCaseInsensitive", [Column("message"), "foo"]),
+                    Op.NEQ,
+                    0,
+                ),
+                *self.default_conditions,
+            ],
+        )
+
     def test_query_without_project_ids(self):
         params: ParamsType = {
             "start": self.params["start"],

--- a/tests/sentry/search/events/builder/test_spans_indexed.py
+++ b/tests/sentry/search/events/builder/test_spans_indexed.py
@@ -144,10 +144,41 @@ def test_where_project(params):
 @pytest.mark.parametrize(
     ["query", "result"],
     [
-        pytest.param("span.op:params test", Condition(Column("description"), Op.EQ, "test")),
-        pytest.param("testing", Condition(Column("description"), Op.EQ, "testing")),
         pytest.param(
-            "span.description:test1 test2", Condition(Column("description"), Op.EQ, "test2")
+            "span.op:params test",
+            Condition(
+                Function("positionCaseInsensitive", [Column("description"), "test"]),
+                Op.NEQ,
+                0,
+            ),
+            id="span.op:params test",
+        ),
+        pytest.param(
+            "testing",
+            Condition(
+                Function("positionCaseInsensitive", [Column("description"), "testing"]),
+                Op.NEQ,
+                0,
+            ),
+            id="testing",
+        ),
+        pytest.param(
+            "span.description:test1 test2",
+            Condition(
+                Function("positionCaseInsensitive", [Column("description"), "test2"]),
+                Op.NEQ,
+                0,
+            ),
+            id="span.description:test1 test2",
+        ),
+        pytest.param(
+            "*testing*",
+            Condition(
+                Function("match", [Column("description"), "(?i).*testing.*"]),
+                Op.EQ,
+                1,
+            ),
+            id="*testing*",
         ),
     ],
 )


### PR DESCRIPTION
Free text search was previously generating exact match conditions. This changes the behaviour to generate glob conditions so we get better matches for these free text searches. One caveat here is that we should expect free text search to be slow on the spans dataset.