### PR TITLE
add extra metadata

### DIFF
--- a/src/sentry/celery.py
+++ b/src/sentry/celery.py
@@ -87,10 +87,12 @@ class SentryTask(Task):
     Request = "sentry.celery:SentryRequest"
 
     @classmethod
-    def _add_metadata(cls, kwargs: dict[str, Any]) -> None:
+    def _add_metadata(cls, kwargs: dict[str, Any] | None) -> None:
         """
         Helper method that adds relevant metadata
         """
+        if kwargs is None:
+            return None
         # Add the start time when the task was kicked off for async processing by the calling code
         kwargs["__start_time"] = datetime.now().timestamp()
 

--- a/src/sentry/testutils/helpers/task_runner.py
+++ b/src/sentry/testutils/helpers/task_runner.py
@@ -52,7 +52,7 @@ class _BurstState:
 
         try:
             _start_time = options.pop("__start_time", None)
-            if _start_time:
+            if _start_time and kwargs:
                 kwargs["__start_time"] = _start_time
         except Exception:
             pass

--- a/src/sentry/testutils/helpers/task_runner.py
+++ b/src/sentry/testutils/helpers/task_runner.py
@@ -45,7 +45,7 @@ class _BurstState:
         kwargs: dict[str, Any] | None = None,
         countdown: float | None = None,
         queue: str | None = None,
-        **options,
+        **options: Any,
     ) -> None:
         if not self._active:
             raise AssertionError("task enqueued to burst runner while burst was not active!")

--- a/src/sentry/testutils/helpers/task_runner.py
+++ b/src/sentry/testutils/helpers/task_runner.py
@@ -45,9 +45,18 @@ class _BurstState:
         kwargs: dict[str, Any] | None = None,
         countdown: float | None = None,
         queue: str | None = None,
+        **options,
     ) -> None:
         if not self._active:
             raise AssertionError("task enqueued to burst runner while burst was not active!")
+
+        try:
+            _start_time = options.pop("__start_time", None)
+            if _start_time:
+                kwargs["__start_time"] = _start_time
+        except Exception:
+            pass
+
         self.queue.append((task, args, {} if kwargs is None else kwargs))
 
     @contextlib.contextmanager


### PR DESCRIPTION
For `apply_async` we weren't passing in `start_time` so the tasks weren't getting the queue time