### PR TITLE
feat(contexts): Stop pruning null keys from contexts

### DIFF
--- a/src/sentry/interfaces/contexts.py
+++ b/src/sentry/interfaces/contexts.py
@@ -6,7 +6,6 @@ from typing import Any, ClassVar, TypeVar
 from django.utils.encoding import force_str
 
 from sentry.interfaces.base import Interface
-from sentry.utils.json import prune_empty_keys
 from sentry.utils.safe import get_path
 
 __all__ = ("Contexts",)
@@ -89,10 +88,7 @@ class ContextType:
             # we use a simple check here, rather than ' in set()' to avoid
             # issues with maps/lists.
 
-            # Even if the value is an empty string,
-            # we still want to display the info the UI
-            if value is not None:
-                ctx_data[force_str(key)] = value
+            ctx_data[force_str(key)] = value
             # Numbers exceeding 15 place values will be converted to strings to avoid rendering issues
             if isinstance(value, (int, float, list, dict)):
                 ctx_data[force_str(key)] = self.change_type(value)
@@ -101,7 +97,7 @@ class ContextType:
     def to_json(self):
         rv = dict(self.data)
         rv["type"] = self.type
-        return prune_empty_keys(rv)
+        return rv
 
     @classmethod
     def values_for_data(cls, data):

--- a/tests/sentry/event_manager/interfaces/snapshots/test_contexts/test_null_values_custom_context.pysnap
+++ b/tests/sentry/event_manager/interfaces/snapshots/test_contexts/test_null_values_custom_context.pysnap
@@ -1,0 +1,11 @@
+---
+created: '2024-06-18T20:52:40.636824+00:00'
+creator: sentry
+source: tests/sentry/event_manager/interfaces/test_contexts.py
+---
+errors: null
+tags: []
+to_json:
+  custom_context:
+    null_value: null
+    type: default

--- a/tests/sentry/event_manager/interfaces/test_contexts.py
+++ b/tests/sentry/event_manager/interfaces/test_contexts.py
@@ -39,6 +39,10 @@ def test_null_values3(make_ctx_snapshot):
     make_ctx_snapshot({"os": {"name": None}})
 
 
+def test_null_values_custom_context(make_ctx_snapshot):
+    make_ctx_snapshot({"custom_context": {"null_value": None}})
+
+
 def test_os_normalization(make_ctx_snapshot):
     make_ctx_snapshot({"os": {"raw_description": "Microsoft Windows 6.1.7601 S"}})
 


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry/issues/72890

Before:

![CleanShot 2024-06-18 at 10 14 00](https://github.com/getsentry/sentry/assets/10888943/4e918d36-e546-4a89-8a9d-b83dd93f0fab)

After:

![CleanShot 2024-06-18 at 09 46 18](https://github.com/getsentry/sentry/assets/10888943/5af24286-8c01-400b-91ae-8dd4a565d9f2)