### PR TITLE
ref(custom-views): Delete member's views upon member removal

### DIFF
--- a/src/sentry/api/endpoints/organization_member/details.py
+++ b/src/sentry/api/endpoints/organization_member/details.py
@@ -441,9 +441,9 @@ class OrganizationMemberDetailsEndpoint(OrganizationMemberEndpoint):
                 using=router.db_for_write(Project),
             )
 
-        # Delete a member's views of this org once the member is removed
-        # We will need to modify this to delete ONLY the member-scoped views of the org and not their
-        # Organization-scoped views if we choose to support that feature in the future.
+        # Delete a member's views of this org upon member's removal
+        # Should we choose to support Organization-scoped views in the future,
+        # we will need to modify this to delete ONLY the member-scoped views of the org
         GroupSearchView.objects.filter(user_id=member.user_id, organization=organization).delete()
 
         self.create_audit_entry(


### PR DESCRIPTION
This PR implements logic to delete an organization member's custom views upon removal from the organization. The table used to store custom views, `sentry_groupsearchview`, does not use `org_member_id` as a foreign key, so deletion of the member will **not** cascade delete their views, hence why we must implement manual logic to do so. 
