### PR TITLE
test(js): Remove all usages of routerContext

### DIFF
--- a/static/app/components/breadcrumbs.spec.tsx
+++ b/static/app/components/breadcrumbs.spec.tsx
@@ -1,11 +1,11 @@
-import {RouterContextFixture} from 'sentry-fixture/routerContextFixture';
+import {RouterFixture} from 'sentry-fixture/routerFixture';
 
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
 import {Breadcrumbs} from 'sentry/components/breadcrumbs';
 
 describe('Breadcrumbs', () => {
-  const routerContext = RouterContextFixture();
+  const router = RouterFixture();
 
   afterEach(() => {
     jest.resetAllMocks();
@@ -29,7 +29,7 @@ describe('Breadcrumbs', () => {
           },
         ]}
       />,
-      {context: routerContext}
+      {router}
     );
   }
 
@@ -46,15 +46,15 @@ describe('Breadcrumbs', () => {
   it('generates correct links', async () => {
     createWrapper();
     await userEvent.click(screen.getByText('Test 1'));
-    expect(routerContext.context.router.push).toHaveBeenCalledWith('/test1');
+    expect(router.push).toHaveBeenCalledWith('/test1');
     await userEvent.click(screen.getByText('Test 2'));
-    expect(routerContext.context.router.push).toHaveBeenCalledWith('/test2');
+    expect(router.push).toHaveBeenCalledWith('/test2');
   });
 
   it('does not make links where no `to` is provided', async () => {
     createWrapper();
     await userEvent.click(screen.getByText('Test 3'));
-    expect(routerContext.context.router.push).not.toHaveBeenCalled();
+    expect(router.push).not.toHaveBeenCalled();
   });
 
   it('renders a crumb dropdown', async () => {
@@ -81,7 +81,7 @@ describe('Breadcrumbs', () => {
           },
         ]}
       />,
-      {context: routerContext}
+      {router}
     );
     await userEvent.hover(screen.getByText('dropdown crumb'));
 

--- a/static/app/components/charts/optionSelector.spec.tsx
+++ b/static/app/components/charts/optionSelector.spec.tsx
@@ -53,7 +53,7 @@ describe('Charts > OptionSelector (Multiple)', function () {
       projects: [],
     });
 
-    return render(<TestComponent />, {context: initialData.routerContext});
+    return render(<TestComponent />, {router: initialData.router});
   };
 
   it('renders yAxisOptions with yAxisValue selected', async function () {

--- a/static/app/components/createAlertButton.spec.tsx
+++ b/static/app/components/createAlertButton.spec.tsx
@@ -1,6 +1,6 @@
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {ProjectFixture} from 'sentry-fixture/project';
-import {RouterContextFixture} from 'sentry-fixture/routerContextFixture';
+import {RouterFixture} from 'sentry-fixture/routerFixture';
 
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
@@ -251,7 +251,7 @@ describe('CreateAlertFromViewButton', () => {
   });
 
   it('removes a duplicate project filter', async () => {
-    const context = RouterContextFixture();
+    const router = RouterFixture();
 
     const projects = [ProjectFixture()];
     jest.mocked(useProjects).mockReturnValue({
@@ -276,10 +276,10 @@ describe('CreateAlertFromViewButton', () => {
         projects={projects}
         onClick={onClickMock}
       />,
-      {context}
+      {router}
     );
     await userEvent.click(screen.getByRole('button'));
-    expect(context.context.router.push).toHaveBeenCalledWith({
+    expect(router.push).toHaveBeenCalledWith({
       pathname: `/organizations/org-slug/alerts/new/metric/`,
       query: expect.objectContaining({
         query: 'event.type:error ',

--- a/static/app/components/eventOrGroupExtraDetails.spec.tsx
+++ b/static/app/components/eventOrGroupExtraDetails.spec.tsx
@@ -1,12 +1,9 @@
-import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render} from 'sentry-test/reactTestingLibrary';
 
 import EventOrGroupExtraDetails from 'sentry/components/eventOrGroupExtraDetails';
 import type {Group} from 'sentry/types/group';
 
 describe('EventOrGroupExtraDetails', function () {
-  const {routerContext} = initializeOrg();
-
   it('renders last and first seen', function () {
     render(
       <EventOrGroupExtraDetails
@@ -18,8 +15,7 @@ describe('EventOrGroupExtraDetails', function () {
             firstSeen: '2017-07-01T02:06:02Z',
           } as Group
         }
-      />,
-      {context: routerContext}
+      />
     );
   });
 
@@ -33,8 +29,7 @@ describe('EventOrGroupExtraDetails', function () {
             firstSeen: '2017-07-01T02:06:02Z',
           } as Group
         }
-      />,
-      {context: routerContext}
+      />
     );
   });
 
@@ -48,8 +43,7 @@ describe('EventOrGroupExtraDetails', function () {
             lastSeen: '2017-07-25T22:56:12Z',
           } as Group
         }
-      />,
-      {context: routerContext}
+      />
     );
   });
 
@@ -71,8 +65,7 @@ describe('EventOrGroupExtraDetails', function () {
             status: 'resolved',
           } as Group
         }
-      />,
-      {context: routerContext}
+      />
     );
   });
 
@@ -95,8 +88,7 @@ describe('EventOrGroupExtraDetails', function () {
           } as Group
         }
         showAssignee
-      />,
-      {context: routerContext}
+      />
     );
   });
 
@@ -115,8 +107,7 @@ describe('EventOrGroupExtraDetails', function () {
             subscriptionDetails: {reason: 'mentioned'},
           } as Group
         }
-      />,
-      {context: routerContext}
+      />
     );
   });
 });

--- a/static/app/components/eventOrGroupHeader.spec.tsx
+++ b/static/app/components/eventOrGroupHeader.spec.tsx
@@ -36,7 +36,7 @@ const event = EventFixture({
 });
 
 describe('EventOrGroupHeader', function () {
-  const {organization, router, routerContext} = initializeOrg();
+  const {organization, router} = initializeOrg();
 
   describe('Group', function () {
     it('renders with `type = error`', function () {
@@ -181,7 +181,6 @@ describe('EventOrGroupHeader', function () {
           }}
         />,
         {
-          context: routerContext,
           router: {
             ...router,
             location: {
@@ -211,7 +210,6 @@ describe('EventOrGroupHeader', function () {
           }}
         />,
         {
-          context: routerContext,
           router: {
             ...router,
             location: {

--- a/static/app/components/events/eventAttachments.spec.tsx
+++ b/static/app/components/events/eventAttachments.spec.tsx
@@ -14,7 +14,7 @@ import {
 import {EventAttachments} from 'sentry/components/events/eventAttachments';
 
 describe('EventAttachments', function () {
-  const {routerContext, organization, project} = initializeOrg({
+  const {router, organization, project} = initializeOrg({
     organization: {
       features: ['event-attachments'],
       orgRole: 'member',
@@ -41,7 +41,7 @@ describe('EventAttachments', function () {
     });
     const strippedCrashEvent = {...event, metadata: {stripped_crash: true}};
     render(<EventAttachments {...props} event={strippedCrashEvent} />, {
-      context: routerContext,
+      router,
       organization,
     });
 
@@ -77,7 +77,7 @@ describe('EventAttachments', function () {
         {...props}
         event={{...event, metadata: {stripped_crash: false}}}
       />,
-      {context: routerContext, organization}
+      {router, organization}
     );
 
     // No loading state to wait for
@@ -87,14 +87,13 @@ describe('EventAttachments', function () {
   });
 
   it('displays message when user lacks permission to preview an attachment', async function () {
-    const {routerContext: newRouterContext, organization: orgWithWrongAttachmentRole} =
-      initializeOrg({
-        organization: {
-          features: ['event-attachments'],
-          orgRole: 'member',
-          attachmentsRole: 'admin',
-        },
-      } as any);
+    const {router: newRouter, organization: orgWithWrongAttachmentRole} = initializeOrg({
+      organization: {
+        features: ['event-attachments'],
+        orgRole: 'member',
+        attachmentsRole: 'admin',
+      },
+    } as any);
     const attachment = EventAttachmentFixture({
       name: 'some_file.txt',
       headers: {
@@ -114,7 +113,7 @@ describe('EventAttachments', function () {
     });
 
     render(<EventAttachments {...props} />, {
-      context: newRouterContext,
+      router: newRouter,
       organization: orgWithWrongAttachmentRole,
     });
 
@@ -145,7 +144,7 @@ describe('EventAttachments', function () {
       body: 'file contents',
     });
 
-    render(<EventAttachments {...props} />, {context: routerContext, organization});
+    render(<EventAttachments {...props} />, {router, organization});
 
     expect(await screen.findByText('Attachments (1)')).toBeInTheDocument();
 
@@ -172,7 +171,7 @@ describe('EventAttachments', function () {
       method: 'DELETE',
     });
 
-    render(<EventAttachments {...props} />, {context: routerContext, organization});
+    render(<EventAttachments {...props} />, {router, organization});
     renderGlobalModal();
 
     expect(await screen.findByText('Attachments (2)')).toBeInTheDocument();

--- a/static/app/components/events/eventReplay/replayClipPreview.spec.tsx
+++ b/static/app/components/events/eventReplay/replayClipPreview.spec.tsx
@@ -65,7 +65,7 @@ const render = (
   children: React.ReactElement,
   orgParams: Partial<DetailedOrganization> = {}
 ) => {
-  const {routerContext, organization} = initializeOrg({
+  const {router, organization} = initializeOrg({
     organization: {slug: mockOrgSlug, ...orgParams},
     router: {
       routes: [
@@ -81,7 +81,7 @@ const render = (
   });
 
   return baseRender(children, {
-    context: routerContext,
+    router,
     organization,
   });
 };

--- a/static/app/components/events/eventReplay/replayPreview.spec.tsx
+++ b/static/app/components/events/eventReplay/replayPreview.spec.tsx
@@ -63,7 +63,7 @@ mockUseReplayReader.mockImplementation(() => {
 });
 
 const render: typeof baseRender = children => {
-  const {routerContext} = initializeOrg({
+  const {router} = initializeOrg({
     router: {
       routes: [
         {path: '/'},
@@ -78,7 +78,7 @@ const render: typeof baseRender = children => {
   });
 
   return baseRender(children, {
-    context: routerContext,
+    router,
     organization: OrganizationFixture({slug: mockOrgSlug}),
   });
 };

--- a/static/app/components/events/eventTagsAndScreenshot/screenshot/modal.spec.tsx
+++ b/static/app/components/events/eventTagsAndScreenshot/screenshot/modal.spec.tsx
@@ -14,7 +14,7 @@ import type {EventAttachment, Project} from 'sentry/types';
 const stubEl = (props: {children?: React.ReactNode}) => <div>{props.children}</div>;
 
 function renderModal({
-  initialData: {organization, routerContext},
+  initialData: {organization, router},
   eventAttachment,
   projectSlug,
   attachmentIndex,
@@ -53,7 +53,7 @@ function renderModal({
       enablePagination={enablePagination}
     />,
     {
-      context: routerContext,
+      router,
       organization,
     }
   );
@@ -172,7 +172,7 @@ describe('Modals -> ScreenshotModal', function () {
         enablePagination
       />,
       {
-        context: initialData.routerContext,
+        router: initialData.router,
         organization: initialData.organization,
       }
     );
@@ -209,7 +209,7 @@ describe('Modals -> ScreenshotModal', function () {
         enablePagination
       />,
       {
-        context: initialData.routerContext,
+        router: initialData.router,
         organization: initialData.organization,
       }
     );

--- a/static/app/components/events/interfaces/crashContent/exception/content.spec.tsx
+++ b/static/app/components/events/interfaces/crashContent/exception/content.spec.tsx
@@ -46,11 +46,7 @@ describe('Exception Content', function () {
       body: projectDetails,
     });
 
-    const {
-      organization: org,
-      router,
-      routerContext,
-    } = initializeOrg({
+    const {organization: org, router} = initializeOrg({
       router: {
         location: {query: {project: project.id}},
       },
@@ -145,7 +141,7 @@ describe('Exception Content', function () {
         meta={event._meta!.entries[0].data.values}
         projectSlug={project.slug}
       />,
-      {organization: org, router, context: routerContext}
+      {organization: org, router}
     );
 
     expect(screen.getAllByText(/redacted/)).toHaveLength(2);

--- a/static/app/components/events/interfaces/frame/frameVariables.spec.tsx
+++ b/static/app/components/events/interfaces/frame/frameVariables.spec.tsx
@@ -21,7 +21,7 @@ describe('Frame Variables', function () {
     });
     ProjectsStore.loadInitialData([project]);
 
-    const {organization, router, routerContext} = initializeOrg({
+    const {organization, router} = initializeOrg({
       router: {
         location: {query: {project: project.id}},
       },
@@ -70,7 +70,7 @@ describe('Frame Variables', function () {
           },
         }}
       />,
-      {organization, router, context: routerContext}
+      {organization, router}
     );
 
     expect(screen.getAllByText(/redacted/)).toHaveLength(2);

--- a/static/app/components/events/sdkUpdates/index.spec.tsx
+++ b/static/app/components/events/sdkUpdates/index.spec.tsx
@@ -1,13 +1,10 @@
 import {EventFixture} from 'sentry-fixture/event';
 
-import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render} from 'sentry-test/reactTestingLibrary';
 
 import {EventSdkUpdates} from 'sentry/components/events/sdkUpdates';
 
 describe('EventSdkUpdates', function () {
-  const {routerContext} = initializeOrg();
-
   it('renders a suggestion to update the sdk and then enable an integration', function () {
     const event = EventFixture({
       id: '123',
@@ -33,6 +30,6 @@ describe('EventSdkUpdates', function () {
       ],
     });
 
-    render(<EventSdkUpdates event={event} />, {context: routerContext});
+    render(<EventSdkUpdates event={event} />);
   });
 });

--- a/static/app/components/globalSelectionLink.spec.tsx
+++ b/static/app/components/globalSelectionLink.spec.tsx
@@ -1,4 +1,3 @@
-import {RouterContextFixture} from 'sentry-fixture/routerContextFixture';
 import {RouterFixture} from 'sentry-fixture/routerFixture';
 
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
@@ -8,35 +7,29 @@ import GlobalSelectionLink from 'sentry/components/globalSelectionLink';
 const path = 'http://some.url/';
 
 describe('GlobalSelectionLink', function () {
-  const getContext = (query?: {environment: string; project: string[]}) =>
-    RouterContextFixture([
-      {
-        router: RouterFixture({
-          location: {query},
-        }),
-      },
-    ]);
+  const getRouter = (query?: {environment: string; project: string[]}) =>
+    RouterFixture({location: {query}});
 
   it('has global selection values in query', async function () {
     const query = {
       project: ['foo', 'bar'],
       environment: 'staging',
     };
-    const context = getContext(query);
+    const router = getRouter(query);
 
-    render(<GlobalSelectionLink to={path}>Go somewhere!</GlobalSelectionLink>, {context});
+    render(<GlobalSelectionLink to={path}>Go somewhere!</GlobalSelectionLink>, {router});
     expect(screen.getByText('Go somewhere!')).toHaveAttribute(
       'href',
       'http://some.url/?environment=staging&project=foo&project=bar'
     );
 
     await userEvent.click(screen.getByText('Go somewhere!'));
-    expect(context.context.router.push).toHaveBeenCalledWith({pathname: path, query});
+    expect(router.push).toHaveBeenCalledWith({pathname: path, query});
   });
 
   it('does not have global selection values in query', function () {
     render(<GlobalSelectionLink to={path}>Go somewhere!</GlobalSelectionLink>, {
-      context: getContext(),
+      router: getRouter(),
     });
 
     expect(screen.getByText('Go somewhere!')).toHaveAttribute('href', path);
@@ -47,17 +40,17 @@ describe('GlobalSelectionLink', function () {
       project: ['foo', 'bar'],
       environment: 'staging',
     };
-    const context = getContext(query);
+    const router = getRouter(query);
     const customQuery = {query: 'something'};
     render(
       <GlobalSelectionLink to={{pathname: path, query: customQuery}}>
         Go somewhere!
       </GlobalSelectionLink>,
-      {context}
+      {router}
     );
 
     await userEvent.click(screen.getByText('Go somewhere!'));
-    expect(context.context.router.push).toHaveBeenCalledWith({
+    expect(router.push).toHaveBeenCalledWith({
       pathname: path,
       query: {project: ['foo', 'bar'], environment: 'staging', query: 'something'},
     });
@@ -68,14 +61,14 @@ describe('GlobalSelectionLink', function () {
       project: ['foo', 'bar'],
       environment: 'staging',
     };
-    const context = getContext(query);
+    const router = getRouter(query);
     render(
       <GlobalSelectionLink to={{pathname: path}}>Go somewhere!</GlobalSelectionLink>,
-      {context}
+      {router}
     );
 
     await userEvent.click(screen.getByText('Go somewhere!'));
 
-    expect(context.context.router.push).toHaveBeenCalledWith({pathname: path, query});
+    expect(router.push).toHaveBeenCalledWith({pathname: path, query});
   });
 });

--- a/static/app/components/group/issueReplayCount.spec.tsx
+++ b/static/app/components/group/issueReplayCount.spec.tsx
@@ -22,7 +22,7 @@ function mockCount(count: undefined | number) {
 describe('IssueReplayCount', function () {
   const groupId = '3363325111';
   const group = GroupFixture({id: groupId});
-  const {organization, routerContext} = initializeOrg();
+  const {organization, router} = initializeOrg();
 
   it('does not render when a group has undefined count', async function () {
     const mockGetReplayCountForIssue = mockCount(undefined);
@@ -52,7 +52,7 @@ describe('IssueReplayCount', function () {
     const mockGetReplayCountForIssue = mockCount(2);
 
     const {container} = render(<IssueReplayCount group={group} />, {
-      context: routerContext,
+      router,
     });
 
     await waitFor(() => {

--- a/static/app/components/group/tagFacets/index.spec.tsx
+++ b/static/app/components/group/tagFacets/index.spec.tsx
@@ -6,7 +6,7 @@ import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrar
 import TagFacets, {TAGS_FORMATTER} from 'sentry/components/group/tagFacets';
 
 const mockProject = ProjectFixture();
-const {router, organization, routerContext} = initializeOrg({
+const {router, organization} = initializeOrg({
   organization: {},
   project: mockProject,
   projects: [mockProject],
@@ -200,9 +200,8 @@ describe('Tag Facets', function () {
           tagFormatter={TAGS_FORMATTER}
         />,
         {
-          context: routerContext,
-          organization,
           router,
+          organization,
         }
       );
       await waitFor(() => {
@@ -231,9 +230,8 @@ describe('Tag Facets', function () {
           tagFormatter={TAGS_FORMATTER}
         />,
         {
-          context: routerContext,
-          organization,
           router,
+          organization,
         }
       );
       await waitFor(() => {

--- a/static/app/components/modals/commandPalette.spec.tsx
+++ b/static/app/components/modals/commandPalette.spec.tsx
@@ -1,7 +1,6 @@
 import {MembersFixture} from 'sentry-fixture/members';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {ProjectFixture} from 'sentry-fixture/project';
-import {RouterContextFixture} from 'sentry-fixture/routerContextFixture';
 import {RouterFixture} from 'sentry-fixture/routerFixture';
 import {TeamFixture} from 'sentry-fixture/team';
 
@@ -89,13 +88,9 @@ describe('Command Palette Modal', function () {
         Footer={ModalFooter}
       />,
       {
-        context: RouterContextFixture([
-          {
-            router: RouterFixture({
-              params: {orgId: 'org-slug'},
-            }),
-          },
-        ]),
+        router: RouterFixture({
+          params: {orgId: 'org-slug'},
+        }),
       }
     );
 

--- a/static/app/components/modals/dashboardWidgetQuerySelectorModal.spec.tsx
+++ b/static/app/components/modals/dashboardWidgetQuerySelectorModal.spec.tsx
@@ -21,7 +21,7 @@ function renderModal({initialData, widget}) {
       widget={widget}
       api={api}
     />,
-    {context: initialData.routerContext}
+    {router: initialData.router}
   );
 }
 

--- a/static/app/components/modals/widgetViewerModal.spec.tsx
+++ b/static/app/components/modals/widgetViewerModal.spec.tsx
@@ -35,7 +35,7 @@ const waitForMetaToHaveBeenCalled = async () => {
 };
 
 async function renderModal({
-  initialData: {organization, routerContext},
+  initialData: {organization, router},
   widget,
   seriesData,
   tableData,
@@ -70,7 +70,7 @@ async function renderModal({
       />
     </div>,
     {
-      context: routerContext,
+      router,
       organization,
     }
   );

--- a/static/app/components/onboarding/platformOptionsControl.spec.tsx
+++ b/static/app/components/onboarding/platformOptionsControl.spec.tsx
@@ -30,7 +30,7 @@ describe('Onboarding Product Selection', function () {
   };
 
   it('renders default state', function () {
-    const {routerContext} = initializeOrg({
+    const {router} = initializeOrg({
       router: {
         location: {
           query: {
@@ -43,7 +43,7 @@ describe('Onboarding Product Selection', function () {
     });
 
     render(<PlatformOptionsControl platformOptions={platformOptions} />, {
-      context: routerContext,
+      router,
     });
 
     // Find the Spring Boot option, preselected from the URL
@@ -75,7 +75,7 @@ describe('Onboarding Product Selection', function () {
   });
 
   it('updates the url on change', async function () {
-    const {router, routerContext} = initializeOrg({
+    const {router} = initializeOrg({
       router: {
         location: {
           query: {
@@ -88,7 +88,7 @@ describe('Onboarding Product Selection', function () {
     });
 
     render(<PlatformOptionsControl platformOptions={platformOptions} />, {
-      context: routerContext,
+      router,
     });
 
     const springBootV3 = screen.getByRole('radio', {name: 'V3'});

--- a/static/app/components/onboarding/productSelection.spec.tsx
+++ b/static/app/components/onboarding/productSelection.spec.tsx
@@ -16,7 +16,7 @@ describe('Onboarding Product Selection', function () {
   });
 
   it('renders default state', async function () {
-    const {router, routerContext} = initializeOrg({
+    const {router} = initializeOrg({
       router: {
         location: {
           query: {
@@ -31,7 +31,7 @@ describe('Onboarding Product Selection', function () {
     });
 
     render(<ProductSelection organization={organization} platform="javascript-react" />, {
-      context: routerContext,
+      router,
     });
 
     // Introduction
@@ -95,7 +95,7 @@ describe('Onboarding Product Selection', function () {
   });
 
   it('renders for Loader Script', async function () {
-    const {routerContext} = initializeOrg({
+    const {router} = initializeOrg({
       router: {
         location: {
           query: {
@@ -119,7 +119,7 @@ describe('Onboarding Product Selection', function () {
         platform="javascript-react"
       />,
       {
-        context: routerContext,
+        router,
       }
     );
 
@@ -141,7 +141,7 @@ describe('Onboarding Product Selection', function () {
   });
 
   it('renders disabled product', async function () {
-    const {router, routerContext} = initializeOrg({
+    const {router} = initializeOrg({
       router: {
         location: {
           query: {product: [ProductSolution.SESSION_REPLAY]},
@@ -163,7 +163,7 @@ describe('Onboarding Product Selection', function () {
         platform="javascript-react"
       />,
       {
-        context: routerContext,
+        router,
       }
     );
 
@@ -191,7 +191,7 @@ describe('Onboarding Product Selection', function () {
       ProductSolution.PERFORMANCE_MONITORING,
     ];
 
-    const {router, routerContext} = initializeOrg({
+    const {router} = initializeOrg({
       router: {
         location: {
           query: {product: [ProductSolution.SESSION_REPLAY]},
@@ -201,7 +201,7 @@ describe('Onboarding Product Selection', function () {
     });
 
     render(<ProductSelection organization={organization} platform="javascript-react" />, {
-      context: routerContext,
+      router,
     });
 
     expect(
@@ -218,7 +218,7 @@ describe('Onboarding Product Selection', function () {
   });
 
   it('render Profiling', async function () {
-    const {router, routerContext} = initializeOrg({
+    const {router} = initializeOrg({
       router: {
         location: {
           query: {product: [ProductSolution.PERFORMANCE_MONITORING]},
@@ -228,7 +228,7 @@ describe('Onboarding Product Selection', function () {
     });
 
     render(<ProductSelection organization={organization} platform="python-django" />, {
-      context: routerContext,
+      router,
     });
 
     expect(screen.getByRole('checkbox', {name: 'Profiling'})).toBeInTheDocument();
@@ -245,7 +245,7 @@ describe('Onboarding Product Selection', function () {
   });
 
   it('renders npm & yarn info text', function () {
-    const {routerContext} = initializeOrg({
+    const {router} = initializeOrg({
       router: {
         location: {
           query: {product: [ProductSolution.PERFORMANCE_MONITORING]},
@@ -255,7 +255,7 @@ describe('Onboarding Product Selection', function () {
     });
 
     render(<ProductSelection organization={organization} platform="javascript-react" />, {
-      context: routerContext,
+      router,
     });
 
     expect(screen.queryByText('npm')).toBeInTheDocument();
@@ -263,7 +263,7 @@ describe('Onboarding Product Selection', function () {
   });
 
   it('does not render npm & yarn info text', function () {
-    const {routerContext} = initializeOrg({
+    const {router} = initializeOrg({
       router: {
         location: {
           query: {product: [ProductSolution.PERFORMANCE_MONITORING]},
@@ -273,7 +273,7 @@ describe('Onboarding Product Selection', function () {
     });
 
     render(<ProductSelection organization={organization} platform="python-django" />, {
-      context: routerContext,
+      router,
     });
 
     expect(screen.queryByText('npm')).not.toBeInTheDocument();

--- a/static/app/components/organizations/datePageFilter.spec.tsx
+++ b/static/app/components/organizations/datePageFilter.spec.tsx
@@ -6,7 +6,7 @@ import {DatePageFilter} from 'sentry/components/organizations/datePageFilter';
 import OrganizationStore from 'sentry/stores/organizationStore';
 import PageFiltersStore from 'sentry/stores/pageFiltersStore';
 
-const {organization, router, routerContext} = initializeOrg({
+const {organization, router} = initializeOrg({
   router: {
     location: {
       query: {},
@@ -38,7 +38,7 @@ describe('DatePageFilter', function () {
   });
 
   it('can change period', async function () {
-    render(<DatePageFilter />, {context: routerContext, organization});
+    render(<DatePageFilter />, {router, organization});
 
     // Open time period dropdown
     await userEvent.click(screen.getByRole('button', {name: '7D', expanded: false}));
@@ -72,7 +72,7 @@ describe('DatePageFilter', function () {
   });
 
   it('can change absolute range', async function () {
-    render(<DatePageFilter />, {context: routerContext, organization});
+    render(<DatePageFilter />, {router, organization});
 
     // Open time period dropdown
     await userEvent.click(screen.getByRole('button', {name: '7D', expanded: false}));
@@ -124,11 +124,7 @@ describe('DatePageFilter', function () {
   });
 
   it('displays a desynced state message', async function () {
-    const {
-      organization: desyncOrganization,
-      router: desyncRouter,
-      routerContext: desyncRouterContext,
-    } = initializeOrg({
+    const {organization: desyncOrganization, router: desyncRouter} = initializeOrg({
       router: {
         location: {
           // the datetime parameters need to be non-null for desync detection to work
@@ -150,7 +146,7 @@ describe('DatePageFilter', function () {
     });
 
     render(<DatePageFilter />, {
-      context: desyncRouterContext,
+      router: desyncRouter,
       organization: desyncOrganization,
     });
 

--- a/static/app/components/organizations/environmentPageFilter/index.spec.tsx
+++ b/static/app/components/organizations/environmentPageFilter/index.spec.tsx
@@ -7,7 +7,7 @@ import OrganizationStore from 'sentry/stores/organizationStore';
 import PageFiltersStore from 'sentry/stores/pageFiltersStore';
 import ProjectsStore from 'sentry/stores/projectsStore';
 
-const {organization, router, routerContext} = initializeOrg({
+const {organization, router} = initializeOrg({
   organization: {features: ['global-views', 'open-membership']},
   project: undefined,
   projects: [
@@ -45,7 +45,7 @@ describe('EnvironmentPageFilter', function () {
 
   it('renders & handles single selection', async function () {
     render(<EnvironmentPageFilter />, {
-      context: routerContext,
+      router,
       organization,
     });
 
@@ -69,7 +69,7 @@ describe('EnvironmentPageFilter', function () {
 
   it('handles multiple selection', async function () {
     render(<EnvironmentPageFilter />, {
-      context: routerContext,
+      router,
       organization,
     });
 
@@ -93,7 +93,7 @@ describe('EnvironmentPageFilter', function () {
   it('handles reset', async function () {
     const onReset = jest.fn();
     render(<EnvironmentPageFilter onReset={onReset} />, {
-      context: routerContext,
+      router,
       organization,
     });
 
@@ -117,7 +117,7 @@ describe('EnvironmentPageFilter', function () {
 
   it('responds to page filter changes, async e.g. from back button nav', async function () {
     render(<EnvironmentPageFilter />, {
-      context: routerContext,
+      router,
       organization,
     });
 
@@ -132,11 +132,7 @@ describe('EnvironmentPageFilter', function () {
   });
 
   it('displays a desynced state message', async function () {
-    const {
-      organization: desyncOrganization,
-      router: desyncRouter,
-      routerContext: desyncRouterContext,
-    } = initializeOrg({
+    const {organization: desyncOrganization, router: desyncRouter} = initializeOrg({
       organization: {features: ['global-views', 'open-membership']},
       project: undefined,
       projects: [
@@ -164,7 +160,7 @@ describe('EnvironmentPageFilter', function () {
     });
 
     render(<EnvironmentPageFilter />, {
-      context: desyncRouterContext,
+      router: desyncRouter,
       organization: desyncOrganization,
     });
 

--- a/static/app/components/organizations/pageFilters/container.spec.tsx
+++ b/static/app/components/organizations/pageFilters/container.spec.tsx
@@ -15,26 +15,20 @@ import PageFiltersStore from 'sentry/stores/pageFiltersStore';
 import ProjectsStore from 'sentry/stores/projectsStore';
 import localStorage from 'sentry/utils/localStorage';
 
-const changeQuery = (routerContext, query) => ({
-  ...routerContext,
-  context: {
-    ...routerContext.context,
-    router: {
-      ...routerContext.context.router,
-      location: {
-        ...routerContext.context.router.location,
-        query,
-      },
-    },
+const changeQuery = (router, query) => ({
+  ...router,
+  location: {
+    ...router.location,
+    query,
   },
 });
 
-function renderComponent(component, routerContext, organization) {
-  return render(component, {context: routerContext, organization});
+function renderComponent(component, router, organization) {
+  return render(component, {router, organization});
 }
 
 describe('PageFiltersContainer', function () {
-  const {organization, router, routerContext} = initializeOrg({
+  const {organization, router} = initializeOrg({
     organization: {features: ['global-views']},
     projects: [
       {
@@ -86,11 +80,7 @@ describe('PageFiltersContainer', function () {
     renderComponent(
       <PageFiltersContainer />,
       {
-        ...routerContext,
-        context: {
-          ...routerContext.context,
-          router: {...routerContext.context.router, params: {orgId: 'diff-org'}},
-        },
+        router: {...router, params: {orgId: 'diff-org'}},
       },
       organization
     );
@@ -98,7 +88,7 @@ describe('PageFiltersContainer', function () {
   });
 
   it('does not replace URL with values from store when mounted with no query params', function () {
-    renderComponent(<PageFiltersContainer />, routerContext, organization);
+    renderComponent(<PageFiltersContainer />, router, organization);
 
     expect(router.replace).not.toHaveBeenCalled();
   });
@@ -106,7 +96,7 @@ describe('PageFiltersContainer', function () {
   it('only updates GlobalSelection store when mounted with query params', async function () {
     renderComponent(
       <PageFiltersContainer />,
-      changeQuery(routerContext, {statsPeriod: '7d'}),
+      changeQuery(router, {statsPeriod: '7d'}),
       organization
     );
 
@@ -129,7 +119,7 @@ describe('PageFiltersContainer', function () {
   it('updates GlobalSelection store with default period', async function () {
     renderComponent(
       <PageFiltersContainer />,
-      changeQuery(routerContext, {
+      changeQuery(router, {
         environment: 'prod',
       }),
       organization
@@ -161,7 +151,7 @@ describe('PageFiltersContainer', function () {
   it('updates GlobalSelection store with empty dates in URL', async function () {
     renderComponent(
       <PageFiltersContainer />,
-      changeQuery(routerContext, {
+      changeQuery(router, {
         statsPeriod: null,
       }),
       organization
@@ -190,7 +180,7 @@ describe('PageFiltersContainer', function () {
   it('resets start&end if showAbsolute prop is false', async function () {
     renderComponent(
       <PageFiltersContainer showAbsolute={false} />,
-      changeQuery(routerContext, {
+      changeQuery(router, {
         start: '2020-05-05T07:26:53.000',
         end: '2020-05-05T09:19:12.000',
       }),
@@ -223,7 +213,7 @@ describe('PageFiltersContainer', function () {
   it('does not update store if url params have not changed', async function () {
     const {rerender} = renderComponent(
       <PageFiltersContainer />,
-      changeQuery(routerContext, {statsPeriod: '7d'}),
+      changeQuery(router, {statsPeriod: '7d'}),
       organization
     );
 
@@ -278,7 +268,7 @@ describe('PageFiltersContainer', function () {
 
     renderComponent(
       <PageFiltersContainer />,
-      initializationObj.routerContext,
+      initializationObj.router,
       initializationObj.organization
     );
 
@@ -317,7 +307,7 @@ describe('PageFiltersContainer', function () {
 
     renderComponent(
       <PageFiltersContainer />,
-      initializationObj.routerContext,
+      initializationObj.router,
       initializationObj.organization
     );
 
@@ -343,7 +333,7 @@ describe('PageFiltersContainer', function () {
 
     renderComponent(
       <PageFiltersContainer />,
-      initializationObj.routerContext,
+      initializationObj.router,
       initializationObj.organization
     );
 
@@ -370,7 +360,7 @@ describe('PageFiltersContainer', function () {
 
     renderComponent(
       <PageFiltersContainer />,
-      initializationObj.routerContext,
+      initializationObj.router,
       initializationObj.organization
     );
 
@@ -404,7 +394,7 @@ describe('PageFiltersContainer', function () {
 
     renderComponent(
       <PageFiltersContainer />,
-      initializationObj.routerContext,
+      initializationObj.router,
       initializationObj.organization
     );
 
@@ -434,7 +424,7 @@ describe('PageFiltersContainer', function () {
 
     renderComponent(
       <PageFiltersContainer disablePersistence />,
-      initializationObj.routerContext,
+      initializationObj.router,
       initializationObj.organization
     );
 
@@ -505,7 +495,7 @@ describe('PageFiltersContainer', function () {
       // current org in context In this case params.orgId = 'org-slug'
       const {rerender} = renderComponent(
         <PageFiltersContainer />,
-        initialData.routerContext,
+        initialData.router,
         initialData.organization
       );
 
@@ -551,7 +541,7 @@ describe('PageFiltersContainer', function () {
 
       renderComponent(
         <PageFiltersContainer />,
-        initializationObj.routerContext,
+        initializationObj.router,
         initializationObj.organization
       );
 
@@ -584,7 +574,7 @@ describe('PageFiltersContainer', function () {
 
       renderComponent(
         <PageFiltersContainer />,
-        initializationObj.routerContext,
+        initializationObj.router,
         initializationObj.organization
       );
 
@@ -611,7 +601,7 @@ describe('PageFiltersContainer', function () {
 
       renderComponent(
         <PageFiltersContainer />,
-        initializationObj.routerContext,
+        initializationObj.router,
         initializationObj.organization
       );
 
@@ -650,7 +640,7 @@ describe('PageFiltersContainer', function () {
           shouldForceProject
           forceProject={initialData.projects[0]}
         />,
-        initialData.routerContext,
+        initialData.router,
         initialData.organization
       );
 
@@ -686,7 +676,7 @@ describe('PageFiltersContainer', function () {
           shouldForceProject
           forceProject={initialData.projects[0]}
         />,
-        initialData.routerContext,
+        initialData.router,
         initialData.organization
       );
 
@@ -723,7 +713,7 @@ describe('PageFiltersContainer', function () {
       function renderForNonGlobalView(props = {}) {
         const result = renderComponent(
           getComponentForNonGlobalView(props),
-          initialData.routerContext,
+          initialData.router,
           initialData.organization
         );
 
@@ -821,7 +811,7 @@ describe('PageFiltersContainer', function () {
             shouldForceProject
             forceProject={initialData.projects[1]}
           />,
-          initialData.routerContext,
+          initialData.router,
           initialData.organization
         );
 
@@ -861,7 +851,7 @@ describe('PageFiltersContainer', function () {
         const result = renderComponent(
           getComponentForGlobalView(props),
           {
-            ...initialData.routerContext,
+            ...initialData.router,
             ...ctx,
           },
           initialData.organization
@@ -921,7 +911,7 @@ describe('PageFiltersContainer', function () {
         // forceProject generally starts undefined
         const {rerender} = renderForGlobalView(
           {shouldForceProject: true},
-          changeQuery(initialData.routerContext, {project: 2})
+          changeQuery(initialData.router, {project: 2})
         );
 
         rerender({forceProject: initialData.projects[1]});

--- a/static/app/components/organizations/projectPageFilter/index.spec.tsx
+++ b/static/app/components/organizations/projectPageFilter/index.spec.tsx
@@ -14,7 +14,7 @@ import OrganizationStore from 'sentry/stores/organizationStore';
 import PageFiltersStore from 'sentry/stores/pageFiltersStore';
 import ProjectsStore from 'sentry/stores/projectsStore';
 
-const {organization, router, routerContext} = initializeOrg({
+const {organization, router} = initializeOrg({
   organization: {features: ['global-views', 'open-membership']},
   project: undefined,
   projects: [
@@ -53,7 +53,7 @@ describe('ProjectPageFilter', function () {
 
   it('renders & handles single selection', async function () {
     render(<ProjectPageFilter />, {
-      context: routerContext,
+      router,
       organization,
     });
 
@@ -76,7 +76,7 @@ describe('ProjectPageFilter', function () {
 
   it('handles multiple selection', async function () {
     render(<ProjectPageFilter />, {
-      context: routerContext,
+      router,
       organization,
     });
 
@@ -107,7 +107,7 @@ describe('ProjectPageFilter', function () {
     });
 
     render(<ProjectPageFilter />, {
-      context: routerContext,
+      router,
       organization,
     });
 
@@ -168,7 +168,7 @@ describe('ProjectPageFilter', function () {
   it('handles reset', async function () {
     const onReset = jest.fn();
     render(<ProjectPageFilter onReset={onReset} />, {
-      context: routerContext,
+      router,
       organization,
     });
 
@@ -192,7 +192,7 @@ describe('ProjectPageFilter', function () {
 
   it('responds to page filter changes, async e.g. from back button nav', async function () {
     render(<ProjectPageFilter />, {
-      context: routerContext,
+      router,
       organization,
     });
 
@@ -208,11 +208,7 @@ describe('ProjectPageFilter', function () {
   });
 
   it('displays a desynced state message', async function () {
-    const {
-      organization: desyncOrganization,
-      router: desyncRouter,
-      routerContext: desyncRouterContext,
-    } = initializeOrg({
+    const {organization: desyncOrganization, router: desyncRouter} = initializeOrg({
       organization: {features: ['global-views', 'open-membership']},
       project: undefined,
       projects: [
@@ -241,7 +237,7 @@ describe('ProjectPageFilter', function () {
     });
 
     render(<ProjectPageFilter />, {
-      context: desyncRouterContext,
+      router: desyncRouter,
       organization: desyncOrganization,
     });
 

--- a/static/app/components/performanceOnboarding/sidebar.spec.tsx
+++ b/static/app/components/performanceOnboarding/sidebar.spec.tsx
@@ -20,7 +20,7 @@ import {generateDocKeys} from './utils';
 jest.mock('sentry/utils/useServiceIncidents');
 
 describe('Sidebar > Performance Onboarding Checklist', function () {
-  const {organization, routerContext, router} = initializeOrg({
+  const {organization, router} = initializeOrg({
     router: {
       location: {query: {}, search: '', pathname: '/test/'},
     },
@@ -38,7 +38,7 @@ describe('Sidebar > Performance Onboarding Checklist', function () {
   };
 
   const renderSidebar = props =>
-    render(getElement(), {organization: props.organization, context: routerContext});
+    render(getElement(), {organization: props.organization, router});
 
   beforeEach(function () {
     jest.resetAllMocks();

--- a/static/app/components/profiling/profileEventsTable.spec.tsx
+++ b/static/app/components/profiling/profileEventsTable.spec.tsx
@@ -25,7 +25,7 @@ describe('ProfileEventsTable', function () {
   });
 
   it('renders loading', function () {
-    const {organization, routerContext} = initializeOrg();
+    const {organization, router} = initializeOrg();
 
     const columns = ['count()' as const];
     const sort = {
@@ -41,14 +41,14 @@ describe('ProfileEventsTable', function () {
         isLoading
         sort={sort}
       />,
-      {context: routerContext, organization}
+      {router, organization}
     );
 
     expect(screen.getByTestId('loading-indicator')).toBeInTheDocument();
   });
 
   it('renders error', function () {
-    const {organization, routerContext} = initializeOrg();
+    const {organization, router} = initializeOrg();
 
     const columns = ['count()' as const];
     const sort = {
@@ -64,14 +64,14 @@ describe('ProfileEventsTable', function () {
         isLoading={false}
         sort={sort}
       />,
-      {context: routerContext, organization}
+      {router, organization}
     );
 
     expect(screen.getByTestId('error-indicator')).toBeInTheDocument();
   });
 
   it('renders asc sort links on the header', function () {
-    const {organization, routerContext} = initializeOrg();
+    const {organization, router} = initializeOrg();
 
     const columns = ['count()' as const];
     const sort = {
@@ -88,7 +88,7 @@ describe('ProfileEventsTable', function () {
         sort={sort}
         sortableColumns={new Set(columns)}
       />,
-      {context: routerContext, organization}
+      {router, organization}
     );
 
     const link = screen.getByRole('link', {name: 'Count()'});
@@ -100,7 +100,7 @@ describe('ProfileEventsTable', function () {
   });
 
   it('renders desc sort links on the header', function () {
-    const {organization, routerContext} = initializeOrg();
+    const {organization, router} = initializeOrg();
 
     const columns = ['count()' as const];
     const sort = {
@@ -117,7 +117,7 @@ describe('ProfileEventsTable', function () {
         sort={sort}
         sortableColumns={new Set(columns)}
       />,
-      {context: routerContext, organization}
+      {router, organization}
     );
 
     const link = screen.getByRole('link', {name: 'Count()'});
@@ -129,7 +129,7 @@ describe('ProfileEventsTable', function () {
   });
 
   it('renders formatted values', function () {
-    const {organization, routerContext} = initializeOrg();
+    const {organization, router} = initializeOrg();
 
     const columns = [
       'id',
@@ -189,7 +189,7 @@ describe('ProfileEventsTable', function () {
         sort={sort}
         sortableColumns={new Set(columns)}
       />,
-      {context: routerContext, organization}
+      {router, organization}
     );
 
     // id

--- a/static/app/components/profiling/profilingBreadcrumbs.spec.tsx
+++ b/static/app/components/profiling/profilingBreadcrumbs.spec.tsx
@@ -5,7 +5,7 @@ import {ProfilingBreadcrumbs} from 'sentry/components/profiling/profilingBreadcr
 
 describe('Breadcrumb', function () {
   it('renders the profiling link', function () {
-    const {organization, routerContext} = initializeOrg();
+    const {organization, router} = initializeOrg();
     render(
       <ProfilingBreadcrumbs
         organization={organization}
@@ -22,7 +22,7 @@ describe('Breadcrumb', function () {
           },
         ]}
       />,
-      {context: routerContext}
+      {router}
     );
     expect(screen.getByText('Profiling')).toBeInTheDocument();
     expect(screen.getByRole('link', {name: 'Profiling'})).toHaveAttribute(

--- a/static/app/components/stream/group.spec.tsx
+++ b/static/app/components/stream/group.spec.tsx
@@ -44,9 +44,9 @@ describe('StreamGroup', function () {
   });
 
   it('renders with anchors', async function () {
-    const {routerContext, organization} = initializeOrg();
-    render(<StreamGroup id="1337" hasGuideAnchor {...routerContext} />, {
-      context: routerContext,
+    const {router, organization} = initializeOrg();
+    render(<StreamGroup id="1337" hasGuideAnchor />, {
+      router,
       organization,
     });
 
@@ -55,14 +55,13 @@ describe('StreamGroup', function () {
   });
 
   it('marks as reviewed', async function () {
-    const {routerContext, organization} = initializeOrg();
+    const {router, organization} = initializeOrg();
     render(
       <StreamGroup
         id="1337"
         query="is:unresolved is:for_review assigned_or_suggested:[me, none]"
-        {...routerContext}
       />,
-      {context: routerContext, organization}
+      {router, organization}
     );
 
     expect(await screen.findByTestId('group')).toHaveAttribute(
@@ -78,9 +77,9 @@ describe('StreamGroup', function () {
   });
 
   it('marks as resolved', async function () {
-    const {routerContext, organization} = initializeOrg();
+    const {router, organization} = initializeOrg();
     render(<StreamGroup id="1337" query="is:unresolved" />, {
-      context: routerContext,
+      router,
       organization,
     });
 
@@ -126,14 +125,13 @@ describe('StreamGroup', function () {
   });
 
   it('tracks clicks from issues stream', async function () {
-    const {routerContext, organization} = initializeOrg();
+    const {router, organization} = initializeOrg();
     render(
       <StreamGroup
         id="1337"
         query="is:unresolved is:for_review assigned_or_suggested:[me, none]"
-        {...routerContext}
       />,
-      {context: routerContext, organization}
+      {router, organization}
     );
 
     // skipHover - Prevent stacktrace preview from being rendered

--- a/static/app/components/timeRangeSelector/index.spec.tsx
+++ b/static/app/components/timeRangeSelector/index.spec.tsx
@@ -7,7 +7,7 @@ import {fireEvent, render, screen, userEvent} from 'sentry-test/reactTestingLibr
 import {TimeRangeSelector} from 'sentry/components/timeRangeSelector';
 import ConfigStore from 'sentry/stores/configStore';
 
-const {organization, routerContext} = initializeOrg({
+const {organization, router} = initializeOrg({
   organization: {features: ['global-views', 'open-membership']},
   project: undefined,
   projects: [
@@ -32,7 +32,7 @@ describe('TimeRangeSelector', function () {
   }
 
   function renderComponent(props = {}) {
-    return render(getComponent(props), {context: routerContext});
+    return render(getComponent(props), {router});
   }
 
   beforeEach(function () {
@@ -52,7 +52,7 @@ describe('TimeRangeSelector', function () {
   });
 
   it('renders when given an invalid relative period', async function () {
-    render(<TimeRangeSelector relative="1y" />, {context: routerContext, organization});
+    render(<TimeRangeSelector relative="1y" />, {router, organization});
     expect(
       await screen.findByRole('button', {name: 'Invalid Period'})
     ).toBeInTheDocument();

--- a/static/app/components/version.spec.tsx
+++ b/static/app/components/version.spec.tsx
@@ -1,4 +1,4 @@
-import {RouterContextFixture} from 'sentry-fixture/routerContextFixture';
+import {RouterFixture} from 'sentry-fixture/routerFixture';
 
 import {act, render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
@@ -7,7 +7,7 @@ import Version from 'sentry/components/version';
 const VERSION = 'foo.bar.Baz@1.0.0+20200101';
 
 describe('Version', () => {
-  const context = RouterContextFixture();
+  const router = RouterFixture();
   afterEach(() => {
     jest.resetAllMocks();
   });
@@ -25,11 +25,11 @@ describe('Version', () => {
 
   it('links to release page', async () => {
     render(<Version version={VERSION} projectId="1" />, {
-      context,
+      router,
     });
 
     await userEvent.click(screen.getByText('1.0.0 (20200101)'));
-    expect(context.context.router.push).toHaveBeenCalledWith({
+    expect(router.push).toHaveBeenCalledWith({
       pathname: '/organizations/org-slug/releases/foo.bar.Baz%401.0.0%2B20200101/',
       query: {project: '1'},
     });
@@ -38,7 +38,7 @@ describe('Version', () => {
   it('shows raw version in tooltip', async () => {
     jest.useFakeTimers();
     render(<Version version={VERSION} tooltipRawVersion />, {
-      context,
+      router,
     });
     expect(screen.queryByText(VERSION)).not.toBeInTheDocument();
 

--- a/static/app/components/waitingForEvents.spec.tsx
+++ b/static/app/components/waitingForEvents.spec.tsx
@@ -1,6 +1,6 @@
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {ProjectFixture} from 'sentry-fixture/project';
-import {RouterContextFixture} from 'sentry-fixture/routerContextFixture';
+import {RouterFixture} from 'sentry-fixture/routerFixture';
 
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
@@ -8,10 +8,10 @@ import WaitingForEvents from 'sentry/components/waitingForEvents';
 
 describe('WaitingForEvents', function () {
   let getIssues: jest.Func;
-  let routerContext;
+  let router;
 
   beforeEach(function () {
-    routerContext = RouterContextFixture();
+    router = RouterFixture();
     getIssues = MockApiClient.addMockResponse({
       url: '/projects/org-slug/project-slug/issues/',
       method: 'GET',
@@ -29,7 +29,7 @@ describe('WaitingForEvents', function () {
       return render(
         <WaitingForEvents org={OrganizationFixture()} project={ProjectFixture()} />,
         {
-          context: routerContext,
+          router,
         }
       );
     }
@@ -44,16 +44,14 @@ describe('WaitingForEvents', function () {
     it('Renders installation instructions', async function () {
       createWrapper();
       await userEvent.click(screen.getByText('Installation Instructions'));
-      expect(routerContext.context.router.push).toHaveBeenCalledWith(
-        '/org-slug/project-slug/getting-started/'
-      );
+      expect(router.push).toHaveBeenCalledWith('/org-slug/project-slug/getting-started/');
     });
   });
 
   describe('without a project', function () {
     function createWrapper() {
       return render(<WaitingForEvents org={OrganizationFixture()} />, {
-        context: routerContext,
+        router,
       });
     }
 

--- a/static/app/utils/discover/fieldRenderers.spec.tsx
+++ b/static/app/utils/discover/fieldRenderers.spec.tsx
@@ -264,7 +264,7 @@ describe('getFieldRenderer', function () {
     const renderer = getFieldRenderer('release', {release: 'string'});
 
     render(renderer(data, {location, organization}) as React.ReactElement<any, any>, {
-      context: context.routerContext,
+      router: context.router,
     });
 
     expect(screen.queryByRole('link')).toHaveAttribute(
@@ -278,7 +278,7 @@ describe('getFieldRenderer', function () {
     const renderer = getFieldRenderer('issue', {issue: 'string'});
 
     render(renderer(data, {location, organization}) as React.ReactElement<any, any>, {
-      context: context.routerContext,
+      router: context.router,
     });
 
     expect(screen.queryByRole('link')).toHaveAttribute(
@@ -292,7 +292,7 @@ describe('getFieldRenderer', function () {
     const renderer = getFieldRenderer('project', {project: 'string'});
 
     render(renderer(data, {location, organization}) as React.ReactElement<any, any>, {
-      context: context.routerContext,
+      router: context.router,
     });
 
     expect(screen.queryByTestId('letter_avatar-avatar')).not.toBeInTheDocument();
@@ -305,7 +305,7 @@ describe('getFieldRenderer', function () {
     data = {...data, project: parseInt(project.id, 10)};
 
     render(renderer(data, {location, organization}) as React.ReactElement<any, any>, {
-      context: context.routerContext,
+      router: context.router,
     });
 
     expect(screen.queryByTestId('letter_avatar-avatar')).not.toBeInTheDocument();
@@ -318,7 +318,7 @@ describe('getFieldRenderer', function () {
     });
 
     render(renderer(data, {location, organization}) as React.ReactElement<any, any>, {
-      context: context.routerContext,
+      router: context.router,
     });
 
     const star = screen.getByRole('button', {name: 'Toggle star for team'});
@@ -335,7 +335,7 @@ describe('getFieldRenderer', function () {
     delete data.project;
 
     render(renderer(data, {location, organization}) as React.ReactElement<any, any>, {
-      context: context.routerContext,
+      router: context.router,
     });
 
     const star = screen.getByRole('button', {name: 'Toggle star for team'});
@@ -356,7 +356,7 @@ describe('getFieldRenderer', function () {
       });
 
       render(renderer(data, {location, organization}) as React.ReactElement<any, any>, {
-        context: context.routerContext,
+        router: context.router,
       });
 
       expect(getWidths()).toEqual(['13.333%', '40.000%', '20.000%', '26.667%', '0.000%']);
@@ -388,7 +388,7 @@ describe('getFieldRenderer', function () {
             topEvents: undefined,
           }),
         }) as React.ReactElement<any, any>,
-        {context: context.routerContext}
+        {router: context.router}
       );
 
       expect(getWidths()).toEqual(['40.000%', '13.333%', '20.000%', '26.667%', '0.000%']);

--- a/static/app/utils/withDomainRedirect.spec.tsx
+++ b/static/app/utils/withDomainRedirect.spec.tsx
@@ -65,7 +65,7 @@ describe('withDomainRedirect', function () {
     const params = {
       orgId: 'albertos-apples',
     };
-    const {router, route, routerContext} = initializeOrg({
+    const {router, route} = initializeOrg({
       router: {
         params,
       },
@@ -80,7 +80,7 @@ describe('withDomainRedirect', function () {
         routeParams={router.params}
         route={route}
       />,
-      {context: routerContext}
+      {router}
     );
 
     expect(screen.getByText('Org slug: albertos-apples')).toBeInTheDocument();
@@ -95,7 +95,7 @@ describe('withDomainRedirect', function () {
     const params = {
       orgId: 'albertos-apples',
     };
-    const {router, route, routerContext} = initializeOrg({
+    const {router, route} = initializeOrg({
       organization,
       router: {
         params,
@@ -114,7 +114,7 @@ describe('withDomainRedirect', function () {
           route={route}
         />
       </OrganizationContext.Provider>,
-      {context: routerContext}
+      {router}
     );
 
     expect(container).toBeEmptyDOMElement();
@@ -130,7 +130,7 @@ describe('withDomainRedirect', function () {
     const params = {
       orgId: organization.slug,
     };
-    const {router, route, routerContext} = initializeOrg({
+    const {router, route} = initializeOrg({
       organization,
       router: {
         params,
@@ -149,7 +149,7 @@ describe('withDomainRedirect', function () {
           route={route}
         />
       </OrganizationContext.Provider>,
-      {context: routerContext}
+      {router}
     );
 
     expect(container).toBeEmptyDOMElement();
@@ -169,7 +169,7 @@ describe('withDomainRedirect', function () {
       orgId: organization.slug,
       projectId: 'react',
     };
-    const {router, route, routerContext} = initializeOrg({
+    const {router, route} = initializeOrg({
       organization,
       router: {
         params,
@@ -189,7 +189,7 @@ describe('withDomainRedirect', function () {
           route={route}
         />
       </OrganizationContext.Provider>,
-      {context: routerContext}
+      {router}
     );
 
     expect(container).toBeEmptyDOMElement();
@@ -205,7 +205,7 @@ describe('withDomainRedirect', function () {
 
     const params = {};
 
-    const {router, route, routerContext} = initializeOrg({
+    const {router, route} = initializeOrg({
       organization,
       router: {
         params,
@@ -233,7 +233,7 @@ describe('withDomainRedirect', function () {
           route={route}
         />
       </OrganizationContext.Provider>,
-      {context: routerContext}
+      {router}
     );
 
     expect(screen.getByText('Org slug: no org slug')).toBeInTheDocument();
@@ -255,7 +255,7 @@ describe('withDomainRedirect', function () {
       orgId: organization.slug,
       projectId: 'react',
     };
-    const {router, route, routerContext} = initializeOrg({
+    const {router, route} = initializeOrg({
       organization,
       router: {
         params,
@@ -275,7 +275,7 @@ describe('withDomainRedirect', function () {
           route={route}
         />
       </OrganizationContext.Provider>,
-      {context: routerContext}
+      {router}
     );
 
     expect(router.replace).toHaveBeenCalledTimes(1);

--- a/static/app/utils/withDomainRequired.spec.tsx
+++ b/static/app/utils/withDomainRequired.spec.tsx
@@ -252,7 +252,7 @@ describe('withDomainRequired', function () {
     const params = {
       orgId: 'albertos-apples',
     };
-    const {router, route, routerContext} = initializeOrg({
+    const {router, route} = initializeOrg({
       organization,
       router: {
         params,
@@ -268,7 +268,7 @@ describe('withDomainRequired', function () {
         routeParams={router.params}
         route={route}
       />,
-      {context: routerContext}
+      {router}
     );
 
     expect(container).toBeEmptyDOMElement();
@@ -301,7 +301,7 @@ describe('withDomainRequired', function () {
     const params = {
       orgId: 'albertos-apples',
     };
-    const {router, route, routerContext} = initializeOrg({
+    const {router, route} = initializeOrg({
       organization,
       router: {
         params,
@@ -317,7 +317,7 @@ describe('withDomainRequired', function () {
         routeParams={router.params}
         route={route}
       />,
-      {context: routerContext}
+      {router}
     );
 
     expect(container).toBeEmptyDOMElement();
@@ -350,7 +350,7 @@ describe('withDomainRequired', function () {
     const params = {
       orgId: 'albertos-apples',
     };
-    const {router, route, routerContext} = initializeOrg({
+    const {router, route} = initializeOrg({
       organization,
       router: {
         params,
@@ -366,7 +366,7 @@ describe('withDomainRequired', function () {
         routeParams={router.params}
         route={route}
       />,
-      {context: routerContext}
+      {router}
     );
 
     expect(screen.getByText('Org slug: albertos-apples')).toBeInTheDocument();

--- a/static/app/utils/withSentryRouter.spec.tsx
+++ b/static/app/utils/withSentryRouter.spec.tsx
@@ -41,13 +41,13 @@ describe('withSentryRouter', function () {
       features: [],
     });
 
-    const {routerContext} = initializeOrg({
+    const {router} = initializeOrg({
       organization,
     });
 
     const WrappedComponent = withSentryRouter(MyComponent);
     render(<WrappedComponent />, {
-      context: routerContext,
+      router,
     });
 
     expect(screen.getByText('Org slug: albertos-apples')).toBeInTheDocument();
@@ -65,7 +65,7 @@ describe('withSentryRouter', function () {
     const params = {
       orgId: 'something-else',
     };
-    const {routerContext} = initializeOrg({
+    const {router} = initializeOrg({
       organization,
       router: {
         params,
@@ -74,7 +74,7 @@ describe('withSentryRouter', function () {
 
     const WrappedComponent = withSentryRouter(MyComponent);
     render(<WrappedComponent />, {
-      context: routerContext,
+      router,
     });
 
     expect(screen.getByText('Org slug: something-else')).toBeInTheDocument();

--- a/static/app/views/alerts/create.spec.tsx
+++ b/static/app/views/alerts/create.spec.tsx
@@ -81,7 +81,7 @@ describe('ProjectAlertsCreate', function () {
   });
 
   const createWrapper = (props = {}, location = {}) => {
-    const {organization, project, router, routerContext} = initializeOrg(props);
+    const {organization, project, router} = initializeOrg(props);
     ProjectsStore.loadInitialData([project]);
     const params = {orgId: organization.slug, projectId: project.slug};
     const wrapper = render(
@@ -108,7 +108,7 @@ describe('ProjectAlertsCreate', function () {
           />
         </AlertBuilderProjectProvider>
       </AlertsContainer>,
-      {organization, context: routerContext}
+      {organization, router}
     );
 
     return {

--- a/static/app/views/alerts/incidentRedirect.spec.tsx
+++ b/static/app/views/alerts/incidentRedirect.spec.tsx
@@ -12,7 +12,7 @@ jest.mock('sentry/utils/analytics');
 
 describe('IncidentRedirect', () => {
   const params = {alertId: '123'};
-  const {organization, project, routerContext, routerProps} = initializeOrg({
+  const {organization, project, router, routerProps} = initializeOrg({
     router: {
       params,
     },
@@ -33,7 +33,7 @@ describe('IncidentRedirect', () => {
 
   it('redirects to alert details page', async () => {
     render(<IncidentRedirect organization={organization} {...routerProps} />, {
-      context: routerContext,
+      router,
     });
 
     expect(trackAnalytics).toHaveBeenCalledWith(

--- a/static/app/views/alerts/list/header.spec.tsx
+++ b/static/app/views/alerts/list/header.spec.tsx
@@ -10,7 +10,7 @@ import AlertHeader from 'sentry/views/alerts/list/header';
 
 describe('AlertHeader', () => {
   const project = ProjectFixture();
-  const {routerContext, organization} = initializeOrg();
+  const {router, organization} = initializeOrg();
   beforeEach(() => {
     PageFiltersStore.init();
     PageFiltersStore.onInitializeUrlState(
@@ -32,7 +32,7 @@ describe('AlertHeader', () => {
 
   it('should pass global selection project to create alert button', () => {
     render(<AlertHeader activeTab="stream" router={RouterFixture()} />, {
-      context: routerContext,
+      router,
       organization,
     });
     expect(screen.getByRole('button', {name: 'Create Alert'})).toHaveAttribute(

--- a/static/app/views/alerts/list/incidents/index.spec.tsx
+++ b/static/app/views/alerts/list/incidents/index.spec.tsx
@@ -23,7 +23,7 @@ describe('IncidentsList', () => {
   }
 
   const renderComponent = ({orgOverride}: Props = {}) => {
-    const {organization, routerContext, routerProps, router} = initializeOrg({
+    const {organization, routerProps, router} = initializeOrg({
       organization: {features: ['incidents'], ...orgOverride},
     });
 
@@ -32,7 +32,7 @@ describe('IncidentsList', () => {
         <AlertsContainer>
           <IncidentsList {...routerProps} organization={organization} />
         </AlertsContainer>,
-        {context: routerContext, organization}
+        {router, organization}
       ),
       router,
     };

--- a/static/app/views/alerts/list/rules/alertRulesList.spec.tsx
+++ b/static/app/views/alerts/list/rules/alertRulesList.spec.tsx
@@ -85,8 +85,8 @@ describe('AlertRulesList', () => {
   });
 
   it('displays list', async () => {
-    const {routerContext, organization} = initializeOrg({organization: defaultOrg});
-    render(<AlertRulesList />, {context: routerContext, organization});
+    const {router, organization} = initializeOrg({organization: defaultOrg});
+    render(<AlertRulesList />, {router, organization});
 
     expect(await screen.findByText('First Issue Alert')).toBeInTheDocument();
 
@@ -105,8 +105,8 @@ describe('AlertRulesList', () => {
       url: '/organizations/org-slug/combined-rules/',
       body: [],
     });
-    const {routerContext, organization} = initializeOrg({organization: defaultOrg});
-    render(<AlertRulesList />, {context: routerContext, organization});
+    const {router, organization} = initializeOrg({organization: defaultOrg});
+    render(<AlertRulesList />, {router, organization});
 
     expect(
       await screen.findByText('No alert rules found for the current query.')
@@ -116,8 +116,8 @@ describe('AlertRulesList', () => {
   });
 
   it('displays team dropdown context if unassigned', async () => {
-    const {routerContext, organization} = initializeOrg({organization: defaultOrg});
-    render(<AlertRulesList />, {context: routerContext, organization});
+    const {router, organization} = initializeOrg({organization: defaultOrg});
+    render(<AlertRulesList />, {router, organization});
     const assignee = (await screen.findAllByTestId('alert-row-assignee'))[0];
     const btn = within(assignee).getAllByRole('button')[0];
 
@@ -136,8 +136,8 @@ describe('AlertRulesList', () => {
       url: '/projects/org-slug/earth/rules/123/',
       body: [],
     });
-    const {routerContext, organization} = initializeOrg({organization: defaultOrg});
-    render(<AlertRulesList />, {context: routerContext, organization});
+    const {router, organization} = initializeOrg({organization: defaultOrg});
+    render(<AlertRulesList />, {router, organization});
 
     const assignee = (await screen.findAllByTestId('alert-row-assignee'))[0];
     const btn = within(assignee).getAllByRole('button')[0];
@@ -157,8 +157,8 @@ describe('AlertRulesList', () => {
   });
 
   it('displays dropdown context menu with actions', async () => {
-    const {routerContext, organization} = initializeOrg({organization: defaultOrg});
-    render(<AlertRulesList />, {context: routerContext, organization});
+    const {router, organization} = initializeOrg({organization: defaultOrg});
+    render(<AlertRulesList />, {router, organization});
     const actions = (await screen.findAllByRole('button', {name: 'Actions'}))[0];
     expect(actions).toBeInTheDocument();
 
@@ -170,7 +170,7 @@ describe('AlertRulesList', () => {
   });
 
   it('deletes a rule', async () => {
-    const {routerContext, organization} = initializeOrg({
+    const {router, organization} = initializeOrg({
       organization: defaultOrg,
     });
     const deletedRuleName = 'First Issue Alert';
@@ -192,7 +192,7 @@ describe('AlertRulesList', () => {
       body: {},
     });
 
-    render(<AlertRulesList />, {context: routerContext, organization});
+    render(<AlertRulesList />, {router, organization});
     renderGlobalModal();
 
     const actions = (await screen.findAllByRole('button', {name: 'Actions'}))[0];
@@ -215,10 +215,10 @@ describe('AlertRulesList', () => {
   });
 
   it('sends user to new alert page on duplicate action', async () => {
-    const {routerContext, organization, router} = initializeOrg({
+    const {organization, router} = initializeOrg({
       organization: defaultOrg,
     });
-    render(<AlertRulesList />, {context: routerContext, organization});
+    render(<AlertRulesList />, {router, organization});
     const actions = (await screen.findAllByRole('button', {name: 'Actions'}))[0];
     expect(actions).toBeInTheDocument();
 
@@ -241,7 +241,7 @@ describe('AlertRulesList', () => {
   });
 
   it('sorts by name', async () => {
-    const {routerContext, organization} = initializeOrg({
+    const {router, organization} = initializeOrg({
       organization: defaultOrg,
       router: {
         location: LocationFixture({
@@ -251,7 +251,7 @@ describe('AlertRulesList', () => {
         }),
       },
     });
-    render(<AlertRulesList />, {context: routerContext, organization});
+    render(<AlertRulesList />, {router, organization});
 
     expect(await screen.findByText('Alert Rule')).toHaveAttribute(
       'aria-sort',
@@ -272,15 +272,15 @@ describe('AlertRulesList', () => {
       ...defaultOrg,
       access: [],
     };
-    const {routerContext, organization} = initializeOrg({organization: noAccessOrg});
-    render(<AlertRulesList />, {context: routerContext, organization});
+    const {router, organization} = initializeOrg({organization: noAccessOrg});
+    render(<AlertRulesList />, {router, organization});
 
     expect(await screen.findByLabelText('Create Alert')).toBeDisabled();
   });
 
   it('searches by name', async () => {
-    const {routerContext, organization, router} = initializeOrg();
-    render(<AlertRulesList />, {context: routerContext, organization});
+    const {organization, router} = initializeOrg();
+    render(<AlertRulesList />, {router, organization});
 
     const search = await screen.findByPlaceholderText('Search by name');
     expect(search).toBeInTheDocument();
@@ -298,7 +298,7 @@ describe('AlertRulesList', () => {
   });
 
   it('uses empty team query parameter when removing all teams', async () => {
-    const {routerContext, organization, router} = initializeOrg({
+    const {organization, router} = initializeOrg({
       router: {
         location: LocationFixture({
           query: {team: 'myteams'},
@@ -306,7 +306,7 @@ describe('AlertRulesList', () => {
         }),
       },
     });
-    render(<AlertRulesList />, {context: routerContext, organization});
+    render(<AlertRulesList />, {router, organization});
 
     expect(await screen.findByText('First Issue Alert')).toBeInTheDocument();
 
@@ -326,8 +326,8 @@ describe('AlertRulesList', () => {
   });
 
   it('displays metric alert status', async () => {
-    const {routerContext, organization} = initializeOrg({organization: defaultOrg});
-    render(<AlertRulesList />, {context: routerContext, organization});
+    const {router, organization} = initializeOrg({organization: defaultOrg});
+    render(<AlertRulesList />, {router, organization});
     const rules = await screen.findAllByText('My Incident Rule');
 
     expect(rules[0]).toBeInTheDocument();
@@ -374,8 +374,8 @@ describe('AlertRulesList', () => {
         }),
       ],
     });
-    const {routerContext, organization} = initializeOrg({organization: defaultOrg});
-    render(<AlertRulesList />, {context: routerContext, organization});
+    const {router, organization} = initializeOrg({organization: defaultOrg});
+    render(<AlertRulesList />, {router, organization});
 
     expect(await screen.findByText('Active Activated Alert')).toBeInTheDocument();
     expect(await screen.findByText('Ready Activated Alert')).toBeInTheDocument();
@@ -399,8 +399,8 @@ describe('AlertRulesList', () => {
         }),
       ],
     });
-    const {routerContext, organization} = initializeOrg({organization: defaultOrg});
-    render(<AlertRulesList />, {context: routerContext, organization});
+    const {router, organization} = initializeOrg({organization: defaultOrg});
+    render(<AlertRulesList />, {router, organization});
     expect(await screen.findByText('First Issue Alert')).toBeInTheDocument();
     expect(screen.getByText('Disabled')).toBeInTheDocument();
   });
@@ -419,8 +419,8 @@ describe('AlertRulesList', () => {
         }),
       ],
     });
-    const {routerContext, organization} = initializeOrg({organization: defaultOrg});
-    render(<AlertRulesList />, {context: routerContext, organization});
+    const {router, organization} = initializeOrg({organization: defaultOrg});
+    render(<AlertRulesList />, {router, organization});
     expect(await screen.findByText('First Issue Alert')).toBeInTheDocument();
     expect(screen.getByText('Disabled')).toBeInTheDocument();
     expect(screen.queryByText('Muted')).not.toBeInTheDocument();
@@ -438,8 +438,8 @@ describe('AlertRulesList', () => {
         }),
       ],
     });
-    const {routerContext, organization} = initializeOrg({organization: defaultOrg});
-    render(<AlertRulesList />, {context: routerContext, organization});
+    const {router, organization} = initializeOrg({organization: defaultOrg});
+    render(<AlertRulesList />, {router, organization});
     expect(await screen.findByText('First Issue Alert')).toBeInTheDocument();
     expect(screen.getByText('Muted')).toBeInTheDocument();
   });
@@ -455,15 +455,15 @@ describe('AlertRulesList', () => {
         }),
       ],
     });
-    const {routerContext, organization} = initializeOrg({organization: defaultOrg});
-    render(<AlertRulesList />, {context: routerContext, organization});
+    const {router, organization} = initializeOrg({organization: defaultOrg});
+    render(<AlertRulesList />, {router, organization});
     expect(await screen.findByText('My Incident Rule')).toBeInTheDocument();
     expect(screen.getByText('Muted')).toBeInTheDocument();
   });
 
   it('sorts by alert rule', async () => {
-    const {routerContext, organization} = initializeOrg({organization: defaultOrg});
-    render(<AlertRulesList />, {context: routerContext, organization});
+    const {router, organization} = initializeOrg({organization: defaultOrg});
+    render(<AlertRulesList />, {router, organization});
 
     expect(await screen.findByText('First Issue Alert')).toBeInTheDocument();
 
@@ -480,10 +480,10 @@ describe('AlertRulesList', () => {
   });
 
   it('preserves empty team query parameter on pagination', async () => {
-    const {routerContext, organization, router} = initializeOrg({
+    const {organization, router} = initializeOrg({
       organization: defaultOrg,
     });
-    render(<AlertRulesList />, {context: routerContext, organization});
+    render(<AlertRulesList />, {router, organization});
     expect(await screen.findByText('First Issue Alert')).toBeInTheDocument();
 
     await userEvent.click(screen.getByLabelText('Next'));
@@ -528,8 +528,8 @@ describe('AlertRulesList', () => {
       ],
     });
 
-    const {routerContext, organization} = initializeOrg({organization: defaultOrg});
-    render(<AlertRulesList />, {context: routerContext, organization});
+    const {router, organization} = initializeOrg({organization: defaultOrg});
+    render(<AlertRulesList />, {router, organization});
 
     expect(await screen.findByText('Test Metric Alert 2')).toBeInTheDocument();
     expect(await screen.findByText('First Issue Alert')).toBeInTheDocument();

--- a/static/app/views/alerts/rules/issue/details/ruleDetails.spec.tsx
+++ b/static/app/views/alerts/rules/issue/details/ruleDetails.spec.tsx
@@ -24,7 +24,6 @@ describe('AlertRuleDetails', () => {
 
   const createWrapper = (props: any = {}, newContext?: any, org = organization) => {
     const router = newContext ? newContext.router : context.router;
-    const routerContext = newContext ? newContext.routerContext : context.routerContext;
 
     return render(
       <AlertRuleDetails
@@ -37,7 +36,7 @@ describe('AlertRuleDetails', () => {
         router={router}
         {...props}
       />,
-      {context: routerContext, organization: org}
+      {router, organization: org}
     );
   };
 

--- a/static/app/views/alerts/rules/issue/index.spec.tsx
+++ b/static/app/views/alerts/rules/issue/index.spec.tsx
@@ -82,7 +82,7 @@ const projectAlertRuleDetailsRoutes: PlainRoute<any>[] = [
 ];
 
 const createWrapper = (props = {}) => {
-  const {organization, project, routerContext, router} = initializeOrg(props);
+  const {organization, project, router} = initializeOrg(props);
   const params = {
     projectId: project.slug,
     organizationId: organization.slug,
@@ -109,7 +109,7 @@ const createWrapper = (props = {}) => {
         userTeamIds={[]}
       />
     </ProjectAlerts>,
-    {context: routerContext, organization}
+    {router, organization}
   );
 
   return {

--- a/static/app/views/alerts/rules/issue/ticketRuleModal.spec.tsx
+++ b/static/app/views/alerts/rules/issue/ticketRuleModal.spec.tsx
@@ -88,7 +88,7 @@ describe('ProjectAlerts -> TicketRuleModal', function () {
       name: 'reporter',
     }
   ) => {
-    const {organization, routerContext} = initializeOrg();
+    const {organization, router} = initializeOrg();
     addMockConfigsAPICall(otherField);
 
     const body = styled(c => c.children);
@@ -107,7 +107,7 @@ describe('ProjectAlerts -> TicketRuleModal', function () {
         onSubmitAction={() => {}}
         organization={organization}
       />,
-      {context: routerContext}
+      {router}
     );
   };
 

--- a/static/app/views/alerts/rules/metric/details/index.spec.tsx
+++ b/static/app/views/alerts/rules/metric/details/index.spec.tsx
@@ -43,7 +43,7 @@ describe('MetricAlertDetails', () => {
   });
 
   it('renders', async () => {
-    const {routerContext, organization, routerProps} = initializeOrg();
+    const {organization, routerProps, router} = initializeOrg();
     const incident = IncidentFixture();
     const rule = MetricRuleFixture({
       projects: [project.slug],
@@ -65,7 +65,7 @@ describe('MetricAlertDetails', () => {
         {...routerProps}
         params={{ruleId: rule.id}}
       />,
-      {context: routerContext, organization}
+      {router, organization}
     );
 
     expect(await screen.findAllByText(rule.name)).toHaveLength(2);
@@ -84,7 +84,7 @@ describe('MetricAlertDetails', () => {
   });
 
   it('renders selected incident', async () => {
-    const {routerContext, organization, router, routerProps} = initializeOrg();
+    const {organization, router, routerProps} = initializeOrg();
     const rule = MetricRuleFixture({projects: [project.slug]});
     const incident = IncidentFixture();
 
@@ -113,7 +113,7 @@ describe('MetricAlertDetails', () => {
         location={{...router.location, query: {alert: incident.id}}}
         params={{ruleId: rule.id}}
       />,
-      {context: routerContext, organization}
+      {router, organization}
     );
 
     expect(await screen.findAllByText(rule.name)).toHaveLength(2);
@@ -131,7 +131,7 @@ describe('MetricAlertDetails', () => {
   });
 
   it('renders mute button for metric alert', async () => {
-    const {routerContext, organization, routerProps} = initializeOrg();
+    const {organization, routerProps, router} = initializeOrg();
     const incident = IncidentFixture();
     const rule = MetricRuleFixture({
       projects: [project.slug],
@@ -162,7 +162,7 @@ describe('MetricAlertDetails', () => {
         organization={organization}
         params={{ruleId: rule.id}}
       />,
-      {context: routerContext, organization}
+      {router, organization}
     );
 
     expect(await screen.findByText('Mute for me')).toBeInTheDocument();
@@ -177,7 +177,7 @@ describe('MetricAlertDetails', () => {
   });
 
   it('renders open in discover button with dataset=errors for is:unresolved query', async () => {
-    const {routerContext, organization, routerProps} = initializeOrg({
+    const {organization, routerProps, router} = initializeOrg({
       organization: {features: ['discover-basic', 'metric-alert-ignore-archived']},
     });
     const rule = MetricRuleFixture({
@@ -205,7 +205,7 @@ describe('MetricAlertDetails', () => {
         {...routerProps}
         params={{ruleId: rule.id}}
       />,
-      {context: routerContext, organization}
+      {router, organization}
     );
 
     expect(await screen.findAllByText(rule.name)).toHaveLength(2);

--- a/static/app/views/alerts/rules/metric/details/relatedIssues.spec.tsx
+++ b/static/app/views/alerts/rules/metric/details/relatedIssues.spec.tsx
@@ -11,7 +11,7 @@ describe('metric details -> RelatedIssues', () => {
   const project = ProjectFixture();
 
   it('adds environment to query parameters', async () => {
-    const {routerContext, organization, router} = initializeOrg({
+    const {router, organization} = initializeOrg({
       router: {
         location: {
           pathname: '/mock-pathname/',
@@ -47,7 +47,7 @@ describe('metric details -> RelatedIssues', () => {
           usingPeriod: true,
         }}
       />,
-      {context: routerContext, organization}
+      {router, organization}
     );
 
     expect(await screen.findByTestId('group')).toBeInTheDocument();

--- a/static/app/views/alerts/rules/metric/ruleForm.spec.tsx
+++ b/static/app/views/alerts/rules/metric/ruleForm.spec.tsx
@@ -27,7 +27,7 @@ jest.mock('sentry/utils/analytics', () => ({
 }));
 
 describe('Incident Rules Form', () => {
-  let organization, project, routerContext, location;
+  let organization, project, router, location;
   // create wrapper
   const createWrapper = props =>
     render(
@@ -38,7 +38,7 @@ describe('Incident Rules Form', () => {
         project={project}
         {...props}
       />,
-      {context: routerContext, organization}
+      {router, organization}
     );
 
   beforeEach(() => {
@@ -49,7 +49,7 @@ describe('Incident Rules Form', () => {
     project = initialData.project;
     location = initialData.router.location;
     ProjectsStore.loadInitialData([project]);
-    routerContext = initialData.routerContext;
+    router = initialData.router;
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/tags/',
       body: [],

--- a/static/app/views/alerts/wizard/index.spec.tsx
+++ b/static/app/views/alerts/wizard/index.spec.tsx
@@ -5,7 +5,7 @@ import AlertWizard from 'sentry/views/alerts/wizard/index';
 
 describe('AlertWizard', () => {
   it('sets crash free dataset to metrics', async () => {
-    const {organization, project, routerProps, routerContext} = initializeOrg({
+    const {organization, project, routerProps, router} = initializeOrg({
       organization: {
         features: [
           'alert-crash-free-metrics',
@@ -22,12 +22,12 @@ describe('AlertWizard', () => {
         projectId={project.slug}
         {...routerProps}
       />,
-      {context: routerContext, organization}
+      {router, organization}
     );
 
     await userEvent.click(screen.getByText('Crash Free Session Rate'));
     await userEvent.click(screen.getByText('Set Conditions'));
-    expect(routerContext.context.router.push).toHaveBeenCalledWith({
+    expect(router.push).toHaveBeenCalledWith({
       pathname: '/organizations/org-slug/alerts/new/metric/',
       query: {
         aggregate:

--- a/static/app/views/dashboards/dashboard.spec.tsx
+++ b/static/app/views/dashboards/dashboard.spec.tsx
@@ -131,7 +131,7 @@ describe('Dashboards > Dashboard', () => {
         widgetLimitReached={false}
         isEditingDashboard={false}
       />,
-      {context: initialData.routerContext}
+      {router: initialData.router}
     );
     expect(tagsMock).toHaveBeenCalled();
   });
@@ -154,7 +154,7 @@ describe('Dashboards > Dashboard', () => {
         widgetLimitReached={false}
         onSetNewWidget={mockCallbackToUnsetNewWidget}
       />,
-      {context: initialData.routerContext}
+      {router: initialData.router}
     );
     await waitFor(() => expect(mockHandleAddCustomWidget).toHaveBeenCalled());
     expect(mockCallbackToUnsetNewWidget).toHaveBeenCalled();
@@ -177,7 +177,7 @@ describe('Dashboards > Dashboard', () => {
         widgetLimitReached={false}
         onSetNewWidget={mockCallbackToUnsetNewWidget}
       />,
-      {context: initialData.routerContext}
+      {router: initialData.router}
     );
     expect(mockHandleAddCustomWidget).not.toHaveBeenCalled();
     expect(mockCallbackToUnsetNewWidget).not.toHaveBeenCalled();
@@ -220,7 +220,7 @@ describe('Dashboards > Dashboard', () => {
         widgetLimitReached={false}
         onSetNewWidget={mockCallbackToUnsetNewWidget}
       />,
-      {context: initialData.routerContext}
+      {router: initialData.router}
     );
     expect(mockHandleAddCustomWidget).not.toHaveBeenCalled();
     expect(mockCallbackToUnsetNewWidget).not.toHaveBeenCalled();

--- a/static/app/views/dashboards/datasetConfig/errorsAndTransactions.spec.tsx
+++ b/static/app/views/dashboards/datasetConfig/errorsAndTransactions.spec.tsx
@@ -9,7 +9,7 @@ import EventView from 'sentry/utils/discover/eventView';
 import {getCustomEventsFieldRenderer} from 'sentry/views/dashboards/datasetConfig/errorsAndTransactions';
 
 describe('getCustomFieldRenderer', function () {
-  const {organization, router, routerContext} = initializeOrg();
+  const {organization, router} = initializeOrg();
 
   const baseEventViewOptions: EventViewOptions = {
     start: undefined,
@@ -43,7 +43,7 @@ describe('getCustomFieldRenderer', function () {
           }),
         }
       ) as React.ReactElement<any, any>,
-      {context: routerContext}
+      {router}
     );
     await userEvent.click(await screen.findByText('abcd'));
     expect(router.push).toHaveBeenCalledWith({
@@ -72,7 +72,7 @@ describe('getCustomFieldRenderer', function () {
           }),
         }
       ) as React.ReactElement<any, any>,
-      {context: routerContext}
+      {router}
     );
 
     await userEvent.click(await screen.findByText('defg'));
@@ -114,7 +114,7 @@ describe('getCustomFieldRenderer', function () {
           }),
         }
       ) as React.ReactElement<any, any>,
-      {context: routerContext}
+      {router}
     );
 
     await userEvent.click(await screen.findByText('<< unparameterized >>'));

--- a/static/app/views/dashboards/detail.spec.tsx
+++ b/static/app/views/dashboards/detail.spec.tsx
@@ -163,7 +163,7 @@ describe('Dashboards > Detail', function () {
             {null}
           </ViewEditDashboard>
         </OrganizationContext.Provider>,
-        {context: initialData.routerContext}
+        {router: initialData.router}
       );
 
       expect(await screen.findByText('Default Widget 1')).toBeInTheDocument();
@@ -183,7 +183,7 @@ describe('Dashboards > Detail', function () {
         >
           {null}
         </CreateDashboard>,
-        {context: initialData.routerContext, organization: initialData.organization}
+        {router: initialData.router, organization: initialData.organization}
       );
 
       await waitFor(() => {
@@ -389,7 +389,7 @@ describe('Dashboards > Detail', function () {
             {null}
           </ViewEditDashboard>
         </OrganizationContext.Provider>,
-        {context: initialData.routerContext}
+        {router: initialData.router}
       );
 
       await waitFor(() => expect(mockVisit).toHaveBeenCalledTimes(1));
@@ -445,7 +445,7 @@ describe('Dashboards > Detail', function () {
             {null}
           </ViewEditDashboard>
         </OrganizationContext.Provider>,
-        {context: initialData.routerContext}
+        {router: initialData.router}
       );
 
       await waitFor(() =>
@@ -474,7 +474,7 @@ describe('Dashboards > Detail', function () {
             {null}
           </ViewEditDashboard>
         </OrganizationContext.Provider>,
-        {context: initialData.routerContext}
+        {router: initialData.router}
       );
 
       // Enter edit mode.
@@ -512,7 +512,7 @@ describe('Dashboards > Detail', function () {
             {null}
           </ViewEditDashboard>
         </OrganizationContext.Provider>,
-        {context: initialData.routerContext}
+        {router: initialData.router}
       );
       expect(await screen.findByText('All Releases')).toBeInTheDocument();
       expect(mockReleases).toHaveBeenCalledTimes(1);
@@ -534,7 +534,7 @@ describe('Dashboards > Detail', function () {
             {null}
           </ViewEditDashboard>
         </OrganizationContext.Provider>,
-        {context: initialData.routerContext}
+        {router: initialData.router}
       );
 
       // Enter edit mode.
@@ -594,7 +594,7 @@ describe('Dashboards > Detail', function () {
         >
           {null}
         </ViewEditDashboard>,
-        {context: initialData.routerContext, organization: initialData.organization}
+        {router: initialData.router, organization: initialData.organization}
       );
 
       expect(await screen.findByText('First Widget')).toBeInTheDocument();
@@ -637,7 +637,7 @@ describe('Dashboards > Detail', function () {
         >
           {null}
         </ViewEditDashboard>,
-        {context: initialData.routerContext, organization: initialData.organization}
+        {router: initialData.router, organization: initialData.organization}
       );
 
       await userEvent.click(await screen.findByText('Edit Dashboard'));
@@ -683,7 +683,7 @@ describe('Dashboards > Detail', function () {
         >
           {null}
         </ViewEditDashboard>,
-        {context: initialData.routerContext, organization: initialData.organization}
+        {router: initialData.router, organization: initialData.organization}
       );
 
       await userEvent.click(await screen.findByText('Edit Dashboard'));
@@ -731,7 +731,7 @@ describe('Dashboards > Detail', function () {
         >
           {null}
         </ViewEditDashboard>,
-        {context: initialData.routerContext, organization: initialData.organization}
+        {router: initialData.router, organization: initialData.organization}
       );
 
       await userEvent.click(await screen.findByText('Edit Dashboard'));
@@ -773,7 +773,7 @@ describe('Dashboards > Detail', function () {
         >
           {null}
         </ViewEditDashboard>,
-        {context: initialData.routerContext, organization: initialData.organization}
+        {router: initialData.router, organization: initialData.organization}
       );
 
       await waitFor(() => {
@@ -803,7 +803,7 @@ describe('Dashboards > Detail', function () {
         >
           {null}
         </ViewEditDashboard>,
-        {context: initialData.routerContext, organization: initialData.organization}
+        {router: initialData.router, organization: initialData.organization}
       );
 
       expect(await screen.findByText('All Releases')).toBeInTheDocument();
@@ -842,7 +842,7 @@ describe('Dashboards > Detail', function () {
           {null}
         </CreateDashboard>,
         {
-          context: initialData.routerContext,
+          router: initialData.router,
           organization: initialData.organization,
         }
       );
@@ -885,7 +885,7 @@ describe('Dashboards > Detail', function () {
           {null}
         </CreateDashboard>,
         {
-          context: initialData.routerContext,
+          router: initialData.router,
           organization: initialData.organization,
         }
       );
@@ -924,7 +924,7 @@ describe('Dashboards > Detail', function () {
           {null}
         </CreateDashboard>,
         {
-          context: initialData.routerContext,
+          router: initialData.router,
           organization: initialData.organization,
         }
       );
@@ -956,7 +956,7 @@ describe('Dashboards > Detail', function () {
         >
           {null}
         </ViewEditDashboard>,
-        {context: initialData.routerContext, organization: initialData.organization}
+        {router: initialData.router, organization: initialData.organization}
       );
 
       await waitFor(() => {
@@ -991,7 +991,7 @@ describe('Dashboards > Detail', function () {
         >
           {null}
         </ViewEditDashboard>,
-        {context: initialData.routerContext, organization: initialData.organization}
+        {router: initialData.router, organization: initialData.organization}
       );
 
       await waitFor(() => {
@@ -1042,7 +1042,7 @@ describe('Dashboards > Detail', function () {
         >
           {null}
         </ViewEditDashboard>,
-        {context: testData.routerContext, organization: testData.organization}
+        {router: testData.router, organization: testData.organization}
       );
 
       await userEvent.click(await screen.findByText('Save'));
@@ -1105,7 +1105,7 @@ describe('Dashboards > Detail', function () {
         >
           {null}
         </ViewEditDashboard>,
-        {context: testData.routerContext, organization: testData.organization}
+        {router: testData.router, organization: testData.organization}
       );
 
       await screen.findByText('7D');
@@ -1156,7 +1156,7 @@ describe('Dashboards > Detail', function () {
         >
           {null}
         </ViewEditDashboard>,
-        {context: testData.routerContext, organization: testData.organization}
+        {router: testData.router, organization: testData.organization}
       );
 
       await userEvent.click(await screen.findByText('Save'));
@@ -1212,7 +1212,7 @@ describe('Dashboards > Detail', function () {
         >
           {null}
         </ViewEditDashboard>,
-        {context: testData.routerContext, organization: testData.organization}
+        {router: testData.router, organization: testData.organization}
       );
 
       await screen.findByText('7D');
@@ -1274,7 +1274,7 @@ describe('Dashboards > Detail', function () {
         >
           {null}
         </ViewEditDashboard>,
-        {context: testData.routerContext, organization: testData.organization}
+        {router: testData.router, organization: testData.organization}
       );
 
       expect(await screen.findByText('Save')).toBeInTheDocument();
@@ -1331,7 +1331,7 @@ describe('Dashboards > Detail', function () {
         >
           {null}
         </ViewEditDashboard>,
-        {context: testData.routerContext, organization: testData.organization}
+        {router: testData.router, organization: testData.organization}
       );
 
       await waitFor(() => expect(screen.queryAllByText('Loading\u2026')).toEqual([]));
@@ -1379,7 +1379,7 @@ describe('Dashboards > Detail', function () {
         >
           {null}
         </ViewEditDashboard>,
-        {context: testData.routerContext, organization: testData.organization}
+        {router: testData.router, organization: testData.organization}
       );
 
       await screen.findByText(/not-selected-1/);
@@ -1426,7 +1426,7 @@ describe('Dashboards > Detail', function () {
         >
           {null}
         </ViewEditDashboard>,
-        {context: testData.routerContext, organization: testData.organization}
+        {router: testData.router, organization: testData.organization}
       );
 
       await screen.findByText(/not-selected-1/);
@@ -1480,7 +1480,7 @@ describe('Dashboards > Detail', function () {
         >
           {null}
         </ViewEditDashboard>,
-        {context: testData.routerContext, organization: testData.organization}
+        {router: testData.router, organization: testData.organization}
       );
 
       await userEvent.click(await screen.findByText('All Releases'));
@@ -1545,7 +1545,7 @@ describe('Dashboards > Detail', function () {
         >
           {null}
         </ViewEditDashboard>,
-        {context: testData.routerContext, organization: testData.organization}
+        {router: testData.router, organization: testData.organization}
       );
 
       await userEvent.click(await screen.findByText('All Releases'));

--- a/static/app/views/dashboards/manage/dashboardList.spec.tsx
+++ b/static/app/views/dashboards/manage/dashboardList.spec.tsx
@@ -24,7 +24,7 @@ describe('Dashboards - DashboardList', function () {
     projects: [ProjectFixture()],
   });
 
-  const {router, routerContext} = initializeOrg();
+  const {router} = initializeOrg();
 
   beforeEach(function () {
     MockApiClient.clearMockResponses();
@@ -137,7 +137,7 @@ describe('Dashboards - DashboardList', function () {
         pageLinks=""
         location={router.location}
       />,
-      {context: routerContext}
+      {router}
     );
 
     expect(screen.getByRole('link', {name: 'Dashboard 1'})).toHaveAttribute(
@@ -159,7 +159,7 @@ describe('Dashboards - DashboardList', function () {
         pageLinks=""
         location={{...LocationFixture(), query: {statsPeriod: '7d'}}}
       />,
-      {context: routerContext}
+      {router}
     );
 
     expect(screen.getByRole('link', {name: 'Dashboard 1'})).toHaveAttribute(
@@ -177,7 +177,7 @@ describe('Dashboards - DashboardList', function () {
         location={{...LocationFixture(), query: {}}}
         onDashboardsChange={dashboardUpdateMock}
       />,
-      {context: routerContext}
+      {router}
     );
     renderGlobalModal();
 

--- a/static/app/views/dashboards/orgDashboards.spec.tsx
+++ b/static/app/views/dashboards/orgDashboards.spec.tsx
@@ -82,7 +82,7 @@ describe('OrgDashboards', () => {
             <DashboardDetail
               api={api}
               initialState={DashboardState.VIEW}
-              location={initialData.routerContext.location}
+              location={initialData.router.location}
               router={initialData.router}
               dashboard={dashboard}
               dashboards={dashboards}
@@ -93,7 +93,7 @@ describe('OrgDashboards', () => {
           );
         }}
       </OrgDashboards>,
-      {context: initialData.routerContext}
+      {router: initialData.router}
     );
 
     await waitFor(() =>
@@ -159,7 +159,7 @@ describe('OrgDashboards', () => {
           );
         }}
       </OrgDashboards>,
-      {context: initialData.routerContext}
+      {router: initialData.router}
     );
 
     await waitFor(() =>
@@ -232,7 +232,7 @@ describe('OrgDashboards', () => {
           );
         }}
       </OrgDashboards>,
-      {context: initialData.routerContext}
+      {router: initialData.router}
     );
 
     expect(browserHistory.replace).not.toHaveBeenCalled();
@@ -251,7 +251,7 @@ describe('OrgDashboards', () => {
             <DashboardDetail
               api={api}
               initialState={DashboardState.VIEW}
-              location={initialData.routerContext.location}
+              location={initialData.router.location}
               router={initialData.router}
               dashboard={dashboard}
               dashboards={dashboards}
@@ -262,7 +262,7 @@ describe('OrgDashboards', () => {
           );
         }}
       </OrgDashboards>,
-      {context: initialData.routerContext}
+      {router: initialData.router}
     );
 
     expect(browserHistory.replace).not.toHaveBeenCalled();
@@ -298,7 +298,7 @@ describe('OrgDashboards', () => {
             <DashboardDetail
               api={api}
               initialState={DashboardState.VIEW}
-              location={initialData.routerContext.location}
+              location={initialData.router.location}
               router={initialData.router}
               dashboard={dashboard}
               dashboards={dashboards}
@@ -309,7 +309,7 @@ describe('OrgDashboards', () => {
           );
         }}
       </OrgDashboards>,
-      {context: initialData.routerContext}
+      {router: initialData.router}
     );
 
     await waitFor(() => expect(browserHistory.replace).toHaveBeenCalledTimes(1));
@@ -317,7 +317,7 @@ describe('OrgDashboards', () => {
     rerender(
       <OrgDashboards
         api={api}
-        location={{...initialData.routerContext.location, query: {}}}
+        location={{...initialData.router.location, query: {}}}
         organization={initialData.organization}
         params={{orgId: 'org-slug', dashboardId: '1'}}
       >
@@ -326,7 +326,7 @@ describe('OrgDashboards', () => {
             <DashboardDetail
               api={api}
               initialState={DashboardState.VIEW}
-              location={initialData.routerContext.location}
+              location={initialData.router.location}
               router={initialData.router}
               dashboard={dashboard}
               dashboards={dashboards}

--- a/static/app/views/dashboards/widgetBuilder/buildSteps/visualizationStep.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/buildSteps/visualizationStep.spec.tsx
@@ -74,7 +74,7 @@ function mockRequests(orgSlug: Organization['slug']) {
 }
 
 describe('VisualizationStep', function () {
-  const {organization, router, routerContext} = initializeOrg({
+  const {organization, router} = initializeOrg({
     organization: {
       features: ['dashboards-edit', 'global-views', 'dashboards-mep'],
     },
@@ -117,7 +117,7 @@ describe('VisualizationStep', function () {
         }}
       />,
       {
-        context: routerContext,
+        router,
         organization,
       }
     );
@@ -166,7 +166,7 @@ describe('VisualizationStep', function () {
         }}
       />,
       {
-        context: routerContext,
+        router,
         organization: {
           ...organization,
           features: [...organization.features, 'dynamic-sampling', 'mep-rollout-flag'],
@@ -208,7 +208,7 @@ describe('VisualizationStep', function () {
         }}
       />,
       {
-        context: routerContext,
+        router,
         organization,
       }
     );
@@ -254,7 +254,7 @@ describe('VisualizationStep', function () {
         }}
       />,
       {
-        context: routerContext,
+        router,
         organization,
       }
     );

--- a/static/app/views/dashboards/widgetBuilder/widgetBuilder.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/widgetBuilder.spec.tsx
@@ -62,7 +62,7 @@ function renderTestComponent({
   params?: Partial<WidgetBuilderProps['params']>;
   query?: Record<string, any>;
 } = {}) {
-  const {organization, router, routerContext} = initializeOrg({
+  const {organization, router} = initializeOrg({
     organization: {
       features: orgFeatures ?? defaultOrgFeatures,
     },
@@ -103,7 +103,7 @@ function renderTestComponent({
       }}
     />,
     {
-      context: routerContext,
+      router,
       organization,
     }
   );

--- a/static/app/views/dashboards/widgetBuilder/widgetBuilderDataset.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/widgetBuilderDataset.spec.tsx
@@ -59,7 +59,7 @@ function renderTestComponent({
   params?: Partial<WidgetBuilderProps['params']>;
   query?: Record<string, any>;
 } = {}) {
-  const {organization, router, routerContext} = initializeOrg({
+  const {organization, router} = initializeOrg({
     organization: {
       features: orgFeatures ?? defaultOrgFeatures,
     },
@@ -100,7 +100,7 @@ function renderTestComponent({
       }}
     />,
     {
-      context: routerContext,
+      router,
       organization,
     }
   );

--- a/static/app/views/dashboards/widgetBuilder/widgetBuilderSortBy.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/widgetBuilderSortBy.spec.tsx
@@ -47,7 +47,7 @@ function renderTestComponent({
   params?: Partial<WidgetBuilderProps['params']>;
   query?: Record<string, any>;
 } = {}) {
-  const {organization, router, routerContext} = initializeOrg({
+  const {organization, router} = initializeOrg({
     organization: {
       features: orgFeatures ?? defaultOrgFeatures,
     },
@@ -88,7 +88,7 @@ function renderTestComponent({
       }}
     />,
     {
-      context: routerContext,
+      router,
       organization,
     }
   );

--- a/static/app/views/dashboards/widgetCard/index.spec.tsx
+++ b/static/app/views/dashboards/widgetCard/index.spec.tsx
@@ -27,7 +27,7 @@ jest.mock('sentry/components/lazyRender', () => ({
 }));
 
 describe('Dashboards > WidgetCard', function () {
-  const {router, organization, routerContext} = initializeOrg({
+  const {router, organization} = initializeOrg({
     organization: OrganizationFixture({
       features: ['dashboards-edit', 'discover-basic'],
       projects: [ProjectFixture()],
@@ -38,7 +38,7 @@ describe('Dashboards > WidgetCard', function () {
   const renderWithProviders = (component: React.ReactNode) =>
     render(
       <MEPSettingProvider forceTransactions={false}>{component}</MEPSettingProvider>,
-      {organization, router, context: routerContext}
+      {organization, router}
     );
 
   const multipleQueryWidget: Widget = {

--- a/static/app/views/dashboards/widgetCard/issueWidgetCard.spec.tsx
+++ b/static/app/views/dashboards/widgetCard/issueWidgetCard.spec.tsx
@@ -11,7 +11,7 @@ import WidgetCard from 'sentry/views/dashboards/widgetCard';
 import {IssueSortOptions} from 'sentry/views/issueList/utils';
 
 describe('Dashboards > IssueWidgetCard', function () {
-  const {router, organization, routerContext} = initializeOrg({
+  const {router, organization} = initializeOrg({
     organization: OrganizationFixture({
       features: ['dashboards-edit'],
     }),
@@ -126,7 +126,7 @@ describe('Dashboards > IssueWidgetCard', function () {
         showContextMenu
         widgetLimitReached={false}
       />,
-      {context: routerContext}
+      {router}
     );
 
     await userEvent.click(await screen.findByLabelText('Widget actions'));

--- a/static/app/views/discover/chartFooter.spec.tsx
+++ b/static/app/views/discover/chartFooter.spec.tsx
@@ -56,7 +56,7 @@ describe('Discover > ChartFooter', function () {
       />
     );
 
-    render(chartFooter, {context: initialData.routerContext});
+    render(chartFooter, {router: initialData.router});
 
     expect(
       await screen.findByRole('button', {
@@ -98,7 +98,7 @@ describe('Discover > ChartFooter', function () {
       />
     );
 
-    render(chartFooter, {context: initialData.routerContext});
+    render(chartFooter, {router: initialData.router});
 
     expect(
       await screen.findByRole('button', {name: `Limit ${limit}`})

--- a/static/app/views/discover/eventDetails/index.spec.tsx
+++ b/static/app/views/discover/eventDetails/index.spec.tsx
@@ -186,7 +186,7 @@ describe('Discover > EventDetails', function () {
   });
 
   it('navigates when tag values are clicked', async function () {
-    const {organization, routerContext} = initializeOrg({
+    const {organization, router} = initializeOrg({
       organization: OrganizationFixture(),
       router: {
         location: {
@@ -205,7 +205,7 @@ describe('Discover > EventDetails', function () {
           query: allEventsView.generateQueryStringObject(),
         }}
       />,
-      {context: routerContext}
+      {router}
     );
 
     // Get the first link as we wrap react-router's link
@@ -229,7 +229,7 @@ describe('Discover > EventDetails', function () {
   });
 
   it('navigates to homepage when tag values are clicked', async function () {
-    const {organization, routerContext, router} = initializeOrg({
+    const {organization, router} = initializeOrg({
       organization: OrganizationFixture(),
       router: {
         location: {
@@ -245,7 +245,7 @@ describe('Discover > EventDetails', function () {
         params={{eventSlug: 'project-slug:deadbeef'}}
         location={router.location}
       />,
-      {context: routerContext}
+      {router}
     );
 
     // Get the first link as we wrap react-router's link
@@ -269,7 +269,7 @@ describe('Discover > EventDetails', function () {
   });
 
   it('appends tag value to existing query when clicked', async function () {
-    const {organization, routerContext} = initializeOrg({
+    const {organization, router} = initializeOrg({
       organization: OrganizationFixture(),
       router: {
         location: {
@@ -288,7 +288,7 @@ describe('Discover > EventDetails', function () {
           query: {...allEventsView.generateQueryStringObject(), query: 'Dumpster'},
         }}
       />,
-      {context: routerContext}
+      {router}
     );
 
     // Get the first link as we wrap react-router's link
@@ -311,7 +311,7 @@ describe('Discover > EventDetails', function () {
   });
 
   it('links back to the homepage if the query param contains homepage flag', async () => {
-    const {organization, router, routerContext} = initializeOrg({
+    const {organization, router} = initializeOrg({
       organization: OrganizationFixture(),
       router: {
         location: {
@@ -328,7 +328,7 @@ describe('Discover > EventDetails', function () {
         params={{eventSlug: 'project-slug:deadbeef'}}
         location={router.location}
       />,
-      {context: routerContext, organization}
+      {router, organization}
     );
 
     const breadcrumb = await screen.findByTestId('breadcrumb-link');

--- a/static/app/views/discover/homepage.spec.tsx
+++ b/static/app/views/discover/homepage.spec.tsx
@@ -101,7 +101,7 @@ describe('Discover > Homepage', () => {
         setSavedQuery={jest.fn()}
         loading={false}
       />,
-      {context: initialData.routerContext, organization: initialData.organization}
+      {router: initialData.router, organization: initialData.organization}
     );
 
     await screen.findByText('Discover Trends');
@@ -119,7 +119,7 @@ describe('Discover > Homepage', () => {
         setSavedQuery={jest.fn()}
         loading={false}
       />,
-      {context: initialData.routerContext, organization: initialData.organization}
+      {router: initialData.router, organization: initialData.organization}
     );
 
     expect(mockHomepage).toHaveBeenCalled();
@@ -153,7 +153,7 @@ describe('Discover > Homepage', () => {
         setSavedQuery={jest.fn()}
         loading={false}
       />,
-      {context: initialData.routerContext, organization: initialData.organization}
+      {router: initialData.router, organization: initialData.organization}
     );
 
     expect(mockHomepage).toHaveBeenCalled();
@@ -172,7 +172,7 @@ describe('Discover > Homepage', () => {
         setSavedQuery={jest.fn()}
         loading={false}
       />,
-      {context: initialData.routerContext, organization: initialData.organization}
+      {router: initialData.router, organization: initialData.organization}
     );
     renderGlobalModal();
 
@@ -201,7 +201,7 @@ describe('Discover > Homepage', () => {
         setSavedQuery={jest.fn()}
         loading={false}
       />,
-      {context: initialData.routerContext, organization: initialData.organization}
+      {router: initialData.router, organization: initialData.organization}
     );
     await waitFor(() => {
       expect(measurementsMetaMock).toHaveBeenCalled();
@@ -248,7 +248,7 @@ describe('Discover > Homepage', () => {
         setSavedQuery={jest.fn()}
         loading={false}
       />,
-      {context: initialData.routerContext, organization: initialData.organization}
+      {router: initialData.router, organization: initialData.organization}
     );
 
     expect(await screen.findByText('Remove Default')).toBeInTheDocument();
@@ -281,7 +281,7 @@ describe('Discover > Homepage', () => {
         setSavedQuery={jest.fn()}
         loading={false}
       />,
-      {context: initialData.routerContext, organization: initialData.organization}
+      {router: initialData.router, organization: initialData.organization}
     );
 
     expect(mockHomepage).toHaveBeenCalled();
@@ -317,7 +317,7 @@ describe('Discover > Homepage', () => {
         setSavedQuery={jest.fn()}
         loading={false}
       />,
-      {context: initialData.routerContext, organization: initialData.organization}
+      {router: initialData.router, organization: initialData.organization}
     );
 
     await userEvent.click(await screen.findByText('24H'));
@@ -355,7 +355,7 @@ describe('Discover > Homepage', () => {
         setSavedQuery={jest.fn()}
         loading={false}
       />,
-      {context: initialData.routerContext, organization: initialData.organization}
+      {router: initialData.router, organization: initialData.organization}
     );
     renderGlobalModal();
 
@@ -411,7 +411,7 @@ describe('Discover > Homepage', () => {
         setSavedQuery={jest.fn()}
         loading={false}
       />,
-      {context: initialData.routerContext, organization: initialData.organization}
+      {router: initialData.router, organization: initialData.organization}
     );
     renderGlobalModal();
 
@@ -467,7 +467,7 @@ describe('Discover > Homepage', () => {
         setSavedQuery={jest.fn()}
         loading={false}
       />,
-      {context: initialData.routerContext, organization: initialData.organization}
+      {router: initialData.router, organization: initialData.organization}
     );
     await waitFor(() => {
       expect(measurementsMetaMock).toHaveBeenCalled();
@@ -502,7 +502,7 @@ describe('Discover > Homepage', () => {
         setSavedQuery={jest.fn()}
         loading={false}
       />,
-      {context: initialData.routerContext, organization: initialData.organization}
+      {router: initialData.router, organization: initialData.organization}
     );
 
     await waitFor(() => expect(screen.getByTestId('set-as-default')).toBeEnabled());

--- a/static/app/views/discover/miniGraph.spec.tsx
+++ b/static/app/views/discover/miniGraph.spec.tsx
@@ -50,7 +50,7 @@ describe('Discover > MiniGraph', function () {
         organization={organization}
         yAxis={yAxis}
       />,
-      {context: initialData.routerContext}
+      {router: initialData.router}
     );
 
     expect(eventRequest.default).toHaveBeenCalledWith(
@@ -70,7 +70,7 @@ describe('Discover > MiniGraph', function () {
         organization={organization}
         yAxis={yAxis}
       />,
-      {context: initialData.routerContext}
+      {router: initialData.router}
     );
 
     expect(eventRequest.default).toHaveBeenCalledWith(

--- a/static/app/views/discover/queryList.spec.tsx
+++ b/static/app/views/discover/queryList.spec.tsx
@@ -30,7 +30,7 @@ describe('Discover > QueryList', function () {
     eventsStatsMock,
     wrapper;
 
-  const {router, routerContext} = initializeOrg();
+  const {router} = initializeOrg();
 
   beforeAll(async function () {
     await import('sentry/components/modals/widgetBuilder/addToDashboardModal');
@@ -194,7 +194,7 @@ describe('Discover > QueryList', function () {
         onQueryChange={queryChangeMock}
         location={location}
       />,
-      {context: routerContext}
+      {router}
     );
 
     await userEvent.click(screen.getAllByTestId(/card-*/).at(0)!);
@@ -216,7 +216,7 @@ describe('Discover > QueryList', function () {
         onQueryChange={queryChangeMock}
         location={location}
       />,
-      {context: routerContext}
+      {router}
     );
 
     const card = screen.getAllByTestId(/card-*/).at(0)!;

--- a/static/app/views/discover/results.spec.tsx
+++ b/static/app/views/discover/results.spec.tsx
@@ -238,7 +238,7 @@ describe('Results', function () {
       });
 
       // Start off with an invalid view (empty is invalid)
-      const initialData = initializeOrg({
+      const {router} = initializeOrg({
         organization,
         router: {
           location: {query: {query: 'tag:value'}},
@@ -251,13 +251,13 @@ describe('Results', function () {
 
       render(
         <Results
-          location={initialData.router.location}
-          router={initialData.router}
+          location={router.location}
+          router={router}
           loading={false}
           setSavedQuery={jest.fn()}
         />,
         {
-          context: initialData.routerContext,
+          router: router,
           organization,
         }
       );
@@ -281,7 +281,7 @@ describe('Results', function () {
         features,
       });
 
-      const initialData = initializeOrg({
+      const {router} = initializeOrg({
         organization,
         router: {
           location: {
@@ -300,19 +300,19 @@ describe('Results', function () {
       render(
         <Results
           organization={organization}
-          location={initialData.router.location}
-          router={initialData.router}
+          location={router.location}
+          router={router}
           loading={false}
           setSavedQuery={jest.fn()}
         />,
         {
-          context: initialData.routerContext,
+          router: router,
           organization,
         }
       );
 
       // ensure cursor query string is initially present in the location
-      expect(initialData.router.location).toEqual({
+      expect(router.location).toEqual({
         query: {
           ...generateFields(),
           cursor: '0%3A50%3A0',
@@ -334,7 +334,7 @@ describe('Results', function () {
       expect(mockRequests.mockVisit).not.toHaveBeenCalled();
 
       // cursor query string should be omitted from the query string
-      expect(initialData.router.push).toHaveBeenCalledWith({
+      expect(router.push).toHaveBeenCalledWith({
         pathname: undefined,
         query: {
           ...generateFields(),
@@ -349,7 +349,7 @@ describe('Results', function () {
         features,
       });
 
-      const initialData = initializeOrg({
+      const {router} = initializeOrg({
         organization,
         router: {
           location: {query: {...generateFields(), yAxis: 'count()'}},
@@ -363,13 +363,13 @@ describe('Results', function () {
       render(
         <Results
           organization={organization}
-          location={initialData.router.location}
-          router={initialData.router}
+          location={router.location}
+          router={router}
           loading={false}
           setSavedQuery={jest.fn()}
         />,
         {
-          context: initialData.routerContext,
+          router: router,
           organization,
         }
       );
@@ -386,7 +386,7 @@ describe('Results', function () {
         features,
       });
 
-      const initialData = initializeOrg({
+      const {router} = initializeOrg({
         organization,
         router: {
           location: {query: {...generateFields(), display: 'default', yAxis: 'count'}},
@@ -400,13 +400,13 @@ describe('Results', function () {
       render(
         <Results
           organization={organization}
-          location={initialData.router.location}
-          router={initialData.router}
+          location={router.location}
+          router={router}
           loading={false}
           setSavedQuery={jest.fn()}
         />,
         {
-          context: initialData.routerContext,
+          router: router,
           organization,
         }
       );
@@ -423,7 +423,7 @@ describe('Results', function () {
         features: ['discover-basic'],
       });
 
-      const initialData = initializeOrg({
+      const {router} = initializeOrg({
         organization,
         router: {
           location: {query: {...generateFields(), display: 'previous'}},
@@ -437,13 +437,13 @@ describe('Results', function () {
       render(
         <Results
           organization={organization}
-          location={initialData.router.location}
-          router={initialData.router}
+          location={router.location}
+          router={router}
           loading={false}
           setSavedQuery={jest.fn()}
         />,
         {
-          context: initialData.routerContext,
+          router: router,
           organization,
         }
       );
@@ -459,7 +459,7 @@ describe('Results', function () {
         features: ['discover-basic'],
       });
 
-      const initialData = initializeOrg({
+      const {router} = initializeOrg({
         organization,
         router: {
           location: {query: {...generateFields(), statsPeriod: '60d', project: '-1'}},
@@ -473,13 +473,13 @@ describe('Results', function () {
       render(
         <Results
           organization={organization}
-          location={initialData.router.location}
-          router={initialData.router}
+          location={router.location}
+          router={router}
           loading={false}
           setSavedQuery={jest.fn()}
         />,
         {
-          context: initialData.routerContext,
+          router: router,
           organization,
         }
       );
@@ -495,7 +495,7 @@ describe('Results', function () {
         features: ['discover-basic'],
       });
 
-      const initialData = initializeOrg({
+      const {router} = initializeOrg({
         organization,
         router: {
           location: {
@@ -515,13 +515,13 @@ describe('Results', function () {
       render(
         <Results
           organization={organization}
-          location={initialData.router.location}
-          router={initialData.router}
+          location={router.location}
+          router={router}
           loading={false}
           setSavedQuery={jest.fn()}
         />,
         {
-          context: initialData.routerContext,
+          router: router,
           organization,
         }
       );
@@ -537,7 +537,7 @@ describe('Results', function () {
         features: ['discover-basic'],
       });
 
-      const initialData = initializeOrg({
+      const {router} = initializeOrg({
         organization,
         router: {
           location: {query: {...generateFields(), statsPeriod: '30d', project: '-1'}},
@@ -551,13 +551,13 @@ describe('Results', function () {
       render(
         <Results
           organization={organization}
-          location={initialData.router.location}
-          router={initialData.router}
+          location={router.location}
+          router={router}
           loading={false}
           setSavedQuery={jest.fn()}
         />,
         {
-          context: initialData.routerContext,
+          router: router,
           organization,
         }
       );
@@ -573,7 +573,7 @@ describe('Results', function () {
         features: ['discover-basic'],
       });
 
-      const initialData = initializeOrg({
+      const {router} = initializeOrg({
         organization,
         router: {
           location: {
@@ -593,13 +593,13 @@ describe('Results', function () {
       render(
         <Results
           organization={organization}
-          location={initialData.router.location}
-          router={initialData.router}
+          location={router.location}
+          router={router}
           loading={false}
           setSavedQuery={jest.fn()}
         />,
         {
-          context: initialData.routerContext,
+          router: router,
           organization,
         }
       );
@@ -616,7 +616,7 @@ describe('Results', function () {
         slug: 'org-slug',
       });
 
-      const initialData = initializeOrg({
+      const {router} = initializeOrg({
         organization,
         router: {
           location: {query: {id: '1', statsPeriod: '24h'}},
@@ -630,13 +630,13 @@ describe('Results', function () {
       render(
         <Results
           organization={organization}
-          location={initialData.router.location}
-          router={initialData.router}
+          location={router.location}
+          router={router}
           loading={false}
           setSavedQuery={jest.fn()}
         />,
         {
-          context: initialData.routerContext,
+          router: router,
           organization,
         }
       );
@@ -675,7 +675,7 @@ describe('Results', function () {
         features,
         slug: 'org-slug',
       });
-      const initialData = initializeOrg({
+      const {router} = initializeOrg({
         organization,
         router: {
           location: {
@@ -696,13 +696,13 @@ describe('Results', function () {
       render(
         <Results
           organization={organization}
-          location={initialData.router.location}
-          router={initialData.router}
+          location={router.location}
+          router={router}
           loading={false}
           setSavedQuery={jest.fn()}
         />,
         {
-          context: initialData.routerContext,
+          router: router,
           organization,
         }
       );
@@ -720,7 +720,7 @@ describe('Results', function () {
         features,
       });
 
-      const initialData = initializeOrg({
+      const {router} = initializeOrg({
         organization,
         router: {
           location: {query: {...generateFields(), yAxis: 'count()'}},
@@ -734,13 +734,13 @@ describe('Results', function () {
       const {rerender} = render(
         <Results
           organization={organization}
-          location={initialData.router.location}
-          router={initialData.router}
+          location={router.location}
+          router={router}
           loading={false}
           setSavedQuery={jest.fn()}
         />,
         {
-          context: initialData.routerContext,
+          router: router,
           organization,
         }
       );
@@ -766,10 +766,10 @@ describe('Results', function () {
         <Results
           organization={organization}
           location={{
-            ...initialData.router.location,
+            ...router.location,
             query: {...generateFields(), yAxis: 'count_unique(user)'},
           }}
-          router={initialData.router}
+          router={router}
           loading={false}
           setSavedQuery={jest.fn()}
         />
@@ -797,7 +797,7 @@ describe('Results', function () {
         features,
       });
 
-      const initialData = initializeOrg({
+      const {router} = initializeOrg({
         organization,
         router: {
           location: {query: {...generateFields(), display: 'default', yAxis: 'count()'}},
@@ -811,13 +811,13 @@ describe('Results', function () {
       const {rerender} = render(
         <Results
           organization={organization}
-          location={initialData.router.location}
-          router={initialData.router}
+          location={router.location}
+          router={router}
           loading={false}
           setSavedQuery={jest.fn()}
         />,
         {
-          context: initialData.routerContext,
+          router: router,
           organization,
         }
       );
@@ -843,10 +843,10 @@ describe('Results', function () {
         <Results
           organization={organization}
           location={{
-            ...initialData.router.location,
+            ...router.location,
             query: {...generateFields(), display: 'previous', yAxis: 'count()'},
           }}
-          router={initialData.router}
+          router={router}
           loading={false}
           setSavedQuery={jest.fn()}
         />
@@ -874,7 +874,7 @@ describe('Results', function () {
         features,
       });
 
-      const initialData = initializeOrg({
+      const {router} = initializeOrg({
         organization,
         router: {
           location: {query: {...generateFields(), display: 'default', yAxis: 'count()'}},
@@ -888,13 +888,13 @@ describe('Results', function () {
       const {rerender} = render(
         <Results
           organization={organization}
-          location={initialData.router.location}
-          router={initialData.router}
+          location={router.location}
+          router={router}
           loading={false}
           setSavedQuery={jest.fn()}
         />,
         {
-          context: initialData.routerContext,
+          router: router,
           organization,
         }
       );
@@ -920,14 +920,14 @@ describe('Results', function () {
         <Results
           organization={organization}
           location={{
-            ...initialData.router.location,
+            ...router.location,
             query: {
               ...generateFields(),
               display: 'previous',
               yAxis: 'count_unique(user)',
             },
           }}
-          router={initialData.router}
+          router={router}
           loading={false}
           setSavedQuery={jest.fn()}
         />
@@ -955,7 +955,7 @@ describe('Results', function () {
         features,
       });
 
-      const initialData = initializeOrg({
+      const {router} = initializeOrg({
         organization,
         router: {
           location: {query: {...generateFields(), display: 'default', yAxis: 'count'}},
@@ -969,13 +969,13 @@ describe('Results', function () {
       render(
         <Results
           organization={organization}
-          location={initialData.router.location}
-          router={initialData.router}
+          location={router.location}
+          router={router}
           loading={false}
           setSavedQuery={jest.fn()}
         />,
         {
-          context: initialData.routerContext,
+          router: router,
           organization,
         }
       );
@@ -1007,7 +1007,7 @@ describe('Results', function () {
         features: [...features, 'global-views'],
       });
 
-      const initialData = initializeOrg({
+      const {router} = initializeOrg({
         organization,
         router: {
           location: {query: {...generateFields(), display: 'default', yAxis: 'count'}},
@@ -1033,12 +1033,12 @@ describe('Results', function () {
       render(
         <Results
           organization={organization}
-          location={initialData.router.location}
-          router={initialData.router}
+          location={router.location}
+          router={router}
           loading={false}
           setSavedQuery={jest.fn()}
         />,
-        {context: initialData.routerContext, organization}
+        {router: router, organization}
       );
 
       const projectPageFilter = await screen.findByTestId('page-filter-project-selector');
@@ -1064,7 +1064,7 @@ describe('Results', function () {
         features,
       });
 
-      const initialData = initializeOrg({
+      const {router} = initializeOrg({
         organization,
         router: {
           location: {query: {...generateFields(), yAxis: 'count()'}},
@@ -1076,12 +1076,12 @@ describe('Results', function () {
       render(
         <Results
           organization={organization}
-          location={initialData.router.location}
-          router={initialData.router}
+          location={router.location}
+          router={router}
           loading={false}
           setSavedQuery={jest.fn()}
         />,
-        {context: initialData.routerContext, organization}
+        {router: router, organization}
       );
 
       expect(await screen.findByText('this is a tip')).toBeInTheDocument();
@@ -1092,7 +1092,7 @@ describe('Results', function () {
         features: ['discover-basic'],
       });
 
-      const initialData = initializeOrg({
+      const {router} = initializeOrg({
         organization,
         router: {
           location: {query: {fromMetric: 'true', id: '1'}},
@@ -1106,13 +1106,13 @@ describe('Results', function () {
       render(
         <Results
           organization={organization}
-          location={initialData.router.location}
-          router={initialData.router}
+          location={router.location}
+          router={router}
           loading={false}
           setSavedQuery={jest.fn()}
         />,
         {
-          context: initialData.routerContext,
+          router: router,
           organization,
         }
       );
@@ -1129,7 +1129,7 @@ describe('Results', function () {
         features: ['discover-basic'],
       });
 
-      const initialData = initializeOrg({
+      const {router} = initializeOrg({
         organization,
         router: {
           location: {query: {showUnparameterizedBanner: 'true', id: '1'}},
@@ -1143,13 +1143,13 @@ describe('Results', function () {
       render(
         <Results
           organization={organization}
-          location={initialData.router.location}
-          router={initialData.router}
+          location={router.location}
+          router={router}
           loading={false}
           setSavedQuery={jest.fn()}
         />,
         {
-          context: initialData.routerContext,
+          router: router,
           organization,
         }
       );
@@ -1170,7 +1170,7 @@ describe('Results', function () {
         features: ['discover-basic', 'discover-query'],
       });
 
-      const initialData = initializeOrg({
+      const {router} = initializeOrg({
         organization,
         router: {
           // These fields take priority and should be sent in the request
@@ -1184,12 +1184,12 @@ describe('Results', function () {
       render(
         <Results
           organization={organization}
-          location={initialData.router.location}
-          router={initialData.router}
+          location={router.location}
+          router={router}
           loading={false}
           setSavedQuery={jest.fn()}
         />,
-        {context: initialData.routerContext, organization}
+        {router: router, organization}
       );
 
       await waitFor(() =>
@@ -1236,7 +1236,7 @@ describe('Results', function () {
         features: ['discover-basic', 'discover-query'],
       });
 
-      const initialData = initializeOrg({
+      const {router} = initializeOrg({
         organization,
         router: {
           location: {query: {id: '1'}},
@@ -1251,10 +1251,10 @@ describe('Results', function () {
           loading={false}
           setSavedQuery={jest.fn()}
           organization={organization}
-          location={initialData.router.location}
-          router={initialData.router}
+          location={router.location}
+          router={router}
         />,
-        {context: initialData.routerContext, organization}
+        {router: router, organization}
       );
 
       await waitFor(() =>
@@ -1269,7 +1269,7 @@ describe('Results', function () {
       const rerenderData = initializeOrg({
         organization,
         router: {
-          location: {query: {...initialData.router.location.query, display: 'previous'}},
+          location: {query: {...router.location.query, display: 'previous'}},
         },
       });
 
@@ -1297,7 +1297,7 @@ describe('Results', function () {
         features: ['discover-basic', 'discover-query'],
       });
 
-      const initialData = initializeOrg({
+      const {router} = initializeOrg({
         organization,
         router: {
           location: {
@@ -1318,12 +1318,12 @@ describe('Results', function () {
       const {rerender} = render(
         <Results
           organization={organization}
-          location={initialData.router.location}
-          router={initialData.router}
+          location={router.location}
+          router={router}
           loading={false}
           setSavedQuery={jest.fn()}
         />,
-        {context: initialData.routerContext, organization}
+        {router: router, organization}
       );
 
       await screen.findAllByText(TRANSACTION_VIEWS[0].name);
@@ -1335,7 +1335,7 @@ describe('Results', function () {
       const rerenderData = initializeOrg({
         organization,
         router: {
-          location: {query: {...initialData.router.location.query, display: 'previous'}},
+          location: {query: {...router.location.query, display: 'previous'}},
         },
       });
 
@@ -1357,7 +1357,7 @@ describe('Results', function () {
         features: ['discover-basic', 'discover-query'],
       });
 
-      const initialData = initializeOrg({
+      const {router} = initializeOrg({
         organization,
         router: {
           location: {query: {id: '1'}},
@@ -1370,12 +1370,12 @@ describe('Results', function () {
       render(
         <Results
           organization={organization}
-          location={initialData.router.location}
-          router={initialData.router}
+          location={router.location}
+          router={router}
           loading={false}
           setSavedQuery={jest.fn()}
         />,
-        {context: initialData.routerContext, organization}
+        {router: router, organization}
       );
 
       await waitFor(() => {
@@ -1393,7 +1393,7 @@ describe('Results', function () {
         features: ['discover-basic', 'discover-query'],
       });
 
-      const initialData = initializeOrg({
+      const {router} = initializeOrg({
         organization,
         router: {
           location: {query: {id: '1'}},
@@ -1404,12 +1404,12 @@ describe('Results', function () {
       render(
         <Results
           organization={organization}
-          location={initialData.router.location}
-          router={initialData.router}
+          location={router.location}
+          router={router}
           loading={false}
           setSavedQuery={jest.fn()}
         />,
-        {context: initialData.routerContext, organization}
+        {router: router, organization}
       );
 
       await waitFor(() => {
@@ -1427,7 +1427,7 @@ describe('Results', function () {
         features: ['discover-basic', 'discover-query'],
       });
 
-      const initialData = initializeOrg({
+      const {router} = initializeOrg({
         organization,
         router: {
           location: {
@@ -1448,12 +1448,12 @@ describe('Results', function () {
       render(
         <Results
           organization={organization}
-          location={initialData.router.location}
-          router={initialData.router}
+          location={router.location}
+          router={router}
           loading={false}
           setSavedQuery={jest.fn()}
         />,
-        {context: initialData.routerContext, organization}
+        {router: router, organization}
       );
 
       await waitFor(() => {
@@ -1467,7 +1467,7 @@ describe('Results', function () {
       const organization = OrganizationFixture({
         features: ['discover-basic', 'discover-query'],
       });
-      const initialData = initializeOrg({
+      const {router} = initializeOrg({
         organization,
         router: {
           location: {
@@ -1486,12 +1486,12 @@ describe('Results', function () {
       render(
         <Results
           organization={organization}
-          location={initialData.router.location}
-          router={initialData.router}
+          location={router.location}
+          router={router}
           loading={false}
           setSavedQuery={jest.fn()}
         />,
-        {context: initialData.routerContext, organization}
+        {router: router, organization}
       );
 
       await waitFor(() => {

--- a/static/app/views/discover/resultsChart.spec.tsx
+++ b/static/app/views/discover/resultsChart.spec.tsx
@@ -59,7 +59,7 @@ describe('Discover > ResultsChart', function () {
         yAxis={['count()', 'failure_count()']}
         onTopEventsChange={() => {}}
       />,
-      {context: initialData.routerContext}
+      {router: initialData.router}
     );
 
     await userEvent.click(screen.getByText(/Display/));
@@ -93,7 +93,7 @@ describe('Discover > ResultsChart', function () {
         yAxis={[]}
         onTopEventsChange={() => {}}
       />,
-      {context: initialData.routerContext}
+      {router: initialData.router}
     );
 
     expect(await screen.findByText(/No Y-Axis selected/)).toBeInTheDocument();

--- a/static/app/views/discover/savedQuery/datasetSelector.spec.tsx
+++ b/static/app/views/discover/savedQuery/datasetSelector.spec.tsx
@@ -4,13 +4,13 @@ import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 import {DatasetSelector} from 'sentry/views/discover/savedQuery/datasetSelector';
 
 describe('Discover DatasetSelector', function () {
-  const {router, routerContext} = initializeOrg({
+  const {router} = initializeOrg({
     organization: {features: ['performance-view']},
   });
 
   it('renders selector and options', async function () {
     render(<DatasetSelector isHomepage={false} savedQuery={undefined} />, {
-      context: routerContext,
+      router,
     });
     await userEvent.click(screen.getByText('Dataset'));
     const menuOptions = await screen.findAllByRole('option');
@@ -19,7 +19,7 @@ describe('Discover DatasetSelector', function () {
 
   it('pushes new event view', async function () {
     render(<DatasetSelector isHomepage={false} savedQuery={undefined} />, {
-      context: routerContext,
+      router,
     });
     await userEvent.click(screen.getByText('Dataset'));
     await userEvent.click(screen.getByRole('option', {name: 'Transactions'}));

--- a/static/app/views/discover/table/columnEditModal.spec.tsx
+++ b/static/app/views/discover/table/columnEditModal.spec.tsx
@@ -31,7 +31,7 @@ function mountModal({columns, onApply, customMeasurements}, initialData) {
       measurementKeys={null}
       customMeasurements={customMeasurements}
     />,
-    {context: initialData.routerContext}
+    {router: initialData.router}
   );
 }
 

--- a/static/app/views/discover/table/tableView.spec.tsx
+++ b/static/app/views/discover/table/tableView.spec.tsx
@@ -52,7 +52,7 @@ describe('TableView > CellActions', function () {
         showTags={false}
         title=""
       />,
-      {context: context.routerContext}
+      {router: context.router}
     );
   }
 

--- a/static/app/views/discover/tags.spec.tsx
+++ b/static/app/views/discover/tags.spec.tsx
@@ -126,7 +126,7 @@ describe('Tags', function () {
         generateUrl={generateUrl}
         confirmedQuery={false}
       />,
-      {context: initialData.routerContext}
+      {router: initialData.router}
     );
 
     // component has loaded
@@ -198,7 +198,7 @@ describe('Tags', function () {
         generateUrl={generateUrl}
         confirmedQuery={false}
       />,
-      {context: initialData.routerContext}
+      {router: initialData.router}
     );
 
     await waitForElementToBeRemoved(

--- a/static/app/views/integrationOrganizationLink/index.spec.tsx
+++ b/static/app/views/integrationOrganizationLink/index.spec.tsx
@@ -109,7 +109,7 @@ describe('IntegrationOrganizationLink', () => {
         params={{integrationSlug: 'vercel'}}
       />,
       {
-        context: initialData.routerContext,
+        router: initialData.router,
       }
     );
 

--- a/static/app/views/issueDetails/groupActivity.spec.tsx
+++ b/static/app/views/issueDetails/groupActivity.spec.tsx
@@ -63,7 +63,7 @@ describe('GroupActivity', function () {
       ],
       project,
     });
-    const {organization, routerContext, routerProps} = initializeOrg({
+    const {organization, routerProps, router} = initializeOrg({
       organization: additionalOrg,
     });
     GroupStore.add([group]);
@@ -71,7 +71,7 @@ describe('GroupActivity', function () {
     OrganizationStore.onUpdate(organization, {replace: true});
     return render(
       <GroupActivity {...routerProps} params={{orgId: 'org-slug'}} group={group} />,
-      {context: routerContext, organization}
+      {router, organization}
     );
   }
 

--- a/static/app/views/issueDetails/groupDetails.spec.tsx
+++ b/static/app/views/issueDetails/groupDetails.spec.tsx
@@ -100,7 +100,7 @@ describe('groupDetails', () => {
       <GroupDetails {...init.routerProps}>
         <MockComponent />
       </GroupDetails>,
-      {context: init.routerContext, organization: init.organization, router: init.router}
+      {organization: init.organization, router: init.router}
     );
   };
 

--- a/static/app/views/issueDetails/groupEventAttachments/groupEventAttachments.spec.tsx
+++ b/static/app/views/issueDetails/groupEventAttachments/groupEventAttachments.spec.tsx
@@ -14,7 +14,7 @@ import GroupEventAttachments, {MAX_SCREENSHOTS_PER_PAGE} from './groupEventAttac
 jest.mock('sentry/actionCreators/modal');
 
 describe('GroupEventAttachments > Screenshots', function () {
-  const {organization, routerContext} = initializeOrg({
+  const {organization, router} = initializeOrg({
     organization: OrganizationFixture(),
     router: {
       params: {orgId: 'org-slug', groupId: 'group-id'},
@@ -39,7 +39,7 @@ describe('GroupEventAttachments > Screenshots', function () {
 
   function renderGroupEventAttachments() {
     return render(<GroupEventAttachments project={project} />, {
-      context: routerContext,
+      router,
       organization,
     });
   }

--- a/static/app/views/issueDetails/groupEvents.spec.tsx
+++ b/static/app/views/issueDetails/groupEvents.spec.tsx
@@ -30,12 +30,12 @@ describe('groupEvents', () => {
   });
 
   let organization: Organization;
-  let routerContext;
+  let router;
 
   beforeEach(() => {
     browserHistory.push = jest.fn();
 
-    ({organization, routerContext} = initializeOrg({
+    ({organization, router} = initializeOrg({
       organization: {
         features: ['event-attachments'],
       },
@@ -126,7 +126,7 @@ describe('groupEvents', () => {
 
   it('fetches and renders a table of events', async () => {
     render(<GroupEvents {...baseProps} location={{...location, query: {}}} />, {
-      context: routerContext,
+      router,
       organization,
     });
 
@@ -144,7 +144,7 @@ describe('groupEvents', () => {
 
   it('handles search', async () => {
     render(<GroupEvents {...baseProps} location={{...location, query: {}}} />, {
-      context: routerContext,
+      router,
       organization,
     });
 
@@ -176,7 +176,7 @@ describe('groupEvents', () => {
         {...baseProps}
         location={{...location, query: {environment: ['prod', 'staging']}}}
       />,
-      {context: routerContext, organization}
+      {router, organization}
     );
     await waitFor(() => {
       expect(screen.getByText('transaction')).toBeInTheDocument();
@@ -199,7 +199,7 @@ describe('groupEvents', () => {
         group={group}
         location={{...location, query: {environment: ['prod', 'staging']}}}
       />,
-      {context: routerContext, organization}
+      {router, organization}
     );
     expect(requests.discover).toHaveBeenCalledWith(
       '/organizations/org-slug/events/',
@@ -224,7 +224,7 @@ describe('groupEvents', () => {
         group={group}
         location={{...location, query: {environment: ['prod', 'staging']}}}
       />,
-      {context: routerContext, organization}
+      {router, organization}
     );
     await waitForElementToBeRemoved(() => screen.queryByTestId('loading-indicator'));
 
@@ -241,7 +241,7 @@ describe('groupEvents', () => {
         {...baseProps}
         location={{...location, query: {environment: ['prod', 'staging']}}}
       />,
-      {context: routerContext, organization: {...organization, features: []}}
+      {router, organization: {...organization, features: []}}
     );
     await waitForElementToBeRemoved(() => screen.queryByTestId('loading-indicator'));
 
@@ -256,7 +256,7 @@ describe('groupEvents', () => {
         {...baseProps}
         location={{...location, query: {environment: ['prod', 'staging']}}}
       />,
-      {context: routerContext, organization}
+      {router, organization}
     );
     await waitForElementToBeRemoved(() => screen.queryByTestId('loading-indicator'));
 
@@ -271,7 +271,7 @@ describe('groupEvents', () => {
         {...baseProps}
         location={{...location, query: {environment: ['prod', 'staging']}}}
       />,
-      {context: routerContext, organization}
+      {router, organization}
     );
     await waitForElementToBeRemoved(() => screen.queryByTestId('loading-indicator'));
 
@@ -304,7 +304,7 @@ describe('groupEvents', () => {
         {...baseProps}
         location={{...location, query: {environment: ['prod', 'staging']}}}
       />,
-      {context: routerContext, organization}
+      {router, organization}
     );
     await waitForElementToBeRemoved(() => screen.queryByTestId('loading-indicator'));
     const minidumpColumn = screen.queryByText('minidump');
@@ -336,7 +336,7 @@ describe('groupEvents', () => {
         {...baseProps}
         location={{...location, query: {environment: ['prod', 'staging']}}}
       />,
-      {context: routerContext, organization}
+      {router, organization}
     );
     await waitForElementToBeRemoved(() => screen.queryByTestId('loading-indicator'));
     const attachmentsColumn = screen.queryByText('attachments');
@@ -352,7 +352,7 @@ describe('groupEvents', () => {
         {...baseProps}
         location={{...location, query: {environment: ['prod', 'staging']}}}
       />,
-      {context: routerContext, organization}
+      {router, organization}
     );
     expect(requests.discover).toHaveBeenCalledWith(
       '/organizations/org-slug/events/',
@@ -375,7 +375,7 @@ describe('groupEvents', () => {
         {...baseProps}
         location={{...location, query: {environment: ['prod', 'staging'], sort: 'user'}}}
       />,
-      {context: routerContext, organization}
+      {router, organization}
     );
     expect(requests.discover).toHaveBeenCalledWith(
       '/organizations/org-slug/events/',
@@ -402,7 +402,7 @@ describe('groupEvents', () => {
           },
         }}
       />,
-      {context: routerContext, organization}
+      {router, organization}
     );
     expect(requests.discover).toHaveBeenCalledWith(
       '/organizations/org-slug/events/',
@@ -430,7 +430,7 @@ describe('groupEvents', () => {
         {...baseProps}
         location={{...location, query: {environment: ['prod', 'staging']}}}
       />,
-      {context: routerContext, organization}
+      {router, organization}
     );
 
     await waitForElementToBeRemoved(() => screen.queryByTestId('loading-indicator'));
@@ -447,7 +447,7 @@ describe('groupEvents', () => {
         group={group}
         location={{...location, query: {environment: ['prod', 'staging']}}}
       />,
-      {context: routerContext, organization}
+      {router, organization}
     );
 
     await waitForElementToBeRemoved(() => screen.queryByTestId('loading-indicator'));

--- a/static/app/views/issueDetails/groupMerged/index.spec.tsx
+++ b/static/app/views/issueDetails/groupMerged/index.spec.tsx
@@ -40,7 +40,7 @@ describe('Issues -> Merged View', function () {
   });
 
   it('renders initially with loading component', async function () {
-    const {organization, project, router, routerContext} = initializeOrg({
+    const {organization, project, router} = initializeOrg({
       project: {
         slug: 'projectId',
       },
@@ -62,7 +62,7 @@ describe('Issues -> Merged View', function () {
         routes={router.routes}
         router={router}
       />,
-      {context: routerContext}
+      {router}
     );
 
     expect(screen.getByTestId('loading-indicator')).toBeInTheDocument();
@@ -70,7 +70,7 @@ describe('Issues -> Merged View', function () {
   });
 
   it('renders with mocked data', async function () {
-    const {organization, project, router, routerContext} = initializeOrg({
+    const {organization, project, router} = initializeOrg({
       project: {
         slug: 'projectId',
       },
@@ -92,7 +92,7 @@ describe('Issues -> Merged View', function () {
         routes={router.routes}
         router={router}
       />,
-      {context: routerContext}
+      {router}
     );
 
     await waitForElementToBeRemoved(() => screen.queryByTestId('loading-indicator'));

--- a/static/app/views/issueDetails/groupReplays/groupReplays.spec.tsx
+++ b/static/app/views/issueDetails/groupReplays/groupReplays.spec.tsx
@@ -34,7 +34,7 @@ import ReplayReader from 'sentry/utils/replays/replayReader';
 const REPLAY_ID_1 = '346789a703f6454384f1de473b8b9fcc';
 const REPLAY_ID_2 = 'b05dae9b6be54d21a4d5ad9f8f02b780';
 
-let router, organization, routerContext;
+let router, organization;
 
 jest.mock('sentry/utils/replays/hooks/useReplayReader');
 // Mock screenfull library
@@ -90,7 +90,7 @@ mockUseReplayReader.mockImplementation(() => {
 
 function init({organizationProps = {features: ['session-replay']}}: InitializeOrgProps) {
   const mockProject = ProjectFixture();
-  ({router, organization, routerContext} = initializeOrg({
+  ({router, organization} = initializeOrg({
     organization: {
       ...organizationProps,
     },
@@ -112,7 +112,7 @@ function init({organizationProps = {features: ['session-replay']}}: InitializeOr
   ProjectsStore.init();
   ProjectsStore.loadInitialData(organization.projects);
 
-  return {router, organization, routerContext};
+  return {router, organization};
 }
 
 describe('GroupReplays', () => {
@@ -132,13 +132,12 @@ describe('GroupReplays', () => {
     const mockGroup = GroupFixture();
 
     it("should show a message when the organization doesn't have access to the replay feature", () => {
-      ({router, organization, routerContext} = init({
+      ({router, organization} = init({
         organizationProps: {features: []},
       }));
       render(<GroupReplays group={mockGroup} />, {
-        context: routerContext,
-        organization,
         router,
+        organization,
       });
 
       expect(
@@ -149,7 +148,7 @@ describe('GroupReplays', () => {
 
   describe('Replay Feature Enabled', () => {
     beforeEach(() => {
-      ({router, organization, routerContext} = init({}));
+      ({router, organization} = init({}));
     });
 
     it('should query the replay-count endpoint with the fetched replayIds', async () => {
@@ -170,9 +169,8 @@ describe('GroupReplays', () => {
       });
 
       render(<GroupReplays group={mockGroup} />, {
-        context: routerContext,
-        organization,
         router,
+        organization,
       });
 
       await waitFor(() => {
@@ -240,9 +238,8 @@ describe('GroupReplays', () => {
       });
 
       render(<GroupReplays group={mockGroup} />, {
-        context: routerContext,
-        organization,
         router,
+        organization,
       });
 
       expect(
@@ -271,9 +268,8 @@ describe('GroupReplays', () => {
       });
 
       render(<GroupReplays group={mockGroup} />, {
-        context: routerContext,
-        organization,
         router,
+        organization,
       });
 
       expect(
@@ -303,9 +299,8 @@ describe('GroupReplays', () => {
       });
 
       render(<GroupReplays group={mockGroup} />, {
-        context: routerContext,
-        organization,
         router,
+        organization,
       });
 
       expect(
@@ -339,9 +334,8 @@ describe('GroupReplays', () => {
       });
 
       render(<GroupReplays group={mockGroup} />, {
-        context: routerContext,
-        organization,
         router,
+        organization,
       });
 
       expect(screen.getByTestId('loading-indicator')).toBeInTheDocument();
@@ -403,9 +397,8 @@ describe('GroupReplays', () => {
       setMockDate(new Date('Sep 28, 2022 11:29:13 PM UTC'));
 
       render(<GroupReplays group={mockGroup} />, {
-        context: routerContext,
-        organization,
         router,
+        organization,
       });
 
       await waitFor(() => {
@@ -455,7 +448,7 @@ describe('GroupReplays', () => {
     });
 
     it('Should render the replay player when replay-play-from-replay-tab is enabled', async () => {
-      ({router, organization, routerContext} = init({
+      ({router, organization} = init({
         organizationProps: {features: ['replay-play-from-replay-tab', 'session-replay']},
       }));
       const mockGroup = GroupFixture();
@@ -505,9 +498,8 @@ describe('GroupReplays', () => {
       });
 
       render(<GroupReplays group={mockGroup} />, {
-        context: routerContext,
-        organization,
         router,
+        organization,
       });
 
       expect(await screen.findByText('See Full Replay')).toBeInTheDocument();
@@ -526,7 +518,7 @@ describe('GroupReplays', () => {
     });
 
     it('Should switch replays when clicking and replay-play-from-replay-tab is enabled', async () => {
-      ({router, organization, routerContext} = init({
+      ({router, organization} = init({
         organizationProps: {features: ['session-replay']},
       }));
       const mockGroup = GroupFixture();
@@ -581,9 +573,8 @@ describe('GroupReplays', () => {
       });
 
       render(<GroupReplays group={mockGroup} />, {
-        context: routerContext,
-        organization,
         router,
+        organization,
       });
 
       await waitFor(() => {

--- a/static/app/views/issueDetails/groupSimilarIssues/index.spec.tsx
+++ b/static/app/views/issueDetails/groupSimilarIssues/index.spec.tsx
@@ -1,6 +1,5 @@
 import {GroupsFixture} from 'sentry-fixture/groups';
 import {ProjectFixture} from 'sentry-fixture/project';
-import {RouterContextFixture} from 'sentry-fixture/routerContextFixture';
 import {RouterFixture} from 'sentry-fixture/routerFixture';
 
 import {
@@ -27,14 +26,9 @@ describe('Issues Similar View', function () {
     features: ['similarity-view'],
   });
 
-  const routerContext = RouterContextFixture([
-    {
-      router: {
-        ...RouterFixture(),
-        params: {orgId: 'org-slug', projectId: 'project-slug', groupId: 'group-id'},
-      },
-    },
-  ]);
+  const router = RouterFixture({
+    params: {orgId: 'org-slug', projectId: 'project-slug', groupId: 'group-id'},
+  });
 
   const scores = [
     {'exception:stacktrace:pairs': 0.375},
@@ -46,8 +40,6 @@ describe('Issues Similar View', function () {
   const mockData = {
     similar: GroupsFixture().map((issue, i) => [issue, scores[i]]),
   };
-
-  const router = RouterFixture();
 
   beforeEach(function () {
     mock = MockApiClient.addMockResponse({
@@ -82,7 +74,7 @@ describe('Issues Similar View', function () {
         routes={router.routes}
         route={{}}
       />,
-      {context: routerContext}
+      {router}
     );
 
     expect(screen.getByTestId('loading-indicator')).toBeInTheDocument();
@@ -111,7 +103,7 @@ describe('Issues Similar View', function () {
         routes={router.routes}
         route={{}}
       />,
-      {context: routerContext}
+      {router}
     );
     renderGlobalModal();
 
@@ -144,7 +136,7 @@ describe('Issues Similar View', function () {
         routes={router.routes}
         route={{}}
       />,
-      {context: routerContext}
+      {router}
     );
     renderGlobalModal();
 
@@ -175,7 +167,7 @@ describe('Issues Similar View', function () {
         routes={router.routes}
         route={{}}
       />,
-      {context: routerContext}
+      {router}
     );
     renderGlobalModal();
 
@@ -201,14 +193,9 @@ describe('Issues Similar Embeddings View', function () {
     features: ['similarity-view', 'similarity-embeddings'],
   });
 
-  const routerContext = RouterContextFixture([
-    {
-      router: {
-        ...RouterFixture(),
-        params: {orgId: 'org-slug', projectId: 'project-slug', groupId: 'group-id'},
-      },
-    },
-  ]);
+  const router = RouterFixture({
+    params: {orgId: 'org-slug', projectId: 'project-slug', groupId: 'group-id'},
+  });
 
   const similarEmbeddingsScores = [
     {exception: 0.01, message: 0.3748, shouldBeGrouped: 'Yes'},
@@ -223,8 +210,6 @@ describe('Issues Similar Embeddings View', function () {
       similarEmbeddingsScores[i],
     ]),
   };
-
-  const router = RouterFixture();
 
   beforeEach(function () {
     mock = MockApiClient.addMockResponse({
@@ -259,7 +244,7 @@ describe('Issues Similar Embeddings View', function () {
         routes={router.routes}
         route={{}}
       />,
-      {context: routerContext}
+      {router}
     );
 
     expect(screen.getByTestId('loading-indicator')).toBeInTheDocument();
@@ -289,7 +274,7 @@ describe('Issues Similar Embeddings View', function () {
         routes={router.routes}
         route={{}}
       />,
-      {context: routerContext}
+      {router}
     );
     renderGlobalModal();
 
@@ -322,7 +307,7 @@ describe('Issues Similar Embeddings View', function () {
         routes={router.routes}
         route={{}}
       />,
-      {context: routerContext}
+      {router}
     );
     renderGlobalModal();
 
@@ -345,7 +330,7 @@ describe('Issues Similar Embeddings View', function () {
         routes={router.routes}
         route={{}}
       />,
-      {context: routerContext}
+      {router}
     );
     renderGlobalModal();
 
@@ -382,7 +367,7 @@ describe('Issues Similar Embeddings View', function () {
         routes={router.routes}
         route={{}}
       />,
-      {context: routerContext}
+      {router}
     );
     renderGlobalModal();
 

--- a/static/app/views/issueDetails/groupTagValues.spec.tsx
+++ b/static/app/views/issueDetails/groupTagValues.spec.tsx
@@ -43,7 +43,7 @@ describe('GroupTagValues', () => {
   });
 
   it('renders a list of tag values', async () => {
-    const {routerProps, routerContext, project} = init('user');
+    const {router, routerProps, project} = init('user');
 
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/issues/1/tags/user/values/',
@@ -57,7 +57,7 @@ describe('GroupTagValues', () => {
         baseUrl=""
         {...routerProps}
       />,
-      {context: routerContext}
+      {router}
     );
 
     await waitForElementToBeRemoved(() => screen.getByTestId('loading-indicator'));
@@ -74,7 +74,7 @@ describe('GroupTagValues', () => {
   });
 
   it('can page through tag values', async () => {
-    const {routerProps, routerContext, project} = init('user');
+    const {router, routerProps, project} = init('user');
 
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/issues/1/tags/user/values/',
@@ -93,7 +93,7 @@ describe('GroupTagValues', () => {
         baseUrl=""
         {...routerProps}
       />,
-      {context: routerContext}
+      {router}
     );
 
     await waitForElementToBeRemoved(() => screen.getByTestId('loading-indicator'));
@@ -111,7 +111,7 @@ describe('GroupTagValues', () => {
   });
 
   it('navigates to issue details events tab with correct query params', async () => {
-    const {routerProps, routerContext, router, project} = init('user');
+    const {routerProps, router, project} = init('user');
 
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/issues/1/tags/user/values/',
@@ -126,7 +126,7 @@ describe('GroupTagValues', () => {
         {...routerProps}
       />,
       {
-        context: routerContext,
+        router,
       }
     );
 
@@ -144,7 +144,7 @@ describe('GroupTagValues', () => {
   });
 
   it('renders an error message if tag values request fails', async () => {
-    const {routerProps, routerContext, project} = init('user');
+    const {router, routerProps, project} = init('user');
 
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/issues/1/tags/user/values/',
@@ -159,7 +159,7 @@ describe('GroupTagValues', () => {
         baseUrl=""
         {...routerProps}
       />,
-      {context: routerContext}
+      {router}
     );
 
     expect(
@@ -168,7 +168,7 @@ describe('GroupTagValues', () => {
   });
 
   it('renders an error message if no tag values are returned because of environment selection', async () => {
-    const {routerProps, routerContext, project} = init('user');
+    const {router, routerProps, project} = init('user');
 
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/issues/1/tags/user/values/',
@@ -183,7 +183,7 @@ describe('GroupTagValues', () => {
         baseUrl=""
         {...routerProps}
       />,
-      {context: routerContext}
+      {router}
     );
 
     expect(

--- a/static/app/views/issueDetails/groupTags.spec.tsx
+++ b/static/app/views/issueDetails/groupTags.spec.tsx
@@ -7,7 +7,7 @@ import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 import GroupTags from 'sentry/views/issueDetails/groupTags';
 
 describe('GroupTags', function () {
-  const {routerProps, routerContext, router, organization} = initializeOrg();
+  const {routerProps, router, organization} = initializeOrg();
   const group = GroupFixture();
   let tagsMock;
   beforeEach(function () {
@@ -25,7 +25,7 @@ describe('GroupTags', function () {
         environments={['dev']}
         baseUrl={`/organizations/${organization.slug}/issues/${group.id}/`}
       />,
-      {context: routerContext, organization}
+      {router, organization}
     );
 
     const headers = await screen.findAllByTestId('tag-title');
@@ -66,7 +66,7 @@ describe('GroupTags', function () {
         environments={['dev']}
         baseUrl={`/organizations/${organization.slug}/issues/${group.id}/`}
       />,
-      {context: routerContext, organization}
+      {router, organization}
     );
 
     expect(

--- a/static/app/views/issueList/overview.polling.spec.tsx
+++ b/static/app/views/issueList/overview.polling.spec.tsx
@@ -37,7 +37,7 @@ describe('IssueList -> Polling', function () {
     MockApiClient.clearMockResponses();
   });
 
-  const {organization, project, routerProps, routerContext} = initializeOrg({
+  const {organization, project, routerProps, router} = initializeOrg({
     organization: {
       access: ['project:releases'],
     },
@@ -63,7 +63,7 @@ describe('IssueList -> Polling', function () {
   /* helpers */
   const renderComponent = async () => {
     render(<IssueList {...routerProps} {...defaultProps} />, {
-      context: routerContext,
+      router,
     });
 
     await Promise.resolve();

--- a/static/app/views/issueList/overview.spec.tsx
+++ b/static/app/views/issueList/overview.spec.tsx
@@ -43,7 +43,7 @@ const project = ProjectFixture({
   firstEvent: new Date().toISOString(),
 });
 
-const {organization, router, routerContext} = initializeOrg({
+const {organization, router} = initializeOrg({
   organization: {
     id: '1337',
     slug: 'org-slug',
@@ -202,9 +202,7 @@ describe('IssueList', function () {
     });
 
     it('loads group rows with default query (no pinned queries, async and no query in URL)', async function () {
-      render(<IssueListWithStores {...routerProps} />, {
-        context: routerContext,
-      });
+      render(<IssueListWithStores {...routerProps} />, {router});
 
       // Loading saved searches
       await waitForElementToBeRemoved(() => screen.getByTestId('loading-indicator'));
@@ -248,7 +246,6 @@ describe('IssueList', function () {
       const location = LocationFixture({query: {query: 'level:foo'}});
 
       render(<IssueListWithStores {...merge({}, routerProps, {location})} />, {
-        context: routerContext,
         router: {location},
       });
 
@@ -284,9 +281,7 @@ describe('IssueList', function () {
         ],
       });
 
-      render(<IssueListWithStores {...routerProps} />, {
-        context: routerContext,
-      });
+      render(<IssueListWithStores {...routerProps} />, {router});
 
       await waitFor(() => {
         expect(issuesRequest).toHaveBeenCalledWith(
@@ -306,7 +301,7 @@ describe('IssueList', function () {
 
     it('shows archived tab', async function () {
       render(<IssueListWithStores {...routerProps} organization={{...organization}} />, {
-        context: routerContext,
+        router,
       });
 
       await waitFor(() => {
@@ -338,7 +333,6 @@ describe('IssueList', function () {
       const localRouter = {params: {searchId: '123'}};
 
       render(<IssueListWithStores {...merge({}, routerProps, localRouter)} />, {
-        context: routerContext,
         router: localRouter,
       });
 
@@ -378,7 +372,7 @@ describe('IssueList', function () {
       const localRouter = {location: {query: {query: 'level:error'}}};
 
       render(<IssueListWithStores {...merge({}, routerProps, localRouter)} />, {
-        context: routerContext,
+        router,
       });
 
       await waitFor(() => {
@@ -415,7 +409,7 @@ describe('IssueList', function () {
         <IssueListWithStores
           {...merge({}, routerProps, {location: {query: {query: undefined}}})}
         />,
-        {context: routerContext}
+        {router}
       );
 
       await waitFor(() => {
@@ -460,7 +454,7 @@ describe('IssueList', function () {
         }),
       };
       const {unmount} = render(<IssueListWithStores {...defaultProps} />, {
-        context: routerContext,
+        router,
         organization: defaultProps.organization,
       });
 
@@ -472,7 +466,7 @@ describe('IssueList', function () {
 
       // Mount component again, getting from cache
       render(<IssueListWithStores {...defaultProps} />, {
-        context: routerContext,
+        router,
         organization: defaultProps.organization,
       });
 
@@ -490,7 +484,7 @@ describe('IssueList', function () {
       });
 
       render(<IssueListWithStores {...routerProps} />, {
-        context: routerContext,
+        router,
       });
 
       await waitForElementToBeRemoved(() => screen.getByTestId('loading-indicator'));
@@ -521,7 +515,7 @@ describe('IssueList', function () {
       });
 
       render(<IssueListWithStores {...routerProps} />, {
-        context: routerContext,
+        router,
       });
 
       await waitForElementToBeRemoved(() => screen.getByTestId('loading-indicator'));
@@ -560,7 +554,7 @@ describe('IssueList', function () {
       });
 
       const {rerender} = render(<IssueListWithStores {...routerProps} />, {
-        context: routerContext,
+        router,
       });
 
       await waitForElementToBeRemoved(() => screen.getByTestId('loading-indicator'));
@@ -634,7 +628,6 @@ describe('IssueList', function () {
       };
 
       render(<IssueListWithStores {...merge({}, routerProps, routerWithSavedSearch)} />, {
-        context: routerContext,
         router: routerWithSavedSearch,
       });
 
@@ -684,7 +677,6 @@ describe('IssueList', function () {
       const routerWithSavedSearch = {params: {searchId: '789'}};
 
       render(<IssueListWithStores {...merge({}, routerProps, routerWithSavedSearch)} />, {
-        context: routerContext,
         router: routerWithSavedSearch,
       });
 
@@ -843,7 +835,7 @@ describe('IssueList', function () {
 
     it('does not allow pagination to "previous" while on first page and resets cursors when navigating back to initial page', async function () {
       const {rerender} = render(<IssueListWithStores {...routerProps} />, {
-        context: routerContext,
+        router,
       });
 
       await waitForElementToBeRemoved(() => screen.getByTestId('loading-indicator'));
@@ -957,7 +949,7 @@ describe('IssueList', function () {
       });
 
       render(<IssueListOverview {...props} />, {
-        context: routerContext,
+        router,
       });
 
       const queryInput = screen.getByDisplayValue('is:unresolved');
@@ -978,7 +970,7 @@ describe('IssueList', function () {
   });
 
   it('fetches tags and members', async function () {
-    render(<IssueListOverview {...routerProps} {...props} />, {context: routerContext});
+    render(<IssueListOverview {...routerProps} {...props} />, {router});
 
     await waitFor(() => {
       expect(fetchTagsRequest).toHaveBeenCalled();
@@ -1002,7 +994,7 @@ describe('IssueList', function () {
 
     it('fetches data on selection change', function () {
       const {rerender} = render(<IssueListOverview {...routerProps} {...props} />, {
-        context: routerContext,
+        router,
       });
 
       rerender(
@@ -1018,7 +1010,7 @@ describe('IssueList', function () {
 
     it('fetches data on savedSearch change', function () {
       const {rerender} = render(<IssueListOverview {...routerProps} {...props} />, {
-        context: routerContext,
+        router,
       });
 
       rerender(
@@ -1034,7 +1026,7 @@ describe('IssueList', function () {
 
     it('uses correct statsPeriod when fetching issues list and no datetime given', function () {
       const {rerender} = render(<IssueListOverview {...routerProps} {...props} />, {
-        context: routerContext,
+        router,
       });
       const selection = {projects: [99], environments: [], datetime: {}};
       rerender(<IssueListOverview {...routerProps} {...props} selection={selection} />);
@@ -1051,7 +1043,7 @@ describe('IssueList', function () {
   describe('componentDidUpdate fetching members', function () {
     it('fetches memberlist and tags list on project change', function () {
       const {rerender} = render(<IssueListOverview {...routerProps} {...props} />, {
-        context: routerContext,
+        router,
       });
       // Called during componentDidMount
       expect(fetchMembersRequest).toHaveBeenCalledTimes(1);
@@ -1071,7 +1063,7 @@ describe('IssueList', function () {
   describe('render states', function () {
     it('displays the loading icon when saved searches are loading', function () {
       render(<IssueListOverview {...routerProps} {...props} savedSearchLoading />, {
-        context: routerContext,
+        router,
       });
       expect(screen.getByTestId('loading-indicator')).toBeInTheDocument();
     });
@@ -1083,7 +1075,7 @@ describe('IssueList', function () {
         statusCode: 500,
       });
       render(<IssueListOverview {...routerProps} {...props} />, {
-        context: routerContext,
+        router,
       });
 
       expect(await screen.findByTestId('loading-error')).toBeInTheDocument();
@@ -1097,7 +1089,7 @@ describe('IssueList', function () {
           Link: DEFAULT_LINKS_HEADER,
         },
       });
-      render(<IssueListOverview {...routerProps} {...props} />, {context: routerContext});
+      render(<IssueListOverview {...routerProps} {...props} />, {router});
 
       expect(
         await screen.findByText(/We couldn't find any issues that matched your filters/i)
@@ -1113,7 +1105,7 @@ describe('IssueList', function () {
         },
       });
 
-      render(<IssueListOverview {...routerProps} {...props} />, {context: routerContext});
+      render(<IssueListOverview {...routerProps} {...props} />, {router});
 
       await userEvent.type(
         screen.getByDisplayValue('is:unresolved'),
@@ -1153,9 +1145,7 @@ describe('IssueList', function () {
         }),
         ...moreProps,
       };
-      render(<IssueListOverview {...defaultProps} />, {
-        context: routerContext,
-      });
+      render(<IssueListOverview {...defaultProps} />, {router});
 
       await waitForElementToBeRemoved(() => screen.getByTestId('loading-indicator'));
     };
@@ -1428,9 +1418,7 @@ describe('IssueList', function () {
           ])
         );
 
-        render(<IssueListOverview {...props} />, {
-          context: routerContext,
-        });
+        render(<IssueListOverview {...props} />, {router});
 
         expect(
           screen.getByText(/Event Processing for this project is currently degraded/i)

--- a/static/app/views/issueList/searchBar.spec.tsx
+++ b/static/app/views/issueList/searchBar.spec.tsx
@@ -10,7 +10,7 @@ describe('IssueListSearchBar', function () {
   let recentSearchMock;
   let defaultProps;
 
-  const {routerContext, organization} = initializeOrg();
+  const {router, organization} = initializeOrg();
 
   beforeEach(function () {
     TagStore.reset();
@@ -42,7 +42,7 @@ describe('IssueListSearchBar', function () {
       });
 
       render(<IssueListSearchBar {...defaultProps} />, {
-        context: routerContext,
+        router,
       });
 
       await userEvent.click(screen.getByRole('textbox'));
@@ -68,7 +68,7 @@ describe('IssueListSearchBar', function () {
       });
 
       render(<IssueListSearchBar {...defaultProps} />, {
-        context: routerContext,
+        router,
       });
 
       await userEvent.click(screen.getByRole('textbox'));
@@ -85,7 +85,7 @@ describe('IssueListSearchBar', function () {
       });
 
       render(<IssueListSearchBar {...defaultProps} />, {
-        context: routerContext,
+        router,
       });
 
       await userEvent.click(screen.getByRole('textbox'));
@@ -110,7 +110,7 @@ describe('IssueListSearchBar', function () {
       const onSearch = jest.fn();
 
       render(<IssueListSearchBar {...defaultProps} onSearch={onSearch} />, {
-        context: routerContext,
+        router,
       });
 
       await userEvent.click(screen.getByRole('textbox'));
@@ -148,7 +148,7 @@ describe('IssueListSearchBar', function () {
         body: [],
       });
 
-      render(<IssueListSearchBar {...defaultProps} />, {context: routerContext});
+      render(<IssueListSearchBar {...defaultProps} />, {router});
 
       await userEvent.click(screen.getByRole('textbox'));
       await userEvent.paste('is:', {delay: null});

--- a/static/app/views/monitors/components/monitorForm.spec.tsx
+++ b/static/app/views/monitors/components/monitorForm.spec.tsx
@@ -25,7 +25,7 @@ describe('MonitorForm', function () {
 
   const member = MemberFixture({user: UserFixture({name: 'John Smith'})});
   const team = TeamFixture({slug: 'test-team'});
-  const {project, routerContext} = initializeOrg({organization});
+  const {project, router} = initializeOrg({organization});
 
   beforeEach(() => {
     jest.mocked(useProjects).mockReturnValue({
@@ -66,7 +66,7 @@ describe('MonitorForm', function () {
         apiEndpoint={`/organizations/${organization.slug}/monitors/`}
         onSubmitSuccess={jest.fn()}
       />,
-      {context: routerContext, organization}
+      {router, organization}
     );
 
     const schedule = screen.getByRole('textbox', {name: 'Crontab Schedule'});
@@ -88,7 +88,7 @@ describe('MonitorForm', function () {
         onSubmitSuccess={mockHandleSubmitSuccess}
         submitLabel="Add Monitor"
       />,
-      {context: routerContext, organization}
+      {router, organization}
     );
 
     await userEvent.type(screen.getByRole('textbox', {name: 'Name'}), 'My Monitor');
@@ -190,7 +190,7 @@ describe('MonitorForm', function () {
         onSubmitSuccess={jest.fn()}
         submitLabel="Edit Monitor"
       />,
-      {context: routerContext, organization}
+      {router, organization}
     );
 
     // Name and slug

--- a/static/app/views/onboarding/onboarding.spec.tsx
+++ b/static/app/views/onboarding/onboarding.spec.tsx
@@ -25,7 +25,7 @@ describe('Onboarding', function () {
       step: 'welcome',
     };
 
-    const {routerProps, routerContext, organization} = initializeOrg({
+    const {routerProps, router, organization} = initializeOrg({
       router: {
         params: routeParams,
       },
@@ -36,7 +36,7 @@ describe('Onboarding', function () {
         <Onboarding {...routerProps} />
       </OnboardingContextProvider>,
       {
-        context: routerContext,
+        router,
         organization,
       }
     );
@@ -50,7 +50,7 @@ describe('Onboarding', function () {
       step: 'select-platform',
     };
 
-    const {routerProps, routerContext, organization} = initializeOrg({
+    const {routerProps, router, organization} = initializeOrg({
       router: {
         params: routeParams,
       },
@@ -61,7 +61,7 @@ describe('Onboarding', function () {
         <Onboarding {...routerProps} />
       </OnboardingContextProvider>,
       {
-        context: routerContext,
+        router,
         organization,
       }
     );
@@ -82,7 +82,7 @@ describe('Onboarding', function () {
       step: 'setup-docs',
     };
 
-    const {routerProps, routerContext, organization} = initializeOrg({
+    const {routerProps, router, organization} = initializeOrg({
       router: {
         params: routeParams,
       },
@@ -149,7 +149,7 @@ describe('Onboarding', function () {
         <Onboarding {...routerProps} />
       </OnboardingContextProvider>,
       {
-        context: routerContext,
+        router,
         organization,
       }
     );
@@ -172,7 +172,7 @@ describe('Onboarding', function () {
       step: 'setup-docs',
     };
 
-    const {routerProps, routerContext, organization} = initializeOrg({
+    const {routerProps, router, organization} = initializeOrg({
       router: {
         params: routeParams,
       },
@@ -234,7 +234,7 @@ describe('Onboarding', function () {
         <Onboarding {...routerProps} />
       </OnboardingContextProvider>,
       {
-        context: routerContext,
+        router,
         organization,
       }
     );
@@ -267,7 +267,7 @@ describe('Onboarding', function () {
       step: 'setup-docs',
     };
 
-    const {routerProps, routerContext, organization} = initializeOrg({
+    const {routerProps, router, organization} = initializeOrg({
       router: {
         params: routeParams,
       },
@@ -329,7 +329,7 @@ describe('Onboarding', function () {
         <Onboarding {...routerProps} />
       </OnboardingContextProvider>,
       {
-        context: routerContext,
+        router,
         organization,
       }
     );
@@ -353,7 +353,7 @@ describe('Onboarding', function () {
       step: 'select-platform',
     };
 
-    const {routerProps, routerContext, organization} = initializeOrg({
+    const {routerProps, router, organization} = initializeOrg({
       organization: {
         features: ['onboarding-sdk-selection'],
       },
@@ -367,7 +367,7 @@ describe('Onboarding', function () {
         <Onboarding {...routerProps} />
       </OnboardingContextProvider>,
       {
-        context: routerContext,
+        router,
         organization,
       }
     );
@@ -392,7 +392,7 @@ describe('Onboarding', function () {
       step: 'select-platform',
     };
 
-    const {routerProps, routerContext, organization} = initializeOrg({
+    const {routerProps, router, organization} = initializeOrg({
       organization: {
         features: ['onboarding-sdk-selection'],
       },
@@ -406,7 +406,7 @@ describe('Onboarding', function () {
         <Onboarding {...routerProps} />
       </OnboardingContextProvider>,
       {
-        context: routerContext,
+        router,
         organization,
       }
     );

--- a/static/app/views/onboarding/setupDocs.spec.tsx
+++ b/static/app/views/onboarding/setupDocs.spec.tsx
@@ -57,7 +57,7 @@ function renderMockRequests({
 
 describe('Onboarding Setup Docs', function () {
   it('does not render Product Selection', async function () {
-    const {router, route, routerContext, organization, project} = initializeOrg({
+    const {router, route, organization, project} = initializeOrg({
       projects: [
         {
           ...initializeOrg().project,
@@ -88,7 +88,7 @@ describe('Onboarding Setup Docs', function () {
         />
       </OnboardingContextProvider>,
       {
-        context: routerContext,
+        router,
         organization,
       }
     );
@@ -105,7 +105,7 @@ describe('Onboarding Setup Docs', function () {
   });
 
   it('renders SDK version from the sentry release registry', async function () {
-    const {router, route, routerContext, organization, project} = initializeOrg({
+    const {router, route, organization, project} = initializeOrg({
       projects: [
         {
           ...initializeOrg().project,
@@ -136,7 +136,7 @@ describe('Onboarding Setup Docs', function () {
         />
       </OnboardingContextProvider>,
       {
-        context: routerContext,
+        router,
         organization,
       }
     );
@@ -148,7 +148,7 @@ describe('Onboarding Setup Docs', function () {
 
   describe('renders Product Selection', function () {
     it('all products checked', async function () {
-      const {router, route, routerContext, organization, project} = initializeOrg({
+      const {router, route, organization, project} = initializeOrg({
         router: {
           location: {
             query: {
@@ -192,7 +192,7 @@ describe('Onboarding Setup Docs', function () {
           />
         </OnboardingContextProvider>,
         {
-          context: routerContext,
+          router,
           organization,
         }
       );
@@ -207,7 +207,7 @@ describe('Onboarding Setup Docs', function () {
     });
 
     it('only performance checked', async function () {
-      const {router, route, routerContext, organization, project} = initializeOrg({
+      const {router, route, organization, project} = initializeOrg({
         router: {
           location: {
             query: {product: [ProductSolution.PERFORMANCE_MONITORING]},
@@ -246,7 +246,7 @@ describe('Onboarding Setup Docs', function () {
           />
         </OnboardingContextProvider>,
         {
-          context: routerContext,
+          router,
           organization,
         }
       );
@@ -257,7 +257,7 @@ describe('Onboarding Setup Docs', function () {
     });
 
     it('only session replay checked', async function () {
-      const {router, route, routerContext, organization, project} = initializeOrg({
+      const {router, route, organization, project} = initializeOrg({
         router: {
           location: {
             query: {product: [ProductSolution.SESSION_REPLAY]},
@@ -296,7 +296,7 @@ describe('Onboarding Setup Docs', function () {
           />
         </OnboardingContextProvider>,
         {
-          context: routerContext,
+          router,
           organization,
         }
       );
@@ -307,7 +307,7 @@ describe('Onboarding Setup Docs', function () {
     });
 
     it('only error monitoring checked', async function () {
-      const {router, route, routerContext, organization, project} = initializeOrg({
+      const {router, route, organization, project} = initializeOrg({
         router: {
           location: {
             query: {product: []},
@@ -346,7 +346,7 @@ describe('Onboarding Setup Docs', function () {
           />
         </OnboardingContextProvider>,
         {
-          context: routerContext,
+          router,
           organization,
         }
       );
@@ -361,7 +361,7 @@ describe('Onboarding Setup Docs', function () {
 
   describe('JS Loader Script', function () {
     it('renders Loader Script setup', async function () {
-      const {router, route, routerContext, organization, project} = initializeOrg({
+      const {router, route, organization, project} = initializeOrg({
         router: {
           location: {
             query: {
@@ -411,7 +411,7 @@ describe('Onboarding Setup Docs', function () {
           />
         </OnboardingContextProvider>,
         {
-          context: routerContext,
+          router,
           organization,
         }
       );
@@ -479,7 +479,7 @@ describe('Onboarding Setup Docs', function () {
 
   describe('special platforms', () => {
     it('renders platform other', async function () {
-      const {router, route, routerContext, organization, project} = initializeOrg({
+      const {router, route, organization, project} = initializeOrg({
         projects: [
           {
             ...initializeOrg().project,
@@ -510,7 +510,7 @@ describe('Onboarding Setup Docs', function () {
           />
         </OnboardingContextProvider>,
         {
-          context: routerContext,
+          router,
           organization,
         }
       );

--- a/static/app/views/organizationActivity/index.spec.tsx
+++ b/static/app/views/organizationActivity/index.spec.tsx
@@ -7,7 +7,7 @@ import {GroupActivityType} from 'sentry/types/group';
 import OrganizationActivity from 'sentry/views/organizationActivity';
 
 describe('OrganizationActivity', function () {
-  const {router, organization, routerContext} = initializeOrg();
+  const {router, organization} = initializeOrg();
   let params = {};
 
   beforeEach(function () {
@@ -31,7 +31,7 @@ describe('OrganizationActivity', function () {
   });
 
   it('renders', async function () {
-    render(<OrganizationActivity {...params} />, {context: routerContext});
+    render(<OrganizationActivity {...params} />, {router});
 
     expect(await screen.findAllByTestId('activity-feed-item')).toHaveLength(2);
   });
@@ -41,7 +41,7 @@ describe('OrganizationActivity', function () {
       url: '/organizations/org-slug/activity/',
       body: [],
     });
-    render(<OrganizationActivity {...params} />, {context: routerContext});
+    render(<OrganizationActivity {...params} />, {router});
 
     expect(screen.queryByTestId('activity-feed-item')).not.toBeInTheDocument();
     expect(await screen.findByTestId('empty-state')).toBeInTheDocument();
@@ -53,7 +53,7 @@ describe('OrganizationActivity', function () {
       body: [],
       statusCode: 404,
     });
-    render(<OrganizationActivity {...params} />, {context: routerContext});
+    render(<OrganizationActivity {...params} />, {router});
 
     expect(screen.queryByTestId('activity-feed-item')).not.toBeInTheDocument();
     expect(await screen.findByTestId('empty-state')).toBeInTheDocument();

--- a/static/app/views/organizationLayout/index.spec.tsx
+++ b/static/app/views/organizationLayout/index.spec.tsx
@@ -17,7 +17,7 @@ jest.mock(
 );
 
 describe('OrganizationLayout', function () {
-  const {routerContext} = initializeOrg();
+  const {router} = initializeOrg();
 
   beforeEach(function () {
     OrganizationStore.reset();
@@ -49,7 +49,7 @@ describe('OrganizationLayout', function () {
         <OrganizationLayout>
           <div />
         </OrganizationLayout>,
-        {context: routerContext, organization}
+        {router, organization}
       );
 
       expect(await screen.findByText('Deletion Scheduled')).toBeInTheDocument();
@@ -75,7 +75,7 @@ describe('OrganizationLayout', function () {
         <OrganizationLayout>
           <div />
         </OrganizationLayout>,
-        {context: routerContext, organization}
+        {router, organization}
       );
 
       expect(await screen.findByText('Deletion Scheduled')).toBeInTheDocument();
@@ -102,7 +102,7 @@ describe('OrganizationLayout', function () {
       <OrganizationLayout>
         <div />
       </OrganizationLayout>,
-      {context: routerContext, organization}
+      {router, organization}
     );
 
     const inProgress = await screen.findByText(

--- a/static/app/views/organizationRestore/index.spec.tsx
+++ b/static/app/views/organizationRestore/index.spec.tsx
@@ -30,10 +30,10 @@ describe('OrganizationRestore', function () {
       status: 200,
       body: pendingDeleteOrg,
     });
-    const {routerProps, routerContext} = initializeOrg<{orgId: string}>({
+    const {routerProps, router} = initializeOrg<{orgId: string}>({
       organization: pendingDeleteOrg,
     });
-    render(<OrganizationRestore {...routerProps} />, {context: routerContext});
+    render(<OrganizationRestore {...routerProps} />, {router});
 
     const text = await screen.findByText(/currently scheduled for deletion/);
     expect(mockGet).toHaveBeenCalled();
@@ -49,10 +49,10 @@ describe('OrganizationRestore', function () {
       body: pendingDeleteOrg,
     });
 
-    const {routerProps, routerContext} = initializeOrg<{orgId: string}>({
+    const {routerProps, router} = initializeOrg<{orgId: string}>({
       organization: pendingDeleteOrg,
     });
-    render(<OrganizationRestore {...routerProps} />, {context: routerContext});
+    render(<OrganizationRestore {...routerProps} />, {router});
 
     const button = await screen.findByTestId('form-submit');
     await userEvent.click(button);
@@ -71,10 +71,10 @@ describe('OrganizationRestore', function () {
       body: deleteInProgressOrg,
     });
 
-    const {routerProps, routerContext} = initializeOrg<{orgId: string}>({
+    const {routerProps, router} = initializeOrg<{orgId: string}>({
       organization: deleteInProgressOrg,
     });
-    render(<OrganizationRestore {...routerProps} />, {context: routerContext});
+    render(<OrganizationRestore {...routerProps} />, {router});
 
     const text = await screen.findByText(
       /organization is currently in progress of being deleted/

--- a/static/app/views/organizationStats/index.spec.tsx
+++ b/static/app/views/organizationStats/index.spec.tsx
@@ -25,7 +25,7 @@ describe('OrganizationStats', function () {
     },
   };
   const projects = ['1', '2', '3'].map(id => ProjectFixture({id, slug: `proj-${id}`}));
-  const {organization, router, routerContext} = initializeOrg({
+  const {organization, router} = initializeOrg({
     organization: {features: ['global-views', 'team-insights']},
     projects,
     project: undefined,
@@ -67,13 +67,13 @@ describe('OrganizationStats', function () {
   it('renders header state without tabs', async () => {
     const newOrg = initializeOrg();
     render(<OrganizationStats {...defaultProps} organization={newOrg.organization} />, {
-      context: newOrg.routerContext,
+      router: newOrg.router,
     });
     expect(await screen.findByText('Organization Usage Stats')).toBeInTheDocument();
   });
 
   it('renders header state with tabs', async () => {
-    render(<OrganizationStats {...defaultProps} />, {context: routerContext});
+    render(<OrganizationStats {...defaultProps} />, {router});
     expect(await screen.findByText('Stats')).toBeInTheDocument();
     expect(screen.getByText('Usage')).toBeInTheDocument();
     expect(screen.getByText('Issues')).toBeInTheDocument();
@@ -84,7 +84,7 @@ describe('OrganizationStats', function () {
    * Base + Error Handling
    */
   it('renders the base view', async () => {
-    render(<OrganizationStats {...defaultProps} />, {context: routerContext});
+    render(<OrganizationStats {...defaultProps} />, {router});
 
     // Default to Errors category
     expect(screen.getAllByText('Errors')[0]).toBeInTheDocument();
@@ -146,7 +146,7 @@ describe('OrganizationStats', function () {
       url: endpoint,
       statusCode: 500,
     });
-    render(<OrganizationStats {...defaultProps} />, {context: routerContext});
+    render(<OrganizationStats {...defaultProps} />, {router});
 
     expect(await screen.findByTestId('usage-stats-chart')).toBeInTheDocument();
     expect(screen.getByTestId('usage-stats-table')).toBeInTheDocument();
@@ -160,7 +160,7 @@ describe('OrganizationStats', function () {
       statusCode: 400,
       body: {detail: 'No projects available'},
     });
-    render(<OrganizationStats {...defaultProps} />, {context: routerContext});
+    render(<OrganizationStats {...defaultProps} />, {router});
 
     expect(await screen.findByTestId('usage-stats-chart')).toBeInTheDocument();
     expect(screen.getByTestId('usage-stats-table')).toBeInTheDocument();
@@ -171,7 +171,7 @@ describe('OrganizationStats', function () {
    * Router Handling
    */
   it('pushes state changes to the route', async () => {
-    render(<OrganizationStats {...defaultProps} />, {context: routerContext});
+    render(<OrganizationStats {...defaultProps} />, {router});
 
     await userEvent.click(await screen.findByText('Category'));
     await userEvent.click(screen.getByText('Attachments'));
@@ -215,7 +215,7 @@ describe('OrganizationStats', function () {
       {query: {}}
     );
     render(<OrganizationStats {...defaultProps} location={dummyLocation as any} />, {
-      context: routerContext,
+      router,
     });
 
     const projectLinks = await screen.findAllByTestId('badge-display-name');
@@ -237,7 +237,7 @@ describe('OrganizationStats', function () {
     newOrg.organization.features = ['team-insights'];
 
     render(<OrganizationStats {...defaultProps} organization={newOrg.organization} />, {
-      context: newOrg.routerContext,
+      router: newOrg.router,
       organization: newOrg.organization,
     });
 
@@ -251,7 +251,7 @@ describe('OrganizationStats', function () {
     newOrg.organization.features = ['global-views', 'team-insights'];
     OrganizationStore.onUpdate(newOrg.organization, {replace: true});
     render(<OrganizationStats {...defaultProps} organization={newOrg.organization} />, {
-      context: newOrg.routerContext,
+      router: newOrg.router,
       organization: newOrg.organization,
     });
 
@@ -286,7 +286,7 @@ describe('OrganizationStats', function () {
         selection={newSelection}
       />,
       {
-        context: newOrg.routerContext,
+        router: newOrg.router,
         organization: newOrg.organization,
       }
     );
@@ -326,7 +326,7 @@ describe('OrganizationStats', function () {
         selection={newSelection}
       />,
       {
-        context: newOrg.routerContext,
+        router: newOrg.router,
         organization: newOrg.organization,
       }
     );
@@ -355,7 +355,7 @@ describe('OrganizationStats', function () {
     const newOrg = initializeOrg();
     newOrg.organization.features = ['global-views', 'team-insights'];
     render(<OrganizationStats {...defaultProps} organization={newOrg.organization} />, {
-      context: newOrg.routerContext,
+      router: newOrg.router,
       organization: newOrg.organization,
     });
     await userEvent.click(screen.getByTestId('proj-1'));
@@ -382,7 +382,7 @@ describe('OrganizationStats', function () {
           selection={newSelection}
         />,
         {
-          context: newOrg.routerContext,
+          router: newOrg.router,
           organization: newOrg.organization,
         }
       );

--- a/static/app/views/performance/content.spec.tsx
+++ b/static/app/views/performance/content.spec.tsx
@@ -274,10 +274,10 @@ describe('Performance > Content', function () {
 
   it('renders basic UI elements', async function () {
     const projects = [ProjectFixture({firstTransactionEvent: true})];
-    const data = initializeData(projects, {});
+    const {router} = initializeData(projects, {});
 
-    render(<WrappedComponent router={data.router} />, {
-      context: data.routerContext,
+    render(<WrappedComponent router={router} />, {
+      router: router,
     });
 
     expect(await screen.findByTestId('performance-landing-v3')).toBeInTheDocument();
@@ -290,10 +290,10 @@ describe('Performance > Content', function () {
       ProjectFixture({id: '1', firstTransactionEvent: false}),
       ProjectFixture({id: '2', firstTransactionEvent: true}),
     ];
-    const data = initializeData(projects, {project: [1]});
+    const {router} = initializeData(projects, {project: [1]});
 
-    render(<WrappedComponent router={data.router} />, {
-      context: data.routerContext,
+    render(<WrappedComponent router={router} />, {
+      router: router,
     });
 
     expect(await screen.findByTestId('performance-landing-v3')).toBeInTheDocument();
@@ -306,10 +306,10 @@ describe('Performance > Content', function () {
       ProjectFixture({id: '1', firstTransactionEvent: false}),
       ProjectFixture({id: '2', firstTransactionEvent: true}),
     ];
-    const data = initializeData(projects, {project: ['-1']});
+    const {router} = initializeData(projects, {project: ['-1']});
 
-    render(<WrappedComponent router={data.router} />, {
-      context: data.routerContext,
+    render(<WrappedComponent router={router} />, {
+      router: router,
     });
     expect(await screen.findByTestId('performance-landing-v3')).toBeInTheDocument();
     expect(screen.queryByText('Pinpoint problems')).not.toBeInTheDocument();
@@ -317,10 +317,10 @@ describe('Performance > Content', function () {
 
   it('forwards conditions to transaction summary', async function () {
     const projects = [ProjectFixture({id: '1', firstTransactionEvent: true})];
-    const data = initializeData(projects, {project: ['1'], query: 'sentry:yes'});
+    const {router} = initializeData(projects, {project: ['1'], query: 'sentry:yes'});
 
-    render(<WrappedComponent router={data.router} />, {
-      context: data.routerContext,
+    render(<WrappedComponent router={router} />, {
+      router: router,
     });
 
     expect(await screen.findByTestId('performance-landing-v3')).toBeInTheDocument();
@@ -328,7 +328,7 @@ describe('Performance > Content', function () {
 
     await userEvent.click(link);
 
-    expect(data.router.push).toHaveBeenCalledWith(
+    expect(router.push).toHaveBeenCalledWith(
       expect.objectContaining({
         query: expect.objectContaining({
           transaction: '/apple/cart',
@@ -339,9 +339,9 @@ describe('Performance > Content', function () {
   });
 
   it('Default period for trends does not call updateDateTime', async function () {
-    const data = initializeTrendsData({query: 'tag:value'}, false);
-    render(<WrappedComponent router={data.router} />, {
-      context: data.routerContext,
+    const {router} = initializeTrendsData({query: 'tag:value'}, false);
+    render(<WrappedComponent router={router} />, {
+      router: router,
     });
 
     expect(await screen.findByTestId('performance-landing-v3')).toBeInTheDocument();
@@ -350,13 +350,13 @@ describe('Performance > Content', function () {
   });
 
   it('Navigating to trends does not modify statsPeriod when already set', async function () {
-    const data = initializeTrendsData({
+    const {router} = initializeTrendsData({
       query: `tpm():>0.005 transaction.duration:>10 transaction.duration:<${DEFAULT_MAX_DURATION} api`,
       statsPeriod: '24h',
     });
 
-    render(<WrappedComponent router={data.router} />, {
-      context: data.routerContext,
+    render(<WrappedComponent router={router} />, {
+      router: router,
     });
 
     expect(await screen.findByTestId('performance-landing-v3')).toBeInTheDocument();
@@ -382,10 +382,10 @@ describe('Performance > Content', function () {
       ProjectFixture({id: '1', firstTransactionEvent: false}),
       ProjectFixture({id: '2', firstTransactionEvent: true}),
     ];
-    const data = initializeData(projects, {view: undefined});
+    const {router} = initializeData(projects, {view: undefined});
 
-    render(<WrappedComponent router={data.router} />, {
-      context: data.routerContext,
+    render(<WrappedComponent router={router} />, {
+      router: router,
     });
     expect(await screen.findByTestId('performance-landing-v3')).toBeInTheDocument();
 
@@ -393,20 +393,20 @@ describe('Performance > Content', function () {
   });
 
   it('Default page (transactions) with trends feature will not update filters if none are set', async function () {
-    const data = initializeTrendsData({view: undefined}, false);
+    const {router} = initializeTrendsData({view: undefined}, false);
 
-    render(<WrappedComponent router={data.router} />, {
-      context: data.routerContext,
+    render(<WrappedComponent router={router} />, {
+      router: router,
     });
     expect(await screen.findByTestId('performance-landing-v3')).toBeInTheDocument();
     expect(browserHistory.push).toHaveBeenCalledTimes(0);
   });
 
   it('Tags are replaced with trends default query if navigating to trends', async function () {
-    const data = initializeTrendsData({query: 'device.family:Mac'}, false);
+    const {router} = initializeTrendsData({query: 'device.family:Mac'}, false);
 
-    render(<WrappedComponent router={data.router} />, {
-      context: data.routerContext,
+    render(<WrappedComponent router={router} />, {
+      router: router,
     });
 
     const trendsLinks = await screen.findAllByTestId('landing-header-trends');
@@ -428,10 +428,10 @@ describe('Performance > Content', function () {
       ProjectFixture({id: '1', firstTransactionEvent: false}),
       ProjectFixture({id: '2', firstTransactionEvent: false}),
     ];
-    const data = initializeData(projects, {view: undefined});
+    const {router} = initializeData(projects, {view: undefined});
 
-    render(<WrappedComponent router={data.router} />, {
-      context: data.routerContext,
+    render(<WrappedComponent router={router} />, {
+      router: router,
     });
 
     expect(await screen.findByTestId('performance-landing-v3')).toBeInTheDocument();

--- a/static/app/views/performance/landing/index.spec.tsx
+++ b/static/app/views/performance/landing/index.spec.tsx
@@ -150,7 +150,7 @@ describe('Performance > Landing > Index', function () {
   it('renders basic UI elements', function () {
     const data = initializeData();
 
-    wrapper = render(<WrappedComponent data={data} />, data.routerContext);
+    wrapper = render(<WrappedComponent data={data} />);
 
     expect(screen.getByTestId('performance-landing-v3')).toBeInTheDocument();
   });
@@ -160,7 +160,7 @@ describe('Performance > Landing > Index', function () {
       query: {landingDisplay: LandingDisplayField.FRONTEND_OTHER},
     });
 
-    wrapper = render(<WrappedComponent data={data} />, data.routerContext);
+    wrapper = render(<WrappedComponent data={data} />);
     expect(screen.getByTestId('performance-table')).toBeInTheDocument();
   });
 
@@ -169,7 +169,7 @@ describe('Performance > Landing > Index', function () {
       query: {landingDisplay: LandingDisplayField.BACKEND},
     });
 
-    wrapper = render(<WrappedComponent data={data} />, data.routerContext);
+    wrapper = render(<WrappedComponent data={data} />);
     expect(screen.getByTestId('performance-table')).toBeInTheDocument();
   });
 
@@ -178,7 +178,7 @@ describe('Performance > Landing > Index', function () {
       query: {landingDisplay: LandingDisplayField.MOBILE},
     });
 
-    wrapper = render(<WrappedComponent data={data} />, data.routerContext);
+    wrapper = render(<WrappedComponent data={data} />);
     expect(screen.getByTestId('performance-table')).toBeInTheDocument();
   });
 
@@ -191,7 +191,7 @@ describe('Performance > Landing > Index', function () {
       projects,
     });
 
-    wrapper = render(<WrappedComponent data={data} />, data.routerContext);
+    wrapper = render(<WrappedComponent data={data} />);
 
     expect(await screen.findByTestId('performance-table')).toBeInTheDocument();
     expect(screen.getByTestId('grid-editable')).toBeInTheDocument();
@@ -208,7 +208,7 @@ describe('Performance > Landing > Index', function () {
       query: {landingDisplay: LandingDisplayField.ALL},
     });
 
-    wrapper = render(<WrappedComponent data={data} />, data.routerContext);
+    wrapper = render(<WrappedComponent data={data} />);
 
     expect(await screen.findByTestId('performance-table')).toBeInTheDocument();
 
@@ -248,7 +248,7 @@ describe('Performance > Landing > Index', function () {
       query: {landingDisplay: LandingDisplayField.FRONTEND_OTHER, abc: '123'},
     });
 
-    wrapper = render(<WrappedComponent data={data} />, data.routerContext);
+    wrapper = render(<WrappedComponent data={data} />);
     expect(screen.getByTestId('frontend-other-view')).toBeInTheDocument();
     await userEvent.click(screen.getByRole('tab', {name: 'All Transactions'}));
 
@@ -266,7 +266,7 @@ describe('Performance > Landing > Index', function () {
       query: {landingDisplay: LandingDisplayField.FRONTEND_OTHER},
     });
 
-    wrapper = render(<WrappedComponent data={data} />, data.routerContext);
+    wrapper = render(<WrappedComponent data={data} />);
 
     expect(screen.getByTestId('frontend-other-view')).toBeInTheDocument();
 
@@ -275,7 +275,7 @@ describe('Performance > Landing > Index', function () {
       selectedProject: 123,
     });
 
-    wrapper.rerender(<WrappedComponent data={updatedData} />, data.routerContext);
+    wrapper.rerender(<WrappedComponent data={updatedData} />);
 
     expect(screen.getByTestId('all-transactions-view')).toBeInTheDocument();
   });
@@ -286,7 +286,7 @@ describe('Performance > Landing > Index', function () {
       selectedProject: 99,
     });
 
-    wrapper = render(<WrappedComponent data={data} />, data.routerContext);
+    wrapper = render(<WrappedComponent data={data} />);
     expect(screen.getByTestId('frontend-other-view')).toBeInTheDocument();
   });
 
@@ -294,7 +294,7 @@ describe('Performance > Landing > Index', function () {
     it('does not search for empty string transaction', async function () {
       const data = initializeData();
 
-      render(<WrappedComponent data={data} withStaticFilters />, data.routerContext);
+      render(<WrappedComponent data={data} withStaticFilters />);
 
       await waitForElementToBeRemoved(() => screen.getAllByTestId('loading-indicator'));
       await userEvent.type(screen.getByPlaceholderText('Search Transactions'), '{enter}');
@@ -310,10 +310,7 @@ describe('Performance > Landing > Index', function () {
         },
       });
 
-      wrapper = render(
-        <WrappedComponent data={data} withStaticFilters />,
-        data.routerContext
-      );
+      wrapper = render(<WrappedComponent data={data} withStaticFilters />);
 
       expect(await screen.findByTestId('transaction-search-bar')).toBeInTheDocument();
     });
@@ -321,7 +318,7 @@ describe('Performance > Landing > Index', function () {
     it('extracts free text from the query', async function () {
       const data = initializeData();
 
-      wrapper = render(<WrappedComponent data={data} />, data.routerContext);
+      wrapper = render(<WrappedComponent data={data} />);
 
       await waitForElementToBeRemoved(() => screen.getAllByTestId('loading-indicator'));
 
@@ -340,7 +337,7 @@ describe('Performance > Landing > Index', function () {
         ],
       });
 
-      wrapper = render(<WrappedComponent data={data} />, data.routerContext);
+      wrapper = render(<WrappedComponent data={data} />);
       const titles = await screen.findAllByTestId('performance-widget-title');
       expect(titles.at(0)).toHaveTextContent('Most Regressed');
     });

--- a/static/app/views/performance/landing/metricsDataSwitcher.spec.tsx
+++ b/static/app/views/performance/landing/metricsDataSwitcher.spec.tsx
@@ -133,7 +133,7 @@ describe('Performance > Landing > MetricsDataSwitcher', function () {
       features,
     });
 
-    wrapper = render(<WrappedComponent data={data} />, data.routerContext);
+    wrapper = render(<WrappedComponent data={data} />);
     expect(screen.getByTestId('performance-landing-v3')).toBeInTheDocument();
   });
 
@@ -146,7 +146,7 @@ describe('Performance > Landing > MetricsDataSwitcher', function () {
       features,
     });
 
-    wrapper = render(<WrappedComponent data={data} />, data.routerContext);
+    wrapper = render(<WrappedComponent data={data} />);
 
     expect(await screen.findByTestId('transaction-search-bar')).toBeInTheDocument();
   });
@@ -164,7 +164,7 @@ describe('Performance > Landing > MetricsDataSwitcher', function () {
       features,
     });
 
-    wrapper = render(<WrappedComponent data={data} />, data.routerContext);
+    wrapper = render(<WrappedComponent data={data} />);
 
     expect(await screen.findByTestId('transaction-search-bar')).toBeInTheDocument();
   });
@@ -182,7 +182,7 @@ describe('Performance > Landing > MetricsDataSwitcher', function () {
       features,
     });
 
-    wrapper = render(<WrappedComponent data={data} />, data.routerContext);
+    wrapper = render(<WrappedComponent data={data} />);
     expect(await screen.findByTestId('transaction-search-bar')).toBeInTheDocument();
     expect(
       await screen.findByTestId('landing-mep-alert-single-project-incompatible')
@@ -204,7 +204,7 @@ describe('Performance > Landing > MetricsDataSwitcher', function () {
       features,
     });
 
-    wrapper = render(<WrappedComponent data={data} />, data.routerContext);
+    wrapper = render(<WrappedComponent data={data} />);
     expect(await screen.findByTestId('transaction-search-bar')).toBeInTheDocument();
     expect(
       await screen.findByTestId('landing-mep-alert-multi-project-incompatible')
@@ -226,7 +226,7 @@ describe('Performance > Landing > MetricsDataSwitcher', function () {
       features,
     });
 
-    wrapper = render(<WrappedComponent data={data} />, data.routerContext);
+    wrapper = render(<WrappedComponent data={data} />);
     expect(await screen.findByTestId('transaction-search-bar')).toBeInTheDocument();
     expect(
       await screen.findByTestId('landing-mep-alert-multi-project-all-incompatible')
@@ -246,7 +246,7 @@ describe('Performance > Landing > MetricsDataSwitcher', function () {
       features,
     });
 
-    wrapper = render(<WrappedComponent data={data} />, data.routerContext);
+    wrapper = render(<WrappedComponent data={data} />);
     expect(await screen.findByTestId('transaction-search-bar')).toBeInTheDocument();
     expect(
       await screen.findByTestId('landing-mep-alert-unnamed-discover')
@@ -266,7 +266,7 @@ describe('Performance > Landing > MetricsDataSwitcher', function () {
       features,
     });
 
-    wrapper = render(<WrappedComponent data={data} />, data.routerContext);
+    wrapper = render(<WrappedComponent data={data} />);
     expect(await screen.findByTestId('transaction-search-bar')).toBeInTheDocument();
     expect(
       await screen.findByTestId('landing-mep-alert-unnamed-discover-or-set')
@@ -286,7 +286,7 @@ describe('Performance > Landing > MetricsDataSwitcher', function () {
       features,
     });
 
-    wrapper = render(<WrappedComponent data={data} />, data.routerContext);
+    wrapper = render(<WrappedComponent data={data} />);
     expect(await screen.findByTestId('transaction-search-bar')).toBeInTheDocument();
     expect(
       await screen.findByTestId('landing-mep-alert-unnamed-discover')

--- a/static/app/views/performance/newTraceDetails/trace.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/trace.spec.tsx
@@ -152,7 +152,7 @@ let tid = -1;
 const span_id = () => `${++sid}`;
 const txn_id = () => `${++tid}`;
 
-const {routerContext} = initializeOrg({
+const {router} = initializeOrg({
   router: {
     params: {orgId: 'org-slug', traceSlug: 'trace-id'},
   },
@@ -241,7 +241,7 @@ async function keyboardNavigationTestSetup() {
   mockTraceEventDetails();
   mockMetricsResponse();
 
-  const value = render(<TraceView />, {context: routerContext});
+  const value = render(<TraceView />, {router});
   const virtualizedContainer = screen.queryByTestId('trace-virtualized-list');
   const virtualizedScrollContainer = screen.queryByTestId(
     'trace-virtualized-list-scroll-container'
@@ -285,7 +285,7 @@ async function pageloadTestSetup() {
   mockTraceEventDetails();
   mockMetricsResponse();
 
-  const value = render(<TraceView />, {context: routerContext});
+  const value = render(<TraceView />, {router});
   const virtualizedContainer = screen.queryByTestId('trace-virtualized-list');
   const virtualizedScrollContainer = screen.queryByTestId(
     'trace-virtualized-list-scroll-container'
@@ -329,7 +329,7 @@ async function searchTestSetup() {
   mockTraceEventDetails();
   mockMetricsResponse();
 
-  const value = render(<TraceView />, {context: routerContext});
+  const value = render(<TraceView />, {router});
   const virtualizedContainer = screen.queryByTestId('trace-virtualized-list');
   const virtualizedScrollContainer = screen.queryByTestId(
     'trace-virtualized-list-scroll-container'
@@ -379,7 +379,7 @@ async function simpleTestSetup() {
   mockTraceEventDetails();
   mockMetricsResponse();
 
-  const value = render(<TraceView />, {context: routerContext});
+  const value = render(<TraceView />, {router});
   const virtualizedContainer = screen.queryByTestId('trace-virtualized-list');
   const virtualizedScrollContainer = screen.queryByTestId(
     'trace-virtualized-list-scroll-container'
@@ -504,7 +504,7 @@ describe('trace view', () => {
     mockTraceMetaResponse();
     mockTraceTagsResponse();
 
-    render(<TraceView />, {context: routerContext});
+    render(<TraceView />, {router});
     expect(await screen.findByText(/assembling the trace/i)).toBeInTheDocument();
   });
 
@@ -513,7 +513,7 @@ describe('trace view', () => {
     mockTraceMetaResponse({statusCode: 404});
     mockTraceTagsResponse({statusCode: 404});
 
-    render(<TraceView />, {context: routerContext});
+    render(<TraceView />, {router});
     expect(await screen.findByText(/we failed to load your trace/i)).toBeInTheDocument();
   });
 
@@ -527,7 +527,7 @@ describe('trace view', () => {
     mockTraceMetaResponse();
     mockTraceTagsResponse();
 
-    render(<TraceView />, {context: routerContext});
+    render(<TraceView />, {router});
     expect(
       await screen.findByText(/trace does not contain any data/i)
     ).toBeInTheDocument();
@@ -1135,7 +1135,7 @@ describe('trace view', () => {
         }
       );
 
-      const value = render(<TraceView />, {context: routerContext});
+      const value = render(<TraceView />, {router});
 
       // Awaits for the placeholder rendering rows to be removed
       expect(await findByText(value.container, /transaction-op-0/i)).toBeInTheDocument();

--- a/static/app/views/performance/table.spec.tsx
+++ b/static/app/views/performance/table.spec.tsx
@@ -202,7 +202,7 @@ describe('Performance > Table', function () {
           summaryConditions=""
           projects={data.projects}
         />,
-        {context: data.routerContext}
+        {router: data.router}
       );
 
       const rows = await screen.findAllByTestId('grid-body-row');

--- a/static/app/views/performance/transactionEvents.spec.tsx
+++ b/static/app/views/performance/transactionEvents.spec.tsx
@@ -156,12 +156,12 @@ describe('Performance > TransactionSummary', function () {
   });
 
   it('renders basic UI elements', async function () {
-    const {organization, router, routerContext} = initializeData();
+    const {organization, router} = initializeData();
 
     ProjectsStore.loadInitialData(organization.projects);
 
     render(<TransactionEvents organization={organization} location={router.location} />, {
-      context: routerContext,
+      router,
     });
 
     // Breadcrumb
@@ -190,12 +190,12 @@ describe('Performance > TransactionSummary', function () {
   });
 
   it('renders relative span breakdown header when no filter selected', async function () {
-    const {organization, router, routerContext} = initializeData();
+    const {organization, router} = initializeData();
 
     ProjectsStore.loadInitialData(organization.projects);
 
     render(<TransactionEvents organization={organization} location={router.location} />, {
-      context: routerContext,
+      router,
     });
 
     expect(await screen.findByText('operation duration')).toBeInTheDocument();
@@ -205,12 +205,12 @@ describe('Performance > TransactionSummary', function () {
   });
 
   it('renders event column results correctly', async function () {
-    const {organization, router, routerContext} = initializeData();
+    const {organization, router} = initializeData();
 
     ProjectsStore.loadInitialData(organization.projects);
 
     render(<TransactionEvents organization={organization} location={router.location} />, {
-      context: routerContext,
+      router,
     });
 
     const tableHeader = await screen.findAllByRole('columnheader');
@@ -234,14 +234,14 @@ describe('Performance > TransactionSummary', function () {
   });
 
   it('renders additional Web Vital column', async function () {
-    const {organization, router, routerContext} = initializeData({
+    const {organization, router} = initializeData({
       query: {webVital: WebVital.LCP},
     });
 
     ProjectsStore.loadInitialData(organization.projects);
 
     render(<TransactionEvents organization={organization} location={router.location} />, {
-      context: routerContext,
+      router,
     });
 
     const tableHeader = await screen.findAllByRole('columnheader');

--- a/static/app/views/performance/transactionSummary/transactionAnomalies/index.spec.tsx
+++ b/static/app/views/performance/transactionSummary/transactionAnomalies/index.spec.tsx
@@ -49,7 +49,7 @@ describe('AnomaliesTab', function () {
     });
 
     render(<TransactionAnomalies location={initialData.router.location} />, {
-      context: initialData.routerContext,
+      router: initialData.router,
       organization: initialData.organization,
     });
 

--- a/static/app/views/performance/transactionSummary/transactionEvents/content.spec.tsx
+++ b/static/app/views/performance/transactionSummary/transactionEvents/content.spec.tsx
@@ -192,7 +192,7 @@ describe('Performance Transaction Events Content', function () {
           projects={[]}
         />
       </OrganizationContext.Provider>,
-      {context: initialData.routerContext}
+      {router: initialData.router}
     );
 
     expect(await screen.findByTestId('events-table')).toBeInTheDocument();
@@ -233,7 +233,7 @@ describe('Performance Transaction Events Content', function () {
           projects={[]}
         />
       </OrganizationContext.Provider>,
-      {context: initialData.routerContext}
+      {router: initialData.router}
     );
 
     expect(await screen.findByTestId('events-table')).toBeInTheDocument();
@@ -279,7 +279,7 @@ describe('Performance Transaction Events Content', function () {
           projects={[ProjectFixture({id: '1', platform: 'python'})]}
         />
       </OrganizationContext.Provider>,
-      {context: initialData.routerContext}
+      {router: initialData.router}
     );
 
     expect(await screen.findByTestId('events-table')).toBeInTheDocument();

--- a/static/app/views/performance/transactionSummary/transactionEvents/eventsTable.spec.tsx
+++ b/static/app/views/performance/transactionSummary/transactionEvents/eventsTable.spec.tsx
@@ -201,7 +201,7 @@ describe('Performance GridEditable Table', function () {
         columnTitles={transactionsListTitles}
         transactionName={transactionName}
       />,
-      {context: initialData.routerContext}
+      {router: initialData.router}
     );
 
     expect(await screen.findAllByTestId('relative-ops-breakdown')).toHaveLength(2);
@@ -254,7 +254,7 @@ describe('Performance GridEditable Table', function () {
         columnTitles={transactionsListTitles}
         transactionName={transactionName}
       />,
-      {context: initialData.routerContext}
+      {router: initialData.router}
     );
 
     expect(await screen.findAllByRole('columnheader')).toHaveLength(6);
@@ -288,7 +288,7 @@ describe('Performance GridEditable Table', function () {
         columnTitles={transactionsListTitles}
         transactionName={transactionName}
       />,
-      {context: initialData.routerContext}
+      {router: initialData.router}
     );
 
     expect(await screen.findByRole('link', {name: 'deadbeef'})).toHaveAttribute(
@@ -338,7 +338,7 @@ describe('Performance GridEditable Table', function () {
         columnTitles={transactionsListTitles}
         transactionName={transactionName}
       />,
-      {context: initialData.routerContext}
+      {router: initialData.router}
     );
 
     await waitForElementToBeRemoved(() => screen.queryByTestId('loading-indicator'));
@@ -376,7 +376,7 @@ describe('Performance GridEditable Table', function () {
         columnTitles={transactionsListTitles}
         transactionName={transactionName}
       />,
-      {context: initialData.routerContext}
+      {router: initialData.router}
     );
 
     await waitForElementToBeRemoved(() => screen.queryByTestId('loading-indicator'));

--- a/static/app/views/performance/transactionSummary/transactionEvents/index.spec.tsx
+++ b/static/app/views/performance/transactionSummary/transactionEvents/index.spec.tsx
@@ -144,7 +144,7 @@ describe('Performance > Transaction Summary > Transaction Events > Index', () =>
   it('should contain all transaction events', async () => {
     const data = initializeData();
 
-    render(<WrappedComponent data={data} />, {context: data.routerContext});
+    render(<WrappedComponent data={data} />, {router: data.router});
     expect(await screen.findByText('uhoh@example.com')).toBeInTheDocument();
     expect(await screen.findByText('moreuhoh@example.com')).toBeInTheDocument();
   });
@@ -154,7 +154,7 @@ describe('Performance > Transaction Summary > Transaction Events > Index', () =>
       query: {project: '1', transaction: 'transaction', showTransactions: 'p50'},
     });
 
-    render(<WrappedComponent data={data} />, {context: data.routerContext});
+    render(<WrappedComponent data={data} />, {router: data.router});
     expect(await screen.findByText('uhoh@example.com')).toBeInTheDocument();
     expect(screen.queryByText('moreuhoh@example.com')).not.toBeInTheDocument();
   });
@@ -162,7 +162,7 @@ describe('Performance > Transaction Summary > Transaction Events > Index', () =>
   it('should update transaction percentile query if selected', async () => {
     const data = initializeData();
 
-    render(<WrappedComponent data={data} />, {context: data.routerContext});
+    render(<WrappedComponent data={data} />, {router: data.router});
     const percentileButton = await screen.findByRole('button', {
       name: /percentile p100/i,
     });

--- a/static/app/views/performance/transactionSummary/transactionOverview/index.spec.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/index.spec.tsx
@@ -471,7 +471,7 @@ describe('Performance > TransactionSummary', function () {
 
   describe('with events', function () {
     it('renders basic UI elements', async function () {
-      const {organization, router, routerContext} = initializeData();
+      const {organization, router} = initializeData();
 
       render(
         <TestComponent
@@ -480,7 +480,7 @@ describe('Performance > TransactionSummary', function () {
           location={router.location}
         />,
         {
-          context: routerContext,
+          router,
           organization,
         }
       );
@@ -521,7 +521,7 @@ describe('Performance > TransactionSummary', function () {
     });
 
     it('renders feature flagged UI elements', function () {
-      const {organization, router, routerContext} = initializeData({
+      const {organization, router} = initializeData({
         features: ['incidents'],
       });
 
@@ -532,7 +532,7 @@ describe('Performance > TransactionSummary', function () {
           location={router.location}
         />,
         {
-          context: routerContext,
+          router,
           organization,
         }
       );
@@ -542,7 +542,7 @@ describe('Performance > TransactionSummary', function () {
     });
 
     it('renders Web Vitals widget', async function () {
-      const {organization, router, routerContext} = initializeData({
+      const {organization, router} = initializeData({
         project: ProjectFixture({teams, platform: 'javascript'}),
         query: {
           query:
@@ -557,7 +557,7 @@ describe('Performance > TransactionSummary', function () {
           location={router.location}
         />,
         {
-          context: routerContext,
+          router,
           organization,
         }
       );
@@ -576,7 +576,7 @@ describe('Performance > TransactionSummary', function () {
     });
 
     it('renders sidebar widgets', async function () {
-      const {organization, router, routerContext} = initializeData({});
+      const {organization, router} = initializeData({});
 
       render(
         <TestComponent
@@ -585,7 +585,7 @@ describe('Performance > TransactionSummary', function () {
           location={router.location}
         />,
         {
-          context: routerContext,
+          router,
           organization,
         }
       );
@@ -642,7 +642,7 @@ describe('Performance > TransactionSummary', function () {
       OrganizationStore.onUpdate(OrganizationFixture({slug: 'org-slug'}), {
         replace: true,
       });
-      const {organization, router, routerContext} = initializeData({projects});
+      const {organization, router} = initializeData({projects});
       const spy = jest.spyOn(router, 'replace');
 
       // Ensure project id is not in path
@@ -654,7 +654,7 @@ describe('Performance > TransactionSummary', function () {
           router={router}
           location={router.location}
         />,
-        {context: routerContext, organization}
+        {router, organization}
       );
 
       renderGlobalModal();
@@ -671,7 +671,7 @@ describe('Performance > TransactionSummary', function () {
     });
 
     it('fetches transaction threshold', function () {
-      const {organization, router, routerContext} = initializeData();
+      const {organization, router} = initializeData();
 
       const getTransactionThresholdMock = MockApiClient.addMockResponse({
         url: '/organizations/org-slug/project-transaction-threshold-override/',
@@ -698,7 +698,7 @@ describe('Performance > TransactionSummary', function () {
           location={router.location}
         />,
         {
-          context: routerContext,
+          router,
           organization,
         }
       );
@@ -708,7 +708,7 @@ describe('Performance > TransactionSummary', function () {
     });
 
     it('fetches project transaction threshdold', async function () {
-      const {organization, router, routerContext} = initializeData();
+      const {organization, router} = initializeData();
 
       const getTransactionThresholdMock = MockApiClient.addMockResponse({
         url: '/organizations/org-slug/project-transaction-threshold-override/',
@@ -732,7 +732,7 @@ describe('Performance > TransactionSummary', function () {
           location={router.location}
         />,
         {
-          context: routerContext,
+          router,
           organization,
         }
       );
@@ -744,7 +744,7 @@ describe('Performance > TransactionSummary', function () {
     });
 
     it('triggers a navigation on search', async function () {
-      const {organization, router, routerContext} = initializeData();
+      const {organization, router} = initializeData();
 
       render(
         <TestComponent
@@ -753,7 +753,7 @@ describe('Performance > TransactionSummary', function () {
           location={router.location}
         />,
         {
-          context: routerContext,
+          router,
           organization,
         }
       );
@@ -779,7 +779,7 @@ describe('Performance > TransactionSummary', function () {
     });
 
     it('can mark a transaction as key', async function () {
-      const {organization, router, routerContext} = initializeData();
+      const {organization, router} = initializeData();
 
       render(
         <TestComponent
@@ -788,7 +788,7 @@ describe('Performance > TransactionSummary', function () {
           location={router.location}
         />,
         {
-          context: routerContext,
+          router,
           organization,
         }
       );
@@ -811,7 +811,7 @@ describe('Performance > TransactionSummary', function () {
     });
 
     it('triggers a navigation on transaction filter', async function () {
-      const {organization, router, routerContext} = initializeData();
+      const {organization, router} = initializeData();
 
       render(
         <TestComponent
@@ -820,7 +820,7 @@ describe('Performance > TransactionSummary', function () {
           location={router.location}
         />,
         {
-          context: routerContext,
+          router,
           organization,
         }
       );
@@ -850,7 +850,7 @@ describe('Performance > TransactionSummary', function () {
     });
 
     it('renders pagination buttons', async function () {
-      const {organization, router, routerContext} = initializeData();
+      const {organization, router} = initializeData();
 
       render(
         <TestComponent
@@ -859,7 +859,7 @@ describe('Performance > TransactionSummary', function () {
           location={router.location}
         />,
         {
-          context: routerContext,
+          router,
           organization,
         }
       );
@@ -888,7 +888,7 @@ describe('Performance > TransactionSummary', function () {
         body: [],
       });
 
-      const {organization, router, routerContext} = initializeData({
+      const {organization, router} = initializeData({
         query: {query: 'tag:value'},
       });
 
@@ -899,7 +899,7 @@ describe('Performance > TransactionSummary', function () {
           location={router.location}
         />,
         {
-          context: routerContext,
+          router,
           organization,
         }
       );
@@ -921,7 +921,7 @@ describe('Performance > TransactionSummary', function () {
         ],
       });
 
-      const {organization, router, routerContext} = initializeData({
+      const {organization, router} = initializeData({
         query: {query: 'tag:value event.type:transaction'},
       });
 
@@ -932,7 +932,7 @@ describe('Performance > TransactionSummary', function () {
           location={router.location}
         />,
         {
-          context: routerContext,
+          router,
           organization,
         }
       );
@@ -948,7 +948,7 @@ describe('Performance > TransactionSummary', function () {
         body: [],
       });
 
-      const {organization, router, routerContext} = initializeData();
+      const {organization, router} = initializeData();
 
       render(
         <TestComponent
@@ -957,7 +957,7 @@ describe('Performance > TransactionSummary', function () {
           location={router.location}
         />,
         {
-          context: routerContext,
+          router,
           organization,
         }
       );
@@ -966,7 +966,7 @@ describe('Performance > TransactionSummary', function () {
     });
 
     it('adds search condition on transaction status when clicking on status breakdown', async function () {
-      const {organization, router, routerContext} = initializeData();
+      const {organization, router} = initializeData();
 
       render(
         <TestComponent
@@ -975,7 +975,7 @@ describe('Performance > TransactionSummary', function () {
           location={router.location}
         />,
         {
-          context: routerContext,
+          router,
           organization,
         }
       );
@@ -995,7 +995,7 @@ describe('Performance > TransactionSummary', function () {
     });
 
     it('appends tag value to existing query when clicked', async function () {
-      const {organization, router, routerContext} = initializeData();
+      const {organization, router} = initializeData();
 
       render(
         <TestComponent
@@ -1004,7 +1004,7 @@ describe('Performance > TransactionSummary', function () {
           location={router.location}
         />,
         {
-          context: routerContext,
+          router,
           organization,
         }
       );
@@ -1044,7 +1044,7 @@ describe('Performance > TransactionSummary', function () {
     });
 
     it('does not use MEP dataset for stats query without features', async function () {
-      const {organization, router, routerContext} = initializeData({
+      const {organization, router} = initializeData({
         query: {query: 'transaction.op:pageload'}, // transaction.op is covered by the metrics dataset
         features: [''], // No 'dynamic-sampling' feature to indicate it can use metrics dataset or metrics enhanced.
       });
@@ -1056,7 +1056,7 @@ describe('Performance > TransactionSummary', function () {
           location={router.location}
         />,
         {
-          context: routerContext,
+          router,
           organization,
         }
       );
@@ -1093,7 +1093,7 @@ describe('Performance > TransactionSummary', function () {
     });
 
     it('uses MEP dataset for stats query', async function () {
-      const {organization, router, routerContext} = initializeData({
+      const {organization, router} = initializeData({
         query: {query: 'transaction.op:pageload'}, // transaction.op is covered by the metrics dataset
         features: ['dynamic-sampling', 'mep-rollout-flag'],
       });
@@ -1105,7 +1105,7 @@ describe('Performance > TransactionSummary', function () {
           location={router.location}
         />,
         {
-          context: routerContext,
+          router,
           organization,
         }
       );
@@ -1149,7 +1149,7 @@ describe('Performance > TransactionSummary', function () {
           },
         },
       });
-      const {organization, router, routerContext} = initializeData({
+      const {organization, router} = initializeData({
         query: {query: 'transaction.op:pageload'}, // transaction.op is covered by the metrics dataset
         features: ['dynamic-sampling', 'mep-rollout-flag'],
       });
@@ -1161,7 +1161,7 @@ describe('Performance > TransactionSummary', function () {
           location={router.location}
         />,
         {
-          context: routerContext,
+          router,
           organization,
         }
       );
@@ -1232,7 +1232,7 @@ describe('Performance > TransactionSummary', function () {
           },
         ],
       });
-      const {organization, router, routerContext} = initializeData({
+      const {organization, router} = initializeData({
         query: {query: 'transaction.op:pageload has:not-compatible'}, // Adds incompatible w/ metrics tag
         features: ['dynamic-sampling', 'mep-rollout-flag'],
       });
@@ -1244,7 +1244,7 @@ describe('Performance > TransactionSummary', function () {
           location={router.location}
         />,
         {
-          context: routerContext,
+          router,
           organization,
         }
       );

--- a/static/app/views/performance/transactionSummary/transactionOverview/tagExplorer.spec.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/tagExplorer.spec.tsx
@@ -176,7 +176,7 @@ describe('WrapperComponent', function () {
       api,
       spanOperationBreakdownFilter,
       transactionName,
-      routerContext,
+      router,
     } = initialize(
       projects,
       {
@@ -195,7 +195,7 @@ describe('WrapperComponent', function () {
         transactionName={transactionName}
         currentFilter={spanOperationBreakdownFilter}
       />,
-      {context: routerContext}
+      {router}
     );
 
     const button = await screen.findByTestId('tags-explorer-open-tags');
@@ -248,7 +248,7 @@ describe('WrapperComponent', function () {
       api,
       spanOperationBreakdownFilter,
       transactionName,
-      routerContext,
+      router,
     } = initialize(projects, {});
 
     render(
@@ -261,7 +261,7 @@ describe('WrapperComponent', function () {
         transactionName={transactionName}
         currentFilter={spanOperationBreakdownFilter}
       />,
-      {context: routerContext}
+      {router}
     );
 
     await waitFor(() => expect(facetApiMock).toHaveBeenCalled());

--- a/static/app/views/performance/transactionSummary/transactionReplays/index.spec.tsx
+++ b/static/app/views/performance/transactionSummary/transactionReplays/index.spec.tsx
@@ -34,7 +34,7 @@ const renderComponent = ({
   location,
   organizationProps = {features: ['performance-view', 'session-replay']},
 }: InitializeOrgProps = {}) => {
-  const {organization, routerContext} = initializeOrg({
+  const {organization, router} = initializeOrg({
     organization: {
       ...organizationProps,
     },
@@ -60,7 +60,7 @@ const renderComponent = ({
   ProjectsStore.init();
   ProjectsStore.loadInitialData(organization.projects);
 
-  return render(<TransactionReplays />, {context: routerContext, organization});
+  return render(<TransactionReplays />, {router, organization});
 };
 
 describe('TransactionReplays', () => {

--- a/static/app/views/performance/transactionSummary/transactionSpans/index.spec.tsx
+++ b/static/app/views/performance/transactionSummary/transactionSpans/index.spec.tsx
@@ -87,7 +87,7 @@ describe('Performance > Transaction Spans', function () {
         query: {sort: SpanSortOthers.SUM_EXCLUSIVE_TIME},
       });
       render(<TransactionSpans location={initialData.router.location} />, {
-        context: initialData.routerContext,
+        router: initialData.router,
         organization: initialData.organization,
       });
 
@@ -110,7 +110,7 @@ describe('Performance > Transaction Spans', function () {
         query: {sort: SpanSortOthers.SUM_EXCLUSIVE_TIME},
       });
       render(<TransactionSpans location={initialData.router.location} />, {
-        context: initialData.routerContext,
+        router: initialData.router,
         organization: initialData.organization,
       });
 
@@ -140,7 +140,7 @@ describe('Performance > Transaction Spans', function () {
       it('renders the right percentile header', async function () {
         const initialData = initializeData({query: {sort}});
         render(<TransactionSpans location={initialData.router.location} />, {
-          context: initialData.routerContext,
+          router: initialData.router,
           organization: initialData.organization,
         });
 
@@ -156,7 +156,7 @@ describe('Performance > Transaction Spans', function () {
     it('renders the right avg occurrence header', async function () {
       const initialData = initializeData({query: {sort: SpanSortOthers.AVG_OCCURRENCE}});
       render(<TransactionSpans location={initialData.router.location} />, {
-        context: initialData.routerContext,
+        router: initialData.router,
         organization: initialData.organization,
       });
 

--- a/static/app/views/performance/transactionSummary/transactionSpans/opsFilter.spec.tsx
+++ b/static/app/views/performance/transactionSummary/transactionSpans/opsFilter.spec.tsx
@@ -61,7 +61,7 @@ describe('Performance > Transaction Spans', function () {
         handleOpChange={() => {}}
         transactionName="Test Transaction"
       />,
-      {context: initialData.routerContext}
+      {router: initialData.router}
     );
 
     expect(eventsSpanOpsMock).toHaveBeenCalledTimes(1);
@@ -89,7 +89,7 @@ describe('Performance > Transaction Spans', function () {
         handleOpChange={handleOpChange}
         transactionName="Test Transaction"
       />,
-      {context: initialData.routerContext}
+      {router: initialData.router}
     );
 
     expect(handleOpChange).not.toHaveBeenCalled();
@@ -119,7 +119,7 @@ describe('Performance > Transaction Spans', function () {
         handleOpChange={handleOpChange}
         transactionName="Test Transaction"
       />,
-      {context: initialData.routerContext}
+      {router: initialData.router}
     );
 
     expect(await screen.findByRole('button', {name: 'op1'})).toBeInTheDocument();

--- a/static/app/views/performance/transactionSummary/transactionSpans/spanDetails/index.spec.tsx
+++ b/static/app/views/performance/transactionSummary/transactionSpans/spanDetails/index.spec.tsx
@@ -126,7 +126,7 @@ describe('Performance > Transaction Spans > Span Summary', function () {
       });
 
       render(<SpanDetails params={{spanSlug: 'op:aaaaaaaa'}} {...data} />, {
-        context: data.routerContext,
+        router: data.router,
         organization: data.organization,
       });
 
@@ -205,7 +205,7 @@ describe('Performance > Transaction Spans > Span Summary', function () {
       });
 
       render(<SpanDetails params={{spanSlug: 'op:aaaaaaaa'}} {...data} />, {
-        context: data.routerContext,
+        router: data.router,
         organization: data.organization,
       });
 
@@ -279,7 +279,7 @@ describe('Performance > Transaction Spans > Span Summary', function () {
       });
 
       render(<SpanDetails params={{spanSlug: 'op:aaaaaaaa'}} {...data} />, {
-        context: data.routerContext,
+        router: data.router,
         organization: data.organization,
       });
 
@@ -345,7 +345,7 @@ describe('Performance > Transaction Spans > Span Summary', function () {
       });
 
       render(<SpanDetails params={{spanSlug: 'op:aaaaaaaa'}} {...data} />, {
-        context: data.routerContext,
+        router: data.router,
         organization: data.organization,
       });
 
@@ -359,7 +359,7 @@ describe('Performance > Transaction Spans > Span Summary', function () {
       });
 
       render(<SpanDetails params={{spanSlug: 'op:aaaaaaaa'}} {...data} />, {
-        context: data.routerContext,
+        router: data.router,
         organization: data.organization,
       });
 
@@ -388,7 +388,7 @@ describe('Performance > Transaction Spans > Span Summary', function () {
         });
 
         render(<SpanDetails params={{spanSlug: 'op:aaaaaaaa'}} {...data} />, {
-          context: data.routerContext,
+          router: data.router,
           organization: data.organization,
         });
 
@@ -403,7 +403,7 @@ describe('Performance > Transaction Spans > Span Summary', function () {
         });
 
         render(<SpanDetails params={{spanSlug: 'op:aaaaaaaa'}} {...data} />, {
-          context: data.routerContext,
+          router: data.router,
           organization: data.organization,
         });
 
@@ -421,7 +421,7 @@ describe('Performance > Transaction Spans > Span Summary', function () {
         });
 
         render(<SpanDetails params={{spanSlug: 'op:aaaaaaaa'}} {...data} />, {
-          context: data.routerContext,
+          router: data.router,
           organization: data.organization,
         });
 
@@ -438,7 +438,7 @@ describe('Performance > Transaction Spans > Span Summary', function () {
         });
 
         render(<SpanDetails params={{spanSlug: 'op:aaaaaaaa'}} {...data} />, {
-          context: data.routerContext,
+          router: data.router,
           organization: data.organization,
         });
 
@@ -458,7 +458,7 @@ describe('Performance > Transaction Spans > Span Summary', function () {
         });
 
         render(<SpanDetails params={{spanSlug: 'op:aaaaaaaa'}} {...data} />, {
-          context: data.routerContext,
+          router: data.router,
           organization: data.organization,
         });
 
@@ -485,7 +485,7 @@ describe('Performance > Transaction Spans > Span Summary', function () {
         });
 
         render(<SpanDetails params={{spanSlug: 'op:aaaaaaaa'}} {...data} />, {
-          context: data.routerContext,
+          router: data.router,
           organization: data.organization,
         });
 
@@ -534,7 +534,7 @@ describe('Performance > Transaction Spans > Span Summary', function () {
         });
 
         render(<SpanDetails params={{spanSlug: 'op:aaaaaaaa'}} {...data} />, {
-          context: data.routerContext,
+          router: data.router,
           organization: data.organization,
         });
 
@@ -559,7 +559,7 @@ describe('Performance > Transaction Spans > Span Summary', function () {
         });
 
         render(<SpanDetails params={{spanSlug: 'op:aaaaaaaa'}} {...data} />, {
-          context: data.routerContext,
+          router: data.router,
           organization: data.organization,
         });
 
@@ -582,7 +582,7 @@ describe('Performance > Transaction Spans > Span Summary', function () {
         });
 
         render(<SpanDetails params={{spanSlug: 'op:aaaaaaaa'}} {...data} />, {
-          context: data.routerContext,
+          router: data.router,
           organization: data.organization,
         });
 
@@ -601,7 +601,7 @@ describe('Performance > Transaction Spans > Span Summary', function () {
         });
 
         render(<SpanDetails params={{spanSlug: 'op:aaaaaaaa'}} {...data} />, {
-          context: data.routerContext,
+          router: data.router,
           organization: data.organization,
         });
 
@@ -629,7 +629,7 @@ describe('Performance > Transaction Spans > Span Summary', function () {
         });
 
         render(<SpanDetails params={{spanSlug: 'op:aaaaaaaa'}} {...data} />, {
-          context: data.routerContext,
+          router: data.router,
           organization: data.organization,
         });
 

--- a/static/app/views/performance/transactionSummary/transactionSpans/spanMetricsTable.spec.tsx
+++ b/static/app/views/performance/transactionSummary/transactionSpans/spanMetricsTable.spec.tsx
@@ -16,7 +16,7 @@ const initializeData = () => {
 describe('SuspectSpansTable', () => {
   it('should render the table and rows of data', async () => {
     const initialData = initializeData();
-    const {organization, project, routerContext} = initialData;
+    const {organization, project} = initialData;
 
     const mockRequest = MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/events/`,
@@ -35,9 +35,7 @@ describe('SuspectSpansTable', () => {
       },
     });
 
-    render(<SpanMetricsTable transactionName="Test Transaction" project={project} />, {
-      context: routerContext,
-    });
+    render(<SpanMetricsTable transactionName="Test Transaction" project={project} />);
 
     await waitFor(() =>
       expect(screen.queryByTestId('loading-indicator')).not.toBeInTheDocument()

--- a/static/app/views/performance/transactionSummary/transactionSpans/suspectSpansTable.spec.tsx
+++ b/static/app/views/performance/transactionSummary/transactionSpans/suspectSpansTable.spec.tsx
@@ -34,7 +34,7 @@ describe('SuspectSpansTable', () => {
         totals={{'count()': 100}}
         sort={SpanSortOthers.SUM_EXCLUSIVE_TIME}
       />,
-      {context: initialData.routerContext}
+      {router: initialData.router}
     );
 
     const frequencyHeader = await screen.findByTestId('grid-editable');

--- a/static/app/views/performance/transactionSummary/transactionTags/index.spec.tsx
+++ b/static/app/views/performance/transactionSummary/transactionTags/index.spec.tsx
@@ -147,10 +147,10 @@ describe('Performance > Transaction Tags', function () {
   });
 
   it('renders basic UI elements', async function () {
-    const {organization, router, routerContext} = initializeData();
+    const {organization, router} = initializeData();
 
     render(<TransactionTags location={router.location} />, {
-      context: routerContext,
+      router,
       organization,
     });
 
@@ -179,10 +179,10 @@ describe('Performance > Transaction Tags', function () {
   });
 
   it('Default tagKey is set when loading the page without one', async function () {
-    const {organization, router, routerContext} = initializeData();
+    const {organization, router} = initializeData();
 
     render(<TransactionTags location={router.location} />, {
-      context: routerContext,
+      router,
       organization,
     });
 
@@ -214,12 +214,12 @@ describe('Performance > Transaction Tags', function () {
   });
 
   it('Passed tagKey gets used when calling queries', async function () {
-    const {organization, router, routerContext} = initializeData({
+    const {organization, router} = initializeData({
       query: {tagKey: 'effectiveConnectionType'},
     });
 
     render(<TransactionTags location={router.location} />, {
-      context: routerContext,
+      router,
       organization,
     });
 
@@ -254,7 +254,7 @@ describe('Performance > Transaction Tags', function () {
     const initialData = initializeData({query: {tagKey: 'release'}});
 
     render(<TransactionTags location={initialData.router.location} />, {
-      context: initialData.routerContext,
+      router: initialData.router,
       organization: initialData.organization,
     });
 
@@ -274,7 +274,7 @@ describe('Performance > Transaction Tags', function () {
   });
 
   it('clears tableCursor when selecting a new tag', async function () {
-    const {organization, router, routerContext} = initializeData({
+    const {organization, router} = initializeData({
       query: {
         statsPeriod: '14d',
         tagKey: 'hardwareConcurrency',
@@ -282,7 +282,7 @@ describe('Performance > Transaction Tags', function () {
     });
 
     render(<TransactionTags location={router.location} />, {
-      context: routerContext,
+      router,
       organization,
     });
 
@@ -332,12 +332,12 @@ describe('Performance > Transaction Tags', function () {
   });
 
   it('changes the aggregate column when a new x-axis is selected', async function () {
-    const {organization, router, routerContext} = initializeData({
+    const {organization, router} = initializeData({
       query: {tagKey: 'os'},
     });
 
     render(<TransactionTags location={router.location} />, {
-      context: routerContext,
+      router,
       organization,
     });
 

--- a/static/app/views/performance/transactionSummary/transactionVitals/index.spec.tsx
+++ b/static/app/views/performance/transactionSummary/transactionVitals/index.spec.tsx
@@ -174,24 +174,24 @@ describe('Performance > Web Vitals', function () {
   });
 
   it('render no access without feature', function () {
-    const {organization, router, routerContext} = initialize({
+    const {organization, router} = initialize({
       features: [],
     });
 
     render(<TransactionVitals organization={organization} location={router.location} />, {
-      context: routerContext,
+      router,
       organization,
     });
     expect(screen.getByText("You don't have access to this feature")).toBeInTheDocument();
   });
 
   it('renders the basic UI components', function () {
-    const {organization, router, routerContext} = initialize({
+    const {organization, router} = initialize({
       transaction: '/organizations/:orgId/',
     });
 
     render(<TransactionVitals organization={organization} location={router.location} />, {
-      context: routerContext,
+      router,
       organization,
     });
 
@@ -205,10 +205,10 @@ describe('Performance > Web Vitals', function () {
   });
 
   it('renders the correct bread crumbs', function () {
-    const {organization, router, routerContext} = initialize();
+    const {organization, router} = initialize();
 
     render(<TransactionVitals organization={organization} location={router.location} />, {
-      context: routerContext,
+      router,
       organization,
     });
 
@@ -216,12 +216,12 @@ describe('Performance > Web Vitals', function () {
   });
 
   describe('renders all vitals cards correctly', function () {
-    const {organization, router, routerContext} = initialize();
+    const {organization, router} = initialize();
 
     beforeEach(() => {
       render(
         <TransactionVitals organization={organization} location={router.location} />,
-        {context: routerContext, organization}
+        {router, organization}
       );
     });
 
@@ -233,18 +233,18 @@ describe('Performance > Web Vitals', function () {
 
   describe('reset view', function () {
     it('disables button on default view', function () {
-      const {organization, router, routerContext} = initialize();
+      const {organization, router} = initialize();
 
       render(
         <TransactionVitals organization={organization} location={router.location} />,
-        {context: routerContext, organization}
+        {router, organization}
       );
 
       expect(screen.getByRole('button', {name: 'Reset View'})).toBeDisabled();
     });
 
     it('enables button on left zoom', function () {
-      const {organization, router, routerContext} = initialize({
+      const {organization, router} = initialize({
         query: {
           lcpStart: '20',
         },
@@ -252,14 +252,14 @@ describe('Performance > Web Vitals', function () {
 
       render(
         <TransactionVitals organization={organization} location={router.location} />,
-        {context: routerContext, organization}
+        {router, organization}
       );
 
       expect(screen.getByRole('button', {name: 'Reset View'})).toBeEnabled();
     });
 
     it('enables button on right zoom', function () {
-      const {organization, router, routerContext} = initialize({
+      const {organization, router} = initialize({
         query: {
           fpEnd: '20',
         },
@@ -267,14 +267,14 @@ describe('Performance > Web Vitals', function () {
 
       render(
         <TransactionVitals organization={organization} location={router.location} />,
-        {context: routerContext, organization}
+        {router, organization}
       );
 
       expect(screen.getByRole('button', {name: 'Reset View'})).toBeEnabled();
     });
 
     it('enables button on left and right zoom', function () {
-      const {organization, router, routerContext} = initialize({
+      const {organization, router} = initialize({
         query: {
           fcpStart: '20',
           fcpEnd: '20',
@@ -283,14 +283,14 @@ describe('Performance > Web Vitals', function () {
 
       render(
         <TransactionVitals organization={organization} location={router.location} />,
-        {context: routerContext, organization}
+        {router, organization}
       );
 
       expect(screen.getByRole('button', {name: 'Reset View'})).toBeEnabled();
     });
 
     it('resets view properly', async function () {
-      const {organization, router, routerContext} = initialize({
+      const {organization, router} = initialize({
         query: {
           fidStart: '20',
           lcpEnd: '20',
@@ -299,7 +299,7 @@ describe('Performance > Web Vitals', function () {
 
       render(
         <TransactionVitals organization={organization} location={router.location} />,
-        {context: routerContext, organization}
+        {router, organization}
       );
 
       await userEvent.click(screen.getByRole('button', {name: 'Reset View'}));
@@ -323,7 +323,7 @@ describe('Performance > Web Vitals', function () {
         },
       });
 
-      const {organization, router, routerContext} = initialize({
+      const {organization, router} = initialize({
         query: {
           lcpStart: '20',
         },
@@ -331,7 +331,7 @@ describe('Performance > Web Vitals', function () {
 
       render(
         <TransactionVitals organization={organization} location={router.location} />,
-        {context: routerContext, organization}
+        {router, organization}
       );
 
       await waitForElementToBeRemoved(() =>
@@ -346,7 +346,7 @@ describe('Performance > Web Vitals', function () {
     });
 
     it('does not render an info alert when data from all web vitals is present', async function () {
-      const {organization, router, routerContext} = initialize({
+      const {organization, router} = initialize({
         query: {
           lcpStart: '20',
         },
@@ -354,7 +354,7 @@ describe('Performance > Web Vitals', function () {
 
       render(
         <TransactionVitals organization={organization} location={router.location} />,
-        {context: routerContext, organization}
+        {router, organization}
       );
 
       await waitForElementToBeRemoved(() =>
@@ -381,14 +381,14 @@ describe('Performance > Web Vitals', function () {
       },
     });
 
-    const {organization, router, routerContext} = initialize({
+    const {organization, router} = initialize({
       query: {
         lcpStart: '20',
       },
     });
 
     render(<TransactionVitals organization={organization} location={router.location} />, {
-      context: routerContext,
+      router,
       organization,
     });
 

--- a/static/app/views/performance/trends/changeExplorer.spec.tsx
+++ b/static/app/views/performance/trends/changeExplorer.spec.tsx
@@ -363,7 +363,7 @@ describe('Performance > Trends > Performance Change Explorer', function () {
         location={data.location}
       />,
       {
-        context: data.routerContext,
+        router: data.router,
         organization: data.organization,
       }
     );

--- a/static/app/views/performance/trends/index.spec.tsx
+++ b/static/app/views/performance/trends/index.spec.tsx
@@ -300,7 +300,7 @@ describe('Performance > Trends', function () {
     render(
       <TrendsIndex location={data.router.location} organization={data.organization} />,
       {
-        context: data.routerContext,
+        router: data.router,
         organization: data.organization,
       }
     );
@@ -316,7 +316,7 @@ describe('Performance > Trends', function () {
     render(
       <TrendsIndex location={data.router.location} organization={data.organization} />,
       {
-        context: data.routerContext,
+        router: data.router,
         organization: data.organization,
       }
     );
@@ -332,7 +332,7 @@ describe('Performance > Trends', function () {
     render(
       <TrendsIndex location={data.router.location} organization={data.organization} />,
       {
-        context: data.routerContext,
+        router: data.router,
         organization: data.organization,
       }
     );
@@ -358,7 +358,7 @@ describe('Performance > Trends', function () {
     render(
       <TrendsIndex location={data.router.location} organization={data.organization} />,
       {
-        context: data.routerContext,
+        router: data.router,
         organization: data.organization,
       }
     );
@@ -388,7 +388,7 @@ describe('Performance > Trends', function () {
     render(
       <TrendsIndex location={data.router.location} organization={data.organization} />,
       {
-        context: data.routerContext,
+        router: data.router,
         organization: data.organization,
       }
     );
@@ -418,7 +418,7 @@ describe('Performance > Trends', function () {
     render(
       <TrendsIndex location={data.router.location} organization={data.organization} />,
       {
-        context: data.routerContext,
+        router: data.router,
         organization: data.organization,
       }
     );
@@ -446,7 +446,7 @@ describe('Performance > Trends', function () {
     render(
       <TrendsIndex location={data.router.location} organization={data.organization} />,
       {
-        context: data.routerContext,
+        router: data.router,
         organization: data.organization,
       }
     );
@@ -476,7 +476,7 @@ describe('Performance > Trends', function () {
     render(
       <TrendsIndex location={data.router.location} organization={data.organization} />,
       {
-        context: data.routerContext,
+        router: data.router,
         organization: data.organization,
       }
     );
@@ -506,7 +506,7 @@ describe('Performance > Trends', function () {
     render(
       <TrendsIndex location={data.router.location} organization={data.organization} />,
       {
-        context: data.routerContext,
+        router: data.router,
         organization: data.organization,
       }
     );
@@ -537,7 +537,7 @@ describe('Performance > Trends', function () {
     render(
       <TrendsIndex location={data.router.location} organization={data.organization} />,
       {
-        context: data.routerContext,
+        router: data.router,
         organization: data.organization,
       }
     );
@@ -553,7 +553,7 @@ describe('Performance > Trends', function () {
     render(
       <TrendsIndex location={data.router.location} organization={data.organization} />,
       {
-        context: data.routerContext,
+        router: data.router,
         organization: data.organization,
       }
     );
@@ -569,7 +569,7 @@ describe('Performance > Trends', function () {
     render(
       <TrendsIndex location={data.router.location} organization={data.organization} />,
       {
-        context: data.routerContext,
+        router: data.router,
         organization: data.organization,
       }
     );
@@ -585,7 +585,7 @@ describe('Performance > Trends', function () {
     render(
       <TrendsIndex location={data.router.location} organization={data.organization} />,
       {
-        context: data.routerContext,
+        router: data.router,
         organization: data.organization,
       }
     );
@@ -614,7 +614,7 @@ describe('Performance > Trends', function () {
     const {rerender} = render(
       <TrendsIndex location={data.router.location} organization={data.organization} />,
       {
-        context: data.routerContext,
+        router: data.router,
         organization: data.organization,
       }
     );
@@ -669,7 +669,7 @@ describe('Performance > Trends', function () {
     const {rerender} = render(
       <TrendsIndex location={data.router.location} organization={data.organization} />,
       {
-        context: data.routerContext,
+        router: data.router,
         organization: data.organization,
       }
     );
@@ -741,7 +741,7 @@ describe('Performance > Trends', function () {
     render(
       <TrendsIndex location={data.router.location} organization={data.organization} />,
       {
-        context: data.routerContext,
+        router: data.router,
         organization: data.organization,
       }
     );
@@ -770,7 +770,7 @@ describe('Performance > Trends', function () {
     render(
       <TrendsIndex location={data.router.location} organization={data.organization} />,
       {
-        context: data.routerContext,
+        router: data.router,
         organization: data.organization,
       }
     );

--- a/static/app/views/performance/vitalDetail/index.spec.tsx
+++ b/static/app/views/performance/vitalDetail/index.spec.tsx
@@ -2,7 +2,6 @@ import type {InjectedRouter} from 'react-router';
 import {MetricsFieldFixture} from 'sentry-fixture/metrics';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {ProjectFixture} from 'sentry-fixture/project';
-import {RouterContextFixture} from 'sentry-fixture/routerContextFixture';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen, userEvent, within} from 'sentry-test/reactTestingLibrary';
@@ -23,11 +22,7 @@ const organization = OrganizationFixture({
   projects: [ProjectFixture()],
 });
 
-const {
-  routerContext,
-  organization: org,
-  router,
-} = initializeOrg({
+const {organization: org, router} = initializeOrg({
   organization,
   router: {
     location: {
@@ -222,7 +217,7 @@ describe('Performance > VitalDetail', function () {
 
   it('renders basic UI elements', async function () {
     render(<TestComponent />, {
-      context: routerContext,
+      router,
       organization: org,
     });
 
@@ -247,7 +242,7 @@ describe('Performance > VitalDetail', function () {
 
   it('triggers a navigation on search', async function () {
     render(<TestComponent />, {
-      context: routerContext,
+      router,
       organization: org,
     });
 
@@ -279,10 +274,8 @@ describe('Performance > VitalDetail', function () {
       },
     };
 
-    const context = RouterContextFixture([{router: newRouter}]);
-
     render(<TestComponent router={newRouter} />, {
-      context,
+      router: newRouter,
       organization: org,
     });
 
@@ -326,10 +319,8 @@ describe('Performance > VitalDetail', function () {
       },
     };
 
-    const context = RouterContextFixture([{router: newRouter}]);
-
     render(<TestComponent router={newRouter} />, {
-      context,
+      router: newRouter,
       organization: org,
     });
 
@@ -374,10 +365,8 @@ describe('Performance > VitalDetail', function () {
       },
     };
 
-    const context = RouterContextFixture([{router: newRouter}]);
-
     render(<TestComponent router={newRouter} />, {
-      context,
+      router: newRouter,
       organization: org,
     });
 
@@ -402,7 +391,7 @@ describe('Performance > VitalDetail', function () {
 
   it('renders LCP vital correctly', async function () {
     render(<TestComponent />, {
-      context: routerContext,
+      router,
       organization: org,
     });
 
@@ -417,7 +406,7 @@ describe('Performance > VitalDetail', function () {
 
   it('correctly renders which browsers support LCP', async function () {
     render(<TestComponent />, {
-      context: routerContext,
+      router,
       organization: org,
     });
 
@@ -437,7 +426,7 @@ describe('Performance > VitalDetail', function () {
     };
 
     render(<TestComponent router={newRouter} />, {
-      context: routerContext,
+      router,
       organization: org,
     });
 
@@ -462,7 +451,7 @@ describe('Performance > VitalDetail', function () {
     });
 
     render(<TestComponent router={newRouter} />, {
-      context: routerContext,
+      router,
       organization: org,
     });
 
@@ -487,7 +476,7 @@ describe('Performance > VitalDetail', function () {
     });
 
     render(<TestComponent router={newRouter} />, {
-      context: routerContext,
+      router,
       organization: org,
     });
 

--- a/static/app/views/projectDetail/index.spec.tsx
+++ b/static/app/views/projectDetail/index.spec.tsx
@@ -7,7 +7,7 @@ import ProjectsStore from 'sentry/stores/projectsStore';
 import ProjectDetails from 'sentry/views/projectDetail/projectDetail';
 
 describe('ProjectDetail', function () {
-  const {routerContext, organization, project, router} = initializeOrg();
+  const {organization, project, router} = initializeOrg();
   const params = {...router.params, projectId: project.slug} as any;
 
   beforeEach(() => {
@@ -61,7 +61,7 @@ describe('ProjectDetail', function () {
           route={{}}
         />,
         {
-          context: routerContext,
+          router,
           organization,
         }
       );
@@ -107,7 +107,7 @@ describe('ProjectDetail', function () {
           route={{}}
         />,
         {
-          context: routerContext,
+          router,
           organization,
         }
       );

--- a/static/app/views/projectDetail/projectIssues.spec.tsx
+++ b/static/app/views/projectDetail/projectIssues.spec.tsx
@@ -10,7 +10,7 @@ describe('ProjectDetail > ProjectIssues', function () {
     filteredEndpointMock: ReturnType<typeof MockApiClient.addMockResponse>,
     newIssuesEndpointMock: ReturnType<typeof MockApiClient.addMockResponse>;
 
-  const {organization, router, project, routerContext} = initializeOrg({
+  const {organization, router, project} = initializeOrg({
     organization: {
       features: ['discover-basic'],
     },
@@ -66,7 +66,7 @@ describe('ProjectDetail > ProjectIssues', function () {
         projectId={parseInt(project.id, 10)}
       />,
       {
-        context: routerContext,
+        router,
         organization,
       }
     );
@@ -83,7 +83,7 @@ describe('ProjectDetail > ProjectIssues', function () {
         location={router.location}
       />,
       {
-        context: routerContext,
+        router,
         organization,
       }
     );
@@ -112,7 +112,7 @@ describe('ProjectDetail > ProjectIssues', function () {
         projectId={parseInt(project.id, 10)}
       />,
       {
-        context: routerContext,
+        router,
         organization,
       }
     );
@@ -142,7 +142,7 @@ describe('ProjectDetail > ProjectIssues', function () {
         projectId={parseInt(project.id, 10)}
       />,
       {
-        context: routerContext,
+        router,
         organization,
       }
     );
@@ -175,7 +175,7 @@ describe('ProjectDetail > ProjectIssues', function () {
           query: {statsPeriod: '7d', environment: 'staging', somethingBad: 'nope'},
         }}
       />,
-      {context: routerContext, organization}
+      {router, organization}
     );
 
     expect(endpointMock).toHaveBeenCalledTimes(0);

--- a/static/app/views/projectDetail/projectLatestAlerts.spec.tsx
+++ b/static/app/views/projectDetail/projectLatestAlerts.spec.tsx
@@ -11,7 +11,7 @@ import ProjectLatestAlerts from './projectLatestAlerts';
 describe('ProjectDetail > ProjectLatestAlerts', function () {
   let endpointMock: jest.Mock;
   let rulesEndpointMock: jest.Mock;
-  const {organization, project, router, routerContext} = initializeOrg();
+  const {organization, project, router} = initializeOrg();
 
   beforeEach(function () {
     endpointMock = MockApiClient.addMockResponse({
@@ -40,7 +40,7 @@ describe('ProjectDetail > ProjectLatestAlerts', function () {
         location={router.location}
         isProjectStabilized
       />,
-      {context: routerContext}
+      {router}
     );
 
     expect(endpointMock).toHaveBeenCalledTimes(2); // one for closed, one for open
@@ -117,7 +117,7 @@ describe('ProjectDetail > ProjectLatestAlerts', function () {
         location={router.location}
         isProjectStabilized
       />,
-      {context: routerContext}
+      {router}
     );
 
     expect(await screen.findByRole('button', {name: 'Create Alert'})).toHaveAttribute(

--- a/static/app/views/projectDetail/projectQuickLinks.spec.tsx
+++ b/static/app/views/projectDetail/projectQuickLinks.spec.tsx
@@ -6,7 +6,7 @@ import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 import ProjectQuickLinks from 'sentry/views/projectDetail/projectQuickLinks';
 
 describe('ProjectDetail > ProjectQuickLinks', function () {
-  const {organization, router, routerContext} = initializeOrg({
+  const {organization, router} = initializeOrg({
     organization: {features: ['performance-view']},
   });
 
@@ -21,7 +21,7 @@ describe('ProjectDetail > ProjectQuickLinks', function () {
         location={router.location}
         project={ProjectFixture()}
       />,
-      {context: routerContext}
+      {router}
     );
 
     expect(screen.getByRole('heading', {name: 'Quick Links'})).toBeInTheDocument();
@@ -63,7 +63,7 @@ describe('ProjectDetail > ProjectQuickLinks', function () {
         location={router.location}
         project={ProjectFixture()}
       />,
-      {context: routerContext}
+      {router}
     );
 
     const keyTransactions = screen.getByText('View Transactions');

--- a/static/app/views/projectDetail/projectScoreCards/projectAnrScoreCard.spec.tsx
+++ b/static/app/views/projectDetail/projectScoreCards/projectAnrScoreCard.spec.tsx
@@ -7,7 +7,7 @@ import {ProjectAnrScoreCard} from 'sentry/views/projectDetail/projectScoreCards/
 describe('ProjectDetail > ProjectAnr', function () {
   let endpointMock, endpointMockPreviousPeriod;
 
-  const {organization, router, routerContext} = initializeOrg({
+  const {organization, router} = initializeOrg({
     router: {
       location: {
         query: {project: '1', statsPeriod: '7d'},
@@ -123,7 +123,7 @@ describe('ProjectDetail > ProjectAnr', function () {
         location={router.location}
       />,
       {
-        context: routerContext,
+        router,
       }
     );
 

--- a/static/app/views/projectDetail/projectTeamAccess.spec.tsx
+++ b/static/app/views/projectDetail/projectTeamAccess.spec.tsx
@@ -7,7 +7,7 @@ import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 import ProjectTeamAccess from 'sentry/views/projectDetail/projectTeamAccess';
 
 describe('ProjectDetail > ProjectTeamAccess', function () {
-  const {organization, routerContext} = initializeOrg();
+  const {organization, router} = initializeOrg();
 
   it('renders a list', function () {
     render(
@@ -15,7 +15,7 @@ describe('ProjectDetail > ProjectTeamAccess', function () {
         organization={organization}
         project={ProjectFixture({teams: [TeamFixture()]})}
       />,
-      {context: routerContext}
+      {router}
     );
 
     expect(screen.getByText('Team Access')).toBeInTheDocument();
@@ -28,7 +28,7 @@ describe('ProjectDetail > ProjectTeamAccess', function () {
         organization={organization}
         project={ProjectFixture({teams: [TeamFixture()]})}
       />,
-      {context: routerContext}
+      {router}
     );
 
     expect(screen.getByRole('link', {name: '#team-slug'})).toHaveAttribute(
@@ -39,7 +39,7 @@ describe('ProjectDetail > ProjectTeamAccess', function () {
 
   it('display the right empty state with access', function () {
     render(<ProjectTeamAccess organization={organization} project={ProjectFixture()} />, {
-      context: routerContext,
+      router,
     });
 
     expect(screen.getByRole('button', {name: 'Assign Team'})).toHaveAttribute(
@@ -54,7 +54,7 @@ describe('ProjectDetail > ProjectTeamAccess', function () {
         organization={{...organization, access: []}}
         project={ProjectFixture({teams: []})}
       />,
-      {context: routerContext}
+      {router}
     );
     expect(screen.getByRole('button', {name: 'Assign Team'})).toBeDisabled();
   });
@@ -75,7 +75,7 @@ describe('ProjectDetail > ProjectTeamAccess', function () {
           ],
         })}
       />,
-      {context: routerContext}
+      {router}
     );
 
     expect(screen.getAllByTestId('badge-display-name')).toHaveLength(5);
@@ -99,7 +99,7 @@ describe('ProjectDetail > ProjectTeamAccess', function () {
           ],
         })}
       />,
-      {context: routerContext}
+      {router}
     );
 
     const badges = screen.getAllByTestId('badge-display-name');

--- a/static/app/views/projectInstall/newProject.spec.tsx
+++ b/static/app/views/projectInstall/newProject.spec.tsx
@@ -1,6 +1,5 @@
 import {MOCK_RESP_VERBOSE} from 'sentry-fixture/ruleConditions';
 
-import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render} from 'sentry-test/reactTestingLibrary';
 
 import NewProject from 'sentry/views/projectInstall/newProject';
@@ -18,7 +17,6 @@ describe('NewProjectPlatform', function () {
   });
 
   it('should render', function () {
-    const {routerContext} = initializeOrg();
-    render(<NewProject />, {context: routerContext});
+    render(<NewProject />);
   });
 });

--- a/static/app/views/projectInstall/platform.spec.tsx
+++ b/static/app/views/projectInstall/platform.spec.tsx
@@ -59,7 +59,7 @@ describe('ProjectInstallPlatform', function () {
     const routeParams = {
       projectId: ProjectFixture().slug,
     };
-    const {organization, routerProps, project, routerContext} = initializeOrg({
+    const {organization, routerProps, project, router} = initializeOrg({
       router: {
         location: {
           query: {},
@@ -72,7 +72,7 @@ describe('ProjectInstallPlatform', function () {
 
     render(<ProjectInstallPlatform {...routerProps} />, {
       organization,
-      context: routerContext,
+      router,
     });
 
     expect(await screen.findByText('Page Not Found')).toBeInTheDocument();
@@ -114,7 +114,7 @@ describe('ProjectInstallPlatform', function () {
       platform: 'python',
     };
 
-    const {routerProps, routerContext} = initializeOrg({
+    const {routerProps, router} = initializeOrg({
       router: {
         location: {
           query: {},
@@ -128,7 +128,7 @@ describe('ProjectInstallPlatform', function () {
     mockProjectApiResponses([project]);
 
     render(<ProjectInstallPlatform {...routerProps} />, {
-      context: routerContext,
+      router,
     });
 
     expect(

--- a/static/app/views/releases/detail/commitsAndFiles/commits.spec.tsx
+++ b/static/app/views/releases/detail/commitsAndFiles/commits.spec.tsx
@@ -16,7 +16,7 @@ import Commits from './commits';
 describe('Commits', () => {
   const release = ReleaseFixture();
   const project = ReleaseProjectFixture() as Required<ReleaseProject>;
-  const {routerProps, routerContext, organization} = initializeOrg({
+  const {routerProps, router, organization} = initializeOrg({
     router: {params: {release: release.version}},
   });
   const repos = [RepositoryFixture({integrationId: '1'})];
@@ -36,7 +36,7 @@ describe('Commits', () => {
       >
         <Commits releaseRepos={[]} projectSlug={project.slug} {...routerProps} />
       </ReleaseContext.Provider>,
-      {context: routerContext}
+      {router}
     );
   }
 
@@ -133,7 +133,7 @@ describe('Commits', () => {
       integrationId: '1',
     });
     // Current repo is stored in query parameter activeRepo
-    const {routerContext: newRouterContext, routerProps: newRouterProps} = initializeOrg({
+    const {router: newRouterContext, routerProps: newRouterProps} = initializeOrg({
       router: {
         params: {release: release.version},
         location: {query: {activeRepo: otherRepo.name}},
@@ -170,7 +170,7 @@ describe('Commits', () => {
       >
         <Commits releaseRepos={[]} projectSlug={project.slug} {...newRouterProps} />
       </ReleaseContext.Provider>,
-      {context: newRouterContext}
+      {router: newRouterContext}
     );
     expect(await screen.findByRole('button')).toHaveTextContent(otherRepo.name);
     expect(screen.queryByText('example/repo-name')).not.toBeInTheDocument();

--- a/static/app/views/releases/detail/commitsAndFiles/filesChanged.spec.tsx
+++ b/static/app/views/releases/detail/commitsAndFiles/filesChanged.spec.tsx
@@ -29,7 +29,7 @@ function CommitFileFixture(params: Partial<CommitFile> = {}): CommitFile {
 describe('FilesChanged', () => {
   const release = ReleaseFixture();
   const project = ReleaseProjectFixture() as Required<ReleaseProject>;
-  const {routerProps, routerContext, organization} = initializeOrg({
+  const {routerProps, router, organization} = initializeOrg({
     router: {params: {release: release.version}},
   });
   const repos = [RepositoryFixture({integrationId: '1'})];
@@ -54,7 +54,7 @@ describe('FilesChanged', () => {
           {...routerProps}
         />
       </ReleaseContext.Provider>,
-      {context: routerContext}
+      {router}
     );
   }
 

--- a/static/app/views/releases/detail/overview/releaseComparisonChart/index.spec.tsx
+++ b/static/app/views/releases/detail/overview/releaseComparisonChart/index.spec.tsx
@@ -12,7 +12,7 @@ import {browserHistory} from 'sentry/utils/browserHistory';
 import ReleaseComparisonChart from 'sentry/views/releases/detail/overview/releaseComparisonChart';
 
 describe('Releases > Detail > Overview > ReleaseComparison', () => {
-  const {routerContext, organization, project: rawProject} = initializeOrg();
+  const {router, organization, project: rawProject} = initializeOrg();
   const api = new MockApiClient();
   const release = ReleaseFixture();
   const releaseSessions = SessionUserCountByStatusFixture();
@@ -33,7 +33,7 @@ describe('Releases > Detail > Overview > ReleaseComparison', () => {
         releaseSessions={releaseSessions}
         allSessions={allSessions}
         platform="javascript"
-        location={{...routerContext.location, query: {}}}
+        location={{...router.location, query: {}}}
         loading={false}
         reloading={false}
         errored={false}
@@ -42,7 +42,7 @@ describe('Releases > Detail > Overview > ReleaseComparison', () => {
         api={api}
         hasHealthData
       />,
-      {context: routerContext}
+      {router}
     );
 
     expect(screen.getByLabelText('Chart Title')).toHaveTextContent(
@@ -67,7 +67,7 @@ describe('Releases > Detail > Overview > ReleaseComparison', () => {
         releaseSessions={releaseSessions}
         allSessions={allSessions}
         platform="javascript"
-        location={{...routerContext.location, query: {}}}
+        location={{...router.location, query: {}}}
         loading={false}
         reloading={false}
         errored={false}
@@ -76,12 +76,14 @@ describe('Releases > Detail > Overview > ReleaseComparison', () => {
         api={api}
         hasHealthData
       />,
-      {context: routerContext}
+      {router}
     );
 
     await userEvent.click(screen.getByLabelText(/crash free user rate/i));
 
-    expect(browserHistory.push).toHaveBeenCalledWith({query: {chart: 'crashFreeUsers'}});
+    expect(browserHistory.push).toHaveBeenCalledWith(
+      expect.objectContaining({query: {chart: 'crashFreeUsers'}})
+    );
 
     rerender(
       <ReleaseComparisonChart
@@ -89,7 +91,7 @@ describe('Releases > Detail > Overview > ReleaseComparison', () => {
         releaseSessions={releaseSessions}
         allSessions={allSessions}
         platform="javascript"
-        location={{...routerContext.location, query: {chart: 'crashFreeUsers'}}}
+        location={{...router.location, query: {chart: 'crashFreeUsers'}}}
         loading={false}
         reloading={false}
         errored={false}
@@ -113,7 +115,7 @@ describe('Releases > Detail > Overview > ReleaseComparison', () => {
         releaseSessions={releaseSessions}
         allSessions={allSessions}
         platform="javascript"
-        location={{...routerContext.location, query: {}}}
+        location={{...router.location, query: {}}}
         loading={false}
         reloading={false}
         errored={false}
@@ -122,7 +124,7 @@ describe('Releases > Detail > Overview > ReleaseComparison', () => {
         api={api}
         hasHealthData
       />,
-      {context: routerContext}
+      {router}
     );
 
     for (const toggle of screen.getAllByLabelText(/toggle chart/i)) {
@@ -168,7 +170,7 @@ describe('Releases > Detail > Overview > ReleaseComparison', () => {
         releaseSessions={null}
         allSessions={null}
         platform="javascript"
-        location={{...routerContext.location, query: {}}}
+        location={{...router.location, query: {}}}
         loading={false}
         reloading={false}
         errored={false}
@@ -180,7 +182,7 @@ describe('Releases > Detail > Overview > ReleaseComparison', () => {
         api={api}
         hasHealthData={false}
       />,
-      {context: routerContext}
+      {router}
     );
 
     expect(screen.getAllByRole('radio').length).toBe(1);

--- a/static/app/views/releases/detail/overview/releaseIssues.spec.tsx
+++ b/static/app/views/releases/detail/overview/releaseIssues.spec.tsx
@@ -114,9 +114,9 @@ describe('ReleaseIssues', function () {
   });
 
   it('can switch issue filters', async function () {
-    const {routerContext} = initializeOrg();
+    const {router} = initializeOrg();
 
-    const {rerender} = render(<ReleaseIssues {...props} />, {context: routerContext});
+    const {rerender} = render(<ReleaseIssues {...props} />, {router});
 
     // New
     expect(await screen.findByRole('radio', {name: 'New Issues 0'})).toBeChecked();
@@ -176,9 +176,9 @@ describe('ReleaseIssues', function () {
       body: [GroupFixture({id: '123'})],
     });
 
-    const {routerContext} = initializeOrg();
+    const {router} = initializeOrg();
 
-    render(<ReleaseIssues {...props} />, {context: routerContext});
+    render(<ReleaseIssues {...props} />, {router});
 
     await userEvent.click(screen.getByRole('radio', {name: /New Issues/}));
 

--- a/static/app/views/releases/list/index.spec.tsx
+++ b/static/app/views/releases/list/index.spec.tsx
@@ -20,7 +20,7 @@ import {ReleasesSortOption} from 'sentry/views/releases/list/releasesSortOptions
 import {ReleasesStatusOption} from 'sentry/views/releases/list/releasesStatusOptions';
 
 describe('ReleasesList', () => {
-  const {organization, routerContext, router, routerProps} = initializeOrg();
+  const {organization, router, routerProps} = initializeOrg();
   const semverVersionInfo = {
     buildHash: null,
     description: '1.2.3',
@@ -114,7 +114,7 @@ describe('ReleasesList', () => {
 
   it('renders list', async () => {
     render(<ReleasesList {...props} />, {
-      context: routerContext,
+      router,
       organization,
     });
     const items = await screen.findAllByTestId('release-panel');
@@ -163,7 +163,7 @@ describe('ReleasesList', () => {
         selection={{...props.selection, projects: [4]}}
       />,
       {
-        context: routerContext,
+        router,
         organization,
       }
     );
@@ -253,7 +253,7 @@ describe('ReleasesList', () => {
     });
 
     render(<ReleasesList {...props} />, {
-      context: routerContext,
+      router,
       organization,
     });
 
@@ -273,7 +273,7 @@ describe('ReleasesList', () => {
     });
 
     render(<ReleasesList {...props} />, {
-      context: routerContext,
+      router,
       organization,
     });
 
@@ -299,7 +299,7 @@ describe('ReleasesList', () => {
 
   it('sorts releases', async () => {
     render(<ReleasesList {...props} />, {
-      context: routerContext,
+      router,
       organization,
     });
 
@@ -342,7 +342,7 @@ describe('ReleasesList', () => {
         selection={{...props.selection, environments: ['a', 'b']}}
       />,
       {
-        context: routerContext,
+        router,
         organization,
       }
     );
@@ -353,7 +353,7 @@ describe('ReleasesList', () => {
 
   it('display the right Crash Free column', async () => {
     render(<ReleasesList {...props} />, {
-      context: routerContext,
+      router,
       organization,
     });
 
@@ -391,7 +391,7 @@ describe('ReleasesList', () => {
         }}
       />,
       {
-        context: routerContext,
+        router,
         organization,
       }
     );
@@ -445,7 +445,7 @@ describe('ReleasesList', () => {
 
   it('calls api with only explicitly permitted query params', async () => {
     render(<ReleasesList {...props} />, {
-      context: routerContext,
+      router,
       organization,
     });
 
@@ -463,7 +463,7 @@ describe('ReleasesList', () => {
 
   it('calls session api for health data', async () => {
     render(<ReleasesList {...props} />, {
-      context: routerContext,
+      router,
       organization,
     });
 
@@ -536,7 +536,7 @@ describe('ReleasesList', () => {
       ],
     });
     render(<ReleasesList {...props} selection={{...props.selection, projects: [2]}} />, {
-      context: routerContext,
+      router,
       organization,
     });
     const hiddenProjectsMessage = await screen.findByTestId('hidden-projects');
@@ -553,7 +553,7 @@ describe('ReleasesList', () => {
       body: [ReleaseFixture({version: '2.0.0'})],
     });
     render(<ReleasesList {...props} selection={{...props.selection, projects: [-1]}} />, {
-      context: routerContext,
+      router,
       organization,
     });
 
@@ -580,7 +580,7 @@ describe('ReleasesList', () => {
       method: 'POST',
     });
     render(<ReleasesList {...props} />, {
-      context: routerContext,
+      router,
       organization,
     });
     const smartSearchBar = await screen.findByTestId('smart-search-input');

--- a/static/app/views/releases/utils/index.spec.tsx
+++ b/static/app/views/releases/utils/index.spec.tsx
@@ -105,12 +105,12 @@ describe('releases/utils', () => {
   });
 
   describe('getReleaseParams', () => {
-    const {routerContext} = initializeOrg();
+    const {router} = initializeOrg();
     const releaseBounds = getReleaseBounds(ReleaseFixture());
 
     it('returns params related to a release', () => {
       const location = {
-        ...routerContext.location,
+        ...router.location,
         query: {
           pageStatsPeriod: '30d',
           project: ['456'],
@@ -134,7 +134,7 @@ describe('releases/utils', () => {
     it('returns release start/end if no other datetime is present', () => {
       expect(
         getReleaseParams({
-          location: {...routerContext.location, query: {}},
+          location: {...router.location, query: {}},
           releaseBounds,
         })
       ).toEqual({
@@ -147,7 +147,7 @@ describe('releases/utils', () => {
       expect(
         getReleaseParams({
           location: {
-            ...routerContext.location,
+            ...router.location,
             query: {pageStart: '2021-03-23T01:02:30Z', pageEnd: '2022-03-23T01:02:30Z'},
           },
           releaseBounds,

--- a/static/app/views/relocation/index.spec.tsx
+++ b/static/app/views/relocation/index.spec.tsx
@@ -35,14 +35,14 @@ describe('Relocation Onboarding Container', function () {
   });
 
   it('should render if feature enabled', function () {
-    const {routerProps, routerContext, organization} = initializeOrg({
+    const {routerProps, router, organization} = initializeOrg({
       router: {
         params: {step: '1'},
       },
     });
     ConfigStore.set('features', new Set(['relocation:enabled']));
     render(<RelocationOnboardingContainer {...routerProps} />, {
-      context: routerContext,
+      router,
       organization,
     });
     expect(
@@ -51,14 +51,14 @@ describe('Relocation Onboarding Container', function () {
   });
 
   it('should not render if feature disabled', async function () {
-    const {routerProps, routerContext, organization} = initializeOrg({
+    const {routerProps, router, organization} = initializeOrg({
       router: {
         params: {step: '1'},
       },
     });
     ConfigStore.set('features', new Set([]));
     render(<RelocationOnboardingContainer {...routerProps} />, {
-      context: routerContext,
+      router,
       organization,
     });
     expect(

--- a/static/app/views/relocation/relocation.spec.tsx
+++ b/static/app/views/relocation/relocation.spec.tsx
@@ -86,14 +86,14 @@ describe('Relocation', function () {
       step,
     };
 
-    const {routerProps, routerContext, organization} = initializeOrg({
+    const {router, routerProps, organization} = initializeOrg({
       router: {
         params: routeParams,
       },
     });
 
     return render(<Relocation {...routerProps} />, {
-      context: routerContext,
+      router,
       organization,
     });
   }

--- a/static/app/views/routeError.spec.tsx
+++ b/static/app/views/routeError.spec.tsx
@@ -6,7 +6,7 @@ import {render, waitFor} from 'sentry-test/reactTestingLibrary';
 import RouteError from 'sentry/views/routeError';
 
 describe('RouteError', function () {
-  const {routerContext} = initializeOrg({
+  const {router} = initializeOrg({
     router: {
       routes: [
         {path: '/'},
@@ -20,7 +20,7 @@ describe('RouteError', function () {
 
   it('captures errors with sentry', async function () {
     render(<RouteError error={new Error('Big Bad Error')} />, {
-      context: routerContext,
+      router,
     });
 
     await waitFor(() =>

--- a/static/app/views/settings/account/accountSecurity/accountSecurityDetails.spec.tsx
+++ b/static/app/views/settings/account/accountSecurity/accountSecurityDetails.spec.tsx
@@ -51,7 +51,7 @@ describe('AccountSecurityDetails', function () {
       const params = {
         authId: '15',
       };
-      const {routerProps, routerContext} = initializeOrg({
+      const {routerProps, router} = initializeOrg({
         router: {
           params,
         },
@@ -65,7 +65,7 @@ describe('AccountSecurityDetails', function () {
             deleteDisabled={false}
           />
         </AccountSecurityWrapper>,
-        {context: routerContext}
+        {router}
       );
 
       expect(await screen.findByTestId('auth-status-enabled')).toBeInTheDocument();
@@ -84,7 +84,7 @@ describe('AccountSecurityDetails', function () {
       const params = {
         authId: '15',
       };
-      const {routerProps, routerContext} = initializeOrg({
+      const {routerProps, router} = initializeOrg({
         router: {
           params,
         },
@@ -98,7 +98,7 @@ describe('AccountSecurityDetails', function () {
             deleteDisabled={false}
           />
         </AccountSecurityWrapper>,
-        {context: routerContext}
+        {router}
       );
 
       await userEvent.click(await screen.findByRole('button', {name: 'Remove'}));
@@ -124,7 +124,7 @@ describe('AccountSecurityDetails', function () {
       const params = {
         authId: '15',
       };
-      const {routerProps, routerContext} = initializeOrg({
+      const {routerProps, router} = initializeOrg({
         router: {
           params,
         },
@@ -138,7 +138,7 @@ describe('AccountSecurityDetails', function () {
             deleteDisabled={false}
           />
         </AccountSecurityWrapper>,
-        {context: routerContext}
+        {router}
       );
 
       await userEvent.click(await screen.findByRole('button', {name: 'Remove'}));
@@ -165,7 +165,7 @@ describe('AccountSecurityDetails', function () {
         authId: '15',
       };
 
-      const {routerContext, routerProps} = initializeOrg({
+      const {router, routerProps} = initializeOrg({
         router: {
           params,
         },
@@ -179,7 +179,7 @@ describe('AccountSecurityDetails', function () {
             deleteDisabled={false}
           />
         </AccountSecurityWrapper>,
-        {context: routerContext}
+        {router}
       );
 
       expect(await screen.findByRole('button', {name: 'Remove'})).toBeDisabled();
@@ -214,7 +214,7 @@ describe('AccountSecurityDetails', function () {
         authId: '16',
       };
 
-      const {routerProps, routerContext} = initializeOrg({
+      const {routerProps, router} = initializeOrg({
         router: {
           params,
         },
@@ -228,7 +228,7 @@ describe('AccountSecurityDetails', function () {
             deleteDisabled={false}
           />
         </AccountSecurityWrapper>,
-        {context: routerContext}
+        {router}
       );
 
       expect(await screen.findByTestId('auth-status-enabled')).toBeInTheDocument();
@@ -246,7 +246,7 @@ describe('AccountSecurityDetails', function () {
         authId: '16',
       };
 
-      const {routerProps, routerContext} = initializeOrg({
+      const {routerProps, router} = initializeOrg({
         router: {
           params,
         },
@@ -260,7 +260,7 @@ describe('AccountSecurityDetails', function () {
             deleteDisabled={false}
           />
         </AccountSecurityWrapper>,
-        {context: routerContext}
+        {router}
       );
 
       await userEvent.click(
@@ -285,7 +285,7 @@ describe('AccountSecurityDetails', function () {
         authId: '16',
       };
 
-      const {routerProps, routerContext} = initializeOrg({
+      const {routerProps, router} = initializeOrg({
         router: {
           params,
         },
@@ -303,7 +303,7 @@ describe('AccountSecurityDetails', function () {
             deleteDisabled={false}
           />
         </AccountSecurityWrapper>,
-        {context: routerContext}
+        {router}
       );
 
       expect(await screen.findByRole('button', {name: 'print'})).toBeInTheDocument();

--- a/static/app/views/settings/account/accountSecurity/accountSecurityEnroll.spec.tsx
+++ b/static/app/views/settings/account/accountSecurity/accountSecurityEnroll.spec.tsx
@@ -1,6 +1,5 @@
 import {AuthenticatorsFixture} from 'sentry-fixture/authenticators';
 import {OrganizationFixture} from 'sentry-fixture/organization';
-import {RouterContextFixture} from 'sentry-fixture/routerContextFixture';
 import {RouterFixture} from 'sentry-fixture/routerFixture';
 
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
@@ -34,14 +33,9 @@ describe('AccountSecurityEnroll', function () {
       ],
     });
 
-    const routerContext = RouterContextFixture([
-      {
-        router: {
-          ...RouterFixture(),
-          params: {authId: authenticator.authId},
-        },
-      },
-    ]);
+    const router = RouterFixture({
+      params: {authId: authenticator.authId},
+    });
 
     let location;
     beforeEach(function () {
@@ -66,7 +60,7 @@ describe('AccountSecurityEnroll', function () {
     });
 
     it('does not have enrolled circle indicator', function () {
-      render(<AccountSecurityEnroll />, {context: routerContext});
+      render(<AccountSecurityEnroll />, {router});
 
       expect(
         screen.getByRole('status', {name: 'Authentication Method Inactive'})
@@ -74,7 +68,7 @@ describe('AccountSecurityEnroll', function () {
     });
 
     it('has qrcode component', function () {
-      render(<AccountSecurityEnroll />, {context: routerContext});
+      render(<AccountSecurityEnroll />, {router});
 
       expect(screen.getByLabelText('Enrollment QR Code')).toBeInTheDocument();
     });
@@ -99,7 +93,7 @@ describe('AccountSecurityEnroll', function () {
         body: [usorg],
       });
 
-      render(<AccountSecurityEnroll />, {context: routerContext});
+      render(<AccountSecurityEnroll />, {router});
 
       await userEvent.type(screen.getByRole('textbox', {name: 'OTP Code'}), 'otp{enter}');
 
@@ -137,7 +131,7 @@ describe('AccountSecurityEnroll', function () {
         body: [usorg],
       });
 
-      render(<AccountSecurityEnroll />, {context: routerContext});
+      render(<AccountSecurityEnroll />, {router});
 
       await userEvent.type(screen.getByRole('textbox', {name: 'OTP Code'}), 'otp{enter}');
 
@@ -164,16 +158,12 @@ describe('AccountSecurityEnroll', function () {
       });
 
       const pushMock = jest.fn();
-      const routerContextWithMock = RouterContextFixture([
-        {
-          router: {
-            ...RouterFixture({push: pushMock}),
-            params: {authId: authenticator.authId},
-          },
-        },
-      ]);
+      const routerWithMock = RouterFixture({
+        push: pushMock,
+        params: {authId: authenticator.authId},
+      });
 
-      render(<AccountSecurityEnroll />, {context: routerContextWithMock});
+      render(<AccountSecurityEnroll />, {router: routerWithMock});
 
       expect(pushMock).toHaveBeenCalledWith('/settings/account/security/');
     });

--- a/static/app/views/settings/account/accountSecurity/components/twoFactorRequired.spec.tsx
+++ b/static/app/views/settings/account/accountSecurity/components/twoFactorRequired.spec.tsx
@@ -33,7 +33,7 @@ describe('TwoFactorRequired', function () {
     });
   });
 
-  const {routerContext, routerProps} = initializeOrg();
+  const {router, routerProps} = initializeOrg();
 
   const baseProps = {
     authenticators: null,
@@ -56,7 +56,7 @@ describe('TwoFactorRequired', function () {
       <AccountSecurityWrapper {...routerProps} params={{authId: ''}}>
         <TwoFactorRequired {...baseProps} />
       </AccountSecurityWrapper>,
-      {context: routerContext}
+      {router}
     );
 
     expect(await screen.findByText('Your current password')).toBeInTheDocument();
@@ -68,7 +68,7 @@ describe('TwoFactorRequired', function () {
       <AccountSecurityWrapper {...routerProps} params={{authId: ''}}>
         <TwoFactorRequired {...baseProps} />
       </AccountSecurityWrapper>,
-      {context: routerContext}
+      {router}
     );
 
     expect(await screen.findByText('Your current password')).toBeInTheDocument();
@@ -85,7 +85,7 @@ describe('TwoFactorRequired', function () {
       <AccountSecurityWrapper {...routerProps} params={{authId: ''}}>
         <TwoFactorRequired {...baseProps} />
       </AccountSecurityWrapper>,
-      {context: routerContext}
+      {router}
     );
 
     expect(await screen.findByText('Your current password')).toBeInTheDocument();
@@ -112,7 +112,7 @@ describe('TwoFactorRequired', function () {
       <AccountSecurityWrapper {...routerProps} params={{authId: ''}}>
         <TwoFactorRequired {...baseProps} />
       </AccountSecurityWrapper>,
-      {context: routerContext}
+      {router}
     );
 
     expect(await screen.findByText('Your current password')).toBeInTheDocument();
@@ -131,7 +131,7 @@ describe('TwoFactorRequired', function () {
       <AccountSecurityWrapper {...routerProps} params={{authId: ''}}>
         <TwoFactorRequired {...baseProps} />
       </AccountSecurityWrapper>,
-      {context: routerContext}
+      {router}
     );
 
     expect(await screen.findByTestId('require-2fa')).toBeInTheDocument();

--- a/static/app/views/settings/account/notifications/notificationSettings.spec.tsx
+++ b/static/app/views/settings/account/notifications/notificationSettings.spec.tsx
@@ -20,12 +20,12 @@ function renderMockRequests({}: {}) {
 
 describe('NotificationSettings', function () {
   it('should render', async function () {
-    const {routerContext, organization} = initializeOrg();
+    const {router, organization} = initializeOrg();
 
     renderMockRequests({});
 
     render(<NotificationSettings organizations={[organization]} />, {
-      context: routerContext,
+      router,
     });
 
     // There are 8 notification setting Selects/Toggles.
@@ -46,7 +46,7 @@ describe('NotificationSettings', function () {
   });
 
   it('renders quota section with feature flag', async function () {
-    const {routerContext, organization} = initializeOrg({
+    const {router, organization} = initializeOrg({
       organization: {
         features: ['user-spend-notifications-settings'],
       },
@@ -55,7 +55,7 @@ describe('NotificationSettings', function () {
     renderMockRequests({});
 
     render(<NotificationSettings organizations={[organization]} />, {
-      context: routerContext,
+      router,
     });
 
     // There are 9 notification setting Selects/Toggles.
@@ -78,7 +78,7 @@ describe('NotificationSettings', function () {
   });
 
   it('renders spend section instead of quota section with feature flag', async function () {
-    const {routerContext, organization} = initializeOrg({
+    const {router, organization} = initializeOrg({
       organization: {
         features: ['user-spend-notifications-settings', 'spend-visibility-notifications'],
       },
@@ -90,7 +90,7 @@ describe('NotificationSettings', function () {
     renderMockRequests({});
 
     render(<NotificationSettings organizations={[organization, organizationNoFlag]} />, {
-      context: routerContext,
+      router,
     });
 
     expect(await screen.findByText('Spend')).toBeInTheDocument();

--- a/static/app/views/settings/components/settingsBreadcrumb/breadcrumbTitle.spec.tsx
+++ b/static/app/views/settings/components/settingsBreadcrumb/breadcrumbTitle.spec.tsx
@@ -15,7 +15,7 @@ describe('BreadcrumbTitle', function () {
   ];
 
   it('renders settings breadcrumbs and replaces title', function () {
-    const {routerContext} = initializeOrg({
+    const {router} = initializeOrg({
       router: {
         routes: testRoutes,
       },
@@ -26,7 +26,7 @@ describe('BreadcrumbTitle', function () {
         <SettingsBreadcrumb routes={testRoutes} params={{}} route={{}} />
         <BreadcrumbTitle routes={testRoutes} title="Last Title" />
       </BreadcrumbContextProvider>,
-      {context: routerContext}
+      {router}
     );
 
     const crumbs = screen.getAllByRole('link');
@@ -36,7 +36,7 @@ describe('BreadcrumbTitle', function () {
   });
 
   it('cleans up routes', () => {
-    const {routerContext} = initializeOrg({
+    const {router} = initializeOrg({
       router: {
         routes: testRoutes,
       },
@@ -50,7 +50,7 @@ describe('BreadcrumbTitle', function () {
         <BreadcrumbTitle routes={upOneRoutes} title="Second Title" />
         <BreadcrumbTitle routes={testRoutes} title="Last Title" />
       </BreadcrumbContextProvider>,
-      {context: routerContext}
+      {router}
     );
 
     const crumbs = screen.getAllByRole('link');

--- a/static/app/views/settings/components/settingsBreadcrumb/organizationCrumb.spec.tsx
+++ b/static/app/views/settings/components/settingsBreadcrumb/organizationCrumb.spec.tsx
@@ -14,7 +14,7 @@ jest.unmock('sentry/utils/recreateRoute');
 
 describe('OrganizationCrumb', function () {
   let initialData: Config;
-  const {organization, project, routerContext, routerProps} = initializeOrg();
+  const {organization, project, router, routerProps} = initializeOrg();
   const organizations = [
     organization,
     OrganizationFixture({
@@ -43,7 +43,7 @@ describe('OrganizationCrumb', function () {
     >
   ) =>
     render(<OrganizationCrumb {...routerProps} params={{}} {...props} />, {
-      context: routerContext,
+      router,
       organization,
     });
 

--- a/static/app/views/settings/organizationApiKeys/organizationApiKeyDetails.spec.tsx
+++ b/static/app/views/settings/organizationApiKeys/organizationApiKeyDetails.spec.tsx
@@ -16,9 +16,9 @@ describe('OrganizationApiKeyDetails', function () {
   });
 
   it('renders', function () {
-    const {organization, routerContext, routerProps} = initializeOrg();
+    const {organization, router, routerProps} = initializeOrg();
     render(<OrganizationApiKeyDetails {...routerProps} params={{apiKey: '1'}} />, {
-      context: routerContext,
+      router,
       organization,
     });
 

--- a/static/app/views/settings/organizationAuditLog/auditLogView.spec.tsx
+++ b/static/app/views/settings/organizationAuditLog/auditLogView.spec.tsx
@@ -15,7 +15,7 @@ import OrganizationAuditLog from 'sentry/views/settings/organizationAuditLog';
 // XXX(epurkhiser): This appears to also be tested by ./index.spec.tsx
 
 describe('OrganizationAuditLog', function () {
-  const {routerContext, organization, router} = initializeOrg({
+  const {organization, router} = initializeOrg({
     projects: [],
     router: {
       params: {orgId: 'org-slug'},
@@ -33,7 +33,7 @@ describe('OrganizationAuditLog', function () {
 
   it('renders', async function () {
     render(<OrganizationAuditLog location={router.location} />, {
-      context: routerContext,
+      router,
     });
 
     expect(await screen.findByRole('heading')).toHaveTextContent('Audit Log');
@@ -54,7 +54,7 @@ describe('OrganizationAuditLog', function () {
     });
 
     render(<OrganizationAuditLog location={router.location} />, {
-      context: routerContext,
+      router,
     });
 
     expect(await screen.findByText('No audit entries available')).toBeInTheDocument();
@@ -62,7 +62,7 @@ describe('OrganizationAuditLog', function () {
 
   it('displays whether an action was done by a superuser', async () => {
     render(<OrganizationAuditLog location={router.location} />, {
-      context: routerContext,
+      router,
     });
 
     expect(await screen.findByText('Sentry Staff')).toBeInTheDocument();
@@ -80,7 +80,7 @@ describe('OrganizationAuditLog', function () {
     });
 
     render(<OrganizationAuditLog location={router.location} />, {
-      context: routerContext,
+      router,
     });
 
     await userEvent.click(screen.getByText('Select Action:'));
@@ -123,7 +123,7 @@ describe('OrganizationAuditLog', function () {
     });
 
     render(<OrganizationAuditLog location={router.location} />, {
-      context: routerContext,
+      router,
     });
 
     await waitForElementToBeRemoved(() => screen.getByTestId('loading-indicator'));

--- a/static/app/views/settings/organizationAuditLog/index.spec.tsx
+++ b/static/app/views/settings/organizationAuditLog/index.spec.tsx
@@ -59,7 +59,7 @@ describe('OrganizationAuditLog', function () {
       },
     });
 
-    const {routerContext, router} = initializeOrg({
+    const {router} = initializeOrg({
       projects: [],
       router: {
         params: {orgId: 'org-slug'},
@@ -67,7 +67,7 @@ describe('OrganizationAuditLog', function () {
     });
 
     render(<OrganizationAuditLog location={router.location} />, {
-      context: routerContext,
+      router,
     });
 
     expect(await screen.findByText('project.remove')).toBeInTheDocument();
@@ -77,7 +77,7 @@ describe('OrganizationAuditLog', function () {
   });
 
   it('Displays pretty dynamic sampling logs', async function () {
-    const {routerContext, router, project, projects, organization} = initializeOrg({
+    const {router, project, projects, organization} = initializeOrg({
       router: {
         params: {orgId: 'org-slug'},
       },
@@ -128,7 +128,7 @@ describe('OrganizationAuditLog', function () {
     });
 
     render(<OrganizationAuditLog location={router.location} />, {
-      context: routerContext,
+      router,
     });
 
     // Enabled dynamic sampling priority

--- a/static/app/views/settings/organizationIntegrations/integrationExternalMappings.spec.tsx
+++ b/static/app/views/settings/organizationIntegrations/integrationExternalMappings.spec.tsx
@@ -11,7 +11,7 @@ import {
 import IntegrationExternalMappings from './integrationExternalMappings';
 
 describe('IntegrationExternalMappings', function () {
-  const {organization, routerContext} = initializeOrg();
+  const {organization, router} = initializeOrg();
 
   const onCreateMock = jest.fn();
   const onDeleteMock = jest.fn();
@@ -86,7 +86,7 @@ describe('IntegrationExternalMappings', function () {
         sentryNamesMapper={data => data}
       />,
       {
-        context: routerContext,
+        router,
       }
     );
     expect(container).toHaveTextContent('Set up External User Mappings.');
@@ -108,7 +108,7 @@ describe('IntegrationExternalMappings', function () {
         sentryNamesMapper={data => data}
       />,
       {
-        context: routerContext,
+        router,
       }
     );
 
@@ -135,7 +135,7 @@ describe('IntegrationExternalMappings', function () {
         sentryNamesMapper={data => data}
       />,
       {
-        context: routerContext,
+        router,
       }
     );
 
@@ -168,7 +168,7 @@ describe('IntegrationExternalMappings', function () {
         sentryNamesMapper={data => data}
       />,
       {
-        context: routerContext,
+        router,
       }
     );
     renderGlobalModal();

--- a/static/app/views/settings/organizationIntegrations/integrationListDirectory.spec.tsx
+++ b/static/app/views/settings/organizationIntegrations/integrationListDirectory.spec.tsx
@@ -22,7 +22,7 @@ describe('IntegrationListDirectory', function () {
     MockApiClient.clearMockResponses();
   });
 
-  const {organization: org, routerContext, routerProps} = initializeOrg();
+  const {organization: org, router, routerProps} = initializeOrg();
 
   describe('Renders view', function () {
     beforeEach(() => {
@@ -53,7 +53,7 @@ describe('IntegrationListDirectory', function () {
           hideHeader={false}
         />,
         {
-          context: routerContext,
+          router,
         }
       );
 
@@ -78,7 +78,7 @@ describe('IntegrationListDirectory', function () {
           routeParams={{orgId: org.slug}}
           hideHeader={false}
         />,
-        {context: routerContext}
+        {router}
       );
 
       expect(await screen.findByRole('textbox', {name: 'Filter'})).toBeInTheDocument();
@@ -93,7 +93,7 @@ describe('IntegrationListDirectory', function () {
           routeParams={{orgId: org.slug}}
           hideHeader={false}
         />,
-        {context: routerContext}
+        {router}
       );
 
       expect(await screen.findByText('PagerDuty (Legacy)')).toBeInTheDocument();

--- a/static/app/views/settings/organizationIntegrations/integrationRow.spec.tsx
+++ b/static/app/views/settings/organizationIntegrations/integrationRow.spec.tsx
@@ -4,7 +4,7 @@ import {render, screen} from 'sentry-test/reactTestingLibrary';
 import IntegrationRow from 'sentry/views/settings/organizationIntegrations/integrationRow';
 
 describe('IntegrationRow', function () {
-  const {organization: org, routerContext} = initializeOrg();
+  const {organization: org, router} = initializeOrg();
 
   describe('SentryApp', function () {
     it('is an internal SentryApp', function () {
@@ -37,7 +37,7 @@ describe('IntegrationRow', function () {
           configurations={0}
           categories={[]}
         />,
-        {context: routerContext}
+        {router}
       );
       expect(screen.getByText('ClickUp')).toBeInTheDocument();
       expect(screen.getByText('ClickUp')).toHaveAttribute(
@@ -60,7 +60,7 @@ describe('IntegrationRow', function () {
           configurations={1}
           categories={[]}
         />,
-        {context: routerContext}
+        {router}
       );
       expect(screen.getByText('Bitbucket')).toBeInTheDocument();
       expect(screen.getByText('Bitbucket')).toHaveAttribute(
@@ -82,7 +82,7 @@ describe('IntegrationRow', function () {
           configurations={3}
           categories={[]}
         />,
-        {context: routerContext}
+        {router}
       );
       expect(screen.getByText('Installed')).toBeInTheDocument();
       expect(screen.getByText('Bitbucket')).toHaveAttribute(
@@ -104,7 +104,7 @@ describe('IntegrationRow', function () {
           configurations={0}
           categories={[]}
         />,
-        {context: routerContext}
+        {router}
       );
       expect(screen.getByText('Not Installed')).toBeInTheDocument();
       expect(screen.getByText('Github')).toHaveAttribute(
@@ -126,7 +126,7 @@ describe('IntegrationRow', function () {
           configurations={1}
           categories={[]}
         />,
-        {context: routerContext}
+        {router}
       );
       expect(screen.getByText('Installed')).toBeInTheDocument();
       expect(screen.getByText('1 Configuration')).toBeInTheDocument();
@@ -148,7 +148,7 @@ describe('IntegrationRow', function () {
           configurations={3}
           categories={[]}
         />,
-        {context: routerContext}
+        {router}
       );
       expect(screen.getByText('Installed')).toBeInTheDocument();
       expect(screen.getByText('3 Configurations')).toBeInTheDocument();

--- a/static/app/views/settings/organizationMembers/organizationMemberDetail.spec.tsx
+++ b/static/app/views/settings/organizationMembers/organizationMemberDetail.spec.tsx
@@ -138,12 +138,12 @@ describe('OrganizationMemberDetail', function () {
     });
 
     it('changes org role to owner', async function () {
-      const {routerContext, routerProps} = initializeOrg({organization});
+      const {router, routerProps} = initializeOrg({organization});
 
       render(
         <OrganizationMemberDetail {...routerProps} params={{memberId: member.id}} />,
         {
-          context: routerContext,
+          router,
           organization,
         }
       );
@@ -170,12 +170,12 @@ describe('OrganizationMemberDetail', function () {
     });
 
     it('leaves a team', async function () {
-      const {routerContext, routerProps} = initializeOrg({organization});
+      const {router, routerProps} = initializeOrg({organization});
 
       render(
         <OrganizationMemberDetail {...routerProps} params={{memberId: member.id}} />,
         {
-          context: routerContext,
+          router,
           organization,
         }
       );
@@ -197,7 +197,7 @@ describe('OrganizationMemberDetail', function () {
     });
 
     it('cannot leave idp-provisioned team', function () {
-      const {routerContext, routerProps} = initializeOrg({organization});
+      const {router, routerProps} = initializeOrg({organization});
 
       render(
         <OrganizationMemberDetail
@@ -205,7 +205,7 @@ describe('OrganizationMemberDetail', function () {
           params={{memberId: idpTeamMember.id}}
         />,
         {
-          context: routerContext,
+          router,
           organization,
         }
       );
@@ -214,12 +214,12 @@ describe('OrganizationMemberDetail', function () {
     });
 
     it('joins a team and assign a team-role', async function () {
-      const {routerContext, routerProps} = initializeOrg({organization});
+      const {router, routerProps} = initializeOrg({organization});
 
       render(
         <OrganizationMemberDetail {...routerProps} params={{memberId: member.id}} />,
         {
-          context: routerContext,
+          router,
           organization,
         }
       );
@@ -254,12 +254,12 @@ describe('OrganizationMemberDetail', function () {
     });
 
     it('cannot join idp-provisioned team', async function () {
-      const {routerContext, routerProps} = initializeOrg({organization});
+      const {router, routerProps} = initializeOrg({organization});
 
       render(
         <OrganizationMemberDetail {...routerProps} params={{memberId: member.id}} />,
         {
-          context: routerContext,
+          router,
           organization,
         }
       );
@@ -302,12 +302,12 @@ describe('OrganizationMemberDetail', function () {
     });
 
     it('can not change roles, teams, or save', function () {
-      const {routerContext, routerProps} = initializeOrg({organization});
+      const {router, routerProps} = initializeOrg({organization});
 
       render(
         <OrganizationMemberDetail {...routerProps} params={{memberId: member.id}} />,
         {
-          context: routerContext,
+          router,
           organization,
         }
       );
@@ -349,7 +349,7 @@ describe('OrganizationMemberDetail', function () {
     });
 
     it('display pending status', function () {
-      const {routerContext, routerProps} = initializeOrg({organization});
+      const {router, routerProps} = initializeOrg({organization});
 
       render(
         <OrganizationMemberDetail
@@ -357,7 +357,7 @@ describe('OrganizationMemberDetail', function () {
           params={{memberId: pendingMember.id}}
         />,
         {
-          context: routerContext,
+          router,
           organization,
         }
       );
@@ -366,7 +366,7 @@ describe('OrganizationMemberDetail', function () {
     });
 
     it('display expired status', function () {
-      const {routerContext, routerProps} = initializeOrg({organization});
+      const {router, routerProps} = initializeOrg({organization});
 
       render(
         <OrganizationMemberDetail
@@ -374,7 +374,7 @@ describe('OrganizationMemberDetail', function () {
           params={{memberId: expiredMember.id}}
         />,
         {
-          context: routerContext,
+          router,
           organization,
         }
       );
@@ -411,7 +411,7 @@ describe('OrganizationMemberDetail', function () {
     });
 
     it('shows for pending', function () {
-      const {routerContext, routerProps} = initializeOrg({organization});
+      const {router, routerProps} = initializeOrg({organization});
 
       render(
         <OrganizationMemberDetail
@@ -419,7 +419,7 @@ describe('OrganizationMemberDetail', function () {
           params={{memberId: pendingMember.id}}
         />,
         {
-          context: routerContext,
+          router,
           organization,
         }
       );
@@ -428,7 +428,7 @@ describe('OrganizationMemberDetail', function () {
     });
 
     it('does not show for expired', function () {
-      const {routerContext, routerProps} = initializeOrg({organization});
+      const {router, routerProps} = initializeOrg({organization});
 
       render(
         <OrganizationMemberDetail
@@ -436,7 +436,7 @@ describe('OrganizationMemberDetail', function () {
           params={{memberId: expiredMember.id}}
         />,
         {
-          context: routerContext,
+          router,
           organization,
         }
       );
@@ -540,7 +540,7 @@ describe('OrganizationMemberDetail', function () {
     };
 
     it('does not show for pending member', function () {
-      const {routerContext, routerProps} = initializeOrg({organization});
+      const {router, routerProps} = initializeOrg({organization});
 
       render(
         <OrganizationMemberDetail
@@ -548,7 +548,7 @@ describe('OrganizationMemberDetail', function () {
           params={{memberId: pendingMember.id}}
         />,
         {
-          context: routerContext,
+          router,
           organization,
         }
       );
@@ -556,12 +556,12 @@ describe('OrganizationMemberDetail', function () {
     });
 
     it('shows tooltip for joined member without permission to edit', async function () {
-      const {routerContext, routerProps} = initializeOrg({organization});
+      const {router, routerProps} = initializeOrg({organization});
 
       render(
         <OrganizationMemberDetail {...routerProps} params={{memberId: noAccess.id}} />,
         {
-          context: routerContext,
+          router,
           organization,
         }
       );
@@ -569,12 +569,12 @@ describe('OrganizationMemberDetail', function () {
     });
 
     it('shows tooltip for member without 2fa', async function () {
-      const {routerContext, routerProps} = initializeOrg({organization});
+      const {router, routerProps} = initializeOrg({organization});
 
       render(
         <OrganizationMemberDetail {...routerProps} params={{memberId: no2fa.id}} />,
         {
-          context: routerContext,
+          router,
           organization,
         }
       );
@@ -582,7 +582,7 @@ describe('OrganizationMemberDetail', function () {
     });
 
     it('can reset member 2FA', async function () {
-      const {routerContext, routerProps} = initializeOrg({organization});
+      const {router, routerProps} = initializeOrg({organization});
 
       const deleteMocks = (has2fa.user?.authenticators || []).map(auth =>
         MockApiClient.addMockResponse({
@@ -594,7 +594,7 @@ describe('OrganizationMemberDetail', function () {
       render(
         <OrganizationMemberDetail {...routerProps} params={{memberId: has2fa.id}} />,
         {
-          context: routerContext,
+          router,
           organization,
         }
       );
@@ -611,7 +611,7 @@ describe('OrganizationMemberDetail', function () {
     });
 
     it('shows tooltip for member in multiple orgs', async function () {
-      const {routerContext, routerProps} = initializeOrg({organization});
+      const {router, routerProps} = initializeOrg({organization});
 
       render(
         <OrganizationMemberDetail
@@ -619,7 +619,7 @@ describe('OrganizationMemberDetail', function () {
           params={{memberId: multipleOrgs.id}}
         />,
         {
-          context: routerContext,
+          router,
           organization,
         }
       );
@@ -630,7 +630,7 @@ describe('OrganizationMemberDetail', function () {
 
     it('shows tooltip for member in 2FA required org', async function () {
       organization.require2FA = true;
-      const {routerContext, routerProps} = initializeOrg({organization});
+      const {router, routerProps} = initializeOrg({organization});
       MockApiClient.addMockResponse({
         url: `/organizations/${organization.slug}/members/${has2fa.id}/`,
         body: has2fa,
@@ -639,7 +639,7 @@ describe('OrganizationMemberDetail', function () {
       render(
         <OrganizationMemberDetail {...routerProps} params={{memberId: has2fa.id}} />,
         {
-          context: routerContext,
+          router,
           organization,
         }
       );
@@ -696,12 +696,12 @@ describe('OrganizationMemberDetail', function () {
     });
 
     it('does not overwrite team-roles for org members', async () => {
-      const {routerContext, routerProps} = initializeOrg({organization});
+      const {router, routerProps} = initializeOrg({organization});
 
       render(
         <OrganizationMemberDetail {...routerProps} params={{memberId: member.id}} />,
         {
-          context: routerContext,
+          router,
           organization,
         }
       );
@@ -726,7 +726,7 @@ describe('OrganizationMemberDetail', function () {
     });
 
     it('overwrite team-roles for org admin/manager/owner', async () => {
-      const {routerContext, routerProps} = initializeOrg({organization});
+      const {router, routerProps} = initializeOrg({organization});
 
       async function testForOrgRole(testMember) {
         cleanup();
@@ -736,7 +736,7 @@ describe('OrganizationMemberDetail', function () {
             params={{memberId: testMember.id}}
           />,
           {
-            context: routerContext,
+            router,
             organization,
           }
         );
@@ -762,12 +762,12 @@ describe('OrganizationMemberDetail', function () {
     });
 
     it('overwrites when changing from member to manager', async () => {
-      const {routerContext, routerProps} = initializeOrg({organization});
+      const {router, routerProps} = initializeOrg({organization});
 
       render(
         <OrganizationMemberDetail {...routerProps} params={{memberId: member.id}} />,
         {
-          context: routerContext,
+          router,
           organization,
         }
       );

--- a/static/app/views/settings/organizationMembers/organizationMembersList.spec.tsx
+++ b/static/app/views/settings/organizationMembers/organizationMembersList.spec.tsx
@@ -2,7 +2,6 @@ import {AuthProviderFixture} from 'sentry-fixture/authProvider';
 import {MemberFixture} from 'sentry-fixture/member';
 import {MembersFixture} from 'sentry-fixture/members';
 import {OrganizationFixture} from 'sentry-fixture/organization';
-import {RouterContextFixture} from 'sentry-fixture/routerContextFixture';
 import {RouterFixture} from 'sentry-fixture/routerFixture';
 import {TeamFixture} from 'sentry-fixture/team';
 import {UserFixture} from 'sentry-fixture/user';
@@ -328,10 +327,8 @@ describe('OrganizationMembersList', function () {
       body: [],
     });
 
-    const routerContext = RouterContextFixture();
-
     render(<OrganizationMembersList {...defaultProps} />, {
-      context: routerContext,
+      router,
     });
 
     await userEvent.type(screen.getByPlaceholderText('Search Members'), 'member');
@@ -348,7 +345,7 @@ describe('OrganizationMembersList', function () {
 
     await userEvent.keyboard('{enter}');
 
-    expect(routerContext.context.router.push).toHaveBeenCalledTimes(1);
+    expect(router.push).toHaveBeenCalledTimes(1);
   });
 
   it('can filter members', async function () {

--- a/static/app/views/settings/organizationProjects/index.spec.tsx
+++ b/static/app/views/settings/organizationProjects/index.spec.tsx
@@ -1,6 +1,5 @@
 import {ProjectFixture} from 'sentry-fixture/project';
 
-import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
 import {browserHistory} from 'sentry/utils/browserHistory';
@@ -11,7 +10,6 @@ describe('OrganizationProjects', function () {
   let statsGetMock: jest.Mock;
   let projectsPutMock: jest.Mock;
   const project = ProjectFixture();
-  const {routerContext} = initializeOrg();
 
   beforeEach(function () {
     projectsGetMock = MockApiClient.addMockResponse({
@@ -53,9 +51,7 @@ describe('OrganizationProjects', function () {
 
   it('should search organization projects', async function () {
     jest.useFakeTimers();
-    render(<OrganizationProjectsContainer />, {
-      context: routerContext,
-    });
+    render(<OrganizationProjectsContainer />);
 
     expect(await screen.findByText('project-slug')).toBeInTheDocument();
 

--- a/static/app/views/settings/organizationRepositories/index.spec.tsx
+++ b/static/app/views/settings/organizationRepositories/index.spec.tsx
@@ -1,10 +1,8 @@
-import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render} from 'sentry-test/reactTestingLibrary';
 
 import OrganizationRepositoriesContainer from 'sentry/views/settings/organizationRepositories';
 
 describe('OrganizationRepositoriesContainer', function () {
-  const {routerContext} = initializeOrg();
   beforeEach(function () {
     MockApiClient.clearMockResponses();
   });
@@ -22,7 +20,7 @@ describe('OrganizationRepositoriesContainer', function () {
     });
 
     it('is loading when initially rendering', function () {
-      render(<OrganizationRepositoriesContainer />, {context: routerContext});
+      render(<OrganizationRepositoriesContainer />);
     });
   });
 });

--- a/static/app/views/settings/organizationTeams/teamDetails.spec.tsx
+++ b/static/app/views/settings/organizationTeams/teamDetails.spec.tsx
@@ -29,7 +29,7 @@ describe('TeamMembers', () => {
   });
 
   it('can request membership', async () => {
-    const {routerProps, routerContext} = initializeOrg({
+    const {routerProps, router} = initializeOrg({
       organization,
       router: {
         params: {orgId: organization.slug, teamId: team.slug},
@@ -40,7 +40,7 @@ describe('TeamMembers', () => {
       <TeamDetails {...routerProps}>
         <div data-test-id="test" />
       </TeamDetails>,
-      {organization, context: routerContext}
+      {organization, router}
     );
 
     await userEvent.click(screen.getByRole('button', {name: 'Request Access'}));
@@ -50,7 +50,7 @@ describe('TeamMembers', () => {
   });
 
   it('displays children', () => {
-    const {routerContext, routerProps} = initializeOrg({
+    const {router, routerProps} = initializeOrg({
       organization,
       router: {
         params: {orgId: organization.slug, teamId: teamHasAccess.slug},
@@ -60,7 +60,7 @@ describe('TeamMembers', () => {
       <TeamDetails {...routerProps}>
         <div data-test-id="test" />
       </TeamDetails>,
-      {organization, context: routerContext}
+      {organization, router}
     );
 
     expect(screen.getByTestId('test')).toBeInTheDocument();

--- a/static/app/views/settings/organizationTeams/teamMembers.spec.tsx
+++ b/static/app/views/settings/organizationTeams/teamMembers.spec.tsx
@@ -168,7 +168,7 @@ describe('TeamMembers', function () {
   });
 
   it('can invite member from team dropdown with access', async function () {
-    const {organization: org, routerContext} = initializeOrg({
+    const {organization: org} = initializeOrg({
       organization: OrganizationFixture({
         access: ['team:admin'],
         openMembership: false,
@@ -181,7 +181,7 @@ describe('TeamMembers', function () {
         organization={org}
         team={team}
       />,
-      {context: routerContext}
+      {router}
     );
 
     await userEvent.click(
@@ -193,7 +193,7 @@ describe('TeamMembers', function () {
   });
 
   it('can invite member from team dropdown with access and `Open Membership` enabled', async function () {
-    const {organization: org, routerContext} = initializeOrg({
+    const {organization: org} = initializeOrg({
       organization: OrganizationFixture({
         access: ['team:admin'],
         openMembership: true,
@@ -206,7 +206,7 @@ describe('TeamMembers', function () {
         organization={org}
         team={team}
       />,
-      {context: routerContext}
+      {router}
     );
 
     await userEvent.click(
@@ -218,7 +218,7 @@ describe('TeamMembers', function () {
   });
 
   it('can invite member from team dropdown without access and `Open Membership` enabled', async function () {
-    const {organization: org, routerContext} = initializeOrg({
+    const {organization: org} = initializeOrg({
       organization: OrganizationFixture({access: [], openMembership: true}),
     });
     render(
@@ -228,7 +228,7 @@ describe('TeamMembers', function () {
         organization={org}
         team={team}
       />,
-      {context: routerContext}
+      {router}
     );
 
     await userEvent.click(
@@ -240,7 +240,7 @@ describe('TeamMembers', function () {
   });
 
   it('can invite member from team dropdown without access and `Open Membership` disabled', async function () {
-    const {organization: org, routerContext} = initializeOrg({
+    const {organization: org} = initializeOrg({
       organization: OrganizationFixture({access: [], openMembership: false}),
     });
     render(
@@ -250,7 +250,7 @@ describe('TeamMembers', function () {
         organization={org}
         team={team}
       />,
-      {context: routerContext}
+      {router}
     );
 
     await userEvent.click(

--- a/static/app/views/settings/organizationTeams/teamNotifications.spec.tsx
+++ b/static/app/views/settings/organizationTeams/teamNotifications.spec.tsx
@@ -25,7 +25,7 @@ const EXAMPLE_INTEGRATION = {
 };
 
 describe('TeamNotificationSettings', () => {
-  const {organization, routerContext, routerProps} = initializeOrg();
+  const {organization, router, routerProps} = initializeOrg();
   const team = TeamFixture();
 
   beforeEach(() => {
@@ -52,7 +52,7 @@ describe('TeamNotificationSettings', () => {
         params={{teamId: team.id}}
         organization={organization}
       />,
-      {context: routerContext}
+      {router}
     );
 
     expect(
@@ -81,7 +81,7 @@ describe('TeamNotificationSettings', () => {
         organization={organization}
       />,
       {
-        context: routerContext,
+        router,
       }
     );
 
@@ -109,7 +109,7 @@ describe('TeamNotificationSettings', () => {
         organization={organization}
       />,
       {
-        context: routerContext,
+        router,
       }
     );
 
@@ -149,7 +149,7 @@ describe('TeamNotificationSettings', () => {
         organization={organization}
       />,
       {
-        context: routerContext,
+        router,
       }
     );
 

--- a/static/app/views/settings/organizationTeams/teamProjects.spec.tsx
+++ b/static/app/views/settings/organizationTeams/teamProjects.spec.tsx
@@ -25,7 +25,7 @@ describe('OrganizationTeamProjects', function () {
     access: ['project:read', 'project:write', 'project:admin'],
   });
 
-  const {routerContext, routerProps, organization} = initializeOrg({
+  const {router, routerProps, organization} = initializeOrg({
     organization: OrganizationFixture({slug: 'org-slug'}),
     projects: [project, project2],
     router: {params: {teamId: team.slug}},
@@ -64,7 +64,7 @@ describe('OrganizationTeamProjects', function () {
 
   it('should fetch linked and unlinked projects', async function () {
     render(<OrganizationTeamProjects {...routerProps} team={team} />, {
-      context: routerContext,
+      router,
       organization,
     });
 
@@ -78,7 +78,7 @@ describe('OrganizationTeamProjects', function () {
 
   it('should allow bookmarking', async function () {
     render(<OrganizationTeamProjects {...routerProps} team={team} />, {
-      context: routerContext,
+      router,
       organization,
     });
 
@@ -101,7 +101,7 @@ describe('OrganizationTeamProjects', function () {
 
   it('should allow adding and removing projects', async function () {
     render(<OrganizationTeamProjects {...routerProps} team={team} />, {
-      context: routerContext,
+      router,
       organization,
     });
 
@@ -121,7 +121,7 @@ describe('OrganizationTeamProjects', function () {
 
   it('handles filtering unlinked projects', async function () {
     render(<OrganizationTeamProjects {...routerProps} team={team} />, {
-      context: routerContext,
+      router,
       organization,
     });
 

--- a/static/app/views/settings/project/projectReplays.spec.tsx
+++ b/static/app/views/settings/project/projectReplays.spec.tsx
@@ -6,7 +6,7 @@ import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 import ProjectReplays from 'sentry/views/settings/project/projectReplays';
 
 describe('ProjectReplays', function () {
-  const {routerProps, organization, project, routerContext} = initializeOrg();
+  const {routerProps, organization, project, router} = initializeOrg();
   const url = `/projects/${organization.slug}/${project.slug}/`;
 
   beforeEach(function () {
@@ -27,7 +27,7 @@ describe('ProjectReplays', function () {
     render(
       <ProjectReplays {...routerProps} organization={organization} project={project} />,
       {
-        context: routerContext,
+        router,
       }
     );
 

--- a/static/app/views/settings/projectDebugFiles/sources/customRepositories/index.spec.tsx
+++ b/static/app/views/settings/projectDebugFiles/sources/customRepositories/index.spec.tsx
@@ -60,7 +60,7 @@ function TestComponent({
 }
 
 function getProps(props?: Parameters<typeof initializeOrg>[0]) {
-  const {organization, router, project, routerContext} = initializeOrg({
+  const {organization, router, project} = initializeOrg({
     router: props?.router,
   });
 
@@ -71,7 +71,6 @@ function getProps(props?: Parameters<typeof initializeOrg>[0]) {
     router,
     isLoading: false,
     location: router.location,
-    routerContext,
   };
 }
 
@@ -111,9 +110,7 @@ describe('Custom Repositories', function () {
   it('renders', async function () {
     const props = getProps();
 
-    const {rerender} = render(<TestComponent {...props} />, {
-      context: props.routerContext,
-    });
+    const {rerender} = render(<TestComponent {...props} />, {router: props.router});
 
     // Section title
     expect(screen.getByText('Custom Repositories')).toBeInTheDocument();
@@ -207,7 +204,7 @@ describe('Custom Repositories', function () {
 
     const {rerender} = render(
       <TestComponent {...props} organization={newOrganization} />,
-      {context: props.routerContext}
+      {router: props.router}
     );
 
     // Section title
@@ -270,7 +267,7 @@ describe('Custom Repositories', function () {
         organization={newOrganization}
         customRepositories={[httpRepository, appStoreConnectRepository]}
       />,
-      {context: props.routerContext}
+      {router: props.router}
     );
 
     // Section title
@@ -319,7 +316,7 @@ describe('Custom Repositories', function () {
         organization={newOrganization}
         customRepositories={[httpRepository, appStoreConnectRepository]}
       />,
-      {context: props.routerContext}
+      {router: props.router}
     );
 
     // Content
@@ -356,7 +353,7 @@ describe('Custom Repositories', function () {
           organization={props.organization}
           customRepositories={[httpRepository, appStoreConnectRepository]}
         />,
-        {context: props.routerContext}
+        {router: props.router}
       );
 
       const syncNowButton = screen.getByRole('button', {name: 'Sync Now'});
@@ -410,7 +407,7 @@ describe('Custom Repositories', function () {
           customRepositories={[httpRepository, appStoreConnectRepository]}
           credetialsStatus={{status: 'invalid', code: 'app-connect-authentication-error'}}
         />,
-        {context: props.routerContext}
+        {router: props.router}
       );
 
       const syncNowButton = screen.getByRole('button', {name: 'Sync Now'});
@@ -436,7 +433,7 @@ describe('Custom Repositories', function () {
           organization={props.organization}
           customRepositories={[httpRepository]}
         />,
-        {context: props.routerContext}
+        {router: props.router}
       );
 
       expect(screen.queryByRole('button', {name: 'Sync Now'})).not.toBeInTheDocument();
@@ -488,7 +485,7 @@ describe('Custom Repositories', function () {
           organization={props.organization}
           customRepositories={[appStoreConnectRepository]}
         />,
-        {context: props.routerContext}
+        {router: props.router}
       );
 
       // Display modal content
@@ -530,7 +527,7 @@ describe('Custom Repositories', function () {
           organization={props.organization}
           customRepositories={[appStoreConnectRepository]}
         />,
-        {context: props.routerContext}
+        {router: props.router}
       );
 
       // Display modal content

--- a/static/app/views/settings/projectSourceMaps/projectSourceMaps.spec.tsx
+++ b/static/app/views/settings/projectSourceMaps/projectSourceMaps.spec.tsx
@@ -66,7 +66,7 @@ function renderDebugIdBundlesMockRequests({
 describe('ProjectSourceMaps', function () {
   describe('Release Bundles', function () {
     it('renders default state', async function () {
-      const {organization, project, routerContext, routerProps} = initializeOrg({
+      const {organization, project, router, routerProps} = initializeOrg({
         router: {
           location: {
             query: {},
@@ -83,7 +83,7 @@ describe('ProjectSourceMaps', function () {
       });
 
       render(<ProjectSourceMaps project={project} {...routerProps} />, {
-        context: routerContext,
+        router,
         organization,
       });
 
@@ -170,7 +170,7 @@ describe('ProjectSourceMaps', function () {
     });
 
     it('renders empty state', async function () {
-      const {organization, project, routerContext, routerProps} = initializeOrg({
+      const {organization, project, router, routerProps} = initializeOrg({
         router: {
           location: {
             query: {},
@@ -188,7 +188,7 @@ describe('ProjectSourceMaps', function () {
       });
 
       render(<ProjectSourceMaps project={project} {...routerProps} />, {
-        context: routerContext,
+        router,
         organization,
       });
 
@@ -200,7 +200,7 @@ describe('ProjectSourceMaps', function () {
 
   describe('Artifact Bundles', function () {
     it('renders default state', async function () {
-      const {organization, project, routerContext, router, routerProps} = initializeOrg({
+      const {organization, project, router, routerProps} = initializeOrg({
         router: {
           location: {
             query: {},
@@ -217,7 +217,7 @@ describe('ProjectSourceMaps', function () {
       });
 
       render(<ProjectSourceMaps project={project} {...routerProps} />, {
-        context: routerContext,
+        router,
         organization,
       });
       expect(mockRequests.artifactBundles).toHaveBeenCalledTimes(1);
@@ -305,7 +305,7 @@ describe('ProjectSourceMaps', function () {
     });
 
     it('renders empty state', async function () {
-      const {organization, project, routerProps, routerContext} = initializeOrg({
+      const {organization, project, routerProps, router} = initializeOrg({
         router: {
           location: {
             query: {},
@@ -323,7 +323,7 @@ describe('ProjectSourceMaps', function () {
       });
 
       render(<ProjectSourceMaps project={project} {...routerProps} />, {
-        context: routerContext,
+        router,
         organization,
       });
 

--- a/static/app/views/settings/projectSourceMaps/projectSourceMapsArtifacts.spec.tsx
+++ b/static/app/views/settings/projectSourceMaps/projectSourceMapsArtifacts.spec.tsx
@@ -86,7 +86,7 @@ describe('ProjectSourceMapsArtifacts', function () {
 
   describe('Release Bundles', function () {
     it('renders default state', async function () {
-      const {organization, routerContext, project, routerProps} = initializeOrg({
+      const {organization, router, project, routerProps} = initializeOrg({
         organization: OrganizationFixture({
           access: ['org:superuser'],
         }),
@@ -120,7 +120,7 @@ describe('ProjectSourceMapsArtifacts', function () {
             bundleId: 'bea7335dfaebc0ca6e65a057',
           }}
         />,
-        {context: routerContext, organization}
+        {router, organization}
       );
 
       // Title
@@ -148,7 +148,7 @@ describe('ProjectSourceMapsArtifacts', function () {
     });
 
     it('renders empty state', async function () {
-      const {organization, routerProps, project, routerContext} = initializeOrg({
+      const {organization, routerProps, project, router} = initializeOrg({
         router: {
           location: {
             query: {},
@@ -173,7 +173,7 @@ describe('ProjectSourceMapsArtifacts', function () {
             bundleId: 'bea7335dfaebc0ca6e65a057',
           }}
         />,
-        {context: routerContext, organization}
+        {router, organization}
       );
 
       expect(
@@ -184,7 +184,7 @@ describe('ProjectSourceMapsArtifacts', function () {
 
   describe('Artifact Bundles', function () {
     it('renders default state', async function () {
-      const {organization, project, routerProps, routerContext} = initializeOrg({
+      const {organization, project, routerProps, router} = initializeOrg({
         organization: OrganizationFixture({
           access: ['org:superuser', 'project:releases'],
         }),
@@ -221,7 +221,7 @@ describe('ProjectSourceMapsArtifacts', function () {
             bundleId: '7227e105-744e-4066-8c69-3e5e344723fc',
           }}
         />,
-        {context: routerContext, organization}
+        {router, organization}
       );
 
       // Title
@@ -288,7 +288,7 @@ describe('ProjectSourceMapsArtifacts', function () {
     });
 
     it('renders empty state', async function () {
-      const {organization, project, routerProps, routerContext} = initializeOrg({
+      const {organization, project, routerProps, router} = initializeOrg({
         router: {
           location: {
             pathname: `/settings/${initializeOrg().organization.slug}/projects/${
@@ -316,7 +316,7 @@ describe('ProjectSourceMapsArtifacts', function () {
             bundleId: '7227e105-744e-4066-8c69-3e5e344723fc',
           }}
         />,
-        {context: routerContext, organization}
+        {router, organization}
       );
 
       expect(

--- a/static/app/views/settings/projectUserFeedback/index.spec.tsx
+++ b/static/app/views/settings/projectUserFeedback/index.spec.tsx
@@ -6,7 +6,7 @@ import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 import ProjectUserFeedback from 'sentry/views/settings/projectUserFeedback';
 
 describe('ProjectUserFeedback', function () {
-  const {routerProps, organization, project, routerContext} = initializeOrg();
+  const {routerProps, organization, project, router} = initializeOrg();
   const url = `/projects/${organization.slug}/${project.slug}/`;
 
   beforeEach(function () {
@@ -31,7 +31,7 @@ describe('ProjectUserFeedback', function () {
         project={project}
       />,
       {
-        context: routerContext,
+        router,
       }
     );
 
@@ -57,7 +57,7 @@ describe('ProjectUserFeedback', function () {
 });
 
 describe('ProjectUserFeedbackProcessing', function () {
-  const {routerProps, organization, project, routerContext} = initializeOrg();
+  const {routerProps, organization, project, router} = initializeOrg();
   const url = `/projects/${organization.slug}/${project.slug}/`;
 
   beforeEach(function () {
@@ -82,7 +82,7 @@ describe('ProjectUserFeedbackProcessing', function () {
         project={project}
       />,
       {
-        context: routerContext,
+        router,
       }
     );
 

--- a/static/app/views/unsubscribe/issue.spec.tsx
+++ b/static/app/views/unsubscribe/issue.spec.tsx
@@ -25,7 +25,7 @@ describe('UnsubscribeIssue', function () {
   });
 
   it('loads data from the API based on URL parameters', async function () {
-    const {router, routerProps, routerContext} = initializeOrg({
+    const {router, routerProps} = initializeOrg({
       router: {
         location: {query: {_: 'signature-value'}},
         params,
@@ -33,7 +33,7 @@ describe('UnsubscribeIssue', function () {
     });
     render(
       <UnsubscribeIssue {...routerProps} location={router.location} params={params} />,
-      {context: routerContext}
+      {router}
     );
 
     expect(await screen.findByText('selected issue')).toBeInTheDocument();
@@ -43,7 +43,7 @@ describe('UnsubscribeIssue', function () {
   });
 
   it('makes an API request when the form is submitted', async function () {
-    const {router, routerProps, routerContext} = initializeOrg({
+    const {router, routerProps} = initializeOrg({
       router: {
         location: {query: {_: 'signature-value'}},
         params,
@@ -51,7 +51,7 @@ describe('UnsubscribeIssue', function () {
     });
     render(
       <UnsubscribeIssue {...routerProps} location={router.location} params={params} />,
-      {context: routerContext}
+      {router}
     );
 
     expect(await screen.findByText('selected issue')).toBeInTheDocument();

--- a/static/app/views/unsubscribe/project.spec.tsx
+++ b/static/app/views/unsubscribe/project.spec.tsx
@@ -26,12 +26,12 @@ describe('UnsubscribeProject', function () {
   });
 
   it('loads data from the API based on URL parameters', async function () {
-    const {router, routerProps, routerContext} = initializeOrg({
+    const {router, routerProps} = initializeOrg({
       router: {location: {query: {_: 'signature-value'}}, params},
     });
     render(
       <UnsubscribeProject {...routerProps} location={router.location} params={params} />,
-      {context: routerContext}
+      {router}
     );
 
     expect(await screen.findByText('acme / react')).toBeInTheDocument();
@@ -40,12 +40,12 @@ describe('UnsubscribeProject', function () {
   });
 
   it('makes an API request when the form is submitted', async function () {
-    const {router, routerProps, routerContext} = initializeOrg({
+    const {router, routerProps} = initializeOrg({
       router: {location: {query: {_: 'signature-value'}}, params},
     });
     render(
       <UnsubscribeProject {...routerProps} location={router.location} params={params} />,
-      {context: routerContext}
+      {router}
     );
 
     expect(await screen.findByText('acme / react')).toBeInTheDocument();

--- a/static/app/views/userFeedback/index.spec.tsx
+++ b/static/app/views/userFeedback/index.spec.tsx
@@ -10,7 +10,7 @@ import ProjectsStore from 'sentry/stores/projectsStore';
 import UserFeedback from 'sentry/views/userFeedback';
 
 describe('UserFeedback', function () {
-  const {organization, router, routerContext} = initializeOrg();
+  const {organization, router} = initializeOrg();
   const pageLinks =
     '<https://sentry.io/api/0/organizations/sentry/user-feedback/?statsPeriod=14d&cursor=0:0:1>; rel="previous"; results="false"; cursor="0:0:1", ' +
     '<https://sentry.io/api/0/organizations/sentry/user-feedback/?statsPeriod=14d&cursor=0:100:0>; rel="next"; results="true"; cursor="0:100:0"';
@@ -59,7 +59,7 @@ describe('UserFeedback', function () {
       headers: {Link: pageLinks},
     });
 
-    render(<UserFeedback {...params} />, {context: routerContext});
+    render(<UserFeedback {...params} />);
 
     expect(await screen.findByText('Something bad happened')).toBeInTheDocument();
   });
@@ -74,7 +74,7 @@ describe('UserFeedback', function () {
       },
       ...routeProps,
     };
-    render(<UserFeedback {...params} />, {context: routerContext});
+    render(<UserFeedback {...params} />);
 
     expect(
       screen.getByText('You need at least one project to use this view')
@@ -96,7 +96,7 @@ describe('UserFeedback', function () {
       },
       ...routeProps,
     };
-    render(<UserFeedback {...params} />, {context: routerContext});
+    render(<UserFeedback {...params} />);
 
     expect(await screen.findByTestId('user-feedback-empty')).toBeInTheDocument();
   });
@@ -122,7 +122,7 @@ describe('UserFeedback', function () {
         orgId: organization.slug,
       },
     };
-    render(<UserFeedback {...params} />, {context: routerContext});
+    render(<UserFeedback {...params} />);
 
     expect(await screen.findByTestId('user-feedback-empty')).toBeInTheDocument();
   });
@@ -137,7 +137,7 @@ describe('UserFeedback', function () {
       },
       ...routeProps,
     };
-    render(<UserFeedback {...params} />, {context: routerContext});
+    render(<UserFeedback {...params} />);
 
     // "Unresolved"  is selected by default
     const unresolved = screen.getByRole('radio', {name: 'Unresolved'});
@@ -176,7 +176,7 @@ describe('UserFeedback', function () {
         orgId: organization.slug,
       },
     };
-    render(<UserFeedback {...params} />, {context: routerContext});
+    render(<UserFeedback {...params} />);
 
     expect(await screen.findByTestId('user-feedback-empty')).toBeInTheDocument();
   });


### PR DESCRIPTION
This is replaced with `router`. We already had this and there were
simply two ways of doing things.