### PR TITLE
ref: upgrade django-stubs

### DIFF
--- a/requirements-dev-frozen.txt
+++ b/requirements-dev-frozen.txt
@@ -42,7 +42,7 @@ django==5.0.6
 django-crispy-forms==1.14.0
 django-csp==3.8
 django-pg-zero-downtime-migrations==0.13
-django-stubs-ext==5.0.0
+django-stubs-ext==5.0.2
 djangorestframework==3.15.1
 docker==6.1.3
 drf-spectacular==0.26.3
@@ -179,7 +179,7 @@ selenium==4.16.0
 sentry-arroyo==2.16.5
 sentry-cli==2.16.0
 sentry-devenv==1.6.2
-sentry-forked-django-stubs==5.0.0.post3
+sentry-forked-django-stubs==5.0.2.post2
 sentry-forked-djangorestframework-stubs==3.15.0.post1
 sentry-kafka-schemas==0.1.81
 sentry-ophio==0.2.7
@@ -223,7 +223,7 @@ types-redis==3.5.18
 types-requests==2.31.0.20240406
 types-setuptools==69.0.0.0
 types-simplejson==3.17.7.2
-typing-extensions==4.9.0
+typing-extensions==4.12.0
 tzdata==2023.3
 ua-parser==0.10.0
 unidiff==0.7.4

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -35,7 +35,7 @@ pip-tools>=7.1.0
 packaging>=21.3
 
 # for type checking
-sentry-forked-django-stubs>=5.0.0.post3
+sentry-forked-django-stubs>=5.0.2.post2
 sentry-forked-djangorestframework-stubs>=3.15.0.post1
 lxml-stubs
 msgpack-types>=0.2.0

--- a/requirements-frozen.txt
+++ b/requirements-frozen.txt
@@ -140,7 +140,7 @@ symbolic==12.8.0
 tiktoken==0.6.0
 toronado==0.1.0
 tqdm==4.64.1
-typing-extensions==4.9.0
+typing-extensions==4.12.0
 tzdata==2023.3
 ua-parser==0.10.0
 unidiff==0.7.4

--- a/src/sentry/utils/json.py
+++ b/src/sentry/utils/json.py
@@ -7,10 +7,11 @@ import decimal
 import uuid
 from collections.abc import Callable, Collection, Generator, Mapping
 from enum import Enum
-from typing import IO, TYPE_CHECKING, Any, NoReturn, TypeVar, overload
+from typing import IO, Any, NoReturn, TypeVar, overload
 
 import orjson
 import rapidjson
+from django.db.models.query import QuerySet
 from django.utils.encoding import force_str
 from django.utils.functional import Promise
 from django.utils.safestring import SafeString, mark_safe
@@ -19,17 +20,6 @@ from simplejson import _default_decoder  # type: ignore[attr-defined]  # noqa: S
 from simplejson import JSONDecodeError, JSONEncoder  # noqa: S003
 
 from bitfield.types import BitHandler
-
-# A more traditional raw import from django_stubs_ext.aliases here breaks monkeypatching,
-# So we jump through hoops to get only the exact types
-if TYPE_CHECKING:
-    from django.db.models.query import _QuerySetAny
-
-    QuerySetAny = _QuerySetAny
-else:
-    from django.db.models.query import QuerySet
-
-    QuerySetAny = QuerySet
 
 TKey = TypeVar("TKey")
 TValue = TypeVar("TValue")
@@ -64,7 +54,7 @@ def better_default_encoder(o: object) -> object:
         return int(o)
     elif callable(o):
         return "<function>"
-    elif isinstance(o, QuerySetAny):
+    elif isinstance(o, QuerySet):
         return list(o)
     # serialization for certain Django objects here: https://docs.djangoproject.com/en/1.8/topics/serialization/
     elif isinstance(o, Promise):


### PR DESCRIPTION
the differences in ignored errors are all of the form:

```diff
-src/sentry/api/endpoints/artifact_lookup.py:248: error: Incompatible return value type (got "_QuerySet[Any, Any]", expected "Sequence[ReleaseFile]")  [return-value]
+src/sentry/api/endpoints/artifact_lookup.py:248: error: Incompatible return value type (got "QuerySet[Any, Any]", expected "Sequence[ReleaseFile]")  [return-value]
```

(QuerySet gained "default generics" so `_QuerySet` and `_QuerySetAny` are gone)

<!-- Describe your PR here. -->