### PR TITLE
fix: When SCIM is disabled, clear Team.idp_provisioned flags

### DIFF
--- a/src/sentry/services/hybrid_cloud/organization/impl.py
+++ b/src/sentry/services/hybrid_cloud/organization/impl.py
@@ -555,6 +555,9 @@ class DatabaseBackedOrganizationService(OrganizationService):
                 .bitand(~OrganizationMember.flags["idp:role-restricted"])
             )
 
+        with unguarded_write(using=router.db_for_write(Team)):
+            Team.objects.filter(organization_id=organization_id).update(idp_provisioned=False)
+
     def update_region_user(self, *, user: RpcRegionUser, region_name: str) -> None:
         # Normally, calling update on a QS for organization member fails because we need to ensure that updates to
         # OrganizationMember objects produces outboxes.  In this case, it is safe to do the update directly because


### PR DESCRIPTION
Fix a bug where, after SCIM is disabled, teams are left in a state where team membership can no longer be managed.

Should resolve https://github.com/getsentry/sentry/issues/71218.