### PR TITLE
ref: avoid holding a django transaction while sending notifications

### DIFF
--- a/src/sentry/notifications/notifications/base.py
+++ b/src/sentry/notifications/notifications/base.py
@@ -284,7 +284,7 @@ class BaseNotification(abc.ABC):
         context = self.get_context()
         for provider, recipients in participants_by_provider.items():
             with sentry_sdk.start_span(op="notification.send", description=f"send_for_{provider}"):
-                safe_execute(notify, provider, self, recipients, context)
+                safe_execute(notify, provider, self, recipients, context, _with_transaction=False)
 
 
 class ProjectNotification(BaseNotification, abc.ABC):


### PR DESCRIPTION
the transaction wasn't being written to, these can take a long time holding a db connection

aside: I'm trying to remove _with_transaction=True default entirely, but setting them all to False first to be safer

<!-- Describe your PR here. -->