### PR TITLE
ref(rules): Fix get_condition_groups

### DIFF
--- a/tests/sentry/rules/processing/test_delayed_processing.py
+++ b/tests/sentry/rules/processing/test_delayed_processing.py
@@ -208,7 +208,7 @@ class ProcessDelayedAlertConditionsTest(
             environment_id=env3.id,
         )
         rules_to_groups = {rule_1.id: {1, 2, 3}, rule_2.id: {3, 4, 5}}
-        orig_rules_to_groups = deepcopy(rules_to_groups)  # type: ignore[arg-type]
+        orig_rules_to_groups = deepcopy(rules_to_groups)
         get_condition_groups([rule_1, rule_2], rules_to_groups)  # type: ignore[arg-type]
         assert orig_rules_to_groups == rules_to_groups
 

--- a/tests/sentry/rules/processing/test_delayed_processing.py
+++ b/tests/sentry/rules/processing/test_delayed_processing.py
@@ -1,3 +1,4 @@
+from copy import deepcopy
 from datetime import UTC, datetime
 from unittest.mock import patch
 from uuid import uuid4
@@ -10,6 +11,7 @@ from sentry.models.project import Project
 from sentry.models.rulefirehistory import RuleFireHistory
 from sentry.rules.processing.delayed_processing import (
     apply_delayed,
+    get_condition_groups,
     process_delayed_alert_conditions,
 )
 from sentry.rules.processing.processor import PROJECT_ID_BUFFER_LIST_KEY
@@ -27,7 +29,13 @@ class ProcessDelayedAlertConditionsTest(
     TestCase, APITestCase, BaseEventFrequencyPercentTest, PerformanceIssueTestCase
 ):
     def create_event(
-        self, project_id, timestamp, fingerprint, environment=None, user: bool = True
+        self,
+        project_id,
+        timestamp,
+        fingerprint,
+        environment=None,
+        user: bool = True,
+        tags: list[str] | None = None,
     ) -> Event:
         data = {
             "timestamp": iso_format(timestamp),
@@ -44,6 +52,9 @@ class ProcessDelayedAlertConditionsTest(
                 ]
             },
         }
+        if tags:
+            data["tags"] = tags
+
         return self.store_event(
             data=data, project_id=project_id, assert_no_errors=False, event_type=EventType.ERROR
         )
@@ -74,6 +85,13 @@ class ProcessDelayedAlertConditionsTest(
         super().setUp()
         self.mock_redis_buffer = mock_redis_buffer()
         self.mock_redis_buffer.__enter__()
+
+        self.tag_filter = {
+            "id": "sentry.rules.filters.tagged_event.TaggedEventFilter",
+            "key": "foo",
+            "match": "eq",
+            "value": "bar",
+        }
 
         self.event_frequency_condition = self.create_event_frequency_condition()
         self.event_frequency_condition2 = self.create_event_frequency_condition(value=2)
@@ -174,6 +192,25 @@ class ProcessDelayedAlertConditionsTest(
             PROJECT_ID_BUFFER_LIST_KEY, 0, datetime.now(UTC).timestamp()
         )
         assert project_ids == []
+
+    def test_get_condition_groups(self):
+        project_three = self.create_project(organization=self.organization)
+        env3 = self.create_environment(project=project_three)
+        rule_1 = self.create_project_rule(
+            project=project_three,
+            condition_match=[self.event_frequency_condition],
+            filter_match=[self.tag_filter],
+            environment_id=env3.id,
+        )
+        rule_2 = self.create_project_rule(
+            project=project_three,
+            condition_match=[self.event_frequency_condition2],
+            environment_id=env3.id,
+        )
+        rules_to_groups = {rule_1.id: {1, 2, 3}, rule_2.id: {3, 4, 5}}
+        orig_rules_to_groups = deepcopy(rules_to_groups)
+        get_condition_groups([rule_1, rule_2], rules_to_groups)
+        assert orig_rules_to_groups == rules_to_groups
 
     @patch("sentry.rules.conditions.event_frequency.MIN_SESSIONS_TO_FIRE", 1)
     def test_apply_delayed_rules_to_fire(self):
@@ -312,9 +349,8 @@ class ProcessDelayedAlertConditionsTest(
             event_id__in=[self.event1.event_id, event5.event_id],
             project=self.project,
         ).values_list("rule", "group")
-        assert len(rule_fire_histories) == 3
+        assert len(rule_fire_histories) == 2
         assert (self.rule1.id, self.group1.id) in rule_fire_histories
-        assert (self.rule1.id, group5.id) in rule_fire_histories
         assert (rule5.id, group5.id) in rule_fire_histories
         self.assert_buffer_cleared(project_id=self.project.id)
 
@@ -413,9 +449,8 @@ class ProcessDelayedAlertConditionsTest(
             event_id__in=[self.event1.event_id, event5.event_id],
             project=self.project,
         ).values_list("rule", "group")
-        assert len(rule_fire_histories) == 2
+        assert len(rule_fire_histories) == 1
         assert (self.rule1.id, self.group1.id) in rule_fire_histories
-        assert (self.rule1.id, group5.id) in rule_fire_histories
         self.assert_buffer_cleared(project_id=self.project.id)
 
     def test_apply_delayed_action_match_all(self):
@@ -457,8 +492,53 @@ class ProcessDelayedAlertConditionsTest(
             event_id__in=[self.event1.event_id, event5.event_id],
             project=self.project,
         ).values_list("rule", "group")
-        assert len(rule_fire_histories) == 3
+        assert len(rule_fire_histories) == 2
         assert (self.rule1.id, self.group1.id) in rule_fire_histories
-        assert (self.rule1.id, group5.id) in rule_fire_histories
         assert (two_conditions_match_all_rule.id, group5.id) in rule_fire_histories
         self.assert_buffer_cleared(project_id=self.project.id)
+
+    def test_apply_delayed_shared_condition_diff_filter(self):
+        project_three = self.create_project(organization=self.organization)
+        env3 = self.create_environment(project=project_three)
+        buffer.backend.push_to_sorted_set(key=PROJECT_ID_BUFFER_LIST_KEY, value=project_three.id)
+        rule_1 = self.create_project_rule(
+            project=project_three,
+            condition_match=[self.event_frequency_condition],
+            filter_match=[self.tag_filter],
+            environment_id=env3.id,
+        )
+        rule_2 = self.create_project_rule(
+            project=project_three,
+            condition_match=[self.event_frequency_condition],
+            environment_id=env3.id,
+        )
+        event1 = self.create_event(
+            project_three.id, self.now, "group-5", env3.name, tags=[["foo", "bar"]]
+        )
+        self.create_event(project_three.id, self.now, "group-5", env3.name, tags=[["foo", "bar"]])
+        group1 = event1.group
+        assert group1
+
+        event2 = self.create_event(project_three.id, self.now, "group-6", env3.name)
+        self.create_event(project_three.id, self.now, "group-6", env3.name)
+        group2 = event2.group
+        assert group2
+
+        self.push_to_hash(project_three.id, rule_1.id, group1.id, event1.event_id)
+        self.push_to_hash(project_three.id, rule_2.id, group2.id, event2.event_id)
+
+        project_ids = buffer.backend.get_sorted_set(
+            PROJECT_ID_BUFFER_LIST_KEY, 0, datetime.now(UTC).timestamp()
+        )
+        assert project_three.id == project_ids[2][0]
+        apply_delayed(project_ids[2][0])
+        rule_fire_histories = RuleFireHistory.objects.filter(
+            rule__in=[rule_1, rule_2],
+            group__in=[group1, group2],
+            event_id__in=[event1.event_id, event2.event_id],
+            project=project_three,
+        ).values_list("rule", "group")
+        assert len(rule_fire_histories) == 2
+        assert (rule_1.id, group1.id) in rule_fire_histories
+        assert (rule_2.id, group2.id) in rule_fire_histories
+        self.assert_buffer_cleared(project_id=project_three.id)

--- a/tests/sentry/rules/processing/test_delayed_processing.py
+++ b/tests/sentry/rules/processing/test_delayed_processing.py
@@ -1,6 +1,5 @@
 from copy import deepcopy
 from datetime import UTC, datetime
-from typing import DefaultDict
 from unittest.mock import patch
 from uuid import uuid4
 
@@ -208,9 +207,9 @@ class ProcessDelayedAlertConditionsTest(
             condition_match=[self.event_frequency_condition2],
             environment_id=env3.id,
         )
-        rules_to_groups: DefaultDict[int, set[int]] = {rule_1.id: {1, 2, 3}, rule_2.id: {3, 4, 5}}
-        orig_rules_to_groups = deepcopy(rules_to_groups)
-        get_condition_groups([rule_1, rule_2], rules_to_groups)
+        rules_to_groups = {rule_1.id: {1, 2, 3}, rule_2.id: {3, 4, 5}}
+        orig_rules_to_groups = deepcopy(rules_to_groups)  # type: ignore[misc]
+        get_condition_groups([rule_1, rule_2], rules_to_groups)  # type: ignore[misc]
         assert orig_rules_to_groups == rules_to_groups
 
     @patch("sentry.rules.conditions.event_frequency.MIN_SESSIONS_TO_FIRE", 1)

--- a/tests/sentry/rules/processing/test_delayed_processing.py
+++ b/tests/sentry/rules/processing/test_delayed_processing.py
@@ -208,8 +208,8 @@ class ProcessDelayedAlertConditionsTest(
             environment_id=env3.id,
         )
         rules_to_groups = {rule_1.id: {1, 2, 3}, rule_2.id: {3, 4, 5}}
-        orig_rules_to_groups = deepcopy(rules_to_groups)  # type: ignore[misc]
-        get_condition_groups([rule_1, rule_2], rules_to_groups)  # type: ignore[misc]
+        orig_rules_to_groups = deepcopy(rules_to_groups)  # type: ignore[arg-type]
+        get_condition_groups([rule_1, rule_2], rules_to_groups)  # type: ignore[arg-type]
         assert orig_rules_to_groups == rules_to_groups
 
     @patch("sentry.rules.conditions.event_frequency.MIN_SESSIONS_TO_FIRE", 1)

--- a/tests/sentry/rules/processing/test_delayed_processing.py
+++ b/tests/sentry/rules/processing/test_delayed_processing.py
@@ -1,5 +1,6 @@
 from copy import deepcopy
 from datetime import UTC, datetime
+from typing import DefaultDict
 from unittest.mock import patch
 from uuid import uuid4
 
@@ -35,7 +36,7 @@ class ProcessDelayedAlertConditionsTest(
         fingerprint,
         environment=None,
         user: bool = True,
-        tags: list[str] | None = None,
+        tags: list[list[str]] | None = None,
     ) -> Event:
         data = {
             "timestamp": iso_format(timestamp),
@@ -207,7 +208,7 @@ class ProcessDelayedAlertConditionsTest(
             condition_match=[self.event_frequency_condition2],
             environment_id=env3.id,
         )
-        rules_to_groups = {rule_1.id: {1, 2, 3}, rule_2.id: {3, 4, 5}}
+        rules_to_groups: DefaultDict[int, set[int]] = {rule_1.id: {1, 2, 3}, rule_2.id: {3, 4, 5}}
         orig_rules_to_groups = deepcopy(rules_to_groups)
         get_condition_groups([rule_1, rule_2], rules_to_groups)
         assert orig_rules_to_groups == rules_to_groups
@@ -220,7 +221,7 @@ class ProcessDelayedAlertConditionsTest(
         project_ids = buffer.backend.get_sorted_set(
             PROJECT_ID_BUFFER_LIST_KEY, 0, datetime.now(UTC).timestamp()
         )
-        apply_delayed(project_ids[0][0], project_ids[0][1])
+        apply_delayed(project_ids[0][0])
         rule_fire_histories = RuleFireHistory.objects.filter(
             rule__in=[self.rule1, self.rule2],
             group__in=[self.group1, self.group2],
@@ -234,7 +235,7 @@ class ProcessDelayedAlertConditionsTest(
         assert (self.rule2.id, self.group2.id) in rule_fire_histories
         self.assert_buffer_cleared(project_id=self.project.id)
 
-        apply_delayed(project_ids[1][0], project_ids[1][1])
+        apply_delayed(project_ids[1][0])
         rule_fire_histories = RuleFireHistory.objects.filter(
             rule__in=[self.rule3, self.rule4],
             group__in=[self.group3, self.group4],
@@ -279,7 +280,7 @@ class ProcessDelayedAlertConditionsTest(
         project_ids = buffer.backend.get_sorted_set(
             PROJECT_ID_BUFFER_LIST_KEY, 0, datetime.now(UTC).timestamp()
         )
-        apply_delayed(project_ids[0][0], project_ids[0][1])
+        apply_delayed(project_ids[0][0])
         rule_fire_histories = RuleFireHistory.objects.filter(
             rule__in=[self.rule1, rule5],
             group__in=[self.group1, group5],
@@ -312,7 +313,7 @@ class ProcessDelayedAlertConditionsTest(
         project_ids = buffer.backend.get_sorted_set(
             PROJECT_ID_BUFFER_LIST_KEY, 0, datetime.now(UTC).timestamp()
         )
-        apply_delayed(project_ids[0][0], project_ids[0][1])
+        apply_delayed(project_ids[0][0])
         rule_fire_histories = RuleFireHistory.objects.filter(
             rule__in=[rule5],
             group__in=[self.group1, group5],
@@ -342,7 +343,7 @@ class ProcessDelayedAlertConditionsTest(
         project_ids = buffer.backend.get_sorted_set(
             PROJECT_ID_BUFFER_LIST_KEY, 0, datetime.now(UTC).timestamp()
         )
-        apply_delayed(project_ids[0][0], project_ids[0][1])
+        apply_delayed(project_ids[0][0])
         rule_fire_histories = RuleFireHistory.objects.filter(
             rule__in=[self.rule1, rule5],
             group__in=[self.group1, group5],
@@ -373,7 +374,7 @@ class ProcessDelayedAlertConditionsTest(
         project_ids = buffer.backend.get_sorted_set(
             PROJECT_ID_BUFFER_LIST_KEY, 0, datetime.now(UTC).timestamp()
         )
-        apply_delayed(project_ids[0][0], project_ids[0][1])
+        apply_delayed(project_ids[0][0])
         rule_fire_histories = RuleFireHistory.objects.filter(
             rule__in=[self.rule1, diff_interval_rule],
             group__in=[self.group1, group5],
@@ -405,7 +406,7 @@ class ProcessDelayedAlertConditionsTest(
         project_ids = buffer.backend.get_sorted_set(
             PROJECT_ID_BUFFER_LIST_KEY, 0, datetime.now(UTC).timestamp()
         )
-        apply_delayed(project_ids[0][0], project_ids[0][1])
+        apply_delayed(project_ids[0][0])
         rule_fire_histories = RuleFireHistory.objects.filter(
             rule__in=[self.rule1, diff_env_rule],
             group__in=[self.group1, group5],
@@ -442,7 +443,7 @@ class ProcessDelayedAlertConditionsTest(
         project_ids = buffer.backend.get_sorted_set(
             PROJECT_ID_BUFFER_LIST_KEY, 0, datetime.now(UTC).timestamp()
         )
-        apply_delayed(project_ids[0][0], project_ids[0][1])
+        apply_delayed(project_ids[0][0])
         rule_fire_histories = RuleFireHistory.objects.filter(
             rule__in=[self.rule1, no_fire_rule],
             group__in=[self.group1, group5],


### PR DESCRIPTION
Fix `get_condition_groups` to not combine groups from multiple rules - this was causing the wrong rule to be fired for a given group.

I also renamed `get_rule_to_slow_conditions` to `get_rules_to_slow_conditions` since it's more accurate.