### PR TITLE
feat(related_issues): Generate title and subtitle from events data

### DIFF
--- a/static/app/views/issueDetails/traceTimeline/traceIssue.tsx
+++ b/static/app/views/issueDetails/traceTimeline/traceIssue.tsx
@@ -3,14 +3,10 @@ import styled from '@emotion/styled';
 
 import ProjectBadge from 'sentry/components/idBadge/projectBadge';
 import Link from 'sentry/components/links/link';
-import LoadingIndicator from 'sentry/components/loadingIndicator';
 import Placeholder from 'sentry/components/placeholder';
 import {space} from 'sentry/styles/space';
-import type {Group} from 'sentry/types/group';
-import {useApiQuery} from 'sentry/utils/queryClient';
 import useOrganization from 'sentry/utils/useOrganization';
 import useProjectFromSlug from 'sentry/utils/useProjectFromSlug';
-import {getGroupDetailsQueryData} from 'sentry/views/issueDetails/utils';
 
 import type {TimelineEvent} from './useTraceTimelineEvents';
 
@@ -22,71 +18,61 @@ export function TraceIssueEvent({event}: TraceIssueEventProps) {
   const organization = useOrganization();
   const project = useProjectFromSlug({organization, projectSlug: event['project.name']});
   const issueId = event['issue.id'];
-  // We are view issue X and loading data for issue Y. This means that this call will not be cached,
-  // thus, it is a little bit slow to render the component.
-  // XXX: Create new endpoint that only fetches the metadata for the group
-  const {data: groupData, isLoading: isLoadingGroupData} = useApiQuery<Group>(
-    [
-      `/organizations/${organization.slug}/issues/${issueId}/`,
-      {query: getGroupDetailsQueryData({})},
-    ],
-    {
-      staleTime: 30000,
-      cacheTime: 30000,
-      retry: false,
-    }
-  );
+  const {title, subtitle} = getTitleSubtitle(event);
   const avatarSize = parseInt(space(4), 10);
 
   // If any of data fails to load, we don't want to render the component
   // Only "One other issue appears in the same trace. View Full Trace (X issues)" would show up
   return (
     <Fragment>
-      {isLoadingGroupData ? (
-        <LoadingIndicator mini />
-      ) : (
-        groupData && (
-          // XXX: Determine plan for analytics
-          <TraceIssueLinkContainer
-            to={{
-              pathname: `/organizations/${organization.slug}/issues/${issueId}/events/${event.id}/`,
-              query: {
-                referrer: 'issues_trace_issue',
-              },
-            }}
-          >
-            <TraceIssueProjectBadge>
-              {project ? (
-                <ProjectBadge
-                  project={project}
-                  avatarSize={avatarSize}
-                  hideName
-                  disableLink
-                />
-              ) : (
-                <Placeholder
-                  shape="rect"
-                  width={`${projectBadgeSize}px`}
-                  height={`${projectBadgeSize}px`}
-                />
-              )}
-            </TraceIssueProjectBadge>
-            <TraceIssueDetailsContainer>
-              <NoOverflowDiv>
-                <TraceIssueEventTitle>
-                  {groupData.metadata.title || groupData.metadata.type}
-                </TraceIssueEventTitle>
-                <TraceIssueEventTransaction>
-                  {event.transaction}
-                </TraceIssueEventTransaction>
-              </NoOverflowDiv>
-              <NoOverflowDiv>{groupData.metadata.value}</NoOverflowDiv>
-            </TraceIssueDetailsContainer>
-          </TraceIssueLinkContainer>
-        )
-      )}
+      {/* // XXX: Determine plan for analytics */}
+      <TraceIssueLinkContainer
+        to={{
+          pathname: `/organizations/${organization.slug}/issues/${issueId}/events/${event.id}/`,
+          query: {
+            referrer: 'issues_trace_issue',
+          },
+        }}
+      >
+        <TraceIssueProjectBadge>
+          {project ? (
+            <ProjectBadge
+              project={project}
+              avatarSize={avatarSize}
+              hideName
+              disableLink
+            />
+          ) : (
+            <Placeholder
+              shape="rect"
+              width={`${projectBadgeSize}px`}
+              height={`${projectBadgeSize}px`}
+            />
+          )}
+        </TraceIssueProjectBadge>
+        <TraceIssueDetailsContainer>
+          <NoOverflowDiv>
+            <TraceIssueEventTitle>{title}</TraceIssueEventTitle>
+            <TraceIssueEventTransaction>{event.transaction}</TraceIssueEventTransaction>
+          </NoOverflowDiv>
+          <NoOverflowDiv>{subtitle}</NoOverflowDiv>
+        </TraceIssueDetailsContainer>
+      </TraceIssueLinkContainer>
     </Fragment>
   );
+}
+
+function getTitleSubtitle(event: TimelineEvent) {
+  let title;
+  let subtitle;
+  if (event['event.type'] === 'error') {
+    title = event.title.split(':')[0];
+    subtitle = event.message;
+  } else {
+    title = event.title;
+    subtitle = event.message.replace(event.transaction, '').replace(title, '');
+  }
+  return {title, subtitle};
 }
 
 const TraceIssueLinkContainer = styled(Link)`

--- a/static/app/views/issueDetails/traceTimeline/traceLink.spec.tsx
+++ b/static/app/views/issueDetails/traceTimeline/traceLink.spec.tsx
@@ -23,6 +23,8 @@ describe('TraceLink', () => {
   const issuePlatformBody: TraceEventResponse = {
     data: [
       {
+        // In issuePlatform, we store the subtitle within the message
+        message: '/api/slow/ Slow DB Query SELECT "sentry_monitorcheckin"."monitor_id"',
         timestamp: '2024-01-24T09:09:03+00:00',
         'issue.id': 1000,
         project: project.slug,
@@ -37,6 +39,7 @@ describe('TraceLink', () => {
   const discoverBody: TraceEventResponse = {
     data: [
       {
+        message: 'This is the subtitle of the issue',
         timestamp: '2024-01-23T22:11:42+00:00',
         'issue.id': 4909507143,
         project: project.slug,

--- a/static/app/views/issueDetails/traceTimeline/traceTimeline.spec.tsx
+++ b/static/app/views/issueDetails/traceTimeline/traceTimeline.spec.tsx
@@ -31,6 +31,9 @@ describe('TraceTimeline', () => {
       {
         timestamp: '2024-01-24T09:09:03+00:00',
         'issue.id': 1000,
+        // In issuePlatform, we store the subtitle within the message
+        // XXX: File issue to fix this
+        message: '/api/slow/ Slow DB Query SELECT "sentry_monitorcheckin"."monitor_id"',
         project: project.slug,
         'project.name': project.name,
         title: 'Slow DB Query',
@@ -45,6 +48,7 @@ describe('TraceTimeline', () => {
       {
         timestamp: '2024-01-23T22:11:42+00:00',
         'issue.id': 4909507143,
+        message: 'Irrelevant for errors',
         project: project.slug,
         'project.name': project.name,
         title: 'AttributeError: Something Failed',
@@ -169,16 +173,6 @@ describe('TraceTimeline', () => {
     MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/projects/`,
       body: [],
-    });
-    // We need the metadata from the issue in order to render the related issue
-    MockApiClient.addMockResponse({
-      url: `/organizations/${organization.slug}/issues/1000/`,
-      body: {
-        metadata: {
-          title: 'Slow DB Query',
-          value: 'bar',
-        },
-      },
     });
 
     render(<TraceTimeline event={event} />, {

--- a/static/app/views/issueDetails/traceTimeline/traceTimeline.spec.tsx
+++ b/static/app/views/issueDetails/traceTimeline/traceTimeline.spec.tsx
@@ -29,11 +29,11 @@ describe('TraceTimeline', () => {
   const issuePlatformBody: TraceEventResponse = {
     data: [
       {
+        // In issuePlatform, we store the subtitle within the message
+        message: '/api/slow/ Slow DB Query SELECT "sentry_monitorcheckin"."monitor_id"',
         timestamp: '2024-01-24T09:09:03+00:00',
         'issue.id': 1000,
-        // In issuePlatform, we store the subtitle within the message
-        // XXX: File issue to fix this
-        message: '/api/slow/ Slow DB Query SELECT "sentry_monitorcheckin"."monitor_id"',
+
         project: project.slug,
         'project.name': project.name,
         title: 'Slow DB Query',
@@ -46,9 +46,9 @@ describe('TraceTimeline', () => {
   const discoverBody: TraceEventResponse = {
     data: [
       {
+        message: 'This is the subtitle of the issue',
         timestamp: '2024-01-23T22:11:42+00:00',
         'issue.id': 4909507143,
-        message: 'Irrelevant for errors',
         project: project.slug,
         'project.name': project.name,
         title: 'AttributeError: Something Failed',
@@ -183,6 +183,9 @@ describe('TraceTimeline', () => {
 
     // Instead of a timeline, we should see the other related issue
     expect(await screen.findByText('Slow DB Query')).toBeInTheDocument();
+    expect(
+      await screen.findByText('SELECT "sentry_monitorcheckin"."monitor_id"')
+    ).toBeInTheDocument();
     expect(screen.queryByLabelText('Current Event')).not.toBeInTheDocument();
     expect(useRouteAnalyticsParams).toHaveBeenCalledWith({
       trace_timeline_status: 'empty',

--- a/static/app/views/issueDetails/traceTimeline/useTraceTimelineEvents.tsx
+++ b/static/app/views/issueDetails/traceTimeline/useTraceTimelineEvents.tsx
@@ -9,6 +9,7 @@ import useOrganization from 'sentry/utils/useOrganization';
 interface BaseEvent {
   id: string;
   'issue.id': number;
+  message: string;
   project: string;
   'project.name': string;
   timestamp: string;
@@ -57,7 +58,7 @@ export function useTraceTimelineEvents({event}: UseTraceTimelineEventsOptions): 
         query: {
           // Get performance issues
           dataset: DiscoverDatasets.ISSUE_PLATFORM,
-          field: ['title', 'project', 'timestamp', 'issue.id', 'transaction'],
+          field: ['message', 'title', 'project', 'timestamp', 'issue.id', 'transaction'],
           per_page: 100,
           query: `trace:${traceId}`,
           referrer: 'api.issues.issue_events',
@@ -84,6 +85,7 @@ export function useTraceTimelineEvents({event}: UseTraceTimelineEventsOptions): 
           // Other events
           dataset: DiscoverDatasets.DISCOVER,
           field: [
+            'message',
             'title',
             'project',
             'timestamp',
@@ -129,6 +131,7 @@ export function useTraceTimelineEvents({event}: UseTraceTimelineEventsOptions): 
       events.push({
         id: event.id,
         'issue.id': Number(event.groupID),
+        message: event.message,
         project: event.projectID,
         // The project name for current event is not used
         'project.name': '',


### PR DESCRIPTION
We need to fix the metadata for events to store the title and subtitle to match how issues are rendered in the product.

This change is a hack to speed up the related issues feature while we figure out the right way of fixing the data incosistency.

The screenshot that both the error event and the issue platform cards match the title/subtitle from the issue details page.
![image](https://github.com/getsentry/sentry/assets/44410/1cb75ab9-2bfd-4d6a-b5f4-52025919313c)