### PR TITLE
fix(issues): Disable assignee selector tooltip on open

### DIFF
--- a/static/app/components/assigneeBadge.tsx
+++ b/static/app/components/assigneeBadge.tsx
@@ -18,6 +18,7 @@ type AssigneeBadgeProps = {
   assignedTo?: Actor | undefined;
   assignmentReason?: SuggestedOwnerReason;
   chevronDirection?: 'up' | 'down';
+  isTooltipDisabled?: boolean;
   loading?: boolean;
   showLabel?: boolean;
 };
@@ -30,6 +31,7 @@ export function AssigneeBadge({
   showLabel = false,
   chevronDirection = 'down',
   loading = false,
+  isTooltipDisabled,
 }: AssigneeBadgeProps) {
   const suggestedReasons: Record<SuggestedOwnerReason, React.ReactNode> = {
     suspectCommit: tct('Based on [commit:commit data]', {
@@ -92,6 +94,7 @@ export function AssigneeBadge({
   ) : assignedTo ? (
     <Tooltip
       isHoverable
+      disabled={isTooltipDisabled}
       title={
         <TooltipWrapper>
           {t('Assigned to ')}
@@ -107,6 +110,7 @@ export function AssigneeBadge({
   ) : (
     <Tooltip
       isHoverable
+      disabled={isTooltipDisabled}
       title={
         <TooltipWrapper>
           <div>{t('Unassigned')}</div>

--- a/static/app/components/stream/group.tsx
+++ b/static/app/components/stream/group.tsx
@@ -574,6 +574,7 @@ function BaseGroupRow({
                             }
                             loading={assigneeLoading}
                             chevronDirection={isOpen ? 'up' : 'down'}
+                            isTooltipDisabled={isOpen}
                           />
                         </StyledDropdownButton>
                       )


### PR DESCRIPTION
thought it was kinda annoying

tooltip is disabled on open
![image](https://github.com/getsentry/sentry/assets/1400464/c15dcca6-65e9-4a1b-9dcc-c90237850f1c)
