### PR TITLE
feat(inc): add a per second rate limiter to event attachments

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -2621,7 +2621,14 @@ register(
 register(
     "sentry.save-event-attachments.project-per-5-minute-limit",
     type=Int,
-    default=20000000,
+    default=2000,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+
+register(
+    "sentry.save-event-attachments.project-per-sec-limit",
+    type=Int,
+    default=100,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 


### PR DESCRIPTION
The 5 minute rate limit is helpful but we still see large spikes that are the cause of abuse. Add two levels of rate limiting for event attachments