### PR TITLE
fix(query-builder): Fix bug where menu state is closed but displays as open

### DIFF
--- a/static/app/components/searchQueryBuilder/combobox.tsx
+++ b/static/app/components/searchQueryBuilder/combobox.tsx
@@ -137,7 +137,7 @@ function menuIsOpen({
     0
   );
 
-  return totalOptions > hiddenOptions.size;
+  return state.isOpen && totalOptions > hiddenOptions.size;
 }
 
 function useHiddenItems<T extends SelectOptionOrSectionWithKey<string>>({

--- a/static/app/components/searchQueryBuilder/index.spec.tsx
+++ b/static/app/components/searchQueryBuilder/index.spec.tsx
@@ -326,7 +326,6 @@ describe('SearchQueryBuilder', function () {
         'placeholder',
         '-1d'
       );
-      await userEvent.click(screen.getByRole('combobox', {name: 'Edit filter value'}));
 
       // Clicking the "-14d" option should update the value
       await userEvent.click(await screen.findByRole('option', {name: '-14d'}));
@@ -360,7 +359,6 @@ describe('SearchQueryBuilder', function () {
           'firefox,'
         )
       ).toBeInTheDocument();
-      await userEvent.click(screen.getByRole('combobox', {name: 'Edit filter value'}));
 
       // Clicking the "Chrome option should add it to the list and commit changes
       await userEvent.click(screen.getByRole('option', {name: 'Chrome'}));
@@ -474,7 +472,6 @@ describe('SearchQueryBuilder', function () {
       // New token should be added with the correct key
       expect(screen.getByRole('row', {name: 'browser.name:'})).toBeInTheDocument();
 
-      await userEvent.click(screen.getByRole('combobox', {name: 'Edit filter value'}));
       await userEvent.click(screen.getByRole('option', {name: 'Firefox'}));
 
       // New token should have a value


### PR DESCRIPTION
Followup to https://github.com/getsentry/sentry/pull/72776

Missed one extra part that was missing - the test was checking the state of the menu, but the component was actually ignoring that state erroneously. Added the check for the state and it all works as expected.