### PR TITLE
ref(slack): use sdk webhook client in responding to link commands

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -397,6 +397,8 @@ def register_temporary_features(manager: FeatureManager):
     manager.add("organizations:slack-sdk-notify-recipient", OrganizationFeature, FeatureHandlerStrategy.OPTIONS)
     # Use new Slack SDK Client in get_channel_id_with_timeout
     manager.add("organizations:slack-sdk-get-channel-id", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE)
+    # Use new Slack SDK Client to respond to link commands
+    manager.add("organizations:slack-sdk-link-commands", OrganizationFeature, FeatureHandlerStrategy.OPTIONS)
     # Add regression chart as image to slack message
     manager.add("organizations:slack-endpoint-regression-image", OrganizationFeature, FeatureHandlerStrategy.OPTIONS)
     manager.add("organizations:slack-function-regression-image", OrganizationFeature, FeatureHandlerStrategy.OPTIONS)

--- a/src/sentry/integrations/slack/utils/notifications.py
+++ b/src/sentry/integrations/slack/utils/notifications.py
@@ -173,8 +173,8 @@ def respond_to_slack_command(
     if params.response_url:
         logger.info(log + "respond-webhook", extra={"response_url": params.response_url})
         try:
-            client = WebhookClient(params.response_url)
-            client.send(text=text, replace_original=False, response_type="ephemeral")
+            webhook_client = WebhookClient(params.response_url)
+            webhook_client.send(text=text, replace_original=False, response_type="ephemeral")
         except SlackApiError as e:
             logger.exception(log + "error", extra={"error": str(e)})
         except SlackRequestError as e:

--- a/src/sentry/integrations/slack/utils/notifications.py
+++ b/src/sentry/integrations/slack/utils/notifications.py
@@ -175,9 +175,7 @@ def respond_to_slack_command(
         try:
             webhook_client = WebhookClient(params.response_url)
             webhook_client.send(text=text, replace_original=False, response_type="ephemeral")
-        except SlackApiError as e:
-            logger.exception(log + "error", extra={"error": str(e)})
-        except SlackRequestError as e:
+        except (SlackApiError, SlackRequestError) as e:
             logger.exception(log + "error", extra={"error": str(e)})
     else:
         logger.info(log + "respond-ephemeral")

--- a/src/sentry/integrations/slack/utils/notifications.py
+++ b/src/sentry/integrations/slack/utils/notifications.py
@@ -183,7 +183,12 @@ def respond_to_slack_command(
         logger.info(log + "respond-ephemeral")
         try:
             client = SlackSdkClient(integration_id=params.integration.id)
-            client.chat_postEphemeral(text=text, channel=params.slack_id, replace_original=False)
+            client.chat_postMessage(
+                text=text,
+                channel=params.slack_id,
+                replace_original=False,
+                response_type="ephemeral",
+            )
         except SlackApiError as e:
             logger.exception(log + "error", extra={"error": str(e)})
 

--- a/src/sentry/integrations/slack/views/link_identity.py
+++ b/src/sentry/integrations/slack/views/link_identity.py
@@ -7,10 +7,12 @@ from django.http.response import HttpResponseBase
 from django.utils.decorators import method_decorator
 from rest_framework.request import Request
 
+from sentry import features
 from sentry.integrations.slack.metrics import (
     SLACK_BOT_COMMAND_LINK_IDENTITY_FAILURE_DATADOG_METRIC,
     SLACK_BOT_COMMAND_LINK_IDENTITY_SUCCESS_DATADOG_METRIC,
 )
+from sentry.integrations.slack.utils.notifications import respond_to_slack_command
 from sentry.integrations.slack.views import render_error_page
 from sentry.integrations.slack.views.types import IdentityParams
 from sentry.integrations.types import ExternalProviderEnum, ExternalProviders
@@ -138,7 +140,10 @@ class SlackLinkIdentityView(BaseView):
             )
             raise Http404
 
-        send_slack_response(params, SUCCESS_LINKED_MESSAGE, command="link")
+        if features.has("organizations:slack-sdk-link-commands", params.organization):
+            respond_to_slack_command(params, SUCCESS_LINKED_MESSAGE, command="link")
+        else:
+            send_slack_response(params, SUCCESS_LINKED_MESSAGE, command="link")
 
         controller = NotificationController(
             recipients=[request.user],

--- a/src/sentry/integrations/slack/views/unlink_identity.py
+++ b/src/sentry/integrations/slack/views/unlink_identity.py
@@ -7,11 +7,15 @@ from django.http.response import HttpResponseBase
 from django.utils.decorators import method_decorator
 from rest_framework.request import Request
 
+from sentry import features
 from sentry.integrations.slack.metrics import (
     SLACK_BOT_COMMAND_UNLINK_IDENTITY_FAILURE_DATADOG_METRIC,
     SLACK_BOT_COMMAND_UNLINK_IDENTITY_SUCCESS_DATADOG_METRIC,
 )
-from sentry.integrations.slack.utils.notifications import send_slack_response
+from sentry.integrations.slack.utils.notifications import (
+    respond_to_slack_command,
+    send_slack_response,
+)
 from sentry.integrations.slack.views import build_linking_url as base_build_linking_url
 from sentry.integrations.slack.views import never_cache, render_error_page
 from sentry.integrations.slack.views.types import IdentityParams
@@ -125,7 +129,10 @@ class SlackUnlinkIdentityView(BaseView):
             )
             raise Http404
 
-        send_slack_response(params, SUCCESS_UNLINKED_MESSAGE, command="unlink")
+        if features.has("organizations:slack-sdk-link-commands", params.organization):
+            respond_to_slack_command(params, SUCCESS_UNLINKED_MESSAGE, command="link")
+        else:
+            send_slack_response(params, SUCCESS_UNLINKED_MESSAGE, command="unlink")
 
         _logger.info("unlink_identity_success", extra={"slack_id": params.slack_id})
         metrics.incr(self._METRICS_SUCCESS_KEY + ".post.unlink_identity", sample_rate=1.0)

--- a/tests/sentry/integrations/slack/test_link_identity.py
+++ b/tests/sentry/integrations/slack/test_link_identity.py
@@ -295,4 +295,4 @@ class SlackIntegrationUnlinkIdentityTest(SlackIntegrationLinkIdentityTestBase):
         # Unlink identity of user.
         self.client.post(self.unlinking_url)
         assert not Identity.objects.filter(external_id="new-slack-id", user=self.user).exists()
-        assert self.mock_post.call_count == 1
+        assert self.mock_webhook.call_count == 1

--- a/tests/sentry/integrations/slack/test_link_identity.py
+++ b/tests/sentry/integrations/slack/test_link_identity.py
@@ -1,10 +1,15 @@
+from unittest.mock import patch
+
+import pytest
 import responses
+from slack_sdk.webhook import WebhookResponse
 
 from sentry.integrations.slack.views.link_identity import build_linking_url
 from sentry.integrations.slack.views.unlink_identity import build_unlinking_url
 from sentry.models.identity import Identity, IdentityStatus
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers import add_identity, install_slack
+from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.silo import control_silo_test
 
 
@@ -27,6 +32,19 @@ class SlackIntegrationLinkIdentityTestBase(TestCase):
             status=200,
             content_type="application/json",
         )
+
+    @pytest.fixture(autouse=True)
+    def mock_chat_postMessage(self):
+        with patch(
+            "slack_sdk.webhook.WebhookClient.send",
+            return_value=WebhookResponse(
+                url="",
+                body='{"ok": true}',
+                headers={},
+                status_code=200,
+            ),
+        ) as self.mock_post:
+            yield
 
 
 @control_silo_test
@@ -55,6 +73,52 @@ class SlackIntegrationLinkIdentityTest(SlackIntegrationLinkIdentityTestBase):
 
     @responses.activate
     def test_overwrites_existing_identities(self):
+        external_id_2 = "slack-id2"
+
+        # Create a second user.
+        user2 = self.create_user(is_superuser=False)
+        self.create_member(
+            user=user2, organization=self.organization, role="member", teams=[self.team]
+        )
+        Identity.objects.create(
+            user=user2, idp=self.idp, external_id=external_id_2, status=IdentityStatus.VALID
+        )
+
+        linking_url = build_linking_url(
+            self.integration, external_id_2, self.channel_id, self.response_url
+        )
+        self.client.post(linking_url)
+
+        assert Identity.objects.filter(external_id=external_id_2, user=self.user).exists()
+        assert not Identity.objects.filter(external_id=self.external_id, user=self.user).exists()
+        assert not Identity.objects.filter(external_id=external_id_2, user=user2).exists()
+
+    @with_feature("organizations:slack-sdk-link-commands")
+    @responses.activate
+    def test_basic_flow_with_sdk(self):
+        """Do the auth flow and assert that the identity was created."""
+        linking_url = build_linking_url(
+            self.integration, self.external_id, self.channel_id, self.response_url
+        )
+
+        # Load page.
+        response = self.client.get(linking_url)
+        assert response.status_code == 200
+        self.assertTemplateUsed(response, "sentry/auth-link-identity.html")
+
+        # Link identity of user
+        self.client.post(linking_url)
+
+        identity = Identity.objects.filter(external_id="new-slack-id", user=self.user)
+
+        assert len(identity) == 1
+        assert identity[0].idp == self.idp
+        assert identity[0].status == IdentityStatus.VALID
+        assert self.mock_post.call_count == 1
+
+    @with_feature("organizations:slack-sdk-link-commands")
+    @responses.activate
+    def test_overwrites_existing_identities_with_sdk(self):
         external_id_2 = "slack-id2"
 
         # Create a second user.
@@ -115,3 +179,33 @@ class SlackIntegrationUnlinkIdentityTest(SlackIntegrationLinkIdentityTestBase):
         self.client.post(self.unlinking_url)
         assert not Identity.objects.filter(external_id="new-slack-id", user=self.user).exists()
         assert len(responses.calls) == 1
+
+    @with_feature("organizations:slack-sdk-link-commands")
+    @responses.activate
+    def test_basic_flow_with_sdk(self):
+        # Load page.
+        response = self.client.get(self.unlinking_url)
+        assert response.status_code == 200
+        self.assertTemplateUsed(response, "sentry/auth-unlink-identity.html")
+
+        # Unlink identity of user.
+        response = self.client.post(self.unlinking_url)
+        assert response.status_code == 200
+        self.assertTemplateUsed(response, "sentry/integrations/slack/unlinked.html")
+
+        assert not Identity.objects.filter(external_id="new-slack-id", user=self.user).exists()
+        assert self.mock_post.call_count == 1
+
+    @with_feature("organizations:slack-sdk-link-commands")
+    @responses.activate
+    def test_user_with_multiple_organizations_with_sdk(self):
+        # Create a second organization where the user is _not_ a member.
+        self.create_organization_integration(
+            organization_id=self.create_organization(name="Another Org").id,
+            integration=self.integration,
+        )
+
+        # Unlink identity of user.
+        self.client.post(self.unlinking_url)
+        assert not Identity.objects.filter(external_id="new-slack-id", user=self.user).exists()
+        assert self.mock_post.call_count == 1


### PR DESCRIPTION
Adds feature-flagged usage of responding to webhook commands (link / unlink identity) using the Slack SDK Client. I believe all of them are responding to the response_url provided in the incoming request from Slack, but I'm keeping the version of posting to `chat.postMessage` and logging different loggers to be sure.