### PR TITLE
chore(billing): Remove metrics notification type

### DIFF
--- a/src/sentry/notifications/defaults.py
+++ b/src/sentry/notifications/defaults.py
@@ -21,7 +21,6 @@ NOTIFICATION_SETTINGS_TYPE_DEFAULTS = {
     NotificationSettingEnum.QUOTA_MONITOR_SEATS: NotificationSettingsOptionEnum.ALWAYS,
     NotificationSettingEnum.QUOTA_SPANS: NotificationSettingsOptionEnum.ALWAYS,
     NotificationSettingEnum.QUOTA_PROFILE_DURATION: NotificationSettingsOptionEnum.ALWAYS,
-    NotificationSettingEnum.QUOTA_METRIC_SECONDS: NotificationSettingsOptionEnum.ALWAYS,
     NotificationSettingEnum.QUOTA_WARNINGS: NotificationSettingsOptionEnum.ALWAYS,
     NotificationSettingEnum.QUOTA_SPEND_ALLOCATIONS: NotificationSettingsOptionEnum.ALWAYS,
     NotificationSettingEnum.QUOTA_THRESHOLDS: NotificationSettingsOptionEnum.ALWAYS,

--- a/src/sentry/notifications/types.py
+++ b/src/sentry/notifications/types.py
@@ -29,7 +29,6 @@ class NotificationSettingEnum(ValueEqualityEnum):
     QUOTA_MONITOR_SEATS = "quotaMonitorSeats"
     QUOTA_SPANS = "quotaSpans"
     QUOTA_PROFILE_DURATION = "quotaProfileDuration"
-    QUOTA_METRIC_SECONDS = "quotaMetricSeconds"
     QUOTA_SPEND_ALLOCATIONS = "quotaSpendAllocations"
     SPIKE_PROTECTION = "spikeProtection"
     MISSING_MEMBERS = "missingMembers"
@@ -119,10 +118,6 @@ VALID_VALUES_FOR_KEY = {
         NotificationSettingsOptionEnum.NEVER,
     },
     NotificationSettingEnum.QUOTA_PROFILE_DURATION: {
-        NotificationSettingsOptionEnum.ALWAYS,
-        NotificationSettingsOptionEnum.NEVER,
-    },
-    NotificationSettingEnum.QUOTA_METRIC_SECONDS: {
         NotificationSettingsOptionEnum.ALWAYS,
         NotificationSettingsOptionEnum.NEVER,
     },

--- a/tests/sentry/api/endpoints/test_notification_defaults.py
+++ b/tests/sentry/api/endpoints/test_notification_defaults.py
@@ -27,7 +27,6 @@ class NotificationDefaultTest(APITestCase):
                 "quotaMonitorSeats": "always",
                 "quotaSpans": "always",
                 "quotaProfileDuration": "always",
-                "quotaMetricSeconds": "always",
                 "reports": "always",
                 "spikeProtection": "always",
                 "workflow": "subscribe_only",


### PR DESCRIPTION
We're no longer need the metrics notification type.

The profile notification type will be retained as we will be shipping that later on.