### PR TITLE
feat(lpq): Enable different budgets per platform

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -3076,16 +3076,17 @@ SENTRY_LPQ_OPTIONS = {
     # There is one budget for each of the symbolication platforms: native, js, and jvm.
     # The "project_budget" value exists for backward compatibility.
     #
-    # This has been arbitrarily chosen as `5.0` for now, which means an average of:
+    # This has been arbitrarily chosen as `5.0` for native and js, which means an average of:
     # -  1x 5-second event per second, or
     # -  5x 1-second events per second, or
     # - 10x 0.5-second events per second
     #
+    # For jvm events we use a higher budget of `7.5`.
     # Cost increases quadratically with symbolication time.
     "project_budget": 5.0,
     "project_budget_native": 5.0,
     "project_budget_js": 5.0,
-    "project_budget_jvm": 5.0,
+    "project_budget_jvm": 7.5,
 }
 
 # XXX(meredith): Temporary metrics indexer

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -3072,7 +3072,9 @@ SENTRY_ENABLE_AUTO_LOW_PRIORITY_QUEUE = False
 # This value is already adjusted according to the
 # `symbolicate-event.low-priority.metrics.submission-rate` option.
 SENTRY_LPQ_OPTIONS = {
-    # This is the per-project budget in per-second "symbolication time budget".
+    # These are the per-project budget in per-second "symbolication time budget".
+    # There is one budget for each of the symbolication platforms: native, js, and jvm.
+    # The "project_budget" value exists for backward compatibility.
     #
     # This has been arbitrarily chosen as `5.0` for now, which means an average of:
     # -  1x 5-second event per second, or
@@ -3080,7 +3082,10 @@ SENTRY_LPQ_OPTIONS = {
     # - 10x 0.5-second events per second
     #
     # Cost increases quadratically with symbolication time.
-    "project_budget": 5.0
+    "project_budget": 5.0,
+    "project_budget_native": 5.0,
+    "project_budget_js": 5.0,
+    "project_budget_jvm": 5.0,
 }
 
 # XXX(meredith): Temporary metrics indexer

--- a/src/sentry/processing/realtime_metrics/redis.py
+++ b/src/sentry/processing/realtime_metrics/redis.py
@@ -128,7 +128,7 @@ class RedisRealtimeMetricsStore(base.RealtimeMetricsStore):
 
         # the counts in redis are in ms resolution.
         average_used = total_sum / total_time_window / 1000
-        budget = settings.SENTRY_LPQ_OPTIONS["project_budget"]
+        budget = settings.SENTRY_LPQ_OPTIONS[f"project_budget_{platform.value}"]
         new_is_lpq = average_used > budget
 
         if new_is_lpq:

--- a/src/sentry/processing/realtime_metrics/redis.py
+++ b/src/sentry/processing/realtime_metrics/redis.py
@@ -128,7 +128,10 @@ class RedisRealtimeMetricsStore(base.RealtimeMetricsStore):
 
         # the counts in redis are in ms resolution.
         average_used = total_sum / total_time_window / 1000
-        budget = settings.SENTRY_LPQ_OPTIONS[f"project_budget_{platform.value}"]
+        budget = (
+            settings.SENTRY_LPQ_OPTIONS.get(f"project_budget_{platform.value}")
+            or settings.SENTRY_LPQ_OPTIONS["project_budget"]
+        )
         new_is_lpq = average_used > budget
 
         if new_is_lpq:


### PR DESCRIPTION
The reasoning behind this change is that proguard events may need a higher lpq budget than native and js events.