### PR TITLE
feat(insights): adds inp to count_web_vitals allow list

### DIFF
--- a/src/sentry/search/events/datasets/metrics.py
+++ b/src/sentry/search/events/datasets/metrics.py
@@ -593,6 +593,7 @@ class MetricsDatasetConfig(DatasetConfig):
                                 "measurements.fid",
                                 "measurements.cls",
                                 "measurements.ttfb",
+                                "measurements.inp",
                             ],
                             allow_custom_measurements=False,
                         ),
@@ -1359,6 +1360,7 @@ class MetricsDatasetConfig(DatasetConfig):
             "measurements.fid",
             "measurements.cls",
             "measurements.ttfb",
+            "measurements.inp",
         ]:
             raise InvalidSearchQuery("count_web_vitals only supports measurements")
 


### PR DESCRIPTION
Adds `measurements.inp` to the allowlist for the `count_web_vitals` function in the discover metrics dataset.