### PR TITLE
ref(slack): use sdk client in handle_parent_notification

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -404,6 +404,8 @@ def register_temporary_features(manager: FeatureManager):
     manager.add("organizations:slack-sdk-issue-alert-action", OrganizationFeature, FeatureHandlerStrategy.OPTIONS)
     # Use new Slack SDK Client for verifying webhook signatures
     manager.add("organizations:slack-sdk-signature", OrganizationFeature, FeatureHandlerStrategy.OPTIONS)
+    # Use new Slack SDK Client for sending activity messages in threads
+    manager.add("organizations:slack-sdk-activity-threads", OrganizationFeature, FeatureHandlerStrategy.OPTIONS)
     # Add regression chart as image to slack message
     manager.add("organizations:slack-endpoint-regression-image", OrganizationFeature, FeatureHandlerStrategy.OPTIONS)
     manager.add("organizations:slack-function-regression-image", OrganizationFeature, FeatureHandlerStrategy.OPTIONS)

--- a/src/sentry/integrations/slack/service.py
+++ b/src/sentry/integrations/slack/service.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 from logging import Logger, getLogger
 
 import orjson
+from slack_sdk.errors import SlackApiError
 
+from sentry import features
 from sentry.constants import ISSUE_ALERTS_THREAD_DEFAULT
 from sentry.integrations.repository import get_default_issue_alert_repository
 from sentry.integrations.repository.issue_alert import (
@@ -11,6 +13,7 @@ from sentry.integrations.repository.issue_alert import (
     IssueAlertNotificationMessageRepository,
 )
 from sentry.integrations.slack import BlockSlackMessageBuilder, SlackClient
+from sentry.integrations.slack.sdk_client import SlackSdkClient
 from sentry.integrations.slack.threads.activity_notifications import (
     AssignedActivityNotification,
     ExternalIssueCreatedActivityNotification,
@@ -158,7 +161,11 @@ class SlackService:
             )
             return None
 
-        slack_client = SlackClient(integration_id=integration.id)
+        slack_client: SlackClient | SlackSdkClient = SlackClient(integration_id=integration.id)
+        if features.has(
+            "organizations:slack-sdk-activity-threads", organization=activity.group.organization
+        ):
+            slack_client = SlackSdkClient(integration_id=integration.id)
 
         # Get all parent notifications, which will have the message identifier to use to reply in a thread
         parent_notifications = (
@@ -190,7 +197,7 @@ class SlackService:
         self,
         parent_notification: IssueAlertNotificationMessage,
         notification_to_send: str,
-        client: SlackClient,
+        client: SlackClient | SlackSdkClient,
     ) -> None:
         # For each parent notification, we need to get the channel that the notification is replied to
         # Get the channel by using the action uuid
@@ -224,21 +231,38 @@ class SlackService:
         )
         payload.update(slack_payload)
         # TODO (Yash): Users should not have to remember to do this, interface should handle serializing the field
-        payload["blocks"] = orjson.dumps(payload.get("blocks")).decode()
-        try:
-            client.post("/chat.postMessage", data=payload, timeout=5)
-        except Exception as err:
-            self._logger.info(
-                "failed to post message to slack",
-                extra={
-                    "error": str(err),
-                    "payload": payload,
-                    "channel": channel_id,
-                    "thread_ts": parent_notification.message_identifier,
-                    "rule_action_uuid": parent_notification.rule_action_uuid,
-                },
-            )
-            raise
+        json_blocks = orjson.dumps(payload.get("blocks")).decode()
+        payload["blocks"] = json_blocks
+
+        extra = {
+            "channel": channel_id,
+            "thread_ts": parent_notification.message_identifier,
+            "rule_action_uuid": parent_notification.rule_action_uuid,
+        }
+
+        if isinstance(client, SlackClient):
+            try:
+                client.post("/chat.postMessage", data=payload, timeout=5)
+            except Exception as err:
+                self._logger.info(
+                    "failed to post message to slack",
+                    extra={"error": str(err), "payload": payload, **extra},
+                )
+                raise
+        else:
+            try:
+                client.chat_postMessage(
+                    channel=channel_id,
+                    thread_ts=parent_notification.message_identifier,
+                    text=notification_to_send,
+                    blocks=json_blocks,
+                )
+            except SlackApiError as err:
+                self._logger.info(
+                    "failed to post message to slack",
+                    extra={"error": str(err), "blocks": json_blocks, **extra},
+                )
+                raise
 
     def _get_notification_message_to_send(self, activity: Activity) -> str | None:
         """

--- a/tests/sentry/integrations/slack/service/test_slack_service.py
+++ b/tests/sentry/integrations/slack/service/test_slack_service.py
@@ -2,14 +2,23 @@ from datetime import datetime
 from unittest import mock
 from uuid import uuid4
 
+import orjson
 import pytest
+import responses
+from slack_sdk.errors import SlackApiError
 
 from sentry.integrations.repository.issue_alert import IssueAlertNotificationMessage
+from sentry.integrations.slack.client import SlackClient
+from sentry.integrations.slack.sdk_client import SlackSdkClient
 from sentry.integrations.slack.service import RuleDataError, SlackService
 from sentry.models.activity import Activity
 from sentry.models.notificationmessage import NotificationMessage
+from sentry.models.options.organization_option import OrganizationOption
 from sentry.models.rulefirehistory import RuleFireHistory
+from sentry.silo.base import SiloMode
 from sentry.testutils.cases import TestCase
+from sentry.testutils.helpers.features import with_feature
+from sentry.testutils.silo import assume_test_silo_mode
 from sentry.types.activity import ActivityType
 
 
@@ -40,12 +49,16 @@ class TestGetNotificationMessageToSend(TestCase):
         assert result == "admin@localhost archived BAR-1"
 
 
-class TestHandleParentNotification(TestCase):
+class TestNotifyAllThreadsForActivity(TestCase):
     def setUp(self) -> None:
-        """
-        Setup default and reusable testing data or objects
-        """
         self.service = SlackService.default()
+        self.activity = Activity.objects.create(
+            group=self.group,
+            project=self.project,
+            type=ActivityType.SET_IGNORED.value,
+            user_id=self.user.id,
+            data={"ignoreUntilEscalating": True},
+        )
 
         self.rule_action_uuid = str(uuid4())
         self.notify_issue_owners_action = [
@@ -67,6 +80,192 @@ class TestHandleParentNotification(TestCase):
             event_id=456,
             notification_uuid=str(uuid4()),
         )
+        self.parent_notification = NotificationMessage.objects.create(
+            rule_fire_history_id=self.rule_fire_history.id,
+            rule_action_uuid=self.rule_action_uuid,
+        )
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            self.integration = self.create_integration(
+                organization=self.organization,
+                name="slack",
+                provider="slack",
+                external_id="slack:1",
+                metadata={"access_token": "xoxb-access-token"},
+            )
+
+    def test_none_group(self):
+        self.activity.update(group=None)
+        assert self.service.notify_all_threads_for_activity(activity=self.activity) is None
+
+    def test_none_user_id(self):
+        self.activity.update(user_id=None)
+        assert self.service.notify_all_threads_for_activity(activity=self.activity) is None
+
+    def test_disabled_option(self):
+        OrganizationOption.objects.set_value(
+            self.organization, "sentry:issue_alerts_thread_flag", False
+        )
+        assert self.service.notify_all_threads_for_activity(activity=self.activity) is None
+
+    def test_no_message_to_send(self):
+        # unsupported activity
+        self.activity.update(type=ActivityType.FIRST_SEEN.value)
+        assert self.service.notify_all_threads_for_activity(activity=self.activity) is None
+
+    def test_no_integration(self):
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            self.integration.delete()
+        assert self.service.notify_all_threads_for_activity(activity=self.activity) is None
+
+    def test_no_parent_notification(self):
+        self.parent_notification.delete()
+        assert self.service.notify_all_threads_for_activity(activity=self.activity) is None
+
+    @mock.patch("sentry.integrations.slack.service.SlackService._handle_parent_notification")
+    def test_calls_handle_parent_notification(self, mock_handle):
+        parent_notification = IssueAlertNotificationMessage.from_model(
+            instance=self.parent_notification
+        )
+        self.service.notify_all_threads_for_activity(activity=self.activity)
+
+        mock_handle.assert_called()
+        assert mock_handle.call_args.kwargs["parent_notification"] == parent_notification
+
+        # check client type
+        assert isinstance(mock_handle.call_args.kwargs["client"], SlackClient)
+
+    @mock.patch("sentry.integrations.slack.service.SlackService._handle_parent_notification")
+    @with_feature("organizations:slack-sdk-activity-threads")
+    def test_calls_handle_parent_notification_sdk_client(self, mock_handle):
+        parent_notification = IssueAlertNotificationMessage.from_model(
+            instance=self.parent_notification
+        )
+        self.service.notify_all_threads_for_activity(activity=self.activity)
+
+        mock_handle.assert_called()
+        assert mock_handle.call_args.kwargs["parent_notification"] == parent_notification
+
+        # check client type
+        assert isinstance(mock_handle.call_args.kwargs["client"], SlackSdkClient)
+
+
+class TestHandleParentNotification(TestCase):
+    def setUp(self) -> None:
+        """
+        Setup default and reusable testing data or objects
+        """
+        self.service = SlackService.default()
+
+        self.rule_action_uuid = str(uuid4())
+        self.notify_issue_owners_action = [
+            {
+                "targetType": "IssueOwners",
+                "fallthroughType": "ActiveMembers",
+                "id": "sentry.mail.actions.NotifyEmailAction",
+                "targetIdentifier": "",
+                "uuid": self.rule_action_uuid,
+            }
+        ]
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            self.integration = self.create_integration(
+                organization=self.organization,
+                name="slack",
+                provider="slack",
+                external_id="slack:1",
+                metadata={"access_token": "xoxb-access-token"},
+            )
+        self.slack_action = {
+            "workspace": str(self.integration.id),
+            "id": "sentry.integrations.slack.notify_action.SlackNotifyServiceAction",
+            "channel_id": "C0123456789",
+            "tags": "",
+            "channel": "test-notifications",
+            "uuid": self.rule_action_uuid,
+        }
+        self.rule = self.create_project_rule(
+            project=self.project, action_match=self.notify_issue_owners_action
+        )
+        self.rule_fire_history = RuleFireHistory.objects.create(
+            project=self.project,
+            rule=self.rule,
+            group=self.group,
+            event_id=456,
+            notification_uuid=str(uuid4()),
+        )
+
+        self.slack_rule = self.create_project_rule(
+            project=self.project, action_match=[self.slack_action]
+        )
+        self.slack_rule_fire_history = RuleFireHistory.objects.create(
+            project=self.project,
+            rule=self.slack_rule,
+            group=self.group,
+            event_id=543,
+            notification_uuid=str(uuid4()),
+        )
+        self.parent_notification = IssueAlertNotificationMessage(
+            id=123,
+            date_added=datetime.now(),
+            message_identifier="1a2s3d",
+            rule_action_uuid=self.rule_action_uuid,
+            rule_fire_history=self.slack_rule_fire_history,
+        )
+
+    @responses.activate
+    def test_handles_parent_notification(
+        self,
+    ) -> None:
+        responses.add(
+            responses.POST,
+            url="https://slack.com/api/chat.postMessage",
+            json={"ok": True},
+            status=200,
+        )
+        self.service._handle_parent_notification(
+            parent_notification=self.parent_notification,
+            notification_to_send="",
+            client=SlackClient(integration_id=self.integration.id),
+        )
+
+    @responses.activate
+    def test_handles_parent_notification_slack_error(
+        self,
+    ) -> None:
+        responses.add(
+            responses.POST,
+            url="https://slack.com/api/chat.postMessage",
+            json={},
+            status=500,
+        )
+        with pytest.raises(Exception):
+            self.service._handle_parent_notification(
+                parent_notification=self.parent_notification,
+                notification_to_send="",
+                client=SlackClient(integration_id=self.integration.id),
+            )
+
+    @mock.patch("slack_sdk.web.client.WebClient._perform_urllib_http_request")
+    def test_handles_parent_notification_sdk(self, mock_api_call):
+        mock_api_call.return_value = {
+            "body": orjson.dumps({"ok": True}).decode(),
+            "headers": {},
+            "status": 200,
+        }
+        self.service._handle_parent_notification(
+            parent_notification=self.parent_notification,
+            notification_to_send="hello",
+            client=SlackSdkClient(integration_id=self.integration.id),
+        )
+
+    def test_handles_parent_notification_sdk_error(
+        self,
+    ) -> None:
+        with pytest.raises(SlackApiError):
+            self.service._handle_parent_notification(
+                parent_notification=self.parent_notification,
+                notification_to_send="hello",
+                client=SlackSdkClient(integration_id=self.integration.id),
+            )
 
     def test_raises_exception_when_parent_notification_does_not_have_rule_fire_history_data(
         self,


### PR DESCRIPTION
Adds feature-flagged used of Slack SDK Client (initialized in `notify_all_threads_for_activity`) and adds tests for `notify_all_threads_for_activity` where there were previously none.