### PR TITLE
feat(custom-views): add custom views get endpoint

### DIFF
--- a/src/sentry/api/serializers/models/groupsearchview.py
+++ b/src/sentry/api/serializers/models/groupsearchview.py
@@ -1,10 +1,23 @@
+from typing import TypedDict
+
 from sentry.api.serializers import Serializer, register
 from sentry.models.groupsearchview import GroupSearchView
+from sentry.models.savedsearch import SORT_LITERALS
+
+
+class View(TypedDict):
+    id: str
+    name: str
+    query: str
+    querySort: SORT_LITERALS
+    position: int
+    dateCreated: str | None
+    dateUpdated: str | None
 
 
 @register(GroupSearchView)
 class GroupSearchViewSerializer(Serializer):
-    def serialize(self, obj, attrs, user):
+    def serialize(self, obj, attrs, user) -> View:
         return {
             "id": str(obj.id),
             "name": obj.name,

--- a/src/sentry/api/serializers/models/groupsearchview.py
+++ b/src/sentry/api/serializers/models/groupsearchview.py
@@ -1,0 +1,16 @@
+from sentry.api.serializers import Serializer, register
+from sentry.models.groupsearchview import GroupSearchView
+
+
+@register(GroupSearchView)
+class GroupSearchViewSerializer(Serializer):
+    def serialize(self, obj, attrs, user):
+        return {
+            "id": str(obj.id),
+            "name": obj.name,
+            "query": obj.query,
+            "querySort": obj.query_sort,
+            "position": obj.position,
+            "dateCreated": obj.date_added,
+            "dateUpdated": obj.date_updated,
+        }

--- a/src/sentry/api/serializers/models/groupsearchview.py
+++ b/src/sentry/api/serializers/models/groupsearchview.py
@@ -5,7 +5,7 @@ from sentry.models.groupsearchview import GroupSearchView
 from sentry.models.savedsearch import SORT_LITERALS
 
 
-class View(TypedDict):
+class GroupSearchViewSerializerResponse(TypedDict):
     id: str
     name: str
     query: str
@@ -17,7 +17,7 @@ class View(TypedDict):
 
 @register(GroupSearchView)
 class GroupSearchViewSerializer(Serializer):
-    def serialize(self, obj, attrs, user) -> View:
+    def serialize(self, obj, attrs, user, **kwargs) -> GroupSearchViewSerializerResponse:
         return {
             "id": str(obj.id),
             "name": obj.name,

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -115,6 +115,7 @@ from sentry.issues.endpoints import (
     GroupEventsEndpoint,
     OrganizationActivityEndpoint,
     OrganizationGroupIndexEndpoint,
+    OrganizationGroupSearchViewsEndpoint,
     OrganizationReleasePreviousCommitsEndpoint,
     OrganizationSearchesEndpoint,
     ProjectStacktraceLinkEndpoint,
@@ -1702,6 +1703,11 @@ ORGANIZATION_URLS = [
             csrf_exempt=True,
         ),
         name="sentry-api-0-organization-monitor-check-in-attachment",
+    ),
+    re_path(
+        r"^(?P<organization_id_or_slug>[^\/]+)/group-search-views/$",
+        OrganizationGroupSearchViewsEndpoint.as_view(),
+        name="sentry-api-0-organization-group-search-views",
     ),
     # Pinned and saved search
     re_path(

--- a/src/sentry/issues/endpoints/__init__.py
+++ b/src/sentry/issues/endpoints/__init__.py
@@ -2,6 +2,7 @@ from .actionable_items import ActionableItemsEndpoint
 from .group_events import GroupEventsEndpoint
 from .organization_activity import OrganizationActivityEndpoint
 from .organization_group_index import OrganizationGroupIndexEndpoint
+from .organization_group_search_views import OrganizationGroupSearchViewsEndpoint
 from .organization_release_previous_commits import OrganizationReleasePreviousCommitsEndpoint
 from .organization_searches import OrganizationSearchesEndpoint
 from .project_stacktrace_link import ProjectStacktraceLinkEndpoint
@@ -12,6 +13,7 @@ __all__ = (
     "GroupEventsEndpoint",
     "OrganizationActivityEndpoint",
     "OrganizationGroupIndexEndpoint",
+    "OrganizationGroupSearchViewsEndpoint",
     "OrganizationReleasePreviousCommitsEndpoint",
     "OrganizationSearchesEndpoint",
     "ProjectStacktraceLinkEndpoint",

--- a/src/sentry/issues/endpoints/organization_group_search_views.py
+++ b/src/sentry/issues/endpoints/organization_group_search_views.py
@@ -9,12 +9,15 @@ from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.organization import OrganizationEndpoint, OrganizationPermission
 from sentry.api.paginator import SequencePaginator
 from sentry.api.serializers import serialize
-from sentry.api.serializers.models.groupsearchview import GroupSearchViewSerializer, View
+from sentry.api.serializers.models.groupsearchview import (
+    GroupSearchViewSerializer,
+    GroupSearchViewSerializerResponse,
+)
 from sentry.models.groupsearchview import GroupSearchView
 from sentry.models.organization import Organization
 from sentry.models.savedsearch import SortOptions
 
-DEFAULT_VIEWS: list[View] = [
+DEFAULT_VIEWS: list[GroupSearchViewSerializerResponse] = [
     {
         "id": "",
         "name": "Prioritized",

--- a/src/sentry/issues/endpoints/organization_group_search_views.py
+++ b/src/sentry/issues/endpoints/organization_group_search_views.py
@@ -1,0 +1,45 @@
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from sentry.api.api_owners import ApiOwner
+from sentry.api.api_publish_status import ApiPublishStatus
+from sentry.api.base import region_silo_endpoint
+from sentry.api.bases.organization import OrganizationEndpoint, OrganizationPermission
+from sentry.api.serializers import serialize
+from sentry.api.serializers.models.groupsearchview import GroupSearchViewSerializer
+from sentry.models.groupsearchview import GroupSearchView
+from sentry.models.organization import Organization
+
+
+class MemberPermission(OrganizationPermission):
+    scope_map = {
+        "GET": ["member:read", "member:write"],
+        "PUT": ["member:read", "member:write"],
+    }
+
+
+@region_silo_endpoint
+class OrganizationGroupSearchViewsEndpoint(OrganizationEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.EXPERIMENTAL,
+        "POST": ApiPublishStatus.EXPERIMENTAL,
+    }
+    owner = ApiOwner.ISSUES
+    permission_classes = (MemberPermission,)
+
+    def get(self, request: Request, organization: Organization) -> Response:
+        """
+        List a organization member's custom views
+        `````````````````````````````````````````
+
+        Retrieve a list of custom views for a given organization member.
+        """
+
+        query = GroupSearchView.objects.filter(organization=organization, user_id=request.user.id)
+
+        return self.paginate(
+            request=request,
+            queryset=query,
+            order_by="position",
+            on_results=lambda x: serialize(x, request.user, serializer=GroupSearchViewSerializer()),
+        )

--- a/src/sentry/issues/endpoints/organization_group_search_views.py
+++ b/src/sentry/issues/endpoints/organization_group_search_views.py
@@ -46,7 +46,7 @@ class OrganizationGroupSearchViewsEndpoint(OrganizationEndpoint):
         Retrieve a list of custom views for the current organization member.
         """
         if not features.has("organizations:issue-stream-custom-views", organization):
-            return Response(status=status.HTTP_405_METHOD_NOT_ALLOWED)
+            return Response(status=status.HTTP_404_NOT_FOUND)
 
         query = GroupSearchView.objects.filter(organization=organization, user_id=request.user.id)
 

--- a/src/sentry/issues/endpoints/organization_group_search_views.py
+++ b/src/sentry/issues/endpoints/organization_group_search_views.py
@@ -9,17 +9,20 @@ from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.organization import OrganizationEndpoint, OrganizationPermission
 from sentry.api.paginator import SequencePaginator
 from sentry.api.serializers import serialize
-from sentry.api.serializers.models.groupsearchview import GroupSearchViewSerializer
+from sentry.api.serializers.models.groupsearchview import GroupSearchViewSerializer, View
 from sentry.models.groupsearchview import GroupSearchView
 from sentry.models.organization import Organization
+from sentry.models.savedsearch import SortOptions
 
-DEFAULT_VIEWS = [
+DEFAULT_VIEWS: list[View] = [
     {
         "id": "",
         "name": "Prioritized",
         "query": "is:unresolved issue.priority:[high, medium]",
-        "querySort": "date",
+        "querySort": SortOptions.DATE.value,
         "position": 0,
+        "dateCreated": None,
+        "dateUpdated": None,
     }
 ]
 

--- a/src/sentry/issues/endpoints/organization_group_search_views.py
+++ b/src/sentry/issues/endpoints/organization_group_search_views.py
@@ -1,6 +1,8 @@
+from rest_framework import status
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry import features
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
@@ -27,11 +29,13 @@ class OrganizationGroupSearchViewsEndpoint(OrganizationEndpoint):
 
     def get(self, request: Request, organization: Organization) -> Response:
         """
-        List a organization member's custom views
+        List the current organization member's custom views
         `````````````````````````````````````````
 
-        Retrieve a list of custom views for a given organization member.
+        Retrieve a list of custom views for the current organization member.
         """
+        if not features.has("organizations:issue-stream-custom-views", organization):
+            return Response(status=status.HTTP_405_METHOD_NOT_ALLOWED)
 
         query = GroupSearchView.objects.filter(organization=organization, user_id=request.user.id)
 

--- a/src/sentry/issues/endpoints/organization_group_search_views.py
+++ b/src/sentry/issues/endpoints/organization_group_search_views.py
@@ -14,7 +14,6 @@ from sentry.models.organization import Organization
 class MemberPermission(OrganizationPermission):
     scope_map = {
         "GET": ["member:read", "member:write"],
-        "PUT": ["member:read", "member:write"],
     }
 
 
@@ -22,7 +21,6 @@ class MemberPermission(OrganizationPermission):
 class OrganizationGroupSearchViewsEndpoint(OrganizationEndpoint):
     publish_status = {
         "GET": ApiPublishStatus.EXPERIMENTAL,
-        "POST": ApiPublishStatus.EXPERIMENTAL,
     }
     owner = ApiOwner.ISSUES
     permission_classes = (MemberPermission,)

--- a/src/sentry/models/savedsearch.py
+++ b/src/sentry/models/savedsearch.py
@@ -1,4 +1,5 @@
-from typing import Any
+from enum import StrEnum
+from typing import Any, Literal
 
 from django.db import models
 from django.db.models import Q, UniqueConstraint
@@ -14,7 +15,7 @@ from sentry.db.models.fields.text import CharField
 from sentry.models.search_common import SearchType
 
 
-class SortOptions:
+class SortOptions(StrEnum):
     DATE = "date"
     NEW = "new"
     TRENDS = "trends"
@@ -32,6 +33,9 @@ class SortOptions:
             (cls.USER, _("Users")),
             (cls.INBOX, _("Date Added")),
         )
+
+
+SORT_LITERALS = Literal["date", "new", "trends", "freq", "user", "inbox"]
 
 
 class Visibility:

--- a/tests/sentry/issues/endpoints/test_organization_group_search_views.py
+++ b/tests/sentry/issues/endpoints/test_organization_group_search_views.py
@@ -1,6 +1,7 @@
 from sentry.api.serializers.base import serialize
 from sentry.models.groupsearchview import GroupSearchView
 from sentry.testutils.cases import APITestCase
+from sentry.testutils.helpers.features import with_feature
 
 
 class OrganizationGroupSearchViewsTest(APITestCase):
@@ -68,6 +69,7 @@ class OrganizationGroupSearchViewsTest(APITestCase):
             "user_two_views": [first_custom_view_user_two, second_custom_view_user_two],
         }
 
+    @with_feature({"organizations:issue-stream-custom-views": True})
     def test_get_user_one_custom_views(self):
         objs = self.create_base_data()
 
@@ -76,6 +78,7 @@ class OrganizationGroupSearchViewsTest(APITestCase):
 
         assert response.data == serialize(objs["user_one_views"])
 
+    @with_feature({"organizations:issue-stream-custom-views": True})
     def test_get_user_two_custom_views(self):
         objs = self.create_base_data()
 

--- a/tests/sentry/issues/endpoints/test_organization_group_search_views.py
+++ b/tests/sentry/issues/endpoints/test_organization_group_search_views.py
@@ -5,6 +5,7 @@ from sentry.testutils.cases import APITestCase
 
 class OrganizationGroupSearchViewsTest(APITestCase):
     endpoint = "sentry-api-0-organization-group-search-views"
+    method = "get"
 
     def create_base_data(self):
         user_1 = self.user

--- a/tests/sentry/issues/endpoints/test_organization_group_search_views.py
+++ b/tests/sentry/issues/endpoints/test_organization_group_search_views.py
@@ -9,9 +9,9 @@ class OrganizationGroupSearchViewsTest(APITestCase):
 
     def create_base_data(self):
         user_1 = self.user
-        user_2 = self.create_user()
+        self.user_2 = self.create_user()
 
-        self.user_2 = self.create_member(organization=self.organization, user=user_2)
+        self.create_member(organization=self.organization, user=self.user_2)
 
         first_custom_view_user_one = GroupSearchView.objects.create(
             name="Custom View One",
@@ -71,7 +71,7 @@ class OrganizationGroupSearchViewsTest(APITestCase):
     def test_get_user_one_custom_views(self):
         objs = self.create_base_data()
 
-        self.login_as(self.user)
+        self.login_as(user=self.user)
         response = self.get_success_response(self.organization.slug)
 
         assert response.data == serialize(objs["user_one_views"])
@@ -79,7 +79,7 @@ class OrganizationGroupSearchViewsTest(APITestCase):
     def test_get_user_two_custom_views(self):
         objs = self.create_base_data()
 
-        self.login_as(self.user_2)
+        self.login_as(user=self.user_2)
         response = self.get_success_response(self.organization.slug)
 
         assert response.data == serialize(objs["user_two_views"])


### PR DESCRIPTION
This endpoint creates the `GET` `organizations/<org_id_or_slug>/group-search-views/` Endpoint along with some tests. This endpoint will be responsible for fetching a user's custom views within an organization. 

⚠️ This PR is dependent on #71731  being ~~merged~~ run in production, and this branch will need to be rebased upon that happening