### PR TITLE
feat(slack): Show culprit in notifications

### DIFF
--- a/src/sentry/integrations/slack/message_builder/issues.py
+++ b/src/sentry/integrations/slack/message_builder/issues.py
@@ -521,6 +521,12 @@ class SlackIssuesMessageBuilder(BlockSlackMessageBuilder):
 
         return self.get_markdown_block(title_text)
 
+    def get_culprit_block(self, event_or_group: GroupEvent | Group) -> SlackBlock | None:
+        if isinstance(event_or_group.culprit, str) and event_or_group.culprit != "":
+            return self.get_context_block(event_or_group.culprit)
+        else:
+            return None
+
     def get_text_block(self, text) -> SlackBlock:
         if self.group.issue_category == GroupCategory.FEEDBACK:
             max_block_text_length = USER_FEEDBACK_MAX_BLOCK_TEXT_LENGTH
@@ -607,6 +613,9 @@ class SlackIssuesMessageBuilder(BlockSlackMessageBuilder):
                 has_action = True
 
         blocks = [self.get_title_block(rule_id, notification_uuid, obj, has_action)]
+
+        if culprit_block := self.get_culprit_block(obj):
+            blocks.append(culprit_block)
 
         # build up text block
         text = text.lstrip(" ")

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -2911,16 +2911,17 @@ class SlackActivityNotificationTest(ActivityTestCase):
             blocks[1]["text"]["text"]
             == f":large_blue_circle: :chart_with_upwards_trend: <{issue_link}|*N+1 Query*>"
         )
+        assert blocks[2]["elements"][0]["text"] == "/books/"
         assert (
-            blocks[2]["text"]["text"]
+            blocks[3]["text"]["text"]
             == "```db - SELECT `books_author`.`id`, `books_author`.`name` FROM `books_author` WHERE `books_author`.`id` = %s LIMIT 21```"
         )
         assert (
-            blocks[3]["elements"][0]["text"] == "State: *Ongoing*   First Seen: *10\xa0minutes ago*"
+            blocks[4]["elements"][0]["text"] == "State: *Ongoing*   First Seen: *10\xa0minutes ago*"
         )
         optional_org_id = f"&organizationId={org.id}" if alert_page_needs_org_id(alert_type) else ""
         assert (
-            blocks[4]["elements"][0]["text"]
+            blocks[5]["elements"][0]["text"]
             == f"{project_slug} | production | <http://testserver/settings/account/notifications/{alert_type}/?referrer={referrer}-user&notification_uuid={notification_uuid}{optional_org_id}|Notification Settings>"
         )
 
@@ -2944,6 +2945,7 @@ class SlackActivityNotificationTest(ActivityTestCase):
         referrer,
         alert_type="workflow",
         issue_link_extra_params=None,
+        with_culprit=False,
     ):
         notification_uuid = self.get_notification_uuid(blocks[1]["text"]["text"])
         issue_link = f"http://testserver/organizations/{org.slug}/issues/{group.id}/?referrer={referrer}&notification_uuid={notification_uuid}"
@@ -2953,8 +2955,14 @@ class SlackActivityNotificationTest(ActivityTestCase):
             blocks[1]["text"]["text"]
             == f":red_circle: <{issue_link}|*{TEST_ISSUE_OCCURRENCE.issue_title}*>"
         )
+        if with_culprit:
+            assert blocks[2]["elements"][0]["text"] == "raven.tasks.run_a_test"
+            evidence_index = 3
+        else:
+            evidence_index = 2
+
         assert (
-            blocks[2]["text"]["text"]
+            blocks[evidence_index]["text"]["text"]
             == "```" + TEST_ISSUE_OCCURRENCE.evidence_display[0].value + "```"
         )
 

--- a/tests/sentry/integrations/slack/notifications/test_issue_alert.py
+++ b/tests/sentry/integrations/slack/notifications/test_issue_alert.py
@@ -446,9 +446,9 @@ class SlackIssueAlertNotificationTest(SlackActivityNotificationTest, Performance
             blocks[1]["text"]["text"]
             == f":red_circle: <http://testserver/organizations/{event.organization.slug}/issues/{event.group.id}/?referrer=issue_alert-slack&notification_uuid={notification_uuid}&alert_rule_id={rule.id}&alert_type=issue|*Hello world*>"
         )
-        assert blocks[5]["elements"][0]["text"] == f"Suggested Assignees: #{self.team.slug}"
+        assert blocks[6]["elements"][0]["text"] == f"Suggested Assignees: #{self.team.slug}"
         assert (
-            blocks[6]["elements"][0]["text"]
+            blocks[7]["elements"][0]["text"]
             == f"{event.project.slug} | <http://testserver/settings/{event.organization.slug}/teams/{self.team.slug}/notifications/?referrer=issue_alert-slack-team&notification_uuid={notification_uuid}|Notification Settings>"
         )
 

--- a/tests/sentry/integrations/slack/notifications/test_regression.py
+++ b/tests/sentry/integrations/slack/notifications/test_regression.py
@@ -106,7 +106,12 @@ class SlackRegressionNotificationTest(SlackActivityNotificationTest, Performance
         and block kit is enabled.
         """
         event = self.store_event(
-            data={"message": "Hellboy's world", "level": "error"}, project_id=self.project.id
+            data={
+                "message": "Hellboy's world",
+                "level": "error",
+                "culprit": "raven.tasks.run_a_test",
+            },
+            project_id=self.project.id,
         )
         group_event = event.for_group(event.groups[0])
 
@@ -122,4 +127,5 @@ class SlackRegressionNotificationTest(SlackActivityNotificationTest, Performance
             group_event.project.slug,
             group_event.group,
             "regression_activity-slack",
+            with_culprit=True,
         )

--- a/tests/sentry/integrations/slack/test_message_builder.py
+++ b/tests/sentry/integrations/slack/test_message_builder.py
@@ -88,6 +88,9 @@ def build_test_message_blocks(
             "block_id": f'{{"issue":{group.id}}}',
         },
     ]
+    if culprit := event and event.culprit or group.culprit:
+        culprit_section = {"elements": [{"text": culprit, "type": "mrkdwn"}], "type": "context"}
+        blocks.append(culprit_section)
     if text:
         new_text = text.lstrip(" ")
         if new_text:
@@ -773,7 +776,7 @@ class BuildGroupAttachmentTest(TestCase, PerformanceIssueTestCase, OccurrenceTes
         assert "N+1 Query" in blocks["blocks"][0]["text"]["text"]
         assert (
             "db - SELECT `books_author`.`id`, `books_author`.`name` FROM `books_author` WHERE `books_author`.`id` = %s LIMIT 21"
-            in blocks["blocks"][1]["text"]["text"]
+            in blocks["blocks"][2]["text"]["text"]
         )
         assert blocks["text"] == f"[{self.project.slug}] N+1 Query"
 

--- a/tests/sentry/integrations/slack/webhooks/actions/test_status.py
+++ b/tests/sentry/integrations/slack/webhooks/actions/test_status.py
@@ -1038,13 +1038,14 @@ class StatusActionTest(BaseEventTest, PerformanceIssueTestCase, HybridCloudTestM
 
         expect_status = f"*Issue resolved by <@{self.external_id}>*"
         assert (
-            "db - SELECT `books_author`.`id`, `books_author`.`name` FROM `books_author` WHERE `books_author`.`id` = %s LIMIT 21"
-            in update_data["blocks"][1]["text"]["text"]
-        )
-        assert update_data["blocks"][2]["text"]["text"] == expect_status
-        assert (
             ":white_circle: :chart_with_upwards_trend:" in update_data["blocks"][0]["text"]["text"]
         )
+        assert update_data["blocks"][1]["elements"][0]["text"] == "/books/"
+        assert (
+            "db - SELECT `books_author`.`id`, `books_author`.`name` FROM `books_author` WHERE `books_author`.`id` = %s LIMIT 21"
+            in update_data["blocks"][2]["text"]["text"]
+        )
+        assert update_data["blocks"][3]["text"]["text"] == expect_status
 
     @responses.activate
     def test_resolve_issue_block_kit_through_unfurl(self):


### PR DESCRIPTION
Relates to/part of #30164 (which has absorbed #26006). 

This adds a context-like culprit-block directly under the title, which mirrors how the culprit is presented in the web UI.

<!-- Describe your PR here. -->

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
