### PR TITLE
ref(test): Remove location from context

### DIFF
--- a/static/app/components/sidebar/index.spec.tsx
+++ b/static/app/components/sidebar/index.spec.tsx
@@ -1,19 +1,23 @@
 import type {UseQueryResult} from '@tanstack/react-query';
 import {BroadcastFixture} from 'sentry-fixture/broadcast';
+import {LocationFixture} from 'sentry-fixture/locationFixture';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {ServiceIncidentFixture} from 'sentry-fixture/serviceIncident';
 import {UserFixture} from 'sentry-fixture/user';
 
-import {initializeOrg} from 'sentry-test/initializeOrg';
 import {act, render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import {OnboardingContextProvider} from 'sentry/components/onboarding/onboardingContext';
 import SidebarContainer from 'sentry/components/sidebar';
 import ConfigStore from 'sentry/stores/configStore';
 import type {Organization, StatuspageIncident} from 'sentry/types';
+import {useLocation} from 'sentry/utils/useLocation';
 import * as incidentsHook from 'sentry/utils/useServiceIncidents';
 
 jest.mock('sentry/utils/useServiceIncidents');
+jest.mock('sentry/utils/useLocation');
+
+const mockUseLocation = jest.mocked(useLocation);
 
 const sidebarAccordionFeatures = [
   'performance-view',
@@ -23,7 +27,7 @@ const sidebarAccordionFeatures = [
 ];
 
 describe('Sidebar', function () {
-  const {organization, routerContext} = initializeOrg();
+  const organization = OrganizationFixture();
   const broadcast = BroadcastFixture();
   const user = UserFixture();
   const apiMocks = {
@@ -39,9 +43,10 @@ describe('Sidebar', function () {
   );
 
   const renderSidebar = ({organization: org}: {organization: Organization | null}) =>
-    render(getElement(), {context: routerContext, organization: org});
+    render(getElement(), {organization: org});
 
   beforeEach(function () {
+    mockUseLocation.mockReset();
     jest.spyOn(incidentsHook, 'useServiceIncidents').mockImplementation(
       () =>
         ({
@@ -171,11 +176,9 @@ describe('Sidebar', function () {
       expect(await screen.findByRole('dialog')).toBeInTheDocument();
       expect(screen.getByText("What's new in Sentry")).toBeInTheDocument();
 
-      const oldPath = routerContext.context.location.pathname;
-      routerContext.context.location.pathname = '/other/path';
+      mockUseLocation.mockReturnValue({...LocationFixture(), pathname: '/other/path'});
       rerender(getElement());
       expect(screen.queryByText("What's new in Sentry")).not.toBeInTheDocument();
-      routerContext.context.location.pathname = oldPath;
     });
 
     it('can have onboarding feature', async function () {

--- a/static/app/views/performance/vitalDetail/index.spec.tsx
+++ b/static/app/views/performance/vitalDetail/index.spec.tsx
@@ -279,12 +279,7 @@ describe('Performance > VitalDetail', function () {
       },
     };
 
-    const context = RouterContextFixture([
-      {
-        router: newRouter,
-        location: newRouter.location,
-      },
-    ]);
+    const context = RouterContextFixture([{router: newRouter}]);
 
     render(<TestComponent router={newRouter} />, {
       context,
@@ -331,12 +326,7 @@ describe('Performance > VitalDetail', function () {
       },
     };
 
-    const context = RouterContextFixture([
-      {
-        router: newRouter,
-        location: newRouter.location,
-      },
-    ]);
+    const context = RouterContextFixture([{router: newRouter}]);
 
     render(<TestComponent router={newRouter} />, {
       context,
@@ -384,12 +374,7 @@ describe('Performance > VitalDetail', function () {
       },
     };
 
-    const context = RouterContextFixture([
-      {
-        router: newRouter,
-        location: newRouter.location,
-      },
-    ]);
+    const context = RouterContextFixture([{router: newRouter}]);
 
     render(<TestComponent router={newRouter} />, {
       context,

--- a/tests/js/fixtures/routerContextFixture.ts
+++ b/tests/js/fixtures/routerContextFixture.ts
@@ -1,4 +1,3 @@
-import {LocationFixture} from 'sentry-fixture/locationFixture';
 import {RouterFixture} from 'sentry-fixture/routerFixture';
 
 import {SentryPropTypeValidators} from 'sentry/sentryPropTypeValidators';
@@ -6,13 +5,11 @@ import {SentryPropTypeValidators} from 'sentry/sentryPropTypeValidators';
 export function RouterContextFixture([context, childContextTypes] = []) {
   return {
     context: {
-      location: LocationFixture(),
       router: RouterFixture(),
       ...context,
     },
     childContextTypes: {
       router: SentryPropTypeValidators.isObject,
-      location: SentryPropTypeValidators.isObject,
       ...childContextTypes,
     },
   };

--- a/tests/js/sentry-test/initializeOrg.tsx
+++ b/tests/js/sentry-test/initializeOrg.tsx
@@ -36,7 +36,7 @@ interface InitializeOrgOptions<RouterParams> {
  *   - a project or projects
  *   - organization owning above projects
  *   - router
- *   - context that contains org + projects + router
+ *   - context that contains router
  */
 export function initializeOrg<RouterParams = {orgId: string; projectId: string}>({
   organization: additionalOrg,
@@ -65,12 +65,7 @@ export function initializeOrg<RouterParams = {orgId: string; projectId: string}>
     },
   });
 
-  const routerContext: any = RouterContextFixture([
-    {
-      router,
-      location: router.location,
-    },
-  ]);
+  const routerContext: any = RouterContextFixture([{router}]);
 
   /**
    * A collection of router props that are passed to components by react-router
@@ -86,7 +81,7 @@ export function initializeOrg<RouterParams = {orgId: string; projectId: string}>
     router,
     route: router.routes[0],
     routes: router.routes,
-    location: routerContext.context.location,
+    location: router.location,
   };
 
   return {


### PR DESCRIPTION
This should have never been in here. Location was never in react routers
context.