### PR TITLE
fix(grouping): Provide defaults for `CalculatedHashes` fields

### DIFF
--- a/src/sentry/grouping/api.py
+++ b/src/sentry/grouping/api.py
@@ -72,7 +72,7 @@ class GroupHashInfo:
 
 
 NULL_GROUPING_CONFIG: GroupingConfig = {"id": "", "enhancements": ""}
-NULL_HASHES = CalculatedHashes(hashes=[], hierarchical_hashes=[], tree_labels=[])
+NULL_HASHES = CalculatedHashes([])
 NULL_GROUPHASH_INFO = GroupHashInfo(NULL_GROUPING_CONFIG, NULL_HASHES, [], None)
 
 

--- a/src/sentry/grouping/ingest/hashing.py
+++ b/src/sentry/grouping/ingest/hashing.py
@@ -370,6 +370,9 @@ def get_hash_values(
         tree_labels=(
             primary_hashes.tree_labels or (secondary_hashes and secondary_hashes.tree_labels) or []
         ),
+        # We don't set a combo `variants` value here because one set of variants would/could
+        # partially or fully overwrite the other (it's a dictionary), and having variants from two
+        # different configs all mixed in together makes no sense.
     )
 
     if all_hashes.tree_labels:

--- a/src/sentry/grouping/ingest/seer.py
+++ b/src/sentry/grouping/ingest/seer.py
@@ -36,14 +36,6 @@ def should_call_seer_for_grouping(
     if not has_either_seer_grouping_feature:
         return False
 
-    # TODO: In our context, this can never happen. There are other scenarios in which `variants` can
-    # be `None`, but where we'll be using this (during ingestion) it's not possible. This check is
-    # primarily to satisfy mypy. Once we get rid of hierarchical hashing, we'll be able to
-    # make `variants` required in `CalculatedHashes`, meaning we can remove this check. (See note in
-    # `CalculatedHashes` class definition.)
-    if primary_hashes.variants is None:
-        raise Exception("Primary hashes missing variants data")
-
     fingerprint_variant = primary_hashes.variants.get(
         "custom-fingerprint"
     ) or primary_hashes.variants.get("built-in-fingerprint")
@@ -149,14 +141,6 @@ def get_seer_similar_issues(
     Will also return `None` for the neighboring group if the `projects:similarity-embeddings-grouping`
     feature flag is off.
     """
-
-    # TODO: In our context, this can never happen. There are other scenarios in which `variants` can
-    # be `None`, but where we'll be using this (during ingestion) it's not possible. This check is
-    # primarily to satisfy mypy. Once we get rid of hierarchical hashing, we'll be able to
-    # make `variants` required in `CalculatedHashes`, meaning we can remove this check. (See note in
-    # `CalculatedHashes` class definition.)
-    if primary_hashes.variants is None:
-        raise Exception("Primary hashes missing variants data")
 
     event_hash = primary_hashes.hashes[0]
     stacktrace_string = get_stacktrace_string(

--- a/src/sentry/grouping/result.py
+++ b/src/sentry/grouping/result.py
@@ -1,5 +1,5 @@
 from collections.abc import Sequence
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any, Optional, TypedDict
 
 from sentry.db.models import NodeData
@@ -98,8 +98,8 @@ def _write_tree_labels(tree_labels: Sequence[TreeLabel | None], event_data: Node
 @dataclass(frozen=True)
 class CalculatedHashes:
     hashes: list[str]
-    hierarchical_hashes: list[str]
-    tree_labels: list[TreeLabel | None]
+    hierarchical_hashes: list[str] = field(default_factory=list)
+    tree_labels: list[TreeLabel | None] = field(default_factory=list)
     # `variants` will never be `None` when the `CalculatedHashes` instance is created as part of
     # event grouping, but it has to be typed including `None` because we use the `CalculatedHashes`
     # container in other places where we don't have the variants data
@@ -108,7 +108,7 @@ class CalculatedHashes:
     # `CalculatedHashes` to wrap `hashes` - meaning we don't need a wrapper at all, and can save use
     # of `CalculatedHashes` for times when we know the variants are there (so we can make them
     # required in the type)
-    variants: dict[str, BaseVariant] | None = None
+    variants: dict[str, BaseVariant] = field(default_factory=dict)
 
     def write_to_event(self, event_data: NodeData) -> None:
         event_data["hashes"] = self.hashes

--- a/tests/sentry/event_manager/test_event_manager_grouping.py
+++ b/tests/sentry/event_manager/test_event_manager_grouping.py
@@ -420,15 +420,11 @@ class EventManagerGroupingMetricsTest(TestCase):
         for primary_hashes, secondary_hashes, expected_tag in cases:
             with mock.patch(
                 "sentry.grouping.ingest.hashing._calculate_primary_hash",
-                return_value=CalculatedHashes(
-                    hashes=primary_hashes, hierarchical_hashes=[], tree_labels=[]
-                ),
+                return_value=CalculatedHashes(primary_hashes),
             ):
                 with mock.patch(
                     "sentry.grouping.ingest.hashing._calculate_secondary_hash",
-                    return_value=CalculatedHashes(
-                        hashes=secondary_hashes, hierarchical_hashes=[], tree_labels=[]
-                    ),
+                    return_value=CalculatedHashes(secondary_hashes),
                 ):
                     save_new_event({"message": "Dogs are great!"}, self.project)
 

--- a/tests/sentry/event_manager/test_save_aggregate.py
+++ b/tests/sentry/event_manager/test_save_aggregate.py
@@ -65,11 +65,7 @@ def test_group_creation_race_new(
         "11212012123120120415201309082013",
         data={"timestamp": time.time()},
     )
-    hashes = CalculatedHashes(
-        hashes=["pound sign", "octothorpe"],
-        hierarchical_hashes=[],
-        tree_labels=[],
-    )
+    hashes = CalculatedHashes(["pound sign", "octothorpe"])
 
     # Mypy has a bug and can't handle the combo of a `...` input type and a ternary for the value
     # See https://github.com/python/mypy/issues/14661

--- a/tests/sentry/eventstore/test_models.py
+++ b/tests/sentry/eventstore/test_models.py
@@ -410,7 +410,7 @@ class EventTest(TestCase, PerformanceIssueTestCase):
             project_id=self.project.id,
         )
 
-        assert event.get_hashes() == CalculatedHashes(hashes, [], [], None)
+        assert event.get_hashes() == CalculatedHashes(hashes)
 
     def test_get_hashes_gets_hashes_and_variants_if_none_on_event(self):
         self.project.update_option("sentry:grouping_config", NEWSTYLE_GROUPING_CONFIG)

--- a/tests/sentry/grouping/test_seer.py
+++ b/tests/sentry/grouping/test_seer.py
@@ -51,8 +51,6 @@ class ShouldCallSeerTest(TestCase):
         )
         self.primary_hashes = CalculatedHashes(
             hashes=["04152013090820131121201212312012"],
-            hierarchical_hashes=[],
-            tree_labels=[],
             variants={"default": FallbackVariant()},
         )
 
@@ -138,14 +136,10 @@ class ShouldCallSeerTest(TestCase):
     def test_returns_false_if_event_has_custom_fingerprint(self):
         custom_fingerprint_hashes = CalculatedHashes(
             hashes=["04152013090820131121201212312012"],
-            hierarchical_hashes=[],
-            tree_labels=[],
             variants={"custom-fingerprint": CustomFingerprintVariant(["maisey"])},
         )
         built_in_fingerprint_hashes = CalculatedHashes(
             hashes=["04152013090820131121201212312012"],
-            hierarchical_hashes=[],
-            tree_labels=[],
             variants={"built-in-fingerprint": BuiltInFingerprintVariant(["charlie"])},
         )
 
@@ -169,12 +163,7 @@ class GetSeerSimilarIssuesTest(TestCase):
             event_id="11212012123120120415201309082013",
             data={"message": "Adopt don't shop"},
         )
-        self.new_event_hashes = CalculatedHashes(
-            hashes=["20130809201315042012311220122111"],
-            hierarchical_hashes=[],
-            tree_labels=[],
-            variants={},
-        )
+        self.new_event_hashes = CalculatedHashes(["20130809201315042012311220122111"])
 
     @with_feature({"projects:similarity-embeddings-grouping": False})
     def test_returns_metadata_but_no_group_if_seer_grouping_flag_off(self):


### PR DESCRIPTION
This adds default values for all fields in the `CalculatedHashes` class except for `hashes`. The advantages of doing this are twofold:

- There are a bunch of places were we pass in the default values, not because we actually need them, but because otherwise the constructor crashes. This lets us clean those up.
- By doing this, we can force the `variants` field to always have a value, which then saves us needing to check whether or not it does, especially in places where we know ahead of time it will. (This latter reason is what inspired the change, as those spots were starting to proliferate.)