### PR TITLE
ref: replace .all().first() with .get() or in some cases [0] in tests

### DIFF
--- a/tests/sentry/backup/test_imports.py
+++ b/tests/sentry/backup/test_imports.py
@@ -1416,7 +1416,7 @@ class CollisionTests(ImportTestCase):
 
         # Take note of a `Monitor` that was created by the exhaustive organization - this is the
         # one we'll be importing.
-        colliding = Monitor.objects.filter().first()
+        colliding = Monitor.objects.get()
 
         with tempfile.TemporaryDirectory() as tmp_dir:
             tmp_path = self.export_to_tmp_file_and_clear_database(tmp_dir)
@@ -1449,7 +1449,7 @@ class CollisionTests(ImportTestCase):
         # Take note of the `OrgAuthToken` that was created by the exhaustive organization - this is
         # the one we'll be importing.
         with assume_test_silo_mode(SiloMode.CONTROL):
-            colliding = OrgAuthToken.objects.filter().first()
+            colliding = OrgAuthToken.objects.get()
 
         with tempfile.TemporaryDirectory() as tmp_dir:
             tmp_path = self.export_to_tmp_file_and_clear_database(tmp_dir)
@@ -1497,7 +1497,7 @@ class CollisionTests(ImportTestCase):
 
         # Take note of a `ProjectKey` that was created by the exhaustive organization - this is the
         # one we'll be importing.
-        colliding = ProjectKey.objects.filter().first()
+        colliding = ProjectKey.objects.all()[0]
 
         with tempfile.TemporaryDirectory() as tmp_dir:
             tmp_path = self.export_to_tmp_file_and_clear_database(tmp_dir)
@@ -1539,10 +1539,10 @@ class CollisionTests(ImportTestCase):
 
             # Take note of the `QuerySubscription` that was created by the exhaustive organization -
             # this is the one we'll be importing.
-            colliding_snuba_query = SnubaQuery.objects.all().first()
-            colliding_query_subscription = QuerySubscription.objects.filter(
+            colliding_snuba_query = SnubaQuery.objects.all()[0]
+            colliding_query_subscription = QuerySubscription.objects.get(
                 snuba_query=colliding_snuba_query
-            ).first()
+            )
 
             with tempfile.TemporaryDirectory() as tmp_dir:
                 tmp_path = self.export_to_tmp_file_and_clear_database(tmp_dir)
@@ -1616,16 +1616,16 @@ class CollisionTests(ImportTestCase):
         self.create_exhaustive_global_configs(owner)
 
         # Take note of the configs we want to track - this is the one we'll be importing.
-        colliding_option = Option.objects.all().first()
-        colliding_relay = Relay.objects.all().first()
-        colliding_relay_usage = RelayUsage.objects.all().first()
+        colliding_option = Option.objects.get()
+        colliding_relay = Relay.objects.get()
+        colliding_relay_usage = RelayUsage.objects.get()
 
         old_relay_public_key = colliding_relay.public_key
         old_relay_usage_public_key = colliding_relay_usage.public_key
 
         with assume_test_silo_mode(SiloMode.CONTROL):
-            colliding_control_option = ControlOption.objects.all().first()
-            colliding_user_role = UserRole.objects.all().first()
+            colliding_control_option = ControlOption.objects.get()
+            colliding_user_role = UserRole.objects.get()
             old_user_role_permissions = colliding_user_role.permissions
 
         with tempfile.TemporaryDirectory() as tmp_dir:
@@ -1696,7 +1696,7 @@ class CollisionTests(ImportTestCase):
                 assert ControlOption.objects.count() == 1
                 assert ControlOption.objects.filter(value__exact="b").exists()
 
-                actual_user_role = UserRole.objects.first()
+                actual_user_role = UserRole.objects.get()
                 assert len(actual_user_role.permissions) == len(old_user_role_permissions)
                 for i, actual_permission in enumerate(actual_user_role.permissions):
                     assert actual_permission == old_user_role_permissions[i]
@@ -1712,13 +1712,13 @@ class CollisionTests(ImportTestCase):
         self.create_exhaustive_global_configs(owner)
 
         # Take note of the configs we want to track - this is the one we'll be importing.
-        colliding_option = Option.objects.all().first()
-        colliding_relay = Relay.objects.all().first()
-        colliding_relay_usage = RelayUsage.objects.all().first()
+        colliding_option = Option.objects.get()
+        colliding_relay = Relay.objects.get()
+        colliding_relay_usage = RelayUsage.objects.get()
 
         with assume_test_silo_mode(SiloMode.CONTROL):
-            colliding_control_option = ControlOption.objects.all().first()
-            colliding_user_role = UserRole.objects.all().first()
+            colliding_control_option = ControlOption.objects.get()
+            colliding_user_role = UserRole.objects.get()
 
         with tempfile.TemporaryDirectory() as tmp_dir:
             tmp_path = self.export_to_tmp_file_and_clear_database(tmp_dir)
@@ -1789,7 +1789,7 @@ class CollisionTests(ImportTestCase):
                 assert ControlOption.objects.filter(value__exact="z").exists()
 
                 assert UserRole.objects.count() == 1
-                actual_user_role = UserRole.objects.first()
+                actual_user_role = UserRole.objects.get()
                 assert len(actual_user_role.permissions) == 1
                 assert actual_user_role.permissions[0] == "other.admin"
 

--- a/tests/sentry/integrations/github/test_webhooks.py
+++ b/tests/sentry/integrations/github/test_webhooks.py
@@ -790,8 +790,7 @@ class PullRequestEventWebhook(APITestCase):
         assert mock_metrics.incr.call_count == 0
 
     def assert_group_link(self, group, pr):
-        link = GroupLink.objects.all().first()
-        assert link
+        link = GroupLink.objects.get()
         assert link.group_id == group.id
         assert link.linked_id == pr.id
         assert link.linked_type == GroupLink.LinkedType.pull_request

--- a/tests/sentry/integrations/gitlab/test_webhook.py
+++ b/tests/sentry/integrations/gitlab/test_webhook.py
@@ -20,12 +20,12 @@ from sentry.testutils.silo import assume_test_silo_mode, assume_test_silo_mode_o
 class WebhookTest(GitLabTestCase):
     url = "/extensions/gitlab/webhook/"
 
-    def assert_commit_author(self, author):
+    def assert_commit_author(self, author: CommitAuthor) -> None:
         assert author.email
         assert author.name
         assert author.organization_id == self.organization.id
 
-    def assert_pull_request(self, pull, author):
+    def assert_pull_request(self, pull: PullRequest, author: CommitAuthor) -> None:
         assert pull.title
         assert pull.message
         assert pull.date_added
@@ -34,7 +34,7 @@ class WebhookTest(GitLabTestCase):
         assert pull.organization_id == self.organization.id
 
     def assert_group_link(self, group, pull):
-        link = GroupLink.objects.all().first()
+        link = GroupLink.objects.get()
         assert link.group_id == group.id
         assert link.linked_type == GroupLink.LinkedType.pull_request
         assert link.linked_id == pull.id
@@ -304,10 +304,10 @@ class WebhookTest(GitLabTestCase):
             HTTP_X_GITLAB_EVENT="Merge Request Hook",
         )
         assert response.status_code == 204
-        author = CommitAuthor.objects.all().first()
+        author = CommitAuthor.objects.get()
         self.assert_commit_author(author)
 
-        pull = PullRequest.objects.all().first()
+        pull = PullRequest.objects.get()
         self.assert_pull_request(pull, author)
         self.assert_group_link(group, pull)
 
@@ -330,10 +330,10 @@ class WebhookTest(GitLabTestCase):
             HTTP_X_GITLAB_EVENT="Merge Request Hook",
         )
         assert response.status_code == 204
-        author = CommitAuthor.objects.all().first()
+        author = CommitAuthor.objects.get()
         self.assert_commit_author(author)
 
-        pull = PullRequest.objects.all().first()
+        pull = PullRequest.objects.get()
         assert pull.title != "Old title"
         assert pull.message != "Old message"
 

--- a/tests/sentry/tasks/test_derive_code_mappings.py
+++ b/tests/sentry/tasks/test_derive_code_mappings.py
@@ -631,9 +631,8 @@ class TestPythonDeriveCodeMappings(BaseDeriveCodeMappings):
         assert mock_identify_stacktraces.call_count == 1
         assert mock_get_trees_for_org.call_count == 1
         assert mock_generate_code_mappings.call_count == 1
-        code_mapping = RepositoryProjectPathConfig.objects.filter(project_id=self.project.id)
-        assert code_mapping.exists()
-        assert code_mapping.first().automatically_generated is True
+        code_mapping = RepositoryProjectPathConfig.objects.get(project_id=self.project.id)
+        assert code_mapping.automatically_generated is True
 
     def test_skips_not_supported_platforms(self):
         data = self.generate_data([{}], platform="elixir")
@@ -689,9 +688,8 @@ class TestPythonDeriveCodeMappings(BaseDeriveCodeMappings):
         assert mock_identify_stacktraces.call_count == 1
         assert mock_get_trees_for_org.call_count == 1
         assert mock_generate_code_mappings.call_count == 1
-        code_mapping = RepositoryProjectPathConfig.objects.filter(project_id=self.project.id)
-        assert code_mapping.exists()
-        assert code_mapping.first().automatically_generated is False
+        code_mapping = RepositoryProjectPathConfig.objects.get(project_id=self.project.id)
+        assert code_mapping.automatically_generated is False
         assert mock_logger.info.call_count == 1
 
     @responses.activate
@@ -704,7 +702,7 @@ class TestPythonDeriveCodeMappings(BaseDeriveCodeMappings):
                 repo_name: RepoTree(Repo(repo_name, "master"), ["src/sentry/models/release.py"])
             }
             derive_code_mappings(self.project.id, self.test_data)
-            code_mapping = RepositoryProjectPathConfig.objects.all().first()
+            code_mapping = RepositoryProjectPathConfig.objects.get()
             # sentry/models/release.py -> models/release.py -> src/sentry/models/release.py
             assert code_mapping.stack_root == "sentry/"
             assert code_mapping.source_root == "src/sentry/"
@@ -719,7 +717,7 @@ class TestPythonDeriveCodeMappings(BaseDeriveCodeMappings):
                 repo_name: RepoTree(Repo(repo_name, "master"), ["sentry/models/release.py"])
             }
             derive_code_mappings(self.project.id, self.test_data)
-            code_mapping = RepositoryProjectPathConfig.objects.all().first()
+            code_mapping = RepositoryProjectPathConfig.objects.get()
 
             assert code_mapping.stack_root == ""
             assert code_mapping.source_root == ""


### PR DESCRIPTION
.first() is nullable, .get() is not (and enforces that there's exactly one item)

for a few of the cases in `test_imports` I needed `[0]` instead of `.get()` as there were multiple rows in the table already

this fixes 67 errors when BaseManager becomes typechecked

<!-- Describe your PR here. -->