### PR TITLE
fix(metrics): Duplicated custom metrics in dropdown

### DIFF
--- a/static/app/utils/metrics/useMetricsMeta.tsx
+++ b/static/app/utils/metrics/useMetricsMeta.tsx
@@ -35,10 +35,25 @@ export function useMetricsMeta(
     }
   );
 
-  const meta = useMemo(
-    () => (data ?? []).sort((a, b) => formatMRI(a.mri).localeCompare(formatMRI(b.mri))),
-    [data]
-  );
+  const meta = useMemo(() => {
+    const sortedMeta = (data ?? []).sort((a, b) =>
+      formatMRI(a.mri).localeCompare(formatMRI(b.mri))
+    );
+
+    // Filter duplicate MRIs and metrics without a project (faulty data)
+    // TODO: Remove this once the endpoint is fixed
+    const seen = new Set<string>();
+    return sortedMeta.filter(entry => {
+      if (!entry.projectIds.length) {
+        return false;
+      }
+      if (seen.has(entry.mri)) {
+        return false;
+      }
+      seen.add(entry.mri);
+      return true;
+    });
+  }, [data]);
 
   const filteredMeta = useMemo(
     () =>


### PR DESCRIPTION
Filter duplicated metrics and metrics without projects from metrics meta response.
Meant as a temporary fix until it is solved on the BE.

Relates to https://github.com/getsentry/sentry/issues/72609