### PR TITLE
feat(insights): Updates queues module throughput chart to display as a rate/spm

### DIFF
--- a/static/app/views/performance/queues/charts/latencyChart.spec.tsx
+++ b/static/app/views/performance/queues/charts/latencyChart.spec.tsx
@@ -30,14 +30,11 @@ describe('latencyChart', () => {
       expect.objectContaining({
         query: expect.objectContaining({
           yAxis: [
-            'avg_if(span.duration,span.op,queue.publish)',
-            'avg_if(span.duration,span.op,queue.process)',
+            'avg(span.duration)',
             'avg(messaging.message.receive.latency)',
-            'count_op(queue.publish)',
-            'count_op(queue.process)',
+            'spm()',
           ],
-          query:
-            'span.op:[queue.process,queue.publish] messaging.destination.name:events',
+          query: 'span.op:queue.process messaging.destination.name:events',
         }),
       })
     );

--- a/static/app/views/performance/queues/charts/latencyChart.tsx
+++ b/static/app/views/performance/queues/charts/latencyChart.tsx
@@ -1,7 +1,7 @@
 import {CHART_PALETTE} from 'sentry/constants/chartPalette';
 import {t} from 'sentry/locale';
 import {CHART_HEIGHT} from 'sentry/views/performance/database/settings';
-import {useQueuesTimeSeriesQuery} from 'sentry/views/performance/queues/queries/useQueuesTimeSeriesQuery';
+import {useProcessQueuesTimeSeriesQuery} from 'sentry/views/performance/queues/queries/useProcessQueuesTimeSeriesQuery';
 import type {Referrer} from 'sentry/views/performance/queues/referrers';
 import Chart, {ChartType} from 'sentry/views/starfish/components/chart';
 import ChartPanel from 'sentry/views/starfish/components/chartPanel';
@@ -13,7 +13,11 @@ interface Props {
 }
 
 export function LatencyChart({error, destination, referrer}: Props) {
-  const {data, isLoading} = useQueuesTimeSeriesQuery({destination, referrer});
+  const {data, isLoading} = useProcessQueuesTimeSeriesQuery({
+    destination,
+    referrer,
+  });
+
   return (
     <ChartPanel title={t('Avg Latency')}>
       <Chart
@@ -32,7 +36,7 @@ export function LatencyChart({error, destination, referrer}: Props) {
             },
             {
               seriesName: t('Average Processing Time'),
-              data: data['avg_if(span.duration,span.op,queue.process)'].data,
+              data: data['avg(span.duration)'].data,
             },
           ] ?? []
         }

--- a/static/app/views/performance/queues/charts/throughputChart.spec.tsx
+++ b/static/app/views/performance/queues/charts/throughputChart.spec.tsx
@@ -27,13 +27,20 @@ describe('throughputChart', () => {
       expect.objectContaining({
         query: expect.objectContaining({
           yAxis: [
-            'avg_if(span.duration,span.op,queue.publish)',
-            'avg_if(span.duration,span.op,queue.process)',
+            'avg(span.duration)',
             'avg(messaging.message.receive.latency)',
-            'count_op(queue.publish)',
-            'count_op(queue.process)',
+            'spm()',
           ],
-          query: 'span.op:[queue.process,queue.publish]',
+          query: 'span.op:queue.process',
+        }),
+      })
+    );
+    expect(eventsStatsMock).toHaveBeenCalledWith(
+      '/organizations/org-slug/events-stats/',
+      expect.objectContaining({
+        query: expect.objectContaining({
+          yAxis: ['avg(span.duration)', 'spm()'],
+          query: 'span.op:queue.publish',
         }),
       })
     );

--- a/static/app/views/performance/queues/queries/useProcessQueuesTimeSeriesQuery.tsx
+++ b/static/app/views/performance/queues/queries/useProcessQueuesTimeSeriesQuery.tsx
@@ -1,6 +1,5 @@
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import type {Referrer} from 'sentry/views/performance/queues/referrers';
-import {DEFAULT_QUERY_FILTER} from 'sentry/views/performance/queues/settings';
 import {useSpanMetricsSeries} from 'sentry/views/starfish/queries/useDiscoverSeries';
 import type {SpanMetricsProperty} from 'sentry/views/starfish/types';
 
@@ -11,23 +10,21 @@ type Props = {
 };
 
 const yAxis: SpanMetricsProperty[] = [
-  'avg_if(span.duration,span.op,queue.publish)',
-  'avg_if(span.duration,span.op,queue.process)',
+  'avg(span.duration)',
   'avg(messaging.message.receive.latency)',
-  'count_op(queue.publish)',
-  'count_op(queue.process)',
+  'spm()',
 ];
 
-export function useQueuesTimeSeriesQuery({enabled, destination, referrer}: Props) {
-  const mutableSearch = new MutableSearch(DEFAULT_QUERY_FILTER);
+export function useProcessQueuesTimeSeriesQuery({enabled, destination, referrer}: Props) {
+  const search = new MutableSearch('span.op:queue.process');
   if (destination) {
-    mutableSearch.addFilterValue('messaging.destination.name', destination, false);
+    search.addFilterValue('messaging.destination.name', destination, false);
   }
 
   return useSpanMetricsSeries(
     {
       yAxis,
-      search: mutableSearch,
+      search,
       enabled,
     },
     referrer

--- a/static/app/views/performance/queues/queries/usePublishQueuesTimeSeriesQuery.tsx
+++ b/static/app/views/performance/queues/queries/usePublishQueuesTimeSeriesQuery.tsx
@@ -1,0 +1,28 @@
+import {MutableSearch} from 'sentry/utils/tokenizeSearch';
+import type {Referrer} from 'sentry/views/performance/queues/referrers';
+import {useSpanMetricsSeries} from 'sentry/views/starfish/queries/useDiscoverSeries';
+import type {SpanMetricsProperty} from 'sentry/views/starfish/types';
+
+type Props = {
+  referrer: Referrer;
+  destination?: string;
+  enabled?: boolean;
+};
+
+const yAxis: SpanMetricsProperty[] = ['avg(span.duration)', 'spm()'];
+
+export function usePublishQueuesTimeSeriesQuery({enabled, destination, referrer}: Props) {
+  const search = new MutableSearch('span.op:queue.publish');
+  if (destination) {
+    search.addFilterValue('messaging.destination.name', destination, false);
+  }
+
+  return useSpanMetricsSeries(
+    {
+      yAxis,
+      search,
+      enabled,
+    },
+    referrer
+  );
+}


### PR DESCRIPTION
Refactors useQueuesTimeseriesQuery into two separate hooks/queries (it was getting messy managing aggregate functions for both publish and process span ops).
Updates queues module throughput table to display throughput in spm rate.
<img width="584" alt="image" src="https://github.com/getsentry/sentry/assets/83961295/92eb9d4c-67c8-4262-a07d-e7f5cd82d584">
