### PR TITLE
fix(query-builder): Allow adding unsupported filter keys

### DIFF
--- a/static/app/components/searchQueryBuilder/index.spec.tsx
+++ b/static/app/components/searchQueryBuilder/index.spec.tsx
@@ -188,6 +188,17 @@ describe('SearchQueryBuilder', function () {
   });
 
   describe('new search tokens', function () {
+    it('can add an unsupported filter key and value', async function () {
+      render(<SearchQueryBuilder {...defaultProps} />);
+      await userEvent.click(screen.getByRole('combobox', {name: 'Add a search term'}));
+      await userEvent.type(
+        screen.getByRole('combobox', {name: 'Add a search term'}),
+        'a:b{enter}'
+      );
+
+      expect(screen.getByRole('row', {name: 'a:b'})).toBeInTheDocument();
+    });
+
     it('breaks keys into sections', async function () {
       render(<SearchQueryBuilder {...defaultProps} />);
       await userEvent.click(screen.getByRole('combobox', {name: 'Add a search term'}));

--- a/static/app/components/searchQueryBuilder/valueCombobox.tsx
+++ b/static/app/components/searchQueryBuilder/valueCombobox.tsx
@@ -58,7 +58,11 @@ function getPredefinedValues({key}: {key?: Tag}): string[] {
   }
 }
 
-function keySupportsMultipleValues(key: Tag): boolean {
+function keySupportsMultipleValues(key?: Tag): boolean {
+  if (!key) {
+    return true;
+  }
+
   const fieldDef = getFieldDefinition(key.key);
 
   switch (fieldDef?.valueType) {


### PR DESCRIPTION
Simple bug fix and corresponding test - adding a new filter key used to cause an error if it was not in the provided supported keys map.