### PR TITLE
ref: fix typing for sdk tag normalization

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -207,7 +207,7 @@ def sdk_metadata_from_event(event: Event) -> Mapping[str, Any]:
         return {
             "sdk": {
                 "name": sdk_metadata.get("name") or "unknown",
-                "name_normalized": normalized_sdk_tag_from_event(event),
+                "name_normalized": normalized_sdk_tag_from_event(event.data),
             }
         }
     except Exception:
@@ -1574,7 +1574,7 @@ def _save_aggregate(
                         skip_internal=True,
                         tags={
                             "platform": event.platform or "unknown",
-                            "sdk": normalized_sdk_tag_from_event(event),
+                            "sdk": normalized_sdk_tag_from_event(event.data),
                         },
                     )
 
@@ -1588,7 +1588,7 @@ def _save_aggregate(
                             sample_rate=1.0,
                             tags={
                                 "platform": event.platform or "unknown",
-                                "sdk": normalized_sdk_tag_from_event(event),
+                                "sdk": normalized_sdk_tag_from_event(event.data),
                                 "frame_mix": frame_mix,
                             },
                         )

--- a/src/sentry/grouping/ingest/hashing.py
+++ b/src/sentry/grouping/ingest/hashing.py
@@ -52,7 +52,7 @@ def _calculate_event_grouping(
     metric_tags: MutableTags = {
         "grouping_config": grouping_config["id"],
         "platform": event.platform or "unknown",
-        "sdk": normalized_sdk_tag_from_event(event),
+        "sdk": normalized_sdk_tag_from_event(event.data),
     }
 
     with metrics.timer("save_event._calculate_event_grouping", tags=metric_tags):
@@ -117,7 +117,7 @@ def _calculate_background_grouping(
     metric_tags: MutableTags = {
         "grouping_config": config["id"],
         "platform": event.platform or "unknown",
-        "sdk": normalized_sdk_tag_from_event(event),
+        "sdk": normalized_sdk_tag_from_event(event.data),
     }
     with metrics.timer("event_manager.background_grouping", tags=metric_tags):
         return _calculate_event_grouping(project, event, config)

--- a/src/sentry/grouping/ingest/metrics.py
+++ b/src/sentry/grouping/ingest/metrics.py
@@ -93,13 +93,13 @@ def record_calculation_metric_with_result(
     metrics.incr("grouping.total_calculations", amount=2 if has_secondary_hashes else 1, tags=tags)
 
 
-def record_new_group_metrics(event: Event):
+def record_new_group_metrics(event: Event) -> None:
     metrics.incr(
         "group.created",
         skip_internal=True,
         tags={
             "platform": event.platform or "unknown",
-            "sdk": normalized_sdk_tag_from_event(event),
+            "sdk": normalized_sdk_tag_from_event(event.data),
         },
     )
 
@@ -111,7 +111,7 @@ def record_new_group_metrics(event: Event):
             sample_rate=1.0,
             tags={
                 "platform": event.platform or "unknown",
-                "sdk": normalized_sdk_tag_from_event(event),
+                "sdk": normalized_sdk_tag_from_event(event.data),
                 "frame_mix": frame_mix,
             },
         )

--- a/src/sentry/issues/ingest.py
+++ b/src/sentry/issues/ingest.py
@@ -4,7 +4,7 @@ import logging
 from collections.abc import Mapping
 from datetime import datetime
 from hashlib import md5
-from typing import Any, TypedDict, cast
+from typing import Any, TypedDict
 
 import sentry_sdk
 from django.conf import settings
@@ -209,9 +209,7 @@ def save_issue_from_occurrence(
             ) as metric_tags,
             transaction.atomic(router.db_for_write(GroupHash)),
         ):
-            group, is_new = save_grouphash_and_group(
-                project, event, new_grouphash, **cast(Mapping[str, Any], issue_kwargs)
-            )
+            group, is_new = save_grouphash_and_group(project, event, new_grouphash, **issue_kwargs)
             is_regression = False
             span.set_tag("save_issue_from_occurrence.outcome", "new_group")
             metric_tags["save_issue_from_occurrence.outcome"] = "new_group"
@@ -221,7 +219,7 @@ def save_issue_from_occurrence(
                 tags={
                     "platform": event.platform or "unknown",
                     "type": occurrence.type.type_id,
-                    "sdk": normalized_sdk_tag_from_event(event),
+                    "sdk": normalized_sdk_tag_from_event(event.data),
                 },
             )
             group_info = GroupInfo(group=group, is_new=is_new, is_regression=is_regression)
@@ -235,7 +233,7 @@ def save_issue_from_occurrence(
                     tags={
                         "platform": event.platform or "unknown",
                         "frame_mix": frame_mix,
-                        "sdk": normalized_sdk_tag_from_event(event),
+                        "sdk": normalized_sdk_tag_from_event(event.data),
                     },
                 )
         if is_new and occurrence.assignee:

--- a/src/sentry/utils/tag_normalization.py
+++ b/src/sentry/utils/tag_normalization.py
@@ -1,8 +1,10 @@
+from __future__ import annotations
+
 import functools
 import logging
 import re
-
-from sentry.eventstore.models import Event
+from collections.abc import Mapping
+from typing import Any
 
 logger = logging.getLogger(__name__)
 
@@ -100,7 +102,7 @@ def normalize_sdk_tag(tag: str) -> str:
     return tag
 
 
-def normalized_sdk_tag_from_event(event: Event) -> str:
+def normalized_sdk_tag_from_event(event: Mapping[str, Any]) -> str:
     """
      Normalize tags coming from SDKs to more manageable canonical form, by:
 
@@ -114,7 +116,7 @@ def normalized_sdk_tag_from_event(event: Event) -> str:
     the ones interesinting to us as granual as possible.
     """
     try:
-        return normalize_sdk_tag((event.data.get("sdk") or {}).get("name") or "other")
+        return normalize_sdk_tag((event.get("sdk") or {}).get("name") or "other")
     except Exception:
         logger.warning("failed to get SDK name", exc_info=True)
         return "other"

--- a/src/sentry/utils/tag_normalization.py
+++ b/src/sentry/utils/tag_normalization.py
@@ -102,7 +102,7 @@ def normalize_sdk_tag(tag: str) -> str:
     return tag
 
 
-def normalized_sdk_tag_from_event(event: Mapping[str, Any]) -> str:
+def normalized_sdk_tag_from_event(data: Mapping[str, Any]) -> str:
     """
      Normalize tags coming from SDKs to more manageable canonical form, by:
 
@@ -116,7 +116,7 @@ def normalized_sdk_tag_from_event(event: Mapping[str, Any]) -> str:
     the ones interesinting to us as granual as possible.
     """
     try:
-        return normalize_sdk_tag((event.get("sdk") or {}).get("name") or "other")
+        return normalize_sdk_tag((data.get("sdk") or {}).get("name") or "other")
     except Exception:
         logger.warning("failed to get SDK name", exc_info=True)
         return "other"

--- a/tests/sentry/utils/test_tag_normalization.py
+++ b/tests/sentry/utils/test_tag_normalization.py
@@ -2,7 +2,6 @@ from unittest import mock
 
 import pytest
 
-from sentry.eventstore.models import Event
 from sentry.utils.tag_normalization import normalize_sdk_tag, normalized_sdk_tag_from_event
 
 
@@ -75,11 +74,6 @@ def test_responses_cached():
     assert normalize_sdk_tag.cache_info().misses == 1
 
 
-@pytest.fixture
-def mock_event():
-    return mock.Mock(spec=Event)
-
-
 @pytest.mark.parametrize(
     ("tag", "expected"),
     (
@@ -90,11 +84,10 @@ def mock_event():
         ("sentry.javascript.react.native.expo", "sentry.javascript.react.native"),
     ),
 )
-def test_normalized_sdk_tag_from_event(tag, expected, mock_event):
-    mock_event.data = {"sdk": {"name": tag}}
-    assert normalized_sdk_tag_from_event(mock_event) == expected
+def test_normalized_sdk_tag_from_event(tag: str, expected: str) -> None:
+    assert normalized_sdk_tag_from_event({"sdk": {"name": tag}}) == expected
 
 
-def test_normalized_sdk_tag_from_event_exception(mock_event):
-    mock_event.side_effect = Exception("foo")
+def test_normalized_sdk_tag_from_event_exception():
+    mock_event = mock.Mock()
     assert normalized_sdk_tag_from_event(mock_event) == "other"


### PR DESCRIPTION
callers currently call this with both Event and CanonicalKeyDict which happens to accidentally work due to the .data property

I'm killing CanonicalKeyDict so I have to fix this first

this also fixes an error in ignored files:

```diff
$ diff -u .artifacts/mypy-all{,.new}
--- .artifacts/mypy-all	2024-06-11 14:59:12
+++ .artifacts/mypy-all.new	2024-06-11 14:57:56
@@ -232,7 +232,6 @@
 src/sentry/grouping/fingerprinting/__init__.py:150: error: Incompatible types in assignment (expression has type "list[dict[str, Any]]", variable has type "None")  [assignment]
 src/sentry/grouping/fingerprinting/__init__.py:153: error: Incompatible return value type (got "None", expected "list[dict[str, str]]")  [return-value]
 src/sentry/grouping/fingerprinting/__init__.py:157: error: Incompatible types in assignment (expression has type "list[dict[str, str]]", variable has type "None")  [assignment]
-src/sentry/grouping/fingerprinting/__init__.py:157: error: Argument 1 to "normalized_sdk_tag_from_event" has incompatible type "dict[str, object]"; expected "Event"  [arg-type]
 src/sentry/grouping/fingerprinting/__init__.py:158: error: Incompatible return value type (got "None", expected "list[dict[str, str]]")  [return-value]
 src/sentry/grouping/fingerprinting/__init__.py:161: error: Incompatible types in assignment (expression has type "list[dict[str, Any]]", variable has type "None")  [assignment]
 src/sentry/grouping/fingerprinting/__init__.py:164: error: Incompatible return value type (got "None", expected "list[dict[str, str]]")  [return-value]
@@ -3889,4 +3888,4 @@
 tests/sentry/api/bases/test_organization.py:87: error: Argument "request" to "has_permission" of "ScopedPermission" has incompatible type "HttpRequest"; expected "Request"  [arg-type]
 tests/sentry/api/bases/test_organization.py:88: error: Argument "request" to "has_object_permission" of "OrganizationPermission" has incompatible type "HttpRequest"; expected "Request"  [arg-type]
 tests/sentry/api/bases/test_organization.py:244: error: Argument "request" to "is_not_2fa_compliant" of "OrganizationPermission" has incompatible type "HttpRequest"; expected "Request"  [arg-type]
-Found 2896 errors in 381 files (checked 5795 source files)
+Found 2895 errors in 381 files (checked 5795 source files)
```

<!-- Describe your PR here. -->