### PR TITLE
fix(app-start): Show app start type for count

### DIFF
--- a/static/app/views/performance/mobile/appStarts/screens/screensTable.spec.tsx
+++ b/static/app/views/performance/mobile/appStarts/screens/screensTable.spec.tsx
@@ -63,7 +63,9 @@ describe('AppStartScreens', () => {
     expect(
       screen.getByRole('columnheader', {name: 'Type Breakdown'})
     ).toBeInTheDocument();
-    expect(screen.getByRole('columnheader', {name: 'Count'})).toBeInTheDocument();
+    expect(
+      screen.getByRole('columnheader', {name: 'Cold Start Count'})
+    ).toBeInTheDocument();
   });
 
   it('renders custom transaction and breakdown fields', () => {

--- a/static/app/views/performance/mobile/appStarts/screens/screensTable.tsx
+++ b/static/app/views/performance/mobile/appStarts/screens/screensTable.tsx
@@ -59,8 +59,8 @@ export function AppStartScreens({data, eventView, isLoading, pageLinks}: Props) 
     [`avg_compare(measurements.app_start_warm,release,${primaryRelease},${secondaryRelease})`]:
       t('Change'),
     app_start_breakdown: t('Type Breakdown'),
-    'count_starts(measurements.app_start_cold)': t('Count'),
-    'count_starts(measurements.app_start_warm)': t('Count'),
+    'count_starts(measurements.app_start_cold)': t('Cold Start Count'),
+    'count_starts(measurements.app_start_warm)': t('Warm Start Count'),
   };
 
   function renderBodyCell(column, row): React.ReactNode {


### PR DESCRIPTION
Show app start type for the count column to align with the rest of the table.

| Before | After |
|--------|--------|
| ![CleanShot 2024-06-06 at 10 07 18@2x](https://github.com/getsentry/sentry/assets/2443292/0e5ab9a1-6763-41cf-9a5c-25025e1e5f6d) |![CleanShot 2024-06-06 at 10 06 49@2x](https://github.com/getsentry/sentry/assets/2443292/0d31d8cf-92b1-4f31-a8b8-2c28f257a55d) | 



