### PR TITLE
fix(slack): Ensure `integration_id` is Valid

### DIFF
--- a/src/sentry/integrations/slack/actions/form.py
+++ b/src/sentry/integrations/slack/actions/form.py
@@ -71,6 +71,10 @@ class SlackNotifyServiceForm(forms.Form):
         assert cleaned_data is not None
 
         workspace = cleaned_data.get("workspace")
+        if not workspace:
+            raise forms.ValidationError(
+                self._format_slack_error_message("Workspace is a required field."), code="invalid"
+            )
 
         if channel_id:
             try:


### PR DESCRIPTION
https://sentry.sentry.io/issues/4927267210/?alert_rule_id=14700499&alert_type=issue&notification_uuid=36c508db-184c-4705-ace3-0a60fcb71207&project=1 occurs because the function expects that the `integration_id` is not None which was not the case because we didn't validate this in the form here.

I add the check here.