### PR TITLE
fix(traces): Remove click opening desc

### DIFF
--- a/static/app/views/performance/traces/content.tsx
+++ b/static/app/views/performance/traces/content.tsx
@@ -255,7 +255,7 @@ function TraceRow({
         />
         <TraceIdRenderer traceId={trace.trace} timestamp={trace.spans[0].timestamp} />
       </StyledPanelItem>
-      <StyledPanelItem align="left" overflow onClick={onClickExpand}>
+      <StyledPanelItem align="left" overflow>
         <Description>
           {trace.project ? (
             <ProjectRenderer projectSlug={trace.project} hideName />


### PR DESCRIPTION
Description sometimes needs to be copy pasted, in which cases the onClick on description is better left off.
