### PR TITLE
ref: convert DummyNewsletter's enable / disable to a context manager

### DIFF
--- a/src/sentry/newsletter/dummy.py
+++ b/src/sentry/newsletter/dummy.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
+import contextlib
 from collections import defaultdict
-from collections.abc import Sequence
+from collections.abc import Generator, Sequence
 from typing import Any
 
 from django.utils import timezone
@@ -75,11 +76,13 @@ class DummyNewsletter(Newsletter):
         self._subscriptions: dict[User, dict[int, NewsletterSubscription]] = defaultdict(dict)
         self._enabled = enabled
 
-    def enable(self):
+    @contextlib.contextmanager
+    def enable(self) -> Generator[None, None, None]:
         self._enabled = True
-
-    def disable(self):
-        self._enabled = False
+        try:
+            yield
+        finally:
+            self._enabled = False
 
     def clear(self):
         self._subscriptions = defaultdict(dict)

--- a/tests/sentry/api/endpoints/test_auth_config.py
+++ b/tests/sentry/api/endpoints/test_auth_config.py
@@ -3,6 +3,7 @@ from django.conf import settings
 from django.test.utils import override_settings
 
 from sentry import newsletter
+from sentry.newsletter.dummy import DummyNewsletter
 from sentry.receivers import create_default_projects
 from sentry.silo.base import SiloMode
 from sentry.testutils.cases import APITestCase
@@ -60,9 +61,8 @@ class AuthConfigEndpointTest(APITestCase):
         reason="Requires DummyNewsletter.",
     )
     def test_has_newsletter(self):
-        newsletter.backend.enable()
-        response = self.client.get(self.path)
-        newsletter.backend.disable()
+        with newsletter.backend.test_only__downcast_to(DummyNewsletter).enable():
+            response = self.client.get(self.path)
 
         assert response.status_code == 200
         assert response.data["hasNewsletter"]


### PR DESCRIPTION
split out from my typesafe-LazyServiceWrapper branch.  this enables a "safe" way to access service-implementation-specific methods under test

<!-- Describe your PR here. -->