### PR TITLE
feat(trace-explorer): Bump trace explorer to 50 results

### DIFF
--- a/static/app/views/performance/traces/content.tsx
+++ b/static/app/views/performance/traces/content.tsx
@@ -55,7 +55,7 @@ import {
   normalizeTraces,
 } from './utils';
 
-const DEFAULT_PER_PAGE = 20;
+const DEFAULT_PER_PAGE = 50;
 
 export function Content() {
   const location = useLocation();


### PR DESCRIPTION
Since we can't easily paginate, bump the number of results to show more traces by default.