### PR TITLE
feat(related_issues): Track analytic even when feature is enabled

### DIFF
--- a/static/app/views/issueDetails/traceTimeline/traceTimeline.spec.tsx
+++ b/static/app/views/issueDetails/traceTimeline/traceTimeline.spec.tsx
@@ -205,6 +205,13 @@ describe('TraceTimeline', () => {
 
     // Test analytics
     await userEvent.click(await screen.findByText('Slow DB Query'));
+    expect(useRouteAnalyticsParams).toHaveBeenLastCalledWith({
+      has_related_trace_issue: true,
+      trace_timeline_status: 'empty',
+      // Even though the trace timeline has not been rendered, we still
+      // track that it would have been the two issues case that related issues is replacing
+      trace_timeline_two_issues: true,
+    });
     expect(trackAnalytics).toHaveBeenCalledTimes(1);
     expect(trackAnalytics).toHaveBeenCalledWith(
       'issue_details.related_trace_issue.trace_issue_clicked',

--- a/static/app/views/issueDetails/traceTimeline/traceTimeline.tsx
+++ b/static/app/views/issueDetails/traceTimeline/traceTimeline.tsx
@@ -45,13 +45,10 @@ export function TraceTimeline({event}: TraceTimelineProps) {
     organization.features.includes('related-issues-issue-details-page') &&
     oneOtherIssueEvent !== undefined;
 
-  // Once we GA trace related issues this will drop to 0 and we can remove this
-  const traceTimelineTwoIssues =
-    timelineStatus === 'shown' && oneOtherIssueEvent !== undefined;
-
   useRouteAnalyticsParams({
     trace_timeline_status: timelineStatus,
-    trace_timeline_two_issues: traceTimelineTwoIssues,
+    // Once we GA trace related issues we will have no need for this
+    trace_timeline_two_issues: oneOtherIssueEvent !== undefined,
     has_related_trace_issue: showTraceRelatedIssue,
   });
 


### PR DESCRIPTION
This is a follow up to #73020 since we are not tracking the metric when `related-issues-issue-details-page` is enabled.