### PR TITLE
feat(remote-config): Add proxy endpoint for configurations

### DIFF
--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -949,11 +949,6 @@ RELAY_URLS = [
         RelayDetailsEndpoint.as_view(),
         name="sentry-api-0-relays-details",
     ),
-    re_path(
-        r"^(?P<project_id>[^\/]+)/configuration/$",
-        ProjectConfigurationProxyEndpoint.as_view(),
-        name="sentry-api-0-relays-remote-configuration",
-    ),
 ]
 
 USER_URLS = [
@@ -3263,6 +3258,11 @@ urlpatterns = [
         r"^wizard/(?P<wizard_hash>[^\/]+)/$",
         SetupWizard.as_view(),
         name="sentry-api-0-project-wizard",
+    ),
+    re_path(
+        r"^configuration/(?P<project_id>[^\/]+)/$",
+        ProjectConfigurationProxyEndpoint.as_view(),
+        name="sentry-api-0-project-remote-configuration",
     ),
     # Internal
     re_path(

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -3260,7 +3260,7 @@ urlpatterns = [
         name="sentry-api-0-project-wizard",
     ),
     re_path(
-        r"^proxy/projects/(?P<project_id>[^\/]+)/configuration/$",
+        r"^project/(?P<project_id>[^\/]+)/configuration/$",
         ProjectConfigurationProxyEndpoint.as_view(),
         name="sentry-api-0-project-remote-configuration",
     ),

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -3260,7 +3260,7 @@ urlpatterns = [
         name="sentry-api-0-project-wizard",
     ),
     re_path(
-        r"^project/(?P<project_id>[^\/]+)/configuration/$",
+        r"^remote-config/projects/(?P<project_id>[^\/]+)$",
         ProjectConfigurationProxyEndpoint.as_view(),
         name="sentry-api-0-project-remote-configuration",
     ),

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -163,7 +163,10 @@ from sentry.monitors.endpoints.project_monitor_stats import ProjectMonitorStatsE
 from sentry.monitors.endpoints.project_processing_errors_details import (
     ProjectProcessingErrorsDetailsEndpoint,
 )
-from sentry.remote_config.endpoints import ProjectConfigurationEndpoint
+from sentry.remote_config.endpoints import (
+    ProjectConfigurationEndpoint,
+    ProjectConfigurationProxyEndpoint,
+)
 from sentry.replays.endpoints.organization_replay_count import OrganizationReplayCountEndpoint
 from sentry.replays.endpoints.organization_replay_details import OrganizationReplayDetailsEndpoint
 from sentry.replays.endpoints.organization_replay_events_meta import (
@@ -945,6 +948,11 @@ RELAY_URLS = [
         r"^(?P<relay_id>[^\/]+)/$",
         RelayDetailsEndpoint.as_view(),
         name="sentry-api-0-relays-details",
+    ),
+    re_path(
+        r"^(?P<project_id>[^\/]+)/configuration/$",
+        ProjectConfigurationProxyEndpoint.as_view(),
+        name="sentry-api-0-relays-remote-configuration",
     ),
 ]
 

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -3260,7 +3260,7 @@ urlpatterns = [
         name="sentry-api-0-project-wizard",
     ),
     re_path(
-        r"^configuration/(?P<project_id>[^\/]+)/$",
+        r"^proxy/projects/(?P<project_id>[^\/]+)/configuration/$",
         ProjectConfigurationProxyEndpoint.as_view(),
         name="sentry-api-0-project-remote-configuration",
     ),

--- a/src/sentry/remote_config/docs/api.md
+++ b/src/sentry/remote_config/docs/api.md
@@ -118,7 +118,7 @@ Delete the project's configuration.
 
 - Response 204
 
-## Configuration Proxy [/projects/<project_id>/configuration/]
+## Configuration Proxy [/remote-config/projects/<project_id>/]
 
 Temporary configuration proxy resource.
 

--- a/src/sentry/remote_config/docs/api.md
+++ b/src/sentry/remote_config/docs/api.md
@@ -118,7 +118,7 @@ Delete the project's configuration.
 
 - Response 204
 
-## Configuration Proxy [/relays/<project_id>/configuration/]
+## Configuration Proxy [/project/<project_id>/configuration/]
 
 Temporary configuration proxy resource.
 

--- a/src/sentry/remote_config/docs/api.md
+++ b/src/sentry/remote_config/docs/api.md
@@ -118,7 +118,7 @@ Delete the project's configuration.
 
 - Response 204
 
-## Configuration Proxy [/project/<project_id>/configuration/]
+## Configuration Proxy [/proxy/projects/<project_id>/configuration/]
 
 Temporary configuration proxy resource.
 

--- a/src/sentry/remote_config/docs/api.md
+++ b/src/sentry/remote_config/docs/api.md
@@ -118,7 +118,7 @@ Delete the project's configuration.
 
 - Response 204
 
-## Configuration Proxy [/proxy/projects/<project_id>/configuration/]
+## Configuration Proxy [/projects/<project_id>/configuration/]
 
 Temporary configuration proxy resource.
 

--- a/src/sentry/remote_config/docs/api.md
+++ b/src/sentry/remote_config/docs/api.md
@@ -10,7 +10,7 @@ Host: https://sentry.io/api/0
 
 ### Get Configuration [GET]
 
-Retrieve the DSN's configuration.
+Retrieve the project's configuration.
 
 **Attributes**
 
@@ -64,7 +64,7 @@ Retrieve the DSN's configuration.
 
 ### Set Configuration [POST]
 
-Set the DSN's configuration.
+Set the project's configuration.
 
 - Request
 
@@ -114,7 +114,7 @@ Set the DSN's configuration.
 
 ### Delete Configuration [DELETE]
 
-Delete the DSN's configuration.
+Delete the project's configuration.
 
 - Response 204
 

--- a/src/sentry/remote_config/docs/api.md
+++ b/src/sentry/remote_config/docs/api.md
@@ -117,3 +117,41 @@ Set the DSN's configuration.
 Delete the DSN's configuration.
 
 - Response 204
+
+## Configuration Proxy [/relays/<project_id>/configuration/]
+
+Temporary configuration proxy resource.
+
+### Get Configuration [GET]
+
+Fetch a project's configuration. Responses should be proxied exactly to the SDK.
+
+- Response 200
+
+  - Headers
+
+    Cache-Control: public, max-age=3600
+    Content-Type: application/json
+    ETag: a7966bf58e23583c9a5a4059383ff850
+
+  - Body
+
+    ```json
+    {
+      "features": [
+        {
+          "key": "hello",
+          "value": "world"
+        },
+        {
+          "key": "has_access",
+          "value": true
+        }
+      ],
+      "options": {
+        "sample_rate": 1.0,
+        "traces_sample_rate": 0.5
+      },
+      "version": 1
+    }
+    ```

--- a/src/sentry/remote_config/endpoints.py
+++ b/src/sentry/remote_config/endpoints.py
@@ -3,7 +3,6 @@ import hashlib
 from django.contrib.auth.models import AnonymousUser
 from rest_framework import serializers
 from rest_framework.authentication import BasicAuthentication
-from rest_framework.exceptions import AuthenticationFailed
 from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.serializers import Serializer
@@ -11,16 +10,14 @@ from rest_framework.serializers import Serializer
 from sentry import features
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
-from sentry.api.authentication import AuthenticationSiloLimit, relay_from_id
+from sentry.api.authentication import AuthenticationSiloLimit
 from sentry.api.base import Endpoint, region_silo_endpoint
 from sentry.api.bases.project import ProjectEndpoint, ProjectEventPermission
 from sentry.api.permissions import RelayPermission
 from sentry.models.project import Project
-from sentry.relay.utils import get_header_relay_id
 from sentry.remote_config.storage import BlobDriver, make_storage
 from sentry.silo.base import SiloMode
 from sentry.utils import json, metrics
-from sentry.utils.sdk import configure_scope
 
 
 class OptionsValidator(Serializer):
@@ -60,7 +57,7 @@ class ProjectConfigurationEndpoint(ProjectEndpoint):
         if not features.has(
             "organizations:remote-config", project.organization, actor=request.user
         ):
-            return Response(status=404)
+            return Response("Disabled", status=404)
 
         remote_config = make_storage(project).get()
         if remote_config is None:
@@ -73,7 +70,7 @@ class ProjectConfigurationEndpoint(ProjectEndpoint):
         if not features.has(
             "organizations:remote-config", project.organization, actor=request.user
         ):
-            return Response(status=404)
+            return Response("Disabled", status=404)
 
         validator = ConfigurationContainerValidator(data=request.data)
         if not validator.is_valid():
@@ -82,6 +79,7 @@ class ProjectConfigurationEndpoint(ProjectEndpoint):
         result = validator.validated_data["data"]
 
         make_storage(project).set(result)
+        metrics.incr("remote_config.configuration.write")
         return Response({"data": result}, status=201)
 
     def delete(self, request: Request, project: Project) -> Response:
@@ -89,9 +87,10 @@ class ProjectConfigurationEndpoint(ProjectEndpoint):
         if not features.has(
             "organizations:remote-config", project.organization, actor=request.user
         ):
-            return Response(status=404)
+            return Response("Disabled", status=404)
 
         make_storage(project).pop()
+        metrics.incr("remote_config.configuration.delete")
         return Response("", status=204)
 
 
@@ -100,17 +99,6 @@ class RelayAuthentication(BasicAuthentication):
     """Same as default Relay authentication except without body signing."""
 
     def authenticate(self, request: Request):
-        relay_id = get_header_relay_id(request)
-        if not relay_id:
-            raise AuthenticationFailed("Invalid relay ID")
-
-        with configure_scope() as scope:
-            scope.set_tag("relay_id", relay_id)
-
-        relay, _ = relay_from_id(request, relay_id)
-        if relay is None:
-            raise AuthenticationFailed("Unknown relay")
-
         return (AnonymousUser(), None)
 
 
@@ -132,18 +120,21 @@ class ProjectConfigurationProxyEndpoint(Endpoint):
     enforce_rate_limit = False
 
     def get(self, request: Request, project_id: int) -> Response:
-        metrics.incr("remote_config.configuration_requested")
+        metrics.incr("remote_config.configuration.requested")
 
         project = Project.objects.select_related("organization").get(pk=project_id)
         if not features.has("organizations:remote-config", project.organization, actor=None):
-            return Response("", status=404)
+            metrics.incr("remote_config.configuration.flag_disabled")
+            return Response("Disabled", status=404)
 
         result = BlobDriver(project).get()
         if result is None:
-            return Response("", status=404)
+            metrics.incr("remote_config.configuration.not_found")
+            return Response("Not found", status=404)
 
         result_str = json.dumps(result)
-        metrics.distribution("remote_config.configuration_size", value=len(result_str))
+        metrics.incr("remote_config.configuration.returned")
+        metrics.distribution("remote_config.configuration.size", value=len(result_str))
 
         # Emulating cache headers just because.
         return Response(

--- a/src/sentry/remote_config/endpoints.py
+++ b/src/sentry/remote_config/endpoints.py
@@ -1,7 +1,9 @@
 import hashlib
 
+from django.contrib.auth.models import AnonymousUser
 from rest_framework import serializers
 from rest_framework.authentication import BasicAuthentication
+from rest_framework.exceptions import AuthenticationFailed
 from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.serializers import Serializer
@@ -9,21 +11,16 @@ from rest_framework.serializers import Serializer
 from sentry import features
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
-from sentry.api.authentication import (
-    AnonymousUser,
-    AuthenticationFailed,
-    AuthenticationSiloLimit,
-    SiloMode,
-    configure_scope,
-    get_header_relay_id,
-    relay_from_id,
-)
+from sentry.api.authentication import AuthenticationSiloLimit, relay_from_id
 from sentry.api.base import Endpoint, region_silo_endpoint
 from sentry.api.bases.project import ProjectEndpoint, ProjectEventPermission
 from sentry.api.permissions import RelayPermission
 from sentry.models.project import Project
+from sentry.relay.utils import get_header_relay_id
 from sentry.remote_config.storage import BlobDriver, make_storage
+from sentry.silo.base import SiloMode
 from sentry.utils import json
+from sentry.utils.sdk import configure_scope
 
 
 class OptionsValidator(Serializer):

--- a/tests/sentry/remote_config/endpoints/test_configuration.py
+++ b/tests/sentry/remote_config/endpoints/test_configuration.py
@@ -1,14 +1,17 @@
 from typing import Any
+from uuid import uuid4
 
 from django.urls import reverse
+from sentry_relay.auth import generate_key_pair
 
+from sentry.models.relay import Relay
 from sentry.remote_config.storage import StorageBackend
 from sentry.testutils.cases import APITestCase
 
 REMOTE_CONFIG_FEATURES = {"organizations:remote-config": True}
 
 
-class ConfiguratioAPITestCase(APITestCase):
+class ConfigurationAPITestCase(APITestCase):
     endpoint = "sentry-api-0-project-key-configuration"
 
     def setUp(self):
@@ -173,4 +176,68 @@ class ConfiguratioAPITestCase(APITestCase):
 
     def test_delete_configuration_not_enabled(self):
         response = self.client.delete(self.url)
+        assert response.status_code == 404
+
+
+class ConfigurationProxyAPITestCase(APITestCase):
+    endpoint = "sentry-api-0-relays-remote-configuration"
+
+    def setUp(self):
+        super().setUp()
+        self.url = reverse(self.endpoint, args=(self.project.id,))
+
+    @property
+    def storage(self):
+        return StorageBackend(self.project)
+
+    def test_remote_config_proxy(self):
+        """Assert configurations are returned successfully."""
+        self.storage.set(
+            {
+                "features": [{"key": "abc", "value": "def"}],
+                "options": {"sample_rate": 0.5, "traces_sample_rate": 0},
+            },
+        )
+
+        keys = generate_key_pair()
+        relay = Relay.objects.create(
+            relay_id=str(uuid4()), public_key=str(keys[1]), is_internal=True
+        )
+
+        with self.feature(REMOTE_CONFIG_FEATURES):
+            response = self.client.get(
+                self.url, content_type="application/json", HTTP_X_SENTRY_RELAY_ID=relay.relay_id
+            )
+            assert response.status_code == 200
+            assert response["ETag"] is not None
+            assert response["Cache-Control"] == "public, max-age=3600"
+            assert response["Content-Type"] == "application/json"
+
+    def test_remote_config_proxy_not_found(self):
+        """Assert missing configurations 404."""
+        self.storage.pop()
+
+        keys = generate_key_pair()
+        relay = Relay.objects.create(
+            relay_id=str(uuid4()), public_key=str(keys[1]), is_internal=True
+        )
+
+        with self.feature(REMOTE_CONFIG_FEATURES):
+            response = self.client.get(
+                self.url, content_type="application/json", HTTP_X_SENTRY_RELAY_ID=relay.relay_id
+            )
+            assert response.status_code == 404
+
+    def test_remote_config_proxy_feature_disabled(self):
+        """Assert access is gated by feature flag."""
+        self.storage.pop()
+
+        keys = generate_key_pair()
+        relay = Relay.objects.create(
+            relay_id=str(uuid4()), public_key=str(keys[1]), is_internal=True
+        )
+
+        response = self.client.get(
+            self.url, content_type="application/json", HTTP_X_SENTRY_RELAY_ID=relay.relay_id
+        )
         assert response.status_code == 404

--- a/tests/sentry/remote_config/endpoints/test_configuration.py
+++ b/tests/sentry/remote_config/endpoints/test_configuration.py
@@ -180,7 +180,7 @@ class ConfigurationAPITestCase(APITestCase):
 
 
 class ConfigurationProxyAPITestCase(APITestCase):
-    endpoint = "sentry-api-0-relays-remote-configuration"
+    endpoint = "sentry-api-0-project-remote-configuration"
 
     def setUp(self):
         super().setUp()


### PR DESCRIPTION
Temporarily adds an endpoint to proxy configuration requests from Relay.  This is to help us test the proof of concept.

Related: https://github.com/getsentry/sentry/issues/70942