### PR TITLE
chore(api): Removed `ORG_SLUG` Global Param

### DIFF
--- a/src/sentry/apidocs/parameters.py
+++ b/src/sentry/apidocs/parameters.py
@@ -20,13 +20,6 @@ def build_typed_list(type: Any):
 
 
 class GlobalParams:
-    ORG_SLUG = OpenApiParameter(
-        name="organization_slug",
-        description="The slug of the organization the resource belongs to.",
-        required=True,
-        type=str,
-        location="path",
-    )
     ORG_ID_OR_SLUG = OpenApiParameter(
         name="organization_id_or_slug",
         description="The ID or slug of the organization the resource belongs to.",

--- a/src/sentry/monitors/endpoints/organization_monitor_processing_errors_index.py
+++ b/src/sentry/monitors/endpoints/organization_monitor_processing_errors_index.py
@@ -27,7 +27,7 @@ class OrganizationMonitorProcessingErrorsIndexEndpoint(OrganizationEndpoint):
     @extend_schema(
         operation_id="Retrieve checkin processing errors for an Organization",
         parameters=[
-            GlobalParams.ORG_SLUG,
+            GlobalParams.ORG_ID_OR_SLUG,
         ],
         responses={
             200: inline_sentry_response_serializer(

--- a/src/sentry/monitors/endpoints/project_monitor_processing_errors_index.py
+++ b/src/sentry/monitors/endpoints/project_monitor_processing_errors_index.py
@@ -39,7 +39,7 @@ class ProjectMonitorProcessingErrorsIndexEndpoint(ProjectMonitorEndpoint):
     @extend_schema(
         operation_id="Retrieve checkin processing errors for a monitor",
         parameters=[
-            GlobalParams.ORG_SLUG,
+            GlobalParams.ORG_ID_OR_SLUG,
             GlobalParams.PROJECT_ID_OR_SLUG,
             MonitorParams.MONITOR_ID_OR_SLUG,
         ],
@@ -67,7 +67,7 @@ class ProjectMonitorProcessingErrorsIndexEndpoint(ProjectMonitorEndpoint):
     @extend_schema(
         operation_id="Delete all processing errors by type for a Monitor",
         parameters=[
-            GlobalParams.ORG_SLUG,
+            GlobalParams.ORG_ID_OR_SLUG,
             GlobalParams.PROJECT_ID_OR_SLUG,
             MonitorParams.MONITOR_ID_OR_SLUG,
         ],

--- a/src/sentry/monitors/endpoints/project_processing_errors_details.py
+++ b/src/sentry/monitors/endpoints/project_processing_errors_details.py
@@ -38,7 +38,7 @@ class ProjectProcessingErrorsDetailsEndpoint(ProjectEndpoint):
     @extend_schema(
         operation_id="Delete a processing error for a Monitor",
         parameters=[
-            GlobalParams.ORG_SLUG,
+            GlobalParams.ORG_ID_OR_SLUG,
             GlobalParams.PROJECT_ID_OR_SLUG,
             MonitorParams.PROCESSING_ERROR_ID,
         ],


### PR DESCRIPTION
Our APIs now work with ids (guids for crons) and slugs. we should remove the `ORG_SLUG` global param in favor of usign `ORG_ID_OR_SLUG`.
