### PR TITLE
feat(fe): Updated OrganizationDetailsEndpoint Urls to use Query Paramaters

### DIFF
--- a/src/sentry/api/endpoints/project_details.py
+++ b/src/sentry/api/endpoints/project_details.py
@@ -479,10 +479,6 @@ class ProjectDetailsEndpoint(ProjectEndpoint):
         """
         Return details on an individual project.
         """
-        # This param will be used to determine if we should include feature flags in the response
-        include_feature_flags = request.GET.get("include_feature_flags", "0") != "0"
-        (include_feature_flags)  # TODO: Remove this once include_feature_flags is used
-
         data = serialize(project, request.user, DetailedProjectSerializer())
 
         # TODO: should switch to expand and move logic into the serializer
@@ -532,9 +528,6 @@ class ProjectDetailsEndpoint(ProjectEndpoint):
         Note that solely having the **`project:read`** scope restricts updatable settings to
         `isBookmarked`.
         """
-        # This param will be used to determine if we should include feature flags in the response
-        include_feature_flags = request.GET.get("include_feature_flags", "0") != "0"
-        (include_feature_flags)  # TODO: Remove this once include_feature_flags is used
 
         old_data = serialize(project, request.user, DetailedProjectSerializer())
         has_elevated_scopes = request.access and (

--- a/src/sentry/api/endpoints/project_details.py
+++ b/src/sentry/api/endpoints/project_details.py
@@ -479,6 +479,10 @@ class ProjectDetailsEndpoint(ProjectEndpoint):
         """
         Return details on an individual project.
         """
+        # This param will be used to determine if we should include feature flags in the response
+        include_feature_flags = request.GET.get("include_feature_flags", "0") != "0"
+        (include_feature_flags)  # TODO: Remove this once include_feature_flags is used
+
         data = serialize(project, request.user, DetailedProjectSerializer())
 
         # TODO: should switch to expand and move logic into the serializer
@@ -528,6 +532,9 @@ class ProjectDetailsEndpoint(ProjectEndpoint):
         Note that solely having the **`project:read`** scope restricts updatable settings to
         `isBookmarked`.
         """
+        # This param will be used to determine if we should include feature flags in the response
+        include_feature_flags = request.GET.get("include_feature_flags", "0") != "0"
+        (include_feature_flags)  # TODO: Remove this once include_feature_flags is used
 
         old_data = serialize(project, request.user, DetailedProjectSerializer())
         has_elevated_scopes = request.access and (

--- a/src/sentry/templates/sentry/partial/preload-data.html
+++ b/src/sentry/templates/sentry/partial/preload-data.html
@@ -53,7 +53,7 @@
       return;
     }
 
-    preloadPromises.organization = promiseRequest(makeUrl('/?detailed=0'));
+    preloadPromises.organization = promiseRequest(makeUrl('/?detailed=0&include_feature_flags=1'));
     preloadPromises.projects = promiseRequest(
       makeUrl('/projects/?all_projects=1&collapse=latestDeploys&collapse=unusedFeatures')
     );

--- a/static/app/actionCreators/organization.tsx
+++ b/static/app/actionCreators/organization.tsx
@@ -30,7 +30,7 @@ async function fetchOrg(
       // If this url changes make sure to update the preload
       api.requestPromise(`/organizations/${slug}/`, {
         includeAllArgs: true,
-        query: {detailed: 0},
+        query: {detailed: 0, include_feature_flags: 1},
       }),
     usePreload
   );

--- a/static/app/bootstrap/index.tsx
+++ b/static/app/bootstrap/index.tsx
@@ -97,7 +97,9 @@ function preloadOrganizationData(config: Config) {
     if (!slug) {
       return;
     }
-    preloadPromises.organization = promiseRequest(makeUrl('/?detailed=0'));
+    preloadPromises.organization = promiseRequest(
+      makeUrl('/?detailed=0&include_feature_flags=1')
+    );
     preloadPromises.projects = promiseRequest(
       makeUrl('/projects/?all_projects=1&collapse=latestDeploys&collapse=unusedFeatures')
     );


### PR DESCRIPTION
In this pr, I update the urls for OrganizationDetailsEndpoint to use the new query parameter, `include_feature_flags`, which we will use to determine if the features data get returned in the API response object. 

We mentioned two places where we will be updating the urls in our research [here](https://www.notion.so/sentry/Remove-feature-flags-from-API-response-95ed20b0c6b74b7fad4cbc4495cd4c9b). The third place I modify is `preload-data.html` was because it was also preloading data and the preloaded org should also have all the features since they are used throughout our frontend.

Not sure if there are other gotchas for this.