### PR TITLE
ref(messaging): Moved `types/integrations.py` to `integrations/*.py` 

### DIFF
--- a/src/sentry/integrations/errors.py
+++ b/src/sentry/integrations/errors.py
@@ -1,0 +1,6 @@
+class InvalidProviderException(Exception):
+    """
+    Provider that is passed does not exist.
+    """
+
+    pass

--- a/src/sentry/integrations/types.py
+++ b/src/sentry/integrations/types.py
@@ -1,0 +1,67 @@
+from enum import Enum
+
+from sentry.services.hybrid_cloud import ValueEqualityEnum
+
+
+class ExternalProviders(ValueEqualityEnum):
+    UNUSED_GH = 0
+    UNUSED_GL = 1
+
+    EMAIL = 100
+    SLACK = 110
+    MSTEAMS = 120
+    PAGERDUTY = 130
+    DISCORD = 140
+    OPSGENIE = 150
+    GITHUB = 200
+    GITHUB_ENTERPRISE = 201
+    GITLAB = 210
+
+    # TODO: do migration to delete this from database
+    CUSTOM = 700
+
+
+class ExternalProviderEnum(Enum):
+    EMAIL = "email"
+    SLACK = "slack"
+    MSTEAMS = "msteams"
+    PAGERDUTY = "pagerduty"
+    DISCORD = "discord"
+    OPSGENIE = "opsgenie"
+    GITHUB = "github"
+    GITHUB_ENTERPRISE = "github_enterprise"
+    GITLAB = "gitlab"
+    CUSTOM = "custom_scm"
+
+
+EXTERNAL_PROVIDERS_REVERSE = {
+    ExternalProviderEnum.EMAIL: ExternalProviders.EMAIL,
+    ExternalProviderEnum.SLACK: ExternalProviders.SLACK,
+    ExternalProviderEnum.MSTEAMS: ExternalProviders.MSTEAMS,
+    ExternalProviderEnum.PAGERDUTY: ExternalProviders.PAGERDUTY,
+    ExternalProviderEnum.DISCORD: ExternalProviders.DISCORD,
+    ExternalProviderEnum.OPSGENIE: ExternalProviders.OPSGENIE,
+    ExternalProviderEnum.GITHUB: ExternalProviders.GITHUB,
+    ExternalProviderEnum.GITHUB_ENTERPRISE: ExternalProviders.GITHUB_ENTERPRISE,
+    ExternalProviderEnum.GITLAB: ExternalProviders.GITLAB,
+    ExternalProviderEnum.CUSTOM: ExternalProviders.CUSTOM,
+}
+
+EXTERNAL_PROVIDERS = {
+    ExternalProviders.EMAIL: ExternalProviderEnum.EMAIL.value,
+    ExternalProviders.SLACK: ExternalProviderEnum.SLACK.value,
+    ExternalProviders.MSTEAMS: ExternalProviderEnum.MSTEAMS.value,
+    ExternalProviders.PAGERDUTY: ExternalProviderEnum.PAGERDUTY.value,
+    ExternalProviders.DISCORD: ExternalProviderEnum.DISCORD.value,
+    ExternalProviders.OPSGENIE: ExternalProviderEnum.OPSGENIE.value,
+    ExternalProviders.GITHUB: ExternalProviderEnum.GITHUB.value,
+    ExternalProviders.GITHUB_ENTERPRISE: ExternalProviderEnum.GITHUB_ENTERPRISE.value,
+    ExternalProviders.GITLAB: ExternalProviderEnum.GITLAB.value,
+    ExternalProviders.CUSTOM: ExternalProviderEnum.CUSTOM.value,
+}
+
+PERSONAL_NOTIFICATION_PROVIDERS = [
+    ExternalProviderEnum.EMAIL.value,
+    ExternalProviderEnum.SLACK.value,
+    ExternalProviderEnum.MSTEAMS.value,
+]

--- a/src/sentry/integrations/utils/providers.py
+++ b/src/sentry/integrations/utils/providers.py
@@ -1,0 +1,41 @@
+from collections.abc import Sequence
+
+from sentry.integrations.errors import InvalidProviderException
+from sentry.integrations.types import (
+    EXTERNAL_PROVIDERS,
+    PERSONAL_NOTIFICATION_PROVIDERS,
+    ExternalProviders,
+)
+
+_UNKNOWN_PROVIDER = "unknown"
+
+
+def get_provider_name(value: int) -> str | None:
+    return EXTERNAL_PROVIDERS.get(ExternalProviders(value), None)
+
+
+def get_provider_string(provider_int: int) -> str:
+    return get_provider_name(provider_int) or _UNKNOWN_PROVIDER
+
+
+def get_provider_enum(value: str | None) -> ExternalProviders | None:
+    if value is None:
+        return None
+    return {v: k for k, v in EXTERNAL_PROVIDERS.items()}.get(value, None)
+
+
+def get_provider_choices(providers: set[ExternalProviders]) -> Sequence[str]:
+    return list(EXTERNAL_PROVIDERS[i] for i in providers if i in EXTERNAL_PROVIDERS)
+
+
+def get_provider_enum_from_string(provider: str) -> ExternalProviders:
+    for k, v in EXTERNAL_PROVIDERS.items():
+        if v == provider:
+            return k
+    raise InvalidProviderException(f"Invalid provider {provider}")
+
+
+PERSONAL_NOTIFICATION_PROVIDERS_AS_INT = [
+    get_provider_enum_from_string(provider_name).value
+    for provider_name in PERSONAL_NOTIFICATION_PROVIDERS
+]


### PR DESCRIPTION
https://www.notion.so/sentry/Task-list-for-Messaging-Vertical-ca4f431d43b84e72b8a91643fe880b66#410553168fb143ef857badd06e50ddbd
tldr: Ecosystem Team is working on refactoring our integration logic to be more stable. 

This PR aims to move all the code under `types/integration.py` to the `integration` folder. I split up the code into `integrations/types.py`, `integration/errors.py`, and `integrations/utils/provider.py`.

To make sure we can switch over to these new files, first I will make a PR to to update the imports in `getsentry`, then `sentry`

I will follow up with another PR to remove the file once I update the import statements in `sentry`.