### PR TITLE
ref: make eventstore signatures match

### DIFF
--- a/src/sentry/eventstore/base.py
+++ b/src/sentry/eventstore/base.py
@@ -164,11 +164,12 @@ class EventStorage(Service):
 
     def get_events(
         self,
-        snuba_filter,
+        filter,
         orderby=None,
         limit=100,
         offset=0,
         referrer="eventstore.get_events",
+        dataset=Dataset.Events,
         tenant_ids=None,
     ):
         """
@@ -204,11 +205,12 @@ class EventStorage(Service):
 
     def get_unfetched_events(
         self,
-        snuba_filter,
+        filter,
         orderby=None,
         limit=100,
         offset=0,
         referrer="eventstore.get_unfetched_events",
+        dataset=Dataset.Events,
         tenant_ids=None,
     ):
         """


### PR DESCRIPTION
the mismatch violates substitutability -- these signatures are copied from the snuba implementation

<!-- Describe your PR here. -->