### PR TITLE
ref(issues): don't persist sort param when clicking from issue list to tabs

### DIFF
--- a/static/app/views/issueDetails/header.spec.tsx
+++ b/static/app/views/issueDetails/header.spec.tsx
@@ -79,7 +79,10 @@ describe('GroupHeader', () => {
       expect(browserHistory.push).toHaveBeenCalledWith('BASE_URL/merged/');
 
       await userEvent.click(screen.getByRole('tab', {name: /replays/i}));
-      expect(browserHistory.push).toHaveBeenCalledWith('BASE_URL/replays/');
+      expect(browserHistory.push).toHaveBeenCalledWith({
+        pathname: 'BASE_URL/replays/',
+        query: {},
+      });
 
       expect(screen.queryByRole('tab', {name: /replays/i})).toBeInTheDocument();
     });

--- a/static/app/views/issueDetails/header.spec.tsx
+++ b/static/app/views/issueDetails/header.spec.tsx
@@ -58,16 +58,28 @@ describe('GroupHeader', () => {
       expect(browserHistory.push).toHaveBeenLastCalledWith('BASE_URL/');
 
       await userEvent.click(screen.getByRole('tab', {name: /activity/i}));
-      expect(browserHistory.push).toHaveBeenCalledWith('BASE_URL/activity/');
+      expect(browserHistory.push).toHaveBeenCalledWith({
+        pathname: 'BASE_URL/activity/',
+        query: {},
+      });
 
       await userEvent.click(screen.getByRole('tab', {name: /user feedback/i}));
-      expect(browserHistory.push).toHaveBeenCalledWith('BASE_URL/feedback/');
+      expect(browserHistory.push).toHaveBeenCalledWith({
+        pathname: 'BASE_URL/feedback/',
+        query: {},
+      });
 
       await userEvent.click(screen.getByRole('tab', {name: /attachments/i}));
-      expect(browserHistory.push).toHaveBeenCalledWith('BASE_URL/attachments/');
+      expect(browserHistory.push).toHaveBeenCalledWith({
+        pathname: 'BASE_URL/attachments/',
+        query: {},
+      });
 
       await userEvent.click(screen.getByRole('tab', {name: /tags/i}));
-      expect(browserHistory.push).toHaveBeenCalledWith('BASE_URL/tags/');
+      expect(browserHistory.push).toHaveBeenCalledWith({
+        pathname: 'BASE_URL/tags/',
+        query: {},
+      });
 
       await userEvent.click(screen.getByRole('tab', {name: /all events/i}));
       expect(browserHistory.push).toHaveBeenCalledWith({
@@ -76,7 +88,10 @@ describe('GroupHeader', () => {
       });
 
       await userEvent.click(screen.getByRole('tab', {name: /merged issues/i}));
-      expect(browserHistory.push).toHaveBeenCalledWith('BASE_URL/merged/');
+      expect(browserHistory.push).toHaveBeenCalledWith({
+        pathname: 'BASE_URL/merged/',
+        query: {},
+      });
 
       await userEvent.click(screen.getByRole('tab', {name: /replays/i}));
       expect(browserHistory.push).toHaveBeenCalledWith({
@@ -126,7 +141,10 @@ describe('GroupHeader', () => {
       );
 
       await userEvent.click(screen.getByRole('tab', {name: /similar issues/i}));
-      expect(browserHistory.push).toHaveBeenCalledWith('BASE_URL/similar/');
+      expect(browserHistory.push).toHaveBeenCalledWith({
+        pathname: 'BASE_URL/similar/',
+        query: {},
+      });
 
       expect(screen.queryByRole('tab', {name: /replays/i})).not.toBeInTheDocument();
     });
@@ -173,7 +191,10 @@ describe('GroupHeader', () => {
       expect(browserHistory.push).toHaveBeenLastCalledWith('BASE_URL/');
 
       await userEvent.click(screen.getByRole('tab', {name: /tags/i}));
-      expect(browserHistory.push).toHaveBeenCalledWith('BASE_URL/tags/');
+      expect(browserHistory.push).toHaveBeenCalledWith({
+        pathname: 'BASE_URL/tags/',
+        query: {},
+      });
 
       await userEvent.click(screen.getByRole('tab', {name: /sampled events/i}));
       expect(browserHistory.push).toHaveBeenCalledWith({

--- a/static/app/views/issueDetails/header.tsx
+++ b/static/app/views/issueDetails/header.tsx
@@ -47,7 +47,6 @@ type Props = {
 interface GroupHeaderTabsProps extends Pick<Props, 'baseUrl' | 'group' | 'project'> {
   disabledTabs: Tab[];
   eventRoute: LocationDescriptor;
-  replayRoute: LocationDescriptor;
 }
 
 function GroupHeaderTabs({
@@ -56,14 +55,15 @@ function GroupHeaderTabs({
   eventRoute,
   group,
   project,
-  replayRoute,
 }: GroupHeaderTabsProps) {
   const organization = useOrganization();
+  const location = useLocation();
 
   const {getReplayCountForIssue} = useReplayCountForIssues({
     statsPeriod: '90d',
   });
   const replaysCount = getReplayCountForIssue(group.id, group.issueCategory);
+  const queryParams = omit(location.query, ['sort']);
 
   const projectFeatures = new Set(project ? project.features : []);
   const organizationFeatures = new Set(organization ? organization.features : []);
@@ -93,7 +93,7 @@ function GroupHeaderTabs({
         key={Tab.ACTIVITY}
         textValue={t('Activity')}
         disabled={disabledTabs.includes(Tab.ACTIVITY)}
-        to={`${baseUrl}activity/${location.search}`}
+        to={{pathname: `${baseUrl}activity/`, query: queryParams}}
       >
         {t('Activity')}
         <IconBadge>
@@ -106,7 +106,7 @@ function GroupHeaderTabs({
         textValue={t('User Feedback')}
         hidden={!issueTypeConfig.userFeedback.enabled}
         disabled={disabledTabs.includes(Tab.USER_FEEDBACK)}
-        to={`${baseUrl}feedback/${location.search}`}
+        to={{pathname: `${baseUrl}feedback/`, query: queryParams}}
       >
         {t('User Feedback')} <Badge text={group.userReportCount} />
       </TabList.Item>
@@ -114,7 +114,7 @@ function GroupHeaderTabs({
         key={Tab.ATTACHMENTS}
         hidden={!hasEventAttachments || !issueTypeConfig.attachments.enabled}
         disabled={disabledTabs.includes(Tab.ATTACHMENTS)}
-        to={`${baseUrl}attachments/${location.search}`}
+        to={{pathname: `${baseUrl}attachments/`, query: queryParams}}
       >
         {t('Attachments')}
       </TabList.Item>
@@ -122,7 +122,7 @@ function GroupHeaderTabs({
         key={Tab.TAGS}
         hidden={!issueTypeConfig.tags.enabled}
         disabled={disabledTabs.includes(Tab.TAGS)}
-        to={`${baseUrl}tags/${location.search}`}
+        to={{pathname: `${baseUrl}tags/`, query: queryParams}}
       >
         {t('Tags')}
       </TabList.Item>
@@ -140,7 +140,7 @@ function GroupHeaderTabs({
         key={Tab.MERGED}
         hidden={!issueTypeConfig.mergedIssues.enabled}
         disabled={disabledTabs.includes(Tab.MERGED)}
-        to={`${baseUrl}merged/${location.search}`}
+        to={{pathname: `${baseUrl}merged/`, query: queryParams}}
       >
         {t('Merged Issues')}
       </TabList.Item>
@@ -148,7 +148,7 @@ function GroupHeaderTabs({
         key={Tab.SIMILAR_ISSUES}
         hidden={!hasSimilarView || !issueTypeConfig.similarIssues.enabled}
         disabled={disabledTabs.includes(Tab.SIMILAR_ISSUES)}
-        to={`${baseUrl}similar/${location.search}`}
+        to={{pathname: `${baseUrl}similar/`, query: queryParams}}
       >
         {t('Similar Issues')}
       </TabList.Item>
@@ -156,7 +156,7 @@ function GroupHeaderTabs({
         key={Tab.REPLAYS}
         textValue={t('Replays')}
         hidden={!hasReplaySupport || !issueTypeConfig.replays.enabled}
-        to={replayRoute}
+        to={{pathname: `${baseUrl}replays/`, query: queryParams}}
       >
         {t('Replays')}
         <ReplayCountBadge count={replaysCount} />
@@ -208,14 +208,6 @@ function GroupHeader({
     return {
       pathname: `${baseUrl}events/`,
       query: searchTermWithoutQuery,
-    };
-  }, [location, baseUrl]);
-
-  const replayRoute = useMemo(() => {
-    const searchTermWithoutSort = omit(location.query, ['sort']);
-    return {
-      pathname: `${baseUrl}replays/`,
-      query: searchTermWithoutSort,
     };
   }, [location, baseUrl]);
 
@@ -325,9 +317,7 @@ function GroupHeader({
         <HeaderRow className="hidden-sm hidden-md hidden-lg">
           <EnvironmentPageFilter position="bottom-end" />
         </HeaderRow>
-        <GroupHeaderTabs
-          {...{baseUrl, disabledTabs, eventRoute, group, project, replayRoute}}
-        />
+        <GroupHeaderTabs {...{baseUrl, disabledTabs, eventRoute, group, project}} />
       </div>
     </Layout.Header>
   );

--- a/static/app/views/issueDetails/header.tsx
+++ b/static/app/views/issueDetails/header.tsx
@@ -47,6 +47,7 @@ type Props = {
 interface GroupHeaderTabsProps extends Pick<Props, 'baseUrl' | 'group' | 'project'> {
   disabledTabs: Tab[];
   eventRoute: LocationDescriptor;
+  replayRoute: LocationDescriptor;
 }
 
 function GroupHeaderTabs({
@@ -55,6 +56,7 @@ function GroupHeaderTabs({
   eventRoute,
   group,
   project,
+  replayRoute,
 }: GroupHeaderTabsProps) {
   const organization = useOrganization();
 
@@ -154,7 +156,7 @@ function GroupHeaderTabs({
         key={Tab.REPLAYS}
         textValue={t('Replays')}
         hidden={!hasReplaySupport || !issueTypeConfig.replays.enabled}
-        to={`${baseUrl}replays/${location.search}`}
+        to={replayRoute}
       >
         {t('Replays')}
         <ReplayCountBadge count={replaysCount} />
@@ -206,6 +208,14 @@ function GroupHeader({
     return {
       pathname: `${baseUrl}events/`,
       query: searchTermWithoutQuery,
+    };
+  }, [location, baseUrl]);
+
+  const replayRoute = useMemo(() => {
+    const searchTermWithoutSort = omit(location.query, ['sort']);
+    return {
+      pathname: `${baseUrl}replays/`,
+      query: searchTermWithoutSort,
     };
   }, [location, baseUrl]);
 
@@ -315,7 +325,9 @@ function GroupHeader({
         <HeaderRow className="hidden-sm hidden-md hidden-lg">
           <EnvironmentPageFilter position="bottom-end" />
         </HeaderRow>
-        <GroupHeaderTabs {...{baseUrl, disabledTabs, eventRoute, group, project}} />
+        <GroupHeaderTabs
+          {...{baseUrl, disabledTabs, eventRoute, group, project, replayRoute}}
+        />
       </div>
     </Layout.Header>
   );

--- a/static/app/views/issueDetails/header.tsx
+++ b/static/app/views/issueDetails/header.tsx
@@ -63,6 +63,9 @@ function GroupHeaderTabs({
     statsPeriod: '90d',
   });
   const replaysCount = getReplayCountForIssue(group.id, group.issueCategory);
+
+  // omit `sort` param from the URLs because it persists from the issues list,
+  // which can cause the tab content rendering to break
   const queryParams = omit(location.query, ['sort']);
 
   const projectFeatures = new Set(project ? project.features : []);


### PR DESCRIPTION
Persisting the `sort` param from the issue list to issue details sometimes causes the replay tab table to break, since some of the issue list sort params like `users` and `trends` don't apply to the replay table. This PR removes the `sort` param from the URL once we click into the replay tab, to prevent this.

Before:

https://github.com/getsentry/sentry/assets/56095982/1f1831ec-57e1-4216-b223-11f4f6863249


After:

https://github.com/getsentry/sentry/assets/56095982/17e3b427-1576-4b64-b30c-34400393ddc9

closes https://github.com/getsentry/sentry/issues/72617

Also made the change to remove the `sort` param from every tab on the issue details (see @aliu39's comment below). 
