### PR TITLE
Remove organization auth tokens alert

### DIFF
--- a/static/app/views/settings/account/apiTokens.spec.tsx
+++ b/static/app/views/settings/account/apiTokens.spec.tsx
@@ -1,5 +1,4 @@
 import {ApiTokenFixture} from 'sentry-fixture/apiToken';
-import {OrganizationFixture} from 'sentry-fixture/organization';
 
 import {
   render,
@@ -9,8 +8,6 @@ import {
 } from 'sentry-test/reactTestingLibrary';
 
 import {ApiTokens} from 'sentry/views/settings/account/apiTokens';
-
-const organization = OrganizationFixture();
 
 describe('ApiTokens', function () {
   beforeEach(function () {
@@ -23,7 +20,7 @@ describe('ApiTokens', function () {
       body: null,
     });
 
-    render(<ApiTokens organization={organization} />);
+    render(<ApiTokens />);
   });
 
   it('renders with result', function () {
@@ -32,7 +29,7 @@ describe('ApiTokens', function () {
       body: [ApiTokenFixture()],
     });
 
-    render(<ApiTokens organization={organization} />);
+    render(<ApiTokens />);
   });
 
   it('can delete token', async function () {
@@ -47,7 +44,7 @@ describe('ApiTokens', function () {
     });
     expect(mock).not.toHaveBeenCalled();
 
-    render(<ApiTokens organization={organization} />);
+    render(<ApiTokens />);
     renderGlobalModal();
 
     await userEvent.click(screen.getByRole('button', {name: 'Remove'}));

--- a/static/app/views/settings/account/apiTokens.tsx
+++ b/static/app/views/settings/account/apiTokens.tsx
@@ -3,7 +3,6 @@ import {
   addLoadingMessage,
   addSuccessMessage,
 } from 'sentry/actionCreators/indicator';
-import AlertLink from 'sentry/components/alertLink';
 import {Button} from 'sentry/components/button';
 import EmptyMessage from 'sentry/components/emptyMessage';
 import ExternalLink from 'sentry/components/links/externalLink';
@@ -11,16 +10,13 @@ import Panel from 'sentry/components/panels/panel';
 import PanelBody from 'sentry/components/panels/panelBody';
 import PanelHeader from 'sentry/components/panels/panelHeader';
 import {t, tct} from 'sentry/locale';
-import type {InternalAppApiToken, Organization} from 'sentry/types';
-import withOrganization from 'sentry/utils/withOrganization';
+import type {InternalAppApiToken} from 'sentry/types';
 import DeprecatedAsyncView from 'sentry/views/deprecatedAsyncView';
 import ApiTokenRow from 'sentry/views/settings/account/apiTokenRow';
 import SettingsPageHeader from 'sentry/views/settings/components/settingsPageHeader';
 import TextBlock from 'sentry/views/settings/components/text/textBlock';
 
-type Props = {
-  organization: Organization;
-} & DeprecatedAsyncView['props'];
+type Props = DeprecatedAsyncView['props'];
 
 type State = {
   tokenList: InternalAppApiToken[] | null;
@@ -69,7 +65,6 @@ export class ApiTokens extends DeprecatedAsyncView<Props, State> {
   };
 
   renderBody() {
-    const {organization} = this.props;
     const {tokenList} = this.state;
 
     const isEmpty = !Array.isArray(tokenList) || tokenList.length === 0;
@@ -125,4 +120,4 @@ export class ApiTokens extends DeprecatedAsyncView<Props, State> {
   }
 }
 
-export default withOrganization(ApiTokens);
+export default ApiTokens;

--- a/static/app/views/settings/account/apiTokens.tsx
+++ b/static/app/views/settings/account/apiTokens.tsx
@@ -88,11 +88,6 @@ export class ApiTokens extends DeprecatedAsyncView<Props, State> {
     return (
       <div>
         <SettingsPageHeader title={this.getTitle()} action={action} />
-        <AlertLink to={`/settings/${organization?.slug ?? ''}/auth-tokens/`}>
-          {t(
-            "User Auth Tokens are tied to the logged in user, meaning they'll stop working if the user leaves the organization! We suggest using Organization Auth Tokens to create/manage tokens tied to the organization instead."
-          )}
-        </AlertLink>
         <TextBlock>
           {t(
             "Authentication tokens allow you to perform actions against the Sentry API on behalf of your account. They're the easiest way to get started using the API."


### PR DESCRIPTION
Organization auth tokens currently only support the `org:ci` scope. We can't suggest using them for anything else. Hence, I removed the alert, which only adds confusion.