### PR TITLE
feat(crons): Instrument processing error storage with analytics

### DIFF
--- a/src/sentry/monitors/processing_errors/manager.py
+++ b/src/sentry/monitors/processing_errors/manager.py
@@ -9,7 +9,7 @@ from django.conf import settings
 from redis.client import StrictRedis
 from rediscluster import RedisCluster
 
-from sentry import features
+from sentry import analytics, features
 from sentry.models.organization import Organization
 from sentry.models.project import Project
 from sentry.monitors.models import Monitor
@@ -177,6 +177,13 @@ def handle_processing_errors(item: CheckinItem, error: ProcessingErrorsException
                 "source": "consumer",
                 "sdk_platform": item.message["sdk"],
             },
+        )
+        analytics.record(
+            "checkin_processing_error.stored",
+            organization_id=organization.id,
+            project_id=project.id,
+            monitor_slug=item.payload["monitor_slug"],
+            error_types=[process_error["type"] for process_error in error.processing_errors],
         )
 
         checkin_processing_error = CheckinProcessingError(error.processing_errors, item)

--- a/tests/sentry/monitors/processing_errors/test_manager.py
+++ b/tests/sentry/monitors/processing_errors/test_manager.py
@@ -206,7 +206,8 @@ class CheckinProcessErrorsManagerTest(TestCase):
 
 
 class HandleProcessingErrorsTest(TestCase):
-    def test(self):
+    @mock.patch("sentry.analytics.record")
+    def test(self, mock_record):
         monitor = self.create_monitor()
         exception = ProcessingErrorsException(
             [{"type": ProcessingErrorType.CHECKIN_INVALID_GUID}],
@@ -224,8 +225,17 @@ class HandleProcessingErrorsTest(TestCase):
             handle_processing_errors(
                 build_checkin_item(
                     message_overrides={"project_id": self.project.id},
+                    payload_overrides={"monitor_slug": monitor.slug},
                 ),
                 exception,
             )
         errors = get_errors_for_monitor(monitor)
         assert len(errors) == 1
+
+        mock_record.assert_called_with(
+            "checkin_processing_error.stored",
+            organization_id=self.organization.id,
+            project_id=self.project.id,
+            monitor_slug=monitor.slug,
+            error_types=[ProcessingErrorType.CHECKIN_INVALID_GUID],
+        )


### PR DESCRIPTION
Records an analytics event to track when a processing error is stored, will be useful for verifying processing errors as we roll out this feature to new orgs

depends on https://github.com/getsentry/sentry/pull/71951