### PR TITLE
feat(replay): add toggle button for hydration issue setting

### DIFF
--- a/static/app/data/forms/replay.tsx
+++ b/static/app/data/forms/replay.tsx
@@ -16,6 +16,15 @@ const formGroups: JsonFormObject[] = [
         help: t('Toggles whether or not to create Session Replay Rage Click Issues'),
         getData: data => ({options: data}),
       },
+      {
+        name: 'sentry:replay_hydration_error_issues',
+        type: 'boolean',
+
+        // additional data/props that is related to rendering of form field rather than data
+        label: t('Create Hydration Error Issues'),
+        help: t('Toggles whether or not to create Session Replay Hydration Error Issues'),
+        getData: data => ({options: data}),
+      },
     ],
   },
 ];


### PR DESCRIPTION
Follow-up to https://github.com/getsentry/sentry/pull/71411, fixes https://github.com/getsentry/sentry/issues/71396
Builds on settings page Josh added in https://github.com/getsentry/sentry/pull/64241

![Screenshot 2024-05-30 at 3 15 52 PM](https://github.com/getsentry/sentry/assets/159852527/d64ca6de-9881-4892-b1ce-d7a34e110ed3)
Button in dev-ui + correct payload sent to settings endpoint