### PR TITLE
feat(data-consent): Backend changes for data consent on org creation

### DIFF
--- a/src/sentry/analytics/events/__init__.py
+++ b/src/sentry/analytics/events/__init__.py
@@ -12,6 +12,7 @@ from .codeowners_updated import *  # noqa: F401,F403
 from .comment_webhooks import *  # noqa: F401,F403
 from .cron_monitor_broken_status_recovery import *  # noqa: F401,F403
 from .cron_monitor_created import *  # noqa: F401,F403
+from .data_consent_org_creation import *  # noqa: F401,F403
 from .eventuser_endpoint_request import *  # noqa: F401,F403
 from .eventuser_equality_check import *  # noqa: F401,F403
 from .eventuser_snuba_for_projects import *  # noqa: F401,F403

--- a/src/sentry/analytics/events/data_consent_org_creation.py
+++ b/src/sentry/analytics/events/data_consent_org_creation.py
@@ -1,0 +1,10 @@
+from sentry import analytics
+
+
+class AggregatedDataConsentOrganizationCreatedEvent(analytics.Event):
+    type = "aggregated_data_consent.organization_created"
+
+    attributes = (analytics.Attribute("organization_id"),)
+
+
+analytics.register(AggregatedDataConsentOrganizationCreatedEvent)

--- a/tests/sentry/api/endpoints/test_organization_index.py
+++ b/tests/sentry/api/endpoints/test_organization_index.py
@@ -8,6 +8,7 @@ from django.test import override_settings
 
 from sentry.auth.authenticators.totp import TotpInterface
 from sentry.models.authenticator import Authenticator
+from sentry.models.options.organization_option import OrganizationOption
 from sentry.models.organization import Organization, OrganizationStatus
 from sentry.models.organizationmapping import OrganizationMapping
 from sentry.models.organizationmember import OrganizationMember
@@ -274,6 +275,23 @@ class OrganizationsCreateTest(OrganizationIndexTest, HybridCloudTestMixin):
             organization_id=response.data["id"], user_id=self.user.id
         )
         self.assert_org_member_mapping(org_member=org_member)
+
+    def test_data_consent(self):
+        data = {"name": "hello world original", "agreeTerms": True}
+        response = self.get_success_response(**data)
+
+        organization_id = response.data["id"]
+        org = Organization.objects.get(id=organization_id)
+        assert org.name == data["name"]
+        assert not OrganizationOption.objects.get_value(org, "sentry:aggregated_data_consent")
+
+        data = {"name": "hello world", "agreeTerms": True, "aggregatedDataConsent": True}
+        response = self.get_success_response(**data)
+
+        organization_id = response.data["id"]
+        org = Organization.objects.get(id=organization_id)
+        assert org.name == data["name"]
+        assert OrganizationOption.objects.get_value(org, "sentry:aggregated_data_consent") is True
 
 
 @region_silo_test(regions=create_test_regions("de", "us"))


### PR DESCRIPTION
this pr adds in the backend changes needed to support consenting to the aggregated data consent option on org creation. it also adds in analytics so we can track how many orgs are created with this consent.