### PR TITLE
chore(metrics): remove use metrics layer in alerts flag

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -475,8 +475,6 @@ def register_temporary_features(manager: FeatureManager):
     # Sanitize transaction names in the ingestion pipeline. # Deprecated
     manager.add("organizations:transaction-name-sanitization", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
     manager.add("organizations:use-metrics-layer", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
-    # Enable the metrics layer for alerts queries.
-    manager.add("organizations:use-metrics-layer-in-alerts", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
     # Enable User Feedback v2 ingest
     manager.add("organizations:user-feedback-ingest", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
     # Use ReplayClipPreview inside the User Feedback Details panel

--- a/src/sentry/snuba/entity_subscription.py
+++ b/src/sentry/snuba/entity_subscription.py
@@ -237,7 +237,7 @@ class BaseMetricsEntitySubscription(BaseEntitySubscription, ABC):
         self.org_id = extra_fields["org_id"]
         self.time_window = time_window
         self.use_metrics_layer = features.has(
-            "organizations:use-metrics-layer-in-alerts",
+            "organizations:custom-metrics",
             Organization.objects.get_from_cache(id=self.org_id),
         )
         self.on_demand_metrics_enabled = features.has(

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
@@ -864,7 +864,7 @@ class AlertRuleCreateEndpointTest(AlertRuleIndexBase):
                 "organizations:performance-view",
                 "organizations:mep-rollout-flag",
                 "organizations:dynamic-sampling",
-                "organizations:use-metrics-layer-in-alerts",
+                "organizations:custom-metrics",
             ]
         ):
             for mri in (
@@ -898,7 +898,6 @@ class AlertRuleCreateEndpointTest(AlertRuleIndexBase):
                 "organizations:mep-rollout-flag",
                 "organizations:dynamic-sampling",
                 "organizations:custom-metrics",
-                "organizations:use-metrics-layer-in-alerts",
             ]
         ):
             for mri in (
@@ -932,7 +931,6 @@ class AlertRuleCreateEndpointTest(AlertRuleIndexBase):
                 "organizations:mep-rollout-flag",
                 "organizations:dynamic-sampling",
                 "organizations:custom-metrics",
-                "organizations:use-metrics-layer-in-alerts",
             ]
         ):
             test_params = {

--- a/tests/sentry/snuba/test_entity_subscriptions.py
+++ b/tests/sentry/snuba/test_entity_subscriptions.py
@@ -109,7 +109,7 @@ class EntitySubscriptionTestCase(TestCase):
             )
 
     def test_get_entity_subscription_for_metrics_dataset_for_users_with_metrics_layer(self) -> None:
-        with Feature("organizations:use-metrics-layer-in-alerts"):
+        with Feature("organizations:custom-metrics"):
             org_id = self.organization.id
             use_case_id = UseCaseID.SESSIONS
 
@@ -240,7 +240,7 @@ class EntitySubscriptionTestCase(TestCase):
     def test_get_entity_subscription_for_metrics_dataset_for_sessions_with_metrics_layer(
         self,
     ) -> None:
-        with Feature("organizations:use-metrics-layer-in-alerts"):
+        with Feature("organizations:custom-metrics"):
             org_id = self.organization.id
             use_case_id = UseCaseID.SESSIONS
             aggregate = "percentage(sessions_crashed, sessions) AS _crash_rate_alert_aggregate"
@@ -397,7 +397,7 @@ class EntitySubscriptionTestCase(TestCase):
     def test_get_entity_subscription_for_performance_metrics_dataset_with_metrics_layer(
         self,
     ) -> None:
-        with Feature("organizations:use-metrics-layer-in-alerts"):
+        with Feature("organizations:custom-metrics"):
             aggregate = "percentile(transaction.duration,.95)"
             entity_subscription = get_entity_subscription(
                 query_type=SnubaQuery.Type.PERFORMANCE,
@@ -457,7 +457,7 @@ class EntitySubscriptionTestCase(TestCase):
         mri = "d:custom/sentry.process_profile.track_outcome@second"
         indexer.record(use_case_id=UseCaseID.CUSTOM, org_id=self.organization.id, string=mri)
 
-        with Feature("organizations:use-metrics-layer-in-alerts"):
+        with Feature("organizations:custom-metrics"):
             aggregate = f"max({mri})"
             entity_subscription = get_entity_subscription(
                 query_type=SnubaQuery.Type.PERFORMANCE,
@@ -512,7 +512,7 @@ class EntitySubscriptionTestCase(TestCase):
     def test_get_entity_subscription_with_multiple_entities_with_metrics_layer(
         self,
     ) -> None:
-        with Feature("organizations:use-metrics-layer-in-alerts"):
+        with Feature("organizations:custom-metrics"):
             aggregate = "percentile(transaction.duration,.95)"
             entity_subscription = get_entity_subscription(
                 query_type=SnubaQuery.Type.PERFORMANCE,
@@ -821,7 +821,7 @@ class GetEntityKeyFromSnubaQueryTest(TestCase):
                 )
 
             if supported_with_metrics_layer:
-                with Feature("organizations:use-metrics-layer-in-alerts"):
+                with Feature("organizations:custom-metrics"):
                     assert expected_entity_key == get_entity_key_from_snuba_query(
                         snuba_query, self.organization.id, self.project.id
                     )

--- a/tests/sentry/snuba/test_tasks.py
+++ b/tests/sentry/snuba/test_tasks.py
@@ -702,7 +702,7 @@ class BuildSnqlQueryTest(TestCase):
         )
 
     def test_simple_performance_metrics(self):
-        with Feature("organizations:use-metrics-layer-in-alerts"):
+        with Feature("organizations:custom-metrics"):
             metric_id = resolve(UseCaseID.TRANSACTIONS, self.organization.id, METRICS_MAP["user"])
             self.run_test(
                 SnubaQuery.Type.PERFORMANCE,
@@ -762,7 +762,7 @@ class BuildSnqlQueryTest(TestCase):
         )
 
     def test_aliased_query_performance_metrics(self):
-        with Feature("organizations:use-metrics-layer-in-alerts"):
+        with Feature("organizations:custom-metrics"):
             version = "something"
             self.create_release(self.project, version=version)
             metric_id = resolve(
@@ -835,7 +835,7 @@ class BuildSnqlQueryTest(TestCase):
         )
 
     def test_tag_query_performance_metrics(self):
-        with Feature("organizations:use-metrics-layer-in-alerts"):
+        with Feature("organizations:custom-metrics"):
             # Note: We don't support user queries on the performance metrics dataset, so using a
             # different tag here.
             metric_id = resolve(
@@ -994,7 +994,7 @@ class BuildSnqlQueryTest(TestCase):
         )
 
     def test_simple_sessions_for_metrics(self):
-        with Feature("organizations:use-metrics-layer-in-alerts"):
+        with Feature("organizations:custom-metrics"):
             org_id = self.organization.id
             for tag in [SessionMRI.RAW_SESSION.value, "session.status", "crashed", "init"]:
                 rh_indexer_record(org_id, tag)
@@ -1040,7 +1040,7 @@ class BuildSnqlQueryTest(TestCase):
             )
 
     def test_simple_users_for_metrics(self):
-        with Feature("organizations:use-metrics-layer-in-alerts"):
+        with Feature("organizations:custom-metrics"):
             org_id = self.organization.id
             for tag in [SessionMRI.RAW_USER.value, "session.status", "crashed"]:
                 rh_indexer_record(org_id, tag)
@@ -1073,7 +1073,7 @@ class BuildSnqlQueryTest(TestCase):
             )
 
     def test_query_and_environment_sessions_metrics(self):
-        with Feature("organizations:use-metrics-layer-in-alerts"):
+        with Feature("organizations:custom-metrics"):
             env = self.create_environment(self.project, name="development")
             org_id = self.organization.id
             for tag in [
@@ -1153,7 +1153,7 @@ class BuildSnqlQueryTest(TestCase):
             )
 
     def test_query_and_environment_users_metrics(self):
-        with Feature("organizations:use-metrics-layer-in-alerts"):
+        with Feature("organizations:custom-metrics"):
             env = self.create_environment(self.project, name="development")
             org_id = self.organization.id
             for tag in [


### PR DESCRIPTION
Replacing `use-metrics-layer-in-alerts` with `custom-metrics`