### PR TITLE
chore(insights): Add CODEOWNERS entry

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -273,7 +273,7 @@ static/app/components/events/eventStatisticalDetector/                    @getse
 /src/sentry/api/endpoints/organization_traces.py                                    @getsentry/performance
 /tests/sentry/api/endpoints/test_organization_traces.py                             @getsentry/performance
 
-/static/app/views/starfish/                                                         @getsentry/performance
+/static/app/views/insights/                                                         @getsentry/performance
 ## Endof Performance
 
 


### PR DESCRIPTION
`/starfish/` is gone, replaced with `/insights/`
