### PR TITLE
feat(codeowners): Ignore lines with no owners, only comment

### DIFF
--- a/src/sentry/ownership/grammar.py
+++ b/src/sentry/ownership/grammar.py
@@ -35,9 +35,12 @@ ownership_grammar = Grammar(
 
 ownership = line*
 
-line = _ (comment / rule / empty) newline?
+line = _ (comment / rule / rule_comment / empty) newline?
 
 rule = _ matcher owners
+
+# A partial rule is a rule without owners
+rule_comment = _ matcher comment?
 
 matcher      = _ matcher_tag any_identifier
 matcher_tag  = (matcher_type sep)?
@@ -226,7 +229,7 @@ class Owner(namedtuple("Owner", "type identifier")):
 
 
 class OwnershipVisitor(NodeVisitor):
-    visit_comment = visit_empty = lambda *a: None
+    visit_rule_comment = visit_comment = visit_empty = lambda *a: None
 
     def visit_ownership(self, node: Node, children: Sequence[Rule | None]) -> Sequence[Rule]:
         return [_f for _f in children if _f]

--- a/tests/sentry/ownership/test_grammar.py
+++ b/tests/sentry/ownership/test_grammar.py
@@ -58,6 +58,20 @@ def test_parse_rules():
     ]
 
 
+def test_parse_lines_with_comments_in_place_of_owners():
+    data = """
+    # regular comment
+    codeowners:/team #frontend
+    codeowners:/ignore # skip
+    """
+    expected_rules = [
+        Rule(Matcher("codeowners", "/team"), [Owner("team", "frontend")]),
+    ]
+
+    parsed_rules = parse_rules(data)
+    assert parsed_rules == expected_rules
+
+
 def test_dump_schema():
     assert dump_schema([Rule(Matcher("path", "*.js"), [Owner("team", "frontend")])]) == {
         "$version": 1,


### PR DESCRIPTION
ignores codeowners lines with a comment instead of an owner
```codeowners
/apps/github # Skip
```

fixes #72480
