### PR TITLE
feat(autofix): Modify link and styles for autofix github app onboarding

### DIFF
--- a/static/app/components/modals/autofixSetupModal.tsx
+++ b/static/app/components/modals/autofixSetupModal.tsx
@@ -125,12 +125,10 @@ function GitRepoLink({repo}: {repo: AutofixSetupRepoDefinition}) {
     return (
       <RepoLinkItem>
         <GithubLink>
-          <ExternalLink href={`https://github.com/${repo.owner}/${repo.name}`}>
-            <IconGithub color="linkColor" size="sm" />
-            <span>
-              {repo.owner}/{repo.name}
-            </span>
-          </ExternalLink>
+          <IconGithub size="sm" />
+          <span>
+            {repo.owner}/{repo.name}
+          </span>
         </GithubLink>
         {repo.ok ? <IconCheckmark color="success" isCircled /> : null}
       </RepoLinkItem>
@@ -190,7 +188,7 @@ function AutofixGithubIntegrationStep({
           'Install the [link:Sentry Autofix Github App] on your Github organization or each individual repository with write permissions to enable Autofix.',
           {
             link: (
-              <ExternalLink href="https://github.com/apps/sentry-autofix-experimental" />
+              <ExternalLink href="https://github.com/apps/sentry-autofix-experimental/installations/new" />
             ),
           }
         )}
@@ -403,6 +401,7 @@ const RepoLinkUl = styled('ul')`
   display: flex;
   flex-direction: column;
   gap: ${space(0.5)};
+  padding: 0;
 `;
 
 const RepoLinkItem = styled('li')`
@@ -414,13 +413,5 @@ const RepoLinkItem = styled('li')`
 const GithubLink = styled('div')`
   display: flex;
   align-items: center;
-
-  a {
-    display: flex;
-    align-items: center;
-  }
-
-  svg {
-    margin-right: ${space(0.5)};
-  }
+  gap: ${space(0.5)};
 `;


### PR DESCRIPTION
- Removes repo links to draw attention to the GH app link
- Modify link to point to `/installations/new` to save users a click

![CleanShot 2024-05-30 at 11 30 10](https://github.com/getsentry/sentry/assets/10888943/862bcdee-afb7-49ba-9114-42ff95e150f3)
