### PR TITLE
feat(flagpole): Add to_dict method to EvaluationContext

### DIFF
--- a/src/flagpole/evaluation_context.py
+++ b/src/flagpole/evaluation_context.py
@@ -73,6 +73,9 @@ class EvaluationContext:
     def size(self) -> int:
         return len(self.__data)
 
+    def to_dict(self) -> T_CONTEXT_DATA:
+        return deepcopy(self.__data)
+
 
 T_CONTEXT_DATA = TypeVar("T_CONTEXT_DATA")
 

--- a/src/flagpole/evaluation_context.py
+++ b/src/flagpole/evaluation_context.py
@@ -73,7 +73,7 @@ class EvaluationContext:
     def size(self) -> int:
         return len(self.__data)
 
-    def to_dict(self) -> T_CONTEXT_DATA:
+    def to_dict(self) -> EvaluationContextDict:
         return deepcopy(self.__data)
 
 


### PR DESCRIPTION
Adds a method to deepcopy an evaluation context to a dictionary. The
plan is to use this to dump the internal state of the evaluation context
when logging.


