### PR TITLE
fix(relay): Update react error patterns

### DIFF
--- a/src/sentry/relay/config/__init__.py
+++ b/src/sentry/relay/config/__init__.py
@@ -159,7 +159,8 @@ def get_filter_settings(project: Project) -> Mapping[str, Any]:
         # 423 - There was an error while hydrating. Because the error happened outside of a Suspense boundary, the entire root will switch to client rendering.
         # 425 - Text content does not match server-rendered HTML.
         error_messages += [
-            "*https://reactjs.org/docs/error-decoder.html?invariant={418,419,422,423,425}*"
+            "*https://reactjs.org/docs/error-decoder.html?invariant={418,419,422,423,425}*",
+            "*https://react.dev/errors/{418,419,422,423,425}*",
         ]
 
     if project.get_option("filters:chunk-load-error") == "1":

--- a/tests/sentry/relay/snapshots/test_config/test_get_project_config/full_config/MONOLITH.pysnap
+++ b/tests/sentry/relay/snapshots/test_config/test_get_project_config/full_config/MONOLITH.pysnap
@@ -83,6 +83,7 @@ config:
     errorMessages:
       patterns:
       - '*https://reactjs.org/docs/error-decoder.html?invariant={418,419,422,423,425}*'
+      - '*https://react.dev/errors/{418,419,422,423,425}*'
       - 'ChunkLoadError: Loading chunk *'
     ignoreTransactions:
       isEnabled: true

--- a/tests/sentry/relay/snapshots/test_config/test_get_project_config/full_config/REGION.pysnap
+++ b/tests/sentry/relay/snapshots/test_config/test_get_project_config/full_config/REGION.pysnap
@@ -83,6 +83,7 @@ config:
     errorMessages:
       patterns:
       - '*https://reactjs.org/docs/error-decoder.html?invariant={418,419,422,423,425}*'
+      - '*https://react.dev/errors/{418,419,422,423,425}*'
       - 'ChunkLoadError: Loading chunk *'
       - '*Uncaught *: ChunkLoadError: Loading chunk *'
     ignoreTransactions:


### PR DESCRIPTION
<!-- Describe your PR here. -->

In recent React releases, the official domain for React documentation has changed from reactjs.org to react.dev. The `react-hydration-errors` inbound filter uses React’s website URLs in error messages to match errors. This pull request updates the URL patterns to include the new react.dev domain.

This also fixes #70119

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
