### PR TITLE
feat(performance): Update starfish charts to show incomplete data points with dotted line

### DIFF
--- a/static/app/components/metrics/chart/chart.tsx
+++ b/static/app/components/metrics/chart/chart.tsx
@@ -450,7 +450,7 @@ function transformToScatterSeries({
   });
 }
 
-function createIngestionSeries(
+export function createIngestionSeries(
   orignalSeries: Series,
   ingestionBuckets: number,
   displayType: MetricDisplayType
@@ -539,7 +539,10 @@ const AVERAGE_INGESTION_DELAY_MS = 90_000;
  * @param bucketSize in ms
  * @param lastBucketTimestamp starting time of the last bucket in ms
  */
-function getIngestionDelayBucketCount(bucketSize: number, lastBucketTimestamp: number) {
+export function getIngestionDelayBucketCount(
+  bucketSize: number,
+  lastBucketTimestamp: number
+) {
   const timeSinceLastBucket = Date.now() - (lastBucketTimestamp + bucketSize);
   const ingestionAffectedTime = Math.max(
     0,

--- a/static/app/views/performance/browser/webVitals/components/performanceScoreBreakdownChart.tsx
+++ b/static/app/views/performance/browser/webVitals/components/performanceScoreBreakdownChart.tsx
@@ -229,7 +229,6 @@ export function PerformanceScoreBreakdownChart({transaction}: Props) {
         }}
         dataMax={100}
         chartColors={segmentColors}
-        preserveIncompletePoints
         tooltipFormatterOptions={{
           nameFormatter: (name, seriesParams: any) => {
             if (name === 'FID') {

--- a/static/app/views/performance/http/charts/durationChart.tsx
+++ b/static/app/views/performance/http/charts/durationChart.tsx
@@ -36,9 +36,7 @@ export function DurationChart({
       let {seriesIndex} = batch;
       const {dataIndex} = batch;
       // TODO: More hacks. The Chart component partitions the data series into a complete and incomplete series. Wrap the series index to work around overflowing index.
-      if (seriesIndex >= allSeries.length) {
-        seriesIndex = seriesIndex - allSeries.length;
-      }
+      seriesIndex = seriesIndex % allSeries.length;
 
       const highlightedSeries = allSeries?.[seriesIndex];
       const highlightedDataPoint = highlightedSeries?.data?.[dataIndex];

--- a/static/app/views/performance/http/charts/durationChart.tsx
+++ b/static/app/views/performance/http/charts/durationChart.tsx
@@ -33,10 +33,15 @@ export function DurationChart({
     const allSeries = [...series, ...(scatterPlot ?? [])];
 
     const highlightedDataPoints = event.batch.map(batch => {
-      const {seriesIndex, dataIndex} = batch;
+      let {seriesIndex} = batch;
+      const {dataIndex} = batch;
+      // TODO: More hacks. The Chart component partitions the data series into a complete and incomplete series. Wrap the series index to work around overflowing index.
+      if (seriesIndex >= allSeries.length) {
+        seriesIndex = seriesIndex - allSeries.length;
+      }
 
       const highlightedSeries = allSeries?.[seriesIndex];
-      const highlightedDataPoint = highlightedSeries.data?.[dataIndex];
+      const highlightedDataPoint = highlightedSeries?.data?.[dataIndex];
 
       return {series: highlightedSeries, dataPoint: highlightedDataPoint};
     });

--- a/static/app/views/starfish/components/chart.tsx
+++ b/static/app/views/starfish/components/chart.tsx
@@ -1,5 +1,5 @@
 import type {RefObject} from 'react';
-import {useEffect, useRef, useState} from 'react';
+import {useEffect, useMemo, useRef, useState} from 'react';
 import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 import type {LineSeriesOption} from 'echarts';
@@ -13,7 +13,6 @@ import type {
 } from 'echarts/types/dist/shared';
 import max from 'lodash/max';
 import min from 'lodash/min';
-import moment from 'moment';
 
 import type {AreaChartProps} from 'sentry/components/charts/areaChart';
 import {AreaChart} from 'sentry/components/charts/areaChart';
@@ -29,6 +28,11 @@ import TransitionChart from 'sentry/components/charts/transitionChart';
 import TransparentLoadingMask from 'sentry/components/charts/transparentLoadingMask';
 import {isChartHovered} from 'sentry/components/charts/utils';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
+import {
+  createIngestionSeries,
+  getIngestionDelayBucketCount,
+} from 'sentry/components/metrics/chart/chart';
+import type {Series as MetricSeries} from 'sentry/components/metrics/chart/types';
 import {IconWarning} from 'sentry/icons';
 import type {
   EChartClickHandler,
@@ -47,6 +51,7 @@ import {
 } from 'sentry/utils/discover/charts';
 import type {AggregationOutputType, RateUnit} from 'sentry/utils/discover/fields';
 import {aggregateOutputType} from 'sentry/utils/discover/fields';
+import {MetricDisplayType} from 'sentry/utils/metrics/types';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import useRouter from 'sentry/utils/useRouter';
 
@@ -88,7 +93,6 @@ type Props = {
   }>;
   onMouseOut?: EChartMouseOutHandler;
   onMouseOver?: EChartMouseOverHandler;
-  preserveIncompletePoints?: boolean;
   previousData?: Series[];
   rateUnit?: RateUnit;
   scatterPlot?: Series[];
@@ -129,7 +133,6 @@ function Chart({
   onLegendSelectChanged,
   onDataZoom,
   legendFormatter,
-  preserveIncompletePoints,
 }: Props) {
   const router = useRouter();
   const theme = useTheme();
@@ -198,6 +201,45 @@ function Chart({
     });
   }
 
+  let series: Series[] = data.map((values, index) => ({
+    ...values,
+    yAxisIndex: 0,
+    xAxisIndex: 0,
+    id: values.seriesName,
+    color: colors[index],
+  }));
+  let incompleteSeries: Series[] = [];
+
+  const bucketSize =
+    new Date(series[0]?.data[1]?.name).getTime() -
+    new Date(series[0]?.data[0]?.name).getTime();
+  const lastBucketTimestamp = new Date(
+    series[0]?.data?.[series[0]?.data?.length - 1]?.name
+  ).getTime();
+  const ingestionBuckets = useMemo(
+    () => getIngestionDelayBucketCount(bucketSize, lastBucketTimestamp),
+    [bucketSize, lastBucketTimestamp]
+  );
+
+  // TODO: Support area and bar charts
+  if (type === ChartType.LINE || type === ChartType.AREA) {
+    const metricChartType =
+      type === ChartType.AREA ? MetricDisplayType.AREA : MetricDisplayType.LINE;
+    const seriesToShow = series.map(serie =>
+      createIngestionSeries(serie as MetricSeries, ingestionBuckets, metricChartType)
+    );
+    [series, incompleteSeries] = seriesToShow.reduce(
+      (acc, serie, index) => {
+        const [trimmed, incomplete] = acc;
+        return [
+          [...trimmed, {...serie[0], color: colors[index]}],
+          [...incomplete, {...serie[1], markLine: undefined}],
+        ];
+      },
+      [[], []] as [MetricSeries[], MetricSeries[]]
+    );
+  }
+
   const yAxes = [
     {
       minInterval: durationUnit ?? getDurationUnit(data),
@@ -221,27 +263,52 @@ function Chart({
     ...additionalAxis,
   ];
 
+  const xAxis: XAXisOption = disableXAxis
+    ? {
+        show: false,
+        axisLabel: {show: true, margin: 0},
+        axisLine: {show: false},
+      }
+    : {};
+
   const formatter: TooltipFormatterCallback<TopLevelFormatterParams> = (
     params,
     asyncTicket
   ) => {
-    if (isChartHovered(chartRef?.current)) {
-      // Return undefined to use default formatter
-      return getFormatter({
-        isGroupedByDate: true,
-        showTimeInTooltip: true,
-        utc: utc ?? false,
-        valueFormatter: (value, seriesName) => {
-          return tooltipFormatter(
-            value,
-            aggregateOutputFormat ?? aggregateOutputType(seriesName)
-          );
-        },
-        ...tooltipFormatterOptions,
-      })(params, asyncTicket);
+    // Only show the tooltip if the current chart is hovered
+    // as chart groups trigger the tooltip for all charts in the group when one is hoverered
+    if (!isChartHovered(chartRef?.current)) {
+      return '';
     }
-    // Return empty string, ie no tooltip
-    return '';
+    let deDupedParams = params;
+    if (Array.isArray(params)) {
+      const uniqueSeries = new Set<string>();
+      deDupedParams = params.filter(param => {
+        // Filter null values from tooltip
+        if (param.value[1] === null) {
+          return false;
+        }
+
+        if (uniqueSeries.has(param.seriesName)) {
+          return false;
+        }
+        uniqueSeries.add(param.seriesName);
+        return true;
+      });
+    }
+    // Return undefined to use default formatter
+    return getFormatter({
+      isGroupedByDate: true,
+      showTimeInTooltip: true,
+      utc: utc ?? false,
+      valueFormatter: (value, seriesName) => {
+        return tooltipFormatter(
+          value,
+          aggregateOutputFormat ?? aggregateOutputType(seriesName)
+        );
+      },
+      ...tooltipFormatterOptions,
+    })(deDupedParams, asyncTicket);
   };
 
   const areaChartProps = {
@@ -279,36 +346,6 @@ function Chart({
       },
     },
   } as Omit<AreaChartProps, 'series'>;
-
-  const series: Series[] = data.map((values, _) => ({
-    ...values,
-    yAxisIndex: 0,
-    xAxisIndex: 0,
-  }));
-
-  // Trims off the last data point because it's incomplete
-  const trimmedSeries =
-    !preserveIncompletePoints && period && !start && !end
-      ? series.map(serie => {
-          return {
-            ...serie,
-            data: serie.data.slice(0, -1),
-          };
-        })
-      : series;
-
-  const xAxis: XAXisOption = disableXAxis
-    ? {
-        show: false,
-        axisLabel: {show: true, margin: 0},
-        axisLine: {show: false},
-      }
-    : {
-        min: moment(trimmedSeries[0]?.data[0]?.name).unix() * 1000,
-        max:
-          moment(trimmedSeries[0]?.data[trimmedSeries[0].data.length - 1]?.name).unix() *
-          1000,
-      };
 
   function getChart() {
     if (error) {
@@ -351,7 +388,7 @@ function Chart({
                 onMouseOver={onMouseOver}
                 onHighlight={onHighlight}
                 series={[
-                  ...trimmedSeries.map(({seriesName, data: seriesData, ...options}) =>
+                  ...series.map(({seriesName, data: seriesData, ...options}) =>
                     LineSeries({
                       ...options,
                       name: seriesName,
@@ -370,6 +407,16 @@ function Chart({
                         animation: false,
                       })
                   ),
+                  ...incompleteSeries.map(({seriesName, data: seriesData, ...options}) =>
+                    LineSeries({
+                      ...options,
+                      name: seriesName,
+                      data: seriesData?.map(({value, name}) => [name, value]),
+                      animation: false,
+                      animationThreshold: 1,
+                      animationDuration: 0,
+                    })
+                  ),
                 ]}
               />
             );
@@ -379,7 +426,7 @@ function Chart({
             return (
               <BarChart
                 height={height}
-                series={trimmedSeries}
+                series={series}
                 xAxis={{
                   type: 'category',
                   axisTick: {show: true},
@@ -429,7 +476,7 @@ function Chart({
               forwardedRef={chartRef}
               height={height}
               {...zoomRenderProps}
-              series={trimmedSeries}
+              series={[...series, ...incompleteSeries]}
               previousPeriod={previousData}
               additionalSeries={transformedThroughput}
               xAxis={xAxis}

--- a/static/app/views/starfish/components/chart.tsx
+++ b/static/app/views/starfish/components/chart.tsx
@@ -216,10 +216,12 @@ function Chart({
   const lastBucketTimestamp = new Date(
     series[0]?.data?.[series[0]?.data?.length - 1]?.name
   ).getTime();
-  const ingestionBuckets = useMemo(
-    () => getIngestionDelayBucketCount(bucketSize, lastBucketTimestamp),
-    [bucketSize, lastBucketTimestamp]
-  );
+  const ingestionBuckets = useMemo(() => {
+    if (isNaN(bucketSize) || isNaN(lastBucketTimestamp)) {
+      return 1;
+    }
+    return getIngestionDelayBucketCount(bucketSize, lastBucketTimestamp);
+  }, [bucketSize, lastBucketTimestamp]);
 
   // TODO: Support area and bar charts
   if (type === ChartType.LINE || type === ChartType.AREA) {

--- a/static/app/views/starfish/views/spanSummaryPage/sampleList/durationChart/index.tsx
+++ b/static/app/views/starfish/views/spanSummaryPage/sampleList/durationChart/index.tsx
@@ -139,7 +139,8 @@ function DurationChart({
 
   const handleChartHighlight: EChartHighlightHandler = e => {
     const {seriesIndex} = e.batch[0];
-    const isSpanSample = seriesIndex > 1;
+    const isSpanSample =
+      seriesIndex > 1 && seriesIndex < 2 + sampledSpanDataSeries.length;
     if (isSpanSample && onMouseOverSample) {
       const spanSampleData = sampledSpanDataSeries?.[seriesIndex - 2]?.data[0];
       const {name: timestamp, value: duration} = spanSampleData;

--- a/static/app/views/traces/tracesChart.tsx
+++ b/static/app/views/traces/tracesChart.tsx
@@ -66,7 +66,6 @@ export function TracesChart({}: Props) {
           tooltipFormatterOptions={{
             valueFormatter: value => formatRate(value, RateUnit.PER_MINUTE),
           }}
-          preserveIncompletePoints
         />
       </ChartPanel>
     </ChartContainer>


### PR DESCRIPTION
Currently we provide a `preserveIncompletePoints` option to control displaying the last data point in insights charts. This is because the last datapoint often contains incomplete data.

This update removes the `preserveIncompletePoints` option and updates insights and trace view charts to always display incomplete data points with a dotted line. This is the same behaviour as the Metrics chart.

Reuses `createIngestionSeries` and `getIngestionDelayBucketCount` from the Metrics chart.

![image](https://github.com/getsentry/sentry/assets/83961295/63bd41ad-3a46-4725-8473-601e57b0110e)
![image](https://github.com/getsentry/sentry/assets/83961295/b7eb3121-0948-4adb-b5db-d4dd96ada84e)
