### PR TITLE
fix(query-builder): Allow editing operator for filter with multiple values

### DIFF
--- a/static/app/components/searchQueryBuilder/index.spec.tsx
+++ b/static/app/components/searchQueryBuilder/index.spec.tsx
@@ -100,6 +100,39 @@ describe('SearchQueryBuilder', function () {
       ).toBeInTheDocument();
     });
 
+    it('can modify operator for filter with multiple values', async function () {
+      render(
+        <SearchQueryBuilder
+          {...defaultProps}
+          initialQuery="browser.name:[firefox,chrome]"
+        />
+      );
+
+      // Should display as "is" to start
+      expect(
+        within(
+          screen.getByRole('button', {name: 'Edit operator for filter: browser.name'})
+        ).getByText('is')
+      ).toBeInTheDocument();
+
+      await userEvent.click(
+        screen.getByRole('button', {name: 'Edit operator for filter: browser.name'})
+      );
+      await userEvent.click(screen.getByRole('menuitemradio', {name: 'is not'}));
+
+      // Token should be modified to be negated
+      expect(
+        screen.getByRole('row', {name: '!browser.name:[firefox,chrome]'})
+      ).toBeInTheDocument();
+
+      // Should now have "is not" label
+      expect(
+        within(
+          screen.getByRole('button', {name: 'Edit operator for filter: browser.name'})
+        ).getByText('is not')
+      ).toBeInTheDocument();
+    });
+
     it('can modify the value by clicking into it (single-select)', async function () {
       // `age` is a duration filter which only accepts single values
       render(<SearchQueryBuilder {...defaultProps} initialQuery="age:-1d" />);

--- a/static/app/components/searchQueryBuilder/useQueryBuilderState.tsx
+++ b/static/app/components/searchQueryBuilder/useQueryBuilderState.tsx
@@ -68,14 +68,11 @@ function modifyFilterOperator(
 ): string {
   const isNotEqual = newOperator === TermOperator.NOT_EQUAL;
 
-  token.operator = isNotEqual ? TermOperator.DEFAULT : newOperator;
-  token.negated = isNotEqual;
+  const newToken: TokenResult<Token.FILTER> = {...token};
+  newToken.operator = isNotEqual ? TermOperator.DEFAULT : newOperator;
+  newToken.negated = isNotEqual;
 
-  return (
-    query.substring(0, token.location.start.offset) +
-    stringifyToken(token) +
-    query.substring(token.location.end.offset)
-  );
+  return replaceQueryToken(query, token, stringifyToken(newToken));
 }
 
 function replaceQueryToken(

--- a/static/app/components/searchSyntax/parser.tsx
+++ b/static/app/components/searchSyntax/parser.tsx
@@ -145,7 +145,7 @@ export const filterTypeConfig = {
   },
   [FilterType.TEXT_IN]: {
     validKeys: textKeys,
-    validOps: [],
+    validOps: basicOperators,
     validValues: [Token.VALUE_TEXT_LIST],
     canNegate: true,
   },
@@ -187,7 +187,7 @@ export const filterTypeConfig = {
   },
   [FilterType.NUMERIC_IN]: {
     validKeys: [Token.KEY_SIMPLE],
-    validOps: [],
+    validOps: basicOperators,
     validValues: [Token.VALUE_NUMBER_LIST],
     canNegate: true,
   },

--- a/static/app/components/searchSyntax/utils.tsx
+++ b/static/app/components/searchSyntax/utils.tsx
@@ -269,12 +269,15 @@ export function stringifyToken(token: TokenResult<Token>) {
     case Token.LOGIC_BOOLEAN:
       return token.value;
     case Token.VALUE_TEXT_LIST:
-      return token.items.map(v => v.value).join(',');
+      const textListItems = token.items
+        .map(item => item.value?.text ?? '')
+        .filter(text => text.length > 0);
+      return `[${textListItems.join(',')}]`;
     case Token.VALUE_NUMBER_LIST:
-      return token.items
+      const numberListItems = token.items
         .map(item => (item.value ? item.value.value + item.value.unit : ''))
-        .filter(str => str.length > 0)
-        .join(', ');
+        .filter(str => str.length > 0);
+      return `[${numberListItems.join(',')}]`;
     case Token.KEY_SIMPLE:
       return token.value;
     case Token.KEY_AGGREGATE:


### PR DESCRIPTION
Prior to this change, filters with multiple values could not switch from `is` to `is not`.

- Modifies the filter operator config to add the basic ops to TEXT_IN  and NUMERIC_IN so the util that finds valid ops returns the correct items
- Modifies the stringify logic to work correctly for filters with multiple values

This also fixes the current search experience, which wasn't showing any valid ops:

Before:
![CleanShot 2024-05-29 at 11 55 43](https://github.com/getsentry/sentry/assets/10888943/80d97e65-39a1-4f9f-b4c8-f67b470850cb)

After:
![CleanShot 2024-05-29 at 11 56 30](https://github.com/getsentry/sentry/assets/10888943/e4c91ac6-10be-4264-ab3d-99ce46c2425d)
