### PR TITLE
chore(hybridcloud) Move hacky AlertRule sentryapp logic to serializer

### DIFF
--- a/src/sentry/api/serializers/models/rule.py
+++ b/src/sentry/api/serializers/models/rule.py
@@ -129,7 +129,7 @@ class RuleSerializer(Serializer):
                 )
                 if sentry_app_uuid is not None
             ]
-            install_contexts = app_service.get_component_context(
+            install_contexts = app_service.get_component_contexts(
                 filter={"uuids": sentry_app_uuids}, component_type="alert-rule-action"
             )
             sentry_app_installations_by_uuid = {

--- a/src/sentry/api/serializers/models/rule.py
+++ b/src/sentry/api/serializers/models/rule.py
@@ -1,23 +1,17 @@
 from collections.abc import Mapping
-from typing import Any, TypedDict
+from typing import TypedDict
 
 from django.db.models import Max, Q, prefetch_related_objects
 from rest_framework import serializers
 
 from sentry.api.serializers import Serializer, register
-from sentry.constants import ObjectStatus, SentryAppStatus
-from sentry.models.apiapplication import ApiApplication
+from sentry.constants import ObjectStatus
 from sentry.models.environment import Environment
-from sentry.models.integrations.sentry_app import SentryApp
-from sentry.models.integrations.sentry_app_component import SentryAppComponent
-from sentry.models.integrations.sentry_app_installation import (
-    SentryAppInstallation,
-    prepare_ui_component,
-)
+from sentry.models.integrations.sentry_app_installation import prepare_ui_component
 from sentry.models.rule import NeglectedRule, Rule, RuleActivity, RuleActivityType
 from sentry.models.rulefirehistory import RuleFireHistory
 from sentry.models.rulesnooze import RuleSnooze
-from sentry.services.hybrid_cloud.app.model import RpcSentryApp
+from sentry.services.hybrid_cloud.app.model import RpcSentryAppComponentContext
 from sentry.services.hybrid_cloud.user.service import user_service
 
 
@@ -124,8 +118,7 @@ class RuleSerializer(Serializer):
 
         rules = {item.id: item for item in item_list}
 
-        sentry_app_installations_by_uuid: Mapping[str, Any] = {}
-        sentry_app_map: Mapping[int, RpcSentryApp] = {}
+        sentry_app_installations_by_uuid: Mapping[str, RpcSentryAppComponentContext] = {}
         if self.prepare_component_fields:
             sentry_app_uuids = [
                 sentry_app_uuid
@@ -136,18 +129,13 @@ class RuleSerializer(Serializer):
                 )
                 if sentry_app_uuid is not None
             ]
-            sentry_app_installs = app_service.get_many(filter=dict(uuids=sentry_app_uuids))
-            sentry_app_map = {
-                install.sentry_app.id: install.sentry_app for install in sentry_app_installs
-            }
-            sentry_app_ids: list[int] = list(sentry_app_map.keys())
-
-            sentry_app_installations_by_uuid = app_service.get_related_sentry_app_components(
-                organization_ids=[rule.project.organization_id for rule in rules.values()],
-                sentry_app_ids=sentry_app_ids,
-                type="alert-rule-action",
-                group_by="uuid",
+            install_contexts = app_service.get_component_context(
+                filter={"uuids": sentry_app_uuids}, component_type="alert-rule-action"
             )
+            sentry_app_installations_by_uuid = {
+                install_context.installation.uuid: install_context
+                for install_context in install_contexts
+            }
 
         for rule in rules.values():
             actor = rule.owner
@@ -160,66 +148,22 @@ class RuleSerializer(Serializer):
                     str(action.get("sentryAppInstallationUuid"))
                 )
                 if install_context:
-                    installation = install_context.get("sentry_app_installation")
-                    sentry_app_component = install_context.get("sentry_app_component")
-                    sentry_app_installation = installation
-                    sentry_app = sentry_app_map.get(installation.get("sentry_app_id"))
-                    if not sentry_app or not sentry_app.application:
-                        continue
+                    rpc_install = install_context.installation
+                    rpc_component = install_context.component
+                    rpc_app = rpc_install.sentry_app
 
-                    # TODO(hybridcloud) This is gross as we're converting between RPC and ORM
-                    # objects to satisfy interface requirements. Ideally we do one RPC call to get
-                    # the necessary sentryapp context, and then prepare ui components from RPC
-                    # objects.
-                    #
-                    # Fixing this mess requires a few steps:
-                    #
-                    # 1. Get this logic out of the endpoint and into the serializer so we can avoid
-                    #    hacking data into the serialized data.
-                    # 2. Introduce new RPC methods that return RPC objects instead of a nested
-                    #    set of maps
-                    # 3. Add new prepare_ui_component function that works with RPC objects.
-                    installation = SentryAppInstallation(**sentry_app_installation)
-                    # The api_token_id field is nulled out to prevent relation traversal as these
-                    # ORM objects are turned back into RPC objects.
-                    installation.api_token_id = None
-
-                    installation.sentry_app = SentryApp(
-                        id=sentry_app.id,
-                        scope_list=sentry_app.scope_list,
-                        application_id=sentry_app.application_id,
-                        application=ApiApplication(
-                            id=sentry_app.application.id,
-                            client_id=sentry_app.application.client_id,
-                            client_secret=sentry_app.application.client_secret,
-                        ),
-                        proxy_user_id=sentry_app.proxy_user_id,
-                        owner_id=sentry_app.owner_id,
-                        name=sentry_app.name,
-                        slug=sentry_app.slug,
-                        uuid=sentry_app.uuid,
-                        events=sentry_app.events,
-                        webhook_url=sentry_app.webhook_url,
-                        status=SentryAppStatus.as_int(sentry_app.status),
-                        metadata=sentry_app.metadata,
-                    )
                     component = prepare_ui_component(
-                        installation,
-                        SentryAppComponent(**sentry_app_component),
+                        rpc_install,
+                        rpc_component,
                         self.project_slug,
                         action.get("settings"),
                     )
-
                     if component is None:
-                        errors.append(
-                            {
-                                "detail": f"Could not fetch details from {installation.sentry_app.name}"
-                            }
-                        )
+                        errors.append({"detail": f"Could not fetch details from {rpc_app.name}"})
                         action["disabled"] = True
                         continue
 
-                    action["formFields"] = component.schema.get("settings", {})
+                    action["formFields"] = component.app_schema.get("settings", {})
 
             if len(errors):
                 result[rule]["errors"] = errors

--- a/src/sentry/incidents/endpoints/organization_alert_rule_details.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_details.py
@@ -18,7 +18,6 @@ from sentry.apidocs.constants import (
 )
 from sentry.apidocs.examples.metric_alert_examples import MetricAlertExamples
 from sentry.apidocs.parameters import GlobalParams, MetricAlertParams
-from sentry.constants import SentryAppStatus
 from sentry.incidents.endpoints.bases import OrganizationAlertRuleEndpoint
 from sentry.incidents.endpoints.serializers.alert_rule import (
     AlertRuleSerializer,
@@ -32,10 +31,6 @@ from sentry.incidents.logic import (
 from sentry.incidents.serializers import AlertRuleSerializer as DrfAlertRuleSerializer
 from sentry.incidents.utils.sentry_apps import trigger_sentry_app_action_creators_for_incidents
 from sentry.integrations.slack.utils import RedisRuleStatus
-from sentry.models.apiapplication import ApiApplication
-from sentry.models.integrations.sentry_app import SentryApp
-from sentry.models.integrations.sentry_app_component import SentryAppComponent
-from sentry.models.integrations.sentry_app_installation import SentryAppInstallation
 from sentry.models.rulesnooze import RuleSnooze
 from sentry.services.hybrid_cloud.app import app_service
 from sentry.services.hybrid_cloud.user.service import user_service
@@ -46,79 +41,10 @@ def fetch_alert_rule(request: Request, organization, alert_rule):
     # Serialize Alert Rule
     expand = request.GET.getlist("expand", [])
     serialized_rule = serialize(
-        alert_rule, request.user, DetailedAlertRuleSerializer(expand=expand)
+        alert_rule,
+        request.user,
+        DetailedAlertRuleSerializer(expand=expand, prepare_component_fields=True),
     )
-
-    # Fetch sentryapp instances to avoid impossible relationship traversal in region silo mode.
-    sentry_app_ids: list[int] = []
-    for trigger in serialized_rule.get("triggers", []):
-        for action in trigger.get("actions", []):
-            if action.get("_sentry_app_installation"):
-                sentry_app_ids.append(
-                    action.get("_sentry_app_installation", {}).get("sentry_app_id", None)
-                )
-    if sentry_app_ids:
-        fetched_rpc_installations = app_service.get_many(
-            filter=dict(app_ids=sentry_app_ids, organization_id=organization.id)
-        )
-        sentry_app_map = {
-            install.sentry_app.id: install.sentry_app for install in fetched_rpc_installations
-        }
-
-    # Prepare AlertRuleTriggerActions that are SentryApp components
-    errors = []
-    for trigger in serialized_rule.get("triggers", []):
-        for action in trigger.get("actions", []):
-            if action.get("_sentry_app_installation") and action.get("_sentry_app_component"):
-                # TODO(hybridcloud) This is nasty and should be fixed.
-                # Because all of the prepare_* functions currently operate on ORM
-                # records we need to convert our RpcSentryApp and dict data into detached
-                # ORM models and stitch together relations used in preparing UI components.
-                installation = SentryAppInstallation(**action.get("_sentry_app_installation", {}))
-                rpc_app = sentry_app_map.get(installation.sentry_app_id)
-                installation.sentry_app = SentryApp(
-                    id=rpc_app.id,
-                    scope_list=rpc_app.scope_list,
-                    application_id=rpc_app.application_id,
-                    application=ApiApplication(
-                        id=rpc_app.application.id,
-                        client_id=rpc_app.application.client_id,
-                        client_secret=rpc_app.application.client_secret,
-                    ),
-                    proxy_user_id=rpc_app.proxy_user_id,
-                    owner_id=rpc_app.owner_id,
-                    name=rpc_app.name,
-                    slug=rpc_app.slug,
-                    uuid=rpc_app.uuid,
-                    events=rpc_app.events,
-                    webhook_url=rpc_app.webhook_url,
-                    status=SentryAppStatus.as_int(rpc_app.status),
-                    metadata=rpc_app.metadata,
-                )
-                # The api_token_id field is nulled out to prevent relation traversal as these
-                # ORM objects are turned back into RPC objects.
-                installation.api_token_id = None
-
-                component = installation.prepare_ui_component(
-                    SentryAppComponent(**action.get("_sentry_app_component")),
-                    None,
-                    action.get("settings"),
-                )
-                if component is None:
-                    errors.append(
-                        {"detail": f"Could not fetch details from {installation.sentry_app.name}"}
-                    )
-                    action["disabled"] = True
-                    continue
-
-                action["formFields"] = component.schema.get("settings", {})
-
-                # Delete meta fields
-                del action["_sentry_app_installation"]
-                del action["_sentry_app_component"]
-
-    if len(errors):
-        serialized_rule["errors"] = errors
 
     rule_snooze = RuleSnooze.objects.filter(
         Q(user_id=request.user.id) | Q(user_id=None), alert_rule=alert_rule

--- a/src/sentry/incidents/endpoints/serializers/alert_rule.py
+++ b/src/sentry/incidents/endpoints/serializers/alert_rule.py
@@ -91,7 +91,7 @@ class AlertRuleSerializerResponse(AlertRuleSerializerResponseOptional):
     createdBy: dict
     monitorType: int
     activations: list[dict]
-    errors: list[str]
+    errors: list[str] | None
 
 
 @register(AlertRule)

--- a/src/sentry/models/integrations/sentry_app_component.py
+++ b/src/sentry/models/integrations/sentry_app_component.py
@@ -1,3 +1,4 @@
+from collections.abc import MutableMapping
 from typing import Any
 
 from django.db import models
@@ -21,6 +22,11 @@ class SentryAppComponent(Model):
     class Meta:
         app_label = "sentry"
         db_table = "sentry_sentryappcomponent"
+
+    @property
+    def app_schema(self) -> MutableMapping[str, Any]:
+        """Provides consistent interface with RpcSentryAppComponent"""
+        return self.schema
 
     @classmethod
     def sanitize_relocation_json(

--- a/src/sentry/models/integrations/sentry_app_installation.py
+++ b/src/sentry/models/integrations/sentry_app_installation.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import uuid
 from collections.abc import Collection, Mapping
 from itertools import chain
-from typing import TYPE_CHECKING, Any, ClassVar
+from typing import TYPE_CHECKING, Any, ClassVar, overload
 
 from django.db import models
 from django.db.models import OuterRef, QuerySet, Subquery
@@ -20,6 +20,7 @@ from sentry.db.models import (
 )
 from sentry.db.models.fields.hybrid_cloud_foreign_key import HybridCloudForeignKey
 from sentry.db.models.outboxes import ReplicatedControlModel
+from sentry.services.hybrid_cloud.app.model import RpcSentryAppComponent, RpcSentryAppInstallation
 from sentry.services.hybrid_cloud.auth import AuthenticatedToken
 from sentry.services.hybrid_cloud.project import RpcProject
 from sentry.types.region import find_regions_for_orgs
@@ -259,12 +260,32 @@ def prepare_sentry_app_components(
     return prepare_ui_component(installation, component, project_slug, values)
 
 
+@overload
 def prepare_ui_component(
     installation: SentryAppInstallation,
     component: SentryAppComponent,
     project_slug: str | None = None,
     values: list[Mapping[str, Any]] | None = None,
 ) -> SentryAppComponent | None:
+    ...
+
+
+@overload
+def prepare_ui_component(
+    installation: RpcSentryAppInstallation,
+    component: RpcSentryAppComponent,
+    project_slug: str | None = None,
+    values: list[Mapping[str, Any]] | None = None,
+) -> RpcSentryAppComponent | None:
+    ...
+
+
+def prepare_ui_component(
+    installation: SentryAppInstallation | RpcSentryAppInstallation,
+    component: SentryAppComponent | RpcSentryAppComponent,
+    project_slug: str | None = None,
+    values: list[Mapping[str, Any]] | None = None,
+) -> SentryAppComponent | RpcSentryAppComponent | None:
     from sentry.coreapi import APIError
     from sentry.sentry_apps.components import SentryAppComponentPreparer
 

--- a/src/sentry/sentry_apps/components.py
+++ b/src/sentry/sentry_apps/components.py
@@ -11,14 +11,15 @@ from django.utils.http import urlencode
 from sentry.mediators.external_requests.select_requester import SelectRequester
 from sentry.models.integrations.sentry_app_component import SentryAppComponent
 from sentry.models.integrations.sentry_app_installation import SentryAppInstallation
+from sentry.services.hybrid_cloud.app.model import RpcSentryAppComponent, RpcSentryAppInstallation
 from sentry.services.hybrid_cloud.app.serial import serialize_sentry_app_installation
 from sentry.utils import json
 
 
 @dataclasses.dataclass
 class SentryAppComponentPreparer:
-    component: SentryAppComponent
-    install: SentryAppInstallation
+    component: SentryAppComponent | RpcSentryAppComponent
+    install: SentryAppInstallation | RpcSentryAppInstallation
     project_slug: str | None = None
     values: list[Mapping[str, Any]] = dataclasses.field(default_factory=list)
 
@@ -31,11 +32,11 @@ class SentryAppComponentPreparer:
             self._prepare_alert_rule_action()
 
     def _prepare_stacktrace_link(self) -> None:
-        schema = self.component.schema
+        schema = self.component.app_schema
         uri = schema.get("uri")
 
         urlparts = list(urlparse(force_str(self.install.sentry_app.webhook_url)))
-        urlparts[2] = uri
+        urlparts[2] = str(uri)
 
         query = {"installationId": self.install.uuid}
 
@@ -46,7 +47,7 @@ class SentryAppComponentPreparer:
         schema.update({"url": urlunparse(urlparts)})
 
     def _prepare_issue_link(self) -> None:
-        schema = self.component.schema.copy()
+        schema = dict(**self.component.app_schema)
 
         link = schema.get("link", {})
         create = schema.get("create", {})
@@ -64,7 +65,7 @@ class SentryAppComponentPreparer:
             self._prepare_field(field)
 
     def _prepare_alert_rule_action(self) -> None:
-        schema = self.component.schema.copy()
+        schema = dict(**self.component.app_schema)
         settings = schema.get("settings", {})
 
         for field in settings.get("required_fields", []):
@@ -101,7 +102,9 @@ class SentryAppComponentPreparer:
                 field.update(self._request(field["uri"], dependent_data=dependant_data))
 
     def _request(self, uri: str, dependent_data: str | None = None) -> Any:
-        install = serialize_sentry_app_installation(self.install, self.install.sentry_app)
+        install = self.install
+        if isinstance(install, SentryAppInstallation):
+            install = serialize_sentry_app_installation(install, install.sentry_app)
         return SelectRequester.run(
             install=install,
             project_slug=self.project_slug,

--- a/src/sentry/services/hybrid_cloud/app/model.py
+++ b/src/sentry/services/hybrid_cloud/app/model.py
@@ -5,7 +5,7 @@
 
 import datetime
 import hmac
-from collections.abc import Mapping
+from collections.abc import MutableMapping
 from hashlib import sha256
 from typing import Any, Protocol, TypedDict
 
@@ -88,7 +88,7 @@ class RpcSentryAppComponent(RpcModel):
     uuid: str = ""
     sentry_app_id: int = -1
     type: str = ""
-    app_schema: Mapping[str, Any] = Field(default_factory=dict)
+    app_schema: MutableMapping[str, Any] = Field(default_factory=dict)
 
 
 class RpcSentryAppComponentContext(RpcModel):

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_details.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_details.py
@@ -268,8 +268,9 @@ class AlertRuleDetailsGetEndpointTest(AlertRuleDetailsBase):
             slug=sentry_app.slug, organization=org2, user=self.superuser
         )
 
-        getmany_response = app_service.get_many(
-            filter=dict(app_ids=[sentry_app.id], organization_id=self.organization.id)
+        get_context_response = app_service.get_component_contexts(
+            filter=dict(app_ids=[sentry_app.id], organization_id=self.organization.id),
+            component_type="alert-rule-action",
         )
 
         rule = self.create_alert_rule()
@@ -298,16 +299,17 @@ class AlertRuleDetailsGetEndpointTest(AlertRuleDetailsBase):
             status=200,
         )
         with self.feature("organizations:incidents"):
-            with mock.patch.object(app_service, "get_many") as mock_get_many:
-                mock_get_many.return_value = getmany_response
+            with mock.patch.object(app_service, "get_component_contexts") as mock_get:
+                mock_get.return_value = get_context_response
                 resp = self.get_response(self.organization.slug, rule.id)
 
-                assert mock_get_many.call_count == 1
-                mock_get_many.assert_called_with(
+                assert mock_get.call_count == 1
+                mock_get.assert_called_with(
                     filter={
                         "app_ids": [sentry_app.id],
                         "organization_id": self.organization.id,
                     },
+                    component_type="alert-rule-action",
                 )
 
         assert resp.status_code == 200


### PR DESCRIPTION
These changes echo the changes made in #71956 and #72035 to AlertRule serialization. Getting this logic out of the endpoint and into the serializer will be helpful for reducing complexity here in the future.

Refs HC-1024