### PR TITLE
fix(grouping): Mark dart packages as non inApp

### DIFF
--- a/src/sentry/grouping/enhancer/enhancement-configs/newstyle@2023-01-11.txt
+++ b/src/sentry/grouping/enhancer/enhancement-configs/newstyle@2023-01-11.txt
@@ -86,6 +86,14 @@ family:javascript module:**/packages/flutter/** -app
 # sentry-dart SDK frames are not in app
 stack.abs_path:package:sentry/** -app -group
 stack.abs_path:package:sentry_flutter/** -app -group
+# other sentry-dart packages that are non in app
+stack.abs_path:package:sentry_logging/** -app -group
+stack.abs_path:package:sentry_dio/** -app -group
+stack.abs_path:package:sentry_file/** -app -group
+stack.abs_path:package:sentry_hive/** -app -group
+stack.abs_path:package:sentry_isar/** -app -group
+stack.abs_path:package:sentry_sqflite/** -app -group
+stack.abs_path:package:sentry_drift/** -app -group
 
 # Categorization of frames
 family:native package:"/System/Library/Frameworks/**" category=system

--- a/tests/sentry/grouping/grouping_inputs/frame-ignores-sentry-dart-packages.json
+++ b/tests/sentry/grouping/grouping_inputs/frame-ignores-sentry-dart-packages.json
@@ -1,0 +1,55 @@
+{
+  "stacktrace": {
+    "frames": [
+      {
+        "function": "SentryLogging.log",
+        "package": "sentry_logging",
+        "filename": "sentry_logging.dart",
+        "abs_path": "package:sentry_logging/src/sentry_logging.dart",
+        "in_app": true
+      },
+      {
+        "function": "SentryDio.dio",
+        "package": "sentry_dio",
+        "filename": "sentry_dio.dart",
+        "abs_path": "package:sentry_dio/src/sentry_dio.dart",
+        "in_app": true
+      },
+      {
+        "function": "SentryFile.file",
+        "package": "sentry_file",
+        "filename": "sentry_file.dart",
+        "abs_path": "package:sentry_file/src/sentry_file.dart",
+        "in_app": true
+      },
+      {
+        "function": "SentryHive.hive",
+        "package": "sentry_hive",
+        "filename": "sentry_hive.dart",
+        "abs_path": "package:sentry_hive/src/sentry_hive.dart",
+        "in_app": true
+      },{
+        "function": "SentryIsar.isar",
+        "package": "sentry_isar",
+        "filename": "sentry_isar.dart",
+        "abs_path": "package:sentry_isar/src/sentry_isar.dart",
+        "in_app": true
+      },
+      {
+        "function": "SentrySqflite.sqflite",
+        "package": "sentry_sqflite",
+        "filename": "sentry_sqflite.dart",
+        "abs_path": "package:sentry_sqflite/src/sentry_sqflite.dart",
+        "in_app": true
+      },
+      {
+        "function": "SentryDrift.drift",
+        "package": "sentry_drift",
+        "filename": "sentry_drift.dart",
+        "abs_path": "package:sentry_drift/src/sentry_drift.dart",
+        "in_app": true
+      }
+    ]
+  },
+  "platform": "other"
+}

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/frame_ignores_sentry_dart_packages.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/frame_ignores_sentry_dart_packages.pysnap
@@ -1,0 +1,86 @@
+---
+created: '2024-06-05T14:22:34.954498+00:00'
+creator: sentry
+source: tests/sentry/grouping/test_variants.py
+---
+app:
+  hash: null
+  component:
+    app (stacktrace of system takes precedence)
+      stacktrace (ignored because hash matches system variant)
+        frame*
+          filename*
+            "sentry_logging.dart"
+          function*
+            "SentryLogging.log"
+        frame*
+          filename*
+            "sentry_dio.dart"
+          function*
+            "SentryDio.dio"
+        frame*
+          filename*
+            "sentry_file.dart"
+          function*
+            "SentryFile.file"
+        frame*
+          filename*
+            "sentry_hive.dart"
+          function*
+            "SentryHive.hive"
+        frame*
+          filename*
+            "sentry_isar.dart"
+          function*
+            "SentryIsar.isar"
+        frame*
+          filename*
+            "sentry_sqflite.dart"
+          function*
+            "SentrySqflite.sqflite"
+        frame*
+          filename*
+            "sentry_drift.dart"
+          function*
+            "SentryDrift.drift"
+--------------------------------------------------------------------------
+system:
+  hash: "278cdd35be92e2ffde1d0a40524e7786"
+  component:
+    system*
+      stacktrace*
+        frame*
+          filename*
+            "sentry_logging.dart"
+          function*
+            "SentryLogging.log"
+        frame*
+          filename*
+            "sentry_dio.dart"
+          function*
+            "SentryDio.dio"
+        frame*
+          filename*
+            "sentry_file.dart"
+          function*
+            "SentryFile.file"
+        frame*
+          filename*
+            "sentry_hive.dart"
+          function*
+            "SentryHive.hive"
+        frame*
+          filename*
+            "sentry_isar.dart"
+          function*
+            "SentryIsar.isar"
+        frame*
+          filename*
+            "sentry_sqflite.dart"
+          function*
+            "SentrySqflite.sqflite"
+        frame*
+          filename*
+            "sentry_drift.dart"
+          function*
+            "SentryDrift.drift"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_ignores_sentry_dart_packages.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_ignores_sentry_dart_packages.pysnap
@@ -1,0 +1,198 @@
+---
+created: '2024-06-05T14:22:40.667888+00:00'
+creator: sentry
+source: tests/sentry/grouping/test_variants.py
+---
+app-depth-1:
+  hash: "e10a3875f73ec3361d0dddd2ae273c4a"
+  tree_label: "SentryDrift.drift"
+  component:
+    app-depth-1*
+      stacktrace*
+        frame*
+          filename*
+            "sentry_drift.dart"
+          function*
+            "SentryDrift.drift"
+--------------------------------------------------------------------------
+app-depth-2:
+  hash: "f1885edef882cf108468d65d2d096993"
+  tree_label: "SentryDrift.drift | SentrySqflite.sqflite"
+  component:
+    app-depth-2*
+      stacktrace*
+        frame*
+          filename*
+            "sentry_sqflite.dart"
+          function*
+            "SentrySqflite.sqflite"
+        frame*
+          filename*
+            "sentry_drift.dart"
+          function*
+            "SentryDrift.drift"
+--------------------------------------------------------------------------
+app-depth-3:
+  hash: "36b0fd388c246ad386048546d60352f0"
+  tree_label: "SentryDrift.drift | SentrySqflite.sqflite | SentryIsar.isar"
+  component:
+    app-depth-3*
+      stacktrace*
+        frame*
+          filename*
+            "sentry_isar.dart"
+          function*
+            "SentryIsar.isar"
+        frame*
+          filename*
+            "sentry_sqflite.dart"
+          function*
+            "SentrySqflite.sqflite"
+        frame*
+          filename*
+            "sentry_drift.dart"
+          function*
+            "SentryDrift.drift"
+--------------------------------------------------------------------------
+app-depth-4:
+  hash: "cce67867706823ac00a254dd8281e25f"
+  tree_label: "SentryDrift.drift | SentrySqflite.sqflite | SentryIsar.isar | SentryHive.hive"
+  component:
+    app-depth-4*
+      stacktrace*
+        frame*
+          filename*
+            "sentry_hive.dart"
+          function*
+            "SentryHive.hive"
+        frame*
+          filename*
+            "sentry_isar.dart"
+          function*
+            "SentryIsar.isar"
+        frame*
+          filename*
+            "sentry_sqflite.dart"
+          function*
+            "SentrySqflite.sqflite"
+        frame*
+          filename*
+            "sentry_drift.dart"
+          function*
+            "SentryDrift.drift"
+--------------------------------------------------------------------------
+app-depth-5:
+  hash: "3a36778c4dc968ce25730308094e9cec"
+  tree_label: "SentryDrift.drift | SentrySqflite.sqflite | SentryIsar.isar | SentryHive.hive | SentryFile.file"
+  component:
+    app-depth-5*
+      stacktrace*
+        frame*
+          filename*
+            "sentry_file.dart"
+          function*
+            "SentryFile.file"
+        frame*
+          filename*
+            "sentry_hive.dart"
+          function*
+            "SentryHive.hive"
+        frame*
+          filename*
+            "sentry_isar.dart"
+          function*
+            "SentryIsar.isar"
+        frame*
+          filename*
+            "sentry_sqflite.dart"
+          function*
+            "SentrySqflite.sqflite"
+        frame*
+          filename*
+            "sentry_drift.dart"
+          function*
+            "SentryDrift.drift"
+--------------------------------------------------------------------------
+app-depth-max:
+  hash: "278cdd35be92e2ffde1d0a40524e7786"
+  tree_label: "SentryDrift.drift | SentrySqflite.sqflite | SentryIsar.isar | SentryHive.hive | SentryFile.file | SentryDio.dio | SentryLogging.log"
+  component:
+    app-depth-max*
+      stacktrace*
+        frame*
+          filename*
+            "sentry_logging.dart"
+          function*
+            "SentryLogging.log"
+        frame*
+          filename*
+            "sentry_dio.dart"
+          function*
+            "SentryDio.dio"
+        frame*
+          filename*
+            "sentry_file.dart"
+          function*
+            "SentryFile.file"
+        frame*
+          filename*
+            "sentry_hive.dart"
+          function*
+            "SentryHive.hive"
+        frame*
+          filename*
+            "sentry_isar.dart"
+          function*
+            "SentryIsar.isar"
+        frame*
+          filename*
+            "sentry_sqflite.dart"
+          function*
+            "SentrySqflite.sqflite"
+        frame*
+          filename*
+            "sentry_drift.dart"
+          function*
+            "SentryDrift.drift"
+--------------------------------------------------------------------------
+system:
+  hash: "278cdd35be92e2ffde1d0a40524e7786"
+  tree_label: "SentryDrift.drift | SentrySqflite.sqflite | SentryIsar.isar | SentryHive.hive | SentryFile.file | SentryDio.dio | SentryLogging.log"
+  component:
+    system*
+      stacktrace*
+        frame*
+          filename*
+            "sentry_logging.dart"
+          function*
+            "SentryLogging.log"
+        frame*
+          filename*
+            "sentry_dio.dart"
+          function*
+            "SentryDio.dio"
+        frame*
+          filename*
+            "sentry_file.dart"
+          function*
+            "SentryFile.file"
+        frame*
+          filename*
+            "sentry_hive.dart"
+          function*
+            "SentryHive.hive"
+        frame*
+          filename*
+            "sentry_isar.dart"
+          function*
+            "SentryIsar.isar"
+        frame*
+          filename*
+            "sentry_sqflite.dart"
+          function*
+            "SentrySqflite.sqflite"
+        frame*
+          filename*
+            "sentry_drift.dart"
+          function*
+            "SentryDrift.drift"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_04_05/frame_ignores_sentry_dart_packages.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_04_05/frame_ignores_sentry_dart_packages.pysnap
@@ -1,0 +1,86 @@
+---
+created: '2024-06-05T14:22:44.396711+00:00'
+creator: sentry
+source: tests/sentry/grouping/test_variants.py
+---
+app:
+  hash: null
+  component:
+    app (stacktrace of system takes precedence)
+      stacktrace (ignored because hash matches system variant)
+        frame*
+          filename*
+            "sentry_logging.dart"
+          function*
+            "SentryLogging.log"
+        frame*
+          filename*
+            "sentry_dio.dart"
+          function*
+            "SentryDio.dio"
+        frame*
+          filename*
+            "sentry_file.dart"
+          function*
+            "SentryFile.file"
+        frame*
+          filename*
+            "sentry_hive.dart"
+          function*
+            "SentryHive.hive"
+        frame*
+          filename*
+            "sentry_isar.dart"
+          function*
+            "SentryIsar.isar"
+        frame*
+          filename*
+            "sentry_sqflite.dart"
+          function*
+            "SentrySqflite.sqflite"
+        frame*
+          filename*
+            "sentry_drift.dart"
+          function*
+            "SentryDrift.drift"
+--------------------------------------------------------------------------
+system:
+  hash: "278cdd35be92e2ffde1d0a40524e7786"
+  component:
+    system*
+      stacktrace*
+        frame*
+          filename*
+            "sentry_logging.dart"
+          function*
+            "SentryLogging.log"
+        frame*
+          filename*
+            "sentry_dio.dart"
+          function*
+            "SentryDio.dio"
+        frame*
+          filename*
+            "sentry_file.dart"
+          function*
+            "SentryFile.file"
+        frame*
+          filename*
+            "sentry_hive.dart"
+          function*
+            "SentryHive.hive"
+        frame*
+          filename*
+            "sentry_isar.dart"
+          function*
+            "SentryIsar.isar"
+        frame*
+          filename*
+            "sentry_sqflite.dart"
+          function*
+            "SentrySqflite.sqflite"
+        frame*
+          filename*
+            "sentry_drift.dart"
+          function*
+            "SentryDrift.drift"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_04_17/frame_ignores_sentry_dart_packages.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_04_17/frame_ignores_sentry_dart_packages.pysnap
@@ -1,0 +1,86 @@
+---
+created: '2024-06-05T14:22:46.221114+00:00'
+creator: sentry
+source: tests/sentry/grouping/test_variants.py
+---
+app:
+  hash: null
+  component:
+    app (stacktrace of system takes precedence)
+      stacktrace (ignored because hash matches system variant)
+        frame*
+          filename*
+            "sentry_logging.dart"
+          function*
+            "SentryLogging.log"
+        frame*
+          filename*
+            "sentry_dio.dart"
+          function*
+            "SentryDio.dio"
+        frame*
+          filename*
+            "sentry_file.dart"
+          function*
+            "SentryFile.file"
+        frame*
+          filename*
+            "sentry_hive.dart"
+          function*
+            "SentryHive.hive"
+        frame*
+          filename*
+            "sentry_isar.dart"
+          function*
+            "SentryIsar.isar"
+        frame*
+          filename*
+            "sentry_sqflite.dart"
+          function*
+            "SentrySqflite.sqflite"
+        frame*
+          filename*
+            "sentry_drift.dart"
+          function*
+            "SentryDrift.drift"
+--------------------------------------------------------------------------
+system:
+  hash: "278cdd35be92e2ffde1d0a40524e7786"
+  component:
+    system*
+      stacktrace*
+        frame*
+          filename*
+            "sentry_logging.dart"
+          function*
+            "SentryLogging.log"
+        frame*
+          filename*
+            "sentry_dio.dart"
+          function*
+            "SentryDio.dio"
+        frame*
+          filename*
+            "sentry_file.dart"
+          function*
+            "SentryFile.file"
+        frame*
+          filename*
+            "sentry_hive.dart"
+          function*
+            "SentryHive.hive"
+        frame*
+          filename*
+            "sentry_isar.dart"
+          function*
+            "SentryIsar.isar"
+        frame*
+          filename*
+            "sentry_sqflite.dart"
+          function*
+            "SentrySqflite.sqflite"
+        frame*
+          filename*
+            "sentry_drift.dart"
+          function*
+            "SentryDrift.drift"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/frame_ignores_sentry_dart_packages.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/frame_ignores_sentry_dart_packages.pysnap
@@ -1,0 +1,86 @@
+---
+created: '2024-06-05T14:22:36.817822+00:00'
+creator: sentry
+source: tests/sentry/grouping/test_variants.py
+---
+app:
+  hash: null
+  component:
+    app (stacktrace of system takes precedence)
+      stacktrace (ignored because hash matches system variant)
+        frame*
+          filename*
+            "sentry_logging.dart"
+          function*
+            "SentryLogging.log"
+        frame*
+          filename*
+            "sentry_dio.dart"
+          function*
+            "SentryDio.dio"
+        frame*
+          filename*
+            "sentry_file.dart"
+          function*
+            "SentryFile.file"
+        frame*
+          filename*
+            "sentry_hive.dart"
+          function*
+            "SentryHive.hive"
+        frame*
+          filename*
+            "sentry_isar.dart"
+          function*
+            "SentryIsar.isar"
+        frame*
+          filename*
+            "sentry_sqflite.dart"
+          function*
+            "SentrySqflite.sqflite"
+        frame*
+          filename*
+            "sentry_drift.dart"
+          function*
+            "SentryDrift.drift"
+--------------------------------------------------------------------------
+system:
+  hash: "278cdd35be92e2ffde1d0a40524e7786"
+  component:
+    system*
+      stacktrace*
+        frame*
+          filename*
+            "sentry_logging.dart"
+          function*
+            "SentryLogging.log"
+        frame*
+          filename*
+            "sentry_dio.dart"
+          function*
+            "SentryDio.dio"
+        frame*
+          filename*
+            "sentry_file.dart"
+          function*
+            "SentryFile.file"
+        frame*
+          filename*
+            "sentry_hive.dart"
+          function*
+            "SentryHive.hive"
+        frame*
+          filename*
+            "sentry_isar.dart"
+          function*
+            "SentryIsar.isar"
+        frame*
+          filename*
+            "sentry_sqflite.dart"
+          function*
+            "SentrySqflite.sqflite"
+        frame*
+          filename*
+            "sentry_drift.dart"
+          function*
+            "SentryDrift.drift"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/frame_ignores_sentry_dart_packages.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/frame_ignores_sentry_dart_packages.pysnap
@@ -1,0 +1,86 @@
+---
+created: '2024-06-05T14:22:38.794583+00:00'
+creator: sentry
+source: tests/sentry/grouping/test_variants.py
+---
+app:
+  hash: null
+  component:
+    app (stacktrace of system takes precedence)
+      stacktrace (ignored because hash matches system variant)
+        frame*
+          filename*
+            "sentry_logging.dart"
+          function*
+            "SentryLogging.log"
+        frame*
+          filename*
+            "sentry_dio.dart"
+          function*
+            "SentryDio.dio"
+        frame*
+          filename*
+            "sentry_file.dart"
+          function*
+            "SentryFile.file"
+        frame*
+          filename*
+            "sentry_hive.dart"
+          function*
+            "SentryHive.hive"
+        frame*
+          filename*
+            "sentry_isar.dart"
+          function*
+            "SentryIsar.isar"
+        frame*
+          filename*
+            "sentry_sqflite.dart"
+          function*
+            "SentrySqflite.sqflite"
+        frame*
+          filename*
+            "sentry_drift.dart"
+          function*
+            "SentryDrift.drift"
+--------------------------------------------------------------------------
+system:
+  hash: "278cdd35be92e2ffde1d0a40524e7786"
+  component:
+    system*
+      stacktrace*
+        frame*
+          filename*
+            "sentry_logging.dart"
+          function*
+            "SentryLogging.log"
+        frame*
+          filename*
+            "sentry_dio.dart"
+          function*
+            "SentryDio.dio"
+        frame*
+          filename*
+            "sentry_file.dart"
+          function*
+            "SentryFile.file"
+        frame*
+          filename*
+            "sentry_hive.dart"
+          function*
+            "SentryHive.hive"
+        frame*
+          filename*
+            "sentry_isar.dart"
+          function*
+            "SentryIsar.isar"
+        frame*
+          filename*
+            "sentry_sqflite.dart"
+          function*
+            "SentrySqflite.sqflite"
+        frame*
+          filename*
+            "sentry_drift.dart"
+          function*
+            "SentryDrift.drift"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/frame_ignores_sentry_dart_packages.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/frame_ignores_sentry_dart_packages.pysnap
@@ -1,0 +1,89 @@
+---
+created: '2024-06-05T14:22:42.534841+00:00'
+creator: sentry
+source: tests/sentry/grouping/test_variants.py
+---
+app:
+  hash: null
+  component:
+    app
+      stacktrace
+        frame (marked out of app by stack trace rule (path:package:sentry_logging/** -app -group))
+          filename*
+            "sentry_logging.dart"
+          function*
+            "SentryLogging.log"
+        frame (marked out of app by stack trace rule (path:package:sentry_dio/** -app -group))
+          filename*
+            "sentry_dio.dart"
+          function*
+            "SentryDio.dio"
+        frame (marked out of app by stack trace rule (path:package:sentry_file/** -app -group))
+          filename*
+            "sentry_file.dart"
+          function*
+            "SentryFile.file"
+        frame (marked out of app by stack trace rule (path:package:sentry_hive/** -app -group))
+          filename*
+            "sentry_hive.dart"
+          function*
+            "SentryHive.hive"
+        frame (marked out of app by stack trace rule (path:package:sentry_isar/** -app -group))
+          filename*
+            "sentry_isar.dart"
+          function*
+            "SentryIsar.isar"
+        frame (marked out of app by stack trace rule (path:package:sentry_sqflite/** -app -group))
+          filename*
+            "sentry_sqflite.dart"
+          function*
+            "SentrySqflite.sqflite"
+        frame (marked out of app by stack trace rule (path:package:sentry_drift/** -app -group))
+          filename*
+            "sentry_drift.dart"
+          function*
+            "SentryDrift.drift"
+--------------------------------------------------------------------------
+fallback:
+  hash: "d41d8cd98f00b204e9800998ecf8427e"
+--------------------------------------------------------------------------
+system:
+  hash: null
+  component:
+    system
+      stacktrace
+        frame (ignored by stack trace rule (path:package:sentry_logging/** -app -group))
+          filename*
+            "sentry_logging.dart"
+          function*
+            "SentryLogging.log"
+        frame (ignored by stack trace rule (path:package:sentry_dio/** -app -group))
+          filename*
+            "sentry_dio.dart"
+          function*
+            "SentryDio.dio"
+        frame (ignored by stack trace rule (path:package:sentry_file/** -app -group))
+          filename*
+            "sentry_file.dart"
+          function*
+            "SentryFile.file"
+        frame (ignored by stack trace rule (path:package:sentry_hive/** -app -group))
+          filename*
+            "sentry_hive.dart"
+          function*
+            "SentryHive.hive"
+        frame (ignored by stack trace rule (path:package:sentry_isar/** -app -group))
+          filename*
+            "sentry_isar.dart"
+          function*
+            "SentryIsar.isar"
+        frame (ignored by stack trace rule (path:package:sentry_sqflite/** -app -group))
+          filename*
+            "sentry_sqflite.dart"
+          function*
+            "SentrySqflite.sqflite"
+        frame (ignored by stack trace rule (path:package:sentry_drift/** -app -group))
+          filename*
+            "sentry_drift.dart"
+          function*
+            "SentryDrift.drift"


### PR DESCRIPTION
Mark all published Dart packages as non-inApp.

Taken from https://github.com/getsentry/sentry-dart/blob/e6b16cd4aa51b0236a52f4c6380d53b6d1a1aee9/.craft.yml#L22-L28 and mentioned here https://github.com/getsentry/sentry-dart/issues/2080#issuecomment-2149717943.