### PR TITLE
fix(rules): Fix issue alert rule display when filtered to assignees

### DIFF
--- a/src/sentry/rules/filters/assigned_to.py
+++ b/src/sentry/rules/filters/assigned_to.py
@@ -7,14 +7,15 @@ from django import forms
 
 from sentry.eventstore.models import GroupEvent
 from sentry.mail.forms.assigned_to import AssignedToForm
+from sentry.models.team import Team
 from sentry.notifications.types import ASSIGNEE_CHOICES, AssigneeTargetType
 from sentry.rules import EventState
 from sentry.rules.filters.base import EventFilter
+from sentry.services.hybrid_cloud.user.service import user_service
 from sentry.utils.cache import cache
 
 if TYPE_CHECKING:
     from sentry.models.group import Group
-    from sentry.models.team import Team
     from sentry.models.user import User
 
 
@@ -55,3 +56,19 @@ class AssignedToFilter(EventFilter):
     def get_form_instance(self) -> forms.Form:
         form: forms.Form = self.form_cls(self.project, self.data)
         return form
+
+    def render_label(self) -> str:
+        target_type = AssigneeTargetType(self.get_option("targetType"))
+        target_identifer = self.get_option("targetIdentifier")
+        if target_type == AssigneeTargetType.TEAM:
+            try:
+                team = Team.objects.get(id=target_identifer)
+            except Team.DoesNotExist:
+                return self.label.format(**self.data)
+            return self.label.format(targetType=f"team {team.slug}")
+
+        elif target_type == AssigneeTargetType.MEMBER:
+            user = user_service.get_user(user_id=target_identifer)
+            return self.label.format(targetType=user.username)
+
+        return self.label.format(**self.data)

--- a/src/sentry/rules/filters/assigned_to.py
+++ b/src/sentry/rules/filters/assigned_to.py
@@ -65,7 +65,7 @@ class AssignedToFilter(EventFilter):
                 team = Team.objects.get(id=target_identifer)
             except Team.DoesNotExist:
                 return self.label.format(**self.data)
-            return self.label.format(targetType=f"team {team.slug}")
+            return self.label.format(targetType=f"team #{team.slug}")
 
         elif target_type == AssigneeTargetType.MEMBER:
             user = user_service.get_user(user_id=target_identifer)

--- a/tests/sentry/api/endpoints/test_project_rule_details.py
+++ b/tests/sentry/api/endpoints/test_project_rule_details.py
@@ -203,7 +203,8 @@ class ProjectRuleDetailsTest(ProjectRuleDetailsBaseTestCase):
         )
         assert response.data["id"] == str(self.rule.id)
         assert (
-            response.data["filters"][0]["name"] == f"The issue is assigned to team {self.team.slug}"
+            response.data["filters"][0]["name"]
+            == f"The issue is assigned to team #{self.team.slug}"
         )
 
     def test_with_assigned_to_user_filter(self):


### PR DESCRIPTION
When the filter "The issue is assigned to ___" is used, the rule details page just shows it as "The issue is assigned to Member" or "The issue is assigned to Team" rather than actually showing the name of the user or team. This PR displays the names.

Fixes https://github.com/getsentry/team-core-product-foundations/issues/265