### PR TITLE
fix(new-trace): Tag heat map event target url missing traceSlug.

### DIFF
--- a/static/app/views/performance/transactionSummary/transactionTags/tagsHeatMap.tsx
+++ b/static/app/views/performance/transactionSummary/transactionTags/tagsHeatMap.tsx
@@ -243,7 +243,8 @@ function TagsHeatMap(
 
     const newTransactionEventView = eventView.clone();
 
-    newTransactionEventView.fields = [{field: aggregateColumn}];
+    // We need the traceSlug here to navigate to the transaction in the trace view.
+    newTransactionEventView.fields = [{field: aggregateColumn}, {field: 'trace'}];
     const [_, tagValue] = bucket.value;
 
     if (histogramBucketInfo && histogramData) {


### PR DESCRIPTION
<img width="1512" alt="Screenshot 2024-06-04 at 5 53 22 PM" src="https://github.com/getsentry/sentry/assets/60121741/450db260-18f3-4be8-8aef-0bffa0641368">
