### PR TITLE
fix(insights): remove hardcoded searchsource in sample panel

### DIFF
--- a/static/app/views/performance/mobile/components/spanSamplesPanelContainer.tsx
+++ b/static/app/views/performance/mobile/components/spanSamplesPanelContainer.tsx
@@ -196,7 +196,7 @@ export function SpanSamplesContainer({
 
       <Feature features="performance-sample-panel-search">
         <StyledSearchBar
-          searchSource="queries-sample-panel"
+          searchSource={`${moduleName}-sample-panel`}
           query={searchQuery}
           onSearch={handleSearch}
           placeholder={t('Search for span attributes')}


### PR DESCRIPTION
Remove an accidentally hardcoded search source in the mobile sample panels.