### PR TITLE
chore(hybridcloud) Mainline servicehook cached reads

### DIFF
--- a/src/sentry/services/hybrid_cloud/app/service.py
+++ b/src/sentry/services/hybrid_cloud/app/service.py
@@ -7,7 +7,6 @@ import abc
 from collections.abc import Mapping
 from typing import Any
 
-from sentry.features.rollout import in_random_rollout
 from sentry.hybridcloud.rpc.services.caching.service import back_with_silo_cache
 from sentry.services.hybrid_cloud.app import (
     RpcAlertRuleActionResult,
@@ -121,9 +120,7 @@ class AppService(RpcService):
 
         Wraps find_service_hook_sentry_app with caching.
         """
-        if in_random_rollout("sentryapps.get_by_application_id_cached"):
-            return get_by_application_id(application_id)
-        return self.find_service_hook_sentry_app(api_application_id=application_id)
+        return get_by_application_id(application_id)
 
     @rpc_method
     @abc.abstractmethod


### PR DESCRIPTION
The caching for this RPC method has been working well and we can make the cached variant permanent now.

Refs HC-1193