### PR TITLE
Bump Sentry SDK to version 2.5.0

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -66,7 +66,7 @@ sentry-kafka-schemas>=0.1.81
 sentry-ophio==0.2.7
 sentry-redis-tools>=0.1.7
 sentry-relay>=0.8.67
-sentry-sdk>=2.2.1
+sentry-sdk>=2.5.0
 slack-sdk>=3.27.2
 snuba-sdk>=2.0.33
 simplejson>=3.17.6

--- a/requirements-dev-frozen.txt
+++ b/requirements-dev-frozen.txt
@@ -185,7 +185,7 @@ sentry-kafka-schemas==0.1.81
 sentry-ophio==0.2.7
 sentry-redis-tools==0.1.7
 sentry-relay==0.8.67
-sentry-sdk==2.2.1
+sentry-sdk==2.5.0
 sentry-usage-accountant==0.0.10
 simplejson==3.17.6
 six==1.16.0

--- a/requirements-frozen.txt
+++ b/requirements-frozen.txt
@@ -125,7 +125,7 @@ sentry-kafka-schemas==0.1.81
 sentry-ophio==0.2.7
 sentry-redis-tools==0.1.7
 sentry-relay==0.8.67
-sentry-sdk==2.2.1
+sentry-sdk==2.5.0
 sentry-usage-accountant==0.0.10
 simplejson==3.17.6
 six==1.16.0


### PR DESCRIPTION
- fixes Celery Beat trace propagation problem.
- fixes caches insights module in redis integration.