### PR TITLE
ref(custom-views): Return default view query if enabled

### DIFF
--- a/src/sentry/api/helpers/group_index/index.py
+++ b/src/sentry/api/helpers/group_index/index.py
@@ -90,7 +90,7 @@ def build_query_params_from_request(
     query = query.strip()
 
     if request.GET.get("savedSearch") == "0" and request.user and not has_query:
-        if features.has("organizations:issue-stream-custom-views"):
+        if features.has("organizations:issue-stream-custom-views", organization):
             selected_view_id = request.GET.get("groupSearchViewId")
             if selected_view_id:
                 default_view = GroupSearchView.objects.get(id=int(selected_view_id))

--- a/src/sentry/api/helpers/group_index/index.py
+++ b/src/sentry/api/helpers/group_index/index.py
@@ -93,15 +93,15 @@ def build_query_params_from_request(
         if features.has("organizations:issue-stream-custom-views", organization):
             selected_view_id = request.GET.get("searchId")
             if selected_view_id:
-                default_view = GroupSearchView.objects.get(id=int(selected_view_id))
+                default_view = GroupSearchView.objects.filter(id=int(selected_view_id)).first()
             else:
                 default_view = GroupSearchView.objects.filter(
                     organization=organization,
                     user_id=request.user.id,
                     position=0,
-                )
+                ).first()
 
-            if default_view.exists():
+            if default_view:
                 query_kwargs["sort_by"] = default_view.query_sort
                 query = default_view.query
         else:
@@ -127,9 +127,9 @@ def build_query_params_from_request(
                 # pinned saved search
                 saved_search = saved_searches.filter(visibility=Visibility.OWNER_PINNED).first()
 
-        if saved_search:
-            query_kwargs["sort_by"] = saved_search.sort
-            query = saved_search.query
+            if saved_search:
+                query_kwargs["sort_by"] = saved_search.sort
+                query = saved_search.query
 
     sentry_sdk.set_tag("search.query", query)
     sentry_sdk.set_tag("search.sort", query)

--- a/src/sentry/api/helpers/group_index/index.py
+++ b/src/sentry/api/helpers/group_index/index.py
@@ -15,6 +15,7 @@ from sentry.api.issue_search import convert_query_values, parse_search_query
 from sentry.api.serializers import serialize
 from sentry.constants import DEFAULT_SORT_OPTION
 from sentry.exceptions import InvalidSearchQuery
+from sentry.issues.endpoints.organization_group_search_views import DEFAULT_VIEWS
 from sentry.models.environment import Environment
 from sentry.models.group import Group, looks_like_short_id
 from sentry.models.groupsearchview import GroupSearchView
@@ -339,5 +340,8 @@ def get_first_last_release_info(
 def _get_default_query(organization: Organization) -> str:
     if features.has("organizations:issue-priority-ui", organization):
         return "is:unresolved issue.priority:[high, medium]"
+
+    if features.has("organizations:issue-stream-custom-views", organization):
+        return DEFAULT_VIEWS[0]["query"]
 
     return "is:unresolved"

--- a/src/sentry/api/helpers/group_index/index.py
+++ b/src/sentry/api/helpers/group_index/index.py
@@ -17,6 +17,7 @@ from sentry.constants import DEFAULT_SORT_OPTION
 from sentry.exceptions import InvalidSearchQuery
 from sentry.models.environment import Environment
 from sentry.models.group import Group, looks_like_short_id
+from sentry.models.groupsearchview import GroupSearchView
 from sentry.models.organization import Organization
 from sentry.models.project import Project
 from sentry.models.release import Release
@@ -89,31 +90,46 @@ def build_query_params_from_request(
     query = query.strip()
 
     if request.GET.get("savedSearch") == "0" and request.user and not has_query:
-        saved_searches = (
-            SavedSearch.objects
-            # Do not include pinned or personal searches from other users in
-            # the same organization. DOES include the requesting users pinned
-            # search
-            .exclude(
-                ~Q(owner_id=request.user.id),
-                visibility__in=(Visibility.OWNER, Visibility.OWNER_PINNED),
-            )
-            .filter(
-                Q(organization=organization) | Q(is_global=True),
-            )
-            .extra(order_by=["name"])
-        )
-        selected_search_id = request.GET.get("searchId", None)
-        if selected_search_id:
-            # saved search requested by the id
-            saved_search = saved_searches.filter(id=int(selected_search_id)).first()
-        else:
-            # pinned saved search
-            saved_search = saved_searches.filter(visibility=Visibility.OWNER_PINNED).first()
+        if features.has("organizations:issue-stream-custom-views"):
+            selected_view_id = request.GET.get("groupSearchViewId")
+            if selected_view_id:
+                default_view = GroupSearchView.objects.get(id=int(selected_view_id))
+            else:
+                default_view = GroupSearchView.objects.get(
+                    organization=organization,
+                    user_id=request.user.id,
+                    position=0,
+                )
 
-        if saved_search:
-            query_kwargs["sort_by"] = saved_search.sort
-            query = saved_search.query
+            if default_view:
+                query_kwargs["sort_by"] = default_view.query_sort
+                query = default_view.query
+        else:
+            saved_searches = (
+                SavedSearch.objects
+                # Do not include pinned or personal searches from other users in
+                # the same organization. DOES include the requesting users pinned
+                # search
+                .exclude(
+                    ~Q(owner_id=request.user.id),
+                    visibility__in=(Visibility.OWNER, Visibility.OWNER_PINNED),
+                )
+                .filter(
+                    Q(organization=organization) | Q(is_global=True),
+                )
+                .extra(order_by=["name"])
+            )
+            selected_search_id = request.GET.get("searchId", None)
+            if selected_search_id:
+                # saved search requested by the id
+                saved_search = saved_searches.filter(id=int(selected_search_id)).first()
+            else:
+                # pinned saved search
+                saved_search = saved_searches.filter(visibility=Visibility.OWNER_PINNED).first()
+
+            if saved_search:
+                query_kwargs["sort_by"] = saved_search.sort
+                query = saved_search.query
 
     sentry_sdk.set_tag("search.query", query)
     sentry_sdk.set_tag("search.sort", query)

--- a/src/sentry/api/helpers/group_index/index.py
+++ b/src/sentry/api/helpers/group_index/index.py
@@ -15,7 +15,6 @@ from sentry.api.issue_search import convert_query_values, parse_search_query
 from sentry.api.serializers import serialize
 from sentry.constants import DEFAULT_SORT_OPTION
 from sentry.exceptions import InvalidSearchQuery
-from sentry.issues.endpoints.organization_group_search_views import DEFAULT_VIEWS
 from sentry.models.environment import Environment
 from sentry.models.group import Group, looks_like_short_id
 from sentry.models.groupsearchview import GroupSearchView
@@ -342,6 +341,6 @@ def _get_default_query(organization: Organization) -> str:
         return "is:unresolved issue.priority:[high, medium]"
 
     if features.has("organizations:issue-stream-custom-views", organization):
-        return DEFAULT_VIEWS[0]["query"]
+        return "is:unresolved issue.priority:[high, medium]"
 
     return "is:unresolved"

--- a/src/sentry/api/helpers/group_index/index.py
+++ b/src/sentry/api/helpers/group_index/index.py
@@ -91,7 +91,7 @@ def build_query_params_from_request(
 
     if request.GET.get("savedSearch") == "0" and request.user and not has_query:
         if features.has("organizations:issue-stream-custom-views", organization):
-            selected_view_id = request.GET.get("groupSearchViewId")
+            selected_view_id = request.GET.get("searchId")
             if selected_view_id:
                 default_view = GroupSearchView.objects.get(id=int(selected_view_id))
             else:
@@ -127,9 +127,9 @@ def build_query_params_from_request(
                 # pinned saved search
                 saved_search = saved_searches.filter(visibility=Visibility.OWNER_PINNED).first()
 
-            if saved_search:
-                query_kwargs["sort_by"] = saved_search.sort
-                query = saved_search.query
+        if saved_search:
+            query_kwargs["sort_by"] = saved_search.sort
+            query = saved_search.query
 
     sentry_sdk.set_tag("search.query", query)
     sentry_sdk.set_tag("search.sort", query)

--- a/src/sentry/api/helpers/group_index/index.py
+++ b/src/sentry/api/helpers/group_index/index.py
@@ -95,13 +95,13 @@ def build_query_params_from_request(
             if selected_view_id:
                 default_view = GroupSearchView.objects.get(id=int(selected_view_id))
             else:
-                default_view = GroupSearchView.objects.get(
+                default_view = GroupSearchView.objects.filter(
                     organization=organization,
                     user_id=request.user.id,
                     position=0,
                 )
 
-            if default_view:
+            if default_view.exists():
                 query_kwargs["sort_by"] = default_view.query_sort
                 query = default_view.query
         else:

--- a/tests/sentry/issues/endpoints/test_organization_group_index.py
+++ b/tests/sentry/issues/endpoints/test_organization_group_index.py
@@ -32,6 +32,7 @@ from sentry.models.groupinbox import (
 from sentry.models.grouplink import GroupLink
 from sentry.models.groupowner import GROUP_OWNER_TYPE, GroupOwner, GroupOwnerType
 from sentry.models.groupresolution import GroupResolution
+from sentry.models.groupsearchview import GroupSearchView
 from sentry.models.groupseen import GroupSeen
 from sentry.models.groupshare import GroupShare
 from sentry.models.groupsnooze import GroupSnooze
@@ -2309,6 +2310,93 @@ class GroupListTest(APITestCase, SnubaTestCase, SearchIssueTestMixin):
             limit=10,
             collapse=["unhandled"],
             query="ZeroDivisionError",
+            savedSearch=0,
+        )
+        assert response.status_code == 200
+        assert len(response.data) == 1
+        assert int(response.data[0]["id"]) == event.group.id
+
+    @with_feature("organizations:issue-stream-custom-views")
+    def test_default_custom_view_query(self) -> None:
+        SavedSearch.objects.create(
+            name="Saved Search",
+            query="TypeError",
+            organization=self.organization,
+            owner_id=self.user.id,
+            visibility=Visibility.OWNER_PINNED,
+        )
+        GroupSearchView.objects.create(
+            organization=self.organization,
+            user_id=self.user.id,
+            position=0,
+            name="Default View",
+            query="ZeroDivisionError",
+            query_sort="date",
+        )
+        event = self.store_event(
+            data={
+                "timestamp": iso_format(before_now(seconds=500)),
+                "fingerprint": ["group-1"],
+                "message": "ZeroDivisionError",
+            },
+            project_id=self.project.id,
+        )
+
+        self.store_event(
+            data={
+                "timestamp": iso_format(before_now(seconds=500)),
+                "fingerprint": ["group-2"],
+                "message": "TypeError",
+            },
+            project_id=self.project.id,
+        )
+
+        self.login_as(user=self.user)
+        response = self.get_response(
+            sort_by="date",
+            limit=10,
+            collapse=["unhandled"],
+            savedSearch=0,
+        )
+        assert response.status_code == 200
+        assert len(response.data) == 1
+        assert int(response.data[0]["id"]) == event.group.id
+
+    @with_feature("organizations:issue-stream-custom-views")
+    def test_non_default_custom_view_query(self) -> None:
+        GroupSearchView.objects.create(
+            organization=self.organization,
+            user_id=self.user.id,
+            position=0,
+            name="Default View",
+            query="TypeError",
+            query_sort="date",
+        )
+
+        view = GroupSearchView.objects.create(
+            organization=self.organization,
+            user_id=self.user.id,
+            position=1,
+            name="Custom View",
+            query="ZeroDivisionError",
+            query_sort="date",
+        )
+
+        event = self.store_event(
+            data={
+                "timestamp": iso_format(before_now(seconds=500)),
+                "fingerprint": ["group-1"],
+                "message": "ZeroDivisionError",
+            },
+            project_id=self.project.id,
+        )
+
+        self.login_as(user=self.user)
+        response = self.get_response(
+            sort_by="date",
+            limit=10,
+            collapse=["unhandled"],
+            groupSearchViewId=view.id,
             savedSearch=0,
         )
         assert response.status_code == 200

--- a/tests/sentry/issues/endpoints/test_organization_group_index.py
+++ b/tests/sentry/issues/endpoints/test_organization_group_index.py
@@ -2396,7 +2396,7 @@ class GroupListTest(APITestCase, SnubaTestCase, SearchIssueTestMixin):
             sort_by="date",
             limit=10,
             collapse=["unhandled"],
-            groupSearchViewId=view.id,
+            searchId=view.id,
             savedSearch=0,
         )
         assert response.status_code == 200
@@ -2418,7 +2418,7 @@ class GroupListTest(APITestCase, SnubaTestCase, SearchIssueTestMixin):
         self.login_as(user=self.user)
         response = self.get_response(sort_by="date", limit=10, collapse=["unhandled"])
 
-        # The request is not populated with a query, or a groupSearchViewId to draw a query from, so the
+        # The request is not populated with a query, or a searchId to extract a query from, so the
         # query used should be the global default, the Prioritized query. Since the only event is a low priority event,
         # we should expect no results here.
         assert response.status_code == 200


### PR DESCRIPTION
Closes #71594

This PR branches the issues/ endpoint, specifically the part that returns the query and query sort that the user will see upon loading the page. Before, it would use either the saved search you were currently on, or fallback to your pinned search if you were logging in fresh. 

Now, it will first check if you have custom views enabled as a feature, and if so, it will return the query and sort from either the view you are currently on (`selected_view_id`), or your default view. 

We will need to remember to populate the `groupsearchview_id` property on the frontend when making the request to this endpoint with custom views enabled