### PR TITLE
fix(metrics): 404 instead of 500 if metric is not found in /metrics/meta/tags/{metric}

### DIFF
--- a/src/sentry/api/endpoints/organization_metrics_tags.py
+++ b/src/sentry/api/endpoints/organization_metrics_tags.py
@@ -6,6 +6,7 @@ from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases import OrganizationAndStaffPermission, OrganizationEndpoint
+from sentry.api.exceptions import BadRequest
 from sentry.api.utils import get_date_range_from_params
 from sentry.exceptions import InvalidParams
 from sentry.sentry_metrics.use_case_utils import get_use_case_id
@@ -38,6 +39,9 @@ class OrganizationMetricsTagsEndpoint(OrganizationEndpoint):
         projects = self.get_projects(request, organization)
         if not projects:
             raise InvalidParams("You must supply at least one project to see the tag names")
+
+        if len(metric_names) > 1:
+            raise BadRequest(message="Please provide only a single metric name.")
 
         start, end = get_date_range_from_params(request.GET)
 

--- a/src/sentry/api/endpoints/organization_metrics_tags.py
+++ b/src/sentry/api/endpoints/organization_metrics_tags.py
@@ -11,8 +11,8 @@ from sentry.exceptions import InvalidParams
 from sentry.sentry_metrics.use_case_utils import get_use_case_id
 from sentry.snuba.metrics import (
     DerivedMetricParseException,
-    get_all_tags,
     MetricDoesNotExistInIndexer,
+    get_all_tags,
 )
 
 

--- a/src/sentry/snuba/metrics/datasource.py
+++ b/src/sentry/snuba/metrics/datasource.py
@@ -514,16 +514,11 @@ def _fetch_tags_or_values_for_mri(
     """
     org_id = projects[0].organization_id
 
-    try:
-        metric_ids = _get_metrics_filter_ids(
-            projects=projects, metric_mris=metric_mris, use_case_id=use_case_id
-        )
-    except MetricDoesNotExistInIndexer:
-        raise InvalidParams(
-            f"Some or all of the metric names in {metric_mris} do not exist in the indexer"
-        )
-    else:
-        where = [Condition(Column("metric_id"), Op.IN, list(metric_ids))] if metric_ids else []
+    metric_ids = _get_metrics_filter_ids(
+        projects=projects, metric_mris=metric_mris, use_case_id=use_case_id
+    )
+
+    where = [Condition(Column("metric_id"), Op.IN, list(metric_ids))] if metric_ids else []
 
     tag_or_value_ids_per_metric_id = defaultdict(list)
     # This dictionary is required as a mapping from an entity to the ids available in it to

--- a/tests/sentry/api/endpoints/test_organization_metrics_tags.py
+++ b/tests/sentry/api/endpoints/test_organization_metrics_tags.py
@@ -294,3 +294,17 @@ class OrganizationMetricsTagsTest(OrganizationMetricsIntegrationTestCase):
             useCase="custom",
         )
         assert len(response.data) == 4
+
+    def test_metric_not_in_indexer(self):
+        mri = "c:custom/sentry_metric@none"
+        response = self.get_response(
+            self.organization.slug,
+            metric=[mri],
+            project=self.project.id,
+            useCase="custom",
+        )
+        assert (
+            response.json()["detail"]
+            == "One of the specified metrics was not found: ['c:custom/sentry_metric@none']"
+        )
+        assert response.status_code == 404

--- a/tests/sentry/api/endpoints/test_organization_metrics_tags.py
+++ b/tests/sentry/api/endpoints/test_organization_metrics_tags.py
@@ -7,14 +7,10 @@ import pytest
 
 from sentry.sentry_metrics import indexer
 from sentry.sentry_metrics.use_case_id_registry import UseCaseID
-from sentry.snuba.metrics.naming_layer import get_mri
 from sentry.snuba.metrics.naming_layer.mri import SessionMRI
 from sentry.snuba.metrics.naming_layer.public import SessionMetricKey
 from sentry.testutils.cases import MetricsAPIBaseTestCase, OrganizationMetricsIntegrationTestCase
-from tests.sentry.api.endpoints.test_organization_metrics import (
-    MOCKED_DERIVED_METRICS,
-    mocked_mri_resolver,
-)
+from tests.sentry.api.endpoints.test_organization_metrics import MOCKED_DERIVED_METRICS
 
 pytestmark = pytest.mark.sentry_metrics
 
@@ -30,10 +26,6 @@ class OrganizationMetricsTagsTest(OrganizationMetricsIntegrationTestCase):
     def now(self):
         return MetricsAPIBaseTestCase.MOCK_DATETIME
 
-    @patch(
-        "sentry.snuba.metrics.datasource.get_mri",
-        mocked_mri_resolver(["metric1", "metric2", "metric3"], get_mri),
-    )
     def test_metric_tags(self):
         response = self.get_success_response(
             self.organization.slug,
@@ -46,27 +38,8 @@ class OrganizationMetricsTagsTest(OrganizationMetricsIntegrationTestCase):
             {"key": "project"},
         ]
 
-        # When metric names are supplied, get intersection of tag names:
-        response = self.get_success_response(
-            self.organization.slug,
-            metric=["metric1", "metric2"],
-        )
-        assert response.data == [{"key": "tag1"}, {"key": "tag2"}, {"key": "project"}]
-
-        response = self.get_success_response(
-            self.organization.slug,
-            metric=["metric1", "metric2", "metric3"],
-        )
-        assert response.data == [{"key": "project"}]
-
-    @patch(
-        "sentry.snuba.metrics.datasource.get_mri",
-        mocked_mri_resolver(
-            ["d:transactions/duration@millisecond", "d:sessions/duration.exited@second"], get_mri
-        ),
-    )
-    def test_mri_metric_tags(self):
-        response = self.get_success_response(
+    def test_multiple_metrics_tags(self):
+        response = self.get_response(
             self.organization.slug,
         )
         assert response.data == [
@@ -77,26 +50,13 @@ class OrganizationMetricsTagsTest(OrganizationMetricsIntegrationTestCase):
             {"key": "project"},
         ]
 
-        response = self.get_success_response(
+        response = self.get_response(
             self.organization.slug,
             metric=["d:transactions/duration@millisecond", "d:sessions/duration.exited@second"],
             useCase="transactions",
         )
-        assert response.data == []
-
-    @patch(
-        "sentry.snuba.metrics.datasource.get_mri",
-        mocked_mri_resolver(
-            ["d:transactions/duration@millisecond", "d:sessions/duration.exited@second"], get_mri
-        ),
-    )
-    def test_mixed_metric_identifiers(self):
-        response = self.get_success_response(
-            self.organization.slug,
-            metric=["d:transactions/duration@millisecond", "not_mri"],
-        )
-
-        assert response.data == []
+        assert response.status_code == 400
+        assert response.json()["detail"]["message"] == "Please provide only a single metric name."
 
     @patch(
         "sentry.snuba.metrics.datasource.bulk_reverse_resolve",
@@ -191,15 +151,6 @@ class OrganizationMetricsTagsTest(OrganizationMetricsIntegrationTestCase):
         response = self.get_success_response(
             self.organization.slug,
             metric=["session.crash_free_rate"],
-        )
-        assert response.data == [{"key": "environment"}, {"key": "release"}, {"key": "project"}]
-
-        response = self.get_success_response(
-            self.organization.slug,
-            metric=[
-                SessionMetricKey.CRASH_FREE_RATE.value,
-                SessionMetricKey.ALL.value,
-            ],
         )
         assert response.data == [{"key": "environment"}, {"key": "release"}, {"key": "project"}]
 


### PR DESCRIPTION
Contributes to https://github.com/getsentry/sentry/issues/71973
Fixes SENTRY-2M4E
