### PR TITLE
chore(hybridcloud) Remove redundant signed link handling

### DIFF
--- a/src/sentry/api/endpoints/organization_unsubscribe.py
+++ b/src/sentry/api/endpoints/organization_unsubscribe.py
@@ -22,6 +22,7 @@ from sentry.notifications.types import (
 )
 from sentry.services.hybrid_cloud.notifications.service import notifications_service
 from sentry.types.actor import Actor, ActorType
+from sentry.utils import auth
 
 T = TypeVar("T", bound=BaseModel)
 
@@ -49,7 +50,7 @@ class OrganizationUnsubscribeBase(Endpoint, Generic[T]):
     def get(
         self, request: Request, organization_id_or_slug: int | str, id: int, **kwargs
     ) -> Response:
-        if not request.user_from_signed_request:
+        if not auth.is_user_signed_request(request):
             raise NotFound()
         instance = self.fetch_instance(request, organization_id_or_slug, id)
         view_url = ""

--- a/src/sentry/middleware/auth.py
+++ b/src/sentry/middleware/auth.py
@@ -16,7 +16,6 @@ from sentry.api.authentication import (
 )
 from sentry.models.userip import UserIP
 from sentry.utils.auth import AuthUserPasswordExpired, logger
-from sentry.utils.linksign import process_signature
 
 
 def get_user(request):
@@ -85,23 +84,45 @@ class SessionAuthenticationMiddleware(MiddlewareMixin):
             return None
 
 
-class AuthenticationMiddleware(SessionAuthenticationMiddleware):
+class AuthenticationMiddleware(MiddlewareMixin):
     def process_request(self, request: HttpRequest) -> None:
-        request.user_from_signed_request = False
-
         if request.path.startswith("/api/0/internal/rpc/"):
             # Avoid doing RPC authentication when we're already
             # in an RPC request.
             request.user = AnonymousUser()
             return
 
-        # If there is a valid signature on the request we override the
-        # user with the user contained within the signature.
-        user = process_signature(request)
+        auth = get_authorization_header(request).split()
 
-        if user is not None:
-            request.user = user
-            request.user_from_signed_request = True
-            return
+        if auth:
+            for authenticator_class in [
+                UserAuthTokenAuthentication,
+                OrgAuthTokenAuthentication,
+                ApiKeyAuthentication,
+            ]:
+                authenticator = authenticator_class()
+                if not authenticator.accepts_auth(auth):
+                    continue
+                try:
+                    result = authenticator.authenticate(request)
+                except AuthenticationFailed:
+                    result = None
+                if result:
+                    request.user, request.auth = result
+                else:
+                    # default to anonymous user and use IP ratelimit
+                    request.user = SimpleLazyObject(lambda: get_user(request))
+                return
 
-        return super().process_request(request)
+        # default to anonymous user and use IP ratelimit
+        request.user = SimpleLazyObject(lambda: get_user(request))
+
+    def process_exception(
+        self, request: HttpRequest, exception: Exception
+    ) -> HttpResponseBase | None:
+        if isinstance(exception, AuthUserPasswordExpired):
+            from sentry.web.frontend.accounts import expired
+
+            return expired(request, exception.user)
+        else:
+            return None


### PR DESCRIPTION
We don't need to handle signed link requests in multiple places. Instead we can handle that logic in the authentication adapter. I've combined AuthenticationMiddleware and its mixin as there is no other usage of that mixin in sentry or getsentry.