### PR TITLE
feat[apis]: Pass frontend to Snuba - phase 1

### DIFF
--- a/src/sentry/api/base.py
+++ b/src/sentry/api/base.py
@@ -225,6 +225,7 @@ class Endpoint(APIView):
         str, dict[RateLimitCategory, RateLimit]
     ] = DEFAULT_RATE_LIMIT_CONFIG
     enforce_rate_limit: bool = settings.SENTRY_RATELIMITER_ENABLED
+    snuba_methods: list[HTTP_METHOD_NAME] = []
 
     def build_link_header(self, request: Request, path: str, rel: str):
         # TODO(dcramer): it would be nice to expand this to support params to consolidate `build_cursor_link`

--- a/src/sentry/api/endpoints/organization_event_details.py
+++ b/src/sentry/api/endpoints/organization_event_details.py
@@ -144,7 +144,7 @@ class OrganizationEventDetailsEndpoint(OrganizationEventsEndpointBase):
                 "organizations:insights-initial-modules", organization, actor=request.user
             )
         ):
-            add_comparison_to_event(event, average_columns, request)
+            add_comparison_to_event(event=event, average_columns=average_columns, request=request)
 
         # TODO: Remove `for_group` check once performance issues are moved to the issue platform
         if hasattr(event, "for_group") and event.group:

--- a/src/sentry/api/endpoints/organization_event_details.py
+++ b/src/sentry/api/endpoints/organization_event_details.py
@@ -21,6 +21,7 @@ from sentry.models.project import Project
 from sentry.search.events.builder import SpansMetricsQueryBuilder
 from sentry.search.events.types import QueryBuilderConfig
 from sentry.snuba.dataset import Dataset
+from sentry.snuba.query_sources import QuerySource
 from sentry.snuba.referrer import Referrer
 
 VALID_AVERAGE_COLUMNS = {"span.self_time", "span.duration"}
@@ -71,7 +72,9 @@ def add_comparison_to_event(event, average_columns, request: Request):
         result = builder.process_results(
             builder.run_query(
                 referrer=Referrer.API_PERFORMANCE_ORG_EVENT_AVERAGE_SPAN.value,
-                is_frontend=is_frontend_request(request),
+                query_source=(
+                    QuerySource.FRONTEND if is_frontend_request(request) else QuerySource.API
+                ),
             )
         )
         sentry_sdk.set_measurement("query.groups_found", len(result["data"]))

--- a/src/sentry/api/endpoints/organization_event_details.py
+++ b/src/sentry/api/endpoints/organization_event_details.py
@@ -94,6 +94,7 @@ class OrganizationEventDetailsEndpoint(OrganizationEventsEndpointBase):
     publish_status = {
         "GET": ApiPublishStatus.PRIVATE,
     }
+    snuba_methods = ["GET"]
 
     def convert_args(
         self,

--- a/src/sentry/search/events/builder/metrics.py
+++ b/src/sentry/search/events/builder/metrics.py
@@ -1110,7 +1110,9 @@ class MetricsQueryBuilder(QueryBuilder):
                 )
         return result
 
-    def run_query(self, referrer: str, use_cache: bool = False) -> Any:
+    def run_query(
+        self, referrer: str, is_frontend: bool | None = None, use_cache: bool = False
+    ) -> Any:
         groupbys = self.groupby
         if not groupbys and self.use_on_demand:
             # Need this otherwise top_events returns only 1 item
@@ -1315,9 +1317,10 @@ class MetricsQueryBuilder(QueryBuilder):
                     tenant_ids=self.tenant_ids,
                 )
                 current_result = raw_snql_query(
-                    request,
-                    f"{referrer}.{referrer_suffix}",
-                    use_cache,
+                    request=request,
+                    referrer=f"{referrer}.{referrer_suffix}",
+                    is_frontend=is_frontend,
+                    use_cache=use_cache,
                 )
                 for meta in current_result["meta"]:
                     meta_dict[meta["name"]] = meta["type"]

--- a/src/sentry/search/events/builder/metrics.py
+++ b/src/sentry/search/events/builder/metrics.py
@@ -75,6 +75,7 @@ from sentry.snuba.metrics.query import (
     MetricOrderByField,
 )
 from sentry.snuba.metrics.utils import get_num_intervals
+from sentry.snuba.query_sources import QuerySource
 from sentry.utils.snuba import DATASETS, bulk_snuba_queries, raw_snql_query
 
 
@@ -1111,7 +1112,7 @@ class MetricsQueryBuilder(QueryBuilder):
         return result
 
     def run_query(
-        self, referrer: str, is_frontend: bool | None = None, use_cache: bool = False
+        self, referrer: str, query_source: QuerySource | None = None, use_cache: bool = False
     ) -> Any:
         groupbys = self.groupby
         if not groupbys and self.use_on_demand:
@@ -1319,7 +1320,7 @@ class MetricsQueryBuilder(QueryBuilder):
                 current_result = raw_snql_query(
                     request=request,
                     referrer=f"{referrer}.{referrer_suffix}",
-                    is_frontend=is_frontend,
+                    query_source=query_source,
                     use_cache=use_cache,
                 )
                 for meta in current_result["meta"]:

--- a/src/sentry/search/events/builder/metrics.py
+++ b/src/sentry/search/events/builder/metrics.py
@@ -1112,7 +1112,7 @@ class MetricsQueryBuilder(QueryBuilder):
         return result
 
     def run_query(
-        self, referrer: str, query_source: QuerySource | None = None, use_cache: bool = False
+        self, referrer: str, use_cache: bool = False, query_source: QuerySource | None = None
     ) -> Any:
         groupbys = self.groupby
         if not groupbys and self.use_on_demand:

--- a/src/sentry/snuba/query_sources.py
+++ b/src/sentry/snuba/query_sources.py
@@ -1,0 +1,6 @@
+from enum import Enum
+
+
+class QuerySource(Enum):
+    FRONTEND = "frontend"
+    API = "api"

--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -897,12 +897,10 @@ def bulk_snuba_queries(
             if referrer:
                 request.tenant_ids["referrer"] = referrer
             if query_source:
-                request.tenant_ids["query_source"] = query_source
+                request.tenant_ids["query_source"] = query_source.value
 
     params = [(request, lambda x: x, lambda x: x) for request in requests]
-    return _apply_cache_and_build_results(
-        snuba_param_list=params, referrer=referrer, use_cache=use_cache
-    )
+    return _apply_cache_and_build_results(params, referrer=referrer, use_cache=use_cache)
 
 
 # TODO: This is the endpoint that accepts legacy (non-SnQL/MQL queries)

--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -857,10 +857,10 @@ ResultSet = list[Mapping[str, Any]]
 def raw_snql_query(
     request: Request,
     referrer: str | None = None,
+    use_cache: bool = False,
     query_source: (
         QuerySource | None
     ) = None,  # TODO: @athena Make this field required after updated all the callsites
-    use_cache: bool = False,
 ) -> Mapping[str, Any]:
     """
     Alias for `bulk_snuba_queries`, kept for backwards compatibility.
@@ -876,10 +876,10 @@ def raw_snql_query(
 def bulk_snuba_queries(
     requests: list[Request],
     referrer: str | None = None,
+    use_cache: bool = False,
     query_source: (
         QuerySource | None
     ) = None,  # TODO: @athena Make this field required after updated all the callsites
-    use_cache: bool = False,
 ) -> ResultSet:
     """
     The main entrypoint to running queries in Snuba. This function accepts

--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -897,7 +897,7 @@ def bulk_snuba_queries(
 
     params = [(request, lambda x: x, lambda x: x) for request in requests]
     return _apply_cache_and_build_results(
-        params, referrer=referrer, is_frontend=is_frontend, use_cache=use_cache
+        snuba_param_list=params, referrer=referrer, is_frontend=is_frontend, use_cache=use_cache
     )
 
 
@@ -943,7 +943,7 @@ def _apply_cache_and_build_results(
     if referrer:
         headers["referer"] = referrer
     if is_frontend is not None:
-        headers["is_frontend"] = is_frontend
+        headers["is_frontend"] = str(is_frontend)
     # Store the original position of the query so that we can maintain the order
     query_param_list = list(enumerate(snuba_param_list))
 


### PR DESCRIPTION
EDIT: updated boolean is_frontend with query_source based on feedback
---

For better debugability we're passing a new field to snuba while querying: `is_frontend`. I decided the field is a better fit for request header since that's how we pass the `referrer` in the Snuba request and `is_frontend` is kind of a break down of referrer. 

This PR right now only apply the changes to one endpoint, putting it up for discussion before adding it everywhere else.