### PR TITLE
ref(related_issues): Improve code for title, subtitle and message

### DIFF
--- a/static/app/views/issueDetails/traceTimeline/traceIssue.tsx
+++ b/static/app/views/issueDetails/traceTimeline/traceIssue.tsx
@@ -102,7 +102,6 @@ function getTitleSubtitleMessage(event: TimelineEvent) {
     // If we fail, report it so we can figure it out
     Sentry.captureException(error);
   }
-
   return {title, subtitle, message};
 }
 

--- a/static/app/views/issueDetails/traceTimeline/traceIssue.tsx
+++ b/static/app/views/issueDetails/traceTimeline/traceIssue.tsx
@@ -69,17 +69,18 @@ export function TraceIssueEvent({event}: TraceIssueEventProps) {
   );
 }
 
-// This function tries to imitate getTitle() from utils.events
-// In that module, the data comes from the issues/ endpoint while here
-// we grab the data from the events/ endpoint. A larger effort is
+// This function tries to imitate what getTitle() from utils.events does.
+// In that module, the data comes from the issues endpoint while in here
+// we grab the data from the events endpoint. A larger effort is
 // required in order to use that function directly since the data between
-// the two endpoint is slightly different. We would need
-// to grab the metadata for the issue from the issues endpoint (which requires work).
-// At this moment, the issues endpoint is extremely slow and we
-// would need to change it to only return the metadata for the issue.
+// the two endpoint is slightly different.
+// For instance, the events endpoint could include a _metadata dict with
+// the title, subtitle and message.
+// We could also make another call to the issues endpoint  to fetch the metadata,
+// however, we currently don't support it and it is extremely slow
 function getTitleSubtitleMessage(event: TimelineEvent) {
   let title = event.title.trimEnd();
-  let message = event.message;
+  let message;
   // culprit is what getTitle() from utils.events uses rather than the transaction
   const subtitle = event.culprit || '';
   try {

--- a/static/app/views/issueDetails/traceTimeline/traceIssue.tsx
+++ b/static/app/views/issueDetails/traceTimeline/traceIssue.tsx
@@ -78,13 +78,15 @@ export function TraceIssueEvent({event}: TraceIssueEventProps) {
 // At this moment, the issues endpoint is extremely slow and we
 // would need to change it to only return the metadata for the issue.
 function getTitleSubtitleMessage(event: TimelineEvent) {
-  let title = event.title;
+  let title = event.title.trimEnd();
   let message = event.message;
   // culprit is what getTitle() from utils.events uses rather than the transaction
   const subtitle = event.culprit || '';
   try {
     if (event['event.type'] === 'error') {
-      title = event.title.split(':')[0];
+      if (title[title.length - 1] !== ':') {
+        title = event.title.split(':')[0];
+      }
       message = event['error.value'][event['error.value'].length - 1];
     } else {
       // It is suspected that this value is calculated somewhere in Relay

--- a/static/app/views/issueDetails/traceTimeline/traceLink.spec.tsx
+++ b/static/app/views/issueDetails/traceTimeline/traceLink.spec.tsx
@@ -32,6 +32,7 @@ describe('TraceLink', () => {
         title: 'Slow DB Query',
         id: 'abc',
         transaction: '/api/slow/',
+        culprit: '/api/slow/',
       },
     ],
     meta: {fields: {}, units: {}},
@@ -39,7 +40,6 @@ describe('TraceLink', () => {
   const discoverBody: TraceEventResponse = {
     data: [
       {
-        message: 'This is the subtitle of the issue',
         timestamp: '2024-01-23T22:11:42+00:00',
         'issue.id': 4909507143,
         project: project.slug,
@@ -48,6 +48,9 @@ describe('TraceLink', () => {
         id: event.id,
         transaction: 'important.task',
         'event.type': 'error',
+        culprit: 'foo',
+        'error.value': [],
+        'stack.function': [],
       },
     ],
     meta: {fields: {}, units: {}},

--- a/static/app/views/issueDetails/traceTimeline/useTraceTimelineEvents.tsx
+++ b/static/app/views/issueDetails/traceTimeline/useTraceTimelineEvents.tsx
@@ -22,7 +22,7 @@ interface TimelineDiscoverEvent extends BaseEvent {
   'event.type': string;
   'stack.function': string[];
 }
-interface TimelineIssuePlatformEvent extends BaseEvent {
+export interface TimelineIssuePlatformEvent extends BaseEvent {
   message: string; // Used for the message
 }
 

--- a/static/app/views/issueDetails/traceTimeline/useTraceTimelineEvents.tsx
+++ b/static/app/views/issueDetails/traceTimeline/useTraceTimelineEvents.tsx
@@ -149,6 +149,7 @@ export function useTraceTimelineEvents({event}: UseTraceTimelineEventsOptions): 
       events.push({
         id: event.id,
         culprit: event.culprit,
+        'error.value': event['errors.value'] ?? [],
         'issue.id': Number(event.groupID),
         message: event.message,
         project: event.projectID,

--- a/static/app/views/issueDetails/traceTimeline/useTraceTimelineEvents.tsx
+++ b/static/app/views/issueDetails/traceTimeline/useTraceTimelineEvents.tsx
@@ -7,6 +7,7 @@ import {useApiQuery} from 'sentry/utils/queryClient';
 import useOrganization from 'sentry/utils/useOrganization';
 
 interface BaseEvent {
+  culprit: string; // Used for subtitle
   id: string;
   'issue.id': number;
   message: string;
@@ -17,11 +18,11 @@ interface BaseEvent {
   transaction: string;
 }
 
-interface TimelineDiscoverEvent extends BaseEvent {}
-interface TimelineIssuePlatformEvent extends BaseEvent {
+interface TimelineDiscoverEvent extends BaseEvent {
   'event.type': string;
   'stack.function': string[];
 }
+interface TimelineIssuePlatformEvent extends BaseEvent {}
 
 export type TimelineEvent = TimelineDiscoverEvent | TimelineIssuePlatformEvent;
 
@@ -62,7 +63,15 @@ export function useTraceTimelineEvents({event}: UseTraceTimelineEventsOptions): 
         query: {
           // Get performance issues
           dataset: DiscoverDatasets.ISSUE_PLATFORM,
-          field: ['message', 'title', 'project', 'timestamp', 'issue.id', 'transaction'],
+          field: [
+            'message',
+            'title',
+            'project',
+            'timestamp',
+            'issue.id',
+            'transaction',
+            'culprit', // Used for the subtitle
+          ],
           per_page: 100,
           query: `trace:${traceId}`,
           referrer: 'api.issues.issue_events',
@@ -98,6 +107,7 @@ export function useTraceTimelineEvents({event}: UseTraceTimelineEventsOptions): 
             'transaction',
             'event.type',
             'stack.function',
+            'culprit', // Used for the subtitle
           ],
           per_page: 100,
           query: `trace:${traceId}`,
@@ -136,6 +146,7 @@ export function useTraceTimelineEvents({event}: UseTraceTimelineEventsOptions): 
     if (!hasCurrentEvent) {
       events.push({
         id: event.id,
+        culprit: event.culprit,
         'issue.id': Number(event.groupID),
         message: event.message,
         project: event.projectID,

--- a/static/app/views/issueDetails/traceTimeline/useTraceTimelineEvents.tsx
+++ b/static/app/views/issueDetails/traceTimeline/useTraceTimelineEvents.tsx
@@ -19,6 +19,7 @@ interface BaseEvent {
 }
 
 interface TimelineDiscoverEvent extends BaseEvent {
+  'error.value': string[];
   'event.type': string;
   'stack.function': string[];
 }
@@ -108,6 +109,7 @@ export function useTraceTimelineEvents({event}: UseTraceTimelineEventsOptions): 
             'event.type',
             'stack.function',
             'culprit', // Used for the subtitle
+            'error.value', // Used for the message
           ],
           per_page: 100,
           query: `trace:${traceId}`,

--- a/static/app/views/issueDetails/traceTimeline/useTraceTimelineEvents.tsx
+++ b/static/app/views/issueDetails/traceTimeline/useTraceTimelineEvents.tsx
@@ -10,7 +10,6 @@ interface BaseEvent {
   culprit: string; // Used for subtitle
   id: string;
   'issue.id': number;
-  message: string;
   project: string;
   'project.name': string;
   timestamp: string;
@@ -23,7 +22,9 @@ interface TimelineDiscoverEvent extends BaseEvent {
   'event.type': string;
   'stack.function': string[];
 }
-interface TimelineIssuePlatformEvent extends BaseEvent {}
+interface TimelineIssuePlatformEvent extends BaseEvent {
+  message: string; // Used for the message
+}
 
 export type TimelineEvent = TimelineDiscoverEvent | TimelineIssuePlatformEvent;
 
@@ -62,10 +63,10 @@ export function useTraceTimelineEvents({event}: UseTraceTimelineEventsOptions): 
       `/organizations/${organization.slug}/events/`,
       {
         query: {
-          // Get performance issues
+          // Get issue platform issues
           dataset: DiscoverDatasets.ISSUE_PLATFORM,
           field: [
-            'message',
+            'message', // Used for the message
             'title',
             'project',
             'timestamp',
@@ -100,7 +101,6 @@ export function useTraceTimelineEvents({event}: UseTraceTimelineEventsOptions): 
           // Other events
           dataset: DiscoverDatasets.DISCOVER,
           field: [
-            'message',
             'title',
             'project',
             'timestamp',

--- a/static/app/views/issueDetails/traceTimelineOrRelatedIssue.spec.tsx
+++ b/static/app/views/issueDetails/traceTimelineOrRelatedIssue.spec.tsx
@@ -42,6 +42,7 @@ describe('TraceTimeline & TraceRelated Issue', () => {
       {
         // In issuePlatform, the message contains the title and the transaction
         message: '/api/slow/ Slow DB Query SELECT "sentry_monitorcheckin"."monitor_id"',
+        culprit: '/api/slow/', // Used for subtitle
         timestamp: '2024-01-24T09:09:03+00:00',
         'issue.id': 1000,
         project: project.slug,
@@ -55,6 +56,7 @@ describe('TraceTimeline & TraceRelated Issue', () => {
   };
   const mainError = {
     message: 'This is the message for the issue',
+    culprit: '/api/foo/', // Used for subtitle
     timestamp: firstEventTimestamp,
     'issue.id': event['issue.id'],
     project: project.slug,
@@ -67,6 +69,7 @@ describe('TraceTimeline & TraceRelated Issue', () => {
   };
   const secondError = {
     message: 'Message of the second issue',
+    culprit: '/api/foo/', // Used for subtitle
     timestamp: '2024-01-24T09:09:04+00:00',
     'issue.id': 9999,
     project: project.slug,
@@ -287,9 +290,7 @@ describe('TraceTimeline & TraceRelated Issue', () => {
     });
 
     render(<TraceTimeLineOrRelatedIssue event={event} />, {
-      organization: OrganizationFixture({
-        features: [],
-      }),
+      organization: OrganizationFixture({features: []}), // No global-views feature
     });
     expect(await screen.findByLabelText('Current Event')).toBeInTheDocument();
   });

--- a/static/app/views/issueDetails/traceTimelineOrRelatedIssue.spec.tsx
+++ b/static/app/views/issueDetails/traceTimelineOrRelatedIssue.spec.tsx
@@ -69,7 +69,7 @@ describe('TraceTimeline & TraceRelated Issue', () => {
     'stack.function': ['important.task', 'task.run'],
   };
   const secondError = {
-    title: 'WorkerLostError: ', // XXX: The colon is not being handled in the code
+    title: 'WorkerLostError: ', // The code handles the colon and extra space in the title
     culprit: 'billiard.pool in mark_as_worker_lost', // Used for subtitle
     message: 'Some other error message',
     // This is a case where the culprit is available while the transaction is not
@@ -257,8 +257,8 @@ describe('TraceTimeline & TraceRelated Issue', () => {
     render(<TraceTimeLineOrRelatedIssue event={event} />, {organization});
 
     // Check title, subtitle and message of error event
-    // XXX: Follow up PR to handle the colon missing
-    expect(await screen.findByText('WorkerLostError')).toBeInTheDocument();
+    // Some errors have a colon in the title and we should preserve it
+    expect(await screen.findByText('WorkerLostError:')).toBeInTheDocument();
     expect(
       await screen.findByText('billiard.pool in mark_as_worker_lost')
     ).toBeInTheDocument();

--- a/static/app/views/issueDetails/traceTimelineOrRelatedIssue.spec.tsx
+++ b/static/app/views/issueDetails/traceTimelineOrRelatedIssue.spec.tsx
@@ -55,32 +55,31 @@ describe('TraceTimeline & TraceRelated Issue', () => {
     meta: {fields: {}, units: {}},
   };
   const mainError = {
-    title: event.title,
     culprit: '/api/foo/', // Used for subtitle
-    message: '',
-    transaction: 'not-being-tested',
     'error.value': [],
     timestamp: firstEventTimestamp,
     'issue.id': event['issue.id'],
     project: project.slug,
     'project.name': project.name,
+    title: event.title,
     id: event.id,
+    transaction: 'not-being-tested',
     'event.type': event.type,
     'stack.function': ['important.task', 'task.run'],
   };
   const secondError = {
-    title: 'WorkerLostError: ', // The code handles the colon and extra space in the title
     culprit: 'billiard.pool in mark_as_worker_lost', // Used for subtitle
-    message: 'Some other error message',
-    // This is a case where the culprit is available while the transaction is not
-    transaction: '',
-    'error.value': ['some-other-error-value', 'The error message used for the issue'],
+    'error.value': ['some-other-error-value', 'The last error value'],
     timestamp: '2024-01-24T09:09:04+00:00',
     'issue.id': 9999,
     project: project.slug,
     'project.name': project.name,
+    title: 'WorkerLostError: ', // The code handles the colon and extra space in the title
     id: '12345',
+    // This is a case where the culprit is available while the transaction is not
+    transaction: '',
     'event.type': event.type,
+    'stack.function': [],
   };
   const discoverBody: TraceEventResponse = {
     data: [mainError],
@@ -259,17 +258,12 @@ describe('TraceTimeline & TraceRelated Issue', () => {
     // Check title, subtitle and message of error event
     // Some errors have a colon in the title and we should preserve it
     expect(await screen.findByText('WorkerLostError:')).toBeInTheDocument();
+    // The subtitle is the culprit
     expect(
       await screen.findByText('billiard.pool in mark_as_worker_lost')
     ).toBeInTheDocument();
-    expect(
-      // The message value is not found in the page
-      await screen.queryByText('Task handler raised error:')
-    ).not.toBeInTheDocument();
-    expect(
-      // The message value is not found in the page
-      await screen.findByText('The error message used for the issue')
-    ).toBeInTheDocument();
+    // The message from the last error value
+    expect(await screen.findByText('The last error value')).toBeInTheDocument();
   });
 
   it('skips the timeline and shows NO related issues (only 1 issue)', async () => {


### PR DESCRIPTION
This fixes the rendering of some issues to match what we do on the Issue Details page.

Changes:
* Fix default events
* Fix some error events edge cases using `culprit` and `error.value` information

![image](https://github.com/getsentry/sentry/assets/44410/6821f165-86e9-402e-9598-60c9dc89011d)

This shows a working default event:
![image](https://github.com/getsentry/sentry/assets/44410/8851d767-eb81-4d93-9e87-3eb8de8c90c5)
instead of this:
<img width="508" alt="image" src="https://github.com/getsentry/sentry/assets/44410/945e4a57-898d-452f-8e36-3a732fffe5f4">

NOTE: We can't use the same function we use for the Issue Details page since the data come from different endpoints and have different types.


