### PR TITLE
fix(gridEditable): Remove vertical scrollbar from Grid

### DIFF
--- a/static/app/components/gridEditable/styles.tsx
+++ b/static/app/components/gridEditable/styles.tsx
@@ -52,6 +52,7 @@ export const Body = styled(({children, ...props}) => (
   </Panel>
 ))`
   overflow-x: auto;
+  overflow-y: hidden;
   z-index: ${Z_INDEX_PANEL};
 `;
 


### PR DESCRIPTION
`overflow-x: auto` was added in https://github.com/getsentry/sentry/pull/51851 to prevent content in the Grid element from getting cut off with no way to see it on smaller screens. However, this causes a janky vertical scrollbar to appear on tables with many rows (for example, the transaction table in the Performance landing page). It appears even though all rows are fully visible in the table. 

Example:
![image](https://github.com/getsentry/sentry/assets/16740047/620b80f0-83ea-48b2-99c2-ab8d41a141af)

Adding `overflow-y: hidden` resolves this issue by ensuring that the scrollbar does not appear vertically, but does not affect the behaviour of the horizontal scrollbar. Grid elements are always expanded vertically to show all rows at once on a page, so content will never be cut off vertically (meaning it is safe to not have a vertical scrollbar).

