### PR TITLE
perf: move sentry/charts to orjson

### DIFF
--- a/src/sentry/charts/chartcuterie.py
+++ b/src/sentry/charts/chartcuterie.py
@@ -3,6 +3,7 @@ from typing import Any
 from urllib.parse import urljoin
 from uuid import uuid4
 
+import orjson
 import requests
 import sentry_sdk
 from django.conf import settings
@@ -10,7 +11,6 @@ from django.conf import settings
 from sentry import options
 from sentry.exceptions import InvalidConfiguration
 from sentry.models.file import get_storage
-from sentry.utils import json
 from sentry.utils.http import absolute_uri
 
 from .base import ChartRenderer, logger
@@ -76,7 +76,7 @@ class Chartcuterie(ChartRenderer):
             assert self.service_url is not None
             resp = requests.post(
                 url=urljoin(self.service_url, "render"),
-                data=json.dumps(payload),
+                data=orjson.dumps(payload, option=orjson.OPT_UTC_Z | orjson.OPT_NON_STR_KEYS),
                 headers={"Content-Type": "application/json"},
             )
 


### PR DESCRIPTION
Splitting the changes from https://github.com/getsentry/sentry/pull/71185 into multiple pull-requests as a recommendation from @fpacifici (ref: https://github.com/getsentry/sentry/pull/71185#issuecomment-2125854962).

This pull-request only changes `json` usages in `src/sentry/charts` folder.