### PR TITLE
ref: remove unused upload= argument for chart rendering (always True)

### DIFF
--- a/src/sentry/charts/base.py
+++ b/src/sentry/charts/base.py
@@ -29,11 +29,6 @@ class ChartRenderer(Service):
         """
         return bool(options.get("chart-rendering.enabled", False))
 
-    def generate_chart(
-        self, style: ChartType, data: Any, upload: bool = True, size: ChartSize | None = None
-    ) -> str | bytes:
-        """
-        Produces a chart. You may specify the upload kwarg to have the chart
-        uploaded to storage and receive a public URL for the chart
-        """
+    def generate_chart(self, style: ChartType, data: Any, size: ChartSize | None = None) -> str:
+        """Produces a chart. Returns the public URL for the chart"""
         raise NotImplementedError

--- a/src/sentry/charts/chartcuterie.py
+++ b/src/sentry/charts/chartcuterie.py
@@ -52,9 +52,7 @@ class Chartcuterie(ChartRenderer):
         if not self.service_url:
             raise InvalidConfiguration("`chart-rendering.chartcuterie.url` is not configured")
 
-    def generate_chart(
-        self, style: ChartType, data: Any, upload: bool = True, size: ChartSize | None = None
-    ) -> str | bytes:
+    def generate_chart(self, style: ChartType, data: Any, size: ChartSize | None = None) -> str:
         request_id = uuid4().hex
 
         payload = {
@@ -87,9 +85,6 @@ class Chartcuterie(ChartRenderer):
 
             if resp.status_code != 200:
                 raise RuntimeError(f"Chartcuterie responded with {resp.status_code}: {resp.text}")
-
-        if not upload:
-            return resp.content
 
         file_name = f"{request_id}.png"
 

--- a/tests/sentry/charts/test_chartcuterie.py
+++ b/tests/sentry/charts/test_chartcuterie.py
@@ -51,13 +51,11 @@ class ChartcuterieTest(TestCase):
             "chart-rendering.chartcuterie": {"url": service_url},
         }
 
-        # Don't upload our image anywhere
+        # Test the image can be uploaded and we get a URL back
         with self.options(options):
-            data = charts.generate_chart(
-                ChartType.SLACK_DISCOVER_TOTAL_PERIOD, chart_data, upload=False
-            )
+            url = charts.generate_chart(ChartType.SLACK_DISCOVER_TOTAL_PERIOD, chart_data)
 
-        assert data == image_data
+        assert url == absolute_uri(reverse("sentry-serve-media", args=["abc123.png"]))
 
         request = responses.calls[0].request
         payload = json.loads(request.body)
@@ -66,12 +64,6 @@ class ChartcuterieTest(TestCase):
             "style": ChartType.SLACK_DISCOVER_TOTAL_PERIOD.value,
             "data": chart_data,
         }
-
-        # Test the image can be uploaded and we get a URL back
-        with self.options(options):
-            url = charts.generate_chart(ChartType.SLACK_DISCOVER_TOTAL_PERIOD, chart_data)
-
-        assert url == absolute_uri(reverse("sentry-serve-media", args=["abc123.png"]))
 
         resp = self.client.get(url)
         assert close_streaming_response(resp) == image_data
@@ -127,14 +119,11 @@ class ChartcuterieTest(TestCase):
         }
 
         with self.options(options):
-            data = charts.generate_chart(
+            url = charts.generate_chart(
                 ChartType.SLACK_DISCOVER_TOTAL_PERIOD,
                 chart_data,
-                upload=False,
                 size={"width": 1000, "height": 200},
             )
-
-        assert data == image_data
 
         request = responses.calls[0].request
         payload = json.loads(request.body)
@@ -145,3 +134,6 @@ class ChartcuterieTest(TestCase):
             "width": 1000,
             "height": 200,
         }
+
+        resp = self.client.get(url)
+        assert close_streaming_response(resp) == image_data


### PR DESCRIPTION
upload=False was only utilized by tests

this fixes several type errors when LazyServiceWrapper becomes typechecked

<!-- Describe your PR here. -->