### PR TITLE
ref: M typevar is covariant

### DIFF
--- a/src/sentry/db/models/manager/__init__.py
+++ b/src/sentry/db/models/manager/__init__.py
@@ -8,7 +8,7 @@ from sentry.utils.hashlib import md5_text
 
 __all__ = ("BaseManager", "BaseQuerySet", "OptionManager", "M", "Value", "ValidateFunction")
 
-M = TypeVar("M", bound=Model)
+M = TypeVar("M", bound=Model, covariant=True)
 Value = Any
 ValidateFunction = Callable[[Value], bool]
 


### PR DESCRIPTION
this matches what django-stubs sets here, and makes inheritance work better

when fixing typing for our BaseManager this fixes ~80 errors of the form:

```diff
-src/sentry/discover/models.py:166: error: Incompatible types in assignment (expression has type "TeamKeyTransactionModelManager", base class "Model" defined the type as "BaseManager[Model]")  [assignment]
```

<!-- Describe your PR here. -->