### PR TITLE
ref(metrics-page): Add a new version of the 'add metric' button

### DIFF
--- a/static/app/views/metrics/pageHeaderActions.spec.tsx
+++ b/static/app/views/metrics/pageHeaderActions.spec.tsx
@@ -1,0 +1,55 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
+import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+
+import {navigateTo} from 'sentry/actionCreators/navigation';
+import {PageHeaderActions} from 'sentry/views/metrics/pageHeaderActions';
+
+jest.mock('sentry/actionCreators/navigation');
+jest.mock('sentry/views/metrics/useCreateDashboard');
+
+describe('Metrics Page Header Actions', function () {
+  describe('add metric buttons', function () {
+    it('display "add custom metrics" button', async function () {
+      const addCustomMetric = jest.fn();
+
+      render(
+        <PageHeaderActions showCustomMetricButton addCustomMetric={addCustomMetric} />
+      );
+
+      const button = screen.getByRole('button', {name: 'Add Custom Metrics'});
+
+      expect(button).toBeInTheDocument();
+
+      await userEvent.click(button);
+
+      expect(addCustomMetric).toHaveBeenCalled();
+    });
+
+    it('display "add new metric" button', async function () {
+      render(
+        <PageHeaderActions showCustomMetricButton addCustomMetric={() => jest.fn()} />,
+        {
+          organization: OrganizationFixture({
+            features: ['custom-metrics-extraction-rule'],
+          }),
+        }
+      );
+
+      const button = screen.getByRole('button', {name: 'Add New Metric'});
+
+      expect(button).toBeInTheDocument();
+
+      await userEvent.click(button);
+
+      expect(navigateTo).toHaveBeenCalledWith(
+        `/settings/projects/:projectId/metrics/`,
+        expect.objectContaining({
+          params: expect.objectContaining({
+            projectId: 'project-slug',
+          }),
+        })
+      );
+    });
+  });
+});

--- a/static/app/views/metrics/pageHeaderActions.tsx
+++ b/static/app/views/metrics/pageHeaderActions.tsx
@@ -19,6 +19,7 @@ import {
 import {t} from 'sentry/locale';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {isCustomMeasurement} from 'sentry/utils/metrics';
+import {hasCustomMetricsExtractionRules} from 'sentry/utils/metrics/features';
 import {formatMRI} from 'sentry/utils/metrics/mri';
 import {MetricExpressionType, type MetricsQueryWidget} from 'sentry/utils/metrics/types';
 import {middleEllipsis} from 'sentry/utils/string/middleEllipsis';
@@ -141,11 +142,20 @@ export function PageHeaderActions({showCustomMetricButton, addCustomMetric}: Pro
 
   return (
     <ButtonBar gap={1}>
-      {showCustomMetricButton && (
-        <Button priority="primary" onClick={() => addCustomMetric()} size="sm">
-          {t('Add Custom Metrics')}
-        </Button>
-      )}
+      {showCustomMetricButton &&
+        (hasCustomMetricsExtractionRules(organization) ? (
+          <Button
+            priority="primary"
+            onClick={() => navigateTo(`/settings/projects/:projectId/metrics/`, router)}
+            size="sm"
+          >
+            {t('Add New Metric')}
+          </Button>
+        ) : (
+          <Button priority="primary" onClick={() => addCustomMetric()} size="sm">
+            {t('Add Custom Metrics')}
+          </Button>
+        ))}
       <Button
         size="sm"
         icon={<IconBookmark isSolid={isDefaultQuery} />}


### PR DESCRIPTION
### Goal

Users with the `custom-metrics-extraction-rule` feature flag on the Metrics page will see the "Add New Metric" button instead of the previous "Add Custom Metrics" button. Clicking this button will navigate users to the metrics settings page of the selected project.

### Note

Users only see the button if we have ingested custom metrics for the selected projects


closes https://github.com/getsentry/sentry/issues/73166