### PR TITLE
ref(seer grouping): Small fixes to Seer ingest code

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -1502,7 +1502,7 @@ def _save_aggregate(
             if existing_grouphash is None:
                 seer_matched_group = None
 
-                if should_call_seer_for_grouping(event, project, primary_hashes):
+                if should_call_seer_for_grouping(event, primary_hashes):
                     try:
                         # If the `projects:similarity-embeddings-grouping` feature is disabled,
                         # we'll still get back result metadata, but `seer_matched_group` will be None

--- a/src/sentry/grouping/ingest/seer.py
+++ b/src/sentry/grouping/ingest/seer.py
@@ -20,14 +20,14 @@ from sentry.utils import metrics
 logger = logging.getLogger("sentry.events.grouping")
 
 
-def should_call_seer_for_grouping(
-    event: Event, project: Project, primary_hashes: CalculatedHashes
-) -> bool:
+def should_call_seer_for_grouping(event: Event, primary_hashes: CalculatedHashes) -> bool:
     """
     Use event content, feature flags, rate limits, killswitches, seer health, etc. to determine
     whether a call to Seer should be made.
     """
     # TODO: Implement rate limits, kill switches, other flags, etc
+
+    project = event.project
 
     has_either_seer_grouping_feature = features.has(
         "projects:similarity-embeddings-metadata", project

--- a/src/sentry/grouping/ingest/seer.py
+++ b/src/sentry/grouping/ingest/seer.py
@@ -54,8 +54,15 @@ def should_call_seer_for_grouping(event: Event, primary_hashes: CalculatedHashes
     if not event_content_is_seer_eligible(event):
         return False
 
-    # The circuit breaker check which might naturally also go here (along with its killswitch and
-    # ratelimiting friends) instead happens in the `with_circuit_breaker` helper used where
+    # **Do not add any new checks after this.** The rate limit check MUST remain the last of all the
+    # checks.
+    #
+    # (Checking the rate limit for calling Seer also increments the counter of how many times we've
+    # tried to call it, and if we fail any of the other checks, it shouldn't count as an attempt.
+    # Thus we only want to run the rate limit check if every other check has already succeeded.)
+    #
+    # Note: The circuit breaker check which might naturally be here alongside its killswitch
+    # and rate limiting friends instead happens in the `with_circuit_breaker` helper used where
     # `get_seer_similar_issues` is actually called. (It has to be there in order for it to track
     # errors arising from that call.)
     if _killswitch_enabled(event, project) or _ratelimiting_enabled(event, project):

--- a/src/sentry/grouping/ingest/seer.py
+++ b/src/sentry/grouping/ingest/seer.py
@@ -25,7 +25,6 @@ def should_call_seer_for_grouping(event: Event, primary_hashes: CalculatedHashes
     Use event content, feature flags, rate limits, killswitches, seer health, etc. to determine
     whether a call to Seer should be made.
     """
-    # TODO: Implement rate limits, kill switches, other flags, etc
 
     project = event.project
 

--- a/tests/sentry/grouping/test_seer.py
+++ b/tests/sentry/grouping/test_seer.py
@@ -70,7 +70,7 @@ class ShouldCallSeerTest(TestCase):
                 }
             ):
                 assert (
-                    should_call_seer_for_grouping(self.event, self.project, self.primary_hashes)
+                    should_call_seer_for_grouping(self.event, self.primary_hashes)
                     is expected_result
                 ), f"Case ({metadata_flag}, {grouping_flag}) failed."
 
@@ -82,7 +82,7 @@ class ShouldCallSeerTest(TestCase):
                 return_value=content_eligibility,
             ):
                 assert (
-                    should_call_seer_for_grouping(self.event, self.project, self.primary_hashes)
+                    should_call_seer_for_grouping(self.event, self.primary_hashes)
                     is expected_result
                 )
 
@@ -91,7 +91,7 @@ class ShouldCallSeerTest(TestCase):
         for killswitch_enabled, expected_result in [(True, False), (False, True)]:
             with override_options({"seer.global-killswitch.enabled": killswitch_enabled}):
                 assert (
-                    should_call_seer_for_grouping(self.event, self.project, self.primary_hashes)
+                    should_call_seer_for_grouping(self.event, self.primary_hashes)
                     is expected_result
                 )
 
@@ -100,7 +100,7 @@ class ShouldCallSeerTest(TestCase):
         for killswitch_enabled, expected_result in [(True, False), (False, True)]:
             with override_options({"seer.similarity-killswitch.enabled": killswitch_enabled}):
                 assert (
-                    should_call_seer_for_grouping(self.event, self.project, self.primary_hashes)
+                    should_call_seer_for_grouping(self.event, self.primary_hashes)
                     is expected_result
                 )
 
@@ -114,7 +114,7 @@ class ShouldCallSeerTest(TestCase):
                 ),
             ):
                 assert (
-                    should_call_seer_for_grouping(self.event, self.project, self.primary_hashes)
+                    should_call_seer_for_grouping(self.event, self.primary_hashes)
                     is expected_result
                 )
 
@@ -130,7 +130,7 @@ class ShouldCallSeerTest(TestCase):
                 ),
             ):
                 assert (
-                    should_call_seer_for_grouping(self.event, self.project, self.primary_hashes)
+                    should_call_seer_for_grouping(self.event, self.primary_hashes)
                     is expected_result
                 )
 
@@ -150,15 +150,9 @@ class ShouldCallSeerTest(TestCase):
         )
 
         # `self.primary_hashes` has only a `FallbackVariant`
-        assert should_call_seer_for_grouping(self.event, self.project, self.primary_hashes) is True
-        assert (
-            should_call_seer_for_grouping(self.event, self.project, custom_fingerprint_hashes)
-            is False
-        )
-        assert (
-            should_call_seer_for_grouping(self.event, self.project, built_in_fingerprint_hashes)
-            is False
-        )
+        assert should_call_seer_for_grouping(self.event, self.primary_hashes) is True
+        assert should_call_seer_for_grouping(self.event, custom_fingerprint_hashes) is False
+        assert should_call_seer_for_grouping(self.event, built_in_fingerprint_hashes) is False
 
 
 class GetSeerSimilarIssuesTest(TestCase):


### PR DESCRIPTION
This includes a few small changes cleaning up the work I did recently on calling Seer during ingest:

- Simplify the `should_call_seer_for_grouping` signature
- Remove an old TODO
- Add a comment to remind us that we want to check rate limiting last when deciding whether to call Seer