### PR TITLE
fix(security): hide integrations code from members, attempt 2

### DIFF
--- a/src/sentry/api/endpoints/integrations/sentry_apps/installation/details.py
+++ b/src/sentry/api/endpoints/integrations/sentry_apps/installation/details.py
@@ -27,7 +27,9 @@ class SentryAppInstallationDetailsEndpoint(SentryAppInstallationBaseEndpoint):
     }
 
     def get(self, request: Request, installation) -> Response:
-        return Response(serialize(SentryAppInstallation.objects.get(id=installation.id)))
+        return Response(
+            serialize(SentryAppInstallation.objects.get(id=installation.id), access=request.access)
+        )
 
     def delete(self, request: Request, installation) -> Response:
         installation = SentryAppInstallation.objects.get(id=installation.id)

--- a/src/sentry/api/endpoints/integrations/sentry_apps/installation/index.py
+++ b/src/sentry/api/endpoints/integrations/sentry_apps/installation/index.py
@@ -39,7 +39,7 @@ class SentryAppInstallationsEndpoint(SentryAppInstallationsBaseEndpoint):
             queryset=queryset,
             order_by="-date_added",
             paginator_cls=OffsetPaginator,
-            on_results=lambda x: serialize(x, request.user),
+            on_results=lambda x: serialize(x, request.user, access=request.access),
         )
 
     def post(self, request: Request, organization) -> Response:

--- a/src/sentry/api/endpoints/integrations/sentry_apps/installation/index.py
+++ b/src/sentry/api/endpoints/integrations/sentry_apps/installation/index.py
@@ -94,4 +94,4 @@ class SentryAppInstallationsEndpoint(SentryAppInstallationsBaseEndpoint):
                 organization_id=organization.id, slug=slug, notify=True
             ).run(user=request.user, request=request)
 
-        return Response(serialize(install))
+        return Response(serialize(install, access=request.access))

--- a/src/sentry/api/serializers/models/sentry_app_installation.py
+++ b/src/sentry/api/serializers/models/sentry_app_installation.py
@@ -36,7 +36,7 @@ class SentryAppInstallationSerializer(Serializer):
             }
         return result
 
-    def serialize(self, install, attrs, user):
+    def serialize(self, install, attrs, user, access=None):
         data = {
             "app": {"uuid": attrs["sentry_app"].uuid, "slug": attrs["sentry_app"].slug},
             "organization": {"slug": attrs["organization"].slug},
@@ -44,7 +44,7 @@ class SentryAppInstallationSerializer(Serializer):
             "status": SentryAppInstallationStatus.as_str(install.status),
         }
 
-        if install.api_grant:
+        if install.api_grant and access and access.has_scope("org:integrations"):
             data["code"] = install.api_grant.code
 
         return data

--- a/tests/sentry/mediators/sentry_app_installations/test_installation_notifier.py
+++ b/tests/sentry/mediators/sentry_app_installations/test_installation_notifier.py
@@ -56,7 +56,6 @@ class TestInstallationNotifier(TestCase):
                     "app": {"uuid": self.sentry_app.uuid, "slug": self.sentry_app.slug},
                     "organization": {"slug": self.organization.slug},
                     "uuid": self.install.uuid,
-                    "code": self.install.api_grant.code,
                     "status": "installed",
                 }
             },
@@ -85,7 +84,6 @@ class TestInstallationNotifier(TestCase):
                     "app": {"uuid": self.sentry_app.uuid, "slug": self.sentry_app.slug},
                     "organization": {"slug": self.organization.slug},
                     "uuid": self.install.uuid,
-                    "code": self.install.api_grant.code,
                     "status": "installed",
                 }
             },


### PR DESCRIPTION
Another attempt of https://github.com/getsentry/sentry/pull/70128
This also adds the missing access parameter to the serializer call in `post()` method.