### PR TITLE
fix(hybridcloud) Make flagpole context compatible with more org types

### DIFF
--- a/src/sentry/services/hybrid_cloud/organization/model.py
+++ b/src/sentry/services/hybrid_cloud/organization/model.py
@@ -207,6 +207,7 @@ class RpcOrganizationSummary(RpcModel, OrganizationAbsoluteUrlMixin):
     slug: str = ""
     id: int = -1
     name: str = ""
+    flags: RpcOrganizationFlags = Field(default_factory=lambda: RpcOrganizationFlags())
 
     def __hash__(self) -> int:
         # Mimic the behavior of hashing a Django ORM entity, for compatibility with
@@ -240,7 +241,6 @@ class RpcOrganization(RpcOrganizationSummary):
     teams: list[RpcTeam] = Field(default_factory=list)
     projects: list[RpcProject] = Field(default_factory=list)
 
-    flags: RpcOrganizationFlags = Field(default_factory=lambda: RpcOrganizationFlags())
     status: int = Field(default_factory=_DefaultEnumHelpers.get_default_organization_status_value)
 
     default_role: str = ""

--- a/src/sentry/services/hybrid_cloud/organization/model.py
+++ b/src/sentry/services/hybrid_cloud/organization/model.py
@@ -207,7 +207,9 @@ class RpcOrganizationSummary(RpcModel, OrganizationAbsoluteUrlMixin):
     slug: str = ""
     id: int = -1
     name: str = ""
-    flags: RpcOrganizationFlags = Field(default_factory=lambda: RpcOrganizationFlags())
+    flags: RpcOrganizationMappingFlags = Field(
+        default_factory=lambda: RpcOrganizationMappingFlags()
+    )
 
     def __hash__(self) -> int:
         # Mimic the behavior of hashing a Django ORM entity, for compatibility with
@@ -241,6 +243,7 @@ class RpcOrganization(RpcOrganizationSummary):
     teams: list[RpcTeam] = Field(default_factory=list)
     projects: list[RpcProject] = Field(default_factory=list)
 
+    flags: RpcOrganizationFlags = Field(default_factory=lambda: RpcOrganizationFlags())
     status: int = Field(default_factory=_DefaultEnumHelpers.get_default_organization_status_value)
 
     default_role: str = ""

--- a/src/sentry/services/hybrid_cloud/organization/serial.py
+++ b/src/sentry/services/hybrid_cloud/organization/serial.py
@@ -122,6 +122,7 @@ def serialize_organization_summary(org: Organization) -> RpcOrganizationSummary:
         slug=org.slug,
         id=org.id,
         name=org.name,
+        flags=_serialize_flags(org),
     )
 
 

--- a/tests/sentry/features/test_flagpole_context.py
+++ b/tests/sentry/features/test_flagpole_context.py
@@ -10,6 +10,8 @@ from sentry.features.flagpole_context import (
     user_context_transformer,
 )
 from sentry.models.useremail import UserEmail
+from sentry.services.hybrid_cloud.organization import organization_service
+from sentry.services.hybrid_cloud.organization_mapping import organization_mapping_service
 from sentry.testutils.cases import TestCase
 from sentry.testutils.silo import control_silo_test
 
@@ -55,6 +57,44 @@ class TestSentryOrganizationContextTransformer(TestCase):
             "organization_id": org.id,
             "organization_name": "Foo Bar",
             "organization_is-early-adopter": True,
+        }
+
+    def test_with_rpc_organization_summary(self):
+        org = self.create_organization(slug="foobar", name="Foo Bar")
+        rpc_org_summary = organization_service.get_org_by_id(id=org.id)
+
+        context_data = organization_context_transformer(
+            SentryContextData(organization=rpc_org_summary)
+        )
+        assert context_data == {
+            "organization_slug": "foobar",
+            "organization_id": org.id,
+            "organization_name": "Foo Bar",
+            "organization_is-early-adopter": False,
+        }
+
+    def test_with_rpc_organization(self):
+        org = self.create_organization(slug="foobar", name="Foo Bar")
+        rpc_org = organization_service.get(id=org.id)
+
+        context_data = organization_context_transformer(SentryContextData(organization=rpc_org))
+        assert context_data == {
+            "organization_slug": "foobar",
+            "organization_id": org.id,
+            "organization_name": "Foo Bar",
+            "organization_is-early-adopter": False,
+        }
+
+    def test_with_rpc_organization_mapping(self):
+        org = self.create_organization(slug="foobar", name="Foo Bar")
+        org_mapping = organization_mapping_service.get(organization_id=org.id)
+
+        context_data = organization_context_transformer(SentryContextData(organization=org_mapping))
+        assert context_data == {
+            "organization_slug": "foobar",
+            "organization_id": org.id,
+            "organization_name": "Foo Bar",
+            "organization_is-early-adopter": False,
         }
 
 


### PR DESCRIPTION
Add more organization representations to the compatible types for context generation.

Fixes SENTRY-FOR-SENTRY-9BQ
