### PR TITLE
fix(insights): fixes Web Vitals module perf score ring and breakdown chart display bugs

### DIFF
--- a/static/app/views/insights/browser/webVitals/components/charts/performanceScoreChart.tsx
+++ b/static/app/views/insights/browser/webVitals/components/charts/performanceScoreChart.tsx
@@ -3,6 +3,7 @@ import styled from '@emotion/styled';
 
 import EmptyStateWarning from 'sentry/components/emptyStateWarning';
 import ExternalLink from 'sentry/components/links/externalLink';
+import LoadingIndicator from 'sentry/components/loadingIndicator';
 import QuestionTooltip from 'sentry/components/questionTooltip';
 import {DEFAULT_RELATIVE_PERIODS} from 'sentry/constants';
 import {t} from 'sentry/locale';
@@ -59,18 +60,6 @@ export function PerformanceScoreChart({
   const period = pageFilters.selection.datetime.period;
   const performanceScoreSubtext = (period && DEFAULT_RELATIVE_PERIODS[period]) ?? '';
 
-  // Gets weights to dynamically size the performance score ring segments
-  const weights = projectScore
-    ? {
-        lcp: projectScore.lcpWeight,
-        fcp: projectScore.fcpWeight,
-        fid: 0,
-        inp: projectScore.inpWeight,
-        cls: projectScore.clsWeight,
-        ttfb: projectScore.ttfbWeight,
-      }
-    : undefined;
-
   return (
     <Flex>
       <PerformanceScoreLabelContainer>
@@ -91,6 +80,7 @@ export function PerformanceScoreChart({
           />
         </PerformanceScoreLabel>
         <PerformanceScoreSubtext>{performanceScoreSubtext}</PerformanceScoreSubtext>
+        {isProjectScoreLoading && <StyledLoadingIndicator size={50} />}
         {!isProjectScoreLoading && projectScore && (
           <PerformanceScoreRingWithTooltips
             projectScore={projectScore}
@@ -99,7 +89,6 @@ export function PerformanceScoreChart({
             height={200}
             ringBackgroundColors={ringBackgroundColors}
             ringSegmentColors={ringSegmentColors}
-            weights={weights}
           />
         )}
         {!isProjectScoreLoading && !projectScore && (
@@ -154,4 +143,8 @@ const StyledQuestionTooltip = styled(QuestionTooltip)`
   position: relative;
   margin-left: ${space(0.5)};
   top: ${space(0.25)};
+`;
+
+const StyledLoadingIndicator = styled(LoadingIndicator)`
+  margin: 50px;
 `;

--- a/static/app/views/insights/browser/webVitals/components/pageOverviewSidebar.tsx
+++ b/static/app/views/insights/browser/webVitals/components/pageOverviewSidebar.tsx
@@ -115,18 +115,6 @@ export function PageOverviewSidebar({
   const ringSegmentColors = theme.charts.getColorPalette(3);
   const ringBackgroundColors = ringSegmentColors.map(color => `${color}50`);
 
-  // Gets weights to dynamically size the performance score ring segments
-  const weights = projectScore
-    ? {
-        lcp: projectScore.lcpWeight,
-        fcp: projectScore.fcpWeight,
-        fid: 0,
-        inp: projectScore.inpWeight,
-        cls: projectScore.clsWeight,
-        ttfb: projectScore.ttfbWeight,
-      }
-    : undefined;
-
   return (
     <Fragment>
       <SectionHeading>
@@ -154,7 +142,6 @@ export function PageOverviewSidebar({
             height={200}
             ringBackgroundColors={ringBackgroundColors}
             ringSegmentColors={ringSegmentColors}
-            weights={weights}
           />
         )}
         {projectScoreIsLoading && <ProjectScoreEmptyLoadingElement />}

--- a/static/app/views/insights/browser/webVitals/components/performanceScoreRingWithTooltips.spec.tsx
+++ b/static/app/views/insights/browser/webVitals/components/performanceScoreRingWithTooltips.spec.tsx
@@ -5,26 +5,25 @@ import {render, screen} from 'sentry-test/reactTestingLibrary';
 import PerformanceScoreRingWithTooltips from 'sentry/views/insights/browser/webVitals/components/performanceScoreRingWithTooltips';
 
 describe('PerformanceScoreRingWithTooltips', function () {
-  const projectScore = {
-    lcpScore: 74,
-    fcpScore: 92,
-    clsScore: 71,
-    ttfbScore: 99,
-    fidScore: 98,
-    inpScore: 98,
-    totalScore: 83,
-    lcpWeight: 38,
-    fcpWeight: 23,
-    clsWeight: 18,
-    ttfbWeight: 16,
-    fidWeight: 5,
-    inpWeight: 5,
-  };
-
   it('renders segment labels', async () => {
+    const projectScore = {
+      lcpScore: 74,
+      fcpScore: 92,
+      clsScore: 71,
+      ttfbScore: 99,
+      fidScore: 98,
+      inpScore: 98,
+      totalScore: 83,
+      lcpWeight: 38,
+      fcpWeight: 23,
+      clsWeight: 18,
+      ttfbWeight: 16,
+      fidWeight: 10,
+      inpWeight: 0,
+    };
+
     render(
       <PerformanceScoreRingWithTooltips
-        weights={{lcp: 38, fcp: 23, cls: 18, ttfb: 16, fid: 10, inp: 0}}
         width={220}
         height={200}
         projectScore={projectScore}
@@ -41,10 +40,25 @@ describe('PerformanceScoreRingWithTooltips', function () {
   });
 
   it('renders inp', async () => {
+    const projectScore = {
+      lcpScore: 74,
+      fcpScore: 92,
+      clsScore: 71,
+      ttfbScore: 99,
+      fidScore: 98,
+      inpScore: 98,
+      totalScore: 83,
+      lcpWeight: 38,
+      fcpWeight: 23,
+      clsWeight: 18,
+      ttfbWeight: 16,
+      fidWeight: 0,
+      inpWeight: 10,
+    };
+
     const organizationWithInp = OrganizationFixture();
     render(
       <PerformanceScoreRingWithTooltips
-        weights={{lcp: 38, fcp: 23, cls: 18, ttfb: 16, fid: 0, inp: 10}}
         width={220}
         height={200}
         projectScore={projectScore}
@@ -53,6 +67,39 @@ describe('PerformanceScoreRingWithTooltips', function () {
         text={undefined}
       />,
       {organization: organizationWithInp}
+    );
+    await screen.findByText('inp');
+    screen.getByText('fcp');
+    screen.getByText('cls');
+    screen.getByText('ttfb');
+    screen.getByText('lcp');
+  });
+
+  it('renders empty state with default weights', async () => {
+    const projectScore = {
+      lcpScore: 0,
+      fcpScore: 0,
+      clsScore: 0,
+      ttfbScore: 0,
+      fidScore: 0,
+      inpScore: 0,
+      totalScore: 0,
+      lcpWeight: 0,
+      fcpWeight: 0,
+      clsWeight: 0,
+      ttfbWeight: 0,
+      fidWeight: 0,
+      inpWeight: 0,
+    };
+    render(
+      <PerformanceScoreRingWithTooltips
+        width={220}
+        height={200}
+        projectScore={projectScore}
+        ringBackgroundColors={['#444674', '#895289', '#d6567f', '#f38150', '#f2b712']}
+        ringSegmentColors={['#444674', '#895289', '#d6567f', '#f38150', '#f2b712']}
+        text={undefined}
+      />
     );
     await screen.findByText('inp');
     screen.getByText('fcp');

--- a/static/app/views/insights/browser/webVitals/components/performanceScoreRingWithTooltips.tsx
+++ b/static/app/views/insights/browser/webVitals/components/performanceScoreRingWithTooltips.tsx
@@ -21,15 +21,6 @@ import {useModuleURL} from 'sentry/views/insights/common/utils/useModuleURL';
 
 import {getFormattedDuration} from './webVitalMeters';
 
-const {
-  lcp: LCP_WEIGHT,
-  fcp: FCP_WEIGHT,
-  fid: FID_WEIGHT,
-  cls: CLS_WEIGHT,
-  ttfb: TTFB_WEIGHT,
-  inp: INP_WEIGHT,
-} = PERFORMANCE_SCORE_WEIGHTS;
-
 type Coordinates = {
   x: number;
   y: number;
@@ -55,9 +46,6 @@ type Props = {
   radiusPadding?: number;
   size?: number;
   webVitalLabelCoordinates?: WebVitalsLabelCoordinates;
-  weights?: {
-    [key in WebVitals]: number;
-  };
   x?: number;
   y?: number;
 };
@@ -135,15 +123,6 @@ function PerformanceScoreRingWithTooltips({
   height,
   text,
   webVitalLabelCoordinates,
-  // TODO: This prop isn't really needed anymore since we should always get weights from projectScore
-  weights = {
-    lcp: LCP_WEIGHT,
-    fcp: FCP_WEIGHT,
-    fid: FID_WEIGHT,
-    cls: CLS_WEIGHT,
-    ttfb: TTFB_WEIGHT,
-    inp: INP_WEIGHT,
-  },
   barWidth = 16,
   hideWebVitalLabels = false,
   inPerformanceWidget = false,
@@ -182,6 +161,24 @@ function PerformanceScoreRingWithTooltips({
       return i === index ? color : `${theme.gray200}33`;
     });
   }
+
+  const weights = [
+    'lcpWeight',
+    'fcpWeight',
+    'inpWeight',
+    'fidWeight',
+    'clsWeight',
+    'ttfbWeight',
+  ].every(key => projectScore[key] === 0)
+    ? PERFORMANCE_SCORE_WEIGHTS
+    : {
+        lcp: projectScore.lcpWeight,
+        fcp: projectScore.fcpWeight,
+        inp: projectScore.inpWeight,
+        fid: projectScore.fidWeight,
+        cls: projectScore.clsWeight,
+        ttfb: projectScore.ttfbWeight,
+      };
 
   const commonWebVitalLabelProps = {
     organization,

--- a/static/app/views/insights/browser/webVitals/queries/rawWebVitalsQueries/calculatePerformanceScore.tsx
+++ b/static/app/views/insights/browser/webVitals/queries/rawWebVitalsQueries/calculatePerformanceScore.tsx
@@ -5,10 +5,9 @@ import {getWebVitalsFromTableData} from 'sentry/views/insights/browser/webVitals
 export const PERFORMANCE_SCORE_WEIGHTS = {
   lcp: 30,
   fcp: 15,
+  inp: 30,
+  fid: 0,
   cls: 15,
-  fid: 30,
-  // INP is unused in FE score calculation but we need this here to satisfy TS
-  inp: 0,
   ttfb: 10,
 };
 

--- a/static/app/views/insights/browser/webVitals/queries/storedScoreQueries/calculatePerformanceScoreFromStored.tsx
+++ b/static/app/views/insights/browser/webVitals/queries/storedScoreQueries/calculatePerformanceScoreFromStored.tsx
@@ -78,6 +78,13 @@ export function getWebVitalScores(data?: TableDataRow): ProjectScore {
 }
 
 const calculateWeights = (data: TableDataRow) => {
+  const hasLcp = hasWebVitalScore(data, 'lcp');
+  const hasFcp = hasWebVitalScore(data, 'fcp');
+  const hasCls = hasWebVitalScore(data, 'cls');
+  const hasFid = hasWebVitalScore(data, 'fid');
+  const hasInp = hasWebVitalScore(data, 'inp');
+  const hasTtfb = hasWebVitalScore(data, 'ttfb');
+
   // We need to do this because INP and pageLoads are different score profiles
   const inpScoreCount = getWebVitalScoreCount(data, 'inp') || 0;
   const totalScoreCount = getWebVitalScoreCount(data, 'total');
@@ -97,11 +104,11 @@ const calculateWeights = (data: TableDataRow) => {
     }
   );
   return {
-    lcpWeight,
-    fcpWeight,
-    clsWeight,
-    ttfbWeight,
-    fidWeight,
-    inpWeight: inpActualWeight,
+    lcpWeight: hasLcp ? lcpWeight : 0,
+    fcpWeight: hasFcp ? fcpWeight : 0,
+    clsWeight: hasCls ? clsWeight : 0,
+    ttfbWeight: hasTtfb ? ttfbWeight : 0,
+    fidWeight: hasFid ? fidWeight : 0,
+    inpWeight: hasInp ? inpActualWeight : 0,
   };
 };

--- a/static/app/views/performance/landing/widgets/widgets/performanceScoreWidget.tsx
+++ b/static/app/views/performance/landing/widgets/widgets/performanceScoreWidget.tsx
@@ -34,17 +34,6 @@ export function PerformanceScoreWidget(props: PerformanceWidgetProps) {
   const ringSegmentColors = theme.charts.getColorPalette(3);
   const ringBackgroundColors = ringSegmentColors.map(color => `${color}50`);
 
-  const weights = projectScore
-    ? {
-        lcp: projectScore.lcpWeight,
-        fcp: projectScore.fcpWeight,
-        inp: projectScore.inpWeight,
-        fid: 0,
-        cls: projectScore.clsWeight,
-        ttfb: projectScore.ttfbWeight,
-      }
-    : undefined;
-
   const moduleURL = useModuleURL('vital');
 
   return (
@@ -105,7 +94,6 @@ export function PerformanceScoreWidget(props: PerformanceWidgetProps) {
                   ringSegmentColors={ringSegmentColors}
                   radiusPadding={10}
                   labelHeightPadding={0}
-                  weights={weights}
                 />
               ) : isLoading ? (
                 <StyledLoadingIndicator size={40} />


### PR DESCRIPTION
- Adds loading spinner to the Webvitals page performance score ring when loading
- Fix/update perf score breakdown chart tooltip weight to display as `0` instead of `NaN` when no data is available
- Fix performance score ring to properly display empty ring segments with default weights when no webvitals data is available
![image](https://github.com/getsentry/sentry/assets/83961295/afbaeaaf-06ca-4e86-8927-b0c27327a0c8)
