### PR TITLE
fix(grouping): Clean up and fix issues with Seer grouping tests

### DIFF
--- a/tests/sentry/event_manager/grouping/test_seer_grouping.py
+++ b/tests/sentry/event_manager/grouping/test_seer_grouping.py
@@ -234,7 +234,8 @@ class SeerEventManagerGroupingTest(TestCase):
             assert existing_event.group_id == new_event.group_id
 
     @with_feature("projects:similarity-embeddings-grouping")
-    def test_creates_new_group_if_no_neighbor_found(self):
+    @patch("sentry.event_manager.should_call_seer_for_grouping", return_value=True)
+    def test_creates_new_group_if_no_neighbor_found(self, _):
         existing_event = save_new_event({"message": "Dogs are great!"}, self.project)
 
         with patch(
@@ -246,7 +247,8 @@ class SeerEventManagerGroupingTest(TestCase):
             assert existing_event.group_id != new_event.group_id
 
     @with_feature("projects:similarity-embeddings-grouping")
-    def test_creates_new_group_if_too_far_neighbor_found(self):
+    @patch("sentry.event_manager.should_call_seer_for_grouping", return_value=True)
+    def test_creates_new_group_if_too_far_neighbor_found(self, _):
         existing_event = save_new_event({"message": "Dogs are great!"}, self.project)
 
         no_cigar_data = SeerSimilarIssueData(

--- a/tests/sentry/event_manager/grouping/test_seer_grouping.py
+++ b/tests/sentry/event_manager/grouping/test_seer_grouping.py
@@ -227,19 +227,23 @@ class SeerEventManagerGroupingTest(TestCase):
         with patch(
             "sentry.grouping.ingest.seer.get_similarity_data_from_seer",
             return_value=[seer_result_data],
-        ):
+        ) as mock_get_similarity_data:
             new_event = save_new_event({"message": "Adopt don't shop"}, self.project)
 
-        assert existing_event.group_id == new_event.group_id
+            assert mock_get_similarity_data.call_count == 1
+            assert existing_event.group_id == new_event.group_id
 
     @with_feature("projects:similarity-embeddings-grouping")
     def test_creates_new_group_if_no_neighbor_found(self):
         existing_event = save_new_event({"message": "Dogs are great!"}, self.project)
 
-        with patch("sentry.grouping.ingest.seer.get_similarity_data_from_seer", return_value=[]):
+        with patch(
+            "sentry.grouping.ingest.seer.get_similarity_data_from_seer", return_value=[]
+        ) as mock_get_similarity_data:
             new_event = save_new_event({"message": "Adopt don't shop"}, self.project)
 
-        assert existing_event.group_id != new_event.group_id
+            assert mock_get_similarity_data.call_count == 1
+            assert existing_event.group_id != new_event.group_id
 
     @with_feature("projects:similarity-embeddings-grouping")
     def test_creates_new_group_if_too_far_neighbor_found(self):
@@ -256,7 +260,8 @@ class SeerEventManagerGroupingTest(TestCase):
         with patch(
             "sentry.grouping.ingest.seer.get_similarity_data_from_seer",
             return_value=[no_cigar_data],
-        ):
+        ) as mock_get_similarity_data:
             new_event = save_new_event({"message": "Adopt don't shop"}, self.project)
 
-        assert existing_event.group_id != new_event.group_id
+            assert mock_get_similarity_data.call_count == 1
+            assert existing_event.group_id != new_event.group_id

--- a/tests/sentry/event_manager/grouping/test_seer_grouping.py
+++ b/tests/sentry/event_manager/grouping/test_seer_grouping.py
@@ -169,15 +169,13 @@ class SeerEventManagerGroupingTest(TestCase):
             assert mock_with_circuit_breaker.call_count == 2  # increased
             assert mock_get_seer_similar_issues.call_count == 1  # didn't increase
 
-    @with_feature("projects:similarity-embeddings-metadata")
-    @patch("sentry.grouping.ingest.seer.event_content_is_seer_eligible", return_value=True)
+    @patch("sentry.event_manager.should_call_seer_for_grouping", return_value=True)
     @patch("sentry.event_manager.get_seer_similar_issues", return_value=({}, None))
     def test_calls_seer_if_no_group_found(self, mock_get_seer_similar_issues: MagicMock, _):
         save_new_event({"message": "Dogs are great!"}, self.project)
         assert mock_get_seer_similar_issues.call_count == 1
 
-    @with_feature("projects:similarity-embeddings-metadata")
-    @patch("sentry.grouping.ingest.seer.event_content_is_seer_eligible", return_value=True)
+    @patch("sentry.event_manager.should_call_seer_for_grouping", return_value=True)
     @patch("sentry.event_manager.get_seer_similar_issues", return_value=({}, None))
     def test_bypasses_seer_if_group_found(self, mock_get_seer_similar_issues: MagicMock, _):
         existing_event = save_new_event({"message": "Dogs are great!"}, self.project)
@@ -187,8 +185,7 @@ class SeerEventManagerGroupingTest(TestCase):
         assert existing_event.group_id == new_event.group_id
         assert mock_get_seer_similar_issues.call_count == 1  # didn't get called again
 
-    @with_feature("projects:similarity-embeddings-metadata")
-    @patch("sentry.grouping.ingest.seer.event_content_is_seer_eligible", return_value=True)
+    @patch("sentry.event_manager.should_call_seer_for_grouping", return_value=True)
     def test_stores_seer_results_in_metadata(self, _):
         existing_event = save_new_event({"message": "Dogs are great!"}, self.project)
 
@@ -215,7 +212,7 @@ class SeerEventManagerGroupingTest(TestCase):
         assert new_event.data["seer_similarity"] == expected_metadata
 
     @with_feature("projects:similarity-embeddings-grouping")
-    @patch("sentry.grouping.ingest.seer.event_content_is_seer_eligible", return_value=True)
+    @patch("sentry.event_manager.should_call_seer_for_grouping", return_value=True)
     def test_assigns_event_to_neighbor_group_if_found(self, _):
         existing_event = save_new_event({"message": "Dogs are great!"}, self.project)
 


### PR DESCRIPTION
This is a small clean-up/fix related to a bug I realized I'd written into my recently added `test_creates_new_group_if_no_neighbor_found` and `test_creates_new_group_if_too_far_neighbor_found` Seer grouping tests, to wit: My assertions were passing, but for the wrong reason (the Seer codepath being skipped entirely rather than the codepath running and deciding not to group). To fix this, I made the following changes:

- The tests now check that the Seer function (`get_similarity_data_from_seer`) is actually called.
- In order to make sure they actually do call the function, `should_call_seer_for_grouping` is mocked to return `True`.

As I was making the second change, I realized that was actually a better/cleaner/more robust way to force use of the Seer codepath in the other tests, too, so I also switched them to use the same method.