### PR TITLE
fix(replay): handle missing payload data for hydrate-error breadcrumbs

### DIFF
--- a/src/sentry/replays/usecases/ingest/dom_index.py
+++ b/src/sentry/replays/usecases/ingest/dom_index.py
@@ -450,7 +450,12 @@ def _handle_breadcrumb(
             return click
 
     elif category == "replay.hydrate-error":
-        if replay_event is not None and _should_report_hydration_error_issue(project_id):
+        if (
+            replay_event is not None
+            and _should_report_hydration_error_issue(project_id)
+            and "data" in payload
+            and "timestamp" in payload
+        ):
             report_hydration_error_issue_with_replay_event(
                 project_id,
                 replay_id,

--- a/src/sentry/replays/usecases/ingest/dom_index.py
+++ b/src/sentry/replays/usecases/ingest/dom_index.py
@@ -450,17 +450,12 @@ def _handle_breadcrumb(
             return click
 
     elif category == "replay.hydrate-error":
-        if (
-            replay_event is not None
-            and _should_report_hydration_error_issue(project_id)
-            and "data" in payload
-            and "timestamp" in payload
-        ):
+        if replay_event is not None and _should_report_hydration_error_issue(project_id):
             report_hydration_error_issue_with_replay_event(
                 project_id,
                 replay_id,
                 payload["timestamp"],
-                payload["data"].get("url"),
+                payload.get("data", {}).get("url"),
                 replay_event,
             )
 


### PR DESCRIPTION
Fixes [SENTRY_EXPERIMENTAL-253](https://sentry.sentry.io/issues/5451660180/)
Follow up to https://github.com/getsentry/sentry/pull/71769

Sometimes the breadcrumb event payload might be missing "data", if using older SDK. Checked with @ryan953 we'd still like to make a hydrate issue, we're only using it for the url after all