### PR TITLE
fix(github): update repo name in webhook

### DIFF
--- a/tests/sentry/integrations/github/test_webhooks.py
+++ b/tests/sentry/integrations/github/test_webhooks.py
@@ -229,7 +229,7 @@ class PushEventWebhookTest(APITestCase):
             organization_id=project.organization.id,
             external_id="35129377",
             provider="integrations:github",
-            name="baxterthehacker/public-repo",
+            name="baxterthehacker/repo",
         )
 
         self._setup_repo_test(project)
@@ -267,6 +267,7 @@ class PushEventWebhookTest(APITestCase):
 
         repo.refresh_from_db()
         assert set(repo.languages) == {"python", "javascript"}
+        assert repo.name == "baxterthehacker/public-repo"
 
     @responses.activate
     @patch("sentry.integrations.github.webhook.metrics")


### PR DESCRIPTION
The method of updating repo names was removed a while ago because there were too many IntegrityErrors happening. These should occur less frequently because we don't have the constraint on the repo name anymore, it was removed here https://github.com/getsentry/sentry/pull/53286