### PR TITLE
fead(release-health): Decrease crash free decimal threshold to 90%

### DIFF
--- a/static/app/views/organizationStats/teamInsights/teamStability.spec.tsx
+++ b/static/app/views/organizationStats/teamInsights/teamStability.spec.tsx
@@ -27,7 +27,7 @@ describe('TeamStability', () => {
     );
 
     expect(screen.getByText('project-slug')).toBeInTheDocument();
-    expect(await screen.findAllByText('90%')).toHaveLength(2);
+    expect(await screen.findAllByText('90.416%')).toHaveLength(2);
     expect(await screen.findByText('0%')).toBeInTheDocument();
     expect(sessionsApi).toHaveBeenCalledTimes(2);
   });

--- a/static/app/views/releases/utils/index.tsx
+++ b/static/app/views/releases/utils/index.tsx
@@ -16,7 +16,7 @@ import {defined} from 'sentry/utils';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {IssueSortOptions} from 'sentry/views/issueList/utils';
 
-export const CRASH_FREE_DECIMAL_THRESHOLD = 95;
+export const CRASH_FREE_DECIMAL_THRESHOLD = 90;
 
 export const roundDuration = (seconds: number) => {
   return round(seconds, seconds > 60 ? 0 : 3);


### PR DESCRIPTION
We show three decimal places when displaying a crash-free rate if it's above 95%. If it's below that, we show 0. There's a user request, we lower the threshold to 90% and this PR is making it happen.

Closes https://github.com/getsentry/sentry/issues/64810