### PR TITLE
feat(metrics): Add extraction-rules-search

### DIFF
--- a/static/app/views/settings/projectMetrics/metricsExtractionRulesTable.tsx
+++ b/static/app/views/settings/projectMetrics/metricsExtractionRulesTable.tsx
@@ -92,7 +92,7 @@ export function MetricsExtractionRulesTable({project}: Props) {
         <h6>{t('Metric Extraction Rules')}</h6>
         <FlexSpacer />
         <SearchBar
-          placeholder={t('Search Metrics')}
+          placeholder={t('Search Extraction Rules')}
           onChange={setQuery}
           query={query}
           size="sm"

--- a/static/app/views/settings/projectMetrics/utils/useSearchQueryParam.tsx
+++ b/static/app/views/settings/projectMetrics/utils/useSearchQueryParam.tsx
@@ -1,0 +1,29 @@
+import {useMemo} from 'react';
+import debounce from 'lodash/debounce';
+
+import {DEFAULT_DEBOUNCE_DURATION} from 'sentry/constants';
+import {decodeScalar} from 'sentry/utils/queryString';
+import {useLocation} from 'sentry/utils/useLocation';
+import {useNavigate} from 'sentry/utils/useNavigate';
+
+export function useSearchQueryParam(key: string) {
+  const location = useLocation();
+  const navigate = useNavigate();
+
+  const query = decodeScalar(location.query[key], '').trim();
+
+  const setQuery = useMemo(
+    () =>
+      debounce(
+        (searchQuery: string) =>
+          navigate({
+            pathname: location.pathname,
+            query: {...location.query, [key]: searchQuery || undefined},
+          }),
+        DEFAULT_DEBOUNCE_DURATION
+      ),
+    [location.pathname, location.query, navigate, key]
+  );
+
+  return [query, setQuery] as const;
+}


### PR DESCRIPTION
Extract search query logic into hook.
Rename query param for custom metrics table from `query` to `metricsQuery`.
Add search to extraction rule table.

<img width="1369" alt="Screenshot 2024-06-24 at 14 19 16" src="https://github.com/getsentry/sentry/assets/7033940/8a87eb9a-0fae-433b-9cc8-b9c7d63de3b8">

Closes https://github.com/getsentry/sentry/issues/73158