### PR TITLE
feat(billing): Prepare spend notifications for AM3

### DIFF
--- a/static/app/views/settings/account/notifications/fields2.tsx
+++ b/static/app/views/settings/account/notifications/fields2.tsx
@@ -165,6 +165,17 @@ export const QUOTA_FIELDS = [
     ] as const,
   },
   {
+    name: 'quotaSpans',
+    label: t('Spans'),
+    help: tct('Receive notifications about your spans quotas. [learnMore:Learn more]', {
+      learnMore: <ExternalLink href={getDocsLinkForEventType('spans')} />,
+    }),
+    choices: [
+      ['always', t('On')],
+      ['never', t('Off')],
+    ] as const,
+  },
+  {
     name: 'quotaReplays',
     label: t('Replays'),
     help: tct('Receive notifications about your replay quotas. [learnMore:Learn more]', {
@@ -235,17 +246,6 @@ export const SPEND_FIELDS = [
         ),
       }
     ),
-    choices: [
-      ['always', t('On')],
-      ['never', t('Off')],
-    ] as const,
-  },
-  {
-    name: 'quotaSpans',
-    label: t('Spans'),
-    help: tct('Receive notifications about your spans quotas. [learnMore:Learn more]', {
-      learnMore: <ExternalLink href={getDocsLinkForEventType('spans')} />,
-    }),
     choices: [
       ['always', t('On')],
       ['never', t('Off')],

--- a/static/app/views/settings/account/notifications/fields2.tsx
+++ b/static/app/views/settings/account/notifications/fields2.tsx
@@ -168,7 +168,7 @@ export const QUOTA_FIELDS = [
     name: 'quotaSpans',
     label: t('Spans'),
     help: tct('Receive notifications about your spans quotas. [learnMore:Learn more]', {
-      learnMore: <ExternalLink href={getDocsLinkForEventType('spans')} />,
+      learnMore: <ExternalLink href={getDocsLinkForEventType('span')} />,
     }),
     choices: [
       ['always', t('On')],

--- a/static/app/views/settings/account/notifications/fields2.tsx
+++ b/static/app/views/settings/account/notifications/fields2.tsx
@@ -240,5 +240,16 @@ export const SPEND_FIELDS = [
       ['never', t('Off')],
     ] as const,
   },
+  {
+    name: 'quotaSpans',
+    label: t('Spans'),
+    help: tct('Receive notifications about your spans quotas. [learnMore:Learn more]', {
+      learnMore: <ExternalLink href={getDocsLinkForEventType('spans')} />,
+    }),
+    choices: [
+      ['always', t('On')],
+      ['never', t('Off')],
+    ] as const,
+  },
   ...QUOTA_FIELDS.slice(1),
 ];

--- a/static/app/views/settings/account/notifications/notificationSettingsByType.spec.tsx
+++ b/static/app/views/settings/account/notifications/notificationSettingsByType.spec.tsx
@@ -317,7 +317,7 @@ describe('NotificationSettingsByType', function () {
     );
   });
 
-  it('spend notifications on org with am3', async function () {
+  it('spend notifications on org with am3 with spend visibility notifications', async function () {
     const organization = OrganizationFixture();
     organization.features.push('spend-visibility-notifications');
     organization.features.push('am3-tier');
@@ -327,6 +327,73 @@ describe('NotificationSettingsByType', function () {
     });
 
     expect(await screen.getAllByText('Spend Notifications').length).toEqual(2);
+
+    expect(screen.getByText('Errors')).toBeInTheDocument();
+    expect(screen.getByText('Spans')).toBeInTheDocument();
+    expect(screen.getByText('Replays')).toBeInTheDocument();
+    expect(screen.getByText('Attachments')).toBeInTheDocument();
+    expect(screen.getByText('Spend Allocations')).toBeInTheDocument();
+    expect(screen.queryByText('Transactions')).not.toBeInTheDocument();
+
+    const editSettingMock = MockApiClient.addMockResponse({
+      url: `/users/me/notification-options/`,
+      method: 'PUT',
+      body: {
+        id: '7',
+        scopeIdentifier: '1',
+        scopeType: 'user',
+        type: 'quotaSpans',
+        value: 'never',
+      },
+    });
+
+    // toggle spans quota notifications off
+    await selectEvent.select(screen.getAllByText('On')[2], 'Off');
+
+    expect(editSettingMock).toHaveBeenCalledTimes(1);
+    expect(editSettingMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        data: {
+          scopeIdentifier: '1',
+          scopeType: 'user',
+          type: 'quotaSpans',
+          value: 'never',
+        },
+      })
+    );
+  });
+
+  it('spend notifications on org with am3 and org without am3', async function () {
+    const organization = OrganizationFixture();
+    organization.features.push('spend-visibility-notifications');
+    organization.features.push('am3-tier');
+    const otherOrganization = OrganizationFixture();
+    renderComponent({
+      notificationType: 'quota',
+      organizations: [organization, otherOrganization],
+    });
+
+    expect(await screen.getAllByText('Spend Notifications').length).toEqual(2);
+
+    expect(screen.getByText('Errors')).toBeInTheDocument();
+    expect(screen.getByText('Spans')).toBeInTheDocument();
+    expect(screen.getByText('Replays')).toBeInTheDocument();
+    expect(screen.getByText('Attachments')).toBeInTheDocument();
+    expect(screen.getByText('Spend Allocations')).toBeInTheDocument();
+    expect(screen.getByText('Transactions')).toBeInTheDocument();
+  });
+
+  it('spend notifications on org with am3 without spend visibility notifications', async function () {
+    const organization = OrganizationFixture();
+    organization.features.push('am3-tier');
+    renderComponent({
+      notificationType: 'quota',
+      organizations: [organization],
+    });
+
+    expect(await screen.getAllByText('Quota Notifications').length).toEqual(1);
+    expect(screen.queryByText('Spend Notifications')).not.toBeInTheDocument();
 
     expect(screen.getByText('Errors')).toBeInTheDocument();
     expect(screen.getByText('Spans')).toBeInTheDocument();
@@ -362,25 +429,5 @@ describe('NotificationSettingsByType', function () {
         },
       })
     );
-  });
-
-  it('spend notifications on org with am3 and org without am3', async function () {
-    const organization = OrganizationFixture();
-    organization.features.push('spend-visibility-notifications');
-    organization.features.push('am3-tier');
-    const otherOrganization = OrganizationFixture();
-    renderComponent({
-      notificationType: 'quota',
-      organizations: [organization, otherOrganization],
-    });
-
-    expect(await screen.getAllByText('Spend Notifications').length).toEqual(2);
-
-    expect(screen.getByText('Errors')).toBeInTheDocument();
-    expect(screen.getByText('Spans')).toBeInTheDocument();
-    expect(screen.getByText('Replays')).toBeInTheDocument();
-    expect(screen.getByText('Attachments')).toBeInTheDocument();
-    expect(screen.getByText('Spend Allocations')).toBeInTheDocument();
-    expect(screen.getByText('Transactions')).toBeInTheDocument();
   });
 });

--- a/static/app/views/settings/account/notifications/notificationSettingsByType.spec.tsx
+++ b/static/app/views/settings/account/notifications/notificationSettingsByType.spec.tsx
@@ -164,6 +164,7 @@ describe('NotificationSettingsByType', function () {
     expect(screen.getByText('Replays')).toBeInTheDocument();
     expect(screen.getByText('Attachments')).toBeInTheDocument();
     expect(screen.getByText('Spend Allocations')).toBeInTheDocument();
+    expect(screen.queryByText('Spans')).not.toBeInTheDocument();
   });
   it('adds a project override and removes it', async function () {
     renderComponent({});
@@ -314,5 +315,72 @@ describe('NotificationSettingsByType', function () {
         },
       })
     );
+  });
+
+  it('spend notifications on org with am3', async function () {
+    const organization = OrganizationFixture();
+    organization.features.push('spend-visibility-notifications');
+    organization.features.push('am3-tier');
+    renderComponent({
+      notificationType: 'quota',
+      organizations: [organization],
+    });
+
+    expect(await screen.getAllByText('Spend Notifications').length).toEqual(2);
+
+    expect(screen.getByText('Errors')).toBeInTheDocument();
+    expect(screen.getByText('Spans')).toBeInTheDocument();
+    expect(screen.getByText('Replays')).toBeInTheDocument();
+    expect(screen.getByText('Attachments')).toBeInTheDocument();
+    expect(screen.getByText('Spend Allocations')).toBeInTheDocument();
+    expect(screen.queryByText('Transactions')).not.toBeInTheDocument();
+
+    const editSettingMock = MockApiClient.addMockResponse({
+      url: `/users/me/notification-options/`,
+      method: 'PUT',
+      body: {
+        id: '7',
+        scopeIdentifier: '1',
+        scopeType: 'user',
+        type: 'quotaSpans',
+        value: 'never',
+      },
+    });
+
+    // toggle spans quota notifications off
+    await selectEvent.select(screen.getAllByText('On')[1], 'Off');
+
+    expect(editSettingMock).toHaveBeenCalledTimes(1);
+    expect(editSettingMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        data: {
+          scopeIdentifier: '1',
+          scopeType: 'user',
+          type: 'quotaSpans',
+          value: 'never',
+        },
+      })
+    );
+  });
+
+  it('spend notifications on org with am3 and org without am3', async function () {
+    const organization = OrganizationFixture();
+    organization.features.push('spend-visibility-notifications');
+    organization.features.push('am3-tier');
+    const otherOrganization = OrganizationFixture();
+    renderComponent({
+      notificationType: 'quota',
+      organizations: [organization, otherOrganization],
+    });
+
+    expect(await screen.getAllByText('Spend Notifications').length).toEqual(2);
+
+    expect(screen.getByText('Errors')).toBeInTheDocument();
+    expect(screen.getByText('Spans')).toBeInTheDocument();
+    expect(screen.getByText('Replays')).toBeInTheDocument();
+    expect(screen.getByText('Attachments')).toBeInTheDocument();
+    expect(screen.getByText('Spend Allocations')).toBeInTheDocument();
+    expect(screen.getByText('Transactions')).toBeInTheDocument();
   });
 });

--- a/static/app/views/settings/account/notifications/notificationSettingsByType.tsx
+++ b/static/app/views/settings/account/notifications/notificationSettingsByType.tsx
@@ -398,18 +398,19 @@ class NotificationSettingsByTypeV2 extends DeprecatedAsyncComponent<Props, State
     const {notificationType, organizations} = this.props;
     const {notificationOptions} = this.state;
     const unlinkedSlackOrgs = this.getUnlinkedOrgs('slack');
-    const notificationDetails = ACCOUNT_NOTIFICATION_FIELDS[notificationType];
+    let notificationDetails = ACCOUNT_NOTIFICATION_FIELDS[notificationType];
     // TODO(isabella): Once GA, remove this
     if (
       notificationType === 'quota' &&
       organizations.some(org => org.features?.includes('spend-visibility-notifications'))
     ) {
-      notificationDetails.title = t('Spend Notifications');
-      notificationDetails.description = t(
-        'Control the notifications you receive for organization spend.'
-      );
+      notificationDetails = {
+        ...notificationDetails,
+        title: t('Spend Notifications'),
+        description: t('Control the notifications you receive for organization spend.'),
+      };
     }
-    const {title, description} = ACCOUNT_NOTIFICATION_FIELDS[notificationType];
+    const {title, description} = notificationDetails;
 
     const entityType = isGroupedByProject(notificationType) ? 'project' : 'organization';
     return (

--- a/static/app/views/settings/account/notifications/utils.tsx
+++ b/static/app/views/settings/account/notifications/utils.tsx
@@ -36,7 +36,7 @@ export const groupByOrganization = (
  * Returns a link to docs on explaining how to manage quotas for that event type
  */
 export function getDocsLinkForEventType(
-  event: 'error' | 'transaction' | 'attachment' | 'replay' | 'monitorSeat'
+  event: 'error' | 'transaction' | 'attachment' | 'replay' | 'monitorSeat' | 'spans'
 ) {
   switch (event) {
     case 'transaction':
@@ -47,6 +47,8 @@ export function getDocsLinkForEventType(
       return 'https://docs.sentry.io/product/session-replay/';
     case 'monitorSeat':
       return 'https://docs.sentry.io/product/crons/';
+    case 'spans':
+      return 'https://docs.sentry.io/product/spans/';
     default:
       return 'https://docs.sentry.io/product/accounts/quotas/manage-event-stream-guide/#common-workflows-for-managing-your-event-stream';
   }

--- a/static/app/views/settings/account/notifications/utils.tsx
+++ b/static/app/views/settings/account/notifications/utils.tsx
@@ -41,14 +41,14 @@ export function getDocsLinkForEventType(
   switch (event) {
     case 'transaction':
       return 'https://docs.sentry.io/product/performance/transaction-summary/#what-is-a-transaction';
+    case 'spans':
+      return 'https://docs.sentry.io/product/performance/transaction-summary/#what-is-a-transaction';
     case 'attachment':
       return 'https://docs.sentry.io/product/accounts/quotas/manage-attachments-quota/#2-rate-limiting';
     case 'replay':
       return 'https://docs.sentry.io/product/session-replay/';
     case 'monitorSeat':
       return 'https://docs.sentry.io/product/crons/';
-    case 'spans':
-      return 'https://docs.sentry.io/product/spans/';
     default:
       return 'https://docs.sentry.io/product/accounts/quotas/manage-event-stream-guide/#common-workflows-for-managing-your-event-stream';
   }

--- a/static/app/views/settings/account/notifications/utils.tsx
+++ b/static/app/views/settings/account/notifications/utils.tsx
@@ -36,12 +36,12 @@ export const groupByOrganization = (
  * Returns a link to docs on explaining how to manage quotas for that event type
  */
 export function getDocsLinkForEventType(
-  event: 'error' | 'transaction' | 'attachment' | 'replay' | 'monitorSeat' | 'spans'
+  event: 'error' | 'transaction' | 'attachment' | 'replay' | 'monitorSeat' | 'span'
 ) {
   switch (event) {
     case 'transaction':
       return 'https://docs.sentry.io/product/performance/transaction-summary/#what-is-a-transaction';
-    case 'spans':
+    case 'span':
       return 'https://docs.sentry.io/product/performance/transaction-summary/#what-is-a-transaction';
     case 'attachment':
       return 'https://docs.sentry.io/product/accounts/quotas/manage-attachments-quota/#2-rate-limiting';


### PR DESCRIPTION
On the user's personal notification preferences for spend notifications:

- If a user is a member of an organization on the AM3 tier plan, we display the spans quota notification.
- We hide transactions quota notification only if the user is a member of all organizations that are on the AM3 tier plan

# TODO

- [x] update spans "Learn More" link to actual documentation when it is available
