### PR TITLE
feat(insights): rename Processing Time column to Span Duration

### DIFF
--- a/static/app/views/performance/queues/destinationSummary/messageSpanSamplesTable.spec.tsx
+++ b/static/app/views/performance/queues/destinationSummary/messageSpanSamplesTable.spec.tsx
@@ -15,9 +15,7 @@ describe('messageSpanSamplesTable', () => {
     expect(screen.getByRole('table', {name: 'Span Samples'})).toBeInTheDocument();
     expect(screen.getByRole('columnheader', {name: 'Span ID'})).toBeInTheDocument();
     expect(screen.getByRole('columnheader', {name: 'Message ID'})).toBeInTheDocument();
-    expect(
-      screen.getByRole('columnheader', {name: 'Processing Time'})
-    ).toBeInTheDocument();
+    expect(screen.getByRole('columnheader', {name: 'Span Duration'})).toBeInTheDocument();
     expect(screen.getByRole('columnheader', {name: 'Retries'})).toBeInTheDocument();
     expect(screen.getByRole('columnheader', {name: 'Status'})).toBeInTheDocument();
   });

--- a/static/app/views/performance/queues/destinationSummary/messageSpanSamplesTable.tsx
+++ b/static/app/views/performance/queues/destinationSummary/messageSpanSamplesTable.tsx
@@ -57,7 +57,7 @@ const CONSUMER_COLUMN_ORDER: Column[] = [
   },
   {
     key: SpanIndexedField.SPAN_DURATION,
-    name: t('Processing Time'),
+    name: t('Span Duration'),
     width: COL_WIDTH_UNDEFINED,
   },
   {


### PR DESCRIPTION
Rename Processing Time column in queues module to Span Duration.