### PR TITLE
ref(rules): Use different referrer for batch queries

### DIFF
--- a/src/sentry/rules/conditions/event_frequency.py
+++ b/src/sentry/rules/conditions/event_frequency.py
@@ -405,7 +405,7 @@ class EventFrequencyCondition(BaseEventFrequencyCondition):
                 start=start,
                 end=end,
                 environment_id=environment_id,
-                referrer_suffix="alert_event_frequency",
+                referrer_suffix="batch_alert_event_frequency",
             )
             batch_sums.update(error_sums)
 
@@ -417,7 +417,7 @@ class EventFrequencyCondition(BaseEventFrequencyCondition):
                 start=start,
                 end=end,
                 environment_id=environment_id,
-                referrer_suffix="alert_event_frequency",
+                referrer_suffix="batch_alert_event_frequency",
             )
             batch_sums.update(generic_sums)
 
@@ -462,7 +462,7 @@ class EventUniqueUserFrequencyCondition(BaseEventFrequencyCondition):
                 start=start,
                 end=end,
                 environment_id=environment_id,
-                referrer_suffix="alert_event_uniq_user_frequency",
+                referrer_suffix="batch_alert_event_uniq_user_frequency",
             )
             batch_totals.update(error_totals)
 
@@ -474,7 +474,7 @@ class EventUniqueUserFrequencyCondition(BaseEventFrequencyCondition):
                 start=start,
                 end=end,
                 environment_id=environment_id,
-                referrer_suffix="alert_event_uniq_user_frequency",
+                referrer_suffix="batch_alert_event_uniq_user_frequency",
             )
             batch_totals.update(generic_totals)
 
@@ -633,7 +633,7 @@ class EventFrequencyPercentCondition(BaseEventFrequencyCondition):
                     start=start,
                     end=end,
                     environment_id=environment_id,
-                    referrer_suffix="alert_event_frequency_percent",
+                    referrer_suffix="batch_alert_event_frequency_percent",
                 )
                 for group_id, count in error_issue_count.items():
                     percent: int = int(100 * round(count / avg_sessions_in_interval, 4))


### PR DESCRIPTION
Snuba queries are rate limited based on the referrer and I forgot to change the referrer for the batch queries so I'm hitting rate limiting issues (e.g. https://sentry.sentry.io/issues/5474708906) since it's competing with the pre-INC-666 queries.