### PR TITLE
chore(highlights): Remove 'event-tags-tree-ui' flag from backend

### DIFF
--- a/src/sentry/api/endpoints/project_details.py
+++ b/src/sentry/api/endpoints/project_details.py
@@ -662,13 +662,12 @@ class ProjectDetailsEndpoint(ProjectEndpoint):
         if result.get("safeFields") is not None:
             if project.update_option("sentry:safe_fields", result["safeFields"]):
                 changed_proj_settings["sentry:safe_fields"] = result["safeFields"]
-        if features.has("organizations:event-tags-tree-ui", project.organization):
-            if result.get("highlightContext") is not None:
-                if project.update_option("sentry:highlight_context", result["highlightContext"]):
-                    changed_proj_settings["sentry:highlight_context"] = result["highlightContext"]
-            if result.get("highlightTags") is not None:
-                if project.update_option("sentry:highlight_tags", result["highlightTags"]):
-                    changed_proj_settings["sentry:highlight_tags"] = result["highlightTags"]
+        if result.get("highlightContext") is not None:
+            if project.update_option("sentry:highlight_context", result["highlightContext"]):
+                changed_proj_settings["sentry:highlight_context"] = result["highlightContext"]
+        if result.get("highlightTags") is not None:
+            if project.update_option("sentry:highlight_tags", result["highlightTags"]):
+                changed_proj_settings["sentry:highlight_tags"] = result["highlightTags"]
         if result.get("storeCrashReports") is not None:
             if project.get_option("sentry:store_crash_reports") != result["storeCrashReports"]:
                 changed_proj_settings["sentry:store_crash_reports"] = result["storeCrashReports"]

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1554,7 +1554,7 @@ SENTRY_FEATURES: dict[str, bool | None] = {
     # Enable attaching arbitrary files to events.
     "organizations:event-attachments": True,
     # Enable the Event Tags Tree UI feature
-    "organizations:event-tags-tree-ui": False,
+    "organizations:event-tags-tree-ui": True,
     # Enable the frontend to request from region & control silo domains.
     "organizations:frontend-domainsplit": False,
     # Enable disabling gitlab integrations when broken is detected

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1553,8 +1553,6 @@ SENTRY_FEATURES: dict[str, bool | None] = {
     "organizations:escalating-metrics-backend": False,
     # Enable attaching arbitrary files to events.
     "organizations:event-attachments": True,
-    # Enable the Event Tags Tree UI feature
-    "organizations:event-tags-tree-ui": True,
     # Enable the frontend to request from region & control silo domains.
     "organizations:frontend-domainsplit": False,
     # Enable disabling gitlab integrations when broken is detected

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -71,7 +71,6 @@ def register_temporary_features(manager: FeatureManager):
     manager.add("organizations:escalating-issues-msteams", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
     manager.add("organizations:escalating-issues-v2", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
     manager.add("organizations:escalating-metrics-backend", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
-    manager.add("organizations:event-tags-tree-ui", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
     manager.add("organizations:gitlab-disable-on-broken", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
     manager.add("organizations:grouping-stacktrace-ui", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
     manager.add("organizations:grouping-suppress-unnecessary-secondary-hash", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)

--- a/tests/sentry/api/endpoints/test_project_details.py
+++ b/tests/sentry/api/endpoints/test_project_details.py
@@ -952,24 +952,23 @@ class ProjectUpdateTest(APITestCase):
         preset = get_highlight_preset_for_project(self.project)
         assert resp.data["highlightTags"] == preset["tags"]
 
-        with self.feature("organizations:event-tags-tree-ui"):
-            # Set to custom
-            resp = self.get_success_response(
-                self.org_slug,
-                self.proj_slug,
-                highlightTags=highlight_tags,
-            )
-            assert self.project.get_option("sentry:highlight_tags") == highlight_tags
-            assert resp.data["highlightTags"] == highlight_tags
+        # Set to custom
+        resp = self.get_success_response(
+            self.org_slug,
+            self.proj_slug,
+            highlightTags=highlight_tags,
+        )
+        assert self.project.get_option("sentry:highlight_tags") == highlight_tags
+        assert resp.data["highlightTags"] == highlight_tags
 
-            # Set to empty
-            resp = self.get_success_response(
-                self.org_slug,
-                self.proj_slug,
-                highlightTags=[],
-            )
-            assert self.project.get_option("sentry:highlight_tags") == []
-            assert resp.data["highlightTags"] == []
+        # Set to empty
+        resp = self.get_success_response(
+            self.org_slug,
+            self.proj_slug,
+            highlightTags=[],
+        )
+        assert self.project.get_option("sentry:highlight_tags") == []
+        assert resp.data["highlightTags"] == []
 
     def test_highlight_context(self):
         # Default with or without flag, ignore update attempt
@@ -985,53 +984,52 @@ class ProjectUpdateTest(APITestCase):
         preset = get_highlight_preset_for_project(self.project)
         assert resp.data["highlightContext"] == preset["context"]
 
-        with self.feature("organizations:event-tags-tree-ui"):
-            # Set to custom
-            resp = self.get_success_response(
-                self.org_slug,
-                self.proj_slug,
-                highlightContext=highlight_context,
-            )
-            option_result = self.project.get_option("sentry:highlight_context")
-            resp_result = resp.data["highlightContext"]
-            for highlight_context_key in highlight_context[highlight_context_type]:
-                assert highlight_context_key in option_result[highlight_context_type]
-                assert highlight_context_key in resp_result[highlight_context_type]
-            # Filters duplicates
-            assert (
-                len(option_result[highlight_context_type])
-                == len(resp_result[highlight_context_type])
-                == 4
-            )
+        # Set to custom
+        resp = self.get_success_response(
+            self.org_slug,
+            self.proj_slug,
+            highlightContext=highlight_context,
+        )
+        option_result = self.project.get_option("sentry:highlight_context")
+        resp_result = resp.data["highlightContext"]
+        for highlight_context_key in highlight_context[highlight_context_type]:
+            assert highlight_context_key in option_result[highlight_context_type]
+            assert highlight_context_key in resp_result[highlight_context_type]
+        # Filters duplicates
+        assert (
+            len(option_result[highlight_context_type])
+            == len(resp_result[highlight_context_type])
+            == 4
+        )
 
-            # Set to empty
-            resp = self.get_success_response(
-                self.org_slug,
-                self.proj_slug,
-                highlightContext={},
-            )
-            assert self.project.get_option("sentry:highlight_context") == {}
-            assert resp.data["highlightContext"] == {}
+        # Set to empty
+        resp = self.get_success_response(
+            self.org_slug,
+            self.proj_slug,
+            highlightContext={},
+        )
+        assert self.project.get_option("sentry:highlight_context") == {}
+        assert resp.data["highlightContext"] == {}
 
-            # Checking validation
-            resp = self.get_error_response(
-                self.org_slug,
-                self.proj_slug,
-                highlightContext=["bird-words", ["red", "blue"]],
-            )
-            assert "Expected a dictionary" in resp.data["highlightContext"][0]
-            resp = self.get_error_response(
-                self.org_slug,
-                self.proj_slug,
-                highlightContext={"": ["empty", "context", "type"]},
-            )
-            assert "Key '' is invalid" in resp.data["highlightContext"][0]
-            resp = self.get_error_response(
-                self.org_slug,
-                self.proj_slug,
-                highlightContext={"bird-words": ["invalid", 123, "integer"]},
-            )
-            assert "must be a list of strings" in resp.data["highlightContext"][0]
+        # Checking validation
+        resp = self.get_error_response(
+            self.org_slug,
+            self.proj_slug,
+            highlightContext=["bird-words", ["red", "blue"]],
+        )
+        assert "Expected a dictionary" in resp.data["highlightContext"][0]
+        resp = self.get_error_response(
+            self.org_slug,
+            self.proj_slug,
+            highlightContext={"": ["empty", "context", "type"]},
+        )
+        assert "Key '' is invalid" in resp.data["highlightContext"][0]
+        resp = self.get_error_response(
+            self.org_slug,
+            self.proj_slug,
+            highlightContext={"bird-words": ["invalid", 123, "integer"]},
+        )
+        assert "must be a list of strings" in resp.data["highlightContext"][0]
 
     def test_store_crash_reports(self):
         resp = self.get_success_response(self.org_slug, self.proj_slug, storeCrashReports=10)

--- a/tests/sentry/api/endpoints/test_project_details.py
+++ b/tests/sentry/api/endpoints/test_project_details.py
@@ -940,19 +940,15 @@ class ProjectUpdateTest(APITestCase):
         ]
 
     def test_highlight_tags(self):
-        # Default with or without flag, ignore update attempt
-        highlight_tags = ["bears", "beets", "battlestar_galactica"]
-        resp = self.get_success_response(
-            self.org_slug,
-            self.proj_slug,
-            highlightTags=highlight_tags,
-        )
+        # Unrelated change returns presets
+        resp = self.get_success_response(self.org_slug, self.proj_slug)
         assert self.project.get_option("sentry:highlight_tags") is None
-
         preset = get_highlight_preset_for_project(self.project)
         assert resp.data["highlightTags"] == preset["tags"]
+        assert resp.data["highlightPreset"] == preset
 
         # Set to custom
+        highlight_tags = ["bears", "beets", "battlestar_galactica"]
         resp = self.get_success_response(
             self.org_slug,
             self.proj_slug,
@@ -969,22 +965,19 @@ class ProjectUpdateTest(APITestCase):
         )
         assert self.project.get_option("sentry:highlight_tags") == []
         assert resp.data["highlightTags"] == []
+        assert resp.data["highlightPreset"] == preset
 
     def test_highlight_context(self):
-        # Default with or without flag, ignore update attempt
-        highlight_context_type = "bird-words"
-        highlight_context = {highlight_context_type: ["red", "robin", "blue", "jay", "red", "blue"]}
-        resp = self.get_success_response(
-            self.org_slug,
-            self.proj_slug,
-            highlightContext=highlight_context,
-        )
-        assert self.project.get_option("sentry:highlight_context") is None
-
+        # Unrelated change returns presets
+        resp = self.get_success_response(self.org_slug, self.proj_slug)
         preset = get_highlight_preset_for_project(self.project)
+        assert self.project.get_option("sentry:highlight_context") is None
         assert resp.data["highlightContext"] == preset["context"]
+        assert resp.data["highlightPreset"] == preset
 
         # Set to custom
+        highlight_context_type = "bird-words"
+        highlight_context = {highlight_context_type: ["red", "robin", "blue", "jay", "red", "blue"]}
         resp = self.get_success_response(
             self.org_slug,
             self.proj_slug,
@@ -995,6 +988,7 @@ class ProjectUpdateTest(APITestCase):
         for highlight_context_key in highlight_context[highlight_context_type]:
             assert highlight_context_key in option_result[highlight_context_type]
             assert highlight_context_key in resp_result[highlight_context_type]
+
         # Filters duplicates
         assert (
             len(option_result[highlight_context_type])
@@ -1010,6 +1004,7 @@ class ProjectUpdateTest(APITestCase):
         )
         assert self.project.get_option("sentry:highlight_context") == {}
         assert resp.data["highlightContext"] == {}
+        assert resp.data["highlightPreset"] == preset
 
         # Checking validation
         resp = self.get_error_response(


### PR DESCRIPTION
Removes all occurrences of `event-tags-tree-ui` flag. All conditional code had already been modified in #71403.