### PR TITLE
ref: fix typing for relay redis cluster check under test

### DIFF
--- a/src/sentry/testutils/pytest/relay.py
+++ b/src/sentry/testutils/pytest/relay.py
@@ -70,8 +70,12 @@ def relay_server_setup(live_server, tmpdir_factory):
 
     redis_db = TEST_REDIS_DB
     from sentry.relay import projectconfig_cache
+    from sentry.relay.projectconfig_cache.redis import RedisProjectConfigCache
 
-    assert redis_db == projectconfig_cache.backend.cluster.connection_pool.connection_kwargs["db"]
+    projectconfig_backend = projectconfig_cache.backend.test_only__downcast_to(
+        RedisProjectConfigCache
+    )
+    assert redis_db == projectconfig_backend.cluster.connection_pool.connection_kwargs["db"]
 
     template_vars = {
         "SENTRY_HOST": f"http://host.docker.internal:{port}/",


### PR DESCRIPTION
`cluster` is specific to the redis implementation of `ProjectConfigCache` and otherwise can't safely be accessed on `projectconfig_cache.backend`

<!-- Describe your PR here. -->