### PR TITLE
feat(slack): add slack-sdk

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -67,6 +67,7 @@ sentry-ophio==0.2.7
 sentry-redis-tools>=0.1.7
 sentry-relay>=0.8.67
 sentry-sdk>=2.2.1
+slack-sdk>=3.27.2
 snuba-sdk>=2.0.33
 simplejson>=3.17.6
 sqlparse>=0.4.4

--- a/requirements-dev-frozen.txt
+++ b/requirements-dev-frozen.txt
@@ -189,6 +189,7 @@ sentry-sdk==2.2.1
 sentry-usage-accountant==0.0.10
 simplejson==3.17.6
 six==1.16.0
+slack-sdk==3.27.2
 sniffio==1.2.0
 snuba-sdk==2.0.34
 sortedcontainers==2.4.0

--- a/requirements-frozen.txt
+++ b/requirements-frozen.txt
@@ -129,6 +129,7 @@ sentry-sdk==2.2.1
 sentry-usage-accountant==0.0.10
 simplejson==3.17.6
 six==1.16.0
+slack-sdk==3.27.2
 sniffio==1.3.0
 snuba-sdk==2.0.34
 soupsieve==2.3.2.post1


### PR DESCRIPTION
Added slack-sdk to pypi here https://github.com/getsentry/pypi/pull/839

See https://www.notion.so/sentry/Task-list-for-Messaging-Vertical-ca4f431d43b84e72b8a91643fe880b66
- We are adding the `slack-sdk` package to be able to use the `WebClient` in place of our custom `SlackClient` implementation

Following https://develop.sentry.dev/python-dependencies/
