### PR TITLE
fix(trace-explorer): Remove spans without transaction id from stats

### DIFF
--- a/src/sentry/api/endpoints/organization_traces.py
+++ b/src/sentry/api/endpoints/organization_traces.py
@@ -1228,6 +1228,9 @@ class TraceStatsExecutor:
         elif len(trace_conditions) > 1:
             query.where.append(BooleanCondition(op=BooleanOp.OR, conditions=trace_conditions))
 
+        if options.get("performance.traces.trace-explorer-skip-floating-spans"):
+            query.add_conditions([Condition(Column("transaction_id"), Op.IS_NOT_NULL, None)])
+
         return query
 
 


### PR DESCRIPTION
Spans without transaction ids are free floating spans such as INP spans. These spans can't be visualized in the trace explorer or trace view. So remove them from the results.