### PR TITLE
feat(ui): Add loading indicator to page filters wrapper

### DIFF
--- a/static/app/components/organizations/pageFilters/container.tsx
+++ b/static/app/components/organizations/pageFilters/container.tsx
@@ -120,7 +120,6 @@ function PageFiltersContainer({
   // This happens when we mount the container.
   useEffect(() => {
     if (!projectsLoaded) {
-      // doInitialization();
       return;
     }
 

--- a/static/app/components/organizations/pageFilters/container.tsx
+++ b/static/app/components/organizations/pageFilters/container.tsx
@@ -186,7 +186,7 @@ function PageFiltersContainer({
   }, [location.query]);
 
   // Wait for global selection to be ready before rendering children
-  // TODO: Not waiting for projects to be readly but initalizing the correct page filters
+  // TODO: Not waiting for projects to be ready but initializing the correct page filters
   // would speed up orgs with tons of projects
   if (!isReady) {
     return (

--- a/static/app/components/organizations/pageFilters/container.tsx
+++ b/static/app/components/organizations/pageFilters/container.tsx
@@ -10,6 +10,7 @@ import {
   updateProjects,
 } from 'sentry/actionCreators/pageFilters';
 import * as Layout from 'sentry/components/layouts/thirds';
+import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {SIDEBAR_NAVIGATION_SOURCE} from 'sentry/components/sidebar/utils';
 import {DEFAULT_STATS_PERIOD} from 'sentry/constants';
 import {useLocation} from 'sentry/utils/useLocation';
@@ -119,6 +120,7 @@ function PageFiltersContainer({
   // This happens when we mount the container.
   useEffect(() => {
     if (!projectsLoaded) {
+      // doInitialization();
       return;
     }
 
@@ -185,8 +187,14 @@ function PageFiltersContainer({
   }, [location.query]);
 
   // Wait for global selection to be ready before rendering children
+  // TODO: Not waiting for projects to be readly but initalizing the correct page filters
+  // would speed up orgs with tons of projects
   if (!isReady) {
-    return <Layout.Page withPadding />;
+    return (
+      <Layout.Page withPadding>
+        <LoadingIndicator />
+      </Layout.Page>
+    );
   }
 
   return <Fragment>{children}</Fragment>;

--- a/static/app/views/dashboards/orgDashboards.spec.tsx
+++ b/static/app/views/dashboards/orgDashboards.spec.tsx
@@ -2,8 +2,9 @@ import {LocationFixture} from 'sentry-fixture/locationFixture';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
-import {act, render, waitFor} from 'sentry-test/reactTestingLibrary';
+import {render, screen, waitFor} from 'sentry-test/reactTestingLibrary';
 
+import ProjectsStore from 'sentry/stores/projectsStore';
 import {browserHistory} from 'sentry/utils/browserHistory';
 import DashboardDetail from 'sentry/views/dashboards/detail';
 import OrgDashboards from 'sentry/views/dashboards/orgDashboards';
@@ -43,6 +44,7 @@ describe('OrgDashboards', () => {
       url: '/organizations/org-slug/dashboards/',
       body: [mockDashboard],
     });
+    ProjectsStore.loadInitialData(initialData.projects);
   });
 
   afterEach(() => {
@@ -339,7 +341,7 @@ describe('OrgDashboards', () => {
       </OrgDashboards>
     );
 
-    await act(tick);
+    expect(screen.queryByTestId('loading-indicator')).not.toBeInTheDocument();
     expect(browserHistory.replace).toHaveBeenCalledTimes(1);
   });
 });

--- a/static/app/views/dashboards/orgDashboards.spec.tsx
+++ b/static/app/views/dashboards/orgDashboards.spec.tsx
@@ -2,7 +2,7 @@ import {LocationFixture} from 'sentry-fixture/locationFixture';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
-import {render, screen, waitFor} from 'sentry-test/reactTestingLibrary';
+import {act, render, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import {browserHistory} from 'sentry/utils/browserHistory';
 import DashboardDetail from 'sentry/views/dashboards/detail';
@@ -339,7 +339,7 @@ describe('OrgDashboards', () => {
       </OrgDashboards>
     );
 
-    expect(screen.queryByTestId('loading-indicator')).not.toBeInTheDocument();
+    await act(tick);
     expect(browserHistory.replace).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
Previously showed a blank screen until projects were loaded.

