### PR TITLE
feat(discover): track successful discover query result count

### DIFF
--- a/static/app/utils/analytics/discoverAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/discoverAnalyticsEvents.tsx
@@ -30,6 +30,11 @@ export type DiscoverEventParameters = SaveQueryEventParameters & {
     search_source: string;
     search_type: string;
   };
+  'discover_search.success': {
+    has_results: boolean;
+    search_source: string;
+    search_type: string;
+  };
   'discover_v2.add_equation': {};
   'discover_v2.build_new_query': {};
   'discover_v2.change_sort': {sort: string};
@@ -110,4 +115,5 @@ export const discoverEventMap: Record<DiscoverEventKey, string | null> = {
   'discover_v2.results.drilldown': 'Discoverv2: Click aggregate drilldown',
   'discover_v2.update_columns': 'Discoverv2: Update columns',
   'discover_search.failed': 'Discover Search: Failed',
+  'discover_search.success': 'Discover Search: Succeeded',
 };

--- a/static/app/views/discover/table/index.tsx
+++ b/static/app/views/discover/table/index.tsx
@@ -179,6 +179,13 @@ class Table extends PureComponent<TableProps, TableState> {
           meta: {...fields, ...nonFieldsMeta},
         };
 
+        trackAnalytics('discover_search.success', {
+          has_results: tableData.data.length > 0,
+          organization: this.props.organization,
+          search_type: 'events',
+          search_source: 'discover_search',
+        });
+
         this.setState(prevState => ({
           isLoading: false,
           tableFetchID: undefined,


### PR DESCRIPTION
Adds `discover_search.success` to track % of discover queries return empty/non-empty results.