### PR TITLE
fix(query-builder): Ignore arrow up/down behavior when a token is focused

### DIFF
--- a/static/app/components/searchQueryBuilder/useQueryBuilderGrid.tsx
+++ b/static/app/components/searchQueryBuilder/useQueryBuilderGrid.tsx
@@ -92,7 +92,14 @@ export function useQueryBuilderGrid(
         }
       }
 
-      originalGridProps.onKeyDown?.(e);
+      switch (e.key) {
+        // Default behavior for these keys is to move the focus, which we don't want
+        case 'ArrowUp':
+        case 'ArrowDown':
+          break;
+        default:
+          originalGridProps.onKeyDown?.(e);
+      }
     },
     [dispatch, originalGridProps, query, state.collection, state.selectionManager]
   );


### PR DESCRIPTION
Small fix for a bug which was introduced after adding the cmd+a behavior. Arrow up/down wanted to focus or select a different item, but we should ignore it instead.