### PR TITLE
feat(query-builder): Make date filters more user friendly

### DIFF
--- a/static/app/components/searchQueryBuilder/filterValueParser/date/grammar.pegjs
+++ b/static/app/components/searchQueryBuilder/filterValueParser/date/grammar.pegjs
@@ -1,0 +1,24 @@
+{
+    const { TokenConverter, config = {} } = options;
+    const tc = new TokenConverter({text, location, config});
+}
+
+value = iso_8601_date_format / rel_date_format
+
+num2 = [0-9] [0-9]
+num4 = [0-9] [0-9] [0-9] [0-9]
+
+date_format = num4 "-" num2 "-" num2
+time_format = "T" num2 ":" num2 ":" num2 ("." ms_format)?
+ms_format   = [0-9] [0-9]? [0-9]? [0-9]? [0-9]? [0-9]?
+tz_format   = [+-] num2 ":" num2
+
+iso_8601_date_format
+  = date_format time_format? ("Z" / tz_format)? {
+      return tc.tokenValueIso8601Date(text());
+    }
+
+rel_date_format
+  = sign:[+-] value:[0-9]+ unit:[wdhm] {
+      return tc.tokenValueRelativeDate(value.join(''), sign, unit);
+    }

--- a/static/app/components/searchQueryBuilder/filterValueParser/date/parser.tsx
+++ b/static/app/components/searchQueryBuilder/filterValueParser/date/parser.tsx
@@ -1,0 +1,23 @@
+import {
+  type Token,
+  TokenConverter,
+  type TokenResult,
+} from 'sentry/components/searchSyntax/parser';
+
+import grammar from './grammar.pegjs';
+
+/**
+ * This parser is specifically meant for parsing the value of a date filter.
+ * This should mirror the grammar used for search syntax, but we cannot
+ * use it directly since the grammar is designed to parse the entire search query
+ * and will fail if we just pass in a date value.
+ */
+export function parseFilterValueDate(
+  query: string
+): TokenResult<Token.VALUE_ISO_8601_DATE | Token.VALUE_RELATIVE_DATE> | null {
+  try {
+    return grammar.parse(query, {TokenConverter});
+  } catch (e) {
+    return null;
+  }
+}

--- a/static/app/components/searchQueryBuilder/index.spec.tsx
+++ b/static/app/components/searchQueryBuilder/index.spec.tsx
@@ -55,6 +55,7 @@ const FITLER_KEY_SECTIONS: FilterKeySection[] = [
         name: 'is',
         alias: 'issue.status',
         predefined: true,
+        values: ['resolved', 'unresolved', 'ignored'],
       },
       {
         key: FieldKey.TIMES_SEEN,
@@ -308,32 +309,32 @@ describe('SearchQueryBuilder', function () {
     });
 
     it('can modify the value by clicking into it (single-select)', async function () {
-      // `age` is a duration filter which only accepts single values
-      render(<SearchQueryBuilder {...defaultProps} initialQuery="age:-1d" />);
+      // `is` only accepts single values
+      render(<SearchQueryBuilder {...defaultProps} initialQuery="is:unresolved" />);
 
-      // Should display as "-1d" to start
+      // Should display as "unresolved" to start
       expect(
-        within(
-          screen.getByRole('button', {name: 'Edit value for filter: age'})
-        ).getByText('-1d')
+        within(screen.getByRole('button', {name: 'Edit value for filter: is'})).getByText(
+          'unresolved'
+        )
       ).toBeInTheDocument();
 
       await userEvent.click(
-        screen.getByRole('button', {name: 'Edit value for filter: age'})
+        screen.getByRole('button', {name: 'Edit value for filter: is'})
       );
       // Should have placeholder text of previous value
       expect(screen.getByRole('combobox', {name: 'Edit filter value'})).toHaveAttribute(
         'placeholder',
-        '-1d'
+        'unresolved'
       );
 
-      // Clicking the "-14d" option should update the value
-      await userEvent.click(await screen.findByRole('option', {name: '-14d'}));
-      expect(screen.getByRole('row', {name: 'age:-14d'})).toBeInTheDocument();
+      // Clicking the "resolved" option should update the value
+      await userEvent.click(await screen.findByRole('option', {name: 'resolved'}));
+      expect(screen.getByRole('row', {name: 'is:resolved'})).toBeInTheDocument();
       expect(
-        within(
-          screen.getByRole('button', {name: 'Edit value for filter: age'})
-        ).getByText('-14d')
+        within(screen.getByRole('button', {name: 'Edit value for filter: is'})).getByText(
+          'resolved'
+        )
       ).toBeInTheDocument();
     });
 
@@ -962,6 +963,96 @@ describe('SearchQueryBuilder', function () {
         expect(
           await screen.findByRole('row', {name: 'timesSeen:<=100k'})
         ).toBeInTheDocument();
+      });
+    });
+
+    describe('date', function () {
+      it('new date filters start with a value', async function () {
+        render(<SearchQueryBuilder {...defaultProps} />);
+        await userEvent.click(screen.getByRole('grid'));
+        await userEvent.keyboard('age{ArrowDown}{Enter}');
+
+        // Should start with a relative date value
+        expect(await screen.findByRole('row', {name: 'age:-24h'})).toBeInTheDocument();
+      });
+
+      it('does not allow invalid values', async function () {
+        render(<SearchQueryBuilder {...defaultProps} initialQuery="age:-24h" />);
+        await userEvent.click(
+          screen.getByRole('button', {name: 'Edit value for filter: age'})
+        );
+        await userEvent.keyboard('a{Enter}');
+
+        // Should have the same value because "a" is not a date value
+        expect(screen.getByRole('row', {name: 'age:-24h'})).toBeInTheDocument();
+      });
+
+      it('shows default date suggestions', async function () {
+        render(<SearchQueryBuilder {...defaultProps} initialQuery="age:-24h" />);
+        await userEvent.click(
+          screen.getByRole('button', {name: 'Edit value for filter: age'})
+        );
+        await userEvent.click(await screen.findByRole('option', {name: '1 hour ago'}));
+        expect(screen.getByRole('row', {name: 'age:-1h'})).toBeInTheDocument();
+      });
+
+      it('shows date suggestions when typing', async function () {
+        render(<SearchQueryBuilder {...defaultProps} initialQuery="age:-24h" />);
+        await userEvent.click(
+          screen.getByRole('button', {name: 'Edit value for filter: age'})
+        );
+
+        // Typing "7" should show suggestions for 7 minutes, hours, days, and weeks
+        await userEvent.keyboard('7');
+        await screen.findByRole('option', {name: '7 minutes ago'});
+        expect(screen.getByRole('option', {name: '7 hours ago'})).toBeInTheDocument();
+        expect(screen.getByRole('option', {name: '7 days ago'})).toBeInTheDocument();
+        expect(screen.getByRole('option', {name: '7 weeks ago'})).toBeInTheDocument();
+
+        await userEvent.click(screen.getByRole('option', {name: '7 weeks ago'}));
+        expect(screen.getByRole('row', {name: 'age:-7w'})).toBeInTheDocument();
+      });
+
+      it('can search before a relative date', async function () {
+        render(<SearchQueryBuilder {...defaultProps} initialQuery="age:-24h" />);
+        await userEvent.click(
+          screen.getByRole('button', {name: 'Edit operator for filter: age'})
+        );
+        await userEvent.click(await screen.findByRole('option', {name: 'is before'}));
+
+        // Should flip from "-" to "+"
+        expect(await screen.findByRole('row', {name: 'age:+24h'})).toBeInTheDocument();
+      });
+
+      it('switches to an absolute date when choosing operator with equality', async function () {
+        render(<SearchQueryBuilder {...defaultProps} initialQuery="age:-24h" />);
+        await userEvent.click(
+          screen.getByRole('button', {name: 'Edit operator for filter: age'})
+        );
+        await userEvent.click(
+          await screen.findByRole('option', {name: 'is on or after'})
+        );
+
+        // Changes operator and fills in the current date (ISO format)
+        expect(
+          await screen.findByRole('row', {name: 'age:>=2017-10-17T02:41:20.000Z'})
+        ).toBeInTheDocument();
+      });
+
+      it('changes operator when selecting a relative date', async function () {
+        render(<SearchQueryBuilder {...defaultProps} initialQuery="age:>=2017-10-17" />);
+        await userEvent.click(
+          screen.getByRole('button', {name: 'Edit value for filter: age'})
+        );
+        await userEvent.click(await screen.findByRole('option', {name: '1 hour ago'}));
+
+        // Because relative dates only work with ":", should change the operator to "is after"
+        expect(
+          within(
+            screen.getByRole('button', {name: 'Edit operator for filter: age'})
+          ).getByText('is after')
+        ).toBeInTheDocument();
+        expect(await screen.findByRole('row', {name: 'age:-1h'})).toBeInTheDocument();
       });
     });
   });

--- a/static/app/components/searchQueryBuilder/index.stories.tsx
+++ b/static/app/components/searchQueryBuilder/index.stories.tsx
@@ -41,11 +41,6 @@ const FITLER_KEY_SECTIONS: FilterKeySection[] = [
         predefined: true,
         values: ['Chrome', 'Firefox', 'Safari', 'Edge'],
       },
-      {
-        key: FieldKey.LAST_SEEN,
-        name: 'Last Seen',
-        kind: FieldKind.FIELD,
-      },
     ],
   },
   {

--- a/static/app/components/searchQueryBuilder/useQueryBuilderState.tsx
+++ b/static/app/components/searchQueryBuilder/useQueryBuilderState.tsx
@@ -1,11 +1,14 @@
 import {type Reducer, useCallback, useReducer} from 'react';
 
+import {parseFilterValueDate} from 'sentry/components/searchQueryBuilder/filterValueParser/date/parser';
 import type {FocusOverride} from 'sentry/components/searchQueryBuilder/types';
 import {
+  isDateToken,
   makeTokenKey,
   parseQueryBuilderValue,
 } from 'sentry/components/searchQueryBuilder/utils';
 import {
+  FilterType,
   type ParseResultToken,
   TermOperator,
   Token,
@@ -53,7 +56,7 @@ type UpdateFilterOpAction = {
 };
 
 type UpdateTokenValueAction = {
-  token: TokenResult<Token>;
+  token: TokenResult<Token.FILTER>;
   type: 'UPDATE_TOKEN_VALUE';
   value: string;
 };
@@ -93,6 +96,10 @@ function modifyFilterOperator(
   token: TokenResult<Token.FILTER>,
   newOperator: TermOperator
 ): string {
+  if (isDateToken(token)) {
+    return modifyFilterOperatorDate(query, token, newOperator);
+  }
+
   const isNotEqual = newOperator === TermOperator.NOT_EQUAL;
 
   const newToken: TokenResult<Token.FILTER> = {...token};
@@ -100,6 +107,62 @@ function modifyFilterOperator(
   newToken.negated = isNotEqual;
 
   return replaceQueryToken(query, token, stringifyToken(newToken));
+}
+
+function modifyFilterOperatorDate(
+  query: string,
+  token: TokenResult<Token.FILTER>,
+  newOperator: TermOperator
+): string {
+  switch (newOperator) {
+    case TermOperator.GREATER_THAN:
+    case TermOperator.LESS_THAN: {
+      if (token.filter === FilterType.RELATIVE_DATE) {
+        token.value.sign = newOperator === TermOperator.GREATER_THAN ? '-' : '+';
+      } else if (
+        token.filter === FilterType.SPECIFIC_DATE ||
+        token.filter === FilterType.DATE
+      ) {
+        token.operator = newOperator;
+      }
+      return replaceQueryToken(query, token, stringifyToken(token));
+    }
+
+    // The "equal" and "or equal to" operators require a specific date
+    case TermOperator.EQUAL:
+    case TermOperator.GREATER_THAN_EQUAL:
+    case TermOperator.LESS_THAN_EQUAL:
+      // If it's a relative date, modify the operator and generate an ISO timestamp
+      if (token.filter === FilterType.RELATIVE_DATE) {
+        const generatedIsoDateStr = new Date().toISOString();
+        const newTokenStr = `${token.key.text}:${newOperator}${generatedIsoDateStr}`;
+        return replaceQueryToken(query, token, newTokenStr);
+      }
+      return modifyFilterOperator(query, token, newOperator);
+    default:
+      return replaceQueryToken(query, token, newOperator);
+  }
+}
+
+function modifyFilterValueDate(
+  query: string,
+  token: TokenResult<Token.FILTER>,
+  newValue: string
+): string {
+  const parsedValue = parseFilterValueDate(newValue);
+
+  if (!parsedValue) {
+    return query;
+  }
+
+  if (token.value.type === parsedValue?.type) {
+    return replaceQueryToken(query, token.value, newValue);
+  }
+
+  if (parsedValue.type === Token.VALUE_ISO_8601_DATE) {
+    return replaceQueryToken(query, token.value, newValue);
+  }
+  return `${token.key.text}:${newValue}`;
 }
 
 function replaceQueryToken(
@@ -166,6 +229,18 @@ function pasteFreeText(
     query: newQuery,
     focusOverride: focusedItemKey ? {itemKey: focusedItemKey} : null,
   };
+}
+
+function modifyFilterValue(
+  query: string,
+  token: TokenResult<Token.FILTER>,
+  newValue: string
+): string {
+  if (isDateToken(token)) {
+    return modifyFilterValueDate(query, token, newValue);
+  }
+
+  return replaceQueryToken(query, token.value, newValue);
 }
 
 function updateFilterMultipleValues(
@@ -274,7 +349,7 @@ export function useQueryBuilderState({initialQuery}: {initialQuery: string}) {
         case 'UPDATE_TOKEN_VALUE':
           return {
             ...state,
-            query: replaceQueryToken(state.query, action.token, action.value),
+            query: modifyFilterValue(state.query, action.token, action.value),
           };
         case 'TOGGLE_FILTER_VALUE':
           return multiSelectTokenValue(state, action);

--- a/static/app/components/searchQueryBuilder/utils.tsx
+++ b/static/app/components/searchQueryBuilder/utils.tsx
@@ -4,6 +4,7 @@ import type {ListState} from '@react-stately/list';
 import type {Node} from '@react-types/shared';
 
 import {
+  FilterType,
   filterTypeConfig,
   interchangeableFilterOperators,
   type ParseResult,
@@ -14,6 +15,7 @@ import {
   Token,
   type TokenResult,
 } from 'sentry/components/searchSyntax/parser';
+import {t} from 'sentry/locale';
 import type {Tag, TagCollection} from 'sentry/types';
 import {escapeDoubleQuotes} from 'sentry/utils';
 import {FieldValueType, getFieldDefinition} from 'sentry/utils/fields';
@@ -80,7 +82,7 @@ export function parseQueryBuilderValue(
  */
 export function makeTokenKey(token: ParseResultToken, allTokens: ParseResult | null) {
   const tokenTypeIndex =
-    allTokens?.filter(t => t.type === token.type).indexOf(token) ?? 0;
+    allTokens?.filter(tk => tk.type === token.type).indexOf(token) ?? 0;
 
   return `${token.type}:${tokenTypeIndex}`;
 }
@@ -166,6 +168,8 @@ export function formatFilterValue(token: TokenResult<Token.FILTER>['value']): st
   switch (token.type) {
     case Token.VALUE_TEXT:
       return unescapeTagValue(token.value);
+    case Token.VALUE_RELATIVE_DATE:
+      return t('%s', `${token.value}${token.unit} ago`);
     default:
       return token.text;
   }
@@ -201,4 +205,10 @@ export function useShiftFocusToChild(
   return {
     shiftFocusProps: {onFocus},
   };
+}
+
+export function isDateToken(token: TokenResult<Token.FILTER>) {
+  return [FilterType.DATE, FilterType.RELATIVE_DATE, FilterType.SPECIFIC_DATE].includes(
+    token.filter
+  );
 }

--- a/static/app/components/searchQueryBuilder/valueCombobox.tsx
+++ b/static/app/components/searchQueryBuilder/valueCombobox.tsx
@@ -9,6 +9,7 @@ import type {SelectOptionWithKey} from 'sentry/components/compactSelect/types';
 import {getItemsWithKeys} from 'sentry/components/compactSelect/utils';
 import {SearchQueryBuilderCombobox} from 'sentry/components/searchQueryBuilder/combobox';
 import {useSearchQueryBuilder} from 'sentry/components/searchQueryBuilder/context';
+import {parseFilterValueDate} from 'sentry/components/searchQueryBuilder/filterValueParser/date/parser';
 import {
   escapeTagValue,
   formatFilterValue,
@@ -40,6 +41,7 @@ type SearchQueryValueBuilderProps = {
 type SuggestionItem = {
   value: string;
   description?: ReactNode;
+  label?: string;
 };
 
 type SuggestionSection = {
@@ -53,9 +55,10 @@ type SuggestionSectionItem = {
 };
 
 const NUMERIC_REGEX = /^-?\d+(\.\d+)?$/;
-const RELATIVE_DATE_REGEX = /^([+-]?)(\d+)([mhdw]?)$/;
 const FILTER_VALUE_NUMERIC = /^-?\d+(\.\d+)?[kmb]?$/i;
 const FILTER_VALUE_INT = /^-?\d+[kmb]?$/i;
+
+const RELATIVE_DATE_INPUT_REGEX = /^(\d+)\s*([mhdw]?)/;
 
 function isNumeric(value: string) {
   return NUMERIC_REGEX.test(value);
@@ -69,7 +72,6 @@ function isStringFilterValues(
 
 const NUMERIC_UNITS = ['k', 'm', 'b'] as const;
 const RELATIVE_DATE_UNITS = ['m', 'h', 'd', 'w'] as const;
-const RELATIVE_DATE_SIGNS = ['-', '+'] as const;
 const DURATION_UNITS = ['ms', 's', 'm', 'h', 'd', 'w'] as const;
 
 const DEFAULT_NUMERIC_SUGGESTIONS: SuggestionSection[] = [
@@ -93,53 +95,45 @@ const DEFAULT_BOOLEAN_SUGGESTIONS: SuggestionSection[] = [
   },
 ];
 
-const DEFAULT_DATE_SUGGESTIONS: SuggestionSection[] = [
-  {
-    sectionText: '',
-    suggestions: [
-      {value: '-1h', description: t('Last hour')},
-      {value: '-24h', description: t('Last 24 hours')},
-      {value: '-7d', description: t('Last 7 days')},
-      {value: '-14d', description: t('Last 14 days')},
-      {value: '-30d', description: t('Last 30 days')},
-      {value: '+1d', description: t('More than 1 day ago')},
-    ],
-  },
-];
+function getRelativeDateSign(token: TokenResult<Token.FILTER>) {
+  return token.value.type === Token.VALUE_RELATIVE_DATE ? token.value.sign : '-';
+}
 
-const makeRelativeDateDescription = (sign: '+' | '-', value: number, unit: string) => {
-  if (sign === '-') {
-    switch (unit) {
-      case 's':
-        return tn('Last %s second', 'Last %s seconds', value);
-      case 'm':
-        return tn('Last %s minute', 'Last %s minutes', value);
-      case 'h':
-        return tn('Last %s hour', 'Last %s hours', value);
-      case 'd':
-        return tn('Last %s day', 'Last %s days', value);
-      case 'w':
-        return tn('Last %s week', 'Last %s weeks', value);
-      default:
-        return '';
-    }
-  }
-
+function makeRelativeDateDescription(value: number, unit: string) {
   switch (unit) {
     case 's':
-      return tn('More than %s second ago', 'More than %s seconds ago', value);
+      return tn('%s second ago', '%s seconds ago', value);
     case 'm':
-      return tn('More than %s minute ago', 'More than %s minutes ago', value);
+      return tn('%s minute ago', '%s minutes ago', value);
     case 'h':
-      return tn('More than %s hour ago', 'More than %s hours ago', value);
+      return tn('%s hour ago', '%s hours ago', value);
     case 'd':
-      return tn('More than %s day ago', 'More than %s days ago', value);
+      return tn('%s day ago', '%s days ago', value);
     case 'w':
-      return tn('More than %s week ago', 'More than %s weeks ago', value);
+      return tn('%s week ago', '%s weeks ago', value);
     default:
       return '';
   }
-};
+}
+
+function makeDefaultDateSuggestions(
+  token: TokenResult<Token.FILTER>
+): SuggestionSection[] {
+  const sign = getRelativeDateSign(token);
+
+  return [
+    {
+      sectionText: '',
+      suggestions: [
+        {value: `${sign}1h`, label: makeRelativeDateDescription(1, 'h')},
+        {value: `${sign}24h`, label: makeRelativeDateDescription(24, 'h')},
+        {value: `${sign}7d`, label: makeRelativeDateDescription(7, 'd')},
+        {value: `${sign}14d`, label: makeRelativeDateDescription(14, 'd')},
+        {value: `${sign}30d`, label: makeRelativeDateDescription(30, 'd')},
+      ],
+    },
+  ];
+}
 
 function getNumericSuggestions(inputValue: string): SuggestionSection[] {
   if (!inputValue) {
@@ -181,33 +175,34 @@ function getDurationSuggestions(inputValue: string): SuggestionSection[] {
   return [];
 }
 
-function getRelativeDateSuggestions(inputValue: string): SuggestionSection[] {
-  const match = inputValue.match(RELATIVE_DATE_REGEX);
+function getRelativeDateSuggestions(
+  inputValue: string,
+  token: TokenResult<Token.FILTER>
+): SuggestionSection[] {
+  const match = inputValue.match(RELATIVE_DATE_INPUT_REGEX);
 
   if (!match) {
-    return DEFAULT_DATE_SUGGESTIONS;
+    return makeDefaultDateSuggestions(token);
   }
 
-  const [, , value] = match;
+  const [, value] = match;
   const intValue = parseInt(value, 10);
 
   if (isNaN(intValue)) {
-    return DEFAULT_DATE_SUGGESTIONS;
+    return makeDefaultDateSuggestions(token);
   }
+
+  const sign = token.value.type === Token.VALUE_RELATIVE_DATE ? token.value.sign : '-';
 
   return [
     {
       sectionText: '',
-      suggestions: [
-        ...RELATIVE_DATE_SIGNS.flatMap(sign =>
-          RELATIVE_DATE_UNITS.map(unit => {
-            return {
-              value: `${sign}${intValue}${unit}`,
-              description: makeRelativeDateDescription(sign, intValue, unit),
-            };
-          })
-        ),
-      ],
+      suggestions: RELATIVE_DATE_UNITS.map(unit => {
+        return {
+          value: `${sign}${intValue}${unit}`,
+          label: makeRelativeDateDescription(intValue, unit),
+        };
+      }),
     },
   ];
 }
@@ -225,8 +220,10 @@ function getSuggestionDescription(group: SearchGroup | SearchItem) {
 function getPredefinedValues({
   key,
   inputValue,
+  token,
 }: {
   inputValue: string;
+  token: TokenResult<Token.FILTER>;
   key?: Tag;
 }): SuggestionSection[] {
   if (!key) {
@@ -245,7 +242,7 @@ function getPredefinedValues({
         return DEFAULT_BOOLEAN_SUGGESTIONS;
       // TODO(malwilley): Better date suggestions
       case FieldValueType.DATE:
-        return getRelativeDateSuggestions(inputValue);
+        return getRelativeDateSuggestions(inputValue, token);
       default:
         return [];
     }
@@ -351,6 +348,13 @@ function cleanFilterValue(key: string, value: string): string {
         return value;
       }
       return '';
+    case FieldValueType.DATE:
+      const parsed = parseFilterValueDate(value);
+
+      if (!parsed) {
+        return '';
+      }
+      return value;
     default:
       return escapeTagValue(value);
   }
@@ -368,8 +372,8 @@ function useFilterSuggestions({
   const {getTagValues, keys} = useSearchQueryBuilder();
   const key = keys[token.key.text];
   const predefinedValues = useMemo(
-    () => getPredefinedValues({key, inputValue}),
-    [key, inputValue]
+    () => getPredefinedValues({key, inputValue, token}),
+    [key, inputValue, token]
   );
   const shouldFetchValues = key && !key.predefined && !predefinedValues.length;
   const canSelectMultipleValues = tokenSupportsMultipleValues(token, keys);
@@ -385,7 +389,7 @@ function useFilterSuggestions({
   const createItem = useCallback(
     (suggestion: SuggestionItem, selected = false) => {
       return {
-        label: suggestion.value,
+        label: suggestion.label ?? suggestion.value,
         value: suggestion.value,
         details: suggestion.description,
         textValue: suggestion.value,
@@ -538,7 +542,7 @@ export function SearchQueryBuilderValueCombobox({
       } else {
         dispatch({
           type: 'UPDATE_TOKEN_VALUE',
-          token: token.value,
+          token: token,
           value: cleanedValue,
         });
         onCommit();

--- a/static/app/components/searchSyntax/utils.tsx
+++ b/static/app/components/searchSyntax/utils.tsx
@@ -290,11 +290,12 @@ export function stringifyToken(token: TokenResult<Token>) {
       return `${token.prefix}[${token.key.value}]`;
     case Token.VALUE_TEXT:
       return token.quoted ? `"${token.value}"` : token.value;
+    case Token.VALUE_RELATIVE_DATE:
+      return `${token.sign}${token.value}${token.unit}`;
     case Token.VALUE_BOOLEAN:
     case Token.VALUE_DURATION:
     case Token.VALUE_ISO_8601_DATE:
     case Token.VALUE_PERCENTAGE:
-    case Token.VALUE_RELATIVE_DATE:
     case Token.VALUE_SIZE:
     case Token.VALUE_NUMBER:
       return token.text;


### PR DESCRIPTION
Instead of displaying `is -24h`, the actual search syntax is abstracted away:

`age:-24h` -> `age is after 24h ago`
`age:+24h` -> `age is before 24h ago`
`age:>=2024-01-01` -> `age is on or after 2024-01-01`

When selecting an operator with equality ("is", "is on or after", etc), it will automatically switch to an ISO date string. Next step is to make that editable with a date picker component.

![CleanShot 2024-06-17 at 15 40 47](https://github.com/getsentry/sentry/assets/10888943/c403a20e-fdd3-41ea-848a-ac3f411e13de)

![CleanShot 2024-06-17 at 15 40 55](https://github.com/getsentry/sentry/assets/10888943/8f258536-9841-4b88-9f98-09a441829e0a)
