### PR TITLE
ref(custom-views): Update tasks to delete custom views upon org or member deletion

### DIFF
--- a/src/sentry/deletions/__init__.py
+++ b/src/sentry/deletions/__init__.py
@@ -139,6 +139,7 @@ def load_defaults():
     default_manager.register(
         models.OrganizationIntegration, defaults.OrganizationIntegrationDeletionTask
     )
+    default_manager.register(models.OrganizationMember, defaults.OrganizationMemberDeletionTask)
     default_manager.register(models.OrganizationMemberTeam, BulkModelDeletionTask)
     default_manager.register(
         models.PlatformExternalIssue, defaults.PlatformExternalIssueDeletionTask

--- a/src/sentry/deletions/defaults/__init__.py
+++ b/src/sentry/deletions/defaults/__init__.py
@@ -10,6 +10,7 @@ from .monitor import *  # noqa: F401,F403
 from .monitor_environment import *  # noqa: F401,F403
 from .organization import *  # noqa: F401,F403
 from .organizationintegration import *  # noqa: F401,F403
+from .organizationmember import *  # noqa: F401,F403
 from .platform_external_issue import *  # noqa: F401,F403
 from .project import *  # noqa: F401,F403
 from .pullrequest import *  # noqa: F401,F403

--- a/src/sentry/deletions/defaults/organization.py
+++ b/src/sentry/deletions/defaults/organization.py
@@ -25,6 +25,7 @@ class OrganizationDeletionTask(ModelDeletionTask):
         from sentry.models.commitauthor import CommitAuthor
         from sentry.models.dashboard import Dashboard
         from sentry.models.environment import Environment
+        from sentry.models.groupsearchview import GroupSearchView
         from sentry.models.integrations.external_issue import ExternalIssue
         from sentry.models.organizationmember import OrganizationMember
         from sentry.models.project import Project
@@ -52,6 +53,7 @@ class OrganizationDeletionTask(ModelDeletionTask):
             PromptsActivity,
             ProjectTransactionThreshold,
             ArtifactBundle,
+            GroupSearchView,
         )
         relations.extend([ModelRelation(m, {"organization_id": instance.id}) for m in model_list])
         # Explicitly assign the task here as it was getting replaced with BulkModelDeletionTask in CI.

--- a/src/sentry/deletions/defaults/organization.py
+++ b/src/sentry/deletions/defaults/organization.py
@@ -25,7 +25,6 @@ class OrganizationDeletionTask(ModelDeletionTask):
         from sentry.models.commitauthor import CommitAuthor
         from sentry.models.dashboard import Dashboard
         from sentry.models.environment import Environment
-        from sentry.models.groupsearchview import GroupSearchView
         from sentry.models.integrations.external_issue import ExternalIssue
         from sentry.models.organizationmember import OrganizationMember
         from sentry.models.project import Project
@@ -53,7 +52,6 @@ class OrganizationDeletionTask(ModelDeletionTask):
             PromptsActivity,
             ProjectTransactionThreshold,
             ArtifactBundle,
-            GroupSearchView,
         )
         relations.extend([ModelRelation(m, {"organization_id": instance.id}) for m in model_list])
         # Explicitly assign the task here as it was getting replaced with BulkModelDeletionTask in CI.

--- a/src/sentry/deletions/defaults/organizationmember.py
+++ b/src/sentry/deletions/defaults/organizationmember.py
@@ -1,0 +1,9 @@
+from sentry.deletions.base import ModelDeletionTask, ModelRelation
+from sentry.models.groupsearchview import GroupSearchView
+
+
+class OrganizationMemberDeletionTask(ModelDeletionTask):
+    def get_child_relations(self, instance):
+        relations = [ModelRelation(GroupSearchView, {"user_id": instance.user_id})]
+
+        return relations

--- a/src/sentry/deletions/defaults/organizationmember.py
+++ b/src/sentry/deletions/defaults/organizationmember.py
@@ -8,7 +8,7 @@ class OrganizationMemberDeletionTask(ModelDeletionTask):
         relations = [
             ModelRelation(
                 GroupSearchView,
-                {"user_id": instance.user_id, "organization": instance.organization},
+                {"user_id": instance.user_id, "organization_id": instance.organization_id},
             )
         ]
 

--- a/src/sentry/deletions/defaults/organizationmember.py
+++ b/src/sentry/deletions/defaults/organizationmember.py
@@ -1,5 +1,6 @@
-from sentry.deletions.base import ModelDeletionTask, ModelRelation
 from sentry.models.groupsearchview import GroupSearchView
+
+from ..base import ModelDeletionTask, ModelRelation
 
 
 class OrganizationMemberDeletionTask(ModelDeletionTask):

--- a/src/sentry/deletions/defaults/organizationmember.py
+++ b/src/sentry/deletions/defaults/organizationmember.py
@@ -5,6 +5,11 @@ from ..base import ModelDeletionTask, ModelRelation
 
 class OrganizationMemberDeletionTask(ModelDeletionTask):
     def get_child_relations(self, instance):
-        relations = [ModelRelation(GroupSearchView, {"user_id": instance.user_id})]
+        relations = [
+            ModelRelation(
+                GroupSearchView,
+                {"user_id": instance.user_id, "organization": instance.organization},
+            )
+        ]
 
         return relations

--- a/tests/sentry/deletions/test_organization.py
+++ b/tests/sentry/deletions/test_organization.py
@@ -12,6 +12,7 @@ from sentry.models.dashboard_widget import (
 )
 from sentry.models.environment import Environment, EnvironmentProject
 from sentry.models.group import Group
+from sentry.models.groupsearchview import GroupSearchView
 from sentry.models.integrations.external_issue import ExternalIssue
 from sentry.models.organization import Organization, OrganizationStatus
 from sentry.models.organizationmapping import OrganizationMapping
@@ -98,6 +99,14 @@ class DeleteOrganizationTest(TransactionTestCase, HybridCloudTestMixin):
         widget_2_data_2 = DashboardWidgetQuery.objects.create(
             widget=widget_2, order=2, name="Outgoing data"
         )
+        custom_view = GroupSearchView.objects.create(
+            organization=org,
+            user_id=org_owner.id,
+            name="Custom View",
+            query="is:unresolved",
+            query_sort="date",
+            position=0,
+        )
 
         org.update(status=OrganizationStatus.PENDING_DELETION)
 
@@ -129,6 +138,7 @@ class DeleteOrganizationTest(TransactionTestCase, HybridCloudTestMixin):
         assert not DashboardWidgetQuery.objects.filter(
             id__in=[widget_1_data.id, widget_2_data_1.id, widget_2_data_2.id]
         ).exists()
+        assert not GroupSearchView.objects.filter(id=custom_view.id).exists()
 
     def test_no_delete_visible(self):
         org = self.create_organization(name="test")

--- a/tests/sentry/deletions/test_organization.py
+++ b/tests/sentry/deletions/test_organization.py
@@ -12,7 +12,6 @@ from sentry.models.dashboard_widget import (
 )
 from sentry.models.environment import Environment, EnvironmentProject
 from sentry.models.group import Group
-from sentry.models.groupsearchview import GroupSearchView
 from sentry.models.integrations.external_issue import ExternalIssue
 from sentry.models.organization import Organization, OrganizationStatus
 from sentry.models.organizationmapping import OrganizationMapping
@@ -99,15 +98,6 @@ class DeleteOrganizationTest(TransactionTestCase, HybridCloudTestMixin):
         widget_2_data_2 = DashboardWidgetQuery.objects.create(
             widget=widget_2, order=2, name="Outgoing data"
         )
-        custom_view = GroupSearchView.objects.create(
-            organization=org,
-            user_id=org_owner.id,
-            name="Custom View",
-            query="is:unresolved",
-            query_sort="date",
-            position=0,
-        )
-
         org.update(status=OrganizationStatus.PENDING_DELETION)
 
         self.ScheduledDeletion.schedule(instance=org, days=0)
@@ -138,7 +128,6 @@ class DeleteOrganizationTest(TransactionTestCase, HybridCloudTestMixin):
         assert not DashboardWidgetQuery.objects.filter(
             id__in=[widget_1_data.id, widget_2_data_1.id, widget_2_data_2.id]
         ).exists()
-        assert not GroupSearchView.objects.filter(id=custom_view.id).exists()
 
     def test_no_delete_visible(self):
         org = self.create_organization(name="test")

--- a/tests/sentry/deletions/test_organizationmember.py
+++ b/tests/sentry/deletions/test_organizationmember.py
@@ -26,3 +26,40 @@ class DeleteOrganizationMemberTest(APITestCase, TransactionTestCase, HybridCloud
 
         assert not OrganizationMember.objects.filter(id=member.id).exists()
         assert not GroupSearchView.objects.filter(id=custom_view.id).exists()
+
+    def test_only_org_specific_views_deleted(self):
+        # If a member is removed from an organization, only their custom views in that organization should be deleted.
+        org_one = self.create_organization(name="test1")
+        org_two = self.create_organization(name="test2")
+        user = self.create_user()
+        member_one = self.create_member(organization=org_one, user=user)
+        member_two = self.create_member(organization=org_two, user=user)
+
+        custom_view_one = GroupSearchView.objects.create(
+            organization=org_one,
+            user_id=user.id,
+            name="Custom View",
+            query="is:unresolved",
+            query_sort="date",
+            position=0,
+        )
+
+        custom_view_two = GroupSearchView.objects.create(
+            organization=org_two,
+            user_id=user.id,
+            name="Custom View",
+            query="is:unresolved",
+            query_sort="date",
+            position=0,
+        )
+
+        self.ScheduledDeletion.schedule(instance=member_one, days=0)
+
+        with self.tasks():
+            run_scheduled_deletions()
+
+        assert not OrganizationMember.objects.filter(id=member_one.id).exists()
+        assert not GroupSearchView.objects.filter(id=custom_view_one.id).exists()
+
+        assert OrganizationMember.objects.filter(id=member_two.id).exists()
+        assert GroupSearchView.objects.filter(id=custom_view_two.id).exists()

--- a/tests/sentry/deletions/test_organizationmember.py
+++ b/tests/sentry/deletions/test_organizationmember.py
@@ -1,0 +1,28 @@
+from sentry.models.groupsearchview import GroupSearchView
+from sentry.models.organizationmember import OrganizationMember
+from sentry.tasks.deletion.scheduled import run_scheduled_deletions
+from sentry.testutils.cases import APITestCase, TransactionTestCase
+from sentry.testutils.hybrid_cloud import HybridCloudTestMixin
+
+
+class DeleteOrganizationMemberTest(APITestCase, TransactionTestCase, HybridCloudTestMixin):
+    def test_simple(self):
+        organization = self.create_organization(name="test")
+        user = self.create_user()
+        member = self.create_member(organization=organization, user=user)
+        custom_view = GroupSearchView.objects.create(
+            organization=organization,
+            user_id=user.id,
+            name="Custom View",
+            query="is:unresolved",
+            query_sort="date",
+            position=0,
+        )
+
+        self.ScheduledDeletion.schedule(instance=member, days=0)
+
+        with self.tasks():
+            run_scheduled_deletions()
+
+        assert not OrganizationMember.objects.filter(id=member.id).exists()
+        assert not GroupSearchView.objects.filter(id=custom_view.id).exists()


### PR DESCRIPTION
This PR updates the Organization deletion task to make custom views a child of organization, thus deleting any custom views in the org upon org deletion. It also adds a new task for Organization members, and makes custom views a child of org members as well. 