### PR TITLE
chore(hybridcloud) Merge frontend-domains feature into multi-region

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -3442,7 +3442,7 @@ if ngrok_host:
     SENTRY_OPTIONS["system.url-prefix"] = f"https://{ngrok_host}"
     SENTRY_OPTIONS["system.base-hostname"] = ngrok_host
     SENTRY_OPTIONS["system.region-api-url-template"] = f"https://{{region}}.{ngrok_host}"
-    SENTRY_FEATURES["organizations:frontend-domainsplit"] = True
+    SENTRY_FEATURES["system:multi-region"] = True
 
     CSRF_TRUSTED_ORIGINS = [f"https://*.{ngrok_host}", f"https://{ngrok_host}"]
     ALLOWED_HOSTS = [f".{ngrok_host}", "localhost", "127.0.0.1", ".docker.internal"]

--- a/src/sentry/features/permanent.py
+++ b/src/sentry/features/permanent.py
@@ -106,8 +106,6 @@ def register_permanent_features(manager: FeatureManager):
         "organizations:custom-metrics": False,
         # Enable usage of customer domains on the frontend
         "organizations:customer-domains": False,
-        # Enable the frontend to request from region & control silo domains.
-        "organizations:frontend-domainsplit": False,
         # Prefix host with organization ID when giving users DSNs (can be
         # customized with SENTRY_ORG_SUBDOMAIN_TEMPLATE) eg. o123.ingest.us.sentry.io
         "organizations:org-ingest-subdomains": False,

--- a/static/app/api.spec.tsx
+++ b/static/app/api.spec.tsx
@@ -91,20 +91,19 @@ describe('api', function () {
 });
 
 describe('resolveHostname', function () {
-  let devUi, location, orgstate, configstate;
+  let devUi, location, configstate;
 
   const controlPath = '/api/0/broadcasts/';
   const regionPath = '/api/0/organizations/slug/issues/';
 
   beforeEach(function () {
-    orgstate = OrganizationStore.get();
     configstate = ConfigStore.getState();
     location = window.location;
     devUi = window.__SENTRY_DEV_UI;
 
-    OrganizationStore.onUpdate(OrganizationFixture({features: ['frontend-domainsplit']}));
     ConfigStore.loadInitialData({
       ...configstate,
+      features: ['system:multi-region'],
       links: {
         organizationUrl: 'https://acme.sentry.io',
         sentryUrl: 'https://sentry.io',
@@ -116,13 +115,15 @@ describe('resolveHostname', function () {
   afterEach(() => {
     window.location = location;
     window.__SENTRY_DEV_UI = devUi;
-    OrganizationStore.onUpdate(orgstate.organization);
     ConfigStore.loadInitialData(configstate);
   });
 
   it('does nothing without feature', function () {
-    // Org does not have the required feature.
-    OrganizationStore.onUpdate(OrganizationFixture());
+    ConfigStore.loadInitialData({
+      ...configstate,
+      // Remove the feature flag
+      features: [],
+    });
 
     let result = resolveHostname(controlPath);
     expect(result).toBe(controlPath);

--- a/static/app/api.tsx
+++ b/static/app/api.tsx
@@ -19,7 +19,6 @@ import RequestError from 'sentry/utils/requestError/requestError';
 import {sanitizePath} from 'sentry/utils/requestError/sanitizePath';
 
 import ConfigStore from './stores/configStore';
-import OrganizationStore from './stores/organizationStore';
 
 export class Request {
   /**
@@ -698,11 +697,11 @@ export class Client {
 }
 
 export function resolveHostname(path: string, hostname?: string): string {
-  const storeState = OrganizationStore.get();
   const configLinks = ConfigStore.get('links');
+  const systemFeatures = ConfigStore.get('features');
 
   hostname = hostname ?? '';
-  if (!hostname && storeState.organization?.features.includes('frontend-domainsplit')) {
+  if (!hostname && systemFeatures.has('system:multi-region')) {
     // /_admin/ is special: since it doesn't update OrganizationStore, it's
     // commonly the case that requests will be made for data which does not
     // exist in the same region as the one in configLinks.regionUrl. Because of


### PR DESCRIPTION
The system:multi-region feature will replace the various hybridcloud related feature flags, and these changes merge frontend-domainsplit into `multi-region`.

Requires getsentry/getsentry#14291 to merge and deploy first

Refs getsentry/sentry#72537