### PR TITLE
Adding transfer project note.

### DIFF
--- a/static/app/views/settings/projectGeneralSettings/index.tsx
+++ b/static/app/views/settings/projectGeneralSettings/index.tsx
@@ -221,7 +221,7 @@ class ProjectGeneralSettings extends DeprecatedAsyncView<Props, State> {
                 </TextBlock>
                 <TextBlock>
                   {t(
-                    'Please enter the email of an organization owner to whom you would like to transfer this project.'
+                    'Please enter the email of an organization owner to whom you would like to transfer this project. Note: It is not possible to transfer projects between organisations in different regions.'
                   )}
                 </TextBlock>
                 <Panel>

--- a/static/app/views/settings/projectGeneralSettings/index.tsx
+++ b/static/app/views/settings/projectGeneralSettings/index.tsx
@@ -221,7 +221,7 @@ class ProjectGeneralSettings extends DeprecatedAsyncView<Props, State> {
                 </TextBlock>
                 <TextBlock>
                   {t(
-                    'Please enter the email of an organization owner to whom you would like to transfer this project. Note: It is not possible to transfer projects between organisations in different regions.'
+                    'Please enter the email of an organization owner to whom you would like to transfer this project. Note: It is not possible to transfer projects between organizations in different regions.'
                   )}
                 </TextBlock>
                 <Panel>


### PR DESCRIPTION
Adding a note to the transfer project pop up informing users it is not possible to transfer projects between regions.