### PR TITLE
chore(ui): Improve sidebar specs

### DIFF
--- a/static/app/components/sidebar/index.spec.tsx
+++ b/static/app/components/sidebar/index.spec.tsx
@@ -301,10 +301,10 @@ describe('Sidebar', function () {
       ConfigStore.set('user', user);
     });
 
-    it('renders navigation', function () {
+    it('renders navigation', async function () {
       renderSidebar({organization});
 
-      waitFor(function () {
+      await waitFor(function () {
         expect(apiMocks.broadcasts).toHaveBeenCalled();
       });
 
@@ -313,12 +313,12 @@ describe('Sidebar', function () {
       ).toBeInTheDocument();
     });
 
-    it('in self-hosted-errors-only mode, only shows links to basic features', function () {
+    it('in self-hosted-errors-only mode, only shows links to basic features', async function () {
       ConfigStore.set('isSelfHostedErrorsOnly', true);
 
       renderSidebarWithFeatures(ALL_AVAILABLE_FEATURES);
 
-      waitFor(function () {
+      await waitFor(function () {
         expect(apiMocks.broadcasts).toHaveBeenCalled();
       });
 
@@ -335,17 +335,17 @@ describe('Sidebar', function () {
         'Stats',
         'Settings',
         'Help',
-        "What's new",
+        /What's new/,
         'Service status',
       ].forEach((title, index) => {
         expect(links[index]).toHaveAccessibleName(title);
       });
     });
 
-    it('in regular mode, also shows links to Performance and Crons', function () {
+    it('in regular mode, also shows links to Performance and Crons', async function () {
       renderSidebarWithFeatures(ALL_AVAILABLE_FEATURES);
 
-      waitFor(function () {
+      await waitFor(function () {
         expect(apiMocks.broadcasts).toHaveBeenCalled();
       });
 
@@ -379,17 +379,17 @@ describe('Sidebar', function () {
         'Stats',
         'Settings',
         'Help',
-        "What's new",
+        /What's new/,
         'Service status',
       ].forEach((title, index) => {
         expect(links[index]).toHaveAccessibleName(title);
       });
     });
 
-    it('if Insights are on, shows links to Explore and Insights', function () {
+    it('if Insights are on, shows links to Explore and Insights', async function () {
       renderSidebarWithFeatures([...ALL_AVAILABLE_FEATURES, 'performance-insights']);
 
-      waitFor(function () {
+      await waitFor(function () {
         expect(apiMocks.broadcasts).toHaveBeenCalled();
       });
 
@@ -425,7 +425,7 @@ describe('Sidebar', function () {
         'Stats',
         'Settings',
         'Help',
-        "What's new",
+        /What's new/,
         'Service status',
       ].forEach((title, index) => {
         expect(links[index]).toHaveAccessibleName(title);

--- a/static/app/components/sidebar/index.spec.tsx
+++ b/static/app/components/sidebar/index.spec.tsx
@@ -283,8 +283,15 @@ describe('Sidebar', function () {
   });
 
   describe('sidebar links', () => {
+    beforeEach(function () {
+      ConfigStore.init();
+      ConfigStore.set('features', new Set([]));
+      ConfigStore.set('user', user);
+    });
+
     it('renders for self-hosted errors only', async function () {
-      act(() => void ConfigStore.set('isSelfHostedErrorsOnly', true));
+      ConfigStore.set('isSelfHostedErrorsOnly', true);
+
       const {container} = renderSidebar({organization});
       expect(await screen.findByTestId('sidebar-dropdown')).toBeInTheDocument();
       const sidebarItems = container.querySelectorAll('[id^="sidebar-item"]');
@@ -302,7 +309,6 @@ describe('Sidebar', function () {
         'sidebar-item-statusupdate',
         'sidebar-item-collapse',
       ]);
-      act(() => void ConfigStore.set('isSelfHostedErrorsOnly', false));
     });
 
     it('renders sidebar with features', async function () {

--- a/static/app/components/sidebar/index.spec.tsx
+++ b/static/app/components/sidebar/index.spec.tsx
@@ -41,6 +41,15 @@ describe('Sidebar', function () {
   const renderSidebar = ({organization: org}: {organization: Organization | null}) =>
     render(getElement(), {context: routerContext, organization: org});
 
+  const renderSidebarWithFeatures = (features: string[] = []) => {
+    return renderSidebar({
+      organization: {
+        ...organization,
+        features: [...organization.features, ...sidebarAccordionFeatures, ...features],
+      },
+    });
+  };
+
   beforeEach(function () {
     jest.spyOn(incidentsHook, 'useServiceIncidents').mockImplementation(
       () =>
@@ -76,28 +85,6 @@ describe('Sidebar', function () {
     expect(screen.getByText(user.email)).toBeInTheDocument();
 
     await userEvent.click(screen.getByTestId('sidebar-dropdown'));
-  });
-
-  it('renders for self-hosted errors only', async function () {
-    act(() => void ConfigStore.set('isSelfHostedErrorsOnly', true));
-    const {container} = renderSidebar({organization});
-    expect(await screen.findByTestId('sidebar-dropdown')).toBeInTheDocument();
-    const sidebarItems = container.querySelectorAll('[id^="sidebar-item"]');
-    const sidebarItemIds = Array.from(sidebarItems).map(sidebarItem => sidebarItem.id);
-    expect(sidebarItems.length).toEqual(10);
-    expect(sidebarItemIds).toEqual([
-      'sidebar-item-issues',
-      'sidebar-item-projects',
-      'sidebar-item-alerts',
-      'sidebar-item-releases',
-      'sidebar-item-stats',
-      'sidebar-item-settings',
-      'sidebar-item-help',
-      'sidebar-item-broadcasts',
-      'sidebar-item-statusupdate',
-      'sidebar-item-collapse',
-    ]);
-    act(() => void ConfigStore.set('isSelfHostedErrorsOnly', false));
   });
 
   it('has can logout', async function () {
@@ -295,15 +282,28 @@ describe('Sidebar', function () {
     expect(await screen.findByText(organization.name)).toBeInTheDocument();
   });
 
-  describe('when the accordion is used', () => {
-    const renderSidebarWithFeatures = (features: string[] = []) => {
-      return renderSidebar({
-        organization: {
-          ...organization,
-          features: [...organization.features, ...sidebarAccordionFeatures, ...features],
-        },
-      });
-    };
+  describe('sidebar links', () => {
+    it('renders for self-hosted errors only', async function () {
+      act(() => void ConfigStore.set('isSelfHostedErrorsOnly', true));
+      const {container} = renderSidebar({organization});
+      expect(await screen.findByTestId('sidebar-dropdown')).toBeInTheDocument();
+      const sidebarItems = container.querySelectorAll('[id^="sidebar-item"]');
+      const sidebarItemIds = Array.from(sidebarItems).map(sidebarItem => sidebarItem.id);
+      expect(sidebarItems.length).toEqual(10);
+      expect(sidebarItemIds).toEqual([
+        'sidebar-item-issues',
+        'sidebar-item-projects',
+        'sidebar-item-alerts',
+        'sidebar-item-releases',
+        'sidebar-item-stats',
+        'sidebar-item-settings',
+        'sidebar-item-help',
+        'sidebar-item-broadcasts',
+        'sidebar-item-statusupdate',
+        'sidebar-item-collapse',
+      ]);
+      act(() => void ConfigStore.set('isSelfHostedErrorsOnly', false));
+    });
 
     it('renders sidebar with features', async function () {
       const {container} = renderSidebarWithFeatures();

--- a/static/app/components/sidebar/index.spec.tsx
+++ b/static/app/components/sidebar/index.spec.tsx
@@ -361,28 +361,6 @@ describe('Sidebar', function () {
       ]);
     });
 
-    it('renders sidebar items for self-hosted errors only', async function () {
-      act(() => void ConfigStore.set('isSelfHostedErrorsOnly', true));
-      const {container} = renderSidebarWithFeatures();
-      expect(await screen.findByTestId('sidebar-dropdown')).toBeInTheDocument();
-      const sidebarItems = container.querySelectorAll('[id^="sidebar-item"]');
-      const sidebarItemIds = Array.from(sidebarItems).map(sidebarItem => sidebarItem.id);
-      expect(sidebarItems.length).toEqual(10);
-      expect(sidebarItemIds).toEqual([
-        'sidebar-item-issues',
-        'sidebar-item-projects',
-        'sidebar-item-alerts',
-        'sidebar-item-releases',
-        'sidebar-item-stats',
-        'sidebar-item-settings',
-        'sidebar-item-help',
-        'sidebar-item-broadcasts',
-        'sidebar-item-statusupdate',
-        'sidebar-item-collapse',
-      ]);
-      act(() => void ConfigStore.set('isSelfHostedErrorsOnly', false));
-    });
-
     it('should not render floating accordion when expanded', async () => {
       renderSidebarWithFeatures();
       await userEvent.click(screen.getByTestId('sidebar-accordion-performance-item'));

--- a/static/app/components/sidebar/index.tsx
+++ b/static/app/components/sidebar/index.tsx
@@ -547,7 +547,7 @@ function Sidebar() {
       icon={hasNewSidebarHierarchy ? <SubitemDot collapsed /> : <IconGraph />}
       label={t('Metrics')}
       to={metricsPath}
-      search={location.pathname === normalizeUrl(metricsPath) ? location.search : ''}
+      search={location?.pathname === normalizeUrl(metricsPath) ? location.search : ''}
       id="metrics"
       isBeta={!isNewFeatureBadge}
       isNew={!!isNewFeatureBadge}


### PR DESCRIPTION
Follow-up to https://github.com/getsentry/sentry/pull/72012. Updates the tests a bit, moves things around, and expands test coverage.

- Move link set tests together

- Simplify `ConfigStore` init
    
    - init in `beforeEach`
    - remove `act`

- Update spec structure
    
    1. Set up all possible sidebar feature flags
    2. Await `Broadcast` mount
    3. Fetch elements by role, not by ID
    4. Check element by accessible title, not by ID
