### PR TITLE
perf: move sentry/plugins to orjson

### DIFF
--- a/src/sentry/plugins/base/configuration.py
+++ b/src/sentry/plugins/base/configuration.py
@@ -8,7 +8,7 @@ from sentry import options
 from sentry.api import client
 from sentry.api.serializers import serialize
 from sentry.models.options.project_option import ProjectOption
-from sentry.utils import json
+from sentry.utils.json import dumps_htmlsafe
 from sentry.web.helpers import render_to_string
 
 
@@ -42,9 +42,9 @@ def react_plugin_config(plugin, project, request):
     """
         % (
             nonce,
-            json.dumps_htmlsafe(serialize(project, request.user)),
-            json.dumps_htmlsafe(serialize(project.organization, request.user)),
-            json.dumps_htmlsafe(response.data),
+            dumps_htmlsafe(serialize(project, request.user)),
+            dumps_htmlsafe(serialize(project.organization, request.user)),
+            dumps_htmlsafe(response.data),
         )
     )
 

--- a/src/sentry/plugins/base/response.py
+++ b/src/sentry/plugins/base/response.py
@@ -1,9 +1,8 @@
 __all__ = ("Response", "JSONResponse")
 
+import orjson
 from django.http import HttpResponse
 from django.template.context_processors import csrf
-
-from sentry.utils import json
 
 
 class Response:
@@ -35,5 +34,7 @@ class JSONResponse(Response):
 
     def respond(self, request, context=None):
         return HttpResponse(
-            json.dumps(self.context), content_type="application/json", status=self.status
+            orjson.dumps(self.context, option=orjson.OPT_UTC_Z | orjson.OPT_NON_STR_KEYS),
+            content_type="application/json",
+            status=self.status,
         )

--- a/tests/sentry/plugins/base/test_response.py
+++ b/tests/sentry/plugins/base/test_response.py
@@ -1,3 +1,5 @@
+import datetime
+
 from sentry.plugins.base.response import JSONResponse
 
 
@@ -9,3 +11,15 @@ def test_json_response():
 def test_json_response_with_status_kwarg():
     resp = JSONResponse({}, status=400).respond(None)
     assert resp.status_code == 400
+
+
+def test_json_response_with_weird_inputs():
+    # This test is required for validating orjson serializing/deserializing.
+    date = datetime.datetime(2017, 1, 20, 21, 39, 23, 30723, tzinfo=datetime.UTC)
+    date_resp = JSONResponse({"date": date}).respond(None)
+    assert date_resp.status_code == 200
+    assert date_resp.content.decode() == '{"date":"2017-01-20T21:39:23.030723Z"}'
+
+    non_str_key_resp = JSONResponse({1: "non-str-key-value"}).respond(None)
+    assert non_str_key_resp.status_code == 200
+    assert non_str_key_resp.content.decode() == '{"1":"non-str-key-value"}'


### PR DESCRIPTION
Splitting the changes from https://github.com/getsentry/sentry/pull/71185 into multiple pull-requests as a recommendation from @fpacifici (ref: https://github.com/getsentry/sentry/pull/71185#issuecomment-2125854962).

This pull-request only changes `json` usages in `src/sentry/plugins` folder.