### PR TITLE
ref(js): Introduce ProjectContext to replace project legacy context

### DIFF
--- a/static/app/components/acl/feature.spec.tsx
+++ b/static/app/components/acl/feature.spec.tsx
@@ -1,13 +1,13 @@
 import {ConfigFixture} from 'sentry-fixture/config';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {ProjectFixture} from 'sentry-fixture/project';
-import {RouterContextFixture} from 'sentry-fixture/routerContextFixture';
 
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
 import Feature from 'sentry/components/acl/feature';
 import ConfigStore from 'sentry/stores/configStore';
 import HookStore from 'sentry/stores/hookStore';
+import {ProjectContext} from 'sentry/views/projects/projectContext';
 
 describe('Feature', function () {
   const organization = OrganizationFixture({
@@ -16,7 +16,14 @@ describe('Feature', function () {
   const project = ProjectFixture({
     features: ['project-foo', 'project-bar'],
   });
-  const routerContext = RouterContextFixture([{project}]);
+
+  function WrappedFeature(props: React.ComponentProps<typeof Feature>) {
+    return (
+      <ProjectContext.Provider value={project}>
+        <Feature {...props} />
+      </ProjectContext.Provider>
+    );
+  }
 
   describe('as render prop', function () {
     const childrenMock = jest.fn().mockReturnValue(null);
@@ -27,8 +34,7 @@ describe('Feature', function () {
     it('has features', function () {
       const features = ['org-foo', 'project-foo'];
 
-      render(<Feature features={features}>{childrenMock}</Feature>, {
-        context: routerContext,
+      render(<WrappedFeature features={features}>{childrenMock}</WrappedFeature>, {
         organization,
       });
 
@@ -45,10 +51,10 @@ describe('Feature', function () {
       const features = ['org-foo', 'project-foo', 'apple'];
 
       render(
-        <Feature features={features} requireAll={false}>
+        <WrappedFeature features={features} requireAll={false}>
           {childrenMock}
-        </Feature>,
-        {context: routerContext, organization}
+        </WrappedFeature>,
+        {organization}
       );
 
       expect(childrenMock).toHaveBeenCalledWith({
@@ -61,8 +67,7 @@ describe('Feature', function () {
     });
 
     it('has no features', function () {
-      render(<Feature features="org-baz">{childrenMock}</Feature>, {
-        context: routerContext,
+      render(<WrappedFeature features="org-baz">{childrenMock}</WrappedFeature>, {
         organization,
       });
 
@@ -78,10 +83,10 @@ describe('Feature', function () {
     it('calls render function when no features', function () {
       const noFeatureRenderer = jest.fn(() => null);
       render(
-        <Feature features="org-baz" renderDisabled={noFeatureRenderer}>
+        <WrappedFeature features="org-baz" renderDisabled={noFeatureRenderer}>
           {childrenMock}
-        </Feature>,
-        {context: routerContext, organization}
+        </WrappedFeature>,
+        {organization}
       );
 
       expect(childrenMock).not.toHaveBeenCalled();
@@ -97,10 +102,10 @@ describe('Feature', function () {
     it('can specify org from props', function () {
       const customOrg = OrganizationFixture({features: ['org-bazar']});
       render(
-        <Feature organization={customOrg} features="org-bazar">
+        <WrappedFeature organization={customOrg} features="org-bazar">
           {childrenMock}
-        </Feature>,
-        {context: routerContext, organization}
+        </WrappedFeature>,
+        {organization}
       );
 
       expect(childrenMock).toHaveBeenCalledWith({
@@ -115,10 +120,10 @@ describe('Feature', function () {
     it('can specify project from props', function () {
       const customProject = ProjectFixture({features: ['project-baz']});
       render(
-        <Feature project={customProject} features="project-baz">
+        <WrappedFeature project={customProject} features="project-baz">
           {childrenMock}
-        </Feature>,
-        {context: routerContext, organization}
+        </WrappedFeature>,
+        {organization}
       );
 
       expect(childrenMock).toHaveBeenCalledWith({
@@ -132,8 +137,7 @@ describe('Feature', function () {
 
     it('handles no org/project', function () {
       const features = ['org-foo', 'project-foo'];
-      render(<Feature features={features}>{childrenMock}</Feature>, {
-        context: routerContext,
+      render(<WrappedFeature features={features}>{childrenMock}</WrappedFeature>, {
         organization,
       });
 
@@ -149,10 +153,12 @@ describe('Feature', function () {
     });
 
     it('handles features prefixed with org/project', function () {
-      render(<Feature features="organizations:org-bar">{childrenMock}</Feature>, {
-        context: routerContext,
-        organization,
-      });
+      render(
+        <WrappedFeature features="organizations:org-bar">{childrenMock}</WrappedFeature>,
+        {
+          organization,
+        }
+      );
 
       expect(childrenMock).toHaveBeenCalledWith({
         hasFeature: true,
@@ -162,8 +168,7 @@ describe('Feature', function () {
         renderDisabled: false,
       });
 
-      render(<Feature features="projects:bar">{childrenMock}</Feature>, {
-        context: routerContext,
+      render(<WrappedFeature features="projects:bar">{childrenMock}</WrappedFeature>, {
         organization,
       });
 
@@ -181,10 +186,12 @@ describe('Feature', function () {
         features: new Set(['organizations:create']),
       });
 
-      render(<Feature features="organizations:create">{childrenMock}</Feature>, {
-        context: routerContext,
-        organization,
-      });
+      render(
+        <WrappedFeature features="organizations:create">{childrenMock}</WrappedFeature>,
+        {
+          organization,
+        }
+      );
 
       expect(childrenMock).toHaveBeenCalledWith({
         hasFeature: true,
@@ -199,20 +206,20 @@ describe('Feature', function () {
   describe('no children', function () {
     it('should display renderDisabled with no feature', function () {
       render(
-        <Feature features="nope" renderDisabled={() => <span>disabled</span>}>
+        <WrappedFeature features="nope" renderDisabled={() => <span>disabled</span>}>
           <div>The Child</div>
-        </Feature>,
-        {context: routerContext, organization}
+        </WrappedFeature>,
+        {organization}
       );
       expect(screen.getByText('disabled')).toBeInTheDocument();
     });
 
     it('should display be empty when on', function () {
       render(
-        <Feature features="org-bar" renderDisabled={() => <span>disabled</span>}>
+        <WrappedFeature features="org-bar" renderDisabled={() => <span>disabled</span>}>
           <div>The Child</div>
-        </Feature>,
-        {context: routerContext, organization}
+        </WrappedFeature>,
+        {organization}
       );
       expect(screen.queryByText('disabled')).not.toBeInTheDocument();
     });
@@ -221,10 +228,10 @@ describe('Feature', function () {
   describe('as React node', function () {
     it('has features', function () {
       render(
-        <Feature features="org-bar">
+        <WrappedFeature features="org-bar">
           <div>The Child</div>
-        </Feature>,
-        {context: routerContext, organization}
+        </WrappedFeature>,
+        {organization}
       );
 
       expect(screen.getByText('The Child')).toBeInTheDocument();
@@ -232,10 +239,10 @@ describe('Feature', function () {
 
     it('has no features', function () {
       render(
-        <Feature features="org-baz">
+        <WrappedFeature features="org-baz">
           <div>The Child</div>
-        </Feature>,
-        {context: routerContext, organization}
+        </WrappedFeature>,
+        {organization}
       );
 
       expect(screen.queryByText('The Child')).not.toBeInTheDocument();
@@ -243,10 +250,10 @@ describe('Feature', function () {
 
     it('renders a default disabled component', function () {
       render(
-        <Feature features="org-baz" renderDisabled>
+        <WrappedFeature features="org-baz" renderDisabled>
           <div>The Child</div>
-        </Feature>,
-        {context: routerContext, organization}
+        </WrappedFeature>,
+        {organization}
       );
 
       expect(screen.getByText('This feature is coming soon!')).toBeInTheDocument();
@@ -257,10 +264,10 @@ describe('Feature', function () {
       const noFeatureRenderer = jest.fn(() => null);
       const children = <div>The Child</div>;
       render(
-        <Feature features="org-baz" renderDisabled={noFeatureRenderer}>
+        <WrappedFeature features="org-baz" renderDisabled={noFeatureRenderer}>
           {children}
-        </Feature>,
-        {context: routerContext, organization}
+        </WrappedFeature>,
+        {organization}
       );
 
       expect(screen.queryByText('The Child')).not.toBeInTheDocument();
@@ -290,10 +297,10 @@ describe('Feature', function () {
     it('uses hookName if provided', function () {
       const children = <div>The Child</div>;
       render(
-        <Feature features="org-bazar" hookName="feature-disabled:sso-basic">
+        <WrappedFeature features="org-bazar" hookName="feature-disabled:sso-basic">
           {children}
-        </Feature>,
-        {context: routerContext, organization}
+        </WrappedFeature>,
+        {organization}
       );
 
       expect(screen.queryByText('The Child')).not.toBeInTheDocument();

--- a/static/app/sentryPropTypeValidators.tsx
+++ b/static/app/sentryPropTypeValidators.tsx
@@ -1,7 +1,5 @@
 import type {Avatar} from 'sentry/types/core';
 import type {Group} from 'sentry/types/group';
-import type {Team} from 'sentry/types/organization';
-import type {Project} from 'sentry/types/project';
 import type {User, UserEmail} from 'sentry/types/user';
 
 /**
@@ -276,81 +274,6 @@ function isGroup(
 /**
  * @deprecated
  */
-function isTeamShape(team: unknown) {
-  if (typeof team !== 'object' || team === null) {
-    return new Error('Team has to be of object type');
-  }
-
-  const maybeTeamShape = team as Partial<Team>;
-  if (!('id' in maybeTeamShape) || typeof maybeTeamShape.id !== 'string') {
-    return new Error(`id must be string.`);
-  }
-
-  if (!('slug' in maybeTeamShape) || typeof maybeTeamShape.slug !== 'string') {
-    return new Error(`slug must be string.`);
-  }
-
-  return null;
-}
-
-/**
- * @deprecated
- */
-function isProject(
-  props: unknown,
-  propName: string,
-  _componentName: unknown
-): null | Error {
-  if (typeof props !== 'object' || props === null) {
-    return new Error('props is not an object');
-  }
-
-  if (!(propName in props) || typeof props[propName] !== 'object') {
-    return null;
-  }
-
-  if (!props[propName]) {
-    return null;
-  }
-
-  const project = props[propName] as Partial<Project>;
-
-  if (
-    !('id' in project) ||
-    ('id' in project && typeof project.id !== 'string' && typeof project.id !== 'number')
-  ) {
-    return new Error(`id must be string or number.`);
-  }
-  if ('slug' in project && typeof project.slug !== 'string') {
-    return new Error('slug must be string');
-  }
-
-  if ('isBookmarked' in project && typeof project.isBookmarked !== 'boolean') {
-    return new Error('isBookmarked must be boolean');
-  }
-  if ('status' in project && typeof project.status !== 'string') {
-    return new Error('status must be string');
-  }
-
-  if ('teams' in project) {
-    if (!Array.isArray(project.teams)) {
-      return new Error('teams must be array');
-    }
-    if (!project.teams.every(t => isTeamShape(t) === null)) {
-      return new Error(`teams must be array of Team types.`);
-    }
-  }
-
-  if ('name' in project && typeof project.name !== 'string') {
-    return new Error('name must be string');
-  }
-
-  return null;
-}
-
-/**
- * @deprecated
- */
 function isObject(
   props: unknown,
   propName: string,
@@ -379,6 +302,5 @@ function isObject(
  */
 export const SentryPropTypeValidators = {
   isGroup,
-  isProject,
   isObject,
 };

--- a/static/app/utils/withProject.tsx
+++ b/static/app/utils/withProject.tsx
@@ -1,36 +1,27 @@
-import {Component} from 'react';
+import {useContext} from 'react';
 
-import {SentryPropTypeValidators} from 'sentry/sentryPropTypeValidators';
 import type {Project} from 'sentry/types/project';
 import getDisplayName from 'sentry/utils/getDisplayName';
+import {ProjectContext} from 'sentry/views/projects/projectContext';
 
 type InjectedProjectProps = {
   project?: Project;
 };
 
-/**
- * Currently wraps component with project from context
- */
-const withProject = <P extends InjectedProjectProps>(
+function withProject<P extends InjectedProjectProps>(
   WrappedComponent: React.ComponentType<P>
-) =>
-  class extends Component<
-    Omit<P, keyof InjectedProjectProps> & Partial<InjectedProjectProps>
-  > {
-    static displayName = `withProject(${getDisplayName(WrappedComponent)})`;
-    static contextTypes = {
-      project: SentryPropTypeValidators.isProject,
-    };
-    declare context: {project: Project};
+) {
+  type Props = Omit<P, keyof InjectedProjectProps> & Partial<InjectedProjectProps>;
 
-    render() {
-      const {project, ...props} = this.props;
-      return (
-        <WrappedComponent
-          {...({project: project ?? this.context.project, ...props} as P)}
-        />
-      );
-    }
-  };
+  function Wrapper(props: Props) {
+    const project = useContext(ProjectContext);
+
+    return <WrappedComponent project={project} {...(props as P)} />;
+  }
+
+  Wrapper.displayName = `withProject(${getDisplayName(WrappedComponent)})`;
+
+  return Wrapper;
+}
 
 export default withProject;

--- a/static/app/views/performance/vitalDetail/index.spec.tsx
+++ b/static/app/views/performance/vitalDetail/index.spec.tsx
@@ -27,7 +27,6 @@ const {
   routerContext,
   organization: org,
   router,
-  project,
 } = initializeOrg({
   organization,
   router: {
@@ -282,7 +281,6 @@ describe('Performance > VitalDetail', function () {
 
     const context = RouterContextFixture([
       {
-        project,
         router: newRouter,
         location: newRouter.location,
       },
@@ -335,7 +333,6 @@ describe('Performance > VitalDetail', function () {
 
     const context = RouterContextFixture([
       {
-        project,
         router: newRouter,
         location: newRouter.location,
       },
@@ -389,7 +386,6 @@ describe('Performance > VitalDetail', function () {
 
     const context = RouterContextFixture([
       {
-        project,
         router: newRouter,
         location: newRouter.location,
       },

--- a/static/app/views/projects/projectContext.spec.tsx
+++ b/static/app/views/projects/projectContext.spec.tsx
@@ -3,7 +3,7 @@ import {ProjectFixture} from 'sentry-fixture/project';
 
 import {render, screen, waitFor} from 'sentry-test/reactTestingLibrary';
 
-import {ProjectContext} from 'sentry/views/projects/projectContext';
+import {ProjectContextProvider} from 'sentry/views/projects/projectContext';
 
 jest.unmock('sentry/utils/recreateRoute');
 jest.mock('sentry/actionCreators/modal', () => ({
@@ -38,7 +38,7 @@ describe('projectContext component', function () {
     });
 
     const projectContext = (
-      <ProjectContext
+      <ProjectContextProvider
         api={new MockApiClient()}
         loadingProjects={false}
         projects={[]}
@@ -46,7 +46,7 @@ describe('projectContext component', function () {
         projectSlug={project.slug}
       >
         {null}
-      </ProjectContext>
+      </ProjectContextProvider>
     );
 
     render(projectContext);
@@ -69,7 +69,7 @@ describe('projectContext component', function () {
     });
 
     const projectContext = (
-      <ProjectContext
+      <ProjectContextProvider
         api={new MockApiClient()}
         projects={[]}
         loadingProjects={false}
@@ -77,7 +77,7 @@ describe('projectContext component', function () {
         projectSlug={project.slug}
       >
         {null}
-      </ProjectContext>
+      </ProjectContextProvider>
     );
 
     const {rerender} = render(projectContext);
@@ -96,7 +96,7 @@ describe('projectContext component', function () {
     });
 
     rerender(
-      <ProjectContext
+      <ProjectContextProvider
         api={new MockApiClient()}
         projects={[]}
         loadingProjects={false}
@@ -104,7 +104,7 @@ describe('projectContext component', function () {
         projectSlug="new-slug"
       >
         {null}
-      </ProjectContext>
+      </ProjectContextProvider>
     );
 
     expect(fetchMock).toHaveBeenCalled();
@@ -119,7 +119,7 @@ describe('projectContext component', function () {
     });
 
     const projectContext = (
-      <ProjectContext
+      <ProjectContextProvider
         api={new MockApiClient()}
         loadingProjects={false}
         projects={[]}
@@ -127,7 +127,7 @@ describe('projectContext component', function () {
         projectSlug={project.slug}
       >
         {null}
-      </ProjectContext>
+      </ProjectContextProvider>
     );
 
     const {rerender} = render(projectContext);
@@ -143,7 +143,7 @@ describe('projectContext component', function () {
     });
 
     rerender(
-      <ProjectContext
+      <ProjectContextProvider
         organization={org}
         loadingProjects={false}
         api={new MockApiClient()}
@@ -151,7 +151,7 @@ describe('projectContext component', function () {
         projectSlug={project.slug}
       >
         {null}
-      </ProjectContext>
+      </ProjectContextProvider>
     );
 
     await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));

--- a/static/app/views/projects/projectContext.tsx
+++ b/static/app/views/projects/projectContext.tsx
@@ -1,4 +1,4 @@
-import {Component} from 'react';
+import {Component, createContext} from 'react';
 import styled from '@emotion/styled';
 
 import {fetchOrgMembers} from 'sentry/actionCreators/members';
@@ -11,7 +11,6 @@ import LoadingIndicator from 'sentry/components/loadingIndicator';
 import MissingProjectMembership from 'sentry/components/projects/missingProjectMembership';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import {t} from 'sentry/locale';
-import {SentryPropTypeValidators} from 'sentry/sentryPropTypeValidators';
 import MemberListStore from 'sentry/stores/memberListStore';
 import ProjectsStore from 'sentry/stores/projectsStore';
 import {space} from 'sentry/styles/space';
@@ -51,6 +50,8 @@ type State = {
   project: Project | null;
 };
 
+const ProjectContext = createContext<Project | null>(null);
+
 /**
  * Higher-order component that sets `project` as a child context
  * value to be accessed by child elements.
@@ -58,11 +59,7 @@ type State = {
  * Additionally delays rendering of children until project XHR has finished
  * and context is populated.
  */
-class ProjectContext extends Component<Props, State> {
-  static childContextTypes = {
-    project: SentryPropTypeValidators.isProject,
-  };
-
+class ProjectContextProvider extends Component<Props, State> {
   state = this.getInitialState();
 
   getInitialState(): State {
@@ -72,12 +69,6 @@ class ProjectContext extends Component<Props, State> {
       errorType: null,
       memberList: [],
       project: null,
-    };
-  }
-
-  getChildContext() {
-    return {
-      project: this.state.project,
     };
   }
 
@@ -240,7 +231,11 @@ class ProjectContext extends Component<Props, State> {
     }
 
     if (!error && project) {
-      return typeof children === 'function' ? children({project}) : children;
+      return (
+        <ProjectContext.Provider value={project}>
+          {typeof children === 'function' ? children({project}) : children}
+        </ProjectContext.Provider>
+      );
     }
 
     switch (errorType) {
@@ -275,9 +270,9 @@ class ProjectContext extends Component<Props, State> {
   }
 }
 
-export {ProjectContext};
+export {ProjectContext, ProjectContextProvider};
 
-export default withApi(withOrganization(withProjects(ProjectContext)));
+export default withApi(withOrganization(withProjects(ProjectContextProvider)));
 
 const ErrorWrapper = styled('div')`
   width: 100%;

--- a/static/app/views/settings/projectGeneralSettings/index.spec.tsx
+++ b/static/app/views/settings/projectGeneralSettings/index.spec.tsx
@@ -18,7 +18,7 @@ import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicato
 import {removePageFiltersStorage} from 'sentry/components/organizations/pageFilters/persistence';
 import ProjectsStore from 'sentry/stores/projectsStore';
 import {browserHistory} from 'sentry/utils/browserHistory';
-import ProjectContext from 'sentry/views/projects/projectContext';
+import ProjectContextProvider from 'sentry/views/projects/projectContext';
 import ProjectGeneralSettings from 'sentry/views/settings/projectGeneralSettings';
 
 jest.mock('sentry/actionCreators/indicator');
@@ -256,14 +256,14 @@ describe('projectGeneralSettings', function () {
     });
 
     render(
-      <ProjectContext projectSlug={project.slug}>
+      <ProjectContextProvider projectSlug={project.slug}>
         <ProjectGeneralSettings
           {...routerProps}
           routes={[]}
           location={LocationFixture()}
           params={params}
         />
-      </ProjectContext>,
+      </ProjectContextProvider>,
       {organization}
     );
 
@@ -290,14 +290,14 @@ describe('projectGeneralSettings', function () {
     });
 
     render(
-      <ProjectContext projectSlug={project.slug}>
+      <ProjectContextProvider projectSlug={project.slug}>
         <ProjectGeneralSettings
           {...routerProps}
           routes={[]}
           location={LocationFixture()}
           params={params}
         />
-      </ProjectContext>,
+      </ProjectContextProvider>,
       {organization}
     );
 
@@ -334,14 +334,14 @@ describe('projectGeneralSettings', function () {
     function renderProjectGeneralSettings() {
       const params = {projectId: project.slug};
       render(
-        <ProjectContext projectSlug={project.slug}>
+        <ProjectContextProvider projectSlug={project.slug}>
           <ProjectGeneralSettings
             {...routerProps}
             routes={[]}
             location={LocationFixture()}
             params={params}
           />
-        </ProjectContext>,
+        </ProjectContextProvider>,
         {organization}
       );
     }

--- a/tests/js/fixtures/routerContextFixture.ts
+++ b/tests/js/fixtures/routerContextFixture.ts
@@ -1,5 +1,4 @@
 import {LocationFixture} from 'sentry-fixture/locationFixture';
-import {ProjectFixture} from 'sentry-fixture/project';
 import {RouterFixture} from 'sentry-fixture/routerFixture';
 
 import {SentryPropTypeValidators} from 'sentry/sentryPropTypeValidators';
@@ -9,13 +8,11 @@ export function RouterContextFixture([context, childContextTypes] = []) {
     context: {
       location: LocationFixture(),
       router: RouterFixture(),
-      project: ProjectFixture(),
       ...context,
     },
     childContextTypes: {
       router: SentryPropTypeValidators.isObject,
       location: SentryPropTypeValidators.isObject,
-      project: SentryPropTypeValidators.isObject,
       ...childContextTypes,
     },
   };

--- a/tests/js/sentry-test/initializeOrg.tsx
+++ b/tests/js/sentry-test/initializeOrg.tsx
@@ -67,7 +67,6 @@ export function initializeOrg<RouterParams = {orgId: string; projectId: string}>
 
   const routerContext: any = RouterContextFixture([
     {
-      project,
       router,
       location: router.location,
     },


### PR DESCRIPTION
This kills one of the last few legacy context's