### PR TITLE
fix(ui) Fix URL generation for orgs with accounts in the slug

### DIFF
--- a/src/sentry/api/utils.py
+++ b/src/sentry/api/utils.py
@@ -310,13 +310,13 @@ _path_patterns: list[tuple[re.Pattern[str], str]] = [
     (re.compile(r"\/?organizations\/(?!new)[^\/]+\/(.*)"), r"/\1"),
     # For /settings/:orgId/ -> /settings/organization/
     (
-        re.compile(r"\/settings\/(?!account)(?!billing)(?!projects)(?!teams)[^\/]+\/?$"),
+        re.compile(r"\/settings\/(?!account\/|!billing\/|projects\/|teams)[^\/]+\/?$"),
         "/settings/organization/",
     ),
     # Move /settings/:orgId/:section -> /settings/:section
     # but not /settings/organization or /settings/projects which is a new URL
     (
-        re.compile(r"^\/?settings\/(?!account)(?!billing)(?!projects)(?!teams)[^\/]+\/(.*)"),
+        re.compile(r"^\/?settings\/(?!account\/|billing\/|projects\/|teams)[^\/]+\/(.*)"),
         r"/settings/\1",
     ),
     (re.compile(r"^\/?join-request\/[^\/]+\/?.*"), r"/join-request/"),

--- a/static/app/utils/withDomainRequired.spec.tsx
+++ b/static/app/utils/withDomainRequired.spec.tsx
@@ -47,6 +47,19 @@ describe('normalizeUrl', function () {
         '/settings/sentry-organizations/integrations/vercel/12345/?next=something',
         '/settings/integrations/vercel/12345/?next=something',
       ],
+      // Settings views for orgs with acccount/billing in their slugs.
+      ['/settings/account-on/', '/settings/organization/'],
+      ['/settings/billing-co/', '/settings/organization/'],
+      ['/settings/account-on/integrations/', '/settings/integrations/'],
+      [
+        '/settings/account-on/projects/billing-app/source-maps/',
+        '/settings/projects/billing-app/source-maps/',
+      ],
+      ['/settings/billing-co/integrations/', '/settings/integrations/'],
+      [
+        '/settings/billing-co/projects/billing-app/source-maps/',
+        '/settings/projects/billing-app/source-maps/',
+      ],
       // Account settings should stay the same
       ['/settings/account/', '/settings/account/'],
       ['/settings/account/security/', '/settings/account/security/'],

--- a/static/app/utils/withDomainRequired.tsx
+++ b/static/app/utils/withDomainRequired.tsx
@@ -9,13 +9,13 @@ const NORMALIZE_PATTERNS: Array<[pattern: RegExp, replacement: string]> = [
   [/\/organizations\/(?!new)[^\/]+\/(.*)/, '/$1'],
   // For /settings/:orgId/ -> /settings/organization/
   [
-    /\/settings\/(?!account)(?!billing)(?!projects)(?!teams)[^\/]+\/?$/,
+    /\/settings\/(?!account\/|billing\/|projects\/|teams\/)[^\/]+\/?$/,
     '/settings/organization/',
   ],
   // Move /settings/:orgId/:section -> /settings/:section
   // but not /settings/organization or /settings/projects which is a new URL
   [
-    /^\/?settings\/(?!account)(?!billing)(?!projects)(?!teams)[^\/]+\/(.*)/,
+    /^\/?settings\/(?!account\/|billing\/|projects\/|teams\/)[^\/]+\/(.*)/,
     '/settings/$1',
   ],
   [/^\/?join-request\/[^\/]+\/?.*/, '/join-request/'],

--- a/tests/sentry/api/test_utils.py
+++ b/tests/sentry/api/test_utils.py
@@ -181,6 +181,19 @@ def test_customer_domain_path():
             "/settings/acme/developer-settings/release-bot/",
             "/settings/developer-settings/release-bot/",
         ],
+        # Settings views for orgs with acccount/billing in their slugs.
+        ["/settings/account-on/", "/settings/organization/"],
+        ["/settings/billing-co/", "/settings/organization/"],
+        ["/settings/account-on/integrations/", "/settings/integrations/"],
+        [
+            "/settings/account-on/projects/billing-app/source-maps/",
+            "/settings/projects/billing-app/source-maps/",
+        ],
+        ["/settings/billing-co/integrations/", "/settings/integrations/"],
+        [
+            "/settings/billing-co/projects/billing-app/source-maps/",
+            "/settings/projects/billing-app/source-maps/",
+        ],
         # Account settings should stay the same
         ["/settings/account/", "/settings/account/"],
         ["/settings/account/security/", "/settings/account/security/"],


### PR DESCRIPTION
For orgs with accounts* in their slug settings URL generation wasn't working correctly and resulted in additional client side redirects and broken links.