### PR TITLE
feat(hybridcloud) Add a system feature to combine hybridcloud features

### DIFF
--- a/src/sentry/features/permanent.py
+++ b/src/sentry/features/permanent.py
@@ -1,4 +1,9 @@
-from sentry.features.base import FeatureHandlerStrategy, OrganizationFeature, ProjectFeature
+from sentry.features.base import (
+    FeatureHandlerStrategy,
+    OrganizationFeature,
+    ProjectFeature,
+    SystemFeature,
+)
 from sentry.features.manager import FeatureManager
 
 # XXX: See `features/__init__.py` for documentation on how to use feature flags
@@ -127,3 +132,6 @@ def register_permanent_features(manager: FeatureManager):
         manager.add(
             project_feature, ProjectFeature, FeatureHandlerStrategy.INTERNAL, default=default
         )
+
+    # Enable support for multiple regions, and org slug subdomains.
+    manager.add("system:multi-region", SystemFeature, default=False)

--- a/src/sentry/web/client_config.py
+++ b/src/sentry/web/client_config.py
@@ -221,6 +221,8 @@ class _ClientConfig:
             yield "auth:register"
         if features.has("relocation:enabled", actor=self.user):
             yield "relocation:enabled"
+        if features.has("system:multi-region", actor=self.user):
+            yield "system:multi-region"
         if self.customer_domain or (
             self.last_org and features.has("organizations:customer-domains", self.last_org)
         ):


### PR DESCRIPTION
We have a few feature flags that all need to move in unison to make multi-region sentry work. I'd like to collapse these flags into a single system feature flag.

The feature flags that will be combined are:

- organizations:customer-domains
- organizations:frontend-domainsplit
- organizations:multi-region-selector

The `system:multi-region` feature will be disabled by default, but enabled in saas, and getsentry dev. The `multi-region` feature needs to be part of `window.__initialData` because we currently rely on `customer-domains` when starting up the react app.

Refs HC-1096