### PR TITLE
ref(replay): Refactor OpenReplayComparisonButton to take more params

### DIFF
--- a/static/app/components/replays/breadcrumbs/breadcrumbItem.tsx
+++ b/static/app/components/replays/breadcrumbs/breadcrumbItem.tsx
@@ -14,6 +14,7 @@ import {OpenReplayComparisonButton} from 'sentry/components/replays/breadcrumbs/
 import {useReplayContext} from 'sentry/components/replays/replayContext';
 import {useReplayGroupContext} from 'sentry/components/replays/replayGroupContext';
 import {Tooltip} from 'sentry/components/tooltip';
+import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {Extraction} from 'sentry/utils/replays/extractDomNodes';
 import getFrameDetails from 'sentry/utils/replays/getFrameDetails';
@@ -118,7 +119,10 @@ function BreadcrumbItem({
                   (frame.data.mutations.next?.timestamp ?? 0) -
                   (replay?.getReplay().started_at.getTime() ?? 0)
                 }
-              />
+                size="xs"
+              >
+                {t('Open Hydration Diff')}
+              </OpenReplayComparisonButton>
             </div>
           ) : null}
 

--- a/static/app/components/replays/breadcrumbs/openReplayComparisonButton.tsx
+++ b/static/app/components/replays/breadcrumbs/openReplayComparisonButton.tsx
@@ -1,10 +1,10 @@
-import {Fragment, lazy, Suspense} from 'react';
+import {Fragment, lazy, type ReactNode, Suspense} from 'react';
 import {css} from '@emotion/react';
 
 import {openModal} from 'sentry/actionCreators/modal';
-import {Button} from 'sentry/components/button';
+import FeatureBadge from 'sentry/components/badge/featureBadge';
+import {Button, type ButtonProps} from 'sentry/components/button';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
-import {t} from 'sentry/locale';
 import type ReplayReader from 'sentry/utils/replays/replayReader';
 import useOrganization from 'sentry/utils/useOrganization';
 
@@ -13,22 +13,26 @@ const LazyComparisonModal = lazy(
 );
 
 interface Props {
+  children: ReactNode;
   leftTimestamp: number;
   replay: null | ReplayReader;
   rightTimestamp: number;
+  size?: ButtonProps['size'];
 }
 
 export function OpenReplayComparisonButton({
+  children,
   leftTimestamp,
   replay,
   rightTimestamp,
+  size,
 }: Props) {
   const organization = useOrganization();
 
   return (
     <Button
       role="button"
-      size="xs"
+      size={size}
       analyticsEventKey="replay.details-hydration-modal-opened"
       analyticsEventName="Replay Details Hydration Modal Opened"
       onClick={event => {
@@ -39,7 +43,12 @@ export function OpenReplayComparisonButton({
               fallback={
                 <Fragment>
                   <deps.Header closeButton>
-                    <deps.Header>{t('Hydration Error')}</deps.Header>
+                    <deps.Header>
+                      <h4>
+                        Hydration Error
+                        <FeatureBadge type="beta" />
+                      </h4>
+                    </deps.Header>
                   </deps.Header>
                   <deps.Body>
                     <LoadingIndicator />
@@ -60,7 +69,7 @@ export function OpenReplayComparisonButton({
         );
       }}
     >
-      {t('Open Hydration Diff')}
+      {children}
     </Button>
   );
 }


### PR DESCRIPTION
Refactoring OpenReplayComparisonButton to take more params, so I can more easily customize it to be part of the Issue Details page.

Related to https://github.com/getsentry/sentry/issues/70199