### PR TITLE
fix(ui): fix link overflow on mobile modules

### DIFF
--- a/static/app/views/performance/mobile/appStarts/screenSummary/spanOperationTable.tsx
+++ b/static/app/views/performance/mobile/appStarts/screenSummary/spanOperationTable.tsx
@@ -165,9 +165,9 @@ export function SpanOperationTable({
       };
 
       return (
-        <Link to={`${pathname}?${qs.stringify(query)}`}>
-          <OverflowEllipsisTextContainer>{label}</OverflowEllipsisTextContainer>
-        </Link>
+        <OverflowEllipsisTextContainer>
+          <Link to={`${pathname}?${qs.stringify(query)}`}>{label}</Link>
+        </OverflowEllipsisTextContainer>
       );
     }
 

--- a/static/app/views/performance/mobile/screenload/screenLoadSpans/table.tsx
+++ b/static/app/views/performance/mobile/screenload/screenLoadSpans/table.tsx
@@ -166,9 +166,9 @@ export function ScreenLoadSpansTable({
       };
 
       return (
-        <Link to={`${pathname}?${qs.stringify(query)}`}>
-          <OverflowEllipsisTextContainer>{label}</OverflowEllipsisTextContainer>
-        </Link>
+        <OverflowEllipsisTextContainer>
+          <Link to={`${pathname}?${qs.stringify(query)}`}>{label}</Link>
+        </OverflowEllipsisTextContainer>
       );
     }
 


### PR DESCRIPTION
before
![image](https://github.com/getsentry/sentry/assets/58920989/78b3a2bc-b092-495c-b8e2-dde0bf5a7e67)

after
<img width="1042" alt="image" src="https://github.com/getsentry/sentry/assets/58920989/781dab60-b7ee-43b3-aa83-38fc7d2d0597">