### PR TITLE
ref(api): Refactor Org Serializers to Selectively Include feature flags

### DIFF
--- a/src/sentry/api/endpoints/organization_details.py
+++ b/src/sentry/api/endpoints/organization_details.py
@@ -605,10 +605,13 @@ class OrganizationDetailsEndpoint(OrganizationEndpoint):
             if is_detailed:
                 serializer = org_serializers.DetailedOrganizationSerializerWithProjectsAndTeams
 
-        context = serialize(organization, request.user, serializer(), access=request.access)
-
-        if not include_feature_flags:
-            context.pop("features", None)
+        context = serialize(
+            organization,
+            request.user,
+            serializer(),
+            access=request.access,
+            include_feature_flags=include_feature_flags,
+        )
 
         return self.respond(context)
 
@@ -699,10 +702,8 @@ class OrganizationDetailsEndpoint(OrganizationEndpoint):
                 request.user,
                 org_serializers.DetailedOrganizationSerializerWithProjectsAndTeams(),
                 access=request.access,
+                include_feature_flags=include_feature_flags,
             )
-
-            if not include_feature_flags:
-                context.pop("features", None)
 
             return self.respond(context)
         return self.respond(serializer.errors, status=status.HTTP_400_BAD_REQUEST)

--- a/src/sentry/api/serializers/models/organization.py
+++ b/src/sentry/api/serializers/models/organization.py
@@ -239,22 +239,11 @@ class OrganizationSerializer(Serializer):
             for o in item_list
         }
 
-    def serialize(
+    def get_feature_set(
         self, obj: Organization, attrs: Mapping[str, Any], user: User, **kwargs: Any
-    ) -> OrganizationSerializerResponse:
+    ) -> set[str]:
         from sentry import features
         from sentry.features.base import OrganizationFeature
-
-        if attrs.get("avatar"):
-            avatar = {
-                "avatarType": attrs["avatar"].get_avatar_type_display(),
-                "avatarUuid": attrs["avatar"].ident if attrs["avatar"].file_id else None,
-                "avatarUrl": attrs["avatar"].absolute_url(),
-            }
-        else:
-            avatar = {"avatarType": "letter_avatar", "avatarUuid": None, "avatarUrl": None}
-
-        status = OrganizationStatus(obj.status)
 
         # Retrieve all registered organization features
         org_features = [
@@ -262,7 +251,7 @@ class OrganizationSerializer(Serializer):
             for feature in features.all(feature_type=OrganizationFeature).keys()
             if feature.startswith(_ORGANIZATION_SCOPE_PREFIX)
         ]
-        feature_list = set()
+        feature_set = set()
 
         with sentry_sdk.start_span(op="features.check", description="check batch features"):
             # Check features in batch using the entity handler
@@ -275,7 +264,7 @@ class OrganizationSerializer(Serializer):
                 ).items():
                     if active:
                         # Remove organization prefix
-                        feature_list.add(feature_name[len(_ORGANIZATION_SCOPE_PREFIX) :])
+                        feature_set.add(feature_name[len(_ORGANIZATION_SCOPE_PREFIX) :])
 
                     # This feature_name was found via `batch_has`, don't check again using `has`
                     org_features.remove(feature_name)
@@ -285,18 +274,18 @@ class OrganizationSerializer(Serializer):
             for feature_name in org_features:
                 if features.has(feature_name, obj, actor=user, skip_entity=True):
                     # Remove the organization scope prefix
-                    feature_list.add(feature_name[len(_ORGANIZATION_SCOPE_PREFIX) :])
+                    feature_set.add(feature_name[len(_ORGANIZATION_SCOPE_PREFIX) :])
 
         # Do not include the onboarding feature if OrganizationOptions exist
         if (
-            "onboarding" in feature_list
+            "onboarding" in feature_set
             and OrganizationOption.objects.filter(organization=obj).exists()
         ):
-            feature_list.remove("onboarding")
+            feature_set.remove("onboarding")
 
         # Include api-keys feature if they previously had any api-keys
-        if "api-keys" not in feature_list and attrs["has_api_key"]:
-            feature_list.add("api-keys")
+        if "api-keys" not in feature_set and attrs["has_api_key"]:
+            feature_set.add("api-keys")
 
         # Organization flag features (not provided through the features module)
         options_as_features = OrganizationOption.objects.filter(
@@ -305,19 +294,39 @@ class OrganizationSerializer(Serializer):
         for option in options_as_features:
             for option_feature, option_function in ORGANIZATION_OPTIONS_AS_FEATURES[option.key]:
                 if option_function(option):
-                    feature_list.add(option_feature)
+                    feature_set.add(option_feature)
 
         if getattr(obj.flags, "allow_joinleave"):
-            feature_list.add("open-membership")
+            feature_set.add("open-membership")
         if not getattr(obj.flags, "disable_shared_issues"):
-            feature_list.add("shared-issues")
+            feature_set.add("shared-issues")
         request = env.request
         if request and is_using_customer_domain(request):
             # If the current request is using a customer domain, then we activate the feature for this organization.
-            feature_list.add("customer-domains")
+            feature_set.add("customer-domains")
 
-        if "dynamic-sampling" not in feature_list and "mep-rollout-flag" in feature_list:
-            feature_list.remove("mep-rollout-flag")
+        if "dynamic-sampling" not in feature_set and "mep-rollout-flag" in feature_set:
+            feature_set.remove("mep-rollout-flag")
+
+        return feature_set
+
+    def serialize(
+        self, obj: Organization, attrs: Mapping[str, Any], user: User, **kwargs: Any
+    ) -> OrganizationSerializerResponse:
+        from sentry import features
+
+        if attrs.get("avatar"):
+            avatar = {
+                "avatarType": attrs["avatar"].get_avatar_type_display(),
+                "avatarUuid": attrs["avatar"].ident if attrs["avatar"].file_id else None,
+                "avatarUrl": attrs["avatar"].absolute_url(),
+            }
+        else:
+            avatar = {"avatarType": "letter_avatar", "avatarUuid": None, "avatarUrl": None}
+
+        status = OrganizationStatus(obj.status)
+
+        include_feature_flags = kwargs.get("include_feature_flags", False)
 
         has_auth_provider = attrs.get("auth_provider", None) is not None
 
@@ -334,13 +343,15 @@ class OrganizationSerializer(Serializer):
                 and obj.flags.require_email_verification
             ),
             "avatar": avatar,
-            "features": feature_list,
             "links": {
                 "organizationUrl": generate_organization_url(obj.slug),
                 "regionUrl": generate_region_url(),
             },
             "hasAuthProvider": has_auth_provider,
         }
+
+        if include_feature_flags:
+            context["features"] = self.get_feature_set(obj, attrs, user, **kwargs)
 
         if "access" in kwargs:
             context["access"] = kwargs["access"].scopes
@@ -446,17 +457,20 @@ class DetailedOrganizationSerializer(OrganizationSerializer):
         return super().get_attrs(item_list, user)
 
     def serialize(  # type: ignore[explicit-override, override]
-        self, obj: Organization, attrs: Mapping[str, Any], user: User, access: Access
+        self, obj: Organization, attrs: Mapping[str, Any], user: User, access: Access, **kwargs: Any
     ) -> DetailedOrganizationSerializerResponse:
         # TODO: rectify access argument overriding parent if we want to remove above type ignore
 
         from sentry import experiments
 
         experiment_assignments = experiments.all(org=obj, actor=user)
+        include_feature_flags = kwargs.get("include_feature_flags", False)
 
         context = cast(
             DetailedOrganizationSerializerResponse,
-            super().serialize(obj, attrs, user, access=access),
+            super().serialize(
+                obj, attrs, user, access=access, include_feature_flags=include_feature_flags
+            ),
         )
         max_rate = quotas.get_maximum_quota(obj)
         context["experiments"] = experiment_assignments
@@ -647,7 +661,7 @@ class DetailedOrganizationSerializerWithProjectsAndTeams(DetailedOrganizationSer
         return team_list
 
     def serialize(  # type: ignore[explicit-override, override]
-        self, obj: Organization, attrs: Mapping[str, Any], user: User, access: Access
+        self, obj: Organization, attrs: Mapping[str, Any], user: User, access: Access, **kwargs: Any
     ) -> DetailedOrganizationSerializerWithProjectsAndTeamsResponse:
         from sentry.api.serializers.models.project import (
             LATEST_DEPLOYS_KEY,
@@ -657,7 +671,7 @@ class DetailedOrganizationSerializerWithProjectsAndTeams(DetailedOrganizationSer
 
         context = cast(
             DetailedOrganizationSerializerWithProjectsAndTeamsResponse,
-            super().serialize(obj, attrs, user, access),
+            super().serialize(obj, attrs, user, access, **kwargs),
         )
 
         team_list = self._team_list(obj, access)

--- a/src/sentry/api/serializers/models/organization.py
+++ b/src/sentry/api/serializers/models/organization.py
@@ -326,7 +326,7 @@ class OrganizationSerializer(Serializer):
 
         status = OrganizationStatus(obj.status)
 
-        include_feature_flags = kwargs.get("include_feature_flags", False)
+        include_feature_flags = kwargs.get("include_feature_flags", True)
 
         has_auth_provider = attrs.get("auth_provider", None) is not None
 
@@ -464,7 +464,7 @@ class DetailedOrganizationSerializer(OrganizationSerializer):
         from sentry import experiments
 
         experiment_assignments = experiments.all(org=obj, actor=user)
-        include_feature_flags = kwargs.get("include_feature_flags", False)
+        include_feature_flags = kwargs.get("include_feature_flags", True)
 
         context = cast(
             DetailedOrganizationSerializerResponse,


### PR DESCRIPTION
Followup on https://github.com/getsentry/sentry/pull/71668

I refactored the serializers here so they accept a new kwarg - `include_feature_flag`. if the kwarg is passed, it will only determine the `features` field if the flag is `True`.

This should reduce the amount of computation that we do if the response doesn't require feature flags.