### PR TITLE
ref: don't hold a django transaction while doing a bunch of redis operations

### DIFF
--- a/src/sentry/ingest/transaction_clusterer/datasource/redis.py
+++ b/src/sentry/ingest/transaction_clusterer/datasource/redis.py
@@ -190,7 +190,9 @@ def record_span_descriptions(
         description = _get_span_description_to_store(span)
         if not description:
             continue
-        safe_execute(_record_sample, ClustererNamespace.SPANS, project, description)
+        safe_execute(
+            _record_sample, ClustererNamespace.SPANS, project, description, _with_transaction=False
+        )
 
 
 def _get_span_description_to_store(span: Mapping[str, Any]) -> str | None:


### PR DESCRIPTION
`_with_transaction` defaults to true and opens an atomic django transaction (for no database operations!)

I'm trying to kill this surprising behaviour -- but first setting each callsite to `_with_transaction=False` before doing so


<!-- Describe your PR here. -->