### PR TITLE
fix(metrics): don't duplicate metrics output when querying metrics_details with multiple use-cases and blocked metrics

### DIFF
--- a/src/sentry/sentry_metrics/querying/metadata/metrics.py
+++ b/src/sentry/sentry_metrics/querying/metadata/metrics.py
@@ -68,24 +68,25 @@ def get_metrics_meta(
                 _build_metric_meta(parsed_mri, project_ids, blocking_status, operations_config)
             )
 
-        for metric_mri, metric_blocking in metrics_blocking_state.items():
-            parsed_mri = parse_mri(metric_mri)
-            if parsed_mri is None:
-                continue
+        if use_case_id == UseCaseID.CUSTOM:
+            for metric_mri, metric_blocking in metrics_blocking_state.items():
+                parsed_mri = parse_mri(metric_mri)
+                if parsed_mri is None:
+                    continue
 
-            metrics_metas.append(
-                _build_metric_meta(
-                    parsed_mri,
-                    [],
-                    [
-                        BlockedMetric(
-                            isBlocked=is_blocked, blockedTags=blocked_tags, projectId=project_id
-                        )
-                        for is_blocked, blocked_tags, project_id in metric_blocking
-                    ],
-                    operations_config,
+                metrics_metas.append(
+                    _build_metric_meta(
+                        parsed_mri,
+                        [],
+                        [
+                            BlockedMetric(
+                                isBlocked=is_blocked, blockedTags=blocked_tags, projectId=project_id
+                            )
+                            for is_blocked, blocked_tags, project_id in metric_blocking
+                        ],
+                        operations_config,
+                    )
                 )
-            )
 
     return metrics_metas
 

--- a/src/sentry/sentry_metrics/querying/metadata/metrics.py
+++ b/src/sentry/sentry_metrics/querying/metadata/metrics.py
@@ -40,11 +40,10 @@ def get_metrics_meta(
 
     for use_case_id in use_case_ids:
         stored_metrics = get_available_mris(organization, projects, use_case_id)
-        metrics_blocking_state = (
-            get_metrics_blocking_state_of_projects(projects)
-            if UseCaseID.CUSTOM in use_case_ids
-            else {}
-        )
+        if use_case_id == UseCaseID.CUSTOM:
+            metrics_blocking_state = get_metrics_blocking_state_of_projects(projects)
+        else:
+            metrics_blocking_state = {}
 
         for metric_mri, project_ids in stored_metrics.items():
             parsed_mri = parse_mri(metric_mri)
@@ -68,25 +67,24 @@ def get_metrics_meta(
                 _build_metric_meta(parsed_mri, project_ids, blocking_status, operations_config)
             )
 
-        if use_case_id == UseCaseID.CUSTOM:
-            for metric_mri, metric_blocking in metrics_blocking_state.items():
-                parsed_mri = parse_mri(metric_mri)
-                if parsed_mri is None:
-                    continue
+        for metric_mri, metric_blocking in metrics_blocking_state.items():
+            parsed_mri = parse_mri(metric_mri)
+            if parsed_mri is None:
+                continue
 
-                metrics_metas.append(
-                    _build_metric_meta(
-                        parsed_mri,
-                        [],
-                        [
-                            BlockedMetric(
-                                isBlocked=is_blocked, blockedTags=blocked_tags, projectId=project_id
-                            )
-                            for is_blocked, blocked_tags, project_id in metric_blocking
-                        ],
-                        operations_config,
-                    )
+            metrics_metas.append(
+                _build_metric_meta(
+                    parsed_mri,
+                    [],
+                    [
+                        BlockedMetric(
+                            isBlocked=is_blocked, blockedTags=blocked_tags, projectId=project_id
+                        )
+                        for is_blocked, blocked_tags, project_id in metric_blocking
+                    ],
+                    operations_config,
                 )
+            )
 
     return metrics_metas
 


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry/issues/72609 on the backend - the processing-logic for the metrics meta call checked for presence of the 'custom' UseCaseID in a list, duplicating metrics if that was the case. 
