### PR TITLE
fix(replay-onboarding): Adjust Replay onboarding instructions for Astro

### DIFF
--- a/static/app/gettingStartedDocs/javascript/astro.tsx
+++ b/static/app/gettingStartedDocs/javascript/astro.tsx
@@ -18,10 +18,7 @@ import {
   getFeedbackSDKSetupSnippet,
 } from 'sentry/components/onboarding/gettingStartedDoc/utils/feedbackOnboarding';
 import {getJSMetricsOnboarding} from 'sentry/components/onboarding/gettingStartedDoc/utils/metricsOnboarding';
-import {
-  getReplayConfigureDescription,
-  getReplaySDKSetupSnippet,
-} from 'sentry/components/onboarding/gettingStartedDoc/utils/replayOnboarding';
+import {getReplaySDKSetupSnippet} from 'sentry/components/onboarding/gettingStartedDoc/utils/replayOnboarding';
 import {t, tct} from 'sentry/locale';
 
 type Params = DocsParams;
@@ -206,20 +203,74 @@ const onboarding: OnboardingConfig = {
 };
 
 const replayOnboarding: OnboardingConfig = {
-  install: () => getInstallConfig(),
+  install: () => [
+    {
+      ...getInstallConfig()[0],
+      additionalInfo:
+        'Session Replay is enabled by default when you install the Astro SDK!',
+    },
+  ],
   configure: (params: Params) => [
     {
       type: StepType.CONFIGURE,
-      description: getReplayConfigureDescription({
-        link: 'https://docs.sentry.io/platforms/javascript/guides/astro/session-replay/',
-      }),
+      description: tct(
+        'Session Replay is enabled by default when you install the Astro SDK. There are several privacy and sampling options available. Learn more about configuring Session Replay by reading the [link:configuration docs].',
+        {
+          code: <code />,
+          code2: <code />,
+          link: (
+            <ExternalLink
+              href={
+                'https://docs.sentry.io/platforms/javascript/guides/astro/session-replay/'
+              }
+            />
+          ),
+        }
+      ),
       configurations: [
+        {
+          description: tct(
+            'You can set sample rates directly in your [code:astro.config.js] file:',
+            {
+              code: <code />,
+            }
+          ),
+          code: [
+            {
+              label: 'JavaScript',
+              value: 'javascript',
+              language: 'javascript',
+              filename: 'astro.config.js',
+              code: `
+import { defineConfig } from "astro/config";
+import sentry from "@sentry/astro";
+
+export default defineConfig({
+  integrations: [
+    sentry({
+      dsn: "${params.dsn}",
+      replaysSessionSampleRate: 0.2, // defaults to 0.1
+      replaysOnErrorSampleRate: 1.0, // defaults to 1.0
+    }),
+  ],
+});
+              `,
+            },
+          ],
+          additionalInfo: tct(
+            'Further Replay options, like privacy settings, can be set in a [code:sentry.client.config.js] file:',
+            {
+              code: <code />,
+            }
+          ),
+        },
         {
           code: [
             {
               label: 'JavaScript',
               value: 'javascript',
               language: 'javascript',
+              filename: 'sentry.client.config.js',
               code: getReplaySDKSetupSnippet({
                 importStatement: `import * as Sentry from "@sentry/astro";`,
                 dsn: params.dsn,
@@ -228,9 +279,20 @@ const replayOnboarding: OnboardingConfig = {
               }),
             },
           ],
+          additionalInfo: tct(
+            `Note that creating your own [code:sentry.client.config.js] file will override the default settings in your [code2:astro.config.js] file. Learn more about this [link:here].`,
+            {
+              code: <code />,
+              code2: <code />,
+              link: (
+                <ExternalLink href="https://docs.sentry.io/platforms/javascript/guides/astro/manual-setup/#manual-sdk-initialization" />
+              ),
+            }
+          ),
         },
       ],
       additionalInfo: <TracePropagationMessage />,
+      isOptional: true,
     },
   ],
   verify: () => [],

--- a/static/app/gettingStartedDocs/javascript/astro.tsx
+++ b/static/app/gettingStartedDocs/javascript/astro.tsx
@@ -214,10 +214,8 @@ const replayOnboarding: OnboardingConfig = {
     {
       type: StepType.CONFIGURE,
       description: tct(
-        'Session Replay is enabled by default when you install the Astro SDK. There are several privacy and sampling options available. Learn more about configuring Session Replay by reading the [link:configuration docs].',
+        'There are several privacy and sampling options available. Learn more about configuring Session Replay by reading the [link:configuration docs].',
         {
-          code: <code />,
-          code2: <code />,
           link: (
             <ExternalLink
               href={
@@ -272,7 +270,9 @@ export default defineConfig({
               language: 'javascript',
               filename: 'sentry.client.config.js',
               code: getReplaySDKSetupSnippet({
-                importStatement: `import * as Sentry from "@sentry/astro";`,
+                importStatement: `// This file overrides \`astro.config.mjs\` for the browser-side.
+// SDK options from \`astro.config.mjs\` will not apply.
+import * as Sentry from "@sentry/astro";`,
                 dsn: params.dsn,
                 mask: params.replayOptions?.mask,
                 block: params.replayOptions?.block,


### PR DESCRIPTION
This PR adjusts the in-product Replay onboarding doc by:

- stating that Replay is enabled by default in the Astro SDK (=> configuration becomes optional)
- diffrentiating between which options can be set in the simple `astro.config.mjs` vs which options can only be set by creating a dedicated `sentry.client.config.js` file. 
- Adjusting text as necessary.

Before (taken from https://github.com/getsentry/sentry-javascript/issues/12408): 

![image](https://github.com/getsentry/sentry/assets/8420481/90b1b378-2191-4f7d-96a1-470e81eb7962)

After:
![image](https://github.com/getsentry/sentry/assets/8420481/8b163683-573a-4ff0-9132-a9497e7f5e75)


closes https://github.com/getsentry/sentry-javascript/issues/12408

cc @whitep4nth3r 