### PR TITLE
fix(profiling): consider profile to txn offset

### DIFF
--- a/static/app/types/profiling.d.ts
+++ b/static/app/types/profiling.d.ts
@@ -200,6 +200,7 @@ declare namespace Profiling {
       traceID: string;
       transactionID: string;
       transactionName: string;
+      timestamp?: string;
     };
     profileID: string;
     projectID: number;


### PR DESCRIPTION
At some point we lost the profile timestamp, meaning we were only applying thread offsets. This reintroduces the timestamp and offsets the flamechart view for the difference of profile-txn timestamp