### PR TITLE
feat(billing): Add a dynamic sampling rule to sample everything on AM3

### DIFF
--- a/src/sentry/features/permanent.py
+++ b/src/sentry/features/permanent.py
@@ -103,6 +103,8 @@ def register_permanent_features(manager: FeatureManager):
         "organizations:customer-domains": False,
         # Enable the frontend to request from region & control silo domains.
         "organizations:frontend-domainsplit": False,
+        # Enable AM3 tier
+        "organizations:am3-tier": False,
     }
 
     permanent_project_features = {
@@ -120,10 +122,16 @@ def register_permanent_features(manager: FeatureManager):
 
     for org_feature, default in permanent_organization_features.items():
         manager.add(
-            org_feature, OrganizationFeature, FeatureHandlerStrategy.INTERNAL, default=default
+            org_feature,
+            OrganizationFeature,
+            FeatureHandlerStrategy.INTERNAL,
+            default=default,
         )
 
     for project_feature, default in permanent_project_features.items():
         manager.add(
-            project_feature, ProjectFeature, FeatureHandlerStrategy.INTERNAL, default=default
+            project_feature,
+            ProjectFeature,
+            FeatureHandlerStrategy.INTERNAL,
+            default=default,
         )


### PR DESCRIPTION
We bill on `DataCategory.SPAN`, which is the processed span category. This is the category that's emitted when dynamic sampling will extract metrics and not store the event.

Now, we disabled dynamic sampling because we want 100% of the spans indexed. So Relay will not emit those outcomes, needed for billing.

Instead of disabling dynamic sampling, we will re-activate it with https://github.com/getsentry/getsentry/pull/14281 and instead use a rule that will sample 100% of the events it sees and with this, it will get Relay to emit outcomes for processed spans again.

We discussed briefly switching the billing to use indexed span outcomes but it means we'd have to change that back when we do enable dynamic sampling back. This solution has the advantage to allow this to happen easily then all we'd do is change the rules.