### PR TITLE
feat(issues): Render diffs for hydration errors when replay is available

### DIFF
--- a/static/app/components/events/eventEntries.tsx
+++ b/static/app/components/events/eventEntries.tsx
@@ -3,6 +3,7 @@ import styled from '@emotion/styled';
 
 import {CommitRow} from 'sentry/components/commitRow';
 import {EventEvidence} from 'sentry/components/events/eventEvidence';
+import EventHydrationDiff from 'sentry/components/events/eventHydrationDiff';
 import EventReplay from 'sentry/components/events/eventReplay';
 import {ActionableItems} from 'sentry/components/events/interfaces/crashContent/exception/actionableItems';
 import {actionableItemsEnabled} from 'sentry/components/events/interfaces/crashContent/exception/useActionableItems';
@@ -209,6 +210,7 @@ export function Entries({
         beforeReplayEntries.map((entry, entryIdx) => (
           <EventEntry key={entryIdx} entry={entry} {...eventEntryProps} />
         ))}
+      {!isShare && <EventHydrationDiff {...eventEntryProps} />}
       {!isShare && <EventReplay {...eventEntryProps} />}
       {afterReplayEntries.map((entry, entryIdx) => {
         if (hideBreadCrumbs && entry.type === EntryType.BREADCRUMBS) {

--- a/static/app/components/events/eventHydrationDiff/index.tsx
+++ b/static/app/components/events/eventHydrationDiff/index.tsx
@@ -1,0 +1,20 @@
+import {ReplayDiffSection} from 'sentry/components/events/eventHydrationDiff/replayDiffSection';
+import type {Event} from 'sentry/types/event';
+import type {Group} from 'sentry/types/group';
+import isHydrationError from 'sentry/utils/react/isHydrationError';
+import {getReplayIdFromEvent} from 'sentry/utils/replays/getReplayIdFromEvent';
+
+interface Props {
+  event: Event;
+  group?: Group;
+}
+
+export default function EventHydrationDiff({event, group}: Props) {
+  const replayId = getReplayIdFromEvent(event);
+
+  if (replayId && isHydrationError(event.title)) {
+    return <ReplayDiffSection event={event} replayId={replayId} group={group} />;
+  }
+
+  return null;
+}

--- a/static/app/components/events/eventHydrationDiff/replayDiffContent.tsx
+++ b/static/app/components/events/eventHydrationDiff/replayDiffContent.tsx
@@ -1,0 +1,68 @@
+import ErrorBoundary from 'sentry/components/errorBoundary';
+import {EventDataSection} from 'sentry/components/events/eventDataSection';
+import Placeholder from 'sentry/components/placeholder';
+import {OpenReplayComparisonButton} from 'sentry/components/replays/breadcrumbs/openReplayComparisonButton';
+import ReplayDiff, {DiffType} from 'sentry/components/replays/replayDiff';
+import {ReplayGroupContextProvider} from 'sentry/components/replays/replayGroupContext';
+import {t} from 'sentry/locale';
+import type {Event} from 'sentry/types/event';
+import type {Group} from 'sentry/types/group';
+import useReplayReader from 'sentry/utils/replays/hooks/useReplayReader';
+
+interface Props {
+  event: Event;
+  group: Group | undefined;
+  orgSlug: string;
+  replaySlug: string;
+}
+
+export default function ReplayDiffContent({event, group, orgSlug, replaySlug}: Props) {
+  const replayContext = useReplayReader({
+    orgSlug,
+    replaySlug,
+  });
+  const {fetching, replay} = replayContext;
+
+  if (fetching) {
+    return <Placeholder />;
+  }
+
+  if (!replay) {
+    return null;
+  }
+
+  // TODO: base the event timestamp off the replay data itself.
+  const startTimestampMS =
+    'startTimestamp' in event ? event.startTimestamp * 1000 : undefined;
+  const timeOfEvent = event.dateCreated ?? startTimestampMS ?? event.dateReceived;
+  const eventTimestampMs = timeOfEvent ? Math.floor(new Date(timeOfEvent).getTime()) : 0;
+
+  return (
+    <EventDataSection
+      type="hydration-diff"
+      title={t('Hydration Error Diff')}
+      actions={
+        <OpenReplayComparisonButton
+          key="open-modal-button"
+          leftTimestamp={0}
+          replay={replay}
+          rightTimestamp={eventTimestampMs}
+          size="xs"
+        >
+          {t('Open Diff Viewer')}
+        </OpenReplayComparisonButton>
+      }
+    >
+      <ErrorBoundary mini>
+        <ReplayGroupContextProvider groupId={group?.id} eventId={event.id}>
+          <ReplayDiff
+            defaultTab={DiffType.VISUAL}
+            leftTimestamp={0}
+            replay={replay}
+            rightTimestamp={eventTimestampMs}
+          />
+        </ReplayGroupContextProvider>
+      </ErrorBoundary>
+    </EventDataSection>
+  );
+}

--- a/static/app/components/events/eventHydrationDiff/replayDiffSection.tsx
+++ b/static/app/components/events/eventHydrationDiff/replayDiffSection.tsx
@@ -1,0 +1,53 @@
+import {lazy} from 'react';
+import ReactLazyLoad from 'react-lazyload';
+import styled from '@emotion/styled';
+
+import NegativeSpaceContainer from 'sentry/components/container/negativeSpaceContainer';
+import ErrorBoundary from 'sentry/components/errorBoundary';
+import {EventDataSection} from 'sentry/components/events/eventDataSection';
+import {REPLAY_LOADING_HEIGHT} from 'sentry/components/events/eventReplay/constants';
+import LazyLoad from 'sentry/components/lazyLoad';
+import LoadingIndicator from 'sentry/components/loadingIndicator';
+import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
+import type {Event} from 'sentry/types/event';
+import type {Group} from 'sentry/types/group';
+import useOrganization from 'sentry/utils/useOrganization';
+
+interface Props {
+  event: Event;
+  group: Group | undefined;
+  replayId: string;
+}
+
+const ReplayDiffContent = lazy(() => import('./replayDiffContent'));
+
+export function ReplayDiffSection({event, group, replayId}: Props) {
+  const organization = useOrganization();
+
+  return (
+    <ErrorBoundary mini>
+      <ReactLazyLoad debounce={50} height={448} offset={0} once>
+        <LazyLoad
+          event={event}
+          group={group}
+          orgSlug={organization.slug}
+          replaySlug={replayId}
+          LazyComponent={ReplayDiffContent}
+          loadingFallback={
+            <EventDataSection type="hydration-diff" title={t('Hydration Error Diff')}>
+              <StyledNegativeSpaceContainer testId="replay-diff-loading-placeholder">
+                <LoadingIndicator />
+              </StyledNegativeSpaceContainer>
+            </EventDataSection>
+          }
+        />
+      </ReactLazyLoad>
+    </ErrorBoundary>
+  );
+}
+
+export const StyledNegativeSpaceContainer = styled(NegativeSpaceContainer)`
+  height: ${REPLAY_LOADING_HEIGHT}px;
+  margin-bottom: ${space(2)};
+`;

--- a/static/app/views/issueDetails/groupEventDetails/groupEventDetailsContent.tsx
+++ b/static/app/views/issueDetails/groupEventDetails/groupEventDetailsContent.tsx
@@ -10,6 +10,7 @@ import {EventDataSection} from 'sentry/components/events/eventDataSection';
 import {EventEntry} from 'sentry/components/events/eventEntry';
 import {EventEvidence} from 'sentry/components/events/eventEvidence';
 import {EventExtraData} from 'sentry/components/events/eventExtraData';
+import EventHydrationDiff from 'sentry/components/events/eventHydrationDiff';
 import EventReplay from 'sentry/components/events/eventReplay';
 import {EventSdk} from 'sentry/components/events/eventSdk';
 import AggregateSpanDiff from 'sentry/components/events/eventStatisticalDetector/aggregateSpanDiff';
@@ -210,6 +211,7 @@ function DefaultGroupEventDetailsContent({
           projectSlug={project.slug}
         />
       )}
+      <EventHydrationDiff event={event} group={group} />
       <EventReplay event={event} group={group} projectSlug={project.slug} />
       <GroupEventEntry entryType={EntryType.HPKP} {...eventEntryProps} />
       <GroupEventEntry entryType={EntryType.CSP} {...eventEntryProps} />


### PR DESCRIPTION
New section in the Issue Details page, and event details page, to give users debugging context when a hydration error happens.

This context only appears when a replay exists. 
So for issues with `issueType==IssueType.ERROR` it's not guaranteed (these issues will exist if the inbound filter is disabled)
But for issues with `issueType==IssueType.REPLAY_HYDRATION_ERROR` then there will be a replay (new issue type needs to be enabled in 'Project Settings > Replay')

**New Context**
| Visual Diff | HTML Diff |
| --- | --- |
| <img width="993" alt="SCR-20240610-lkdb" src="https://github.com/getsentry/sentry/assets/187460/e579976d-3cc8-4530-a7a9-af717a3d69d6"> | <img width="990" alt="SCR-20240610-lked" src="https://github.com/getsentry/sentry/assets/187460/a2ef5210-1507-43c3-bb55-ff54a800478c"> |

Fixes https://github.com/getsentry/sentry/issues/72150
Relates to https://github.com/getsentry/sentry/issues/70199