### PR TITLE
fix(issues): Add 504 handling for Splunk plugin

### DIFF
--- a/src/sentry_plugins/splunk/plugin.py
+++ b/src/sentry_plugins/splunk/plugin.py
@@ -228,6 +228,8 @@ class SplunkPlugin(CorePluginMixin, DataForwardingPlugin):
                 or (exc.code is not None and (401 <= exc.code <= 404))
                 # 502s are too noisy.
                 or exc.code == 502
+                # Treat gateway timeout the same as ApiTimeoutError
+                or exc.code == 504
             ):
                 return False
             raise


### PR DESCRIPTION
504s are gateway timeout errors, let's treat them the same as 502s (bad gateway) and ApiTimeoutErrors.

Fixes SENTRY-3A3W