### PR TITLE
chore(issues): clean up issues.occurrence_consumer.use_orjson option

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -2550,11 +2550,3 @@ register(
     default=50,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
-
-# Enable orjson in the occurrence_consumer.process_[message|batch]
-register(
-    "issues.occurrence_consumer.use_orjson",
-    type=Bool,
-    default=False,
-    flags=FLAG_AUTOMATOR_MODIFIABLE,
-)


### PR DESCRIPTION
Orjson has proven to work fine, so deleting the option after it has been enabled permanently 

Third of three PRs:
1. https://github.com/getsentry/sentry/pull/72917
2. https://github.com/getsentry/sentry-options-automator/pull/1637
3. this 
