### PR TITLE
feat(contexts): Add laravel as known platform context

### DIFF
--- a/static/app/components/events/contexts/contextCard.tsx
+++ b/static/app/components/events/contexts/contextCard.tsx
@@ -103,7 +103,7 @@ export default function ContextCard({
       title={
         <Title>
           <div>{getContextTitle({alias, type, value})}</div>
-          <div>{getContextIcon({type, value})}</div>
+          <div>{getContextIcon({alias, type, value})}</div>
         </Title>
       }
       sortAlphabetically

--- a/static/app/components/events/contexts/platform/index.spec.tsx
+++ b/static/app/components/events/contexts/platform/index.spec.tsx
@@ -1,0 +1,40 @@
+import {EventFixture} from 'sentry-fixture/event';
+import {GroupFixture} from 'sentry-fixture/group';
+import {OrganizationFixture} from 'sentry-fixture/organization';
+import {ProjectFixture} from 'sentry-fixture/project';
+
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import ContextCard from 'sentry/components/events/contexts/contextCard';
+
+describe('platform event context', function () {
+  const platformContexts = {
+    laravel: {
+      type: 'default',
+      some: 'value',
+      number: 123,
+    },
+  };
+  const organization = OrganizationFixture();
+  const event = EventFixture({contexts: platformContexts});
+  const group = GroupFixture();
+  const project = ProjectFixture();
+
+  it('renders laravel context', function () {
+    const alias = 'laravel';
+    render(
+      <ContextCard
+        type={platformContexts[alias].type}
+        alias={alias}
+        value={platformContexts[alias]}
+        event={event}
+        group={group}
+        project={project}
+      />,
+      {organization}
+    );
+
+    expect(screen.getByText('Laravel Context')).toBeInTheDocument();
+    expect(screen.getByTestId(`${alias}-context-icon`)).toBeInTheDocument();
+  });
+});

--- a/static/app/components/events/contexts/platform/index.tsx
+++ b/static/app/components/events/contexts/platform/index.tsx
@@ -1,0 +1,68 @@
+import {PlatformIcon} from 'platformicons';
+
+import {getKnownData, getUnknownData} from 'sentry/components/events/contexts/utils';
+
+/**
+ * Mapping of platform to known context keys for platform-specific context.
+ */
+const KNOWN_PLATFORM_CONTEXT_KEYS: Record<string, string[]> = {
+  laravel: [],
+};
+
+export const KNOWN_PLATFORM_CONTEXTS = new Set(Object.keys(KNOWN_PLATFORM_CONTEXT_KEYS));
+
+interface PlatformContextProps {
+  data: Record<string, any>;
+  platform: string;
+  meta?: Record<string, any>;
+}
+
+enum PlatformContextKeys {}
+
+export function getKnownPlatformContextData({
+  platform,
+  data,
+  meta,
+}: PlatformContextProps) {
+  return getKnownData<PlatformContextProps['data'], PlatformContextKeys>({
+    data,
+    meta,
+    knownDataTypes: KNOWN_PLATFORM_CONTEXT_KEYS[platform] ?? [],
+    onGetKnownDataDetails: () => {
+      switch (platform) {
+        default:
+          return undefined;
+      }
+    },
+  });
+}
+
+export function getUnknownPlatformContextData({
+  platform,
+  data,
+  meta,
+}: PlatformContextProps) {
+  return getUnknownData({
+    allData: data,
+    knownKeys: KNOWN_PLATFORM_CONTEXT_KEYS[platform] ?? [],
+    meta,
+  });
+}
+
+export function getPlatformContextIcon({
+  platform,
+}: Pick<PlatformContextProps, 'platform'>) {
+  let platformIconName = '';
+  switch (platform) {
+    case 'laravel':
+      platformIconName = 'php-laravel';
+      break;
+    default:
+      break;
+  }
+
+  if (platformIconName.length === 0) {
+    return null;
+  }
+  return <PlatformIcon format="sm" platform={platformIconName} />;
+}

--- a/static/app/components/events/contexts/platform/index.tsx
+++ b/static/app/components/events/contexts/platform/index.tsx
@@ -64,5 +64,11 @@ export function getPlatformContextIcon({
   if (platformIconName.length === 0) {
     return null;
   }
-  return <PlatformIcon format="sm" platform={platformIconName} />;
+  return (
+    <PlatformIcon
+      format="sm"
+      platform={platformIconName}
+      data-test-id={`${platform}-context-icon`}
+    />
+  );
 }

--- a/static/app/components/events/contexts/utils.tsx
+++ b/static/app/components/events/contexts/utils.tsx
@@ -1,5 +1,6 @@
 import {Fragment} from 'react';
 import styled from '@emotion/styled';
+import startCase from 'lodash/startCase';
 import moment from 'moment-timezone';
 
 import UserAvatar from 'sentry/components/avatar/userAvatar';
@@ -18,6 +19,7 @@ import type {
   Project,
 } from 'sentry/types';
 import {defined} from 'sentry/utils';
+import {toTitleCase} from 'sentry/utils/string/toTitleCase';
 
 import {AppEventContext, getKnownAppContextData, getUnknownAppContextData} from './app';
 import {
@@ -290,7 +292,7 @@ export function getUnknownData({
     .map(([key, value]) => ({
       key,
       value,
-      subject: key,
+      subject: startCase(key),
       meta: meta?.[key]?.[''],
     }));
 }
@@ -309,7 +311,7 @@ export function getContextTitle({
   }
 
   if (!defined(type)) {
-    return alias;
+    return toTitleCase(alias);
   }
 
   switch (type) {
@@ -328,9 +330,9 @@ export function getContextTitle({
     case 'trace':
       return t('Trace Details');
     case 'otel':
-      return 'OpenTelemetry';
+      return t('OpenTelemetry');
     case 'unity':
-      return 'Unity';
+      return t('Unity');
     case 'memory_info': // Current value for memory info
     case 'Memory Info': // Legacy for memory info
       return t('Memory Info');
@@ -344,10 +346,10 @@ export function getContextTitle({
         case 'laravel':
           return t('Laravel Context');
         default:
-          return alias;
+          return toTitleCase(alias);
       }
     default:
-      return type;
+      return toTitleCase(type);
   }
 }
 


### PR DESCRIPTION
Resolves https://github.com/getsentry/sentry/issues/68082

Adds `laravel` as a known context. Rather than adding each SDK specific context as its own item, this will let us extend it if more come in with `type: default`.

![image](https://github.com/getsentry/sentry/assets/35509934/78ebdd08-64fd-4d79-a745-642e034c6def)
