### PR TITLE
chore(api): Publish change team role endpoint

### DIFF
--- a/src/sentry/api/endpoints/organization_member/team_details.py
+++ b/src/sentry/api/endpoints/organization_member/team_details.py
@@ -64,7 +64,7 @@ class OrganizationMemberTeamDetailsSerializer(Serializer):
     ) -> OrganizationMemberTeamSerializerResponse:
         return {
             "isActive": obj.is_active,
-            "teamRole": obj.role,
+            "teamRole": obj.role,  # type:ignore[typeddict-item]
         }
 
 

--- a/src/sentry/api/endpoints/organization_member/team_details.py
+++ b/src/sentry/api/endpoints/organization_member/team_details.py
@@ -1,7 +1,7 @@
-from collections.abc import Mapping, MutableMapping
-from typing import Any
+from collections.abc import Mapping
+from typing import Any, Literal, TypedDict
 
-from drf_spectacular.utils import OpenApiResponse, extend_schema
+from drf_spectacular.utils import OpenApiResponse, extend_schema, extend_schema_serializer
 from rest_framework import serializers, status
 from rest_framework.exceptions import ValidationError
 from rest_framework.request import Request
@@ -41,15 +41,27 @@ from . import can_admin_team, can_set_team_role
 ERR_INSUFFICIENT_ROLE = "You do not have permission to edit that user's membership."
 
 
+class OrganizationMemberTeamSerializerResponse(TypedDict):
+    isActive: bool
+    # This must be manually kept up to date, because we cannot dynamically
+    # unpack into static type annotations. See https://github.com/microsoft/pylance-release/issues/4084
+    teamRole: Literal["contributor", "admin"]
+
+
+@extend_schema_serializer(exclude_fields=["isActive"])
 class OrganizationMemberTeamSerializer(serializers.Serializer):
     isActive = serializers.BooleanField()
-    teamRole = serializers.CharField(allow_null=True, allow_blank=True)
+    teamRole = serializers.ChoiceField(
+        choices=team_roles.get_choices(),
+        default=team_roles.get_default().id,
+        help_text="The team-level role to switch to. Valid roles include:",  # choices will follow in the docs
+    )
 
 
 class OrganizationMemberTeamDetailsSerializer(Serializer):
     def serialize(
         self, obj: OrganizationMemberTeam, attrs: Mapping[Any, Any], user: Any, **kwargs: Any
-    ) -> MutableMapping[str, Any]:
+    ) -> OrganizationMemberTeamSerializerResponse:
         return {
             "isActive": obj.is_active,
             "teamRole": obj.role,
@@ -132,8 +144,8 @@ class OrganizationMemberTeamDetailsEndpoint(OrganizationMemberEndpoint):
 
     publish_status = {
         "DELETE": ApiPublishStatus.PUBLIC,
-        "GET": ApiPublishStatus.UNKNOWN,
-        "PUT": ApiPublishStatus.UNKNOWN,
+        "GET": ApiPublishStatus.PRIVATE,
+        "PUT": ApiPublishStatus.PUBLIC,
         "POST": ApiPublishStatus.PUBLIC,
     }
     owner = ApiOwner.ENTERPRISE
@@ -345,6 +357,21 @@ class OrganizationMemberTeamDetailsEndpoint(OrganizationMemberEndpoint):
 
         return Response(serialize(team, request.user, TeamSerializer()), status=201)
 
+    @extend_schema(
+        operation_id="Update an Organization Member's Team Role",
+        parameters=[
+            GlobalParams.ORG_ID_OR_SLUG,
+            GlobalParams.member_id("The ID of the organization member to change"),
+            GlobalParams.TEAM_ID_OR_SLUG,
+        ],
+        request=OrganizationMemberTeamSerializer,
+        responses={
+            200: OrganizationMemberTeamDetailsSerializer,
+            400: RESPONSE_BAD_REQUEST,
+            404: RESPONSE_NOT_FOUND,
+        },
+        examples=TeamExamples.UPDATE_TEAM_ROLE,
+    )
     def put(
         self,
         request: Request,
@@ -352,7 +379,13 @@ class OrganizationMemberTeamDetailsEndpoint(OrganizationMemberEndpoint):
         member: OrganizationMember,
         team: Team,
     ) -> Response:
+        """
+        The relevant organization member must already be a part of the team.
 
+        Note that for organization admins, managers, and owners, they are
+        automatically granted a minimum team role of `admin` on all teams they
+        are part of. Read more about [team roles](https://docs.sentry.io/product/teams/roles/).
+        """
         try:
             omt = OrganizationMemberTeam.objects.get(team=team, organizationmember=member)
         except OrganizationMemberTeam.DoesNotExist:

--- a/src/sentry/apidocs/examples/team_examples.py
+++ b/src/sentry/apidocs/examples/team_examples.py
@@ -468,3 +468,15 @@ class TeamExamples:
             response_only=True,
         )
     ]
+
+    UPDATE_TEAM_ROLE = [
+        OpenApiExample(
+            "Update a Team Role",
+            value={
+                "isActive": True,
+                "teamRole": "admin",
+            },
+            status_codes=["200"],
+            response_only=True,
+        )
+    ]

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -2642,8 +2642,7 @@ SENTRY_TEAM_ROLES: tuple[RoleDict, ...] = (
             # TODO: Editing pass
             """
             Admin privileges on the team. They can create and remove projects,
-            and can manage the team's memberships. They cannot invite members to
-            the organization.
+            and can manage the team's memberships.
             """
         ),
         "scopes": {

--- a/src/sentry/roles/manager.py
+++ b/src/sentry/roles/manager.py
@@ -35,7 +35,7 @@ class Role(abc.ABC):
         cls: type[R],
         parent: RoleManager,
         priority: int,
-        desc: str = "",
+        desc: str,
         scopes: Iterable[str] = (),
         **kwargs: Any,
     ) -> R:
@@ -85,7 +85,7 @@ class RoleLevel(Generic[R]):
         self._priority_seq = tuple(sorted(roles, key=lambda r: r.priority))
         self._id_map = {r.id: r for r in self._priority_seq}
 
-        self._choices = tuple((r.id, r.name) for r in self._priority_seq)
+        self._choices = tuple((r.id, r.desc) for r in self._priority_seq)
         self._default = self._id_map[default_id] if default_id else self._priority_seq[0]
         self._top_dog = self._priority_seq[-1]
 
@@ -101,7 +101,7 @@ class RoleLevel(Generic[R]):
     def get_all(self) -> Sequence[R]:
         return self._priority_seq
 
-    def get_choices(self) -> Sequence[tuple[str, str]]:
+    def get_choices(self) -> tuple[tuple[str, str]]:
         return self._choices
 
     def get_default(self) -> R:

--- a/src/sentry/roles/manager.py
+++ b/src/sentry/roles/manager.py
@@ -101,7 +101,7 @@ class RoleLevel(Generic[R]):
     def get_all(self) -> Sequence[R]:
         return self._priority_seq
 
-    def get_choices(self) -> tuple[tuple[str, str]]:
+    def get_choices(self) -> Sequence[tuple[str, str]]:
         return self._choices
 
     def get_default(self) -> R:

--- a/tests/sentry/models/test_organizationmember.py
+++ b/tests/sentry/models/test_organizationmember.py
@@ -26,15 +26,20 @@ from sentry.testutils.silo import assume_test_silo_mode
 
 class MockOrganizationRoles:
     TEST_ORG_ROLES = [
-        {"id": "alice", "name": "Alice", "scopes": ["project:read", "project:write"]},
-        {"id": "bob", "name": "Bob", "scopes": ["project:read"]},
-        {"id": "carol", "name": "Carol", "scopes": ["project:write"]},
+        {
+            "id": "alice",
+            "name": "Alice",
+            "desc": "In Wonderland",
+            "scopes": ["project:read", "project:write"],
+        },
+        {"id": "bob", "name": "Bob", "desc": "The builder", "scopes": ["project:read"]},
+        {"id": "carol", "name": "Carol", "desc": "A nanny?", "scopes": ["project:write"]},
     ]
 
     TEST_TEAM_ROLES = [
-        {"id": "alice", "name": "Alice"},
-        {"id": "bob", "name": "Bob"},
-        {"id": "carol", "name": "Carol"},
+        {"id": "alice", "name": "Alice", "desc": "In Wonderland"},
+        {"id": "bob", "name": "Bob", "desc": "The builder"},
+        {"id": "carol", "name": "Carol", "desc": "A nanny?"},
     ]
 
     def __init__(self):
@@ -513,8 +518,9 @@ class OrganizationMemberTest(TestCase, HybridCloudTestMixin):
 
     def test_get_allowed_org_roles_to_invite_subset_logic(self):
         mock_org_roles = MockOrganizationRoles()
-        with patch("sentry.roles.organization_roles.get", mock_org_roles.get), patch(
-            "sentry.roles.organization_roles.get_all", mock_org_roles.get_all
+        with (
+            patch("sentry.roles.organization_roles.get", mock_org_roles.get),
+            patch("sentry.roles.organization_roles.get_all", mock_org_roles.get_all),
         ):
             alice = self.create_member(
                 user=self.create_user(), organization=self.organization, role="alice"

--- a/tests/sentry/roles/test_manager.py
+++ b/tests/sentry/roles/test_manager.py
@@ -25,18 +25,33 @@ class RoleManagerTest(TestCase):
         self._assert_minimum_team_role_is(default_manager, "owner", "admin")
 
     TEST_ORG_ROLES = [
-        {"id": "peasant", "name": "Peasant"},
-        {"id": "baron", "name": "Baron"},
-        {"id": "earl", "name": "Earl"},
-        {"id": "duke", "name": "Duke"},
-        {"id": "monarch", "name": "Monarch"},
+        {"id": "peasant", "name": "Peasant", "desc": "Poor farmer"},
+        {"id": "baron", "name": "Baron", "desc": "Lowest of nobility"},
+        {"id": "earl", "name": "Earl", "desc": "Middle of nobility"},
+        {"id": "duke", "name": "Duke", "desc": "Highest of nobility"},
+        {"id": "monarch", "name": "Monarch", "desc": "Ruler of all"},
     ]
 
     TEST_TEAM_ROLES = [
-        {"id": "private", "name": "Private", "is_minimum_role_for": "peasant"},
-        {"id": "sergeant", "name": "Sergeant", "is_minimum_role_for": "earl"},
-        {"id": "lieutenant", "name": "Lieutenant"},
-        {"id": "captain", "name": "Captain", "is_minimum_role_for": "monarch"},
+        {
+            "id": "private",
+            "name": "Private",
+            "is_minimum_role_for": "peasant",
+            "desc": "Lowest rank in the army",
+        },
+        {
+            "id": "sergeant",
+            "name": "Sergeant",
+            "is_minimum_role_for": "earl",
+            "desc": "Low officer class",
+        },
+        {"id": "lieutenant", "name": "Lieutenant", "desc": "Leads platoons and companies"},
+        {
+            "id": "captain",
+            "name": "Captain",
+            "is_minimum_role_for": "monarch",
+            "desc": "Commands big groups",
+        },
     ]
 
     def test_priority(self):
@@ -61,6 +76,14 @@ class RoleManagerTest(TestCase):
         self._assert_minimum_team_role_is(manager, "baron", "private")
         self._assert_minimum_team_role_is(manager, "peasant", "private")
 
+    def test_choices(self):
+        manager = RoleManager(self.TEST_ORG_ROLES, self.TEST_TEAM_ROLES)
+
+        assert manager.get_choices() == manager.organization_roles.get_choices()
+        assert manager.team_roles.get_choices() == tuple(
+            (role["id"], role["desc"]) for role in self.TEST_TEAM_ROLES
+        )
+
     def test_team_default_mapping(self):
         # Check that RoleManager provides sensible defaults in case the team roles
         # don't specify any mappings
@@ -82,10 +105,15 @@ class RoleManagerTest(TestCase):
         # it's explicitly mapped to a lower role
 
         team_roles = [
-            {"id": "private", "name": "Private", "is_minimum_role_for": "peasant"},
-            {"id": "sergeant", "name": "Sergeant", "is_minimum_role_for": "earl"},
-            {"id": "lieutenant", "name": "Lieutenant", "is_minimum_role_for": "monarch"},
-            {"id": "captain", "name": "Captain"},
+            {"id": "private", "name": "Private", "is_minimum_role_for": "peasant", "desc": "fee"},
+            {"id": "sergeant", "name": "Sergeant", "is_minimum_role_for": "earl", "desc": "fi"},
+            {
+                "id": "lieutenant",
+                "name": "Lieutenant",
+                "is_minimum_role_for": "monarch",
+                "desc": "fo",
+            },
+            {"id": "captain", "name": "Captain", "desc": "fum"},
         ]
         manager = RoleManager(self.TEST_ORG_ROLES, team_roles)
 
@@ -97,10 +125,10 @@ class RoleManagerTest(TestCase):
 
     def test_if_team_top_dog_is_not_org_top_dog(self):
         team_roles = [
-            {"id": "private", "name": "Private", "is_minimum_role_for": "peasant"},
-            {"id": "sergeant", "name": "Sergeant", "is_minimum_role_for": "earl"},
-            {"id": "lieutenant", "name": "Lieutenant"},
-            {"id": "captain", "name": "Captain", "is_minimum_role_for": "duke"},
+            {"id": "private", "name": "Private", "is_minimum_role_for": "peasant", "desc": "fee"},
+            {"id": "sergeant", "name": "Sergeant", "is_minimum_role_for": "earl", "desc": "fi"},
+            {"id": "lieutenant", "name": "Lieutenant", "desc": "fo"},
+            {"id": "captain", "name": "Captain", "is_minimum_role_for": "duke", "desc": "fum"},
         ]
         manager = RoleManager(self.TEST_ORG_ROLES, team_roles)
 
@@ -115,10 +143,10 @@ class RoleManagerTest(TestCase):
         # org role and maps to the highest one
 
         team_roles = [
-            {"id": "private", "name": "Private", "is_minimum_role_for": "peasant"},
-            {"id": "sergeant", "name": "Sergeant", "is_minimum_role_for": "earl"},
-            {"id": "lieutenant", "name": "Lieutenant", "is_minimum_role_for": "earl"},
-            {"id": "captain", "name": "Captain", "is_minimum_role_for": "monarch"},
+            {"id": "private", "name": "Private", "is_minimum_role_for": "peasant", "desc": "fee"},
+            {"id": "sergeant", "name": "Sergeant", "is_minimum_role_for": "earl", "desc": "fi"},
+            {"id": "lieutenant", "name": "Lieutenant", "is_minimum_role_for": "earl", "desc": "fo"},
+            {"id": "captain", "name": "Captain", "is_minimum_role_for": "monarch", "desc": "fum"},
         ]
         manager = RoleManager(self.TEST_ORG_ROLES, team_roles)
 
@@ -135,9 +163,9 @@ class RoleManagerTest(TestCase):
         # team roles with mapping keys that point to nothing
 
         legacy_roles = [
-            {"id": "legionary", "name": "Legionary"},
-            {"id": "centurion", "name": "Centurion"},
-            {"id": "legate", "name": "Legate"},
+            {"id": "legionary", "name": "Legionary", "desc": "Member of a legion"},
+            {"id": "centurion", "name": "Centurion", "desc": "Commander of a military unit"},
+            {"id": "legate", "name": "Legate", "desc": "Commander of a legion"},
         ]
         manager = RoleManager(legacy_roles, self.TEST_TEAM_ROLES)
 


### PR DESCRIPTION
I changed the `get_choices` to actually return a tuple of 
`(id, description) e.g. (contributor, Base role that has access to...)`
instead of
`(id, name) e.g. (contributor, Contributor)` so that we could actually use the function in `serializer.choiceField` and not have to duplicate the information already stored in `server.py`.

Note that this endpoint's functionality is actually already duplicated in from [another published API](https://docs.sentry.io/api/organizations/update-an-organization-members-roles/), but I'm still choosing to publish it for convenience for our users.

Another thing to note is that some org roles are guaranteed a minimum team-level role of `admin`. This functionally works, but there is a bug where you can actually successfully set someone with a minimum role to `contributor`, and the endpoint will return a 200. It will then store that `contributor` role, but when in the UI and functionally the person actually still has their minimum team-level role.
 
Closes ALRT-73

<img width="1483" alt="Screenshot 2024-06-03 at 3 26 28 PM" src="https://github.com/getsentry/sentry/assets/67301797/775e5e5d-e37e-4bb8-8f2b-990e257ba5da">


