### PR TITLE
ref: annotate test helper create_project as returning Project

### DIFF
--- a/src/sentry/testutils/factories.py
+++ b/src/sentry/testutils/factories.py
@@ -471,7 +471,9 @@ class Factories:
 
     @staticmethod
     @assume_test_silo_mode(SiloMode.REGION)
-    def create_project(organization=None, teams=None, fire_project_created=False, **kwargs):
+    def create_project(
+        organization=None, teams=None, fire_project_created=False, **kwargs
+    ) -> Project:
         if not kwargs.get("name"):
             kwargs["name"] = petname.generate(2, " ", letters=10).title()
         if not kwargs.get("slug"):

--- a/tests/sentry/tasks/test_on_demand_metrics.py
+++ b/tests/sentry/tasks/test_on_demand_metrics.py
@@ -39,7 +39,7 @@ def organization(owner: User) -> None:
 
 
 @pytest.fixture
-def project(organization: Organization) -> None:
+def project(organization: Organization) -> Project:
     return Factories.create_project(organization=organization)
 
 


### PR DESCRIPTION
fixes a handful of errors when BaseManager becomes type checked

<!-- Describe your PR here. -->