### PR TITLE
chore(frontend): Add `@tanstack/react-virtual` for newer virtualized lists

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "@spotlightjs/spotlight": "^2.0.0-alpha.1",
     "@tanstack/react-query": "^4.29.7",
     "@tanstack/react-query-devtools": "^4.36.1",
+    "@tanstack/react-virtual": "^3.5.1",
     "@types/color": "^3.0.3",
     "@types/diff": "5.2.1",
     "@types/dompurify": "^3.0.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3334,6 +3334,18 @@
     "@tanstack/query-core" "4.29.7"
     use-sync-external-store "^1.2.0"
 
+"@tanstack/react-virtual@^3.5.1":
+  version "3.5.1"
+  resolved "https://registry.yarnpkg.com/@tanstack/react-virtual/-/react-virtual-3.5.1.tgz#1ce466f530a10f781871360ed2bf7ff83e664f85"
+  integrity sha512-jIsuhfgy8GqA67PdWqg73ZB2LFE+HD9hjWL1L6ifEIZVyZVAKpYmgUG4WsKQ005aEyImJmbuimPiEvc57IY0Aw==
+  dependencies:
+    "@tanstack/virtual-core" "3.5.1"
+
+"@tanstack/virtual-core@3.5.1":
+  version "3.5.1"
+  resolved "https://registry.yarnpkg.com/@tanstack/virtual-core/-/virtual-core-3.5.1.tgz#f519149bce9156d0e7954b9531df15f446f2fc12"
+  integrity sha512-046+AUSiDru/V9pajE1du8WayvBKeCvJ2NmKPy/mR8/SbKKrqmSbj7LJBfXE+nSq4f5TBXvnCzu0kcYebI9WdQ==
+
 "@testing-library/dom@10.1.0":
   version "10.1.0"
   resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-10.1.0.tgz#2d073e49771ad614da999ca48f199919e5176fb6"


### PR DESCRIPTION
Going forward we'll want to implement these with the new API. Advised to do this by @scttcper for some update work to breadcrumbs.