### PR TITLE
ref: don't hold a transaction while sending user report notifications

### DIFF
--- a/src/sentry/tasks/user_report.py
+++ b/src/sentry/tasks/user_report.py
@@ -18,4 +18,6 @@ def user_report(report, project_id):
     from sentry.models.project import Project
 
     project = Project.objects.get_from_cache(id=project_id)
-    safe_execute(mail_adapter.handle_user_report, report=report, project=project)
+    safe_execute(
+        mail_adapter.handle_user_report, report=report, project=project, _with_transaction=False
+    )


### PR DESCRIPTION
fixes SENTRY-R7P

an aside: I'm trying to kill `_with_transaction` entirely -- but want to move everything over to using `=False` separately before doing so

<!-- Describe your PR here. -->