### PR TITLE
feat(releases): Support IN and NOT IN for release filter

### DIFF
--- a/src/sentry/api/endpoints/organization_releases.py
+++ b/src/sentry/api/endpoints/organization_releases.py
@@ -87,8 +87,8 @@ def _filter_releases_by_query(queryset, organization, query, filter_params):
 
         if search_filter.key.name == RELEASE_ALIAS:
             query_q = Q()
+            raw_value = search_filter.value.raw_value
             if search_filter.value.is_wildcard():
-                raw_value = search_filter.value.raw_value
                 if raw_value.endswith("*") and raw_value.startswith("*"):
                     query_q = Q(version__contains=raw_value[1:-1])
                 elif raw_value.endswith("*"):
@@ -97,6 +97,10 @@ def _filter_releases_by_query(queryset, organization, query, filter_params):
                     query_q = Q(version__endswith=raw_value[1:])
             elif search_filter.operator == "!=":
                 query_q = ~Q(version=search_filter.value.value)
+            elif search_filter.operator == "NOT IN":
+                query_q = ~Q(version__in=raw_value)
+            elif search_filter.operator == "IN":
+                query_q = Q(version__in=raw_value)
             else:
                 query_q = Q(version=search_filter.value.value)
 

--- a/tests/sentry/api/endpoints/test_organization_releases.py
+++ b/tests/sentry/api/endpoints/test_organization_releases.py
@@ -330,7 +330,7 @@ class OrganizationReleaseListTest(APITestCase, BaseMetricsTestCase):
 
         release2 = Release.objects.create(
             organization_id=org.id,
-            version="sdfsdfsdf",
+            version="release2",
             date_added=datetime(2013, 8, 13, 3, 8, 24, 880386, tzinfo=UTC),
         )
         release2.add_project(project)
@@ -346,11 +346,31 @@ class OrganizationReleaseListTest(APITestCase, BaseMetricsTestCase):
         response = self.get_success_response(self.organization.slug, query=f"{RELEASE_ALIAS}:baz")
         self.assert_expected_versions(response, [])
 
+        response = self.get_success_response(
+            self.organization.slug, query=f"{RELEASE_ALIAS}:[foobar]"
+        )
+        self.assert_expected_versions(response, [release])
+
+        response = self.get_success_response(
+            self.organization.slug, query=f"{RELEASE_ALIAS}:[foobar,release2]"
+        )
+        self.assert_expected_versions(response, [release, release2])
+
         # NOT release
         response = self.get_success_response(
             self.organization.slug, query=f"!{RELEASE_ALIAS}:foobar"
         )
         self.assert_expected_versions(response, [release2])
+
+        response = self.get_success_response(
+            self.organization.slug, query=f"!{RELEASE_ALIAS}:[foobar]"
+        )
+        self.assert_expected_versions(response, [release2])
+
+        response = self.get_success_response(
+            self.organization.slug, query=f"!{RELEASE_ALIAS}:[foobar,release2]"
+        )
+        self.assert_expected_versions(response, [])
 
     def test_query_filter_suffix(self):
         user = self.create_user(is_staff=False, is_superuser=False)


### PR DESCRIPTION
Adds support for IN and NOT IN filters for the release alias. This addition supports passing along arbitrary releases for release health ordering in dashboards. I'm adding this IN filtering to fix a bug in a release health widget for dashboards where a release is selected, but the widget doesn't display the relevant data.

The bug: to sort release health by date, we make a call to the releases endpoint to fetch <=50 latest releases by date. Those are used to conduct a metrics request and the result is ordered in the frontend. If the release isn't in that first 50 set, then it gets lost. See the relevant code [here](https://github.com/getsentry/sentry/blob/master/static/app/views/dashboards/datasetConfig/releases.tsx#L439)