### PR TITLE
fix(perf): Navigating to Spans Tab propagates incompatible filters

### DIFF
--- a/static/app/views/performance/transactionSummary/transactionSpans/content.tsx
+++ b/static/app/views/performance/transactionSummary/transactionSpans/content.tsx
@@ -24,7 +24,6 @@ import SuspectSpansQuery from 'sentry/utils/performance/suspectSpans/suspectSpan
 import {VisuallyCompleteWithData} from 'sentry/utils/performanceForSentry';
 import {decodeScalar} from 'sentry/utils/queryString';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
-import useLocationQuery from 'sentry/utils/url/useLocationQuery';
 import useProjects from 'sentry/utils/useProjects';
 import SpanMetricsTable from 'sentry/views/performance/transactionSummary/transactionSpans/spanMetricsTable';
 import {useSpanFieldSupportedTags} from 'sentry/views/performance/utils/useSpanFieldSupportedTags';
@@ -197,14 +196,10 @@ function SpansContentV2(props: Props) {
   const {projects} = useProjects();
   const project = projects.find(p => p.id === projectId);
 
-  const query = useLocationQuery({
-    fields: {
-      query: decodeScalar,
-    },
-  });
+  const query = decodeScalar(location.query.query);
 
   const supportedTags = useSpanFieldSupportedTags();
-  const mutableSearch = new MutableSearch(query.query);
+  const mutableSearch = new MutableSearch(query ?? '');
   const supportedTagSet = new Set(Object.keys(supportedTags));
 
   const incompatibleFilterKeys = mutableSearch

--- a/static/app/views/performance/transactionSummary/transactionSpans/index.spec.tsx
+++ b/static/app/views/performance/transactionSummary/transactionSpans/index.spec.tsx
@@ -186,15 +186,13 @@ describe('Performance > Transaction Spans', function () {
   describe('Spans Tab V2', function () {
     it('does not propagate invalid span search tags from the URL', async function () {
       const initialData = initializeData({
-        query: {'http.method': 'POST', 'span.op': 'http'},
+        query: {query: 'span.op:db http.method:POST span.action:SELECT'},
         additionalFeatures: [
           'performance-view',
           'performance-spans-new-ui',
           'insights-initial-modules',
         ],
       });
-
-      console.dir(initialData.router.location);
 
       render(<TransactionSpans location={initialData.router.location} />, {
         router: initialData.router,
@@ -203,7 +201,13 @@ describe('Performance > Transaction Spans', function () {
 
       await waitForElementToBeRemoved(() => screen.queryAllByTestId('loading-indicator'));
 
-      screen.debug();
+      const searchTokens = await screen.findAllByTestId('filter-token');
+      expect(searchTokens).toHaveLength(2);
+      expect(searchTokens[0]).toHaveTextContent('span.op:db');
+      expect(searchTokens[1]).toHaveTextContent('span.action:SELECT');
+      expect(await screen.findByTestId('smart-search-bar')).not.toHaveTextContent(
+        'http.method:POST'
+      );
     });
   });
 });

--- a/static/app/views/performance/transactionSummary/transactionSpans/spanMetricsTable.spec.tsx
+++ b/static/app/views/performance/transactionSummary/transactionSpans/spanMetricsTable.spec.tsx
@@ -13,7 +13,7 @@ const initializeData = () => {
   return data;
 };
 
-describe('SuspectSpansTable', () => {
+describe('SpanMetricsTable', () => {
   it('should render the table and rows of data', async () => {
     const {organization, project} = initializeData();
 
@@ -100,6 +100,58 @@ describe('SuspectSpansTable', () => {
     expect(opCell).toHaveTextContent('db');
     expect(descriptionCell).toHaveTextContent('\u2014');
   });
+
+  // it('should not accept invalid tags in the search query', () => {
+  //   const {organization, project} = initializeData();
+
+  //   const mockRequest = MockApiClient.addMockResponse({
+  //     url: `/organizations/${organization.slug}/events/`,
+  //     method: 'GET',
+  //     body: {
+  //       data: [
+  //         {
+  //           'span.op': 'db',
+  //           'spm()': 5000,
+  //           'sum(span.self_time)': 12346071121.5044901,
+  //           'avg(span.duration)': 30900.700924083318,
+  //         },
+  //       ],
+  //     },
+  //   });
+
+  //   render(
+  //     <SpanMetricsTable
+  //       transactionName="Test Transaction"
+  //       project={project}
+  //       query={'http.method:POST span.op:db'}
+  //     />
+  //   );
+
+  //   expect(mockRequest).toHaveBeenCalledWith(
+  //     expect.objectContaining({
+  //       method: 'GET',
+  //       query: {
+  //         cursor: undefined,
+  //         dataset: 'spansMetrics',
+  //         environment: [],
+  //         excludeOther: 0,
+  //         field: [],
+  //         interval: '30m',
+  //         orderby: undefined,
+  //         partial: 1,
+  //         per_page: 50,
+  //         project: [],
+  //         query: 'span.op:[cache.get_item,cache.get] project.id:1',
+  //         referrer: 'api.performance.cache.samples-cache-hit-miss-chart',
+  //         statsPeriod: '10d',
+  //         topEvents: undefined,
+  //         yAxis: 'cache_miss_rate()',
+  //       },
+  //     })
+  //   );
+
+  //   screen.debug();
+  // });
 });
 
 async function findTableHeaders() {

--- a/static/app/views/performance/transactionSummary/transactionSpans/spanMetricsTable.spec.tsx
+++ b/static/app/views/performance/transactionSummary/transactionSpans/spanMetricsTable.spec.tsx
@@ -34,7 +34,9 @@ describe('SuspectSpansTable', () => {
       },
     });
 
-    render(<SpanMetricsTable transactionName="Test Transaction" project={project} />);
+    render(
+      <SpanMetricsTable transactionName="Test Transaction" project={project} query={''} />
+    );
 
     await waitFor(() =>
       expect(screen.queryByTestId('loading-indicator')).not.toBeInTheDocument()
@@ -84,7 +86,9 @@ describe('SuspectSpansTable', () => {
       },
     });
 
-    render(<SpanMetricsTable transactionName="Test Transaction" project={project} />);
+    render(
+      <SpanMetricsTable transactionName="Test Transaction" project={project} query={''} />
+    );
 
     await waitFor(() =>
       expect(screen.queryByTestId('loading-indicator')).not.toBeInTheDocument()

--- a/static/app/views/performance/transactionSummary/transactionSpans/spanMetricsTable.tsx
+++ b/static/app/views/performance/transactionSummary/transactionSpans/spanMetricsTable.tsx
@@ -86,24 +86,24 @@ const LIMIT = 12;
 
 type Props = {
   project: Project | undefined;
+  query: string;
   transactionName: string;
 };
 
 export default function SpanMetricsTable(props: Props) {
-  const {project, transactionName} = props;
+  const {project, transactionName, query: search} = props;
   const organization = useOrganization();
   const location = useLocation();
   const sort = useSpansTabTableSort();
 
   const query = useLocationQuery({
     fields: {
-      query: decodeScalar,
       spansCursor: decodeScalar,
       spanOp: decodeScalar,
     },
   });
 
-  const {query: search, spansCursor, spanOp} = query;
+  const {spansCursor, spanOp} = query;
 
   const filters: SpanMetricsQueryFilters = {
     transaction: transactionName,


### PR DESCRIPTION
If you navigate to the spans tab from the transaction summary, it propagates any of the filters you had in the transaction summary. However, the filters used on transactions are very likely to be incompatible with the filter on the spans tab.

Take this example flow: 

Click into a transaction from the performance landing page with an HTTP method. It will automatically propagate the searchbar an `http.method` filter:
![image](https://github.com/getsentry/sentry/assets/16740047/0a735155-55d8-4a13-b75d-33908cd1e328)

When you click on the Spans tab from here, it will pass on the same filter:
![image](https://github.com/getsentry/sentry/assets/16740047/5726f748-dd3e-4757-b39a-5d80240a79c7)

Unfortunately, you can't filter spans with the same `http.method` tag. This PR fixes this by checking all filters in the URL and confirming whether they are compatible with spans, and then sanitizing it.

Note: As a byproduct, the searchbar also does not allow you to input any incompatible tags in the search bar, but I think this is a nice thing to have:

![image](https://github.com/getsentry/sentry/assets/16740047/fce27835-3b7c-4eb0-b5af-9d274a0ea2d5)
