### PR TITLE
fix(projects): turn off degraded symbolication fetching in project serializer

### DIFF
--- a/src/sentry/api/serializers/models/project.py
+++ b/src/sentry/api/serializers/models/project.py
@@ -27,7 +27,6 @@ from sentry.features.base import ProjectFeature
 from sentry.ingest.inbound_filters import FilterTypes
 from sentry.issues.highlights import get_highlight_preset_for_project
 from sentry.lang.native.sources import parse_sources, redact_source_secrets
-from sentry.lang.native.symbolicator import SymbolicatorPlatform
 from sentry.lang.native.utils import convert_crashreport_count
 from sentry.models.environment import EnvironmentProject
 from sentry.models.options.project_option import OPTION_KEYS, ProjectOption
@@ -42,7 +41,6 @@ from sentry.models.userreport import UserReport
 from sentry.release_health.base import CurrentAndPreviousCrashFreeRate
 from sentry.roles import organization_roles
 from sentry.snuba import discover
-from sentry.tasks.symbolication import should_demote_symbolication
 
 STATUS_LABELS = {
     ObjectStatus.ACTIVE: "active",
@@ -694,10 +692,9 @@ class ProjectSummarySerializer(ProjectWithTeamSerializer):
             if not self._collapse(LATEST_DEPLOYS_KEY):
                 attrs[item]["deploys"] = deploys_by_project.get(item.id)
             # check if the project is in LPQ for any platform
-            attrs[item]["symbolication_degraded"] = any(
-                should_demote_symbolication(platform, project_id=item.id)
-                for platform in SymbolicatorPlatform
-            )
+            # XXX(joshferge): determine if the frontend needs this flag at all
+            # removing redis call as was causing problematic latency issues
+            attrs[item]["symbolication_degraded"] = False
 
         return attrs
 


### PR DESCRIPTION
we're seeing intermittent issues with redis calls here, and because we're doing a lookup for every project, when hundreds/thousands of projects are serialized for example, large customers, we cause the frontend to be extremely slow.

As i understand it, this flag is used to show alerts in the frontend if the project is experiencing symbolication issues. As we have an active incident around this, i'd prefer to degrade that feature as opposed to potentially degrading our entire frontend.
example trace below:

https://sentry.sentry.io/performance/trace/9f053aa7eba34c2abd67e0718ed043a6/?fov=0%2C17287.39013671875&node=span-89270e03b5b7089d&node=txn-bc0d8c17509a45f4966d2ba3a47bc161&node=span-a9277732a1315499&node=ag-9addab0c2f620509&node=txn-879531f290ed4cf28f67d1543503c22a&project=1&query=http.method%3AGET&referrer=performance-transaction-summary&showTransactions=outlier&source=performance_transaction_summary&statsPeriod=24h&timestamp=1718748017&transaction=%2Fapi%2F0%2Forganizations%2F%7Borganization_id_or_slug%7D%2Fprojects%2F&transactionCursor=0%3A35%3A0&unselectedSeries=avg%28%29&unselectedSeries=p100%28%29&unselectedSeries=Releases