### PR TITLE
ref(replay): fix x-axis date formatting on dom and memory charts

### DIFF
--- a/static/app/views/replays/detail/memoryPanel/domNodesChart.tsx
+++ b/static/app/views/replays/detail/memoryPanel/domNodesChart.tsx
@@ -38,6 +38,9 @@ export default function DomNodesChart({
 }: Props) {
   const theme = useTheme();
   const idRef = useRef(domId('replay-dom-nodes-chart-'));
+  const formatTimestampTrim = (start, offset) => {
+    return getFormattedDate(start + offset, 'MMM D hh:mm', {local: false});
+  };
 
   const chartOptions: Omit<AreaChartProps, 'series'> = useMemo(
     () => ({
@@ -81,7 +84,7 @@ export default function DomNodesChart({
       xAxis: XAxis({
         type: 'time',
         axisLabel: {
-          formatter: (time: number) => formatTime(startTimestampMs + time, false),
+          formatter: (time: number) => formatTimestampTrim(startTimestampMs, time),
         },
         theme,
       }),

--- a/static/app/views/replays/detail/memoryPanel/domNodesChart.tsx
+++ b/static/app/views/replays/detail/memoryPanel/domNodesChart.tsx
@@ -38,9 +38,6 @@ export default function DomNodesChart({
 }: Props) {
   const theme = useTheme();
   const idRef = useRef(domId('replay-dom-nodes-chart-'));
-  const formatTimestampTrim = (start, offset) => {
-    return getFormattedDate(start + offset, 'MMM D hh:mm', {local: false});
-  };
 
   const chartOptions: Omit<AreaChartProps, 'series'> = useMemo(
     () => ({
@@ -84,7 +81,7 @@ export default function DomNodesChart({
       xAxis: XAxis({
         type: 'time',
         axisLabel: {
-          formatter: (time: number) => formatTimestampTrim(startTimestampMs, time),
+          formatter: (time: number) => formatTime(time),
         },
         theme,
       }),

--- a/static/app/views/replays/detail/memoryPanel/memoryChart.tsx
+++ b/static/app/views/replays/detail/memoryPanel/memoryChart.tsx
@@ -38,6 +38,9 @@ export default function MemoryChart({
 }: Props) {
   const theme = useTheme();
   const idRef = useRef(domId('replay-memory-chart-'));
+  const formatTimestampTrim = (start, offset) => {
+    return getFormattedDate(start + offset, 'MMM D hh:mm', {local: false});
+  };
 
   const chartOptions: Omit<AreaChartProps, 'series'> = useMemo(
     () => ({
@@ -80,7 +83,7 @@ export default function MemoryChart({
       xAxis: XAxis({
         type: 'time',
         axisLabel: {
-          formatter: (time: number) => formatTime(startTimestampMs + time, false),
+          formatter: (time: number) => formatTimestampTrim(startTimestampMs, time),
         },
         theme,
       }),

--- a/static/app/views/replays/detail/memoryPanel/memoryChart.tsx
+++ b/static/app/views/replays/detail/memoryPanel/memoryChart.tsx
@@ -38,9 +38,6 @@ export default function MemoryChart({
 }: Props) {
   const theme = useTheme();
   const idRef = useRef(domId('replay-memory-chart-'));
-  const formatTimestampTrim = (start, offset) => {
-    return getFormattedDate(start + offset, 'MMM D hh:mm', {local: false});
-  };
 
   const chartOptions: Omit<AreaChartProps, 'series'> = useMemo(
     () => ({
@@ -83,7 +80,7 @@ export default function MemoryChart({
       xAxis: XAxis({
         type: 'time',
         axisLabel: {
-          formatter: (time: number) => formatTimestampTrim(startTimestampMs, time),
+          formatter: (time: number) => formatTime(time),
         },
         theme,
       }),


### PR DESCRIPTION
The dom/memory chart x-axis timestamps in replay details got messed up in this PR or related refactors: https://github.com/getsentry/sentry/pull/67975

This PR fixes the formatting so that it aligns with the replay timeline.

before:
<img width="449" alt="SCR-20240612-ogme" src="https://github.com/getsentry/sentry/assets/56095982/2884ea5c-5192-4671-83ba-3ade8ed61f62">

after:
<img width="611" alt="SCR-20240612-ohuj" src="https://github.com/getsentry/sentry/assets/56095982/3dd77894-f2ec-41f5-b018-6a3c86657bfc">

where the replay is 7min long:
<img width="1226" alt="SCR-20240612-oivt" src="https://github.com/getsentry/sentry/assets/56095982/0276a1df-1d48-4c51-9328-3a59985afd94">
