### PR TITLE
ref: remove unnecessary build_query_builder helper

### DIFF
--- a/src/sentry/incidents/logic.py
+++ b/src/sentry/incidents/logic.py
@@ -76,7 +76,6 @@ from sentry.snuba.subscriptions import (
     create_snuba_query,
     update_snuba_query,
 )
-from sentry.snuba.tasks import build_query_builder
 from sentry.tasks.relay import schedule_invalidate_project_config
 from sentry.types.actor import Actor
 from sentry.utils import metrics
@@ -339,11 +338,10 @@ def build_incident_query_builder(
     project_ids = list(
         IncidentProject.objects.filter(incident=incident).values_list("project_id", flat=True)
     )
-    query_builder = build_query_builder(
-        entity_subscription,
-        snuba_query.query,
-        project_ids,
-        snuba_query.environment,
+    query_builder = entity_subscription.build_query_builder(
+        query=snuba_query.query,
+        project_ids=project_ids,
+        environment=snuba_query.environment,
         params={
             "organization_id": incident.organization_id,
             "project_id": project_ids,

--- a/src/sentry/incidents/serializers/alert_rule.py
+++ b/src/sentry/incidents/serializers/alert_rule.py
@@ -40,7 +40,6 @@ from sentry.snuba.entity_subscription import (
     get_entity_subscription,
 )
 from sentry.snuba.models import QuerySubscription, SnubaQuery, SnubaQueryEventType
-from sentry.snuba.tasks import build_query_builder
 
 from ...snuba.metrics.naming_layer.mri import is_mri
 from . import (
@@ -334,11 +333,10 @@ class AlertRuleSerializer(CamelSnakeModelSerializer):
         end = timezone.now()
         start = end - timedelta(minutes=10)
         try:
-            query_builder = build_query_builder(
-                entity_subscription,
-                data["query"],
-                [p.id for p in projects],
-                data.get("environment"),
+            query_builder = entity_subscription.build_query_builder(
+                query=data["query"],
+                project_ids=[p.id for p in projects],
+                environment=data.get("environment"),
                 params={
                     "organization_id": projects[0].organization_id,
                     "project_id": [p.id for p in projects],

--- a/src/sentry/incidents/subscription_processor.py
+++ b/src/sentry/incidents/subscription_processor.py
@@ -50,7 +50,6 @@ from sentry.snuba.entity_subscription import (
     get_entity_subscription_from_snuba_query,
 )
 from sentry.snuba.models import QuerySubscription
-from sentry.snuba.tasks import build_query_builder
 from sentry.utils import metrics, redis
 from sentry.utils.dates import to_datetime
 
@@ -204,11 +203,10 @@ class SubscriptionProcessor:
         )
         try:
             project_ids = [self.subscription.project_id]
-            query_builder = build_query_builder(
-                entity_subscription,
-                snuba_query.query,
-                project_ids,
-                snuba_query.environment,
+            query_builder = entity_subscription.build_query_builder(
+                query=snuba_query.query,
+                project_ids=project_ids,
+                environment=snuba_query.environment,
                 params={
                     "organization_id": self.subscription.project.organization.id,
                     "project_id": project_ids,

--- a/tests/sentry/snuba/test_tasks.py
+++ b/tests/sentry/snuba/test_tasks.py
@@ -29,7 +29,6 @@ from sentry.snuba.metrics.naming_layer.mri import SessionMRI
 from sentry.snuba.models import QuerySubscription, SnubaQuery, SnubaQueryEventType
 from sentry.snuba.tasks import (
     SUBSCRIPTION_STATUS_MAX_AGE,
-    build_query_builder,
     create_subscription_in_snuba,
     delete_subscription_from_snuba,
     subscription_checker,
@@ -603,10 +602,9 @@ class BuildSnqlQueryTest(TestCase):
                 time_window=time_window,
                 extra_fields=entity_extra_fields,
             )
-            query_builder = build_query_builder(
-                entity_subscription,
-                query,
-                [self.project.id],
+            query_builder = entity_subscription.build_query_builder(
+                query=query,
+                project_ids=[self.project.id],
                 environment=environment,
                 params={
                     "organization_id": self.organization.id,


### PR DESCRIPTION
the `build_query_builder` helper is just taking the passed `entity_subscription` and invoking it with the remaining args.

This is unnecessary and confusing.