### PR TITLE
feat(performance): Adds tooltip to explain webvitals pages missing

### DIFF
--- a/static/app/views/performance/browser/webVitals/webVitalsLandingPage.tsx
+++ b/static/app/views/performance/browser/webVitals/webVitalsLandingPage.tsx
@@ -181,10 +181,10 @@ export function WebVitalsLandingPage() {
                     <div>
                       <div>
                         {tct(
-                          'If your instrumented pages are not appearing in the table below, you may be missing necessary web vitals in your page loads due to unsupported browsers or missing instrumentation. Find out what browsers are supported here [link:here].',
+                          'If pages you expect to see are missing, your framework is most likely not supported by the SDK, or your traffic is coming from unsupported browsers. Find supported browsers and frameworks here [link:here]',
                           {
                             link: (
-                              <ExternalLink href="https://docs.sentry.io/product/insights/web-vitals/web-vitals-concepts/#browser-support" />
+                              <ExternalLink href="https://docs.sentry.io/product/insights/web-vitals/#prerequisites-and-limitations" />
                             ),
                           }
                         )}
@@ -192,7 +192,7 @@ export function WebVitalsLandingPage() {
                       <br />
                       <div>
                         {t(
-                          'It is recommended to keep your javascript sdk updated to the latest version for the best webvitals support.'
+                          'Keep your JavaScript SDK updated to the latest version for the best Web Vitals support.'
                         )}
                       </div>
                     </div>

--- a/static/app/views/performance/browser/webVitals/webVitalsLandingPage.tsx
+++ b/static/app/views/performance/browser/webVitals/webVitalsLandingPage.tsx
@@ -15,6 +15,7 @@ import {EnvironmentPageFilter} from 'sentry/components/organizations/environment
 import PageFilterBar from 'sentry/components/organizations/pageFilterBar';
 import {ProjectPageFilter} from 'sentry/components/organizations/projectPageFilter';
 import {PageHeadingQuestionTooltip} from 'sentry/components/pageHeadingQuestionTooltip';
+import {Tooltip} from 'sentry/components/tooltip';
 import {IconClose} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
 import ConfigStore from 'sentry/stores/configStore';
@@ -174,6 +175,32 @@ export function WebVitalsLandingPage() {
                 />
               </WebVitalMetersContainer>
               <PagePerformanceTable />
+              <PagesTooltipContainer>
+                <Tooltip
+                  title={
+                    <div>
+                      <div>
+                        {tct(
+                          'If your instrumented pages are not appearing in the table below, you may be missing necessary web vitals in your page loads due to unsupported browsers or missing instrumentation. Find out what browsers are supported here [link:here].',
+                          {
+                            link: (
+                              <ExternalLink href="https://docs.sentry.io/product/insights/web-vitals/web-vitals-concepts/#browser-support" />
+                            ),
+                          }
+                        )}
+                      </div>
+                      <br />
+                      <div>
+                        {t(
+                          'It is recommended to keep your javascript sdk updated to the latest version for the best webvitals support.'
+                        )}
+                      </div>
+                    </div>
+                  }
+                >
+                  <PagesTooltip>{t('Why are my pages not showing up?')}</PagesTooltip>
+                </Tooltip>
+              </PagesTooltipContainer>
             </Fragment>
           )}
         </Layout.Main>
@@ -235,4 +262,14 @@ export const DismissButton = styled(Button)`
 
 export const StyledAlert = styled(Alert)`
   margin-top: ${space(2)};
+`;
+
+export const PagesTooltip = styled('span')`
+  font-size: ${p => p.theme.fontSizeSmall};
+  color: ${p => p.theme.gray300};
+  text-decoration: underline dotted ${p => p.theme.gray300};
+`;
+
+export const PagesTooltipContainer = styled('div')`
+  display: flex;
 `;

--- a/static/app/views/performance/browser/webVitals/webVitalsLandingPage.tsx
+++ b/static/app/views/performance/browser/webVitals/webVitalsLandingPage.tsx
@@ -177,11 +177,12 @@ export function WebVitalsLandingPage() {
               <PagePerformanceTable />
               <PagesTooltipContainer>
                 <Tooltip
+                  isHoverable
                   title={
                     <div>
                       <div>
                         {tct(
-                          'If pages you expect to see are missing, your framework is most likely not supported by the SDK, or your traffic is coming from unsupported browsers. Find supported browsers and frameworks here [link:here]',
+                          'If pages you expect to see are missing, your framework is most likely not supported by the SDK, or your traffic is coming from unsupported browsers. Find supported browsers and frameworks [link:here].',
                           {
                             link: (
                               <ExternalLink href="https://docs.sentry.io/product/insights/web-vitals/#prerequisites-and-limitations" />


### PR DESCRIPTION
Adds tooltip to explain missing pages in web vitals module and link to docs
![image](https://github.com/getsentry/sentry/assets/83961295/a8d0d019-fcae-480a-9cbc-696ce3c7df68)
