### PR TITLE
ref(replay): rm blue dom banner while video loading

### DIFF
--- a/static/app/components/replays/replayPlayer.tsx
+++ b/static/app/components/replays/replayPlayer.tsx
@@ -148,7 +148,7 @@ function BasePlayerRoot({className, overlayContent, isPreview = false}: Props) {
         <div ref={viewEl} className={className} />
         {fastForwardSpeed ? <PositionedFastForward speed={fastForwardSpeed} /> : null}
         {isBuffering || isVideoBuffering ? <PositionedBuffering /> : null}
-        {isPreview || isVideoReplay ? null : <PlayerDOMAlert />}
+        {isPreview || isVideoReplay || isFetching ? null : <PlayerDOMAlert />}
         {isFetching ? <PositionedLoadingIndicator /> : null}
       </StyledNegativeSpaceContainer>
     </Fragment>


### PR DESCRIPTION
the last of the PRs to fix the mobile jumping issue
closes https://github.com/getsentry/sentry/issues/68109

hide the 'right click & inspect the dom' banner until the replay is finished loading.

mobile before:

https://github.com/getsentry/sentry/assets/56095982/9cfc0cfc-d515-4b0a-86d0-d20e1178da0d


mobile after:

https://github.com/getsentry/sentry/assets/56095982/cfd6757f-c9b0-40ef-8bbd-5c38f7ef6cd1

web after:


https://github.com/getsentry/sentry/assets/56095982/394112b0-980d-4ed4-83ea-dd2f76850944

