### PR TITLE
fix(bar-charts): Set opacity to 1 on metrics bar chart 

### DIFF
--- a/static/app/components/charts/barChart.tsx
+++ b/static/app/components/charts/barChart.tsx
@@ -20,7 +20,7 @@ export interface BarChartProps extends BaseChartProps {
 }
 
 export function transformToBarSeries({
-  barOpacity = 0.6,
+  barOpacity = 1,
   series,
   stacked,
   hideZeros = false,


### PR DESCRIPTION
Changes the default opacity for bar bar charts from 0.6 to 1. 

Example Before:
![image](https://github.com/getsentry/sentry/assets/55160142/01cef577-84ce-4e6d-b139-55397f88d7b5)

Example After:
![image](https://github.com/getsentry/sentry/assets/55160142/b7d694e8-8c7d-4c68-a465-d20ca35abdc9)

After some investigation, I realized I mistakenly thought that the opacity from `<MiniBarChart/>` was the default opacity for all bar charts when making changes to the events graph in this [PR](https://github.com/getsentry/sentry/pull/71130/files#diff-c4d47f3c3a5e2da4ead0e4925c071df5fbfff0287d49c009b00bb04b5974d758). 