### PR TITLE
feat(spans): Expose user fields

### DIFF
--- a/static/app/views/performance/traces/content.tsx
+++ b/static/app/views/performance/traces/content.tsx
@@ -477,7 +477,7 @@ function useTraces<F extends string>({
       per_page: limit,
       breakdownSlices: 40,
       minBreakdownPercentage: 1 / 40,
-      maxSpansPerTrace: 5,
+      maxSpansPerTrace: 10,
       mri,
       metricsMax,
       metricsMin,

--- a/static/app/views/starfish/types.tsx
+++ b/static/app/views/starfish/types.tsx
@@ -196,6 +196,9 @@ export enum SpanIndexedField {
   REPLAY_ID = 'replay.id',
   BROWSER_NAME = 'browser.name',
   USER = 'user',
+  USER_ID = 'user.id',
+  USER_EMAIL = 'user.email',
+  USER_USERNAME = 'user.username',
   INP = 'measurements.inp',
   INP_SCORE = 'measurements.score.inp',
   INP_SCORE_WEIGHT = 'measurements.score.weight.inp',
@@ -260,6 +263,9 @@ export type IndexedResponse = {
   [SpanIndexedField.REPLAY_ID]: string;
   [SpanIndexedField.BROWSER_NAME]: string;
   [SpanIndexedField.USER]: string;
+  [SpanIndexedField.USER_ID]: string;
+  [SpanIndexedField.USER_EMAIL]: string;
+  [SpanIndexedField.USER_USERNAME]: string;
   [SpanIndexedField.INP]: number;
   [SpanIndexedField.INP_SCORE]: number;
   [SpanIndexedField.INP_SCORE_WEIGHT]: number;


### PR DESCRIPTION
We started extracting user fields for id, email and username. Expose it in the frontend so it works with autocompletion.