### PR TITLE
ref(profiling): remove unused ProjectProfilingFlamegraphEndpoint class and urls

### DIFF
--- a/src/sentry/api/endpoints/project_profiling_profile.py
+++ b/src/sentry/api/endpoints/project_profiling_profile.py
@@ -143,20 +143,6 @@ class ProjectProfilingRawProfileEndpoint(ProjectProfilingBaseEndpoint):
 
 
 @region_silo_endpoint
-class ProjectProfilingFlamegraphEndpoint(ProjectProfilingBaseEndpoint):
-    def get(self, request: Request, project: Project) -> HttpResponse:
-        if not features.has("organizations:profiling", project.organization, actor=request.user):
-            return Response(status=404)
-
-        kwargs: dict[str, Any] = {
-            "method": "GET",
-            "path": f"/organizations/{project.organization_id}/projects/{project.id}/flamegraph",
-            "params": self.get_profiling_params(request, project),
-        }
-        return proxy_profiling_service(**kwargs)
-
-
-@region_silo_endpoint
 class ProjectProfilingFunctionsEndpoint(ProjectProfilingPaginatedBaseEndpoint):
     DEFAULT_PER_PAGE = 5
     MAX_PER_PAGE = 50

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -551,7 +551,6 @@ from .endpoints.project_processingissues import (
 )
 from .endpoints.project_profiling_profile import (
     ProjectProfilingEventEndpoint,
-    ProjectProfilingFlamegraphEndpoint,
     ProjectProfilingFunctionsEndpoint,
     ProjectProfilingProfileEndpoint,
     ProjectProfilingRawProfileEndpoint,
@@ -2743,11 +2742,6 @@ PROJECT_URLS: list[URLPattern | URLResolver] = [
         r"^(?P<organization_id_or_slug>[^\/]+)/(?P<project_id_or_slug>[^\/]+)/profiling/raw_profiles/(?P<profile_id>(?:\d+|[A-Fa-f0-9-]{32,36}))/$",
         ProjectProfilingRawProfileEndpoint.as_view(),
         name="sentry-api-0-project-profiling-raw-profile",
-    ),
-    re_path(
-        r"^(?P<organization_id_or_slug>[^\/]+)/(?P<project_id_or_slug>[^\/]+)/profiling/flamegraph/$",
-        ProjectProfilingFlamegraphEndpoint.as_view(),
-        name="sentry-api-0-project-profiling-flamegraph",
     ),
     re_path(
         r"^(?P<organization_id_or_slug>[^\/]+)/(?P<project_id_or_slug>[^\/]+)/profiling/transactions/(?P<transaction_id>(?:\d+|[A-Fa-f0-9-]{32,36}))/$",


### PR DESCRIPTION
This was an old endpoint that is not used anymore (dead code).