### PR TITLE
ref(replay): use placeholder for loading in tabs

### DIFF
--- a/static/app/views/replays/detail/layout/index.tsx
+++ b/static/app/views/replays/detail/layout/index.tsx
@@ -2,6 +2,7 @@ import {useRef} from 'react';
 import styled from '@emotion/styled';
 
 import ErrorBoundary from 'sentry/components/errorBoundary';
+import Placeholder from 'sentry/components/placeholder';
 import ReplayController from 'sentry/components/replays/replayController';
 import ReplayView from 'sentry/components/replays/replayView';
 import {space} from 'sentry/styles/space';
@@ -70,7 +71,15 @@ function ReplayLayout({
   }
 
   const focusArea = (
-    <FluidPanel title={<SmallMarginFocusTabs isVideoReplay={isVideoReplay} />}>
+    <FluidPanel
+      title={
+        isLoading ? (
+          <Placeholder width="704px" height="32px" style={{marginBottom: '8px'}} />
+        ) : (
+          <SmallMarginFocusTabs isVideoReplay={isVideoReplay} />
+        )
+      }
+    >
       <ErrorBoundary mini>
         <FocusArea isVideoReplay={isVideoReplay} replayRecord={replayRecord} />
       </ErrorBoundary>

--- a/static/app/views/replays/detail/layout/index.tsx
+++ b/static/app/views/replays/detail/layout/index.tsx
@@ -70,16 +70,10 @@ function ReplayLayout({
     );
   }
 
-  const focusArea = (
-    <FluidPanel
-      title={
-        isLoading ? (
-          <Placeholder width="704px" height="32px" style={{marginBottom: '8px'}} />
-        ) : (
-          <SmallMarginFocusTabs isVideoReplay={isVideoReplay} />
-        )
-      }
-    >
+  const focusArea = isLoading ? (
+    <Placeholder width="100%" height="100%" />
+  ) : (
+    <FluidPanel title={<SmallMarginFocusTabs isVideoReplay={isVideoReplay} />}>
       <ErrorBoundary mini>
         <FocusArea isVideoReplay={isVideoReplay} replayRecord={replayRecord} />
       </ErrorBoundary>


### PR DESCRIPTION
relates to https://github.com/getsentry/sentry/issues/68109

adds loading placeholders for the tabs focus area, since some tabs go away for mobile replays.


https://github.com/getsentry/sentry/assets/56095982/1387add2-cf98-46d0-9f01-173e4a0471bf

