### PR TITLE
feat(query-builder): Add undo stack with ctrl-z

### DIFF
--- a/static/app/components/searchQueryBuilder/combobox.tsx
+++ b/static/app/components/searchQueryBuilder/combobox.tsx
@@ -69,6 +69,7 @@ type SearchQueryBuilderComboboxProps<T extends SelectOptionOrSectionWithKey<stri
    * Called when the user explicitly closes the combobox with the escape key.
    */
   onExit?: () => void;
+  onFocus?: (e: React.FocusEvent<HTMLInputElement>) => void;
   onInputChange?: React.ChangeEventHandler<HTMLInputElement>;
   onKeyDown?: (e: KeyboardEvent) => void;
   onPaste?: (e: React.ClipboardEvent<HTMLInputElement>) => void;
@@ -293,6 +294,7 @@ function SearchQueryBuilderComboboxInner<T extends SelectOptionOrSectionWithKey<
     onInputChange,
     autoFocus,
     openOnFocus,
+    onFocus,
     tabIndex = -1,
     maxOptions,
     shouldCloseOnInteractOutside,
@@ -346,10 +348,11 @@ function SearchQueryBuilderComboboxInner<T extends SelectOptionOrSectionWithKey<
       inputValue: filterValue,
       onSelectionChange,
       autoFocus,
-      onFocus: () => {
+      onFocus: e => {
         if (openOnFocus) {
           state.open();
         }
+        onFocus?.(e);
       },
       onBlur: () => {
         onCustomValueBlurred(inputValue);

--- a/static/app/components/searchQueryBuilder/index.spec.tsx
+++ b/static/app/components/searchQueryBuilder/index.spec.tsx
@@ -821,6 +821,64 @@ describe('SearchQueryBuilder', function () {
         'browser.name:firefox foo'
       );
     });
+
+    it('can undo last action with ctrl-z', async function () {
+      render(
+        <SearchQueryBuilder {...defaultProps} initialQuery="browser.name:firefox" />
+      );
+
+      // Clear search query removes the token
+      await userEvent.click(screen.getByRole('button', {name: 'Clear search query'}));
+      expect(
+        screen.queryByRole('row', {name: 'browser.name:firefox'})
+      ).not.toBeInTheDocument();
+
+      // Ctrl+Z adds it back
+      await userEvent.keyboard('{Control>}z{/Control}');
+      expect(
+        await screen.findByRole('row', {name: 'browser.name:firefox'})
+      ).toBeInTheDocument();
+    });
+
+    it('works with excess undo actions', async function () {
+      render(
+        <SearchQueryBuilder {...defaultProps} initialQuery="browser.name:firefox" />
+      );
+
+      // Remove the token
+      await userEvent.click(
+        screen.getByRole('button', {name: 'Remove filter: browser.name'})
+      );
+      await waitFor(() => {
+        expect(
+          screen.queryByRole('row', {name: 'browser.name:firefox'})
+        ).not.toBeInTheDocument();
+      });
+
+      // Ctrl+Z adds it back
+      await userEvent.keyboard('{Control>}z{/Control}');
+      expect(
+        await screen.findByRole('row', {name: 'browser.name:firefox'})
+      ).toBeInTheDocument();
+      // Extra Ctrl-Z should not do anything
+      await userEvent.keyboard('{Control>}z{/Control}');
+
+      // Remove token again
+      await userEvent.click(
+        screen.getByRole('button', {name: 'Remove filter: browser.name'})
+      );
+      await waitFor(() => {
+        expect(
+          screen.queryByRole('row', {name: 'browser.name:firefox'})
+        ).not.toBeInTheDocument();
+      });
+
+      // Ctrl+Z adds it back again
+      await userEvent.keyboard('{Control>}z{/Control}');
+      expect(
+        await screen.findByRole('row', {name: 'browser.name:firefox'})
+      ).toBeInTheDocument();
+    });
   });
 
   describe('token values', function () {

--- a/static/app/components/searchQueryBuilder/input.tsx
+++ b/static/app/components/searchQueryBuilder/input.tsx
@@ -249,8 +249,19 @@ function SearchQueryBuilderInputInternal({
 
   const onKeyDown = useCallback(
     (e: KeyboardEvent) => {
-      if (e.key === 'a' && isCtrlKeyPressed(e)) {
-        e.continuePropagation();
+      // Default combobox behavior stops events from propagating outside of input
+      // Certain keys like ctrl+z and ctrl+a are handled in useQueryBuilderGrid()
+      // so we need to continue propagation for those.
+      if (isCtrlKeyPressed(e)) {
+        if (e.key === 'z') {
+          // First let native undo behavior take place, but once that is done
+          // allow the event to propagate so that the grid can handle it.
+          if (inputValue === trimmedTokenValue) {
+            e.continuePropagation();
+          }
+        } else if (e.key === 'a') {
+          e.continuePropagation();
+        }
       }
 
       // At start and pressing backspace, focus the previous full token
@@ -275,7 +286,7 @@ function SearchQueryBuilderInputInternal({
         }
       }
     },
-    [item.key, state.collection, state.selectionManager]
+    [inputValue, item.key, state.collection, state.selectionManager, trimmedTokenValue]
   );
 
   const onPaste = useCallback(

--- a/static/app/components/searchQueryBuilder/useQueryBuilderGrid.tsx
+++ b/static/app/components/searchQueryBuilder/useQueryBuilderGrid.tsx
@@ -6,6 +6,7 @@ import {useListState} from '@react-stately/list';
 import type {CollectionChildren} from '@react-types/shared';
 
 import {useSearchQueryBuilder} from 'sentry/components/searchQueryBuilder/context';
+import {useUndoStack} from 'sentry/components/searchQueryBuilder/useUndoStack';
 import type {ParseResultToken} from 'sentry/components/searchSyntax/parser';
 import {isCtrlKeyPressed} from 'sentry/utils/isCtrlKeyPressed';
 
@@ -60,8 +61,17 @@ export function useQueryBuilderGrid(
     ref
   );
 
+  const {undo} = useUndoStack(state);
+
   const onKeyDown = useCallback(
     (e: React.KeyboardEvent<HTMLDivElement>) => {
+      if (e.key === 'z' && isCtrlKeyPressed(e)) {
+        undo();
+        e.stopPropagation();
+        e.preventDefault();
+        return;
+      }
+
       // When there is a selection, the grid will have focus and handle that behavior.
       if (state.selectionManager.selectedKeys.size > 0) {
         switch (e.key) {
@@ -94,7 +104,7 @@ export function useQueryBuilderGrid(
 
       originalGridProps.onKeyDown?.(e);
     },
-    [dispatch, originalGridProps, query, state.collection, state.selectionManager]
+    [dispatch, originalGridProps, query, state.collection, state.selectionManager, undo]
   );
 
   const gridProps = useMemo(

--- a/static/app/components/searchQueryBuilder/useUndoStack.tsx
+++ b/static/app/components/searchQueryBuilder/useUndoStack.tsx
@@ -1,0 +1,112 @@
+import {useCallback, useRef} from 'react';
+import type {ListState} from '@react-stately/list';
+import type {Key} from '@react-types/shared';
+
+import {useSearchQueryBuilder} from 'sentry/components/searchQueryBuilder/context';
+import type {FocusOverride} from 'sentry/components/searchQueryBuilder/types';
+import type {ParseResultToken} from 'sentry/components/searchSyntax/parser';
+import {defined} from 'sentry/utils';
+
+type UndoItem = {
+  /**
+   * If there was a focus override when the query was saved, it should be
+   * restored when undoing if available. Otherwise, the last focused key
+   * should be used.
+   */
+  focusOverride: FocusOverride | null | undefined;
+  /**
+   * The last focused key when the query was shown.
+   */
+  focusedKey: Key | null;
+  /**
+   * The raw query string. No two sequential items should have the same query.
+   */
+  query: string;
+};
+
+const MAX_ITEMS = 100;
+
+function getPreviousUndoItem(undoStack: UndoItem[], query: string) {
+  while (undoStack.length > 0) {
+    const undoItem = undoStack.at(-1);
+    if (undoItem?.query !== query) {
+      return undoItem;
+    }
+    // Prevent last item from being removed
+    if (undoStack.length === 1) {
+      return undefined;
+    }
+    undoStack.pop();
+  }
+
+  return undefined;
+}
+
+function updateUndoStack({
+  undoStack,
+  query,
+  focusOverride,
+  state,
+}: {
+  focusOverride: FocusOverride | null;
+  query: string;
+  state: ListState<ParseResultToken>;
+  undoStack: UndoItem[];
+}) {
+  const lastQuery = undoStack.at(-1)?.query;
+
+  if (lastQuery !== query) {
+    undoStack.push({
+      query,
+      focusOverride,
+      focusedKey: state.selectionManager.focusedKey ?? state.collection.getLastKey(),
+    });
+  } else if (
+    undoStack.length > 0 &&
+    state.selectionManager.focusedKey !== undoStack.at(-1)?.focusedKey
+  ) {
+    undoStack.at(-1)!.focusedKey = state.selectionManager.focusedKey;
+  }
+
+  if (undoStack.length > MAX_ITEMS) {
+    undoStack.splice(0, undoStack.length - MAX_ITEMS);
+  }
+}
+
+/**
+ * Hook that manages the undo stack for the search query builder.
+ */
+export function useUndoStack(state: ListState<ParseResultToken>) {
+  const {query, focusOverride, dispatch} = useSearchQueryBuilder();
+  const undoStackRef = useRef<UndoItem[]>([]);
+  const trimmedQuery = query.trim();
+
+  updateUndoStack({
+    undoStack: undoStackRef.current,
+    query: trimmedQuery,
+    focusOverride,
+    state,
+  });
+
+  const undo = useCallback(() => {
+    const previousItem = getPreviousUndoItem(undoStackRef.current, trimmedQuery);
+
+    if (defined(previousItem) && previousItem.query !== trimmedQuery) {
+      const newFocusOverride: FocusOverride | null | undefined =
+        previousItem.focusOverride ??
+        (previousItem.focusedKey
+          ? {itemKey: previousItem.focusedKey.toString()}
+          : undefined);
+      dispatch({
+        type: 'UPDATE_QUERY',
+        query: previousItem.query,
+        focusOverride: newFocusOverride,
+      });
+    }
+  }, [dispatch, trimmedQuery]);
+
+  return {
+    undoStack: undoStackRef.current,
+    undo,
+  };
+}

--- a/static/app/components/searchQueryBuilder/valueCombobox.tsx
+++ b/static/app/components/searchQueryBuilder/valueCombobox.tsx
@@ -1,6 +1,7 @@
 import {type ReactNode, useCallback, useMemo, useRef, useState} from 'react';
 import styled from '@emotion/styled';
 import {Item, Section} from '@react-stately/collections';
+import type {KeyboardEvent} from '@react-types/shared';
 import orderBy from 'lodash/orderBy';
 
 import Checkbox from 'sentry/components/checkbox';
@@ -28,6 +29,7 @@ import {t, tn} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {Tag, TagCollection} from 'sentry/types';
 import {FieldValueType, getFieldDefinition} from 'sentry/utils/fields';
+import {isCtrlKeyPressed} from 'sentry/utils/isCtrlKeyPressed';
 import {type QueryKey, useQuery} from 'sentry/utils/queryClient';
 
 type SearchQueryValueBuilderProps = {
@@ -546,7 +548,14 @@ export function SearchQueryBuilderValueCombobox({
   );
 
   const onKeyDown = useCallback(
-    (e: React.KeyboardEvent<HTMLInputElement>) => {
+    (e: KeyboardEvent) => {
+      // Default combobox behavior stops events from propagating outside of input
+      // Certain keys like ctrl+z should be handled handled in useQueryBuilderGrid()
+      // so we need to continue propagation for those.
+      if (e.key === 'z' && isCtrlKeyPressed(e)) {
+        e.continuePropagation();
+      }
+
       // If at the start of the input and backspace is pressed, delete the last selected value
       if (
         e.key === 'Backspace' &&


### PR DESCRIPTION
Adds a basic undo stack so that ctrl/cmd+z will revert to the last state. Note that this only supports undoing for now, but can be modified to support redoing in the future.

https://github.com/getsentry/sentry/assets/10888943/5c1056b7-86c7-427f-933a-b581f313c33c

