### PR TITLE
fix(priority-alerts): Change default action_match to any

### DIFF
--- a/src/sentry/receivers/rules.py
+++ b/src/sentry/receivers/rules.py
@@ -29,7 +29,7 @@ DEFAULT_RULE_ACTIONS_NEW = [
     }
 ]
 DEFAULT_RULE_DATA_NEW = {
-    "action_match": "all",
+    "action_match": "any",
     "conditions": [
         {"id": "sentry.rules.conditions.high_priority_issue.NewHighPriorityIssueCondition"},
         {"id": "sentry.rules.conditions.high_priority_issue.ExistingHighPriorityIssueCondition"},


### PR DESCRIPTION
This fixes a bug where high priority alerts are not being sent out since the action match expects both the new and existing issue condition to be true.

Changing the `action_match` to `any` will send an alert if either of the conditions are met.