### PR TITLE
feat(rules): Minor formatting and copy changes

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -340,7 +340,7 @@ def register_temporary_features(manager: FeatureManager):
     # Enable resolve in upcoming release
     manager.add("organizations:resolve-in-upcoming-release", OrganizationFeature, FeatureHandlerStrategy.OPTIONS)
     # Enable post create/edit rule confirmation notifications
-    manager.add("organizations:rule-create-edit-confirm-notification", OrganizationFeature, FeatureHandlerStrategy.REMOTE, default=True)
+    manager.add("organizations:rule-create-edit-confirm-notification", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
     manager.add("organizations:sandbox-kill-switch", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
     # Enable team member role provisioning through scim
     manager.add("organizations:scim-team-roles", OrganizationFeature, FeatureHandlerStrategy.REMOTE)

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -340,7 +340,7 @@ def register_temporary_features(manager: FeatureManager):
     # Enable resolve in upcoming release
     manager.add("organizations:resolve-in-upcoming-release", OrganizationFeature, FeatureHandlerStrategy.OPTIONS)
     # Enable post create/edit rule confirmation notifications
-    manager.add("organizations:rule-create-edit-confirm-notification", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
+    manager.add("organizations:rule-create-edit-confirm-notification", OrganizationFeature, FeatureHandlerStrategy.REMOTE, default=True)
     manager.add("organizations:sandbox-kill-switch", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
     # Enable team member role provisioning through scim
     manager.add("organizations:scim-team-roles", OrganizationFeature, FeatureHandlerStrategy.REMOTE)

--- a/src/sentry/integrations/slack/message_builder/notifications/rule_save_edit.py
+++ b/src/sentry/integrations/slack/message_builder/notifications/rule_save_edit.py
@@ -29,7 +29,7 @@ class SlackRuleSaveEditMessageBuilder(BlockSlackMessageBuilder):
         return f"<{rule_url}|*{escape_slack_text(rule_name)}*>"
 
     def linkify_project(self, org_slug: str, project_slug: str):
-        project_url_path = f"/projects/{project_slug}/"
+        project_url_path = f"/organizations/{org_slug}/projects/{project_slug}/"
         project_url = absolute_uri(project_url_path)
         return f"<{project_url}|*{escape_slack_text(project_slug)}*>"
 

--- a/src/sentry/integrations/slack/message_builder/notifications/rule_save_edit.py
+++ b/src/sentry/integrations/slack/message_builder/notifications/rule_save_edit.py
@@ -20,15 +20,18 @@ class SlackRuleSaveEditMessageBuilder(BlockSlackMessageBuilder):
         self.new = new
         self.changed = changed
 
-    def linkify_rule(self):
-        org_slug = self.rule.project.organization.slug
-        project_slug = self.rule.project.slug
+    def linkify_rule(self, org_slug: str, project_slug: str):
         rule_url_path = (
             f"/organizations/{org_slug}/alerts/rules/{project_slug}/{self.rule.id}/details/"
         )
         rule_url = absolute_uri(rule_url_path)
         rule_name = self.rule.label
         return f"<{rule_url}|*{escape_slack_text(rule_name)}*>"
+
+    def linkify_project(self, org_slug: str, project_slug: str):
+        project_url_path = f"/projects/{project_slug}/"
+        project_url = absolute_uri(project_url_path)
+        return f"<{project_url}|*{escape_slack_text(project_slug)}*>"
 
     def get_settings_url(self):
         url_str = "/settings/account/notifications/"
@@ -39,12 +42,14 @@ class SlackRuleSaveEditMessageBuilder(BlockSlackMessageBuilder):
 
     def build(self) -> SlackBlock:
         blocks = []
-        rule_url = self.linkify_rule()
-        project = self.rule.project.slug
+        org_slug = self.rule.project.organization.slug
+        project_slug = self.rule.project.slug
+        rule_url = self.linkify_rule(org_slug, project_slug)
+        project_url = self.linkify_project(org_slug, project_slug)
         if self.new:
-            rule_text = f"Alert rule {rule_url} was created in the *{project}* project and will send notifications here."
+            rule_text = f"Alert rule {rule_url} was created in the {project_url} project and will send notifications to this channel."
         else:
-            rule_text = f"Alert rule {rule_url} in the *{project}* project was updated."
+            rule_text = f"Alert rule {rule_url} in the {project_url} project was updated."
             # TODO potentially use old name if it's changed?
 
         blocks.append(self.get_markdown_block(rule_text))

--- a/src/sentry/integrations/slack/message_builder/notifications/rule_save_edit.py
+++ b/src/sentry/integrations/slack/message_builder/notifications/rule_save_edit.py
@@ -20,18 +20,9 @@ class SlackRuleSaveEditMessageBuilder(BlockSlackMessageBuilder):
         self.new = new
         self.changed = changed
 
-    def linkify_rule(self, org_slug: str, project_slug: str):
-        rule_url_path = (
-            f"/organizations/{org_slug}/alerts/rules/{project_slug}/{self.rule.id}/details/"
-        )
-        rule_url = absolute_uri(rule_url_path)
-        rule_name = self.rule.label
-        return f"<{rule_url}|*{escape_slack_text(rule_name)}*>"
-
-    def linkify_project(self, org_slug: str, project_slug: str):
-        project_url_path = f"/organizations/{org_slug}/projects/{project_slug}/"
-        project_url = absolute_uri(project_url_path)
-        return f"<{project_url}|*{escape_slack_text(project_slug)}*>"
+    def linkify(self, org_slug: str, project_slug: str, url_str: str, url_text: str):
+        url = absolute_uri(url_str)
+        return f"<{url}|*{escape_slack_text(url_text)}*>"
 
     def get_settings_url(self):
         url_str = "/settings/account/notifications/"
@@ -44,8 +35,13 @@ class SlackRuleSaveEditMessageBuilder(BlockSlackMessageBuilder):
         blocks = []
         org_slug = self.rule.project.organization.slug
         project_slug = self.rule.project.slug
-        rule_url = self.linkify_rule(org_slug, project_slug)
-        project_url = self.linkify_project(org_slug, project_slug)
+        rule_url_path = (
+            f"/organizations/{org_slug}/alerts/rules/{project_slug}/{self.rule.id}/details/"
+        )
+        rule_name = self.rule.label
+        rule_url = self.linkify(org_slug, project_slug, rule_url_path, rule_name)
+        project_url_path = f"/organizations/{org_slug}/projects/{project_slug}/"
+        project_url = self.linkify(org_slug, project_slug, project_url_path, project_slug)
         if self.new:
             rule_text = f"Alert rule {rule_url} was created in the {project_url} project and will send notifications to this channel."
         else:

--- a/src/sentry/rules/actions/utils.py
+++ b/src/sentry/rules/actions/utils.py
@@ -27,7 +27,7 @@ def check_value_changed(
     if present_state.get(key) != prior_state.get(key):
         old_value = prior_state.get(key)
         new_value = present_state.get(key)
-        return f"Changed {word} from *{old_value}* to *{new_value}*"
+        return f"Changed {word} from '{old_value}' to '{new_value}'"
     return None
 
 
@@ -54,7 +54,7 @@ def generate_diff_labels(
         if prior_state.get(changed_id) != present_state.get(changed_id):
             old_label = generate_rule_label(rule.project, rule, prior_state.get(changed_id))
             new_label = generate_rule_label(rule.project, rule, present_state.get(changed_id))
-            changed_data[changed_id] = [(f"Changed {key} from *{old_label}* to *{new_label}*")]
+            changed_data[changed_id] = [(f"Changed {key} from '{old_label}' to '{new_label}'")]
 
     # Removed items
     for removed_id in prior_ids.difference(present_ids):
@@ -110,7 +110,7 @@ def get_changed_data(
     current_frequency = get_frequency_label(rule_data.get("frequency"))
     previous_frequency = get_frequency_label(rule_data_before.get("frequency"))
     if current_frequency != previous_frequency:
-        frequency_text = f"Changed frequency from *{previous_frequency}* to *{current_frequency}*"
+        frequency_text = f"Changed frequency from '{previous_frequency}' to '{current_frequency}'"
         changed_data["changed_frequency"].append(frequency_text)
 
     if rule_data.get("environment_id") and not rule_data_before.get("environment_id"):
@@ -121,7 +121,7 @@ def get_changed_data(
             pass
 
         if environment:
-            changed_data["environment"].append(f"Added *{environment.name}* environment")
+            changed_data["environment"].append(f"Added '{environment.name}' environment")
 
     if rule_data_before.get("environment_id") and not rule_data.get("environment_id"):
         environment = None
@@ -131,7 +131,7 @@ def get_changed_data(
             pass
 
         if environment:
-            changed_data["environment"].append(f"Removed *{environment.name}* environment")
+            changed_data["environment"].append(f"Removed '{environment.name}' environment")
 
     label_text = check_value_changed(rule_data, rule_data_before, "label", "rule name")
     if label_text:
@@ -155,7 +155,7 @@ def get_changed_data(
         new_actor = "Unassigned"
         if new_owner:
             new_actor = new_owner.resolve()
-        owner_changed_text = f"Changed owner from *{old_actor}* to *{new_actor}*"
+        owner_changed_text = f"Changed owner from '{old_actor}' to '{new_actor}'"
         changed_data["owner"].append(owner_changed_text)
 
     return changed_data

--- a/tests/sentry/api/endpoints/test_project_rule_details.py
+++ b/tests/sentry/api/endpoints/test_project_rule_details.py
@@ -1189,7 +1189,7 @@ class UpdateProjectRuleTest(ProjectRuleDetailsBaseTestCase):
         message = f"Alert rule <http://testserver/organizations/{self.organization.slug}/alerts/rules/{self.project.slug}/{rule_id}/details/|*{rule_label}*> in the <http://testserver/organizations/{self.organization.slug}/projects/{self.project.slug}/|*{self.project.slug}*> project was updated."
         assert sent_blocks[0]["text"]["text"] == message
 
-        changes = "'Changes'\n"
+        changes = "*Changes*\n"
         changes += "• Added condition 'The issue's category is equal to Performance'\n"
         changes += "• Changed action from 'Send a notification to the Awesome Team Slack workspace to #old_channel_name' to 'Send a notification to the Awesome Team Slack workspace to #new_channel_name'\n"
         changes += "• Changed frequency from '5 minutes' to '3 hours'\n"

--- a/tests/sentry/api/endpoints/test_project_rule_details.py
+++ b/tests/sentry/api/endpoints/test_project_rule_details.py
@@ -1186,18 +1186,18 @@ class UpdateProjectRuleTest(ProjectRuleDetailsBaseTestCase):
         rule_label = response.data["name"]
         assert response.data["actions"][0]["channel_id"] == "new_channel_id"
         sent_blocks = orjson.loads(mock_post.call_args.kwargs["blocks"])
-        message = f"Alert rule <http://testserver/organizations/{self.organization.slug}/alerts/rules/{self.project.slug}/{rule_id}/details/|*{rule_label}*> in the *{self.project.slug}* project was updated."
+        message = f"Alert rule <http://testserver/organizations/{self.organization.slug}/alerts/rules/{self.project.slug}/{rule_id}/details/|*{rule_label}*> in the <http://testserver/organizations/{self.organization.slug}/projects/{self.project.slug}/|*{self.project.slug}*> project was updated."
         assert sent_blocks[0]["text"]["text"] == message
 
-        changes = "*Changes*\n"
+        changes = "'Changes'\n"
         changes += "• Added condition 'The issue's category is equal to Performance'\n"
-        changes += "• Changed action from *Send a notification to the Awesome Team Slack workspace to #old_channel_name* to *Send a notification to the Awesome Team Slack workspace to #new_channel_name*\n"
-        changes += "• Changed frequency from *5 minutes* to *3 hours*\n"
-        changes += f"• Added *{staging_env.name}* environment\n"
-        changes += "• Changed rule name from *my rule* to *new rule*\n"
-        changes += "• Changed trigger from *None* to *any*\n"
-        changes += "• Changed filter from *None* to *any*\n"
-        changes += f"• Changed owner from *Unassigned* to *{self.user.email}*\n"
+        changes += "• Changed action from 'Send a notification to the Awesome Team Slack workspace to #old_channel_name' to 'Send a notification to the Awesome Team Slack workspace to #new_channel_name'\n"
+        changes += "• Changed frequency from '5 minutes' to '3 hours'\n"
+        changes += f"• Added '{staging_env.name}' environment\n"
+        changes += "• Changed rule name from 'my rule' to 'new rule'\n"
+        changes += "• Changed trigger from 'None' to 'any'\n"
+        changes += "• Changed filter from 'None' to 'any'\n"
+        changes += f"• Changed owner from 'Unassigned' to '{self.user.email}'\n"
         assert sent_blocks[1]["text"]["text"] == changes
         assert (
             sent_blocks[2]["elements"][0]["text"]

--- a/tests/sentry/api/endpoints/test_project_rules.py
+++ b/tests/sentry/api/endpoints/test_project_rules.py
@@ -412,7 +412,7 @@ class CreateProjectRuleTest(ProjectRuleBaseTestCase):
         rule_label = response.data["name"]
         assert response.data["actions"][0]["channel_id"] == self.channel_id
         sent_blocks = orjson.loads(mock_post.call_args.kwargs["blocks"])
-        message = f"Alert rule <http://testserver/organizations/{self.organization.slug}/alerts/rules/{self.project.slug}/{rule_id}/details/|*{rule_label}*> was created in the *{self.project.slug}* project and will send notifications here."
+        message = f"Alert rule <http://testserver/organizations/{self.organization.slug}/alerts/rules/{self.project.slug}/{rule_id}/details/|*{rule_label}*> was created in the <http://testserver/organizations/{self.organization.slug}/projects/{self.project.slug}/|*{self.project.slug}*> project and will send notifications to this channel."
         assert sent_blocks[0]["text"]["text"] == message
         assert (
             sent_blocks[1]["elements"][0]["text"]


### PR DESCRIPTION
Final touches before EAing the Slack notification confirming issue alert rule creation and edits - change bold items to be in single quotes and change the create confirmation notification text to be "...and will send notifications here" to "...and will send notifications to this channel". 

<img width="657" alt="Screenshot 2024-06-13 at 2 45 35 PM" src="https://github.com/getsentry/sentry/assets/29959063/cccf83ef-0df7-44ff-9173-f9073ad1d128">
