### PR TITLE
feat(insights): Improve Insights sidebar upsells

### DIFF
--- a/static/app/components/sidebar/sidebarItem.tsx
+++ b/static/app/components/sidebar/sidebarItem.tsx
@@ -459,7 +459,7 @@ const SidebarItemLabel = styled('span')<{
   opacity: 1;
   flex: 1;
   display: flex;
-  align-items: flex-start;
+  align-items: center;
   overflow: hidden;
 `;
 

--- a/static/app/components/sidebar/sidebarItem.tsx
+++ b/static/app/components/sidebar/sidebarItem.tsx
@@ -238,7 +238,7 @@ function SidebarItem({
                   >
                     <LabelHook id={id}>
                       <TruncatedLabel>{label}</TruncatedLabel>
-                      {additionalContent || badges}
+                      {additionalContent ?? badges}
                     </LabelHook>
                   </SidebarItemLabel>
                 )}

--- a/static/app/components/sidebar/sidebarItem.tsx
+++ b/static/app/components/sidebar/sidebarItem.tsx
@@ -238,8 +238,7 @@ function SidebarItem({
                   >
                     <LabelHook id={id}>
                       <TruncatedLabel>{label}</TruncatedLabel>
-                      {badges}
-                      {additionalContent}
+                      {additionalContent || badges}
                     </LabelHook>
                   </SidebarItemLabel>
                 )}


### PR DESCRIPTION
Two changes:

- **Vertically center label items** Otherwise it looks weird
- **Never show additional content _and_ badges** Otherwise, the combination of an upsell badge _and_ a "new" badge is a little much.

**Before:**
<img width="232" alt="Screenshot 2024-05-31 at 3 36 12 PM" src="https://github.com/getsentry/sentry/assets/989898/ce999693-2b0a-404b-b971-e57cf3b79d7f">

**After:**
<img width="230" alt="Screenshot 2024-05-31 at 3 38 41 PM" src="https://github.com/getsentry/sentry/assets/989898/16c784b2-5b37-486e-bdd7-a9148bd8ec1e">

