### PR TITLE
ref(insights): Set all module page titles from constants

### DIFF
--- a/static/app/views/alerts/wizard/options.tsx
+++ b/static/app/views/alerts/wizard/options.tsx
@@ -21,6 +21,7 @@ import {
   EventTypes,
   SessionsAggregate,
 } from 'sentry/views/alerts/rules/metric/types';
+import {MODULE_TITLE as LLM_MONITORING_MODULE_TITLE} from 'sentry/views/llmMonitoring/settings';
 
 export type AlertType =
   | 'issues'
@@ -113,7 +114,7 @@ export const getAlertWizardCategories = (org: Organization) => {
   });
   if (org.features.includes('ai-analytics')) {
     result.push({
-      categoryHeading: t('LLM Monitoring'),
+      categoryHeading: LLM_MONITORING_MODULE_TITLE,
       options: ['llm_tokens', 'llm_cost'],
     });
   }

--- a/static/app/views/llmMonitoring/landing.tsx
+++ b/static/app/views/llmMonitoring/landing.tsx
@@ -15,7 +15,7 @@ import {
   TotalTokensUsedChart,
 } from 'sentry/views/llmMonitoring/llmMonitoringCharts';
 import {PipelinesTable} from 'sentry/views/llmMonitoring/pipelinesTable';
-import {MODULE_DOC_LINK} from 'sentry/views/llmMonitoring/settings';
+import {MODULE_DOC_LINK, MODULE_TITLE} from 'sentry/views/llmMonitoring/settings';
 import * as ModuleLayout from 'sentry/views/performance/moduleLayout';
 import {ModulePageProviders} from 'sentry/views/performance/modulePageProviders';
 import {ModulesOnboarding} from 'sentry/views/performance/onboarding/modulesOnboarding';
@@ -34,7 +34,7 @@ export function LLMMonitoringPage() {
           <Layout.HeaderContent>
             <Breadcrumbs crumbs={crumbs} />
             <Layout.Title>
-              {t('LLM Monitoring')}
+              {MODULE_TITLE}
               <PageHeadingQuestionTooltip
                 title={t('View analytics and information about your AI pipelines')}
                 docsUrl={MODULE_DOC_LINK}

--- a/static/app/views/llmMonitoring/llmMonitoringDetailsPage.tsx
+++ b/static/app/views/llmMonitoring/llmMonitoringDetailsPage.tsx
@@ -20,6 +20,7 @@ import {
   TotalTokensUsedChart,
 } from 'sentry/views/llmMonitoring/llmMonitoringCharts';
 import {PipelineSpansTable} from 'sentry/views/llmMonitoring/pipelineSpansTable';
+import {MODULE_TITLE} from 'sentry/views/llmMonitoring/settings';
 import {MetricReadout} from 'sentry/views/performance/metricReadout';
 import * as ModuleLayout from 'sentry/views/performance/moduleLayout';
 import {ModulePageProviders} from 'sentry/views/performance/modulePageProviders';
@@ -100,7 +101,7 @@ export function LLMMonitoringPage({params}: Props) {
                 },
               ]}
             />
-            <Layout.Title>{t('LLM Monitoring')}</Layout.Title>
+            <Layout.Title>{MODULE_TITLE}</Layout.Title>
           </Layout.HeaderContent>
         </Layout.Header>
         <Layout.Body>

--- a/static/app/views/performance/browser/resources/index.tsx
+++ b/static/app/views/performance/browser/resources/index.tsx
@@ -10,7 +10,6 @@ import {EnvironmentPageFilter} from 'sentry/components/organizations/environment
 import PageFilterBar from 'sentry/components/organizations/pageFilterBar';
 import {ProjectPageFilter} from 'sentry/components/organizations/projectPageFilter';
 import {PageHeadingQuestionTooltip} from 'sentry/components/pageHeadingQuestionTooltip';
-import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {RateUnit} from 'sentry/utils/discover/fields';
 import {PageAlert, PageAlertProvider} from 'sentry/utils/performance/contexts/pageAlert';
@@ -21,6 +20,7 @@ import ResourceView, {
 import {
   MODULE_DESCRIPTION,
   MODULE_DOC_LINK,
+  MODULE_TITLE,
 } from 'sentry/views/performance/browser/resources/settings';
 import {
   BrowserStarfishFields,
@@ -48,7 +48,7 @@ function ResourcesLandingPage() {
             <Breadcrumbs crumbs={crumbs} />
 
             <Layout.Title>
-              {t('Resources')}
+              {MODULE_TITLE}
               <PageHeadingQuestionTooltip
                 docsUrl={MODULE_DOC_LINK}
                 title={MODULE_DESCRIPTION}

--- a/static/app/views/performance/browser/webVitals/webVitalsLandingPage.tsx
+++ b/static/app/views/performance/browser/webVitals/webVitalsLandingPage.tsx
@@ -30,6 +30,7 @@ import {PerformanceScoreChart} from 'sentry/views/performance/browser/webVitals/
 import {
   MODULE_DESCRIPTION,
   MODULE_DOC_LINK,
+  MODULE_TITLE,
 } from 'sentry/views/performance/browser/webVitals/settings';
 import {useProjectRawWebVitalsQuery} from 'sentry/views/performance/browser/webVitals/utils/queries/rawWebVitalsQueries/useProjectRawWebVitalsQuery';
 import {calculatePerformanceScoreFromStoredTableDataRow} from 'sentry/views/performance/browser/webVitals/utils/queries/storedScoreQueries/calculatePerformanceScoreFromStored';
@@ -81,7 +82,7 @@ export function WebVitalsLandingPage() {
           <Breadcrumbs crumbs={crumbs} />
 
           <Layout.Title>
-            {t('Web Vitals')}
+            {MODULE_TITLE}
             <PageHeadingQuestionTooltip
               docsUrl={MODULE_DOC_LINK}
               title={MODULE_DESCRIPTION}

--- a/static/app/views/performance/database/databaseLandingPage.tsx
+++ b/static/app/views/performance/database/databaseLandingPage.tsx
@@ -26,6 +26,7 @@ import {isAValidSort, QueriesTable} from 'sentry/views/performance/database/quer
 import {
   MODULE_DESCRIPTION,
   MODULE_DOC_LINK,
+  MODULE_TITLE,
 } from 'sentry/views/performance/database/settings';
 import {ThroughputChart} from 'sentry/views/performance/database/throughputChart';
 import {useSelectedDurationAggregate} from 'sentry/views/performance/database/useSelectedDurationAggregate';
@@ -149,7 +150,7 @@ export function DatabaseLandingPage() {
           <Breadcrumbs crumbs={crumbs} />
 
           <Layout.Title>
-            {t('Queries')}
+            {MODULE_TITLE}
             <PageHeadingQuestionTooltip
               docsUrl={MODULE_DOC_LINK}
               title={MODULE_DESCRIPTION}

--- a/static/app/views/performance/mobile/appStarts/index.tsx
+++ b/static/app/views/performance/mobile/appStarts/index.tsx
@@ -1,9 +1,9 @@
 import AppStartup from 'sentry/views/performance/mobile/appStarts/screens';
 import {StartTypeSelector} from 'sentry/views/performance/mobile/appStarts/screenSummary/startTypeSelector';
+import {MODULE_TITLE} from 'sentry/views/performance/mobile/appStarts/settings';
 import ScreensTemplate from 'sentry/views/performance/mobile/components/screensTemplate';
 import {ModulePageProviders} from 'sentry/views/performance/modulePageProviders';
 import {ModuleName} from 'sentry/views/starfish/types';
-import {ROUTE_NAMES} from 'sentry/views/starfish/utils/routeNames';
 
 export function InitializationModule() {
   return (
@@ -11,7 +11,7 @@ export function InitializationModule() {
       additionalSelectors={<StartTypeSelector />}
       content={<AppStartup chartHeight={200} />}
       moduleName={ModuleName.APP_START}
-      title={ROUTE_NAMES['app-startup']}
+      title={MODULE_TITLE}
     />
   );
 }

--- a/static/app/views/performance/mobile/screenload/index.tsx
+++ b/static/app/views/performance/mobile/screenload/index.tsx
@@ -10,7 +10,6 @@ import {EnvironmentPageFilter} from 'sentry/components/organizations/environment
 import PageFilterBar from 'sentry/components/organizations/pageFilterBar';
 import {ProjectPageFilter} from 'sentry/components/organizations/projectPageFilter';
 import {PageHeadingQuestionTooltip} from 'sentry/components/pageHeadingQuestionTooltip';
-import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {PageAlert, PageAlertProvider} from 'sentry/utils/performance/contexts/pageAlert';
 import useOrganization from 'sentry/utils/useOrganization';
@@ -20,6 +19,7 @@ import {PlatformSelector} from 'sentry/views/performance/mobile/screenload/scree
 import {
   MODULE_DESCRIPTION,
   MODULE_DOC_LINK,
+  MODULE_TITLE,
 } from 'sentry/views/performance/mobile/screenload/settings';
 import useCrossPlatformProject from 'sentry/views/performance/mobile/useCrossPlatformProject';
 import {ModulePageProviders} from 'sentry/views/performance/modulePageProviders';
@@ -42,7 +42,7 @@ export function PageloadModule() {
             <Breadcrumbs crumbs={crumbs} />
             <HeaderWrapper>
               <Layout.Title>
-                {t('Screen Loads')}
+                {MODULE_TITLE}
                 <PageHeadingQuestionTooltip
                   docsUrl={MODULE_DOC_LINK}
                   title={MODULE_DESCRIPTION}

--- a/static/app/views/performance/mobile/ui/index.tsx
+++ b/static/app/views/performance/mobile/ui/index.tsx
@@ -1,14 +1,14 @@
 import ScreensTemplate from 'sentry/views/performance/mobile/components/screensTemplate';
 import {UIScreens} from 'sentry/views/performance/mobile/ui/screens';
+import {MODULE_TITLE} from 'sentry/views/performance/mobile/ui/settings';
 import {ModulePageProviders} from 'sentry/views/performance/modulePageProviders';
 import {ModuleName} from 'sentry/views/starfish/types';
-import {ROUTE_NAMES} from 'sentry/views/starfish/utils/routeNames';
 
 export function ResponsivenessModule() {
   return (
     <ScreensTemplate
       content={<UIScreens />}
-      title={ROUTE_NAMES.mobileUI}
+      title={MODULE_TITLE}
       moduleName={ModuleName.MOBILE_UI}
     />
   );

--- a/static/app/views/starfish/utils/routeNames.tsx
+++ b/static/app/views/starfish/utils/routeNames.tsx
@@ -1,9 +1,0 @@
-import {t} from 'sentry/locale';
-
-export const ROUTE_NAMES = {
-  api: t('API Calls'),
-  database: t('Database'),
-  'app-startup': t('App Starts'),
-  pageload: t('Screen Loads'),
-  mobileUI: t('Mobile UI'),
-};


### PR DESCRIPTION
This is the last spot where we use inline strings instead of the constants that define what the module titles are.
