### PR TITLE
feat(query-builder): Add plain text interface toggle

### DIFF
--- a/static/app/components/searchQueryBuilder/index.spec.tsx
+++ b/static/app/components/searchQueryBuilder/index.spec.tsx
@@ -9,8 +9,11 @@ import {
 } from 'sentry-test/reactTestingLibrary';
 
 import {SearchQueryBuilder} from 'sentry/components/searchQueryBuilder';
+import {QueryInterfaceType} from 'sentry/components/searchQueryBuilder/types';
+import {INTERFACE_TYPE_LOCALSTORAGE_KEY} from 'sentry/components/searchQueryBuilder/utils';
 import type {TagCollection} from 'sentry/types/group';
 import {FieldKey, FieldKind} from 'sentry/utils/fields';
+import localStorageWrapper from 'sentry/utils/localStorage';
 
 const MOCK_SUPPORTED_KEYS: TagCollection = {
   [FieldKey.AGE]: {
@@ -37,6 +40,10 @@ const MOCK_SUPPORTED_KEYS: TagCollection = {
 };
 
 describe('SearchQueryBuilder', function () {
+  beforeEach(() => {
+    localStorageWrapper.clear();
+  });
+
   afterEach(function () {
     jest.restoreAllMocks();
   });
@@ -67,6 +74,58 @@ describe('SearchQueryBuilder', function () {
       expect(
         screen.queryByRole('row', {name: 'browser.name:firefox'})
       ).not.toBeInTheDocument();
+    });
+
+    it('can switch between interfaces', async function () {
+      render(
+        <SearchQueryBuilder {...defaultProps} initialQuery="browser.name:firefox" />
+      );
+
+      // Displays in tokenized mode by default
+      expect(screen.getByRole('row', {name: 'browser.name:firefox'})).toBeInTheDocument();
+
+      await userEvent.click(screen.getByRole('button', {name: 'Switch to plain text'}));
+
+      // No longer displays tokens, has an input instead
+      expect(
+        screen.queryByRole('row', {name: 'browser.name:firefox'})
+      ).not.toBeInTheDocument();
+      expect(screen.getByRole('textbox')).toHaveValue('browser.name:firefox');
+
+      // Switching back should restore the tokens
+      await userEvent.click(
+        screen.getByRole('button', {name: 'Switch to tokenized search'})
+      );
+      expect(screen.getByRole('row', {name: 'browser.name:firefox'})).toBeInTheDocument();
+    });
+  });
+
+  describe('plain text interface', function () {
+    beforeEach(() => {
+      localStorageWrapper.setItem(
+        INTERFACE_TYPE_LOCALSTORAGE_KEY,
+        JSON.stringify(QueryInterfaceType.TEXT)
+      );
+    });
+
+    it('can change the query by typing', async function () {
+      const mockOnChange = jest.fn();
+      render(
+        <SearchQueryBuilder
+          {...defaultProps}
+          initialQuery="browser.name:firefox"
+          onChange={mockOnChange}
+        />
+      );
+
+      expect(screen.getByRole('textbox')).toHaveValue('browser.name:firefox');
+      await userEvent.type(screen.getByRole('textbox'), ' assigned:me');
+
+      expect(screen.getByRole('textbox')).toHaveValue('browser.name:firefox assigned:me');
+
+      await waitFor(() => {
+        expect(mockOnChange).toHaveBeenLastCalledWith('browser.name:firefox assigned:me');
+      });
     });
   });
 

--- a/static/app/components/searchQueryBuilder/index.tsx
+++ b/static/app/components/searchQueryBuilder/index.tsx
@@ -1,9 +1,5 @@
-import {useMemo, useRef} from 'react';
+import {useMemo} from 'react';
 import styled from '@emotion/styled';
-import type {AriaGridListOptions} from '@react-aria/gridlist';
-import {Item} from '@react-stately/collections';
-import {useListState} from '@react-stately/list';
-import type {CollectionChildren} from '@react-types/shared';
 
 import {Button} from 'sentry/components/button';
 import {inputStyles} from 'sentry/components/input';
@@ -11,25 +7,22 @@ import {
   SearchQueryBuilerContext,
   useSearchQueryBuilder,
 } from 'sentry/components/searchQueryBuilder/context';
-import {SearchQueryBuilderFilter} from 'sentry/components/searchQueryBuilder/filter';
-import {SearchQueryBuilderInput} from 'sentry/components/searchQueryBuilder/input';
-import {useQueryBuilderGrid} from 'sentry/components/searchQueryBuilder/useQueryBuilderGrid';
+import {PlainTextQueryInput} from 'sentry/components/searchQueryBuilder/plainTextQueryInput';
+import {TokenizedQueryGrid} from 'sentry/components/searchQueryBuilder/tokenizedQueryGrid';
+import {QueryInterfaceType} from 'sentry/components/searchQueryBuilder/types';
 import {useQueryBuilderState} from 'sentry/components/searchQueryBuilder/useQueryBuilderState';
 import {
   collapseTextTokens,
-  makeTokenKey,
+  INTERFACE_TYPE_LOCALSTORAGE_KEY,
 } from 'sentry/components/searchQueryBuilder/utils';
-import {
-  type ParseResultToken,
-  parseSearch,
-  Token,
-} from 'sentry/components/searchSyntax/parser';
-import {IconClose, IconSearch} from 'sentry/icons';
+import {parseSearch} from 'sentry/components/searchSyntax/parser';
+import {IconClose, IconSearch, IconSync} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {Tag, TagCollection} from 'sentry/types';
 import PanelProvider from 'sentry/utils/panelProvider';
 import {useEffectAfterFirstRender} from 'sentry/utils/useEffectAfterFirstRender';
+import {useSyncedLocalStorageState} from 'sentry/utils/useSyncedLocalStorageState';
 
 interface SearchQueryBuilderProps {
   getTagValues: (key: Tag, query: string) => Promise<string[]>;
@@ -39,56 +32,35 @@ interface SearchQueryBuilderProps {
   onChange?: (query: string) => void;
 }
 
-interface GridProps extends AriaGridListOptions<ParseResultToken> {
-  children: CollectionChildren<ParseResultToken>;
-  items: ParseResultToken[];
-}
-
-function Grid(props: GridProps) {
-  const ref = useRef<HTMLDivElement>(null);
-  const state = useListState<ParseResultToken>(props);
-  const {gridProps} = useQueryBuilderGrid(props, state, ref);
-
-  return (
-    <SearchQueryGridWrapper {...gridProps} ref={ref}>
-      <PositionedSearchIcon size="sm" />
-      {[...state.collection].map(item => {
-        const token = item.value;
-
-        switch (token?.type) {
-          case Token.FILTER:
-            return (
-              <SearchQueryBuilderFilter
-                key={item.key}
-                token={token}
-                item={item}
-                state={state}
-              />
-            );
-          case Token.FREE_TEXT:
-          case Token.SPACES:
-            return (
-              <SearchQueryBuilderInput
-                key={item.key}
-                token={token}
-                item={item}
-                state={state}
-              />
-            );
-          // TODO(malwilley): Add other token types
-          default:
-            return null;
-        }
-      })}
-    </SearchQueryGridWrapper>
-  );
-}
-
 function ActionButtons() {
-  const {dispatch} = useSearchQueryBuilder();
+  const {parsedQuery, dispatch} = useSearchQueryBuilder();
+  const [queryInterface, setQueryInterface] = useSyncedLocalStorageState(
+    INTERFACE_TYPE_LOCALSTORAGE_KEY,
+    QueryInterfaceType.TOKENIZED
+  );
+
+  const interfaceToggleText =
+    queryInterface === QueryInterfaceType.TEXT
+      ? t('Switch to tokenized search')
+      : t('Switch to plain text');
 
   return (
     <ButtonsWrapper>
+      <ActionButton
+        title={interfaceToggleText}
+        aria-label={interfaceToggleText}
+        size="zero"
+        icon={<IconSync />}
+        borderless
+        onClick={() =>
+          setQueryInterface(
+            queryInterface === QueryInterfaceType.TEXT
+              ? QueryInterfaceType.TOKENIZED
+              : QueryInterfaceType.TEXT
+          )
+        }
+        disabled={!parsedQuery}
+      />
       <ActionButton
         aria-label={t('Clear search query')}
         size="zero"
@@ -108,6 +80,10 @@ export function SearchQueryBuilder({
   onChange,
 }: SearchQueryBuilderProps) {
   const {state, dispatch} = useQueryBuilderState({initialQuery});
+  const [queryInterface] = useSyncedLocalStorageState(
+    INTERFACE_TYPE_LOCALSTORAGE_KEY,
+    QueryInterfaceType.TOKENIZED
+  );
 
   const parsedQuery = useMemo(
     () => collapseTextTokens(parseSearch(state.query || ' ')),
@@ -128,21 +104,16 @@ export function SearchQueryBuilder({
     };
   }, [state, parsedQuery, supportedKeys, getTagValues, dispatch]);
 
-  if (!parsedQuery) {
-    return null;
-  }
-
   return (
     <SearchQueryBuilerContext.Provider value={contextValue}>
       <PanelProvider>
         <Wrapper>
-          <Grid aria-label={label ?? t('Create a search query')} items={parsedQuery}>
-            {item => (
-              <Item key={makeTokenKey(item, parsedQuery)}>
-                {item.text.trim() ? item.text : t('Space')}
-              </Item>
-            )}
-          </Grid>
+          <PositionedSearchIcon size="sm" />
+          {!parsedQuery || queryInterface === QueryInterfaceType.TEXT ? (
+            <PlainTextQueryInput label={label} />
+          ) : (
+            <TokenizedQueryGrid label={label} />
+          )}
           <ActionButtons />
         </Wrapper>
       </PanelProvider>
@@ -151,21 +122,13 @@ export function SearchQueryBuilder({
 }
 
 const Wrapper = styled('div')`
+  ${inputStyles}
+  min-height: 38px;
+  padding: 0;
+  height: auto;
   width: 100%;
   position: relative;
-`;
-
-const SearchQueryGridWrapper = styled('div')`
-  ${inputStyles}
-  height: auto;
-  position: relative;
-
-  display: flex;
-  align-items: stretch;
-  row-gap: ${space(0.5)};
-  flex-wrap: wrap;
   font-size: ${p => p.theme.fontSizeMedium};
-  padding: ${space(0.75)} 36px ${space(0.75)} 36px;
   cursor: text;
 
   :focus-within {
@@ -180,6 +143,7 @@ const ButtonsWrapper = styled('div')`
   top: 9px;
   display: flex;
   align-items: center;
+  gap: ${space(0.5)};
 `;
 
 const ActionButton = styled(Button)`

--- a/static/app/components/searchQueryBuilder/plainTextQueryInput.tsx
+++ b/static/app/components/searchQueryBuilder/plainTextQueryInput.tsx
@@ -1,0 +1,113 @@
+import {
+  type ChangeEvent,
+  type SyntheticEvent,
+  useCallback,
+  useRef,
+  useState,
+} from 'react';
+import styled from '@emotion/styled';
+
+import {useSearchQueryBuilder} from 'sentry/components/searchQueryBuilder/context';
+import HighlightQuery from 'sentry/components/searchSyntax/renderer';
+import {space} from 'sentry/styles/space';
+
+interface PlainTextQueryInputProps {
+  label?: string;
+}
+
+export function PlainTextQueryInput({label}: PlainTextQueryInputProps) {
+  const inputRef = useRef<HTMLTextAreaElement>(null);
+  const {query, parsedQuery, dispatch} = useSearchQueryBuilder();
+  const [cursorPosition, setCursorPosition] = useState(0);
+
+  const handler = (event: SyntheticEvent<HTMLTextAreaElement>) => {
+    if (event.currentTarget !== document.activeElement) {
+      setCursorPosition(-1);
+    } else {
+      setCursorPosition(event.currentTarget.selectionStart);
+    }
+  };
+
+  const onChange = useCallback(
+    (e: ChangeEvent<HTMLTextAreaElement>) => {
+      setCursorPosition(e.target.selectionStart);
+      dispatch({type: 'UPDATE_QUERY', query: e.target.value});
+    },
+    [dispatch]
+  );
+
+  return (
+    <InputWrapper>
+      {parsedQuery ? (
+        <Highlight>
+          <HighlightQuery parsedQuery={parsedQuery} cursorPosition={cursorPosition} />
+        </Highlight>
+      ) : null}
+      <InvisibleInput
+        aria-label={label}
+        ref={inputRef}
+        autoComplete="off"
+        value={query}
+        onFocus={handler}
+        onBlur={handler}
+        onKeyUp={handler}
+        onKeyDown={handler}
+        onChange={onChange}
+        onClick={handler}
+        onPaste={handler}
+        spellCheck={false}
+      />
+    </InputWrapper>
+  );
+}
+
+const InputWrapper = styled('div')`
+  position: relative;
+  width: 100%;
+  height: 100%;
+`;
+
+const Highlight = styled('div')`
+  padding: ${space(0.75)} 48px ${space(0.75)} 44px;
+  width: 100%;
+  height: 100%;
+  user-select: none;
+  white-space: pre-wrap;
+  word-break: break-word;
+  line-height: 24px;
+  font-size: ${p => p.theme.fontSizeSmall};
+  font-family: ${p => p.theme.text.familyMono};
+`;
+
+const InvisibleInput = styled('textarea')`
+  padding: ${space(0.75)} 48px ${space(0.75)} 44px;
+  position: absolute;
+  inset: 0;
+  resize: none;
+  outline: none;
+  border: 0;
+  width: 100%;
+  line-height: 25px;
+  margin-bottom: -1px;
+  background: transparent;
+  font-size: ${p => p.theme.fontSizeSmall};
+  font-family: ${p => p.theme.text.familyMono};
+  caret-color: ${p => p.theme.subText};
+  color: transparent;
+
+  &::selection {
+    background: rgba(0, 0, 0, 0.2);
+  }
+  &::placeholder {
+    color: ${p => p.theme.formPlaceholder};
+  }
+  :placeholder-shown {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  [disabled] {
+    color: ${p => p.theme.disabled};
+  }
+`;

--- a/static/app/components/searchQueryBuilder/tokenizedQueryGrid.tsx
+++ b/static/app/components/searchQueryBuilder/tokenizedQueryGrid.tsx
@@ -1,0 +1,90 @@
+import {useRef} from 'react';
+import styled from '@emotion/styled';
+import type {AriaGridListOptions} from '@react-aria/gridlist';
+import {Item} from '@react-stately/collections';
+import {useListState} from '@react-stately/list';
+import type {CollectionChildren} from '@react-types/shared';
+
+import {useSearchQueryBuilder} from 'sentry/components/searchQueryBuilder/context';
+import {SearchQueryBuilderFilter} from 'sentry/components/searchQueryBuilder/filter';
+import {SearchQueryBuilderInput} from 'sentry/components/searchQueryBuilder/input';
+import {useQueryBuilderGrid} from 'sentry/components/searchQueryBuilder/useQueryBuilderGrid';
+import {makeTokenKey} from 'sentry/components/searchQueryBuilder/utils';
+import {type ParseResultToken, Token} from 'sentry/components/searchSyntax/parser';
+import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
+
+interface TokenizedQueryGridProps {
+  label?: string;
+}
+
+interface GridProps extends AriaGridListOptions<ParseResultToken> {
+  children: CollectionChildren<ParseResultToken>;
+  items: ParseResultToken[];
+}
+
+function Grid(props: GridProps) {
+  const ref = useRef<HTMLDivElement>(null);
+  const state = useListState<ParseResultToken>(props);
+  const {gridProps} = useQueryBuilderGrid(props, state, ref);
+
+  return (
+    <SearchQueryGridWrapper {...gridProps} ref={ref}>
+      {[...state.collection].map(item => {
+        const token = item.value;
+
+        switch (token?.type) {
+          case Token.FILTER:
+            return (
+              <SearchQueryBuilderFilter
+                key={item.key}
+                token={token}
+                item={item}
+                state={state}
+              />
+            );
+          case Token.FREE_TEXT:
+          case Token.SPACES:
+            return (
+              <SearchQueryBuilderInput
+                key={item.key}
+                token={token}
+                item={item}
+                state={state}
+              />
+            );
+          // TODO(malwilley): Add other token types
+          default:
+            return null;
+        }
+      })}
+    </SearchQueryGridWrapper>
+  );
+}
+
+export function TokenizedQueryGrid({label}: TokenizedQueryGridProps) {
+  const {parsedQuery} = useSearchQueryBuilder();
+
+  // Shouldn't ever get here since we will render the plain text input instead
+  if (!parsedQuery) {
+    return null;
+  }
+
+  return (
+    <Grid aria-label={label ?? t('Create a search query')} items={parsedQuery}>
+      {item => (
+        <Item key={makeTokenKey(item, parsedQuery)}>
+          {item.text.trim() ? item.text : t('Space')}
+        </Item>
+      )}
+    </Grid>
+  );
+}
+
+const SearchQueryGridWrapper = styled('div')`
+  padding: ${space(0.75)} 48px ${space(0.75)} 36px;
+  display: flex;
+  align-items: stretch;
+  row-gap: ${space(0.5)};
+  flex-wrap: wrap;
+`;

--- a/static/app/components/searchQueryBuilder/types.tsx
+++ b/static/app/components/searchQueryBuilder/types.tsx
@@ -1,0 +1,4 @@
+export enum QueryInterfaceType {
+  TEXT = 'text',
+  TOKENIZED = 'tokenized',
+}

--- a/static/app/components/searchQueryBuilder/useQueryBuilderState.tsx
+++ b/static/app/components/searchQueryBuilder/useQueryBuilderState.tsx
@@ -14,6 +14,8 @@ type QueryBuilderState = {
 
 type ClearAction = {type: 'CLEAR'};
 
+type UpdateQueryAction = {query: string; type: 'UPDATE_QUERY'};
+
 type DeleteTokenAction = {
   token: ParseResultToken;
   type: 'DELETE_TOKEN';
@@ -50,6 +52,7 @@ type DeleteLastMultiSelectFilterValueAction = {
 
 export type QueryBuilderActions =
   | ClearAction
+  | UpdateQueryAction
   | DeleteTokenAction
   | UpdateFreeTextAction
   | UpdateFilterOpAction
@@ -187,6 +190,10 @@ export function useQueryBuilderState({initialQuery}: {initialQuery: string}) {
         case 'CLEAR':
           return {
             query: '',
+          };
+        case 'UPDATE_QUERY':
+          return {
+            query: action.query,
           };
         case 'DELETE_TOKEN':
           return {

--- a/static/app/components/searchQueryBuilder/utils.tsx
+++ b/static/app/components/searchQueryBuilder/utils.tsx
@@ -9,6 +9,8 @@ import {
 } from 'sentry/components/searchSyntax/parser';
 import {escapeDoubleQuotes} from 'sentry/utils';
 
+export const INTERFACE_TYPE_LOCALSTORAGE_KEY = 'search-query-builder-interface';
+
 /**
  * Generates a unique key for the given token.
  *


### PR DESCRIPTION
Closes https://github.com/getsentry/sentry/issues/69734

Adds a button to switch to a plain text input, similar to the old experience. Uses the same renderer to apply syntax highlighting.

https://github.com/getsentry/sentry/assets/10888943/3d41dc01-9832-4c20-8ed5-58243d394e60

