### PR TITLE
chore(trace-explorer): Remove ops category

### DIFF
--- a/tests/sentry/api/endpoints/test_organization_traces.py
+++ b/tests/sentry/api/endpoints/test_organization_traces.py
@@ -152,7 +152,6 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
             duration=1_000,
             exclusive_time=1_000,
             op="http.client",
-            category="http",
         )
 
         timestamps.append(before_now(days=0, minutes=19, seconds=40).replace(microsecond=0))
@@ -167,7 +166,6 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
             duration=3_000,
             exclusive_time=3_000,
             op="db.sql",
-            category="db",
         )
 
         timestamps.append(before_now(days=0, minutes=19, seconds=45).replace(microsecond=0))
@@ -182,7 +180,6 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
             duration=3,
             exclusive_time=3,
             op="db.sql",
-            category="db",
         )
 
         timestamps.append(before_now(days=0, minutes=20).replace(microsecond=0))
@@ -259,7 +256,6 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
             duration=1_000,
             exclusive_time=1_000,
             op="ui.navigation.click",
-            category="ui",
         )
 
         return (
@@ -588,7 +584,6 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
                         "end": timestamp + 60100,
                         "isRoot": False,
                         "kind": "project",
-                        "opCategory": None,
                         "project": project.slug,
                         "sdkName": "sentry.javascript.remix",
                         "start": timestamp,
@@ -598,7 +593,6 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
                         "end": timestamp + 60000,
                         "isRoot": False,
                         "kind": "project",
-                        "opCategory": None,
                         "project": project.slug,
                         "sdkName": "sentry.javascript.node",
                         "start": timestamp,
@@ -671,7 +665,6 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
                         "end": timestamp + 60100,
                         "isRoot": False,
                         "kind": "project",
-                        "opCategory": None,
                         "project": project.slug,
                         "sdkName": "sentry.javascript.node",
                         "start": timestamp,
@@ -762,7 +755,6 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
                         "breakdowns": [
                             {
                                 "project": project_1.slug,
-                                "opCategory": None,
                                 "sdkName": "sentry.javascript.node",
                                 "isRoot": False,
                                 "start": timestamps[0],
@@ -772,7 +764,6 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
                             },
                             {
                                 "project": project_2.slug,
-                                "opCategory": None,
                                 "sdkName": "sentry.javascript.node",
                                 "isRoot": False,
                                 "start": timestamps[1],
@@ -819,7 +810,6 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
                         "breakdowns": [
                             {
                                 "project": project_1.slug,
-                                "opCategory": None,
                                 "sdkName": "sentry.javascript.node",
                                 "isRoot": False,
                                 "start": timestamps[4],
@@ -829,7 +819,6 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
                             },
                             {
                                 "project": project_2.slug,
-                                "opCategory": None,
                                 "sdkName": "sentry.javascript.node",
                                 "isRoot": False,
                                 "start": timestamps[5],
@@ -861,123 +850,6 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
                 ],
                 key=lambda trace: trace["trace"],
             )
-
-    def test_matching_tag_breakdown_with_category(self):
-        (
-            project_1,
-            project_2,
-            _,
-            trace_id_2,
-            _,
-            timestamps,
-            span_ids,
-        ) = self.create_mock_traces()
-
-        query = {
-            "project": [project_1.id],
-            "field": ["id", "parent_span", "span.duration"],
-            "query": "span.category:[db,http]",
-            "suggestedQuery": "span.category:[db,http]",
-            "maxSpansPerTrace": 3,
-            "sort": ["-span.duration"],
-            "breakdownCategory": ["db", "http"],
-            "minBreakdownDuration": 10,
-        }
-
-        response = self.do_request(query)
-        assert response.status_code == 200, response.data
-
-        assert response.data["meta"] == {
-            "dataset": "unknown",
-            "datasetReason": "unchanged",
-            "fields": {
-                "id": "string",
-                "parent_span": "string",
-                "span.duration": "duration",
-            },
-            "isMetricsData": False,
-            "isMetricsExtractedData": False,
-            "tips": {},
-            "units": {
-                "id": None,
-                "parent_span": None,
-                "span.duration": "millisecond",
-            },
-        }
-
-        assert response.data["data"] == [
-            {
-                "trace": trace_id_2,
-                "numErrors": 0,
-                "numOccurrences": 0,
-                "numSpans": 6,
-                "project": project_1.slug,
-                "name": "bar",
-                "duration": 90_123,
-                "start": timestamps[4],
-                "end": timestamps[4] + 90_123,
-                "breakdowns": [
-                    {
-                        "project": project_1.slug,
-                        "opCategory": None,
-                        "sdkName": "sentry.javascript.node",
-                        "isRoot": False,
-                        "start": timestamps[4],
-                        "end": timestamps[4] + 90_123,
-                        "kind": "project",
-                        "duration": 90_123,
-                    },
-                    {
-                        "project": project_1.slug,
-                        "opCategory": "http",
-                        "sdkName": "",
-                        "isRoot": False,
-                        "start": timestamps[7],
-                        "end": timestamps[7] + 1_000,
-                        "kind": "project",
-                        "duration": 1_000,
-                    },
-                    {
-                        "project": project_2.slug,
-                        "opCategory": None,
-                        "sdkName": "sentry.javascript.node",
-                        "isRoot": False,
-                        "start": timestamps[5],
-                        "end": timestamps[6] + 20_006,
-                        "kind": "project",
-                        "duration": timestamps[6] - timestamps[5] + 20_006,
-                    },
-                    {
-                        "project": project_1.slug,
-                        "opCategory": "db",
-                        "sdkName": "",
-                        "isRoot": False,
-                        "start": timestamps[8],
-                        "end": timestamps[8] + 3_000,
-                        "kind": "project",
-                        "duration": 3_000,
-                    },
-                ],
-                "spans": [
-                    {
-                        "id": span_ids[8],
-                        "parent_span": span_ids[4],
-                        "span.duration": 3_000.0,
-                    },
-                    {
-                        "id": span_ids[7],
-                        "parent_span": span_ids[4],
-                        "span.duration": 1_000.0,
-                    },
-                    {
-                        "id": span_ids[9],
-                        "parent_span": span_ids[4],
-                        "span.duration": 3.0,
-                    },
-                ],
-                "suggestedSpans": [],
-            },
-        ]
 
     def test_matching_tag_metrics(self):
         (
@@ -1039,7 +911,6 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
                         "breakdowns": [
                             {
                                 "project": project_1.slug,
-                                "opCategory": None,
                                 "sdkName": "sentry.javascript.remix",
                                 "isRoot": False,
                                 "start": timestamps[10],
@@ -1049,7 +920,6 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
                             },
                             {
                                 "project": project_1.slug,
-                                "opCategory": None,
                                 "sdkName": "sentry.javascript.node",
                                 "isRoot": False,
                                 "start": timestamps[11],
@@ -1140,7 +1010,6 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
                 * 32: [
                     {
                         "project": "foo",
-                        "opCategory": None,
                         "sdkName": "sentry.javascript.node",
                         "start": 0,
                         "end": 100,
@@ -1179,7 +1048,6 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
                 * 32: [
                     {
                         "project": "foo",
-                        "opCategory": None,
                         "sdkName": "sentry.javascript.node",
                         "start": 0,
                         "end": 100,
@@ -1189,7 +1057,6 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
                     },
                     {
                         "project": "bar",
-                        "opCategory": None,
                         "sdkName": "sentry.javascript.node",
                         "start": 25,
                         "end": 75,
@@ -1237,7 +1104,6 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
                 * 32: [
                     {
                         "project": "foo",
-                        "opCategory": None,
                         "sdkName": "sentry.javascript.node",
                         "start": 0,
                         "end": 50,
@@ -1247,7 +1113,6 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
                     },
                     {
                         "project": "bar",
-                        "opCategory": None,
                         "sdkName": "sentry.javascript.node",
                         "start": 25,
                         "end": 75,
@@ -1257,7 +1122,6 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
                     },
                     {
                         "project": "baz",
-                        "opCategory": None,
                         "sdkName": "sentry.javascript.node",
                         "start": 50,
                         "end": 100,
@@ -1296,7 +1160,6 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
                 * 32: [
                     {
                         "project": "foo",
-                        "opCategory": None,
                         "sdkName": "sentry.javascript.node",
                         "start": 0,
                         "end": 25,
@@ -1306,7 +1169,6 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
                     },
                     {
                         "project": None,
-                        "opCategory": None,
                         "sdkName": None,
                         "start": 25,
                         "end": 50,
@@ -1316,7 +1178,6 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
                     },
                     {
                         "project": "bar",
-                        "opCategory": None,
                         "sdkName": "sentry.javascript.node",
                         "start": 50,
                         "end": 75,
@@ -1355,7 +1216,6 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
                 * 32: [
                     {
                         "project": "foo",
-                        "opCategory": None,
                         "sdkName": "sentry.javascript.node",
                         "start": 0,
                         "end": 100,
@@ -1394,7 +1254,6 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
                 * 32: [
                     {
                         "project": "foo",
-                        "opCategory": None,
                         "sdkName": "sentry.javascript.node",
                         "start": 0,
                         "end": 100,
@@ -1433,7 +1292,6 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
                 * 32: [
                     {
                         "project": "foo",
-                        "opCategory": None,
                         "sdkName": "sentry.javascript.node",
                         "start": 0,
                         "end": 25,
@@ -1443,7 +1301,6 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
                     },
                     {
                         "project": None,
-                        "opCategory": None,
                         "sdkName": None,
                         "start": 25,
                         "end": 50,
@@ -1453,7 +1310,6 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
                     },
                     {
                         "project": "foo",
-                        "opCategory": None,
                         "sdkName": "sentry.javascript.node",
                         "start": 50,
                         "end": 75,
@@ -1501,7 +1357,6 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
                 * 32: [
                     {
                         "project": "foo",
-                        "opCategory": None,
                         "sdkName": "sentry.javascript.node",
                         "start": 0,
                         "end": 100,
@@ -1511,7 +1366,6 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
                     },
                     {
                         "project": "bar",
-                        "opCategory": None,
                         "sdkName": "sentry.javascript.node",
                         "start": 20,
                         "end": 80,
@@ -1521,7 +1375,6 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
                     },
                     {
                         "project": "baz",
-                        "opCategory": None,
                         "sdkName": "sentry.javascript.node",
                         "start": 40,
                         "end": 60,
@@ -1569,7 +1422,6 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
                 * 32: [
                     {
                         "project": "foo",
-                        "opCategory": None,
                         "sdkName": "sentry.javascript.node",
                         "start": 0,
                         "end": 100,
@@ -1579,7 +1431,6 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
                     },
                     {
                         "project": "bar",
-                        "opCategory": None,
                         "sdkName": "sentry.javascript.node",
                         "start": 25,
                         "end": 50,
@@ -1589,7 +1440,6 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
                     },
                     {
                         "project": "baz",
-                        "opCategory": None,
                         "sdkName": "sentry.javascript.node",
                         "start": 50,
                         "end": 75,
@@ -1637,7 +1487,6 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
                 * 32: [
                     {
                         "project": "foo",
-                        "opCategory": None,
                         "sdkName": "sentry.javascript.node",
                         "start": 0,
                         "end": 50,
@@ -1647,7 +1496,6 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
                     },
                     {
                         "project": "bar",
-                        "opCategory": None,
                         "sdkName": "sentry.javascript.node",
                         "start": 20,
                         "end": 30,
@@ -1657,7 +1505,6 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
                     },
                     {
                         "project": "baz",
-                        "opCategory": None,
                         "sdkName": "sentry.javascript.node",
                         "start": 50,
                         "end": 75,
@@ -1705,7 +1552,6 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
                 * 32: [
                     {
                         "project": "foo",
-                        "opCategory": None,
                         "sdkName": "sentry.javascript.node",
                         "start": 0,
                         "end": 50,
@@ -1715,7 +1561,6 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
                     },
                     {
                         "project": "bar",
-                        "opCategory": None,
                         "sdkName": "sentry.javascript.node",
                         "start": 20,
                         "end": 30,
@@ -1725,7 +1570,6 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
                     },
                     {
                         "project": "baz",
-                        "opCategory": None,
                         "sdkName": "sentry.javascript.node",
                         "start": 40,
                         "end": 60,
@@ -1773,7 +1617,6 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
                 * 32: [
                     {
                         "project": "foo",
-                        "opCategory": None,
                         "sdkName": "sentry.javascript.node",
                         "start": 0,
                         "end": 50,
@@ -1783,7 +1626,6 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
                     },
                     {
                         "project": "bar",
-                        "opCategory": None,
                         "sdkName": "sentry.javascript.node",
                         "start": 10,
                         "end": 20,
@@ -1813,7 +1655,6 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
                 * 32: [
                     {
                         "project": "foo",
-                        "opCategory": None,
                         "sdkName": "sentry.javascript.node",
                         "start": 0,
                         "end": 50,
@@ -1843,7 +1684,6 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
                 * 32: [
                     {
                         "project": "foo",
-                        "opCategory": None,
                         "sdkName": "sentry.javascript.node",
                         "start": 0,
                         "end": 40,
@@ -1853,7 +1693,6 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
                     },
                     {
                         "project": None,
-                        "opCategory": None,
                         "sdkName": None,
                         "start": 40,
                         "end": 100,
@@ -1901,7 +1740,6 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
                 * 32: [
                     {
                         "project": "foo",
-                        "opCategory": None,
                         "sdkName": "sentry.javascript.node",
                         "start": 0,
                         "end": 20,
@@ -1911,7 +1749,6 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
                     },
                     {
                         "project": None,
-                        "opCategory": None,
                         "sdkName": None,
                         "start": 20,
                         "end": 30,
@@ -1921,7 +1758,6 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
                     },
                     {
                         "project": "foo",
-                        "opCategory": None,
                         "sdkName": "sentry.javascript.node",
                         "start": 30,
                         "end": 40,
@@ -1969,7 +1805,6 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
                 * 32: [
                     {
                         "project": "foo",
-                        "opCategory": None,
                         "sdkName": "sentry.javascript.node",
                         "start": 0,
                         "end": 100,
@@ -1979,7 +1814,6 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
                     },
                     {
                         "project": "bar",
-                        "opCategory": None,
                         "sdkName": "sentry.javascript.node",
                         "start": 0,
                         "end": 40,
@@ -2018,7 +1852,6 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
                 * 32: [
                     {
                         "project": "foo",
-                        "opCategory": None,
                         "sdkName": "sentry.javascript.node",
                         "start": 0,
                         "end": 100,
@@ -2083,7 +1916,6 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
                 * 32: [
                     {
                         "project": "foo",
-                        "opCategory": None,
                         "sdkName": "sentry.javascript.remix",
                         "start": 0,
                         "end": 100,
@@ -2093,7 +1925,6 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
                     },
                     {
                         "project": "bar",
-                        "opCategory": None,
                         "sdkName": "sentry.javascript.node",
                         "start": 20,
                         "end": 80,
@@ -2103,7 +1934,6 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
                     },
                     {
                         "project": "foo",
-                        "opCategory": None,
                         "sdkName": "sentry.javascript.remix",
                         "start": 30,
                         "end": 70,
@@ -2142,7 +1972,6 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
                 * 32: [
                     {
                         "project": "foo",
-                        "opCategory": None,
                         "sdkName": "sentry.javascript.remix",
                         "start": 0,
                         "end": 100,
@@ -2152,7 +1981,6 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
                     },
                     {
                         "project": "foo",
-                        "opCategory": None,
                         "sdkName": "sentry.javascript.node",
                         "start": 0,
                         "end": 100,
@@ -2211,7 +2039,6 @@ def test_quantize_range_error(mock_quantize_range, mock_capture_exception):
         * 32: [
             {
                 "project": None,
-                "opCategory": None,
                 "sdkName": None,
                 "start": 0,
                 "end": 100,
@@ -2259,7 +2086,6 @@ def test_build_breakdown_error(mock_new_trace_interval, mock_capture_exception):
         * 32: [
             {
                 "project": None,
-                "opCategory": None,
                 "sdkName": None,
                 "start": 0,
                 "end": 100,


### PR DESCRIPTION
Superseded by the sdk. So we can go ahead and delete this.
