### PR TITLE
fix(trace-explorer): Cross project autocompletion

### DIFF
--- a/static/app/views/performance/cache/samplePanel/samplePanel.tsx
+++ b/static/app/views/performance/cache/samplePanel/samplePanel.tsx
@@ -62,7 +62,9 @@ export function CacheSamplePanel() {
   const location = useLocation();
   const organization = useOrganization();
   const {selection} = usePageFilters();
-  const supportedTags = useSpanFieldSupportedTags([SpanIndexedField.CACHE_HIT]);
+  const supportedTags = useSpanFieldSupportedTags({
+    excludedTags: [SpanIndexedField.CACHE_HIT],
+  });
 
   const query = useLocationQuery({
     fields: {

--- a/static/app/views/performance/queues/destinationSummary/messageSpanSamplesPanel.tsx
+++ b/static/app/views/performance/queues/destinationSummary/messageSpanSamplesPanel.tsx
@@ -69,10 +69,12 @@ export function MessageSpanSamplesPanel() {
   });
   const {projects} = useProjects();
   const {selection} = usePageFilters();
-  const supportedTags = useSpanFieldSupportedTags([
-    SpanIndexedField.TRACE_STATUS,
-    SpanIndexedField.MESSAGING_MESSAGE_RETRY_COUNT,
-  ]);
+  const supportedTags = useSpanFieldSupportedTags({
+    excludedTags: [
+      SpanIndexedField.TRACE_STATUS,
+      SpanIndexedField.MESSAGING_MESSAGE_RETRY_COUNT,
+    ],
+  });
 
   const project = projects.find(p => query.project === p.id);
 

--- a/static/app/views/traces/tracesSearchBar.tsx
+++ b/static/app/views/traces/tracesSearchBar.tsx
@@ -7,7 +7,6 @@ import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import useOrganization from 'sentry/utils/useOrganization';
-import usePageFilters from 'sentry/utils/usePageFilters';
 import {useSpanFieldSupportedTags} from 'sentry/views/performance/utils/useSpanFieldSupportedTags';
 
 interface TracesSearchBarProps {
@@ -25,17 +24,22 @@ const getSpanName = (index: number) => {
   return spanNames[index];
 };
 
+// Since trace explorer permits cross project searches,
+// autocompletion should also be cross projects.
+const ALL_PROJECTS = [-1];
+
 export function TracesSearchBar({
   queries,
   handleSearch,
   handleClearSearch,
 }: TracesSearchBarProps) {
   // TODO: load tags for autocompletion
-  const {selection} = usePageFilters();
   const organization = useOrganization();
   const canAddMoreQueries = queries.length <= 2;
   const localQueries = queries.length ? queries : [''];
-  const supportedTags = useSpanFieldSupportedTags();
+  const supportedTags = useSpanFieldSupportedTags({
+    projects: ALL_PROJECTS,
+  });
 
   return (
     <TraceSearchBarsContainer>
@@ -51,7 +55,7 @@ export function TracesSearchBar({
             metricAlert={false}
             supportedTags={supportedTags}
             dataset={DiscoverDatasets.SPANS_INDEXED}
-            projectIds={selection.projects}
+            projectIds={ALL_PROJECTS}
           />
           <StyledButton
             aria-label={t('Remove span')}


### PR DESCRIPTION
Trace explorer allows for cross project searches so the autocompletion should also be cross project.