### PR TITLE
Add additional logs for weekly report investigation

### DIFF
--- a/src/sentry/tasks/summaries/weekly_reports.py
+++ b/src/sentry/tasks/summaries/weekly_reports.py
@@ -695,7 +695,8 @@ def send_email(
         # TODO see if we can use the UUID to track if the email was sent or not
         logger.info(
             "weekly_report.send_email",
-            extra={"organization": ctx.organization.id, uuid: template_ctx["notification_uuid"]},
+            extra={"organization": ctx.organization.id, "uuid": template_ctx["notification_uuid"]},
         )
+
         message.add_users((user_id,))
         message.send_async()


### PR DESCRIPTION
## Description
We currently have logs for notifications, but there all happening after a few retry events and it's difficult to tell what is triggering another send. Existing metrics are just saying that we are invoking  send mulitple times, but not what triggered the calls.

I also found a spot where we have a UUID per template send, we can likely utilize this uuid to mark the email as "sent".