### PR TITLE
feat(uptime): Add uptime issue frontend type and config

### DIFF
--- a/static/app/components/stream/group.tsx
+++ b/static/app/components/stream/group.tsx
@@ -384,6 +384,7 @@ function BaseGroupRow({
     [IssueCategory.PROFILE]: t('Profile Events'),
     [IssueCategory.CRON]: t('Cron Events'),
     [IssueCategory.REPLAY]: t('Replay Events'),
+    [IssueCategory.UPTIME]: t('Uptime Events'),
   };
 
   const groupCount = !defined(primaryCount) ? (

--- a/static/app/types/group.tsx
+++ b/static/app/types/group.tsx
@@ -65,6 +65,7 @@ export enum IssueCategory {
   CRON = 'cron',
   PROFILE = 'profile',
   REPLAY = 'replay',
+  UPTIME = 'uptime',
 }
 
 export enum IssueType {

--- a/static/app/utils/issueTypeConfig/index.tsx
+++ b/static/app/utils/issueTypeConfig/index.tsx
@@ -12,6 +12,7 @@ import type {
   IssueCategoryConfigMapping,
   IssueTypeConfig,
 } from 'sentry/utils/issueTypeConfig/types';
+import uptimeConfig from 'sentry/utils/issueTypeConfig/uptimeConfig';
 
 type Config = Record<IssueCategory, IssueCategoryConfigMapping>;
 
@@ -57,6 +58,7 @@ const issueTypeConfig: Config = {
   [IssueCategory.PROFILE]: performanceConfig,
   [IssueCategory.CRON]: cronConfig,
   [IssueCategory.REPLAY]: replayConfig,
+  [IssueCategory.UPTIME]: uptimeConfig,
 };
 
 /**

--- a/static/app/utils/issueTypeConfig/uptimeConfig.tsx
+++ b/static/app/utils/issueTypeConfig/uptimeConfig.tsx
@@ -1,0 +1,26 @@
+import type {IssueCategoryConfigMapping} from 'sentry/utils/issueTypeConfig/types';
+
+const uptimeConfig: IssueCategoryConfigMapping = {
+  _categoryDefaults: {
+    actions: {
+      archiveUntilOccurrence: {enabled: true},
+      delete: {enabled: false},
+      deleteAndDiscard: {enabled: false},
+      merge: {enabled: false},
+      ignore: {enabled: true},
+      resolveInRelease: {enabled: true},
+      share: {enabled: true},
+    },
+    attachments: {enabled: false},
+    autofix: false,
+    mergedIssues: {enabled: false},
+    replays: {enabled: false},
+    similarIssues: {enabled: false},
+    userFeedback: {enabled: false},
+    usesIssuePlatform: true,
+    traceTimeline: true,
+    stats: {enabled: false},
+  },
+};
+
+export default uptimeConfig;


### PR DESCRIPTION
Adds new uptime issue type to frontend, to my knowledge this shouldn't be shown anywhere until we have uptime issues being created.

Related to: 
- https://github.com/getsentry/sentry/pull/72574
- https://github.com/getsentry/sentry/pull/72793

Fixes: https://github.com/getsentry/sentry/issues/72914