### PR TITLE
feat(screen-loads): Add tooltips for table

### DIFF
--- a/static/app/views/performance/mobile/screenload/screens/screensTable.tsx
+++ b/static/app/views/performance/mobile/screenload/screens/screensTable.tsx
@@ -81,7 +81,7 @@ export function ScreensTable({data, eventView, isLoading, pageLinks, onCursor}: 
       'Average time to full display of %s.',
       SECONDARY_RELEASE_ALIAS
     ),
-    [countColumnName]: t('The total count of all screen loads.'),
+    [countColumnName]: t('The total count of screen loads.'),
   };
 
   function renderBodyCell(column, row): React.ReactNode {

--- a/static/app/views/performance/mobile/screenload/screens/screensTable.tsx
+++ b/static/app/views/performance/mobile/screenload/screens/screensTable.tsx
@@ -1,4 +1,5 @@
 import {Fragment} from 'react';
+import styled from '@emotion/styled';
 import * as qs from 'query-string';
 
 import type {GridColumnHeader} from 'sentry/components/gridEditable';
@@ -48,25 +49,39 @@ export function ScreensTable({data, eventView, isLoading, pageLinks, onCursor}: 
   const {project} = useCrossPlatformProject();
   const eventViewColumns = eventView.getColumns();
 
+  const ttidColumnNamePrimaryRelease = `avg_if(measurements.time_to_initial_display,release,${primaryRelease})`;
+  const ttidColumnNameSecondaryRelease = `avg_if(measurements.time_to_initial_display,release,${secondaryRelease})`;
+  const ttfdColumnNamePrimaryRelease = `avg_if(measurements.time_to_full_display,release,${primaryRelease})`;
+  const ttfdColumnNameSecondaryRelease = `avg_if(measurements.time_to_full_display,release,${secondaryRelease})`;
+  const countColumnName = `count()`;
+
   const columnNameMap = {
     transaction: t('Screen'),
-    [`avg_if(measurements.time_to_initial_display,release,${primaryRelease})`]: t(
-      'TTID (%s)',
+    [ttidColumnNamePrimaryRelease]: t('AVG TTID (%s)', PRIMARY_RELEASE_ALIAS),
+    [ttidColumnNameSecondaryRelease]: t('AVG TTID (%s)', SECONDARY_RELEASE_ALIAS),
+    [ttfdColumnNamePrimaryRelease]: t('AVG TTFD (%s)', PRIMARY_RELEASE_ALIAS),
+    [ttfdColumnNameSecondaryRelease]: t('AVG TTFD (%s)', SECONDARY_RELEASE_ALIAS),
+    [countColumnName]: t('Total Count'),
+  };
+
+  const columnTooltipMap = {
+    [ttidColumnNamePrimaryRelease]: t(
+      'Average time to initial display of %s.',
       PRIMARY_RELEASE_ALIAS
     ),
-    [`avg_if(measurements.time_to_initial_display,release,${secondaryRelease})`]: t(
-      'TTID (%s)',
+    [ttidColumnNameSecondaryRelease]: t(
+      'Average time to initial display of %s.',
       SECONDARY_RELEASE_ALIAS
     ),
-    [`avg_if(measurements.time_to_full_display,release,${primaryRelease})`]: t(
-      'TTFD (%s)',
+    [ttfdColumnNamePrimaryRelease]: t(
+      'Average time to initial display of %s.',
       PRIMARY_RELEASE_ALIAS
     ),
-    [`avg_if(measurements.time_to_full_display,release,${secondaryRelease})`]: t(
-      'TTFD (%s)',
+    [ttfdColumnNameSecondaryRelease]: t(
+      'Average time to full display of %s.',
       SECONDARY_RELEASE_ALIAS
     ),
-    'count()': t('Total Count'),
+    [countColumnName]: t('The total count of all screen loads.'),
   };
 
   function renderBodyCell(column, row): React.ReactNode {
@@ -173,6 +188,21 @@ export function ScreensTable({data, eventView, isLoading, pageLinks, onCursor}: 
         generateSortLink={generateSortLink}
       />
     );
+
+    function columnWithToolTip(tooltipTitle: string) {
+      return (
+        <Alignment align={alignment}>
+          <StyledTooltip isHoverable title={<span>{tooltipTitle}</span>}>
+            {sortLink}
+          </StyledTooltip>
+        </Alignment>
+      );
+    }
+
+    const columnToolTip = columnTooltipMap[column.key];
+    if (columnToolTip) {
+      return columnWithToolTip(columnToolTip);
+    }
     return sortLink;
   }
 
@@ -248,3 +278,15 @@ export function useTableQuery({
     pageLinks: result.pageLinks,
   };
 }
+
+const Alignment = styled('span')<{align: string}>`
+  display: block;
+  margin: auto;
+  text-align: ${props => props.align};
+  width: 100%;
+`;
+
+const StyledTooltip = styled(Tooltip)`
+  top: 1px;
+  position: relative;
+`;


### PR DESCRIPTION
Prefix column names with avg to clearly communicate the values are averages, and add a tooltip to clarify what TTID and TTFD stand for in case users are unaware.

| Before | After |
|--------|--------|
| ![CleanShot 2024-06-06 at 11 22 15@2x](https://github.com/getsentry/sentry/assets/2443292/7ada1a30-a835-4b0a-acb2-d7006424f984) | ![CleanShot 2024-06-06 at 11 21 48@2x](https://github.com/getsentry/sentry/assets/2443292/fed00672-20c7-48b0-bc90-33a5da404df6) | 


