### PR TITLE
feat(slack): distinguish between linking / creating external issues in activity notifications

### DIFF
--- a/src/sentry/api/endpoints/group_integration_details.py
+++ b/src/sentry/api/endpoints/group_integration_details.py
@@ -11,7 +11,7 @@ from sentry.api.base import region_silo_endpoint
 from sentry.api.bases import GroupEndpoint
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.integration import IntegrationSerializer
-from sentry.integrations.base import IntegrationFeatures
+from sentry.integrations.base import IntegrationFeatures, IntegrationInstallation
 from sentry.models.activity import Activity
 from sentry.models.group import Group
 from sentry.models.grouplink import GroupLink
@@ -74,7 +74,14 @@ class GroupIntegrationDetailsEndpoint(GroupEndpoint):
             feature=IntegrationFeatures.ISSUE_BASIC
         ) or integration.has_feature(feature=IntegrationFeatures.ISSUE_SYNC)
 
-    def create_issue_activity(self, request: Request, group, installation, external_issue, new):
+    def create_issue_activity(
+        self,
+        request: Request,
+        group: Group,
+        installation: IntegrationInstallation,
+        external_issue: ExternalIssue,
+        new: bool,
+    ):
         issue_information = {
             "title": external_issue.title,
             "provider": installation.model.get_provider().name,

--- a/src/sentry/integrations/slack/threads/activity_notifications.py
+++ b/src/sentry/integrations/slack/threads/activity_notifications.py
@@ -220,6 +220,9 @@ class ExternalIssueCreatedActivityNotification(GroupActivityNotification):
             base_template = "<{link}|" + base_template + ">"
 
         # Template should look something like "{author} created <{link}| a/an {provider} issue {ticket}>"
-        base_template = "{author} created " + base_template
+        if self.activity.data.get("new", True):
+            base_template = "{author} created " + base_template
+        else:
+            base_template = "{author} linked " + base_template
 
         return base_template, None, {"provider": provider, "ticket": ticket_number, "link": link}

--- a/tests/sentry/api/endpoints/test_group_integration_details.py
+++ b/tests/sentry/api/endpoints/test_group_integration_details.py
@@ -212,6 +212,7 @@ class GroupIntegrationDetailsTest(APITestCase):
                 "provider": "Example",
                 "location": "https://example/issues/APP-123",
                 "label": "display name: APP-123",
+                "new": False,
             }
 
     def test_put_feature_disabled(self):
@@ -281,6 +282,7 @@ class GroupIntegrationDetailsTest(APITestCase):
                 "provider": "Example",
                 "location": "https://example/issues/APP-123",
                 "label": "display name: APP-123",
+                "new": True,
             }
 
     def test_post_feature_disabled(self):

--- a/tests/sentry/integrations/slack/threads/activity_notifications/test_external_issue_created_activity_notification.py
+++ b/tests/sentry/integrations/slack/threads/activity_notifications/test_external_issue_created_activity_notification.py
@@ -60,3 +60,22 @@ class TestGetDescription(BaseTestCase):
         assert metadata["provider"] == provider
         assert metadata["ticket"] == label
         assert metadata["link"] == location
+
+    def test_linked_issue(self) -> None:
+        provider = "Github"
+        label = "ABC-123"
+        location = "www.example.com"
+        self.activity.data = {
+            "provider": provider,
+            "label": label,
+            "location": location,
+            "new": False,
+        }
+
+        notification = ExternalIssueCreatedActivityNotification(self.activity)
+        template, _, metadata = notification.get_description()
+
+        assert template == "{author} linked <{link}|a {provider} issue {ticket}>"
+        assert metadata["provider"] == "GitHub"  # This is how Github is officially spelled
+        assert metadata["ticket"] == label
+        assert metadata["link"] == location


### PR DESCRIPTION
Resolves #72924

We can distinguish between newly created and newly linked external issues, issues are created + linked via POST and existing issues are linked via PUT. The issue is asking that we fix the text for activity notifications to distinguish when somebody creates a new external issue vs linking an existing external issue.