### PR TITLE
feat(insights): Promote new Insights modules and Trace View to Beta

### DIFF
--- a/static/app/components/sidebar/index.tsx
+++ b/static/app/components/sidebar/index.tsx
@@ -380,7 +380,7 @@ function Sidebar() {
         to={`/organizations/${organization.slug}/performance/traces/`}
         id="performance-trace-explorer"
         icon={<SubitemDot collapsed />}
-        isAlpha
+        isBeta
       />
     </Feature>
   );

--- a/static/app/components/sidebar/index.tsx
+++ b/static/app/components/sidebar/index.tsx
@@ -380,7 +380,7 @@ function Sidebar() {
         to={`/organizations/${organization.slug}/performance/traces/`}
         id="performance-trace-explorer"
         icon={<SubitemDot collapsed />}
-        isBeta
+        isNew
       />
     </Feature>
   );

--- a/static/app/views/llmMonitoring/settings.ts
+++ b/static/app/views/llmMonitoring/settings.ts
@@ -4,14 +4,10 @@ import {t} from 'sentry/locale';
 export const MODULE_TITLE = t('LLM Monitoring');
 export const BASE_URL = 'llm-monitoring';
 
-export const RELEASE_LEVEL: BadgeType = 'alpha';
+export const RELEASE_LEVEL: BadgeType = 'beta';
 
-// NOTE: Awkward typing, but without it `RELEASE_LEVEL` is narrowed and the comparison is not allowed
 export const releaseLevelAsBadgeProps = {
-  isAlpha: (RELEASE_LEVEL as BadgeType) === 'alpha',
-  isBeta: (RELEASE_LEVEL as BadgeType) === 'beta',
-  isNew: (RELEASE_LEVEL as BadgeType) === 'new',
-  variant: 'short' as const,
+  isNew: true,
 };
 
 export const MODULE_DOC_LINK = 'https://docs.sentry.io/product/llm-monitoring/';

--- a/static/app/views/performance/cache/settings.ts
+++ b/static/app/views/performance/cache/settings.ts
@@ -9,9 +9,7 @@ export const RELEASE_LEVEL: BadgeType = 'beta';
 
 // NOTE: Awkward typing, but without it `RELEASE_LEVEL` is narrowed and the comparison is not allowed
 export const releaseLevelAsBadgeProps = {
-  isAlpha: (RELEASE_LEVEL as BadgeType) === 'alpha',
-  isBeta: (RELEASE_LEVEL as BadgeType) === 'beta',
-  isNew: (RELEASE_LEVEL as BadgeType) === 'new',
+  isNew: true,
 };
 
 export const CHART_HEIGHT = 160;

--- a/static/app/views/performance/queues/settings.ts
+++ b/static/app/views/performance/queues/settings.ts
@@ -9,9 +9,7 @@ export const DESTINATION_TITLE = t('Destination Summary');
 export const RELEASE_LEVEL: BadgeType = 'beta';
 
 export const releaseLevelAsBadgeProps = {
-  isAlpha: (RELEASE_LEVEL as BadgeType) === 'alpha',
-  isBeta: (RELEASE_LEVEL as BadgeType) === 'beta',
-  isNew: (RELEASE_LEVEL as BadgeType) === 'new',
+  isNew: true,
 };
 
 export const DEFAULT_QUERY_FILTER = 'span.op:[queue.process,queue.publish]';


### PR DESCRIPTION
Ask from product is that all the modules that are launching get a "New" badge in the sidebar, but a "Beta" badge in-app.
