### PR TITLE
ref: remove expected_errors= from safe_execute

### DIFF
--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -1280,13 +1280,16 @@ def plugin_post_process_group(plugin_slug, event, **kwargs):
     from sentry.plugins.base import plugins
 
     plugin = plugins.get(plugin_slug)
-    safe_execute(
-        plugin.post_process,
-        event=event,
-        group=event.group,
-        expected_errors=(PluginError,),
-        **kwargs,
-    )
+    try:
+        plugin.post_process(
+            event=event,
+            group=event.group,
+            **kwargs,
+        )
+    except PluginError as e:
+        logger.info("post_process.process_error_ignored", extra={"exception": e})
+    except Exception as e:
+        logger.exception("post_process.process_error", extra={"exception": e})
 
 
 def feedback_filter_decorator(func):

--- a/src/sentry/utils/safe.py
+++ b/src/sentry/utils/safe.py
@@ -13,7 +13,6 @@ PathSearchable = Union[Mapping[str, Any], Sequence[Any], None]
 
 
 def safe_execute(func, *args, **kwargs):
-    expected_errors = kwargs.pop("expected_errors", None)
     try:
         result = func(*args, **kwargs)
     except Exception as e:
@@ -26,9 +25,6 @@ def safe_execute(func, *args, **kwargs):
         cls_name = cls.__name__
         logger = logging.getLogger(f"sentry.safe.{cls_name.lower()}")
 
-        if expected_errors and isinstance(e, expected_errors):
-            logger.info("%s.process_error_ignored", func_name, extra={"exception": e})
-            return
         logger.exception("%s.process_error", func_name, extra={"exception": e})
     else:
         return result

--- a/tests/sentry/utils/test_safe.py
+++ b/tests/sentry/utils/test_safe.py
@@ -4,7 +4,6 @@ import unittest
 from collections.abc import MutableMapping
 from functools import partial
 from typing import Any
-from unittest.mock import Mock, patch
 
 import pytest
 
@@ -94,18 +93,6 @@ class SafeExecuteTest(TestCase):
                 raise Exception()
 
         assert safe_execute(Foo().simple, 1) is None
-
-    @patch("sentry.utils.safe.logging.getLogger")
-    def test_with_expected_errors(self, mock_get_logger):
-        mock_log = Mock()
-        mock_get_logger.return_value = mock_log
-
-        def simple(a):
-            raise ValueError()
-
-        assert safe_execute(simple, 1, expected_errors=(ValueError,)) is None
-        assert mock_log.info.called
-        assert mock_log.error.called is False
 
 
 class GetPathTest(unittest.TestCase):


### PR DESCRIPTION
this prevents it from being made typesafe (followup PR) -- fixed the one user of this functionality to just use plain try/except

<!-- Describe your PR here. -->