### PR TITLE
ref: remove OptionMixin

### DIFF
--- a/src/sentry/models/options/option.py
+++ b/src/sentry/models/options/option.py
@@ -1,22 +1,12 @@
 from __future__ import annotations
 
-import abc
-
 from django.db import models
 from django.utils import timezone
 
 from sentry.backup.dependencies import PrimaryKeyMap
 from sentry.backup.mixins import OverwritableConfigMixin
 from sentry.backup.scopes import RelocationScope
-from sentry.db.models import (
-    Model,
-    OptionManager,
-    ValidateFunction,
-    Value,
-    control_silo_model,
-    region_silo_model,
-    sane_repr,
-)
+from sentry.db.models import Model, control_silo_model, region_silo_model, sane_repr
 from sentry.db.models.fields.picklefield import PickledObjectField
 from sentry.options.manager import UpdateChannel
 
@@ -81,43 +71,3 @@ class ControlOption(BaseOption):
         db_table = "sentry_controloption"
 
     __repr__ = sane_repr("key", "value")
-
-
-class HasOption:
-    # Logically this is an abstract interface. Leaving off abc.ABC because it clashes
-    # with the Model metaclass.
-
-    @abc.abstractmethod
-    def get_option(
-        self,
-        key: str,
-        default: Value | None = None,
-        validate: ValidateFunction | None = None,
-    ) -> Value:
-        raise NotImplementedError
-
-    @abc.abstractmethod
-    def update_option(self, key: str, value: Value) -> bool:
-        raise NotImplementedError
-
-    @abc.abstractmethod
-    def delete_option(self, key: str) -> None:
-        raise NotImplementedError
-
-
-class OptionMixin(HasOption):
-    @property
-    @abc.abstractmethod
-    def option_manager(self) -> OptionManager:
-        raise NotImplementedError
-
-    def get_option(
-        self, key: str, default: Value | None = None, validate: ValidateFunction | None = None
-    ) -> Value:
-        return self.option_manager.get_value(self, key, default, validate)
-
-    def update_option(self, key: str, value: Value) -> bool:
-        return self.option_manager.set_value(self, key, value)
-
-    def delete_option(self, key: str) -> None:
-        self.option_manager.unset_value(self, key)

--- a/src/sentry/models/project.py
+++ b/src/sentry/models/project.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 from collections import defaultdict
 from collections.abc import Collection, Iterable, Mapping
-from typing import TYPE_CHECKING, ClassVar
+from typing import TYPE_CHECKING, Any, ClassVar
 from uuid import uuid1
 
 import sentry_sdk
@@ -27,16 +27,14 @@ from sentry.db.models import (
     BoundedPositiveIntegerField,
     FlexibleForeignKey,
     Model,
-    OptionManager,
-    Value,
     region_silo_model,
     sane_repr,
 )
 from sentry.db.models.fields.slug import SentrySlugField
+from sentry.db.models.manager import ValidateFunction
 from sentry.db.models.utils import slugify_instance
 from sentry.locks import locks
 from sentry.models.grouplink import GroupLink
-from sentry.models.options.option import OptionMixin
 from sentry.models.outbox import OutboxCategory, OutboxScope, RegionOutbox, outbox_context
 from sentry.models.team import Team
 from sentry.monitors.models import MonitorEnvironment, MonitorStatus
@@ -52,6 +50,7 @@ from sentry.utils.retries import TimedRetryPolicy
 from sentry.utils.snowflake import save_with_snowflake_id, snowflake_id_model
 
 if TYPE_CHECKING:
+    from sentry.models.options.project_option import ProjectOptionManager
     from sentry.models.user import User
 
 SENTRY_USE_SNOWFLAKE = getattr(settings, "SENTRY_USE_SNOWFLAKE", False)
@@ -217,7 +216,7 @@ class ProjectManager(BaseManager["Project"]):
 
 @snowflake_id_model
 @region_silo_model
-class Project(Model, PendingDeletionMixin, OptionMixin):
+class Project(Model, PendingDeletionMixin):
     from sentry.models.projectteam import ProjectTeam
 
     """
@@ -374,18 +373,23 @@ class Project(Model, PendingDeletionMixin, OptionMixin):
         return False
 
     @property
-    def option_manager(self) -> OptionManager:
+    def option_manager(self) -> ProjectOptionManager:
         from sentry.models.options.project_option import ProjectOption
 
         return ProjectOption.objects
 
-    def update_option(self, key: str, value: Value) -> bool:
+    def get_option(
+        self, key: str, default: Any | None = None, validate: ValidateFunction | None = None
+    ) -> Any:
+        return self.option_manager.get_value(self, key, default, validate)
+
+    def update_option(self, key: str, value: Any) -> bool:
         projectoptions.update_rev_for_option(self)
-        return super().update_option(key, value)
+        return self.option_manager.set_value(self, key, value)
 
     def delete_option(self, key: str) -> None:
         projectoptions.update_rev_for_option(self)
-        super().delete_option(key)
+        self.option_manager.unset_value(self, key)
 
     def update_rev_for_option(self):
         return projectoptions.update_rev_for_option(self)

--- a/src/sentry/services/hybrid_cloud/organization/model.py
+++ b/src/sentry/services/hybrid_cloud/organization/model.py
@@ -13,7 +13,6 @@ from pydantic import Field
 
 from sentry import roles
 from sentry.db.models import ValidateFunction, Value
-from sentry.models.options.option import HasOption
 from sentry.roles import team_roles
 from sentry.roles.manager import TeamRole
 from sentry.services.hybrid_cloud import RpcModel
@@ -194,7 +193,7 @@ class RpcOrganizationInvite(RpcModel):
     email: str = ""
 
 
-class RpcOrganizationSummary(RpcModel, OrganizationAbsoluteUrlMixin, HasOption):
+class RpcOrganizationSummary(RpcModel, OrganizationAbsoluteUrlMixin):
     """
     The subset of organization metadata available from the control silo specifically.
     """

--- a/src/sentry/services/hybrid_cloud/project/model.py
+++ b/src/sentry/services/hybrid_cloud/project/model.py
@@ -10,7 +10,6 @@ from pydantic.fields import Field
 
 from sentry.constants import ObjectStatus
 from sentry.db.models import ValidateFunction, Value
-from sentry.models.options.option import HasOption
 from sentry.services.hybrid_cloud import OptionValue, RpcModel
 
 
@@ -22,7 +21,7 @@ class ProjectFilterArgs(TypedDict, total=False):
     project_ids: list[int]
 
 
-class RpcProject(RpcModel, HasOption):
+class RpcProject(RpcModel):
     id: int = -1
     slug: str = ""
     name: str = ""


### PR DESCRIPTION
this fixes types for the various models involved

mixins aren't sound in typing unless they have an associated protocol -- and even then there aren't dependent types so this mixin couldn't possibly be typed properly.  it also wasn't being used at runtime either so it was easier to just write the methods directly in the two subclasses

<!-- Describe your PR here. -->