### PR TITLE
fix(stats): Switch metrics api name to metricOutcomes

### DIFF
--- a/static/app/constants/index.tsx
+++ b/static/app/constants/index.tsx
@@ -339,7 +339,7 @@ export const DATA_CATEGORY_INFO = {
    */
   [DataCategoryExact.METRICS]: {
     name: DataCategoryExact.METRICS,
-    apiName: 'metrics',
+    apiName: 'metricOutcomes',
     plural: 'metrics',
     displayName: 'metrics',
     titleName: t('Metrics'),

--- a/static/app/views/organizationStats/usageStatsOrg.tsx
+++ b/static/app/views/organizationStats/usageStatsOrg.tsx
@@ -127,7 +127,7 @@ class UsageStatsOrganization<
 
   // Metric stats are not reported when grouping by category, so we make a separate request
   // and combine the results
-  get metricsEndpoint(): [string, string, {query: Record<string, any>}][] {
+  get metricsEndpoint(): ReturnType<DeprecatedAsyncComponent['getEndpoints']> {
     if (hasCustomMetrics(this.props.organization)) {
       return [
         [


### PR DESCRIPTION
this was changed here https://github.com/getsentry/sentry/pull/71552/files#diff-fa04253c7f72dde5952478eb745634f3689aa540b5d3b9a95013813b339320a7R172-R174 in #71552
