### PR TITLE
fix(query-builder): Update selection index more often

### DIFF
--- a/static/app/components/searchQueryBuilder/combobox.tsx
+++ b/static/app/components/searchQueryBuilder/combobox.tsx
@@ -67,6 +67,7 @@ type SearchQueryBuilderComboboxProps<T extends SelectOptionOrSectionWithKey<stri
   filterValue?: string;
   isLoading?: boolean;
   maxOptions?: number;
+  onClick?: (e: React.MouseEvent) => void;
   /**
    * Called when the user explicitly closes the combobox with the escape key.
    */
@@ -300,6 +301,7 @@ function SearchQueryBuilderComboboxInner<T extends SelectOptionOrSectionWithKey<
     onPaste,
     displayTabbedMenu,
     isLoading,
+    onClick,
   }: SearchQueryBuilderComboboxProps<T>,
   ref: ForwardedRef<HTMLInputElement>
 ) {
@@ -438,8 +440,9 @@ function SearchQueryBuilderComboboxInner<T extends SelectOptionOrSectionWithKey<
       e.stopPropagation();
       inputProps.onClick?.(e);
       state.toggle();
+      onClick?.(e);
     },
-    [inputProps, state]
+    [inputProps, state, onClick]
   );
 
   return (


### PR DESCRIPTION
The selection index is used to determine which suggestions to show based on where your cursor is, but it wasn't getting updated when clicking or when the input was reset, which was causing some bugs that prevented the user from selecting a key.