### PR TITLE
fix(app-start): Show app start type for chart

### DIFF
--- a/static/app/views/performance/mobile/appStarts/screens/countChart.tsx
+++ b/static/app/views/performance/mobile/appStarts/screens/countChart.tsx
@@ -115,9 +115,12 @@ export function CountChart({chartHeight}: Props) {
 
   const {truncatedPrimaryRelease, truncatedSecondaryRelease} = useTruncatedReleaseNames();
 
+  const chartTitle =
+    appStartType === COLD_START_TYPE ? t('Cold Start Count') : t('Warm Start Count');
+
   return (
     <MiniChartPanel
-      title={t('Count')}
+      title={chartTitle}
       subtitle={
         primaryRelease
           ? t(


### PR DESCRIPTION
Show the app start type so the count chart aligns with the rest of the charts.

| Before | After |
|--------|--------|
| ![CleanShot 2024-06-06 at 10 16 14@2x](https://github.com/getsentry/sentry/assets/2443292/888aaca3-2575-41e8-9983-2a33bc62b5ba) | ![CleanShot 2024-06-06 at 10 15 45@2x](https://github.com/getsentry/sentry/assets/2443292/abe9bdcc-be23-464a-b90f-e900ec92c600) | 


