### PR TITLE
fix(query-builder): Handle escapes in wildcard optimization

### DIFF
--- a/tests/sentry/api/endpoints/test_organization_spans_fields.py
+++ b/tests/sentry/api/endpoints/test_organization_spans_fields.py
@@ -133,7 +133,7 @@ class OrganizationSpansTagKeyValuesEndpointTest(BaseSpansTestCase, APITestCase):
 
     def test_tags_keys_autocomplete_default(self):
         timestamp = before_now(days=0, minutes=10).replace(microsecond=0)
-        for tag in ["foo", "bar", "baz"]:
+        for tag in ["foo", "*bar", "*baz"]:
             self.store_segment(
                 self.project.id,
                 uuid4().hex,
@@ -154,16 +154,16 @@ class OrganizationSpansTagKeyValuesEndpointTest(BaseSpansTestCase, APITestCase):
                 {
                     "count": 1,
                     "key": key,
-                    "value": "bar",
-                    "name": "bar",
+                    "value": "*bar",
+                    "name": "*bar",
                     "firstSeen": timestamp.strftime("%Y-%m-%dT%H:%M:%S+00:00"),
                     "lastSeen": timestamp.strftime("%Y-%m-%dT%H:%M:%S+00:00"),
                 },
                 {
                     "count": 1,
                     "key": key,
-                    "value": "baz",
-                    "name": "baz",
+                    "value": "*baz",
+                    "name": "*baz",
                     "firstSeen": timestamp.strftime("%Y-%m-%dT%H:%M:%S+00:00"),
                     "lastSeen": timestamp.strftime("%Y-%m-%dT%H:%M:%S+00:00"),
                 },
@@ -177,22 +177,28 @@ class OrganizationSpansTagKeyValuesEndpointTest(BaseSpansTestCase, APITestCase):
                 },
             ]
 
-            response = self.do_request(key, query={"query": "b"})
+        for key, query in [
+            ("tag", "b"),
+            ("transaction", "b"),
+            ("tag", r"\*b"),
+            ("transaction", r"\*b"),
+        ]:
+            response = self.do_request(key, query={"query": query})
             assert response.status_code == 200, response.data
             assert response.data == [
                 {
                     "count": 1,
                     "key": key,
-                    "value": "bar",
-                    "name": "bar",
+                    "value": "*bar",
+                    "name": "*bar",
                     "firstSeen": timestamp.strftime("%Y-%m-%dT%H:%M:%S+00:00"),
                     "lastSeen": timestamp.strftime("%Y-%m-%dT%H:%M:%S+00:00"),
                 },
                 {
                     "count": 1,
                     "key": key,
-                    "value": "baz",
-                    "name": "baz",
+                    "value": "*baz",
+                    "name": "*baz",
                     "firstSeen": timestamp.strftime("%Y-%m-%dT%H:%M:%S+00:00"),
                     "lastSeen": timestamp.strftime("%Y-%m-%dT%H:%M:%S+00:00"),
                 },


### PR DESCRIPTION
This was not handling escape sequences like `\*` within the search well and adding extra `\` to the condition.