### PR TITLE
fix(assignee-selector): Fix assignee selector having wrong z-index

### DIFF
--- a/static/app/components/assigneeSelectorDropdown.tsx
+++ b/static/app/components/assigneeSelectorDropdown.tsx
@@ -583,6 +583,7 @@ const AssigneeWrapper = styled('div')`
 `;
 
 const AssigneeDropdownButton = styled(DropdownButton)`
+  z-index: 0;
   padding-left: ${space(0.5)};
   padding-right: ${space(0.5)};
 `;


### PR DESCRIPTION
Fixes #71542

The Assignee button on the issue stream is a styled `<DropdownButton/>`, which for some reason has a z-index of 2. This change overwrites that and sets it to 0, so it will not overlay on top of components like the column header. 

This is admittedly a bit of a hacky solution (we should just switch to a different component), but this button is going to be swapped out entirely for `<AssigneeBadge/>` in less than a week from now, so I think a quick fix is okay to avoid any weirdness with swapping components. 