### PR TITLE
ref: Move getExactDuration() into utils/duration/

### DIFF
--- a/static/app/components/duration.tsx
+++ b/static/app/components/duration.tsx
@@ -1,5 +1,5 @@
 import getDuration from 'sentry/utils/duration/getDuration';
-import {getExactDuration} from 'sentry/utils/formatters';
+import {getExactDuration} from 'sentry/utils/duration/getExactDuration';
 
 interface Props extends React.HTMLAttributes<HTMLSpanElement> {
   seconds: number;

--- a/static/app/utils/duration/getExactDuration.spec.tsx
+++ b/static/app/utils/duration/getExactDuration.spec.tsx
@@ -1,0 +1,45 @@
+import {getExactDuration} from 'sentry/utils/duration/getExactDuration';
+
+describe('getExactDuration', () => {
+  it('should provide default value', () => {
+    expect(getExactDuration(0)).toEqual('0 milliseconds');
+  });
+
+  it('should format durations without extra suffixes', () => {
+    expect(getExactDuration(2.030043848568126)).toEqual('2 seconds 30 milliseconds');
+    expect(getExactDuration(0.2)).toEqual('200 milliseconds');
+    expect(getExactDuration(13)).toEqual('13 seconds');
+    expect(getExactDuration(60)).toEqual('1 minute');
+    expect(getExactDuration(121)).toEqual('2 minutes 1 second');
+    expect(getExactDuration(234235435)).toEqual(
+      '387 weeks 2 days 1 hour 23 minutes 55 seconds'
+    );
+  });
+
+  it('should format negative durations', () => {
+    expect(getExactDuration(-2.030043848568126)).toEqual('-2 seconds -30 milliseconds');
+    expect(getExactDuration(-0.2)).toEqual('-200 milliseconds');
+    expect(getExactDuration(-13)).toEqual('-13 seconds');
+    expect(getExactDuration(-60)).toEqual('-1 minute');
+    expect(getExactDuration(-121)).toEqual('-2 minutes -1 second');
+    expect(getExactDuration(-234235435)).toEqual(
+      '-387 weeks -2 days -1 hour -23 minutes -55 seconds'
+    );
+  });
+
+  it('should abbreviate label', () => {
+    expect(getExactDuration(234235435, true)).toEqual('387wk 2d 1hr 23min 55s');
+  });
+
+  it('should pin/truncate to the min suffix precision if provided', () => {
+    expect(getExactDuration(0, false, 'seconds')).toEqual('0 seconds');
+    expect(getExactDuration(0.2, false, 'seconds')).toEqual('0 seconds');
+    expect(getExactDuration(2.030043848568126, false, 'seconds')).toEqual('2 seconds');
+    expect(getExactDuration(13, false, 'seconds')).toEqual('13 seconds');
+    expect(getExactDuration(60, false, 'seconds')).toEqual('1 minute');
+    expect(getExactDuration(121, false, 'seconds')).toEqual('2 minutes 1 second');
+    expect(getExactDuration(234235435.2, false, 'seconds')).toEqual(
+      '387 weeks 2 days 1 hour 23 minutes 55 seconds'
+    );
+  });
+});

--- a/static/app/utils/duration/getExactDuration.tsx
+++ b/static/app/utils/duration/getExactDuration.tsx
@@ -1,0 +1,79 @@
+import round from 'lodash/round';
+
+import {t, tn} from 'sentry/locale';
+
+import {DAY, HOUR, MINUTE, SECOND, SUFFIX_ABBR, WEEK} from '../formatters';
+
+/**
+ * Returns a human readable exact duration.
+ * 'precision' arg will truncate the results to the specified suffix
+ *
+ * e.g. 1 hour 25 minutes 15 seconds
+ */
+export function getExactDuration(
+  seconds: number,
+  abbreviation: boolean = false,
+  precision: keyof typeof SUFFIX_ABBR = 'milliseconds'
+) {
+  const minSuffix = ` ${precision}`;
+
+  const convertDuration = (secs: number, abbr: boolean): string => {
+    // value in milliseconds
+    const msValue = round(secs * 1000);
+    const value = round(Math.abs(secs * 1000));
+
+    const divideBy = (time: number) => {
+      return {
+        quotient: msValue < 0 ? Math.ceil(msValue / time) : Math.floor(msValue / time),
+        remainder: msValue % time,
+      };
+    };
+
+    if (value >= WEEK || (value && minSuffix === ' weeks')) {
+      const {quotient, remainder} = divideBy(WEEK);
+      const suffix = abbr ? t('wk') : ` ${tn('week', 'weeks', quotient)}`;
+
+      return `${quotient}${suffix} ${minSuffix === suffix ? '' : convertDuration(remainder / 1000, abbr)}`;
+    }
+    if (value >= DAY || (value && minSuffix === ' days')) {
+      const {quotient, remainder} = divideBy(DAY);
+      const suffix = abbr ? t('d') : ` ${tn('day', 'days', quotient)}`;
+
+      return `${quotient}${suffix} ${minSuffix === suffix ? '' : convertDuration(remainder / 1000, abbr)}`;
+    }
+    if (value >= HOUR || (value && minSuffix === ' hours')) {
+      const {quotient, remainder} = divideBy(HOUR);
+      const suffix = abbr ? t('hr') : ` ${tn('hour', 'hours', quotient)}`;
+
+      return `${quotient}${suffix} ${minSuffix === suffix ? '' : convertDuration(remainder / 1000, abbr)}`;
+    }
+    if (value >= MINUTE || (value && minSuffix === ' minutes')) {
+      const {quotient, remainder} = divideBy(MINUTE);
+      const suffix = abbr ? t('min') : ` ${tn('minute', 'minutes', quotient)}`;
+
+      return `${quotient}${suffix} ${minSuffix === suffix ? '' : convertDuration(remainder / 1000, abbr)}`;
+    }
+    if (value >= SECOND || (value && minSuffix === ' seconds')) {
+      const {quotient, remainder} = divideBy(SECOND);
+      const suffix = abbr ? t('s') : ` ${tn('second', 'seconds', quotient)}`;
+
+      return `${quotient}${suffix} ${minSuffix === suffix ? '' : convertDuration(remainder / 1000, abbr)}`;
+    }
+
+    if (value === 0) {
+      return '';
+    }
+
+    const suffix = abbr ? t('ms') : ` ${tn('millisecond', 'milliseconds', value)}`;
+
+    return `${msValue}${suffix}`;
+  };
+
+  const result = convertDuration(seconds, abbreviation).trim();
+
+  if (result.length) {
+    return result;
+  }
+
+  return `0${abbreviation ? SUFFIX_ABBR[precision] : minSuffix}`;
+}

--- a/static/app/utils/duration/getExactDuration.tsx
+++ b/static/app/utils/duration/getExactDuration.tsx
@@ -2,7 +2,17 @@ import round from 'lodash/round';
 
 import {t, tn} from 'sentry/locale';
 
-import {DAY, HOUR, MINUTE, SECOND, SUFFIX_ABBR, WEEK} from '../formatters';
+import {DAY, HOUR, MINUTE, SECOND, WEEK} from '../formatters';
+
+const SUFFIX_ABBR = {
+  years: t('yr'),
+  weeks: t('wk'),
+  days: t('d'),
+  hours: t('hr'),
+  minutes: t('min'),
+  seconds: t('s'),
+  milliseconds: t('ms'),
+};
 
 /**
  * Returns a human readable exact duration.

--- a/static/app/utils/formatters.spec.tsx
+++ b/static/app/utils/formatters.spec.tsx
@@ -8,7 +8,6 @@ import {
   formatRate,
   formatSecondsToClock,
   formatSpanOperation,
-  getExactDuration,
   MONTH, // ms in month
   parseClockToSeconds,
   userDisplayName,
@@ -305,50 +304,6 @@ describe('userDisplayName', function () {
     // @ts-expect-error
     expect(userDisplayName()).toEqual('Unknown author');
     expect(userDisplayName({})).toEqual('Unknown author');
-  });
-});
-
-describe('getExactDuration', () => {
-  it('should provide default value', () => {
-    expect(getExactDuration(0)).toEqual('0 milliseconds');
-  });
-
-  it('should format durations without extra suffixes', () => {
-    expect(getExactDuration(2.030043848568126)).toEqual('2 seconds 30 milliseconds');
-    expect(getExactDuration(0.2)).toEqual('200 milliseconds');
-    expect(getExactDuration(13)).toEqual('13 seconds');
-    expect(getExactDuration(60)).toEqual('1 minute');
-    expect(getExactDuration(121)).toEqual('2 minutes 1 second');
-    expect(getExactDuration(234235435)).toEqual(
-      '387 weeks 2 days 1 hour 23 minutes 55 seconds'
-    );
-  });
-
-  it('should format negative durations', () => {
-    expect(getExactDuration(-2.030043848568126)).toEqual('-2 seconds -30 milliseconds');
-    expect(getExactDuration(-0.2)).toEqual('-200 milliseconds');
-    expect(getExactDuration(-13)).toEqual('-13 seconds');
-    expect(getExactDuration(-60)).toEqual('-1 minute');
-    expect(getExactDuration(-121)).toEqual('-2 minutes -1 second');
-    expect(getExactDuration(-234235435)).toEqual(
-      '-387 weeks -2 days -1 hour -23 minutes -55 seconds'
-    );
-  });
-
-  it('should abbreviate label', () => {
-    expect(getExactDuration(234235435, true)).toEqual('387wk 2d 1hr 23min 55s');
-  });
-
-  it('should pin/truncate to the min suffix precision if provided', () => {
-    expect(getExactDuration(0, false, 'seconds')).toEqual('0 seconds');
-    expect(getExactDuration(0.2, false, 'seconds')).toEqual('0 seconds');
-    expect(getExactDuration(2.030043848568126, false, 'seconds')).toEqual('2 seconds');
-    expect(getExactDuration(13, false, 'seconds')).toEqual('13 seconds');
-    expect(getExactDuration(60, false, 'seconds')).toEqual('1 minute');
-    expect(getExactDuration(121, false, 'seconds')).toEqual('2 minutes 1 second');
-    expect(getExactDuration(234235435.2, false, 'seconds')).toEqual(
-      '387 weeks 2 days 1 hour 23 minutes 55 seconds'
-    );
   });
 });
 

--- a/static/app/utils/formatters.tsx
+++ b/static/app/utils/formatters.tsx
@@ -37,15 +37,6 @@ export const NANOSECOND = 0.000001;
  */
 export {getExactDuration} from 'sentry/utils/duration/getExactDuration';
 
-export const SUFFIX_ABBR = {
-  years: t('yr'),
-  weeks: t('wk'),
-  days: t('d'),
-  hours: t('hr'),
-  minutes: t('min'),
-  seconds: t('s'),
-  milliseconds: t('ms'),
-};
 export function formatSecondsToClock(
   seconds: number,
   {padAll}: {padAll: boolean} = {padAll: true}

--- a/static/app/utils/formatters.tsx
+++ b/static/app/utils/formatters.tsx
@@ -1,6 +1,6 @@
 import round from 'lodash/round';
 
-import {t, tn} from 'sentry/locale';
+import {t} from 'sentry/locale';
 import type {CommitAuthor, User} from 'sentry/types';
 import {RATE_UNIT_LABELS, RateUnit} from 'sentry/utils/discover/fields';
 import {formatFloat} from 'sentry/utils/number/formatFloat';
@@ -31,7 +31,13 @@ export const MILLISECOND = 1;
 export const MICROSECOND = 0.001;
 export const NANOSECOND = 0.000001;
 
-const SUFFIX_ABBR = {
+/**
+ * @deprecated Import directly from `sentry/utils/duration/getExactDuration` instead.
+ * biome-ignore lint/performance/noBarrelFile: Temporary for getsentry
+ */
+export {getExactDuration} from 'sentry/utils/duration/getExactDuration';
+
+export const SUFFIX_ABBR = {
   years: t('yr'),
   weeks: t('wk'),
   days: t('d'),
@@ -40,90 +46,6 @@ const SUFFIX_ABBR = {
   seconds: t('s'),
   milliseconds: t('ms'),
 };
-/**
- * Returns a human readable exact duration.
- * 'precision' arg will truncate the results to the specified suffix
- *
- * e.g. 1 hour 25 minutes 15 seconds
- */
-export function getExactDuration(
-  seconds: number,
-  abbreviation: boolean = false,
-  precision: keyof typeof SUFFIX_ABBR = 'milliseconds'
-) {
-  const minSuffix = ` ${precision}`;
-
-  const convertDuration = (secs: number, abbr: boolean): string => {
-    // value in milliseconds
-    const msValue = round(secs * 1000);
-    const value = round(Math.abs(secs * 1000));
-
-    const divideBy = (time: number) => {
-      return {
-        quotient: msValue < 0 ? Math.ceil(msValue / time) : Math.floor(msValue / time),
-        remainder: msValue % time,
-      };
-    };
-
-    if (value >= WEEK || (value && minSuffix === ' weeks')) {
-      const {quotient, remainder} = divideBy(WEEK);
-      const suffix = abbr ? t('wk') : ` ${tn('week', 'weeks', quotient)}`;
-
-      return `${quotient}${suffix} ${
-        minSuffix === suffix ? '' : convertDuration(remainder / 1000, abbr)
-      }`;
-    }
-    if (value >= DAY || (value && minSuffix === ' days')) {
-      const {quotient, remainder} = divideBy(DAY);
-      const suffix = abbr ? t('d') : ` ${tn('day', 'days', quotient)}`;
-
-      return `${quotient}${suffix} ${
-        minSuffix === suffix ? '' : convertDuration(remainder / 1000, abbr)
-      }`;
-    }
-    if (value >= HOUR || (value && minSuffix === ' hours')) {
-      const {quotient, remainder} = divideBy(HOUR);
-      const suffix = abbr ? t('hr') : ` ${tn('hour', 'hours', quotient)}`;
-
-      return `${quotient}${suffix} ${
-        minSuffix === suffix ? '' : convertDuration(remainder / 1000, abbr)
-      }`;
-    }
-    if (value >= MINUTE || (value && minSuffix === ' minutes')) {
-      const {quotient, remainder} = divideBy(MINUTE);
-      const suffix = abbr ? t('min') : ` ${tn('minute', 'minutes', quotient)}`;
-
-      return `${quotient}${suffix} ${
-        minSuffix === suffix ? '' : convertDuration(remainder / 1000, abbr)
-      }`;
-    }
-    if (value >= SECOND || (value && minSuffix === ' seconds')) {
-      const {quotient, remainder} = divideBy(SECOND);
-      const suffix = abbr ? t('s') : ` ${tn('second', 'seconds', quotient)}`;
-
-      return `${quotient}${suffix} ${
-        minSuffix === suffix ? '' : convertDuration(remainder / 1000, abbr)
-      }`;
-    }
-
-    if (value === 0) {
-      return '';
-    }
-
-    const suffix = abbr ? t('ms') : ` ${tn('millisecond', 'milliseconds', value)}`;
-
-    return `${msValue}${suffix}`;
-  };
-
-  const result = convertDuration(seconds, abbreviation).trim();
-
-  if (result.length) {
-    return result;
-  }
-
-  return `0${abbreviation ? SUFFIX_ABBR[precision] : minSuffix}`;
-}
-
 export function formatSecondsToClock(
   seconds: number,
   {padAll}: {padAll: boolean} = {padAll: true}

--- a/static/app/views/settings/project/projectKeys/details/keyRateLimitsForm.tsx
+++ b/static/app/views/settings/project/projectKeys/details/keyRateLimitsForm.tsx
@@ -16,7 +16,7 @@ import {t, tct, tn} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {Organization, ProjectKey} from 'sentry/types';
 import {defined} from 'sentry/utils';
-import {getExactDuration} from 'sentry/utils/formatters';
+import {getExactDuration} from 'sentry/utils/duration/getExactDuration';
 
 const PREDEFINED_RATE_LIMIT_VALUES = [
   0, 60, 300, 900, 3600, 7200, 14400, 21600, 43200, 86400,


### PR DESCRIPTION
Related to https://github.com/getsentry/frontend-tsc/issues/13