### PR TITLE
ref: remove safe_execute in send_confirmation_notification

### DIFF
--- a/src/sentry/api/endpoints/project_rules.py
+++ b/src/sentry/api/endpoints/project_rules.py
@@ -34,14 +34,12 @@ from sentry.rules.processing.processor import is_condition_slow
 from sentry.signals import alert_rule_created
 from sentry.tasks.integrations.slack import find_channel_id_for_rule
 from sentry.utils import metrics
-from sentry.utils.safe import safe_execute
 
 
 def send_confirmation_notification(rule: Rule, new: bool, changed: dict | None = None):
     for action in rule.data.get("actions", ()):
         action_inst = instantiate_action(rule, action)
-        safe_execute(
-            action_inst.send_confirmation_notification,
+        action_inst.send_confirmation_notification(
             rule=rule,
             new=new,
             changed=changed,


### PR DESCRIPTION
errors are already handled gracefully in this method and it is creating an unnecessary transaction

I am trying to remove the transaction side-effect of safe_execute since almost all of the callers do not use it

I checked a week of logs and this has never produces a safe execute log line for this function

<!-- Describe your PR here. -->