### PR TITLE
feat(empty-states): Update arcade for issue stream empty state

### DIFF
--- a/static/app/components/updatedEmptyState.tsx
+++ b/static/app/components/updatedEmptyState.tsx
@@ -258,7 +258,7 @@ export default function UpdatedEmptyState({project}: {project?: Project}) {
           <BodyTitle>{t('Preview a Sentry Issue')}</BodyTitle>
           <ArcadeWrapper>
             <Arcade
-              src="https://demo.arcade.software/LjEJ1sfLaVRdtOs3mri1?embed"
+              src="https://demo.arcade.software/54VidzNthU5ykIFPCdW1?embed"
               loading="lazy"
               allowFullScreen
             />


### PR DESCRIPTION
this pr updates the arcade used for the issue stream empty state to show the changes to the issue details since the last demo was recorded