### PR TITLE
feat(query-builder): Add alias for the 'is' key

### DIFF
--- a/static/app/components/searchQueryBuilder/filter.tsx
+++ b/static/app/components/searchQueryBuilder/filter.tsx
@@ -11,6 +11,7 @@ import {useSearchQueryBuilder} from 'sentry/components/searchQueryBuilder/contex
 import {useQueryBuilderGridItem} from 'sentry/components/searchQueryBuilder/useQueryBuilderGridItem';
 import {
   formatFilterValue,
+  getKeyLabel,
   getValidOpsForFilter,
 } from 'sentry/components/searchQueryBuilder/utils';
 import {SearchQueryBuilderValueCombobox} from 'sentry/components/searchQueryBuilder/valueCombobox';
@@ -99,7 +100,10 @@ function FilterOperator({token, state, item}: SearchQueryTokenProps) {
 }
 
 function FilterKey({token, state, item}: SearchQueryTokenProps) {
-  const label = token.key.text;
+  const {keys} = useSearchQueryBuilder();
+  const key = token.key.text;
+  const tag = keys[key];
+  const label = tag ? getKeyLabel(tag) : key;
 
   const filterButtonProps = useFilterButtonProps({state, item});
   // TODO(malwilley): Add edit functionality

--- a/static/app/components/searchQueryBuilder/index.spec.tsx
+++ b/static/app/components/searchQueryBuilder/index.spec.tsx
@@ -49,6 +49,12 @@ const MOCK_SUPPORTED_KEYS: TagCollection = {
     predefined: true,
     values: ['Chrome', 'Firefox', 'Safari', 'Edge'],
   },
+  [FieldKey.IS]: {
+    key: FieldKey.IS,
+    name: 'is',
+    alias: 'status',
+    predefined: true,
+  },
   custom_tag_name: {key: 'custom_tag_name', name: 'Custom_Tag_Name', kind: FieldKind.TAG},
 };
 
@@ -98,6 +104,33 @@ describe('SearchQueryBuilder', function () {
       await waitFor(() => {
         expect(mockOnBlur).toHaveBeenCalledWith('foo');
       });
+    });
+  });
+
+  describe('filter key aliases', function () {
+    it('displays the key alias instead of the actual value', async function () {
+      render(<SearchQueryBuilder {...defaultProps} initialQuery="is:resolved" />);
+
+      expect(
+        await screen.findByRole('button', {name: 'Edit filter key: status'})
+      ).toBeInTheDocument();
+    });
+
+    it('when adding a filter by typing, replaces aliases tokens', async function () {
+      const mockOnChange = jest.fn();
+      render(
+        <SearchQueryBuilder {...defaultProps} initialQuery="" onChange={mockOnChange} />
+      );
+
+      await userEvent.click(screen.getByRole('grid'));
+      await userEvent.keyboard('status:');
+
+      // Component should display alias `status`
+      expect(
+        await screen.findByRole('button', {name: 'Edit filter key: status'})
+      ).toBeInTheDocument();
+      // Query should use the actual key `is`
+      expect(mockOnChange).toHaveBeenCalledWith('is:');
     });
   });
 

--- a/static/app/components/searchQueryBuilder/utils.tsx
+++ b/static/app/components/searchQueryBuilder/utils.tsx
@@ -12,6 +12,7 @@ import {
   Token,
   type TokenResult,
 } from 'sentry/components/searchSyntax/parser';
+import type {Tag} from 'sentry/types';
 import {escapeDoubleQuotes} from 'sentry/utils';
 
 export const INTERFACE_TYPE_LOCALSTORAGE_KEY = 'search-query-builder-interface';
@@ -38,6 +39,10 @@ const isSimpleTextToken = (
 ): token is TokenResult<Token.FREE_TEXT> | TokenResult<Token.SPACES> => {
   return [Token.FREE_TEXT, Token.SPACES].includes(token.type);
 };
+
+export function getKeyLabel(key: Tag) {
+  return key.alias ?? key.key;
+}
 
 /**
  * Collapse adjacent FREE_TEXT and SPACES tokens into a single token.

--- a/static/app/stores/tagStore.tsx
+++ b/static/app/stores/tagStore.tsx
@@ -56,6 +56,7 @@ const storeConfig: TagStoreDefinition = {
 
     const tagCollection = {
       [FieldKey.IS]: {
+        alias: 'issue.status',
         key: FieldKey.IS,
         name: 'Status',
         values: isSuggestions,

--- a/static/app/types/group.tsx
+++ b/static/app/types/group.tsx
@@ -236,6 +236,7 @@ export type EventAttachment = IssueAttachment;
 export type Tag = {
   key: string;
   name: string;
+  alias?: string;
 
   isInput?: boolean;
 


### PR DESCRIPTION
- Displays `is` as `issue.status` so that we aren't showing `is is unresolved`. It also describes the key a bit better and places it next to other similar fields like issue.priority in the dropdown. 
- Still accepts `is:` as before if typed manually
- Translates `issue.status` to `is:` if typed manually

This does have some downsides:
- Users are currently used to using `is`
- The actual backend query being `is:` could be confusing (but we could modify the backend to support `issue.status` also) 

This is the best solution I have so far, but will accept others

Before:

![CleanShot 2024-06-03 at 13 50 12](https://github.com/getsentry/sentry/assets/10888943/877ab261-0edf-4852-b7f7-e2680d868fb3)


After:

![CleanShot 2024-06-03 at 14 08 55](https://github.com/getsentry/sentry/assets/10888943/2ce7f39e-6e35-4387-a7a5-65c779536a3d)

![CleanShot 2024-06-03 at 14 09 42](https://github.com/getsentry/sentry/assets/10888943/82768615-f857-4a76-a657-14695403166e)

