### PR TITLE
fix(crons): Don't show processing errors when none exist

### DIFF
--- a/static/app/views/monitors/overview.tsx
+++ b/static/app/views/monitors/overview.tsx
@@ -154,7 +154,7 @@ export default function Monitors() {
                 onSearch={handleSearch}
               />
             </Filters>
-            {processingErrors && (
+            {!!processingErrors?.length && (
               <MonitorProcessingErrors checkinErrors={processingErrors}>
                 {t(
                   'Errors were encountered while ingesting check-ins for the selected projects'


### PR DESCRIPTION
My bad on this one, the api will always return atleast an `[]`, so we need to verify that there are items inside the array before showing here

fixes: https://github.com/getsentry/sentry/issues/71499
