### PR TITLE
fix(trace-explorer): Render chart legend without html escape characters

### DIFF
--- a/static/app/views/starfish/components/chart.tsx
+++ b/static/app/views/starfish/components/chart.tsx
@@ -132,7 +132,11 @@ function Chart({
   error,
   onLegendSelectChanged,
   onDataZoom,
-  legendFormatter,
+  /**
+   * Setting a default formatter for some reason causes `>` to
+   * render correctly instead of rendering as `&gt;` in the legend.
+   */
+  legendFormatter = name => name,
 }: Props) {
   const router = useRouter();
   const theme = useTheme();
@@ -320,13 +324,7 @@ function Chart({
     grid,
     yAxes,
     utc,
-    legend: showLegend
-      ? {
-          top: 0,
-          right: 10,
-          ...(legendFormatter ? {formatter: legendFormatter} : {}),
-        }
-      : undefined,
+    legend: showLegend ? {top: 0, right: 10, formatter: legendFormatter} : undefined,
     isGroupedByDate: true,
     showTimeInTooltip: true,
     tooltip: {
@@ -467,7 +465,9 @@ function Chart({
                 }}
                 colors={colors}
                 grid={grid}
-                legend={showLegend ? {top: 0, right: 10} : undefined}
+                legend={
+                  showLegend ? {top: 0, right: 10, formatter: legendFormatter} : undefined
+                }
                 onClick={onClick}
               />
             );


### PR DESCRIPTION
Not too sure exactly why but by setting a default legend formatter, `>` is rendered correctly instead of being turned into `&gt;` in the legend.