### PR TITLE
feat(insights): show update SDK banner cache module

### DIFF
--- a/static/app/utils/performance/contexts/pageAlert.tsx
+++ b/static/app/utils/performance/contexts/pageAlert.tsx
@@ -10,6 +10,7 @@ type PageAlertType = keyof Theme['alert'];
 
 export enum DismissId {
   RESOURCE_SIZE_ALERT = 0,
+  CACHE_SDK_UPDATE_ALERT = 1,
 }
 
 export type PageAlertOptions = {
@@ -81,7 +82,7 @@ export function PageAlertProvider({children}: {children: React.ReactNode}) {
 
 export function PageAlert() {
   const {pageAlert} = useContext(pageErrorContext);
-  const [dismissedAlerts, setDismissedAlerts] = useLocalStorageState<string[]>(
+  const [dismissedAlerts, setDismissedAlerts] = useLocalStorageState<number[]>(
     localStorageKey,
     []
   );

--- a/static/app/views/performance/cache/cacheLandingPage.tsx
+++ b/static/app/views/performance/cache/cacheLandingPage.tsx
@@ -60,9 +60,7 @@ const SDK_UPDATE_ALERT = (
     {t(
       `If you're noticing missing cache data, try updating to the latest SDK or ensure spans are manually instrumented with the right attributes. `
     )}
-    <ExternalLink
-      href={'https://docs.sentry.io/product/performance/caches/#instrumentation'}
-    >
+    <ExternalLink href={`${MODULE_DOC_LINK}#instrumentation`}>
       {t('Read the Docs')}
     </ExternalLink>
   </Fragment>

--- a/static/app/views/performance/cache/cacheLandingPage.tsx
+++ b/static/app/views/performance/cache/cacheLandingPage.tsx
@@ -1,4 +1,4 @@
-import React, {useEffect} from 'react';
+import React, {Fragment, useEffect} from 'react';
 import keyBy from 'lodash/keyBy';
 
 import FeatureBadge from 'sentry/components/badge/featureBadge';
@@ -6,6 +6,7 @@ import {Breadcrumbs} from 'sentry/components/breadcrumbs';
 import ButtonBar from 'sentry/components/buttonBar';
 import FeedbackWidgetButton from 'sentry/components/feedback/widget/feedbackWidgetButton';
 import * as Layout from 'sentry/components/layouts/thirds';
+import ExternalLink from 'sentry/components/links/externalLink';
 import {DatePageFilter} from 'sentry/components/organizations/datePageFilter';
 import {EnvironmentPageFilter} from 'sentry/components/organizations/environmentPageFilter';
 import PageFilterBar from 'sentry/components/organizations/pageFilterBar';
@@ -54,8 +55,15 @@ import {DataTitles} from 'sentry/views/starfish/views/spans/types';
 const {CACHE_MISS_RATE} = SpanFunction;
 const {CACHE_ITEM_SIZE} = SpanMetricsField;
 
-const SDK_UPDATE_ALERT = t(
-  `If you're noticing missing cache data, try updating to the latest SDK.`
+const SDK_UPDATE_ALERT = (
+  <Fragment>
+    {t(
+      `If you're noticing missing cache data, try updating to the latest SDK or ensure spans are manually instrumented with the right attributes. `
+    )}
+    <ExternalLink href={'https://docs.sentry.io/product/performance/caches/'}>
+      {t('Read the Docs')}
+    </ExternalLink>
+  </Fragment>
 );
 
 const CACHE_ERROR_MESSAGE = 'Column cache.hit was not found in metrics indexer';

--- a/static/app/views/performance/cache/cacheLandingPage.tsx
+++ b/static/app/views/performance/cache/cacheLandingPage.tsx
@@ -60,7 +60,9 @@ const SDK_UPDATE_ALERT = (
     {t(
       `If you're noticing missing cache data, try updating to the latest SDK or ensure spans are manually instrumented with the right attributes. `
     )}
-    <ExternalLink href={'https://docs.sentry.io/product/performance/caches/'}>
+    <ExternalLink
+      href={'https://docs.sentry.io/product/performance/caches/#instrumentation'}
+    >
       {t('Read the Docs')}
     </ExternalLink>
   </Fragment>
@@ -141,11 +143,11 @@ export function CacheLandingPage() {
     Referrer.LANDING_CACHE_TRANSACTION_DURATION
   );
 
+  const onboardingProject = useOnboardingProject();
   const {hasData, isLoading: isHasDataLoading} = useHasData(
     MutableSearch.fromQueryObject(BASE_FILTERS),
     Referrer.LANDING_CACHE_ONBOARDING
   );
-  const onboardingProject = useOnboardingProject();
 
   useEffect(() => {
     const hasMissingDataError =


### PR DESCRIPTION
1. If the cache hit miss rate chart aren't showing data, this likely means the customer is on an outdated SDK or they aren't sending `cache.hit`, so we display a message accordingly
![image](https://github.com/getsentry/sentry/assets/44422760/bf9e2972-3765-43fa-baf4-2d7fd0b561a0)

2. The message is not displayed if it is in an onboarding state