### PR TITLE
log(issues): log to debug dropped status changes, for feedback spam detection

### DIFF
--- a/src/sentry/issues/status_change_consumer.py
+++ b/src/sentry/issues/status_change_consumer.py
@@ -194,6 +194,10 @@ def process_status_change_message(
         groups_by_fingerprints = bulk_get_groups_from_fingerprints([(project.id, fingerprint)])
         group = groups_by_fingerprints.get((project.id, fingerprint[0]), None)
         if not group:
+            logger.info(
+                "status_change.dropped_group_not_found",
+                extra={"fingerprint": fingerprint, "new_status": status_change_data["new_status"]},
+            )
             metrics.incr(
                 "occurrence_ingest.status_change.dropped_group_not_found",
                 sample_rate=1.0,

--- a/src/sentry/issues/status_change_consumer.py
+++ b/src/sentry/issues/status_change_consumer.py
@@ -196,7 +196,11 @@ def process_status_change_message(
         if not group:
             logger.info(
                 "status_change.dropped_group_not_found",
-                extra={"fingerprint": fingerprint, "new_status": status_change_data["new_status"]},
+                extra={
+                    "fingerprint": fingerprint,
+                    "new_status": status_change_data["new_status"],
+                    "project_id": status_change_data["project_id"],
+                },
             )
             metrics.incr(
                 "occurrence_ingest.status_change.dropped_group_not_found",


### PR DESCRIPTION
After GAing spam detection, we see another spike in dropped status change msgs [here](https://app.datadoghq.com/metric/explorer?fromUser=false&start=1716844994053&end=1717017794053&paused=false#N4Ig7glgJg5gpgFxALlAGwIYE8D2BXJVEADxQEYAaELcqyKBAC1pEbghkcLIF8qo4AMwgA7CAgg4RKUAiwAHOChASAtnADOcAE4RNIKtrgBHPJoQaUAbVBGN8qVoD6gnNtUZCKiOq279VKY6epbINiAiGOrKQdpYAMwGIFCeGE4a+NoAxkrIIOoIulmWgWZxyhp4qshaIoVYAHQ4WVl42kYiOU6i8BoIDX2eeBpOWYwYIvANUNo48opQTjCzePJOIjgILvgiUMAAVDwNGCNZOwgAFACUIHygkdF5sVgALEkpCGkZbTnKBUUlEDPCpVGpwOpxJotNodLo9cwDT4IYajcaTOANXwaDC9A5HE6jc7XW4AXSornceEwoXCFNUVIwMTKCVuFFAdIZTJ0r1JVD6WDQuVA8gwgoQCFyyRwMFG1I0ECySTQojgTjkigqOGVUCVKqc9CYyg27lFrOSEHsmCwaoUkuVIiUPBJPD4IEt4gAwlJhDAUCIqWgeEA). This problem should've been fixed by adding partition key in https://github.com/getsentry/sentry/pull/71673. Adding a log to narrow down this problem