### PR TITLE
ref(metrics) Handle 500 error when there are no projects while fetching organization metrics tags

### DIFF
--- a/src/sentry/api/endpoints/organization_metrics_tags.py
+++ b/src/sentry/api/endpoints/organization_metrics_tags.py
@@ -40,7 +40,9 @@ class OrganizationMetricsTagsEndpoint(OrganizationEndpoint):
         metric_names = request.GET.getlist("metric") or []
         projects = self.get_projects(request, organization)
         if not projects:
-            raise InvalidParams("You must supply at least one project to see the tag names")
+            return Response(
+                {"detail": "You must supply at least one project to see its metrics"}, status=404
+            )
 
         if len(metric_names) != 1:
             raise BadRequest(message="Please provide a single metric to query its tags.")

--- a/tests/sentry/api/endpoints/test_organization_metrics_tags.py
+++ b/tests/sentry/api/endpoints/test_organization_metrics_tags.py
@@ -280,3 +280,10 @@ class OrganizationMetricsTagsIntegrationTest(MetricsAPIBaseTestCase):
             project=self.project.id,
         )
         assert len(response.data) == 4
+
+    def test_metrics_tags_when_organization_has_no_projects(self):
+        organization_without_projects = self.create_organization()
+        self.create_member(user=self.user, organization=organization_without_projects)
+        response = self.get_response(organization_without_projects.slug)
+        assert response.status_code == 404
+        assert response.data["detail"] == "You must supply at least one project to see its metrics"


### PR DESCRIPTION
part of 
[#72847](https://github.com/getsentry/sentry/issues/72847)