### PR TITLE
feat(query-builder): Improve focus management after new tokens are created

### DIFF
--- a/static/app/components/searchQueryBuilder/context.tsx
+++ b/static/app/components/searchQueryBuilder/context.tsx
@@ -1,11 +1,13 @@
 import {createContext, type Dispatch, useContext} from 'react';
 
+import type {FocusOverride} from 'sentry/components/searchQueryBuilder/types';
 import type {QueryBuilderActions} from 'sentry/components/searchQueryBuilder/useQueryBuilderState';
 import type {ParseResult} from 'sentry/components/searchSyntax/parser';
 import type {Tag, TagCollection} from 'sentry/types';
 
 interface ContextData {
   dispatch: Dispatch<QueryBuilderActions>;
+  focusOverride: FocusOverride | null;
   getTagValues: (tag: Tag, query: string) => Promise<string[]>;
   keys: TagCollection;
   parsedQuery: ParseResult | null;
@@ -19,6 +21,7 @@ export function useSearchQueryBuilder() {
 
 export const SearchQueryBuilerContext = createContext<ContextData>({
   query: '',
+  focusOverride: null,
   keys: {},
   getTagValues: () => Promise.resolve([]),
   dispatch: () => {},

--- a/static/app/components/searchQueryBuilder/filter.tsx
+++ b/static/app/components/searchQueryBuilder/filter.tsx
@@ -1,4 +1,4 @@
-import {Fragment, useCallback, useMemo, useRef, useState} from 'react';
+import {Fragment, useCallback, useLayoutEffect, useMemo, useRef, useState} from 'react';
 import styled from '@emotion/styled';
 import {useFocusWithin} from '@react-aria/interactions';
 import {mergeProps} from '@react-aria/utils';
@@ -138,12 +138,20 @@ function FilterValueText({token}: {token: TokenResult<Token.FILTER>}) {
 
 function FilterValue({token, state, item}: SearchQueryTokenProps) {
   const ref = useRef<HTMLDivElement>(null);
+  const {dispatch, focusOverride} = useSearchQueryBuilder();
 
   const [isEditing, setIsEditing] = useState(false);
 
-  if (!token.value.text && !isEditing) {
-    setIsEditing(true);
-  }
+  useLayoutEffect(() => {
+    if (
+      !isEditing &&
+      focusOverride?.itemKey === item.key &&
+      focusOverride.part === 'value'
+    ) {
+      setIsEditing(true);
+      dispatch({type: 'RESET_FOCUS_OVERRIDE'});
+    }
+  }, [dispatch, focusOverride, isEditing, item.key]);
 
   const {focusWithinProps} = useFocusWithin({
     onBlurWithin: () => {

--- a/static/app/components/searchQueryBuilder/index.spec.tsx
+++ b/static/app/components/searchQueryBuilder/index.spec.tsx
@@ -462,6 +462,9 @@ describe('SearchQueryBuilder', function () {
       await userEvent.keyboard('(');
 
       expect(await screen.findByRole('row', {name: '('})).toBeInTheDocument();
+
+      // Last input (the one after the paren) should have focus
+      expect(screen.getAllByRole('combobox').at(-1)).toHaveFocus();
     });
   });
 

--- a/static/app/components/searchQueryBuilder/tokenizedQueryGrid.tsx
+++ b/static/app/components/searchQueryBuilder/tokenizedQueryGrid.tsx
@@ -1,7 +1,8 @@
-import {useRef} from 'react';
+import {useLayoutEffect, useRef} from 'react';
 import styled from '@emotion/styled';
 import type {AriaGridListOptions} from '@react-aria/gridlist';
 import {Item} from '@react-stately/collections';
+import type {ListState} from '@react-stately/list';
 import {useListState} from '@react-stately/list';
 import type {CollectionChildren} from '@react-types/shared';
 
@@ -24,10 +25,23 @@ interface GridProps extends AriaGridListOptions<ParseResultToken> {
   items: ParseResultToken[];
 }
 
+function useApplyFocusOverride(state: ListState<ParseResultToken>) {
+  const {focusOverride, dispatch} = useSearchQueryBuilder();
+
+  useLayoutEffect(() => {
+    if (focusOverride && !focusOverride.part) {
+      state.selectionManager.setFocusedKey(focusOverride.itemKey);
+      dispatch({type: 'RESET_FOCUS_OVERRIDE'});
+    }
+  }, [dispatch, focusOverride, state.selectionManager]);
+}
+
 function Grid(props: GridProps) {
   const ref = useRef<HTMLDivElement>(null);
   const state = useListState<ParseResultToken>(props);
   const {gridProps} = useQueryBuilderGrid(props, state, ref);
+
+  useApplyFocusOverride(state);
 
   return (
     <SearchQueryGridWrapper {...gridProps} ref={ref}>

--- a/static/app/components/searchQueryBuilder/types.tsx
+++ b/static/app/components/searchQueryBuilder/types.tsx
@@ -2,3 +2,8 @@ export enum QueryInterfaceType {
   TEXT = 'text',
   TOKENIZED = 'tokenized',
 }
+
+export type FocusOverride = {
+  itemKey: string;
+  part?: 'value';
+};

--- a/static/app/components/searchQueryBuilder/useQueryBuilderState.tsx
+++ b/static/app/components/searchQueryBuilder/useQueryBuilderState.tsx
@@ -1,5 +1,6 @@
 import {type Reducer, useCallback, useReducer} from 'react';
 
+import type {FocusOverride} from 'sentry/components/searchQueryBuilder/types';
 import {
   type ParseResultToken,
   TermOperator,
@@ -9,12 +10,15 @@ import {
 import {stringifyToken} from 'sentry/components/searchSyntax/utils';
 
 type QueryBuilderState = {
+  focusOverride: FocusOverride | null;
   query: string;
 };
 
 type ClearAction = {type: 'CLEAR'};
 
 type UpdateQueryAction = {query: string; type: 'UPDATE_QUERY'};
+
+type ResetFocusOverrideAction = {type: 'RESET_FOCUS_OVERRIDE'};
 
 type DeleteTokenAction = {
   token: ParseResultToken;
@@ -25,6 +29,7 @@ type UpdateFreeTextAction = {
   text: string;
   token: TokenResult<Token.FREE_TEXT> | TokenResult<Token.SPACES>;
   type: 'UPDATE_FREE_TEXT';
+  focusOverride?: FocusOverride;
 };
 
 type UpdateFilterOpAction = {
@@ -53,6 +58,7 @@ type DeleteLastMultiSelectFilterValueAction = {
 export type QueryBuilderActions =
   | ClearAction
   | UpdateQueryAction
+  | ResetFocusOverrideAction
   | DeleteTokenAction
   | UpdateFreeTextAction
   | UpdateFilterOpAction
@@ -114,6 +120,8 @@ function updateFreeText(
   return {
     ...state,
     query: newQuery,
+    focusOverride:
+      action.focusOverride === undefined ? state.focusOverride : action.focusOverride,
   };
 }
 
@@ -182,31 +190,41 @@ function deleteLastMultiSelectTokenValue(
 }
 
 export function useQueryBuilderState({initialQuery}: {initialQuery: string}) {
-  const initialState: QueryBuilderState = {query: initialQuery};
+  const initialState: QueryBuilderState = {query: initialQuery, focusOverride: null};
 
   const reducer: Reducer<QueryBuilderState, QueryBuilderActions> = useCallback(
     (state, action): QueryBuilderState => {
       switch (action.type) {
         case 'CLEAR':
           return {
+            ...state,
             query: '',
           };
         case 'UPDATE_QUERY':
           return {
+            ...state,
             query: action.query,
+          };
+        case 'RESET_FOCUS_OVERRIDE':
+          return {
+            ...state,
+            focusOverride: null,
           };
         case 'DELETE_TOKEN':
           return {
+            ...state,
             query: removeQueryToken(state.query, action.token),
           };
         case 'UPDATE_FREE_TEXT':
           return updateFreeText(state, action);
         case 'UPDATE_FILTER_OP':
           return {
+            ...state,
             query: modifyFilterOperator(state.query, action.token, action.op),
           };
         case 'UPDATE_TOKEN_VALUE':
           return {
+            ...state,
             query: replaceQueryToken(state.query, action.token, action.value),
           };
         case 'TOGGLE_FILTER_VALUE':


### PR DESCRIPTION
This adds a new state `focusOverride` which can be used to move the focused element after the state change has taken place. This is used for:

- Typing `(` or `)` will correctly place the cursor after the created paren
- Typing `foo:` will create a new token and focus the value element so the user can start typing right away 