### PR TITLE
fix(query-builder): Some minor behavior fixes when editing filter values

### DIFF
--- a/static/app/components/searchQueryBuilder/index.spec.tsx
+++ b/static/app/components/searchQueryBuilder/index.spec.tsx
@@ -360,6 +360,23 @@ describe('SearchQueryBuilder', function () {
       ).toBeInTheDocument();
     });
 
+    it('opens the value suggestions menu when clicking anywhere in the filter value', async function () {
+      render(
+        <SearchQueryBuilder
+          {...defaultProps}
+          initialQuery="browser.name:[Chrome,Firefox]"
+        />
+      );
+
+      // Start editing value
+      await userEvent.click(
+        screen.getByRole('button', {name: 'Edit value for filter: browser.name'})
+      );
+      // Click in the filter value area, should open the menu
+      await userEvent.click(screen.getByTestId('filter-value-editing'));
+      expect(await screen.findByRole('option', {name: 'Chrome'})).toBeInTheDocument();
+    });
+
     it('can remove parens by clicking the delete button', async function () {
       render(<SearchQueryBuilder {...defaultProps} initialQuery="(" />);
 
@@ -589,6 +606,31 @@ describe('SearchQueryBuilder', function () {
       await userEvent.keyboard('{backspace}{backspace}');
 
       expect(screen.queryByRole('row', {name: '('})).not.toBeInTheDocument();
+    });
+
+    it('exits filter value when pressing escape', async function () {
+      render(
+        <SearchQueryBuilder {...defaultProps} initialQuery="browser.name:Firefox" />
+      );
+
+      // Click into filter value (button to edit will no longer exist)
+      await userEvent.click(
+        screen.getByRole('button', {name: 'Edit value for filter: browser.name'})
+      );
+      expect(
+        screen.queryByRole('button', {name: 'Edit value for filter: browser.name'})
+      ).not.toBeInTheDocument();
+
+      // Pressing escape will exit the filter value, so edit button will come back
+      await userEvent.keyboard('{Escape}');
+      expect(
+        await screen.findByRole('button', {name: 'Edit value for filter: browser.name'})
+      ).toBeInTheDocument();
+
+      // Focus should now be to the right of the filter
+      expect(
+        screen.getAllByRole('combobox', {name: 'Add a search term'}).at(-1)
+      ).toHaveFocus();
     });
   });
 

--- a/static/app/components/searchQueryBuilder/valueCombobox.tsx
+++ b/static/app/components/searchQueryBuilder/valueCombobox.tsx
@@ -264,10 +264,11 @@ export function SearchQueryBuilderValueCombobox({
 
   const handleSelectValue = useCallback(
     (value: string) => {
+      if (!value) {
+        return;
+      }
+
       if (canSelectMultipleValues) {
-        if (!value && !selectedValues.length) {
-          return;
-        }
         dispatch({
           type: 'TOGGLE_FILTER_VALUE',
           token: token,
@@ -279,9 +280,6 @@ export function SearchQueryBuilderValueCombobox({
           onCommit();
         }
       } else {
-        if (!value) {
-          return;
-        }
         dispatch({
           type: 'UPDATE_TOKEN_VALUE',
           token: token.value,
@@ -318,7 +316,7 @@ export function SearchQueryBuilderValueCombobox({
   }, []);
 
   return (
-    <ValueEditing onClick={onClick}>
+    <ValueEditing onClick={onClick} data-test-id="filter-value-editing">
       {selectedValues.map(value => (
         <SelectedValue key={value}>{value},</SelectedValue>
       ))}
@@ -328,6 +326,7 @@ export function SearchQueryBuilderValueCombobox({
         onOptionSelected={handleSelectValue}
         onCustomValueBlurred={handleSelectValue}
         onCustomValueCommitted={handleSelectValue}
+        onExit={onCommit}
         inputValue={inputValue}
         placeholder={canSelectMultipleValues ? '' : formatFilterValue(token.value)}
         token={token}


### PR DESCRIPTION
- Clicking anywhere in the filter value while editing should open the menu (this used to be working but regressed)
- Pressing Esc while editing should exit the filter

Added tests so these don't regress again.