### PR TITLE
ref(profiling): fix typing for profiles dataset

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -392,7 +392,6 @@ module = [
     "sentry.search.events.datasets.metrics",
     "sentry.search.events.datasets.metrics_layer",
     "sentry.search.events.datasets.profile_functions",
-    "sentry.search.events.datasets.profiles",
     "sentry.search.events.datasets.spans_metrics",
     "sentry.search.events.fields",
     "sentry.search.events.filter",

--- a/src/sentry/search/events/datasets/profiles.py
+++ b/src/sentry/search/events/datasets/profiles.py
@@ -22,7 +22,7 @@ from sentry.search.events.fields import (
     SnQLFunction,
     with_default,
 )
-from sentry.search.events.types import NormalizedArg, ParamsType, SelectType, WhereType
+from sentry.search.events.types import ParamsType, SelectType, WhereType
 
 
 class Kind(Enum):
@@ -107,9 +107,7 @@ COLUMN_MAP = {column.alias: column for column in COLUMNS}
 
 
 class ProfileColumnArg(ColumnArg):
-    def normalize(
-        self, value: str, params: ParamsType, combinator: Combinator | None
-    ) -> NormalizedArg:
+    def normalize(self, value: str, params: ParamsType, combinator: Combinator | None) -> str:
         column = COLUMN_MAP.get(value)
 
         # must be a known column or field alias


### PR DESCRIPTION
Remove profiles dataset from the mypy list of ignored modules and fix the typing.