### PR TITLE
ref(slack): use sdk client to get users with pagination

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -389,6 +389,8 @@ def register_temporary_features(manager: FeatureManager):
     # Enable improvements to Slack notifications
     manager.add("organizations:slack-improvements", OrganizationFeature, FeatureHandlerStrategy.OPTIONS)
     # Feature flags for migrating to the Slack SDK WebClient
+    # Use new Slack SDK Client for getting users
+    manager.add("organizations:slack-sdk-get-users", OrganizationFeature, FeatureHandlerStrategy.OPTIONS)
     # Use new Slack SDK Client in _notify_recipient
     manager.add("organizations:slack-sdk-notify-recipient", OrganizationFeature, FeatureHandlerStrategy.OPTIONS)
     # Add regression chart as image to slack message

--- a/src/sentry/integrations/slack/utils/users.py
+++ b/src/sentry/integrations/slack/utils/users.py
@@ -45,7 +45,7 @@ def get_users(integration: Integration, organization: Organization) -> Sequence[
         for _ in range(SLACK_GET_USERS_PAGE_LIMIT):
             try:
                 user_list += next_users.get("members")
-                next_users = next(users)
+                next_users = next(next_users)
             except StopIteration:
                 break
             except SlackApiError:

--- a/src/sentry/tasks/integrations/slack/link_slack_user_identities.py
+++ b/src/sentry/tasks/integrations/slack/link_slack_user_identities.py
@@ -58,41 +58,8 @@ def link_slack_user_identities(
         update_identities(data, idp)
 
 
-def update_identities(slack_data_by_user: Mapping[User, Mapping[str, str]], idp: IdentityProvider):
-    date_verified = timezone.now()
-    identities_by_user = get_identities_by_user(idp, slack_data_by_user.keys())
-
-    for user, data in slack_data_by_user.items():
-        # Identity already exists, the emails match, AND the external ID has changed
-        if user in identities_by_user.keys():
-            if data["slack_id"] != identities_by_user[user].external_id:
-                # replace the Identity's external_id with the new one we just got from Slack
-                identities_by_user[user].update(external_id=data["slack_id"])
-            continue
-        # the user doesn't already have an Identity and one of their Sentry emails matches their Slack email
-        matched_identity, created = Identity.objects.get_or_create(
-            idp=idp,
-            external_id=data["slack_id"],
-            defaults={"user": user, "status": IdentityStatus.VALID, "date_verified": date_verified},
-        )
-        # the Identity matching that idp/external_id combo is linked to a different user
-        if not created:
-            logger.info(
-                "post_install.identity_linked_different_user",
-                extra={
-                    "idp_id": idp.id,
-                    "external_id": data["slack_id"],
-                    "object_id": matched_identity.id,
-                    "user_id": user.id,
-                    "type": idp.type,
-                },
-            )
-
-
 # has different typing for slack_data_by_user, need to grab slack_id from a dataclass
-def update_identities_with_dataclass(
-    slack_data_by_user: Mapping[User, SlackUserData], idp: IdentityProvider
-):
+def update_identities(slack_data_by_user: Mapping[User, SlackUserData], idp: IdentityProvider):
     date_verified = timezone.now()
     identities_by_user = get_identities_by_user(idp, slack_data_by_user.keys())
 

--- a/src/sentry/tasks/integrations/slack/link_slack_user_identities.py
+++ b/src/sentry/tasks/integrations/slack/link_slack_user_identities.py
@@ -7,7 +7,7 @@ from django.utils import timezone
 
 from sentry import features
 from sentry.integrations.slack.utils import get_slack_data_by_user
-from sentry.integrations.slack.utils.users import get_slack_data_by_user_via_sdk
+from sentry.integrations.slack.utils.users import SlackUserData, get_slack_data_by_user_via_sdk
 from sentry.integrations.utils import get_identities_by_user
 from sentry.models.identity import Identity, IdentityProvider, IdentityStatus
 from sentry.models.user import User
@@ -82,6 +82,41 @@ def update_identities(slack_data_by_user: Mapping[User, Mapping[str, str]], idp:
                 extra={
                     "idp_id": idp.id,
                     "external_id": data["slack_id"],
+                    "object_id": matched_identity.id,
+                    "user_id": user.id,
+                    "type": idp.type,
+                },
+            )
+
+
+# has different typing for slack_data_by_user, need to grab slack_id from a dataclass
+def update_identities_with_dataclass(
+    slack_data_by_user: Mapping[User, SlackUserData], idp: IdentityProvider
+):
+    date_verified = timezone.now()
+    identities_by_user = get_identities_by_user(idp, slack_data_by_user.keys())
+
+    for user, data in slack_data_by_user.items():
+        slack_id = data.slack_id
+        # Identity already exists, the emails match, AND the external ID has changed
+        if user in identities_by_user.keys():
+            if slack_id != identities_by_user[user].external_id:
+                # replace the Identity's external_id with the new one we just got from Slack
+                identities_by_user[user].update(external_id=data.slack_id)
+            continue
+        # the user doesn't already have an Identity and one of their Sentry emails matches their Slack email
+        matched_identity, created = Identity.objects.get_or_create(
+            idp=idp,
+            external_id=slack_id,
+            defaults={"user": user, "status": IdentityStatus.VALID, "date_verified": date_verified},
+        )
+        # the Identity matching that idp/external_id combo is linked to a different user
+        if not created:
+            logger.info(
+                "post_install.identity_linked_different_user",
+                extra={
+                    "idp_id": idp.id,
+                    "external_id": slack_id,
                     "object_id": matched_identity.id,
                     "user_id": user.id,
                     "type": idp.type,

--- a/tests/sentry/integrations/slack/test_integration.py
+++ b/tests/sentry/integrations/slack/test_integration.py
@@ -362,7 +362,7 @@ class SlackIntegrationPostInstallTest(APITestCase):
     @with_feature("organizations:slack-sdk-get-users")
     @responses.activate
     def test_link_multiple_users_sdk_client_pagination(self, mock_api_call):
-        self.response_json["response_metadata"]["next_cursor"] = "dXNlcjpVMEc5V0ZYTlo"
+        self.response_json["response_metadata"] = {"next_cursor": "dXNlcjpVMEc5V0ZYTlo"}
         mock_api_call.side_effect = [
             {
                 "body": orjson.dumps(
@@ -413,7 +413,7 @@ class SlackIntegrationPostInstallTest(APITestCase):
     @with_feature("organizations:slack-sdk-get-users")
     @responses.activate
     def test_link_multiple_users_sdk_client_pagination_error(self, mock_api_call):
-        self.response_json["response_metadata"]["next_cursor"] = "dXNlcjpVMEc5V0ZYTlo"
+        self.response_json["response_metadata"] = {"next_cursor": "dXNlcjpVMEc5V0ZYTlo"}
         mock_api_call.side_effect = [
             {
                 "body": orjson.dumps(

--- a/tests/sentry/integrations/slack/test_integration.py
+++ b/tests/sentry/integrations/slack/test_integration.py
@@ -13,6 +13,7 @@ from sentry.models.identity import Identity, IdentityProvider, IdentityStatus
 from sentry.models.integrations.integration import Integration
 from sentry.models.integrations.organization_integration import OrganizationIntegration
 from sentry.testutils.cases import APITestCase, IntegrationTestCase, TestCase
+from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.silo import control_silo_test
 
 
@@ -265,52 +266,54 @@ class SlackIntegrationPostInstallTest(APITestCase):
             scopes=[],
         )
 
+        self.response_json = {
+            "ok": True,
+            "members": [
+                {
+                    "id": "UXXXXXXX1",
+                    "team_id": "TXXXXXXX1",
+                    "deleted": False,
+                    "profile": {
+                        "email": self.user.email,
+                        "team": "TXXXXXXX1",
+                    },
+                },
+                {
+                    "id": "UXXXXXXX2",
+                    "team_id": "TXXXXXXX1",
+                    "deleted": False,
+                    "profile": {
+                        "email": self.user2.email,
+                        "team": "TXXXXXXX1",
+                    },
+                },
+                {
+                    "id": "UXXXXXXX3",
+                    "team_id": "TXXXXXXX1",
+                    "deleted": False,
+                    "profile": {
+                        "email": "wrongemail@example.com",
+                        "team": "TXXXXXXX1",
+                    },
+                },
+                {
+                    "id": "UXXXXXXX4",
+                    "team_id": "TXXXXXXX1",
+                    "deleted": False,
+                    "profile": {
+                        "email": "ialreadyexist@example.com",
+                        "team": "TXXXXXXX1",
+                    },
+                },
+            ],
+            "response_metadata": {"next_cursor": ""},
+        }
+
         responses.add(
             method=responses.GET,
             url="https://slack.com/api/users.list",
             match=[query_string_matcher(f"limit={SLACK_GET_USERS_PAGE_SIZE}")],
-            json={
-                "ok": True,
-                "members": [
-                    {
-                        "id": "UXXXXXXX1",
-                        "team_id": "TXXXXXXX1",
-                        "deleted": False,
-                        "profile": {
-                            "email": self.user.email,
-                            "team": "TXXXXXXX1",
-                        },
-                    },
-                    {
-                        "id": "UXXXXXXX2",
-                        "team_id": "TXXXXXXX1",
-                        "deleted": False,
-                        "profile": {
-                            "email": self.user2.email,
-                            "team": "TXXXXXXX1",
-                        },
-                    },
-                    {
-                        "id": "UXXXXXXX3",
-                        "team_id": "TXXXXXXX1",
-                        "deleted": False,
-                        "profile": {
-                            "email": "wrongemail@example.com",
-                            "team": "TXXXXXXX1",
-                        },
-                    },
-                    {
-                        "id": "UXXXXXXX4",
-                        "team_id": "TXXXXXXX1",
-                        "deleted": False,
-                        "profile": {
-                            "email": "ialreadyexist@example.com",
-                            "team": "TXXXXXXX1",
-                        },
-                    },
-                ],
-                "response_metadata": {"next_cursor": ""},
-            },
+            json=self.response_json,
         )
 
     @responses.activate
@@ -331,6 +334,114 @@ class SlackIntegrationPostInstallTest(APITestCase):
         assert user2_identity
         assert user2_identity.external_id == "UXXXXXXX2"
         assert user2_identity.user.email == "foo@example.com"
+
+    @patch("slack_sdk.web.client.WebClient._perform_urllib_http_request")
+    @with_feature("organizations:slack-sdk-get-users")
+    @responses.activate
+    def test_link_multiple_users_sdk_client(self, mock_api_call):
+        mock_api_call.return_value = {
+            "body": orjson.dumps(self.response_json).decode(),
+            "headers": {},
+            "status": 200,
+        }
+
+        with self.tasks():
+            SlackIntegrationProvider().post_install(self.integration, self.organization)
+
+        user1_identity = Identity.objects.get(user=self.user)
+        assert user1_identity
+        assert user1_identity.external_id == "UXXXXXXX1"
+        assert user1_identity.user.email == "admin@localhost"
+
+        user2_identity = Identity.objects.get(user=self.user2)
+        assert user2_identity
+        assert user2_identity.external_id == "UXXXXXXX2"
+        assert user2_identity.user.email == "foo@example.com"
+
+    @patch("slack_sdk.web.client.WebClient._perform_urllib_http_request")
+    @with_feature("organizations:slack-sdk-get-users")
+    @responses.activate
+    def test_link_multiple_users_sdk_client_pagination(self, mock_api_call):
+        self.response_json["response_metadata"]["next_cursor"] = "dXNlcjpVMEc5V0ZYTlo"
+        mock_api_call.side_effect = [
+            {
+                "body": orjson.dumps(
+                    self.response_json,
+                ).decode(),
+                "headers": {},
+                "status": 200,
+            },
+            {
+                "body": orjson.dumps(
+                    {
+                        "ok": True,
+                        "members": [
+                            {
+                                "id": "UXXXXXXX5",
+                                "team_id": "TXXXXXXX1",
+                                "deleted": False,
+                                "profile": {
+                                    "email": "hello@example.com",
+                                    "team": "TXXXXXXX1",
+                                },
+                            }
+                        ],
+                    },
+                ),
+                "headers": {},
+                "status": 200,
+            },
+        ]
+
+        user5 = self.create_user("hello@example.com")
+        self.create_member(
+            user=user5,
+            organization=self.organization,
+            role="manager",
+            teams=[self.team],
+        )
+
+        with self.tasks():
+            SlackIntegrationProvider().post_install(self.integration, self.organization)
+
+        user5_identity = Identity.objects.get(user=user5)
+        assert user5_identity
+        assert user5_identity.external_id == "UXXXXXXX5"
+        assert user5_identity.user.email == "hello@example.com"
+
+    @patch("slack_sdk.web.client.WebClient._perform_urllib_http_request")
+    @with_feature("organizations:slack-sdk-get-users")
+    @responses.activate
+    def test_link_multiple_users_sdk_client_pagination_error(self, mock_api_call):
+        self.response_json["response_metadata"]["next_cursor"] = "dXNlcjpVMEc5V0ZYTlo"
+        mock_api_call.side_effect = [
+            {
+                "body": orjson.dumps(
+                    self.response_json,
+                ).decode(),
+                "headers": {},
+                "status": 200,
+            },
+            {
+                "body": orjson.dumps({"ok": False}),
+                "headers": {},
+                "status": 200,
+            },
+        ]
+
+        user5 = self.create_user("hello@example.com")
+        self.create_member(
+            user=user5,
+            organization=self.organization,
+            role="manager",
+            teams=[self.team],
+        )
+
+        with self.tasks():
+            SlackIntegrationProvider().post_install(self.integration, self.organization)
+
+        user5_identity = Identity.objects.filter(user=user5).first()
+        assert user5_identity is None
 
     @responses.activate
     def test_email_no_match(self):

--- a/tests/sentry/integrations/slack/test_integration.py
+++ b/tests/sentry/integrations/slack/test_integration.py
@@ -387,7 +387,7 @@ class SlackIntegrationPostInstallTest(APITestCase):
                             }
                         ],
                     },
-                ),
+                ).decode(),
                 "headers": {},
                 "status": 200,
             },
@@ -423,7 +423,7 @@ class SlackIntegrationPostInstallTest(APITestCase):
                 "status": 200,
             },
             {
-                "body": orjson.dumps({"ok": False}),
+                "body": orjson.dumps({"ok": False}).decode(),
                 "headers": {},
                 "status": 200,
             },


### PR DESCRIPTION
Use the Slack SDK client to get users during integration post-install. The `slack_sdk` `SlackResponse` class has a built in method of pagination using an iterator, so we can use that here.