### PR TITLE
chore(api): Make `UserDetailsEndpoint` Private

### DIFF
--- a/src/sentry/api/endpoints/user_details.py
+++ b/src/sentry/api/endpoints/user_details.py
@@ -150,9 +150,9 @@ class DeleteUserSerializer(serializers.Serializer):
 @control_silo_endpoint
 class UserDetailsEndpoint(UserEndpoint):
     publish_status = {
-        "DELETE": ApiPublishStatus.UNKNOWN,
-        "GET": ApiPublishStatus.UNKNOWN,
-        "PUT": ApiPublishStatus.UNKNOWN,
+        "DELETE": ApiPublishStatus.PRIVATE,
+        "GET": ApiPublishStatus.PRIVATE,
+        "PUT": ApiPublishStatus.PRIVATE,
     }
 
     permission_classes = (UserAndStaffPermission,)


### PR DESCRIPTION
This pr marks UserDetailsEndpoint as private. 

The endpoint gives a user's information, including all the orgs they are part of and the authenticators associated with their account. Currently it can only be hit by the user themself & staff. The endpoint requires a user to know their id, which isn't something we ever surface.

For: https://github.com/getsentry/team-core-product-foundations/issues/325
