### PR TITLE
chore(insights): Update documentation URLs

### DIFF
--- a/static/app/views/llmMonitoring/settings.ts
+++ b/static/app/views/llmMonitoring/settings.ts
@@ -10,4 +10,4 @@ export const releaseLevelAsBadgeProps = {
   isNew: true,
 };
 
-export const MODULE_DOC_LINK = 'https://docs.sentry.io/product/llm-monitoring/';
+export const MODULE_DOC_LINK = 'https://docs.sentry.io/product/insights/llm-monitoring/';

--- a/static/app/views/performance/browser/resources/settings.ts
+++ b/static/app/views/performance/browser/resources/settings.ts
@@ -14,4 +14,4 @@ export const PERFORMANCE_MODULE_DESCRIPTION = t(
   'Find large and slow-to-load resources used by your application and understand their impact on page performance.'
 );
 
-export const MODULE_DOC_LINK = 'https://docs.sentry.io/product/performance/resources/';
+export const MODULE_DOC_LINK = 'https://docs.sentry.io/product/insights/assets/';

--- a/static/app/views/performance/browser/webVitals/settings.ts
+++ b/static/app/views/performance/browser/webVitals/settings.ts
@@ -9,7 +9,7 @@ export const REPLACE_FID_WITH_INP = false;
 export const MODULE_DESCRIPTION = t(
   'Measure the quality of real user experience in your web applications using industry standard quality signals.'
 );
-export const MODULE_DOC_LINK = 'https://docs.sentry.io/product/performance/web-vitals/';
+export const MODULE_DOC_LINK = 'https://docs.sentry.io/product/insights/web-vitals/';
 
 export const DEFAULT_QUERY_FILTER =
   'transaction.op:[pageload,""] span.op:[ui.interaction.click,ui.interaction.hover,ui.interaction.drag,ui.interaction.press,""] !transaction:"<< unparameterized >>"';

--- a/static/app/views/performance/cache/settings.ts
+++ b/static/app/views/performance/cache/settings.ts
@@ -20,7 +20,7 @@ export const BASE_FILTERS: SpanMetricsQueryFilters = {
 export const MODULE_DESCRIPTION = t(
   'Discover whether your application is utilizing caching effectively and understand the latency associated with cache misses.'
 );
-export const MODULE_DOC_LINK = 'https://docs.sentry.io/product/performance/caches/';
+export const MODULE_DOC_LINK = 'https://docs.sentry.io/product/insights/caches/';
 
 export const ONBOARDING_CONTENT = {
   title: t('Start collecting Insights about your Caches!'),

--- a/static/app/views/performance/database/settings.ts
+++ b/static/app/views/performance/database/settings.ts
@@ -59,4 +59,4 @@ export const DISTRIBUTION_GRANULARITIES = new GranularityLadder([
 export const MODULE_DESCRIPTION = t(
   'Investigate the performance of database queries and get the information necessary to improve them.'
 );
-export const MODULE_DOC_LINK = 'https://docs.sentry.io/product/performance/queries/';
+export const MODULE_DOC_LINK = 'https://docs.sentry.io/product/insights/queries/';

--- a/static/app/views/performance/http/settings.ts
+++ b/static/app/views/performance/http/settings.ts
@@ -17,4 +17,4 @@ export const BASE_FILTERS = {
 export const MODULE_DESCRIPTION = t(
   'Monitor outgoing HTTP requests and investigate errors and performance bottlenecks tied to domains.'
 );
-export const MODULE_DOC_LINK = 'https://docs.sentry.io/product/performance/requests/';
+export const MODULE_DOC_LINK = 'https://docs.sentry.io/product/insights/requests/';

--- a/static/app/views/performance/mobile/appStarts/settings.ts
+++ b/static/app/views/performance/mobile/appStarts/settings.ts
@@ -7,4 +7,4 @@ export const MODULE_DESCRIPTION = t(
   'Improve the latency associated with your application starting up. '
 );
 export const MODULE_DOC_LINK =
-  'https://docs.sentry.io/product/performance/mobile-vitals/app-starts/';
+  'https://docs.sentry.io/product/insights/mobile-vitals/app-starts/';

--- a/static/app/views/performance/mobile/screenload/settings.ts
+++ b/static/app/views/performance/mobile/screenload/settings.ts
@@ -7,4 +7,4 @@ export const MODULE_DESCRIPTION = t(
   'View the most active screens in your mobile application and monitor your releases for TTID and TTFD regressions.'
 );
 export const MODULE_DOC_LINK =
-  'https://docs.sentry.io/product/performance/mobile-vitals/screen-loads/';
+  'https://docs.sentry.io/product/insights/mobile-vitals/screen-loads/';

--- a/static/app/views/performance/mobile/ui/settings.ts
+++ b/static/app/views/performance/mobile/ui/settings.ts
@@ -6,5 +6,4 @@ export const BASE_URL = 'mobile/ui';
 export const MODULE_DESCRIPTION = t("Improve your application's responsiveness.");
 
 // TODO: Update this link once we have the proper docs.
-export const MODULE_DOC_LINK =
-  'https://docs.sentry.io/product/performance/mobile-vitals/';
+export const MODULE_DOC_LINK = 'https://docs.sentry.io/product/insights/mobile-vitals/';

--- a/static/app/views/performance/queues/settings.ts
+++ b/static/app/views/performance/queues/settings.ts
@@ -44,7 +44,7 @@ export const MODULE_DESCRIPTION = t(
   'Understand the health and performance impact that queues have on your application and diagnose errors tied to jobs.'
 );
 export const MODULE_DOC_LINK =
-  'https://docs.sentry.io/product/performance/queue-monitoring/';
+  'https://docs.sentry.io/product/insights/queue-monitoring/';
 
 export const ONBOARDING_CONTENT = {
   title: t('Start collecting Insights about your Queues!'),


### PR DESCRIPTION
The URLs have changed! Redirects exist, but why rely on redirects?
