### PR TITLE
docs(remote-config): Add support for named, versioned configurations and allow features to be disabled

### DIFF
--- a/src/sentry/remote_config/docs/api.md
+++ b/src/sentry/remote_config/docs/api.md
@@ -50,6 +50,15 @@ Fetch a project's configuration. Responses should be proxied exactly to the SDK.
 
 ## Configurations [/projects/<organization_id_or_slug>/<project_id_or_slug>/configurations/]
 
+**Parameters**
+
+- offset (optional, number)
+  Default: 0
+- per_page (optional, number)
+  Default: 10
+
+**Attributes**
+
 | Field              | Type             | Description                                                                   |
 | ------------------ | ---------------- | ----------------------------------------------------------------------------- |
 | environment        | optional[string] | The environment the configuration is associated with.                         |
@@ -170,6 +179,23 @@ Delete a configuration.
 - Response 204
 
 ## Features [/projects/<organization_id_or_slug>/<project_id_or_slug>/configuration/<configuration_id>/features/]
+
+**Parameters**
+
+- offset (optional, number)
+  Default: 0
+- per_page (optional, number)
+  Default: 10
+
+**Attributes**
+
+| Field       | Type   | Description                                           |
+| ----------- | ------ | ----------------------------------------------------- |
+| description | string | The environment the configuration is associated with. |
+| id          | string | A server generated unique identifier.                 |
+| is_enabled  | bool   | Disabled features are not visible to clients.         |
+| key         | string | A unique, per-config feature identifier.              |
+| value       | any    | The value associated to the key.                      |
 
 ### Get Features [GET]
 

--- a/src/sentry/remote_config/docs/api.md
+++ b/src/sentry/remote_config/docs/api.md
@@ -6,6 +6,44 @@ Host: https://sentry.io/api/0
 
 @cmanallen
 
+## Configuration Proxy [/remote-config/projects/<project_id>/]
+
+Temporary configuration proxy resource.
+
+### Get Configuration [GET]
+
+Fetch a project's configuration. Responses should be proxied exactly to the SDK.
+
+- Response 200
+
+  - Headers
+
+    Cache-Control: public, max-age=3600
+    Content-Type: application/json
+    ETag: a7966bf58e23583c9a5a4059383ff850
+
+  - Body
+
+    ```json
+    {
+      "features": [
+        {
+          "key": "hello",
+          "value": "world"
+        },
+        {
+          "key": "has_access",
+          "value": true
+        }
+      ],
+      "options": {
+        "sample_rate": 1.0,
+        "traces_sample_rate": 0.5
+      },
+      "version": 1
+    }
+    ```
+
 ## Configuration [/projects/<organization_id_or_slug>/<project_id_or_slug>/configuration/]
 
 ### Get Configuration [GET]
@@ -117,41 +155,3 @@ Set the project's configuration.
 Delete the project's configuration.
 
 - Response 204
-
-## Configuration Proxy [/remote-config/projects/<project_id>/]
-
-Temporary configuration proxy resource.
-
-### Get Configuration [GET]
-
-Fetch a project's configuration. Responses should be proxied exactly to the SDK.
-
-- Response 200
-
-  - Headers
-
-    Cache-Control: public, max-age=3600
-    Content-Type: application/json
-    ETag: a7966bf58e23583c9a5a4059383ff850
-
-  - Body
-
-    ```json
-    {
-      "features": [
-        {
-          "key": "hello",
-          "value": "world"
-        },
-        {
-          "key": "has_access",
-          "value": true
-        }
-      ],
-      "options": {
-        "sample_rate": 1.0,
-        "traces_sample_rate": 0.5
-      },
-      "version": 1
-    }
-    ```

--- a/src/sentry/remote_config/docs/api.md
+++ b/src/sentry/remote_config/docs/api.md
@@ -182,6 +182,7 @@ Retrieve configuration features.
     "data": [
       {
         "description": "A feature description.",
+        "id": "59d105e1872d4280b5206015d68e95a8",
         "is_enabled": true,
         "key": "hello",
         "value": 22.3
@@ -213,6 +214,7 @@ Create a configuration feature.
   {
     "data": {
       "description": "Another key.",
+      "id": "59d105e1872d4280b5206015d68e95a8",
       "is_enabled": true,
       "key": "other",
       "value": "key"
@@ -232,6 +234,7 @@ Retrieve a configuration feature.
   {
     "data": {
       "description": "A feature description.",
+      "id": "59d105e1872d4280b5206015d68e95a8",
       "is_enabled": true,
       "key": "hello",
       "value": 22.3
@@ -259,6 +262,7 @@ Update a configuration feature.
   {
     "data": {
       "description": "A feature description.",
+      "id": "59d105e1872d4280b5206015d68e95a8",
       "is_enabled": false,
       "key": "hello",
       "value": 22.3

--- a/src/sentry/remote_config/docs/api.md
+++ b/src/sentry/remote_config/docs/api.md
@@ -49,7 +49,7 @@ Fetch a project's configuration. Responses should be proxied exactly to the SDK.
 | Field              | Type             | Description                                                                   |
 | ------------------ | ---------------- | ----------------------------------------------------------------------------- |
 | environment        | optional[string] | The environment the configuration is associated with.                         |
-| id                 | string           | A server generted unique identifier.                                          |
+| id                 | string           | A server generated unique identifier.                                          |
 | name               | optional[string] | A custom name distinguishing the configuration from the default project name. |
 | sample_rate        | number           |                                                                               |
 | traces_sample_rate | number           |                                                                               |

--- a/src/sentry/remote_config/docs/api.md
+++ b/src/sentry/remote_config/docs/api.md
@@ -44,85 +44,51 @@ Fetch a project's configuration. Responses should be proxied exactly to the SDK.
     }
     ```
 
-## Configuration [/projects/<organization_id_or_slug>/<project_id_or_slug>/configuration/]
+## Configurations [/projects/<organization_id_or_slug>/<project_id_or_slug>/configurations/]
 
-### Get Configuration [GET]
+| Field              | Type             | Description                                                                   |
+| ------------------ | ---------------- | ----------------------------------------------------------------------------- |
+| environment        | optional[string] | The environment the configuration is associated with.                         |
+| id                 | string           | A server generted unique identifier.                                          |
+| name               | optional[string] | A custom name distinguishing the configuration from the default project name. |
+| sample_rate        | number           |                                                                               |
+| traces_sample_rate | number           |                                                                               |
+| version            | number           | The current configuration version. Initialized to 1.                          |
 
-Retrieve the project's configuration.
+### Get Configurations [GET]
 
-**Attributes**
-
-| Column   | Type           | Description                                   |
-| -------- | -------------- | --------------------------------------------- |
-| features | array[Feature] | Custom, user-defined configuration container. |
-| options  | Option         | Sentry SDK options container.                 |
-
-**Feature Object**
-
-| Field | Type   | Description                        |
-| ----- | ------ | ---------------------------------- |
-| key   | string | The name used to lookup a feature. |
-| value | any    | A JSON value.                      |
-
-**Option Object**
-
-| Field              | Type  | Description                                         |
-| ------------------ | ----- | --------------------------------------------------- |
-| sample_rate        | float | Error sample rate. A numeric value between 0 and 1. |
-| traces_sample_rate | float | Trace sample rate. A numeric value between 0 and 1. |
-
-**If an existing configuration exists**
+Retrieve configurations.
 
 - Response 200
 
   ```json
   {
-    "data": {
-      "features": [
-        {
-          "key": "hello",
-          "value": "world"
-        },
-        {
-          "key": "has_access",
-          "value": true
-        }
-      ],
-      "options": {
-        "sample_rate": 1.0,
-        "traces_sample_rate": 0.5
+    "data": [
+      {
+        "environment": null,
+        "id": "0b88ac27a7b444a6baeb312c0493aed5",
+        "name": null,
+        "sample_rate": 0,
+        "traces_sample_rate": 0.75,
+        "version": 1
       }
-    }
+    ]
   }
   ```
 
-**If no existing configuration exists**
+### Create Configuration [POST]
 
-- Response 404
-
-### Set Configuration [POST]
-
-Set the project's configuration.
+Create a new configuration. The version field is ignored on create. Version is initialized to 1.
 
 - Request
 
   ```json
   {
     "data": {
-      "features": [
-        {
-          "key": "hello",
-          "value": "world"
-        },
-        {
-          "key": "has_access",
-          "value": true
-        }
-      ],
-      "options": {
-        "sample_rate": 1.0,
-        "traces_sample_rate": 0.5
-      }
+      "environment": "production",
+      "name": "custom-name",
+      "sample_rate": 1.0,
+      "traces_sample_rate": 0.5
     }
   }
   ```
@@ -132,26 +98,172 @@ Set the project's configuration.
   ```json
   {
     "data": {
-      "features": [
-        {
-          "key": "hello",
-          "value": "world"
-        },
-        {
-          "key": "has_access",
-          "value": true
-        }
-      ],
-      "options": {
-        "sample_rate": 1.0,
-        "traces_sample_rate": 0.5
-      }
+      "id": "0b88ac27a7b444a6baeb312c0493aed5",
+      "environment": "production",
+      "name": "custom-name",
+      "sample_rate": 1.0,
+      "traces_sample_rate": 0.5,
+      "version": 1
+    }
+  }
+  ```
+
+## Configuration [/projects/<organization_id_or_slug>/<project_id_or_slug>/configurations/<configuration_id>/]
+
+### Get Configuration [GET]
+
+Retrieve a configuration.
+
+- Response 200
+
+  ```json
+  {
+    "data": {
+      "environment": null,
+      "id": "0b88ac27a7b444a6baeb312c0493aed5",
+      "sample_rate": 0,
+      "name": null,
+      "traces_sample_rate": 0.75,
+      "version": 1
+    }
+  }
+  ```
+
+### Update Configuration [PATCH]
+
+Update a configuration. The version attribute is required for all update requests and must match the current server configuration in order to update else an error is returned.
+
+- Request
+
+  ```json
+  {
+    "data": {
+      "sample_rate": 0,
+      "version": 2
+    }
+  }
+  ```
+
+- Response 202
+
+  ```json
+  {
+    "data": {
+      "environment": "production",
+      "id": "0b88ac27a7b444a6baeb312c0493aed5",
+      "name": null,
+      "sample_rate": 0,
+      "traces_sample_rate": 0.5,
+      "version": 2
     }
   }
   ```
 
 ### Delete Configuration [DELETE]
 
-Delete the project's configuration.
+Delete a configuration.
+
+- Response 204
+
+## Features [/projects/<organization_id_or_slug>/<project_id_or_slug>/configuration/<configuration_id>/features/]
+
+### Get Features [GET]
+
+Retrieve configuration features.
+
+- Response 200
+
+  ```json
+  {
+    "data": [
+      {
+        "description": "A feature description.",
+        "is_enabled": true,
+        "key": "hello",
+        "value": 22.3
+      }
+    ]
+  }
+  ```
+
+### Create Feature [POST]
+
+Create a configuration feature.
+
+- Request
+
+  ```json
+  {
+    "data": {
+      "description": "Another key.",
+      "is_enabled": true,
+      "key": "other",
+      "value": "key"
+    }
+  }
+  ```
+
+- Response 201
+
+  ```json
+  {
+    "data": {
+      "description": "Another key.",
+      "is_enabled": true,
+      "key": "other",
+      "value": "key"
+    }
+  }
+  ```
+
+## Feature [/projects/<organization_id_or_slug>/<project_id_or_slug>/configuration/<configuration_id>/features/<feature_id>/]
+
+### Get Feature [GET]
+
+Retrieve a configuration feature.
+
+- Response 200
+
+  ```json
+  {
+    "data": {
+      "description": "A feature description.",
+      "is_enabled": true,
+      "key": "hello",
+      "value": 22.3
+    }
+  }
+  ```
+
+### Update Feature [PATCH]
+
+Update a configuration feature.
+
+- Request
+
+  ```json
+  {
+    "data": {
+      "is_enabled": false
+    }
+  }
+  ```
+
+- Response 202
+
+  ```json
+  {
+    "data": {
+      "description": "A feature description.",
+      "is_enabled": false,
+      "key": "hello",
+      "value": 22.3
+    }
+  }
+  ```
+
+### Delete Feature [DELETE]
+
+Delete a configuration feature.
 
 - Response 204

--- a/src/sentry/remote_config/docs/api.md
+++ b/src/sentry/remote_config/docs/api.md
@@ -10,6 +10,10 @@ Host: https://sentry.io/api/0
 
 Temporary configuration proxy resource.
 
+- Parameters
+  - environment (optional, string) - The environment to scope the configuration by.
+  - name (optional, string) - An explicit name to scope the configuration by.
+
 ### Get Configuration [GET]
 
 Fetch a project's configuration. Responses should be proxied exactly to the SDK.

--- a/src/sentry/remote_config/docs/api.md
+++ b/src/sentry/remote_config/docs/api.md
@@ -98,8 +98,8 @@ Create a new configuration. The version field is ignored on create. Version is i
   ```json
   {
     "data": {
-      "id": "0b88ac27a7b444a6baeb312c0493aed5",
       "environment": "production",
+      "id": "0b88ac27a7b444a6baeb312c0493aed5",
       "name": "custom-name",
       "sample_rate": 1.0,
       "traces_sample_rate": 0.5,

--- a/src/sentry/remote_config/docs/api.md
+++ b/src/sentry/remote_config/docs/api.md
@@ -49,7 +49,7 @@ Fetch a project's configuration. Responses should be proxied exactly to the SDK.
 | Field              | Type             | Description                                                                   |
 | ------------------ | ---------------- | ----------------------------------------------------------------------------- |
 | environment        | optional[string] | The environment the configuration is associated with.                         |
-| id                 | string           | A server generated unique identifier.                                          |
+| id                 | string           | A server generated unique identifier.                                         |
 | name               | optional[string] | A custom name distinguishing the configuration from the default project name. |
 | sample_rate        | number           |                                                                               |
 | traces_sample_rate | number           |                                                                               |

--- a/src/sentry/remote_config/docs/api.md
+++ b/src/sentry/remote_config/docs/api.md
@@ -121,8 +121,8 @@ Retrieve a configuration.
     "data": {
       "environment": null,
       "id": "0b88ac27a7b444a6baeb312c0493aed5",
-      "sample_rate": 0,
       "name": null,
+      "sample_rate": 0,
       "traces_sample_rate": 0.75,
       "version": 1
     }

--- a/src/sentry/remote_config/docs/protocol.md
+++ b/src/sentry/remote_config/docs/protocol.md
@@ -8,6 +8,10 @@ Host: https://o1300299.ingest.us.sentry.io
 
 ## Configuration [/api/<project_id>/configuration/]
 
+- Parameters
+  - environment (optional, string) - The environment to scope the configuration by.
+  - name (optional, string) - An explicit name to scope the configuration by.
+
 ### Get Configuration [GET]
 
 Retrieve a project's configuration.


### PR DESCRIPTION
- Adds support for explicitly naming configurations.
- Adds support for associating configurations to environments.
- Adds support for versioning configurations.
- Adds support for disabling and enabling features.

Open Questions:

- When do we push? Automatically? Manually? How do we stage changes so the user can modify a feature without necessarily publishing it. How do we prevent other users from accidentally publishing staged feature changes?
- How do we handle environment renames?
   - Need to associate to a foreign-key.
   - Push the associated configuration on environment rename?
   - Do SDKs automatically update on environment rename?

Related: https://github.com/getsentry/sentry/issues/70942