### PR TITLE
ref(slack): verify signature with SDK class

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -404,6 +404,8 @@ def register_temporary_features(manager: FeatureManager):
     # Feature flags for migrating to the Slack SDK WebClient
     # SlackNotifyServiceAction
     manager.add("organizations:slack-sdk-issue-alert-action", OrganizationFeature, FeatureHandlerStrategy.OPTIONS)
+    # Use new Slack SDK Client for verifying webhook signatures
+    manager.add("organizations:slack-sdk-signature", OrganizationFeature, FeatureHandlerStrategy.OPTIONS)
     # Add regression chart as image to slack message
     manager.add("organizations:slack-endpoint-regression-image", OrganizationFeature, FeatureHandlerStrategy.OPTIONS)
     manager.add("organizations:slack-function-regression-image", OrganizationFeature, FeatureHandlerStrategy.OPTIONS)

--- a/src/sentry/integrations/slack/requests/base.py
+++ b/src/sentry/integrations/slack/requests/base.py
@@ -212,12 +212,27 @@ class SlackRequest:
             if self._org and features.has("organizations:slack-sdk-signature", self._org):
                 signature = self.request.META.get("HTTP_X_SLACK_SIGNATURE")
                 timestamp = self.request.META.get("HTTP_X_SLACK_REQUEST_TIMESTAMP")
+                logger.info(
+                    "slack.request.verify_signature",
+                    extra={
+                        "organization_id": self._org.id,
+                        "integration_id": self._integration.id if self._integration else None,
+                    },
+                )
                 if SignatureVerifier(signing_secret).is_valid(
                     body=self.request.body, timestamp=timestamp, signature=signature
                 ):
                     return
-            elif self._check_signing_secret(signing_secret):
-                return
+            else:
+                logger.info(
+                    "slack.request.check_signing_secret",
+                    extra={
+                        "organization_id": self._org.id if self._org else None,
+                        "integration_id": self._integration.id if self._integration else None,
+                    },
+                )
+                if self._check_signing_secret(signing_secret):
+                    return
         elif verification_token and self._check_verification_token(verification_token):
             return
 

--- a/src/sentry/integrations/slack/requests/base.py
+++ b/src/sentry/integrations/slack/requests/base.py
@@ -233,18 +233,12 @@ class SlackRequest:
         if self._organization and features.has(
             "organizations:slack-sdk-signature", self._organization
         ):
-            logger.info(
-                "slack.request.verify_signature",
-                extra=log_extra,
-            )
+            logger.info("slack.request.verify_signature", extra=log_extra)
             return SignatureVerifier(signing_secret).is_valid(
                 body=self.request.body, timestamp=timestamp, signature=signature
             )
 
-        logger.info(
-            "slack.request.check_signing_secret",
-            extra=log_extra,
-        )
+        logger.info("slack.request.check_signing_secret", extra=log_extra)
 
         return check_signing_secret(signing_secret, self.request.body, timestamp, signature)
 

--- a/src/sentry/integrations/slack/requests/base.py
+++ b/src/sentry/integrations/slack/requests/base.py
@@ -117,7 +117,7 @@ class SlackRequest:
                 integration_id=context.integration.id, status=0
             )
             if org_integrations:
-                self._organization = organization_service.get_org_by_id(
+                self._organization = organization_service.get(
                     id=org_integrations[0].organization_id
                 )
 

--- a/src/sentry/integrations/slack/requests/base.py
+++ b/src/sentry/integrations/slack/requests/base.py
@@ -225,15 +225,17 @@ class SlackRequest:
         if not (signature and timestamp):
             return False
 
+        log_extra = {
+            "organization_id": self._organization.id if self._organization else None,
+            "integration_id": self._integration.id if self._integration else None,
+        }
+
         if self._organization and features.has(
             "organizations:slack-sdk-signature", self._organization
         ):
             logger.info(
                 "slack.request.verify_signature",
-                extra={
-                    "organization_id": self._organization.id,
-                    "integration_id": self._integration.id if self._integration else None,
-                },
+                extra=log_extra,
             )
             return SignatureVerifier(signing_secret).is_valid(
                 body=self.request.body, timestamp=timestamp, signature=signature
@@ -241,10 +243,7 @@ class SlackRequest:
 
         logger.info(
             "slack.request.check_signing_secret",
-            extra={
-                "organization_id": self._organization.id if self._organization else None,
-                "integration_id": self._integration.id if self._integration else None,
-            },
+            extra=log_extra,
         )
 
         return check_signing_secret(signing_secret, self.request.body, timestamp, signature)

--- a/tests/sentry/integrations/slack/test_requests.py
+++ b/tests/sentry/integrations/slack/test_requests.py
@@ -1,4 +1,5 @@
 from unittest import mock
+from unittest.mock import patch
 from urllib.parse import urlencode
 
 import orjson
@@ -12,6 +13,7 @@ from sentry.integrations.slack.requests.event import SlackEventRequest
 from sentry.integrations.slack.utils import set_signing_secret
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers import override_options
+from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.silo import control_silo_test
 
 
@@ -36,6 +38,22 @@ class SlackRequestTest(TestCase):
     @cached_property
     def slack_request(self):
         return SlackRequest(self.request)
+
+    def test_validate(self):
+        self.create_integration(
+            organization=self.organization, external_id="T001", provider="slack"
+        )
+        self.slack_request.validate()
+
+    @with_feature("organizations:slack-sdk-signature")
+    @patch("slack_sdk.signature.SignatureVerifier.is_valid")
+    def test_validate_using_sdk(self, mock_verify):
+        self.create_integration(
+            organization=self.organization, external_id="T001", provider="slack"
+        )
+        self.slack_request.validate()
+
+        mock_verify.assert_called()
 
     def test_exposes_data(self):
         assert self.slack_request.data["type"] == "foo"


### PR DESCRIPTION
Use `SignatureVerifier` from the `slack_sdk` to verify Slack webhook signatures.

Re-up of #72285 with `organization_service.get` which returns `RpcOrganization` instead of `organization_service.get_org_by_id` which returns `RpcOrganizationSummary`. You can call `features.has` with `RpcOrganization`, not `RpcOrganizationSummary` -- [this error](https://sentry.sentry.io/issues/5237541715/) popped up before with the previous method.