### PR TITLE
Set linguist language to Bash for `.envrc`

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,4 +1,3 @@
-#!/not/executable/bash
 # This is the .envrc for sentry, for use with direnv.
 # It's responsible for enforcing a standard dev environment by checking as much state as possible, and either performing
 # initialization (e.g. activating the venv) or giving recommendations on how to reach the desired state.

--- a/.envrc
+++ b/.envrc
@@ -1,3 +1,4 @@
+# shellcheck shell=bash
 # This is the .envrc for sentry, for use with direnv.
 # It's responsible for enforcing a standard dev environment by checking as much state as possible, and either performing
 # initialization (e.g. activating the venv) or giving recommendations on how to reach the desired state.

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
+.envrc linguist-language=Bash
 model-manifest.json binary
 tests/js/test-balancer/jest-balance.json binary
 


### PR DESCRIPTION
Basically, this is a nitpick to use the proper language override instead of a fake shebang.

AFAICT this shebang was added to trick GitHub to apply shell syntax highlighting to the `.envrc` file. Clever! But GitHub uses [linguist](https://github.com/github-linguist/linguist), and using the `linguist-language` attribute is the "official" way to override the detected language and syntax highlighting. I stumbled on this file while searching GitHub for `.envrc` usage examples, and figured that it would be slightly better to not use a fake shebang. Apologies for a PR that is bikeshedding a bit :sweat_smile:

You might also want to look into the `linguist-generated` attribute for your generated files, but Linguist should be smart enough to detect which files are generated on its own. At least for minified files.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
