### PR TITLE
fix(insights): Consistent page headers

### DIFF
--- a/static/app/views/insights/browser/webVitals/views/pageOverview.tsx
+++ b/static/app/views/insights/browser/webVitals/views/pageOverview.tsx
@@ -139,7 +139,7 @@ export function PageOverview() {
         <Layout.Header>
           <Layout.HeaderContent>
             <Breadcrumbs
-              crumbs={[...crumbs, ...(transaction ? [{label: 'Page Overview'}] : [])]}
+              crumbs={[...crumbs, ...(transaction ? [{label: 'Page Summary'}] : [])]}
             />
             <Layout.Title>
               {transaction && project && <ProjectAvatar project={project} size={24} />}

--- a/static/app/views/insights/llmMonitoring/views/llmMonitoringDetailsPage.tsx
+++ b/static/app/views/insights/llmMonitoring/views/llmMonitoringDetailsPage.tsx
@@ -26,7 +26,7 @@ import {
   TotalTokensUsedChart,
 } from 'sentry/views/insights/llmMonitoring/components/charts/llmMonitoringCharts';
 import {PipelineSpansTable} from 'sentry/views/insights/llmMonitoring/components/tables/pipelineSpansTable';
-import {MODULE_TITLE, RELEASE_LEVEL} from 'sentry/views/insights/llmMonitoring/settings';
+import {RELEASE_LEVEL} from 'sentry/views/insights/llmMonitoring/settings';
 import {
   SpanFunction,
   SpanMetricsField,
@@ -95,12 +95,12 @@ export function LLMMonitoringPage({params}: Props) {
               crumbs={[
                 ...crumbs,
                 {
-                  label: spanDescription ?? t('(no name)'),
+                  label: t('Pipeline Summary'),
                 },
               ]}
             />
             <Layout.Title>
-              {MODULE_TITLE}
+              {spanDescription}
               <FeatureBadge type={RELEASE_LEVEL} />
             </Layout.Title>
           </Layout.HeaderContent>
@@ -167,14 +167,10 @@ export function LLMMonitoringPage({params}: Props) {
 }
 
 function PageWithProviders({params}: Props) {
-  const location = useLocation<Query>();
-
-  const {'span.description': spanDescription} = location.query;
-
   return (
     <ModulePageProviders
       moduleName="ai"
-      pageTitle={spanDescription ?? t('(no name)')}
+      pageTitle={t('Pipeline Summary')}
       features="insights-addon-modules"
     >
       <LLMMonitoringPage params={params} />

--- a/static/app/views/insights/mobile/appStarts/views/screenSummaryPage.tsx
+++ b/static/app/views/insights/mobile/appStarts/views/screenSummaryPage.tsx
@@ -195,14 +195,10 @@ export function ScreenSummary() {
 }
 
 function PageWithProviders() {
-  const location = useLocation<Query>();
-
-  const {transaction} = location.query;
-
   return (
     <ModulePageProviders
       moduleName="app_start"
-      pageTitle={transaction}
+      pageTitle={t('Screen Summary')}
       features="insights-initial-modules"
     >
       <ScreenSummary />

--- a/static/app/views/insights/mobile/screenload/views/screenLoadSpansPage.tsx
+++ b/static/app/views/insights/mobile/screenload/views/screenLoadSpansPage.tsx
@@ -204,14 +204,10 @@ function ScreenLoadSpans() {
 }
 
 function PageWithProviders() {
-  const location = useLocation<Query>();
-
-  const {transaction} = location.query;
-
   return (
     <ModulePageProviders
       moduleName="screen_load"
-      pageTitle={transaction}
+      pageTitle={t('Screen Summary')}
       features="insights-initial-modules"
     >
       <ScreenLoadSpans />

--- a/static/app/views/insights/mobile/ui/views/screenSummaryPage.tsx
+++ b/static/app/views/insights/mobile/ui/views/screenSummaryPage.tsx
@@ -114,14 +114,10 @@ function ScreenSummary() {
 }
 
 function PageWithProviders() {
-  const location = useLocation<Query>();
-
-  const {transaction} = location.query;
-
   return (
     <ModulePageProviders
       moduleName="mobile-ui"
-      pageTitle={transaction}
+      pageTitle={t('Screen Summary')}
       features={['insights-addon-modules', 'starfish-mobile-ui-module']}
     >
       <ScreenSummary />


### PR DESCRIPTION
We strayed from the mocks in a few places

- page breadcrumb always generic and ends in "Summary" if relevant (e.g., "Insights > Requests > Domain
  Summary")
- page title is always reverse of breadcrumb (e.g., "Domain Summary -
  Requests - Insights - Sentry")
- page heading is always the module, or the entity being looked (e.g.,
  "Requests" or "127.0.0.1:7000" as appropriate)

**e.g.,**
<img width="616" alt="Screenshot 2024-06-19 at 4 28 55 PM" src="https://github.com/getsentry/sentry/assets/989898/3b81dce3-6221-4c25-b603-618de857cc0f">
