### PR TITLE
feat(query-builder): Add support for sectioned filter value suggestions

### DIFF
--- a/static/app/components/searchQueryBuilder/index.spec.tsx
+++ b/static/app/components/searchQueryBuilder/index.spec.tsx
@@ -27,7 +27,20 @@ const MOCK_SUPPORTED_KEYS: TagCollection = {
     name: 'Assigned To',
     kind: FieldKind.FIELD,
     predefined: true,
-    values: ['me', 'unassigned', 'person@sentry.io'],
+    values: [
+      {
+        title: 'Suggested',
+        type: 'header',
+        icon: null,
+        children: [{value: 'me'}, {value: 'unassigned'}],
+      },
+      {
+        title: 'All',
+        type: 'header',
+        icon: null,
+        children: [{value: 'person1@sentry.io'}, {value: 'person2@sentry.io'}],
+      },
+    ],
   },
   [FieldKey.BROWSER_NAME]: {
     key: FieldKey.BROWSER_NAME,
@@ -543,6 +556,39 @@ describe('SearchQueryBuilder', function () {
       await userEvent.keyboard('{backspace}{backspace}');
 
       expect(screen.queryByRole('row', {name: '('})).not.toBeInTheDocument();
+    });
+  });
+
+  describe('token values', function () {
+    it('supports grouped token value suggestions', async function () {
+      render(<SearchQueryBuilder {...defaultProps} initialQuery="assigned:me" />);
+      await userEvent.click(
+        screen.getByRole('button', {name: 'Edit value for filter: assigned'})
+      );
+      await userEvent.click(screen.getByRole('combobox', {name: 'Edit filter value'}));
+
+      const groups = within(screen.getByRole('listbox')).getAllByRole('group');
+
+      // First group is selected option, second is "Suggested", third is "All"
+      expect(groups).toHaveLength(3);
+      expect(
+        within(screen.getByRole('listbox')).getByText('Suggested')
+      ).toBeInTheDocument();
+      expect(within(screen.getByRole('listbox')).getByText('All')).toBeInTheDocument();
+
+      // First group is the selected "me"
+      expect(within(groups[0]).getByRole('option', {name: 'me'})).toBeInTheDocument();
+      // Second group is the remaining option in the "Suggested" section
+      expect(
+        within(groups[1]).getByRole('option', {name: 'unassigned'})
+      ).toBeInTheDocument();
+      // Third group are the options under the "All" section
+      expect(
+        within(groups[2]).getByRole('option', {name: 'person1@sentry.io'})
+      ).toBeInTheDocument();
+      expect(
+        within(groups[2]).getByRole('option', {name: 'person2@sentry.io'})
+      ).toBeInTheDocument();
     });
   });
 });

--- a/static/app/components/searchQueryBuilder/index.stories.tsx
+++ b/static/app/components/searchQueryBuilder/index.stories.tsx
@@ -20,7 +20,20 @@ const SUPPORTED_KEYS: TagCollection = {
     name: 'Assigned To',
     kind: FieldKind.FIELD,
     predefined: true,
-    values: ['me', 'unassigned', 'person@sentry.io'],
+    values: [
+      {
+        title: 'Suggested',
+        type: 'header',
+        icon: null,
+        children: [{value: 'me'}, {value: 'unassigned'}],
+      },
+      {
+        title: 'All',
+        type: 'header',
+        icon: null,
+        children: [{value: 'person1@sentry.io'}, {value: 'person2@sentry.io'}],
+      },
+    ],
   },
   [FieldKey.BROWSER_NAME]: {
     key: FieldKey.BROWSER_NAME,

--- a/static/app/components/searchQueryBuilder/valueCombobox.tsx
+++ b/static/app/components/searchQueryBuilder/valueCombobox.tsx
@@ -4,6 +4,7 @@ import {Item, Section} from '@react-stately/collections';
 import orderBy from 'lodash/orderBy';
 
 import Checkbox from 'sentry/components/checkbox';
+import type {SelectOptionWithKey} from 'sentry/components/compactSelect/types';
 import {getItemsWithKeys} from 'sentry/components/compactSelect/utils';
 import {SearchQueryBuilderCombobox} from 'sentry/components/searchQueryBuilder/combobox';
 import {useSearchQueryBuilder} from 'sentry/components/searchQueryBuilder/context';
@@ -17,6 +18,7 @@ import type {SearchGroup} from 'sentry/components/smartSearchBar/types';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {Tag} from 'sentry/types';
+import {defined} from 'sentry/utils';
 import {FieldValueType, getFieldDefinition} from 'sentry/utils/fields';
 import {type QueryKey, useQuery} from 'sentry/utils/queryClient';
 
@@ -25,37 +27,52 @@ type SearchQueryValueBuilderProps = {
   token: TokenResult<Token.FILTER>;
 };
 
+type SuggestionSection = {
+  sectionText: string;
+  suggestions: string[];
+};
+
+type SuggestionSectionItem = {
+  items: SelectOptionWithKey<string>[];
+  sectionText: string;
+};
+
 function isStringFilterValues(
   tagValues: string[] | SearchGroup[]
 ): tagValues is string[] {
   return typeof tagValues[0] === 'string';
 }
 
-function getPredefinedValues({key}: {key?: Tag}): string[] {
+function getPredefinedValues({key}: {key?: Tag}): SuggestionSection[] {
   if (!key) {
     return [];
   }
 
   const fieldDef = getFieldDefinition(key.key);
 
-  if (key.values && isStringFilterValues(key.values)) {
-    return key.values;
+  if (!key.values) {
+    switch (fieldDef?.valueType) {
+      // TODO(malwilley): Better duration suggestions
+      case FieldValueType.DURATION:
+        return [{sectionText: '', suggestions: ['-1d', '-7d', '+14d']}];
+      case FieldValueType.BOOLEAN:
+        return [{sectionText: '', suggestions: ['true', 'false']}];
+      // TODO(malwilley): Better date suggestions
+      case FieldValueType.DATE:
+        return [{sectionText: '', suggestions: ['-1h', '-24h', '-7d', '-14d', '-30d']}];
+      default:
+        return [];
+    }
   }
 
-  // TODO(malwilley): Add support for grouped values
-
-  switch (fieldDef?.valueType) {
-    // TODO(malwilley): Better duration suggestions
-    case FieldValueType.DURATION:
-      return ['-1d', '-7d', '+14d'];
-    case FieldValueType.BOOLEAN:
-      return ['true', 'false'];
-    // TODO(malwilley): Better date suggestions
-    case FieldValueType.DATE:
-      return ['-1h', '-24h', '-7d', '-14d', '-30d'];
-    default:
-      return [];
+  if (isStringFilterValues(key.values)) {
+    return [{sectionText: '', suggestions: key.values}];
   }
+
+  return key.values.map(group => ({
+    sectionText: group.title,
+    suggestions: group.children.map(child => child.value).filter(defined),
+  }));
 }
 
 function keySupportsMultipleValues(key?: Tag): boolean {
@@ -89,6 +106,99 @@ function getOtherSelectedValues(token: TokenResult<Token.FILTER>): string[] {
     default:
       return [];
   }
+}
+
+function useFilterSuggestions({
+  token,
+  inputValue,
+  selectedValues,
+}: {
+  inputValue: string;
+  selectedValues: string[];
+  token: TokenResult<Token.FILTER>;
+}) {
+  const {getTagValues, keys} = useSearchQueryBuilder();
+  const key = keys[token.key.text];
+  const shouldFetchValues = key && !key.predefined;
+  const canSelectMultipleValues = keySupportsMultipleValues(key);
+
+  // TODO(malwilley): Display error states
+  const {data} = useQuery<string[]>({
+    queryKey: ['search-query-builder', token.key, inputValue] as QueryKey,
+    queryFn: () => getTagValues(key, inputValue),
+    keepPreviousData: true,
+    enabled: shouldFetchValues,
+  });
+
+  const createItem = useCallback(
+    (value: string, selected = false) => {
+      return {
+        label: value,
+        value: value,
+        textValue: value,
+        hideCheck: true,
+        selectionMode: canSelectMultipleValues ? 'multiple' : 'single',
+        trailingItems: ({isFocused, disabled}) => {
+          if (!canSelectMultipleValues) {
+            return null;
+          }
+
+          return (
+            <ItemCheckbox
+              isFocused={isFocused}
+              selected={selected}
+              token={token}
+              disabled={disabled}
+              value={value}
+            />
+          );
+        },
+      };
+    },
+    [canSelectMultipleValues, token]
+  );
+
+  const suggestionGroups: SuggestionSection[] = useMemo(() => {
+    return shouldFetchValues
+      ? [{sectionText: '', suggestions: data ?? []}]
+      : getPredefinedValues({key});
+  }, [data, key, shouldFetchValues]);
+
+  // Grouped sections for rendering purposes
+  const suggestionSectionItems = useMemo<SuggestionSectionItem[]>(() => {
+    const itemsWithoutSection = suggestionGroups
+      .filter(group => group.sectionText === '')
+      .flatMap(group => group.suggestions);
+    const sections = suggestionGroups.filter(group => group.sectionText !== '');
+
+    return [
+      {
+        sectionText: '',
+        items: getItemsWithKeys(
+          [...selectedValues, ...itemsWithoutSection].map(value => createItem(value))
+        ),
+      },
+      ...sections.map(group => ({
+        sectionText: group.sectionText,
+        items: getItemsWithKeys(
+          group.suggestions
+            .filter(value => !selectedValues.includes(value))
+            .map(value => createItem(value))
+        ),
+      })),
+    ];
+  }, [createItem, selectedValues, suggestionGroups]);
+
+  // Flat list used for state management
+  const items = useMemo(() => {
+    return suggestionSectionItems.flatMap(section => section.items);
+  }, [suggestionSectionItems]);
+
+  return {
+    selectedValues,
+    items,
+    suggestionSectionItems,
+  };
 }
 
 function ItemCheckbox({
@@ -134,9 +244,8 @@ export function SearchQueryBuilderValueCombobox({
 }: SearchQueryValueBuilderProps) {
   const [inputValue, setInputValue] = useState('');
 
-  const {getTagValues, keys, dispatch} = useSearchQueryBuilder();
+  const {keys, dispatch} = useSearchQueryBuilder();
   const key = keys[token.key.text];
-  const shouldFetchValues = key && !key.predefined;
   const canSelectMultipleValues = keySupportsMultipleValues(key);
   const selectedValues = useMemo(
     () =>
@@ -145,53 +254,11 @@ export function SearchQueryBuilderValueCombobox({
         : [],
     [canSelectMultipleValues, token]
   );
-
-  // TODO(malwilley): Display error states
-  const {data} = useQuery<string[]>({
-    queryKey: ['search-query-builder', token.key, inputValue] as QueryKey,
-    queryFn: () => getTagValues(key, inputValue),
-    keepPreviousData: true,
-    enabled: shouldFetchValues,
+  const {items, suggestionSectionItems} = useFilterSuggestions({
+    token,
+    inputValue,
+    selectedValues,
   });
-
-  const createItem = useCallback(
-    (value: string, selected = false) => {
-      return {
-        label: value,
-        value: value,
-        textValue: value,
-        hideCheck: true,
-        selectionMode: canSelectMultipleValues ? 'multiple' : 'single',
-        trailingItems: ({isFocused, disabled}) => {
-          if (!canSelectMultipleValues) {
-            return null;
-          }
-
-          return (
-            <ItemCheckbox
-              isFocused={isFocused}
-              selected={selected}
-              token={token}
-              disabled={disabled}
-              value={value}
-            />
-          );
-        },
-      };
-    },
-    [canSelectMultipleValues, token]
-  );
-
-  const items = useMemo(() => {
-    const values = (shouldFetchValues ? data : getPredefinedValues({key})) ?? [];
-
-    return getItemsWithKeys([
-      ...selectedValues.map(value => createItem(value, true)),
-      ...values
-        .filter(value => !selectedValues.includes(value))
-        .map(value => createItem(value)),
-    ]);
-  }, [createItem, data, key, selectedValues, shouldFetchValues]);
 
   const handleSelectValue = useCallback(
     (value: string) => {
@@ -249,13 +316,15 @@ export function SearchQueryBuilderValueCombobox({
         onKeyDown={onKeyDown}
         autoFocus
       >
-        <Section>
-          {items.map(item => (
-            <Item {...item} key={item.key}>
-              {item.label}
-            </Item>
-          ))}
-        </Section>
+        {suggestionSectionItems.map(section => (
+          <Section key={section.sectionText} title={section.sectionText}>
+            {section.items.map(item => (
+              <Item {...item} key={item.key}>
+                {item.label}
+              </Item>
+            ))}
+          </Section>
+        ))}
       </SearchQueryBuilderCombobox>
     </ValueEditing>
   );


### PR DESCRIPTION
Grouped suggestions are already supported for the existing search component and used for keys like `assignee`. This adds basic support for those values.

![CleanShot 2024-05-30 at 11 18 38](https://github.com/getsentry/sentry/assets/10888943/6095b0c2-b2d3-422a-bb88-f33b301b36d4)
