### PR TITLE
fix(app-start): Display correct change color

### DIFF
--- a/static/app/components/percentChange.tsx
+++ b/static/app/components/percentChange.tsx
@@ -10,7 +10,7 @@ interface Props extends React.HTMLAttributes<HTMLSpanElement> {
   preferredPolarity?: Polarity;
 }
 
-type Polarity = '+' | '-' | '';
+export type Polarity = '+' | '-' | '';
 
 type Rating = 'good' | 'bad' | 'neutral';
 

--- a/static/app/views/performance/metricReadout.spec.tsx
+++ b/static/app/views/performance/metricReadout.spec.tsx
@@ -94,6 +94,25 @@ describe('MetricReadout', function () {
       expect(screen.getByRole('heading', {name: '% Difference'})).toBeInTheDocument();
       expect(screen.getByText('+5.52%')).toBeInTheDocument();
     });
+
+    it('respects preferred negative polarity', () => {
+      render(
+        <MetricReadout
+          title="% Difference"
+          unit="percent_change"
+          value={0.0552}
+          preferredPolarity="-"
+        />
+      );
+
+      expect(screen.getByText('+5.52%')).toHaveAttribute('data-rating', 'bad');
+    });
+
+    it('respects preferred default polarity', () => {
+      render(<MetricReadout title="% Difference" unit="percent_change" value={0.0552} />);
+
+      expect(screen.getByText('+5.52%')).toHaveAttribute('data-rating', 'good');
+    });
   });
 
   it('renders counts', () => {

--- a/static/app/views/performance/metricReadout.tsx
+++ b/static/app/views/performance/metricReadout.tsx
@@ -5,7 +5,7 @@ import styled from '@emotion/styled';
 import Duration from 'sentry/components/duration';
 import FileSize from 'sentry/components/fileSize';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
-import {PercentChange} from 'sentry/components/percentChange';
+import {PercentChange, type Polarity} from 'sentry/components/percentChange';
 import {Tooltip} from 'sentry/components/tooltip';
 import {defined} from 'sentry/utils';
 import {
@@ -39,6 +39,7 @@ interface Props {
   value: ReactText | undefined;
   align?: 'left' | 'right';
   isLoading?: boolean;
+  preferredPolarity?: Polarity;
   tooltip?: React.ReactNode;
 }
 
@@ -50,7 +51,14 @@ export function MetricReadout(props: Props) {
   );
 }
 
-function ReadoutContent({unit, value, tooltip, align = 'right', isLoading}: Props) {
+function ReadoutContent({
+  unit,
+  value,
+  tooltip,
+  align = 'right',
+  isLoading,
+  preferredPolarity,
+}: Props) {
   if (isLoading) {
     return (
       <LoadingContainer align={align}>
@@ -138,6 +146,7 @@ function ReadoutContent({unit, value, tooltip, align = 'right', isLoading}: Prop
         <PercentChange
           value={typeof value === 'string' ? parseFloat(value) : value}
           minimumValue={MINIMUM_PERCENTAGE_VALUE}
+          preferredPolarity={preferredPolarity}
         />
       </NumberContainer>
     );

--- a/static/app/views/performance/mobile/appStarts/screenSummary/index.spec.tsx
+++ b/static/app/views/performance/mobile/appStarts/screenSummary/index.spec.tsx
@@ -132,6 +132,8 @@ describe('Screen Summary', function () {
         const blockEl = screen.getByRole('heading', {name: block.header}).closest('div');
         await within(blockEl!).findByText(block.value);
       }
+
+      expect(screen.getByText('-50%')).toHaveAttribute('data-rating', 'good');
     });
   });
 });

--- a/static/app/views/performance/mobile/appStarts/screenSummary/index.tsx
+++ b/static/app/views/performance/mobile/appStarts/screenSummary/index.tsx
@@ -143,6 +143,7 @@ export function ScreenSummary() {
                     unit: 'percent_change',
                     title: t('Change'),
                     dataKey: `avg_compare(span.duration,release,${primaryRelease},${secondaryRelease})`,
+                    preferredPolarity: '-',
                   },
                   {
                     unit: 'count',

--- a/static/app/views/performance/mobile/screenload/screenLoadSpans/metricsRibbon.tsx
+++ b/static/app/views/performance/mobile/screenload/screenLoadSpans/metricsRibbon.tsx
@@ -2,6 +2,7 @@ import type {ComponentProps} from 'react';
 import {useMemo} from 'react';
 import styled from '@emotion/styled';
 
+import type {Polarity} from 'sentry/components/percentChange';
 import {space} from 'sentry/styles/space';
 import type {NewQuery} from 'sentry/types/organization';
 import type {TableData, TableDataRow} from 'sentry/utils/discover/discoverQuery';
@@ -21,6 +22,7 @@ interface BlockProps {
   title: string;
   unit: ComponentProps<typeof MetricReadout>['unit'];
   allowZero?: boolean;
+  preferredPolarity?: Polarity;
 }
 
 export function MetricsRibbon({
@@ -80,7 +82,7 @@ export function MetricsRibbon({
 
   return (
     <BlockContainer>
-      {blocks.map(({title, dataKey, unit}) => (
+      {blocks.map(({title, dataKey, unit, preferredPolarity}) => (
         <MetricsBlock
           key={title}
           title={title}
@@ -88,6 +90,7 @@ export function MetricsRibbon({
           dataKey={dataKey}
           data={data}
           isLoading={isLoading}
+          preferredPolarity={preferredPolarity}
         />
       ))}
     </BlockContainer>
@@ -101,6 +104,7 @@ function MetricsBlock({
   dataKey,
   isLoading,
   allowZero,
+  preferredPolarity,
 }: {
   isLoading: boolean;
   title: string;
@@ -121,6 +125,7 @@ function MetricsBlock({
       value={hasData ? value : undefined}
       isLoading={isLoading}
       unit={unit}
+      preferredPolarity={preferredPolarity}
     />
   );
 }


### PR DESCRIPTION
The app starts module screen summary page displayed the wrong change color in the metrics readout. This is fixed now.

| Before | After |
|--------|--------|
| ![CleanShot 2024-06-06 at 14 42 32@2x](https://github.com/getsentry/sentry/assets/2443292/a48bd848-317c-43a8-a07d-207d2e6add47) | ![CleanShot 2024-06-06 at 14 45 10@2x](https://github.com/getsentry/sentry/assets/2443292/9bb89f5f-2f8b-4b0e-9f68-d36f7e46756e) | 


