### PR TITLE
frontend(remote_config): add warning about storing secrets in features

### DIFF
--- a/static/app/components/modals/remoteConfigCreateFeatureModal.tsx
+++ b/static/app/components/modals/remoteConfigCreateFeatureModal.tsx
@@ -2,6 +2,7 @@ import {Fragment} from 'react';
 import {css} from '@emotion/react';
 
 import type {ModalRenderProps} from 'sentry/actionCreators/modal';
+import Alert from 'sentry/components/alert';
 import FieldFromConfig from 'sentry/components/forms/fieldFromConfig';
 import Form from 'sentry/components/forms/form';
 import type {Field} from 'sentry/components/forms/types';
@@ -42,6 +43,11 @@ export default function RemoteConfigCreateFeatureModal({
         <h4>{t('Add Remote Config Feature')}</h4>
       </Header>
       <Body>
+        <Alert type="warning" showIcon>
+          {t(
+            'Feature keys and values are publicly readable with your DSN. Do NOT store secrets or sensitive information here.'
+          )}
+        </Alert>
         <Form
           submitLabel={t('Add')}
           cancelLabel={t('Cancel')}


### PR DESCRIPTION
Trying to make it abundantly clear to users that storing sensitive values here is a **very bad** idea. I assume we'll make note of it in our docs, but having it listed here as well makes sure it's always in the mind of the user when adding a feature entry. 

![image](https://github.com/getsentry/sentry/assets/20070360/f80a4177-7430-4d2d-b4f9-dfa6abf05fa8)
