### PR TITLE
feat(insights): add receiver and signals for has_insights_xx spans

### DIFF
--- a/src/sentry/analytics/events/__init__.py
+++ b/src/sentry/analytics/events/__init__.py
@@ -22,6 +22,7 @@ from .first_cron_checkin_sent import *  # noqa: F401,F403
 from .first_custom_metric_sent import *  # noqa: F401,F403
 from .first_event_sent import *  # noqa: F401,F403
 from .first_feedback_sent import *  # noqa: F401,F403
+from .first_insight_span_sent import *  # noqa: F401,F403
 from .first_new_feedback_sent import *  # noqa: F401,F403
 from .first_profile_sent import *  # noqa: F401,F403
 from .first_release_tag_sent import *  # noqa: F401,F403

--- a/src/sentry/analytics/events/first_insight_span_sent.py
+++ b/src/sentry/analytics/events/first_insight_span_sent.py
@@ -1,0 +1,16 @@
+from sentry import analytics
+
+
+class FirstInsightSpanSentEvent(analytics.Event):
+    type = "first_insight_span.sent"
+
+    attributes = (
+        analytics.Attribute("organization_id"),
+        analytics.Attribute("user_id"),
+        analytics.Attribute("project_id"),
+        analytics.Attribute("module"),
+        analytics.Attribute("platform", required=False),
+    )
+
+
+analytics.register(FirstInsightSpanSentEvent)

--- a/src/sentry/constants.py
+++ b/src/sentry/constants.py
@@ -8,6 +8,7 @@ import os.path
 from collections import namedtuple
 from collections.abc import Sequence
 from datetime import timedelta
+from enum import Enum
 from typing import cast
 
 import sentry_relay.consts
@@ -597,6 +598,18 @@ class ExportQueryType:
             return cls.DISCOVER
         else:
             raise ValueError(f"Not an ExportQueryType str: {string!r}")
+
+
+class InsightModules(Enum):
+    HTTP = "http"
+    DB = "db"
+    ASSETS = "assets"  # previously named resources
+    APP_START = "app_start"
+    SCREEN_LOAD = "screen_load"
+    VITAL = "vital"
+    CACHE = "cache"
+    QUEUE = "queue"
+    LLM_MONITORING = "llm_monitoring"
 
 
 StatsPeriod = namedtuple("StatsPeriod", ("segments", "interval"))

--- a/src/sentry/receivers/onboarding.py
+++ b/src/sentry/receivers/onboarding.py
@@ -7,6 +7,7 @@ from django.db.models import F
 from django.utils import timezone as django_timezone
 
 from sentry import analytics, features
+from sentry.constants import InsightModules
 from sentry.models.organization import Organization
 from sentry.models.organizationonboardingtask import (
     OnboardingTask,
@@ -29,6 +30,7 @@ from sentry.signals import (
     first_event_received,
     first_event_with_minified_stack_trace_received,
     first_feedback_received,
+    first_insight_span_received,
     first_new_feedback_received,
     first_profile_received,
     first_replay_received,
@@ -329,6 +331,41 @@ def record_first_custom_metric(project, **kwargs):
         organization_id=project.organization_id,
         project_id=project.id,
         platform=project.platform,
+    )
+
+
+@first_insight_span_received.connect(weak=False)
+def record_first_insight_span(project, module, **kwargs):
+    flag = None
+    if module == InsightModules.HTTP:
+        flag = Project.flags.has_insights_http
+    elif module == InsightModules.DB:
+        flag = Project.flags.has_insights_db
+    elif module == InsightModules.ASSETS:
+        flag = Project.flags.has_insights_assets
+    elif module == InsightModules.APP_START:
+        flag = Project.flags.has_insights_app_start
+    elif module == InsightModules.SCREEN_LOAD:
+        flag = Project.flags.has_insights_screen_load
+    elif module == InsightModules.VITAL:
+        flag = Project.flags.has_insights_vitals
+    elif module == InsightModules.CACHE:
+        flag = Project.flags.has_insights_caches
+    elif module == InsightModules.QUEUE:
+        flag = Project.flags.has_insights_queues
+    elif module == InsightModules.LLM_MONITORING:
+        flag = Project.flags.has_insights_llm_monitoring
+
+    if flag is not None:
+        project.update(flags=F("flags").bitor(flag))
+
+    analytics.record(
+        "first_insight_span.sent",
+        user_id=project.organization.default_owner_id,
+        organization_id=project.organization_id,
+        project_id=project.id,
+        platform=project.platform,
+        module=module,
     )
 
 

--- a/src/sentry/signals.py
+++ b/src/sentry/signals.py
@@ -117,6 +117,7 @@ first_cron_monitor_created = BetterSignal()  # ["project", "user", "from_upsert"
 cron_monitor_created = BetterSignal()  # ["project", "user", "from_upsert"]
 first_cron_checkin_received = BetterSignal()  # ["project", "monitor_id"]
 first_custom_metric_received = BetterSignal()  # ["project"]
+first_insight_span_received = BetterSignal()  # ["project", "module"]
 member_invited = BetterSignal()  # ["member", "user"]
 member_joined = BetterSignal()  # ["organization_member_id", "organization_id", "user_id"]
 issue_tracker_used = BetterSignal()  # ["plugin", "project", "user"]


### PR DESCRIPTION
A continuation of https://github.com/getsentry/sentry/pull/72904.

This PR adds a signal and receiver for the `has_insights_xx_span` event, which will trigger when the user first receives a span of a specific insight module type.

The following PR will implement the logic that triggers the signal for each module.