### PR TITLE
fix(trace-explorer): Check if queries are enabled before is loading

### DIFF
--- a/static/app/views/traces/tracesChart.tsx
+++ b/static/app/views/traces/tracesChart.tsx
@@ -27,39 +27,62 @@ export function TracesChart({}: Props) {
     return decodeList(location.query.query);
   }, [location.query.query]);
 
-  const firstCountSeries = useTraceCountSeries(queries[0] ?? ''); // Always provide query string to visualize at least some spans when landing on the page.
-  const secondCountSeries = useTraceCountSeries(queries[1]);
-  const thirdCountSeries = useTraceCountSeries(queries[2]);
+  const enabled = useMemo(
+    () => [
+      true, // always visualize the first series
+      Boolean(queries?.[1]?.trim()),
+      Boolean(queries?.[2]?.trim()),
+    ],
+    [queries]
+  );
+
+  const firstCountSeries = useTraceCountSeries({
+    query: queries?.[0] || '',
+    enabled: enabled[0],
+  });
+  const secondCountSeries = useTraceCountSeries({
+    query: queries?.[1],
+    enabled: enabled[1],
+  });
+  const thirdCountSeries = useTraceCountSeries({
+    query: queries?.[2],
+    enabled: enabled[2],
+  });
 
   const seriesAreLoading =
-    firstCountSeries.isLoading ||
-    secondCountSeries.isLoading ||
-    thirdCountSeries.isLoading;
+    // Disabled queries have `isLoading: true`, but this changes in v5.
+    // To handle this gracefully, we check if the query is enabled + isLoading.
+    //
+    // References
+    // - https://tanstack.com/query/v4/docs/framework/react/guides/disabling-queries
+    // - https://tanstack.com/query/latest/docs/framework/react/guides/disabling-queries#isloading-previously-isinitialloading
+    (enabled[0] && firstCountSeries.isLoading) ||
+    (enabled[1] && secondCountSeries.isLoading) ||
+    (enabled[2] && thirdCountSeries.isLoading);
 
   const chartData = useMemo<Series[]>(() => {
-    const data: Series[] = [];
-    const firstQueryData = firstCountSeries.data['count()'];
-    const secondQueryData = secondCountSeries.data['count()'];
-    const thirdQueryData = thirdCountSeries.data['count()'];
+    const series = [firstCountSeries.data, secondCountSeries.data, thirdCountSeries.data];
 
-    firstQueryData.color = CHART_PALETTE[2][0];
-    secondQueryData.color = CHART_PALETTE[2][1];
-    thirdQueryData.color = CHART_PALETTE[2][2];
+    const allData: Series[] = [];
 
-    firstQueryData.seriesName = queries[0] || t('All spans');
-    secondQueryData.seriesName = queries[1];
-    thirdQueryData.seriesName = queries[2];
-
-    data.push(firstQueryData);
-
-    if (queries[1]) {
-      data.push(secondQueryData);
+    for (let i = 0; i < series.length; i++) {
+      if (!enabled[i]) {
+        continue;
+      }
+      const data = series[i]['count()'];
+      data.color = CHART_PALETTE[2][i];
+      data.seriesName = queries[i] || t('All spans');
+      allData.push(data);
     }
-    if (queries[2]) {
-      data.push(thirdQueryData);
-    }
-    return data;
-  }, [queries, firstCountSeries.data, secondCountSeries.data, thirdCountSeries.data]);
+
+    return allData;
+  }, [
+    enabled,
+    queries,
+    firstCountSeries.data,
+    secondCountSeries.data,
+    thirdCountSeries.data,
+  ]);
 
   return (
     <ChartContainer>
@@ -96,7 +119,13 @@ const ChartContainer = styled('div')`
   grid-template-columns: 1fr;
 `;
 
-const useTraceCountSeries = (query: string | null) => {
+const useTraceCountSeries = ({
+  enabled,
+  query,
+}: {
+  enabled: boolean;
+  query: string | null;
+}) => {
   const pageFilters = usePageFilters();
 
   return useSpanIndexedSeries(
@@ -105,7 +134,7 @@ const useTraceCountSeries = (query: string | null) => {
       yAxis: ['count()'],
       interval: getInterval(pageFilters.selection.datetime, 'metrics'),
       overriddenRoute: 'traces-stats',
-      enabled: query !== null && query !== undefined,
+      enabled,
     },
     'api.trace-explorer.stats'
   );


### PR DESCRIPTION
React query sets isLoading to true for disabled queries in v4. So we have to check if it's enabled and loading before rendering the loading circle. Alternatively we could use `isInitialLoading` but that gets renamed to `isLoading` in v5.