### PR TITLE
fix(perf): Use avg duration on span summary page

### DIFF
--- a/static/app/views/performance/transactionSummary/transactionSpans/spanSummary/content.tsx
+++ b/static/app/views/performance/transactionSummary/transactionSpans/spanSummary/content.tsx
@@ -111,10 +111,9 @@ function SpanSummaryContent(props: ContentProps) {
   const {data: spanHeaderData} = useSpanMetrics(
     {
       search: MutableSearch.fromQueryObject(filters),
-      // TODO: query average duration instead of self time before releasing this
       fields: [
         'span.description',
-        'avg(span.self_time)',
+        'avg(span.duration)',
         'sum(span.self_time)',
         'count()',
       ],
@@ -124,7 +123,7 @@ function SpanSummaryContent(props: ContentProps) {
 
   const description = spanHeaderData[0]?.['span.description'];
   const timeSpent = spanHeaderData[0]?.['sum(span.self_time)'];
-  const avgDuration = spanHeaderData[0]?.['avg(span.self_time)'];
+  const avgDuration = spanHeaderData[0]?.['avg(span.duration)'];
   const spanCount = spanHeaderData[0]?.['count()'];
 
   return (

--- a/static/app/views/performance/transactionSummary/transactionSpans/spanSummary/spanSummaryCharts.tsx
+++ b/static/app/views/performance/transactionSummary/transactionSpans/spanSummary/spanSummaryCharts.tsx
@@ -60,8 +60,7 @@ function SpanSummaryCharts() {
   } = useSpanMetricsSeries(
     {
       search: MutableSearch.fromQueryObject(filters),
-      // TODO: Switch this to SPAN_DURATION before release
-      yAxis: [`avg(${SpanMetricsField.SPAN_SELF_TIME})`],
+      yAxis: [`avg(${SpanMetricsField.SPAN_DURATION})`],
     },
     SpanSummaryReferrer.SPAN_SUMMARY_DURATION_CHART
   );
@@ -121,7 +120,7 @@ function SpanSummaryCharts() {
         <ChartPanel title={t('Average Duration')}>
           <Chart
             height={160}
-            data={[avgDurationData?.[`avg(${SpanMetricsField.SPAN_SELF_TIME})`]]}
+            data={[avgDurationData?.[`avg(${SpanMetricsField.SPAN_DURATION})`]]}
             loading={isAvgDurationDataLoading}
             type={ChartType.LINE}
             definedAxisTicks={4}


### PR DESCRIPTION
This was temporarily set to query by `avg(span.self_time)` because `span.duration` got ingested later on and we had sparse data. We got data now so we can switch back to using `avg(span.duration)`