### PR TITLE
feat(mobile-starfish): Add env to summary views

### DIFF
--- a/static/app/views/performance/mobile/appStarts/screenSummary/index.tsx
+++ b/static/app/views/performance/mobile/appStarts/screenSummary/index.tsx
@@ -6,6 +6,7 @@ import Breadcrumbs from 'sentry/components/breadcrumbs';
 import ErrorBoundary from 'sentry/components/errorBoundary';
 import * as Layout from 'sentry/components/layouts/thirds';
 import {DatePageFilter} from 'sentry/components/organizations/datePageFilter';
+import {EnvironmentPageFilter} from 'sentry/components/organizations/environmentPageFilter';
 import PageFilterBar from 'sentry/components/organizations/pageFilterBar';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
@@ -98,6 +99,7 @@ export function ScreenSummary() {
             <HeaderContainer>
               <ControlsContainer>
                 <PageFilterBar condensed>
+                  <EnvironmentPageFilter />
                   <DatePageFilter />
                 </PageFilterBar>
                 <ReleaseComparisonSelector />

--- a/static/app/views/performance/mobile/screenload/screenLoadSpans/index.tsx
+++ b/static/app/views/performance/mobile/screenload/screenLoadSpans/index.tsx
@@ -7,6 +7,7 @@ import ErrorBoundary from 'sentry/components/errorBoundary';
 import FeedbackWidgetButton from 'sentry/components/feedback/widget/feedbackWidgetButton';
 import * as Layout from 'sentry/components/layouts/thirds';
 import {DatePageFilter} from 'sentry/components/organizations/datePageFilter';
+import {EnvironmentPageFilter} from 'sentry/components/organizations/environmentPageFilter';
 import PageFilterBar from 'sentry/components/organizations/pageFilterBar';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
@@ -97,6 +98,7 @@ function ScreenLoadSpans() {
             <Container>
               <FilterContainer>
                 <PageFilterBar condensed>
+                  <EnvironmentPageFilter />
                   <DatePageFilter />
                 </PageFilterBar>
                 <ReleaseComparisonSelector />

--- a/static/app/views/performance/mobile/ui/screenSummary/index.tsx
+++ b/static/app/views/performance/mobile/ui/screenSummary/index.tsx
@@ -4,6 +4,7 @@ import omit from 'lodash/omit';
 import Breadcrumbs from 'sentry/components/breadcrumbs';
 import * as Layout from 'sentry/components/layouts/thirds';
 import {DatePageFilter} from 'sentry/components/organizations/datePageFilter';
+import {EnvironmentPageFilter} from 'sentry/components/organizations/environmentPageFilter';
 import PageFilterBar from 'sentry/components/organizations/pageFilterBar';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
@@ -66,6 +67,7 @@ function ScreenSummary() {
             <HeaderContainer>
               <ControlsContainer>
                 <PageFilterBar condensed>
+                  <EnvironmentPageFilter />
                   <DatePageFilter />
                 </PageFilterBar>
                 <ReleaseComparisonSelector />


### PR DESCRIPTION
Add EnvironmentPageFilter to all screen summary views because it's useful to filter by environment without having to navigate to the screen overview pages.

| Before | Now |
|--------|--------|
| ![CleanShot 2024-06-12 at 09 00 02](https://github.com/getsentry/sentry/assets/2443292/e2826546-5fce-4bf6-99fd-06e90228c35c) | ![CleanShot 2024-06-12 at 08 59 33](https://github.com/getsentry/sentry/assets/2443292/2ca4b69b-ebd2-4aa2-9903-ee436faa77ed) | 