### PR TITLE
feat(discover): Add dataset selector to saved query

### DIFF
--- a/static/app/views/discover/savedQuery/datasetSelector.tsx
+++ b/static/app/views/discover/savedQuery/datasetSelector.tsx
@@ -1,0 +1,33 @@
+import {CompactSelect} from 'sentry/components/compactSelect';
+import {t} from 'sentry/locale';
+import {decodeScalar} from 'sentry/utils/queryString';
+import {useLocation} from 'sentry/utils/useLocation';
+import {useNavigate} from 'sentry/utils/useNavigate';
+
+const DATASET_PARAM = 'query_dataset';
+
+export function DatasetSelector() {
+  const location = useLocation();
+  const navigate = useNavigate();
+  const value = decodeScalar(location.query[DATASET_PARAM]) ?? 'errors';
+
+  const options = [
+    {value: 'errors', label: t('Errors')},
+    {value: 'transactions-like', label: t('Transactions')},
+  ];
+
+  return (
+    <CompactSelect
+      triggerProps={{prefix: t('Dataset')}}
+      value={value}
+      options={options}
+      onChange={newValue => {
+        navigate({
+          ...location,
+          query: {...location.query, [DATASET_PARAM]: newValue.value},
+        });
+      }}
+      size="sm"
+    />
+  );
+}

--- a/static/app/views/discover/savedQuery/datasetSelector.tsx
+++ b/static/app/views/discover/savedQuery/datasetSelector.tsx
@@ -13,7 +13,7 @@ export function DatasetSelector() {
 
   const options = [
     {value: 'errors', label: t('Errors')},
-    {value: 'transactions-like', label: t('Transactions')},
+    {value: 'transaction-like', label: t('Transactions')},
   ];
 
   return (

--- a/static/app/views/discover/savedQuery/index.tsx
+++ b/static/app/views/discover/savedQuery/index.tsx
@@ -32,6 +32,7 @@ import useOverlay from 'sentry/utils/useOverlay';
 import withApi from 'sentry/utils/withApi';
 import {normalizeUrl} from 'sentry/utils/withDomainRequired';
 import withProjects from 'sentry/utils/withProjects';
+import {DatasetSelector} from 'sentry/views/discover/savedQuery/datasetSelector';
 import {handleAddQueryToDashboard} from 'sentry/views/discover/utils';
 
 import {DEFAULT_EVENT_VIEW} from '../data';
@@ -575,6 +576,12 @@ class SavedQueryButtonGroup extends PureComponent<Props, State> {
 
     return (
       <ResponsiveButtonBar gap={1}>
+        <Feature
+          organization={organization}
+          features="performance-discover-dataset-selector"
+        >
+          {({hasFeature}) => hasFeature && <DatasetSelector />}
+        </Feature>
         {this.renderQueryButton(disabled => this.renderSaveAsHomepage(disabled))}
         {this.renderQueryButton(disabled => this.renderButtonSave(disabled))}
         <Feature organization={organization} features="incidents">


### PR DESCRIPTION
to have existing discover saved queries to hit the spans dataset, 
we need to split saved queries into errors and transactions so that
only transactions go to spans and we can deprecate the "discover"
dataset.

adds a selector to the ui behind a feature flag (since there isn't
really any point in trying to split out the datasets before we split
them in the UI too). 

Selector doesn't do anything yet

![Screenshot 2024-05-28 at 10 41 07 AM](https://github.com/getsentry/sentry/assets/63818634/b92a48c4-39fb-4e5c-b1c4-97d7c549aa02)
