### PR TITLE
feat(uptime): Add do-nothing uptime results consumer

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -62,7 +62,7 @@ rfc3339-validator>=0.1.2
 rfc3986-validator>=0.1.1
 # [end] jsonschema format validators
 sentry-arroyo>=2.16.5
-sentry-kafka-schemas>=0.1.81
+sentry-kafka-schemas>=0.1.90
 sentry-ophio==0.2.7
 sentry-redis-tools>=0.1.7
 sentry-relay>=0.8.67

--- a/requirements-dev-frozen.txt
+++ b/requirements-dev-frozen.txt
@@ -181,7 +181,7 @@ sentry-cli==2.16.0
 sentry-devenv==1.6.2
 sentry-forked-django-stubs==5.0.2.post2
 sentry-forked-djangorestframework-stubs==3.15.0.post1
-sentry-kafka-schemas==0.1.81
+sentry-kafka-schemas==0.1.90
 sentry-ophio==0.2.7
 sentry-redis-tools==0.1.7
 sentry-relay==0.8.67

--- a/requirements-frozen.txt
+++ b/requirements-frozen.txt
@@ -121,7 +121,7 @@ rpds-py==0.15.2
 rsa==4.8
 s3transfer==0.10.0
 sentry-arroyo==2.16.5
-sentry-kafka-schemas==0.1.81
+sentry-kafka-schemas==0.1.90
 sentry-ophio==0.2.7
 sentry-redis-tools==0.1.7
 sentry-relay==0.8.67

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -2255,6 +2255,9 @@ SENTRY_USE_REPLAY_ANALYZER_SERVICE = False
 # This flag activates Spotlight Sidecar in the development environment
 SENTRY_USE_SPOTLIGHT = False
 
+# This flag activates uptime checks in the developemnt environment
+SENTRY_USE_UPTIME = False
+
 # This flags enables the `peanutbutter` realtime metrics backend.
 # See https://github.com/getsentry/peanutbutter.
 # We do not want/need this in normal devservices, but we need it for certain tests.
@@ -2953,6 +2956,7 @@ KAFKA_TOPIC_TO_CLUSTER: Mapping[str, str] = {
     "ingest-monitors": "default",
     "monitors-clock-tick": "default",
     "monitors-clock-tasks": "default",
+    "uptime-results": "default",
     "generic-events": "default",
     "snuba-generic-events-commit-log": "default",
     "group-attributes": "default",

--- a/src/sentry/conf/types/kafka_definition.py
+++ b/src/sentry/conf/types/kafka_definition.py
@@ -45,6 +45,7 @@ class Topic(Enum):
     INGEST_MONITORS = "ingest-monitors"
     MONITORS_CLOCK_TICK = "monitors-clock-tick"
     MONITORS_CLOCK_TASKS = "monitors-clock-tasks"
+    UPTIME_RESULTS = "uptime-results"
     EVENTSTREAM_GENERIC = "generic-events"
     GENERIC_EVENTS_COMMIT_LOG = "snuba-generic-events-commit-log"
     GROUP_ATTRIBUTES = "group-attributes"

--- a/src/sentry/consumers/__init__.py
+++ b/src/sentry/consumers/__init__.py
@@ -235,6 +235,10 @@ KAFKA_CONSUMERS: Mapping[str, ConsumerDefinition] = {
         "topic": Topic.MONITORS_CLOCK_TASKS,
         "strategy_factory": "sentry.monitors.consumers.clock_tasks_consumer.MonitorClockTasksStrategyFactory",
     },
+    "uptime-results": {
+        "topic": Topic.UPTIME_RESULTS,
+        "strategy_factory": "sentry.uptime.consumers.results_consumer.UptimeResultsStrategyFactory",
+    },
     "billing-metrics-consumer": {
         "topic": Topic.SNUBA_GENERIC_METRICS,
         "strategy_factory": "sentry.ingest.billing_metrics_consumer.BillingMetricsConsumerStrategyFactory",

--- a/src/sentry/runner/commands/devserver.py
+++ b/src/sentry/runner/commands/devserver.py
@@ -319,6 +319,9 @@ def devserver(
             kafka_consumers.add("ingest-generic-metrics")
             kafka_consumers.add("billing-metrics-consumer")
 
+        if settings.SENTRY_USE_UPTIME:
+            kafka_consumers.add("uptime-results")
+
         if settings.SENTRY_USE_RELAY:
             daemons += [("relay", ["sentry", "devservices", "attach", "relay"])]
 

--- a/src/sentry/uptime/consumers/results_consumer.py
+++ b/src/sentry/uptime/consumers/results_consumer.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import logging
+from collections.abc import Mapping
+
+from arroyo.backends.kafka.consumer import KafkaPayload
+from arroyo.processing.strategies.abstract import ProcessingStrategy, ProcessingStrategyFactory
+from arroyo.processing.strategies.commit import CommitOffsets
+from arroyo.processing.strategies.run_task import RunTask
+from arroyo.types import BrokerValue, Commit, FilteredPayload, Message, Partition
+from sentry_kafka_schemas.codecs import Codec
+from sentry_kafka_schemas.schema_types.uptime_results_v1 import UptimeResult
+
+from sentry.conf.types.kafka_definition import Topic, get_topic_codec
+
+logger = logging.getLogger(__name__)
+
+UPTIME_RESULTS_CODEC: Codec[UptimeResult] = get_topic_codec(Topic.UPTIME_RESULTS)
+
+
+def process_result(message: Message[KafkaPayload | FilteredPayload]):
+    assert not isinstance(message.payload, FilteredPayload)
+    assert isinstance(message.value, BrokerValue)
+
+    result: UptimeResult = UPTIME_RESULTS_CODEC.decode(message.payload.value)
+
+    # XXX(epurkhiser): This consumer literally does nothing except log right now
+    logger.info("process_result", extra=result)
+
+
+class UptimeResultsStrategyFactory(ProcessingStrategyFactory[KafkaPayload]):
+    def __init__(self) -> None:
+        pass
+
+    def create_with_partitions(
+        self,
+        commit: Commit,
+        partitions: Mapping[Partition, int],
+    ) -> ProcessingStrategy[KafkaPayload]:
+        return RunTask(
+            function=process_result,
+            next_step=CommitOffsets(commit),
+        )

--- a/tests/sentry/consumers/test_run.py
+++ b/tests/sentry/consumers/test_run.py
@@ -39,6 +39,7 @@ def test_dlq(consumer_def) -> None:
         "ingest-monitors",
         "monitors-clock-tick",
         "monitors-clock-tasks",
+        "uptime-results",
         "metrics-last-seen-updater",
         "generic-metrics-last-seen-updater",
         "billing-metrics-consumer",


### PR DESCRIPTION
This reads and decodes results from the uptime-results topic and just logs them