### PR TITLE
feat(flagpole): Adds auto-option registration for remote features

### DIFF
--- a/src/sentry/features/manager.py
+++ b/src/sentry/features/manager.py
@@ -175,7 +175,15 @@ class FeatureManager(RegisteredFeatureManager):
                 )
             self.option_features.add(name)
 
-        if entity_feature_strategy == FeatureHandlerStrategy.FLAGPOLE:
+        is_external_flag = (
+            entity_feature_strategy == FeatureHandlerStrategy.FLAGPOLE
+            or entity_feature_strategy == FeatureHandlerStrategy.REMOTE
+        )
+
+        # Register all remote and flagpole features with options automator,
+        # so long as they haven't already been registered. This will allow
+        # us to backfill and cut over to Flagpole without interruptions.
+        if is_external_flag and name not in self.flagpole_features:
             self.flagpole_features.add(name)
             # Set a default of {} to ensure the feature evaluates to None when checked
             feature_option_name = f"{FLAGPOLE_OPTION_PREFIX}.{name}"


### PR DESCRIPTION
<!-- Describe your PR here. -->
Auto registers every remote feature as a potential flagpole option to make backfilling our features easier. Without this change, we'd effectively have to individually convert every option to use the `FLAGPOLE` strategy in code, which will slow down reverts if a backfilled option is incorrect.

This should be a temporary measure until we can cleanly convert all of our remote feature checks to use Flagpole.

