### PR TITLE
fix(trace-explorer): Direct traces url to react

### DIFF
--- a/src/sentry/web/urls.py
+++ b/src/sentry/web/urls.py
@@ -725,6 +725,12 @@ urlpatterns += [
         react_page_view,
         name="insights",
     ),
+    # Insights
+    re_path(
+        r"^traces/",
+        react_page_view,
+        name="traces",
+    ),
     # Profiling
     re_path(
         r"^profiling/",


### PR DESCRIPTION
Looks like without this, the `/traces/` routes eventually gets redirected to the `/issues/` route.