### PR TITLE
ref: fix passing slug=None to HC slug check

### DIFF
--- a/src/sentry/web/frontend/auth_login.py
+++ b/src/sentry/web/frontend/auth_login.py
@@ -504,10 +504,11 @@ class AuthLoginView(BaseView):
         """
         Returns True if the organization passed in a request exists.
         """
-        return bool(
+        return request.subdomain is not None and (
             organization_service.check_organization_by_slug(
                 slug=request.subdomain, only_visible=True
             )
+            is not None
         )
 
     def can_register(self, request: Request) -> bool:
@@ -563,13 +564,7 @@ class AuthLoginView(BaseView):
         op = request.POST.get("op")
         organization = kwargs.pop("organization", None)
 
-        org_exists = bool(
-            organization_service.check_organization_by_slug(
-                slug=request.subdomain, only_visible=True
-            )
-        )
-
-        if request.method == "GET" and request.subdomain and org_exists:
+        if request.method == "GET" and request.subdomain and self.org_exists(request):
             urls = [
                 reverse("sentry-auth-organization", args=[request.subdomain]),
                 reverse("sentry-register"),


### PR DESCRIPTION
this currently produces an INFO log on every logged out request

```
16:38:59 server  | 16:38:59 [INFO] sentry.services.hybrid_cloud: Organization by slug [None] not found
```

this fixes these two type errors as well:

```
src/sentry/web/frontend/auth_login.py:509: error: Argument "slug" to "check_organization_by_slug" of "OrganizationService" has incompatible type "str | None"; expected "str"  [arg-type]
src/sentry/web/frontend/auth_login.py:568: error: Argument "slug" to "check_organization_by_slug" of "OrganizationService" has incompatible type "str | None"; expected "str"  [arg-type]
```

<!-- Describe your PR here. -->