### PR TITLE
feat(insights): ignore duplicate filter fields in search bar

### DIFF
--- a/static/app/views/performance/cache/samplePanel/samplePanel.tsx
+++ b/static/app/views/performance/cache/samplePanel/samplePanel.tsx
@@ -62,7 +62,7 @@ export function CacheSamplePanel() {
   const location = useLocation();
   const organization = useOrganization();
   const {selection} = usePageFilters();
-  const supportedTags = useSpanFieldSupportedTags();
+  const supportedTags = useSpanFieldSupportedTags([SpanIndexedField.CACHE_HIT]);
 
   const query = useLocationQuery({
     fields: {

--- a/static/app/views/performance/queues/destinationSummary/messageSpanSamplesPanel.tsx
+++ b/static/app/views/performance/queues/destinationSummary/messageSpanSamplesPanel.tsx
@@ -69,7 +69,10 @@ export function MessageSpanSamplesPanel() {
   });
   const {projects} = useProjects();
   const {selection} = usePageFilters();
-  const supportedTags = useSpanFieldSupportedTags();
+  const supportedTags = useSpanFieldSupportedTags([
+    SpanIndexedField.TRACE_STATUS,
+    SpanIndexedField.MESSAGING_MESSAGE_RETRY_COUNT,
+  ]);
 
   const project = projects.find(p => query.project === p.id);
 

--- a/static/app/views/performance/utils/useSpanFieldSupportedTags.tsx
+++ b/static/app/views/performance/utils/useSpanFieldSupportedTags.tsx
@@ -5,10 +5,10 @@ import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import {SpanIndexedField} from 'sentry/views/starfish/types';
 
-const getSpanFieldSupportedTags = omitSupportedTags => {
+const getSpanFieldSupportedTags = excludedTags => {
   const tags: TagCollection = Object.fromEntries(
     Object.values(SpanIndexedField)
-      .filter(v => !omitSupportedTags.includes(v))
+      .filter(v => !excludedTags.includes(v))
       .map(v => [v, {key: v, name: v}])
   );
   tags.has = getHasTag(tags);

--- a/static/app/views/performance/utils/useSpanFieldSupportedTags.tsx
+++ b/static/app/views/performance/utils/useSpanFieldSupportedTags.tsx
@@ -5,9 +5,7 @@ import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import {SpanIndexedField} from 'sentry/views/starfish/types';
 
-const omitSupportedTags = [SpanIndexedField.SPAN_AI_PIPELINE_GROUP];
-
-const getSpanFieldSupportedTags = () => {
+const getSpanFieldSupportedTags = omitSupportedTags => {
   const tags: TagCollection = Object.fromEntries(
     Object.values(SpanIndexedField)
       .filter(v => !omitSupportedTags.includes(v))
@@ -34,10 +32,14 @@ const getDynamicSpanFieldsEndpoint = (orgSlug: string, selection): ApiQueryKey =
   },
 ];
 
-export function useSpanFieldSupportedTags(): TagCollection {
+export function useSpanFieldSupportedTags(excludedTags: string[] = []): TagCollection {
   const {selection} = usePageFilters();
   const organization = useOrganization();
-  const staticTags = getSpanFieldSupportedTags();
+  // we do not yet support span field search by SPAN_AI_PIPELINE_GROUP
+  const staticTags = getSpanFieldSupportedTags([
+    SpanIndexedField.SPAN_AI_PIPELINE_GROUP,
+    ...excludedTags,
+  ]);
 
   const dynamicTagQuery = useApiQuery<SpanFieldsResponse>(
     getDynamicSpanFieldsEndpoint(organization.slug, selection),


### PR DESCRIPTION
Removes the filter field as a searchable span field in the sample panel search bars.