### PR TITLE
ref(pinned-searches): Save new/updated default searches to new `groupsearchview` table

### DIFF
--- a/src/sentry/api/endpoints/organization_pinned_searches.py
+++ b/src/sentry/api/endpoints/organization_pinned_searches.py
@@ -7,6 +7,7 @@ from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.organization import OrganizationEndpoint, OrganizationPinnedSearchPermission
 from sentry.api.serializers import serialize
+from sentry.models.groupsearchview import GroupSearchView
 from sentry.models.savedsearch import SavedSearch, SortOptions, Visibility
 from sentry.models.search_common import SearchType
 
@@ -53,7 +54,7 @@ class OrganizationPinnedSearchEndpoint(OrganizationEndpoint):
             values={"query": result["query"], "sort": result["sort"]},
         )
 
-        GroupSearchView.objects.create_or_update(  # type: ignore
+        GroupSearchView.objects.create_or_update(
             organizaiton=organization,
             user_id=request.user.id,
             values={

--- a/src/sentry/api/endpoints/organization_pinned_searches.py
+++ b/src/sentry/api/endpoints/organization_pinned_searches.py
@@ -55,13 +55,13 @@ class OrganizationPinnedSearchEndpoint(OrganizationEndpoint):
         )
 
         GroupSearchView.objects.create_or_update(
-            organizaiton=organization,
+            organization=organization,
             user_id=request.user.id,
+            position=0,
             values={
                 "name": "Default Search",
                 "query": result["query"],
                 "query_sort": result["sort"],
-                "position": 0,  # 0 position indicates default view
             },
         )
         pinned_search = SavedSearch.objects.get(

--- a/src/sentry/api/endpoints/organization_pinned_searches.py
+++ b/src/sentry/api/endpoints/organization_pinned_searches.py
@@ -7,7 +7,6 @@ from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.organization import OrganizationEndpoint, OrganizationPinnedSearchPermission
 from sentry.api.serializers import serialize
-from sentry.models.organizationmember import OrganizationMember
 from sentry.models.savedsearch import SavedSearch, SortOptions, Visibility
 from sentry.models.search_common import SearchType
 
@@ -53,12 +52,10 @@ class OrganizationPinnedSearchEndpoint(OrganizationEndpoint):
             visibility=Visibility.OWNER_PINNED,
             values={"query": result["query"], "sort": result["sort"]},
         )
-        org_member = OrganizationMember.objects.get(
-            organization=organization, user_id=request.user.id
-        )
 
-        IssueUserViews.objects.create_or_update(  # type: ignore
-            org_member_id=org_member.id,
+        GroupSearchView.objects.create_or_update(  # type: ignore
+            organizaiton=organization,
+            user_id=request.user.id,
             values={
                 "name": "Default Search",
                 "query": result["query"],

--- a/src/sentry/api/endpoints/organization_pinned_searches.py
+++ b/src/sentry/api/endpoints/organization_pinned_searches.py
@@ -54,6 +54,7 @@ class OrganizationPinnedSearchEndpoint(OrganizationEndpoint):
             values={"query": result["query"], "sort": result["sort"]},
         )
 
+        # This entire endpoint will be removed once custom views are GA'd
         GroupSearchView.objects.create_or_update(
             organization=organization,
             user_id=request.user.id,
@@ -83,5 +84,8 @@ class OrganizationPinnedSearchEndpoint(OrganizationEndpoint):
             owner_id=request.user.id,
             type=search_type.value,
             visibility=Visibility.OWNER_PINNED,
+        ).delete()
+        GroupSearchView.objects.filter(
+            organization=organization, user_id=request.user.id, position=0
         ).delete()
         return Response(status=204)

--- a/tests/sentry/api/endpoints/test_organization_pinned_searches.py
+++ b/tests/sentry/api/endpoints/test_organization_pinned_searches.py
@@ -1,6 +1,7 @@
 from functools import cached_property
 
 from sentry.api.endpoints.organization_pinned_searches import PINNED_SEARCH_NAME
+from sentry.models.groupsearchview import GroupSearchView
 from sentry.models.savedsearch import SavedSearch, SortOptions, Visibility
 from sentry.models.search_common import SearchType
 from sentry.testutils.cases import APITestCase
@@ -34,6 +35,7 @@ class CreateOrganizationPinnedSearchTest(APITestCase):
             sort=sort,
             visibility=Visibility.OWNER_PINNED,
         ).exists()
+
         # TODO(msun): Remove this when custom views are GA'd
         assert GroupSearchView.objects.filter(
             organization=self.organization,

--- a/tests/sentry/api/endpoints/test_organization_pinned_searches.py
+++ b/tests/sentry/api/endpoints/test_organization_pinned_searches.py
@@ -36,7 +36,6 @@ class CreateOrganizationPinnedSearchTest(APITestCase):
             visibility=Visibility.OWNER_PINNED,
         ).exists()
 
-        # TODO(msun): Remove this when custom views are GA'd
         assert GroupSearchView.objects.filter(
             organization=self.organization,
             name="Default Search",
@@ -171,6 +170,23 @@ class DeleteOrganizationPinnedSearchTest(APITestCase):
         # delete
         self.get_success_response(type=saved_search.type, status_code=204)
         assert SavedSearch.objects.filter(id=other_saved_search.id).exists()
+
+    def test_views_deleted(self):
+        self.login_as(self.member)
+
+        saved_search = SavedSearch.objects.create(
+            organization=self.organization,
+            owner_id=self.member.id,
+            type=SearchType.ISSUE.value,
+            query="wat",
+            visibility=Visibility.OWNER_PINNED,
+        )
+
+        self.get_success_response(type=saved_search.type, status_code=204)
+        assert not SavedSearch.objects.filter(id=saved_search.id).exists()
+        assert not GroupSearchView.objects.filter(
+            organization=self.organization, user_id=self.member.id, position=0
+        ).exists()
 
     def test_invalid_type(self):
         self.login_as(self.member)

--- a/tests/sentry/api/endpoints/test_organization_pinned_searches.py
+++ b/tests/sentry/api/endpoints/test_organization_pinned_searches.py
@@ -34,6 +34,15 @@ class CreateOrganizationPinnedSearchTest(APITestCase):
             sort=sort,
             visibility=Visibility.OWNER_PINNED,
         ).exists()
+        # TODO(msun): Remove this when custom views are GA'd
+        assert GroupSearchView.objects.filter(
+            organization=self.organization,
+            name="Default Search",
+            user_id=self.member.id,
+            query=query,
+            query_sort=sort,
+            position=0,
+        ).exists()
 
         query = "test_2"
         self.get_success_response(type=search_type, query=query, sort=sort, status_code=201)


### PR DESCRIPTION
This PR augments the `.../pinned-searches` endpoint. This endpoint previously saved a new pinned (default) search to only the `sentry_savedsearches` table with `visibility="owner_pinned"`. This PR adds new logic to also save a new or updated default to the upcoming custom views table (`sentry_issueuserviews`). This is because we will want to persist user's default searches as a new tab, so we will need to start actively saving default searches to this new table. 