### PR TITLE
feat(issues): Use title from React caused errors

### DIFF
--- a/src/sentry/grouping/strategies/newstyle.py
+++ b/src/sentry/grouping/strategies/newstyle.py
@@ -1,11 +1,10 @@
 from __future__ import annotations
 
 import itertools
+import logging
 import re
 from collections.abc import Generator
 from typing import Any
-
-import sentry_sdk
 
 from sentry.eventstore.models import Event
 from sentry.grouping.component import GroupingComponent, calculate_tree_label
@@ -24,6 +23,8 @@ from sentry.interfaces.exception import Mechanism, SingleException
 from sentry.interfaces.stacktrace import Frame, Stacktrace
 from sentry.interfaces.threads import Threads
 from sentry.stacktraces.platform import get_behavior_family_for_platform
+
+logger = logging.getLogger(__name__)
 
 _ruby_erb_func = re.compile(r"__\d{4,}_\d{4,}$")
 _basename_re = re.compile(r"[/\\]")
@@ -699,8 +700,14 @@ def chained_exception(
         )
     except Exception:
         # We shouldn't have exceptions here. But if we do, just record it and continue with the original list.
-        sentry_sdk.capture_exception()
+        logging.exception(
+            "Failed to filter exceptions for exception groups. Continuing with original list."
+        )
         exceptions = all_exceptions
+
+    main_exception_id = determine_main_exception_id(exceptions)
+    if main_exception_id:
+        event.data["main_exception_id"] = main_exception_id
 
     # Case 1: we have a single exception, use the single exception
     # component directly to avoid a level of nesting
@@ -899,3 +906,27 @@ def threads_variant_processor(
     variants: ReturnedVariants, context: GroupingContext, **meta: Any
 ) -> ReturnedVariants:
     return remove_non_stacktrace_variants(variants)
+
+
+def react_hydration_error_with_cause(exceptions: list[SingleException]) -> int:
+    # Starting with React 19, hydration errors can contain a cause error which is useful to display
+    if (
+        exceptions[0].type == "Error"
+        and exceptions[0].value
+        == "There was an error while hydrating but React was able to recover by instead client rendering from the nearest Suspense boundary."
+        and exceptions[-1].mechanism.source == "cause"
+    ):
+        return exceptions[-1].mechanism.exception_id
+
+
+def determine_main_exception_id(exceptions: list[SingleException]) -> int:
+    MAIN_EXCEPTION_ID_FUNCS = [
+        react_hydration_error_with_cause,
+    ]
+    main_exception_id = None
+    for func in MAIN_EXCEPTION_ID_FUNCS:
+        main_exception_id = func(exceptions)
+        if main_exception_id is not None:
+            break
+
+    return main_exception_id

--- a/src/sentry/grouping/strategies/newstyle.py
+++ b/src/sentry/grouping/strategies/newstyle.py
@@ -908,17 +908,19 @@ def threads_variant_processor(
     return remove_non_stacktrace_variants(variants)
 
 
+REACT_ERRORS_WITH_CAUSE = [
+    "There was an error during concurrent rendering but React was able to recover by instead synchronously rendering the entire root.",
+    "There was an error while hydrating but React was able to recover by instead client rendering from the nearest Suspense boundary.",
+]
+
+
 def react_error_with_cause(exceptions: list[SingleException]) -> int | None:
     main_exception_id = None
     # Starting with React 19, errors can also contain a cause error which
     # is useful to display instead of the default message
     if (
         exceptions[0].type == "Error"
-        and exceptions[0].value
-        in [
-            "There was an error during concurrent rendering but React was able to recover by instead synchronously rendering the entire root.",
-            "There was an error while hydrating but React was able to recover by instead client rendering from the nearest Suspense boundary.",
-        ]
+        and exceptions[0].value in REACT_ERRORS_WITH_CAUSE
         and exceptions[-1].mechanism.source == "cause"
     ):
         main_exception_id = exceptions[-1].mechanism.exception_id

--- a/src/sentry/grouping/strategies/newstyle.py
+++ b/src/sentry/grouping/strategies/newstyle.py
@@ -908,7 +908,8 @@ def threads_variant_processor(
     return remove_non_stacktrace_variants(variants)
 
 
-def react_hydration_error_with_cause(exceptions: list[SingleException]) -> int:
+def react_hydration_error_with_cause(exceptions: list[SingleException]) -> int | None:
+    main_exception_id = None
     # Starting with React 19, hydration errors can contain a cause error which is useful to display
     if (
         exceptions[0].type == "Error"
@@ -916,10 +917,11 @@ def react_hydration_error_with_cause(exceptions: list[SingleException]) -> int:
         == "There was an error while hydrating but React was able to recover by instead client rendering from the nearest Suspense boundary."
         and exceptions[-1].mechanism.source == "cause"
     ):
-        return exceptions[-1].mechanism.exception_id
+        main_exception_id = exceptions[-1].mechanism.exception_id
+    return main_exception_id
 
 
-def determine_main_exception_id(exceptions: list[SingleException]) -> int:
+def determine_main_exception_id(exceptions: list[SingleException]) -> int | None:
     MAIN_EXCEPTION_ID_FUNCS = [
         react_hydration_error_with_cause,
     ]

--- a/src/sentry/interfaces/exception.py
+++ b/src/sentry/interfaces/exception.py
@@ -168,6 +168,9 @@ class Mechanism(Interface):
         if self.handled is not None:
             yield ("handled", self.handled and "yes" or "no")
 
+    def __repr__(self) -> str:
+        return f"{type(self).__name__} -> id:{self.exception_id}, parent_id:{self.parent_id}, source:{self.source}, type:{self.type}"
+
 
 def uncontribute_non_stacktrace_variants(variants):
     """If we have multiple variants and at least one has a stacktrace, we
@@ -183,7 +186,7 @@ def uncontribute_non_stacktrace_variants(variants):
 
     # In case any of the variants has a contributing stacktrace, we want
     # to make all other variants non contributing.  Thr e
-    for (key, component) in variants.items():
+    for key, component in variants.items():
         if any(
             s.contributes for s in component.iter_subcomponents(id="stacktrace", recursive=True)
         ):
@@ -346,6 +349,12 @@ class SingleException(Interface):
             "module": meta.get("module"),
             "stacktrace": stacktrace_meta,
         }
+
+    def __str__(self) -> str:
+        return f"{type(self).__name__}: {self.type}: {self.value}"
+
+    def __repr__(self) -> str:
+        return f"{type(self).__name__} -> {self.type}: {self.value}"
 
 
 class Exception(Interface):

--- a/tests/sentry/event_manager/test_event_manager.py
+++ b/tests/sentry/event_manager/test_event_manager.py
@@ -256,6 +256,7 @@ class EventManagerTest(TestCase, SnubaTestCase, EventManagerTestMixin, Performan
         event = manager.save(self.project.id)
         assert event.data["metadata"]["value"] == cause_error_value
         assert event.data["metadata"]["type"] == "TypeError"
+        assert event.group is not None
         assert event.group.title == f"TypeError: {cause_error_value}"
 
     @mock.patch("sentry.signals.issue_unresolved.send_robust")

--- a/tests/sentry/event_manager/test_event_manager.py
+++ b/tests/sentry/event_manager/test_event_manager.py
@@ -223,6 +223,41 @@ class EventManagerTest(TestCase, SnubaTestCase, EventManagerTestMixin, Performan
 
         assert materialized["metadata"] == {"title": "<unlabeled event>", "dogs": "are great"}
 
+    def test_react19_hydration_error_picks_cause_error_title_subtitle(self) -> None:
+        cause_error_value = "Cannot read properties of undefined (reading 'nodeName')"
+        # React 19 hydration error include the hydration error and a cause
+        # If we derive the title from the cause error the developer will more easily distinguish them
+        manager = EventManager(
+            make_event(
+                exception={
+                    "values": [
+                        {
+                            "type": "TypeError",
+                            "value": cause_error_value,
+                            "mechanism": {
+                                "type": "chained",
+                                "source": "cause",
+                                "exception_id": 1,
+                                "parent_id": 0,
+                            },
+                        },
+                        {
+                            "type": "Error",
+                            "value": "There was an error while hydrating but React was able to recover by instead client rendering from the nearest Suspense boundary.",
+                            "mechanism": {
+                                "type": "generic",
+                                "exception_id": 0,
+                            },
+                        },
+                    ]
+                },
+            )
+        )
+        event = manager.save(self.project.id)
+        assert event.data["metadata"]["value"] == cause_error_value
+        assert event.data["metadata"]["type"] == "TypeError"
+        assert event.group.title == f"TypeError: {cause_error_value}"
+
     @mock.patch("sentry.signals.issue_unresolved.send_robust")
     def test_unresolves_group(self, send_robust: mock.MagicMock) -> None:
         ts = time() - 300


### PR DESCRIPTION
Starting with React 19, errors can include a `cause` error. Instead of using the generic `Error` title, we can use the title from the `cause` error, thus, making each issue unique.

This design shows what the Issue Stream looks like now vs after this change:
<img width="541" alt="image" src="https://github.com/getsentry/sentry/assets/44410/362b6658-6c5a-462c-a16e-7ad253debb76">
