### PR TITLE
feat(hybridcloud) Add cached implementation of user.get_many_by_id

### DIFF
--- a/src/sentry/api/serializers/models/group.py
+++ b/src/sentry/api/serializers/models/group.py
@@ -179,7 +179,7 @@ class GroupSerializerBase(Serializer, ABC):
         for team in Team.objects.filter(id__in=all_team_ids.keys()):
             for group_id in all_team_ids[team.id]:
                 result[group_id] = team
-        for user in user_service.get_many(filter=dict(user_ids=list(all_user_ids.keys()))):
+        for user in user_service.get_many_by_id(ids=list(all_user_ids.keys())):
             for group_id in all_user_ids[user.id]:
                 result[group_id] = user
 

--- a/src/sentry/api/serializers/models/organization_member/base.py
+++ b/src/sentry/api/serializers/models/organization_member/base.py
@@ -50,7 +50,7 @@ class OrganizationMemberSerializer(Serializer):
             }
         )
         inviters_by_id: Mapping[int, RpcUser] = {
-            u.id: u for u in user_service.get_many(filter={"user_ids": inviters_set})
+            u.id: u for u in user_service.get_many_by_id(ids=inviters_set)
         }
 
         external_users_map = defaultdict(list)

--- a/src/sentry/api/serializers/models/rule.py
+++ b/src/sentry/api/serializers/models/rule.py
@@ -104,8 +104,8 @@ class RuleSerializer(Serializer):
 
         users = {
             u.id: u
-            for u in user_service.get_many(
-                filter=dict(user_ids=[ra.user_id for ra in ras if ra.user_id is not None])
+            for u in user_service.get_many_by_id(
+                ids=[ra.user_id for ra in ras if ra.user_id is not None]
             )
         }
 

--- a/src/sentry/hybridcloud/options.py
+++ b/src/sentry/hybridcloud/options.py
@@ -1,5 +1,5 @@
 from sentry.options import FLAG_AUTOMATOR_MODIFIABLE, register
-from sentry.utils.types import Bool, Int, Sequence
+from sentry.utils.types import Bool, Float, Int, Sequence
 
 register(
     "outbox_replication.sentry_organizationmember.replication_version",
@@ -159,5 +159,12 @@ register(
     "hybrid_cloud.authentication.disabled_user_shards",
     type=Sequence,
     default=[],
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+
+register(
+    "user.get_many_by_id.rollout",
+    type=Float,
+    default=0.0,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )

--- a/src/sentry/incidents/action_handlers.py
+++ b/src/sentry/incidents/action_handlers.py
@@ -171,7 +171,7 @@ class EmailActionHandler(ActionHandler):
         notification_uuid: str | None = None,
     ) -> None:
         targets = [(user_id, email) for user_id, email in self.get_targets()]
-        users = user_service.get_many(filter={"user_ids": [user_id for user_id, _ in targets]})
+        users = user_service.get_many_by_id(ids=[user_id for user_id, _ in targets])
         for index, (user_id, email) in enumerate(targets):
             user = users[index]
             email_context = generate_incident_trigger_email_context(

--- a/src/sentry/incidents/endpoints/serializers/alert_rule.py
+++ b/src/sentry/incidents/endpoints/serializers/alert_rule.py
@@ -174,8 +174,8 @@ class AlertRuleSerializer(Serializer):
 
         user_by_user_id: MutableMapping[int, RpcUser] = {
             user.id: user
-            for user in user_service.get_many(
-                filter=dict(user_ids=[r.user_id for r in rule_activities if r.user_id is not None])
+            for user in user_service.get_many_by_id(
+                ids=[r.user_id for r in rule_activities if r.user_id is not None]
             )
         }
         for rule_activity in rule_activities:

--- a/src/sentry/models/organization.py
+++ b/src/sentry/models/organization.py
@@ -309,7 +309,7 @@ class Organization(
         )
 
         with in_test_hide_transaction_boundary():
-            return user_service.get_many(filter={"user_ids": list(owners)})
+            return user_service.get_many_by_id(ids=list(owners))
 
     def get_default_owner(self) -> RpcUser:
         if not hasattr(self, "_default_owner"):

--- a/src/sentry/models/organizationaccessrequest.py
+++ b/src/sentry/models/organizationaccessrequest.py
@@ -71,7 +71,7 @@ class OrganizationAccessRequest(Model):
             organization=self.team.organization,
             user_id__isnull=False,
         ).values_list("user_id", flat=True)
-        member_users = user_service.get_many(filter=dict(user_ids=list(member_list)))
+        member_users = user_service.get_many_by_id(ids=list(member_list))
 
         msg.send_async([user.email for user in member_users])
 

--- a/src/sentry/models/project.py
+++ b/src/sentry/models/project.py
@@ -410,7 +410,7 @@ class Project(Model, PendingDeletionMixin, OptionMixin, SnowflakeIdMixin):
 
     def get_members_as_rpc_users(self) -> Iterable[RpcUser]:
         member_ids = self.member_set.values_list("user_id", flat=True)
-        return user_service.get_many(filter=dict(user_ids=list(member_ids)))
+        return user_service.get_many_by_id(ids=list(member_ids))
 
     def get_audit_log_data(self):
         return {

--- a/src/sentry/models/user.py
+++ b/src/sentry/models/user.py
@@ -529,15 +529,21 @@ class User(BaseModel, AbstractBaseUser):
         payload: Mapping[str, Any] | None,
     ) -> None:
         from sentry.hybridcloud.rpc.services.caching import region_caching_service
-        from sentry.services.hybrid_cloud.user.service import get_user
+        from sentry.services.hybrid_cloud.user.service import get_many_by_id, get_user
 
         region_caching_service.clear_key(key=get_user.key_from(identifier), region_name=region_name)
+        region_caching_service.clear_key(
+            key=get_many_by_id.key_from(identifier), region_name=region_name
+        )
 
     def handle_async_replication(self, region_name: str, shard_identifier: int) -> None:
         from sentry.hybridcloud.rpc.services.caching import region_caching_service
-        from sentry.services.hybrid_cloud.user.service import get_user
+        from sentry.services.hybrid_cloud.user.service import get_many_by_id, get_user
 
         region_caching_service.clear_key(key=get_user.key_from(self.id), region_name=region_name)
+        region_caching_service.clear_key(
+            key=get_many_by_id.key_from(self.id), region_name=region_name
+        )
         organization_service.update_region_user(
             user=RpcRegionUser(
                 id=self.id,

--- a/src/sentry/notifications/notifications/strategies/role_based_recipient_strategy.py
+++ b/src/sentry/notifications/notifications/strategies/role_based_recipient_strategy.py
@@ -51,7 +51,9 @@ class RoleBasedRecipientStrategy(metaclass=ABCMeta):
         for member in members:
             self.set_member_in_cache(member)
         # convert members to users
-        return user_service.get_many(filter={"user_ids": [member.user_id for member in members]})
+        return user_service.get_many_by_id(
+            ids=[member.user_id for member in members if member.user_id]
+        )
 
     def determine_member_recipients(self) -> QuerySet[OrganizationMember]:
         """

--- a/src/sentry/notifications/utils/participants.py
+++ b/src/sentry/notifications/utils/participants.py
@@ -222,8 +222,8 @@ def get_owners(
 
     elif owners == ProjectOwnership.Everyone:
         outcome = "everyone"
-        users = user_service.get_many(
-            filter=dict(user_ids=list(project.member_set.values_list("user_id", flat=True)))
+        users = user_service.get_many_by_id(
+            ids=list(project.member_set.values_list("user_id", flat=True))
         )
         recipients = Actor.many_from_object(users)
 
@@ -409,15 +409,13 @@ def get_fallthrough_recipients(
         return []
 
     elif fallthrough_choice == FallthroughChoiceType.ALL_MEMBERS:
-        return user_service.get_many(
-            filter=dict(user_ids=list(project.member_set.values_list("user_id", flat=True)))
+        return user_service.get_many_by_id(
+            ids=list(project.member_set.values_list("user_id", flat=True))
         )
 
     elif fallthrough_choice == FallthroughChoiceType.ACTIVE_MEMBERS:
-        member_users = user_service.get_many(
-            filter={
-                "user_ids": list(project.member_set.values_list("user_id", flat=True)),
-            },
+        member_users = user_service.get_many_by_id(
+            ids=list(project.member_set.values_list("user_id", flat=True)),
         )
         member_users.sort(
             key=lambda u: u.last_active.isoformat() if u.last_active else "", reverse=True
@@ -493,7 +491,7 @@ def _get_users_from_team_fall_back(
         for member in members
         if member.organizationmember.user_id is not None
     }
-    return user_service.get_many(filter={"user_ids": list(user_ids)})
+    return user_service.get_many_by_id(ids=list(user_ids))
 
 
 def combine_recipients_by_provider(

--- a/src/sentry/services/hybrid_cloud/organization/model.py
+++ b/src/sentry/services/hybrid_cloud/organization/model.py
@@ -262,8 +262,8 @@ class RpcOrganization(RpcOrganizationSummary):
             owners = OrganizationMember.objects.filter(
                 organization_id=self.id, role__in=[roles.get_top_dog().id]
             ).values_list("user_id", flat=True)
-        return user_service.get_many(
-            filter={"user_ids": [owner_id for owner_id in owners if owner_id is not None]}
+        return user_service.get_many_by_id(
+            ids=[owner_id for owner_id in owners if owner_id is not None]
         )
 
     @property

--- a/src/sentry/services/hybrid_cloud/user/service.py
+++ b/src/sentry/services/hybrid_cloud/user/service.py
@@ -6,7 +6,9 @@
 from abc import abstractmethod
 from typing import Any
 
+from sentry.features.rollout import in_random_rollout
 from sentry.hybridcloud.rpc.services.caching import back_with_silo_cache
+from sentry.hybridcloud.rpc.services.caching.service import back_with_silo_cache_many
 from sentry.services.hybrid_cloud.auth import AuthenticationContext
 from sentry.services.hybrid_cloud.filter_query import OpaqueSerializedResponse
 from sentry.services.hybrid_cloud.organization_mapping.model import RpcOrganizationMapping
@@ -25,6 +27,7 @@ from sentry.services.hybrid_cloud.user.model import (
     UserIdEmailArgs,
 )
 from sentry.silo.base import SiloMode
+from sentry.utils import metrics
 
 
 class UserService(RpcService):
@@ -112,6 +115,20 @@ class UserService(RpcService):
         :param is_active: Whether the users need to be active
         :param is_verified: Whether the user's emails need to be verified.
         """
+
+    def get_many_by_id(self, *, ids: list[int]) -> list[RpcUser]:
+        """
+        Get many users by id.
+
+        Will use region local cache to minimize network overhead.
+        Cache keys in regions will be expired as users are updated via outbox receivers.
+
+        :param ids: A list of user ids to fetch
+        """
+        if in_random_rollout("user.get_many_by_id.rollout"):
+            metrics.incr("user_service.get_many_by_id.fetch", len(ids))
+            return get_many_by_id(ids)
+        return self.get_many(filter={"user_ids": ids})
 
     @rpc_method
     @abstractmethod
@@ -311,10 +328,16 @@ class UserService(RpcService):
 
 @back_with_silo_cache("user_service.get_user", SiloMode.REGION, RpcUser)
 def get_user(user_id: int) -> RpcUser | None:
-    users = user_service.get_many(filter=dict(user_ids=[user_id]))
+    users = user_service.get_many(filter={"user_ids": [user_id]})
     if len(users) > 0:
         return users[0]
     return None
+
+
+@back_with_silo_cache_many("user_service.get_many_by_id", SiloMode.REGION, RpcUser)
+def get_many_by_id(ids: list[int]) -> list[RpcUser]:
+    metrics.incr("user_service.get_many_by_id.fetch_rpc", len(ids))
+    return user_service.get_many(filter={"user_ids": ids})
 
 
 user_service = UserService.create_delegation()

--- a/src/sentry/tasks/auth.py
+++ b/src/sentry/tasks/auth.py
@@ -149,9 +149,7 @@ class OrganizationComplianceTask(abc.ABC):
         org_members = OrganizationMember.objects.filter(
             organization_id=org_id, user_id__isnull=False
         )
-        rpc_users = user_service.get_many(
-            filter=dict(user_ids=[member.user_id for member in org_members])
-        )
+        rpc_users = user_service.get_many_by_id(ids=[member.user_id for member in org_members])
         rpc_users_dict = {user.id: user for user in rpc_users}
         for member in org_members:
             user = rpc_users_dict.get(member.user_id, None)

--- a/src/sentry/tasks/commits.py
+++ b/src/sentry/tasks/commits.py
@@ -264,9 +264,7 @@ def get_emails_for_user_or_org(user: RpcUser | None, orgId: int):
         organization = Organization.objects.get(id=orgId)
         members = organization.get_members_with_org_roles(roles=["owner"])
         user_ids = [m.user_id for m in members if m.user_id]
-        emails = list(
-            {u.email for u in user_service.get_many(filter={"user_ids": user_ids}) if u.email}
-        )
+        emails = list({u.email for u in user_service.get_many_by_id(ids=user_ids) if u.email})
     else:
         emails = [user.email]
 

--- a/src/sentry/types/actor.py
+++ b/src/sentry/types/actor.py
@@ -58,7 +58,7 @@ class Actor(RpcModel):
         results: dict[tuple[ActorType, int], Team | RpcUser] = {}
         for actor_type, actor_list in actors_by_type.items():
             if actor_type == ActorType.USER:
-                for user in user_service.get_many(filter={"user_ids": [u.id for u in actor_list]}):
+                for user in user_service.get_many_by_id(ids=[u.id for u in actor_list]):
                     results[(actor_type, user.id)] = user
             if actor_type == ActorType.TEAM:
                 for team in Team.objects.filter(id__in=[t.id for t in actor_list]):

--- a/src/sentry/utils/email/manager.py
+++ b/src/sentry/utils/email/manager.py
@@ -49,7 +49,7 @@ def get_email_addresses(
         user_option_service.delete_options(option_ids=[o.id for o in to_delete])
 
     if pending:
-        users = user_service.get_many(filter={"user_ids": list(pending)})
+        users = user_service.get_many_by_id(ids=list(pending))
         for user_id, email in [(user.id, user.email) for user in users]:
             if email and not is_fake_email(email):
                 results[user_id] = email

--- a/tests/sentry/hybridcloud/test_user.py
+++ b/tests/sentry/hybridcloud/test_user.py
@@ -1,5 +1,6 @@
 from sentry.services.hybrid_cloud.user.service import user_service
 from sentry.testutils.cases import TransactionTestCase
+from sentry.testutils.helpers.options import override_options
 from sentry.testutils.silo import all_silo_test
 
 
@@ -44,3 +45,16 @@ class UserServiceTest(TransactionTestCase):
         profiles = user_service.get_many_profiles(filter=dict(user_ids=target_ids))
         assert len(profiles) == 1
         assert profiles[0].id == users[0].id
+
+    def test_get_many_by_id(self) -> None:
+        users = [self.create_user() for _ in range(2)]
+        target_ids = [users[0].id]
+        result = user_service.get_many_by_id(ids=target_ids)
+
+        assert len(result) == 1
+        assert result[0].id == users[0].id
+
+        with override_options({"user.get_many_by_id.rollout": 1.0}):
+            result = user_service.get_many_by_id(ids=target_ids)
+            result_two = user_service.get_many_by_id(ids=target_ids)
+            assert result == result_two


### PR DESCRIPTION
We make a ton of RPC calls for lists of users. Many of those calls are simple ID lists. We can cache these quite effectively as the queries are simple and cache keys can be expired via outboxes.

The rollout of using cache is controlled by an option, and I've added metrics to observe the effective hit rate of cached/rpc fetches.

Caching decorators were added in #71719