### PR TITLE
ref(slack): Refactor Unlink Team View

### DIFF
--- a/src/sentry/integrations/slack/metrics.py
+++ b/src/sentry/integrations/slack/metrics.py
@@ -6,3 +6,23 @@ SLACK_ACTIVITY_THREAD_SUCCESS_DATADOG_METRIC = "sentry.integrations.slack.activi
 SLACK_ACTIVITY_THREAD_FAILURE_DATADOG_METRIC = "sentry.integrations.slack.activity_thread.failure"
 SLACK_METRIC_ALERT_SUCCESS_DATADOG_METRIC = "sentry.integrations.slack.metric_alert.success"
 SLACK_METRIC_ALERT_FAILURE_DATADOG_METRIC = "sentry.integrations.slack.metric_alert.failure"
+
+# Bot commands
+SLACK_BOT_COMMAND_LINK_IDENTITY_SUCCESS_DATADOG_METRIC = (
+    "sentry.integrations.slack.link_identity_view.success"
+)
+SLACK_BOT_COMMAND_LINK_IDENTITY_FAILURE_DATADOG_METRIC = (
+    "sentry.integrations.slack.link_identity_view.failure"
+)
+SLACK_BOT_COMMAND_UNLINK_IDENTITY_SUCCESS_DATADOG_METRIC = (
+    "sentry.integrations.slack.unlink_identity_view.success"
+)
+SLACK_BOT_COMMAND_UNLINK_IDENTITY_FAILURE_DATADOG_METRIC = (
+    "sentry.integrations.slack.unlink_identity_view.failure"
+)
+SLACK_BOT_COMMAND_UNLINK_TEAM_SUCCESS_DATADOG_METRIC = (
+    "sentry.integrations.slack.unlink_team.success"
+)
+SLACK_BOT_COMMAND_UNLINK_TEAM_FAILURE_DATADOG_METRIC = (
+    "sentry.integrations.slack.unlink_team.failure"
+)

--- a/src/sentry/integrations/slack/views/link_identity.py
+++ b/src/sentry/integrations/slack/views/link_identity.py
@@ -7,6 +7,10 @@ from django.http.response import HttpResponseBase
 from django.utils.decorators import method_decorator
 from rest_framework.request import Request
 
+from sentry.integrations.slack.metrics import (
+    SLACK_BOT_COMMAND_LINK_IDENTITY_FAILURE_DATADOG_METRIC,
+    SLACK_BOT_COMMAND_LINK_IDENTITY_SUCCESS_DATADOG_METRIC,
+)
 from sentry.integrations.slack.views import render_error_page
 from sentry.integrations.slack.views.types import IdentityParams
 from sentry.integrations.types import ExternalProviderEnum, ExternalProviders
@@ -49,8 +53,8 @@ class SlackLinkIdentityView(BaseView):
     Django view for linking user to slack account. Creates an entry on Identity table.
     """
 
-    _METRICS_SUCCESS_KEY = "sentry.integrations.slack.link_identity_view.success"
-    _METRICS_FAILURE_KEY = "sentry.integrations.slack.link_identity_view.failure"
+    _METRICS_SUCCESS_KEY = SLACK_BOT_COMMAND_LINK_IDENTITY_SUCCESS_DATADOG_METRIC
+    _METRICS_FAILURE_KEY = SLACK_BOT_COMMAND_LINK_IDENTITY_FAILURE_DATADOG_METRIC
 
     @method_decorator(never_cache)
     def dispatch(self, request: HttpRequest, signed_params: str) -> HttpResponseBase:

--- a/src/sentry/integrations/slack/views/types.py
+++ b/src/sentry/integrations/slack/views/types.py
@@ -21,3 +21,23 @@ class IdentityParams:
         self.slack_id = slack_id
         self.channel_id = channel_id
         self.response_url = response_url
+
+
+@dataclass
+class TeamIdentityParams:
+    organization_id: str
+    integration_id: str
+    channel_id: str
+    channel_name: str
+    slack_id: str
+    response_url: str | None = None
+
+    def __init__(
+        self, organization_id, integration_id, channel_id, channel_name, slack_id, response_url=None
+    ):
+        self.organization_id = organization_id
+        self.integration_id = integration_id
+        self.channel_id = channel_id
+        self.channel_name = channel_name
+        self.slack_id = slack_id
+        self.response_url = response_url

--- a/src/sentry/integrations/slack/views/types.py
+++ b/src/sentry/integrations/slack/views/types.py
@@ -14,30 +14,12 @@ class IdentityParams:
     channel_id: str
     response_url: str | None = None
 
-    def __init__(self, organization, integration, idp, slack_id, channel_id, response_url=None):
-        self.organization = organization
-        self.integration = integration
-        self.idp = idp
-        self.slack_id = slack_id
-        self.channel_id = channel_id
-        self.response_url = response_url
-
 
 @dataclass
-class TeamIdentityParams:
+class TeamIdentityRequest:
     organization_id: str
     integration_id: str
     channel_id: str
     channel_name: str
     slack_id: str
     response_url: str | None = None
-
-    def __init__(
-        self, organization_id, integration_id, channel_id, channel_name, slack_id, response_url=None
-    ):
-        self.organization_id = organization_id
-        self.integration_id = integration_id
-        self.channel_id = channel_id
-        self.channel_name = channel_name
-        self.slack_id = slack_id
-        self.response_url = response_url

--- a/src/sentry/integrations/slack/views/types.py
+++ b/src/sentry/integrations/slack/views/types.py
@@ -5,7 +5,7 @@ from sentry.models.integrations.integration import Integration
 from sentry.services.hybrid_cloud.organization import RpcOrganization
 
 
-@dataclass
+@dataclass(frozen=True)
 class IdentityParams:
     organization: RpcOrganization
     integration: Integration
@@ -15,7 +15,7 @@ class IdentityParams:
     response_url: str | None = None
 
 
-@dataclass
+@dataclass(frozen=True)
 class TeamIdentityRequest:
     organization_id: str
     integration_id: str

--- a/src/sentry/integrations/slack/views/unlink_identity.py
+++ b/src/sentry/integrations/slack/views/unlink_identity.py
@@ -7,6 +7,10 @@ from django.http.response import HttpResponseBase
 from django.utils.decorators import method_decorator
 from rest_framework.request import Request
 
+from sentry.integrations.slack.metrics import (
+    SLACK_BOT_COMMAND_UNLINK_IDENTITY_FAILURE_DATADOG_METRIC,
+    SLACK_BOT_COMMAND_UNLINK_IDENTITY_SUCCESS_DATADOG_METRIC,
+)
 from sentry.integrations.slack.utils.notifications import send_slack_response
 from sentry.integrations.slack.views import build_linking_url as base_build_linking_url
 from sentry.integrations.slack.views import never_cache, render_error_page
@@ -42,8 +46,8 @@ class SlackUnlinkIdentityView(BaseView):
     Django view for unlinking user from slack account. Deletes from Identity table.
     """
 
-    _METRICS_SUCCESS_KEY = "sentry.integrations.slack.unlink_identity_view.success"
-    _METRICS_FAILURE_KEY = "sentry.integrations.slack.unlink_identity_view.failure"
+    _METRICS_SUCCESS_KEY = SLACK_BOT_COMMAND_UNLINK_IDENTITY_SUCCESS_DATADOG_METRIC
+    _METRICS_FAILURE_KEY = SLACK_BOT_COMMAND_UNLINK_IDENTITY_FAILURE_DATADOG_METRIC
 
     @method_decorator(never_cache)
     def dispatch(self, request: HttpRequest, signed_params: str) -> HttpResponseBase:

--- a/src/sentry/integrations/slack/views/unlink_team.py
+++ b/src/sentry/integrations/slack/views/unlink_team.py
@@ -1,23 +1,28 @@
+import logging
+
 from django.core.signing import BadSignature, SignatureExpired
-from django.http import Http404, HttpResponse
+from django.http import HttpRequest, HttpResponse
 from django.utils.decorators import method_decorator
-from rest_framework.request import Request
 
 from sentry.api.helpers.teams import is_team_admin
 from sentry.integrations.mixins import SUCCESS_UNLINKED_TEAM_MESSAGE, SUCCESS_UNLINKED_TEAM_TITLE
+from sentry.integrations.slack.views.types import TeamIdentityParams
 from sentry.integrations.types import EXTERNAL_PROVIDERS, ExternalProviders
 from sentry.models.integrations.external_actor import ExternalActor
 from sentry.models.integrations.integration import Integration
 from sentry.models.organizationmember import OrganizationMember
 from sentry.services.hybrid_cloud.identity import identity_service
 from sentry.services.hybrid_cloud.integration import integration_service
+from sentry.utils import metrics
 from sentry.utils.signing import unsign
 from sentry.web.frontend.base import BaseView, region_silo_view
 from sentry.web.helpers import render_to_response
 
-from ..utils import is_valid_role, logger
+from ..utils import is_valid_role
 from . import build_linking_url as base_build_linking_url
 from . import never_cache, render_error_page
+
+_logger = logging.getLogger(__name__)
 
 INSUFFICIENT_ACCESS = (
     "You must be a Sentry organization admin/manager/owner or a team admin to unlink a team."
@@ -51,32 +56,59 @@ class SlackUnlinkTeamView(BaseView):
     Django view for unlinking team from slack channel. Deletes from ExternalActor table.
     """
 
+    _METRICS_SUCCESS_KEY = "sentry.integrations.slack.unlink_team_view.success"
+    _METRICS_FAILURE_KEY = "sentry.integrations.slack.unlink_team_view.failure"
+
     @method_decorator(never_cache)
-    def handle(self, request: Request, signed_params: str) -> HttpResponse:
+    def dispatch(self, request: HttpRequest, signed_params: str) -> HttpResponse:
         if request.method not in ALLOWED_METHODS:
             return HttpResponse(status=405)
 
         try:
-            params = unsign(signed_params)
-        except (SignatureExpired, BadSignature):
+            converted = unsign(signed_params)
+            params = TeamIdentityParams(**converted)
+        except (SignatureExpired, BadSignature) as e:
+            _logger.warning("dispatch.signature_error", exc_info=e)
+            metrics.incr(self._METRICS_FAILURE_KEY, tags={"error": str(e)}, sample_rate=1.0)
             return render_to_response(
                 "sentry/integrations/slack/expired-link.html",
                 request=request,
             )
+        except TypeError:
+            _logger.exception("dispatch.type_error")
+            metrics.incr(self._METRICS_FAILURE_KEY, sample_rate=1.0)
+            return render_error_page(request, status=400, body_text="HTTP 400: Invalid parameters")
 
-        integration = integration_service.get_integration(integration_id=params["integration_id"])
+        logger_params = {
+            "organization_id": params.organization_id,
+            "integration_id": params.integration_id,
+            "channel_id": params.channel_id,
+            "channel_name": params.channel_name,
+            "slack_id": params.slack_id,
+            "user_id": request.user.id,
+        }
+
+        integration = integration_service.get_integration(integration_id=params.integration_id)
         if not integration:
-            raise Http404
+            _logger.info("no-integration-found", extra=logger_params)
+            metrics.incr(self._METRICS_FAILURE_KEY + ".get_integration", sample_rate=1.0)
+            return render_error_page(
+                request, status=404, body_text="HTTP 404: Could not find the Slack integration."
+            )
 
         om = OrganizationMember.objects.get_for_integration(
-            integration, request.user, organization_id=params["organization_id"]
+            integration, request.user, organization_id=params.organization_id
         ).first()
         organization = om.organization if om else None
         if organization is None:
-            raise Http404
+            _logger.info("no-organization-found", extra=logger_params)
+            metrics.incr(self._METRICS_FAILURE_KEY + ".get_organization", sample_rate=1.0)
+            return render_error_page(
+                request, status=404, body_text="HTTP 404: Could not find the organization."
+            )
 
-        channel_name = params["channel_name"]
-        channel_id = params["channel_id"]
+        channel_name = params.channel_name
+        channel_id = params.channel_id
 
         external_teams = ExternalActor.objects.filter(
             organization_id=organization.id,
@@ -86,21 +118,34 @@ class SlackUnlinkTeamView(BaseView):
             external_id=channel_id,
         )
         if len(external_teams) == 0:
+            _logger.info(
+                "no-team-found",
+                extra={logger_params},
+            )
+            metrics.incr(self._METRICS_FAILURE_KEY + ".get_team", sample_rate=1.0)
             return render_error_page(request, status=404, body_text="HTTP 404: Team not found")
 
         team = external_teams[0].team
         if team is None:
+            _logger.info(
+                "no-team-found",
+                extra={logger_params},
+            )
+            metrics.incr(self._METRICS_FAILURE_KEY + ".get_team", sample_rate=1.0)
             return render_error_page(request, status=404, body_text="HTTP 404: Team not found")
+
+        logger_params["team_id"] = team.id
 
         # Error if you don't have a sufficient role and you're not a team admin
         # on the team you're trying to unlink.
         if not is_valid_role(om) and not is_team_admin(om, team=team):
-            logger.info(
-                "slack.action.invalid-role",
-                extra={"slack_id": integration.external_id, "user_id": request.user.id},
+            _logger.info(
+                "invalid-role",
+                extra=logger_params,
             )
+            metrics.incr(self._METRICS_FAILURE_KEY + ".invalid_role", sample_rate=1.0)
             return render_error_page(
-                request, status=404, body_text="HTTP 404: " + INSUFFICIENT_ACCESS
+                request, status=403, body_text="HTTP 403: " + INSUFFICIENT_ACCESS
             )
 
         if request.method == "GET":
@@ -120,8 +165,10 @@ class SlackUnlinkTeamView(BaseView):
         )
 
         if not idp or not identity_service.get_identity(
-            filter={"provider_id": idp.id, "identity_ext_id": params["slack_id"]}
+            filter={"provider_id": idp.id, "identity_ext_id": params.slack_id}
         ):
+            _logger.info("identity-not-found", extra=logger_params)
+            metrics.incr(self._METRICS_FAILURE_KEY + ".identity_not_found", sample_rate=1.0)
             return render_error_page(
                 request, status=403, body_text="HTTP 403: User identity does not exist"
             )
@@ -129,6 +176,9 @@ class SlackUnlinkTeamView(BaseView):
         # Someone may have accidentally added multiple teams so unlink them all.
         for external_team in external_teams:
             external_team.delete()
+
+        _logger.info("unlink-team-success", extra=logger_params)
+        metrics.incr(self._METRICS_SUCCESS_KEY + "post.unlink_team", sample_rate=1.0)
 
         return render_to_response(
             "sentry/integrations/slack/unlinked-team.html",

--- a/src/sentry/integrations/slack/views/unlink_team.py
+++ b/src/sentry/integrations/slack/views/unlink_team.py
@@ -6,7 +6,7 @@ from django.utils.decorators import method_decorator
 
 from sentry.api.helpers.teams import is_team_admin
 from sentry.integrations.mixins import SUCCESS_UNLINKED_TEAM_MESSAGE, SUCCESS_UNLINKED_TEAM_TITLE
-from sentry.integrations.slack.views.types import TeamIdentityParams
+from sentry.integrations.slack.views.types import TeamIdentityRequest
 from sentry.integrations.types import EXTERNAL_PROVIDERS, ExternalProviders
 from sentry.models.integrations.external_actor import ExternalActor
 from sentry.models.integrations.integration import Integration
@@ -66,7 +66,7 @@ class SlackUnlinkTeamView(BaseView):
 
         try:
             converted = unsign(signed_params)
-            params = TeamIdentityParams(**converted)
+            params = TeamIdentityRequest(**converted)
         except (SignatureExpired, BadSignature) as e:
             _logger.warning("dispatch.signature_error", exc_info=e)
             metrics.incr(self._METRICS_FAILURE_KEY, tags={"error": str(e)}, sample_rate=1.0)


### PR DESCRIPTION
https://www.notion.so/sentry/Slack-ff5b8ab4fd1e4760ab829438ce97ce15

Addresses `bot-4` task.

I created a dataclass for the input params, added logging & metrics, and instead of raising errors, we instead render the error page
