### PR TITLE
perf: move sentry/shared_integrations to orjson

### DIFF
--- a/src/sentry/shared_integrations/client/base.py
+++ b/src/sentry/shared_integrations/client/base.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from collections.abc import Callable, Mapping, Sequence
 from typing import Any, Literal, Self, Union, overload
 
+import orjson
 import sentry_sdk
 from django.core.cache import cache
 from requests import PreparedRequest, Request, Response
@@ -19,7 +20,7 @@ from sentry.models.integrations.utils import is_response_error, is_response_succ
 from sentry.net.http import SafeSession
 from sentry.services.hybrid_cloud.integration import integration_service
 from sentry.services.hybrid_cloud.organization import organization_service
-from sentry.utils import json, metrics
+from sentry.utils import metrics
 from sentry.utils.audit import create_system_audit_entry
 from sentry.utils.hashlib import md5_text
 
@@ -332,7 +333,9 @@ class BaseApiClient(TrackResponseMixin):
         data = kwargs.get("data", None)
         query = ""
         if kwargs.get("params", None):
-            query = json.dumps(kwargs.get("params"))
+            query = orjson.dumps(
+                kwargs.get("params"), option=orjson.OPT_UTC_Z | orjson.OPT_NON_STR_KEYS
+            ).decode()
 
         key = self.get_cache_key(path, query, data)
         result: BaseApiResponseX | None = self.check_cache(key)

--- a/src/sentry/shared_integrations/exceptions/__init__.py
+++ b/src/sentry/shared_integrations/exceptions/__init__.py
@@ -5,12 +5,11 @@ from collections.abc import Mapping
 from typing import Any, Protocol
 from urllib.parse import urlparse
 
+import orjson
 from bs4 import BeautifulSoup
 from requests import Response
 from requests.adapters import RetryError
 from requests.exceptions import RequestException
-
-from sentry.utils import json
 
 __all__ = (
     "ApiConnectionResetError",
@@ -53,8 +52,8 @@ class ApiError(Exception):
         # TODO(dcramer): pull in XML support from Jira
         if text:
             try:
-                self.json = json.loads(text)
-            except (json.JSONDecodeError, ValueError):
+                self.json = orjson.loads(text)
+            except (orjson.JSONDecodeError, ValueError):
                 if self.text[:5] == "<?xml":
                     # perhaps it's XML?
                     self.xml = BeautifulSoup(self.text, "xml")


### PR DESCRIPTION
Splitting the changes from https://github.com/getsentry/sentry/pull/71185 into multiple pull-requests as a recommendation from @fpacifici (ref: https://github.com/getsentry/sentry/pull/71185#issuecomment-2125854962).

This pull-request only changes `json` usages in `src/sentry/shared_integrations` folder.