### PR TITLE
fix(autofix): Remove footer actions from modal after successfully setting up write access

### DIFF
--- a/static/app/components/events/autofix/autofixSetupWriteAccessModal.spec.tsx
+++ b/static/app/components/events/autofix/autofixSetupWriteAccessModal.spec.tsx
@@ -1,0 +1,108 @@
+import {act, renderGlobalModal, screen} from 'sentry-test/reactTestingLibrary';
+
+import {openModal} from 'sentry/actionCreators/modal';
+import {AutofixSetupWriteAccessModal} from 'sentry/components/events/autofix/autofixSetupWriteAccessModal';
+
+describe('AutofixSetupWriteAccessModal', function () {
+  it('displays help text when repos are not all installed', async function () {
+    MockApiClient.addMockResponse({
+      url: '/issues/1/autofix/setup/',
+      body: {
+        genAIConsent: {ok: false},
+        integration: {ok: true},
+        githubWriteIntegration: {
+          ok: false,
+          repos: [
+            {
+              provider: 'integrations:github',
+              owner: 'getsentry',
+              name: 'sentry',
+              external_id: '123',
+              ok: true,
+            },
+            {
+              provider: 'integrations:github',
+              owner: 'getsentry',
+              name: 'seer',
+              external_id: '235',
+              ok: false,
+            },
+          ],
+        },
+        codebaseIndexing: {ok: false},
+      },
+    });
+
+    const closeModal = jest.fn();
+
+    renderGlobalModal();
+
+    act(() => {
+      openModal(
+        modalProps => <AutofixSetupWriteAccessModal {...modalProps} groupId="1" />,
+        {
+          onClose: closeModal,
+        }
+      );
+    });
+
+    expect(screen.getByText(/In order to create pull requests/i)).toBeInTheDocument();
+    expect(await screen.findByText('getsentry/sentry')).toBeInTheDocument();
+    expect(screen.getByText('getsentry/seer')).toBeInTheDocument();
+
+    expect(
+      screen.getByRole('button', {name: 'Install the Autofix GitHub App'})
+    ).toHaveAttribute(
+      'href',
+      'https://github.com/apps/sentry-autofix-experimental/installations/new'
+    );
+  });
+
+  it('displays success text when installed repos for github app text', async function () {
+    MockApiClient.addMockResponse({
+      url: '/issues/1/autofix/setup/',
+      body: {
+        genAIConsent: {ok: false},
+        integration: {ok: true},
+        githubWriteIntegration: {
+          ok: true,
+          repos: [
+            {
+              provider: 'integrations:github',
+              owner: 'getsentry',
+              name: 'sentry',
+              external_id: '123',
+              ok: true,
+            },
+            {
+              provider: 'integrations:github',
+              owner: 'getsentry',
+              name: 'seer',
+              external_id: '235',
+              ok: true,
+            },
+          ],
+        },
+        codebaseIndexing: {ok: false},
+      },
+    });
+
+    const closeModal = jest.fn();
+
+    renderGlobalModal();
+
+    act(() => {
+      openModal(
+        modalProps => <AutofixSetupWriteAccessModal {...modalProps} groupId="1" />,
+        {onClose: closeModal}
+      );
+    });
+
+    expect(
+      await screen.findByText("You've successfully configured write access!")
+    ).toBeInTheDocument();
+
+    // Footer with actions should no longer be visible
+    expect(screen.queryByRole('button', {name: /install/i})).not.toBeInTheDocument();
+  });
+});

--- a/static/app/components/events/autofix/autofixSetupWriteAccessModal.tsx
+++ b/static/app/components/events/autofix/autofixSetupWriteAccessModal.tsx
@@ -49,7 +49,7 @@ function Content({groupId, closeModal}: {closeModal: () => void; groupId: string
       <Fragment>
         <p>
           {tct(
-            'In order to create pull requests, install and grant write access to the [link:Sentry Autofix Github App] for the following repositories:',
+            'In order to create pull requests, install and grant write access to the [link:Sentry Autofix GitHub App] for the following repositories:',
             {
               link: (
                 <ExternalLink
@@ -72,7 +72,7 @@ function Content({groupId, closeModal}: {closeModal: () => void; groupId: string
     <Fragment>
       <p>
         {tct(
-          'In order to create pull requests, install and grant write access to the [link:Sentry Autofix Github App] for the relevant repositories.',
+          'In order to create pull requests, install and grant write access to the [link:Sentry Autofix GitHub App] for the relevant repositories.',
           {
             link: (
               <ExternalLink
@@ -93,6 +93,8 @@ export function AutofixSetupWriteAccessModal({
   groupId,
   closeModal,
 }: AutofixSetupWriteAccessModalProps) {
+  const {canCreatePullRequests} = useAutofixSetup({groupId});
+
   return (
     <Fragment>
       <Header closeButton>
@@ -101,18 +103,20 @@ export function AutofixSetupWriteAccessModal({
       <Body>
         <Content groupId={groupId} closeModal={closeModal} />
       </Body>
-      <Footer>
-        <ButtonBar gap={1}>
-          <Button onClick={closeModal}>{t('Later')}</Button>
-          <LinkButton
-            href="https://github.com/apps/sentry-autofix-experimental/installations/new"
-            external
-            priority="primary"
-          >
-            {t('Install the Autofix GitHub App')}
-          </LinkButton>
-        </ButtonBar>
-      </Footer>
+      {!canCreatePullRequests && (
+        <Footer>
+          <ButtonBar gap={1}>
+            <Button onClick={closeModal}>{t('Later')}</Button>
+            <LinkButton
+              href="https://github.com/apps/sentry-autofix-experimental/installations/new"
+              external
+              priority="primary"
+            >
+              {t('Install the Autofix GitHub App')}
+            </LinkButton>
+          </ButtonBar>
+        </Footer>
+      )}
     </Fragment>
   );
 }


### PR DESCRIPTION
Small fix and added more tests. The footer isn't necessary after the user has come back to the tab after setting up the github app.