### PR TITLE
ref: rewrite bounded tests to use fields directly

### DIFF
--- a/tests/sentry/db/models/fields/test_bounded.py
+++ b/tests/sentry/db/models/fields/test_bounded.py
@@ -1,37 +1,20 @@
 import pytest
-from django.db import models
 
-from sentry.backup.scopes import RelocationScope
-from sentry.db.models import (
+from sentry.db.models.fields.bounded import (
     BoundedBigIntegerField,
     BoundedIntegerField,
     BoundedPositiveIntegerField,
-    Model,
 )
-from sentry.testutils.cases import TestCase
 
 
-# There's a good chance this model wont get created in the db, so avoid
-# assuming it exists in these tests.
-class DummyModel(Model):
-    __relocation_scope__ = RelocationScope.Excluded
-
-    foo = models.CharField(max_length=32)
-    normint = BoundedIntegerField(null=True)
-    bigint = BoundedBigIntegerField(null=True)
-    posint = BoundedPositiveIntegerField(null=True)
-
-    class Meta:
-        app_label = "fixtures"
+def test_norm_int():
+    field = BoundedIntegerField()
+    with pytest.raises(AssertionError):
+        field.get_prep_value(9223372036854775807)
 
 
-class ModelTest(TestCase):
-    def test_large_int(self):
-        with pytest.raises(AssertionError):
-            DummyModel.objects.create(normint=int(9223372036854775807), foo="bar")
-
-        with pytest.raises(AssertionError):
-            DummyModel.objects.create(bigint=int(9223372036854775808), foo="bar")
-
-        with pytest.raises(AssertionError):
-            DummyModel.objects.create(posint=int(9223372036854775808), foo="bar")
+@pytest.mark.parametrize("cls", (BoundedBigIntegerField, BoundedPositiveIntegerField))
+def test_big_int(cls):
+    field = cls()
+    with pytest.raises(AssertionError):
+        field.get_prep_value(9223372036854775808)


### PR DESCRIPTION
mypy does not approve of constructing unbounded models

<!-- Describe your PR here. -->