### PR TITLE
chore(metrics): Revert duplicated metrics quick fix

### DIFF
--- a/static/app/utils/metrics/useMetricsMeta.tsx
+++ b/static/app/utils/metrics/useMetricsMeta.tsx
@@ -35,25 +35,10 @@ export function useMetricsMeta(
     }
   );
 
-  const meta = useMemo(() => {
-    const sortedMeta = (data ?? []).sort((a, b) =>
-      formatMRI(a.mri).localeCompare(formatMRI(b.mri))
-    );
-
-    // Filter duplicate MRIs and metrics without a project (faulty data)
-    // TODO: Remove this once the endpoint is fixed
-    const seen = new Set<string>();
-    return sortedMeta.filter(entry => {
-      if (!entry.projectIds.length) {
-        return false;
-      }
-      if (seen.has(entry.mri)) {
-        return false;
-      }
-      seen.add(entry.mri);
-      return true;
-    });
-  }, [data]);
+  const meta = useMemo(
+    () => (data ?? []).sort((a, b) => formatMRI(a.mri).localeCompare(formatMRI(b.mri))),
+    [data]
+  );
 
   const filteredMeta = useMemo(
     () =>


### PR DESCRIPTION
Revert the [FE quick fix](https://github.com/getsentry/sentry/pull/72671) as it is now [solved on the BE](https://github.com/getsentry/sentry/pull/72672).

Relates to https://github.com/getsentry/sentry/issues/72609