### PR TITLE
ref: remove unused CanonicalKeyView

### DIFF
--- a/src/sentry/utils/canonical.py
+++ b/src/sentry/utils/canonical.py
@@ -6,7 +6,7 @@ from typing import Self, TypeVar
 
 V = TypeVar("V")
 
-__all__ = ("CanonicalKeyDict", "CanonicalKeyView", "get_canonical_name")
+__all__ = ("CanonicalKeyDict", "get_canonical_name")
 
 
 LEGACY_KEY_MAPPING = {
@@ -64,41 +64,6 @@ def get_canonical_name(key: str) -> str:
         return rv[0]
 
 
-class CanonicalKeyView(Mapping[str, V]):
-    def __init__(self, data: dict[str, V]) -> None:
-        self.data = data
-        self._len = len({get_canonical_name(key) for key in self.data})
-
-    def copy(self) -> Self:
-        return self
-
-    __copy__ = copy
-
-    def __len__(self) -> int:
-        return self._len
-
-    def __iter__(self) -> Iterator[str]:
-        # Preserve the order of iteration while prioritizing canonical keys
-        keys = list(self.data)
-        for key in keys:
-            canonicals = CANONICAL_KEY_MAPPING.get(key, ())
-            if not canonicals:
-                yield key
-            elif all(k not in keys for k in canonicals):
-                yield canonicals[0]
-
-    def __getitem__(self, key: str) -> V:
-        canonical = get_canonical_name(key)
-        for k in (canonical,) + LEGACY_KEY_MAPPING.get(canonical, ()):
-            if k in self.data:
-                return self.data[k]
-
-        raise KeyError(key)
-
-    def __repr__(self) -> str:
-        return f"CanonicalKeyView({self.data!r})"
-
-
 class CanonicalKeyDict(MutableMapping[str, V]):
     def __init__(self, data: Mapping[str, V]) -> None:
         self.data: dict[str, V] = {}
@@ -136,4 +101,4 @@ class CanonicalKeyDict(MutableMapping[str, V]):
         return f"CanonicalKeyDict({self.data!r})"
 
 
-CANONICAL_TYPES = (CanonicalKeyDict, CanonicalKeyView)
+CANONICAL_TYPES = (CanonicalKeyDict,)

--- a/tests/sentry/utils/test_canonical.py
+++ b/tests/sentry/utils/test_canonical.py
@@ -3,67 +3,13 @@ import unittest
 import pytest
 
 from sentry.testutils.helpers.options import override_options
-from sentry.utils.canonical import CanonicalKeyDict, CanonicalKeyView
+from sentry.utils.canonical import CanonicalKeyDict
 
 
 @pytest.fixture(autouse=True)
 def _disable_fallback_logging():
     with override_options({"canonical-fallback.send-error-to-sentry": 0}):
         yield
-
-
-class CanonicalKeyViewTests(unittest.TestCase):
-    canonical_data = {
-        "release": "asdf",
-        "exception": {"type": "DemoException"},
-        "user": {"id": "DemoUser"},
-    }
-
-    legacy_data = {
-        "release": "asdf",
-        "sentry.interfaces.Exception": {"type": "DemoException"},
-        "sentry.interfaces.User": {"id": "DemoUser"},
-    }
-
-    mixed_data = {
-        "release": "asdf",
-        "sentry.interfaces.User": {"id": "INVALID"},
-        "exception": {"type": "DemoException"},
-        "user": {"id": "DemoUser"},
-        "sentry.interfaces.Exception": {"type": "INVALID"},
-    }
-
-    def test_len(self):
-        assert len(CanonicalKeyView(self.canonical_data)) == 3
-        assert len(CanonicalKeyView(self.legacy_data)) == 3
-        assert len(CanonicalKeyView(self.mixed_data)) == 3
-
-    def test_iter(self):
-        assert list(CanonicalKeyView(self.canonical_data).keys()) == [
-            "release",
-            "exception",
-            "user",
-        ]
-        assert list(CanonicalKeyView(self.legacy_data).keys()) == ["release", "exception", "user"]
-        assert list(CanonicalKeyView(self.mixed_data).keys()) == ["release", "exception", "user"]
-
-    def test_contains(self):
-        assert "user" in CanonicalKeyView(self.canonical_data)
-        assert "user" in CanonicalKeyView(self.legacy_data)
-        assert "user" in CanonicalKeyView(self.mixed_data)
-
-        assert "sentry.interfaces.User" in CanonicalKeyView(self.canonical_data)
-        assert "sentry.interfaces.User" in CanonicalKeyView(self.legacy_data)
-        assert "sentry.interfaces.User" in CanonicalKeyView(self.mixed_data)
-
-    def test_getitem(self):
-        assert CanonicalKeyView(self.canonical_data)["user"] == {"id": "DemoUser"}
-        assert CanonicalKeyView(self.legacy_data)["user"] == {"id": "DemoUser"}
-        assert CanonicalKeyView(self.mixed_data)["user"] == {"id": "DemoUser"}
-
-        assert CanonicalKeyView(self.canonical_data)["sentry.interfaces.User"] == {"id": "DemoUser"}
-        assert CanonicalKeyView(self.legacy_data)["sentry.interfaces.User"] == {"id": "DemoUser"}
-        assert CanonicalKeyView(self.mixed_data)["sentry.interfaces.User"] == {"id": "DemoUser"}
 
 
 class CanonicalKeyDictTests(unittest.TestCase):
@@ -151,73 +97,6 @@ class CanonicalKeyDictTests(unittest.TestCase):
             )
             == 3
         )
-
-
-class DoubleAliasingTests(unittest.TestCase):
-    def test_canonical(self):
-        view = CanonicalKeyView({"logentry": "foo"})
-        assert len(view) == 1
-        assert list(view.keys()) == ["logentry"]
-
-        assert "logentry" in view
-        assert "sentry.interfaces.Message" in view
-        assert "message" in view
-
-        assert view["logentry"] == "foo"
-        assert view["sentry.interfaces.Message"] == "foo"
-        assert view["message"] == "foo"
-
-    def test_legacy_first(self):
-        view = CanonicalKeyView({"sentry.interfaces.Message": "foo"})
-        assert len(view) == 1
-        assert list(view.keys()) == ["logentry"]
-
-        assert "logentry" in view
-        assert "sentry.interfaces.Message" in view
-        assert "message" in view
-
-        assert view["logentry"] == "foo"
-        assert view["sentry.interfaces.Message"] == "foo"
-        assert view["message"] == "foo"
-
-    def test_legacy_second(self):
-        view = CanonicalKeyView({"message": "foo"})
-        assert len(view) == 1
-        assert list(view.keys()) == ["logentry"]
-
-        assert "logentry" in view
-        assert "sentry.interfaces.Message" in view
-        assert "message" in view
-
-        assert view["logentry"] == "foo"
-        assert view["sentry.interfaces.Message"] == "foo"
-        assert view["message"] == "foo"
-
-    def test_override(self):
-        view = CanonicalKeyView({"logentry": "foo", "sentry.interfaces.Message": "bar"})
-        assert len(view) == 1
-        assert list(view.keys()) == ["logentry"]
-
-        assert "logentry" in view
-        assert "sentry.interfaces.Message" in view
-        assert "message" in view
-
-        assert view["logentry"] == "foo"
-        assert view["sentry.interfaces.Message"] == "foo"
-        assert view["message"] == "foo"
-
-    def test_two_legacy(self):
-        view = CanonicalKeyView({"message": "bar", "sentry.interfaces.Message": "foo"})
-        assert len(view) == 1
-        assert list(view.keys()) == ["logentry"]
-
-        assert "logentry" in view
-        assert "sentry.interfaces.Message" in view
-        assert "message" in view
-
-        assert view["logentry"] == "foo"
-        assert view["sentry.interfaces.Message"] == "foo"
-        assert view["message"] == "foo"
 
 
 def _trigger_canonical_fallback():


### PR DESCRIPTION
after removing the last usage this should be safe to clean up now \o/

still need to do CanonicalKeyDict after this

<!-- Describe your PR here. -->