### PR TITLE
feat(breadcrumbs): Use new timeline UI for issue breadcrumbs

### DIFF
--- a/static/app/components/events/breadcrumbs/breadcrumbsDataSection.tsx
+++ b/static/app/components/events/breadcrumbs/breadcrumbsDataSection.tsx
@@ -1,0 +1,188 @@
+import {useState} from 'react';
+import styled from '@emotion/styled';
+
+import {Button} from 'sentry/components/button';
+import ButtonBar from 'sentry/components/buttonBar';
+import ClippedBox from 'sentry/components/clippedBox';
+import {CompactSelect} from 'sentry/components/compactSelect';
+import DropdownButton from 'sentry/components/dropdownButton';
+import ErrorBoundary from 'sentry/components/errorBoundary';
+import BreadcrumbsTimeline from 'sentry/components/events/breadcrumbs/breadcrumbsTimeline';
+import {
+  applyBreadcrumbSearch,
+  BREADCRUMB_TIME_DISPLAY_LOCALSTORAGE_KEY,
+  BREADCRUMB_TIME_DISPLAY_OPTIONS,
+  BreadcrumbTimeDisplay,
+  getBreadcrumbFilters,
+} from 'sentry/components/events/breadcrumbs/utils';
+import {EventDataSection} from 'sentry/components/events/eventDataSection';
+import {
+  BREADCRUMB_SORT_LOCALSTORAGE_KEY,
+  BREADCRUMB_SORT_OPTIONS,
+  BreadcrumbSort,
+} from 'sentry/components/events/interfaces/breadcrumbs';
+import {getVirtualCrumb} from 'sentry/components/events/interfaces/breadcrumbs/utils';
+import Input from 'sentry/components/input';
+import {IconClock, IconFilter, IconSort} from 'sentry/icons';
+import {t, tn} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
+import {EntryType, type Event} from 'sentry/types';
+import {useLocalStorageState} from 'sentry/utils/useLocalStorageState';
+
+interface BreadcrumbsDataSectionProps {
+  event: Event;
+}
+
+export default function BreadcrumbsDataSection({event}: BreadcrumbsDataSectionProps) {
+  const [search, setSearch] = useState('');
+  const [filterSet, setFilterSet] = useState(new Set<string>());
+  const [sort, setSort] = useLocalStorageState<BreadcrumbSort>(
+    BREADCRUMB_SORT_LOCALSTORAGE_KEY,
+    BreadcrumbSort.NEWEST
+  );
+  const [timeDisplay, setTimeDisplay] = useLocalStorageState<BreadcrumbTimeDisplay>(
+    BREADCRUMB_TIME_DISPLAY_LOCALSTORAGE_KEY,
+    BreadcrumbTimeDisplay.RELATIVE
+  );
+
+  const breadcrumbEntryIndex = event.entries.findIndex(
+    entry => entry.type === EntryType.BREADCRUMBS
+  );
+  if (!breadcrumbEntryIndex) {
+    return null;
+  }
+  const breadcrumbs = event.entries[breadcrumbEntryIndex]?.data?.values ?? [];
+  if (breadcrumbs.length <= 0) {
+    return null;
+  }
+
+  const meta = event._meta?.entries?.[breadcrumbEntryIndex]?.data?.values;
+
+  // The virtual crumb is a representation of this event, displayed alongside
+  // the rest of the breadcrumbs for more additional context.
+  const virtualCrumb = getVirtualCrumb(event);
+  let virtualCrumbIndex: number | undefined;
+  const allCrumbs = [...breadcrumbs];
+  if (virtualCrumb) {
+    virtualCrumbIndex = allCrumbs.length;
+    allCrumbs.push(virtualCrumb);
+  }
+
+  const filterOptions = getBreadcrumbFilters(allCrumbs);
+  const filteredCrumbs = allCrumbs.filter(bc =>
+    filterSet.size === 0 ? true : filterSet.has(bc.type)
+  );
+
+  const searchedCrumbs = applyBreadcrumbSearch(search, filteredCrumbs);
+
+  const hasFilters = filterSet.size > 0 || search.length > 0;
+
+  const actions = (
+    <ButtonBar gap={1}>
+      <Input
+        size="xs"
+        placeholder={t('Search')}
+        value={search}
+        onChange={e => setSearch(e.target.value)}
+      />
+      <CompactSelect
+        size="xs"
+        onChange={options => {
+          const newFilters = options.map(({value}) => value);
+          setFilterSet(new Set(newFilters));
+        }}
+        multiple
+        options={filterOptions}
+        maxMenuHeight={400}
+        trigger={(props, isOpen) => (
+          <DropdownButton
+            isOpen={isOpen}
+            size="xs"
+            icon={<IconFilter size="xs" />}
+            {...props}
+          >
+            {filterSet.size
+              ? tn('%s Active Filter', '%s Active Filters', filterSet.size)
+              : t('Filter')}
+          </DropdownButton>
+        )}
+      />
+      <CompactSelect
+        size="xs"
+        triggerProps={{
+          icon: <IconSort size="xs" />,
+        }}
+        onChange={selectedOption => {
+          setSort(selectedOption.value);
+        }}
+        value={sort}
+        options={BREADCRUMB_SORT_OPTIONS}
+      />
+      <CompactSelect
+        size="xs"
+        triggerProps={{
+          icon: <IconClock size="xs" />,
+        }}
+        onChange={selectedOption => {
+          setTimeDisplay(selectedOption.value);
+        }}
+        value={timeDisplay}
+        options={BREADCRUMB_TIME_DISPLAY_OPTIONS}
+      />
+    </ButtonBar>
+  );
+
+  return (
+    <EventDataSection
+      key="breadcrumbs"
+      type="breadcrmbs"
+      title={t('Breadcrumbs')}
+      actions={actions}
+      data-test-id="breadcrumbs-data-section"
+    >
+      <ErrorBoundary mini message={t('There was an error loading the event breadcrumbs')}>
+        {searchedCrumbs.length ? (
+          <ClippedBox clipHeight={250}>
+            <BreadcrumbsTimeline
+              breadcrumbs={searchedCrumbs}
+              virtualCrumbIndex={virtualCrumbIndex}
+              meta={meta}
+              sort={sort}
+              timeDisplay={timeDisplay}
+            />
+          </ClippedBox>
+        ) : (
+          <EmptyBreadcrumbsMessage>
+            {t('No breadcrumbs found. ')}
+            {hasFilters && (
+              <ClearFiltersButton
+                size="xs"
+                onClick={() => {
+                  setFilterSet(new Set());
+                  setSearch('');
+                }}
+              >
+                {t('Clear filters')}
+              </ClearFiltersButton>
+            )}
+          </EmptyBreadcrumbsMessage>
+        )}
+      </ErrorBoundary>
+    </EventDataSection>
+  );
+}
+
+const EmptyBreadcrumbsMessage = styled('div')`
+  border: 1px solid ${p => p.theme.border};
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  color: ${p => p.theme.subText};
+  border-radius: 4px;
+  padding: ${space(3)} ${space(1)};
+`;
+
+const ClearFiltersButton = styled(Button)`
+  margin-top: ${space(1)};
+`;

--- a/static/app/components/events/breadcrumbs/breadcrumbsDataSection.tsx
+++ b/static/app/components/events/breadcrumbs/breadcrumbsDataSection.tsx
@@ -1,9 +1,9 @@
 import {useState} from 'react';
 import styled from '@emotion/styled';
+import color from 'color';
 
 import {Button} from 'sentry/components/button';
 import ButtonBar from 'sentry/components/buttonBar';
-import ClippedBox from 'sentry/components/clippedBox';
 import {CompactSelect} from 'sentry/components/compactSelect';
 import DropdownButton from 'sentry/components/dropdownButton';
 import ErrorBoundary from 'sentry/components/errorBoundary';
@@ -21,6 +21,7 @@ import {
   BREADCRUMB_SORT_OPTIONS,
   BreadcrumbSort,
 } from 'sentry/components/events/interfaces/breadcrumbs';
+import {PANEL_INITIAL_HEIGHT} from 'sentry/components/events/interfaces/breadcrumbs/breadcrumbs';
 import {getVirtualCrumb} from 'sentry/components/events/interfaces/breadcrumbs/utils';
 import Input from 'sentry/components/input';
 import {IconClock, IconFilter, IconSort} from 'sentry/icons';
@@ -142,7 +143,7 @@ export default function BreadcrumbsDataSection({event}: BreadcrumbsDataSectionPr
     >
       <ErrorBoundary mini message={t('There was an error loading the event breadcrumbs')}>
         {searchedCrumbs.length ? (
-          <ClippedBox clipHeight={250}>
+          <ScrollBox>
             <BreadcrumbsTimeline
               breadcrumbs={searchedCrumbs}
               virtualCrumbIndex={virtualCrumbIndex}
@@ -150,7 +151,7 @@ export default function BreadcrumbsDataSection({event}: BreadcrumbsDataSectionPr
               sort={sort}
               timeDisplay={timeDisplay}
             />
-          </ClippedBox>
+          </ScrollBox>
         ) : (
           <EmptyBreadcrumbsMessage>
             {t('No breadcrumbs found. ')}
@@ -185,4 +186,30 @@ const EmptyBreadcrumbsMessage = styled('div')`
 
 const ClearFiltersButton = styled(Button)`
   margin-top: ${space(1)};
+`;
+
+const ScrollBox = styled('div')`
+  position: relative;
+  overflow-y: scroll;
+  resize: vertical;
+  max-height: ${PANEL_INITIAL_HEIGHT}px;
+  /* Unsets max-height when resized */
+  &[style*='height'] {
+    max-height: unset;
+  }
+  padding-right: ${space(2)};
+  &:after {
+    content: '';
+    position: sticky;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    height: 20px;
+    display: block;
+    background-image: linear-gradient(
+      to bottom,
+      ${p => color(p.theme.background).alpha(0.15).string()},
+      ${p => p.theme.background}
+    );
+  }
 `;

--- a/static/app/components/events/breadcrumbs/breadcrumbsDataSection.tsx
+++ b/static/app/components/events/breadcrumbs/breadcrumbsDataSection.tsx
@@ -1,4 +1,4 @@
-import {useState} from 'react';
+import {useMemo, useState} from 'react';
 import styled from '@emotion/styled';
 import color from 'color';
 
@@ -27,7 +27,8 @@ import Input from 'sentry/components/input';
 import {IconClock, IconFilter, IconSort} from 'sentry/icons';
 import {t, tn} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
-import {EntryType, type Event} from 'sentry/types';
+import type {RawCrumb} from 'sentry/types/breadcrumbs';
+import {EntryType, type Event} from 'sentry/types/event';
 import {useLocalStorageState} from 'sentry/utils/useLocalStorageState';
 
 interface BreadcrumbsDataSectionProps {
@@ -46,37 +47,44 @@ export default function BreadcrumbsDataSection({event}: BreadcrumbsDataSectionPr
     BreadcrumbTimeDisplay.RELATIVE
   );
 
-  const breadcrumbEntryIndex = event.entries.findIndex(
-    entry => entry.type === EntryType.BREADCRUMBS
+  const breadcrumbEntryIndex =
+    event.entries?.findIndex(entry => entry.type === EntryType.BREADCRUMBS) ?? -1;
+  const breadcrumbs: RawCrumb[] = useMemo(
+    () => event.entries?.[breadcrumbEntryIndex]?.data?.values ?? [],
+    [event, breadcrumbEntryIndex]
   );
-  if (!breadcrumbEntryIndex) {
-    return null;
-  }
-  const breadcrumbs = event.entries[breadcrumbEntryIndex]?.data?.values ?? [];
-  if (breadcrumbs.length <= 0) {
-    return null;
-  }
-
-  const meta = event._meta?.entries?.[breadcrumbEntryIndex]?.data?.values;
+  const allCrumbs = useMemo(() => [...breadcrumbs], [breadcrumbs]);
+  // Mapping of breadcrumb index -> breadcrumb meta
+  const meta: Record<number, any> =
+    event._meta?.entries?.[breadcrumbEntryIndex]?.data?.values;
 
   // The virtual crumb is a representation of this event, displayed alongside
   // the rest of the breadcrumbs for more additional context.
   const virtualCrumb = getVirtualCrumb(event);
   let virtualCrumbIndex: number | undefined;
-  const allCrumbs = [...breadcrumbs];
   if (virtualCrumb) {
     virtualCrumbIndex = allCrumbs.length;
     allCrumbs.push(virtualCrumb);
   }
 
-  const filterOptions = getBreadcrumbFilters(allCrumbs);
+  const filterOptions = useMemo(() => getBreadcrumbFilters(allCrumbs), [allCrumbs]);
   const filteredCrumbs = allCrumbs.filter(bc =>
     filterSet.size === 0 ? true : filterSet.has(bc.type)
   );
-
-  const searchedCrumbs = applyBreadcrumbSearch(search, filteredCrumbs);
+  const searchedCrumbs = useMemo(
+    () => applyBreadcrumbSearch(search, filteredCrumbs),
+    [search, filteredCrumbs]
+  );
 
   const hasFilters = filterSet.size > 0 || search.length > 0;
+
+  if (!breadcrumbEntryIndex) {
+    return null;
+  }
+
+  if (breadcrumbs.length <= 0) {
+    return null;
+  }
 
   const actions = (
     <ButtonBar gap={1}>

--- a/static/app/components/events/breadcrumbs/breadcrumbsTimeline.tsx
+++ b/static/app/components/events/breadcrumbs/breadcrumbsTimeline.tsx
@@ -1,0 +1,85 @@
+import {
+  BREADCRUMB_TIMESTAMP_PLACEHOLDER,
+  BreadcrumbTimeDisplay,
+  getBreadcrumbColorConfig,
+  getBreadcrumbIcon,
+  getBreadcrumbTitle,
+} from 'sentry/components/events/breadcrumbs/utils';
+import {BreadcrumbSort} from 'sentry/components/events/interfaces/breadcrumbs';
+import {convertCrumbType} from 'sentry/components/events/interfaces/breadcrumbs/utils';
+import {StructuredData} from 'sentry/components/structuredEventData';
+import Timeline from 'sentry/components/timeline';
+import type {RawCrumb} from 'sentry/types/breadcrumbs';
+import {defined} from 'sentry/utils';
+
+interface BreadcrumbsTimelineProps {
+  breadcrumbs: RawCrumb[];
+  meta?: Record<string, any>;
+  sort?: BreadcrumbSort;
+  timeDisplay?: BreadcrumbTimeDisplay;
+  virtualCrumbIndex?: number;
+}
+export default function BreadcrumbsTimeline({
+  breadcrumbs,
+  virtualCrumbIndex,
+  sort = BreadcrumbSort.NEWEST,
+  timeDisplay = BreadcrumbTimeDisplay.RELATIVE,
+  meta = {},
+}: BreadcrumbsTimelineProps) {
+  if (!breadcrumbs.length) {
+    return null;
+  }
+
+  const startTimestamp =
+    timeDisplay === BreadcrumbTimeDisplay.RELATIVE
+      ? breadcrumbs[breadcrumbs.length - 1].timestamp
+      : undefined;
+  const items = breadcrumbs.map((breadcrumb, i) => {
+    const bc = convertCrumbType(breadcrumb);
+    const bcMeta = meta[i];
+    const isVirtualCrumb = defined(virtualCrumbIndex) && i === virtualCrumbIndex;
+    return (
+      <Timeline.Item
+        key={i}
+        title={getBreadcrumbTitle(bc.category)}
+        colorConfig={getBreadcrumbColorConfig(bc.type)}
+        icon={getBreadcrumbIcon(bc.type)}
+        timeString={bc.timestamp ?? BREADCRUMB_TIMESTAMP_PLACEHOLDER}
+        startTimeString={startTimestamp}
+        // XXX: Only the virtual crumb can be marked as active for breadcrumbs
+        isActive={isVirtualCrumb ?? false}
+      >
+        {defined(bc.message) && (
+          <Timeline.Text>
+            <StructuredData
+              value={bc.message}
+              depth={0}
+              maxDefaultDepth={1}
+              meta={bcMeta?.message}
+              withAnnotatedText
+              withOnlyFormattedText
+            />
+          </Timeline.Text>
+        )}
+        {defined(bc.data) && (
+          <Timeline.Data>
+            <StructuredData
+              value={bc.data}
+              depth={0}
+              maxDefaultDepth={1}
+              meta={bcMeta?.data}
+              withAnnotatedText
+              withOnlyFormattedText
+            />
+          </Timeline.Data>
+        )}
+      </Timeline.Item>
+    );
+  });
+
+  return (
+    <Timeline.Container>
+      {sort === BreadcrumbSort.NEWEST ? items.reverse() : items}
+    </Timeline.Container>
+  );
+}

--- a/static/app/components/events/breadcrumbs/breadcrumbsTimeline.tsx
+++ b/static/app/components/events/breadcrumbs/breadcrumbsTimeline.tsx
@@ -1,8 +1,8 @@
 import {
   BREADCRUMB_TIMESTAMP_PLACEHOLDER,
+  BreadcrumbIcon,
   BreadcrumbTimeDisplay,
   getBreadcrumbColorConfig,
-  getBreadcrumbIcon,
   getBreadcrumbTitle,
 } from 'sentry/components/events/breadcrumbs/utils';
 import {BreadcrumbSort} from 'sentry/components/events/interfaces/breadcrumbs';
@@ -32,7 +32,7 @@ export default function BreadcrumbsTimeline({
 
   const startTimestamp =
     timeDisplay === BreadcrumbTimeDisplay.RELATIVE
-      ? breadcrumbs[breadcrumbs.length - 1].timestamp
+      ? breadcrumbs?.at(-1)?.timestamp
       : undefined;
   const items = breadcrumbs.map((breadcrumb, i) => {
     const bc = convertCrumbType(breadcrumb);
@@ -43,7 +43,7 @@ export default function BreadcrumbsTimeline({
         key={i}
         title={getBreadcrumbTitle(bc.category)}
         colorConfig={getBreadcrumbColorConfig(bc.type)}
-        icon={getBreadcrumbIcon(bc.type)}
+        icon={<BreadcrumbIcon type={bc.type} />}
         timeString={bc.timestamp ?? BREADCRUMB_TIMESTAMP_PLACEHOLDER}
         startTimeString={startTimestamp}
         // XXX: Only the virtual crumb can be marked as active for breadcrumbs

--- a/static/app/components/events/breadcrumbs/utils.tsx
+++ b/static/app/components/events/breadcrumbs/utils.tsx
@@ -1,0 +1,143 @@
+import styled from '@emotion/styled';
+
+import type {SelectOption} from 'sentry/components/compactSelect';
+import type * as Timeline from 'sentry/components/timeline';
+import {
+  IconCursorArrow,
+  IconFire,
+  IconFix,
+  IconInfo,
+  IconLocation,
+  IconMobile,
+  IconRefresh,
+  IconSort,
+  IconSpan,
+  IconStack,
+  IconTerminal,
+  IconUser,
+  IconWarning,
+} from 'sentry/icons';
+import {t} from 'sentry/locale';
+import {BreadcrumbType, type RawCrumb} from 'sentry/types/breadcrumbs';
+import {toTitleCase} from 'sentry/utils/string/toTitleCase';
+
+export const BREADCRUMB_TIMESTAMP_PLACEHOLDER = '--';
+const BREADCRUMB_TITLE_PLACEHOLDER = t('Generic');
+
+export enum BreadcrumbTimeDisplay {
+  RELATIVE = 'relative',
+  ABSOLUTE = 'absolute',
+}
+export const BREADCRUMB_TIME_DISPLAY_OPTIONS = [
+  {label: t('Relative'), value: BreadcrumbTimeDisplay.RELATIVE},
+  {label: t('Absolute'), value: BreadcrumbTimeDisplay.ABSOLUTE},
+];
+export const BREADCRUMB_TIME_DISPLAY_LOCALSTORAGE_KEY = 'event-breadcrumb-time-display';
+
+const Color = styled('span')<{colorConfig: Timeline.ColorConfig}>`
+  color: ${p => p.theme[p.colorConfig.primary]};
+`;
+
+export function applyBreadcrumbSearch(search: string, crumbs: RawCrumb[]): RawCrumb[] {
+  return crumbs.filter(
+    c =>
+      c.type.includes(search) ||
+      c.message?.includes(search) ||
+      c.category?.includes(search) ||
+      JSON.stringify(c.data).includes(search)
+  );
+}
+
+export function getBreadcrumbFilters(crumbs: RawCrumb[]) {
+  const uniqueCrumbTypes = crumbs.reduce((crumbTypeSet, crumb) => {
+    crumbTypeSet.add(crumb.type);
+    return crumbTypeSet;
+  }, new Set<BreadcrumbType>());
+
+  const filters: SelectOption<string>[] = [...uniqueCrumbTypes].map(crumbType => ({
+    value: crumbType,
+    leadingItems: (
+      <Color colorConfig={getBreadcrumbColorConfig(crumbType)}>
+        {getBreadcrumbIcon(crumbType)}
+      </Color>
+    ),
+    label: toTitleCase(crumbType),
+  }));
+
+  return filters;
+}
+
+export function getBreadcrumbTitle(category: RawCrumb['category']) {
+  switch (category) {
+    case 'http':
+      return t('HTTP');
+    case 'httplib':
+      return t('httplib');
+    case 'ui.click':
+      return t('UI Click');
+    case 'ui.input':
+      return t('UI Input');
+    case null:
+    case undefined:
+      return BREADCRUMB_TITLE_PLACEHOLDER;
+    default:
+      const titleCategory = category.split('.').join(' ');
+      return toTitleCase(titleCategory);
+  }
+}
+
+export function getBreadcrumbColorConfig(type?: BreadcrumbType): Timeline.ColorConfig {
+  switch (type) {
+    case BreadcrumbType.ERROR:
+      return {primary: 'red400', secondary: 'red200'};
+    case BreadcrumbType.WARNING:
+      return {primary: 'yellow400', secondary: 'yellow200'};
+    case BreadcrumbType.NAVIGATION:
+    case BreadcrumbType.HTTP:
+      return {primary: 'green400', secondary: 'green200'};
+    case BreadcrumbType.INFO:
+    case BreadcrumbType.QUERY:
+    case BreadcrumbType.UI:
+      return {primary: 'blue400', secondary: 'blue200'};
+    case BreadcrumbType.USER:
+    case BreadcrumbType.DEBUG:
+      return {primary: 'purple400', secondary: 'purple200'};
+    case BreadcrumbType.SYSTEM:
+    case BreadcrumbType.SESSION:
+    case BreadcrumbType.TRANSACTION:
+      return {primary: 'pink400', secondary: 'pink200'};
+    default:
+      return {primary: 'gray300', secondary: 'gray200'};
+  }
+}
+
+export function getBreadcrumbIcon(type?: BreadcrumbType): React.ReactNode {
+  switch (type) {
+    case BreadcrumbType.USER:
+      return <IconUser size="xs" />;
+    case BreadcrumbType.UI:
+      return <IconCursorArrow size="xs" />;
+    case BreadcrumbType.NAVIGATION:
+      return <IconLocation size="xs" />;
+    case BreadcrumbType.DEBUG:
+      return <IconFix size="xs" />;
+    case BreadcrumbType.INFO:
+      return <IconInfo size="xs" />;
+    case BreadcrumbType.ERROR:
+      return <IconFire size="xs" />;
+    case BreadcrumbType.HTTP:
+      return <IconSort size="xs" rotated />;
+    case BreadcrumbType.WARNING:
+      return <IconWarning size="xs" />;
+    case BreadcrumbType.QUERY:
+      return <IconStack size="xs" />;
+    case BreadcrumbType.SYSTEM:
+      return <IconMobile size="xs" />;
+    case BreadcrumbType.SESSION:
+      return <IconRefresh size="xs" />;
+    case BreadcrumbType.TRANSACTION:
+      return <IconSpan size="xs" />;
+    default:
+      return <IconTerminal size="xs" />;
+  }
+}

--- a/static/app/components/events/breadcrumbs/utils.tsx
+++ b/static/app/components/events/breadcrumbs/utils.tsx
@@ -39,12 +39,15 @@ const Color = styled('span')<{colorConfig: Timeline.ColorConfig}>`
 `;
 
 export function applyBreadcrumbSearch(search: string, crumbs: RawCrumb[]): RawCrumb[] {
+  if (search === '') {
+    return crumbs;
+  }
   return crumbs.filter(
     c =>
       c.type.includes(search) ||
       c.message?.includes(search) ||
       c.category?.includes(search) ||
-      JSON.stringify(c.data).includes(search)
+      (c.data && JSON.stringify(c.data)?.includes(search))
   );
 }
 

--- a/static/app/components/events/breadcrumbs/utils.tsx
+++ b/static/app/components/events/breadcrumbs/utils.tsx
@@ -24,7 +24,7 @@ import {toTitleCase} from 'sentry/utils/string/toTitleCase';
 export const BREADCRUMB_TIMESTAMP_PLACEHOLDER = '--';
 const BREADCRUMB_TITLE_PLACEHOLDER = t('Generic');
 
-export enum BreadcrumbTimeDisplay {
+export const enum BreadcrumbTimeDisplay {
   RELATIVE = 'relative',
   ABSOLUTE = 'absolute',
 }
@@ -58,7 +58,7 @@ export function getBreadcrumbFilters(crumbs: RawCrumb[]) {
     value: crumbType,
     leadingItems: (
       <Color colorConfig={getBreadcrumbColorConfig(crumbType)}>
-        {getBreadcrumbIcon(crumbType)}
+        <BreadcrumbIcon type={crumbType} />
       </Color>
     ),
     label: toTitleCase(crumbType),
@@ -111,8 +111,8 @@ export function getBreadcrumbColorConfig(type?: BreadcrumbType): Timeline.ColorC
   }
 }
 
-export function getBreadcrumbIcon(type?: BreadcrumbType): React.ReactNode {
-  switch (type) {
+export function BreadcrumbIcon(props: {type?: BreadcrumbType}) {
+  switch (props.type) {
     case BreadcrumbType.USER:
       return <IconUser size="xs" />;
     case BreadcrumbType.UI:

--- a/static/app/components/events/interfaces/breadcrumbs/breadcrumbs.tsx
+++ b/static/app/components/events/interfaces/breadcrumbs/breadcrumbs.tsx
@@ -25,7 +25,7 @@ import type {BreadcrumbProps} from './breadcrumb';
 import {Breadcrumb} from './breadcrumb';
 
 const PANEL_MIN_HEIGHT = 200;
-const PANEL_INITIAL_HEIGHT = 400;
+export const PANEL_INITIAL_HEIGHT = 400;
 
 const noop = () => void 0;
 

--- a/static/app/components/events/interfaces/breadcrumbs/index.tsx
+++ b/static/app/components/events/interfaces/breadcrumbs/index.tsx
@@ -37,14 +37,14 @@ type Props = {
   hideTitle?: boolean;
 };
 
-enum BreadcrumbSort {
+export enum BreadcrumbSort {
   NEWEST = 'newest',
   OLDEST = 'oldest',
 }
 
-const EVENT_BREADCRUMB_SORT_LOCALSTORAGE_KEY = 'event-breadcrumb-sort';
+export const BREADCRUMB_SORT_LOCALSTORAGE_KEY = 'event-breadcrumb-sort';
 
-const sortOptions = [
+export const BREADCRUMB_SORT_OPTIONS = [
   {label: t('Newest'), value: BreadcrumbSort.NEWEST},
   {label: t('Oldest'), value: BreadcrumbSort.OLDEST},
 ];
@@ -54,7 +54,7 @@ function BreadcrumbsContainer({data, event, organization, hideTitle = false}: Pr
   const [filterSelections, setFilterSelections] = useState<SelectOption<string>[]>([]);
   const [displayRelativeTime, setDisplayRelativeTime] = useState(false);
   const [sort, setSort] = useLocalStorageState<BreadcrumbSort>(
-    EVENT_BREADCRUMB_SORT_LOCALSTORAGE_KEY,
+    BREADCRUMB_SORT_LOCALSTORAGE_KEY,
     BreadcrumbSort.NEWEST
   );
 
@@ -301,7 +301,7 @@ function BreadcrumbsContainer({data, event, organization, hideTitle = false}: Pr
           setSort(selectedOption.value);
         }}
         value={sort}
-        options={sortOptions}
+        options={BREADCRUMB_SORT_OPTIONS}
       />
     </SearchAndSortWrapper>
   );

--- a/static/app/views/issueDetails/groupEventDetails/groupEventDetailsContent.tsx
+++ b/static/app/views/issueDetails/groupEventDetails/groupEventDetailsContent.tsx
@@ -3,6 +3,7 @@ import styled from '@emotion/styled';
 
 import {CommitRow} from 'sentry/components/commitRow';
 import ErrorBoundary from 'sentry/components/errorBoundary';
+import BreadcrumbsDataSection from 'sentry/components/events/breadcrumbs/breadcrumbsDataSection';
 import {EventContexts} from 'sentry/components/events/contexts';
 import {EventDevice} from 'sentry/components/events/device';
 import {EventAttachments} from 'sentry/components/events/eventAttachments';
@@ -37,6 +38,7 @@ import {DataSection} from 'sentry/components/events/styles';
 import {SuspectCommits} from 'sentry/components/events/suspectCommits';
 import {EventUserFeedback} from 'sentry/components/events/userFeedback';
 import LazyLoad from 'sentry/components/lazyLoad';
+import {useHasNewTimelineUI} from 'sentry/components/timeline/utils';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {
@@ -100,6 +102,7 @@ function DefaultGroupEventDetailsContent({
 }: Required<GroupEventDetailsContentProps>) {
   const organization = useOrganization();
   const location = useLocation();
+  const hasNewTimelineUI = useHasNewTimelineUI();
   const tagsRef = useRef<HTMLDivElement>(null);
 
   const projectSlug = project.slug;
@@ -218,7 +221,11 @@ function DefaultGroupEventDetailsContent({
       <GroupEventEntry entryType={EntryType.EXPECTCT} {...eventEntryProps} />
       <GroupEventEntry entryType={EntryType.EXPECTSTAPLE} {...eventEntryProps} />
       <GroupEventEntry entryType={EntryType.TEMPLATE} {...eventEntryProps} />
-      <GroupEventEntry entryType={EntryType.BREADCRUMBS} {...eventEntryProps} />
+      {hasNewTimelineUI ? (
+        <BreadcrumbsDataSection event={event} />
+      ) : (
+        <GroupEventEntry entryType={EntryType.BREADCRUMBS} {...eventEntryProps} />
+      )}
       {!showPossibleSolutionsHigher && (
         <ResourcesAndPossibleSolutionsIssueDetailsContent
           event={event}


### PR DESCRIPTION
This work is currently behind a flag and there are no SaaS orgs opted in, nor is it enabled for self-hosted.

There is a few changes to make in future PRs:
- Use new tanstack virtualized lists (if final design has inner scroll)
- Enrich known breadcrumbs (e.g. transactions, navigation, etc).
- Correct usage of colors/icons to match replays

Still a WIP UI, but feedback is welcome! Once this is merged, it can be inspected by adding an org to the `new-timeline-ui` flag, or setting `newTimeline=1` as a query param.

![image](https://github.com/getsentry/sentry/assets/35509934/06abc8f6-562c-4acb-b693-365b73998e96)

