### PR TITLE
feat(seer-rpc): Seer RPC endpoint to check for autofix consent

### DIFF
--- a/src/sentry/api/endpoints/seer_rpc.py
+++ b/src/sentry/api/endpoints/seer_rpc.py
@@ -151,8 +151,17 @@ def get_organization_slug(*, org_id: int) -> dict:
     return {"slug": org.slug}
 
 
+def get_organization_autofix_consent(*, org_id: int) -> dict:
+    org: Organization = Organization.objects.get(id=org_id)
+    consent = org.get_option("sentry:gen_ai_consent", False)
+    return {
+        "consent": consent,
+    }
+
+
 seer_method_registry = {
     "get_organization_slug": get_organization_slug,
+    "get_organization_autofix_consent": get_organization_autofix_consent,
 }
 
 


### PR DESCRIPTION
Endpoint to check for genai consent. Follows the pattern from the setup modal: https://github.com/getsentry/sentry/blob/a10e7ca997509e85c77b18602a48f32109d7ae0b/src/sentry/api/endpoints/group_autofix_setup_check.py#L104