### PR TITLE
fix(insights): Use module URL helper in special widgets

### DIFF
--- a/static/app/views/performance/landing/widgets/widgets/mobileReleaseComparisonListWidget.tsx
+++ b/static/app/views/performance/landing/widgets/widgets/mobileReleaseComparisonListWidget.tsx
@@ -26,6 +26,7 @@ import {useLocation} from 'sentry/utils/useLocation';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import {formatVersion} from 'sentry/utils/versions/formatVersion';
 import {normalizeUrl} from 'sentry/utils/withDomainRequired';
+import {useModuleURLBuilder} from 'sentry/views/performance/utils/useModuleURL';
 import {Subtitle} from 'sentry/views/profiling/landing/styles';
 import {RightAlignedCell} from 'sentry/views/replays/deadRageClick/deadRageSelectorCards';
 import Chart, {ChartType} from 'sentry/views/starfish/components/chart';
@@ -310,13 +311,15 @@ function MobileReleaseComparisonListWidget(props: PerformanceWidgetProps) {
     );
   };
 
+  const moduleURLBuilder = useModuleURLBuilder();
+
   const isAppStartup = [
     PerformanceWidgetSetting.SLOW_SCREENS_BY_COLD_START,
     PerformanceWidgetSetting.SLOW_SCREENS_BY_WARM_START,
   ].includes(props.chartSetting);
   const targetModulePath = isAppStartup
-    ? '/performance/mobile/app-startup/'
-    : '/performance/mobile/screens/';
+    ? moduleURLBuilder('app_start')
+    : moduleURLBuilder('screen_load');
   const targetQueryParams = isAppStartup
     ? {
         app_start_type:
@@ -332,8 +335,8 @@ function MobileReleaseComparisonListWidget(props: PerformanceWidgetProps) {
       return (
         <Fragment key={i}>
           <GrowLink
-            to={normalizeUrl({
-              pathname: `${targetModulePath}spans/`,
+            to={{
+              pathname: `${targetModulePath}/spans/`,
               query: {
                 project: listItem['project.id'],
                 transaction,
@@ -342,7 +345,7 @@ function MobileReleaseComparisonListWidget(props: PerformanceWidgetProps) {
                 ...normalizeDateTimeParams(location.query),
                 ...targetQueryParams,
               },
-            })}
+            }}
           >
             <Truncate value={transaction} maxLength={40} />
           </GrowLink>

--- a/static/app/views/performance/landing/widgets/widgets/performanceScoreListWidget.tsx
+++ b/static/app/views/performance/landing/widgets/widgets/performanceScoreListWidget.tsx
@@ -22,6 +22,7 @@ import {useProjectWebVitalsScoresQuery} from 'sentry/views/performance/browser/w
 import {useProjectWebVitalsTimeseriesQuery} from 'sentry/views/performance/browser/webVitals/utils/queries/useProjectWebVitalsTimeseriesQuery';
 import {useTransactionWebVitalsQuery} from 'sentry/views/performance/browser/webVitals/utils/queries/useTransactionWebVitalsQuery';
 import type {RowWithScoreAndOpportunity} from 'sentry/views/performance/browser/webVitals/utils/types';
+import {useModuleURL} from 'sentry/views/performance/utils/useModuleURL';
 import Chart, {ChartType} from 'sentry/views/starfish/components/chart';
 
 import {Accordion} from '../components/accordion';
@@ -44,7 +45,7 @@ type DataType = {
 export function PerformanceScoreListWidget(props: PerformanceWidgetProps) {
   const location = useLocation();
   const [selectedListIndex, setSelectListIndex] = useState<number>(0);
-  const {ContainerActions, organization, InteractiveTitle} = props;
+  const {ContainerActions, InteractiveTitle} = props;
   const theme = useTheme();
 
   const {data: projectScoresData, isLoading: isProjectScoresLoading} =
@@ -88,6 +89,8 @@ export function PerformanceScoreListWidget(props: PerformanceWidgetProps) {
     );
   };
 
+  const moduleURL = useModuleURL('vital');
+
   const getHeaders = _ =>
     transactionWebVitals.map((listItem, i) => {
       const transaction = (listItem.transaction as string | undefined) ?? '';
@@ -101,7 +104,7 @@ export function PerformanceScoreListWidget(props: PerformanceWidgetProps) {
         <Fragment key={i}>
           <GrowLink
             to={{
-              pathname: '/performance/browser/pageloads/overview/',
+              pathname: `${moduleURL}/overview/`,
               query: {...location.query, transaction},
             }}
           >
@@ -157,10 +160,7 @@ export function PerformanceScoreListWidget(props: PerformanceWidgetProps) {
     return (
       <Fragment>
         <div>
-          <LinkButton
-            to={`/organizations/${organization.slug}/performance/browser/pageloads/`}
-            size="sm"
-          >
+          <LinkButton to={`${moduleURL}/`} size="sm">
             {t('View All')}
           </LinkButton>
         </div>

--- a/static/app/views/performance/landing/widgets/widgets/performanceScoreWidget.tsx
+++ b/static/app/views/performance/landing/widgets/widgets/performanceScoreWidget.tsx
@@ -11,6 +11,7 @@ import PerformanceScoreRingWithTooltips from 'sentry/views/performance/browser/w
 import {useProjectRawWebVitalsQuery} from 'sentry/views/performance/browser/webVitals/utils/queries/rawWebVitalsQueries/useProjectRawWebVitalsQuery';
 import {calculatePerformanceScoreFromStoredTableDataRow} from 'sentry/views/performance/browser/webVitals/utils/queries/storedScoreQueries/calculatePerformanceScoreFromStored';
 import {useProjectWebVitalsScoresQuery} from 'sentry/views/performance/browser/webVitals/utils/queries/storedScoreQueries/useProjectWebVitalsScoresQuery';
+import {useModuleURL} from 'sentry/views/performance/utils/useModuleURL';
 
 import {GenericPerformanceWidget} from '../components/performanceWidget';
 import {Subtitle, WidgetEmptyStateWarning} from '../components/selectableList';
@@ -18,7 +19,7 @@ import type {PerformanceWidgetProps} from '../types';
 
 export function PerformanceScoreWidget(props: PerformanceWidgetProps) {
   const location = useLocation();
-  const {InteractiveTitle, organization} = props;
+  const {InteractiveTitle} = props;
   const theme = useTheme();
   const {data: projectData, isLoading} = useProjectRawWebVitalsQuery();
   const {data: projectScores, isLoading: isProjectScoresLoading} =
@@ -44,6 +45,8 @@ export function PerformanceScoreWidget(props: PerformanceWidgetProps) {
       }
     : undefined;
 
+  const moduleURL = useModuleURL('vital');
+
   return (
     <GenericPerformanceWidget
       {...props}
@@ -51,10 +54,7 @@ export function PerformanceScoreWidget(props: PerformanceWidgetProps) {
       Subtitle={() => <Subtitle>{props.subTitle}</Subtitle>}
       HeaderActions={() => (
         <div>
-          <LinkButton
-            to={`/organizations/${organization.slug}/performance/browser/pageloads/`}
-            size="sm"
-          >
+          <LinkButton to={`${moduleURL}/`} size="sm">
             {t('View All')}
           </LinkButton>
         </div>


### PR DESCRIPTION
This must be the last place where we manually constructed URLs that linked to `/performance/`. Instead, use the `useModuleURL` helper, which will direct people to `/insights/` vs. `/performance/` when necessary.
