### PR TITLE
chore(api): Remove `id_or_slug` Options

### DIFF
--- a/src/sentry/api/utils.py
+++ b/src/sentry/api/utils.py
@@ -466,31 +466,6 @@ def handle_query_errors() -> Generator[None, None, None]:
         raise APIException(detail=message)
 
 
-def id_or_slug_path_params_enabled(
-    convert_args_class: str | None = None, organization_id_or_slug: str | None = None
-) -> bool:
-    # GA option
-    if options.get("api.id-or-slug-enabled"):
-        return True
-
-    # Apigateway
-    if not convert_args_class and organization_id_or_slug:
-        # Return True if the organization is in the list of enabled organizations and the apigateway option is enabled
-        return organization_id_or_slug in options.get("api.id-or-slug-enabled-ea-org")
-
-    # EA option for endpoints where organization is available
-    if organization_id_or_slug and organization_id_or_slug not in options.get(
-        "api.id-or-slug-enabled-ea-org"
-    ):
-        return False
-
-    # EA option for endpoints where organization is not available
-    if convert_args_class:
-        return convert_args_class in options.get("api.id-or-slug-enabled-ea-endpoints")
-
-    return False
-
-
 def update_snuba_params_with_timestamp(
     request: HttpRequest, params: MutableMapping[str, Any], timestamp_key: str = "timestamp"
 ) -> None:

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -296,20 +296,6 @@ register(
     default=False,
     flags=FLAG_MODIFIABLE_BOOL | FLAG_AUTOMATOR_MODIFIABLE,
 )
-# Enable EA endpoints to work with id or slug as path parameters
-register(
-    "api.id-or-slug-enabled-ea-endpoints",
-    type=Sequence,
-    default=[],
-    flags=FLAG_ALLOW_EMPTY | FLAG_AUTOMATOR_MODIFIABLE,
-)
-# EA option limiting to certain specific organizations for endpoints where organization is available
-register(
-    "api.id-or-slug-enabled-ea-org",
-    type=Sequence,
-    default=[],
-    flags=FLAG_ALLOW_EMPTY | FLAG_AUTOMATOR_MODIFIABLE,
-)
 
 # API Tokens
 register(

--- a/tests/sentry/api/test_utils.py
+++ b/tests/sentry/api/test_utils.py
@@ -12,13 +12,11 @@ from sentry.api.utils import (
     customer_domain_path,
     get_date_range_from_params,
     handle_query_errors,
-    id_or_slug_path_params_enabled,
     print_and_capture_handler_exception,
 )
 from sentry.exceptions import IncompatibleMetricsQuery, InvalidParams, InvalidSearchQuery
-from sentry.testutils.cases import APITestCase, TestCase
+from sentry.testutils.cases import APITestCase
 from sentry.testutils.helpers.datetime import freeze_time
-from sentry.testutils.helpers.options import override_options
 from sentry.utils.snuba import (
     DatasetSelectionError,
     QueryConnectionFailed,
@@ -255,30 +253,3 @@ class HandleQueryErrorsTest:
                     raise ex
             except Exception as e:
                 assert isinstance(e, (FooBarError, APIException))
-
-
-class IdOrSlugPathParamsEnabledTest(TestCase):
-    def test_no_options_enabled(self):
-        assert not id_or_slug_path_params_enabled("TestEndpoint.convert_args")
-
-    @override_options({"api.id-or-slug-enabled": True})
-    def test_ga_option_enabled(self):
-        assert id_or_slug_path_params_enabled(convert_args_class="TestEndpoint.convert_args")
-
-    @override_options({"api.id-or-slug-enabled-ea-endpoints": ["TestEndpoint.convert_args"]})
-    def test_ea_endpoint_option_enabled(self):
-        assert not id_or_slug_path_params_enabled(convert_args_class="NotTestEndpoint.convert_args")
-        assert id_or_slug_path_params_enabled(convert_args_class="TestEndpoint.convert_args")
-
-    @override_options({"api.id-or-slug-enabled-ea-org": ["sentry"]})
-    def test_ea_org_option_enabled(self):
-        assert not id_or_slug_path_params_enabled("NotTestEndpoint.convert_args", "not-sentry")
-        assert not id_or_slug_path_params_enabled("NotTestEndpoint.convert_args", "sentry")
-
-    @override_options({"api.id-or-slug-enabled-ea-org": ["sentry"]})
-    @override_options({"api.id-or-slug-enabled-ea-endpoints": ["TestEndpoint.convert_args"]})
-    def test_ea_org_and_endpoint_option_enabled(self):
-        assert not id_or_slug_path_params_enabled("NotTestEndpoint.convert_args", "not-sentry")
-        assert not id_or_slug_path_params_enabled("NotTestEndpoint.convert_args", "sentry")
-        assert not id_or_slug_path_params_enabled("TestEndpoint.convert_args", "not-sentry")
-        assert id_or_slug_path_params_enabled("TestEndpoint.convert_args", "sentry")


### PR DESCRIPTION
Here, I am removing the wrapper function that uses the options and the options themselves. The options are related to allowing our apis work with id_or_slug, but this change has been GAed for a month and its a good time to cleanup.