### PR TITLE
fix(metrics): Tab list text value console warning

### DIFF
--- a/static/app/views/metrics/widgetDetails.tsx
+++ b/static/app/views/metrics/widgetDetails.tsx
@@ -160,7 +160,7 @@ export function MetricDetails({
       <Tabs value={selectedTab} onChange={handleTabChange}>
         <TabsAndAction>
           <TabList>
-            <TabList.Item key={Tab.SAMPLES}>
+            <TabList.Item textValue={t('Span Samples')} key={Tab.SAMPLES}>
               <GuideAnchor target="metrics_table" position="top">
                 {t('Span Samples')}
               </GuideAnchor>


### PR DESCRIPTION
Fixes this console warning:
```
<Item> with non-plain text contents is unsupported by type to select for accessibility. Please add a `textValue` prop.
```