### PR TITLE
ref(slack): track response_urls in send_slack_response

### DIFF
--- a/src/sentry/integrations/slack/metrics.py
+++ b/src/sentry/integrations/slack/metrics.py
@@ -26,6 +26,3 @@ SLACK_BOT_COMMAND_UNLINK_TEAM_SUCCESS_DATADOG_METRIC = (
 SLACK_BOT_COMMAND_UNLINK_TEAM_FAILURE_DATADOG_METRIC = (
     "sentry.integrations.slack.unlink_team.failure"
 )
-
-# Temporary
-SLACK_SEND_RESPONSE_DATADOG_METRIC = "sentry.integrations.slack.send_response"

--- a/src/sentry/integrations/slack/metrics.py
+++ b/src/sentry/integrations/slack/metrics.py
@@ -26,3 +26,6 @@ SLACK_BOT_COMMAND_UNLINK_TEAM_SUCCESS_DATADOG_METRIC = (
 SLACK_BOT_COMMAND_UNLINK_TEAM_FAILURE_DATADOG_METRIC = (
     "sentry.integrations.slack.unlink_team.failure"
 )
+
+# Temporary
+SLACK_SEND_RESPONSE_DATADOG_METRIC = "sentry.integrations.slack.send_response"

--- a/src/sentry/integrations/slack/utils/notifications.py
+++ b/src/sentry/integrations/slack/utils/notifications.py
@@ -179,7 +179,7 @@ def send_slack_response(
         "slack.send_slack_response",
         extra={
             "integration_id": integration.id,
-            "response_url": params.get("response_url", default_path),
+            "response_url": params.response_url or default_path,
             "payload": payload,
         },
     )

--- a/src/sentry/integrations/slack/utils/notifications.py
+++ b/src/sentry/integrations/slack/utils/notifications.py
@@ -21,7 +21,6 @@ from sentry.integrations.slack.message_builder.incidents import SlackIncidentsMe
 from sentry.integrations.slack.metrics import (
     SLACK_METRIC_ALERT_FAILURE_DATADOG_METRIC,
     SLACK_METRIC_ALERT_SUCCESS_DATADOG_METRIC,
-    SLACK_SEND_RESPONSE_DATADOG_METRIC,
 )
 from sentry.integrations.slack.sdk_client import SlackSdkClient
 from sentry.integrations.slack.views.types import IdentityParams
@@ -175,11 +174,7 @@ def send_slack_response(
     default_path = "/chat.postMessage"
 
     client = SlackClient(integration_id=integration.id)
-    metrics.incr(
-        SLACK_SEND_RESPONSE_DATADOG_METRIC,
-        sample_rate=1.0,
-        tags={"response_url": params.response_url if params.response_url else default_path},
-    )
+
     logger.info(
         "slack.send_slack_response",
         extra={

--- a/src/sentry/integrations/slack/views/link_identity.py
+++ b/src/sentry/integrations/slack/views/link_identity.py
@@ -111,6 +111,7 @@ class SlackLinkIdentityView(BaseView):
                 idp=kwargs["idp"],
                 slack_id=params_dict["slack_id"],
                 channel_id=params_dict["channel_id"],
+                response_url=params_dict.get("response_url"),
             )
         except KeyError as e:
             _logger.exception("slack.link.missing_params")

--- a/src/sentry/integrations/slack/views/link_identity.py
+++ b/src/sentry/integrations/slack/views/link_identity.py
@@ -137,10 +137,7 @@ class SlackLinkIdentityView(BaseView):
             )
             raise Http404
 
-        # TODO: We should use use the dataclass to send the slack response
-        send_slack_response(
-            params.integration, SUCCESS_LINKED_MESSAGE, params.__dict__, command="link"
-        )
+        send_slack_response(params, SUCCESS_LINKED_MESSAGE, command="link")
 
         controller = NotificationController(
             recipients=[request.user],

--- a/src/sentry/integrations/slack/views/unlink_identity.py
+++ b/src/sentry/integrations/slack/views/unlink_identity.py
@@ -104,6 +104,7 @@ class SlackUnlinkIdentityView(BaseView):
                 idp=kwargs["idp"],
                 slack_id=params_dict["slack_id"],
                 channel_id=params_dict["channel_id"],
+                response_url=params_dict.get("response_url"),
             )
         except KeyError as e:
             _logger.exception("slack.unlink.missing_params", extra={"error": str(e)})

--- a/src/sentry/integrations/slack/views/unlink_identity.py
+++ b/src/sentry/integrations/slack/views/unlink_identity.py
@@ -124,10 +124,7 @@ class SlackUnlinkIdentityView(BaseView):
             )
             raise Http404
 
-        # TODO: We should use use the dataclass to send the slack response
-        send_slack_response(
-            params.integration, SUCCESS_UNLINKED_MESSAGE, params.__dict__, command="unlink"
-        )
+        send_slack_response(params, SUCCESS_UNLINKED_MESSAGE, command="unlink")
 
         _logger.info("unlink_identity_success", extra={"slack_id": params.slack_id})
         metrics.incr(self._METRICS_SUCCESS_KEY + ".post.unlink_identity", sample_rate=1.0)

--- a/src/sentry/tasks/integrations/slack/link_slack_user_identities.py
+++ b/src/sentry/tasks/integrations/slack/link_slack_user_identities.py
@@ -55,6 +55,14 @@ def link_slack_user_identities(
     )
     slack_data_by_user = get_slack_data_by_user_via_sdk(integration, organization, emails_by_user)
     for data in slack_data_by_user:
+        logger.info(
+            "slack.post_install.link_identities.paginate",
+            extra={
+                "organization": organization.slug,
+                "integration_id": integration.id,
+                "num_users": len(data),
+            },
+        )
         update_identities(data, idp)
 
 


### PR DESCRIPTION
Small refactor for the `send_slack_response`. Also adds back the `response_url` when initializing the params as `IdentityParams`, so we can properly log the kinds of `response_urls` we're getting.