### PR TITLE
fix(stats): Hide profiles when profile durations is visible

### DIFF
--- a/static/app/views/organizationStats/index.tsx
+++ b/static/app/views/organizationStats/index.tsx
@@ -252,6 +252,9 @@ export class OrganizationStats extends Component<OrganizationStatsProps> {
       if (DATA_CATEGORY_INFO.profileDuration.plural === opt.value) {
         return organization.features.includes('continuous-profiling-stats');
       }
+      if (DATA_CATEGORY_INFO.profile.plural === opt.value) {
+        return !organization.features.includes('continuous-profiling-stats');
+      }
       return true;
     });
 


### PR DESCRIPTION
on the stats page, hides profiles when the profile durations option is available