### PR TITLE
feat(breadcrumbs): Use new timeline interface for replay frames

### DIFF
--- a/static/app/components/replays/breadcrumbs/breadcrumbItem.spec.tsx
+++ b/static/app/components/replays/breadcrumbs/breadcrumbItem.spec.tsx
@@ -1,0 +1,67 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
+import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+
+import BreadcrumbItem from 'sentry/components/replays/breadcrumbs/breadcrumbItem';
+
+const MOCK_FRAME = {
+  timestamp: new Date(1718818835397),
+  type: 'default',
+  category: 'ui.click',
+  message:
+    'div.app-pv36ag.e151korg0 > IntegrationRow > FlexContainer > TitleContainer > IntegrationName',
+  data: {
+    nodeId: 6889,
+    node: {
+      id: 6889,
+      tagName: 'a',
+      textContent: '',
+      attributes: {
+        class: 'app-3jkjlw ek2xunm6',
+        'data-sentry-component': 'IntegrationName',
+      },
+    },
+  },
+  offsetMs: 208397,
+  timestampMs: 1718818835397,
+};
+
+const MOCK_EXTRACTION = {
+  frame: MOCK_FRAME,
+  html: '<a data-sentry-element="IntegrationName" data-sentry-source-file="integrationRow.tsx" class="app-3jkjlw ek2xunm6" href="https://pelpr-org.sentry.io/settings/integrations/msteams/">********* *****</a>',
+  timestamp: 1718818835397,
+};
+
+describe('BreadcrumbItem', function () {
+  const organization = OrganizationFixture({features: ['new-timeline-ui']});
+
+  it('displays the breadcrumb item', async function () {
+    const mockClick = jest.fn();
+    const mockMouseEnter = jest.fn();
+    const mockMouseLeave = jest.fn();
+    render(
+      <BreadcrumbItem
+        extraction={MOCK_EXTRACTION}
+        frame={MOCK_FRAME}
+        onMouseEnter={mockMouseEnter}
+        onMouseLeave={mockMouseLeave}
+        onClick={mockClick}
+        onInspectorExpanded={() => {}}
+        startTimestampMs={MOCK_FRAME.timestampMs}
+      />,
+      {organization}
+    );
+
+    const title = screen.getByText('User Click');
+    expect(title).toBeInTheDocument();
+    expect(screen.getByText('00:00')).toBeInTheDocument();
+    expect(screen.getByText('IntegrationName')).toBeInTheDocument();
+
+    await userEvent.hover(title);
+    expect(mockMouseEnter).toHaveBeenCalled();
+    await userEvent.unhover(title);
+    expect(mockMouseLeave).toHaveBeenCalled();
+    await userEvent.click(title);
+    expect(mockClick).toHaveBeenCalled();
+  });
+});

--- a/static/app/components/replays/breadcrumbs/breadcrumbItem.spec.tsx
+++ b/static/app/components/replays/breadcrumbs/breadcrumbItem.spec.tsx
@@ -1,36 +1,21 @@
 import {OrganizationFixture} from 'sentry-fixture/organization';
+import {ReplayClickFrameFixture} from 'sentry-fixture/replay/replayBreadcrumbFrameData';
+import {ReplayRecordFixture} from 'sentry-fixture/replayRecord';
 
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
 import BreadcrumbItem from 'sentry/components/replays/breadcrumbs/breadcrumbItem';
+import hydrateBreadcrumbs from 'sentry/utils/replays/hydrateBreadcrumbs';
 
-const MOCK_FRAME = {
-  timestamp: new Date(1718818835397),
-  type: 'default',
-  category: 'ui.click',
-  message:
-    'div.app-pv36ag.e151korg0 > IntegrationRow > FlexContainer > TitleContainer > IntegrationName',
-  data: {
-    nodeId: 6889,
-    node: {
-      id: 6889,
-      tagName: 'a',
-      textContent: '',
-      attributes: {
-        class: 'app-3jkjlw ek2xunm6',
-        'data-sentry-component': 'IntegrationName',
-      },
-    },
-  },
-  offsetMs: 208397,
-  timestampMs: 1718818835397,
-};
-
-const MOCK_EXTRACTION = {
-  frame: MOCK_FRAME,
-  html: '<a data-sentry-element="IntegrationName" data-sentry-source-file="integrationRow.tsx" class="app-3jkjlw ek2xunm6" href="https://pelpr-org.sentry.io/settings/integrations/msteams/">********* *****</a>',
-  timestamp: 1718818835397,
-};
+const [MOCK_FRAME] = hydrateBreadcrumbs(
+  ReplayRecordFixture(),
+  [
+    ReplayClickFrameFixture({
+      timestamp: new Date('2024/06/21'),
+    }),
+  ],
+  []
+);
 
 describe('BreadcrumbItem', function () {
   const organization = OrganizationFixture({features: ['new-timeline-ui']});
@@ -41,7 +26,6 @@ describe('BreadcrumbItem', function () {
     const mockMouseLeave = jest.fn();
     render(
       <BreadcrumbItem
-        extraction={MOCK_EXTRACTION}
         frame={MOCK_FRAME}
         onMouseEnter={mockMouseEnter}
         onMouseLeave={mockMouseLeave}
@@ -55,7 +39,6 @@ describe('BreadcrumbItem', function () {
     const title = screen.getByText('User Click');
     expect(title).toBeInTheDocument();
     expect(screen.getByText('00:00')).toBeInTheDocument();
-    expect(screen.getByText('IntegrationName')).toBeInTheDocument();
 
     await userEvent.hover(title);
     expect(mockMouseEnter).toHaveBeenCalled();

--- a/static/app/components/replays/breadcrumbs/breadcrumbItem.tsx
+++ b/static/app/components/replays/breadcrumbs/breadcrumbItem.tsx
@@ -130,14 +130,16 @@ function BreadcrumbItem({
       title={title}
       colorConfig={{primary: color, secondary: color}}
       timeString={timeString}
-      startTimeString={startTimeString}
-      onClick={e => onClick?.(frame, e)}
-      onMouseEnter={e => onMouseEnter(frame, e)}
-      onMouseLeave={e => onMouseLeave(frame, e)}
       renderTimestamp={(_ts, _sts) =>
         showPlayerTime(frame.timestampMs, startTimestampMs, false)
       }
+      startTimeString={startTimeString}
       data-is-error-frame={isErrorFrame(frame)}
+      style={style}
+      className={className}
+      onClick={e => onClick?.(frame, e)}
+      onMouseEnter={e => onMouseEnter(frame, e)}
+      onMouseLeave={e => onMouseLeave(frame, e)}
     >
       <ErrorBoundary mini>
         {renderDescription()}
@@ -265,6 +267,7 @@ const StyledTimelineItem = styled(Timeline.Item)`
   width: 100%;
   position: relative;
   padding: ${space(0.5)} ${space(0.75)};
+  margin: 0;
   &:hover {
     background: ${p => p.theme.translucentSurface200};
   }
@@ -275,7 +278,7 @@ const StyledTimelineItem = styled(Timeline.Item)`
     position: absolute;
     left: 16.5px;
     width: 1px;
-    top: 0;
+    top: -2px;
     bottom: -9px;
     background: ${p => p.theme.border};
     z-index: 0;

--- a/static/app/components/replays/breadcrumbs/breadcrumbItem.tsx
+++ b/static/app/components/replays/breadcrumbs/breadcrumbItem.tsx
@@ -275,7 +275,7 @@ const StyledTimelineItem = styled(Timeline.Item)`
   }
   cursor: pointer;
   /* vertical line connecting items */
-  &::before {
+  &:not(:last-child)::before {
     content: '';
     position: absolute;
     left: 16.5px;
@@ -284,6 +284,9 @@ const StyledTimelineItem = styled(Timeline.Item)`
     bottom: -9px;
     background: ${p => p.theme.border};
     z-index: 0;
+  }
+  &:first-child::before {
+    top: 4px;
   }
 `;
 

--- a/static/app/components/replays/breadcrumbs/breadcrumbItem.tsx
+++ b/static/app/components/replays/breadcrumbs/breadcrumbItem.tsx
@@ -13,6 +13,7 @@ import PanelItem from 'sentry/components/panels/panelItem';
 import {OpenReplayComparisonButton} from 'sentry/components/replays/breadcrumbs/openReplayComparisonButton';
 import {useReplayContext} from 'sentry/components/replays/replayContext';
 import {useReplayGroupContext} from 'sentry/components/replays/replayGroupContext';
+import {showPlayerTime} from 'sentry/components/replays/utils';
 import Timeline from 'sentry/components/timeline';
 import {useHasNewTimelineUI} from 'sentry/components/timeline/utils';
 import {Tooltip} from 'sentry/components/tooltip';
@@ -133,6 +134,9 @@ function BreadcrumbItem({
       onClick={e => onClick?.(frame, e)}
       onMouseEnter={e => onMouseEnter(frame, e)}
       onMouseLeave={e => onMouseLeave(frame, e)}
+      renderTimestamp={(_ts, _sts) =>
+        showPlayerTime(frame.timestampMs, startTimestampMs, false)
+      }
       data-is-error-frame={isErrorFrame(frame)}
     >
       <ErrorBoundary mini>

--- a/static/app/components/replays/breadcrumbs/breadcrumbItem.tsx
+++ b/static/app/components/replays/breadcrumbs/breadcrumbItem.tsx
@@ -1,5 +1,5 @@
 import type {CSSProperties, MouseEvent} from 'react';
-import {isValidElement, memo} from 'react';
+import {isValidElement, memo, useCallback} from 'react';
 import styled from '@emotion/styled';
 import beautify from 'js-beautify';
 
@@ -66,7 +66,7 @@ function BreadcrumbItem({
 
   const forceSpan = 'category' in frame && FRAMES_WITH_BUTTONS.includes(frame.category);
 
-  function renderDescription() {
+  const renderDescription = useCallback(() => {
     return typeof description === 'string' ||
       (description !== undefined && isValidElement(description)) ? (
       <Description title={description} showOnlyOnOverflow isHoverable>
@@ -85,10 +85,10 @@ function BreadcrumbItem({
         />
       </InspectorWrapper>
     );
-  }
+  }, [description, expandPaths, onInspectorExpanded]);
 
-  function renderComparisonButton() {
-    return 'data' in frame && frame.data && 'mutations' in frame.data ? (
+  const renderComparisonButton = useCallback(() => {
+    return frame?.data && 'mutations' in frame.data ? (
       <div>
         <OpenReplayComparisonButton
           replay={replay}
@@ -103,9 +103,9 @@ function BreadcrumbItem({
         </OpenReplayComparisonButton>
       </div>
     ) : null;
-  }
+  }, [frame?.data, frame.offsetMs, replay]);
 
-  function renderCodeSnippet() {
+  const renderCodeSnippet = useCallback(() => {
     return extraction?.html ? (
       <CodeContainer>
         <CodeSnippet language="html" hideCopyButton>
@@ -113,13 +113,13 @@ function BreadcrumbItem({
         </CodeSnippet>
       </CodeContainer>
     ) : null;
-  }
+  }, [extraction?.html]);
 
-  function renderIssueLink() {
+  const renderIssueLink = useCallback(() => {
     return isErrorFrame(frame) || isFeedbackFrame(frame) ? (
       <CrumbErrorIssue frame={frame} />
     ) : null;
-  }
+  }, [frame]);
 
   const hasNewTimelineUI = useHasNewTimelineUI();
   const timeString = new Date(frame.timestampMs).toISOString();

--- a/static/app/components/replays/breadcrumbs/breadcrumbItem.tsx
+++ b/static/app/components/replays/breadcrumbs/breadcrumbItem.tsx
@@ -33,7 +33,6 @@ type MouseCallback = (frame: ReplayFrame, e: React.MouseEvent<HTMLElement>) => v
 const FRAMES_WITH_BUTTONS = ['replay.hydrate-error'];
 
 interface Props {
-  extraction: Extraction | undefined;
   frame: ReplayFrame;
   onClick: null | MouseCallback;
   onInspectorExpanded: (
@@ -46,6 +45,7 @@ interface Props {
   startTimestampMs: number;
   className?: string;
   expandPaths?: string[];
+  extraction?: Extraction;
   style?: CSSProperties;
 }
 
@@ -124,31 +124,34 @@ function BreadcrumbItem({
   const hasNewTimelineUI = useHasNewTimelineUI();
   const timeString = new Date(frame.timestampMs).toISOString();
   const startTimeString = new Date(startTimestampMs).toISOString();
-  return hasNewTimelineUI ? (
-    <StyledTimelineItem
-      icon={icon}
-      title={title}
-      colorConfig={{primary: color, secondary: color}}
-      timeString={timeString}
-      renderTimestamp={(_ts, _sts) =>
-        showPlayerTime(frame.timestampMs, startTimestampMs, false)
-      }
-      startTimeString={startTimeString}
-      data-is-error-frame={isErrorFrame(frame)}
-      style={style}
-      className={className}
-      onClick={e => onClick?.(frame, e)}
-      onMouseEnter={e => onMouseEnter(frame, e)}
-      onMouseLeave={e => onMouseLeave(frame, e)}
-    >
-      <ErrorBoundary mini>
-        {renderDescription()}
-        {renderComparisonButton()}
-        {renderCodeSnippet()}
-        {renderIssueLink()}
-      </ErrorBoundary>
-    </StyledTimelineItem>
-  ) : (
+  if (hasNewTimelineUI) {
+    return (
+      <StyledTimelineItem
+        icon={icon}
+        title={title}
+        colorConfig={{primary: color, secondary: color}}
+        timeString={timeString}
+        renderTimestamp={(_ts, _sts) =>
+          showPlayerTime(frame.timestampMs, startTimestampMs, false)
+        }
+        startTimeString={startTimeString}
+        data-is-error-frame={isErrorFrame(frame)}
+        style={style}
+        className={className}
+        onClick={e => onClick?.(frame, e)}
+        onMouseEnter={e => onMouseEnter(frame, e)}
+        onMouseLeave={e => onMouseLeave(frame, e)}
+      >
+        <ErrorBoundary mini>
+          {renderDescription()}
+          {renderComparisonButton()}
+          {renderCodeSnippet()}
+          {renderIssueLink()}
+        </ErrorBoundary>
+      </StyledTimelineItem>
+    );
+  }
+  return (
     <CrumbItem
       data-is-error-frame={isErrorFrame(frame)}
       as={onClick && !forceSpan ? 'button' : 'span'}
@@ -161,7 +164,6 @@ function BreadcrumbItem({
       <IconWrapper color={color} hasOccurred>
         {icon}
       </IconWrapper>
-
       <ErrorBoundary mini>
         <CrumbDetails>
           <Flex column>

--- a/static/app/components/timeline/index.tsx
+++ b/static/app/components/timeline/index.tsx
@@ -1,4 +1,4 @@
-import {useRef} from 'react';
+import {type CSSProperties, useRef} from 'react';
 import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 
@@ -14,12 +14,11 @@ export interface ColorConfig {
 }
 
 export interface TimelineItemProps {
-  className: any;
   icon: React.ReactNode;
-  style: any;
   timeString: string;
   title: React.ReactNode;
   children?: React.ReactNode;
+  className?: string;
   colorConfig?: ColorConfig;
   isActive?: boolean;
   onClick?: React.MouseEventHandler<HTMLDivElement>;
@@ -30,6 +29,7 @@ export interface TimelineItemProps {
     startTimeString: TimelineItemProps['startTimeString']
   ) => React.ReactNode;
   startTimeString?: string;
+  style?: CSSProperties;
 }
 
 export function Item({

--- a/static/app/components/timeline/index.tsx
+++ b/static/app/components/timeline/index.tsx
@@ -34,9 +34,7 @@ export function Item({
   startTimeString,
   colorConfig = {primary: 'gray300', secondary: 'gray200'},
   isActive = false,
-  onClick,
-  onMouseEnter,
-  onMouseLeave,
+  ...props
 }: TimelineItemProps) {
   const theme = useTheme();
   const placeholderTime = useRef(new Date().toTimeString()).current;
@@ -54,12 +52,10 @@ export function Item({
     <Row
       color={secondary}
       hasLowerBorder={isActive}
-      onClick={onClick}
-      onMouseEnter={onMouseEnter}
-      onMouseLeave={onMouseLeave}
       style={{
         borderBottom: `1px solid ${isActive ? theme[secondary] : 'transparent'}`,
       }}
+      {...props}
     >
       <IconWrapper
         style={{
@@ -130,6 +126,7 @@ const IconWrapper = styled('div')`
   border-radius: 100%;
   border: 1px solid;
   background: ${p => p.theme.background};
+  z-index: 10;
   svg {
     display: block;
     margin: ${space(0.5)};
@@ -159,7 +156,7 @@ const Spacer = styled('div')`
 const Content = styled('div')`
   grid-column: span 2;
   color: ${p => p.theme.subText};
-  margin: ${space(0.25)} 0 ${space(2)};
+  margin: ${space(0.25)} 0 0;
 `;
 
 export const Text = styled('div')`

--- a/static/app/components/timeline/index.tsx
+++ b/static/app/components/timeline/index.tsx
@@ -23,6 +23,10 @@ export interface TimelineItemProps {
   onClick?: React.MouseEventHandler<HTMLDivElement>;
   onMouseEnter?: React.MouseEventHandler<HTMLDivElement>;
   onMouseLeave?: React.MouseEventHandler<HTMLDivElement>;
+  renderTimestamp?: (
+    timeString: TimelineItemProps['timeString'],
+    startTimeString: TimelineItemProps['startTimeString']
+  ) => React.ReactNode;
   startTimeString?: string;
 }
 
@@ -31,8 +35,9 @@ export function Item({
   children,
   icon,
   timeString,
-  startTimeString,
   colorConfig = {primary: 'gray300', secondary: 'gray200'},
+  startTimeString,
+  renderTimestamp,
   isActive = false,
   ...props
 }: TimelineItemProps) {
@@ -68,7 +73,7 @@ export function Item({
       <Title style={{color: theme[primary]}}>{title}</Title>
       <Timestamp>
         <Tooltip title={`${preciseTime} - ${date}`} skipWrapper>
-          {displayTime}
+          {renderTimestamp ? renderTimestamp(timeString, startTimeString) : displayTime}
         </Tooltip>
       </Timestamp>
       <Spacer

--- a/static/app/components/timeline/index.tsx
+++ b/static/app/components/timeline/index.tsx
@@ -14,7 +14,9 @@ export interface ColorConfig {
 }
 
 export interface TimelineItemProps {
+  className: any;
   icon: React.ReactNode;
+  style: any;
   timeString: string;
   title: React.ReactNode;
   children?: React.ReactNode;
@@ -39,6 +41,7 @@ export function Item({
   startTimeString,
   renderTimestamp,
   isActive = false,
+  style,
   ...props
 }: TimelineItemProps) {
   const theme = useTheme();
@@ -59,6 +62,7 @@ export function Item({
       hasLowerBorder={isActive}
       style={{
         borderBottom: `1px solid ${isActive ? theme[secondary] : 'transparent'}`,
+        ...style,
       }}
       {...props}
     >

--- a/static/app/components/timeline/index.tsx
+++ b/static/app/components/timeline/index.tsx
@@ -125,7 +125,8 @@ const Row = styled('div')<{hasLowerBorder: boolean}>`
     margin-bottom: 0;
     background: ${p => p.theme.background};
   }
-  &:last-child > :last-child {
+  &:last-child > :last-child,
+  &:first-child > :last-child {
     margin-bottom: ${p => (p.hasLowerBorder ? space(1) : 0)};
   }
 `;
@@ -146,6 +147,7 @@ const Title = styled('p')`
   margin: 0;
   font-weight: bold;
   text-transform: capitalize;
+  text-align: left;
   grid-column: span 1;
 `;
 
@@ -163,12 +165,14 @@ const Spacer = styled('div')`
 `;
 
 const Content = styled('div')`
+  text-align: left;
   grid-column: span 2;
   color: ${p => p.theme.subText};
   margin: ${space(0.25)} 0 0;
 `;
 
 export const Text = styled('div')`
+  text-align: left;
   &:only-child {
     margin-top: 0;
   }


### PR DESCRIPTION
This PR introduces a new interface for timeline items that will better match the breadcrumbs on issue details pages. It relates to [this project](https://github.com/getsentry/sentry/issues/72504).

Searching and filtering still work as is so no need to adjust any of that code, this is just an updated UI.
<img width="896" alt="image" src="https://github.com/getsentry/sentry/assets/35509934/44dcae2c-5b05-4a93-84c4-887f740fb8f8">
<img width="311" alt="image" src="https://github.com/getsentry/sentry/assets/35509934/11c2b53d-bd18-478b-ac0b-9d773bcb0e7d">

**todo**
- [x] Add tests 
- [x] Figure out the flickering with scrolling the virtualized list