### PR TITLE
feat(query-builder): Use CompactSelect for operator button

### DIFF
--- a/static/app/components/compactSelect/control.tsx
+++ b/static/app/components/compactSelect/control.tsx
@@ -444,6 +444,8 @@ export function Control({
       if (e.key === 'ArrowDown' || e.key === 'ArrowUp') {
         e.preventDefault(); // Prevent scroll
         overlayState.open();
+      } else {
+        e.continuePropagation();
       }
     },
   });

--- a/static/app/components/searchQueryBuilder/filter.tsx
+++ b/static/app/components/searchQueryBuilder/filter.tsx
@@ -1,23 +1,19 @@
-import {Fragment, useCallback, useLayoutEffect, useMemo, useRef, useState} from 'react';
+import {Fragment, useLayoutEffect, useRef, useState} from 'react';
 import styled from '@emotion/styled';
 import {useFocusWithin} from '@react-aria/interactions';
 import {mergeProps} from '@react-aria/utils';
 import type {ListState} from '@react-stately/list';
 import type {Node} from '@react-types/shared';
 
-import {DropdownMenu, type MenuItemProps} from 'sentry/components/dropdownMenu';
 import InteractionStateLayer from 'sentry/components/interactionStateLayer';
 import {useSearchQueryBuilder} from 'sentry/components/searchQueryBuilder/context';
+import {FilterOperator} from 'sentry/components/searchQueryBuilder/filterOperator';
+import {useFilterButtonProps} from 'sentry/components/searchQueryBuilder/useFilterButtonProps';
 import {useQueryBuilderGridItem} from 'sentry/components/searchQueryBuilder/useQueryBuilderGridItem';
-import {
-  formatFilterValue,
-  getKeyLabel,
-  getValidOpsForFilter,
-} from 'sentry/components/searchQueryBuilder/utils';
+import {formatFilterValue, getKeyLabel} from 'sentry/components/searchQueryBuilder/utils';
 import {SearchQueryBuilderValueCombobox} from 'sentry/components/searchQueryBuilder/valueCombobox';
 import {
   type ParseResultToken,
-  TermOperator,
   Token,
   type TokenResult,
 } from 'sentry/components/searchSyntax/parser';
@@ -31,73 +27,6 @@ type SearchQueryTokenProps = {
   state: ListState<ParseResultToken>;
   token: TokenResult<Token.FILTER>;
 };
-
-const OP_LABELS = {
-  [TermOperator.DEFAULT]: 'is',
-  [TermOperator.GREATER_THAN]: '>',
-  [TermOperator.GREATER_THAN_EQUAL]: '>=',
-  [TermOperator.LESS_THAN]: '<',
-  [TermOperator.LESS_THAN_EQUAL]: '<=',
-  [TermOperator.NOT_EQUAL]: 'is not',
-};
-
-const getOpLabel = (token: TokenResult<Token.FILTER>) => {
-  if (token.negated) {
-    return OP_LABELS[TermOperator.NOT_EQUAL];
-  }
-
-  return OP_LABELS[token.operator] ?? token.operator;
-};
-
-function useFilterButtonProps({
-  item,
-  state,
-}: Pick<SearchQueryTokenProps, 'item' | 'state'>) {
-  const onFocus = useCallback(() => {
-    // Ensure that the state is updated correctly
-    state.selectionManager.setFocusedKey(item.key);
-  }, [item.key, state.selectionManager]);
-
-  return {
-    onFocus,
-    tabIndex: -1,
-  };
-}
-
-function FilterOperator({token, state, item}: SearchQueryTokenProps) {
-  const {dispatch} = useSearchQueryBuilder();
-
-  const items: MenuItemProps[] = useMemo(() => {
-    return getValidOpsForFilter(token).map(op => ({
-      key: op,
-      label: OP_LABELS[op] ?? op,
-      onAction: val => {
-        dispatch({
-          type: 'UPDATE_FILTER_OP',
-          token,
-          op: val as TermOperator,
-        });
-      },
-    }));
-  }, [dispatch, token]);
-
-  const filterButtonProps = useFilterButtonProps({state, item});
-
-  return (
-    <DropdownMenu
-      trigger={triggerProps => (
-        <OpButton
-          aria-label={t('Edit operator for filter: %s', token.key.text)}
-          {...mergeProps(triggerProps, filterButtonProps)}
-        >
-          <InteractionStateLayer />
-          {getOpLabel(token)}
-        </OpButton>
-      )}
-      items={items}
-    />
-  );
-}
 
 function FilterKey({token}: {token: TokenResult<Token.FILTER>}) {
   const {keys} = useSearchQueryBuilder();
@@ -299,20 +228,6 @@ const KeyLabel = styled('div')`
   :focus-within {
     background-color: ${p => p.theme.translucentGray100};
     border-right: 1px solid ${p => p.theme.innerBorder};
-  }
-`;
-
-const OpButton = styled(UnstyledButton)`
-  padding: 0 ${space(0.5)};
-  color: ${p => p.theme.subText};
-  height: 100%;
-  border-left: 1px solid transparent;
-  border-right: 1px solid transparent;
-
-  :focus {
-    background-color: ${p => p.theme.translucentGray100};
-    border-right: 1px solid ${p => p.theme.innerBorder};
-    border-left: 1px solid ${p => p.theme.innerBorder};
   }
 `;
 

--- a/static/app/components/searchQueryBuilder/filterOperator.tsx
+++ b/static/app/components/searchQueryBuilder/filterOperator.tsx
@@ -1,0 +1,110 @@
+import {useMemo} from 'react';
+import styled from '@emotion/styled';
+import {mergeProps} from '@react-aria/utils';
+import type {ListState} from '@react-stately/list';
+import type {Node} from '@react-types/shared';
+
+import {CompactSelect, type SelectOption} from 'sentry/components/compactSelect';
+import InteractionStateLayer from 'sentry/components/interactionStateLayer';
+import {useSearchQueryBuilder} from 'sentry/components/searchQueryBuilder/context';
+import {useFilterButtonProps} from 'sentry/components/searchQueryBuilder/useFilterButtonProps';
+import {getValidOpsForFilter} from 'sentry/components/searchQueryBuilder/utils';
+import {
+  type ParseResultToken,
+  TermOperator,
+  type Token,
+  type TokenResult,
+} from 'sentry/components/searchSyntax/parser';
+import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
+
+type FilterOperatorProps = {
+  item: Node<ParseResultToken>;
+  state: ListState<ParseResultToken>;
+  token: TokenResult<Token.FILTER>;
+};
+
+const OP_LABELS = {
+  [TermOperator.DEFAULT]: 'is',
+  [TermOperator.GREATER_THAN]: '>',
+  [TermOperator.GREATER_THAN_EQUAL]: '>=',
+  [TermOperator.LESS_THAN]: '<',
+  [TermOperator.LESS_THAN_EQUAL]: '<=',
+  [TermOperator.NOT_EQUAL]: 'is not',
+};
+
+function getTermOperatorFromToken(token: TokenResult<Token.FILTER>) {
+  if (token.negated) {
+    return TermOperator.NOT_EQUAL;
+  }
+
+  return token.operator;
+}
+
+export function FilterOperator({token, state, item}: FilterOperatorProps) {
+  const {dispatch} = useSearchQueryBuilder();
+  const operator = getTermOperatorFromToken(token);
+  const label = OP_LABELS[operator] ?? operator;
+  const filterButtonProps = useFilterButtonProps({state, item});
+
+  const options = useMemo<SelectOption<TermOperator>[]>(() => {
+    return getValidOpsForFilter(token)
+      .filter(op => op !== TermOperator.EQUAL)
+      .map(
+        (op): SelectOption<TermOperator> => ({
+          value: op,
+          label: OP_LABELS[op] ?? op,
+        })
+      );
+  }, [token]);
+
+  return (
+    <CompactSelect
+      trigger={triggerProps => (
+        <OpButton
+          aria-label={t('Edit operator for filter: %s', token.key.text)}
+          {...mergeProps(triggerProps, filterButtonProps)}
+        >
+          <InteractionStateLayer />
+          {label}
+        </OpButton>
+      )}
+      size="sm"
+      options={options}
+      value={operator}
+      onChange={option => {
+        dispatch({
+          type: 'UPDATE_FILTER_OP',
+          token,
+          op: option.value,
+        });
+      }}
+    />
+  );
+}
+
+const UnstyledButton = styled('button')`
+  background: none;
+  border: none;
+  outline: none;
+  padding: 0;
+  user-select: none;
+
+  :focus {
+    outline: none;
+  }
+`;
+
+const OpButton = styled(UnstyledButton)`
+  padding: 0 ${space(0.5)};
+  color: ${p => p.theme.subText};
+  height: 100%;
+  border-left: 1px solid transparent;
+  border-right: 1px solid transparent;
+
+  :focus {
+    background-color: ${p => p.theme.translucentGray100};
+    border-right: 1px solid ${p => p.theme.innerBorder};
+    border-left: 1px solid ${p => p.theme.innerBorder};
+  }
+`;

--- a/static/app/components/searchQueryBuilder/index.spec.tsx
+++ b/static/app/components/searchQueryBuilder/index.spec.tsx
@@ -259,7 +259,7 @@ describe('SearchQueryBuilder', function () {
       await userEvent.click(
         screen.getByRole('button', {name: 'Edit operator for filter: browser.name'})
       );
-      await userEvent.click(screen.getByRole('menuitemradio', {name: 'is not'}));
+      await userEvent.click(screen.getByRole('option', {name: 'is not'}));
 
       // Token should be modified to be negated
       expect(
@@ -292,7 +292,7 @@ describe('SearchQueryBuilder', function () {
       await userEvent.click(
         screen.getByRole('button', {name: 'Edit operator for filter: browser.name'})
       );
-      await userEvent.click(screen.getByRole('menuitemradio', {name: 'is not'}));
+      await userEvent.click(screen.getByRole('option', {name: 'is not'}));
 
       // Token should be modified to be negated
       expect(
@@ -668,8 +668,12 @@ describe('SearchQueryBuilder', function () {
         screen.getAllByRole('combobox', {name: 'Add a search term'}).at(-1)
       ).toHaveFocus();
 
-      // Shift-tabbing should exit the component
-      await userEvent.keyboard('{Shift>}{Tab}{/Shift}');
+      // One more tab should go to the clear button
+      await userEvent.keyboard('{Tab}');
+      expect(screen.getByRole('button', {name: 'Clear search query'})).toHaveFocus();
+
+      // Another should exit component
+      await userEvent.keyboard('{Tab}');
       expect(document.body).toHaveFocus();
     });
 
@@ -953,7 +957,7 @@ describe('SearchQueryBuilder', function () {
         await userEvent.click(
           screen.getByRole('button', {name: 'Edit operator for filter: timesSeen'})
         );
-        await userEvent.click(screen.getByRole('menuitemradio', {name: '<='}));
+        await userEvent.click(screen.getByRole('option', {name: '<='}));
 
         expect(
           await screen.findByRole('row', {name: 'timesSeen:<=100k'})

--- a/static/app/components/searchQueryBuilder/index.stories.tsx
+++ b/static/app/components/searchQueryBuilder/index.stories.tsx
@@ -41,6 +41,11 @@ const FITLER_KEY_SECTIONS: FilterKeySection[] = [
         predefined: true,
         values: ['Chrome', 'Firefox', 'Safari', 'Edge'],
       },
+      {
+        key: FieldKey.LAST_SEEN,
+        name: 'Last Seen',
+        kind: FieldKind.FIELD,
+      },
     ],
   },
   {

--- a/static/app/components/searchQueryBuilder/useFilterButtonProps.tsx
+++ b/static/app/components/searchQueryBuilder/useFilterButtonProps.tsx
@@ -1,0 +1,22 @@
+import {useCallback} from 'react';
+import type {ListState} from '@react-stately/list';
+import type {Node} from '@react-types/shared';
+
+import type {ParseResultToken} from 'sentry/components/searchSyntax/parser';
+
+type Props = {
+  item: Node<ParseResultToken>;
+  state: ListState<ParseResultToken>;
+};
+
+export function useFilterButtonProps({item, state}: Props) {
+  const onFocus = useCallback(() => {
+    // Ensure that the state is updated correctly
+    state.selectionManager.setFocusedKey(item.key);
+  }, [item.key, state.selectionManager]);
+
+  return {
+    onFocus,
+    tabIndex: -1,
+  };
+}

--- a/static/app/components/searchQueryBuilder/useQueryBuilderGridItem.tsx
+++ b/static/app/components/searchQueryBuilder/useQueryBuilderGridItem.tsx
@@ -69,7 +69,10 @@ export function useQueryBuilderGridItem(
         return;
       }
 
-      const walker = getFocusableTreeWalker(e.currentTarget, {wrap: false});
+      const walker = getFocusableTreeWalker(e.currentTarget, {
+        wrap: false,
+        accept: node => node.tagName === 'BUTTON',
+      });
       walker.currentNode = e.target as FocusableElement;
 
       // On ArrowRight, we want to focus the next grid cell if there is one.


### PR DESCRIPTION
Because the operator has a success state, we should be using CompactSelect instead of a DropdownMenu. This also sets us up better for making more complex operator actions.

![CleanShot 2024-06-17 at 09 02 52](https://github.com/getsentry/sentry/assets/10888943/1cbe1d2f-bf73-4798-9bb1-fa536bf3b12f)
