### PR TITLE
fix: Switch role get_choices back to using name

### DIFF
--- a/src/sentry/api/endpoints/organization_member/team_details.py
+++ b/src/sentry/api/endpoints/organization_member/team_details.py
@@ -52,9 +52,10 @@ class OrganizationMemberTeamSerializerResponse(TypedDict):
 class OrganizationMemberTeamSerializer(serializers.Serializer):
     isActive = serializers.BooleanField()
     teamRole = serializers.ChoiceField(
-        choices=team_roles.get_choices(),
+        choices=team_roles.get_descriptions(),
         default=team_roles.get_default().id,
-        help_text="The team-level role to switch to. Valid roles include:",  # choices will follow in the docs
+        help_text="The team-level role to switch to. Valid roles include:",
+        # choices will follow in the docs
     )
 
 

--- a/src/sentry/roles/manager.py
+++ b/src/sentry/roles/manager.py
@@ -85,7 +85,8 @@ class RoleLevel(Generic[R]):
         self._priority_seq = tuple(sorted(roles, key=lambda r: r.priority))
         self._id_map = {r.id: r for r in self._priority_seq}
 
-        self._choices = tuple((r.id, r.desc) for r in self._priority_seq)
+        self._choices = tuple((r.id, r.name) for r in self._priority_seq)
+        self._descriptions = tuple((r.id, r.desc) for r in self._priority_seq)
         self._default = self._id_map[default_id] if default_id else self._priority_seq[0]
         self._top_dog = self._priority_seq[-1]
 
@@ -103,6 +104,9 @@ class RoleLevel(Generic[R]):
 
     def get_choices(self) -> Sequence[tuple[str, str]]:
         return self._choices
+
+    def get_descriptions(self) -> Sequence[tuple[str, str]]:
+        return self._descriptions
 
     def get_default(self) -> R:
         return self._default

--- a/tests/sentry/roles/test_manager.py
+++ b/tests/sentry/roles/test_manager.py
@@ -81,6 +81,13 @@ class RoleManagerTest(TestCase):
 
         assert manager.get_choices() == manager.organization_roles.get_choices()
         assert manager.team_roles.get_choices() == tuple(
+            (role["id"], role["name"]) for role in self.TEST_TEAM_ROLES
+        )
+
+    def test_descriptions(self):
+        manager = RoleManager(self.TEST_ORG_ROLES, self.TEST_TEAM_ROLES)
+
+        assert manager.team_roles.get_descriptions() == tuple(
             (role["id"], role["desc"]) for role in self.TEST_TEAM_ROLES
         )
 


### PR DESCRIPTION
In https://github.com/getsentry/sentry/pull/71953 I switched `get_choices` to use the description as the human-readable part in the tuple, but turns out we actually use the name in the SSO role dropdown shown below.

![Screenshot 2024-06-11 at 4 18 52 PM](https://github.com/getsentry/sentry/assets/67301797/ad1b3013-335b-42e5-ae57-a3dd0284ce58)

For the API, to get the description instead I added a different helper to do this