### PR TITLE
fix(relocation): Remove deprecated API fields

### DIFF
--- a/src/sentry/api/serializers/models/relocation.py
+++ b/src/sentry/api/serializers/models/relocation.py
@@ -92,15 +92,7 @@ class RelocationSerializer(Serializer):
             "dateUpdated": obj.date_updated,
             "uuid": str(obj.uuid),
             "creator": creator,
-            # TODO(azaslavsky): delete these 3 fields after clients are migrated
-            "creatorEmail": creator["email"] if creator else None,
-            "creatorId": creator["id"] if creator else None,
-            "creatorUsername": creator["username"] if creator else None,
             "owner": owner,
-            # TODO(azaslavsky): delete these 3 fields after clients are migrated
-            "ownerEmail": owner["email"] if owner else None,
-            "ownerId": owner["id"] if owner else None,
-            "ownerUsername": owner["username"] if owner else None,
             "status": Relocation.Status(obj.status).name,
             "step": Relocation.Step(obj.step).name,
             "failureReason": obj.failure_reason,

--- a/tests/sentry/api/endpoints/relocations/test_index.py
+++ b/tests/sentry/api/endpoints/relocations/test_index.py
@@ -127,17 +127,9 @@ class GetRelocationsTest(APITestCase):
         assert response.data[0]["creator"]["id"] == str(self.superuser.id)
         assert response.data[0]["creator"]["email"] == str(self.superuser.email)
         assert response.data[0]["creator"]["username"] == str(self.superuser.username)
-        # TODO(azaslavsky): delete these after clients are migrated
-        assert response.data[0]["creatorId"] == str(self.superuser.id)
-        assert response.data[0]["creatorEmail"] == str(self.superuser.email)
-        assert response.data[0]["creatorUsername"] == str(self.superuser.username)
         assert response.data[0]["owner"]["id"] == str(self.owner.id)
         assert response.data[0]["owner"]["email"] == str(self.owner.email)
         assert response.data[0]["owner"]["username"] == str(self.owner.username)
-        # TODO(azaslavsky): delete these after clients are migrated
-        assert response.data[0]["ownerId"] == str(self.owner.id)
-        assert response.data[0]["ownerEmail"] == str(self.owner.email)
-        assert response.data[0]["ownerUsername"] == str(self.owner.username)
 
     def test_good_status_pause(self):
         self.login_as(user=self.superuser, superuser=True)
@@ -339,17 +331,9 @@ class PostRelocationsTest(APITestCase):
         assert response.data["creator"]["id"] == str(self.owner.id)
         assert response.data["creator"]["email"] == str(self.owner.email)
         assert response.data["creator"]["username"] == str(self.owner.username)
-        # TODO(azaslavsky): delete these after clients are migrated
-        assert response.data["creatorId"] == str(self.owner.id)
-        assert response.data["creatorEmail"] == str(self.owner.email)
-        assert response.data["creatorUsername"] == str(self.owner.username)
         assert response.data["owner"]["id"] == str(self.owner.id)
         assert response.data["owner"]["email"] == str(self.owner.email)
         assert response.data["owner"]["username"] == str(self.owner.username)
-        # TODO(azaslavsky): delete these after clients are migrated
-        assert response.data["ownerId"] == str(self.owner.id)
-        assert response.data["ownerEmail"] == str(self.owner.email)
-        assert response.data["ownerUsername"] == str(self.owner.username)
 
         relocation: Relocation = Relocation.objects.get(owner_id=self.owner.id)
         assert str(relocation.uuid) == response.data["uuid"]
@@ -362,8 +346,8 @@ class PostRelocationsTest(APITestCase):
         assert analytics_record_mock.call_count == 1
         analytics_record_mock.assert_called_with(
             "relocation.created",
-            creator_id=int(response.data["creatorId"]),
-            owner_id=int(response.data["ownerId"]),
+            creator_id=int(response.data["creator"]["id"]),
+            owner_id=int(response.data["owner"]["id"]),
             uuid=response.data["uuid"],
         )
 
@@ -410,17 +394,9 @@ class PostRelocationsTest(APITestCase):
         assert response.data["creator"]["id"] == str(self.owner.id)
         assert response.data["creator"]["email"] == str(self.owner.email)
         assert response.data["creator"]["username"] == str(self.owner.username)
-        # TODO(azaslavsky): delete these after clients are migrated
-        assert response.data["creatorId"] == str(self.owner.id)
-        assert response.data["creatorEmail"] == str(self.owner.email)
-        assert response.data["creatorUsername"] == str(self.owner.username)
         assert response.data["owner"]["id"] == str(self.owner.id)
         assert response.data["owner"]["email"] == str(self.owner.email)
         assert response.data["owner"]["username"] == str(self.owner.username)
-        # TODO(azaslavsky): delete these after clients are migrated
-        assert response.data["ownerId"] == str(self.owner.id)
-        assert response.data["ownerEmail"] == str(self.owner.email)
-        assert response.data["ownerUsername"] == str(self.owner.username)
 
         relocation: Relocation = Relocation.objects.get(owner_id=self.owner.id)
         assert str(relocation.uuid) == response.data["uuid"]
@@ -433,8 +409,8 @@ class PostRelocationsTest(APITestCase):
         assert analytics_record_mock.call_count == 1
         analytics_record_mock.assert_called_with(
             "relocation.created",
-            creator_id=int(response.data["creatorId"]),
-            owner_id=int(response.data["ownerId"]),
+            creator_id=int(response.data["creator"]["id"]),
+            owner_id=int(response.data["owner"]["id"]),
             uuid=response.data["uuid"],
         )
 
@@ -487,8 +463,8 @@ class PostRelocationsTest(APITestCase):
         assert analytics_record_mock.call_count == 1
         analytics_record_mock.assert_called_with(
             "relocation.created",
-            creator_id=int(response.data["creatorId"]),
-            owner_id=int(response.data["ownerId"]),
+            creator_id=int(response.data["creator"]["id"]),
+            owner_id=int(response.data["owner"]["id"]),
             uuid=response.data["uuid"],
         )
 
@@ -540,8 +516,8 @@ class PostRelocationsTest(APITestCase):
         assert analytics_record_mock.call_count == 1
         analytics_record_mock.assert_called_with(
             "relocation.created",
-            creator_id=int(response.data["creatorId"]),
-            owner_id=int(response.data["ownerId"]),
+            creator_id=int(response.data["creator"]["id"]),
+            owner_id=int(response.data["owner"]["id"]),
             uuid=response.data["uuid"],
         )
 
@@ -588,17 +564,9 @@ class PostRelocationsTest(APITestCase):
         assert response.data["creator"]["id"] == str(self.staff_user.id)
         assert response.data["creator"]["email"] == str(self.staff_user.email)
         assert response.data["creator"]["username"] == str(self.staff_user.username)
-        # TODO(azaslavsky): delete these after clients are migrated
-        assert response.data["creatorId"] == str(self.staff_user.id)
-        assert response.data["creatorEmail"] == str(self.staff_user.email)
-        assert response.data["creatorUsername"] == str(self.staff_user.username)
         assert response.data["owner"]["id"] == str(self.owner.id)
         assert response.data["owner"]["email"] == str(self.owner.email)
         assert response.data["owner"]["username"] == str(self.owner.username)
-        # TODO(azaslavsky): delete these after clients are migrated
-        assert response.data["ownerId"] == str(self.owner.id)
-        assert response.data["ownerEmail"] == str(self.owner.email)
-        assert response.data["ownerUsername"] == str(self.owner.username)
 
         relocation: Relocation = Relocation.objects.get(owner_id=self.owner.id)
         assert str(relocation.uuid) == response.data["uuid"]
@@ -611,8 +579,8 @@ class PostRelocationsTest(APITestCase):
         assert analytics_record_mock.call_count == 1
         analytics_record_mock.assert_called_with(
             "relocation.created",
-            creator_id=int(response.data["creatorId"]),
-            owner_id=int(response.data["ownerId"]),
+            creator_id=int(response.data["creator"]["id"]),
+            owner_id=int(response.data["owner"]["id"]),
             uuid=response.data["uuid"],
         )
 
@@ -657,17 +625,9 @@ class PostRelocationsTest(APITestCase):
         assert response.data["creator"]["id"] == str(self.superuser.id)
         assert response.data["creator"]["email"] == str(self.superuser.email)
         assert response.data["creator"]["username"] == str(self.superuser.username)
-        # TODO(azaslavsky): delete these after clients are migrated
-        assert response.data["creatorId"] == str(self.superuser.id)
-        assert response.data["creatorEmail"] == str(self.superuser.email)
-        assert response.data["creatorUsername"] == str(self.superuser.username)
         assert response.data["owner"]["id"] == str(self.owner.id)
         assert response.data["owner"]["email"] == str(self.owner.email)
         assert response.data["owner"]["username"] == str(self.owner.username)
-        # TODO(azaslavsky): delete these after clients are migrated
-        assert response.data["ownerId"] == str(self.owner.id)
-        assert response.data["ownerEmail"] == str(self.owner.email)
-        assert response.data["ownerUsername"] == str(self.owner.username)
 
         relocation: Relocation = Relocation.objects.get(owner_id=self.owner.id)
         assert str(relocation.uuid) == response.data["uuid"]
@@ -680,8 +640,8 @@ class PostRelocationsTest(APITestCase):
         assert analytics_record_mock.call_count == 1
         analytics_record_mock.assert_called_with(
             "relocation.created",
-            creator_id=int(response.data["creatorId"]),
-            owner_id=int(response.data["ownerId"]),
+            creator_id=int(response.data["creator"]["id"]),
+            owner_id=int(response.data["owner"]["id"]),
             uuid=response.data["uuid"],
         )
 
@@ -795,8 +755,8 @@ class PostRelocationsTest(APITestCase):
             assert analytics_record_mock.call_count == 1
             analytics_record_mock.assert_called_with(
                 "relocation.created",
-                creator_id=int(response.data["creatorId"]),
-                owner_id=int(response.data["ownerId"]),
+                creator_id=int(response.data["creator"]["id"]),
+                owner_id=int(response.data["owner"]["id"]),
                 uuid=response.data["uuid"],
             )
 
@@ -902,8 +862,8 @@ class PostRelocationsTest(APITestCase):
         assert analytics_record_mock.call_count == 1
         analytics_record_mock.assert_called_with(
             "relocation.created",
-            creator_id=int(response.data["creatorId"]),
-            owner_id=int(response.data["ownerId"]),
+            creator_id=int(response.data["creator"]["id"]),
+            owner_id=int(response.data["owner"]["id"]),
             uuid=response.data["uuid"],
         )
 
@@ -1179,8 +1139,8 @@ class PostRelocationsTest(APITestCase):
         assert analytics_record_mock.call_count == 1
         analytics_record_mock.assert_called_with(
             "relocation.created",
-            creator_id=int(initial_response.data["creatorId"]),
-            owner_id=int(initial_response.data["ownerId"]),
+            creator_id=int(initial_response.data["creator"]["id"]),
+            owner_id=int(initial_response.data["owner"]["id"]),
             uuid=initial_response.data["uuid"],
         )
 
@@ -1247,14 +1207,14 @@ class PostRelocationsTest(APITestCase):
             [
                 call(
                     "relocation.created",
-                    creator_id=int(initial_response.data["creatorId"]),
-                    owner_id=int(initial_response.data["ownerId"]),
+                    creator_id=int(initial_response.data["creator"]["id"]),
+                    owner_id=int(initial_response.data["owner"]["id"]),
                     uuid=initial_response.data["uuid"],
                 ),
                 call(
                     "relocation.created",
-                    creator_id=int(unthrottled_response.data["creatorId"]),
-                    owner_id=int(unthrottled_response.data["ownerId"]),
+                    creator_id=int(unthrottled_response.data["creator"]["id"]),
+                    owner_id=int(unthrottled_response.data["owner"]["id"]),
                     uuid=unthrottled_response.data["uuid"],
                 ),
             ]
@@ -1330,14 +1290,14 @@ class PostRelocationsTest(APITestCase):
             [
                 call(
                     "relocation.created",
-                    creator_id=int(initial_response.data["creatorId"]),
-                    owner_id=int(initial_response.data["ownerId"]),
+                    creator_id=int(initial_response.data["creator"]["id"]),
+                    owner_id=int(initial_response.data["owner"]["id"]),
                     uuid=initial_response.data["uuid"],
                 ),
                 call(
                     "relocation.created",
-                    creator_id=int(unthrottled_response.data["creatorId"]),
-                    owner_id=int(unthrottled_response.data["ownerId"]),
+                    creator_id=int(unthrottled_response.data["creator"]["id"]),
+                    owner_id=int(unthrottled_response.data["owner"]["id"]),
                     uuid=unthrottled_response.data["uuid"],
                 ),
             ]
@@ -1420,14 +1380,14 @@ class PostRelocationsTest(APITestCase):
             [
                 call(
                     "relocation.created",
-                    creator_id=int(initial_response.data["creatorId"]),
-                    owner_id=int(initial_response.data["ownerId"]),
+                    creator_id=int(initial_response.data["creator"]["id"]),
+                    owner_id=int(initial_response.data["owner"]["id"]),
                     uuid=initial_response.data["uuid"],
                 ),
                 call(
                     "relocation.created",
-                    creator_id=int(unthrottled_response.data["creatorId"]),
-                    owner_id=int(unthrottled_response.data["ownerId"]),
+                    creator_id=int(unthrottled_response.data["creator"]["id"]),
+                    owner_id=int(unthrottled_response.data["owner"]["id"]),
                     uuid=unthrottled_response.data["uuid"],
                 ),
             ]
@@ -1508,14 +1468,14 @@ class PostRelocationsTest(APITestCase):
             [
                 call(
                     "relocation.created",
-                    creator_id=int(initial_response.data["creatorId"]),
-                    owner_id=int(initial_response.data["ownerId"]),
+                    creator_id=int(initial_response.data["creator"]["id"]),
+                    owner_id=int(initial_response.data["owner"]["id"]),
                     uuid=initial_response.data["uuid"],
                 ),
                 call(
                     "relocation.created",
-                    creator_id=int(unthrottled_response.data["creatorId"]),
-                    owner_id=int(unthrottled_response.data["ownerId"]),
+                    creator_id=int(unthrottled_response.data["creator"]["id"]),
+                    owner_id=int(unthrottled_response.data["owner"]["id"]),
                     uuid=unthrottled_response.data["uuid"],
                 ),
             ]

--- a/tests/sentry/api/endpoints/relocations/test_retry.py
+++ b/tests/sentry/api/endpoints/relocations/test_retry.py
@@ -104,17 +104,9 @@ class RetryRelocationTest(APITestCase):
         assert response.data["creator"]["id"] == str(self.owner.id)
         assert response.data["creator"]["email"] == str(self.owner.email)
         assert response.data["creator"]["username"] == str(self.owner.username)
-        # TODO(azaslavsky): delete these after clients are migrated
-        assert response.data["creatorId"] == str(self.owner.id)
-        assert response.data["creatorEmail"] == str(self.owner.email)
-        assert response.data["creatorUsername"] == str(self.owner.username)
         assert response.data["owner"]["id"] == str(self.owner.id)
         assert response.data["owner"]["email"] == str(self.owner.email)
         assert response.data["owner"]["username"] == str(self.owner.username)
-        # TODO(azaslavsky): delete these after clients are migrated
-        assert response.data["ownerId"] == str(self.owner.id)
-        assert response.data["ownerEmail"] == str(self.owner.email)
-        assert response.data["ownerUsername"] == str(self.owner.username)
         assert response.data["latestNotified"] is None
         assert response.data["latestUnclaimedEmailsSentAt"] is None
         assert response.data["scheduledPauseAtStep"] is None
@@ -135,8 +127,8 @@ class RetryRelocationTest(APITestCase):
 
         analytics_record_mock.assert_called_with(
             "relocation.created",
-            creator_id=int(response.data["creatorId"]),
-            owner_id=int(response.data["ownerId"]),
+            creator_id=int(response.data["creator"]["id"]),
+            owner_id=int(response.data["owner"]["id"]),
             uuid=response.data["uuid"],
         )
 
@@ -158,17 +150,9 @@ class RetryRelocationTest(APITestCase):
         assert response.data["creator"]["id"] == str(self.staff_user.id)
         assert response.data["creator"]["email"] == str(self.staff_user.email)
         assert response.data["creator"]["username"] == str(self.staff_user.username)
-        # TODO(azaslavsky): delete these after clients are migrated
-        assert response.data["creatorId"] == str(self.staff_user.id)
-        assert response.data["creatorEmail"] == str(self.staff_user.email)
-        assert response.data["creatorUsername"] == str(self.staff_user.username)
         assert response.data["owner"]["id"] == str(self.owner.id)
         assert response.data["owner"]["email"] == str(self.owner.email)
         assert response.data["owner"]["username"] == str(self.owner.username)
-        # TODO(azaslavsky): delete these after clients are migrated
-        assert response.data["ownerId"] == str(self.owner.id)
-        assert response.data["ownerEmail"] == str(self.owner.email)
-        assert response.data["ownerUsername"] == str(self.owner.username)
 
         assert (
             Relocation.objects.filter(owner_id=self.owner.id)
@@ -183,8 +167,8 @@ class RetryRelocationTest(APITestCase):
 
         analytics_record_mock.assert_called_with(
             "relocation.created",
-            creator_id=int(response.data["creatorId"]),
-            owner_id=int(response.data["ownerId"]),
+            creator_id=int(response.data["creator"]["id"]),
+            owner_id=int(response.data["owner"]["id"]),
             uuid=response.data["uuid"],
         )
 
@@ -204,17 +188,9 @@ class RetryRelocationTest(APITestCase):
         assert response.data["creator"]["id"] == str(self.superuser.id)
         assert response.data["creator"]["email"] == str(self.superuser.email)
         assert response.data["creator"]["username"] == str(self.superuser.username)
-        # TODO(azaslavsky): delete these after clients are migrated
-        assert response.data["creatorId"] == str(self.superuser.id)
-        assert response.data["creatorEmail"] == str(self.superuser.email)
-        assert response.data["creatorUsername"] == str(self.superuser.username)
         assert response.data["owner"]["id"] == str(self.owner.id)
         assert response.data["owner"]["email"] == str(self.owner.email)
         assert response.data["owner"]["username"] == str(self.owner.username)
-        # TODO(azaslavsky): delete these after clients are migrated
-        assert response.data["ownerId"] == str(self.owner.id)
-        assert response.data["ownerEmail"] == str(self.owner.email)
-        assert response.data["ownerUsername"] == str(self.owner.username)
 
         assert (
             Relocation.objects.filter(owner_id=self.owner.id)
@@ -229,8 +205,8 @@ class RetryRelocationTest(APITestCase):
 
         analytics_record_mock.assert_called_with(
             "relocation.created",
-            creator_id=int(response.data["creatorId"]),
-            owner_id=int(response.data["ownerId"]),
+            creator_id=int(response.data["creator"]["id"]),
+            owner_id=int(response.data["owner"]["id"]),
             uuid=response.data["uuid"],
         )
 

--- a/tests/sentry/api/serializers/test_relocation.py
+++ b/tests/sentry/api/serializers/test_relocation.py
@@ -76,17 +76,9 @@ class RelocationSerializerTest(TestCase):
         assert result["creator"]["id"] == str(self.superuser.id)
         assert result["creator"]["email"] == str(self.superuser.email)
         assert result["creator"]["username"] == str(self.superuser.username)
-        # TODO(azaslavsky): delete these after clients are migrated
-        assert result["creatorId"] == str(self.superuser.id)
-        assert result["creatorEmail"] == self.superuser.email
-        assert result["creatorUsername"] == self.superuser.username
         assert result["owner"]["id"] == str(self.owner.id)
         assert result["owner"]["email"] == str(self.owner.email)
         assert result["owner"]["username"] == str(self.owner.username)
-        # TODO(azaslavsky): delete these after clients are migrated
-        assert result["ownerId"] == str(self.owner.id)
-        assert result["ownerEmail"] == self.owner.email
-        assert result["ownerUsername"] == self.owner.username
         assert result["status"] == Relocation.Status.IN_PROGRESS.name
         assert result["step"] == Relocation.Step.UPLOADING.name
         assert not result["failureReason"]
@@ -123,17 +115,9 @@ class RelocationSerializerTest(TestCase):
         assert result["creator"]["id"] == str(self.superuser.id)
         assert result["creator"]["email"] == str(self.superuser.email)
         assert result["creator"]["username"] == str(self.superuser.username)
-        # TODO(azaslavsky): delete these after clients are migrated
-        assert result["creatorId"] == str(self.superuser.id)
-        assert result["creatorEmail"] == self.superuser.email
-        assert result["creatorUsername"] == self.superuser.username
         assert result["owner"]["id"] == str(self.owner.id)
         assert result["owner"]["email"] == str(self.owner.email)
         assert result["owner"]["username"] == str(self.owner.username)
-        # TODO(azaslavsky): delete these after clients are migrated
-        assert result["ownerId"] == str(self.owner.id)
-        assert result["ownerEmail"] == self.owner.email
-        assert result["ownerUsername"] == self.owner.username
         assert result["status"] == Relocation.Status.PAUSE.name
         assert result["step"] == Relocation.Step.IMPORTING.name
         assert not result["failureReason"]
@@ -174,17 +158,9 @@ class RelocationSerializerTest(TestCase):
         assert result["creator"]["id"] == str(self.superuser.id)
         assert result["creator"]["email"] == str(self.superuser.email)
         assert result["creator"]["username"] == str(self.superuser.username)
-        # TODO(azaslavsky): delete these after clients are migrated
-        assert result["creatorId"] == str(self.superuser.id)
-        assert result["creatorEmail"] == self.superuser.email
-        assert result["creatorUsername"] == self.superuser.username
         assert result["owner"]["id"] == str(self.owner.id)
         assert result["owner"]["email"] == str(self.owner.email)
         assert result["owner"]["username"] == str(self.owner.username)
-        # TODO(azaslavsky): delete these after clients are migrated
-        assert result["ownerId"] == str(self.owner.id)
-        assert result["ownerEmail"] == self.owner.email
-        assert result["ownerUsername"] == self.owner.username
         assert result["status"] == Relocation.Status.SUCCESS.name
         assert result["step"] == Relocation.Step.COMPLETED.name
         assert not result["failureReason"]
@@ -225,17 +201,9 @@ class RelocationSerializerTest(TestCase):
         assert result["creator"]["id"] == str(self.superuser.id)
         assert result["creator"]["email"] == str(self.superuser.email)
         assert result["creator"]["username"] == str(self.superuser.username)
-        # TODO(azaslavsky): delete these after clients are migrated
-        assert result["creatorId"] == str(self.superuser.id)
-        assert result["creatorEmail"] == self.superuser.email
-        assert result["creatorUsername"] == self.superuser.username
         assert result["owner"]["id"] == str(self.owner.id)
         assert result["owner"]["email"] == str(self.owner.email)
         assert result["owner"]["username"] == str(self.owner.username)
-        # TODO(azaslavsky): delete these after clients are migrated
-        assert result["ownerId"] == str(self.owner.id)
-        assert result["ownerEmail"] == self.owner.email
-        assert result["ownerUsername"] == self.owner.username
         assert result["status"] == Relocation.Status.FAILURE.name
         assert result["step"] == Relocation.Step.VALIDATING.name
         assert result["failureReason"] == "Some failure reason"


### PR DESCRIPTION
This is part of a series of changes to fix
[SENTRY-38N6](https://sentry.sentry.io/issues/5282819613/). This is change 4 of 4:

[1](https://github.com/getsentry/getsentry/pull/14166). Add a new API to client in getsentry
[2](https://github.com/getsentry/sentry/pull/71930). Add new API to server in sentry
[3](https://github.com/getsentry/getsentry/pull/14169). Remove old API, and only use new one, in getsentry
4. Remove old API from server in sentry <- THIS CHANGE

Now that all clients that rely on this serializer only use new fields, we can go ahead and remove the old, flattened versions.
