### PR TITLE
feat(admin): Impove user account merging

### DIFF
--- a/src/sentry/backup/dependencies.py
+++ b/src/sentry/backup/dependencies.py
@@ -6,12 +6,13 @@ from enum import Enum, auto, unique
 from functools import lru_cache
 from typing import NamedTuple
 
-from django.db import models
-from django.db.models import UniqueConstraint
+from django.db import IntegrityError, models, router, transaction
+from django.db.models import Q, UniqueConstraint
 from django.db.models.fields.related import ForeignKey, OneToOneField
 
 from sentry.backup.helpers import EXCLUDED_APPS
 from sentry.backup.scopes import RelocationScope
+from sentry.db.postgres.transactions import enforce_constraints
 from sentry.silo.base import SiloMode
 from sentry.utils import json
 
@@ -701,3 +702,32 @@ def get_exportable_sentry_models() -> set[type[models.base.Model]]:
             get_final_derivations_of(BaseModel),
         )
     )
+
+
+def merge_users_for_model_in_org(
+    model: type[models.base.Model], *, organization_id: int, from_user_id: int, to_user_id: int
+) -> None:
+    """
+    All instances of this model in a certain organization that reference both the organization and
+    user in question will be pointed at the new user instead.
+    """
+
+    from sentry.models.organization import Organization
+    from sentry.models.user import User
+
+    model_relations = dependencies()[get_model_name(model)]
+    user_refs = {k for k, v in model_relations.foreign_keys.items() if v.model == User}
+    org_refs = {
+        k if k.endswith("_id") else f"{k}_id"
+        for k, v in model_relations.foreign_keys.items()
+        if v.model == Organization
+    }
+    for_this_org = Q(**{field_name: organization_id for field_name in org_refs})
+    for user_ref in user_refs:
+        q = for_this_org & Q(**{user_ref: from_user_id})
+        obj = model.objects.filter(q)
+        try:
+            with enforce_constraints(transaction.atomic(router.db_for_write(model))):
+                obj.update(**{user_ref: to_user_id})
+        except IntegrityError:
+            pass

--- a/src/sentry/services/hybrid_cloud/organization/impl.py
+++ b/src/sentry/services/hybrid_cloud/organization/impl.py
@@ -9,20 +9,33 @@ from django.dispatch import Signal
 
 from sentry import roles
 from sentry.api.serializers import serialize
+from sentry.backup.dependencies import merge_users_for_model_in_org
 from sentry.db.postgres.transactions import enforce_constraints
+from sentry.incidents.models.alert_rule import AlertRule, AlertRuleActivity
+from sentry.incidents.models.incident import IncidentActivity, IncidentSubscription
 from sentry.models.activity import Activity
+from sentry.models.dashboard import Dashboard
+from sentry.models.dynamicsampling import CustomDynamicSamplingRule
 from sentry.models.groupassignee import GroupAssignee
 from sentry.models.groupbookmark import GroupBookmark
+from sentry.models.groupsearchview import GroupSearchView
 from sentry.models.groupseen import GroupSeen
 from sentry.models.groupshare import GroupShare
 from sentry.models.groupsubscription import GroupSubscription
 from sentry.models.organization import Organization, OrganizationStatus
+from sentry.models.organizationaccessrequest import OrganizationAccessRequest
 from sentry.models.organizationmapping import OrganizationMapping
 from sentry.models.organizationmember import InviteStatus, OrganizationMember
 from sentry.models.organizationmemberteam import OrganizationMemberTeam
 from sentry.models.outbox import ControlOutbox, OutboxCategory, OutboxScope, outbox_context
+from sentry.models.projectbookmark import ProjectBookmark
+from sentry.models.recentsearch import RecentSearch
+from sentry.models.rule import Rule, RuleActivity
+from sentry.models.rulesnooze import RuleSnooze
+from sentry.models.savedsearch import SavedSearch
 from sentry.models.scheduledeletion import RegionScheduledDeletion
 from sentry.models.team import Team, TeamStatus
+from sentry.monitors.models import Monitor
 from sentry.services.hybrid_cloud import OptionValue, logger
 from sentry.services.hybrid_cloud.app import app_service
 from sentry.services.hybrid_cloud.organization import (
@@ -515,33 +528,67 @@ class DatabaseBackedOrganizationService(OrganizationService):
 
         assert to_member
 
+        # Delete all org access requests between the two now-merged users.
+        OrganizationAccessRequest.objects.filter(
+            member=from_member, requester_id=to_user_id
+        ).delete()
+        OrganizationAccessRequest.objects.filter(
+            member=to_member, requester_id=from_user_id
+        ).delete()
+
+        # All other org access requests should be pointed from the old member to the new one.
+        reqs = OrganizationAccessRequest.objects.filter(member=from_member)
+        for req in reqs:
+            req.member = to_member
+            req.save()
+
         for team in from_member.teams.all():
             try:
                 with enforce_constraints(
                     transaction.atomic(router.db_for_write(OrganizationMemberTeam))
                 ):
                     OrganizationMemberTeam.objects.create(organizationmember=to_member, team=team)
+                    OrganizationMemberTeam.objects.filter(
+                        organizationmember=from_member, team=team
+                    ).delete()
             except IntegrityError:
                 pass
 
-        model_list = (
+        # Update all organization region models to only use the new user id.
+        model_set = {
+            Activity,
+            AlertRule,
+            AlertRuleActivity,
+            CustomDynamicSamplingRule,
+            Dashboard,
             GroupAssignee,
             GroupBookmark,
             GroupSeen,
             GroupShare,
+            GroupSearchView,
             GroupSubscription,
-            Activity,
-        )
+            IncidentActivity,
+            IncidentSubscription,
+            Monitor,
+            OrganizationAccessRequest,
+            OrganizationMember,
+            ProjectBookmark,
+            RecentSearch,
+            Rule,
+            RuleActivity,
+            RuleSnooze,
+            SavedSearch,
+        }
+        for model in model_set:
+            merge_users_for_model_in_org(
+                model,
+                organization_id=organization_id,
+                from_user_id=from_user_id,
+                to_user_id=to_user_id,
+            )
 
-        for model in model_list:
-            for obj in model.objects.filter(
-                user_id=from_user_id, project__organization_id=organization_id
-            ):
-                try:
-                    with enforce_constraints(transaction.atomic(router.db_for_write(model))):
-                        obj.update(user_id=to_user_id)
-                except IntegrityError:
-                    pass
+        # Finally, delete the old member.
+        from_member.delete()
 
     def reset_idp_flags(self, *, organization_id: int) -> None:
         with unguarded_write(using=router.db_for_write(OrganizationMember)):

--- a/src/sentry/testutils/helpers/backups.py
+++ b/src/sentry/testutils/helpers/backups.py
@@ -41,7 +41,6 @@ from sentry.backup.helpers import Printer
 from sentry.backup.imports import import_in_global_scope
 from sentry.backup.scopes import ExportScope
 from sentry.backup.validate import validate
-from sentry.db.models.fields.bounded import BoundedBigAutoField
 from sentry.db.models.paranoia import ParanoidModel
 from sentry.incidents.models.alert_rule import AlertRuleMonitorType
 from sentry.incidents.models.incident import (
@@ -53,6 +52,7 @@ from sentry.incidents.models.incident import (
     TimeSeriesSnapshot,
 )
 from sentry.incidents.utils.types import AlertRuleActivationConditionType
+from sentry.models.activity import Activity
 from sentry.models.apiauthorization import ApiAuthorization
 from sentry.models.apigrant import ApiGrant
 from sentry.models.apikey import ApiKey
@@ -69,7 +69,12 @@ from sentry.models.dashboard_widget import (
     DashboardWidgetTypes,
 )
 from sentry.models.dynamicsampling import CustomDynamicSamplingRule
+from sentry.models.groupassignee import GroupAssignee
+from sentry.models.groupbookmark import GroupBookmark
 from sentry.models.groupsearchview import GroupSearchView
+from sentry.models.groupseen import GroupSeen
+from sentry.models.groupshare import GroupShare
+from sentry.models.groupsubscription import GroupSubscription
 from sentry.models.integrations.integration import Integration
 from sentry.models.integrations.organization_integration import OrganizationIntegration
 from sentry.models.integrations.project_integration import ProjectIntegration
@@ -369,7 +374,7 @@ class ExhaustiveFixtures(Fixtures):
         accepted_invites: dict[User, list[User]] | None = None,
     ) -> Organization:
         org = self.create_organization(name=slug, owner=owner)
-        owner_id: BoundedBigAutoField = owner.id
+        owner_id: int = owner.id
         invited = self.create_member(organization=org, user=member, role="member")
         if other_members:
             for user in other_members:
@@ -397,7 +402,7 @@ class ExhaustiveFixtures(Fixtures):
         # Team
         team = self.create_team(name=f"test_team_in_{slug}", organization=org)
         self.create_team_membership(user=owner, team=team)
-        OrganizationAccessRequest.objects.create(member=invited, team=team)
+        OrganizationAccessRequest.objects.create(member=invited, team=team, requester_id=owner_id)
 
         # Project*
         project_template = ProjectTemplate.objects.create(name=f"template-{slug}", organization=org)
@@ -428,8 +433,10 @@ class ExhaustiveFixtures(Fixtures):
         )
 
         # Rule*
-        rule = self.create_project_rule(project=project)
-        RuleActivity.objects.create(rule=rule, type=RuleActivityType.CREATED.value)
+        rule = self.create_project_rule(project=project, owner_user_id=owner_id)
+        RuleActivity.objects.create(
+            rule=rule, type=RuleActivityType.CREATED.value, user_id=owner_id
+        )
         self.snooze_rule(user_id=owner_id, owner_id=owner_id, rule=rule)
         NeglectedRule.objects.create(
             rule=rule,
@@ -439,6 +446,7 @@ class ExhaustiveFixtures(Fixtures):
             sent_final_email_date=timezone.now(),
         )
         CustomDynamicSamplingRule.update_or_create(
+            created_by_id=owner_id,
             condition={"op": "equals", "name": "environment", "value": "prod"},
             start=timezone.now(),
             end=timezone.now() + timedelta(hours=1),
@@ -458,6 +466,7 @@ class ExhaustiveFixtures(Fixtures):
             project_id=project.id,
             type=MonitorType.CRON_JOB,
             config={"schedule": "* * * * *", "schedule_type": ScheduleType.CRONTAB},
+            owner_user_id=owner_id,
         )
 
         # AlertRule*
@@ -467,7 +476,10 @@ class ExhaustiveFixtures(Fixtures):
             projects=[project],
             include_all_projects=True,
             excluded_projects=[other_project],
+            user=owner,
         )
+        alert.user_id = owner_id
+        alert.save()
         trigger = self.create_alert_rule_trigger(alert_rule=alert, excluded_projects=[project])
         self.create_alert_rule_trigger_action(alert_rule_trigger=trigger)
         activated_alert = self.create_alert_rule(
@@ -492,6 +504,7 @@ class ExhaustiveFixtures(Fixtures):
             incident=incident,
             type=1,
             comment=f"hello {slug}",
+            user_id=owner_id,
         )
         IncidentSnapshot.objects.create(
             incident=incident,
@@ -549,6 +562,7 @@ class ExhaustiveFixtures(Fixtures):
             name=f"Saved query for {slug}",
             query=f"saved query for {slug}",
             visibility=Visibility.ORGANIZATION,
+            owner_id=owner_id,
         )
 
         # misc
@@ -563,7 +577,8 @@ class ExhaustiveFixtures(Fixtures):
         repo.external_id = "https://git.example.com:1234"
         repo.save()
 
-        # View
+        # Group*
+        group = self.create_group(project=project)
         GroupSearchView.objects.create(
             name=f"View 1 for {slug}",
             user_id=owner_id,
@@ -572,6 +587,18 @@ class ExhaustiveFixtures(Fixtures):
             query_sort="date",
             position=0,
         )
+        Activity.objects.create(
+            project=project,
+            group=group,
+            user_id=owner_id,
+            type=1,
+        )
+        for group_model in {GroupAssignee, GroupBookmark, GroupSeen, GroupShare, GroupSubscription}:
+            group_model.objects.create(
+                project=project,
+                group=group,
+                user_id=owner_id,
+            )
 
         return org
 
@@ -592,6 +619,7 @@ class ExhaustiveFixtures(Fixtures):
         )
         OrgAuthToken.objects.create(
             organization_id=org.id,
+            created_by=owner,
             name=f"token 1 for {org.slug}",
             token_hashed=f"ABCDEF{org.slug}",
             token_last_characters="xyz1",

--- a/tests/sentry/backup/snapshots/ReleaseTests/test_at_head.pysnap
+++ b/tests/sentry/backup/snapshots/ReleaseTests/test_at_head.pysnap
@@ -1,18 +1,18 @@
 ---
-created: '2024-06-10T19:38:25.461766+00:00'
+created: '2024-06-13T16:17:49.842791+00:00'
 creator: sentry
 source: tests/sentry/backup/test_releases.py
 ---
 - fields:
     key: bar
-    last_updated: '2024-06-10T19:38:25.108Z'
+    last_updated: '2024-06-13T16:17:49.544Z'
     last_updated_by: unknown
     value: '"b"'
   model: sentry.controloption
   pk: 1
 - fields:
-    date_added: '2024-06-10T19:38:24.411Z'
-    date_updated: '2024-06-10T19:38:24.411Z'
+    date_added: '2024-06-13T16:17:48.987Z'
+    date_updated: '2024-06-13T16:17:48.987Z'
     external_id: slack:test-org
     metadata: {}
     name: Slack for test-org
@@ -22,13 +22,13 @@ source: tests/sentry/backup/test_releases.py
   pk: 1
 - fields:
     key: foo
-    last_updated: '2024-06-10T19:38:25.106Z'
+    last_updated: '2024-06-13T16:17:49.543Z'
     last_updated_by: unknown
     value: '"a"'
   model: sentry.option
   pk: 1
 - fields:
-    date_added: '2024-06-10T19:38:23.258Z'
+    date_added: '2024-06-13T16:17:48.309Z'
     default_role: member
     flags: '1'
     is_test: false
@@ -36,40 +36,40 @@ source: tests/sentry/backup/test_releases.py
     slug: test-org
     status: 0
   model: sentry.organization
-  pk: 4554157368213504
+  pk: 4554173566418944
 - fields:
-    date_added: '2024-06-10T19:38:24.651Z'
+    date_added: '2024-06-13T16:17:49.170Z'
     default_role: member
     flags: '1'
     is_test: false
-    name: Immune Roughy
-    slug: immune-roughy
+    name: Cute Stingray
+    slug: cute-stingray
     status: 0
   model: sentry.organization
-  pk: 4554157368279043
+  pk: 4554173566484481
 - fields:
     config:
       hello: hello
-    date_added: '2024-06-10T19:38:24.413Z'
-    date_updated: '2024-06-10T19:38:24.413Z'
+    date_added: '2024-06-13T16:17:48.988Z'
+    date_updated: '2024-06-13T16:17:48.988Z'
     default_auth_id: null
     grace_period_end: null
     integration: 1
-    organization_id: 4554157368213504
+    organization_id: 4554173566418944
     status: 0
   model: sentry.organizationintegration
   pk: 1
 - fields:
     key: sentry:account-rate-limit
-    organization: 4554157368213504
+    organization: 4554173566418944
     value: 0
   model: sentry.organizationoption
   pk: 1
 - fields:
-    date_added: '2024-06-10T19:38:24.162Z'
-    date_updated: '2024-06-10T19:38:24.162Z'
+    date_added: '2024-06-13T16:17:48.842Z'
+    date_updated: '2024-06-13T16:17:48.842Z'
     name: template-test-org
-    organization: 4554157368213504
+    organization: 4554173566418944
   model: sentry.projecttemplate
   pk: 1
 - fields:
@@ -82,44 +82,44 @@ source: tests/sentry/backup/test_releases.py
     first_seen: null
     is_internal: true
     last_seen: null
-    public_key: 7ZqqBi4-PVxOYOwkafAhWyIzZKZ0KW3-eEHqszzy6ek
-    relay_id: 56725b4d-32c6-4b56-94c4-b2a64791d111
+    public_key: 7Zj8hxJRBcYUBg6kjoGNMMIVj1_gsGBB2UhZ4C8At-M
+    relay_id: 9eeb5e2b-c309-4ae5-a8b7-71791e0e72a5
   model: sentry.relay
   pk: 1
 - fields:
-    first_seen: '2024-06-10T19:38:25.104Z'
-    last_seen: '2024-06-10T19:38:25.104Z'
-    public_key: 7ZqqBi4-PVxOYOwkafAhWyIzZKZ0KW3-eEHqszzy6ek
-    relay_id: 56725b4d-32c6-4b56-94c4-b2a64791d111
+    first_seen: '2024-06-13T16:17:49.542Z'
+    last_seen: '2024-06-13T16:17:49.542Z'
+    public_key: 7Zj8hxJRBcYUBg6kjoGNMMIVj1_gsGBB2UhZ4C8At-M
+    relay_id: 9eeb5e2b-c309-4ae5-a8b7-71791e0e72a5
     version: 0.0.1
   model: sentry.relayusage
   pk: 1
 - fields:
     config: {}
-    date_added: '2024-06-10T19:38:24.634Z'
+    date_added: '2024-06-13T16:17:49.136Z'
     external_id: https://git.example.com:1234
     integration_id: 1
     languages: '[]'
     name: getsentry/getsentry
-    organization_id: 4554157368213504
+    organization_id: 4554173566418944
     provider: integrations:github
     status: 0
     url: https://github.com/getsentry/getsentry
   model: sentry.repository
   pk: 1
 - fields:
-    date_added: '2024-06-10T19:38:24.054Z'
+    date_added: '2024-06-13T16:17:48.789Z'
     idp_provisioned: false
     name: test_team_in_test-org
-    organization: 4554157368213504
+    organization: 4554173566418944
     slug: test_team_in_test-org
     status: 0
   model: sentry.team
-  pk: 4554157368279040
+  pk: 4554173566418945
 - fields:
     avatar_type: 0
     avatar_url: null
-    date_joined: '2024-06-10T19:38:22.255Z'
+    date_joined: '2024-06-13T16:17:47.222Z'
     email: superadmin
     flags: '0'
     is_active: true
@@ -129,11 +129,11 @@ source: tests/sentry/backup/test_releases.py
     is_staff: true
     is_superuser: true
     is_unclaimed: false
-    last_active: '2024-06-10T19:38:22.255Z'
+    last_active: '2024-06-13T16:17:47.222Z'
     last_login: null
-    last_password_change: '2024-06-10T19:38:22.255Z'
+    last_password_change: '2024-06-13T16:17:47.222Z'
     name: ''
-    password: md5$YyRycJSebyXJfc4hJ9aOjE$ab8ac6d3779b3816cc0d7c5947699258
+    password: md5$5yEp1PNbXdmNev1XtYq2qy$6f2ec1f378c430308c709707af0f1046
     session_nonce: null
     username: superadmin
   model: sentry.user
@@ -141,7 +141,7 @@ source: tests/sentry/backup/test_releases.py
 - fields:
     avatar_type: 0
     avatar_url: null
-    date_joined: '2024-06-10T19:38:23.153Z'
+    date_joined: '2024-06-13T16:17:48.202Z'
     email: owner
     flags: '0'
     is_active: true
@@ -151,11 +151,11 @@ source: tests/sentry/backup/test_releases.py
     is_staff: false
     is_superuser: false
     is_unclaimed: false
-    last_active: '2024-06-10T19:38:23.153Z'
+    last_active: '2024-06-13T16:17:48.202Z'
     last_login: null
-    last_password_change: '2024-06-10T19:38:23.153Z'
+    last_password_change: '2024-06-13T16:17:48.202Z'
     name: ''
-    password: md5$pEKyThOkc9SwrgN8JRHMbi$b37286c3dd44e255b975be2817b0aedb
+    password: md5$0dT3bQDKhpF82GfcePhON0$f5d951a9905777af863633e24ab651f0
     session_nonce: null
     username: owner
   model: sentry.user
@@ -163,7 +163,7 @@ source: tests/sentry/backup/test_releases.py
 - fields:
     avatar_type: 0
     avatar_url: null
-    date_joined: '2024-06-10T19:38:23.185Z'
+    date_joined: '2024-06-13T16:17:48.238Z'
     email: member
     flags: '0'
     is_active: true
@@ -173,11 +173,11 @@ source: tests/sentry/backup/test_releases.py
     is_staff: false
     is_superuser: false
     is_unclaimed: false
-    last_active: '2024-06-10T19:38:23.185Z'
+    last_active: '2024-06-13T16:17:48.238Z'
     last_login: null
-    last_password_change: '2024-06-10T19:38:23.185Z'
+    last_password_change: '2024-06-13T16:17:48.238Z'
     name: ''
-    password: md5$JzAdkp0MJUmsYOAhs9mWOk$a733f7c462d9a4f3761c293e237187d2
+    password: md5$FFgFZqryiQcjEsO0SKAhbG$49ca6d10f572db2b156f174086a9774d
     session_nonce: null
     username: member
   model: sentry.user
@@ -185,7 +185,7 @@ source: tests/sentry/backup/test_releases.py
 - fields:
     avatar_type: 0
     avatar_url: null
-    date_joined: '2024-06-10T19:38:23.201Z'
+    date_joined: '2024-06-13T16:17:48.256Z'
     email: added-by-superadmin-not-in-org
     flags: '0'
     is_active: true
@@ -195,11 +195,11 @@ source: tests/sentry/backup/test_releases.py
     is_staff: false
     is_superuser: false
     is_unclaimed: false
-    last_active: '2024-06-10T19:38:23.201Z'
+    last_active: '2024-06-13T16:17:48.256Z'
     last_login: null
-    last_password_change: '2024-06-10T19:38:23.201Z'
+    last_password_change: '2024-06-13T16:17:48.257Z'
     name: ''
-    password: md5$LDQFyB55mbvqfMaxZnONzm$e2edf8ec06188f33502ff4c279591b0d
+    password: md5$GE2nmbbEQlj9DzFWQaicnf$b653700f8b9ebdfc2780c931f1f18e78
     session_nonce: null
     username: added-by-superadmin-not-in-org
   model: sentry.user
@@ -207,7 +207,7 @@ source: tests/sentry/backup/test_releases.py
 - fields:
     avatar_type: 0
     avatar_url: null
-    date_joined: '2024-06-10T19:38:23.220Z'
+    date_joined: '2024-06-13T16:17:48.274Z'
     email: added-by-org-owner
     flags: '0'
     is_active: true
@@ -217,11 +217,11 @@ source: tests/sentry/backup/test_releases.py
     is_staff: false
     is_superuser: false
     is_unclaimed: false
-    last_active: '2024-06-10T19:38:23.220Z'
+    last_active: '2024-06-13T16:17:48.274Z'
     last_login: null
-    last_password_change: '2024-06-10T19:38:23.220Z'
+    last_password_change: '2024-06-13T16:17:48.274Z'
     name: ''
-    password: md5$tSCAKL6aHwR4ccYbkQEUhL$bcf830a4552462c0f743f12a700092a3
+    password: md5$s2AdKwPyUOZO2ikdHb5TuG$82122ae82b97c91442577117767fc4d0
     session_nonce: null
     username: added-by-org-owner
   model: sentry.user
@@ -229,7 +229,7 @@ source: tests/sentry/backup/test_releases.py
 - fields:
     avatar_type: 0
     avatar_url: null
-    date_joined: '2024-06-10T19:38:23.239Z'
+    date_joined: '2024-06-13T16:17:48.291Z'
     email: added-by-org-member
     flags: '0'
     is_active: true
@@ -239,11 +239,11 @@ source: tests/sentry/backup/test_releases.py
     is_staff: false
     is_superuser: false
     is_unclaimed: false
-    last_active: '2024-06-10T19:38:23.239Z'
+    last_active: '2024-06-13T16:17:48.291Z'
     last_login: null
-    last_password_change: '2024-06-10T19:38:23.239Z'
+    last_password_change: '2024-06-13T16:17:48.292Z'
     name: ''
-    password: md5$7ZAspwTcHeB8isRTcjY6mO$0182aa4bdea639482ede2b58fd14e010
+    password: md5$MiYCW0g4BnO4z5LuQmSm3S$4d44e274e5c550ec430b8171e65b2950
     session_nonce: null
     username: added-by-org-member
   model: sentry.user
@@ -251,7 +251,7 @@ source: tests/sentry/backup/test_releases.py
 - fields:
     avatar_type: 0
     avatar_url: null
-    date_joined: '2024-06-10T19:38:24.565Z'
+    date_joined: '2024-06-13T16:17:49.076Z'
     email: admin@localhost
     flags: '0'
     is_active: true
@@ -261,11 +261,11 @@ source: tests/sentry/backup/test_releases.py
     is_staff: true
     is_superuser: true
     is_unclaimed: false
-    last_active: '2024-06-10T19:38:24.565Z'
+    last_active: '2024-06-13T16:17:49.076Z'
     last_login: null
-    last_password_change: '2024-06-10T19:38:24.565Z'
+    last_password_change: '2024-06-13T16:17:49.076Z'
     name: ''
-    password: md5$dZgm6TV3dhbmv1JDoKThmI$1d59c9253048ab85d6ac1562468b8bb0
+    password: md5$Si9rXJ6Mze1ZsTIKY82WD7$57aff986066ac8c6d117a145cf8743df
     session_nonce: null
     username: admin@localhost
   model: sentry.user
@@ -273,8 +273,8 @@ source: tests/sentry/backup/test_releases.py
 - fields:
     avatar_type: 0
     avatar_url: null
-    date_joined: '2024-06-10T19:38:24.638Z'
-    email: 9c16599997e44e69a07f7c62f26e293a@example.com
+    date_joined: '2024-06-13T16:17:49.158Z'
+    email: b570ba8f83e9419999ed98c61553c5ef@example.com
     flags: '0'
     is_active: true
     is_managed: false
@@ -283,19 +283,19 @@ source: tests/sentry/backup/test_releases.py
     is_staff: false
     is_superuser: false
     is_unclaimed: false
-    last_active: '2024-06-10T19:38:24.638Z'
+    last_active: '2024-06-13T16:17:49.158Z'
     last_login: null
-    last_password_change: '2024-06-10T19:38:24.639Z'
+    last_password_change: '2024-06-13T16:17:49.158Z'
     name: ''
-    password: md5$zh0xf2H6vSFaOrNVyQcvSE$18104dabe0350b4fdf3998910aa2d2ec
+    password: md5$N34PwQg4OtO2y2A2eBhBSQ$8f3a1412f985e4e38bc356921ac9a863
     session_nonce: null
-    username: 9c16599997e44e69a07f7c62f26e293a@example.com
+    username: b570ba8f83e9419999ed98c61553c5ef@example.com
   model: sentry.user
   pk: 8
 - fields:
     avatar_type: 0
     avatar_url: null
-    date_joined: '2024-06-10T19:38:24.711Z'
+    date_joined: '2024-06-13T16:17:49.221Z'
     email: ''
     flags: '0'
     is_active: true
@@ -305,20 +305,20 @@ source: tests/sentry/backup/test_releases.py
     is_staff: false
     is_superuser: false
     is_unclaimed: false
-    last_active: '2024-06-10T19:38:24.711Z'
+    last_active: '2024-06-13T16:17:49.221Z'
     last_login: null
     last_password_change: null
     name: ''
     password: ''
     session_nonce: null
-    username: test-app-4090848c-27eb-4bf8-998b-7229df0ae11a
+    username: test-app-937d1ea6-6d68-47d5-be1a-cdba980b704e
   model: sentry.user
   pk: 9
 - fields:
     avatar_type: 0
     avatar_url: null
-    date_joined: '2024-06-10T19:38:24.986Z'
-    email: b2cb2576bfbf439782183048f5f06074@example.com
+    date_joined: '2024-06-13T16:17:49.455Z'
+    email: 75edc948a7b94b44a17968f7d3341cd5@example.com
     flags: '0'
     is_active: true
     is_managed: false
@@ -327,13 +327,13 @@ source: tests/sentry/backup/test_releases.py
     is_staff: false
     is_superuser: false
     is_unclaimed: false
-    last_active: '2024-06-10T19:38:24.986Z'
+    last_active: '2024-06-13T16:17:49.455Z'
     last_login: null
-    last_password_change: '2024-06-10T19:38:24.986Z'
+    last_password_change: '2024-06-13T16:17:49.455Z'
     name: ''
-    password: md5$PV06acbqAnYbxsn0QwD2m7$87fdc091353e4a4979737bab5e4fa1cd
+    password: md5$3xNEVEN7BHCfrrSTtH6m5r$9f563f54b0ac35be32725ebaac6088a7
     session_nonce: null
-    username: b2cb2576bfbf439782183048f5f06074@example.com
+    username: 75edc948a7b94b44a17968f7d3341cd5@example.com
   model: sentry.user
   pk: 10
 - fields:
@@ -396,25 +396,25 @@ source: tests/sentry/backup/test_releases.py
   model: sentry.userpermission
   pk: 1
 - fields:
-    date_added: '2024-06-10T19:38:22.287Z'
-    date_updated: '2024-06-10T19:38:22.287Z'
+    date_added: '2024-06-13T16:17:47.249Z'
+    date_updated: '2024-06-13T16:17:47.249Z'
     name: test-admin-role
     permissions: '[]'
   model: sentry.userrole
   pk: 1
 - fields:
-    date_added: '2024-06-10T19:38:22.294Z'
-    date_updated: '2024-06-10T19:38:22.294Z'
+    date_added: '2024-06-13T16:17:47.254Z'
+    date_updated: '2024-06-13T16:17:47.254Z'
     role: 1
     user: 1
   model: sentry.userroleuser
   pk: 1
 - fields:
-    date_added: '2024-06-10T19:38:24.628Z'
+    date_added: '2024-06-13T16:17:49.130Z'
     is_global: false
     name: Saved query for test-org
-    organization: 4554157368213504
-    owner_id: null
+    organization: 4554173566418944
+    owner_id: 2
     query: saved query for test-org
     sort: date
     type: 0
@@ -422,9 +422,9 @@ source: tests/sentry/backup/test_releases.py
   model: sentry.savedsearch
   pk: 1
 - fields:
-    date_added: '2024-06-10T19:38:24.627Z'
-    last_seen: '2024-06-10T19:38:24.627Z'
-    organization: 4554157368213504
+    date_added: '2024-06-13T16:17:49.129Z'
+    last_seen: '2024-06-13T16:17:49.129Z'
+    organization: 4554173566418944
     query: some query for test-org
     query_hash: 7c69362cd42207b83f80087bc15ebccb
     type: 0
@@ -432,82 +432,82 @@ source: tests/sentry/backup/test_releases.py
   model: sentry.recentsearch
   pk: 1
 - fields:
-    date_added: '2024-06-10T19:38:24.166Z'
+    date_added: '2024-06-13T16:17:48.844Z'
     first_event: null
     flags: '10'
     forced_color: null
     name: project-test-org
-    organization: 4554157368213504
+    organization: 4554173566418944
     platform: null
     public: false
     slug: project-test-org
     status: 0
     template: null
   model: sentry.project
-  pk: 4554157368279041
+  pk: 4554173566418946
 - fields:
-    date_added: '2024-06-10T19:38:24.456Z'
+    date_added: '2024-06-13T16:17:49.015Z'
     first_event: null
     flags: '10'
     forced_color: null
     name: other-project-test-org
-    organization: 4554157368213504
+    organization: 4554173566418944
     platform: null
     public: false
     slug: other-project-test-org
     status: 0
     template: null
   model: sentry.project
-  pk: 4554157368279042
+  pk: 4554173566484480
 - fields:
-    date_added: '2024-06-10T19:38:24.732Z'
+    date_added: '2024-06-13T16:17:49.241Z'
     first_event: null
     flags: '10'
     forced_color: null
-    name: Intent Aardvark
-    organization: 4554157368213504
+    name: Special Oriole
+    organization: 4554173566418944
     platform: null
     public: false
-    slug: intent-aardvark
+    slug: special-oriole
     status: 0
     template: null
   model: sentry.project
-  pk: 4554157368279044
+  pk: 4554173566484482
 - fields:
-    date_added: '2024-06-10T19:38:24.999Z'
+    date_added: '2024-06-13T16:17:49.466Z'
     first_event: null
     flags: '10'
     forced_color: null
-    name: Merry Caribou
-    organization: 4554157368213504
+    name: Wondrous Cicada
+    organization: 4554173566418944
     platform: null
     public: false
-    slug: merry-caribou
+    slug: wondrous-cicada
     status: 0
     template: null
   model: sentry.project
-  pk: 4554157368279045
+  pk: 4554173566484483
 - fields:
-    created_by: null
-    date_added: '2024-06-10T19:38:24.353Z'
+    created_by: 2
+    date_added: '2024-06-13T16:17:48.966Z'
     date_deactivated: null
     date_last_used: null
     name: token 1 for test-org
-    organization_id: 4554157368213504
-    project_last_used_id: 4554157368279041
+    organization_id: 4554173566418944
+    project_last_used_id: 4554173566418946
     scope_list: '[''org:ci'']'
     token_hashed: ABCDEFtest-org
     token_last_characters: xyz1
   model: sentry.orgauthtoken
   pk: 1
 - fields:
-    date_added: '2024-06-10T19:38:23.346Z'
+    date_added: '2024-06-13T16:17:48.392Z'
     email: null
     flags: '0'
     has_global_access: true
     invite_status: 0
     inviter_id: null
-    organization: 4554157368213504
+    organization: 4554173566418944
     role: owner
     token: null
     token_expires_at: null
@@ -518,13 +518,13 @@ source: tests/sentry/backup/test_releases.py
   model: sentry.organizationmember
   pk: 1
 - fields:
-    date_added: '2024-06-10T19:38:23.422Z'
+    date_added: '2024-06-13T16:17:48.451Z'
     email: null
     flags: '0'
     has_global_access: true
     invite_status: 0
     inviter_id: null
-    organization: 4554157368213504
+    organization: 4554173566418944
     role: member
     token: null
     token_expires_at: null
@@ -535,13 +535,13 @@ source: tests/sentry/backup/test_releases.py
   model: sentry.organizationmember
   pk: 2
 - fields:
-    date_added: '2024-06-10T19:38:23.505Z'
+    date_added: '2024-06-13T16:17:48.510Z'
     email: invited-by-superadmin-not-in-org@example.com
     flags: '0'
     has_global_access: true
     invite_status: 1
     inviter_id: 1
-    organization: 4554157368213504
+    organization: 4554173566418944
     role: member
     token: null
     token_expires_at: null
@@ -552,13 +552,13 @@ source: tests/sentry/backup/test_releases.py
   model: sentry.organizationmember
   pk: 3
 - fields:
-    date_added: '2024-06-10T19:38:23.537Z'
+    date_added: '2024-06-13T16:17:48.534Z'
     email: invited-by-org-owner@example.com
     flags: '0'
     has_global_access: true
     invite_status: 1
     inviter_id: 2
-    organization: 4554157368213504
+    organization: 4554173566418944
     role: member
     token: null
     token_expires_at: null
@@ -569,13 +569,13 @@ source: tests/sentry/backup/test_releases.py
   model: sentry.organizationmember
   pk: 4
 - fields:
-    date_added: '2024-06-10T19:38:23.568Z'
+    date_added: '2024-06-13T16:17:48.556Z'
     email: invited-by-org-member@example.com
     flags: '0'
     has_global_access: true
     invite_status: 1
     inviter_id: 3
-    organization: 4554157368213504
+    organization: 4554173566418944
     role: member
     token: null
     token_expires_at: null
@@ -586,13 +586,13 @@ source: tests/sentry/backup/test_releases.py
   model: sentry.organizationmember
   pk: 5
 - fields:
-    date_added: '2024-06-10T19:38:23.603Z'
+    date_added: '2024-06-13T16:17:48.577Z'
     email: null
     flags: '0'
     has_global_access: true
     invite_status: 0
     inviter_id: 1
-    organization: 4554157368213504
+    organization: 4554173566418944
     role: member
     token: null
     token_expires_at: null
@@ -603,13 +603,13 @@ source: tests/sentry/backup/test_releases.py
   model: sentry.organizationmember
   pk: 6
 - fields:
-    date_added: '2024-06-10T19:38:23.735Z'
+    date_added: '2024-06-13T16:17:48.635Z'
     email: null
     flags: '0'
     has_global_access: true
     invite_status: 0
     inviter_id: 2
-    organization: 4554157368213504
+    organization: 4554173566418944
     role: member
     token: null
     token_expires_at: null
@@ -620,13 +620,13 @@ source: tests/sentry/backup/test_releases.py
   model: sentry.organizationmember
   pk: 7
 - fields:
-    date_added: '2024-06-10T19:38:23.876Z'
+    date_added: '2024-06-13T16:17:48.707Z'
     email: null
     flags: '0'
     has_global_access: true
     invite_status: 0
     inviter_id: 3
-    organization: 4554157368213504
+    organization: 4554173566418944
     role: member
     token: null
     token_expires_at: null
@@ -638,32 +638,32 @@ source: tests/sentry/backup/test_releases.py
   pk: 8
 - fields:
     member: 2
-    requester_id: null
-    team: 4554157368279040
+    requester_id: 2
+    team: 4554173566418945
   model: sentry.organizationaccessrequest
   pk: 1
 - fields:
     config:
       schedule: '* * * * *'
       schedule_type: 1
-    date_added: '2024-06-10T19:38:24.448Z'
-    guid: b6b1abed-a90d-43c9-9342-6626892600ff
+    date_added: '2024-06-13T16:17:49.011Z'
+    guid: c1358ee6-d90b-42aa-9575-0efd4d89e192
     is_muted: false
     name: ''
-    organization_id: 4554157368213504
+    organization_id: 4554173566418944
     owner_team_id: null
-    owner_user_id: null
-    project_id: 4554157368279041
-    slug: 7e7708fcc669
+    owner_user_id: 2
+    project_id: 4554173566418946
+    slug: 3ecbdb7f9086
     status: 0
     type: 3
   model: sentry.monitor
   pk: 1
 - fields:
-    date_added: '2024-06-10T19:38:24.637Z'
-    date_updated: '2024-06-10T19:38:24.637Z'
+    date_added: '2024-06-13T16:17:49.144Z'
+    date_updated: '2024-06-13T16:17:49.144Z'
     name: View 1 for test-org
-    organization: 4554157368213504
+    organization: 4554173566418944
     position: 0
     query: some query for test-org
     query_sort: date
@@ -671,107 +671,107 @@ source: tests/sentry/backup/test_releases.py
   model: sentry.groupsearchview
   pk: 1
 - fields:
-    date_added: '2024-06-10T19:38:24.444Z'
-    name: partially supreme drum
-    organization_id: 4554157368213504
+    date_added: '2024-06-13T16:17:49.008Z'
+    name: jolly smashing muskox
+    organization_id: 4554173566418944
   model: sentry.environment
   pk: 1
 - fields:
-    date_added: '2024-06-10T19:38:22.265Z'
+    date_added: '2024-06-13T16:17:47.229Z'
     email: superadmin
   model: sentry.email
   pk: 1
 - fields:
-    date_added: '2024-06-10T19:38:23.162Z'
+    date_added: '2024-06-13T16:17:48.209Z'
     email: owner
   model: sentry.email
   pk: 2
 - fields:
-    date_added: '2024-06-10T19:38:23.189Z'
+    date_added: '2024-06-13T16:17:48.243Z'
     email: member
   model: sentry.email
   pk: 3
 - fields:
-    date_added: '2024-06-10T19:38:23.205Z'
+    date_added: '2024-06-13T16:17:48.261Z'
     email: added-by-superadmin-not-in-org
   model: sentry.email
   pk: 4
 - fields:
-    date_added: '2024-06-10T19:38:23.225Z'
+    date_added: '2024-06-13T16:17:48.279Z'
     email: added-by-org-owner
   model: sentry.email
   pk: 5
 - fields:
-    date_added: '2024-06-10T19:38:23.243Z'
+    date_added: '2024-06-13T16:17:48.296Z'
     email: added-by-org-member
   model: sentry.email
   pk: 6
 - fields:
-    date_added: '2024-06-10T19:38:24.570Z'
+    date_added: '2024-06-13T16:17:49.081Z'
     email: admin@localhost
   model: sentry.email
   pk: 7
 - fields:
-    date_added: '2024-06-10T19:38:24.643Z'
-    email: 9c16599997e44e69a07f7c62f26e293a@example.com
+    date_added: '2024-06-13T16:17:49.163Z'
+    email: b570ba8f83e9419999ed98c61553c5ef@example.com
   model: sentry.email
   pk: 8
 - fields:
-    date_added: '2024-06-10T19:38:24.716Z'
+    date_added: '2024-06-13T16:17:49.225Z'
     email: ''
   model: sentry.email
   pk: 9
 - fields:
-    date_added: '2024-06-10T19:38:24.991Z'
-    email: b2cb2576bfbf439782183048f5f06074@example.com
+    date_added: '2024-06-13T16:17:49.459Z'
+    email: 75edc948a7b94b44a17968f7d3341cd5@example.com
   model: sentry.email
   pk: 10
 - fields:
-    date_added: '2024-06-10T19:38:24.626Z'
-    organization: 4554157368213504
+    date_added: '2024-06-13T16:17:49.128Z'
+    organization: 4554173566418944
     slug: test-tombstone-in-test-org
   model: sentry.dashboardtombstone
   pk: 1
 - fields:
     created_by_id: 2
-    date_added: '2024-06-10T19:38:24.622Z'
+    date_added: '2024-06-13T16:17:49.124Z'
     filters: null
-    last_visited: '2024-06-10T19:38:24.622Z'
-    organization: 4554157368213504
+    last_visited: '2024-06-13T16:17:49.124Z'
+    organization: 4554173566418944
     title: Dashboard 1 for test-org
     visits: 1
   model: sentry.dashboard
   pk: 1
 - fields:
     condition: '{"op":"equals","name":"environment","value":"prod"}'
-    condition_hash: 9d6f8f46d85accd14ec1c5d2757b8b8fb2bb9805
-    created_by_id: null
-    date_added: '2024-06-10T19:38:24.436Z'
-    end_date: '2024-06-10T20:38:24.430Z'
+    condition_hash: 7c31808dc95e35f98ae5d735219298790b049069
+    created_by_id: 2
+    date_added: '2024-06-13T16:17:49.003Z'
+    end_date: '2024-06-13T17:17:48.998Z'
     is_active: true
     is_org_level: false
     notification_sent: false
     num_samples: 100
-    organization: 4554157368213504
+    organization: 4554173566418944
     query: environment:prod event.type:transaction
     rule_id: 1
     sample_rate: 0.5
-    start_date: '2024-06-10T19:38:24.430Z'
+    start_date: '2024-06-13T16:17:48.998Z'
   model: sentry.customdynamicsamplingrule
   pk: 1
 - fields:
-    project: 4554157368279041
-    value: 1
+    project: 4554173566418946
+    value: 2
   model: sentry.counter
   pk: 1
 - fields:
     config: {}
-    date_added: '2024-06-10T19:38:24.287Z'
+    date_added: '2024-06-13T16:17:48.919Z'
     default_global_access: true
     default_role: 50
     flags: '0'
     last_sync: null
-    organization_id: 4554157368213504
+    organization_id: 4554173566418944
     provider: sentry
     sync_time: null
   model: sentry.authprovider
@@ -787,16 +787,16 @@ source: tests/sentry/backup/test_releases.py
       - 3
       key4:
         nested_key: nested_value
-    date_added: '2024-06-10T19:38:24.315Z'
+    date_added: '2024-06-13T16:17:48.942Z'
     ident: 123456789test-org
-    last_synced: '2024-06-10T19:38:24.315Z'
-    last_verified: '2024-06-10T19:38:24.315Z'
+    last_synced: '2024-06-13T16:17:48.942Z'
+    last_verified: '2024-06-13T16:17:48.942Z'
     user: 2
   model: sentry.authidentity
   pk: 1
 - fields:
     config: '""'
-    created_at: '2024-06-10T19:38:22.277Z'
+    created_at: '2024-06-13T16:17:47.239Z'
     last_used_at: null
     type: 1
     user: 1
@@ -804,7 +804,7 @@ source: tests/sentry/backup/test_releases.py
   pk: 1
 - fields:
     config: '""'
-    created_at: '2024-06-10T19:38:23.180Z'
+    created_at: '2024-06-13T16:17:48.231Z'
     last_used_at: null
     type: 1
     user: 2
@@ -812,7 +812,7 @@ source: tests/sentry/backup/test_releases.py
   pk: 2
 - fields:
     config: '""'
-    created_at: '2024-06-10T19:38:23.197Z'
+    created_at: '2024-06-13T16:17:48.252Z'
     last_used_at: null
     type: 1
     user: 3
@@ -820,7 +820,7 @@ source: tests/sentry/backup/test_releases.py
   pk: 3
 - fields:
     config: '""'
-    created_at: '2024-06-10T19:38:23.215Z'
+    created_at: '2024-06-13T16:17:48.270Z'
     last_used_at: null
     type: 1
     user: 4
@@ -828,7 +828,7 @@ source: tests/sentry/backup/test_releases.py
   pk: 4
 - fields:
     config: '""'
-    created_at: '2024-06-10T19:38:23.234Z'
+    created_at: '2024-06-13T16:17:48.287Z'
     last_used_at: null
     type: 1
     user: 5
@@ -836,7 +836,7 @@ source: tests/sentry/backup/test_releases.py
   pk: 5
 - fields:
     config: '""'
-    created_at: '2024-06-10T19:38:23.253Z'
+    created_at: '2024-06-13T16:17:48.305Z'
     last_used_at: null
     type: 1
     user: 6
@@ -844,10 +844,10 @@ source: tests/sentry/backup/test_releases.py
   pk: 6
 - fields:
     allowed_origins: null
-    date_added: '2024-06-10T19:38:24.258Z'
-    key: 8870e09a48224ced927cd19a4d085a98
+    date_added: '2024-06-13T16:17:48.898Z'
+    key: 22dd1ab834034dc5989053ad82ce0186
     label: Default
-    organization_id: 4554157368213504
+    organization_id: 4554173566418944
     scope_list: '[]'
     scopes: '0'
     status: 0
@@ -855,11 +855,11 @@ source: tests/sentry/backup/test_releases.py
   pk: 1
 - fields:
     allowed_origins: ''
-    client_id: 58046df937854586aa956e3a116b0a979f7dffbbe13a4235038e58f0311a376b
-    client_secret: 0e1fc29d04cb31027f7f84ec62ec0651ebc21675571bb2938835973467653dac
-    date_added: '2024-06-10T19:38:24.722Z'
+    client_id: 45f041d970b941974719947f936222bf02b8e2d10775d9a5231ba0a8ca607ede
+    client_secret: 6bd303e6d8faad2185d4f6b8181d83ebe2734bb58b4a555ab7896502e58b4dd7
+    date_added: '2024-06-13T16:17:49.232Z'
     homepage_url: null
-    name: Innocent Raptor
+    name: Solid Escargot
     owner: 9
     privacy_url: null
     redirect_uris: ''
@@ -916,89 +916,89 @@ source: tests/sentry/backup/test_releases.py
   model: sentry.useroption
   pk: 6
 - fields:
-    date_hash_added: '2024-06-10T19:38:22.260Z'
+    date_hash_added: '2024-06-13T16:17:47.226Z'
     email: superadmin
     is_verified: true
     user: 1
-    validation_hash: cqYlwLnQeipBUlzbs1Dm45QhkC0i3W8W
+    validation_hash: 0kEchpnUnB0bqQAbW2CyCuDn90FfO7dE
   model: sentry.useremail
   pk: 1
 - fields:
-    date_hash_added: '2024-06-10T19:38:23.157Z'
+    date_hash_added: '2024-06-13T16:17:48.205Z'
     email: owner
     is_verified: true
     user: 2
-    validation_hash: IWYXZdnz5zIwRoTWBi2GKHJXakyKkYRk
+    validation_hash: 2xP0Ni8AzDhg0bZjM7KWPyo1dxpJpgyj
   model: sentry.useremail
   pk: 2
 - fields:
-    date_hash_added: '2024-06-10T19:38:23.187Z'
+    date_hash_added: '2024-06-13T16:17:48.241Z'
     email: member
     is_verified: true
     user: 3
-    validation_hash: HlLAppQmuaZkvV8aUL3p8bMdyfP4MYER
+    validation_hash: jwqUdYZxIMeMQFGhKk9nl7fkZI8NDX0j
   model: sentry.useremail
   pk: 3
 - fields:
-    date_hash_added: '2024-06-10T19:38:23.203Z'
+    date_hash_added: '2024-06-13T16:17:48.259Z'
     email: added-by-superadmin-not-in-org
     is_verified: true
     user: 4
-    validation_hash: CAtGpEcnJCspCeUOxidDZugBr2gq4Gyp
+    validation_hash: 7VqHq9gTXSoAiijPGz7xjkVk7TLWWpUl
   model: sentry.useremail
   pk: 4
 - fields:
-    date_hash_added: '2024-06-10T19:38:23.222Z'
+    date_hash_added: '2024-06-13T16:17:48.276Z'
     email: added-by-org-owner
     is_verified: true
     user: 5
-    validation_hash: 8WBSu34lDho2wfrGT9ymT253ebx6VerH
+    validation_hash: GQoSOU43PCovPk4JiqfPvDzMtQHIj9sC
   model: sentry.useremail
   pk: 5
 - fields:
-    date_hash_added: '2024-06-10T19:38:23.241Z'
+    date_hash_added: '2024-06-13T16:17:48.293Z'
     email: added-by-org-member
     is_verified: true
     user: 6
-    validation_hash: OImccT4dFbfWt1vgYURl1DnKUq22xR7Z
+    validation_hash: 8b57Lzj9WyMBhcyaOHFISDOc7cdPrezJ
   model: sentry.useremail
   pk: 6
 - fields:
-    date_hash_added: '2024-06-10T19:38:24.568Z'
+    date_hash_added: '2024-06-13T16:17:49.078Z'
     email: admin@localhost
     is_verified: true
     user: 7
-    validation_hash: NrGV2bqjwz8H38pvZyFAFhuhUDrGBjE1
+    validation_hash: HA2u4Wd1U00QuEpLGERZp9RsEABWUVYr
   model: sentry.useremail
   pk: 7
 - fields:
-    date_hash_added: '2024-06-10T19:38:24.641Z'
-    email: 9c16599997e44e69a07f7c62f26e293a@example.com
+    date_hash_added: '2024-06-13T16:17:49.160Z'
+    email: b570ba8f83e9419999ed98c61553c5ef@example.com
     is_verified: true
     user: 8
-    validation_hash: HsvQxNUSV3ZmMdnK2sqvCVXK99wbrBjn
+    validation_hash: sKs5KnO0ZkUBa5OG7GAm4NUT6pLMcWEF
   model: sentry.useremail
   pk: 8
 - fields:
-    date_hash_added: '2024-06-10T19:38:24.713Z'
+    date_hash_added: '2024-06-13T16:17:49.223Z'
     email: ''
     is_verified: false
     user: 9
-    validation_hash: dVtOoDFlYuoHpnSizQHGRZcoexWRpFN8
+    validation_hash: 2l5M2F1SeQcb9noqXOynBnjAhFgvWS7z
   model: sentry.useremail
   pk: 9
 - fields:
-    date_hash_added: '2024-06-10T19:38:24.988Z'
-    email: b2cb2576bfbf439782183048f5f06074@example.com
+    date_hash_added: '2024-06-13T16:17:49.457Z'
+    email: 75edc948a7b94b44a17968f7d3341cd5@example.com
     is_verified: true
     user: 10
-    validation_hash: rc1ffDumAN5dItKMz0zebUmmOe4KSRoJ
+    validation_hash: r3fICdzMdGhDkWpMYhlAmXZubMslmiQ8
   model: sentry.useremail
   pk: 10
 - fields:
     aggregate: count()
     dataset: events
-    date_added: '2024-06-10T19:38:24.527Z'
+    date_added: '2024-06-13T16:17:49.053Z'
     environment: null
     query: level:error
     resolution: 60
@@ -1009,7 +1009,7 @@ source: tests/sentry/backup/test_releases.py
 - fields:
     aggregate: count()
     dataset: events
-    date_added: '2024-06-10T19:38:24.578Z'
+    date_added: '2024-06-13T16:17:49.089Z'
     environment: null
     query: level:error
     resolution: 60
@@ -1020,7 +1020,7 @@ source: tests/sentry/backup/test_releases.py
 - fields:
     aggregate: count()
     dataset: events
-    date_added: '2024-06-10T19:38:24.603Z'
+    date_added: '2024-06-13T16:17:49.105Z'
     environment: null
     query: test query
     resolution: 60
@@ -1031,18 +1031,18 @@ source: tests/sentry/backup/test_releases.py
 - fields:
     application: 1
     author: A Company
-    creator_label: 9c16599997e44e69a07f7c62f26e293a@example.com
+    creator_label: b570ba8f83e9419999ed98c61553c5ef@example.com
     creator_user: 8
-    date_added: '2024-06-10T19:38:24.723Z'
+    date_added: '2024-06-13T16:17:49.233Z'
     date_deleted: null
     date_published: null
-    date_updated: '2024-06-10T19:38:24.938Z'
+    date_updated: '2024-06-13T16:17:49.419Z'
     events: '[]'
     is_alertable: false
     metadata: {}
     name: test app
     overview: A sample description
-    owner_id: 4554157368213504
+    owner_id: 4554173566418944
     popularity: 1
     proxy_user: 9
     redirect_url: https://example.com/sentry-app/redirect/
@@ -1083,27 +1083,27 @@ source: tests/sentry/backup/test_releases.py
     scopes: '0'
     slug: test-app
     status: 0
-    uuid: b8235b9e-074e-4825-80f9-c87d606d5c29
+    uuid: 2e42b096-5718-4c0c-87b5-3856dcb8cb8b
     verify_install: true
     webhook_url: https://example.com/sentry-app/webhook/
   model: sentry.sentryapp
   pk: 1
 - fields:
     data: '{"conditions":[{"id":"sentry.rules.conditions.first_seen_event.FirstSeenEventCondition"},{"id":"sentry.rules.conditions.every_event.EveryEventCondition"}],"action_match":"all","filter_match":"all","actions":[{"id":"sentry.rules.actions.notify_event.NotifyEventAction"},{"id":"sentry.rules.actions.notify_event_service.NotifyEventServiceAction","service":"mail"}]}'
-    date_added: '2024-06-10T19:38:24.423Z'
+    date_added: '2024-06-13T16:17:48.994Z'
     environment_id: null
     label: ''
     owner_team: null
-    owner_user_id: null
-    project: 4554157368279041
+    owner_user_id: 2
+    project: 4554173566418946
     source: 0
     status: 0
   model: sentry.rule
   pk: 1
 - fields:
-    date_added: '2024-06-10T19:38:24.545Z'
-    date_updated: '2024-06-10T19:38:24.545Z'
-    project: 4554157368279041
+    date_added: '2024-06-13T16:17:49.065Z'
+    date_updated: '2024-06-13T16:17:49.065Z'
+    project: 4554173566418946
     query_extra: null
     snuba_query: 1
     status: 1
@@ -1112,9 +1112,9 @@ source: tests/sentry/backup/test_releases.py
   model: sentry.querysubscription
   pk: 1
 - fields:
-    date_added: '2024-06-10T19:38:24.588Z'
-    date_updated: '2024-06-10T19:38:24.588Z'
-    project: 4554157368279041
+    date_added: '2024-06-13T16:17:49.096Z'
+    date_updated: '2024-06-13T16:17:49.096Z'
+    project: 4554173566418946
     query_extra: null
     snuba_query: 2
     status: 1
@@ -1123,9 +1123,9 @@ source: tests/sentry/backup/test_releases.py
   model: sentry.querysubscription
   pk: 2
 - fields:
-    date_added: '2024-06-10T19:38:24.608Z'
-    date_updated: '2024-06-10T19:38:24.608Z'
-    project: 4554157368279041
+    date_added: '2024-06-13T16:17:49.109Z'
+    date_updated: '2024-06-13T16:17:49.109Z'
+    project: 4554173566418946
     query_extra: null
     snuba_query: 3
     status: 1
@@ -1134,9 +1134,9 @@ source: tests/sentry/backup/test_releases.py
   model: sentry.querysubscription
   pk: 3
 - fields:
-    date_added: '2024-06-10T19:38:24.735Z'
-    date_updated: '2024-06-10T19:38:24.735Z'
-    project: 4554157368279044
+    date_added: '2024-06-13T16:17:49.245Z'
+    date_updated: '2024-06-13T16:17:49.245Z'
+    project: 4554173566484482
     query_extra: null
     snuba_query: 1
     status: 1
@@ -1145,9 +1145,9 @@ source: tests/sentry/backup/test_releases.py
   model: sentry.querysubscription
   pk: 4
 - fields:
-    date_added: '2024-06-10T19:38:25.004Z'
-    date_updated: '2024-06-10T19:38:25.004Z'
-    project: 4554157368279045
+    date_added: '2024-06-13T16:17:49.470Z'
+    date_updated: '2024-06-13T16:17:49.470Z'
+    project: 4554173566484483
     query_extra: null
     snuba_query: 1
     status: 1
@@ -1156,30 +1156,30 @@ source: tests/sentry/backup/test_releases.py
   model: sentry.querysubscription
   pk: 5
 - fields:
-    project: 4554157368279041
-    team: 4554157368279040
+    project: 4554173566418946
+    team: 4554173566418945
   model: sentry.projectteam
   pk: 1
 - fields:
-    project: 4554157368279042
-    team: 4554157368279040
+    project: 4554173566484480
+    team: 4554173566418945
   model: sentry.projectteam
   pk: 2
 - fields:
-    date_added: '2024-06-10T19:38:24.246Z'
-    organization: 4554157368213504
-    project: 4554157368279041
+    date_added: '2024-06-13T16:17:48.890Z'
+    organization: 4554173566418944
+    project: 4554173566418946
     redirect_slug: project_slug_in_test-org
   model: sentry.projectredirect
   pk: 1
 - fields:
     auto_assignment: true
     codeowners_auto_sync: true
-    date_created: '2024-06-10T19:38:24.241Z'
+    date_created: '2024-06-13T16:17:48.885Z'
     fallthrough: true
     is_active: true
-    last_updated: '2024-06-10T19:38:24.241Z'
-    project: 4554157368279041
+    last_updated: '2024-06-13T16:17:48.885Z'
+    project: 4554173566418946
     raw: '{"hello":"hello"}'
     schema:
       hello: hello
@@ -1188,73 +1188,73 @@ source: tests/sentry/backup/test_releases.py
   pk: 1
 - fields:
     key: sentry:relay-rev
-    project: 4554157368279041
-    value: '"cd16feabd785483c979091d88579579d"'
+    project: 4554173566418946
+    value: '"9b3c1b4af6004d84824e55a6a070c503"'
   model: sentry.projectoption
   pk: 1
 - fields:
     key: sentry:relay-rev-lastchange
-    project: 4554157368279041
-    value: '"2024-06-10T19:38:24.210350Z"'
+    project: 4554173566418946
+    value: '"2024-06-13T16:17:48.869168Z"'
   model: sentry.projectoption
   pk: 2
 - fields:
     key: sentry:option-epoch
-    project: 4554157368279041
+    project: 4554173566418946
     value: 12
   model: sentry.projectoption
   pk: 3
 - fields:
     key: sentry:relay-rev
-    project: 4554157368279042
-    value: '"19e4e24244ad4e1eafec5af2d6c424b4"'
+    project: 4554173566484480
+    value: '"7804475d2c77473da6374725a60a5617"'
   model: sentry.projectoption
   pk: 4
 - fields:
     key: sentry:relay-rev-lastchange
-    project: 4554157368279042
-    value: '"2024-06-10T19:38:24.501411Z"'
+    project: 4554173566484480
+    value: '"2024-06-13T16:17:49.040081Z"'
   model: sentry.projectoption
   pk: 5
 - fields:
     key: sentry:option-epoch
-    project: 4554157368279042
+    project: 4554173566484480
     value: 12
   model: sentry.projectoption
   pk: 6
 - fields:
     key: sentry:relay-rev
-    project: 4554157368279044
-    value: '"1ed0b81864c14308bdecd149be4769b0"'
+    project: 4554173566484482
+    value: '"197a11df86384643be4ca9a2f14b3c1e"'
   model: sentry.projectoption
   pk: 7
 - fields:
     key: sentry:relay-rev-lastchange
-    project: 4554157368279044
-    value: '"2024-06-10T19:38:24.760569Z"'
+    project: 4554173566484482
+    value: '"2024-06-13T16:17:49.269239Z"'
   model: sentry.projectoption
   pk: 8
 - fields:
     key: sentry:option-epoch
-    project: 4554157368279044
+    project: 4554173566484482
     value: 12
   model: sentry.projectoption
   pk: 9
 - fields:
     key: sentry:relay-rev
-    project: 4554157368279045
-    value: '"92d93f0d82a54ff49cf41cb64f9256a5"'
+    project: 4554173566484483
+    value: '"27ac1a48954747b692bd2fae2648a276"'
   model: sentry.projectoption
   pk: 10
 - fields:
     key: sentry:relay-rev-lastchange
-    project: 4554157368279045
-    value: '"2024-06-10T19:38:25.043980Z"'
+    project: 4554173566484483
+    value: '"2024-06-13T16:17:49.493130Z"'
   model: sentry.projectoption
   pk: 11
 - fields:
     key: sentry:option-epoch
-    project: 4554157368279045
+    project: 4554173566484483
     value: 12
   model: sentry.projectoption
   pk: 12
@@ -1263,14 +1263,14 @@ source: tests/sentry/backup/test_releases.py
       dynamicSdkLoaderOptions:
         hasPerformance: true
         hasReplay: true
-    date_added: '2024-06-10T19:38:24.202Z'
+    date_added: '2024-06-13T16:17:48.863Z'
     label: Default
-    project: 4554157368279041
-    public_key: ff4e792c5410210ab3c6729612ff553e
+    project: 4554173566418946
+    public_key: 53f9d2dc49d279aea8a8effe15cf6681
     rate_limit_count: null
     rate_limit_window: null
     roles: '1'
-    secret_key: 7a5c6cfb2d921cd4aded5566a60090cb
+    secret_key: 885f04b1781b607871cb17c453c03f1a
     status: 0
     use_case: user
   model: sentry.projectkey
@@ -1280,14 +1280,14 @@ source: tests/sentry/backup/test_releases.py
       dynamicSdkLoaderOptions:
         hasPerformance: true
         hasReplay: true
-    date_added: '2024-06-10T19:38:24.491Z'
+    date_added: '2024-06-13T16:17:49.035Z'
     label: Default
-    project: 4554157368279042
-    public_key: 691a6bf8e7b253dea8304b8c482ca0e2
+    project: 4554173566484480
+    public_key: e41f259902d0cc5f7751c159bc0337a7
     rate_limit_count: null
     rate_limit_window: null
     roles: '1'
-    secret_key: 8e755c066c7d12a31bc88c930df187ba
+    secret_key: 4b223a115144478625852d6688d694f5
     status: 0
     use_case: user
   model: sentry.projectkey
@@ -1297,14 +1297,14 @@ source: tests/sentry/backup/test_releases.py
       dynamicSdkLoaderOptions:
         hasPerformance: true
         hasReplay: true
-    date_added: '2024-06-10T19:38:24.754Z'
+    date_added: '2024-06-13T16:17:49.263Z'
     label: Default
-    project: 4554157368279044
-    public_key: cb323288b7ebf6f49b97388eb0359872
+    project: 4554173566484482
+    public_key: 61dda44d217af9e3d3bdeab907dc2270
     rate_limit_count: null
     rate_limit_window: null
     roles: '1'
-    secret_key: 02a0c450d740332b92b399fe3fa7f31f
+    secret_key: 07d977ef086ae9d092fcae33a8b2f4f2
     status: 0
     use_case: user
   model: sentry.projectkey
@@ -1314,14 +1314,14 @@ source: tests/sentry/backup/test_releases.py
       dynamicSdkLoaderOptions:
         hasPerformance: true
         hasReplay: true
-    date_added: '2024-06-10T19:38:25.031Z'
+    date_added: '2024-06-13T16:17:49.487Z'
     label: Default
-    project: 4554157368279045
-    public_key: 3ea2b2694d254c455f6971ed55ff3b69
+    project: 4554173566484483
+    public_key: 0d8d76e5ff24bae770de3adaeb01893f
     rate_limit_count: null
     rate_limit_window: null
     roles: '1'
-    secret_key: ffbca784d7a68628d67734eb92191451
+    secret_key: 616a4ca4fadd9dc056c810e979b6aab9
     status: 0
     use_case: user
   model: sentry.projectkey
@@ -1330,12 +1330,12 @@ source: tests/sentry/backup/test_releases.py
     config:
       hello: hello
     integration_id: 1
-    project: 4554157368279041
+    project: 4554173566418946
   model: sentry.projectintegration
   pk: 1
 - fields:
-    date_added: '2024-06-10T19:38:24.239Z'
-    project: 4554157368279041
+    date_added: '2024-06-13T16:17:48.884Z'
+    project: 4554173566418946
     user_id: 2
   model: sentry.projectbookmark
   pk: 1
@@ -1343,12 +1343,12 @@ source: tests/sentry/backup/test_releases.py
     is_active: true
     organizationmember: 1
     role: null
-    team: 4554157368279040
+    team: 4554173566418945
   model: sentry.organizationmemberteam
   pk: 1
 - fields:
     integration_id: null
-    organization: 4554157368213504
+    organization: 4554173566418944
     sentry_app_id: null
     target_display: Sentry User
     target_identifier: '1'
@@ -1359,7 +1359,7 @@ source: tests/sentry/backup/test_releases.py
   pk: 1
 - fields:
     integration_id: null
-    organization: 4554157368213504
+    organization: 4554173566418944
     sentry_app_id: 1
     target_display: Sentry User
     target_identifier: '1'
@@ -1369,23 +1369,23 @@ source: tests/sentry/backup/test_releases.py
   model: sentry.notificationaction
   pk: 2
 - fields:
-    disable_date: '2024-06-10T19:38:24.429Z'
+    disable_date: '2024-06-13T16:17:48.997Z'
     opted_out: false
-    organization: 4554157368213504
+    organization: 4554173566418944
     rule: 1
-    sent_final_email_date: '2024-06-10T19:38:24.429Z'
-    sent_initial_email_date: '2024-06-10T19:38:24.429Z'
+    sent_final_email_date: '2024-06-13T16:17:48.997Z'
+    sent_initial_email_date: '2024-06-13T16:17:48.997Z'
   model: sentry.neglectedrule
   pk: 1
 - fields:
     environment: 1
     is_hidden: null
-    project: 4554157368279041
+    project: 4554173566418946
   model: sentry.environmentproject
   pk: 1
 - fields:
     dashboard: 1
-    date_added: '2024-06-10T19:38:24.623Z'
+    date_added: '2024-06-13T16:17:49.125Z'
     description: null
     detail: null
     discover_widget_split: null
@@ -1400,60 +1400,60 @@ source: tests/sentry/backup/test_releases.py
   pk: 1
 - fields:
     custom_dynamic_sampling_rule: 1
-    project: 4554157368279041
+    project: 4554173566418946
   model: sentry.customdynamicsamplingruleproject
   pk: 1
 - fields:
     application: 1
-    date_added: '2024-06-10T19:38:24.870Z'
-    expires_at: '2024-06-11T03:38:24.869Z'
-    hashed_refresh_token: 6946450199095bdce661de977c74e80057a5121a9824805a19758133dfc849e0
-    hashed_token: 3a6b8fca0297f5d46dbb430e0dc0fce0847b8dcaaaa3ce3df7b80fda1700070a
+    date_added: '2024-06-13T16:17:49.365Z'
+    expires_at: '2024-06-14T00:17:49.365Z'
+    hashed_refresh_token: 31aeeebe560df8242db994d1ad25afa652643998cf517eb5515b18d9e4e16f0c
+    hashed_token: 36e3c05fd42ad73b2bc8488f079858f1e821adb58e4e5de6c48aa79ac17ac150
     name: null
-    refresh_token: 5776e14188b3a459078364a26f5ba68ab826ff4d6efc772eb5f4bf875e4b2c39
+    refresh_token: 3c8cd58128964d32eab75369ac9b8c64fc881d3ba562aab0db1a254ad3fc87be
     scope_list: '[]'
     scopes: '0'
-    token: 4cda2733ba5ee1cf0a13e78128aa77fad2f6688c94ba5051cefaabc15e4bb927
-    token_last_characters: b927
+    token: 4f4bef6d1cdfad9559937adf728c37ecedd14327103d1dd0492720dfa2de11b2
+    token_last_characters: 11b2
     token_type: null
     user: 9
   model: sentry.apitoken
   pk: 1
 - fields:
     application: 1
-    date_added: '2024-06-10T19:38:24.956Z'
+    date_added: '2024-06-13T16:17:49.432Z'
     expires_at: null
-    hashed_refresh_token: 8e902b96b6a755f86fb8c4527044d84dbd34eef80444ce72f47d88bee63c92b3
-    hashed_token: 3019fa1ddf49f85c0d845412ce5c3c277ea1bf270735fa24df692f4985299778
+    hashed_refresh_token: df84904477c17e38156bab26e88650f81cf8cd14b4731827f7e3cf644aec6ec6
+    hashed_token: e3242a90d0b90440527d468f73b88d51b259fa66a0c21b353dac8479c4d6e2a7
     name: create_exhaustive_sentry_app
-    refresh_token: 6aadb631faeca70d1029898cffe7a89bfc710cd20c8bc85c2295b0be7ebb64d8
+    refresh_token: 02a6abadb898948f8d38c75424c15d6a9b6fb50a1548a07d25ca519c4f4edb77
     scope_list: '[]'
     scopes: '0'
-    token: 416b16886a30115aaa1a73a4eb08906fe27b334b3897051513c641c0d84f2139
-    token_last_characters: '2139'
+    token: 1076f9c0462819e372d210a5e0b5aa1830bf3f6e89515bb5ec1b889360716fcc
+    token_last_characters: 6fcc
     token_type: null
     user: 2
   model: sentry.apitoken
   pk: 2
 - fields:
     application: null
-    date_added: '2024-06-10T19:38:25.074Z'
+    date_added: '2024-06-13T16:17:49.516Z'
     expires_at: null
     hashed_refresh_token: null
-    hashed_token: bd1b3192b7d8e315536fe0abb9f307a470e28e32297abcf3ccd305706b41a7fa
+    hashed_token: 3fde242d9411ac9d3e321d64482addc6ee87a5dae9721efd7c728f5be48f3e59
     name: create_exhaustive_global_configs_for_
     refresh_token: null
     scope_list: '[]'
     scopes: '0'
-    token: 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
-    token_last_characters: 26de
+    token: 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
+    token_last_characters: 5bdf
     token_type: sntryu_
     user: 2
   model: sentry.apitoken
   pk: 3
 - fields:
     application: 1
-    code: 8042d71f1404b9aa5a6009d0dfbe821b55b3bdb25f06805aa49c83c3d9a9a9f7
+    code: fa1e60a59a35d3e3fc7e8ee2ce27df4030553f4a62e9ed24f4367ebad7f1c886
     expires_at: '2022-01-01T11:11:00.000Z'
     redirect_uri: https://example.com
     scope_list: '[''openid'', ''profile'', ''email'']'
@@ -1463,7 +1463,7 @@ source: tests/sentry/backup/test_releases.py
   pk: 2
 - fields:
     application: 1
-    date_added: '2024-06-10T19:38:24.954Z'
+    date_added: '2024-06-13T16:17:49.430Z'
     scope_list: '[]'
     scopes: '0'
     user: 2
@@ -1471,7 +1471,7 @@ source: tests/sentry/backup/test_releases.py
   pk: 1
 - fields:
     application: null
-    date_added: '2024-06-10T19:38:25.073Z'
+    date_added: '2024-06-13T16:17:49.515Z'
     scope_list: '[]'
     scopes: '0'
     user: 2
@@ -1479,31 +1479,31 @@ source: tests/sentry/backup/test_releases.py
   pk: 2
 - fields:
     comparison_delta: null
-    date_added: '2024-06-10T19:38:24.534Z'
-    date_modified: '2024-06-10T19:38:24.534Z'
+    date_added: '2024-06-13T16:17:49.056Z'
+    date_modified: '2024-06-13T16:17:49.056Z'
     description: null
     include_all_projects: true
     monitor_type: 0
-    name: Famous Flounder
-    organization: 4554157368213504
+    name: Pet Rattler
+    organization: 4554173566418944
     resolve_threshold: null
     snuba_query: 1
     status: 0
     team: null
     threshold_period: 1
     threshold_type: 0
-    user_id: null
+    user_id: 2
   model: sentry.alertrule
   pk: 1
 - fields:
     comparison_delta: null
-    date_added: '2024-06-10T19:38:24.583Z'
-    date_modified: '2024-06-10T19:38:24.583Z'
+    date_added: '2024-06-13T16:17:49.091Z'
+    date_modified: '2024-06-13T16:17:49.091Z'
     description: null
     include_all_projects: false
     monitor_type: 1
-    name: Aware Racer
-    organization: 4554157368213504
+    name: Trusted Wahoo
+    organization: 4554173566418944
     resolve_threshold: null
     snuba_query: 2
     status: 0
@@ -1515,13 +1515,13 @@ source: tests/sentry/backup/test_releases.py
   pk: 2
 - fields:
     comparison_delta: null
-    date_added: '2024-06-10T19:38:24.606Z'
-    date_modified: '2024-06-10T19:38:24.606Z'
+    date_added: '2024-06-13T16:17:49.107Z'
+    date_modified: '2024-06-13T16:17:49.107Z'
     description: null
     include_all_projects: false
     monitor_type: 0
-    name: Easy Garfish
-    organization: 4554157368213504
+    name: Settled Octopus
+    organization: 4554173566418944
     resolve_threshold: null
     snuba_query: 3
     status: 0
@@ -1549,13 +1549,13 @@ source: tests/sentry/backup/test_releases.py
 - fields:
     api_grant: null
     api_token: 1
-    date_added: '2024-06-10T19:38:24.776Z'
+    date_added: '2024-06-13T16:17:49.283Z'
     date_deleted: null
-    date_updated: '2024-06-10T19:38:24.834Z'
-    organization_id: 4554157368213504
+    date_updated: '2024-06-13T16:17:49.337Z'
+    organization_id: 4554173566418944
     sentry_app: 1
     status: 1
-    uuid: 98d53a20-a1f8-4a8d-89a6-c7e8cfd3f16b
+    uuid: f3aba60f-1887-46b4-add8-40ce085cf854
   model: sentry.sentryappinstallation
   pk: 1
 - fields:
@@ -1593,12 +1593,12 @@ source: tests/sentry/backup/test_releases.py
       type: alert-rule-action
     sentry_app: 1
     type: alert-rule-action
-    uuid: 59281021-a66c-4f41-8013-f451f2cb6902
+    uuid: 566e85f8-e824-4b82-8433-ac717d6f349d
   model: sentry.sentryappcomponent
   pk: 1
 - fields:
     alert_rule: null
-    date_added: '2024-06-10T19:38:24.427Z'
+    date_added: '2024-06-13T16:17:48.996Z'
     owner_id: 2
     rule: 1
     until: null
@@ -1606,28 +1606,28 @@ source: tests/sentry/backup/test_releases.py
   model: sentry.rulesnooze
   pk: 1
 - fields:
-    date_added: '2024-06-10T19:38:24.426Z'
+    date_added: '2024-06-13T16:17:48.995Z'
     rule: 1
     type: 1
-    user_id: null
+    user_id: 2
   model: sentry.ruleactivity
   pk: 1
 - fields:
     action: 1
-    project: 4554157368279041
+    project: 4554173566418946
   model: sentry.notificationactionproject
   pk: 1
 - fields:
     action: 2
-    project: 4554157368279041
+    project: 4554173566418946
   model: sentry.notificationactionproject
   pk: 2
 - fields:
     aggregates: null
     columns: null
     conditions: ''
-    date_added: '2024-06-10T19:38:24.624Z'
-    date_modified: '2024-06-10T19:38:24.624Z'
+    date_added: '2024-06-13T16:17:49.126Z'
+    date_modified: '2024-06-13T16:17:49.126Z'
     field_aliases: null
     fields: '[]'
     is_hidden: false
@@ -1640,8 +1640,8 @@ source: tests/sentry/backup/test_releases.py
 - fields:
     alert_rule: 1
     alert_threshold: 100.0
-    date_added: '2024-06-10T19:38:24.561Z'
-    label: Useful Opossum
+    date_added: '2024-06-13T16:17:49.073Z'
+    label: Composed Tetra
     resolve_threshold: null
     threshold_type: null
   model: sentry.alertruletrigger
@@ -1649,47 +1649,47 @@ source: tests/sentry/backup/test_releases.py
 - fields:
     alert_rule: 2
     alert_threshold: 100.0
-    date_added: '2024-06-10T19:38:24.600Z'
-    label: Bold Mollusk
+    date_added: '2024-06-13T16:17:49.102Z'
+    label: Humorous Dragon
     resolve_threshold: null
     threshold_type: null
   model: sentry.alertruletrigger
   pk: 2
 - fields:
     alert_rule: 1
-    date_added: '2024-06-10T19:38:24.543Z'
-    project: 4554157368279041
+    date_added: '2024-06-13T16:17:49.064Z'
+    project: 4554173566418946
   model: sentry.alertruleprojects
   pk: 1
 - fields:
     alert_rule: 2
-    date_added: '2024-06-10T19:38:24.586Z'
-    project: 4554157368279041
+    date_added: '2024-06-13T16:17:49.093Z'
+    project: 4554173566418946
   model: sentry.alertruleprojects
   pk: 2
 - fields:
     alert_rule: 3
-    date_added: '2024-06-10T19:38:24.607Z'
-    project: 4554157368279041
+    date_added: '2024-06-13T16:17:49.108Z'
+    project: 4554173566418946
   model: sentry.alertruleprojects
   pk: 3
 - fields:
     alert_rule: 1
-    date_added: '2024-06-10T19:38:24.539Z'
-    project: 4554157368279042
+    date_added: '2024-06-13T16:17:49.062Z'
+    project: 4554173566484480
   model: sentry.alertruleexcludedprojects
   pk: 1
 - fields:
     alert_rule: 1
-    date_added: '2024-06-10T19:38:24.550Z'
+    date_added: '2024-06-13T16:17:49.067Z'
     previous_alert_rule: null
     type: 1
-    user_id: null
+    user_id: 2
   model: sentry.alertruleactivity
   pk: 1
 - fields:
     alert_rule: 2
-    date_added: '2024-06-10T19:38:24.586Z'
+    date_added: '2024-06-13T16:17:49.094Z'
     previous_alert_rule: null
     type: 1
     user_id: null
@@ -1697,7 +1697,7 @@ source: tests/sentry/backup/test_releases.py
   pk: 2
 - fields:
     alert_rule: 3
-    date_added: '2024-06-10T19:38:24.609Z'
+    date_added: '2024-06-13T16:17:49.110Z'
     previous_alert_rule: null
     type: 1
     user_id: null
@@ -1706,20 +1706,20 @@ source: tests/sentry/backup/test_releases.py
 - fields:
     alert_rule: 2
     condition_type: 0
-    date_added: '2024-06-10T19:38:24.585Z'
+    date_added: '2024-06-13T16:17:49.092Z'
     label: ''
   model: sentry.alertruleactivationcondition
   pk: 1
 - fields:
     actor_id: 1
     application_id: 1
-    date_added: '2024-06-10T19:38:24.830Z'
+    date_added: '2024-06-13T16:17:49.334Z'
     events: '[]'
-    guid: 2cf6d72546074b68a77a04da234524c4
+    guid: 13e1cf763c5742d68c1a0b67e7d30787
     installation_id: 1
-    organization_id: 4554157368213504
+    organization_id: 4554173566418944
     project_id: null
-    secret: 458c56a1c1f8e564f9a7671a5fbc153b018c92f139149c1e136f8e1b22d5fbcf
+    secret: e8006ca9f370faeea1117c24fedda460e16dbe4641895f33ac2d91a80c9df8a6
     status: 0
     url: https://example.com/sentry-app/webhook/
     version: 0
@@ -1728,13 +1728,13 @@ source: tests/sentry/backup/test_releases.py
 - fields:
     actor_id: 10
     application_id: 1
-    date_added: '2024-06-10T19:38:25.059Z'
+    date_added: '2024-06-13T16:17:49.504Z'
     events: '[''event.created'']'
-    guid: 542ec3d566dd4652a2bba4696820b88f
+    guid: dfac5eb99acb465194261e2f0b526c1c
     installation_id: 1
-    organization_id: 4554157368213504
-    project_id: 4554157368279045
-    secret: 0dee834363fcbf29505ee03bd0c075a086739a9a3747533680d219756f14a0ed
+    organization_id: 4554173566418944
+    project_id: 4554173566484483
+    secret: db54c42f5bac669236dd7675483b634598b3dafec1ce6d9be51615fc471f02b5
     status: 0
     url: https://example.com/sentry/webhook
     version: 0
@@ -1743,23 +1743,23 @@ source: tests/sentry/backup/test_releases.py
 - fields:
     activation: null
     alert_rule: 3
-    date_added: '2024-06-10T19:38:24.613Z'
+    date_added: '2024-06-13T16:17:49.114Z'
     date_closed: null
-    date_detected: '2024-06-10T19:38:24.611Z'
-    date_started: '2024-06-10T19:38:24.611Z'
+    date_detected: '2024-06-13T16:17:49.112Z'
+    date_started: '2024-06-13T16:17:49.112Z'
     detection_uuid: null
     identifier: 1
-    organization: 4554157368213504
+    organization: 4554173566418944
     status: 1
     status_method: 3
-    title: Star Civet
+    title: Informed Moray
     type: 2
   model: sentry.incident
   pk: 1
 - fields:
     dashboard_widget_query: 1
-    date_added: '2024-06-10T19:38:24.625Z'
-    date_modified: '2024-06-10T19:38:24.625Z'
+    date_added: '2024-06-13T16:17:49.127Z'
+    date_modified: '2024-06-13T16:17:49.127Z'
     extraction_state: disabled:not-applicable
     spec_hashes: '[]'
     spec_version: null
@@ -1767,13 +1767,13 @@ source: tests/sentry/backup/test_releases.py
   pk: 1
 - fields:
     alert_rule_trigger: 1
-    date_added: '2024-06-10T19:38:24.563Z'
+    date_added: '2024-06-13T16:17:49.074Z'
     query_subscription: 1
   model: sentry.alertruletriggerexclusion
   pk: 1
 - fields:
     alert_rule_trigger: 1
-    date_added: '2024-06-10T19:38:24.577Z'
+    date_added: '2024-06-13T16:17:49.088Z'
     integration_id: null
     sentry_app_config: null
     sentry_app_id: null
@@ -1786,7 +1786,7 @@ source: tests/sentry/backup/test_releases.py
   pk: 1
 - fields:
     alert_rule_trigger: 2
-    date_added: '2024-06-10T19:38:24.602Z'
+    date_added: '2024-06-13T16:17:49.104Z'
     integration_id: null
     sentry_app_config: null
     sentry_app_id: null
@@ -1798,35 +1798,35 @@ source: tests/sentry/backup/test_releases.py
   model: sentry.alertruletriggeraction
   pk: 2
 - fields:
-    date_added: '2024-06-10T19:38:24.617Z'
-    end: '2024-06-10T19:38:24.617Z'
+    date_added: '2024-06-13T16:17:49.119Z'
+    end: '2024-06-13T16:17:49.119Z'
     period: 1
-    start: '2024-06-09T19:38:24.617Z'
+    start: '2024-06-12T16:17:49.119Z'
     values: '[[1.0, 2.0, 3.0], [1.5, 2.5, 3.5]]'
   model: sentry.timeseriessnapshot
   pk: 1
 - fields:
-    date_added: '2024-06-10T19:38:24.621Z'
+    date_added: '2024-06-13T16:17:49.123Z'
     incident: 1
-    target_run_date: '2024-06-10T23:38:24.621Z'
+    target_run_date: '2024-06-13T20:17:49.123Z'
   model: sentry.pendingincidentsnapshot
   pk: 1
 - fields:
     alert_rule_trigger: 1
-    date_added: '2024-06-10T19:38:24.620Z'
-    date_modified: '2024-06-10T19:38:24.620Z'
+    date_added: '2024-06-13T16:17:49.122Z'
+    date_modified: '2024-06-13T16:17:49.122Z'
     incident: 1
     status: 1
   model: sentry.incidenttrigger
   pk: 1
 - fields:
-    date_added: '2024-06-10T19:38:24.619Z'
+    date_added: '2024-06-13T16:17:49.121Z'
     incident: 1
     user_id: 2
   model: sentry.incidentsubscription
   pk: 1
 - fields:
-    date_added: '2024-06-10T19:38:24.618Z'
+    date_added: '2024-06-13T16:17:49.120Z'
     event_stats_snapshot: 1
     incident: 1
     total_events: 1
@@ -1835,12 +1835,12 @@ source: tests/sentry/backup/test_releases.py
   pk: 1
 - fields:
     comment: hello test-org
-    date_added: '2024-06-10T19:38:24.617Z'
+    date_added: '2024-06-13T16:17:49.118Z'
     incident: 1
     notification_uuid: null
     previous_value: null
     type: 1
-    user_id: null
+    user_id: 2
     value: null
   model: sentry.incidentactivity
   pk: 1

--- a/tests/sentry/backup/test_coverage.py
+++ b/tests/sentry/backup/test_coverage.py
@@ -2,11 +2,19 @@ from __future__ import annotations
 
 from sentry.backup.dependencies import dependencies, get_exportable_sentry_models, get_model_name
 from sentry.backup.scopes import RelocationScope
+from sentry.models.activity import Activity
+from sentry.models.groupassignee import GroupAssignee
+from sentry.models.groupbookmark import GroupBookmark
+from sentry.models.groupseen import GroupSeen
+from sentry.models.groupshare import GroupShare
+from sentry.models.groupsubscription import GroupSubscription
+from sentry.models.user import User
 from tests.sentry.backup.test_exhaustive import EXHAUSTIVELY_TESTED, UNIQUENESS_TESTED
 from tests.sentry.backup.test_imports import COLLISION_TESTED
 from tests.sentry.backup.test_models import DYNAMIC_RELOCATION_SCOPE_TESTED
 from tests.sentry.backup.test_releases import RELEASE_TESTED
 from tests.sentry.backup.test_sanitize import SANITIZATION_TESTED
+from tests.sentry.models.test_user import ORG_MEMBER_MERGE_TESTED
 
 ALL_EXPORTABLE_MODELS = {get_model_name(c) for c in get_exportable_sentry_models()}
 
@@ -70,22 +78,30 @@ def test_exportable_final_derivations_of_sentry_model_are_collision_tested():
                 want_collision_tested.add(model_relations.model)
 
     untested = {get_model_name(m) for m in want_collision_tested} - COLLISION_TESTED
-    assert not {str(u) for u in untested}
+    assert not {
+        str(u) for u in untested
+    }, "The aforementioned models are not covered in the `COLLISION` backup tests; please go to `tests/sentry/backup/test_exhaustive.py` and make sure at least one test in the suite contains covers each of the missing models."
 
 
 def test_exportable_final_derivations_of_sentry_model_are_exhaustively_tested():
     untested = ALL_EXPORTABLE_MODELS - EXHAUSTIVELY_TESTED
-    assert not {str(u) for u in untested}
+    assert not {
+        str(u) for u in untested
+    }, "The aforementioned models are not covered in the backup tests; please go to `tests/sentry/backup/test_exhaustive.py` and make sure at least one test in the suite contains covers each of the missing models."
 
 
 def test_exportable_final_derivations_of_sentry_model_are_release_tested_at_head():
     untested = ALL_EXPORTABLE_MODELS - RELEASE_TESTED
-    assert not {str(u) for u in untested}
+    assert not {
+        str(u) for u in untested
+    }, "The aforementioned models are not covered in the `RELEASE` backup tests; please go to `tests/sentry/backup/test_release.py` and make sure at least one test in the suite contains covers each of the missing models."
 
 
 def test_exportable_final_derivations_of_sentry_model_are_sanitization_tested_at_head():
     untested = ALL_EXPORTABLE_MODELS - SANITIZATION_TESTED
-    assert not {str(u) for u in untested}
+    assert not {
+        str(u) for u in untested
+    }, "The aforementioned models are not covered in the `SANITIZATION` backup tests; please go to `tests/sentry/backup/test_sanitize.py` and make sure at least one test in the suite contains covers each of the missing models."
 
 
 def test_exportable_final_derivations_of_sentry_model_are_uniqueness_tested():
@@ -99,4 +115,39 @@ def test_exportable_final_derivations_of_sentry_model_are_uniqueness_tested():
     }
 
     untested = all_non_global_sentry_models - UNIQUENESS_TESTED
-    assert not {str(u) for u in untested}
+    assert not {
+        str(u) for u in untested
+    }, "The aforementioned models are not covered in the `UNIQUENESS` backup tests; please go to `tests/sentry/backup/test_exhaustive.py` and make sure at least one test in the suite contains covers each of the missing models."
+
+
+def test_all_eligible_organization_scoped_models_tested_for_user_merge():
+    all_org_scope_models_that_reference_user = set()
+    for model in get_exportable_sentry_models():
+        model_name = get_model_name(model)
+        model_relations = dependencies()[model_name]
+        possible_relocation_scopes = model_relations.get_possible_relocation_scopes()
+        if RelocationScope.Organization not in possible_relocation_scopes:
+            continue
+        for foreign_field in model_relations.foreign_keys.values():
+            if foreign_field.model == User:
+                all_org_scope_models_that_reference_user.add(model_name)
+                break
+
+    # Manually add some models that are currently excluded from exports, but still included in user
+    # merging.
+    all_org_scope_models_that_reference_user |= {
+        get_model_name(m)
+        for m in {
+            Activity,
+            GroupAssignee,
+            GroupBookmark,
+            GroupSeen,
+            GroupShare,
+            GroupSubscription,
+        }
+    }
+
+    untested = all_org_scope_models_that_reference_user - ORG_MEMBER_MERGE_TESTED
+    assert not {
+        str(u) for u in untested
+    }, "The aforementioned models are not covered in the `ORG_MEMBER_MERGE` backup tests; please go to `tests/sentry/models/test_user.py::UserMergeToTest` and make sure at least one test in the suite contains covers each of the missing models."

--- a/tests/sentry/backup/test_exhaustive.py
+++ b/tests/sentry/backup/test_exhaustive.py
@@ -14,7 +14,7 @@ from sentry.backup.imports import (
 from sentry.backup.scopes import ExportScope
 from sentry.testutils.helpers.backups import (
     NOOP_PRINTER,
-    BackupTestCase,
+    BackupTransactionTestCase,
     clear_database,
     export_to_file,
 )
@@ -24,7 +24,7 @@ EXHAUSTIVELY_TESTED: set[NormalizedModelName] = set()
 UNIQUENESS_TESTED: set[NormalizedModelName] = set()
 
 
-class ExhaustiveTests(BackupTestCase):
+class ExhaustiveTests(BackupTransactionTestCase):
     """
     Ensure that a database with all exportable models filled out still works.
     """

--- a/tests/sentry/backup/test_exports.py
+++ b/tests/sentry/backup/test_exports.py
@@ -20,7 +20,7 @@ from sentry.models.useremail import UserEmail
 from sentry.models.userpermission import UserPermission
 from sentry.models.userrole import UserRole, UserRoleUser
 from sentry.testutils.helpers.backups import (
-    BackupTestCase,
+    BackupTransactionTestCase,
     ValidationError,
     export_to_encrypted_tarball,
     export_to_file,
@@ -29,7 +29,7 @@ from sentry.testutils.helpers.datetime import freeze_time
 from tests.sentry.backup import get_matching_exportable_models
 
 
-class ExportTestCase(BackupTestCase):
+class ExportTestCase(BackupTransactionTestCase):
     @staticmethod
     def count(data: Any, model: type[models.base.BaseModel]) -> int:
         return len(list(filter(lambda d: d["model"] == str(get_model_name(model)), data)))

--- a/tests/sentry/backup/test_imports.py
+++ b/tests/sentry/backup/test_imports.py
@@ -73,7 +73,7 @@ from sentry.testutils.factories import get_fixture_path
 from sentry.testutils.helpers import override_options
 from sentry.testutils.helpers.backups import (
     NOOP_PRINTER,
-    BackupTestCase,
+    BackupTransactionTestCase,
     clear_database,
     export_to_file,
     generate_rsa_key_pair,
@@ -88,7 +88,7 @@ from tests.sentry.backup import (
 )
 
 
-class ImportTestCase(BackupTestCase):
+class ImportTestCase(BackupTransactionTestCase):
     def export_to_tmp_file_and_clear_database(self, tmp_dir) -> Path:
         tmp_path = Path(tmp_dir).joinpath(f"{self._testMethodName}.json")
         export_to_file(tmp_path, ExportScope.Global)

--- a/tests/sentry/backup/test_imports.py
+++ b/tests/sentry/backup/test_imports.py
@@ -1456,9 +1456,11 @@ class CollisionTests(ImportTestCase):
 
             # After exporting and clearing the database, insert a copy of the same `OrgAuthToken` as
             # the one found in the import.
+            new_user = self.create_user("new")
             org = self.create_organization()
 
             with assume_test_silo_mode(SiloMode.CONTROL):
+                colliding.created_by = new_user
                 colliding.organization_id = org.id
                 colliding.project_last_used_id = self.create_project(organization=org).id
                 colliding.save()

--- a/tests/sentry/backup/test_releases.py
+++ b/tests/sentry/backup/test_releases.py
@@ -15,7 +15,7 @@ from sentry.backup.scopes import ExportScope
 from sentry.backup.validate import validate
 from sentry.testutils.helpers.backups import (
     NOOP_PRINTER,
-    BackupTestCase,
+    BackupTransactionTestCase,
     clear_database,
     export_to_file,
 )
@@ -26,7 +26,7 @@ from tests.sentry.backup import expect_models, verify_models_in_output
 RELEASE_TESTED: set[NormalizedModelName] = set()
 
 
-class ReleaseTests(BackupTestCase):
+class ReleaseTests(BackupTransactionTestCase):
     """
     Ensure that exports from the last two released versions of self-hosted are still able to be
     imported.

--- a/tests/sentry/backup/test_sanitize.py
+++ b/tests/sentry/backup/test_sanitize.py
@@ -30,7 +30,7 @@ from sentry.db.models.fields.slug import SentrySlugField
 from sentry.db.models.fields.uuid import UUIDField
 from sentry.testutils.cases import TestCase
 from sentry.testutils.factories import get_fixture_path
-from sentry.testutils.helpers.backups import BackupTestCase
+from sentry.testutils.helpers.backups import BackupTransactionTestCase
 from sentry.testutils.silo import strip_silo_mode_test_suffix
 from tests.sentry.backup import expect_models, verify_models_in_output
 
@@ -487,7 +487,7 @@ class SanitizationIntegrationTests(IntegrationTestCase):
 SANITIZATION_TESTED: set[NormalizedModelName] = set()
 
 
-class SanitizationExhaustiveTests(BackupTestCase, IntegrationTestCase):
+class SanitizationExhaustiveTests(BackupTransactionTestCase, IntegrationTestCase):
     """
     Take our exhaustive test case and sanitize it, ensuring that the specific fields that
     were sanitized remain constant.

--- a/tests/sentry/backup/test_snapshots.py
+++ b/tests/sentry/backup/test_snapshots.py
@@ -13,14 +13,14 @@ from sentry.backup.validate import validate
 from sentry.testutils.factories import get_fixture_path
 from sentry.testutils.helpers.backups import (
     NOOP_PRINTER,
-    BackupTestCase,
+    BackupTransactionTestCase,
     ValidationError,
     clear_database,
     export_to_file,
 )
 
 
-class SnapshotTests(BackupTestCase):
+class SnapshotTests(BackupTransactionTestCase):
     """
     Tests against specific JSON snapshots.
     """

--- a/tests/sentry/models/test_user.py
+++ b/tests/sentry/models/test_user.py
@@ -1,13 +1,36 @@
 from unittest.mock import patch
 
+from django.db.models import Q
+
 import sentry.hybridcloud.rpc.services.caching as caching_module
+from sentry.backup.dependencies import NormalizedModelName, dependencies, get_model_name
+from sentry.db.models.base import Model
+from sentry.incidents.models.alert_rule import AlertRule, AlertRuleActivity
+from sentry.incidents.models.incident import IncidentActivity, IncidentSubscription
+from sentry.models.activity import Activity
 from sentry.models.authenticator import Authenticator
 from sentry.models.authidentity import AuthIdentity
+from sentry.models.dashboard import Dashboard
+from sentry.models.dynamicsampling import CustomDynamicSamplingRule
+from sentry.models.groupassignee import GroupAssignee
+from sentry.models.groupbookmark import GroupBookmark
+from sentry.models.groupsearchview import GroupSearchView
+from sentry.models.groupseen import GroupSeen
+from sentry.models.groupshare import GroupShare
+from sentry.models.groupsubscription import GroupSubscription
+from sentry.models.organizationaccessrequest import OrganizationAccessRequest
 from sentry.models.organizationmember import OrganizationMember
+from sentry.models.organizationmembermapping import OrganizationMemberMapping
+from sentry.models.orgauthtoken import OrgAuthToken
+from sentry.models.projectbookmark import ProjectBookmark
+from sentry.models.recentsearch import RecentSearch
+from sentry.models.rule import Rule, RuleActivity
+from sentry.models.rulesnooze import RuleSnooze
 from sentry.models.savedsearch import SavedSearch
 from sentry.models.tombstone import RegionTombstone
 from sentry.models.user import User
 from sentry.models.useremail import UserEmail
+from sentry.monitors.models import Monitor
 from sentry.silo.base import SiloMode
 from sentry.tasks.deletion.hybrid_cloud import schedule_hybrid_cloud_foreign_key_jobs
 from sentry.testutils.cases import TestCase
@@ -17,6 +40,7 @@ from sentry.testutils.hybrid_cloud import HybridCloudTestMixin
 from sentry.testutils.outbox import outbox_runner
 from sentry.testutils.silo import assume_test_silo_mode, assume_test_silo_mode_of, control_silo_test
 from sentry.types.region import Region, RegionCategory, find_regions_for_user
+from tests.sentry.backup import expect_models
 
 _TEST_REGIONS = (
     Region("na", 1, "http://eu.testserver", RegionCategory.MULTI_TENANT),
@@ -162,16 +186,42 @@ class UserDetailsTest(TestCase):
         assert user.get_salutation_name() == "Hello"
 
 
+ORG_MEMBER_MERGE_TESTED: set[NormalizedModelName] = set()
+
+
 @control_silo_test
 class UserMergeToTest(BackupTestCase, HybridCloudTestMixin):
+    def verify_model_existence_by_user(
+        self, models: list[type[Model]], *, present: list[User], absent: list[User]
+    ) -> None:
+        for model in sorted(models, key=lambda x: get_model_name(x)):
+            model_relations = dependencies()[get_model_name(model)]
+            user_refs = [k for k, v in model_relations.foreign_keys.items() if v.model == User]
+            is_region_model = SiloMode.REGION in model_relations.silos
+            with assume_test_silo_mode(SiloMode.REGION if is_region_model else SiloMode.CONTROL):
+                for present_user in present:
+                    q = Q()
+                    for ref in user_refs:
+                        args = {}
+                        args[f"{ref}"] = present_user.id
+                        q |= Q(**args)
+                    assert model.objects.filter(q).count() > 0
+                for absent_user in absent:
+                    q = Q()
+                    for ref in user_refs:
+                        args = {}
+                        args[f"{ref}"] = absent_user.id
+                        q |= Q(**args)
+                    assert not model.objects.filter(q).exists()
+
     def test_simple(self):
         from_user = self.create_exhaustive_user("foo@example.com")
         self.create_exhaustive_api_keys_for_user(from_user)
         to_user = self.create_exhaustive_user("bar@example.com")
         self.create_exhaustive_api_keys_for_user(to_user)
 
-        org = self.create_organization(name="my-org")
-        proj = self.create_project(name="my-proj", organization=org)
+        org = self.create_organization(name="simple-org")
+        proj = self.create_project(name="simple-proj", organization=org)
         self.create_exhaustive_organization_auth(from_user, org, proj)
 
         Authenticator.objects.get(user=from_user, type=1)
@@ -201,25 +251,179 @@ class UserMergeToTest(BackupTestCase, HybridCloudTestMixin):
         assert AuthIdentity.objects.filter(user=to_user).count() == 1
         assert not AuthIdentity.objects.filter(user=from_user).exists()
 
-    def test_duplicate_memberships(self):
+    @expect_models(
+        ORG_MEMBER_MERGE_TESTED,
+        OrgAuthToken,
+        OrganizationMember,
+        OrganizationMemberMapping,
+    )
+    def test_duplicate_memberships(self, expected_models: list[type[Model]]):
         from_user = self.create_user("foo@example.com")
         to_user = self.create_user("bar@example.com")
+        org_slug = "org-with-duplicate-members-being-merged"
+        org = self.create_organization(name=org_slug)
+        team_1 = self.create_team(organization=org)
+        team_2 = self.create_team(organization=org)
+        team_3 = self.create_team(organization=org)
+        all_teams = [team_1, team_2, team_3]
+        from_user_member = self.create_member(
+            organization=org, user=from_user, role="owner", teams=[team_1, team_2]
+        )
 
-        org_1 = self.create_organization()
-        team_1 = self.create_team(organization=org_1)
-        team_2 = self.create_team(organization=org_1)
-        team_3 = self.create_team(organization=org_1)
-        self.create_member(organization=org_1, user=from_user, role="owner", teams=[team_1, team_2])
         # to_user should have less roles
-        self.create_member(organization=org_1, user=to_user, role="member", teams=[team_2, team_3])
+        to_user_member = self.create_member(
+            organization=org, user=to_user, role="member", teams=[team_2, team_3]
+        )
 
+        OrgAuthToken.objects.create(
+            created_by=from_user,
+            organization_id=org.id,
+            name=f"token 1 for {org.slug}",
+            token_hashed=f"ABCDEF{org.slug}{from_user.id}",
+            token_last_characters="xyz1",
+            scope_list=["org:ci"],
+            date_last_used=None,
+        )
+        OrgAuthToken.objects.create(
+            created_by=to_user,
+            organization_id=org.id,
+            name=f"token 1 for {org.slug}",
+            token_hashed=f"ABCDEF{org.slug}{to_user.id}",
+            token_last_characters="xyz1",
+            scope_list=["org:ci"],
+            date_last_used=None,
+        )
+
+        # Access requests should cancel out once users are merged.
+        with assume_test_silo_mode(SiloMode.REGION):
+            OrganizationAccessRequest.objects.create(
+                team=team_1, member=from_user_member, requester_id=to_user.id
+            )
+            OrganizationAccessRequest.objects.create(
+                team=team_3, member=to_user_member, requester_id=from_user.id
+            )
+            assert OrganizationAccessRequest.objects.filter(team__in=all_teams).count() == 2
+
+        self.verify_model_existence_by_user(
+            expected_models, present=[from_user, to_user], absent=[]
+        )
         with outbox_runner():
             from_user.merge_to(to_user)
 
+        self.verify_model_existence_by_user(expected_models, present=[to_user], absent=[from_user])
         with assume_test_silo_mode(SiloMode.REGION):
             for member in OrganizationMember.objects.filter(user_id__in=[from_user.id, to_user.id]):
                 self.assert_org_member_mapping(org_member=member)
             member = OrganizationMember.objects.get(user_id=to_user.id)
 
         assert member.role == "owner"
-        assert list(member.teams.all().order_by("pk")) == [team_1, team_2, team_3]
+        assert list(member.teams.all().order_by("pk")) == all_teams
+
+        with assume_test_silo_mode(SiloMode.REGION):
+            assert not OrganizationAccessRequest.objects.filter(team__in=all_teams).exists()
+
+    @expect_models(
+        ORG_MEMBER_MERGE_TESTED,
+        Activity,
+        AlertRule,
+        AlertRuleActivity,
+        CustomDynamicSamplingRule,
+        Dashboard,
+        GroupAssignee,
+        GroupBookmark,
+        GroupSeen,
+        GroupShare,
+        GroupSearchView,
+        GroupSubscription,
+        IncidentActivity,
+        IncidentSubscription,
+        Monitor,
+        OrganizationAccessRequest,
+        OrganizationMember,
+        OrgAuthToken,
+        ProjectBookmark,
+        RecentSearch,
+        Rule,
+        RuleActivity,
+        RuleSnooze,
+        SavedSearch,
+    )
+    def test_only_source_user_is_member_of_organization(self, expected_models: list[type[Model]]):
+        from_user = self.create_exhaustive_user("foo@example.com")
+        to_user = self.create_exhaustive_user("bar@example.com")
+        org_slug = "org-only-from-user-is-member-of"
+        self.create_exhaustive_organization(
+            slug=org_slug, owner=from_user, member=self.create_user("random@example.com")
+        )
+
+        self.verify_model_existence_by_user(expected_models, present=[from_user], absent=[to_user])
+        with outbox_runner():
+            from_user.merge_to(to_user)
+
+        self.verify_model_existence_by_user(expected_models, present=[to_user], absent=[from_user])
+
+    @expect_models(
+        ORG_MEMBER_MERGE_TESTED,
+        Activity,
+        AlertRule,
+        AlertRuleActivity,
+        CustomDynamicSamplingRule,
+        Dashboard,
+        GroupAssignee,
+        GroupBookmark,
+        GroupSeen,
+        GroupShare,
+        GroupSearchView,
+        GroupSubscription,
+        IncidentActivity,
+        IncidentSubscription,
+        Monitor,
+        OrganizationAccessRequest,
+        OrganizationMember,
+        OrgAuthToken,
+        ProjectBookmark,
+        RecentSearch,
+        Rule,
+        RuleActivity,
+        RuleSnooze,
+        SavedSearch,
+    )
+    def test_both_users_are_members_of_organization(self, expected_models: list[type[Model]]):
+        from_user = self.create_exhaustive_user("foo@example.com")
+        to_user = self.create_exhaustive_user("bar@example.com")
+        random_user = self.create_user("random@example.com")
+        org_slug = "org-both-users-are-member-of"
+        org = self.create_exhaustive_organization(
+            slug=org_slug, owner=from_user, member=to_user, other_members=[random_user]
+        )
+        with assume_test_silo_mode(SiloMode.REGION):
+            from_member = OrganizationMember.objects.get(organization=org, user_id=from_user.id)
+            rand_member = OrganizationMember.objects.get(organization=org, user_id=random_user.id)
+            team_1 = self.create_team(organization=org, members=[from_member])
+            team_2 = self.create_team(organization=org, members=[rand_member])
+            OrganizationAccessRequest.objects.create(
+                member=from_member,
+                team=team_1,
+                requester_id=random_user.id,
+            )
+            OrganizationAccessRequest.objects.create(
+                member=rand_member,
+                team=team_2,
+                requester_id=from_user.id,
+            )
+
+        self.verify_model_existence_by_user(expected_models, present=[from_user], absent=[])
+        with outbox_runner():
+            from_user.merge_to(to_user)
+
+        self.verify_model_existence_by_user(expected_models, present=[to_user], absent=[from_user])
+
+        with assume_test_silo_mode(SiloMode.REGION):
+            to_member = OrganizationMember.objects.get(organization=org, user_id=to_user.id)
+            assert OrganizationAccessRequest.objects.filter(
+                member=to_member,
+                requester_id=random_user.id,
+            ).exists()
+            assert OrganizationAccessRequest.objects.filter(
+                requester_id=to_user.id,
+            ).exists()


### PR DESCRIPTION
We now ensure that user account merges are much more complete. All exportable (and even some non-exportable!) data associated with the user-being-merged is now properly pointed at the newly combined `User` and `OrganizationMember` models, and awkward collisions (what if the users had invited one another to a certain team?) are handled gracefully.