### PR TITLE
feat(metrics): use new meta tables to query MRI-based metrics, retain old API for non-MRI metrics and track

### DIFF
--- a/src/sentry/api/endpoints/organization_metrics_tags.py
+++ b/src/sentry/api/endpoints/organization_metrics_tags.py
@@ -13,6 +13,7 @@ from sentry.sentry_metrics.querying.metadata.tags import get_tag_keys
 from sentry.sentry_metrics.use_case_utils import get_use_case_id
 from sentry.snuba.metrics import (
     DerivedMetricParseException,
+    MetricDoesNotExistException,
     MetricDoesNotExistInIndexer,
     get_all_tags,
     get_mri,
@@ -64,7 +65,7 @@ class OrganizationMetricsTagsEndpoint(OrganizationEndpoint):
         except (InvalidParams, DerivedMetricParseException) as exc:
             raise (ParseError(detail=str(exc)))
 
-        except MetricDoesNotExistInIndexer:
-            raise NotFound(f"One of the specified metrics was not found: {metric_names}")
+        except (MetricDoesNotExistInIndexer, MetricDoesNotExistException):
+            raise NotFound(f"The specified metric was not found: {metric_name}")
 
         return Response(formatted_tags, status=200)

--- a/src/sentry/api/endpoints/organization_metrics_tags.py
+++ b/src/sentry/api/endpoints/organization_metrics_tags.py
@@ -54,7 +54,7 @@ class OrganizationMetricsTagsEndpoint(OrganizationEndpoint):
                 # If metric_name starts with "e:", and therefore is a derived metric, use the old get_all_tags functionality
                 # This branch should be deleted eventually.
                 sentry_sdk.capture_message("organization_metrics_tags.non-mri-metric-name")
-                formatted_tags = get_all_tags(
+                formatted_tags: Sequence[Tag] = get_all_tags(
                     projects, [metric_name], use_case_id=get_use_case_id(request)
                 )
 
@@ -66,7 +66,7 @@ class OrganizationMetricsTagsEndpoint(OrganizationEndpoint):
                     mri=metric_name,
                 )
                 tags.append("project")
-                formatted_tags: Sequence[Tag] = [Tag(key=tag) for tag in set(tags)]
+                formatted_tags = [Tag(key=tag) for tag in set(tags)]
 
         except (InvalidParams, DerivedMetricParseException) as exc:
             raise (ParseError(detail=str(exc)))

--- a/src/sentry/api/endpoints/organization_metrics_tags.py
+++ b/src/sentry/api/endpoints/organization_metrics_tags.py
@@ -1,3 +1,5 @@
+from collections.abc import Sequence
+
 import sentry_sdk
 from rest_framework.exceptions import NotFound, ParseError
 from rest_framework.request import Request
@@ -15,6 +17,7 @@ from sentry.snuba.metrics import (
     DerivedMetricParseException,
     MetricDoesNotExistException,
     MetricDoesNotExistInIndexer,
+    Tag,
     get_all_tags,
     get_mri,
 )
@@ -55,7 +58,7 @@ class OrganizationMetricsTagsEndpoint(OrganizationEndpoint):
                     mri=metric_name,
                 )
                 tags.append("project")
-                formatted_tags = [{"key": tag} for tag in set(tags)]
+                formatted_tags: Sequence[Tag] = [Tag(key=tag) for tag in set(tags)]
 
             else:
                 sentry_sdk.capture_message("organization_metrics_tags.non-mri-metric-name")

--- a/src/sentry/api/endpoints/organization_metrics_tags.py
+++ b/src/sentry/api/endpoints/organization_metrics_tags.py
@@ -1,3 +1,4 @@
+import sentry_sdk
 from rest_framework.exceptions import NotFound, ParseError
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -7,14 +8,16 @@ from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases import OrganizationAndStaffPermission, OrganizationEndpoint
 from sentry.api.exceptions import BadRequest
-from sentry.api.utils import get_date_range_from_params
 from sentry.exceptions import InvalidParams
+from sentry.sentry_metrics.querying.metadata.tags import get_tag_keys
 from sentry.sentry_metrics.use_case_utils import get_use_case_id
 from sentry.snuba.metrics import (
     DerivedMetricParseException,
     MetricDoesNotExistInIndexer,
     get_all_tags,
+    get_mri,
 )
+from sentry.snuba.metrics.naming_layer.mri import extract_use_case_id, is_mri
 
 
 @region_silo_endpoint
@@ -26,12 +29,8 @@ class OrganizationMetricsTagsEndpoint(OrganizationEndpoint):
     permission_classes = (OrganizationAndStaffPermission,)
 
     """Get list of tag names for this project
-
-    If the ``metric`` query param is provided, only tags for a certain metric
-    are provided.
-
-    If the ``metric`` query param is provided more than once, the *intersection*
-    of available tags is used.
+    The ``metric``query param must be provided and can only be a single metric name or MRI. Providing either
+    no metric or more than one will produce an HTTP 400 error.
     """
 
     def get(self, request: Request, organization) -> Response:
@@ -40,23 +39,32 @@ class OrganizationMetricsTagsEndpoint(OrganizationEndpoint):
         if not projects:
             raise InvalidParams("You must supply at least one project to see the tag names")
 
-        if len(metric_names) > 1:
-            raise BadRequest(message="Please provide only a single metric name.")
-
-        start, end = get_date_range_from_params(request.GET)
+        if len(metric_names) != 1:
+            raise BadRequest(message="Please provide a single metric to query its tags.")
 
         try:
-            tags = get_all_tags(
-                projects=projects,
-                metric_names=metric_names,
-                use_case_id=get_use_case_id(request),
-                start=start,
-                end=end,
-            )
+            metric_name = metric_names[0]
+            # If metric_name is a valid MRI, use the snuba meta table for tags.
+            # If metric_name corresponds to some legacy type of metric, use the old get_all_tags functionality
+            if is_mri(metric_name):
+                tags = get_tag_keys(
+                    organization=organization,
+                    projects=projects,
+                    use_case_ids=[extract_use_case_id(metric_name)],
+                    mri=metric_name,
+                )
+                tags.append("project")
+                formatted_tags = [{"key": tag} for tag in set(tags)]
+
+            else:
+                sentry_sdk.capture_message("organization_metrics_tags.non-mri-metric-name")
+                mri = get_mri(metric_name)
+                formatted_tags = get_all_tags(projects, [mri], use_case_id=get_use_case_id(request))
+
         except (InvalidParams, DerivedMetricParseException) as exc:
             raise (ParseError(detail=str(exc)))
 
         except MetricDoesNotExistInIndexer:
             raise NotFound(f"One of the specified metrics was not found: {metric_names}")
 
-        return Response(tags, status=200)
+        return Response(formatted_tags, status=200)

--- a/src/sentry/sentry_metrics/querying/metadata/tags.py
+++ b/src/sentry/sentry_metrics/querying/metadata/tags.py
@@ -20,7 +20,7 @@ def get_tag_keys(
     organization: Organization,
     projects: Sequence[Project],
     use_case_ids: Sequence[UseCaseID],
-    mris: list[str],
+    mri: str,
 ) -> list[str]:
     """
     Get all available tag keys for a given MRI, specified projects and use_case_ids.
@@ -28,13 +28,10 @@ def get_tag_keys(
     """
     all_tag_keys: set[str] = set()
     project_ids = [project.id for project in projects]
-    for mri in mris:
-        for use_case_id in use_case_ids:
-            tag_keys_per_project = fetch_metric_tag_keys(
-                organization.id, project_ids, use_case_id, mri
-            )
-            for tag_keys in tag_keys_per_project.values():
-                all_tag_keys = all_tag_keys.union(tag_keys)
+    for use_case_id in use_case_ids:
+        tag_keys_per_project = fetch_metric_tag_keys(organization.id, project_ids, use_case_id, mri)
+        for tag_keys in tag_keys_per_project.values():
+            all_tag_keys = all_tag_keys.union(tag_keys)
 
     return sorted(list(all_tag_keys))
 

--- a/src/sentry/snuba/metrics_layer/query.py
+++ b/src/sentry/snuba/metrics_layer/query.py
@@ -38,7 +38,7 @@ from sentry.sentry_metrics.utils import (
 from sentry.snuba.dataset import Dataset
 from sentry.snuba.metrics.naming_layer.mapping import get_mri
 from sentry.snuba.metrics.naming_layer.mri import parse_mri
-from sentry.snuba.metrics.utils import to_intervals
+from sentry.snuba.metrics.utils import MetricDoesNotExistException, to_intervals
 from sentry.utils import metrics
 from sentry.utils.snuba import bulk_snuba_queries
 
@@ -569,7 +569,7 @@ def _query_meta_table(
         column_name = "tag_key"
         metric_id = resolve_weak(use_case_id, org_id, mri)
         if metric_id == -1:
-            raise InvalidParams(f"Unknown metric: {mri}")
+            raise MetricDoesNotExistException(f"Unknown metric: {mri}")
         extra_condition = Condition(Column("metric_id"), Op.EQ, metric_id)
     else:
         column_name = "metric_id"

--- a/tests/sentry/api/endpoints/test_organization_metrics_tags.py
+++ b/tests/sentry/api/endpoints/test_organization_metrics_tags.py
@@ -1,143 +1,153 @@
 import time
-from collections.abc import Collection
 from datetime import timedelta
 from unittest.mock import patch
 
 import pytest
 
-from sentry.sentry_metrics import indexer
 from sentry.sentry_metrics.use_case_id_registry import UseCaseID
-from sentry.snuba.metrics.naming_layer.mri import SessionMRI
-from sentry.snuba.metrics.naming_layer.public import SessionMetricKey
-from sentry.testutils.cases import MetricsAPIBaseTestCase, OrganizationMetricsIntegrationTestCase
+from sentry.snuba.metrics import TransactionMRI
+from sentry.testutils.cases import MetricsAPIBaseTestCase
+from sentry.testutils.helpers.datetime import freeze_time
 from tests.sentry.api.endpoints.test_organization_metrics import MOCKED_DERIVED_METRICS
 
 pytestmark = pytest.mark.sentry_metrics
 
 
-def mocked_bulk_reverse_resolve(use_case_id, org_id: int, ids: Collection[int]):
-    return {}
+@freeze_time(MetricsAPIBaseTestCase.MOCK_DATETIME)
+class OrganizationMetricsTagsIntegrationTest(MetricsAPIBaseTestCase):
 
-
-class OrganizationMetricsTagsTest(OrganizationMetricsIntegrationTestCase):
     endpoint = "sentry-api-0-organization-metrics-tags"
 
-    @property
+    def setUp(self):
+        super().setUp()
+        self.login_as(self.user)
+
+        release_1 = self.create_release(
+            project=self.project, version="1.0", date_added=MetricsAPIBaseTestCase.MOCK_DATETIME
+        )
+        release_2 = self.create_release(
+            project=self.project,
+            version="2.0",
+            date_added=MetricsAPIBaseTestCase.MOCK_DATETIME + timedelta(minutes=5),
+        )
+
+        # Use Case: TRANSACTIONS
+        for value, transaction, platform, env, release, timestamp in (
+            (1, "/hello", "android", "prod", release_1.version, self.now()),
+            (6, "/hello", "ios", "dev", release_2.version, self.now()),
+            (5, "/world", "windows", "prod", release_1.version, self.now() + timedelta(minutes=30)),
+            (3, "/hello", "ios", "dev", release_2.version, self.now() + timedelta(hours=1)),
+            (2, "/hello", "android", "dev", release_1.version, self.now() + timedelta(hours=1)),
+            (
+                4,
+                "/world",
+                "windows",
+                "prod",
+                release_2.version,
+                self.now() + timedelta(hours=1, minutes=30),
+            ),
+        ):
+            self.store_metric(
+                self.project.organization.id,
+                self.project.id,
+                "distribution",
+                TransactionMRI.DURATION.value,
+                {
+                    "transaction": transaction,
+                    "platform": platform,
+                    "environment": env,
+                    "release": release,
+                },
+                timestamp.timestamp(),
+                value,
+                UseCaseID.TRANSACTIONS,
+            )
+        # Use Case: CUSTOM
+        for value, release, tag_value, timestamp in (
+            (1, release_1.version, "tag_value_1", self.now()),
+            (1, release_1.version, "tag_value_1", self.now()),
+            (1, release_1.version, "tag_value_2", self.now() - timedelta(days=40)),
+            (1, release_2.version, "tag_value_3", self.now() - timedelta(days=50)),
+            (1, release_2.version, "tag_value_4", self.now() - timedelta(days=60)),
+        ):
+            self.store_metric(
+                self.project.organization.id,
+                self.project.id,
+                "distribution",
+                "d:custom/my_test_metric@percent",
+                {
+                    "transaction": "/hello",
+                    "platform": "platform",
+                    "environment": "prod",
+                    "release": release,
+                    "mytag": tag_value,
+                },
+                timestamp.timestamp(),
+                value,
+                UseCaseID.CUSTOM,
+            )
+
+        self.prod_env = self.create_environment(name="prod", project=self.project)
+        self.dev_env = self.create_environment(name="dev", project=self.project)
+
     def now(self):
         return MetricsAPIBaseTestCase.MOCK_DATETIME
 
     def test_metric_tags(self):
         response = self.get_success_response(
-            self.organization.slug,
+            self.organization.slug, metric=[TransactionMRI.DURATION.value]
         )
-        assert response.data == [
-            {"key": "tag1"},
-            {"key": "tag2"},
-            {"key": "tag3"},
-            {"key": "tag4"},
+        assert sorted(response.data, key=lambda x: x["key"]) == [
+            {"key": "environment"},
+            {"key": "platform"},
             {"key": "project"},
+            {"key": "release"},
+            {"key": "transaction"},
         ]
 
-    def test_multiple_metrics_tags(self):
+    def test_no_metric_in_request(self):
         response = self.get_response(
             self.organization.slug,
-        )
-        assert response.data == [
-            {"key": "tag1"},
-            {"key": "tag2"},
-            {"key": "tag3"},
-            {"key": "tag4"},
-            {"key": "project"},
-        ]
-
-        response = self.get_response(
-            self.organization.slug,
-            metric=["d:transactions/duration@millisecond", "d:sessions/duration.exited@second"],
-            useCase="transactions",
         )
         assert response.status_code == 400
-        assert response.json()["detail"]["message"] == "Please provide only a single metric name."
+        assert (
+            response.json()["detail"]["message"]
+            == "Please provide a single metric to query its tags."
+        )
 
-    @patch(
-        "sentry.snuba.metrics.datasource.bulk_reverse_resolve",
-        mocked_bulk_reverse_resolve,
-    )
-    def test_unknown_tag(self):
-        response = self.get_success_response(
+    def test_multiple_metrics_in_request(self):
+        response = self.get_response(
             self.organization.slug,
+            metric=["metric1", "metric2"],
         )
-        assert response.data == [{"key": "project"}]
+        assert response.status_code == 400
+        assert (
+            response.json()["detail"]["message"]
+            == "Please provide a single metric to query its tags."
+        )
 
-    def test_staff_session_metric_tags(self):
-        staff_user = self.create_user(is_staff=True)
-        self.login_as(user=staff_user, staff=True)
+    def test_metric_tags_metric_does_not_exist_in_indexer(self):
 
-        self.store_session(
-            self.build_session(
-                project_id=self.project.id,
-                started=(time.time() // 60) * 60,
-                status="ok",
-                release="foobar@2.0",
-            )
-        )
-        response = self.get_success_response(
-            self.organization.slug,
-        )
-        assert response.data == [
-            {"key": "environment"},
-            {"key": "release"},
-            {"key": "tag1"},
-            {"key": "tag2"},
-            {"key": "tag3"},
-            {"key": "tag4"},
-            {"key": "project"},
-        ]
-
-    def test_session_metric_tags(self):
-        self.store_session(
-            self.build_session(
-                project_id=self.project.id,
-                started=(time.time() // 60) * 60,
-                status="ok",
-                release="foobar@2.0",
-            )
-        )
-        response = self.get_success_response(
-            self.organization.slug,
-        )
-        assert response.data == [
-            {"key": "environment"},
-            {"key": "release"},
-            {"key": "tag1"},
-            {"key": "tag2"},
-            {"key": "tag3"},
-            {"key": "tag4"},
-            {"key": "project"},
-        ]
-
-    def test_metric_tags_metric_does_not_exist_in_naming_layer(self):
         response = self.get_response(
             self.organization.slug,
             metric=["foo.bar"],
         )
-        assert response.data == []
+        assert response.status_code == 400
+        assert (
+            response.data["detail"]
+            == "Failed to parse 'foo.bar'. The metric name must belong to a public metric."
+        )
 
     def test_metric_tags_metric_does_not_have_data(self):
-        indexer.record(
-            use_case_id=UseCaseID.SESSIONS,
-            org_id=self.organization.id,
-            string=SessionMRI.RAW_SESSION.value,
-        )
         response = self.get_response(
             self.organization.slug,
-            metric=[SessionMetricKey.CRASH_FREE_RATE.value],
+            metric=["foo.bar"],
         )
+        assert response.status_code == 400
         assert (
             response.json()["detail"]
-            == "The following metrics ['e:sessions/crash_free_rate@ratio'] do not exist in the dataset"
+            == "Failed to parse 'foo.bar'. The metric name must belong to a public metric."
         )
-
-        assert response.status_code == 404
 
     def test_derived_metric_tags(self):
         self.store_session(
@@ -152,7 +162,28 @@ class OrganizationMetricsTagsTest(OrganizationMetricsIntegrationTestCase):
             self.organization.slug,
             metric=["session.crash_free_rate"],
         )
+        assert response.status_code == 200
         assert response.data == [{"key": "environment"}, {"key": "release"}, {"key": "project"}]
+
+    def test_multiple_derived_metric_tags(self):
+        self.store_session(
+            self.build_session(
+                project_id=self.project.id,
+                started=(time.time() // 60) * 60,
+                status="ok",
+                release="foobar@2.0",
+            )
+        )
+
+        response = self.get_response(
+            self.organization.slug,
+            metric=["session.crash_free_rate", "session.all"],
+        )
+        assert response.status_code == 400
+        assert (
+            response.json()["detail"]["message"]
+            == "Please provide a single metric to query its tags."
+        )
 
     def test_composite_derived_metrics(self):
         for minute in range(4):
@@ -167,15 +198,13 @@ class OrganizationMetricsTagsTest(OrganizationMetricsIntegrationTestCase):
             )
         response = self.get_success_response(
             self.organization.slug,
-            metric=[SessionMetricKey.HEALTHY.value],
+            metric=["session.healthy"],
         )
         assert response.data == [{"key": "environment"}, {"key": "release"}, {"key": "project"}]
 
     @patch("sentry.snuba.metrics.fields.base.DERIVED_METRICS", MOCKED_DERIVED_METRICS)
-    @patch("sentry.snuba.metrics.datasource.get_mri")
     @patch("sentry.snuba.metrics.datasource.get_derived_metrics")
-    def test_incorrectly_setup_derived_metric(self, mocked_derived_metrics, mocked_mri):
-        mocked_mri.return_value = "crash_free_fake"
+    def test_incorrectly_setup_derived_metric(self, mocked_derived_metrics):
         mocked_derived_metrics.return_value = MOCKED_DERIVED_METRICS
         self.store_session(
             self.build_session(
@@ -191,71 +220,7 @@ class OrganizationMetricsTagsTest(OrganizationMetricsIntegrationTestCase):
             metric=["crash_free_fake"],
         )
         assert response.status_code == 400
-        assert response.json()["detail"] == (
-            "The following metrics {'crash_free_fake'} cannot be computed from single entities. "
-            "Please revise the definition of these singular entity derived metrics"
-        )
-
-    def test_metric_tags_with_date_range(self):
-        mri = "c:custom/clicks@none"
-        tags = (
-            ("transaction", "/hello", 0),
-            ("release", "1.0", 1),
-            ("environment", "prod", 7),
-        )
-        for tag_name, tag_value, days in tags:
-            self.store_metric(
-                self.project.organization.id,
-                self.project.id,
-                "counter",
-                mri,
-                {tag_name: tag_value},
-                int((self.now - timedelta(days=days)).timestamp()),
-                10,
-                UseCaseID.CUSTOM,
-            )
-
-        for stats_period, expected_count in (("1d", 2), ("2d", 3), ("2w", 4)):
-            response = self.get_success_response(
-                self.organization.slug,
-                metric=[mri],
-                project=self.project.id,
-                useCase="custom",
-                statsPeriod=stats_period,
-            )
-            assert len(response.data) == expected_count
-
-    def test_metric_tags_with_gauge(self):
-        mri = "g:custom/page_load@millisecond"
-        self.store_metric(
-            self.project.organization.id,
-            self.project.id,
-            "gauge",
-            mri,
-            {"transaction": "/hello", "release": "1.0", "environment": "prod"},
-            int(self.now.timestamp()),
-            10,
-            UseCaseID.CUSTOM,
-        )
-
-        response = self.get_success_response(
-            self.organization.slug,
-            metric=[mri],
-            project=self.project.id,
-            useCase="custom",
-        )
-        assert len(response.data) == 4
-
-    def test_metric_not_in_indexer(self):
-        mri = "c:custom/sentry_metric@none"
-        response = self.get_response(
-            self.organization.slug,
-            metric=[mri],
-            project=self.project.id,
-            useCase="custom",
-        )
         assert (
             response.json()["detail"]
-            == "One of the specified metrics was not found: ['c:custom/sentry_metric@none']"
+            == "Failed to parse 'crash_free_fake'. The metric name must belong to a public metric."
         )
-        assert response.status_code == 404


### PR DESCRIPTION
We want to use the new meta tables for querying for metrics tags. 
There are multiple cases that need to be handled: 
1. MRIs that are correctly parseable and correspond to one of the metric types c:, s:, d:, g:
2. MRIs that are correctly parseable, but correspond to the derived metric type e:
3. Metric names that are not parseable as MRIs 

Case 1 can use the new meta tables
Case 2 is not contained in the new meta tables, and should therefore still use the old function
Case 3 will not be supported at all anymore - only valid MRIs are allowed