### PR TITLE
chore(flagpole): Adds optional flag logging to org serializer endpoint

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1806,6 +1806,7 @@ register("flagpole.feature_compare_list", default=[], flags=FLAG_AUTOMATOR_MODIF
 register("hybridcloud.regionsiloclient.retries", default=5, flags=FLAG_AUTOMATOR_MODIFIABLE)
 register("hybridcloud.rpc.retries", default=5, flags=FLAG_AUTOMATOR_MODIFIABLE)
 register("hybridcloud.integrationproxy.retries", default=5, flags=FLAG_AUTOMATOR_MODIFIABLE)
+register("hybridcloud.endpoint_flag_logging", default=False, flags=FLAG_AUTOMATOR_MODIFIABLE)
 
 # Webhook processing controls
 register(


### PR DESCRIPTION
Adds an option-enabled logging path for organization features in the serializer code.
