### PR TITLE
ref(slack): use sdk client to send metric alerts

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -406,6 +406,8 @@ def register_temporary_features(manager: FeatureManager):
     manager.add("organizations:slack-sdk-signature", OrganizationFeature, FeatureHandlerStrategy.OPTIONS)
     # Use new Slack SDK Client for sending activity messages in threads
     manager.add("organizations:slack-sdk-activity-threads", OrganizationFeature, FeatureHandlerStrategy.OPTIONS)
+    # Use new Slack SDK Client for sending metric alerts
+    manager.add("organizations:slack-sdk-metric-alert", OrganizationFeature, FeatureHandlerStrategy.OPTIONS)
     # Add regression chart as image to slack message
     manager.add("organizations:slack-endpoint-regression-image", OrganizationFeature, FeatureHandlerStrategy.OPTIONS)
     manager.add("organizations:slack-function-regression-image", OrganizationFeature, FeatureHandlerStrategy.OPTIONS)

--- a/src/sentry/integrations/slack/actions/notification.py
+++ b/src/sentry/integrations/slack/actions/notification.py
@@ -210,10 +210,7 @@ class SlackNotifyServiceAction(IntegrationEventAction):
                         extra=log_params,
                     )
                 else:
-                    ts = None
-                    response_data = sdk_response.data
-                    if isinstance(response_data, dict):
-                        ts = response_data.get("ts")
+                    ts = sdk_response.get("ts")
 
                     self.logger.info("slack.issue_alert.ts", extra={"ts": ts})
 

--- a/src/sentry/integrations/slack/actions/notification.py
+++ b/src/sentry/integrations/slack/actions/notification.py
@@ -215,7 +215,7 @@ class SlackNotifyServiceAction(IntegrationEventAction):
                     if isinstance(response_data, dict):
                         ts = response_data.get("ts")
 
-                    self.logger.info("slack.issue-alert.ts", extra={"ts": ts})
+                    self.logger.info("slack.issue_alert.ts", extra={"ts": ts})
 
                     new_notification_message_object.message_identifier = (
                         str(ts) if ts is not None else None

--- a/src/sentry/integrations/slack/utils/notifications.py
+++ b/src/sentry/integrations/slack/utils/notifications.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
+from typing import Any
 
 import orjson
 import sentry_sdk
@@ -58,7 +59,7 @@ def send_incident_alert_notification(
             sentry_sdk.capture_exception(e)
 
     channel = action.target_identifier
-    attachment = SlackIncidentsMessageBuilder(
+    attachment: Any = SlackIncidentsMessageBuilder(
         incident, new_status, metric_value, chart_url, notification_uuid
     ).build()
     text = str(attachment["text"])

--- a/src/sentry/integrations/slack/utils/notifications.py
+++ b/src/sentry/integrations/slack/utils/notifications.py
@@ -143,11 +143,7 @@ def send_incident_alert_notification(
             logger.info("slack.metric_alert.error", exc_info=True, extra=log_params)
         else:
             success = True
-
-            ts = None
-            response_data = sdk_response.data
-            if isinstance(response_data, dict):
-                ts = response_data.get("ts")
+            ts = sdk_response.get("ts")
 
             logger.info("slack.metric_alert.ts", extra={"ts": ts})
 


### PR DESCRIPTION
Adds feature-flagged usage of Slack SDK client to send metric alerts. Also adds tests for the code area.