### PR TITLE
feat: Set up realtime metrics for multiple platforms

### DIFF
--- a/src/sentry/api/serializers/models/project.py
+++ b/src/sentry/api/serializers/models/project.py
@@ -27,6 +27,7 @@ from sentry.features.base import ProjectFeature
 from sentry.ingest.inbound_filters import FilterTypes
 from sentry.issues.highlights import get_highlight_preset_for_project
 from sentry.lang.native.sources import parse_sources, redact_source_secrets
+from sentry.lang.native.symbolicator import SymbolicatorPlatform
 from sentry.lang.native.utils import convert_crashreport_count
 from sentry.models.environment import EnvironmentProject
 from sentry.models.options.project_option import OPTION_KEYS, ProjectOption
@@ -695,7 +696,7 @@ class ProjectSummarySerializer(ProjectWithTeamSerializer):
             # check if the project is in LPQ for any platform
             attrs[item]["symbolication_degraded"] = any(
                 should_demote_symbolication(platform, project_id=item.id)
-                for platform in ["native", "js", "jvm"]
+                for platform in SymbolicatorPlatform
             )
 
         return attrs

--- a/src/sentry/api/serializers/models/project.py
+++ b/src/sentry/api/serializers/models/project.py
@@ -38,10 +38,10 @@ from sentry.models.projectteam import ProjectTeam
 from sentry.models.release import Release
 from sentry.models.user import User
 from sentry.models.userreport import UserReport
-from sentry.processing import realtime_metrics
 from sentry.release_health.base import CurrentAndPreviousCrashFreeRate
 from sentry.roles import organization_roles
 from sentry.snuba import discover
+from sentry.tasks.symbolication import should_demote_symbolication
 
 STATUS_LABELS = {
     ObjectStatus.ACTIVE: "active",
@@ -690,7 +690,7 @@ class ProjectSummarySerializer(ProjectWithTeamSerializer):
             # check if the project is in LPQ for any platform
             symbolication_degraded = False
             for platform in ["native", "js", "jvm"]:
-                if realtime_metrics.is_lpq_project(platform, project_id=item.id):
+                if should_demote_symbolication(platform, project_id=item.id):
                     symbolication_degraded = True
                     break
 

--- a/src/sentry/api/serializers/models/project.py
+++ b/src/sentry/api/serializers/models/project.py
@@ -687,14 +687,19 @@ class ProjectSummarySerializer(ProjectWithTeamSerializer):
             deploys_by_project = self.get_deploys_by_project(item_list)
 
         for item in item_list:
+            # check if the project is in LPQ for any platform
+            symbolication_degraded = False
+            for platform in ["native", "js", "jvm"]:
+                if realtime_metrics.is_lpq_project(platform, project_id=item.id):
+                    symbolication_degraded = True
+                    break
+
             attrs[item]["latest_release"] = latest_release_versions.get(item.id)
             attrs[item]["environments"] = environments_by_project.get(item.id, [])
             attrs[item]["has_user_reports"] = item.id in projects_with_user_reports
             if not self._collapse(LATEST_DEPLOYS_KEY):
                 attrs[item]["deploys"] = deploys_by_project.get(item.id)
-            attrs[item]["symbolication_degraded"] = realtime_metrics.is_lpq_project(
-                project_id=item.id
-            )
+            attrs[item]["symbolication_degraded"] = symbolication_degraded
 
         return attrs
 

--- a/src/sentry/api/serializers/models/project.py
+++ b/src/sentry/api/serializers/models/project.py
@@ -687,19 +687,16 @@ class ProjectSummarySerializer(ProjectWithTeamSerializer):
             deploys_by_project = self.get_deploys_by_project(item_list)
 
         for item in item_list:
-            # check if the project is in LPQ for any platform
-            symbolication_degraded = False
-            for platform in ["native", "js", "jvm"]:
-                if should_demote_symbolication(platform, project_id=item.id):
-                    symbolication_degraded = True
-                    break
-
             attrs[item]["latest_release"] = latest_release_versions.get(item.id)
             attrs[item]["environments"] = environments_by_project.get(item.id, [])
             attrs[item]["has_user_reports"] = item.id in projects_with_user_reports
             if not self._collapse(LATEST_DEPLOYS_KEY):
                 attrs[item]["deploys"] = deploys_by_project.get(item.id)
-            attrs[item]["symbolication_degraded"] = symbolication_degraded
+            # check if the project is in LPQ for any platform
+            attrs[item]["symbolication_degraded"] = any(
+                should_demote_symbolication(platform, project_id=item.id)
+                for platform in ["native", "js", "jvm"]
+            )
 
         return attrs
 

--- a/src/sentry/processing/realtime_metrics/base.py
+++ b/src/sentry/processing/realtime_metrics/base.py
@@ -16,9 +16,9 @@ class RealtimeMetricsStore(Service):
         """
         raise NotImplementedError
 
-    def record_project_duration(self, project_id: int, duration: float) -> None:
+    def record_project_duration(self, platform: str, project_id: int, duration: float) -> None:
         """
-        Records the duration of a symbolication request for the given project_id.
+        Records the duration of a symbolication request for the given project_id and platform.
 
         The duration (from the start of the symbolication request)
         should be recorded at regular intervals *as the event is being processed*.
@@ -46,8 +46,9 @@ class RealtimeMetricsStore(Service):
         """
         raise NotImplementedError
 
-    def is_lpq_project(self, project_id: int) -> bool:
+    def is_lpq_project(self, platform: str, project_id: int) -> bool:
         """
-        Checks whether the given project is currently using the low priority queue.
+        Checks whether the given project is currently using the low priority queue for
+        the given platform.
         """
         raise NotImplementedError

--- a/src/sentry/processing/realtime_metrics/base.py
+++ b/src/sentry/processing/realtime_metrics/base.py
@@ -1,3 +1,4 @@
+from sentry.lang.native.symbolicator import SymbolicatorPlatform
 from sentry.utils.services import Service
 
 
@@ -16,7 +17,9 @@ class RealtimeMetricsStore(Service):
         """
         raise NotImplementedError
 
-    def record_project_duration(self, platform: str, project_id: int, duration: float) -> None:
+    def record_project_duration(
+        self, platform: SymbolicatorPlatform, project_id: int, duration: float
+    ) -> None:
         """
         Records the duration of a symbolication request for the given project_id and platform.
 
@@ -46,7 +49,7 @@ class RealtimeMetricsStore(Service):
         """
         raise NotImplementedError
 
-    def is_lpq_project(self, platform: str, project_id: int) -> bool:
+    def is_lpq_project(self, platform: SymbolicatorPlatform, project_id: int) -> bool:
         """
         Checks whether the given project is currently using the low priority queue for
         the given platform.

--- a/src/sentry/processing/realtime_metrics/dummy.py
+++ b/src/sentry/processing/realtime_metrics/dummy.py
@@ -13,8 +13,8 @@ class DummyRealtimeMetricsStore(base.RealtimeMetricsStore):
     def validate(self) -> None:
         pass
 
-    def record_project_duration(self, project_id: int, duration: float) -> None:
+    def record_project_duration(self, platform: str, project_id: int, duration: float) -> None:
         pass
 
-    def is_lpq_project(self, project_id: int) -> bool:
+    def is_lpq_project(self, platform: str, project_id: int) -> bool:
         return False

--- a/src/sentry/processing/realtime_metrics/dummy.py
+++ b/src/sentry/processing/realtime_metrics/dummy.py
@@ -1,6 +1,8 @@
 import logging
 from typing import Any
 
+from sentry.lang.native.symbolicator import SymbolicatorPlatform
+
 from . import base
 
 logger = logging.getLogger(__name__)
@@ -13,8 +15,10 @@ class DummyRealtimeMetricsStore(base.RealtimeMetricsStore):
     def validate(self) -> None:
         pass
 
-    def record_project_duration(self, platform: str, project_id: int, duration: float) -> None:
+    def record_project_duration(
+        self, platform: SymbolicatorPlatform, project_id: int, duration: float
+    ) -> None:
         pass
 
-    def is_lpq_project(self, platform: str, project_id: int) -> bool:
+    def is_lpq_project(self, platform: SymbolicatorPlatform, project_id: int) -> bool:
         return False

--- a/src/sentry/processing/realtime_metrics/pb.py
+++ b/src/sentry/processing/realtime_metrics/pb.py
@@ -3,6 +3,7 @@ from urllib.parse import urljoin
 
 from requests import RequestException
 
+from sentry.lang.native.symbolicator import SymbolicatorPlatform
 from sentry.net.http import Session
 
 from . import base
@@ -19,10 +20,12 @@ class PbRealtimeMetricsStore(base.RealtimeMetricsStore):
         self.target = target
         self.session = Session()
 
-    def record_project_duration(self, platform: str, project_id: int, duration: float) -> None:
+    def record_project_duration(
+        self, platform: SymbolicatorPlatform, project_id: int, duration: float
+    ) -> None:
         url = urljoin(self.target, "/record_spending")
         request = {
-            "config_name": f"symbolication-{platform}",
+            "config_name": f"symbolication-{platform.value}",
             "project_id": project_id,
             "spent": duration,
         }
@@ -35,10 +38,10 @@ class PbRealtimeMetricsStore(base.RealtimeMetricsStore):
         except RequestException:
             pass
 
-    def is_lpq_project(self, platform: str, project_id: int) -> bool:
+    def is_lpq_project(self, platform: SymbolicatorPlatform, project_id: int) -> bool:
         url = urljoin(self.target, "/exceeds_budget")
         request = {
-            "config_name": f"symbolication-{platform}",
+            "config_name": f"symbolication-{platform.value}",
             "project_id": project_id,
         }
         try:

--- a/src/sentry/processing/realtime_metrics/pb.py
+++ b/src/sentry/processing/realtime_metrics/pb.py
@@ -19,10 +19,10 @@ class PbRealtimeMetricsStore(base.RealtimeMetricsStore):
         self.target = target
         self.session = Session()
 
-    def record_project_duration(self, project_id: int, duration: float) -> None:
+    def record_project_duration(self, platform: str, project_id: int, duration: float) -> None:
         url = urljoin(self.target, "/record_spending")
         request = {
-            "config_name": "symbolication-native",
+            "config_name": f"symbolication-{platform}",
             "project_id": project_id,
             "spent": duration,
         }
@@ -35,10 +35,10 @@ class PbRealtimeMetricsStore(base.RealtimeMetricsStore):
         except RequestException:
             pass
 
-    def is_lpq_project(self, project_id: int) -> bool:
+    def is_lpq_project(self, platform: str, project_id: int) -> bool:
         url = urljoin(self.target, "/exceeds_budget")
         request = {
-            "config_name": "symbolication-native",
+            "config_name": f"symbolication-{platform}",
             "project_id": project_id,
         }
         try:

--- a/src/sentry/processing/realtime_metrics/redis.py
+++ b/src/sentry/processing/realtime_metrics/redis.py
@@ -111,7 +111,7 @@ class RedisRealtimeMetricsStore(base.RealtimeMetricsStore):
 
         buckets = range(first_bucket, now_bucket + bucket_size, bucket_size)
         keys = [self._budget_key(platform, project_id, ts) for ts in buckets]
-        member_key = f"{MEMBER_KEY_PREFIX}:{project_id}"
+        member_key = f"{MEMBER_KEY_PREFIX}:{platform}:{project_id}"
         keys.insert(0, member_key)
         results = self.cluster.mget(keys)
         is_lpq = results[0]

--- a/src/sentry/processing/realtime_metrics/redis.py
+++ b/src/sentry/processing/realtime_metrics/redis.py
@@ -51,12 +51,12 @@ class RedisRealtimeMetricsStore(base.RealtimeMetricsStore):
         if self._backoff_timer < 1:
             raise InvalidConfiguration("backoff timer must be at least a second")
 
-    def _budget_key_prefix(self) -> str:
-        return f"{BUDGET_KEY_PREFIX}:{self._budget_bucket_size}"
+    def _budget_key(self, platform: str, project_id: int, timestamp: int) -> str:
+        return f"{BUDGET_KEY_PREFIX}:{self._budget_bucket_size}:{platform}:{project_id}:{timestamp}"
 
-    def record_project_duration(self, project_id: int, duration: float) -> None:
+    def record_project_duration(self, platform: str, project_id: int, duration: float) -> None:
         """
-        Records the duration of a symbolication request for the given project_id.
+        Records the duration of a symbolication request for the given project_id and platform.
 
         The duration (from the start of the symbolication request)
         should be recorded at regular intervals *as the event is being processed*.
@@ -86,7 +86,7 @@ class RedisRealtimeMetricsStore(base.RealtimeMetricsStore):
 
         timestamp -= timestamp % self._budget_bucket_size
 
-        key = f"{self._budget_key_prefix()}:{project_id}:{timestamp}"
+        key = self._budget_key(platform, project_id, timestamp)
 
         # the duration internally is stores as ms
         duration = int(duration * 1000)
@@ -96,9 +96,10 @@ class RedisRealtimeMetricsStore(base.RealtimeMetricsStore):
             pipeline.expire(key, self._budget_time_window + self._budget_bucket_size)
             pipeline.execute()
 
-    def is_lpq_project(self, project_id: int) -> bool:
+    def is_lpq_project(self, platform: str, project_id: int) -> bool:
         """
-        Checks whether the given project is currently using the low priority queue.
+        Checks whether the given project is currently using the low priority queue for
+        the given platform.
         """
         timestamp = int(time())
 
@@ -109,7 +110,7 @@ class RedisRealtimeMetricsStore(base.RealtimeMetricsStore):
         first_bucket = first_bucket - first_bucket % bucket_size
 
         buckets = range(first_bucket, now_bucket + bucket_size, bucket_size)
-        keys = [f"{self._budget_key_prefix()}:{project_id}:{ts}" for ts in buckets]
+        keys = [self._budget_key(platform, project_id, ts) for ts in buckets]
         member_key = f"{MEMBER_KEY_PREFIX}:{project_id}"
         keys.insert(0, member_key)
         results = self.cluster.mget(keys)

--- a/src/sentry/tasks/store.py
+++ b/src/sentry/tasks/store.py
@@ -182,7 +182,7 @@ def _do_preprocess_event(
         ):
             reprocessing2.backup_unprocessed_event(data=original_data)
 
-            is_low_priority = should_demote_symbolication(first_platform.value, project_id)
+            is_low_priority = should_demote_symbolication(first_platform, project_id)
             submit_symbolicate(
                 SymbolicatorTaskKind(
                     platform=first_platform,

--- a/src/sentry/tasks/store.py
+++ b/src/sentry/tasks/store.py
@@ -182,7 +182,7 @@ def _do_preprocess_event(
         ):
             reprocessing2.backup_unprocessed_event(data=original_data)
 
-            is_low_priority = should_demote_symbolication(project_id)
+            is_low_priority = should_demote_symbolication(first_platform.value, project_id)
             submit_symbolicate(
                 SymbolicatorTaskKind(
                     platform=first_platform,

--- a/src/sentry/tasks/symbolication.py
+++ b/src/sentry/tasks/symbolication.py
@@ -33,7 +33,9 @@ info_logger = logging.getLogger("sentry.symbolication")
 SYMBOLICATOR_MAX_QUEUE_SWITCHES = 3
 
 
-def should_demote_symbolication(platform: str, project_id: int, emit_metrics=True) -> bool:
+def should_demote_symbolication(
+    platform: SymbolicatorPlatform, project_id: int, emit_metrics=True
+) -> bool:
     """
     Determines whether a project's symbolication events should be pushed to the low priority queue.
 
@@ -155,7 +157,7 @@ def _do_symbolicate_event(
     if queue_switches >= SYMBOLICATOR_MAX_QUEUE_SWITCHES:
         metrics.incr("tasks.store.symbolicate_event.low_priority.max_queue_switches", sample_rate=1)
     else:
-        should_be_low_priority = should_demote_symbolication(task_kind.platform.value, project_id)
+        should_be_low_priority = should_demote_symbolication(task_kind.platform, project_id)
 
         if task_kind.is_low_priority != should_be_low_priority:
             metrics.incr("tasks.store.symbolicate_event.low_priority.wrong_queue", sample_rate=1)
@@ -239,7 +241,7 @@ def _do_symbolicate_event(
                     # the same even considering sampling of metrics.
                     recorded_duration = symbolication_duration / submission_ratio
                     realtime_metrics.record_project_duration(
-                        task_kind.platform.value, project_id, recorded_duration
+                        task_kind.platform, project_id, recorded_duration
                     )
                 except Exception as e:
                     sentry_sdk.capture_exception(e)

--- a/tests/sentry/processing/realtime_metrics/test_pb.py
+++ b/tests/sentry/processing/realtime_metrics/test_pb.py
@@ -7,14 +7,14 @@ from sentry.processing.realtime_metrics.pb import PbRealtimeMetricsStore
 def test_invalid_target():
     # there is no grpc service at that addr
     store = PbRealtimeMetricsStore(target="http://localhost:12345")
-    store.record_project_duration(1, 123456789)
-    assert not store.is_lpq_project(1)
+    store.record_project_duration("native", 1, 123456789)
+    assert not store.is_lpq_project("native", 1)
 
 
 def test_pb_works():
     store = PbRealtimeMetricsStore(target="http://localhost:4433")
 
     project_id = floor(random() * (1 << 32))
-    assert not store.is_lpq_project(project_id)
-    store.record_project_duration(project_id, 123456789)
-    assert store.is_lpq_project(project_id)
+    assert not store.is_lpq_project("native", project_id)
+    store.record_project_duration("native", project_id, 123456789)
+    assert store.is_lpq_project("native", project_id)

--- a/tests/sentry/processing/realtime_metrics/test_pb.py
+++ b/tests/sentry/processing/realtime_metrics/test_pb.py
@@ -1,20 +1,21 @@
 from math import floor
 from random import random
 
+from sentry.lang.native.symbolicator import SymbolicatorPlatform
 from sentry.processing.realtime_metrics.pb import PbRealtimeMetricsStore
 
 
 def test_invalid_target():
     # there is no grpc service at that addr
     store = PbRealtimeMetricsStore(target="http://localhost:12345")
-    store.record_project_duration("native", 1, 123456789)
-    assert not store.is_lpq_project("native", 1)
+    store.record_project_duration(SymbolicatorPlatform.native, 1, 123456789)
+    assert not store.is_lpq_project(SymbolicatorPlatform.native, 1)
 
 
 def test_pb_works():
     store = PbRealtimeMetricsStore(target="http://localhost:4433")
 
     project_id = floor(random() * (1 << 32))
-    assert not store.is_lpq_project("native", project_id)
-    store.record_project_duration("native", project_id, 123456789)
-    assert store.is_lpq_project("native", project_id)
+    assert not store.is_lpq_project(SymbolicatorPlatform.native, project_id)
+    store.record_project_duration(SymbolicatorPlatform.native, project_id, 123456789)
+    assert store.is_lpq_project(SymbolicatorPlatform.native, project_id)

--- a/tests/sentry/processing/realtime_metrics/test_redis.py
+++ b/tests/sentry/processing/realtime_metrics/test_redis.py
@@ -6,6 +6,7 @@ import pytest
 from redis import StrictRedis
 
 from sentry.exceptions import InvalidConfiguration
+from sentry.lang.native.symbolicator import SymbolicatorPlatform
 from sentry.processing import realtime_metrics
 from sentry.processing.realtime_metrics.redis import RedisRealtimeMetricsStore
 from sentry.testutils.helpers.datetime import freeze_time
@@ -34,7 +35,7 @@ def store(config: dict[str, Any]) -> RedisRealtimeMetricsStore:
 
 def test_default() -> None:
     with freeze_time(datetime.fromtimestamp(1234)):
-        realtime_metrics.record_project_duration("native", 17, 1.0)
+        realtime_metrics.record_project_duration(SymbolicatorPlatform.native, 17, 1.0)
 
 
 def test_invalid_config() -> None:
@@ -57,9 +58,9 @@ def test_record_project_duration_same_bucket(
     store: RedisRealtimeMetricsStore, redis_cluster: StrictRedis
 ) -> None:
     with freeze_time(datetime.fromtimestamp(1147)) as frozen_datetime:
-        store.record_project_duration("native", 17, 1.0)
+        store.record_project_duration(SymbolicatorPlatform.native, 17, 1.0)
         frozen_datetime.shift(2)
-        store.record_project_duration("native", 17, 1.0)
+        store.record_project_duration(SymbolicatorPlatform.native, 17, 1.0)
 
     assert redis_cluster.get("symbolicate_event_low_priority:budget:10:native:17:1140") == "2000"
 
@@ -68,20 +69,20 @@ def test_record_project_duration_different_buckets(
     store: RedisRealtimeMetricsStore, redis_cluster: StrictRedis
 ) -> None:
     with freeze_time(datetime.fromtimestamp(1147)) as frozen_datetime:
-        store.record_project_duration("native", 17, 1.0)
+        store.record_project_duration(SymbolicatorPlatform.native, 17, 1.0)
         frozen_datetime.shift(5)
-        store.record_project_duration("native", 17, 1.0)
+        store.record_project_duration(SymbolicatorPlatform.native, 17, 1.0)
 
     assert redis_cluster.get("symbolicate_event_low_priority:budget:10:native:17:1140") == "1000"
     assert redis_cluster.get("symbolicate_event_low_priority:budget:10:native:17:1150") == "1000"
 
 
 def test_is_lpq_spike(store: RedisRealtimeMetricsStore) -> None:
-    assert not store.is_lpq_project("native", 17)
+    assert not store.is_lpq_project(SymbolicatorPlatform.native, 17)
 
-    store.record_project_duration("native", 17, 1000000.0)
-    assert store.is_lpq_project("native", 17)
-    assert not store.is_lpq_project("js", 17)
+    store.record_project_duration(SymbolicatorPlatform.native, 17, 1000000.0)
+    assert store.is_lpq_project(SymbolicatorPlatform.native, 17)
+    assert not store.is_lpq_project(SymbolicatorPlatform.js, 17)
 
 
 def test_is_lpq_gradual(store: RedisRealtimeMetricsStore) -> None:
@@ -89,19 +90,19 @@ def test_is_lpq_gradual(store: RedisRealtimeMetricsStore) -> None:
         for _ in range(60):
             delta = random.randint(1, 6)
             used = 5.5 * delta
-            store.record_project_duration("native", 17, used)
+            store.record_project_duration(SymbolicatorPlatform.native, 17, used)
             frozen_datetime.shift(delta)
-        assert store.is_lpq_project("native", 17)
+        assert store.is_lpq_project(SymbolicatorPlatform.native, 17)
         assert not store.is_lpq_project("js", 17)
 
 
 def test_not_lpq_spike(store: RedisRealtimeMetricsStore) -> None:
-    assert not store.is_lpq_project("native", 17)
+    assert not store.is_lpq_project(SymbolicatorPlatform.native, 17)
 
     # just under the entire budget for 2min
     used = 5.0 * 115
-    store.record_project_duration("native", 17, used)
-    assert not store.is_lpq_project("native", 17)
+    store.record_project_duration(SymbolicatorPlatform.native, 17, used)
+    assert not store.is_lpq_project(SymbolicatorPlatform.native, 17)
 
 
 def test_not_lpq_gradual(store: RedisRealtimeMetricsStore) -> None:
@@ -109,6 +110,6 @@ def test_not_lpq_gradual(store: RedisRealtimeMetricsStore) -> None:
         for _ in range(60):
             delta = random.randint(1, 6)
             used = 4.5 * delta
-            store.record_project_duration("native", 17, used)
+            store.record_project_duration(SymbolicatorPlatform.native, 17, used)
             frozen_datetime.shift(delta)
-        assert not store.is_lpq_project("native", 17)
+        assert not store.is_lpq_project(SymbolicatorPlatform.native, 17)

--- a/tests/sentry/processing/realtime_metrics/test_redis.py
+++ b/tests/sentry/processing/realtime_metrics/test_redis.py
@@ -34,7 +34,7 @@ def store(config: dict[str, Any]) -> RedisRealtimeMetricsStore:
 
 def test_default() -> None:
     with freeze_time(datetime.fromtimestamp(1234)):
-        realtime_metrics.record_project_duration(17, 1.0)
+        realtime_metrics.record_project_duration("native", 17, 1.0)
 
 
 def test_invalid_config() -> None:
@@ -57,9 +57,9 @@ def test_record_project_duration_same_bucket(
     store: RedisRealtimeMetricsStore, redis_cluster: StrictRedis
 ) -> None:
     with freeze_time(datetime.fromtimestamp(1147)) as frozen_datetime:
-        store.record_project_duration(17, 1.0)
+        store.record_project_duration("native", 17, 1.0)
         frozen_datetime.shift(2)
-        store.record_project_duration(17, 1.0)
+        store.record_project_duration("native", 17, 1.0)
 
     assert redis_cluster.get("symbolicate_event_low_priority:budget:10:17:1140") == "2000"
 
@@ -68,19 +68,20 @@ def test_record_project_duration_different_buckets(
     store: RedisRealtimeMetricsStore, redis_cluster: StrictRedis
 ) -> None:
     with freeze_time(datetime.fromtimestamp(1147)) as frozen_datetime:
-        store.record_project_duration(17, 1.0)
+        store.record_project_duration("native", 17, 1.0)
         frozen_datetime.shift(5)
-        store.record_project_duration(17, 1.0)
+        store.record_project_duration("native", 17, 1.0)
 
     assert redis_cluster.get("symbolicate_event_low_priority:budget:10:17:1140") == "1000"
     assert redis_cluster.get("symbolicate_event_low_priority:budget:10:17:1150") == "1000"
 
 
 def test_is_lpq_spike(store: RedisRealtimeMetricsStore) -> None:
-    assert not store.is_lpq_project(17)
+    assert not store.is_lpq_project("native", 17)
 
-    store.record_project_duration(17, 1000000.0)
-    assert store.is_lpq_project(17)
+    store.record_project_duration("native", 17, 1000000.0)
+    assert store.is_lpq_project("native", 17)
+    assert not store.is_lpq_project("js", 17)
 
 
 def test_is_lpq_gradual(store: RedisRealtimeMetricsStore) -> None:
@@ -88,25 +89,26 @@ def test_is_lpq_gradual(store: RedisRealtimeMetricsStore) -> None:
         for _ in range(60):
             delta = random.randint(1, 6)
             used = 5.5 * delta
-            store.record_project_duration(17, used)
+            store.record_project_duration("native", 17, used)
             frozen_datetime.shift(delta)
-        assert store.is_lpq_project(17)
+        assert store.is_lpq_project("native", 17)
+        assert not store.is_lpq_project("js", 17)
 
 
 def test_not_lpq_spike(store: RedisRealtimeMetricsStore) -> None:
-    assert not store.is_lpq_project(17)
+    assert not store.is_lpq_project("native", 17)
 
     # just under the entire budget for 2min
     used = 5.0 * 115
-    store.record_project_duration(17, used)
-    assert not store.is_lpq_project(17)
+    store.record_project_duration("native", 17, used)
+    assert not store.is_lpq_project("native", 17)
 
 
 def test_not_lpq_gradual(store: RedisRealtimeMetricsStore) -> None:
-    with freeze_time(datetime.fromtimestamp(1147)) as frozen_datetime:
+    with freeze_time(datetime.fromtimestamp("native", 1147)) as frozen_datetime:
         for _ in range(60):
             delta = random.randint(1, 6)
             used = 4.5 * delta
-            store.record_project_duration(17, used)
+            store.record_project_duration("native", 17, used)
             frozen_datetime.shift(delta)
-        assert not store.is_lpq_project(17)
+        assert not store.is_lpq_project("native", 17)

--- a/tests/sentry/processing/realtime_metrics/test_redis.py
+++ b/tests/sentry/processing/realtime_metrics/test_redis.py
@@ -93,7 +93,7 @@ def test_is_lpq_gradual(store: RedisRealtimeMetricsStore) -> None:
             store.record_project_duration(SymbolicatorPlatform.native, 17, used)
             frozen_datetime.shift(delta)
         assert store.is_lpq_project(SymbolicatorPlatform.native, 17)
-        assert not store.is_lpq_project("js", 17)
+        assert not store.is_lpq_project(SymbolicatorPlatform.js, 17)
 
 
 def test_not_lpq_spike(store: RedisRealtimeMetricsStore) -> None:

--- a/tests/sentry/processing/realtime_metrics/test_redis.py
+++ b/tests/sentry/processing/realtime_metrics/test_redis.py
@@ -61,7 +61,7 @@ def test_record_project_duration_same_bucket(
         frozen_datetime.shift(2)
         store.record_project_duration("native", 17, 1.0)
 
-    assert redis_cluster.get("symbolicate_event_low_priority:budget:10:17:1140") == "2000"
+    assert redis_cluster.get("symbolicate_event_low_priority:budget:10:native:17:1140") == "2000"
 
 
 def test_record_project_duration_different_buckets(
@@ -72,8 +72,8 @@ def test_record_project_duration_different_buckets(
         frozen_datetime.shift(5)
         store.record_project_duration("native", 17, 1.0)
 
-    assert redis_cluster.get("symbolicate_event_low_priority:budget:10:17:1140") == "1000"
-    assert redis_cluster.get("symbolicate_event_low_priority:budget:10:17:1150") == "1000"
+    assert redis_cluster.get("symbolicate_event_low_priority:budget:10:native:17:1140") == "1000"
+    assert redis_cluster.get("symbolicate_event_low_priority:budget:10:native:17:1150") == "1000"
 
 
 def test_is_lpq_spike(store: RedisRealtimeMetricsStore) -> None:
@@ -105,7 +105,7 @@ def test_not_lpq_spike(store: RedisRealtimeMetricsStore) -> None:
 
 
 def test_not_lpq_gradual(store: RedisRealtimeMetricsStore) -> None:
-    with freeze_time(datetime.fromtimestamp("native", 1147)) as frozen_datetime:
+    with freeze_time(datetime.fromtimestamp(1147)) as frozen_datetime:
         for _ in range(60):
             delta = random.randint(1, 6)
             used = 4.5 * delta

--- a/tests/sentry/tasks/test_symbolication.py
+++ b/tests/sentry/tasks/test_symbolication.py
@@ -145,19 +145,19 @@ def test_symbolicate_event_doesnt_call_process_inline(
 
 @django_db_all
 def test_should_demote_symbolication_empty(default_project):
-    assert not should_demote_symbolication("native", default_project.id)
+    assert not should_demote_symbolication(SymbolicatorPlatform.native, default_project.id)
 
 
 @django_db_all
 def test_should_demote_symbolication_always(default_project):
     with override_options({"store.symbolicate-event-lpq-always": [default_project.id]}):
-        assert should_demote_symbolication("native", default_project.id)
+        assert should_demote_symbolication(SymbolicatorPlatform.native, default_project.id)
 
 
 @django_db_all
 def test_should_demote_symbolication_never(default_project):
     with override_options({"store.symbolicate-event-lpq-never": [default_project.id]}):
-        assert not should_demote_symbolication("native", default_project.id)
+        assert not should_demote_symbolication(SymbolicatorPlatform.native, default_project.id)
 
 
 @django_db_all
@@ -168,7 +168,7 @@ def test_should_demote_symbolication_always_and_never(default_project):
             "store.symbolicate-event-lpq-always": [default_project.id],
         }
     ):
-        assert not should_demote_symbolication("native", default_project.id)
+        assert not should_demote_symbolication(SymbolicatorPlatform.native, default_project.id)
 
 
 @django_db_all
@@ -180,7 +180,7 @@ def test_should_demote_symbolication_with_non_existing_lpq_projects(default_proj
             "store.symbolicate-event-lpq-always": [],
         }
     ):
-        assert not should_demote_symbolication("native", default_project.id)
+        assert not should_demote_symbolication(SymbolicatorPlatform.native, default_project.id)
 
 
 @django_db_all
@@ -203,7 +203,9 @@ def test_submit_symbolicate_queue_switch(
     mock_event_processing_store.get.return_value = data
     mock_event_processing_store.store.return_value = "e:1"
 
-    is_low_priority = mock_should_demote_symbolication("native", default_project.id)
+    is_low_priority = mock_should_demote_symbolication(
+        SymbolicatorPlatform.native, default_project.id
+    )
     assert is_low_priority
     with TaskRunner():
         task_kind = SymbolicatorTaskKind(

--- a/tests/sentry/tasks/test_symbolication.py
+++ b/tests/sentry/tasks/test_symbolication.py
@@ -145,19 +145,19 @@ def test_symbolicate_event_doesnt_call_process_inline(
 
 @django_db_all
 def test_should_demote_symbolication_empty(default_project):
-    assert not should_demote_symbolication(default_project.id)
+    assert not should_demote_symbolication("native", default_project.id)
 
 
 @django_db_all
 def test_should_demote_symbolication_always(default_project):
     with override_options({"store.symbolicate-event-lpq-always": [default_project.id]}):
-        assert should_demote_symbolication(default_project.id)
+        assert should_demote_symbolication("native", default_project.id)
 
 
 @django_db_all
 def test_should_demote_symbolication_never(default_project):
     with override_options({"store.symbolicate-event-lpq-never": [default_project.id]}):
-        assert not should_demote_symbolication(default_project.id)
+        assert not should_demote_symbolication("native", default_project.id)
 
 
 @django_db_all
@@ -168,19 +168,7 @@ def test_should_demote_symbolication_always_and_never(default_project):
             "store.symbolicate-event-lpq-always": [default_project.id],
         }
     ):
-        assert not should_demote_symbolication(default_project.id)
-
-
-@django_db_all
-@override_settings(SENTRY_ENABLE_AUTO_LOW_PRIORITY_QUEUE=True)
-def test_should_demote_symbolication_with_lpq_projects(default_project):
-    with override_options(
-        {
-            "store.symbolicate-event-lpq-never": [],
-            "store.symbolicate-event-lpq-always": [],
-        }
-    ):
-        assert should_demote_symbolication(default_project.id, lpq_projects={default_project.id})
+        assert not should_demote_symbolication("native", default_project.id)
 
 
 @django_db_all
@@ -192,7 +180,7 @@ def test_should_demote_symbolication_with_non_existing_lpq_projects(default_proj
             "store.symbolicate-event-lpq-always": [],
         }
     ):
-        assert not should_demote_symbolication(default_project.id)
+        assert not should_demote_symbolication("native", default_project.id)
 
 
 @django_db_all
@@ -215,7 +203,7 @@ def test_submit_symbolicate_queue_switch(
     mock_event_processing_store.get.return_value = data
     mock_event_processing_store.store.return_value = "e:1"
 
-    is_low_priority = mock_should_demote_symbolication(default_project.id)
+    is_low_priority = mock_should_demote_symbolication("native", default_project.id)
     assert is_low_priority
     with TaskRunner():
         task_kind = SymbolicatorTaskKind(


### PR DESCRIPTION
This adds `platform` parameters to `record_project_duration` and `is_lpq_project`, meaning that spent budget and LPQ status can now be tracked per symbolication platform.