### PR TITLE
fix(insights): Add keys to parsed tokens on queries page

### DIFF
--- a/static/app/views/starfish/components/tableCells/spanDescriptionCell.tsx
+++ b/static/app/views/starfish/components/tableCells/spanDescriptionCell.tsx
@@ -1,4 +1,4 @@
-import {cloneElement, Fragment, useMemo} from 'react';
+import {Fragment, useMemo} from 'react';
 import styled from '@emotion/styled';
 
 import {Hovercard} from 'sentry/components/hovercard';
@@ -33,12 +33,7 @@ export function SpanDescriptionCell({
       return rawDescription;
     }
 
-    return (
-      formatter
-        .toSimpleMarkup(rawDescription)
-        // Since the order of the tokens will never change, it's safe to assign the index as the key
-        .map((e, i) => cloneElement(e, {key: i}))
-    );
+    return formatter.toSimpleMarkup(rawDescription);
   }, [moduleName, rawDescription]);
 
   if (!rawDescription) {

--- a/static/app/views/starfish/components/tableCells/spanDescriptionCell.tsx
+++ b/static/app/views/starfish/components/tableCells/spanDescriptionCell.tsx
@@ -1,4 +1,4 @@
-import {Fragment, useMemo} from 'react';
+import {cloneElement, Fragment, useMemo} from 'react';
 import styled from '@emotion/styled';
 
 import {Hovercard} from 'sentry/components/hovercard';
@@ -33,7 +33,12 @@ export function SpanDescriptionCell({
       return rawDescription;
     }
 
-    return formatter.toSimpleMarkup(rawDescription);
+    return (
+      formatter
+        .toSimpleMarkup(rawDescription)
+        // Since the order of the tokens will never change, it's safe to assign the index as the key
+        .map((e, i) => cloneElement(e, {key: i}))
+    );
   }, [moduleName, rawDescription]);
 
   if (!rawDescription) {

--- a/static/app/views/starfish/utils/sqlish/formatters/simpleMarkup.tsx
+++ b/static/app/views/starfish/utils/sqlish/formatters/simpleMarkup.tsx
@@ -3,7 +3,7 @@ import type {Token} from 'sentry/views/starfish/utils/sqlish/types';
 export function simpleMarkup(tokens: Token[]): React.ReactElement[] {
   const accumulator: React.ReactElement[] = [];
 
-  function contentize(token: Token): void {
+  function contentize(token: Token, index: number): void {
     if (Array.isArray(token.content)) {
       token.content.forEach(contentize);
       return;
@@ -11,11 +11,11 @@ export function simpleMarkup(tokens: Token[]): React.ReactElement[] {
 
     if (typeof token.content === 'string') {
       if (token.type === 'Keyword') {
-        accumulator.push(<b>{token.content.toUpperCase()}</b>);
+        accumulator.push(<b key={index}>{token.content.toUpperCase()}</b>);
       } else if (token.type === 'Whitespace') {
-        accumulator.push(<span> </span>);
+        accumulator.push(<span key={index}> </span>);
       } else {
-        accumulator.push(<span>{token.content}</span>);
+        accumulator.push(<span key={index}>{token.content}</span>);
       }
     }
 


### PR DESCRIPTION
Fixes the unique prop key warning that is always present when viewing the Queries page. This was occuring because the SQL parser was outputting the tokens as a list HTML elements without keys.

![image](https://github.com/getsentry/sentry/assets/16740047/7ebbee90-5800-40f1-b37d-fc198ca00154)
