### PR TITLE
chore(grouping): Remove unused `grouping-tree-ui` flag

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1437,7 +1437,6 @@ SENTRY_EARLY_FEATURES = {
     "organizations:gitlab-disable-on-broken": "Enable disabling gitlab integrations when broken is detected",
     "organizations:grouping-stacktrace-ui": "Enable experimental new version of stacktrace component where additional data related to grouping is shown on each frame",
     "organizations:grouping-title-ui": "Enable tweaks to group title in relation to hierarchical grouping.",
-    "organizations:grouping-tree-ui": "Enable experimental new version of Merged Issues where sub-hashes are shown",
     "organizations:issue-details-tag-improvements": "Enable tag improvements in the issue details page",
     "organizations:mobile-cpu-memory-in-transactions": "Display CPU and memory metrics in transactions with profiles",
     "organizations:performance-metrics-backed-transaction-summary": "Enable metrics-backed transaction summary view",

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -117,8 +117,6 @@ def register_temporary_features(manager: FeatureManager):
     manager.add("organizations:grouping-suppress-unnecessary-secondary-hash", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
     # Enable tweaks to group title in relation to hierarchical grouping.
     manager.add("organizations:grouping-title-ui", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
-    # Enable experimental new version of Merged Issues where sub-hashes are shown
-    manager.add("organizations:grouping-tree-ui", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
     # Allows an org to have a larger set of project ownership rules per project
     manager.add("organizations:higher-ownership-limit", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
     # Enable increased issue_owners rate limit for auto-assignment

--- a/tests/sentry/api/endpoints/test_project_grouping_configs.py
+++ b/tests/sentry/api/endpoints/test_project_grouping_configs.py
@@ -1,11 +1,8 @@
-from unittest import mock
-
 from django.urls import reverse
 
 from sentry.models.apitoken import ApiToken
 from sentry.silo.base import SiloMode
 from sentry.testutils.cases import APITestCase
-from sentry.testutils.helpers import with_feature
 from sentry.testutils.silo import assume_test_silo_mode
 
 
@@ -20,26 +17,3 @@ class ProjectGroupingConfigsPermissionsTest(APITestCase):
         response = self.client.get(url, HTTP_AUTHORIZATION=f"Bearer {token.token}", format="json")
 
         assert response.status_code == 403
-
-
-class ProjectGroupingConfigsTest(APITestCase):
-
-    endpoint = "sentry-api-0-project-grouping-configs"
-
-    def setUp(self):
-        super().setUp()
-        self.login_as(user=self.user)
-
-    @with_feature({"organizations:grouping-tree-ui": False})
-    @mock.patch("sentry.grouping.strategies.base.projectoptions.LATEST_EPOCH", 7)
-    def test_feature_flag_off(self):
-        response = self.get_success_response(self.project.organization.slug, self.project.slug)
-        for config in response.data:
-            assert config["latest"] == (config["id"] == "newstyle:2023-01-11")
-
-    @with_feature({"organizations:grouping-tree-ui": True})
-    @mock.patch("sentry.grouping.strategies.base.projectoptions.LATEST_EPOCH", 7)
-    def test_feature_flag_on(self):
-        response = self.get_success_response(self.project.organization.slug, self.project.slug)
-        for config in response.data:
-            assert config["latest"] == (config["id"] == "newstyle:2023-01-11")

--- a/tests/sentry/api/endpoints/test_project_grouping_configs.py
+++ b/tests/sentry/api/endpoints/test_project_grouping_configs.py
@@ -6,7 +6,7 @@ from sentry.testutils.cases import APITestCase
 from sentry.testutils.silo import assume_test_silo_mode
 
 
-class ProjectGroupingConfigsPermissionsTest(APITestCase):
+class ProjectGroupingConfigsTest(APITestCase):
 
     endpoint = "sentry-api-0-project-grouping-configs"
 


### PR DESCRIPTION
This removes the unused `grouping-tree-ui` flag, along with the tests testing its effect (which is none, as evidenced by the fact that the flag-on and flag-off tests contain identical code).