### PR TITLE
feat(sidebar): expand nested items if parent has no link

### DIFF
--- a/static/app/components/sidebar/sidebarAccordion.tsx
+++ b/static/app/components/sidebar/sidebarAccordion.tsx
@@ -55,6 +55,7 @@ function SidebarAccordion({children, ...itemProps}: SidebarAccordionProps) {
   const isOpenInFloatingSidebar = expandedItemId === mainItemId;
 
   const isActive = isItemActive(itemProps);
+  const hasMainLink = Boolean(itemProps.to);
 
   const childSidebarItems = findChildElementsInTree(children, 'SidebarItem');
 
@@ -82,6 +83,9 @@ function SidebarAccordion({children, ...itemProps}: SidebarAccordionProps) {
   ) => {
     if ((!horizontal && !sidebarCollapsed) || !children) {
       setExpandedItemId(null);
+      if (!hasMainLink) {
+        setExpanded(!expanded);
+      }
       return;
     }
 

--- a/static/app/components/sidebar/sidebarItem.tsx
+++ b/static/app/components/sidebar/sidebarItem.tsx
@@ -201,6 +201,7 @@ function SidebarItem({
   );
 
   const isInCollapsedState = !isInFloatingAccordion && collapsed;
+  const hasLink = Boolean(to);
 
   return (
     <Tooltip
@@ -224,6 +225,7 @@ function SidebarItem({
               isInFloatingAccordion={isInFloatingAccordion}
               active={isActive ? 'true' : undefined}
               to={disabled ? '' : toProps}
+              disabled={!hasLink && isInFloatingAccordion}
               className={className}
               aria-current={isActive ? 'page' : undefined}
               onClick={handleItemClick}
@@ -333,8 +335,6 @@ const getActiveStyle = ({
   }
   if (isInFloatingAccordion) {
     return css`
-      background-color: ${theme?.hover};
-
       &:active,
       &:focus,
       &:hover {


### PR DESCRIPTION
1. If the sidebar is in the desktop mode and expanded, clicking on the parent item of a sidebar accordion that does not have a link, toggles expansion of the accordion.
![image](https://github.com/getsentry/sentry/assets/44422760/a0d1343c-d190-4089-b293-f70761bfb45f)

2. If the sidebar is in mobile mobile or its in desktop mode and collapsed, we disable the hover on the parent item. (Can't click insights in this screenshot)
![image](https://github.com/getsentry/sentry/assets/44422760/72a2baa1-7712-418a-a52e-6bdf53dd919d)

