### PR TITLE
fix(hybridcloud) Don't use RPC to fetch user.id

### DIFF
--- a/src/sentry/models/organization.py
+++ b/src/sentry/models/organization.py
@@ -323,10 +323,12 @@ class Organization(ReplicatedRegionModel, OptionMixin, OrganizationAbsoluteUrlMi
         if there is no owner. Used for analytics primarily.
         """
         if not hasattr(self, "_default_owner_id"):
-            owners = self.get_owners()
-            if len(owners) == 0:
+            owner_ids = self.get_members_with_org_roles(roles=[roles.get_top_dog().id]).values_list(
+                "user_id", flat=True
+            )
+            if len(owner_ids) == 0:
                 return None
-            self._default_owner_id = owners[0].id
+            self._default_owner_id = owner_ids[0]
         return self._default_owner_id
 
     @classmethod

--- a/src/sentry/receivers/onboarding.py
+++ b/src/sentry/receivers/onboarding.py
@@ -378,9 +378,9 @@ def record_release_received(project, event, **kwargs):
         project_id=project.id,
     )
     if success:
-        try:
-            user: RpcUser = Organization.objects.get(id=project.organization_id).get_default_owner()
-        except IndexError:
+        organization = Organization.objects.get_from_cache(id=project.organization_id)
+        owner_id = organization.default_owner_id
+        if not owner_id:
             logger.warning(
                 "Cannot record release received for organization (%s) due to missing owners",
                 project.organization_id,
@@ -389,7 +389,7 @@ def record_release_received(project, event, **kwargs):
 
         analytics.record(
             "first_release_tag.sent",
-            user_id=user.id if user else None,
+            user_id=owner_id,
             project_id=project.id,
             organization_id=project.organization_id,
         )
@@ -415,11 +415,9 @@ def record_user_context_received(project, event, **kwargs):
             project_id=project.id,
         )
         if success:
-            try:
-                user: RpcUser = Organization.objects.get(
-                    id=project.organization_id
-                ).get_default_owner()
-            except IndexError:
+            organization = Organization.objects.get_from_cache(id=project.organization_id)
+            owner_id = organization.default_owner_id
+            if not owner_id:
                 logger.warning(
                     "Cannot record user context received for organization (%s) due to missing owners",
                     project.organization_id,
@@ -428,7 +426,7 @@ def record_user_context_received(project, event, **kwargs):
 
             analytics.record(
                 "first_user_context.sent",
-                user_id=user.id if user else None,
+                user_id=owner_id,
                 organization_id=project.organization_id,
                 project_id=project.id,
             )
@@ -440,9 +438,9 @@ event_processed.connect(record_user_context_received, weak=False)
 
 @first_event_with_minified_stack_trace_received.connect(weak=False)
 def record_event_with_first_minified_stack_trace_for_project(project, event, **kwargs):
-    try:
-        user: RpcUser = Organization.objects.get(id=project.organization_id).get_default_owner()
-    except IndexError:
+    organization = Organization.objects.get_from_cache(id=project.organization_id)
+    owner_id = organization.default_owner_id
+    if not owner_id:
         logger.warning(
             "Cannot record first event for organization (%s) due to missing owners",
             project.organization_id,
@@ -464,7 +462,7 @@ def record_event_with_first_minified_stack_trace_for_project(project, event, **k
         ):
             analytics.record(
                 "first_event_with_minified_stack_trace_for_project.sent",
-                user_id=user.id if user else None,
+                user_id=owner_id,
                 organization_id=project.organization_id,
                 project_id=project.id,
                 platform=event.platform,
@@ -488,9 +486,9 @@ def record_sourcemaps_received(project, event, **kwargs):
         project_id=project.id,
     )
     if success:
-        try:
-            user: RpcUser = Organization.objects.get(id=project.organization_id).get_default_owner()
-        except IndexError:
+        organization = Organization.objects.get_from_cache(id=project.organization_id)
+        owner_id = organization.default_owner_id
+        if not owner_id:
             logger.warning(
                 "Cannot record sourcemaps received for organization (%s) due to missing owners",
                 project.organization_id,
@@ -498,7 +496,7 @@ def record_sourcemaps_received(project, event, **kwargs):
             return
         analytics.record(
             "first_sourcemaps.sent",
-            user_id=user.id if user else None,
+            user_id=owner_id,
             organization_id=project.organization_id,
             project_id=project.id,
             platform=event.platform,
@@ -513,9 +511,9 @@ def record_sourcemaps_received_for_project(project, event, **kwargs):
     if not has_sourcemap(event):
         return
 
-    try:
-        user: RpcUser = Organization.objects.get(id=project.organization_id).get_default_owner()
-    except IndexError:
+    organization = Organization.objects.get_from_cache(id=project.organization_id)
+    owner_id = organization.default_owner_id
+    if not owner_id:
         logger.warning(
             "Cannot record sourcemaps received for organization (%s) due to missing owners",
             project.organization_id,
@@ -534,7 +532,7 @@ def record_sourcemaps_received_for_project(project, event, **kwargs):
         if project.date_added > START_DATE_TRACKING_FIRST_SOURCEMAP_PER_PROJ and affected > 0:
             analytics.record(
                 "first_sourcemaps_for_project.sent",
-                user_id=user.id if user else None,
+                user_id=owner_id,
                 organization_id=project.organization_id,
                 project_id=project.id,
                 platform=event.platform,

--- a/tests/sentry/models/test_organization.py
+++ b/tests/sentry/models/test_organization.py
@@ -74,7 +74,10 @@ class OrganizationTest(TestCase, HybridCloudTestMixin):
         assert org.default_owner_id is None
 
     @mock.patch.object(
-        Organization, "get_owners", side_effect=Organization.get_owners, autospec=True
+        Organization,
+        "get_members_with_org_roles",
+        side_effect=Organization.get_members_with_org_roles,
+        autospec=True,
     )
     def test_default_owner_id_cached(self, mock_get_owners):
         user = self.create_user("foo@example.com")


### PR DESCRIPTION
Within post_process_group we trigger several signal handlers. Many of these handlers fetch an organization, and the owner of that organization. Fetching the user via RPC to only use its `id` is very wasteful. Refactoring this logic to reduce the number of SQL queries (organization reads) and not using RPC should help reduce RPC throughput and make post_process_group marginally faster.