### PR TITLE
ref(replay): remove 'configure replay' card in details for mobile replays

### DIFF
--- a/static/app/views/replays/detail/page.tsx
+++ b/static/app/views/replays/detail/page.tsx
@@ -81,7 +81,7 @@ export default function Page({
 
       <ButtonActionsWrapper>
         {isVideoReplay ? <FeedbackWidgetButton /> : <FeedbackButton />}
-        <ConfigureReplayCard />
+        {isVideoReplay ? null : <ConfigureReplayCard />}
         <DropdownMenu
           position="bottom-end"
           triggerProps={{


### PR DESCRIPTION
the `configure replay` card is web-specific. until we have mobile-specific docs, let's hide this. relates to https://github.com/getsentry/sentry/issues/72231
<img width="324" alt="SCR-20240611-jxjp" src="https://github.com/getsentry/sentry/assets/56095982/a93abd80-6a95-4338-b4d8-e4b90e122f8e">

before:
<img width="808" alt="SCR-20240611-jwvd" src="https://github.com/getsentry/sentry/assets/56095982/7ba963ba-1795-41fb-8f20-1bdf6989aee3">

after:
<img width="804" alt="SCR-20240611-jwtb" src="https://github.com/getsentry/sentry/assets/56095982/ffceff2a-b921-4cf5-8657-cc5859ac321c">

another thing that will cause jumping on the page, to be fixed later
