### PR TITLE
chore(rules): Remove metric alert ignore archived flag

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -157,8 +157,6 @@ def register_temporary_features(manager: FeatureManager):
     manager.add("organizations:mep-use-default-tags", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
     # Enable metric alert charts in email/slack
     manager.add("organizations:metric-alert-chartcuterie", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
-    # Enable ignoring archived issues in metric alerts
-    manager.add("organizations:metric-alert-ignore-archived", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
     # Enable load shedding for newly created metric alerts
     manager.add("organizations:metric-alert-load-shedding", OrganizationFeature, FeatureHandlerStrategy.OPTIONS)
     # Enable threshold period in metric alert rule builder

--- a/src/sentry/incidents/serializers/alert_rule.py
+++ b/src/sentry/incidents/serializers/alert_rule.py
@@ -357,9 +357,7 @@ class AlertRuleSerializer(CamelSnakeModelSerializer):
         dataset = Dataset(data["dataset"].value)
         self._validate_time_window(dataset, data.get("time_window"))
 
-        entity = None
-        if features.has("organizations:metric-alert-ignore-archived", projects[0].organization):
-            entity = Entity(Dataset.Events.value, alias=Dataset.Events.value)
+        entity = Entity(Dataset.Events.value, alias=Dataset.Events.value)
 
         time_col = ENTITY_TIME_COLUMNS[get_entity_key_from_query_builder(query_builder)]
         query_builder.add_conditions(

--- a/src/sentry/snuba/entity_subscription.py
+++ b/src/sentry/snuba/entity_subscription.py
@@ -179,12 +179,8 @@ class BaseEventsAndTransactionEntitySubscription(BaseEntitySubscription, ABC):
             params["environment"] = environment.name
 
         query_builder_cls = QueryBuilder
-        # TODO: Remove this query when we remove the feature check
-        organization = Organization.objects.filter(project__id__in=project_ids)[0]
         parser_config_overrides: MutableMapping[str, Any] = {"blocked_keys": ALERT_BLOCKED_FIELDS}
-        if self.dataset == Dataset.Events and features.has(
-            "organizations:metric-alert-ignore-archived", organization
-        ):
+        if self.dataset == Dataset.Events:
             from sentry.snuba.errors import PARSER_CONFIG_OVERRIDES
 
             query_builder_cls = ErrorsQueryBuilder

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
@@ -256,7 +256,6 @@ class AlertRuleCreateEndpointTest(AlertRuleIndexBase):
                 [
                     "organizations:incidents",
                     "organizations:performance-view",
-                    "organizations:metric-alert-ignore-archived",
                 ]
             ),
         ):

--- a/tests/sentry/incidents/endpoints/test_project_alert_rule_index.py
+++ b/tests/sentry/incidents/endpoints/test_project_alert_rule_index.py
@@ -125,7 +125,6 @@ class AlertRuleCreateEndpointTest(APITestCase):
                 [
                     "organizations:incidents",
                     "organizations:performance-view",
-                    "organizations:metric-alert-ignore-archived",
                 ]
             ),
         ):

--- a/tests/sentry/incidents/endpoints/test_serializers.py
+++ b/tests/sentry/incidents/endpoints/test_serializers.py
@@ -737,9 +737,8 @@ class TestAlertRuleSerializer(TestAlertRuleSerializerBase):
     def test_error_issue_status(self):
         params = self.valid_params.copy()
         params["query"] = "status:abcd"
-        with self.feature("organizations:metric-alert-ignore-archived"):
-            serializer = AlertRuleSerializer(context=self.context, data=params, partial=True)
-            assert not serializer.is_valid()
+        serializer = AlertRuleSerializer(context=self.context, data=params, partial=True)
+        assert not serializer.is_valid()
         assert serializer.errors == {
             "nonFieldErrors": [
                 ErrorDetail(
@@ -750,10 +749,9 @@ class TestAlertRuleSerializer(TestAlertRuleSerializerBase):
 
         params = self.valid_params.copy()
         params["query"] = "status:unresolved"
-        with self.feature("organizations:metric-alert-ignore-archived"):
-            serializer = AlertRuleSerializer(context=self.context, data=params, partial=True)
-            assert serializer.is_valid()
-            alert_rule = serializer.save()
+        serializer = AlertRuleSerializer(context=self.context, data=params, partial=True)
+        assert serializer.is_valid()
+        alert_rule = serializer.save()
         assert alert_rule.snuba_query.query == "status:unresolved"
 
 

--- a/tests/sentry/incidents/test_logic.py
+++ b/tests/sentry/incidents/test_logic.py
@@ -296,7 +296,6 @@ class GetIncidentAggregatesTest(TestCase, BaseIncidentAggregatesTest):
         assert get_incident_aggregates(self.project_incident) == {"count": 4}
 
     @override_options({"issues.group_attributes.send_kafka": True})
-    @with_feature("organizations:metric-alert-ignore-archived")
     def test_is_unresolved_query(self):
         incident = self.create_incident(
             date_started=self.now - timedelta(minutes=5),
@@ -546,19 +545,18 @@ class CreateAlertRuleTest(TestCase, BaseIncidentsTest):
         resolve_threshold = 10
         threshold_period = 1
         event_types = [SnubaQueryEventType.EventType.ERROR]
-        with self.feature("organizations:metric-alert-ignore-archived"):
-            alert_rule = create_alert_rule(
-                self.organization,
-                [self.project],
-                name,
-                query,
-                aggregate,
-                time_window,
-                threshold_type,
-                threshold_period,
-                resolve_threshold=resolve_threshold,
-                event_types=event_types,
-            )
+        alert_rule = create_alert_rule(
+            self.organization,
+            [self.project],
+            name,
+            query,
+            aggregate,
+            time_window,
+            threshold_type,
+            threshold_period,
+            resolve_threshold=resolve_threshold,
+            event_types=event_types,
+        )
         assert alert_rule.snuba_query.subscriptions.get().project == self.project
         assert alert_rule.name == name
         assert alert_rule.user_id is None

--- a/tests/sentry/incidents/test_subscription_processor.py
+++ b/tests/sentry/incidents/test_subscription_processor.py
@@ -51,7 +51,6 @@ from sentry.snuba.models import QuerySubscription, SnubaQueryEventType
 from sentry.testutils.cases import BaseMetricsTestCase, SnubaTestCase, TestCase
 from sentry.testutils.factories import DEFAULT_EVENT_DATA
 from sentry.testutils.helpers.datetime import freeze_time, iso_format
-from sentry.testutils.helpers.features import with_feature
 from sentry.utils import json
 
 EMPTY = object()
@@ -2048,7 +2047,6 @@ class ProcessUpdateTest(ProcessUpdateBaseClass):
             incident, [self.action], [(50.0, IncidentStatus.CLOSED, mock.ANY)]
         )
 
-    @with_feature("organizations:metric-alert-ignore-archived")
     def test_is_unresolved_comparison_query(self):
         """
         Test that uses the ErrorsQueryBuilder (because of the specific query) and requires an entity

--- a/tests/sentry/search/events/builder/test_errors.py
+++ b/tests/sentry/search/events/builder/test_errors.py
@@ -20,20 +20,19 @@ class ErrorsQueryBuilderTest(TestCase):
         self.projects = [self.project.id]
 
     def test_simple_query(self):
-        with self.feature("organizations:metric-alert-ignore-archived"):
-            query = ErrorsQueryBuilder(
-                dataset=Dataset.Events,
-                query="status:unresolved",
-                selected_columns=["count_unique(user)"],
-                params={
-                    "project_id": self.projects,
-                },
-                offset=None,
-                limit=None,
-                config=QueryBuilderConfig(
-                    skip_time_conditions=True,
-                ),
-            ).get_snql_query()
+        query = ErrorsQueryBuilder(
+            dataset=Dataset.Events,
+            query="status:unresolved",
+            selected_columns=["count_unique(user)"],
+            params={
+                "project_id": self.projects,
+            },
+            offset=None,
+            limit=None,
+            config=QueryBuilderConfig(
+                skip_time_conditions=True,
+            ),
+        ).get_snql_query()
         query.validate()
         e_entity = Entity(Dataset.Events.value, alias=Dataset.Events.value)
         g_entity = Entity("group_attributes", alias="ga")
@@ -61,21 +60,20 @@ class ErrorsQueryBuilderTest(TestCase):
         ]
 
     def test_is_status_simple_query(self):
-        with self.feature("organizations:metric-alert-ignore-archived"):
-            query = ErrorsQueryBuilder(
-                dataset=Dataset.Events,
-                query="is:unresolved",
-                selected_columns=["count_unique(user)"],
-                params={
-                    "project_id": self.projects,
-                },
-                offset=None,
-                limit=None,
-                config=QueryBuilderConfig(
-                    skip_time_conditions=True,
-                    parser_config_overrides=PARSER_CONFIG_OVERRIDES,
-                ),
-            ).get_snql_query()
+        query = ErrorsQueryBuilder(
+            dataset=Dataset.Events,
+            query="is:unresolved",
+            selected_columns=["count_unique(user)"],
+            params={
+                "project_id": self.projects,
+            },
+            offset=None,
+            limit=None,
+            config=QueryBuilderConfig(
+                skip_time_conditions=True,
+                parser_config_overrides=PARSER_CONFIG_OVERRIDES,
+            ),
+        ).get_snql_query()
         query.validate()
         e_entity = Entity(Dataset.Events.value, alias=Dataset.Events.value)
         g_entity = Entity("group_attributes", alias="ga")

--- a/tests/sentry/snuba/test_entity_subscriptions.py
+++ b/tests/sentry/snuba/test_entity_subscriptions.py
@@ -550,10 +550,9 @@ class EntitySubscriptionTestCase(TestCase):
 
         entity = Entity(Dataset.Events.value, alias=Dataset.Events.value)
 
-        with self.feature("organizations:metric-alert-ignore-archived"):
-            snql_query = entity_subscription.build_query_builder(
-                "release:latest", [self.project.id], None
-            ).get_snql_query()
+        snql_query = entity_subscription.build_query_builder(
+            "release:latest", [self.project.id], None
+        ).get_snql_query()
         assert snql_query.query.select == [
             Function(
                 function="uniq",
@@ -594,10 +593,9 @@ class EntitySubscriptionTestCase(TestCase):
         e_entity = Entity(Dataset.Events.value, alias=Dataset.Events.value)
         g_entity = Entity("group_attributes", alias="ga")
 
-        with self.feature("organizations:metric-alert-ignore-archived"):
-            snql_query = entity_subscription.build_query_builder(
-                "status:unresolved", [self.project.id], None
-            ).get_snql_query()
+        snql_query = entity_subscription.build_query_builder(
+            "status:unresolved", [self.project.id], None
+        ).get_snql_query()
         assert snql_query.query.match == Join([Relationship(e_entity, "attributes", g_entity)])
         assert snql_query.query.select == [
             Function(

--- a/tests/sentry/snuba/test_tasks.py
+++ b/tests/sentry/snuba/test_tasks.py
@@ -156,11 +156,8 @@ class CreateSubscriptionInSnubaTest(BaseSnubaTaskTest):
         assert sub.subscription_id is not None
 
     def test_status_join(self):
-        with self.feature("organizations:metric-alert-ignore-archived"):
-            sub = self.create_subscription(
-                QuerySubscription.Status.CREATING, query="status:unresolved"
-            )
-            create_subscription_in_snuba(sub.id)
+        sub = self.create_subscription(QuerySubscription.Status.CREATING, query="status:unresolved")
+        create_subscription_in_snuba(sub.id)
         sub = QuerySubscription.objects.get(id=sub.id)
         assert sub.status == QuerySubscription.Status.ACTIVE.value
         assert sub.subscription_id is not None
@@ -594,24 +591,23 @@ class BuildSnqlQueryTest(TestCase):
     ):
         aggregate_kwargs = aggregate_kwargs if aggregate_kwargs else {}
         time_window = 3600
-        with self.feature("organizations:metric-alert-ignore-archived"):
-            entity_subscription = get_entity_subscription(
-                query_type=query_type,
-                dataset=dataset,
-                aggregate=aggregate,
-                time_window=time_window,
-                extra_fields=entity_extra_fields,
-            )
-            query_builder = entity_subscription.build_query_builder(
-                query=query,
-                project_ids=[self.project.id],
-                environment=environment,
-                params={
-                    "organization_id": self.organization.id,
-                    "project_id": [self.project.id],
-                },
-            )
-            snql_query = query_builder.get_snql_query()
+        entity_subscription = get_entity_subscription(
+            query_type=query_type,
+            dataset=dataset,
+            aggregate=aggregate,
+            time_window=time_window,
+            extra_fields=entity_extra_fields,
+        )
+        query_builder = entity_subscription.build_query_builder(
+            query=query,
+            project_ids=[self.project.id],
+            environment=environment,
+            params={
+                "organization_id": self.organization.id,
+                "project_id": [self.project.id],
+            },
+        )
+        snql_query = query_builder.get_snql_query()
         select = self.string_aggregate_to_snql(query_type, dataset, aggregate, aggregate_kwargs)
         if dataset == Dataset.Sessions:
             col_name = "sessions" if "sessions" in aggregate else "users"


### PR DESCRIPTION
Remove the flag for ignoring archived issues in metric alerts - it's been fully rolled out for a while. Relies on https://github.com/getsentry/sentry/pull/72832 being merged first.