### PR TITLE
fix: remove appstore connect fields from POST and PUT

### DIFF
--- a/src/sentry/api/endpoints/project_symbol_sources.py
+++ b/src/sentry/api/endpoints/project_symbol_sources.py
@@ -34,7 +34,7 @@ from sentry.models.project import Project
 
 class LayoutSerializer(serializers.Serializer):
     """
-    Layout settings for the source. This is required for HTTP, GCS, and S3 sources and invalid for AppStoreConnect sources.
+    Layout settings for the source. This is required for HTTP, GCS, and S3 sources.
 
     **`type`** ***(string)*** - The layout of the folder structure. The options are:
     - `native` - Platform-Specific (SymStore / GDB / LLVM)
@@ -70,7 +70,6 @@ class LayoutSerializer(serializers.Serializer):
 class SourceSerializer(serializers.Serializer):
     type = serializers.ChoiceField(
         choices=[
-            ("appStoreConnect", "App Store Connect"),
             ("http", "SymbolServer (HTTP)"),
             ("gcs", "Google Cloud Storage"),
             ("s3", "Amazon S3"),
@@ -89,44 +88,6 @@ class SourceSerializer(serializers.Serializer):
     layout = LayoutSerializer(
         required=False,
     )
-    appconnectIssuer = serializers.CharField(
-        min_length=36,
-        max_length=36,
-        required=False,
-        help_text="The [App Store Connect Issuer ID](https://developer.apple.com/documentation/appstoreserverapi/generating_tokens_for_api_requests). Required for AppStoreConnect sources, invalid for all others.",
-    )
-    appconnectKey = (
-        serializers.CharField(
-            min_length=2,
-            max_length=20,
-            required=False,
-            help_text='The [App Store Connect API Key](https://developer.apple.com/documentation/appstoreconnectapi/creating_api_keys_for_app_store_connect_api) ID. Note that the key must have the "Developer" role for Sentry to discover the app builds. Required for AppStoreConnect sources, invalid for all others.',
-        ),
-    )
-    appconnectPrivateKey = serializers.CharField(
-        required=False,
-        help_text="The [App Store Connect API Private Key](https://developer.apple.com/documentation/appstoreconnectapi/creating_api_keys_for_app_store_connect_api). Required for AppStoreConnect sources, invalid for all others.",
-    )
-    appName = (
-        serializers.CharField(
-            min_length=1,
-            max_length=512,
-            required=False,
-            help_text="The [App Store Connect App Name](https://developer.apple.com/help/app-store-connect/create-an-app-record/add-a-new-app). Required for AppStoreConnect sources, invalid for all others.",
-        ),
-    )
-    appId = serializers.CharField(
-        min_length=1,
-        required=False,
-        help_text="The App Store Connect App ID. Required for AppStoreConnect sources, invalid for all others.",
-    )
-    bundleId = (
-        serializers.CharField(
-            min_length=1,
-            required=False,
-            help_text="The [App Store Connect App Bundle](https://developer.apple.com/help/app-store-connect/create-an-app-record/create-and-submit-app-bundles) ID. Required for AppStoreConnect sources, invalid for all others.",
-        ),
-    )
     url = serializers.CharField(
         required=False,
         help_text="The source's URL. Optional for HTTP sources, invalid for all others.",
@@ -141,7 +102,7 @@ class SourceSerializer(serializers.Serializer):
     )
     bucket = serializers.CharField(
         required=False,
-        help_text="The GCS or S3 bucket where the source resides. Required for GCS and S3 sourcse, invalid for HTTP and AppStoreConnect sources.",
+        help_text="The GCS or S3 bucket where the source resides. Required for GCS and S3 source, invalid for HTTP sources.",
     )
     region = serializers.ChoiceField(
         choices=[
@@ -180,7 +141,7 @@ class SourceSerializer(serializers.Serializer):
     )
     prefix = serializers.CharField(
         required=False,
-        help_text="The GCS or [S3](https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-prefixes.html) prefix. Optional for GCS and S3 sourcse, invalid for HTTP and AppStoreConnect sources.",
+        help_text="The GCS or [S3](https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-prefixes.html) prefix. Optional for GCS and S3 sourcse, invalid for HTTP.",
     )
     client_email = serializers.CharField(
         required=False,
@@ -192,19 +153,7 @@ class SourceSerializer(serializers.Serializer):
     )
 
     def validate(self, data):
-        if data["type"] == "appStoreConnect":
-            required = [
-                "type",
-                "name",
-                "appconnectIssuer",
-                "appconnectKey",
-                "appconnectPrivateKey",
-                "appName",
-                "appId",
-                "bundleId",
-            ]
-            allowed = required
-        elif data["type"] == "http":
+        if data["type"] == "http":
             required = ["type", "name", "url", "layout"]
             allowed = required + ["username", "password"]
         elif data["type"] == "s3":


### PR DESCRIPTION
This removes the fields for POST and PUT on appstore connect integration and potentially rejecting PUT requests involving AppStore connect integration.

This change is required to remove AppStore connect from the following pages:

- https://docs.sentry.io/api/projects/update-a-projects-symbol-source/
- https://docs.sentry.io/api/projects/add-a-symbol-source-to-a-project/

Ref: https://github.com/getsentry/sentry/issues/51994