### PR TITLE
fix(span-summary): Span sample table without linked transactions

### DIFF
--- a/static/app/views/performance/transactionSummary/transactionSpans/spanSummary/spanSummaryTable.tsx
+++ b/static/app/views/performance/transactionSummary/transactionSpans/spanSummary/spanSummaryTable.tsx
@@ -7,6 +7,8 @@ import type {GridColumnHeader} from 'sentry/components/gridEditable';
 import GridEditable, {COL_WIDTH_UNDEFINED} from 'sentry/components/gridEditable';
 import Pagination, {type CursorHandler} from 'sentry/components/pagination';
 import {ROW_HEIGHT, ROW_PADDING} from 'sentry/components/performance/waterfall/constants';
+import PerformanceDuration from 'sentry/components/performanceDuration';
+import {Tooltip} from 'sentry/components/tooltip';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {Organization} from 'sentry/types/organization';
@@ -245,7 +247,20 @@ function renderBodyCell(
 
     if (column.key === SpanIndexedField.SPAN_DURATION) {
       if (isTxnDurationDataLoading) {
-        return <SpanDurationBarLoading />;
+        return <EmptySpanDurationBar />;
+      }
+
+      if (!transactionDuration) {
+        return (
+          <EmptySpanDurationBar>
+            <Tooltip
+              title={t('Transaction duration unknown')}
+              containerDisplayMode="block"
+            >
+              <PerformanceDuration abbreviation milliseconds={spanDuration} />
+            </Tooltip>
+          </EmptySpanDurationBar>
+        );
       }
 
       return (
@@ -277,11 +292,18 @@ function renderBodyCell(
   };
 }
 
-const SpanDurationBarLoading = styled('div')`
+const EmptySpanDurationBar = styled('div')`
   height: ${ROW_HEIGHT - 2 * ROW_PADDING}px;
   width: 100%;
   position: relative;
   display: flex;
+  align-items: center;
   top: ${space(0.5)};
   background-color: ${p => p.theme.gray100};
+  padding-left: ${space(1)};
+
+  color: ${p => p.theme.gray300};
+  font-size: ${p => p.theme.fontSizeExtraSmall};
+  font-variant-numeric: tabular-nums;
+  line-height: 1;
 `;


### PR DESCRIPTION
On the new Span Summary page, there are sometimes instances where the transaction that a span sample is linked to is not indexed / found. This results in the span duration bar in the table to be bugged:

![image](https://github.com/getsentry/sentry/assets/16740047/3cf4b5b1-e896-4fea-aaf8-ecb1c70b4f66)

This PR handles these cases by displaying the span duration inside an empty bar, and a tooltip hover that tells the user that the transaction duration is unknown:

![image](https://github.com/getsentry/sentry/assets/16740047/6cc61eae-e901-476c-bc80-f6f342f9ca6a)
![image](https://github.com/getsentry/sentry/assets/16740047/1fa96ebd-5238-4954-8191-eeeb04eb8377)
