### PR TITLE
fix(spans): Return proper type for span duration

### DIFF
--- a/tests/sentry/api/endpoints/test_organization_traces.py
+++ b/tests/sentry/api/endpoints/test_organization_traces.py
@@ -1091,6 +1091,19 @@ class OrganizationTracesStatsEndpointTest(OrganizationTracesEndpointTestBase):
             ],
         }
 
+    def test_span_duration_filter(self):
+        for q in [
+            ["span.duration:>100"],
+        ]:
+            query = {
+                "yAxis": ["count()"],
+                "query": q,
+                "project": [self.project.id],
+            }
+
+            response = self.do_request(query)
+            assert response.status_code == 200, response.data
+
     def test_stats(self):
         project_1 = self.create_project()
         project_2 = self.create_project()


### PR DESCRIPTION
The attribute span.duration needs to be marked as a duration type on all query builders so that conditions on it resolve correctly, but this was only done for the `SpansIndexedQueryBuilder`. This ensures it also correctly classified for the other spans indexed dataset related query builders.