### PR TITLE
feat(crons): Differentiate processing errors from differing projects

### DIFF
--- a/static/app/views/monitors/components/processingErrors/monitorProcessingErrors.spec.tsx
+++ b/static/app/views/monitors/components/processingErrors/monitorProcessingErrors.spec.tsx
@@ -1,0 +1,72 @@
+// import {initializeOrg} from 'sentry-test/initializeOrg';
+import {CheckinProcessingErrorFixture} from 'sentry-fixture/checkinProcessingError';
+
+import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+
+import MonitorProcessingErrors from 'sentry/views/monitors/components/processingErrors/monitorProcessingErrors';
+
+describe('MonitorProcessingErrors', () => {
+  it('should group errors by type', async () => {
+    const checkinErrors = [
+      CheckinProcessingErrorFixture(),
+      CheckinProcessingErrorFixture(),
+      CheckinProcessingErrorFixture({errors: [{type: 1}, {type: 6}]}),
+      CheckinProcessingErrorFixture({errors: [{type: 6}]}),
+    ];
+
+    const children =
+      'Errors were encountered while ingesting check-ins for the selected projects';
+    render(
+      <MonitorProcessingErrors checkinErrors={checkinErrors}>
+        {children}
+      </MonitorProcessingErrors>
+    );
+
+    expect(screen.getByText(children)).toBeInTheDocument();
+    await userEvent.click(screen.getByText(children));
+
+    // Shows two different groups from a flattened list of errors
+    expect(screen.getByText('3x')).toBeInTheDocument();
+    expect(screen.getByText('Check-in already completed')).toBeInTheDocument();
+    expect(screen.getByText('2x')).toBeInTheDocument();
+    expect(screen.getByText('Monitor disabled')).toBeInTheDocument();
+  });
+
+  it('should group errors by project and type', async () => {
+    const {checkin: otherProjectCheckin} = CheckinProcessingErrorFixture();
+    otherProjectCheckin.message.project_id = 2;
+
+    const checkinErrors = [
+      CheckinProcessingErrorFixture(),
+      CheckinProcessingErrorFixture(),
+      CheckinProcessingErrorFixture({errors: [{type: 1}, {type: 6}]}),
+      CheckinProcessingErrorFixture({errors: [{type: 6}]}),
+      CheckinProcessingErrorFixture({checkin: otherProjectCheckin}),
+      CheckinProcessingErrorFixture({checkin: otherProjectCheckin}),
+      CheckinProcessingErrorFixture({checkin: otherProjectCheckin, errors: [{type: 6}]}),
+      CheckinProcessingErrorFixture({
+        checkin: otherProjectCheckin,
+        errors: [{type: 1}, {type: 6}],
+      }),
+    ];
+
+    const children =
+      'Errors were encountered while ingesting check-ins for the selected projects';
+    render(
+      <MonitorProcessingErrors checkinErrors={checkinErrors}>
+        {children}
+      </MonitorProcessingErrors>
+    );
+
+    expect(screen.getByText(children)).toBeInTheDocument();
+    await userEvent.click(screen.getByText(children));
+
+    // Shows two different groups from a flattened list of errors under two different projects
+    expect(screen.getByText('Project 1')).toBeInTheDocument();
+    expect(screen.getByText('Project 2')).toBeInTheDocument();
+    expect(screen.getAllByText('3x')).toHaveLength(2);
+    expect(screen.getAllByText('Check-in already completed')).toHaveLength(2);
+    expect(screen.getAllByText('2x')).toHaveLength(2);
+    expect(screen.getAllByText('Monitor disabled')).toHaveLength(2);
+  });
+});


### PR DESCRIPTION
When looking at the cron processing errors we currently only group checkin-errors by type, but we should also differentiate by project. If there are errors from multiple different projects we will show a view that looks like this: (otherwise we will not show project information)

After:
<img width="1247" alt="Screenshot 2024-06-12 at 10 50 07 AM" src="https://github.com/getsentry/sentry/assets/9372512/47f2f828-3330-4a05-80f2-88e8c933d139">

Before:
<img width="1243" alt="image" src="https://github.com/getsentry/sentry/assets/9372512/6761e4ab-faa2-426d-ae3f-b8650b9bf50e">


