### PR TITLE
fix(similarity): fix call logic for seer

### DIFF
--- a/src/sentry/grouping/ingest/seer.py
+++ b/src/sentry/grouping/ingest/seer.py
@@ -24,15 +24,20 @@ def should_call_seer_for_grouping(event: Event, project: Project) -> bool:
     # TODO: Implement rate limits, kill switches, other flags, etc
     # TODO: Return False if the event has a custom fingerprint (check for both client- and server-side fingerprints)
 
+    has_either_seer_grouping_feature = features.has(
+        "projects:similarity-embeddings-metadata", project
+    ) or features.has("projects:similarity-embeddings-grouping", project)
+
+    if not has_either_seer_grouping_feature:
+        return False
+
     if _killswitch_enabled(event, project) or _ratelimiting_enabled(event, project):
         return False
 
     if not event_content_is_seer_eligible(event):
         return False
 
-    return features.has("projects:similarity-embeddings-metadata", project) or features.has(
-        "projects:similarity-embeddings-grouping", project
-    )
+    return True
 
 
 def _killswitch_enabled(event: Event, project: Project) -> bool:


### PR DESCRIPTION
right now we are running rate limits for _all_ projects regardless if they have the flag enabled or not. this is not great -- see [here](https://console.cloud.google.com/logs/query;query=labels.name%3D~%22sentry.events.grouping%22;cursorTimestamp=2024-05-29T12:04:38.763032760Z;aroundTime=2024-05-29T12:00:10.334Z;duration=PT1H?project=internal-sentry)

we should check feature flags first before looking at rate limits.