### PR TITLE
feat(span-summary): Add search bar for filtering indexed spans

### DIFF
--- a/static/app/views/performance/transactionSummary/transactionSpans/spanSummary/content.spec.tsx
+++ b/static/app/views/performance/transactionSummary/transactionSpans/spanSummary/content.spec.tsx
@@ -219,6 +219,11 @@ describe('SpanSummaryPage', function () {
   });
 
   it('correctly renders the details in the header', async function () {
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/spans/fields/',
+      body: [],
+    });
+
     headerDataMock = MockApiClient.addMockResponse({
       url: '/organizations/org-slug/events/',
       body: {
@@ -277,6 +282,11 @@ describe('SpanSummaryPage', function () {
   });
 
   it('renders the charts', async () => {
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/spans/fields/',
+      body: [],
+    });
+
     render(
       <SpanSummary
         spanSlug={{group: 'aaaaaaaa', op: 'db'}}

--- a/static/app/views/performance/transactionSummary/transactionSpans/spanSummary/spanSummaryTable.tsx
+++ b/static/app/views/performance/transactionSummary/transactionSpans/spanSummary/spanSummaryTable.tsx
@@ -3,6 +3,7 @@ import {browserHistory} from 'react-router';
 import styled from '@emotion/styled';
 import type {Location} from 'history';
 
+import SearchBar from 'sentry/components/events/searchBar';
 import type {GridColumnHeader} from 'sentry/components/gridEditable';
 import GridEditable, {COL_WIDTH_UNDEFINED} from 'sentry/components/gridEditable';
 import Pagination, {type CursorHandler} from 'sentry/components/pagination';
@@ -21,15 +22,18 @@ import {
   type DiscoverQueryProps,
   useGenericDiscoverQuery,
 } from 'sentry/utils/discover/genericDiscoverQuery';
+import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import {VisuallyCompleteWithData} from 'sentry/utils/performanceForSentry';
 import {decodeScalar} from 'sentry/utils/queryString';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {useLocation} from 'sentry/utils/useLocation';
+import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
 import {useParams} from 'sentry/utils/useParams';
 import {SpanDurationBar} from 'sentry/views/performance/transactionSummary/transactionSpans/spanDetails/spanDetailsTable';
 import {SpanSummaryReferrer} from 'sentry/views/performance/transactionSummary/transactionSpans/spanSummary/referrers';
 import {useSpanSummarySort} from 'sentry/views/performance/transactionSummary/transactionSpans/spanSummary/useSpanSummarySort';
+import {useSpanFieldSupportedTags} from 'sentry/views/performance/utils/useSpanFieldSupportedTags';
 import {renderHeadCell} from 'sentry/views/starfish/components/tableCells/renderHeadCell';
 import {SpanIdCell} from 'sentry/views/starfish/components/tableCells/spanIdCell';
 import {useSpansIndexed} from 'sentry/views/starfish/queries/useDiscover';
@@ -94,12 +98,15 @@ type Props = {
 export default function SpanSummaryTable(props: Props) {
   const {project} = props;
   const organization = useOrganization();
+  const supportedTags = useSpanFieldSupportedTags();
   const {spanSlug} = useParams();
+  const navigate = useNavigate();
   const [spanOp, groupId] = spanSlug.split(':');
 
   const location = useLocation();
   const {transaction} = location.query;
   const spansCursor = decodeScalar(location.query?.[QueryParameterNames.SPANS_CURSOR]);
+  const spansQuery = decodeScalar(location.query.spansQuery);
 
   const filters: SpanMetricsQueryFilters = {
     'span.group': groupId,
@@ -108,6 +115,9 @@ export default function SpanSummaryTable(props: Props) {
   };
 
   const sort = useSpanSummarySort();
+  const spanSearchString = new MutableSearch(spansQuery ?? '').formatString();
+  const search = MutableSearch.fromQueryObject(filters);
+  search.addStringMultiFilter(spanSearchString);
 
   const {
     data: rowData,
@@ -123,7 +133,7 @@ export default function SpanSummaryTable(props: Props) {
         SpanIndexedField.TRACE,
         SpanIndexedField.PROJECT,
       ],
-      search: MutableSearch.fromQueryObject(filters),
+      search,
       limit: LIMIT,
       sorts: [sort],
       cursor: spansCursor,
@@ -196,8 +206,28 @@ export default function SpanSummaryTable(props: Props) {
     });
   };
 
+  const handleSearch = (searchString: string) => {
+    navigate({
+      ...location,
+      query: {
+        ...location.query,
+        spansQuery: new MutableSearch(searchString).formatString(),
+      },
+    });
+  };
+
   return (
     <Fragment>
+      <StyledSearchBar
+        organization={organization}
+        projectIds={eventView.project}
+        query={spansQuery}
+        fields={eventView.fields}
+        placeholder={t('Search for span attributes')}
+        supportedTags={supportedTags}
+        dataset={DiscoverDatasets.SPANS_INDEXED}
+        onSearch={handleSearch}
+      />
       <VisuallyCompleteWithData
         id="SpanDetails-SpanDetailsTable"
         hasData={!!mergedData?.length}
@@ -311,4 +341,8 @@ const EmptySpanDurationBar = styled('div')`
   font-size: ${p => p.theme.fontSizeExtraSmall};
   font-variant-numeric: tabular-nums;
   line-height: 1;
+`;
+
+const StyledSearchBar = styled(SearchBar)`
+  margin-bottom: ${space(2)};
 `;


### PR DESCRIPTION
Adds the smart searchbar to the new span summary page for filtering the list of sample spans. Note that this only affects the table and not the data displayed in the charts

![image](https://github.com/getsentry/sentry/assets/16740047/5b6eee0e-76c5-4838-a2c3-4c149bdaaa51)
