### PR TITLE
refactor: move ts-fork options to webpack

### DIFF
--- a/package.json
+++ b/package.json
@@ -266,11 +266,6 @@
   "volta": {
     "extends": ".volta.json"
   },
-  "fork-ts-checker": {
-    "typescript": {
-      "memoryLimit": 4096
-    }
-  },
   "prettier": {
     "bracketSpacing": false,
     "bracketSameLine": false,

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -372,9 +372,9 @@ const appConfig: Configuration = {
               configOverwrite: {
                 compilerOptions: {incremental: true},
               },
+              memoryLimit: 4096,
             },
             devServer: false,
-            // memorylimit is configured in package.json
           }),
         ]
       : []),


### PR DESCRIPTION
I didn't understand why we defined this in package.json rather than in webpack.config where it belongs.