### PR TITLE
fix(related_issues): Fix on click events

### DIFF
--- a/static/app/utils/analytics/issueAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/issueAnalyticsEvents.tsx
@@ -2,7 +2,6 @@ import type {SourceMapProcessingIssueType} from 'sentry/components/events/interf
 import type {FieldValue} from 'sentry/components/forms/model';
 import type {PriorityLevel} from 'sentry/types/group';
 import type {IntegrationType} from 'sentry/types/integrations';
-import type {Organization} from 'sentry/types/organization';
 import type {BaseEventAnalyticsParams} from 'sentry/utils/analytics/workflowAnalyticsEvents';
 import type {CommonGroupAnalyticsData} from 'sentry/utils/events';
 
@@ -110,7 +109,6 @@ export type IssueEventParameters = {
   'issue_details.performance.hidden_spans_expanded': {};
   'issue_details.related_trace_issue.trace_issue_clicked': {
     group_id: number;
-    organization: Organization;
   };
   'issue_details.set_priority': SetPriorityParams;
   'issue_details.similar_issues.diff_clicked': {

--- a/static/app/utils/analytics/issueAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/issueAnalyticsEvents.tsx
@@ -2,6 +2,7 @@ import type {SourceMapProcessingIssueType} from 'sentry/components/events/interf
 import type {FieldValue} from 'sentry/components/forms/model';
 import type {PriorityLevel} from 'sentry/types/group';
 import type {IntegrationType} from 'sentry/types/integrations';
+import type {Organization} from 'sentry/types/organization';
 import type {BaseEventAnalyticsParams} from 'sentry/utils/analytics/workflowAnalyticsEvents';
 import type {CommonGroupAnalyticsData} from 'sentry/utils/events';
 
@@ -109,6 +110,7 @@ export type IssueEventParameters = {
   'issue_details.performance.hidden_spans_expanded': {};
   'issue_details.related_trace_issue.trace_issue_clicked': {
     group_id: number;
+    organization: Organization;
   };
   'issue_details.set_priority': SetPriorityParams;
   'issue_details.similar_issues.diff_clicked': {

--- a/static/app/views/issueDetails/traceTimeline/traceIssue.tsx
+++ b/static/app/views/issueDetails/traceTimeline/traceIssue.tsx
@@ -35,7 +35,7 @@ export function TraceIssueEvent({event}: TraceIssueEventProps) {
         }}
         onClick={() => {
           trackAnalytics(`${referrer}.trace_issue_clicked`, {
-            organization: organization.slug,
+            organization,
             group_id: issueId,
           });
         }}

--- a/static/app/views/issueDetails/traceTimeline/traceTimeline.spec.tsx
+++ b/static/app/views/issueDetails/traceTimeline/traceTimeline.spec.tsx
@@ -200,7 +200,9 @@ describe('TraceTimeline', () => {
       'issue_details.related_trace_issue.trace_issue_clicked',
       {
         group_id: issuePlatformBody.data[0]['issue.id'],
-        organization: organization.slug,
+        organization: OrganizationFixture({
+          features: ['related-issues-issue-details-page'],
+        }),
       }
     );
   });


### PR DESCRIPTION
We were passing the `org.slug` instead of the `organization`, thus, failing to report the event.

It's unclear why it was letting me do the wrong thing.