### PR TITLE
ref: Move formatSecondsToClock & parseClockToSeconds into utils/duration/

### DIFF
--- a/static/app/components/replays/utils.tsx
+++ b/static/app/components/replays/utils.tsx
@@ -1,4 +1,4 @@
-import {formatSecondsToClock} from 'sentry/utils/formatters';
+import {formatSecondsToClock} from 'sentry/utils/duration/formatSecondsToClock';
 import type {ReplayFrame, SpanFrame, VideoEvent} from 'sentry/utils/replays/types';
 
 const SECOND = 1000;

--- a/static/app/utils/duration/formatDuration.tsx
+++ b/static/app/utils/duration/formatDuration.tsx
@@ -1,5 +1,5 @@
+import {formatSecondsToClock} from 'sentry/utils/duration/formatSecondsToClock';
 import type {Duration, Unit} from 'sentry/utils/duration/types';
-import {formatSecondsToClock} from 'sentry/utils/formatters';
 
 type Format =
   // example: `3,600`

--- a/static/app/utils/duration/formatSecondsToClock.spec.tsx
+++ b/static/app/utils/duration/formatSecondsToClock.spec.tsx
@@ -1,0 +1,60 @@
+import {formatSecondsToClock} from 'sentry/utils/duration/formatSecondsToClock';
+
+describe('getDuration()', function () {
+  it('should format durations', function () {
+    expect(formatSecondsToClock(0)).toBe('00:00');
+    expect(formatSecondsToClock(0.001)).toBe('00:00.001');
+    expect(formatSecondsToClock(0.01)).toBe('00:00.010');
+  });
+
+  it('should format negative durations', function () {
+    expect(formatSecondsToClock(0)).toBe('00:00');
+    expect(formatSecondsToClock(-0.001)).toBe('00:00.001');
+    expect(formatSecondsToClock(-0.01)).toBe('00:00.010');
+  });
+
+  it('should format negative durations with absolute', function () {
+    expect(formatSecondsToClock(0)).toBe('00:00');
+    expect(formatSecondsToClock(-0.001)).toBe('00:00.001');
+    expect(formatSecondsToClock(-0.01)).toBe('00:00.010');
+  });
+});
+
+describe('formatSecondsToClock', function () {
+  it('should format durations', function () {
+    expect(formatSecondsToClock(0)).toBe('00:00');
+    expect(formatSecondsToClock(0.1)).toBe('00:00.100');
+    expect(formatSecondsToClock(1)).toBe('00:01');
+    expect(formatSecondsToClock(2)).toBe('00:02');
+    expect(formatSecondsToClock(65)).toBe('01:05');
+    expect(formatSecondsToClock(65.123)).toBe('01:05.123');
+    expect(formatSecondsToClock(122)).toBe('02:02');
+    expect(formatSecondsToClock(3720)).toBe('01:02:00');
+    expect(formatSecondsToClock(36000)).toBe('10:00:00');
+    expect(formatSecondsToClock(86400)).toBe('24:00:00');
+    expect(formatSecondsToClock(86400 * 2)).toBe('48:00:00');
+  });
+
+  it('should format negative durations', function () {
+    expect(formatSecondsToClock(-0)).toBe('00:00');
+    expect(formatSecondsToClock(-0.1)).toBe('00:00.100');
+    expect(formatSecondsToClock(-1)).toBe('00:01');
+    expect(formatSecondsToClock(-2)).toBe('00:02');
+    expect(formatSecondsToClock(-65)).toBe('01:05');
+    expect(formatSecondsToClock(-65.123)).toBe('01:05.123');
+    expect(formatSecondsToClock(-122)).toBe('02:02');
+    expect(formatSecondsToClock(-3720)).toBe('01:02:00');
+    expect(formatSecondsToClock(-36000)).toBe('10:00:00');
+    expect(formatSecondsToClock(-86400)).toBe('24:00:00');
+    expect(formatSecondsToClock(-86400 * 2)).toBe('48:00:00');
+  });
+
+  it('should not pad when padAll:false is set', function () {
+    const padAll = false;
+    expect(formatSecondsToClock(0, {padAll})).toBe('0:00');
+    expect(formatSecondsToClock(0.1, {padAll})).toBe('0:00.100');
+    expect(formatSecondsToClock(1, {padAll})).toBe('0:01');
+    expect(formatSecondsToClock(65, {padAll})).toBe('1:05');
+    expect(formatSecondsToClock(3720, {padAll})).toBe('1:02:00');
+  });
+});

--- a/static/app/utils/duration/formatSecondsToClock.tsx
+++ b/static/app/utils/duration/formatSecondsToClock.tsx
@@ -1,6 +1,6 @@
 import round from 'lodash/round';
 
-import {HOUR, MINUTE, SECOND} from '../formatters';
+import {HOUR, MINUTE, SECOND} from 'sentry/utils/formatters';
 
 export function formatSecondsToClock(
   seconds: number,

--- a/static/app/utils/duration/formatSecondsToClock.tsx
+++ b/static/app/utils/duration/formatSecondsToClock.tsx
@@ -1,0 +1,35 @@
+import round from 'lodash/round';
+
+import {HOUR, MINUTE, SECOND} from '../formatters';
+
+export function formatSecondsToClock(
+  seconds: number,
+  {padAll}: {padAll: boolean} = {padAll: true}
+) {
+  if (seconds === 0 || isNaN(seconds)) {
+    return padAll ? '00:00' : '0:00';
+  }
+
+  const divideBy = (msValue: number, time: number) => {
+    return {
+      quotient: msValue < 0 ? Math.ceil(msValue / time) : Math.floor(msValue / time),
+      remainder: msValue % time,
+    };
+  };
+
+  // value in milliseconds
+  const absMSValue = round(Math.abs(seconds * 1000));
+
+  const {quotient: hours, remainder: rMins} = divideBy(absMSValue, HOUR);
+  const {quotient: minutes, remainder: rSeconds} = divideBy(rMins, MINUTE);
+  const {quotient: secs, remainder: milliseconds} = divideBy(rSeconds, SECOND);
+
+  const fill = (num: number) => (num < 10 ? `0${num}` : String(num));
+
+  const parts = hours
+    ? [padAll ? fill(hours) : hours, fill(minutes), fill(secs)]
+    : [padAll ? fill(minutes) : minutes, fill(secs)];
+
+  const ms = `000${milliseconds}`.slice(-3);
+  return milliseconds ? `${parts.join(':')}.${ms}` : parts.join(':');
+}

--- a/static/app/utils/duration/parseClockToSeconds.spec.tsx
+++ b/static/app/utils/duration/parseClockToSeconds.spec.tsx
@@ -1,0 +1,39 @@
+import {parseClockToSeconds} from 'sentry/utils/duration/parseClockToSeconds';
+import {
+  DAY, // ms in day
+  MONTH, // ms in month
+  WEEK, // ms in week
+} from 'sentry/utils/formatters';
+
+describe('parseClockToSeconds', function () {
+  it('should format durations', function () {
+    expect(parseClockToSeconds('0:00')).toBe(0);
+    expect(parseClockToSeconds('0:00.100')).toBe(0.1);
+    expect(parseClockToSeconds('0:01')).toBe(1);
+    expect(parseClockToSeconds('0:02')).toBe(2);
+    expect(parseClockToSeconds('1:05')).toBe(65);
+    expect(parseClockToSeconds('1:05.123')).toBe(65.123);
+    expect(parseClockToSeconds('2:02')).toBe(122);
+    expect(parseClockToSeconds('1:02:00')).toBe(3720);
+    expect(parseClockToSeconds('10:00:00')).toBe(36000);
+    expect(parseClockToSeconds('24:00:00')).toBe(DAY / 1000);
+    expect(parseClockToSeconds('48:00:00')).toBe((DAY * 2) / 1000);
+    expect(parseClockToSeconds('2:00:00:00')).toBe((DAY * 2) / 1000);
+    expect(parseClockToSeconds('1:00:00:00:00')).toBe(WEEK / 1000);
+    expect(parseClockToSeconds('1:00:00:00:00:00')).toBe(MONTH / 1000);
+  });
+
+  it('should ignore non-numeric input', function () {
+    expect(parseClockToSeconds('hello world')).toBe(0);
+    expect(parseClockToSeconds('a:b:c')).toBe(0);
+    expect(parseClockToSeconds('a:b:c.d')).toBe(0);
+    expect(parseClockToSeconds('a:b:10.d')).toBe(10);
+    expect(parseClockToSeconds('a:10:c.d')).toBe(600);
+  });
+
+  it('should handle as much invalid input as possible', function () {
+    expect(parseClockToSeconds('a:b:c.123')).toBe(0.123);
+    expect(parseClockToSeconds('a:b:10.d')).toBe(10);
+    expect(parseClockToSeconds('a:10:c.d')).toBe(600);
+  });
+});

--- a/static/app/utils/duration/parseClockToSeconds.tsx
+++ b/static/app/utils/duration/parseClockToSeconds.tsx
@@ -1,0 +1,16 @@
+import {DAY, HOUR, MINUTE, MONTH, SECOND, WEEK} from '../formatters';
+
+export function parseClockToSeconds(clock: string) {
+  const [rest, milliseconds] = clock.split('.');
+  const parts = rest.split(':');
+
+  let seconds = 0;
+  const progression = [MONTH, WEEK, DAY, HOUR, MINUTE, SECOND].slice(parts.length * -1);
+  for (let i = 0; i < parts.length; i++) {
+    const num = Number(parts[i]) || 0;
+    const time = progression[i] / 1000;
+    seconds += num * time;
+  }
+  const ms = Number(milliseconds) || 0;
+  return seconds + ms / 1000;
+}

--- a/static/app/utils/duration/parseClockToSeconds.tsx
+++ b/static/app/utils/duration/parseClockToSeconds.tsx
@@ -1,4 +1,4 @@
-import {DAY, HOUR, MINUTE, MONTH, SECOND, WEEK} from '../formatters';
+import {DAY, HOUR, MINUTE, MONTH, SECOND, WEEK} from 'sentry/utils/formatters';
 
 export function parseClockToSeconds(clock: string) {
   const [rest, milliseconds] = clock.split('.');

--- a/static/app/utils/formatters.spec.tsx
+++ b/static/app/utils/formatters.spec.tsx
@@ -1,110 +1,13 @@
 import {RateUnit} from 'sentry/utils/discover/fields';
 import {
-  DAY, // ms in day
   formatAbbreviatedNumber,
   formatAbbreviatedNumberWithDynamicPrecision,
   formatNumberWithDynamicDecimalPoints,
   formatPercentage,
   formatRate,
-  formatSecondsToClock,
   formatSpanOperation,
-  MONTH, // ms in month
-  parseClockToSeconds,
   userDisplayName,
-  WEEK, // ms in week
 } from 'sentry/utils/formatters';
-
-describe('getDuration()', function () {
-  it('should format durations', function () {
-    expect(formatSecondsToClock(0)).toBe('00:00');
-    expect(formatSecondsToClock(0.001)).toBe('00:00.001');
-    expect(formatSecondsToClock(0.01)).toBe('00:00.010');
-  });
-
-  it('should format negative durations', function () {
-    expect(formatSecondsToClock(0)).toBe('00:00');
-    expect(formatSecondsToClock(-0.001)).toBe('00:00.001');
-    expect(formatSecondsToClock(-0.01)).toBe('00:00.010');
-  });
-
-  it('should format negative durations with absolute', function () {
-    expect(formatSecondsToClock(0)).toBe('00:00');
-    expect(formatSecondsToClock(-0.001)).toBe('00:00.001');
-    expect(formatSecondsToClock(-0.01)).toBe('00:00.010');
-  });
-});
-
-describe('formatSecondsToClock', function () {
-  it('should format durations', function () {
-    expect(formatSecondsToClock(0)).toBe('00:00');
-    expect(formatSecondsToClock(0.1)).toBe('00:00.100');
-    expect(formatSecondsToClock(1)).toBe('00:01');
-    expect(formatSecondsToClock(2)).toBe('00:02');
-    expect(formatSecondsToClock(65)).toBe('01:05');
-    expect(formatSecondsToClock(65.123)).toBe('01:05.123');
-    expect(formatSecondsToClock(122)).toBe('02:02');
-    expect(formatSecondsToClock(3720)).toBe('01:02:00');
-    expect(formatSecondsToClock(36000)).toBe('10:00:00');
-    expect(formatSecondsToClock(86400)).toBe('24:00:00');
-    expect(formatSecondsToClock(86400 * 2)).toBe('48:00:00');
-  });
-
-  it('should format negative durations', function () {
-    expect(formatSecondsToClock(-0)).toBe('00:00');
-    expect(formatSecondsToClock(-0.1)).toBe('00:00.100');
-    expect(formatSecondsToClock(-1)).toBe('00:01');
-    expect(formatSecondsToClock(-2)).toBe('00:02');
-    expect(formatSecondsToClock(-65)).toBe('01:05');
-    expect(formatSecondsToClock(-65.123)).toBe('01:05.123');
-    expect(formatSecondsToClock(-122)).toBe('02:02');
-    expect(formatSecondsToClock(-3720)).toBe('01:02:00');
-    expect(formatSecondsToClock(-36000)).toBe('10:00:00');
-    expect(formatSecondsToClock(-86400)).toBe('24:00:00');
-    expect(formatSecondsToClock(-86400 * 2)).toBe('48:00:00');
-  });
-
-  it('should not pad when padAll:false is set', function () {
-    const padAll = false;
-    expect(formatSecondsToClock(0, {padAll})).toBe('0:00');
-    expect(formatSecondsToClock(0.1, {padAll})).toBe('0:00.100');
-    expect(formatSecondsToClock(1, {padAll})).toBe('0:01');
-    expect(formatSecondsToClock(65, {padAll})).toBe('1:05');
-    expect(formatSecondsToClock(3720, {padAll})).toBe('1:02:00');
-  });
-});
-
-describe('parseClockToSeconds', function () {
-  it('should format durations', function () {
-    expect(parseClockToSeconds('0:00')).toBe(0);
-    expect(parseClockToSeconds('0:00.100')).toBe(0.1);
-    expect(parseClockToSeconds('0:01')).toBe(1);
-    expect(parseClockToSeconds('0:02')).toBe(2);
-    expect(parseClockToSeconds('1:05')).toBe(65);
-    expect(parseClockToSeconds('1:05.123')).toBe(65.123);
-    expect(parseClockToSeconds('2:02')).toBe(122);
-    expect(parseClockToSeconds('1:02:00')).toBe(3720);
-    expect(parseClockToSeconds('10:00:00')).toBe(36000);
-    expect(parseClockToSeconds('24:00:00')).toBe(DAY / 1000);
-    expect(parseClockToSeconds('48:00:00')).toBe((DAY * 2) / 1000);
-    expect(parseClockToSeconds('2:00:00:00')).toBe((DAY * 2) / 1000);
-    expect(parseClockToSeconds('1:00:00:00:00')).toBe(WEEK / 1000);
-    expect(parseClockToSeconds('1:00:00:00:00:00')).toBe(MONTH / 1000);
-  });
-
-  it('should ignore non-numeric input', function () {
-    expect(parseClockToSeconds('hello world')).toBe(0);
-    expect(parseClockToSeconds('a:b:c')).toBe(0);
-    expect(parseClockToSeconds('a:b:c.d')).toBe(0);
-    expect(parseClockToSeconds('a:b:10.d')).toBe(10);
-    expect(parseClockToSeconds('a:10:c.d')).toBe(600);
-  });
-
-  it('should handle as much invalid input as possible', function () {
-    expect(parseClockToSeconds('a:b:c.123')).toBe(0.123);
-    expect(parseClockToSeconds('a:b:10.d')).toBe(10);
-    expect(parseClockToSeconds('a:10:c.d')).toBe(600);
-  });
-});
 
 describe('formatAbbreviatedNumber()', function () {
   it('should format numbers smaller than 1', function () {

--- a/static/app/utils/formatters.tsx
+++ b/static/app/utils/formatters.tsx
@@ -37,53 +37,6 @@ export const NANOSECOND = 0.000001;
  */
 export {getExactDuration} from 'sentry/utils/duration/getExactDuration';
 
-export function formatSecondsToClock(
-  seconds: number,
-  {padAll}: {padAll: boolean} = {padAll: true}
-) {
-  if (seconds === 0 || isNaN(seconds)) {
-    return padAll ? '00:00' : '0:00';
-  }
-
-  const divideBy = (msValue: number, time: number) => {
-    return {
-      quotient: msValue < 0 ? Math.ceil(msValue / time) : Math.floor(msValue / time),
-      remainder: msValue % time,
-    };
-  };
-
-  // value in milliseconds
-  const absMSValue = round(Math.abs(seconds * 1000));
-
-  const {quotient: hours, remainder: rMins} = divideBy(absMSValue, HOUR);
-  const {quotient: minutes, remainder: rSeconds} = divideBy(rMins, MINUTE);
-  const {quotient: secs, remainder: milliseconds} = divideBy(rSeconds, SECOND);
-
-  const fill = (num: number) => (num < 10 ? `0${num}` : String(num));
-
-  const parts = hours
-    ? [padAll ? fill(hours) : hours, fill(minutes), fill(secs)]
-    : [padAll ? fill(minutes) : minutes, fill(secs)];
-
-  const ms = `000${milliseconds}`.slice(-3);
-  return milliseconds ? `${parts.join(':')}.${ms}` : parts.join(':');
-}
-
-export function parseClockToSeconds(clock: string) {
-  const [rest, milliseconds] = clock.split('.');
-  const parts = rest.split(':');
-
-  let seconds = 0;
-  const progression = [MONTH, WEEK, DAY, HOUR, MINUTE, SECOND].slice(parts.length * -1);
-  for (let i = 0; i < parts.length; i++) {
-    const num = Number(parts[i]) || 0;
-    const time = progression[i] / 1000;
-    seconds += num * time;
-  }
-  const ms = Number(milliseconds) || 0;
-  return seconds + ms / 1000;
-}
-
 /**
  * Format a value between 0 and 1 as a percentage
  */

--- a/static/app/utils/replays/hooks/useShareReplayAtTimestamp.tsx
+++ b/static/app/utils/replays/hooks/useShareReplayAtTimestamp.tsx
@@ -8,7 +8,8 @@ import {useReplayContext} from 'sentry/components/replays/replayContext';
 import TextCopyInput from 'sentry/components/textCopyInput';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
-import {formatSecondsToClock, parseClockToSeconds} from 'sentry/utils/formatters';
+import {formatSecondsToClock} from 'sentry/utils/duration/formatSecondsToClock';
+import {parseClockToSeconds} from 'sentry/utils/duration/parseClockToSeconds';
 import getRouteStringFromRoutes from 'sentry/utils/getRouteStringFromRoutes';
 import {useRoutes} from 'sentry/utils/useRoutes';
 


### PR DESCRIPTION
Related to https://github.com/getsentry/frontend-tsc/issues/13