### PR TITLE
fix(similarity): Filter out null from event title

### DIFF
--- a/src/sentry/grouping/ingest/seer.py
+++ b/src/sentry/grouping/ingest/seer.py
@@ -10,7 +10,11 @@ from sentry.models.group import Group
 from sentry.models.project import Project
 from sentry.seer.similarity.similar_issues import get_similarity_data_from_seer
 from sentry.seer.similarity.types import SeerSimilarIssuesMetadata, SimilarIssuesEmbeddingsRequest
-from sentry.seer.similarity.utils import event_content_is_seer_eligible, get_stacktrace_string
+from sentry.seer.similarity.utils import (
+    event_content_is_seer_eligible,
+    filter_null_from_event_title,
+    get_stacktrace_string,
+)
 from sentry.utils import metrics
 
 logger = logging.getLogger("sentry.events.grouping")
@@ -163,7 +167,7 @@ def get_seer_similar_issues(
         "hash": event_hash,
         "project_id": event.project.id,
         "stacktrace": stacktrace_string,
-        "message": event.title,
+        "message": filter_null_from_event_title(event.title),
         "k": num_neighbors,
     }
 

--- a/src/sentry/seer/similarity/utils.py
+++ b/src/sentry/seer/similarity/utils.py
@@ -97,3 +97,10 @@ def event_content_is_seer_eligible(event: Event) -> bool:
         return False
 
     return True
+
+
+def filter_null_from_event_title(title: str) -> str:
+    """
+    Filter out null bytes from event title so that it can be saved in records table.
+    """
+    return title.replace("\x00", "")

--- a/src/sentry/tasks/backfill_seer_grouping_records.py
+++ b/src/sentry/tasks/backfill_seer_grouping_records.py
@@ -31,7 +31,7 @@ from sentry.seer.similarity.types import (
     SeerSimilarIssueData,
     SimilarGroupNotFoundError,
 )
-from sentry.seer.similarity.utils import get_stacktrace_string
+from sentry.seer.similarity.utils import filter_null_from_event_title, get_stacktrace_string
 from sentry.silo.base import SiloMode
 from sentry.snuba.dataset import Dataset
 from sentry.snuba.referrer import Referrer
@@ -463,7 +463,7 @@ def lookup_group_data_stacktrace_bulk(
                         CreateGroupingRecordData(
                             group_id=group_id,
                             project_id=project_id,
-                            message=event.title,
+                            message=filter_null_from_event_title(event.title),
                             hash=primary_hash,
                         )
                     )
@@ -536,7 +536,7 @@ def lookup_group_data_stacktrace_single(
                     group_id=group_id,
                     hash=primary_hash,
                     project_id=project_id,
-                    message=event.title,
+                    message=filter_null_from_event_title(event.title),
                 )
                 if stacktrace_string != ""
                 else None

--- a/tests/sentry/seer/similarity/test_utils.py
+++ b/tests/sentry/seer/similarity/test_utils.py
@@ -7,6 +7,7 @@ from sentry.eventstore.models import Event
 from sentry.seer.similarity.utils import (
     SEER_ELIGIBLE_PLATFORMS,
     event_content_is_seer_eligible,
+    filter_null_from_event_title,
     get_stacktrace_string,
 )
 from sentry.testutils.cases import TestCase
@@ -653,3 +654,7 @@ class EventContentIsSeerEligibleTest(TestCase):
         assert bad_event_data["platform"] not in SEER_ELIGIBLE_PLATFORMS
         assert event_content_is_seer_eligible(good_event) is True
         assert event_content_is_seer_eligible(bad_event) is False
+
+    def test_filter_null_from_event_title(self):
+        title_with_null = 'Title with null \x00, "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00" is null'
+        assert filter_null_from_event_title(title_with_null) == 'Title with null , "" is null'


### PR DESCRIPTION
Filter out null byte from event title since it cannot be saved in records table

fixes [SEER-63](https://sentry.sentry.io/issues/5473319314/)