### PR TITLE
ref(crons): Remove legacy bulk edit endpoint code

### DIFF
--- a/src/sentry/monitors/validators.py
+++ b/src/sentry/monitors/validators.py
@@ -396,22 +396,6 @@ class MonitorCheckInValidator(serializers.Serializer):
         return attrs
 
 
-class MonitorBulkEditValidatorLegacy(MonitorValidator):
-    slugs = serializers.ListField(
-        child=SentrySerializerSlugField(
-            max_length=MAX_SLUG_LENGTH,
-        ),
-        required=True,
-    )
-
-    def validate_slugs(self, value):
-        if Monitor.objects.filter(
-            slug__in=value, organization_id=self.context["organization"].id
-        ).count() != len(value):
-            raise ValidationError("Not all slugs are valid for this organization.")
-        return value
-
-
 class MonitorBulkEditValidator(MonitorValidator):
     ids = serializers.ListField(
         child=serializers.UUIDField(format="hex"),


### PR DESCRIPTION
Now that https://github.com/getsentry/sentry/pull/72375 is merged, once the [frontend](https://github.com/getsentry/sentry/pull/72734) is merged/deployed to use the new endpoint parameters we should remove this legacy code here. 

Luckily the API schema is marked as EXPERIMENTAL so this change should be fine.