### PR TITLE
ref(slack): use sdk client to notify recipients

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -404,6 +404,8 @@ def register_temporary_features(manager: FeatureManager):
     manager.add("organizations:slack-sdk-activity-threads", OrganizationFeature, FeatureHandlerStrategy.OPTIONS)
     # Use new Slack SDK Client for sending metric alerts
     manager.add("organizations:slack-sdk-metric-alert", OrganizationFeature, FeatureHandlerStrategy.OPTIONS)
+    # Use new Slack SDK Client in _notify_recipient
+    manager.add("organizations:slack-sdk-notify-recipient", OrganizationFeature, FeatureHandlerStrategy.OPTIONS)
     # Add regression chart as image to slack message
     manager.add("organizations:slack-endpoint-regression-image", OrganizationFeature, FeatureHandlerStrategy.OPTIONS)
     manager.add("organizations:slack-function-regression-image", OrganizationFeature, FeatureHandlerStrategy.OPTIONS)

--- a/src/sentry/integrations/slack/notifications.py
+++ b/src/sentry/integrations/slack/notifications.py
@@ -8,6 +8,7 @@ from typing import Any
 import orjson
 import sentry_sdk
 
+from sentry import features
 from sentry.integrations.mixins import NotifyBasicMixin
 from sentry.integrations.notifications import get_context, get_integrations_by_channel_by_recipient
 from sentry.integrations.slack.message_builder import SlackBlock
@@ -109,17 +110,26 @@ def _notify_recipient(
         if SiloMode.get_current_mode() == SiloMode.CONTROL:
             post_message_task = post_message_control
 
+        has_sdk_flag = features.has(
+            "organizations:slack-sdk-notify-recipient", notification.organization
+        )
+
         log_params = {
             "notification": str(notification),
             "recipient": recipient.id,
             "channel_id": channel,
         }
+        if has_sdk_flag:
+            log_error_message = "slack.notify_recipient.fail"
+        else:
+            log_error_message = "notification.fail.slack_post"
         post_message_task.apply_async(
             kwargs={
                 "integration_id": integration.id,
                 "payload": payload,
-                "log_error_message": "notification.fail.slack_post",
+                "log_error_message": log_error_message,
                 "log_params": log_params,
+                "has_sdk_flag": has_sdk_flag,
             }
         )
     # recording data outside of span

--- a/src/sentry/integrations/slack/service.py
+++ b/src/sentry/integrations/slack/service.py
@@ -257,6 +257,7 @@ class SlackService:
                     text=notification_to_send,
                     blocks=json_blocks,
                 )
+                self._logger.info("successfully posted message to slack with sdk", extra=extra)
             except SlackApiError as err:
                 self._logger.info(
                     "failed to post message to slack",

--- a/src/sentry/tasks/integrations/slack/post_message.py
+++ b/src/sentry/tasks/integrations/slack/post_message.py
@@ -20,7 +20,7 @@ def _send_message_to_slack_channel(
     payload: Mapping[str, Any],
     log_error_message: str,
     log_params: Mapping[str, Any],
-    has_sdk_flag: bool,
+    has_sdk_flag: bool | None = False,
 ) -> None:
     if has_sdk_flag:
         sdk_client = SlackSdkClient(integration_id=integration_id)

--- a/src/sentry/tasks/integrations/slack/post_message.py
+++ b/src/sentry/tasks/integrations/slack/post_message.py
@@ -4,7 +4,10 @@ import logging
 from collections.abc import Mapping
 from typing import Any
 
+from slack_sdk.errors import SlackApiError
+
 from sentry.integrations.slack.client import SlackClient
+from sentry.integrations.slack.sdk_client import SlackSdkClient
 from sentry.shared_integrations.exceptions import ApiError
 from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task
@@ -17,13 +20,28 @@ def _send_message_to_slack_channel(
     payload: Mapping[str, Any],
     log_error_message: str,
     log_params: Mapping[str, Any],
+    has_sdk_flag: bool,
 ) -> None:
-    client = SlackClient(integration_id=integration_id)
-    try:
-        client.post("/chat.postMessage", data=payload, timeout=5)
-    except ApiError as e:
-        extra = {"error": str(e), **log_params}
-        logger.info(log_error_message, extra=extra)
+    if has_sdk_flag:
+        sdk_client = SlackSdkClient(integration_id=integration_id)
+        try:
+            sdk_client.chat_postMessage(
+                blocks=str(payload["blocks"]),
+                text=str(payload["text"]),
+                channel=str(payload["channel"]),
+                unfurl_links=False,
+                unfurl_media=False,
+            )
+        except SlackApiError as e:
+            extra = {"error": str(e), **log_params}
+            logger.info(log_error_message, extra=extra)
+    else:
+        client = SlackClient(integration_id=integration_id)
+        try:
+            client.post("/chat.postMessage", data=payload, timeout=5)
+        except ApiError as e:
+            extra = {"error": str(e), **log_params}
+            logger.info(log_error_message, extra=extra)
 
 
 # TODO: add retry logic
@@ -38,12 +56,14 @@ def post_message(
     payload: Mapping[str, Any],
     log_error_message: str,
     log_params: Mapping[str, Any],
+    has_sdk_flag: bool,
 ) -> None:
     _send_message_to_slack_channel(
         integration_id=integration_id,
         payload=payload,
         log_error_message=log_error_message,
         log_params=log_params,
+        has_sdk_flag=has_sdk_flag,
     )
 
 
@@ -59,10 +79,12 @@ def post_message_control(
     payload: Mapping[str, Any],
     log_error_message: str,
     log_params: Mapping[str, Any],
+    has_sdk_flag: bool,
 ) -> None:
     _send_message_to_slack_channel(
         integration_id=integration_id,
         payload=payload,
         log_error_message=log_error_message,
         log_params=log_params,
+        has_sdk_flag=has_sdk_flag,
     )

--- a/src/sentry/tasks/integrations/slack/post_message.py
+++ b/src/sentry/tasks/integrations/slack/post_message.py
@@ -26,9 +26,9 @@ def _send_message_to_slack_channel(
         sdk_client = SlackSdkClient(integration_id=integration_id)
         try:
             sdk_client.chat_postMessage(
-                blocks=str(payload["blocks"]),
-                text=str(payload["text"]),
-                channel=str(payload["channel"]),
+                blocks=str(payload.get("blocks", "")),
+                text=str(payload.get("text", "")),
+                channel=str(payload.get("channel", "")),
                 unfurl_links=False,
                 unfurl_media=False,
             )

--- a/src/sentry/tasks/integrations/slack/post_message.py
+++ b/src/sentry/tasks/integrations/slack/post_message.py
@@ -32,6 +32,7 @@ def _send_message_to_slack_channel(
                 unfurl_links=False,
                 unfurl_media=False,
             )
+            logger.info("slack.send_message_to_channel.success", extra=log_params)
         except SlackApiError as e:
             extra = {"error": str(e), **log_params}
             logger.info(log_error_message, extra=extra)

--- a/src/sentry/tasks/integrations/slack/post_message.py
+++ b/src/sentry/tasks/integrations/slack/post_message.py
@@ -56,7 +56,7 @@ def post_message(
     payload: Mapping[str, Any],
     log_error_message: str,
     log_params: Mapping[str, Any],
-    has_sdk_flag: bool,
+    has_sdk_flag: bool | None = False,
 ) -> None:
     _send_message_to_slack_channel(
         integration_id=integration_id,

--- a/tests/sentry/integrations/slack/test_notifications.py
+++ b/tests/sentry/integrations/slack/test_notifications.py
@@ -5,9 +5,11 @@ import orjson
 import responses
 
 from sentry.integrations.slack.notifications import send_notification_as_slack
+from sentry.integrations.slack.sdk_client import SLACK_DATADOG_METRIC
 from sentry.integrations.types import ExternalProviders
 from sentry.notifications.additional_attachment_manager import manager
 from sentry.testutils.cases import SlackActivityNotificationTest
+from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.helpers.notifications import DummyNotification
 
 
@@ -100,3 +102,45 @@ class SlackNotificationsTest(SlackActivityNotificationTest):
             ],
             "type": "actions",
         }
+
+    @mock.patch("sentry.integrations.slack.sdk_client.metrics")
+    @mock.patch("slack_sdk.web.client.WebClient._perform_urllib_http_request")
+    @with_feature("organizations:slack-sdk-notify-recipient")
+    def test_send_notification_as_slack_sdk(self, mock_api_call, mock_metrics):
+        mock_api_call.return_value = {
+            "body": orjson.dumps({"ok": True}).decode(),
+            "headers": {},
+            "status": 200,
+        }
+        with (
+            mock.patch.dict(
+                manager.attachment_generators,
+                {ExternalProviders.SLACK: additional_attachment_generator_block_kit},
+            ),
+        ):
+            with self.tasks():
+                send_notification_as_slack(self.notification, [self.user], {}, {})
+
+        mock_metrics.incr.assert_called_with(
+            SLACK_DATADOG_METRIC,
+            sample_rate=1.0,
+            tags={"ok": True, "status": 200},
+        )
+
+    @mock.patch("sentry.integrations.slack.sdk_client.metrics")
+    @with_feature("organizations:slack-sdk-notify-recipient")
+    def test_send_notification_as_slack_sdk_error(self, mock_metrics):
+        with (
+            mock.patch.dict(
+                manager.attachment_generators,
+                {ExternalProviders.SLACK: additional_attachment_generator_block_kit},
+            ),
+        ):
+            with self.tasks():
+                send_notification_as_slack(self.notification, [self.user], {}, {})
+
+        mock_metrics.incr.assert_called_with(
+            SLACK_DATADOG_METRIC,
+            sample_rate=1.0,
+            tags={"ok": False, "status": 200},
+        )

--- a/tests/sentry/integrations/slack/test_tasks.py
+++ b/tests/sentry/integrations/slack/test_tasks.py
@@ -7,6 +7,7 @@ import pytest
 import responses
 
 from sentry.incidents.models.alert_rule import AlertRule, AlertRuleTriggerAction
+from sentry.integrations.slack.sdk_client import SLACK_DATADOG_METRIC
 from sentry.integrations.slack.utils import RedisRuleStatus
 from sentry.models.rule import Rule
 from sentry.receivers.rules import DEFAULT_RULE_LABEL, DEFAULT_RULE_LABEL_NEW
@@ -320,9 +321,10 @@ class SlackTasksTest(TestCase):
         data = parse_qs(responses.calls[0].request.body)
         assert data == {"key": ["val"]}
 
+    @patch("sentry.integrations.slack.sdk_client.metrics")
     @patch("slack_sdk.web.client.WebClient._perform_urllib_http_request")
     @responses.activate
-    def test_post_message_success_sdk(self, mock_api_call):
+    def test_post_message_success_sdk(self, mock_api_call, mock_metrics):
         mock_api_call.return_value = {
             "body": orjson.dumps({"ok": True}).decode(),
             "headers": {},
@@ -333,26 +335,35 @@ class SlackTasksTest(TestCase):
             post_message.apply_async(
                 kwargs={
                     "integration_id": self.integration.id,
-                    "payload": {"key": ["val"]},
+                    "payload": {"blocks": ["hello"], "text": "text", "channel": "channel"},
                     "log_error_message": "my_message",
                     "log_params": {"log_key": "log_value"},
                     "has_sdk_flag": True,
                 }
             )
-        data = parse_qs(responses.calls[0].request.body)
-        assert data == {"key": ["val"]}
 
+        mock_metrics.incr.assert_called_with(
+            SLACK_DATADOG_METRIC,
+            sample_rate=1.0,
+            tags={"ok": True, "status": 200},
+        )
+
+    @patch("sentry.integrations.slack.sdk_client.metrics")
     @responses.activate
-    def test_post_message_failure_sdk(self):
+    def test_post_message_failure_sdk(self, mock_metrics):
         with self.tasks():
             post_message.apply_async(
                 kwargs={
                     "integration_id": self.integration.id,
-                    "payload": {"key": ["val"]},
+                    "payload": {"blocks": ["hello"], "text": "text", "channel": "channel"},
                     "log_error_message": "my_message",
                     "log_params": {"log_key": "log_value"},
                     "has_sdk_flag": True,
                 }
             )
-        data = parse_qs(responses.calls[0].request.body)
-        assert data == {"key": ["val"]}
+
+        mock_metrics.incr.assert_called_with(
+            SLACK_DATADOG_METRIC,
+            sample_rate=1.0,
+            tags={"ok": False, "status": 200},
+        )

--- a/tests/sentry/integrations/slack/test_tasks.py
+++ b/tests/sentry/integrations/slack/test_tasks.py
@@ -319,3 +319,40 @@ class SlackTasksTest(TestCase):
             )
         data = parse_qs(responses.calls[0].request.body)
         assert data == {"key": ["val"]}
+
+    @patch("slack_sdk.web.client.WebClient._perform_urllib_http_request")
+    @responses.activate
+    def test_post_message_success_sdk(self, mock_api_call):
+        mock_api_call.return_value = {
+            "body": orjson.dumps({"ok": True}).decode(),
+            "headers": {},
+            "status": 200,
+        }
+
+        with self.tasks():
+            post_message.apply_async(
+                kwargs={
+                    "integration_id": self.integration.id,
+                    "payload": {"key": ["val"]},
+                    "log_error_message": "my_message",
+                    "log_params": {"log_key": "log_value"},
+                    "has_sdk_flag": True,
+                }
+            )
+        data = parse_qs(responses.calls[0].request.body)
+        assert data == {"key": ["val"]}
+
+    @responses.activate
+    def test_post_message_failure_sdk(self):
+        with self.tasks():
+            post_message.apply_async(
+                kwargs={
+                    "integration_id": self.integration.id,
+                    "payload": {"key": ["val"]},
+                    "log_error_message": "my_message",
+                    "log_params": {"log_key": "log_value"},
+                    "has_sdk_flag": True,
+                }
+            )
+        data = parse_qs(responses.calls[0].request.body)
+        assert data == {"key": ["val"]}


### PR DESCRIPTION
From the docstring for the function
> Send an "activity" or "alert rule" notification to a Slack user or team, but NOT to a channel directly.
> Sending Slack notifications to a channel is in integrations/slack/actions/notification.py