### PR TITLE
chore(insights): Run Prettier on Insights settings files

### DIFF
--- a/static/app/views/performance/cache/settings.ts
+++ b/static/app/views/performance/cache/settings.ts
@@ -24,6 +24,8 @@ export const MODULE_DOC_LINK = 'https://docs.sentry.io/product/insights/caches/'
 
 export const ONBOARDING_CONTENT = {
   title: t('Make sure your application’s caching is behaving properly'),
-  description: t('We tell you if your application is hitting cache as often as expected and whether it’s delivering the anticipated performance improvements.'),
+  description: t(
+    'We tell you if your application is hitting cache as often as expected and whether it’s delivering the anticipated performance improvements.'
+  ),
   link: MODULE_DOC_LINK,
 };

--- a/static/app/views/performance/queues/settings.ts
+++ b/static/app/views/performance/queues/settings.ts
@@ -48,7 +48,9 @@ export const MODULE_DOC_LINK =
 
 export const ONBOARDING_CONTENT = {
   title: t('Make sure your jobs complete without errors'),
-  description: t('Track the behavior of background jobs at each step in their processing, allowing you to see whether jobs are completing on time and making it easy to debug when they are failing.'),
+  description: t(
+    'Track the behavior of background jobs at each step in their processing, allowing you to see whether jobs are completing on time and making it easy to debug when they are failing.'
+  ),
   link: MODULE_DOC_LINK,
 };
 


### PR DESCRIPTION
For some reason builds are failing on `master` with these changes. No idea how they slipped in.
