### PR TITLE
Enable negated transaction filtering for dynamic sampling custom rules

### DIFF
--- a/src/sentry/snuba/metrics/extraction.py
+++ b/src/sentry/snuba/metrics/extraction.py
@@ -332,6 +332,8 @@ _IGNORED_METRIC_FIELDS = [
 ]
 _IGNORED_METRIC_CONDITION = [
     "event.type=transaction",
+    "event.type!=error",
+    "event.type!=default",
 ]
 
 # Operators used in ``ComparingRuleCondition``.

--- a/src/sentry/snuba/metrics/extraction.py
+++ b/src/sentry/snuba/metrics/extraction.py
@@ -426,9 +426,21 @@ def _check_event_type_transaction(
 
     for token in query:
         if isinstance(token, SearchFilter):
-            if token.key.name == "event.type" and token.value.value == "transaction":
+            if (
+                token.key.name == "event.type"
+                and token.operator == "="
+                and token.value.value == "transaction"
+            ):
                 transaction_filter = True
                 break
+            if (
+                token.key.name == "event.type"
+                and token.operator == "!="
+                and token.value.value != "transaction"
+            ):
+                transaction_filter = True
+                break
+
         elif isinstance(token, ParenExpression):
             contains_transaction = _check_event_type_transaction(
                 token.children, is_top_level_call=False

--- a/tests/sentry/api/endpoints/test_custom_rules.py
+++ b/tests/sentry/api/endpoints/test_custom_rules.py
@@ -465,6 +465,20 @@ class TestCustomRuleSerializerWithProjects(TestCase):
                 ],
             },
         ),
+        (
+            "environment:prod hello world !event.type:error",
+            {
+                "op": "and",
+                "inner": [
+                    {"op": "eq", "name": "event.environment", "value": "prod"},
+                    {"op": "glob", "name": "event.transaction", "value": ["*hello world*"]},
+                    {
+                        "op": "not",
+                        "inner": {"op": "eq", "name": "event.tags.event.type", "value": "error"},
+                    },
+                ],
+            },
+        ),
     ],
 )
 def test_get_condition(query, condition):

--- a/tests/sentry/api/endpoints/test_custom_rules.py
+++ b/tests/sentry/api/endpoints/test_custom_rules.py
@@ -466,16 +466,12 @@ class TestCustomRuleSerializerWithProjects(TestCase):
             },
         ),
         (
-            "environment:prod hello world !event.type:error",
+            "!event.type:error environment:prod hello world",
             {
                 "op": "and",
                 "inner": [
                     {"op": "eq", "name": "event.environment", "value": "prod"},
                     {"op": "glob", "name": "event.transaction", "value": ["*hello world*"]},
-                    {
-                        "op": "not",
-                        "inner": {"op": "eq", "name": "event.tags.event.type", "value": "error"},
-                    },
                 ],
             },
         ),


### PR DESCRIPTION
- To date, not filtering for event.type:transactions causes a Bad Request 400 on /dynamic-sampling/custom-rules/, even if something valid like a negated other event type is entered. This PR hotfixes this by adding the logic to the extraction code.
- Contributes to https://github.com/getsentry/sentry/issues/72300