### PR TITLE
ref(replays): rm network onboarding for mobile replays

### DIFF
--- a/static/app/views/replays/detail/network/details/onboarding.tsx
+++ b/static/app/views/replays/detail/network/details/onboarding.tsx
@@ -3,6 +3,7 @@ import styled from '@emotion/styled';
 import Alert from 'sentry/components/alert';
 import {CodeSnippet} from 'sentry/components/codeSnippet';
 import ExternalLink from 'sentry/components/links/externalLink';
+import {useReplayContext} from 'sentry/components/replays/replayContext';
 import TextCopyInput from 'sentry/components/textCopyInput';
 import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
@@ -68,10 +69,12 @@ export function Setup({
     projectId: [projectId],
   });
   const sdkNeedsUpdate = !isFetching && Boolean(needsUpdate);
+  const {replay} = useReplayContext();
+  const isVideoReplay = replay?.isVideoReplay();
 
   const url = item.description || 'http://example.com';
 
-  return (
+  return isVideoReplay ? null : (
     <SetupInstructions
       minVersion="7.53.1"
       sdkNeedsUpdate={sdkNeedsUpdate}


### PR DESCRIPTION
this onboarding snippet is JS and not relevant to mobile replays.
closes https://github.com/getsentry/sentry/issues/72232

before:
<img width="737" alt="SCR-20240611-kgcn" src="https://github.com/getsentry/sentry/assets/56095982/cb34b4d9-1ef5-4f9d-acc4-486143c68fc1">

after:
<img width="559" alt="SCR-20240611-kgtf" src="https://github.com/getsentry/sentry/assets/56095982/5e4fbe22-ae97-4eb2-b3d0-040a95ec4b20">
