### PR TITLE
feat(custom-views): Add custom views PUT endpoint

### DIFF
--- a/src/sentry/api/serializers/models/groupsearchview.py
+++ b/src/sentry/api/serializers/models/groupsearchview.py
@@ -22,7 +22,7 @@ class GroupSearchViewSerializer(Serializer):
             "id": str(obj.id),
             "name": obj.name,
             "query": obj.query,
-            "query_sort": obj.query_sort,
+            "querySort": obj.query_sort,
             "position": obj.position,
             "dateCreated": obj.date_added,
             "dateUpdated": obj.date_updated,

--- a/src/sentry/api/serializers/models/groupsearchview.py
+++ b/src/sentry/api/serializers/models/groupsearchview.py
@@ -22,7 +22,7 @@ class GroupSearchViewSerializer(Serializer):
             "id": str(obj.id),
             "name": obj.name,
             "query": obj.query,
-            "querySort": obj.query_sort,
+            "query_sort": obj.query_sort,
             "position": obj.position,
             "dateCreated": obj.date_added,
             "dateUpdated": obj.date_updated,

--- a/src/sentry/api/serializers/rest_framework/groupsearchview.py
+++ b/src/sentry/api/serializers/rest_framework/groupsearchview.py
@@ -1,0 +1,23 @@
+from rest_framework import serializers
+
+from sentry.models.savedsearch import SortOptions
+
+MAX_VIEWS = 50
+
+
+class ViewSerializer(serializers.Serializer):
+    id = serializers.CharField(required=False)
+    name = serializers.CharField(required=True)
+    query = serializers.CharField(required=True)
+    query_sort = serializers.ChoiceField(
+        choices=SortOptions.as_choices(), default=SortOptions.DATE, required=False
+    )
+
+
+class GroupSearchViewRestSerializer(serializers.Serializer):
+    views = serializers.ListField(child=ViewSerializer(), required=True, max_length=MAX_VIEWS)
+
+    def validate(self, data):
+        if len(data.get("views", [])) == 0:
+            raise serializers.ValidationError("Must provide at least one view")
+        return data

--- a/src/sentry/api/serializers/rest_framework/groupsearchview.py
+++ b/src/sentry/api/serializers/rest_framework/groupsearchview.py
@@ -15,9 +15,9 @@ class ViewValidator(serializers.Serializer):
 
 
 class GroupSearchViewValidator(serializers.Serializer):
-    views = serializers.ListField(child=ViewValidator(), required=True, max_length=MAX_VIEWS)
+    views = serializers.ListField(
+        child=ViewValidator(), required=True, min_length=1, max_length=MAX_VIEWS
+    )
 
     def validate(self, data):
-        if len(data.get("views", [])) == 0:
-            raise serializers.ValidationError("Must provide at least one view")
         return data

--- a/src/sentry/api/serializers/rest_framework/groupsearchview.py
+++ b/src/sentry/api/serializers/rest_framework/groupsearchview.py
@@ -9,7 +9,7 @@ class ViewSerializer(serializers.Serializer):
     id = serializers.CharField(required=False)
     name = serializers.CharField(required=True)
     query = serializers.CharField(required=True)
-    query_sort = serializers.ChoiceField(
+    querySort = serializers.ChoiceField(
         choices=SortOptions.as_choices(), default=SortOptions.DATE, required=False
     )
 

--- a/src/sentry/api/serializers/rest_framework/groupsearchview.py
+++ b/src/sentry/api/serializers/rest_framework/groupsearchview.py
@@ -5,7 +5,7 @@ from sentry.models.savedsearch import SortOptions
 MAX_VIEWS = 50
 
 
-class ViewSerializer(serializers.Serializer):
+class ViewValidator(serializers.Serializer):
     id = serializers.CharField(required=False)
     name = serializers.CharField(required=True)
     query = serializers.CharField(required=True)
@@ -14,8 +14,8 @@ class ViewSerializer(serializers.Serializer):
     )
 
 
-class GroupSearchViewRestSerializer(serializers.Serializer):
-    views = serializers.ListField(child=ViewSerializer(), required=True, max_length=MAX_VIEWS)
+class GroupSearchViewValidator(serializers.Serializer):
+    views = serializers.ListField(child=ViewValidator(), required=True, max_length=MAX_VIEWS)
 
     def validate(self, data):
         if len(data.get("views", [])) == 0:

--- a/src/sentry/issues/endpoints/organization_group_search_views.py
+++ b/src/sentry/issues/endpoints/organization_group_search_views.py
@@ -83,7 +83,7 @@ class OrganizationGroupSearchViewsEndpoint(OrganizationEndpoint):
         serializer = GroupSearchViewRestSerializer(data=request.data)
 
         if not serializer.is_valid():
-            return Response(serializer.errors, status=400)
+            return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
         validated_data = serializer.validated_data
         bulk_update_views(organization, request.user.id, validated_data)
@@ -133,6 +133,6 @@ def _create_view(org: Organization, user_id: int, view, position: int):
         user_id=user_id,
         name=view["name"],
         query=view["query"],
-        query_sort=view.get("querySort", SortOptions.DATE),
+        query_sort=view["querySort"],
         position=position,
     )

--- a/src/sentry/issues/endpoints/organization_group_search_views.py
+++ b/src/sentry/issues/endpoints/organization_group_search_views.py
@@ -78,6 +78,13 @@ class OrganizationGroupSearchViewsEndpoint(OrganizationEndpoint):
         )
 
     def put(self, request: Request, organization: Organization) -> Response:
+        """
+        Bulk updates the current organization member's custom views. This endpoint
+        will delete any views that are not included in the request, add views if
+        they are new, and update existing views if they are included in the request.
+        This endpoint is explcititly designed to be used by our frontend.
+
+        """
         if not features.has("organizations:issue-stream-custom-views", organization):
             return Response(status=status.HTTP_404_NOT_FOUND)
 

--- a/src/sentry/issues/endpoints/organization_group_search_views.py
+++ b/src/sentry/issues/endpoints/organization_group_search_views.py
@@ -78,7 +78,7 @@ class OrganizationGroupSearchViewsEndpoint(OrganizationEndpoint):
 
     def put(self, request: Request, organization: Organization) -> Response:
         if not features.has("organizations:issue-stream-custom-views", organization):
-            return Response(status=status.HTTP_405_METHOD_NOT_ALLOWED)
+            return Response(status=status.HTTP_404_NOT_FOUND)
 
         serializer = GroupSearchViewRestSerializer(data=request.data)
 

--- a/src/sentry/issues/endpoints/organization_group_search_views.py
+++ b/src/sentry/issues/endpoints/organization_group_search_views.py
@@ -97,12 +97,10 @@ class OrganizationGroupSearchViewsEndpoint(OrganizationEndpoint):
         try:
             with transaction.atomic(using=router.db_for_write(GroupSearchView)):
                 bulk_update_views(organization, request.user.id, validated_data)
-
-                query = GroupSearchView.objects.filter(
-                    organization=organization, user_id=request.user.id
-                )
         except IntegrityError:
             return Response(status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+
+        query = GroupSearchView.objects.filter(organization=organization, user_id=request.user.id)
 
         return self.paginate(
             request=request,

--- a/src/sentry/issues/endpoints/organization_group_search_views.py
+++ b/src/sentry/issues/endpoints/organization_group_search_views.py
@@ -126,7 +126,7 @@ def _delete_missing_views(org: Organization, user_id: int, view_ids_to_keep: lis
 
 
 def _update_existing_view(view: GroupSearchViewSerializerResponse, position: int):
-    GroupSearchView.objects.filter(id=view["id"]).update(
+    GroupSearchView.objects.get(id=view["id"]).update(
         name=view["name"],
         query=view["query"],
         query_sort=view["querySort"],

--- a/src/sentry/issues/endpoints/organization_group_search_views.py
+++ b/src/sentry/issues/endpoints/organization_group_search_views.py
@@ -15,7 +15,7 @@ from sentry.api.serializers.models.groupsearchview import (
     GroupSearchViewSerializer,
     GroupSearchViewSerializerResponse,
 )
-from sentry.api.serializers.rest_framework.groupsearchview import GroupSearchViewRestSerializer
+from sentry.api.serializers.rest_framework.groupsearchview import GroupSearchViewValidator
 from sentry.models.groupsearchview import GroupSearchView
 from sentry.models.organization import Organization
 from sentry.models.savedsearch import SortOptions
@@ -89,7 +89,7 @@ class OrganizationGroupSearchViewsEndpoint(OrganizationEndpoint):
         if not features.has("organizations:issue-stream-custom-views", organization):
             return Response(status=status.HTTP_404_NOT_FOUND)
 
-        serializer = GroupSearchViewRestSerializer(data=request.data)
+        serializer = GroupSearchViewValidator(data=request.data)
 
         if not serializer.is_valid():
             return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)

--- a/src/sentry/issues/endpoints/organization_group_search_views.py
+++ b/src/sentry/issues/endpoints/organization_group_search_views.py
@@ -1,5 +1,3 @@
-from typing import TypedDict
-
 from rest_framework import status
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -38,13 +36,6 @@ class MemberPermission(OrganizationPermission):
         "GET": ["member:read", "member:write"],
         "PUT": ["member:read", "member:write"],
     }
-
-
-class View(TypedDict):
-    id: str | None
-    name: str
-    query: str
-    query_sort: SortOptions
 
 
 @region_silo_endpoint
@@ -129,11 +120,11 @@ def _delete_missing_views(org: Organization, user_id: int, view_ids_to_keep: lis
     ).delete()
 
 
-def _update_existing_view(view: View, position: int):
+def _update_existing_view(view: GroupSearchViewSerializerResponse, position: int):
     GroupSearchView.objects.filter(id=view["id"]).update(
         name=view["name"],
         query=view["query"],
-        query_sort=view["query_sort"],
+        query_sort=view["querySort"],
         position=position,
     )
 
@@ -144,6 +135,6 @@ def _create_view(org: Organization, user_id: int, view, position: int):
         user_id=user_id,
         name=view["name"],
         query=view["query"],
-        query_sort=view.get("query_sort", SortOptions.DATE),
+        query_sort=view.get("querySort", SortOptions.DATE),
         position=position,
     )

--- a/src/sentry/issues/endpoints/organization_group_search_views.py
+++ b/src/sentry/issues/endpoints/organization_group_search_views.py
@@ -12,8 +12,8 @@ from sentry.api.bases.organization import OrganizationEndpoint, OrganizationPerm
 from sentry.api.paginator import SequencePaginator
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.groupsearchview import (
-    GroupSearchViewSerializer,
     GroupSearchViewRestSerializer,
+    GroupSearchViewSerializer,
     GroupSearchViewSerializerResponse,
 )
 from sentry.models.groupsearchview import GroupSearchView

--- a/src/sentry/issues/endpoints/organization_group_search_views.py
+++ b/src/sentry/issues/endpoints/organization_group_search_views.py
@@ -12,10 +12,10 @@ from sentry.api.bases.organization import OrganizationEndpoint, OrganizationPerm
 from sentry.api.paginator import SequencePaginator
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.groupsearchview import (
-    GroupSearchViewRestSerializer,
     GroupSearchViewSerializer,
     GroupSearchViewSerializerResponse,
 )
+from sentry.api.serializers.rest_framework.groupsearchview import GroupSearchViewRestSerializer
 from sentry.models.groupsearchview import GroupSearchView
 from sentry.models.organization import Organization
 from sentry.models.savedsearch import SortOptions

--- a/src/sentry/issues/endpoints/organization_group_search_views.py
+++ b/src/sentry/issues/endpoints/organization_group_search_views.py
@@ -105,13 +105,11 @@ def bulk_update_views(org: Organization, user_id: int, validated_data):
 
     _delete_missing_views(org, user_id, view_ids_to_keep=existing_view_ids)
 
-    updated_views = []
     for idx, view in enumerate(validated_data["views"]):
         if "id" not in view:
-            updated_views.append(_create_view(org, user_id, view, position=idx))
+            _create_view(org, user_id, view, position=idx)
         else:
-            updated_views.append(_update_existing_view(view, position=idx))
-    return updated_views
+            _update_existing_view(view, position=idx)
 
 
 def _delete_missing_views(org: Organization, user_id: int, view_ids_to_keep: list[int]):

--- a/src/sentry/issues/endpoints/organization_group_search_views.py
+++ b/src/sentry/issues/endpoints/organization_group_search_views.py
@@ -33,7 +33,6 @@ DEFAULT_VIEWS: list[GroupSearchViewSerializerResponse] = [
 class MemberPermission(OrganizationPermission):
     scope_map = {
         "GET": ["member:read", "member:write"],
-        "PUT": ["member:read", "member:write"],
     }
 
 
@@ -41,7 +40,6 @@ class MemberPermission(OrganizationPermission):
 class OrganizationGroupSearchViewsEndpoint(OrganizationEndpoint):
     publish_status = {
         "GET": ApiPublishStatus.EXPERIMENTAL,
-        "POST": ApiPublishStatus.EXPERIMENTAL,
     }
     owner = ApiOwner.ISSUES
     permission_classes = (MemberPermission,)

--- a/src/sentry/issues/endpoints/organization_group_search_views.py
+++ b/src/sentry/issues/endpoints/organization_group_search_views.py
@@ -33,6 +33,7 @@ DEFAULT_VIEWS: list[GroupSearchViewSerializerResponse] = [
 class MemberPermission(OrganizationPermission):
     scope_map = {
         "GET": ["member:read", "member:write"],
+        "PUT": ["member:read", "member:write"],
     }
 
 
@@ -40,6 +41,7 @@ class MemberPermission(OrganizationPermission):
 class OrganizationGroupSearchViewsEndpoint(OrganizationEndpoint):
     publish_status = {
         "GET": ApiPublishStatus.EXPERIMENTAL,
+        "POST": ApiPublishStatus.EXPERIMENTAL,
     }
     owner = ApiOwner.ISSUES
     permission_classes = (MemberPermission,)

--- a/tests/sentry/issues/endpoints/test_organization_group_search_views.py
+++ b/tests/sentry/issues/endpoints/test_organization_group_search_views.py
@@ -191,7 +191,7 @@ class OrganizationGroupSearchViewsPutTest(APITestCase):
         assert len(response.data) == 4  # 3 existing views + 1 new view
         assert response.data[3]["name"] == "Custom View Four"
         assert response.data[3]["query"] == "is:unresolved"
-        assert response.data[3]["query_sort"] == "date"
+        assert response.data[3]["querySort"] == "date"
 
     @with_feature({"organizations:issue-stream-custom-views": True})
     def test_reorder_views(self):
@@ -221,7 +221,7 @@ class OrganizationGroupSearchViewsPutTest(APITestCase):
         assert len(response.data) == 3
         assert response.data[0]["name"] == "New Name"
         assert response.data[0]["query"] == view["query"]
-        assert response.data[0]["query_sort"] == view["query_sort"]
+        assert response.data[0]["querySort"] == view["querySort"]
 
     @with_feature({"organizations:issue-stream-custom-views": True})
     def test_change_query(self):
@@ -232,18 +232,18 @@ class OrganizationGroupSearchViewsPutTest(APITestCase):
         assert len(response.data) == 3
         assert response.data[0]["name"] == view["name"]
         assert response.data[0]["query"] == "is:resolved"
-        assert response.data[0]["query_sort"] == view["query_sort"]
+        assert response.data[0]["querySort"] == view["querySort"]
 
     @with_feature({"organizations:issue-stream-custom-views": True})
     def test_change_sort(self):
         views = self.client.get(self.url).data
         view = views[0]
-        view["query_sort"] = "freq"
+        view["querySort"] = "freq"
         response = self.get_success_response(self.organization.slug, views=views)
         assert len(response.data) == 3
         assert response.data[0]["name"] == view["name"]
         assert response.data[0]["query"] == view["query"]
-        assert response.data[0]["query_sort"] == "freq"
+        assert response.data[0]["querySort"] == "freq"
 
     @with_feature({"organizations:issue-stream-custom-views": True})
     def test_change_everything(self):
@@ -251,12 +251,12 @@ class OrganizationGroupSearchViewsPutTest(APITestCase):
         view = views[0]
         view["name"] = "New Name"
         view["query"] = "is:resolved"
-        view["query_sort"] = "freq"
+        view["querySort"] = "freq"
         response = self.get_success_response(self.organization.slug, views=views)
         assert len(response.data) == 3
         assert response.data[0]["name"] == "New Name"
         assert response.data[0]["query"] == "is:resolved"
-        assert response.data[0]["query_sort"] == "freq"
+        assert response.data[0]["querySort"] == "freq"
 
     @with_feature({"organizations:issue-stream-custom-views": True})
     def test_invalid_no_views(self):
@@ -272,12 +272,12 @@ class OrganizationGroupSearchViewsPutTest(APITestCase):
     def test_invalid_sort(self):
         views = self.client.get(self.url).data
         view = views[0]
-        view["query_sort"] = "alphabetically"
+        view["querySort"] = "alphabetically"
         response = self.get_error_response(self.organization.slug, views=views)
 
         assert response.data == {
             "views": {
-                "query_sort": [
+                "querySort": [
                     ErrorDetail(
                         string='"alphabetically" is not a valid choice.', code="invalid_choice"
                     )

--- a/tests/sentry/issues/endpoints/test_organization_group_search_views.py
+++ b/tests/sentry/issues/endpoints/test_organization_group_search_views.py
@@ -263,8 +263,8 @@ class OrganizationGroupSearchViewsPutTest(APITestCase):
         response = self.get_error_response(self.organization.slug, views=[])
 
         assert response.data == {
-            "non_field_errors": [
-                ErrorDetail(string="Must provide at least one view", code="invalid")
+            "views": [
+                ErrorDetail(string="Ensure this field has at least 1 elements.", code="min_length")
             ]
         }
 

--- a/tests/sentry/issues/endpoints/test_organization_group_search_views.py
+++ b/tests/sentry/issues/endpoints/test_organization_group_search_views.py
@@ -1,10 +1,13 @@
+from django.urls import reverse
+from rest_framework.exceptions import ErrorDetail
+
 from sentry.api.serializers.base import serialize
 from sentry.models.groupsearchview import GroupSearchView
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.helpers.features import with_feature
 
 
-class OrganizationGroupSearchViewsTest(APITestCase):
+class OrganizationGroupSearchViewsGetTest(APITestCase):
     endpoint = "sentry-api-0-organization-group-search-views"
     method = "get"
 
@@ -103,3 +106,198 @@ class OrganizationGroupSearchViewsTest(APITestCase):
         assert view["query"] == "is:unresolved issue.priority:[high, medium]"
         assert view["querySort"] == "date"
         assert view["position"] == 0
+
+
+class OrganizationGroupSearchViewsPutTest(APITestCase):
+    endpoint = "sentry-api-0-organization-group-search-views"
+    method = "put"
+
+    def create_base_data(self):
+        self.custom_view_one = GroupSearchView.objects.create(
+            name="Custom View One",
+            organization=self.organization,
+            user_id=self.user.id,
+            query="is:unresolved",
+            query_sort="date",
+            position=0,
+        )
+
+        self.custom_view_two = GroupSearchView.objects.create(
+            name="Custom View Two",
+            organization=self.organization,
+            user_id=self.user.id,
+            query="is:resolved",
+            query_sort="new",
+            position=1,
+        )
+
+        self.custom_view_three = GroupSearchView.objects.create(
+            name="Custom View Three",
+            organization=self.organization,
+            user_id=self.user.id,
+            query="is:ignored",
+            query_sort="freq",
+            position=2,
+        )
+
+        return {
+            "views": [
+                self.custom_view_one,
+                self.custom_view_two,
+                self.custom_view_three,
+            ]
+        }
+
+    def setUp(self):
+        self.login_as(user=self.user)
+        self.base_data = self.create_base_data()
+
+        self.url = reverse(
+            "sentry-api-0-organization-group-search-views",
+            kwargs={"organization_id_or_slug": self.organization.slug},
+        )
+
+    @with_feature({"organizations:issue-stream-custom-views": True})
+    def test_deletes_missing_views(self):
+        views = self.client.get(self.url).data
+
+        update_custom_view_three = views[2]
+
+        views.pop(1)
+        response = self.get_success_response(self.organization.slug, views=views)
+
+        # Since we removed custom view two from the views list, custom view three
+        # should now be at position 1 (previously position 2)
+        update_custom_view_three["position"] = 1
+
+        assert len(response.data) == 2
+        # The first view should remain unchanged
+        assert response.data[0] == views[0]
+        assert response.data[1] == update_custom_view_three
+
+    @with_feature({"organizations:issue-stream-custom-views": True})
+    def test_adds_view_with_no_id(self):
+        views = self.client.get(self.url).data
+        views.append(
+            {
+                "name": "Custom View Four",
+                "query": "is:unresolved",
+                "query_sort": "date",
+            }
+        )
+
+        response = self.get_success_response(self.organization.slug, views=views)
+
+        assert len(response.data) == 4  # 3 existing views + 1 new view
+        assert response.data[3]["name"] == "Custom View Four"
+        assert response.data[3]["query"] == "is:unresolved"
+        assert response.data[3]["query_sort"] == "date"
+
+    @with_feature({"organizations:issue-stream-custom-views": True})
+    def test_reorder_views(self):
+        views = self.client.get(self.url).data
+        view_one = views[0]
+        view_two = views[1]
+        views[0] = view_two
+        views[1] = view_one
+
+        # We should expect the position of these two views to be swapped in the response
+        view_one["position"] = 1
+        view_two["position"] = 0
+
+        response = self.get_success_response(self.organization.slug, views=views)
+
+        assert len(response.data) == 3
+        assert response.data[0] == view_two
+        assert response.data[1] == view_one
+        assert response.data[2] == views[2]
+
+    @with_feature({"organizations:issue-stream-custom-views": True})
+    def test_rename_views(self):
+        views = self.client.get(self.url).data
+        view = views[0]
+        view["name"] = "New Name"
+        response = self.get_success_response(self.organization.slug, views=views)
+        assert len(response.data) == 3
+        assert response.data[0]["name"] == "New Name"
+        assert response.data[0]["query"] == view["query"]
+        assert response.data[0]["query_sort"] == view["query_sort"]
+
+    @with_feature({"organizations:issue-stream-custom-views": True})
+    def test_change_query(self):
+        views = self.client.get(self.url).data
+        view = views[0]
+        view["query"] = "is:resolved"
+        response = self.get_success_response(self.organization.slug, views=views)
+        assert len(response.data) == 3
+        assert response.data[0]["name"] == view["name"]
+        assert response.data[0]["query"] == "is:resolved"
+        assert response.data[0]["query_sort"] == view["query_sort"]
+
+    @with_feature({"organizations:issue-stream-custom-views": True})
+    def test_change_sort(self):
+        views = self.client.get(self.url).data
+        view = views[0]
+        view["query_sort"] = "freq"
+        response = self.get_success_response(self.organization.slug, views=views)
+        assert len(response.data) == 3
+        assert response.data[0]["name"] == view["name"]
+        assert response.data[0]["query"] == view["query"]
+        assert response.data[0]["query_sort"] == "freq"
+
+    @with_feature({"organizations:issue-stream-custom-views": True})
+    def test_change_everything(self):
+        views = self.client.get(self.url).data
+        view = views[0]
+        view["name"] = "New Name"
+        view["query"] = "is:resolved"
+        view["query_sort"] = "freq"
+        response = self.get_success_response(self.organization.slug, views=views)
+        assert len(response.data) == 3
+        assert response.data[0]["name"] == "New Name"
+        assert response.data[0]["query"] == "is:resolved"
+        assert response.data[0]["query_sort"] == "freq"
+
+    @with_feature({"organizations:issue-stream-custom-views": True})
+    def test_invalid_no_views(self):
+        response = self.get_error_response(self.organization.slug, views=[])
+
+        assert response.data == {
+            "non_field_errors": [
+                ErrorDetail(string="Must provide at least one view", code="invalid")
+            ]
+        }
+
+    @with_feature({"organizations:issue-stream-custom-views": True})
+    def test_invalid_sort(self):
+        views = self.client.get(self.url).data
+        view = views[0]
+        view["query_sort"] = "alphabetically"
+        response = self.get_error_response(self.organization.slug, views=views)
+
+        assert response.data == {
+            "views": {
+                "query_sort": [
+                    ErrorDetail(
+                        string='"alphabetically" is not a valid choice.', code="invalid_choice"
+                    )
+                ]
+            }
+        }
+
+    @with_feature({"organizations:issue-stream-custom-views": True})
+    def test_invalid_over_max_views(self):
+        from sentry.api.serializers.rest_framework.groupsearchview import MAX_VIEWS
+
+        views = [
+            {"name": f"Custom View {i}", "query": "is:unresolved", "query_sort": "date"}
+            for i in range(MAX_VIEWS + 1)
+        ]
+        response = self.get_error_response(self.organization.slug, views=views)
+        assert response.data == {
+            "views": [
+                ErrorDetail(
+                    string="Ensure this field has no more than 50 elements.", code="max_length"
+                )
+            ]
+        }


### PR DESCRIPTION
This PR implements the `PUT` `organizations/.../group-search-views` endpoint, which bulk updates a user's custom views within an organization. 