### PR TITLE
chore(rules): Remove metric alert ignore archived flag

### DIFF
--- a/static/app/components/events/searchBar.spec.tsx
+++ b/static/app/components/events/searchBar.spec.tsx
@@ -365,10 +365,8 @@ describe('Events > SearchBar', function () {
     ).toBeInTheDocument();
   });
 
-  it('is query works for metric alert search bar when the flag is on', async function () {
-    const OrganizationIs = OrganizationFixture({
-      features: ['metric-alert-ignore-archived'],
-    });
+  it('is query works for metric alert search bar', async function () {
+    const OrganizationIs = OrganizationFixture();
     render(
       <SearchBar
         {...props}
@@ -382,10 +380,8 @@ describe('Events > SearchBar', function () {
     expect(autocomplete.at(0)).toHaveTextContent('is:');
   });
 
-  it('handled query works for metric alert search bar when the flag is on', async function () {
-    const OrganizationIs = OrganizationFixture({
-      features: ['metric-alert-ignore-archived'],
-    });
+  it('handled query works for metric alert search bar', async function () {
+    const OrganizationIs = OrganizationFixture();
     render(
       <SearchBar
         {...props}
@@ -397,19 +393,5 @@ describe('Events > SearchBar', function () {
 
     const autocomplete = await screen.findAllByTestId('search-autocomplete-item');
     expect(autocomplete.at(0)).toHaveTextContent('handled:');
-  });
-
-  it('is query does not work when the flag is off', async function () {
-    render(
-      <SearchBar
-        {...props}
-        metricAlert
-        supportedTags={datasetSupportedTags(Dataset.ERRORS, props.organization)}
-      />
-    );
-    await setQuery('is:');
-
-    const autocomplete = await screen.findAllByTestId('search-autocomplete-item');
-    expect(autocomplete.at(0)).not.toHaveTextContent('is:');
   });
 });

--- a/static/app/views/alerts/rules/metric/details/errorMigrationWarning.spec.tsx
+++ b/static/app/views/alerts/rules/metric/details/errorMigrationWarning.spec.tsx
@@ -10,7 +10,7 @@ import {ErrorMigrationWarning} from './errorMigrationWarning';
 
 describe('ErrorMigrationWarning', () => {
   const project = ProjectFixture();
-  const organization = OrganizationFixture({features: ['metric-alert-ignore-archived']});
+  const organization = OrganizationFixture();
 
   afterEach(() => {
     MockApiClient.clearMockResponses();

--- a/static/app/views/alerts/rules/metric/details/errorMigrationWarning.tsx
+++ b/static/app/views/alerts/rules/metric/details/errorMigrationWarning.tsx
@@ -17,10 +17,7 @@ import {setApiQueryData, useQueryClient} from 'sentry/utils/queryClient';
 import useApi from 'sentry/utils/useApi';
 import useOrganization from 'sentry/utils/useOrganization';
 import type {MetricRule} from 'sentry/views/alerts/rules/metric/types';
-import {
-  hasIgnoreArchivedFeatureFlag,
-  ruleNeedsErrorMigration,
-} from 'sentry/views/alerts/utils/migrationUi';
+import {ruleNeedsErrorMigration} from 'sentry/views/alerts/utils/migrationUi';
 
 interface ErrorMigrationWarningProps {
   project?: Project;
@@ -45,8 +42,7 @@ export function ErrorMigrationWarning({project, rule}: ErrorMigrationWarningProp
   const api = useApi();
   const organization = useOrganization();
   const queryClient = useQueryClient();
-  const showErrorMigrationWarning =
-    rule && hasIgnoreArchivedFeatureFlag(organization) && ruleNeedsErrorMigration(rule);
+  const showErrorMigrationWarning = rule && ruleNeedsErrorMigration(rule);
   const isCreatedAfterMigration = rule && createdOrModifiedAfterMigration(rule);
   const prompt = usePromptsCheck(
     {

--- a/static/app/views/alerts/rules/metric/details/index.spec.tsx
+++ b/static/app/views/alerts/rules/metric/details/index.spec.tsx
@@ -49,7 +49,14 @@ describe('MetricAlertDetails', () => {
       projects: [project.slug],
       latestIncident: incident,
     });
-
+    const promptResponse = {
+      dismissed_ts: undefined,
+      snoozed_ts: undefined,
+    };
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/prompts-activity/`,
+      body: promptResponse,
+    });
     MockApiClient.addMockResponse({
       url: `/organizations/org-slug/alert-rules/${rule.id}/`,
       body: rule,
@@ -87,7 +94,14 @@ describe('MetricAlertDetails', () => {
     const {organization, router, routerProps} = initializeOrg();
     const rule = MetricRuleFixture({projects: [project.slug]});
     const incident = IncidentFixture();
-
+    const promptResponse = {
+      dismissed_ts: undefined,
+      snoozed_ts: undefined,
+    };
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/prompts-activity/`,
+      body: promptResponse,
+    });
     MockApiClient.addMockResponse({
       url: `/organizations/org-slug/alert-rules/${rule.id}/`,
       body: rule,
@@ -137,7 +151,6 @@ describe('MetricAlertDetails', () => {
       projects: [project.slug],
       latestIncident: incident,
     });
-
     MockApiClient.addMockResponse({
       url: `/organizations/org-slug/alert-rules/${rule.id}/`,
       body: rule,
@@ -146,7 +159,14 @@ describe('MetricAlertDetails', () => {
       url: `/organizations/org-slug/incidents/`,
       body: [incident],
     });
-
+    const promptResponse = {
+      dismissed_ts: undefined,
+      snoozed_ts: undefined,
+    };
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/prompts-activity/`,
+      body: promptResponse,
+    });
     const postRequest = MockApiClient.addMockResponse({
       url: `/projects/${organization.slug}/${project.slug}/alert-rules/${rule.id}/snooze/`,
       method: 'POST',

--- a/static/app/views/alerts/rules/metric/details/index.spec.tsx
+++ b/static/app/views/alerts/rules/metric/details/index.spec.tsx
@@ -177,9 +177,7 @@ describe('MetricAlertDetails', () => {
   });
 
   it('renders open in discover button with dataset=errors for is:unresolved query', async () => {
-    const {organization, routerProps, router} = initializeOrg({
-      organization: {features: ['discover-basic', 'metric-alert-ignore-archived']},
-    });
+    const {organization, routerProps, router} = initializeOrg();
     const rule = MetricRuleFixture({
       projects: [project.slug],
       dataset: Dataset.ERRORS,

--- a/static/app/views/alerts/rules/metric/details/index.spec.tsx
+++ b/static/app/views/alerts/rules/metric/details/index.spec.tsx
@@ -177,7 +177,9 @@ describe('MetricAlertDetails', () => {
   });
 
   it('renders open in discover button with dataset=errors for is:unresolved query', async () => {
-    const {organization, routerProps, router} = initializeOrg();
+    const {organization, routerProps, router} = initializeOrg({
+      organization: {features: ['discover-basic']},
+    });
     const rule = MetricRuleFixture({
       projects: [project.slug],
       dataset: Dataset.ERRORS,

--- a/static/app/views/alerts/rules/metric/details/metricChart.tsx
+++ b/static/app/views/alerts/rules/metric/details/metricChart.tsx
@@ -146,16 +146,8 @@ function getRuleChangeSeries(
   ];
 }
 
-function shouldUseErrorsDataset(
-  organization: Organization,
-  dataset: Dataset,
-  query: string
-): boolean {
-  return (
-    dataset === Dataset.ERRORS &&
-    /\bis:unresolved\b/.test(query) &&
-    organization.features.includes('metric-alert-ignore-archived')
-  );
+function shouldUseErrorsDataset(dataset: Dataset, query: string): boolean {
+  return dataset === Dataset.ERRORS && /\bis:unresolved\b/.test(query);
 }
 
 class MetricChart extends PureComponent<Props, State> {
@@ -181,7 +173,7 @@ class MetricChart extends PureComponent<Props, State> {
     const {rule, organization, project, timePeriod, query} = this.props;
 
     let dataset: DiscoverDatasets | undefined = undefined;
-    if (shouldUseErrorsDataset(organization, rule.dataset, query)) {
+    if (shouldUseErrorsDataset(rule.dataset, query)) {
       dataset = DiscoverDatasets.ERRORS;
     }
 
@@ -555,7 +547,7 @@ class MetricChart extends PureComponent<Props, State> {
       ...getForceMetricsLayerQueryExtras(organization, dataset),
     };
 
-    if (shouldUseErrorsDataset(organization, dataset, query)) {
+    if (shouldUseErrorsDataset(dataset, query)) {
       queryExtras.dataset = 'errors';
     }
 

--- a/static/app/views/alerts/rules/metric/ruleForm.spec.tsx
+++ b/static/app/views/alerts/rules/metric/ruleForm.spec.tsx
@@ -516,7 +516,6 @@ describe('Incident Rules Form', () => {
         dataset: Dataset.ERRORS,
         query: 'example-error',
       });
-      organization.features = [...organization.features, 'metric-alert-ignore-archived'];
       location = {...location, query: {migration: '1'}};
 
       const onSubmitSuccess = jest.fn();

--- a/static/app/views/alerts/rules/metric/ruleForm.spec.tsx
+++ b/static/app/views/alerts/rules/metric/ruleForm.spec.tsx
@@ -516,7 +516,6 @@ describe('Incident Rules Form', () => {
         dataset: Dataset.ERRORS,
         query: 'example-error',
       });
-      organization.features = [...organization.features];
       location = {...location, query: {migration: '1'}};
 
       const onSubmitSuccess = jest.fn();

--- a/static/app/views/alerts/rules/metric/ruleForm.spec.tsx
+++ b/static/app/views/alerts/rules/metric/ruleForm.spec.tsx
@@ -516,6 +516,7 @@ describe('Incident Rules Form', () => {
         dataset: Dataset.ERRORS,
         query: 'example-error',
       });
+      organization.features = [...organization.features];
       location = {...location, query: {migration: '1'}};
 
       const onSubmitSuccess = jest.fn();

--- a/static/app/views/alerts/rules/metric/ruleForm.tsx
+++ b/static/app/views/alerts/rules/metric/ruleForm.tsx
@@ -58,10 +58,7 @@ import {getEventTypeFilter} from 'sentry/views/alerts/rules/metric/utils/getEven
 import hasThresholdValue from 'sentry/views/alerts/rules/metric/utils/hasThresholdValue';
 import {isOnDemandMetricAlert} from 'sentry/views/alerts/rules/metric/utils/onDemandMetricAlert';
 import {AlertRuleType} from 'sentry/views/alerts/types';
-import {
-  hasIgnoreArchivedFeatureFlag,
-  ruleNeedsErrorMigration,
-} from 'sentry/views/alerts/utils/migrationUi';
+import {ruleNeedsErrorMigration} from 'sentry/views/alerts/utils/migrationUi';
 import type {MetricAlertType} from 'sentry/views/alerts/wizard/options';
 import {
   AlertWizardAlertNames,
@@ -200,9 +197,7 @@ class RuleFormContainer extends DeprecatedAsyncComponent<Props, State> {
     const dataset = _dataset ?? rule.dataset;
 
     const isErrorMigration =
-      this.props.location?.query?.migration === '1' &&
-      hasIgnoreArchivedFeatureFlag(this.props.organization) &&
-      ruleNeedsErrorMigration(rule);
+      this.props.location?.query?.migration === '1' && ruleNeedsErrorMigration(rule);
     // TODO(issues): Does this need to be smarter about where its inserting the new filter?
     const query = isErrorMigration
       ? `is:unresolved ${rule.query ?? ''}`
@@ -1096,10 +1091,7 @@ class RuleFormContainer extends DeprecatedAsyncComponent<Props, State> {
     const submitDisabled = formDisabled || !this.state.isQueryValid;
 
     const showErrorMigrationWarning =
-      !!ruleId &&
-      isMigration &&
-      hasIgnoreArchivedFeatureFlag(organization) &&
-      ruleNeedsErrorMigration(rule);
+      !!ruleId && isMigration && ruleNeedsErrorMigration(rule);
 
     // Rendering the main form body
     return (

--- a/static/app/views/alerts/utils/migrationUi.tsx
+++ b/static/app/views/alerts/utils/migrationUi.tsx
@@ -1,12 +1,5 @@
-import type {Organization} from 'sentry/types/organization';
 import type {MetricRule} from 'sentry/views/alerts/rules/metric/types';
 import {Dataset} from 'sentry/views/alerts/rules/metric/types';
-
-/**
- * Enable ignoring archived issues in metric alerts
- */
-export const hasIgnoreArchivedFeatureFlag = (organization: Organization): boolean =>
-  organization.features.includes('metric-alert-ignore-archived');
 
 export const ruleNeedsErrorMigration = (rule: MetricRule): boolean => {
   return (

--- a/static/app/views/alerts/wizard/index.tsx
+++ b/static/app/views/alerts/wizard/index.tsx
@@ -67,10 +67,7 @@ function AlertWizard({organization, params, location, projectId}: AlertWizardPro
       metricRuleTemplate = {...metricRuleTemplate, dataset: Dataset.METRICS};
     }
 
-    if (
-      organization.features.includes('metric-alert-ignore-archived') &&
-      metricRuleTemplate?.dataset === Dataset.ERRORS
-    ) {
+    if (metricRuleTemplate?.dataset === Dataset.ERRORS) {
       // Pre-fill is:unresolved for error metric alerts
       // Filters out events in issues that are archived or resolved
       metricRuleTemplate = {...metricRuleTemplate, query: 'is:unresolved'};

--- a/static/app/views/alerts/wizard/options.tsx
+++ b/static/app/views/alerts/wizard/options.tsx
@@ -281,9 +281,7 @@ export function datasetSupportedTags(
 ): TagCollection | undefined {
   return mapValues(
     {
-      [Dataset.ERRORS]: org.features.includes('metric-alert-ignore-archived')
-        ? [FieldKey.IS]
-        : undefined,
+      [Dataset.ERRORS]: [FieldKey.IS],
       [Dataset.TRANSACTIONS]: org.features.includes('alert-allow-indexed')
         ? undefined
         : transactionSupportedTags(org),


### PR DESCRIPTION
Remove the flag for ignoring archived issues in metric alerts - it's been fully rolled out for a while. 