### PR TITLE
feat(metrics): Ensure spans metric has default settings

### DIFF
--- a/src/sentry/sentry_metrics/aggregation_option_registry.py
+++ b/src/sentry/sentry_metrics/aggregation_option_registry.py
@@ -21,6 +21,7 @@ class TimeWindow(Enum):
 METRIC_ID_AGG_OPTION = {
     "d:transactions/measurements.fcp@millisecond": {AggregationOption.HIST: TimeWindow.NINETY_DAYS},
     "d:transactions/measurements.lcp@millisecond": {AggregationOption.HIST: TimeWindow.NINETY_DAYS},
+    "d:spans/webvital.inp@millisecond": None,
 }
 
 # Currently there are no default per-use case aggregation options


### PR DESCRIPTION
Sets the `d:spans/webvital.inp@millisecond` aggregation option to
`None`. This allows us to disable percentiles in the spans use case
without affecting this metric.