### PR TITLE
perf: move sentry/monitors to orjson

### DIFF
--- a/src/sentry/monitors/consumers/monitor_consumer.py
+++ b/src/sentry/monitors/consumers/monitor_consumer.py
@@ -10,6 +10,7 @@ from datetime import datetime, timedelta
 from functools import partial
 from typing import Literal
 
+import orjson
 import sentry_sdk
 from arroyo.backends.kafka.consumer import KafkaPayload
 from arroyo.processing.strategies.abstract import ProcessingStrategy, ProcessingStrategyFactory
@@ -74,7 +75,7 @@ from sentry.monitors.utils import (
 )
 from sentry.monitors.validators import ConfigValidator, MonitorCheckInValidator
 from sentry.types.actor import parse_and_validate_actor
-from sentry.utils import json, metrics
+from sentry.utils import metrics
 from sentry.utils.dates import to_datetime
 from sentry.utils.outcomes import Outcome, track_outcome
 
@@ -975,7 +976,7 @@ def process_batch(executor: ThreadPoolExecutor, message: Message[ValuesBatch[Kaf
             ts=item.timestamp,
             partition=item.partition.index,
             message=wrapper,
-            payload=json.loads(wrapper["payload"]),
+            payload=orjson.loads(wrapper["payload"]),
         )
         checkin_mapping[item.processing_key].append(item)
 
@@ -1022,7 +1023,7 @@ def process_single(message: Message[KafkaPayload | FilteredPayload]):
             ts=ts,
             partition=partition,
             message=wrapper,
-            payload=json.loads(wrapper["payload"]),
+            payload=orjson.loads(wrapper["payload"]),
         )
         process_checkin(item)
     except Exception:

--- a/src/sentry/monitors/processing_errors/manager.py
+++ b/src/sentry/monitors/processing_errors/manager.py
@@ -5,6 +5,7 @@ import uuid
 from datetime import timedelta
 from itertools import chain
 
+import orjson
 from django.conf import settings
 from redis.client import StrictRedis
 from rediscluster import RedisCluster
@@ -14,7 +15,7 @@ from sentry.models.organization import Organization
 from sentry.models.project import Project
 from sentry.monitors.models import Monitor
 from sentry.monitors.types import CheckinItem
-from sentry.utils import json, metrics, redis
+from sentry.utils import metrics, redis
 
 from .errors import CheckinProcessingError, ProcessingErrorsException, ProcessingErrorType
 
@@ -79,7 +80,7 @@ def _get_for_entities(entity_identifiers: list[str]) -> list[CheckinProcessingEr
         for error_identifier in chain(*pipeline.execute())
     ]
     errors = [
-        CheckinProcessingError.from_dict(json.loads(raw_error))
+        CheckinProcessingError.from_dict(orjson.loads(raw_error))
         for raw_error in redis.mget(error_identifiers)
         if raw_error is not None
     ]
@@ -111,7 +112,9 @@ def _delete_for_entity_by_type(entity_identifier: str, type: ProcessingErrorType
         else:
             filtered_errors = list(filter(lambda error: error["type"] != type, errors))
             new_checkin_error = CheckinProcessingError(filtered_errors, checkin_error.checkin)
-            new_serialized_checkin_error = json.dumps(new_checkin_error.to_dict())
+            new_serialized_checkin_error = orjson.dumps(
+                new_checkin_error.to_dict(), option=orjson.OPT_UTC_Z
+            )
             error_key = build_error_identifier(checkin_error.id)
             pipeline.set(error_key, new_serialized_checkin_error, ex=MONITOR_ERRORS_LIFETIME)
 
@@ -122,7 +125,7 @@ def store_error(error: CheckinProcessingError, monitor: Monitor | None):
     entity_identifier = _get_entity_identifier_from_error(error, monitor)
     error_set_key = build_set_identifier(entity_identifier)
     error_key = build_error_identifier(error.id)
-    serialized_error = json.dumps(error.to_dict())
+    serialized_error = orjson.dumps(error.to_dict(), option=orjson.OPT_UTC_Z).decode()
     redis_client = _get_cluster()
     pipeline = redis_client.pipeline(transaction=False)
     pipeline.zadd(error_set_key, {error.id.hex: error.checkin.ts.timestamp()})
@@ -139,7 +142,7 @@ def delete_error(project: Project, uuid: uuid.UUID):
     raw_error = redis.get(error_identifier)
     if raw_error is None:
         return
-    error = CheckinProcessingError.from_dict(json.loads(raw_error))
+    error = CheckinProcessingError.from_dict(orjson.loads(raw_error))
     if error.checkin.message["project_id"] != project.id:
         # TODO: Better exception class
         raise InvalidProjectError()


### PR DESCRIPTION
Splitting the changes from https://github.com/getsentry/sentry/pull/71185 into multiple pull-requests as a recommendation from @fpacifici (ref: https://github.com/getsentry/sentry/pull/71185#issuecomment-2125854962).

This pull-request only changes `json` usages in `src/sentry/monitors` folder.