### PR TITLE
test(js): Remove projects / teams from organizations

### DIFF
--- a/static/app/actionCreators/navigation.spec.tsx
+++ b/static/app/actionCreators/navigation.spec.tsx
@@ -20,7 +20,7 @@ describe('navigation ActionCreator', () => {
       },
     });
     router = initialData.router;
-    ProjectsStore.loadInitialData(initialData.organization.projects);
+    ProjectsStore.loadInitialData(initialData.projects);
   });
 
   afterEach(() => {

--- a/static/app/actionCreators/onboardingTasks.spec.tsx
+++ b/static/app/actionCreators/onboardingTasks.spec.tsx
@@ -1,6 +1,4 @@
 import {OrganizationFixture} from 'sentry-fixture/organization';
-import {ProjectFixture} from 'sentry-fixture/project';
-import {TeamFixture} from 'sentry-fixture/team';
 
 import {updateOnboardingTask} from 'sentry/actionCreators/onboardingTasks';
 import ConfigStore from 'sentry/stores/configStore';
@@ -15,10 +13,7 @@ describe('actionCreators/onboardingTasks', function () {
 
   describe('updateOnboardingTask', function () {
     it('Adds the task to the organization when task does not exists', async function () {
-      const detailedOrg = OrganizationFixture({
-        teams: [TeamFixture()],
-        projects: [ProjectFixture()],
-      });
+      const detailedOrg = OrganizationFixture({});
 
       // User is not passed into the update request
       const testTask = {
@@ -44,8 +39,6 @@ describe('actionCreators/onboardingTasks', function () {
 
     it('Updates existing onboarding task', async function () {
       const detailedOrg = OrganizationFixture({
-        teams: [TeamFixture()],
-        projects: [ProjectFixture()],
         onboardingTasks: [{task: OnboardingTaskKey.FIRST_EVENT, status: 'skipped'}],
       });
 
@@ -74,10 +67,7 @@ describe('actionCreators/onboardingTasks', function () {
     });
 
     it('Does not make API request without api object', async function () {
-      const detailedOrg = OrganizationFixture({
-        teams: [TeamFixture()],
-        projects: [ProjectFixture()],
-      });
+      const detailedOrg = OrganizationFixture({});
 
       const testTask = {
         task: OnboardingTaskKey.FIRST_EVENT,

--- a/static/app/actionCreators/pageFilters.spec.tsx
+++ b/static/app/actionCreators/pageFilters.spec.tsx
@@ -17,7 +17,7 @@ import localStorage from 'sentry/utils/localStorage';
 
 jest.mock('sentry/utils/localStorage');
 
-const {organization} = initializeOrg({
+const {organization, projects} = initializeOrg({
   projects: [
     {id: '1', slug: 'project-1', environments: ['prod', 'staging']},
     {id: '2', slug: 'project-2', environments: ['prod', 'stage']},
@@ -59,7 +59,7 @@ describe('PageFilters ActionCreators', function () {
         organization,
         queryParams: {},
         router,
-        memberProjects: organization.projects,
+        memberProjects: projects,
         nonMemberProjects: [],
         shouldEnforceSingleProject: false,
       });
@@ -91,7 +91,7 @@ describe('PageFilters ActionCreators', function () {
         organization,
         queryParams: {},
         skipLoadLastUsed: true,
-        memberProjects: organization.projects,
+        memberProjects: projects,
         nonMemberProjects: [],
         shouldEnforceSingleProject: false,
         router,
@@ -115,7 +115,7 @@ describe('PageFilters ActionCreators', function () {
         queryParams: {},
         shouldPersist: false,
         router,
-        memberProjects: organization.projects,
+        memberProjects: projects,
         nonMemberProjects: [],
         shouldEnforceSingleProject: false,
       });
@@ -152,7 +152,7 @@ describe('PageFilters ActionCreators', function () {
         queryParams: {
           project: '1',
         },
-        memberProjects: organization.projects,
+        memberProjects: projects,
         nonMemberProjects: [],
         shouldEnforceSingleProject: false,
         router,
@@ -177,7 +177,7 @@ describe('PageFilters ActionCreators', function () {
         queryParams: {
           project: '1',
         },
-        memberProjects: organization.projects,
+        memberProjects: projects,
         nonMemberProjects: [],
         shouldEnforceSingleProject: false,
         defaultSelection: {
@@ -211,7 +211,7 @@ describe('PageFilters ActionCreators', function () {
           statsPeriod: '1h',
           project: '1',
         },
-        memberProjects: organization.projects,
+        memberProjects: projects,
         nonMemberProjects: [],
         shouldEnforceSingleProject: false,
         defaultSelection: {
@@ -244,7 +244,7 @@ describe('PageFilters ActionCreators', function () {
           end: '2020-04-21T00:53:38',
           project: '1',
         },
-        memberProjects: organization.projects,
+        memberProjects: projects,
         nonMemberProjects: [],
         shouldEnforceSingleProject: false,
         defaultSelection: {
@@ -276,7 +276,7 @@ describe('PageFilters ActionCreators', function () {
         queryParams: {
           project: '1',
         },
-        memberProjects: organization.projects,
+        memberProjects: projects,
         nonMemberProjects: [],
         shouldEnforceSingleProject: false,
         router,
@@ -312,7 +312,7 @@ describe('PageFilters ActionCreators', function () {
         queryParams: {
           project: '-1',
         },
-        memberProjects: organization.projects,
+        memberProjects: projects,
         nonMemberProjects: [],
         shouldEnforceSingleProject: false,
         router,
@@ -339,7 +339,7 @@ describe('PageFilters ActionCreators', function () {
         queryParams: {
           project: '-1',
         },
-        memberProjects: organization.projects,
+        memberProjects: projects,
         nonMemberProjects: [],
         // User does not have access to global views
         shouldEnforceSingleProject: true,
@@ -382,7 +382,7 @@ describe('PageFilters ActionCreators', function () {
         organization,
         queryParams: {},
         router,
-        memberProjects: organization.projects,
+        memberProjects: projects,
         nonMemberProjects: [],
         shouldEnforceSingleProject: false,
       });
@@ -414,7 +414,7 @@ describe('PageFilters ActionCreators', function () {
         organization,
         queryParams: {},
         router,
-        memberProjects: organization.projects,
+        memberProjects: projects,
         nonMemberProjects: [],
         shouldEnforceSingleProject: false,
       });
@@ -448,7 +448,7 @@ describe('PageFilters ActionCreators', function () {
         organization,
         queryParams: {},
         router,
-        memberProjects: organization.projects,
+        memberProjects: projects,
         nonMemberProjects: [],
         shouldEnforceSingleProject: false,
         storageNamespace: 'starfish',

--- a/static/app/components/contextPickerModal.spec.tsx
+++ b/static/app/components/contextPickerModal.spec.tsx
@@ -26,7 +26,7 @@ describe('ContextPickerModal', function () {
     MockApiClient.clearMockResponses();
 
     project = ProjectFixture();
-    org = OrganizationFixture({projects: [project]});
+    org = OrganizationFixture();
     project2 = ProjectFixture({slug: 'project2'});
     org2 = OrganizationFixture({
       slug: 'org2',

--- a/static/app/components/events/eventReplay/replayClipPreview.spec.tsx
+++ b/static/app/components/events/eventReplay/replayClipPreview.spec.tsx
@@ -6,7 +6,7 @@ import {ReplayRecordFixture} from 'sentry-fixture/replayRecord';
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render as baseRender, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
-import type {DetailedOrganization} from 'sentry/types/organization';
+import type {Organization} from 'sentry/types/organization';
 import useReplayReader from 'sentry/utils/replays/hooks/useReplayReader';
 import ReplayReader from 'sentry/utils/replays/replayReader';
 import type RequestError from 'sentry/utils/requestError/requestError';
@@ -61,10 +61,7 @@ mockUseReplayReader.mockImplementation(() => {
   };
 });
 
-const render = (
-  children: React.ReactElement,
-  orgParams: Partial<DetailedOrganization> = {}
-) => {
+const render = (children: React.ReactElement, orgParams: Partial<Organization> = {}) => {
   const {router, organization} = initializeOrg({
     organization: {slug: mockOrgSlug, ...orgParams},
     router: {

--- a/static/app/components/events/interfaces/spans/traceView.spec.tsx
+++ b/static/app/components/events/interfaces/spans/traceView.spec.tsx
@@ -23,7 +23,7 @@ import QuickTraceQuery from 'sentry/utils/performance/quickTrace/quickTraceQuery
 
 function initializeData(settings) {
   const data = _initializeData(settings);
-  ProjectsStore.loadInitialData(data.organization.projects);
+  ProjectsStore.loadInitialData(data.projects);
   return data;
 }
 

--- a/static/app/components/modals/inviteMembersModal/index.spec.tsx
+++ b/static/app/components/modals/inviteMembersModal/index.spec.tsx
@@ -72,7 +72,7 @@ describe('InviteMembersModal', function () {
     orgTeams?: DetailedTeam[];
     roles?: object[];
   } = {}) => {
-    const org = OrganizationFixture({access: orgAccess, teams: orgTeams});
+    const org = OrganizationFixture({access: orgAccess});
     TeamStore.reset();
     TeamStore.loadInitialData(orgTeams);
 

--- a/static/app/components/modals/inviteMissingMembersModal/index.spec.tsx
+++ b/static/app/components/modals/inviteMissingMembersModal/index.spec.tsx
@@ -33,7 +33,7 @@ const mockRefObject = {
 
 describe('InviteMissingMembersModal', function () {
   const team = TeamFixture();
-  const org = OrganizationFixture({access: ['member:write'], teams: [team]});
+  const org = OrganizationFixture({access: ['member:write']});
   TeamStore.loadInitialData([team]);
   const missingMembers = MissingMembersFixture();
 
@@ -166,7 +166,7 @@ describe('InviteMissingMembersModal', function () {
     render(
       <InviteMissingMembersModal
         {...modalProps}
-        organization={OrganizationFixture({defaultRole: 'member', teams: [team]})}
+        organization={OrganizationFixture({defaultRole: 'member'})}
         missingMembers={missingMembers}
         allowedRoles={roles}
       />

--- a/static/app/components/modals/widgetViewerModal.spec.tsx
+++ b/static/app/components/modals/widgetViewerModal.spec.tsx
@@ -562,7 +562,7 @@ describe('Modals -> WidgetViewerModal', function () {
       });
 
       it('renders transaction summary link', async function () {
-        ProjectsStore.loadInitialData(initialData.organization.projects);
+        ProjectsStore.loadInitialData(initialData.projects);
         MockApiClient.addMockResponse({
           url: '/organizations/org-slug/events/',
           body: {

--- a/static/app/components/organizations/environmentPageFilter/index.spec.tsx
+++ b/static/app/components/organizations/environmentPageFilter/index.spec.tsx
@@ -7,7 +7,7 @@ import OrganizationStore from 'sentry/stores/organizationStore';
 import PageFiltersStore from 'sentry/stores/pageFiltersStore';
 import ProjectsStore from 'sentry/stores/projectsStore';
 
-const {organization, router} = initializeOrg({
+const {organization, projects, router} = initializeOrg({
   organization: {features: ['global-views', 'open-membership']},
   projects: [
     {id: '1', slug: 'project-1', environments: ['prod', 'staging']},
@@ -37,7 +37,7 @@ describe('EnvironmentPageFilter', function () {
     );
 
     OrganizationStore.onUpdate(organization, {replace: true});
-    ProjectsStore.loadInitialData(organization.projects);
+    ProjectsStore.loadInitialData(projects);
   });
 
   afterEach(() => PageFiltersStore.reset());
@@ -149,7 +149,7 @@ describe('EnvironmentPageFilter', function () {
 
     PageFiltersStore.reset();
     initializeUrlState({
-      memberProjects: organization.projects,
+      memberProjects: projects,
       nonMemberProjects: [],
       organization: desyncOrganization,
       queryParams: {project: ['1'], environment: 'staging'},

--- a/static/app/components/organizations/pageFilters/container.spec.tsx
+++ b/static/app/components/organizations/pageFilters/container.spec.tsx
@@ -28,7 +28,7 @@ function renderComponent(component, router, organization) {
 }
 
 describe('PageFiltersContainer', function () {
-  const {organization, router} = initializeOrg({
+  const {organization, projects, router} = initializeOrg({
     organization: {features: ['global-views']},
     projects: [
       {
@@ -59,7 +59,7 @@ describe('PageFiltersContainer', function () {
 
   beforeEach(function () {
     MockApiClient.clearMockResponses();
-    ProjectsStore.loadInitialData(organization.projects);
+    ProjectsStore.loadInitialData(projects);
     OrganizationStore.onUpdate(organization);
     OrganizationsStore.addOrReplace(organization);
 
@@ -560,9 +560,9 @@ describe('PageFiltersContainer', function () {
         })
       );
       const project = ProjectFixture({id: '3', isMember: false});
-      const org = OrganizationFixture({projects: [project]});
+      const org = OrganizationFixture();
 
-      ProjectsStore.loadInitialData(org.projects);
+      ProjectsStore.loadInitialData([project]);
 
       const initializationObj = initializeOrg({
         organization: org,
@@ -587,9 +587,9 @@ describe('PageFiltersContainer', function () {
 
     it('selects first project if none (i.e. all) is requested', function () {
       const project = ProjectFixture({id: '3'});
-      const org = OrganizationFixture({projects: [project]});
+      const org = OrganizationFixture();
 
-      ProjectsStore.loadInitialData(org.projects);
+      ProjectsStore.loadInitialData([project]);
 
       const initializationObj = initializeOrg({
         organization: org,

--- a/static/app/components/organizations/projectPageFilter/index.spec.tsx
+++ b/static/app/components/organizations/projectPageFilter/index.spec.tsx
@@ -14,7 +14,7 @@ import OrganizationStore from 'sentry/stores/organizationStore';
 import PageFiltersStore from 'sentry/stores/pageFiltersStore';
 import ProjectsStore from 'sentry/stores/projectsStore';
 
-const {organization, router} = initializeOrg({
+const {organization, projects, router} = initializeOrg({
   organization: {features: ['global-views', 'open-membership']},
   projects: [
     {id: '1', slug: 'project-1', isMember: true},
@@ -45,7 +45,7 @@ describe('ProjectPageFilter', function () {
     );
 
     OrganizationStore.onUpdate(organization, {replace: true});
-    ProjectsStore.loadInitialData(organization.projects);
+    ProjectsStore.loadInitialData(projects);
   });
 
   afterEach(() => PageFiltersStore.reset());
@@ -226,8 +226,8 @@ describe('ProjectPageFilter', function () {
 
     PageFiltersStore.reset();
     initializeUrlState({
-      memberProjects: organization.projects.filter(p => p.isMember),
-      nonMemberProjects: organization.projects.filter(p => !p.isMember),
+      memberProjects: projects.filter(p => p.isMember),
+      nonMemberProjects: projects.filter(p => !p.isMember),
       organization: desyncOrganization,
       queryParams: {project: ['2']},
       router: desyncRouter,

--- a/static/app/views/acceptProjectTransfer/index.spec.tsx
+++ b/static/app/views/acceptProjectTransfer/index.spec.tsx
@@ -1,6 +1,5 @@
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {ProjectFixture} from 'sentry-fixture/project';
-import {TeamFixture} from 'sentry-fixture/team';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
@@ -22,7 +21,7 @@ describe('AcceptProjectTransfer', function () {
       method: 'GET',
       body: {
         project: ProjectFixture(),
-        organizations: [OrganizationFixture({teams: [TeamFixture()]})],
+        organizations: [OrganizationFixture()],
       },
     });
 
@@ -53,7 +52,7 @@ describe('AcceptProjectTransfer', function () {
       method: 'GET',
       body: {
         project: ProjectFixture(),
-        organizations: [OrganizationFixture({teams: [TeamFixture()]})],
+        organizations: [OrganizationFixture()],
       },
       match: [(_url, options) => options.host === 'http://us.sentry.io'],
     });

--- a/static/app/views/alerts/rules/issue/ruleNode.spec.tsx
+++ b/static/app/views/alerts/rules/issue/ruleNode.spec.tsx
@@ -9,7 +9,7 @@ import RuleNode from 'sentry/views/alerts/rules/issue/ruleNode';
 
 describe('RuleNode', () => {
   const project = ProjectFixture();
-  const organization = OrganizationFixture({projects: [project]});
+  const organization = OrganizationFixture();
   const index = 0;
   const onDelete = jest.fn();
   const onReset = jest.fn();

--- a/static/app/views/dashboards/detail.spec.tsx
+++ b/static/app/views/dashboards/detail.spec.tsx
@@ -147,7 +147,6 @@ describe('Dashboards > Detail', function () {
       initialData = initializeOrg({
         organization: OrganizationFixture({
           features: ['global-views', 'dashboards-basic', 'discover-query'],
-          projects: [ProjectFixture()],
         }),
       });
 
@@ -496,7 +495,6 @@ describe('Dashboards > Detail', function () {
             'dashboards-edit',
             'discover-query',
           ],
-          projects: [ProjectFixture()],
         }),
       });
 

--- a/static/app/views/dashboards/manage/dashboardList.spec.tsx
+++ b/static/app/views/dashboards/manage/dashboardList.spec.tsx
@@ -1,7 +1,6 @@
 import {DashboardListItemFixture} from 'sentry-fixture/dashboard';
 import {LocationFixture} from 'sentry-fixture/locationFixture';
 import {OrganizationFixture} from 'sentry-fixture/organization';
-import {ProjectFixture} from 'sentry-fixture/project';
 import {UserFixture} from 'sentry-fixture/user';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
@@ -21,7 +20,6 @@ describe('Dashboards - DashboardList', function () {
   let dashboards, deleteMock, dashboardUpdateMock, createMock;
   const organization = OrganizationFixture({
     features: ['global-views', 'dashboards-basic', 'dashboards-edit', 'discover-query'],
-    projects: [ProjectFixture()],
   });
 
   const {router} = initializeOrg();

--- a/static/app/views/dashboards/widgetBuilder/buildSteps/visualizationStep.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/buildSteps/visualizationStep.spec.tsx
@@ -74,7 +74,7 @@ function mockRequests(orgSlug: Organization['slug']) {
 }
 
 describe('VisualizationStep', function () {
-  const {organization, router} = initializeOrg({
+  const {organization, projects, router} = initializeOrg({
     organization: {
       features: ['dashboards-edit', 'global-views', 'dashboards-mep'],
     },
@@ -88,7 +88,7 @@ describe('VisualizationStep', function () {
   });
 
   beforeEach(function () {
-    ProjectsStore.loadInitialData(organization.projects);
+    ProjectsStore.loadInitialData(projects);
   });
 
   it('debounce works as expected and requests are not triggered often', async function () {

--- a/static/app/views/dashboards/widgetBuilder/widgetBuilder.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/widgetBuilder.spec.tsx
@@ -62,7 +62,7 @@ function renderTestComponent({
   params?: Partial<WidgetBuilderProps['params']>;
   query?: Record<string, any>;
 } = {}) {
-  const {organization, router} = initializeOrg({
+  const {organization, projects, router} = initializeOrg({
     organization: {
       features: orgFeatures ?? defaultOrgFeatures,
     },
@@ -76,7 +76,7 @@ function renderTestComponent({
     },
   });
 
-  ProjectsStore.loadInitialData(organization.projects);
+  ProjectsStore.loadInitialData(projects);
 
   render(
     <WidgetBuilder

--- a/static/app/views/dashboards/widgetBuilder/widgetBuilderDataset.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/widgetBuilderDataset.spec.tsx
@@ -59,7 +59,7 @@ function renderTestComponent({
   params?: Partial<WidgetBuilderProps['params']>;
   query?: Record<string, any>;
 } = {}) {
-  const {organization, router} = initializeOrg({
+  const {organization, projects, router} = initializeOrg({
     organization: {
       features: orgFeatures ?? defaultOrgFeatures,
     },
@@ -73,7 +73,7 @@ function renderTestComponent({
     },
   });
 
-  ProjectsStore.loadInitialData(organization.projects);
+  ProjectsStore.loadInitialData(projects);
 
   render(
     <WidgetBuilder

--- a/static/app/views/dashboards/widgetBuilder/widgetBuilderSortBy.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/widgetBuilderSortBy.spec.tsx
@@ -47,7 +47,7 @@ function renderTestComponent({
   params?: Partial<WidgetBuilderProps['params']>;
   query?: Record<string, any>;
 } = {}) {
-  const {organization, router} = initializeOrg({
+  const {organization, projects, router} = initializeOrg({
     organization: {
       features: orgFeatures ?? defaultOrgFeatures,
     },
@@ -61,7 +61,7 @@ function renderTestComponent({
     },
   });
 
-  ProjectsStore.loadInitialData(organization.projects);
+  ProjectsStore.loadInitialData(projects);
 
   render(
     <WidgetBuilder

--- a/static/app/views/dashboards/widgetCard/index.spec.tsx
+++ b/static/app/views/dashboards/widgetCard/index.spec.tsx
@@ -1,5 +1,4 @@
 import {OrganizationFixture} from 'sentry-fixture/organization';
-import {ProjectFixture} from 'sentry-fixture/project';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {
@@ -30,7 +29,6 @@ describe('Dashboards > WidgetCard', function () {
   const {router, organization} = initializeOrg({
     organization: OrganizationFixture({
       features: ['dashboards-edit', 'discover-basic'],
-      projects: [ProjectFixture()],
     }),
     router: {orgId: 'orgId'},
   } as Parameters<typeof initializeOrg>[0]);

--- a/static/app/views/discover/homepage.spec.tsx
+++ b/static/app/views/discover/homepage.spec.tsx
@@ -34,7 +34,7 @@ describe('Discover > Homepage', () => {
       },
     });
 
-    ProjectsStore.loadInitialData(organization.projects);
+    ProjectsStore.loadInitialData(initialData.projects);
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/events/',
       body: [],

--- a/static/app/views/discover/miniGraph.spec.tsx
+++ b/static/app/views/discover/miniGraph.spec.tsx
@@ -1,6 +1,5 @@
 import {LocationFixture} from 'sentry-fixture/locationFixture';
 import {OrganizationFixture} from 'sentry-fixture/organization';
-import {ProjectFixture} from 'sentry-fixture/project';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render} from 'sentry-test/reactTestingLibrary';
@@ -23,7 +22,6 @@ describe('Discover > MiniGraph', function () {
   beforeEach(() => {
     organization = OrganizationFixture({
       features,
-      projects: [ProjectFixture()],
     });
     initialData = initializeOrg({
       organization,

--- a/static/app/views/discover/resultsChart.spec.tsx
+++ b/static/app/views/discover/resultsChart.spec.tsx
@@ -1,6 +1,5 @@
 import {LocationFixture} from 'sentry-fixture/locationFixture';
 import {OrganizationFixture} from 'sentry-fixture/organization';
-import {ProjectFixture} from 'sentry-fixture/project';
 import {RouterFixture} from 'sentry-fixture/routerFixture';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
@@ -17,10 +16,7 @@ describe('Discover > ResultsChart', function () {
     pathname: '/',
   });
 
-  const organization = OrganizationFixture({
-    features,
-    projects: [ProjectFixture()],
-  });
+  const organization = OrganizationFixture({features});
 
   const initialData = initializeOrg({
     organization,

--- a/static/app/views/discover/table/tableView.spec.tsx
+++ b/static/app/views/discover/table/tableView.spec.tsx
@@ -1,6 +1,5 @@
 import {LocationFixture} from 'sentry-fixture/locationFixture';
 import {OrganizationFixture} from 'sentry-fixture/organization';
-import {ProjectFixture} from 'sentry-fixture/project';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {act, render, screen, userEvent, within} from 'sentry-test/reactTestingLibrary';
@@ -69,7 +68,6 @@ describe('TableView > CellActions', function () {
 
     const organization = OrganizationFixture({
       features: ['discover-basic'],
-      projects: [ProjectFixture()],
     });
 
     initialData = initializeOrg({
@@ -77,7 +75,7 @@ describe('TableView > CellActions', function () {
       router: {location},
     });
     act(() => {
-      ProjectsStore.loadInitialData(initialData.organization.projects);
+      ProjectsStore.loadInitialData(initialData.projects);
       TagStore.reset();
       TagStore.loadTagsSuccess([
         {name: 'size', key: 'size'},
@@ -352,9 +350,7 @@ describe('TableView > CellActions', function () {
   });
 
   it('renders size columns correctly', function () {
-    const orgWithFeature = OrganizationFixture({
-      projects: [ProjectFixture()],
-    });
+    const orgWithFeature = OrganizationFixture();
 
     render(
       <TableView
@@ -404,9 +400,7 @@ describe('TableView > CellActions', function () {
   });
 
   it('shows events with value less than selected custom performance metric', async function () {
-    const orgWithFeature = OrganizationFixture({
-      projects: [ProjectFixture()],
-    });
+    const orgWithFeature = OrganizationFixture();
 
     render(
       <TableView

--- a/static/app/views/issueDetails/groupDetails.spec.tsx
+++ b/static/app/views/issueDetails/groupDetails.spec.tsx
@@ -106,7 +106,7 @@ describe('groupDetails', () => {
   beforeEach(() => {
     MockApiClient.clearMockResponses();
     OrganizationStore.onUpdate(defaultInit.organization);
-    act(() => ProjectsStore.loadInitialData(defaultInit.organization.projects));
+    act(() => ProjectsStore.loadInitialData(defaultInit.projects));
 
     MockApiClient.addMockResponse({
       url: `/organizations/${defaultInit.organization.slug}/issues/${group.id}/`,
@@ -172,7 +172,7 @@ describe('groupDetails', () => {
 
     expect(screen.queryByText(group.title)).not.toBeInTheDocument();
 
-    act(() => ProjectsStore.loadInitialData(defaultInit.organization.projects));
+    act(() => ProjectsStore.loadInitialData(defaultInit.projects));
 
     expect(await screen.findByText(group.title, {exact: false})).toBeInTheDocument();
 

--- a/static/app/views/issueDetails/groupReplays/groupReplays.spec.tsx
+++ b/static/app/views/issueDetails/groupReplays/groupReplays.spec.tsx
@@ -34,8 +34,6 @@ import ReplayReader from 'sentry/utils/replays/replayReader';
 const REPLAY_ID_1 = '346789a703f6454384f1de473b8b9fcc';
 const REPLAY_ID_2 = 'b05dae9b6be54d21a4d5ad9f8f02b780';
 
-let router, organization;
-
 jest.mock('sentry/utils/replays/hooks/useReplayReader');
 // Mock screenfull library
 jest.mock('screenfull', () => ({
@@ -90,7 +88,7 @@ mockUseReplayReader.mockImplementation(() => {
 
 function init({organizationProps = {features: ['session-replay']}}: InitializeOrgProps) {
   const mockProject = ProjectFixture();
-  ({router, organization} = initializeOrg({
+  const {router, projects, organization} = initializeOrg({
     organization: {
       ...organizationProps,
     },
@@ -106,10 +104,10 @@ function init({organizationProps = {features: ['session-replay']}}: InitializeOr
         query: {},
       },
     },
-  }));
+  });
 
   ProjectsStore.init();
-  ProjectsStore.loadInitialData(organization.projects);
+  ProjectsStore.loadInitialData(projects);
 
   return {router, organization};
 }
@@ -131,9 +129,7 @@ describe('GroupReplays', () => {
     const mockGroup = GroupFixture();
 
     it("should show a message when the organization doesn't have access to the replay feature", () => {
-      ({router, organization} = init({
-        organizationProps: {features: []},
-      }));
+      const {router, organization} = init({organizationProps: {features: []}});
       render(<GroupReplays group={mockGroup} />, {
         router,
         organization,
@@ -146,11 +142,8 @@ describe('GroupReplays', () => {
   });
 
   describe('Replay Feature Enabled', () => {
-    beforeEach(() => {
-      ({router, organization} = init({}));
-    });
-
     it('should query the replay-count endpoint with the fetched replayIds', async () => {
+      const {router, organization} = init({});
       const mockGroup = GroupFixture();
 
       const mockReplayCountApi = MockApiClient.addMockResponse({
@@ -220,6 +213,7 @@ describe('GroupReplays', () => {
     });
 
     it('should show empty message when no replays are found', async () => {
+      const {router, organization} = init({});
       const mockGroup = GroupFixture();
 
       const mockReplayCountApi = MockApiClient.addMockResponse({
@@ -249,6 +243,7 @@ describe('GroupReplays', () => {
     });
 
     it('should display error message when api call fails', async () => {
+      const {router, organization} = init({});
       const mockGroup = GroupFixture();
 
       const mockReplayCountApi = MockApiClient.addMockResponse({
@@ -282,6 +277,7 @@ describe('GroupReplays', () => {
     });
 
     it('should display default error message when api call fails without a body', async () => {
+      const {router, organization} = init({});
       const mockGroup = GroupFixture();
 
       const mockReplayCountApi = MockApiClient.addMockResponse({
@@ -315,6 +311,7 @@ describe('GroupReplays', () => {
     });
 
     it('should show loading indicator when loading replays', async () => {
+      const {router, organization} = init({});
       const mockGroup = GroupFixture();
 
       const mockReplayCountApi = MockApiClient.addMockResponse({
@@ -345,6 +342,7 @@ describe('GroupReplays', () => {
     });
 
     it('should show a list of replays and have the correct values', async () => {
+      const {router, organization} = init({});
       const mockGroup = GroupFixture();
 
       const mockReplayCountApi = MockApiClient.addMockResponse({
@@ -447,9 +445,9 @@ describe('GroupReplays', () => {
     });
 
     it('Should render the replay player when replay-play-from-replay-tab is enabled', async () => {
-      ({router, organization} = init({
+      const {router, organization} = init({
         organizationProps: {features: ['replay-play-from-replay-tab', 'session-replay']},
-      }));
+      });
       const mockGroup = GroupFixture();
 
       const mockReplayCountApi = MockApiClient.addMockResponse({
@@ -517,9 +515,9 @@ describe('GroupReplays', () => {
     });
 
     it('Should switch replays when clicking and replay-play-from-replay-tab is enabled', async () => {
-      ({router, organization} = init({
+      const {router, organization} = init({
         organizationProps: {features: ['session-replay']},
-      }));
+      });
       const mockGroup = GroupFixture();
       const mockReplayRecord = mockReplay?.getReplay();
 

--- a/static/app/views/issueList/overview.spec.tsx
+++ b/static/app/views/issueList/overview.spec.tsx
@@ -43,7 +43,7 @@ const project = ProjectFixture({
   firstEvent: new Date().toISOString(),
 });
 
-const {organization, router} = initializeOrg({
+const {organization, projects, router} = initializeOrg({
   organization: {
     id: '1337',
     slug: 'org-slug',
@@ -154,7 +154,7 @@ describe('IssueList', function () {
       savedSearches: [savedSearch],
       useOrgSavedSearches: true,
       selection: {
-        projects: [parseInt(organization.projects[0].id, 10)],
+        projects: [parseInt(projects[0].id, 10)],
         environments: [],
         datetime: {period: '14d'},
       },
@@ -450,7 +450,6 @@ describe('IssueList', function () {
         },
         organization: OrganizationFixture({
           features: ['issue-stream-performance'],
-          projects: [],
         }),
       };
       const {unmount} = render(<IssueListWithStores {...defaultProps} />, {
@@ -1140,9 +1139,7 @@ describe('IssueList', function () {
           params: {},
           location: {query: {query: 'is:unresolved'}, search: 'query=is:unresolved'},
         }),
-        organization: OrganizationFixture({
-          projects: [],
-        }),
+        organization: OrganizationFixture(),
         ...moreProps,
       };
       render(<IssueListOverview {...defaultProps} />, {router});
@@ -1151,7 +1148,7 @@ describe('IssueList', function () {
     };
 
     it('displays when no projects selected and all projects user is member of, async does not have first event', async function () {
-      const projects = [
+      const projectsBody = [
         ProjectFixture({
           id: '1',
           slug: 'foo',
@@ -1180,7 +1177,7 @@ describe('IssueList', function () {
       });
       MockApiClient.addMockResponse({
         url: '/organizations/org-slug/projects/',
-        body: projects,
+        body: projectsBody,
       });
       MockApiClient.addMockResponse({
         url: '/projects/org-slug/foo/issues/',
@@ -1188,16 +1185,14 @@ describe('IssueList', function () {
       });
 
       await createWrapper({
-        organization: OrganizationFixture({
-          projects,
-        }),
+        organization: OrganizationFixture(),
       });
 
       expect(await screen.findByTestId('awaiting-events')).toBeInTheDocument();
     });
 
     it('does not display when no projects selected and any projects have a first event', async function () {
-      const projects = [
+      const projectsBody = [
         ProjectFixture({
           id: '1',
           slug: 'foo',
@@ -1226,19 +1221,17 @@ describe('IssueList', function () {
       });
       MockApiClient.addMockResponse({
         url: '/organizations/org-slug/projects/',
-        body: projects,
+        body: projectsBody,
       });
       await createWrapper({
-        organization: OrganizationFixture({
-          projects,
-        }),
+        organization: OrganizationFixture(),
       });
 
       expect(screen.queryByTestId('awaiting-events')).not.toBeInTheDocument();
     });
 
     it('displays when all selected projects do not have first event', async function () {
-      const projects = [
+      const projectsBody = [
         ProjectFixture({
           id: '1',
           slug: 'foo',
@@ -1267,7 +1260,7 @@ describe('IssueList', function () {
       });
       MockApiClient.addMockResponse({
         url: '/organizations/org-slug/projects/',
-        body: projects,
+        body: projectsBody,
       });
       MockApiClient.addMockResponse({
         url: '/projects/org-slug/foo/issues/',
@@ -1280,16 +1273,14 @@ describe('IssueList', function () {
           environments: [],
           datetime: {period: '14d'},
         },
-        organization: OrganizationFixture({
-          projects,
-        }),
+        organization: OrganizationFixture(),
       });
 
       expect(await screen.findByTestId('awaiting-events')).toBeInTheDocument();
     });
 
     it('does not display when any selected projects have first event', async function () {
-      const projects = [
+      const projectsBody = [
         ProjectFixture({
           id: '1',
           slug: 'foo',
@@ -1318,7 +1309,7 @@ describe('IssueList', function () {
       });
       MockApiClient.addMockResponse({
         url: '/organizations/org-slug/projects/',
-        body: projects,
+        body: projectsBody,
       });
 
       await createWrapper({
@@ -1327,9 +1318,7 @@ describe('IssueList', function () {
           environments: [],
           datetime: {period: '14d'},
         },
-        organization: OrganizationFixture({
-          projects,
-        }),
+        organization: OrganizationFixture({}),
       });
 
       expect(screen.queryByTestId('awaiting-events')).not.toBeInTheDocument();

--- a/static/app/views/organizationStats/teamInsights/health.spec.tsx
+++ b/static/app/views/organizationStats/teamInsights/health.spec.tsx
@@ -169,10 +169,7 @@ describe('TeamStatsHealth', () => {
     teams = teams ?? [team1, team2, team3];
     projects = projects ?? [project1, project2];
     ProjectsStore.loadInitialData(projects);
-    const organization = OrganizationFixture({
-      teams,
-      projects,
-    });
+    const organization = OrganizationFixture();
 
     if (isOrgOwner !== undefined && !isOrgOwner) {
       organization.access = organization.access.filter(scope => scope !== 'org:admin');

--- a/static/app/views/organizationStats/teamInsights/issues.spec.tsx
+++ b/static/app/views/organizationStats/teamInsights/issues.spec.tsx
@@ -137,10 +137,7 @@ describe('TeamStatsIssues', () => {
     teams = teams ?? [team1, team2, team3];
     projects = projects ?? [project1, project2];
     ProjectsStore.loadInitialData(projects);
-    const organization = OrganizationFixture({
-      teams,
-      projects,
-    });
+    const organization = OrganizationFixture();
 
     if (isOrgOwner !== undefined && !isOrgOwner) {
       organization.access = organization.access.filter(scope => scope !== 'org:admin');

--- a/static/app/views/organizationStats/teamInsights/teamUnresolvedIssues.spec.tsx
+++ b/static/app/views/organizationStats/teamInsights/teamUnresolvedIssues.spec.tsx
@@ -10,7 +10,7 @@ describe('TeamUnresolvedIssues', () => {
   it('should render graph with table with % change', async () => {
     const team = TeamFixture();
     const project = ProjectFixture();
-    const organization = OrganizationFixture({projects: [project]});
+    const organization = OrganizationFixture();
     const issuesApi = MockApiClient.addMockResponse({
       url: `/teams/${organization.slug}/${team.slug}/all-unresolved-issues/`,
       body: {
@@ -35,7 +35,7 @@ describe('TeamUnresolvedIssues', () => {
     render(
       <TeamUnresolvedIssues
         organization={organization}
-        projects={organization.projects}
+        projects={[project]}
         teamSlug={team.slug}
         period="14d"
       />

--- a/static/app/views/performance/browser/resources/index.spec.tsx
+++ b/static/app/views/performance/browser/resources/index.spec.tsx
@@ -2,7 +2,7 @@ import {OrganizationFixture} from 'sentry-fixture/organization';
 
 import {render, screen, waitForElementToBeRemoved} from 'sentry-test/reactTestingLibrary';
 
-import type {DetailedOrganization} from 'sentry/types';
+import type {Organization} from 'sentry/types/organization';
 import {useLocation} from 'sentry/utils/useLocation';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import ResourcesLandingPage from 'sentry/views/performance/browser/resources';
@@ -123,7 +123,7 @@ const setupMocks = () => {
   });
 };
 
-const setupMockRequests = (organization: DetailedOrganization) => {
+const setupMockRequests = (organization: Organization) => {
   requestMocks.mainTable = MockApiClient.addMockResponse({
     url: `/organizations/${organization.slug}/events/`,
     method: 'GET',

--- a/static/app/views/performance/browser/resources/resourceSummaryPage/sampleImages.spec.tsx
+++ b/static/app/views/performance/browser/resources/resourceSummaryPage/sampleImages.spec.tsx
@@ -4,7 +4,7 @@ import {ProjectFixture} from 'sentry-fixture/project';
 import {render, screen, waitForElementToBeRemoved} from 'sentry-test/reactTestingLibrary';
 
 import ProjectsStore from 'sentry/stores/projectsStore';
-import type {DetailedOrganization} from 'sentry/types';
+import type {Organization} from 'sentry/types';
 import {useLocation} from 'sentry/utils/useLocation';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import SampleImages from 'sentry/views/performance/browser/resources/resourceSummaryPage/sampleImages';
@@ -91,7 +91,7 @@ const setupMocks = () => {
 };
 
 const setupMockRequests = (
-  organization: DetailedOrganization,
+  organization: Organization,
   settings: {enableImages: boolean} = {enableImages: true}
 ) => {
   const {enableImages} = settings;

--- a/static/app/views/performance/content.spec.tsx
+++ b/static/app/views/performance/content.spec.tsx
@@ -26,9 +26,9 @@ function WrappedComponent({router}) {
 function initializeData(projects, query, features = FEATURES) {
   const organization = OrganizationFixture({
     features,
-    projects,
   });
   const initialData = initializeOrg({
+    projects,
     organization,
     router: {
       location: {
@@ -38,7 +38,7 @@ function initializeData(projects, query, features = FEATURES) {
     },
   });
   act(() => void OrganizationStore.onUpdate(initialData.organization, {replace: true}));
-  act(() => ProjectsStore.loadInitialData(initialData.organization.projects));
+  act(() => ProjectsStore.loadInitialData(initialData.projects));
   return initialData;
 }
 
@@ -47,10 +47,7 @@ function initializeTrendsData(query, addDefaultQuery = true) {
     ProjectFixture({id: '1', firstTransactionEvent: false}),
     ProjectFixture({id: '2', firstTransactionEvent: true}),
   ];
-  const organization = OrganizationFixture({
-    features: FEATURES,
-    projects,
-  });
+  const organization = OrganizationFixture({features: FEATURES});
 
   const otherTrendsQuery = addDefaultQuery
     ? {
@@ -60,6 +57,7 @@ function initializeTrendsData(query, addDefaultQuery = true) {
 
   const initialData = initializeOrg({
     organization,
+    projects,
     router: {
       location: {
         pathname: '/test',
@@ -70,7 +68,7 @@ function initializeTrendsData(query, addDefaultQuery = true) {
       },
     },
   });
-  act(() => ProjectsStore.loadInitialData(initialData.organization.projects));
+  act(() => ProjectsStore.loadInitialData(initialData.projects));
   return initialData;
 }
 

--- a/static/app/views/performance/landing/utils.spec.tsx
+++ b/static/app/views/performance/landing/utils.spec.tsx
@@ -10,7 +10,6 @@ import {getCurrentLandingDisplay} from 'sentry/views/performance/landing/utils';
 function initializeData(projects, query = {}) {
   const organization = OrganizationFixture({
     features: [],
-    projects,
   });
   const initialData = initializeOrg({
     organization,
@@ -22,7 +21,7 @@ function initializeData(projects, query = {}) {
     projects,
   });
   const eventView = EventView.fromLocation(initialData.router.location);
-  ProjectsStore.loadInitialData(initialData.organization.projects);
+  ProjectsStore.loadInitialData(initialData.projects);
   return {
     ...initialData,
     eventView,

--- a/static/app/views/performance/mobile/screenload/index.spec.tsx
+++ b/static/app/views/performance/mobile/screenload/index.spec.tsx
@@ -22,7 +22,6 @@ describe('PageloadModule', function () {
   const project = ProjectFixture({platform: 'react-native'});
   const organization = OrganizationFixture({
     features: ['insights-initial-modules'],
-    projects: [project],
   });
   jest.mocked(useOnboardingProject).mockReturnValue(undefined);
 

--- a/static/app/views/performance/mobile/screenload/screenLoadSpans/index.spec.tsx
+++ b/static/app/views/performance/mobile/screenload/screenLoadSpans/index.spec.tsx
@@ -113,10 +113,7 @@ describe('Screen Summary', function () {
     let organization;
     beforeEach(function () {
       const project = ProjectFixture({platform: 'react-native'});
-      organization = OrganizationFixture({
-        features: ['insights-initial-modules'],
-        projects: [project],
-      });
+      organization = OrganizationFixture({features: ['insights-initial-modules']});
       mockResponses(organization, project);
       localStorage.clear();
       browserHistory.push = jest.fn();
@@ -209,10 +206,7 @@ describe('Screen Summary', function () {
     let organization;
     beforeEach(function () {
       const project = ProjectFixture({platform: 'android'});
-      organization = OrganizationFixture({
-        features: ['insights-initial-modules'],
-        projects: [project],
-      });
+      organization = OrganizationFixture({features: ['insights-initial-modules']});
       mockResponses(organization, project);
       localStorage.clear();
       browserHistory.push = jest.fn();

--- a/static/app/views/performance/table.spec.tsx
+++ b/static/app/views/performance/table.spec.tsx
@@ -192,7 +192,7 @@ describe('Performance > Table', function () {
         query: 'event.type:transaction transaction:/api*',
       });
 
-      ProjectsStore.loadInitialData(data.organization.projects);
+      ProjectsStore.loadInitialData(data.projects);
 
       render(
         <WrappedComponent
@@ -277,7 +277,7 @@ describe('Performance > Table', function () {
         projects,
       });
 
-      ProjectsStore.loadInitialData(data.organization.projects);
+      ProjectsStore.loadInitialData(data.projects);
 
       render(
         <WrappedComponent
@@ -308,7 +308,7 @@ describe('Performance > Table', function () {
         projects,
       });
 
-      ProjectsStore.loadInitialData(data.organization.projects);
+      ProjectsStore.loadInitialData(data.projects);
 
       render(
         <WrappedComponent

--- a/static/app/views/performance/traceDetails/content.spec.tsx
+++ b/static/app/views/performance/traceDetails/content.spec.tsx
@@ -18,7 +18,7 @@ const initializeData = () => {
     features: ['performance-view', 'trace-view'],
   });
 
-  act(() => ProjectsStore.loadInitialData(data.organization.projects));
+  act(() => ProjectsStore.loadInitialData(data.projects));
   return data;
 };
 

--- a/static/app/views/performance/transactionDetails/index.spec.tsx
+++ b/static/app/views/performance/transactionDetails/index.spec.tsx
@@ -15,7 +15,6 @@ describe('EventDetails', () => {
   const project = ProjectFixture();
   const organization = OrganizationFixture({
     features: ['performance-view'],
-    projects: [project],
   });
 
   beforeEach(() => {

--- a/static/app/views/performance/transactionEvents.spec.tsx
+++ b/static/app/views/performance/transactionEvents.spec.tsx
@@ -1,5 +1,4 @@
 import {OrganizationFixture} from 'sentry-fixture/organization';
-import {ProjectFixture} from 'sentry-fixture/project';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen} from 'sentry-test/reactTestingLibrary';
@@ -21,7 +20,6 @@ function initializeData({features: additionalFeatures = [], query = {}}: Data = 
   const features = ['discover-basic', 'performance-view', ...additionalFeatures];
   const organization = OrganizationFixture({
     features,
-    projects: [ProjectFixture()],
   });
   return initializeOrg({
     organization,
@@ -156,9 +154,9 @@ describe('Performance > TransactionSummary', function () {
   });
 
   it('renders basic UI elements', async function () {
-    const {organization, router} = initializeData();
+    const {organization, projects, router} = initializeData();
 
-    ProjectsStore.loadInitialData(organization.projects);
+    ProjectsStore.loadInitialData(projects);
 
     render(<TransactionEvents organization={organization} location={router.location} />, {
       router,
@@ -190,9 +188,9 @@ describe('Performance > TransactionSummary', function () {
   });
 
   it('renders relative span breakdown header when no filter selected', async function () {
-    const {organization, router} = initializeData();
+    const {organization, projects, router} = initializeData();
 
-    ProjectsStore.loadInitialData(organization.projects);
+    ProjectsStore.loadInitialData(projects);
 
     render(<TransactionEvents organization={organization} location={router.location} />, {
       router,
@@ -205,9 +203,9 @@ describe('Performance > TransactionSummary', function () {
   });
 
   it('renders event column results correctly', async function () {
-    const {organization, router} = initializeData();
+    const {organization, projects, router} = initializeData();
 
-    ProjectsStore.loadInitialData(organization.projects);
+    ProjectsStore.loadInitialData(projects);
 
     render(<TransactionEvents organization={organization} location={router.location} />, {
       router,
@@ -234,11 +232,11 @@ describe('Performance > TransactionSummary', function () {
   });
 
   it('renders additional Web Vital column', async function () {
-    const {organization, router} = initializeData({
+    const {organization, projects, router} = initializeData({
       query: {webVital: WebVital.LCP},
     });
 
-    ProjectsStore.loadInitialData(organization.projects);
+    ProjectsStore.loadInitialData(projects);
 
     render(<TransactionEvents organization={organization} location={router.location} />, {
       router,

--- a/static/app/views/performance/transactionSummary/header.spec.tsx
+++ b/static/app/views/performance/transactionSummary/header.spec.tsx
@@ -18,7 +18,6 @@ function initializeData(opts?: InitialOpts) {
   const {features, platform} = opts ?? {};
   const project = ProjectFixture({platform});
   const organization = OrganizationFixture({
-    projects: [project],
     features: features ?? [],
   });
 

--- a/static/app/views/performance/transactionSummary/transactionAnomalies/index.spec.tsx
+++ b/static/app/views/performance/transactionSummary/transactionAnomalies/index.spec.tsx
@@ -8,7 +8,7 @@ import TransactionAnomalies from 'sentry/views/performance/transactionSummary/tr
 const initializeData = (settings: InitializeDataSettings) => {
   const data = _initializeData(settings);
 
-  act(() => void ProjectsStore.loadInitialData(data.organization.projects));
+  act(() => void ProjectsStore.loadInitialData(data.projects));
   return data;
 };
 

--- a/static/app/views/performance/transactionSummary/transactionEvents/content.spec.tsx
+++ b/static/app/views/performance/transactionSummary/transactionEvents/content.spec.tsx
@@ -20,7 +20,6 @@ import {EventsDisplayFilterName} from 'sentry/views/performance/transactionSumma
 function initializeData() {
   const organization = OrganizationFixture({
     features: ['discover-basic', 'performance-view'],
-    projects: [ProjectFixture()],
   });
   const initialData = initializeOrg({
     organization,
@@ -35,7 +34,7 @@ function initializeData() {
     },
     projects: [],
   });
-  act(() => void ProjectsStore.loadInitialData(initialData.organization.projects));
+  act(() => void ProjectsStore.loadInitialData(initialData.projects));
   return initialData;
 }
 

--- a/static/app/views/performance/transactionSummary/transactionEvents/eventsTable.spec.tsx
+++ b/static/app/views/performance/transactionSummary/transactionEvents/eventsTable.spec.tsx
@@ -1,5 +1,4 @@
 import {OrganizationFixture} from 'sentry-fixture/organization';
-import {ProjectFixture} from 'sentry-fixture/project';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen, waitForElementToBeRemoved} from 'sentry-test/reactTestingLibrary';
@@ -63,7 +62,6 @@ function initializeData({features: additionalFeatures = []}: Data = {}) {
   const features = ['discover-basic', 'performance-view', ...additionalFeatures];
   const organization = OrganizationFixture({
     features,
-    projects: [ProjectFixture()],
   });
   const initialData = initializeOrg({
     organization,
@@ -78,7 +76,7 @@ function initializeData({features: additionalFeatures = []}: Data = {}) {
     },
     projects: [],
   });
-  ProjectsStore.loadInitialData(initialData.organization.projects);
+  ProjectsStore.loadInitialData(initialData.projects);
   return initialData;
 }
 

--- a/static/app/views/performance/transactionSummary/transactionEvents/index.spec.tsx
+++ b/static/app/views/performance/transactionSummary/transactionEvents/index.spec.tsx
@@ -130,7 +130,7 @@ const initializeData = (settings?: InitializeDataSettings) => {
     ...settings,
   };
   const data = _initializeData(settings);
-  act(() => void ProjectsStore.loadInitialData(data.organization.projects));
+  act(() => void ProjectsStore.loadInitialData(data.projects));
   return data;
 };
 

--- a/static/app/views/performance/transactionSummary/transactionOverview/content.spec.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/content.spec.tsx
@@ -10,11 +10,10 @@ import {MEPSettingProvider} from 'sentry/utils/performance/contexts/metricsEnhan
 import {SpanOperationBreakdownFilter} from 'sentry/views/performance/transactionSummary/filter';
 import SummaryContent from 'sentry/views/performance/transactionSummary/transactionOverview/content';
 
-function initialize(project, query, additionalFeatures: string[] = []) {
+function initialize(query, additionalFeatures: string[] = []) {
   const features = ['transaction-event', 'performance-view', ...additionalFeatures];
   const organization = OrganizationFixture({
     features,
-    projects: [project],
   });
   const initialData = initializeOrg({
     organization,
@@ -145,7 +144,7 @@ describe('Transaction Summary Content', function () {
       spanOperationBreakdownFilter,
       transactionName,
       router,
-    } = initialize(project, {});
+    } = initialize({});
 
     render(
       <WrappedComponent

--- a/static/app/views/performance/transactionSummary/transactionOverview/index.spec.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/index.spec.tsx
@@ -47,10 +47,10 @@ function initializeData({
   const project = prj ?? ProjectFixture({teams});
   const organization = OrganizationFixture({
     features,
-    projects: projects ? projects : [project],
   });
   const initialData = initializeOrg({
     organization,
+    projects: projects ? projects : [project],
     router: {
       location: {
         query: {
@@ -63,7 +63,7 @@ function initializeData({
     },
   });
 
-  ProjectsStore.loadInitialData(initialData.organization.projects);
+  ProjectsStore.loadInitialData(initialData.projects);
   TeamStore.loadInitialData(teams, false, null);
 
   return initialData;

--- a/static/app/views/performance/transactionSummary/transactionOverview/suspectSpans.spec.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/suspectSpans.spec.tsx
@@ -1,5 +1,4 @@
 import {OrganizationFixture} from 'sentry-fixture/organization';
-import {ProjectFixture} from 'sentry-fixture/project';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {generateSuspectSpansResponse} from 'sentry-test/performance/initializePerformanceData';
@@ -18,10 +17,7 @@ import SuspectSpans from 'sentry/views/performance/transactionSummary/transactio
 
 function initializeData({query} = {query: {}}) {
   const features = ['performance-view'];
-  const organization = OrganizationFixture({
-    features,
-    projects: [ProjectFixture()],
-  });
+  const organization = OrganizationFixture({features});
   const initialData = initializeOrg({
     organization,
     router: {
@@ -36,7 +32,7 @@ function initializeData({query} = {query: {}}) {
     projects: [],
   });
 
-  act(() => void ProjectsStore.loadInitialData(initialData.organization.projects));
+  act(() => void ProjectsStore.loadInitialData(initialData.projects));
   return {
     ...initialData,
     eventView: EventView.fromLocation(initialData.router.location),

--- a/static/app/views/performance/transactionSummary/transactionOverview/tagExplorer.spec.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/tagExplorer.spec.tsx
@@ -22,11 +22,10 @@ function WrapperComponent(props) {
   );
 }
 
-function initialize(projects, query, additionalFeatures = []) {
+function initialize(query, additionalFeatures = []) {
   const features = ['transaction-event', 'performance-view', ...additionalFeatures];
   const organization = OrganizationFixture({
     features,
-    projects,
   });
   const initialOrgData = {
     organization,
@@ -37,7 +36,7 @@ function initialize(projects, query, additionalFeatures = []) {
     },
   };
   const initialData = initializeOrg(initialOrgData);
-  ProjectsStore.loadInitialData(initialData.organization.projects);
+  ProjectsStore.loadInitialData(initialData.projects);
   const eventView = EventView.fromLocation(initialData.router.location);
 
   const spanOperationBreakdownFilter = SpanOperationBreakdownFilter.NONE;
@@ -108,7 +107,7 @@ describe('WrapperComponent', function () {
       api,
       spanOperationBreakdownFilter,
       transactionName,
-    } = initialize(projects, {});
+    } = initialize({});
 
     render(
       <WrapperComponent
@@ -137,7 +136,7 @@ describe('WrapperComponent', function () {
       api,
       spanOperationBreakdownFilter,
       transactionName,
-    } = initialize(projects, {
+    } = initialize({
       project: '123',
     });
 
@@ -178,7 +177,6 @@ describe('WrapperComponent', function () {
       transactionName,
       router,
     } = initialize(
-      projects,
       {
         project: '123',
       },
@@ -208,10 +206,7 @@ describe('WrapperComponent', function () {
 
   it('Tag explorer uses the operation breakdown as a column', async function () {
     const projects = [ProjectFixture({platform: 'javascript-react'})];
-    const {organization, location, eventView, api, transactionName} = initialize(
-      projects,
-      {}
-    );
+    const {organization, location, eventView, api, transactionName} = initialize({});
 
     render(
       <WrapperComponent
@@ -249,7 +244,7 @@ describe('WrapperComponent', function () {
       spanOperationBreakdownFilter,
       transactionName,
       router,
-    } = initialize(projects, {});
+    } = initialize({});
 
     render(
       <WrapperComponent

--- a/static/app/views/performance/transactionSummary/transactionReplays/index.spec.tsx
+++ b/static/app/views/performance/transactionSummary/transactionReplays/index.spec.tsx
@@ -34,7 +34,7 @@ const renderComponent = ({
   location,
   organizationProps = {features: ['performance-view', 'session-replay']},
 }: InitializeOrgProps = {}) => {
-  const {organization, router} = initializeOrg({
+  const {organization, projects, router} = initializeOrg({
     organization: {
       ...organizationProps,
     },
@@ -57,7 +57,7 @@ const renderComponent = ({
   });
 
   ProjectsStore.init();
-  ProjectsStore.loadInitialData(organization.projects);
+  ProjectsStore.loadInitialData(projects);
 
   return render(<TransactionReplays />, {router, organization});
 };

--- a/static/app/views/performance/transactionSummary/transactionSpans/index.spec.tsx
+++ b/static/app/views/performance/transactionSummary/transactionSpans/index.spec.tsx
@@ -1,5 +1,4 @@
 import {OrganizationFixture} from 'sentry-fixture/organization';
-import {ProjectFixture} from 'sentry-fixture/project';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {generateSuspectSpansResponse} from 'sentry-test/performance/initializePerformanceData';
@@ -25,7 +24,6 @@ function initializeData(options: {query: {}; additionalFeatures?: string[]}) {
 
   const organization = OrganizationFixture({
     features: [...defaultFeatures, ...(additionalFeatures ? additionalFeatures : [])],
-    projects: [ProjectFixture()],
   });
   const initialData = initializeOrg({
     organization,
@@ -39,7 +37,7 @@ function initializeData(options: {query: {}; additionalFeatures?: string[]}) {
       },
     },
   });
-  act(() => void ProjectsStore.loadInitialData(initialData.organization.projects));
+  act(() => void ProjectsStore.loadInitialData(initialData.projects));
   return initialData;
 }
 

--- a/static/app/views/performance/transactionSummary/transactionSpans/opsFilter.spec.tsx
+++ b/static/app/views/performance/transactionSummary/transactionSpans/opsFilter.spec.tsx
@@ -1,6 +1,5 @@
 import type {Location} from 'history';
 import {OrganizationFixture} from 'sentry-fixture/organization';
-import {ProjectFixture} from 'sentry-fixture/project';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
@@ -10,10 +9,7 @@ import OpsFilter from 'sentry/views/performance/transactionSummary/transactionSp
 
 function initializeData({query} = {query: {}}) {
   const features = ['performance-view'];
-  const organization = OrganizationFixture({
-    features,
-    projects: [ProjectFixture()],
-  });
+  const organization = OrganizationFixture({features});
   const initialData = initializeOrg({
     organization,
     router: {

--- a/static/app/views/performance/transactionSummary/transactionSpans/spanDetails/index.spec.tsx
+++ b/static/app/views/performance/transactionSummary/transactionSpans/spanDetails/index.spec.tsx
@@ -18,7 +18,7 @@ import {spanDetailsRouteWithQuery} from 'sentry/views/performance/transactionSum
 
 function initializeData(settings) {
   const data = _initializeData(settings);
-  act(() => void ProjectsStore.loadInitialData(data.organization.projects));
+  act(() => void ProjectsStore.loadInitialData(data.projects));
   return data;
 }
 

--- a/static/app/views/performance/transactionSummary/transactionSpans/spanMetricsTable.spec.tsx
+++ b/static/app/views/performance/transactionSummary/transactionSpans/spanMetricsTable.spec.tsx
@@ -9,7 +9,7 @@ const initializeData = () => {
     features: ['performance-view'],
   });
 
-  act(() => ProjectsStore.loadInitialData(data.organization.projects));
+  act(() => ProjectsStore.loadInitialData(data.projects));
   return data;
 };
 

--- a/static/app/views/performance/transactionSummary/transactionSpans/suspectSpansTable.spec.tsx
+++ b/static/app/views/performance/transactionSummary/transactionSpans/suspectSpansTable.spec.tsx
@@ -14,7 +14,7 @@ const initializeData = () => {
     features: ['performance-view'],
   });
 
-  act(() => ProjectsStore.loadInitialData(data.organization.projects));
+  act(() => ProjectsStore.loadInitialData(data.projects));
   return data;
 };
 

--- a/static/app/views/performance/transactionSummary/transactionTags/index.spec.tsx
+++ b/static/app/views/performance/transactionSummary/transactionTags/index.spec.tsx
@@ -1,5 +1,4 @@
 import {OrganizationFixture} from 'sentry-fixture/organization';
-import {ProjectFixture} from 'sentry-fixture/project';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {act, render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
@@ -16,7 +15,6 @@ function initializeData({query} = {query: {}}) {
 
   const organization = OrganizationFixture({
     features,
-    projects: [ProjectFixture()],
   });
 
   const initialData = initializeOrg({
@@ -32,7 +30,7 @@ function initializeData({query} = {query: {}}) {
     },
   });
 
-  act(() => ProjectsStore.loadInitialData(initialData.organization.projects));
+  act(() => ProjectsStore.loadInitialData(initialData.projects));
 
   return initialData;
 }

--- a/static/app/views/performance/transactionSummary/transactionVitals/index.spec.tsx
+++ b/static/app/views/performance/transactionSummary/transactionVitals/index.spec.tsx
@@ -42,7 +42,6 @@ function initialize({
   const data = initializeOrg({
     organization: OrganizationFixture({
       features,
-      projects: project ? [project] : [],
     }),
     router: {
       location: {
@@ -54,7 +53,7 @@ function initialize({
       },
     },
   });
-  act(() => ProjectsStore.loadInitialData(data.organization.projects));
+  act(() => ProjectsStore.loadInitialData(data.projects));
   return data;
 }
 

--- a/static/app/views/performance/trends/index.spec.tsx
+++ b/static/app/views/performance/trends/index.spec.tsx
@@ -129,10 +129,7 @@ function initializeTrendsData(
   const features = extraFeatures
     ? ['transaction-event', 'performance-view', ...extraFeatures]
     : ['transaction-event', 'performance-view'];
-  const organization = OrganizationFixture({
-    features,
-    projects: _projects,
-  });
+  const organization = OrganizationFixture({features});
 
   const newQuery = {...(includeDefaultQuery ? trendsViewQuery : {}), ...query};
 
@@ -146,7 +143,7 @@ function initializeTrendsData(
     projects: _projects,
   });
 
-  act(() => ProjectsStore.loadInitialData(initialData.organization.projects));
+  act(() => ProjectsStore.loadInitialData(initialData.projects));
 
   return initialData;
 }

--- a/static/app/views/performance/vitalDetail/index.spec.tsx
+++ b/static/app/views/performance/vitalDetail/index.spec.tsx
@@ -1,7 +1,6 @@
 import type {InjectedRouter} from 'react-router';
 import {MetricsFieldFixture} from 'sentry-fixture/metrics';
 import {OrganizationFixture} from 'sentry-fixture/organization';
-import {ProjectFixture} from 'sentry-fixture/project';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen, userEvent, within} from 'sentry-test/reactTestingLibrary';
@@ -19,10 +18,13 @@ import {vitalSupportedBrowsers} from 'sentry/views/performance/vitalDetail/utils
 const api = new MockApiClient();
 const organization = OrganizationFixture({
   features: ['discover-basic', 'performance-view'],
-  projects: [ProjectFixture()],
 });
 
-const {organization: org, router} = initializeOrg({
+const {
+  organization: org,
+  project,
+  router,
+} = initializeOrg({
   organization,
   router: {
     location: {
@@ -65,7 +67,7 @@ const testSupportedBrowserRendering = (webVital: WebVital) => {
 describe('Performance > VitalDetail', function () {
   beforeEach(function () {
     TeamStore.loadInitialData([], false, null);
-    ProjectsStore.loadInitialData(org.projects);
+    ProjectsStore.loadInitialData([project]);
     browserHistory.push = jest.fn();
     MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/projects/`,

--- a/static/app/views/profiling/profileSummary/profileSummaryPage.spec.tsx
+++ b/static/app/views/profiling/profileSummary/profileSummaryPage.spec.tsx
@@ -43,10 +43,7 @@ window.ResizeObserver =
 
 describe('ProfileSummaryPage', () => {
   it('renders new page', async () => {
-    const organization = OrganizationFixture({
-      features: [],
-      projects: [ProjectFixture()],
-    });
+    const organization = OrganizationFixture({features: []});
     OrganizationStore.onUpdate(organization);
 
     MockApiClient.addMockResponse({

--- a/static/app/views/releases/list/index.spec.tsx
+++ b/static/app/views/releases/list/index.spec.tsx
@@ -20,7 +20,7 @@ import {ReleasesSortOption} from 'sentry/views/releases/list/releasesSortOptions
 import {ReleasesStatusOption} from 'sentry/views/releases/list/releasesStatusOptions';
 
 describe('ReleasesList', () => {
-  const {organization, router, routerProps} = initializeOrg();
+  const {organization, projects, router, routerProps} = initializeOrg();
   const semverVersionInfo = {
     buildHash: null,
     description: '1.2.3',
@@ -64,7 +64,7 @@ describe('ReleasesList', () => {
   let endpointMock, sessionApiMock;
 
   beforeEach(() => {
-    act(() => ProjectsStore.loadInitialData(organization.projects));
+    act(() => ProjectsStore.loadInitialData(projects));
     endpointMock = MockApiClient.addMockResponse({
       url: '/organizations/org-slug/releases/',
       body: [
@@ -145,8 +145,8 @@ describe('ReleasesList', () => {
       name: 'test-name-2',
       features: [],
     });
-    const org = OrganizationFixture({projects: [project, projectWithouReleases]});
-    ProjectsStore.loadInitialData(org.projects);
+    const org = OrganizationFixture();
+    ProjectsStore.loadInitialData([project, projectWithouReleases]);
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/releases/',
       body: [],

--- a/static/app/views/settings/organizationMembers/organizationMemberDetail.spec.tsx
+++ b/static/app/views/settings/organizationMembers/organizationMemberDetail.spec.tsx
@@ -102,7 +102,7 @@ describe('OrganizationMemberDetail', function () {
   });
 
   describe('Can Edit', function () {
-    const organization = OrganizationFixture({teams, features: ['team-roles']});
+    const organization = OrganizationFixture({features: ['team-roles']});
 
     beforeEach(function () {
       TeamStore.init();
@@ -275,7 +275,7 @@ describe('OrganizationMemberDetail', function () {
   });
 
   describe('Cannot Edit', function () {
-    const organization = OrganizationFixture({teams, access: ['org:read']});
+    const organization = OrganizationFixture({access: ['org:read']});
 
     beforeEach(function () {
       TeamStore.init();
@@ -322,7 +322,7 @@ describe('OrganizationMemberDetail', function () {
   });
 
   describe('Display status', function () {
-    const organization = OrganizationFixture({teams, access: ['org:read']});
+    const organization = OrganizationFixture({access: ['org:read']});
 
     beforeEach(function () {
       TeamStore.init();
@@ -384,7 +384,7 @@ describe('OrganizationMemberDetail', function () {
   });
 
   describe('Show resend button', function () {
-    const organization = OrganizationFixture({teams, access: ['org:read']});
+    const organization = OrganizationFixture({access: ['org:read']});
 
     beforeEach(function () {
       TeamStore.init();
@@ -490,7 +490,7 @@ describe('OrganizationMemberDetail', function () {
       }),
     });
 
-    const organization = OrganizationFixture({teams});
+    const organization = OrganizationFixture();
 
     beforeEach(function () {
       MockApiClient.clearMockResponses();
@@ -673,7 +673,7 @@ describe('OrganizationMemberDetail', function () {
       ...teamAssignment,
     });
 
-    const organization = OrganizationFixture({teams, features: ['team-roles']});
+    const organization = OrganizationFixture({features: ['team-roles']});
 
     beforeEach(() => {
       MockApiClient.clearMockResponses();

--- a/static/app/views/userFeedback/index.spec.tsx
+++ b/static/app/views/userFeedback/index.spec.tsx
@@ -88,9 +88,7 @@ describe('UserFeedback', function () {
     });
 
     const params = {
-      organization: OrganizationFixture({
-        projects: [ProjectFixture({isMember: true})],
-      }),
+      organization: OrganizationFixture({}),
       params: {
         orgId: organization.slug,
       },
@@ -109,9 +107,7 @@ describe('UserFeedback', function () {
 
     const params = {
       ...routeProps,
-      organization: OrganizationFixture({
-        projects: [ProjectFixture({isMember: true})],
-      }),
+      organization: OrganizationFixture({}),
       location: {
         ...routeProps.location,
         pathname: 'sentry',
@@ -129,9 +125,7 @@ describe('UserFeedback', function () {
 
   it('renders issue status filter', async function () {
     const params = {
-      organization: OrganizationFixture({
-        projects: [ProjectFixture({isMember: true})],
-      }),
+      organization: OrganizationFixture(),
       params: {
         orgId: organization.slug,
       },
@@ -163,9 +157,7 @@ describe('UserFeedback', function () {
 
     const params = {
       ...routeProps,
-      organization: OrganizationFixture({
-        projects: [ProjectFixture({isMember: true})],
-      }),
+      organization: OrganizationFixture(),
       location: {
         ...routeProps.location,
         pathname: 'sentry',


### PR DESCRIPTION
Our tests fixture was still using the very old "DetailedOrganization"
object. We no longer include the projects or teams fields on
organizations, this removes all usages of those fields in tests