### PR TITLE
fix(similarity): handle cases where 0 results in backfill step

### DIFF
--- a/src/sentry/tasks/backfill_seer_grouping_records.py
+++ b/src/sentry/tasks/backfill_seer_grouping_records.py
@@ -51,14 +51,6 @@ class FeatureError(Exception):
     pass
 
 
-class NoNodestoreDataError(Exception):
-    pass
-
-
-class NoMoreGroupsToBackfillError(Exception):
-    pass
-
-
 class GroupEventRow(TypedDict):
     event_id: str
     group_id: int
@@ -112,13 +104,13 @@ def backfill_seer_grouping_records(
 
     batch_size = options.get("embeddings-grouping.seer.backfill-batch-size")
 
-    try:
-        (
-            groups_to_backfill_with_no_embedding,
-            batch_end_index,
-            total_groups_to_backfill_length,
-        ) = get_current_batch_groups_from_postgres(project, last_processed_index, batch_size)
-    except NoMoreGroupsToBackfillError:
+    (
+        groups_to_backfill_with_no_embedding,
+        batch_end_index,
+        total_groups_to_backfill_length,
+    ) = get_current_batch_groups_from_postgres(project, last_processed_index, batch_size)
+
+    if len(groups_to_backfill_with_no_embedding) == 0:
         return
 
     last_group_id = groups_to_backfill_with_no_embedding[-1]
@@ -130,11 +122,21 @@ def backfill_seer_grouping_records(
         groups_to_backfill_with_no_embedding_has_snuba_row,
     ) = filter_snuba_results(snuba_results, groups_to_backfill_with_no_embedding, project)
 
-    try:
-        nodestore_results, group_hashes_dict = get_events_from_nodestore(
-            project, filtered_snuba_results, groups_to_backfill_with_no_embedding_has_snuba_row
+    if len(groups_to_backfill_with_no_embedding_has_snuba_row) == 0:
+        call_next_backfill(
+            batch_end_index,
+            project_id,
+            redis_client,
+            total_groups_to_backfill_length,
+            last_group_id,
+            dry_run,
         )
-    except NoNodestoreDataError:
+        return
+
+    nodestore_results, group_hashes_dict = get_events_from_nodestore(
+        project, filtered_snuba_results, groups_to_backfill_with_no_embedding_has_snuba_row
+    )
+    if not group_hashes_dict:
         call_next_backfill(
             batch_end_index,
             project_id,
@@ -272,7 +274,11 @@ def get_current_batch_groups_from_postgres(project, last_processed_index, batch_
             "backfill_seer_grouping_records.no_more_groups",
             extra={"project_id": project.id},
         )
-        raise NoMoreGroupsToBackfillError("No more groups to backfill")
+        return (
+            groups_to_backfill_batch,
+            batch_end_index,
+            total_groups_to_backfill_length,
+        )
 
     groups_to_backfill_with_no_embedding = [
         group_id
@@ -295,12 +301,12 @@ def get_current_batch_groups_from_postgres(project, last_processed_index, batch_
 
 
 @sentry_sdk.tracing.trace
-def get_data_from_snuba(project, group_id_batch_filtered):
+def get_data_from_snuba(project, groups_to_backfill_with_no_embedding):
     # TODO(jangjodi): Only query per group if it has over 1 million events, or batch queries with new where condition
     events_entity = Entity("events", alias="events")
 
     snuba_requests = []
-    for group_id in group_id_batch_filtered:
+    for group_id in groups_to_backfill_with_no_embedding:
         group = Group.objects.get(id=group_id)
         query = Query(
             match=events_entity,
@@ -344,7 +350,9 @@ def get_data_from_snuba(project, group_id_batch_filtered):
 
 
 @sentry_sdk.tracing.trace
-def get_events_from_nodestore(project, snuba_results, group_id_batch_filtered):
+def get_events_from_nodestore(
+    project, snuba_results, groups_to_backfill_with_no_embedding_has_snuba_row
+):
     nodestore_events = lookup_group_data_stacktrace_bulk(project, snuba_results)
     # If nodestore returns no data
     if len(nodestore_events) == 0:
@@ -352,10 +360,13 @@ def get_events_from_nodestore(project, snuba_results, group_id_batch_filtered):
             "tasks.backfill_seer_grouping_records.no_data",
             extra={
                 "project_id": project.id,
-                "group_id_batch": json.dumps(group_id_batch_filtered),
+                "group_id_batch": json.dumps(groups_to_backfill_with_no_embedding_has_snuba_row),
             },
         )
-        raise NoNodestoreDataError("No data found in nodestore")
+        return (
+            GroupStacktraceData(data=[], stacktrace_list=[]),
+            {},
+        )
 
     group_data = []
     stacktrace_strings = []
@@ -390,13 +401,15 @@ def get_events_from_nodestore(project, snuba_results, group_id_batch_filtered):
         group_stacktrace_data["group_id"]: group_stacktrace_data["hash"]
         for group_stacktrace_data in group_data
     }
-    logger.info(
-        "backfill_seer_grouping_records.invalid_group_ids",
-        extra={
-            "project_id": project.id,
-            "invalid_group_ids": invalid_event_group_ids,
-        },
-    )
+    if len(invalid_event_group_ids) > 0:
+        logger.info(
+            "backfill_seer_grouping_records.invalid_group_ids",
+            extra={
+                "project_id": project.id,
+                "invalid_group_ids": invalid_event_group_ids,
+            },
+        )
+
     return (
         GroupStacktraceData(data=group_data, stacktrace_list=stacktrace_strings),
         group_hashes_dict,
@@ -404,10 +417,12 @@ def get_events_from_nodestore(project, snuba_results, group_id_batch_filtered):
 
 
 @sentry_sdk.tracing.trace
-def send_group_and_stacktrace_to_seer(project, group_id_batch_filtered, nodestore_results):
+def send_group_and_stacktrace_to_seer(
+    project, groups_to_backfill_with_no_embedding_has_snuba_row_and_nodestore_row, nodestore_results
+):
     seer_response = post_bulk_grouping_records(
         CreateGroupingRecordsRequest(
-            group_id_list=group_id_batch_filtered,
+            group_id_list=groups_to_backfill_with_no_embedding_has_snuba_row_and_nodestore_row,
             data=nodestore_results["data"],
             stacktrace_list=nodestore_results["stacktrace_list"],
         )


### PR DESCRIPTION
- in a few spots, we weren't returning if the backfill step returned 0 results. this PR checks the length in those spots and will call the next backfill if so
- removes the defined exceptions, choosing to use empty state instead of an error to control these flows.
