### PR TITLE
fix(crons): Add option to specify monitors by guid in bulk edit

### DIFF
--- a/src/sentry/monitors/validators.py
+++ b/src/sentry/monitors/validators.py
@@ -396,7 +396,7 @@ class MonitorCheckInValidator(serializers.Serializer):
         return attrs
 
 
-class MonitorBulkEditValidator(MonitorValidator):
+class MonitorBulkEditValidatorLegacy(MonitorValidator):
     slugs = serializers.ListField(
         child=SentrySerializerSlugField(
             max_length=MAX_SLUG_LENGTH,
@@ -409,4 +409,18 @@ class MonitorBulkEditValidator(MonitorValidator):
             slug__in=value, organization_id=self.context["organization"].id
         ).count() != len(value):
             raise ValidationError("Not all slugs are valid for this organization.")
+        return value
+
+
+class MonitorBulkEditValidator(MonitorValidator):
+    ids = serializers.ListField(
+        child=serializers.UUIDField(format="hex"),
+        required=True,
+    )
+
+    def validate_ids(self, value):
+        if Monitor.objects.filter(
+            guid__in=value, organization_id=self.context["organization"].id
+        ).count() != len(value):
+            raise ValidationError("Not all ids are valid for this organization.")
         return value


### PR DESCRIPTION
Allows for the client to specify a list of monitor guids which correspond to the monitors they are trying to edit. Keeping the old functionality as we transition the frontend to use the new request payload

Related to: https://github.com/getsentry/team-crons/issues/184