### PR TITLE
fix(performance): Fix score colors on perf landing

### DIFF
--- a/static/app/views/performance/landing/widgets/widgets/performanceScoreListWidget.tsx
+++ b/static/app/views/performance/landing/widgets/widgets/performanceScoreListWidget.tsx
@@ -63,7 +63,7 @@ export function PerformanceScoreListWidget(props: PerformanceWidgetProps) {
   const order = ORDER_WITH_INP_WITHOUT_FID;
 
   const getAreaChart = _ => {
-    const segmentColors = theme.charts.getColorPalette(3);
+    const segmentColors = theme.charts.getColorPalette(3).slice(0, 5);
     return (
       <Chart
         stacked
@@ -85,6 +85,7 @@ export function PerformanceScoreListWidget(props: PerformanceWidgetProps) {
         }}
         dataMax={100}
         chartColors={segmentColors}
+        hideYAxisSplitLine
       />
     );
   };


### PR DESCRIPTION
Fix score chart colors on the performance landing page.
Normally we only have 5 series so we only need 5 colors. `theme.charts.getColorPalette(3)` actually gives us 6 colors. We don't need the last color so we can trim it off. This is a fix because we now have 10 series and we wrap around the `segmentColors` array when our series exceeds the number of colors. 