### PR TITLE
If a GroupEvent has no occurance - don't follow through to the else

### DIFF
--- a/src/sentry/integrations/message_builder.py
+++ b/src/sentry/integrations/message_builder.py
@@ -67,8 +67,9 @@ def build_attachment_title(obj: Group | GroupEvent) -> str:
 
     else:
         group = getattr(obj, "group", obj)
-        if isinstance(obj, GroupEvent) and obj.occurrence is not None:
-            title = obj.occurrence.issue_title
+        if isinstance(obj, GroupEvent):
+            if obj.occurrence is not None:
+                title = obj.occurrence.issue_title
         else:
             event = group.get_latest_event()
             if event is not None and event.occurrence is not None:


### PR DESCRIPTION
we already default the title

If a GroupEvent has no occurance - then there's no point in fetching the latest event of the group again