### PR TITLE
feat(insights): add missing dashboard analytics

### DIFF
--- a/static/app/utils/analytics/dashboardsAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/dashboardsAnalyticsEvents.tsx
@@ -32,6 +32,8 @@ export type DashboardsEventParameters = {
   'dashboards2.edit.cancel': {};
   'dashboards2.edit.complete': {};
   'dashboards2.edit.start': {};
+  'dashboards2.filter.cancel': {};
+  'dashboards2.filter.save': {};
   'dashboards_manage.change_sort': {
     sort: string;
   };
@@ -109,6 +111,8 @@ export const dashboardsEventMap: Record<DashboardsEventKey, string | null> = {
   'dashboards2.edit.cancel': 'Dashboards2: Edit cancel',
   'dashboards2.edit.complete': 'Dashboards2: Edit complete',
   'dashboards2.edit.start': 'Dashboards2: Edit start',
+  'dashboards2.filter.save': 'Dashboards2: Filter bar save',
+  'dashboards2.filter.cancel': 'Dashboards2: Filter bar cancel',
   'dashboards_views.query_selector.opened':
     'Dashboards2: Query Selector opened for Widget',
   'dashboards_views.query_selector.selected':

--- a/static/app/utils/analytics/dashboardsAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/dashboardsAnalyticsEvents.tsx
@@ -62,6 +62,15 @@ export type DashboardsEventParameters = {
   'dashboards_views.query_selector.selected': {
     widget_type: string;
   };
+  'dashboards_views.widget.delete': {
+    widget_type: string;
+  };
+  'dashboards_views.widget.duplicate': {
+    widget_type: string;
+  };
+  'dashboards_views.widget.edit': {
+    widget_type: string;
+  };
   'dashboards_views.widget_library.add_widget': {
     title: string;
   };
@@ -117,6 +126,9 @@ export const dashboardsEventMap: Record<DashboardsEventKey, string | null> = {
     'Dashboards2: Query Selector opened for Widget',
   'dashboards_views.query_selector.selected':
     'Dashboards2: Query selected in Query Selector',
+  'dashboards_views.widget.edit': 'Dashboards2: dashboard widget edited',
+  'dashboards_views.widget.duplicate': 'Dashboards2: dashboard widget duplicated',
+  'dashboards_views.widget.delete': 'Dashboards2: dashboard widget deleted',
   'dashboards_views.open_in_discover.opened': 'Dashboards2: Widget Opened In Discover',
   'dashboards_views.widget_library.add_widget':
     'Dashboards2: Title of prebuilt widget added',

--- a/static/app/views/dashboards/dashboard.tsx
+++ b/static/app/views/dashboards/dashboard.tsx
@@ -23,6 +23,7 @@ import {t} from 'sentry/locale';
 import GroupStore from 'sentry/stores/groupStore';
 import {space} from 'sentry/styles/space';
 import type {Organization, PageFilters} from 'sentry/types';
+import {trackAnalytics} from 'sentry/utils/analytics';
 import {hasCustomMetrics} from 'sentry/utils/metrics/features';
 import theme from 'sentry/utils/theme';
 import withApi from 'sentry/utils/withApi';
@@ -280,7 +281,18 @@ class Dashboard extends Component<Props, State> {
   };
 
   handleDeleteWidget = (widgetToDelete: Widget) => () => {
-    const {dashboard, onUpdate, isEditingDashboard, handleUpdateWidgetList} = this.props;
+    const {
+      organization,
+      dashboard,
+      onUpdate,
+      isEditingDashboard,
+      handleUpdateWidgetList,
+    } = this.props;
+
+    trackAnalytics('dashboards_views.widget.delete', {
+      organization,
+      widget_type: widgetToDelete.displayType,
+    });
 
     let nextList = dashboard.widgets.filter(widget => widget !== widgetToDelete);
     nextList = generateWidgetsAfterCompaction(nextList);
@@ -293,7 +305,18 @@ class Dashboard extends Component<Props, State> {
   };
 
   handleDuplicateWidget = (widget: Widget, index: number) => () => {
-    const {dashboard, onUpdate, isEditingDashboard, handleUpdateWidgetList} = this.props;
+    const {
+      organization,
+      dashboard,
+      onUpdate,
+      isEditingDashboard,
+      handleUpdateWidgetList,
+    } = this.props;
+
+    trackAnalytics('dashboards_views.widget.duplicate', {
+      organization,
+      widget_type: widget.displayType,
+    });
 
     const widgetCopy = cloneDeep(
       assignTempId({...widget, id: undefined, tempId: undefined})
@@ -311,8 +334,12 @@ class Dashboard extends Component<Props, State> {
 
   handleEditWidget = (index: number) => () => {
     const {organization, router, location, paramDashboardId} = this.props;
-
     const widget = this.props.dashboard.widgets[index];
+
+    trackAnalytics('dashboards_views.widget.edit', {
+      organization,
+      widget_type: widget.displayType,
+    });
 
     if (widget.widgetType === WidgetType.METRICS && hasCustomMetrics(organization)) {
       // TODO(ddm): open preview modal

--- a/static/app/views/dashboards/detail.tsx
+++ b/static/app/views/dashboards/detail.tsx
@@ -912,6 +912,10 @@ class DashboardDetail extends Component<Props, State> {
                                 onDashboardFilterChange={this.handleChangeFilter}
                                 onCancel={() => {
                                   resetPageFilters(dashboard, location);
+                                  trackAnalytics('dashboards2.filter.cancel', {
+                                    organization,
+                                  });
+
                                   this.setState({
                                     modifiedDashboard: {
                                       ...(modifiedDashboard ?? dashboard),
@@ -934,6 +938,9 @@ class DashboardDetail extends Component<Props, State> {
                                   ).then(
                                     (newDashboard: DashboardDetails) => {
                                       addSuccessMessage(t('Dashboard filters updated'));
+                                      trackAnalytics('dashboards2.filter.save', {
+                                        organization,
+                                      });
 
                                       const navigateToDashboard = () => {
                                         browserHistory.replace(


### PR DESCRIPTION
Adds additional dashboard analytics:
- [x] Filter bar save/cancel
- [x] Delete, duplicate, and edit widget clicks for both Widget Actions and through "Edit Dashboard"