### PR TITLE
ref: CacheNotPopulated is only used by GroupMeta

### DIFF
--- a/src/sentry/exceptions.py
+++ b/src/sentry/exceptions.py
@@ -21,10 +21,6 @@ class InvalidOrigin(InvalidRequest):
         return "Invalid origin: '%s'" % self.origin
 
 
-class CacheNotPopulated(Exception):
-    pass
-
-
 class InvalidConfiguration(Exception):
     pass
 

--- a/src/sentry/models/groupmeta.py
+++ b/src/sentry/models/groupmeta.py
@@ -8,9 +8,12 @@ from django.db import models
 from sentry.backup.scopes import RelocationScope
 from sentry.db.models import FlexibleForeignKey, Model, region_silo_model, sane_repr
 from sentry.db.models.manager import BaseManager
-from sentry.exceptions import CacheNotPopulated
 
 ERR_CACHE_MISSING = "Cache not populated for instance id=%s"
+
+
+class GroupMetaCacheNotPopulated(Exception):
+    pass
 
 
 class GroupMetaManager(BaseManager["GroupMeta"]):
@@ -38,7 +41,6 @@ class GroupMetaManager(BaseManager["GroupMeta"]):
     __cache = property(_get_cache, _set_cache)
 
     def contribute_to_class(self, model, name):
-        model.CacheNotPopulated = CacheNotPopulated
         super().contribute_to_class(model, name)
         task_postrun.connect(self.clear_local_cache)
         request_finished.connect(self.clear_local_cache)
@@ -60,7 +62,7 @@ class GroupMetaManager(BaseManager["GroupMeta"]):
             try:
                 inst_cache = self.__cache[instance.id]
             except KeyError:
-                raise self.model.CacheNotPopulated(ERR_CACHE_MISSING % (instance.id,))
+                raise GroupMetaCacheNotPopulated(ERR_CACHE_MISSING % (instance.id,))
             results[instance] = inst_cache.get(key, default)
         return results
 
@@ -68,7 +70,7 @@ class GroupMetaManager(BaseManager["GroupMeta"]):
         try:
             inst_cache = self.__cache[instance.id]
         except KeyError:
-            raise self.model.CacheNotPopulated(ERR_CACHE_MISSING % (instance.id,))
+            raise GroupMetaCacheNotPopulated(ERR_CACHE_MISSING % (instance.id,))
         return inst_cache.get(key, default)
 
     def unset_value(self, instance, key):

--- a/tests/sentry/models/test_groupmeta.py
+++ b/tests/sentry/models/test_groupmeta.py
@@ -1,7 +1,6 @@
 import pytest
 
-from sentry.exceptions import CacheNotPopulated
-from sentry.models.groupmeta import GroupMeta
+from sentry.models.groupmeta import GroupMeta, GroupMetaCacheNotPopulated
 from sentry.testutils.cases import TestCase
 
 
@@ -11,11 +10,11 @@ class GroupMetaManagerTest(TestCase):
         assert GroupMeta.objects.filter(group=self.group, key="foo", value="bar").exists()
 
     def test_get_value(self):
-        with pytest.raises(CacheNotPopulated):
+        with pytest.raises(GroupMetaCacheNotPopulated):
             GroupMeta.objects.get_value(self.group, "foo")
 
         GroupMeta.objects.create(group=self.group, key="foo", value="bar")
-        with pytest.raises(CacheNotPopulated):
+        with pytest.raises(GroupMetaCacheNotPopulated):
             GroupMeta.objects.get_value(self.group, "foo")
 
         GroupMeta.objects.populate_cache([self.group])
@@ -29,11 +28,11 @@ class GroupMetaManagerTest(TestCase):
         assert not GroupMeta.objects.filter(group=self.group, key="foo").exists()
 
     def test_get_value_bulk(self):
-        with pytest.raises(CacheNotPopulated):
+        with pytest.raises(GroupMetaCacheNotPopulated):
             GroupMeta.objects.get_value_bulk([self.group], "foo")
 
         GroupMeta.objects.create(group=self.group, key="foo", value="bar")
-        with pytest.raises(CacheNotPopulated):
+        with pytest.raises(GroupMetaCacheNotPopulated):
             GroupMeta.objects.get_value_bulk([self.group], "foo")
 
         GroupMeta.objects.populate_cache([self.group])


### PR DESCRIPTION
this fixes a few errors (AttributeError on the class) when BaseModel becomes typechecked

<!-- Describe your PR here. -->