### PR TITLE
update clickhouse version to 23.3.19.33

### DIFF
--- a/config/clickhouse/loc_config.xml
+++ b/config/clickhouse/loc_config.xml
@@ -1,3 +1,6 @@
 <yandex>
     <max_server_memory_usage_to_ram_ratio>0.3</max_server_memory_usage_to_ram_ratio>
+    <merge_tree>
+        <old_parts_lifetime>1</old_parts_lifetime>
+    </merge_tree>
 </yandex>

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -2868,7 +2868,7 @@ SENTRY_DEVSERVICES: dict[str, Callable[[Any, Any], dict[str, Any]]] = {
     "clickhouse": lambda settings, options: (
         {
             "image": (
-                "ghcr.io/getsentry/image-mirror-altinity-clickhouse-server:22.8.15.25.altinitystable"
+                "ghcr.io/getsentry/image-mirror-altinity-clickhouse-server:23.3.19.33.altinitystable"
             ),
             "ports": {"9000/tcp": 9000, "9009/tcp": 9009, "8123/tcp": 8123},
             "ulimits": [{"name": "nofile", "soft": 262144, "hard": 262144}],


### PR DESCRIPTION
As of today we have finally upgrade all SaaS clickhouse clusters to `23.3.19.33`, we should now be using that as the default for local development. Self-hosted is actually already defaulting to `23.8`, which will be the next version SaaS/ST will be upgrading to shortly. 