### PR TITLE
ref: fix typing of endpoints.project_event_details

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -173,7 +173,6 @@ module = [
     "sentry.api.endpoints.organization_stats",
     "sentry.api.endpoints.organization_teams",
     "sentry.api.endpoints.project_artifact_bundle_file_details",
-    "sentry.api.endpoints.project_event_details",
     "sentry.api.endpoints.project_group_index",
     "sentry.api.endpoints.project_index",
     "sentry.api.endpoints.project_ownership",

--- a/src/sentry/api/endpoints/project_event_details.py
+++ b/src/sentry/api/endpoints/project_event_details.py
@@ -74,8 +74,8 @@ class ProjectEventDetailsEndpoint(ProjectEndpoint):
         :auth: required
         """
 
-        group_id = request.GET.get("group_id")
-        group_id = int(group_id) if group_id else None
+        group_id_s = request.GET.get("group_id")
+        group_id = int(group_id_s) if group_id_s else None
 
         event = eventstore.backend.get_event_by_id(project.id, event_id, group_id=group_id)
 
@@ -89,7 +89,7 @@ class ProjectEventDetailsEndpoint(ProjectEndpoint):
             event = event.for_group(event.group)
 
         data = wrap_event_response(
-            request.user, event, environments, include_full_release_data=True
+            request.user, event, list(environments), include_full_release_data=True
         )
         return Response(data)
 

--- a/src/sentry/eventstore/base.py
+++ b/src/sentry/eventstore/base.py
@@ -245,7 +245,7 @@ class EventStorage(Service):
         """
         raise NotImplementedError
 
-    def get_adjacent_event_ids(self, event, snuba_filter):
+    def get_adjacent_event_ids(self, event, filter):
         """
         Gets the previous and next event IDs given a current event and some conditions/filters.
         Returns a tuple of (project_id, event_id) for (prev_ids, next_ids)


### PR DESCRIPTION
fixes the typing of this module as well as a new error which appears once LazyServiceWrapper becomes type checked

<!-- Describe your PR here. -->