### PR TITLE
ref: remove django transaction when querying snuba

### DIFF
--- a/src/sentry/rules/processing/delayed_processing.py
+++ b/src/sentry/rules/processing/delayed_processing.py
@@ -154,6 +154,7 @@ def get_condition_group_results(
             group_ids,
             unique_condition.environment_id,
             comparison_type,
+            _with_transaction=False,
         )
         condition_group_results[unique_condition] = result
     return condition_group_results


### PR DESCRIPTION
nothing is written to the sentry datastore so the transaction side-effect of safe_execute isn't needed

I'm trying to remove the surprising _with_transaction=True default entirely but setting them all to False individually first is safer

<!-- Describe your PR here. -->