### PR TITLE
fix(spans): Use span type for traces searches

### DIFF
--- a/static/app/components/events/searchBar.tsx
+++ b/static/app/components/events/searchBar.tsx
@@ -171,6 +171,7 @@ export type SearchBarProps = Omit<React.ComponentProps<typeof SmartSearchBar>, '
   metricAlert?: boolean;
   omitTags?: string[];
   projectIds?: number[] | Readonly<number[]>;
+  savedSearchType?: SavedSearchType;
   supportedTags?: TagCollection | undefined;
 };
 
@@ -188,6 +189,7 @@ function SearchBar(props: SearchBarProps) {
     maxMenuHeight,
     customMeasurements,
     dataset,
+    savedSearchType = SavedSearchType.EVENT,
   } = props;
 
   const api = useApi();
@@ -309,7 +311,7 @@ function SearchBar(props: SearchBarProps) {
       {({measurements}) => (
         <SmartSearchBar
           hasRecentSearches
-          savedSearchType={SavedSearchType.EVENT}
+          savedSearchType={savedSearchType}
           projectIds={projectIds}
           onGetTagValues={getEventFieldValues}
           prepareQuery={query => {

--- a/static/app/types/group.tsx
+++ b/static/app/types/group.tsx
@@ -56,6 +56,7 @@ export enum SavedSearchType {
   SESSION = 2,
   REPLAY = 3,
   METRIC = 4,
+  SPAN = 5,
 }
 
 export enum IssueCategory {

--- a/static/app/views/traces/tracesSearchBar.tsx
+++ b/static/app/views/traces/tracesSearchBar.tsx
@@ -5,6 +5,7 @@ import SearchBar from 'sentry/components/events/searchBar';
 import {IconAdd, IconClose} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
+import {SavedSearchType} from 'sentry/types/group';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import useOrganization from 'sentry/utils/useOrganization';
@@ -58,6 +59,7 @@ export function TracesSearchBar({
             supportedTags={supportedTags}
             dataset={DiscoverDatasets.SPANS_INDEXED}
             projectIds={ALL_PROJECTS}
+            savedSearchType={SavedSearchType.SPAN}
           />
           <StyledButton
             aria-label={t('Remove span')}


### PR DESCRIPTION
This was using the event type so searches from other parts of the product like discover were being mixed here. Switch to use it's own type.

Depends on #72938