### PR TITLE
fix: Only format less files, no eslint

### DIFF
--- a/.github/file-filters.yml
+++ b/.github/file-filters.yml
@@ -17,10 +17,15 @@ lintable_css_in_js_rules_changed: &lintable_css_in_js_rules_changed
   - added|modified: 'yarn.lock'
   - added|deleted|modified: 'stylelint.*'
 
+# Provides list of changed files to format (prettier)
+lintable_formatable_modified: &lintable_formatable_modified
+  - added|modified: '**/*.[tj]{s,sx}'
+  - added|modified: '**/*.{less,json,yml}'
+
 # Provides list of changed files to lint against (eslint)
 lintable_modified: &lintable_modified
   - added|modified: '**/*.[tj]{s,sx}'
-  - added|modified: '**/*.{less,json,yml}'
+  - added|modified: '**/*.{json,yml}'
 
 # Trigger for when we must run full lint (eslint)
 lintable_rules_changed: &lintable_rules_changed

--- a/.github/file-filters.yml
+++ b/.github/file-filters.yml
@@ -26,7 +26,7 @@ lintable_css_in_js_rules_changed: &lintable_css_in_js_rules_changed
 # Provides list of changed files to lint against (eslint)
 lintable_modified: &lintable_modified
   - added|modified: '**/*.[tj]{s,sx}'
-  - added|modified: '**/*.{json,yml}'
+  - added|modified: '**/*.{json}'
 
 # Trigger for when we must run full lint (eslint)
 lintable_eslint_modified: &lintable_eslint_modified

--- a/.github/file-filters.yml
+++ b/.github/file-filters.yml
@@ -6,9 +6,15 @@ sentry_specific_test_files: &sentry_specific_test_files
   - added|modified: 'tests/js/**/*'
   - added|deleted|modified: 'fixtures/search-syntax/**/*'
 
+# Provides list of changed files to format (prettier)
+lintable_prettier_modified: &lintable_prettier_modified
+  - added|modified: '**/*.[tj]{s,sx}'
+  - added|modified: '**/*.{less,json,yml}'
+
 # Provides list of changed app files to lint against (stylelint)
 lintable_css_in_js_modified: &lintable_css_in_js_modified
   - added|modified: '**/*.[tj]{s,sx}'
+  - added|modified: '**/*.less'
 
 # Trigger for when we must run full lint (stylelint)
 lintable_css_in_js_rules_changed: &lintable_css_in_js_rules_changed
@@ -17,18 +23,13 @@ lintable_css_in_js_rules_changed: &lintable_css_in_js_rules_changed
   - added|modified: 'yarn.lock'
   - added|deleted|modified: 'stylelint.*'
 
-# Provides list of changed files to format (prettier)
-lintable_formatable_modified: &lintable_formatable_modified
-  - added|modified: '**/*.[tj]{s,sx}'
-  - added|modified: '**/*.{less,json,yml}'
-
 # Provides list of changed files to lint against (eslint)
 lintable_modified: &lintable_modified
   - added|modified: '**/*.[tj]{s,sx}'
   - added|modified: '**/*.{json,yml}'
 
 # Trigger for when we must run full lint (eslint)
-lintable_rules_changed: &lintable_rules_changed
+lintable_eslint_modified: &lintable_eslint_modified
   - *sentry_specific_workflow
   - added|modified: '.github/file-filters.yml'
   - added|modified: 'package.json'
@@ -61,8 +62,9 @@ typecheckable_rules_changed: &typecheckable_rules_changed
 
 # Trigger to apply the 'Scope: Frontend' label to PRs
 frontend_all: &frontend_all
+  - *lintable_prettier_modified
+  - *lintable_eslint_modified
   - *lintable_css_in_js_rules_changed
-  - *lintable_rules_changed
   - *testable_rules_changed
   - *typecheckable_rules_changed
   - added|modified: '{.volta,vercel}.json'

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -27,6 +27,7 @@ jobs:
       lintable_css_in_js_modified: ${{ steps.changes.outputs.lintable_css_in_js_modified }}
       lintable_css_in_js_modified_files: ${{ steps.changes.outputs.lintable_css_in_js_modified_files }}
       lintable_css_in_js_rules_changed: ${{ steps.changes.output.lintable_css_in_js_rules_changed }}
+      lintable_formatable_modified: ${{ steps.changes.output.lintable_formatable_modified }}
       lintable_modified: ${{ steps.changes.outputs.lintable_modified }}
       lintable_modified_files: ${{ steps.changes.outputs.lintable_modified_files }}
       lintable_rules_changed: ${{ steps.changes.outputs.lintable_rules_changed }}
@@ -98,7 +99,7 @@ jobs:
         run: yarn fix:biome
 
       - name: prettier (changed files only)
-        if: github.ref != 'refs/heads/master' && needs.files-changed.outputs.lintable_rules_changed != 'true' && needs.files-changed.outputs.lintable_modified == 'true'
+        if: github.ref != 'refs/heads/master' && needs.files-changed.outputs.lintable_formatable_modified != 'true' && needs.files-changed.outputs.lintable_modified == 'true'
         run: yarn prettier --write ${{ needs.files-changed.outputs.lintable_modified_files }}
 
       - name: eslint (changed files only)

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -24,10 +24,11 @@ jobs:
     timeout-minutes: 3
     # Map a step output to a job output
     outputs:
+      lintable_prettier_modified: ${{ steps.changes.output.lintable_prettier_modified }}
+      lintable_prettier_modified_files: ${{ steps.changes.output.lintable_prettier_modified_files }}
       lintable_css_in_js_modified: ${{ steps.changes.outputs.lintable_css_in_js_modified }}
       lintable_css_in_js_modified_files: ${{ steps.changes.outputs.lintable_css_in_js_modified_files }}
       lintable_css_in_js_rules_changed: ${{ steps.changes.output.lintable_css_in_js_rules_changed }}
-      lintable_formatable_modified: ${{ steps.changes.output.lintable_formatable_modified }}
       lintable_modified: ${{ steps.changes.outputs.lintable_modified }}
       lintable_modified_files: ${{ steps.changes.outputs.lintable_modified_files }}
       lintable_rules_changed: ${{ steps.changes.outputs.lintable_rules_changed }}
@@ -99,8 +100,8 @@ jobs:
         run: yarn fix:biome
 
       - name: prettier (changed files only)
-        if: github.ref != 'refs/heads/master' && needs.files-changed.outputs.lintable_formatable_modified != 'true' && needs.files-changed.outputs.lintable_modified == 'true'
-        run: yarn prettier --write ${{ needs.files-changed.outputs.lintable_modified_files }}
+        if: github.ref != 'refs/heads/master' && needs.files-changed.outputs.lintable_rules_changed != 'true' && needs.files-changed.outputs.lintable_prettier_modified == 'true'
+        run: yarn prettier --write ${{ needs.files-changed.outputs.lintable_prettier_modified_files }}
 
       - name: eslint (changed files only)
         if: github.ref != 'refs/heads/master' && needs.files-changed.outputs.lintable_rules_changed != 'true' && needs.files-changed.outputs.lintable_modified == 'true'


### PR DESCRIPTION
A bug was discovered in the CI config with PR https://github.com/getsentry/sentry/pull/71674

Basically we shouldn't be trying to lint a `*.less` file with eslint, we instead need to pass less files into prettier (new config for this) and stylelint (added to existing config for this)

The matching change is applied to getsentry here: https://github.com/getsentry/getsentry/pull/14167