### PR TITLE
fix(feedback/issues): check if latest_event is None before filtering attachments

### DIFF
--- a/src/sentry/api/endpoints/group_details.py
+++ b/src/sentry/api/endpoints/group_details.py
@@ -245,10 +245,11 @@ class GroupDetailsEndpoint(GroupEndpoint, EnvironmentMixin):
                     return self.respond(status=404)
 
                 latest_event = group.get_latest_event()
-                num_attachments = EventAttachment.objects.filter(
-                    project_id=latest_event.project_id, event_id=latest_event.event_id
-                ).count()
-                data.update({"latestEventHasAttachments": num_attachments > 0})
+                if latest_event is not None:
+                    num_attachments = EventAttachment.objects.filter(
+                        project_id=latest_event.project_id, event_id=latest_event.event_id
+                    ).count()
+                    data.update({"latestEventHasAttachments": num_attachments > 0})
 
             data.update(
                 {

--- a/src/sentry/api/serializers/models/group_stream.py
+++ b/src/sentry/api/serializers/models/group_stream.py
@@ -407,10 +407,11 @@ class StreamGroupSerializerSnuba(GroupSerializerSnuba, GroupStatsMixin):
 
             for item in item_list:
                 latest_event = item.get_latest_event()
-                num_attachments = EventAttachment.objects.filter(
-                    project_id=latest_event.project_id, event_id=latest_event.event_id
-                ).count()
-                attrs[item].update({"latestEventHasAttachments": num_attachments > 0})
+                if latest_event is not None:
+                    num_attachments = EventAttachment.objects.filter(
+                        project_id=latest_event.project_id, event_id=latest_event.event_id
+                    ).count()
+                    attrs[item].update({"latestEventHasAttachments": num_attachments > 0})
 
         return attrs
 

--- a/src/sentry/api/serializers/models/group_stream.py
+++ b/src/sentry/api/serializers/models/group_stream.py
@@ -471,7 +471,7 @@ class StreamGroupSerializerSnuba(GroupSerializerSnuba, GroupStatsMixin):
         if self._expand("sentryAppIssues"):
             result["sentryAppIssues"] = attrs["sentryAppIssues"]
 
-        if self._expand("latestEventHasAttachments"):
+        if self._expand("latestEventHasAttachments") and "latestEventHasAttachments" in result:
             result["latestEventHasAttachments"] = attrs["latestEventHasAttachments"]
 
         return result

--- a/src/sentry/api/serializers/models/group_stream.py
+++ b/src/sentry/api/serializers/models/group_stream.py
@@ -471,7 +471,7 @@ class StreamGroupSerializerSnuba(GroupSerializerSnuba, GroupStatsMixin):
         if self._expand("sentryAppIssues"):
             result["sentryAppIssues"] = attrs["sentryAppIssues"]
 
-        if self._expand("latestEventHasAttachments") and "latestEventHasAttachments" in result:
+        if self._expand("latestEventHasAttachments") and "latestEventHasAttachments" in attrs:
             result["latestEventHasAttachments"] = attrs["latestEventHasAttachments"]
 
         return result

--- a/tests/sentry/issues/endpoints/test_organization_group_index.py
+++ b/tests/sentry/issues/endpoints/test_organization_group_index.py
@@ -1951,7 +1951,7 @@ class GroupListTest(APITestCase, SnubaTestCase, SearchIssueTestMixin):
     @patch("sentry.models.Group.get_latest_event", return_value=None)
     def test_expand_no_latest_event_has_no_attachments(self, mock_latest_event) -> None:
         self.store_event(
-            data={"timestamp": None, "fingerprint": ["group-1"]},
+            data={"timestamp": iso_format(before_now(seconds=500)), "fingerprint": ["group-1"]},
             project_id=self.project.id,
         )
         query = "status:unresolved"

--- a/tests/sentry/issues/endpoints/test_organization_group_index.py
+++ b/tests/sentry/issues/endpoints/test_organization_group_index.py
@@ -1947,6 +1947,23 @@ class GroupListTest(APITestCase, SnubaTestCase, SearchIssueTestMixin):
         assert response.status_code == 200
         assert response.data[0]["latestEventHasAttachments"] is True
 
+    @with_feature("organizations:event-attachments")
+    @patch("sentry.models.Group.get_latest_event", return_value=None)
+    def test_expand_no_latest_event_has_no_attachments(self, mock_latest_event) -> None:
+        self.store_event(
+            data={"timestamp": None, "fingerprint": ["group-1"]},
+            project_id=self.project.id,
+        )
+        query = "status:unresolved"
+        self.login_as(user=self.user)
+        response = self.get_response(
+            sort_by="date", limit=10, query=query, expand=["latestEventHasAttachments"]
+        )
+        assert response.status_code == 200
+
+        # Expand should not execute since there is no latest event
+        assert "latestEventHasAttachments" not in response.data[0]
+
     def test_expand_owners(self) -> None:
         event = self.store_event(
             data={"timestamp": iso_format(before_now(seconds=500)), "fingerprint": ["group-1"]},


### PR DESCRIPTION
fixes SENTRY-39PV