### PR TITLE
ref(replay): Extract useEventCanShowReplayUpsell to re-use

### DIFF
--- a/static/app/components/events/eventReplay/index.spec.tsx
+++ b/static/app/components/events/eventReplay/index.spec.tsx
@@ -8,10 +8,7 @@ import {ReplayRecordFixture} from 'sentry-fixture/replayRecord';
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
 import EventReplay from 'sentry/components/events/eventReplay';
-import {
-  useHasOrganizationSentAnyReplayEvents,
-  useReplayOnboardingSidebarPanel,
-} from 'sentry/utils/replays/hooks/useReplayOnboarding';
+import {useReplayOnboardingSidebarPanel} from 'sentry/utils/replays/hooks/useReplayOnboarding';
 import useReplayReader from 'sentry/utils/replays/hooks/useReplayReader';
 import ReplayReader from 'sentry/utils/replays/replayReader';
 import useProjects from 'sentry/utils/useProjects';
@@ -100,10 +97,6 @@ describe('EventReplay', function () {
     useReplayOnboardingSidebarPanel
   );
 
-  const MockUseHasOrganizationSentAnyReplayEvents = jest.mocked(
-    useHasOrganizationSentAnyReplayEvents
-  );
-
   const organization = OrganizationFixture({
     features: ['session-replay'],
   });
@@ -137,20 +130,12 @@ describe('EventReplay', function () {
       placeholders: [],
       projects: [project],
     });
-    MockUseHasOrganizationSentAnyReplayEvents.mockReturnValue({
-      hasOrgSentReplays: false,
-      fetching: false,
-    });
     MockUseReplayOnboardingSidebarPanel.mockReturnValue({
       activateSidebar: jest.fn(),
     });
   });
 
   it('should render the replay inline onboarding component when replays are enabled and the project supports replay', async function () {
-    MockUseHasOrganizationSentAnyReplayEvents.mockReturnValue({
-      hasOrgSentReplays: false,
-      fetching: false,
-    });
     MockUseReplayOnboardingSidebarPanel.mockReturnValue({
       activateSidebar: jest.fn(),
     });
@@ -166,10 +151,6 @@ describe('EventReplay', function () {
   });
 
   it('should render a replay when there is a replayId from tags', async function () {
-    MockUseHasOrganizationSentAnyReplayEvents.mockReturnValue({
-      hasOrgSentReplays: true,
-      fetching: false,
-    });
     MockUseReplayOnboardingSidebarPanel.mockReturnValue({
       activateSidebar: jest.fn(),
     });
@@ -189,10 +170,6 @@ describe('EventReplay', function () {
   });
 
   it('should render a replay when there is a replay_id from contexts', async function () {
-    MockUseHasOrganizationSentAnyReplayEvents.mockReturnValue({
-      hasOrgSentReplays: true,
-      fetching: false,
-    });
     MockUseReplayOnboardingSidebarPanel.mockReturnValue({
       activateSidebar: jest.fn(),
     });

--- a/static/app/components/events/eventReplay/index.tsx
+++ b/static/app/components/events/eventReplay/index.tsx
@@ -3,14 +3,10 @@ import {lazy} from 'react';
 import ErrorBoundary from 'sentry/components/errorBoundary';
 import {ReplayClipSection} from 'sentry/components/events/eventReplay/replayClipSection';
 import LazyLoad from 'sentry/components/lazyLoad';
-import {replayBackendPlatforms} from 'sentry/data/platformCategories';
 import type {Event} from 'sentry/types/event';
 import type {Group} from 'sentry/types/group';
+import useEventCanShowReplayUpsell from 'sentry/utils/event/useEventCanShowReplayUpsell';
 import {getReplayIdFromEvent} from 'sentry/utils/replays/getReplayIdFromEvent';
-import {useHasOrganizationSentAnyReplayEvents} from 'sentry/utils/replays/hooks/useReplayOnboarding';
-import {projectCanUpsellReplay} from 'sentry/utils/replays/projectSupportsReplay';
-import useOrganization from 'sentry/utils/useOrganization';
-import useProjectFromSlug from 'sentry/utils/useProjectFromSlug';
 
 interface Props {
   event: Event;
@@ -21,36 +17,24 @@ interface Props {
 const ReplayOnboardingPanel = lazy(() => import('./replayInlineOnboardingPanel'));
 
 export default function EventReplay({event, group, projectSlug}: Props) {
-  const organization = useOrganization();
-  const hasReplaysFeature = organization.features.includes('session-replay');
-
-  const {hasOrgSentReplays, fetching: fetchingHasSentReplays} =
-    useHasOrganizationSentAnyReplayEvents();
-  const project = useProjectFromSlug({organization, projectSlug});
-
   const replayId = getReplayIdFromEvent(event);
-
-  if (!hasReplaysFeature || fetchingHasSentReplays) {
-    return null;
-  }
-
-  const platform = group?.project.platform ?? group?.platform ?? 'other';
-  const projectId = group?.project.id ?? event.projectID ?? '';
+  const {canShowUpsell, upsellPlatform, upsellProjectId} = useEventCanShowReplayUpsell({
+    event,
+    group,
+    projectSlug,
+  });
 
   if (replayId) {
     return <ReplayClipSection event={event} replayId={replayId} group={group} />;
   }
 
-  if (
-    projectCanUpsellReplay(project) &&
-    (!hasOrgSentReplays || replayBackendPlatforms.includes(platform))
-  ) {
+  if (canShowUpsell) {
     return (
       <ErrorBoundary mini>
         <LazyLoad
           LazyComponent={ReplayOnboardingPanel}
-          platform={platform}
-          projectId={projectId}
+          platform={upsellPlatform}
+          projectId={upsellProjectId}
         />
       </ErrorBoundary>
     );

--- a/static/app/utils/event/useEventCanShowReplayUpsell.tsx
+++ b/static/app/utils/event/useEventCanShowReplayUpsell.tsx
@@ -1,0 +1,62 @@
+import {useMemo} from 'react';
+
+import {replayBackendPlatforms} from 'sentry/data/platformCategories';
+import type {Event} from 'sentry/types/event';
+import type {Group} from 'sentry/types/group';
+import type {PlatformKey} from 'sentry/types/project';
+import {projectCanUpsellReplay} from 'sentry/utils/replays/projectSupportsReplay';
+import useOrganization from 'sentry/utils/useOrganization';
+import useProjectFromSlug from 'sentry/utils/useProjectFromSlug';
+import useProjects from 'sentry/utils/useProjects';
+
+interface Props {
+  event: Event;
+  projectSlug: string;
+  group?: Group;
+}
+
+type Result =
+  | {
+      canShowUpsell: false;
+      upsellPlatform: undefined;
+      upsellProjectId: undefined;
+    }
+  | {
+      canShowUpsell: boolean;
+      upsellPlatform: PlatformKey;
+      upsellProjectId: string;
+    };
+
+export default function useEventCanShowReplayUpsell({
+  event,
+  group,
+  projectSlug,
+}: Props): Result {
+  const organization = useOrganization();
+  const hasReplaysFeature = organization.features.includes('session-replay');
+
+  const {projects, fetching: fetchingHasSentReplays} = useProjects();
+  const hasOrgSentReplays = useMemo(() => projects.some(p => p.hasReplays), [projects]);
+  const project = useProjectFromSlug({organization, projectSlug});
+
+  if (!hasReplaysFeature || fetchingHasSentReplays) {
+    return {
+      canShowUpsell: false,
+      upsellPlatform: undefined,
+      upsellProjectId: undefined,
+    };
+  }
+
+  const upsellPlatform = group?.project.platform ?? group?.platform ?? 'other';
+  const upsellProjectId = group?.project.id ?? event.projectID ?? '';
+
+  const canShowUpsell =
+    projectCanUpsellReplay(project) &&
+    (!hasOrgSentReplays || replayBackendPlatforms.includes(upsellPlatform));
+
+  return {
+    canShowUpsell,
+    upsellPlatform,
+    upsellProjectId,
+  };
+}

--- a/static/app/utils/replays/hooks/useReplayOnboarding.tsx
+++ b/static/app/utils/replays/hooks/useReplayOnboarding.tsx
@@ -1,4 +1,4 @@
-import {useCallback, useEffect, useMemo} from 'react';
+import {useCallback, useEffect} from 'react';
 
 import {SidebarPanelKey} from 'sentry/components/sidebar/types';
 import SidebarPanelStore from 'sentry/stores/sidebarPanelStore';
@@ -6,13 +6,6 @@ import {trackAnalytics} from 'sentry/utils/analytics';
 import useSelectedProjectsHaveField from 'sentry/utils/project/useSelectedProjectsHaveField';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
-import useProjects from 'sentry/utils/useProjects';
-
-export function useHasOrganizationSentAnyReplayEvents() {
-  const {projects, fetching} = useProjects();
-  const hasOrgSentReplays = useMemo(() => projects.some(p => p.hasReplays), [projects]);
-  return {hasOrgSentReplays, fetching};
-}
 
 export function useHaveSelectedProjectsSentAnyReplayEvents() {
   const {hasField: hasSentOneReplay, fetching} =


### PR DESCRIPTION
Extracting useEventCanShowReplayUpsell, which also replaces `useHasOrganizationSentAnyReplayEvents`, so it can be re-used for the new (coming next) hydration-error-diff section inside the issue details page. 

Pulling this logic out makes `static/app/components/events/eventReplay/index.tsx` much simpler and easier to copy+paste in order to make a new component.

Relates to https://github.com/getsentry/sentry/issues/70199