### PR TITLE
fix(insights): failure to fetch full span description

### DIFF
--- a/static/app/views/performance/database/databaseSpanSummaryPage.spec.tsx
+++ b/static/app/views/performance/database/databaseSpanSummaryPage.spec.tsx
@@ -311,7 +311,7 @@ describe('DatabaseSpanSummaryPage', function () {
         query: {
           dataset: 'spansIndexed',
           environment: [],
-          field: ['transaction.id', 'project', 'span_id', 'span.self_time'],
+          field: ['timestamp', 'transaction.id', 'project', 'span_id', 'span.self_time'],
           per_page: 1,
           project: [],
           query: 'span.group:1756baf8fd19c116',

--- a/static/app/views/starfish/queries/useFullSpanFromTrace.tsx
+++ b/static/app/views/starfish/queries/useFullSpanFromTrace.tsx
@@ -30,6 +30,7 @@ export function useFullSpanFromTrace(
       limit: 1,
       enabled,
       fields: [
+        SpanIndexedField.TIMESTAMP,
         SpanIndexedField.TRANSACTION_ID,
         SpanIndexedField.PROJECT,
         SpanIndexedField.ID,


### PR DESCRIPTION
Fixes
![image](https://github.com/getsentry/sentry/assets/44422760/06aa62af-f605-47dc-9f96-d41ea8d8dd45)

This resulting in us defaulting to show the short span description rather then a full example in our modules

Before
![image](https://github.com/getsentry/sentry/assets/44422760/fd32fb1f-6c0a-4371-aebd-76daa6970bd0)

After
![image](https://github.com/getsentry/sentry/assets/44422760/29f7618d-5601-4747-a5ed-45742087cdf6)
