### PR TITLE
fix(features) Support rollout=0 with flagpole

### DIFF
--- a/src/flagpole/__init__.py
+++ b/src/flagpole/__init__.py
@@ -87,10 +87,13 @@ class Feature(BaseModel):
     """This datetime is when this instance was created. It can be used to decide when to re-read configuration data"""
 
     def match(self, context: EvaluationContext) -> bool:
-        if self.enabled:
-            for segment in self.segments:
-                if segment.match(context):
-                    return True
+        if not self.enabled:
+            return False
+
+        for segment in self.segments:
+            match = segment.match(context)
+            if match:
+                return segment.in_rollout(context)
 
         return False
 

--- a/src/flagpole/conditions.py
+++ b/src/flagpole/conditions.py
@@ -204,6 +204,14 @@ class Segment(BaseModel):
             match_condition = condition.match(context, segment_name=self.name)
             if not match_condition:
                 return False
+        return True
+
+    def in_rollout(self, context: EvaluationContext) -> bool:
+        # Rollout = 0 allows segments to match and disable a feature
+        # even if other segments would match
+        if self.rollout == 0:
+            return False
+
         # Apply incremental rollout if available.
         if self.rollout is not None and self.rollout < 100:
             return context.id % 100 <= self.rollout

--- a/tests/flagpole/test_feature.py
+++ b/tests/flagpole/test_feature.py
@@ -43,6 +43,80 @@ class TestParseFeatureConfig:
 
         assert not feature.match(EvaluationContext(dict()))
 
+    def test_feature_with_rollout_zero(self):
+        feature = Feature.from_feature_config_json(
+            "foobar",
+            """
+            {
+                "created_at": "2023-10-12T00:00:00.000Z",
+                "owner": "test-owner",
+                "segments": [
+                    {
+                        "name": "exclude",
+                        "rollout": 0,
+                        "conditions": [
+                            {
+                                "property": "user_email",
+                                "operator": "equals",
+                                "value": "nope@example.com"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "friends",
+                        "rollout": 100,
+                        "conditions": [
+                            {
+                                "property": "organization_slug",
+                                "operator": "in",
+                                "value": ["acme", "sentry"]
+                            }
+                        ]
+                    }
+                ]
+            }
+            """,
+        )
+        exclude_user = {"user_email": "nope@example.com", "organization_slug": "acme"}
+        assert not feature.match(EvaluationContext(exclude_user))
+
+        match_user = {"user_email": "yes@example.com", "organization_slug": "acme"}
+        assert feature.match(EvaluationContext(match_user))
+
+    def test_all_conditions_in_segment(self):
+        feature = Feature.from_feature_config_json(
+            "foobar",
+            """
+            {
+                "created_at": "2023-10-12T00:00:00.000Z",
+                "owner": "test-owner",
+                "segments": [
+                    {
+                        "name": "multiple conditions",
+                        "rollout": 100,
+                        "conditions": [
+                            {
+                                "property": "user_email",
+                                "operator": "equals",
+                                "value": "yes@example.com"
+                            },
+                            {
+                                "property": "organization_slug",
+                                "operator": "in",
+                                "value": ["acme", "sentry"]
+                            }
+                        ]
+                    }
+                ]
+            }
+            """,
+        )
+        exclude_user = {"user_email": "yes@example.com"}
+        assert not feature.match(EvaluationContext(exclude_user))
+
+        match_user = {"user_email": "yes@example.com", "organization_slug": "acme"}
+        assert feature.match(EvaluationContext(match_user))
+
     def test_valid_with_all_nesting(self):
         feature = Feature.from_feature_config_json(
             "foobar",


### PR DESCRIPTION
We currently have several features that use rollout=0 to create exceptions/exclude lists for other segments. For example, a feature can be enabled for all early adopters, but turned off for individual users/orgs with a rollout=0 segment.

We'll need this behavior to migrate existing flags as they are configured today.