### PR TITLE
feat(query-builder): Add support for boolean operators

### DIFF
--- a/static/app/components/searchQueryBuilder/boolean.tsx
+++ b/static/app/components/searchQueryBuilder/boolean.tsx
@@ -2,30 +2,26 @@ import type {ListState} from '@react-stately/list';
 import type {Node} from '@react-types/shared';
 
 import {DeletableToken} from 'sentry/components/searchQueryBuilder/deletableToken';
-import {
-  type ParseResultToken,
+import type {
+  ParseResultToken,
   Token,
-  type TokenResult,
+  TokenResult,
 } from 'sentry/components/searchSyntax/parser';
-import {IconParenthesis} from 'sentry/icons/iconParenthesis';
 
-type SearchQueryBuilderParenProps = {
+type SearchQueryBuilderBooleanProps = {
   item: Node<ParseResultToken>;
   state: ListState<ParseResultToken>;
-  token: TokenResult<Token.L_PAREN | Token.R_PAREN>;
+  token: TokenResult<Token.LOGIC_BOOLEAN>;
 };
 
-export function SearchQueryBuilderParen({
+export function SearchQueryBuilderBoolean({
   item,
   state,
   token,
-}: SearchQueryBuilderParenProps) {
+}: SearchQueryBuilderBooleanProps) {
   return (
     <DeletableToken item={item} state={state} token={token} label={token.value}>
-      <IconParenthesis
-        side={token.type === Token.L_PAREN ? 'left' : 'right'}
-        height={26}
-      />
+      {token.text}
     </DeletableToken>
   );
 }

--- a/static/app/components/searchQueryBuilder/deletableToken.tsx
+++ b/static/app/components/searchQueryBuilder/deletableToken.tsx
@@ -1,0 +1,145 @@
+import type React from 'react';
+import {useRef} from 'react';
+import styled from '@emotion/styled';
+import {mergeProps} from '@react-aria/utils';
+import type {ListState} from '@react-stately/list';
+import type {Node} from '@react-types/shared';
+
+import InteractionStateLayer from 'sentry/components/interactionStateLayer';
+import {useSearchQueryBuilder} from 'sentry/components/searchQueryBuilder/context';
+import {useQueryBuilderGridItem} from 'sentry/components/searchQueryBuilder/useQueryBuilderGridItem';
+import {
+  shiftFocusToChild,
+  useShiftFocusToChild,
+} from 'sentry/components/searchQueryBuilder/utils';
+import type {ParseResultToken} from 'sentry/components/searchSyntax/parser';
+import {IconClose} from 'sentry/icons';
+import {t} from 'sentry/locale';
+
+type DeletableTokenProps = {
+  children: React.ReactNode;
+  item: Node<ParseResultToken>;
+  label: string;
+  state: ListState<ParseResultToken>;
+  token: ParseResultToken;
+};
+
+export function DeletableToken({
+  item,
+  state,
+  token,
+  label,
+  children,
+}: DeletableTokenProps) {
+  const ref = useRef<HTMLDivElement>(null);
+  const {dispatch} = useSearchQueryBuilder();
+  const {rowProps, gridCellProps} = useQueryBuilderGridItem(item, state, ref);
+  const {shiftFocusProps} = useShiftFocusToChild(item, state);
+
+  const onKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    if (e.key === 'Backspace' || e.key === 'Delete') {
+      e.preventDefault();
+      e.stopPropagation();
+      dispatch({type: 'DELETE_TOKEN', token});
+    }
+  };
+
+  const onClick = (e: React.MouseEvent<HTMLDivElement>) => {
+    e.stopPropagation();
+    shiftFocusToChild(e.currentTarget, item, state);
+  };
+
+  return (
+    <Wrapper {...mergeProps(rowProps, shiftFocusProps, {onKeyDown, onClick})} ref={ref}>
+      {children}
+      <HoverFocusBorder>
+        <FloatingCloseButton
+          {...gridCellProps}
+          tabIndex={-1}
+          aria-label={t('Delete %s', label)}
+          onClick={e => {
+            e.stopPropagation();
+            dispatch({type: 'DELETE_TOKEN', token});
+          }}
+        >
+          <InteractionStateLayer />
+          <IconClose legacySize="10px" />
+        </FloatingCloseButton>
+      </HoverFocusBorder>
+    </Wrapper>
+  );
+}
+
+const FloatingCloseButton = styled('button')`
+  background: ${p => p.theme.background};
+  outline: none;
+  user-select: none;
+  padding: 0;
+  border: none;
+  color: ${p => p.theme.subText};
+  border-radius: 2px 2px 0 0;
+  box-shadow: 0 0 0 1px ${p => p.theme.innerBorder};
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  position: absolute;
+  top: -14px;
+  height: 14px;
+  width: 100%;
+
+  &:focus,
+  &:hover {
+    outline: none;
+    border: none;
+    background: ${p => p.theme.button.default.backgroundActive};
+  }
+
+  &:focus-visible {
+    box-shadow: 0 0 0 1px ${p => p.theme.innerBorder};
+  }
+`;
+
+const Wrapper = styled('div')`
+  position: relative;
+  height: 24px;
+  border-radius: 2px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: fit-content;
+
+  &:focus {
+    outline: none;
+  }
+
+  /* Need to hide visually but keep focusable */
+  &:not(:hover):not(:focus-within) {
+    color: ${p => p.theme.subText};
+
+    ${FloatingCloseButton} {
+      clip: rect(0 0 0 0);
+      clip-path: inset(50%);
+      height: 1px;
+      overflow: hidden;
+      position: absolute;
+      white-space: nowrap;
+      width: 1px;
+    }
+  }
+`;
+
+const HoverFocusBorder = styled('div')`
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  height: 33px;
+  transform: translate(-50%, -50%);
+  border-radius: 0 0 2px 2px;
+  min-width: 14px;
+  width: calc(100% + 4px);
+
+  &:focus-within,
+  &:hover {
+    box-shadow: 0 0 0 1px ${p => p.theme.innerBorder};
+  }
+`;

--- a/static/app/components/searchQueryBuilder/index.spec.tsx
+++ b/static/app/components/searchQueryBuilder/index.spec.tsx
@@ -390,6 +390,15 @@ describe('SearchQueryBuilder', function () {
 
       expect(screen.queryByRole('row', {name: '('})).not.toBeInTheDocument();
     });
+
+    it('can remove boolean ops by clicking the delete button', async function () {
+      render(<SearchQueryBuilder {...defaultProps} initialQuery="OR" />);
+
+      expect(screen.getByRole('row', {name: 'OR'})).toBeInTheDocument();
+      await userEvent.click(screen.getByRole('gridcell', {name: 'Delete OR'}));
+
+      expect(screen.queryByRole('row', {name: 'OR'})).not.toBeInTheDocument();
+    });
   });
 
   describe('new search tokens', function () {
@@ -625,6 +634,17 @@ describe('SearchQueryBuilder', function () {
       await userEvent.keyboard('{backspace}{backspace}');
 
       expect(screen.queryByRole('row', {name: '('})).not.toBeInTheDocument();
+    });
+
+    it('can remove boolean ops with the keyboard', async function () {
+      render(<SearchQueryBuilder {...defaultProps} initialQuery="and" />);
+
+      expect(screen.getByRole('row', {name: 'and'})).toBeInTheDocument();
+
+      await userEvent.click(screen.getByRole('grid'));
+      await userEvent.keyboard('{backspace}{backspace}');
+
+      expect(screen.queryByRole('row', {name: 'and'})).not.toBeInTheDocument();
     });
 
     it('exits filter value when pressing escape', async function () {

--- a/static/app/components/searchQueryBuilder/input.tsx
+++ b/static/app/components/searchQueryBuilder/input.tsx
@@ -23,7 +23,7 @@ import {
 } from 'sentry/components/searchSyntax/parser';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
-import type {Tag} from 'sentry/types';
+import type {Tag} from 'sentry/types/group';
 import {FieldKind, getFieldDefinition} from 'sentry/utils/fields';
 import {toTitleCase} from 'sentry/utils/string/toTitleCase';
 
@@ -215,7 +215,7 @@ function SearchQueryBuilderInputInternal({
   tabIndex,
   state,
 }: SearchQueryBuilderInputInternalProps) {
-  const trimmedTokenValue = token.value.trim();
+  const trimmedTokenValue = token.text.trim();
   const [inputValue, setInputValue] = useState(trimmedTokenValue);
   // TODO(malwilley): Use input ref to update cursor position on mount
   const [selectionIndex, setSelectionIndex] = useState(0);
@@ -304,9 +304,11 @@ function SearchQueryBuilderInputInternal({
       }}
       onCustomValueBlurred={value => {
         dispatch({type: 'UPDATE_FREE_TEXT', token, text: value});
+        resetInputValue();
       }}
       onCustomValueCommitted={value => {
         dispatch({type: 'UPDATE_FREE_TEXT', token, text: value});
+        resetInputValue();
 
         // Because the query does not change until a subsequent render,
         // we need to do the replacement that is does in the ruducer here
@@ -315,6 +317,7 @@ function SearchQueryBuilderInputInternal({
       onExit={() => {
         if (inputValue !== token.value.trim()) {
           dispatch({type: 'UPDATE_FREE_TEXT', token, text: inputValue});
+          resetInputValue();
         }
       }}
       inputValue={inputValue}
@@ -329,6 +332,7 @@ function SearchQueryBuilderInputInternal({
             text: e.target.value,
             focusOverride: calculateNextFocusForParen(item),
           });
+          resetInputValue();
           return;
         }
 

--- a/static/app/components/searchQueryBuilder/tokenizedQueryGrid.tsx
+++ b/static/app/components/searchQueryBuilder/tokenizedQueryGrid.tsx
@@ -6,6 +6,7 @@ import type {ListState} from '@react-stately/list';
 import {useListState} from '@react-stately/list';
 import type {CollectionChildren} from '@react-types/shared';
 
+import {SearchQueryBuilderBoolean} from 'sentry/components/searchQueryBuilder/boolean';
 import {useSearchQueryBuilder} from 'sentry/components/searchQueryBuilder/context';
 import {SearchQueryBuilderFilter} from 'sentry/components/searchQueryBuilder/filter';
 import {SearchQueryBuilderInput} from 'sentry/components/searchQueryBuilder/input';
@@ -73,6 +74,15 @@ function Grid(props: GridProps) {
           case Token.R_PAREN:
             return (
               <SearchQueryBuilderParen
+                key={item.key}
+                token={token}
+                item={item}
+                state={state}
+              />
+            );
+          case Token.LOGIC_BOOLEAN:
+            return (
+              <SearchQueryBuilderBoolean
                 key={item.key}
                 token={token}
                 item={item}


### PR DESCRIPTION
Similar to parens, so I pulled out the common logic into a new `DeletableToken` component.

![CleanShot 2024-06-05 at 11 56 06](https://github.com/getsentry/sentry/assets/10888943/402ff8cc-7b9f-4182-a5ab-e8ec25226413)
