### PR TITLE
fix(metrics): Ensure MQB uses transaction for free text search

### DIFF
--- a/src/sentry/search/events/builder/metrics.py
+++ b/src/sentry/search/events/builder/metrics.py
@@ -81,7 +81,15 @@ class MetricsQueryBuilder(QueryBuilder):
 
     organization_column: str = "organization_id"
 
-    column_remapping = {}
+    column_remapping = {
+        # This MetricsQueryBuilder is only used for transaction metrics.
+        # So `message` is mapped to `transaction` but subclasses of this
+        # should be mindful of this and override this value appropriately.
+        #
+        # Note: This really shouldn't be in the parent class at all, and
+        # should live strictly in child classes.
+        "message": "transaction",
+    }
     default_metric_tags = constants.DEFAULT_METRIC_TAGS
 
     def __init__(

--- a/src/sentry/search/events/datasets/metrics.py
+++ b/src/sentry/search/events/datasets/metrics.py
@@ -27,6 +27,7 @@ class MetricsDatasetConfig(DatasetConfig):
         self,
     ) -> Mapping[str, Callable[[SearchFilter], WhereType | None]]:
         return {
+            "message": self._message_filter_converter,
             constants.PROJECT_ALIAS: self._project_slug_filter_converter,
             constants.PROJECT_NAME_ALIAS: self._project_slug_filter_converter,
             constants.EVENT_TYPE_ALIAS: self._event_type_converter,
@@ -969,6 +970,9 @@ class MetricsDatasetConfig(DatasetConfig):
             return None
 
         raise IncompatibleMetricsQuery("Can only filter event.type:transaction")
+
+    def _message_filter_converter(self, search_filter: SearchFilter) -> WhereType | None:
+        return filter_aliases.message_filter_converter(self.builder, search_filter)
 
     def _project_slug_filter_converter(self, search_filter: SearchFilter) -> WhereType | None:
         return filter_aliases.project_slug_converter(self.builder, search_filter)


### PR DESCRIPTION
The MQB is exclusively used to search transaction metrics so map `message` to the `transaction` column. But we should be wary of subclasses that are used for other metrics.