### PR TITLE
feat(traces): Add graph for matching spans to traces

### DIFF
--- a/static/app/views/performance/traces/tracesChart.tsx
+++ b/static/app/views/performance/traces/tracesChart.tsx
@@ -1,0 +1,72 @@
+import {useMemo} from 'react';
+import styled from '@emotion/styled';
+
+import {getInterval} from 'sentry/components/charts/utils';
+import {t} from 'sentry/locale';
+import {RateUnit} from 'sentry/utils/discover/fields';
+import {formatRate} from 'sentry/utils/formatters';
+import {decodeList} from 'sentry/utils/queryString';
+import {MutableSearch} from 'sentry/utils/tokenizeSearch';
+import {useLocation} from 'sentry/utils/useLocation';
+import usePageFilters from 'sentry/utils/usePageFilters';
+import {CHART_HEIGHT} from 'sentry/views/performance/database/settings';
+import {COUNT_COLOR} from 'sentry/views/starfish/colors';
+import Chart, {ChartType} from 'sentry/views/starfish/components/chart';
+import ChartPanel from 'sentry/views/starfish/components/chartPanel';
+import {useSpanIndexedSeries} from 'sentry/views/starfish/queries/useDiscoverSeries';
+
+import {areQueriesEmpty} from './utils';
+
+interface Props {}
+
+export function TracesChart({}: Props) {
+  const location = useLocation();
+  const pageFilters = usePageFilters();
+
+  const queries = useMemo(() => {
+    return decodeList(location.query.query);
+  }, [location.query.query]);
+
+  const spanIndexedCountSeries = useSpanIndexedSeries(
+    {
+      search: new MutableSearch(queries.map(q => `(${q})`).join(' OR ')),
+      yAxis: ['count()'],
+      interval: getInterval(pageFilters.selection.datetime, 'metrics'),
+    },
+    'testing.test'
+  );
+
+  const seriesData = spanIndexedCountSeries.data?.['count()'];
+
+  return (
+    <ChartContainer>
+      <ChartPanel
+        title={areQueriesEmpty(queries) ? t('Total Spans') : t('Matching Spans')}
+      >
+        <Chart
+          height={CHART_HEIGHT}
+          grid={{
+            left: '0',
+            right: '0',
+            top: '8px',
+            bottom: '0',
+          }}
+          data={[seriesData]}
+          loading={spanIndexedCountSeries.isLoading}
+          chartColors={[COUNT_COLOR]}
+          type={ChartType.AREA}
+          aggregateOutputFormat="number"
+          tooltipFormatterOptions={{
+            valueFormatter: value => formatRate(value, RateUnit.PER_MINUTE),
+          }}
+        />
+      </ChartPanel>
+    </ChartContainer>
+  );
+}
+
+const ChartContainer = styled('div')`
+  display: grid;
+  gap: 0;
+  grid-template-columns: 1fr;
+`;

--- a/static/app/views/performance/traces/utils.tsx
+++ b/static/app/views/performance/traces/utils.tsx
@@ -27,6 +27,21 @@ export function getStylingSliceName(
   return sliceName;
 }
 
+export function areQueriesEmpty(queries: string[]): boolean {
+  if (queries.length > 1) {
+    return false;
+  }
+  if (queries.length === 0) {
+    return true;
+  }
+
+  if (queries.length === 1) {
+    return queries[0].length === 0;
+  }
+
+  return false;
+}
+
 export function getSecondaryNameFromSpan(span: SpanResult<Field>) {
   return span['sdk.name'];
 }


### PR DESCRIPTION
### Summary
This includes a graph that displays # of cumulative matching spans according to your search conditions.

Other:
- Small changes to not show 'matching' spans when you have no filters, instead will show 'total' and not have 'of'

#### Screenshots
![Screenshot 2024-06-04 at 12 38 27 PM](https://github.com/getsentry/sentry/assets/6111995/3698b8e1-052e-47b6-a195-f1547a2a2a7c)
