### PR TITLE
fix(backup): Keep `OrganizationMember`s with external inviters

### DIFF
--- a/fixtures/backup/fresh-install.json
+++ b/fixtures/backup/fresh-install.json
@@ -56,6 +56,14 @@
   }
 },
 {
+  "model": "sentry.email",
+  "pk": 3,
+  "fields": {
+    "email": "superadmin@example.com",
+    "date_added": "2023-06-22T22:59:57.531Z"
+  }
+},
+{
   "model": "sentry.organization",
   "pk": 1,
   "fields": {
@@ -114,6 +122,31 @@
     "session_nonce": null,
     "date_joined": "2023-06-22T22:59:56.488Z",
     "last_active": "2023-06-22T22:59:56.489Z",
+    "avatar_type": 0,
+    "avatar_url": null
+  }
+},
+{
+  "model": "sentry.user",
+  "pk": 3,
+  "fields": {
+    "password": "pbkdf2_sha256$720000$Qr71byRoUAtqx37gux7FZLx3Wa7mVU1gL2KbL8Iozk/Fw9dVd/93cwBk=",
+    "last_login": null,
+    "username": "superadmin@example.com",
+    "name": "",
+    "email": "superadmin@example.com",
+    "is_staff": true,
+    "is_active": true,
+    "is_superuser": true,
+    "is_managed": false,
+    "is_sentry_app": null,
+    "is_password_expired": false,
+    "is_unclaimed": false,
+    "last_password_change": "2023-06-22T22:59:59.023Z",
+    "flags": "0",
+    "session_nonce": null,
+    "date_joined": "2023-06-22T22:59:57.488Z",
+    "last_active": "2023-06-22T22:59:57.489Z",
     "avatar_type": 0,
     "avatar_url": null
   }
@@ -185,6 +218,17 @@
   }
 },
 {
+  "model": "sentry.useremail",
+  "pk": 3,
+  "fields": {
+    "user": 3,
+    "email": "superadmin@example.com",
+    "validation_hash": "VSj0hfPGiq1UdkHDg8p49sOP9saYvIwH",
+    "date_hash_added": "2023-06-22T22:59:57.521Z",
+    "is_verified": true
+  }
+},
+{
   "model": "sentry.userrole",
   "pk": 1,
   "fields": {
@@ -201,6 +245,16 @@
     "date_updated": "2023-06-22T23:00:00.123Z",
     "date_added": "2023-06-22T22:59:57.000Z",
     "user": 1,
+    "role": 1
+  }
+},
+{
+  "model": "sentry.userroleuser",
+  "pk": 2,
+  "fields": {
+    "date_updated": "2023-06-22T23:00:00.456Z",
+    "date_added": "2023-06-22T22:59:58.000Z",
+    "user": 3,
     "role": 1
   }
 },
@@ -250,11 +304,31 @@
     "date_added": "2023-06-22T22:59:56.561Z",
     "token_expires_at": null,
     "has_global_access": true,
-    "inviter_id": null,
+    "inviter_id": 3,
     "invite_status": 0,
     "type": 50,
     "user_is_active": true,
     "user_email": "member@example.com"
+  }
+},
+{
+  "model": "sentry.organizationmember",
+  "pk": 3,
+  "fields": {
+    "organization": 1,
+    "user_id": null,
+    "email": "pending@example.com",
+    "role": "member",
+    "flags": "0",
+    "token": null,
+    "date_added": "2023-06-22T22:59:56.561Z",
+    "token_expires_at": null,
+    "has_global_access": true,
+    "inviter_id": 1,
+    "invite_status": 1,
+    "type": 50,
+    "user_is_active": true,
+    "user_email": null
   }
 },
 {

--- a/src/sentry/backup/comparators.py
+++ b/src/sentry/backup/comparators.py
@@ -817,7 +817,6 @@ def get_default_comparators() -> dict[str, list[JSONScrubbingComparator]]:
             "sentry.organizationintegration": [DateUpdatedComparator("date_updated")],
             "sentry.organizationmember": [
                 HashObfuscatingComparator("token"),
-                EqualOrRemovedComparator("inviter_id"),
             ],
             "sentry.projectkey": [
                 HashObfuscatingComparator("public_key", "secret_key"),

--- a/src/sentry/db/postgres/base.py
+++ b/src/sentry/db/postgres/base.py
@@ -93,7 +93,7 @@ class CursorWrapper:
 
 class DatabaseWrapper(DjangoDatabaseWrapper):
     SchemaEditorClass = DatabaseSchemaEditorProxy
-    queries_limit = 10000
+    queries_limit = 12000
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/src/sentry/models/organizationmember.py
+++ b/src/sentry/models/organizationmember.py
@@ -644,6 +644,29 @@ class OrganizationMember(ReplicatedRegionModel):
             mapping=rpc_org_member_update,
         )
 
+    @classmethod
+    def query_for_relocation_export(cls, q: Q, pk_map: PrimaryKeyMap) -> Q:
+        q = super().query_for_relocation_export(q, pk_map)
+
+        # Manually avoid filtering on `inviter_id` when exporting. This ensures that
+        # `OrganizationMember`s that were invited by a user from a different organization are not
+        # filtered out when export in `Organization` scope.
+        new_q = Q()
+        for clause in q.children:
+            if not isinstance(clause, Q):
+                new_q.children.append(clause)
+                continue
+
+            mentioned_inviter = False
+            for subclause in clause.children:
+                if isinstance(subclause, tuple) and "inviter" in subclause[0]:
+                    mentioned_inviter = True
+                    break
+            if not mentioned_inviter:
+                new_q.children.append(clause)
+
+        return new_q
+
     def normalize_before_relocation_import(
         self, pk_map: PrimaryKeyMap, scope: ImportScope, flags: ImportFlags
     ) -> int | None:

--- a/src/sentry/testutils/helpers/backups.py
+++ b/src/sentry/testutils/helpers/backups.py
@@ -365,7 +365,9 @@ class BackupTestCase(TransactionTestCase):
         owner: User,
         member: User,
         other_members: list[User] | None = None,
-        invites: dict[User, str] | None = None,
+        pending_invites: dict[User, str] | None = None,
+        # A dictionary of a user to the other users they invited
+        accepted_invites: dict[User, list[User]] | None = None,
     ) -> Organization:
         org = self.create_organization(name=slug, owner=owner)
         owner_id: BoundedBigAutoField = owner.id
@@ -373,8 +375,8 @@ class BackupTestCase(TransactionTestCase):
         if other_members:
             for user in other_members:
                 self.create_member(organization=org, user=user, role="member")
-        if invites:
-            for inviter, email in invites.items():
+        if pending_invites:
+            for inviter, email in pending_invites.items():
                 OrganizationMember.objects.create(
                     organization_id=org.id,
                     role="member",
@@ -382,6 +384,12 @@ class BackupTestCase(TransactionTestCase):
                     inviter_id=inviter.id,
                     invite_status=InviteStatus.REQUESTED_TO_BE_INVITED.value,
                 )
+        if accepted_invites:
+            for inviter, users in accepted_invites.items():
+                for user in users:
+                    self.create_member(
+                        organization=org, user=user, role="member", inviter_id=inviter.id
+                    )
 
         OrganizationOption.objects.create(
             organization=org, key="sentry:account-rate-limit", value=0
@@ -644,15 +652,9 @@ class BackupTestCase(TransactionTestCase):
 
     @assume_test_silo_mode(SiloMode.CONTROL)
     def create_exhaustive_global_configs(self, owner: User):
+        self.create_exhaustive_api_keys_for_user(owner)
         self.create_exhaustive_global_configs_regional()
         ControlOption.objects.create(key="bar", value="b")
-        ApiAuthorization.objects.create(user=owner)
-        ApiToken.objects.create(
-            user=owner,
-            expires_at=None,
-            name="create_exhaustive_global_configs",
-            token_type=AuthTokenType.USER,
-        )
 
     @assume_test_silo_mode(SiloMode.REGION)
     def create_exhaustive_global_configs_regional(self):
@@ -669,13 +671,38 @@ class BackupTestCase(TransactionTestCase):
         extensions, and all global flags set.
         """
 
-        owner = self.create_exhaustive_user(
-            "owner", is_admin=is_superadmin, is_superuser=is_superadmin, is_staff=is_superadmin
+        superadmin = self.create_exhaustive_user(
+            "superadmin", is_admin=is_superadmin, is_superuser=is_superadmin, is_staff=is_superadmin
         )
+        owner = self.create_exhaustive_user("owner")
         member = self.create_exhaustive_user("member")
-        org = self.create_exhaustive_organization("test-org", owner, member)
+        org = self.create_exhaustive_organization(
+            "test-org",
+            owner,
+            member,
+            pending_invites={
+                superadmin: "invited-by-superadmin-not-in-org@example.com",
+                owner: "invited-by-org-owner@example.com",
+                member: "invited-by-org-member@example.com",
+            },
+            accepted_invites={
+                superadmin: [self.create_exhaustive_user("added-by-superadmin-not-in-org")],
+                owner: [self.create_exhaustive_user("added-by-org-owner")],
+                member: [self.create_exhaustive_user("added-by-org-member")],
+            },
+        )
         self.create_exhaustive_sentry_app("test app", owner, org)
         self.create_exhaustive_global_configs(owner)
+
+    @assume_test_silo_mode(SiloMode.CONTROL)
+    def create_exhaustive_api_keys_for_user(self, user: User):
+        ApiAuthorization.objects.create(user=user)
+        ApiToken.objects.create(
+            user=user,
+            expires_at=None,
+            name=f"create_exhaustive_global_configs_for_{user.name}",
+            token_type=AuthTokenType.USER,
+        )
 
     def import_export_then_validate(self, out_name, *, reset_pks: bool = True) -> Any:
         return import_export_then_validate(out_name, reset_pks=reset_pks)

--- a/tests/sentry/backup/snapshots/ReleaseTests/test_at_head.pysnap
+++ b/tests/sentry/backup/snapshots/ReleaseTests/test_at_head.pysnap
@@ -1,18 +1,18 @@
 ---
-created: '2024-05-16T20:51:24.715838+00:00'
+created: '2024-05-28T16:56:39.161027+00:00'
 creator: sentry
 source: tests/sentry/backup/test_releases.py
 ---
 - fields:
     key: bar
-    last_updated: '2024-05-16T20:51:24.419Z'
+    last_updated: '2024-05-28T16:56:38.856Z'
     last_updated_by: unknown
     value: '"b"'
   model: sentry.controloption
   pk: 1
 - fields:
-    date_added: '2024-05-16T20:51:23.930Z'
-    date_updated: '2024-05-16T20:51:23.931Z'
+    date_added: '2024-05-28T16:56:38.393Z'
+    date_updated: '2024-05-28T16:56:38.393Z'
     external_id: slack:test-org
     metadata: {}
     name: Slack for test-org
@@ -22,13 +22,13 @@ source: tests/sentry/backup/test_releases.py
   pk: 1
 - fields:
     key: foo
-    last_updated: '2024-05-16T20:51:24.418Z'
+    last_updated: '2024-05-28T16:56:38.855Z'
     last_updated_by: unknown
     value: '"a"'
   model: sentry.option
   pk: 1
 - fields:
-    date_added: '2024-05-16T20:51:23.512Z'
+    date_added: '2024-05-28T16:56:37.785Z'
     default_role: member
     flags: '1'
     is_test: false
@@ -36,40 +36,40 @@ source: tests/sentry/backup/test_releases.py
     slug: test-org
     status: 0
   model: sentry.organization
-  pk: 4554016097501184
+  pk: 4554083122085888
 - fields:
-    date_added: '2024-05-16T20:51:24.104Z'
+    date_added: '2024-05-28T16:56:38.553Z'
     default_role: member
     flags: '1'
     is_test: false
-    name: Infinite Malamute
-    slug: infinite-malamute
+    name: Alert Redbird
+    slug: alert-redbird
     status: 0
   model: sentry.organization
-  pk: 4554016097566720
+  pk: 4554083122151427
 - fields:
     config:
       hello: hello
-    date_added: '2024-05-16T20:51:23.931Z'
-    date_updated: '2024-05-16T20:51:23.931Z'
+    date_added: '2024-05-28T16:56:38.394Z'
+    date_updated: '2024-05-28T16:56:38.394Z'
     default_auth_id: null
     grace_period_end: null
     integration: 1
-    organization_id: 4554016097501184
+    organization_id: 4554083122085888
     status: 0
   model: sentry.organizationintegration
   pk: 1
 - fields:
     key: sentry:account-rate-limit
-    organization: 4554016097501184
+    organization: 4554083122085888
     value: 0
   model: sentry.organizationoption
   pk: 1
 - fields:
-    date_added: '2024-05-16T20:51:23.769Z'
-    date_updated: '2024-05-16T20:51:23.770Z'
+    date_added: '2024-05-28T16:56:38.246Z'
+    date_updated: '2024-05-28T16:56:38.246Z'
     name: template-test-org
-    organization: 4554016097501184
+    organization: 4554083122085888
   model: sentry.projecttemplate
   pk: 1
 - fields:
@@ -82,45 +82,45 @@ source: tests/sentry/backup/test_releases.py
     first_seen: null
     is_internal: true
     last_seen: null
-    public_key: Alr5qAtd8GxwYx5bIQ3KOr65b8rewgwpX16QCF3rW7g
-    relay_id: e49aba99-acd4-4dc6-a6cb-bdede2c075d3
+    public_key: OUmfu1i-maro-0zJYRXrnNSfpyqWy5JKtP3dEbzyd2k
+    relay_id: 80ffbd40-d4e6-4b5a-8d7e-21a205dc7361
   model: sentry.relay
   pk: 1
 - fields:
-    first_seen: '2024-05-16T20:51:24.417Z'
-    last_seen: '2024-05-16T20:51:24.417Z'
-    public_key: Alr5qAtd8GxwYx5bIQ3KOr65b8rewgwpX16QCF3rW7g
-    relay_id: e49aba99-acd4-4dc6-a6cb-bdede2c075d3
+    first_seen: '2024-05-28T16:56:38.854Z'
+    last_seen: '2024-05-28T16:56:38.854Z'
+    public_key: OUmfu1i-maro-0zJYRXrnNSfpyqWy5JKtP3dEbzyd2k
+    relay_id: 80ffbd40-d4e6-4b5a-8d7e-21a205dc7361
     version: 0.0.1
   model: sentry.relayusage
   pk: 1
 - fields:
     config: {}
-    date_added: '2024-05-16T20:51:24.089Z'
+    date_added: '2024-05-28T16:56:38.539Z'
     external_id: https://git.example.com:1234
     integration_id: 1
     languages: '[]'
     name: getsentry/getsentry
-    organization_id: 4554016097501184
+    organization_id: 4554083122085888
     provider: integrations:github
     status: 0
     url: https://github.com/getsentry/getsentry
   model: sentry.repository
   pk: 1
 - fields:
-    date_added: '2024-05-16T20:51:23.711Z'
+    date_added: '2024-05-28T16:56:38.189Z'
     idp_provisioned: false
     name: test_team_in_test-org
-    organization: 4554016097501184
+    organization: 4554083122085888
     slug: test_team_in_test-org
     status: 0
   model: sentry.team
-  pk: 4554016097501185
+  pk: 4554083122151424
 - fields:
     avatar_type: 0
     avatar_url: null
-    date_joined: '2024-05-16T20:51:22.753Z'
-    email: owner
+    date_joined: '2024-05-28T16:56:37.117Z'
+    email: superadmin
     flags: '0'
     is_active: true
     is_managed: false
@@ -129,19 +129,41 @@ source: tests/sentry/backup/test_releases.py
     is_staff: true
     is_superuser: true
     is_unclaimed: false
-    last_active: '2024-05-16T20:51:22.753Z'
+    last_active: '2024-05-28T16:56:37.117Z'
     last_login: null
-    last_password_change: '2024-05-16T20:51:22.753Z'
+    last_password_change: '2024-05-28T16:56:37.117Z'
     name: ''
-    password: md5$K3ZeSCYghggBrfxUd4l3i4$a9631f94453d1280a376e80509859382
+    password: md5$qW6vFeYWYQCMEL6q5OiHHQ$81af5bc438b936045dfd580b0e4f8ff1
     session_nonce: null
-    username: owner
+    username: superadmin
   model: sentry.user
   pk: 1
 - fields:
     avatar_type: 0
     avatar_url: null
-    date_joined: '2024-05-16T20:51:23.485Z'
+    date_joined: '2024-05-28T16:56:37.695Z'
+    email: owner
+    flags: '0'
+    is_active: true
+    is_managed: false
+    is_password_expired: false
+    is_sentry_app: null
+    is_staff: false
+    is_superuser: false
+    is_unclaimed: false
+    last_active: '2024-05-28T16:56:37.695Z'
+    last_login: null
+    last_password_change: '2024-05-28T16:56:37.695Z'
+    name: ''
+    password: md5$47AVsnAsOojIn9bYR83WM0$98bb32ed516051dcfb65a1a566e466b4
+    session_nonce: null
+    username: owner
+  model: sentry.user
+  pk: 2
+- fields:
+    avatar_type: 0
+    avatar_url: null
+    date_joined: '2024-05-28T16:56:37.714Z'
     email: member
     flags: '0'
     is_active: true
@@ -151,19 +173,85 @@ source: tests/sentry/backup/test_releases.py
     is_staff: false
     is_superuser: false
     is_unclaimed: false
-    last_active: '2024-05-16T20:51:23.485Z'
+    last_active: '2024-05-28T16:56:37.714Z'
     last_login: null
-    last_password_change: '2024-05-16T20:51:23.485Z'
+    last_password_change: '2024-05-28T16:56:37.714Z'
     name: ''
-    password: md5$URMRqIYbd38mZyB41lSHbo$557159944db551879008c4be52e07fe7
+    password: md5$m5YneVjt3gyjwMbpy6kmCK$1931753247bd9cce8e21babae51d84f2
     session_nonce: null
     username: member
   model: sentry.user
-  pk: 2
+  pk: 3
 - fields:
     avatar_type: 0
     avatar_url: null
-    date_joined: '2024-05-16T20:51:24.024Z'
+    date_joined: '2024-05-28T16:56:37.732Z'
+    email: added-by-superadmin-not-in-org
+    flags: '0'
+    is_active: true
+    is_managed: false
+    is_password_expired: false
+    is_sentry_app: null
+    is_staff: false
+    is_superuser: false
+    is_unclaimed: false
+    last_active: '2024-05-28T16:56:37.732Z'
+    last_login: null
+    last_password_change: '2024-05-28T16:56:37.732Z'
+    name: ''
+    password: md5$7dEfxZnykO4cweKmtnVCNS$adb8a3f12d6e242569cff5c7b06d8560
+    session_nonce: null
+    username: added-by-superadmin-not-in-org
+  model: sentry.user
+  pk: 4
+- fields:
+    avatar_type: 0
+    avatar_url: null
+    date_joined: '2024-05-28T16:56:37.749Z'
+    email: added-by-org-owner
+    flags: '0'
+    is_active: true
+    is_managed: false
+    is_password_expired: false
+    is_sentry_app: null
+    is_staff: false
+    is_superuser: false
+    is_unclaimed: false
+    last_active: '2024-05-28T16:56:37.749Z'
+    last_login: null
+    last_password_change: '2024-05-28T16:56:37.750Z'
+    name: ''
+    password: md5$tGJlFGR7v9Sm2NDJPlqEWM$0c8372f014e8294dcfbbd88e78b3601d
+    session_nonce: null
+    username: added-by-org-owner
+  model: sentry.user
+  pk: 5
+- fields:
+    avatar_type: 0
+    avatar_url: null
+    date_joined: '2024-05-28T16:56:37.767Z'
+    email: added-by-org-member
+    flags: '0'
+    is_active: true
+    is_managed: false
+    is_password_expired: false
+    is_sentry_app: null
+    is_staff: false
+    is_superuser: false
+    is_unclaimed: false
+    last_active: '2024-05-28T16:56:37.767Z'
+    last_login: null
+    last_password_change: '2024-05-28T16:56:37.767Z'
+    name: ''
+    password: md5$dYFzs5DQDK4p9rL0bjKrSs$13705076007769a0324dd0c1617cb9c3
+    session_nonce: null
+    username: added-by-org-member
+  model: sentry.user
+  pk: 6
+- fields:
+    avatar_type: 0
+    avatar_url: null
+    date_joined: '2024-05-28T16:56:38.478Z'
     email: admin@localhost
     flags: '0'
     is_active: true
@@ -173,20 +261,20 @@ source: tests/sentry/backup/test_releases.py
     is_staff: true
     is_superuser: true
     is_unclaimed: false
-    last_active: '2024-05-16T20:51:24.024Z'
+    last_active: '2024-05-28T16:56:38.478Z'
     last_login: null
-    last_password_change: '2024-05-16T20:51:24.024Z'
+    last_password_change: '2024-05-28T16:56:38.478Z'
     name: ''
-    password: md5$RezP0asu5ZekHHnVkT2exN$b7e2a9ca64424074fd4a96fefaac74ac
+    password: md5$gNQfzyhiRm8F4G6zk5goIZ$03ff87f1427b5d0078efcc91538e15b8
     session_nonce: null
     username: admin@localhost
   model: sentry.user
-  pk: 3
+  pk: 7
 - fields:
     avatar_type: 0
     avatar_url: null
-    date_joined: '2024-05-16T20:51:24.092Z'
-    email: fe87e607391e48c88b53dfc959e55b92@example.com
+    date_joined: '2024-05-28T16:56:38.542Z'
+    email: b224f8aaad404d2ca06d9674f8e3d770@example.com
     flags: '0'
     is_active: true
     is_managed: false
@@ -195,19 +283,19 @@ source: tests/sentry/backup/test_releases.py
     is_staff: false
     is_superuser: false
     is_unclaimed: false
-    last_active: '2024-05-16T20:51:24.092Z'
+    last_active: '2024-05-28T16:56:38.542Z'
     last_login: null
-    last_password_change: '2024-05-16T20:51:24.092Z'
+    last_password_change: '2024-05-28T16:56:38.542Z'
     name: ''
-    password: md5$TJPojDipvs6hp9Bk3UvV3G$373a778fb32af40c1ed2b07ed129ca70
+    password: md5$CshYknTUuboV1lpuAK0wSP$4d41a8929dacbf0b82fa7170a4860d0b
     session_nonce: null
-    username: fe87e607391e48c88b53dfc959e55b92@example.com
+    username: b224f8aaad404d2ca06d9674f8e3d770@example.com
   model: sentry.user
-  pk: 4
+  pk: 8
 - fields:
     avatar_type: 0
     avatar_url: null
-    date_joined: '2024-05-16T20:51:24.162Z'
+    date_joined: '2024-05-28T16:56:38.608Z'
     email: ''
     flags: '0'
     is_active: true
@@ -217,20 +305,20 @@ source: tests/sentry/backup/test_releases.py
     is_staff: false
     is_superuser: false
     is_unclaimed: false
-    last_active: '2024-05-16T20:51:24.162Z'
+    last_active: '2024-05-28T16:56:38.608Z'
     last_login: null
     last_password_change: null
     name: ''
     password: ''
     session_nonce: null
-    username: test-app-56509f56-ca39-4ec7-9498-07b973a720d9
+    username: test-app-c1bed4b5-5f34-4e5f-a1cf-429d7b6a74d5
   model: sentry.user
-  pk: 5
+  pk: 9
 - fields:
     avatar_type: 0
     avatar_url: null
-    date_joined: '2024-05-16T20:51:24.350Z'
-    email: b7734f629f4248f8ad7aea5b84b6abb5@example.com
+    date_joined: '2024-05-28T16:56:38.794Z'
+    email: 048e6d902f1f489dbfacae45482c7ace@example.com
     flags: '0'
     is_active: true
     is_managed: false
@@ -239,15 +327,15 @@ source: tests/sentry/backup/test_releases.py
     is_staff: false
     is_superuser: false
     is_unclaimed: false
-    last_active: '2024-05-16T20:51:24.350Z'
+    last_active: '2024-05-28T16:56:38.794Z'
     last_login: null
-    last_password_change: '2024-05-16T20:51:24.350Z'
+    last_password_change: '2024-05-28T16:56:38.794Z'
     name: ''
-    password: md5$oRjQlJxjH4PuIssdA3ZH3f$bfd53903cf6316edc4f2a8396eea7b6a
+    password: md5$QJ0kE1ktm9bS4oj9nzfnm9$1c69204b49e8fd8ef60bf677440a3741
     session_nonce: null
-    username: b7734f629f4248f8ad7aea5b84b6abb5@example.com
+    username: 048e6d902f1f489dbfacae45482c7ace@example.com
   model: sentry.user
-  pk: 6
+  pk: 10
 - fields:
     country_code: null
     first_seen: '2012-04-05T03:29:45.000Z'
@@ -267,29 +355,65 @@ source: tests/sentry/backup/test_releases.py
   model: sentry.userip
   pk: 2
 - fields:
+    country_code: null
+    first_seen: '2012-04-05T03:29:45.000Z'
+    ip_address: 127.0.0.2
+    last_seen: '2012-04-05T03:29:45.000Z'
+    region_code: null
+    user: 3
+  model: sentry.userip
+  pk: 3
+- fields:
+    country_code: null
+    first_seen: '2012-04-05T03:29:45.000Z'
+    ip_address: 127.0.0.2
+    last_seen: '2012-04-05T03:29:45.000Z'
+    region_code: null
+    user: 4
+  model: sentry.userip
+  pk: 4
+- fields:
+    country_code: null
+    first_seen: '2012-04-05T03:29:45.000Z'
+    ip_address: 127.0.0.2
+    last_seen: '2012-04-05T03:29:45.000Z'
+    region_code: null
+    user: 5
+  model: sentry.userip
+  pk: 5
+- fields:
+    country_code: null
+    first_seen: '2012-04-05T03:29:45.000Z'
+    ip_address: 127.0.0.2
+    last_seen: '2012-04-05T03:29:45.000Z'
+    region_code: null
+    user: 6
+  model: sentry.userip
+  pk: 6
+- fields:
     permission: users.admin
     user: 1
   model: sentry.userpermission
   pk: 1
 - fields:
-    date_added: '2024-05-16T20:51:22.779Z'
-    date_updated: '2024-05-16T20:51:22.779Z'
+    date_added: '2024-05-28T16:56:37.144Z'
+    date_updated: '2024-05-28T16:56:37.144Z'
     name: test-admin-role
     permissions: '[]'
   model: sentry.userrole
   pk: 1
 - fields:
-    date_added: '2024-05-16T20:51:22.785Z'
-    date_updated: '2024-05-16T20:51:22.785Z'
+    date_added: '2024-05-28T16:56:37.149Z'
+    date_updated: '2024-05-28T16:56:37.149Z'
     role: 1
     user: 1
   model: sentry.userroleuser
   pk: 1
 - fields:
-    date_added: '2024-05-16T20:51:24.082Z'
+    date_added: '2024-05-28T16:56:38.532Z'
     is_global: false
     name: Saved query for test-org
-    organization: 4554016097501184
+    organization: 4554083122085888
     owner_id: null
     query: saved query for test-org
     sort: date
@@ -298,223 +422,345 @@ source: tests/sentry/backup/test_releases.py
   model: sentry.savedsearch
   pk: 1
 - fields:
-    date_added: '2024-05-16T20:51:24.081Z'
-    last_seen: '2024-05-16T20:51:24.081Z'
-    organization: 4554016097501184
+    date_added: '2024-05-28T16:56:38.531Z'
+    last_seen: '2024-05-28T16:56:38.531Z'
+    organization: 4554083122085888
     query: some query for test-org
     query_hash: 7c69362cd42207b83f80087bc15ebccb
     type: 0
-    user_id: 1
+    user_id: 2
   model: sentry.recentsearch
   pk: 1
 - fields:
-    date_added: '2024-05-16T20:51:23.773Z'
+    date_added: '2024-05-28T16:56:38.248Z'
     first_event: null
     flags: '10'
     forced_color: null
     name: project-test-org
-    organization: 4554016097501184
+    organization: 4554083122085888
     platform: null
     public: false
     slug: project-test-org
     status: 0
     template: null
   model: sentry.project
-  pk: 4554016097501186
+  pk: 4554083122151425
 - fields:
-    date_added: '2024-05-16T20:51:23.962Z'
+    date_added: '2024-05-28T16:56:38.422Z'
     first_event: null
     flags: '10'
     forced_color: null
     name: other-project-test-org
-    organization: 4554016097501184
+    organization: 4554083122085888
     platform: null
     public: false
     slug: other-project-test-org
     status: 0
     template: null
   model: sentry.project
-  pk: 4554016097501187
+  pk: 4554083122151426
 - fields:
-    date_added: '2024-05-16T20:51:24.179Z'
+    date_added: '2024-05-28T16:56:38.625Z'
     first_event: null
     flags: '10'
     forced_color: null
-    name: Renewing Elephant
-    organization: 4554016097501184
+    name: Musical Fly
+    organization: 4554083122085888
     platform: null
     public: false
-    slug: renewing-elephant
+    slug: musical-fly
     status: 0
     template: null
   model: sentry.project
-  pk: 4554016097566721
+  pk: 4554083122151428
 - fields:
-    date_added: '2024-05-16T20:51:24.362Z'
+    date_added: '2024-05-28T16:56:38.805Z'
     first_event: null
     flags: '10'
     forced_color: null
-    name: Current Drake
-    organization: 4554016097501184
+    name: Balanced Eel
+    organization: 4554083122085888
     platform: null
     public: false
-    slug: current-drake
+    slug: balanced-eel
     status: 0
     template: null
   model: sentry.project
-  pk: 4554016097566722
+  pk: 4554083122151429
 - fields:
     created_by: null
-    date_added: '2024-05-16T20:51:23.909Z'
+    date_added: '2024-05-28T16:56:38.372Z'
     date_deactivated: null
     date_last_used: null
     name: token 1 for test-org
-    organization_id: 4554016097501184
-    project_last_used_id: 4554016097501186
+    organization_id: 4554083122085888
+    project_last_used_id: 4554083122151425
     scope_list: '[''org:ci'']'
     token_hashed: ABCDEFtest-org
     token_last_characters: xyz1
   model: sentry.orgauthtoken
   pk: 1
 - fields:
-    date_added: '2024-05-16T20:51:23.587Z'
+    date_added: '2024-05-28T16:56:37.845Z'
     email: null
     flags: '0'
     has_global_access: true
     invite_status: 0
     inviter_id: null
-    organization: 4554016097501184
+    organization: 4554083122085888
     role: owner
     token: null
     token_expires_at: null
     type: 50
     user_email: owner
-    user_id: 1
+    user_id: 2
     user_is_active: true
   model: sentry.organizationmember
   pk: 1
 - fields:
-    date_added: '2024-05-16T20:51:23.639Z'
+    date_added: '2024-05-28T16:56:37.897Z'
     email: null
     flags: '0'
     has_global_access: true
     invite_status: 0
     inviter_id: null
-    organization: 4554016097501184
+    organization: 4554083122085888
     role: member
     token: null
     token_expires_at: null
     type: 50
     user_email: member
-    user_id: 2
+    user_id: 3
     user_is_active: true
   model: sentry.organizationmember
   pk: 2
 - fields:
+    date_added: '2024-05-28T16:56:37.954Z'
+    email: invited-by-superadmin-not-in-org@example.com
+    flags: '0'
+    has_global_access: true
+    invite_status: 1
+    inviter_id: 1
+    organization: 4554083122085888
+    role: member
+    token: null
+    token_expires_at: null
+    type: 50
+    user_email: null
+    user_id: null
+    user_is_active: true
+  model: sentry.organizationmember
+  pk: 3
+- fields:
+    date_added: '2024-05-28T16:56:37.978Z'
+    email: invited-by-org-owner@example.com
+    flags: '0'
+    has_global_access: true
+    invite_status: 1
+    inviter_id: 2
+    organization: 4554083122085888
+    role: member
+    token: null
+    token_expires_at: null
+    type: 50
+    user_email: null
+    user_id: null
+    user_is_active: true
+  model: sentry.organizationmember
+  pk: 4
+- fields:
+    date_added: '2024-05-28T16:56:38.000Z'
+    email: invited-by-org-member@example.com
+    flags: '0'
+    has_global_access: true
+    invite_status: 1
+    inviter_id: 3
+    organization: 4554083122085888
+    role: member
+    token: null
+    token_expires_at: null
+    type: 50
+    user_email: null
+    user_id: null
+    user_is_active: true
+  model: sentry.organizationmember
+  pk: 5
+- fields:
+    date_added: '2024-05-28T16:56:38.022Z'
+    email: null
+    flags: '0'
+    has_global_access: true
+    invite_status: 0
+    inviter_id: 1
+    organization: 4554083122085888
+    role: member
+    token: null
+    token_expires_at: null
+    type: 50
+    user_email: added-by-superadmin-not-in-org
+    user_id: 4
+    user_is_active: true
+  model: sentry.organizationmember
+  pk: 6
+- fields:
+    date_added: '2024-05-28T16:56:38.072Z'
+    email: null
+    flags: '0'
+    has_global_access: true
+    invite_status: 0
+    inviter_id: 2
+    organization: 4554083122085888
+    role: member
+    token: null
+    token_expires_at: null
+    type: 50
+    user_email: added-by-org-owner
+    user_id: 5
+    user_is_active: true
+  model: sentry.organizationmember
+  pk: 7
+- fields:
+    date_added: '2024-05-28T16:56:38.119Z'
+    email: null
+    flags: '0'
+    has_global_access: true
+    invite_status: 0
+    inviter_id: 3
+    organization: 4554083122085888
+    role: member
+    token: null
+    token_expires_at: null
+    type: 50
+    user_email: added-by-org-member
+    user_id: 6
+    user_is_active: true
+  model: sentry.organizationmember
+  pk: 8
+- fields:
     member: 2
     requester_id: null
-    team: 4554016097501185
+    team: 4554083122151424
   model: sentry.organizationaccessrequest
   pk: 1
 - fields:
     config:
       schedule: '* * * * *'
       schedule_type: 1
-    date_added: '2024-05-16T20:51:23.957Z'
-    guid: bddedecf-989d-4150-b8c1-dc9480ec7ba5
+    date_added: '2024-05-28T16:56:38.418Z'
+    guid: 44bb683d-317e-4f05-827b-235a83fb027f
     is_muted: false
     name: ''
-    organization_id: 4554016097501184
+    organization_id: 4554083122085888
     owner_team_id: null
     owner_user_id: null
-    project_id: 4554016097501186
-    slug: 1087680245a9
+    project_id: 4554083122151425
+    slug: ed7fddf64f46
     status: 0
     type: 3
   model: sentry.monitor
   pk: 1
 - fields:
-    date_added: '2024-05-16T20:51:23.954Z'
-    name: precisely equal humpback
-    organization_id: 4554016097501184
+    date_added: '2024-05-28T16:56:38.415Z'
+    name: nearly amazed mantis
+    organization_id: 4554083122085888
   model: sentry.environment
   pk: 1
 - fields:
-    date_added: '2024-05-16T20:51:22.759Z'
-    email: owner
+    date_added: '2024-05-28T16:56:37.123Z'
+    email: superadmin
   model: sentry.email
   pk: 1
 - fields:
-    date_added: '2024-05-16T20:51:23.493Z'
-    email: member
+    date_added: '2024-05-28T16:56:37.700Z'
+    email: owner
   model: sentry.email
   pk: 2
 - fields:
-    date_added: '2024-05-16T20:51:24.029Z'
-    email: admin@localhost
+    date_added: '2024-05-28T16:56:37.718Z'
+    email: member
   model: sentry.email
   pk: 3
 - fields:
-    date_added: '2024-05-16T20:51:24.097Z'
-    email: fe87e607391e48c88b53dfc959e55b92@example.com
+    date_added: '2024-05-28T16:56:37.736Z'
+    email: added-by-superadmin-not-in-org
   model: sentry.email
   pk: 4
 - fields:
-    date_added: '2024-05-16T20:51:24.166Z'
-    email: ''
+    date_added: '2024-05-28T16:56:37.754Z'
+    email: added-by-org-owner
   model: sentry.email
   pk: 5
 - fields:
-    date_added: '2024-05-16T20:51:24.355Z'
-    email: b7734f629f4248f8ad7aea5b84b6abb5@example.com
+    date_added: '2024-05-28T16:56:37.771Z'
+    email: added-by-org-member
   model: sentry.email
   pk: 6
 - fields:
-    date_added: '2024-05-16T20:51:24.080Z'
-    organization: 4554016097501184
+    date_added: '2024-05-28T16:56:38.482Z'
+    email: admin@localhost
+  model: sentry.email
+  pk: 7
+- fields:
+    date_added: '2024-05-28T16:56:38.546Z'
+    email: b224f8aaad404d2ca06d9674f8e3d770@example.com
+  model: sentry.email
+  pk: 8
+- fields:
+    date_added: '2024-05-28T16:56:38.613Z'
+    email: ''
+  model: sentry.email
+  pk: 9
+- fields:
+    date_added: '2024-05-28T16:56:38.798Z'
+    email: 048e6d902f1f489dbfacae45482c7ace@example.com
+  model: sentry.email
+  pk: 10
+- fields:
+    date_added: '2024-05-28T16:56:38.530Z'
+    organization: 4554083122085888
     slug: test-tombstone-in-test-org
   model: sentry.dashboardtombstone
   pk: 1
 - fields:
-    created_by_id: 1
-    date_added: '2024-05-16T20:51:24.076Z'
+    created_by_id: 2
+    date_added: '2024-05-28T16:56:38.526Z'
     filters: null
-    last_visited: '2024-05-16T20:51:24.076Z'
-    organization: 4554016097501184
+    last_visited: '2024-05-28T16:56:38.526Z'
+    organization: 4554083122085888
     title: Dashboard 1 for test-org
     visits: 1
   model: sentry.dashboard
   pk: 1
 - fields:
     condition: '{"op":"equals","name":"environment","value":"prod"}'
-    condition_hash: 30a4e96accb51160d791dbae45d3740fa0af5492
+    condition_hash: 2667deba459b25603bacafe7e136f1bcfae800eb
     created_by_id: null
-    date_added: '2024-05-16T20:51:23.947Z'
-    end_date: '2024-05-16T21:51:23.943Z'
+    date_added: '2024-05-28T16:56:38.409Z'
+    end_date: '2024-05-28T17:56:38.405Z'
     is_active: true
     is_org_level: false
     notification_sent: false
     num_samples: 100
-    organization: 4554016097501184
+    organization: 4554083122085888
     query: environment:prod event.type:transaction
     rule_id: 1
     sample_rate: 0.5
-    start_date: '2024-05-16T20:51:23.943Z'
+    start_date: '2024-05-28T16:56:38.405Z'
   model: sentry.customdynamicsamplingrule
   pk: 1
 - fields:
-    project: 4554016097501186
+    project: 4554083122151425
     value: 1
   model: sentry.counter
   pk: 1
 - fields:
     config: {}
-    date_added: '2024-05-16T20:51:23.853Z'
+    date_added: '2024-05-28T16:56:38.323Z'
     default_global_access: true
     default_role: 50
     flags: '0'
     last_sync: null
-    organization_id: 4554016097501184
+    organization_id: 4554083122085888
     provider: sentry
     sync_time: null
   model: sentry.authprovider
@@ -530,16 +776,16 @@ source: tests/sentry/backup/test_releases.py
       - 3
       key4:
         nested_key: nested_value
-    date_added: '2024-05-16T20:51:23.878Z'
+    date_added: '2024-05-28T16:56:38.347Z'
     ident: 123456789test-org
-    last_synced: '2024-05-16T20:51:23.878Z'
-    last_verified: '2024-05-16T20:51:23.878Z'
-    user: 1
+    last_synced: '2024-05-28T16:56:38.347Z'
+    last_verified: '2024-05-28T16:56:38.347Z'
+    user: 2
   model: sentry.authidentity
   pk: 1
 - fields:
     config: '""'
-    created_at: '2024-05-16T20:51:22.769Z'
+    created_at: '2024-05-28T16:56:37.134Z'
     last_used_at: null
     type: 1
     user: 1
@@ -547,18 +793,50 @@ source: tests/sentry/backup/test_releases.py
   pk: 1
 - fields:
     config: '""'
-    created_at: '2024-05-16T20:51:23.507Z'
+    created_at: '2024-05-28T16:56:37.710Z'
     last_used_at: null
     type: 1
     user: 2
   model: sentry.authenticator
   pk: 2
 - fields:
+    config: '""'
+    created_at: '2024-05-28T16:56:37.727Z'
+    last_used_at: null
+    type: 1
+    user: 3
+  model: sentry.authenticator
+  pk: 3
+- fields:
+    config: '""'
+    created_at: '2024-05-28T16:56:37.745Z'
+    last_used_at: null
+    type: 1
+    user: 4
+  model: sentry.authenticator
+  pk: 4
+- fields:
+    config: '""'
+    created_at: '2024-05-28T16:56:37.763Z'
+    last_used_at: null
+    type: 1
+    user: 5
+  model: sentry.authenticator
+  pk: 5
+- fields:
+    config: '""'
+    created_at: '2024-05-28T16:56:37.780Z'
+    last_used_at: null
+    type: 1
+    user: 6
+  model: sentry.authenticator
+  pk: 6
+- fields:
     allowed_origins: null
-    date_added: '2024-05-16T20:51:23.829Z'
-    key: 27219e349a31460aaff47cbfaeee852c
+    date_added: '2024-05-28T16:56:38.302Z'
+    key: f553451d535340abb14f9a4485b8d5fb
     label: Default
-    organization_id: 4554016097501184
+    organization_id: 4554083122085888
     scope_list: '[]'
     scopes: '0'
     status: 0
@@ -566,12 +844,12 @@ source: tests/sentry/backup/test_releases.py
   pk: 1
 - fields:
     allowed_origins: ''
-    client_id: 89852f579627b7d33a9610ac516cfa54c16a27d5dc4ab7bd1354ec741655d41b
-    client_secret: 05cd905bbc775a3ee3816e62bb732081032fbfd9d5835a3afbadcbf39ac1a697
-    date_added: '2024-05-16T20:51:24.172Z'
+    client_id: cfde15cb49c2e350786335e0a3b25fdd85ceeedf38b81628909f04c775fb4e84
+    client_secret: 3256d0beea28e15398c14d53602598d5bcc7f0a03c4125ac39eb625b32fb8f25
+    date_added: '2024-05-28T16:56:38.619Z'
     homepage_url: null
-    name: Guiding Feline
-    owner: 5
+    name: Obliging Javelin
+    owner: 9
     privacy_url: null
     redirect_uris: ''
     status: 0
@@ -595,57 +873,121 @@ source: tests/sentry/backup/test_releases.py
   model: sentry.useroption
   pk: 2
 - fields:
-    date_hash_added: '2024-05-16T20:51:22.756Z'
-    email: owner
+    key: timezone
+    organization_id: null
+    project_id: null
+    user: 3
+    value: '"Europe/Vienna"'
+  model: sentry.useroption
+  pk: 3
+- fields:
+    key: timezone
+    organization_id: null
+    project_id: null
+    user: 4
+    value: '"Europe/Vienna"'
+  model: sentry.useroption
+  pk: 4
+- fields:
+    key: timezone
+    organization_id: null
+    project_id: null
+    user: 5
+    value: '"Europe/Vienna"'
+  model: sentry.useroption
+  pk: 5
+- fields:
+    key: timezone
+    organization_id: null
+    project_id: null
+    user: 6
+    value: '"Europe/Vienna"'
+  model: sentry.useroption
+  pk: 6
+- fields:
+    date_hash_added: '2024-05-28T16:56:37.120Z'
+    email: superadmin
     is_verified: true
     user: 1
-    validation_hash: 3QdWaC4LmilCveqFu2JE09IK9O0U4Yfr
+    validation_hash: 7dSAtDtmv32rBJP9hhs9nKyOUBhzQApZ
   model: sentry.useremail
   pk: 1
 - fields:
-    date_hash_added: '2024-05-16T20:51:23.488Z'
-    email: member
+    date_hash_added: '2024-05-28T16:56:37.697Z'
+    email: owner
     is_verified: true
     user: 2
-    validation_hash: ADMSF43s51cyCHBejp4uG0sUDm3Oheje
+    validation_hash: Vm6OyTiZGqZmk8D5LNEtI3oWVC1KEmgm
   model: sentry.useremail
   pk: 2
 - fields:
-    date_hash_added: '2024-05-16T20:51:24.027Z'
-    email: admin@localhost
+    date_hash_added: '2024-05-28T16:56:37.716Z'
+    email: member
     is_verified: true
     user: 3
-    validation_hash: SiPJegdticbrXxaGB4mTOXGSDo2giusk
+    validation_hash: aIjYRiiPZsKGQE04E1qy2YZvoGmroseb
   model: sentry.useremail
   pk: 3
 - fields:
-    date_hash_added: '2024-05-16T20:51:24.094Z'
-    email: fe87e607391e48c88b53dfc959e55b92@example.com
+    date_hash_added: '2024-05-28T16:56:37.734Z'
+    email: added-by-superadmin-not-in-org
     is_verified: true
     user: 4
-    validation_hash: GS3SLtESn2hSdqRuGFdffCoot7oxQ6Ax
+    validation_hash: kSdwXsWFIswP2r4WyH0DSflJvPsyh5QU
   model: sentry.useremail
   pk: 4
 - fields:
-    date_hash_added: '2024-05-16T20:51:24.164Z'
-    email: ''
-    is_verified: false
+    date_hash_added: '2024-05-28T16:56:37.751Z'
+    email: added-by-org-owner
+    is_verified: true
     user: 5
-    validation_hash: 6uQFfpFnUq1HqdnBHbNZKouqk3DYG6ch
+    validation_hash: g5M4jnweVVfIU5yXct8NuxbKxJMWUXPZ
   model: sentry.useremail
   pk: 5
 - fields:
-    date_hash_added: '2024-05-16T20:51:24.352Z'
-    email: b7734f629f4248f8ad7aea5b84b6abb5@example.com
+    date_hash_added: '2024-05-28T16:56:37.769Z'
+    email: added-by-org-member
     is_verified: true
     user: 6
-    validation_hash: 9bo58slLI6dNA83zyRihCLJgMODk5pel
+    validation_hash: opD5HI4Tb2fm2LzNRCMwAeAcMIRNhL3m
   model: sentry.useremail
   pk: 6
 - fields:
+    date_hash_added: '2024-05-28T16:56:38.480Z'
+    email: admin@localhost
+    is_verified: true
+    user: 7
+    validation_hash: WBxvsZNJuVqfpfcssOjYEQrVuV72x7Qb
+  model: sentry.useremail
+  pk: 7
+- fields:
+    date_hash_added: '2024-05-28T16:56:38.544Z'
+    email: b224f8aaad404d2ca06d9674f8e3d770@example.com
+    is_verified: true
+    user: 8
+    validation_hash: FWqKdqj3KK7hRhFR6eUrKeV2yAT4d7z3
+  model: sentry.useremail
+  pk: 8
+- fields:
+    date_hash_added: '2024-05-28T16:56:38.610Z'
+    email: ''
+    is_verified: false
+    user: 9
+    validation_hash: xnZ9eD1uxBtaLxrmw1GPp11kwngZrMsU
+  model: sentry.useremail
+  pk: 9
+- fields:
+    date_hash_added: '2024-05-28T16:56:38.796Z'
+    email: 048e6d902f1f489dbfacae45482c7ace@example.com
+    is_verified: true
+    user: 10
+    validation_hash: vp44gXxeioOb332L7rMEBIcQ0NrJkgAs
+  model: sentry.useremail
+  pk: 10
+- fields:
     aggregate: count()
     dataset: events
-    date_added: '2024-05-16T20:51:24.004Z'
+    date_added: '2024-05-28T16:56:38.459Z'
     environment: null
     query: level:error
     resolution: 60
@@ -656,7 +998,7 @@ source: tests/sentry/backup/test_releases.py
 - fields:
     aggregate: count()
     dataset: events
-    date_added: '2024-05-16T20:51:24.038Z'
+    date_added: '2024-05-28T16:56:38.490Z'
     environment: null
     query: level:error
     resolution: 60
@@ -667,7 +1009,7 @@ source: tests/sentry/backup/test_releases.py
 - fields:
     aggregate: count()
     dataset: events
-    date_added: '2024-05-16T20:51:24.055Z'
+    date_added: '2024-05-28T16:56:38.507Z'
     environment: null
     query: test query
     resolution: 60
@@ -678,20 +1020,20 @@ source: tests/sentry/backup/test_releases.py
 - fields:
     application: 1
     author: A Company
-    creator_label: fe87e607391e48c88b53dfc959e55b92@example.com
-    creator_user: 4
-    date_added: '2024-05-16T20:51:24.173Z'
+    creator_label: b224f8aaad404d2ca06d9674f8e3d770@example.com
+    creator_user: 8
+    date_added: '2024-05-28T16:56:38.620Z'
     date_deleted: null
     date_published: null
-    date_updated: '2024-05-16T20:51:24.318Z'
+    date_updated: '2024-05-28T16:56:38.762Z'
     events: '[]'
     is_alertable: false
     metadata: {}
     name: test app
     overview: A sample description
-    owner_id: 4554016097501184
+    owner_id: 4554083122085888
     popularity: 1
-    proxy_user: 5
+    proxy_user: 9
     redirect_url: https://example.com/sentry-app/redirect/
     schema:
       elements:
@@ -730,27 +1072,27 @@ source: tests/sentry/backup/test_releases.py
     scopes: '0'
     slug: test-app
     status: 0
-    uuid: bdd08a34-8f61-4102-9636-bb60e1db8b7b
+    uuid: 161b8f7b-cc66-46e3-9e65-262e186673b4
     verify_install: true
     webhook_url: https://example.com/sentry-app/webhook/
   model: sentry.sentryapp
   pk: 1
 - fields:
     data: '{"conditions":[{"id":"sentry.rules.conditions.first_seen_event.FirstSeenEventCondition"},{"id":"sentry.rules.conditions.every_event.EveryEventCondition"}],"action_match":"all","filter_match":"all","actions":[{"id":"sentry.rules.actions.notify_event.NotifyEventAction"},{"id":"sentry.rules.actions.notify_event_service.NotifyEventServiceAction","service":"mail"}]}'
-    date_added: '2024-05-16T20:51:23.938Z'
+    date_added: '2024-05-28T16:56:38.401Z'
     environment_id: null
     label: ''
     owner_team: null
     owner_user_id: null
-    project: 4554016097501186
+    project: 4554083122151425
     source: 0
     status: 0
   model: sentry.rule
   pk: 1
 - fields:
-    date_added: '2024-05-16T20:51:24.013Z'
-    date_updated: '2024-05-16T20:51:24.013Z'
-    project: 4554016097501186
+    date_added: '2024-05-28T16:56:38.467Z'
+    date_updated: '2024-05-28T16:56:38.467Z'
+    project: 4554083122151425
     query_extra: null
     snuba_query: 1
     status: 1
@@ -759,9 +1101,9 @@ source: tests/sentry/backup/test_releases.py
   model: sentry.querysubscription
   pk: 1
 - fields:
-    date_added: '2024-05-16T20:51:24.046Z'
-    date_updated: '2024-05-16T20:51:24.046Z'
-    project: 4554016097501186
+    date_added: '2024-05-28T16:56:38.497Z'
+    date_updated: '2024-05-28T16:56:38.497Z'
+    project: 4554083122151425
     query_extra: null
     snuba_query: 2
     status: 1
@@ -770,9 +1112,9 @@ source: tests/sentry/backup/test_releases.py
   model: sentry.querysubscription
   pk: 2
 - fields:
-    date_added: '2024-05-16T20:51:24.060Z'
-    date_updated: '2024-05-16T20:51:24.060Z'
-    project: 4554016097501186
+    date_added: '2024-05-28T16:56:38.511Z'
+    date_updated: '2024-05-28T16:56:38.511Z'
+    project: 4554083122151425
     query_extra: null
     snuba_query: 3
     status: 1
@@ -781,9 +1123,9 @@ source: tests/sentry/backup/test_releases.py
   model: sentry.querysubscription
   pk: 3
 - fields:
-    date_added: '2024-05-16T20:51:24.183Z'
-    date_updated: '2024-05-16T20:51:24.183Z'
-    project: 4554016097566721
+    date_added: '2024-05-28T16:56:38.629Z'
+    date_updated: '2024-05-28T16:56:38.629Z'
+    project: 4554083122151428
     query_extra: null
     snuba_query: 1
     status: 1
@@ -792,9 +1134,9 @@ source: tests/sentry/backup/test_releases.py
   model: sentry.querysubscription
   pk: 4
 - fields:
-    date_added: '2024-05-16T20:51:24.365Z'
-    date_updated: '2024-05-16T20:51:24.365Z'
-    project: 4554016097566722
+    date_added: '2024-05-28T16:56:38.809Z'
+    date_updated: '2024-05-28T16:56:38.809Z'
+    project: 4554083122151429
     query_extra: null
     snuba_query: 1
     status: 1
@@ -803,30 +1145,30 @@ source: tests/sentry/backup/test_releases.py
   model: sentry.querysubscription
   pk: 5
 - fields:
-    project: 4554016097501186
-    team: 4554016097501185
+    project: 4554083122151425
+    team: 4554083122151424
   model: sentry.projectteam
   pk: 1
 - fields:
-    project: 4554016097501187
-    team: 4554016097501185
+    project: 4554083122151426
+    team: 4554083122151424
   model: sentry.projectteam
   pk: 2
 - fields:
-    date_added: '2024-05-16T20:51:23.821Z'
-    organization: 4554016097501184
-    project: 4554016097501186
+    date_added: '2024-05-28T16:56:38.294Z'
+    organization: 4554083122085888
+    project: 4554083122151425
     redirect_slug: project_slug_in_test-org
   model: sentry.projectredirect
   pk: 1
 - fields:
     auto_assignment: true
     codeowners_auto_sync: true
-    date_created: '2024-05-16T20:51:23.816Z'
+    date_created: '2024-05-28T16:56:38.289Z'
     fallthrough: true
     is_active: true
-    last_updated: '2024-05-16T20:51:23.816Z'
-    project: 4554016097501186
+    last_updated: '2024-05-28T16:56:38.289Z'
+    project: 4554083122151425
     raw: '{"hello":"hello"}'
     schema:
       hello: hello
@@ -835,73 +1177,73 @@ source: tests/sentry/backup/test_releases.py
   pk: 1
 - fields:
     key: sentry:relay-rev
-    project: 4554016097501186
-    value: '"71a59a2120174d58b59058c28e9f5cb9"'
+    project: 4554083122151425
+    value: '"a7e8adcb443244bf9bfce42f065332ea"'
   model: sentry.projectoption
   pk: 1
 - fields:
     key: sentry:relay-rev-lastchange
-    project: 4554016097501186
-    value: '"2024-05-16T20:51:23.800343Z"'
+    project: 4554083122151425
+    value: '"2024-05-28T16:56:38.273400Z"'
   model: sentry.projectoption
   pk: 2
 - fields:
     key: sentry:option-epoch
-    project: 4554016097501186
+    project: 4554083122151425
     value: 12
   model: sentry.projectoption
   pk: 3
 - fields:
     key: sentry:relay-rev
-    project: 4554016097501187
-    value: '"884c628019fc4f039a95cef448f524c2"'
+    project: 4554083122151426
+    value: '"295fb2183b3f4bbca1c49cf22127424f"'
   model: sentry.projectoption
   pk: 4
 - fields:
     key: sentry:relay-rev-lastchange
-    project: 4554016097501187
-    value: '"2024-05-16T20:51:23.988513Z"'
+    project: 4554083122151426
+    value: '"2024-05-28T16:56:38.446101Z"'
   model: sentry.projectoption
   pk: 5
 - fields:
     key: sentry:option-epoch
-    project: 4554016097501187
+    project: 4554083122151426
     value: 12
   model: sentry.projectoption
   pk: 6
 - fields:
     key: sentry:relay-rev
-    project: 4554016097566721
-    value: '"470a65ab0a1048268c0256749c3ceb3a"'
+    project: 4554083122151428
+    value: '"9ce2ace1b46a458c98040c44f3c8c987"'
   model: sentry.projectoption
   pk: 7
 - fields:
     key: sentry:relay-rev-lastchange
-    project: 4554016097566721
-    value: '"2024-05-16T20:51:24.208719Z"'
+    project: 4554083122151428
+    value: '"2024-05-28T16:56:38.653811Z"'
   model: sentry.projectoption
   pk: 8
 - fields:
     key: sentry:option-epoch
-    project: 4554016097566721
+    project: 4554083122151428
     value: 12
   model: sentry.projectoption
   pk: 9
 - fields:
     key: sentry:relay-rev
-    project: 4554016097566722
-    value: '"6e5cc0d1766845fa9127db1829e67f82"'
+    project: 4554083122151429
+    value: '"0ec8f6cd595b4464a711bbffe28b572b"'
   model: sentry.projectoption
   pk: 10
 - fields:
     key: sentry:relay-rev-lastchange
-    project: 4554016097566722
-    value: '"2024-05-16T20:51:24.390887Z"'
+    project: 4554083122151429
+    value: '"2024-05-28T16:56:38.831946Z"'
   model: sentry.projectoption
   pk: 11
 - fields:
     key: sentry:option-epoch
-    project: 4554016097566722
+    project: 4554083122151429
     value: 12
   model: sentry.projectoption
   pk: 12
@@ -910,14 +1252,14 @@ source: tests/sentry/backup/test_releases.py
       dynamicSdkLoaderOptions:
         hasPerformance: true
         hasReplay: true
-    date_added: '2024-05-16T20:51:23.794Z'
+    date_added: '2024-05-28T16:56:38.267Z'
     label: Default
-    project: 4554016097501186
-    public_key: 6a5d3d4d2736255c16fc60a7d9e8f007
+    project: 4554083122151425
+    public_key: f2735313c0e49c2279401ee80f664945
     rate_limit_count: null
     rate_limit_window: null
     roles: '1'
-    secret_key: 6977e5dceb854472041ed09be765b95b
+    secret_key: 674f0b511378179441ba06d4fa7e604e
     status: 0
     use_case: user
   model: sentry.projectkey
@@ -927,14 +1269,14 @@ source: tests/sentry/backup/test_releases.py
       dynamicSdkLoaderOptions:
         hasPerformance: true
         hasReplay: true
-    date_added: '2024-05-16T20:51:23.982Z'
+    date_added: '2024-05-28T16:56:38.440Z'
     label: Default
-    project: 4554016097501187
-    public_key: e3664790c37e14c11c6f04ba70c09ab9
+    project: 4554083122151426
+    public_key: 943b48331358e49c1fa72afe4d727b07
     rate_limit_count: null
     rate_limit_window: null
     roles: '1'
-    secret_key: 526ff1dde52ff0a5728610cf2664f5d1
+    secret_key: b99be3724f8f10c0c742d32ddf09a8ee
     status: 0
     use_case: user
   model: sentry.projectkey
@@ -944,14 +1286,14 @@ source: tests/sentry/backup/test_releases.py
       dynamicSdkLoaderOptions:
         hasPerformance: true
         hasReplay: true
-    date_added: '2024-05-16T20:51:24.203Z'
+    date_added: '2024-05-28T16:56:38.648Z'
     label: Default
-    project: 4554016097566721
-    public_key: 691115ef197bd2747c15c253f2157c7b
+    project: 4554083122151428
+    public_key: ac10157a89b20d3218ee102ebd567a5d
     rate_limit_count: null
     rate_limit_window: null
     roles: '1'
-    secret_key: 653dafd88a6f8d643a4571956eba079a
+    secret_key: 7dd45560a5c35ab275ac5bccfe28debb
     status: 0
     use_case: user
   model: sentry.projectkey
@@ -961,14 +1303,14 @@ source: tests/sentry/backup/test_releases.py
       dynamicSdkLoaderOptions:
         hasPerformance: true
         hasReplay: true
-    date_added: '2024-05-16T20:51:24.385Z'
+    date_added: '2024-05-28T16:56:38.826Z'
     label: Default
-    project: 4554016097566722
-    public_key: 50d3c35f7a45e1ad76000b98346af3cf
+    project: 4554083122151429
+    public_key: 15219de41236b748c586f69460868d10
     rate_limit_count: null
     rate_limit_window: null
     roles: '1'
-    secret_key: 784794eb9ddaaaef1b424777791ae110
+    secret_key: be3ba7804534a67dab50a0a12adc5b63
     status: 0
     use_case: user
   model: sentry.projectkey
@@ -977,25 +1319,25 @@ source: tests/sentry/backup/test_releases.py
     config:
       hello: hello
     integration_id: 1
-    project: 4554016097501186
+    project: 4554083122151425
   model: sentry.projectintegration
   pk: 1
 - fields:
-    date_added: '2024-05-16T20:51:23.815Z'
-    project: 4554016097501186
-    user_id: 1
+    date_added: '2024-05-28T16:56:38.288Z'
+    project: 4554083122151425
+    user_id: 2
   model: sentry.projectbookmark
   pk: 1
 - fields:
     is_active: true
     organizationmember: 1
     role: null
-    team: 4554016097501185
+    team: 4554083122151424
   model: sentry.organizationmemberteam
   pk: 1
 - fields:
     integration_id: null
-    organization: 4554016097501184
+    organization: 4554083122085888
     sentry_app_id: null
     target_display: Sentry User
     target_identifier: '1'
@@ -1006,7 +1348,7 @@ source: tests/sentry/backup/test_releases.py
   pk: 1
 - fields:
     integration_id: null
-    organization: 4554016097501184
+    organization: 4554083122085888
     sentry_app_id: 1
     target_display: Sentry User
     target_identifier: '1'
@@ -1016,23 +1358,23 @@ source: tests/sentry/backup/test_releases.py
   model: sentry.notificationaction
   pk: 2
 - fields:
-    disable_date: '2024-05-16T20:51:23.942Z'
+    disable_date: '2024-05-28T16:56:38.404Z'
     opted_out: false
-    organization: 4554016097501184
+    organization: 4554083122085888
     rule: 1
-    sent_final_email_date: '2024-05-16T20:51:23.942Z'
-    sent_initial_email_date: '2024-05-16T20:51:23.942Z'
+    sent_final_email_date: '2024-05-28T16:56:38.404Z'
+    sent_initial_email_date: '2024-05-28T16:56:38.404Z'
   model: sentry.neglectedrule
   pk: 1
 - fields:
     environment: 1
     is_hidden: null
-    project: 4554016097501186
+    project: 4554083122151425
   model: sentry.environmentproject
   pk: 1
 - fields:
     dashboard: 1
-    date_added: '2024-05-16T20:51:24.077Z'
+    date_added: '2024-05-28T16:56:38.527Z'
     description: null
     detail: null
     discover_widget_split: null
@@ -1047,91 +1389,91 @@ source: tests/sentry/backup/test_releases.py
   pk: 1
 - fields:
     custom_dynamic_sampling_rule: 1
-    project: 4554016097501186
+    project: 4554083122151425
   model: sentry.customdynamicsamplingruleproject
   pk: 1
 - fields:
     application: 1
-    date_added: '2024-05-16T20:51:24.271Z'
-    expires_at: '2024-05-17T04:51:24.270Z'
-    hashed_refresh_token: d7b375e8524cde0a9d8c27257e25630cd5617c56650f8fe80ce5f799922e888a
-    hashed_token: 5dd007bce49975965fac04c86070f57007b5376ee3a506ec04a956a63f7ea70a
+    date_added: '2024-05-28T16:56:38.715Z'
+    expires_at: '2024-05-29T00:56:38.714Z'
+    hashed_refresh_token: 9a6aeebb89d7d7dacb92b91e3ed46a26023b23718e1f200df7d8900a7ff2d3fd
+    hashed_token: 51142c396117118c05e2d19b89c7af87d07ee7d3b978d052192b2fc045928836
     name: null
-    refresh_token: 70339b19a26ea9dd47c38babb7a67f789c817649661aff833246608f4907a2e4
+    refresh_token: d36d6b6c443093bc4169227d6a804c5ae4e83aee5d132e3cd9a3156113f7a88d
     scope_list: '[]'
     scopes: '0'
-    token: c89f04f25f9e18e4d8bf2daf24386fed732ce2e1b26adf44d140ec5966e9d485
-    token_last_characters: d485
+    token: 8398cfdda8c88d47de23d0aaf24e99c8bea9b5fb656618f14f73347dd9e51c06
+    token_last_characters: 1c06
     token_type: null
-    user: 5
+    user: 9
   model: sentry.apitoken
   pk: 1
 - fields:
     application: 1
-    date_added: '2024-05-16T20:51:24.328Z'
+    date_added: '2024-05-28T16:56:38.771Z'
     expires_at: null
-    hashed_refresh_token: 0638ad5f761b6940b8ea237e1013c3a3cbd4e81f4094247b0be51edeb850a36f
-    hashed_token: 81a5d80a537aa1789de784147cf226b45d69228230a3d5ef237ef8a25209809f
+    hashed_refresh_token: 328a10c34d0a6f6cd206d345c955c0f6160c41e4af5ead2c0d8b501cd99bac70
+    hashed_token: b6889828e72c55a889b4d5c052e320d6763cd9aef1b41b5ab7e7cec68041e266
     name: create_exhaustive_sentry_app
-    refresh_token: a1c31f5ed6a2f6486c64486ccdde000fd780a6e7b79f53d5c11667afefc0b21c
+    refresh_token: 24f84262f3fe86c99f7737f221360fdb78a52a08cfba64ff43028fbb48516ed1
     scope_list: '[]'
     scopes: '0'
-    token: fab9bf9674b4254732d503140d7511550ed9410195d8419d47bbc09fe56a8c7b
-    token_last_characters: 8c7b
+    token: 209c062db2d9491f2e8f5faf335820a31f22a0e4c31accf61c7eb4c576f5cfd6
+    token_last_characters: cfd6
     token_type: null
-    user: 1
+    user: 2
   model: sentry.apitoken
   pk: 2
 - fields:
     application: null
-    date_added: '2024-05-16T20:51:24.421Z'
+    date_added: '2024-05-28T16:56:38.858Z'
     expires_at: null
     hashed_refresh_token: null
-    hashed_token: f012b463a2e58f4a7658acd4ef4aa1fd654632283e0eacdd16ef9426fc772857
+    hashed_token: 52f2d85576dcd1e8f3c9a9a64682a25c3a8caa9be6e52bf53a812da205de5096
     name: create_exhaustive_global_configs
     refresh_token: null
     scope_list: '[]'
     scopes: '0'
-    token: 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
-    token_last_characters: '8910'
+    token: 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
+    token_last_characters: 543e
     token_type: sntryu_
-    user: 1
+    user: 2
   model: sentry.apitoken
   pk: 3
 - fields:
     application: 1
-    code: 513d348f654b846126d3fb2f70bdd508a3a2c2bf16b35370a03da884a1979a05
+    code: f900286fe0eb6207031b29585a3f72bc088cdb16ad421a4ff31a85787df40e9e
     expires_at: '2022-01-01T11:11:00.000Z'
     redirect_uri: https://example.com
     scope_list: '[''openid'', ''profile'', ''email'']'
     scopes: '0'
-    user: 1
+    user: 2
   model: sentry.apigrant
   pk: 2
 - fields:
     application: 1
-    date_added: '2024-05-16T20:51:24.326Z'
+    date_added: '2024-05-28T16:56:38.770Z'
     scope_list: '[]'
     scopes: '0'
-    user: 1
+    user: 2
   model: sentry.apiauthorization
   pk: 1
 - fields:
     application: null
-    date_added: '2024-05-16T20:51:24.420Z'
+    date_added: '2024-05-28T16:56:38.857Z'
     scope_list: '[]'
     scopes: '0'
-    user: 1
+    user: 2
   model: sentry.apiauthorization
   pk: 2
 - fields:
     comparison_delta: null
-    date_added: '2024-05-16T20:51:24.007Z'
-    date_modified: '2024-05-16T20:51:24.007Z'
+    date_added: '2024-05-28T16:56:38.461Z'
+    date_modified: '2024-05-28T16:56:38.461Z'
     include_all_projects: true
     monitor_type: 0
-    name: Wanted Dodo
-    organization: 4554016097501184
+    name: Flying Humpback
+    organization: 4554083122085888
     resolve_threshold: null
     snuba_query: 1
     status: 0
@@ -1143,12 +1485,12 @@ source: tests/sentry/backup/test_releases.py
   pk: 1
 - fields:
     comparison_delta: null
-    date_added: '2024-05-16T20:51:24.040Z'
-    date_modified: '2024-05-16T20:51:24.040Z'
+    date_added: '2024-05-28T16:56:38.493Z'
+    date_modified: '2024-05-28T16:56:38.493Z'
     include_all_projects: false
     monitor_type: 1
-    name: Fresh Oryx
-    organization: 4554016097501184
+    name: Enough Squirrel
+    organization: 4554083122085888
     resolve_threshold: null
     snuba_query: 2
     status: 0
@@ -1160,12 +1502,12 @@ source: tests/sentry/backup/test_releases.py
   pk: 2
 - fields:
     comparison_delta: null
-    date_added: '2024-05-16T20:51:24.057Z'
-    date_modified: '2024-05-16T20:51:24.057Z'
+    date_added: '2024-05-28T16:56:38.509Z'
+    date_modified: '2024-05-28T16:56:38.509Z'
     include_all_projects: false
     monitor_type: 0
-    name: Trusted Rodent
-    organization: 4554016097501184
+    name: Thorough Walrus
+    organization: 4554083122085888
     resolve_threshold: null
     snuba_query: 3
     status: 0
@@ -1193,13 +1535,13 @@ source: tests/sentry/backup/test_releases.py
 - fields:
     api_grant: null
     api_token: 1
-    date_added: '2024-05-16T20:51:24.224Z'
+    date_added: '2024-05-28T16:56:38.670Z'
     date_deleted: null
-    date_updated: '2024-05-16T20:51:24.249Z'
-    organization_id: 4554016097501184
+    date_updated: '2024-05-28T16:56:38.693Z'
+    organization_id: 4554083122085888
     sentry_app: 1
     status: 1
-    uuid: 8e6de9df-7f88-4c2d-adb2-26d5d4dfaca8
+    uuid: c93fdee5-9a90-462c-979c-f0474f4ef571
   model: sentry.sentryappinstallation
   pk: 1
 - fields:
@@ -1237,20 +1579,20 @@ source: tests/sentry/backup/test_releases.py
       type: alert-rule-action
     sentry_app: 1
     type: alert-rule-action
-    uuid: d0e9f343-fe20-448d-a7db-d0dbfc9f6d97
+    uuid: 2dd93329-f1a1-4d2e-82c6-6f04fa86665c
   model: sentry.sentryappcomponent
   pk: 1
 - fields:
     alert_rule: null
-    date_added: '2024-05-16T20:51:23.941Z'
-    owner_id: 1
+    date_added: '2024-05-28T16:56:38.403Z'
+    owner_id: 2
     rule: 1
     until: null
-    user_id: 1
+    user_id: 2
   model: sentry.rulesnooze
   pk: 1
 - fields:
-    date_added: '2024-05-16T20:51:23.940Z'
+    date_added: '2024-05-28T16:56:38.402Z'
     rule: 1
     type: 1
     user_id: null
@@ -1258,20 +1600,20 @@ source: tests/sentry/backup/test_releases.py
   pk: 1
 - fields:
     action: 1
-    project: 4554016097501186
+    project: 4554083122151425
   model: sentry.notificationactionproject
   pk: 1
 - fields:
     action: 2
-    project: 4554016097501186
+    project: 4554083122151425
   model: sentry.notificationactionproject
   pk: 2
 - fields:
     aggregates: null
     columns: null
     conditions: ''
-    date_added: '2024-05-16T20:51:24.078Z'
-    date_modified: '2024-05-16T20:51:24.078Z'
+    date_added: '2024-05-28T16:56:38.528Z'
+    date_modified: '2024-05-28T16:56:38.528Z'
     field_aliases: null
     fields: '[]'
     is_hidden: false
@@ -1284,8 +1626,8 @@ source: tests/sentry/backup/test_releases.py
 - fields:
     alert_rule: 1
     alert_threshold: 100.0
-    date_added: '2024-05-16T20:51:24.020Z'
-    label: Next Worm
+    date_added: '2024-05-28T16:56:38.474Z'
+    label: Advanced Grizzly
     resolve_threshold: null
     threshold_type: null
   model: sentry.alertruletrigger
@@ -1293,39 +1635,39 @@ source: tests/sentry/backup/test_releases.py
 - fields:
     alert_rule: 2
     alert_threshold: 100.0
-    date_added: '2024-05-16T20:51:24.052Z'
-    label: Prepared Hornet
+    date_added: '2024-05-28T16:56:38.503Z'
+    label: Concrete Seagull
     resolve_threshold: null
     threshold_type: null
   model: sentry.alertruletrigger
   pk: 2
 - fields:
     alert_rule: 1
-    date_added: '2024-05-16T20:51:24.012Z'
-    project: 4554016097501186
+    date_added: '2024-05-28T16:56:38.466Z'
+    project: 4554083122151425
   model: sentry.alertruleprojects
   pk: 1
 - fields:
     alert_rule: 2
-    date_added: '2024-05-16T20:51:24.043Z'
-    project: 4554016097501186
+    date_added: '2024-05-28T16:56:38.495Z'
+    project: 4554083122151425
   model: sentry.alertruleprojects
   pk: 2
 - fields:
     alert_rule: 3
-    date_added: '2024-05-16T20:51:24.059Z'
-    project: 4554016097501186
+    date_added: '2024-05-28T16:56:38.510Z'
+    project: 4554083122151425
   model: sentry.alertruleprojects
   pk: 3
 - fields:
     alert_rule: 1
-    date_added: '2024-05-16T20:51:24.009Z'
-    project: 4554016097501187
+    date_added: '2024-05-28T16:56:38.464Z'
+    project: 4554083122151426
   model: sentry.alertruleexcludedprojects
   pk: 1
 - fields:
     alert_rule: 1
-    date_added: '2024-05-16T20:51:24.015Z'
+    date_added: '2024-05-28T16:56:38.469Z'
     previous_alert_rule: null
     type: 1
     user_id: null
@@ -1333,7 +1675,7 @@ source: tests/sentry/backup/test_releases.py
   pk: 1
 - fields:
     alert_rule: 2
-    date_added: '2024-05-16T20:51:24.044Z'
+    date_added: '2024-05-28T16:56:38.496Z'
     previous_alert_rule: null
     type: 1
     user_id: null
@@ -1341,7 +1683,7 @@ source: tests/sentry/backup/test_releases.py
   pk: 2
 - fields:
     alert_rule: 3
-    date_added: '2024-05-16T20:51:24.061Z'
+    date_added: '2024-05-28T16:56:38.513Z'
     previous_alert_rule: null
     type: 1
     user_id: null
@@ -1350,35 +1692,35 @@ source: tests/sentry/backup/test_releases.py
 - fields:
     alert_rule: 2
     condition_type: 0
-    date_added: '2024-05-16T20:51:24.042Z'
+    date_added: '2024-05-28T16:56:38.494Z'
     label: ''
   model: sentry.alertruleactivationcondition
   pk: 1
 - fields:
     actor_id: 1
     application_id: 1
-    date_added: '2024-05-16T20:51:24.246Z'
+    date_added: '2024-05-28T16:56:38.690Z'
     events: '[]'
-    guid: 2b3a3f0ad2f04794b31fc3ab2a78d6bf
+    guid: 0edabb9955504609981d104072974544
     installation_id: 1
-    organization_id: 4554016097501184
+    organization_id: 4554083122085888
     project_id: null
-    secret: 4cb161ca297278cbba8466cf6599bdb410c2dcd90103ed9b4280119934408c4c
+    secret: 60f3dc74629c38a31ecf9767461367cf5213041b62ecfdd23c2f0604070e2dc3
     status: 0
     url: https://example.com/sentry-app/webhook/
     version: 0
   model: sentry.servicehook
   pk: 1
 - fields:
-    actor_id: 6
+    actor_id: 10
     application_id: 1
-    date_added: '2024-05-16T20:51:24.403Z'
+    date_added: '2024-05-28T16:56:38.843Z'
     events: '[''event.created'']'
-    guid: 4ba5c660bb674bb6b49b0f06fd16eee8
+    guid: 6c414cdc4d414c7899b5024e7bb2ddcc
     installation_id: 1
-    organization_id: 4554016097501184
-    project_id: 4554016097566722
-    secret: 2c7a6fbd129860d9fca0e4aa26c729e32a7530b1653cfe81c7e10e7d4c7a3fea
+    organization_id: 4554083122085888
+    project_id: 4554083122151429
+    secret: bab7071cb7cd590761113edb5306f581846685f3e5ff0f28f613314c5de7414b
     status: 0
     url: https://example.com/sentry/webhook
     version: 0
@@ -1387,23 +1729,23 @@ source: tests/sentry/backup/test_releases.py
 - fields:
     activation: null
     alert_rule: 3
-    date_added: '2024-05-16T20:51:24.065Z'
+    date_added: '2024-05-28T16:56:38.516Z'
     date_closed: null
-    date_detected: '2024-05-16T20:51:24.063Z'
-    date_started: '2024-05-16T20:51:24.063Z'
+    date_detected: '2024-05-28T16:56:38.514Z'
+    date_started: '2024-05-28T16:56:38.514Z'
     detection_uuid: null
     identifier: 1
-    organization: 4554016097501184
+    organization: 4554083122085888
     status: 1
     status_method: 3
-    title: Tender Camel
+    title: Grateful Lizard
     type: 2
   model: sentry.incident
   pk: 1
 - fields:
     dashboard_widget_query: 1
-    date_added: '2024-05-16T20:51:24.079Z'
-    date_modified: '2024-05-16T20:51:24.079Z'
+    date_added: '2024-05-28T16:56:38.529Z'
+    date_modified: '2024-05-28T16:56:38.529Z'
     extraction_state: disabled:not-applicable
     spec_hashes: '[]'
     spec_version: null
@@ -1411,66 +1753,66 @@ source: tests/sentry/backup/test_releases.py
   pk: 1
 - fields:
     alert_rule_trigger: 1
-    date_added: '2024-05-16T20:51:24.022Z'
+    date_added: '2024-05-28T16:56:38.475Z'
     query_subscription: 1
   model: sentry.alertruletriggerexclusion
   pk: 1
 - fields:
     alert_rule_trigger: 1
-    date_added: '2024-05-16T20:51:24.036Z'
+    date_added: '2024-05-28T16:56:38.489Z'
     integration_id: null
     sentry_app_config: null
     sentry_app_id: null
     status: 0
     target_display: null
-    target_identifier: '3'
+    target_identifier: '7'
     target_type: 1
     type: 0
   model: sentry.alertruletriggeraction
   pk: 1
 - fields:
     alert_rule_trigger: 2
-    date_added: '2024-05-16T20:51:24.054Z'
+    date_added: '2024-05-28T16:56:38.505Z'
     integration_id: null
     sentry_app_config: null
     sentry_app_id: null
     status: 0
     target_display: null
-    target_identifier: '3'
+    target_identifier: '7'
     target_type: 1
     type: 0
   model: sentry.alertruletriggeraction
   pk: 2
 - fields:
-    date_added: '2024-05-16T20:51:24.071Z'
-    end: '2024-05-16T20:51:24.071Z'
+    date_added: '2024-05-28T16:56:38.521Z'
+    end: '2024-05-28T16:56:38.521Z'
     period: 1
-    start: '2024-05-15T20:51:24.071Z'
+    start: '2024-05-27T16:56:38.521Z'
     values: '[[1.0, 2.0, 3.0], [1.5, 2.5, 3.5]]'
   model: sentry.timeseriessnapshot
   pk: 1
 - fields:
-    date_added: '2024-05-16T20:51:24.075Z'
+    date_added: '2024-05-28T16:56:38.525Z'
     incident: 1
-    target_run_date: '2024-05-17T00:51:24.075Z'
+    target_run_date: '2024-05-28T20:56:38.525Z'
   model: sentry.pendingincidentsnapshot
   pk: 1
 - fields:
     alert_rule_trigger: 1
-    date_added: '2024-05-16T20:51:24.074Z'
-    date_modified: '2024-05-16T20:51:24.074Z'
+    date_added: '2024-05-28T16:56:38.524Z'
+    date_modified: '2024-05-28T16:56:38.524Z'
     incident: 1
     status: 1
   model: sentry.incidenttrigger
   pk: 1
 - fields:
-    date_added: '2024-05-16T20:51:24.073Z'
+    date_added: '2024-05-28T16:56:38.523Z'
     incident: 1
-    user_id: 1
+    user_id: 2
   model: sentry.incidentsubscription
   pk: 1
 - fields:
-    date_added: '2024-05-16T20:51:24.072Z'
+    date_added: '2024-05-28T16:56:38.522Z'
     event_stats_snapshot: 1
     incident: 1
     total_events: 1
@@ -1479,7 +1821,7 @@ source: tests/sentry/backup/test_releases.py
   pk: 1
 - fields:
     comment: hello test-org
-    date_added: '2024-05-16T20:51:24.070Z'
+    date_added: '2024-05-28T16:56:38.520Z'
     incident: 1
     notification_uuid: null
     previous_value: null

--- a/tests/sentry/backup/snapshots/SanitizationExhaustiveTests/test_clean_pks.pysnap
+++ b/tests/sentry/backup/snapshots/SanitizationExhaustiveTests/test_clean_pks.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-01-01T00:00:00+00:00'
+created: '2024-05-28T16:45:57.037010+00:00'
 creator: sentry
 source: tests/sentry/backup/test_sanitize.py
 ---
@@ -115,10 +115,46 @@ source: tests/sentry/backup/test_sanitize.py
   ordinal: 5
   sanitized_fields:
   - date_joined
+  - email
   - last_active
+  - last_password_change
+  - password
   - username
 - model_name: sentry.user
   ordinal: 6
+  sanitized_fields:
+  - date_joined
+  - email
+  - last_active
+  - last_password_change
+  - password
+  - username
+- model_name: sentry.user
+  ordinal: 7
+  sanitized_fields:
+  - date_joined
+  - email
+  - last_active
+  - last_password_change
+  - password
+  - username
+- model_name: sentry.user
+  ordinal: 8
+  sanitized_fields:
+  - date_joined
+  - email
+  - last_active
+  - last_password_change
+  - password
+  - username
+- model_name: sentry.user
+  ordinal: 9
+  sanitized_fields:
+  - date_joined
+  - last_active
+  - username
+- model_name: sentry.user
+  ordinal: 10
   sanitized_fields:
   - date_joined
   - email
@@ -134,6 +170,30 @@ source: tests/sentry/backup/test_sanitize.py
   - last_seen
 - model_name: sentry.userip
   ordinal: 2
+  sanitized_fields:
+  - first_seen
+  - ip_address
+  - last_seen
+- model_name: sentry.userip
+  ordinal: 3
+  sanitized_fields:
+  - first_seen
+  - ip_address
+  - last_seen
+- model_name: sentry.userip
+  ordinal: 4
+  sanitized_fields:
+  - first_seen
+  - ip_address
+  - last_seen
+- model_name: sentry.userip
+  ordinal: 5
+  sanitized_fields:
+  - first_seen
+  - ip_address
+  - last_seen
+- model_name: sentry.userip
+  ordinal: 6
   sanitized_fields:
   - first_seen
   - ip_address
@@ -201,6 +261,33 @@ source: tests/sentry/backup/test_sanitize.py
   ordinal: 2
   sanitized_fields:
   - date_added
+- model_name: sentry.organizationmember
+  ordinal: 3
+  sanitized_fields:
+  - date_added
+  - email
+- model_name: sentry.organizationmember
+  ordinal: 4
+  sanitized_fields:
+  - date_added
+  - email
+- model_name: sentry.organizationmember
+  ordinal: 5
+  sanitized_fields:
+  - date_added
+  - email
+- model_name: sentry.organizationmember
+  ordinal: 6
+  sanitized_fields:
+  - date_added
+- model_name: sentry.organizationmember
+  ordinal: 7
+  sanitized_fields:
+  - date_added
+- model_name: sentry.organizationmember
+  ordinal: 8
+  sanitized_fields:
+  - date_added
 - model_name: sentry.organizationaccessrequest
   ordinal: 1
   sanitized_fields: []
@@ -239,8 +326,28 @@ source: tests/sentry/backup/test_sanitize.py
   ordinal: 5
   sanitized_fields:
   - date_added
+  - email
 - model_name: sentry.email
   ordinal: 6
+  sanitized_fields:
+  - date_added
+  - email
+- model_name: sentry.email
+  ordinal: 7
+  sanitized_fields:
+  - date_added
+  - email
+- model_name: sentry.email
+  ordinal: 8
+  sanitized_fields:
+  - date_added
+  - email
+- model_name: sentry.email
+  ordinal: 9
+  sanitized_fields:
+  - date_added
+- model_name: sentry.email
+  ordinal: 10
   sanitized_fields:
   - date_added
   - email
@@ -283,6 +390,22 @@ source: tests/sentry/backup/test_sanitize.py
   ordinal: 2
   sanitized_fields:
   - created_at
+- model_name: sentry.authenticator
+  ordinal: 3
+  sanitized_fields:
+  - created_at
+- model_name: sentry.authenticator
+  ordinal: 4
+  sanitized_fields:
+  - created_at
+- model_name: sentry.authenticator
+  ordinal: 5
+  sanitized_fields:
+  - created_at
+- model_name: sentry.authenticator
+  ordinal: 6
+  sanitized_fields:
+  - created_at
 - model_name: sentry.apikey
   ordinal: 1
   sanitized_fields:
@@ -301,6 +424,18 @@ source: tests/sentry/backup/test_sanitize.py
   sanitized_fields: []
 - model_name: sentry.useroption
   ordinal: 2
+  sanitized_fields: []
+- model_name: sentry.useroption
+  ordinal: 3
+  sanitized_fields: []
+- model_name: sentry.useroption
+  ordinal: 4
+  sanitized_fields: []
+- model_name: sentry.useroption
+  ordinal: 5
+  sanitized_fields: []
+- model_name: sentry.useroption
+  ordinal: 6
   sanitized_fields: []
 - model_name: sentry.useremail
   ordinal: 1
@@ -330,9 +465,33 @@ source: tests/sentry/backup/test_sanitize.py
   ordinal: 5
   sanitized_fields:
   - date_hash_added
+  - email
   - validation_hash
 - model_name: sentry.useremail
   ordinal: 6
+  sanitized_fields:
+  - date_hash_added
+  - email
+  - validation_hash
+- model_name: sentry.useremail
+  ordinal: 7
+  sanitized_fields:
+  - date_hash_added
+  - email
+  - validation_hash
+- model_name: sentry.useremail
+  ordinal: 8
+  sanitized_fields:
+  - date_hash_added
+  - email
+  - validation_hash
+- model_name: sentry.useremail
+  ordinal: 9
+  sanitized_fields:
+  - date_hash_added
+  - validation_hash
+- model_name: sentry.useremail
+  ordinal: 10
   sanitized_fields:
   - date_hash_added
   - email

--- a/tests/sentry/backup/snapshots/SanitizationIntegrationTests/test_fresh_install.pysnap
+++ b/tests/sentry/backup/snapshots/SanitizationIntegrationTests/test_fresh_install.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-05-08T18:10:03.554472+00:00'
+created: '2024-05-28T16:45:51.971601+00:00'
 creator: sentry
 source: tests/sentry/backup/test_sanitize.py
 ---
@@ -29,6 +29,11 @@ source: tests/sentry/backup/test_sanitize.py
   sanitized_fields:
   - date_added
   - email
+- model_name: sentry.email
+  ordinal: 3
+  sanitized_fields:
+  - date_added
+  - email
 - model_name: sentry.organization
   ordinal: 1
   sanitized_fields:
@@ -46,6 +51,15 @@ source: tests/sentry/backup/test_sanitize.py
   - username
 - model_name: sentry.user
   ordinal: 2
+  sanitized_fields:
+  - date_joined
+  - email
+  - last_active
+  - last_password_change
+  - password
+  - username
+- model_name: sentry.user
+  ordinal: 3
   sanitized_fields:
   - date_joined
   - email
@@ -85,6 +99,12 @@ source: tests/sentry/backup/test_sanitize.py
   - date_hash_added
   - email
   - validation_hash
+- model_name: sentry.useremail
+  ordinal: 3
+  sanitized_fields:
+  - date_hash_added
+  - email
+  - validation_hash
 - model_name: sentry.userrole
   ordinal: 1
   sanitized_fields:
@@ -93,6 +113,11 @@ source: tests/sentry/backup/test_sanitize.py
   - name
 - model_name: sentry.userroleuser
   ordinal: 1
+  sanitized_fields:
+  - date_added
+  - date_updated
+- model_name: sentry.userroleuser
+  ordinal: 2
   sanitized_fields:
   - date_added
   - date_updated
@@ -110,6 +135,11 @@ source: tests/sentry/backup/test_sanitize.py
   ordinal: 2
   sanitized_fields:
   - date_added
+- model_name: sentry.organizationmember
+  ordinal: 3
+  sanitized_fields:
+  - date_added
+  - email
 - model_name: sentry.project
   ordinal: 1
   sanitized_fields:

--- a/tests/sentry/backup/snapshots/test_comparators/test_default_comparators.pysnap
+++ b/tests/sentry/backup/snapshots/test_comparators/test_default_comparators.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-05-09T23:29:47.969852+00:00'
+created: '2024-05-28T16:54:51.531380+00:00'
 creator: sentry
 source: tests/sentry/backup/test_comparators.py
 ---
@@ -922,9 +922,6 @@ source: tests/sentry/backup/test_comparators.py
   - class: HashObfuscatingComparator
     fields:
     - token
-  - class: EqualOrRemovedComparator
-    fields:
-    - inviter_id
   - class: DatetimeEqualityComparator
     fields:
     - date_added

--- a/tests/sentry/backup/test_exports.py
+++ b/tests/sentry/backup/test_exports.py
@@ -130,9 +130,12 @@ class ScopingTests(ExportTestCase):
     @freeze_time("2023-10-11 18:00:00")
     def test_config_export_scoping(self):
         self.create_exhaustive_instance(is_superadmin=True)
-        self.create_exhaustive_user("admin", is_admin=True)
-        self.create_exhaustive_user("staff", is_staff=True)
-        self.create_exhaustive_user("superuser", is_superuser=True)
+        admin = self.create_exhaustive_user("admin", is_admin=True)
+        staff = self.create_exhaustive_user("staff", is_staff=True)
+        superuser = self.create_exhaustive_user("superuser", is_superuser=True)
+        self.create_exhaustive_api_keys_for_user(admin)
+        self.create_exhaustive_api_keys_for_user(staff)
+        self.create_exhaustive_api_keys_for_user(superuser)
         with tempfile.TemporaryDirectory() as tmp_dir:
             unencrypted = self.export(tmp_dir, scope=ExportScope.Config)
             self.verify_model_inclusion(unencrypted, ExportScope.Config)

--- a/tests/sentry/backup/test_imports.py
+++ b/tests/sentry/backup/test_imports.py
@@ -2185,7 +2185,7 @@ class CustomImportBehaviorTests(ImportTestCase):
             slug="test-org",
             owner=owner,
             member=member,
-            invites={
+            pending_invites={
                 admin: "invited-by-admin@test.com",
                 owner: "invited-by-owner@test.com",
             },

--- a/tests/sentry/tasks/test_relocation.py
+++ b/tests/sentry/tasks/test_relocation.py
@@ -310,6 +310,7 @@ class PreprocessingScanTest(RelocationTaskTestCase):
         assert relocation.want_usernames == [
             "admin@example.com",
             "member@example.com",
+            "superadmin@example.com",
         ]
         assert relocation.latest_notified == Relocation.EmailKind.STARTED.value
 
@@ -338,6 +339,7 @@ class PreprocessingScanTest(RelocationTaskTestCase):
         assert relocation.want_usernames == [
             "admin@example.com",
             "member@example.com",
+            "superadmin@example.com",
         ]
         assert relocation.latest_notified == Relocation.EmailKind.STARTED.value
 
@@ -557,7 +559,7 @@ class PreprocessingScanTest(RelocationTaskTestCase):
         relocation = Relocation.objects.get(uuid=self.uuid)
         assert relocation.status == Relocation.Status.FAILURE.value
         assert relocation.latest_notified == Relocation.EmailKind.FAILED.value
-        assert relocation.failure_reason == ERR_PREPROCESSING_TOO_MANY_USERS.substitute(count=2)
+        assert relocation.failure_reason == ERR_PREPROCESSING_TOO_MANY_USERS.substitute(count=3)
 
     def test_fail_no_orgs(
         self,


### PR DESCRIPTION
There was previously a bug with how we exported `OrganizationMember`s: we assumed that all `invited_id` would also be in the organization, and therefore included in the filtering `pk_map`, but this is not actually true. This is because it is possible for an instance admin who is not a member of this (or really, any) org to invite the user. This creates an exception in the general assumption that "all org scope models reference user IDs already in the org".

To get around this, we simply wrap the exporting function for `OrganizationMember` in such a way that we no longer filter by `inviter_id`; we simply ignore the filed and take all values. The code already has an allowance that enables it to ignore unknown `inviter_id` values at import time, so doing this is okay.

To enable this change, a number of tests have been robustified with different kinds of `OrganizationMember` instances: pending invites, members invited by users in the org, members invited by users outside of the org, admins, superadmins, etc. We should have much better coverage of all of the edge cases associated with this model going forward.