### PR TITLE
fix(query-builder): Escape tag values more consistently

### DIFF
--- a/static/app/components/searchQueryBuilder/valueCombobox.tsx
+++ b/static/app/components/searchQueryBuilder/valueCombobox.tsx
@@ -337,7 +337,7 @@ function getOtherSelectedValues(token: TokenResult<Token.FILTER>): string[] {
 function cleanFilterValue(key: string, value: string): string {
   const fieldDef = getFieldDefinition(key);
   if (!fieldDef) {
-    return value;
+    return escapeTagValue(value);
   }
 
   switch (fieldDef.valueType) {


### PR DESCRIPTION
When we don't have the field definition, we should still escape the tag value. This fixes a bug where tag values with spaces would spill out of the filter.