### PR TITLE
test(ui): Silence console warning with aria-label

### DIFF
--- a/static/app/views/performance/mobile/appStarts/screenSummary/samples.tsx
+++ b/static/app/views/performance/mobile/appStarts/screenSummary/samples.tsx
@@ -76,7 +76,11 @@ export function SamplesTables({transactionName}) {
           )}
           <DeviceClassSelector size="md" clearSpansTableCursor />
         </FiltersContainer>
-        <SegmentedControl onChange={value => setSampleType(value)} defaultValue={SPANS}>
+        <SegmentedControl
+          onChange={value => setSampleType(value)}
+          defaultValue={SPANS}
+          aria-label={t('Sample Type Selection')}
+        >
           <SegmentedControl.Item key={SPANS}>{t('By Spans')}</SegmentedControl.Item>
           <SegmentedControl.Item key={EVENT}>{t('By Event')}</SegmentedControl.Item>
         </SegmentedControl>


### PR DESCRIPTION
Silences one of those annoying warnings https://github.com/getsentry/sentry/actions/runs/9419987328/job/25951020859?pr=72320#step:6:157

```
    console.warn
      If you do not provide a visible label, you must specify an aria-label or aria-labelledby attribute for accessibility
```
