### PR TITLE
ref(similarity): restructure backfill code

### DIFF
--- a/src/sentry/api/endpoints/project_backfill_similar_issues_embeddings_records.py
+++ b/src/sentry/api/endpoints/project_backfill_similar_issues_embeddings_records.py
@@ -8,7 +8,9 @@ from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.project import ProjectEndpoint
 from sentry.auth.superuser import is_active_superuser
-from sentry.tasks.backfill_seer_grouping_records import backfill_seer_grouping_records
+from sentry.tasks.embeddings_grouping.backfill_seer_grouping_records_for_project import (
+    backfill_seer_grouping_records_for_project,
+)
 
 
 @region_silo_endpoint
@@ -41,5 +43,7 @@ class ProjectBackfillSimilarIssuesEmbeddingsRecords(ProjectEndpoint):
         if request.data.get("only_delete"):
             only_delete = True
 
-        backfill_seer_grouping_records.delay(project.id, last_processed_index, dry_run, only_delete)
+        backfill_seer_grouping_records_for_project.delay(
+            project.id, last_processed_index, dry_run, only_delete
+        )
         return Response(status=204)

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -740,7 +740,7 @@ CELERY_IMPORTS = (
     "sentry.tasks.auto_remove_inbox",
     "sentry.tasks.auto_resolve_issues",
     "sentry.tasks.backfill_outboxes",
-    "sentry.tasks.backfill_seer_grouping_records",
+    "sentry.tasks.embeddings_grouping.backfill_seer_grouping_records_for_project",
     "sentry.tasks.beacon",
     "sentry.tasks.check_auth",
     "sentry.tasks.check_new_issue_threshold_met",

--- a/src/sentry/tasks/embeddings_grouping/backfill_seer_grouping_records_for_project.py
+++ b/src/sentry/tasks/embeddings_grouping/backfill_seer_grouping_records_for_project.py
@@ -1,0 +1,193 @@
+import logging
+from typing import Any
+
+from redis.client import StrictRedis
+from rediscluster import RedisCluster
+
+from sentry import options
+from sentry.silo.base import SiloMode
+from sentry.tasks.base import instrumented_task
+from sentry.tasks.embeddings_grouping.utils import (
+    FeatureError,
+    delete_seer_grouping_records,
+    filter_snuba_results,
+    get_current_batch_groups_from_postgres,
+    get_data_from_snuba,
+    get_events_from_nodestore,
+    initialize_backfill,
+    make_backfill_redis_key,
+    send_group_and_stacktrace_to_seer,
+    update_groups,
+)
+
+BACKFILL_NAME = "backfill_grouping_records"
+BULK_DELETE_METADATA_CHUNK_SIZE = 100
+SNUBA_QUERY_RATELIMIT = 4
+
+logger = logging.getLogger(__name__)
+
+
+@instrumented_task(
+    name="sentry.tasks.backfill_seer_grouping_records",
+    queue="default",
+    max_retries=0,
+    silo_mode=SiloMode.REGION,
+    soft_time_limit=60 * 15,
+    time_limit=60 * 15 + 5,
+)
+def backfill_seer_grouping_records_for_project(
+    project_id: int,
+    last_processed_index: int | None,
+    dry_run: bool = False,
+    only_delete=False,
+    *args: Any,
+    **kwargs: Any,
+) -> None:
+    """
+    Task to backfill seer grouping_records table.
+    Pass in last_processed_index = None if calling for the first time. This function will spawn
+    child tasks that will pass the last_processed_index
+    """
+
+    try:
+        project, redis_client, last_processed_index = initialize_backfill(
+            project_id, last_processed_index, dry_run
+        )
+    except FeatureError:
+        logger.info(
+            "backfill_seer_grouping_records.no_feature",
+            extra={"project_id": project_id},
+        )
+        return
+
+    if only_delete:
+        delete_seer_grouping_records(project.id, redis_client)
+        logger.info(
+            "backfill_seer_grouping_records.deleted_all_records",
+            extra={"project_id": project.id},
+        )
+        return
+
+    batch_size = options.get("embeddings-grouping.seer.backfill-batch-size")
+
+    (
+        groups_to_backfill_with_no_embedding,
+        batch_end_index,
+        total_groups_to_backfill_length,
+    ) = get_current_batch_groups_from_postgres(project, last_processed_index, batch_size)
+
+    if len(groups_to_backfill_with_no_embedding) == 0:
+        return
+
+    last_group_id = groups_to_backfill_with_no_embedding[-1]
+
+    snuba_results = get_data_from_snuba(project, groups_to_backfill_with_no_embedding)
+
+    (
+        filtered_snuba_results,
+        groups_to_backfill_with_no_embedding_has_snuba_row,
+    ) = filter_snuba_results(snuba_results, groups_to_backfill_with_no_embedding, project)
+
+    if len(groups_to_backfill_with_no_embedding_has_snuba_row) == 0:
+        call_next_backfill(
+            batch_end_index,
+            project_id,
+            redis_client,
+            total_groups_to_backfill_length,
+            last_group_id,
+            dry_run,
+        )
+        return
+
+    nodestore_results, group_hashes_dict = get_events_from_nodestore(
+        project, filtered_snuba_results, groups_to_backfill_with_no_embedding_has_snuba_row
+    )
+    if not group_hashes_dict:
+        call_next_backfill(
+            batch_end_index,
+            project_id,
+            redis_client,
+            total_groups_to_backfill_length,
+            last_group_id,
+            dry_run,
+        )
+        return
+
+    groups_to_backfill_with_no_embedding_has_snuba_row_and_nodestore_row = [
+        group_id
+        for group_id in groups_to_backfill_with_no_embedding_has_snuba_row
+        if group_id in group_hashes_dict
+    ]
+
+    seer_response = send_group_and_stacktrace_to_seer(
+        project,
+        groups_to_backfill_with_no_embedding_has_snuba_row_and_nodestore_row,
+        nodestore_results,
+    )
+    if not seer_response.get("success"):
+        logger.info(
+            "backfill_seer_grouping_records.seer_down",
+            extra={"project_id": project.id},
+        )
+        return
+
+    update_groups(
+        project,
+        seer_response,
+        groups_to_backfill_with_no_embedding_has_snuba_row_and_nodestore_row,
+        group_hashes_dict,
+        dry_run,
+    )
+
+    logger.info(
+        "about to call next backfill",
+        extra={
+            "project_id": project_id,
+        },
+    )
+    call_next_backfill(
+        batch_end_index,
+        project_id,
+        redis_client,
+        total_groups_to_backfill_length,
+        last_group_id,
+        dry_run,
+    )
+
+
+def call_next_backfill(
+    last_processed_index: int,
+    project_id: int,
+    redis_client: RedisCluster | StrictRedis,
+    len_group_id_batch_unfiltered: int,
+    last_group_id: int,
+    dry_run: bool,
+):
+    redis_client.set(
+        f"{make_backfill_redis_key(project_id)}",
+        last_processed_index if last_processed_index is not None else 0,
+        ex=60 * 60 * 24 * 7,
+    )
+
+    if last_processed_index and last_processed_index < len_group_id_batch_unfiltered:
+        logger.info(
+            "calling next backfill task",
+            extra={
+                "project_id": project_id,
+                "last_processed_index": last_processed_index,
+                "last_processed_group_id": last_group_id,
+                "dry_run": dry_run,
+            },
+        )
+        backfill_seer_grouping_records_for_project.apply_async(
+            args=[project_id, last_processed_index, dry_run],
+        )
+    else:
+        logger.info(
+            "reached the end of the group id list",
+            extra={
+                "project_id": project_id,
+                "last_processed_index": last_processed_index,
+                "dry_run": dry_run,
+            },
+        )

--- a/src/sentry/tasks/embeddings_grouping/utils.py
+++ b/src/sentry/tasks/embeddings_grouping/utils.py
@@ -11,7 +11,7 @@ from redis.client import StrictRedis
 from rediscluster import RedisCluster
 from snuba_sdk import Column, Condition, Entity, Limit, Op, Query, Request
 
-from sentry import features, nodestore, options
+from sentry import features, nodestore
 from sentry.conf.server import SEER_SIMILARITY_MODEL_VERSION
 from sentry.eventstore.models import Event
 from sentry.grouping.grouping_info import get_grouping_info
@@ -31,10 +31,8 @@ from sentry.seer.similarity.types import (
     SimilarGroupNotFoundError,
 )
 from sentry.seer.similarity.utils import filter_null_from_event_title, get_stacktrace_string
-from sentry.silo.base import SiloMode
 from sentry.snuba.dataset import Dataset
 from sentry.snuba.referrer import Referrer
-from sentry.tasks.base import instrumented_task
 from sentry.utils import json, metrics, redis
 from sentry.utils.iterators import chunked
 from sentry.utils.query import RangeQuerySetWrapper
@@ -60,134 +58,6 @@ class GroupEventRow(TypedDict):
 class GroupStacktraceData(TypedDict):
     data: list[CreateGroupingRecordData]
     stacktrace_list: list[str]
-
-
-@instrumented_task(
-    name="sentry.tasks.backfill_seer_grouping_records",
-    queue="default",
-    max_retries=0,
-    silo_mode=SiloMode.REGION,
-    soft_time_limit=60 * 15,
-    time_limit=60 * 15 + 5,
-)
-def backfill_seer_grouping_records(
-    project_id: int,
-    last_processed_index: int | None,
-    dry_run: bool = False,
-    only_delete=False,
-    *args: Any,
-    **kwargs: Any,
-) -> None:
-    """
-    Task to backfill seer grouping_records table.
-    Pass in last_processed_index = None if calling for the first time. This function will spawn
-    child tasks that will pass the last_processed_index
-    """
-
-    try:
-        project, redis_client, last_processed_index = initialize_backfill(
-            project_id, last_processed_index, dry_run
-        )
-    except FeatureError:
-        logger.info(
-            "backfill_seer_grouping_records.no_feature",
-            extra={"project_id": project_id},
-        )
-        return
-
-    if only_delete:
-        delete_seer_grouping_records(project.id, redis_client)
-        logger.info(
-            "backfill_seer_grouping_records.deleted_all_records",
-            extra={"project_id": project.id},
-        )
-        return
-
-    batch_size = options.get("embeddings-grouping.seer.backfill-batch-size")
-
-    (
-        groups_to_backfill_with_no_embedding,
-        batch_end_index,
-        total_groups_to_backfill_length,
-    ) = get_current_batch_groups_from_postgres(project, last_processed_index, batch_size)
-
-    if len(groups_to_backfill_with_no_embedding) == 0:
-        return
-
-    last_group_id = groups_to_backfill_with_no_embedding[-1]
-
-    snuba_results = get_data_from_snuba(project, groups_to_backfill_with_no_embedding)
-
-    (
-        filtered_snuba_results,
-        groups_to_backfill_with_no_embedding_has_snuba_row,
-    ) = filter_snuba_results(snuba_results, groups_to_backfill_with_no_embedding, project)
-
-    if len(groups_to_backfill_with_no_embedding_has_snuba_row) == 0:
-        call_next_backfill(
-            batch_end_index,
-            project_id,
-            redis_client,
-            total_groups_to_backfill_length,
-            last_group_id,
-            dry_run,
-        )
-        return
-
-    nodestore_results, group_hashes_dict = get_events_from_nodestore(
-        project, filtered_snuba_results, groups_to_backfill_with_no_embedding_has_snuba_row
-    )
-    if not group_hashes_dict:
-        call_next_backfill(
-            batch_end_index,
-            project_id,
-            redis_client,
-            total_groups_to_backfill_length,
-            last_group_id,
-            dry_run,
-        )
-        return
-
-    groups_to_backfill_with_no_embedding_has_snuba_row_and_nodestore_row = [
-        group_id
-        for group_id in groups_to_backfill_with_no_embedding_has_snuba_row
-        if group_id in group_hashes_dict
-    ]
-
-    seer_response = send_group_and_stacktrace_to_seer(
-        project,
-        groups_to_backfill_with_no_embedding_has_snuba_row_and_nodestore_row,
-        nodestore_results,
-    )
-    if not seer_response.get("success"):
-        logger.info(
-            "backfill_seer_grouping_records.seer_down",
-            extra={"project_id": project.id},
-        )
-        return
-
-    update_groups(
-        project,
-        seer_response,
-        groups_to_backfill_with_no_embedding_has_snuba_row_and_nodestore_row,
-        group_hashes_dict,
-        dry_run,
-    )
-
-    logger.info(
-        "about to call next backfill",
-        extra={
-            "project_id": project_id,
-        },
-    )
-    call_next_backfill(
-        batch_end_index,
-        project_id,
-        redis_client,
-        total_groups_to_backfill_length,
-        last_group_id,
-        dry_run,
-    )
 
 
 def filter_snuba_results(snuba_results, groups_to_backfill_with_no_embedding, project):
@@ -619,41 +489,3 @@ def delete_seer_grouping_records(
         for group in groups_with_seer_metadata:
             del group.data["metadata"]["seer_similarity"]
         Group.objects.bulk_update(groups_with_seer_metadata, ["data"])
-
-
-def call_next_backfill(
-    last_processed_index: int,
-    project_id: int,
-    redis_client: RedisCluster | StrictRedis,
-    len_group_id_batch_unfiltered: int,
-    last_group_id: int,
-    dry_run: bool,
-):
-    redis_client.set(
-        f"{make_backfill_redis_key(project_id)}",
-        last_processed_index if last_processed_index is not None else 0,
-        ex=60 * 60 * 24 * 7,
-    )
-
-    if last_processed_index and last_processed_index < len_group_id_batch_unfiltered:
-        logger.info(
-            "calling next backfill task",
-            extra={
-                "project_id": project_id,
-                "last_processed_index": last_processed_index,
-                "last_processed_group_id": last_group_id,
-                "dry_run": dry_run,
-            },
-        )
-        backfill_seer_grouping_records.apply_async(
-            args=[project_id, last_processed_index, dry_run],
-        )
-    else:
-        logger.info(
-            "reached the end of the group id list",
-            extra={
-                "project_id": project_id,
-                "last_processed_index": last_processed_index,
-                "dry_run": dry_run,
-            },
-        )

--- a/src/sentry/utils/sdk.py
+++ b/src/sentry/utils/sdk.py
@@ -82,7 +82,7 @@ SAMPLED_TASKS = {
     "sentry.dynamic_sampling.tasks.sliding_window_org": 0.2,
     "sentry.dynamic_sampling.tasks.custom_rule_notifications": 0.2,
     "sentry.dynamic_sampling.tasks.clean_custom_rule_notifications": 0.2,
-    "sentry.tasks.backfill_seer_grouping_records": 1.0,
+    "sentry.tasks.embeddings_grouping.backfill_seer_grouping_records_for_project": 1.0,
 }
 
 if settings.ADDITIONAL_SAMPLED_TASKS:

--- a/tests/sentry/api/endpoints/test_project_backfill_similar_issues_embeddings_records.py
+++ b/tests/sentry/api/endpoints/test_project_backfill_similar_issues_embeddings_records.py
@@ -38,7 +38,7 @@ class ProjectBackfillSimilarIssuesEmbeddingsRecordsTest(APITestCase):
         return_value=True,
     )
     @patch(
-        "sentry.api.endpoints.project_backfill_similar_issues_embeddings_records.backfill_seer_grouping_records.delay"
+        "sentry.api.endpoints.project_backfill_similar_issues_embeddings_records.backfill_seer_grouping_records_for_project.delay"
     )
     @with_feature("projects:similarity-embeddings-backfill")
     def test_post_success_no_last_processed_index(
@@ -49,7 +49,7 @@ class ProjectBackfillSimilarIssuesEmbeddingsRecordsTest(APITestCase):
         mock_backfill_seer_grouping_records.assert_called_with(self.project.id, None, False, False)
 
     @patch(
-        "sentry.api.endpoints.project_backfill_similar_issues_embeddings_records.backfill_seer_grouping_records.delay"
+        "sentry.api.endpoints.project_backfill_similar_issues_embeddings_records.backfill_seer_grouping_records_for_project.delay"
     )
     @with_feature("projects:similarity-embeddings-backfill")
     @override_settings(SENTRY_SINGLE_ORGANIZATION=True)
@@ -65,7 +65,7 @@ class ProjectBackfillSimilarIssuesEmbeddingsRecordsTest(APITestCase):
         return_value=True,
     )
     @patch(
-        "sentry.api.endpoints.project_backfill_similar_issues_embeddings_records.backfill_seer_grouping_records.delay"
+        "sentry.api.endpoints.project_backfill_similar_issues_embeddings_records.backfill_seer_grouping_records_for_project.delay"
     )
     @with_feature("projects:similarity-embeddings-backfill")
     def test_post_success_last_processed_index(
@@ -80,7 +80,7 @@ class ProjectBackfillSimilarIssuesEmbeddingsRecordsTest(APITestCase):
         return_value=True,
     )
     @patch(
-        "sentry.api.endpoints.project_backfill_similar_issues_embeddings_records.backfill_seer_grouping_records.delay"
+        "sentry.api.endpoints.project_backfill_similar_issues_embeddings_records.backfill_seer_grouping_records_for_project.delay"
     )
     @with_feature("projects:similarity-embeddings-backfill")
     def test_post_success_dry_run(
@@ -95,7 +95,7 @@ class ProjectBackfillSimilarIssuesEmbeddingsRecordsTest(APITestCase):
         return_value=True,
     )
     @patch(
-        "sentry.api.endpoints.project_backfill_similar_issues_embeddings_records.backfill_seer_grouping_records.delay"
+        "sentry.api.endpoints.project_backfill_similar_issues_embeddings_records.backfill_seer_grouping_records_for_project.delay"
     )
     @with_feature("projects:similarity-embeddings-backfill")
     def test_post_success_only_delete(

--- a/tests/sentry/tasks/test_backfill_seer_grouping_records.py
+++ b/tests/sentry/tasks/test_backfill_seer_grouping_records.py
@@ -20,8 +20,10 @@ from sentry.seer.similarity.backfill import CreateGroupingRecordData
 from sentry.seer.similarity.types import RawSeerSimilarIssueData
 from sentry.snuba.dataset import Dataset
 from sentry.snuba.referrer import Referrer
-from sentry.tasks.backfill_seer_grouping_records import (
-    backfill_seer_grouping_records,
+from sentry.tasks.embeddings_grouping.backfill_seer_grouping_records_for_project import (
+    backfill_seer_grouping_records_for_project,
+)
+from sentry.tasks.embeddings_grouping.utils import (
     get_data_from_snuba,
     get_events_from_nodestore,
     lookup_event,
@@ -162,7 +164,7 @@ class TestBackfillSeerGroupingRecords(SnubaTestCase, TestCase):
         with pytest.raises(EventLookupError):
             lookup_event(self.project.id, "1000000", 1000000)
 
-    @patch("sentry.tasks.backfill_seer_grouping_records.metrics")
+    @patch("sentry.tasks.embeddings_grouping.utils.metrics")
     def test_lookup_group_data_stacktrace_bulk_success(self, mock_metrics):
         """Test successful bulk group data and stacktrace lookup"""
         rows, events = self.bulk_rows, self.bulk_events
@@ -191,7 +193,7 @@ class TestBackfillSeerGroupingRecords(SnubaTestCase, TestCase):
         )
 
     @patch("time.sleep", return_value=None)
-    @patch("sentry.tasks.backfill_seer_grouping_records.logger")
+    @patch("sentry.tasks.embeddings_grouping.utils.logger")
     @patch("sentry.nodestore.backend.get_multi")
     def test_lookup_group_data_stacktrace_bulk_exceptions(
         self, mock_get_multi, mock_logger, mock_sleep
@@ -362,7 +364,7 @@ class TestBackfillSeerGroupingRecords(SnubaTestCase, TestCase):
         assert bulk_group_data_stacktraces["data"] == expected_group_data
         assert bulk_group_data_stacktraces["stacktrace_list"] == expected_stacktraces
 
-    @patch("sentry.tasks.backfill_seer_grouping_records.logger")
+    @patch("sentry.tasks.embeddings_grouping.utils.logger")
     def test_lookup_group_data_stacktrace_bulk_with_fallback_event_lookup_error(self, mock_logger):
         """
         Test bulk lookup with fallback catches EventLookupError and returns data for events that
@@ -419,7 +421,7 @@ class TestBackfillSeerGroupingRecords(SnubaTestCase, TestCase):
             assert group_id in group_ids_results
 
     @with_feature("projects:similarity-embeddings-backfill")
-    @patch("sentry.tasks.backfill_seer_grouping_records.post_bulk_grouping_records")
+    @patch("sentry.tasks.embeddings_grouping.utils.post_bulk_grouping_records")
     def test_backfill_seer_grouping_records_success_simple(self, mock_post_bulk_grouping_records):
         """
         Test that the metadata is set for all groups showing that the record has been created.
@@ -427,7 +429,7 @@ class TestBackfillSeerGroupingRecords(SnubaTestCase, TestCase):
         mock_post_bulk_grouping_records.return_value = {"success": True, "groups_with_neighbor": {}}
 
         with TaskRunner():
-            backfill_seer_grouping_records(self.project.id, None)
+            backfill_seer_grouping_records_for_project(self.project.id, None)
 
         groups = Group.objects.filter(project_id=self.project.id)
         for group in groups:
@@ -441,7 +443,7 @@ class TestBackfillSeerGroupingRecords(SnubaTestCase, TestCase):
 
     @patch("time.sleep", return_value=None)
     @patch("sentry.nodestore.backend.get_multi")
-    @patch("sentry.tasks.backfill_seer_grouping_records.lookup_event")
+    @patch("sentry.tasks.embeddings_grouping.utils.lookup_event")
     def test_backfill_seer_grouping_records_failure(
         self, mock_lookup_event, mock_get_multi, mock_sleep
     ):
@@ -452,7 +454,7 @@ class TestBackfillSeerGroupingRecords(SnubaTestCase, TestCase):
         mock_get_multi.side_effect = ServiceUnavailable(message="Service Unavailable")
 
         with TaskRunner():
-            backfill_seer_grouping_records(self.project.id, None)
+            backfill_seer_grouping_records_for_project(self.project.id, None)
 
         redis_client = redis.redis_clusters.get(settings.SENTRY_MONITORS_REDIS_CLUSTER)
         last_processed_index = int(redis_client.get(make_backfill_redis_key(self.project.id)) or 0)
@@ -468,14 +470,14 @@ class TestBackfillSeerGroupingRecords(SnubaTestCase, TestCase):
         project = self.create_project(organization=self.organization)
 
         with TaskRunner():
-            backfill_seer_grouping_records(project, None)
+            backfill_seer_grouping_records_for_project(project, None)
 
         for group in Group.objects.filter(project_id=self.project.id):
             assert not group.data["metadata"].get("seer_similarity")
 
     @with_feature("projects:similarity-embeddings-backfill")
-    @patch("sentry.tasks.backfill_seer_grouping_records.post_bulk_grouping_records")
-    @patch("sentry.tasks.backfill_seer_grouping_records.delete_grouping_records")
+    @patch("sentry.tasks.embeddings_grouping.utils.post_bulk_grouping_records")
+    @patch("sentry.tasks.embeddings_grouping.utils.delete_grouping_records")
     def test_backfill_seer_grouping_records_dry_run(
         self, mock_delete_grouping_records, mock_post_bulk_grouping_records
     ):
@@ -485,7 +487,7 @@ class TestBackfillSeerGroupingRecords(SnubaTestCase, TestCase):
         mock_post_bulk_grouping_records.return_value = {"success": True, "groups_with_neighbor": []}
         mock_delete_grouping_records.return_value = True
         with TaskRunner():
-            backfill_seer_grouping_records(self.project.id, 0, dry_run=True)
+            backfill_seer_grouping_records_for_project(self.project.id, 0, dry_run=True)
 
         groups = Group.objects.filter(project_id=self.project.id)
         for group in groups:
@@ -498,7 +500,7 @@ class TestBackfillSeerGroupingRecords(SnubaTestCase, TestCase):
         assert last_processed_index == len(groups)
 
     @with_feature("projects:similarity-embeddings-backfill")
-    @patch("sentry.tasks.backfill_seer_grouping_records.post_bulk_grouping_records")
+    @patch("sentry.tasks.embeddings_grouping.utils.post_bulk_grouping_records")
     def test_backfill_seer_grouping_records_groups_1_times_seen(
         self, mock_post_bulk_grouping_records
     ):
@@ -523,7 +525,7 @@ class TestBackfillSeerGroupingRecords(SnubaTestCase, TestCase):
             groups_seen_once.append(event.group)
 
         with TaskRunner():
-            backfill_seer_grouping_records(self.project.id, None)
+            backfill_seer_grouping_records_for_project(self.project.id, None)
 
         for group in Group.objects.filter(project_id=self.project.id):
             if group not in groups_seen_once:
@@ -544,7 +546,7 @@ class TestBackfillSeerGroupingRecords(SnubaTestCase, TestCase):
         "this test is flakey in production; trying to replicate locally and skipping it for now"
     )
     @with_feature("projects:similarity-embeddings-backfill")
-    @patch("sentry.tasks.backfill_seer_grouping_records.post_bulk_grouping_records")
+    @patch("sentry.tasks.embeddings_grouping.utils.post_bulk_grouping_records")
     def test_backfill_seer_grouping_records_groups_have_neighbor(
         self, mock_post_bulk_grouping_records
     ):
@@ -588,7 +590,7 @@ class TestBackfillSeerGroupingRecords(SnubaTestCase, TestCase):
         }
 
         with TaskRunner():
-            backfill_seer_grouping_records(self.project.id, None)
+            backfill_seer_grouping_records_for_project(self.project.id, None)
 
         groups = Group.objects.filter(project_id=self.project.id, times_seen__gt=1)
         for group in groups:
@@ -619,8 +621,8 @@ class TestBackfillSeerGroupingRecords(SnubaTestCase, TestCase):
         assert last_processed_index == len(groups)
 
     @with_feature("projects:similarity-embeddings-backfill")
-    @patch("sentry.tasks.backfill_seer_grouping_records.logger")
-    @patch("sentry.tasks.backfill_seer_grouping_records.post_bulk_grouping_records")
+    @patch("sentry.tasks.embeddings_grouping.utils.logger")
+    @patch("sentry.tasks.embeddings_grouping.utils.post_bulk_grouping_records")
     def test_backfill_seer_grouping_records_groups_has_invalid_neighbor(
         self, mock_post_bulk_grouping_records, mock_logger
     ):
@@ -654,7 +656,7 @@ class TestBackfillSeerGroupingRecords(SnubaTestCase, TestCase):
         }
 
         with TaskRunner():
-            backfill_seer_grouping_records(self.project.id, None)
+            backfill_seer_grouping_records_for_project(self.project.id, None)
 
         groups = Group.objects.filter(project_id=self.project.id, times_seen__gt=1)
         for group in groups:
@@ -682,7 +684,7 @@ class TestBackfillSeerGroupingRecords(SnubaTestCase, TestCase):
         "this test is flakey in production; trying to replicate locally and skipping it for now"
     )
     @with_feature("projects:similarity-embeddings-backfill")
-    @patch("sentry.tasks.backfill_seer_grouping_records.post_bulk_grouping_records")
+    @patch("sentry.tasks.embeddings_grouping.utils.post_bulk_grouping_records")
     def test_backfill_seer_grouping_records_multiple_batches(self, mock_post_bulk_grouping_records):
         """
         Test that the metadata is set for all 21 groups showing that the record has been created,
@@ -706,7 +708,7 @@ class TestBackfillSeerGroupingRecords(SnubaTestCase, TestCase):
         mock_post_bulk_grouping_records.return_value = {"success": True, "groups_with_neighbor": {}}
 
         with TaskRunner():
-            backfill_seer_grouping_records(self.project.id, None)
+            backfill_seer_grouping_records_for_project(self.project.id, None)
         groups = Group.objects.filter(project_id=self.project.id)
         for group in groups:
             assert group.data["metadata"].get("seer_similarity") is not None
@@ -716,7 +718,7 @@ class TestBackfillSeerGroupingRecords(SnubaTestCase, TestCase):
         assert last_processed_index == len(groups)
 
     @with_feature("projects:similarity-embeddings-backfill")
-    @patch("sentry.tasks.backfill_seer_grouping_records.delete_grouping_records")
+    @patch("sentry.tasks.embeddings_grouping.utils.delete_grouping_records")
     def test_backfill_seer_grouping_records_only_delete(self, mock_delete_grouping_records):
         """
         Test that when the only_delete flag is on, seer_similarity is deleted from the metadata
@@ -748,14 +750,14 @@ class TestBackfillSeerGroupingRecords(SnubaTestCase, TestCase):
 
         mock_delete_grouping_records.return_value = True
         with TaskRunner():
-            backfill_seer_grouping_records(self.project.id, None, only_delete=True)
+            backfill_seer_grouping_records_for_project(self.project.id, None, only_delete=True)
 
         groups = Group.objects.filter(project_id=self.project.id, id__in=group_ids)
         for group in groups:
             assert group.data["metadata"] == default_metadata
 
     @with_feature("projects:similarity-embeddings-backfill")
-    @patch("sentry.tasks.backfill_seer_grouping_records.post_bulk_grouping_records")
+    @patch("sentry.tasks.embeddings_grouping.utils.post_bulk_grouping_records")
     def test_backfill_seer_grouping_records_exclude_deleted_groups(
         self, mock_post_bulk_grouping_records
     ):
@@ -789,7 +791,7 @@ class TestBackfillSeerGroupingRecords(SnubaTestCase, TestCase):
         deleted_group_ids.append(event.group.id)
 
         with TaskRunner():
-            backfill_seer_grouping_records(self.project.id, None)
+            backfill_seer_grouping_records_for_project(self.project.id, None)
 
         groups = Group.objects.filter(project_id=self.project.id).exclude(id__in=deleted_group_ids)
         for group in groups:
@@ -806,9 +808,9 @@ class TestBackfillSeerGroupingRecords(SnubaTestCase, TestCase):
             assert group.data["metadata"].get("seer_similarity") is None
 
     @with_feature("projects:similarity-embeddings-backfill")
-    @patch("sentry.tasks.backfill_seer_grouping_records.logger")
-    @patch("sentry.tasks.backfill_seer_grouping_records.bulk_snuba_queries")
-    @patch("sentry.tasks.backfill_seer_grouping_records.post_bulk_grouping_records")
+    @patch("sentry.tasks.embeddings_grouping.utils.logger")
+    @patch("sentry.tasks.embeddings_grouping.utils.bulk_snuba_queries")
+    @patch("sentry.tasks.embeddings_grouping.utils.post_bulk_grouping_records")
     def test_backfill_seer_grouping_records_no_events(
         self, mock_post_bulk_grouping_records, mock_snuba_queries, mock_logger
     ):
@@ -863,7 +865,7 @@ class TestBackfillSeerGroupingRecords(SnubaTestCase, TestCase):
         mock_snuba_queries.return_value = result
 
         with TaskRunner():
-            backfill_seer_grouping_records(self.project.id, None)
+            backfill_seer_grouping_records_for_project(self.project.id, None)
 
         for group in Group.objects.filter(project_id=self.project.id).order_by("id")[1:]:
             assert group.data["metadata"].get("seer_similarity") is not None
@@ -884,7 +886,7 @@ class TestBackfillSeerGroupingRecords(SnubaTestCase, TestCase):
         )
 
     @with_feature("projects:similarity-embeddings-backfill")
-    @patch("sentry.tasks.backfill_seer_grouping_records.post_bulk_grouping_records")
+    @patch("sentry.tasks.embeddings_grouping.utils.post_bulk_grouping_records")
     def test_backfill_seer_grouping_records_exclude_90_day_old_groups(
         self, mock_post_bulk_grouping_records
     ):
@@ -907,7 +909,7 @@ class TestBackfillSeerGroupingRecords(SnubaTestCase, TestCase):
         old_group_id = event.group.id
 
         with TaskRunner():
-            backfill_seer_grouping_records(self.project.id, None)
+            backfill_seer_grouping_records_for_project(self.project.id, None)
 
         groups = Group.objects.filter(project_id=self.project.id).exclude(id=old_group_id)
         for group in groups:
@@ -924,9 +926,11 @@ class TestBackfillSeerGroupingRecords(SnubaTestCase, TestCase):
         assert old_group.data["metadata"].get("seer_similarity") is None
 
     @with_feature("projects:similarity-embeddings-backfill")
-    @patch("sentry.tasks.backfill_seer_grouping_records.logger")
-    @patch("sentry.tasks.backfill_seer_grouping_records.lookup_group_data_stacktrace_bulk")
-    @patch("sentry.tasks.backfill_seer_grouping_records.call_next_backfill")
+    @patch("sentry.tasks.embeddings_grouping.utils.logger")
+    @patch("sentry.tasks.embeddings_grouping.utils.lookup_group_data_stacktrace_bulk")
+    @patch(
+        "sentry.tasks.embeddings_grouping.backfill_seer_grouping_records_for_project.call_next_backfill"
+    )
     def test_backfill_seer_grouping_records_empty_nodestore(
         self,
         mock_call_next_backfill,
@@ -936,7 +940,7 @@ class TestBackfillSeerGroupingRecords(SnubaTestCase, TestCase):
         mock_lookup_group_data_stacktrace_bulk.return_value = []
 
         with TaskRunner():
-            backfill_seer_grouping_records(self.project.id, None)
+            backfill_seer_grouping_records_for_project(self.project.id, None)
 
         groups = Group.objects.all()
         groups_len = len(groups)
@@ -953,8 +957,8 @@ class TestBackfillSeerGroupingRecords(SnubaTestCase, TestCase):
         )
 
     @with_feature("projects:similarity-embeddings-backfill")
-    @patch("sentry.tasks.backfill_seer_grouping_records.logger")
-    @patch("sentry.tasks.backfill_seer_grouping_records.post_bulk_grouping_records")
+    @patch("sentry.tasks.embeddings_grouping.utils.logger")
+    @patch("sentry.tasks.embeddings_grouping.utils.post_bulk_grouping_records")
     def test_backfill_seer_grouping_records_exclude_invalid_groups(
         self, mock_post_bulk_grouping_records, mock_logger
     ):
@@ -970,7 +974,7 @@ class TestBackfillSeerGroupingRecords(SnubaTestCase, TestCase):
         event.group.save()
 
         with TaskRunner():
-            backfill_seer_grouping_records(self.project.id, None)
+            backfill_seer_grouping_records_for_project(self.project.id, None)
 
         groups = Group.objects.filter(project_id=self.project.id).exclude(id=event.group.id)
         for group in groups:


### PR DESCRIPTION
preparing for cohort backfill job, restructure backfill logic so methods that are called by the task are in their own file. 

that way, we can use composition and simply reuse these methods for the cohort backfill. this is preferred to combining the logic for both into one task, as it was getting complicated to do so.

also renames the task / puts it in its own folder within tasks. 

should be no behavior change in this PR.