### PR TITLE
fix(issues): Add partition key for status change kafka msg

### DIFF
--- a/src/sentry/issues/producer.py
+++ b/src/sentry/issues/producer.py
@@ -67,6 +67,8 @@ def produce_occurrence_to_kafka(
     partition_key = None
     if occurrence and occurrence.fingerprint:
         partition_key = occurrence.fingerprint[0].encode()
+    elif status_change and status_change.fingerprint:
+        partition_key = status_change.fingerprint[0].encode()
     payload = KafkaPayload(partition_key, json.dumps(payload_data).encode("utf-8"), [])
     if settings.SENTRY_EVENTSTREAM != "sentry.eventstream.kafka.KafkaEventStream":
         # If we're not running Kafka then we're just in dev.


### PR DESCRIPTION
Reopened from https://github.com/getsentry/sentry/pull/71620
Previously status change had no key. There are no order guarantees across partitions, resulting in status changes being processed before the first occurrence/group was created.