### PR TITLE
feat(api): Logic for `include_feature_flag` Query Parameter

### DIFF
--- a/api-docs/components/schemas/organization-details.json
+++ b/api-docs/components/schemas/organization-details.json
@@ -12,7 +12,6 @@
       "defaultRole",
       "enhancedPrivacy",
       "experiments",
-      "features",
       "id",
       "isDefault",
       "isEarlyAdopter",

--- a/src/sentry/api/endpoints/organization_details.py
+++ b/src/sentry/api/endpoints/organization_details.py
@@ -590,6 +590,7 @@ class OrganizationDetailsEndpoint(OrganizationEndpoint):
         :pparam string organization_id_or_slug: the id or slug of the organization the
                                           team should be created for.
         :param string detailed: Specify '0' to retrieve details without projects and teams.
+         :qparam string include_feature_flags: whether or not to include feature flags in the response
         :auth: required
         """
         # This param will be used to determine if we should include feature flags in the response

--- a/src/sentry/api/endpoints/organization_details.py
+++ b/src/sentry/api/endpoints/organization_details.py
@@ -624,6 +624,7 @@ class OrganizationDetailsEndpoint(OrganizationEndpoint):
         :param string name: an optional new name for the organization.
         :param string slug: an optional new slug for the organization.  Needs
                             to be available and unique.
+        :qparam string include_feature_flags: whether or not to include feature flags in the response
         :auth: required
         """
         from sentry import features

--- a/src/sentry/api/endpoints/organization_details.py
+++ b/src/sentry/api/endpoints/organization_details.py
@@ -590,7 +590,7 @@ class OrganizationDetailsEndpoint(OrganizationEndpoint):
         :pparam string organization_id_or_slug: the id or slug of the organization the
                                           team should be created for.
         :param string detailed: Specify '0' to retrieve details without projects and teams.
-         :qparam string include_feature_flags: whether or not to include feature flags in the response
+        :qparam string include_feature_flags: whether or not to include feature flags in the response
         :auth: required
         """
         # This param will be used to determine if we should include feature flags in the response

--- a/src/sentry/api/endpoints/organization_details.py
+++ b/src/sentry/api/endpoints/organization_details.py
@@ -594,7 +594,6 @@ class OrganizationDetailsEndpoint(OrganizationEndpoint):
         """
         # This param will be used to determine if we should include feature flags in the response
         include_feature_flags = request.GET.get("include_feature_flags", "0") != "0"
-        (include_feature_flags)  # TODO: Remove this once include_feature_flags is used
 
         serializer = org_serializers.OrganizationSerializer
 
@@ -606,6 +605,9 @@ class OrganizationDetailsEndpoint(OrganizationEndpoint):
                 serializer = org_serializers.DetailedOrganizationSerializerWithProjectsAndTeams
 
         context = serialize(organization, request.user, serializer(), access=request.access)
+
+        if not include_feature_flags:
+            context.pop("features", None)
 
         return self.respond(context)
 
@@ -628,7 +630,6 @@ class OrganizationDetailsEndpoint(OrganizationEndpoint):
 
         # This param will be used to determine if we should include feature flags in the response
         include_feature_flags = request.GET.get("include_feature_flags", "0") != "0"
-        (include_feature_flags)  # TODO: Remove this once include_feature_flags is used
 
         # We don't need to check for staff here b/c the _admin portal uses another endpoint to update orgs
         if request.access.has_scope("org:admin"):
@@ -697,6 +698,9 @@ class OrganizationDetailsEndpoint(OrganizationEndpoint):
                 org_serializers.DetailedOrganizationSerializerWithProjectsAndTeams(),
                 access=request.access,
             )
+
+            if not include_feature_flags:
+                context.pop("features", None)
 
             return self.respond(context)
         return self.respond(serializer.errors, status=status.HTTP_400_BAD_REQUEST)

--- a/tests/sentry/api/endpoints/test_organization_details.py
+++ b/tests/sentry/api/endpoints/test_organization_details.py
@@ -83,7 +83,9 @@ class MockAccess:
 @region_silo_test(regions=create_test_regions("us"), include_monolith_run=True)
 class OrganizationDetailsTest(OrganizationDetailsTestBase):
     def test_simple(self):
-        response = self.get_success_response(self.organization.slug)
+        response = self.get_success_response(
+            self.organization.slug, qs_params={"include_feature_flags": 1}
+        )
 
         assert response.data["slug"] == self.organization.slug
         assert response.data["links"] == {
@@ -97,10 +99,21 @@ class OrganizationDetailsTest(OrganizationDetailsTestBase):
         assert len(response.data["projects"]) == 0
         assert "customer-domains" not in response.data["features"]
 
+    def test_include_feature_flag_query_param(self):
+        response = self.get_success_response(
+            self.organization.slug, qs_params={"include_feature_flags": 1}
+        )
+        assert "features" in response.data
+
+        response = self.get_success_response(self.organization.slug)
+        assert "features" not in response.data
+
     def test_simple_customer_domain(self):
         HTTP_HOST = f"{self.organization.slug}.testserver"
         response = self.get_success_response(
-            self.organization.slug, extra_headers={"HTTP_HOST": HTTP_HOST}
+            self.organization.slug,
+            extra_headers={"HTTP_HOST": HTTP_HOST},
+            qs_params={"include_feature_flags": 1},
         )
 
         assert response.data["slug"] == self.organization.slug
@@ -118,7 +131,9 @@ class OrganizationDetailsTest(OrganizationDetailsTestBase):
         with self.feature({"organizations:customer-domains": False}):
             HTTP_HOST = f"{self.organization.slug}.testserver"
             response = self.get_success_response(
-                self.organization.slug, extra_headers={"HTTP_HOST": HTTP_HOST}
+                self.organization.slug,
+                extra_headers={"HTTP_HOST": HTTP_HOST},
+                qs_params={"include_feature_flags": 1},
             )
             assert "customer-domains" in response.data["features"]
 
@@ -343,6 +358,15 @@ class OrganizationUpdateTest(OrganizationDetailsTestBase):
         org = Organization.objects.get(id=self.organization.id)
         assert org.name == "hello world"
         assert org.slug == "foobar"
+
+    def test_include_feature_flag_query_param(self):
+        response = self.get_success_response(
+            self.organization.slug, qs_params={"include_feature_flags": 1}
+        )
+        assert "features" in response.data
+
+        response = self.get_success_response(self.organization.slug)
+        assert "features" not in response.data
 
     def test_dupe_slug(self):
         org = self.create_organization(owner=self.user, slug="duplicate")


### PR DESCRIPTION
In this final PR, I implement the logic to use the `include_feature_flag` logic and selective remove the "features" key from the response.

Closes: https://github.com/getsentry/team-core-product-foundations/issues/326
