### PR TITLE
fix(feedback): Fix padding on Feedback List items

### DIFF
--- a/static/app/components/feedback/list/feedbackListHeader.tsx
+++ b/static/app/components/feedback/list/feedbackListHeader.tsx
@@ -96,7 +96,7 @@ const HeaderPanel = styled('div')`
 `;
 
 const HeaderPanelItem = styled('div')`
-  padding: ${space(1)} ${space(2)} ${space(1)} ${space(2)};
+  padding: ${space(1)} ${space(1.5)} ${space(1)} ${space(1.5)};
   display: flex;
   gap: ${space(1)};
   align-items: center;

--- a/static/app/components/feedback/list/feedbackListHeader.tsx
+++ b/static/app/components/feedback/list/feedbackListHeader.tsx
@@ -96,7 +96,7 @@ const HeaderPanel = styled('div')`
 `;
 
 const HeaderPanelItem = styled('div')`
-  padding: ${space(1)} ${space(1.5)} ${space(1)} ${space(1.5)};
+  padding: ${space(1)} ${space(1.5)};
   display: flex;
   gap: ${space(1)};
   align-items: center;


### PR DESCRIPTION
Fixes alignment of the header after https://github.com/getsentry/sentry/pull/71687. With this PR the width of the list-items got bigger, because we removed extra padding/whitespace around each item.

Notice that in the 'before' screenshot the "all items" checkbox is not vertically aligned above the checkbox inside the list-item. Now the header is wider, so the checkboxes align vertically.

**Before:**
![before](https://github.com/getsentry/sentry/assets/187460/017bc144-0d73-44b9-bb6c-db1508580cd6)

**After:**
![after](https://github.com/getsentry/sentry/assets/187460/e41c9967-f61c-44dc-8f5e-d41ff2c4188f)

