### PR TITLE
fix(issue): Fix size of See All Replays button on issue details

### DIFF
--- a/static/app/components/events/eventReplay/replayClipSection.tsx
+++ b/static/app/components/events/eventReplay/replayClipSection.tsx
@@ -55,7 +55,7 @@ export function ReplayClipSection({event, group, replayId}: Props) {
   const replayUrl = baseUrl ? `${baseUrl}replays/${location.search}/` : '';
   const seeAllReplaysButton = replayUrl ? (
     <LinkButton
-      size="sm"
+      size="xs"
       to={replayUrl}
       analyticsEventKey="issue_details.replay_player.clicked_see_all_replays"
       analyticsEventName="Issue Details: Replay Player Clicked See All Replays"


### PR DESCRIPTION
**Before; "See All Replays" on the right side is big-ish:**
<img width="813" alt="SCR-20240610-iyvk" src="https://github.com/getsentry/sentry/assets/187460/b5373767-8b33-4313-80dc-59e3de19fba3">

**After; button is smaller:**
<img width="844" alt="SCR-20240610-izbs" src="https://github.com/getsentry/sentry/assets/187460/fb523e41-da41-4999-8354-4ea1d075c552">


**See also other buttons on the same page**
| Comment | Img |
| --- | --- |
| Sometimes we use `xs`, like with tags | <img width="832" alt="SCR-20240610-iyxd" src="https://github.com/getsentry/sentry/assets/187460/0d48697c-d0d0-4355-ac6d-e8dfc9ab99b7"> |
| Sometimes we use `sm` like with breadcrumb search/filters | <img width="818" alt="SCR-20240610-iyyk" src="https://github.com/getsentry/sentry/assets/187460/08832db6-45d3-4823-9c84-7d3f1dd8ca09"> |


Related to https://github.com/getsentry/sentry/issues/70199