### PR TITLE
feat(metrics): Lower granularity limit for set metrics

### DIFF
--- a/static/app/components/modals/metricWidgetViewerModal/visualization.tsx
+++ b/static/app/components/modals/metricWidgetViewerModal/visualization.tsx
@@ -11,7 +11,12 @@ import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {MetricsQueryApiResponse} from 'sentry/types/metrics';
 import {DEFAULT_SORT_STATE} from 'sentry/utils/metrics/constants';
-import type {FocusedMetricsSeries, SortState} from 'sentry/utils/metrics/types';
+import {parseMRI} from 'sentry/utils/metrics/mri';
+import {
+  type FocusedMetricsSeries,
+  MetricExpressionType,
+  type SortState,
+} from 'sentry/utils/metrics/types';
 import {
   type MetricsQueryApiQueryParams,
   useMetricsQuery,
@@ -128,8 +133,18 @@ export function MetricVisualization({
   interval,
 }: MetricVisualizationProps) {
   const {selection} = usePageFilters();
+  const hasSetMetric = useMemo(
+    () =>
+      expressions.some(
+        expression =>
+          expression.type === MetricExpressionType.QUERY &&
+          parseMRI(expression.mri)!.type === 's'
+      ),
+    [expressions]
+  );
   const {interval: validatedInterval} = useMetricsIntervalOptions({
     interval,
+    hasSetMetric,
     datetime: selection.datetime,
     onIntervalChange: EMPTY_FN,
   });

--- a/static/app/views/dashboards/metrics/widgetCard.tsx
+++ b/static/app/views/dashboards/metrics/widgetCard.tsx
@@ -12,6 +12,8 @@ import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {PageFilters} from 'sentry/types/core';
 import type {Organization} from 'sentry/types/organization';
+import {parseMRI} from 'sentry/utils/metrics/mri';
+import {MetricExpressionType} from 'sentry/utils/metrics/types';
 import {useMetricsQuery} from 'sentry/utils/metrics/useMetricsQuery';
 import {MetricBigNumberContainer} from 'sentry/views/dashboards/metrics/bigNumber';
 import {MetricChartContainer} from 'sentry/views/dashboards/metrics/chart';
@@ -27,6 +29,7 @@ import {WidgetCardPanel, WidgetTitleRow} from 'sentry/views/dashboards/widgetCar
 import {DashboardsMEPContext} from 'sentry/views/dashboards/widgetCard/dashboardsMEPContext';
 import {Toolbar} from 'sentry/views/dashboards/widgetCard/toolbar';
 import WidgetCardContextMenu from 'sentry/views/dashboards/widgetCard/widgetCardContextMenu';
+import {useMetricsIntervalOptions} from 'sentry/views/metrics/utils/useMetricsIntervalParam';
 import {getWidgetTitle} from 'sentry/views/metrics/widget';
 
 type Props = {
@@ -46,6 +49,8 @@ type Props = {
   showContextMenu?: boolean;
 };
 
+const EMPTY_FN = () => {};
+
 export function MetricWidgetCard({
   organization,
   selection,
@@ -63,8 +68,24 @@ export function MetricWidgetCard({
     () => expressionsToApiQueries(getMetricExpressions(widget, dashboardFilters)),
     [widget, dashboardFilters]
   );
+  const hasSetMetric = useMemo(
+    () =>
+      getMetricExpressions(widget, dashboardFilters).some(
+        expression =>
+          expression.type === MetricExpressionType.QUERY &&
+          parseMRI(expression.mri)!.type === 's'
+      ),
+    [widget, dashboardFilters]
+  );
 
   const widgetMQL = useMemo(() => getWidgetTitle(metricQueries), [metricQueries]);
+
+  const {interval: validatedInterval} = useMetricsIntervalOptions({
+    interval: widget.interval,
+    hasSetMetric,
+    datetime: selection.datetime,
+    onIntervalChange: EMPTY_FN,
+  });
 
   const {
     data: timeseriesData,
@@ -72,7 +93,7 @@ export function MetricWidgetCard({
     isError,
     error,
   } = useMetricsQuery(metricQueries, selection, {
-    intervalLadder: widget.displayType === DisplayType.BAR ? 'bar' : 'dashboard',
+    interval: validatedInterval,
   });
 
   const vizualizationComponent = useMemo(() => {


### PR DESCRIPTION
<img width="1251" alt="Screenshot 2024-06-11 at 14 20 28" src="https://github.com/getsentry/sentry/assets/7033940/0692da1d-b5bc-429b-aab7-77b3852ea592">

Disable interval options that are smaller than `1h` for set metrics.
Ensure dashboard widgets do not query with a more granular interval.

Closes https://github.com/getsentry/sentry/issues/70722