### PR TITLE
fix: Improve trimming of Swift function names

### DIFF
--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_04_05/in_app_in_ui.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_04_05/in_app_in_ui.pysnap
@@ -4,7 +4,7 @@ creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
-  hash: "9b037f38798ea127aac3e8b8e1e1024a"
+  hash: "61c031e5e187212561f67b5567f8ae47"
   component:
     app*
       exception*
@@ -122,7 +122,7 @@ app:
             filename*
               "mediaslideshow+extensions.swift"
             function* (isolated function)
-              "MediaSlideshow.toSources"
+              "closure in MediaSlideshow.toSources"
           frame*
             filename*
               "mediaslideshow+extensions.swift"
@@ -147,7 +147,7 @@ app:
           "EXC_BREAKPOINT"
 --------------------------------------------------------------------------
 system:
-  hash: "fe8b15fe322c91ede2fc48363fe43587"
+  hash: "7c47e696e27052f4849cb07e99cf649e"
   component:
     system*
       exception*
@@ -265,7 +265,7 @@ system:
             filename*
               "mediaslideshow+extensions.swift"
             function* (isolated function)
-              "MediaSlideshow.toSources"
+              "closure in MediaSlideshow.toSources"
           frame*
             filename*
               "mediaslideshow+extensions.swift"

--- a/tests/sentry/stacktraces/test_functions.py
+++ b/tests/sentry/stacktraces/test_functions.py
@@ -103,6 +103,30 @@ from sentry.stacktraces.functions import (
         ],
         ["pthread_cond_timedwait@@GLIBC_2.3.2", "pthread_cond_timedwait"],
         ["glob64@GLIBC_2.2", "glob64"],
+        [
+            "static Namespace.ThrowingFunction() throws -> Namespace.ExitValue?",
+            "Namespace.ThrowingFunction",
+        ],
+        [
+            "closure #1 @Swift.MainActor () -> () in static Foo.CallFunction(args: [Swift.String]) -> ()",
+            "closure in Foo.CallFunction",
+        ],
+        [
+            "closure #1 () -> () in Bar.PostTask(() -> ()) -> ()",
+            "closure in Bar.PostTask",
+        ],
+        [
+            "closure #1 @Sendable () -> Swift.String in variable initialization expression of static Namespace.Class.var : Namespace.Parent",
+            "closure in initializer expression of Namespace.Class.var",
+        ],
+        [
+            "variable initialization expression of static Namespace.Class.var : Namespace.Parent",
+            "initializer expression of Namespace.Class.var",
+        ],
+        [
+            "closure #1 () -> () in variable initialization expression of static (extension in SpaceCreation):Namespace.Class.var : Namespace.Parent",
+            "closure in initializer expression of Namespace.Class.var",
+        ],
     ],
 )
 def test_trim_native_function_name(input, output):
@@ -142,14 +166,13 @@ def test_trim_csharp_function_name(input, output):
             "partial apply for thunk for @escaping @callee_guaranteed (@guaranteed SomeType, @guaranteed [String : SomeType2], @guaranteed SomeType3) -> ()",
             "thunk for closure",
         ],
-        [  # "closure ... in ..." functions are converted to containing
-            # function. We might want to change this in the future
+        [
             "closure #1 (T1) in foo(bar: T2)",
-            "foo",
+            "closure in foo",
         ],
         [
             "partial apply for closure #1 () in closure #2 (T1) in f1(_: T2, arg: T3)",
-            "f1",
+            "closure in f1",
         ],
     ],
 )


### PR DESCRIPTION
Some Swift for Windows function names were trimmed to incorrect tokens in the UI, resulting in hard-to-read stack traces. For instance, some functions were shown as `"throws"` and closures were shown as `"#1"`.

This change fixes the former issue by using the correct function name. Closures are now displayed as `"closure in <function name>"`, and initialization expressions are displayed as `"initializer expression of <value>"`, improving the user experience when browsing stack traces.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
