### PR TITLE
fix(sdk-crashes): Ignore Dart SDK function

### DIFF
--- a/fixtures/sdk_crash_detection/crash_event_dart.py
+++ b/fixtures/sdk_crash_detection/crash_event_dart.py
@@ -3,8 +3,7 @@ from collections.abc import Mapping, MutableMapping, Sequence
 
 
 def get_frames(
-    sdk_frame_abs_path: str,
-    system_frame_abs_path: str,
+    sdk_frame_abs_path: str, system_frame_abs_path: str, sdk_function: str
 ) -> Sequence[MutableMapping[str, str]]:
     frames = [
         {
@@ -26,7 +25,7 @@ def get_frames(
             "abs_path": "package:sentry_flutter_example/main.dart",
         },
         {
-            "function": "SentryTracer.setTag",
+            "function": sdk_function,
             "filename": "sentry_tracer.dart",
             "abs_path": sdk_frame_abs_path,
         },
@@ -42,10 +41,11 @@ def get_frames(
 def get_crash_event(
     sdk_frame_abs_path="package:sentry/src/sentry_tracer.dart",
     system_frame_abs_path="dart:core-patch/growable_array.dart",
+    sdk_function="SentryTracer.setTag",
     **kwargs,
 ) -> dict[str, object]:
     return get_crash_event_with_frames(
-        get_frames(sdk_frame_abs_path, system_frame_abs_path),
+        get_frames(sdk_frame_abs_path, system_frame_abs_path, sdk_function=sdk_function),
         **kwargs,
     )
 

--- a/src/sentry/utils/sdk_crashes/sdk_crash_detection_config.py
+++ b/src/sentry/utils/sdk_crashes/sdk_crash_detection_config.py
@@ -293,7 +293,9 @@ def build_sdk_crash_detection_configs() -> Sequence[SDKCrashDetectionConfig]:
                 },
                 path_replacer=KeepFieldPathReplacer(fields={"package", "filename", "abs_path"}),
             ),
-            sdk_crash_ignore_functions_matchers=set(),
+            # SentryExceptionFactory.getSentryException is always part of the stacktrace when
+            # users capture exceptions and would cause false positives. Therefore, we ignore it.
+            sdk_crash_ignore_functions_matchers={"SentryExceptionFactory.getSentryException"},
         )
         configs.append(dart_config)
 

--- a/tests/sentry/utils/sdk_crashes/test_sdk_crash_detection_dart.py
+++ b/tests/sentry/utils/sdk_crashes/test_sdk_crash_detection_dart.py
@@ -143,6 +143,21 @@ def test_sdk_crash_is_reported_with_flutter_paths(
 
 
 @decorators
+def test_ignore_get_sentry_exception(mock_sdk_crash_reporter, mock_random, store_event, configs):
+    event_data = get_crash_event(sdk_function="SentryExceptionFactory.getSentryException")
+    event = store_event(data=event_data)
+
+    configs[1].organization_allowlist = [event.project.organization_id]
+
+    sdk_crash_detection.detect_sdk_crash(
+        event=event,
+        configs=configs,
+    )
+
+    assert mock_sdk_crash_reporter.report.call_count == 0
+
+
+@decorators
 def test_beta_sdk_version_detected(mock_sdk_crash_reporter, mock_random, store_event, configs):
     event_data = get_crash_event()
     set_path(event_data, "sdk", "version", value="8.2.1-beta.0")


### PR DESCRIPTION
Ignore a specific dart SDK function to ignore false positives.

In an upcoming Dart release, we will wrap the `StackTrace.current` in `SentryExceptionFactory.getSentryException` in an extra function so the SDK crash detection can detect crashes in `getSentryException`.