### PR TITLE
fix(traces): Remove extra checks on durations

### DIFF
--- a/static/app/views/performance/traces/fieldRenderers.tsx
+++ b/static/app/views/performance/traces/fieldRenderers.tsx
@@ -184,12 +184,6 @@ export function SpanBreakdownSliceRenderer({
   const traceDuration = trace.end - trace.start;
 
   const sliceDuration = sliceEnd - sliceStart;
-
-  if (sliceNumberWidth === 0 && sliceNumberWidth === undefined && sliceDuration <= 0) {
-    // No slice width or no duration width if it's a regular span.
-    return null;
-  }
-
   const pixelsPerSlice = BREAKDOWN_SIZE_PX / BREAKDOWN_SLICES;
   const relativeSliceStart = sliceStart - trace.start;
 


### PR DESCRIPTION
### Summary
From a comment in another PR, removing some old defensive code from earlier on in the project;
Backend should have the constraints checked, if you have a breakdown at this point it shouldn't be 0 size.
