### PR TITLE
feat(search-query-builder): Add tabbed empty state for discovering filter keys

### DIFF
--- a/static/app/components/searchQueryBuilder/combobox.tsx
+++ b/static/app/components/searchQueryBuilder/combobox.tsx
@@ -1,20 +1,30 @@
 import {
+  type ForwardedRef,
   forwardRef,
   type Key,
   type MouseEventHandler,
+  type ReactNode,
   useCallback,
   useMemo,
   useRef,
+  useState,
 } from 'react';
 import isPropValid from '@emotion/is-prop-valid';
 import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 import {useComboBox} from '@react-aria/combobox';
-import {useComboBoxState} from '@react-stately/combobox';
+import type {AriaListBoxOptions} from '@react-aria/listbox';
+import {type ComboBoxState, useComboBoxState} from '@react-stately/combobox';
 import type {CollectionChildren} from '@react-types/shared';
 
+import {Button} from 'sentry/components/button';
 import {ListBox} from 'sentry/components/compactSelect/listBox';
-import type {SelectOptionWithKey} from 'sentry/components/compactSelect/types';
+import type {
+  SelectKey,
+  SelectOptionOrSectionWithKey,
+  SelectOptionWithKey,
+  SelectSectionWithKey,
+} from 'sentry/components/compactSelect/types';
 import {
   getDisabledOptions,
   getEscapedKey,
@@ -23,14 +33,16 @@ import {
 import {GrowingInput} from 'sentry/components/growingInput';
 import {Overlay, PositionWrapper} from 'sentry/components/overlay';
 import type {Token, TokenResult} from 'sentry/components/searchSyntax/parser';
+import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
 import mergeRefs from 'sentry/utils/mergeRefs';
 import useOverlay from 'sentry/utils/useOverlay';
 
-type SearchQueryBuilderComboboxProps = {
-  children: CollectionChildren<SelectOptionWithKey<string>>;
+type SearchQueryBuilderComboboxProps<T extends SelectOptionOrSectionWithKey<string>> = {
+  children: CollectionChildren<T>;
   inputLabel: string;
   inputValue: string;
-  items: SelectOptionWithKey<string>[];
+  items: T[];
   /**
    * Called when the input is blurred.
    * Passes the current input value.
@@ -48,6 +60,10 @@ type SearchQueryBuilderComboboxProps = {
   onOptionSelected: (value: string) => void;
   token: TokenResult<Token>;
   autoFocus?: boolean;
+  /**
+   * Whether to display the tabbed menu.
+   */
+  displayTabbedMenu?: boolean;
   filterValue?: string;
   maxOptions?: number;
   /**
@@ -67,153 +83,341 @@ type SearchQueryBuilderComboboxProps = {
   tabIndex?: number;
 };
 
-export const SearchQueryBuilderCombobox = forwardRef(
-  (
-    {
-      children,
-      items,
-      inputValue,
-      filterValue = inputValue,
-      placeholder,
-      onCustomValueBlurred,
-      onCustomValueCommitted,
-      onOptionSelected,
-      inputLabel,
-      onExit,
-      onKeyDown,
-      onInputChange,
-      autoFocus,
-      openOnFocus,
-      tabIndex = -1,
-      maxOptions,
-      shouldCloseOnInteractOutside,
-      onPaste,
-    }: SearchQueryBuilderComboboxProps,
-    ref
-  ) => {
-    const theme = useTheme();
-    const listBoxRef = useRef<HTMLUListElement>(null);
-    const inputRef = useRef<HTMLInputElement>(null);
-    const popoverRef = useRef<HTMLDivElement>(null);
+function itemIsSection(
+  item: SelectOptionOrSectionWithKey<string>
+): item is SelectSectionWithKey<string> {
+  return 'options' in item;
+}
 
-    const hiddenOptions = useMemo(() => {
-      return getHiddenOptions(items, filterValue, maxOptions);
-    }, [items, filterValue, maxOptions]);
+function findItemInSections(items: SelectOptionOrSectionWithKey<string>[], key: Key) {
+  for (const item of items) {
+    if (itemIsSection(item)) {
+      const option = item.options.find(child => child.key === key);
+      if (option) {
+        return option;
+      }
+    } else {
+      if (item.key === key) {
+        return item;
+      }
+    }
+  }
+  return null;
+}
 
-    const disabledKeys = useMemo(
-      () => [...getDisabledOptions(items), ...hiddenOptions].map(getEscapedKey),
-      [hiddenOptions, items]
-    );
+function menuIsOpen({
+  state,
+  hiddenOptions,
+  items,
+  displayTabbedMenu,
+}: {
+  hiddenOptions: Set<SelectKey>;
+  items: SelectOptionOrSectionWithKey<string>[];
+  state: ComboBoxState<any>;
+  displayTabbedMenu?: boolean;
+}) {
+  if (displayTabbedMenu) {
+    return state.isOpen;
+  }
 
-    const onSelectionChange = useCallback(
-      (key: Key) => {
-        const selectedOption = items.find(item => item.key === key);
-        if (selectedOption) {
-          onOptionSelected(selectedOption.textValue ?? '');
-        } else if (key) {
-          onOptionSelected(key.toString());
+  // When the tabbed menu is not being displayed, we only want to show the menu
+  // when there are options to select from
+  const totalOptions = items.reduce(
+    (acc, item) => acc + (itemIsSection(item) ? item.options.length : 1),
+    0
+  );
+
+  return totalOptions > hiddenOptions.size;
+}
+
+function useHiddenItems<T extends SelectOptionOrSectionWithKey<string>>({
+  items,
+  filterValue,
+  maxOptions,
+  displayTabbedMenu,
+  selectedSection,
+}: {
+  filterValue: string;
+  items: T[];
+  selectedSection: Key | null;
+  displayTabbedMenu?: boolean;
+  maxOptions?: number;
+}) {
+  const hiddenOptions: Set<SelectKey> = useMemo(() => {
+    if (displayTabbedMenu) {
+      if (selectedSection === null) {
+        const sets = items.map(section =>
+          itemIsSection(section)
+            ? getHiddenOptions(section.options, filterValue, maxOptions)
+            : new Set<string>()
+        );
+        const combinedSet = new Set<string>();
+        for (const set of sets) {
+          for (const value of set) {
+            combinedSet.add(value);
+          }
         }
-      },
-      [items, onOptionSelected]
-    );
+        return combinedSet;
+      }
+      const hiddenSections = items.filter(item => item.key !== selectedSection);
+      return getHiddenOptions(hiddenSections, '', 0);
+    }
 
-    const state = useComboBoxState<SelectOptionWithKey<string>>({
-      children,
+    return getHiddenOptions(items, filterValue, maxOptions);
+  }, [displayTabbedMenu, items, filterValue, maxOptions, selectedSection]);
+
+  const disabledKeys: string[] = useMemo(
+    () => [...getDisabledOptions(items), ...hiddenOptions].map(getEscapedKey),
+    [hiddenOptions, items]
+  );
+
+  return {
+    hiddenOptions,
+    disabledKeys,
+  };
+}
+
+function ListBoxSectionButton({
+  onClick,
+  selected,
+  children,
+}: {
+  children: ReactNode;
+  onClick: () => void;
+  selected: boolean;
+}) {
+  return (
+    <SectionButton size="zero" borderless aria-selected={selected} onClick={onClick}>
+      {children}
+    </SectionButton>
+  );
+}
+
+function SectionedListBox<T extends SelectOptionOrSectionWithKey<string>>({
+  popoverRef,
+  listBoxRef,
+  listBoxProps,
+  state,
+  hiddenOptions,
+  isOpen,
+  selectedSection,
+  setSelectedSection,
+}: {
+  hiddenOptions: Set<SelectKey>;
+  isOpen: boolean;
+  listBoxProps: AriaListBoxOptions<T>;
+  listBoxRef: React.RefObject<HTMLUListElement>;
+  popoverRef: React.RefObject<HTMLDivElement>;
+  selectedSection: Key | null;
+  setSelectedSection: (section: Key | null) => void;
+  state: ComboBoxState<T>;
+}) {
+  const sections = useMemo(
+    () => [...state.collection].filter(node => node.type === 'section'),
+    [state.collection]
+  );
+
+  return (
+    <SectionedOverlay ref={popoverRef}>
+      <SectionedListBoxTabPane>
+        <ListBoxSectionButton
+          selected={selectedSection === null}
+          onClick={() => {
+            setSelectedSection(null);
+            state.selectionManager.setFocusedKey(null);
+          }}
+        >
+          {t('All')}
+        </ListBoxSectionButton>
+        {sections.map(node => (
+          <ListBoxSectionButton
+            key={node.key}
+            selected={selectedSection === node.key}
+            onClick={() => {
+              setSelectedSection(node.key);
+              state.selectionManager.setFocusedKey(null);
+            }}
+          >
+            {node.props.title}
+          </ListBoxSectionButton>
+        ))}
+      </SectionedListBoxTabPane>
+      <SectionedListBoxPane>
+        <ListBox
+          {...listBoxProps}
+          ref={listBoxRef}
+          listState={state}
+          hasSearch={false}
+          hiddenOptions={hiddenOptions}
+          keyDownHandler={() => true}
+          overlayIsOpen={isOpen}
+          size="md"
+        />
+      </SectionedListBoxPane>
+    </SectionedOverlay>
+  );
+}
+
+function SearchQueryBuilderComboboxInner<T extends SelectOptionOrSectionWithKey<string>>(
+  {
+    children,
+    items,
+    inputValue,
+    filterValue = inputValue,
+    placeholder,
+    onCustomValueBlurred,
+    onCustomValueCommitted,
+    onOptionSelected,
+    inputLabel,
+    onExit,
+    onKeyDown,
+    onInputChange,
+    autoFocus,
+    openOnFocus,
+    tabIndex = -1,
+    maxOptions,
+    shouldCloseOnInteractOutside,
+    onPaste,
+    displayTabbedMenu,
+  }: SearchQueryBuilderComboboxProps<T>,
+  ref: ForwardedRef<HTMLInputElement>
+) {
+  const theme = useTheme();
+  const listBoxRef = useRef<HTMLUListElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const popoverRef = useRef<HTMLDivElement>(null);
+  const [selectedSection, setSelectedSection] = useState<Key | null>(null);
+
+  const {hiddenOptions, disabledKeys} = useHiddenItems({
+    items,
+    filterValue,
+    maxOptions,
+    displayTabbedMenu,
+    selectedSection,
+  });
+
+  const onSelectionChange = useCallback(
+    (key: Key) => {
+      const selectedOption = findItemInSections(items, key);
+      if (selectedOption && 'textValue' in selectedOption && selectedOption.textValue) {
+        onOptionSelected(selectedOption.textValue);
+      } else if (key) {
+        onOptionSelected(key.toString());
+      }
+    },
+    [items, onOptionSelected]
+  );
+
+  const state = useComboBoxState<T>({
+    children,
+    items,
+    autoFocus,
+    inputValue: filterValue,
+    onSelectionChange,
+    disabledKeys,
+  });
+
+  const {inputProps, listBoxProps} = useComboBox<T>(
+    {
+      'aria-label': inputLabel,
+      listBoxRef,
+      inputRef,
+      popoverRef,
       items,
-      autoFocus,
       inputValue: filterValue,
       onSelectionChange,
-      disabledKeys,
-    });
-    const {inputProps, listBoxProps} = useComboBox<SelectOptionWithKey<string>>(
-      {
-        'aria-label': inputLabel,
-        listBoxRef,
-        inputRef,
-        popoverRef,
-        items,
-        inputValue: filterValue,
-        onSelectionChange,
-        autoFocus,
-        onFocus: () => {
-          if (openOnFocus) {
-            state.open();
-          }
-        },
-        onBlur: () => {
-          onCustomValueBlurred(inputValue);
-          state.close();
-        },
-        onKeyDown: e => {
-          onKeyDown?.(e);
-          switch (e.key) {
-            case 'Escape':
-              state.close();
-              onExit?.();
-              return;
-            case 'Enter':
-              if (state.selectionManager.focusedKey) {
-                return;
-              }
-              state.close();
-              onCustomValueCommitted(inputValue);
-              return;
-            default:
-              return;
-          }
-        },
-      },
-      state
-    );
-
-    const isOpen = state.isOpen && hiddenOptions.size < items.length;
-
-    const {overlayProps, triggerProps} = useOverlay({
-      type: 'listbox',
-      isOpen,
-      position: 'bottom-start',
-      offset: [0, 8],
-      isKeyboardDismissDisabled: true,
-      shouldCloseOnBlur: true,
-      shouldCloseOnInteractOutside,
-      onInteractOutside: () => {
-        if (state.inputValue) {
-          onCustomValueBlurred(inputValue);
-        } else {
-          onExit?.();
+      autoFocus,
+      onFocus: () => {
+        if (openOnFocus) {
+          state.open();
         }
+      },
+      onBlur: () => {
+        onCustomValueBlurred(inputValue);
         state.close();
       },
-    });
-
-    const handleInputClick: MouseEventHandler<HTMLInputElement> = useCallback(
-      e => {
-        e.stopPropagation();
-        inputProps.onClick?.(e);
-        state.open();
+      onKeyDown: e => {
+        onKeyDown?.(e);
+        switch (e.key) {
+          case 'Escape':
+            state.close();
+            onExit?.();
+            return;
+          case 'Enter':
+            if (state.selectionManager.focusedKey) {
+              return;
+            }
+            state.close();
+            onCustomValueCommitted(inputValue);
+            return;
+          default:
+            return;
+        }
       },
-      [inputProps, state]
-    );
+    },
+    state
+  );
 
-    return (
-      <Wrapper>
-        <UnstyledInput
-          {...inputProps}
-          size="md"
-          ref={mergeRefs([ref, inputRef, triggerProps.ref])}
-          type="text"
-          placeholder={placeholder}
-          onClick={handleInputClick}
-          value={inputValue}
-          onChange={onInputChange}
-          tabIndex={tabIndex}
-          onPaste={onPaste}
-        />
-        <StyledPositionWrapper
-          {...overlayProps}
-          zIndex={theme.zIndex?.tooltip}
-          visible={isOpen}
-        >
+  const isOpen = menuIsOpen({state, hiddenOptions, items, displayTabbedMenu});
+
+  const {overlayProps, triggerProps} = useOverlay({
+    type: 'listbox',
+    isOpen,
+    position: 'bottom-start',
+    offset: [0, 8],
+    isKeyboardDismissDisabled: true,
+    shouldCloseOnBlur: true,
+    shouldCloseOnInteractOutside,
+    onInteractOutside: () => {
+      if (state.inputValue) {
+        onCustomValueBlurred(inputValue);
+      } else {
+        onExit?.();
+      }
+      state.close();
+    },
+  });
+
+  const handleInputClick: MouseEventHandler<HTMLInputElement> = useCallback(
+    e => {
+      e.stopPropagation();
+      inputProps.onClick?.(e);
+      state.open();
+    },
+    [inputProps, state]
+  );
+
+  return (
+    <Wrapper>
+      <UnstyledInput
+        {...inputProps}
+        size="md"
+        ref={mergeRefs([ref, inputRef, triggerProps.ref])}
+        type="text"
+        placeholder={placeholder}
+        onClick={handleInputClick}
+        value={inputValue}
+        onChange={onInputChange}
+        tabIndex={tabIndex}
+        onPaste={onPaste}
+      />
+      <StyledPositionWrapper
+        {...overlayProps}
+        zIndex={theme.zIndex?.tooltip}
+        visible={isOpen}
+      >
+        {displayTabbedMenu ? (
+          <SectionedListBox
+            popoverRef={popoverRef}
+            listBoxProps={listBoxProps}
+            listBoxRef={listBoxRef}
+            state={state}
+            isOpen={isOpen}
+            hiddenOptions={hiddenOptions}
+            selectedSection={selectedSection}
+            setSelectedSection={setSelectedSection}
+          />
+        ) : (
           <StyledOverlay ref={popoverRef}>
             <ListBox
               {...listBoxProps}
@@ -226,11 +430,17 @@ export const SearchQueryBuilderCombobox = forwardRef(
               size="md"
             />
           </StyledOverlay>
-        </StyledPositionWrapper>
-      </Wrapper>
-    );
-  }
-);
+        )}
+      </StyledPositionWrapper>
+    </Wrapper>
+  );
+}
+
+export const SearchQueryBuilderCombobox = forwardRef(SearchQueryBuilderComboboxInner) as <
+  T extends SelectOptionWithKey<string>,
+>(
+  props: SearchQueryBuilderComboboxProps<T> & {ref?: ForwardedRef<HTMLInputElement>}
+) => ReturnType<typeof SearchQueryBuilderComboboxInner>;
 
 const Wrapper = styled('div')`
   position: relative;
@@ -268,4 +478,42 @@ const StyledPositionWrapper = styled(PositionWrapper, {
 const StyledOverlay = styled(Overlay)`
   max-height: 400px;
   overflow-y: auto;
+`;
+
+const SectionedOverlay = styled(Overlay)`
+  overflow: hidden;
+  display: grid;
+  grid-template-columns: 120px 240px;
+  height: 400px;
+`;
+
+const SectionedListBoxPane = styled('div')`
+  overflow-y: auto;
+`;
+
+const SectionedListBoxTabPane = styled(SectionedListBoxPane)`
+  padding: ${space(1)};
+  display: flex;
+  flex-direction: column;
+  gap: ${space(0.25)};
+  border-right: 1px solid ${p => p.theme.innerBorder};
+`;
+
+const SectionButton = styled(Button)`
+  display: block;
+  height: 32px;
+  width: 100%;
+  text-align: left;
+  font-weight: ${p => p.theme.fontWeightNormal};
+  padding: 0 ${space(1)};
+
+  span {
+    justify-content: flex-start;
+  }
+
+  &[aria-selected='true'] {
+    background-color: ${p => p.theme.purple100};
+    color: ${p => p.theme.purple300};
+    font-weight: ${p => p.theme.fontWeightBold};
+  }
 `;

--- a/static/app/components/searchQueryBuilder/context.tsx
+++ b/static/app/components/searchQueryBuilder/context.tsx
@@ -1,12 +1,16 @@
 import {createContext, type Dispatch, useContext} from 'react';
 
-import type {FocusOverride} from 'sentry/components/searchQueryBuilder/types';
+import type {
+  FilterKeySection,
+  FocusOverride,
+} from 'sentry/components/searchQueryBuilder/types';
 import type {QueryBuilderActions} from 'sentry/components/searchQueryBuilder/useQueryBuilderState';
 import type {ParseResult} from 'sentry/components/searchSyntax/parser';
-import type {Tag, TagCollection} from 'sentry/types';
+import type {Tag, TagCollection} from 'sentry/types/group';
 
 interface ContextData {
   dispatch: Dispatch<QueryBuilderActions>;
+  filterKeySections: FilterKeySection[];
   focusOverride: FocusOverride | null;
   getTagValues: (tag: Tag, query: string) => Promise<string[]>;
   keys: TagCollection;
@@ -23,6 +27,7 @@ export const SearchQueryBuilerContext = createContext<ContextData>({
   query: '',
   focusOverride: null,
   keys: {},
+  filterKeySections: [],
   getTagValues: () => Promise.resolve([]),
   dispatch: () => {},
   parsedQuery: null,

--- a/static/app/components/searchQueryBuilder/index.stories.tsx
+++ b/static/app/components/searchQueryBuilder/index.stories.tsx
@@ -3,47 +3,58 @@ import styled from '@emotion/styled';
 
 import Alert from 'sentry/components/alert';
 import {SearchQueryBuilder} from 'sentry/components/searchQueryBuilder';
+import type {FilterKeySection} from 'sentry/components/searchQueryBuilder/types';
 import SizingWindow from 'sentry/components/stories/sizingWindow';
 import storyBook from 'sentry/stories/storyBook';
-import type {TagCollection} from 'sentry/types/group';
 import {FieldKey, FieldKind} from 'sentry/utils/fields';
 
-const SUPPORTED_KEYS: TagCollection = {
-  [FieldKey.AGE]: {
-    key: FieldKey.AGE,
-    name: 'Age',
-    kind: FieldKind.FIELD,
-    predefined: true,
-  },
-  [FieldKey.ASSIGNED]: {
-    key: FieldKey.ASSIGNED,
-    name: 'Assigned To',
-    kind: FieldKind.FIELD,
-    predefined: true,
-    values: [
+const FITLER_KEY_SECTIONS: FilterKeySection[] = [
+  {
+    value: FieldKind.FIELD,
+    label: 'Category 1',
+    children: [
+      {key: FieldKey.AGE, name: 'Age', kind: FieldKind.FIELD, predefined: true},
       {
-        title: 'Suggested',
-        type: 'header',
-        icon: null,
-        children: [{value: 'me'}, {value: 'unassigned'}],
+        key: FieldKey.ASSIGNED,
+        name: 'Assigned To',
+        kind: FieldKind.FIELD,
+        predefined: true,
+        values: [
+          {
+            title: 'Suggested',
+            type: 'header',
+            icon: null,
+            children: [{value: 'me'}, {value: 'unassigned'}],
+          },
+          {
+            title: 'All',
+            type: 'header',
+            icon: null,
+            children: [{value: 'person1@sentry.io'}, {value: 'person2@sentry.io'}],
+          },
+        ],
       },
       {
-        title: 'All',
-        type: 'header',
-        icon: null,
-        children: [{value: 'person1@sentry.io'}, {value: 'person2@sentry.io'}],
+        key: FieldKey.BROWSER_NAME,
+        name: 'Browser Name',
+        kind: FieldKind.FIELD,
+        predefined: true,
+        values: ['Chrome', 'Firefox', 'Safari', 'Edge'],
       },
     ],
   },
-  [FieldKey.BROWSER_NAME]: {
-    key: FieldKey.BROWSER_NAME,
-    name: 'Browser Name',
-    kind: FieldKind.FIELD,
-    predefined: true,
-    values: ['Chrome', 'Firefox', 'Safari', 'Edge'],
+  {
+    value: FieldKind.TAG,
+    label: 'Category 2',
+    children: [
+      {
+        key: 'custom_tag_name',
+        name: 'Custom_Tag_Name',
+        values: ['tag value one', 'tag value two', 'tag value three'],
+      },
+    ],
   },
-  custom_tag_name: {key: 'custom_tag_name', name: 'Custom_Tag_Name', kind: FieldKind.TAG},
-};
+];
 
 const getTagValues = (): Promise<string[]> => {
   return new Promise(resolve => {
@@ -61,7 +72,7 @@ export default storyBook(SearchQueryBuilder, story => {
         <MinHeightSizingWindow>
           <SearchQueryBuilder
             initialQuery="browser.name:Firefox assigned:me custom_tag_name:123"
-            supportedKeys={SUPPORTED_KEYS}
+            filterKeySections={FITLER_KEY_SECTIONS}
             getTagValues={getTagValues}
           />
         </MinHeightSizingWindow>
@@ -72,4 +83,5 @@ export default storyBook(SearchQueryBuilder, story => {
 
 const MinHeightSizingWindow = styled(SizingWindow)`
   min-height: 500px;
+  align-items: flex-start;
 `;

--- a/static/app/components/searchQueryBuilder/index.tsx
+++ b/static/app/components/searchQueryBuilder/index.tsx
@@ -9,20 +9,23 @@ import {
 } from 'sentry/components/searchQueryBuilder/context';
 import {PlainTextQueryInput} from 'sentry/components/searchQueryBuilder/plainTextQueryInput';
 import {TokenizedQueryGrid} from 'sentry/components/searchQueryBuilder/tokenizedQueryGrid';
-import {QueryInterfaceType} from 'sentry/components/searchQueryBuilder/types';
+import {
+  type FilterKeySection,
+  QueryInterfaceType,
+} from 'sentry/components/searchQueryBuilder/types';
 import {useQueryBuilderState} from 'sentry/components/searchQueryBuilder/useQueryBuilderState';
 import {parseQueryBuilderValue} from 'sentry/components/searchQueryBuilder/utils';
 import {IconClose, IconSearch} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
-import type {Tag, TagCollection} from 'sentry/types';
+import type {Tag} from 'sentry/types';
 import PanelProvider from 'sentry/utils/panelProvider';
 import {useEffectAfterFirstRender} from 'sentry/utils/useEffectAfterFirstRender';
 
 interface SearchQueryBuilderProps {
+  filterKeySections: FilterKeySection[];
   getTagValues: (key: Tag, query: string) => Promise<string[]>;
   initialQuery: string;
-  supportedKeys: TagCollection;
   className?: string;
   label?: string;
   onBlur?: (query: string) => void;
@@ -60,7 +63,7 @@ export function SearchQueryBuilder({
   className,
   label,
   initialQuery,
-  supportedKeys,
+  filterKeySections,
   getTagValues,
   onChange,
   onSearch,
@@ -80,15 +83,23 @@ export function SearchQueryBuilder({
   }, [onChange, state.query]);
 
   const contextValue = useMemo(() => {
+    const allKeys = filterKeySections.reduce((acc, section) => {
+      for (const tag of section.children) {
+        acc[tag.key] = tag;
+      }
+      return acc;
+    }, {});
+
     return {
       ...state,
       parsedQuery,
-      keys: supportedKeys,
+      filterKeySections,
+      keys: allKeys,
       getTagValues,
       dispatch,
       onSearch,
     };
-  }, [state, parsedQuery, supportedKeys, getTagValues, dispatch, onSearch]);
+  }, [state, parsedQuery, filterKeySections, getTagValues, dispatch, onSearch]);
 
   return (
     <SearchQueryBuilerContext.Provider value={contextValue}>

--- a/static/app/components/searchQueryBuilder/input.tsx
+++ b/static/app/components/searchQueryBuilder/input.tsx
@@ -5,17 +5,16 @@ import {Item, Section} from '@react-stately/collections';
 import type {ListState} from '@react-stately/list';
 import type {Node} from '@react-types/shared';
 
-import type {SelectOptionWithKey} from 'sentry/components/compactSelect/types';
 import {getEscapedKey} from 'sentry/components/compactSelect/utils';
 import {SearchQueryBuilderCombobox} from 'sentry/components/searchQueryBuilder/combobox';
 import {useSearchQueryBuilder} from 'sentry/components/searchQueryBuilder/context';
-import type {FocusOverride} from 'sentry/components/searchQueryBuilder/types';
+import type {
+  FilterKeySection,
+  FocusOverride,
+} from 'sentry/components/searchQueryBuilder/types';
 import {useQueryBuilderGridItem} from 'sentry/components/searchQueryBuilder/useQueryBuilderGridItem';
 import {replaceTokenWithPadding} from 'sentry/components/searchQueryBuilder/useQueryBuilderState';
-import {
-  getKeyLabel,
-  useShiftFocusToChild,
-} from 'sentry/components/searchQueryBuilder/utils';
+import {useShiftFocusToChild} from 'sentry/components/searchQueryBuilder/utils';
 import {
   type ParseResultToken,
   Token,
@@ -24,7 +23,7 @@ import {
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {Tag} from 'sentry/types/group';
-import {FieldKind, getFieldDefinition} from 'sentry/utils/fields';
+import {getFieldDefinition} from 'sentry/utils/fields';
 import {toTitleCase} from 'sentry/utils/string/toTitleCase';
 
 type SearchQueryBuilderInputProps = {
@@ -39,8 +38,6 @@ type SearchQueryBuilderInputInternalProps = {
   tabIndex: number;
   token: TokenResult<Token.FREE_TEXT> | TokenResult<Token.SPACES>;
 };
-
-const PROMOTED_SECTIONS = [FieldKind.FIELD];
 
 function getWordAtCursorPosition(value: string, cursorPosition: number) {
   const words = value.split(' ');
@@ -102,45 +99,27 @@ function replaceAliasedFilterKeys(value: string, aliasToKeyMap: Record<string, s
   return value;
 }
 
-function getItemsBySection(allKeys: Tag[]) {
-  const itemsBySection = allKeys.reduce<{
-    [section: string]: Array<SelectOptionWithKey<string>>;
-  }>((acc, tag) => {
-    const fieldDefinition = getFieldDefinition(tag.key);
+function getItemsBySection(filterKeySections: FilterKeySection[]) {
+  return filterKeySections.map(section => {
+    return {
+      key: section.value,
+      value: section.value,
+      title: section.label,
+      options: section.children.map(tag => {
+        const fieldDefinition = getFieldDefinition(tag.key);
 
-    const section = tag.kind ?? fieldDefinition?.kind ?? t('other');
-    const item = {
-      label: getKeyLabel(tag),
-      key: getEscapedKey(tag.key),
-      value: tag.key,
-      textValue: tag.key,
-      hideCheck: true,
-      showDetailsInOverlay: true,
-      details: fieldDefinition?.desc ? <KeyDescription tag={tag} /> : null,
-    };
-
-    if (acc[section]) {
-      acc[section].push(item);
-    } else {
-      acc[section] = [item];
-    }
-
-    return acc;
-  }, {});
-
-  return [
-    ...PROMOTED_SECTIONS.filter(section => section in itemsBySection).map(section => {
-      return {
-        title: section,
-        children: itemsBySection[section],
-      };
-    }),
-    ...Object.entries(itemsBySection)
-      .filter(([section]) => !PROMOTED_SECTIONS.includes(section as FieldKind))
-      .map(([section, children]) => {
-        return {title: section, children};
+        return {
+          key: getEscapedKey(tag.key),
+          label: tag.key,
+          value: tag.key,
+          textValue: tag.key,
+          hideCheck: true,
+          showDetailsInOverlay: true,
+          details: fieldDefinition?.desc ? <KeyDescription tag={tag} /> : null,
+        };
       }),
-  ];
+    };
+  });
 }
 
 function countPreviousItemsOfType({
@@ -227,17 +206,14 @@ function SearchQueryBuilderInputInternal({
 
   const filterValue = getWordAtCursorPosition(inputValue, selectionIndex);
 
-  const {query, keys, dispatch, onSearch} = useSearchQueryBuilder();
+  const {query, keys, filterKeySections, dispatch, onSearch} = useSearchQueryBuilder();
   const aliasToKeyMap = useMemo(() => {
     return Object.fromEntries(Object.values(keys).map(key => [key.alias, key.key]));
   }, [keys]);
-  const allKeys = useMemo(() => {
-    return Object.values(keys).sort((a, b) =>
-      getKeyLabel(a).localeCompare(getKeyLabel(b))
-    );
-  }, [keys]);
-  const sections = useMemo(() => getItemsBySection(allKeys), [allKeys]);
-  const items = useMemo(() => sections.flatMap(section => section.children), [sections]);
+  const sections = useMemo(
+    () => getItemsBySection(filterKeySections),
+    [filterKeySections]
+  );
 
   // When token value changes, reset the input value
   const [prevValue, setPrevValue] = useState(inputValue);
@@ -292,7 +268,7 @@ function SearchQueryBuilderInputInternal({
 
   return (
     <SearchQueryBuilderCombobox
-      items={items}
+      items={sections}
       onOptionSelected={value => {
         dispatch({
           type: 'UPDATE_FREE_TEXT',
@@ -352,18 +328,19 @@ function SearchQueryBuilderInputInternal({
       }}
       onKeyDown={onKeyDown}
       tabIndex={tabIndex}
-      maxOptions={50}
+      maxOptions={20}
       onPaste={onPaste}
+      displayTabbedMenu={inputValue.length === 0}
     >
-      {sections.map(({title, children}) => (
-        <Section title={title} key={title}>
-          {children.map(child => (
+      {section => (
+        <Section title={section.title} key={section.key}>
+          {section.options.map(child => (
             <Item {...child} key={child.key}>
               {child.label}
             </Item>
           ))}
         </Section>
-      ))}
+      )}
     </SearchQueryBuilderCombobox>
   );
 }

--- a/static/app/components/searchQueryBuilder/input.tsx
+++ b/static/app/components/searchQueryBuilder/input.tsx
@@ -328,7 +328,7 @@ function SearchQueryBuilderInputInternal({
       }}
       onKeyDown={onKeyDown}
       tabIndex={tabIndex}
-      maxOptions={20}
+      maxOptions={50}
       onPaste={onPaste}
       displayTabbedMenu={inputValue.length === 0}
     >

--- a/static/app/components/searchQueryBuilder/types.tsx
+++ b/static/app/components/searchQueryBuilder/types.tsx
@@ -1,3 +1,13 @@
+import type {ReactNode} from 'react';
+
+import type {Tag} from 'sentry/types/group';
+
+export type FilterKeySection = {
+  children: Tag[];
+  label: ReactNode;
+  value: string;
+};
+
 export enum QueryInterfaceType {
   TEXT = 'text',
   TOKENIZED = 'tokenized',

--- a/static/app/views/issueList/searchBar.tsx
+++ b/static/app/views/issueList/searchBar.tsx
@@ -1,9 +1,11 @@
 import {useCallback} from 'react';
 import styled from '@emotion/styled';
+import orderBy from 'lodash/orderBy';
 
 // eslint-disable-next-line no-restricted-imports
 import {fetchTagValues} from 'sentry/actionCreators/tags';
 import {SearchQueryBuilder} from 'sentry/components/searchQueryBuilder';
+import type {FilterKeySection} from 'sentry/components/searchQueryBuilder/types';
 import SmartSearchBar from 'sentry/components/smartSearchBar';
 import type {SearchGroup} from 'sentry/components/smartSearchBar/types';
 import {ItemType} from 'sentry/components/smartSearchBar/types';
@@ -40,6 +42,28 @@ const getSupportedTags = (supportedTags: TagCollection, org: Organization) => {
       ])
       .filter(([key, _]) => (key === FieldKey.ISSUE_PRIORITY ? include_priority : true))
   );
+};
+
+const getFilterKeySections = (
+  tags: TagCollection,
+  org: Organization
+): FilterKeySection[] => {
+  const allTags: Tag[] = orderBy(Object.values(getSupportedTags(tags, org)), 'key');
+  const eventTags = allTags.filter(tag => tag.kind === FieldKind.TAG);
+  const issueFields = allTags.filter(tag => tag.kind === FieldKind.FIELD);
+
+  return [
+    {
+      value: FieldKind.FIELD,
+      label: t('Issue Fields'),
+      children: issueFields,
+    },
+    {
+      value: FieldKind.TAG,
+      label: t('Event Tags'),
+      children: eventTags,
+    },
+  ];
 };
 
 interface Props extends React.ComponentProps<typeof SmartSearchBar>, WithIssueTagsProps {
@@ -153,7 +177,7 @@ function IssueListSearchBar({organization, tags, ...props}: Props) {
         className={props.className}
         initialQuery={props.query ?? ''}
         getTagValues={getTagValues}
-        supportedKeys={getSupportedTags(tags, organization)}
+        filterKeySections={getFilterKeySections(tags, organization)}
         onSearch={props.onSearch}
         onBlur={props.onBlur}
         onChange={value => {


### PR DESCRIPTION
Closes https://github.com/getsentry/sentry/issues/69723

This adds a tabbed version of the combobox menu when the user has not yet started searching for a specific key. This list is configurable with the new `filterKeySections` prop, which replaces the old `supportedKeys` prop.

![CleanShot 2024-06-06 at 14 30 16](https://github.com/getsentry/sentry/assets/10888943/0690c507-0a46-4b6c-b891-7c54f1a4380b)
