### PR TITLE
ref(feedback): hide pagination for screenshots if only 1 screenshot

### DIFF
--- a/static/app/components/feedback/feedbackItem/screenshotsModal.tsx
+++ b/static/app/components/feedback/feedbackItem/screenshotsModal.tsx
@@ -34,22 +34,24 @@ export default function ScreenshotsModal({
   return (
     <Fragment>
       <Header closeButton>
-        <PaginationWrapper lightText>
-          <StyledScreenshotPagination
-            nextDisabled={screenshots.length > 1}
-            onNext={() => {
-              setSelectedIndex(prev => prev + 1);
-            }}
-            onPrevious={() => {
-              setSelectedIndex(prev => prev - 1);
-            }}
-            previousDisabled={screenshots.length > 1}
-            headerText={tct('[currentScreenshotIndex] of [totalScreenshotCount]', {
-              currentScreenshotIndex: currentIndex + 1,
-              totalScreenshotCount: screenshots.length,
-            })}
-          />
-        </PaginationWrapper>
+        {screenshots.length > 1 && (
+          <PaginationWrapper lightText>
+            <StyledScreenshotPagination
+              nextDisabled={false}
+              previousDisabled={false}
+              onNext={() => {
+                setSelectedIndex(prev => prev + 1);
+              }}
+              onPrevious={() => {
+                setSelectedIndex(prev => prev - 1);
+              }}
+              headerText={tct('[currentScreenshotIndex] of [totalScreenshotCount]', {
+                currentScreenshotIndex: currentIndex + 1,
+                totalScreenshotCount: screenshots.length,
+              })}
+            />
+          </PaginationWrapper>
+        )}
       </Header>
       <Body>
         <FeedbackScreenshot


### PR DESCRIPTION
if there is 1 screenshot only (which is all we have the ability to attach right now), hide the pagination bar

before:
<img width="1345" alt="SCR-20240528-jtvk" src="https://github.com/getsentry/sentry/assets/56095982/f3e8150f-b762-4b0d-939f-eebfe4471862">

after:
<img width="1338" alt="SCR-20240528-jtse" src="https://github.com/getsentry/sentry/assets/56095982/1e8418a3-15e7-42dc-b886-e8a86f59b4bd">

closes https://github.com/getsentry/sentry/issues/71573#issuecomment-2135751353