### PR TITLE
perf(trace-explorer): Add additional conditions to trace query

### DIFF
--- a/src/sentry/api/endpoints/organization_traces.py
+++ b/src/sentry/api/endpoints/organization_traces.py
@@ -505,15 +505,29 @@ class TraceSamplesExecutor:
                 ),
             )
 
+            trace_conditions = []
             for user_query in self.user_queries:
                 # We want to ignore all the aggregate conditions here because we're strictly
                 # searching on span attributes, not aggregates
                 where, _ = query.resolve_conditions(user_query)
+                if not where:
+                    continue
+                elif len(where) == 1:
+                    trace_conditions.extend(where)
+                else:
+                    trace_conditions.append(BooleanCondition(op=BooleanOp.AND, conditions=where))
 
                 # Transform the condition into it's aggregate form so it can be used to
                 # match on the trace.
                 new_condition = generate_trace_condition(where)
                 query.having.append(new_condition)
+
+            if len(trace_conditions) == 1:
+                # This should never happen since it should use a flat query
+                # but handle it just in case.
+                query.where.extend(trace_conditions)
+            elif len(trace_conditions) > 1:
+                query.where.append(BooleanCondition(op=BooleanOp.OR, conditions=trace_conditions))
 
         return query, timestamp_column
 

--- a/src/sentry/api/endpoints/organization_traces.py
+++ b/src/sentry/api/endpoints/organization_traces.py
@@ -510,17 +510,16 @@ class TraceSamplesExecutor:
                 # We want to ignore all the aggregate conditions here because we're strictly
                 # searching on span attributes, not aggregates
                 where, _ = query.resolve_conditions(user_query)
-                if not where:
-                    continue
-                elif len(where) == 1:
+                if len(where) == 1:
                     trace_conditions.extend(where)
-                else:
+                elif len(where) > 1:
                     trace_conditions.append(BooleanCondition(op=BooleanOp.AND, conditions=where))
 
                 # Transform the condition into it's aggregate form so it can be used to
                 # match on the trace.
                 new_condition = generate_trace_condition(where)
-                query.having.append(new_condition)
+                if new_condition:
+                    query.having.append(new_condition)
 
             if len(trace_conditions) == 1:
                 # This should never happen since it should use a flat query

--- a/tests/sentry/api/endpoints/test_organization_traces.py
+++ b/tests/sentry/api/endpoints/test_organization_traces.py
@@ -720,6 +720,7 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
                 "(foo:bar AND span.duration:>10s) OR (foo:bar AND span.duration:<10m)",
                 "foo:baz",
             ],
+            ["foo:bar span.duration:>10s", "foo:baz"],
             ["foo:[bar, baz]"],
         ]:
             query = {


### PR DESCRIPTION
This shouldn't change the result of the query but adding these additional non aggregate conditions means the rows that the aggregate conditions are applied on is reduced and any application indicies are used as well.