### PR TITLE
fix(semver): Handle semver filters that go over query limit

### DIFF
--- a/src/sentry/search/events/constants.py
+++ b/src/sentry/search/events/constants.py
@@ -418,3 +418,7 @@ METRIC_FUNCTION_LIST_BY_TYPE = {
         "count_unique",
     ],
 }
+
+# The limit in snuba currently for a single query is 131,535bytes, including room for other parameters picking 120,000
+# for now
+MAX_PARAMETERS_IN_ARRAY = 120_000

--- a/src/sentry/search/events/datasets/filter_aliases.py
+++ b/src/sentry/search/events/datasets/filter_aliases.py
@@ -18,7 +18,7 @@ from sentry.search.events.filter import (
     translate_transaction_status,
 )
 from sentry.search.events.types import WhereType
-from sentry.search.utils import DEVICE_CLASS, parse_release
+from sentry.search.utils import DEVICE_CLASS, parse_release, validate_snuba_array_parameter
 from sentry.utils.strings import oxfordize_list
 
 
@@ -156,6 +156,11 @@ def release_stage_filter_converter(
         # XXX: Just return a filter that will return no results if we have no versions
         versions = [constants.SEMVER_EMPTY_RELEASE]
 
+    if not validate_snuba_array_parameter(versions):
+        raise InvalidSearchQuery(
+            "Your semantic release.stage filter cannot be handled, please try again with a more narrow filter"
+        )
+
     return Condition(builder.column("release"), Op.IN, versions)
 
 
@@ -222,6 +227,11 @@ def semver_filter_converter(
             final_operator = Op.NOT_IN
             versions = exclude_versions
 
+    if not validate_snuba_array_parameter(versions):
+        raise InvalidSearchQuery(
+            "Your semantic release.version filter cannot be handled, please try again with a more narrow filter"
+        )
+
     if not versions:
         # XXX: Just return a filter that will return no results if we have no versions
         versions = [constants.SEMVER_EMPTY_RELEASE]
@@ -252,6 +262,11 @@ def semver_package_filter_converter(
         # XXX: Just return a filter that will return no results if we have no versions
         versions = [constants.SEMVER_EMPTY_RELEASE]
 
+    if not validate_snuba_array_parameter(versions):
+        raise InvalidSearchQuery(
+            "Your semantic release.package filter cannot be handled, please try again with a more narrow filter"
+        )
+
     return Condition(builder.column("release"), Op.IN, versions)
 
 
@@ -280,6 +295,11 @@ def semver_build_filter_converter(
             negated=negated,
         ).values_list("version", flat=True)[: constants.MAX_SEARCH_RELEASES]
     )
+
+    if not validate_snuba_array_parameter(versions):
+        raise InvalidSearchQuery(
+            "Your semantic release.build filter cannot be handled, please try again with a more narrow filter"
+        )
 
     if not versions:
         # XXX: Just return a filter that will return no results if we have no versions

--- a/src/sentry/search/events/datasets/filter_aliases.py
+++ b/src/sentry/search/events/datasets/filter_aliases.py
@@ -158,7 +158,7 @@ def release_stage_filter_converter(
 
     if not validate_snuba_array_parameter(versions):
         raise InvalidSearchQuery(
-            "Your semantic release.stage filter cannot be handled, please try again with a more narrow filter"
+            "There are too many releases that match your release.stage filter, please try again with a narrower range"
         )
 
     return Condition(builder.column("release"), Op.IN, versions)
@@ -229,7 +229,7 @@ def semver_filter_converter(
 
     if not validate_snuba_array_parameter(versions):
         raise InvalidSearchQuery(
-            "Your semantic release.version filter cannot be handled, please try again with a more narrow filter"
+            "There are too many releases that match your release.version filter, please try again with a narrower range"
         )
 
     if not versions:
@@ -264,7 +264,7 @@ def semver_package_filter_converter(
 
     if not validate_snuba_array_parameter(versions):
         raise InvalidSearchQuery(
-            "Your semantic release.package filter cannot be handled, please try again with a more narrow filter"
+            "There are too many releases that match your release.package filter, please try again with a narrower range"
         )
 
     return Condition(builder.column("release"), Op.IN, versions)
@@ -298,7 +298,7 @@ def semver_build_filter_converter(
 
     if not validate_snuba_array_parameter(versions):
         raise InvalidSearchQuery(
-            "Your semantic release.build filter cannot be handled, please try again with a more narrow filter"
+            "There are too many releases that match your release.build filter, please try again with a narrower range"
         )
 
     if not versions:

--- a/src/sentry/search/utils.py
+++ b/src/sentry/search/utils.py
@@ -19,6 +19,7 @@ from sentry.models.release import Release, follows_semver_versioning_scheme
 from sentry.models.team import Team
 from sentry.models.user import User
 from sentry.search.base import ANY
+from sentry.search.events.constants import MAX_PARAMETERS_IN_ARRAY
 from sentry.services.hybrid_cloud.user.model import RpcUser
 from sentry.services.hybrid_cloud.user.serial import serialize_rpc_user
 from sentry.services.hybrid_cloud.user.service import user_service
@@ -828,3 +829,15 @@ def map_device_class_level(device_class: str) -> str | None:
         if device_class in value:
             return key
     return None
+
+
+def validate_snuba_array_parameter(parameter: Sequence[str]) -> bool:
+    """Returns whether parameter is within a reasonable length to be used as a snuba parameter"""
+    # 4 here is for the 2 quotes around the string + a comma + a space
+    # this should be roughly equivalent to len(str(parameter)), but runs 2x as fast
+    # python -m timeit -n 10000 -s "array=['abcdef123456']*1000" "sum(len(x) for x in array) + 4 * len(array)"
+    # 10000 loops, best of 5: 23.6 usec per loop
+    # python -m timeit -n 10000 -s "array=['abcdef123456']*1000" "len(str(array))"
+    # 10000 loops, best of 5: 42.6 usec per loop
+    converted_length = sum(len(item) for item in parameter) + (4 * len(parameter))
+    return converted_length <= MAX_PARAMETERS_IN_ARRAY


### PR DESCRIPTION
- Currently the semver limits only based on the number of values in the parameter, but not based on the actual bytes its adding to the query
- Introduces a validate_snuba_array_parameter so we can use this more in the future
- Picking 120k as the limit because that's what we're doing in the trace view too
- I'm unsure about the error message, i'm not sure if its clear to customers what "a more narrow filter" means
- Fixes SENTRY-38A7