### PR TITLE
ref(slack): temporarily remove notify disable logic

### DIFF
--- a/src/sentry/integrations/slack/sdk_client.py
+++ b/src/sentry/integrations/slack/sdk_client.py
@@ -46,6 +46,7 @@ def is_response_fatal(response: SlackResponse) -> bool:
     return False
 
 
+# TODO: add this to the client somehow
 def record_response_for_disabling_integration(response: SlackResponse, integration_id: int) -> None:
     redis_key = f"sentry-integration-error:{integration_id}"
 
@@ -62,7 +63,7 @@ def record_response_for_disabling_integration(response: SlackResponse, integrati
         disable_integration(buffer, redis_key, integration_id)
 
 
-def wrapper(method: FunctionType, integration_id):
+def wrapper(method: FunctionType):
     @wraps(method)
     def wrapped(*args, **kwargs):
         if method.__name__ not in SLACK_SDK_WRAP_METHODS:
@@ -71,12 +72,9 @@ def wrapper(method: FunctionType, integration_id):
         try:
             response = method(*args, **kwargs)
             track_response_data(response=response, method=method.__name__)
-            record_response_for_disabling_integration(response, integration_id)
         except SlackApiError as e:
             if e.response:
                 track_response_data(response=e.response, error=str(e), method=method.__name__)
-
-                record_response_for_disabling_integration(e.response, integration_id)
             else:
                 logger.info("slack_sdk.missing_error_response", extra={"error": str(e)})
             raise
@@ -86,20 +84,20 @@ def wrapper(method: FunctionType, integration_id):
     return wrapped
 
 
-def wrap_methods_in_class(cls, integration_id):
+def wrap_methods_in_class(cls):
     for name, attribute in vars(cls).items():
         if isinstance(attribute, FunctionType):
-            setattr(cls, name, wrapper(attribute, integration_id))
+            setattr(cls, name, wrapper(attribute))
 
     for base in cls.__bases__:
-        wrap_methods_in_class(base, integration_id)
+        wrap_methods_in_class(base)
 
 
 class MetaClass(type):
-    def __call__(cls, *args, **kwargs):
-        obj = super().__call__(*args, **kwargs)
-        wrap_methods_in_class(cls, obj.integration_id)
-        return obj
+    def __new__(meta, name, bases, dct):
+        cls = super().__new__(meta, name, bases, dct)
+        wrap_methods_in_class(cls)
+        return cls
 
 
 class SlackSdkClient(WebClient, metaclass=MetaClass):

--- a/tests/sentry/integrations/slack/test_disable.py
+++ b/tests/sentry/integrations/slack/test_disable.py
@@ -1,19 +1,16 @@
 import time
 from datetime import datetime, timedelta
-from unittest.mock import patch
 
 import orjson
 import pytest
 import responses
 from django.core import mail
-from slack_sdk.errors import SlackApiError
 
 from sentry import audit_log
 from sentry.constants import ObjectStatus
 from sentry.integrations.notify_disable import notify_disable
 from sentry.integrations.request_buffer import IntegrationRequestBuffer
 from sentry.integrations.slack.client import SlackClient
-from sentry.integrations.slack.sdk_client import SlackSdkClient
 from sentry.models.auditlogentry import AuditLogEntry
 from sentry.models.integrations.integration import Integration
 from sentry.shared_integrations.exceptions import ApiError
@@ -69,29 +66,6 @@ class SlackClientDisable(TestCase):
         with outbox_runner(), self.tasks(), pytest.raises(ApiError):
             client.post("/chat.postMessage", data=self.payload)
         buffer = IntegrationRequestBuffer(client._get_redis_key())
-        with assume_test_silo_mode(SiloMode.CONTROL):
-            integration = Integration.objects.get(id=self.integration.id)
-            assert integration.status == ObjectStatus.DISABLED
-            assert [len(item) == 0 for item in buffer._get_broken_range_from_buffer()]
-            assert len(buffer._get_all_from_buffer()) == 0
-            assert AuditLogEntry.objects.filter(
-                event=audit_log.get_event_id("INTEGRATION_DISABLED"),
-                organization_id=self.organization.id,
-            ).exists()
-
-    @patch("slack_sdk.web.client.WebClient._perform_urllib_http_request")
-    def test_fatal_and_disable_integration_sdk(self, mock_api_call):
-        mock_api_call.return_value = {
-            "body": orjson.dumps({"ok": False, "error": "account_inactive"}).decode(),
-            "headers": {},
-            "status": 200,
-        }
-
-        client = SlackSdkClient(integration_id=self.integration.id)
-
-        with outbox_runner(), self.tasks(), pytest.raises(SlackApiError):
-            client.chat_postMessage(channel=self.payload["channel"], text=self.payload["message"])
-        buffer = IntegrationRequestBuffer(f"sentry-integration-error:{self.integration.id}")
         with assume_test_silo_mode(SiloMode.CONTROL):
             integration = Integration.objects.get(id=self.integration.id)
             assert integration.status == ObjectStatus.DISABLED


### PR DESCRIPTION
There are a few issues happening that are all `TimeoutErrors` for the new client. We are wrapping all the methods in the SDK client upon initializing a new class in order to account for the notify disable logic (since we want to track the responses for a specific `integration_id`, which we do not have until initialization), but this can take too long as seen in SENTRY-3AQ2, SENTRY-3ANH, and SENTRY-3ANH.

The new client is only used in a few places, and I suspect the timeouts will become widespread when we completely replace the old `SlackClient`.

The original logic had the wrapping happen when the class is declared to track the slack response status codes, and this happens once at compile time. We can revert to this for now and look into the notify disable logic later, since we will likely have to have a similar solution for the MSTeams SDK client.