### PR TITLE
fix(issues): Prevent error when stream ids don't match group store

### DIFF
--- a/static/app/components/stream/group.spec.tsx
+++ b/static/app/components/stream/group.spec.tsx
@@ -8,14 +8,15 @@ import {act, render, screen, userEvent, within} from 'sentry-test/reactTestingLi
 import StreamGroup from 'sentry/components/stream/group';
 import GroupStore from 'sentry/stores/groupStore';
 import GuideStore from 'sentry/stores/guideStore';
-import type {GroupStatusResolution, MarkReviewed} from 'sentry/types';
-import {EventOrGroupType, GroupStatus, PriorityLevel} from 'sentry/types';
+import {EventOrGroupType} from 'sentry/types/event';
+import type {Group, GroupStatusResolution, MarkReviewed} from 'sentry/types/group';
+import {GroupStatus, PriorityLevel} from 'sentry/types/group';
 import {trackAnalytics} from 'sentry/utils/analytics';
 
 jest.mock('sentry/utils/analytics');
 
 describe('StreamGroup', function () {
-  let group1;
+  let group1!: Group;
 
   beforeEach(function () {
     group1 = GroupFixture({
@@ -149,5 +150,19 @@ describe('StreamGroup', function () {
     expect(checkbox).toBeChecked();
     await userEvent.click(checkbox);
     expect(checkbox).not.toBeChecked();
+  });
+
+  it('does not error when group is not in GroupStore', function () {
+    const {router, organization} = initializeOrg();
+    GroupStore.reset();
+    const {container} = render(
+      <StreamGroup
+        id="1337"
+        query="is:unresolved is:for_review assigned_or_suggested:[me, none]"
+      />,
+      {router, organization}
+    );
+
+    expect(container).toBeEmptyDOMElement();
   });
 });


### PR DESCRIPTION
There seems to be a race between updating the group ids in the issues stream and the groups being removed from the group store. Ideally we would not use the group store and just pass the group from the stream. For now, avoid throwing errors.

fixes JAVASCRIPT-2TK8

replays show the user resolving or another action that removes the issues from the current stream
