### PR TITLE
fix(trace) improve rendering precision

### DIFF
--- a/static/app/views/performance/newTraceDetails/trace.tsx
+++ b/static/app/views/performance/newTraceDetails/trace.tsx
@@ -2244,6 +2244,17 @@ const TraceStylingWrapper = styled('div')`
           fill: ${p => p.theme.white};
         }
       }
+
+      &.error {
+        color: ${p => p.theme.red300};
+
+        .TraceChildrenCountWrapper {
+          button {
+            color: ${p => p.theme.white};
+            background-color: ${p => p.theme.red300};
+          }
+        }
+      }
     }
   }
 

--- a/static/app/views/performance/newTraceDetails/trace.tsx
+++ b/static/app/views/performance/newTraceDetails/trace.tsx
@@ -2298,7 +2298,7 @@ const TraceStylingWrapper = styled('div')`
   .TraceBar {
     position: absolute;
     height: 16px;
-    width: 100%;
+    width: 1px;
     background-color: black;
     transform-origin: left center;
 

--- a/static/app/views/performance/newTraceDetails/trace.tsx
+++ b/static/app/views/performance/newTraceDetails/trace.tsx
@@ -2032,6 +2032,7 @@ const TraceStylingWrapper = styled('div')`
     transition: none;
     font-size: ${p => p.theme.fontSizeSmall};
     transform: translateZ(0);
+    contain: content;
 
     --row-background-odd: ${p => p.theme.translucentSurface100};
     --row-background-hover: ${p => p.theme.translucentSurface100};

--- a/static/app/views/performance/newTraceDetails/traceModels/traceTree.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/traceTree.tsx
@@ -274,6 +274,9 @@ export function makeTraceNodeBarColor(
     return pickBarColor(node.value.op);
   }
   if (isAutogroupedNode(node)) {
+    if (node.errors.size > 0) {
+      return theme.red300;
+    }
     return theme.blue300;
   }
   if (isMissingInstrumentationNode(node)) {

--- a/static/app/views/performance/newTraceDetails/traceRenderers/virtualizedViewManager.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceRenderers/virtualizedViewManager.spec.tsx
@@ -141,9 +141,7 @@ describe('VirtualizedViewManger', () => {
       manager.initializeTraceSpace([0, 0, 1000, 1]);
       manager.initializePhysicalSpace(1000, 1);
 
-      expect(manager.computeSpanCSSMatrixTransform([0, 0.1])).toEqual([
-        0.001, 0, 0, 1, 0, 0,
-      ]);
+      expect(manager.computeSpanCSSMatrixTransform([0, 0.1])).toEqual([1, 0, 0, 1, 0, 0]);
     });
     it('computes width scaling correctly', () => {
       const manager = new VirtualizedViewManager({
@@ -154,7 +152,9 @@ describe('VirtualizedViewManger', () => {
       manager.initializeTraceSpace([0, 0, 100, 1]);
       manager.initializePhysicalSpace(1000, 1);
 
-      expect(manager.computeSpanCSSMatrixTransform([0, 100])).toEqual([1, 0, 0, 1, 0, 0]);
+      expect(manager.computeSpanCSSMatrixTransform([0, 100])).toEqual([
+        1000, 0, 0, 1, 0, 0,
+      ]);
     });
 
     it('computes x position correctly', () => {
@@ -167,7 +167,7 @@ describe('VirtualizedViewManger', () => {
       manager.initializePhysicalSpace(1000, 1);
 
       expect(manager.computeSpanCSSMatrixTransform([50, 1000])).toEqual([
-        1, 0, 0, 1, 50, 0,
+        1000, 0, 0, 1, 50, 0,
       ]);
     });
 
@@ -181,7 +181,7 @@ describe('VirtualizedViewManger', () => {
       manager.initializePhysicalSpace(1000, 1);
 
       expect(manager.computeSpanCSSMatrixTransform([50, 1000])).toEqual([
-        1, 0, 0, 1, 50, 0,
+        1000, 0, 0, 1, 50, 0,
       ]);
     });
 
@@ -196,7 +196,7 @@ describe('VirtualizedViewManger', () => {
         manager.initializePhysicalSpace(1000, 1);
 
         expect(manager.computeSpanCSSMatrixTransform([100, 100])).toEqual([
-          1, 0, 0, 1, 0, 0,
+          1000, 0, 0, 1, 0, 0,
         ]);
       });
       it('computes x position correctly when view is offset', () => {
@@ -209,7 +209,7 @@ describe('VirtualizedViewManger', () => {
         manager.initializePhysicalSpace(1000, 1);
 
         expect(manager.computeSpanCSSMatrixTransform([100, 100])).toEqual([
-          1, 0, 0, 1, 0, 0,
+          1000, 0, 0, 1, 0, 0,
         ]);
       });
     });

--- a/static/app/views/performance/newTraceDetails/traceRenderers/virtualizedViewManager.tsx
+++ b/static/app/views/performance/newTraceDetails/traceRenderers/virtualizedViewManager.tsx
@@ -584,7 +584,7 @@ export class VirtualizedViewManager {
       // which results in the value of x being incorrectly set and the view moving to the right.
       // To prevent this, we will only update the x position if the new width is greater than the min zoom precision.
       this.setTraceView({
-        x: newView[2] < this.MAX_ZOOM_PRECISION ? this.trace_view.x : newView[0],
+        x: newView[2] < this.MAX_ZOOM_PRECISION_MS ? this.trace_view.x : newView[0],
         width: newView[2],
       });
       this.draw();
@@ -787,7 +787,7 @@ export class VirtualizedViewManager {
     this.trace_view.x = clamp(
       x,
       0,
-      Math.max(this.trace_space.width - width, this.MAX_ZOOM_PRECISION)
+      Math.max(this.trace_space.width - width, this.MAX_ZOOM_PRECISION_MS)
     );
 
     this.recomputeTimelineIntervals();

--- a/static/app/views/performance/newTraceDetails/traceRenderers/virtualizedViewManager.tsx
+++ b/static/app/views/performance/newTraceDetails/traceRenderers/virtualizedViewManager.tsx
@@ -1104,7 +1104,7 @@ export class VirtualizedViewManager {
 
   recomputeSpanToPxMatrix() {
     const traceViewToSpace = this.trace_space.between(this.trace_view);
-    const tracePhysicalToView = this.trace_physical_space.between(this.trace_space);
+    const tracePhysicalToView = this.trace_physical_space.between(this.trace_view);
 
     this.span_to_px = mat3.multiply(
       this.span_to_px,
@@ -1145,11 +1145,13 @@ export class VirtualizedViewManager {
   computeSpanCSSMatrixTransform(
     space: [number, number]
   ): [number, number, number, number, number, number] {
-    const scale = space[1] / this.trace_view.width;
-    this.span_matrix[0] = Math.max(scale, this.span_to_px[0] / this.trace_view.width);
+    const spaceToView = this.trace_space.width / this.trace_view.width;
+    const viewToPhysical = this.trace_physical_space.width / this.trace_view.width;
+    const spaceToPhysical = spaceToView * viewToPhysical;
+
+    this.span_matrix[0] = space[1] * spaceToPhysical;
     this.span_matrix[4] =
-      (space[0] - this.to_origin) / this.span_to_px[0] -
-      this.trace_view.x / this.span_to_px[0];
+      (space[0] - this.to_origin) * spaceToPhysical - this.trace_view.x * viewToPhysical;
 
     return this.span_matrix;
   }

--- a/static/app/views/performance/newTraceDetails/traceRenderers/virtualizedViewManager.tsx
+++ b/static/app/views/performance/newTraceDetails/traceRenderers/virtualizedViewManager.tsx
@@ -1342,7 +1342,7 @@ export class VirtualizedViewManager {
     });
 
     // 60px error margin. ~52px is roughly the width of 500.00ms, we add a bit more, to be safe.
-    const error_margin = 60 * this.span_to_px;
+    const error_margin = 60 / this.span_to_px;
 
     for (let i = 0; i < this.columns.list.column_refs.length; i++) {
       const span = this.span_bars[i];

--- a/static/app/views/performance/newTraceDetails/traceRenderers/virtualizedViewManager.tsx
+++ b/static/app/views/performance/newTraceDetails/traceRenderers/virtualizedViewManager.tsx
@@ -808,6 +808,7 @@ export class VirtualizedViewManager {
       this.timers.onFovChange = null;
     }, 500);
   }
+
   onNewMaxRowWidth(max) {
     this.syncHorizontalScrollbar(max);
   }
@@ -1125,6 +1126,7 @@ export class VirtualizedViewManager {
       }
       return;
     }
+
     const tracePhysicalToView = this.trace_physical_space.between(this.trace_view);
     const time_at_100 =
       tracePhysicalToView[0] * (100 * window.devicePixelRatio) +
@@ -1141,6 +1143,12 @@ export class VirtualizedViewManager {
   computeSpanCSSMatrixTransform(
     space: [number, number]
   ): [number, number, number, number, number, number] {
+    if (this.trace_space.width === 0) {
+      this.span_matrix[0] = this.trace_physical_space.width;
+      this.span_matrix[4] = 0;
+      return this.span_matrix;
+    }
+
     const spaceToView = this.trace_space.width / this.trace_view.width;
     const viewToPhysical = this.trace_physical_space.width / this.trace_space.width;
     const spaceToPhysical = spaceToView * viewToPhysical;
@@ -1467,7 +1475,7 @@ export class VirtualizedViewManager {
   drawSpanBar(span_bar: this['span_bars'][0]) {
     if (!span_bar) return;
 
-    const span_transform = this.computeSpanCSSMatrixTransform(span_bar?.space);
+    const span_transform = this.computeSpanCSSMatrixTransform(span_bar.space);
     span_bar.ref.style.transform = `matrix(${span_transform.join(',')}`;
     const inverseScale = Math.round((1 / span_transform[0]) * 1e4) / 1e4;
     span_bar.ref.style.setProperty(

--- a/static/app/views/performance/newTraceDetails/traceRenderers/virtualizedViewManager.tsx
+++ b/static/app/views/performance/newTraceDetails/traceRenderers/virtualizedViewManager.tsx
@@ -19,6 +19,11 @@ function easeOutSine(x: number): number {
   return Math.sin((x * Math.PI) / 2);
 }
 
+function inverseScale(scale: number, precision: number = 1e8): number {
+  const n = Math.round((1 / scale) * precision) / precision;
+  return isNaN(n) ? 1 : n;
+}
+
 function getHorizontalDelta(x: number, y: number): number {
   if (x >= 0 && y >= 0) {
     return Math.max(x, y);
@@ -443,11 +448,10 @@ export class VirtualizedViewManager {
 
       const span_transform = this.computeSpanCSSMatrixTransform(space);
       ref.style.transform = `matrix(${span_transform.join(',')}`;
-      const inverseScale = Math.round((1 / span_transform[0]) * 1e8) / 1e8;
       ref.style.setProperty(
         '--inverse-span-scale',
         // @ts-expect-error this is a number
-        isNaN(inverseScale) ? 1 : inverseScale
+        inverseScale(span_transform[0])
       );
     }
   }
@@ -1477,11 +1481,10 @@ export class VirtualizedViewManager {
 
     const span_transform = this.computeSpanCSSMatrixTransform(span_bar.space);
     span_bar.ref.style.transform = `matrix(${span_transform.join(',')}`;
-    const inverseScale = Math.round((1 / span_transform[0]) * 1e8) / 1e8;
     span_bar.ref.style.setProperty(
       '--inverse-span-scale',
       // @ts-expect-error we set number value type on purpose
-      isNaN(inverseScale) ? 1 : inverseScale
+      inverseScale(span_transform[0])
     );
   }
 
@@ -1674,11 +1677,10 @@ export class VirtualizedViewManager {
       if (invisible_bar) {
         const span_transform = this.computeSpanCSSMatrixTransform(invisible_bar?.space);
         invisible_bar.ref.style.transform = `matrix(${span_transform.join(',')}`;
-        const inverseScale = Math.round((1 / span_transform[0]) * 1e8) / 1e8;
         invisible_bar.ref.style.setProperty(
           '--inverse-span-scale',
           // @ts-expect-error we set number value type on purpose
-          isNaN(inverseScale) ? 1 : inverseScale
+          inverseScale(span_transform[0])
         );
       }
 

--- a/static/app/views/performance/newTraceDetails/traceRenderers/virtualizedViewManager.tsx
+++ b/static/app/views/performance/newTraceDetails/traceRenderers/virtualizedViewManager.tsx
@@ -443,7 +443,7 @@ export class VirtualizedViewManager {
 
       const span_transform = this.computeSpanCSSMatrixTransform(space);
       ref.style.transform = `matrix(${span_transform.join(',')}`;
-      const inverseScale = Math.round((1 / span_transform[0]) * 1e4) / 1e4;
+      const inverseScale = Math.round((1 / span_transform[0]) * 1e8) / 1e8;
       ref.style.setProperty(
         '--inverse-span-scale',
         // @ts-expect-error this is a number
@@ -1477,7 +1477,7 @@ export class VirtualizedViewManager {
 
     const span_transform = this.computeSpanCSSMatrixTransform(span_bar.space);
     span_bar.ref.style.transform = `matrix(${span_transform.join(',')}`;
-    const inverseScale = Math.round((1 / span_transform[0]) * 1e4) / 1e4;
+    const inverseScale = Math.round((1 / span_transform[0]) * 1e8) / 1e8;
     span_bar.ref.style.setProperty(
       '--inverse-span-scale',
       // @ts-expect-error we set number value type on purpose
@@ -1674,7 +1674,7 @@ export class VirtualizedViewManager {
       if (invisible_bar) {
         const span_transform = this.computeSpanCSSMatrixTransform(invisible_bar?.space);
         invisible_bar.ref.style.transform = `matrix(${span_transform.join(',')}`;
-        const inverseScale = Math.round((1 / span_transform[0]) * 1e4) / 1e4;
+        const inverseScale = Math.round((1 / span_transform[0]) * 1e8) / 1e8;
         invisible_bar.ref.style.setProperty(
           '--inverse-span-scale',
           // @ts-expect-error we set number value type on purpose


### PR DESCRIPTION
When trace bars are rendered as 100% and downscaled, we hit imprecise rendering errors in Chrome. This isnt an issue in Safari or Firefox. I suspect we lose precision when downscaling large values (when zooming in, the error increases). To fix this, change the rendering to scale up using 1px precision.