### PR TITLE
fix(link_to_bundle): Use stackFramePath if available

### DIFF
--- a/static/app/components/events/interfaces/frame/defaultTitle/index.tsx
+++ b/static/app/components/events/interfaces/frame/defaultTitle/index.tsx
@@ -27,6 +27,7 @@ type Props = {
   isHoverPreviewed?: boolean;
   isUsedForGrouping?: boolean;
   meta?: Record<any, any>;
+  stackFramePath?: string | null | undefined;
 };
 
 type GetPathNameOutput = {key: string; value: string; meta?: Meta};
@@ -37,6 +38,7 @@ function DefaultTitle({
   isHoverPreviewed,
   isUsedForGrouping,
   meta,
+  stackFramePath,
 }: Props) {
   const title: Array<React.ReactElement> = [];
   const framePlatform = getPlatform(frame.platform, platform);
@@ -135,9 +137,13 @@ function DefaultTitle({
     }
 
     if (frame.absPath && isUrl(frame.absPath)) {
+      let url = frame.absPath;
+      if (stackFramePath && isUrl(stackFramePath)) {
+        url = stackFramePath;
+      }
       title.push(
-        <StyledExternalLink href={frame.absPath} key="share" onClick={handleExternalLink}>
-          <IconOpen size="xs" />
+        <StyledExternalLink href={url} key="share" onClick={handleExternalLink}>
+          <IconOpen size="sm" />
         </StyledExternalLink>
       );
     }

--- a/static/app/components/events/interfaces/frame/deprecatedLine.tsx
+++ b/static/app/components/events/interfaces/frame/deprecatedLine.tsx
@@ -366,6 +366,7 @@ export class DeprecatedLine extends Component<Props, State> {
                   platform={this.props.platform ?? 'other'}
                   isHoverPreviewed={isHoverPreviewed}
                   meta={this.props.frameMeta}
+                  stackFramePath={this.props.frameSourceResolutionResults?.stackFramePath}
                 />
               </div>
             </LeftLineTitle>


### PR DESCRIPTION
If a JS error has source maps, we should use the resolved stackFramePath instead of the frame's absPath which can be incorrect.

Fixes #71216