### PR TITLE
ref(settings-relay): Convert to functional component

### DIFF
--- a/static/app/views/settings/organizationRelay/emptyState.tsx
+++ b/static/app/views/settings/organizationRelay/emptyState.tsx
@@ -5,7 +5,7 @@ import {t} from 'sentry/locale';
 function EmptyState() {
   return (
     <Panel>
-      <EmptyMessage>{t('No Keys Registered.')}</EmptyMessage>
+      <EmptyMessage>{t('No Keys Registered')}</EmptyMessage>
     </Panel>
   );
 }

--- a/static/app/views/settings/organizationRelay/index.tsx
+++ b/static/app/views/settings/organizationRelay/index.tsx
@@ -5,9 +5,9 @@ import PanelBody from 'sentry/components/panels/panelBody';
 import {t} from 'sentry/locale';
 import useOrganization from 'sentry/utils/useOrganization';
 
-import RelayWrapper from './relayWrapper';
+import {RelayWrapper} from './relayWrapper';
 
-function OrganizationRelay(props: Omit<RelayWrapper['props'], 'organization'>) {
+function OrganizationRelay() {
   const organization = useOrganization();
   return (
     <Feature
@@ -26,7 +26,7 @@ function OrganizationRelay(props: Omit<RelayWrapper['props'], 'organization'>) {
         </Panel>
       )}
     >
-      <RelayWrapper organization={organization} {...props} />
+      <RelayWrapper />
     </Feature>
   );
 }


### PR DESCRIPTION
### Goal

Replace the deprecated DeprecatedAsyncView with a functional component
Part of https://github.com/getsentry/frontend-tsc/issues/2


### Note

- I attempted to use `useMutate`(my first time), however, it didn't work as expected when deleting relays. Therefore, I've decided to leave it as is for now.

- Everything was manually tested locally
