### PR TITLE
fix(query-builder): Backspace should first focus token before deleting

### DIFF
--- a/static/app/components/searchQueryBuilder/filter.tsx
+++ b/static/app/components/searchQueryBuilder/filter.tsx
@@ -211,7 +211,13 @@ export function SearchQueryBuilderFilter({item, state, token}: SearchQueryTokenP
     if (e.key === 'Backspace' || e.key === 'Delete') {
       e.preventDefault();
       e.stopPropagation();
-      dispatch({type: 'DELETE_TOKEN', token});
+
+      // Only delete if full filter token is focused, otherwise focus it
+      if (ref.current === document.activeElement) {
+        dispatch({type: 'DELETE_TOKEN', token});
+      } else {
+        ref.current?.focus();
+      }
     }
   };
 

--- a/static/app/components/searchQueryBuilder/index.spec.tsx
+++ b/static/app/components/searchQueryBuilder/index.spec.tsx
@@ -621,6 +621,27 @@ describe('SearchQueryBuilder', function () {
       ).toHaveFocus();
     });
 
+    it('when focus is in a filter segment, backspace first focuses the filter then deletes it', async function () {
+      render(
+        <SearchQueryBuilder {...defaultProps} initialQuery="browser.name:firefox" />
+      );
+
+      // Focus into search (cursor be at end of the query)
+      screen
+        .getByRole('button', {name: 'Edit operator for filter: browser.name'})
+        .focus();
+
+      // Pressing backspace once should focus the token
+      await userEvent.keyboard('{backspace}');
+      expect(screen.queryByRole('row', {name: 'browser.name:firefox'})).toHaveFocus();
+
+      // Pressing backspace again should remove the token
+      await userEvent.keyboard('{backspace}');
+      expect(
+        screen.queryByRole('row', {name: 'browser.name:firefox'})
+      ).not.toBeInTheDocument();
+    });
+
     it('has a single tab stop', async function () {
       render(
         <SearchQueryBuilder {...defaultProps} initialQuery="browser.name:firefox" />


### PR DESCRIPTION
When a part of a filter is focused, like the operator or value, pressing backspace should move focus to the entire token instead of deleting it. This should prevent some accidental token deletions.