### PR TITLE
fix(issue-stream): Send correct request on first load when query is an empty string

### DIFF
--- a/static/app/views/issueList/overview.tsx
+++ b/static/app/views/issueList/overview.tsx
@@ -628,7 +628,7 @@ class IssueListOverview extends Component<Props, State> {
     if (
       this.props.organization.features.includes('issue-stream-performance') &&
       this.props.savedSearchLoading &&
-      !this.props.location.query.query
+      !defined(this.props.location.query.query)
     ) {
       delete requestParams.query;
     }


### PR DESCRIPTION
If you have an empty query string in the URL, this check was deleting it form the query params, which is incorrect and led to querying the wrong issues in some cases.

