### PR TITLE
perf(issues): using orjson in occurence_consumer

### DIFF
--- a/src/sentry/issues/occurrence_consumer.py
+++ b/src/sentry/issues/occurrence_consumer.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import functools
 import logging
 from collections import defaultdict
 from collections.abc import Mapping
@@ -8,6 +9,7 @@ from typing import Any
 from uuid import UUID
 
 import jsonschema
+import orjson
 import sentry_sdk
 from arroyo.backends.kafka.consumer import KafkaPayload
 from arroyo.processing.strategies.batching import ValuesBatch
@@ -16,7 +18,7 @@ from django.core.cache import cache
 from django.utils import timezone
 from sentry_sdk.tracing import NoOpSpan, Span, Transaction
 
-from sentry import nodestore
+from sentry import nodestore, options
 from sentry.event_manager import GroupInfo
 from sentry.eventstore.models import Event
 from sentry.issues.grouptype import get_group_type_by_type_id
@@ -377,11 +379,16 @@ def _process_batch(worker: ThreadPoolExecutor, message: Message[ValuesBatch[Kafk
 
     occcurrence_mapping: Mapping[str, list[Mapping[str, Any]]] = defaultdict(list)
 
+    if options.get("issues.occurrence_consumer.use_orjson"):
+        json_loads = orjson.loads
+    else:
+        json_loads = functools.partial(json.loads, use_rapid_json=True)
+
     for item in batch:
         assert isinstance(item, BrokerValue)
 
         try:
-            payload = json.loads(item.payload.value, use_rapid_json=True)
+            payload = json_loads(item.payload.value)
         except Exception:
             logger.exception("Failed to unpack message payload")
             continue

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -2559,3 +2559,11 @@ register(
     default=100,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
+
+# Enable orjson in the occurrence_consumer.process_[message|batch]
+register(
+    "issues.occurrence_consumer.use_orjson",
+    type=Bool,
+    default=False,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)

--- a/tests/sentry/issues/test_occurrence_consumer.py
+++ b/tests/sentry/issues/test_occurrence_consumer.py
@@ -28,6 +28,7 @@ from sentry.models.group import Group, GroupStatus
 from sentry.models.groupassignee import GroupAssignee
 from sentry.receivers import create_default_projects
 from sentry.testutils.cases import SnubaTestCase, TestCase
+from sentry.testutils.helpers import override_options
 from sentry.testutils.helpers.datetime import before_now, iso_format
 from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.pytest.fixtures import django_db_all
@@ -577,3 +578,18 @@ class ParseEventPayloadTest(IssueOccurrenceTestBase):
 
         group = Group.objects.get(id=group.id)
         assert group.status == status
+
+
+@override_options({"issues.occurrence_consumer.use_orjson": True})
+class IssueOccurrenceProcessMessageWithOrjsonTest(IssueOccurrenceProcessMessageTest):
+    pass
+
+
+@override_options({"issues.occurrence_consumer.use_orjson": True})
+class IssueOccurrenceLookupEventIdWithOrjsonTest(IssueOccurrenceLookupEventIdTest):
+    pass
+
+
+@override_options({"issues.occurrence_consumer.use_orjson": True})
+class ParseEventPayloadWithOrjsonTest(ParseEventPayloadTest):
+    pass

--- a/tests/sentry/issues/test_run.py
+++ b/tests/sentry/issues/test_run.py
@@ -13,6 +13,7 @@ from sentry.issues.occurrence_consumer import process_occurrence_group
 from sentry.issues.producer import _prepare_occurrence_message
 from sentry.issues.run import OccurrenceStrategyFactory
 from sentry.testutils.cases import TestCase
+from sentry.testutils.helpers import override_options
 from sentry.testutils.helpers.datetime import before_now
 from sentry.testutils.helpers.features import with_feature
 from sentry.types.group import PriorityLevel
@@ -260,3 +261,13 @@ class TestBatchedOccurrenceConsumer(TestCase, OccurrenceTestMixin):
         assert len(item_list2) == 2
         assert item_list2[0]["event_id"] == occurrence2.event_id
         assert item_list2[1]["event_id"] == occurrence3.event_id
+
+
+@override_options({"issues.occurrence_consumer.use_orjson": True})
+class TestOccurrenceConsumerWithOrjson(TestOccurrenceConsumer):
+    pass
+
+
+@override_options({"issues.occurrence_consumer.use_orjson": True})
+class TestBatchedOccurrenceConsumerWithOrjson(TestBatchedOccurrenceConsumer):
+    pass


### PR DESCRIPTION
Currently this is using _rapidjson_, which contrary to its name is [extremely slow](https://catnotfoundnear.github.io/finding-the-fastest-python-json-library-on-all-python-versions-8-compared.html). Adding _orjson_ as an option.

This will not fully resolve issues identified in INC-786 postmortem, but would be an improvement.  


![slow](https://catnotfoundnear.github.io/media/posts/3/gallery/All-libraries-Average-Time-py3_11.png)