### PR TITLE
feat(perf): Make suggested fields on Spans tab metrics only

### DIFF
--- a/static/app/views/performance/transactionSummary/transactionSpans/content.tsx
+++ b/static/app/views/performance/transactionSummary/transactionSpans/content.tsx
@@ -25,7 +25,7 @@ import {VisuallyCompleteWithData} from 'sentry/utils/performanceForSentry';
 import {decodeScalar} from 'sentry/utils/queryString';
 import useProjects from 'sentry/utils/useProjects';
 import SpanMetricsTable from 'sentry/views/performance/transactionSummary/transactionSpans/spanMetricsTable';
-import {useSpanFieldSupportedTags} from 'sentry/views/performance/utils/useSpanFieldSupportedTags';
+import {useSpanMetricsFieldSupportedTags} from 'sentry/views/performance/utils/useSpanFieldSupportedTags';
 
 import type {SetStateAction} from '../types';
 
@@ -192,9 +192,9 @@ function SpansContent(props: Props) {
 // TODO: Temporary component while we make the switch to spans only. Will fully replace the old Spans tab when GA'd
 function SpansContentV2(props: Props) {
   const {location, organization, eventView, projectId, transactionName} = props;
+  const supportedTags = useSpanMetricsFieldSupportedTags();
   const {projects} = useProjects();
   const project = projects.find(p => p.id === projectId);
-
   const spansQuery = decodeScalar(location.query.spansQuery);
 
   function handleChange(key: string) {
@@ -219,8 +219,6 @@ function SpansContentV2(props: Props) {
       });
     };
   }
-
-  const supportedTags = useSpanFieldSupportedTags();
 
   return (
     <Layout.Main fullWidth>

--- a/static/app/views/performance/utils/useSpanFieldSupportedTags.tsx
+++ b/static/app/views/performance/utils/useSpanFieldSupportedTags.tsx
@@ -1,13 +1,24 @@
 import {getHasTag} from 'sentry/components/events/searchBar';
 import type {PageFilters, TagCollection} from 'sentry/types';
+import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import {type ApiQueryKey, useApiQuery} from 'sentry/utils/queryClient';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
-import {SpanIndexedField} from 'sentry/views/starfish/types';
+import {SpanIndexedField, SpanMetricsField} from 'sentry/views/starfish/types';
 
-const getSpanFieldSupportedTags = excludedTags => {
+const DATASET_TO_FIELDS = {
+  [DiscoverDatasets.SPANS_INDEXED]: SpanIndexedField,
+  [DiscoverDatasets.SPANS_METRICS]: SpanMetricsField,
+};
+
+const getSpanFieldSupportedTags = (
+  excludedTags,
+  dataset: DiscoverDatasets.SPANS_INDEXED | DiscoverDatasets.SPANS_METRICS
+) => {
+  const fields = DATASET_TO_FIELDS[dataset];
+
   const tags: TagCollection = Object.fromEntries(
-    Object.values(SpanIndexedField)
+    Object.values(fields)
       .filter(v => !excludedTags.includes(v))
       .map(v => [v, {key: v, name: v}])
   );
@@ -36,6 +47,16 @@ const getDynamicSpanFieldsEndpoint = (
   },
 ];
 
+export function useSpanMetricsFieldSupportedTags(options?: {excludedTags?: string[]}) {
+  const {excludedTags = []} = options || {};
+
+  // we do not yet support span field search by SPAN_AI_PIPELINE_GROUP
+  return getSpanFieldSupportedTags(
+    [SpanIndexedField.SPAN_AI_PIPELINE_GROUP, ...excludedTags],
+    DiscoverDatasets.SPANS_METRICS
+  );
+}
+
 export function useSpanFieldSupportedTags(options?: {
   excludedTags?: string[];
   projects?: PageFilters['projects'];
@@ -44,10 +65,10 @@ export function useSpanFieldSupportedTags(options?: {
   const {selection} = usePageFilters();
   const organization = useOrganization();
   // we do not yet support span field search by SPAN_AI_PIPELINE_GROUP
-  const staticTags = getSpanFieldSupportedTags([
-    SpanIndexedField.SPAN_AI_PIPELINE_GROUP,
-    ...excludedTags,
-  ]);
+  const staticTags = getSpanFieldSupportedTags(
+    [SpanIndexedField.SPAN_AI_PIPELINE_GROUP, ...excludedTags],
+    DiscoverDatasets.SPANS_INDEXED
+  );
 
   const dynamicTagQuery = useApiQuery<SpanFieldsResponse>(
     getDynamicSpanFieldsEndpoint(


### PR DESCRIPTION
The Spans tab queries on span metrics, but the searchbar's autosuggest includes indexed fields. This PR adds a new hook that suggests only metrics-compatible fields for span search

![image](https://github.com/getsentry/sentry/assets/16740047/51ef1f78-3595-4311-b6de-ec131e39440d)
