### PR TITLE
fix(processing): Use correct comparison interval

### DIFF
--- a/src/sentry/rules/conditions/event_frequency.py
+++ b/src/sentry/rules/conditions/event_frequency.py
@@ -261,7 +261,7 @@ class BaseEventFrequencyCondition(EventCondition, abc.ABC):
         return option_override_cm
 
     def get_comparison_start_end(
-        self, interval: timedelta, duration: timedelta
+        self, end: datetime, duration: timedelta, interval: timedelta = None
     ) -> tuple[datetime, datetime]:
         """
         Calculate the start and end times for the query. `interval` is only used for EventFrequencyPercentCondition
@@ -269,7 +269,8 @@ class BaseEventFrequencyCondition(EventCondition, abc.ABC):
         `duration` is the time frame in which the condition is measuring counts, e.g. the '10 minutes' in
         "The issue is seen more than 100 times in 10 minutes"
         """
-        end = timezone.now() - interval
+        if interval:
+            end = end - interval
         start = end - duration
         return (start, end)
 
@@ -281,14 +282,17 @@ class BaseEventFrequencyCondition(EventCondition, abc.ABC):
         environment_id: int,
         comparison_type: str,
     ) -> int:
-        start, end = self.get_comparison_start_end(timedelta(), duration)
+        current_time = timezone.now()
+        start, end = self.get_comparison_start_end(current_time, duration)
         with self.disable_consistent_snuba_mode(duration):
             result = self.query(event, start, end, environment_id=environment_id)
             if comparison_type == ComparisonType.PERCENT:
                 # TODO: Figure out if there's a way we can do this less frequently. All queries are
                 # automatically cached for 10s. We could consider trying to cache this and the main
                 # query for 20s to reduce the load.
-                start, end = self.get_comparison_start_end(comparison_interval, duration)
+                start, end = self.get_comparison_start_end(
+                    current_time, duration, comparison_interval
+                )
                 comparison_result = self.query(event, start, end, environment_id=environment_id)
                 result = percent_increase(result, comparison_result)
 
@@ -297,31 +301,31 @@ class BaseEventFrequencyCondition(EventCondition, abc.ABC):
     def get_rate_bulk(
         self,
         duration: timedelta,
-        comparison_interval: timedelta,
         group_ids: set[int],
         environment_id: int,
         comparison_type: str,
+        current_time: datetime,
+        comparison_interval: timedelta | None = None,
     ) -> dict[int, int]:
-        start, end = self.get_comparison_start_end(timedelta(), duration)
         with self.disable_consistent_snuba_mode(duration):
-            result = self.batch_query(
-                group_ids=group_ids,
-                start=start,
-                end=end,
-                environment_id=environment_id,
-            )
-        if comparison_type == ComparisonType.PERCENT:
-            start, comparison_end = self.get_comparison_start_end(comparison_interval, duration)
-            comparison_result = self.batch_query(
-                group_ids=group_ids,
-                start=start,
-                end=comparison_end,
-                environment_id=environment_id,
-            )
-            result = {
-                group_id: percent_increase(result[group_id], comparison_result[group_id])
-                for group_id in group_ids
-            }
+            if comparison_type == ComparisonType.COUNT:
+                start, end = self.get_comparison_start_end(current_time, duration)
+                result = self.batch_query(
+                    group_ids=group_ids,
+                    start=start,
+                    end=end,
+                    environment_id=environment_id,
+                )
+            elif comparison_type == ComparisonType.PERCENT:
+                start, comparison_end = self.get_comparison_start_end(
+                    current_time, duration, comparison_interval
+                )
+                result = self.batch_query(
+                    group_ids=group_ids,
+                    start=start,
+                    end=comparison_end,
+                    environment_id=environment_id,
+                )
         return result
 
     def get_snuba_query_result(

--- a/src/sentry/rules/conditions/event_frequency.py
+++ b/src/sentry/rules/conditions/event_frequency.py
@@ -50,6 +50,9 @@ COMPARISON_INTERVALS: dict[str, tuple[str, timedelta]] = {
 SNUBA_LIMIT = 10000
 
 
+DEFAULT_COMPARISON_INTERVAL = "5m"
+
+
 class ComparisonType(TextChoices):
     COUNT = "count"
     PERCENT = "percent"
@@ -165,7 +168,9 @@ class BaseEventFrequencyCondition(EventCondition, abc.ABC):
             return False
 
         comparison_type = self.get_option("comparisonType", ComparisonType.COUNT)
-        comparison_interval_option = self.get_option("comparisonInterval", "5m")
+        comparison_interval_option = self.get_option(
+            "comparisonInterval", DEFAULT_COMPARISON_INTERVAL
+        )
         if comparison_interval_option == "":
             return False
         comparison_interval = COMPARISON_INTERVALS[comparison_interval_option][1]

--- a/src/sentry/rules/processing/delayed_processing.py
+++ b/src/sentry/rules/processing/delayed_processing.py
@@ -15,6 +15,7 @@ from sentry.models.rule import Rule
 from sentry.models.rulesnooze import RuleSnooze
 from sentry.rules import history, rules
 from sentry.rules.conditions.event_frequency import (
+    DEFAULT_COMPARISON_INTERVAL,
     BaseEventFrequencyCondition,
     ComparisonType,
     EventFrequencyConditionData,
@@ -143,7 +144,7 @@ def get_condition_group_results(
 
         _, duration = condition_inst.intervals[unique_condition.interval]
         comparison_interval = condition_inst.intervals[
-            condition_data.get("comparisonInterval", "5m")
+            condition_data.get("comparisonInterval", DEFAULT_COMPARISON_INTERVAL)
         ][1]
         comparison_type = (
             condition_data.get("comparisonType", ComparisonType.COUNT)

--- a/src/sentry/rules/processing/delayed_processing.py
+++ b/src/sentry/rules/processing/delayed_processing.py
@@ -48,7 +48,7 @@ class UniqueCondition(NamedTuple):
 
 
 class DataAndGroups(NamedTuple):
-    data: EventFrequencyConditionData | None
+    data: EventFrequencyConditionData
     group_ids: set[int]
 
     def __repr__(self):
@@ -142,7 +142,9 @@ def get_condition_group_results(
             return None
 
         _, duration = condition_inst.intervals[unique_condition.interval]
-        comparison_interval = condition_inst.intervals[unique_condition.interval][1]
+        comparison_interval = condition_inst.intervals[
+            condition_data.get("comparisonInterval", "5m")
+        ][1]
         comparison_type = (
             condition_data.get("comparisonType", ComparisonType.COUNT)
             if condition_data

--- a/src/sentry/rules/processing/delayed_processing.py
+++ b/src/sentry/rules/processing/delayed_processing.py
@@ -19,6 +19,7 @@ from sentry.rules.conditions.event_frequency import (
     BaseEventFrequencyCondition,
     ComparisonType,
     EventFrequencyConditionData,
+    percent_increase,
 )
 from sentry.rules.processing.processor import (
     PROJECT_ID_BUFFER_LIST_KEY,
@@ -39,10 +40,17 @@ logger = logging.getLogger("sentry.rules.delayed_processing")
 EVENT_LIMIT = 100
 
 
-class UniqueCondition(NamedTuple):
+class UniqueQuery(NamedTuple):
+    """
+    This class represents all the data that uniquely identifies a Snuba query
+    which can share the same scan for multiple conditions. Note that all
+    conditions must be of the same class however.
+    """
+
     cls_id: str
     interval: str
     environment_id: int
+    comparisonInterval: str | None = None
 
     def __repr__(self):
         return f"id: {self.cls_id},\ninterval: {self.interval},\nenv id: {self.environment_id}"
@@ -92,42 +100,58 @@ def get_rules_to_slow_conditions(
     return rules_to_slow_conditions
 
 
+def _generate_unique_queries(
+    condition_data: EventFrequencyConditionData, environment_id: int
+) -> list[UniqueQuery]:
+    """
+    Returns a list of all unique queries that must be made for a condition.
+    Count comparison conditions will only have one unique query, while percent
+    comparison conditions will have two unique queries.
+    """
+    unique_queries = [UniqueQuery(condition_data["id"], condition_data["interval"], environment_id)]
+    if condition_data.get("comparisonType") == ComparisonType.PERCENT:
+        # We will later compare the first query results against the second query to calculate
+        # a percentage for percentage comparison conditions.
+        comparison_interval = condition_data.get("comparisonInterval", DEFAULT_COMPARISON_INTERVAL)
+        unique_queries.append(unique_queries[0]._replace(comparisonInterval=comparison_interval))
+    return unique_queries
+
+
 def get_condition_groups(
     alert_rules: list[Rule], rules_to_groups: DefaultDict[int, set[int]]
-) -> dict[UniqueCondition, DataAndGroups]:
+) -> dict[UniqueQuery, DataAndGroups]:
     """
-    Map unique conditions to the group IDs that need to checked for that
+    Map unique queries to the group IDs that need to checked for that
     condition. We also store a pointer to that condition's JSON so we can
     instantiate the class later
     """
-    condition_groups: dict[UniqueCondition, DataAndGroups] = {}
+    condition_groups: dict[UniqueQuery, DataAndGroups] = {}
     for rule in alert_rules:
         # We only want a rule's slow conditions because alert_rules are only added
         # to the buffer if we've already checked their fast conditions.
         slow_conditions = get_slow_conditions(rule)
         for condition_data in slow_conditions:
             if condition_data:
-                unique_condition = UniqueCondition(
-                    condition_data["id"], condition_data["interval"], rule.environment_id
-                )
-                # Add to set of group_ids if there are already group_ids
-                # that apply to the unique condition
-                if data_and_groups := condition_groups.get(unique_condition):
-                    data_and_groups.group_ids.update(rules_to_groups[rule.id])
-                # Otherwise, create the tuple containing the condition data and the
-                # set of group_ids that apply to the unique condition
-                else:
-                    condition_groups[unique_condition] = DataAndGroups(
-                        condition_data, set(rules_to_groups[rule.id])
-                    )
+                for unique_cond in _generate_unique_queries(condition_data, rule.environment_id):
+                    # Add to set of group_ids if there are already group_ids
+                    # that apply to the unique query
+                    if data_and_groups := condition_groups.get(unique_cond):
+                        data_and_groups.group_ids.update(rules_to_groups[rule.id])
+                    # Otherwise, create the tuple containing the condition data and the
+                    # set of group_ids that apply to the unique query
+                    else:
+                        condition_groups[unique_cond] = DataAndGroups(
+                            condition_data, set(rules_to_groups[rule.id])
+                        )
     return condition_groups
 
 
 def get_condition_group_results(
-    condition_groups: dict[UniqueCondition, DataAndGroups],
+    condition_groups: dict[UniqueQuery, DataAndGroups],
     project: Project,
-) -> dict[UniqueCondition, dict[int, int]] | None:
-    condition_group_results: dict[UniqueCondition, dict[int, int]] = {}
+) -> dict[UniqueQuery, dict[int, int]] | None:
+    condition_group_results: dict[UniqueQuery, dict[int, int]] = {}
+    current_time = datetime.now(tz=timezone.utc)
     for unique_condition, (condition_data, group_ids) in condition_groups.items():
         condition_cls = rules.get(unique_condition.cls_id)
 
@@ -143,28 +167,60 @@ def get_condition_group_results(
             return None
 
         _, duration = condition_inst.intervals[unique_condition.interval]
-        comparison_interval = condition_inst.intervals[
-            condition_data.get("comparisonInterval", DEFAULT_COMPARISON_INTERVAL)
-        ][1]
-        comparison_type = (
-            condition_data.get("comparisonType", ComparisonType.COUNT)
-            if condition_data
-            else ComparisonType.COUNT
-        )
+
+        comparison_type = condition_data.get("comparisonType", ComparisonType.COUNT)
+        if comparison_type == ComparisonType.PERCENT:
+            comparison_interval = condition_inst.intervals[
+                condition_data.get("comparisonInterval", DEFAULT_COMPARISON_INTERVAL)
+            ][1]
+        else:
+            comparison_interval = None
+
         result = safe_execute(
             condition_inst.get_rate_bulk,
-            duration,
-            comparison_interval,
-            group_ids,
-            unique_condition.environment_id,
-            comparison_type,
+            duration=duration,
+            group_ids=group_ids,
+            environment_id=unique_condition.environment_id,
+            comparison_type=comparison_type,
+            current_time=current_time,
+            comparison_interval=comparison_interval,
         )
         condition_group_results[unique_condition] = result or {}
     return condition_group_results
 
 
+def _passes_comparison(
+    condition_group_results: dict[UniqueQuery, dict[int, int]],
+    condition_data: EventFrequencyConditionData,
+    group_id: int,
+    environment_id: int,
+) -> bool:
+    """
+    Checks if a specific condition has passed.
+    """
+    unique_queries = _generate_unique_queries(condition_data, environment_id)
+    try:
+        query_values = [
+            condition_group_results[unique_query][group_id] for unique_query in unique_queries
+        ]
+    except KeyError as e:
+        logger.exception(
+            "delayed_processing.missing_query_results", extra={"exception": e, "group_id": group_id}
+        )
+        return False
+
+    # Return the result if we only have one query, which means we have a count comparison.
+    calculated_value = query_values[0]
+    if len(query_values) == 2:
+        calculated_value = percent_increase(calculated_value, query_values[1])
+
+    target_value = float(str(condition_data.get("value")))
+
+    return calculated_value > target_value
+
+
 def get_rules_to_fire(
-    condition_group_results: dict[UniqueCondition, dict[int, int]],
+    condition_group_results: dict[UniqueQuery, dict[int, int]],
     rules_to_slow_conditions: DefaultDict[Rule, list[EventFrequencyConditionData]],
     rules_to_groups: DefaultDict[int, set[int]],
 ) -> DefaultDict[Rule, set[int]]:
@@ -174,23 +230,17 @@ def get_rules_to_fire(
         for group_id in rules_to_groups[alert_rule.id]:
             conditions_matched = 0
             for slow_condition in slow_conditions:
-                unique_condition = UniqueCondition(
-                    str(slow_condition.get("id")),
-                    str(slow_condition.get("interval")),
-                    alert_rule.environment_id,
-                )
-                results = condition_group_results.get(unique_condition, {})
-                if results:
-                    target_value = float(str(slow_condition.get("value")))
-                    if results[group_id] > target_value:
-                        if action_match == "any":
-                            rules_to_fire[alert_rule].add(group_id)
-                            break
-                        conditions_matched += 1
-                    else:
-                        if action_match == "all":
-                            # We failed to match all conditions for this group, skip
-                            break
+                if _passes_comparison(
+                    condition_group_results, slow_condition, group_id, alert_rule.environment_id
+                ):
+                    if action_match == "any":
+                        rules_to_fire[alert_rule].add(group_id)
+                        break
+                    conditions_matched += 1
+                else:
+                    if action_match == "all":
+                        # We failed to match all conditions for this group, skip
+                        break
             if action_match == "all" and conditions_matched == len(slow_conditions):
                 rules_to_fire[alert_rule].add(group_id)
     return rules_to_fire
@@ -358,7 +408,7 @@ def apply_delayed(project_id: int, *args: Any, **kwargs: Any) -> None:
     )
     alert_rules = [rule for rule in alert_rules_qs if rule.id not in snoozed_rules]
 
-    # STEP 4: Create a map of unique conditions to a tuple containing the JSON
+    # STEP 4: Create a map of unique queries to a tuple containing the JSON
     # information needed to instantiate that condition class and the group_ids that
     # must be checked for that condition. We don't query per rule condition because
     # condition of the same class, interval, and environment can share a single scan.
@@ -368,8 +418,8 @@ def apply_delayed(project_id: int, *args: Any, **kwargs: Any) -> None:
         extra={"condition_groups": condition_groups, "project_id": project_id},
     )
 
-    # Step 5: Instantiate each unique condition, and evaluate the relevant
-    # group_ids that apply for that condition
+    # Step 5: Instantiate the generic condition that we can apply to each unique
+    # query, and evaluate the relevant group_ids that apply for that query.
     with metrics.timer("delayed_processing.get_condition_group_results.duration"):
         condition_group_results = get_condition_group_results(condition_groups, project)
 

--- a/src/sentry/rules/processing/delayed_processing.py
+++ b/src/sentry/rules/processing/delayed_processing.py
@@ -19,7 +19,6 @@ from sentry.rules.conditions.event_frequency import (
     BaseEventFrequencyCondition,
     ComparisonType,
     EventFrequencyConditionData,
-    percent_increase,
 )
 from sentry.rules.processing.processor import (
     PROJECT_ID_BUFFER_LIST_KEY,
@@ -40,17 +39,10 @@ logger = logging.getLogger("sentry.rules.delayed_processing")
 EVENT_LIMIT = 100
 
 
-class UniqueQuery(NamedTuple):
-    """
-    This class represents all the data that uniquely identifies a Snuba query
-    which can share the same scan for multiple conditions. Note that all
-    conditions must be of the same class however.
-    """
-
+class UniqueCondition(NamedTuple):
     cls_id: str
     interval: str
     environment_id: int
-    comparisonInterval: str | None = None
 
     def __repr__(self):
         return f"id: {self.cls_id},\ninterval: {self.interval},\nenv id: {self.environment_id}"
@@ -100,58 +92,42 @@ def get_rules_to_slow_conditions(
     return rules_to_slow_conditions
 
 
-def _generate_unique_queries(
-    condition_data: EventFrequencyConditionData, environment_id: int
-) -> list[UniqueQuery]:
-    """
-    Returns a list of all unique queries that must be made for a condition.
-    Count comparison conditions will only have one unique query, while percent
-    comparison conditions will have two unique queries.
-    """
-    unique_queries = [UniqueQuery(condition_data["id"], condition_data["interval"], environment_id)]
-    if condition_data.get("comparisonType") == ComparisonType.PERCENT:
-        # We will later compare the first query results against the second query to calculate
-        # a percentage for percentage comparison conditions.
-        comparison_interval = condition_data.get("comparisonInterval", DEFAULT_COMPARISON_INTERVAL)
-        unique_queries.append(unique_queries[0]._replace(comparisonInterval=comparison_interval))
-    return unique_queries
-
-
 def get_condition_groups(
     alert_rules: list[Rule], rules_to_groups: DefaultDict[int, set[int]]
-) -> dict[UniqueQuery, DataAndGroups]:
+) -> dict[UniqueCondition, DataAndGroups]:
     """
-    Map unique queries to the group IDs that need to checked for that
+    Map unique conditions to the group IDs that need to checked for that
     condition. We also store a pointer to that condition's JSON so we can
     instantiate the class later
     """
-    condition_groups: dict[UniqueQuery, DataAndGroups] = {}
+    condition_groups: dict[UniqueCondition, DataAndGroups] = {}
     for rule in alert_rules:
         # We only want a rule's slow conditions because alert_rules are only added
         # to the buffer if we've already checked their fast conditions.
         slow_conditions = get_slow_conditions(rule)
         for condition_data in slow_conditions:
             if condition_data:
-                for unique_cond in _generate_unique_queries(condition_data, rule.environment_id):
-                    # Add to set of group_ids if there are already group_ids
-                    # that apply to the unique query
-                    if data_and_groups := condition_groups.get(unique_cond):
-                        data_and_groups.group_ids.update(rules_to_groups[rule.id])
-                    # Otherwise, create the tuple containing the condition data and the
-                    # set of group_ids that apply to the unique query
-                    else:
-                        condition_groups[unique_cond] = DataAndGroups(
-                            condition_data, set(rules_to_groups[rule.id])
-                        )
+                unique_condition = UniqueCondition(
+                    condition_data["id"], condition_data["interval"], rule.environment_id
+                )
+                # Add to set of group_ids if there are already group_ids
+                # that apply to the unique condition
+                if data_and_groups := condition_groups.get(unique_condition):
+                    data_and_groups.group_ids.update(rules_to_groups[rule.id])
+                # Otherwise, create the tuple containing the condition data and the
+                # set of group_ids that apply to the unique condition
+                else:
+                    condition_groups[unique_condition] = DataAndGroups(
+                        condition_data, set(rules_to_groups[rule.id])
+                    )
     return condition_groups
 
 
 def get_condition_group_results(
-    condition_groups: dict[UniqueQuery, DataAndGroups],
+    condition_groups: dict[UniqueCondition, DataAndGroups],
     project: Project,
-) -> dict[UniqueQuery, dict[int, int]] | None:
-    condition_group_results: dict[UniqueQuery, dict[int, int]] = {}
-    current_time = datetime.now(tz=timezone.utc)
+) -> dict[UniqueCondition, dict[int, int]] | None:
+    condition_group_results: dict[UniqueCondition, dict[int, int]] = {}
     for unique_condition, (condition_data, group_ids) in condition_groups.items():
         condition_cls = rules.get(unique_condition.cls_id)
 
@@ -167,60 +143,28 @@ def get_condition_group_results(
             return None
 
         _, duration = condition_inst.intervals[unique_condition.interval]
-
-        comparison_type = condition_data.get("comparisonType", ComparisonType.COUNT)
-        if comparison_type == ComparisonType.PERCENT:
-            comparison_interval = condition_inst.intervals[
-                condition_data.get("comparisonInterval", DEFAULT_COMPARISON_INTERVAL)
-            ][1]
-        else:
-            comparison_interval = None
-
+        comparison_interval = condition_inst.intervals[
+            condition_data.get("comparisonInterval", DEFAULT_COMPARISON_INTERVAL)
+        ][1]
+        comparison_type = (
+            condition_data.get("comparisonType", ComparisonType.COUNT)
+            if condition_data
+            else ComparisonType.COUNT
+        )
         result = safe_execute(
             condition_inst.get_rate_bulk,
-            duration=duration,
-            group_ids=group_ids,
-            environment_id=unique_condition.environment_id,
-            comparison_type=comparison_type,
-            current_time=current_time,
-            comparison_interval=comparison_interval,
+            duration,
+            comparison_interval,
+            group_ids,
+            unique_condition.environment_id,
+            comparison_type,
         )
         condition_group_results[unique_condition] = result or {}
     return condition_group_results
 
 
-def _passes_comparison(
-    condition_group_results: dict[UniqueQuery, dict[int, int]],
-    condition_data: EventFrequencyConditionData,
-    group_id: int,
-    environment_id: int,
-) -> bool:
-    """
-    Checks if a specific condition has passed.
-    """
-    unique_queries = _generate_unique_queries(condition_data, environment_id)
-    try:
-        query_values = [
-            condition_group_results[unique_query][group_id] for unique_query in unique_queries
-        ]
-    except KeyError as e:
-        logger.exception(
-            "delayed_processing.missing_query_results", extra={"exception": e, "group_id": group_id}
-        )
-        return False
-
-    # Return the result if we only have one query, which means we have a count comparison.
-    calculated_value = query_values[0]
-    if len(query_values) == 2:
-        calculated_value = percent_increase(calculated_value, query_values[1])
-
-    target_value = float(str(condition_data.get("value")))
-
-    return calculated_value > target_value
-
-
 def get_rules_to_fire(
-    condition_group_results: dict[UniqueQuery, dict[int, int]],
+    condition_group_results: dict[UniqueCondition, dict[int, int]],
     rules_to_slow_conditions: DefaultDict[Rule, list[EventFrequencyConditionData]],
     rules_to_groups: DefaultDict[int, set[int]],
 ) -> DefaultDict[Rule, set[int]]:
@@ -230,17 +174,23 @@ def get_rules_to_fire(
         for group_id in rules_to_groups[alert_rule.id]:
             conditions_matched = 0
             for slow_condition in slow_conditions:
-                if _passes_comparison(
-                    condition_group_results, slow_condition, group_id, alert_rule.environment_id
-                ):
-                    if action_match == "any":
-                        rules_to_fire[alert_rule].add(group_id)
-                        break
-                    conditions_matched += 1
-                else:
-                    if action_match == "all":
-                        # We failed to match all conditions for this group, skip
-                        break
+                unique_condition = UniqueCondition(
+                    str(slow_condition.get("id")),
+                    str(slow_condition.get("interval")),
+                    alert_rule.environment_id,
+                )
+                results = condition_group_results.get(unique_condition, {})
+                if results:
+                    target_value = float(str(slow_condition.get("value")))
+                    if results[group_id] > target_value:
+                        if action_match == "any":
+                            rules_to_fire[alert_rule].add(group_id)
+                            break
+                        conditions_matched += 1
+                    else:
+                        if action_match == "all":
+                            # We failed to match all conditions for this group, skip
+                            break
             if action_match == "all" and conditions_matched == len(slow_conditions):
                 rules_to_fire[alert_rule].add(group_id)
     return rules_to_fire
@@ -408,7 +358,7 @@ def apply_delayed(project_id: int, *args: Any, **kwargs: Any) -> None:
     )
     alert_rules = [rule for rule in alert_rules_qs if rule.id not in snoozed_rules]
 
-    # STEP 4: Create a map of unique queries to a tuple containing the JSON
+    # STEP 4: Create a map of unique conditions to a tuple containing the JSON
     # information needed to instantiate that condition class and the group_ids that
     # must be checked for that condition. We don't query per rule condition because
     # condition of the same class, interval, and environment can share a single scan.
@@ -418,8 +368,8 @@ def apply_delayed(project_id: int, *args: Any, **kwargs: Any) -> None:
         extra={"condition_groups": condition_groups, "project_id": project_id},
     )
 
-    # Step 5: Instantiate the generic condition that we can apply to each unique
-    # query, and evaluate the relevant group_ids that apply for that query.
+    # Step 5: Instantiate each unique condition, and evaluate the relevant
+    # group_ids that apply for that condition
     with metrics.timer("delayed_processing.get_condition_group_results.duration"):
         condition_group_results = get_condition_group_results(condition_groups, project)
 

--- a/src/sentry/testutils/fixtures.py
+++ b/src/sentry/testutils/fixtures.py
@@ -175,7 +175,13 @@ class Fixtures:
         return Factories.create_project_key(project=project, *args, **kwargs)
 
     def create_project_rule(
-        self, project=None, action_match=None, condition_match=None, *args, **kwargs
+        self,
+        project=None,
+        action_match=None,
+        condition_match=None,
+        comparison_interval=None,
+        *args,
+        **kwargs,
     ):
         if project is None:
             project = self.project

--- a/tests/sentry/rules/processing/test_delayed_processing.py
+++ b/tests/sentry/rules/processing/test_delayed_processing.py
@@ -69,12 +69,12 @@ class ProcessDelayedAlertConditionsTest(
         comparison_interval=None,
     ) -> EventFrequencyConditionData:
         condition_id = f"sentry.rules.conditions.event_frequency.{id}"
-        condition_blob = {
-            "interval": interval,
-            "id": condition_id,
-            "value": value,
-            "comparisonType": comparison_type,
-        }
+        condition_blob = EventFrequencyConditionData(
+            interval=interval,
+            id=condition_id,
+            value=value,
+            comparisonType=comparison_type,
+        )
         if comparison_interval:
             condition_blob["comparisonInterval"] = comparison_interval
 


### PR DESCRIPTION
From Slack:
Comparison conditions are using the incorrect comparison interval (comparison interval is "how far back should we go". interval is "what period of time should we query")

Basically when deciding how far back to go for the past session, we were using 1 instead of 2
<img width="711" alt="Screenshot 2024-06-20 at 10 21 34 AM" src="https://github.com/getsentry/sentry/assets/67301797/39b852ff-c87a-468e-9ddb-9fbb06594ef5">

Additional PR to fix test bug: https://github.com/getsentry/sentry/pull/73235

Fixes ALRT-100