### PR TITLE
fix(migrations): Add accurate constrains for `sentry_notificationsettingsprovider`

### DIFF
--- a/src/sentry/models/notificationsettingprovider.py
+++ b/src/sentry/models/notificationsettingprovider.py
@@ -20,6 +20,12 @@ class NotificationSettingProvider(NotificationSettingBase):
                 "scope_type",
                 "scope_identifier",
                 "user_id",
+                "provider",
+                "type",
+            ),
+            (
+                "scope_type",
+                "scope_identifier",
                 "team_id",
                 "provider",
                 "type",


### PR DESCRIPTION
This PR modifies the constraints for the NotificationSettingsProvider table. The previous unique constraint would never be enforced because `NULL` columns act as unique for Postgres, and only one of `team_id` or `user_id` would ever have a value. This allows duplicate entries to be created. The new constraints will enforce that when specified, `team_id` must be unique (with the other fields) and does the same for `user_id`. 

Currently, I seem to be having trouble generating the Django Migration though, as `sentry django makemigrations` is producing a `KeyError` when trying to auto-generate the migration.

```
  File "/Users/leander/dev/sentry/.venv/lib/python3.11/site-packages/django/db/migrations/autodetector.py", line 1518, in _generate_removed_altered_foo_together
    for (
  File "/Users/leander/dev/sentry/.venv/lib/python3.11/site-packages/django/db/migrations/autodetector.py", line 1499, in _get_altered_foo_together_operations
    field = new_model_state.get_field(field_name)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/leander/dev/sentry/.venv/lib/python3.11/site-packages/django/db/migrations/state.py", line 765, in get_field
    return self.fields[field_name]
           ~~~~~~~~~~~^^^^^^^^^^^^
KeyError: 'user_id'
```

Insights are welcome, but I'll try to fix this up when I have a moment.