### PR TITLE
ref: have models.User extend Model instead of BaseModel

### DIFF
--- a/src/sentry/api/bases/user.py
+++ b/src/sentry/api/bases/user.py
@@ -102,7 +102,7 @@ class UserEndpoint(Endpoint):
     permission_classes: tuple[type[BasePermission], ...] = (UserPermission,)
 
     @override
-    def convert_args(self, request: Request, user_id: str | None = None, *args, **kwargs):
+    def convert_args(self, request: Request, user_id: int | str | None = None, *args, **kwargs):
         if user_id == "me":
             if not request.user.is_authenticated:
                 raise ResourceDoesNotExist

--- a/src/sentry/api/endpoints/api_tokens.py
+++ b/src/sentry/api/endpoints/api_tokens.py
@@ -39,7 +39,7 @@ class ApiTokensEndpoint(Endpoint):
     permission_classes = (IsAuthenticated,)
 
     @classmethod
-    def _get_appropriate_user_id(cls, request: Request) -> str:
+    def _get_appropriate_user_id(cls, request: Request) -> int:
         """
         Gets the user id to use for the request, based on what the current state of the request is.
         If the request is made by a superuser, then they are allowed to act on behalf of other user's data.
@@ -54,7 +54,7 @@ class ApiTokensEndpoint(Endpoint):
         if has_elevated_mode(request):
             datastore = request.GET if request.GET else request.data
             # If a userId override is not found, use the id for the user who made the request
-            user_id = datastore.get("userId", user_id)
+            user_id = int(datastore.get("userId", user_id))
 
         return user_id
 

--- a/src/sentry/models/user.py
+++ b/src/sentry/models/user.py
@@ -31,13 +31,7 @@ from sentry.backup.dependencies import (
 from sentry.backup.helpers import ImportFlags
 from sentry.backup.sanitize import SanitizableField, Sanitizer
 from sentry.backup.scopes import ImportScope, RelocationScope
-from sentry.db.models import (
-    BaseManager,
-    BaseModel,
-    BoundedBigAutoField,
-    control_silo_model,
-    sane_repr,
-)
+from sentry.db.models import BaseManager, Model, control_silo_model, sane_repr
 from sentry.db.models.utils import unique_db_instance
 from sentry.db.postgres.transactions import enforce_constraints
 from sentry.integrations.types import EXTERNAL_PROVIDERS, ExternalProviders
@@ -94,13 +88,12 @@ class UserManager(BaseManager["User"], DjangoUserManager["User"]):
 
 
 @control_silo_model
-class User(BaseModel, AbstractBaseUser):
+class User(Model, AbstractBaseUser):
     __relocation_scope__ = RelocationScope.User
     __relocation_custom_ordinal__ = ["username"]
 
     replication_version: int = 2
 
-    id = BoundedBigAutoField(primary_key=True)
     username = models.CharField(_("username"), max_length=MAX_USERNAME_LENGTH, unique=True)
     # this column is called first_name for legacy reasons, but it is the entire
     # display name
@@ -368,7 +361,7 @@ class User(BaseModel, AbstractBaseUser):
             with enforce_constraints(
                 transaction.atomic(using=router.db_for_write(OrganizationMemberMapping))
             ):
-                control_side_org_models: tuple[type[BaseModel], ...] = (
+                control_side_org_models: tuple[type[Model], ...] = (
                     OrgAuthToken,
                     OrganizationMemberMapping,
                 )
@@ -383,7 +376,7 @@ class User(BaseModel, AbstractBaseUser):
         # While it would be nice to make the following changes in a transaction, there are too many
         # unique constraints to make this feasible. Instead, we just do it sequentially and ignore
         # the `IntegrityError`s.
-        user_related_models: tuple[type[BaseModel], ...] = (
+        user_related_models: tuple[type[Model], ...] = (
             Authenticator,
             Identity,
             UserAvatar,

--- a/src/sentry/tasks/summaries/weekly_reports.py
+++ b/src/sentry/tasks/summaries/weekly_reports.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import heapq
 import logging
 import uuid
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from datetime import timedelta
 from functools import partial
@@ -452,7 +452,7 @@ def get_group_status_badge(group: Group) -> tuple[str, str, str]:
     return ("Ongoing", "rgba(219, 214, 225, 1)", "rgba(219, 214, 225, 1)")
 
 
-def render_template_context(ctx, user_id):
+def render_template_context(ctx, user_id: int | None) -> dict[str, Any] | None:
     # Serialize ctx for template, and calculate view parameters (like graph bar heights)
     # Fetch the list of projects associated with the user.
     # Projects owned by teams that the user has membership of.
@@ -748,7 +748,7 @@ def render_template_context(ctx, user_id):
 
 
 def prepare_template_context(
-    ctx: OrganizationReportContext, user_ids: list[int]
+    ctx: OrganizationReportContext, user_ids: Sequence[int | None]
 ) -> list[Mapping[str, Any]] | list:
     user_template_context_by_user_id_list = []
     for user_id in user_ids:


### PR DESCRIPTION
most of our db helpers expected .id to be a Field[int, int] and use Model as the type for that

no migration was generated so I believe this to be a fancy noop

<!-- Describe your PR here. -->