### PR TITLE
feat(insights): show is new badge insights/explore

### DIFF
--- a/static/app/components/sidebar/index.tsx
+++ b/static/app/components/sidebar/index.tsx
@@ -622,7 +622,6 @@ function Sidebar() {
       icon={<IconSearch />}
       label={<GuideAnchor target="explore">{t('Explore')}</GuideAnchor>}
       id="explore"
-      isNew
       exact={!shouldAccordionFloat}
     >
       {traces}

--- a/static/app/components/sidebar/index.tsx
+++ b/static/app/components/sidebar/index.tsx
@@ -600,6 +600,7 @@ function Sidebar() {
       icon={<IconGraph />}
       label={<GuideAnchor target="insights">{t('Insights')}</GuideAnchor>}
       id="insights"
+      isNew
       exact={!shouldAccordionFloat}
     >
       {requests}
@@ -621,6 +622,7 @@ function Sidebar() {
       icon={<IconSearch />}
       label={<GuideAnchor target="explore">{t('Explore')}</GuideAnchor>}
       id="explore"
+      isNew
       exact={!shouldAccordionFloat}
     >
       {traces}

--- a/static/app/components/sidebar/sidebarItem.tsx
+++ b/static/app/components/sidebar/sidebarItem.tsx
@@ -157,14 +157,16 @@ function SidebarItem({
     !hasPanel && router && isItemActive({to, label: labelString}, exact);
 
   const isInFloatingAccordion = (isNested || isMainItem) && shouldAccordionFloat;
+  const hasLink = Boolean(to);
 
   const isActive = defined(active) ? active : isActiveRouter;
   const isTop = orientation === 'top' && !isInFloatingAccordion;
   const placement = isTop ? 'bottom' : 'right';
 
   const seenSuffix = isNewSeenKeySuffix ?? '';
-  const isNewSeenKey = `sidebar-new-seen:${id}${seenSuffix}`;
-  const showIsNew = isNew && !localStorage.getItem(isNewSeenKey) && Boolean(to);
+  const isNewSeenKey = `sidebar-new-seen:${id}${seenSuffix}-1`;
+  const showIsNew =
+    isNew && !localStorage.getItem(isNewSeenKey) && !(isInFloatingAccordion && !hasLink);
 
   const organization = useOrganization({allowNull: true});
 
@@ -201,7 +203,6 @@ function SidebarItem({
   );
 
   const isInCollapsedState = !isInFloatingAccordion && collapsed;
-  const hasLink = Boolean(to);
 
   return (
     <Tooltip

--- a/static/app/components/sidebar/sidebarItem.tsx
+++ b/static/app/components/sidebar/sidebarItem.tsx
@@ -164,7 +164,7 @@ function SidebarItem({
   const placement = isTop ? 'bottom' : 'right';
 
   const seenSuffix = isNewSeenKeySuffix ?? '';
-  const isNewSeenKey = `sidebar-new-seen:${id}${seenSuffix}-1`;
+  const isNewSeenKey = `sidebar-new-seen:${id}${seenSuffix}`;
   const showIsNew =
     isNew && !localStorage.getItem(isNewSeenKey) && !(isInFloatingAccordion && !hasLink);
 

--- a/static/app/components/sidebar/sidebarItem.tsx
+++ b/static/app/components/sidebar/sidebarItem.tsx
@@ -164,7 +164,7 @@ function SidebarItem({
 
   const seenSuffix = isNewSeenKeySuffix ?? '';
   const isNewSeenKey = `sidebar-new-seen:${id}${seenSuffix}`;
-  const showIsNew = isNew && !localStorage.getItem(isNewSeenKey);
+  const showIsNew = isNew && !localStorage.getItem(isNewSeenKey) && Boolean(to);
 
   const organization = useOrganization({allowNull: true});
 


### PR DESCRIPTION
Show new badge for insights and explore menus, these badges get removed as soon as the accordion gets expanded.
![image](https://github.com/getsentry/sentry/assets/44422760/d8af2178-7f4e-4779-b0ea-239eb20b7d58)

If the parent item does not have a link, we won't show the new badge when the accordion is floating (otherwise the new badge would be permanent here as the item is non-clickable)
I.e Insights in this state would never show `New`
![image](https://github.com/getsentry/sentry/assets/44422760/58f6ac27-a55f-4de9-bd56-c5a9c169508a)

