### PR TITLE
feat(relocation): Don't email manually claimed users

### DIFF
--- a/src/sentry/services/hybrid_cloud/user/model.py
+++ b/src/sentry/services/hybrid_cloud/user/model.py
@@ -50,6 +50,7 @@ class RpcUserProfile(RpcModel):
     is_anonymous: bool = False
     is_active: bool = False
     is_staff: bool = False
+    is_unclaimed: bool = False
     last_active: datetime.datetime | None = None
     is_sentry_app: bool = False
     password_usable: bool = False

--- a/src/sentry/services/hybrid_cloud/user/serial.py
+++ b/src/sentry/services/hybrid_cloud/user/serial.py
@@ -43,6 +43,7 @@ def _serialize_from_user_fields(user: User) -> dict[str, Any]:
     args["display_name"] = user.get_display_name()
     args["label"] = user.get_label()
     args["is_superuser"] = user.is_superuser
+    args["is_unclaimed"] = user.is_unclaimed
     args["is_sentry_app"] = bool(user.is_sentry_app)
     args["password_usable"] = user.has_usable_password()
     args["session_nonce"] = user.session_nonce

--- a/src/sentry/tasks/relocation.py
+++ b/src/sentry/tasks/relocation.py
@@ -1251,6 +1251,11 @@ def notifying_users(uuid: str) -> None:
 
         # Okay, everything seems fine - go ahead and send those emails.
         for user in imported_users:
+            # Sometimes, we merge users together before unpausing a relocation. No need to send an
+            # email to these users!
+            if not user.is_unclaimed:
+                continue
+
             hash = lost_password_hash_service.get_or_create(user_id=user.id).hash
             LostPasswordHash.send_relocate_account_email(user, hash, list(imported_org_slugs))
 


### PR DESCRIPTION
Sometimes, it is useful for an admin to merge user accounts before "unpausing" an active relocation. In such cases, we do not want to email users that have been manually merged.
