### PR TITLE
chore(slack): remove old slack client from notify recipient

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -392,8 +392,6 @@ def register_temporary_features(manager: FeatureManager):
     # Enable improvements to Slack notifications
     manager.add("organizations:slack-improvements", OrganizationFeature, FeatureHandlerStrategy.OPTIONS)
     # Feature flags for migrating to the Slack SDK WebClient
-    # Use new Slack SDK Client in _notify_recipient
-    manager.add("organizations:slack-sdk-notify-recipient", OrganizationFeature, FeatureHandlerStrategy.OPTIONS)
     # Use new Slack SDK Client in get_channel_id_with_timeout
     manager.add("organizations:slack-sdk-get-channel-id", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE)
     # Use new Slack SDK Client to respond to link commands

--- a/src/sentry/integrations/slack/metrics.py
+++ b/src/sentry/integrations/slack/metrics.py
@@ -6,6 +6,8 @@ SLACK_ACTIVITY_THREAD_SUCCESS_DATADOG_METRIC = "sentry.integrations.slack.activi
 SLACK_ACTIVITY_THREAD_FAILURE_DATADOG_METRIC = "sentry.integrations.slack.activity_thread.failure"
 SLACK_METRIC_ALERT_SUCCESS_DATADOG_METRIC = "sentry.integrations.slack.metric_alert.success"
 SLACK_METRIC_ALERT_FAILURE_DATADOG_METRIC = "sentry.integrations.slack.metric_alert.failure"
+SLACK_NOTIFY_RECIPIENT_SUCCESS_DATADOG_METRIC = "sentry.integrations.slack.notify_recipient.success"
+SLACK_NOTIFY_RECIPIENT_FAILURE_DATADOG_METRIC = "sentry.integrations.slack.notify_recipient.failure"
 
 # Bot commands
 SLACK_BOT_COMMAND_LINK_IDENTITY_SUCCESS_DATADOG_METRIC = (

--- a/src/sentry/integrations/slack/notifications.py
+++ b/src/sentry/integrations/slack/notifications.py
@@ -8,7 +8,6 @@ from typing import Any
 import orjson
 import sentry_sdk
 
-from sentry import features
 from sentry.integrations.mixins import NotifyBasicMixin
 from sentry.integrations.notifications import get_context, get_integrations_by_channel_by_recipient
 from sentry.integrations.slack.message_builder import SlackBlock
@@ -110,26 +109,17 @@ def _notify_recipient(
         if SiloMode.get_current_mode() == SiloMode.CONTROL:
             post_message_task = post_message_control
 
-        has_sdk_flag = features.has(
-            "organizations:slack-sdk-notify-recipient", notification.organization
-        )
-
         log_params = {
             "notification": str(notification),
             "recipient": recipient.id,
             "channel_id": channel,
         }
-        if has_sdk_flag:
-            log_error_message = "slack.notify_recipient.fail"
-        else:
-            log_error_message = "notification.fail.slack_post"
         post_message_task.apply_async(
             kwargs={
                 "integration_id": integration.id,
                 "payload": payload,
-                "log_error_message": log_error_message,
+                "log_error_message": "slack.notify_recipient.fail",
                 "log_params": log_params,
-                "has_sdk_flag": has_sdk_flag,
             }
         )
     # recording data outside of span

--- a/src/sentry/notifications/notifications/organization_request/abstract_invite_request.py
+++ b/src/sentry/notifications/notifications/organization_request/abstract_invite_request.py
@@ -78,7 +78,7 @@ class AbstractInviteRequestNotification(OrganizationRequestNotification, abc.ABC
             MessageAction(
                 name="Reject",
                 style="danger",
-                action_id="approve_request",
+                action_id="reject_request",
                 value="reject_member",
                 label="Reject",
             ),

--- a/src/sentry/tasks/integrations/slack/post_message.py
+++ b/src/sentry/tasks/integrations/slack/post_message.py
@@ -23,7 +23,7 @@ def _send_message_to_slack_channel(
     payload: Mapping[str, Any],
     log_error_message: str,
     log_params: Mapping[str, Any],
-    has_sdk_flag: bool | None = False,  # TODO: remove all these
+    has_sdk_flag: bool | None = True,  # TODO: remove all these
 ) -> None:
     client = SlackSdkClient(integration_id=integration_id)
     try:
@@ -58,7 +58,7 @@ def post_message(
     payload: Mapping[str, Any],
     log_error_message: str,
     log_params: Mapping[str, Any],
-    has_sdk_flag: bool | None = False,
+    has_sdk_flag: bool | None = True,
 ) -> None:
     _send_message_to_slack_channel(
         integration_id=integration_id,
@@ -80,7 +80,7 @@ def post_message_control(
     payload: Mapping[str, Any],
     log_error_message: str,
     log_params: Mapping[str, Any],
-    has_sdk_flag: bool,
+    has_sdk_flag: bool | None = True,
 ) -> None:
     _send_message_to_slack_channel(
         integration_id=integration_id,

--- a/src/sentry/tasks/integrations/slack/post_message.py
+++ b/src/sentry/tasks/integrations/slack/post_message.py
@@ -33,6 +33,7 @@ def _send_message_to_slack_channel(
             channel=str(payload.get("channel", "")),
             unfurl_links=False,
             unfurl_media=False,
+            callback_id=str(payload.get("callback_id", "")),
         )
         metrics.incr(SLACK_NOTIFY_RECIPIENT_SUCCESS_DATADOG_METRIC, sample_rate=1.0)
     except SlackApiError as e:

--- a/src/sentry/tasks/integrations/slack/post_message.py
+++ b/src/sentry/tasks/integrations/slack/post_message.py
@@ -6,11 +6,14 @@ from typing import Any
 
 from slack_sdk.errors import SlackApiError
 
-from sentry.integrations.slack.client import SlackClient
+from sentry.integrations.slack.metrics import (
+    SLACK_NOTIFY_RECIPIENT_FAILURE_DATADOG_METRIC,
+    SLACK_NOTIFY_RECIPIENT_SUCCESS_DATADOG_METRIC,
+)
 from sentry.integrations.slack.sdk_client import SlackSdkClient
-from sentry.shared_integrations.exceptions import ApiError
 from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task
+from sentry.utils import metrics
 
 logger = logging.getLogger("sentry.integrations.slack.tasks")
 
@@ -20,29 +23,26 @@ def _send_message_to_slack_channel(
     payload: Mapping[str, Any],
     log_error_message: str,
     log_params: Mapping[str, Any],
-    has_sdk_flag: bool | None = False,
+    has_sdk_flag: bool | None = False,  # TODO: remove all these
 ) -> None:
-    if has_sdk_flag:
-        sdk_client = SlackSdkClient(integration_id=integration_id)
-        try:
-            sdk_client.chat_postMessage(
-                blocks=str(payload.get("blocks", "")),
-                text=str(payload.get("text", "")),
-                channel=str(payload.get("channel", "")),
-                unfurl_links=False,
-                unfurl_media=False,
-            )
-            logger.info("slack.send_message_to_channel.success", extra=log_params)
-        except SlackApiError as e:
-            extra = {"error": str(e), **log_params}
-            logger.info(log_error_message, extra=extra)
-    else:
-        client = SlackClient(integration_id=integration_id)
-        try:
-            client.post("/chat.postMessage", data=payload, timeout=5)
-        except ApiError as e:
-            extra = {"error": str(e), **log_params}
-            logger.info(log_error_message, extra=extra)
+    sdk_client = SlackSdkClient(integration_id=integration_id)
+    try:
+        sdk_client.chat_postMessage(
+            blocks=str(payload.get("blocks", "")),
+            text=str(payload.get("text", "")),
+            channel=str(payload.get("channel", "")),
+            unfurl_links=False,
+            unfurl_media=False,
+        )
+        metrics.incr(SLACK_NOTIFY_RECIPIENT_SUCCESS_DATADOG_METRIC, sample_rate=1.0)
+    except SlackApiError as e:
+        extra = {"error": str(e), **log_params}
+        logger.info(log_error_message, extra=extra)
+        metrics.incr(
+            SLACK_NOTIFY_RECIPIENT_FAILURE_DATADOG_METRIC,
+            sample_rate=1.0,
+            tags={"ok": e.response.get("ok", False), "status": e.response.status_code},
+        )
 
 
 # TODO: add retry logic
@@ -64,7 +64,6 @@ def post_message(
         payload=payload,
         log_error_message=log_error_message,
         log_params=log_params,
-        has_sdk_flag=has_sdk_flag,
     )
 
 
@@ -87,5 +86,4 @@ def post_message_control(
         payload=payload,
         log_error_message=log_error_message,
         log_params=log_params,
-        has_sdk_flag=has_sdk_flag,
     )

--- a/src/sentry/tasks/integrations/slack/post_message.py
+++ b/src/sentry/tasks/integrations/slack/post_message.py
@@ -25,9 +25,9 @@ def _send_message_to_slack_channel(
     log_params: Mapping[str, Any],
     has_sdk_flag: bool | None = False,  # TODO: remove all these
 ) -> None:
-    sdk_client = SlackSdkClient(integration_id=integration_id)
+    client = SlackSdkClient(integration_id=integration_id)
     try:
-        sdk_client.chat_postMessage(
+        client.chat_postMessage(
             blocks=str(payload.get("blocks", "")),
             text=str(payload.get("text", "")),
             channel=str(payload.get("channel", "")),

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -2893,13 +2893,6 @@ class SlackActivityNotificationTest(ActivityTestCase):
                 status=IdentityStatus.VALID,
                 scopes=[],
             )
-        responses.add(
-            method=responses.POST,
-            url="https://slack.com/api/chat.postMessage",
-            body='{"ok": true}',
-            status=200,
-            content_type="application/json",
-        )
         self.name = self.user.get_display_name()
         self.short_id = self.group.qualified_short_id
 

--- a/tests/sentry/api/endpoints/test_organization_invite_request_index.py
+++ b/tests/sentry/api/endpoints/test_organization_invite_request_index.py
@@ -2,7 +2,6 @@ from functools import cached_property
 from urllib.parse import parse_qs, urlparse
 
 import orjson
-import responses
 from django.core import mail
 from django.urls import reverse
 
@@ -10,7 +9,6 @@ from sentry.models.options.organization_option import OrganizationOption
 from sentry.models.organizationmember import InviteStatus, OrganizationMember
 from sentry.models.organizationmemberteam import OrganizationMemberTeam
 from sentry.testutils.cases import APITestCase, SlackActivityNotificationTest
-from sentry.testutils.helpers.slack import get_blocks_and_fallback_text
 from sentry.testutils.hybrid_cloud import HybridCloudTestMixin
 from sentry.testutils.outbox import outbox_runner
 
@@ -186,7 +184,6 @@ class OrganizationInviteRequestCreateTest(
         assert mail.outbox[0].subject == expected_subject
         assert "eric@localhost" in mail.outbox[0].body
 
-    @responses.activate
     def test_request_to_invite_slack(self):
         with self.tasks():
             self.get_success_response(
@@ -197,7 +194,9 @@ class OrganizationInviteRequestCreateTest(
                 status_code=201,
             )
 
-        blocks, fallback_text = get_blocks_and_fallback_text()
+        blocks = orjson.loads(self.mock_post.call_args.kwargs["blocks"])
+        fallback_text = self.mock_post.call_args.kwargs["text"]
+
         assert (
             fallback_text
             == f"foo@localhost is requesting to invite eric@localhost into {self.organization.name}"
@@ -217,7 +216,7 @@ class OrganizationInviteRequestCreateTest(
             {
                 "type": "button",
                 "text": {"type": "plain_text", "text": "Reject"},
-                "action_id": "approve_request",
+                "action_id": "reject_request",
                 "value": "reject_member",
             },
             {
@@ -233,8 +232,8 @@ class OrganizationInviteRequestCreateTest(
             == f"You are receiving this notification because you have the scope member:write | <http://testserver/settings/account/notifications/approval/?referrer=invite_request-slack-user&notification_uuid={notification_uuid}|Notification Settings>"
         )
         member = OrganizationMember.objects.get(email="eric@localhost")
-        data = parse_qs(responses.calls[0].request.body)
-        assert orjson.loads(data["callback_id"][0]) == {
+        callback_id = orjson.loads(self.mock_post.call_args.kwargs["callback_id"])
+        assert callback_id == {
             "member_id": member.id,
             "member_email": "eric@localhost",
         }

--- a/tests/sentry/api/endpoints/test_organization_join_request.py
+++ b/tests/sentry/api/endpoints/test_organization_join_request.py
@@ -3,7 +3,6 @@ from unittest.mock import patch
 from urllib.parse import parse_qs, urlparse
 
 import orjson
-import responses
 from django.core import mail
 
 from sentry.models.authprovider import AuthProvider
@@ -12,7 +11,6 @@ from sentry.models.organizationmember import InviteStatus, OrganizationMember
 from sentry.silo.base import SiloMode
 from sentry.testutils.cases import APITestCase, SlackActivityNotificationTest
 from sentry.testutils.helpers.features import with_feature
-from sentry.testutils.helpers.slack import get_blocks_and_fallback_text
 from sentry.testutils.hybrid_cloud import HybridCloudTestMixin
 from sentry.testutils.outbox import outbox_runner
 from sentry.testutils.silo import assume_test_silo_mode
@@ -174,12 +172,13 @@ class OrganizationJoinRequestTest(APITestCase, SlackActivityNotificationTest, Hy
         assert mail.outbox[0].subject == f"Access request to {self.organization.name}"
         assert self.organization.absolute_url("/settings/members/") in mail.outbox[0].body
 
-    @responses.activate
     def test_request_to_join_slack(self):
         with self.tasks():
             self.get_success_response(self.organization.slug, email=self.email, status_code=204)
 
-        blocks, fallback_text = get_blocks_and_fallback_text()
+        blocks = orjson.loads(self.mock_post.call_args.kwargs["blocks"])
+        fallback_text = self.mock_post.call_args.kwargs["text"]
+
         assert fallback_text == f"{self.email} is requesting to join {self.organization.name}"
         query_params = parse_qs(urlparse(blocks[1]["elements"][0]["text"]).query)
         notification_uuid = query_params["notification_uuid"][0]
@@ -197,7 +196,7 @@ class OrganizationJoinRequestTest(APITestCase, SlackActivityNotificationTest, Hy
             {
                 "type": "button",
                 "text": {"type": "plain_text", "text": "Reject"},
-                "action_id": "approve_request",
+                "action_id": "reject_request",
                 "value": "reject_member",
             },
             {
@@ -207,12 +206,11 @@ class OrganizationJoinRequestTest(APITestCase, SlackActivityNotificationTest, Hy
                 "value": "link_clicked",
             },
         ]
-
-        data = parse_qs(responses.calls[0].request.body)
+        callback_id = orjson.loads(self.mock_post.call_args.kwargs["callback_id"])
 
         with outbox_runner():
             member = OrganizationMember.objects.get(email=self.email)
-        assert orjson.loads(data["callback_id"][0]) == {
+        assert callback_id == {
             "member_id": member.id,
             "member_email": self.email,
         }

--- a/tests/sentry/integrations/slack/notifications/test_assigned.py
+++ b/tests/sentry/integrations/slack/notifications/test_assigned.py
@@ -1,7 +1,6 @@
 from unittest import mock
-from urllib.parse import parse_qs
 
-import responses
+import orjson
 
 from sentry.integrations.types import ExternalProviders
 from sentry.models.activity import Activity
@@ -9,7 +8,6 @@ from sentry.notifications.notifications.activity.assigned import AssignedActivit
 from sentry.testutils.cases import PerformanceIssueTestCase, SlackActivityNotificationTest
 from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.helpers.notifications import TEST_ISSUE_OCCURRENCE, TEST_PERF_ISSUE_OCCURRENCE
-from sentry.testutils.helpers.slack import get_blocks_and_fallback_text
 from sentry.testutils.skips import requires_snuba
 from sentry.types.activity import ActivityType
 
@@ -28,7 +26,6 @@ class SlackAssignedNotificationTest(SlackActivityNotificationTest, PerformanceIs
             )
         )
 
-    @responses.activate
     def test_multiple_identities(self):
         """
         Test that we notify a user with multiple Identities in each place
@@ -50,30 +47,21 @@ class SlackAssignedNotificationTest(SlackActivityNotificationTest, PerformanceIs
             external_id="UXXXXXXX2",
             identity_provider=idp2,
         )
-        # create a second response
-        responses.add(
-            method=responses.POST,
-            url="https://slack.com/api/chat.postMessage",
-            body='{"ok": true}',
-            status=200,
-            content_type="application/json",
-        )
 
         with self.tasks():
             self.create_notification(self.group, AssignedActivityNotification).send()
 
-        assert len(responses.calls) >= 2
-        data = parse_qs(responses.calls[0].request.body)
+        assert self.mock_post.call_count == 2
+        data = self.mock_post.call_args_list[0].kwargs
         assert "channel" in data
-        channel = data["channel"][0]
+        channel = data["channel"]
         assert channel == self.identity.external_id
 
-        data = parse_qs(responses.calls[1].request.body)
+        data = self.mock_post.call_args_list[1].kwargs
         assert "channel" in data
-        channel = data["channel"][0]
+        channel = data["channel"]
         assert channel == identity2.external_id
 
-    @responses.activate
     def test_multiple_orgs(self):
         """
         Test that if a user is in 2 orgs with Slack and has an Identity linked in each,
@@ -93,25 +81,13 @@ class SlackAssignedNotificationTest(SlackActivityNotificationTest, PerformanceIs
         )
         idp2 = self.create_identity_provider(type="slack", external_id="TXXXXXXX2")
         self.create_identity(external_id="UXXXXXXX2", identity_provider=idp2, user=self.user)
-        # create a second response that won't actually be used, but here to make sure it's not a false positive
-        responses.add(
-            method=responses.POST,
-            url="https://slack.com/api/chat.postMessage",
-            body='{"ok": true}',
-            status=200,
-            content_type="application/json",
-        )
 
         with self.tasks():
             self.create_notification(self.group, AssignedActivityNotification).send()
 
-        assert len(responses.calls) == 1
-        data = parse_qs(responses.calls[0].request.body)
-        assert "channel" in data
-        channel = data["channel"][0]
-        assert channel == self.identity.external_id
+        assert self.mock_post.call_count == 1
+        assert self.mock_post.call_args.kwargs["channel"] == self.identity.external_id
 
-    @responses.activate
     def test_assignment_block(self):
         """
         Test that a Slack message is sent with the expected payload when an issue is assigned
@@ -119,7 +95,8 @@ class SlackAssignedNotificationTest(SlackActivityNotificationTest, PerformanceIs
         """
         with self.tasks():
             self.create_notification(self.group, AssignedActivityNotification).send()
-        blocks, fallback_text = get_blocks_and_fallback_text()
+        blocks = orjson.loads(self.mock_post.call_args.kwargs["blocks"])
+        fallback_text = self.mock_post.call_args.kwargs["text"]
         assert fallback_text == f"Issue assigned to {self.name} by themselves"
         assert blocks[0]["text"]["text"] == fallback_text
         notification_uuid = self.get_notification_uuid(blocks[1]["text"]["text"])
@@ -132,7 +109,6 @@ class SlackAssignedNotificationTest(SlackActivityNotificationTest, PerformanceIs
             == f"{self.project.slug} | <http://testserver/settings/account/notifications/workflow/?referrer=assigned_activity-slack-user&notification_uuid={notification_uuid}&organizationId={self.organization.id}|Notification Settings>"
         )
 
-    @responses.activate
     @mock.patch(
         "sentry.eventstore.models.GroupEvent.occurrence",
         return_value=TEST_ISSUE_OCCURRENCE,
@@ -150,7 +126,8 @@ class SlackAssignedNotificationTest(SlackActivityNotificationTest, PerformanceIs
 
         with self.tasks():
             self.create_notification(group_event.group, AssignedActivityNotification).send()
-        blocks, fallback_text = get_blocks_and_fallback_text()
+        blocks = orjson.loads(self.mock_post.call_args.kwargs["blocks"])
+        fallback_text = self.mock_post.call_args.kwargs["text"]
         assert fallback_text == f"Issue assigned to {self.name} by themselves"
         assert blocks[0]["text"]["text"] == fallback_text
         self.assert_generic_issue_blocks(
@@ -161,7 +138,6 @@ class SlackAssignedNotificationTest(SlackActivityNotificationTest, PerformanceIs
             "assigned_activity-slack",
         )
 
-    @responses.activate
     @mock.patch(
         "sentry.eventstore.models.GroupEvent.occurrence",
         return_value=TEST_PERF_ISSUE_OCCURRENCE,
@@ -176,7 +152,8 @@ class SlackAssignedNotificationTest(SlackActivityNotificationTest, PerformanceIs
         with self.tasks():
             self.create_notification(event.group, AssignedActivityNotification).send()
 
-        blocks, fallback_text = get_blocks_and_fallback_text()
+        blocks = orjson.loads(self.mock_post.call_args.kwargs["blocks"])
+        fallback_text = self.mock_post.call_args.kwargs["text"]
         assert fallback_text == f"Issue assigned to {self.name} by themselves"
         assert blocks[0]["text"]["text"] == fallback_text
         self.assert_performance_issue_blocks(

--- a/tests/sentry/integrations/slack/notifications/test_assigned.py
+++ b/tests/sentry/integrations/slack/notifications/test_assigned.py
@@ -164,7 +164,6 @@ class SlackAssignedNotificationTest(SlackActivityNotificationTest, PerformanceIs
             "assigned_activity-slack",
         )
 
-    @responses.activate
     @mock.patch(
         "sentry.eventstore.models.GroupEvent.occurrence",
         return_value=TEST_PERF_ISSUE_OCCURRENCE,
@@ -180,7 +179,9 @@ class SlackAssignedNotificationTest(SlackActivityNotificationTest, PerformanceIs
         with self.tasks():
             self.create_notification(event.group, AssignedActivityNotification).send()
 
-        blocks, fallback_text = get_blocks_and_fallback_text()
+        blocks = orjson.loads(self.mock_post.call_args.kwargs["blocks"])
+        fallback_text = self.mock_post.call_args.kwargs["text"]
+
         assert fallback_text == f"Issue assigned to {self.name} by themselves"
         assert blocks[0]["text"]["text"] == fallback_text
         self.assert_performance_issue_blocks_with_culprit_blocks(

--- a/tests/sentry/integrations/slack/notifications/test_issue_alert.py
+++ b/tests/sentry/integrations/slack/notifications/test_issue_alert.py
@@ -2,7 +2,6 @@ import uuid
 from datetime import UTC, datetime
 from unittest import mock
 from unittest.mock import patch
-from urllib.parse import parse_qs
 
 import orjson
 import responses

--- a/tests/sentry/integrations/slack/notifications/test_issue_alert.py
+++ b/tests/sentry/integrations/slack/notifications/test_issue_alert.py
@@ -33,7 +33,6 @@ from sentry.tasks.digests import deliver_digest
 from sentry.testutils.cases import PerformanceIssueTestCase, SlackActivityNotificationTest
 from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.helpers.notifications import TEST_ISSUE_OCCURRENCE, TEST_PERF_ISSUE_OCCURRENCE
-from sentry.testutils.helpers.slack import get_blocks_and_fallback_text
 from sentry.testutils.silo import assume_test_silo_mode
 from sentry.testutils.skips import requires_snuba
 
@@ -64,7 +63,6 @@ class SlackIssueAlertNotificationTest(SlackActivityNotificationTest, Performance
             },
         )
 
-    @responses.activate
     def test_issue_alert_user_block(self):
         """
         Test that issues alert are sent to a Slack user with the proper payload when block kit is
@@ -84,7 +82,8 @@ class SlackIssueAlertNotificationTest(SlackActivityNotificationTest, Performance
         with self.tasks():
             notification.send()
 
-        blocks, fallback_text = get_blocks_and_fallback_text()
+        blocks = orjson.loads(self.mock_post.call_args.kwargs["blocks"])
+        fallback_text = self.mock_post.call_args.kwargs["text"]
         assert (
             fallback_text
             == f"Alert triggered <http://testserver/organizations/{event.organization.slug}/alerts/rules/{event.project.slug}/{self.rule.id}/details/|ja rule>"
@@ -101,8 +100,8 @@ class SlackIssueAlertNotificationTest(SlackActivityNotificationTest, Performance
         )
 
     @responses.activate
-    @mock.patch("sentry.integrations.slack.message_builder.issues.get_tags", new=fake_get_tags)
-    @mock.patch(
+    @patch("sentry.integrations.slack.message_builder.issues.get_tags", new=fake_get_tags)
+    @patch(
         "sentry.eventstore.models.GroupEvent.occurrence",
         return_value=TEST_PERF_ISSUE_OCCURRENCE,
         new_callable=mock.PropertyMock,
@@ -121,7 +120,8 @@ class SlackIssueAlertNotificationTest(SlackActivityNotificationTest, Performance
         with self.tasks():
             notification.send()
 
-        blocks, fallback_text = get_blocks_and_fallback_text()
+        blocks = orjson.loads(self.mock_post.call_args.kwargs["blocks"])
+        fallback_text = self.mock_post.call_args.kwargs["text"]
         assert (
             fallback_text
             == f"Alert triggered <http://testserver/organizations/{event.organization.slug}/alerts/rules/{event.project.slug}/{self.rule.id}/details/|ja rule>"
@@ -159,7 +159,8 @@ class SlackIssueAlertNotificationTest(SlackActivityNotificationTest, Performance
         with self.tasks():
             notification.send()
 
-        blocks, fallback_text = get_blocks_and_fallback_text()
+        blocks = orjson.loads(self.mock_post.call_args.kwargs["blocks"])
+        fallback_text = self.mock_post.call_args.kwargs["text"]
         assert (
             fallback_text
             == f"Alert triggered <http://testserver/organizations/{event.organization.slug}/alerts/rules/{event.project.slug}/{self.rule.id}/details/|ja rule>"
@@ -211,15 +212,15 @@ class SlackIssueAlertNotificationTest(SlackActivityNotificationTest, Performance
         with self.tasks():
             notification.send()
 
-        blocks, fallback_text = get_blocks_and_fallback_text()
+        blocks = orjson.loads(self.mock_post.call_args.kwargs["blocks"])
+        fallback_text = self.mock_post.call_args.kwargs["text"]
         assert (
             fallback_text
             == f"Alert triggered <http://testserver/organizations/{event.organization.slug}/alerts/rules/{event.project.slug}/{self.rule.id}/details/|ja rule>"
         )
         assert len(blocks) == 5
 
-    @responses.activate
-    @mock.patch(
+    @patch(
         "sentry.eventstore.models.GroupEvent.occurrence",
         return_value=TEST_ISSUE_OCCURRENCE,
         new_callable=mock.PropertyMock,
@@ -240,7 +241,8 @@ class SlackIssueAlertNotificationTest(SlackActivityNotificationTest, Performance
         with self.tasks():
             notification.send()
 
-        blocks, fallback_text = get_blocks_and_fallback_text()
+        blocks = orjson.loads(self.mock_post.call_args.kwargs["blocks"])
+        fallback_text = self.mock_post.call_args.kwargs["text"]
         assert (
             fallback_text
             == f"Alert triggered <http://testserver/organizations/{event.organization.slug}/alerts/rules/{event.project.slug}/{self.rule.id}/details/|ja rule>"
@@ -257,7 +259,6 @@ class SlackIssueAlertNotificationTest(SlackActivityNotificationTest, Performance
             issue_link_extra_params=f"&alert_rule_id={self.rule.id}&alert_type=issue",
         )
 
-    @responses.activate
     def test_disabled_org_integration_for_user(self):
         with assume_test_silo_mode(SiloMode.CONTROL):
             OrganizationIntegration.objects.get(integration=self.integration).update(
@@ -275,9 +276,8 @@ class SlackIssueAlertNotificationTest(SlackActivityNotificationTest, Performance
         with self.tasks():
             notification.send()
 
-        assert len(responses.calls) == 0
+        assert not self.mock_post.called
 
-    @responses.activate
     def test_issue_alert_issue_owners_block(self):
         """
         Test that issue alerts are sent to issue owners in Slack with the proper payload when block
@@ -312,7 +312,8 @@ class SlackIssueAlertNotificationTest(SlackActivityNotificationTest, Performance
         with self.tasks():
             notification.send()
 
-        blocks, fallback_text = get_blocks_and_fallback_text()
+        blocks = orjson.loads(self.mock_post.call_args.kwargs["blocks"])
+        fallback_text = self.mock_post.call_args.kwargs["text"]
         notification_uuid = notification.notification_uuid
         assert (
             fallback_text
@@ -329,7 +330,6 @@ class SlackIssueAlertNotificationTest(SlackActivityNotificationTest, Performance
             == f"{event.project.slug} | <http://testserver/settings/account/notifications/alerts/?referrer=issue_alert-slack-user&notification_uuid={notification_uuid}&organizationId={event.organization.id}|Notification Settings>"
         )
 
-    @responses.activate
     def test_issue_alert_issue_owners_environment_block(self):
         """
         Test that issue alerts are sent to issue owners in Slack with the environment in the query
@@ -372,7 +372,8 @@ class SlackIssueAlertNotificationTest(SlackActivityNotificationTest, Performance
         with self.tasks():
             notification.send()
 
-        blocks, fallback_text = get_blocks_and_fallback_text()
+        blocks = orjson.loads(self.mock_post.call_args.kwargs["blocks"])
+        fallback_text = self.mock_post.call_args.kwargs["text"]
         notification_uuid = notification.notification_uuid
         assert (
             fallback_text
@@ -389,7 +390,6 @@ class SlackIssueAlertNotificationTest(SlackActivityNotificationTest, Performance
             == f"{event.project.slug} | {environment.name} | <http://testserver/settings/account/notifications/alerts/?referrer=issue_alert-slack-user&notification_uuid={notification_uuid}&organizationId={event.organization.id}|Notification Settings>"
         )
 
-    @responses.activate
     def test_issue_alert_team_issue_owners_block(self):
         """
         Test that issue alerts are sent to a team in Slack via an Issue Owners rule action with the
@@ -464,15 +464,12 @@ class SlackIssueAlertNotificationTest(SlackActivityNotificationTest, Performance
 
         # check that only one was sent out - more would mean each user is being notified
         # rather than the team
-        assert len(responses.calls) == 1
+        assert self.mock_post.call_count == 1
 
         # check that the team got a notification
-        data = parse_qs(responses.calls[0].request.body)
-        assert data["channel"] == ["CXXXXXXX2"]
-        assert "blocks" in data
-        assert "text" in data
-        blocks = orjson.loads(data["blocks"][0])
-        fallback_text = data["text"][0]
+        assert self.mock_post.call_args.kwargs["channel"] == "CXXXXXXX2"
+        blocks = orjson.loads(self.mock_post.call_args.kwargs["blocks"])
+        fallback_text = self.mock_post.call_args.kwargs["text"]
         notification_uuid = notification.notification_uuid
 
         assert (
@@ -567,15 +564,13 @@ class SlackIssueAlertNotificationTest(SlackActivityNotificationTest, Performance
 
         # check that only one was sent out - more would mean each user is being notified
         # rather than the team
-        assert len(responses.calls) == 1
+        assert self.mock_post.call_count == 1
 
         # check that the team got a notification
-        data = parse_qs(responses.calls[0].request.body)
-        assert data["channel"] == ["CXXXXXXX2"]
-        assert "blocks" in data
-        assert "text" in data
-        blocks = orjson.loads(data["blocks"][0])
-        fallback_text = data["text"][0]
+        blocks = orjson.loads(self.mock_post.call_args.kwargs["blocks"])
+        fallback_text = self.mock_post.call_args.kwargs["text"]
+        channel = self.mock_post.call_args.kwargs["channel"]
+        assert channel == "CXXXXXXX2"
         notification_uuid = notification.notification_uuid
 
         assert (
@@ -647,9 +642,8 @@ class SlackIssueAlertNotificationTest(SlackActivityNotificationTest, Performance
             notification.send()
 
         # org integrationon disabled
-        assert len(responses.calls) == 0
+        assert self.mock_post.call_count == 0
 
-    @responses.activate
     @patch.object(sentry, "digests")
     def test_issue_alert_team_issue_owners_user_settings_off_digests(self, digests):
         """Test that issue alerts are sent to a team in Slack via an Issue Owners rule action
@@ -736,13 +730,11 @@ class SlackIssueAlertNotificationTest(SlackActivityNotificationTest, Performance
 
         # check that only one was sent out - more would mean each user is being notified
         # rather than the team
-        assert len(responses.calls) == 1
 
         # check that the team got a notification
-        data = parse_qs(responses.calls[0].request.body)
-        assert data["channel"] == ["CXXXXXXX2"]
-        assert "blocks" in data
-        blocks = orjson.loads(data["blocks"][0])
+        assert self.mock_post.call_args.kwargs["channel"] == "CXXXXXXX2"
+        blocks = orjson.loads(self.mock_post.call_args.kwargs["blocks"])
+
         assert "Hello world" in blocks[1]["text"]["text"]
         title_link = blocks[1]["text"]["text"][13:][1:-1]
         notification_uuid = self.get_notification_uuid(title_link)
@@ -751,7 +743,6 @@ class SlackIssueAlertNotificationTest(SlackActivityNotificationTest, Performance
             == f"{self.project.slug} | <http://testserver/settings/{self.organization.slug}/teams/{self.team.slug}/notifications/?referrer=issue_alert-slack-team&notification_uuid={notification_uuid}|Notification Settings>"
         )
 
-    @responses.activate
     def test_issue_alert_team_block(self):
         """Test that issue alerts are sent to a team in Slack when block kit is enabled."""
         # add a second organization
@@ -816,15 +807,13 @@ class SlackIssueAlertNotificationTest(SlackActivityNotificationTest, Performance
 
         # check that only one was sent out - more would mean each user is being notified
         # rather than the team
-        assert len(responses.calls) == 1
+        assert self.mock_post.call_count == 1
 
         # check that the team got a notification
-        data = parse_qs(responses.calls[0].request.body)
-        assert data["channel"] == ["CXXXXXXX2"]
-        assert "blocks" in data
-        assert "text" in data
-        blocks = orjson.loads(data["blocks"][0])
-        fallback_text = data["text"][0]
+        assert self.mock_post.call_args.kwargs["channel"] == "CXXXXXXX2"
+        blocks = orjson.loads(self.mock_post.call_args.kwargs["blocks"])
+        fallback_text = self.mock_post.call_args.kwargs["text"]
+
         notification_uuid = self.get_notification_uuid(blocks[1]["text"]["text"])
 
         assert (
@@ -842,7 +831,6 @@ class SlackIssueAlertNotificationTest(SlackActivityNotificationTest, Performance
             == f"{event.project.slug} | <http://example.com/settings/{event.organization.slug}/teams/{self.team.slug}/notifications/?referrer=issue_alert-slack-team&notification_uuid={notification_uuid}|Notification Settings>"
         )
 
-    @responses.activate
     def test_issue_alert_team_new_project(self):
         """Test that issue alerts are sent to a team in Slack when the team has added a new project"""
 
@@ -905,13 +893,12 @@ class SlackIssueAlertNotificationTest(SlackActivityNotificationTest, Performance
 
         # check that only one was sent out - more would mean each user is being notified
         # rather than the team
-        assert len(responses.calls) == 1
+        assert self.mock_post.call_count == 1
 
         # check that the team got a notification
-        data = parse_qs(responses.calls[0].request.body)
-        assert data["channel"] == ["CXXXXXXX2"]
-        assert "blocks" in data
-        blocks = orjson.loads(data["blocks"][0])
+
+        assert self.mock_post.call_args.kwargs["channel"] == "CXXXXXXX2"
+        blocks = orjson.loads(self.mock_post.call_args.kwargs["blocks"])
         assert "Hello world" in blocks[1]["text"]["text"]
         title_link = blocks[1]["text"]["text"][13:][1:-1]
         notification_uuid = self.get_notification_uuid(title_link)
@@ -920,7 +907,6 @@ class SlackIssueAlertNotificationTest(SlackActivityNotificationTest, Performance
             == f"{project2.slug} | <http://example.com/settings/{self.organization.slug}/teams/{self.team.slug}/notifications/?referrer=issue_alert-slack-team&notification_uuid={notification_uuid}|Notification Settings>"
         )
 
-    @responses.activate
     def test_not_issue_alert_team_removed_project(self):
         """Test that issue alerts are not sent to a team in Slack when the team has removed the project the issue belongs to"""
 
@@ -966,9 +952,8 @@ class SlackIssueAlertNotificationTest(SlackActivityNotificationTest, Performance
         with self.options({"system.url-prefix": "http://example.com"}), self.tasks():
             self.adapter.notify(notification, ActionTargetType.TEAM, self.team.id)
 
-        assert len(responses.calls) == 0
+        assert self.mock_post.call_count == 0
 
-    @responses.activate
     def test_issue_alert_team_fallback(self):
         """Test that issue alerts are sent to each member of a team in Slack."""
 
@@ -1004,19 +989,18 @@ class SlackIssueAlertNotificationTest(SlackActivityNotificationTest, Performance
         with self.options({"system.url-prefix": "http://example.com"}), self.tasks():
             self.adapter.notify(notification, ActionTargetType.TEAM, self.team.id)
 
-        assert len(responses.calls) == 2
+        assert self.mock_post.call_count == 2
 
         # check that self.user got a notification
-        call1 = parse_qs(responses.calls[0].request.body)
-        call2 = parse_qs(responses.calls[1].request.body)
+        call1 = self.mock_post.call_args_list[0].kwargs
+        call2 = self.mock_post.call_args_list[1].kwargs
 
         # don't assume a particular order
-        data = call1 if call1["channel"] == ["UXXXXXXX1"] else call2
-        data2 = call2 if call2["channel"] == ["UXXXXXXX2"] else call1
+        data = call1 if call1["channel"] == "UXXXXXXX1" else call2
+        data2 = call2 if call2["channel"] == "UXXXXXXX2" else call1
 
-        assert data["channel"] == ["UXXXXXXX1"]
-        assert "blocks" in data
-        blocks = orjson.loads(data["blocks"][0])
+        assert data["channel"] == "UXXXXXXX1"
+        blocks = orjson.loads(data["blocks"])
         assert "Hello world" in blocks[1]["text"]["text"]
         title_link = blocks[1]["text"]["text"]
         notification_uuid = self.get_notification_uuid(title_link)
@@ -1026,16 +1010,15 @@ class SlackIssueAlertNotificationTest(SlackActivityNotificationTest, Performance
         )
 
         # check that user2 got a notification as well
-        assert data2["channel"] == ["UXXXXXXX2"]
+        assert data2["channel"] == "UXXXXXXX2"
         assert "blocks" in data2
-        blocks = orjson.loads(data2["blocks"][0])
+        blocks = orjson.loads(data2["blocks"])
         assert "Hello world" in blocks[1]["text"]["text"]
         assert (
             blocks[-2]["elements"][0]["text"]
             == f"{self.project.slug} | <http://example.com/settings/account/notifications/alerts/?referrer=issue_alert-slack-user&notification_uuid={notification_uuid}&organizationId={event.organization.id}|Notification Settings>"
         )
 
-    @responses.activate
     @patch.object(sentry, "digests")
     def test_digest_enabled_block(self, digests):
         """
@@ -1059,7 +1042,9 @@ class SlackIssueAlertNotificationTest(SlackActivityNotificationTest, Performance
         with self.tasks():
             deliver_digest(key)
 
-        blocks, fallback_text = get_blocks_and_fallback_text()
+        blocks = orjson.loads(self.mock_post.call_args.kwargs["blocks"])
+        fallback_text = self.mock_post.call_args.kwargs["text"]
+
         notification_uuid = self.get_notification_uuid(blocks[1]["text"]["text"])
         assert (
             fallback_text

--- a/tests/sentry/integrations/slack/notifications/test_new_processing_issues.py
+++ b/tests/sentry/integrations/slack/notifications/test_new_processing_issues.py
@@ -49,7 +49,7 @@ class SlackNewProcessingIssuesNotificationTest(SlackActivityNotificationTest):
             == f"{self.project.slug} | <http://testserver/settings/account/notifications/workflow/?referrer=new_processing_issues_activity-slack-user&notification_uuid={notification_uuid}&organizationId={self.organization.id}|Notification Settings>"
         )
 
-    @with_feature("organizations:customer-domains")
+    @with_feature("system:multi-region")
     def test_new_processing_issue_customer_domains_block(self):
         notification = NewProcessingIssuesActivityNotification(
             Activity(

--- a/tests/sentry/integrations/slack/notifications/test_new_processing_issues.py
+++ b/tests/sentry/integrations/slack/notifications/test_new_processing_issues.py
@@ -1,4 +1,4 @@
-import responses
+import orjson
 
 from sentry.models.activity import Activity
 from sentry.notifications.notifications.activity.new_processing_issues import (
@@ -6,13 +6,11 @@ from sentry.notifications.notifications.activity.new_processing_issues import (
 )
 from sentry.testutils.cases import SlackActivityNotificationTest
 from sentry.testutils.helpers.features import with_feature
-from sentry.testutils.helpers.slack import get_blocks_and_fallback_text
 from sentry.types.activity import ActivityType
 from sentry.web.frontend.debug.debug_new_processing_issues_email import get_issues_data
 
 
 class SlackNewProcessingIssuesNotificationTest(SlackActivityNotificationTest):
-    @responses.activate
     def test_new_processing_issue_block(self):
         """
         Test that a Slack message is sent with the expected payload when an issue is held back in reprocessing
@@ -33,7 +31,9 @@ class SlackNewProcessingIssuesNotificationTest(SlackActivityNotificationTest):
         with self.tasks():
             notification.send()
 
-        blocks, fallback_text = get_blocks_and_fallback_text()
+        blocks = orjson.loads(self.mock_post.call_args.kwargs["blocks"])
+        fallback_text = self.mock_post.call_args.kwargs["text"]
+
         notification_uuid = self.get_notification_uuid(blocks[0]["text"]["text"])
         assert (
             fallback_text
@@ -49,8 +49,7 @@ class SlackNewProcessingIssuesNotificationTest(SlackActivityNotificationTest):
             == f"{self.project.slug} | <http://testserver/settings/account/notifications/workflow/?referrer=new_processing_issues_activity-slack-user&notification_uuid={notification_uuid}&organizationId={self.organization.id}|Notification Settings>"
         )
 
-    @responses.activate
-    @with_feature("system:multi-region")
+    @with_feature("organizations:customer-domains")
     def test_new_processing_issue_customer_domains_block(self):
         notification = NewProcessingIssuesActivityNotification(
             Activity(
@@ -67,7 +66,9 @@ class SlackNewProcessingIssuesNotificationTest(SlackActivityNotificationTest):
         with self.tasks():
             notification.send()
 
-        blocks, fallback_text = get_blocks_and_fallback_text()
+        blocks = orjson.loads(self.mock_post.call_args.kwargs["blocks"])
+        fallback_text = self.mock_post.call_args.kwargs["text"]
+
         notification_uuid = self.get_notification_uuid(blocks[0]["text"]["text"])
         assert (
             fallback_text

--- a/tests/sentry/integrations/slack/notifications/test_nudge.py
+++ b/tests/sentry/integrations/slack/notifications/test_nudge.py
@@ -1,5 +1,3 @@
-from urllib.parse import parse_qs
-
 import orjson
 import responses
 
@@ -9,7 +7,6 @@ from sentry.notifications.notifications.integration_nudge import (
     IntegrationNudgeNotification,
 )
 from sentry.testutils.cases import SlackActivityNotificationTest
-from sentry.testutils.helpers.slack import get_blocks_and_fallback_text
 
 SEED = 0
 
@@ -27,7 +24,8 @@ class SlackNudgeNotificationTest(SlackActivityNotificationTest):
         with self.tasks():
             notification.send()
 
-        blocks, fallback_text = get_blocks_and_fallback_text()
+        blocks = orjson.loads(self.mock_post.call_args.kwargs["blocks"])
+        fallback_text = self.mock_post.call_args.kwargs["text"]
         assert fallback_text == MESSAGE_LIBRARY[SEED].format(provider="Slack")
         assert blocks[0]["text"]["text"] == fallback_text
         assert len(blocks[1]["elements"]) == 1
@@ -36,5 +34,5 @@ class SlackNudgeNotificationTest(SlackActivityNotificationTest):
         assert blocks[1]["elements"][0]["value"] == "all_slack"
 
         # Slack requires callback_id to handle enablement
-        request_data = parse_qs(responses.calls[0].request.body)
-        assert orjson.loads(request_data["callback_id"][0]) == {"enable_notifications": True}
+        callback_id = orjson.loads(self.mock_post.call_args.kwargs["callback_id"])
+        assert callback_id == {"enable_notifications": True}

--- a/tests/sentry/integrations/slack/notifications/test_regression.py
+++ b/tests/sentry/integrations/slack/notifications/test_regression.py
@@ -1,13 +1,12 @@
 from unittest import mock
 
-import responses
+import orjson
 
 from sentry.models.activity import Activity
 from sentry.notifications.notifications.activity.regression import RegressionActivityNotification
 from sentry.testutils.cases import PerformanceIssueTestCase, SlackActivityNotificationTest
 from sentry.testutils.helpers import with_feature
 from sentry.testutils.helpers.notifications import TEST_ISSUE_OCCURRENCE, TEST_PERF_ISSUE_OCCURRENCE
-from sentry.testutils.helpers.slack import get_blocks_and_fallback_text
 from sentry.testutils.skips import requires_snuba
 from sentry.types.activity import ActivityType
 
@@ -26,7 +25,6 @@ class SlackRegressionNotificationTest(SlackActivityNotificationTest, Performance
             )
         )
 
-    @responses.activate
     def test_regression_block(self):
         """
         Test that a Slack message is sent with the expected payload when an issue regresses
@@ -35,7 +33,8 @@ class SlackRegressionNotificationTest(SlackActivityNotificationTest, Performance
         with self.tasks():
             self.create_notification(self.group).send()
 
-        blocks, fallback_text = get_blocks_and_fallback_text()
+        blocks = orjson.loads(self.mock_post.call_args.kwargs["blocks"])
+        fallback_text = self.mock_post.call_args.kwargs["text"]
         assert fallback_text == "Issue marked as regression"
         assert blocks[0]["text"]["text"] == fallback_text
         notification_uuid = self.get_notification_uuid(blocks[1]["text"]["text"])
@@ -46,7 +45,6 @@ class SlackRegressionNotificationTest(SlackActivityNotificationTest, Performance
             f"{self.project.slug} | <http://testserver/settings/account/notifications/workflow/?referrer=regression_activity-slack-user&notification_uuid={notification_uuid}&organizationId={self.organization.id}|Notification Settings>"
         )
 
-    @responses.activate
     def test_regression_with_release_block(self):
         """
         Test that a Slack message is sent with the expected payload when an issue regresses
@@ -55,7 +53,8 @@ class SlackRegressionNotificationTest(SlackActivityNotificationTest, Performance
         with self.tasks():
             self.create_notification(self.group, {"version": "1.0.0"}).send()
 
-        blocks, fallback_text = get_blocks_and_fallback_text()
+        blocks = orjson.loads(self.mock_post.call_args.kwargs["blocks"])
+        fallback_text = self.mock_post.call_args.kwargs["text"]
         notification_uuid = self.get_notification_uuid(blocks[1]["text"]["text"])
         assert (
             fallback_text
@@ -69,7 +68,6 @@ class SlackRegressionNotificationTest(SlackActivityNotificationTest, Performance
             f"{self.project.slug} | <http://testserver/settings/account/notifications/workflow/?referrer=regression_activity-slack-user&notification_uuid={notification_uuid}&organizationId={self.organization.id}|Notification Settings>"
         )
 
-    @responses.activate
     @mock.patch(
         "sentry.eventstore.models.GroupEvent.occurrence",
         return_value=TEST_PERF_ISSUE_OCCURRENCE,
@@ -84,7 +82,8 @@ class SlackRegressionNotificationTest(SlackActivityNotificationTest, Performance
         with self.tasks():
             self.create_notification(event.group).send()
 
-        blocks, fallback_text = get_blocks_and_fallback_text()
+        blocks = orjson.loads(self.mock_post.call_args.kwargs["blocks"])
+        fallback_text = self.mock_post.call_args.kwargs["text"]
         assert fallback_text == "Issue marked as regression"
         assert blocks[0]["text"]["text"] == fallback_text
         self.assert_performance_issue_blocks(
@@ -95,7 +94,6 @@ class SlackRegressionNotificationTest(SlackActivityNotificationTest, Performance
             "regression_activity-slack",
         )
 
-    @responses.activate
     @mock.patch(
         "sentry.eventstore.models.GroupEvent.occurrence",
         return_value=TEST_PERF_ISSUE_OCCURRENCE,
@@ -146,7 +144,8 @@ class SlackRegressionNotificationTest(SlackActivityNotificationTest, Performance
         with self.tasks():
             self.create_notification(group_event.group).send()
 
-        blocks, fallback_text = get_blocks_and_fallback_text()
+        blocks = orjson.loads(self.mock_post.call_args.kwargs["blocks"])
+        fallback_text = self.mock_post.call_args.kwargs["text"]
         assert fallback_text == "Issue marked as regression"
         assert blocks[0]["text"]["text"] == fallback_text
         self.assert_generic_issue_blocks(

--- a/tests/sentry/integrations/slack/notifications/test_regression.py
+++ b/tests/sentry/integrations/slack/notifications/test_regression.py
@@ -109,7 +109,8 @@ class SlackRegressionNotificationTest(SlackActivityNotificationTest, Performance
         with self.tasks():
             self.create_notification(event.group).send()
 
-        blocks, fallback_text = get_blocks_and_fallback_text()
+        blocks = orjson.loads(self.mock_post.call_args.kwargs["blocks"])
+        fallback_text = self.mock_post.call_args.kwargs["text"]
         assert fallback_text == "Issue marked as regression"
         assert blocks[0]["text"]["text"] == fallback_text
         self.assert_performance_issue_blocks_with_culprit_blocks(
@@ -120,7 +121,6 @@ class SlackRegressionNotificationTest(SlackActivityNotificationTest, Performance
             "regression_activity-slack",
         )
 
-    @responses.activate
     @mock.patch(
         "sentry.eventstore.models.GroupEvent.occurrence",
         return_value=TEST_ISSUE_OCCURRENCE,
@@ -157,7 +157,6 @@ class SlackRegressionNotificationTest(SlackActivityNotificationTest, Performance
             with_culprit=False,
         )
 
-    @responses.activate
     @mock.patch(
         "sentry.eventstore.models.GroupEvent.occurrence",
         return_value=TEST_ISSUE_OCCURRENCE,
@@ -182,7 +181,8 @@ class SlackRegressionNotificationTest(SlackActivityNotificationTest, Performance
         with self.tasks():
             self.create_notification(group_event.group).send()
 
-        blocks, fallback_text = get_blocks_and_fallback_text()
+        blocks = orjson.loads(self.mock_post.call_args.kwargs["blocks"])
+        fallback_text = self.mock_post.call_args.kwargs["text"]
         assert fallback_text == "Issue marked as regression"
         assert blocks[0]["text"]["text"] == fallback_text
         self.assert_generic_issue_blocks(

--- a/tests/sentry/integrations/slack/notifications/test_resolved.py
+++ b/tests/sentry/integrations/slack/notifications/test_resolved.py
@@ -1,13 +1,12 @@
 from unittest import mock
 
-import responses
+import orjson
 
 from sentry.models.activity import Activity
 from sentry.notifications.notifications.activity.resolved import ResolvedActivityNotification
 from sentry.testutils.cases import PerformanceIssueTestCase, SlackActivityNotificationTest
 from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.helpers.notifications import TEST_ISSUE_OCCURRENCE, TEST_PERF_ISSUE_OCCURRENCE
-from sentry.testutils.helpers.slack import get_blocks_and_fallback_text
 from sentry.testutils.skips import requires_snuba
 from sentry.types.activity import ActivityType
 
@@ -26,7 +25,6 @@ class SlackResolvedNotificationTest(SlackActivityNotificationTest, PerformanceIs
             )
         )
 
-    @responses.activate
     def test_resolved_block(self):
         """
         Test that a Slack message is sent with the expected payload when an issue is resolved
@@ -35,7 +33,8 @@ class SlackResolvedNotificationTest(SlackActivityNotificationTest, PerformanceIs
         with self.tasks():
             self.create_notification(self.group).send()
 
-        blocks, fallback_text = get_blocks_and_fallback_text()
+        blocks = orjson.loads(self.mock_post.call_args.kwargs["blocks"])
+        fallback_text = self.mock_post.call_args.kwargs["text"]
         notification_uuid = self.get_notification_uuid(fallback_text)
         issue_link = (
             f"http://testserver/organizations/{self.organization.slug}/issues/{self.group.id}"
@@ -54,7 +53,6 @@ class SlackResolvedNotificationTest(SlackActivityNotificationTest, PerformanceIs
             == f"{self.project.slug} | <http://testserver/settings/account/notifications/workflow/?referrer=resolved_activity-slack-user&notification_uuid={notification_uuid}&organizationId={self.organization.id}|Notification Settings>"
         )
 
-    @responses.activate
     @mock.patch(
         "sentry.eventstore.models.GroupEvent.occurrence",
         return_value=TEST_PERF_ISSUE_OCCURRENCE,
@@ -69,7 +67,8 @@ class SlackResolvedNotificationTest(SlackActivityNotificationTest, PerformanceIs
         with self.tasks():
             self.create_notification(event.group).send()
 
-        blocks, fallback_text = get_blocks_and_fallback_text()
+        blocks = orjson.loads(self.mock_post.call_args.kwargs["blocks"])
+        fallback_text = self.mock_post.call_args.kwargs["text"]
         notification_uuid = self.get_notification_uuid(blocks[0]["text"]["text"])
         assert (
             fallback_text
@@ -84,7 +83,6 @@ class SlackResolvedNotificationTest(SlackActivityNotificationTest, PerformanceIs
             "resolved_activity-slack",
         )
 
-    @responses.activate
     @mock.patch(
         "sentry.eventstore.models.GroupEvent.occurrence",
         return_value=TEST_PERF_ISSUE_OCCURRENCE,
@@ -133,7 +131,8 @@ class SlackResolvedNotificationTest(SlackActivityNotificationTest, PerformanceIs
         with self.tasks():
             self.create_notification(group_event.group).send()
 
-        blocks, fallback_text = get_blocks_and_fallback_text()
+        blocks = orjson.loads(self.mock_post.call_args.kwargs["blocks"])
+        fallback_text = self.mock_post.call_args.kwargs["text"]
         notification_uuid = self.get_notification_uuid(blocks[0]["text"]["text"])
         assert event.group
         assert (

--- a/tests/sentry/integrations/slack/notifications/test_resolved.py
+++ b/tests/sentry/integrations/slack/notifications/test_resolved.py
@@ -98,7 +98,8 @@ class SlackResolvedNotificationTest(SlackActivityNotificationTest, PerformanceIs
         with self.tasks():
             self.create_notification(event.group).send()
 
-        blocks, fallback_text = get_blocks_and_fallback_text()
+        blocks = orjson.loads(self.mock_post.call_args.kwargs["blocks"])
+        fallback_text = self.mock_post.call_args.kwargs["text"]
         notification_uuid = self.get_notification_uuid(blocks[0]["text"]["text"])
         assert (
             fallback_text
@@ -113,7 +114,6 @@ class SlackResolvedNotificationTest(SlackActivityNotificationTest, PerformanceIs
             "resolved_activity-slack",
         )
 
-    @responses.activate
     @mock.patch(
         "sentry.eventstore.models.GroupEvent.occurrence",
         return_value=TEST_ISSUE_OCCURRENCE,

--- a/tests/sentry/integrations/slack/notifications/test_resolved_in_release.py
+++ b/tests/sentry/integrations/slack/notifications/test_resolved_in_release.py
@@ -1,6 +1,6 @@
 from unittest import mock
 
-import responses
+import orjson
 
 from sentry.models.activity import Activity
 from sentry.notifications.notifications.activity.resolved_in_release import (
@@ -9,7 +9,6 @@ from sentry.notifications.notifications.activity.resolved_in_release import (
 from sentry.testutils.cases import PerformanceIssueTestCase, SlackActivityNotificationTest
 from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.helpers.notifications import TEST_ISSUE_OCCURRENCE, TEST_PERF_ISSUE_OCCURRENCE
-from sentry.testutils.helpers.slack import get_blocks_and_fallback_text
 from sentry.testutils.skips import requires_snuba
 from sentry.types.activity import ActivityType
 
@@ -30,13 +29,14 @@ class SlackResolvedInReleaseNotificationTest(
             )
         )
 
-    @responses.activate
     def test_resolved_in_release_block(self):
         notification = self.create_notification(self.group)
         with self.tasks():
             notification.send()
 
-        blocks, fallback_text = get_blocks_and_fallback_text()
+        blocks = orjson.loads(self.mock_post.call_args.kwargs["blocks"])
+        fallback_text = self.mock_post.call_args.kwargs["text"]
+
         release_name = notification.activity.data["version"]
         assert fallback_text == f"Issue marked as resolved in {release_name} by {self.name}"
         assert blocks[0]["text"]["text"] == fallback_text
@@ -50,7 +50,6 @@ class SlackResolvedInReleaseNotificationTest(
             == f"{self.project.slug} | <http://testserver/settings/account/notifications/workflow/?referrer=resolved_in_release_activity-slack-user&notification_uuid={notification_uuid}&organizationId={self.organization.id}|Notification Settings>"
         )
 
-    @responses.activate
     @mock.patch(
         "sentry.eventstore.models.GroupEvent.occurrence",
         return_value=TEST_PERF_ISSUE_OCCURRENCE,
@@ -66,7 +65,9 @@ class SlackResolvedInReleaseNotificationTest(
         with self.tasks():
             notification.send()
 
-        blocks, fallback_text = get_blocks_and_fallback_text()
+        blocks = orjson.loads(self.mock_post.call_args.kwargs["blocks"])
+        fallback_text = self.mock_post.call_args.kwargs["text"]
+
         release_name = notification.activity.data["version"]
         assert fallback_text == f"Issue marked as resolved in {release_name} by {self.name}"
         assert blocks[0]["text"]["text"] == fallback_text
@@ -78,7 +79,6 @@ class SlackResolvedInReleaseNotificationTest(
             "resolved_in_release_activity-slack",
         )
 
-    @responses.activate
     @mock.patch(
         "sentry.eventstore.models.GroupEvent.occurrence",
         return_value=TEST_PERF_ISSUE_OCCURRENCE,
@@ -126,7 +126,9 @@ class SlackResolvedInReleaseNotificationTest(
         with self.tasks():
             notification.send()
 
-        blocks, fallback_text = get_blocks_and_fallback_text()
+        blocks = orjson.loads(self.mock_post.call_args.kwargs["blocks"])
+        fallback_text = self.mock_post.call_args.kwargs["text"]
+
         release_name = notification.activity.data["version"]
         assert fallback_text == f"Issue marked as resolved in {release_name} by {self.name}"
         assert blocks[0]["text"]["text"] == fallback_text
@@ -138,7 +140,6 @@ class SlackResolvedInReleaseNotificationTest(
             "resolved_in_release_activity-slack",
         )
 
-    @responses.activate
     def test_resolved_in_release_parsed_version_block(self):
         """
         Test that the release version is formatted to the short version when block kit is enabled.
@@ -147,7 +148,9 @@ class SlackResolvedInReleaseNotificationTest(
         with self.tasks():
             notification.send()
 
-        blocks, fallback_text = get_blocks_and_fallback_text()
+        blocks = orjson.loads(self.mock_post.call_args.kwargs["blocks"])
+        fallback_text = self.mock_post.call_args.kwargs["text"]
+
         assert fallback_text == f"Issue marked as resolved in 1.0.0 by {self.name}"
         assert blocks[0]["text"]["text"] == fallback_text
         notification_uuid = self.get_notification_uuid(blocks[1]["text"]["text"])

--- a/tests/sentry/integrations/slack/notifications/test_resolved_in_release.py
+++ b/tests/sentry/integrations/slack/notifications/test_resolved_in_release.py
@@ -95,7 +95,9 @@ class SlackResolvedInReleaseNotificationTest(
         with self.tasks():
             notification.send()
 
-        blocks, fallback_text = get_blocks_and_fallback_text()
+        blocks = orjson.loads(self.mock_post.call_args.kwargs["blocks"])
+        fallback_text = self.mock_post.call_args.kwargs["text"]
+
         release_name = notification.activity.data["version"]
         assert fallback_text == f"Issue marked as resolved in {release_name} by {self.name}"
         assert blocks[0]["text"]["text"] == fallback_text
@@ -107,7 +109,6 @@ class SlackResolvedInReleaseNotificationTest(
             "resolved_in_release_activity-slack",
         )
 
-    @responses.activate
     @mock.patch(
         "sentry.eventstore.models.GroupEvent.occurrence",
         return_value=TEST_ISSUE_OCCURRENCE,

--- a/tests/sentry/integrations/slack/notifications/test_unassigned.py
+++ b/tests/sentry/integrations/slack/notifications/test_unassigned.py
@@ -1,5 +1,6 @@
 from unittest import mock
 
+import orjson
 import responses
 
 from sentry.models.activity import Activity
@@ -7,7 +8,6 @@ from sentry.notifications.notifications.activity.unassigned import UnassignedAct
 from sentry.testutils.cases import PerformanceIssueTestCase, SlackActivityNotificationTest
 from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.helpers.notifications import TEST_ISSUE_OCCURRENCE, TEST_PERF_ISSUE_OCCURRENCE
-from sentry.testutils.helpers.slack import get_blocks_and_fallback_text
 from sentry.testutils.skips import requires_snuba
 from sentry.types.activity import ActivityType
 
@@ -26,7 +26,6 @@ class SlackUnassignedNotificationTest(SlackActivityNotificationTest, Performance
             )
         )
 
-    @responses.activate
     def test_unassignment_block(self):
         """
         Test that a Slack message is sent with the expected payload when an issue is unassigned
@@ -35,7 +34,9 @@ class SlackUnassignedNotificationTest(SlackActivityNotificationTest, Performance
         with self.tasks():
             self.create_notification(self.group).send()
 
-        blocks, fallback_text = get_blocks_and_fallback_text()
+        blocks = orjson.loads(self.mock_post.call_args.kwargs["blocks"])
+        fallback_text = self.mock_post.call_args.kwargs["text"]
+
         assert fallback_text == f"Issue unassigned by {self.name}"
         assert blocks[0]["text"]["text"] == fallback_text
         notification_uuid = self.get_notification_uuid(blocks[1]["text"]["text"])
@@ -47,7 +48,6 @@ class SlackUnassignedNotificationTest(SlackActivityNotificationTest, Performance
             == f"{self.project.slug} | <http://testserver/settings/account/notifications/workflow/?referrer=unassigned_activity-slack-user&notification_uuid={notification_uuid}&organizationId={self.organization.id}|Notification Settings>"
         )
 
-    @responses.activate
     @mock.patch(
         "sentry.eventstore.models.GroupEvent.occurrence",
         return_value=TEST_PERF_ISSUE_OCCURRENCE,
@@ -62,7 +62,9 @@ class SlackUnassignedNotificationTest(SlackActivityNotificationTest, Performance
         with self.tasks():
             self.create_notification(event.group).send()
 
-        blocks, fallback_text = get_blocks_and_fallback_text()
+        blocks = orjson.loads(self.mock_post.call_args.kwargs["blocks"])
+        fallback_text = self.mock_post.call_args.kwargs["text"]
+
         assert fallback_text == f"Issue unassigned by {self.name}"
         assert blocks[0]["text"]["text"] == fallback_text
         self.assert_performance_issue_blocks(
@@ -118,7 +120,9 @@ class SlackUnassignedNotificationTest(SlackActivityNotificationTest, Performance
         with self.tasks():
             self.create_notification(group_event.group).send()
 
-        blocks, fallback_text = get_blocks_and_fallback_text()
+        blocks = orjson.loads(self.mock_post.call_args.kwargs["blocks"])
+        fallback_text = self.mock_post.call_args.kwargs["text"]
+
         assert fallback_text == f"Issue unassigned by {self.name}"
         assert blocks[0]["text"]["text"] == fallback_text
         self.assert_generic_issue_blocks(

--- a/tests/sentry/integrations/slack/notifications/test_unassigned.py
+++ b/tests/sentry/integrations/slack/notifications/test_unassigned.py
@@ -91,7 +91,8 @@ class SlackUnassignedNotificationTest(SlackActivityNotificationTest, Performance
         with self.tasks():
             self.create_notification(event.group).send()
 
-        blocks, fallback_text = get_blocks_and_fallback_text()
+        blocks = orjson.loads(self.mock_post.call_args.kwargs["blocks"])
+        fallback_text = self.mock_post.call_args.kwargs["text"]
         assert fallback_text == f"Issue unassigned by {self.name}"
         assert blocks[0]["text"]["text"] == fallback_text
         self.assert_performance_issue_blocks_with_culprit_blocks(

--- a/tests/sentry/integrations/slack/test_notifications.py
+++ b/tests/sentry/integrations/slack/test_notifications.py
@@ -1,16 +1,17 @@
-from unittest import mock
-from urllib.parse import parse_qs
+from unittest.mock import patch
 
 import orjson
-import responses
 from slack_sdk.errors import SlackApiError
 from slack_sdk.web import SlackResponse
 
+from sentry.integrations.slack.metrics import (
+    SLACK_NOTIFY_RECIPIENT_FAILURE_DATADOG_METRIC,
+    SLACK_NOTIFY_RECIPIENT_SUCCESS_DATADOG_METRIC,
+)
 from sentry.integrations.slack.notifications import send_notification_as_slack
 from sentry.integrations.types import ExternalProviders
 from sentry.notifications.additional_attachment_manager import manager
 from sentry.testutils.cases import SlackActivityNotificationTest
-from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.helpers.notifications import DummyNotification
 
 
@@ -26,10 +27,17 @@ class SlackNotificationsTest(SlackActivityNotificationTest):
         super().setUp()
         self.notification = DummyNotification(self.organization)
 
-    @responses.activate
-    def test_additional_attachment_block_kit(self):
+    @patch("sentry.tasks.integrations.slack.post_message.metrics")
+    @patch("slack_sdk.web.client.WebClient._perform_urllib_http_request")
+    @patch("slack_sdk.web.client.WebClient.chat_postMessage")
+    def test_additional_attachment_block_kit(self, mock_post, mock_api_call, mock_metrics):
+        mock_api_call.return_value = {
+            "body": orjson.dumps({"ok": True}).decode(),
+            "headers": {},
+            "status": 200,
+        }
         with (
-            mock.patch.dict(
+            patch.dict(
                 manager.attachment_generators,
                 {ExternalProviders.SLACK: additional_attachment_generator_block_kit},
             ),
@@ -37,13 +45,11 @@ class SlackNotificationsTest(SlackActivityNotificationTest):
             with self.tasks():
                 send_notification_as_slack(self.notification, [self.user], {}, {})
 
-            data = parse_qs(responses.calls[0].request.body)
+            blocks = orjson.loads(mock_post.call_args.kwargs["blocks"])
+            text = mock_post.call_args.kwargs["text"]
 
-            assert "blocks" in data
-            assert "text" in data
-            assert data["text"][0] == "Notification Title"
+            assert text == "Notification Title"
 
-            blocks = orjson.loads(data["blocks"][0])
             assert len(blocks) == 5
 
             assert blocks[0]["text"]["text"] == "Notification Title"
@@ -69,18 +75,27 @@ class SlackNotificationsTest(SlackActivityNotificationTest):
             assert blocks[3]["text"]["text"] == self.organization.slug
             assert blocks[4]["text"]["text"] == self.integration.id
 
-    @responses.activate
-    def test_no_additional_attachment_block_kit(self):
+        mock_metrics.incr.assert_called_with(
+            SLACK_NOTIFY_RECIPIENT_SUCCESS_DATADOG_METRIC,
+            sample_rate=1.0,
+        )
+
+    @patch("sentry.tasks.integrations.slack.post_message.metrics")
+    @patch("slack_sdk.web.client.WebClient._perform_urllib_http_request")
+    @patch("slack_sdk.web.client.WebClient.chat_postMessage")
+    def test_no_additional_attachment_block_kit(self, mock_post, mock_api_call, mock_metrics):
+        mock_api_call.return_value = {
+            "body": orjson.dumps({"ok": True}).decode(),
+            "headers": {},
+            "status": 200,
+        }
         with self.tasks():
             send_notification_as_slack(self.notification, [self.user], {}, {})
 
-        data = parse_qs(responses.calls[0].request.body)
+        blocks = orjson.loads(mock_post.call_args.kwargs["blocks"])
+        text = mock_post.call_args.kwargs["text"]
 
-        assert "blocks" in data
-        assert "text" in data
-        assert data["text"][0] == "Notification Title"
-
-        blocks = orjson.loads(data["blocks"][0])
+        assert text == "Notification Title"
         assert len(blocks) == 3
 
         assert blocks[0]["text"]["text"] == "Notification Title"
@@ -104,10 +119,10 @@ class SlackNotificationsTest(SlackActivityNotificationTest):
             "type": "actions",
         }
 
-    @with_feature("organizations:slack-sdk-notify-recipient")
-    def test_send_notification_as_slack_sdk(self):
+    @patch("sentry.tasks.integrations.slack.post_message.metrics")
+    def test_send_notification_as_slack_sdk(self, mock_metrics):
         with (
-            mock.patch.dict(
+            patch.dict(
                 manager.attachment_generators,
                 {ExternalProviders.SLACK: additional_attachment_generator_block_kit},
             ),
@@ -115,8 +130,13 @@ class SlackNotificationsTest(SlackActivityNotificationTest):
             with self.tasks():
                 send_notification_as_slack(self.notification, [self.user], {}, {})
 
-    @with_feature("organizations:slack-sdk-notify-recipient")
-    def test_send_notification_as_slack_sdk_error(self):
+        mock_metrics.incr.assert_called_with(
+            SLACK_NOTIFY_RECIPIENT_SUCCESS_DATADOG_METRIC,
+            sample_rate=1.0,
+        )
+
+    @patch("sentry.tasks.integrations.slack.post_message.metrics")
+    def test_send_notification_as_slack_error(self, mock_metrics):
         mock_slack_response = SlackResponse(
             client=None,
             http_verb="POST",
@@ -128,14 +148,20 @@ class SlackNotificationsTest(SlackActivityNotificationTest):
         )
 
         with (
-            mock.patch.dict(
+            patch.dict(
                 manager.attachment_generators,
                 {ExternalProviders.SLACK: additional_attachment_generator_block_kit},
             ),
-            mock.patch(
+            patch(
                 "slack_sdk.web.client.WebClient.chat_postMessage",
                 side_effect=SlackApiError("error", mock_slack_response),
             ),
         ):
             with self.tasks():
                 send_notification_as_slack(self.notification, [self.user], {}, {})
+
+        mock_metrics.incr.assert_called_with(
+            SLACK_NOTIFY_RECIPIENT_FAILURE_DATADOG_METRIC,
+            sample_rate=1.0,
+            tags={"ok": False, "status": 200},
+        )

--- a/tests/sentry/notifications/notifications/test_assigned.py
+++ b/tests/sentry/notifications/notifications/test_assigned.py
@@ -1,17 +1,30 @@
-import responses
+from unittest.mock import patch
+
+import orjson
 from django.core import mail
 from django.core.mail.message import EmailMultiAlternatives
+from slack_sdk.web import SlackResponse
 
 from sentry.models.activity import Activity
 from sentry.testutils.cases import APITestCase
-from sentry.testutils.helpers import get_channel
-from sentry.testutils.helpers.slack import get_blocks_and_fallback_text
 from sentry.testutils.skips import requires_snuba
 from sentry.types.activity import ActivityType
 
 pytestmark = [requires_snuba]
 
 
+@patch(
+    "slack_sdk.web.client.WebClient.chat_postMessage",
+    return_value=SlackResponse(
+        client=None,
+        http_verb="POST",
+        api_url="https://slack.com/api/chat.postMessage",
+        req_args={},
+        data={"ok": True},
+        headers={},
+        status_code=200,
+    ),
+)
 class AssignedNotificationAPITest(APITestCase):
     def validate_email(self, outbox, index, email, txt_msg, html_msg):
         msg = outbox[index]
@@ -23,15 +36,15 @@ class AssignedNotificationAPITest(APITestCase):
         assert isinstance(msg.alternatives[0][0], str)
         assert html_msg in msg.alternatives[0][0]
 
-    def validate_slack_message(self, msg, group, project, user_id, index=0):
-        blocks, fallback_text = get_blocks_and_fallback_text(index)
+    def validate_slack_message(self, msg, group, project, user_id, mock_post, index=0):
+        blocks = orjson.loads(mock_post.call_args_list[index].kwargs["blocks"])
+        fallback_text = mock_post.call_args_list[index].kwargs["text"]
         assert fallback_text == msg
-        blocks, fallback_text = get_blocks_and_fallback_text()
 
         assert group.title in blocks[1]["text"]["text"]
         assert project.slug in blocks[-2]["elements"][0]["text"]
-        channel = get_channel(index)
-        assert channel == user_id
+        channel = mock_post.call_args_list[index].kwargs["channel"]
+        assert channel == str(user_id)
 
     def setup_user(self, user, team):
         member = self.create_member(user=user, organization=self.organization, role="member")
@@ -60,8 +73,7 @@ class AssignedNotificationAPITest(APITestCase):
 
         self.login_as(self.user)
 
-    @responses.activate
-    def test_sends_assignment_notification(self):
+    def test_sends_assignment_notification(self, mock_post):
         """
         Test that an email AND Slack notification are sent with
         the expected values when an issue is assigned.
@@ -83,13 +95,14 @@ class AssignedNotificationAPITest(APITestCase):
         assert isinstance(msg.alternatives[0][0], str)
         assert f"{self.group.qualified_short_id}</a> to themselves</p>" in msg.alternatives[0][0]
 
-        blocks, fallback_text = get_blocks_and_fallback_text()
+        blocks = orjson.loads(mock_post.call_args.kwargs["blocks"])
+        fallback_text = mock_post.call_args.kwargs["text"]
+
         assert fallback_text == f"Issue assigned to {user.get_display_name()} by themselves"
         assert self.group.title in blocks[1]["text"]["text"]
         assert self.project.slug in blocks[-2]["elements"][0]["text"]
 
-    @responses.activate
-    def test_sends_reassignment_notification_user(self):
+    def test_sends_reassignment_notification_user(self, mock_post):
         """Test that if a user is assigned to an issue and then the issue is reassigned to a different user
         that the original assignee receives an unassignment notification as well as the new assignee
         receiving an assignment notification"""
@@ -119,7 +132,7 @@ class AssignedNotificationAPITest(APITestCase):
         html_msg = f"{self.group.qualified_short_id}</a> to themselves</p>"
 
         msg = f"Issue assigned to {user1.get_display_name()} by themselves"
-        self.validate_slack_message(msg, self.group, self.project, user1.id, index=0)
+        self.validate_slack_message(msg, self.group, self.project, user1.id, mock_post, index=0)
         self.validate_email(mail.outbox, 0, user1.email, txt_msg, html_msg)
 
         # re-assign to user 2
@@ -145,11 +158,10 @@ class AssignedNotificationAPITest(APITestCase):
         self.validate_email(mail.outbox, 2, user2.email, txt_msg, html_msg)
 
         msg = f"Issue assigned to {user2.get_display_name()} by {user1.get_display_name()}"
-        self.validate_slack_message(msg, self.group, self.project, user1.id, index=1)
-        self.validate_slack_message(msg, self.group, self.project, user2.id, index=2)
+        self.validate_slack_message(msg, self.group, self.project, user1.id, mock_post, index=1)
+        self.validate_slack_message(msg, self.group, self.project, user2.id, mock_post, index=2)
 
-    @responses.activate
-    def test_sends_reassignment_notification_team(self):
+    def test_sends_reassignment_notification_team(self, mock_post):
         """Test that if a team is assigned to an issue and then the issue is reassigned to a different team
         that the originally assigned team receives an unassignment notification as well as the new assigned
         team receiving an assignment notification"""
@@ -190,8 +202,8 @@ class AssignedNotificationAPITest(APITestCase):
         self.validate_email(mail.outbox, 1, user2.email, txt_msg, html_msg)
 
         msg = f"Issue assigned to the {team1.slug} team by {user1.email}"
-        self.validate_slack_message(msg, group, project, user1.id, index=0)
-        self.validate_slack_message(msg, group, project, user2.id, index=1)
+        self.validate_slack_message(msg, group, project, user1.id, mock_post, index=0)
+        self.validate_slack_message(msg, group, project, user2.id, mock_post, index=1)
 
         # reassign to team2
         with self.tasks():
@@ -219,7 +231,7 @@ class AssignedNotificationAPITest(APITestCase):
         self.validate_email(mail.outbox, 5, user4.email, txt_msg, html_msg)
 
         msg = f"Issue assigned to the {team2.slug} team by {user1.email}"
-        self.validate_slack_message(msg, group, project, user1.id, index=2)
-        self.validate_slack_message(msg, group, project, user2.id, index=3)
-        self.validate_slack_message(msg, group, project, user3.id, index=4)
-        self.validate_slack_message(msg, group, project, user4.id, index=5)
+        self.validate_slack_message(msg, group, project, user1.id, mock_post, index=2)
+        self.validate_slack_message(msg, group, project, user2.id, mock_post, index=3)
+        self.validate_slack_message(msg, group, project, user3.id, mock_post, index=4)
+        self.validate_slack_message(msg, group, project, user4.id, mock_post, index=5)

--- a/tests/sentry/notifications/notifications/test_digests.py
+++ b/tests/sentry/notifications/notifications/test_digests.py
@@ -2,6 +2,7 @@ import uuid
 from unittest import mock
 from unittest.mock import ANY, patch
 
+import orjson
 from django.core import mail
 from django.core.mail.message import EmailMultiAlternatives
 
@@ -203,7 +204,7 @@ class DigestSlackNotification(SlackActivityNotificationTest):
             deliver_digest(key)
 
         assert self.mock_post.call_count == 1
-        blocks = self.mock_post.call_args.kwargs["blocks"]
+        blocks = orjson.loads(self.mock_post.call_args.kwargs["blocks"])
         fallback_text = self.mock_post.call_args.kwargs["text"]
         assert (
             fallback_text

--- a/tests/sentry/notifications/notifications/test_digests.py
+++ b/tests/sentry/notifications/notifications/test_digests.py
@@ -2,7 +2,6 @@ import uuid
 from unittest import mock
 from unittest.mock import ANY, patch
 
-import responses
 from django.core import mail
 from django.core.mail.message import EmailMultiAlternatives
 
@@ -15,7 +14,6 @@ from sentry.models.rule import Rule
 from sentry.tasks.digests import deliver_digest
 from sentry.testutils.cases import PerformanceIssueTestCase, SlackActivityNotificationTest, TestCase
 from sentry.testutils.helpers.datetime import before_now, iso_format
-from sentry.testutils.helpers.slack import get_blocks_and_fallback_text
 from sentry.testutils.skips import requires_snuba
 from tests.sentry.issues.test_utils import OccurrenceTestMixin
 
@@ -154,7 +152,6 @@ class DigestNotificationTest(TestCase, OccurrenceTestMixin, PerformanceIssueTest
 
 
 class DigestSlackNotification(SlackActivityNotificationTest):
-    @responses.activate
     @mock.patch.object(sentry, "digests")
     def test_slack_digest_notification_block(self, digests):
         """
@@ -205,8 +202,9 @@ class DigestSlackNotification(SlackActivityNotificationTest):
         with self.tasks():
             deliver_digest(key)
 
-        assert len(responses.calls) >= 1
-        blocks, fallback_text = get_blocks_and_fallback_text()
+        assert self.mock_post.call_count == 1
+        blocks = self.mock_post.call_args.kwargs["blocks"]
+        fallback_text = self.mock_post.call_args.kwargs["text"]
         assert (
             fallback_text
             == f"<!date^{timestamp_secs}^2 issues detected {{date_pretty}} in| Digest Report for> <http://testserver/organizations/{self.organization.slug}/projects/{self.project.slug}/|{self.project.name}>"

--- a/tests/sentry/notifications/test_notifications.py
+++ b/tests/sentry/notifications/test_notifications.py
@@ -4,12 +4,14 @@ from time import time
 from unittest.mock import patch
 from urllib.parse import parse_qs, urlparse
 
+import orjson
 import responses
 from django.conf import settings
 from django.core import mail
 from django.core.mail.message import EmailMultiAlternatives
 from django.utils import timezone
 from sentry_relay.processing import parse_release
+from slack_sdk.web import SlackResponse
 
 from sentry.digests.notifications import Notification
 from sentry.event_manager import EventManager
@@ -94,6 +96,18 @@ def get_notification_uuid(url: str):
 
 
 @control_silo_test
+@patch(
+    "slack_sdk.web.client.WebClient.chat_postMessage",
+    return_value=SlackResponse(
+        client=None,
+        http_verb="POST",
+        api_url="https://slack.com/api/chat.postMessage",
+        req_args={},
+        data={"ok": True},
+        headers={},
+        status_code=200,
+    ),
+)
 class ActivityNotificationTest(APITestCase):
     """
     Enable Slack AND email notification settings for a user
@@ -130,22 +144,13 @@ class ActivityNotificationTest(APITestCase):
                 type=type,
                 value="always",
             )
-
-        responses.add(
-            method=responses.POST,
-            url="https://slack.com/api/chat.postMessage",
-            body='{"ok": true}',
-            status=200,
-            content_type="application/json",
-        )
         responses.add_passthru(
             settings.SENTRY_SNUBA + "/tests/entities/generic_metrics_counters/insert",
         )
         self.name = self.user.get_display_name()
         self.short_id = self.group.qualified_short_id
 
-    @responses.activate
-    def test_sends_note_notification(self):
+    def test_sends_note_notification(self, mock_post):
         """
         Test that an email AND Slack notification are sent with
         the expected values when a comment is created on an issue.
@@ -166,7 +171,11 @@ class ActivityNotificationTest(APITestCase):
         assert isinstance(msg.alternatives[0][0], str)
         assert "blah blah</p></div>" in msg.alternatives[0][0]
 
-        block, text, footer, url = get_blocks()
+        blocks = orjson.loads(mock_post.call_args.kwargs["blocks"])
+        block = blocks[1]["text"]["text"]
+        footer = blocks[2]["elements"][0]["text"]
+        text = mock_post.call_args.kwargs["text"]
+
         # check the Slack version
         assert text == f"New comment by {self.name}"
         assert self.group.title in block
@@ -181,8 +190,7 @@ class ActivityNotificationTest(APITestCase):
             == f"{self.project.slug} | <http://testserver/settings/account/notifications/workflow/?referrer=note_activity-slack-user&notification_uuid={notification_uuid}&organizationId={self.organization.id}|Notification Settings>"
         )
 
-    @responses.activate
-    def test_sends_unassignment_notification(self):
+    def test_sends_unassignment_notification(self, mock_post):
         """
         Test that an email AND Slack notification are sent with
         the expected values when an issue is unassigned.
@@ -207,7 +215,10 @@ class ActivityNotificationTest(APITestCase):
         assert isinstance(msg.alternatives[0][0], str)
         assert f"{self.user.username}</strong> unassigned" in msg.alternatives[0][0]
 
-        block, text, footer, url = get_blocks()
+        blocks = orjson.loads(mock_post.call_args.kwargs["blocks"])
+        block = blocks[1]["text"]["text"]
+        footer = blocks[3]["elements"][0]["text"]
+        text = mock_post.call_args.kwargs["text"]
 
         assert text == f"Issue unassigned by {self.name}"
         assert self.group.title in block
@@ -218,8 +229,7 @@ class ActivityNotificationTest(APITestCase):
             == f"{self.project.slug} | <http://testserver/settings/account/notifications/workflow/?referrer=unassigned_activity-slack-user&notification_uuid={notification_uuid}&organizationId={self.organization.id}|Notification Settings>"
         )
 
-    @responses.activate
-    def test_html_escape(self):
+    def test_html_escape(self, mock_post):
         other_user = self.create_user(name="<b>test</b>", is_staff=False, is_superuser=False)
         activity = Activity(
             project=self.project, data={"assignee": other_user.id}, group=self.group
@@ -231,8 +241,7 @@ class ActivityNotificationTest(APITestCase):
         assert "&lt;b&gt;test&lt;/b&gt;" in html
         assert "<b>test</b>" not in html
 
-    @responses.activate
-    def test_regression_html_link(self):
+    def test_regression_html_link(self, mock_post):
         notification = RegressionActivityNotification(
             Activity(
                 project=self.project,
@@ -247,15 +256,14 @@ class ActivityNotificationTest(APITestCase):
         assert "as a regression in 777" in context["text_description"]
         assert "as a regression in <a href=" in context["html_description"]
 
-    @responses.activate
     @patch("sentry.analytics.record")
-    def test_sends_resolution_notification(self, record_analytics):
+    def test_sends_resolution_notification(self, record_analytics, mock_post):
         """
         Test that an email AND Slack notification are sent with
         the expected values when an issue is resolved.
         """
         url = f"/api/0/issues/{self.group.id}/"
-        with assume_test_silo_mode(SiloMode.MONOLITH):
+        with assume_test_silo_mode(SiloMode.REGION):
             with self.tasks():
                 response = self.client.put(url, format="json", data={"status": "resolved"})
             assert response.status_code == 200, response.content
@@ -268,7 +276,10 @@ class ActivityNotificationTest(APITestCase):
         assert isinstance(msg.alternatives[0][0], str)
         assert f"{self.short_id}</a> as resolved</p>" in msg.alternatives[0][0]
 
-        block, text, footer, url = get_blocks()
+        blocks = orjson.loads(mock_post.call_args.kwargs["blocks"])
+        block = blocks[1]["text"]["text"]
+        footer = blocks[3]["elements"][0]["text"]
+        text = mock_post.call_args.kwargs["text"]
 
         assert self.group.title in block
         title_link = block[13:][1:-1]  # removes emoji and <>
@@ -300,9 +311,8 @@ class ActivityNotificationTest(APITestCase):
             actor_type="User",
         )
 
-    @responses.activate
     @patch("sentry.analytics.record")
-    def test_sends_deployment_notification(self, record_analytics):
+    def test_sends_deployment_notification(self, record_analytics, mock_post):
         """
         Test that an email AND Slack notification are sent with
         the expected values when a release is deployed.
@@ -331,14 +341,16 @@ class ActivityNotificationTest(APITestCase):
             in msg.alternatives[0][0]
         )
 
-        block, text, footer, url = get_blocks()
+        blocks = orjson.loads(mock_post.call_args.kwargs["blocks"])
+        footer = blocks[1]["elements"][0]["text"]
+        url = blocks[2]["elements"][0]["url"]
+        text = mock_post.call_args.kwargs["text"]
 
         assert (
             text
             == f"Release {version_parsed} was deployed to {self.environment.name} for this project"
         )
-        title_link = block[13:][1:-1]  # removes emoji and <>
-        notification_uuid = get_notification_uuid(title_link)
+        notification_uuid = get_notification_uuid(url)
         assert url == (
             f"http://testserver/organizations/{self.organization.slug}/releases/{release.version}/?project={self.project.id}&unselectedSeries=Healthy&referrer=release_activity&notification_uuid={notification_uuid}"
         )
@@ -364,9 +376,8 @@ class ActivityNotificationTest(APITestCase):
             actor_type="User",
         )
 
-    @responses.activate
     @patch("sentry.analytics.record")
-    def test_sends_regression_notification(self, record_analytics):
+    def test_sends_regression_notification(self, record_analytics, mock_post):
         """
         Test that an email AND Slack notification are sent with
         the expected values when an issue regresses.
@@ -402,7 +413,10 @@ class ActivityNotificationTest(APITestCase):
         assert isinstance(msg.alternatives[0][0], str)
         assert f"{group.qualified_short_id}</a> as a regression</p>" in msg.alternatives[0][0]
 
-        block, text, footer, url = get_blocks()
+        blocks = orjson.loads(mock_post.call_args.kwargs["blocks"])
+        block = blocks[1]["text"]["text"]
+        footer = blocks[3]["elements"][0]["text"]
+        text = mock_post.call_args.kwargs["text"]
 
         assert text == "Issue marked as regression"
         title_link = block[13:][1:-1]  # removes emoji and <>
@@ -429,15 +443,14 @@ class ActivityNotificationTest(APITestCase):
             actor_type="User",
         )
 
-    @responses.activate
     @patch("sentry.analytics.record")
-    def test_sends_resolved_in_release_notification(self, record_analytics):
+    def test_sends_resolved_in_release_notification(self, record_analytics, mock_post):
         """
         Test that an email AND Slack notification are sent with
         the expected values when an issue is resolved by a release.
         """
         release = self.create_release()
-        with assume_test_silo_mode(SiloMode.MONOLITH):
+        with assume_test_silo_mode(SiloMode.REGION):
             url = f"/api/0/issues/{self.group.id}/"
             with self.tasks():
                 response = self.client.put(
@@ -461,7 +474,10 @@ class ActivityNotificationTest(APITestCase):
             f'text-decoration: none">{self.short_id}</a> as resolved in' in msg.alternatives[0][0]
         )
 
-        block, text, footer, url = get_blocks()
+        blocks = orjson.loads(mock_post.call_args.kwargs["blocks"])
+        block = blocks[1]["text"]["text"]
+        footer = blocks[3]["elements"][0]["text"]
+        text = mock_post.call_args.kwargs["text"]
 
         assert text == f"Issue marked as resolved in {parsed_version} by {self.name}"
         assert self.group.title in block
@@ -489,16 +505,14 @@ class ActivityNotificationTest(APITestCase):
             actor_type="User",
         )
 
-    @responses.activate
-    def test_sends_processing_issue_notification(self):
+    def test_sends_processing_issue_notification(self, mock_post):
         """
         Test that an email AND Slack notification are sent with
         the expected values when an issue is held back for reprocessing
         """
 
-    @responses.activate
     @patch("sentry.analytics.record")
-    def test_sends_issue_notification(self, record_analytics):
+    def test_sends_issue_notification(self, record_analytics, mock_post):
         """
         Test that an email AND Slack notification are sent with
         the expected values when an issue comes in that triggers an alert rule.
@@ -509,7 +523,7 @@ class ActivityNotificationTest(APITestCase):
             "targetType": "Member",
             "targetIdentifier": str(self.user.id),
         }
-        with assume_test_silo_mode(SiloMode.MONOLITH):
+        with assume_test_silo_mode(SiloMode.REGION):
             Rule.objects.create(
                 project=self.project,
                 label="a rule",
@@ -545,7 +559,9 @@ class ActivityNotificationTest(APITestCase):
         assert isinstance(msg.alternatives[0][0], str)
         assert "Hello world</pre>" in msg.alternatives[0][0]
 
-        block, text, footer, url = get_blocks()
+        blocks = orjson.loads(mock_post.call_args_list[0].kwargs["blocks"])
+        block = blocks[1]["text"]["text"]
+        footer = blocks[4]["elements"][0]["text"]
 
         assert "Hello world" in block
         title_link = block[13:][1:-1]  # removes emoji and <>

--- a/tests/sentry/tasks/test_daily_summary.py
+++ b/tests/sentry/tasks/test_daily_summary.py
@@ -3,6 +3,7 @@ from typing import cast
 from unittest import mock
 from urllib.parse import urlencode
 
+import orjson
 import pytest
 import responses
 from django.conf import settings
@@ -31,7 +32,6 @@ from sentry.testutils.cases import (
 from sentry.testutils.factories import EventType
 from sentry.testutils.helpers.datetime import before_now, freeze_time, iso_format
 from sentry.testutils.helpers.features import with_feature
-from sentry.testutils.helpers.slack import get_blocks_and_fallback_text
 from sentry.types.activity import ActivityType
 from sentry.types.group import GroupSubStatus
 from sentry.utils.outcomes import Outcome
@@ -624,7 +624,6 @@ class DailySummaryTest(
         top_projects_context_map = build_top_projects_map(context, user2.id)
         assert list(top_projects_context_map.keys()) == [self.project.id, self.project2.id]
 
-    @responses.activate
     def test_slack_notification_contents(self):
         self.populate_event_data()
         ctx = build_summary_data(
@@ -641,7 +640,8 @@ class DailySummaryTest(
                 provider=ExternalProviders.SLACK,
                 project_context=top_projects_context_map,
             ).send()
-        blocks, fallback_text = get_blocks_and_fallback_text()
+        blocks = orjson.loads(self.mock_post.call_args.kwargs["blocks"])
+        fallback_text = self.mock_post.call_args.kwargs["text"]
         link_text = "http://testserver/organizations/baz/issues/{}/?referrer=daily_summary-slack"
         assert fallback_text == f"Daily Summary for Your {self.organization.slug.title()} Projects"
         assert f":bell: *{fallback_text}*" in blocks[0]["text"]["text"]
@@ -686,7 +686,6 @@ class DailySummaryTest(
             in blocks[12]["elements"][0]["text"]
         )
 
-    @responses.activate
     @with_feature("organizations:discover")
     def test_slack_notification_contents_discover_link(self):
         self.populate_event_data()
@@ -704,7 +703,8 @@ class DailySummaryTest(
                 provider=ExternalProviders.SLACK,
                 project_context=top_projects_context_map,
             ).send()
-        blocks, fallback_text = get_blocks_and_fallback_text()
+        blocks = orjson.loads(self.mock_post.call_args.kwargs["blocks"])
+        fallback_text = self.mock_post.call_args.kwargs["text"]
         query_params = {
             "field": ["title", "event.type", "project", "user.display", "timestamp"],
             "name": "All Events",
@@ -730,7 +730,6 @@ class DailySummaryTest(
         )
         assert "higher than last 14d avg" in blocks[3]["fields"][1]["text"]
 
-    @responses.activate
     def test_slack_notification_contents_newline(self):
         type_string = '"""\nTraceback (most recent call last):\nFile /\'/usr/hb/meow/\''
         data = {
@@ -778,10 +777,9 @@ class DailySummaryTest(
                 provider=ExternalProviders.SLACK,
                 project_context=top_projects_context_map,
             ).send()
-        blocks, fallback_text = get_blocks_and_fallback_text()
+        blocks = orjson.loads(self.mock_post.call_args.kwargs["blocks"])
         assert '""" Traceback (most recent call las...' in blocks[4]["fields"][0]["text"]
 
-    @responses.activate
     def test_slack_notification_contents_newline_no_attachment_text(self):
         data = {
             "timestamp": iso_format(self.now),
@@ -828,10 +826,9 @@ class DailySummaryTest(
                 provider=ExternalProviders.SLACK,
                 project_context=top_projects_context_map,
             ).send()
-        blocks, fallback_text = get_blocks_and_fallback_text()
+        blocks = orjson.loads(self.mock_post.call_args.kwargs["blocks"])
         assert "" in blocks[4]["fields"][0]["text"]
 
-    @responses.activate
     def test_slack_notification_contents_truncate_text(self):
         data = {
             "timestamp": iso_format(self.now),
@@ -878,11 +875,10 @@ class DailySummaryTest(
                 provider=ExternalProviders.SLACK,
                 project_context=top_projects_context_map,
             ).send()
-        blocks, fallback_text = get_blocks_and_fallback_text()
+        blocks = orjson.loads(self.mock_post.call_args.kwargs["blocks"])
         assert "OperationalErrorThatIsVeryLongForSo..." in blocks[4]["fields"][0]["text"]
         assert "QueryCanceled('canceling statement ..." in blocks[4]["fields"][0]["text"]
 
-    @responses.activate
     def test_limit_to_two_projects(self):
         """Test that if we have data for more than 2 projects that we only show data for the top 2"""
         self.populate_event_data()
@@ -911,10 +907,9 @@ class DailySummaryTest(
                 provider=ExternalProviders.SLACK,
                 project_context=top_projects_context_map,
             ).send()
-        blocks, _ = get_blocks_and_fallback_text()
+        blocks = orjson.loads(self.mock_post.call_args.kwargs["blocks"])
         assert len(blocks) == 13
 
-    @responses.activate
     def test_no_release_data(self):
         """
         Test that the notification formats as expected when we don't have release data
@@ -934,14 +929,13 @@ class DailySummaryTest(
                 provider=ExternalProviders.SLACK,
                 project_context=top_projects_context_map,
             ).send()
-        blocks, fallback_text = get_blocks_and_fallback_text()
+        blocks = orjson.loads(self.mock_post.call_args.kwargs["blocks"])
         assert f"*{self.project.slug}*" in blocks[2]["text"]["text"]
         # check that we skip ahead to the today's event count section
         # if we had release data, it would be here instead
         assert "*Today’s Event Count*" in blocks[3]["fields"][0]["text"]
         assert "higher than last 14d avg" in blocks[3]["fields"][1]["text"]
 
-    @responses.activate
     def test_no_performance_issues(self):
         """
         Test that the notification formats as expected when we don't have performance issues
@@ -961,7 +955,7 @@ class DailySummaryTest(
                 provider=ExternalProviders.SLACK,
                 project_context=top_projects_context_map,
             ).send()
-        blocks, fallback_text = get_blocks_and_fallback_text()
+        blocks = orjson.loads(self.mock_post.call_args.kwargs["blocks"])
         link_text = "http://testserver/organizations/baz/issues/{}/?referrer=daily_summary-slack"
         # check the today's event count section
         assert "*Today’s Event Count*" in blocks[3]["fields"][0]["text"]
@@ -989,7 +983,6 @@ class DailySummaryTest(
         # check footer
         assert "Getting this at a funky time?" in blocks[12]["elements"][0]["text"]
 
-    @responses.activate
     def test_no_escalated_regressed_issues(self):
         """
         Test that the notification formats as expected when we don't have escalated and/or regressed issues
@@ -1009,7 +1002,7 @@ class DailySummaryTest(
                 provider=ExternalProviders.SLACK,
                 project_context=top_projects_context_map,
             ).send()
-        blocks, fallback_text = get_blocks_and_fallback_text()
+        blocks = orjson.loads(self.mock_post.call_args.kwargs["blocks"])
         link_text = "http://testserver/organizations/baz/issues/{}/?referrer=daily_summary-slack"
         assert f"*{self.project.slug}*" in blocks[2]["text"]["text"]
         # check the today's event count section


### PR DESCRIPTION
Default to using the Slack SDK Client for notifying recipients (sending an "activity" or "alert rule" notification to a Slack user or team, but NOT to a channel directly). The feature has been GA'd.

Also adds metrics for success/failure of chat_postMessage for notifying recipients.

Fixes a LOT of tests that were using the `responses` library to mock Slack responses, but this needed to be replaced because slack_sdk uses urllib. These tests check the call args to `chat_postMessage`.