### PR TITLE
fix(trace): hide trace multiple root warning for js traces with multiple roots

### DIFF
--- a/static/app/utils/performance/quickTrace/types.tsx
+++ b/static/app/utils/performance/quickTrace/types.tsx
@@ -79,6 +79,7 @@ export type TraceFull = Omit<QuickTraceEvent, 'generation' | 'errors'> & {
  */
 export type TraceFullDetailed = Omit<TraceFull, 'children'> & {
   children: TraceTree.Transaction[];
+  sdk_name: string;
   start_timestamp: number;
   timestamp: number;
   'transaction.op': string;

--- a/static/app/utils/performance/quickTrace/types.tsx
+++ b/static/app/utils/performance/quickTrace/types.tsx
@@ -5,6 +5,7 @@ import type {
   DiscoverQueryProps,
   GenericChildrenProps,
 } from 'sentry/utils/discover/genericDiscoverQuery';
+import type {TraceTree} from 'sentry/views/performance/newTraceDetails/traceModels/traceTree';
 
 /**
  * `EventLite` represents the type of a simplified event from
@@ -77,7 +78,7 @@ export type TraceFull = Omit<QuickTraceEvent, 'generation' | 'errors'> & {
  * additional information by setting `detailed=1`.
  */
 export type TraceFullDetailed = Omit<TraceFull, 'children'> & {
-  children: TraceFullDetailed[];
+  children: TraceTree.Transaction[];
   start_timestamp: number;
   timestamp: number;
   'transaction.op': string;

--- a/static/app/views/performance/newTraceDetails/index.tsx
+++ b/static/app/views/performance/newTraceDetails/index.tsx
@@ -28,7 +28,6 @@ import {trackAnalytics} from 'sentry/utils/analytics';
 import {browserHistory} from 'sentry/utils/browserHistory';
 import EventView from 'sentry/utils/discover/eventView';
 import type {
-  TraceFullDetailed,
   TraceMeta,
   TraceSplitResults,
 } from 'sentry/utils/performance/quickTrace/types';
@@ -229,7 +228,7 @@ type TraceViewContentProps = {
   metaResults: UseApiQueryResult<TraceMeta | null, any>;
   organization: Organization;
   status: UseApiQueryResult<any, any>['status'];
-  trace: TraceSplitResults<TraceFullDetailed> | null;
+  trace: TraceSplitResults<TraceTree.Transaction> | null;
   traceEventView: EventView;
   traceSlug: string;
 };

--- a/static/app/views/performance/newTraceDetails/trace.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/trace.spec.tsx
@@ -184,6 +184,7 @@ function makeTransaction(overrides: Partial<TraceFullDetailed> = {}): TraceFullD
     timestamp: 1,
     generation: 0,
     span_id: s,
+    sdk_name: 'sdk_name',
     'transaction.duration': 1,
     transaction: 'transaction-name' + t,
     'transaction.op': 'transaction-op-' + t,

--- a/static/app/views/performance/newTraceDetails/traceApi/useTrace.tsx
+++ b/static/app/views/performance/newTraceDetails/traceApi/useTrace.tsx
@@ -136,6 +136,7 @@ function makeTraceFromTransaction(
     transaction: event.title,
     'transaction.duration': (event.endTimestamp - event.startTimestamp) * 1000,
     errors: [],
+    sdk_name: event.sdk?.name ?? '',
     children: [],
     start_timestamp: event.startTimestamp,
     'transaction.op': traceContext?.op ?? '',

--- a/static/app/views/performance/newTraceDetails/traceApi/useTrace.tsx
+++ b/static/app/views/performance/newTraceDetails/traceApi/useTrace.tsx
@@ -15,6 +15,8 @@ import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import {useParams} from 'sentry/utils/useParams';
 
+import type {TraceTree} from '../traceModels/traceTree';
+
 export function fetchTrace(
   api: Client,
   params: {
@@ -148,7 +150,7 @@ function makeTraceFromTransaction(
 function useDemoTrace(
   demo: string | undefined,
   organization: {slug: string}
-): UseApiQueryResult<TraceSplitResults<TraceFullDetailed> | undefined, any> {
+): UseApiQueryResult<TraceSplitResults<TraceTree.Transaction> | undefined, any> {
   const demoEventSlug = parseDemoEventSlug(demo);
 
   // When projects don't have performance set up, we allow them to view a demo transaction.
@@ -180,7 +182,7 @@ function useDemoTrace(
   // Casting here since the 'select' option is not available in the useApiQuery hook to transform the data
   // from EventTransaction to TraceSplitResults<TraceFullDetailed>
   return {...demoEventQuery, data} as UseApiQueryResult<
-    TraceSplitResults<TraceFullDetailed> | undefined,
+    TraceSplitResults<TraceTree.Transaction> | undefined,
     any
   >;
 }
@@ -192,7 +194,7 @@ type UseTraceParams = {
 const DEFAULT_OPTIONS = {};
 export function useTrace(
   options: Partial<UseTraceParams> = DEFAULT_OPTIONS
-): UseApiQueryResult<TraceSplitResults<TraceFullDetailed> | undefined, any> {
+): UseApiQueryResult<TraceSplitResults<TraceTree.Transaction> | undefined, any> {
   const filters = usePageFilters();
   const organization = useOrganization();
   const params = useParams<{traceSlug?: string}>();
@@ -203,7 +205,7 @@ export function useTrace(
   }, [options]);
   const mode = queryParams.demo ? 'demo' : undefined;
   const demoTrace = useDemoTrace(queryParams.demo, organization);
-  const traceQuery = useApiQuery<TraceSplitResults<TraceFullDetailed>>(
+  const traceQuery = useApiQuery<TraceSplitResults<TraceTree.Transaction>>(
     [
       `/organizations/${organization.slug}/events-trace/${params.traceSlug ?? ''}/`,
       {query: queryParams},

--- a/static/app/views/performance/newTraceDetails/traceModels/traceTree.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/traceTree.spec.tsx
@@ -5,7 +5,6 @@ import {waitFor} from 'sentry-test/reactTestingLibrary';
 import type {RawSpanType} from 'sentry/components/events/interfaces/spans/types';
 import {EntryType, type Event, type EventTransaction} from 'sentry/types';
 import type {
-  TraceFullDetailed,
   TracePerformanceIssue,
   TraceSplitResults,
 } from 'sentry/utils/performance/quickTrace/types';
@@ -31,18 +30,21 @@ const EVENT_REQUEST_URL =
   '/organizations/org-slug/events/project:event_id/?averageColumn=span.self_time&averageColumn=span.duration';
 
 function makeTrace(
-  overrides: Partial<TraceSplitResults<TraceFullDetailed>>
-): TraceSplitResults<TraceFullDetailed> {
+  overrides: Partial<TraceSplitResults<TraceTree.Transaction>>
+): TraceSplitResults<TraceTree.Transaction> {
   return {
     transactions: [],
     orphan_errors: [],
     ...overrides,
-  } as TraceSplitResults<TraceFullDetailed>;
+  } as TraceSplitResults<TraceTree.Transaction>;
 }
 
-function makeTransaction(overrides: Partial<TraceFullDetailed> = {}): TraceFullDetailed {
+function makeTransaction(
+  overrides: Partial<TraceTree.Transaction> = {}
+): TraceTree.Transaction {
   return {
     children: [],
+    sdk: '',
     start_timestamp: 0,
     timestamp: 1,
     transaction: 'transaction',
@@ -51,7 +53,7 @@ function makeTransaction(overrides: Partial<TraceFullDetailed> = {}): TraceFullD
     performance_issues: [],
     errors: [],
     ...overrides,
-  } as TraceFullDetailed;
+  } as TraceTree.Transaction;
 }
 
 function makeSpan(overrides: Partial<RawSpanType> = {}): TraceTree.Span {
@@ -991,6 +993,20 @@ describe('TraceTree', () => {
     );
 
     expect(tree.shape).toBe(TraceType.ONLY_ERRORS);
+  });
+
+  it('browser multiple roots shape', () => {
+    const tree = TraceTree.FromTrace(
+      makeTrace({
+        transactions: [
+          makeTransaction({sdk: 'javascript', parent_span_id: null}),
+          makeTransaction({sdk: 'javascript', parent_span_id: null}),
+        ],
+        orphan_errors: [],
+      })
+    );
+
+    expect(tree.shape).toBe(TraceType.BROWSER_MULTIPLE_ROOTS);
   });
 
   it('builds from spans when root is a transaction node', () => {

--- a/static/app/views/performance/newTraceDetails/traceModels/traceTree.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/traceTree.spec.tsx
@@ -44,7 +44,7 @@ function makeTransaction(
 ): TraceTree.Transaction {
   return {
     children: [],
-    sdk: '',
+    sdk_name: '',
     start_timestamp: 0,
     timestamp: 1,
     transaction: 'transaction',
@@ -999,8 +999,8 @@ describe('TraceTree', () => {
     const tree = TraceTree.FromTrace(
       makeTrace({
         transactions: [
-          makeTransaction({sdk: 'javascript', parent_span_id: null}),
-          makeTransaction({sdk: 'javascript', parent_span_id: null}),
+          makeTransaction({sdk_name: 'javascript', parent_span_id: null}),
+          makeTransaction({sdk_name: 'javascript', parent_span_id: null}),
         ],
         orphan_errors: [],
       })

--- a/static/app/views/performance/newTraceDetails/traceModels/traceTree.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/traceTree.tsx
@@ -203,6 +203,12 @@ function fetchTransactionSpans(
   );
 }
 
+function isJavascriptSDKTransaction(transaction: TraceTree.Transaction): boolean {
+  return /javascript|angular|astro|backbone|ember|gatsby|nextjs|react|remix|svelte|vue/.test(
+    transaction.sdk
+  );
+}
+
 function measurementToTimestamp(
   start_timestamp: number,
   measurement: number,
@@ -588,7 +594,8 @@ export class TraceTree {
       (stats, transaction) => {
         if (isRootTransaction(transaction)) {
           stats.roots++;
-          if (transaction.sdk === 'javascript') {
+
+          if (isJavascriptSDKTransaction(transaction)) {
             stats.javascriptRootTransactions.push(transaction);
           }
         } else {

--- a/static/app/views/performance/newTraceDetails/traceModels/traceTree.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/traceTree.tsx
@@ -113,7 +113,7 @@ type ArgumentTypes<F> = F extends (...args: infer A) => any ? A : never;
 
 export declare namespace TraceTree {
   interface Transaction extends TraceFullDetailed {
-    sdk: string;
+    sdk_name: string;
   }
   interface Span extends RawSpanType {
     childTransactions: TraceTreeNode<TraceTree.Transaction>[];
@@ -205,7 +205,7 @@ function fetchTransactionSpans(
 
 function isJavascriptSDKTransaction(transaction: TraceTree.Transaction): boolean {
   return /javascript|angular|astro|backbone|ember|gatsby|nextjs|react|remix|svelte|vue/.test(
-    transaction.sdk
+    transaction.sdk_name
   );
 }
 
@@ -2420,7 +2420,7 @@ function partialTransaction(
     span_id: '',
     parent_event_id: '',
     project_id: 0,
-    sdk: '',
+    sdk_name: '',
     'transaction.duration': 0,
     'transaction.op': 'loading-transaction',
     'transaction.status': 'loading-status',

--- a/static/app/views/performance/newTraceDetails/traceRenderers/virtualizedViewManager.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceRenderers/virtualizedViewManager.spec.tsx
@@ -2,10 +2,7 @@ import {OrganizationFixture} from 'sentry-fixture/organization';
 
 import type {RawSpanType} from 'sentry/components/events/interfaces/spans/types';
 import {EntryType, type Event} from 'sentry/types';
-import type {
-  TraceFullDetailed,
-  TraceSplitResults,
-} from 'sentry/utils/performance/quickTrace/types';
+import type {TraceSplitResults} from 'sentry/utils/performance/quickTrace/types';
 import {
   type VirtualizedList,
   VirtualizedViewManager,
@@ -21,16 +18,18 @@ function makeEvent(overrides: Partial<Event> = {}, spans: RawSpanType[] = []): E
 }
 
 function makeTrace(
-  overrides: Partial<TraceSplitResults<TraceFullDetailed>>
-): TraceSplitResults<TraceFullDetailed> {
+  overrides: Partial<TraceSplitResults<TraceTree.Transaction>>
+): TraceSplitResults<TraceTree.Transaction> {
   return {
     transactions: [],
     orphan_errors: [],
     ...overrides,
-  } as TraceSplitResults<TraceFullDetailed>;
+  } as TraceSplitResults<TraceTree.Transaction>;
 }
 
-function makeTransaction(overrides: Partial<TraceFullDetailed> = {}): TraceFullDetailed {
+function makeTransaction(
+  overrides: Partial<TraceTree.Transaction> = {}
+): TraceTree.Transaction {
   return {
     children: [],
     start_timestamp: 0,
@@ -41,7 +40,7 @@ function makeTransaction(overrides: Partial<TraceFullDetailed> = {}): TraceFullD
     errors: [],
     performance_issues: [],
     ...overrides,
-  } as TraceFullDetailed;
+  } as TraceTree.Transaction;
 }
 
 function makeSpan(overrides: Partial<RawSpanType> = {}): RawSpanType {

--- a/static/app/views/performance/newTraceDetails/traceType.tsx
+++ b/static/app/views/performance/newTraceDetails/traceType.tsx
@@ -1,6 +1,7 @@
 export enum TraceType {
   ONE_ROOT = 'one_root',
   NO_ROOT = 'no_root',
+  BROWSER_MULTIPLE_ROOTS = 'browser_multiple_roots',
   MULTIPLE_ROOTS = 'multiple_roots',
   BROKEN_SUBTRACES = 'broken_subtraces',
   ONLY_ERRORS = 'only_errors',

--- a/static/app/views/performance/newTraceDetails/traceWarnings.tsx
+++ b/static/app/views/performance/newTraceDetails/traceWarnings.tsx
@@ -41,6 +41,10 @@ export function TraceWarnings({type}: TraceWarningsProps) {
           </ExternalLink>
         </Alert>
       );
+    // Multiple roots are an edge case in browser SDKs and should be handled by the SDK.
+    // The user should not see a warning as they cannot do anything about it.
+    case TraceType.BROWSER_MULTIPLE_ROOTS:
+      return null;
     case TraceType.MULTIPLE_ROOTS:
       return (
         <Alert type="info" showIcon>

--- a/static/app/views/performance/traceDetails/newTraceDetailsTraceView.tsx
+++ b/static/app/views/performance/traceDetails/newTraceDetailsTraceView.tsx
@@ -31,6 +31,7 @@ import type {
   TraceFullDetailed,
   TraceMeta,
 } from 'sentry/utils/performance/quickTrace/types';
+import type {TraceTree} from 'sentry/views/performance/newTraceDetails/traceModels/traceTree';
 import {
   TraceDetailBody,
   TraceViewContainer,
@@ -62,7 +63,7 @@ type Props = Pick<RouteComponentProps<{}, {}>, 'location'> & {
   traceEventView: EventView;
   traceSlug: string;
   traceType: TraceType;
-  traces: TraceFullDetailed[];
+  traces: TraceTree.Transaction[];
   filteredEventIds?: Set<string>;
   handleLimitChange?: (newLimit: number) => void;
   orphanErrors?: TraceError[];


### PR DESCRIPTION
Removes multiple roots warning for JS traces with multiple roots. A backend change to add SDK to the response needs to be added and the detection needs to be extended to include all other browser sdks