### PR TITLE
fix(trace): eval AND before OR in operator precedence

### DIFF
--- a/static/app/components/searchSyntax/evaluator.tsx
+++ b/static/app/components/searchSyntax/evaluator.tsx
@@ -98,8 +98,8 @@ function processTokenResults(tokens: TokenResult<Token>[]): ProcessedTokenResult
   return withImplicitAnd;
 }
 
-function isBooleanOR(token: ProcessedTokenResult): boolean {
-  return token?.type === Token.LOGIC_BOOLEAN && token?.value === BooleanOperator.OR;
+function isBooleanAND(token: ProcessedTokenResult): boolean {
+  return token?.type === Token.LOGIC_BOOLEAN && token?.value === BooleanOperator.AND;
 }
 
 // https://en.wikipedia.org/wiki/Shunting_yard_algorithm
@@ -113,13 +113,14 @@ export function toPostFix(tokens: TokenResult<Token>[]): ProcessedTokenResult[] 
     switch (token.type) {
       case Token.LOGIC_BOOLEAN: {
         while (
-          // Establishes higher precedence for OR operators.
-          // Whenever the current stack top operator is an OR,
+          // Establishes higher precedence for AND operators.
+          // Whenever the current operator is an OR and the top of the stack is an AND,
+          // we need to pop the AND operator from the stack and push it to the output.
           stack.length > 0 &&
-          token.value === BooleanOperator.AND &&
+          token.value === BooleanOperator.OR &&
           stack[stack.length - 1].type === Token.LOGIC_BOOLEAN &&
           stack[stack.length - 1].type !== 'L_PAREN' &&
-          isBooleanOR(stack[stack.length - 1])
+          isBooleanAND(stack[stack.length - 1])
         ) {
           result.push(stack.pop()!);
         }

--- a/static/app/views/performance/newTraceDetails/traceSearch/traceSearchEvaluator.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceSearch/traceSearchEvaluator.spec.tsx
@@ -141,9 +141,7 @@ describe('TraceSearchEvaluator', () => {
     ]);
 
     const cb = jest.fn();
-    // @TODO check if this makes sense with some users. We might only want to do this only if we have a set of parens.
     search(
-      // (transaction.op:operation OR transaction.op:other) AND transaction:something
       'transaction.op:operation AND transaction:something OR transaction.op:other',
       tree,
       cb
@@ -151,8 +149,11 @@ describe('TraceSearchEvaluator', () => {
     await waitFor(() => {
       expect(cb).toHaveBeenCalled();
     });
-    expect(cb.mock.calls[0][0][1].size).toBe(1);
-    expect(cb.mock.calls[0][0][0]).toEqual([{index: 0, value: tree.list[0]}]);
+    expect(cb.mock.calls[0][0][1].size).toBe(2);
+    expect(cb.mock.calls[0][0][0]).toEqual([
+      {index: 0, value: tree.list[0]},
+      {index: 1, value: tree.list[1]},
+    ]);
     expect(cb.mock.calls[0][0][2]).toBe(null);
   });
 


### PR DESCRIPTION
This was wrong. We want AND to be evaluated before OR