### PR TITLE
feat(hybridcloud) Add caching to service hook RPC method

### DIFF
--- a/src/sentry/models/servicehook.py
+++ b/src/sentry/models/servicehook.py
@@ -88,7 +88,7 @@ class ServiceHook(Model):
 
     @cached_property
     def sentry_app(self):
-        return app_service.find_service_hook_sentry_app(api_application_id=self.application_id)
+        return app_service.get_by_application_id(api_application_id=self.application_id)
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/src/sentry/models/servicehook.py
+++ b/src/sentry/models/servicehook.py
@@ -88,7 +88,7 @@ class ServiceHook(Model):
 
     @cached_property
     def sentry_app(self):
-        return app_service.get_by_application_id(api_application_id=self.application_id)
+        return app_service.get_by_application_id(application_id=self.application_id)
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1856,6 +1856,7 @@ register(
 register("hybrid_cloud.rpc.disabled-service-methods", default=[], flags=FLAG_AUTOMATOR_MODIFIABLE)
 
 # RPC optimization
+register("sentryapps.get_by_application_id_cached", default=0.0, flags=FLAG_AUTOMATOR_MODIFIABLE)
 register("sentryapps.get_installation_cached", default=0.0, flags=FLAG_AUTOMATOR_MODIFIABLE)
 # == End hybrid cloud subsystem
 

--- a/tests/sentry/receivers/outbox/test_control.py
+++ b/tests/sentry/receivers/outbox/test_control.py
@@ -58,3 +58,7 @@ class ProcessControlOutboxTest(TestCase):
         mock_caching.clear_key.assert_any_call(
             key=f"app_service.get_installation:{install_two.id}", region_name=_TEST_REGION.name
         )
+        mock_caching.clear_key.assert_any_call(
+            key=f"app_service.get_by_application_id:{sentry_app.application_id}",
+            region_name=_TEST_REGION.name,
+        )


### PR DESCRIPTION
This RPC method is called quite frequently from post_process flows. Having caching on this method will remove most overhead as sentryapps rarely change.

Refs HC-1193

