### PR TITLE
perf: move sentry/interfaces to orjson

### DIFF
--- a/src/sentry/interfaces/message.py
+++ b/src/sentry/interfaces/message.py
@@ -1,8 +1,8 @@
 __all__ = ("Message",)
 
+import orjson
 
 from sentry.interfaces.base import Interface
-from sentry.utils import json
 from sentry.utils.json import prune_empty_keys
 
 
@@ -11,7 +11,7 @@ def stringify(value):
         return value
 
     if isinstance(value, (int, float, bool)):
-        return json.dumps(value)
+        return orjson.dumps(value)
 
     return None
 

--- a/src/sentry/interfaces/security.py
+++ b/src/sentry/interfaces/security.py
@@ -1,8 +1,8 @@
+import orjson
 from django.utils.functional import cached_property
 
 from sentry.interfaces.base import Interface
 from sentry.security import csp
-from sentry.utils import json
 from sentry.web.helpers import render_to_string
 
 __all__ = ("Csp", "Hpkp", "ExpectCT", "ExpectStaple")
@@ -173,7 +173,10 @@ class Csp(SecurityReport):
         return super().to_python(data, **kwargs)
 
     def to_string(self, is_public=False, **kwargs):
-        return json.dumps({"csp-report": self.get_api_context()})
+        return orjson.dumps(
+            {"csp-report": self.get_api_context()},
+            option=orjson.OPT_UTC_Z | orjson.OPT_NON_STR_KEYS,
+        ).decode()
 
     def to_email_html(self, event, **kwargs):
         return render_to_string(


### PR DESCRIPTION
Splitting the changes from https://github.com/getsentry/sentry/pull/71185 into multiple pull-requests as a recommendation from @fpacifici (ref: https://github.com/getsentry/sentry/pull/71185#issuecomment-2125854962).

This pull-request only changes `json` usages in `src/sentry/interfaces` folder.