### PR TITLE
test(js): Remove organization from RouterContextFixture

### DIFF
--- a/tests/js/fixtures/routerContextFixture.ts
+++ b/tests/js/fixtures/routerContextFixture.ts
@@ -1,5 +1,4 @@
 import {LocationFixture} from 'sentry-fixture/locationFixture';
-import {OrganizationFixture} from 'sentry-fixture/organization';
 import {ProjectFixture} from 'sentry-fixture/project';
 import {RouterFixture} from 'sentry-fixture/routerFixture';
 
@@ -10,14 +9,12 @@ export function RouterContextFixture([context, childContextTypes] = []) {
     context: {
       location: LocationFixture(),
       router: RouterFixture(),
-      organization: OrganizationFixture(),
       project: ProjectFixture(),
       ...context,
     },
     childContextTypes: {
       router: SentryPropTypeValidators.isObject,
       location: SentryPropTypeValidators.isObject,
-      organization: SentryPropTypeValidators.isObject,
       project: SentryPropTypeValidators.isObject,
       ...childContextTypes,
     },


### PR DESCRIPTION
organization is no longer ever in the legacy context