### PR TITLE
Handle 500 when fetching metric tag details and organization has no projects

### DIFF
--- a/src/sentry/api/endpoints/organization_metrics_tag_details.py
+++ b/src/sentry/api/endpoints/organization_metrics_tag_details.py
@@ -30,7 +30,9 @@ class OrganizationMetricsTagDetailsEndpoint(OrganizationEndpoint):
             )
         projects = self.get_projects(request, organization)
         if not projects:
-            raise InvalidParams("You must supply at least one project to see the tag values")
+            return Response(
+                {"detail": "You must supply at least one project to see its metrics"}, status=404
+            )
 
         try:
             mris = convert_metric_names_to_mris(metric_names)

--- a/tests/sentry/api/endpoints/test_organization_metrics_tag_details_v2.py
+++ b/tests/sentry/api/endpoints/test_organization_metrics_tag_details_v2.py
@@ -252,3 +252,10 @@ class OrganizationMetricsTagValues(MetricsAPIBaseTestCase):
             response.json()["detail"]
             == "Please supply only a single metric name. Specifying multiple metric names is not supported for this endpoint."
         )
+
+    def test_metrics_tags_when_organization_has_no_projects(self):
+        organization_without_projects = self.create_organization()
+        self.create_member(user=self.user, organization=organization_without_projects)
+        response = self.get_error_response(organization_without_projects.slug, "mytag")
+        assert response.status_code == 404
+        assert response.data["detail"] == "You must supply at least one project to see its metrics"


### PR DESCRIPTION
Part of [#72847](https://github.com/getsentry/sentry/issues/72847)