### PR TITLE
fix(codeowners): Do not parse inline comments as owners

### DIFF
--- a/src/sentry/ownership/grammar.py
+++ b/src/sentry/ownership/grammar.py
@@ -345,6 +345,14 @@ def get_codeowners_path_and_owners(rule: str) -> tuple[str, Sequence[str]]:
     # Regex does a negative lookbehind for a backslash. Matches on whitespace without a preceding backslash.
     pattern = re.compile(r"(?<!\\)\s")
     path, *code_owners = (i for i in pattern.split(rule.strip()) if i)
+
+    # Find index of # in code_owners, assume everything after is a comment
+    try:
+        comment_index = code_owners.index("#")
+        code_owners = code_owners[:comment_index]
+    except ValueError:
+        pass
+
     return path, code_owners
 
 

--- a/tests/sentry/ownership/test_grammar.py
+++ b/tests/sentry/ownership/test_grammar.py
@@ -898,6 +898,21 @@ def test_parse_code_owners_with_line_of_spaces():
     )
 
 
+def test_parse_code_owners_comment_placeholder():
+    codeowners = """
+# regular comment
+/path # no owners comment
+/path @getsentry/frontend
+/path @getsentry/issues # inline comment
+/path #team
+    """
+    assert parse_code_owners(codeowners) == (
+        ["@getsentry/frontend", "@getsentry/issues"],
+        ["#team"],
+        [],
+    )
+
+
 def test_convert_codeowners_syntax():
     code_mapping = type("", (), {})()
     code_mapping.stack_root = "webpack://docs"

--- a/tests/sentry/ownership/test_grammar.py
+++ b/tests/sentry/ownership/test_grammar.py
@@ -898,7 +898,7 @@ def test_parse_code_owners_with_line_of_spaces():
     )
 
 
-def test_parse_code_owners_comment_placeholder():
+def test_parse_code_owners_rule_with_comments():
     codeowners = """
 # regular comment
 /path # no owners comment


### PR DESCRIPTION
would prevent a banner from showing when a line only has comments instead of codeowners

related to #72480
