### PR TITLE
chore(hybridcloud) Use cached installation read all the time

### DIFF
--- a/src/sentry/tasks/sentry_apps.py
+++ b/src/sentry/tasks/sentry_apps.py
@@ -12,7 +12,6 @@ from sentry import analytics
 from sentry.api.serializers import AppPlatformEvent, serialize
 from sentry.constants import SentryAppInstallationStatus
 from sentry.eventstore.models import Event, GroupEvent
-from sentry.features.rollout import in_random_rollout
 from sentry.models.activity import Activity
 from sentry.models.group import Group
 from sentry.models.integrations.sentry_app import VALID_EVENTS
@@ -294,10 +293,7 @@ def build_comment_webhook(installation_id, issue_id, type, user_id, *args, **kwa
 
 def get_webhook_data(installation_id, issue_id, user_id):
     extra = {"installation_id": installation_id, "issue_id": issue_id}
-    if in_random_rollout("sentryapps.get_installation_cached"):
-        install = app_service.installation_by_id(id=installation_id)
-    else:
-        install = app_service.get_installation_by_id(id=installation_id)
+    install = app_service.installation_by_id(id=installation_id)
     if not install:
         logger.info("workflow_notification.missing_installation", extra=extra)
         return
@@ -320,10 +316,7 @@ def get_webhook_data(installation_id, issue_id, user_id):
 @instrumented_task("sentry.tasks.send_process_resource_change_webhook", **TASK_OPTIONS)
 @retry_decorator
 def send_resource_change_webhook(installation_id, event, data, *args, **kwargs):
-    if in_random_rollout("sentryapps.get_installation_cached"):
-        installation = app_service.installation_by_id(id=installation_id)
-    else:
-        installation = app_service.get_installation_by_id(id=installation_id)
+    installation = app_service.installation_by_id(id=installation_id)
     if not installation:
         logger.info(
             "send_process_resource_change_webhook.missing_installation",


### PR DESCRIPTION
Remove the rollout option for cached installation reads.

Refs HC-1185

