### PR TITLE
feat(tracing) add tracing session integration

### DIFF
--- a/static/app/bootstrap/initializeSdk.tsx
+++ b/static/app/bootstrap/initializeSdk.tsx
@@ -9,6 +9,7 @@ import type {Config} from 'sentry/types/system';
 import {addExtraMeasurements, addUIElementTag} from 'sentry/utils/performanceForSentry';
 import {normalizeUrl} from 'sentry/utils/withDomainRequired';
 import {getErrorDebugIds} from 'sentry/utils/getErrorDebugIds';
+import {TracingSessionIntegration} from 'sentry/views/performance/newTraceDetails/tracingSessionIntegration';
 
 const SPA_MODE_ALLOW_URLS = [
   'localhost',
@@ -63,6 +64,8 @@ function getSentryIntegrations(routes?: Function) {
       },
     }),
     Sentry.browserProfilingIntegration(),
+    // Experimental tracing session integration to connect traces together
+    TracingSessionIntegration,
   ];
 
   return integrations;

--- a/static/app/views/performance/newTraceDetails/tracingSessionIntegration.test.tsx
+++ b/static/app/views/performance/newTraceDetails/tracingSessionIntegration.test.tsx
@@ -1,0 +1,66 @@
+import {getOrStartTracingSession} from './tracingSessionIntegration';
+
+describe('tracingSessionIntegration', () => {
+  beforeEach(() => {
+    // @ts-expect-error
+    delete window.sessionStorage;
+  });
+  it.each([
+    ['undefined'][JSON.stringify('}')],
+    [JSON.stringify({id: '123', started_at: ''})],
+    [JSON.stringify({id: '', started_at: Date.now()})],
+  ])('starts invalid session when storage is in a broken state', session => {
+    Object.defineProperty(window, 'sessionStorage', {
+      writable: true,
+      value: {
+        getItem() {
+          return session;
+        },
+      },
+    });
+
+    expect(getOrStartTracingSession()).toEqual({
+      id: expect.any(String),
+      started_at: expect.any(Number),
+    });
+  });
+
+  it('handles session storage throwing', () => {
+    Object.defineProperty(window, 'sessionStorage', {
+      writable: true,
+      value: {
+        getItem() {
+          throw new Error('dead');
+        },
+      },
+    });
+
+    expect(getOrStartTracingSession()).toEqual({
+      id: expect.any(String),
+      started_at: expect.any(Number),
+    });
+  });
+
+  it('starts new session after expiry time', () => {
+    // 2 hours past expiry date
+    const YESTERDAY = Date.now() - 24 * 2 * 60 * 60 * 1000;
+    Object.defineProperty(window, 'sessionStorage', {
+      writable: true,
+      value: {
+        getItem() {
+          return JSON.stringify({
+            id: '123',
+            started_at: YESTERDAY,
+          });
+        },
+      },
+    });
+
+    const session = getOrStartTracingSession();
+    expect(session.started_at).toBeGreaterThan(YESTERDAY);
+    expect(session).toEqual({
+      id: expect.any(String),
+      started_at: expect.any(Number),
+    });
+  });
+});

--- a/static/app/views/performance/newTraceDetails/tracingSessionIntegration.tsx
+++ b/static/app/views/performance/newTraceDetails/tracingSessionIntegration.tsx
@@ -1,0 +1,98 @@
+import {getGlobalScope} from '@sentry/core';
+import type {Integration} from '@sentry/types';
+import {uuid4} from '@sentry/utils';
+
+/**
+ * This is a POC to test how/if we could enable a concept of tracing sessions (similarly to what replay does
+ * by connecting sessions with a replay id). The main goal is to allow users viewing traces to visualize the next
+ * or previous trace that was initiated by the user, which would help with debugging and navigation.
+ *
+ * Note: Unlike relay this doesnt rely on user input or dom mutations to detect idle states and just store a session
+ * in session storage and expire it after 24h. For the purposes of the POC, this is probably fine, but we may
+ * want a better approach that mimics the behavior of replay more closely.
+ */
+
+type Session = {
+  id: string;
+  started_at: number;
+};
+
+const TRACE_SESSION_STORAGE_KEY = 'traceSession';
+// Afaik we cant patch a context value, so we'll use a different key to store this and avoid conflicts.
+const TRACE_SESSION_SENTRY_CONTEXT_KEY = 'trace_session';
+
+const EXPIRY_MS = 1000 * 60 * 60 * 24; // 24 hours
+
+function makeSession(): Session {
+  return {
+    id: uuid4(),
+    started_at: Date.now(),
+  };
+}
+
+function safeGetSessionFromStorage(): string | null {
+  try {
+    return window.sessionStorage.getItem(TRACE_SESSION_STORAGE_KEY);
+  } catch {
+    return null;
+  }
+}
+
+function tryParse(input: any): any {
+  if (typeof input !== 'string') {
+    return null;
+  }
+  try {
+    return JSON.parse(input);
+  } catch {
+    return null;
+  }
+}
+
+function validateSessionSchema(input: any): input is Session {
+  return (
+    !!input &&
+    'id' in input &&
+    'started_at' in input &&
+    typeof input.id === 'string' &&
+    input.id.length > 0 &&
+    typeof input.started_at === 'number' &&
+    !isNaN(input.started_at) &&
+    input.started_at > 0
+  );
+}
+
+function sessionHasExpired(session: Session): boolean {
+  return Date.now() - session.started_at > EXPIRY_MS;
+}
+
+export function getOrStartTracingSession(): Session {
+  // This can throw if cookies are disabled or some privacy setting is overriding session storage.
+  // If that happens, just treat sessions as ephemeral
+  if (typeof window === 'undefined' || typeof window.sessionStorage === 'undefined') {
+    return makeSession();
+  }
+
+  const something = safeGetSessionFromStorage();
+  const maybeSession = tryParse(something);
+
+  // If there is garbage stored in the session, start a new one
+  if (!validateSessionSchema(maybeSession)) {
+    return makeSession();
+  }
+
+  // If the session has expired, start a new one
+  if (sessionHasExpired(maybeSession)) {
+    return makeSession();
+  }
+
+  return maybeSession;
+}
+
+export const TracingSessionIntegration: Integration = {
+  name: 'SentrySessionIntegration',
+  setup(_client) {
+    const globalScope = getGlobalScope();
+    globalScope.setContext(TRACE_SESSION_SENTRY_CONTEXT_KEY, getOrStartTracingSession());
+  },
+};


### PR DESCRIPTION
Add a session integration so we can see if it would be feasible to connect traces in a similar way as how replay connects them via replay id so that we can provide a better navigation experience