### PR TITLE
feat(trace-explorer): Separate endpoint to load trace spans

### DIFF
--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -491,6 +491,7 @@ from .endpoints.organization_tags import OrganizationTagsEndpoint
 from .endpoints.organization_teams import OrganizationTeamsEndpoint
 from .endpoints.organization_traces import (
     OrganizationTracesEndpoint,
+    OrganizationTraceSpansEndpoint,
     OrganizationTracesStatsEndpoint,
 )
 from .endpoints.organization_transaction_anomaly_detection import (
@@ -1403,6 +1404,11 @@ ORGANIZATION_URLS = [
         r"^(?P<organization_id_or_slug>[^\/]+)/events-stats/$",
         OrganizationEventsStatsEndpoint.as_view(),
         name="sentry-api-0-organization-events-stats",
+    ),
+    re_path(
+        r"^(?P<organization_id_or_slug>[^\/]+)/trace/(?P<trace_id>(?:\d+|[A-Fa-f0-9-]{32,36}))/spans/$",
+        OrganizationTraceSpansEndpoint.as_view(),
+        name="sentry-api-0-organization-trace-spans",
     ),
     re_path(
         r"^(?P<organization_id_or_slug>[^\/]+)/traces/$",

--- a/src/sentry/snuba/referrer.py
+++ b/src/sentry/snuba/referrer.py
@@ -443,6 +443,7 @@ class Referrer(Enum):
     API_TRACE_EXPLORER_SPANS_LIST = "api.trace-explorer.spans-list"
     API_TRACE_EXPLORER_STATS = "api.trace-explorer.stats"
     API_TRACE_EXPLORER_TRACES_META = "api.trace-explorer.traces-meta"
+    API_TRACE_EXPLORER_TRACE_SPANS_LIST = "api.trace-explorer.trace-spans-list"
     API_SPANS_TAG_KEYS = "api.spans.tags-keys"
     API_SPANS_TRACE_VIEW = "api.spans.trace-view"
 


### PR DESCRIPTION
The trace explorer query to load sample spans is quite slow because it's tries to fetch the spans for all traces at once. Separating it into a separate endpoint allows us to load a single trace at a time and can be optimized separately.

Once we move the frontend to load spans from this endpoint, we can remove the samples query from the original endpoint.