### PR TITLE
feat(insights): disable filters when overriden by search query

### DIFF
--- a/static/app/views/performance/cache/samplePanel/samplePanel.tsx
+++ b/static/app/views/performance/cache/samplePanel/samplePanel.tsx
@@ -190,9 +190,8 @@ export function CacheSamplePanel() {
   let cacheMissSamplesLimit = SPAN_SAMPLE_LIMIT / 2;
 
   if (isCacheHitFilterOverridden) {
-    // if the search query overrides the `cache.hit` filter, ignore the
-    // dropdown filter value (`query.statusClass`) and derive the sample limits from the
-    // search query
+    // if the search query overrides the `cache.hit` filter, ignore the dropdown filter value (`query.statusClass`) and derive the sample limits
+    // from the search query
     const cacheHitSearchFilter = searchQueryObject.getFilterValues('cache.hit')?.[0];
     if (cacheHitSearchFilter === 'hit') {
       cacheHitSamplesLimit = SPAN_SAMPLE_LIMIT;
@@ -202,8 +201,7 @@ export function CacheSamplePanel() {
       cacheMissSamplesLimit = SPAN_SAMPLE_LIMIT;
     }
   } else {
-    // if the search query does not override the `cache.hit` dropdown filter, derive the
-    // sample limits from the dropdown value
+    // if the search query does not override the `cache.hit` dropdown filter, derive the sample limits from the dropdown value
     if (query.statusClass === 'hit') {
       cacheHitSamplesLimit = SPAN_SAMPLE_LIMIT;
       cacheMissSamplesLimit = -1;

--- a/static/app/views/performance/cache/samplePanel/samplePanel.tsx
+++ b/static/app/views/performance/cache/samplePanel/samplePanel.tsx
@@ -190,8 +190,7 @@ export function CacheSamplePanel() {
   let cacheMissSamplesLimit = SPAN_SAMPLE_LIMIT / 2;
 
   if (isCacheHitFilterOverridden) {
-    // if the search query overrides the `cache.hit` filter, ignore the dropdown filter value (`query.statusClass`) and derive the sample limits
-    // from the search query
+    // if the search query overrides the `cache.hit` filter, ignore the dropdown filter value (`query.statusClass`) and derive the sample limits from the search query
     const cacheHitSearchFilter = searchQueryObject.getFilterValues('cache.hit')?.[0];
     if (cacheHitSearchFilter === 'hit') {
       cacheHitSamplesLimit = SPAN_SAMPLE_LIMIT;

--- a/static/app/views/performance/queues/destinationSummary/messageSpanSamplesPanel.tsx
+++ b/static/app/views/performance/queues/destinationSummary/messageSpanSamplesPanel.tsx
@@ -118,6 +118,13 @@ export function MessageSpanSamplesPanel() {
     });
   };
 
+  const searchFilterKeys = Object.keys(new MutableSearch(query.spanSearchQuery).filters);
+  // Disable dropdown filter if the same filter key already exists in the search query
+  const isStatusFilterDisabled = searchFilterKeys.includes(SpanIndexedField.TRACE_STATUS);
+  const isRetryFilterDisabled = searchFilterKeys.includes(
+    SpanIndexedField.MESSAGING_MESSAGE_RETRY_COUNT
+  );
+
   const isPanelOpen = Boolean(detailKey);
 
   const messageActorType =
@@ -140,12 +147,12 @@ export function MessageSpanSamplesPanel() {
   // filter by key-value filters specified in the search bar query
   sampleFilters.addStringMultiFilter(query.spanSearchQuery);
 
-  if (query.traceStatus.length > 0) {
+  if (!isStatusFilterDisabled && query.traceStatus.length > 0) {
     sampleFilters.addFilterValue('trace.status', query.traceStatus);
   }
 
   // Note: only consumer panels should allow filtering by retry count
-  if (messageActorType === MessageActorType.CONSUMER) {
+  if (!isRetryFilterDisabled && messageActorType === MessageActorType.CONSUMER) {
     if (query.retryCount === '0') {
       sampleFilters.addFilterValue('measurements.messaging.message.retry.count', '0');
     } else if (query.retryCount === '1-3') {
@@ -311,6 +318,7 @@ export function MessageSpanSamplesPanel() {
               <CompactSelect
                 searchable
                 value={query.traceStatus}
+                disabled={isStatusFilterDisabled}
                 options={TRACE_STATUS_SELECT_OPTIONS}
                 onChange={handleTraceStatusChange}
                 triggerProps={{
@@ -320,6 +328,7 @@ export function MessageSpanSamplesPanel() {
               {messageActorType === MessageActorType.CONSUMER && (
                 <CompactSelect
                   value={query.retryCount}
+                  disabled={isRetryFilterDisabled}
                   options={RETRY_COUNT_SELECT_OPTIONS}
                   onChange={handleRetryCountChange}
                   triggerProps={{


### PR DESCRIPTION
Disables span sample filters on queues/caches modules when the search query overrides the filter key. This is an alternative to removing the filter key from the search bar entirely, and replaces https://github.com/getsentry/sentry/pull/71614.



<img width="744" alt="image" src="https://github.com/getsentry/sentry/assets/58920989/50236920-5c1f-44af-990f-244cf37add49">
<img width="737" alt="image" src="https://github.com/getsentry/sentry/assets/58920989/b94bc3f9-ba65-4d42-b6f1-aafe62e8de23">
