### PR TITLE
fix(stats): Remove metrics from stats menu

### DIFF
--- a/static/app/views/organizationStats/usageChart/index.tsx
+++ b/static/app/views/organizationStats/usageChart/index.tsx
@@ -90,12 +90,6 @@ export const CHART_OPTIONS_DATACATEGORY: CategoryOption[] = [
     yAxisMinInterval: 100,
   },
   {
-    label: DATA_CATEGORY_INFO.metrics.titleName,
-    value: DATA_CATEGORY_INFO.metrics.plural,
-    disabled: false,
-    yAxisMinInterval: 100,
-  },
-  {
     label: DATA_CATEGORY_INFO.span.titleName,
     value: DATA_CATEGORY_INFO.span.plural,
     disabled: false,


### PR DESCRIPTION
Removes the metrics option from the organization stats page drop down. Will follow-up with PR to fully remove metrics from organizations stats page 