### PR TITLE
ref(slack): Logging & Metrics in Unlink User Flow

### DIFF
--- a/src/sentry/integrations/slack/webhooks/base.py
+++ b/src/sentry/integrations/slack/webhooks/base.py
@@ -19,9 +19,16 @@ UNLINK_USER_MESSAGE = "<{associate_url}|Click here to unlink your identity.>"
 NOT_LINKED_MESSAGE = "You do not have a linked identity to unlink."
 ALREADY_LINKED_MESSAGE = "You are already linked as `{username}`."
 
+from sentry.utils import metrics
+
+from ..utils import logger
+
 
 class SlackDMEndpoint(Endpoint, abc.ABC):
     slack_request_class = SlackDMRequest
+
+    _METRICS_SUCCESS_KEY = "slack.integrations.slack.dm_endpoint.success."
+    _METRIC_FAILURE_KEY = "slack.integrations.slack.dm_endpoint.failure."
 
     def post_dispatcher(self, request: SlackDMRequest) -> Response:
         """
@@ -74,9 +81,15 @@ class SlackDMEndpoint(Endpoint, abc.ABC):
 
     def unlink_user(self, slack_request: SlackDMRequest) -> Response:
         if not slack_request.has_identity:
+            logger.error("unlink-user.no-identity.error", extra={"slack_request": slack_request})
+            metrics.incr(self._METRIC_FAILURE_KEY + "unlink_user.no_identity", sample_rate=1.0)
+
             return self.reply(slack_request, NOT_LINKED_MESSAGE)
 
         if not (slack_request.integration and slack_request.user_id and slack_request.channel_id):
+            logger.error("unlink-user.bad_request.error", extra={"slack_request": slack_request})
+            metrics.incr(self._METRIC_FAILURE_KEY + "unlink_user.bad_request", sample_rate=1.0)
+
             raise SlackRequestError(status=status.HTTP_400_BAD_REQUEST)
 
         associate_url = build_unlinking_url(
@@ -85,6 +98,9 @@ class SlackDMEndpoint(Endpoint, abc.ABC):
             channel_id=slack_request.channel_id,
             response_url=slack_request.response_url,
         )
+
+        metrics.incr(self._METRICS_SUCCESS_KEY + "unlink_user", sample_rate=1.0)
+
         return self.reply(slack_request, UNLINK_USER_MESSAGE.format(associate_url=associate_url))
 
     def link_team(self, slack_request: SlackDMRequest) -> Response:

--- a/src/sentry/integrations/slack/webhooks/base.py
+++ b/src/sentry/integrations/slack/webhooks/base.py
@@ -29,8 +29,8 @@ logger = logging.getLogger(__name__)
 class SlackDMEndpoint(Endpoint, abc.ABC):
     slack_request_class = SlackDMRequest
 
-    _METRICS_SUCCESS_KEY = "slack.integrations.slack.dm_endpoint.success."
-    _METRIC_FAILURE_KEY = "slack.integrations.slack.dm_endpoint.failure."
+    _METRICS_SUCCESS_KEY = "sentry.integrations.slack.dm_endpoint.success"
+    _METRIC_FAILURE_KEY = "sentry.integrations.slack.dm_endpoint.failure"
 
     def post_dispatcher(self, request: SlackDMRequest) -> Response:
         """

--- a/src/sentry/integrations/slack/webhooks/base.py
+++ b/src/sentry/integrations/slack/webhooks/base.py
@@ -19,9 +19,11 @@ UNLINK_USER_MESSAGE = "<{associate_url}|Click here to unlink your identity.>"
 NOT_LINKED_MESSAGE = "You do not have a linked identity to unlink."
 ALREADY_LINKED_MESSAGE = "You are already linked as `{username}`."
 
+import logging
+
 from sentry.utils import metrics
 
-from ..utils import logger
+logger = logging.getLogger(__name__)
 
 
 class SlackDMEndpoint(Endpoint, abc.ABC):

--- a/src/sentry/integrations/slack/webhooks/base.py
+++ b/src/sentry/integrations/slack/webhooks/base.py
@@ -29,8 +29,8 @@ logger = logging.getLogger(__name__)
 class SlackDMEndpoint(Endpoint, abc.ABC):
     slack_request_class = SlackDMRequest
 
-    _METRICS_SUCCESS_KEY = "sentry.integrations.slack.dm_endpoint.success"
-    _METRIC_FAILURE_KEY = "sentry.integrations.slack.dm_endpoint.failure"
+    _METRICS_SUCCESS_KEY = "sentry.integrations.slack.dm_endpoint.success."
+    _METRIC_FAILURE_KEY = "sentry.integrations.slack.dm_endpoint.failure."
 
     def post_dispatcher(self, request: SlackDMRequest) -> Response:
         """


### PR DESCRIPTION
https://www.notion.so/sentry/Slack-ff5b8ab4fd1e4760ab829438ce97ce15

Addresses `bot-1` task. Added logging and metrics to the flow. 

Will start working on a dashboard for all the bot commands.
