### PR TITLE
nit(slack): updated github name in slack threads

### DIFF
--- a/src/sentry/integrations/slack/threads/activity_notifications.py
+++ b/src/sentry/integrations/slack/threads/activity_notifications.py
@@ -128,6 +128,12 @@ class _ExternalIssueCreatedActivity:
 
         return ticket_number
 
+    def get_formatted_provider_name(self, provider: str) -> str:
+        # Make sure to make the proper noun have correct capitalization
+        # I.e. github -> GitHub, jira -> Jira
+        # Special cases like github -> GitHub are implemented in their overriden classes
+        return provider.capitalize()
+
 
 class _AsanaExternalIssueCreatedActivity(_ExternalIssueCreatedActivity):
     """
@@ -161,29 +167,35 @@ class _AsanaExternalIssueCreatedActivity(_ExternalIssueCreatedActivity):
         return last_part
 
 
+class _GithubExternalIssueCreatedActivity(_ExternalIssueCreatedActivity):
+    """
+    Override class for Github, as the provider name that we want to display should be GitHub, not "Github"
+    """
+
+    def get_formatted_provider_name(self, _: str) -> str:
+        return "GitHub"
+
+
 def _external_issue_activity_factory(activity: Activity) -> _ExternalIssueCreatedActivity:
     """
     Returns the correct ExternalIssueCreatedActivity class based on the provider.
     All classes have the same interface, the method for one is simply modified for its use case.
     """
+    activity_classes = {
+        "asana": _AsanaExternalIssueCreatedActivity,
+        "github": _GithubExternalIssueCreatedActivity,
+    }
+
     base_activity = _ExternalIssueCreatedActivity(activity=activity)
     provider = base_activity.get_provider()
-    if provider == "asana":
-        return _AsanaExternalIssueCreatedActivity(activity=activity)
 
-    return base_activity
+    ActivityClass = activity_classes.get(provider, None)
+    return ActivityClass(activity=activity) if ActivityClass else base_activity
 
 
 class ExternalIssueCreatedActivityNotification(GroupActivityNotification):
     metrics_key = "create_issue"
     title = "External Issue Created"
-
-    def format_provider_name(provider: str) -> str:
-        # Make sure to make the proper noun have correct capitalization
-        # Take in account special cases
-        # I.e. github -> GitHub, jira -> Jira
-        special_cases = {"github": "GitHub"}
-        return special_cases.get(provider.lower(), provider.capitalize())
 
     def get_description(self) -> tuple[str, str | None, Mapping[str, Any]]:
         external_issue = _external_issue_activity_factory(activity=self.activity)
@@ -194,7 +206,7 @@ class ExternalIssueCreatedActivityNotification(GroupActivityNotification):
             base_template = "an "
         else:
             base_template = "a "
-            provider = self.format_provider_name(provider)
+            provider = external_issue.get_formatted_provider_name(provider)
         base_template += "{provider} issue"
 
         ticket_number = external_issue.get_ticket_number()

--- a/src/sentry/integrations/slack/threads/activity_notifications.py
+++ b/src/sentry/integrations/slack/threads/activity_notifications.py
@@ -178,6 +178,13 @@ class ExternalIssueCreatedActivityNotification(GroupActivityNotification):
     metrics_key = "create_issue"
     title = "External Issue Created"
 
+    def format_provider_name(provider: str) -> str:
+        # Make sure to make the proper noun have correct capitalization
+        # Take in account special cases
+        # I.e. github -> GitHub, jira -> Jira
+        special_cases = {"github": "GitHub"}
+        return special_cases.get(provider.lower(), provider.capitalize())
+
     def get_description(self) -> tuple[str, str | None, Mapping[str, Any]]:
         external_issue = _external_issue_activity_factory(activity=self.activity)
 
@@ -187,9 +194,7 @@ class ExternalIssueCreatedActivityNotification(GroupActivityNotification):
             base_template = "an "
         else:
             base_template = "a "
-            # Make sure to make the proper noun have correct capitalization
-            # I.e. github -> Github, jira -> Jira
-            provider = provider.capitalize()
+            provider = self.format_provider_name(provider)
         base_template += "{provider} issue"
 
         ticket_number = external_issue.get_ticket_number()

--- a/src/sentry/integrations/slack/threads/activity_notifications.py
+++ b/src/sentry/integrations/slack/threads/activity_notifications.py
@@ -128,11 +128,11 @@ class _ExternalIssueCreatedActivity:
 
         return ticket_number
 
-    def get_formatted_provider_name(self, provider: str) -> str:
+    def get_formatted_provider_name(self) -> str:
         # Make sure to make the proper noun have correct capitalization
         # I.e. github -> GitHub, jira -> Jira
         # Special cases like github -> GitHub are implemented in their overriden classes
-        return provider.capitalize()
+        return self.get_provider().capitalize()
 
 
 class _AsanaExternalIssueCreatedActivity(_ExternalIssueCreatedActivity):
@@ -172,8 +172,14 @@ class _GithubExternalIssueCreatedActivity(_ExternalIssueCreatedActivity):
     Override class for Github, as the provider name that we want to display should be GitHub, not "Github"
     """
 
-    def get_formatted_provider_name(self, _: str) -> str:
+    def get_formatted_provider_name(self) -> str:
         return "GitHub"
+
+
+_activity_classes = {
+    "asana": _AsanaExternalIssueCreatedActivity,
+    "github": _GithubExternalIssueCreatedActivity,
+}
 
 
 def _external_issue_activity_factory(activity: Activity) -> _ExternalIssueCreatedActivity:
@@ -181,15 +187,11 @@ def _external_issue_activity_factory(activity: Activity) -> _ExternalIssueCreate
     Returns the correct ExternalIssueCreatedActivity class based on the provider.
     All classes have the same interface, the method for one is simply modified for its use case.
     """
-    activity_classes = {
-        "asana": _AsanaExternalIssueCreatedActivity,
-        "github": _GithubExternalIssueCreatedActivity,
-    }
 
     base_activity = _ExternalIssueCreatedActivity(activity=activity)
     provider = base_activity.get_provider()
 
-    ActivityClass = activity_classes.get(provider, None)
+    ActivityClass = _activity_classes.get(provider, None)
     return ActivityClass(activity=activity) if ActivityClass else base_activity
 
 
@@ -206,7 +208,7 @@ class ExternalIssueCreatedActivityNotification(GroupActivityNotification):
             base_template = "an "
         else:
             base_template = "a "
-            provider = external_issue.get_formatted_provider_name(provider)
+            provider = external_issue.get_formatted_provider_name()
         base_template += "{provider} issue"
 
         ticket_number = external_issue.get_ticket_number()

--- a/tests/sentry/integrations/slack/threads/activity_notifications/test_external_issue_created_activity_notification.py
+++ b/tests/sentry/integrations/slack/threads/activity_notifications/test_external_issue_created_activity_notification.py
@@ -15,7 +15,7 @@ class TestGetDescription(BaseTestCase):
         template, _, metadata = notification.get_description()
 
         assert template == "{author} created <{link}|a {provider} issue {ticket}>"
-        assert metadata["provider"] == provider
+        assert metadata["provider"] == "GitHub"  # This is how Github is officially spelled
         assert metadata["ticket"] == label
         assert metadata["link"] == location
 


### PR DESCRIPTION
We didn't capitalize github correctly in our slack threads, it should be `GitHub`
