### PR TITLE
feat(traces): Use traces-stats endpoint

### DIFF
--- a/static/app/views/starfish/queries/useDiscoverSeries.ts
+++ b/static/app/views/starfish/queries/useDiscoverSeries.ts
@@ -21,6 +21,7 @@ export interface MetricTimeseriesRow {
 interface UseMetricsSeriesOptions<Fields> {
   enabled?: boolean;
   interval?: string;
+  overriddenRoute?: string;
   referrer?: string;
   search?: MutableSearch;
   yAxis?: Fields;
@@ -79,6 +80,7 @@ const useDiscoverSeries = <T extends string[]>(
     initialData: [],
     referrer,
     enabled: options.enabled,
+    overriddenRoute: options.overriddenRoute,
   });
 
   const parsedData = keyBy(

--- a/static/app/views/starfish/utils/useSpansQuery.tsx
+++ b/static/app/views/starfish/utils/useSpansQuery.tsx
@@ -66,11 +66,13 @@ export function useWrappedDiscoverTimeseriesQuery<T>({
   initialData,
   referrer,
   cursor,
+  overriddenRoute,
 }: {
   eventView: EventView;
   cursor?: string;
   enabled?: boolean;
   initialData?: any;
+  overriddenRoute?: string;
   referrer?: string;
 }) {
   const location = useLocation();
@@ -83,7 +85,7 @@ export function useWrappedDiscoverTimeseriesQuery<T>({
     },
     DiscoverQueryProps
   >({
-    route: 'events-stats',
+    route: overriddenRoute ?? 'events-stats',
     eventView,
     location,
     orgSlug: organization.slug,

--- a/static/app/views/traces/tracesChart.tsx
+++ b/static/app/views/traces/tracesChart.tsx
@@ -3,7 +3,8 @@ import styled from '@emotion/styled';
 
 import {getInterval} from 'sentry/components/charts/utils';
 import {t} from 'sentry/locale';
-import {formatAbbreviatedNumber} from 'sentry/utils/formatters';
+import {RateUnit} from 'sentry/utils/discover/fields';
+import {formatRate} from 'sentry/utils/formatters';
 import {decodeList} from 'sentry/utils/queryString';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {useLocation} from 'sentry/utils/useLocation';
@@ -36,12 +37,12 @@ export function TracesChart({}: Props) {
       ),
       yAxis: ['count()'],
       interval: getInterval(pageFilters.selection.datetime, 'metrics'),
+      overriddenRoute: 'traces-stats',
     },
-    'testing.test'
+    'api.trace-explorer.stats'
   );
 
   const seriesData = spanIndexedCountSeries.data?.['count()'];
-  seriesData.z = 1; // TODO:: This shouldn't be required, but we're putting this in for now to avoid split lines being shown on top of the chart data :).
 
   return (
     <ChartContainer>
@@ -62,7 +63,7 @@ export function TracesChart({}: Props) {
           type={ChartType.AREA}
           aggregateOutputFormat="number"
           tooltipFormatterOptions={{
-            valueFormatter: value => formatAbbreviatedNumber(value),
+            valueFormatter: value => formatRate(value, RateUnit.PER_MINUTE),
           }}
         />
       </ChartPanel>


### PR DESCRIPTION
### Summary
This uses the traces-stats endpoint and fixes the referrer.

Traces-stats is required since we need to do a multi-project event stats search on spans, but we don't want to expose this api outside of the specific use case of trace explorer.
