### PR TITLE
Remove one minute interval as an option for custom metrics

### DIFF
--- a/static/app/views/alerts/rules/metric/ruleConditionsForm.tsx
+++ b/static/app/views/alerts/rules/metric/ruleConditionsForm.tsx
@@ -142,6 +142,17 @@ class RuleConditionsForm extends PureComponent<Props, State> {
 
   get timeWindowOptions() {
     let options: Record<string, string> = TIME_WINDOW_MAP;
+    const {alertType} = this.props;
+
+    if (alertType === 'custom_metrics') {
+      // Do not show ONE MINUTE interval as an option for custom_metrics alert
+      options = Object.keys(TIME_WINDOW_MAP)
+        .filter(key => key !== TimeWindow.ONE_MINUTE.toString())
+        .reduce((obj, key) => {
+          obj[key] = options[key];
+          return obj;
+        }, {});
+    }
 
     if (isCrashFreeAlert(this.props.dataset)) {
       options = pick(TIME_WINDOW_MAP, [

--- a/static/app/views/alerts/rules/metric/ruleConditionsForm.tsx
+++ b/static/app/views/alerts/rules/metric/ruleConditionsForm.tsx
@@ -143,15 +143,11 @@ class RuleConditionsForm extends PureComponent<Props, State> {
 
   get timeWindowOptions() {
     let options: Record<string, string> = TIME_WINDOW_MAP;
-    const {alertType, timeWindow, onTimeWindowChange} = this.props;
+    const {alertType} = this.props;
 
     if (alertType === 'custom_metrics') {
       // Do not show ONE MINUTE interval as an option for custom_metrics alert
       options = omit(options, TimeWindow.ONE_MINUTE.toString());
-
-      if (timeWindow === TimeWindow.ONE_MINUTE) {
-        onTimeWindowChange(TimeWindow.FIVE_MINUTES);
-      }
     }
 
     if (isCrashFreeAlert(this.props.dataset)) {

--- a/static/app/views/alerts/rules/metric/ruleConditionsForm.tsx
+++ b/static/app/views/alerts/rules/metric/ruleConditionsForm.tsx
@@ -3,6 +3,7 @@ import type {InjectedRouter} from 'react-router';
 import {components} from 'react-select';
 import {css} from '@emotion/react';
 import styled from '@emotion/styled';
+import omit from 'lodash/omit';
 import pick from 'lodash/pick';
 
 import {addErrorMessage} from 'sentry/actionCreators/indicator';
@@ -146,12 +147,7 @@ class RuleConditionsForm extends PureComponent<Props, State> {
 
     if (alertType === 'custom_metrics') {
       // Do not show ONE MINUTE interval as an option for custom_metrics alert
-      options = Object.keys(TIME_WINDOW_MAP)
-        .filter(key => key !== TimeWindow.ONE_MINUTE.toString())
-        .reduce((obj, key) => {
-          obj[key] = options[key];
-          return obj;
-        }, {});
+      options = omit(options, TimeWindow.ONE_MINUTE.toString());
     }
 
     if (isCrashFreeAlert(this.props.dataset)) {

--- a/static/app/views/alerts/rules/metric/ruleConditionsForm.tsx
+++ b/static/app/views/alerts/rules/metric/ruleConditionsForm.tsx
@@ -143,11 +143,15 @@ class RuleConditionsForm extends PureComponent<Props, State> {
 
   get timeWindowOptions() {
     let options: Record<string, string> = TIME_WINDOW_MAP;
-    const {alertType} = this.props;
+    const {alertType, timeWindow, onTimeWindowChange} = this.props;
 
     if (alertType === 'custom_metrics') {
       // Do not show ONE MINUTE interval as an option for custom_metrics alert
       options = omit(options, TimeWindow.ONE_MINUTE.toString());
+
+      if (timeWindow === TimeWindow.ONE_MINUTE) {
+        onTimeWindowChange(TimeWindow.FIVE_MINUTES);
+      }
     }
 
     if (isCrashFreeAlert(this.props.dataset)) {

--- a/static/app/views/alerts/rules/metric/ruleForm.tsx
+++ b/static/app/views/alerts/rules/metric/ruleForm.tsx
@@ -526,6 +526,7 @@ class RuleFormContainer extends DeprecatedAsyncComponent<Props, State> {
       value === 'generic_metrics' &&
       this.state.timeWindow === TimeWindow.ONE_MINUTE
     ) {
+      // ONE MINUTE interval is not allowed for custom metrics alerts
       this.setState({timeWindow: TimeWindow.FIVE_MINUTES});
     }
 

--- a/static/app/views/alerts/rules/metric/ruleForm.tsx
+++ b/static/app/views/alerts/rules/metric/ruleForm.tsx
@@ -512,22 +512,18 @@ class RuleFormContainer extends DeprecatedAsyncComponent<Props, State> {
 
   handleFieldChange = (name: string, value: unknown) => {
     const {projects} = this.props;
+    const {timeWindow} = this.state;
 
     if (name === 'alertType') {
       this.setState(({dataset}) => ({
         alertType: value as MetricAlertType,
         dataset: this.checkOnDemandMetricsDataset(dataset, this.state.query),
+        timeWindow:
+          value === 'custom_metrics' && timeWindow === TimeWindow.ONE_MINUTE
+            ? TimeWindow.FIVE_MINUTES
+            : timeWindow,
       }));
       return;
-    }
-
-    if (
-      name === 'dataset' &&
-      value === 'generic_metrics' &&
-      this.state.timeWindow === TimeWindow.ONE_MINUTE
-    ) {
-      // ONE MINUTE interval is not allowed for custom metrics alerts
-      this.setState({timeWindow: TimeWindow.FIVE_MINUTES});
     }
 
     if (

--- a/static/app/views/alerts/rules/metric/ruleForm.tsx
+++ b/static/app/views/alerts/rules/metric/ruleForm.tsx
@@ -91,6 +91,7 @@ import {
   AlertRuleThresholdType,
   AlertRuleTriggerType,
   Dataset,
+  TimeWindow,
 } from './types';
 
 const POLLING_MAX_TIME_LIMIT = 3 * 60000;
@@ -518,6 +519,14 @@ class RuleFormContainer extends DeprecatedAsyncComponent<Props, State> {
         dataset: this.checkOnDemandMetricsDataset(dataset, this.state.query),
       }));
       return;
+    }
+
+    if (
+      name === 'dataset' &&
+      value === 'generic_metrics' &&
+      this.state.timeWindow === TimeWindow.ONE_MINUTE
+    ) {
+      this.setState({timeWindow: TimeWindow.FIVE_MINUTES});
     }
 
     if (


### PR DESCRIPTION
Part of: [#72843](https://github.com/getsentry/sentry/issues/72843)

Alerts for custom metrics and time interval of 1 minute are not reliable due to a big latency (around 3 minutes) when custom metrics are ingested. Because of that, we will disable users to use 1 minute alert interval for custom metrics alerts. This change is only present on custom metrics alert creation.