### PR TITLE
fix(metrics): remove superfluous deserialization in metrics extraction rules endpoint

### DIFF
--- a/src/sentry/api/endpoints/project_metrics_extraction_rules.py
+++ b/src/sentry/api/endpoints/project_metrics_extraction_rules.py
@@ -47,7 +47,7 @@ class ProjectMetricsExtractionRulesEndpoint(ProjectEndpoint):
             return Response(status=204)
 
         try:
-            state_update = self._generated_deleted_rule_objects(rules_update)
+            state_update = self._generate_deleted_rule_objects(rules_update)
             delete_metrics_extraction_rules(project, state_update)
         except Exception as e:
             return Response(status=500, data={"detail": str(e)})
@@ -130,7 +130,7 @@ class ProjectMetricsExtractionRulesEndpoint(ProjectEndpoint):
 
         return state_update
 
-    def _generated_deleted_rule_objects(
+    def _generate_deleted_rule_objects(
         self, updated_rules: list[dict[str, Any]]
     ) -> Sequence[MetricsExtractionRule]:
         state_update = []

--- a/src/sentry/api/endpoints/project_metrics_extraction_rules.py
+++ b/src/sentry/api/endpoints/project_metrics_extraction_rules.py
@@ -42,7 +42,7 @@ class ProjectMetricsExtractionRulesEndpoint(ProjectEndpoint):
         if not self.has_feature(project.organization, request):
             return Response(status=404)
 
-        rules_update = request.data.get("metricsExtractionRules") or ""
+        rules_update = request.data.get("metricsExtractionRules") or []
         if len(rules_update) == 0:
             return Response(status=204)
 


### PR DESCRIPTION
I was lacking some knowledge about the functionality of the testing framework with respect to the payload format, causing the tests to check the wrong thing. This PR fixes the HTTP 400 errors that are currently occurring when trying to POST/PUT/DELETE to the endpoint by removing the double deserialization that was previously done. 