### PR TITLE
feat(crons): Allow for deleting processing error by type

### DIFF
--- a/src/sentry/monitors/processing_errors/manager.py
+++ b/src/sentry/monitors/processing_errors/manager.py
@@ -16,7 +16,7 @@ from sentry.monitors.models import Monitor
 from sentry.monitors.types import CheckinItem
 from sentry.utils import json, metrics, redis
 
-from .errors import CheckinProcessingError, ProcessingErrorsException
+from .errors import CheckinProcessingError, ProcessingErrorsException, ProcessingErrorType
 
 logger = logging.getLogger(__name__)
 
@@ -94,6 +94,30 @@ def _delete_for_entity(entity_identifier: str, uuid: uuid.UUID) -> None:
     pipeline.execute()
 
 
+def _delete_for_entity_by_type(entity_identifier: str, type: ProcessingErrorType) -> None:
+    checkin_errors = _get_for_entities([entity_identifier])
+    redis = _get_cluster()
+    pipeline = redis.pipeline()
+    for checkin_error in checkin_errors:
+        errors = checkin_error.errors
+        if not any(error["type"] == type for error in errors):
+            continue
+
+        # If the processing error only holds this one type of error, remove the whole error
+        if len(errors) == 1:
+            pipeline.zrem(build_set_identifier(entity_identifier), checkin_error.id.hex)
+            pipeline.delete(build_error_identifier(checkin_error.id))
+        # If the processing error has other errors, filter out the matching error and update the redis value
+        else:
+            filtered_errors = list(filter(lambda error: error["type"] != type, errors))
+            new_checkin_error = CheckinProcessingError(filtered_errors, checkin_error.checkin)
+            new_serialized_checkin_error = json.dumps(new_checkin_error.to_dict())
+            error_key = build_error_identifier(checkin_error.id)
+            pipeline.set(error_key, new_serialized_checkin_error, ex=MONITOR_ERRORS_LIFETIME)
+
+    pipeline.execute()
+
+
 def store_error(error: CheckinProcessingError, monitor: Monitor | None):
     entity_identifier = _get_entity_identifier_from_error(error, monitor)
     error_set_key = build_set_identifier(entity_identifier)
@@ -122,6 +146,14 @@ def delete_error(project: Project, uuid: uuid.UUID):
 
     entity_identifier = _get_entity_identifier_from_error(error)
     _delete_for_entity(entity_identifier, uuid)
+
+
+def delete_errors_for_monitor_by_type(monitor: Monitor, type: ProcessingErrorType):
+    _delete_for_entity_by_type(build_monitor_identifier(monitor), type)
+
+
+def delete_errors_for_project_by_type(project: Project, type: ProcessingErrorType):
+    _delete_for_entity_by_type(build_project_identifier(project.id), type)
 
 
 def get_errors_for_monitor(monitor: Monitor) -> list[CheckinProcessingError]:


### PR DESCRIPTION
Add functionality into the `processing_errors/manager.py` to bulk delete processing errors by type. This will allow a user to bulk dismiss a set of processing errors such as this set of 10 that are all the same:
<img width="902" alt="image" src="https://github.com/getsentry/sentry/assets/9372512/293539ef-46d8-403d-b287-02aa455f942f">

This is mostly straightforward, but problems arise when a single check-in processing error has multiple errors inside of it:
```
CheckinProcessingError {
  errors: [ProcessingError(type: 1), ProcessingError(type: 2), etc...]
  id: ...
  checkin: {...}
}
```
If we wanted to just remove all errors with `type: 1`, we go into the processing error, remove the matching type, and then update the key/value in redis. This has the unfortunate side effect of resetting the key's TTL. 

If this is a problem, we can execute a command to fetch the TTL for the existing key and keep it the same. 
There is also an option `keepttl` which seems to exist in more updated versions of redis. Both solutions I figured might not be worth it, so I kept it as is for now.