### PR TITLE
fix(replay): ensure console data arguments is an array

### DIFF
--- a/static/app/views/replays/detail/console/useConsoleFilters.tsx
+++ b/static/app/views/replays/detail/console/useConsoleFilters.tsx
@@ -43,9 +43,10 @@ const FILTERS = {
   logLevel: (item: BreadcrumbFrame, logLevel: string[]) =>
     logLevel.length === 0 || logLevel.includes(getFilterableField(item) ?? ''),
   searchTerm: (item: BreadcrumbFrame, searchTerm: string) =>
-    [item.message ?? '', ...((item as ConsoleFrame).data?.arguments ?? [])].some(val =>
-      JSON.stringify(val).toLowerCase().includes(searchTerm)
-    ),
+    [
+      item.message ?? '',
+      ...Array.from((item as ConsoleFrame).data?.arguments ?? []),
+    ].some(val => JSON.stringify(val).toLowerCase().includes(searchTerm)),
 };
 
 function sortBySeverity(a: string, b: string) {


### PR DESCRIPTION
fixes JAVASCRIPT-2TH8 
fixes JAVASCRIPT-2TJY
fixes JAVASCRIPT-2TDK

not sure how, but this org had `frame.data.arguments` as an object type instead of an array, which was breaking types. this is kind of a special case, but fixes their error and allows them to see the console tab on replays. Since `frame.data.arguments` is supposed to be an array, the `Array.from` doesn't change anything and this'll still work for everyone else.