### PR TITLE
fix(perf): Remove 30d restriction on span page filters

### DIFF
--- a/static/app/views/performance/transactionSummary/transactionSpans/content.tsx
+++ b/static/app/views/performance/transactionSummary/transactionSpans/content.tsx
@@ -234,10 +234,7 @@ function SpansContentV2(props: Props) {
         />
         <PageFilterBar condensed>
           <EnvironmentPageFilter />
-          <DatePageFilter
-            maxPickableDays={SPAN_RETENTION_DAYS}
-            relativeOptions={SPAN_RELATIVE_PERIODS}
-          />
+          <DatePageFilter />
         </PageFilterBar>
         <StyledSearchBar
           organization={organization}

--- a/static/app/views/performance/transactionSummary/transactionSpans/spanSummary/spanSummaryControls.tsx
+++ b/static/app/views/performance/transactionSummary/transactionSpans/spanSummary/spanSummaryControls.tsx
@@ -5,17 +5,12 @@ import {EnvironmentPageFilter} from 'sentry/components/organizations/environment
 import PageFilterBar from 'sentry/components/organizations/pageFilterBar';
 import {space} from 'sentry/styles/space';
 
-import {SPAN_RELATIVE_PERIODS, SPAN_RETENTION_DAYS} from '../utils';
-
 export default function SpanDetailsControls() {
   return (
     <FilterActions>
       <PageFilterBar condensed>
         <EnvironmentPageFilter />
-        <DatePageFilter
-          relativeOptions={SPAN_RELATIVE_PERIODS}
-          maxPickableDays={SPAN_RETENTION_DAYS}
-        />
+        <DatePageFilter />
       </PageFilterBar>
     </FilterActions>
   );


### PR DESCRIPTION
This restriction was in place because spans previously were stored on transactions that have a 30d retention period. Since we are now using metrics, we can let go of this restriction and allow up to a 90d period