### PR TITLE
fix(assignee-selector): Fix avatar not rendering issue

### DIFF
--- a/static/app/components/avatar/actorAvatar.spec.tsx
+++ b/static/app/components/avatar/actorAvatar.spec.tsx
@@ -56,6 +56,20 @@ describe('ActorAvatar', function () {
     expect(screen.getByText('CT')).toBeInTheDocument();
   });
 
+  it('should show an avatar even if the user is not in the memberlist', function () {
+    render(
+      <ActorAvatar
+        actor={{
+          id: '2',
+          name: 'Jane Vloggs',
+          type: 'user',
+        }}
+      />
+    );
+
+    expect(screen.getByText('JV')).toBeInTheDocument();
+  });
+
   it('should return null when actor type is a unknown', function () {
     render(
       <ActorAvatar

--- a/static/app/components/avatar/actorAvatar.tsx
+++ b/static/app/components/avatar/actorAvatar.tsx
@@ -43,7 +43,7 @@ function LoadMemberAvatar({
   const {members, fetching} = useMembers({ids});
   const user = members.find(u => u.id === userId);
 
-  if (fetching) {
+  if (fetching || !user) {
     const size = `${props.size}px`;
     return <Placeholder shape="circle" width={size} height={size} />;
   }

--- a/static/app/components/avatar/actorAvatar.tsx
+++ b/static/app/components/avatar/actorAvatar.tsx
@@ -8,7 +8,7 @@ import type {Actor} from 'sentry/types/core';
 import {useMembers} from 'sentry/utils/useMembers';
 import {useTeamsById} from 'sentry/utils/useTeamsById';
 
-import type {BaseAvatarProps} from './baseAvatar';
+import {BaseAvatar, type BaseAvatarProps} from './baseAvatar';
 
 interface Props extends BaseAvatarProps {
   actor: Actor;
@@ -36,19 +36,25 @@ function LoadTeamAvatar({
  * Wrapper to assist loading the user from api or store
  */
 function LoadMemberAvatar({
-  userId,
+  userActor,
   ...props
-}: {userId: string} & Omit<React.ComponentProps<typeof UserAvatar>, 'team'>) {
-  const ids = useMemo(() => [userId], [userId]);
+}: {userActor: Actor} & Omit<React.ComponentProps<typeof UserAvatar>, 'team'>) {
+  const ids = useMemo(() => [userActor.id], [userActor.id]);
   const {members, fetching} = useMembers({ids});
-  const user = members.find(u => u.id === userId);
+  const member = members.find(u => u.id === userActor.id);
 
-  if (fetching || !user) {
+  if (fetching) {
     const size = `${props.size}px`;
     return <Placeholder shape="circle" width={size} height={size} />;
   }
 
-  return <UserAvatar user={user} {...props} />;
+  if (!member) {
+    return (
+      <BaseAvatar size={props.size} title={userActor.name ?? userActor.email} round />
+    );
+  }
+
+  return <UserAvatar user={member} {...props} />;
 }
 
 function ActorAvatar({size = 24, hasTooltip = true, actor, ...props}: Props) {
@@ -59,7 +65,7 @@ function ActorAvatar({size = 24, hasTooltip = true, actor, ...props}: Props) {
   };
 
   if (actor.type === 'user') {
-    return <LoadMemberAvatar userId={actor.id} {...otherProps} />;
+    return <LoadMemberAvatar userActor={actor} {...otherProps} />;
   }
 
   if (actor.type === 'team') {


### PR DESCRIPTION
This PR fixes a bug where the avatar badge would not render any image for the avatar, like in this photo:

<img width="212" alt="image" src="https://github.com/getsentry/sentry/assets/55160142/8292777a-182f-4a54-9b2f-91264046491b">

This was caused by an assigned actor not being present in the member list, and our actorAvatar component not handling this edge case properly. This situation could have occurred if, for example, a user was assigned to an issue, but was then removed from an organization, thus removing them from the org's memberlist.

The new behavior simply adds a fall back to render a letter avatar if the user cannot be found in the member list : 

<img width="192" alt="image" src="https://github.com/getsentry/sentry/assets/55160142/cedb9a2f-5eb5-4f27-ad57-62fe3d84933f">

In the future, we may want to consider some special visual treatment in this case, just to make it clear that the assignee is no longer part of the organization