### PR TITLE
ref: fix typing in sentry.migrations

### DIFF
--- a/src/sentry/migrations/0641_backfill_group_attributes.py
+++ b/src/sentry/migrations/0641_backfill_group_attributes.py
@@ -62,7 +62,7 @@ def _bulk_retrieve_group_values(group_ids: list[int], Group: type[Group]) -> lis
                 status=group_values["status"],
                 substatus=group_values["substatus"],
                 first_seen=group_values["first_seen"],
-                num_comments=group_values["num_comments"],
+                num_comments=group_values["num_comments"] or 0,
             )
         )
     return results

--- a/src/sentry/migrations/0711_backfill_group_attributes_to_self_hosted.py
+++ b/src/sentry/migrations/0711_backfill_group_attributes_to_self_hosted.py
@@ -64,7 +64,7 @@ def _bulk_retrieve_group_values(group_ids: list[int], Group: type[Group]) -> lis
                 status=group_values["status"],
                 substatus=group_values["substatus"],
                 first_seen=group_values["first_seen"],
-                num_comments=group_values["num_comments"],
+                num_comments=group_values["num_comments"] or 0,
             )
         )
     return results


### PR DESCRIPTION
fixes errors found when BaseManager becomes typechecked

<!-- Describe your PR here. -->