### PR TITLE
feat(features) Allow defining default value for features during registration

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1450,14 +1450,8 @@ SENTRY_EARLY_FEATURES = {
 
 # NOTE: Please maintain alphabetical order when adding new feature flags
 SENTRY_FEATURES: dict[str, bool | None] = {
-    # Enables user registration.
-    "auth:register": True,
-    # Enables activated alert rules
-    "organizations:activated-alert-rules": False,
     # Enable advanced search features, like negation and wildcard matching.
     "organizations:advanced-search": True,
-    # Enable AI analytics pages (sentry for AI teams)
-    "organizations:ai-analytics": False,
     # Enables alert creation on indexed events in UI (use for PoC/testing only)
     "organizations:alert-allow-indexed": False,
     # Use metrics as the dataset for crash free metric alerts

--- a/src/sentry/features/manager.py
+++ b/src/sentry/features/manager.py
@@ -150,7 +150,7 @@ class FeatureManager(RegisteredFeatureManager):
         name: str,
         cls: type[Feature] = Feature,
         entity_feature_strategy: bool | FeatureHandlerStrategy = False,
-        default: bool | None = None,
+        default: bool = False,
     ) -> None:
         """
         Register a feature.
@@ -181,7 +181,7 @@ class FeatureManager(RegisteredFeatureManager):
             feature_option_name = f"{FLAGPOLE_OPTION_PREFIX}.{name}"
             register(feature_option_name, type=Dict, default={}, flags=FLAG_AUTOMATOR_MODIFIABLE)
 
-        if default is not None:
+        if default is not None and name not in settings.SENTRY_FEATURES:
             settings.SENTRY_FEATURES[name] = default
 
         self._feature_registry[name] = cls

--- a/src/sentry/features/manager.py
+++ b/src/sentry/features/manager.py
@@ -181,7 +181,7 @@ class FeatureManager(RegisteredFeatureManager):
             feature_option_name = f"{FLAGPOLE_OPTION_PREFIX}.{name}"
             register(feature_option_name, type=Dict, default={}, flags=FLAG_AUTOMATOR_MODIFIABLE)
 
-        if default is not None and name not in settings.SENTRY_FEATURES:
+        if name not in settings.SENTRY_FEATURES:
             settings.SENTRY_FEATURES[name] = default
 
         self._feature_registry[name] = cls

--- a/src/sentry/features/manager.py
+++ b/src/sentry/features/manager.py
@@ -150,6 +150,7 @@ class FeatureManager(RegisteredFeatureManager):
         name: str,
         cls: type[Feature] = Feature,
         entity_feature_strategy: bool | FeatureHandlerStrategy = False,
+        default: bool | None = None,
     ) -> None:
         """
         Register a feature.
@@ -158,6 +159,8 @@ class FeatureManager(RegisteredFeatureManager):
         to encapsulate the context associated with a feature.
 
         >>> FeatureManager.has('my:feature', actor=request.user)
+
+        Features that use flagpole will have an option automatically registered.
         """
         entity_feature_strategy = self._shim_feature_strategy(entity_feature_strategy)
 
@@ -177,6 +180,9 @@ class FeatureManager(RegisteredFeatureManager):
             # Set a default of {} to ensure the feature evaluates to None when checked
             feature_option_name = f"{FLAGPOLE_OPTION_PREFIX}.{name}"
             register(feature_option_name, type=Dict, default={}, flags=FLAG_AUTOMATOR_MODIFIABLE)
+
+        if default is not None:
+            settings.SENTRY_FEATURES[name] = default
 
         self._feature_registry[name] = cls
 

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -42,9 +42,9 @@ def register_temporary_features(manager: FeatureManager):
     ###############################################################################
 
     # Enables activated alert rules
-    manager.add("organizations:activated-alert-rules", OrganizationFeature, FeatureHandlerStrategy.REMOTE, default=False)
+    manager.add("organizations:activated-alert-rules", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
     # Enable AI analytics pages (sentry for AI teams)
-    manager.add("organizations:ai-analytics", OrganizationFeature, FeatureHandlerStrategy.REMOTE, default=False)
+    manager.add("organizations:ai-analytics", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
     manager.add("organizations:alert-allow-indexed", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
     manager.add("organizations:alert-crash-free-metrics", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
     manager.add("organizations:alert-filters", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -29,15 +29,22 @@ def register_temporary_features(manager: FeatureManager):
 
     # NOTE: Please maintain alphabetical order when adding new feature flags
 
-    # Features that don't use resource scoping
-    manager.add("auth:register", SystemFeature, FeatureHandlerStrategy.INTERNAL)
+    # Features that don't use resource scoping #
+    ############################################
+
+    # Enables user registration.
+    manager.add("auth:register", SystemFeature, FeatureHandlerStrategy.INTERNAL, default=True)
     manager.add("organizations:create", SystemFeature, FeatureHandlerStrategy.INTERNAL)
     manager.add("organizations:multi-region-selector", SystemFeature, FeatureHandlerStrategy.INTERNAL)
     manager.add("relocation:enabled", SystemFeature, FeatureHandlerStrategy.INTERNAL)
 
-    # Organization scoped features that are in development or in customer trials.
-    manager.add("organizations:activated-alert-rules", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
-    manager.add("organizations:ai-analytics", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
+    # Organization scoped features that are in development or in customer trials. #
+    ###############################################################################
+
+    # Enables activated alert rules
+    manager.add("organizations:activated-alert-rules", OrganizationFeature, FeatureHandlerStrategy.REMOTE, default=False)
+    # Enable AI analytics pages (sentry for AI teams)
+    manager.add("organizations:ai-analytics", OrganizationFeature, FeatureHandlerStrategy.REMOTE, default=False)
     manager.add("organizations:alert-allow-indexed", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
     manager.add("organizations:alert-crash-free-metrics", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
     manager.add("organizations:alert-filters", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)

--- a/tests/sentry/features/test_manager.py
+++ b/tests/sentry/features/test_manager.py
@@ -3,6 +3,7 @@ from unittest import mock
 
 import pytest
 from django.conf import settings
+from django.test import override_settings
 
 from sentry import features
 from sentry.features.base import (
@@ -79,6 +80,15 @@ class FeatureManagerTest(TestCase):
 
         assert set(manager.all(OrganizationFeature)) == {"organizations:red-paint"}
         assert settings.SENTRY_FEATURES["organizations:red-paint"] is False
+
+        # Defaults should not override config data.
+        feature_config = {
+            "organizations:red-paint": True,
+        }
+        with override_settings(SENTRY_FEATURES=feature_config):
+            manager = features.FeatureManager()
+            manager.add("organizations:red-paint", OrganizationFeature, default=False)
+            assert settings.SENTRY_FEATURES["organizations:red-paint"] is True
 
     def test_handlers(self):
         project_flag = "projects:test_handlers"

--- a/tests/sentry/features/test_manager.py
+++ b/tests/sentry/features/test_manager.py
@@ -73,6 +73,13 @@ class FeatureManagerTest(TestCase):
             "projects:feature3",
         }
 
+    def test_feature_register_default(self):
+        manager = features.FeatureManager()
+        manager.add("organizations:red-paint", OrganizationFeature, default=False)
+
+        assert set(manager.all(OrganizationFeature)) == {"organizations:red-paint"}
+        assert settings.SENTRY_FEATURES["organizations:red-paint"] is False
+
     def test_handlers(self):
         project_flag = "projects:test_handlers"
         test_user = self.create_user()


### PR DESCRIPTION
Having to remember to update server.py when adding a new feature is no fun. It contributes bloat to server.py and adds friction to adding/removing features. Consolidating the default value with feature registration will improve ergonomics of defining features.