### PR TITLE
feat(hybridcloud) Add RPC method for sentry-app components

### DIFF
--- a/src/sentry/services/hybrid_cloud/app/impl.py
+++ b/src/sentry/services/hybrid_cloud/app/impl.py
@@ -165,7 +165,7 @@ class DatabaseBackedAppService(AppService):
             ).items()
         }
 
-    def get_component_context(
+    def get_component_contexts(
         self, *, filter: SentryAppInstallationFilterArgs, component_type: str
     ) -> list[RpcSentryAppComponentContext]:
         install_query = self._FQ.query_many(filter=filter)

--- a/src/sentry/services/hybrid_cloud/app/model.py
+++ b/src/sentry/services/hybrid_cloud/app/model.py
@@ -91,6 +91,11 @@ class RpcSentryAppComponent(RpcModel):
     app_schema: Mapping[str, Any] = Field(default_factory=dict)
 
 
+class RpcSentryAppComponentContext(RpcModel):
+    installation: RpcSentryAppInstallation
+    component: RpcSentryAppComponent
+
+
 class RpcAlertRuleActionResult(RpcModel):
     success: bool
     message: str

--- a/src/sentry/services/hybrid_cloud/app/service.py
+++ b/src/sentry/services/hybrid_cloud/app/service.py
@@ -144,7 +144,7 @@ class AppService(RpcService):
 
     @rpc_method
     @abc.abstractmethod
-    def get_component_context(
+    def get_component_contexts(
         self, *, filter: SentryAppInstallationFilterArgs, component_type: str
     ) -> list[RpcSentryAppComponentContext]:
         """

--- a/src/sentry/services/hybrid_cloud/app/service.py
+++ b/src/sentry/services/hybrid_cloud/app/service.py
@@ -17,6 +17,7 @@ from sentry.services.hybrid_cloud.app import (
     RpcSentryAppService,
     SentryAppInstallationFilterArgs,
 )
+from sentry.services.hybrid_cloud.app.model import RpcSentryAppComponentContext
 from sentry.services.hybrid_cloud.auth import AuthenticationContext
 from sentry.services.hybrid_cloud.filter_query import OpaqueSerializedResponse
 from sentry.services.hybrid_cloud.rpc import RpcService, rpc_method
@@ -140,6 +141,19 @@ class AppService(RpcService):
         group_by: str = "sentry_app_id",
     ) -> Mapping[str, Any]:
         pass
+
+    @rpc_method
+    @abc.abstractmethod
+    def get_component_context(
+        self, *, filter: SentryAppInstallationFilterArgs, component_type: str
+    ) -> list[RpcSentryAppComponentContext]:
+        """
+        Get a context object for sentryapp components of a certain type.
+        Used for building sentryapp actions for alerts.
+
+        :param filter: The filtering conditions, same conditions as get_many()
+        :param component_type: The sentry-app component to get
+        """
 
     @rpc_method
     @abc.abstractmethod

--- a/tests/sentry/hybridcloud/test_app.py
+++ b/tests/sentry/hybridcloud/test_app.py
@@ -45,7 +45,8 @@ def test_find_alertable_services() -> None:
 
 
 @django_db_all(transaction=True)
-def test_get_component_context() -> None:
+@all_silo_test
+def test_get_component_contexts() -> None:
     user = Factories.create_user()
     org = Factories.create_organization(owner=user)
     other_org = Factories.create_organization(owner=user)
@@ -75,11 +76,11 @@ def test_get_component_context() -> None:
         slug=app.slug,
     )
     # wrong component type
-    result = app_service.get_component_context(filter={"app_ids": [app.id]}, component_type="derp")
+    result = app_service.get_component_contexts(filter={"app_ids": [app.id]}, component_type="derp")
     assert len(result) == 0
 
     # filter by app_id gets all installs
-    result = app_service.get_component_context(
+    result = app_service.get_component_contexts(
         filter={"app_ids": [app.id]}, component_type="alert-rule-trigger"
     )
     assert len(result) == 2
@@ -90,7 +91,7 @@ def test_get_component_context() -> None:
         assert row.component.app_schema
 
     # filter by install_uuid gets only one
-    result = app_service.get_component_context(
+    result = app_service.get_component_contexts(
         filter={"uuids": [install.uuid]}, component_type="alert-rule-trigger"
     )
     assert len(result) == 1


### PR DESCRIPTION
The sentryapp component request flows we have in alert rules could benefit from tailored methods that better match the scenario.

Adding this RPC method will help unblock refactoring to streamline and simplify both issue rule creation and alert rule creation.

Refs HC-1024