### PR TITLE
feat(crons): Dismiss processing errors on monitor details page

### DIFF
--- a/static/app/actionCreators/monitors.tsx
+++ b/static/app/actionCreators/monitors.tsx
@@ -8,7 +8,7 @@ import {t} from 'sentry/locale';
 import type {ObjectStatus} from 'sentry/types/core';
 import {logException} from 'sentry/utils/logging';
 import type RequestError from 'sentry/utils/requestError/requestError';
-import type {Monitor} from 'sentry/views/monitors/types';
+import type {Monitor, ProcessingErrorType} from 'sentry/views/monitors/types';
 
 export async function deleteMonitor(api: Client, orgId: string, monitor: Monitor) {
   addLoadingMessage(t('Deleting Monitor...'));
@@ -142,4 +142,32 @@ export async function bulkEditMonitors(
   }
 
   return null;
+}
+
+export async function deleteMonitorProcessingErrorByType(
+  api: Client,
+  orgId: string,
+  projectId: string,
+  monitorSlug: string,
+  errortype: ProcessingErrorType
+) {
+  addLoadingMessage();
+
+  try {
+    await api.requestPromise(
+      `/projects/${orgId}/${projectId}/monitors/${monitorSlug}/processing-errors/`,
+      {
+        method: 'DELETE',
+        query: {errortype},
+      }
+    );
+    clearIndicators();
+  } catch (err) {
+    logException(err);
+    if (err.status === 403) {
+      addErrorMessage(t('You do not have permission to dismiss these processing errors'));
+    } else {
+      addErrorMessage(t('Unable to dismiss the processing errors'));
+    }
+  }
 }

--- a/static/app/views/monitors/details.tsx
+++ b/static/app/views/monitors/details.tsx
@@ -3,7 +3,10 @@ import type {RouteComponentProps} from 'react-router';
 import styled from '@emotion/styled';
 import sortBy from 'lodash/sortBy';
 
-import {updateMonitor} from 'sentry/actionCreators/monitors';
+import {
+  deleteMonitorProcessingErrorByType,
+  updateMonitor,
+} from 'sentry/actionCreators/monitors';
 import Alert from 'sentry/components/alert';
 import * as Layout from 'sentry/components/layouts/thirds';
 import LoadingError from 'sentry/components/loadingError';
@@ -29,7 +32,7 @@ import MonitorIssues from './components/monitorIssues';
 import MonitorStats from './components/monitorStats';
 import MonitorOnboarding from './components/onboarding';
 import {StatusToggleButton} from './components/statusToggleButton';
-import type {CheckinProcessingError, Monitor} from './types';
+import type {CheckinProcessingError, Monitor, ProcessingErrorType} from './types';
 
 const DEFAULT_POLL_INTERVAL_MS = 5000;
 
@@ -67,13 +70,12 @@ function MonitorDetails({params, location}: Props) {
     },
   });
 
-  const {data: checkinErrors} = useApiQuery<CheckinProcessingError[]>(
-    makeMonitorErrorsQueryKey(organization, params.projectId, params.monitorSlug),
-    {
-      staleTime: 0,
-      refetchOnWindowFocus: true,
-    }
-  );
+  const {data: checkinErrors, refetch: refetchErrors} = useApiQuery<
+    CheckinProcessingError[]
+  >(makeMonitorErrorsQueryKey(organization, params.projectId, params.monitorSlug), {
+    staleTime: 0,
+    refetchOnWindowFocus: true,
+  });
 
   function onUpdate(data: Monitor) {
     const updatedMonitor = {
@@ -96,6 +98,17 @@ function MonitorDetails({params, location}: Props) {
       onUpdate(resp);
     }
   };
+
+  function handleDismissError(errortype: ProcessingErrorType) {
+    deleteMonitorProcessingErrorByType(
+      api,
+      organization.slug,
+      params.projectId,
+      params.monitorSlug,
+      errortype
+    );
+    refetchErrors();
+  }
 
   if (isError) {
     return (
@@ -145,7 +158,10 @@ function MonitorDetails({params, location}: Props) {
               </Alert>
             )}
             {!!checkinErrors?.length && (
-              <MonitorProcessingErrors checkinErrors={checkinErrors}>
+              <MonitorProcessingErrors
+                checkinErrors={checkinErrors}
+                onDismiss={handleDismissError}
+              >
                 {t('Errors were encountered while ingesting check-ins for this monitor')}
               </MonitorProcessingErrors>
             )}


### PR DESCRIPTION
Adds a method to call the processing error api to clear out errors by type, on a monitor

<img width="894" alt="image" src="https://github.com/getsentry/sentry/assets/9372512/975f8472-e36d-4b0e-a41f-aef1d65ac646">

Depends on: https://github.com/getsentry/sentry/pull/72667