### PR TITLE
fix(query-builder): Backspace should not do anything when in a single-select filter value

### DIFF
--- a/static/app/components/searchQueryBuilder/index.spec.tsx
+++ b/static/app/components/searchQueryBuilder/index.spec.tsx
@@ -720,6 +720,28 @@ describe('SearchQueryBuilder', function () {
         screen.getAllByRole('combobox', {name: 'Add a search term'}).at(-1)
       ).toHaveFocus();
     });
+
+    it('backspace does nothing when input is empty', async function () {
+      const mockOnChange = jest.fn();
+      render(
+        <SearchQueryBuilder
+          {...defaultProps}
+          onChange={mockOnChange}
+          initialQuery="age:-24h"
+        />
+      );
+
+      // Click into filter value (button to edit will no longer exist)
+      await userEvent.click(
+        screen.getByRole('button', {name: 'Edit value for filter: age'})
+      );
+
+      await userEvent.keyboard('{Backspace}');
+
+      // Input should still have focus, and no changes should have been made
+      expect(screen.getByRole('combobox', {name: 'Edit filter value'})).toHaveFocus();
+      expect(mockOnChange).not.toHaveBeenCalled();
+    });
   });
 
   describe('token values', function () {

--- a/static/app/components/searchQueryBuilder/valueCombobox.tsx
+++ b/static/app/components/searchQueryBuilder/valueCombobox.tsx
@@ -551,12 +551,13 @@ export function SearchQueryBuilderValueCombobox({
       if (
         e.key === 'Backspace' &&
         e.currentTarget.selectionStart === 0 &&
-        e.currentTarget.selectionEnd === 0
+        e.currentTarget.selectionEnd === 0 &&
+        canSelectMultipleValues
       ) {
         dispatch({type: 'DELETE_LAST_MULTI_SELECT_FILTER_VALUE', token});
       }
     },
-    [dispatch, token]
+    [canSelectMultipleValues, dispatch, token]
   );
 
   // Clicking anywhere in the value editing area should focus the input


### PR DESCRIPTION
Pressing backspace when editing a filter like `timesSeen` used to mess up the filter because it doesn't support multiple values.