### PR TITLE
tmp(processingstore): Temporarily remove tracing from processingstore methods

### DIFF
--- a/src/sentry/eventstore/processing/base.py
+++ b/src/sentry/eventstore/processing/base.py
@@ -4,8 +4,6 @@ from collections.abc import MutableMapping
 from datetime import timedelta
 from typing import Any
 
-import sentry_sdk
-
 from sentry.utils.cache import cache_key_for_event
 from sentry.utils.kvstore.abstract import KVStorage
 from sentry.utils.services import Service
@@ -40,7 +38,6 @@ class EventProcessingStore(Service):
         key = cache_key_for_event(event)
         return self.get(key) is not None
 
-    @sentry_sdk.tracing.trace
     def store(self, event: Event, unprocessed: bool = False) -> str:
         key = cache_key_for_event(event)
         if unprocessed:
@@ -48,13 +45,11 @@ class EventProcessingStore(Service):
         self.inner.set(key, event, self.timeout)
         return key
 
-    @sentry_sdk.tracing.trace
     def get(self, key: str, unprocessed: bool = False) -> MutableMapping[str, Any] | None:
         if unprocessed:
             key = self.__get_unprocessed_key(key)
         return self.inner.get(key)
 
-    @sentry_sdk.tracing.trace
     def delete_by_key(self, key: str) -> None:
         self.inner.delete(key)
         self.inner.delete(self.__get_unprocessed_key(key))


### PR DESCRIPTION
This PR removes the tracing decorators from processing store methods for the duration of an experiment with different secondary backend using the [ServiceDelegator](https://github.com/getsentry/sentry/blob/master/src/sentry/utils/services.py#L329). Due to the threaded executor used in this setup the tracing is broken for the secondary backend spamming the logs with warnings 

```
{"event":"Can not create a child span for sentry.eventstore.processing.base.EventProcessingStore.get. Please start a Sentry transaction before calling this function.", "level":"warning", "name":"sentry_sdk.errors"}
```

<!-- Describe your PR here. -->

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
