### PR TITLE
fix(contexts): Fix casing for known context

### DIFF
--- a/static/app/components/events/contexts/utils.tsx
+++ b/static/app/components/events/contexts/utils.tsx
@@ -317,6 +317,16 @@ export function getContextTitle({
       return t('App');
     case 'device':
       return t('Device');
+    case 'browser':
+      return t('Browser');
+    case 'profile':
+      return t('Profile');
+    case 'replay':
+      return t('Replay');
+    case 'response':
+      return t('Response');
+    case 'feedback':
+      return t('Feedback');
     case 'os':
       return t('Operating System');
     case 'user':
@@ -328,9 +338,9 @@ export function getContextTitle({
     case 'trace':
       return t('Trace Details');
     case 'otel':
-      return t('OpenTelemetry');
+      return 'OpenTelemetry';
     case 'unity':
-      return t('Unity');
+      return 'Unity';
     case 'memory_info': // Current value for memory info
     case 'Memory Info': // Legacy for memory info
       return t('Memory Info');
@@ -343,6 +353,10 @@ export function getContextTitle({
           return t('Application State');
         case 'laravel':
           return t('Laravel Context');
+        case 'profile':
+          return t('Profile');
+        case 'replay':
+          return t('Replay');
         default:
           return alias;
       }


### PR DESCRIPTION
We wanted to preserve casing for unknown context from the sdk in https://github.com/getsentry/sentry/pull/72013, but there are a few non-context context items that weren't accounted for. 

**Before**
![image](https://github.com/getsentry/sentry/assets/35509934/e97ee884-4e66-45b4-ad6e-87b4e6cb9ed8)

**After**
![image](https://github.com/getsentry/sentry/assets/35509934/a12e560f-8231-49e2-bf24-5c28648b79de)
