### PR TITLE
feat(sdk-crashes): Add dart packages to config

### DIFF
--- a/src/sentry/utils/sdk_crashes/sdk_crash_detection_config.py
+++ b/src/sentry/utils/sdk_crashes/sdk_crash_detection_config.py
@@ -290,6 +290,14 @@ def build_sdk_crash_detection_configs() -> Sequence[SDKCrashDetectionConfig]:
                 path_patterns={
                     r"package:sentry/**",  # sentry-dart
                     r"package:sentry_flutter/**",  # sentry-dart-flutter
+                    # sentry-dart packages
+                    r"package:sentry_logging/**",
+                    r"package:sentry_dio/**",
+                    r"package:sentry_file/**",
+                    r"package:sentry_sqflite/**",
+                    r"package:sentry_drift/**",
+                    r"package:sentry_hive/**",
+                    r"package:sentry_isar/**",
                 },
                 path_replacer=KeepFieldPathReplacer(fields={"package", "filename", "abs_path"}),
             ),

--- a/tests/sentry/utils/sdk_crashes/test_sdk_crash_detection_dart.py
+++ b/tests/sentry/utils/sdk_crashes/test_sdk_crash_detection_dart.py
@@ -87,6 +87,41 @@ def configs() -> Sequence[SDKCrashDetectionConfig]:
             "some/path/package/flutter/src/gestures/recognizer.dart",
             False,
         ),
+        (
+            "package:sentry_logging/src/sentry_logging.dart",
+            "dart:core-patch/growable_array.dart",
+            True,
+        ),
+        (
+            "package:sentry_dio/src/sentry_dio.dart",
+            "dart:core-patch/growable_array.dart",
+            True,
+        ),
+        (
+            "package:sentry_file/src/sentry_file.dart",
+            "dart:core-patch/growable_array.dart",
+            True,
+        ),
+        (
+            "package:sentry_sqflite/src/sentry_sqflite.dart",
+            "dart:core-patch/growable_array.dart",
+            True,
+        ),
+        (
+            "package:sentry_drift/src/sentry_drift.dart",
+            "dart:core-patch/growable_array.dart",
+            True,
+        ),
+        (
+            "package:sentry_hive/src/sentry_hive.dart",
+            "dart:core-patch/growable_array.dart",
+            True,
+        ),
+        (
+            "package:sentry_isar/src/sentry_isar.dart",
+            "dart:core-patch/growable_array.dart",
+            True,
+        ),
     ],
 )
 @decorators


### PR DESCRIPTION
Add all published Dart packages to the Dart config to detect SDK crashes.

