### PR TITLE
ref(snql): Add arg count to exception message

### DIFF
--- a/src/sentry/search/events/fields.py
+++ b/src/sentry/search/events/fields.py
@@ -1455,14 +1455,16 @@ class DiscoverFunction:
         if args_count != total_args_count:
             required_args_count = self.required_args_count
             if required_args_count == total_args_count:
-                raise InvalidSearchQuery(f"{field}: expected {total_args_count:g} argument(s)")
+                raise InvalidSearchQuery(
+                    f"{field}: expected {total_args_count:g} argument(s) but got {args_count:g} argument(s)"
+                )
             elif args_count < required_args_count:
                 raise InvalidSearchQuery(
-                    f"{field}: expected at least {required_args_count:g} argument(s)"
+                    f"{field}: expected at least {required_args_count:g} argument(s) but got {args_count:g} argument(s)"
                 )
             elif args_count > total_args_count:
                 raise InvalidSearchQuery(
-                    f"{field}: expected at most {total_args_count:g} argument(s)"
+                    f"{field}: expected at most {total_args_count:g} argument(s) but got {args_count:g} argument(s)"
                 )
 
     def validate_result_type(self, result_type):

--- a/tests/sentry/data_export/endpoints/test_data_export.py
+++ b/tests/sentry/data_export/endpoints/test_data_export.py
@@ -177,7 +177,9 @@ class DataExportTest(APITestCase):
         payload = self.make_payload("discover", {"field": ["min()"]})
         with self.feature("organizations:discover-query"):
             response = self.get_error_response(self.org.slug, status_code=400, **payload)
-        assert response.data == {"non_field_errors": ["min: expected 1 argument(s)"]}
+        assert response.data == {
+            "non_field_errors": ["min: expected 1 argument(s) but got 0 argument(s)"]
+        }
 
     @freeze_time("2020-02-27 12:07:37")
     def test_export_invalid_date_params(self):

--- a/tests/sentry/incidents/endpoints/test_serializers.py
+++ b/tests/sentry/incidents/endpoints/test_serializers.py
@@ -235,12 +235,13 @@ class TestAlertRuleSerializer(TestAlertRuleSerializerBase):
             {"aggregate": "count_unique(123, hello)"},
             {
                 "aggregate": [
-                    "Invalid Metric: count_unique(123, hello): expected at most 1 argument(s)"
+                    "Invalid Metric: count_unique(123, hello): expected at most 1 argument(s) but got 2 argument(s)"
                 ]
             },
         )
         self.run_fail_validation_test(
-            {"aggregate": "max()"}, {"aggregate": ["Invalid Metric: max(): expected 1 argument(s)"]}
+            {"aggregate": "max()"},
+            {"aggregate": ["Invalid Metric: max(): expected 1 argument(s) but got 0 argument(s)"]},
         )
         aggregate = "count_unique(tags[sentry:user])"
         base_params = self.valid_params.copy()

--- a/tests/sentry/search/events/test_filter.py
+++ b/tests/sentry/search/events/test_filter.py
@@ -101,13 +101,15 @@ class DiscoverFunctionTest(unittest.TestCase):
 
     def test_no_optional_not_enough_arguments(self):
         with pytest.raises(
-            InvalidSearchQuery, match=r"fn_wo_optionals\(\): expected 2 argument\(s\)"
+            InvalidSearchQuery,
+            match=r"fn_wo_optionals\(\): expected 2 argument\(s\) but got 1 argument\(s\)",
         ):
             self.fn_wo_optionals.validate_argument_count("fn_wo_optionals()", ["arg1"])
 
     def test_no_optional_too_may_arguments(self):
         with pytest.raises(
-            InvalidSearchQuery, match=r"fn_wo_optionals\(\): expected 2 argument\(s\)"
+            InvalidSearchQuery,
+            match=r"fn_wo_optionals\(\): expected 2 argument\(s\) but got 3 argument\(s\)",
         ):
             self.fn_wo_optionals.validate_argument_count(
                 "fn_wo_optionals()", ["arg1", "arg2", "arg3"]
@@ -120,13 +122,15 @@ class DiscoverFunctionTest(unittest.TestCase):
 
     def test_optional_not_enough_arguments(self):
         with pytest.raises(
-            InvalidSearchQuery, match=r"fn_w_optionals\(\): expected at least 1 argument\(s\)"
+            InvalidSearchQuery,
+            match=r"fn_w_optionals\(\): expected at least 1 argument\(s\) but got 0 argument\(s\)",
         ):
             self.fn_w_optionals.validate_argument_count("fn_w_optionals()", [])
 
     def test_optional_too_many_arguments(self):
         with pytest.raises(
-            InvalidSearchQuery, match=r"fn_w_optionals\(\): expected at most 2 argument\(s\)"
+            InvalidSearchQuery,
+            match=r"fn_w_optionals\(\): expected at most 2 argument\(s\) but got 3 argument\(s\)",
         ):
             self.fn_w_optionals.validate_argument_count(
                 "fn_w_optionals()", ["arg1", "arg2", "arg3"]


### PR DESCRIPTION
Add the actual arg count to the raised exception of `validate_argument_count`.