### PR TITLE
fix(combobox): Wrapper height affected by grid layout

### DIFF
--- a/static/app/components/comboBox/index.tsx
+++ b/static/app/components/comboBox/index.tsx
@@ -370,6 +370,7 @@ function ControlledComboBox<Value extends string>({
 const ControlWrapper = styled('div')`
   position: relative;
   width: max-content;
+  height: max-content;
   min-width: 150px;
   max-width: 100%;
   cursor: pointer;


### PR DESCRIPTION
Closes https://github.com/getsentry/sentry/issues/72583