### PR TITLE
Fix deletion of small inlined attachments

### DIFF
--- a/src/sentry/models/eventattachment.py
+++ b/src/sentry/models/eventattachment.py
@@ -120,7 +120,9 @@ class EventAttachment(Model):
             cache.delete(get_crashreport_key(self.group_id))
 
         if self.blob_path:
-            if self.blob_path.startswith("eventattachments/v1/"):
+            if self.blob_path.startswith(":"):
+                return rv
+            elif self.blob_path.startswith("eventattachments/v1/"):
                 storage = get_storage()
             else:
                 raise NotImplementedError()


### PR DESCRIPTION
Previously, deleting a small inlined attachment would still issue a `delete` on the underlying storage, even though no item in the underlying storage exists for such attachments.