### PR TITLE
style(replays): align left and right side of replay details

### DIFF
--- a/static/app/components/replays/replayView.tsx
+++ b/static/app/components/replays/replayView.tsx
@@ -87,7 +87,7 @@ const PlayerContainer = styled('div')`
   display: grid;
   grid-auto-flow: row;
   grid-template-rows: auto 1fr;
-  gap: ${space(1)};
+  gap: 10px;
   flex-grow: 1;
 `;
 


### PR DESCRIPTION
fixes [#71569](https://github.com/getsentry/sentry/issues/71569)
<img width="787" alt="SCR-20240618-nikv" src="https://github.com/getsentry/sentry/assets/56095982/c1647cc8-68d6-4ed9-9bad-737d0894a0f4">
