### PR TITLE
chore(api): Set two APIs to private

### DIFF
--- a/src/sentry/api/endpoints/team_stats.py
+++ b/src/sentry/api/endpoints/team_stats.py
@@ -15,7 +15,7 @@ from sentry.tsdb.base import TSDBModel
 @region_silo_endpoint
 class TeamStatsEndpoint(TeamEndpoint, EnvironmentMixin, StatsMixin):
     publish_status = {
-        "GET": ApiPublishStatus.UNKNOWN,
+        "GET": ApiPublishStatus.PRIVATE,
     }
     owner = ApiOwner.ENTERPRISE
 

--- a/src/sentry/scim/endpoints/schemas.py
+++ b/src/sentry/scim/endpoints/schemas.py
@@ -190,7 +190,7 @@ SCIM_SCHEMA_LIST = [SCIM_USER_ATTRIBUTES_SCHEMA, SCIM_GROUP_ATTRIBUTES_SCHEMA]
 @region_silo_endpoint
 class OrganizationSCIMSchemaIndex(SCIMEndpoint):
     publish_status = {
-        "GET": ApiPublishStatus.UNKNOWN,
+        "GET": ApiPublishStatus.PRIVATE,
     }
     permission_classes = (OrganizationSCIMMemberPermission,)
 


### PR DESCRIPTION
The SCIM API was needed to comply with some Azure requirements as noted in https://github.com/getsentry/sentry/pull/27186

The Team stats API is a mystery, it's 9 years old and I tried hitting it but couldn't get any results out of it. Moreover, we don't aggregate event counts per team but rather per project now, so I think this endpoint is out-of-date and should prob eventually be deleted.