### PR TITLE
chore: Enable require_bundle_changes for codecov config

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -88,6 +88,7 @@ comment:
   require_changes: true
   require_base: true # must have a base report to post
   require_head: true # must have a head report to post
+  require_bundle_changes: True # only post a comment when there are bundle size changes
 
 cli:
   # This would be used when uploading the ats results


### PR DESCRIPTION
Only post the bundle size comment when there are bundle size changes. Docs: https://docs.codecov.com/docs/javascript-bundle-analysis.