### PR TITLE
perf: emit killswitch metrics when needed

### DIFF
--- a/src/sentry/killswitches.py
+++ b/src/sentry/killswitches.py
@@ -279,7 +279,7 @@ def killswitch_matches_context(killswitch_name: str, context: Context, emit_metr
     option_value = options.get(killswitch_name)
     rv = _value_matches(killswitch_name, option_value, context)
 
-    if emit_metrics:
+    if emit_metrics and options.get("system.emit-kill-switch-metrics"):
         # metrics can have a meaningful performance impact, so allow caller to opt out
         # TODO: re-evaluate after we make metric collection aysnc.
         metrics.incr(

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -103,6 +103,12 @@ register(
     default=False,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
+# Enable kill switch metrics
+register(
+    "system.emit-kill-switch-metrics",
+    default=False,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
 # Redis
 register(
     "redis.clusters",


### PR DESCRIPTION
Warning: This is rather a controversial pull-request. 

We currently emit metrics for each `killswitch` detection regardless of the outcome of the kill switch operation. This is called in a lot of different places, and mostly on hot paths where performance is critical.

I'm recommending using options automator to emit events when needed, rather than the default way which is `always`.

For example, `ingest_consumer.process_event` calls this function, which gets executed 4.5 million times in a 5 minutes time span.

Regardless of this pull-request is getting merged, we should talk about reducing metrics on hot paths such as `ingest_consumer.process_event`

cc @getsentry/ops @getsentry/ingest 