### PR TITLE
fix(slack): actually send the metric alert in a thread

### DIFF
--- a/src/sentry/integrations/slack/utils/notifications.py
+++ b/src/sentry/integrations/slack/utils/notifications.py
@@ -110,10 +110,12 @@ def send_incident_alert_notification(
         # To reply to a thread, use the specific key in the payload as referenced by the docs
         # https://api.slack.com/methods/chat.postMessage#arg_thread_ts
         payload["thread_ts"] = parent_notification_message.message_identifier
+        thread_ts = parent_notification_message.message_identifier
 
         # If the incident is critical status, even if it's in a thread, send to main channel
         if incident.status == IncidentStatus.CRITICAL.value:
             payload["reply_broadcast"] = True
+            reply_broadcast = True
 
     success = False
     if features.has("organizations:slack-sdk-metric-alert", organization):


### PR DESCRIPTION
The tests check that we have the correct relationship between the parent and child message, but we still need to update the values of `thread_ts` and `reply_broadcast` to pass to `client.chat_postMessage`. These are pulled out separately for typing purposes.