### PR TITLE
fix(related_issues): Use noticeable background color on hover

### DIFF
--- a/static/app/views/issueDetails/traceTimeline/traceIssue.tsx
+++ b/static/app/views/issueDetails/traceTimeline/traceIssue.tsx
@@ -92,7 +92,7 @@ const TraceIssueLinkContainer = styled(Link)`
   font-size: ${p => p.theme.fontSizeMedium};
 
   &:hover {
-    background-color: ${p => p.theme.surface200};
+    background-color: ${p => p.theme.backgroundTertiary};
     color: ${p => p.theme.textColor};
   }
 `;


### PR DESCRIPTION
The trace issue was supposed to change the background color on hover, however, the color picked was the same or too similar to our normal background color.

https://github.com/getsentry/sentry/assets/44410/9334c541-ce3a-4559-a9df-42dd9e177c89


