### PR TITLE
feat(breadcrumbs): Implement shared timeline component

### DIFF
--- a/static/app/components/timeline/index.stories.tsx
+++ b/static/app/components/timeline/index.stories.tsx
@@ -1,0 +1,270 @@
+import {Fragment} from 'react';
+
+import {CodeSnippet} from 'sentry/components/codeSnippet';
+import {StructuredData} from 'sentry/components/structuredEventData';
+import * as Timeline from 'sentry/components/timeline';
+import {
+  IconClock,
+  IconCursorArrow,
+  IconDashboard,
+  IconFire,
+  IconSentry,
+  IconSort,
+} from 'sentry/icons';
+import storyBook from 'sentry/stories/storyBook';
+
+export default storyBook('Timeline (Updated 06/17/24)', story => {
+  story('Usage', () => (
+    <Fragment>
+      <CodeSnippet language="js">
+        import * as Timeline from 'sentry/components/timeline';
+      </CodeSnippet>
+    </Fragment>
+  ));
+
+  story('<Timeline.Text />', () => (
+    <Fragment>
+      <p>
+        <code>{'<Timeline.Text/>'}</code> can be used to easily format the children of
+        <code>{'<Timeline.Item>'}</code>. It generally contains descriptive text.
+      </p>
+      <CodeSnippet language="jsx">
+        {`<Timeline.Item ...>
+  <Timeline.Text>{someText}</Timeline.Text>
+</Timeline.Item>`}
+      </CodeSnippet>
+      <h6>Example</h6>
+      <Timeline.Item
+        title={'SyntaxError'}
+        icon={<IconFire size="xs" />}
+        timeString={now.toISOString()}
+        colorConfig={{
+          primary: 'red400',
+          secondary: 'red200',
+        }}
+        isActive
+      >
+        <Timeline.Text>This is a description of the error</Timeline.Text>
+      </Timeline.Item>
+    </Fragment>
+  ));
+
+  story('<Timeline.Data />', () => (
+    <Fragment>
+      <p>
+        <code>{'<Timeline.Data/>'}</code> is used to format the children of
+        <code>{'<Timeline.Item>'}</code>. It generally contains code snippets or payloads.
+      </p>
+      <CodeSnippet language="jsx">
+        {`<Timeline.Item ...>
+  <Timeline.Data>
+    <StructuredData value={someJson} />
+  </Timeline.Data>
+</Timeline.Item>`}
+      </CodeSnippet>
+      <h6>Example</h6>
+      <Timeline.Item
+        title={'Navigation'}
+        icon={<IconSort rotated size="xs" />}
+        timeString={now.toISOString()}
+        colorConfig={{
+          primary: 'green400',
+          secondary: 'green200',
+        }}
+      >
+        <Timeline.Data>
+          <StructuredData
+            value={JSONPayload}
+            depth={0}
+            maxDefaultDepth={1}
+            meta={undefined}
+            withAnnotatedText
+            withOnlyFormattedText
+          />
+        </Timeline.Data>
+      </Timeline.Item>
+    </Fragment>
+  ));
+
+  story('<Timeline.Item />', () => (
+    <Fragment>
+      <p>
+        <code>{'<Timeline.Item/>'}</code> contains each item to represent
+      </p>
+      <h6>Required Props</h6>
+      <ul>
+        <li>
+          <code>icon</code> - Icon component to render alongside item. Size `xs`
+          recommended.
+        </li>
+        <li>
+          <code>timeString</code> - ISO time string detailing the moment the item happened
+        </li>
+        <li>
+          <code>title</code> - The header to appear on the item
+        </li>
+      </ul>
+      <h6>Optional Props</h6>
+      <ul>
+        <li>
+          <code>startTimeString</code> - If provided, time will be displayed relative to
+          start time.
+        </li>
+        <li>
+          <code>colorConfig</code> - A mapping of colors to use for emphasizing the item
+        </li>
+        <li>
+          <code>isActive</code> - If set to true, will display a border under the item
+        </li>
+        <li>
+          <code>onClick</code> - React event handler for the entire item
+        </li>
+        <li>
+          <code>onMouseEnter</code> - React event handler for the entire item
+        </li>
+        <li>
+          <code>onMouseLeave</code> - React event handler for the entire item
+        </li>
+      </ul>
+      <h6>Example</h6>
+      <Timeline.Item
+        title={'SyntaxError'}
+        icon={<IconFire size="xs" />}
+        timeString={now.toISOString()}
+        colorConfig={{
+          primary: 'red400',
+          secondary: 'red200',
+        }}
+      />
+      <Timeline.Item
+        title={'Active Item'}
+        icon={<IconCursorArrow size="xs" />}
+        timeString={now.toISOString()}
+        colorConfig={{
+          primary: 'blue400',
+          secondary: 'blue200',
+        }}
+        isActive
+      >
+        <Timeline.Text>This is a description of the error</Timeline.Text>
+      </Timeline.Item>
+      <Timeline.Item
+        title={'Data'}
+        icon={<IconDashboard size="xs" />}
+        timeString={now.toISOString()}
+        colorConfig={{
+          primary: 'pink400',
+          secondary: 'pink200',
+        }}
+      >
+        <Timeline.Data>
+          <StructuredData
+            value={JSONPayload}
+            depth={0}
+            maxDefaultDepth={1}
+            meta={undefined}
+            withAnnotatedText
+            withOnlyFormattedText
+          />
+        </Timeline.Data>
+      </Timeline.Item>
+      <Timeline.Item
+        title={'Relative Event'}
+        icon={<IconClock size="xs" />}
+        timeString={now.toISOString()}
+        startTimeString={before.toISOString()}
+        colorConfig={{
+          primary: 'purple400',
+          secondary: 'purple200',
+        }}
+      >
+        <Timeline.Text>This is a description of the error</Timeline.Text>
+      </Timeline.Item>
+    </Fragment>
+  ));
+
+  story('<Timeline.Group />', () => (
+    <Fragment>
+      <p>
+        <code>{'<Timeline.Group/>'}</code> expects to contain{' '}
+        <code>{'<Timeline.Item>'}</code> components. Adds a vertical line behind the
+        elements, even if the item is not marked 'isActive'.
+      </p>
+      <h6>Example</h6>
+      <Timeline.Group>
+        <Timeline.Item
+          title={'Error'}
+          icon={<IconFire size="xs" />}
+          timeString={now.toISOString()}
+          colorConfig={{
+            primary: 'red400',
+            secondary: 'red200',
+          }}
+        >
+          <Timeline.Text>This is a description of the error</Timeline.Text>
+        </Timeline.Item>
+
+        <Timeline.Item
+          title={'HTTP'}
+          icon={<IconSort rotated size="xs" />}
+          timeString={now.toISOString()}
+          colorConfig={{
+            primary: 'green400',
+            secondary: 'green200',
+          }}
+        >
+          {' '}
+          <Timeline.Data>
+            <StructuredData
+              value={JSONPayload}
+              depth={0}
+              maxDefaultDepth={1}
+              meta={undefined}
+              withAnnotatedText
+              withOnlyFormattedText
+            />
+          </Timeline.Data>
+        </Timeline.Item>
+
+        <Timeline.Item
+          title={'UI Click'}
+          icon={<IconCursorArrow size="xs" />}
+          timeString={now.toISOString()}
+          colorConfig={{
+            primary: 'blue400',
+            secondary: 'blue200',
+          }}
+        >
+          <Timeline.Text>{'div.abc123 > xyz > somethingsomething'}</Timeline.Text>
+        </Timeline.Item>
+
+        <Timeline.Item
+          title={'Sentry Event'}
+          icon={<IconSentry size="xs" />}
+          timeString={now.toISOString()}
+          colorConfig={{
+            primary: 'purple400',
+            secondary: 'purple200',
+          }}
+        >
+          <Timeline.Text>
+            <a href="sentry.io">sentry.io</a>
+          </Timeline.Text>
+        </Timeline.Item>
+      </Timeline.Group>
+    </Fragment>
+  ));
+});
+
+const JSONPayload: Record<string, any> = {
+  logger: 'info',
+  url: {
+    addr: 'example.com/checkout',
+    query: {isBetaUi: true},
+  },
+  user_id: 123,
+  organizations: ['acme', 'xyz'],
+};
+
+const now = new Date();
+const before = new Date('2024-06-15');

--- a/static/app/components/timeline/index.stories.tsx
+++ b/static/app/components/timeline/index.stories.tsx
@@ -26,11 +26,13 @@ export default storyBook('Timeline (Updated 06/17/24)', story => {
         <code>{'<Timeline.Text />'}</code> can be used to easily format the children of
         <code>{'<Timeline.Item />'}</code>. It generally contains descriptive text.
       </p>
-      <CodeSnippet language="jsx">
-        {`<Timeline.Item ...>
+      <p>
+        <CodeSnippet language="jsx">
+          {`<Timeline.Item ...>
   <Timeline.Text>{someText}</Timeline.Text>
 </Timeline.Item>`}
-      </CodeSnippet>
+        </CodeSnippet>
+      </p>
       <h6>Example</h6>
       <Timeline.Item
         title={'SyntaxError'}
@@ -54,13 +56,15 @@ export default storyBook('Timeline (Updated 06/17/24)', story => {
         <code>{'<Timeline.Item />'}</code>. It generally contains code snippets or
         payloads.
       </p>
-      <CodeSnippet language="jsx">
-        {`<Timeline.Item ...>
+      <p>
+        <CodeSnippet language="jsx">
+          {`<Timeline.Item ...>
   <Timeline.Data>
     <StructuredData value={someJson} />
   </Timeline.Data>
 </Timeline.Item>`}
-      </CodeSnippet>
+        </CodeSnippet>
+      </p>
       <h6>Example</h6>
       <Timeline.Item
         title={'Navigation'}

--- a/static/app/components/timeline/index.stories.tsx
+++ b/static/app/components/timeline/index.stories.tsx
@@ -2,7 +2,7 @@ import {Fragment} from 'react';
 
 import {CodeSnippet} from 'sentry/components/codeSnippet';
 import {StructuredData} from 'sentry/components/structuredEventData';
-import * as Timeline from 'sentry/components/timeline';
+import Timeline from 'sentry/components/timeline';
 import {
   IconClock,
   IconCursorArrow,
@@ -15,18 +15,16 @@ import storyBook from 'sentry/stories/storyBook';
 
 export default storyBook('Timeline (Updated 06/17/24)', story => {
   story('Usage', () => (
-    <Fragment>
-      <CodeSnippet language="js">
-        import * as Timeline from 'sentry/components/timeline';
-      </CodeSnippet>
-    </Fragment>
+    <CodeSnippet language="js">
+      import Timeline from 'sentry/components/timeline';
+    </CodeSnippet>
   ));
 
   story('<Timeline.Text />', () => (
     <Fragment>
       <p>
-        <code>{'<Timeline.Text/>'}</code> can be used to easily format the children of
-        <code>{'<Timeline.Item>'}</code>. It generally contains descriptive text.
+        <code>{'<Timeline.Text />'}</code> can be used to easily format the children of
+        <code>{'<Timeline.Item />'}</code>. It generally contains descriptive text.
       </p>
       <CodeSnippet language="jsx">
         {`<Timeline.Item ...>
@@ -52,8 +50,9 @@ export default storyBook('Timeline (Updated 06/17/24)', story => {
   story('<Timeline.Data />', () => (
     <Fragment>
       <p>
-        <code>{'<Timeline.Data/>'}</code> is used to format the children of
-        <code>{'<Timeline.Item>'}</code>. It generally contains code snippets or payloads.
+        <code>{'<Timeline.Data />'}</code> is used to format the children of
+        <code>{'<Timeline.Item />'}</code>. It generally contains code snippets or
+        payloads.
       </p>
       <CodeSnippet language="jsx">
         {`<Timeline.Item ...>
@@ -183,15 +182,15 @@ export default storyBook('Timeline (Updated 06/17/24)', story => {
     </Fragment>
   ));
 
-  story('<Timeline.Group />', () => (
+  story('<Timeline.Container />', () => (
     <Fragment>
       <p>
-        <code>{'<Timeline.Group/>'}</code> expects to contain{' '}
-        <code>{'<Timeline.Item>'}</code> components. Adds a vertical line behind the
+        <code>{'<Timeline.Container />'}</code> expects to contain{' '}
+        <code>{'<Timeline.Item />'}</code> components. Adds a vertical line behind the
         elements, even if the item is not marked 'isActive'.
       </p>
       <h6>Example</h6>
-      <Timeline.Group>
+      <Timeline.Container>
         <Timeline.Item
           title={'Error'}
           icon={<IconFire size="xs" />}
@@ -251,7 +250,7 @@ export default storyBook('Timeline (Updated 06/17/24)', story => {
             <a href="sentry.io">sentry.io</a>
           </Timeline.Text>
         </Timeline.Item>
-      </Timeline.Group>
+      </Timeline.Container>
     </Fragment>
   ));
 });

--- a/static/app/components/timeline/index.tsx
+++ b/static/app/components/timeline/index.tsx
@@ -1,0 +1,178 @@
+import {useMemo} from 'react';
+import styled from '@emotion/styled';
+
+import {getFormattedTimestamp} from 'sentry/components/events/interfaces/breadcrumbs/breadcrumb/time/utils';
+import {Tooltip} from 'sentry/components/tooltip';
+import {space} from 'sentry/styles/space';
+import {defined} from 'sentry/utils';
+import type {Color} from 'sentry/utils/theme';
+
+export interface ColorConfig {
+  primary: Color;
+  secondary: Color;
+}
+
+export interface ItemProps {
+  icon: React.ReactNode;
+  timestamp: string;
+  title: React.ReactNode;
+  children?: React.ReactNode;
+  colorConfig?: ColorConfig;
+  isActive?: boolean;
+  onClick?: React.MouseEventHandler<HTMLDivElement>;
+  onMouseEnter?: React.MouseEventHandler<HTMLDivElement>;
+  onMouseLeave?: React.MouseEventHandler<HTMLDivElement>;
+  startTimestamp?: string;
+}
+
+export function Item({
+  title,
+  children,
+  icon,
+  timestamp,
+  startTimestamp,
+  colorConfig = {primary: 'gray300', secondary: 'gray200'},
+  isActive = false,
+  onClick,
+  onMouseEnter,
+  onMouseLeave,
+}: ItemProps) {
+  const hasRelativeTime = defined(startTimestamp);
+  const placeholderTime = useMemo(() => new Date().toTimeString(), []);
+
+  const {
+    displayTime,
+    date,
+    timeWithMilliseconds: preciseTime,
+  } = hasRelativeTime
+    ? getFormattedTimestamp(timestamp, startTimestamp, true)
+    : getFormattedTimestamp(timestamp, placeholderTime);
+
+  return (
+    <Row
+      color={colorConfig.secondary}
+      hasLowerBorder={isActive ?? false}
+      onClick={onClick}
+      onMouseEnter={onMouseEnter}
+      onMouseLeave={onMouseLeave}
+    >
+      <IconWrapper colorConfig={colorConfig} hasIconBorder={isActive ?? false}>
+        {icon}
+      </IconWrapper>
+      <Title color={colorConfig.primary}>{title}</Title>
+      <Timestamp>
+        <Tooltip title={`${preciseTime} - ${date}`}>{displayTime}</Tooltip>
+      </Timestamp>
+      <Spacer hasLine={isActive ?? false} />
+      <Content>{children}</Content>
+    </Row>
+  );
+}
+
+interface GroupProps {
+  children: React.ReactNode;
+}
+
+export function Group({children}: GroupProps) {
+  return <GroupWrapper>{children}</GroupWrapper>;
+}
+
+const GroupWrapper = styled('div')`
+  position: relative;
+  /* vertical line connecting items */
+  &::before {
+    content: '';
+    position: absolute;
+    left: 10.5px;
+    width: 1px;
+    top: 0;
+    bottom: 0;
+    background: ${p => p.theme.border};
+  }
+`;
+
+const Row = styled('div')<{color: string; hasLowerBorder: boolean}>`
+  position: relative;
+  color: ${p => p.theme.subText};
+  display: grid;
+  align-items: center;
+  grid-template: auto auto / 22px 1fr auto;
+  grid-column-gap: ${space(1)};
+  border-bottom: 1px solid ${p => (p.hasLowerBorder ? p.theme[p.color] : 'transparent')};
+  margin: ${space(1)} 0;
+  &:first-child {
+    margin-top: 0;
+  }
+  &:last-child {
+    margin-bottom: 0;
+    background: ${p => p.theme.background};
+  }
+  &:last-child > :last-child {
+    margin-bottom: ${p => (p.hasLowerBorder ? space(1) : 0)};
+  }
+`;
+
+const IconWrapper = styled('div')<{colorConfig: ColorConfig; hasIconBorder: boolean}>`
+  grid-column: span 1;
+  border-radius: 100%;
+  border: 1px solid;
+  border-color: ${p =>
+    p.hasIconBorder ? p.theme[p.colorConfig.secondary] : 'transparent'};
+  color: ${p => p.theme[p.colorConfig.primary]};
+  background: ${p => p.theme.background};
+  svg {
+    display: block;
+    margin: ${space(0.5)};
+  }
+`;
+
+const Title = styled('p')<{color: string}>`
+  color: ${p => p.theme[p.color]};
+  margin: 0;
+  font-weight: bold;
+  text-transform: capitalize;
+  grid-column: span 1;
+`;
+
+const Timestamp = styled('p')`
+  margin: 0 ${space(1)};
+  color: ${p => p.theme.subText};
+  span {
+    text-decoration: underline dashed ${p => p.theme.subText};
+  }
+`;
+
+const Spacer = styled('div')<{hasLine?: boolean}>`
+  grid-column: span 1;
+  height: 100%;
+  width: 0;
+  justify-self: center;
+  /* This line overlaps with the vertical line rendered from GroupWrapper */
+  border-left: 1px solid ${p => (p.hasLine ? p.theme.border : 'transparent')};
+`;
+
+const Content = styled('div')`
+  grid-column: span 2;
+  color: ${p => p.theme.subText};
+  margin: ${space(0.25)} 0 ${space(2)};
+`;
+
+export const Text = styled('div')`
+  &:only-child {
+    margin-top: 0;
+  }
+`;
+
+export const Data = styled('div')`
+  border-radius: ${space(0.5)};
+  padding: ${space(0.25)} ${space(0.75)};
+  border: 1px solid ${p => p.theme.translucentInnerBorder};
+  margin: ${space(0.75)} 0 0 -${space(0.75)};
+  font-family: ${p => p.theme.text.familyMono};
+  font-size: ${p => p.theme.fontSizeSmall};
+  background: ${p => p.theme.backgroundSecondary};
+  position: relative;
+  &:only-child {
+    margin-top: 0;
+  }
+`;

--- a/static/app/components/timeline/index.tsx
+++ b/static/app/components/timeline/index.tsx
@@ -14,7 +14,7 @@ export interface ColorConfig {
 
 export interface ItemProps {
   icon: React.ReactNode;
-  timestamp: string;
+  timeString: string;
   title: React.ReactNode;
   children?: React.ReactNode;
   colorConfig?: ColorConfig;
@@ -22,31 +22,30 @@ export interface ItemProps {
   onClick?: React.MouseEventHandler<HTMLDivElement>;
   onMouseEnter?: React.MouseEventHandler<HTMLDivElement>;
   onMouseLeave?: React.MouseEventHandler<HTMLDivElement>;
-  startTimestamp?: string;
+  startTimeString?: string;
 }
 
 export function Item({
   title,
   children,
   icon,
-  timestamp,
-  startTimestamp,
+  timeString,
+  startTimeString,
   colorConfig = {primary: 'gray300', secondary: 'gray200'},
   isActive = false,
   onClick,
   onMouseEnter,
   onMouseLeave,
 }: ItemProps) {
-  const hasRelativeTime = defined(startTimestamp);
+  const hasRelativeTime = defined(startTimeString);
   const placeholderTime = useMemo(() => new Date().toTimeString(), []);
-
   const {
     displayTime,
     date,
     timeWithMilliseconds: preciseTime,
   } = hasRelativeTime
-    ? getFormattedTimestamp(timestamp, startTimestamp, true)
-    : getFormattedTimestamp(timestamp, placeholderTime);
+    ? getFormattedTimestamp(timeString, startTimeString, true)
+    : getFormattedTimestamp(timeString, placeholderTime);
 
   return (
     <Row

--- a/static/app/components/timeline/index.tsx
+++ b/static/app/components/timeline/index.tsx
@@ -1,4 +1,5 @@
-import {useMemo} from 'react';
+import {useRef} from 'react';
+import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import {getFormattedTimestamp} from 'sentry/components/events/interfaces/breadcrumbs/breadcrumb/time/utils';
@@ -12,7 +13,7 @@ export interface ColorConfig {
   secondary: Color;
 }
 
-export interface ItemProps {
+export interface TimelineItemProps {
   icon: React.ReactNode;
   timeString: string;
   title: React.ReactNode;
@@ -36,9 +37,11 @@ export function Item({
   onClick,
   onMouseEnter,
   onMouseLeave,
-}: ItemProps) {
+}: TimelineItemProps) {
+  const theme = useTheme();
+  const placeholderTime = useRef(new Date().toTimeString()).current;
+  const {primary, secondary} = colorConfig;
   const hasRelativeTime = defined(startTimeString);
-  const placeholderTime = useMemo(() => new Date().toTimeString(), []);
   const {
     displayTime,
     date,
@@ -49,20 +52,32 @@ export function Item({
 
   return (
     <Row
-      color={colorConfig.secondary}
-      hasLowerBorder={isActive ?? false}
+      color={secondary}
+      hasLowerBorder={isActive}
       onClick={onClick}
       onMouseEnter={onMouseEnter}
       onMouseLeave={onMouseLeave}
+      style={{
+        borderBottom: `1px solid ${isActive ? theme[secondary] : 'transparent'}`,
+      }}
     >
-      <IconWrapper colorConfig={colorConfig} hasIconBorder={isActive ?? false}>
+      <IconWrapper
+        style={{
+          borderColor: isActive ? theme[secondary] : 'transparent',
+          color: theme[primary],
+        }}
+      >
         {icon}
       </IconWrapper>
-      <Title color={colorConfig.primary}>{title}</Title>
+      <Title style={{color: theme[primary]}}>{title}</Title>
       <Timestamp>
-        <Tooltip title={`${preciseTime} - ${date}`}>{displayTime}</Tooltip>
+        <Tooltip title={`${preciseTime} - ${date}`} skipWrapper>
+          {displayTime}
+        </Tooltip>
       </Timestamp>
-      <Spacer hasLine={isActive ?? false} />
+      <Spacer
+        style={{borderLeft: `1px solid ${isActive ? theme.border : 'transparent'}`}}
+      />
       <Content>{children}</Content>
     </Row>
   );
@@ -72,11 +87,11 @@ interface GroupProps {
   children: React.ReactNode;
 }
 
-export function Group({children}: GroupProps) {
-  return <GroupWrapper>{children}</GroupWrapper>;
+export function Container({children}: GroupProps) {
+  return <Wrapper>{children}</Wrapper>;
 }
 
-const GroupWrapper = styled('div')`
+const Wrapper = styled('div')`
   position: relative;
   /* vertical line connecting items */
   &::before {
@@ -90,14 +105,13 @@ const GroupWrapper = styled('div')`
   }
 `;
 
-const Row = styled('div')<{color: string; hasLowerBorder: boolean}>`
+const Row = styled('div')<{hasLowerBorder: boolean}>`
   position: relative;
   color: ${p => p.theme.subText};
   display: grid;
   align-items: center;
   grid-template: auto auto / 22px 1fr auto;
   grid-column-gap: ${space(1)};
-  border-bottom: 1px solid ${p => (p.hasLowerBorder ? p.theme[p.color] : 'transparent')};
   margin: ${space(1)} 0;
   &:first-child {
     margin-top: 0;
@@ -111,13 +125,10 @@ const Row = styled('div')<{color: string; hasLowerBorder: boolean}>`
   }
 `;
 
-const IconWrapper = styled('div')<{colorConfig: ColorConfig; hasIconBorder: boolean}>`
+const IconWrapper = styled('div')`
   grid-column: span 1;
   border-radius: 100%;
   border: 1px solid;
-  border-color: ${p =>
-    p.hasIconBorder ? p.theme[p.colorConfig.secondary] : 'transparent'};
-  color: ${p => p.theme[p.colorConfig.primary]};
   background: ${p => p.theme.background};
   svg {
     display: block;
@@ -125,8 +136,7 @@ const IconWrapper = styled('div')<{colorConfig: ColorConfig; hasIconBorder: bool
   }
 `;
 
-const Title = styled('p')<{color: string}>`
-  color: ${p => p.theme[p.color]};
+const Title = styled('p')`
   margin: 0;
   font-weight: bold;
   text-transform: capitalize;
@@ -136,18 +146,14 @@ const Title = styled('p')<{color: string}>`
 const Timestamp = styled('p')`
   margin: 0 ${space(1)};
   color: ${p => p.theme.subText};
-  span {
-    text-decoration: underline dashed ${p => p.theme.subText};
-  }
+  text-decoration: underline dashed ${p => p.theme.subText};
 `;
 
-const Spacer = styled('div')<{hasLine?: boolean}>`
+const Spacer = styled('div')`
   grid-column: span 1;
   height: 100%;
   width: 0;
   justify-self: center;
-  /* This line overlaps with the vertical line rendered from GroupWrapper */
-  border-left: 1px solid ${p => (p.hasLine ? p.theme.border : 'transparent')};
 `;
 
 const Content = styled('div')`
@@ -175,3 +181,12 @@ export const Data = styled('div')`
     margin-top: 0;
   }
 `;
+
+export const Timeline = {
+  Data,
+  Text,
+  Item,
+  Container,
+};
+
+export default Timeline;

--- a/static/app/components/timeline/utils.tsx
+++ b/static/app/components/timeline/utils.tsx
@@ -1,0 +1,11 @@
+import {useLocation} from 'sentry/utils/useLocation';
+import useOrganization from 'sentry/utils/useOrganization';
+
+export function useHasNewTimelineUI() {
+  const location = useLocation();
+  const organization = useOrganization();
+  return (
+    location.query.newTimeline === '1' ||
+    organization.features.includes('new-timeline-ui')
+  );
+}


### PR DESCRIPTION
Adds the shared timeline component along with a stories file to inspect it in storybook. Currently unused, but will replace breadcrumbs with it in future PRs

![image](https://github.com/getsentry/sentry/assets/35509934/75248a10-8aba-4f00-9940-cb5a3d8360a9)
![image](https://github.com/getsentry/sentry/assets/35509934/cf2cb927-a3b8-49db-8853-7b7a4085ecc4)
![image](https://github.com/getsentry/sentry/assets/35509934/b46c6530-54e7-4975-8457-edea54c61e28)
