### PR TITLE
fix(crons): Fix bug when deleting keys from processing errors

### DIFF
--- a/tests/sentry/monitors/processing_errors/test_manager.py
+++ b/tests/sentry/monitors/processing_errors/test_manager.py
@@ -68,7 +68,7 @@ class CheckinProcessErrorsManagerTest(TestCase):
                 payload_overrides={"monitor_slug": monitor.slug},
             ),
             build_checkin_processing_error(
-                [{"type": ProcessingErrorType.CHECKIN_VALIDATION_FAILED}],
+                [{"type": ProcessingErrorType.MONITOR_DISABLED_NO_QUOTA}],
                 message_overrides={"project_id": self.project.id},
                 payload_overrides={"monitor_slug": monitor.slug},
             ),

--- a/tests/sentry/monitors/processing_errors/test_manager.py
+++ b/tests/sentry/monitors/processing_errors/test_manager.py
@@ -68,6 +68,11 @@ class CheckinProcessErrorsManagerTest(TestCase):
                 payload_overrides={"monitor_slug": monitor.slug},
             ),
             build_checkin_processing_error(
+                [{"type": ProcessingErrorType.CHECKIN_VALIDATION_FAILED}],
+                message_overrides={"project_id": self.project.id},
+                payload_overrides={"monitor_slug": monitor.slug},
+            ),
+            build_checkin_processing_error(
                 [{"type": ProcessingErrorType.MONITOR_DISABLED}],
                 message_overrides={"project_id": self.project.id},
                 payload_overrides={"monitor_slug": monitor.slug},
@@ -78,18 +83,21 @@ class CheckinProcessErrorsManagerTest(TestCase):
                 payload_overrides={"monitor_slug": monitor.slug},
             ),
         ]
+        for error in processing_errors[:3]:
+            store_error(error, monitor)
+
         with mock.patch("sentry.monitors.processing_errors.manager.MAX_ERRORS_PER_SET", new=2):
-            for error in processing_errors:
-                store_error(error, monitor)
+            store_error(processing_errors[-1], monitor)
 
         retrieved_errors = get_errors_for_monitor(monitor)
         assert len(retrieved_errors) == 2
-        assert_processing_errors_equal(processing_errors[2], retrieved_errors[0])
-        assert_processing_errors_equal(processing_errors[1], retrieved_errors[1])
+        assert_processing_errors_equal(processing_errors[-1], retrieved_errors[0])
+        assert_processing_errors_equal(processing_errors[-2], retrieved_errors[1])
         redis_client = _get_cluster()
         assert not redis_client.exists(build_error_identifier(processing_errors[0].id))
-        assert redis_client.exists(build_error_identifier(processing_errors[1].id))
+        assert not redis_client.exists(build_error_identifier(processing_errors[1].id))
         assert redis_client.exists(build_error_identifier(processing_errors[2].id))
+        assert redis_client.exists(build_error_identifier(processing_errors[3].id))
 
     def test_get_for_monitor_empty(self):
         monitor = self.create_monitor()


### PR DESCRIPTION
The rediscluster client doesn't support passing multiple keys to `delete`. This doesn't get caught in ci since we're using the normal client. Fix this by making individual calls instead.

Fixes SENTRY-3AV5