### PR TITLE
fix(query-builder): Remove 'is' alias

### DIFF
--- a/static/app/stores/tagStore.tsx
+++ b/static/app/stores/tagStore.tsx
@@ -60,7 +60,6 @@ const storeConfig: TagStoreDefinition = {
 
     const tagCollection = {
       [FieldKey.IS]: {
-        alias: 'issue.status',
         key: FieldKey.IS,
         name: 'Status',
         values: isSuggestions,


### PR DESCRIPTION
To solve the `is is unresolved` issue, I added an alias to `issue.status`, but I am reverting that change because I don't think it's the right decision. We should keep the search keys the same as they are now and figure out some other solution to the `is is` problem.