### PR TITLE
feat(crons): Dismiss processing errors on monitor overview page

### DIFF
--- a/static/app/actionCreators/monitors.tsx
+++ b/static/app/actionCreators/monitors.tsx
@@ -171,3 +171,27 @@ export async function deleteMonitorProcessingErrorByType(
     }
   }
 }
+
+export async function deleteProjectProcessingErrorByType(
+  api: Client,
+  orgId: string,
+  projectId: string,
+  errortype: ProcessingErrorType
+) {
+  addLoadingMessage();
+
+  try {
+    await api.requestPromise(`/projects/${orgId}/${projectId}/processing-errors/`, {
+      method: 'DELETE',
+      query: {errortype},
+    });
+    clearIndicators();
+  } catch (err) {
+    logException(err);
+    if (err.status === 403) {
+      addErrorMessage(t('You do not have permission to dismiss these processing errors'));
+    } else {
+      addErrorMessage(t('Unable to dismiss the processing errors'));
+    }
+  }
+}


### PR DESCRIPTION
Similar to https://github.com/getsentry/sentry/pull/72699

Adds dismiss behavior to monitor overview page 

<img width="1238" alt="image" src="https://github.com/getsentry/sentry/assets/9372512/358b78a0-88e0-4a7d-8089-765f68d7c647">


depends on: 
- api changes: https://github.com/getsentry/sentry/pull/72623 
- ui changes: https://github.com/getsentry/sentry/pull/72626