### PR TITLE
ref(discover): clean unused Discover & Dashboard analytic flags

### DIFF
--- a/static/app/utils/analytics/dashboardsAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/dashboardsAnalyticsEvents.tsx
@@ -1,39 +1,3 @@
-// The add/edit widget modal is currently being ported to the widget builder full-page and
-// this will be removed once that is done.
-type DashboardsEventParametersAddWidgetModal = {
-  'dashboards_views.add_widget_modal.change': {
-    field: string;
-    from: string;
-    value: string;
-    widget_type: string;
-  };
-  'dashboards_views.add_widget_modal.confirm': {
-    data_set: string;
-  };
-  'dashboards_views.add_widget_modal.opened': {};
-  'dashboards_views.add_widget_modal.save': {
-    data_set: string;
-  };
-  'dashboards_views.edit_widget_modal.confirm': {};
-  'dashboards_views.edit_widget_modal.opened': {};
-};
-
-const dashboardsEventMapAddWidgetModal: Record<
-  keyof DashboardsEventParametersAddWidgetModal,
-  string | null
-> = {
-  'dashboards_views.edit_widget_modal.confirm':
-    'Dashboards2: Edit Dashboard Widget modal form submitted',
-  'dashboards_views.edit_widget_modal.opened': 'Dashboards2: Edit Widget Modal Opened',
-  'dashboards_views.add_widget_modal.opened': 'Dashboards2: Add Widget Modal opened',
-  'dashboards_views.add_widget_modal.change':
-    'Dashboards2: Field changed in Add Widget Modal',
-  'dashboards_views.add_widget_modal.confirm':
-    'Dashboards2: Add Widget to Dashboard modal form submitted',
-  'dashboards_views.add_widget_modal.save':
-    'Dashboards2: Widget saved directly to Dashboard from Add Widget to Dashboard modal',
-};
-
 // Used in the full-page widget builder
 type DashboardsEventParametersWidgetBuilder = {
   'dashboards_views.widget_builder.change': {
@@ -96,16 +60,10 @@ export type DashboardsEventParameters = {
   'dashboards_views.query_selector.selected': {
     widget_type: string;
   };
-  'dashboards_views.widget_library.add': {
-    num_widgets: number;
-  };
   'dashboards_views.widget_library.add_widget': {
     title: string;
   };
   'dashboards_views.widget_library.opened': {};
-  'dashboards_views.widget_library.switch_tab': {
-    to: string;
-  };
   'dashboards_views.widget_viewer.edit': {
     display_type: string;
     widget_type: string;
@@ -140,8 +98,7 @@ export type DashboardsEventParameters = {
     display_type: string;
     widget_type: string;
   };
-} & DashboardsEventParametersAddWidgetModal &
-  DashboardsEventParametersWidgetBuilder;
+} & DashboardsEventParametersWidgetBuilder;
 
 export type DashboardsEventKey = keyof DashboardsEventParameters;
 
@@ -157,11 +114,8 @@ export const dashboardsEventMap: Record<DashboardsEventKey, string | null> = {
   'dashboards_views.query_selector.selected':
     'Dashboards2: Query selected in Query Selector',
   'dashboards_views.open_in_discover.opened': 'Dashboards2: Widget Opened In Discover',
-  'dashboards_views.widget_library.add': 'Dashboards2: Number of prebuilt widgets added',
   'dashboards_views.widget_library.add_widget':
     'Dashboards2: Title of prebuilt widget added',
-  'dashboards_views.widget_library.switch_tab':
-    'Dashboards2: Widget Library tab switched',
   'dashboards_views.widget_library.opened': 'Dashboards2: Add Widget Library opened',
   'dashboards_manage.search': 'Dashboards Manager: Search',
   'dashboards_manage.change_sort': 'Dashboards Manager: Sort By Changed',
@@ -181,6 +135,5 @@ export const dashboardsEventMap: Record<DashboardsEventKey, string | null> = {
   'dashboards_views.widget_viewer.sort': 'Widget Viewer: Table Sorted',
   'dashboards_views.widget_viewer.toggle_legend': 'Widget Viewer: Legend Toggled',
   'dashboards_views.widget_viewer.zoom': 'Widget Viewer: Chart zoomed',
-  ...dashboardsEventMapAddWidgetModal,
   ...dashboardsEventMapWidgetBuilder,
 };

--- a/static/app/utils/analytics/discoverAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/discoverAnalyticsEvents.tsx
@@ -35,10 +35,7 @@ export type DiscoverEventParameters = SaveQueryEventParameters & {
   'discover_v2.change_sort': {sort: string};
   'discover_v2.column_editor.open': {};
   'discover_v2.create_alert_clicked': {status: string};
-  'discover_v2.event_details': {event_type: EventOrGroupType};
-  'discover_v2.facet_map.clicked': {tag: string};
   'discover_v2.prebuilt_query_click': {query_name?: string};
-  'discover_v2.processed_baseline_toggle.clicked': {toggled: string};
   'discover_v2.quick_context_add_column': {column: string};
   'discover_v2.quick_context_header_copy': {clipBoardTitle: string};
   'discover_v2.quick_context_hover_contexts': {
@@ -64,8 +61,6 @@ export type DiscoverEventParameters = SaveQueryEventParameters & {
   'discover_v2.update_columns': {};
   'discover_v2.view_saved_queries': {};
   'discover_v2.y_axis_change': {y_axis_value: string[]};
-  'discover_views.add_to_dashboard.confirm': {};
-  'discover_views.add_to_dashboard.modal_open': {saved_query: boolean};
 };
 
 export type DiscoverEventKey = keyof DiscoverEventParameters;
@@ -74,10 +69,7 @@ export const discoverEventMap: Record<DiscoverEventKey, string | null> = {
   'discover_v2.add_equation': 'Dicoverv2: Equation added',
   'discover_v2.build_new_query': 'Discoverv2: Build a new Discover Query',
   'discover_v2.change_sort': 'Discoverv2: Sort By Changed',
-  'discover_v2.facet_map.clicked': 'Discoverv2: Clicked on a tag on the facet map',
   'discover_v2.prebuilt_query_click': 'Discoverv2: Click a pre-built query',
-  'discover_v2.processed_baseline_toggle.clicked':
-    'Discoverv2: Clicked processed baseline toggle',
   'discover_v2.tour.advance': 'Discoverv2: Tour Advance',
   'discover_v2.tour.close': 'Discoverv2: Tour Close',
   'discover_v2.tour.start': 'Discoverv2: Tour Start',
@@ -86,10 +78,6 @@ export const discoverEventMap: Record<DiscoverEventKey, string | null> = {
   'discover_v2.set_as_default': 'Discoverv2: Click set as default',
   'discover_v2.remove_default': 'Discoverv2: Click remove default',
   'discover_v2.results.toggle_tag_facets': 'Discoverv2: Toggle Tag Facets',
-  'discover_views.add_to_dashboard.modal_open':
-    'Discover2: Add to Dashboard modal opened',
-  'discover_views.add_to_dashboard.confirm':
-    'Discover2: Add to Dashboard modal form submitted',
   'discover_v2.quick_context_hover_contexts': 'Discover2: Hover over Quick Context',
   'discover_v2.quick_context_add_column': 'Discover2: Add column from Quick Context',
   'discover_v2.quick_context_header_copy':
@@ -116,7 +104,6 @@ export const discoverEventMap: Record<DiscoverEventKey, string | null> = {
   'discover_v2.delete_query_failed': 'Discoverv2: Failed to delete a saved query',
   'discover_v2.delete_query_request': 'Discoverv2: Request to delete a saved query',
   'discover_v2.create_alert_clicked': 'Discoverv2: Create alert clicked',
-  'discover_v2.event_details': 'Discoverv2: Opened Event Details',
   'discover_v2.column_editor.open': 'Discoverv2: Open column editor',
   'discover_v2.results.download_csv': 'Discoverv2: Download CSV',
   'discover_v2.results.cellaction': 'Discoverv2: Cell Action Clicked',

--- a/static/app/views/discover/eventDetails/content.tsx
+++ b/static/app/views/discover/eventDetails/content.tsx
@@ -111,12 +111,6 @@ function EventDetailsContent(props: Props) {
 
     const {organization, location, eventView, isHomepage} = props;
 
-    // metrics
-    trackAnalytics('discover_v2.event_details', {
-      event_type: event.type,
-      organization,
-    });
-
     const transactionName = event.tags.find(tag => tag.key === 'transaction')?.value;
     const transactionSummaryTarget =
       event.type === 'transaction' && transactionName

--- a/static/app/views/discover/tags.tsx
+++ b/static/app/views/discover/tags.tsx
@@ -17,7 +17,6 @@ import {IconWarning} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {Organization} from 'sentry/types/organization';
-import {trackAnalytics} from 'sentry/utils/analytics';
 import type EventView from 'sentry/utils/discover/eventView';
 import {isAPIPayloadSimilar} from 'sentry/utils/discover/eventView';
 import parseLinkHeader from 'sentry/utils/parseLinkHeader';
@@ -153,12 +152,6 @@ class Tags extends Component<Props, State> {
       }
       this.setState({loading: false, error: err});
     }
-  };
-
-  handleTagClick = (tag: string) => {
-    const {organization} = this.props;
-    // metrics
-    trackAnalytics('discover_v2.facet_map.clicked', {organization, tag});
   };
 
   renderTag(tag: Tag, index: number) {


### PR DESCRIPTION
Clean unused Discover and Dashboard feature flags, per https://www.notion.so/sentry/Performance-Analytic-Events-31e3f362b11c4aa88472f4acbfa0a0cb:
- discover_v2.event_details
- discover_v2.facet_map.clicked
- discover_v2.processed_baseline_toggle.clicked
- discover_views.add_to_dashboard.modal_open
- discover_views.add_to_dashboard.confirm
- dashboards_views.widget_library.add
- dashboards_views.widget_library.switch_tab
- dashboard add/edit widget modal analytics