### PR TITLE
feat(issues): Show Maybe-Solutions for replay-generated hydration errors

### DIFF
--- a/static/app/utils/issueTypeConfig/index.tsx
+++ b/static/app/utils/issueTypeConfig/index.tsx
@@ -69,9 +69,13 @@ export function shouldShowCustomErrorResourceConfig(
   project: Project
 ): boolean {
   const isErrorIssue = 'issueType' in params && params.issueType === IssueType.ERROR;
+  const isReplayHydrationIssue =
+    'issueType' in params && params.issueType === IssueType.REPLAY_HYDRATION_ERROR;
   const hasTitle = 'title' in params && !!params.title;
   return (
-    isErrorIssue && hasTitle && !!getErrorHelpResource({title: params.title!, project})
+    (isErrorIssue || isReplayHydrationIssue) &&
+    hasTitle &&
+    !!getErrorHelpResource({title: params.title!, project})
   );
 }
 

--- a/static/app/utils/react/isHydrationError.tsx
+++ b/static/app/utils/react/isHydrationError.tsx
@@ -1,0 +1,10 @@
+const REGEXP =
+  /(does not match server-rendered HTML|Hydration failed because|error while hydrating)/i;
+
+export default function isHydrationError(errorTitle: string) {
+  // Hydration Errors captured by the errors-SDK will match the REGEXP above
+  // while errors generated from the Replay Breadcrumb Ingest will have a static
+  // title set inside `report_hydration_error_issue_with_replay_event()`
+  // See: https://github.com/getsentry/sentry/blob/87e90b595620b76c1afaac247ffde6065c9cc7a5/src/sentry/replays/usecases/ingest/issue_creation.py#L22
+  return REGEXP.test(errorTitle) || errorTitle === 'Hydration Error';
+}


### PR DESCRIPTION
1. **`issueType == IssueType.ERROR`**
  Here's an example Issue of an error caught and reported by the SDK (when the hydration-errors inbound filter was disabled). 
  https://sentry.sentry.io/issues/5456012155/events/c8a6d1a6d86347039ed1722ae39c5189/?project=1267915&query=hydration&referrer=previous-event&statsPeriod=7d&stream_index=1

2. **`issueType == IssueType.REPLAY_HYDRATION_ERROR`**
  And here's an example Issue created by the Replay ingest pipeline (when the 
  https://sentry.sentry.io/issues/5459161744/?project=1267915&referrer=issue-stream&statsPeriod=7d&stream_index=0) 

**Both will now show this help text near the top of the page:**
<img width="805" alt="SCR-20240610-kjty" src="https://github.com/getsentry/sentry/assets/187460/e4dcd26f-4cbd-491e-8983-577c0b73d997">


Relates to https://github.com/getsentry/sentry/issues/70199