### PR TITLE
fix(am3): Put profile duration stats on own flag

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -317,6 +317,8 @@ def register_temporary_features(manager: FeatureManager):
     manager.add("organizations:profiling-using-transactions", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
     # Enable continuous profiling
     manager.add("organizations:continuous-profiling", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
+    # Display profile durations on the stats page
+    manager.add("organizations:continuous-profiling-stats", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
     # Enable asking for feedback after project-create when replay is disabled
     manager.add("organizations:project-create-replay-feedback", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
     # Limit project events endpoint to only query back a certain number of days

--- a/static/app/views/organizationStats/index.tsx
+++ b/static/app/views/organizationStats/index.tsx
@@ -250,7 +250,7 @@ export class OrganizationStats extends Component<OrganizationStatsProps> {
         return !organization.features.includes('spans-usage-tracking');
       }
       if (DATA_CATEGORY_INFO.profileDuration.plural === opt.value) {
-        return organization.features.includes('continuous-profiling');
+        return organization.features.includes('continuous-profiling-stats');
       }
       return true;
     });


### PR DESCRIPTION
We want to show profile durations on the stats page before the rest of continuous profiling is ready. We'll attach `continuous-profiling-stats` to the am3 plan
