### PR TITLE
chore(issue-stream): Unregister new issue stream component flags from BE

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -152,10 +152,6 @@ def register_temporary_features(manager: FeatureManager):
     manager.add("organizations:issue-stream-custom-views", OrganizationFeature, FeatureHandlerStrategy.OPTIONS)
     # Enable the updated empty state for issues
     manager.add("organizations:issue-stream-empty-state", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
-    # Enable the new assignee dropdown trigger on issue stream
-    manager.add("organizations:issue-stream-new-assignee-dropdown-trigger", OrganizationFeature, FeatureHandlerStrategy.OPTIONS)
-    # Enable new events graph design for issue stream
-    manager.add("organizations:issue-stream-new-events-graph", OrganizationFeature, FeatureHandlerStrategy.OPTIONS)
     # Enable issue stream performance improvements
     manager.add("organizations:issue-stream-performance", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
     # Enable the new issue stream search bar UI


### PR DESCRIPTION
This PR unregister the feature flags used to rollout the new event stats graph and assignee selector from the BE. It has been EA'd for a week and has been in GA since Monday without any issues. 

[Associated options PR](https://github.com/getsentry/sentry-options-automator/pull/1556)