### PR TITLE
chore(perf): Adjust flags for suspect spans table

### DIFF
--- a/static/app/views/performance/transactionSummary/transactionOverview/content.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/content.tsx
@@ -403,7 +403,7 @@ function SummaryContent({
           />
         </PerformanceAtScaleContextProvider>
 
-        {hasNewSpansUIFlag && (
+        {!hasNewSpansUIFlag && (
           <SuspectSpans
             location={location}
             organization={organization}

--- a/static/app/views/performance/transactionSummary/transactionOverview/content.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/content.tsx
@@ -330,6 +330,10 @@ function SummaryContent({
     handleOpenAllEventsClick: handleAllEventsViewClick,
   };
 
+  const hasNewSpansUIFlag =
+    organization.features.includes('performance-spans-new-ui') &&
+    organization.features.includes('insights-initial-modules');
+
   return (
     <Fragment>
       <Layout.Main>
@@ -399,18 +403,21 @@ function SummaryContent({
           />
         </PerformanceAtScaleContextProvider>
 
-        <SuspectSpans
-          location={location}
-          organization={organization}
-          eventView={eventView}
-          totals={
-            defined(totalValues?.['count()'])
-              ? {'count()': totalValues!['count()']}
-              : null
-          }
-          projectId={projectId}
-          transactionName={transactionName}
-        />
+        {hasNewSpansUIFlag ? null : (
+          <SuspectSpans
+            location={location}
+            organization={organization}
+            eventView={eventView}
+            totals={
+              defined(totalValues?.['count()'])
+                ? {'count()': totalValues!['count()']}
+                : null
+            }
+            projectId={projectId}
+            transactionName={transactionName}
+          />
+        )}
+
         <TagExplorer
           eventView={eventView}
           organization={organization}

--- a/static/app/views/performance/transactionSummary/transactionOverview/content.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/content.tsx
@@ -403,7 +403,7 @@ function SummaryContent({
           />
         </PerformanceAtScaleContextProvider>
 
-        {hasNewSpansUIFlag ? null : (
+        {hasNewSpansUIFlag && (
           <SuspectSpans
             location={location}
             organization={organization}

--- a/static/app/views/performance/transactionSummary/transactionSpans/spanDetails/content.tsx
+++ b/static/app/views/performance/transactionSummary/transactionSpans/spanDetails/content.tsx
@@ -54,7 +54,9 @@ export default function SpanDetailsContentWrapper(props: Props) {
     project_platforms: project ? getSelectedProjectPlatforms(location, [project]) : '',
   });
 
-  const hasNewSpansUIFlag = organization.features.includes('performance-spans-new-ui');
+  const hasNewSpansUIFlag =
+    organization.features.includes('performance-spans-new-ui') &&
+    organization.features.includes('insights-initial-modules');
 
   // TODO: When this feature is rolled out to GA, we will no longer need the entire `spanDetails` directory and can switch to `spanSummary`
   if (hasNewSpansUIFlag) {


### PR DESCRIPTION
Adjusts some of the feature flag logic for span summary and the suspect spans table:

- Hide the suspect spans table and new span summary for orgs that don't have the `insights-initial-modules` flag, as only these plans will have span metrics ingestion