### PR TITLE
test(ui): Fix release list flake

### DIFF
--- a/static/app/views/performance/transactionSummary/transactionVitals/index.spec.tsx
+++ b/static/app/views/performance/transactionSummary/transactionVitals/index.spec.tsx
@@ -227,7 +227,7 @@ describe('Performance > Web Vitals', function () {
 
     it.each(vitals)('Renders %s', async function (vital) {
       expect(await screen.findByText(vital.heading)).toBeInTheDocument();
-      expect(screen.getByText(vital.baseline)).toBeInTheDocument();
+      expect(await screen.findByText(vital.baseline)).toBeInTheDocument();
     });
   });
 

--- a/static/app/views/releases/list/index.spec.tsx
+++ b/static/app/views/releases/list/index.spec.tsx
@@ -124,7 +124,8 @@ describe('ReleasesList', () => {
     expect(within(items.at(0)!).getByText('1.0.0')).toBeInTheDocument();
     expect(within(items.at(0)!).getByText('Adoption')).toBeInTheDocument();
     expect(within(items.at(1)!).getByText('1.0.1')).toBeInTheDocument();
-    expect(within(items.at(1)!).getByText('0%')).toBeInTheDocument();
+    // Crash free rate loads separately
+    expect(await within(items.at(1)!).findByText('0%')).toBeInTheDocument();
     expect(within(items.at(2)!).getByText('af4f231ec9a8')).toBeInTheDocument();
     expect(within(items.at(2)!).getByText('Project Name')).toBeInTheDocument();
   });


### PR DESCRIPTION
I think its possible the crash rate hasn't loaded yet. Flake in master https://github.com/getsentry/sentry/actions/runs/9412894926/job/25928600993
