### PR TITLE
chore(slack): add fixture to mock chat.postMessage calls

### DIFF
--- a/src/sentry/integrations/slack/utils/notifications.py
+++ b/src/sentry/integrations/slack/utils/notifications.py
@@ -175,7 +175,7 @@ def send_slack_response(
         "slack.send_slack_response",
         extra={
             "integration_id": integration.id,
-            "response_url": params.get("response_url"),
+            "response_url": params.get("response_url", "None"),
             "payload": payload,
         },
     )

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -49,6 +49,7 @@ from sentry_kafka_schemas.schema_types.uptime_results_v1 import (
     CheckResult,
 )
 from sentry_relay.consts import SPAN_STATUS_NAME_TO_CODE
+from slack_sdk.web import SlackResponse
 from snuba_sdk import Granularity, Limit, Offset
 from snuba_sdk.conditions import BooleanCondition, Condition, ConditionGroup
 
@@ -2886,6 +2887,22 @@ class SlackActivityNotificationTest(ActivityTestCase):
     @pytest.fixture(autouse=True)
     def responses_context(self):
         with responses.mock:
+            yield
+
+    @pytest.fixture(autouse=True)
+    def mock_chat_postMessage(self):
+        with mock.patch(
+            "slack_sdk.web.client.WebClient.chat_postMessage",
+            return_value=SlackResponse(
+                client=None,
+                http_verb="POST",
+                api_url="https://slack.com/api/chat.postMessage",
+                req_args={},
+                data={"ok": True},
+                headers={},
+                status_code=200,
+            ),
+        ) as self.mock_post:
             yield
 
     def assert_performance_issue_attachments(


### PR DESCRIPTION
Pulling this out from https://github.com/getsentry/sentry/pull/72863 to make my life easier.

With the new Slack SDK client we can no longer rely on the `responses` library to mock responses since the Slack SDK uses `urllib`. I'm adding a fixture to `ActivityTestCase` (used in the majority of test cases for Slack blocks) that mocks the return value for `WebClient.chat_postMessage`. This way, subclasses of `ActivityTestCase` won't have broken tests -- this is also useful in getsentry.