### PR TITLE
fix(chartcuterie): wrong alt text for slack

### DIFF
--- a/src/sentry/integrations/slack/message_builder/image_block_builder.py
+++ b/src/sentry/integrations/slack/message_builder/image_block_builder.py
@@ -32,6 +32,6 @@ class ImageBlockBuilder(BlockSlackMessageBuilder, IssueAlertImageBuilder):
                 return self.get_image_block(
                     url=image_url,
                     title=self.group.title,
-                    alt=IMAGE_ALT.get(self.group.issue_category),
+                    alt=IMAGE_ALT.get(self.group.issue_type, "issue chart"),
                 )
         return None


### PR DESCRIPTION
self.group.issue_category is like `performance` while `self.group.issue_type` is like `endpoint_regression`. I made this mistake last week which now causes endpoint regression and function regression slack messages fail.
