### PR TITLE
chore(features) Add new name for org-subdomains feature flag

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1770,7 +1770,7 @@ SENTRY_ENDPOINT: str | None = None
 SENTRY_PUBLIC_ENDPOINT: str | None = None
 
 # Hostname prefix to add for organizations that are opted into the
-# `organizations:org-subdomains` feature.
+# `organizations:org-ingest-subdomains` feature.
 SENTRY_ORG_SUBDOMAIN_TEMPLATE = "o{organization_id}.ingest"
 
 # Prevent variables (e.g. context locals, http data, etc) from exceeding this

--- a/src/sentry/features/permanent.py
+++ b/src/sentry/features/permanent.py
@@ -103,6 +103,13 @@ def register_permanent_features(manager: FeatureManager):
         "organizations:customer-domains": False,
         # Enable the frontend to request from region & control silo domains.
         "organizations:frontend-domainsplit": False,
+        # Prefix host with organization ID when giving users DSNs (can be
+        # customized with SENTRY_ORG_SUBDOMAIN_TEMPLATE) eg. o123.ingest.us.sentry.io
+        # Deprecated - use org-ingest-subdomain instead.
+        "organizations:org-subdomains": False,
+        # Prefix host with organization ID when giving users DSNs (can be
+        # customized with SENTRY_ORG_SUBDOMAIN_TEMPLATE) eg. o123.ingest.us.sentry.io
+        "organizations:org-ingest-subdomains": False,
     }
 
     permanent_project_features = {

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -209,9 +209,6 @@ def register_temporary_features(manager: FeatureManager):
     manager.add("organizations:onboarding", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
     # Enable the SDK selection feature in the onboarding
     manager.add("organizations:onboarding-sdk-selection", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
-    # Prefix host with organization ID when giving users DSNs (can be
-    # customized with SENTRY_ORG_SUBDOMAIN_TEMPLATE) eg. o123.ingest.us.sentry.io
-    manager.add("organizations:org-subdomains", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
     # Enable views for anomaly detection
     manager.add("organizations:performance-anomaly-detection-ui", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
     # Enable mobile performance score calculation for transactions in relay

--- a/src/sentry/models/projectkey.py
+++ b/src/sentry/models/projectkey.py
@@ -290,7 +290,7 @@ class ProjectKey(Model):
         try:
             has_org_subdomain = features.has(
                 "organizations:org-subdomains", self.project.organization
-            )
+            ) or features.has("organizations:org-ingest-subdomains", self.project.organization)
         except ProgrammingError:
             # This happens during migration generation for the organization model.
             pass


### PR DESCRIPTION
This feature flag has a name that is easily confused with `customer-subdomains`. Adding the `ingest` attribute helps disambiguate the flags.

Refs HC-1096