### PR TITLE
Incident subscription fk - don't cascade delete

### DIFF
--- a/src/sentry/incidents/models/incident.py
+++ b/src/sentry/incidents/models/incident.py
@@ -212,7 +212,9 @@ class Incident(Model):
     activation = FlexibleForeignKey(
         "sentry.AlertRuleActivations", on_delete=models.SET_NULL, null=True
     )
-    subscription = FlexibleForeignKey("sentry.QuerySubscription", null=True)
+    subscription = FlexibleForeignKey(
+        "sentry.QuerySubscription", on_delete=models.SET_NULL, null=True
+    )
 
     class Meta:
         app_label = "sentry"

--- a/src/sentry/migrations/0730_add_subscription_fk_to_incident.py
+++ b/src/sentry/migrations/0730_add_subscription_fk_to_incident.py
@@ -70,7 +70,7 @@ class Migration(CheckedMigration):
             name="subscription",
             field=sentry.db.models.fields.foreignkey.FlexibleForeignKey(
                 null=True,
-                on_delete=django.db.models.deletion.CASCADE,
+                on_delete=django.db.models.deletion.SET_NULL,
                 to="sentry.querysubscription",
             ),
         ),

--- a/tests/sentry/migrations/test_0730_add_subscription_fk_to_incident.py
+++ b/tests/sentry/migrations/test_0730_add_subscription_fk_to_incident.py
@@ -140,6 +140,7 @@ class AlertRuleProjectBackfillTest(TestMigrations):
 
         self.query_subscription.delete()
         self.incident.refresh_from_db()
+        assert self.incident
         assert self.incident.subscription is None
 
         self.incident_existing_sub.refresh_from_db()

--- a/tests/sentry/migrations/test_0730_add_subscription_fk_to_incident.py
+++ b/tests/sentry/migrations/test_0730_add_subscription_fk_to_incident.py
@@ -138,6 +138,10 @@ class AlertRuleProjectBackfillTest(TestMigrations):
         assert self.incident.subscription is not None
         assert self.incident.subscription == self.query_subscription
 
+        self.query_subscription.delete()
+        self.incident.refresh_from_db()
+        assert self.incident.subscription is None
+
         self.incident_existing_sub.refresh_from_db()
         assert self.incident_existing_sub.subscription is not None
         assert self.incident_existing_sub.subscription == self.query_subscription_existing_sub


### PR DESCRIPTION
Inciden'ts should not be deleted when subscriptions are deleted

editing the migration should be fine since this migration is applied post_deployment