### PR TITLE
fix(insights): Unlink "Insights" breadcrumb

### DIFF
--- a/static/app/views/performance/utils/useModuleBreadcrumbs.tsx
+++ b/static/app/views/performance/utils/useModuleBreadcrumbs.tsx
@@ -24,7 +24,7 @@ export function useModuleBreadcrumbs(moduleName: RoutableModuleNames): Crumb[] {
     ? [
         {
           label: insightsTitle,
-          to: normalizeUrl(`/organizations/${organization.slug}/${insightsURL}/`),
+          to: undefined, // There is no page at `/insights/` so there is nothing to link to
           preservePageFilters: true,
         },
         {


### PR DESCRIPTION
There's no page at `/insights/` so there's nowhere for that breadcrumb to go. Therefore, no link.

<img width="232" alt="Screenshot 2024-06-05 at 2 25 34 PM" src="https://github.com/getsentry/sentry/assets/989898/9936aa4e-b25d-414b-a23b-304e59c545d4">
