### PR TITLE
fix(crons): Fix bulk edit modal

### DIFF
--- a/static/app/actionCreators/monitors.tsx
+++ b/static/app/actionCreators/monitors.tsx
@@ -118,7 +118,7 @@ interface BulkEditResponse {
 export async function bulkEditMonitors(
   api: Client,
   orgId: string,
-  slugs: string[],
+  ids: string[],
   operation: BulkEditOperation
 ): Promise<BulkEditResponse | null> {
   addLoadingMessage();
@@ -128,7 +128,7 @@ export async function bulkEditMonitors(
       `/organizations/${orgId}/monitors/`,
       {
         method: 'PUT',
-        data: {...operation, slugs},
+        data: {...operation, ids},
       }
     );
     clearIndicators();

--- a/static/app/components/modals/bulkEditMonitorsModal.tsx
+++ b/static/app/components/modals/bulkEditMonitorsModal.tsx
@@ -78,7 +78,7 @@ export function BulkEditMonitorsModal({Header, Body, Footer, closeModal}: Props)
     const resp = await bulkEditMonitors(
       api,
       organization.slug,
-      selectedMonitors.map(monitor => monitor.slug),
+      selectedMonitors.map(monitor => monitor.id),
       operation
     );
     setSelectedMonitors([]);


### PR DESCRIPTION
Fixes bulk edit modal to use monitor guids instead of slugs (which are not unique to the org anymore) to specify which monitors to apply edits to.

Depends on: https://github.com/getsentry/sentry/pull/72375