### PR TITLE
chore(billing): Remove slack-overage-notifications from frontend

### DIFF
--- a/static/app/views/settings/account/notifications/constants.tsx
+++ b/static/app/views/settings/account/notifications/constants.tsx
@@ -93,10 +93,6 @@ export const CONFIRMATION_MESSAGE = (
 export const NOTIFICATION_FEATURE_MAP: Partial<
   Record<NotificationSettingsType, string | Array<string>>
 > = {
-  quota: [
-    'slack-overage-notifications',
-    'spend-visibility-notifications',
-    'user-spend-notifications-settings',
-  ],
+  quota: ['spend-visibility-notifications', 'user-spend-notifications-settings'],
   spikeProtection: 'spike-projections',
 };


### PR DESCRIPTION
With the introduction of the `user-spend-notifications-settings` feature in https://github.com/getsentry/sentry/pull/71298, we can disconnect the `slack-overage-notifications` feature on frontend.