### PR TITLE
feat(insights): Wrap sidebar navigation items in `sidebar:navigation-item` hook

### DIFF
--- a/static/app/components/sidebar/sidebarItem.tsx
+++ b/static/app/components/sidebar/sidebarItem.tsx
@@ -216,7 +216,7 @@ function SidebarItem({
       position={placement}
     >
       <SidebarNavigationItemHook id={id}>
-        {({disabled, AdditionalContent, Wrapper}) => (
+        {({disabled, additionalContent, Wrapper}) => (
           <Wrapper>
             <StyledSidebarItem
               {...props}
@@ -239,7 +239,7 @@ function SidebarItem({
                     <LabelHook id={id}>
                       <TruncatedLabel>{label}</TruncatedLabel>
                       {badges}
-                      {AdditionalContent}
+                      {additionalContent}
                     </LabelHook>
                   </SidebarItemLabel>
                 )}
@@ -313,7 +313,7 @@ const SidebarNavigationItemHook = HookOrDefault({
   defaultComponent: ({children}) =>
     children({
       disabled: false,
-      AdditionalContent: <Fragment />,
+      additionalContent: <Fragment />,
       Wrapper: Fragment,
     }),
 });

--- a/static/app/components/sidebar/sidebarItem.tsx
+++ b/static/app/components/sidebar/sidebarItem.tsx
@@ -313,7 +313,7 @@ const SidebarNavigationItemHook = HookOrDefault({
   defaultComponent: ({children}) =>
     children({
       disabled: false,
-      additionalContent: <Fragment />,
+      additionalContent: null,
       Wrapper: Fragment,
     }),
 });

--- a/static/app/components/sidebar/sidebarItem.tsx
+++ b/static/app/components/sidebar/sidebarItem.tsx
@@ -215,57 +215,66 @@ function SidebarItem({
       }
       position={placement}
     >
-      <StyledSidebarItem
-        {...props}
-        id={`sidebar-item-${id}`}
-        isInFloatingAccordion={isInFloatingAccordion}
-        active={isActive ? 'true' : undefined}
-        to={toProps}
-        className={className}
-        aria-current={isActive ? 'page' : undefined}
-        onClick={handleItemClick}
-      >
-        <InteractionStateLayer isPressed={isActive} color="white" higherOpacity />
-        <SidebarItemWrapper collapsed={isInCollapsedState}>
-          {!isInFloatingAccordion && <SidebarItemIcon>{icon}</SidebarItemIcon>}
-          {!isInCollapsedState && !isTop && (
-            <SidebarItemLabel
+      <SidebarNavigationItemHook id={id}>
+        {({disabled, AdditionalContent, Wrapper}) => (
+          <Wrapper>
+            <StyledSidebarItem
+              {...props}
+              id={`sidebar-item-${id}`}
               isInFloatingAccordion={isInFloatingAccordion}
-              isNested={isNested}
+              active={isActive ? 'true' : undefined}
+              to={disabled ? '' : toProps}
+              className={className}
+              aria-current={isActive ? 'page' : undefined}
+              onClick={handleItemClick}
             >
-              <LabelHook id={id}>
-                <TruncatedLabel>{label}</TruncatedLabel>
-                {badges}
-              </LabelHook>
-            </SidebarItemLabel>
-          )}
-          {isInCollapsedState && showIsNew && (
-            <CollapsedFeatureBadge
-              type="new"
-              variant="indicator"
-              tooltipProps={tooltipDisabledProps}
-            />
-          )}
-          {isInCollapsedState && isBeta && (
-            <CollapsedFeatureBadge
-              type="beta"
-              variant="indicator"
-              tooltipProps={tooltipDisabledProps}
-            />
-          )}
-          {isInCollapsedState && isAlpha && (
-            <CollapsedFeatureBadge
-              type="alpha"
-              variant="indicator"
-              tooltipProps={tooltipDisabledProps}
-            />
-          )}
-          {badge !== undefined && badge > 0 && (
-            <SidebarItemBadge collapsed={isInCollapsedState}>{badge}</SidebarItemBadge>
-          )}
-          {trailingItems}
-        </SidebarItemWrapper>
-      </StyledSidebarItem>
+              <InteractionStateLayer isPressed={isActive} color="white" higherOpacity />
+              <SidebarItemWrapper collapsed={isInCollapsedState}>
+                {!isInFloatingAccordion && <SidebarItemIcon>{icon}</SidebarItemIcon>}
+                {!isInCollapsedState && !isTop && (
+                  <SidebarItemLabel
+                    isInFloatingAccordion={isInFloatingAccordion}
+                    isNested={isNested}
+                  >
+                    <LabelHook id={id}>
+                      <TruncatedLabel>{label}</TruncatedLabel>
+                      {badges}
+                      {AdditionalContent}
+                    </LabelHook>
+                  </SidebarItemLabel>
+                )}
+                {isInCollapsedState && showIsNew && (
+                  <CollapsedFeatureBadge
+                    type="new"
+                    variant="indicator"
+                    tooltipProps={tooltipDisabledProps}
+                  />
+                )}
+                {isInCollapsedState && isBeta && (
+                  <CollapsedFeatureBadge
+                    type="beta"
+                    variant="indicator"
+                    tooltipProps={tooltipDisabledProps}
+                  />
+                )}
+                {isInCollapsedState && isAlpha && (
+                  <CollapsedFeatureBadge
+                    type="alpha"
+                    variant="indicator"
+                    tooltipProps={tooltipDisabledProps}
+                  />
+                )}
+                {badge !== undefined && badge > 0 && (
+                  <SidebarItemBadge collapsed={isInCollapsedState}>
+                    {badge}
+                  </SidebarItemBadge>
+                )}
+                {trailingItems}
+              </SidebarItemWrapper>
+            </StyledSidebarItem>
+          </Wrapper>
+        )}
+      </SidebarNavigationItemHook>
     </Tooltip>
   );
 }
@@ -298,6 +307,16 @@ export function isItemActive(
     (item?.label === 'Performance' && location.pathname.includes('/performance/'))
   );
 }
+
+const SidebarNavigationItemHook = HookOrDefault({
+  hookName: 'sidebar:navigation-item',
+  defaultComponent: ({children}) =>
+    children({
+      disabled: false,
+      AdditionalContent: <Fragment />,
+      Wrapper: Fragment,
+    }),
+});
 
 export default SidebarItem;
 

--- a/static/app/types/hooks.tsx
+++ b/static/app/types/hooks.tsx
@@ -651,6 +651,9 @@ type InviteButtonCustomizationHook = () => React.ComponentType<{
  * Sidebar navigation item customization allows passing render props to disable
  * the link, wrap it in an upsell modal, and give it some additional content
  * (e.g., a Business Icon) to render.
+ *
+ * TODO: We can use this to replace the sidebar label hook `sidebar:item-label`,
+ * too, since this is a more generic version.
  */
 type SidebarNavigationItemHook = () => React.ComponentType<{
   children: (opts: {

--- a/static/app/types/hooks.tsx
+++ b/static/app/types/hooks.tsx
@@ -240,6 +240,7 @@ export type CustomizationHooks = {
   'integrations:feature-gates': IntegrationsFeatureGatesHook;
   'member-invite-button:customization': InviteButtonCustomizationHook;
   'member-invite-modal:customization': InviteModalCustomizationHook;
+  'sidebar:navigation-item': SidebarNavigationItemHook;
 };
 
 /**
@@ -644,6 +645,15 @@ type InviteButtonCustomizationHook = () => React.ComponentType<{
   }) => React.ReactElement;
   onTriggerModal: () => void;
   organization: Organization;
+}>;
+
+type SidebarNavigationItemHook = () => React.ComponentType<{
+  children: (opts: {
+    AdditionalContent: React.ReactElement | null;
+    Wrapper: React.FunctionComponent<{children: React.ReactElement}>;
+    disabled: boolean;
+  }) => React.ReactElement;
+  id: string;
 }>;
 
 /**

--- a/static/app/types/hooks.tsx
+++ b/static/app/types/hooks.tsx
@@ -654,8 +654,8 @@ type InviteButtonCustomizationHook = () => React.ComponentType<{
  */
 type SidebarNavigationItemHook = () => React.ComponentType<{
   children: (opts: {
-    AdditionalContent: React.ReactElement | null;
     Wrapper: React.FunctionComponent<{children: React.ReactElement}>;
+    additionalContent: React.ReactElement | null;
     disabled: boolean;
   }) => React.ReactElement;
   id: string;

--- a/static/app/types/hooks.tsx
+++ b/static/app/types/hooks.tsx
@@ -647,6 +647,11 @@ type InviteButtonCustomizationHook = () => React.ComponentType<{
   organization: Organization;
 }>;
 
+/**
+ * Sidebar navigation item customization allows passing render props to disable
+ * the link, wrap it in an upsell modal, and give it some additional content
+ * (e.g., a Business Icon) to render.
+ */
 type SidebarNavigationItemHook = () => React.ComponentType<{
   children: (opts: {
     AdditionalContent: React.ReactElement | null;


### PR DESCRIPTION
Declares a new hook called `sidebar:navigation-item`, and wraps all navigation items in it. Here's the scoop on the hook:

- the hook is a _render prop hook_. It accept a render function child, and passes it some computed properties
- the properties are:
    - `disabled`, which indicates if the child should be "active" or not, whatever that means
    - `AdditionalContent` which supplies some React content to render somewhere alongside the child
    - `Wrapper` which supplies a React wrapper to wrap the child in

The `SidebarItem` component uses this hook by checking the `disabled` property, and if present, removes the `to` on the link (thereby disabling it), rendering the `AdditionalContent` next to the item label, and wrapping _the whole thing_ in `Wrapper`.

The default fallthrough behaviour is that the link is enabled, there's no wrapper, and there's no additional content. i.e., no changes to current behaviour.

Why do all this? We want to be able to have _more control_ over the sidebar items from `getsentry`. We want to:

1. Be able to turn off the entire link item (i.e., disable the link)
2. Wrap the whole link in an upsell dialog
3. Pass it some extra content to render (i.e., the Business icon)


The existing `sidebar:item-label` hook doesn't help us, because it doesn't provide a mechanism for wrapping, or turning off the link! See https://github.com/getsentry/getsentry/pull/14127 for the corresponding `getsentry` hook behaviour
