### PR TITLE
chore(insights): Fix temporary Insights redirects

### DIFF
--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -1444,7 +1444,7 @@ function buildRoutes() {
     </Route>
   );
 
-  const llmMonitoringRoutes = USING_CUSTOMER_DOMAIN ? (
+  const llmMonitoringRedirects = USING_CUSTOMER_DOMAIN ? (
     <Redirect
       from="/llm-monitoring/"
       to={`/insights/${MODULE_BASE_URLS[ModuleName.AI]}/`}
@@ -2084,7 +2084,7 @@ function buildRoutes() {
       {performanceRoutes}
       {tracesRoutes}
       {insightsRoutes}
-      {llmMonitoringRoutes}
+      {llmMonitoringRedirects}
       {profilingRoutes}
       {metricsRoutes}
       {gettingStartedRoutes}

--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -1456,13 +1456,18 @@ function buildRoutes() {
     />
   );
 
-  const insightsRedirects = Object.values(MODULE_BASE_URLS).map(moduleBaseURL => (
-    <Redirect
-      key={moduleBaseURL}
-      from={`${moduleBaseURL}`}
-      to={`/insights/${moduleBaseURL}/`}
-    />
-  ));
+  const insightsRedirects = Object.values(MODULE_BASE_URLS)
+    .map(
+      moduleBaseURL =>
+        moduleBaseURL && (
+          <Redirect
+            key={moduleBaseURL}
+            from={`${moduleBaseURL}`}
+            to={`/insights/${moduleBaseURL}/`}
+          />
+        )
+    )
+    .filter(Boolean);
 
   const insightsRoutes = (
     <Route path="/insights/" withOrgPath>

--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -1688,6 +1688,10 @@ function buildRoutes() {
         component={make(() => import('sentry/views/performance/traceDetails'))}
       />
       {insightsRedirects}
+      <Redirect
+        from="browser/resources"
+        to={`/insights/${MODULE_BASE_URLS[ModuleName.RESOURCE]}/`}
+      />
       <Route
         path=":eventSlug/"
         component={make(() => import('sentry/views/performance/transactionDetails'))}

--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -1456,8 +1456,16 @@ function buildRoutes() {
     />
   );
 
-  const insightsSubRoutes = (
-    <Fragment>
+  const insightsRedirects = Object.values(MODULE_BASE_URLS).map(moduleBaseURL => (
+    <Redirect
+      key={moduleBaseURL}
+      from={`${moduleBaseURL}`}
+      to={`/insights/${moduleBaseURL}/`}
+    />
+  ));
+
+  const insightsRoutes = (
+    <Route path="/insights/" withOrgPath>
       <Route path={`${MODULE_BASE_URLS[ModuleName.DB]}/`}>
         <IndexRoute
           component={make(
@@ -1583,12 +1591,6 @@ function buildRoutes() {
           )}
         />
       </Route>
-    </Fragment>
-  );
-
-  const insightsRoutes = (
-    <Route path="/insights/" withOrgPath>
-      {insightsSubRoutes}
     </Route>
   );
 
@@ -1680,7 +1682,7 @@ function buildRoutes() {
         path="trace/:traceSlug/"
         component={make(() => import('sentry/views/performance/traceDetails'))}
       />
-      {insightsSubRoutes}
+      {insightsRedirects}
       <Route
         path=":eventSlug/"
         component={make(() => import('sentry/views/performance/transactionDetails'))}

--- a/static/app/views/performance/modulePageProviders.tsx
+++ b/static/app/views/performance/modulePageProviders.tsx
@@ -1,13 +1,10 @@
-import {type ComponentProps, useEffect} from 'react';
-import * as qs from 'query-string';
+import type {ComponentProps} from 'react';
 
 import Feature from 'sentry/components/acl/feature';
 import * as Layout from 'sentry/components/layouts/thirds';
 import NoProjectMessage from 'sentry/components/noProjectMessage';
 import PageFiltersContainer from 'sentry/components/organizations/pageFilters/container';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
-import {useLocation} from 'sentry/utils/useLocation';
-import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
 import {NoAccess} from 'sentry/views/performance/database/noAccess';
 import {useInsightsTitle} from 'sentry/views/performance/utils/useInsightsTitle';
@@ -26,8 +23,6 @@ interface Props {
 
 export function ModulePageProviders({moduleName, pageTitle, children, features}: Props) {
   const organization = useOrganization();
-  const location = useLocation();
-  const navigate = useNavigate();
 
   const insightsTitle = useInsightsTitle();
   const moduleTitle = useModuleTitle(moduleName);
@@ -35,22 +30,6 @@ export function ModulePageProviders({moduleName, pageTitle, children, features}:
   const fullPageTitle = [pageTitle, moduleTitle, insightsTitle]
     .filter(Boolean)
     .join(' — ');
-  const areInsightsEnabled = organization?.features?.includes('performance-insights');
-  const isOnInsightsRoute = location.pathname.includes(`/insights/`);
-
-  useEffect(() => {
-    // If the Insights feature is enabled, redirect users to the `/insights/` equivalent URL!
-    if (areInsightsEnabled && !isOnInsightsRoute) {
-      const newPathname = location.pathname.replace(/\/performance\//g, '/insights/');
-      navigate(`${newPathname}?${qs.stringify(location.query)}`);
-    }
-  }, [
-    navigate,
-    location.pathname,
-    location.query,
-    areInsightsEnabled,
-    isOnInsightsRoute,
-  ]);
 
   return (
     <PageFiltersContainer>


### PR DESCRIPTION
In https://github.com/getsentry/sentry/pull/71466 I added a `useEffect` redirect to get people from URLs like `/performance/queues` to `/insights/queues`. At the time, using `<Redirect>` components wasn't possible because I needed to feature-flag the redirects. Now the flag is fully rolled out, and I can replace the `useEffect` redirects with proper ones.
