### PR TITLE
feat(traces): Make separate graphs for traces

### DIFF
--- a/static/app/views/traces/tracesChart.tsx
+++ b/static/app/views/traces/tracesChart.tsx
@@ -65,7 +65,7 @@ export function TracesChart({}: Props) {
   return (
     <ChartContainer>
       <ChartPanel
-        title={areQueriesEmpty(queries) ? t('Total Spans') : t('All Matching Spans')}
+        title={areQueriesEmpty(queries) ? t('All Spans') : t('All Matching Spans')}
       >
         <Chart
           height={CHART_HEIGHT}

--- a/static/app/views/traces/tracesChart.tsx
+++ b/static/app/views/traces/tracesChart.tsx
@@ -27,7 +27,7 @@ export function TracesChart({}: Props) {
     return decodeList(location.query.query);
   }, [location.query.query]);
 
-  const firstCountSeries = useTraceCountSeries(queries[0]);
+  const firstCountSeries = useTraceCountSeries(queries[0] ?? ''); // Always provide query string for first query.
   const secondCountSeries = useTraceCountSeries(queries[1]);
   const thirdCountSeries = useTraceCountSeries(queries[2]);
 
@@ -106,6 +106,7 @@ const useTraceCountSeries = (query: string | null) => {
       yAxis: ['count()'],
       interval: getInterval(pageFilters.selection.datetime, 'metrics'),
       overriddenRoute: 'traces-stats',
+      enabled: query !== null && query !== undefined,
     },
     'api.trace-explorer.stats'
   );

--- a/static/app/views/traces/tracesChart.tsx
+++ b/static/app/views/traces/tracesChart.tsx
@@ -46,13 +46,12 @@ export function TracesChart({}: Props) {
     secondQueryData.color = CHART_PALETTE[2][1];
     thirdQueryData.color = CHART_PALETTE[2][2];
 
-    firstQueryData.seriesName = queries[0];
+    firstQueryData.seriesName = queries[0] || t('All spans');
     secondQueryData.seriesName = queries[1];
     thirdQueryData.seriesName = queries[2];
 
-    if (queries[0]) {
-      data.push(firstQueryData);
-    }
+    data.push(firstQueryData);
+
     if (queries[1]) {
       data.push(secondQueryData);
     }

--- a/static/app/views/traces/tracesChart.tsx
+++ b/static/app/views/traces/tracesChart.tsx
@@ -27,7 +27,7 @@ export function TracesChart({}: Props) {
     return decodeList(location.query.query);
   }, [location.query.query]);
 
-  const firstCountSeries = useTraceCountSeries(queries[0] ?? ''); // Always provide query string for first query.
+  const firstCountSeries = useTraceCountSeries(queries[0] ?? ''); // Always provide query string to visualize at least some spans when landing on the page.
   const secondCountSeries = useTraceCountSeries(queries[1]);
   const thirdCountSeries = useTraceCountSeries(queries[2]);
 

--- a/static/app/views/traces/tracesChart.tsx
+++ b/static/app/views/traces/tracesChart.tsx
@@ -2,7 +2,9 @@ import {useMemo} from 'react';
 import styled from '@emotion/styled';
 
 import {getInterval} from 'sentry/components/charts/utils';
+import {CHART_PALETTE} from 'sentry/constants/chartPalette';
 import {t} from 'sentry/locale';
+import type {Series} from 'sentry/types/echarts';
 import {RateUnit} from 'sentry/utils/discover/fields';
 import {formatRate} from 'sentry/utils/formatters';
 import {decodeList} from 'sentry/utils/queryString';
@@ -10,7 +12,6 @@ import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {useLocation} from 'sentry/utils/useLocation';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import {CHART_HEIGHT} from 'sentry/views/performance/database/settings';
-import {COUNT_COLOR} from 'sentry/views/starfish/colors';
 import Chart, {ChartType} from 'sentry/views/starfish/components/chart';
 import ChartPanel from 'sentry/views/starfish/components/chartPanel';
 import {useSpanIndexedSeries} from 'sentry/views/starfish/queries/useDiscoverSeries';
@@ -21,34 +22,50 @@ interface Props {}
 
 export function TracesChart({}: Props) {
   const location = useLocation();
-  const pageFilters = usePageFilters();
 
   const queries = useMemo(() => {
     return decodeList(location.query.query);
   }, [location.query.query]);
 
-  const spanIndexedCountSeries = useSpanIndexedSeries(
-    {
-      search: new MutableSearch(
-        queries
-          .filter(Boolean)
-          .map(q => `(${q})`)
-          .join(' OR ')
-      ),
-      yAxis: ['count()'],
-      interval: getInterval(pageFilters.selection.datetime, 'metrics'),
-      overriddenRoute: 'traces-stats',
-    },
-    'api.trace-explorer.stats'
-  );
+  const firstCountSeries = useTraceCountSeries(queries[0]);
+  const secondCountSeries = useTraceCountSeries(queries[1]);
+  const thirdCountSeries = useTraceCountSeries(queries[2]);
 
-  const seriesData = spanIndexedCountSeries.data?.['count()'];
-  seriesData.z = 1; // TODO:: This shouldn't be required, but we're putting this in for now to avoid split lines being shown on top of the chart data :).
+  const seriesAreLoading =
+    firstCountSeries.isLoading ||
+    secondCountSeries.isLoading ||
+    thirdCountSeries.isLoading;
+
+  const chartData = useMemo<Series[]>(() => {
+    const data: Series[] = [];
+    const firstQueryData = firstCountSeries.data['count()'];
+    const secondQueryData = secondCountSeries.data['count()'];
+    const thirdQueryData = thirdCountSeries.data['count()'];
+
+    firstQueryData.color = CHART_PALETTE[2][0];
+    secondQueryData.color = CHART_PALETTE[2][1];
+    thirdQueryData.color = CHART_PALETTE[2][2];
+
+    firstQueryData.seriesName = queries[0];
+    secondQueryData.seriesName = queries[1];
+    thirdQueryData.seriesName = queries[2];
+
+    if (queries[0]) {
+      data.push(firstQueryData);
+    }
+    if (queries[1]) {
+      data.push(secondQueryData);
+    }
+    if (queries[2]) {
+      data.push(thirdQueryData);
+    }
+    return data;
+  }, [queries, firstCountSeries.data, secondCountSeries.data, thirdCountSeries.data]);
 
   return (
     <ChartContainer>
       <ChartPanel
-        title={areQueriesEmpty(queries) ? t('Total Spans') : t('Matching Spans')}
+        title={areQueriesEmpty(queries) ? t('Total Spans') : t('All Matching Spans')}
       >
         <Chart
           height={CHART_HEIGHT}
@@ -58,11 +75,12 @@ export function TracesChart({}: Props) {
             top: '8px',
             bottom: '0',
           }}
-          data={[seriesData]}
-          loading={spanIndexedCountSeries.isLoading}
-          chartColors={[COUNT_COLOR]}
-          type={ChartType.AREA}
+          data={chartData}
+          loading={seriesAreLoading}
+          chartColors={CHART_PALETTE[2]}
+          type={ChartType.LINE}
           aggregateOutputFormat="number"
+          showLegend
           tooltipFormatterOptions={{
             valueFormatter: value => formatRate(value, RateUnit.PER_MINUTE),
           }}
@@ -78,3 +96,17 @@ const ChartContainer = styled('div')`
   gap: 0;
   grid-template-columns: 1fr;
 `;
+
+const useTraceCountSeries = (query: string | null) => {
+  const pageFilters = usePageFilters();
+
+  return useSpanIndexedSeries(
+    {
+      search: new MutableSearch(query ?? ''),
+      yAxis: ['count()'],
+      interval: getInterval(pageFilters.selection.datetime, 'metrics'),
+      overriddenRoute: 'traces-stats',
+    },
+    'api.trace-explorer.stats'
+  );
+};


### PR DESCRIPTION
### Summary
This makes a separate line for each set of span conditions. Doing long period counts for the sum of 'within' each trace condition matches is computationally expensive and likely to be too slow. This way you can at least see each set of conditions.

### Screenshot
![Screenshot 2024-06-10 at 3 09 11 PM](https://github.com/getsentry/sentry/assets/6111995/d4ea398c-0bdf-4938-b398-976a2ad77207)

