### PR TITLE
fix(performance): Only display Interaction samples with a target

### DIFF
--- a/static/app/views/performance/browser/webVitals/pageOverview.spec.tsx
+++ b/static/app/views/performance/browser/webVitals/pageOverview.spec.tsx
@@ -179,7 +179,7 @@ describe('PageOverview', function () {
               'span.description',
             ],
             query:
-              'span.op:ui.interaction.click measurements.score.weight.inp:>0 origin.transaction:/',
+              'has:message !span.description:<unknown> span.op:ui.interaction.click measurements.score.weight.inp:>0 origin.transaction:/',
           }),
         })
       )
@@ -227,7 +227,7 @@ describe('PageOverview', function () {
               'span.description',
             ],
             query:
-              'span.op:ui.interaction.click measurements.score.weight.inp:>0 origin.transaction:"/page-with-a-\\*/"',
+              'has:message !span.description:<unknown> span.op:ui.interaction.click measurements.score.weight.inp:>0 origin.transaction:"/page-with-a-\\*/"',
           }),
         })
       )

--- a/static/app/views/performance/browser/webVitals/utils/queries/useInpSpanSamplesWebVitalsQuery.tsx
+++ b/static/app/views/performance/browser/webVitals/utils/queries/useInpSpanSamplesWebVitalsQuery.tsx
@@ -30,6 +30,8 @@ export function useInpSpanSamplesWebVitalsQuery({
   const {data, isLoading, ...rest} = useSpansIndexed(
     {
       search: MutableSearch.fromQueryObject({
+        has: 'message',
+        [`!${SpanIndexedField.SPAN_DESCRIPTION}`]: '<unknown>',
         'span.op': 'ui.interaction.click',
         'measurements.score.weight.inp': '>0',
         ...(transaction !== undefined


### PR DESCRIPTION
Some interaction samples may not have a target associated. This can happen for a number of different reasons. This change updates the webvitals module to only fetch interactions that have a target.