### PR TITLE
fix(insights): sample panel overflowing

### DIFF
--- a/static/app/views/performance/cache/samplePanel/samplePanel.tsx
+++ b/static/app/views/performance/cache/samplePanel/samplePanel.tsx
@@ -276,22 +276,20 @@ export function CacheSamplePanel() {
                   tooltip={project.slug}
                 />
               )}
-              <TitleContainer>
-                <Title>
-                  <Link
-                    to={normalizeUrl(
-                      `/organizations/${organization.slug}/performance/summary?${qs.stringify(
-                        {
-                          project: query.project,
-                          transaction: query.transaction,
-                        }
-                      )}`
-                    )}
-                  >
-                    {query.transaction}
-                  </Link>
-                </Title>
-              </TitleContainer>
+              <Title>
+                <Link
+                  to={normalizeUrl(
+                    `/organizations/${organization.slug}/performance/summary?${qs.stringify(
+                      {
+                        project: query.project,
+                        transaction: query.transaction,
+                      }
+                    )}`
+                  )}
+                >
+                  {query.transaction}
+                </Link>
+              </Title>
             </HeaderContainer>
           </ModuleLayout.Full>
 
@@ -478,26 +476,23 @@ const SpanSummaryProjectAvatar = styled(ProjectAvatar)`
   padding-right: ${space(1)};
 `;
 
+// TODO - copy of static/app/views/starfish/views/spanSummaryPage/sampleList/index.tsx
 const HeaderContainer = styled('div')`
   display: grid;
   grid-template-rows: auto auto auto;
+  align-items: center;
 
   @media (min-width: ${p => p.theme.breakpoints.small}) {
     grid-template-rows: auto;
-    grid-template-columns: auto 1fr auto;
+    grid-template-columns: auto 1fr;
   }
 `;
 
-const TitleContainer = styled('div')`
-  width: 100%;
-  position: relative;
-  height: 40px;
-`;
-
 const Title = styled('h4')`
-  position: absolute;
-  bottom: 0;
-  margin-bottom: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  margin: 0;
 `;
 
 const MetricsRibbon = styled('div')`

--- a/static/app/views/performance/http/httpSamplesPanel.tsx
+++ b/static/app/views/performance/http/httpSamplesPanel.tsx
@@ -319,26 +319,24 @@ export function HTTPSamplesPanel() {
                   tooltip={project.slug}
                 />
               )}
-              <TitleContainer>
-                <Title>
-                  <Link
-                    to={normalizeUrl(
-                      `/organizations/${organization.slug}/performance/summary?${qs.stringify(
-                        {
-                          project: query.project,
-                          transaction: query.transaction,
-                        }
-                      )}`
-                    )}
-                  >
-                    {query.transaction &&
-                    query.transactionMethod &&
-                    !query.transaction.startsWith(query.transactionMethod)
-                      ? `${query.transactionMethod} ${query.transaction}`
-                      : query.transaction}
-                  </Link>
-                </Title>
-              </TitleContainer>
+              <Title>
+                <Link
+                  to={normalizeUrl(
+                    `/organizations/${organization.slug}/performance/summary?${qs.stringify(
+                      {
+                        project: query.project,
+                        transaction: query.transaction,
+                      }
+                    )}`
+                  )}
+                >
+                  {query.transaction &&
+                  query.transactionMethod &&
+                  !query.transaction.startsWith(query.transactionMethod)
+                    ? `${query.transactionMethod} ${query.transaction}`
+                    : query.transaction}
+                </Link>
+              </Title>
             </HeaderContainer>
           </ModuleLayout.Full>
 
@@ -603,26 +601,23 @@ const HTTP_RESPONSE_CODE_CLASS_OPTIONS = [
   },
 ];
 
+// TODO - copy of static/app/views/starfish/views/spanSummaryPage/sampleList/index.tsx
 const HeaderContainer = styled('div')`
   display: grid;
   grid-template-rows: auto auto auto;
+  align-items: center;
 
   @media (min-width: ${p => p.theme.breakpoints.small}) {
     grid-template-rows: auto;
-    grid-template-columns: auto 1fr auto;
+    grid-template-columns: auto 1fr;
   }
 `;
 
-const TitleContainer = styled('div')`
-  width: 100%;
-  position: relative;
-  height: 40px;
-`;
-
 const Title = styled('h4')`
-  position: absolute;
-  bottom: 0;
-  margin-bottom: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  margin: 0;
 `;
 
 const MetricsRibbon = styled('div')`

--- a/static/app/views/performance/queues/destinationSummary/messageSpanSamplesPanel.tsx
+++ b/static/app/views/performance/queues/destinationSummary/messageSpanSamplesPanel.tsx
@@ -523,20 +523,20 @@ const HeaderContainer = styled('div')`
 
   @media (min-width: ${p => p.theme.breakpoints.small}) {
     grid-template-rows: auto;
-    grid-template-columns: auto 1fr auto;
+    grid-template-columns: auto 1fr;
   }
 `;
 
 const TitleContainer = styled('div')`
   width: 100%;
-  position: relative;
-  height: 40px;
+  overflow: hidden;
 `;
 
 const Title = styled('h4')`
-  position: absolute;
-  bottom: 0;
-  margin-bottom: 0;
+  overflow: inherit;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  margin: 0;
 `;
 
 const MetricsRibbonContainer = styled('div')`

--- a/static/app/views/starfish/views/spanSummaryPage/sampleList/index.tsx
+++ b/static/app/views/starfish/views/spanSummaryPage/sampleList/index.tsx
@@ -271,7 +271,7 @@ const HeaderContainer = styled('div')`
 
   @media (min-width: ${p => p.theme.breakpoints.small}) {
     grid-template-rows: auto;
-    grid-template-columns: 50px 1fr;
+    grid-template-columns: auto 1fr;
   }
 `;
 

--- a/static/app/views/starfish/views/spanSummaryPage/sampleList/index.tsx
+++ b/static/app/views/starfish/views/spanSummaryPage/sampleList/index.tsx
@@ -46,7 +46,6 @@ type Props = {
   moduleName: ModuleName;
   transactionName: string;
   onClose?: () => void;
-  spanDescription?: string;
   transactionMethod?: string;
   transactionRoute?: string;
 };
@@ -56,7 +55,6 @@ export function SampleList({
   moduleName,
   transactionName,
   transactionMethod,
-  spanDescription,
   onClose,
   transactionRoute = '/performance/summary/',
 }: Props) {
@@ -191,12 +189,9 @@ export function SampleList({
               tooltip={project.slug}
             />
           )}
-          <TitleContainer>
-            {spanDescription && <SpanDescription>{spanDescription}</SpanDescription>}
-            <Title>
-              <Link to={link}>{label}</Link>
-            </Title>
-          </TitleContainer>
+          <Title>
+            <Link to={link}>{label}</Link>
+          </Title>
         </HeaderContainer>
         <PageAlert />
 
@@ -272,31 +267,19 @@ const HeaderContainer = styled('div')`
 
   display: grid;
   grid-template-rows: auto auto auto;
+  align-items: center;
 
   @media (min-width: ${p => p.theme.breakpoints.small}) {
     grid-template-rows: auto;
-    grid-template-columns: auto 1fr auto;
+    grid-template-columns: 50px 1fr;
   }
 `;
 
-const TitleContainer = styled('div')`
-  width: 100%;
-  position: relative;
-  height: 40px;
-`;
-
 const Title = styled('h4')`
-  position: absolute;
-  bottom: 0;
-  margin-bottom: 0;
-`;
-
-const SpanDescription = styled('div')`
-  display: inline-block;
-  white-space: nowrap;
-  overflow: hidden;
   text-overflow: ellipsis;
-  max-width: 35vw;
+  overflow: hidden;
+  white-space: nowrap;
+  margin: 0;
 `;
 
 const StyledSearchBar = styled(SearchBar)`


### PR DESCRIPTION
1. Fixed overflow in transaction title in sample sidebar, vertical center icon / text, and fix overlapping

This applies to the following module, as these appeared to have the copy and pasted sidebar title
1. Requests
2. Queries
3. Assets
4. Caches
5. Queues

| Before | After |
|--------|--------|
| ![image](https://github.com/getsentry/sentry/assets/44422760/2552ef5d-11f1-4a00-a920-f5529b43498a) | ![image](https://github.com/getsentry/sentry/assets/44422760/32722bf0-58cf-4db8-82d8-d913d35a5255) |
| ![image](https://github.com/getsentry/sentry/assets/44422760/f6a0e8f8-3c57-4d5b-bf05-1aebb4ec6c6e) | ![image](https://github.com/getsentry/sentry/assets/44422760/c3816199-8d42-4132-8622-785ee691f10b) |
|![image](https://github.com/getsentry/sentry/assets/44422760/e1d3dfa9-a6fb-455b-aff3-78acac727b60) | ![image](https://github.com/getsentry/sentry/assets/44422760/db5d50ee-5a1f-4a6f-80d3-73dc8deca0d9) |
|![image](https://github.com/getsentry/sentry/assets/44422760/4bcf7198-e39f-493e-8f9a-d65786ddc9fd) | ![image](https://github.com/getsentry/sentry/assets/44422760/4828444e-8f32-4984-94a1-0869b73957c7) |

7. Removes unused `spanDescription` prop from sampleList and corresponding rendered item (made css stuff a bit easier too)