### PR TITLE
fix(insights): Fix horizontal alignment of sidebar feature badge against the power icon

### DIFF
--- a/static/app/components/sidebar/sidebarItem.tsx
+++ b/static/app/components/sidebar/sidebarItem.tsx
@@ -234,7 +234,7 @@ function SidebarItem({
               isNested={isNested}
             >
               <LabelHook id={id}>
-                <TextOverflow>{label}</TextOverflow>
+                <TruncatedLabel>{label}</TruncatedLabel>
                 {badges}
               </LabelHook>
             </SidebarItemLabel>
@@ -441,8 +441,11 @@ const SidebarItemLabel = styled('span')<{
   flex: 1;
   display: flex;
   align-items: flex-start;
-  justify-content: space-between;
   overflow: hidden;
+`;
+
+const TruncatedLabel = styled(TextOverflow)`
+  margin-right: auto;
 `;
 
 const getCollapsedBadgeStyle = ({collapsed, theme}) => {


### PR DESCRIPTION
**Before (Jank):**
<img width="225" alt="Screenshot 2024-05-27 at 4 50 45 PM" src="https://github.com/getsentry/sentry/assets/989898/95a4d3b7-abcc-49d4-898a-64f6109a3d6c">
<img width="226" alt="Screenshot 2024-05-27 at 4 52 42 PM" src="https://github.com/getsentry/sentry/assets/989898/20e828a5-cce8-4a0c-9641-93db1df2bb40">

**After (Class):**
<img width="226" alt="Screenshot 2024-05-27 at 4 50 55 PM" src="https://github.com/getsentry/sentry/assets/989898/57bed1c9-477d-49e1-8309-9b2d2053f992">
<img width="223" alt="Screenshot 2024-05-27 at 4 52 32 PM" src="https://github.com/getsentry/sentry/assets/989898/1fbe899a-11f8-4119-84ea-eaa020c90675">

I'll fix vertical alignment separately, that has to happen in `getsentry`
