### PR TITLE
feat(related_issues): Track trace timeline with two issues

### DIFF
--- a/static/app/views/issueDetails/traceTimeline/traceTimeline.spec.tsx
+++ b/static/app/views/issueDetails/traceTimeline/traceTimeline.spec.tsx
@@ -22,9 +22,12 @@ describe('TraceTimeline', () => {
   });
   // This creates the ApiException event
   const event = EventFixture({
+    // This is used to determine the presence of seconds
     dateCreated: '2024-01-24T09:09:03+00:00',
     contexts: {
       trace: {
+        // This is used to determine if we should attempt
+        // to render the trace timeline
         trace_id: '123',
       },
     },
@@ -54,13 +57,13 @@ describe('TraceTimeline', () => {
       {
         message: 'This is the subtitle of the issue',
         timestamp: '2024-01-23T22:11:42+00:00',
-        'issue.id': 4909507143,
+        'issue.id': event['issue.id'],
         project: project.slug,
         'project.name': project.name,
-        title: 'AttributeError: Something Failed',
+        title: event.title,
         id: event.id,
         transaction: 'important.task',
-        'event.type': 'error',
+        'event.type': event.type,
         'stack.function': ['important.task', 'task.run'],
       },
     ],
@@ -91,6 +94,7 @@ describe('TraceTimeline', () => {
     expect(useRouteAnalyticsParams).toHaveBeenCalledWith({
       has_related_trace_issue: false,
       trace_timeline_status: 'shown',
+      trace_timeline_two_issues: true,
     });
   });
 
@@ -110,6 +114,7 @@ describe('TraceTimeline', () => {
       expect(useRouteAnalyticsParams).toHaveBeenCalledWith({
         has_related_trace_issue: false,
         trace_timeline_status: 'empty',
+        trace_timeline_two_issues: false,
       })
     );
     expect(container).toBeEmptyDOMElement();
@@ -131,6 +136,7 @@ describe('TraceTimeline', () => {
       expect(useRouteAnalyticsParams).toHaveBeenCalledWith({
         has_related_trace_issue: false,
         trace_timeline_status: 'empty',
+        trace_timeline_two_issues: false,
       })
     );
     expect(container).toBeEmptyDOMElement();
@@ -246,6 +252,7 @@ describe('TraceTimeline', () => {
     expect(useRouteAnalyticsParams).toHaveBeenCalledWith({
       has_related_trace_issue: false,
       trace_timeline_status: 'empty',
+      trace_timeline_two_issues: false,
     });
   });
 

--- a/static/app/views/issueDetails/traceTimeline/traceTimeline.tsx
+++ b/static/app/views/issueDetails/traceTimeline/traceTimeline.tsx
@@ -45,8 +45,13 @@ export function TraceTimeline({event}: TraceTimelineProps) {
     organization.features.includes('related-issues-issue-details-page') &&
     oneOtherIssueEvent !== undefined;
 
+  // Once we GA trace related issues this will drop to 0 and we can remove this
+  const traceTimelineTwoIssues =
+    timelineStatus === 'shown' && oneOtherIssueEvent !== undefined;
+
   useRouteAnalyticsParams({
     trace_timeline_status: timelineStatus,
+    trace_timeline_two_issues: traceTimelineTwoIssues,
     has_related_trace_issue: showTraceRelatedIssue,
   });
 


### PR DESCRIPTION
The Related Issue feature replaces the Trace Timeline when only two issues are involved. This will help measure the impact of it.