### PR TITLE
fix(app-start): Prefix app starts with AVG

### DIFF
--- a/static/app/views/performance/mobile/appStarts/screenSummary/index.spec.tsx
+++ b/static/app/views/performance/mobile/appStarts/screenSummary/index.spec.tsx
@@ -122,8 +122,8 @@ describe('Screen Summary', function () {
       });
 
       const blocks = [
-        {header: 'Cold Start (R1)', value: '1.00s'},
-        {header: 'Cold Start (R2)', value: '2.00s'},
+        {header: 'Avg Cold Start (R1)', value: '1.00s'},
+        {header: 'Avg Cold Start (R2)', value: '2.00s'},
         {header: 'Change', value: '-50%'},
         {header: 'Count', value: '20'},
       ];

--- a/static/app/views/performance/mobile/appStarts/screenSummary/index.tsx
+++ b/static/app/views/performance/mobile/appStarts/screenSummary/index.tsx
@@ -126,8 +126,8 @@ export function ScreenSummary() {
                     allowZero: false,
                     title:
                       appStartType === COLD_START_TYPE
-                        ? t('Cold Start (%s)', PRIMARY_RELEASE_ALIAS)
-                        : t('Warm Start (%s)', PRIMARY_RELEASE_ALIAS),
+                        ? t('Avg Cold Start (%s)', PRIMARY_RELEASE_ALIAS)
+                        : t('Avg Warm Start (%s)', PRIMARY_RELEASE_ALIAS),
                     dataKey: `avg_if(span.duration,release,${primaryRelease})`,
                   },
                   {
@@ -135,8 +135,8 @@ export function ScreenSummary() {
                     allowZero: false,
                     title:
                       appStartType === COLD_START_TYPE
-                        ? t('Cold Start (%s)', SECONDARY_RELEASE_ALIAS)
-                        : t('Warm Start (%s)', SECONDARY_RELEASE_ALIAS),
+                        ? t('Avg Cold Start (%s)', SECONDARY_RELEASE_ALIAS)
+                        : t('Avg Warm Start (%s)', SECONDARY_RELEASE_ALIAS),
                     dataKey: `avg_if(span.duration,release,${secondaryRelease})`,
                   },
                   {

--- a/static/app/views/performance/mobile/appStarts/screens/screensTable.spec.tsx
+++ b/static/app/views/performance/mobile/appStarts/screens/screensTable.spec.tsx
@@ -54,10 +54,10 @@ describe('AppStartScreens', () => {
 
     expect(screen.getByRole('columnheader', {name: 'Screen'})).toBeInTheDocument();
     expect(
-      screen.getByRole('columnheader', {name: 'Cold Start (R1)'})
+      screen.getByRole('columnheader', {name: 'Avg Cold Start (R1)'})
     ).toBeInTheDocument();
     expect(
-      screen.getByRole('columnheader', {name: 'Cold Start (R2)'})
+      screen.getByRole('columnheader', {name: 'Avg Cold Start (R2)'})
     ).toBeInTheDocument();
     expect(screen.getByRole('columnheader', {name: 'Change'})).toBeInTheDocument();
     expect(

--- a/static/app/views/performance/mobile/appStarts/screens/screensTable.tsx
+++ b/static/app/views/performance/mobile/appStarts/screens/screensTable.tsx
@@ -39,19 +39,19 @@ export function AppStartScreens({data, eventView, isLoading, pageLinks}: Props) 
   const columnNameMap = {
     transaction: t('Screen'),
     [`avg_if(measurements.app_start_cold,release,${primaryRelease})`]: t(
-      'Cold Start (%s)',
+      'Avg Cold Start (%s)',
       PRIMARY_RELEASE_ALIAS
     ),
     [`avg_if(measurements.app_start_cold,release,${secondaryRelease})`]: t(
-      'Cold Start (%s)',
+      'Avg Cold Start (%s)',
       SECONDARY_RELEASE_ALIAS
     ),
     [`avg_if(measurements.app_start_warm,release,${primaryRelease})`]: t(
-      'Warm Start (%s)',
+      'Avg Warm Start (%s)',
       PRIMARY_RELEASE_ALIAS
     ),
     [`avg_if(measurements.app_start_warm,release,${secondaryRelease})`]: t(
-      'Warm Start (%s)',
+      'Avg Warm Start (%s)',
       SECONDARY_RELEASE_ALIAS
     ),
     [`avg_compare(measurements.app_start_cold,release,${primaryRelease},${secondaryRelease})`]:


### PR DESCRIPTION
Prefix the app starts in the app start table with avg to clearly communicate the duration is an average.

