### PR TITLE
feat(query-builder): Numeric filter improvements

### DIFF
--- a/static/app/components/searchQueryBuilder/index.spec.tsx
+++ b/static/app/components/searchQueryBuilder/index.spec.tsx
@@ -22,7 +22,7 @@ const FITLER_KEY_SECTIONS: FilterKeySection[] = [
     value: FieldKind.FIELD,
     label: 'Category 1',
     children: [
-      {key: FieldKey.AGE, name: 'Age', kind: FieldKind.FIELD, predefined: true},
+      {key: FieldKey.AGE, name: 'Age', kind: FieldKind.FIELD},
       {
         key: FieldKey.ASSIGNED,
         name: 'Assigned To',
@@ -55,6 +55,11 @@ const FITLER_KEY_SECTIONS: FilterKeySection[] = [
         name: 'is',
         alias: 'status',
         predefined: true,
+      },
+      {
+        key: FieldKey.TIMES_SEEN,
+        name: 'timesSeen',
+        kind: FieldKind.FIELD,
       },
     ],
   },
@@ -313,12 +318,12 @@ describe('SearchQueryBuilder', function () {
       await userEvent.click(screen.getByRole('combobox', {name: 'Edit filter value'}));
 
       // Clicking the "+14d" option should update the value
-      await userEvent.click(screen.getByRole('option', {name: '+14d'}));
-      expect(screen.getByRole('row', {name: 'age:+14d'})).toBeInTheDocument();
+      await userEvent.click(screen.getByRole('option', {name: '-14d'}));
+      expect(screen.getByRole('row', {name: 'age:-14d'})).toBeInTheDocument();
       expect(
         within(
           screen.getByRole('button', {name: 'Edit value for filter: age'})
-        ).getByText('+14d')
+        ).getByText('-14d')
       ).toBeInTheDocument();
     });
 
@@ -715,6 +720,51 @@ describe('SearchQueryBuilder', function () {
       expect(
         within(groups[2]).getByRole('option', {name: 'person2@sentry.io'})
       ).toBeInTheDocument();
+    });
+  });
+
+  describe('filter types', function () {
+    describe('numeric', function () {
+      it('new numeric filters start with a value', async function () {
+        render(<SearchQueryBuilder {...defaultProps} />);
+        await userEvent.click(screen.getByRole('grid'));
+        await userEvent.keyboard('time{ArrowDown}{Enter}');
+
+        // Should start with the > operator and a value of 100
+        expect(
+          await screen.findByRole('row', {name: 'timesSeen:>100'})
+        ).toBeInTheDocument();
+      });
+
+      it('does not allow invalid values', async function () {
+        render(<SearchQueryBuilder {...defaultProps} initialQuery="timesSeen:>100" />);
+        await userEvent.click(
+          screen.getByRole('button', {name: 'Edit value for filter: timesSeen'})
+        );
+        await userEvent.keyboard('a{Enter}');
+
+        // Should have the same value because "a" is not a numeric value
+        expect(screen.getByRole('row', {name: 'timesSeen:>100'})).toBeInTheDocument();
+
+        await userEvent.keyboard('{Backspace}7k{Enter}');
+
+        // Should accept "7k" as a valid value
+        expect(
+          await screen.findByRole('row', {name: 'timesSeen:>7k'})
+        ).toBeInTheDocument();
+      });
+
+      it('can change the operator', async function () {
+        render(<SearchQueryBuilder {...defaultProps} initialQuery="timesSeen:>100k" />);
+        await userEvent.click(
+          screen.getByRole('button', {name: 'Edit operator for filter: timesSeen'})
+        );
+        await userEvent.click(screen.getByRole('menuitemradio', {name: '<='}));
+
+        expect(
+          await screen.findByRole('row', {name: 'timesSeen:<=100k'})
+        ).toBeInTheDocument();
+      });
     });
   });
 });

--- a/static/app/components/searchQueryBuilder/index.stories.tsx
+++ b/static/app/components/searchQueryBuilder/index.stories.tsx
@@ -13,7 +13,7 @@ const FITLER_KEY_SECTIONS: FilterKeySection[] = [
     value: FieldKind.FIELD,
     label: 'Category 1',
     children: [
-      {key: FieldKey.AGE, name: 'Age', kind: FieldKind.FIELD, predefined: true},
+      {key: FieldKey.AGE, name: 'Age', kind: FieldKind.FIELD},
       {
         key: FieldKey.ASSIGNED,
         name: 'Assigned To',

--- a/static/app/components/searchQueryBuilder/index.tsx
+++ b/static/app/components/searchQueryBuilder/index.tsx
@@ -72,7 +72,20 @@ export function SearchQueryBuilder({
 }: SearchQueryBuilderProps) {
   const {state, dispatch} = useQueryBuilderState({initialQuery});
 
-  const parsedQuery = useMemo(() => parseQueryBuilderValue(state.query), [state.query]);
+  const keys = useMemo(
+    () =>
+      filterKeySections.reduce((acc, section) => {
+        for (const tag of section.children) {
+          acc[tag.key] = tag;
+        }
+        return acc;
+      }, {}),
+    [filterKeySections]
+  );
+  const parsedQuery = useMemo(
+    () => parseQueryBuilderValue(state.query, {keys}),
+    [keys, state.query]
+  );
 
   useEffectAfterFirstRender(() => {
     dispatch({type: 'UPDATE_QUERY', query: initialQuery});
@@ -83,23 +96,16 @@ export function SearchQueryBuilder({
   }, [onChange, state.query]);
 
   const contextValue = useMemo(() => {
-    const allKeys = filterKeySections.reduce((acc, section) => {
-      for (const tag of section.children) {
-        acc[tag.key] = tag;
-      }
-      return acc;
-    }, {});
-
     return {
       ...state,
       parsedQuery,
       filterKeySections,
-      keys: allKeys,
+      keys,
       getTagValues,
       dispatch,
       onSearch,
     };
-  }, [state, parsedQuery, filterKeySections, getTagValues, dispatch, onSearch]);
+  }, [state, parsedQuery, filterKeySections, keys, getTagValues, dispatch, onSearch]);
 
   return (
     <SearchQueryBuilerContext.Provider value={contextValue}>

--- a/static/app/components/searchQueryBuilder/utils.tsx
+++ b/static/app/components/searchQueryBuilder/utils.tsx
@@ -9,17 +9,63 @@ import {
   type ParseResult,
   type ParseResultToken,
   parseSearch,
+  type SearchConfig,
   type TermOperator,
   Token,
   type TokenResult,
 } from 'sentry/components/searchSyntax/parser';
-import type {Tag} from 'sentry/types';
+import type {Tag, TagCollection} from 'sentry/types';
 import {escapeDoubleQuotes} from 'sentry/utils';
+import {FieldValueType, getFieldDefinition} from 'sentry/utils/fields';
 
 export const INTERFACE_TYPE_LOCALSTORAGE_KEY = 'search-query-builder-interface';
 
-export function parseQueryBuilderValue(value: string): ParseResult | null {
-  return collapseTextTokens(parseSearch(value || ' ', {flattenParenGroups: true}));
+function getSearchConfigFromKeys(keys: TagCollection): Partial<SearchConfig> {
+  const config = {
+    booleanKeys: new Set<string>(),
+    numericKeys: new Set<string>(),
+    dateKeys: new Set<string>(),
+    durationKeys: new Set<string>(),
+  } satisfies Partial<SearchConfig>;
+
+  for (const key in keys) {
+    const fieldDef = getFieldDefinition(key);
+    if (!fieldDef) {
+      continue;
+    }
+
+    switch (fieldDef.valueType) {
+      case FieldValueType.BOOLEAN:
+        config.booleanKeys.add(key);
+        break;
+      case FieldValueType.NUMBER:
+      case FieldValueType.INTEGER:
+        config.numericKeys.add(key);
+        break;
+      case FieldValueType.DATE:
+        config.dateKeys.add(key);
+        break;
+      case FieldValueType.DURATION:
+        config.durationKeys.add(key);
+        break;
+      default:
+        break;
+    }
+  }
+
+  return config;
+}
+
+export function parseQueryBuilderValue(
+  value: string,
+  options?: {keys: TagCollection}
+): ParseResult | null {
+  return collapseTextTokens(
+    parseSearch(value || ' ', {
+      flattenParenGroups: true,
+      ...getSearchConfigFromKeys(options?.keys ?? {}),
+    })
+  );
 }
 
 /**

--- a/static/app/components/searchSyntax/utils.tsx
+++ b/static/app/components/searchSyntax/utils.tsx
@@ -275,7 +275,7 @@ export function stringifyToken(token: TokenResult<Token>) {
       return `[${textListItems.join(',')}]`;
     case Token.VALUE_NUMBER_LIST:
       const numberListItems = token.items
-        .map(item => (item.value ? item.value.value + item.value.unit : ''))
+        .map(item => (item.value ? item.value.value + (item.value.unit ?? '') : ''))
         .filter(str => str.length > 0);
       return `[${numberListItems.join(',')}]`;
     case Token.KEY_SIMPLE:
@@ -297,7 +297,7 @@ export function stringifyToken(token: TokenResult<Token>) {
     case Token.VALUE_RELATIVE_DATE:
     case Token.VALUE_SIZE:
     case Token.VALUE_NUMBER:
-      return token.value;
+      return token.text;
     default:
       return '';
   }

--- a/static/app/utils/fields/index.ts
+++ b/static/app/utils/fields/index.ts
@@ -520,7 +520,7 @@ const EVENT_FIELD_DEFINITIONS: Record<AllEventFieldKeys, FieldDefinition> = {
   [FieldKey.AGE]: {
     desc: t('The age of the issue in relative time'),
     kind: FieldKind.FIELD,
-    valueType: FieldValueType.DURATION,
+    valueType: FieldValueType.DATE,
   },
   [FieldKey.ASSIGNED]: {
     desc: t('Assignee of the issue as a user ID'),


### PR DESCRIPTION
- Adds suggestions for numeric filters (based on the number you type in)
- Allows changing the operator to other things like `<` and `>` instead of just `is`
- When creating a numeric filter, prefills a value (I chose an arbitrary `100`) and doesn't allow you to change it to an invalid one. This was necessary because the parser will not see `timesSeen:` or `timesSeen:abc` as a numeric filter because it does not have a valid value. That resulted in some unwanted behavior. We can change the grammar in the future, but this was a good solution for now.  

Before:

![CleanShot 2024-06-07 at 10 13 39](https://github.com/getsentry/sentry/assets/10888943/36f283d9-a3d4-4d15-9dad-55035ee52fd3)

After:

![CleanShot 2024-06-07 at 10 13 54](https://github.com/getsentry/sentry/assets/10888943/ce0776c3-6bea-48e3-9347-1df0bbcdb1e8)

![CleanShot 2024-06-07 at 13 13 30](https://github.com/getsentry/sentry/assets/10888943/2a51b543-efd3-4bb2-8846-828dd7a31140)
