### PR TITLE
ref(feedback): rm scroll on feedback empty state

### DIFF
--- a/static/app/components/feedback/feedbackSetupPanel.tsx
+++ b/static/app/components/feedback/feedbackSetupPanel.tsx
@@ -53,7 +53,7 @@ export default function FeedbackSetupPanel() {
 
 const NoMarginPanel = styled(Panel)`
   max-height: 100%;
-  overflow: scroll;
+  overflow: hidden;
   margin: 0;
 `;
 


### PR DESCRIPTION
rm scroll bars on feedback empty state.

before:


https://github.com/getsentry/sentry/assets/56095982/346869ff-0bc3-4472-bae5-2819a05383ea


after:


https://github.com/getsentry/sentry/assets/56095982/78dd9490-eaba-4edd-b912-ec36e25477c8

closes https://github.com/getsentry/sentry/issues/72078