### PR TITLE
feat(seer grouping): Add metric to track if Seer actually gets called

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -1520,17 +1520,28 @@ def _save_aggregate(
                                 "seer_similarity"
                             ] = seer_response_data
 
+                        metrics.incr(
+                            "grouping.similarity.did_call_seer",
+                            tags={"call_made": True, "blocker": "none"},
+                        )
+
                     except CircuitBreakerTripped:
-                        # TODO: For now, all of the logging/netrics for this happening are handled
-                        # inside of `with_circuit_breaker`. We should figure out if/how we want to
-                        # reflect landing here in the `outcome` tag on the span and timer metric
-                        # below and in `record_calculation_metric_with_result` (also below). Same
-                        # goes for the various tests the event could fail in
-                        # `should_call_seer_for_grouping`.
-                        pass
+                        # TODO: Do we want to include all of the conditions which cause us to log a
+                        # `grouping.similarity.seer_call_blocked` metric (here and in
+                        # `should_call_seer_for_grouping`) under a single outcome tag on the span
+                        # and timer metric below and in `record_calculation_metric_with_result`
+                        # (also below)? Right now they just fall into the `new_group` bucket.
+                        metrics.incr(
+                            "grouping.similarity.did_call_seer",
+                            tags={"call_made": False, "blocker": "circuit-breaker"},
+                        )
 
                     # Insurance - in theory we shouldn't ever land here
                     except Exception as e:
+                        metrics.incr(
+                            "grouping.similarity.did_call_seer",
+                            tags={"call_made": True, "blocker": "none"},
+                        )
                         sentry_sdk.capture_exception(
                             e, tags={"event": event.event_id, "project": project.id}
                         )

--- a/src/sentry/grouping/ingest/seer.py
+++ b/src/sentry/grouping/ingest/seer.py
@@ -72,6 +72,10 @@ def _has_customized_fingerprint(event: Event, primary_hashes: CalculatedHashes) 
 
         # Hybrid fingerprinting ({{ default }} + some other value(s))
         else:
+            metrics.incr(
+                "grouping.similarity.did_call_seer",
+                tags={"call_made": False, "blocker": "hybrid-fingerprint"},
+            )
             return True
 
     # Fully customized fingerprint (from either us or the user)
@@ -80,6 +84,10 @@ def _has_customized_fingerprint(event: Event, primary_hashes: CalculatedHashes) 
     ) or primary_hashes.variants.get("built-in-fingerprint")
 
     if fingerprint_variant:
+        metrics.incr(
+            "grouping.similarity.did_call_seer",
+            tags={"call_made": False, "blocker": fingerprint_variant.type},
+        )
         return True
 
     return False
@@ -98,6 +106,10 @@ def _killswitch_enabled(event: Event, project: Project) -> bool:
             extra=logger_extra,
         )
         metrics.incr("grouping.similarity.seer_global_killswitch_enabled")
+        metrics.incr(
+            "grouping.similarity.did_call_seer",
+            tags={"call_made": False, "blocker": "global-killswitch"},
+        )
         return True
 
     if options.get("seer.similarity-killswitch.enabled"):
@@ -106,6 +118,10 @@ def _killswitch_enabled(event: Event, project: Project) -> bool:
             extra=logger_extra,
         )
         metrics.incr("grouping.similarity.seer_similarity_killswitch_enabled")
+        metrics.incr(
+            "grouping.similarity.did_call_seer",
+            tags={"call_made": False, "blocker": "similarity-killswitch"},
+        )
         return True
 
     return False
@@ -132,6 +148,10 @@ def _ratelimiting_enabled(event: Event, project: Project) -> bool:
             "grouping.similarity.global_ratelimit_hit",
             tags={"limit_per_sec": global_limit_per_sec},
         )
+        metrics.incr(
+            "grouping.similarity.did_call_seer",
+            tags={"call_made": False, "blocker": "global-rate-limit"},
+        )
 
         return True
 
@@ -144,6 +164,10 @@ def _ratelimiting_enabled(event: Event, project: Project) -> bool:
         metrics.incr(
             "grouping.similarity.project_ratelimit_hit",
             tags={"limit_per_sec": project_limit_per_sec},
+        )
+        metrics.incr(
+            "grouping.similarity.did_call_seer",
+            tags={"call_made": False, "blocker": "project-rate-limit"},
         )
 
         return True


### PR DESCRIPTION
During ingest, there are a number of criteria we check before deciding to make a call to Seer for similar issues, starting with whether the project has the right feature flags and whether the data in the event is Seer-eligible (has a stacktrace, is from a supported platform, etc.). Assuming those tests pass, at that point, all other things being equal, we'd like to send the event to Seer. Sometimes that call is blocked, though, by things like the presence of a customized fingerprint, rate limits, killswitches, and the state of our circuit breaker. It would be useful to know how often this happens and why.

To that end, this PR adds a new metric, `grouping.similarity.did_call_seer`, to track whether or not we're able to make the desired Seer call, and if not, why not.