### PR TITLE
ref(replay): update screen name right away for mobile replay

### DIFF
--- a/static/app/components/replays/replayCurrentScreen.tsx
+++ b/static/app/components/replays/replayCurrentScreen.tsx
@@ -10,15 +10,16 @@ import getCurrentScreenName from 'sentry/utils/replays/getCurrentScreenName';
 function ReplayCurrentScreen() {
   const {currentTime, replay} = useReplayContext();
   const frames = replay?.getMobileNavigationFrames();
+  const replayRecord = replay?.getReplay();
 
   const screenName = useMemo(() => {
     try {
-      return getCurrentScreenName(frames, currentTime);
+      return getCurrentScreenName(replayRecord, frames, currentTime);
     } catch (err) {
       Sentry.captureException(err);
       return '';
     }
-  }, [frames, currentTime]);
+  }, [frames, currentTime, replayRecord]);
 
   if (!replay || !screenName) {
     return (

--- a/static/app/utils/replays/getCurrentScreenName.spec.tsx
+++ b/static/app/utils/replays/getCurrentScreenName.spec.tsx
@@ -37,16 +37,20 @@ describe('getCurrentScreenName', () => {
   it('should return the screen name based on the closest navigation crumb', () => {
     const frames = [PAGELOAD_FRAME, NAV_FRAME_1, NAV_FRAME_2];
 
-    const offsetMS = 1; // at the beginning
-    const screenName = getCurrentScreenName(frames, offsetMS);
-    expect(screenName).toBe('');
+    const offsetMS = 0; // at the beginning
+    const screenName = getCurrentScreenName(
+      ReplayRecordFixture({urls: ['MainActivityScreen', 'ConfirmPayment']}),
+      frames,
+      offsetMS
+    );
+    expect(screenName).toBe('MainActivityScreen');
 
     const offsetMS2 = Number(NAVIGATION_DATE_1) - Number(START_DATE) + 3;
-    const screenName2 = getCurrentScreenName(frames, offsetMS2);
+    const screenName2 = getCurrentScreenName(replayRecord, frames, offsetMS2);
     expect(screenName2).toBe('MainActivityScreen');
 
     const offsetMS3 = Number(NAVIGATION_DATE_2) - Number(START_DATE) + 1;
-    const screenName3 = getCurrentScreenName(frames, offsetMS3);
+    const screenName3 = getCurrentScreenName(replayRecord, frames, offsetMS3);
     expect(screenName3).toBe('ConfirmPayment');
   });
 });

--- a/static/app/utils/replays/getCurrentScreenName.tsx
+++ b/static/app/utils/replays/getCurrentScreenName.tsx
@@ -1,7 +1,9 @@
 import type {BreadcrumbFrame} from 'sentry/utils/replays/types';
+import type {ReplayRecord} from 'sentry/views/replays/types';
 
 // Gets the current screen name for video/mobile replays - mirrors getCurrentUrl.tsx
 function getCurrentScreenName(
+  replayRecord: undefined | ReplayRecord,
   frames: undefined | BreadcrumbFrame[],
   currentOffsetMS: number
 ) {
@@ -12,6 +14,10 @@ function getCurrentScreenName(
   const mostRecentFrame = framesBeforeCurrentOffset?.at(-1) ?? frames?.at(0);
   if (!mostRecentFrame) {
     return '';
+  }
+
+  if ('category' in mostRecentFrame && mostRecentFrame.category === 'replay.init') {
+    return replayRecord?.urls[0] ?? '';
   }
 
   return 'data' in mostRecentFrame && 'to' in mostRecentFrame.data


### PR DESCRIPTION
- closes https://github.com/getsentry/sentry/issues/72233
- this pr sets the screen name in the top right immediately, using the data from the `urls` array 

<img width="1237" alt="SCR-20240621-jmre" src="https://github.com/getsentry/sentry/assets/56095982/a3befed2-7918-45e5-8325-cf620f395082">
