### PR TITLE
chore(performance): Cache events_stats endpoint responses

### DIFF
--- a/src/sentry/api/endpoints/organization_events_stats.py
+++ b/src/sentry/api/endpoints/organization_events_stats.py
@@ -473,12 +473,11 @@ class OrganizationEventsStatsEndpoint(OrganizationEventsV2EndpointBase):
             if (
                 response_data.get("end")
                 and request.GET.get("end")
+                and request.GET.get("project")  # only works if projects are explicitly specified
                 and time.time() - response_data.get("end") > 7200
             ):
                 # this is a request for an absolute time range that ended over two hours ago, it won't change
                 resp.headers["Cache-Control"] = "max-age=86400, private, immutable"
-            else:
-                resp.headers["Cache-Control"] = "max-age=30, private"
             return resp
         except ValidationError:
             return Response({"detail": "Comparison period is outside retention window"}, status=400)


### PR DESCRIPTION
We make a lot of requests for relatively similar data right now, this will let us split up the frontend graph loading into a few cached chunks.