### PR TITLE
chore(trace-explorer): Remove unused samples query in traces endpoint

### DIFF
--- a/src/sentry/api/endpoints/organization_traces.py
+++ b/src/sentry/api/endpoints/organization_traces.py
@@ -10,8 +10,7 @@ from rest_framework import serializers
 from rest_framework.exceptions import ParseError, ValidationError
 from rest_framework.request import Request
 from rest_framework.response import Response
-from snuba_sdk import And, BooleanCondition, BooleanOp, Column, Condition, Function, LimitBy, Op, Or
-from snuba_sdk.expressions import Expression
+from snuba_sdk import And, BooleanCondition, BooleanOp, Column, Condition, Function, Op, Or
 from urllib3.exceptions import ReadTimeoutError
 
 from sentry import features, options
@@ -76,8 +75,6 @@ class TraceResult(TypedDict):
     start: int
     end: int
     breakdowns: list[TraceInterval]
-    spans: list[Mapping[str, Any]]
-    suggestedSpans: list[Mapping[str, Any]]
 
 
 class OrganizationTracesSerializer(serializers.Serializer):
@@ -418,23 +415,14 @@ class TracesExecutor:
             traces_breakdown_projects_results = all_results[idx]
             idx += 1
 
-            user_spans_results = all_results[idx]
-            idx += 1
-
-            suggested_spans_results = all_results[idx] if len(all_results) > idx else None
-            idx += 1
-
-            meta = self.process_meta_results(user_spans_results)
             data = self.process_final_results(
                 traces_metas_results=traces_metas_results,
                 traces_errors_results=traces_errors_results,
                 traces_occurrences_results=traces_occurrences_results,
                 traces_breakdown_projects_results=traces_breakdown_projects_results,
-                user_spans_results=user_spans_results,
-                suggested_spans_results=suggested_spans_results,
             )
 
-        return {"data": data, "meta": meta}
+        return {"data": data}
 
     def refine_params(self, min_timestamp: datetime, max_timestamp: datetime):
         """
@@ -749,14 +737,7 @@ class TracesExecutor:
             trace_ids,
         )
 
-        span_samples_queries = self.get_all_span_samples_queries(
-            params,
-            snuba_params,
-            trace_ids,
-            span_keys,
-        )
-
-        return meta_data_queries + span_samples_queries
+        return meta_data_queries
 
     def get_all_meta_data_queries(
         self,
@@ -797,33 +778,6 @@ class TracesExecutor:
 
         return queries
 
-    def get_all_span_samples_queries(
-        self,
-        params: ParamsType,
-        snuba_params: SnubaParams,
-        trace_ids: list[str],
-        span_keys: list[SpanKey] | None,
-    ) -> list[QueryBuilder]:
-        user_spans_query = self.get_user_spans_query(
-            params,
-            snuba_params,
-            trace_ids,
-            span_keys,
-        )
-
-        suggested_spans_query = self.get_suggested_spans_query(
-            params,
-            snuba_params,
-            trace_ids,
-        )
-
-        span_samples_queries = [user_spans_query]
-
-        if suggested_spans_query:
-            span_samples_queries.append(suggested_spans_query)
-
-        return span_samples_queries
-
     def process_final_results(
         self,
         *,
@@ -831,8 +785,6 @@ class TracesExecutor:
         traces_errors_results,
         traces_occurrences_results,
         traces_breakdown_projects_results,
-        user_spans_results,
-        suggested_spans_results,
     ) -> list[TraceResult]:
         # mapping of trace id to a tuple of start/finish times
         traces_range = {
@@ -892,26 +844,6 @@ class TracesExecutor:
             row["trace"]: row["count()"] for row in traces_occurrences_results["data"]
         }
 
-        traces_user_spans: Mapping[str, list[Mapping[str, Any]]] = defaultdict(list)
-        for row in user_spans_results["data"]:
-            traces_user_spans[row["trace"]].append(row)
-
-        traces_suggested_spans: Mapping[str, list[Mapping[str, Any]]] = defaultdict(list)
-        if suggested_spans_results:
-            for row in suggested_spans_results["data"]:
-                traces_suggested_spans[row["trace"]].append(row)
-
-        for row in traces_metas_results["data"]:
-            if not traces_user_spans[row["trace"]]:
-                context = {
-                    "trace": row["trace"],
-                    "start": row["first_seen()"],
-                    "end": row["last_seen()"],
-                }
-                sentry_sdk.capture_message(
-                    "trace missing spans", contexts={"trace_missing_spans": context}
-                )
-
         return [
             {
                 "trace": row["trace"],
@@ -925,17 +857,8 @@ class TracesExecutor:
                 "start": row["first_seen()"],
                 "end": row["last_seen()"],
                 "breakdowns": traces_breakdowns[row["trace"]],
-                "spans": [
-                    {field: span[field] for field in self.fields}
-                    for span in traces_user_spans[row["trace"]]
-                ],
-                "suggestedSpans": [
-                    {field: span[field] for field in self.fields}
-                    for span in traces_suggested_spans[row["trace"]]
-                ],
             }
             for row in traces_metas_results["data"]
-            if traces_user_spans[row["trace"]]
         ]
 
     def process_meta_results(self, results):
@@ -1081,187 +1004,6 @@ class TracesExecutor:
             ),
         )
 
-    def get_user_spans_query(
-        self,
-        params: ParamsType,
-        snuba_params: SnubaParams,
-        trace_ids: list[str],
-        span_keys: list[SpanKey] | None,
-    ) -> QueryBuilder:
-        # Divide the allowed number of results per trace amoung the number of queries
-        limit_per_query = self.max_spans_per_trace
-        if self.user_queries:
-            limit_per_query = math.floor(self.max_spans_per_trace / len(self.user_queries))
-        limit_per_query = max(limit_per_query, 1)
-
-        limit = len(trace_ids) * limit_per_query
-        if self.user_queries:
-            limit *= len(self.user_queries)
-
-        user_spans_query = SpansIndexedQueryBuilder(
-            Dataset.SpansIndexed,
-            params,
-            snuba_params=snuba_params,
-            query=None,  # Note: conditions are added below
-            selected_columns=["trace"] + self.fields,
-            orderby=self.sort,
-            limit=limit,
-            config=QueryBuilderConfig(
-                transform_alias_to_input_format=True,
-            ),
-        )
-
-        user_conditions = []
-
-        multi_if_args: Expression = []
-
-        for query, i in self.user_queries.items():
-            where, _ = user_spans_query.resolve_conditions(query)
-
-            # The user conditions may be needed to identify which spans
-            # to fetch if not using span keys. So hold on to them for later.
-            user_conditions.append(where)
-
-            trace_conditions: list[Function] = format_as_trace_conditions(where)
-            if not trace_conditions:
-                pass
-            elif len(trace_conditions) == 1:
-                multi_if_args.append(trace_conditions[0])
-                multi_if_args.append(i)
-            elif len(trace_conditions) > 1:
-                multi_if_args.append(Function("and", trace_conditions))
-                multi_if_args.append(i)
-
-        # Insert three 0s to the end
-        # - a placeholder false condition so there's always a condition
-        # - a default value of 0
-        multi_if_args.extend([0, 0, 0])
-
-        # Insert a label column into the query that tells us which span condition
-        # the span matched against.
-        #
-        # We only label it with the first matching span condition even if it
-        # matches multiple.
-        user_spans_query.columns.append(Function("multiIf", multi_if_args, MATCHING_SPAN_LABEL))
-
-        # The built in limit by is restricted to the allowed columns but since we're
-        # injecting columns here to label rows, we'll have to inject the limit by clause
-        # as well.
-        user_spans_query.limitby = LimitBy(
-            [user_spans_query.resolve_column("trace"), Column(MATCHING_SPAN_LABEL)],
-            limit_per_query,
-        )
-
-        # First make sure that we only return spans from one of the traces identified
-        user_spans_query.add_conditions(
-            [
-                Condition(
-                    Column("trace_id"),
-                    Op.IN,
-                    Function("splitByChar", [",", ",".join(trace_ids)]),
-                )
-            ]
-        )
-
-        conditions = []
-        if span_keys is not None:
-            assert span_keys
-
-            # Next if there are known span_keys, we only try to fetch those spans
-            # This are the additional conditions to better take advantage of the ORDER BY
-            # on the spans table. This creates a list of conditions to be `OR`ed together
-            # that can will be used by ClickHouse to narrow down the granules.
-            #
-            # The span ids are not in this condition because they are more effective when
-            # specified within the `PREWHERE` clause. So, it's in a separate condition.
-            conditions = [
-                And(
-                    [
-                        Condition(user_spans_query.column("span.group"), Op.EQ, key.group),
-                        Condition(
-                            user_spans_query.column("timestamp"),
-                            Op.EQ,
-                            datetime.fromisoformat(key.timestamp),
-                        ),
-                    ]
-                )
-                for key in span_keys
-            ]
-
-            if len(conditions) == 1:
-                order_by_condition = conditions[0]
-            else:
-                order_by_condition = Or(conditions)
-
-            # Using `IN` combined with putting the list in a SnQL "tuple" triggers an optimizer
-            # in snuba where it
-            # 1. moves the condition into the `PREWHERE` clause
-            # 2. maps the ids to the underlying UInt64 and uses the bloom filter index
-            span_id_condition = Condition(
-                user_spans_query.column("id"),
-                Op.IN,
-                Function("tuple", [key.span_id for key in span_keys]),
-            )
-
-            user_spans_query.add_conditions([order_by_condition, span_id_condition])
-        else:
-            # Next we have to turn the user queries into the appropriate conditions in
-            # the SnQL that we produce.
-
-            # There are multiple sets of user conditions that needs to be satisfied
-            # and if a span satisfy any of them, it should be considered.
-            #
-            # To handle this use case, we want to OR all the user specified
-            # conditions together in this query.
-            for where in user_conditions:
-                if len(where) > 1:
-                    conditions.append(BooleanCondition(op=BooleanOp.AND, conditions=where))
-                elif len(where) == 1:
-                    conditions.append(where[0])
-
-            if len(conditions) > 1:
-                # More than 1 set of conditions were specified, we want to show
-                # spans that match any 1 of them so join the conditions with `OR`s.
-                user_spans_query.add_conditions(
-                    [BooleanCondition(op=BooleanOp.OR, conditions=conditions)]
-                )
-            elif len(conditions) == 1:
-                # Only 1 set of user conditions were specified, simply insert them into
-                # the final query.
-                user_spans_query.add_conditions([conditions[0]])
-
-        return user_spans_query
-
-    def get_suggested_spans_query(
-        self,
-        params: ParamsType,
-        snuba_params: SnubaParams,
-        trace_ids: list[str],
-    ) -> QueryBuilder | None:
-        # If any user queries is the same as the suggested query, we don't have to run it
-        if (
-            not self.user_queries
-            and not self.suggested_query
-            or any(user_query == self.suggested_query for user_query in self.user_queries)
-        ):
-            return None
-
-        suggested_spans_query = SpansIndexedQueryBuilder(
-            Dataset.SpansIndexed,
-            params,
-            snuba_params=snuba_params,
-            query=self.suggested_query,
-            selected_columns=["trace"] + self.fields,
-            orderby=self.sort,
-            limit=len(trace_ids) * self.max_spans_per_trace,
-            limitby=("trace", self.max_spans_per_trace),
-            config=QueryBuilderConfig(
-                transform_alias_to_input_format=True,
-            ),
-        )
-        suggested_spans_query.add_conditions([Condition(Column("trace_id"), Op.IN, trace_ids)])
-        return suggested_spans_query
-
 
 class TraceSpansExecutor:
     def __init__(
@@ -1272,7 +1014,7 @@ class TraceSpansExecutor:
         trace_id: str,
         fields: list[str],
         user_queries: list[str],
-        sort: str | None,
+        sort: list[str] | None,
         metrics_max: float | None,
         metrics_min: float | None,
         metrics_operation: str | None,

--- a/tests/sentry/api/endpoints/test_organization_traces.py
+++ b/tests/sentry/api/endpoints/test_organization_traces.py
@@ -432,19 +432,11 @@ class OrganizationTracesEndpointTest(OrganizationTracesEndpointTestBase):
         assert response.data["meta"] == {
             "dataset": "unknown",
             "datasetReason": "unchanged",
-            "fields": {
-                "id": "string",
-                "parent_span": "string",
-                "span.duration": "duration",
-            },
+            "fields": {},
             "isMetricsData": False,
             "isMetricsExtractedData": False,
             "tips": {},
-            "units": {
-                "id": None,
-                "parent_span": None,
-                "span.duration": "millisecond",
-            },
+            "units": {},
         }
 
         result_data = sorted(response.data["data"], key=lambda trace: trace["duration"])
@@ -462,30 +454,6 @@ class OrganizationTracesEndpointTest(OrganizationTracesEndpointTestBase):
                 "start": timestamps[0],
                 "end": timestamps[0] + 60_100,
                 "breakdowns": [],
-                "spans": [
-                    {
-                        "id": span_ids[3],
-                        "parent_span": span_ids[0],
-                        "span.duration": 30_003.0,
-                    },
-                    {
-                        "id": span_ids[2],
-                        "parent_span": span_ids[0],
-                        "span.duration": 30_002.0,
-                    },
-                    {
-                        "id": span_ids[1],
-                        "parent_span": span_ids[0],
-                        "span.duration": 30_001.0,
-                    },
-                ],
-                "suggestedSpans": [
-                    {
-                        "id": span_ids[3],
-                        "parent_span": span_ids[0],
-                        "span.duration": 30_003.0,
-                    },
-                ],
             },
             {
                 "trace": trace_id_2,
@@ -499,25 +467,6 @@ class OrganizationTracesEndpointTest(OrganizationTracesEndpointTestBase):
                 "start": timestamps[4],
                 "end": timestamps[4] + 90_123,
                 "breakdowns": [],
-                "spans": [
-                    {
-                        "id": span_ids[6],
-                        "parent_span": span_ids[4],
-                        "span.duration": 20_006.0,
-                    },
-                    {
-                        "id": span_ids[5],
-                        "parent_span": span_ids[4],
-                        "span.duration": 20_005.0,
-                    },
-                ],
-                "suggestedSpans": [
-                    {
-                        "id": span_ids[6],
-                        "parent_span": span_ids[4],
-                        "span.duration": 20_006.0,
-                    },
-                ],
             },
         ]
 
@@ -608,20 +557,7 @@ class OrganizationTracesEndpointTest(OrganizationTracesEndpointTestBase):
                 "numSpans": 2,
                 "matchingSpans": 2,
                 "project": project.slug,
-                "spans": [
-                    {
-                        "id": span_id_1,
-                        "parent_span": "00",
-                        "span.duration": 60000.0,
-                    },
-                    {
-                        "id": span_id_2,
-                        "parent_span": span_id_1,
-                        "span.duration": 15000.0,
-                    },
-                ],
                 "start": timestamp,
-                "suggestedSpans": [],
                 "trace": trace_id,
             },
         ]
@@ -685,15 +621,7 @@ class OrganizationTracesEndpointTest(OrganizationTracesEndpointTestBase):
                 "numSpans": 1,
                 "matchingSpans": 1,
                 "project": project.slug,
-                "spans": [
-                    {
-                        "id": span_id,
-                        "parent_span": parent_span_id,
-                        "span.duration": 60100.0,
-                    },
-                ],
                 "start": timestamp,
-                "suggestedSpans": [],
                 "trace": trace_id,
             },
         ]
@@ -732,19 +660,11 @@ class OrganizationTracesEndpointTest(OrganizationTracesEndpointTestBase):
             assert response.data["meta"] == {
                 "dataset": "unknown",
                 "datasetReason": "unchanged",
-                "fields": {
-                    "id": "string",
-                    "parent_span": "string",
-                    "span.duration": "duration",
-                },
+                "fields": {},
                 "isMetricsData": False,
                 "isMetricsExtractedData": False,
                 "tips": {},
-                "units": {
-                    "id": None,
-                    "parent_span": None,
-                    "span.duration": "millisecond",
-                },
+                "units": {},
             }
 
             result_data = sorted(response.data["data"], key=lambda trace: trace["duration"])
@@ -787,30 +707,6 @@ class OrganizationTracesEndpointTest(OrganizationTracesEndpointTestBase):
                             "duration": timestamps[3] - timestamps[1] + 30_003,
                         },
                     ],
-                    "spans": [
-                        {
-                            "id": span_ids[3],
-                            "parent_span": span_ids[0],
-                            "span.duration": 30_003.0,
-                        },
-                        {
-                            "id": span_ids[2],
-                            "parent_span": span_ids[0],
-                            "span.duration": 30_002.0,
-                        },
-                        {
-                            "id": span_ids[1],
-                            "parent_span": span_ids[0],
-                            "span.duration": 30_001.0,
-                        },
-                    ],
-                    "suggestedSpans": [
-                        {
-                            "id": span_ids[3],
-                            "parent_span": span_ids[0],
-                            "span.duration": 30_003.0,
-                        },
-                    ],
                 },
                 {
                     "trace": trace_id_2,
@@ -847,25 +743,6 @@ class OrganizationTracesEndpointTest(OrganizationTracesEndpointTestBase):
                             "sliceWidth": 10,
                             "kind": "project",
                             "duration": timestamps[6] - timestamps[5] + 20_006,
-                        },
-                    ],
-                    "spans": [
-                        {
-                            "id": span_ids[6],
-                            "parent_span": span_ids[4],
-                            "span.duration": 20_006.0,
-                        },
-                        {
-                            "id": span_ids[5],
-                            "parent_span": span_ids[4],
-                            "span.duration": 20_005.0,
-                        },
-                    ],
-                    "suggestedSpans": [
-                        {
-                            "id": span_ids[6],
-                            "parent_span": span_ids[4],
-                            "span.duration": 20_006.0,
                         },
                     ],
                 },
@@ -955,22 +832,6 @@ class OrganizationTracesEndpointTest(OrganizationTracesEndpointTestBase):
                                 "duration": 10_000,
                             },
                         ],
-                        "spans": [
-                            {
-                                "id": span_ids[10],
-                                "parent_span": "00",
-                                "span.duration": 40_000.0,
-                            },
-                        ],
-                        "suggestedSpans": []
-                        if user_query
-                        else [
-                            {
-                                "id": span_ids[10],
-                                "parent_span": "00",
-                                "span.duration": 40_000.0,
-                            },
-                        ],
                     },
                 ], (mri, user_query)
 
@@ -1014,39 +875,6 @@ class OrganizationTracesEndpointTest(OrganizationTracesEndpointTestBase):
                         "units": {},
                     },
                 }
-
-    def test_limit_by_span_condition(self):
-        (
-            project_1,
-            project_2,
-            trace_id_1,
-            trace_id_2,
-            _,
-            timestamps,
-            span_ids,
-        ) = self.create_mock_traces()
-
-        query = {
-            "project": [project_2.id],
-            "field": ["id", "parent_span", "span.duration", "foo"],
-            "query": ["foo:bar", "foo:baz"],
-            "suggestedQuery": "foo:baz span.duration:>0s",
-            "maxSpansPerTrace": 3,
-            "sort": ["foo", "-span.duration"],
-        }
-
-        response = self.do_request(query)
-        assert response.status_code == 200, response.data
-
-        spans = {
-            result["trace"]: {span["id"] for span in result["spans"]}
-            for result in response.data["data"]
-        }
-
-        assert spans == {
-            trace_id_1: {span_ids[2], span_ids[3]},
-            trace_id_2: {span_ids[5], span_ids[6]},
-        }
 
 
 class OrganizationTraceSpansEndpointTest(OrganizationTracesEndpointTestBase):

--- a/tests/sentry/api/endpoints/test_organization_traces.py
+++ b/tests/sentry/api/endpoints/test_organization_traces.py
@@ -282,60 +282,6 @@ class OrganizationTracesEndpointTest(OrganizationTracesEndpointTestBase):
         response = self.do_request({})
         assert response.status_code == 404, response.data
 
-    def test_bad_params_missing_fields(self):
-        query = {
-            "project": [self.project.id],
-            "field": [],
-            "maxSpansPerTrace": 0,
-        }
-
-        response = self.do_request(query)
-        assert response.status_code == 400, response.data
-        assert response.data == {
-            "field": [
-                ErrorDetail(string="This field is required.", code="required"),
-            ],
-            "maxSpansPerTrace": [
-                ErrorDetail(
-                    string="Ensure this value is greater than or equal to 1.", code="min_value"
-                ),
-            ],
-        }
-
-    def test_bad_params_too_few_spans_per_trace(self):
-        query = {
-            "project": [self.project.id],
-            "field": ["id"],
-            "maxSpansPerTrace": 0,
-        }
-
-        response = self.do_request(query)
-        assert response.status_code == 400, response.data
-        assert response.data == {
-            "maxSpansPerTrace": [
-                ErrorDetail(
-                    string="Ensure this value is greater than or equal to 1.", code="min_value"
-                ),
-            ],
-        }
-
-    def test_bad_params_too_many_spans_per_trace(self):
-        query = {
-            "project": [self.project.id],
-            "field": ["id"],
-            "maxSpansPerTrace": 1000,
-        }
-
-        response = self.do_request(query)
-        assert response.status_code == 400, response.data
-        assert response.data == {
-            "maxSpansPerTrace": [
-                ErrorDetail(
-                    string="Ensure this value is less than or equal to 100.", code="max_value"
-                ),
-            ],
-        }
-
     def test_bad_params_too_many_per_page(self):
         query = {
             "project": [self.project.id],
@@ -898,7 +844,10 @@ class OrganizationTraceSpansEndpointTest(OrganizationTracesEndpointTestBase):
             )
 
     def test_no_feature(self):
-        response = self.do_request(uuid4().hex, {}, features=[])
+        query = {
+            "project": [self.project.id],
+        }
+        response = self.do_request(uuid4().hex, query, features=[])
         assert response.status_code == 404, response.data
 
     def test_no_project(self):
@@ -906,21 +855,10 @@ class OrganizationTraceSpansEndpointTest(OrganizationTracesEndpointTestBase):
         assert response.status_code == 404, response.data
 
     def test_bad_params_missing_field(self):
-        (
-            _,
-            _,
-            trace_id,
-            _,
-            _,
-            _,
-            _,
-        ) = self.create_mock_traces()
-
         query = {
             "project": [self.project.id],
         }
-
-        response = self.do_request(trace_id, query)
+        response = self.do_request(uuid4().hex, query)
         assert response.status_code == 400, response.data
         assert response.data == {
             "field": [


### PR DESCRIPTION
The samples are now fetched per trace when it's expanded (see #73024). So remove it from the traces endpoint. Will follow up to parallelize the timeline query.