### PR TITLE
chore(replay): Remove beta label from hydration error breadcrumb on replay details

### DIFF
--- a/static/app/utils/replays/getFrameDetails.tsx
+++ b/static/app/utils/replays/getFrameDetails.tsx
@@ -1,7 +1,5 @@
 import type {ReactNode} from 'react';
-import {Fragment} from 'react';
 
-import FeatureBadge from 'sentry/components/badge/featureBadge';
 import ExternalLink from 'sentry/components/links/externalLink';
 import CrumbErrorTitle from 'sentry/components/replays/breadcrumbs/errorTitle';
 import SelectorList from 'sentry/components/replays/breadcrumbs/selectorList';
@@ -175,11 +173,7 @@ const MAPPER_FOR_FRAME: Record<string, (frame) => Details> = {
       'There was a conflict between the server rendered html and the first client render.'
     ),
     tabKey: TabKey.BREADCRUMBS,
-    title: (
-      <Fragment>
-        Hydration Error <FeatureBadge type="beta" />
-      </Fragment>
-    ),
+    title: 'Hydration Error',
     icon: <IconFire size="xs" />,
   }),
   'ui.click': frame => ({


### PR DESCRIPTION
**Before**
![SCR-20240611-ilyz](https://github.com/getsentry/sentry/assets/187460/5c267744-48a1-4fe9-961b-ab3de956dfd7)


**After**
![SCR-20240611-imgo](https://github.com/getsentry/sentry/assets/187460/96ad1dc9-25bc-4867-b8f2-016499a6e75a)



Fixes https://github.com/getsentry/sentry/issues/72493