### PR TITLE
feat(utils): Add `with_circuit_breaker` helper

### DIFF
--- a/src/sentry/utils/circuit_breaker.py
+++ b/src/sentry/utils/circuit_breaker.py
@@ -1,9 +1,13 @@
-from typing import TypedDict
+from collections.abc import Callable
+from typing import ParamSpec, TypedDict, TypeVar
 
 from django.core.cache import cache
 
 from sentry import ratelimits as ratelimiter
 from sentry.utils import metrics
+
+# TODO: Right now this circuit breaker is based on count of consecutive errors. We should consider
+# whether basing it on percentage of failed requests would be better.
 
 DEFAULT_ERROR_LIMIT = 30
 ERROR_COUNT_CACHE_KEY = lambda key: f"circuit_breaker:{key}-error-count"
@@ -13,6 +17,41 @@ PASSTHROUGH_RATELIMIT_KEY = lambda key: f"circuit_breaker:{key}-passthrough"
 class CircuitBreakerPassthrough(TypedDict, total=True):
     limit: int
     window: int
+
+
+class CircuitBreakerTripped(Exception):
+    pass
+
+
+class CircuitBreakerConfig(TypedDict, total=False):
+    # The number of consecutive failures within a given window required to trigger the circuit breaker
+    error_limit: int
+    # The window of time in which those errors must happen
+    error_limit_window: int
+    # Allow a configurable subset of function calls to bypass the circuit breaker, for the purposes
+    # of determining when the service is healthy again and requests to it can resume.
+    allow_passthrough: bool
+    # The number of function calls allowed to bypass the circuit breaker every
+    # `passthrough_interval` seconds
+    passthrough_attempts_per_interval: int
+    # The window of time, in seconds, during which to allow `passthrough_attempts_per_interval`
+    # calls to bypass the circuit breaker
+    passthrough_interval: int
+
+
+CIRCUIT_BREAKER_DEFAULTS = CircuitBreakerConfig(
+    error_limit=DEFAULT_ERROR_LIMIT,
+    error_limit_window=3600,  # 1 hour
+    allow_passthrough=False,
+    passthrough_interval=15,  # 15 sec
+    passthrough_attempts_per_interval=1,
+)
+
+# TODO: Once we're on python 3.12, we can get rid of these and change the first line of the
+# signature of `with_circuit_breaker` to
+#   def with_circuit_breaker[T, **P](
+P = ParamSpec("P")
+T = TypeVar("T")
 
 
 def circuit_breaker_activated(
@@ -42,3 +81,103 @@ def circuit_breaker_activated(
 
     metrics.incr(f"circuit_breaker.{key}.throttled")
     return True  # blocked
+
+
+def with_circuit_breaker(
+    key: str,
+    callback: Callable[P, T],
+    custom_config: CircuitBreakerConfig | None = None,
+) -> T:
+    """
+    Attempts to call the given callback, subject to a circuit breaker which will prevent the
+    callback from being called if has previously errored too many times in a row.
+
+    If the breaker has been tripped, raises a `CircuitBreakerTripped` exception. If the callback is
+    called, and errors, increments the error count before allowing the error to bubble up to this
+    function's caller. Otherwise, simply returns the callback's result.
+
+    Can optionally allow a subset of requests to bypass the circuit breaker, as a way to determine
+    whether the service has recovered. Once one of these requests succeeds, the circuit breaker will
+    be reset to its untripped state and the error count will be reset to 0.
+
+    Note: The callback MUST NOT handle and then silently swallow exceptions, or else they won't
+    count towards the ciruit-breaking. In other words, this function should be used - along with an
+    `except CircuitBreakerTripped` block - inside the try-except wrapping the callback call:
+
+        try:
+            with_circuit_breaker("fire", play_with_fire, config)
+            # or, if the callback takes arguments:
+            # with_circuit_breaker("fire", lambda: play_with_fire(fuel_type="wood"), config)
+        except CircuitBreakerTripped:
+            logger.log("Once burned, twice shy. No playing with fire for you today. Try again tomorrow.")
+        except BurnException:
+            logger.log("Ouch!")
+
+    The threshold for tripping the circuit breaker and whether to allow bypass requests (and if so,
+    how many) can be set in the `config` argument. See the `CircuitBreakerConfig` class and
+    `CIRCUIT_BREAKER_DEFAULTS`.
+    """
+    config: CircuitBreakerConfig = {**CIRCUIT_BREAKER_DEFAULTS, **(custom_config or {})}
+    error_count_key = ERROR_COUNT_CACHE_KEY(key)
+
+    if _should_call_callback(key, error_count_key, config):
+        return _call_callback(error_count_key, config["error_limit_window"], callback)
+    else:
+        raise CircuitBreakerTripped
+
+
+def _should_call_callback(
+    key: str,
+    error_count_key: str,
+    config: CircuitBreakerConfig,
+) -> bool:
+    error_count = _get_or_set_error_count(error_count_key, config["error_limit_window"])
+    if error_count < config["error_limit"]:
+        return True
+
+    # Limit has been exceeded, check if we should allow any requests to pass through
+    if config["allow_passthrough"]:
+        should_bypass = not ratelimiter.backend.is_limited(
+            PASSTHROUGH_RATELIMIT_KEY(key),
+            limit=config["passthrough_attempts_per_interval"],
+            window=config["passthrough_interval"],
+        )
+        if should_bypass:
+            metrics.incr(f"circuit_breaker.{key}.bypassed")
+            return True
+
+    metrics.incr(f"circuit_breaker.{key}.throttled")
+    return False
+
+
+def _call_callback(error_count_key: str, error_limit_window: int, callback: Callable[P, T]) -> T:
+    try:
+        result = callback()
+    except Exception:
+        _update_error_count(error_count_key, error_limit_window)
+        raise
+    else:
+        _update_error_count(error_count_key, error_limit_window, reset=True)
+        return result
+
+
+def _update_error_count(
+    error_count_key: str,
+    error_limit_window: int,
+    reset: bool = False,
+) -> None:
+    """
+    Increment the count at the given key, unless `reset` is True, in which case, reset the count to 0.
+    """
+    if reset:
+        new_count = 0
+    else:
+        new_count = _get_or_set_error_count(error_count_key, error_limit_window) + 1
+
+    cache.set(error_count_key, new_count, error_limit_window)
+
+
+def _get_or_set_error_count(error_count_key: str, error_limit_window: int) -> int:
+    error_count = cache.get_or_set(error_count_key, default=0, timeout=error_limit_window)
+    assert error_count is not None
+    return error_count

--- a/tests/sentry/utils/test_circuit_breaker.py
+++ b/tests/sentry/utils/test_circuit_breaker.py
@@ -1,13 +1,17 @@
 import time
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
+import pytest
 from django.core.cache import cache
 
 from sentry.testutils.cases import TestCase
 from sentry.utils.circuit_breaker import (
     ERROR_COUNT_CACHE_KEY,
+    CircuitBreakerConfig,
     CircuitBreakerPassthrough,
+    CircuitBreakerTripped,
     circuit_breaker_activated,
+    with_circuit_breaker,
 )
 
 
@@ -25,7 +29,7 @@ class TestCircuitBreaker(TestCase):
         assert circuit_breaker_activated(key=self.key, error_limit=self.error_limit)
 
     @patch("sentry.utils.circuit_breaker.metrics.incr")
-    def test_passthrough(self, mock_metrics):
+    def test_passthrough(self, mock_metrics: MagicMock):
         assert not circuit_breaker_activated(self.key, self.error_limit, self.passthrough_data)
         mock_metrics.assert_called_with(f"circuit_breaker.{self.key}.bypassed")
 
@@ -39,3 +43,133 @@ class TestCircuitBreaker(TestCase):
         time.sleep(1)
         assert not circuit_breaker_activated(self.key, self.error_limit, self.passthrough_data)
         mock_metrics.assert_called_with(f"circuit_breaker.{self.key}.bypassed")
+
+
+class FailedToFetchError(Exception):
+    pass
+
+
+class WithCircuitBreakerTest(TestCase):
+    def setUp(self):
+        self.key = "with_circuit_breaker_test"
+        self.error_limit = 2
+        self.error_limit_window = 3
+        self.config = CircuitBreakerConfig(
+            error_limit=self.error_limit,
+            error_limit_window=self.error_limit_window,
+            allow_passthrough=False,
+            passthrough_interval=2,
+            passthrough_attempts_per_interval=1,
+        )
+        self.error_count_key = ERROR_COUNT_CACHE_KEY(self.key)
+        self.callback = MagicMock(wraps=lambda: "Dogs are great!")
+        self.erroring_callback = MagicMock(
+            side_effect=FailedToFetchError("Charlie didn't bring the ball back.")
+        )
+
+    def test_calls_callback_if_no_errors(self):
+        assert cache.get_or_set(self.error_count_key, default=0) == 0
+
+        result = with_circuit_breaker(self.key, self.callback, self.config)
+
+        assert self.callback.call_count == 1
+        assert result == "Dogs are great!"
+
+    def test_calls_callback_if_not_too_many_errors(self):
+        cache.set(self.error_count_key, self.error_limit - 1)
+
+        result = with_circuit_breaker(self.key, self.callback, self.config)
+
+        assert self.callback.call_count == 1
+        assert result == "Dogs are great!"
+
+    @patch("sentry.utils.circuit_breaker.metrics.incr")
+    def test_prevents_next_request_if_breaker_is_tripped(self, mock_metrics_incr: MagicMock):
+        cache.set(self.error_count_key, self.error_limit - 1)
+
+        # The breaker hasn't been tripped yet, so the callback's error bubbles up
+        with pytest.raises(FailedToFetchError):
+            with_circuit_breaker(self.key, self.erroring_callback, self.config)
+
+            assert self.erroring_callback.call_count == 1
+            assert cache.get(self.error_count_key) == self.error_limit
+            assert mock_metrics_incr.call_count == 0
+
+        # Now the breaker has been flipped, so we get a circuit breaker error instead
+        with pytest.raises(CircuitBreakerTripped):
+            with_circuit_breaker(self.key, self.erroring_callback, self.config)
+
+            assert self.erroring_callback.call_count == 1  # hasn't increased
+            mock_metrics_incr.assert_called_with(f"circuit_breaker.{self.key}.throttled")
+
+    @patch("sentry.utils.circuit_breaker.metrics.incr")
+    def test_obeys_passthrough_config(self, mock_metrics_incr: MagicMock):
+        cache.set(self.error_count_key, self.error_limit)
+
+        # The passthrough is off by default, so the request is blocked and we get the circuit
+        # breaker error
+        with pytest.raises(CircuitBreakerTripped):
+            with_circuit_breaker(self.key, self.erroring_callback, self.config)
+
+            assert self.erroring_callback.call_count == 0
+            mock_metrics_incr.assert_called_with(f"circuit_breaker.{self.key}.throttled")
+
+        # Allowing passthrough causes the request to go through, so we get the callback's error this time
+        self.config["allow_passthrough"] = True
+        with pytest.raises(FailedToFetchError):
+            with_circuit_breaker(self.key, self.erroring_callback, self.config)
+
+            assert self.erroring_callback.call_count == 1
+            mock_metrics_incr.assert_called_with(f"circuit_breaker.{self.key}.bypassed")
+
+        # According to our config (see `setUp`), even with passthrough on, we only get one attempt
+        # every two seconds, so now we're back to getting the circuit breaker error
+        with pytest.raises(CircuitBreakerTripped):
+            with_circuit_breaker(self.key, self.erroring_callback, self.config)
+
+            assert self.erroring_callback.call_count == 1  # hasn't increased
+            mock_metrics_incr.assert_called_with(f"circuit_breaker.{self.key}.throttled")
+
+        # But if we wait the requisite two seconds, we're allowed another attempt, and we get the
+        # callback's error again
+        time.sleep(2)
+        with pytest.raises(FailedToFetchError):
+            with_circuit_breaker(self.key, self.erroring_callback, self.config)
+
+            assert self.erroring_callback.call_count == 2
+            mock_metrics_incr.assert_called_with(f"circuit_breaker.{self.key}.bypassed")
+
+    @patch("sentry.utils.circuit_breaker.metrics.incr")
+    def test_resets_on_successful_request(self, mock_metrics_incr: MagicMock):
+        cache.set(self.error_count_key, self.error_limit)
+        self.config["allow_passthrough"] = True
+
+        # Passthrough lets this request through
+        result = with_circuit_breaker(self.key, self.callback, self.config)
+
+        assert self.callback.call_count == 1
+        mock_metrics_incr.assert_called_with(f"circuit_breaker.{self.key}.bypassed")
+        assert result == "Dogs are great!"
+
+        # Error count is reset
+        assert cache.get_or_set(self.error_count_key, default=0) == 0
+
+    @patch("sentry.utils.circuit_breaker.metrics.incr")
+    def resets_after_error_window(self, mock_metrics_incr: MagicMock):
+        cache.set(self.error_count_key, self.error_limit)
+
+        with pytest.raises(CircuitBreakerTripped):
+            with_circuit_breaker(self.key, self.callback, self.config)
+
+            assert self.callback.call_count == 0
+            mock_metrics_incr.assert_called_with(f"circuit_breaker.{self.key}.throttled")
+
+        time.sleep(self.error_limit_window)
+
+        assert cache.get_or_set(self.error_count_key, default=0) == 0
+
+        # Now requests go through
+        result = with_circuit_breaker(self.key, self.callback, self.config)
+
+        assert self.callback.call_count == 1
+        assert result == "Dogs are great!"


### PR DESCRIPTION
Currently, our circuit breaker can check if it's been tripped (by too many errors happening within too short a time), but it leaves it to the calling code to actually track those errors. This PR introduces a wrapper function, `with_circuit_breaker`, to combine both tasks into one.

I was deeply conflicted about whether to write this as a wrapper with a callback or as a context manager. I ended up with the wrapper approach because my fear was the that natural tendency with a context manager would be to use it like this:

```python
with circuit_breaker("some_key", config):
	try:
		do_something()
	except Exception:
		handle_exception()
```

The problem with that is that the circuit breaker has to be _inside_ the `try` block - otherwise, the errors it's supposed to be tracking will already have been handled before bubbling up where it could see them. So instead I went with a function which could  be wrapped around `do_something`, because that way - short of pulling the whole `try-except` into `do_something`'s innards - there's no way to make the above mistake. In the end it looks like this:

```python
try:
	with_circuit_breaker("some_key", do_something, config)
except CircuitBreakerTripped:
	logger.log("`do_something` actually did nothing, because the circuit breaker's been tripped.")
except Exception:
	handle_exception()
```

I still don't love it, though - IMHO it's less readable, and you have to stick `do_something` into a lambda if you want to pass it any arguments, which makes it even less readable and is also just kind of a pain. Maybe there's some Python magic I don't know about which would make the above context manager example work? Very open to suggestions on that score, but am going with this for now to keep things moving.

Note: The `_should_call_callback` helper here draws heavy inspiration from the existing `circuit_breaker_activated` function (h/t @snigdhas), the key differences being where the config data comes from and the fact that they return opposite answers (returning True when the other returns False, and vice versa). I left `circuit_breaker_activated` alone rather than refactoring and then wrapping it so as not to have to change everywhere it's used. If those spots choose to switch over to using `with_circuit_breaker`, that can happen in follow-up PRs. 
