### PR TITLE
fix(query-builder): Fix selected values and click behavior for filter values

### DIFF
--- a/static/app/components/searchQueryBuilder/combobox.tsx
+++ b/static/app/components/searchQueryBuilder/combobox.tsx
@@ -1,4 +1,11 @@
-import {type Key, type MouseEventHandler, useCallback, useMemo, useRef} from 'react';
+import {
+  forwardRef,
+  type Key,
+  type MouseEventHandler,
+  useCallback,
+  useMemo,
+  useRef,
+} from 'react';
 import isPropValid from '@emotion/is-prop-valid';
 import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
@@ -37,158 +44,163 @@ type SearchQueryBuilderComboboxProps = {
   tabIndex?: number;
 };
 
-export function SearchQueryBuilderCombobox({
-  children,
-  items,
-  inputValue,
-  filterValue = inputValue,
-  placeholder,
-  onCustomValueSelected,
-  onOptionSelected,
-  inputLabel,
-  onExit,
-  onKeyDown,
-  onInputChange,
-  autoFocus,
-  tabIndex = -1,
-  maxOptions,
-}: SearchQueryBuilderComboboxProps) {
-  const theme = useTheme();
-  const listBoxRef = useRef<HTMLUListElement>(null);
-  const inputRef = useRef<HTMLInputElement>(null);
-  const popoverRef = useRef<HTMLDivElement>(null);
-
-  const hiddenOptions = useMemo(() => {
-    return getHiddenOptions(items, filterValue, maxOptions);
-  }, [items, filterValue, maxOptions]);
-
-  const disabledKeys = useMemo(
-    () => [...getDisabledOptions(items), ...hiddenOptions].map(getEscapedKey),
-    [hiddenOptions, items]
-  );
-
-  const onSelectionChange = useCallback(
-    (key: Key) => {
-      const selectedOption = items.find(item => item.key === key);
-      if (selectedOption) {
-        onOptionSelected(selectedOption.textValue ?? '');
-      } else if (key) {
-        onOptionSelected(key.toString());
-      }
-    },
-    [items, onOptionSelected]
-  );
-
-  const state = useComboBoxState<SelectOptionWithKey<string>>({
-    children,
-    items,
-    autoFocus,
-    inputValue: filterValue,
-    onSelectionChange,
-    disabledKeys,
-  });
-  const {inputProps, listBoxProps} = useComboBox<SelectOptionWithKey<string>>(
+export const SearchQueryBuilderCombobox = forwardRef(
+  (
     {
-      'aria-label': inputLabel,
-      listBoxRef,
-      inputRef,
-      popoverRef,
+      children,
       items,
+      inputValue,
+      filterValue = inputValue,
+      placeholder,
+      onCustomValueSelected,
+      onOptionSelected,
+      inputLabel,
+      onExit,
+      onKeyDown,
+      onInputChange,
+      autoFocus,
+      tabIndex = -1,
+      maxOptions,
+    }: SearchQueryBuilderComboboxProps,
+    ref
+  ) => {
+    const theme = useTheme();
+    const listBoxRef = useRef<HTMLUListElement>(null);
+    const inputRef = useRef<HTMLInputElement>(null);
+    const popoverRef = useRef<HTMLDivElement>(null);
+
+    const hiddenOptions = useMemo(() => {
+      return getHiddenOptions(items, filterValue, maxOptions);
+    }, [items, filterValue, maxOptions]);
+
+    const disabledKeys = useMemo(
+      () => [...getDisabledOptions(items), ...hiddenOptions].map(getEscapedKey),
+      [hiddenOptions, items]
+    );
+
+    const onSelectionChange = useCallback(
+      (key: Key) => {
+        const selectedOption = items.find(item => item.key === key);
+        if (selectedOption) {
+          onOptionSelected(selectedOption.textValue ?? '');
+        } else if (key) {
+          onOptionSelected(key.toString());
+        }
+      },
+      [items, onOptionSelected]
+    );
+
+    const state = useComboBoxState<SelectOptionWithKey<string>>({
+      children,
+      items,
+      autoFocus,
       inputValue: filterValue,
       onSelectionChange,
-      autoFocus,
-      onBlur: () => {
-        if (inputValue) {
+      disabledKeys,
+    });
+    const {inputProps, listBoxProps} = useComboBox<SelectOptionWithKey<string>>(
+      {
+        'aria-label': inputLabel,
+        listBoxRef,
+        inputRef,
+        popoverRef,
+        items,
+        inputValue: filterValue,
+        onSelectionChange,
+        autoFocus,
+        onBlur: () => {
+          if (inputValue) {
+            onCustomValueSelected(inputValue);
+          } else {
+            onExit?.();
+          }
+          state.close();
+        },
+        onKeyDown: e => {
+          onKeyDown?.(e);
+          switch (e.key) {
+            case 'Escape':
+              state.close();
+              onExit?.();
+              return;
+            case 'Enter':
+              if (state.selectionManager.focusedKey) {
+                return;
+              }
+              state.close();
+              onCustomValueSelected(inputValue);
+              return;
+            default:
+              return;
+          }
+        },
+      },
+      state
+    );
+
+    const isOpen = state.isOpen && hiddenOptions.size < items.length;
+
+    const {overlayProps, triggerProps} = useOverlay({
+      type: 'listbox',
+      isOpen,
+      position: 'bottom-start',
+      offset: [0, 8],
+      isKeyboardDismissDisabled: true,
+      shouldCloseOnBlur: true,
+      onInteractOutside: () => {
+        if (state.inputValue) {
           onCustomValueSelected(inputValue);
         } else {
           onExit?.();
         }
         state.close();
       },
-      onKeyDown: e => {
-        onKeyDown?.(e);
-        switch (e.key) {
-          case 'Escape':
-            state.close();
-            onExit?.();
-            return;
-          case 'Enter':
-            if (state.selectionManager.focusedKey) {
-              return;
-            }
-            state.close();
-            onCustomValueSelected(inputValue);
-            return;
-          default:
-            return;
-        }
+    });
+
+    const handleInputClick: MouseEventHandler<HTMLInputElement> = useCallback(
+      e => {
+        e.stopPropagation();
+        inputProps.onClick?.(e);
+        state.open();
       },
-    },
-    state
-  );
+      [inputProps, state]
+    );
 
-  const isOpen = state.isOpen && hiddenOptions.size < items.length;
-
-  const {overlayProps, triggerProps} = useOverlay({
-    type: 'listbox',
-    isOpen,
-    position: 'bottom-start',
-    offset: [0, 8],
-    isKeyboardDismissDisabled: true,
-    shouldCloseOnBlur: true,
-    onInteractOutside: () => {
-      if (state.inputValue) {
-        onCustomValueSelected(inputValue);
-      } else {
-        onExit?.();
-      }
-      state.close();
-    },
-  });
-
-  const handleInputClick: MouseEventHandler<HTMLInputElement> = useCallback(
-    e => {
-      e.stopPropagation();
-      inputProps.onClick?.(e);
-      state.open();
-    },
-    [inputProps, state]
-  );
-
-  return (
-    <Wrapper>
-      <UnstyledInput
-        {...inputProps}
-        size="md"
-        ref={mergeRefs([inputRef, triggerProps.ref])}
-        type="text"
-        placeholder={placeholder}
-        onClick={handleInputClick}
-        value={inputValue}
-        onChange={onInputChange}
-        tabIndex={tabIndex}
-      />
-      <StyledPositionWrapper
-        {...overlayProps}
-        zIndex={theme.zIndex?.tooltip}
-        visible={isOpen}
-      >
-        <StyledOverlay ref={popoverRef}>
-          <ListBox
-            {...listBoxProps}
-            ref={listBoxRef}
-            listState={state}
-            hasSearch={!!filterValue}
-            hiddenOptions={hiddenOptions}
-            keyDownHandler={() => true}
-            overlayIsOpen={isOpen}
-            size="md"
-          />
-        </StyledOverlay>
-      </StyledPositionWrapper>
-    </Wrapper>
-  );
-}
+    return (
+      <Wrapper>
+        <UnstyledInput
+          {...inputProps}
+          size="md"
+          ref={mergeRefs([ref, inputRef, triggerProps.ref])}
+          type="text"
+          placeholder={placeholder}
+          onClick={handleInputClick}
+          value={inputValue}
+          onChange={onInputChange}
+          tabIndex={tabIndex}
+        />
+        <StyledPositionWrapper
+          {...overlayProps}
+          zIndex={theme.zIndex?.tooltip}
+          visible={isOpen}
+        >
+          <StyledOverlay ref={popoverRef}>
+            <ListBox
+              {...listBoxProps}
+              ref={listBoxRef}
+              listState={state}
+              hasSearch={!!filterValue}
+              hiddenOptions={hiddenOptions}
+              keyDownHandler={() => true}
+              overlayIsOpen={isOpen}
+              size="md"
+            />
+          </StyledOverlay>
+        </StyledPositionWrapper>
+      </Wrapper>
+    );
+  }
+);
 
 const Wrapper = styled('div')`
   position: relative;

--- a/static/app/components/searchQueryBuilder/valueCombobox.tsx
+++ b/static/app/components/searchQueryBuilder/valueCombobox.tsx
@@ -1,4 +1,4 @@
-import {useCallback, useMemo, useState} from 'react';
+import {useCallback, useMemo, useRef, useState} from 'react';
 import styled from '@emotion/styled';
 import {Item, Section} from '@react-stately/collections';
 import orderBy from 'lodash/orderBy';
@@ -168,15 +168,17 @@ function useFilterSuggestions({
   const suggestionSectionItems = useMemo<SuggestionSectionItem[]>(() => {
     const itemsWithoutSection = suggestionGroups
       .filter(group => group.sectionText === '')
-      .flatMap(group => group.suggestions);
+      .flatMap(group => group.suggestions)
+      .filter(value => !selectedValues.includes(value));
     const sections = suggestionGroups.filter(group => group.sectionText !== '');
 
     return [
       {
         sectionText: '',
-        items: getItemsWithKeys(
-          [...selectedValues, ...itemsWithoutSection].map(value => createItem(value))
-        ),
+        items: getItemsWithKeys([
+          ...selectedValues.map(value => createItem(value, true)),
+          ...itemsWithoutSection.map(value => createItem(value)),
+        ]),
       },
       ...sections.map(group => ({
         sectionText: group.sectionText,
@@ -195,7 +197,6 @@ function useFilterSuggestions({
   }, [suggestionSectionItems]);
 
   return {
-    selectedValues,
     items,
     suggestionSectionItems,
   };
@@ -242,6 +243,7 @@ export function SearchQueryBuilderValueCombobox({
   token,
   onCommit,
 }: SearchQueryValueBuilderProps) {
+  const inputRef = useRef<HTMLInputElement>(null);
   const [inputValue, setInputValue] = useState('');
 
   const {keys, dispatch} = useSearchQueryBuilder();
@@ -303,12 +305,23 @@ export function SearchQueryBuilderValueCombobox({
     [dispatch, token]
   );
 
+  // Clicking anywhere in the value editing area should focus the input
+  const onClick: React.MouseEventHandler<HTMLDivElement> = useCallback(e => {
+    if (e.target === e.currentTarget) {
+      e.preventDefault();
+      e.stopPropagation();
+      inputRef.current?.click();
+      inputRef.current?.focus();
+    }
+  }, []);
+
   return (
-    <ValueEditing>
+    <ValueEditing onClick={onClick}>
       {selectedValues.map(value => (
-        <span key={value}>{value},</span>
+        <SelectedValue key={value}>{value},</SelectedValue>
       ))}
       <SearchQueryBuilderCombobox
+        ref={inputRef}
         items={items}
         onOptionSelected={handleSelectValue}
         onCustomValueSelected={handleSelectValue}
@@ -340,6 +353,11 @@ const ValueEditing = styled('div')`
   height: 100%;
   align-items: center;
   gap: ${space(0.25)};
+`;
+
+const SelectedValue = styled('span')`
+  pointer-events: none;
+  user-select: none;
 `;
 
 const TrailingWrap = styled('div')`


### PR DESCRIPTION
- When clicking anywhere in the filter value area while editing, forwards that click event to the input instead
- Fixes the items calculation, before it wasn't filtering out selected values correctly in all cases
