### PR TITLE
fix(crons): Update schedule to be parseable by croniter

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1112,7 +1112,7 @@ CELERYBEAT_SCHEDULE_REGION = {
     "schedule-weekly-organization-reports-new": {
         "task": "sentry.tasks.summaries.weekly_reports.schedule_organizations",
         # 05:00 PDT, 09:00 EDT, 12:00 UTC
-        "schedule": crontab(minute="0", hour="12", day_of_week="saturday"),
+        "schedule": crontab(minute="0", hour="12", day_of_week="sat"),
         "options": {"expires": 60 * 60 * 3},
     },
     # "schedule-daily-organization-reports": {


### PR DESCRIPTION
Related to: https://github.com/getsentry/sentry-python/issues/3131

Unfortunately when trying to upsert this monitor we get an error because the schedule `0 0 * * saturday` can't be read by croniter

Instead we need to change this to `0 0 * * sat`

This is a more temporary fix and perhaps in the future we will try to map over more `celery.schedules.crontab` schedules to ones that can be read by `croniter`.

