### PR TITLE
ref(seer grouping): Don't call Seer when there's a custom fingerprint

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -1491,7 +1491,7 @@ def _save_aggregate(
             if existing_grouphash is None:
                 seer_matched_group = None
 
-                if should_call_seer_for_grouping(event, project):
+                if should_call_seer_for_grouping(event, project, primary_hashes):
                     try:
                         # If the `projects:similarity-embeddings-grouping` feature is disabled,
                         # we'll still get back result metadata, but `seer_matched_group` will be None

--- a/src/sentry/grouping/ingest/seer.py
+++ b/src/sentry/grouping/ingest/seer.py
@@ -16,19 +16,36 @@ from sentry.utils import metrics
 logger = logging.getLogger("sentry.events.grouping")
 
 
-def should_call_seer_for_grouping(event: Event, project: Project) -> bool:
+def should_call_seer_for_grouping(
+    event: Event, project: Project, primary_hashes: CalculatedHashes
+) -> bool:
     """
     Use event content, feature flags, rate limits, killswitches, seer health, etc. to determine
     whether a call to Seer should be made.
     """
     # TODO: Implement rate limits, kill switches, other flags, etc
-    # TODO: Return False if the event has a custom fingerprint (check for both client- and server-side fingerprints)
 
     has_either_seer_grouping_feature = features.has(
         "projects:similarity-embeddings-metadata", project
     ) or features.has("projects:similarity-embeddings-grouping", project)
 
     if not has_either_seer_grouping_feature:
+        return False
+
+    # TODO: In our context, this can never happen. There are other scenarios in which `variants` can
+    # be `None`, but where we'll be using this (during ingestion) it's not possible. This check is
+    # primarily to satisfy mypy. Once we get rid of hierarchical hashing, we'll be able to
+    # make `variants` required in `CalculatedHashes`, meaning we can remove this check. (See note in
+    # `CalculatedHashes` class definition.)
+    if primary_hashes.variants is None:
+        raise Exception("Primary hashes missing variants data")
+
+    fingerprint_variant = primary_hashes.variants.get(
+        "custom-fingerprint"
+    ) or primary_hashes.variants.get("built-in-fingerprint")
+    # If there's non-default fingerprint (whether from the user or from us), it should *always*
+    # contribute, but can't hurt to cover our bases
+    if fingerprint_variant and fingerprint_variant.contributes:
         return False
 
     if not event_content_is_seer_eligible(event):


### PR DESCRIPTION
This adds a custom fingerprint check to `should_call_seer_for_grouping`, so that if the user has (or we have) forced the event to have a certain fingerprint, the grouping based on that fingerprint is always used, rather than deferring to Seer. (This new check thus prevents us from calling Seer, since we know we won't use whatever it might tell us.)