### PR TITLE
ref(rules): Percent of sessions affected uses floats

### DIFF
--- a/src/sentry/api/endpoints/project_rules.py
+++ b/src/sentry/api/endpoints/project_rules.py
@@ -325,12 +325,12 @@ A list of triggers that determine when the rule fires. See below for a list of p
 ```
 
 **The issue affects more than `value` percent of sessions in `interval`**
-- `value` - An integer from 0 to 100
+- `value` - A float
 - `interval` - Valid values are `5m`, `10m`, `30m`, and `1h` (`m` for minutes, `h` for hours).
 ```json
 {
     "id": "sentry.rules.conditions.event_frequency.EventFrequencyPercentCondition",
-    "value": 50,
+    "value": 50.0,
     "interval": "10m"
 }
 ```

--- a/src/sentry/rules/processing/delayed_processing.py
+++ b/src/sentry/rules/processing/delayed_processing.py
@@ -177,7 +177,7 @@ def get_rules_to_fire(
                 )
                 results = condition_group_results.get(unique_condition, {})
                 if results:
-                    target_value = int(str(slow_condition.get("value")))
+                    target_value = float(str(slow_condition.get("value")))
                     if results[group_id] > target_value:
                         if action_match == "any":
                             rules_to_fire[alert_rule].add(group_id)

--- a/tests/sentry/api/endpoints/test_project_rule_details.py
+++ b/tests/sentry/api/endpoints/test_project_rule_details.py
@@ -648,7 +648,7 @@ class UpdateProjectRuleTest(ProjectRuleDetailsBaseTestCase):
             {
                 "id": "sentry.rules.conditions.event_frequency.EventFrequencyPercentCondition",
                 "interval": "1h",
-                "value": "100",
+                "value": "100.0",
                 "comparisonType": "count",
             }
         )
@@ -809,7 +809,7 @@ class UpdateProjectRuleTest(ProjectRuleDetailsBaseTestCase):
             {
                 "id": "sentry.rules.conditions.event_frequency.EventFrequencyPercentCondition",
                 "interval": "1h",
-                "value": "100",
+                "value": "100.0",
                 "comparisonType": "count",
             }
         )

--- a/tests/sentry/api/endpoints/test_project_rules.py
+++ b/tests/sentry/api/endpoints/test_project_rules.py
@@ -477,7 +477,7 @@ class CreateProjectRuleTest(ProjectRuleBaseTestCase):
             {
                 "id": "sentry.rules.conditions.event_frequency.EventFrequencyPercentCondition",
                 "interval": "1h",
-                "value": 100,
+                "value": 100.0,
                 "comparisonType": "count",
             }
         ]
@@ -566,7 +566,7 @@ class CreateProjectRuleTest(ProjectRuleBaseTestCase):
         condition = {
             "id": "sentry.rules.conditions.event_frequency.EventFrequencyPercentCondition",
             "interval": "1h",
-            "value": 101,
+            "value": 101.0,
             "comparisonType": "count",
         }
         response = self.get_error_response(

--- a/tests/sentry/rules/processing/test_delayed_processing.py
+++ b/tests/sentry/rules/processing/test_delayed_processing.py
@@ -85,7 +85,7 @@ class ProcessDelayedAlertConditionsTest(
             id="EventUniqueUserFrequencyCondition",
         )
         event_frequency_percent_condition = self.create_event_frequency_condition(
-            interval="5m", id="EventFrequencyPercentCondition"
+            interval="5m", id="EventFrequencyPercentCondition", value=1.0
         )
         self.now = datetime.now(UTC)
 


### PR DESCRIPTION
I began rolling out the delayed rule processor and it triggered this issue: https://sentry.sentry.io/issues/5474453009 - it turns out the `EventFrequencyPercentCondition` value is stored as a float, even though the docs and all tests use integers. 