### PR TITLE
fix(notifications): Fix spend notifications toggle

### DIFF
--- a/static/app/views/settings/account/notifications/fields2.tsx
+++ b/static/app/views/settings/account/notifications/fields2.tsx
@@ -221,7 +221,7 @@ export const QUOTA_FIELDS = [
 
 export const SPEND_FIELDS = [
   {
-    name: 'quotaWarnings',
+    name: 'quota',
     label: t('Spend Notifications'),
     help: tct(
       'Receive notifications when your spend crosses predefined or custom thresholds. [learnMore:Learn more]',

--- a/static/app/views/settings/account/notifications/notificationSettingsByType.spec.tsx
+++ b/static/app/views/settings/account/notifications/notificationSettingsByType.spec.tsx
@@ -275,4 +275,44 @@ describe('NotificationSettingsByType', function () {
       screen.getByText('Control the notifications you receive for organization spend.')
     ).toBeInTheDocument();
   });
+
+  it('toggle user spend notifications', async function () {
+    const organizationWithFlag = OrganizationFixture();
+    organizationWithFlag.features.push('spend-visibility-notifications');
+    const organizationNoFlag = OrganizationFixture();
+    renderComponent({
+      notificationType: 'quota',
+      organizations: [organizationWithFlag, organizationNoFlag],
+    });
+
+    expect(await screen.getAllByText('Spend Notifications').length).toEqual(2);
+
+    const editSettingMock = MockApiClient.addMockResponse({
+      url: `/users/me/notification-options/`,
+      method: 'PUT',
+      body: {
+        id: '7',
+        scopeIdentifier: '1',
+        scopeType: 'user',
+        type: 'quota',
+        value: 'never',
+      },
+    });
+
+    // toggle spend notifications off
+    await selectEvent.select(screen.getAllByText('On')[0], 'Off');
+
+    expect(editSettingMock).toHaveBeenCalledTimes(1);
+    expect(editSettingMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        data: {
+          scopeIdentifier: '1',
+          scopeType: 'user',
+          type: 'quota',
+          value: 'never',
+        },
+      })
+    );
+  });
 });


### PR DESCRIPTION
Toggling "Spend Notifications" on or off is incorrectly toggling `quotaWarnings`, when it should toggle `quota`.

This should match the behaviour for when a user disables all spend notifications here: https://github.com/getsentry/getsentry/blob/c23c7015194f75b9dd9f68c4685a550cc4d40289/tests/getsentry/tasks/test_quota_thresholds.py#L2032-L2043