### PR TITLE
chore(insights): Remove special handling of LLM module

### DIFF
--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -1437,16 +1437,16 @@ function buildRoutes() {
     </Route>
   );
 
-  const llmMonitoringRoutes = (
-    <Route path={`/${MODULE_BASE_URLS[ModuleName.AI]}/`} withOrgPath>
-      <IndexRoute component={make(() => import('sentry/views/llmMonitoring/landing'))} />
-      <Route
-        path="pipeline-type/:groupId/"
-        component={make(
-          () => import('sentry/views/llmMonitoring/llmMonitoringDetailsPage')
-        )}
-      />
-    </Route>
+  const llmMonitoringRoutes = USING_CUSTOMER_DOMAIN ? (
+    <Redirect
+      from="/llm-monitoring/"
+      to={`/insights/${MODULE_BASE_URLS[ModuleName.AI]}/`}
+    />
+  ) : (
+    <Redirect
+      from="/organizations/:orgId/llm-monitoring/"
+      to="/organizations/:orgId/insights/llm-monitoring/"
+    />
   );
 
   const insightsSubRoutes = (

--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -1445,7 +1445,7 @@ function buildRoutes() {
   ) : (
     <Redirect
       from="/organizations/:orgId/llm-monitoring/"
-      to="/organizations/:orgId/insights/llm-monitoring/"
+      to={`/organizations/:orgId/insights/${MODULE_BASE_URLS[ModuleName.AI]}/`}
     />
   );
 

--- a/static/app/views/performance/modulePageProviders.tsx
+++ b/static/app/views/performance/modulePageProviders.tsx
@@ -29,7 +29,7 @@ export function ModulePageProviders({moduleName, pageTitle, children, features}:
   const location = useLocation();
   const navigate = useNavigate();
 
-  const insightsTitle = useInsightsTitle(moduleName);
+  const insightsTitle = useInsightsTitle();
   const moduleTitle = useModuleTitle(moduleName);
 
   const fullPageTitle = [pageTitle, moduleTitle, insightsTitle]

--- a/static/app/views/performance/utils/useInsightsTitle.tsx
+++ b/static/app/views/performance/utils/useInsightsTitle.tsx
@@ -1,17 +1,10 @@
 import {t} from 'sentry/locale';
 import useOrganization from 'sentry/utils/useOrganization';
-import {ModuleName} from 'sentry/views/starfish/types';
 
-type ModuleNameStrings = `${ModuleName}`;
-type TitleableModuleNames = Exclude<ModuleNameStrings, '' | 'other'>;
-
-export function useInsightsTitle(moduleName: TitleableModuleNames) {
+export function useInsightsTitle() {
   const organization = useOrganization();
 
-  // If `insights` flag is present, the top-most title is "Insights". If it's absent, for LLM the topmost title is missing, and for other Insights modules it's "Performance"
   return organization?.features?.includes('performance-insights')
     ? t('Insights')
-    : moduleName === ModuleName.AI
-      ? ''
-      : t('Performance');
+    : t('Performance');
 }

--- a/static/app/views/performance/utils/useInsightsURL.tsx
+++ b/static/app/views/performance/utils/useInsightsURL.tsx
@@ -1,25 +1,18 @@
 import useOrganization from 'sentry/utils/useOrganization';
-import {ModuleName} from 'sentry/views/starfish/types';
 
-type ModuleNameStrings = `${ModuleName}`;
-type RoutableModuleNames = Exclude<ModuleNameStrings, '' | 'other'>;
-
-export function useInsightsURL(moduleName: RoutableModuleNames) {
+export function useInsightsURL() {
   const builder = useInsightsURLBuilder();
-  return builder(moduleName);
+  return builder();
 }
 
-type URLBuilder = (moduleName: RoutableModuleNames) => string;
+type URLBuilder = () => string;
 
 export function useInsightsURLBuilder(): URLBuilder {
   const organization = useOrganization({allowNull: true}); // Some parts of the app, like the main sidebar, render even if the organization isn't available (during loading, or at all).
 
-  return function (moduleName: RoutableModuleNames) {
-    // If `insights` flag is present, all Insights modules are routed from `/insights`. If the flag is absent, LLM is routed from `/` and other insights modules are routed of `/performance`
+  return function () {
     return organization?.features?.includes('performance-insights')
       ? 'insights'
-      : moduleName === ModuleName.AI
-        ? ''
-        : 'performance';
+      : 'performance';
   };
 }

--- a/static/app/views/performance/utils/useModuleBreadcrumbs.tsx
+++ b/static/app/views/performance/utils/useModuleBreadcrumbs.tsx
@@ -14,7 +14,7 @@ export function useModuleBreadcrumbs(moduleName: RoutableModuleNames): Crumb[] {
   const organization = useOrganization();
 
   const insightsURL = useInsightsURL(moduleName);
-  const insightsTitle = useInsightsTitle(moduleName);
+  const insightsTitle = useInsightsTitle();
 
   const moduleLabel = useModuleTitle(moduleName);
   const moduleTo = useModuleURL(moduleName);

--- a/static/app/views/performance/utils/useModuleBreadcrumbs.tsx
+++ b/static/app/views/performance/utils/useModuleBreadcrumbs.tsx
@@ -13,7 +13,7 @@ type RoutableModuleNames = Exclude<ModuleNameStrings, '' | 'other'>;
 export function useModuleBreadcrumbs(moduleName: RoutableModuleNames): Crumb[] {
   const organization = useOrganization();
 
-  const insightsURL = useInsightsURL(moduleName);
+  const insightsURL = useInsightsURL();
   const insightsTitle = useInsightsTitle();
 
   const moduleLabel = useModuleTitle(moduleName);

--- a/static/app/views/performance/utils/useModuleBreadcrumbs.tsx
+++ b/static/app/views/performance/utils/useModuleBreadcrumbs.tsx
@@ -5,7 +5,7 @@ import {useInsightsTitle} from 'sentry/views/performance/utils/useInsightsTitle'
 import {useInsightsURL} from 'sentry/views/performance/utils/useInsightsURL';
 import {useModuleTitle} from 'sentry/views/performance/utils/useModuleTitle';
 import {useModuleURL} from 'sentry/views/performance/utils/useModuleURL';
-import {ModuleName} from 'sentry/views/starfish/types';
+import type {ModuleName} from 'sentry/views/starfish/types';
 
 type ModuleNameStrings = `${ModuleName}`;
 type RoutableModuleNames = Exclude<ModuleNameStrings, '' | 'other'>;
@@ -19,7 +19,6 @@ export function useModuleBreadcrumbs(moduleName: RoutableModuleNames): Crumb[] {
   const moduleLabel = useModuleTitle(moduleName);
   const moduleTo = useModuleURL(moduleName);
 
-  // If `insights` flag is present, the root crumb is "Insights". If it's absent, LLMs base crumb is nothing, and other Insights modules base breadcrumb is "Performance"
   return organization?.features?.includes('performance-insights')
     ? [
         {
@@ -33,24 +32,16 @@ export function useModuleBreadcrumbs(moduleName: RoutableModuleNames): Crumb[] {
           preservePageFilters: true,
         },
       ]
-    : moduleName === ModuleName.AI
-      ? [
-          {
-            label: moduleLabel,
-            to: moduleTo,
-            preservePageFilters: true,
-          },
-        ]
-      : [
-          {
-            label: insightsTitle,
-            to: normalizeUrl(`/organizations/${organization.slug}/${insightsURL}/`),
-            preservePageFilters: true,
-          },
-          {
-            label: moduleLabel,
-            to: moduleTo,
-            preservePageFilters: true,
-          },
-        ];
+    : [
+        {
+          label: insightsTitle,
+          to: normalizeUrl(`/organizations/${organization.slug}/${insightsURL}/`),
+          preservePageFilters: true,
+        },
+        {
+          label: moduleLabel,
+          to: moduleTo,
+          preservePageFilters: true,
+        },
+      ];
 }

--- a/static/app/views/performance/utils/useModuleURL.tsx
+++ b/static/app/views/performance/utils/useModuleURL.tsx
@@ -54,16 +54,7 @@ export function useModuleURLBuilder(bare: boolean = false): URLBuilder {
   const {slug} = organization;
 
   return function (moduleName: RoutableModuleNames) {
-    const insightsURL = insightsURLBuilder(moduleName);
-
-    if (moduleName === ModuleName.AI) {
-      // AI Doesn't live under "/performance", which means `insightsURL` might be an empty string, so we need to account for that
-      const moduleURLSegment = [insightsURL, AI_BASE_URL].filter(Boolean).join('/');
-
-      return bare
-        ? moduleURLSegment
-        : normalizeUrl(`/organizations/${slug}/${moduleURLSegment}`);
-    }
+    const insightsURL = insightsURLBuilder();
 
     return bare
       ? `${insightsURL}/${MODULE_BASE_URLS[moduleName]}`


### PR DESCRIPTION
LLM module is in Open Beta! Which means:

1. It always and only lives at `/insights/llm-monitoring/`
2. Its breadcrumb always says "Insights -> LLM Monitoring"
3. Its title is always "Insights > LLM Monitoring"

No need for special conditions in the UI. Also adding a permanent redirect from `'/llm-monitoring/'` to `'/insights/llm-monitoring/'` which might not be necessary but seems like a good idea.
