### PR TITLE
fix(relocation): Clean up relocation serializer

### DIFF
--- a/src/sentry/api/serializers/models/relocation.py
+++ b/src/sentry/api/serializers/models/relocation.py
@@ -10,6 +10,8 @@ from sentry.models.user import User
 from sentry.services.hybrid_cloud.user.model import RpcUser
 from sentry.services.hybrid_cloud.user.service import user_service
 
+NEEDED_USER_FIELDS = {"email", "id", "username"}
+
 
 @dataclasses.dataclass(frozen=True)
 class RelocationMetadata:
@@ -64,16 +66,41 @@ class RelocationSerializer(Serializer):
             else None
         )
 
+        creator_user = attrs.meta_users.get(obj.creator_id, None)
+        creator = (
+            None
+            if creator_user is None
+            else {
+                "email": creator_user.email,
+                "id": str(creator_user.id),
+                "username": creator_user.username,
+            }
+        )
+        owner_user = attrs.meta_users.get(obj.owner_id, None)
+        owner = (
+            None
+            if owner_user is None
+            else {
+                "email": owner_user.email,
+                "id": str(owner_user.id),
+                "username": owner_user.username,
+            }
+        )
+
         return {
             "dateAdded": obj.date_added,
             "dateUpdated": obj.date_updated,
             "uuid": str(obj.uuid),
-            "creatorEmail": attrs.meta_users[obj.creator_id].email,
-            "creatorId": str(obj.creator_id),
-            "creatorUsername": attrs.meta_users[obj.creator_id].username,
-            "ownerEmail": attrs.meta_users[obj.owner_id].email,
-            "ownerId": str(obj.owner_id),
-            "ownerUsername": attrs.meta_users[obj.owner_id].username,
+            "creator": creator,
+            # TODO(azaslavsky): delete these 3 fields after clients are migrated
+            "creatorEmail": creator["email"] if creator else None,
+            "creatorId": creator["id"] if creator else None,
+            "creatorUsername": creator["username"] if creator else None,
+            "owner": owner,
+            # TODO(azaslavsky): delete these 3 fields after clients are migrated
+            "ownerEmail": owner["email"] if owner else None,
+            "ownerId": owner["id"] if owner else None,
+            "ownerUsername": owner["username"] if owner else None,
             "status": Relocation.Status(obj.status).name,
             "step": Relocation.Step(obj.step).name,
             "failureReason": obj.failure_reason,

--- a/tests/sentry/api/endpoints/relocations/test_index.py
+++ b/tests/sentry/api/endpoints/relocations/test_index.py
@@ -124,9 +124,17 @@ class GetRelocationsTest(APITestCase):
 
         assert len(response.data) == 1
         assert response.data[0]["status"] == Relocation.Status.IN_PROGRESS.name
+        assert response.data[0]["creator"]["id"] == str(self.superuser.id)
+        assert response.data[0]["creator"]["email"] == str(self.superuser.email)
+        assert response.data[0]["creator"]["username"] == str(self.superuser.username)
+        # TODO(azaslavsky): delete these after clients are migrated
         assert response.data[0]["creatorId"] == str(self.superuser.id)
         assert response.data[0]["creatorEmail"] == str(self.superuser.email)
         assert response.data[0]["creatorUsername"] == str(self.superuser.username)
+        assert response.data[0]["owner"]["id"] == str(self.owner.id)
+        assert response.data[0]["owner"]["email"] == str(self.owner.email)
+        assert response.data[0]["owner"]["username"] == str(self.owner.username)
+        # TODO(azaslavsky): delete these after clients are migrated
         assert response.data[0]["ownerId"] == str(self.owner.id)
         assert response.data[0]["ownerEmail"] == str(self.owner.email)
         assert response.data[0]["ownerUsername"] == str(self.owner.username)
@@ -328,9 +336,17 @@ class PostRelocationsTest(APITestCase):
         assert response.data["status"] == Relocation.Status.IN_PROGRESS.name
         assert response.data["step"] == Relocation.Step.UPLOADING.name
         assert response.data["scheduledPauseAtStep"] is None
+        assert response.data["creator"]["id"] == str(self.owner.id)
+        assert response.data["creator"]["email"] == str(self.owner.email)
+        assert response.data["creator"]["username"] == str(self.owner.username)
+        # TODO(azaslavsky): delete these after clients are migrated
         assert response.data["creatorId"] == str(self.owner.id)
         assert response.data["creatorEmail"] == str(self.owner.email)
         assert response.data["creatorUsername"] == str(self.owner.username)
+        assert response.data["owner"]["id"] == str(self.owner.id)
+        assert response.data["owner"]["email"] == str(self.owner.email)
+        assert response.data["owner"]["username"] == str(self.owner.username)
+        # TODO(azaslavsky): delete these after clients are migrated
         assert response.data["ownerId"] == str(self.owner.id)
         assert response.data["ownerEmail"] == str(self.owner.email)
         assert response.data["ownerUsername"] == str(self.owner.username)
@@ -391,9 +407,17 @@ class PostRelocationsTest(APITestCase):
         assert response.data["status"] == Relocation.Status.IN_PROGRESS.name
         assert response.data["step"] == Relocation.Step.UPLOADING.name
         assert response.data["scheduledPauseAtStep"] is None
+        assert response.data["creator"]["id"] == str(self.owner.id)
+        assert response.data["creator"]["email"] == str(self.owner.email)
+        assert response.data["creator"]["username"] == str(self.owner.username)
+        # TODO(azaslavsky): delete these after clients are migrated
         assert response.data["creatorId"] == str(self.owner.id)
         assert response.data["creatorEmail"] == str(self.owner.email)
         assert response.data["creatorUsername"] == str(self.owner.username)
+        assert response.data["owner"]["id"] == str(self.owner.id)
+        assert response.data["owner"]["email"] == str(self.owner.email)
+        assert response.data["owner"]["username"] == str(self.owner.username)
+        # TODO(azaslavsky): delete these after clients are migrated
         assert response.data["ownerId"] == str(self.owner.id)
         assert response.data["ownerEmail"] == str(self.owner.email)
         assert response.data["ownerUsername"] == str(self.owner.username)
@@ -561,9 +585,17 @@ class PostRelocationsTest(APITestCase):
 
         assert response.data["status"] == Relocation.Status.IN_PROGRESS.name
         assert response.data["step"] == Relocation.Step.UPLOADING.name
+        assert response.data["creator"]["id"] == str(self.staff_user.id)
+        assert response.data["creator"]["email"] == str(self.staff_user.email)
+        assert response.data["creator"]["username"] == str(self.staff_user.username)
+        # TODO(azaslavsky): delete these after clients are migrated
         assert response.data["creatorId"] == str(self.staff_user.id)
         assert response.data["creatorEmail"] == str(self.staff_user.email)
         assert response.data["creatorUsername"] == str(self.staff_user.username)
+        assert response.data["owner"]["id"] == str(self.owner.id)
+        assert response.data["owner"]["email"] == str(self.owner.email)
+        assert response.data["owner"]["username"] == str(self.owner.username)
+        # TODO(azaslavsky): delete these after clients are migrated
         assert response.data["ownerId"] == str(self.owner.id)
         assert response.data["ownerEmail"] == str(self.owner.email)
         assert response.data["ownerUsername"] == str(self.owner.username)
@@ -622,9 +654,17 @@ class PostRelocationsTest(APITestCase):
 
         assert response.data["status"] == Relocation.Status.IN_PROGRESS.name
         assert response.data["step"] == Relocation.Step.UPLOADING.name
+        assert response.data["creator"]["id"] == str(self.superuser.id)
+        assert response.data["creator"]["email"] == str(self.superuser.email)
+        assert response.data["creator"]["username"] == str(self.superuser.username)
+        # TODO(azaslavsky): delete these after clients are migrated
         assert response.data["creatorId"] == str(self.superuser.id)
         assert response.data["creatorEmail"] == str(self.superuser.email)
         assert response.data["creatorUsername"] == str(self.superuser.username)
+        assert response.data["owner"]["id"] == str(self.owner.id)
+        assert response.data["owner"]["email"] == str(self.owner.email)
+        assert response.data["owner"]["username"] == str(self.owner.username)
+        # TODO(azaslavsky): delete these after clients are migrated
         assert response.data["ownerId"] == str(self.owner.id)
         assert response.data["ownerEmail"] == str(self.owner.email)
         assert response.data["ownerUsername"] == str(self.owner.username)

--- a/tests/sentry/api/endpoints/relocations/test_retry.py
+++ b/tests/sentry/api/endpoints/relocations/test_retry.py
@@ -101,9 +101,17 @@ class RetryRelocationTest(APITestCase):
         assert response.data["status"] == Relocation.Status.IN_PROGRESS.name
         assert response.data["step"] == Relocation.Step.UPLOADING.name
         assert response.data["wantOrgSlugs"] == self.relocation.want_org_slugs
+        assert response.data["creator"]["id"] == str(self.owner.id)
+        assert response.data["creator"]["email"] == str(self.owner.email)
+        assert response.data["creator"]["username"] == str(self.owner.username)
+        # TODO(azaslavsky): delete these after clients are migrated
         assert response.data["creatorId"] == str(self.owner.id)
         assert response.data["creatorEmail"] == str(self.owner.email)
         assert response.data["creatorUsername"] == str(self.owner.username)
+        assert response.data["owner"]["id"] == str(self.owner.id)
+        assert response.data["owner"]["email"] == str(self.owner.email)
+        assert response.data["owner"]["username"] == str(self.owner.username)
+        # TODO(azaslavsky): delete these after clients are migrated
         assert response.data["ownerId"] == str(self.owner.id)
         assert response.data["ownerEmail"] == str(self.owner.email)
         assert response.data["ownerUsername"] == str(self.owner.username)
@@ -147,9 +155,17 @@ class RetryRelocationTest(APITestCase):
         response = self.get_success_response(self.relocation.uuid, status_code=201)
 
         assert response.data["uuid"] != self.relocation.uuid
+        assert response.data["creator"]["id"] == str(self.staff_user.id)
+        assert response.data["creator"]["email"] == str(self.staff_user.email)
+        assert response.data["creator"]["username"] == str(self.staff_user.username)
+        # TODO(azaslavsky): delete these after clients are migrated
         assert response.data["creatorId"] == str(self.staff_user.id)
         assert response.data["creatorEmail"] == str(self.staff_user.email)
         assert response.data["creatorUsername"] == str(self.staff_user.username)
+        assert response.data["owner"]["id"] == str(self.owner.id)
+        assert response.data["owner"]["email"] == str(self.owner.email)
+        assert response.data["owner"]["username"] == str(self.owner.username)
+        # TODO(azaslavsky): delete these after clients are migrated
         assert response.data["ownerId"] == str(self.owner.id)
         assert response.data["ownerEmail"] == str(self.owner.email)
         assert response.data["ownerUsername"] == str(self.owner.username)
@@ -185,9 +201,17 @@ class RetryRelocationTest(APITestCase):
         response = self.get_success_response(self.relocation.uuid, status_code=201)
 
         assert response.data["uuid"] != self.relocation.uuid
+        assert response.data["creator"]["id"] == str(self.superuser.id)
+        assert response.data["creator"]["email"] == str(self.superuser.email)
+        assert response.data["creator"]["username"] == str(self.superuser.username)
+        # TODO(azaslavsky): delete these after clients are migrated
         assert response.data["creatorId"] == str(self.superuser.id)
         assert response.data["creatorEmail"] == str(self.superuser.email)
         assert response.data["creatorUsername"] == str(self.superuser.username)
+        assert response.data["owner"]["id"] == str(self.owner.id)
+        assert response.data["owner"]["email"] == str(self.owner.email)
+        assert response.data["owner"]["username"] == str(self.owner.username)
+        # TODO(azaslavsky): delete these after clients are migrated
         assert response.data["ownerId"] == str(self.owner.id)
         assert response.data["ownerEmail"] == str(self.owner.email)
         assert response.data["ownerUsername"] == str(self.owner.username)

--- a/tests/sentry/api/serializers/test_relocation.py
+++ b/tests/sentry/api/serializers/test_relocation.py
@@ -73,9 +73,17 @@ class RelocationSerializerTest(TestCase):
         assert result["dateAdded"] == TEST_DATE_ADDED
         assert result["dateUpdated"] == TEST_DATE_UPDATED
         assert result["uuid"] == str(relocation.uuid)
+        assert result["creator"]["id"] == str(self.superuser.id)
+        assert result["creator"]["email"] == str(self.superuser.email)
+        assert result["creator"]["username"] == str(self.superuser.username)
+        # TODO(azaslavsky): delete these after clients are migrated
         assert result["creatorId"] == str(self.superuser.id)
         assert result["creatorEmail"] == self.superuser.email
         assert result["creatorUsername"] == self.superuser.username
+        assert result["owner"]["id"] == str(self.owner.id)
+        assert result["owner"]["email"] == str(self.owner.email)
+        assert result["owner"]["username"] == str(self.owner.username)
+        # TODO(azaslavsky): delete these after clients are migrated
         assert result["ownerId"] == str(self.owner.id)
         assert result["ownerEmail"] == self.owner.email
         assert result["ownerUsername"] == self.owner.username
@@ -112,9 +120,17 @@ class RelocationSerializerTest(TestCase):
         assert result["dateAdded"] == TEST_DATE_ADDED
         assert result["dateUpdated"] == TEST_DATE_UPDATED
         assert result["uuid"] == str(relocation.uuid)
+        assert result["creator"]["id"] == str(self.superuser.id)
+        assert result["creator"]["email"] == str(self.superuser.email)
+        assert result["creator"]["username"] == str(self.superuser.username)
+        # TODO(azaslavsky): delete these after clients are migrated
         assert result["creatorId"] == str(self.superuser.id)
         assert result["creatorEmail"] == self.superuser.email
         assert result["creatorUsername"] == self.superuser.username
+        assert result["owner"]["id"] == str(self.owner.id)
+        assert result["owner"]["email"] == str(self.owner.email)
+        assert result["owner"]["username"] == str(self.owner.username)
+        # TODO(azaslavsky): delete these after clients are migrated
         assert result["ownerId"] == str(self.owner.id)
         assert result["ownerEmail"] == self.owner.email
         assert result["ownerUsername"] == self.owner.username
@@ -155,9 +171,17 @@ class RelocationSerializerTest(TestCase):
         assert result["dateAdded"] == TEST_DATE_ADDED
         assert result["dateUpdated"] == TEST_DATE_UPDATED
         assert result["uuid"] == str(relocation.uuid)
+        assert result["creator"]["id"] == str(self.superuser.id)
+        assert result["creator"]["email"] == str(self.superuser.email)
+        assert result["creator"]["username"] == str(self.superuser.username)
+        # TODO(azaslavsky): delete these after clients are migrated
         assert result["creatorId"] == str(self.superuser.id)
         assert result["creatorEmail"] == self.superuser.email
         assert result["creatorUsername"] == self.superuser.username
+        assert result["owner"]["id"] == str(self.owner.id)
+        assert result["owner"]["email"] == str(self.owner.email)
+        assert result["owner"]["username"] == str(self.owner.username)
+        # TODO(azaslavsky): delete these after clients are migrated
         assert result["ownerId"] == str(self.owner.id)
         assert result["ownerEmail"] == self.owner.email
         assert result["ownerUsername"] == self.owner.username
@@ -198,9 +222,17 @@ class RelocationSerializerTest(TestCase):
         assert result["dateAdded"] == TEST_DATE_ADDED
         assert result["dateUpdated"] == TEST_DATE_UPDATED
         assert result["uuid"] == str(relocation.uuid)
+        assert result["creator"]["id"] == str(self.superuser.id)
+        assert result["creator"]["email"] == str(self.superuser.email)
+        assert result["creator"]["username"] == str(self.superuser.username)
+        # TODO(azaslavsky): delete these after clients are migrated
         assert result["creatorId"] == str(self.superuser.id)
         assert result["creatorEmail"] == self.superuser.email
         assert result["creatorUsername"] == self.superuser.username
+        assert result["owner"]["id"] == str(self.owner.id)
+        assert result["owner"]["email"] == str(self.owner.email)
+        assert result["owner"]["username"] == str(self.owner.username)
+        # TODO(azaslavsky): delete these after clients are migrated
         assert result["ownerId"] == str(self.owner.id)
         assert result["ownerEmail"] == self.owner.email
         assert result["ownerUsername"] == self.owner.username


### PR DESCRIPTION
This is part of a series of changes to fix
[SENTRY-38N6](https://sentry.sentry.io/issues/5282819613/). This is change 2 of 4:

[1](https://github.com/getsentry/getsentry/pull/14166). Add new API to client in getsentry
2. Add new API to server in sentry <- THIS CHANGE
[3](https://github.com/getsentry/getsentry/pull/14169). Remove old API, and only use new one, in getsentry
[4](https://github.com/getsentry/sentry/pull/71933). Remove old API from server in sentry

This change extends the serializer to support both the new style of nested `creator`/`owner` objects, and the old, deprecated style.

Fixes [SENTRY-38N6](https://sentry.sentry.io/issues/5282819613/).
