### PR TITLE
fix(query-builder): Fix bug where the menu stayed open after searching

### DIFF
--- a/static/app/components/searchQueryBuilder/combobox.tsx
+++ b/static/app/components/searchQueryBuilder/combobox.tsx
@@ -11,7 +11,7 @@ import {
 import isPropValid from '@emotion/is-prop-valid';
 import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
-import {useComboBox} from '@react-aria/combobox';
+import {type AriaComboBoxProps, useComboBox} from '@react-aria/combobox';
 import type {AriaListBoxOptions} from '@react-aria/listbox';
 import {type ComboBoxState, useComboBoxState} from '@react-stately/combobox';
 import type {CollectionChildren, Key, KeyboardEvent} from '@react-types/shared';
@@ -329,25 +329,27 @@ function SearchQueryBuilderComboboxInner<T extends SelectOptionOrSectionWithKey<
     [items, onOptionSelected]
   );
 
-  const state = useComboBoxState<T>({
-    children,
+  const comboBoxProps: Partial<AriaComboBoxProps<T>> = {
     items,
     autoFocus,
     inputValue: filterValue,
     onSelectionChange,
+    allowsCustomValue: true,
     disabledKeys,
+  };
+
+  const state = useComboBoxState<T>({
+    children,
+    ...comboBoxProps,
   });
 
   const {inputProps, listBoxProps} = useComboBox<T>(
     {
+      ...comboBoxProps,
       'aria-label': inputLabel,
       listBoxRef,
       inputRef,
       popoverRef,
-      items,
-      inputValue: filterValue,
-      onSelectionChange,
-      autoFocus,
       onFocus: e => {
         if (openOnFocus) {
           state.open();

--- a/static/app/components/searchQueryBuilder/index.spec.tsx
+++ b/static/app/components/searchQueryBuilder/index.spec.tsx
@@ -482,11 +482,18 @@ describe('SearchQueryBuilder', function () {
     });
 
     it('can add free text by typing', async function () {
-      render(<SearchQueryBuilder {...defaultProps} />);
+      const mockOnSearch = jest.fn();
+      render(<SearchQueryBuilder {...defaultProps} onSearch={mockOnSearch} />);
 
       await userEvent.click(screen.getByRole('grid'));
       await userEvent.type(screen.getByRole('combobox'), 'some free text{enter}');
+      await waitFor(() => {
+        expect(mockOnSearch).toHaveBeenCalledWith('some free text');
+      });
+      // Should still have text in the input
       expect(screen.getByRole('combobox')).toHaveValue('some free text');
+      // Should have closed the menu
+      expect(screen.getByRole('combobox')).toHaveAttribute('aria-expanded', 'false');
     });
 
     it('can add a filter after some free text', async function () {


### PR DESCRIPTION
The bug could be replicated by typing in a partial match for a key like `issue` and pressing enter. Whenever you tried to close the menu, `useComboBox` would reopen it due to [this line](https://github.com/adobe/react-spectrum/blob/6e57855257f54738418f98c37efae798bf9fb4ad/packages/%40react-stately/combobox/src/useComboBoxState.ts#L198), which was being triggered because the input value is different from what useComboBox thinks it should be. The problem here is that we were using useComboBox without custom values. Once that is set to true, it works as expected.