### PR TITLE
chore(hybrid-cloud): Adds timeout and retry count options to rpc_method decorator

### DIFF
--- a/src/sentry/hybridcloud/rpc_services/control_organization_provisioning/service.py
+++ b/src/sentry/hybridcloud/rpc_services/control_organization_provisioning/service.py
@@ -31,7 +31,7 @@ class ControlOrganizationProvisioningRpcService(RpcService):
         """
 
     @abstractmethod
-    @rpc_method
+    @rpc_method(timeout_override_seconds=15, retry_count_override=1)
     def idempotent_provision_organization(
         self, *, region_name: str, org_provision_args: OrganizationProvisioningOptions
     ) -> RpcOrganizationSlugReservation | None:


### PR DESCRIPTION
# [WIP] RPC Method Options
Adds `timeout_override_seconds` and `retry_count_override` options to the `rpc_method` decorator, in order to allow per-method overrides of these settings.

Organization provisioning flows have different requirements than most of our typical RPCs and may require additional configuration. Being able to set a retry count and timeout should help with transient failure rates.
