### PR TITLE
feat(perf): Improve Spans Tab / Summary experience for ungrouped spans

### DIFF
--- a/static/app/views/performance/transactionSummary/transactionSpans/spanMetricsTable.spec.tsx
+++ b/static/app/views/performance/transactionSummary/transactionSpans/spanMetricsTable.spec.tsx
@@ -15,8 +15,7 @@ const initializeData = () => {
 
 describe('SuspectSpansTable', () => {
   it('should render the table and rows of data', async () => {
-    const initialData = initializeData();
-    const {organization, project} = initialData;
+    const {organization, project} = initializeData();
 
     const mockRequest = MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/events/`,
@@ -24,9 +23,9 @@ describe('SuspectSpansTable', () => {
       body: {
         data: [
           {
-            'span.group': '',
-            'span.op': 'navigation',
-            'span.description': '',
+            'span.group': 'abc123',
+            'span.op': 'db',
+            'span.description': 'SELECT thing FROM my_cool_db',
             'spm()': 4.448963396488444,
             'sum(span.self_time)': 1236071121.5044901,
             'avg(span.duration)': 30900.700924083318,
@@ -44,20 +43,26 @@ describe('SuspectSpansTable', () => {
     expect(mockRequest).toHaveBeenCalled();
 
     const tableHeaders = await screen.findAllByTestId('grid-head-cell');
-    const [opHeader, nameHeader, throughputHeader, avgDurationHeader, timeSpentHeader] =
-      tableHeaders;
+    const [
+      opHeader,
+      descriptionHeader,
+      throughputHeader,
+      avgDurationHeader,
+      timeSpentHeader,
+    ] = tableHeaders;
 
     expect(opHeader).toHaveTextContent('Span Operation');
-    expect(nameHeader).toHaveTextContent('Span Name');
+    expect(descriptionHeader).toHaveTextContent('Span Description');
     expect(throughputHeader).toHaveTextContent('Throughput');
     expect(avgDurationHeader).toHaveTextContent('Avg Duration');
     expect(timeSpentHeader).toHaveTextContent('Time Spent');
 
     const bodyCells = await screen.findAllByTestId('grid-body-cell');
-    const [opCell, nameCell, throughputCell, avgDurationCell, timeSpentCell] = bodyCells;
+    const [opCell, descriptionCell, throughputCell, avgDurationCell, timeSpentCell] =
+      bodyCells;
 
-    expect(opCell).toHaveTextContent('navigation');
-    expect(nameCell).toHaveTextContent('(unnamed span)');
+    expect(opCell).toHaveTextContent('db');
+    expect(descriptionCell).toHaveTextContent('SELECT thing FROM my_cool_db');
     expect(throughputCell).toHaveTextContent('4.45/s');
     expect(avgDurationCell).toHaveTextContent('30.90s');
     expect(timeSpentCell).toHaveTextContent('2.04wk');

--- a/static/app/views/performance/transactionSummary/transactionSpans/spanMetricsTable.tsx
+++ b/static/app/views/performance/transactionSummary/transactionSpans/spanMetricsTable.tsx
@@ -200,6 +200,10 @@ function renderBodyCell(
     }
 
     if (column.key === SpanMetricsField.SPAN_DESCRIPTION) {
+      if (!dataRow['span.group']) {
+        return '\u2014';
+      }
+
       const target = spanDetailsRouteWithQuery({
         orgSlug: organization.slug,
         transaction: transactionName,
@@ -210,7 +214,7 @@ function renderBodyCell(
 
       return (
         <TableCellContainer>
-          <Link to={target}>{dataRow[column.key] || '\u2014'}</Link>
+          <Link to={target}>{dataRow[column.key]}</Link>
         </TableCellContainer>
       );
     }

--- a/static/app/views/performance/transactionSummary/transactionSpans/spanMetricsTable.tsx
+++ b/static/app/views/performance/transactionSummary/transactionSpans/spanMetricsTable.tsx
@@ -183,6 +183,22 @@ function renderBodyCell(
   project?: Project
 ) {
   return function (column: Column, dataRow: DataRow): React.ReactNode {
+    if (column.key === SpanMetricsField.SPAN_OP) {
+      const target = spanDetailsRouteWithQuery({
+        orgSlug: organization.slug,
+        transaction: transactionName,
+        query: location.query,
+        spanSlug: {op: dataRow['span.op'], group: ''},
+        projectID: project?.id,
+      });
+
+      return (
+        <TableCellContainer>
+          <Link to={target}>{dataRow[column.key]}</Link>
+        </TableCellContainer>
+      );
+    }
+
     if (column.key === SpanMetricsField.SPAN_DESCRIPTION) {
       const target = spanDetailsRouteWithQuery({
         orgSlug: organization.slug,

--- a/static/app/views/performance/transactionSummary/transactionSpans/spanMetricsTable.tsx
+++ b/static/app/views/performance/transactionSummary/transactionSpans/spanMetricsTable.tsx
@@ -194,7 +194,7 @@ function renderBodyCell(
 
       return (
         <TableCellContainer>
-          <Link to={target}>{dataRow[column.key] || t('(unnamed span)')}</Link>
+          <Link to={target}>{dataRow[column.key] || '\u2014'}</Link>
         </TableCellContainer>
       );
     }

--- a/static/app/views/performance/transactionSummary/transactionSpans/spanMetricsTable.tsx
+++ b/static/app/views/performance/transactionSummary/transactionSpans/spanMetricsTable.tsx
@@ -54,7 +54,7 @@ const COLUMN_ORDER: Column[] = [
   },
   {
     key: SpanMetricsField.SPAN_DESCRIPTION,
-    name: t('Span Name'),
+    name: t('Span Description'),
     width: COL_WIDTH_UNDEFINED,
   },
   {

--- a/static/app/views/performance/transactionSummary/transactionSpans/spanMetricsTable.tsx
+++ b/static/app/views/performance/transactionSummary/transactionSpans/spanMetricsTable.tsx
@@ -201,7 +201,7 @@ function renderBodyCell(
 
     if (column.key === SpanMetricsField.SPAN_DESCRIPTION) {
       if (!dataRow['span.group']) {
-        return '\u2014';
+        return <TableCellContainer>{'\u2014'}</TableCellContainer>;
       }
 
       const target = spanDetailsRouteWithQuery({

--- a/static/app/views/performance/transactionSummary/transactionSpans/spanSummary/spanSummaryHeader.tsx
+++ b/static/app/views/performance/transactionSummary/transactionSpans/spanSummary/spanSummaryHeader.tsx
@@ -107,4 +107,4 @@ const EmptyValueContainer = styled('span')`
   color: ${p => p.theme.gray300};
 `;
 
-const emptyValue = <EmptyValueContainer>{t('(unnamed span)')}</EmptyValueContainer>;
+const emptyValue = <EmptyValueContainer>{'\u2014'}</EmptyValueContainer>;


### PR DESCRIPTION
Adds some changes to the spans tab in transaction summary + the span summary page:

- Change `Span Name` heading to `Span Description`
- For spans without grouping, the description will no longer say `(unnamed span)` since that is misleading
- The span operation column now has links that bring the user to a generic span summary page scoped to just the span op (tentative, may want to change this so that it still uses the span group if it is available in the row?)

![image](https://github.com/getsentry/sentry/assets/16740047/83f0079a-f57f-4997-9103-858e31cd22bc)


