### PR TITLE
feat(metrics): Check alerts feature when rendering create button

### DIFF
--- a/static/app/components/metrics/createMetricAlertFeature.tsx
+++ b/static/app/components/metrics/createMetricAlertFeature.tsx
@@ -1,0 +1,46 @@
+import Feature, {type ChildrenRenderFn} from 'sentry/components/acl/feature';
+import FeatureDisabled from 'sentry/components/acl/featureDisabled';
+import {Hovercard} from 'sentry/components/hovercard';
+import {Tooltip} from 'sentry/components/tooltip';
+import {t} from 'sentry/locale';
+import useOrganization from 'sentry/utils/useOrganization';
+
+interface Props {
+  children: React.ReactNode | ChildrenRenderFn;
+}
+
+export function CreateMetricAlertFeature({children}: Props) {
+  const organization = useOrganization();
+  const hasPermission = organization.access.includes('alerts:write');
+  return (
+    <Feature
+      features={['organizations:incidents']}
+      organization={organization}
+      hookName="feature-disabled:create-metrics-alert-tooltip"
+      renderDisabled={p => (
+        <Hovercard
+          body={
+            <FeatureDisabled
+              features={p.features}
+              hideHelpToggle
+              featureName={t('Metric Alerts')}
+            />
+          }
+        >
+          {typeof p.children === 'function' ? p.children(p) : p.children}
+        </Hovercard>
+      )}
+    >
+      {p => (
+        <Tooltip
+          title={t('You do not have permission to create alerts')}
+          disabled={!p.hasFeature || hasPermission}
+        >
+          {typeof children === 'function'
+            ? children({...p, hasFeature: p.hasFeature && hasPermission})
+            : children}
+        </Tooltip>
+      )}
+    </Feature>
+  );
+}

--- a/static/app/components/modals/metricWidgetViewerModal/queries.tsx
+++ b/static/app/components/modals/metricWidgetViewerModal/queries.tsx
@@ -7,6 +7,7 @@ import {Button} from 'sentry/components/button';
 import type {MenuItemProps} from 'sentry/components/dropdownMenu';
 import {DropdownMenu} from 'sentry/components/dropdownMenu';
 import Input, {type InputProps} from 'sentry/components/input';
+import {CreateMetricAlertFeature} from 'sentry/components/metrics/createMetricAlertFeature';
 import {Tooltip} from 'sentry/components/tooltip';
 import {DEFAULT_DEBOUNCE_DURATION, SLOW_TOOLTIP_DELAY} from 'sentry/constants';
 import {
@@ -22,6 +23,7 @@ import {
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {isCustomMetric} from 'sentry/utils/metrics';
+import {hasMetricAlertFeature} from 'sentry/utils/metrics/features';
 import {MetricExpressionType} from 'sentry/utils/metrics/types';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
@@ -232,8 +234,8 @@ function QueryContextMenu({
     const addAlertItem = {
       leadingItems: [<IconSiren key="icon" />],
       key: 'add-alert',
-      label: t('Create Alert'),
-      disabled: !createAlert,
+      label: <CreateMetricAlertFeature>{t('Create Alert')}</CreateMetricAlertFeature>,
+      disabled: !createAlert || !hasMetricAlertFeature(organization),
       onAction: () => {
         createAlert?.();
       },
@@ -272,13 +274,14 @@ function QueryContextMenu({
       ? [duplicateQueryItem, aliasItem, addAlertItem, removeQueryItem, settingsItem]
       : [duplicateQueryItem, aliasItem, addAlertItem, removeQueryItem];
   }, [
-    createAlert,
     metricsQuery.mri,
-    removeQuery,
-    addQuery,
-    editAlias,
+    createAlert,
+    organization,
     canRemoveQuery,
+    addQuery,
     queryIndex,
+    removeQuery,
+    editAlias,
     router,
   ]);
 

--- a/static/app/utils/metrics/features.tsx
+++ b/static/app/utils/metrics/features.tsx
@@ -24,6 +24,10 @@ export function canSeeMetricsPage(organization: Organization) {
   return hasCustomMetrics(organization) || hasRolledOutMetrics(organization);
 }
 
+export function hasMetricAlertFeature(organization: Organization) {
+  return organization.features.includes('organizations:incidents');
+}
+
 /**
  * Returns the forceMetricsLayer query param for the alert
  * wrapped in an object so it can be spread into existing query params

--- a/static/app/views/metrics/metricQueryContextMenu.tsx
+++ b/static/app/views/metrics/metricQueryContextMenu.tsx
@@ -7,6 +7,7 @@ import {navigateTo} from 'sentry/actionCreators/navigation';
 import Feature from 'sentry/components/acl/feature';
 import type {MenuItemProps} from 'sentry/components/dropdownMenu';
 import {DropdownMenu} from 'sentry/components/dropdownMenu';
+import {CreateMetricAlertFeature} from 'sentry/components/metrics/createMetricAlertFeature';
 import {
   IconClose,
   IconCopy,
@@ -25,7 +26,7 @@ import {
   getWidgetAsQueryParams,
   getWidgetQuery,
 } from 'sentry/utils/metrics/dashboard';
-import {hasCustomMetrics} from 'sentry/utils/metrics/features';
+import {hasCustomMetrics, hasMetricAlertFeature} from 'sentry/utils/metrics/features';
 import {
   isMetricsQueryWidget,
   type MetricDisplayType,
@@ -83,8 +84,8 @@ export function MetricQueryContextMenu({
       {
         leadingItems: [<IconSiren key="icon" />],
         key: 'add-alert',
-        label: t('Create Alert'),
-        disabled: !createAlert,
+        label: <CreateMetricAlertFeature>{t('Create Alert')}</CreateMetricAlertFeature>,
+        disabled: !createAlert || !hasMetricAlertFeature(organization),
         onAction: () => {
           trackAnalytics('ddm.create-alert', {
             organization,

--- a/static/app/views/metrics/pageHeaderActions.tsx
+++ b/static/app/views/metrics/pageHeaderActions.tsx
@@ -7,6 +7,7 @@ import Feature from 'sentry/components/acl/feature';
 import {Button} from 'sentry/components/button';
 import ButtonBar from 'sentry/components/buttonBar';
 import {DropdownMenu} from 'sentry/components/dropdownMenu';
+import {CreateMetricAlertFeature} from 'sentry/components/metrics/createMetricAlertFeature';
 import {
   IconBookmark,
   IconDashboard,
@@ -158,27 +159,32 @@ export function PageHeaderActions({showCustomMetricButton, addCustomMetric}: Pro
       >
         {isDefaultQuery ? t('Remove Default') : t('Save as default')}
       </Button>
-      {alertItems.length === 1 ? (
-        <Button
-          size="sm"
-          icon={<IconSiren />}
-          disabled={!alertItems[0].onAction}
-          onClick={alertItems[0].onAction}
-        >
-          {t('Create Alert')}
-        </Button>
-      ) : (
-        <DropdownMenu
-          items={alertItems}
-          triggerLabel={t('Create Alert')}
-          triggerProps={{
-            size: 'sm',
-            showChevron: false,
-            icon: <IconSiren direction="down" size="sm" />,
-          }}
-          position="bottom-end"
-        />
-      )}
+      <CreateMetricAlertFeature>
+        {({hasFeature}) =>
+          alertItems.length === 1 ? (
+            <Button
+              size="sm"
+              icon={<IconSiren />}
+              disabled={!alertItems[0].onAction || !hasFeature}
+              onClick={alertItems[0].onAction}
+            >
+              {t('Create Alert')}
+            </Button>
+          ) : (
+            <DropdownMenu
+              items={alertItems}
+              triggerLabel={t('Create Alert')}
+              isDisabled={!hasFeature}
+              triggerProps={{
+                size: 'sm',
+                showChevron: false,
+                icon: <IconSiren direction="down" size="sm" />,
+              }}
+              position="bottom-end"
+            />
+          )
+        }
+      </CreateMetricAlertFeature>
       <DropdownMenu
         items={items}
         triggerProps={{


### PR DESCRIPTION
Check for metric alerts feature and permission when rendering buttons / menu items for creating alerts.

![Screenshot 2024-06-05 at 08 56 56](https://github.com/getsentry/sentry/assets/7033940/1586ca0d-5f1f-4130-ac58-9fb6d2414ec6)
![Screenshot 2024-06-05 at 08 56 27](https://github.com/getsentry/sentry/assets/7033940/0c8fe89d-fb17-4b10-bf9c-26a9eea6aa80)
![Screenshot 2024-06-05 at 08 48 29](https://github.com/getsentry/sentry/assets/7033940/6197681e-b63e-410a-ac65-cdb5a18d5607)
![Screenshot 2024-06-05 at 10 26 02](https://github.com/getsentry/sentry/assets/7033940/bb36ea2e-1145-48ff-8865-165492b34841)

Closes https://github.com/getsentry/sentry/issues/72082 