### PR TITLE
feat: forbid appstore connect payload

### DIFF
--- a/src/sentry/api/endpoints/project_symbol_sources.py
+++ b/src/sentry/api/endpoints/project_symbol_sources.py
@@ -21,6 +21,7 @@ from sentry.apidocs.parameters import GlobalParams, ProjectParams
 from sentry.lang.native.sources import (
     REDACTED_SOURCE_SCHEMA,
     REDACTED_SOURCES_SCHEMA,
+    SOURCES_WITHOUT_APPSTORE_CONNECT,
     VALID_CASINGS,
     VALID_LAYOUTS,
     InvalidSourcesError,
@@ -337,7 +338,8 @@ class ProjectSymbolSourcesEndpoint(ProjectEndpoint):
         sources.append(source)
 
         try:
-            validate_sources(sources)
+            # TODO(@anonrig): Update this schema when AppStore connect is sunset.
+            validate_sources(sources, schema=SOURCES_WITHOUT_APPSTORE_CONNECT)
         except InvalidSourcesError:
             return Response(status=400)
 

--- a/src/sentry/lang/native/sources.py
+++ b/src/sentry/lang/native/sources.py
@@ -138,6 +138,19 @@ SOURCES_SCHEMA = {
     "items": SOURCE_SCHEMA,
 }
 
+# TODO(@anonrig): Remove this when AppStore connect integration is sunset.
+# Ref: https://github.com/getsentry/sentry/issues/51994
+SOURCES_WITHOUT_APPSTORE_CONNECT = {
+    "type": "array",
+    "items": {
+        "oneOf": [
+            HTTP_SOURCE_SCHEMA,
+            S3_SOURCE_SCHEMA,
+            GCS_SOURCE_SCHEMA,
+        ]
+    },
+}
+
 
 # Schemas for sources with redacted secrets
 HIDDEN_SECRET_SCHEMA = {
@@ -355,13 +368,13 @@ def secret_fields(source_type):
     yield from []
 
 
-def validate_sources(sources):
+def validate_sources(sources, schema=SOURCES_SCHEMA):
     """
     Validates sources against the JSON schema and checks that
     their IDs are ok.
     """
     try:
-        jsonschema.validate(sources, SOURCES_SCHEMA)
+        jsonschema.validate(sources, schema)
     except jsonschema.ValidationError as e:
         raise InvalidSourcesError(f"{e}")
 


### PR DESCRIPTION
This removes the "Appstore connect" payload from being sent to symbol source POST endpoint. This is done to prepare for sunsetting the App Store Connect integration.

Ref: https://github.com/getsentry/sentry/issues/51994