### PR TITLE
ref(replay): disable settings button until replay is loaded

### DIFF
--- a/static/app/components/replays/replayController.tsx
+++ b/static/app/components/replays/replayController.tsx
@@ -21,6 +21,7 @@ const COMPACT_WIDTH_BREAKPOINT = 500;
 interface Props {
   toggleFullscreen: () => void;
   disableSettings?: boolean;
+  isLoading?: boolean;
   speedOptions?: number[];
 }
 
@@ -63,9 +64,11 @@ function ReplayPlayPauseBar() {
 function ReplayOptionsMenu({
   speedOptions,
   disableSettings,
+  isLoading,
 }: {
   disableSettings: boolean;
   speedOptions: number[];
+  isLoading?: boolean;
 }) {
   const {setSpeed, speed, isSkippingInactive, toggleSkipInactive} = useReplayContext();
   const SKIP_OPTION_VALUE = 'skip';
@@ -76,12 +79,14 @@ function ReplayOptionsMenu({
         <Button
           {...triggerProps}
           size="sm"
-          title={t('Settings')}
+          title={
+            disableSettings ? t('Playback settings are not available yet') : t('Settings')
+          }
           aria-label={t('Settings')}
           icon={<IconSettings size="sm" />}
         />
       )}
-      disabled={disableSettings}
+      disabled={isLoading || disableSettings}
     >
       <CompositeSelect.Region
         label={t('Playback Speed')}
@@ -114,6 +119,7 @@ function ReplayControls({
   toggleFullscreen,
   disableSettings = false,
   speedOptions = [0.1, 0.25, 0.5, 1, 2, 4, 8, 16],
+  isLoading,
 }: Props) {
   const barRef = useRef<HTMLDivElement>(null);
   const [isCompact, setIsCompact] = useState(false);
@@ -139,6 +145,7 @@ function ReplayControls({
       </Container>
       <ButtonBar gap={1}>
         <ReplayOptionsMenu
+          isLoading={isLoading}
           speedOptions={speedOptions}
           disableSettings={disableSettings}
         />

--- a/static/app/views/replays/detail/layout/index.tsx
+++ b/static/app/views/replays/detail/layout/index.tsx
@@ -55,6 +55,7 @@ function ReplayLayout({
   const controller = (
     <ErrorBoundary mini>
       <ReplayController
+        isLoading={isLoading}
         toggleFullscreen={toggleFullscreen}
         disableSettings={isVideoReplay}
       />


### PR DESCRIPTION
- disable the settings button (has options for playback speed and fast-forward, which is not available for mobile yet. disabling means that while a mobile replay is loading, the user won't be able to click into the settings dropdown too eagerly)
- add a new tooltip over the mobile version to say it's not available
- closes https://github.com/getsentry/sentry/issues/72998

<img width="187" alt="SCR-20240620-iuqr" src="https://github.com/getsentry/sentry/assets/56095982/d0bf518e-701e-40a1-a3f4-0cb618296fa5">


mobile:

https://github.com/getsentry/sentry/assets/56095982/8db169e2-984a-49b1-bcfa-c4737c3a379d


web:

https://github.com/getsentry/sentry/assets/56095982/16aaedc4-2301-40da-8ff7-b0bc6b006c34


