### PR TITLE
test(ui): Enforce more unique test names

### DIFF
--- a/static/app/gettingStartedDocs/ionic/ionic.spec.tsx
+++ b/static/app/gettingStartedDocs/ionic/ionic.spec.tsx
@@ -3,7 +3,7 @@ import {screen} from 'sentry-test/reactTestingLibrary';
 
 import docs from './ionic';
 
-describe('GettingStartedWithSpring', function () {
+describe('getting started with ionic', function () {
   it('renders docs correctly', function () {
     renderWithOnboardingLayout(docs);
 

--- a/static/app/gettingStartedDocs/java/log4j2.spec.tsx
+++ b/static/app/gettingStartedDocs/java/log4j2.spec.tsx
@@ -4,7 +4,7 @@ import {textWithMarkupMatcher} from 'sentry-test/utils';
 
 import docs, {PackageManager} from './log4j2';
 
-describe('GettingStartedWithSpring', function () {
+describe('getting started with log4j2', function () {
   it('renders gradle docs correctly', async function () {
     renderWithOnboardingLayout(docs, {
       releaseRegistry: {

--- a/static/app/gettingStartedDocs/java/logback.spec.tsx
+++ b/static/app/gettingStartedDocs/java/logback.spec.tsx
@@ -4,7 +4,7 @@ import {textWithMarkupMatcher} from 'sentry-test/utils';
 
 import docs, {PackageManager} from './logback';
 
-describe('GettingStartedWithSpring', function () {
+describe('getting started with logback', function () {
   it('renders gradle docs correctly', async function () {
     renderWithOnboardingLayout(docs, {
       releaseRegistry: {

--- a/static/app/gettingStartedDocs/kotlin/kotlin.spec.tsx
+++ b/static/app/gettingStartedDocs/kotlin/kotlin.spec.tsx
@@ -4,7 +4,7 @@ import {textWithMarkupMatcher} from 'sentry-test/utils';
 
 import docs, {PackageManager} from './kotlin';
 
-describe('GettingStartedWithSpring', function () {
+describe('GettingStartedWithKotlin', function () {
   it('renders gradle docs correctly', async function () {
     renderWithOnboardingLayout(docs, {
       releaseRegistry: {

--- a/static/app/gettingStartedDocs/minidump/minidump.spec.tsx
+++ b/static/app/gettingStartedDocs/minidump/minidump.spec.tsx
@@ -3,7 +3,7 @@ import {screen} from 'sentry-test/reactTestingLibrary';
 
 import docs from './minidump';
 
-describe('GettingStartedWithSpring', function () {
+describe('getting started with minidump', function () {
   it('renders gradle docs correctly', function () {
     renderWithOnboardingLayout(docs);
 

--- a/static/app/gettingStartedDocs/native/native-qt.spec.tsx
+++ b/static/app/gettingStartedDocs/native/native-qt.spec.tsx
@@ -3,7 +3,7 @@ import {screen} from 'sentry-test/reactTestingLibrary';
 
 import docs from './native-qt';
 
-describe('GettingStartedWithSpring', function () {
+describe('getting started with native-qt', function () {
   it('renders gradle docs correctly', function () {
     renderWithOnboardingLayout(docs);
 

--- a/static/app/gettingStartedDocs/native/native.spec.tsx
+++ b/static/app/gettingStartedDocs/native/native.spec.tsx
@@ -3,8 +3,8 @@ import {screen} from 'sentry-test/reactTestingLibrary';
 
 import docs from './native';
 
-describe('GettingStartedWithSpring', function () {
-  it('renders gradle docs correctly', function () {
+describe('getting started with native', function () {
+  it('renders docs correctly', function () {
     renderWithOnboardingLayout(docs);
 
     // Renders main headings

--- a/static/app/gettingStartedDocs/react-native/react-native.spec.tsx
+++ b/static/app/gettingStartedDocs/react-native/react-native.spec.tsx
@@ -6,7 +6,7 @@ import {ProductSolution} from 'sentry/components/onboarding/productSelection';
 
 import docs from './react-native';
 
-describe('GettingStartedWithSpring', function () {
+describe('getting started with react-native', function () {
   it('renders errors onboarding docs correctly', function () {
     renderWithOnboardingLayout(docs);
 

--- a/static/app/gettingStartedDocs/ruby/rack.spec.tsx
+++ b/static/app/gettingStartedDocs/ruby/rack.spec.tsx
@@ -6,7 +6,7 @@ import {ProductSolution} from 'sentry/components/onboarding/productSelection';
 
 import docs from './rack';
 
-describe('GettingStartedWithSpring', function () {
+describe('getting started with rack', function () {
   it('renders errors onboarding docs correctly', function () {
     renderWithOnboardingLayout(docs);
 

--- a/static/app/gettingStartedDocs/ruby/ruby.spec.tsx
+++ b/static/app/gettingStartedDocs/ruby/ruby.spec.tsx
@@ -6,7 +6,7 @@ import {ProductSolution} from 'sentry/components/onboarding/productSelection';
 
 import docs from './ruby';
 
-describe('GettingStartedWithSpring', function () {
+describe('getting started with ruby', function () {
   it('renders errors onboarding docs correctly', function () {
     renderWithOnboardingLayout(docs);
 

--- a/static/app/gettingStartedDocs/unreal/unreal.spec.tsx
+++ b/static/app/gettingStartedDocs/unreal/unreal.spec.tsx
@@ -3,8 +3,8 @@ import {screen} from 'sentry-test/reactTestingLibrary';
 
 import docs from './unreal';
 
-describe('GettingStartedWithSpring', function () {
-  it('renders gradle docs correctly', function () {
+describe('getting started with unreal', function () {
+  it('renders docs correctly', function () {
     renderWithOnboardingLayout(docs);
 
     // Renders main headings


### PR DESCRIPTION
Bunch of tests were called `GettingStartedWithSpring > renders gradle docs correctly` just trying to make sure we have unique names.
