### PR TITLE
ref(ui): Add raw function/symbol on hover for native frames

### DIFF
--- a/static/app/components/events/interfaces/nativeFrame.tsx
+++ b/static/app/components/events/interfaces/nativeFrame.tsx
@@ -329,7 +329,9 @@ function NativeFrame({
           </GenericCellWrapper>
           <FunctionNameCell>
             {functionName ? (
-              <AnnotatedText value={functionName.value} meta={functionName.meta} />
+              <Tooltip title={frame?.rawFunction ?? frame?.symbol} delay={tooltipDelay}>
+                <AnnotatedText value={functionName.value} meta={functionName.meta} />
+              </Tooltip>
             ) : (
               `<${t('unknown')}>`
             )}{' '}


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry/issues/72336.

![image](https://github.com/getsentry/sentry/assets/35509934/386d2f1b-8912-45f3-a719-0103d94bfd68)

This may help people with debugging in the event we incorrectly parse the function name, as is the case in the linked issue.