### PR TITLE
feat(insights): hides y axis split line in performance score chart

### DIFF
--- a/static/app/views/performance/browser/webVitals/components/performanceScoreBreakdownChart.tsx
+++ b/static/app/views/performance/browser/webVitals/components/performanceScoreBreakdownChart.tsx
@@ -207,6 +207,7 @@ export function PerformanceScoreBreakdownChart({transaction}: Props) {
       <PerformanceScoreSubtext>{performanceScoreSubtext}</PerformanceScoreSubtext>
       <Chart
         stacked
+        hideYAxisSplitLine
         height={180}
         data={
           isTimeseriesLoading ||


### PR DESCRIPTION
Hides y axis split line in performance score chart since it wasnt really working.
before
<img width="374" alt="image" src="https://github.com/getsentry/sentry/assets/83961295/69c7c4d4-9b7a-4f38-baed-b20324e4a6e4">

after
<img width="259" alt="image" src="https://github.com/getsentry/sentry/assets/83961295/0114cccc-9635-44e5-89e5-64c5af04a50c">
