### PR TITLE
ref(rules): Make an enum for trigger action methods

### DIFF
--- a/src/sentry/incidents/models/alert_rule.py
+++ b/src/sentry/incidents/models/alert_rule.py
@@ -4,7 +4,7 @@ import logging
 from collections import namedtuple
 from collections.abc import Callable
 from datetime import timedelta
-from enum import Enum
+from enum import Enum, StrEnum
 from typing import Any, ClassVar, Protocol, Self
 
 from django.conf import settings
@@ -437,6 +437,11 @@ class AlertRuleTriggerExclusion(Model):
         app_label = "sentry"
         db_table = "sentry_alertruletriggerexclusion"
         unique_together = (("alert_rule_trigger", "query_subscription"),)
+
+
+class AlertRuleTriggerActionMethod(StrEnum):
+    FIRE = "fire"
+    RESOLVE = "resolve"
 
 
 class AlertRuleTriggerActionManager(BaseManager["AlertRuleTriggerAction"]):

--- a/src/sentry/incidents/subscription_processor.py
+++ b/src/sentry/incidents/subscription_processor.py
@@ -27,6 +27,7 @@ from sentry.incidents.models.alert_rule import (
     AlertRuleMonitorType,
     AlertRuleThresholdType,
     AlertRuleTrigger,
+    AlertRuleTriggerActionMethod,
     invoke_alert_subscription_callback,
 )
 from sentry.incidents.models.alert_rule_activations import AlertRuleActivations
@@ -733,7 +734,11 @@ class SubscriptionProcessor:
         # Grab the first trigger to get incident id (they are all the same)
         # All triggers should either be firing or resolving, so doesn't matter which we grab.
         incident_trigger = incident_triggers[0]
-        method = "fire" if incident_trigger.status == TriggerStatus.ACTIVE.value else "resolve"
+        method = (
+            AlertRuleTriggerActionMethod.FIRE.value
+            if incident_trigger.status == TriggerStatus.ACTIVE.value
+            else AlertRuleTriggerActionMethod.RESOLVE.value
+        )
         try:
             incident = Incident.objects.get(id=incident_trigger.incident_id)
         except Incident.DoesNotExist:
@@ -758,7 +763,7 @@ class SubscriptionProcessor:
         actions_to_fire = []
         new_status = IncidentStatus.CLOSED.value
 
-        if method == "resolve":
+        if method == AlertRuleTriggerActionMethod.RESOLVE.value:
             if incident.status != IncidentStatus.CLOSED.value:
                 # Critical -> warning
                 actions_to_fire = actions

--- a/src/sentry/incidents/tasks.py
+++ b/src/sentry/incidents/tasks.py
@@ -1,13 +1,17 @@
 from __future__ import annotations
 
 import logging
-from typing import Any, Literal
+from typing import Any
 from urllib.parse import urlencode
 
 from django.urls import reverse
 
 from sentry.auth.access import from_user
-from sentry.incidents.models.alert_rule import AlertRuleStatus, AlertRuleTriggerAction
+from sentry.incidents.models.alert_rule import (
+    AlertRuleStatus,
+    AlertRuleTriggerAction,
+    AlertRuleTriggerActionMethod,
+)
 from sentry.incidents.models.incident import (
     INCIDENT_STATUS,
     Incident,
@@ -182,7 +186,7 @@ def handle_trigger_action(
     action_id: int,
     incident_id: int,
     project_id: int,
-    method: Literal["fire", "resolve"],
+    method: AlertRuleTriggerActionMethod,
     new_status: int,
     metric_value: int | None = None,
     **kwargs: Any,

--- a/src/sentry/incidents/tasks.py
+++ b/src/sentry/incidents/tasks.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import logging
-from typing import Any
+from typing import Any, Literal
 from urllib.parse import urlencode
 
 from django.urls import reverse
@@ -182,7 +182,7 @@ def handle_trigger_action(
     action_id: int,
     incident_id: int,
     project_id: int,
-    method: str,
+    method: Literal["fire", "resolve"],
     new_status: int,
     metric_value: int | None = None,
     **kwargs: Any,


### PR DESCRIPTION
During the TTL week investigations I found this area that would benefit from an enum for "fire" and "resolve". 