### PR TITLE
fix(query-builder): Fix bug where the menu closes when clicking and dragging scrollbar

### DIFF
--- a/static/app/components/searchQueryBuilder/combobox.tsx
+++ b/static/app/components/searchQueryBuilder/combobox.tsx
@@ -340,6 +340,9 @@ function SearchQueryBuilderComboboxInner<T extends SelectOptionOrSectionWithKey<
 
   const state = useComboBoxState<T>({
     children,
+    // We handle closing on blur ourselves to prevent the combobox from closing
+    // when the user clicks inside the tabbed menu
+    shouldCloseOnBlur: false,
     ...comboBoxProps,
   });
 
@@ -356,7 +359,10 @@ function SearchQueryBuilderComboboxInner<T extends SelectOptionOrSectionWithKey<
         }
         onFocus?.(e);
       },
-      onBlur: () => {
+      onBlur: e => {
+        if (e.relatedTarget && !shouldCloseOnInteractOutside?.(e.relatedTarget)) {
+          return;
+        }
         onCustomValueBlurred(inputValue);
         state.close();
       },

--- a/static/app/components/searchQueryBuilder/input.tsx
+++ b/static/app/components/searchQueryBuilder/input.tsx
@@ -35,6 +35,7 @@ type SearchQueryBuilderInputProps = {
 
 type SearchQueryBuilderInputInternalProps = {
   item: Node<ParseResultToken>;
+  rowRef: React.RefObject<HTMLDivElement>;
   state: ListState<ParseResultToken>;
   tabIndex: number;
   token: TokenResult<Token.FREE_TEXT> | TokenResult<Token.SPACES>;
@@ -218,6 +219,7 @@ function SearchQueryBuilderInputInternal({
   token,
   tabIndex,
   state,
+  rowRef,
 }: SearchQueryBuilderInputInternalProps) {
   const trimmedTokenValue = token.text.trim();
   const [inputValue, setInputValue] = useState(trimmedTokenValue);
@@ -371,6 +373,12 @@ function SearchQueryBuilderInputInternal({
       maxOptions={50}
       onPaste={onPaste}
       displayTabbedMenu={inputValue.length === 0}
+      shouldCloseOnInteractOutside={el => {
+        if (rowRef.current?.contains(el)) {
+          return false;
+        }
+        return true;
+      }}
     >
       {section => (
         <Section title={section.title} key={section.key}>
@@ -405,6 +413,7 @@ export function SearchQueryBuilderInput({
           state={state}
           token={token}
           tabIndex={isFocused ? 0 : -1}
+          rowRef={ref}
         />
       </GridCell>
     </Row>


### PR DESCRIPTION
For some reason `useCombobox` doesn't consider the scrollbar within the tabbed menu as part of the combobox and will close the menu due to the blur event. I've disabled closing on blur and implement it ourselves instead. Now you can click and drag the scrollbar as expected without the menu closing.