### PR TITLE
chore(highlights): Add help link to highlight section

### DIFF
--- a/static/app/components/events/highlights/highlightsDataSection.tsx
+++ b/static/app/components/events/highlights/highlightsDataSection.tsx
@@ -21,11 +21,13 @@ import {
   EMPTY_HIGHLIGHT_DEFAULT,
   getHighlightContextData,
   getHighlightTagData,
+  HIGHLIGHT_DOCS_LINK,
 } from 'sentry/components/events/highlights/util';
 import useFeedbackWidget from 'sentry/components/feedback/widget/useFeedbackWidget';
+import ExternalLink from 'sentry/components/links/externalLink';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {IconEdit, IconMegaphone} from 'sentry/icons';
-import {t} from 'sentry/locale';
+import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {Event, Group, Project} from 'sentry/types';
 import {trackAnalytics} from 'sentry/utils/analytics';
@@ -238,9 +240,17 @@ export default function HighlightsDataSection({
 
   return (
     <EventDataSection
-      title={t('Event Highlights')}
-      data-test-id="event-highlights"
+      key="event-highlights"
       type="event-highlights"
+      title={t('Event Highlights')}
+      help={tct(
+        'Promoted tags and context items saved for this project. [link:Learn more]',
+        {
+          link: <ExternalLink openInNewTab href={HIGHLIGHT_DOCS_LINK} />,
+        }
+      )}
+      isHelpHoverable
+      data-test-id="event-highlights"
       actions={
         <ButtonBar gap={1}>
           <HighlightsFeedback />

--- a/static/app/components/events/highlights/util.tsx
+++ b/static/app/components/events/highlights/util.tsx
@@ -24,6 +24,8 @@ interface ContextData extends ContextItem {
 }
 
 export const EMPTY_HIGHLIGHT_DEFAULT = '--';
+export const HIGHLIGHT_DOCS_LINK =
+  'https://docs.sentry.io/product/issues/issue-details/#event-highlights';
 
 /**
  * Helper function to use try HighlightContext saved values on multiple fields improve match rate.


### PR DESCRIPTION
Adds help text and a link to the data section.

<img width="294" alt="image" src="https://github.com/getsentry/sentry/assets/35509934/602ac72a-83cd-48c4-826f-c761733870f2">