### PR TITLE
fix(record-backfill): Fix flaky test

### DIFF
--- a/tests/sentry/tasks/test_backfill_seer_grouping_records.py
+++ b/tests/sentry/tasks/test_backfill_seer_grouping_records.py
@@ -1121,11 +1121,12 @@ class TestBackfillSeerGroupingRecords(SnubaTestCase, TestCase):
 
         groups = Group.objects.all()
         groups_len = len(groups)
+        group_ids_sorted = sorted([group.id for group in groups])
         mock_logger.info.assert_called_with(
             "tasks.backfill_seer_grouping_records.no_data",
             extra={
                 "project_id": self.project.id,
-                "group_id_batch": json.dumps([group.id for group in groups]),
+                "group_id_batch": json.dumps(group_ids_sorted),
             },
         )
         mock_call_next_backfill.assert_called_with(


### PR DESCRIPTION
Fix flaky test by sorting group ids, since the actual ids will always be sorted [here](https://github.com/getsentry/sentry/blob/0c91189943e37f3a310837047218fd52012a5463/src/sentry/tasks/backfill_seer_grouping_records.py#L122)
See flaky test [here](https://sentry.sentry.io/issues/5430399082/?project=2423079)