### PR TITLE
add queue monitoring option

### DIFF
--- a/src/sentry/middleware/integrations/tasks.py
+++ b/src/sentry/middleware/integrations/tasks.py
@@ -22,6 +22,7 @@ logger = logging.getLogger(__name__)
     silo_mode=SiloMode.CONTROL,
     max_retries=2,
     default_retry_delay=5,
+    record_timing=True,
 )
 def convert_to_async_slack_response(
     region_names: list[str],

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -2652,3 +2652,10 @@ register(
     default=[],
     flags=FLAG_ALLOW_EMPTY | FLAG_AUTOMATOR_MODIFIABLE,
 )
+
+register(
+    "sentry-metrics.monitor-queue-time",
+    type=Bool,
+    default=False,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)

--- a/src/sentry/tasks/base.py
+++ b/src/sentry/tasks/base.py
@@ -10,6 +10,7 @@ from typing import Any, TypeVar
 from celery import current_task
 from django.db.models import Model
 
+from sentry import options
 from sentry.celery import app
 from sentry.silo.base import SiloLimit, SiloMode
 from sentry.utils import metrics
@@ -90,6 +91,10 @@ def instrumented_task(name, stat_suffix=None, silo_mode=None, record_timing=Fals
     - hybrid cloud silo restrictions
     - disabling of result collection.
     """
+
+    # Use option to control default behavior of queue time monitoring
+    # Value can be dynamically updated, which is why the evaluation happens during function run-time
+    record_timing = record_timing or options.get("sentry-metrics.monitor-queue-time")
 
     def wrapped(func):
         @wraps(func)


### PR DESCRIPTION
We want to monitor the time a task stays on a queue, waiting to get executed. This helps us debug tasks that are more time-sensitive. An option is added to control the default behavior.
