### PR TITLE
chore(insights): Remove rollout flag checks for addon modules

### DIFF
--- a/static/app/components/sidebar/index.spec.tsx
+++ b/static/app/components/sidebar/index.spec.tsx
@@ -32,9 +32,6 @@ const ALL_AVAILABLE_FEATURES = [
   'session-replay-ui',
   'performance-view',
   'performance-trace-explorer',
-  'ai-analytics',
-  'performance-queues-view',
-  'performance-cache-view',
   'starfish-mobile-ui-module',
   'profiling',
 ];

--- a/static/app/components/sidebar/index.tsx
+++ b/static/app/components/sidebar/index.tsx
@@ -277,11 +277,7 @@ function Sidebar() {
   );
 
   const caches = hasOrganization && (
-    <Feature
-      key="cache"
-      features={['insights-entry-points', 'performance-cache-view']}
-      organization={organization}
-    >
+    <Feature key="cache" features="insights-entry-points" organization={organization}>
       <SidebarItem
         {...sidebarItemProps}
         label={
@@ -310,11 +306,7 @@ function Sidebar() {
   );
 
   const queues = hasOrganization && (
-    <Feature
-      key="queue"
-      features={['insights-entry-points', 'performance-queues-view']}
-      organization={organization}
-    >
+    <Feature key="queue" features="insights-entry-points" organization={organization}>
       <SidebarItem
         {...sidebarItemProps}
         label={
@@ -399,10 +391,7 @@ function Sidebar() {
   );
 
   const llmMonitoring = hasOrganization && (
-    <Feature
-      features={['insights-entry-points', 'ai-analytics']}
-      organization={organization}
-    >
+    <Feature features={['insights-entry-points']} organization={organization}>
       <SidebarItem
         {...sidebarItemProps}
         icon={hasNewSidebarHierarchy ? <SubitemDot collapsed /> : <IconRobot />}
@@ -425,8 +414,6 @@ function Sidebar() {
         if (
           !hasNewSidebarHierarchy &&
           (organization.features.includes('insights-entry-points') ||
-            organization.features.includes('performance-cache-view') ||
-            organization.features.includes('performance-queues-view') ||
             organization.features.includes('performance-trace-explorer'))
         ) {
           return (

--- a/static/app/views/alerts/wizard/index.spec.tsx
+++ b/static/app/views/alerts/wizard/index.spec.tsx
@@ -69,9 +69,10 @@ describe('AlertWizard', () => {
     expect(screen.getByText('Errors')).toBeInTheDocument();
     expect(screen.getByText('Sessions')).toBeInTheDocument();
     expect(screen.getByText('Performance')).toBeInTheDocument();
+    expect(screen.getByText('LLM Monitoring')).toBeInTheDocument();
     expect(screen.getByText('Custom')).toBeInTheDocument();
     const alertGroups = screen.getAllByRole('radiogroup');
-    expect(alertGroups.length).toEqual(4);
+    expect(alertGroups.length).toEqual(5);
   });
 
   it('should only render alerts for errors in self-hosted errors only', () => {

--- a/static/app/views/alerts/wizard/index.spec.tsx
+++ b/static/app/views/alerts/wizard/index.spec.tsx
@@ -52,6 +52,7 @@ describe('AlertWizard', () => {
           'incidents',
           'performance-view',
           'crash-rate-alerts',
+          'insights-addon-modules',
         ],
         access: ['org:write', 'alerts:write'],
       },

--- a/static/app/views/alerts/wizard/options.tsx
+++ b/static/app/views/alerts/wizard/options.tsx
@@ -115,10 +115,12 @@ export const getAlertWizardCategories = (org: Organization) => {
         ...(hasCustomMetrics(org) ? (['custom_transactions'] satisfies AlertType[]) : []),
       ],
     });
-    result.push({
-      categoryHeading: LLM_MONITORING_MODULE_TITLE,
-      options: ['llm_tokens', 'llm_cost'],
-    });
+    if (org.features.includes('insights-addon-modules')) {
+      result.push({
+        categoryHeading: LLM_MONITORING_MODULE_TITLE,
+        options: ['llm_tokens', 'llm_cost'],
+      });
+    }
     result.push({
       categoryHeading: hasCustomMetrics(org) ? t('Metrics') : t('Custom'),
       options: [hasCustomMetrics(org) ? 'custom_metrics' : 'custom_transactions'],

--- a/static/app/views/alerts/wizard/options.tsx
+++ b/static/app/views/alerts/wizard/options.tsx
@@ -115,12 +115,10 @@ export const getAlertWizardCategories = (org: Organization) => {
         ...(hasCustomMetrics(org) ? (['custom_transactions'] satisfies AlertType[]) : []),
       ],
     });
-    if (org.features.includes('ai-analytics')) {
-      result.push({
-        categoryHeading: LLM_MONITORING_MODULE_TITLE,
-        options: ['llm_tokens', 'llm_cost'],
-      });
-    }
+    result.push({
+      categoryHeading: LLM_MONITORING_MODULE_TITLE,
+      options: ['llm_tokens', 'llm_cost'],
+    });
     result.push({
       categoryHeading: hasCustomMetrics(org) ? t('Metrics') : t('Custom'),
       options: [hasCustomMetrics(org) ? 'custom_metrics' : 'custom_transactions'],

--- a/static/app/views/issueDetails/groupEventDetails/groupEventDetailsContent.tsx
+++ b/static/app/views/issueDetails/groupEventDetails/groupEventDetailsContent.tsx
@@ -141,7 +141,6 @@ function DefaultGroupEventDetailsContent({
         </EventDataSection>
       )}
       {event.type === EventOrGroupType.ERROR &&
-      organization.features.includes('ai-analytics') &&
       event?.entries
         ?.filter((x): x is EntryException => x.type === EntryType.EXCEPTION)
         .flatMap(x => x.data.values ?? [])

--- a/static/app/views/issueDetails/groupEventDetails/groupEventDetailsContent.tsx
+++ b/static/app/views/issueDetails/groupEventDetails/groupEventDetailsContent.tsx
@@ -141,6 +141,7 @@ function DefaultGroupEventDetailsContent({
         </EventDataSection>
       )}
       {event.type === EventOrGroupType.ERROR &&
+      organization.features.includes('insights-addon-modules') &&
       event?.entries
         ?.filter((x): x is EntryException => x.type === EntryType.EXCEPTION)
         .flatMap(x => x.data.values ?? [])

--- a/static/app/views/llmMonitoring/landing.tsx
+++ b/static/app/views/llmMonitoring/landing.tsx
@@ -99,7 +99,7 @@ export function LLMMonitoringPage() {
 
 function PageWithProviders() {
   return (
-    <ModulePageProviders moduleName="ai" features="ai-analytics">
+    <ModulePageProviders moduleName="ai" features="insights-addon-modules">
       <LLMMonitoringPage />
     </ModulePageProviders>
   );

--- a/static/app/views/llmMonitoring/llmMonitoringDetailsPage.tsx
+++ b/static/app/views/llmMonitoring/llmMonitoringDetailsPage.tsx
@@ -175,7 +175,7 @@ function PageWithProviders({params}: Props) {
     <ModulePageProviders
       moduleName="ai"
       pageTitle={spanDescription ?? t('(no name)')}
-      features="ai-analytics"
+      features="insights-addon-modules"
     >
       <LLMMonitoringPage params={params} />
     </ModulePageProviders>

--- a/static/app/views/performance/cache/cacheLandingPage.tsx
+++ b/static/app/views/performance/cache/cacheLandingPage.tsx
@@ -266,10 +266,7 @@ export function CacheLandingPage() {
 
 function PageWithProviders() {
   return (
-    <ModulePageProviders
-      moduleName="cache"
-      features={['insights-addon-modules', 'performance-cache-view']}
-    >
+    <ModulePageProviders moduleName="cache" features="insights-addon-modules">
       <PageAlertProvider>
         <CacheLandingPage />
       </PageAlertProvider>

--- a/static/app/views/performance/landing/views/backendView.tsx
+++ b/static/app/views/performance/landing/views/backendView.tsx
@@ -73,11 +73,9 @@ export function BackendView(props: BasePerformanceViewProps) {
       doubleChartRowCharts.unshift(PerformanceWidgetSetting.MOST_TIME_CONSUMING_DOMAINS);
       doubleChartRowCharts.unshift(PerformanceWidgetSetting.MOST_TIME_SPENT_DB_QUERIES);
 
-      if (props.organization.features.includes('performance-cache-view')) {
-        doubleChartRowCharts.unshift(
-          PerformanceWidgetSetting.HIGHEST_CACHE_MISS_RATE_TRANSACTIONS
-        );
-      }
+      doubleChartRowCharts.unshift(
+        PerformanceWidgetSetting.HIGHEST_CACHE_MISS_RATE_TRANSACTIONS
+      );
     }
   } else {
     doubleChartRowCharts.push(

--- a/static/app/views/performance/queues/destinationSummary/destinationSummaryPage.spec.tsx
+++ b/static/app/views/performance/queues/destinationSummary/destinationSummaryPage.spec.tsx
@@ -13,7 +13,7 @@ jest.mock('sentry/utils/useProjects');
 
 describe('destinationSummaryPage', () => {
   const organization = OrganizationFixture({
-    features: ['performance-queues-view', 'insights-addon-modules'],
+    features: ['insights-addon-modules'],
   });
 
   jest.mocked(usePageFilters).mockReturnValue({

--- a/static/app/views/performance/queues/destinationSummary/destinationSummaryPage.tsx
+++ b/static/app/views/performance/queues/destinationSummary/destinationSummaryPage.tsx
@@ -164,7 +164,7 @@ function PageWithProviders() {
     <ModulePageProviders
       moduleName="queue"
       pageTitle={t('Destination Summary')}
-      features={['insights-addon-modules', 'performance-queues-view']}
+      features="insights-addon-modules"
     >
       <DestinationSummaryPage />
     </ModulePageProviders>

--- a/static/app/views/performance/queues/queuesLandingPage.spec.tsx
+++ b/static/app/views/performance/queues/queuesLandingPage.spec.tsx
@@ -13,7 +13,7 @@ jest.mock('sentry/utils/useProjects');
 
 describe('queuesLandingPage', () => {
   const organization = OrganizationFixture({
-    features: ['performance-queues-view', 'insights-addon-modules'],
+    features: ['insights-addon-modules'],
   });
 
   jest.mocked(usePageFilters).mockReturnValue({

--- a/static/app/views/performance/queues/queuesLandingPage.tsx
+++ b/static/app/views/performance/queues/queuesLandingPage.tsx
@@ -155,10 +155,7 @@ function QueuesLandingPage() {
 
 function PageWithProviders() {
   return (
-    <ModulePageProviders
-      moduleName="queue"
-      features={['insights-addon-modules', 'performance-queues-view']}
-    >
+    <ModulePageProviders moduleName="queue" features="insights-addon-modules">
       <QueuesLandingPage />
     </ModulePageProviders>
   );


### PR DESCRIPTION
They launched, we're not not unlaunch now. Removing feature flag checks.

- Caches
- Queues
- LLMs
