### PR TITLE
fix(hybridcloud) Don't use RPC to generate redis keys

### DIFF
--- a/src/sentry/models/integrations/utils.py
+++ b/src/sentry/models/integrations/utils.py
@@ -50,12 +50,4 @@ def is_response_error(resp) -> bool:
 
 
 def get_redis_key(sentryapp: SentryApp | RpcSentryApp, org_id):
-    from sentry.services.hybrid_cloud.app.service import app_service
-
-    installation = app_service.get_installation(
-        sentry_app_id=sentryapp.id,
-        organization_id=org_id,
-    )
-    if installation:
-        return f"sentry-app-error:{installation.uuid}"
-    return ""
+    return f"sentry-app-error:{sentryapp.id}:{org_id}"


### PR DESCRIPTION
We're currently using an RPC call to fetch an organization's sentryapp install so that we can create a backwards compatible redis key for request tracking.

By rotating the key we'll lose data continunity for the last 8 days and any sentryapp failures will take longer to detect. The infrequently used sentryapp owner dashboards will also be missing data until buffers under the new keys is populated.

I think this is a reasonable tradeoff to save thousands of RPC calls per minute reducing chances for failed requests.

Refs HC-1193