### PR TITLE
feat(profiling): Format profile durations to hours

### DIFF
--- a/static/app/views/organizationStats/utils.spec.tsx
+++ b/static/app/views/organizationStats/utils.spec.tsx
@@ -148,4 +148,18 @@ describe('formatUsageWithUnits', function () {
       })
     ).toBe('1.23 TB');
   });
+
+  it('should format profile duration correctly', function () {
+    const hourInMs = 1000 * 60 * 60;
+    expect(formatUsageWithUnits(0, DATA_CATEGORY_INFO.profileDuration.plural)).toBe('0');
+    expect(
+      formatUsageWithUnits(7.6 * hourInMs, DATA_CATEGORY_INFO.profileDuration.plural)
+    ).toBe('7.6');
+    expect(
+      formatUsageWithUnits(hourInMs, DATA_CATEGORY_INFO.profileDuration.plural)
+    ).toBe('1');
+    expect(
+      formatUsageWithUnits(24 * hourInMs, DATA_CATEGORY_INFO.profileDuration.plural)
+    ).toBe('24');
+  });
 });

--- a/static/app/views/organizationStats/utils.tsx
+++ b/static/app/views/organizationStats/utils.tsx
@@ -47,7 +47,7 @@ export function formatUsageWithUnits(
     dataCategory === DATA_CATEGORY_INFO.profileDuration.plural &&
     Number.isFinite(usageQuantity)
   ) {
-    // Profile duration is in miliseconds and we want hours
+    // Profile duration is in milliseconds, convert to hours
     return (usageQuantity / 1000 / 60 / 60).toLocaleString(undefined, {
       maximumFractionDigits: 2,
     });

--- a/static/app/views/organizationStats/utils.tsx
+++ b/static/app/views/organizationStats/utils.tsx
@@ -1,7 +1,7 @@
 import type {DateTimeObject} from 'sentry/components/charts/utils';
 import {getSeriesApiInterval} from 'sentry/components/charts/utils';
 import {DATA_CATEGORY_INFO} from 'sentry/constants';
-import type {DataCategoryInfo} from 'sentry/types';
+import type {DataCategoryInfo} from 'sentry/types/core';
 import {formatBytesBase10} from 'sentry/utils';
 import {parsePeriodToHours} from 'sentry/utils/duration/parsePeriodToHours';
 
@@ -31,21 +31,31 @@ export function formatUsageWithUnits(
   usageQuantity: number = 0,
   dataCategory: DataCategoryInfo['plural'],
   options: FormatOptions = {isAbbreviated: false, useUnitScaling: false}
-) {
-  if (dataCategory !== DATA_CATEGORY_INFO.attachment.plural) {
+): string {
+  if (dataCategory === DATA_CATEGORY_INFO.attachment.plural) {
+    if (options.useUnitScaling) {
+      return formatBytesBase10(usageQuantity);
+    }
+
+    const usageGb = usageQuantity / GIGABYTE;
     return options.isAbbreviated
-      ? abbreviateUsageNumber(usageQuantity)
-      : usageQuantity.toLocaleString();
+      ? `${abbreviateUsageNumber(usageGb)} GB`
+      : `${usageGb.toLocaleString(undefined, {maximumFractionDigits: 2})} GB`;
   }
 
-  if (options.useUnitScaling) {
-    return formatBytesBase10(usageQuantity);
+  if (
+    dataCategory === DATA_CATEGORY_INFO.profileDuration.plural &&
+    Number.isFinite(usageQuantity)
+  ) {
+    // Profile duration is in miliseconds and we want hours
+    return (usageQuantity / 1000 / 60 / 60).toLocaleString(undefined, {
+      maximumFractionDigits: 2,
+    });
   }
 
-  const usageGb = usageQuantity / GIGABYTE;
   return options.isAbbreviated
-    ? `${abbreviateUsageNumber(usageGb)} GB`
-    : `${usageGb.toLocaleString(undefined, {maximumFractionDigits: 2})} GB`;
+    ? abbreviateUsageNumber(usageQuantity)
+    : usageQuantity.toLocaleString();
 }
 
 /**


### PR DESCRIPTION
I believe they're in ms, we want to display them as hours

example org with profile duration stats https://testorg-am3launch-am3-business.sentry.io/stats/?dataCategory=profileDuration&project=4507392064290816&statsPeriod=14d