### PR TITLE
chore(seer grouping): Increase `did_call_seer` metric sample rate

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -1522,6 +1522,9 @@ def _save_aggregate(
 
                         metrics.incr(
                             "grouping.similarity.did_call_seer",
+                            # TODO: Consider lowering this (in all the spots this metric is
+                            # collected) once we roll Seer grouping out more widely
+                            sample_rate=1.0,
                             tags={"call_made": True, "blocker": "none"},
                         )
 
@@ -1533,6 +1536,7 @@ def _save_aggregate(
                         # (also below)? Right now they just fall into the `new_group` bucket.
                         metrics.incr(
                             "grouping.similarity.did_call_seer",
+                            sample_rate=1.0,
                             tags={"call_made": False, "blocker": "circuit-breaker"},
                         )
 
@@ -1540,6 +1544,7 @@ def _save_aggregate(
                     except Exception as e:
                         metrics.incr(
                             "grouping.similarity.did_call_seer",
+                            sample_rate=1.0,
                             tags={"call_made": True, "blocker": "none"},
                         )
                         sentry_sdk.capture_exception(

--- a/src/sentry/grouping/ingest/seer.py
+++ b/src/sentry/grouping/ingest/seer.py
@@ -74,6 +74,7 @@ def _has_customized_fingerprint(event: Event, primary_hashes: CalculatedHashes) 
         else:
             metrics.incr(
                 "grouping.similarity.did_call_seer",
+                sample_rate=1.0,
                 tags={"call_made": False, "blocker": "hybrid-fingerprint"},
             )
             return True
@@ -86,6 +87,7 @@ def _has_customized_fingerprint(event: Event, primary_hashes: CalculatedHashes) 
     if fingerprint_variant:
         metrics.incr(
             "grouping.similarity.did_call_seer",
+            sample_rate=1.0,
             tags={"call_made": False, "blocker": fingerprint_variant.type},
         )
         return True
@@ -108,6 +110,7 @@ def _killswitch_enabled(event: Event, project: Project) -> bool:
         metrics.incr("grouping.similarity.seer_global_killswitch_enabled")
         metrics.incr(
             "grouping.similarity.did_call_seer",
+            sample_rate=1.0,
             tags={"call_made": False, "blocker": "global-killswitch"},
         )
         return True
@@ -120,6 +123,7 @@ def _killswitch_enabled(event: Event, project: Project) -> bool:
         metrics.incr("grouping.similarity.seer_similarity_killswitch_enabled")
         metrics.incr(
             "grouping.similarity.did_call_seer",
+            sample_rate=1.0,
             tags={"call_made": False, "blocker": "similarity-killswitch"},
         )
         return True
@@ -150,6 +154,7 @@ def _ratelimiting_enabled(event: Event, project: Project) -> bool:
         )
         metrics.incr(
             "grouping.similarity.did_call_seer",
+            sample_rate=1.0,
             tags={"call_made": False, "blocker": "global-rate-limit"},
         )
 
@@ -167,6 +172,7 @@ def _ratelimiting_enabled(event: Event, project: Project) -> bool:
         )
         metrics.incr(
             "grouping.similarity.did_call_seer",
+            sample_rate=1.0,
             tags={"call_made": False, "blocker": "project-rate-limit"},
         )
 


### PR DESCRIPTION
In our initial testing/rollout phase, we don't try to call Seer during ingest often enough for the default 10% metrics sample rate to net us enough data to make the `grouping.similarity.did_call_seer` metric useful. This therefore ups the sample rate to 100% (for now; there's a TODO to revisit this later). 