### PR TITLE
feat(seer grouping): Add `seer.similar_issues_request` metric

### DIFF
--- a/src/sentry/seer/similarity/similar_issues.py
+++ b/src/sentry/seer/similarity/similar_issues.py
@@ -11,10 +11,15 @@ from sentry.seer.similarity.types import (
     SimilarGroupNotFoundError,
     SimilarIssuesEmbeddingsRequest,
 )
-from sentry.utils import json
+from sentry.utils import json, metrics
 from sentry.utils.json import JSONDecodeError
 
 logger = logging.getLogger(__name__)
+
+# TODO: Keeping this at a 100% sample rate for now in order to get good signal as we're rolling out
+# and calls are still comparatively rare. Once traffic gets heavy enough, we should probably ramp
+# this down.
+SIMILARITY_REQUEST_METRIC_SAMPLE_RATE = 1.0
 
 
 seer_grouping_connection_pool = connection_from_url(
@@ -39,6 +44,8 @@ def get_similarity_data_from_seer(
         ),
     )
 
+    metric_tags: dict[str, str | int] = {"response_status": response.status}
+
     if response.status > 200:
         redirect = response.get_redirect_location()
         if redirect:
@@ -50,6 +57,17 @@ def get_similarity_data_from_seer(
                 f"Received {response.status} when calling Seer endpoint {SEER_SIMILAR_ISSUES_URL}.",  # noqa
                 extra={"response_data": response.data},
             )
+
+        metrics.incr(
+            "seer.similar_issues_request",
+            sample_rate=SIMILARITY_REQUEST_METRIC_SAMPLE_RATE,
+            tags={
+                **metric_tags,
+                "outcome": "error",
+                "error": "Redirect" if redirect else "RequestError",
+            },
+        )
+
         return []
 
     try:
@@ -58,7 +76,7 @@ def get_similarity_data_from_seer(
         AttributeError,  # caused by a response with no data and therefore no `.decode` method
         UnicodeError,
         JSONDecodeError,
-    ):
+    ) as e:
         logger.exception(
             "Failed to parse seer similar issues response",
             extra={
@@ -67,10 +85,24 @@ def get_similarity_data_from_seer(
                 "response_code": response.status,
             },
         )
+        metrics.incr(
+            "seer.similar_issues_request",
+            sample_rate=SIMILARITY_REQUEST_METRIC_SAMPLE_RATE,
+            tags={**metric_tags, "outcome": "error", "error": type(e).__name__},
+        )
         return []
 
     if not response_data:
+        metrics.incr(
+            "seer.similar_issues_request",
+            sample_rate=SIMILARITY_REQUEST_METRIC_SAMPLE_RATE,
+            tags={**metric_tags, "outcome": "no_similar_groups"},
+        )
         return []
+
+    # This may get overwritten as we process the results, but by this point we know that Seer at
+    # least found *something*
+    metric_tags["outcome"] = "similar_groups_found"
 
     normalized_results = []
 
@@ -79,8 +111,21 @@ def get_similarity_data_from_seer(
             normalized = SeerSimilarIssueData.from_raw(
                 similar_issues_request["project_id"], raw_similar_issue_data
             )
+
+            if (
+                normalized.should_group
+                # If an earlier entry in the results list caused an error, we don't want to
+                # overwrite that information
+                and metric_tags["outcome"] != "error"
+            ):
+                metric_tags["outcome"] = "matching_group_found"
+
             normalized_results.append(normalized)
         except IncompleteSeerDataError as err:
+            # This will tag the entire request as errored even if not all of the results are
+            # incomplete, but that's okay, because even one being incomplete means that Seer is
+            # broken in some way
+            metric_tags.update({"outcome": "error", "error": "IncompleteSeerDataError"})
             logger.exception(
                 str(err),
                 extra={
@@ -89,6 +134,11 @@ def get_similarity_data_from_seer(
                 },
             )
         except SimilarGroupNotFoundError:
+            # This will similarly mark the entire request as errored even if it's only one group
+            # that we can't find, but again, we're okay with that because a group being missing
+            # implies there's something wrong with our deletion logic, which is a problem to which
+            # we want to pay attention.
+            metric_tags.update({"outcome": "error", "error": "SimilarGroupNotFoundError"})
             logger.warning(
                 "get_similarity_data_from_seer.parent_group_not_found",
                 extra={
@@ -98,6 +148,11 @@ def get_similarity_data_from_seer(
                 },
             )
 
+    metrics.incr(
+        "seer.similar_issues_request",
+        sample_rate=SIMILARITY_REQUEST_METRIC_SAMPLE_RATE,
+        tags=metric_tags,
+    )
     return sorted(
         normalized_results,
         key=lambda issue_data: issue_data.stacktrace_distance,

--- a/tests/sentry/seer/similarity/test_similar_issues.py
+++ b/tests/sentry/seer/similarity/test_similar_issues.py
@@ -5,7 +5,10 @@ from unittest.mock import MagicMock
 from urllib3.response import HTTPResponse
 
 from sentry.conf.server import SEER_SIMILAR_ISSUES_URL
-from sentry.seer.similarity.similar_issues import get_similarity_data_from_seer
+from sentry.seer.similarity.similar_issues import (
+    SIMILARITY_REQUEST_METRIC_SAMPLE_RATE,
+    get_similarity_data_from_seer,
+)
 from sentry.seer.similarity.types import (
     RawSeerSimilarIssueData,
     SeerSimilarIssueData,
@@ -32,9 +35,10 @@ class GetSimilarityDataFromSeerTest(TestCase):
     def _make_response(self, data: dict[str, Any], status: int = 200):
         return HTTPResponse(json.dumps(data).encode("utf-8"), status=status)
 
+    @mock.patch("sentry.seer.similarity.similar_issues.metrics.incr")
     @mock.patch("sentry.seer.similarity.similar_issues.seer_grouping_connection_pool.urlopen")
-    def test_groups_found(self, mock_seer_request: MagicMock):
-        cases: list[tuple[RawSeerSimilarIssueData]] = [
+    def test_groups_found(self, mock_seer_request: MagicMock, mock_metrics_incr: MagicMock):
+        cases: list[tuple[RawSeerSimilarIssueData, str]] = [
             (
                 {
                     "message_distance": 0.05,
@@ -42,6 +46,7 @@ class GetSimilarityDataFromSeerTest(TestCase):
                     "should_group": True,
                     "stacktrace_distance": 0.01,
                 },
+                "matching_group_found",
             ),
             (
                 {
@@ -50,10 +55,11 @@ class GetSimilarityDataFromSeerTest(TestCase):
                     "should_group": False,
                     "stacktrace_distance": 0.05,
                 },
+                "similar_groups_found",
             ),
         ]
 
-        for (raw_data,) in cases:
+        for raw_data, expected_outcome in cases:
             mock_seer_request.return_value = self._make_response({"responses": [raw_data]})
 
             similar_issue_data: Any = {
@@ -64,18 +70,35 @@ class GetSimilarityDataFromSeerTest(TestCase):
             assert get_similarity_data_from_seer(self.request_params) == [
                 SeerSimilarIssueData(**similar_issue_data)
             ]
+            mock_metrics_incr.assert_any_call(
+                "seer.similar_issues_request",
+                sample_rate=SIMILARITY_REQUEST_METRIC_SAMPLE_RATE,
+                tags={
+                    "response_status": 200,
+                    "outcome": expected_outcome,
+                },
+            )
 
+            mock_metrics_incr.reset_mock()
+
+    @mock.patch("sentry.seer.similarity.similar_issues.metrics.incr")
     @mock.patch("sentry.seer.similarity.similar_issues.seer_grouping_connection_pool.urlopen")
-    def test_no_groups_found(self, mock_seer_request: MagicMock):
+    def test_no_groups_found(self, mock_seer_request: MagicMock, mock_metrics_incr: MagicMock):
         mock_seer_request.return_value = self._make_response({"responses": []})
 
         assert get_similarity_data_from_seer(self.request_params) == []
+        mock_metrics_incr.assert_any_call(
+            "seer.similar_issues_request",
+            sample_rate=SIMILARITY_REQUEST_METRIC_SAMPLE_RATE,
+            tags={"response_status": 200, "outcome": "no_similar_groups"},
+        )
 
+    @mock.patch("sentry.seer.similarity.similar_issues.metrics.incr")
     @mock.patch("sentry.seer.similarity.similar_issues.seer_grouping_connection_pool.urlopen")
-    def test_bad_response_data(self, mock_seer_request: MagicMock):
-        cases: list[tuple[Any]] = [
-            (None,),
-            ([],),
+    def test_bad_response_data(self, mock_seer_request: MagicMock, mock_metrics_incr: MagicMock):
+        cases: list[tuple[Any, str]] = [
+            (None, "AttributeError"),
+            ([], "AttributeError"),
             (
                 {
                     "responses": [
@@ -87,6 +110,7 @@ class GetSimilarityDataFromSeerTest(TestCase):
                         }
                     ]
                 },
+                "IncompleteSeerDataError",
             ),
             (
                 {
@@ -99,17 +123,28 @@ class GetSimilarityDataFromSeerTest(TestCase):
                         }
                     ]
                 },
+                "SimilarGroupNotFoundError",
             ),
         ]
 
-        for (response_data,) in cases:
+        for response_data, expected_error in cases:
             mock_seer_request.return_value = self._make_response(response_data)
 
             assert get_similarity_data_from_seer(self.request_params) == []
+            mock_metrics_incr.assert_any_call(
+                "seer.similar_issues_request",
+                sample_rate=SIMILARITY_REQUEST_METRIC_SAMPLE_RATE,
+                tags={"response_status": 200, "outcome": "error", "error": expected_error},
+            )
 
+            mock_metrics_incr.reset_mock()
+
+    @mock.patch("sentry.seer.similarity.similar_issues.metrics.incr")
     @mock.patch("sentry.seer.similarity.similar_issues.logger")
     @mock.patch("sentry.seer.similarity.similar_issues.seer_grouping_connection_pool.urlopen")
-    def test_redirect(self, mock_seer_request: MagicMock, mock_logger: MagicMock):
+    def test_redirect(
+        self, mock_seer_request: MagicMock, mock_logger: MagicMock, mock_metrics_incr: MagicMock
+    ):
         mock_seer_request.return_value = HTTPResponse(
             status=308, headers={"location": "/new/and/improved/endpoint/"}
         )
@@ -118,16 +153,29 @@ class GetSimilarityDataFromSeerTest(TestCase):
         mock_logger.error.assert_called_with(
             f"Encountered redirect when calling Seer endpoint {SEER_SIMILAR_ISSUES_URL}. Please update `SEER_SIMILAR_ISSUES_URL` in `sentry.conf.server` to be '/new/and/improved/endpoint/'."
         )
+        mock_metrics_incr.assert_any_call(
+            "seer.similar_issues_request",
+            sample_rate=SIMILARITY_REQUEST_METRIC_SAMPLE_RATE,
+            tags={"response_status": 308, "outcome": "error", "error": "Redirect"},
+        )
 
+    @mock.patch("sentry.seer.similarity.similar_issues.metrics.incr")
     @mock.patch("sentry.seer.similarity.similar_issues.logger")
     @mock.patch("sentry.seer.similarity.similar_issues.seer_grouping_connection_pool.urlopen")
-    def test_error_status(self, mock_seer_request: MagicMock, mock_logger: MagicMock):
+    def test_error_status(
+        self, mock_seer_request: MagicMock, mock_logger: MagicMock, mock_metrics_incr: MagicMock
+    ):
         mock_seer_request.return_value = HTTPResponse("No soup for you", status=403)
 
         assert get_similarity_data_from_seer(self.request_params) == []
         mock_logger.error.assert_called_with(
             f"Received 403 when calling Seer endpoint {SEER_SIMILAR_ISSUES_URL}.",
             extra={"response_data": "No soup for you"},
+        )
+        mock_metrics_incr.assert_any_call(
+            "seer.similar_issues_request",
+            sample_rate=SIMILARITY_REQUEST_METRIC_SAMPLE_RATE,
+            tags={"response_status": 403, "outcome": "error", "error": "RequestError"},
         )
 
     @mock.patch("sentry.seer.similarity.similar_issues.seer_grouping_connection_pool.urlopen")


### PR DESCRIPTION
This adds a new metric, `seer.similar_issues_request`, to track the results of our calls to the seer similarity endpoint. In addition to counting the calls themselves, the new metric tracks the response status code, the result of the call (matching group, similar groups, no similar groups, error), and in the erroring case, what type of error occurred. 

Notes:

- For now the sample rate is set to 100%, so that we can get some decent signal even while the feature is only rolled out to a few customers. Once we GA, we'll probably want to change it to a lower rate.

- In keeping with our handling of non-200 responses, redirects are considered errors, because they imply that a change has been made on the Seer side and we haven't correctly updated the Sentry code to match. They are however tracked separately from other request errors.

