### PR TITLE
chore(features) Remove checks for org-subdomains

### DIFF
--- a/src/sentry/apidocs/examples/project_examples.py
+++ b/src/sentry/apidocs/examples/project_examples.py
@@ -177,7 +177,6 @@ DETAILED_PROJECT = {
         "features": [
             "performance-uncompressed-assets-ingest",
             "dashboards-rh-widget",
-            "org-subdomains",
             "performance-db-main-thread-visible",
             "transaction-name-mark-scrubbed-as-sanitized",
             "sentry-pride-logo-footer",

--- a/src/sentry/features/permanent.py
+++ b/src/sentry/features/permanent.py
@@ -105,10 +105,6 @@ def register_permanent_features(manager: FeatureManager):
         "organizations:frontend-domainsplit": False,
         # Prefix host with organization ID when giving users DSNs (can be
         # customized with SENTRY_ORG_SUBDOMAIN_TEMPLATE) eg. o123.ingest.us.sentry.io
-        # Deprecated - use org-ingest-subdomain instead.
-        "organizations:org-subdomains": False,
-        # Prefix host with organization ID when giving users DSNs (can be
-        # customized with SENTRY_ORG_SUBDOMAIN_TEMPLATE) eg. o123.ingest.us.sentry.io
         "organizations:org-ingest-subdomains": False,
     }
 

--- a/src/sentry/models/projectkey.py
+++ b/src/sentry/models/projectkey.py
@@ -289,8 +289,8 @@ class ProjectKey(Model):
         has_org_subdomain = False
         try:
             has_org_subdomain = features.has(
-                "organizations:org-subdomains", self.project.organization
-            ) or features.has("organizations:org-ingest-subdomains", self.project.organization)
+                "organizations:org-ingest-subdomains", self.project.organization
+            )
         except ProgrammingError:
             # This happens during migration generation for the organization model.
             pass

--- a/tests/sentry/models/test_projectkey.py
+++ b/tests/sentry/models/test_projectkey.py
@@ -110,7 +110,7 @@ class ProjectKeyTest(TestCase):
             assert key.js_sdk_loader_cdn_url == "http://testserver/js-sdk-loader/abc.min.js"
 
     def test_get_dsn_org_subdomain(self):
-        with self.feature("organizations:org-subdomains"), self.options(
+        with self.feature("organizations:org-ingest-subdomains"), self.options(
             {"system.region-api-url-template": ""}
         ):
             key = self.model(project_id=self.project.id, public_key="abc", secret_key="xyz")
@@ -151,14 +151,6 @@ class ProjectKeyTest(TestCase):
 
     @override_settings(SENTRY_REGION="us")
     def test_get_dsn_org_subdomain_and_multiregion(self):
-        # Ensure compatibility with old flag.
-        with self.feature("organizations:org-subdomains"):
-            key = self.model(project_id=self.project.id, public_key="abc", secret_key="xyz")
-            host = f"o{key.project.organization_id}.ingest." + (
-                "us.testserver" if SiloMode.get_current_mode() == SiloMode.REGION else "testserver"
-            )
-            assert key.dsn_private == f"http://abc:xyz@{host}/{self.project.id}"
-
         with self.feature("organizations:org-ingest-subdomains"):
             key = self.model(project_id=self.project.id, public_key="abc", secret_key="xyz")
             host = f"o{key.project.organization_id}.ingest." + (


### PR DESCRIPTION
We'll be using org-ingest-subdomains going forward.

Related to getsentry/sentry#72530