### PR TITLE
feat(trace-explorer): Add new traces stats endpoint

### DIFF
--- a/src/sentry/api/endpoints/organization_traces.py
+++ b/src/sentry/api/endpoints/organization_traces.py
@@ -1,13 +1,13 @@
 import math
 from collections import defaultdict
-from collections.abc import Generator, Mapping, MutableMapping
+from collections.abc import Generator, Mapping, MutableMapping, Sequence
 from contextlib import contextmanager
 from datetime import datetime, timedelta
 from typing import Any, Literal, NotRequired, TypedDict, cast
 
 import sentry_sdk
 from rest_framework import serializers
-from rest_framework.exceptions import ParseError
+from rest_framework.exceptions import ParseError, ValidationError
 from rest_framework.request import Request
 from rest_framework.response import Response
 from snuba_sdk import And, BooleanCondition, BooleanOp, Column, Condition, Function, LimitBy, Op, Or
@@ -23,16 +23,21 @@ from sentry.api.paginator import GenericOffsetPaginator
 from sentry.api.utils import handle_query_errors
 from sentry.models.organization import Organization
 from sentry.models.project import Project
-from sentry.search.events.builder import QueryBuilder, SpansIndexedQueryBuilder
+from sentry.search.events.builder import (
+    QueryBuilder,
+    SpansIndexedQueryBuilder,
+    TimeseriesSpanIndexedQueryBuilder,
+)
 from sentry.search.events.constants import TIMEOUT_SPAN_ERROR_MESSAGE
 from sentry.search.events.types import ParamsType, QueryBuilderConfig, SnubaParams, WhereType
 from sentry.sentry_metrics.querying.samples_list import SpanKey, get_sample_list_executor_cls
 from sentry.services.hybrid_cloud.organization import RpcOrganization
+from sentry.snuba import discover, spans_indexed
 from sentry.snuba.dataset import Dataset
 from sentry.snuba.referrer import Referrer
 from sentry.utils.iterators import chunked
 from sentry.utils.numbers import clip
-from sentry.utils.snuba import bulk_snuba_queries
+from sentry.utils.snuba import SnubaTSResult, bulk_snuba_queries
 
 MAX_SNUBA_RESULTS = 10_000
 
@@ -182,6 +187,82 @@ class OrganizationTracesEndpoint(OrganizationTracesEndpointBase):
                 dataset=Dataset.SpansIndexed,
             ),
         )
+
+
+class OrganizationTracesStatsSerializer(serializers.Serializer):
+    query = serializers.ListField(
+        required=False, allow_empty=True, child=serializers.CharField(allow_blank=True)
+    )
+    yAxis = serializers.ListField(required=True, child=serializers.CharField())
+
+
+@region_silo_endpoint
+class OrganizationTracesStatsEndpoint(OrganizationTracesEndpointBase):
+    publish_status = {
+        "GET": ApiPublishStatus.EXPERIMENTAL,
+    }
+    owner = ApiOwner.PERFORMANCE
+
+    def get(self, request: Request, organization: Organization) -> Response:
+        if not features.has(
+            "organizations:performance-trace-explorer", organization, actor=request.user
+        ):
+            return Response(status=404)
+
+        try:
+            snuba_params, params = self.get_snuba_dataclass(request, organization)
+        except NoProjects:
+            return Response(status=404)
+
+        serializer = OrganizationTracesStatsSerializer(data=request.GET)
+        if not serializer.is_valid():
+            return Response(serializer.errors, status=400)
+        serialized = serializer.validated_data
+
+        # The partial parameter determines whether or not partial buckets are allowed.
+        # The last bucket of the time series can potentially be a partial bucket when
+        # the start of the bucket does not align with the rollup.
+        allow_partial_buckets = request.GET.get("partial") == "1"
+
+        zerofill = not (
+            request.GET.get("withoutZerofill") == "1"
+            and features.get(
+                "organizations:performance-chart-interpolation", organization, actor=request.user
+            )
+        )
+
+        def get_event_stats(
+            _columns: Sequence[str],
+            _query: str,
+            _params: dict[str, str],
+            rollup: int,
+            zerofill_results: bool,
+            comparison_delta: timedelta | None,
+        ) -> SnubaTSResult:
+            executor = TraceStatsExecutor(
+                params=cast(ParamsType, params),
+                snuba_params=snuba_params,
+                columns=serialized["yAxis"],
+                user_queries=serialized.get("query", []),
+                rollup=rollup,
+                zerofill_results=zerofill_results,
+            )
+            return executor.execute()
+
+        try:
+            return Response(
+                self.get_event_stats_data(
+                    request,
+                    organization,
+                    get_event_stats,
+                    allow_partial_buckets=allow_partial_buckets,
+                    zerofill_results=zerofill,
+                    dataset=spans_indexed,
+                ),
+                status=200,
+            )
+        except ValidationError:
+            return Response({"detail": "Comparison period is outside retention window"}, status=400)
 
 
 class TraceSamplesExecutor:
@@ -1075,6 +1156,79 @@ class TraceSamplesExecutor:
         )
         suggested_spans_query.add_conditions([Condition(Column("trace_id"), Op.IN, trace_ids)])
         return suggested_spans_query
+
+
+class TraceStatsExecutor:
+    def __init__(
+        self,
+        *,
+        params: ParamsType,
+        snuba_params: SnubaParams,
+        columns: list[str],
+        user_queries: list[str],
+        rollup: int,
+        zerofill_results: bool,
+    ):
+        self.params = params
+        self.snuba_params = snuba_params
+        self.columns = columns
+        # Filter out empty queries as they do not do anything to change the results.
+        self.user_queries = [query.strip() for query in user_queries if query.strip()]
+        self.rollup = rollup
+        self.zerofill_results = zerofill_results
+
+    def execute(self) -> SnubaTSResult:
+        query = self.get_timeseries_query()
+        result = query.run_query(Referrer.API_TRACE_EXPLORER_STATS.value)
+        result = query.process_results(result)
+        result["data"] = (
+            discover.zerofill(
+                result["data"],
+                self.params["start"],
+                self.params["end"],
+                self.rollup,
+                "time",
+            )
+            if self.zerofill_results
+            else result["data"]
+        )
+
+        return SnubaTSResult(
+            {
+                "data": result["data"],
+                "meta": result["meta"],
+            },
+            self.params["start"],
+            self.params["end"],
+            self.rollup,
+        )
+
+    def get_timeseries_query(self) -> QueryBuilder:
+        query = TimeseriesSpanIndexedQueryBuilder(
+            Dataset.SpansIndexed,
+            self.params,
+            self.rollup,
+            query=None,
+            selected_columns=self.columns,
+        )
+
+        trace_conditions = []
+
+        for user_query in self.user_queries:
+            # We want to ignore all the aggregate conditions here because we're strictly
+            # searching on span attributes, not aggregates
+            where, _ = query.resolve_conditions(user_query)
+            if len(where) == 1:
+                trace_conditions.extend(where)
+            elif len(where) > 1:
+                trace_conditions.append(BooleanCondition(op=BooleanOp.AND, conditions=where))
+
+        if len(trace_conditions) == 1:
+            query.where.extend(trace_conditions)
+        elif len(trace_conditions) > 1:
+            query.where.append(BooleanCondition(op=BooleanOp.OR, conditions=trace_conditions))
+
+        return query
 
 
 def convert_to_slice(timestamp, trace_range, left_bound=None) -> int:

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -490,7 +490,10 @@ from .endpoints.organization_stats_v2 import OrganizationStatsEndpointV2
 from .endpoints.organization_tagkey_values import OrganizationTagKeyValuesEndpoint
 from .endpoints.organization_tags import OrganizationTagsEndpoint
 from .endpoints.organization_teams import OrganizationTeamsEndpoint
-from .endpoints.organization_traces import OrganizationTracesEndpoint
+from .endpoints.organization_traces import (
+    OrganizationTracesEndpoint,
+    OrganizationTracesStatsEndpoint,
+)
 from .endpoints.organization_transaction_anomaly_detection import (
     OrganizationTransactionAnomalyDetectionEndpoint,
 )
@@ -1417,6 +1420,11 @@ ORGANIZATION_URLS = [
         r"^(?P<organization_id_or_slug>[^\/]+)/traces/$",
         OrganizationTracesEndpoint.as_view(),
         name="sentry-api-0-organization-traces",
+    ),
+    re_path(
+        r"^(?P<organization_id_or_slug>[^\/]+)/traces-stats/$",
+        OrganizationTracesStatsEndpoint.as_view(),
+        name="sentry-api-0-organization-traces-stats",
     ),
     re_path(
         r"^(?P<organization_id_or_slug>[^\/]+)/spans/fields/$",

--- a/src/sentry/snuba/referrer.py
+++ b/src/sentry/snuba/referrer.py
@@ -440,6 +440,7 @@ class Referrer(Enum):
     API_STARFISH_MOBILE_STARTUP_TOTALS = "api.starfish.mobile-startup-totals"
     API_TRACE_EXPLORER_METRICS_SPANS_LIST = "api.trace-explorer.metrics-spans-list"
     API_TRACE_EXPLORER_SPANS_LIST = "api.trace-explorer.spans-list"
+    API_TRACE_EXPLORER_STATS = "api.trace-explorer.stats"
     API_TRACE_EXPLORER_TRACES_META = "api.trace-explorer.traces-meta"
     API_SPANS_TAG_KEYS = "api.spans.tags-keys"
 

--- a/tests/sentry/api/endpoints/test_organization_traces.py
+++ b/tests/sentry/api/endpoints/test_organization_traces.py
@@ -13,9 +13,7 @@ from sentry.testutils.helpers.datetime import before_now
 from sentry.utils.samples import load_data
 
 
-class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
-    view = "sentry-api-0-organization-traces"
-
+class OrganizationTracesEndpointTestBase(BaseSpansTestCase, APITestCase):
     def setUp(self):
         super().setUp()
         self.login_as(user=self.user)
@@ -71,6 +69,10 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
             duration=duration,
             **kwargs,
         )
+
+
+class OrganizationTracesEndpointTest(OrganizationTracesEndpointTestBase):
+    view = "sentry-api-0-organization-traces"
 
     def create_mock_traces(self):
         project_1 = self.create_project()
@@ -1053,6 +1055,98 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
             trace_id_1: {span_ids[2], span_ids[3]},
             trace_id_2: {span_ids[5], span_ids[6]},
         }
+
+
+class OrganizationTracesStatsEndpointTest(OrganizationTracesEndpointTestBase):
+    view = "sentry-api-0-organization-traces-stats"
+
+    def test_no_feature(self):
+        query = {
+            "yAxis": ["count()"],
+        }
+
+        response = self.do_request(query, features=[])
+        assert response.status_code == 404, response.data
+
+    def test_no_project(self):
+        query = {
+            "yAxis": ["count()"],
+        }
+
+        response = self.do_request(query)
+        assert response.status_code == 404, response.data
+
+    def test_bad_params_missing_y_axis(self):
+        response = self.do_request(
+            {
+                "project": [self.project.id],
+            }
+        )
+        assert response.status_code == 400, response.data
+        assert response.data == {
+            "yAxis": [
+                ErrorDetail(string="This field is required.", code="required"),
+            ],
+        }
+
+    def test_stats(self):
+        project_1 = self.create_project()
+        project_2 = self.create_project()
+
+        timestamp = before_now()
+        timestamp = timestamp.replace(hour=0, minute=0, second=0, microsecond=0)
+        timestamp = timestamp - timedelta(minutes=10)
+
+        self.double_write_segment(
+            project_id=project_1.id,
+            trace_id=uuid4().hex,
+            transaction_id=uuid4().hex,
+            span_id="1" + uuid4().hex[:15],
+            timestamp=timestamp,
+            transaction="foo",
+            duration=100,
+            exclusive_time=100,
+        )
+
+        self.double_write_segment(
+            project_id=project_1.id,
+            trace_id=uuid4().hex,
+            transaction_id=uuid4().hex,
+            span_id="1" + uuid4().hex[:15],
+            timestamp=timestamp,
+            transaction="bar",
+            duration=100,
+            exclusive_time=100,
+        )
+
+        self.double_write_segment(
+            project_id=project_2.id,
+            trace_id=uuid4().hex,
+            transaction_id=uuid4().hex,
+            span_id="1" + uuid4().hex[:15],
+            timestamp=timestamp,
+            transaction="bar",
+            duration=100,
+            exclusive_time=100,
+        )
+
+        for q in [
+            [f"project:{project_1.slug}"],
+            [
+                f"project:{project_1.slug} transaction:bar",
+                f"project:{project_2.slug} transaction:bar",
+            ],
+        ]:
+            query = {
+                "yAxis": ["count()"],
+                "query": q,
+                "project": [project_1.id],
+            }
+
+            response = self.do_request(query)
+            assert response.status_code == 200, response.data
+
+        assert sum(bucket[0]["count"] for _, bucket in response.data["data"]) == 2
 
 
 @pytest.mark.parametrize(

--- a/tests/sentry/api/endpoints/test_organization_traces.py
+++ b/tests/sentry/api/endpoints/test_organization_traces.py
@@ -14,6 +14,8 @@ from sentry.utils.samples import load_data
 
 
 class OrganizationTracesEndpointTestBase(BaseSpansTestCase, APITestCase):
+    view: str
+
     def setUp(self):
         super().setUp()
         self.login_as(user=self.user)


### PR DESCRIPTION
This adds a new /traces-stats/ endpoint to load the number of matching spans given the n span conditions.