### PR TITLE
ref(crons): Ignore in progress check-in coming in after OK, ERROR

### DIFF
--- a/src/sentry/monitors/consumers/monitor_consumer.py
+++ b/src/sentry/monitors/consumers/monitor_consumer.py
@@ -313,6 +313,13 @@ def update_existing_check_in(
     )
 
     if already_user_complete and not updated_duration_only:
+        # If we receive an in-progress check-in after a user-terminal value it
+        # could likely be due to the user's job running very quickly and events
+        # coming in slightly out of order. We can just ignore this type of
+        # error, and also return to not update the duration
+        if updated_status == CheckInStatus.IN_PROGRESS:
+            return
+
         finished_error: CheckinFinished = {
             "type": ProcessingErrorType.CHECKIN_FINISHED,
         }


### PR DESCRIPTION
Don't generate a processing error for the case where an in-progress comes after an OK check-in. This is to remove noise for fast-running jobs (order of milliseconds) where it is common to see something like:

1. OK/ERROR
2. IN-PROGRESS

