### PR TITLE
fix: Improve "Add Member" dropdown alignment on Team Members settings page

### DIFF
--- a/static/app/views/settings/organizationTeams/teamMembers.tsx
+++ b/static/app/views/settings/organizationTeams/teamMembers.tsx
@@ -22,6 +22,7 @@ import LoadingIndicator from 'sentry/components/loadingIndicator';
 import Pagination from 'sentry/components/pagination';
 import Panel from 'sentry/components/panels/panel';
 import PanelHeader from 'sentry/components/panels/panelHeader';
+import {Flex} from 'sentry/components/profiling/flex';
 import {TeamRoleColumnLabel} from 'sentry/components/teamRoleUtils';
 import {IconUser} from 'sentry/icons';
 import {t} from 'sentry/locale';
@@ -368,7 +369,7 @@ class TeamMembers extends DeprecatedAsyncView<Props, State> {
             <div>
               <TeamRoleColumnLabel />
             </div>
-            <div style={{textTransform: 'none'}}>{this.renderDropdown(isTeamAdmin)}</div>
+            <Flex justify="end">{this.renderDropdown(isTeamAdmin)}</Flex>
           </StyledPanelHeader>
           {this.renderMembers(isTeamAdmin)}
         </Panel>


### PR DESCRIPTION
"Add Member" Dropdown in the table header, right side, alignment is fixed:

**Before:**
<img width="922" alt="SCR-20240603-kkce" src="https://github.com/getsentry/sentry/assets/187460/d3d6f4ab-c91f-4e15-8a02-908c7f44fa8e">

**After:**
<img width="906" alt="SCR-20240603-kkcz" src="https://github.com/getsentry/sentry/assets/187460/2692e564-6422-451c-b97a-eef1239d73b5">