### PR TITLE
fix(traces): Fix lines on top of charts, tooltip rates

### DIFF
--- a/static/app/views/traces/tracesChart.tsx
+++ b/static/app/views/traces/tracesChart.tsx
@@ -3,8 +3,7 @@ import styled from '@emotion/styled';
 
 import {getInterval} from 'sentry/components/charts/utils';
 import {t} from 'sentry/locale';
-import {RateUnit} from 'sentry/utils/discover/fields';
-import {formatRate} from 'sentry/utils/formatters';
+import {formatAbbreviatedNumber} from 'sentry/utils/formatters';
 import {decodeList} from 'sentry/utils/queryString';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {useLocation} from 'sentry/utils/useLocation';
@@ -42,6 +41,7 @@ export function TracesChart({}: Props) {
   );
 
   const seriesData = spanIndexedCountSeries.data?.['count()'];
+  seriesData.z = 1; // TODO:: This shouldn't be required, but we're putting this in for now to avoid split lines being shown on top of the chart data :).
 
   return (
     <ChartContainer>
@@ -62,7 +62,7 @@ export function TracesChart({}: Props) {
           type={ChartType.AREA}
           aggregateOutputFormat="number"
           tooltipFormatterOptions={{
-            valueFormatter: value => formatRate(value, RateUnit.PER_MINUTE),
+            valueFormatter: value => formatAbbreviatedNumber(value),
           }}
         />
       </ChartPanel>


### PR DESCRIPTION
### Summary
This fixes lines showing on top of charts -only when the table finishes loading-, which is the echarts data fighting with the splitlines to render. Setting the z-index isn't a great solution but there is only one series on the page for now.

#### Other
- Fixes tooltip units

### Screenshots
#### Before
![Screenshot 2024-06-06 at 3 48 23 PM](https://github.com/getsentry/sentry/assets/6111995/d5e437bb-f32e-40e3-a3c2-218f2de9f333)
