### PR TITLE
feat(insights): Add platform selector to app starts

### DIFF
--- a/static/app/views/performance/mobile/appStarts/screenSummary/deviceClassBreakdownBarChart.tsx
+++ b/static/app/views/performance/mobile/appStarts/screenSummary/deviceClassBreakdownBarChart.tsx
@@ -23,6 +23,7 @@ import {COLD_START_TYPE} from 'sentry/views/performance/mobile/appStarts/screenS
 import {YAxis, YAXIS_COLUMNS} from 'sentry/views/performance/mobile/screenload/screens';
 import {useTableQuery} from 'sentry/views/performance/mobile/screenload/screens/screensTable';
 import {transformDeviceClassEvents} from 'sentry/views/performance/mobile/screenload/screens/utils';
+import useCrossPlatformProject from 'sentry/views/performance/mobile/useCrossPlatformProject';
 import {
   PRIMARY_RELEASE_COLOR,
   SECONDARY_RELEASE_COLOR,
@@ -55,12 +56,17 @@ function DeviceClassBreakdownBarChart({
     secondaryRelease,
     isLoading: isReleasesLoading,
   } = useReleaseSelection();
+  const {isProjectCrossPlatform, selectedPlatform} = useCrossPlatformProject();
 
   const startType =
     decodeScalar(location.query[SpanMetricsField.APP_START_TYPE]) ?? COLD_START_TYPE;
   const yAxis =
     YAXIS_COLUMNS[startType === COLD_START_TYPE ? YAxis.COLD_START : YAxis.WARM_START];
   const query = new MutableSearch([...(additionalFilters ?? [])]);
+
+  if (isProjectCrossPlatform) {
+    query.addFilterValue('os.name', selectedPlatform);
+  }
 
   const searchQuery = decodeScalar(locationQuery.query, '');
   if (searchQuery) {

--- a/static/app/views/performance/mobile/appStarts/screenSummary/eventSamples.tsx
+++ b/static/app/views/performance/mobile/appStarts/screenSummary/eventSamples.tsx
@@ -11,6 +11,7 @@ import usePageFilters from 'sentry/utils/usePageFilters';
 import {COLD_START_TYPE} from 'sentry/views/performance/mobile/appStarts/screenSummary/startTypeSelector';
 import {EventSamplesTable} from 'sentry/views/performance/mobile/screenload/screenLoadSpans/eventSamplesTable';
 import {useTableQuery} from 'sentry/views/performance/mobile/screenload/screens/screensTable';
+import useCrossPlatformProject from 'sentry/views/performance/mobile/useCrossPlatformProject';
 import {
   PRIMARY_RELEASE_ALIAS,
   SECONDARY_RELEASE_ALIAS,
@@ -45,6 +46,8 @@ export function EventSamples({
   const {primaryRelease} = useReleaseSelection();
   const cursor = decodeScalar(location.query?.[cursorName]);
 
+  const {isProjectCrossPlatform, selectedPlatform} = useCrossPlatformProject();
+
   const deviceClass = decodeScalar(location.query[SpanMetricsField.DEVICE_CLASS]) ?? '';
   const startType =
     decodeScalar(location.query[SpanMetricsField.APP_START_TYPE]) ?? COLD_START_TYPE;
@@ -68,6 +71,10 @@ export function EventSamples({
     //   startType || `[${COLD_START_TYPE},${WARM_START_TYPE}]`
     // }`,
   ]);
+
+  if (isProjectCrossPlatform) {
+    searchQuery.addFilterValue('os.name', selectedPlatform);
+  }
 
   const sort = decodeSorts(location.query[sortKey])[0] ?? DEFAULT_SORT;
 

--- a/static/app/views/performance/mobile/appStarts/screenSummary/spanOpSelector.tsx
+++ b/static/app/views/performance/mobile/appStarts/screenSummary/spanOpSelector.tsx
@@ -12,6 +12,7 @@ import {COLD_START_TYPE} from 'sentry/views/performance/mobile/appStarts/screenS
 import {TTID_CONTRIBUTING_SPAN_OPS} from 'sentry/views/performance/mobile/screenload/screenLoadSpans/spanOpSelector';
 import {MobileCursors} from 'sentry/views/performance/mobile/screenload/screens/constants';
 import {useTableQuery} from 'sentry/views/performance/mobile/screenload/screens/screensTable';
+import useCrossPlatformProject from 'sentry/views/performance/mobile/useCrossPlatformProject';
 import {SpanMetricsField} from 'sentry/views/starfish/types';
 import {appendReleaseFilters} from 'sentry/views/starfish/utils/releaseComparison';
 
@@ -34,6 +35,7 @@ type Props = {
 export function SpanOpSelector({transaction, primaryRelease, secondaryRelease}: Props) {
   const location = useLocation();
   const {selection} = usePageFilters();
+  const {isProjectCrossPlatform, selectedPlatform} = useCrossPlatformProject();
 
   const value = decodeScalar(location.query[SpanMetricsField.SPAN_OP]) ?? '';
   const appStartType =
@@ -52,6 +54,11 @@ export function SpanOpSelector({transaction, primaryRelease, secondaryRelease}: 
     `span.op:[${APP_START_SPANS.join(',')}]`,
     `app_start_type:${appStartType}`,
   ]);
+
+  if (isProjectCrossPlatform) {
+    searchQuery.addFilterValue('os.name', selectedPlatform);
+  }
+
   const queryStringPrimary = appendReleaseFilters(
     searchQuery,
     primaryRelease,

--- a/static/app/views/performance/mobile/appStarts/screenSummary/spanOperationTable.tsx
+++ b/static/app/views/performance/mobile/appStarts/screenSummary/spanOperationTable.tsx
@@ -30,6 +30,7 @@ import {
 } from 'sentry/views/performance/mobile/appStarts/screenSummary/startTypeSelector';
 import {MobileCursors} from 'sentry/views/performance/mobile/screenload/screens/constants';
 import {useTableQuery} from 'sentry/views/performance/mobile/screenload/screens/screensTable';
+import useCrossPlatformProject from 'sentry/views/performance/mobile/useCrossPlatformProject';
 import {useModuleURL} from 'sentry/views/performance/utils/useModuleURL';
 import {
   PRIMARY_RELEASE_ALIAS,
@@ -60,6 +61,7 @@ export function SpanOperationTable({
   const location = useLocation();
   const {selection} = usePageFilters();
   const organization = useOrganization();
+  const {isProjectCrossPlatform, selectedPlatform} = useCrossPlatformProject();
   const cursor = decodeScalar(location.query?.[MobileCursors.SPANS_TABLE]);
 
   const spanOp = decodeScalar(location.query[SpanMetricsField.SPAN_OP]) ?? '';
@@ -84,6 +86,11 @@ export function SpanOperationTable({
     ...(spanOp ? [`${SpanMetricsField.SPAN_OP}:${spanOp}`] : []),
     ...(deviceClass ? [`${SpanMetricsField.DEVICE_CLASS}:${deviceClass}`] : []),
   ]);
+
+  if (isProjectCrossPlatform) {
+    searchQuery.addFilterValue('os.name', selectedPlatform);
+  }
+
   const queryStringPrimary = appendReleaseFilters(
     searchQuery,
     primaryRelease,

--- a/static/app/views/performance/mobile/appStarts/screenSummary/startDurationWidget.tsx
+++ b/static/app/views/performance/mobile/appStarts/screenSummary/startDurationWidget.tsx
@@ -13,6 +13,7 @@ import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {useLocation} from 'sentry/utils/useLocation';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import {COLD_START_TYPE} from 'sentry/views/performance/mobile/appStarts/screenSummary/startTypeSelector';
+import useCrossPlatformProject from 'sentry/views/performance/mobile/useCrossPlatformProject';
 import {
   PRIMARY_RELEASE_COLOR,
   SECONDARY_RELEASE_COLOR,
@@ -68,6 +69,7 @@ function StartDurationWidget({additionalFilters, chartHeight}: Props) {
     secondaryRelease,
     isLoading: isReleasesLoading,
   } = useReleaseSelection();
+  const {isProjectCrossPlatform, selectedPlatform} = useCrossPlatformProject();
 
   const startType =
     decodeScalar(location.query[SpanMetricsField.APP_START_TYPE]) ?? COLD_START_TYPE;
@@ -76,6 +78,11 @@ function StartDurationWidget({additionalFilters, chartHeight}: Props) {
     ...(startType === COLD_START_TYPE ? COLD_START_CONDITIONS : WARM_START_CONDITIONS),
     ...(additionalFilters ?? []),
   ]);
+
+  if (isProjectCrossPlatform) {
+    query.addFilterValue('os.name', selectedPlatform);
+  }
+
   const queryString = appendReleaseFilters(query, primaryRelease, secondaryRelease);
 
   const {

--- a/static/app/views/performance/mobile/appStarts/screens/averageComparisonChart.tsx
+++ b/static/app/views/performance/mobile/appStarts/screens/averageComparisonChart.tsx
@@ -15,6 +15,7 @@ import {COLD_START_TYPE} from 'sentry/views/performance/mobile/appStarts/screenS
 import {YAxis, YAXIS_COLUMNS} from 'sentry/views/performance/mobile/screenload/screens';
 import {ScreensBarChart} from 'sentry/views/performance/mobile/screenload/screens/screenBarChart';
 import {useTableQuery} from 'sentry/views/performance/mobile/screenload/screens/screensTable';
+import useCrossPlatformProject from 'sentry/views/performance/mobile/useCrossPlatformProject';
 import useTruncatedReleaseNames from 'sentry/views/performance/mobile/useTruncatedRelease';
 import {PRIMARY_RELEASE_COLOR} from 'sentry/views/starfish/colors';
 import {useReleaseSelection} from 'sentry/views/starfish/queries/useReleases';
@@ -58,6 +59,7 @@ export function AverageComparisonChart({chartHeight}: Props) {
     isLoading: isReleasesLoading,
   } = useReleaseSelection();
   const {selection} = usePageFilters();
+  const {isProjectCrossPlatform, selectedPlatform} = useCrossPlatformProject();
 
   const appStartType =
     decodeScalar(location.query[SpanMetricsField.APP_START_TYPE]) ?? COLD_START_TYPE;
@@ -67,6 +69,11 @@ export function AverageComparisonChart({chartHeight}: Props) {
     'transaction.op:ui.load',
     `count_starts(measurements.app_start_${appStartType}):>0`,
   ]);
+
+  if (isProjectCrossPlatform) {
+    query.addFilterValue('os.name', selectedPlatform);
+  }
+
   const queryString = appendReleaseFilters(query, primaryRelease, secondaryRelease);
 
   const newQuery: NewQuery = {

--- a/static/app/views/performance/mobile/appStarts/screens/countChart.tsx
+++ b/static/app/views/performance/mobile/appStarts/screens/countChart.tsx
@@ -14,6 +14,7 @@ import {useLocation} from 'sentry/utils/useLocation';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import {COLD_START_TYPE} from 'sentry/views/performance/mobile/appStarts/screenSummary/startTypeSelector';
 import {OUTPUT_TYPE, YAxis} from 'sentry/views/performance/mobile/screenload/screens';
+import useCrossPlatformProject from 'sentry/views/performance/mobile/useCrossPlatformProject';
 import useTruncatedReleaseNames from 'sentry/views/performance/mobile/useTruncatedRelease';
 import {
   PRIMARY_RELEASE_COLOR,
@@ -67,11 +68,17 @@ export function CountChart({chartHeight}: Props) {
     secondaryRelease,
     isLoading: isReleasesLoading,
   } = useReleaseSelection();
+  const {isProjectCrossPlatform, selectedPlatform} = useCrossPlatformProject();
 
   const appStartType =
     decodeScalar(location.query[SpanMetricsField.APP_START_TYPE]) ?? COLD_START_TYPE;
 
   const query = new MutableSearch([`span.op:app.start.${appStartType}`]);
+
+  if (isProjectCrossPlatform) {
+    query.addFilterValue('os.name', selectedPlatform);
+  }
+
   const queryString = `${appendReleaseFilters(
     query,
     primaryRelease,

--- a/static/app/views/performance/mobile/appStarts/screens/index.tsx
+++ b/static/app/views/performance/mobile/appStarts/screens/index.tsx
@@ -29,6 +29,7 @@ import {
 import {ScreensBarChart} from 'sentry/views/performance/mobile/screenload/screens/screenBarChart';
 import {useTableQuery} from 'sentry/views/performance/mobile/screenload/screens/screensTable';
 import {transformReleaseEvents} from 'sentry/views/performance/mobile/screenload/screens/utils';
+import useCrossPlatformProject from 'sentry/views/performance/mobile/useCrossPlatformProject';
 import useTruncatedReleaseNames from 'sentry/views/performance/mobile/useTruncatedRelease';
 import {getTransactionSearchQuery} from 'sentry/views/performance/utils';
 import {useReleaseSelection} from 'sentry/views/starfish/queries/useReleases';
@@ -57,6 +58,7 @@ function AppStartup({additionalFilters, chartHeight}: Props) {
     isLoading: isReleasesLoading,
   } = useReleaseSelection();
   const {truncatedPrimaryRelease, truncatedSecondaryRelease} = useTruncatedReleaseNames();
+  const {isProjectCrossPlatform, selectedPlatform} = useCrossPlatformProject();
 
   const router = useRouter();
 
@@ -69,6 +71,10 @@ function AppStartup({additionalFilters, chartHeight}: Props) {
     `count_starts(measurements.app_start_${appStartType}):>0`,
     ...(additionalFilters ?? []),
   ]);
+
+  if (isProjectCrossPlatform) {
+    query.addFilterValue('os.name', selectedPlatform);
+  }
 
   const searchQuery = decodeScalar(locationQuery.query, '');
   if (searchQuery) {

--- a/static/app/views/performance/mobile/appStarts/screens/index.tsx
+++ b/static/app/views/performance/mobile/appStarts/screens/index.tsx
@@ -124,6 +124,10 @@ function AppStartup({additionalFilters, chartHeight}: Props) {
     ...(additionalFilters ?? []),
   ]);
 
+  if (isProjectCrossPlatform) {
+    topEventsQuery.addFilterValue('os.name', selectedPlatform);
+  }
+
   const topEventsQueryString = `${appendReleaseFilters(
     topEventsQuery,
     primaryRelease,

--- a/static/app/views/performance/mobile/components/screensTemplate.tsx
+++ b/static/app/views/performance/mobile/components/screensTemplate.tsx
@@ -22,6 +22,8 @@ import {
   MODULE_DESCRIPTION,
   MODULE_DOC_LINK,
 } from 'sentry/views/performance/mobile/appStarts/settings';
+import {PlatformSelector} from 'sentry/views/performance/mobile/screenload/screens/platformSelector';
+import useCrossPlatformProject from 'sentry/views/performance/mobile/useCrossPlatformProject';
 import Onboarding from 'sentry/views/performance/onboarding';
 import {useModuleBreadcrumbs} from 'sentry/views/performance/utils/useModuleBreadcrumbs';
 import {ReleaseComparisonSelector} from 'sentry/views/starfish/components/releaseSelector';
@@ -43,6 +45,7 @@ export default function ScreensTemplate({
   const organization = useOrganization();
   const onboardingProject = useOnboardingProject();
   const location = useLocation();
+  const {isProjectCrossPlatform} = useCrossPlatformProject();
 
   const handleProjectChange = useCallback(() => {
     browserHistory.replace({
@@ -71,6 +74,7 @@ export default function ScreensTemplate({
           </Layout.HeaderContent>
           <Layout.HeaderActions>
             <ButtonBar gap={1}>
+              {isProjectCrossPlatform && <PlatformSelector />}
               <FeedbackWidgetButton />
             </ButtonBar>
           </Layout.HeaderActions>


### PR DESCRIPTION
Flutter has support for App Starts which means we need to add a platform selector to tweeze out the differences by device.

This PR uses the `useCrossPlatformProject` to pull whether a cross platform project is selected and if it is, show the selector next to the feedback button in header as well as pass along the selected value through the components that execute queries.

Note: Currently "flutter" is supported, so to test in the UI you can select a flutter project and see the selector:

<img width="1451" alt="Screenshot 2024-05-27 at 3 28 39 PM" src="https://github.com/getsentry/sentry/assets/22846452/9aafd3c0-861a-4794-835b-ffef68b05225">
