### PR TITLE
chore(slack): introduce SlackClient using slack_sdk

### DIFF
--- a/src/sentry/integrations/slack/actions/notification.py
+++ b/src/sentry/integrations/slack/actions/notification.py
@@ -7,7 +7,7 @@ from typing import Any
 import orjson
 from slack_sdk.errors import SlackApiError
 
-from sentry import features, options
+from sentry import features
 from sentry.api.serializers.rest_framework.rule import ACTION_UUID_KEY
 from sentry.eventstore.models import GroupEvent
 from sentry.integrations.repository import get_default_issue_alert_repository
@@ -24,6 +24,7 @@ from sentry.integrations.slack.message_builder.notifications.rule_save_edit impo
 )
 from sentry.integrations.slack.sdk_client import SlackSdkClient
 from sentry.integrations.slack.utils import get_channel_id
+from sentry.integrations.slack.utils.options import has_slack_sdk_flag
 from sentry.models.integrations.integration import Integration
 from sentry.models.rule import Rule
 from sentry.notifications.additional_attachment_manager import get_additional_attachment
@@ -167,7 +168,7 @@ class SlackNotifyServiceAction(IntegrationEventAction):
 
             organization = event.group.project.organization
 
-            if organization.id in options.get("slack.sdk-issue-alert"):
+            if has_slack_sdk_flag(organization.id):
                 sdk_client = SlackSdkClient(integration_id=integration.id)
                 text = str(payload["text"]) if payload["text"] is not None else None
                 try:

--- a/src/sentry/integrations/slack/sdk_client.py
+++ b/src/sentry/integrations/slack/sdk_client.py
@@ -1,0 +1,24 @@
+from slack_sdk import WebClient
+
+from sentry.models.integrations import Integration
+from sentry.services.hybrid_cloud.integration import integration_service
+from sentry.silo.base import SiloMode
+
+
+class SlackClient(WebClient):
+    def __init__(self, integration_id: int, base_url: str | None = None):
+        integration = None
+        if SiloMode.get_current_mode() == SiloMode.REGION:
+            integration = integration_service.get_integration(integration_id=integration_id)
+        else:  # control or monolith (local)
+            integration = Integration.objects.filter(id=integration_id).first()
+
+        if integration is None:
+            raise ValueError(f"Integration with id {integration_id} not found")
+
+        access_token = integration.metadata.get("access_token")
+        if not access_token:
+            raise ValueError(f"Missing token for integration with id {integration_id}")
+
+        # TODO: missing from old SlackClient: verify_ssl, logging_context
+        super().__init__(token=access_token)

--- a/src/sentry/integrations/slack/sdk_client.py
+++ b/src/sentry/integrations/slack/sdk_client.py
@@ -6,10 +6,10 @@ from slack_sdk import WebClient
 from slack_sdk.errors import SlackApiError
 from slack_sdk.web import SlackResponse
 
-from sentry import metrics
 from sentry.models.integrations import Integration
 from sentry.services.hybrid_cloud.integration import integration_service
 from sentry.silo.base import SiloMode
+from sentry.utils import metrics
 
 SLACK_DATADOG_METRIC = "integrations.slack.http_response"
 

--- a/src/sentry/integrations/slack/sdk_client.py
+++ b/src/sentry/integrations/slack/sdk_client.py
@@ -5,8 +5,8 @@ from sentry.services.hybrid_cloud.integration import integration_service
 from sentry.silo.base import SiloMode
 
 
-class SlackClient(WebClient):
-    def __init__(self, integration_id: int, base_url: str | None = None):
+class SlackSdkClient(WebClient):
+    def __init__(self, integration_id: int):
         integration = None
         if SiloMode.get_current_mode() == SiloMode.REGION:
             integration = integration_service.get_integration(integration_id=integration_id)

--- a/src/sentry/integrations/slack/sdk_client.py
+++ b/src/sentry/integrations/slack/sdk_client.py
@@ -6,7 +6,7 @@ from sentry.silo.base import SiloMode
 
 
 class SlackSdkClient(WebClient):
-    def __init__(self, integration_id: int):
+    def __init__(self, integration_id: int) -> None:
         integration = None
         if SiloMode.get_current_mode() == SiloMode.REGION:
             integration = integration_service.get_integration(integration_id=integration_id)

--- a/src/sentry/integrations/slack/sdk_client.py
+++ b/src/sentry/integrations/slack/sdk_client.py
@@ -25,6 +25,9 @@ def track_response_data(
     if error:
         response = error.response
 
+    if not response:
+        return
+
     is_ok = response.get("ok", False)
     code = response.status_code
 

--- a/src/sentry/integrations/slack/utils/options.py
+++ b/src/sentry/integrations/slack/utils/options.py
@@ -1,0 +1,5 @@
+from sentry import options
+
+
+def has_slack_sdk_flag(organization_id: int) -> bool:
+    return organization_id in options.get("slack.sdk-web-client")

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -499,6 +499,12 @@ register("slack.client-secret", flags=FLAG_CREDENTIAL | FLAG_PRIORITIZE_DISK)
 # signing-secret is preferred, but need to keep verification-token for apps that use it
 register("slack.verification-token", flags=FLAG_CREDENTIAL | FLAG_PRIORITIZE_DISK)
 register("slack.signing-secret", flags=FLAG_CREDENTIAL | FLAG_PRIORITIZE_DISK)
+register(
+    "slack.sdk-issue-alert",
+    type=Sequence,
+    default=[],
+    flags=FLAG_ALLOW_EMPTY | FLAG_AUTOMATOR_MODIFIABLE,
+)
 
 # Codecov Integration
 register("codecov.client-secret", flags=FLAG_CREDENTIAL | FLAG_PRIORITIZE_DISK)

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -500,7 +500,7 @@ register("slack.client-secret", flags=FLAG_CREDENTIAL | FLAG_PRIORITIZE_DISK)
 register("slack.verification-token", flags=FLAG_CREDENTIAL | FLAG_PRIORITIZE_DISK)
 register("slack.signing-secret", flags=FLAG_CREDENTIAL | FLAG_PRIORITIZE_DISK)
 register(
-    "slack.sdk-issue-alert",
+    "slack.sdk-web-client",
     type=Sequence,
     default=[],
     flags=FLAG_ALLOW_EMPTY | FLAG_AUTOMATOR_MODIFIABLE,

--- a/tests/sentry/integrations/slack/test_sdk_client.py
+++ b/tests/sentry/integrations/slack/test_sdk_client.py
@@ -34,7 +34,7 @@ class SlackClientTest(TestCase):
 
     @patch("sentry.integrations.slack.sdk_client.metrics")
     @patch("slack_sdk.web.client.WebClient._perform_urllib_http_request")
-    def test_authorize_success(self, mock_api_call, mock_metrics):
+    def test_api_call_success(self, mock_api_call, mock_metrics):
         mock_api_call.return_value = {
             "body": orjson.dumps({"ok": True}).decode(),
             "headers": {},
@@ -52,7 +52,7 @@ class SlackClientTest(TestCase):
 
     @patch("sentry.integrations.slack.sdk_client.metrics")
     @patch("slack_sdk.web.client.WebClient._perform_urllib_http_request")
-    def test_authorize_error(self, mock_api_call, mock_metrics):
+    def test_api_call_error(self, mock_api_call, mock_metrics):
         mock_api_call.return_value = {
             "body": orjson.dumps({"ok": False}).decode() + "'",
             "headers": {},

--- a/tests/sentry/integrations/slack/test_sdk_client.py
+++ b/tests/sentry/integrations/slack/test_sdk_client.py
@@ -1,0 +1,37 @@
+import pytest
+from slack_sdk.errors import SlackApiError
+
+from sentry.integrations.slack.sdk_client import SlackClient
+from sentry.silo.base import SiloMode
+from sentry.testutils.cases import TestCase
+from sentry.testutils.silo import assume_test_silo_mode
+
+
+class SlackClientTest(TestCase):
+    def setUp(self):
+        self.access_token = "xoxb-access-token"
+        self.integration, self.organization_integration = self.create_provider_integration_for(
+            organization=self.organization,
+            user=self.user,
+            external_id="slack:1",
+            provider="slack",
+            metadata={"access_token": self.access_token},
+        )
+
+    def test_no_integration_found_error(self):
+        with pytest.raises(ValueError):
+            SlackClient(integration_id=2)
+
+    def test_no_access_token_error(self):
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            self.integration.update(metadata={})
+
+        with pytest.raises(ValueError):
+            SlackClient(integration_id=self.integration.id)
+
+    def test_authorize(self):
+        client = SlackClient(integration_id=self.integration.id)
+
+        with pytest.raises(SlackApiError):
+            # error raised because it's actually trying to POST
+            client.chat_postMessage(channel="#announcements", text="hello")

--- a/tests/sentry/integrations/slack/test_sdk_client.py
+++ b/tests/sentry/integrations/slack/test_sdk_client.py
@@ -1,7 +1,7 @@
 import pytest
 from slack_sdk.errors import SlackApiError
 
-from sentry.integrations.slack.sdk_client import SlackClient
+from sentry.integrations.slack.sdk_client import SlackSdkClient
 from sentry.silo.base import SiloMode
 from sentry.testutils.cases import TestCase
 from sentry.testutils.silo import assume_test_silo_mode
@@ -20,17 +20,17 @@ class SlackClientTest(TestCase):
 
     def test_no_integration_found_error(self):
         with pytest.raises(ValueError):
-            SlackClient(integration_id=2)
+            SlackSdkClient(integration_id=2)
 
     def test_no_access_token_error(self):
         with assume_test_silo_mode(SiloMode.CONTROL):
             self.integration.update(metadata={})
 
         with pytest.raises(ValueError):
-            SlackClient(integration_id=self.integration.id)
+            SlackSdkClient(integration_id=self.integration.id)
 
     def test_authorize(self):
-        client = SlackClient(integration_id=self.integration.id)
+        client = SlackSdkClient(integration_id=self.integration.id)
 
         with pytest.raises(SlackApiError):
             # error raised because it's actually trying to POST


### PR DESCRIPTION
Added slack_sdk here https://github.com/getsentry/sentry/pull/71881

This PR adds a `SlackClient` that subclasses `WebClient` from the official Slack SDK. To make the usage the same as the in-house `SlackClient`, the abstraction accepts `integration_id` and finds the access token before initializing an instance of the `WebClient`.

We also want to track the response outcomes for every outgoing API call to Slack, so I added a wrapper that executes right after every single API call to increment a metric.