### PR TITLE
ref(metrics): Add metrics for script run times

### DIFF
--- a/requirements-dev-frozen.txt
+++ b/requirements-dev-frozen.txt
@@ -177,7 +177,7 @@ rsa==4.8
 s3transfer==0.10.0
 selenium==4.16.0
 sentry-arroyo==2.16.5
-sentry-cli==2.16.0
+sentry-cli==2.32.0
 sentry-devenv==1.6.2
 sentry-forked-django-stubs==5.0.2.post2
 sentry-forked-djangorestframework-stubs==3.15.0.post1

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -18,7 +18,7 @@ pytest-sentry>=0.3.0
 pytest-xdist>=3
 responses>=0.23.1
 selenium>=4.16.0
-sentry-cli>=2.16.0
+sentry-cli>=2.32.0
 
 # pre-commit dependencies
 pre-commit>=3.3

--- a/scripts/do.sh
+++ b/scripts/do.sh
@@ -13,4 +13,15 @@ source "${HERE}/lib.sh"
 # a venv can avoid enabling this by setting SENTRY_NO_VENV_CHECK
 [ -z "${SENTRY_NO_VENV_CHECK+x}" ] && eval "${HERE}/ensure-venv.sh"
 # If you call this script
+start=`date +%s`
 "$@"
+end=`date +%s`
+duration=$(($end-$start))
+
+# If we're not in CI, send a metric of the script's execution time
+if [ -z "${CI+x}" ]; then
+    configure-sentry-cli
+    # DSN for `sentry-devservices` project in the Sentry SDKs org. Used as authentication for sentry-cli.
+    export SENTRY_DSN=https://8ae521d2441786bb405b3b3705bb9dc1@o447951.ingest.us.sentry.io/4507346183716864
+    "${venv_name}"/bin/sentry-cli send-metric distribution -n script_execution_time -v $duration -u second -t script:$1
+fi

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -34,6 +34,21 @@ require() {
     command -v "$1" >/dev/null 2>&1
 }
 
+configure-sentry-cli() {
+    if [ -f "${venv_name}/bin/sentry-cli" ]; then
+        return 0
+    elif [ -f "${venv_name}/bin/pip" ]; then
+        pip-install sentry-cli
+    else
+        cat <<EOF
+${red}${bold}
+ERROR: sentry-cli could not be installed, please run "devenv sync".
+${reset}
+EOF
+        return 1
+    fi
+}
+
 query-valid-python-version() {
     python_version=$(python3 -V 2>&1 | awk '{print $2}')
     if [[ -n "${SENTRY_PYTHON_VERSION:-}" ]]; then


### PR DESCRIPTION
Add metrics for execution times of the scripts in lib.sh. This is an improved version of https://github.com/getsentry/sentry/pull/71822 which failed CI deployment. This new version will not send metrics from the CI pipeline which should solve the deployment problem. It also makes sense not to send these metrics in CI since we are interested in how much time is spent waiting for these scripts to run during **local development**.