### PR TITLE
ref(feedback): link to project from feedback using ProjectBadge

### DIFF
--- a/static/app/components/feedback/feedbackItem/feedbackShortId.tsx
+++ b/static/app/components/feedback/feedbackItem/feedbackShortId.tsx
@@ -2,9 +2,9 @@ import type {CSSProperties} from 'react';
 import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 
-import ProjectAvatar from 'sentry/components/avatar/projectAvatar';
 import {Flex} from 'sentry/components/container/flex';
 import {DropdownMenu} from 'sentry/components/dropdownMenu';
+import ProjectBadge from 'sentry/components/idBadge/projectBadge';
 import TextOverflow from 'sentry/components/textOverflow';
 import {IconChevron} from 'sentry/icons';
 import {t} from 'sentry/locale';
@@ -62,10 +62,11 @@ export default function FeedbackShortId({className, feedbackItem, style}: Props)
       css={hideDropdown}
     >
       <Flex gap={space(0.75)} align="center">
-        <ProjectAvatar
+        <ProjectBadge
           project={feedbackItem.project}
-          size={12}
-          title={feedbackItem.project.slug}
+          avatarSize={16}
+          hideName
+          avatarProps={{hasTooltip: true, tooltip: feedbackItem.project.slug}}
         />
         <ShortId>{feedbackItem.shortId}</ShortId>
       </Flex>

--- a/static/app/components/feedback/list/feedbackListItem.tsx
+++ b/static/app/components/feedback/list/feedbackListItem.tsx
@@ -2,10 +2,10 @@ import type {CSSProperties} from 'react';
 import styled from '@emotion/styled';
 
 import ActorAvatar from 'sentry/components/avatar/actorAvatar';
-import ProjectAvatar from 'sentry/components/avatar/projectAvatar';
 import Checkbox from 'sentry/components/checkbox';
 import {Flex} from 'sentry/components/container/flex';
 import IssueTrackingSignals from 'sentry/components/feedback/list/issueTrackingSignals';
+import ProjectBadge from 'sentry/components/idBadge/projectBadge';
 import InteractionStateLayer from 'sentry/components/interactionStateLayer';
 import Link from 'sentry/components/links/link';
 import TextOverflow from 'sentry/components/textOverflow';
@@ -106,10 +106,11 @@ function FeedbackListItem({feedbackItem, isSelected, onSelect, style}: Props) {
 
       <BottomGrid style={{gridArea: 'bottom'}}>
         <Row justify="flex-start" gap={space(0.75)}>
-          <StyledProjectAvatar
+          <StyledProjectBadge
             project={feedbackItem.project}
-            size={12}
-            title={feedbackItem.project.slug}
+            avatarSize={16}
+            hideName
+            avatarProps={{hasTooltip: false}}
           />
           <TextOverflow>{feedbackItem.shortId}</TextOverflow>
         </Row>
@@ -200,7 +201,7 @@ const BottomGrid = styled('div')`
   overflow: hidden;
 `;
 
-const StyledProjectAvatar = styled(ProjectAvatar)`
+const StyledProjectBadge = styled(ProjectBadge)`
   && img {
     box-shadow: none;
   }


### PR DESCRIPTION
Link back to the project page from feedback. Done automatically by switching `ProjectAvatar` to `ProjectBadge` (this is what issues uses). 

Linked in two spots:
- Left list side (no tooltip)
- Right item details side, in the header (tooltip)

New feedback behavior:

https://github.com/getsentry/sentry/assets/56095982/bef4cb6b-cdd2-4836-a8a5-2e2df1a4aca6

Issues behavior is the same (no tooltip on list, tooltip on details):

https://github.com/getsentry/sentry/assets/56095982/d5b66705-2ec6-4a7e-a120-d202ca7e13dd



Also updated the sizes of the icons to be slightly larger (`12 --> 16`) to be consistent with issues:

| Before (12)  | After (16) |
| ------------- | ------------- |
| <img width="327" alt="SCR-20240611-marz" src="https://github.com/getsentry/sentry/assets/56095982/0c843563-d050-4ae4-824b-917663af62b8">  | <img width="359" alt="SCR-20240611-mard" src="https://github.com/getsentry/sentry/assets/56095982/df3de003-93bb-4f53-9b4d-3651413d9170">  |
| <img width="347" alt="SCR-20240611-malh" src="https://github.com/getsentry/sentry/assets/56095982/8c4a64fa-f171-41c2-a2fd-7ffd7ae50bcf"> |  <img width="352" alt="SCR-20240611-mapu" src="https://github.com/getsentry/sentry/assets/56095982/386d4109-00ff-4213-94e6-2b4cf37247cc"> |







closes https://github.com/getsentry/sentry/issues/70175

