### PR TITLE
feat(crons): Add analytics for tracking processing error

### DIFF
--- a/src/sentry/analytics/events/__init__.py
+++ b/src/sentry/analytics/events/__init__.py
@@ -6,6 +6,7 @@ from .alert_rule_ui_component_webhook_sent import *  # noqa: F401,F403
 from .alert_sent import *  # noqa: F401,F403
 from .api_token_created import *  # noqa: F401,F403
 from .api_token_deleted import *  # noqa: F401,F403
+from .checkin_processing_error_stored import *  # noqa: F401,F403
 from .codeowners_assignment import *  # noqa: F401,F403
 from .codeowners_created import *  # noqa: F401,F403
 from .codeowners_updated import *  # noqa: F401,F403

--- a/src/sentry/analytics/events/checkin_processing_error_stored.py
+++ b/src/sentry/analytics/events/checkin_processing_error_stored.py
@@ -1,0 +1,15 @@
+from sentry import analytics
+
+
+class CheckinProcessingErrorStored(analytics.Event):
+    type = "checkin_processing_error.stored"
+
+    attributes = (
+        analytics.Attribute("organization_id"),
+        analytics.Attribute("project_id"),
+        analytics.Attribute("monitor_slug"),
+        analytics.Attribute("error_types", type=list),
+    )
+
+
+analytics.register(CheckinProcessingErrorStored)


### PR DESCRIPTION
Adds analytics event to track when a processing error is stored, will be useful for verifying processing errors as we roll out this feature to new orgs

to be used in: https://github.com/getsentry/sentry/pull/71952