### PR TITLE
ref(trace-explorer): Lift load all projects

### DIFF
--- a/src/sentry/api/endpoints/organization_traces.py
+++ b/src/sentry/api/endpoints/organization_traces.py
@@ -1,4 +1,3 @@
-import dataclasses
 import math
 from collections import defaultdict
 from collections.abc import Generator, Mapping, MutableMapping
@@ -23,10 +22,12 @@ from sentry.api.bases import NoProjects, OrganizationEventsV2EndpointBase
 from sentry.api.paginator import GenericOffsetPaginator
 from sentry.api.utils import handle_query_errors
 from sentry.models.organization import Organization
+from sentry.models.project import Project
 from sentry.search.events.builder import QueryBuilder, SpansIndexedQueryBuilder
 from sentry.search.events.constants import TIMEOUT_SPAN_ERROR_MESSAGE
 from sentry.search.events.types import ParamsType, QueryBuilderConfig, SnubaParams, WhereType
 from sentry.sentry_metrics.querying.samples_list import SpanKey, get_sample_list_executor_cls
+from sentry.services.hybrid_cloud.organization import RpcOrganization
 from sentry.snuba.dataset import Dataset
 from sentry.snuba.referrer import Referrer
 from sentry.utils.iterators import chunked
@@ -98,8 +99,39 @@ def handle_span_query_errors() -> Generator[None, None, None]:
             raise ParseError(detail=TIMEOUT_SPAN_ERROR_MESSAGE)
 
 
+class OrganizationTracesEndpointBase(OrganizationEventsV2EndpointBase):
+    def get_snuba_dataclass(
+        self, request: Request, organization: Organization, check_global_views: bool = True
+    ) -> tuple[SnubaParams, dict[str, Any]]:
+        """The trace endpoint always wants to get all projects regardless of what's passed into the API.
+        This is because a trace can span any number of projects in an organization. So disable the
+        check_global_views condition."""
+        return super().get_snuba_dataclass(request, organization, check_global_views=False)
+
+    def get_projects(  # type: ignore[override]
+        self,
+        request: Request,
+        organization: Organization | RpcOrganization,
+        project_ids: set[int] | None = None,
+        project_slugs: set[str] | None = None,
+        include_all_accessible: bool = True,
+    ) -> list[Project]:
+        """The trace endpoint always wants to get all projects regardless of what's passed into the API.
+
+        This is because a trace can span any number of projects in an organization. But we still want to
+        use the get_projects function to check for any permissions. So we'll just pass project_ids=-1 everytime
+        which is what would be sent if we wanted all projects"""
+        return super().get_projects(
+            request,
+            organization,
+            project_ids={-1},
+            project_slugs=None,
+            include_all_accessible=True,
+        )
+
+
 @region_silo_endpoint
-class OrganizationTracesEndpoint(OrganizationEventsV2EndpointBase):
+class OrganizationTracesEndpoint(OrganizationTracesEndpointBase):
     publish_status = {
         "GET": ApiPublishStatus.EXPERIMENTAL,
     }
@@ -113,17 +145,6 @@ class OrganizationTracesEndpoint(OrganizationEventsV2EndpointBase):
 
         try:
             snuba_params, params = self.get_snuba_dataclass(request, organization)
-            all_projects = self.get_projects(
-                request,
-                organization,
-                project_ids={-1},
-                project_slugs=None,
-                include_all_accessible=True,
-            )
-            snuba_params = dataclasses.replace(snuba_params, projects=all_projects)
-            params["projects"] = snuba_params.projects
-            params["projects_objects"] = snuba_params.projects
-            params["projects_id"] = snuba_params.project_ids
         except NoProjects:
             return Response(status=404)
 


### PR DESCRIPTION
Preparing for the stats endpoint. Lifting this logic so it can be shared.