### PR TITLE
chore(slack): log response url in send_slack_response

### DIFF
--- a/src/sentry/integrations/slack/utils/notifications.py
+++ b/src/sentry/integrations/slack/utils/notifications.py
@@ -173,7 +173,11 @@ def send_slack_response(
     client = SlackClient(integration_id=integration.id)
     logger.info(
         "slack.send_slack_response",
-        extra={"integration_id": integration.id, "response_url": params.get("response_url")},
+        extra={
+            "integration_id": integration.id,
+            "response_url": params.get("response_url"),
+            "payload": payload,
+        },
     )
 
     if params["response_url"]:

--- a/src/sentry/integrations/slack/utils/notifications.py
+++ b/src/sentry/integrations/slack/utils/notifications.py
@@ -171,6 +171,11 @@ def send_slack_response(
     }
 
     client = SlackClient(integration_id=integration.id)
+    logger.info(
+        "slack.send_slack_response",
+        extra={"integration_id": integration.id, "response_url": params.get("response_url")},
+    )
+
     if params["response_url"]:
         path = params["response_url"]
 


### PR DESCRIPTION
We have this interesting function called `send_slack_response` that is only used when somebody links or unlinks an identity that either POSTs to:
- A `response_url` extracted from the signed params when somebody invokes the command via a slash command
- `chat.postMessage` when somebody invokes the command in a DM, in which we apparently do not have a `response_url` (according to a comment)

It would be good to see what this `response_url` actually is and if it can be condensed into a single API call.