### PR TITLE
chore(hybridcloud) Mainline cached user reads and add generic metrics

### DIFF
--- a/src/sentry/services/hybrid_cloud/user/service.py
+++ b/src/sentry/services/hybrid_cloud/user/service.py
@@ -6,7 +6,6 @@
 from abc import abstractmethod
 from typing import Any
 
-from sentry.features.rollout import in_random_rollout
 from sentry.hybridcloud.rpc.services.caching import back_with_silo_cache
 from sentry.hybridcloud.rpc.services.caching.service import back_with_silo_cache_many
 from sentry.services.hybrid_cloud.auth import AuthenticationContext
@@ -27,7 +26,6 @@ from sentry.services.hybrid_cloud.user.model import (
     UserIdEmailArgs,
 )
 from sentry.silo.base import SiloMode
-from sentry.utils import metrics
 
 
 class UserService(RpcService):
@@ -125,10 +123,7 @@ class UserService(RpcService):
 
         :param ids: A list of user ids to fetch
         """
-        if in_random_rollout("user.get_many_by_id.rollout"):
-            metrics.incr("user_service.get_many_by_id.fetch", len(ids))
-            return get_many_by_id(ids)
-        return self.get_many(filter={"user_ids": ids})
+        return get_many_by_id(ids)
 
     @rpc_method
     @abstractmethod
@@ -336,7 +331,6 @@ def get_user(user_id: int) -> RpcUser | None:
 
 @back_with_silo_cache_many("user_service.get_many_by_id", SiloMode.REGION, RpcUser)
 def get_many_by_id(ids: list[int]) -> list[RpcUser]:
-    metrics.incr("user_service.get_many_by_id.fetch_rpc", len(ids))
     return user_service.get_many(filter={"user_ids": ids})
 
 

--- a/tests/sentry/notifications/notifications/test_assigned.py
+++ b/tests/sentry/notifications/notifications/test_assigned.py
@@ -136,17 +136,17 @@ class AssignedNotificationAPITest(APITestCase):
         ).exists()
 
         assert len(mail.outbox) == 3
-        txt_msg = f"{user1.email} assigned {self.group.qualified_short_id} to {user2.email}"
-        html_msg = f"{self.group.qualified_short_id}</a> to {user2.email}"
-        self.validate_email(mail.outbox, 1, user2.email, txt_msg, html_msg)
-
         txt_msg = f"assigned {self.group.qualified_short_id} to {user2.email}"
         html_msg = f"{self.group.qualified_short_id}</a> to {user2.email}</p>"
-        self.validate_email(mail.outbox, 2, user1.email, txt_msg, html_msg)
+        self.validate_email(mail.outbox, 1, user1.email, txt_msg, html_msg)
+
+        txt_msg = f"{user1.email} assigned {self.group.qualified_short_id} to {user2.email}"
+        html_msg = f"{self.group.qualified_short_id}</a> to {user2.email}"
+        self.validate_email(mail.outbox, 2, user2.email, txt_msg, html_msg)
 
         msg = f"Issue assigned to {user2.get_display_name()} by {user1.get_display_name()}"
-        self.validate_slack_message(msg, self.group, self.project, user2.id, index=1)
-        self.validate_slack_message(msg, self.group, self.project, user1.id, index=2)
+        self.validate_slack_message(msg, self.group, self.project, user1.id, index=1)
+        self.validate_slack_message(msg, self.group, self.project, user2.id, index=2)
 
     @responses.activate
     def test_sends_reassignment_notification_team(self):
@@ -186,11 +186,12 @@ class AssignedNotificationAPITest(APITestCase):
         assert len(mail.outbox) == 2
         txt_msg = f"assigned {group.qualified_short_id} to the {team1.slug} team"
         html_msg = f"{group.qualified_short_id}</a> to the {team1.slug} team</p>"
-        self.validate_email(mail.outbox, 0, user2.email, txt_msg, html_msg)
-        self.validate_email(mail.outbox, 1, user1.email, txt_msg, html_msg)
+        self.validate_email(mail.outbox, 0, user1.email, txt_msg, html_msg)
+        self.validate_email(mail.outbox, 1, user2.email, txt_msg, html_msg)
+
         msg = f"Issue assigned to the {team1.slug} team by {user1.email}"
-        self.validate_slack_message(msg, group, project, user2.id, index=0)
-        self.validate_slack_message(msg, group, project, user1.id, index=1)
+        self.validate_slack_message(msg, group, project, user1.id, index=0)
+        self.validate_slack_message(msg, group, project, user2.id, index=1)
 
         # reassign to team2
         with self.tasks():
@@ -209,16 +210,16 @@ class AssignedNotificationAPITest(APITestCase):
 
         txt_msg = f"{user1.email} assigned {group.qualified_short_id} to the {team2.slug} team"
         html_msg = f"{user1.email}</strong> assigned"
-        self.validate_email(mail.outbox, 2, user2.email, txt_msg, html_msg)
-        self.validate_email(mail.outbox, 3, user3.email, txt_msg, html_msg)
+        self.validate_email(mail.outbox, 2, user1.email, txt_msg, html_msg)
+        self.validate_email(mail.outbox, 3, user2.email, txt_msg, html_msg)
 
         txt_msg = f"assigned {group.qualified_short_id} to the {team2.slug} team"
         html_msg = f"to the {team2.slug} team</p>"
-        self.validate_email(mail.outbox, 4, user4.email, txt_msg, html_msg)
-        self.validate_email(mail.outbox, 5, user1.email, txt_msg, html_msg)
+        self.validate_email(mail.outbox, 4, user3.email, txt_msg, html_msg)
+        self.validate_email(mail.outbox, 5, user4.email, txt_msg, html_msg)
 
         msg = f"Issue assigned to the {team2.slug} team by {user1.email}"
-        self.validate_slack_message(msg, group, project, user2.id, index=2)
-        self.validate_slack_message(msg, group, project, user3.id, index=3)
-        self.validate_slack_message(msg, group, project, user4.id, index=4)
-        self.validate_slack_message(msg, group, project, user1.id, index=5)
+        self.validate_slack_message(msg, group, project, user1.id, index=2)
+        self.validate_slack_message(msg, group, project, user2.id, index=3)
+        self.validate_slack_message(msg, group, project, user3.id, index=4)
+        self.validate_slack_message(msg, group, project, user4.id, index=5)


### PR DESCRIPTION
- Make `get_many_by_id` use caching by default as we're getting a good hit rate on this currently.
- Add generalized metrics for rpc caching so it can be plotted.

Refs HC-1193