### PR TITLE
chore(rules): Update codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -159,6 +159,7 @@ yarn.lock                                                @getsentry/owners-js-de
 /static/app/views/settings/projectAlerts/                 @getsentry/alerts-notifications
 /static/app/views/alerts/                                 @getsentry/alerts-notifications
 /static/app/views/releases/                               @getsentry/alerts-notifications
+/src/sentry/rules/processing/delayed_processing.py        @getsentry/alerts-notifications
 
 /static/app/views/settings/account/notifications/         @getsentry/alerts-notifications
 


### PR DESCRIPTION
The @getsentry/alerts-notifications team didn't initially get assigned to https://sentry.sentry.io/issues/5474453009/activity/?project=1 so this PR updates the codeowners so that we will in the future. I believe the issues team still owns a lot of the other stuff further up the path which is why I was specific with this file.