### PR TITLE
ref(charts): Move STARFISH_FIELDS out of charts.ts

### DIFF
--- a/static/app/utils/discover/fields.tsx
+++ b/static/app/utils/discover/fields.tsx
@@ -10,8 +10,8 @@ import {
   SESSIONS_FIELDS,
   SESSIONS_OPERATIONS,
 } from 'sentry/views/dashboards/widgetBuilder/releaseWidget/fields';
-import {STARFISH_FIELDS} from 'sentry/views/starfish/components/chart';
 import {STARFISH_AGGREGATION_FIELDS} from 'sentry/views/starfish/types';
+import {STARFISH_FIELDS} from 'sentry/views/starfish/utils/constants';
 
 import {
   AGGREGATION_FIELDS,

--- a/static/app/views/starfish/components/chart.tsx
+++ b/static/app/views/starfish/components/chart.tsx
@@ -49,36 +49,8 @@ import type {AggregationOutputType, RateUnit} from 'sentry/utils/discover/fields
 import {aggregateOutputType} from 'sentry/utils/discover/fields';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import useRouter from 'sentry/utils/useRouter';
-import {SpanIndexedField, SpanMetricsField} from 'sentry/views/starfish/types';
 
 const STARFISH_CHART_GROUP = 'starfish_chart_group';
-
-export const STARFISH_FIELDS: Record<string, {outputType: AggregationOutputType}> = {
-  [SpanMetricsField.SPAN_DURATION]: {
-    outputType: 'duration',
-  },
-  [SpanMetricsField.SPAN_SELF_TIME]: {
-    outputType: 'duration',
-  },
-  [SpanMetricsField.HTTP_RESPONSE_TRANSFER_SIZE]: {
-    outputType: 'size',
-  },
-  [SpanMetricsField.HTTP_DECODED_RESPONSE_CONTENT_LENGTH]: {
-    outputType: 'size',
-  },
-  [SpanMetricsField.HTTP_RESPONSE_CONTENT_LENGTH]: {
-    outputType: 'size',
-  },
-  [SpanIndexedField.CACHE_ITEM_SIZE]: {
-    outputType: 'size',
-  },
-  [SpanMetricsField.CACHE_ITEM_SIZE]: {
-    outputType: 'size',
-  },
-  [SpanMetricsField.MESSAGING_MESSAGE_RECEIVE_LATENCY]: {
-    outputType: 'duration',
-  },
-};
 
 export enum ChartType {
   BAR = 0,

--- a/static/app/views/starfish/utils/constants.tsx
+++ b/static/app/views/starfish/utils/constants.tsx
@@ -1,4 +1,34 @@
+import type {AggregationOutputType} from 'sentry/utils/discover/fields';
+import {SpanIndexedField, SpanMetricsField} from 'sentry/views/starfish/types';
+
 // This constant is to be used as an arg for `getInterval`.
 // 'metrics' fidelity is intended to match the granularities of stored metrics.
 // This gives us the best/highest fidelity of data for minimum amount of work (don't need to merge buckets).
 export const STARFISH_CHART_INTERVAL_FIDELITY = 'metrics';
+
+export const STARFISH_FIELDS: Record<string, {outputType: AggregationOutputType}> = {
+  [SpanMetricsField.SPAN_DURATION]: {
+    outputType: 'duration',
+  },
+  [SpanMetricsField.SPAN_SELF_TIME]: {
+    outputType: 'duration',
+  },
+  [SpanMetricsField.HTTP_RESPONSE_TRANSFER_SIZE]: {
+    outputType: 'size',
+  },
+  [SpanMetricsField.HTTP_DECODED_RESPONSE_CONTENT_LENGTH]: {
+    outputType: 'size',
+  },
+  [SpanMetricsField.HTTP_RESPONSE_CONTENT_LENGTH]: {
+    outputType: 'size',
+  },
+  [SpanIndexedField.CACHE_ITEM_SIZE]: {
+    outputType: 'size',
+  },
+  [SpanMetricsField.CACHE_ITEM_SIZE]: {
+    outputType: 'size',
+  },
+  [SpanMetricsField.MESSAGING_MESSAGE_RECEIVE_LATENCY]: {
+    outputType: 'duration',
+  },
+};


### PR DESCRIPTION
This module imports a TON of stuff, STARFISH_FIELDS is used by
discover/fields. By moving this out we can reduce the import graph
generated for chartcuterie by a magnitude of a few MBs.

This is also needed for GH-70632