### PR TITLE
metrics(replay): add a counter for hydrate error breadcrumbs

### DIFF
--- a/src/sentry/replays/usecases/ingest/dom_index.py
+++ b/src/sentry/replays/usecases/ingest/dom_index.py
@@ -450,6 +450,7 @@ def _handle_breadcrumb(
             return click
 
     elif category == "replay.hydrate-error":
+        metrics.incr("replay.hydration_error_breadcrumb")
         if replay_event is not None and _should_report_hydration_error_issue(project_id):
             report_hydration_error_issue_with_replay_event(
                 project_id,


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry/issues/72266
Can refine with tags, extras, later. Org/project is too high cardinality