### PR TITLE
chore(hybridcloud) Introduce caching to installation reads

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1853,6 +1853,9 @@ register(
 
 # Break glass controls
 register("hybrid_cloud.rpc.disabled-service-methods", default=[], flags=FLAG_AUTOMATOR_MODIFIABLE)
+
+# RPC optimization
+register("sentryapps.get_installation_cached", default=0.0, flags=FLAG_AUTOMATOR_MODIFIABLE)
 # == End hybrid cloud subsystem
 
 # Decides whether an incoming transaction triggers an update of the clustering rule applied to it.

--- a/src/sentry/tasks/sentry_apps.py
+++ b/src/sentry/tasks/sentry_apps.py
@@ -12,6 +12,7 @@ from sentry import analytics
 from sentry.api.serializers import AppPlatformEvent, serialize
 from sentry.constants import SentryAppInstallationStatus
 from sentry.eventstore.models import Event, GroupEvent
+from sentry.features.rollout import in_random_rollout
 from sentry.models.activity import Activity
 from sentry.models.group import Group
 from sentry.models.integrations.sentry_app import VALID_EVENTS
@@ -293,8 +294,10 @@ def build_comment_webhook(installation_id, issue_id, type, user_id, *args, **kwa
 
 def get_webhook_data(installation_id, issue_id, user_id):
     extra = {"installation_id": installation_id, "issue_id": issue_id}
-    # TODO(hybridcloud) Use installation_by_id to reduce RPC traffic.
-    install = app_service.get_installation_by_id(id=installation_id)
+    if in_random_rollout("sentryapps.get_installation_cached"):
+        install = app_service.installation_by_id(id=installation_id)
+    else:
+        install = app_service.get_installation_by_id(id=installation_id)
     if not install:
         logger.info("workflow_notification.missing_installation", extra=extra)
         return
@@ -317,8 +320,10 @@ def get_webhook_data(installation_id, issue_id, user_id):
 @instrumented_task("sentry.tasks.send_process_resource_change_webhook", **TASK_OPTIONS)
 @retry_decorator
 def send_resource_change_webhook(installation_id, event, data, *args, **kwargs):
-    # TODO(hybridcloud) Use installation_by_id to reduce RPC traffic
-    installation = app_service.get_installation_by_id(id=installation_id)
+    if in_random_rollout("sentryapps.get_installation_cached"):
+        installation = app_service.installation_by_id(id=installation_id)
+    else:
+        installation = app_service.get_installation_by_id(id=installation_id)
     if not installation:
         logger.info(
             "send_process_resource_change_webhook.missing_installation",

--- a/tests/sentry/tasks/test_sentry_apps.py
+++ b/tests/sentry/tasks/test_sentry_apps.py
@@ -36,6 +36,7 @@ from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers import with_feature
 from sentry.testutils.helpers.datetime import before_now, freeze_time, iso_format
 from sentry.testutils.helpers.eventprocessing import write_event_to_cache
+from sentry.testutils.helpers.options import override_options
 from sentry.testutils.outbox import outbox_runner
 from sentry.testutils.silo import assume_test_silo_mode_of, control_silo_test
 from sentry.testutils.skips import requires_snuba
@@ -440,6 +441,7 @@ class TestInstallationWebhook(TestCase):
         assert len(run.mock_calls) == 0
 
 
+@override_options({"sentryapps.get_installation_cached": 1.0})
 @patch("sentry.utils.sentry_apps.webhooks.safe_urlopen", return_value=MockResponseInstance)
 class TestCommentWebhook(TestCase):
     def setUp(self):


### PR DESCRIPTION
Sentryapp Installations rarely change and can be a source of spiky RPC throughput as customer traffic ebbs and flows. By caching the install reads we could avoid a measurable amount of load and increase reliability.

Refs HC-1185