### PR TITLE
ref: fix typing for hc CacheVersion model

### DIFF
--- a/src/sentry/hybridcloud/models/cacheversion.py
+++ b/src/sentry/hybridcloud/models/cacheversion.py
@@ -19,7 +19,7 @@ class CacheVersionBase(Model):
             cls.objects.create_or_update(
                 key=key, defaults=dict(version=1), values=dict(version=F("version") + 1)
             )
-            return cls.objects.filter(key=key).values("version").first()["version"]
+            return cls.objects.get(key=key).version
 
     @classmethod
     def get_versions(cls, keys: list[str]) -> list[int]:

--- a/tests/sentry/hybridcloud/models/test_cacheversion.py
+++ b/tests/sentry/hybridcloud/models/test_cacheversion.py
@@ -1,0 +1,8 @@
+from sentry.hybridcloud.models.cacheversion import RegionCacheVersion
+from sentry.testutils.pytest.fixtures import django_db_all
+
+
+@django_db_all
+def test_increment_version() -> None:
+    assert RegionCacheVersion.incr_version("hello-world") == 1
+    assert RegionCacheVersion.incr_version("hello-world") == 2


### PR DESCRIPTION
- `.first(...)` is nullable
- `.filter(...).values(...)[...]` is unnecessary conversion to `dict`

fixes errors in this module when BaseManager becomes typed

<!-- Describe your PR here. -->