### PR TITLE
feat(remote-config): Cache remote-config files in Redis

### DIFF
--- a/src/sentry/remote_config/storage.py
+++ b/src/sentry/remote_config/storage.py
@@ -109,7 +109,9 @@ class ConfigurationBackend:
             return (cache_result, "cache")
 
         storage_result = self.storage.get()
-        self.cache.set(storage_result)
+        if storage_result:
+            self.cache.set(storage_result)
+
         return (storage_result, "store")
 
     def set(self, value: StorageFormat) -> None:

--- a/src/sentry/remote_config/storage.py
+++ b/src/sentry/remote_config/storage.py
@@ -113,8 +113,8 @@ class ConfigurationBackend:
         return storage_result
 
     def set(self, value: StorageFormat) -> None:
-        self.cache.set(value)
         self.storage.set(value)
+        self.cache.set(value)
 
     def pop(self) -> None:
         self.cache.pop()

--- a/src/sentry/remote_config/storage.py
+++ b/src/sentry/remote_config/storage.py
@@ -2,9 +2,10 @@ from io import BytesIO
 from typing import TypedDict
 
 from sentry import options
+from sentry.cache import default_cache
 from sentry.models.files.utils import get_storage
 from sentry.models.project import Project
-from sentry.utils import json
+from sentry.utils import json, metrics
 
 JSONValue = str | int | float | bool | None | list["JSONValue"] | dict[str, "JSONValue"]
 
@@ -30,44 +31,33 @@ class APIFormat(TypedDict):
     options: Options
 
 
-class StorageBackend:
-    def __init__(self, key: Project) -> None:
-        self.driver = BlobDriver(key)
+class ConfigurationCache:
+    def __init__(self, key: str) -> None:
         self.key = key
 
-    def get(self) -> APIFormat | None:
-        result = self.driver.get()
-        if result is None:
-            return None
-        return self._deserialize(result)
+    def get(self) -> StorageFormat | None:
+        cache_result = default_cache.get(self.key)
 
-    def set(self, value: APIFormat) -> None:
-        self.driver.set(self._serialize(value))
+        if cache_result is None:
+            metrics.incr("remote_config.configuration.cache_miss")
+        else:
+            metrics.incr("remote_config.configuration.cache_hit")
+
+        return cache_result
+
+    def set(self, value: StorageFormat) -> None:
+        default_cache.set(self.key, value=value, timeout=None)
 
     def pop(self) -> None:
-        self.driver.pop()
-
-    def _deserialize(self, result: StorageFormat) -> APIFormat:
-        return {
-            "features": result["features"],
-            "options": result["options"],
-        }
-
-    def _serialize(self, result: APIFormat) -> StorageFormat:
-        return {
-            "features": result["features"],
-            "options": result["options"],
-            "version": 1,
-        }
+        try:
+            default_cache.delete(self.key)
+        except Exception:
+            pass
 
 
-class BlobDriver:
-    def __init__(self, project: Project) -> None:
-        self.project = project
-
-    @property
-    def key(self):
-        return f"configurations/{self.project.id}/production"
+class ConfigurationStorage:
+    def __init__(self, key: str) -> None:
+        self.key = key
 
     @property
     def storage(self):
@@ -105,5 +95,65 @@ class BlobDriver:
             return None
 
 
-def make_storage(key: Project):
-    return StorageBackend(key)
+class ConfigurationBackend:
+    def __init__(self, project: Project) -> None:
+        self.project = project
+        self.key = f"configurations/{self.project.id}/production"
+
+        self.cache = ConfigurationCache(self.key)
+        self.storage = ConfigurationStorage(self.key)
+
+    def get(self) -> StorageFormat | None:
+        cache_result = self.cache.get()
+        if cache_result is not None:
+            return cache_result
+
+        storage_result = self.storage.get()
+        self.cache.set(storage_result)
+        return storage_result
+
+    def set(self, value: StorageFormat) -> None:
+        self.cache.set(value)
+        self.storage.set(value)
+
+    def pop(self) -> None:
+        self.cache.pop()
+        self.storage.pop()
+
+
+class APIBackendDecorator:
+    def __init__(self, backend: ConfigurationBackend) -> None:
+        self.driver = backend
+
+    def get(self) -> APIFormat | None:
+        return self._deserialize(self.driver.get())
+
+    def set(self, value: APIFormat) -> None:
+        self.driver.set(self._serialize(value))
+
+    def pop(self) -> None:
+        self.driver.pop()
+
+    def _deserialize(self, result: StorageFormat | None) -> APIFormat | None:
+        if result is None:
+            return None
+
+        return {
+            "features": result["features"],
+            "options": result["options"],
+        }
+
+    def _serialize(self, result: APIFormat) -> StorageFormat:
+        return {
+            "features": result["features"],
+            "options": result["options"],
+            "version": 1,
+        }
+
+
+def make_configuration_backend(project: Project):
+    return ConfigurationBackend(project)
+
+
+def make_api_backend(project: Project):
+    return APIBackendDecorator(make_configuration_backend(project))

--- a/src/sentry/remote_config/storage.py
+++ b/src/sentry/remote_config/storage.py
@@ -103,14 +103,14 @@ class ConfigurationBackend:
         self.cache = ConfigurationCache(self.key)
         self.storage = ConfigurationStorage(self.key)
 
-    def get(self) -> StorageFormat | None:
+    def get(self) -> tuple[StorageFormat | None, str]:
         cache_result = self.cache.get()
         if cache_result is not None:
-            return cache_result
+            return (cache_result, "cache")
 
         storage_result = self.storage.get()
         self.cache.set(storage_result)
-        return storage_result
+        return (storage_result, "store")
 
     def set(self, value: StorageFormat) -> None:
         self.storage.set(value)
@@ -125,8 +125,9 @@ class APIBackendDecorator:
     def __init__(self, backend: ConfigurationBackend) -> None:
         self.driver = backend
 
-    def get(self) -> APIFormat | None:
-        return self._deserialize(self.driver.get())
+    def get(self) -> tuple[APIFormat | None, str]:
+        result, source = self.driver.get()
+        return self._deserialize(result), source
 
     def set(self, value: APIFormat) -> None:
         self.driver.set(self._serialize(value))

--- a/tests/sentry/remote_config/endpoints/test_configuration.py
+++ b/tests/sentry/remote_config/endpoints/test_configuration.py
@@ -35,12 +35,35 @@ class ConfigurationAPITestCase(APITestCase):
             response = self.client.get(self.url)
 
         assert response.status_code == 200
+        assert response["X-Sentry-Data-Source"] == "cache"
         assert response.json() == {
             "data": {
                 "features": [{"key": "abc", "value": "def"}],
                 "options": {"sample_rate": 0.5, "traces_sample_rate": 0},
             }
         }
+
+    def test_get_configuration_no_cache(self):
+        self.storage.set(
+            {
+                "features": [{"key": "abc", "value": "def"}],
+                "options": {"sample_rate": 0.5, "traces_sample_rate": 0},
+            },
+        )
+        self.storage.driver.cache.pop()
+
+        with self.feature(REMOTE_CONFIG_FEATURES):
+            response = self.client.get(self.url)
+
+        assert response.status_code == 200
+        assert response["X-Sentry-Data-Source"] == "store"
+        assert response.json() == {
+            "data": {
+                "features": [{"key": "abc", "value": "def"}],
+                "options": {"sample_rate": 0.5, "traces_sample_rate": 0},
+            }
+        }
+        assert self.storage.driver.cache.get() is not None
 
     def test_get_configuration_not_enabled(self):
         self.storage.set(
@@ -80,7 +103,7 @@ class ConfigurationAPITestCase(APITestCase):
         }
 
         # Assert the configuration was stored successfully.
-        assert self.storage.get() == response.json()["data"]
+        assert self.storage.get()[0] == response.json()["data"]
 
     def test_post_configuration_not_enabled(self):
         response = self.client.post(self.url, data={}, format="json")
@@ -161,12 +184,28 @@ class ConfigurationAPITestCase(APITestCase):
                 "options": {"sample_rate": 1.0, "traces_sample_rate": 1.0},
             }
         )
-        assert self.storage.get() is not None
+        assert self.storage.get()[0] is not None
 
         with self.feature(REMOTE_CONFIG_FEATURES):
             response = self.client.delete(self.url)
         assert response.status_code == 204
-        assert self.storage.get() is None
+        assert self.storage.get()[0] is None
+
+    def test_delete_configuration_no_cache(self):
+        self.storage.set(
+            {
+                "features": [],
+                "options": {"sample_rate": 1.0, "traces_sample_rate": 1.0},
+            }
+        )
+        assert self.storage.get()[0] is not None
+        self.storage.driver.cache.pop()
+
+        with self.feature(REMOTE_CONFIG_FEATURES):
+            response = self.client.delete(self.url)
+        assert response.status_code == 204
+        assert self.storage.get()[0] is None
+        assert self.storage.driver.cache.get() is None
 
     def test_delete_configuration_not_found(self):
         self.storage.pop()
@@ -212,6 +251,32 @@ class ConfigurationProxyAPITestCase(APITestCase):
             assert response["ETag"] is not None
             assert response["Cache-Control"] == "public, max-age=3600"
             assert response["Content-Type"] == "application/json"
+            assert response["X-Sentry-Data-Source"] == "cache"
+
+    def test_remote_config_proxy_not_cached(self):
+        """Assert configurations are returned successfully."""
+        self.storage.set(
+            {
+                "features": [{"key": "abc", "value": "def"}],
+                "options": {"sample_rate": 0.5, "traces_sample_rate": 0},
+            },
+        )
+        self.storage.driver.cache.pop()
+
+        keys = generate_key_pair()
+        relay = Relay.objects.create(
+            relay_id=str(uuid4()), public_key=str(keys[1]), is_internal=True
+        )
+
+        with self.feature(REMOTE_CONFIG_FEATURES):
+            response = self.client.get(
+                self.url, content_type="application/json", HTTP_X_SENTRY_RELAY_ID=relay.relay_id
+            )
+            assert response.status_code == 200
+            assert response["ETag"] is not None
+            assert response["Cache-Control"] == "public, max-age=3600"
+            assert response["Content-Type"] == "application/json"
+            assert response["X-Sentry-Data-Source"] == "store"
 
     def test_remote_config_proxy_not_found(self):
         """Assert missing configurations 404."""

--- a/tests/sentry/remote_config/endpoints/test_configuration.py
+++ b/tests/sentry/remote_config/endpoints/test_configuration.py
@@ -5,7 +5,7 @@ from django.urls import reverse
 from sentry_relay.auth import generate_key_pair
 
 from sentry.models.relay import Relay
-from sentry.remote_config.storage import StorageBackend
+from sentry.remote_config.storage import make_api_backend
 from sentry.testutils.cases import APITestCase
 
 REMOTE_CONFIG_FEATURES = {"organizations:remote-config": True}
@@ -21,7 +21,7 @@ class ConfigurationAPITestCase(APITestCase):
 
     @property
     def storage(self):
-        return StorageBackend(self.project)
+        return make_api_backend(self.project)
 
     def test_get_configuration(self):
         self.storage.set(
@@ -188,7 +188,7 @@ class ConfigurationProxyAPITestCase(APITestCase):
 
     @property
     def storage(self):
-        return StorageBackend(self.project)
+        return make_api_backend(self.project)
 
     def test_remote_config_proxy(self):
         """Assert configurations are returned successfully."""


### PR DESCRIPTION
Performance and cost optimization.  Removes the need to reach out to GCS (pretty much ever).  This is a temporary caching facade while we build out the real version which will cache in the PoPs.

Ref: https://github.com/getsentry/sentry/issues/70942