### PR TITLE
chore(hybridcloud) Remove the customer-domains feature

### DIFF
--- a/src/sentry/api/serializers/models/organization.py
+++ b/src/sentry/api/serializers/models/organization.py
@@ -22,7 +22,6 @@ from sentry.api.serializers.models.role import (
 from sentry.api.serializers.models.team import TeamSerializerResponse
 from sentry.api.serializers.types import OrganizationSerializerResponse
 from sentry.api.utils import generate_organization_url, generate_region_url
-from sentry.app import env
 from sentry.auth.access import Access
 from sentry.constants import (
     ACCOUNT_RATE_LIMIT_DEFAULT,
@@ -63,7 +62,6 @@ from sentry.models.user import User
 from sentry.services.hybrid_cloud.auth import RpcOrganizationAuthConfig, auth_service
 from sentry.services.hybrid_cloud.organization import RpcOrganizationSummary
 from sentry.services.hybrid_cloud.user.service import user_service
-from sentry.utils.http import is_using_customer_domain
 
 _ORGANIZATION_SCOPE_PREFIX = "organizations:"
 
@@ -300,12 +298,6 @@ class OrganizationSerializer(Serializer):
             feature_set.add("open-membership")
         if not getattr(obj.flags, "disable_shared_issues"):
             feature_set.add("shared-issues")
-        request = env.request
-        if request and is_using_customer_domain(request):
-            # If the current request is using a customer domain, then we activate the feature for this organization.
-            # TODO(hybridcloud) This needs to be removed alongside the customer-domain feature
-            feature_set.add("customer-domains")
-
         if "dynamic-sampling" not in feature_set and "mep-rollout-flag" in feature_set:
             feature_set.remove("mep-rollout-flag")
 

--- a/src/sentry/features/permanent.py
+++ b/src/sentry/features/permanent.py
@@ -104,8 +104,6 @@ def register_permanent_features(manager: FeatureManager):
         "organizations:on-demand-metrics-prefill": False,
         # Metrics: Enable ingestion and storage of custom metrics. See custom-metrics for UI.
         "organizations:custom-metrics": False,
-        # Enable usage of customer domains on the frontend
-        "organizations:customer-domains": False,
         # Prefix host with organization ID when giving users DSNs (can be
         # customized with SENTRY_ORG_SUBDOMAIN_TEMPLATE) eg. o123.ingest.us.sentry.io
         "organizations:org-ingest-subdomains": False,
@@ -134,5 +132,5 @@ def register_permanent_features(manager: FeatureManager):
             project_feature, ProjectFeature, FeatureHandlerStrategy.INTERNAL, default=default
         )
 
-    # Enable support for multiple regions, and org slug subdomains.
+    # Enable support for multiple regions, and org slug subdomains (customer-domains).
     manager.add("system:multi-region", SystemFeature, default=False)

--- a/src/sentry/middleware/customer_domain.py
+++ b/src/sentry/middleware/customer_domain.py
@@ -10,6 +10,7 @@ from django.http.request import HttpRequest
 from django.http.response import HttpResponseBase
 from django.urls import resolve, reverse
 
+from sentry import features
 from sentry.api.utils import generate_organization_url
 from sentry.services.hybrid_cloud.organization import organization_service
 from sentry.types.region import subdomain_is_region
@@ -88,7 +89,7 @@ class CustomerDomainMiddleware:
     def __call__(self, request: HttpRequest) -> HttpResponseBase:
         if (
             request.method != "GET"
-            or not getattr(settings, "SENTRY_USE_CUSTOMER_DOMAINS", False)
+            or not features.has("system:multi-region")
             or not hasattr(request, "subdomain")
         ):
             return self.get_response(request)

--- a/src/sentry/web/client_config.py
+++ b/src/sentry/web/client_config.py
@@ -223,10 +223,6 @@ class _ClientConfig:
             yield "relocation:enabled"
         if features.has("system:multi-region"):
             yield "system:multi-region"
-        if self.customer_domain or (
-            self.last_org and features.has("organizations:customer-domains", self.last_org)
-        ):
-            yield "organizations:customer-domains"
 
     @property
     def needs_upgrade(self) -> bool:

--- a/static/app/routes.spec.tsx
+++ b/static/app/routes.spec.tsx
@@ -75,7 +75,7 @@ function extractRoutes(rootRoute: any): Record<string, RouteComponent> {
 }
 
 describe('buildRoutes()', function () {
-  // Until customer-domains is mainlined and path
+  // Until customer-domains is enabled for single-tenant, self-hosted and path
   // based slug routes are removed we need to ensure
   // that each orgId route also has slugless path.
   test('orgId routes also have domain routes', function () {

--- a/tests/sentry/api/endpoints/test_organization_details.py
+++ b/tests/sentry/api/endpoints/test_organization_details.py
@@ -97,7 +97,6 @@ class OrganizationDetailsTest(OrganizationDetailsTestBase):
         assert response.data["orgRole"] == "owner"
         assert len(response.data["teams"]) == 0
         assert len(response.data["projects"]) == 0
-        assert "customer-domains" not in response.data["features"]
 
     def test_include_feature_flag_query_param(self):
         response = self.get_success_response(
@@ -126,7 +125,6 @@ class OrganizationDetailsTest(OrganizationDetailsTestBase):
         assert response.data["orgRole"] == "owner"
         assert len(response.data["teams"]) == 0
         assert len(response.data["projects"]) == 0
-        assert "customer-domains" in response.data["features"]
 
         with self.feature({"system:multi-region": False}):
             HTTP_HOST = f"{self.organization.slug}.testserver"
@@ -135,7 +133,6 @@ class OrganizationDetailsTest(OrganizationDetailsTestBase):
                 extra_headers={"HTTP_HOST": HTTP_HOST},
                 qs_params={"include_feature_flags": 1},
             )
-            assert "customer-domains" in response.data["features"]
 
     def test_org_mismatch_customer_domain(self):
         HTTP_HOST = f"{self.organization.slug}-apples.testserver"

--- a/tests/sentry/middleware/test_customer_domain.py
+++ b/tests/sentry/middleware/test_customer_domain.py
@@ -25,8 +25,8 @@ def _session(d: dict[str, str]) -> SessionBase:
 
 
 @all_silo_test(regions=create_test_regions("us", "eu"))
-@override_settings(SENTRY_USE_CUSTOMER_DOMAINS=True)
 class CustomerDomainMiddlewareTest(TestCase):
+    @with_feature("system:multi-region")
     def test_sets_active_organization_if_exists(self):
         self.create_organization(name="test")
 
@@ -39,8 +39,7 @@ class CustomerDomainMiddlewareTest(TestCase):
         assert response == mock.sentinel.response
 
     def test_noop_if_customer_domain_is_off(self):
-
-        with self.settings(SENTRY_USE_CUSTOMER_DOMAINS=False):
+        with self.feature({"system:multi-region": False}):
             self.create_organization(name="test")
 
             request = RequestFactory().get("/")
@@ -51,6 +50,7 @@ class CustomerDomainMiddlewareTest(TestCase):
             assert dict(request.session) == {"activeorg": "albertos-apples"}
             assert response == mock.sentinel.response
 
+    @with_feature("system:multi-region")
     def test_recycles_last_active_org(self):
         self.create_organization(name="test")
 
@@ -63,6 +63,7 @@ class CustomerDomainMiddlewareTest(TestCase):
         assert response.status_code == 302
         assert response["Location"] == "http://test.testserver/organizations/test/issues/"
 
+    @with_feature("system:multi-region")
     def test_recycles_last_active_org_path_mismatch(self):
         self.create_organization(name="test")
 
@@ -75,6 +76,7 @@ class CustomerDomainMiddlewareTest(TestCase):
         assert response.status_code == 302
         assert response["Location"] == "http://test.testserver/organizations/test/issues/"
 
+    @with_feature("system:multi-region")
     def test_removes_active_organization(self):
         request = RequestFactory().get("/")
         request.subdomain = "does-not-exist"
@@ -84,6 +86,7 @@ class CustomerDomainMiddlewareTest(TestCase):
         assert dict(request.session) == {}
         assert response == mock.sentinel.response
 
+    @with_feature("system:multi-region")
     def test_no_session_dict(self):
         request = RequestFactory().get("/")
         request.subdomain = "test"
@@ -99,6 +102,7 @@ class CustomerDomainMiddlewareTest(TestCase):
         assert not hasattr(request, "session")
         assert response == mock.sentinel.response
 
+    @with_feature("system:multi-region")
     def test_no_subdomain(self):
         request = RequestFactory().get("/")
         request.session = _session({"activeorg": "test"})
@@ -107,6 +111,7 @@ class CustomerDomainMiddlewareTest(TestCase):
         assert dict(request.session) == {"activeorg": "test"}
         assert response == mock.sentinel.response
 
+    @with_feature("system:multi-region")
     def test_no_activeorg(self):
         request = RequestFactory().get("/")
         request.session = _session({})
@@ -115,6 +120,7 @@ class CustomerDomainMiddlewareTest(TestCase):
         assert dict(request.session) == {}
         assert response == mock.sentinel.response
 
+    @with_feature("system:multi-region")
     def test_no_op(self):
         request = RequestFactory().get("/")
         response = CustomerDomainMiddleware(lambda request: mock.sentinel.response)(request)
@@ -123,6 +129,7 @@ class CustomerDomainMiddlewareTest(TestCase):
         assert not hasattr(request, "subdomain")
         assert response == mock.sentinel.response
 
+    @with_feature("system:multi-region")
     def test_ignores_region_subdomains(self):
         for region_name in ("us", "eu"):
             request = RequestFactory().get("/")
@@ -133,6 +140,7 @@ class CustomerDomainMiddlewareTest(TestCase):
             assert dict(request.session) == {"activeorg": "test"}
             assert response == mock.sentinel.response
 
+    @with_feature("system:multi-region")
     def test_handles_redirects(self):
         self.create_organization(name="sentry")
         request = RequestFactory().get("/organizations/albertos-apples/issues/")
@@ -232,13 +240,13 @@ def provision_middleware():
 @override_settings(
     ROOT_URLCONF=__name__,
     SENTRY_SELF_HOSTED=False,
-    SENTRY_USE_CUSTOMER_DOMAINS=True,
 )
 class End2EndTest(APITestCase):
     def setUp(self):
         super().setUp()
         self.middleware = provision_middleware()
 
+    @with_feature("system:multi-region")
     def test_with_middleware_no_customer_domain(self):
         self.create_organization(name="albertos-apples")
 
@@ -315,6 +323,7 @@ class End2EndTest(APITestCase):
             assert "activeorg" in self.client.session
             assert self.client.session["activeorg"] == "test"
 
+    @with_feature("system:multi-region")
     def test_with_middleware_and_customer_domain(self):
         self.create_organization(name="albertos-apples")
 
@@ -426,6 +435,7 @@ class End2EndTest(APITestCase):
             assert response.status_code == 200
             assert response.redirect_chain == []
 
+    @with_feature("system:multi-region")
     def test_with_middleware_and_non_staff(self):
         self.create_organization(name="albertos-apples")
         non_staff_user = self.create_user(is_staff=False)
@@ -473,6 +483,7 @@ class End2EndTest(APITestCase):
             )
             assert response.status_code == 405
 
+    @with_feature("system:multi-region")
     def test_with_middleware_and_is_staff(self):
         self.create_organization(name="albertos-apples")
         is_staff_user = self.create_user(is_staff=True)
@@ -494,6 +505,7 @@ class End2EndTest(APITestCase):
             assert "activeorg" in self.client.session
             assert self.client.session["activeorg"] == "albertos-apples"
 
+    @with_feature("system:multi-region")
     def test_without_middleware(self):
         self.create_organization(name="albertos-apples")
 
@@ -545,6 +557,7 @@ class End2EndTest(APITestCase):
             assert "activeorg" in self.client.session
             assert self.client.session["activeorg"] == "test"
 
+    @with_feature("system:multi-region")
     def test_with_middleware_and_nameless_view(self):
         self.create_organization(name="albertos-apples")
 
@@ -564,6 +577,7 @@ class End2EndTest(APITestCase):
             assert "activeorg" in self.client.session
             assert self.client.session["activeorg"] == "albertos-apples"
 
+    @with_feature("system:multi-region")
     def test_disallowed_customer_domain(self):
         with override_settings(
             MIDDLEWARE=tuple(self.middleware), DISALLOWED_CUSTOMER_DOMAINS=["banned"]

--- a/tests/sentry/middleware/test_staff.py
+++ b/tests/sentry/middleware/test_staff.py
@@ -30,7 +30,6 @@ urlpatterns = [
 @override_settings(
     ROOT_URLCONF=__name__,
     SENTRY_SELF_HOSTED=False,
-    SENTRY_USE_CUSTOMER_DOMAINS=True,
 )
 class End2EndTest(APITestCase):
     endpoint = "test-endpoint"

--- a/tests/sentry/web/frontend/test_auth_login.py
+++ b/tests/sentry/web/frontend/test_auth_login.py
@@ -508,9 +508,6 @@ class AuthLoginNewsletterTest(TestCase):
 
 
 @control_silo_test
-@override_settings(
-    SENTRY_USE_CUSTOMER_DOMAINS=True,
-)
 class AuthLoginCustomerDomainTest(TestCase):
     @cached_property
     def path(self):
@@ -594,7 +591,7 @@ class AuthLoginCustomerDomainTest(TestCase):
             ]
 
     def test_login_valid_credentials_invalid_customer_domain(self):
-        with self.disable_registration():
+        with self.feature("system:multi-region"), self.disable_registration():
             self.create_organization(name="albertos-apples", owner=self.user)
 
             # load it once for test cookie
@@ -610,7 +607,6 @@ class AuthLoginCustomerDomainTest(TestCase):
 
             assert resp.status_code == 200
             assert resp.redirect_chain == [
-                ("http://invalid.testserver/auth/login/", 302),
                 ("http://albertos-apples.testserver/auth/login/", 302),
                 ("http://albertos-apples.testserver/issues/", 302),
             ]

--- a/tests/sentry/web/frontend/test_home.py
+++ b/tests/sentry/web/frontend/test_home.py
@@ -76,7 +76,7 @@ class HomeTest(TestCase):
             assert response.redirect_chain == [
                 (f"http://{org.slug}.testserver/restore/", 302),
             ]
-            assert "activeorg" not in self.client.session
+            assert "activeorg" in self.client.session
 
     def test_customer_domain_org_deletion_in_progress(self):
         org = self.create_organization(
@@ -95,4 +95,4 @@ class HomeTest(TestCase):
             assert response.redirect_chain == [
                 ("http://testserver/organizations/new/", 302),
             ]
-            assert "activeorg" not in self.client.session
+            assert "activeorg" in self.client.session

--- a/tests/sentry/web/frontend/test_react_page.py
+++ b/tests/sentry/web/frontend/test_react_page.py
@@ -376,7 +376,7 @@ class ReactPageViewTest(TestCase):
             assert response.redirect_chain == [
                 (f"http://{org.slug}.testserver/restore/", 302),
             ]
-            assert "activeorg" not in self.client.session
+            assert "activeorg" in self.client.session
 
     def test_customer_domain_org_deletion_in_progress(self):
         org = self.create_organization(
@@ -395,7 +395,7 @@ class ReactPageViewTest(TestCase):
             assert response.redirect_chain == [
                 ("http://testserver/organizations/new/", 302),
             ]
-            assert "activeorg" not in self.client.session
+            assert "activeorg" in self.client.session
 
     def test_document_policy_header_when_flag_is_enabled(self):
         org = self.create_organization(owner=self.user)

--- a/tests/sentry/web/frontend/test_react_page.py
+++ b/tests/sentry/web/frontend/test_react_page.py
@@ -1,6 +1,5 @@
 from fnmatch import fnmatch
 
-from django.test import override_settings
 from django.urls import URLResolver, get_resolver, reverse
 
 from sentry.models.organization import OrganizationStatus
@@ -266,10 +265,7 @@ class ReactPageViewTest(TestCase):
         other_org = self.create_organization()
 
         self.login_as(self.user)
-        with (
-            override_settings(SENTRY_USE_CUSTOMER_DOMAINS=True),
-            self.feature({"system:multi-region": True}),
-        ):
+        with self.feature({"system:multi-region": True}):
             # Should not be able to induce activeorg
             assert "activeorg" not in self.client.session
             response = self.client.get(
@@ -287,10 +283,7 @@ class ReactPageViewTest(TestCase):
         other_org = self.create_organization()
 
         self.login_as(user, superuser=is_superuser, staff=is_staff)
-        with (
-            override_settings(SENTRY_USE_CUSTOMER_DOMAINS=True),
-            self.feature({"system:multi-region": True}),
-        ):
+        with self.feature({"system:multi-region": True}):
             # Induce activeorg
             assert "activeorg" not in self.client.session
             response = self.client.get(

--- a/tests/sentry/web/test_api.py
+++ b/tests/sentry/web/test_api.py
@@ -172,10 +172,7 @@ class ClientConfigViewTest(TestCase):
             assert resp.status_code == 200
             assert resp["Content-Type"] == "application/json"
             data = json.loads(resp.content)
-            assert data["features"] == [
-                "organizations:create",
-                "organizations:customer-domains",
-            ]
+            assert data["features"] == ["organizations:create"]
 
     def test_unauthenticated(self):
         resp = self.client.get(self.path)
@@ -239,7 +236,6 @@ class ClientConfigViewTest(TestCase):
 
         # Induce last active organization
         with (
-            override_settings(SENTRY_USE_CUSTOMER_DOMAINS=True),
             self.feature({"system:multi-region": [other_org.slug]}),
             assume_test_silo_mode(SiloMode.MONOLITH),
         ):


### PR DESCRIPTION
With all checks no combined with multi-region the customer-domains feature flag is redundant.

Refs HC-1096
Refs getsentry/getsentry#14385
