### PR TITLE
fix(dynamic-sampling): add project-level permission check before adding custom rule

### DIFF
--- a/src/sentry/api/endpoints/custom_rules.py
+++ b/src/sentry/api/endpoints/custom_rules.py
@@ -130,7 +130,7 @@ class CustomRulesEndpoint(OrganizationEndpoint):
             return Response(serializer.errors, status=400)
 
         query = serializer.validated_data["query"]
-        projects = serializer.validated_data.get("projects")
+        project_ids = serializer.validated_data.get("projects")
 
         try:
             condition = get_rule_condition(query)
@@ -145,7 +145,7 @@ class CustomRulesEndpoint(OrganizationEndpoint):
                 condition=condition,
                 start=start,
                 end=end,
-                project_ids=projects,
+                project_ids=project_ids,
                 organization_id=organization.id,
                 num_samples=NUM_SAMPLES_PER_CUSTOM_RULE,
                 sample_rate=1.0,
@@ -154,7 +154,7 @@ class CustomRulesEndpoint(OrganizationEndpoint):
             )
 
             # schedule update for affected project configs
-            _schedule_invalidate_project_configs(organization, projects)
+            _schedule_invalidate_project_configs(organization, project_ids)
 
             return _rule_to_response(rule)
         except UnsupportedSearchQuery as e:

--- a/src/sentry/api/endpoints/custom_rules.py
+++ b/src/sentry/api/endpoints/custom_rules.py
@@ -5,7 +5,6 @@ import orjson
 import sentry_sdk
 from django.db import DatabaseError
 from rest_framework import serializers
-from rest_framework.permissions import BasePermission
 from rest_framework.request import Request
 from rest_framework.response import Response
 
@@ -13,6 +12,7 @@ from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases import OrganizationEndpoint
+from sentry.api.bases.organization import OrganizationPermission
 from sentry.exceptions import InvalidSearchQuery
 from sentry.models.dynamicsampling import (
     CUSTOM_RULE_DATE_FORMAT,
@@ -94,7 +94,7 @@ class CustomRulesInputSerializer(serializers.Serializer):
         return data
 
 
-class CustomRulePermission(BasePermission):
+class CustomRulePermission(OrganizationPermission):
     scope_map = {
         "GET": [
             "org:read",

--- a/src/sentry/api/endpoints/custom_rules.py
+++ b/src/sentry/api/endpoints/custom_rules.py
@@ -132,6 +132,9 @@ class CustomRulesEndpoint(OrganizationEndpoint):
         query = serializer.validated_data["query"]
         project_ids = serializer.validated_data.get("projects")
 
+        # project-level permission check
+        self.get_projects(request, organization, project_ids=set(project_ids))
+
         try:
             condition = get_rule_condition(query)
 
@@ -188,6 +191,9 @@ class CustomRulesEndpoint(OrganizationEndpoint):
             requested_projects_ids = _clean_project_list(requested_projects_ids)
         except ValueError:
             return Response({"projects": ["Invalid project id"]}, status=400)
+
+        # project-level permission check
+        self.get_projects(request, organization, project_ids=set(requested_projects_ids))
 
         if requested_projects_ids:
             org_rule = False


### PR DESCRIPTION
If an organization user does not have project-level permission to a project (for example, with Open Membership disabled), they should not be allowed to create or view custom rules (aka _Get Samples_).