### PR TITLE
ref: rm remaining session subscription results

### DIFF
--- a/src/sentry/runner/commands/devserver.py
+++ b/src/sentry/runner/commands/devserver.py
@@ -36,7 +36,6 @@ _SUBSCRIPTION_RESULTS_CONSUMERS = [
     "events-subscription-results",
     "transactions-subscription-results",
     "generic-metrics-subscription-results",
-    "sessions-subscription-results",
     "metrics-subscription-results",
 ]
 

--- a/tests/sentry/consumers/test_run.py
+++ b/tests/sentry/consumers/test_run.py
@@ -31,7 +31,6 @@ def test_dlq(consumer_def) -> None:
         "transactions-subscription-results",
         "generic-metrics-subscription-results",
         "metrics-subscription-results",
-        "sessions-subscription-results",
     ]
     consumers_that_should_have_dlq_but_dont = [
         "process-spans",


### PR DESCRIPTION
Following the session result consumer removal in https://github.com/getsentry/sentry/pull/68390 if you set `SENTRY_DEV_PROCESS_SUBSCRIPTIONS` to `True` you encounter an error unless these are removed. 