### PR TITLE
fix(insights): assets domain dropdown broken

### DIFF
--- a/static/app/views/insights/browser/resources/views/resourcesLandingPage.spec.tsx
+++ b/static/app/views/insights/browser/resources/views/resourcesLandingPage.spec.tsx
@@ -52,6 +52,39 @@ describe('ResourcesLandingPage', function () {
     ).toBeInTheDocument();
   });
 
+  it('fetches domain data', async () => {
+    render(<ResourcesLandingPage />, {organization});
+    await waitForElementToBeRemoved(() => screen.queryAllByTestId('loading-indicator'));
+
+    expect(requestMocks.domainSelector.mock.calls).toMatchInlineSnapshot(`
+[
+  [
+    "/organizations/org-slug/events/",
+    {
+      "error": [Function],
+      "method": "GET",
+      "query": {
+        "dataset": "spansMetrics",
+        "environment": [],
+        "field": [
+          "span.domain",
+          "count()",
+        ],
+        "per_page": 100,
+        "project": [],
+        "query": "has:span.description !span.description:"browser-extension://*" span.op:[resource.script,resource.css,resource.font,resource.img]",
+        "referrer": "api.starfish.get-span-domains",
+        "sort": "-count",
+        "statsPeriod": "10d",
+      },
+      "skipAbort": undefined,
+      "success": [Function],
+    },
+  ],
+]
+`);
+  });
+
   it('contains correct query in charts', async () => {
     render(<ResourcesLandingPage />, {organization});
     await waitForElementToBeRemoved(() => screen.queryAllByTestId('loading-indicator'));
@@ -195,7 +228,7 @@ const setupMockRequests = (organization: Organization) => {
     },
   });
 
-  MockApiClient.addMockResponse({
+  requestMocks.domainSelector = MockApiClient.addMockResponse({
     url: `/organizations/${organization.slug}/events/`,
     method: 'GET',
     match: [MockApiClient.matchQuery({referrer: 'api.starfish.get-span-domains'})],

--- a/static/app/views/insights/browser/resources/views/resourcesLandingPage.tsx
+++ b/static/app/views/insights/browser/resources/views/resourcesLandingPage.tsx
@@ -76,7 +76,6 @@ function ResourcesLandingPage() {
                   ...DEFAULT_RESOURCE_FILTERS,
                   `${SPAN_OP}:[${DEFAULT_RESOURCE_TYPES.join(',')}]`,
                 ]}
-                moduleName={ModuleName.RESOURCE}
               />
             </FilterOptionsContainer>
             <ResourceView />


### PR DESCRIPTION
Fixes resource domain dropdown that was caused by `moduleName` being passed into the `domainSelector` component. By passing this in, the query automatically gets `span.module:resource` added to it. But this filter is not supported for resource metrics. @KevinL10 The removal of this prop will mess with analytics, but we can work on fixing that after pushing the fix.

Before
<img width="839" alt="image" src="https://github.com/getsentry/sentry/assets/44422760/2cfa1a64-0e23-4b05-aa16-c3e19292c1f0">

After
<img width="908" alt="image" src="https://github.com/getsentry/sentry/assets/44422760/caf334f4-7223-44cf-8aa6-88ab9f522a95">

