### PR TITLE
ref: fix typing for get_num_sessions_per_project

### DIFF
--- a/src/sentry/api/serializers/models/group.py
+++ b/src/sentry/api/serializers/models/group.py
@@ -905,8 +905,8 @@ class GroupSerializerSnuba(GroupSerializerBase):
     def __init__(
         self,
         environment_ids=None,
-        start=None,
-        end=None,
+        start: datetime | None = None,
+        end: datetime | None = None,
         search_filters=None,
         collapse=None,
         expand=None,

--- a/src/sentry/release_health/base.py
+++ b/src/sentry/release_health/base.py
@@ -472,8 +472,8 @@ class ReleaseHealthBackend(Service):
     def get_num_sessions_per_project(
         self,
         project_ids: Sequence[ProjectId],
-        start: datetime,
-        end: datetime,
+        start: datetime | None,
+        end: datetime | None,
         environment_ids: Sequence[int] | None = None,
         rollup: int | None = None,  # rollup in seconds
     ) -> Sequence[ProjectWithCount]:

--- a/src/sentry/release_health/metrics.py
+++ b/src/sentry/release_health/metrics.py
@@ -1572,8 +1572,8 @@ class MetricsReleaseHealthBackend(ReleaseHealthBackend):
     def get_num_sessions_per_project(
         self,
         project_ids: Sequence[ProjectId],
-        start: datetime,
-        end: datetime,
+        start: datetime | None,
+        end: datetime | None,
         environment_ids: Sequence[int] | None = None,
         rollup: int | None = None,  # rollup in seconds
     ) -> Sequence[ProjectWithCount]:


### PR DESCRIPTION
the underlying types allow datetime | None and the callers pass that type as well

this fixes an error in an ignored file when LazyServiceWrapper becomes type checked

<!-- Describe your PR here. -->