### PR TITLE
feat(autofix): Add frontend for iterative user feedback

### DIFF
--- a/static/app/components/events/autofix/autofixChanges.spec.tsx
+++ b/static/app/components/events/autofix/autofixChanges.spec.tsx
@@ -50,6 +50,75 @@ describe('AutofixChanges', function () {
     );
   });
 
+  it('displays create PR button when it is last step', function () {
+    MockApiClient.addMockResponse({
+      url: '/issues/1/autofix/setup/',
+      body: {
+        genAIConsent: {ok: true},
+        codebaseIndexing: {ok: true},
+        integration: {ok: true},
+        githubWriteIntegration: {
+          repos: [{ok: true, owner: 'owner', name: 'hello-world', id: 100}],
+        },
+      },
+    });
+
+    render(
+      <AutofixChanges
+        {...defaultProps}
+        step={
+          AutofixStepFixture({
+            type: AutofixStepType.CHANGES,
+            changes: [
+              AutofixCodebaseChangeData({
+                pull_request: undefined,
+              }),
+            ],
+          }) as AutofixChangesStep
+        }
+        isLastStep
+      />
+    );
+
+    expect(
+      screen.queryByRole('button', {name: 'Create a Pull Request'})
+    ).toBeInTheDocument();
+  });
+
+  it('does not display create PR button when it is not the last step', function () {
+    MockApiClient.addMockResponse({
+      url: '/issues/1/autofix/setup/',
+      body: {
+        genAIConsent: {ok: true},
+        codebaseIndexing: {ok: true},
+        integration: {ok: true},
+        githubWriteIntegration: {
+          repos: [{ok: true, owner: 'owner', name: 'hello-world', id: 100}],
+        },
+      },
+    });
+
+    render(
+      <AutofixChanges
+        {...defaultProps}
+        step={
+          AutofixStepFixture({
+            type: AutofixStepType.CHANGES,
+            changes: [
+              AutofixCodebaseChangeData({
+                pull_request: undefined,
+              }),
+            ],
+          }) as AutofixChangesStep
+        }
+      />
+    );
+
+    expect(
+      screen.queryByRole('button', {name: 'Create a Pull Request'})
+    ).not.toBeInTheDocument();
+  });
+
   it('displays setup button when permissions do not exist for repo', async function () {
     MockApiClient.addMockResponse({
       url: '/issues/1/autofix/setup/',
@@ -78,6 +147,7 @@ describe('AutofixChanges', function () {
             ],
           }) as AutofixChangesStep
         }
+        isLastStep
       />
     );
     renderGlobalModal();

--- a/static/app/components/events/autofix/autofixChanges.tsx
+++ b/static/app/components/events/autofix/autofixChanges.tsx
@@ -27,6 +27,7 @@ type AutofixChangesProps = {
   groupId: string;
   onRetry: () => void;
   step: AutofixChangesStep;
+  isLastStep?: boolean;
 };
 
 function CreatePullRequestButton({
@@ -107,9 +108,11 @@ function CreatePullRequestButton({
 function PullRequestLinkOrCreateButton({
   change,
   groupId,
+  isLastStep,
 }: {
   change: AutofixCodebaseChange;
   groupId: string;
+  isLastStep?: boolean;
 }) {
   const {data} = useAutofixSetup({groupId});
 
@@ -127,6 +130,10 @@ function PullRequestLinkOrCreateButton({
         {t('View Pull Request')}
       </LinkButton>
     );
+  }
+
+  if (!isLastStep) {
+    return null;
   }
 
   if (
@@ -164,9 +171,11 @@ function PullRequestLinkOrCreateButton({
 function AutofixRepoChange({
   change,
   groupId,
+  isLastStep,
 }: {
   change: AutofixCodebaseChange;
   groupId: string;
+  isLastStep?: boolean;
 }) {
   return (
     <Content>
@@ -175,14 +184,23 @@ function AutofixRepoChange({
           <Title>{change.repo_name}</Title>
           <PullRequestTitle>{change.title}</PullRequestTitle>
         </div>
-        <PullRequestLinkOrCreateButton change={change} groupId={groupId} />
+        <PullRequestLinkOrCreateButton
+          change={change}
+          groupId={groupId}
+          isLastStep={isLastStep}
+        />
       </RepoChangesHeader>
       <AutofixDiff diff={change.diff} />
     </Content>
   );
 }
 
-export function AutofixChanges({step, onRetry, groupId}: AutofixChangesProps) {
+export function AutofixChanges({
+  step,
+  onRetry,
+  groupId,
+  isLastStep,
+}: AutofixChangesProps) {
   const data = useAutofixData({groupId});
 
   if (step.status === 'ERROR' || data?.status === 'ERROR') {
@@ -227,7 +245,7 @@ export function AutofixChanges({step, onRetry, groupId}: AutofixChangesProps) {
       {step.changes.map((change, i) => (
         <Fragment key={change.repo_id}>
           {i > 0 && <Separator />}
-          <AutofixRepoChange change={change} groupId={groupId} />
+          <AutofixRepoChange change={change} groupId={groupId} isLastStep={isLastStep} />
         </Fragment>
       ))}
     </Content>

--- a/static/app/components/events/autofix/autofixInputField.spec.tsx
+++ b/static/app/components/events/autofix/autofixInputField.spec.tsx
@@ -1,0 +1,64 @@
+import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+
+import {AutofixInputField} from 'sentry/components/events/autofix/autofixInputField';
+
+describe('AutofixInputField', function () {
+  const defaultProps = {
+    groupId: '123',
+    runId: '456',
+  };
+
+  it('renders the input field correctly', function () {
+    render(<AutofixInputField {...defaultProps} />);
+
+    // Check if the input field is present
+    expect(
+      screen.getByPlaceholderText('Rename the function foo_bar to fooBar')
+    ).toBeInTheDocument();
+
+    // Check if the send button is present
+    expect(screen.getByText('Send')).toBeInTheDocument();
+  });
+
+  it('handles input change correctly', async function () {
+    render(<AutofixInputField {...defaultProps} />);
+
+    const inputField = screen.getByPlaceholderText(
+      'Rename the function foo_bar to fooBar'
+    );
+
+    // Simulate user typing in the input field
+    await userEvent.click(inputField);
+    await userEvent.type(inputField, 'Change the variable name');
+
+    // Check if the input field value has changed
+    expect(inputField).toHaveValue('Change the variable name');
+  });
+
+  it('handles send button click correctly', async function () {
+    const mockSendUpdate = MockApiClient.addMockResponse({
+      url: '/issues/123/autofix/update/',
+      method: 'POST',
+    });
+
+    render(<AutofixInputField {...defaultProps} />);
+
+    const inputField = screen.getByPlaceholderText(
+      'Rename the function foo_bar to fooBar'
+    );
+    const sendButton = screen.getByText('Send');
+
+    // Simulate user typing in the input field
+    await userEvent.click(inputField);
+    await userEvent.type(inputField, 'Change the variable name');
+
+    // Simulate user clicking the send button
+    await userEvent.click(sendButton);
+
+    // Check if the input field is disabled after clicking the send button
+    expect(inputField).toBeDisabled();
+
+    // Check if the API request was sent
+    expect(mockSendUpdate).toHaveBeenCalledTimes(1);
+  });
+});

--- a/static/app/components/events/autofix/autofixInputField.tsx
+++ b/static/app/components/events/autofix/autofixInputField.tsx
@@ -12,6 +12,7 @@ import LoadingIndicator from 'sentry/components/loadingIndicator';
 import Panel from 'sentry/components/panels/panel';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
+import {isCtrlKeyPressed} from 'sentry/utils/isCtrlKeyPressed';
 import {setApiQueryData, useMutation, useQueryClient} from 'sentry/utils/queryClient';
 import useApi from 'sentry/utils/useApi';
 
@@ -92,7 +93,7 @@ export function AutofixInputField({groupId, runId}: {groupId: string; runId: str
             onChange={e => setInstruction(e.target.value)}
             disabled={isSubmitting}
             onKeyDown={e => {
-              if ((e.metaKey || e.ctrlKey) && e.key === 'Enter') {
+              if (isCtrlKeyPressed(e) && e.key === 'Enter') {
                 sendInstruction();
               }
             }}

--- a/static/app/components/events/autofix/autofixInputField.tsx
+++ b/static/app/components/events/autofix/autofixInputField.tsx
@@ -78,27 +78,36 @@ export function AutofixInputField({groupId, runId}: {groupId: string; runId: str
   return (
     <Card>
       <Title>{t("Doesn't look right? Tell Autofix what needs to be changed")}</Title>
-      <FormRow>
-        <TextArea
-          aria-label={t('Provide context')}
-          placeholder={t('Rename the function foo_bar to fooBar')}
-          value={instruction}
-          onChange={e => setInstruction(e.target.value)}
-          disabled={isSubmitting}
-          onKeyDown={e => {
-            if ((e.metaKey || e.ctrlKey) && e.key === 'Enter') {
-              sendInstruction();
+      <form
+        onSubmit={e => {
+          e.preventDefault();
+          sendInstruction();
+        }}
+      >
+        <FormRow>
+          <TextArea
+            aria-label={t('Provide context')}
+            placeholder={t('Rename the function foo_bar to fooBar')}
+            value={instruction}
+            onChange={e => setInstruction(e.target.value)}
+            disabled={isSubmitting}
+            onKeyDown={e => {
+              if ((e.metaKey || e.ctrlKey) && e.key === 'Enter') {
+                sendInstruction();
+              }
+            }}
+          />
+          <Button
+            type="submit"
+            icon={
+              isSubmitting && <ProcessingStatusIndicator size={18} mini hideMessage />
             }
-          }}
-        />
-        <Button
-          onClick={sendInstruction}
-          icon={isSubmitting && <ProcessingStatusIndicator size={18} mini hideMessage />}
-          disabled={isSubmitting || !instruction}
-        >
-          {t('Send')}
-        </Button>
-      </FormRow>
+            disabled={isSubmitting || !instruction}
+          >
+            {t('Send')}
+          </Button>
+        </FormRow>
+      </form>
     </Card>
   );
 }

--- a/static/app/components/events/autofix/autofixInputField.tsx
+++ b/static/app/components/events/autofix/autofixInputField.tsx
@@ -85,6 +85,11 @@ export function AutofixInputField({groupId, runId}: {groupId: string; runId: str
           value={instruction}
           onChange={e => setInstruction(e.target.value)}
           disabled={isSubmitting}
+          onKeyDown={e => {
+            if ((e.metaKey || e.ctrlKey) && e.key === 'Enter') {
+              sendInstruction();
+            }
+          }}
         />
         <Button
           onClick={sendInstruction}

--- a/static/app/components/events/autofix/autofixInputField.tsx
+++ b/static/app/components/events/autofix/autofixInputField.tsx
@@ -59,6 +59,7 @@ const useAutofixUserInstruction = (groupId: string, runId: string) => {
     },
     onError: () => {
       addErrorMessage(t('Something went wrong when responding to autofix.'));
+      setIsSubmitting(false);
     },
   });
 
@@ -88,7 +89,7 @@ export function AutofixInputField({groupId, runId}: {groupId: string; runId: str
         <Button
           onClick={sendInstruction}
           icon={isSubmitting && <ProcessingStatusIndicator size={18} mini hideMessage />}
-          disabled={isSubmitting}
+          disabled={isSubmitting || !instruction}
         >
           {t('Send')}
         </Button>

--- a/static/app/components/events/autofix/autofixInputField.tsx
+++ b/static/app/components/events/autofix/autofixInputField.tsx
@@ -1,0 +1,127 @@
+import {useCallback, useState} from 'react';
+import styled from '@emotion/styled';
+
+import {addErrorMessage} from 'sentry/actionCreators/indicator';
+import {Button} from 'sentry/components/button';
+import {
+  type AutofixResponse,
+  makeAutofixQueryKey,
+} from 'sentry/components/events/autofix/useAutofix';
+import TextArea from 'sentry/components/forms/controls/textarea';
+import LoadingIndicator from 'sentry/components/loadingIndicator';
+import Panel from 'sentry/components/panels/panel';
+import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
+import {setApiQueryData, useMutation, useQueryClient} from 'sentry/utils/queryClient';
+import useApi from 'sentry/utils/useApi';
+
+const useAutofixUserInstruction = (groupId: string, runId: string) => {
+  const api = useApi();
+  const queryClient = useQueryClient();
+
+  const [instruction, setInstruction] = useState<string>('');
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const {mutate} = useMutation({
+    mutationFn: (params: {instruction: string}) => {
+      return api.requestPromise(`/issues/${groupId}/autofix/update/`, {
+        method: 'POST',
+        data: {
+          run_id: runId,
+          payload: {
+            type: 'instruction',
+            content: {
+              type: 'text',
+              text: params.instruction,
+            },
+          },
+        },
+      });
+    },
+    onSuccess: _ => {
+      setApiQueryData<AutofixResponse>(
+        queryClient,
+        makeAutofixQueryKey(groupId),
+        data => {
+          if (!data || !data.autofix) {
+            return data;
+          }
+
+          return {
+            ...data,
+            autofix: {
+              ...data.autofix,
+              status: 'PROCESSING',
+            },
+          };
+        }
+      );
+    },
+    onError: () => {
+      addErrorMessage(t('Something went wrong when responding to autofix.'));
+    },
+  });
+
+  const sendInstruction = useCallback(() => {
+    mutate({instruction});
+    setIsSubmitting(true);
+  }, [instruction, mutate, setIsSubmitting]);
+
+  return {sendInstruction, instruction, setInstruction, isSubmitting};
+};
+
+export function AutofixInputField({groupId, runId}: {groupId: string; runId: string}) {
+  const {sendInstruction, instruction, setInstruction, isSubmitting} =
+    useAutofixUserInstruction(groupId, runId);
+
+  return (
+    <Card>
+      <Title>{t("Doesn't look right? Tell Autofix what needs to be changed")}</Title>
+      <FormRow>
+        <TextArea
+          aria-label={t('Provide context')}
+          placeholder={t('Rename the function foo_bar to fooBar')}
+          value={instruction}
+          onChange={e => setInstruction(e.target.value)}
+          disabled={isSubmitting}
+        />
+        <Button
+          onClick={sendInstruction}
+          icon={isSubmitting && <ProcessingStatusIndicator size={18} mini hideMessage />}
+          disabled={isSubmitting}
+        >
+          {t('Send')}
+        </Button>
+      </FormRow>
+    </Card>
+  );
+}
+
+const Card = styled(Panel)`
+  padding: ${space(2)};
+  margin-bottom: 0;
+  display: flex;
+  flex-direction: column;
+  gap: ${space(1)};
+`;
+
+const Title = styled('div')`
+  font-weight: bold;
+  white-space: nowrap;
+`;
+
+const FormRow = styled('div')`
+  display: flex;
+  flex-direction: row;
+  align-items: flex-start;
+  gap: ${space(1)};
+  width: 100%;
+`;
+
+const ProcessingStatusIndicator = styled(LoadingIndicator)`
+  && {
+    margin: 0;
+    height: 18px;
+    width: 18px;
+  }
+`;

--- a/static/app/components/events/autofix/autofixSteps.tsx
+++ b/static/app/components/events/autofix/autofixSteps.tsx
@@ -1,16 +1,20 @@
 import {Fragment, useEffect, useState} from 'react';
 import styled from '@emotion/styled';
 
+import UserAvatar from 'sentry/components/avatar/userAvatar';
 import {Button} from 'sentry/components/button';
 import DateTime from 'sentry/components/dateTime';
 import {AutofixChanges} from 'sentry/components/events/autofix/autofixChanges';
+import {AutofixInputField} from 'sentry/components/events/autofix/autofixInputField';
 import {AutofixRootCause} from 'sentry/components/events/autofix/autofixRootCause';
 import {
   type AutofixData,
   type AutofixProgressItem,
   type AutofixStep,
   AutofixStepType,
+  type AutofixUserResponseStep,
 } from 'sentry/components/events/autofix/types';
+import {useAutofixData} from 'sentry/components/events/autofix/useAutofix';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import Panel from 'sentry/components/panels/panel';
 import {
@@ -56,8 +60,8 @@ function StepIcon({step}: {step: AutofixStep}) {
   }
 }
 
-function stepShouldBeginExpanded(step: AutofixStep) {
-  if (step.type === AutofixStepType.CHANGES) {
+function stepShouldBeginExpanded(step: AutofixStep, isLastStep?: boolean) {
+  if (isLastStep) {
     return true;
   }
 
@@ -74,7 +78,12 @@ interface StepProps {
   runId: string;
   step: AutofixStep;
   isChild?: boolean;
+  isLastStep?: boolean;
   stepNumber?: number;
+}
+
+interface UserStepProps extends StepProps {
+  step: AutofixUserResponseStep;
 }
 
 interface AutofixStepsProps {
@@ -112,25 +121,42 @@ function Progress({
 
   return (
     <ProgressStepContainer>
-      <Step step={progress} isChild groupId={groupId} runId={runId} onRetry={onRetry} />
+      <ExpandableStep
+        step={progress}
+        isChild
+        groupId={groupId}
+        runId={runId}
+        onRetry={onRetry}
+      />
     </ProgressStepContainer>
   );
 }
 
-export function Step({step, isChild, groupId, runId, onRetry}: StepProps) {
+export function ExpandableStep({
+  step,
+  isChild,
+  groupId,
+  runId,
+  isLastStep,
+  onRetry,
+}: StepProps) {
+  const previousIsLastStep = usePrevious(isLastStep);
   const previousStepStatus = usePrevious(step.status);
   const isActive = step.status !== 'PENDING' && step.status !== 'CANCELLED';
-  const [isExpanded, setIsExpanded] = useState(() => stepShouldBeginExpanded(step));
+  const [isExpanded, setIsExpanded] = useState(() =>
+    stepShouldBeginExpanded(step, isLastStep)
+  );
 
   useEffect(() => {
     if (
-      previousStepStatus &&
-      previousStepStatus !== step.status &&
-      step.status === 'COMPLETED'
+      (previousStepStatus &&
+        previousStepStatus !== step.status &&
+        step.status === 'COMPLETED') ||
+      (previousIsLastStep && !isLastStep)
     ) {
       setIsExpanded(false);
     }
-  }, [previousStepStatus, step.status]);
+  }, [previousStepStatus, step.status, previousIsLastStep, isLastStep]);
 
   const logs: AutofixProgressItem[] = step.progress?.filter(isProgressLog) ?? [];
   const activeLog = step.completedMessage ?? logs.at(-1)?.message ?? null;
@@ -198,7 +224,12 @@ export function Step({step, isChild, groupId, runId, onRetry}: StepProps) {
             />
           )}
           {step.type === AutofixStepType.CHANGES && (
-            <AutofixChanges step={step} groupId={groupId} onRetry={onRetry} />
+            <AutofixChanges
+              step={step}
+              groupId={groupId}
+              onRetry={onRetry}
+              isLastStep={isLastStep}
+            />
           )}
         </Fragment>
       )}
@@ -206,10 +237,61 @@ export function Step({step, isChild, groupId, runId, onRetry}: StepProps) {
   );
 }
 
+function UserStep({step, groupId}: UserStepProps) {
+  const data = useAutofixData({groupId});
+  const user = data?.users?.[step.user_id];
+
+  return (
+    <StepCard active>
+      <UserStepContent>
+        <UserAvatar user={user} size={19} />
+        <UserTextContentContainer>
+          <UserStepName>{user?.name}</UserStepName>
+          <UserStepText>{step.text}</UserStepText>
+        </UserTextContentContainer>
+      </UserStepContent>
+    </StepCard>
+  );
+}
+
+function Step({step, groupId, runId, onRetry, stepNumber, isLastStep}: StepProps) {
+  if (step.type === AutofixStepType.USER_RESPONSE) {
+    return (
+      <UserStep
+        step={step}
+        groupId={groupId}
+        runId={runId}
+        onRetry={onRetry}
+        isLastStep={isLastStep}
+      />
+    );
+  }
+
+  return (
+    <ExpandableStep
+      step={step}
+      groupId={groupId}
+      runId={runId}
+      onRetry={onRetry}
+      stepNumber={stepNumber}
+      isLastStep={isLastStep}
+    />
+  );
+}
+
 export function AutofixSteps({data, groupId, runId, onRetry}: AutofixStepsProps) {
+  const steps = data.steps;
+
+  if (!steps) {
+    return null;
+  }
+
+  const showInputField =
+    data.options?.iterative_feedback && steps.at(-1)?.type === AutofixStepType.CHANGES;
+
   return (
     <div>
-      {data.steps?.map((step, index) => (
+      {steps.map((step, index) => (
         <Step
           step={step}
           key={step.id}
@@ -217,8 +299,10 @@ export function AutofixSteps({data, groupId, runId, onRetry}: AutofixStepsProps)
           groupId={groupId}
           runId={runId}
           onRetry={onRetry}
+          isLastStep={index === steps.length - 1}
         />
       ))}
+      {showInputField && <AutofixInputField runId={data.run_id} groupId={groupId} />}
     </div>
   );
 }
@@ -247,6 +331,27 @@ const StepHeader = styled('div')<{canToggle: boolean; isChild?: boolean}>`
   }
 `;
 
+const UserStepContent = styled('div')`
+  display: flex;
+  align-items: flex-start;
+  gap: ${space(1)};
+  padding: ${space(2)};
+`;
+
+const UserStepName = styled('div')`
+  font-weight: bold;
+`;
+
+const UserStepText = styled('p')`
+  margin: 0;
+`;
+
+const UserTextContentContainer = styled('div')`
+  display: flex;
+  flex-direction: column;
+  gap: ${space(0.5)};
+`;
+
 const StepHeaderLeft = styled('div')`
   display: flex;
   align-items: center;
@@ -267,7 +372,7 @@ const StepHeaderDescription = styled('div')`
 const StepIconContainer = styled('div')`
   display: flex;
   align-items: center;
-  margin-right: ${space(1)};
+  margin-right: ${space(1.5)};
 `;
 
 const StepHeaderRight = styled('div')`

--- a/static/app/components/events/autofix/types.ts
+++ b/static/app/components/events/autofix/types.ts
@@ -1,5 +1,6 @@
 import type {EventMetadata} from 'sentry/types/event';
 import type {Group} from 'sentry/types/group';
+import type {User} from 'sentry/types/user';
 
 export enum DiffFileType {
   ADDED = 'A',
@@ -17,6 +18,7 @@ export enum AutofixStepType {
   DEFAULT = 'default',
   ROOT_CAUSE_ANALYSIS = 'root_cause_analysis',
   CHANGES = 'changes',
+  USER_RESPONSE = 'user_response',
 }
 
 export enum AutofixCodebaseIndexingStatus {
@@ -32,6 +34,10 @@ export type AutofixPullRequestDetails = {
   pr_url: string;
 };
 
+export type AutofixOptions = {
+  iterative_feedback?: boolean;
+};
+
 export type AutofixData = {
   created_at: string;
   run_id: string;
@@ -42,12 +48,15 @@ export type AutofixData = {
     | 'NOFIX'
     | 'ERROR'
     | 'NEED_MORE_INFORMATION';
+  actor_ids?: number[];
   codebase_indexing?: {
     status: 'COMPLETED';
   };
   completed_at?: string | null;
   error_message?: string;
+  options?: AutofixOptions;
   steps?: AutofixStep[];
+  users?: Record<number, User>;
 };
 
 export type AutofixProgressItem = {
@@ -57,7 +66,11 @@ export type AutofixProgressItem = {
   data?: any;
 };
 
-export type AutofixStep = AutofixDefaultStep | AutofixRootCauseStep | AutofixChangesStep;
+export type AutofixStep =
+  | AutofixDefaultStep
+  | AutofixRootCauseStep
+  | AutofixChangesStep
+  | AutofixUserResponseStep;
 
 interface BaseStep {
   id: string;
@@ -100,6 +113,12 @@ export type AutofixCodebaseChange = {
 export interface AutofixChangesStep extends BaseStep {
   changes: AutofixCodebaseChange[];
   type: AutofixStepType.CHANGES;
+}
+
+export interface AutofixUserResponseStep extends BaseStep {
+  text: string;
+  type: AutofixStepType.USER_RESPONSE;
+  user_id: number;
 }
 
 export type AutofixRootCauseSuggestedFixSnippet = {


### PR DESCRIPTION
Introduces a User Response step:
<img width="711" alt="Screenshot 2024-06-05 at 3 02 17 PM" src="https://github.com/getsentry/sentry/assets/30991498/6da9fda3-be52-412d-bd81-fec7771cc4a1">

And a user input for autofix that only shows for the last changes card:
<img width="1103" alt="Screenshot 2024-06-07 at 10 10 15 AM" src="https://github.com/getsentry/sentry/assets/30991498/c1895d29-a393-4aa7-b276-ac89638cf7ea">

The input is gated behind a flag in the autofix state from seer: `autofixState.options.interative_feedback` which means the input won't show in prod yet. The user response card won't be added to the steps either.