### PR TITLE
feat: sunset adding new appstore connect repos

### DIFF
--- a/static/app/views/settings/projectDebugFiles/sources/customRepositories/index.spec.tsx
+++ b/static/app/views/settings/projectDebugFiles/sources/customRepositories/index.spec.tsx
@@ -107,97 +107,6 @@ describe('Custom Repositories', function () {
     await import('sentry/components/modals/debugFileCustomRepository');
   });
 
-  it('renders', async function () {
-    const props = getProps();
-
-    const {rerender} = render(<TestComponent {...props} />, {router: props.router});
-
-    // Section title
-    expect(screen.getByText('Custom Repositories')).toBeInTheDocument();
-
-    // Enabled button
-    expect(screen.getByText('Add Repository').closest('button')).toBeEnabled();
-
-    // Content
-    expect(screen.getByText('No custom repositories configured')).toBeInTheDocument();
-
-    // Choose an App Store Connect source
-    await userEvent.click(screen.getByText('Add Repository'));
-
-    await userEvent.click(screen.getByText('App Store Connect'));
-
-    // Display modal content
-    // A single instance of App Store Connect is available on free plans
-    expect(await screen.findByText('App Store Connect credentials')).toBeInTheDocument();
-
-    // Close Modal
-    await userEvent.click(screen.getByLabelText('Close Modal'));
-
-    // Choose another source
-    await userEvent.click(screen.getByText('Add Repository'));
-
-    await userEvent.click(screen.getByText('Amazon S3'));
-
-    // Feature disabled warning
-    expect(
-      await screen.findByText('This feature is not enabled on your Sentry installation.')
-    ).toBeInTheDocument();
-
-    // Help content
-    expect(
-      screen.getByText(
-        "# Enables the Custom Symbol Sources feature SENTRY_FEATURES['custom-symbol-sources'] = True"
-      )
-    ).toBeInTheDocument();
-
-    // Close Modal
-    await userEvent.click(screen.getByLabelText('Close Modal'));
-
-    await waitFor(() => {
-      expect(screen.queryByText('App Store Connect credentials')).not.toBeInTheDocument();
-    });
-
-    // Renders disabled repository list
-    rerender(
-      <TestComponent
-        {...props}
-        customRepositories={[httpRepository, appStoreConnectRepository]}
-      />
-    );
-
-    // Content
-    const actions = screen.queryAllByLabelText('Actions');
-    expect(actions).toHaveLength(2);
-
-    // HTTP Repository
-    expect(screen.getByText(httpRepository.name)).toBeInTheDocument();
-    expect(screen.getByText(DEBUG_SOURCE_TYPES.http)).toBeInTheDocument();
-    expect(actions[0]).toBeDisabled();
-
-    // App Store Connect Repository
-    expect(screen.getByText(appStoreConnectRepository.name)).toBeInTheDocument();
-    expect(screen.getByText(DEBUG_SOURCE_TYPES.appStoreConnect)).toBeInTheDocument();
-    expect(actions[1]).toBeEnabled();
-
-    // A new App Store Connect instance is not available on free plans
-    // Choose an App Store Connect source
-    await userEvent.click(screen.getByText('Add Repository'));
-
-    await userEvent.click(screen.getByRole('button', {name: 'App Store Connect'}));
-
-    // Feature disabled warning
-    expect(
-      await screen.findByText('This feature is not enabled on your Sentry installation.')
-    ).toBeInTheDocument();
-
-    // Help content
-    expect(
-      screen.getByText(
-        "# Enables the App Store Connect Multiple feature SENTRY_FEATURES['app-store-connect-multiple'] = True"
-      )
-    ).toBeInTheDocument();
-  });
-
   it('renders with custom-symbol-sources feature enabled', async function () {
     const props = getProps();
     const newOrganization = {...props.organization, features: ['custom-symbol-sources']};
@@ -253,7 +162,7 @@ describe('Custom Repositories', function () {
     expect(actions[1]).toBeEnabled();
   });
 
-  it('renders with app-store-connect-multiple feature enabled', async function () {
+  it('renders with app-store-connect-multiple feature enabled', function () {
     const props = getProps();
 
     const newOrganization = {
@@ -289,17 +198,6 @@ describe('Custom Repositories', function () {
 
     // Enabled button
     expect(screen.getByText('Add Repository').closest('button')).toBeEnabled();
-
-    await userEvent.click(screen.getByText('Add Repository'));
-
-    await userEvent.click(screen.getByRole('button', {name: 'App Store Connect'}));
-
-    // Display modal content
-    // A new App Store Connect instance is available
-    expect(await screen.findByText('App Store Connect credentials')).toBeInTheDocument();
-
-    // Close Modal
-    await userEvent.click(screen.getByLabelText('Close Modal'));
   });
 
   it('renders with custom-symbol-sources and app-store-connect-multiple features enabled', function () {

--- a/static/app/views/settings/projectDebugFiles/sources/customRepositories/utils.tsx
+++ b/static/app/views/settings/projectDebugFiles/sources/customRepositories/utils.tsx
@@ -28,11 +28,6 @@ export const dropDownItems = [
     label: customRepoTypeLabel[CustomRepoType.HTTP],
     searchKey: t('http symbol server ssqp symstore symsrv'),
   },
-  {
-    value: CustomRepoType.APP_STORE_CONNECT,
-    label: customRepoTypeLabel[CustomRepoType.APP_STORE_CONNECT],
-    searchKey: t('apple store connect itunes ios'),
-  },
 ];
 
 export function getRequestMessages(


### PR DESCRIPTION
This removes the "Appstore connect" from the dropdown list. This is done to prepare for sunsetting the App Store Connect integration.

Ref: https://github.com/getsentry/sentry/issues/51994