### PR TITLE
ref(slack): add integration auto-disable logic to SDK client

### DIFF
--- a/src/sentry/integrations/base.py
+++ b/src/sentry/integrations/base.py
@@ -470,13 +470,13 @@ class IntegrationInstallation:
         pass
 
 
-def is_response_success(resp) -> bool:
+def is_response_success(resp: Any) -> bool:
     if resp.status_code and resp.status_code < 300:
         return True
     return False
 
 
-def is_response_error(resp) -> bool:
+def is_response_error(resp: Any) -> bool:
     if not resp.status_code:
         return False
     return resp.status_code >= 400 and resp.status_code != 429 and resp.status_code < 500

--- a/src/sentry/integrations/slack/sdk_client.py
+++ b/src/sentry/integrations/slack/sdk_client.py
@@ -71,6 +71,7 @@ def wrapper(method: FunctionType, integration_id):
         try:
             response = method(*args, **kwargs)
             track_response_data(response=response, method=method.__name__)
+            record_response_for_disabling_integration(response, integration_id)
         except SlackApiError as e:
             if e.response:
                 track_response_data(response=e.response, error=str(e), method=method.__name__)

--- a/src/sentry/models/integrations/utils.py
+++ b/src/sentry/models/integrations/utils.py
@@ -35,19 +35,5 @@ def has_feature(instance: Integration | RpcIntegration, feature: IntegrationFeat
     return feature in instance.get_provider().features
 
 
-def is_response_success(resp) -> bool:
-    if resp.status_code:
-        if resp.status_code < 300:
-            return True
-    return False
-
-
-def is_response_error(resp) -> bool:
-    if resp.status_code:
-        if resp.status_code >= 400 and resp.status_code != 429 and resp.status_code < 500:
-            return True
-    return False
-
-
 def get_redis_key(sentryapp: SentryApp | RpcSentryApp, org_id):
     return f"sentry-app-error:{sentryapp.id}:{org_id}"

--- a/src/sentry/shared_integrations/client/base.py
+++ b/src/sentry/shared_integrations/client/base.py
@@ -395,7 +395,7 @@ class BaseApiClient(TrackResponseMixin):
             if is_response_error(response):
                 buffer.record_error()
         if buffer.is_integration_broken():
-            disable_integration(buffer)
+            disable_integration(buffer, redis_key, self.integration_id)
 
     def record_error(self, error: Exception):
         redis_key = self._get_redis_key()
@@ -407,4 +407,4 @@ class BaseApiClient(TrackResponseMixin):
         else:
             buffer.record_error()
         if buffer.is_integration_broken():
-            disable_integration(buffer)
+            disable_integration(buffer, redis_key, self.integration_id)

--- a/src/sentry/shared_integrations/client/base.py
+++ b/src/sentry/shared_integrations/client/base.py
@@ -9,18 +9,12 @@ from requests import PreparedRequest, Request, Response
 from requests.adapters import RetryError
 from requests.exceptions import ConnectionError, HTTPError, Timeout
 
-from sentry import audit_log, features
-from sentry.constants import ObjectStatus
 from sentry.exceptions import RestrictedIPAddress
 from sentry.http import build_session
-from sentry.integrations.notify_disable import notify_disable
+from sentry.integrations.base import disable_integration, is_response_error, is_response_success
 from sentry.integrations.request_buffer import IntegrationRequestBuffer
-from sentry.models.integrations.utils import is_response_error, is_response_success
 from sentry.net.http import SafeSession
-from sentry.services.hybrid_cloud.integration import integration_service
-from sentry.services.hybrid_cloud.organization import organization_service
 from sentry.utils import json, metrics
-from sentry.utils.audit import create_system_audit_entry
 from sentry.utils.hashlib import md5_text
 
 from ..exceptions import (
@@ -401,7 +395,7 @@ class BaseApiClient(TrackResponseMixin):
             if is_response_error(response):
                 buffer.record_error()
         if buffer.is_integration_broken():
-            self.disable_integration(buffer)
+            disable_integration(buffer)
 
     def record_error(self, error: Exception):
         redis_key = self._get_redis_key()
@@ -413,64 +407,4 @@ class BaseApiClient(TrackResponseMixin):
         else:
             buffer.record_error()
         if buffer.is_integration_broken():
-            self.disable_integration(buffer)
-
-    def disable_integration(self, buffer: IntegrationRequestBuffer) -> None:
-        result = integration_service.organization_contexts(integration_id=self.integration_id)
-        rpc_integration = result.integration
-        rpc_org_integrations = result.organization_integrations
-        if rpc_integration and rpc_integration.status == ObjectStatus.DISABLED:
-            return
-
-        org = None
-        if len(rpc_org_integrations) > 0:
-            org_context = organization_service.get_organization_by_id(
-                id=rpc_org_integrations[0].organization_id,
-                include_projects=False,
-                include_teams=False,
-            )
-            if org_context:
-                org = org_context.organization
-
-        extra = {
-            "integration_id": self.integration_id,
-            "buffer_record": buffer._get_all_from_buffer(),
-        }
-        if len(rpc_org_integrations) == 0 and rpc_integration is None:
-            extra["provider"] = "unknown"
-            extra["organization_id"] = "unknown"
-        elif len(rpc_org_integrations) == 0:
-            extra["provider"] = rpc_integration.provider
-            extra["organization_id"] = "unknown"
-        elif rpc_integration is None:
-            extra["provider"] = "unknown"
-            extra["organization_id"] = rpc_org_integrations[0].organization_id
-        else:
-            extra["provider"] = rpc_integration.provider
-            extra["organization_id"] = rpc_org_integrations[0].organization_id
-
-        self.logger.info(
-            "integration.disabled",
-            extra=extra,
-        )
-
-        if org and (
-            (rpc_integration.provider == "slack" and buffer.is_integration_fatal_broken())
-            or (rpc_integration.provider == "github")
-            or (
-                features.has("organizations:gitlab-disable-on-broken", org)
-                and rpc_integration.provider == "gitlab"
-            )
-        ):
-            integration_service.update_integration(
-                integration_id=rpc_integration.id, status=ObjectStatus.DISABLED
-            )
-            notify_disable(org, rpc_integration.provider, self._get_redis_key())
-            buffer.clear()
-            create_system_audit_entry(
-                organization_id=org.id,
-                target_object=org.id,
-                event=audit_log.get_event_id("INTEGRATION_DISABLED"),
-                data={"provider": rpc_integration.provider},
-            )
-        return
+            disable_integration(buffer)

--- a/src/sentry/utils/sentry_apps/webhooks.py
+++ b/src/sentry/utils/sentry_apps/webhooks.py
@@ -10,10 +10,11 @@ from rest_framework import status
 
 from sentry import audit_log, options
 from sentry.http import safe_urlopen
+from sentry.integrations.base import is_response_error, is_response_success
 from sentry.integrations.notify_disable import notify_disable
 from sentry.integrations.request_buffer import IntegrationRequestBuffer
 from sentry.models.integrations.sentry_app import SentryApp, track_response_code
-from sentry.models.integrations.utils import get_redis_key, is_response_error, is_response_success
+from sentry.models.integrations.utils import get_redis_key
 from sentry.models.organization import Organization
 from sentry.shared_integrations.exceptions import ApiHostError, ApiTimeoutError, ClientError
 from sentry.utils.audit import create_system_audit_entry

--- a/tests/sentry/integrations/slack/test_disable.py
+++ b/tests/sentry/integrations/slack/test_disable.py
@@ -1,16 +1,19 @@
 import time
 from datetime import datetime, timedelta
+from unittest.mock import patch
 
 import orjson
 import pytest
 import responses
 from django.core import mail
+from slack_sdk.errors import SlackApiError
 
 from sentry import audit_log
 from sentry.constants import ObjectStatus
 from sentry.integrations.notify_disable import notify_disable
 from sentry.integrations.request_buffer import IntegrationRequestBuffer
 from sentry.integrations.slack.client import SlackClient
+from sentry.integrations.slack.sdk_client import SlackSdkClient
 from sentry.models.auditlogentry import AuditLogEntry
 from sentry.models.integrations.integration import Integration
 from sentry.shared_integrations.exceptions import ApiError
@@ -66,6 +69,29 @@ class SlackClientDisable(TestCase):
         with outbox_runner(), self.tasks(), pytest.raises(ApiError):
             client.post("/chat.postMessage", data=self.payload)
         buffer = IntegrationRequestBuffer(client._get_redis_key())
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            integration = Integration.objects.get(id=self.integration.id)
+            assert integration.status == ObjectStatus.DISABLED
+            assert [len(item) == 0 for item in buffer._get_broken_range_from_buffer()]
+            assert len(buffer._get_all_from_buffer()) == 0
+            assert AuditLogEntry.objects.filter(
+                event=audit_log.get_event_id("INTEGRATION_DISABLED"),
+                organization_id=self.organization.id,
+            ).exists()
+
+    @patch("slack_sdk.web.client.WebClient._perform_urllib_http_request")
+    def test_fatal_and_disable_integration_sdk(self, mock_api_call):
+        mock_api_call.return_value = {
+            "body": orjson.dumps({"ok": False, "error": "account_inactive"}).decode(),
+            "headers": {},
+            "status": 200,
+        }
+
+        client = SlackSdkClient(integration_id=self.integration.id)
+
+        with outbox_runner(), self.tasks(), pytest.raises(SlackApiError):
+            client.chat_postMessage(channel=self.payload["channel"], text=self.payload["message"])
+        buffer = IntegrationRequestBuffer(f"sentry-integration-error:{self.integration.id}")
         with assume_test_silo_mode(SiloMode.CONTROL):
             integration = Integration.objects.get(id=self.integration.id)
             assert integration.status == ObjectStatus.DISABLED


### PR DESCRIPTION
All integrations currently have integration auto-disable logic and we should have this for the new Slack client too. This is a bit trickier since we are building on top of the existing WebClient.

We can wrap the all functions inside the metaclass's `__call__` method to make sure we have the integration_id, and then use it to in the auto-disable logic.