### PR TITLE
feat(replay): Only show hydration errors project setting if the feature is enabled

### DIFF
--- a/static/app/data/forms/replay.tsx
+++ b/static/app/data/forms/replay.tsx
@@ -24,6 +24,9 @@ const formGroups: JsonFormObject[] = [
         label: t('Create Hydration Error Issues'),
         help: t('Toggles whether or not to create Session Replay Hydration Error Issues'),
         getData: data => ({options: data}),
+        visible({features}) {
+          return features.has('session-replay-hydration-error-issue-creation');
+        },
       },
     ],
   },

--- a/static/app/views/settings/project/projectReplays.tsx
+++ b/static/app/views/settings/project/projectReplays.tsx
@@ -42,7 +42,13 @@ function ProjectReplaySettings({organization, project, params: {projectId}}: Pro
         initialData={project.options}
       >
         <Access access={['project:write']} project={project}>
-          {({hasAccess}) => <JsonForm disabled={!hasAccess} forms={formGroups} />}
+          {({hasAccess}) => (
+            <JsonForm
+              features={new Set(organization.features)}
+              disabled={!hasAccess}
+              forms={formGroups}
+            />
+          )}
         </Access>
       </Form>
     </SentryDocumentTitle>


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry/issues/72068