### PR TITLE
chore(tests): test SlackNotifyServiceAction

### DIFF
--- a/tests/sentry/integrations/slack/actions/notification/test_slack_notify_service_action.py
+++ b/tests/sentry/integrations/slack/actions/notification/test_slack_notify_service_action.py
@@ -1,20 +1,56 @@
+from urllib.parse import parse_qs
 from uuid import uuid4
 
+import orjson
+import responses
+
 from sentry.integrations.slack import SlackNotifyServiceAction
+from sentry.models.notificationmessage import NotificationMessage
 from sentry.models.rulefirehistory import RuleFireHistory
-from sentry.testutils.cases import TestCase
+from sentry.silo.base import SiloMode
+from sentry.testutils.cases import RuleTestCase
+from sentry.testutils.helpers.features import with_feature
+from sentry.testutils.silo import assume_test_silo_mode
+from sentry.types.rules import RuleFuture
 
 
-class TestInit(TestCase):
+class TestInit(RuleTestCase):
+    rule_cls = SlackNotifyServiceAction
+
     def setUp(self) -> None:
-        self.rule = self.create_project_rule(project=self.project)
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            self.integration = self.create_integration(
+                organization=self.organization,
+                name="slack",
+                provider="slack",
+                external_id="slack:1",
+                metadata={"access_token": "xoxb-access-token"},
+            )
+        self.uuid = "5bac5dcc-e201-4cb2-8da2-bac39788a13d"
+        self.action_data = {
+            "workspace": str(self.integration.id),
+            "id": "sentry.integrations.slack.notify_action.SlackNotifyServiceAction",
+            "channel_id": "C0123456789",
+            "tags": "",
+            "channel": "test-notifications",
+            "uuid": self.uuid,
+        }
+        self.rule = self.create_project_rule(project=self.project, action_match=[self.action_data])
         self.notification_uuid = str(uuid4())
-        self.event_id = 456
+        self.event = self.store_event(
+            data={
+                "message": "Hello world",
+                "level": "warning",
+                "platform": "python",
+                "culprit": "foo.bar",
+            },
+            project_id=self.project.id,
+        )
         self.rule_fire_history = RuleFireHistory.objects.create(
             project=self.project,
             rule=self.rule,
-            group=self.group,
-            event_id=self.event_id,
+            group=self.event.group,
+            event_id=self.event.event_id,
             notification_uuid=self.notification_uuid,
         )
 
@@ -33,3 +69,103 @@ class TestInit(TestCase):
             self.project, data={}, rule=self.rule, rule_fire_history=None
         )
         assert instance.rule_fire_history is None
+
+    @responses.activate
+    def test_after(self):
+        rule = self.get_rule(data=self.action_data)
+        results = list(rule.after(event=self.event))
+        assert len(results) == 1
+
+        responses.add(
+            responses.POST,
+            url="https://slack.com/api/chat.postMessage",
+            json={},
+            status=200,
+        )
+
+        results[0].callback(self.event, futures=[])
+        data = parse_qs(responses.calls[0].request.body)
+        blocks = orjson.loads(data["blocks"][0])
+
+        assert (
+            blocks[0]["text"]["text"]
+            == f":large_yellow_circle: <http://testserver/organizations/{self.organization.slug}/issues/{self.event.group.id}/?referrer=slack|*Hello world*>"
+        )
+
+        assert NotificationMessage.objects.all().count() == 0
+
+    @with_feature("organizations:slack-thread-issue-alert")
+    @responses.activate
+    def test_after_with_threads(self):
+        rule = self.get_rule(data=self.action_data, rule_fire_history=self.rule_fire_history)
+        results = list(rule.after(event=self.event))
+        assert len(results) == 1
+
+        responses.add(
+            responses.POST,
+            url="https://slack.com/api/chat.postMessage",
+            json={},
+            status=200,
+        )
+
+        results[0].callback(self.event, futures=[RuleFuture(rule=self.rule, kwargs={})])
+        data = parse_qs(responses.calls[0].request.body)
+        blocks = orjson.loads(data["blocks"][0])
+
+        assert (
+            blocks[0]["text"]["text"]
+            == f":large_yellow_circle: <http://testserver/organizations/{self.organization.slug}/issues/{self.event.group.id}/?referrer=slack&alert_rule_id={self.rule.id}&alert_type=issue|*Hello world*>"
+        )
+
+        assert NotificationMessage.objects.all().count() == 1
+
+    @with_feature("organizations:slack-thread-issue-alert")
+    @responses.activate
+    def test_after_reply_in_thread(self):
+        with assume_test_silo_mode(SiloMode.REGION):
+            msg = NotificationMessage.objects.create(
+                rule_fire_history_id=self.rule_fire_history.id,
+                rule_action_uuid=self.uuid,
+            )
+
+        event = self.store_event(
+            data={
+                "message": "Hello world",
+                "level": "warning",
+                "platform": "python",
+                "culprit": "foo.bar",
+            },
+            project_id=self.project.id,
+        )
+        rule_fire_history = RuleFireHistory.objects.create(
+            project=self.project,
+            rule=self.rule,
+            group=self.event.group,
+            event_id=event.event_id,
+            notification_uuid=self.notification_uuid,
+        )
+
+        rule = self.get_rule(data=self.action_data, rule_fire_history=rule_fire_history)
+        results = list(rule.after(event=event))
+        assert len(results) == 1
+
+        responses.add(
+            responses.POST,
+            url="https://slack.com/api/chat.postMessage",
+            json={},
+            status=200,
+        )
+
+        results[0].callback(self.event, futures=[RuleFuture(rule=self.rule, kwargs={})])
+        data = parse_qs(responses.calls[0].request.body)
+        blocks = orjson.loads(data["blocks"][0])
+
+        assert (
+            blocks[0]["text"]["text"]
+            == f":large_yellow_circle: <http://testserver/organizations/{self.organization.slug}/issues/{self.event.group.id}/?referrer=slack&alert_rule_id={self.rule.id}&alert_type=issue|*Hello world*>"
+        )
+
+        assert NotificationMessage.objects.all().count() == 2
+        assert (
+            NotificationMessage.objects.filter(parent_notification_message_id=msg.id).count() == 1
+        )


### PR DESCRIPTION
Previously there was no test coverage for SlackNotifyServiceAction (Slack issue alerts). Adding some which is important in light of the new threads feature.