### PR TITLE
ref(messaging): Use `ExternalProviderEnum.value`

### DIFF
--- a/src/sentry/integrations/types.py
+++ b/src/sentry/integrations/types.py
@@ -51,6 +51,8 @@ EXTERNAL_PROVIDERS_REVERSE = {
     ExternalProviderEnum.CUSTOM: ExternalProviders.CUSTOM,
 }
 
+EXTERNAL_PROVIDERS_REVERSE_VALUES = {k.value: v for k, v in EXTERNAL_PROVIDERS_REVERSE.items()}
+
 EXTERNAL_PROVIDERS = {
     ExternalProviders.EMAIL: ExternalProviderEnum.EMAIL.value,
     ExternalProviders.SLACK: ExternalProviderEnum.SLACK.value,

--- a/src/sentry/notifications/defaults.py
+++ b/src/sentry/notifications/defaults.py
@@ -34,3 +34,8 @@ DEFAULT_ENABLED_PROVIDERS = [
     ExternalProviderEnum.EMAIL,
     ExternalProviderEnum.SLACK,
 ]
+
+DEFAULT_ENABLED_PROVIDERS_VALUES = [
+    ExternalProviderEnum.EMAIL.value,
+    ExternalProviderEnum.SLACK.value,
+]

--- a/src/sentry/notifications/helpers.py
+++ b/src/sentry/notifications/helpers.py
@@ -11,7 +11,7 @@ from sentry.hybridcloud.models.externalactorreplica import ExternalActorReplica
 from sentry.models.organizationmembermapping import OrganizationMemberMapping
 from sentry.models.organizationmemberteamreplica import OrganizationMemberTeamReplica
 from sentry.notifications.defaults import (
-    DEFAULT_ENABLED_PROVIDERS,
+    DEFAULT_ENABLED_PROVIDERS_VALUES,
     NOTIFICATION_SETTINGS_TYPE_DEFAULTS,
 )
 from sentry.notifications.types import (
@@ -38,7 +38,10 @@ def get_default_for_provider(
     provider: ExternalProviderEnum,
 ) -> NotificationSettingsOptionEnum:
     # check if the provider is enable in our defaults and that the type exists as an enum
-    if provider not in DEFAULT_ENABLED_PROVIDERS or type not in NotificationSettingEnum:
+    if (
+        provider.value not in DEFAULT_ENABLED_PROVIDERS_VALUES
+        or type not in NotificationSettingEnum
+    ):
         return NotificationSettingsOptionEnum.NEVER
 
     # TODO(Steve): Make sure that all keys are present in NOTIFICATION_SETTINGS_TYPE_DEFAULTS
@@ -46,7 +49,10 @@ def get_default_for_provider(
         return NotificationSettingsOptionEnum.NEVER
 
     # special case to disable reports for non-email providers
-    if type == NotificationSettingEnum.REPORTS and provider != ExternalProviderEnum.EMAIL:
+    if (
+        type == NotificationSettingEnum.REPORTS
+        and provider.value != ExternalProviderEnum.EMAIL.value
+    ):
         # Reports are only sent to email
         return NotificationSettingsOptionEnum.NEVER
 

--- a/src/sentry/notifications/notificationcontroller.py
+++ b/src/sentry/notifications/notificationcontroller.py
@@ -30,7 +30,6 @@ from sentry.services.hybrid_cloud.organization_mapping.serial import serialize_o
 from sentry.services.hybrid_cloud.user.model import RpcUser
 from sentry.types.actor import Actor, ActorType
 from sentry.types.integrations import (
-    EXTERNAL_PROVIDERS_REVERSE,
     EXTERNAL_PROVIDERS_REVERSE_VALUES,
     PERSONAL_NOTIFICATION_PROVIDERS,
     ExternalProviderEnum,
@@ -266,7 +265,7 @@ class NotificationController:
         Recipient,
         MutableMapping[
             NotificationSettingEnum,
-            MutableMapping[ExternalProviderEnum, NotificationSettingsOptionEnum],
+            MutableMapping[str, NotificationSettingsOptionEnum],
         ],
     ]:
         """
@@ -352,7 +351,7 @@ class NotificationController:
         Recipient,
         MutableMapping[
             NotificationSettingEnum,
-            MutableMapping[ExternalProviderEnum, NotificationSettingsOptionEnum],
+            MutableMapping[str, NotificationSettingsOptionEnum],
         ],
     ]:
         """
@@ -376,7 +375,7 @@ class NotificationController:
             Recipient,
             MutableMapping[
                 NotificationSettingEnum,
-                MutableMapping[ExternalProviderEnum, NotificationSettingsOptionEnum],
+                MutableMapping[str, NotificationSettingsOptionEnum],
             ],
         ] = defaultdict(
             lambda: defaultdict(
@@ -442,7 +441,7 @@ class NotificationController:
         int,
         MutableMapping[
             NotificationSettingEnum,
-            MutableMapping[ExternalProviderEnum, NotificationSettingsOptionEnum],
+            MutableMapping[str, NotificationSettingsOptionEnum],
         ],
     ]:
         """
@@ -456,7 +455,7 @@ class NotificationController:
             int,
             MutableMapping[
                 NotificationSettingEnum,
-                MutableMapping[ExternalProviderEnum, NotificationSettingsOptionEnum],
+                MutableMapping[str, NotificationSettingsOptionEnum],
             ],
         ] = defaultdict(
             lambda: defaultdict(
@@ -539,7 +538,7 @@ class NotificationController:
             actor = Actor.from_object(recipient)
             provider_map = setting_map[self.type]
             user_to_providers[actor] = {
-                EXTERNAL_PROVIDERS_REVERSE[provider]: value
+                EXTERNAL_PROVIDERS_REVERSE_VALUES[provider]: value
                 for provider, value in provider_map.items()
             }
 

--- a/src/sentry/types/integrations.py
+++ b/src/sentry/types/integrations.py
@@ -52,6 +52,10 @@ EXTERNAL_PROVIDERS_REVERSE = {
     ExternalProviderEnum.CUSTOM: ExternalProviders.CUSTOM,
 }
 
+
+EXTERNAL_PROVIDERS_REVERSE_VALUES = {k.value: v for k, v in EXTERNAL_PROVIDERS_REVERSE.items()}
+
+
 EXTERNAL_PROVIDERS = {
     ExternalProviders.EMAIL: ExternalProviderEnum.EMAIL.value,
     ExternalProviders.SLACK: ExternalProviderEnum.SLACK.value,

--- a/tests/sentry/notifications/test_notificationcontroller.py
+++ b/tests/sentry/notifications/test_notificationcontroller.py
@@ -156,17 +156,19 @@ class NotificationControllerTest(TestCase):
         )
         providers = controller._get_layered_setting_providers()
         assert (
-            providers[self.user][NotificationSettingEnum.ISSUE_ALERTS][ExternalProviderEnum.MSTEAMS]
+            providers[self.user][NotificationSettingEnum.ISSUE_ALERTS][
+                ExternalProviderEnum.MSTEAMS.value
+            ]
             == NotificationSettingsOptionEnum.NEVER
         )
         assert (
-            providers[self.user][NotificationSettingEnum.DEPLOY][ExternalProviderEnum.SLACK]
+            providers[self.user][NotificationSettingEnum.DEPLOY][ExternalProviderEnum.SLACK.value]
             == NotificationSettingsOptionEnum.COMMITTED_ONLY
         )
 
         enabled_settings = controller.get_combined_settings()[self.user]
         assert (
-            enabled_settings[NotificationSettingEnum.ISSUE_ALERTS][ExternalProviderEnum.SLACK]
+            enabled_settings[NotificationSettingEnum.ISSUE_ALERTS][ExternalProviderEnum.SLACK.value]
             == NotificationSettingsOptionEnum.ALWAYS
         )
         assert controller.get_notification_recipients(
@@ -282,15 +284,17 @@ class NotificationControllerTest(TestCase):
         )
         providers = controller._get_layered_setting_providers()
         assert (
-            providers[self.user][NotificationSettingEnum.WORKFLOW][ExternalProviderEnum.EMAIL].value
+            providers[self.user][NotificationSettingEnum.WORKFLOW][
+                ExternalProviderEnum.EMAIL.value
+            ].value
             == top_level_provider.value
         )
         assert (
-            providers[self.user][NotificationSettingEnum.DEPLOY][ExternalProviderEnum.EMAIL]
+            providers[self.user][NotificationSettingEnum.DEPLOY][ExternalProviderEnum.EMAIL.value]
             == NotificationSettingsOptionEnum.COMMITTED_ONLY
         )
         assert (
-            providers[self.user][NotificationSettingEnum.DEPLOY][ExternalProviderEnum.MSTEAMS]
+            providers[self.user][NotificationSettingEnum.DEPLOY][ExternalProviderEnum.MSTEAMS.value]
             == NotificationSettingsOptionEnum.NEVER
         )
 
@@ -360,15 +364,17 @@ class NotificationControllerTest(TestCase):
         options = controller._get_layered_setting_providers()
         user_options = options[self.user]
         assert (
-            user_options[NotificationSettingEnum.ISSUE_ALERTS][ExternalProviderEnum.MSTEAMS].value
+            user_options[NotificationSettingEnum.ISSUE_ALERTS][
+                ExternalProviderEnum.MSTEAMS.value
+            ].value
             == self.setting_providers[1].value
         )
         assert (
-            user_options[NotificationSettingEnum.DEPLOY][ExternalProviderEnum.SLACK].value
+            user_options[NotificationSettingEnum.DEPLOY][ExternalProviderEnum.SLACK.value].value
             == self.setting_providers[0].value
         )
         assert (
-            user_options[NotificationSettingEnum.WORKFLOW][ExternalProviderEnum.EMAIL].value
+            user_options[NotificationSettingEnum.WORKFLOW][ExternalProviderEnum.EMAIL.value].value
             == self.setting_providers[2].value
         )
 
@@ -390,22 +396,24 @@ class NotificationControllerTest(TestCase):
         options = controller._get_layered_setting_providers()
         assert (
             options[new_user][NotificationSettingEnum.ISSUE_ALERTS][
-                ExternalProviderEnum.MSTEAMS
+                ExternalProviderEnum.MSTEAMS.value
             ].value
             == setting_provider_1.value
         )
 
         user_options = options[self.user]
         assert (
-            user_options[NotificationSettingEnum.ISSUE_ALERTS][ExternalProviderEnum.MSTEAMS].value
+            user_options[NotificationSettingEnum.ISSUE_ALERTS][
+                ExternalProviderEnum.MSTEAMS.value
+            ].value
             == self.setting_providers[1].value
         )
         assert (
-            user_options[NotificationSettingEnum.DEPLOY][ExternalProviderEnum.SLACK].value
+            user_options[NotificationSettingEnum.DEPLOY][ExternalProviderEnum.SLACK.value].value
             == self.setting_providers[0].value
         )
         assert (
-            user_options[NotificationSettingEnum.WORKFLOW][ExternalProviderEnum.EMAIL].value
+            user_options[NotificationSettingEnum.WORKFLOW][ExternalProviderEnum.EMAIL.value].value
             == self.setting_providers[2].value
         )
 
@@ -442,35 +450,35 @@ class NotificationControllerTest(TestCase):
             (
                 NotificationSettingEnum.DEPLOY,
                 {
-                    ExternalProviderEnum.EMAIL: NotificationSettingsOptionEnum.ALWAYS,
-                    ExternalProviderEnum.SLACK: NotificationSettingsOptionEnum.ALWAYS,
+                    ExternalProviderEnum.EMAIL.value: NotificationSettingsOptionEnum.ALWAYS,
+                    ExternalProviderEnum.SLACK.value: NotificationSettingsOptionEnum.ALWAYS,
                 },
             ),
             (
                 NotificationSettingEnum.WORKFLOW,
                 {
-                    ExternalProviderEnum.EMAIL: NotificationSettingsOptionEnum.SUBSCRIBE_ONLY,
-                    ExternalProviderEnum.SLACK: NotificationSettingsOptionEnum.SUBSCRIBE_ONLY,
+                    ExternalProviderEnum.EMAIL.value: NotificationSettingsOptionEnum.SUBSCRIBE_ONLY,
+                    ExternalProviderEnum.SLACK.value: NotificationSettingsOptionEnum.SUBSCRIBE_ONLY,
                 },
             ),
             (
                 NotificationSettingEnum.ISSUE_ALERTS,
                 {
-                    ExternalProviderEnum.EMAIL: NotificationSettingsOptionEnum.ALWAYS,
-                    ExternalProviderEnum.SLACK: NotificationSettingsOptionEnum.ALWAYS,
+                    ExternalProviderEnum.EMAIL.value: NotificationSettingsOptionEnum.ALWAYS,
+                    ExternalProviderEnum.SLACK.value: NotificationSettingsOptionEnum.ALWAYS,
                 },
             ),
             (
                 NotificationSettingEnum.REPORTS,
                 {
-                    ExternalProviderEnum.EMAIL: NotificationSettingsOptionEnum.ALWAYS,
+                    ExternalProviderEnum.EMAIL.value: NotificationSettingsOptionEnum.ALWAYS,
                 },
             ),
             (
                 NotificationSettingEnum.QUOTA,
                 {
-                    ExternalProviderEnum.SLACK: NotificationSettingsOptionEnum.ALWAYS,
-                    ExternalProviderEnum.EMAIL: NotificationSettingsOptionEnum.ALWAYS,
+                    ExternalProviderEnum.SLACK.value: NotificationSettingsOptionEnum.ALWAYS,
+                    ExternalProviderEnum.EMAIL.value: NotificationSettingsOptionEnum.ALWAYS,
                 },
             ),
         ]:
@@ -482,36 +490,36 @@ class NotificationControllerTest(TestCase):
             (
                 NotificationSettingEnum.DEPLOY,
                 {
-                    ExternalProviderEnum.EMAIL: NotificationSettingsOptionEnum.COMMITTED_ONLY,
-                    ExternalProviderEnum.SLACK: NotificationSettingsOptionEnum.COMMITTED_ONLY,
+                    ExternalProviderEnum.EMAIL.value: NotificationSettingsOptionEnum.COMMITTED_ONLY,
+                    ExternalProviderEnum.SLACK.value: NotificationSettingsOptionEnum.COMMITTED_ONLY,
                 },
             ),
             (
                 NotificationSettingEnum.WORKFLOW,
                 {
-                    ExternalProviderEnum.EMAIL: NotificationSettingsOptionEnum.SUBSCRIBE_ONLY,
-                    ExternalProviderEnum.SLACK: NotificationSettingsOptionEnum.SUBSCRIBE_ONLY,
+                    ExternalProviderEnum.EMAIL.value: NotificationSettingsOptionEnum.SUBSCRIBE_ONLY,
+                    ExternalProviderEnum.SLACK.value: NotificationSettingsOptionEnum.SUBSCRIBE_ONLY,
                 },
             ),
             (
                 NotificationSettingEnum.ISSUE_ALERTS,
                 {
-                    ExternalProviderEnum.EMAIL: NotificationSettingsOptionEnum.ALWAYS,
-                    ExternalProviderEnum.SLACK: NotificationSettingsOptionEnum.ALWAYS,
-                    ExternalProviderEnum.MSTEAMS: NotificationSettingsOptionEnum.ALWAYS,
+                    ExternalProviderEnum.EMAIL.value: NotificationSettingsOptionEnum.ALWAYS,
+                    ExternalProviderEnum.SLACK.value: NotificationSettingsOptionEnum.ALWAYS,
+                    ExternalProviderEnum.MSTEAMS.value: NotificationSettingsOptionEnum.ALWAYS,
                 },
             ),
             (
                 NotificationSettingEnum.REPORTS,
                 {
-                    ExternalProviderEnum.EMAIL: NotificationSettingsOptionEnum.ALWAYS,
+                    ExternalProviderEnum.EMAIL.value: NotificationSettingsOptionEnum.ALWAYS,
                 },
             ),
             (
                 NotificationSettingEnum.QUOTA,
                 {
-                    ExternalProviderEnum.SLACK: NotificationSettingsOptionEnum.ALWAYS,
-                    ExternalProviderEnum.EMAIL: NotificationSettingsOptionEnum.ALWAYS,
+                    ExternalProviderEnum.SLACK.value: NotificationSettingsOptionEnum.ALWAYS,
+                    ExternalProviderEnum.EMAIL.value: NotificationSettingsOptionEnum.ALWAYS,
                 },
             ),
         ]:


### PR DESCRIPTION
This PR is required to fix the tests in https://github.com/getsentry/getsentry/actions/runs/9389683374/job/25875213718?pr=14211

Because we use the actual Enum class in some of our logic, when I attempt to use the new copied enum class that i created under the integration folder, we actually have a mismatch in our code as `getsentry` will use the newer class while `sentry` won't. 

Specifically in this [line](https://github.com/getsentry/sentry/blob/master/src/sentry/notifications/notificationcontroller.py#L602),  because the defaultdict is keyed with the Enum class (and not the value), the same enum in a different module will actually not exist in the dict 😢 

We need to use the actual enum value (which is a str), which would be the same for both classes.

thanks to @ykamo001  for helping out!