### PR TITLE
feat(metrics): Samples table performance CTA

### DIFF
--- a/static/app/components/metrics/metricSamplesTable.tsx
+++ b/static/app/components/metrics/metricSamplesTable.tsx
@@ -68,6 +68,7 @@ export type Field = (typeof fields)[number];
 
 interface MetricsSamplesTableProps {
   focusArea?: SelectionRange;
+  hasPerformance?: boolean;
   mri?: MRI;
   onRowHover?: (sampleId?: string) => void;
   op?: string;
@@ -150,6 +151,7 @@ export function MetricSamplesTable({
   query,
   setMetricsSamples,
   sortKey = 'sort',
+  hasPerformance = true,
 }: MetricsSamplesTableProps) {
   const location = useLocation();
 
@@ -232,6 +234,21 @@ export function MetricSamplesTable({
   }, [result]);
 
   const emptyMessage = useMemo(() => {
+    if (!hasPerformance) {
+      return (
+        <PerformanceEmptyState withIcon={false}>
+          <p>{t('You need to set up performance monitoring to collect samples.')}</p>
+          <LinkButton
+            priority="primary"
+            external
+            href="https://docs.sentry.io/performance-monitoring/getting-started"
+          >
+            {t('Set Up Now')}
+          </LinkButton>
+        </PerformanceEmptyState>
+      );
+    }
+
     if (!defined(mri)) {
       return (
         <EmptyStateWarning>
@@ -241,7 +258,7 @@ export function MetricSamplesTable({
     }
 
     return null;
-  }, [mri]);
+  }, [mri, hasPerformance]);
 
   const _renderHeadCell = useMemo(() => {
     const generateSortLink = (key: string) => () => {
@@ -766,4 +783,8 @@ const LegendDot = styled('div')<{color: string}>`
 
 const EmptyValueContainer = styled('span')`
   color: ${p => p.theme.gray300};
+`;
+
+const PerformanceEmptyState = styled(EmptyStateWarning)`
+  font-size: ${p => p.theme.fontSizeExtraLarge};
 `;

--- a/static/app/views/metrics/widgetDetails.tsx
+++ b/static/app/views/metrics/widgetDetails.tsx
@@ -43,6 +43,7 @@ export function WidgetDetails() {
     focusArea,
     setHighlightedSampleId,
     setMetricsSamples,
+    hasPerformanceMetrics,
   } = useMetricsContext();
 
   const selectedWidget = widgets[selectedWidgetIndex] as MetricsWidget | undefined;
@@ -69,6 +70,7 @@ export function WidgetDetails() {
       onRowHover={handleSampleRowHover}
       setMetricsSamples={setMetricsSamples}
       focusArea={focusArea}
+      hasPerformanceMetrics={hasPerformanceMetrics}
     />
   );
 }
@@ -76,6 +78,7 @@ export function WidgetDetails() {
 interface MetricDetailsProps {
   focusArea?: FocusAreaProps;
   focusedSeries?: FocusedMetricsSeries[];
+  hasPerformanceMetrics?: boolean;
   mri?: MRI;
   onRowHover?: (sampleId?: string) => void;
   op?: string;
@@ -93,6 +96,7 @@ export function MetricDetails({
   onRowHover,
   focusArea,
   setMetricsSamples,
+  hasPerformanceMetrics,
 }: MetricDetailsProps) {
   const {selection} = usePageFilters();
   const organization = useOrganization();
@@ -204,6 +208,7 @@ export function MetricDetails({
                     op={op}
                     query={queryWithFocusedSeries}
                     setMetricsSamples={setMetricsSamples}
+                    hasPerformance={hasPerformanceMetrics}
                   />
                 ) : (
                   <MetricSamplesTable
@@ -213,6 +218,7 @@ export function MetricDetails({
                     op={op}
                     query={queryWithFocusedSeries}
                     setMetricsSamples={setMetricsSamples}
+                    hasPerformance={hasPerformanceMetrics}
                   />
                 )}
               </MetricSampleTableWrapper>


### PR DESCRIPTION
Add empty state with a CTA for set up performance.

<img width="1371" alt="Screenshot 2024-06-12 at 12 13 51" src="https://github.com/getsentry/sentry/assets/7033940/da086aad-977e-4c6d-8d6d-70208b68c176">

Closes https://github.com/getsentry/sentry/issues/70725