### PR TITLE
fix(hybridcloud) Add cors headers to route error response

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -126,7 +126,6 @@ module = [
     "sentry.api.endpoints.accept_organization_invite",
     "sentry.api.endpoints.auth_config",
     "sentry.api.endpoints.auth_login",
-    "sentry.api.endpoints.catchall",
     "sentry.api.endpoints.chunk",
     "sentry.api.endpoints.codeowners",
     "sentry.api.endpoints.codeowners.index",

--- a/src/sentry/api/endpoints/catchall.py
+++ b/src/sentry/api/endpoints/catchall.py
@@ -2,7 +2,7 @@ from django.http import HttpResponse, JsonResponse
 from django.views.decorators.csrf import csrf_exempt
 from rest_framework.request import Request
 
-from sentry.api.base import Endpoint, all_silo_endpoint
+from sentry.api.base import Endpoint, all_silo_endpoint, allow_cors_options
 
 
 @all_silo_endpoint
@@ -10,6 +10,7 @@ class CatchallEndpoint(Endpoint):
     permission_classes = ()
 
     @csrf_exempt
+    @allow_cors_options
     def dispatch(self, request: Request, *args, **kwargs) -> HttpResponse:
         """
         This endpoint handles routes that did not match

--- a/tests/sentry/api/endpoints/test_catchall.py
+++ b/tests/sentry/api/endpoints/test_catchall.py
@@ -34,3 +34,12 @@ class CatchallTestCase(APITestCase):
         assert response.json() == {
             "info": "Route not found, did you forget a trailing slash? try: /api/0/bad_url/"
         }
+
+    def test_missing_route_response_includes_cors(self):
+        res = self.client.get("/api/0/bad_url/")
+        assert res.status_code == 404
+        assert "x-frame-options" in res
+        assert "access-control-allow-methods" in res
+        assert "access-control-allow-headers" in res
+        assert "access-control-expose-headers" in res
+        assert "access-control-allow-origin" in res


### PR DESCRIPTION
Our API routes include a catch all which is separate from django's error handlers. This catchall route should include CORS headers so that missing route errors don't also cause CORS errors.

Fixes HC-1006