### PR TITLE
fix(dashboards): Apply release selection to RH widget sort request

### DIFF
--- a/static/app/views/dashboards/widgetCard/releaseWidgetQueries.tsx
+++ b/static/app/views/dashboards/widgetCard/releaseWidgetQueries.tsx
@@ -2,6 +2,7 @@ import {Component} from 'react';
 import cloneDeep from 'lodash/cloneDeep';
 import isEqual from 'lodash/isEqual';
 import omit from 'lodash/omit';
+import pick from 'lodash/pick';
 import trimStart from 'lodash/trimStart';
 
 import {addErrorMessage} from 'sentry/actionCreators/indicator';
@@ -19,6 +20,7 @@ import type {Series} from 'sentry/types/echarts';
 import type {TableDataWithTitle} from 'sentry/utils/discover/discoverQuery';
 import {stripDerivedMetricsPrefix} from 'sentry/utils/discover/fields';
 import {TOP_N} from 'sentry/utils/discover/types';
+import {dashboardFiltersToString} from 'sentry/views/dashboards/utils';
 
 import {ReleasesConfig} from '../datasetConfig/releases';
 import type {DashboardFilters, Widget, WidgetQuery} from '../types';
@@ -169,7 +171,7 @@ class ReleaseWidgetQueries extends Component<Props, State> {
 
   fetchReleases = async () => {
     this.setState({loading: true, errorMessage: undefined});
-    const {selection, api, organization} = this.props;
+    const {selection, api, organization, dashboardFilters} = this.props;
     const {environments, projects} = selection;
 
     try {
@@ -182,6 +184,10 @@ class ReleaseWidgetQueries extends Component<Props, State> {
             project: projects,
             per_page: 50,
             environment: environments,
+            // Propagate release filters
+            query: dashboardFilters
+              ? dashboardFiltersToString(pick(dashboardFilters, 'release'))
+              : undefined,
           },
         }
       );


### PR DESCRIPTION
The old metrics endpoint that supports release health widgets doesn't support sorting by release outright, so we make a request to the releases endpoint for the order of releases, getting the first 50 results which we use to sort in the frontend.

I added support for [IN filtering for the release key](https://github.com/getsentry/sentry/pull/71667), which is being used here to ensure the releases applied at the dashboard level are being included in the release data.