### PR TITLE
test(ui): Skip test in searchQueryBuilder due to flakiness

### DIFF
--- a/static/app/components/searchQueryBuilder/index.spec.tsx
+++ b/static/app/components/searchQueryBuilder/index.spec.tsx
@@ -76,7 +76,8 @@ describe('SearchQueryBuilder', function () {
       ).not.toBeInTheDocument();
     });
 
-    it('can switch between interfaces', async function () {
+    // biome-ignore lint/suspicious/noSkippedTests: This test flakes in CI due to an act warning in Tooltip
+    it.skip('can switch between interfaces', async function () {
       render(
         <SearchQueryBuilder {...defaultProps} initialQuery="browser.name:firefox" />
       );


### PR DESCRIPTION
We are already using userEvent and waitFor, so I don't see any other way to avoid this act warning. Have only seen this in CI - here's an example https://github.com/getsentry/sentry/actions/runs/9293960493/job/25578197801