### PR TITLE
ref: point references to snql_query to snuba_query instead

### DIFF
--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -1069,11 +1069,6 @@ def _log_request_query(req: Request) -> None:
 RawResult = tuple[urllib3.response.HTTPResponse, Callable[[Any], Any], Callable[[Any], Any]]
 
 
-def _snql_query(params: tuple[RequestQueryBody, Hub, Mapping[str, str], str]) -> RawResult:
-    # TODO: For backwards compatibility. Some modules in Sentry use this function directly (despite it being marked private).
-    return _snuba_query(params)
-
-
 def _snuba_query(
     params: tuple[
         RequestQueryBody,

--- a/tests/sentry/issues/test_attributes.py
+++ b/tests/sentry/issues/test_attributes.py
@@ -20,7 +20,7 @@ from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers import override_options
 from sentry.types.group import GroupSubStatus
 from sentry.utils import json
-from sentry.utils.snuba import _snql_query
+from sentry.utils.snuba import _snuba_query
 
 
 class GroupAttributesTest(TestCase):
@@ -238,7 +238,7 @@ class PostUpdateLogGroupAttributesChangedTest(TestCase):
             request = json_to_snql(json_body, "group_attributes")
             request.validate()
             identity = lambda x: x
-            resp = _snql_query(((request, identity, identity), Hub(Hub.current), {}, "test_api"))
+            resp = _snuba_query(((request, identity, identity), Hub(Hub.current), {}, "test_api"))
             assert resp[0].status == 200
             stuff = json.loads(resp[0].data)
             assert stuff["data"] == [

--- a/tests/sentry/issues/test_group_attributes_dataset.py
+++ b/tests/sentry/issues/test_group_attributes_dataset.py
@@ -9,7 +9,7 @@ from sentry.issues.attributes import (
 )
 from sentry.testutils.cases import SnubaTestCase, TestCase
 from sentry.utils import json
-from sentry.utils.snuba import _snql_query
+from sentry.utils.snuba import _snuba_query
 
 
 class DatasetTest(SnubaTestCase, TestCase):
@@ -32,7 +32,7 @@ class DatasetTest(SnubaTestCase, TestCase):
         request = json_to_snql(json_body, "group_attributes")
         request.validate()
         identity = lambda x: x
-        resp = _snql_query(((request, identity, identity), Hub(Hub.current), {}, "test_api"))
+        resp = _snuba_query(((request, identity, identity), Hub(Hub.current), {}, "test_api"))
         assert resp[0].status == 200
         stuff = json.loads(resp[0].data)
 
@@ -63,7 +63,7 @@ class DatasetTest(SnubaTestCase, TestCase):
         request = json_to_snql(json_body, "group_attributes")
         request.validate()
         identity = lambda x: x
-        resp = _snql_query(((request, identity, identity), Hub(Hub.current), {}, "test_api"))
+        resp = _snuba_query(((request, identity, identity), Hub(Hub.current), {}, "test_api"))
         assert resp[0].status == 200
         stuff = json.loads(resp[0].data)
 

--- a/tests/sentry/issues/test_search_issues_dataset.py
+++ b/tests/sentry/issues/test_search_issues_dataset.py
@@ -5,7 +5,7 @@ from snuba_sdk.legacy import json_to_snql
 
 from sentry.testutils.cases import SnubaTestCase, TestCase
 from sentry.utils import json
-from sentry.utils.snuba import _snql_query
+from sentry.utils.snuba import _snuba_query
 
 
 class DatasetTest(SnubaTestCase, TestCase):
@@ -31,7 +31,7 @@ class DatasetTest(SnubaTestCase, TestCase):
         request = json_to_snql(json_body, "search_issues")
         request.validate()
         identity = lambda x: x
-        resp = _snql_query(((request, identity, identity), Hub(Hub.current), {}, "test_api"))
+        resp = _snuba_query(((request, identity, identity), Hub(Hub.current), {}, "test_api"))
         assert resp[0].status == 200
         stuff = json.loads(resp[0].data)
 


### PR DESCRIPTION
Note mentions that the private `_snql_query` was kept for backwards compatibility

i've replaced all the references to the `_snql_query` to `_snuba_query` instead now