### PR TITLE
feat(priority-alerts): Change the default alert condition to NewHighPriorityIssueCondition

### DIFF
--- a/static/app/types/alerts.tsx
+++ b/static/app/types/alerts.tsx
@@ -39,7 +39,7 @@ export const enum IssueAlertConditionType {
   EVENT_FREQUENCY = 'sentry.rules.conditions.event_frequency.EventFrequencyCondition',
   EVENT_UNIQUE_USER_FREQUENCY = 'sentry.rules.conditions.event_frequency.EventUniqueUserFrequencyCondition',
   EVENT_FREQUENCY_PERCENT = 'sentry.rules.conditions.event_frequency.EventFrequencyPercentCondition',
-  NEW_HIGH_PRIORITY_ISSUE = 'sentry.rules.conditions.high_priority_issue.NewIssueCondition',
+  NEW_HIGH_PRIORITY_ISSUE = 'sentry.rules.conditions.high_priority_issue.NewHighPriorityIssueCondition',
   EXISTING_HIGH_PRIORITY_ISSUE = 'sentry.rules.conditions.high_priority_issue.ExistingIssueCondition',
 }
 

--- a/static/app/types/alerts.tsx
+++ b/static/app/types/alerts.tsx
@@ -40,7 +40,7 @@ export const enum IssueAlertConditionType {
   EVENT_UNIQUE_USER_FREQUENCY = 'sentry.rules.conditions.event_frequency.EventUniqueUserFrequencyCondition',
   EVENT_FREQUENCY_PERCENT = 'sentry.rules.conditions.event_frequency.EventFrequencyPercentCondition',
   NEW_HIGH_PRIORITY_ISSUE = 'sentry.rules.conditions.high_priority_issue.NewHighPriorityIssueCondition',
-  EXISTING_HIGH_PRIORITY_ISSUE = 'sentry.rules.conditions.high_priority_issue.ExistingIssueCondition',
+  EXISTING_HIGH_PRIORITY_ISSUE = 'sentry.rules.conditions.high_priority_issue.ExistingHighPriorityIssueCondition',
 }
 
 export const enum IssueAlertFilterType {

--- a/static/app/views/alerts/rules/issue/index.tsx
+++ b/static/app/views/alerts/rules/issue/index.tsx
@@ -328,6 +328,7 @@ class IssueRuleEditor extends DeprecatedAsyncView<Props, State> {
       if (hasHighPriorityIssueAlerts) {
         this.handleChange('conditions', [
           {id: IssueAlertConditionType.NEW_HIGH_PRIORITY_ISSUE},
+          {id: IssueAlertConditionType.EXISTING_HIGH_PRIORITY_ISSUE},
         ]);
       } else {
         this.handleChange('conditions', [{id: IssueAlertConditionType.FIRST_SEEN_EVENT}]);

--- a/static/app/views/alerts/rules/issue/index.tsx
+++ b/static/app/views/alerts/rules/issue/index.tsx
@@ -322,7 +322,16 @@ class IssueRuleEditor extends DeprecatedAsyncView<Props, State> {
     if (!ruleId && !this.isDuplicateRule) {
       // now that we've loaded all the possible conditions, we can populate the
       // value of conditions for a new alert
-      this.handleChange('conditions', [{id: IssueAlertConditionType.FIRST_SEEN_EVENT}]);
+      const hasHighPriorityIssueAlerts =
+        this.props.organization.features.includes('default-high-priority-alerts') ||
+        this.props.project.features.includes('high-priority-alerts');
+      if (hasHighPriorityIssueAlerts) {
+        this.handleChange('conditions', [
+          {id: IssueAlertConditionType.NEW_HIGH_PRIORITY_ISSUE},
+        ]);
+      } else {
+        this.handleChange('conditions', [{id: IssueAlertConditionType.FIRST_SEEN_EVENT}]);
+      }
     }
   }
 


### PR DESCRIPTION
The default alert condition for a new issue alert will now include both the `NewHighPriorityIssueCondition` and `ExistingHighPriorityIssueCondition` conditions for organizations where the feature is enabled. 

<img width="1035" alt="image" src="https://github.com/getsentry/sentry/assets/16563948/ac2ade03-f368-4675-923b-c4a2dea712ee">
