### PR TITLE
ref(rules): Render Slack issue alert label better

### DIFF
--- a/src/sentry/integrations/slack/actions/notification.py
+++ b/src/sentry/integrations/slack/actions/notification.py
@@ -359,14 +359,28 @@ class SlackNotifyServiceAction(IntegrationEventAction):
 
     def render_label(self) -> str:
         tags = self.get_tags_list()
+        channel = self.get_option("channel").lstrip("#")
+        workspace = self.get_integration_name()
+        notes = self.get_option("notes")
 
-        return self.label.format(
-            workspace=self.get_integration_name(),
-            channel=self.get_option("channel"),
-            channel_id=self.get_option("channel_id"),
-            tags="[{}]".format(", ".join(tags)),
-            notes=self.get_option("notes", ""),
-        )
+        label = f"Send a notification to the {workspace} Slack workspace to #{channel}"
+        has_tags = True if tags and tags != [""] else False
+        # by default we have a list of empty single quotes if no tags are entered
+
+        if has_tags:
+            formatted_tags = "[{}]".format(", ".join(tags))
+            label += f" and show tags {formatted_tags}"
+
+        if notes:
+            if has_tags:
+                label += f' and notes "{notes}"'
+            else:
+                label += f' and show notes "{notes}"'
+
+        if notes or has_tags:
+            label += " in notification"
+
+        return label
 
     def get_tags_list(self) -> Sequence[str]:
         return [s.strip() for s in self.get_option("tags", "").split(",")]

--- a/tests/sentry/api/endpoints/test_project_rule_details.py
+++ b/tests/sentry/api/endpoints/test_project_rule_details.py
@@ -1132,7 +1132,7 @@ class UpdateProjectRuleTest(ProjectRuleDetailsBaseTestCase):
         assert rendered_blocks[0]["text"]["text"] == message
         changes = "*Changes*\n"
         changes += "• Added condition 'The issue's category is equal to Performance'\n"
-        changes += "• Changed action from *Send a notification to the Awesome Team Slack workspace to #old_channel_name (optionally, an ID: old_channel_id) and show tags [] and notes  in notification* to *Send a notification to the Awesome Team Slack workspace to new_channel_name (optionally, an ID: new_channel_id) and show tags [] and notes  in notification*\n"
+        changes += "• Changed action from *Send a notification to the Awesome Team Slack workspace to #old_channel_name* to *Send a notification to the Awesome Team Slack workspace to #new_channel_name*\n"
         changes += "• Changed frequency from *5 minutes* to *3 hours*\n"
         changes += f"• Added *{staging_env.name}* environment\n"
         changes += "• Changed rule name from *my rule* to *new rule*\n"
@@ -1212,7 +1212,7 @@ class UpdateProjectRuleTest(ProjectRuleDetailsBaseTestCase):
             "actions": [
                 {
                     "id": "sentry.integrations.slack.notify_action.SlackNotifyServiceAction",
-                    "name": "Send a notification to the funinthesun Slack workspace to #team-team-team and show tags [] in notification",
+                    "name": "Send a notification to the funinthesun Slack workspace to #team-team-team",
                     "workspace": str(self.slack_integration.id),
                     "channel": "#team-team-team",
                     "channel_id": channel_id,

--- a/tests/sentry/integrations/slack/test_notify_action.py
+++ b/tests/sentry/integrations/slack/test_notify_action.py
@@ -82,7 +82,7 @@ class SlackNotifyActionTest(RuleTestCase):
 
         assert (
             rule.render_label()
-            == "Send a notification to the Awesome Team Slack workspace to #my-channel (optionally, an ID: ) and show tags [one, two] and notes fix this @colleen in notification"
+            == 'Send a notification to the Awesome Team Slack workspace to #my-channel and show tags [one, two] and notes "fix this @colleen" in notification'
         )
 
     def test_render_label_without_integration(self):
@@ -99,10 +99,7 @@ class SlackNotifyActionTest(RuleTestCase):
         )
 
         label = rule.render_label()
-        assert (
-            label
-            == "Send a notification to the [removed] Slack workspace to #my-channel (optionally, an ID: ) and show tags [] and notes  in notification"
-        )
+        assert label == "Send a notification to the [removed] Slack workspace to #my-channel"
 
     @responses.activate
     def test_valid_bot_channel_selected(self):


### PR DESCRIPTION
Currently the text displayed for Slack actions in issue alerts looks pretty bad: 


We always show the tags and notes fields whether or not there's anything entered there. This is partially because of how we're using Django forms for issue alerts, but we can format it to look nicer.

**With no tags or notes**
<img width="351" alt="Screenshot 2024-06-10 at 5 44 52 PM" src="https://github.com/getsentry/sentry/assets/29959063/2da13b07-6e09-4907-978e-1b9217c3d6b2">
**With tags**
<img width="349" alt="Screenshot 2024-06-10 at 5 45 07 PM" src="https://github.com/getsentry/sentry/assets/29959063/4ade1dd8-37cd-4900-a2f1-f815fa72ebd3">
**With tags and notes**
<img width="334" alt="Screenshot 2024-06-10 at 5 45 27 PM" src="https://github.com/getsentry/sentry/assets/29959063/578b98b7-f5aa-45f2-b9f4-9bb53fcafd31">
**With only notes**
<img width="341" alt="Screenshot 2024-06-10 at 5 45 38 PM" src="https://github.com/getsentry/sentry/assets/29959063/720ae776-f860-465d-adda-e59d516cab77">

Rule edit confirmation notifications look a lot cleaner too - here's an example from before:
![image](https://github.com/getsentry/sentry/assets/29959063/4d92c28e-d2e0-4f54-aa72-1f198875ddb0)


And here's after
<img width="607" alt="Screenshot 2024-06-10 at 5 45 50 PM" src="https://github.com/getsentry/sentry/assets/29959063/92a0cd7d-4913-41b3-95df-3e28d80b8277">
<img width="607" alt="Screenshot 2024-06-10 at 5 45 56 PM" src="https://github.com/getsentry/sentry/assets/29959063/3d6fa2f0-cdd8-4040-a71d-ee56273d26b1">
<img width="621" alt="Screenshot 2024-06-10 at 5 46 01 PM" src="https://github.com/getsentry/sentry/assets/29959063/2aa8e4b5-0971-4632-ba81-f42c2b8a69d1">


Closes https://github.com/getsentry/team-core-product-foundations/issues/293