### PR TITLE
fix(autofix): Display for issues with threaded stack traces

### DIFF
--- a/static/app/views/issueDetails/resourcesAndPossibleSolutions.tsx
+++ b/static/app/views/issueDetails/resourcesAndPossibleSolutions.tsx
@@ -27,7 +27,10 @@ export function ResourcesAndPossibleSolutions({event, project, group}: Props) {
   const config = getConfigForIssueType(group, project);
 
   const hasStacktrace = event.entries.some(
-    entry => entry.type === EntryType.EXCEPTION || entry.type === EntryType.STACKTRACE
+    entry =>
+      entry.type === EntryType.EXCEPTION ||
+      entry.type === EntryType.STACKTRACE ||
+      entry.type === EntryType.THREADS
   );
 
   // NOTE:  Autofix is for INTERNAL testing only for now.


### PR DESCRIPTION
We hide Autofix when there isn't a stack trace, but we weren't counting the threads interface. Before merging we should ensure that seer does in fact look in the threads interface.