### PR TITLE
ref: require group ids to start merge

### DIFF
--- a/src/sentry/eventstream/base.py
+++ b/src/sentry/eventstream/base.py
@@ -150,8 +150,8 @@ class EventStream(Service):
 
     def start_merge(
         self, project_id: int, previous_group_ids: Sequence[int], new_group_id: int
-    ) -> Mapping[str, Any] | None:
-        pass
+    ) -> dict[str, Any]:
+        raise NotImplementedError
 
     def end_merge(self, state: Mapping[str, Any]) -> None:
         pass

--- a/src/sentry/eventstream/snuba.py
+++ b/src/sentry/eventstream/snuba.py
@@ -239,9 +239,9 @@ class SnubaProtocolEventStream(EventStream):
 
     def start_merge(
         self, project_id: int, previous_group_ids: Sequence[int], new_group_id: int
-    ) -> Mapping[str, Any] | None:
+    ) -> dict[str, Any]:
         if not previous_group_ids:
-            return None
+            raise ValueError("expected groups to merge!")
 
         state = {
             "transaction_id": uuid4().hex,


### PR DESCRIPTION
if this were to return `None` it would crash in `end_merge`

<!-- Describe your PR here. -->