### PR TITLE
perf: move sentry/backup to orjson

### DIFF
--- a/src/sentry/backup/crypto.py
+++ b/src/sentry/backup/crypto.py
@@ -14,7 +14,6 @@ from cryptography.hazmat.primitives.asymmetric import padding
 from google.cloud.kms import KeyManagementServiceClient as KeyManagementServiceClient
 from google_crc32c import value as crc32c
 
-from sentry.utils import json
 from sentry.utils.env import gcp_project_id
 
 
@@ -94,7 +93,7 @@ class GCPKMSEncryptor(Encryptor):
     def get_public_key_pem(self) -> bytes:
         if self.crypto_key_version is None:
             # Read the user supplied configuration into the proper format.
-            gcp_kms_config_json = json.load(self.__fp)
+            gcp_kms_config_json = orjson.loads(self.__fp.read())
             try:
                 self.crypto_key_version = CryptoKeyVersion(**gcp_kms_config_json)
             except TypeError:

--- a/src/sentry/backup/imports.py
+++ b/src/sentry/backup/imports.py
@@ -40,7 +40,6 @@ from sentry.services.hybrid_cloud.import_export.model import (
 from sentry.services.hybrid_cloud.import_export.service import ImportExportService
 from sentry.silo.base import SiloMode
 from sentry.silo.safety import unguarded_write
-from sentry.utils import json
 from sentry.utils.env import is_split_db
 
 __all__ = (
@@ -294,7 +293,11 @@ def _import(
                 batch = []
                 last_seen_model_name = model_name
             if len(batch) >= MAX_BATCH_SIZE:
-                yield (last_seen_model_name, json.dumps(batch), num_current_model_instances_yielded)
+                yield (
+                    last_seen_model_name,
+                    orjson.dumps(batch, option=orjson.OPT_UTC_Z | orjson.OPT_NON_STR_KEYS).decode(),
+                    num_current_model_instances_yielded,
+                )
                 num_current_model_instances_yielded += len(batch)
                 batch = []
 

--- a/src/sentry/backup/sanitize.py
+++ b/src/sentry/backup/sanitize.py
@@ -9,11 +9,10 @@ from typing import Any
 from urllib.parse import urlparse, urlunparse
 from uuid import UUID, uuid4
 
+import orjson
 import petname
 from dateutil.parser import parse as parse_datetime
 from django.utils.text import slugify
-
-from sentry.utils import json
 
 UPPER_CASE_HEX = {"A", "B", "C", "D", "E", "F"}
 UPPER_CASE_NON_HEX = {
@@ -291,12 +290,16 @@ class Sanitizer:
         `set_json()` is the preferred method for doing so.
         """
 
-        old_serialized = json.dumps(old_json)
+        old_serialized = orjson.dumps(
+            old_json, option=orjson.OPT_UTC_Z | orjson.OPT_NON_STR_KEYS
+        ).decode()
         interned = self.interned_strings.get(old_serialized)
         if interned is not None:
-            return json.loads(interned)
+            return orjson.loads(interned)
 
-        new_serialized = json.dumps(new_json)
+        new_serialized = orjson.dumps(
+            new_json, option=orjson.OPT_UTC_Z | orjson.OPT_NON_STR_KEYS
+        ).decode()
         self.interned_strings[old_serialized] = new_serialized
         return new_json
 

--- a/tests/sentry/backup/test_dependencies.py
+++ b/tests/sentry/backup/test_dependencies.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from difflib import unified_diff
 
+import orjson
+
 from sentry.backup.dependencies import (
     DependenciesJSONEncoder,
     dependencies,
@@ -9,7 +11,6 @@ from sentry.backup.dependencies import (
     sorted_dependencies,
 )
 from sentry.testutils.factories import get_fixture_path
-from sentry.utils import json
 
 encoder = DependenciesJSONEncoder(
     sort_keys=True,
@@ -46,8 +47,8 @@ def assert_model_dependencies(expect: object, actual: object) -> None:
 
 def test_detailed():
     fixture_path = get_fixture_path("backup", "model_dependencies", "detailed.json")
-    with open(fixture_path) as fixture:
-        expect = json.load(fixture)
+    with open(fixture_path, "rb") as fixture:
+        expect = orjson.loads(fixture.read())
 
     actual = {str(k): v for k, v in dependencies().items()}
     assert_model_dependencies(expect, actual)
@@ -55,8 +56,8 @@ def test_detailed():
 
 def test_flat():
     fixture_path = get_fixture_path("backup", "model_dependencies", "flat.json")
-    with open(fixture_path) as fixture:
-        expect = json.load(fixture)
+    with open(fixture_path, "rb") as fixture:
+        expect = orjson.loads(fixture.read())
 
     actual = {str(k): v.flatten() for k, v in dependencies().items()}
     assert_model_dependencies(expect, actual)
@@ -64,8 +65,8 @@ def test_flat():
 
 def test_sorted():
     fixture_path = get_fixture_path("backup", "model_dependencies", "sorted.json")
-    with open(fixture_path) as fixture:
-        expect = json.load(fixture)
+    with open(fixture_path, "rb") as fixture:
+        expect = orjson.loads(fixture.read())
 
     actual = sorted_dependencies()
     assert_model_dependencies(expect, actual)
@@ -73,8 +74,8 @@ def test_sorted():
 
 def test_truncate():
     fixture_path = get_fixture_path("backup", "model_dependencies", "truncate.json")
-    with open(fixture_path) as fixture:
-        expect = json.load(fixture)
+    with open(fixture_path, "rb") as fixture:
+        expect = orjson.loads(fixture.read())
 
     actual = [dependencies()[get_model_name(m)].table_name for m in sorted_dependencies()]
     assert_model_dependencies(expect, actual)

--- a/tests/sentry/backup/test_imports.py
+++ b/tests/sentry/backup/test_imports.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from unittest.mock import patch
 from uuid import uuid4
 
+import orjson
 import pytest
 import urllib3.exceptions
 from cryptography.fernet import Fernet
@@ -80,7 +81,6 @@ from sentry.testutils.helpers.backups import (
 )
 from sentry.testutils.hybrid_cloud import use_split_dbs
 from sentry.testutils.silo import assume_test_silo_mode
-from sentry.utils import json
 from tests.sentry.backup import (
     expect_models,
     get_matching_exportable_models,
@@ -343,12 +343,9 @@ class SanitizationTests(ImportTestCase):
         with tempfile.TemporaryDirectory() as tmp_dir:
             self.create_user("min_user")
             tmp_path = Path(tmp_dir).joinpath(f"{self._testMethodName}.json")
-            with open(tmp_path, "w+") as tmp_file:
+            with open(tmp_path, "wb+") as tmp_file:
                 models = self.json_of_exhaustive_user_with_minimum_privileges()
-                json.dump(
-                    self.sort_in_memory_json(models),
-                    tmp_file,
-                )
+                tmp_file.write(orjson.dumps(self.sort_in_memory_json(models)))
 
             # Import twice, to check that new suffixes are assigned both times.
             with open(tmp_path, "rb") as tmp_file:
@@ -371,14 +368,14 @@ class SanitizationTests(ImportTestCase):
     def test_bad_invalid_user(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
             tmp_path = Path(tmp_dir).joinpath(f"{self._testMethodName}.json")
-            with open(tmp_path, "w+") as tmp_file:
+            with open(tmp_path, "wb+") as tmp_file:
                 models = self.json_of_exhaustive_user_with_minimum_privileges()
 
                 # Modify all username to be longer than 128 characters.
                 for model in models:
                     if model["model"] == "sentry.user":
                         model["fields"]["username"] = "x" * 129
-                json.dump(models, tmp_file)
+                tmp_file.write(orjson.dumps(models))
 
             with open(tmp_path, "rb") as tmp_file:
                 with pytest.raises(ImportingError) as err:
@@ -397,14 +394,14 @@ class SanitizationTests(ImportTestCase):
 
         with tempfile.TemporaryDirectory() as tmp_dir:
             tmp_path = Path(tmp_dir).joinpath(f"{self._testMethodName}.json")
-            with open(tmp_path, "w+") as tmp_file:
+            with open(tmp_path, "wb+") as tmp_file:
                 models = self.json_of_exhaustive_user_with_minimum_privileges()
 
                 # Modify the UserIP to be in California, USA.
                 for model in models:
                     if model["model"] == "sentry.userip":
                         model["fields"]["ip_address"] = "8.8.8.8"
-                json.dump(models, tmp_file)
+                tmp_file.write(orjson.dumps(models))
 
             with open(tmp_path, "rb") as tmp_file:
                 import_in_global_scope(tmp_file, printer=NOOP_PRINTER)
@@ -434,7 +431,7 @@ class SanitizationTests(ImportTestCase):
 
         with tempfile.TemporaryDirectory() as tmp_dir:
             tmp_path = Path(tmp_dir).joinpath(f"{self._testMethodName}.json")
-            with open(tmp_path, "w+") as tmp_file:
+            with open(tmp_path, "wb+") as tmp_file:
                 models = self.json_of_exhaustive_user_with_minimum_privileges()
 
                 # Modify the UserIP to be in California, USA.
@@ -488,7 +485,7 @@ class SanitizationTests(ImportTestCase):
                     }
                 )
 
-                json.dump(self.sort_in_memory_json(models), tmp_file)
+                tmp_file.write(orjson.dumps(self.sort_in_memory_json(models)))
 
             with open(tmp_path, "rb") as tmp_file:
                 import_in_global_scope(tmp_file, printer=NOOP_PRINTER)
@@ -504,14 +501,14 @@ class SanitizationTests(ImportTestCase):
     def test_bad_invalid_user_ip(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
             tmp_path = Path(tmp_dir).joinpath(f"{self._testMethodName}.json")
-            with open(tmp_path, "w+") as tmp_file:
+            with open(tmp_path, "wb+") as tmp_file:
                 models = self.json_of_exhaustive_user_with_minimum_privileges()
 
                 # Modify the IP address to be in invalid.
                 for m in models:
                     if m["model"] == "sentry.userip":
                         m["fields"]["ip_address"] = "0.1.2.3.4.5.6.7.8.9.abc.def"
-                json.dump(list(models), tmp_file)
+                tmp_file.write(orjson.dumps(list(models)))
 
             with open(tmp_path, "rb") as tmp_file:
                 with pytest.raises(ImportingError) as err:
@@ -524,7 +521,7 @@ class SanitizationTests(ImportTestCase):
     def test_good_multiple_useremails_per_user_in_user_scope(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
             tmp_path = Path(tmp_dir).joinpath(f"{self._testMethodName}.json")
-            with open(tmp_path, "w+") as tmp_file:
+            with open(tmp_path, "wb+") as tmp_file:
                 models = self.json_of_exhaustive_user_with_minimum_privileges()
 
                 # Add two copies (1 verified, 1 not) of the same `UserEmail` - so the user now has 3
@@ -556,7 +553,7 @@ class SanitizationTests(ImportTestCase):
                     }
                 )
 
-                json.dump(self.sort_in_memory_json(models), tmp_file)
+                tmp_file.write(orjson.dumps(self.sort_in_memory_json(models)))
 
             with open(tmp_path, "rb") as tmp_file:
                 import_in_user_scope(tmp_file, printer=NOOP_PRINTER)
@@ -576,7 +573,7 @@ class SanitizationTests(ImportTestCase):
     def test_good_multiple_useremails_per_user_in_global_scope(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
             tmp_path = Path(tmp_dir).joinpath(f"{self._testMethodName}.json")
-            with open(tmp_path, "w+") as tmp_file:
+            with open(tmp_path, "wb+") as tmp_file:
                 models = self.json_of_exhaustive_user_with_minimum_privileges()
 
                 # Add two copies (1 verified, 1 not) of the same `UserEmail` - so the user now has 3
@@ -608,7 +605,7 @@ class SanitizationTests(ImportTestCase):
                     }
                 )
 
-                json.dump(self.sort_in_memory_json(models), tmp_file)
+                tmp_file.write(orjson.dumps(self.sort_in_memory_json(models)))
 
             with open(tmp_path, "rb") as tmp_file:
                 import_in_global_scope(tmp_file, printer=NOOP_PRINTER)
@@ -627,14 +624,14 @@ class SanitizationTests(ImportTestCase):
     def test_bad_invalid_user_option(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
             tmp_path = Path(tmp_dir).joinpath(f"{self._testMethodName}.json")
-            with open(tmp_path, "w+") as tmp_file:
+            with open(tmp_path, "wb+") as tmp_file:
                 models = self.json_of_exhaustive_user_with_minimum_privileges()
 
                 # Modify the `timezone` option to be in invalid.
                 for m in models:
                     if m["model"] == "sentry.useroption" and m["fields"]["key"] == "timezone":
                         m["fields"]["value"] = '"MiddleEarth/Gondor"'
-                json.dump(list(models), tmp_file)
+                tmp_file.write(orjson.dumps(list(models)))
 
             with open(tmp_path, "rb") as tmp_file:
                 with pytest.raises(ImportingError) as err:
@@ -856,8 +853,8 @@ class DatabaseResetTests(ImportTestCase):
     def import_empty_backup_file(self, import_fn):
         with tempfile.TemporaryDirectory() as tmp_dir:
             tmp_empty_file_path = tmp_dir + "empty_backup.json"
-            with open(tmp_empty_file_path, "w") as tmp_file:
-                json.dump([], tmp_file)
+            with open(tmp_empty_file_path, "wb") as tmp_file:
+                tmp_file.write(orjson.dumps([]))
             with open(tmp_empty_file_path, "rb") as empty_backup_json:
                 import_fn(empty_backup_json, printer=NOOP_PRINTER)
 
@@ -952,15 +949,15 @@ class DecryptionTests(ImportTestCase):
         with open(tmp_pub_key_path, "wb") as f:
             f.write(pub_key_pem)
 
-        with open(good_file_path) as f:
-            json_data = json.load(f)
+        with open(good_file_path, "rb") as f:
+            json_data = orjson.loads(f.read())
 
         tmp_tarball_path = Path(tmp_dir).joinpath("input.tar")
         with open(tmp_tarball_path, "wb") as i, open(tmp_pub_key_path, "rb") as p:
             pem = p.read()
             data_encryption_key = Fernet.generate_key()
             backup_encryptor = Fernet(data_encryption_key)
-            encrypted_json_export = backup_encryptor.encrypt(json.dumps(json_data).encode("utf-8"))
+            encrypted_json_export = backup_encryptor.encrypt(orjson.dumps(json_data))
 
             dek_encryption_key = serialization.load_pem_public_key(pem, default_backend())
             sha256 = hashes.SHA256()
@@ -1409,7 +1406,7 @@ class CollisionTests(ImportTestCase):
                 )
 
             with open(tmp_path, "rb") as tmp_file:
-                verify_models_in_output(expected_models, json.load(tmp_file))
+                verify_models_in_output(expected_models, orjson.loads(tmp_file.read()))
 
     @expect_models(COLLISION_TESTED, Monitor)
     def test_colliding_monitor(self, expected_models: list[type[Model]]):
@@ -1440,7 +1437,7 @@ class CollisionTests(ImportTestCase):
             assert Monitor.objects.filter(guid=colliding.guid).count() == 1
 
             with open(tmp_path, "rb") as tmp_file:
-                verify_models_in_output(expected_models, json.load(tmp_file))
+                verify_models_in_output(expected_models, orjson.loads(tmp_file.read()))
 
     @expect_models(COLLISION_TESTED, OrgAuthToken)
     def test_colliding_org_auth_token(self, expected_models: list[type[Model]]):
@@ -1489,7 +1486,7 @@ class CollisionTests(ImportTestCase):
                 )
 
             with open(tmp_path, "rb") as tmp_file:
-                verify_models_in_output(expected_models, json.load(tmp_file))
+                verify_models_in_output(expected_models, orjson.loads(tmp_file.read()))
 
     @expect_models(COLLISION_TESTED, ProjectKey)
     def test_colliding_project_key(self, expected_models: list[type[Model]]):
@@ -1522,7 +1519,7 @@ class CollisionTests(ImportTestCase):
             assert ProjectKey.objects.filter(secret_key=colliding.secret_key).count() == 1
 
             with open(tmp_path, "rb") as tmp_file:
-                verify_models_in_output(expected_models, json.load(tmp_file))
+                verify_models_in_output(expected_models, orjson.loads(tmp_file.read()))
 
     @pytest.mark.xfail(
         not use_split_dbs(),
@@ -1579,7 +1576,7 @@ class CollisionTests(ImportTestCase):
                 )
 
                 with open(tmp_path, "rb") as tmp_file:
-                    verify_models_in_output(expected_models, json.load(tmp_file))
+                    verify_models_in_output(expected_models, orjson.loads(tmp_file.read()))
 
     @expect_models(COLLISION_TESTED, SavedSearch)
     def test_colliding_saved_search(self, expected_models: list[type[Model]]):
@@ -1609,7 +1606,7 @@ class CollisionTests(ImportTestCase):
             assert SavedSearch.objects.count() == 1
 
             with open(tmp_path, "rb") as tmp_file:
-                verify_models_in_output(expected_models, json.load(tmp_file))
+                verify_models_in_output(expected_models, orjson.loads(tmp_file.read()))
 
     @expect_models(COLLISION_TESTED, ControlOption, Option, Relay, RelayUsage, UserRole)
     def test_colliding_configs_overwrite_configs_enabled_in_config_scope(
@@ -1705,7 +1702,7 @@ class CollisionTests(ImportTestCase):
                     assert actual_permission == old_user_role_permissions[i]
 
             with open(tmp_path, "rb") as tmp_file:
-                verify_models_in_output(expected_models, json.load(tmp_file))
+                verify_models_in_output(expected_models, orjson.loads(tmp_file.read()))
 
     @expect_models(COLLISION_TESTED, ControlOption, Option, Relay, RelayUsage, UserRole)
     def test_colliding_configs_overwrite_configs_disabled_in_config_scope(
@@ -1797,7 +1794,7 @@ class CollisionTests(ImportTestCase):
                 assert actual_user_role.permissions[0] == "other.admin"
 
             with open(tmp_path, "rb") as tmp_file:
-                verify_models_in_output(expected_models, json.load(tmp_file))
+                verify_models_in_output(expected_models, orjson.loads(tmp_file.read()))
 
     @expect_models(COLLISION_TESTED, Email, User, UserEmail)
     def test_colliding_user_with_merging_enabled_in_user_scope(
@@ -1841,7 +1838,7 @@ class CollisionTests(ImportTestCase):
                 assert not ControlImportChunk.objects.filter(model="sentry.userpermission").exists()
 
             with open(tmp_path, "rb") as tmp_file:
-                verify_models_in_output(expected_models, json.load(tmp_file))
+                verify_models_in_output(expected_models, orjson.loads(tmp_file.read()))
 
     @expect_models(COLLISION_TESTED, Email, User, UserEmail)
     def test_colliding_user_with_merging_disabled_in_user_scope(
@@ -1886,7 +1883,7 @@ class CollisionTests(ImportTestCase):
                 assert UserEmail.objects.filter(email__icontains="importing@").exists()
 
             with open(tmp_path, "rb") as tmp_file:
-                verify_models_in_output(expected_models, json.load(tmp_file))
+                verify_models_in_output(expected_models, orjson.loads(tmp_file.read()))
 
     @expect_models(COLLISION_TESTED, Email, Organization, OrganizationMember, User, UserEmail)
     def test_colliding_user_with_merging_enabled_in_organization_scope(
@@ -1973,7 +1970,7 @@ class CollisionTests(ImportTestCase):
                 )
 
             with open(tmp_path, "rb") as tmp_file:
-                verify_models_in_output(expected_models, json.load(tmp_file))
+                verify_models_in_output(expected_models, orjson.loads(tmp_file.read()))
 
     @expect_models(COLLISION_TESTED, Email, Organization, OrganizationMember, User, UserEmail)
     def test_colliding_user_with_merging_disabled_in_organization_scope(
@@ -2065,7 +2062,7 @@ class CollisionTests(ImportTestCase):
                 )
 
             with open(tmp_path, "rb") as tmp_file:
-                verify_models_in_output(expected_models, json.load(tmp_file))
+                verify_models_in_output(expected_models, orjson.loads(tmp_file.read()))
 
     @expect_models(COLLISION_TESTED, Email, User, UserEmail, UserPermission)
     def test_colliding_user_with_merging_enabled_in_config_scope(
@@ -2113,7 +2110,7 @@ class CollisionTests(ImportTestCase):
                 assert not ControlImportChunk.objects.filter(model="sentry.userpermission").exists()
 
             with open(tmp_path, "rb") as tmp_file:
-                verify_models_in_output(expected_models, json.load(tmp_file))
+                verify_models_in_output(expected_models, orjson.loads(tmp_file.read()))
 
     @expect_models(COLLISION_TESTED, Email, User, UserEmail, UserPermission)
     def test_colliding_user_with_merging_disabled_in_config_scope(
@@ -2161,7 +2158,7 @@ class CollisionTests(ImportTestCase):
                 assert UserEmail.objects.filter(email__icontains="importing@").exists()
 
             with open(tmp_path, "rb") as tmp_file:
-                verify_models_in_output(expected_models, json.load(tmp_file))
+                verify_models_in_output(expected_models, orjson.loads(tmp_file.read()))
 
 
 CUSTOM_IMPORT_BEHAVIOR_TESTED: set[NormalizedModelName] = set()
@@ -2241,7 +2238,7 @@ class CustomImportBehaviorTests(ImportTestCase):
             ).exists()
 
             with open(tmp_path, "rb") as tmp_file:
-                verify_models_in_output(expected_models, json.load(tmp_file))
+                verify_models_in_output(expected_models, orjson.loads(tmp_file.read()))
 
     @expect_models(CUSTOM_IMPORT_BEHAVIOR_TESTED, Project)
     def test_project_ids_retained_in_global_scope(self, expected_models: list[type[Model]]):
@@ -2272,7 +2269,7 @@ class CustomImportBehaviorTests(ImportTestCase):
             assert set(imported_proj_ids) == set(existing_proj_ids)
 
             with open(tmp_path, "rb") as tmp_file:
-                verify_models_in_output(expected_models, json.load(tmp_file))
+                verify_models_in_output(expected_models, orjson.loads(tmp_file.read()))
 
     @expect_models(CUSTOM_IMPORT_BEHAVIOR_TESTED, Project)
     def test_project_ids_reassigned_in_organization_scope(self, expected_models: list[type[Model]]):
@@ -2303,7 +2300,7 @@ class CustomImportBehaviorTests(ImportTestCase):
             assert set(imported_proj_ids).isdisjoint(set(existing_proj_ids))
 
             with open(tmp_path, "rb") as tmp_file:
-                verify_models_in_output(expected_models, json.load(tmp_file))
+                verify_models_in_output(expected_models, orjson.loads(tmp_file.read()))
 
 
 class BatchingTests(TestCase):
@@ -2314,7 +2311,7 @@ class BatchingTests(TestCase):
     def import_n_users_with_options(self, import_uuid: str, n: int) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:
             tmp_path = Path(tmp_dir).joinpath(f"{self._testMethodName}.json")
-            with open(tmp_path, "w") as tmp_file:
+            with open(tmp_path, "wb") as tmp_file:
                 users = []
                 user_options = []
                 for i in range(1, n + 1):
@@ -2353,7 +2350,7 @@ class BatchingTests(TestCase):
                         }
                     )
 
-                json.dump(users + user_options, tmp_file)
+                tmp_file.write(orjson.dumps(users + user_options))
 
             with open(tmp_path, "rb") as tmp_file:
                 import_in_user_scope(

--- a/tests/sentry/backup/test_releases.py
+++ b/tests/sentry/backup/test_releases.py
@@ -4,6 +4,7 @@ import os
 import tempfile
 from pathlib import Path
 
+import orjson
 import yaml
 from django.db.models import Model
 
@@ -20,7 +21,6 @@ from sentry.testutils.helpers.backups import (
 )
 from sentry.testutils.pytest.fixtures import read_snapshot_file
 from sentry.testutils.silo import strip_silo_mode_test_suffix
-from sentry.utils import json
 from tests.sentry.backup import expect_models, verify_models_in_output
 
 RELEASE_TESTED: set[NormalizedModelName] = set()
@@ -69,8 +69,8 @@ class ReleaseTests(BackupTestCase):
             _, snapshot_refval = read_snapshot_file(snapshot_path)
             snapshot_data = yaml.safe_load(snapshot_refval) or dict()
             tmp_refval_path = Path(tmp_dir).joinpath(f"{self._testMethodName}.refval.json")
-            with open(tmp_refval_path, "w") as f:
-                json.dump(snapshot_data, f)
+            with open(tmp_refval_path, "wb") as f:
+                f.write(orjson.dumps(snapshot_data))
 
             # Take that temporary JSON file and import it. If `SENTRY_SNAPSHOTS_WRITEBACK` is set to
             # true, ignore the data in the existing snapshot file and generate a new exhaustive
@@ -101,8 +101,8 @@ class ReleaseTests(BackupTestCase):
             _, snapshot_refval = read_snapshot_file(self.get_snapshot_path("24.5.0"))
             snapshot_data = yaml.safe_load(snapshot_refval)
             tmp_path = Path(tmp_dir).joinpath(f"{self._testMethodName}.json")
-            with open(tmp_path, "w") as f:
-                json.dump(snapshot_data, f)
+            with open(tmp_path, "wb") as f:
+                f.write(orjson.dumps(snapshot_data))
 
             with open(tmp_path, "rb") as f:
                 import_in_global_scope(f, printer=NOOP_PRINTER)
@@ -112,8 +112,8 @@ class ReleaseTests(BackupTestCase):
             _, snapshot_refval = read_snapshot_file(self.get_snapshot_path("24.4.2"))
             snapshot_data = yaml.safe_load(snapshot_refval)
             tmp_path = Path(tmp_dir).joinpath(f"{self._testMethodName}.json")
-            with open(tmp_path, "w") as f:
-                json.dump(snapshot_data, f)
+            with open(tmp_path, "wb") as f:
+                f.write(orjson.dumps(snapshot_data))
 
             with open(tmp_path, "rb") as f:
                 import_in_global_scope(f, printer=NOOP_PRINTER)
@@ -123,8 +123,8 @@ class ReleaseTests(BackupTestCase):
             _, snapshot_refval = read_snapshot_file(self.get_snapshot_path("24.4.1"))
             snapshot_data = yaml.safe_load(snapshot_refval)
             tmp_path = Path(tmp_dir).joinpath(f"{self._testMethodName}.json")
-            with open(tmp_path, "w") as f:
-                json.dump(snapshot_data, f)
+            with open(tmp_path, "wb") as f:
+                f.write(orjson.dumps(snapshot_data))
 
             with open(tmp_path, "rb") as f:
                 import_in_global_scope(f, printer=NOOP_PRINTER)
@@ -134,8 +134,8 @@ class ReleaseTests(BackupTestCase):
             _, snapshot_refval = read_snapshot_file(self.get_snapshot_path("24.4.0"))
             snapshot_data = yaml.safe_load(snapshot_refval)
             tmp_path = Path(tmp_dir).joinpath(f"{self._testMethodName}.json")
-            with open(tmp_path, "w") as f:
-                json.dump(snapshot_data, f)
+            with open(tmp_path, "wb") as f:
+                f.write(orjson.dumps(snapshot_data))
 
             with open(tmp_path, "rb") as f:
                 import_in_global_scope(f, printer=NOOP_PRINTER)

--- a/tests/sentry/backup/test_sanitize.py
+++ b/tests/sentry/backup/test_sanitize.py
@@ -5,6 +5,7 @@ from datetime import datetime, timedelta
 from typing import Any
 from unittest.mock import Mock, patch
 
+import orjson
 import pytest
 from dateutil.parser import parse as parse_datetime
 from django.core.serializers import serialize
@@ -31,7 +32,6 @@ from sentry.testutils.cases import TestCase
 from sentry.testutils.factories import get_fixture_path
 from sentry.testutils.helpers.backups import BackupTestCase
 from sentry.testutils.silo import strip_silo_mode_test_suffix
-from sentry.utils import json
 from tests.sentry.backup import expect_models, verify_models_in_output
 
 FAKE_EMAIL = "test@fake.com"
@@ -97,7 +97,7 @@ class SanitizationUnitTests(TestCase):
             use_natural_foreign_keys=False,
             cls=DatetimeSafeDjangoJSONEncoder,
         )
-        json_data = json.loads(json_string)
+        json_data = orjson.loads(json_string)
         return json_data
 
     def test_good_all_sanitizers_set_fields(self):
@@ -350,7 +350,7 @@ class SanitizationUnitTests(TestCase):
         assert all(c.isascii() for c in list(sanitized[5]["fields"]["text"]))
 
     def test_bad_invalid_datetime_type(self):
-        invalid = json.loads(
+        invalid = orjson.loads(
             """
                 {
                     "model": "test.fakesanitizablemodel",
@@ -365,7 +365,7 @@ class SanitizationUnitTests(TestCase):
             sanitize([invalid])
 
     def test_bad_invalid_email_type(self):
-        invalid = json.loads(
+        invalid = orjson.loads(
             """
                 {
                     "model": "test.fakesanitizablemodel",
@@ -380,7 +380,7 @@ class SanitizationUnitTests(TestCase):
             sanitize([invalid])
 
     def test_bad_invalid_name_type(self):
-        invalid = json.loads(
+        invalid = orjson.loads(
             """
                 {
                     "model": "test.fakesanitizablemodel",
@@ -395,7 +395,7 @@ class SanitizationUnitTests(TestCase):
             sanitize([invalid])
 
     def test_bad_invalid_slug_type(self):
-        invalid = json.loads(
+        invalid = orjson.loads(
             """
                 {
                     "model": "test.fakesanitizablemodel",
@@ -411,7 +411,7 @@ class SanitizationUnitTests(TestCase):
             sanitize([invalid])
 
     def test_bad_invalid_string_type(self):
-        invalid = json.loads(
+        invalid = orjson.loads(
             """
                 {
                     "model": "test.fakesanitizablemodel",
@@ -479,8 +479,8 @@ class SanitizationIntegrationTests(IntegrationTestCase):
     """
 
     def test_fresh_install(self):
-        with open(get_fixture_path("backup", "fresh-install.json")) as backup_file:
-            unsanitized_json = json.load(backup_file)
+        with open(get_fixture_path("backup", "fresh-install.json"), "rb") as backup_file:
+            unsanitized_json = orjson.loads(backup_file.read())
             self.sanitize_and_compare(unsanitized_json)
 
 

--- a/tests/sentry/backup/test_snapshots.py
+++ b/tests/sentry/backup/test_snapshots.py
@@ -2,6 +2,7 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import Any
 
+import orjson
 import pytest
 
 from sentry.backup.comparators import get_default_comparators
@@ -17,7 +18,6 @@ from sentry.testutils.helpers.backups import (
     clear_database,
     export_to_file,
 )
-from sentry.utils import json
 
 
 class SnapshotTests(BackupTestCase):
@@ -38,8 +38,8 @@ class SnapshotTests(BackupTestCase):
         """
 
         fixture_file_path = get_fixture_path("backup", fixture_file_name)
-        with open(fixture_file_path) as backup_file:
-            expect = json.load(backup_file)
+        with open(fixture_file_path, "rb") as backup_file:
+            expect = orjson.loads(backup_file.read())
         with open(fixture_file_path, "rb") as fixture_file:
             import_in_global_scope(fixture_file, printer=NOOP_PRINTER)
 

--- a/tests/sentry/backup/test_validate.py
+++ b/tests/sentry/backup/test_validate.py
@@ -1,11 +1,12 @@
 from copy import deepcopy
 from typing import Any
 
+import orjson
+
 from sentry.backup.comparators import get_default_comparators
 from sentry.backup.findings import ComparatorFindingKind, InstanceID
 from sentry.backup.validate import validate
 from sentry.testutils.factories import get_fixture_path
-from sentry.utils import json
 
 
 def copy_model(model: Any, new_pk: int) -> Any:
@@ -15,8 +16,8 @@ def copy_model(model: Any, new_pk: int) -> Any:
 
 
 def test_good_ignore_differing_pks():
-    with open(get_fixture_path("backup", "single-integration.json")) as backup_file:
-        test_integration = json.load(backup_file)[0]
+    with open(get_fixture_path("backup", "single-integration.json"), "rb") as backup_file:
+        test_integration = orjson.loads(backup_file.read())[0]
     left = [copy_model(test_integration, 2)]
     right = [copy_model(test_integration, 2)]
     right = deepcopy(left)
@@ -28,8 +29,8 @@ def test_good_ignore_differing_pks():
 
 
 def test_bad_duplicate_entry():
-    with open(get_fixture_path("backup", "single-integration.json")) as backup_file:
-        test_integration = json.load(backup_file)[0]
+    with open(get_fixture_path("backup", "single-integration.json"), "rb") as backup_file:
+        test_integration = orjson.loads(backup_file.read())[0]
     test_json = [test_integration, deepcopy(test_integration)]
     out = validate(test_json, test_json, get_default_comparators())
     findings = out.findings
@@ -46,8 +47,8 @@ def test_bad_duplicate_entry():
 
 
 def test_bad_out_of_order_entry():
-    with open(get_fixture_path("backup", "single-integration.json")) as backup_file:
-        test_integration = json.load(backup_file)[0]
+    with open(get_fixture_path("backup", "single-integration.json"), "rb") as backup_file:
+        test_integration = orjson.loads(backup_file.read())[0]
 
     # Note that entries are appended in reverse pk order.
     test_json = [test_integration, copy_model(test_integration, 3), copy_model(test_integration, 2)]
@@ -66,8 +67,8 @@ def test_bad_out_of_order_entry():
 
 
 def test_bad_extra_left_entry():
-    with open(get_fixture_path("backup", "single-integration.json")) as backup_file:
-        test_integration = json.load(backup_file)[0]
+    with open(get_fixture_path("backup", "single-integration.json"), "rb") as backup_file:
+        test_integration = orjson.loads(backup_file.read())[0]
     left = [deepcopy(test_integration), copy_model(test_integration, 2)]
     right = [test_integration]
     out = validate(left, right)
@@ -83,8 +84,8 @@ def test_bad_extra_left_entry():
 
 
 def test_bad_extra_right_entry():
-    with open(get_fixture_path("backup", "single-integration.json")) as backup_file:
-        test_integration = json.load(backup_file)[0]
+    with open(get_fixture_path("backup", "single-integration.json"), "rb") as backup_file:
+        test_integration = orjson.loads(backup_file.read())[0]
     left = [test_integration]
     right = [deepcopy(test_integration), copy_model(test_integration, 2)]
     out = validate(left, right)
@@ -100,10 +101,10 @@ def test_bad_extra_right_entry():
 
 
 def test_bad_failing_comparator_field():
-    with open(get_fixture_path("backup", "single-option.json")) as backup_file:
-        left = json.load(backup_file)
+    with open(get_fixture_path("backup", "single-option.json"), "rb") as backup_file:
+        left = orjson.loads(backup_file.read())
     right = deepcopy(left)
-    newer = json.loads(
+    newer = orjson.loads(
         """
             {
                 "model": "sentry.userrole",
@@ -117,7 +118,7 @@ def test_bad_failing_comparator_field():
             }
         """
     )
-    older = json.loads(
+    older = orjson.loads(
         """
             {
                 "model": "sentry.userrole",
@@ -144,9 +145,9 @@ def test_bad_failing_comparator_field():
 
 
 def test_good_both_sides_comparator_field_missing():
-    with open(get_fixture_path("backup", "single-option.json")) as backup_file:
-        test_json = json.load(backup_file)
-    userrole_without_date_updated = json.loads(
+    with open(get_fixture_path("backup", "single-option.json"), "rb") as backup_file:
+        test_json = orjson.loads(backup_file.read())
+    userrole_without_date_updated = orjson.loads(
         """
             {
                 "model": "sentry.userrole",
@@ -166,10 +167,10 @@ def test_good_both_sides_comparator_field_missing():
 
 
 def test_bad_left_side_comparator_field_missing():
-    with open(get_fixture_path("backup", "single-option.json")) as backup_file:
-        left = json.load(backup_file)
+    with open(get_fixture_path("backup", "single-option.json"), "rb") as backup_file:
+        left = orjson.loads(backup_file.read())
     right = deepcopy(left)
-    userrole_without_date_updated = json.loads(
+    userrole_without_date_updated = orjson.loads(
         """
             {
                 "model": "sentry.userrole",
@@ -182,7 +183,7 @@ def test_bad_left_side_comparator_field_missing():
             }
         """
     )
-    userrole_with_date_updated = json.loads(
+    userrole_with_date_updated = orjson.loads(
         """
             {
                 "model": "sentry.userrole",
@@ -210,10 +211,10 @@ def test_bad_left_side_comparator_field_missing():
 
 
 def test_bad_right_side_comparator_field_missing():
-    with open(get_fixture_path("backup", "single-option.json")) as backup_file:
-        left = json.load(backup_file)
+    with open(get_fixture_path("backup", "single-option.json"), "rb") as backup_file:
+        left = orjson.loads(backup_file.read())
     right = deepcopy(left)
-    userrole_without_date_updated = json.loads(
+    userrole_without_date_updated = orjson.loads(
         """
             {
                 "model": "sentry.userrole",
@@ -226,7 +227,7 @@ def test_bad_right_side_comparator_field_missing():
             }
         """
     )
-    userrole_with_date_updated = json.loads(
+    userrole_with_date_updated = orjson.loads(
         """
             {
                 "model": "sentry.userrole",
@@ -254,10 +255,10 @@ def test_bad_right_side_comparator_field_missing():
 
 
 def test_auto_assign_email_obfuscating_comparator():
-    with open(get_fixture_path("backup", "single-option.json")) as backup_file:
-        left = json.load(backup_file)
+    with open(get_fixture_path("backup", "single-option.json"), "rb") as backup_file:
+        left = orjson.loads(backup_file.read())
     right = deepcopy(left)
-    email_left = json.loads(
+    email_left = orjson.loads(
         """
             {
                 "model": "sentry.email",
@@ -269,7 +270,7 @@ def test_auto_assign_email_obfuscating_comparator():
             }
         """
     )
-    email_right = json.loads(
+    email_right = orjson.loads(
         """
             {
                 "model": "sentry.email",
@@ -298,13 +299,13 @@ def test_auto_assign_email_obfuscating_comparator():
 
 
 def test_auto_assign_date_updated_comparator():
-    with open(get_fixture_path("backup", "single-option.json")) as backup_file:
-        left = json.load(backup_file)
+    with open(get_fixture_path("backup", "single-option.json"), "rb") as backup_file:
+        left = orjson.loads(backup_file.read())
     right = deepcopy(left)
 
     # Note that `date_added` has different kinds of milliseconds, while `date_updated` has correctly
     # ordered dates.
-    userrole_left = json.loads(
+    userrole_left = orjson.loads(
         """
             {
                 "model": "sentry.userrole",
@@ -318,7 +319,7 @@ def test_auto_assign_date_updated_comparator():
             }
         """
     )
-    userrole_right = json.loads(
+    userrole_right = orjson.loads(
         """
             {
                 "model": "sentry.userrole",
@@ -341,7 +342,7 @@ def test_auto_assign_date_updated_comparator():
 
 def test_auto_assign_foreign_key_comparator():
     left = [
-        json.loads(
+        orjson.loads(
             """
             {
                 "model": "sentry.user",
@@ -358,7 +359,7 @@ def test_auto_assign_foreign_key_comparator():
         )
     ]
     right = [
-        json.loads(
+        orjson.loads(
             """
             {
                 "model": "sentry.user",
@@ -375,7 +376,7 @@ def test_auto_assign_foreign_key_comparator():
         )
     ]
 
-    useremail_left = json.loads(
+    useremail_left = orjson.loads(
         """
             {
                 "model": "sentry.useremail",
@@ -390,7 +391,7 @@ def test_auto_assign_foreign_key_comparator():
             }
         """
     )
-    useremail_right = json.loads(
+    useremail_right = orjson.loads(
         """
             {
                 "model": "sentry.useremail",
@@ -414,7 +415,7 @@ def test_auto_assign_foreign_key_comparator():
 
 def test_auto_assign_ignored_comparator():
     left = [
-        json.loads(
+        orjson.loads(
             """
             {
                 "model": "sentry.user",
@@ -438,7 +439,7 @@ def test_auto_assign_ignored_comparator():
     ]
     right = deepcopy(left)
 
-    useremail_left = json.loads(
+    useremail_left = orjson.loads(
         """
             {
                 "model": "sentry.useremail",
@@ -453,7 +454,7 @@ def test_auto_assign_ignored_comparator():
             }
         """
     )
-    useremail_right = json.loads(
+    useremail_right = orjson.loads(
         """
             {
                 "model": "sentry.useremail",
@@ -476,7 +477,7 @@ def test_auto_assign_ignored_comparator():
 
 
 def test_bad_missing_custom_ordinal():
-    left = json.loads(
+    left = orjson.loads(
         """
             [
                 {
@@ -498,7 +499,7 @@ def test_bad_missing_custom_ordinal():
             ]
         """
     )
-    right = json.loads(
+    right = orjson.loads(
         """
             [
                 {
@@ -534,7 +535,7 @@ def test_bad_missing_custom_ordinal():
 
 
 def test_bad_unequal_custom_ordinal():
-    left = json.loads(
+    left = orjson.loads(
         """
             [
                 {
@@ -550,7 +551,7 @@ def test_bad_unequal_custom_ordinal():
             ]
         """
     )
-    right = json.loads(
+    right = orjson.loads(
         """
             [
                 {
@@ -575,8 +576,8 @@ def test_bad_unequal_custom_ordinal():
 
 
 def test_bad_duplicate_custom_ordinal():
-    with open(get_fixture_path("backup", "single-option.json")) as backup_file:
-        test_option = json.load(backup_file)[0]
+    with open(get_fixture_path("backup", "single-option.json"), "rb") as backup_file:
+        test_option = orjson.loads(backup_file.read())[0]
     test_json = [test_option, copy_model(test_option, 2)]
     out = validate(test_json, test_json, get_default_comparators())
     findings = out.findings
@@ -593,7 +594,7 @@ def test_bad_duplicate_custom_ordinal():
 
 
 def test_good_option_custom_ordinal():
-    left = json.loads(
+    left = orjson.loads(
         """
             [
                 {
@@ -621,7 +622,7 @@ def test_good_option_custom_ordinal():
     )
 
     # Note that all models are in reverse order for their kind.
-    right = json.loads(
+    right = orjson.loads(
         """
             [
 
@@ -655,7 +656,7 @@ def test_good_option_custom_ordinal():
 
 
 def test_good_user_custom_ordinal():
-    left = json.loads(
+    left = orjson.loads(
         """
             [
                 {
@@ -723,7 +724,7 @@ def test_good_user_custom_ordinal():
     )
 
     # Note that all models are in reverse order for their kind.
-    right = json.loads(
+    right = orjson.loads(
         """
             [
                 {
@@ -796,7 +797,7 @@ def test_good_user_custom_ordinal():
 
 
 def test_good_user_option_custom_ordinal():
-    left = json.loads(
+    left = orjson.loads(
         """
             [
                 {
@@ -844,7 +845,7 @@ def test_good_user_option_custom_ordinal():
     )
 
     # Note that the `user`s of the `useroption` models here are reversed.
-    right = json.loads(
+    right = orjson.loads(
         """
             [
                 {
@@ -899,7 +900,7 @@ def test_good_user_option_custom_ordinal():
 # This tests for a prod-only check that is not enumerated in Django: that there can only be one copy
 # of a global option (no org_id/project_id) per key per user.
 def test_good_user_option_duplicate_globals():
-    left = json.loads(
+    left = orjson.loads(
         """
             [
                 {
@@ -944,7 +945,7 @@ def test_good_user_option_duplicate_globals():
         """
     )
 
-    right = json.loads(
+    right = orjson.loads(
         """
             [
                 {


### PR DESCRIPTION
Splitting the changes from https://github.com/getsentry/sentry/pull/71185 into multiple pull-requests as a recommendation from @fpacifici (ref: https://github.com/getsentry/sentry/pull/71185#issuecomment-2125854962).

This pull-request only changes `json` usages in `src/sentry/backup` folder.