### PR TITLE
chore(hybridcloud) Add more logging to debug features in s4s

### DIFF
--- a/src/sentry/api/serializers/models/organization.py
+++ b/src/sentry/api/serializers/models/organization.py
@@ -260,6 +260,8 @@ class OrganizationSerializer(Serializer):
                 extra={
                     "org_features": org_features,
                     "user.id": user.id if not user.is_anonymous else None,
+                    "manager": features.default_manager,
+                    "entity_handler": type(features.default_manager._entity_handler),
                 },
             )
         with sentry_sdk.start_span(op="features.check", description="check batch features"):

--- a/src/sentry/features/manager.py
+++ b/src/sentry/features/manager.py
@@ -141,6 +141,7 @@ class FeatureManager(RegisteredFeatureManager):
         self.option_features: MutableSet[str] = set()
         self.flagpole_features: MutableSet[str] = set()
         self._entity_handler: FeatureHandler | None = None
+        logger.info("feature_manager.init", extra={"manager": self})
 
     def all(self, feature_type: type[Feature] = Feature) -> Mapping[str, type[Feature]]:
         """
@@ -220,7 +221,11 @@ class FeatureManager(RegisteredFeatureManager):
         logging_enabled = options.get("hybridcloud.endpoint_flag_logging")
         if logging_enabled:
             logger.info(
-                "feature_manager.register_entity_handler", extra={"entity_handler": type(handler)}
+                "feature_manager.register_entity_handler",
+                extra={
+                    "entity_handler": type(handler),
+                    "manager": self,
+                },
             )
         self._entity_handler = handler
 
@@ -322,6 +327,7 @@ class FeatureManager(RegisteredFeatureManager):
                 logger.info(
                     "feature_manager.entity_batch_check",
                     extra={
+                        "manager": self,
                         "entity_handler": type(self._entity_handler),
                     },
                 )
@@ -333,6 +339,7 @@ class FeatureManager(RegisteredFeatureManager):
                 logger.info(
                     "feature_manager.individual_batch_check",
                     extra={
+                        "manager": self,
                         "entity_handler": type(self._entity_handler),
                     },
                 )


### PR DESCRIPTION
Our internal sentry instance is exhibiting strange behavior with entity_handler. The entity_handler is registered during startup but is then lost when checking features.

Logging the manager instances, and init should let us see if the memory address of the manager changes between a pod starting and handling requests.