### PR TITLE
ref(seer grouping): Refactor `get_similarity_data_from_seer` and associated tests

### DIFF
--- a/src/sentry/seer/similarity/similar_issues.py
+++ b/src/sentry/seer/similarity/similar_issues.py
@@ -53,7 +53,7 @@ def get_similarity_data_from_seer(
         return []
 
     try:
-        response_data = json.loads(response.data.decode("utf-8"))
+        response_data = json.loads(response.data.decode("utf-8")).get("responses")
     except (
         AttributeError,  # caused by a response with no data and therefore no `.decode` method
         UnicodeError,
@@ -71,7 +71,7 @@ def get_similarity_data_from_seer(
 
     normalized_results = []
 
-    for raw_similar_issue_data in response_data.get("responses") or []:
+    for raw_similar_issue_data in response_data or []:
         try:
             normalized = SeerSimilarIssueData.from_raw(
                 similar_issues_request["project_id"], raw_similar_issue_data

--- a/src/sentry/seer/similarity/similar_issues.py
+++ b/src/sentry/seer/similarity/similar_issues.py
@@ -69,15 +69,14 @@ def get_similarity_data_from_seer(
         )
         return []
 
-    normalized = []
+    normalized_results = []
 
     for raw_similar_issue_data in response_data.get("responses") or []:
         try:
-            normalized.append(
-                SeerSimilarIssueData.from_raw(
-                    similar_issues_request["project_id"], raw_similar_issue_data
-                )
+            normalized = SeerSimilarIssueData.from_raw(
+                similar_issues_request["project_id"], raw_similar_issue_data
             )
+            normalized_results.append(normalized)
         except IncompleteSeerDataError as err:
             logger.exception(
                 str(err),
@@ -97,6 +96,6 @@ def get_similarity_data_from_seer(
             )
 
     return sorted(
-        normalized,
+        normalized_results,
         key=lambda issue_data: issue_data.stacktrace_distance,
     )

--- a/src/sentry/seer/similarity/similar_issues.py
+++ b/src/sentry/seer/similarity/similar_issues.py
@@ -69,9 +69,12 @@ def get_similarity_data_from_seer(
         )
         return []
 
+    if not response_data:
+        return []
+
     normalized_results = []
 
-    for raw_similar_issue_data in response_data or []:
+    for raw_similar_issue_data in response_data:
         try:
             normalized = SeerSimilarIssueData.from_raw(
                 similar_issues_request["project_id"], raw_similar_issue_data

--- a/tests/sentry/seer/similarity/test_similar_issues.py
+++ b/tests/sentry/seer/similarity/test_similar_issues.py
@@ -66,6 +66,12 @@ class GetSimilarityDataFromSeerTest(TestCase):
             ]
 
     @mock.patch("sentry.seer.similarity.similar_issues.seer_grouping_connection_pool.urlopen")
+    def test_no_groups_found(self, mock_seer_request: MagicMock):
+        mock_seer_request.return_value = self._make_response({"responses": []})
+
+        assert get_similarity_data_from_seer(self.request_params) == []
+
+    @mock.patch("sentry.seer.similarity.similar_issues.seer_grouping_connection_pool.urlopen")
     def test_empty_similar_issues_embeddings(self, mock_seer_request: MagicMock):
         mock_seer_request.return_value = HTTPResponse([])
 

--- a/tests/sentry/seer/similarity/test_similar_issues.py
+++ b/tests/sentry/seer/similarity/test_similar_issues.py
@@ -131,7 +131,7 @@ class GetSimilarityDataFromSeerTest(TestCase):
         )
 
     @mock.patch("sentry.seer.similarity.similar_issues.seer_grouping_connection_pool.urlopen")
-    def test_returns_sorted_similarity_results(self, mock_seer_request: MagicMock):
+    def test_returns_sorted_results(self, mock_seer_request: MagicMock):
         less_similar_event = save_new_event({"message": "Charlie is goofy"}, self.project)
 
         raw_similar_issue_data: RawSeerSimilarIssueData = {

--- a/tests/sentry/seer/similarity/test_similar_issues.py
+++ b/tests/sentry/seer/similarity/test_similar_issues.py
@@ -18,71 +18,56 @@ from sentry.utils.types import NonNone
 
 
 class GetSimilarityDataFromSeerTest(TestCase):
+    def setUp(self):
+        self.similar_event = save_new_event({"message": "Dogs are great!"}, self.project)
+        self.similar_event_hash = NonNone(self.similar_event.get_primary_hash())
+        self.request_params: SimilarIssuesEmbeddingsRequest = {
+            "hash": "11212012123120120415201309082013",
+            "project_id": self.project.id,
+            "stacktrace": "<stringified stacktrace>",
+            "message": "Charlie didn't bring the ball back",
+            "exception_type": "FailedToFetchError",
+        }
+
+    def _make_response(self, data: dict[str, Any], status: int = 200):
+        return HTTPResponse(json.dumps(data).encode("utf-8"), status=status)
+
     @mock.patch("sentry.seer.similarity.similar_issues.seer_grouping_connection_pool.urlopen")
     def test_similar_issues_embeddings_simple(self, mock_seer_request: MagicMock):
-        """Test that valid responses are decoded and returned."""
-        event = save_new_event({"message": "Dogs are great!"}, self.project)
-        similar_event = save_new_event({"message": "Adopt don't shop"}, self.project)
-
         raw_similar_issue_data: RawSeerSimilarIssueData = {
             "message_distance": 0.05,
-            "parent_hash": NonNone(similar_event.get_primary_hash()),
+            "parent_hash": self.similar_event_hash,
             "should_group": True,
             "stacktrace_distance": 0.01,
         }
 
-        seer_return_value = {"responses": [raw_similar_issue_data]}
-        mock_seer_request.return_value = HTTPResponse(json.dumps(seer_return_value).encode("utf-8"))
-
-        params: SimilarIssuesEmbeddingsRequest = {
-            "hash": NonNone(event.get_primary_hash()),
-            "project_id": self.project.id,
-            "stacktrace": "string",
-            "message": "message",
-            "exception_type": "FailedToFetchError",
-        }
+        mock_seer_request.return_value = self._make_response(
+            {"responses": [raw_similar_issue_data]}
+        )
 
         similar_issue_data: Any = {
             **raw_similar_issue_data,
-            "parent_group_id": similar_event.group_id,
+            "parent_group_id": self.similar_event.group_id,
         }
 
-        assert get_similarity_data_from_seer(params) == [SeerSimilarIssueData(**similar_issue_data)]
+        assert get_similarity_data_from_seer(self.request_params) == [
+            SeerSimilarIssueData(**similar_issue_data)
+        ]
 
     @mock.patch("sentry.seer.similarity.similar_issues.seer_grouping_connection_pool.urlopen")
     def test_empty_similar_issues_embeddings(self, mock_seer_request: MagicMock):
-        """Test that empty responses are returned."""
-        event = save_new_event({"message": "Dogs are great!"}, self.project)
-
         mock_seer_request.return_value = HTTPResponse([])
 
-        params: SimilarIssuesEmbeddingsRequest = {
-            "hash": NonNone(event.get_primary_hash()),
-            "project_id": self.project.id,
-            "stacktrace": "string",
-            "message": "message",
-            "exception_type": "FailedToFetchError",
-        }
-        assert get_similarity_data_from_seer(params) == []
+        assert get_similarity_data_from_seer(self.request_params) == []
 
     @mock.patch("sentry.seer.similarity.similar_issues.logger")
     @mock.patch("sentry.seer.similarity.similar_issues.seer_grouping_connection_pool.urlopen")
     def test_redirect(self, mock_seer_request: MagicMock, mock_logger: MagicMock):
-        event = save_new_event({"message": "Dogs are great!"}, self.project)
-
         mock_seer_request.return_value = HTTPResponse(
             status=308, headers={"location": "/new/and/improved/endpoint/"}
         )
 
-        params: SimilarIssuesEmbeddingsRequest = {
-            "hash": NonNone(event.get_primary_hash()),
-            "project_id": self.project.id,
-            "stacktrace": "string",
-            "message": "message",
-            "exception_type": "FailedToFetchError",
-        }
-
-        assert get_similarity_data_from_seer(params) == []
+        assert get_similarity_data_from_seer(self.request_params) == []
         mock_logger.error.assert_called_with(
             f"Encountered redirect when calling Seer endpoint {SEER_SIMILAR_ISSUES_URL}. Please update `SEER_SIMILAR_ISSUES_URL` in `sentry.conf.server` to be '/new/and/improved/endpoint/'."
         )
@@ -90,22 +75,9 @@ class GetSimilarityDataFromSeerTest(TestCase):
     @mock.patch("sentry.seer.similarity.similar_issues.logger")
     @mock.patch("sentry.seer.similarity.similar_issues.seer_grouping_connection_pool.urlopen")
     def test_error_status(self, mock_seer_request: MagicMock, mock_logger: MagicMock):
-        event = save_new_event({"message": "Dogs are great!"}, self.project)
+        mock_seer_request.return_value = HTTPResponse("No soup for you", status=403)
 
-        mock_seer_request.return_value = HTTPResponse(
-            "No soup for you",
-            status=403,
-        )
-
-        params: SimilarIssuesEmbeddingsRequest = {
-            "hash": NonNone(event.get_primary_hash()),
-            "project_id": self.project.id,
-            "stacktrace": "string",
-            "message": "message",
-            "exception_type": "FailedToFetchError",
-        }
-
-        assert get_similarity_data_from_seer(params) == []
+        assert get_similarity_data_from_seer(self.request_params) == []
         mock_logger.error.assert_called_with(
             f"Received 403 when calling Seer endpoint {SEER_SIMILAR_ISSUES_URL}.",
             extra={"response_data": "No soup for you"},
@@ -113,13 +85,11 @@ class GetSimilarityDataFromSeerTest(TestCase):
 
     @mock.patch("sentry.seer.similarity.similar_issues.seer_grouping_connection_pool.urlopen")
     def test_returns_sorted_similarity_results(self, mock_seer_request: MagicMock):
-        event = save_new_event({"message": "Dogs are great!"}, self.project)
-        similar_event = save_new_event({"message": "Adopt don't shop"}, self.project)
         less_similar_event = save_new_event({"message": "Charlie is goofy"}, self.project)
 
         raw_similar_issue_data: RawSeerSimilarIssueData = {
             "message_distance": 0.05,
-            "parent_hash": NonNone(similar_event.get_primary_hash()),
+            "parent_hash": self.similar_event_hash,
             "should_group": True,
             "stacktrace_distance": 0.01,
         }
@@ -131,20 +101,13 @@ class GetSimilarityDataFromSeerTest(TestCase):
         }
 
         # Note that the less similar issue is first in the list as it comes back from Seer
-        seer_return_value = {"responses": [raw_less_similar_issue_data, raw_similar_issue_data]}
-        mock_seer_request.return_value = HTTPResponse(json.dumps(seer_return_value).encode("utf-8"))
-
-        params: SimilarIssuesEmbeddingsRequest = {
-            "hash": NonNone(event.get_primary_hash()),
-            "project_id": self.project.id,
-            "stacktrace": "string",
-            "message": "message",
-            "exception_type": "FailedToFetchError",
-        }
+        mock_seer_request.return_value = self._make_response(
+            {"responses": [raw_less_similar_issue_data, raw_similar_issue_data]}
+        )
 
         similar_issue_data: Any = {
             **raw_similar_issue_data,
-            "parent_group_id": similar_event.group_id,
+            "parent_group_id": self.similar_event.group_id,
         }
         less_similar_issue_data: Any = {
             **raw_less_similar_issue_data,
@@ -152,7 +115,7 @@ class GetSimilarityDataFromSeerTest(TestCase):
         }
 
         # The results have been reordered so that the more similar issue comes first
-        assert get_similarity_data_from_seer(params) == [
+        assert get_similarity_data_from_seer(self.request_params) == [
             SeerSimilarIssueData(**similar_issue_data),
             SeerSimilarIssueData(**less_similar_issue_data),
         ]


### PR DESCRIPTION
This is a bunch of small refactors to `get_similarity_data_from_seer` and its associated tests, pulled out of an upcoming PR in order to make it easier to review.

Changes to `get_similarity_data_from_seer`:

- Dig into `response.data` earlier.
- Handle case of there being no similar groups separately.

Changes to tests:

- Pull common operations into `setUp` and a new `_make_response` helper.
- Add new tests and/or new cases to existing tests to cover the following missing scenarios: 
  - similar but not matching groups being found
  - no similar groups being found
  - `response.data` being `None`
  - results missing required data
  - a non-existent parent hash being returned.