### PR TITLE
Fix deserialization of Enhancements

### DIFF
--- a/src/sentry/grouping/enhancer/__init__.py
+++ b/src/sentry/grouping/enhancer/__init__.py
@@ -188,7 +188,6 @@ class Enhancements:
             [x._to_config_structure(self.version) for x in self.rules],
         ]
 
-    @sentry_sdk.tracing.trace
     def dumps(self) -> str:
         encoded = msgpack.dumps(self._to_config_structure())
         compressed = zstandard.compress(encoded)
@@ -207,7 +206,6 @@ class Enhancements:
         )
 
     @classmethod
-    @sentry_sdk.tracing.trace
     def loads(cls, data) -> Enhancements:
         if isinstance(data, str):
             data = data.encode("ascii", "ignore")

--- a/src/sentry/grouping/enhancer/matchers.py
+++ b/src/sentry/grouping/enhancer/matchers.py
@@ -60,6 +60,9 @@ MATCHERS = {
     "path": "path",
     "package": "package",
     "function": "function",
+    "type": "type",
+    "value": "value",
+    "mechanism": "mechanism",
     "category": "category",
     # fingerprinting specific fields
     "family": "family",

--- a/tests/sentry/grouping/snapshots/test_enhancer/test_basic_parsing/2.pysnap
+++ b/tests/sentry/grouping/snapshots/test_enhancer/test_basic_parsing/2.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-04-02T09:11:22.578666Z'
+created: '2024-06-06T14:41:17.725971+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_enhancer.py
 ---
@@ -101,4 +101,11 @@ rules:
   - key: family
     negated: false
     pattern: native
+- actions:
+  - value: 12
+    var: max-frames
+  matchers:
+  - key: value
+    negated: false
+    pattern: '*something*'
 version: 2

--- a/tests/sentry/grouping/test_enhancer.py
+++ b/tests/sentry/grouping/test_enhancer.py
@@ -44,6 +44,8 @@ module:core::*                                  -app
 family:javascript path:*/test.js                -app
 family:javascript app:1 path:*/test.js          -app
 family:native                                   max-frames=3
+
+error.value:"*something*"                       max-frames=12
 """,
         bases=["common:v1"],
     )


### PR DESCRIPTION
Serialization using `Enhancements.dumps` was using shorthands (like `v/value`), whereas the deserialization code did not support those shorthands previously, but expected the full matcher name (like `error.value`).

Adding these shorthands makes sure we support ser/de roundtrips for custom enhancement rules using error matchers.

Fixes #60335
