### PR TITLE
fix(traces): Include all points in graph

### DIFF
--- a/static/app/views/traces/tracesChart.tsx
+++ b/static/app/views/traces/tracesChart.tsx
@@ -64,6 +64,7 @@ export function TracesChart({}: Props) {
           tooltipFormatterOptions={{
             valueFormatter: value => formatAbbreviatedNumber(value),
           }}
+          preserveIncompletePoints
         />
       </ChartPanel>
     </ChartContainer>


### PR DESCRIPTION
### Summary
This leaves all points visible in your graph, and doesn't cut off the last bucket.


### Screenshots
#### Before
<img width="1099" alt="Screenshot 2024-06-10 at 10 30 53 AM" src="https://github.com/getsentry/sentry/assets/6111995/5a472b9e-a83b-49b0-918b-a89e0a6c117d">
#### After 

![Screenshot 2024-06-10 at 10 30 24 AM](https://github.com/getsentry/sentry/assets/6111995/7ea79b05-db0e-48b3-b784-0d82cd9c0c22)
