### PR TITLE
Activated Alert info in Notification

### DIFF
--- a/src/sentry/incidents/action_handlers.py
+++ b/src/sentry/incidents/action_handlers.py
@@ -209,6 +209,13 @@ class EmailActionHandler(ActionHandler):
         display = self.status_display[status]
         alert_rule = self.incident.alert_rule
         activation = self.incident.activation
+        additional_context = {
+            "monitor_type": alert_rule.monitor_type,  # 0 = continuous, 1 = activated
+            "activator": (activation.activator if activation else ""),
+            "condition_type": (
+                activation.condition_type if activation else None
+            ),  # 0 = release creation, 1 = deploy creation
+        }
         return MessageBuilder(
             subject="[{}] {} - {}".format(
                 context["status"], context["incident_name"], self.project.slug
@@ -216,11 +223,11 @@ class EmailActionHandler(ActionHandler):
             template="sentry/emails/incidents/trigger.txt",
             html_template="sentry/emails/incidents/trigger.html",
             type=f"incident.alert_rule_{display.lower()}",
-            context=context,
+            context={
+                **context,
+                **additional_context,
+            },
             headers={"X-SMTPAPI": orjson.dumps({"category": "metric_alert_email"}).decode()},
-            monitor_type=alert_rule.monitor_type,  # 0 = continuous, 1 = activated
-            activator=activation.activator,
-            condition_type=activation.condition_type,  # 0 = release creation, 1 = deploy creation
         )
 
 

--- a/src/sentry/incidents/action_handlers.py
+++ b/src/sentry/incidents/action_handlers.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import abc
 import logging
 from collections.abc import Sequence
+from typing import Any
 from urllib.parse import urlencode
 
 import orjson
@@ -204,7 +205,7 @@ class EmailActionHandler(ActionHandler):
             self.record_alert_sent_analytics(user_id, notification_uuid)
 
     def build_message(
-        self, context: dict[str, any], status: TriggerStatus, user_id: int
+        self, context: dict[str, Any], status: TriggerStatus, user_id: int
     ) -> MessageBuilder:
         display = self.status_display[status]
         alert_rule = self.incident.alert_rule

--- a/src/sentry/incidents/charts.py
+++ b/src/sentry/incidents/charts.py
@@ -22,7 +22,7 @@ from sentry.models.organization import Organization
 from sentry.models.user import User
 from sentry.snuba.dataset import Dataset
 from sentry.snuba.entity_subscription import apply_dataset_query_conditions
-from sentry.snuba.models import QuerySubscription, SnubaQuery
+from sentry.snuba.models import SnubaQuery
 
 CRASH_FREE_SESSIONS = "percentage(sessions_crashed, sessions) AS _crash_rate_alert_aggregate"
 CRASH_FREE_USERS = "percentage(users_crashed, users) AS _crash_rate_alert_aggregate"
@@ -162,7 +162,8 @@ def build_metric_alert_chart(
     end: str | None = None,
     user: Optional["User"] = None,
     size: ChartSize | None = None,
-    subscription: QuerySubscription | None = None,
+    query_extra: str | None = None,
+    project_id: int | None = None,
 ) -> str | None:
     """
     Builds the dataset required for metric alert chart the same way the frontend would
@@ -206,20 +207,15 @@ def build_metric_alert_chart(
     )
     aggregate = translate_aggregate_field(snuba_query.aggregate, reverse=True, allow_mri=allow_mri)
     # If we allow alerts to be across multiple orgs this will break
+    # TODO: determine whether this validation is necessary
     first_subscription_or_none = snuba_query.subscriptions.first()
     if first_subscription_or_none is None:
         return None
 
-    project_id = first_subscription_or_none.project_id
+    project_id = project_id or first_subscription_or_none.project_id
     time_window_minutes = snuba_query.time_window // 60
     env_params = {"environment": snuba_query.environment.name} if snuba_query.environment else {}
-    # update query here
-    extra = ""
-    if subscription and subscription.query_extra:
-        if snuba_query.query:
-            extra = " and "
-        extra += subscription.query_extra
-    query_str = f"{snuba_query.query}{extra}"
+    query_str = f"{snuba_query.query}{query_extra}"
     query = (
         query_str
         if is_crash_free_alert

--- a/src/sentry/incidents/charts.py
+++ b/src/sentry/incidents/charts.py
@@ -215,7 +215,7 @@ def build_metric_alert_chart(
     project_id = project_id or first_subscription_or_none.project_id
     time_window_minutes = snuba_query.time_window // 60
     env_params = {"environment": snuba_query.environment.name} if snuba_query.environment else {}
-    query_str = f"{snuba_query.query}{query_extra}"
+    query_str = f"{snuba_query.query}{query_extra if query_extra else ''}"
     query = (
         query_str
         if is_crash_free_alert

--- a/src/sentry/templates/sentry/debug/mail/preview.html
+++ b/src/sentry/templates/sentry/debug/mail/preview.html
@@ -31,7 +31,7 @@
         <option value="mail/generic-alert/">Generic Alert</option>
         <option value="mail/digest/">Digest</option>
         <option value="mail/incident-trigger">Metric Alert Trigger</option>
-        <option value="mail/incident-trigger">Activated Metric Alert Trigger</option>
+        <option value="mail/activated-incident-trigger">Activated Metric Alert Trigger</option>
       </optgroup>
       <optgroup label="Account">
         <option value="mail/confirm-email/">Confirm Email</option>

--- a/src/sentry/templates/sentry/debug/mail/preview.html
+++ b/src/sentry/templates/sentry/debug/mail/preview.html
@@ -31,6 +31,7 @@
         <option value="mail/generic-alert/">Generic Alert</option>
         <option value="mail/digest/">Digest</option>
         <option value="mail/incident-trigger">Metric Alert Trigger</option>
+        <option value="mail/incident-trigger">Activated Metric Alert Trigger</option>
       </optgroup>
       <optgroup label="Account">
         <option value="mail/confirm-email/">Confirm Email</option>

--- a/src/sentry/templates/sentry/emails/incidents/trigger.html
+++ b/src/sentry/templates/sentry/emails/incidents/trigger.html
@@ -38,7 +38,10 @@
       </div>
     {% endif %}
     <div>
-      <h5 style="margin-bottom: 12px;">Alert Rule Details</h5>
+      <h5 style="margin-bottom: 12px;">
+        {% if monitor_type == 1 %}Activated {% endif %}
+        Alert Rule Details
+      </h5>
       <table class="alert-details">
         <tr>
           <td width="25%">Project</td>
@@ -51,10 +54,10 @@
           {% if monitor_type == 1 %}
             <tr>
               {% if condition_type == 0 %}
-                <td width="25%">Release</td>
+                <td width="25%">New Release</td>
                 <td>{{activator}}</td>
               {% elif condition_type == 1 %}
-                <td width="25%">Deploy</td>
+                <td width="25%">New Deploy</td>
                 <td>{{activator}}</td>
               {% endif %}
               </tr>

--- a/src/sentry/templates/sentry/emails/incidents/trigger.html
+++ b/src/sentry/templates/sentry/emails/incidents/trigger.html
@@ -47,7 +47,18 @@
         <tr>
           <td width="25%">Environment</td>
           <td>{{ environment }}</td>
-        </tr>
+          </tr>
+          {% if monitor_type == 1 %}
+            <tr>
+              {% if condition_type == 0 %}
+                <td width="25%">Release</td>
+                <td>{{activator}}</td>
+              {% elif condition_type == 1 %}
+                <td width="25%">Deploy</td>
+                <td>{{activator}}</td>
+              {% endif %}
+              </tr>
+          {% endif %}
         <tr>
           <td width="25%">Threshold</td>
           <td>

--- a/src/sentry/templates/sentry/emails/incidents/trigger.txt
+++ b/src/sentry/templates/sentry/emails/incidents/trigger.txt
@@ -10,6 +10,13 @@ controls are enabled. For more details about this alert alert, view on Sentry:
 Alert: {{ link }}
 Status: {{ status }}
 Project: {{ project_slug }}
+{% if monitor_type == 1 %}
+    {% if condition_type == 0 %}
+        New Release: {{activator}}
+    {% elif condition_type == 1 %}
+        New Deploy: {{activator}}
+    {% endif %}
+{% endif %}
 
 Metric: {{ aggregate }}
 Environment: {{ environment }}

--- a/src/sentry/templates/sentry/emails/incidents/trigger.txt
+++ b/src/sentry/templates/sentry/emails/incidents/trigger.txt
@@ -1,6 +1,6 @@
 {% spaceless %}
 {% autoescape off %}
-# Alert Rule Trigger on {{ incident_name }}.
+# {% if monitor_type == 1 %} Activated {% endif %}Alert Rule Trigger on {{ incident_name }}.
 
 {% if enhanced_privacy %}
 Details about this alert are not shown in this email since enhanced privacy

--- a/src/sentry/templates/sentry/emails/incidents/trigger.txt
+++ b/src/sentry/templates/sentry/emails/incidents/trigger.txt
@@ -12,12 +12,11 @@ Status: {{ status }}
 Project: {{ project_slug }}
 {% if monitor_type == 1 %}
     {% if condition_type == 0 %}
-        New Release: {{activator}}
+New Release: {{activator}}
     {% elif condition_type == 1 %}
-        New Deploy: {{activator}}
+New Deploy: {{activator}}
     {% endif %}
 {% endif %}
-
 Metric: {{ aggregate }}
 Environment: {{ environment }}
 Threshold: {{ threshold_direction_string }} {{ threshold }}

--- a/src/sentry/testutils/factories.py
+++ b/src/sentry/testutils/factories.py
@@ -1462,6 +1462,7 @@ class Factories:
         seen_by=None,
         alert_rule=None,
         subscription=None,
+        activation=None,
     ):
         if not title:
             title = petname.generate(2, " ", letters=10).title()
@@ -1481,6 +1482,7 @@ class Factories:
             date_closed=timezone.now() if date_closed is not None else date_closed,
             type=IncidentType.ALERT_TRIGGERED.value,
             subscription=subscription,
+            activation=activation,
         )
         for project in projects:
             IncidentProject.objects.create(incident=incident, project=project)

--- a/src/sentry/web/debug_urls.py
+++ b/src/sentry/web/debug_urls.py
@@ -21,6 +21,9 @@ from sentry.web.frontend.debug.debug_feedback_issue import DebugFeedbackIssueEma
 from sentry.web.frontend.debug.debug_generic_issue import DebugGenericIssueEmailView
 from sentry.web.frontend.debug.debug_incident_activity_email import DebugIncidentActivityEmailView
 from sentry.web.frontend.debug.debug_incident_trigger_email import DebugIncidentTriggerEmailView
+from sentry.web.frontend.debug.debug_incident_trigger_email_activated_alert import (
+    DebugIncidentActivatedAlertTriggerEmailView,
+)
 from sentry.web.frontend.debug.debug_invalid_identity_email import DebugInvalidIdentityEmailView
 from sentry.web.frontend.debug.debug_mfa_added_email import DebugMfaAddedEmailView
 from sentry.web.frontend.debug.debug_mfa_removed_email import DebugMfaRemovedEmailView
@@ -158,6 +161,10 @@ urlpatterns = [
     ),
     re_path(r"^debug/mail/incident-activity$", DebugIncidentActivityEmailView.as_view()),
     re_path(r"^debug/mail/incident-trigger$", DebugIncidentTriggerEmailView.as_view()),
+    re_path(
+        r"^debug/mail/activated-incident-trigger$",
+        DebugIncidentActivatedAlertTriggerEmailView.as_view(),
+    ),
     re_path(r"^debug/mail/setup-2fa/$", DebugSetup2faEmailView.as_view()),
     re_path(r"^debug/embed/error-page/$", DebugErrorPageEmbedView.as_view()),
     re_path(r"^debug/trigger-error/$", DebugTriggerErrorView.as_view()),

--- a/src/sentry/web/frontend/debug/debug_incident_trigger_email.py
+++ b/src/sentry/web/frontend/debug/debug_incident_trigger_email.py
@@ -20,7 +20,8 @@ class MockedIncidentTrigger:
 
 class DebugIncidentTriggerEmailView(MailPreviewView):
     @mock.patch(
-        "sentry.incidents.models.IncidentTrigger.objects.get", return_value=MockedIncidentTrigger()
+        "sentry.incidents.models.incident.IncidentTrigger.objects.get",
+        return_value=MockedIncidentTrigger(),
     )
     @mock.patch("sentry.models.UserOption.objects.get_value", return_value="US/Pacific")
     def get_context(self, request, incident_trigger_mock, user_option_mock):

--- a/src/sentry/web/frontend/debug/debug_incident_trigger_email_activated_alert.py
+++ b/src/sentry/web/frontend/debug/debug_incident_trigger_email_activated_alert.py
@@ -1,0 +1,79 @@
+from unittest import mock
+from uuid import uuid4
+
+from django.utils import timezone
+
+from sentry.incidents.action_handlers import generate_incident_trigger_email_context
+from sentry.incidents.models.alert_rule import (
+    AlertRule,
+    AlertRuleActivations,
+    AlertRuleMonitorType,
+    AlertRuleTrigger,
+)
+from sentry.incidents.models.incident import Incident, IncidentStatus, TriggerStatus
+from sentry.incidents.utils.types import AlertRuleActivationConditionType
+from sentry.models.organization import Organization
+from sentry.models.project import Project
+from sentry.models.user import User
+from sentry.snuba.models import SnubaQuery
+
+from .mail import MailPreviewView
+
+
+class MockedIncidentTrigger:
+    date_added = timezone.now()
+
+
+class DebugIncidentActivatedAlertTriggerEmailView(MailPreviewView):
+    @mock.patch(
+        "sentry.incidents.models.IncidentTrigger.objects.get", return_value=MockedIncidentTrigger()
+    )
+    @mock.patch("sentry.models.UserOption.objects.get_value", return_value="US/Pacific")
+    def get_context(self, request, incident_trigger_mock, user_option_mock):
+        organization = Organization(slug="myorg")
+        project = Project(slug="myproject", organization=organization)
+        user = User()
+
+        query = SnubaQuery(
+            time_window=60, query="transaction:/some/transaction", aggregate="count()"
+        )
+        alert_rule = AlertRule(
+            id=1,
+            organization=organization,
+            name="My Alert",
+            snuba_query=query,
+            monitor_type=AlertRuleMonitorType.ACTIVATED,
+        )
+        activation = AlertRuleActivations(
+            alert_rule=alert_rule,
+            label="My Activation",
+            condition_type=AlertRuleActivationConditionType.DEPLOY_CREATION,
+        )
+        incident = Incident(
+            id=2,
+            identifier=123,
+            organization=organization,
+            title="Something broke",
+            alert_rule=alert_rule,
+            status=IncidentStatus.CRITICAL,
+            activation=activation,
+        )
+        trigger = AlertRuleTrigger(alert_rule=alert_rule)
+
+        return generate_incident_trigger_email_context(
+            project,
+            incident,
+            trigger,
+            TriggerStatus.ACTIVE,
+            IncidentStatus(incident.status),
+            user,
+            notification_uuid=str(uuid4()),
+        )
+
+    @property
+    def html_template(self):
+        return "sentry/emails/incidents/trigger.html"
+
+    @property
+    def text_template(self):
+        return "sentry/emails/incidents/trigger.txt"

--- a/src/sentry/web/frontend/debug/debug_incident_trigger_email_activated_alert.py
+++ b/src/sentry/web/frontend/debug/debug_incident_trigger_email_activated_alert.py
@@ -4,12 +4,8 @@ from uuid import uuid4
 from django.utils import timezone
 
 from sentry.incidents.action_handlers import generate_incident_trigger_email_context
-from sentry.incidents.models.alert_rule import (
-    AlertRule,
-    AlertRuleActivations,
-    AlertRuleMonitorType,
-    AlertRuleTrigger,
-)
+from sentry.incidents.models.alert_rule import AlertRule, AlertRuleMonitorType, AlertRuleTrigger
+from sentry.incidents.models.alert_rule_activations import AlertRuleActivations
 from sentry.incidents.models.incident import Incident, IncidentStatus, TriggerStatus
 from sentry.incidents.utils.types import AlertRuleActivationConditionType
 from sentry.models.organization import Organization
@@ -42,12 +38,11 @@ class DebugIncidentActivatedAlertTriggerEmailView(MailPreviewView):
             organization=organization,
             name="My Alert",
             snuba_query=query,
-            monitor_type=AlertRuleMonitorType.ACTIVATED,
+            monitor_type=AlertRuleMonitorType.ACTIVATED.value,
         )
         activation = AlertRuleActivations(
             alert_rule=alert_rule,
-            label="My Activation",
-            condition_type=AlertRuleActivationConditionType.DEPLOY_CREATION,
+            condition_type=AlertRuleActivationConditionType.DEPLOY_CREATION.value,
         )
         incident = Incident(
             id=2,
@@ -55,7 +50,7 @@ class DebugIncidentActivatedAlertTriggerEmailView(MailPreviewView):
             organization=organization,
             title="Something broke",
             alert_rule=alert_rule,
-            status=IncidentStatus.CRITICAL,
+            status=IncidentStatus.CRITICAL.value,
             activation=activation,
         )
         trigger = AlertRuleTrigger(alert_rule=alert_rule)

--- a/src/sentry/web/frontend/debug/debug_incident_trigger_email_activated_alert.py
+++ b/src/sentry/web/frontend/debug/debug_incident_trigger_email_activated_alert.py
@@ -22,7 +22,8 @@ class MockedIncidentTrigger:
 
 class DebugIncidentActivatedAlertTriggerEmailView(MailPreviewView):
     @mock.patch(
-        "sentry.incidents.models.IncidentTrigger.objects.get", return_value=MockedIncidentTrigger()
+        "sentry.incidents.models.incident.IncidentTrigger.objects.get",
+        return_value=MockedIncidentTrigger(),
     )
     @mock.patch("sentry.models.UserOption.objects.get_value", return_value="US/Pacific")
     def get_context(self, request, incident_trigger_mock, user_option_mock):


### PR DESCRIPTION
Changes to the email builder to include activated alert info into the notification templates

Adds the activator ('Deploy' / 'Release') to the message format

<img width="897" alt="Screenshot 2024-06-24 at 9 56 51 AM" src="https://github.com/getsentry/sentry/assets/6186377/54b980f1-a50a-4317-9e1b-fec6fb5acb54">
