### PR TITLE
fix(ui): Avoid extra descender space

### DIFF
--- a/static/app/components/dropdownMenu/index.tsx
+++ b/static/app/components/dropdownMenu/index.tsx
@@ -261,5 +261,6 @@ function DropdownMenu({
 export {DropdownMenu};
 
 const DropdownMenuWrap = styled('div')`
+  display: flex;
   list-style-type: none;
 `;


### PR DESCRIPTION
Because the buttons are `inline-block` we're getting some extra
descender spacing here that we don't want. Using display: flex removes
that descender space.

I'm not 100% confident this is the right solution, but it's definitely
going to help

![image](https://github.com/getsentry/sentry/assets/1421724/37365c15-0523-4c36-8518-097a722ed0ee)
![image](https://github.com/getsentry/sentry/assets/1421724/97931898-24a3-4085-afed-401c27190eec)

Then with `display: flex` we can observe the extra descender spacing is not there:

<img width="314" alt="image" src="https://github.com/getsentry/sentry/assets/1421724/f5300123-9a0e-4677-9904-c20ebc249331">
