### PR TITLE
fix(metrics): Restore add metric button for no feature flag case

### DIFF
--- a/static/app/views/settings/projectMetrics/projectMetrics.tsx
+++ b/static/app/views/settings/projectMetrics/projectMetrics.tsx
@@ -1,6 +1,8 @@
 import {Fragment} from 'react';
 import type {RouteComponentProps} from 'react-router';
+import * as Sentry from '@sentry/react';
 
+import {Button} from 'sentry/components/button';
 import ExternalLink from 'sentry/components/links/externalLink';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import {t, tct} from 'sentry/locale';
@@ -10,6 +12,7 @@ import {METRICS_DOCS_URL} from 'sentry/utils/metrics/constants';
 import {hasCustomMetricsExtractionRules} from 'sentry/utils/metrics/features';
 import routeTitleGen from 'sentry/utils/routeTitle';
 import useOrganization from 'sentry/utils/useOrganization';
+import {useMetricsOnboardingSidebar} from 'sentry/views/metrics/ddmOnboarding/useMetricsOnboardingSidebar';
 import SettingsPageHeader from 'sentry/views/settings/components/settingsPageHeader';
 import TextBlock from 'sentry/views/settings/components/text/textBlock';
 import PermissionAlert from 'sentry/views/settings/project/permissionAlert';
@@ -24,11 +27,32 @@ type Props = {
 function ProjectMetrics({project}: Props) {
   const organization = useOrganization();
   const hasExtractionRules = hasCustomMetricsExtractionRules(organization);
+  const {activateSidebar} = useMetricsOnboardingSidebar();
 
   return (
     <Fragment>
       <SentryDocumentTitle title={routeTitleGen(t('Metrics'), project.slug, false)} />
-      <SettingsPageHeader title={t('Metrics')} />
+      <SettingsPageHeader
+        title={t('Metrics')}
+        action={
+          !hasExtractionRules && (
+            <Button
+              priority="primary"
+              onClick={() => {
+                Sentry.metrics.increment('ddm.add_custom_metric', 1, {
+                  tags: {
+                    referrer: 'settings',
+                  },
+                });
+                activateSidebar();
+              }}
+              size="sm"
+            >
+              {t('Add Metric')}
+            </Button>
+          )
+        }
+      />
 
       <TextBlock>
         {tct(


### PR DESCRIPTION
Show `add metrics` button if the metrics extraction feature is not available.