### PR TITLE
ref(crons): Change copy for over quota processing error

### DIFF
--- a/static/app/views/monitors/components/processingErrors/processingErrorItem.tsx
+++ b/static/app/views/monitors/components/processingErrors/processingErrorItem.tsx
@@ -87,7 +87,7 @@ export function ProcessingErrorItem({error, checkinTooltip}: Props) {
       );
     case ProcessingErrorType.MONITOR_OVER_QUOTA:
       return tct(
-        'A [checkinTooltip:check-in] was sent but dropped due to the monitor being over quota. Please increase your on-demand budget in your [link:subscription settings]. Then, enable this monitor to resume processing check-ins.',
+        'A [checkinTooltip:check-in] was sent but dropped due to the monitor being disabled. Please increase your on-demand budget if needed in your [link:subscription settings]. Then, enable this monitor to resume processing check-ins.',
         {
           checkinTooltip,
           link: <Link to="/settings/billing/overview/" />,

--- a/static/app/views/monitors/components/processingErrors/processingErrorTitle.tsx
+++ b/static/app/views/monitors/components/processingErrors/processingErrorTitle.tsx
@@ -18,7 +18,7 @@ export function ProcessingErrorTitle({type}: {type: ProcessingErrorType}) {
     case ProcessingErrorType.MONITOR_DISABLED:
       return t('Monitor disabled');
     case ProcessingErrorType.MONITOR_DISABLED_NO_QUOTA:
-      return t('Insufficient quota');
+      return t('Insufficient quota to upsert');
     case ProcessingErrorType.MONITOR_INVALID_CONFIG:
       return t('Invalid monitor payload');
     case ProcessingErrorType.MONITOR_INVALID_ENVIRONMENT:
@@ -28,7 +28,7 @@ export function ProcessingErrorTitle({type}: {type: ProcessingErrorType}) {
     case ProcessingErrorType.MONITOR_NOT_FOUND:
       return t('Monitor not found');
     case ProcessingErrorType.MONITOR_OVER_QUOTA:
-      return t('Monitor not enabled due to insufficient quota');
+      return t('Monitor disabled');
     case ProcessingErrorType.MONITOR_ENVIRONMENT_LIMIT_EXCEEDED:
       return t('Environment limit exceeded');
     case ProcessingErrorType.MONITOR_ENVIRONMENT_RATELIMITED:


### PR DESCRIPTION
After more auditing I feel like this is the most appropriate copy for the `MONITOR_OVER_QUOTA` processing error.

This copy is now very similar to the `MONITOR_DISABLED` error. This is because in getsentry we always check to see if we should ingest a check-in based on if there is a seat assigned, before checking if the monitor is disabled. However, when a user disables a monitor the seat is removed.

This means that if a user manually disables a monitor we will write `MONITOR_OVER_QUOTA` errors, rather than `MONITOR_DISABLED` errors if they are a saas customer. In this case, the best action we can give to the user is increase on-demand if needed, and then try enabling the monitor.

Also slightly changed the title for the upsert event to make it more clear.