### PR TITLE
style(feedback): fix loading indicator alignment

### DIFF
--- a/static/app/components/feedback/feedbackItem/feedbackScreenshot.tsx
+++ b/static/app/components/feedback/feedbackItem/feedbackScreenshot.tsx
@@ -53,14 +53,16 @@ const StyledPanel = styled(Panel)`
   margin-bottom: 0;
   border: 0;
   border-radius: ${p => p.theme.borderRadius};
+  gap: 0px;
 `;
 
 const StyledLoadingIndicator = styled('div')`
-  position: absolute;
   display: flex;
   align-items: center;
   justify-content: center;
   height: 100%;
+  overflow: auto;
+  background: ${p => p.theme.purple100};
 `;
 
 const StyledImageButton = styled('button')`

--- a/static/app/components/feedback/feedbackItem/feedbackScreenshot.tsx
+++ b/static/app/components/feedback/feedbackItem/feedbackScreenshot.tsx
@@ -53,7 +53,6 @@ const StyledPanel = styled(Panel)`
   margin-bottom: 0;
   border: 0;
   border-radius: ${p => p.theme.borderRadius};
-  gap: 0px;
 `;
 
 const StyledLoadingIndicator = styled('div')`
@@ -61,7 +60,6 @@ const StyledLoadingIndicator = styled('div')`
   align-items: center;
   justify-content: center;
   height: 100%;
-  overflow: auto;
   background: ${p => p.theme.purple100};
 `;
 

--- a/static/app/components/feedback/feedbackItem/screenshotSection.tsx
+++ b/static/app/components/feedback/feedbackItem/screenshotSection.tsx
@@ -92,5 +92,4 @@ const ScreenshotWrapper = styled('ul')`
 const FixedSizeFeedbackScreenshot = styled(FeedbackScreenshot)`
   max-width: 360px;
   max-height: 360px;
-  gap: ${space(1)};
 `;


### PR DESCRIPTION
closes https://github.com/getsentry/sentry/issues/71582

fix the alignment on the loading indicator for showing screenshots in feedback

before:

https://github.com/getsentry/sentry/assets/56095982/018a66dd-42de-491d-9e54-32dda0138ad7

after:

https://github.com/getsentry/sentry/assets/56095982/1940d5f2-abaa-4598-b7ab-ca9c7747fca8

