### PR TITLE
feat(query-builder): Make last input take up the remaining space

### DIFF
--- a/static/app/components/searchQueryBuilder/combobox.tsx
+++ b/static/app/components/searchQueryBuilder/combobox.tsx
@@ -401,7 +401,7 @@ function SearchQueryBuilderComboboxInner<T extends SelectOptionOrSectionWithKey<
     e => {
       e.stopPropagation();
       inputProps.onClick?.(e);
-      state.open();
+      state.toggle();
     },
     [inputProps, state]
   );
@@ -466,6 +466,7 @@ const Wrapper = styled('div')`
   display: flex;
   align-items: stretch;
   height: 100%;
+  width: 100%;
 `;
 
 const UnstyledInput = styled(GrowingInput)`
@@ -490,12 +491,13 @@ const UnstyledInput = styled(GrowingInput)`
 const StyledPositionWrapper = styled(PositionWrapper, {
   shouldForwardProp: prop => isPropValid(prop),
 })<{visible?: boolean}>`
-  min-width: 100%;
   display: ${p => (p.visible ? 'block' : 'none')};
 `;
 
 const StyledOverlay = styled(Overlay)`
   max-height: 400px;
+  width: 300px;
+  max-width: min-content;
   overflow-y: auto;
 `;
 
@@ -504,6 +506,7 @@ const SectionedOverlay = styled(Overlay)`
   display: grid;
   grid-template-columns: 120px 240px;
   height: 400px;
+  width: 360px;
 `;
 
 const SectionedListBoxPane = styled('div')`

--- a/static/app/components/searchQueryBuilder/index.spec.tsx
+++ b/static/app/components/searchQueryBuilder/index.spec.tsx
@@ -691,7 +691,6 @@ describe('SearchQueryBuilder', function () {
       await userEvent.click(
         screen.getByRole('button', {name: 'Edit value for filter: assigned'})
       );
-      await userEvent.click(screen.getByRole('combobox', {name: 'Edit filter value'}));
 
       const groups = within(screen.getByRole('listbox')).getAllByRole('group');
 

--- a/static/app/components/searchQueryBuilder/input.tsx
+++ b/static/app/components/searchQueryBuilder/input.tsx
@@ -375,16 +375,22 @@ const Row = styled('div')`
   display: flex;
   align-items: stretch;
   height: 24px;
+
+  &:last-child {
+    flex-grow: 1;
+  }
 `;
 
 const GridCell = styled('div')`
   display: flex;
   align-items: stretch;
   height: 100%;
+  width: 100%;
 
   input {
     padding: 0 ${space(0.5)};
     min-width: 9px;
+    width: 100%;
   }
 `;
 

--- a/static/app/components/searchQueryBuilder/tokenizedQueryGrid.tsx
+++ b/static/app/components/searchQueryBuilder/tokenizedQueryGrid.tsx
@@ -118,7 +118,7 @@ export function TokenizedQueryGrid({label}: TokenizedQueryGridProps) {
 }
 
 const SearchQueryGridWrapper = styled('div')`
-  padding: ${space(0.75)} 48px ${space(0.75)} 32px;
+  padding: ${space(0.75)} 34px ${space(0.75)} 32px;
   display: flex;
   align-items: stretch;
   row-gap: ${space(0.5)};


### PR DESCRIPTION
- Adds `flex-grow: 1` to the last input so that clicking the empty space is treated like clicking the input
- Clicking the input now toggles the menu open state instead of always opening
- Some adjustments to menu styles that were necessary because of the increased combobox width

Before:

![CleanShot 2024-06-06 at 17 54 19@2x](https://github.com/getsentry/sentry/assets/10888943/dff8b2c6-cda9-42e4-991a-47a3512c4eee)

After:

![CleanShot 2024-06-06 at 17 53 39@2x](https://github.com/getsentry/sentry/assets/10888943/f2317bc9-9d74-43e3-83a9-11ef7043dfb3)
