### PR TITLE
feat(trace_link): Remove total count of events from copy

### DIFF
--- a/static/app/views/issueDetails/traceTimeline/traceLink.spec.tsx
+++ b/static/app/views/issueDetails/traceTimeline/traceLink.spec.tsx
@@ -69,9 +69,7 @@ describe('TraceLink', () => {
       match: [MockApiClient.matchQuery({dataset: 'discover'})],
     });
     render(<TraceLink event={event} />, {organization});
-    expect(
-      await screen.findByRole('link', {name: 'View Full Trace (2 issues)'})
-    ).toBeInTheDocument();
+    expect(await screen.findByText('View Full Trace')).toBeInTheDocument();
   });
 
   it('renders no trace available', async () => {

--- a/static/app/views/issueDetails/traceTimeline/traceLink.tsx
+++ b/static/app/views/issueDetails/traceTimeline/traceLink.tsx
@@ -1,17 +1,14 @@
-import {Fragment} from 'react';
 import styled from '@emotion/styled';
 
 import Link from 'sentry/components/links/link';
 import QuestionTooltip from 'sentry/components/questionTooltip';
 import {generateTraceTarget} from 'sentry/components/quickTrace/utils';
 import {IconChevron} from 'sentry/icons';
-import {t, tn} from 'sentry/locale';
+import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {Event} from 'sentry/types/event';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import useOrganization from 'sentry/utils/useOrganization';
-
-import {useTraceTimelineEvents} from './useTraceTimelineEvents';
 
 interface TraceLinkProps {
   event: Event;
@@ -19,7 +16,6 @@ interface TraceLinkProps {
 
 export function TraceLink({event}: TraceLinkProps) {
   const organization = useOrganization();
-  const {traceEvents} = useTraceTimelineEvents({event});
   const traceTarget = generateTraceTarget(event, organization);
 
   if (!event.contexts?.trace?.trace_id) {
@@ -47,16 +43,7 @@ export function TraceLink({event}: TraceLinkProps) {
         });
       }}
     >
-      <span>
-        {t('View Full Trace')}
-        {traceEvents.length > 0 && (
-          <Fragment>
-            {traceEvents.length >= 100
-              ? t(' (100+ issues)')
-              : tn(' (%s issue)', ' (%s issues)', traceEvents.length)}
-          </Fragment>
-        )}
-      </span>
+      <span>{t('View Full Trace')}</span>
       <IconChevron direction="right" size="xs" />
     </StyledLink>
   );


### PR DESCRIPTION
We do not believe it brings enough value and it gets complicated because "issues" refers to error events _and_ perf events (e.g. Slow DB query).

Before:
![image](https://github.com/getsentry/sentry/assets/44410/a46120f2-2665-45da-b6ef-f1f2fb525697)

After:
<img width="621" alt="image" src="https://github.com/getsentry/sentry/assets/44410/55f180cb-53c2-4235-9241-46b4ca78dfde">
