### PR TITLE
chore(slack): remove old slack client code for issue alerts

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -391,8 +391,6 @@ def register_temporary_features(manager: FeatureManager):
     # Enable improvements to Slack notifications
     manager.add("organizations:slack-improvements", OrganizationFeature, FeatureHandlerStrategy.OPTIONS)
     # Feature flags for migrating to the Slack SDK WebClient
-    # SlackNotifyServiceAction
-    manager.add("organizations:slack-sdk-issue-alert-action", OrganizationFeature, FeatureHandlerStrategy.OPTIONS)
     # Use new Slack SDK Client for sending activity messages in threads
     manager.add("organizations:slack-sdk-activity-threads", OrganizationFeature, FeatureHandlerStrategy.OPTIONS)
     # Use new Slack SDK Client for sending metric alerts

--- a/src/sentry/integrations/slack/actions/notification.py
+++ b/src/sentry/integrations/slack/actions/notification.py
@@ -173,11 +173,7 @@ class SlackNotifyServiceAction(IntegrationEventAction):
                 metrics.incr(
                     SLACK_ISSUE_ALERT_SUCCESS_DATADOG_METRIC,
                     sample_rate=1.0,
-                    tags={
-                        "action": "send_notification",
-                        "ok": response.get("ok", False),
-                        "status": response.status_code,
-                    },
+                    tags={"action": "send_notification"},
                 )
             except SlackApiError as e:
                 # Record the error code and details from the exception
@@ -212,9 +208,6 @@ class SlackNotifyServiceAction(IntegrationEventAction):
                 )
             else:
                 ts = response.get("ts")
-
-                self.logger.info("slack.issue_alert.ts", extra={"ts": ts})
-
                 new_notification_message_object.message_identifier = (
                     str(ts) if ts is not None else None
                 )
@@ -259,7 +252,7 @@ class SlackNotifyServiceAction(IntegrationEventAction):
         client = SlackSdkClient(integration_id=integration.id)
 
         try:
-            response = client.chat_postMessage(
+            client.chat_postMessage(
                 blocks=json_blocks,
                 text=blocks.get("text"),
                 channel=channel,
@@ -269,11 +262,7 @@ class SlackNotifyServiceAction(IntegrationEventAction):
             metrics.incr(
                 SLACK_ISSUE_ALERT_SUCCESS_DATADOG_METRIC,
                 sample_rate=1.0,
-                tags={
-                    "action": "send_confirmation",
-                    "ok": response.get("ok", False),
-                    "status": response.status_code,
-                },
+                tags={"action": "send_confirmation"},
             )
         except SlackApiError as e:
             log_params = {

--- a/src/sentry/integrations/slack/actions/notification.py
+++ b/src/sentry/integrations/slack/actions/notification.py
@@ -7,7 +7,6 @@ from typing import Any
 import orjson
 from slack_sdk.errors import SlackApiError
 
-from sentry import features
 from sentry.api.serializers.rest_framework.rule import ACTION_UUID_KEY
 from sentry.constants import ISSUE_ALERTS_THREAD_DEFAULT
 from sentry.eventstore.models import GroupEvent
@@ -158,8 +157,6 @@ class SlackNotifyServiceAction(IntegrationEventAction):
                     thread_ts = parent_notification_message.message_identifier
                     # If this flow is triggered again for the same issue, we want it to be seen in the main channel
                     reply_broadcast = True
-
-            organization = event.group.project.organization
 
             client = SlackSdkClient(integration_id=integration.id)
             text = str(blocks.get("text"))

--- a/src/sentry/integrations/slack/actions/notification.py
+++ b/src/sentry/integrations/slack/actions/notification.py
@@ -18,10 +18,13 @@ from sentry.integrations.repository.issue_alert import (
     NewIssueAlertNotificationMessage,
 )
 from sentry.integrations.slack.actions.form import SlackNotifyServiceForm
-from sentry.integrations.slack.client import SlackClient
 from sentry.integrations.slack.message_builder.issues import SlackIssuesMessageBuilder
 from sentry.integrations.slack.message_builder.notifications.rule_save_edit import (
     SlackRuleSaveEditMessageBuilder,
+)
+from sentry.integrations.slack.metrics import (
+    SLACK_ISSUE_ALERT_FAILURE_DATADOG_METRIC,
+    SLACK_ISSUE_ALERT_SUCCESS_DATADOG_METRIC,
 )
 from sentry.integrations.slack.sdk_client import SlackSdkClient
 from sentry.integrations.slack.utils import get_channel_id
@@ -32,8 +35,6 @@ from sentry.notifications.additional_attachment_manager import get_additional_at
 from sentry.rules.actions import IntegrationEventAction
 from sentry.rules.base import CallbackFuture
 from sentry.services.hybrid_cloud.integration import RpcIntegration
-from sentry.shared_integrations.exceptions import ApiError
-from sentry.shared_integrations.response import BaseApiResponse, MappingApiResponse
 from sentry.types.rules import RuleFuture
 from sentry.utils import metrics
 
@@ -99,16 +100,8 @@ class SlackNotifyServiceAction(IntegrationEventAction):
                 for block in additional_attachment:
                     blocks["blocks"].append(block)
 
-            payload = {
-                "text": blocks.get("text"),
-                "channel": channel,
-                "unfurl_links": False,
-                "unfurl_media": False,
-            }
-            json_blocks = None
             if payload_blocks := blocks.get("blocks"):
                 json_blocks = orjson.dumps(payload_blocks).decode()
-                payload["blocks"] = json_blocks
 
             rule = rules[0] if rules else None
             rule_to_use = self.rule if self.rule else rule
@@ -162,106 +155,72 @@ class SlackNotifyServiceAction(IntegrationEventAction):
                     )
                     # To reply to a thread, use the specific key in the payload as referenced by the docs
                     # https://api.slack.com/methods/chat.postMessage#arg_thread_ts
-                    payload["thread_ts"] = parent_notification_message.message_identifier
                     thread_ts = parent_notification_message.message_identifier
                     # If this flow is triggered again for the same issue, we want it to be seen in the main channel
-                    payload["reply_broadcast"] = True
                     reply_broadcast = True
 
             organization = event.group.project.organization
 
-            if features.has("organizations:slack-sdk-issue-alert-action", organization):
-                sdk_client = SlackSdkClient(integration_id=integration.id)
-                text = str(payload["text"]) if payload["text"] is not None else None
-                try:
-                    sdk_response = sdk_client.chat_postMessage(
-                        blocks=json_blocks,
-                        text=text,
-                        channel=channel,
-                        unfurl_links=False,
-                        unfurl_media=False,
-                        thread_ts=thread_ts,
-                        reply_broadcast=reply_broadcast,
-                    )
-                except SlackApiError as e:
-                    # Record the error code and details from the exception
-                    new_notification_message_object.error_code = e.response.status_code
-                    new_notification_message_object.error_details = {
-                        "msg": str(e),
-                        "data": e.response.data,
-                        "url": e.response.api_url,
-                    }
+            client = SlackSdkClient(integration_id=integration.id)
+            text = str(blocks.get("text"))
+            try:
+                response = client.chat_postMessage(
+                    blocks=json_blocks,
+                    text=text,
+                    channel=channel,
+                    unfurl_links=False,
+                    unfurl_media=False,
+                    thread_ts=thread_ts,
+                    reply_broadcast=reply_broadcast,
+                )
+                metrics.incr(
+                    SLACK_ISSUE_ALERT_SUCCESS_DATADOG_METRIC,
+                    sample_rate=1.0,
+                    tags={
+                        "action": "send_notification",
+                        "ok": response.get("ok", False),
+                        "status": response.status_code,
+                    },
+                )
+            except SlackApiError as e:
+                # Record the error code and details from the exception
+                new_notification_message_object.error_code = e.response.status_code
+                new_notification_message_object.error_details = {
+                    "msg": str(e),
+                    "data": e.response.data,
+                    "url": e.response.api_url,
+                }
 
-                    log_params = {
-                        "error": str(e),
-                        "project_id": event.project_id,
-                        "event_id": event.event_id,
-                        "channel_name": self.get_option("channel"),
-                    }
-                    # temporarily log the payload so we can debug message failures
-                    log_params["payload"] = orjson.dumps(payload).decode()
+                log_params = {
+                    "error": str(e),
+                    "project_id": event.project_id,
+                    "event_id": event.event_id,
+                    "channel_name": self.get_option("channel"),
+                }
+                # temporarily log the payload so we can debug message failures
+                log_params["payload"] = json_blocks
 
-                    self.logger.info(
-                        "slack.issue_alert.error",
-                        extra=log_params,
-                    )
-                else:
-                    ts = sdk_response.get("ts")
-
-                    self.logger.info("slack.issue_alert.ts", extra={"ts": ts})
-
-                    new_notification_message_object.message_identifier = (
-                        str(ts) if ts is not None else None
-                    )
-
+                self.logger.info(
+                    "slack.issue_alert.error",
+                    extra=log_params,
+                )
+                metrics.incr(
+                    SLACK_ISSUE_ALERT_FAILURE_DATADOG_METRIC,
+                    sample_rate=1.0,
+                    tags={
+                        "action": "send_notification",
+                        "ok": e.response.get("ok", False),
+                        "status": e.response.status_code,
+                    },
+                )
             else:
-                client = SlackClient(integration_id=integration.id)
-                try:
-                    response = client.post(
-                        "/chat.postMessage", data=payload, timeout=5, log_response_with_error=True
-                    )
-                except ApiError as e:
-                    # Record the error code and details from the exception
-                    new_notification_message_object.error_code = e.code
-                    new_notification_message_object.error_details = {
-                        "url": e.url,
-                        "host": e.host,
-                        "path": e.path,
-                        "data": e.json if e.json else e.text,
-                    }
+                ts = response.get("ts")
 
-                    log_params = {
-                        "error": str(e),
-                        "project_id": event.project_id,
-                        "event_id": event.event_id,
-                        "channel_name": self.get_option("channel"),
-                    }
-                    # temporarily log the payload so we can debug message failures
-                    log_params["payload"] = orjson.dumps(payload).decode()
+                self.logger.info("slack.issue_alert.ts", extra={"ts": ts})
 
-                    self.logger.info(
-                        "rule.fail.slack_post",
-                        extra=log_params,
-                    )
-                else:
-                    # Slack will always send back a ts identifier https://api.slack.com/methods/chat.postMessage#examples
-                    # on a successful message
-                    ts = None
-                    # This is a workaround for typing, and the dynamic nature of the return value
-                    if isinstance(response, BaseApiResponse):
-                        ts = response.json.get("ts")
-                    elif isinstance(response, MappingApiResponse):
-                        ts = response.get("ts")
-                    else:
-                        _default_logger.info(
-                            "failed to get ts from slack response",
-                            extra={
-                                "response_type": type(response).__name__,
-                            },
-                        )
-                    new_notification_message_object.message_identifier = (
-                        str(ts) if ts is not None else None
-                    )
+                new_notification_message_object.message_identifier = (
+                    str(ts) if ts is not None else None
+                )
 
             if rule_action_uuid and rule_id:
                 try:
@@ -300,51 +259,44 @@ class SlackNotifyServiceAction(IntegrationEventAction):
         channel = self.get_option("channel_id")
         blocks = SlackRuleSaveEditMessageBuilder(rule=rule, new=new, changed=changed).build()
         json_blocks = orjson.dumps(blocks.get("blocks")).decode()
-        payload = {
-            "text": blocks.get("text"),
-            "blocks": json_blocks,
-            "channel": channel,
-            "unfurl_links": False,
-            "unfurl_media": False,
-        }
+        client = SlackSdkClient(integration_id=integration.id)
 
-        if features.has("organizations:slack-sdk-issue-alert-action", rule.project.organization):
-            sdk_client = SlackSdkClient(integration_id=integration.id)
-
-            try:
-                sdk_client.chat_postMessage(
-                    blocks=json_blocks,
-                    text=blocks.get("text"),
-                    channel=channel,
-                    unfurl_links=False,
-                    unfurl_media=False,
-                )
-            except SlackApiError as e:
-                log_params = {
-                    "error": str(e),
-                    "project_id": rule.project.id,
-                    "channel_name": self.get_option("channel"),
-                }
-                self.logger.info(
-                    "slack.issue_alert.confirmation.fail",
-                    extra=log_params,
-                )
-        else:
-            client = SlackClient(integration_id=integration.id)
-            try:
-                client.post(
-                    "/chat.postMessage", data=payload, timeout=5, log_response_with_error=True
-                )
-            except ApiError as e:
-                log_params = {
-                    "error": str(e),
-                    "project_id": rule.project.id,
-                    "channel_name": self.get_option("channel"),
-                }
-                self.logger.info(
-                    "rule_confirmation.fail.slack_post",
-                    extra=log_params,
-                )
+        try:
+            response = client.chat_postMessage(
+                blocks=json_blocks,
+                text=blocks.get("text"),
+                channel=channel,
+                unfurl_links=False,
+                unfurl_media=False,
+            )
+            metrics.incr(
+                SLACK_ISSUE_ALERT_SUCCESS_DATADOG_METRIC,
+                sample_rate=1.0,
+                tags={
+                    "action": "send_confirmation",
+                    "ok": response.get("ok", False),
+                    "status": response.status_code,
+                },
+            )
+        except SlackApiError as e:
+            log_params = {
+                "error": str(e),
+                "project_id": rule.project.id,
+                "channel_name": self.get_option("channel"),
+            }
+            self.logger.info(
+                "slack.issue_alert.confirmation.fail",
+                extra=log_params,
+            )
+            metrics.incr(
+                SLACK_ISSUE_ALERT_FAILURE_DATADOG_METRIC,
+                sample_rate=1.0,
+                tags={
+                    "action": "send_confirmation",
+                    "ok": e.response.get("ok", False),
+                    "status": e.response.status_code,
+                },
+            )
 
     def render_label(self) -> str:
         tags = self.get_tags_list()

--- a/src/sentry/integrations/slack/metrics.py
+++ b/src/sentry/integrations/slack/metrics.py
@@ -1,0 +1,4 @@
+# metrics constants
+
+SLACK_ISSUE_ALERT_SUCCESS_DATADOG_METRIC = "sentry.integrations.slack.issue_alert.success"
+SLACK_ISSUE_ALERT_FAILURE_DATADOG_METRIC = "sentry.integrations.slack.issue_alert.failure"

--- a/tests/sentry/api/endpoints/test_project_rule_details.py
+++ b/tests/sentry/api/endpoints/test_project_rule_details.py
@@ -1185,10 +1185,9 @@ class UpdateProjectRuleTest(ProjectRuleDetailsBaseTestCase):
         rule_id = response.data["id"]
         rule_label = response.data["name"]
         assert response.data["actions"][0]["channel_id"] == "new_channel_id"
-        blocks = mock_post.call_args.kwargs["blocks"]
-        blocks = orjson.loads(blocks)
+        sent_blocks = orjson.loads(mock_post.call_args.kwargs["blocks"])
         message = f"Alert rule <http://testserver/organizations/{self.organization.slug}/alerts/rules/{self.project.slug}/{rule_id}/details/|*{rule_label}*> in the *{self.project.slug}* project was updated."
-        assert blocks[0]["text"]["text"] == message
+        assert sent_blocks[0]["text"]["text"] == message
 
         changes = "*Changes*\n"
         changes += "• Added condition 'The issue's category is equal to Performance'\n"
@@ -1199,9 +1198,9 @@ class UpdateProjectRuleTest(ProjectRuleDetailsBaseTestCase):
         changes += "• Changed trigger from *None* to *any*\n"
         changes += "• Changed filter from *None* to *any*\n"
         changes += f"• Changed owner from *Unassigned* to *{self.user.email}*\n"
-        assert blocks[1]["text"]["text"] == changes
+        assert sent_blocks[1]["text"]["text"] == changes
         assert (
-            blocks[2]["elements"][0]["text"]
+            sent_blocks[2]["elements"][0]["text"]
             == "<http://testserver/settings/account/notifications/alerts/|*Notification Settings*>"
         )
 

--- a/tests/sentry/api/endpoints/test_project_rule_details.py
+++ b/tests/sentry/api/endpoints/test_project_rule_details.py
@@ -4,7 +4,6 @@ from collections.abc import Mapping
 from datetime import UTC, datetime, timedelta
 from typing import Any
 from unittest.mock import patch
-from urllib.parse import parse_qs
 
 import orjson
 import responses
@@ -1102,7 +1101,16 @@ class UpdateProjectRuleTest(ProjectRuleDetailsBaseTestCase):
 
     @responses.activate
     @with_feature("organizations:rule-create-edit-confirm-notification")
-    def test_slack_confirmation_notification_contents(self):
+    @patch("sentry.integrations.slack.sdk_client.SlackSdkClient.chat_postMessage")
+    @patch(
+        "slack_sdk.web.client.WebClient._perform_urllib_http_request",
+        return_value={
+            "body": orjson.dumps({"ok": True}).decode(),
+            "headers": {},
+            "status": 200,
+        },
+    )
+    def test_slack_confirmation_notification_contents(self, mock_api_call, mock_post):
         conditions = [
             {"id": "sentry.rules.conditions.first_seen_event.FirstSeenEventCondition"},
         ]
@@ -1157,13 +1165,6 @@ class UpdateProjectRuleTest(ProjectRuleDetailsBaseTestCase):
             "unfurl_links": False,
             "unfurl_media": False,
         }
-        responses.add(
-            method=responses.POST,
-            url="https://slack.com/api/chat.postMessage",
-            status=200,
-            content_type="application/json",
-            body=orjson.dumps(payload),
-        )
         staging_env = self.create_environment(
             self.project, name="staging", organization=self.organization
         )
@@ -1184,11 +1185,11 @@ class UpdateProjectRuleTest(ProjectRuleDetailsBaseTestCase):
         rule_id = response.data["id"]
         rule_label = response.data["name"]
         assert response.data["actions"][0]["channel_id"] == "new_channel_id"
-        data = parse_qs(responses.calls[1].request.body)
+        blocks = mock_post.call_args.kwargs["blocks"]
+        blocks = orjson.loads(blocks)
         message = f"Alert rule <http://testserver/organizations/{self.organization.slug}/alerts/rules/{self.project.slug}/{rule_id}/details/|*{rule_label}*> in the *{self.project.slug}* project was updated."
-        assert data["text"][0] == message
-        rendered_blocks = orjson.loads(data["blocks"][0])
-        assert rendered_blocks[0]["text"]["text"] == message
+        assert blocks[0]["text"]["text"] == message
+
         changes = "*Changes*\n"
         changes += "• Added condition 'The issue's category is equal to Performance'\n"
         changes += "• Changed action from *Send a notification to the Awesome Team Slack workspace to #old_channel_name* to *Send a notification to the Awesome Team Slack workspace to #new_channel_name*\n"
@@ -1198,9 +1199,9 @@ class UpdateProjectRuleTest(ProjectRuleDetailsBaseTestCase):
         changes += "• Changed trigger from *None* to *any*\n"
         changes += "• Changed filter from *None* to *any*\n"
         changes += f"• Changed owner from *Unassigned* to *{self.user.email}*\n"
-        assert rendered_blocks[1]["text"]["text"] == changes
+        assert blocks[1]["text"]["text"] == changes
         assert (
-            rendered_blocks[2]["elements"][0]["text"]
+            blocks[2]["elements"][0]["text"]
             == "<http://testserver/settings/account/notifications/alerts/|*Notification Settings*>"
         )
 

--- a/tests/sentry/api/endpoints/test_project_rules.py
+++ b/tests/sentry/api/endpoints/test_project_rules.py
@@ -4,7 +4,6 @@ from collections.abc import Mapping, Sequence
 from copy import deepcopy
 from typing import Any
 from unittest.mock import patch
-from urllib.parse import parse_qs
 from uuid import uuid4
 
 import orjson
@@ -380,7 +379,16 @@ class CreateProjectRuleTest(ProjectRuleBaseTestCase):
 
     @responses.activate
     @with_feature("organizations:rule-create-edit-confirm-notification")
-    def test_slack_confirmation_notification_contents(self):
+    @patch("sentry.integrations.slack.sdk_client.SlackSdkClient.chat_postMessage")
+    @patch(
+        "slack_sdk.web.client.WebClient._perform_urllib_http_request",
+        return_value={
+            "body": orjson.dumps({"ok": True}).decode(),
+            "headers": {},
+            "status": 200,
+        },
+    )
+    def test_slack_confirmation_notification_contents(self, mock_api_call, mock_post):
         responses.add(
             method=responses.GET,
             url="https://slack.com/api/conversations.info",
@@ -392,20 +400,6 @@ class CreateProjectRuleTest(ProjectRuleBaseTestCase):
         )
 
         blocks = SlackRuleSaveEditMessageBuilder(rule=self.rule, new=True).build()
-        payload = {
-            "text": blocks.get("text"),
-            "blocks": orjson.dumps(blocks.get("blocks")).decode(),
-            "channel": self.channel_id,
-            "unfurl_links": False,
-            "unfurl_media": False,
-        }
-        responses.add(
-            method=responses.POST,
-            url="https://slack.com/api/chat.postMessage",
-            status=200,
-            content_type="application/json",
-            body=orjson.dumps(payload),
-        )
         response = self.get_success_response(
             self.organization.slug,
             self.project.slug,
@@ -421,13 +415,12 @@ class CreateProjectRuleTest(ProjectRuleBaseTestCase):
         rule_id = response.data["id"]
         rule_label = response.data["name"]
         assert response.data["actions"][0]["channel_id"] == self.channel_id
-        data = parse_qs(responses.calls[1].request.body)
+        blocks = mock_post.call_args.kwargs["blocks"]
+        blocks = orjson.loads(blocks)
         message = f"Alert rule <http://testserver/organizations/{self.organization.slug}/alerts/rules/{self.project.slug}/{rule_id}/details/|*{rule_label}*> was created in the *{self.project.slug}* project and will send notifications here."
-        assert data["text"][0] == message
-        rendered_blocks = orjson.loads(data["blocks"][0])
-        assert rendered_blocks[0]["text"]["text"] == message
+        assert blocks[0]["text"]["text"] == message
         assert (
-            rendered_blocks[1]["elements"][0]["text"]
+            blocks[1]["elements"][0]["text"]
             == "<http://testserver/settings/account/notifications/alerts/|*Notification Settings*>"
         )
 

--- a/tests/sentry/rules/processing/test_processor.py
+++ b/tests/sentry/rules/processing/test_processor.py
@@ -858,7 +858,7 @@ class RuleProcessorTestFilters(TestCase):
         assert futures[0].rule == self.rule
         assert futures[0].kwargs == {}
 
-    @patch("sentry.shared_integrations.client.base.BaseApiClient.post")
+    @patch("sentry.integrations.slack.sdk_client.SlackSdkClient.chat_postMessage")
     def test_slack_title_link_notification_uuid(self, mock_post):
         """Test that the slack title link includes the notification uuid from apply function"""
         integration = install_slack(self.organization)
@@ -883,7 +883,7 @@ class RuleProcessorTestFilters(TestCase):
         mock_post.assert_called_once()
         assert (
             "notification_uuid"
-            in json.loads(mock_post.call_args[1]["data"]["blocks"])[0]["text"]["text"]
+            in json.loads(mock_post.call_args.kwargs["blocks"])[0]["text"]["text"]
         )
 
     @patch("sentry.shared_integrations.client.base.BaseApiClient.post")


### PR DESCRIPTION
Default to using the Slack SDK Client for sending issue alert notifications in a channel. The feature has been GA'd.