### PR TITLE
ref(slack): use sdk client to get channel id

### DIFF
--- a/src/sentry/api/serializers/rest_framework/notification_action.py
+++ b/src/sentry/api/serializers/rest_framework/notification_action.py
@@ -205,7 +205,6 @@ Required if **service_type** is `slack` or `opsgenie`.
 
         channel_name = data.get("target_display")
         channel_id = data.get("target_identifier")
-
         if not channel_name:
             raise serializers.ValidationError(
                 {"target_display": "Did not receive a slack user or channel name."}
@@ -227,7 +226,7 @@ Required if **service_type** is `slack` or `opsgenie`.
         # If we've only received a channel name, ask slack for its id
         generic_error_message = f"Could not fetch channel id from Slack for '{channel_name}'. Try providing the channel id, or try again later."
         try:
-            (_prefix, channel_id, timed_out,) = get_channel_id(
+            channel_data = get_channel_id(
                 organization=self.context["organization"],
                 integration=self.integration,
                 channel_name=channel_name,
@@ -235,16 +234,16 @@ Required if **service_type** is `slack` or `opsgenie`.
         except Exception:
             raise serializers.ValidationError({"target_display": generic_error_message})
 
-        if not channel_id:
+        if not channel_data.channel_id:
             raise serializers.ValidationError({"target_display": generic_error_message})
 
-        if timed_out:
+        if channel_data.timed_out:
             raise serializers.ValidationError(
                 {
                     "target_identifier": "Please provide a slack channel id, we encountered an error while searching for it via the channel name."
                 }
             )
-        data["target_identifier"] = channel_id
+        data["target_identifier"] = channel_data.channel_id
         return data
 
     def validate_discord_channel(

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -393,6 +393,8 @@ def register_temporary_features(manager: FeatureManager):
     manager.add("organizations:slack-sdk-get-users", OrganizationFeature, FeatureHandlerStrategy.OPTIONS)
     # Use new Slack SDK Client in _notify_recipient
     manager.add("organizations:slack-sdk-notify-recipient", OrganizationFeature, FeatureHandlerStrategy.OPTIONS)
+    # Use new Slack SDK Client in get_channel_id_with_timeout
+    manager.add("organizations:slack-sdk-get-channel-id", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE)
     # Add regression chart as image to slack message
     manager.add("organizations:slack-endpoint-regression-image", OrganizationFeature, FeatureHandlerStrategy.OPTIONS)
     manager.add("organizations:slack-function-regression-image", OrganizationFeature, FeatureHandlerStrategy.OPTIONS)

--- a/src/sentry/incidents/logic.py
+++ b/src/sentry/incidents/logic.py
@@ -1400,9 +1400,7 @@ def get_alert_rule_trigger_action_slack_channel_id(
         raise InvalidTriggerActionError("Slack workspace is a required field.")
 
     try:
-        _prefix, channel_id, timed_out = get_channel_id(
-            organization, integration, name, use_async_lookup
-        )
+        channel_data = get_channel_id(organization, integration, name, use_async_lookup)
     except DuplicateDisplayNameError as e:
         domain = integration.metadata["domain_name"]
 
@@ -1411,18 +1409,18 @@ def get_alert_rule_trigger_action_slack_channel_id(
             % (e, domain)
         )
 
-    if timed_out:
+    if channel_data.timed_out:
         raise ChannelLookupTimeoutError(
             "Could not find channel %s. We have timed out trying to look for it." % name
         )
 
-    if channel_id is None:
+    if channel_data.channel_id is None:
         raise InvalidTriggerActionError(
             "Could not find channel %s. Channel may not exist, or Sentry may not "
             "have been granted permission to access it" % name
         )
 
-    return channel_id
+    return channel_data.channel_id
 
 
 def get_alert_rule_trigger_action_discord_channel_id(

--- a/src/sentry/integrations/slack/actions/form.py
+++ b/src/sentry/integrations/slack/actions/form.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+from dataclasses import asdict
 from typing import Any
 
 from django import forms
@@ -107,9 +108,8 @@ class SlackNotifyServiceForm(forms.Form):
         # are assuming that they passed in the correct channel_id for the channel
         if not channel_id:
             try:
-                channel_prefix, channel_id, timed_out = self.channel_transformer(
-                    integration, channel
-                )
+                channel_data = self.channel_transformer(integration, channel)
+                channel_prefix, channel_id, timed_out = asdict(channel_data).values()
             except DuplicateDisplayNameError:
                 domain = integration.metadata["domain_name"]
 

--- a/src/sentry/integrations/slack/actions/notification.py
+++ b/src/sentry/integrations/slack/actions/notification.py
@@ -27,6 +27,7 @@ from sentry.integrations.slack.metrics import (
 )
 from sentry.integrations.slack.sdk_client import SlackSdkClient
 from sentry.integrations.slack.utils import get_channel_id
+from sentry.integrations.slack.utils.channel import SlackChannelIdData
 from sentry.models.integrations.integration import Integration
 from sentry.models.options.organization_option import OrganizationOption
 from sentry.models.rule import Rule
@@ -317,5 +318,5 @@ class SlackNotifyServiceAction(IntegrationEventAction):
             self.data, integrations=self.get_integrations(), channel_transformer=self.get_channel_id
         )
 
-    def get_channel_id(self, integration: Integration, name: str) -> tuple[str, str | None, bool]:
+    def get_channel_id(self, integration: Integration, name: str) -> SlackChannelIdData:
         return get_channel_id(self.project.organization, integration, name)

--- a/src/sentry/integrations/slack/utils/__init__.py
+++ b/src/sentry/integrations/slack/utils/__init__.py
@@ -1,6 +1,5 @@
 __all__ = (
     "get_channel_id",
-    "get_channel_id_with_timeout",
     "get_slack_data_by_user",
     "get_users",
     "is_valid_role",
@@ -20,12 +19,7 @@ import logging
 logger = logging.getLogger("sentry.integrations.slack")
 
 from .auth import is_valid_role, set_signing_secret
-from .channel import (
-    get_channel_id,
-    get_channel_id_with_timeout,
-    strip_channel_name,
-    validate_channel_id,
-)
+from .channel import get_channel_id, strip_channel_name, validate_channel_id
 from .notifications import send_incident_alert_notification, send_slack_response
 from .rule_status import RedisRuleStatus
 from .users import get_slack_data_by_user, get_users

--- a/src/sentry/integrations/slack/utils/channel.py
+++ b/src/sentry/integrations/slack/utils/channel.py
@@ -68,12 +68,12 @@ def get_channel_id(
     # This means some users are unable to create/update alert rules. To avoid this, we attempt
     # to find the channel id asynchronously if it takes longer than a certain amount of time,
     # which I have set as the SLACK_DEFAULT_TIMEOUT - arbitrarily - to 10 seconds.
-    if features.has("organizations:slack-sdk-get-channel-id", organization):
-        has_sdk_flag = True
-    else:
-        has_sdk_flag = False
-
-    return get_channel_id_with_timeout(integration, channel_name, timeout, has_sdk_flag)
+    return get_channel_id_with_timeout(
+        integration,
+        channel_name,
+        timeout,
+        features.has("organizations:slack-sdk-get-channel-id", organization),
+    )
 
 
 def validate_channel_id(name: str, integration_id: int | None, input_channel_id: str) -> None:
@@ -139,7 +139,7 @@ def get_channel_id_with_timeout(
     prefix = ""
     channel_id = None
     try:  # Check for channel
-        channel_id = check_for_channel(client, name, has_sdk_flag)
+        channel_id = check_for_channel(client, name)
         prefix = "#"
     except ApiError as e:
         if str(e) != "channel_not_found":
@@ -199,9 +199,11 @@ def get_channel_id_with_timeout(
 
 
 def check_for_channel(
-    client: SlackClient | SlackSdkClient, name: str, has_sdk_flag: bool
+    client: SlackClient | SlackSdkClient,
+    name: str,
 ) -> str | None:
-    if has_sdk_flag:
+
+    if isinstance(client, SlackSdkClient):
         try:
             msg_response = client.chat_scheduleMessage(
                 channel=name,
@@ -218,23 +220,25 @@ def check_for_channel(
             logger.exception("slack.chat_scheduleMessage.error", extra=logger_params)
             raise
 
-        if "channel" in msg_response:
-            try:
-                client.chat_deleteScheduledMessage(
-                    channel=msg_response["channel"],
-                    scheduled_message_id=msg_response["scheduled_message_id"],
-                )
-                return msg_response["channel"]
-            except SlackApiError as e:
-                logger_params = {
-                    "error": str(e),
-                    "integration_id": client.integration_id,
-                    "channel": name,
-                    "channel_id": msg_response["channel"],
-                    "scheduled_message_id": msg_response["scheduled_message_id"],
-                }
-                logger.exception("slack.chat_deleteScheduledMessage.error", extra=logger_params)
-                raise
+        if "channel" not in msg_response:
+            return None
+
+        try:
+            client.chat_deleteScheduledMessage(
+                channel=msg_response["channel"],
+                scheduled_message_id=msg_response["scheduled_message_id"],
+            )
+            return msg_response["channel"]
+        except SlackApiError as e:
+            logger_params = {
+                "error": str(e),
+                "integration_id": client.integration_id,
+                "channel": name,
+                "channel_id": msg_response["channel"],
+                "scheduled_message_id": msg_response["scheduled_message_id"],
+            }
+            logger.exception("slack.chat_deleteScheduledMessage.error", extra=logger_params)
+            raise
 
     else:
         msg_response = client.post(

--- a/src/sentry/integrations/slack/utils/users.py
+++ b/src/sentry/integrations/slack/utils/users.py
@@ -115,11 +115,12 @@ def format_slack_data_by_user(
 
 def get_slack_user_data(
     integration: Integration | RpcIntegration,
-    organization: Organization | RpcOrganization,
+    organization: Organization | RpcOrganization | None = None,
+    kwargs: dict[str, Any] | None = None,
 ) -> Iterable[dict[str, Any]]:
     sdk_client = SlackSdkClient(integration_id=integration.id)
     try:
-        users_list = sdk_client.users_list(limit=SLACK_GET_USERS_PAGE_SIZE)
+        users_list = sdk_client.users_list(limit=SLACK_GET_USERS_PAGE_SIZE, **kwargs)
 
         for page in users_list:
             users: dict[str, Any] = page.get("members")
@@ -130,7 +131,7 @@ def get_slack_user_data(
             "slack.post_install.get_users.error",
             extra={
                 "error": str(e),
-                "organization": organization.slug,
+                "organization": organization.slug if organization else None,
                 "integration_id": integration.id,
             },
         )

--- a/src/sentry/integrations/slack/utils/users.py
+++ b/src/sentry/integrations/slack/utils/users.py
@@ -120,7 +120,11 @@ def get_slack_user_data(
 ) -> Iterable[dict[str, Any]]:
     sdk_client = SlackSdkClient(integration_id=integration.id)
     try:
-        users_list = sdk_client.users_list(limit=SLACK_GET_USERS_PAGE_SIZE, **kwargs)
+        users_list = (
+            sdk_client.users_list(limit=SLACK_GET_USERS_PAGE_SIZE, **kwargs)
+            if kwargs
+            else sdk_client.users_list(limit=SLACK_GET_USERS_PAGE_SIZE)
+        )
 
         for page in users_list:
             users: dict[str, Any] = page.get("members")

--- a/src/sentry/tasks/integrations/slack/find_channel_id_for_rule.py
+++ b/src/sentry/tasks/integrations/slack/find_channel_id_for_rule.py
@@ -2,6 +2,7 @@ import logging
 from collections.abc import Sequence
 from typing import Any
 
+from sentry import features
 from sentry.incidents.models.alert_rule import AlertRuleTriggerAction
 from sentry.integrations.slack.utils import (
     SLACK_RATE_LIMITED_MESSAGE,
@@ -75,7 +76,10 @@ def find_channel_id_for_rule(
     # we can always update later
     try:
         (prefix, item_id, _timed_out) = get_channel_id_with_timeout(
-            integration, channel_name, 3 * 60
+            integration,
+            channel_name,
+            3 * 60,
+            features.has("organizations:slack-sdk-get-channel-id", organization),
         )
     except DuplicateDisplayNameError:
         # if we find a duplicate display name and nothing else, we

--- a/tests/sentry/api/endpoints/test_project_rules.py
+++ b/tests/sentry/api/endpoints/test_project_rules.py
@@ -12,6 +12,7 @@ from django.test import override_settings
 from rest_framework import status
 
 from sentry.constants import ObjectStatus
+from sentry.integrations.slack.utils.channel import SlackChannelIdData
 from sentry.models.environment import Environment
 from sentry.models.rule import Rule, RuleActivity, RuleActivityType
 from sentry.models.user import User
@@ -701,7 +702,7 @@ class CreateProjectRuleTest(ProjectRuleBaseTestCase):
 
     @patch(
         "sentry.integrations.slack.actions.notification.get_channel_id",
-        return_value=("#", None, True),
+        return_value=SlackChannelIdData("#", None, True),
     )
     @patch.object(find_channel_id_for_rule, "apply_async")
     @patch("sentry.integrations.slack.utils.rule_status.uuid4")

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_details.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_details.py
@@ -27,6 +27,7 @@ from sentry.incidents.models.incident import Incident, IncidentStatus
 from sentry.incidents.serializers import AlertRuleSerializer
 from sentry.incidents.utils.types import AlertRuleActivationConditionType
 from sentry.integrations.slack.client import SlackClient
+from sentry.integrations.slack.utils.channel import SlackChannelIdData
 from sentry.models.auditlogentry import AuditLogEntry
 from sentry.models.organizationmemberteam import OrganizationMemberTeam
 from sentry.services.hybrid_cloud.app import app_service
@@ -856,7 +857,7 @@ class AlertRuleDetailsSlackPutEndpointTest(AlertRuleDetailsBase):
 
     @patch(
         "sentry.integrations.slack.utils.channel.get_channel_id_with_timeout",
-        return_value=("#", None, True),
+        return_value=SlackChannelIdData("#", None, True),
     )
     @patch.object(find_channel_id_for_alert_rule, "apply_async")
     @patch("sentry.integrations.slack.utils.rule_status.uuid4")
@@ -1007,8 +1008,12 @@ class AlertRuleDetailsSlackPutEndpointTest(AlertRuleDetailsBase):
         assert resp.data == {"uuid": "abc123"}
 
     @patch(
-        "sentry.integrations.slack.utils.channel.get_channel_id_with_timeout",
-        side_effect=[("#", 10, False), ("#", 10, False), ("#", 20, False)],
+        "sentry.integrations.slack.utils.channel.get_channel_id_with_timeout_deprecated",
+        side_effect=[
+            SlackChannelIdData("#", 10, False),
+            SlackChannelIdData("#", 10, False),
+            SlackChannelIdData("#", 20, False),
+        ],
     )
     @patch("sentry.integrations.slack.utils.rule_status.uuid4")
     def test_async_lookup_outside_transaction(self, mock_uuid4, mock_get_channel_id):

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_details.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_details.py
@@ -1010,9 +1010,9 @@ class AlertRuleDetailsSlackPutEndpointTest(AlertRuleDetailsBase):
     @patch(
         "sentry.integrations.slack.utils.channel.get_channel_id_with_timeout_deprecated",
         side_effect=[
-            SlackChannelIdData("#", 10, False),
-            SlackChannelIdData("#", 10, False),
-            SlackChannelIdData("#", 20, False),
+            SlackChannelIdData("#", "10", False),
+            SlackChannelIdData("#", "10", False),
+            SlackChannelIdData("#", "20", False),
         ],
     )
     @patch("sentry.integrations.slack.utils.rule_status.uuid4")

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
@@ -736,9 +736,9 @@ class AlertRuleCreateEndpointTest(AlertRuleIndexBase):
     @patch(
         "sentry.integrations.slack.utils.channel.get_channel_id_with_timeout_deprecated",
         side_effect=[
-            SlackChannelIdData("#", 10, False),
-            SlackChannelIdData("#", 10, False),
-            SlackChannelIdData("#", 20, False),
+            SlackChannelIdData("#", "10", False),
+            SlackChannelIdData("#", "10", False),
+            SlackChannelIdData("#", "20", False),
         ],
     )
     @patch("sentry.integrations.slack.utils.rule_status.uuid4")

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
@@ -19,6 +19,7 @@ from sentry.incidents.models.alert_rule import (
     AlertRuleTriggerAction,
 )
 from sentry.incidents.utils.types import AlertRuleActivationConditionType
+from sentry.integrations.slack.utils.channel import SlackChannelIdData
 from sentry.models.auditlogentry import AuditLogEntry
 from sentry.models.organizationmember import OrganizationMember
 from sentry.models.outbox import outbox_context
@@ -733,8 +734,12 @@ class AlertRuleCreateEndpointTest(AlertRuleIndexBase):
         mock_find_channel_id_for_alert_rule.assert_called_once_with(kwargs=kwargs)
 
     @patch(
-        "sentry.integrations.slack.utils.channel.get_channel_id_with_timeout",
-        side_effect=[("#", 10, False), ("#", 10, False), ("#", 20, False)],
+        "sentry.integrations.slack.utils.channel.get_channel_id_with_timeout_deprecated",
+        side_effect=[
+            SlackChannelIdData("#", 10, False),
+            SlackChannelIdData("#", 10, False),
+            SlackChannelIdData("#", 20, False),
+        ],
     )
     @patch("sentry.integrations.slack.utils.rule_status.uuid4")
     def test_async_lookup_outside_transaction(self, mock_uuid4, mock_get_channel_id):

--- a/tests/sentry/incidents/endpoints/test_serializers.py
+++ b/tests/sentry/incidents/endpoints/test_serializers.py
@@ -588,7 +588,7 @@ class TestAlertRuleSerializer(TestAlertRuleSerializerBase):
             serializer.save()
         assert excinfo.value.detail == {"nonFieldErrors": ["Team does not exist"]}
         mock_get_channel_id.assert_called_with(
-            serialize_integration(self.integration), "my-channel", 10
+            serialize_integration(self.integration), "my-channel", 10, False
         )
 
     def test_event_types(self):

--- a/tests/sentry/incidents/endpoints/test_serializers.py
+++ b/tests/sentry/incidents/endpoints/test_serializers.py
@@ -33,6 +33,7 @@ from sentry.incidents.serializers import (
 )
 from sentry.integrations.opsgenie.utils import OPSGENIE_CUSTOM_PRIORITIES
 from sentry.integrations.pagerduty.utils import PAGERDUTY_CUSTOM_PRIORITIES
+from sentry.integrations.slack.utils.channel import SlackChannelIdData
 from sentry.models.environment import Environment
 from sentry.models.user import User
 from sentry.services.hybrid_cloud.app import app_service
@@ -531,8 +532,8 @@ class TestAlertRuleSerializer(TestAlertRuleSerializerBase):
         self.run_fail_validation_test({"thresholdType": 50}, {"thresholdType": invalid_values})
 
     @patch(
-        "sentry.integrations.slack.utils.channel.get_channel_id_with_timeout",
-        return_value=("#", None, True),
+        "sentry.integrations.slack.utils.channel.get_channel_id_with_timeout_deprecated",
+        return_value=SlackChannelIdData("#", None, True),
     )
     def test_channel_timeout(self, mock_get_channel_id):
         trigger = {
@@ -560,8 +561,8 @@ class TestAlertRuleSerializer(TestAlertRuleSerializerBase):
         )
 
     @patch(
-        "sentry.integrations.slack.utils.channel.get_channel_id_with_timeout",
-        return_value=("#", None, True),
+        "sentry.integrations.slack.utils.channel.get_channel_id_with_timeout_deprecated",
+        return_value=SlackChannelIdData("#", None, True),
     )
     def test_invalid_team_with_channel_timeout(self, mock_get_channel_id):
         other_org = self.create_organization()
@@ -588,7 +589,7 @@ class TestAlertRuleSerializer(TestAlertRuleSerializerBase):
             serializer.save()
         assert excinfo.value.detail == {"nonFieldErrors": ["Team does not exist"]}
         mock_get_channel_id.assert_called_with(
-            serialize_integration(self.integration), "my-channel", 10, False
+            serialize_integration(self.integration), "my-channel", 10
         )
 
     def test_event_types(self):

--- a/tests/sentry/integrations/slack/test_tasks.py
+++ b/tests/sentry/integrations/slack/test_tasks.py
@@ -192,7 +192,7 @@ class SlackTasksTest(TestCase):
         assert rule.created_by_id == self.user.id
         mock_set_value.assert_called_with("success", rule.id)
         mock_get_channel_id.assert_called_with(
-            serialize_integration(self.integration), "my-channel", 180
+            serialize_integration(self.integration), "my-channel", 180, False
         )
 
         trigger_action = AlertRuleTriggerAction.objects.get(integration_id=self.integration.id)
@@ -220,7 +220,7 @@ class SlackTasksTest(TestCase):
         assert not AlertRule.objects.filter(name="New Rule").exists()
         mock_set_value.assert_called_with("failed")
         mock_get_channel_id.assert_called_with(
-            serialize_integration(self.integration), "my-channel", 180
+            serialize_integration(self.integration), "my-channel", 180, False
         )
 
     @responses.activate
@@ -245,7 +245,7 @@ class SlackTasksTest(TestCase):
         assert not AlertRule.objects.filter(name="New Rule").exists()
         mock_set_value.assert_called_with("failed")
         mock_get_channel_id.assert_called_with(
-            serialize_integration(self.integration), "my-channel", 180
+            serialize_integration(self.integration), "my-channel", 180, False
         )
 
     @responses.activate
@@ -274,7 +274,7 @@ class SlackTasksTest(TestCase):
         rule = AlertRule.objects.get(name="New Rule")
         mock_set_value.assert_called_with("success", rule.id)
         mock_get_channel_id.assert_called_with(
-            serialize_integration(self.integration), "my-channel", 180
+            serialize_integration(self.integration), "my-channel", 180, False
         )
 
         trigger_action = AlertRuleTriggerAction.objects.get(integration_id=self.integration.id)

--- a/tests/sentry/integrations/slack/test_tasks.py
+++ b/tests/sentry/integrations/slack/test_tasks.py
@@ -9,6 +9,7 @@ import responses
 from sentry.incidents.models.alert_rule import AlertRule, AlertRuleTriggerAction
 from sentry.integrations.slack.sdk_client import SLACK_DATADOG_METRIC
 from sentry.integrations.slack.utils import RedisRuleStatus
+from sentry.integrations.slack.utils.channel import SlackChannelIdData
 from sentry.models.rule import Rule
 from sentry.receivers.rules import DEFAULT_RULE_LABEL, DEFAULT_RULE_LABEL_NEW
 from sentry.services.hybrid_cloud.integration.serial import serialize_integration
@@ -18,7 +19,7 @@ from sentry.tasks.integrations.slack import (
     post_message,
 )
 from sentry.testutils.cases import TestCase
-from sentry.testutils.helpers import install_slack
+from sentry.testutils.helpers import install_slack, with_feature
 from sentry.testutils.skips import requires_snuba
 
 pytestmark = [requires_snuba]
@@ -171,8 +172,8 @@ class SlackTasksTest(TestCase):
     @responses.activate
     @patch.object(RedisRuleStatus, "set_value", return_value=None)
     @patch(
-        "sentry.integrations.slack.utils.channel.get_channel_id_with_timeout",
-        return_value=("#", "chan-id", False),
+        "sentry.integrations.slack.utils.channel.get_channel_id_with_timeout_deprecated",
+        return_value=SlackChannelIdData("#", "chan-id", False),
     )
     def test_task_new_alert_rule(self, mock_get_channel_id, mock_set_value):
         alert_rule_data = self.metric_alert_data()
@@ -192,7 +193,7 @@ class SlackTasksTest(TestCase):
         assert rule.created_by_id == self.user.id
         mock_set_value.assert_called_with("success", rule.id)
         mock_get_channel_id.assert_called_with(
-            serialize_integration(self.integration), "my-channel", 180, False
+            serialize_integration(self.integration), "my-channel", 180
         )
 
         trigger_action = AlertRuleTriggerAction.objects.get(integration_id=self.integration.id)
@@ -202,7 +203,38 @@ class SlackTasksTest(TestCase):
     @patch.object(RedisRuleStatus, "set_value", return_value=None)
     @patch(
         "sentry.integrations.slack.utils.channel.get_channel_id_with_timeout",
-        return_value=("#", None, False),
+        return_value=SlackChannelIdData("#", "chan-id", False),
+    )
+    @with_feature("organizations:slack-sdk-get-channel-id")
+    def test_task_new_alert_rule_with_sdk(self, mock_get_channel_id, mock_set_value):
+        alert_rule_data = self.metric_alert_data()
+
+        data = {
+            "data": alert_rule_data,
+            "uuid": self.uuid,
+            "organization_id": self.organization.id,
+            "user_id": self.user.id,
+        }
+
+        with self.tasks():
+            with self.feature(["organizations:incidents"]):
+                find_channel_id_for_alert_rule(**data)
+
+        rule = AlertRule.objects.get(name="New Rule")
+        assert rule.created_by_id == self.user.id
+        mock_set_value.assert_called_with("success", rule.id)
+        mock_get_channel_id.assert_called_with(
+            serialize_integration(self.integration), "my-channel", 180
+        )
+
+        trigger_action = AlertRuleTriggerAction.objects.get(integration_id=self.integration.id)
+        assert trigger_action.target_identifier == "chan-id"
+
+    @responses.activate
+    @patch.object(RedisRuleStatus, "set_value", return_value=None)
+    @patch(
+        "sentry.integrations.slack.utils.channel.get_channel_id_with_timeout_deprecated",
+        return_value=SlackChannelIdData("#", None, False),
     )
     def test_task_failed_id_lookup(self, mock_get_channel_id, mock_set_value):
         alert_rule_data = self.metric_alert_data()
@@ -220,14 +252,40 @@ class SlackTasksTest(TestCase):
         assert not AlertRule.objects.filter(name="New Rule").exists()
         mock_set_value.assert_called_with("failed")
         mock_get_channel_id.assert_called_with(
-            serialize_integration(self.integration), "my-channel", 180, False
+            serialize_integration(self.integration), "my-channel", 180
         )
 
     @responses.activate
     @patch.object(RedisRuleStatus, "set_value", return_value=None)
     @patch(
         "sentry.integrations.slack.utils.channel.get_channel_id_with_timeout",
-        return_value=("#", None, True),
+        return_value=SlackChannelIdData("#", None, False),
+    )
+    @with_feature("organizations:slack-sdk-get-channel-id")
+    def test_task_failed_id_lookup_with_sdk(self, mock_get_channel_id, mock_set_value):
+        alert_rule_data = self.metric_alert_data()
+
+        data = {
+            "data": alert_rule_data,
+            "uuid": self.uuid,
+            "organization_id": self.organization.id,
+        }
+
+        with self.tasks():
+            with self.feature(["organizations:incidents"]):
+                find_channel_id_for_alert_rule(**data)
+
+        assert not AlertRule.objects.filter(name="New Rule").exists()
+        mock_set_value.assert_called_with("failed")
+        mock_get_channel_id.assert_called_with(
+            serialize_integration(self.integration), "my-channel", 180
+        )
+
+    @responses.activate
+    @patch.object(RedisRuleStatus, "set_value", return_value=None)
+    @patch(
+        "sentry.integrations.slack.utils.channel.get_channel_id_with_timeout_deprecated",
+        return_value=SlackChannelIdData("#", None, True),
     )
     def test_task_timeout_id_lookup(self, mock_get_channel_id, mock_set_value):
         alert_rule_data = self.metric_alert_data()
@@ -245,14 +303,40 @@ class SlackTasksTest(TestCase):
         assert not AlertRule.objects.filter(name="New Rule").exists()
         mock_set_value.assert_called_with("failed")
         mock_get_channel_id.assert_called_with(
-            serialize_integration(self.integration), "my-channel", 180, False
+            serialize_integration(self.integration), "my-channel", 180
         )
 
     @responses.activate
     @patch.object(RedisRuleStatus, "set_value", return_value=None)
     @patch(
         "sentry.integrations.slack.utils.channel.get_channel_id_with_timeout",
-        return_value=("#", "chan-id", False),
+        return_value=SlackChannelIdData("#", None, True),
+    )
+    @with_feature("organizations:slack-sdk-get-channel-id")
+    def test_task_timeout_id_lookup_with_sdk(self, mock_get_channel_id, mock_set_value):
+        alert_rule_data = self.metric_alert_data()
+
+        data = {
+            "data": alert_rule_data,
+            "uuid": self.uuid,
+            "organization_id": self.organization.id,
+        }
+
+        with self.tasks():
+            with self.feature(["organizations:incidents"]):
+                find_channel_id_for_alert_rule(**data)
+
+        assert not AlertRule.objects.filter(name="New Rule").exists()
+        mock_set_value.assert_called_with("failed")
+        mock_get_channel_id.assert_called_with(
+            serialize_integration(self.integration), "my-channel", 180
+        )
+
+    @responses.activate
+    @patch.object(RedisRuleStatus, "set_value", return_value=None)
+    @patch(
+        "sentry.integrations.slack.utils.channel.get_channel_id_with_timeout_deprecated",
+        return_value=SlackChannelIdData("#", "chan-id", False),
     )
     def test_task_existing_metric_alert(self, mock_get_channel_id, mock_set_value):
         alert_rule_data = self.metric_alert_data()
@@ -274,7 +358,41 @@ class SlackTasksTest(TestCase):
         rule = AlertRule.objects.get(name="New Rule")
         mock_set_value.assert_called_with("success", rule.id)
         mock_get_channel_id.assert_called_with(
-            serialize_integration(self.integration), "my-channel", 180, False
+            serialize_integration(self.integration), "my-channel", 180
+        )
+
+        trigger_action = AlertRuleTriggerAction.objects.get(integration_id=self.integration.id)
+        assert trigger_action.target_identifier == "chan-id"
+        assert AlertRule.objects.get(id=alert_rule.id)
+
+    @responses.activate
+    @patch.object(RedisRuleStatus, "set_value", return_value=None)
+    @patch(
+        "sentry.integrations.slack.utils.channel.get_channel_id_with_timeout",
+        return_value=SlackChannelIdData("#", "chan-id", False),
+    )
+    @with_feature("organizations:slack-sdk-get-channel-id")
+    def test_task_existing_metric_alert_with_sdk(self, mock_get_channel_id, mock_set_value):
+        alert_rule_data = self.metric_alert_data()
+        alert_rule = self.create_alert_rule(
+            organization=self.organization, projects=[self.project], name="New Rule", user=self.user
+        )
+
+        data = {
+            "data": alert_rule_data,
+            "uuid": self.uuid,
+            "organization_id": self.organization.id,
+            "alert_rule_id": alert_rule.id,
+        }
+
+        with self.tasks():
+            with self.feature(["organizations:incidents"]):
+                find_channel_id_for_alert_rule(**data)
+
+        rule = AlertRule.objects.get(name="New Rule")
+        mock_set_value.assert_called_with("success", rule.id)
+        mock_get_channel_id.assert_called_with(
+            serialize_integration(self.integration), "my-channel", 180
         )
 
         trigger_action = AlertRuleTriggerAction.objects.get(integration_id=self.integration.id)

--- a/tests/sentry/integrations/slack/test_utils.py
+++ b/tests/sentry/integrations/slack/test_utils.py
@@ -1,12 +1,17 @@
+from unittest.mock import patch
+
 import orjson
 import pytest
 import responses
+from slack_sdk.errors import SlackApiError
 
+from sentry.integrations.slack.sdk_client import SLACK_DATADOG_METRIC
 from sentry.integrations.slack.utils import get_channel_id
 from sentry.integrations.slack.utils.channel import CHANNEL_PREFIX, MEMBER_PREFIX
 from sentry.shared_integrations.exceptions import ApiRateLimitedError, DuplicateDisplayNameError
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers import install_slack
+from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.skips import requires_snuba
 
 pytestmark = [requires_snuba]
@@ -62,6 +67,27 @@ class GetChannelIdTest(TestCase):
         )
         self.run_valid_test("#My-Channel", CHANNEL_PREFIX, "m-c", False)
 
+    @with_feature("organizations:slack-sdk-get-channel-id")
+    @patch("sentry.integrations.slack.sdk_client.metrics")
+    @patch("slack_sdk.web.client.WebClient._perform_urllib_http_request")
+    def test_valid_channel_selected_sdk(self, mock_api_call, mock_metrics):
+        # Tests chat_scheduleMessage and chat_deleteScheduledMessage
+        mock_api_call.return_value = {
+            "body": orjson.dumps(
+                {"ok": True, "channel": "m-c", "scheduled_message_id": "Q1298393284"}
+            ).decode(),
+            "headers": {},
+            "status": 200,
+        }
+
+        self.run_valid_test("#My-Channel", CHANNEL_PREFIX, "m-c", False)
+
+        mock_metrics.incr.assert_called_with(
+            SLACK_DATADOG_METRIC,
+            sample_rate=1.0,
+            tags={"ok": True, "status": 200},
+        )
+
     def test_valid_private_channel_selected(self):
         self.add_msg_response("m-p-c")
         self.resp.add(
@@ -72,6 +98,27 @@ class GetChannelIdTest(TestCase):
             body=orjson.dumps({"ok": True}),
         )
         self.run_valid_test("#my-private-channel", CHANNEL_PREFIX, "m-p-c", False)
+
+    @with_feature("organizations:slack-sdk-get-channel-id")
+    @patch("sentry.integrations.slack.sdk_client.metrics")
+    @patch("slack_sdk.web.client.WebClient._perform_urllib_http_request")
+    def test_valid_private_channel_selected_sdk(self, mock_api_call, mock_metrics):
+        # Tests chat_scheduleMessage and chat_deleteScheduledMessage
+        mock_api_call.return_value = {
+            "body": orjson.dumps(
+                {"ok": True, "channel": "m-p-c", "scheduled_message_id": "Q1298393284"}
+            ).decode(),
+            "headers": {},
+            "status": 200,
+        }
+
+        self.run_valid_test("#my-private-channel", CHANNEL_PREFIX, "m-p-c", False)
+
+        mock_metrics.incr.assert_called_with(
+            SLACK_DATADOG_METRIC,
+            sample_rate=1.0,
+            tags={"ok": True, "status": 200},
+        )
 
     def test_valid_member_selected(self):
         self.add_msg_response("channel_not_found")
@@ -117,6 +164,21 @@ class GetChannelIdTest(TestCase):
         self.add_msg_response("channel_not_found")
         assert get_channel_id(self.organization, self.integration, "#fake-channel")[1] is None
         assert get_channel_id(self.organization, self.integration, "@fake-user")[1] is None
+
+    @with_feature("organizations:slack-sdk-get-channel-id")
+    @patch("sentry.integrations.slack.sdk_client.metrics")
+    @patch("slack_sdk.web.client.WebClient._perform_urllib_http_request")
+    def test_invalid_channel_selected_sdk(self, mock_api_call, mock_metrics):
+        # Tests chat_scheduleMessage and chat_deleteScheduledMessage
+        mock_api_call.return_value = {
+            "body": orjson.dumps({"ok": False, "error": "channel_not_found"}).decode(),
+            "headers": {},
+            "status": 200,
+        }
+
+        with pytest.raises(SlackApiError):
+            get_channel_id(self.organization, self.integration, "#fake-channel")
+            get_channel_id(self.organization, self.integration, "@fake-user")
 
     def test_rate_limiting(self):
         """Should handle 429 from Slack when searching for users"""


### PR DESCRIPTION
Adds feature-flagged usage of Slack SDK client to check channel id by schedule-sending a message and then immediately deleting. Also adds tests for the code area.