### PR TITLE
chore(hybridcloud) Remove multi-region-selector feature

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -36,8 +36,6 @@ def register_temporary_features(manager: FeatureManager):
     manager.add("auth:register", SystemFeature, FeatureHandlerStrategy.INTERNAL, default=True)
     # Enable creating organizations within sentry (if SENTRY_SINGLE_ORGANIZATION is not enabled).
     manager.add("organizations:create", SystemFeature, FeatureHandlerStrategy.INTERNAL, default=True)
-    # Enables region provisioning for individual users
-    manager.add("organizations:multi-region-selector", SystemFeature, FeatureHandlerStrategy.INTERNAL, default=True)
     # Controls whether or not the relocation endpoints can be used.
     manager.add("relocation:enabled", SystemFeature, FeatureHandlerStrategy.INTERNAL)
 

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1789,14 +1789,6 @@ register(
 
 # === Hybrid cloud subsystem options ===
 # UI rollout
-register("hybrid_cloud.multi-region-selector", default=False, flags=FLAG_AUTOMATOR_MODIFIABLE)
-register("hybrid_cloud.region-domain-allow-list", default=[], flags=FLAG_AUTOMATOR_MODIFIABLE)
-register("hybrid_cloud.region-user-allow-list", default=[], flags=FLAG_AUTOMATOR_MODIFIABLE)
-
-register(
-    "hybrid_cloud.use_region_specific_upload_url", default=True, flags=FLAG_AUTOMATOR_MODIFIABLE
-)
-
 register(
     "hybrid_cloud.disable_relative_upload_urls", default=False, flags=FLAG_AUTOMATOR_MODIFIABLE
 )

--- a/src/sentry/web/client_config.py
+++ b/src/sentry/web/client_config.py
@@ -228,8 +228,6 @@ class _ClientConfig:
         ):
             yield "organizations:customer-domains"
 
-        yield "organizations:multi-region-selector"
-
     @property
     def needs_upgrade(self) -> bool:
         return self.request is not None and is_active_superuser(self.request) and _needs_upgrade()

--- a/tests/sentry/web/test_api.py
+++ b/tests/sentry/web/test_api.py
@@ -109,7 +109,6 @@ class ClientConfigViewTest(TestCase):
             assert data["features"] == [
                 "organizations:create",
                 "auth:register",
-                "organizations:multi-region-selector",
             ]
 
         with self.options({"auth.allow-registration": False}):
@@ -119,7 +118,6 @@ class ClientConfigViewTest(TestCase):
             data = json.loads(resp.content)
             assert data["features"] == [
                 "organizations:create",
-                "organizations:multi-region-selector",
             ]
 
     def test_org_create_feature(self):
@@ -130,7 +128,6 @@ class ClientConfigViewTest(TestCase):
             data = json.loads(resp.content)
             assert data["features"] == [
                 "organizations:create",
-                "organizations:multi-region-selector",
             ]
 
         with self.feature({"organizations:create": False}):
@@ -138,7 +135,7 @@ class ClientConfigViewTest(TestCase):
             assert resp.status_code == 200
             assert resp["Content-Type"] == "application/json"
             data = json.loads(resp.content)
-            assert data["features"] == ["organizations:multi-region-selector"]
+            assert data["features"] == []
 
     def test_customer_domain_feature(self):
         self.login_as(self.user)
@@ -159,7 +156,6 @@ class ClientConfigViewTest(TestCase):
             assert data["features"] == [
                 "organizations:create",
                 "organizations:customer-domains",
-                "organizations:multi-region-selector",
             ]
 
         with self.feature({"organizations:customer-domains": False}):
@@ -169,7 +165,6 @@ class ClientConfigViewTest(TestCase):
             data = json.loads(resp.content)
             assert data["features"] == [
                 "organizations:create",
-                "organizations:multi-region-selector",
             ]
 
             # Customer domain feature is injected if a customer domain is used.
@@ -180,7 +175,6 @@ class ClientConfigViewTest(TestCase):
             assert data["features"] == [
                 "organizations:create",
                 "organizations:customer-domains",
-                "organizations:multi-region-selector",
             ]
 
     def test_unauthenticated(self):
@@ -191,7 +185,7 @@ class ClientConfigViewTest(TestCase):
         data = json.loads(resp.content)
         assert not data["isAuthenticated"]
         assert data["user"] is None
-        assert data["features"] == ["organizations:create", "organizations:multi-region-selector"]
+        assert data["features"] == ["organizations:create"]
         assert data["customerDomain"] is None
 
     def test_authenticated(self):
@@ -206,7 +200,7 @@ class ClientConfigViewTest(TestCase):
         assert data["isAuthenticated"]
         assert data["user"]
         assert data["user"]["email"] == user.email
-        assert data["features"] == ["organizations:create", "organizations:multi-region-selector"]
+        assert data["features"] == ["organizations:create"]
         assert data["customerDomain"] is None
 
     def _run_test_with_privileges(self, is_superuser: bool, is_staff: bool):


### PR DESCRIPTION
This feature and its related options can be removed as region select UI is enabled by default, and there no remaining feature checks.

Refs getsentry/getsentry#14307