### PR TITLE
test(ts): Remove a ton of RouterContextFixture

### DIFF
--- a/static/app/components/acl/access.spec.tsx
+++ b/static/app/components/acl/access.spec.tsx
@@ -1,7 +1,6 @@
 import {ConfigFixture} from 'sentry-fixture/config';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {ProjectFixture} from 'sentry-fixture/project';
-import {RouterContextFixture} from 'sentry-fixture/routerContextFixture';
 import {TeamFixture} from 'sentry-fixture/team';
 import {UserFixture} from 'sentry-fixture/user';
 
@@ -14,7 +13,6 @@ describe('Access', function () {
   const organization = OrganizationFixture({
     access: ['project:write', 'project:read'],
   });
-  const routerContext = RouterContextFixture([{organization}]);
 
   describe('as render prop', function () {
     const childrenMock = jest.fn().mockReturnValue(null);
@@ -25,7 +23,6 @@ describe('Access', function () {
 
     it('has access', function () {
       render(<Access access={['project:write', 'project:read']}>{childrenMock}</Access>, {
-        context: routerContext,
         organization,
       });
 
@@ -37,7 +34,6 @@ describe('Access', function () {
 
     it('has no access', function () {
       render(<Access access={['org:write']}>{childrenMock}</Access>, {
-        context: routerContext,
         organization,
       });
 
@@ -49,14 +45,13 @@ describe('Access', function () {
 
     it('read access from team', function () {
       const org = OrganizationFixture({access: []});
-      const nextRouterContext = RouterContextFixture([{organization: org}]);
 
       const team1 = TeamFixture({access: []});
       render(
         <Access access={['team:admin']} team={team1}>
           {childrenMock}
         </Access>,
-        {context: nextRouterContext, organization: org}
+        {organization: org}
       );
 
       expect(childrenMock).toHaveBeenCalledWith(
@@ -73,7 +68,7 @@ describe('Access', function () {
         <Access access={['team:admin']} team={team2}>
           {childrenMock}
         </Access>,
-        {context: nextRouterContext, organization: org}
+        {organization: org}
       );
 
       expect(childrenMock).toHaveBeenCalledWith(
@@ -86,14 +81,13 @@ describe('Access', function () {
 
     it('read access from project', function () {
       const org = OrganizationFixture({access: []});
-      const nextRouterContext = RouterContextFixture([{organization: org}]);
 
       const proj1 = ProjectFixture({access: []});
       render(
         <Access access={['project:read']} project={proj1}>
           {childrenMock}
         </Access>,
-        {context: nextRouterContext, organization: org}
+        {organization: org}
       );
 
       expect(childrenMock).toHaveBeenCalledWith(
@@ -108,7 +102,7 @@ describe('Access', function () {
         <Access access={['project:read']} project={proj2}>
           {childrenMock}
         </Access>,
-        {context: nextRouterContext, organization: org}
+        {organization: org}
       );
 
       expect(childrenMock).toHaveBeenCalledWith(
@@ -121,7 +115,6 @@ describe('Access', function () {
 
     it('handles no org', function () {
       render(<Access access={['org:write']}>{childrenMock}</Access>, {
-        context: routerContext,
         organization,
       });
 
@@ -139,7 +132,7 @@ describe('Access', function () {
         user: undefined,
       });
 
-      render(<Access>{childrenMock}</Access>, {context: routerContext, organization});
+      render(<Access>{childrenMock}</Access>, {organization});
 
       expect(childrenMock).toHaveBeenCalledWith({
         hasAccess: true,
@@ -153,7 +146,6 @@ describe('Access', function () {
       });
 
       render(<Access isSuperuser>{childrenMock}</Access>, {
-        context: routerContext,
         organization,
       });
 
@@ -169,7 +161,6 @@ describe('Access', function () {
       });
 
       render(<Access isSuperuser>{childrenMock}</Access>, {
-        context: routerContext,
         organization,
       });
 
@@ -186,7 +177,7 @@ describe('Access', function () {
         <Access access={['project:write']}>
           <p>The Child</p>
         </Access>,
-        {context: routerContext, organization}
+        {organization}
       );
 
       expect(screen.getByText('The Child')).toBeInTheDocument();
@@ -197,7 +188,7 @@ describe('Access', function () {
         <Access access={['org:write']}>
           <p>The Child</p>
         </Access>,
-        {context: routerContext, organization}
+        {organization}
       );
 
       expect(screen.queryByText('The Child')).not.toBeInTheDocument();
@@ -212,7 +203,7 @@ describe('Access', function () {
         <Access isSuperuser>
           <p>The Child</p>
         </Access>,
-        {context: routerContext, organization}
+        {organization}
       );
 
       expect(screen.getByText('The Child')).toBeInTheDocument();
@@ -227,7 +218,7 @@ describe('Access', function () {
         <Access isSuperuser>
           <p>The Child</p>
         </Access>,
-        {context: routerContext, organization}
+        {organization}
       );
       expect(screen.queryByRole('The Child')).not.toBeInTheDocument();
     });

--- a/static/app/components/acl/feature.spec.tsx
+++ b/static/app/components/acl/feature.spec.tsx
@@ -16,12 +16,7 @@ describe('Feature', function () {
   const project = ProjectFixture({
     features: ['project-foo', 'project-bar'],
   });
-  const routerContext = RouterContextFixture([
-    {
-      organization,
-      project,
-    },
-  ]);
+  const routerContext = RouterContextFixture([{project}]);
 
   describe('as render prop', function () {
     const childrenMock = jest.fn().mockReturnValue(null);

--- a/static/app/components/acl/role.spec.tsx
+++ b/static/app/components/acl/role.spec.tsx
@@ -1,5 +1,4 @@
 import {OrganizationFixture} from 'sentry-fixture/organization';
-import {RouterContextFixture} from 'sentry-fixture/routerContextFixture';
 
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
@@ -41,11 +40,6 @@ describe('Role', function () {
       },
     ],
   });
-  const routerContext = RouterContextFixture([
-    {
-      organization,
-    },
-  ]);
 
   describe('as render prop', function () {
     const childrenMock = jest.fn().mockReturnValue(null);
@@ -56,7 +50,6 @@ describe('Role', function () {
 
     it('has a sufficient role', function () {
       render(<Role role="admin">{childrenMock}</Role>, {
-        context: routerContext,
         organization,
       });
 
@@ -67,7 +60,6 @@ describe('Role', function () {
 
     it('has an insufficient role', function () {
       render(<Role role="manager">{childrenMock}</Role>, {
-        context: routerContext,
         organization,
       });
 
@@ -81,7 +73,6 @@ describe('Role', function () {
       OrganizationStore.onUpdate(organization, {replace: true});
 
       render(<Role role="owner">{childrenMock}</Role>, {
-        context: routerContext,
         organization,
       });
 
@@ -92,7 +83,6 @@ describe('Role', function () {
 
     it('does not give access to a made up role', function () {
       render(<Role role="abcdefg">{childrenMock}</Role>, {
-        context: routerContext,
         organization,
       });
 
@@ -105,7 +95,6 @@ describe('Role', function () {
       const user = {...ConfigStore.config.user};
       ConfigStore.config.user = undefined as any;
       render(<Role role="member">{childrenMock}</Role>, {
-        context: routerContext,
         organization,
       });
 
@@ -119,7 +108,6 @@ describe('Role', function () {
       const user = {...ConfigStore.config.user};
       ConfigStore.config.user = undefined as any;
       const {rerender} = render(<Role role="member">{childrenMock}</Role>, {
-        context: routerContext,
         organization,
       });
 
@@ -139,7 +127,7 @@ describe('Role', function () {
         <Role role="member" organization={{...organization, orgRoleList: []}}>
           {childrenMock}
         </Role>,
-        {context: routerContext, organization}
+        {organization}
       );
 
       expect(childrenMock).toHaveBeenCalledWith({
@@ -154,7 +142,7 @@ describe('Role', function () {
         <Role role="member">
           <div>The Child</div>
         </Role>,
-        {context: routerContext, organization}
+        {organization}
       );
 
       expect(screen.getByText('The Child')).toBeInTheDocument();
@@ -165,7 +153,7 @@ describe('Role', function () {
         <Role role="owner">
           <div>The Child</div>
         </Role>,
-        {context: routerContext, organization}
+        {organization}
       );
 
       expect(screen.queryByText('The Child')).not.toBeInTheDocument();

--- a/static/app/components/assigneeSelectorDropdown.spec.tsx
+++ b/static/app/components/assigneeSelectorDropdown.spec.tsx
@@ -1,7 +1,6 @@
 import {GroupFixture} from 'sentry-fixture/group';
 import {MemberFixture} from 'sentry-fixture/member';
 import {ProjectFixture} from 'sentry-fixture/project';
-import {RouterContextFixture} from 'sentry-fixture/routerContextFixture';
 import {TeamFixture} from 'sentry-fixture/team';
 import {UserFixture} from 'sentry-fixture/user';
 
@@ -610,9 +609,6 @@ describe('AssigneeSelectorDropdown', () => {
         loading={false}
         onAssign={newAssignee => updateGroup(GROUP_1, newAssignee)}
       />,
-      {
-        context: RouterContextFixture(),
-      }
     );
     jest.spyOn(ConfigStore, 'get').mockImplementation(() => true);
 

--- a/static/app/components/assigneeSelectorDropdown.spec.tsx
+++ b/static/app/components/assigneeSelectorDropdown.spec.tsx
@@ -608,7 +608,7 @@ describe('AssigneeSelectorDropdown', () => {
         group={GROUP_1}
         loading={false}
         onAssign={newAssignee => updateGroup(GROUP_1, newAssignee)}
-      />,
+      />
     );
     jest.spyOn(ConfigStore, 'get').mockImplementation(() => true);
 

--- a/static/app/components/badge/deployBadge.spec.tsx
+++ b/static/app/components/badge/deployBadge.spec.tsx
@@ -1,5 +1,3 @@
-import {RouterContextFixture} from 'sentry-fixture/routerContextFixture';
-
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
 import DeployBadge from 'sentry/components/badge/deployBadge';
@@ -24,8 +22,7 @@ describe('DeployBadge', () => {
         orgSlug="sentry"
         version="1.2.3"
         projectId={projectId}
-      />,
-      {context: RouterContextFixture()}
+      />
     );
 
     expect(screen.queryByRole('link')).toHaveAttribute(

--- a/static/app/components/badge/tag.spec.tsx
+++ b/static/app/components/badge/tag.spec.tsx
@@ -1,12 +1,9 @@
-import {RouterContextFixture} from 'sentry-fixture/routerContextFixture';
-
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
 import Tag from 'sentry/components/badge/tag';
 import {IconFire} from 'sentry/icons';
 
 describe('Tag', () => {
-  const routerContext = RouterContextFixture();
   it('basic', () => {
     render(<Tag>Text</Tag>);
     expect(screen.getByText('Text')).toBeInTheDocument();
@@ -55,8 +52,7 @@ describe('Tag', () => {
     render(
       <Tag type="highlight" to={to}>
         Internal link
-      </Tag>,
-      {context: routerContext}
+      </Tag>
     );
     expect(screen.getByText('Internal link')).toBeInTheDocument();
     expect(screen.getByRole('link', {name: 'Internal link'})).toBeInTheDocument();

--- a/static/app/components/commitRow.spec.tsx
+++ b/static/app/components/commitRow.spec.tsx
@@ -1,5 +1,3 @@
-import {RouterContextFixture} from 'sentry-fixture/routerContextFixture';
-
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 import {textWithMarkupMatcher} from 'sentry-test/utils';
 
@@ -62,7 +60,7 @@ describe('commitRow', () => {
       },
     } as Commit;
 
-    render(<CommitRow commit={commit} />, {context: RouterContextFixture()});
+    render(<CommitRow commit={commit} />);
     expect(
       screen.getByText(
         textWithMarkupMatcher(

--- a/static/app/components/createAlertButton.spec.tsx
+++ b/static/app/components/createAlertButton.spec.tsx
@@ -38,8 +38,6 @@ describe('CreateAlertFromViewButton', () => {
   });
 
   it('should trigger onClick callback', async () => {
-    const context = RouterContextFixture();
-
     const eventView = EventView.fromSavedQuery({
       ...DEFAULT_EVENT_VIEW,
       query: 'event.type:error',
@@ -51,8 +49,7 @@ describe('CreateAlertFromViewButton', () => {
         eventView={eventView}
         projects={[ProjectFixture()]}
         onClick={onClickMock}
-      />,
-      {context}
+      />
     );
     await userEvent.click(screen.getByRole('button', {name: 'Create Alert'}));
     expect(onClickMock).toHaveBeenCalledTimes(1);
@@ -90,7 +87,6 @@ describe('CreateAlertFromViewButton', () => {
         onClick={onClickMock}
       />,
       {
-        context: RouterContextFixture([{organization: noAccessOrg}]),
         organization: noAccessOrg,
       }
     );
@@ -126,7 +122,6 @@ describe('CreateAlertFromViewButton', () => {
         onClick={onClickMock}
       />,
       {
-        context: RouterContextFixture([{organization}]),
         organization,
       }
     );
@@ -175,7 +170,6 @@ describe('CreateAlertFromViewButton', () => {
         onClick={onClickMock}
       />,
       {
-        context: RouterContextFixture([{organization: noAccessOrg}]),
         organization: noAccessOrg,
       }
     );

--- a/static/app/components/dataExport.spec.tsx
+++ b/static/app/components/dataExport.spec.tsx
@@ -1,5 +1,4 @@
 import {OrganizationFixture} from 'sentry-fixture/organization';
-import {RouterContextFixture} from 'sentry-fixture/routerContextFixture';
 
 import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
@@ -23,9 +22,7 @@ const mockPayload = {
 };
 
 const mockContext = (organization: Organization) => {
-  const routerContext = RouterContextFixture([{organization}]);
-
-  return {context: routerContext, organization};
+  return {organization};
 };
 
 describe('DataExport', function () {

--- a/static/app/components/deprecatedAssigneeSelector.spec.tsx
+++ b/static/app/components/deprecatedAssigneeSelector.spec.tsx
@@ -1,7 +1,6 @@
 import {GroupFixture} from 'sentry-fixture/group';
 import {MemberFixture} from 'sentry-fixture/member';
 import {ProjectFixture} from 'sentry-fixture/project';
-import {RouterContextFixture} from 'sentry-fixture/routerContextFixture';
 import {TeamFixture} from 'sentry-fixture/team';
 import {UserFixture} from 'sentry-fixture/user';
 
@@ -282,9 +281,7 @@ describe('DeprecatedAssigneeSelector', () => {
 
   it('shows invite member button', async () => {
     MemberListStore.loadInitialData([USER_1, USER_2]);
-    render(<DeprecatedAssigneeSelector id={GROUP_1.id} />, {
-      context: RouterContextFixture(),
-    });
+    render(<DeprecatedAssigneeSelector id={GROUP_1.id} />);
     jest.spyOn(ConfigStore, 'get').mockImplementation(() => true);
 
     await openMenu();

--- a/static/app/components/discover/transactionsList.spec.tsx
+++ b/static/app/components/discover/transactionsList.spec.tsx
@@ -1,5 +1,3 @@
-import {RouterContextFixture} from 'sentry-fixture/routerContextFixture';
-
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import type {RenderResult} from 'sentry-test/reactTestingLibrary';
 import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
@@ -47,10 +45,9 @@ describe('TransactionsList', function () {
   });
 
   describe('Basic', function () {
-    let generateLink, routerContext;
+    let generateLink;
 
     beforeEach(function () {
-      routerContext = RouterContextFixture([{organization}]);
       initialize();
       eventView = EventView.fromSavedQuery({
         id: '',
@@ -163,10 +160,7 @@ describe('TransactionsList', function () {
           selected={options[0]}
           options={options}
           handleDropdownChange={handleDropdownChange}
-        />,
-        {
-          context: routerContext,
-        }
+        />
       );
 
       expect(await screen.findByTestId('transactions-table')).toBeInTheDocument();
@@ -203,10 +197,7 @@ describe('TransactionsList', function () {
           selected={options[2]}
           options={options}
           handleDropdownChange={handleDropdownChange}
-        />,
-        {
-          context: routerContext,
-        }
+        />
       );
 
       expect(await screen.findByTestId('transactions-table')).toBeInTheDocument();
@@ -263,10 +254,7 @@ describe('TransactionsList', function () {
           selected={options[0]}
           options={options}
           handleDropdownChange={handleDropdownChange}
-        />,
-        {
-          context: routerContext,
-        }
+        />
       );
 
       expect(await screen.findByTestId('transactions-table')).toBeInTheDocument();
@@ -286,10 +274,7 @@ describe('TransactionsList', function () {
           options={options}
           handleDropdownChange={handleDropdownChange}
           titles={['foo', 'bar']}
-        />,
-        {
-          context: routerContext,
-        }
+        />
       );
 
       expect(await screen.findByTestId('transactions-table')).toBeInTheDocument();
@@ -326,10 +311,7 @@ describe('TransactionsList', function () {
           selected={options[0]}
           options={options}
           handleDropdownChange={handleDropdown}
-        />,
-        {
-          context: routerContext,
-        }
+        />
       );
 
       expect(await screen.findByTestId('transactions-table')).toBeInTheDocument();
@@ -371,8 +353,7 @@ describe('TransactionsList', function () {
           options={options}
           handleDropdownChange={handleDropdownChange}
           generateLink={generateLink}
-        />,
-        {context: routerContext}
+        />
       );
 
       expect(await screen.findByTestId('transactions-table')).toBeInTheDocument();
@@ -400,8 +381,7 @@ describe('TransactionsList', function () {
           options={options}
           handleDropdownChange={handleDropdownChange}
           forceLoading
-        />,
-        {context: routerContext}
+        />
       );
 
       expect(await screen.findByTestId('loading-indicator')).toBeInTheDocument();

--- a/static/app/components/eventOrGroupTitle.spec.tsx
+++ b/static/app/components/eventOrGroupTitle.spec.tsx
@@ -1,5 +1,3 @@
-import {OrganizationFixture} from 'sentry-fixture/organization';
-import {RouterContextFixture} from 'sentry-fixture/routerContextFixture';
 import {UserFixture} from 'sentry-fixture/user';
 
 import {render, screen} from 'sentry-test/reactTestingLibrary';
@@ -67,8 +65,6 @@ describe('EventOrGroupTitle', function () {
   });
 
   it('renders with title override', function () {
-    const routerContext = RouterContextFixture([{organization: OrganizationFixture()}]);
-
     render(
       <EventOrGroupTitle
         data={
@@ -81,8 +77,7 @@ describe('EventOrGroupTitle', function () {
             },
           } as BaseGroup
         }
-      />,
-      {context: routerContext}
+      />
     );
 
     expect(screen.getByText('metadata title')).toBeInTheDocument();
@@ -144,9 +139,7 @@ describe('EventOrGroupTitle', function () {
     } as BaseGroup;
 
     it('should correctly render title', () => {
-      const routerContext = RouterContextFixture([{organization: OrganizationFixture()}]);
-
-      render(<EventOrGroupTitle data={perfData} />, {context: routerContext});
+      render(<EventOrGroupTitle data={perfData} />);
 
       expect(screen.getByText('N+1 Query')).toBeInTheDocument();
       expect(screen.getByText('transaction name')).toBeInTheDocument();

--- a/static/app/components/events/interfaces/frame/stacktraceLinkModal.spec.tsx
+++ b/static/app/components/events/interfaces/frame/stacktraceLinkModal.spec.tsx
@@ -3,7 +3,6 @@ import {OrganizationFixture} from 'sentry-fixture/organization';
 import {ProjectFixture} from 'sentry-fixture/project';
 import {RepositoryFixture} from 'sentry-fixture/repository';
 import {RepositoryProjectPathConfigFixture} from 'sentry-fixture/repositoryProjectPathConfig';
-import {RouterContextFixture} from 'sentry-fixture/routerContextFixture';
 
 import {
   act,
@@ -124,7 +123,7 @@ describe('StacktraceLinkModal', () => {
       statusCode: 400,
     });
 
-    renderGlobalModal({context: RouterContextFixture()});
+    renderGlobalModal();
     act(() =>
       openModal(modalProps => (
         <StacktraceLinkModal

--- a/static/app/components/events/interfaces/message.spec.tsx
+++ b/static/app/components/events/interfaces/message.spec.tsx
@@ -1,6 +1,5 @@
 import {DataScrubbingRelayPiiConfigFixture} from 'sentry-fixture/dataScrubbingRelayPiiConfig';
 import {EventFixture} from 'sentry-fixture/event';
-import {RouterContextFixture} from 'sentry-fixture/routerContextFixture';
 
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 import {textWithMarkupMatcher} from 'sentry-test/utils';
@@ -8,7 +7,6 @@ import {textWithMarkupMatcher} from 'sentry-test/utils';
 import {Message} from 'sentry/components/events/interfaces/message';
 
 describe('Message entry', function () {
-  const routerContext = RouterContextFixture();
   it('display redacted data', async function () {
     const event = EventFixture({
       entries: [
@@ -30,7 +28,6 @@ describe('Message entry', function () {
       },
     });
     render(<Message data={{formatted: null}} event={event} />, {
-      context: routerContext,
       organization: {
         relayPiiConfig: JSON.stringify(DataScrubbingRelayPiiConfigFixture()),
       },

--- a/static/app/components/events/searchBar.spec.tsx
+++ b/static/app/components/events/searchBar.spec.tsx
@@ -1,5 +1,4 @@
 import {OrganizationFixture} from 'sentry-fixture/organization';
-import {RouterContextFixture} from 'sentry-fixture/routerContextFixture';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
@@ -31,7 +30,6 @@ async function setQuery(query) {
 }
 
 describe('Events > SearchBar', function () {
-  let options;
   let tagValuesMock;
   let organization: TOrganization;
   let props: React.ComponentProps<typeof SearchBar>;
@@ -48,8 +46,6 @@ describe('Events > SearchBar', function () {
       {totalValues: 3, key: 'mytag', name: 'Mytag'},
       {totalValues: 0, key: 'browser', name: 'Browser'},
     ]);
-
-    options = RouterContextFixture();
 
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/recent-searches/',
@@ -91,7 +87,7 @@ describe('Events > SearchBar', function () {
       },
     });
     props.organization = initializationObj.organization;
-    render(<SearchBar {...props} />, {context: options});
+    render(<SearchBar {...props} />);
     await setQuery('fcp');
 
     const autocomplete = await screen.findByTestId('search-autocomplete-item');
@@ -102,7 +98,7 @@ describe('Events > SearchBar', function () {
   it('autocompletes release semver queries', async function () {
     const initializationObj = initializeOrg();
     props.organization = initializationObj.organization;
-    render(<SearchBar {...props} />, {context: options});
+    render(<SearchBar {...props} />);
     await setQuery('release.');
 
     const autocomplete = await screen.findAllByTestId('search-autocomplete-item');
@@ -112,7 +108,7 @@ describe('Events > SearchBar', function () {
   });
 
   it('autocomplete has suggestions correctly', async function () {
-    render(<SearchBar {...props} />, {context: options});
+    render(<SearchBar {...props} />);
     await setQuery('has:');
 
     const autocomplete = await screen.findAllByTestId('search-autocomplete-item');
@@ -129,7 +125,7 @@ describe('Events > SearchBar', function () {
   });
 
   it('searches and selects an event field value', async function () {
-    render(<SearchBar {...props} />, {context: options});
+    render(<SearchBar {...props} />);
     await setQuery('gpu:');
 
     expect(tagValuesMock).toHaveBeenCalledWith(
@@ -150,8 +146,7 @@ describe('Events > SearchBar', function () {
     const onBlur = jest.fn();
     const onSearch = jest.fn();
     render(
-      <SearchBar {...props} useFormWrapper={false} onSearch={onSearch} onBlur={onBlur} />,
-      {context: options}
+      <SearchBar {...props} useFormWrapper={false} onSearch={onSearch} onBlur={onBlur} />
     );
 
     await setQuery('gpu:');
@@ -173,7 +168,7 @@ describe('Events > SearchBar', function () {
   });
 
   it('filters dropdown to accommodate for num characters left in query', async function () {
-    render(<SearchBar {...props} maxQueryLength={5} />, {context: options});
+    render(<SearchBar {...props} maxQueryLength={5} />);
 
     await setQuery('g');
 
@@ -183,7 +178,7 @@ describe('Events > SearchBar', function () {
   });
 
   it('returns zero dropdown suggestions if out of characters', async function () {
-    render(<SearchBar {...props} maxQueryLength={2} />, {context: options});
+    render(<SearchBar {...props} maxQueryLength={2} />);
 
     await setQuery('g');
 
@@ -191,12 +186,12 @@ describe('Events > SearchBar', function () {
   });
 
   it('sets maxLength property', function () {
-    render(<SearchBar {...props} maxQueryLength={10} />, {context: options});
+    render(<SearchBar {...props} maxQueryLength={10} />);
     expect(screen.getByTestId('smart-search-input')).toHaveAttribute('maxLength', '10');
   });
 
   it('does not requery for event field values if query does not change', async function () {
-    render(<SearchBar {...props} />, {context: options});
+    render(<SearchBar {...props} />);
 
     await setQuery('gpu:');
 
@@ -207,7 +202,7 @@ describe('Events > SearchBar', function () {
   });
 
   it('removes highlight when query is empty', async function () {
-    render(<SearchBar {...props} />, {context: options});
+    render(<SearchBar {...props} />);
 
     await setQuery('gpu');
 
@@ -222,7 +217,7 @@ describe('Events > SearchBar', function () {
   });
 
   it('ignores negation ("!") at the beginning of search term', async function () {
-    render(<SearchBar {...props} />, {context: options});
+    render(<SearchBar {...props} />);
 
     await setQuery('!gp');
 
@@ -232,7 +227,7 @@ describe('Events > SearchBar', function () {
   });
 
   it('ignores wildcard ("*") at the beginning of tag value query', async function () {
-    render(<SearchBar {...props} />, {context: options});
+    render(<SearchBar {...props} />);
 
     await setQuery('!gpu:*');
 
@@ -252,7 +247,7 @@ describe('Events > SearchBar', function () {
       body: [],
     });
 
-    render(<SearchBar {...props} />, {context: options});
+    render(<SearchBar {...props} />);
 
     // Do 3 searches, the first will find nothing, so no more requests should be made
     await setQuery('browser:Nothing');
@@ -275,7 +270,7 @@ describe('Events > SearchBar', function () {
       body: [],
     });
 
-    render(<SearchBar {...props} />, {context: options});
+    render(<SearchBar {...props} />);
 
     await setQuery('browser:Nothing');
     expect(emptyTagValuesMock).toHaveBeenCalled();

--- a/static/app/components/idBadge/memberBadge.spec.tsx
+++ b/static/app/components/idBadge/memberBadge.spec.tsx
@@ -1,5 +1,4 @@
 import {MemberFixture} from 'sentry-fixture/member';
-import {RouterContextFixture} from 'sentry-fixture/routerContextFixture';
 import {UserFixture} from 'sentry-fixture/user';
 
 import {render, screen} from 'sentry-test/reactTestingLibrary';
@@ -8,13 +7,12 @@ import MemberBadge from 'sentry/components/idBadge/memberBadge';
 
 describe('MemberBadge', function () {
   let member;
-  const routerContext = RouterContextFixture();
   beforeEach(() => {
     member = MemberFixture();
   });
 
   it('renders with link when member and orgId are supplied', function () {
-    render(<MemberBadge member={member} />, {context: routerContext});
+    render(<MemberBadge member={member} />);
 
     expect(screen.getByTestId('letter_avatar-avatar')).toBeInTheDocument();
     expect(screen.getByRole('link', {name: 'Foo Bar'})).toBeInTheDocument();

--- a/static/app/components/idBadge/projectBadge.spec.tsx
+++ b/static/app/components/idBadge/projectBadge.spec.tsx
@@ -1,5 +1,4 @@
 import {ProjectFixture} from 'sentry-fixture/project';
-import {RouterContextFixture} from 'sentry-fixture/routerContextFixture';
 
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
@@ -7,8 +6,7 @@ import ProjectBadge from 'sentry/components/idBadge/projectBadge';
 
 describe('ProjectBadge', function () {
   it('renders with Avatar and team name', function () {
-    const routerContext = RouterContextFixture();
-    render(<ProjectBadge project={ProjectFixture()} />, {context: routerContext});
+    render(<ProjectBadge project={ProjectFixture()} />);
 
     expect(screen.getByRole('img')).toBeInTheDocument();
     expect(screen.getByRole('link')).toHaveAttribute(

--- a/static/app/components/modals/emailVerificationModal.spec.tsx
+++ b/static/app/components/modals/emailVerificationModal.spec.tsx
@@ -1,11 +1,8 @@
-import {RouterContextFixture} from 'sentry-fixture/routerContextFixture';
-
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
 import EmailVerificationModal from 'sentry/components/modals/emailVerificationModal';
 
 describe('Email Verification Modal', function () {
-  const routerContext = RouterContextFixture();
   it('renders', function () {
     MockApiClient.addMockResponse({
       url: '/users/me/emails/',
@@ -16,8 +13,7 @@ describe('Email Verification Modal', function () {
       <EmailVerificationModal
         Body={(p => p.children) as any}
         Header={(p => p.children) as any}
-      />,
-      {context: routerContext}
+      />
     );
     const message = screen.getByText(
       'Please verify your email before taking this action',

--- a/static/app/components/modals/projectCreationModal.spec.tsx
+++ b/static/app/components/modals/projectCreationModal.spec.tsx
@@ -1,5 +1,4 @@
 import {OrganizationFixture} from 'sentry-fixture/organization';
-import {RouterContextFixture} from 'sentry-fixture/routerContextFixture';
 import {MOCK_RESP_VERBOSE} from 'sentry-fixture/ruleConditions';
 import {TeamFixture} from 'sentry-fixture/team';
 
@@ -18,7 +17,6 @@ import TeamStore from 'sentry/stores/teamStore';
 describe('Project Creation Modal', function () {
   const closeModal = jest.fn();
   const organization = OrganizationFixture();
-  const routerContext = RouterContextFixture([{organization}]);
 
   it('renders modal', async function () {
     render(
@@ -93,8 +91,7 @@ describe('Project Creation Modal', function () {
         CloseButton={makeCloseButton(closeModal)}
         Header={makeClosableHeader(closeModal)}
         Footer={ModalFooter}
-      />,
-      {context: routerContext}
+      />
     );
 
     expect(screen.getByRole('button', {name: 'Next Step'})).toBeDisabled();

--- a/static/app/components/modals/recoveryOptionsModal.spec.tsx
+++ b/static/app/components/modals/recoveryOptionsModal.spec.tsx
@@ -33,7 +33,8 @@ describe('RecoveryOptionsModal', function () {
         authenticatorName="Authenticator App"
         closeModal={closeModal}
         CloseButton={makeCloseButton(() => {})}
-      />);
+      />
+    );
   }
 
   it('can redirect to recovery codes if user skips backup phone setup', async function () {

--- a/static/app/components/modals/recoveryOptionsModal.spec.tsx
+++ b/static/app/components/modals/recoveryOptionsModal.spec.tsx
@@ -3,7 +3,6 @@ import {
   AllAuthenticatorsFixture,
   AuthenticatorsFixture,
 } from 'sentry-fixture/authenticators';
-import {RouterContextFixture} from 'sentry-fixture/routerContextFixture';
 
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
@@ -13,7 +12,6 @@ import RecoveryOptionsModal from 'sentry/components/modals/recoveryOptionsModal'
 describe('RecoveryOptionsModal', function () {
   const closeModal = jest.fn();
   const mockId = AuthenticatorsFixture().Recovery().authId;
-  const routerContext = RouterContextFixture();
 
   beforeEach(function () {
     MockApiClient.clearMockResponses();
@@ -35,9 +33,7 @@ describe('RecoveryOptionsModal', function () {
         authenticatorName="Authenticator App"
         closeModal={closeModal}
         CloseButton={makeCloseButton(() => {})}
-      />,
-      {context: routerContext}
-    );
+      />);
   }
 
   it('can redirect to recovery codes if user skips backup phone setup', async function () {

--- a/static/app/components/quickTrace/index.spec.tsx
+++ b/static/app/components/quickTrace/index.spec.tsx
@@ -1,5 +1,3 @@
-import {RouterContextFixture} from 'sentry-fixture/routerContextFixture';
-
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
@@ -381,7 +379,6 @@ describe('Quick Trace', function () {
 
   describe('Event Node Clicks', function () {
     it('renders single event targets', async function () {
-      const routerContext = RouterContextFixture();
       render(
         <QuickTrace
           event={makeTransactionEventFixture(3) as Event}
@@ -401,8 +398,7 @@ describe('Quick Trace', function () {
           transactionDest="performance"
           location={location}
           organization={organization}
-        />,
-        {context: routerContext}
+        />
       );
       const nodes = await screen.findAllByTestId('event-node');
       expect(nodes.length).toEqual(6);

--- a/static/app/components/replays/replayTagsTableRow.spec.tsx
+++ b/static/app/components/replays/replayTagsTableRow.spec.tsx
@@ -1,5 +1,3 @@
-import {RouterContextFixture} from 'sentry-fixture/routerContextFixture';
-
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
 import ReplayTagsTableRow from './replayTagsTableRow';
@@ -27,8 +25,7 @@ describe('ReplayTagsTableRow', () => {
         name="foo"
         values={['bar', 'baz']}
         generateUrl={(name, value) => ({pathname: '/home', query: {[name]: value}})}
-      />,
-      {context: RouterContextFixture()}
+      />
     );
 
     expect(screen.getByText('bar').closest('a')).toHaveAttribute('href', '/home?foo=bar');
@@ -41,8 +38,7 @@ describe('ReplayTagsTableRow', () => {
         name="foo bar"
         values={['biz baz']}
         generateUrl={(name, value) => ({pathname: '/home', query: {[name]: value}})}
-      />,
-      {context: RouterContextFixture()}
+      />
     );
 
     expect(screen.getByText('foo bar')).toBeInTheDocument();

--- a/static/app/components/search/index.spec.tsx
+++ b/static/app/components/search/index.spec.tsx
@@ -109,7 +109,8 @@ describe('Search', () => {
             ]),
           ],
         })}
-      />);
+      />
+    );
 
     const opener = {opener: 'Sentry.io', location: {href: null}};
 
@@ -144,7 +145,8 @@ describe('Search', () => {
             ]),
           ],
         })}
-      />);
+      />
+    );
 
     const opener = {opener: 'Sentry.io', location: {href: null}};
 
@@ -177,7 +179,8 @@ describe('Search', () => {
           maxResults: 5,
           sources: [makeSearchResultsMock(results)],
         })}
-      />);
+      />
+    );
 
     await userEvent.click(screen.getByPlaceholderText('Search Input'));
     await userEvent.keyboard('Vandelay');
@@ -196,7 +199,8 @@ describe('Search', () => {
           maxResults: 5,
           sources: [makeSearchResultsMock([])],
         })}
-      />);
+      />
+    );
 
     await userEvent.click(screen.getByPlaceholderText('Search Input'));
     await userEvent.keyboard('Vandelay');

--- a/static/app/components/search/index.spec.tsx
+++ b/static/app/components/search/index.spec.tsx
@@ -1,5 +1,4 @@
 import Fuse from 'fuse.js';
-import {RouterContextFixture} from 'sentry-fixture/routerContextFixture';
 
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 import {textWithMarkupMatcher} from 'sentry-test/utils';
@@ -78,9 +77,7 @@ describe('Search', () => {
 
   it('renders search results from source', async () => {
     jest.useFakeTimers();
-    render(<Search {...makeSearchProps()} />, {
-      context: RouterContextFixture(),
-    });
+    render(<Search {...makeSearchProps()} />);
 
     await userEvent.click(screen.getByPlaceholderText('Search Input'), {delay: null});
     await userEvent.keyboard('Export', {delay: null});
@@ -112,11 +109,7 @@ describe('Search', () => {
             ]),
           ],
         })}
-      />,
-      {
-        context: RouterContextFixture(),
-      }
-    );
+      />);
 
     const opener = {opener: 'Sentry.io', location: {href: null}};
 
@@ -151,11 +144,7 @@ describe('Search', () => {
             ]),
           ],
         })}
-      />,
-      {
-        context: RouterContextFixture(),
-      }
-    );
+      />);
 
     const opener = {opener: 'Sentry.io', location: {href: null}};
 
@@ -188,11 +177,7 @@ describe('Search', () => {
           maxResults: 5,
           sources: [makeSearchResultsMock(results)],
         })}
-      />,
-      {
-        context: RouterContextFixture(),
-      }
-    );
+      />);
 
     await userEvent.click(screen.getByPlaceholderText('Search Input'));
     await userEvent.keyboard('Vandelay');
@@ -211,11 +196,7 @@ describe('Search', () => {
           maxResults: 5,
           sources: [makeSearchResultsMock([])],
         })}
-      />,
-      {
-        context: RouterContextFixture(),
-      }
-    );
+      />);
 
     await userEvent.click(screen.getByPlaceholderText('Search Input'));
     await userEvent.keyboard('Vandelay');

--- a/static/app/components/sidebar/sidebarDropdown/index.spec.tsx
+++ b/static/app/components/sidebar/sidebarDropdown/index.spec.tsx
@@ -1,6 +1,5 @@
 import {ConfigFixture} from 'sentry-fixture/config';
 import {OrganizationFixture} from 'sentry-fixture/organization';
-import {RouterContextFixture} from 'sentry-fixture/routerContextFixture';
 import {UserFixture} from 'sentry-fixture/user';
 
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
@@ -12,11 +11,6 @@ function renderDropdown(props: any = {}) {
   const user = UserFixture();
   const config = ConfigFixture();
   const organization = OrganizationFixture({orgRole: 'member'});
-  const routerContext = RouterContextFixture([
-    {
-      organization,
-    },
-  ]);
   return render(
     <SidebarDropdown
       orientation="left"
@@ -26,7 +20,7 @@ function renderDropdown(props: any = {}) {
       org={organization}
       {...props}
     />,
-    {context: routerContext, organization}
+    {organization}
   );
 }
 

--- a/static/app/components/sidebar/sidebarDropdown/switchOrganization.spec.tsx
+++ b/static/app/components/sidebar/sidebarDropdown/switchOrganization.spec.tsx
@@ -1,5 +1,4 @@
 import {OrganizationFixture} from 'sentry-fixture/organization';
-import {RouterContextFixture} from 'sentry-fixture/routerContextFixture';
 
 import {act, render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
@@ -7,7 +6,6 @@ import SwitchOrganization from 'sentry/components/sidebar/sidebarDropdown/switch
 import OrganizationsStore from 'sentry/stores/organizationsStore';
 
 describe('SwitchOrganization', function () {
-  const routerContext = RouterContextFixture();
   it('can list organizations', async function () {
     OrganizationsStore.load([
       OrganizationFixture({name: 'Organization 1'}),
@@ -15,9 +13,7 @@ describe('SwitchOrganization', function () {
     ]);
 
     jest.useFakeTimers();
-    render(<SwitchOrganization canCreateOrganization={false} />, {
-      context: RouterContextFixture(),
-    });
+    render(<SwitchOrganization canCreateOrganization={false} />);
 
     await userEvent.hover(screen.getByTestId('sidebar-switch-org'), {delay: null});
     act(() => jest.advanceTimersByTime(500));
@@ -54,9 +50,7 @@ describe('SwitchOrganization', function () {
     ]);
 
     jest.useFakeTimers();
-    render(<SwitchOrganization canCreateOrganization={false} />, {
-      context: routerContext,
-    });
+    render(<SwitchOrganization canCreateOrganization={false} />);
 
     await userEvent.hover(screen.getByTestId('sidebar-switch-org'), {delay: null});
     act(() => jest.advanceTimersByTime(500));
@@ -91,9 +85,7 @@ describe('SwitchOrganization', function () {
     ]);
 
     jest.useFakeTimers();
-    render(<SwitchOrganization canCreateOrganization={false} />, {
-      context: routerContext,
-    });
+    render(<SwitchOrganization canCreateOrganization={false} />);
 
     await userEvent.hover(screen.getByTestId('sidebar-switch-org'), {delay: null});
     act(() => jest.advanceTimersByTime(500));
@@ -181,7 +173,6 @@ describe('SwitchOrganization', function () {
 
     render(<SwitchOrganization canCreateOrganization={false} />, {
       organization: currentOrg,
-      context: routerContext,
     });
 
     await userEvent.hover(screen.getByTestId('sidebar-switch-org'), {delay: null});
@@ -204,9 +195,7 @@ describe('SwitchOrganization', function () {
 
   it('shows "Create an Org" if they have permission', async function () {
     jest.useFakeTimers();
-    render(<SwitchOrganization canCreateOrganization />, {
-      context: routerContext,
-    });
+    render(<SwitchOrganization canCreateOrganization />);
 
     await userEvent.hover(screen.getByTestId('sidebar-switch-org'), {delay: null});
     act(() => jest.advanceTimersByTime(500));

--- a/static/app/components/stream/processingIssueHint.spec.tsx
+++ b/static/app/components/stream/processingIssueHint.spec.tsx
@@ -1,5 +1,3 @@
-import {RouterContextFixture} from 'sentry-fixture/routerContextFixture';
-
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
 import ProcessingIssueHint from 'sentry/components/stream/processingIssueHint';
@@ -28,8 +26,7 @@ describe('ProcessingIssueHint', function () {
         orgId={orgId}
         projectId={projectId}
         showProject={showProject}
-      />,
-      {context: RouterContextFixture()}
+      />
     );
     container = result.container;
   }

--- a/static/app/components/tabs/index.spec.tsx
+++ b/static/app/components/tabs/index.spec.tsx
@@ -1,5 +1,3 @@
-import {RouterContextFixture} from 'sentry-fixture/routerContextFixture';
-
 import {render, screen, userEvent, within} from 'sentry-test/reactTestingLibrary';
 
 import {TabList, TabPanels, Tabs} from 'sentry/components/tabs';
@@ -204,7 +202,6 @@ describe('Tabs', () => {
   });
 
   it('renders tab links', async () => {
-    const routerContext = RouterContextFixture();
     render(
       <Tabs>
         <TabList>
@@ -219,8 +216,7 @@ describe('Tabs', () => {
             <TabPanels.Item key={tab.key}>{tab.content}</TabPanels.Item>
           ))}
         </TabPanels>
-      </Tabs>,
-      {context: routerContext}
+      </Tabs>
     );
 
     TABS.forEach(tab => {

--- a/static/app/views/alerts/index.spec.tsx
+++ b/static/app/views/alerts/index.spec.tsx
@@ -1,5 +1,4 @@
 import {OrganizationFixture} from 'sentry-fixture/organization';
-import {RouterContextFixture} from 'sentry-fixture/routerContextFixture';
 
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
@@ -19,7 +18,6 @@ describe('AlertsContainer', function () {
           <SubView />
         </AlertsContainer>,
         {
-          context: RouterContextFixture([{organization}]),
           organization,
         }
       );
@@ -36,7 +34,6 @@ describe('AlertsContainer', function () {
           <SubView />
         </AlertsContainer>,
         {
-          context: RouterContextFixture([{organization}]),
           organization,
         }
       );

--- a/static/app/views/discover/index.spec.tsx
+++ b/static/app/views/discover/index.spec.tsx
@@ -1,7 +1,6 @@
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {ProjectFixture} from 'sentry-fixture/project';
 import {RouteComponentPropsFixture} from 'sentry-fixture/routeComponentPropsFixture';
-import {RouterContextFixture} from 'sentry-fixture/routerContextFixture';
 
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 import selectEvent from 'sentry-test/selectEvent';
@@ -112,9 +111,7 @@ describe('Discover > Landing', function () {
   it('links back to the homepage', async () => {
     const org = OrganizationFixture({features});
 
-    render(<DiscoverLanding organization={org} {...RouteComponentPropsFixture()} />, {
-      context: RouterContextFixture(),
-    });
+    render(<DiscoverLanding organization={org} {...RouteComponentPropsFixture()} />);
 
     expect(await screen.findByText('Discover')).toHaveAttribute(
       'href',

--- a/static/app/views/issueDetails/groupEventDetails/groupEventDetails.spec.tsx
+++ b/static/app/views/issueDetails/groupEventDetails/groupEventDetails.spec.tsx
@@ -7,7 +7,6 @@ import {GroupFixture} from 'sentry-fixture/group';
 import {LocationFixture} from 'sentry-fixture/locationFixture';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {ProjectFixture} from 'sentry-fixture/project';
-import {RouterContextFixture} from 'sentry-fixture/routerContextFixture';
 import {RouterFixture} from 'sentry-fixture/routerFixture';
 import {SentryAppFixture} from 'sentry-fixture/sentryApp';
 import {SentryAppComponentFixture} from 'sentry-fixture/sentryAppComponent';
@@ -428,10 +427,8 @@ describe('groupEventDetails', () => {
       })
     );
 
-    const routerContext = RouterContextFixture();
     render(<TestComponent group={group} event={transaction} />, {
       organization: props.organization,
-      context: routerContext,
     });
 
     expect(
@@ -478,10 +475,8 @@ describe('groupEventDetails', () => {
       })
     );
 
-    const routerContext = RouterContextFixture();
     render(<TestComponent group={group} event={transaction} />, {
       organization: props.organization,
-      context: routerContext,
     });
 
     expect(
@@ -653,11 +648,9 @@ describe('Platform Integrations', () => {
         props.event,
         mockedTrace(props.project)
       );
-      const routerContext = RouterContextFixture();
 
       render(<TestComponent group={props.group} event={props.event} />, {
         organization: props.organization,
-        context: routerContext,
       });
 
       expect(
@@ -679,11 +672,9 @@ describe('Platform Integrations', () => {
         ...trace,
         performance_issues: [],
       });
-      const routerContext = RouterContextFixture();
 
       render(<TestComponent group={props.group} event={props.event} />, {
         organization: props.organization,
-        context: routerContext,
       });
 
       // mechanism: ANR

--- a/static/app/views/organizationStats/teamInsights/health.spec.tsx
+++ b/static/app/views/organizationStats/teamInsights/health.spec.tsx
@@ -1,6 +1,5 @@
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {ProjectFixture} from 'sentry-fixture/project';
-import {RouterContextFixture} from 'sentry-fixture/routerContextFixture';
 import {TeamFixture} from 'sentry-fixture/team';
 import {TeamAlertsTriggeredFixture} from 'sentry-fixture/teamAlertsTriggered';
 import {TeamResolutionTimeFixture} from 'sentry-fixture/teamResolutionTime';
@@ -179,7 +178,6 @@ describe('TeamStatsHealth', () => {
       organization.access = organization.access.filter(scope => scope !== 'org:admin');
     }
 
-    const context = RouterContextFixture([{organization}]);
     TeamStore.loadInitialData(teams, false, null);
 
     MockApiClient.addMockResponse({
@@ -188,7 +186,6 @@ describe('TeamStatsHealth', () => {
     });
 
     return render(<TeamStatsHealth {...routerProps} />, {
-      context,
       organization,
     });
   }

--- a/static/app/views/organizationStats/teamInsights/index.spec.tsx
+++ b/static/app/views/organizationStats/teamInsights/index.spec.tsx
@@ -1,6 +1,5 @@
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {ProjectFixture} from 'sentry-fixture/project';
-import {RouterContextFixture} from 'sentry-fixture/routerContextFixture';
 
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
@@ -14,12 +13,10 @@ describe('TeamInsightsContainer', () => {
 
   it('blocks access if org is missing flag', () => {
     const organization = OrganizationFixture();
-    const context = RouterContextFixture([{organization}]);
     render(
       <TeamInsightsContainer organization={organization}>
         <div>test</div>
-      </TeamInsightsContainer>,
-      {context}
+      </TeamInsightsContainer>
     );
 
     expect(screen.queryByText('test')).not.toBeInTheDocument();
@@ -27,12 +24,10 @@ describe('TeamInsightsContainer', () => {
   it('allows access for orgs with flag', () => {
     ProjectsStore.loadInitialData([ProjectFixture()]);
     const organization = OrganizationFixture({features: ['team-insights']});
-    const context = RouterContextFixture([{organization}]);
     render(
       <TeamInsightsContainer organization={organization}>
         <div>test</div>
-      </TeamInsightsContainer>,
-      {context}
+      </TeamInsightsContainer>
     );
 
     expect(screen.getByText('test')).toBeInTheDocument();
@@ -40,8 +35,7 @@ describe('TeamInsightsContainer', () => {
   it('shows message for users with no teams', () => {
     ProjectsStore.loadInitialData([]);
     const organization = OrganizationFixture({features: ['team-insights']});
-    const context = RouterContextFixture([{organization}]);
-    render(<TeamInsightsContainer organization={organization} />, {context});
+    render(<TeamInsightsContainer organization={organization} />);
 
     expect(
       screen.getByText('You need at least one project to use this view')

--- a/static/app/views/organizationStats/teamInsights/issues.spec.tsx
+++ b/static/app/views/organizationStats/teamInsights/issues.spec.tsx
@@ -1,6 +1,5 @@
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {ProjectFixture} from 'sentry-fixture/project';
-import {RouterContextFixture} from 'sentry-fixture/routerContextFixture';
 import {TeamFixture} from 'sentry-fixture/team';
 import {TeamIssuesBreakdownFixture} from 'sentry-fixture/teamIssuesBreakdown';
 import {TeamResolutionTimeFixture} from 'sentry-fixture/teamResolutionTime';
@@ -147,13 +146,9 @@ describe('TeamStatsIssues', () => {
       organization.access = organization.access.filter(scope => scope !== 'org:admin');
     }
 
-    const context = RouterContextFixture([{organization}]);
     TeamStore.loadInitialData(teams, false, null);
 
-    return render(<TeamStatsIssues {...routerProps} />, {
-      context,
-      organization,
-    });
+    return render(<TeamStatsIssues {...routerProps} />, {organization});
   }
 
   it('defaults to first team', async () => {

--- a/static/app/views/performance/transactionDetails/eventMetas.spec.tsx
+++ b/static/app/views/performance/transactionDetails/eventMetas.spec.tsx
@@ -1,6 +1,6 @@
 import {EventFixture} from 'sentry-fixture/event';
+import {LocationFixture} from 'sentry-fixture/locationFixture';
 import {OrganizationFixture} from 'sentry-fixture/organization';
-import {RouterContextFixture} from 'sentry-fixture/routerContextFixture';
 
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
@@ -12,7 +12,6 @@ describe('EventMetas', () => {
       dateReceived: '2017-05-21T18:01:48.762Z',
       dateCreated: '2017-05-21T18:02:48.762Z',
     });
-    const routerContext = RouterContextFixture([]);
     const organization = OrganizationFixture({});
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/projects/',
@@ -21,7 +20,7 @@ describe('EventMetas', () => {
     render(
       <EventMetas
         event={event}
-        location={routerContext.context.location}
+        location={LocationFixture()}
         organization={organization}
         errorDest="discover"
         transactionDest="discover"

--- a/static/app/views/performance/transactionDetails/quickTraceMeta.spec.tsx
+++ b/static/app/views/performance/transactionDetails/quickTraceMeta.spec.tsx
@@ -1,6 +1,6 @@
 import {EventFixture} from 'sentry-fixture/event';
+import {LocationFixture} from 'sentry-fixture/locationFixture';
 import {ProjectFixture} from 'sentry-fixture/project';
-import {RouterContextFixture} from 'sentry-fixture/routerContextFixture';
 
 import {render, screen, userEvent, within} from 'sentry-test/reactTestingLibrary';
 
@@ -12,8 +12,7 @@ import type {
 import QuickTraceMeta from 'sentry/views/performance/transactionDetails/quickTraceMeta';
 
 describe('QuickTraceMeta', function () {
-  const routerContext = RouterContextFixture();
-  const location = routerContext.context.location;
+  const location = LocationFixture();
   const project = ProjectFixture({platform: 'javascript'});
   const event = EventFixture({contexts: {trace: {trace_id: 'a'.repeat(32)}}});
   const emptyQuickTrace: QuickTraceQueryChildrenProps = {
@@ -168,8 +167,7 @@ describe('QuickTraceMeta', function () {
         anchor="left"
         errorDest="issue"
         transactionDest="performance"
-      />,
-      {context: routerContext}
+      />
     );
 
     expect(screen.getByRole('heading', {name: 'Trace Navigator'})).toBeInTheDocument();

--- a/static/app/views/performance/transactionSummary/transactionOverview/content.spec.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/content.spec.tsx
@@ -1,7 +1,6 @@
 import type {InjectedRouter} from 'react-router';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {ProjectFixture} from 'sentry-fixture/project';
-import {RouterContextFixture} from 'sentry-fixture/routerContextFixture';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen} from 'sentry-test/reactTestingLibrary';
@@ -154,7 +153,6 @@ describe('Transaction Summary Content', function () {
       transactionName,
       router,
     } = initialize(project, {});
-    const routerContext = RouterContextFixture([{organization}]);
 
     render(
       <WrappedComponent
@@ -169,8 +167,7 @@ describe('Transaction Summary Content', function () {
         error={null}
         onChangeFilter={() => {}}
         router={router}
-      />,
-      {context: routerContext}
+      />
     );
 
     expect(

--- a/static/app/views/performance/vitalDetail/index.spec.tsx
+++ b/static/app/views/performance/vitalDetail/index.spec.tsx
@@ -282,7 +282,6 @@ describe('Performance > VitalDetail', function () {
 
     const context = RouterContextFixture([
       {
-        organization,
         project,
         router: newRouter,
         location: newRouter.location,
@@ -336,7 +335,6 @@ describe('Performance > VitalDetail', function () {
 
     const context = RouterContextFixture([
       {
-        organization,
         project,
         router: newRouter,
         location: newRouter.location,
@@ -391,7 +389,6 @@ describe('Performance > VitalDetail', function () {
 
     const context = RouterContextFixture([
       {
-        organization,
         project,
         router: newRouter,
         location: newRouter.location,

--- a/static/app/views/profiling/profileSummary/profileSummaryPage.spec.tsx
+++ b/static/app/views/profiling/profileSummary/profileSummaryPage.spec.tsx
@@ -2,7 +2,6 @@ import type {Location} from 'history';
 import {GlobalSelectionFixture} from 'sentry-fixture/globalSelection';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {ProjectFixture} from 'sentry-fixture/project';
-import {RouterContextFixture} from 'sentry-fixture/routerContextFixture';
 
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
@@ -97,7 +96,6 @@ describe('ProfileSummaryPage', () => {
         organization: OrganizationFixture({
           features: ['profiling-summary-redesign'],
         }),
-        context: RouterContextFixture(),
       }
     );
 

--- a/static/app/views/projectDetail/projectFilters.spec.tsx
+++ b/static/app/views/projectDetail/projectFilters.spec.tsx
@@ -1,5 +1,3 @@
-import {RouterContextFixture} from 'sentry-fixture/routerContextFixture';
-
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
 import ProjectFilters from 'sentry/views/projectDetail/projectFilters';
@@ -29,8 +27,7 @@ describe('ProjectDetail > ProjectFilters', () => {
         onSearch={onSearch}
         tagValueLoader={tagValueLoader}
         relativeDateOptions={{}}
-      />,
-      {context: RouterContextFixture()}
+      />
     );
 
     await userEvent.click(

--- a/static/app/views/releases/detail/header/releaseActions.spec.tsx
+++ b/static/app/views/releases/detail/header/releaseActions.spec.tsx
@@ -6,7 +6,6 @@ import {ReleaseFixture} from 'sentry-fixture/release';
 import {ReleaseMetaFixture} from 'sentry-fixture/releaseMeta';
 import {ReleaseProjectFixture} from 'sentry-fixture/releaseProject';
 import {RouteComponentPropsFixture} from 'sentry-fixture/routeComponentPropsFixture';
-import {RouterContextFixture} from 'sentry-fixture/routerContextFixture';
 
 import {
   render,
@@ -155,7 +154,6 @@ describe('ReleaseActions', function () {
   });
 
   it('navigates to a next/prev release', function () {
-    const routerContext = RouterContextFixture();
     const {rerender} = render(
       <ReleaseActions
         organization={organization}
@@ -164,8 +162,7 @@ describe('ReleaseActions', function () {
         refetchData={jest.fn()}
         releaseMeta={{...ReleaseMetaFixture(), projects: release.projects}}
         location={location}
-      />,
-      {context: routerContext}
+      />
     );
 
     expect(screen.getByLabelText('Oldest')).toHaveAttribute(

--- a/static/app/views/replays/list/listContent.spec.tsx
+++ b/static/app/views/replays/list/listContent.spec.tsx
@@ -1,9 +1,7 @@
 import {OrganizationFixture} from 'sentry-fixture/organization';
-import {RouterContextFixture} from 'sentry-fixture/routerContextFixture';
 
 import {render, screen, waitFor} from 'sentry-test/reactTestingLibrary';
 
-import type {Organization as TOrganization} from 'sentry/types';
 import useDeadRageSelectors from 'sentry/utils/replays/hooks/useDeadRageSelectors';
 import {
   useHaveSelectedProjectsSentAnyReplayEvents,
@@ -39,10 +37,6 @@ function getMockOrganizationFixture({features}: {features: string[]}) {
   return mockOrg;
 }
 
-function getMockContext(mockOrg: TOrganization) {
-  return RouterContextFixture([{organization: mockOrg}]);
-}
-
 describe('ReplayList', () => {
   let mockFetchReplayListRequest;
   beforeEach(() => {
@@ -73,7 +67,6 @@ describe('ReplayList', () => {
     });
 
     render(<ListPage />, {
-      context: getMockContext(mockOrg),
       organization: mockOrg,
     });
 
@@ -96,7 +89,6 @@ describe('ReplayList', () => {
     });
 
     render(<ListPage />, {
-      context: getMockContext(mockOrg),
       organization: mockOrg,
     });
 
@@ -119,7 +111,6 @@ describe('ReplayList', () => {
     });
 
     render(<ListPage />, {
-      context: getMockContext(mockOrg),
       organization: mockOrg,
     });
 
@@ -142,7 +133,6 @@ describe('ReplayList', () => {
     });
 
     render(<ListPage />, {
-      context: getMockContext(mockOrg),
       organization: mockOrg,
     });
 
@@ -172,7 +162,6 @@ describe('ReplayList', () => {
     });
 
     render(<ListPage />, {
-      context: getMockContext(mockOrg),
       organization: mockOrg,
     });
 

--- a/static/app/views/settings/account/accountAuthorizations.spec.tsx
+++ b/static/app/views/settings/account/accountAuthorizations.spec.tsx
@@ -1,5 +1,4 @@
 import {LocationFixture} from 'sentry-fixture/locationFixture';
-import {RouterContextFixture} from 'sentry-fixture/routerContextFixture';
 import {RouterFixture} from 'sentry-fixture/routerFixture';
 
 import {render} from 'sentry-test/reactTestingLibrary';
@@ -27,10 +26,7 @@ describe('AccountAuthorizations', function () {
         routes={router.routes}
         route={router.routes[0]}
         router={router}
-      />,
-      {
-        context: RouterContextFixture(),
-      }
+      />
     );
   });
 });

--- a/static/app/views/settings/account/accountSecurity/index.spec.tsx
+++ b/static/app/views/settings/account/accountSecurity/index.spec.tsx
@@ -1,7 +1,6 @@
 import {AccountEmailsFixture} from 'sentry-fixture/accountEmails';
 import {AuthenticatorsFixture} from 'sentry-fixture/authenticators';
 import {OrganizationsFixture} from 'sentry-fixture/organizations';
-import {RouterContextFixture} from 'sentry-fixture/routerContextFixture';
 import {RouterFixture} from 'sentry-fixture/routerFixture';
 
 import {
@@ -66,8 +65,7 @@ describe('AccountSecurity', function () {
           routeParams={router.params}
           params={{...router.params, authId: '15'}}
         />
-      </AccountSecurityWrapper>,
-      {context: RouterContextFixture()}
+      </AccountSecurityWrapper>
     );
   }
 

--- a/static/app/views/settings/account/accountSecurity/sessionHistory/index.spec.tsx
+++ b/static/app/views/settings/account/accountSecurity/sessionHistory/index.spec.tsx
@@ -1,5 +1,3 @@
-import {RouterContextFixture} from 'sentry-fixture/routerContextFixture';
-
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
@@ -37,7 +35,7 @@ describe('AccountSecuritySessionHistory', function () {
       ],
     });
 
-    render(<SessionHistory {...routerProps} />, {context: RouterContextFixture()});
+    render(<SessionHistory {...routerProps} />);
 
     expect(await screen.findByText('127.0.0.1')).toBeInTheDocument();
     expect(screen.getByText('192.168.0.1')).toBeInTheDocument();

--- a/static/app/views/settings/account/accountSubscriptions.spec.tsx
+++ b/static/app/views/settings/account/accountSubscriptions.spec.tsx
@@ -1,4 +1,3 @@
-import {RouterContextFixture} from 'sentry-fixture/routerContextFixture';
 import {SubscriptionsFixture} from 'sentry-fixture/subscriptions';
 
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
@@ -17,9 +16,7 @@ describe('AccountSubscriptions', function () {
       url: ENDPOINT,
       body: [],
     });
-    render(<AccountSubscriptions />, {
-      context: RouterContextFixture(),
-    });
+    render(<AccountSubscriptions />);
   });
 
   it('renders list and can toggle', async function () {

--- a/static/app/views/settings/account/apiNewToken.spec.tsx
+++ b/static/app/views/settings/account/apiNewToken.spec.tsx
@@ -1,5 +1,3 @@
-import {RouterContextFixture} from 'sentry-fixture/routerContextFixture';
-
 import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 import selectEvent from 'sentry-test/selectEvent';
 
@@ -7,15 +5,11 @@ import ApiNewToken from 'sentry/views/settings/account/apiNewToken';
 
 describe('ApiNewToken', function () {
   it('renders', function () {
-    render(<ApiNewToken />, {
-      context: RouterContextFixture(),
-    });
+    render(<ApiNewToken />);
   });
 
   it('renders with disabled "Create Token" button', async function () {
-    render(<ApiNewToken />, {
-      context: RouterContextFixture(),
-    });
+    render(<ApiNewToken />);
 
     expect(await screen.getByRole('button', {name: 'Create Token'})).toBeDisabled();
   });
@@ -27,9 +21,7 @@ describe('ApiNewToken', function () {
       url: `/api-tokens/`,
     });
 
-    render(<ApiNewToken />, {
-      context: RouterContextFixture(),
-    });
+    render(<ApiNewToken />);
     const createButton = await screen.getByRole('button', {name: 'Create Token'});
 
     const selectByValue = (name, value) =>
@@ -82,9 +74,7 @@ describe('ApiNewToken', function () {
       url: `/api-tokens/`,
     });
 
-    render(<ApiNewToken />, {
-      context: RouterContextFixture(),
-    });
+    render(<ApiNewToken />);
     const createButton = screen.getByRole('button', {name: 'Create Token'});
 
     const selectByValue = (name, value) =>
@@ -122,9 +112,7 @@ describe('ApiNewToken', function () {
       url: `/api-tokens/`,
     });
 
-    render(<ApiNewToken />, {
-      context: RouterContextFixture(),
-    });
+    render(<ApiNewToken />);
     const createButton = screen.getByRole('button', {name: 'Create Token'});
 
     const selectByValue = (name, value) =>

--- a/static/app/views/settings/components/settingsSearch/index.spec.tsx
+++ b/static/app/views/settings/components/settingsSearch/index.spec.tsx
@@ -1,8 +1,6 @@
 import {MembersFixture} from 'sentry-fixture/members';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {ProjectFixture} from 'sentry-fixture/project';
-import {RouterContextFixture} from 'sentry-fixture/routerContextFixture';
-import {RouterFixture} from 'sentry-fixture/routerFixture';
 import {TeamFixture} from 'sentry-fixture/team';
 
 import {fireEvent, render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
@@ -17,13 +15,6 @@ jest.mock('sentry/actionCreators/navigation');
 
 describe('SettingsSearch', function () {
   let orgsMock: jest.Mock;
-  const routerContext = RouterContextFixture([
-    {
-      router: RouterFixture({
-        params: {},
-      }),
-    },
-  ]);
 
   beforeEach(function () {
     FormSearchStore.loadSearchMap([]);
@@ -80,9 +71,7 @@ describe('SettingsSearch', function () {
   });
 
   it('can search', async function () {
-    render(<SettingsSearch />, {
-      context: routerContext,
-    });
+    render(<SettingsSearch />);
 
     await userEvent.type(screen.getByPlaceholderText('Search'), 'bil');
 

--- a/static/app/views/settings/organizationAuth/organizationAuthList.spec.tsx
+++ b/static/app/views/settings/organizationAuth/organizationAuthList.spec.tsx
@@ -1,6 +1,5 @@
 import {AuthProvidersFixture} from 'sentry-fixture/authProviders';
 import {OrganizationFixture} from 'sentry-fixture/organization';
-import {RouterContextFixture} from 'sentry-fixture/routerContextFixture';
 
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
@@ -31,17 +30,14 @@ describe('OrganizationAuthList', function () {
   });
 
   it('renders for members', function () {
-    const context = RouterContextFixture([
-      {organization: OrganizationFixture({access: ['org:read']})},
-    ]);
+    const organization = OrganizationFixture({access: ['org:read']});
 
     render(
       <OrganizationAuthList
-        organization={OrganizationFixture()}
+        organization={organization}
         providerList={AuthProvidersFixture()}
         activeProvider={AuthProvidersFixture()[0]}
-      />,
-      {context}
+      />
     );
 
     expect(screen.getByText('Active')).toBeInTheDocument();
@@ -54,14 +50,12 @@ describe('OrganizationAuthList', function () {
 
     it('renders', function () {
       const organization = OrganizationFixture({...require2fa, ...withSSO});
-      const context = RouterContextFixture([{organization}]);
 
       render(
         <OrganizationAuthList
           organization={organization}
           providerList={AuthProvidersFixture()}
-        />,
-        {context}
+        />
       );
 
       expect(
@@ -71,14 +65,12 @@ describe('OrganizationAuthList', function () {
 
     it('renders with saml available', function () {
       const organization = OrganizationFixture({...require2fa, ...withSAML});
-      const context = RouterContextFixture([{organization}]);
 
       render(
         <OrganizationAuthList
           organization={organization}
           providerList={AuthProvidersFixture()}
-        />,
-        {context}
+        />
       );
 
       expect(
@@ -88,14 +80,12 @@ describe('OrganizationAuthList', function () {
 
     it('does not render without sso available', function () {
       const organization = OrganizationFixture({...require2fa});
-      const context = RouterContextFixture([{organization}]);
 
       render(
         <OrganizationAuthList
           organization={organization}
           providerList={AuthProvidersFixture()}
-        />,
-        {context}
+        />
       );
 
       expect(
@@ -105,14 +95,12 @@ describe('OrganizationAuthList', function () {
 
     it('does not render with sso and require 2fa disabled', function () {
       const organization = OrganizationFixture({...withSSO});
-      const context = RouterContextFixture([{organization}]);
 
       render(
         <OrganizationAuthList
           organization={organization}
           providerList={AuthProvidersFixture()}
-        />,
-        {context}
+        />
       );
 
       expect(
@@ -122,14 +110,12 @@ describe('OrganizationAuthList', function () {
 
     it('does not render with saml and require 2fa disabled', function () {
       const organization = OrganizationFixture({...withSAML});
-      const context = RouterContextFixture([{organization}]);
 
       render(
         <OrganizationAuthList
           organization={organization}
           providerList={AuthProvidersFixture()}
-        />,
-        {context}
+        />
       );
 
       expect(

--- a/static/app/views/settings/organizationAuth/providerItem.spec.tsx
+++ b/static/app/views/settings/organizationAuth/providerItem.spec.tsx
@@ -1,6 +1,5 @@
 import {AuthProvidersFixture} from 'sentry-fixture/authProviders';
 import {OrganizationFixture} from 'sentry-fixture/organization';
-import {RouterContextFixture} from 'sentry-fixture/routerContextFixture';
 
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
@@ -12,11 +11,9 @@ describe('ProviderItem', function () {
   const org = OrganizationFixture({
     features: [descopeFeatureName(provider.requiredFeature)],
   });
-  const routerContext = RouterContextFixture([{organization: org}]);
 
   it('renders', function () {
     render(<ProviderItem active={false} provider={provider} onConfigure={() => {}} />, {
-      context: routerContext,
       organization: org,
     });
 
@@ -28,7 +25,6 @@ describe('ProviderItem', function () {
   it('calls configure callback', async function () {
     const mock = jest.fn();
     render(<ProviderItem active={false} provider={provider} onConfigure={mock} />, {
-      context: routerContext,
       organization: org,
     });
 
@@ -38,7 +34,6 @@ describe('ProviderItem', function () {
 
   it('renders a disabled Tag when disabled', function () {
     render(<ProviderItem active={false} provider={provider} onConfigure={() => {}} />, {
-      context: RouterContextFixture(),
       organization: OrganizationFixture(),
     });
 

--- a/static/app/views/settings/organizationDeveloperSettings/sentryApplicationDetails.spec.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/sentryApplicationDetails.spec.tsx
@@ -1,6 +1,5 @@
 import {LocationFixture} from 'sentry-fixture/locationFixture';
 import {OrganizationFixture} from 'sentry-fixture/organization';
-import {RouterContextFixture} from 'sentry-fixture/routerContextFixture';
 import {RouterFixture} from 'sentry-fixture/routerFixture';
 import {SentryAppFixture} from 'sentry-fixture/sentryApp';
 import {SentryAppTokenFixture} from 'sentry-fixture/sentryAppToken';
@@ -17,7 +16,6 @@ import selectEvent from 'sentry-test/selectEvent';
 import SentryApplicationDetails from 'sentry/views/settings/organizationDeveloperSettings/sentryApplicationDetails';
 
 describe('Sentry Application Details', function () {
-  let org;
   let sentryApp;
   let token;
   let createAppRequest;
@@ -29,8 +27,6 @@ describe('Sentry Application Details', function () {
 
   beforeEach(() => {
     MockApiClient.clearMockResponses();
-
-    org = OrganizationFixture({features: ['sentry-app-logo-upload']});
   });
 
   describe('Creating a new public Sentry App', () => {
@@ -43,8 +39,7 @@ describe('Sentry Application Details', function () {
           routeParams={{}}
           route={{}}
           params={{}}
-        />,
-        {context: RouterContextFixture([{organization: org}])}
+        />
       );
     }
 
@@ -117,7 +112,7 @@ describe('Sentry Application Details', function () {
       const data = {
         name: 'Test App',
         author: 'Sentry',
-        organization: org.slug,
+        organization: OrganizationFixture().slug,
         redirectUrl: 'https://webhook.com/setup',
         webhookUrl: 'https://webhook.com',
         scopes: expect.arrayContaining([
@@ -154,8 +149,7 @@ describe('Sentry Application Details', function () {
           routeParams={{}}
           route={{}}
           params={{}}
-        />,
-        {context: RouterContextFixture([{organization: org}])}
+        />
       );
     }
 
@@ -189,10 +183,7 @@ describe('Sentry Application Details', function () {
           routeParams={{}}
           route={{}}
           params={{appSlug: sentryApp.slug}}
-        />,
-        {
-          context: RouterContextFixture([{organization: org}]),
-        }
+        />
       );
     }
 
@@ -253,10 +244,7 @@ describe('Sentry Application Details', function () {
           routeParams={{}}
           route={{}}
           params={{appSlug: sentryApp.slug}}
-        />,
-        {
-          context: RouterContextFixture([{organization: org}]),
-        }
+        />
       );
     }
 
@@ -322,10 +310,7 @@ describe('Sentry Application Details', function () {
           routeParams={{}}
           route={{}}
           params={{appSlug: sentryApp.slug}}
-        />,
-        {
-          context: RouterContextFixture([{organization: org}]),
-        }
+        />
       );
     }
 
@@ -371,10 +356,7 @@ describe('Sentry Application Details', function () {
           routeParams={{}}
           route={{}}
           params={{appSlug: sentryApp.slug}}
-        />,
-        {
-          context: RouterContextFixture([{organization: org}]),
-        }
+        />
       );
     }
 
@@ -459,10 +441,7 @@ describe('Sentry Application Details', function () {
           routeParams={{}}
           route={{}}
           params={{appSlug: sentryApp.slug}}
-        />,
-        {
-          context: RouterContextFixture([{organization: org}]),
-        }
+        />
       );
     }
 
@@ -553,10 +532,7 @@ describe('Sentry Application Details', function () {
           routeParams={{}}
           route={{}}
           params={{appSlug: sentryApp.slug}}
-        />,
-        {
-          context: RouterContextFixture([{organization: org}]),
-        }
+        />
       );
     }
 

--- a/static/app/views/settings/organizationMembers/organizationMembersList.spec.tsx
+++ b/static/app/views/settings/organizationMembers/organizationMembersList.spec.tsx
@@ -181,9 +181,7 @@ describe('OrganizationMembersList', function () {
       method: 'DELETE',
     });
 
-    render(<OrganizationMembersList {...defaultProps} />, {
-      context: RouterContextFixture([{organization}]),
-    });
+    render(<OrganizationMembersList {...defaultProps} />);
 
     await userEvent.click(screen.getAllByRole('button', {name: 'Remove'})[0]);
 
@@ -204,9 +202,7 @@ describe('OrganizationMembersList', function () {
       statusCode: 500,
     });
 
-    render(<OrganizationMembersList {...defaultProps} />, {
-      context: RouterContextFixture([{organization}]),
-    });
+    render(<OrganizationMembersList {...defaultProps} />);
 
     await userEvent.click(screen.getAllByRole('button', {name: 'Remove'})[0]);
 
@@ -226,9 +222,7 @@ describe('OrganizationMembersList', function () {
       method: 'DELETE',
     });
 
-    render(<OrganizationMembersList {...defaultProps} />, {
-      context: RouterContextFixture([{organization}]),
-    });
+    render(<OrganizationMembersList {...defaultProps} />);
 
     await userEvent.click(screen.getAllByRole('button', {name: 'Leave'})[0]);
 
@@ -256,9 +250,7 @@ describe('OrganizationMembersList', function () {
     });
     OrganizationsStore.addOrReplace(secondOrg);
 
-    render(<OrganizationMembersList {...defaultProps} />, {
-      context: RouterContextFixture([{organization}]),
-    });
+    render(<OrganizationMembersList {...defaultProps} />);
 
     await userEvent.click(screen.getAllByRole('button', {name: 'Leave'})[0]);
 
@@ -282,9 +274,7 @@ describe('OrganizationMembersList', function () {
       statusCode: 500,
     });
 
-    render(<OrganizationMembersList {...defaultProps} />, {
-      context: RouterContextFixture([{organization}]),
-    });
+    render(<OrganizationMembersList {...defaultProps} />);
 
     await userEvent.click(screen.getAllByRole('button', {name: 'Leave'})[0]);
 
@@ -307,9 +297,7 @@ describe('OrganizationMembersList', function () {
       },
     });
 
-    render(<OrganizationMembersList {...defaultProps} />, {
-      context: RouterContextFixture([{organization}]),
-    });
+    render(<OrganizationMembersList {...defaultProps} />);
 
     expect(inviteMock).not.toHaveBeenCalled();
 
@@ -326,9 +314,7 @@ describe('OrganizationMembersList', function () {
       },
     });
 
-    render(<OrganizationMembersList {...defaultProps} />, {
-      context: RouterContextFixture([{organization}]),
-    });
+    render(<OrganizationMembersList {...defaultProps} />);
 
     expect(inviteMock).not.toHaveBeenCalled();
 
@@ -370,10 +356,7 @@ describe('OrganizationMembersList', function () {
       url: '/organizations/org-slug/members/',
       body: [],
     });
-    const routerContext = RouterContextFixture();
-    render(<OrganizationMembersList {...defaultProps} />, {
-      context: routerContext,
-    });
+    render(<OrganizationMembersList {...defaultProps} />);
 
     await userEvent.click(screen.getByRole('button', {name: 'Filter'}));
     await userEvent.click(screen.getByRole('option', {name: 'Member'}));
@@ -465,9 +448,7 @@ describe('OrganizationMembersList', function () {
         method: 'PUT',
       });
 
-      render(<OrganizationMembersList {...defaultProps} organization={org} />, {
-        context: RouterContextFixture([{organization: org}]),
-      });
+      render(<OrganizationMembersList {...defaultProps} organization={org} />);
 
       expect(await screen.findByText('Pending Members')).toBeInTheDocument();
       expect(screen.getByRole('button', {name: 'Approve'})).toBeDisabled();
@@ -491,9 +472,7 @@ describe('OrganizationMembersList', function () {
         method: 'PUT',
       });
 
-      render(<OrganizationMembersList {...defaultProps} />, {
-        context: RouterContextFixture([{organization: org}]),
-      });
+      render(<OrganizationMembersList {...defaultProps} />);
 
       expect(screen.getByText('Pending Members')).toBeInTheDocument();
 
@@ -529,9 +508,7 @@ describe('OrganizationMembersList', function () {
         method: 'DELETE',
       });
 
-      render(<OrganizationMembersList {...defaultProps} />, {
-        context: RouterContextFixture([{organization: org}]),
-      });
+      render(<OrganizationMembersList {...defaultProps} />);
 
       expect(screen.getByText('Pending Members')).toBeInTheDocument();
 
@@ -565,9 +542,7 @@ describe('OrganizationMembersList', function () {
         method: 'PUT',
       });
 
-      render(<OrganizationMembersList {...defaultProps} />, {
-        context: RouterContextFixture([{organization: org}]),
-      });
+      render(<OrganizationMembersList {...defaultProps} />, {organization: org});
 
       await selectEvent.select(screen.getAllByRole('textbox')[1], ['Admin']);
 

--- a/static/app/views/settings/project/projectOwnership/index.spec.tsx
+++ b/static/app/views/settings/project/projectOwnership/index.spec.tsx
@@ -1,6 +1,5 @@
 import {GitHubIntegrationConfigFixture} from 'sentry-fixture/integrationListDirectory';
 import {OrganizationFixture} from 'sentry-fixture/organization';
-import {RouterContextFixture} from 'sentry-fixture/routerContextFixture';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
@@ -91,8 +90,7 @@ describe('Project Ownership', () => {
           params={{projectId: project.slug}}
           organization={org}
           project={project}
-        />,
-        {context: RouterContextFixture([{organization: org}])}
+        />
       );
 
       // Renders button

--- a/static/app/views/settings/projectGeneralSettings/index.spec.tsx
+++ b/static/app/views/settings/projectGeneralSettings/index.spec.tsx
@@ -2,7 +2,6 @@ import {GroupingConfigsFixture} from 'sentry-fixture/groupingConfigs';
 import {LocationFixture} from 'sentry-fixture/locationFixture';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {ProjectFixture} from 'sentry-fixture/project';
-import {RouterContextFixture} from 'sentry-fixture/routerContextFixture';
 import {RouterFixture} from 'sentry-fixture/routerFixture';
 
 import {
@@ -41,7 +40,6 @@ describe('projectGeneralSettings', function () {
     verifySSL: true,
   });
   const groupingConfigs = GroupingConfigsFixture();
-  let routerContext;
   let putMock;
 
   const router = RouterFixture();
@@ -55,15 +53,6 @@ describe('projectGeneralSettings', function () {
 
   beforeEach(function () {
     jest.spyOn(window.location, 'assign');
-    routerContext = RouterContextFixture([
-      {
-        router: RouterFixture({
-          params: {
-            projectId: project.slug,
-          },
-        }),
-      },
-    ]);
 
     MockApiClient.clearMockResponses();
     MockApiClient.addMockResponse({
@@ -239,12 +228,10 @@ describe('projectGeneralSettings', function () {
 
   it('disables the form for users without write permissions', function () {
     const readOnlyOrg = OrganizationFixture({access: ['org:read']});
-    routerContext.context.organization = readOnlyOrg;
 
     render(
       <ProjectGeneralSettings {...routerProps} params={{projectId: project.slug}} />,
       {
-        context: routerContext,
         organization: readOnlyOrg,
       }
     );
@@ -273,11 +260,11 @@ describe('projectGeneralSettings', function () {
         <ProjectGeneralSettings
           {...routerProps}
           routes={[]}
-          location={routerContext.context.location}
+          location={LocationFixture()}
           params={params}
         />
       </ProjectContext>,
-      {context: routerContext, organization}
+      {organization}
     );
 
     const platformSelect = await screen.findByRole('textbox', {name: 'Platform'});
@@ -307,11 +294,11 @@ describe('projectGeneralSettings', function () {
         <ProjectGeneralSettings
           {...routerProps}
           routes={[]}
-          location={routerContext.context.location}
+          location={LocationFixture()}
           params={params}
         />
       </ProjectContext>,
-      {context: routerContext, organization}
+      {organization}
     );
 
     await userEvent.type(
@@ -351,11 +338,11 @@ describe('projectGeneralSettings', function () {
           <ProjectGeneralSettings
             {...routerProps}
             routes={[]}
-            location={routerContext.context.location}
+            location={LocationFixture()}
             params={params}
           />
         </ProjectContext>,
-        {context: routerContext, organization}
+        {organization}
       );
     }
 

--- a/static/app/views/settings/projectPlugins/projectPluginRow.spec.tsx
+++ b/static/app/views/settings/projectPlugins/projectPluginRow.spec.tsx
@@ -1,7 +1,6 @@
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {PluginFixture} from 'sentry-fixture/plugin';
 import {ProjectFixture} from 'sentry-fixture/project';
-import {RouterContextFixture} from 'sentry-fixture/routerContextFixture';
 
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
@@ -9,10 +8,9 @@ import ProjectPluginRow from 'sentry/views/settings/projectPlugins/projectPlugin
 
 describe('ProjectPluginRow', function () {
   const plugin = PluginFixture();
-  const org = OrganizationFixture({access: ['project:write']});
+  const org = OrganizationFixture();
   const project = ProjectFixture();
   const params = {orgId: org.slug, projectId: project.slug};
-  const routerContext = RouterContextFixture([{organization: org, project}]);
 
   it('calls `onChange` when clicked', async function () {
     const onChange = jest.fn();
@@ -25,8 +23,7 @@ describe('ProjectPluginRow', function () {
         {...plugin}
         onChange={onChange}
         project={project}
-      />,
-      {context: routerContext}
+      />
     );
 
     await userEvent.click(screen.getByRole('checkbox'));

--- a/tests/js/sentry-test/initializeOrg.tsx
+++ b/tests/js/sentry-test/initializeOrg.tsx
@@ -67,7 +67,6 @@ export function initializeOrg<RouterParams = {orgId: string; projectId: string}>
 
   const routerContext: any = RouterContextFixture([
     {
-      organization,
       project,
       router,
       location: router.location,


### PR DESCRIPTION
This is almost never needed anymore.

 1. This was a misnomer from the start, as it also injects organization
    and proejct legacy context, not just the react router context.

 2. Organization legacy context is no more, so any place where it was
    being used to customize the legacy organization context it was
    simply no longer needed

 3. It's already by default inected into legacy context when using
    render. There were a number of places passing it through with no
    modifications. This is simply unnecessary.