### PR TITLE
chore(seer grouping): Add `seer.similarity.supported_platforms` option

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -888,6 +888,12 @@ register(
     flags=FLAG_ALLOW_EMPTY | FLAG_AUTOMATOR_MODIFIABLE,
 )
 
+register(
+    "seer.similarity.supported_platforms",
+    type=Sequence,
+    default=["python", "javascript", "node"],
+    flags=FLAG_ALLOW_EMPTY | FLAG_AUTOMATOR_MODIFIABLE,
+)
 
 # seer nearest neighbour endpoint timeout
 register(

--- a/src/sentry/seer/similarity/utils.py
+++ b/src/sentry/seer/similarity/utils.py
@@ -1,6 +1,7 @@
 import logging
 from typing import Any
 
+from sentry import options
 from sentry.constants import PLACEHOLDER_EVENT_TITLES
 from sentry.eventstore.models import Event
 from sentry.utils.safe import get_path
@@ -8,7 +9,7 @@ from sentry.utils.safe import get_path
 logger = logging.getLogger(__name__)
 
 MAX_FRAME_COUNT = 50
-SEER_ELIGIBLE_PLATFORMS = frozenset(["python", "javascript", "node"])
+SEER_ELIGIBLE_PLATFORMS = options.get("seer.similarity.supported_platforms")
 
 
 def _get_value_if_exists(exception_value: dict[str, Any]) -> str:


### PR DESCRIPTION
This changes our list of Seer similarity supported platforms to be configurable via the options automator. As we canonically support new platforms, we should still add them to the default value here (rather than adding them in the automator), but this will let us selectively enable or disable platforms on the fly as we're testing things out.