### PR TITLE
feat(query-builder): Support pasted values

### DIFF
--- a/static/app/components/searchQueryBuilder/combobox.tsx
+++ b/static/app/components/searchQueryBuilder/combobox.tsx
@@ -41,6 +41,7 @@ type SearchQueryBuilderComboboxProps = {
   onExit?: () => void;
   onInputChange?: React.ChangeEventHandler<HTMLInputElement>;
   onKeyDown?: (e: React.KeyboardEvent<HTMLInputElement>) => void;
+  onPaste?: (e: React.ClipboardEvent<HTMLInputElement>) => void;
   placeholder?: string;
   tabIndex?: number;
 };
@@ -63,6 +64,7 @@ export const SearchQueryBuilderCombobox = forwardRef(
       autoFocus,
       tabIndex = -1,
       maxOptions,
+      onPaste,
     }: SearchQueryBuilderComboboxProps,
     ref
   ) => {
@@ -176,6 +178,7 @@ export const SearchQueryBuilderCombobox = forwardRef(
           value={inputValue}
           onChange={onInputChange}
           tabIndex={tabIndex}
+          onPaste={onPaste}
         />
         <StyledPositionWrapper
           {...overlayProps}

--- a/static/app/components/searchQueryBuilder/index.spec.tsx
+++ b/static/app/components/searchQueryBuilder/index.spec.tsx
@@ -604,6 +604,20 @@ describe('SearchQueryBuilder', function () {
       expect(document.body).toHaveFocus();
     });
 
+    it('converts pasted text into tokens', async function () {
+      render(<SearchQueryBuilder {...defaultProps} initialQuery="" />);
+
+      await userEvent.click(screen.getByRole('grid'));
+      await userEvent.paste('browser.name:firefox');
+
+      // Should have tokenized the pasted text
+      expect(screen.getByRole('row', {name: 'browser.name:firefox'})).toBeInTheDocument();
+      // Focus should be at the end of the pasted text
+      expect(
+        screen.getAllByRole('combobox', {name: 'Add a search term'}).at(-1)
+      ).toHaveFocus();
+    });
+
     it('can remove parens with the keyboard', async function () {
       render(<SearchQueryBuilder {...defaultProps} initialQuery="(" />);
 

--- a/static/app/components/searchQueryBuilder/index.tsx
+++ b/static/app/components/searchQueryBuilder/index.tsx
@@ -11,8 +11,7 @@ import {PlainTextQueryInput} from 'sentry/components/searchQueryBuilder/plainTex
 import {TokenizedQueryGrid} from 'sentry/components/searchQueryBuilder/tokenizedQueryGrid';
 import {QueryInterfaceType} from 'sentry/components/searchQueryBuilder/types';
 import {useQueryBuilderState} from 'sentry/components/searchQueryBuilder/useQueryBuilderState';
-import {collapseTextTokens} from 'sentry/components/searchQueryBuilder/utils';
-import {parseSearch} from 'sentry/components/searchSyntax/parser';
+import {parseQueryBuilderValue} from 'sentry/components/searchQueryBuilder/utils';
 import {IconClose, IconSearch} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
@@ -67,10 +66,7 @@ export function SearchQueryBuilder({
 }: SearchQueryBuilderProps) {
   const {state, dispatch} = useQueryBuilderState({initialQuery});
 
-  const parsedQuery = useMemo(
-    () => collapseTextTokens(parseSearch(state.query || ' ', {flattenParenGroups: true})),
-    [state.query]
-  );
+  const parsedQuery = useMemo(() => parseQueryBuilderValue(state.query), [state.query]);
 
   useEffectAfterFirstRender(() => {
     dispatch({type: 'UPDATE_QUERY', query: initialQuery});

--- a/static/app/components/searchQueryBuilder/input.tsx
+++ b/static/app/components/searchQueryBuilder/input.tsx
@@ -220,10 +220,10 @@ function SearchQueryBuilderInputInternal({
   // TODO(malwilley): Use input ref to update cursor position on mount
   const [selectionIndex, setSelectionIndex] = useState(0);
 
-  const resetInputValue = () => {
+  const resetInputValue = useCallback(() => {
     setInputValue(trimmedTokenValue);
     // TODO(malwilley): Reset cursor position using ref
-  };
+  }, [trimmedTokenValue]);
 
   const filterValue = getWordAtCursorPosition(inputValue, selectionIndex);
 
@@ -271,6 +271,23 @@ function SearchQueryBuilderInputInternal({
       }
     },
     [item.key, state.collection, state.selectionManager]
+  );
+
+  const onPaste = useCallback(
+    (e: React.ClipboardEvent<HTMLInputElement>) => {
+      e.preventDefault();
+      e.stopPropagation();
+
+      const text = e.clipboardData.getData('text/plain').replace('\n', '').trim();
+
+      dispatch({
+        type: 'PASTE_FREE_TEXT',
+        token,
+        text: replaceAliasedFilterKeys(text, aliasToKeyMap),
+      });
+      resetInputValue();
+    },
+    [aliasToKeyMap, dispatch, resetInputValue, token]
   );
 
   return (
@@ -332,6 +349,7 @@ function SearchQueryBuilderInputInternal({
       onKeyDown={onKeyDown}
       tabIndex={tabIndex}
       maxOptions={50}
+      onPaste={onPaste}
     >
       {sections.map(({title, children}) => (
         <Section title={title} key={title}>

--- a/static/app/components/searchQueryBuilder/utils.tsx
+++ b/static/app/components/searchQueryBuilder/utils.tsx
@@ -8,6 +8,7 @@ import {
   interchangeableFilterOperators,
   type ParseResult,
   type ParseResultToken,
+  parseSearch,
   type TermOperator,
   Token,
   type TokenResult,
@@ -16,6 +17,10 @@ import type {Tag} from 'sentry/types';
 import {escapeDoubleQuotes} from 'sentry/utils';
 
 export const INTERFACE_TYPE_LOCALSTORAGE_KEY = 'search-query-builder-interface';
+
+export function parseQueryBuilderValue(value: string): ParseResult | null {
+  return collapseTextTokens(parseSearch(value || ' ', {flattenParenGroups: true}));
+}
 
 /**
  * Generates a unique key for the given token.


### PR DESCRIPTION
Pasting now immediately tokenizes the clipboard data and places the cursor directly after the pasted text.