### PR TITLE
ref(issue-stream): Remove feature flag for event stats graph and assignee selector

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -154,10 +154,6 @@ def register_temporary_features(manager: FeatureManager):
     manager.add("organizations:issue-stream-custom-views", OrganizationFeature, FeatureHandlerStrategy.OPTIONS)
     # Enable the updated empty state for issues
     manager.add("organizations:issue-stream-empty-state", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
-    # Enable the new assignee dropdown trigger on issue stream
-    manager.add("organizations:issue-stream-new-assignee-dropdown-trigger", OrganizationFeature, FeatureHandlerStrategy.OPTIONS)
-    # Enable new events graph design for issue stream
-    manager.add("organizations:issue-stream-new-events-graph", OrganizationFeature, FeatureHandlerStrategy.OPTIONS)
     # Enable issue stream performance improvements
     manager.add("organizations:issue-stream-performance", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
     # Enable the new issue stream search bar UI

--- a/static/app/components/badge/groupPriority.tsx
+++ b/static/app/components/badge/groupPriority.tsx
@@ -99,14 +99,8 @@ export function makeGroupPriorityDropdownOptions({
 }
 
 export function GroupPriorityBadge({priority, children}: GroupPriorityBadgeProps) {
-  const organization = useOrganization();
   return (
-    <StyledTag
-      type={getTagTypeForPriority(priority)}
-      isBigtag={organization.features.includes(
-        'issue-stream-new-assignee-dropdown-trigger'
-      )}
-    >
+    <StyledTag type={getTagTypeForPriority(priority)} isBigtag>
       {PRIORITY_KEY_TO_LABEL[priority] ?? t('Unknown')}
       {children}
     </StyledTag>

--- a/static/app/components/eventOrGroupExtraDetails.tsx
+++ b/static/app/components/eventOrGroupExtraDetails.tsx
@@ -3,7 +3,6 @@ import styled from '@emotion/styled';
 import EventAnnotation from 'sentry/components/events/eventAnnotation';
 import GlobalSelectionLink from 'sentry/components/globalSelectionLink';
 import InboxShortId from 'sentry/components/group/inboxBadges/shortId';
-import {GroupStatusBadge} from 'sentry/components/group/inboxBadges/statusBadge';
 import TimesTag from 'sentry/components/group/inboxBadges/timesTag';
 import UnhandledTag from 'sentry/components/group/inboxBadges/unhandledTag';
 import IssueReplayCount from 'sentry/components/group/issueReplayCount';
@@ -39,8 +38,6 @@ function EventOrGroupExtraDetails({data, showAssignee, organization}: Props) {
     project,
     lifetime,
     isUnhandled,
-    status,
-    substatus,
   } = data as Group;
 
   const issuesPath = `/organizations/${organization.slug}/issues/`;
@@ -51,9 +48,6 @@ function EventOrGroupExtraDetails({data, showAssignee, organization}: Props) {
 
   return (
     <GroupExtra>
-      {!organization.features.includes('issue-stream-new-events-graph') && (
-        <GroupStatusBadge status={status} substatus={substatus} />
-      )}
       {shortId && (
         <InboxShortId
           shortId={shortId}

--- a/static/app/components/stream/group.tsx
+++ b/static/app/components/stream/group.tsx
@@ -24,7 +24,6 @@ import PanelItem from 'sentry/components/panels/panelItem';
 import Placeholder from 'sentry/components/placeholder';
 import ProgressBar from 'sentry/components/progressBar';
 import {joinQuery, parseSearch, Token} from 'sentry/components/searchSyntax/parser';
-import GroupChart from 'sentry/components/stream/groupChart';
 import {getRelativeSummary} from 'sentry/components/timeRangeSelector/utils';
 import TimeSince from 'sentry/components/timeSince';
 import {Tooltip} from 'sentry/components/tooltip';
@@ -497,24 +496,15 @@ function BaseGroupRow({
 
       {withChart && !displayReprocessingLayout && issueTypeConfig.stats.enabled && (
         <ChartWrapper narrowGroups={narrowGroups}>
-          {organization.features.includes('issue-stream-new-events-graph') ? (
-            <GroupStatusChart
-              hideZeros
-              loading={!defined(groupStats)}
-              stats={groupStats}
-              secondaryStats={groupSecondaryStats}
-              showSecondaryPoints={showSecondaryPoints}
-              groupStatus={getBadgeProperties(group.status, group.substatus)?.status}
-              showMarkLine
-            />
-          ) : (
-            <GroupChart
-              stats={groupStats}
-              secondaryStats={groupSecondaryStats}
-              showSecondaryPoints={showSecondaryPoints}
-              showMarkLine
-            />
-          )}
+          <GroupStatusChart
+            hideZeros
+            loading={!defined(groupStats)}
+            stats={groupStats}
+            secondaryStats={groupSecondaryStats}
+            showSecondaryPoints={showSecondaryPoints}
+            groupStatus={getBadgeProperties(group.status, group.substatus)?.status}
+            showMarkLine
+          />
         </ChartWrapper>
       )}
       {displayReprocessingLayout ? (
@@ -522,15 +512,7 @@ function BaseGroupRow({
       ) : (
         <Fragment>
           {withColumns.includes('event') && issueTypeConfig.stats.enabled && (
-            <EventCountsWrapper
-              leftMargin={
-                organization.features.includes('issue-stream-new-events-graph')
-                  ? space(0)
-                  : space(2)
-              }
-            >
-              {groupCount}
-            </EventCountsWrapper>
+            <EventCountsWrapper leftMargin={space(0)}>{groupCount}</EventCountsWrapper>
           )}
           {withColumns.includes('users') && issueTypeConfig.stats.enabled && (
             <EventCountsWrapper>{groupUsersCount}</EventCountsWrapper>
@@ -553,32 +535,26 @@ function BaseGroupRow({
                   handleAssigneeChange(assignedActor)
                 }
                 onClear={() => handleAssigneeChange(null)}
-                trigger={
-                  organization.features.includes(
-                    'issue-stream-new-assignee-dropdown-trigger'
-                  )
-                    ? (props, isOpen) => (
-                        <StyledDropdownButton
-                          {...props}
-                          borderless
-                          aria-label={t('Modify issue assignee')}
-                          size="zero"
-                        >
-                          <AssigneeBadge
-                            assignedTo={group.assignedTo ?? undefined}
-                            assignmentReason={
-                              group.owners?.find(owner => {
-                                const [_ownershipType, ownerId] = owner.owner.split(':');
-                                return ownerId === group.assignedTo?.id;
-                              })?.type
-                            }
-                            loading={assigneeLoading}
-                            chevronDirection={isOpen ? 'up' : 'down'}
-                          />
-                        </StyledDropdownButton>
-                      )
-                    : undefined
-                }
+                trigger={(props, isOpen) => (
+                  <StyledDropdownButton
+                    {...props}
+                    borderless
+                    aria-label={t('Modify issue assignee')}
+                    size="zero"
+                  >
+                    <AssigneeBadge
+                      assignedTo={group.assignedTo ?? undefined}
+                      assignmentReason={
+                        group.owners?.find(owner => {
+                          const [_ownershipType, ownerId] = owner.owner.split(':');
+                          return ownerId === group.assignedTo?.id;
+                        })?.type
+                      }
+                      loading={assigneeLoading}
+                      chevronDirection={isOpen ? 'up' : 'down'}
+                    />
+                  </StyledDropdownButton>
+                )}
               />
             </AssigneeWrapper>
           )}


### PR DESCRIPTION
This PR unregisters and removes all instances of the feature flags used to rollout the new event stats graph and assignee selector. It has been EA'd for a week and has been in GA since Monday without any issues. I will merge this and the associated options PR later tomorrow, 06/06.

[Associated options PR](https://github.com/getsentry/sentry-options-automator/pull/1556)