### PR TITLE
fix(query-builder): Fix issue with aliased token not showing up in search or when typing

### DIFF
--- a/static/app/components/searchQueryBuilder/index.spec.tsx
+++ b/static/app/components/searchQueryBuilder/index.spec.tsx
@@ -53,7 +53,7 @@ const FITLER_KEY_SECTIONS: FilterKeySection[] = [
       {
         key: FieldKey.IS,
         name: 'is',
-        alias: 'status',
+        alias: 'issue.status',
         predefined: true,
       },
     ],
@@ -124,7 +124,18 @@ describe('SearchQueryBuilder', function () {
     it('displays the key alias instead of the actual value', async function () {
       render(<SearchQueryBuilder {...defaultProps} initialQuery="is:resolved" />);
 
-      expect(await screen.findByText('status')).toBeInTheDocument();
+      expect(await screen.findByText('issue.status')).toBeInTheDocument();
+    });
+
+    it('displays the key alias when searching for keys', async function () {
+      render(<SearchQueryBuilder {...defaultProps} initialQuery="" />);
+
+      await userEvent.click(screen.getByRole('grid'));
+      await userEvent.keyboard('issue');
+
+      expect(
+        await screen.findByRole('option', {name: 'issue.status'})
+      ).toBeInTheDocument();
     });
 
     it('when adding a filter by typing, replaces aliased tokens', async function () {
@@ -134,10 +145,10 @@ describe('SearchQueryBuilder', function () {
       );
 
       await userEvent.click(screen.getByRole('grid'));
-      await userEvent.keyboard('status:');
+      await userEvent.keyboard('issue.status:');
 
-      // Component should display alias `status`
-      expect(await screen.findByText('status')).toBeInTheDocument();
+      // Component should display alias `issue.status`
+      expect(await screen.findByText('issue.status')).toBeInTheDocument();
       // Query should use the actual key `is`
       expect(mockOnChange).toHaveBeenCalledWith('is:');
     });

--- a/static/app/components/searchQueryBuilder/input.tsx
+++ b/static/app/components/searchQueryBuilder/input.tsx
@@ -88,7 +88,7 @@ function replaceFocusedWordWithFilter(
  * replaceAliasedFilterKeys('foo issue: bar', {'status': 'is'}) => 'foo is: bar'
  */
 function replaceAliasedFilterKeys(value: string, aliasToKeyMap: Record<string, string>) {
-  const key = value.match(/(\w+):/);
+  const key = value.match(/(\S+):/);
   const matchedKey = key?.[1];
   if (matchedKey && aliasToKeyMap[matchedKey]) {
     const actualKey = aliasToKeyMap[matchedKey];
@@ -110,7 +110,7 @@ function getItemsBySection(filterKeySections: FilterKeySection[]) {
 
         return {
           key: getEscapedKey(tag.key),
-          label: tag.key,
+          label: tag.alias ?? tag.key,
           value: tag.key,
           textValue: tag.key,
           hideCheck: true,


### PR DESCRIPTION
- When searching for keys, prefers the `alias` (used to do this but regressed, added a test for this)
- When typing out the alias, fixed a bug where it wouldn't work if the alias had a `.` character (now we just look for any non-whitespace character)