### PR TITLE
fix(pinned-searches): Delete ALL groupsearchviews upon savedsearch deletion

### DIFF
--- a/src/sentry/api/endpoints/organization_pinned_searches.py
+++ b/src/sentry/api/endpoints/organization_pinned_searches.py
@@ -85,7 +85,5 @@ class OrganizationPinnedSearchEndpoint(OrganizationEndpoint):
             type=search_type.value,
             visibility=Visibility.OWNER_PINNED,
         ).delete()
-        GroupSearchView.objects.filter(
-            organization=organization, user_id=request.user.id, position=0
-        ).delete()
+        GroupSearchView.objects.filter(organization=organization, user_id=request.user.id).delete()
         return Response(status=204)

--- a/src/sentry/api/endpoints/organization_pinned_searches.py
+++ b/src/sentry/api/endpoints/organization_pinned_searches.py
@@ -65,7 +65,9 @@ class OrganizationPinnedSearchEndpoint(OrganizationEndpoint):
                 "query_sort": result["sort"],
             },
         )
-
+        # These groupsearchview entries are temporarily here to ensure that pinned searches
+        # are being dynamically upgraded to custom views until custom views are GA'd, at which
+        # point saved searches will be removed entirely, along with this endpoint.
         GroupSearchView.objects.create_or_update(
             organization=organization,
             user_id=request.user.id,

--- a/src/sentry/api/endpoints/organization_pinned_searches.py
+++ b/src/sentry/api/endpoints/organization_pinned_searches.py
@@ -65,6 +65,18 @@ class OrganizationPinnedSearchEndpoint(OrganizationEndpoint):
                 "query_sort": result["sort"],
             },
         )
+
+        GroupSearchView.objects.create_or_update(
+            organization=organization,
+            user_id=request.user.id,
+            position=1,
+            values={
+                "name": "Prioritized",
+                "query": "is:unresolved issue.priority:[high, medium]",
+                "query_sort": SortOptions.DATE,
+            },
+        )
+
         pinned_search = SavedSearch.objects.get(
             organization=organization,
             owner_id=request.user.id,

--- a/tests/sentry/api/endpoints/test_organization_pinned_searches.py
+++ b/tests/sentry/api/endpoints/test_organization_pinned_searches.py
@@ -45,6 +45,15 @@ class CreateOrganizationPinnedSearchTest(APITestCase):
             position=0,
         ).exists()
 
+        assert GroupSearchView.objects.filter(
+            organization=self.organization,
+            user_id=self.member.id,
+            position=1,
+            name="Prioritized",
+            query="is:unresolved issue.priority:[high, medium]",
+            query_sort="date",
+        ).exists()
+
         query = "test_2"
         self.get_success_response(type=search_type, query=query, sort=sort, status_code=201)
         assert SavedSearch.objects.filter(
@@ -185,7 +194,7 @@ class DeleteOrganizationPinnedSearchTest(APITestCase):
         self.get_success_response(type=saved_search.type, status_code=204)
         assert not SavedSearch.objects.filter(id=saved_search.id).exists()
         assert not GroupSearchView.objects.filter(
-            organization=self.organization, user_id=self.member.id, position=0
+            organization=self.organization, user_id=self.member.id
         ).exists()
 
     def test_invalid_type(self):


### PR DESCRIPTION
We need to ensure that users' saved searches are persisted as custom views, AND that those users with a persisted saved saerch also have a second "Priorizted" tab. This PR updates the pinned searches endpoint to maintain this consistency by deleting ALL groupsearchviews upon savedsearch deletion (as opposed to only the groupsearchview associated with the user's saved search), and adding/updating the "Prioritized" view when a saved search is added/updated. 


This needs to be merged before the savedsearch -> groupsearchview [backfill](https://github.com/getsentry/sentry/pull/71731) is run
