### PR TITLE
fix(issues): Shorten codeowners in assignee selector

### DIFF
--- a/static/app/components/group/assignedTo.spec.tsx
+++ b/static/app/components/group/assignedTo.spec.tsx
@@ -246,7 +246,7 @@ describe('Group > AssignedTo', () => {
     await openMenu();
 
     expect(screen.getByText('Suspect commit author')).toBeInTheDocument();
-    expect(screen.getByText('Owner of codeowners:/./app/components')).toBeInTheDocument();
+    expect(screen.getByText('Codeowners:/./app/components')).toBeInTheDocument();
 
     await userEvent.click(screen.getByText('Suspect commit author'));
 

--- a/static/app/components/group/assignedTo.tsx
+++ b/static/app/components/group/assignedTo.tsx
@@ -30,6 +30,7 @@ import {defined} from 'sentry/utils';
 import type {FeedbackIssue} from 'sentry/utils/feedback/types';
 import {useMutation} from 'sentry/utils/queryClient';
 import type RequestError from 'sentry/utils/requestError/requestError';
+import {toTitleCase} from 'sentry/utils/string/toTitleCase';
 import useApi from 'sentry/utils/useApi';
 import useCommitters from 'sentry/utils/useCommitters';
 import useOrganization from 'sentry/utils/useOrganization';
@@ -83,7 +84,7 @@ function getSuggestedReason(owner: IssueOwner) {
 
   if (owner.rules?.length) {
     const firstRule = owner.rules[0];
-    return t('Owner of %s', firstRule.join(':'));
+    return `${toTitleCase(firstRule[0])}:${firstRule[1]}`;
   }
 
   return '';


### PR DESCRIPTION
before
![image](https://github.com/getsentry/sentry/assets/1400464/0eb85029-755b-47a4-a8cb-24f0e1da0e82)


after
![image](https://github.com/getsentry/sentry/assets/1400464/7f99681b-f1f5-4f98-a30e-5302bb331631)
