### PR TITLE
fix(grouping): Mark Dart SDK frames as non inApp

### DIFF
--- a/src/sentry/grouping/enhancer/enhancement-configs/newstyle@2023-01-11.txt
+++ b/src/sentry/grouping/enhancer/enhancement-configs/newstyle@2023-01-11.txt
@@ -83,6 +83,9 @@ error.mechanism:NSError invert-stacktrace=1
 # Dart/Flutter stacktraces that are not in-app
 family:javascript stack.abs_path:org-dartlang-sdk:///** -app -group
 family:javascript module:**/packages/flutter/** -app
+# sentry-dart SDK frames are not in app
+stack.abs_path:package:sentry/** -app -group
+stack.abs_path:package:sentry_flutter/** -app -group
 
 # Categorization of frames
 family:native package:"/System/Library/Frameworks/**" category=system

--- a/tests/sentry/grouping/grouping_inputs/frame-ignores-sentry-dart-sdk.json
+++ b/tests/sentry/grouping/grouping_inputs/frame-ignores-sentry-dart-sdk.json
@@ -1,0 +1,15 @@
+{
+  "stacktrace": {
+    "frames": [
+      {
+        "function": "SentryExceptionFactory.getSentryException",
+        "package": "sentry",
+        "filename": "sentry_exception_factory.dart",
+        "abs_path": "package:sentry/src/sentry_exception_factory.dart",
+        "lineno": 43,
+        "in_app": true
+      }
+    ]
+  },
+  "platform": "other"
+}

--- a/tests/sentry/grouping/grouping_inputs/frame-ignores-sentry-flutter-sdk.json
+++ b/tests/sentry/grouping/grouping_inputs/frame-ignores-sentry-flutter-sdk.json
@@ -1,0 +1,15 @@
+{
+  "stacktrace": {
+    "frames": [
+      {
+        "function": "SentryExceptionFactory.getSentryException",
+        "package": "sentry",
+        "filename": "sentry_exception_factory.dart",
+        "abs_path": "package:sentry_flutter/src/sentry_exception_factory.dart",
+        "lineno": 43,
+        "in_app": true
+      }
+    ]
+  },
+  "platform": "other"
+}

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/frame_ignores_sentry_dart_sdk.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/frame_ignores_sentry_dart_sdk.pysnap
@@ -1,0 +1,30 @@
+---
+created: '2024-05-28T08:13:48.170799+00:00'
+creator: sentry
+source: tests/sentry/grouping/test_variants.py
+---
+app:
+  hash: null
+  component:
+    app (stacktrace of system takes precedence)
+      stacktrace (ignored because hash matches system variant)
+        frame*
+          filename*
+            "sentry_exception_factory.dart"
+          function*
+            "SentryExceptionFactory.getSentryException"
+          lineno (function takes precedence)
+            43
+--------------------------------------------------------------------------
+system:
+  hash: "d1fe4234d1bddc3823d08dcc529fb161"
+  component:
+    system*
+      stacktrace*
+        frame*
+          filename*
+            "sentry_exception_factory.dart"
+          function*
+            "SentryExceptionFactory.getSentryException"
+          lineno (function takes precedence)
+            43

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/frame_ignores_sentry_flutter_sdk.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/frame_ignores_sentry_flutter_sdk.pysnap
@@ -1,0 +1,30 @@
+---
+created: '2024-05-28T08:13:47.759326+00:00'
+creator: sentry
+source: tests/sentry/grouping/test_variants.py
+---
+app:
+  hash: null
+  component:
+    app (stacktrace of system takes precedence)
+      stacktrace (ignored because hash matches system variant)
+        frame*
+          filename*
+            "sentry_exception_factory.dart"
+          function*
+            "SentryExceptionFactory.getSentryException"
+          lineno (function takes precedence)
+            43
+--------------------------------------------------------------------------
+system:
+  hash: "d1fe4234d1bddc3823d08dcc529fb161"
+  component:
+    system*
+      stacktrace*
+        frame*
+          filename*
+            "sentry_exception_factory.dart"
+          function*
+            "SentryExceptionFactory.getSentryException"
+          lineno (function takes precedence)
+            43

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_ignores_sentry_dart_sdk.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_ignores_sentry_dart_sdk.pysnap
@@ -1,0 +1,40 @@
+---
+created: '2024-05-28T08:21:44.892138+00:00'
+creator: sentry
+source: tests/sentry/grouping/test_variants.py
+---
+app-depth-1:
+  hash: "d1fe4234d1bddc3823d08dcc529fb161"
+  tree_label: "SentryExceptionFactory.getSentryException"
+  component:
+    app-depth-1*
+      stacktrace*
+        frame*
+          filename*
+            "sentry_exception_factory.dart"
+          function*
+            "SentryExceptionFactory.getSentryException"
+--------------------------------------------------------------------------
+app-depth-max:
+  hash: "d1fe4234d1bddc3823d08dcc529fb161"
+  tree_label: "SentryExceptionFactory.getSentryException"
+  component:
+    app-depth-max*
+      stacktrace*
+        frame*
+          filename*
+            "sentry_exception_factory.dart"
+          function*
+            "SentryExceptionFactory.getSentryException"
+--------------------------------------------------------------------------
+system:
+  hash: "d1fe4234d1bddc3823d08dcc529fb161"
+  tree_label: "SentryExceptionFactory.getSentryException"
+  component:
+    system*
+      stacktrace*
+        frame*
+          filename*
+            "sentry_exception_factory.dart"
+          function*
+            "SentryExceptionFactory.getSentryException"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_ignores_sentry_flutter_sdk.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_ignores_sentry_flutter_sdk.pysnap
@@ -1,0 +1,40 @@
+---
+created: '2024-05-28T08:13:55.396261+00:00'
+creator: sentry
+source: tests/sentry/grouping/test_variants.py
+---
+app-depth-1:
+  hash: "d1fe4234d1bddc3823d08dcc529fb161"
+  tree_label: "SentryExceptionFactory.getSentryException"
+  component:
+    app-depth-1*
+      stacktrace*
+        frame*
+          filename*
+            "sentry_exception_factory.dart"
+          function*
+            "SentryExceptionFactory.getSentryException"
+--------------------------------------------------------------------------
+app-depth-max:
+  hash: "d1fe4234d1bddc3823d08dcc529fb161"
+  tree_label: "SentryExceptionFactory.getSentryException"
+  component:
+    app-depth-max*
+      stacktrace*
+        frame*
+          filename*
+            "sentry_exception_factory.dart"
+          function*
+            "SentryExceptionFactory.getSentryException"
+--------------------------------------------------------------------------
+system:
+  hash: "d1fe4234d1bddc3823d08dcc529fb161"
+  tree_label: "SentryExceptionFactory.getSentryException"
+  component:
+    system*
+      stacktrace*
+        frame*
+          filename*
+            "sentry_exception_factory.dart"
+          function*
+            "SentryExceptionFactory.getSentryException"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_04_05/frame_ignores_sentry_dart_sdk.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_04_05/frame_ignores_sentry_dart_sdk.pysnap
@@ -1,0 +1,26 @@
+---
+created: '2024-05-28T08:14:00.818091+00:00'
+creator: sentry
+source: tests/sentry/grouping/test_variants.py
+---
+app:
+  hash: null
+  component:
+    app (stacktrace of system takes precedence)
+      stacktrace (ignored because hash matches system variant)
+        frame*
+          filename*
+            "sentry_exception_factory.dart"
+          function*
+            "SentryExceptionFactory.getSentryException"
+--------------------------------------------------------------------------
+system:
+  hash: "d1fe4234d1bddc3823d08dcc529fb161"
+  component:
+    system*
+      stacktrace*
+        frame*
+          filename*
+            "sentry_exception_factory.dart"
+          function*
+            "SentryExceptionFactory.getSentryException"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_04_05/frame_ignores_sentry_flutter_sdk.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_04_05/frame_ignores_sentry_flutter_sdk.pysnap
@@ -1,0 +1,26 @@
+---
+created: '2024-05-28T08:14:00.400675+00:00'
+creator: sentry
+source: tests/sentry/grouping/test_variants.py
+---
+app:
+  hash: null
+  component:
+    app (stacktrace of system takes precedence)
+      stacktrace (ignored because hash matches system variant)
+        frame*
+          filename*
+            "sentry_exception_factory.dart"
+          function*
+            "SentryExceptionFactory.getSentryException"
+--------------------------------------------------------------------------
+system:
+  hash: "d1fe4234d1bddc3823d08dcc529fb161"
+  component:
+    system*
+      stacktrace*
+        frame*
+          filename*
+            "sentry_exception_factory.dart"
+          function*
+            "SentryExceptionFactory.getSentryException"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_04_17/frame_ignores_sentry_dart_sdk.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_04_17/frame_ignores_sentry_dart_sdk.pysnap
@@ -1,0 +1,26 @@
+---
+created: '2024-05-28T08:14:03.296552+00:00'
+creator: sentry
+source: tests/sentry/grouping/test_variants.py
+---
+app:
+  hash: null
+  component:
+    app (stacktrace of system takes precedence)
+      stacktrace (ignored because hash matches system variant)
+        frame*
+          filename*
+            "sentry_exception_factory.dart"
+          function*
+            "SentryExceptionFactory.getSentryException"
+--------------------------------------------------------------------------
+system:
+  hash: "d1fe4234d1bddc3823d08dcc529fb161"
+  component:
+    system*
+      stacktrace*
+        frame*
+          filename*
+            "sentry_exception_factory.dart"
+          function*
+            "SentryExceptionFactory.getSentryException"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_04_17/frame_ignores_sentry_flutter_sdk.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_04_17/frame_ignores_sentry_flutter_sdk.pysnap
@@ -1,0 +1,26 @@
+---
+created: '2024-05-28T08:14:02.870014+00:00'
+creator: sentry
+source: tests/sentry/grouping/test_variants.py
+---
+app:
+  hash: null
+  component:
+    app (stacktrace of system takes precedence)
+      stacktrace (ignored because hash matches system variant)
+        frame*
+          filename*
+            "sentry_exception_factory.dart"
+          function*
+            "SentryExceptionFactory.getSentryException"
+--------------------------------------------------------------------------
+system:
+  hash: "d1fe4234d1bddc3823d08dcc529fb161"
+  component:
+    system*
+      stacktrace*
+        frame*
+          filename*
+            "sentry_exception_factory.dart"
+          function*
+            "SentryExceptionFactory.getSentryException"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/frame_ignores_sentry_dart_sdk.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/frame_ignores_sentry_dart_sdk.pysnap
@@ -1,0 +1,26 @@
+---
+created: '2024-05-28T08:21:40.346389+00:00'
+creator: sentry
+source: tests/sentry/grouping/test_variants.py
+---
+app:
+  hash: null
+  component:
+    app (stacktrace of system takes precedence)
+      stacktrace (ignored because hash matches system variant)
+        frame*
+          filename*
+            "sentry_exception_factory.dart"
+          function*
+            "SentryExceptionFactory.getSentryException"
+--------------------------------------------------------------------------
+system:
+  hash: "d1fe4234d1bddc3823d08dcc529fb161"
+  component:
+    system*
+      stacktrace*
+        frame*
+          filename*
+            "sentry_exception_factory.dart"
+          function*
+            "SentryExceptionFactory.getSentryException"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/frame_ignores_sentry_flutter_sdk.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/frame_ignores_sentry_flutter_sdk.pysnap
@@ -1,0 +1,26 @@
+---
+created: '2024-05-28T08:13:50.258870+00:00'
+creator: sentry
+source: tests/sentry/grouping/test_variants.py
+---
+app:
+  hash: null
+  component:
+    app (stacktrace of system takes precedence)
+      stacktrace (ignored because hash matches system variant)
+        frame*
+          filename*
+            "sentry_exception_factory.dart"
+          function*
+            "SentryExceptionFactory.getSentryException"
+--------------------------------------------------------------------------
+system:
+  hash: "d1fe4234d1bddc3823d08dcc529fb161"
+  component:
+    system*
+      stacktrace*
+        frame*
+          filename*
+            "sentry_exception_factory.dart"
+          function*
+            "SentryExceptionFactory.getSentryException"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/frame_ignores_sentry_dart_sdk.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/frame_ignores_sentry_dart_sdk.pysnap
@@ -1,0 +1,26 @@
+---
+created: '2024-05-28T08:21:42.682278+00:00'
+creator: sentry
+source: tests/sentry/grouping/test_variants.py
+---
+app:
+  hash: null
+  component:
+    app (stacktrace of system takes precedence)
+      stacktrace (ignored because hash matches system variant)
+        frame*
+          filename*
+            "sentry_exception_factory.dart"
+          function*
+            "SentryExceptionFactory.getSentryException"
+--------------------------------------------------------------------------
+system:
+  hash: "d1fe4234d1bddc3823d08dcc529fb161"
+  component:
+    system*
+      stacktrace*
+        frame*
+          filename*
+            "sentry_exception_factory.dart"
+          function*
+            "SentryExceptionFactory.getSentryException"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/frame_ignores_sentry_flutter_sdk.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/frame_ignores_sentry_flutter_sdk.pysnap
@@ -1,0 +1,26 @@
+---
+created: '2024-05-28T08:13:52.924648+00:00'
+creator: sentry
+source: tests/sentry/grouping/test_variants.py
+---
+app:
+  hash: null
+  component:
+    app (stacktrace of system takes precedence)
+      stacktrace (ignored because hash matches system variant)
+        frame*
+          filename*
+            "sentry_exception_factory.dart"
+          function*
+            "SentryExceptionFactory.getSentryException"
+--------------------------------------------------------------------------
+system:
+  hash: "d1fe4234d1bddc3823d08dcc529fb161"
+  component:
+    system*
+      stacktrace*
+        frame*
+          filename*
+            "sentry_exception_factory.dart"
+          function*
+            "SentryExceptionFactory.getSentryException"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/frame_ignores_sentry_dart_sdk.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/frame_ignores_sentry_dart_sdk.pysnap
@@ -1,0 +1,29 @@
+---
+created: '2024-05-28T08:36:54.891911+00:00'
+creator: sentry
+source: tests/sentry/grouping/test_variants.py
+---
+app:
+  hash: null
+  component:
+    app
+      stacktrace
+        frame (marked out of app by stack trace rule (path:package:sentry/** -app -group))
+          filename*
+            "sentry_exception_factory.dart"
+          function*
+            "SentryExceptionFactory.getSentryException"
+--------------------------------------------------------------------------
+fallback:
+  hash: "d41d8cd98f00b204e9800998ecf8427e"
+--------------------------------------------------------------------------
+system:
+  hash: null
+  component:
+    system
+      stacktrace
+        frame (ignored by stack trace rule (path:package:sentry/** -app -group))
+          filename*
+            "sentry_exception_factory.dart"
+          function*
+            "SentryExceptionFactory.getSentryException"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/frame_ignores_sentry_flutter_sdk.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/frame_ignores_sentry_flutter_sdk.pysnap
@@ -1,0 +1,29 @@
+---
+created: '2024-05-28T08:36:54.505879+00:00'
+creator: sentry
+source: tests/sentry/grouping/test_variants.py
+---
+app:
+  hash: null
+  component:
+    app
+      stacktrace
+        frame (marked out of app by stack trace rule (path:package:sentry_flutter/** -app -group))
+          filename*
+            "sentry_exception_factory.dart"
+          function*
+            "SentryExceptionFactory.getSentryException"
+--------------------------------------------------------------------------
+fallback:
+  hash: "d41d8cd98f00b204e9800998ecf8427e"
+--------------------------------------------------------------------------
+system:
+  hash: null
+  component:
+    system
+      stacktrace
+        frame (ignored by stack trace rule (path:package:sentry_flutter/** -app -group))
+          filename*
+            "sentry_exception_factory.dart"
+          function*
+            "SentryExceptionFactory.getSentryException"


### PR DESCRIPTION
The sentry-dart SDK sends SDK frames since [8.2.0](https://github.com/getsentry/sentry-dart/releases/tag/8.2.0). We need to ignore Dart SDK frames for grouping.
