### PR TITLE
fix(ui) Fix broken redirect on org rename

### DIFF
--- a/static/app/views/settings/organizationGeneralSettings/index.spec.tsx
+++ b/static/app/views/settings/organizationGeneralSettings/index.spec.tsx
@@ -13,8 +13,10 @@ import {
   within,
 } from 'sentry-test/reactTestingLibrary';
 
+import ConfigStore from 'sentry/stores/configStore';
 import OrganizationsStore from 'sentry/stores/organizationsStore';
 import ProjectsStore from 'sentry/stores/projectsStore';
+import type {Config} from 'sentry/types/system';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {browserHistory} from 'sentry/utils/browserHistory';
 import OrganizationGeneralSettings from 'sentry/views/settings/organizationGeneralSettings';
@@ -24,6 +26,7 @@ jest.mock('sentry/utils/analytics');
 describe('OrganizationGeneralSettings', function () {
   const ENDPOINT = '/organizations/org-slug/';
   const {organization, router} = initializeOrg();
+  let configState: Config;
 
   const defaultProps = {
     organization,
@@ -36,6 +39,7 @@ describe('OrganizationGeneralSettings', function () {
   };
 
   beforeEach(function () {
+    configState = ConfigStore.getState();
     OrganizationsStore.addOrReplace(organization);
     MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/auth-provider/`,
@@ -45,6 +49,12 @@ describe('OrganizationGeneralSettings', function () {
       url: `/organizations/${organization.slug}/integrations/?provider_key=github`,
       method: 'GET',
       body: [GitHubIntegrationFixture()],
+    });
+  });
+
+  afterEach(function () {
+    act(function () {
+      ConfigStore.loadInitialData(configState);
     });
   });
 
@@ -121,7 +131,8 @@ describe('OrganizationGeneralSettings', function () {
   });
 
   it('changes org slug and redirects to new customer-domain', async function () {
-    const org = OrganizationFixture({features: ['customer-domains']});
+    ConfigStore.set('features', new Set(['organizations:customer-domains']));
+    const org = OrganizationFixture();
     const updateMock = MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/`,
       method: 'PUT',

--- a/static/app/views/settings/organizationGeneralSettings/index.tsx
+++ b/static/app/views/settings/organizationGeneralSettings/index.tsx
@@ -16,6 +16,7 @@ import Panel from 'sentry/components/panels/panel';
 import PanelHeader from 'sentry/components/panels/panelHeader';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import {t, tct} from 'sentry/locale';
+import ConfigStore from 'sentry/stores/configStore';
 import type {Organization} from 'sentry/types/organization';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {browserHistory} from 'sentry/utils/browserHistory';
@@ -66,7 +67,8 @@ export default function OrganizationGeneralSettings({}: RouteComponentProps<{}, 
     if (updated.slug && updated.slug !== prevData.slug) {
       changeOrganizationSlug(prevData, updated);
 
-      if (updated.features.includes('customer-domains')) {
+      // TODO(mark) Soon to be replaced with multi-region feature flag
+      if (ConfigStore.get('features').has('organizations:customer-domains')) {
         const {organizationUrl} = updated.links;
         window.location.replace(`${organizationUrl}/settings/organization/`);
       } else {


### PR DESCRIPTION
When an organization changes their slug we should redirect to the new slug. This isn't working currently because of changes to OrganizationDetails that elide `features` by default. (#71791)

As customer-domains will soon be retried and replaced with a system configuration feature flag, I've chosen to adapt the logic for org details settings to read from `ConfigStore` like it will in the future.

Fixes HC-1096