### PR TITLE
chore(grouping): Small fixes to tests

### DIFF
--- a/tests/sentry/api/endpoints/test_group_similar_issues_embeddings.py
+++ b/tests/sentry/api/endpoints/test_group_similar_issues_embeddings.py
@@ -520,7 +520,10 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
         mock_seer_request.return_value = HTTPResponse(orjson.dumps(seer_return_value))
 
         # Include no optional parameters
-        response = self.client.get(self.path)
+        response = self.client.get(
+            self.path,
+            # optional params would be here
+        )
         assert response.data == self.get_expected_response(
             [NonNone(self.similar_event.group_id)], [0.95], [0.99], ["Yes"]
         )

--- a/tests/sentry/event_manager/test_event_manager.py
+++ b/tests/sentry/event_manager/test_event_manager.py
@@ -155,32 +155,6 @@ class EventManagerTest(TestCase, SnubaTestCase, EventManagerTestMixin, Performan
 
         assert eventstream_insert.call_count == 2
 
-    def test_updates_group(self) -> None:
-        timestamp = time() - 300
-        manager = EventManager(
-            make_event(message="foo", event_id="a" * 32, checksum="a" * 32, timestamp=timestamp)
-        )
-        manager.normalize()
-        event = manager.save(self.project.id)
-
-        manager = EventManager(
-            make_event(
-                message="foo bar", event_id="b" * 32, checksum="a" * 32, timestamp=timestamp + 2.0
-            )
-        )
-        manager.normalize()
-
-        with self.tasks():
-            event2 = manager.save(self.project.id)
-
-        group = Group.objects.get(id=event.group_id)
-
-        assert group.times_seen == 2
-        assert group.last_seen == event2.datetime
-        assert group.message == event2.message
-        assert group.data["type"] == "default"
-        assert group.data["metadata"]["title"] == "foo bar"
-
     def test_materialze_metadata_simple(self) -> None:
         manager = EventManager(make_event(transaction="/dogs/are/great/"))
         event = manager.save(self.project.id)

--- a/tests/sentry/event_manager/test_event_manager.py
+++ b/tests/sentry/event_manager/test_event_manager.py
@@ -126,20 +126,6 @@ class EventManagerTestMixin:
 
 
 class EventManagerTest(TestCase, SnubaTestCase, EventManagerTestMixin, PerformanceIssueTestCase):
-    def test_similar_message_prefix_doesnt_group(self) -> None:
-        # we had a regression which caused the default hash to just be
-        # 'event.message' instead of '[event.message]' which caused it to
-        # generate a hash per letter
-        manager = EventManager(make_event(event_id="a", message="foo bar"))
-        manager.normalize()
-        event1 = manager.save(self.project.id)
-
-        manager = EventManager(make_event(event_id="b", message="foo baz"))
-        manager.normalize()
-        event2 = manager.save(self.project.id)
-
-        assert event1.group_id != event2.group_id
-
     def test_ephemeral_interfaces_removed_on_save(self) -> None:
         manager = EventManager(make_event(platform="python"))
         manager.normalize()

--- a/tests/sentry/event_manager/test_event_manager_grouping.py
+++ b/tests/sentry/event_manager/test_event_manager_grouping.py
@@ -3,17 +3,23 @@ from __future__ import annotations
 from time import time
 from typing import Any
 from unittest import mock
-from unittest.mock import MagicMock
+from unittest.mock import ANY, MagicMock
 
 import pytest
+from django.test import override_settings
 
+from sentry import audit_log
+from sentry.conf.server import SENTRY_GROUPING_UPDATE_MIGRATION_PHASE
 from sentry.event_manager import _get_updated_group_title
 from sentry.eventtypes.base import DefaultEvent
 from sentry.grouping.result import CalculatedHashes
+from sentry.models.auditlogentry import AuditLogEntry
 from sentry.models.group import Group
+from sentry.projectoptions.defaults import DEFAULT_GROUPING_CONFIG
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.eventprocessing import save_new_event
 from sentry.testutils.pytest.fixtures import django_db_all
+from sentry.testutils.silo import assume_test_silo_mode_of
 from sentry.testutils.skips import requires_snuba
 
 pytestmark = [requires_snuba]
@@ -126,6 +132,44 @@ class EventManagerGroupingTest(TestCase):
         assert group.last_seen == event2.datetime
         assert group.message == event2.message
         assert group.data.get("metadata").get("title") == event2.title
+
+    def test_auto_updates_grouping_config(self):
+        self.project.update_option("sentry:grouping_config", LEGACY_CONFIG)
+
+        with override_settings(SENTRY_GROUPING_AUTO_UPDATE_ENABLED=False):
+            save_new_event({"message": "Dogs are great!"}, self.project)
+            assert self.project.get_option("sentry:grouping_config") == LEGACY_CONFIG
+
+        with override_settings(SENTRY_GROUPING_AUTO_UPDATE_ENABLED=True):
+            save_new_event({"message": "Adopt don't shop"}, self.project)
+            assert self.project.get_option("sentry:grouping_config") == DEFAULT_GROUPING_CONFIG
+
+            with assume_test_silo_mode_of(AuditLogEntry):
+                audit_log_entry = AuditLogEntry.objects.first()
+
+            assert audit_log_entry.event == audit_log.get_event_id("PROJECT_EDIT")
+            assert audit_log_entry.actor_label == "Sentry"
+
+            assert audit_log_entry.data == {
+                "sentry:grouping_config": DEFAULT_GROUPING_CONFIG,
+                "sentry:secondary_grouping_config": LEGACY_CONFIG,
+                "sentry:secondary_grouping_expiry": ANY,  # tested separately below
+                "id": self.project.id,
+                "slug": self.project.slug,
+                "name": self.project.name,
+                "status": 0,
+                "public": False,
+            }
+
+            # When the config upgrade is actually happening, the expiry value is set before the
+            # audit log entry is created, which means the expiry is based on a timestamp
+            # ever-so-slightly before the audit log entry's timestamp, making a one-second tolerance
+            # necessary.
+            actual_expiry = audit_log_entry.data["sentry:secondary_grouping_expiry"]
+            expected_expiry = (
+                int(audit_log_entry.datetime.timestamp()) + SENTRY_GROUPING_UPDATE_MIGRATION_PHASE
+            )
+            assert actual_expiry == expected_expiry or actual_expiry == expected_expiry - 1
 
 
 class PlaceholderTitleTest(TestCase):

--- a/tests/sentry/event_manager/test_event_manager_grouping.py
+++ b/tests/sentry/event_manager/test_event_manager_grouping.py
@@ -55,6 +55,14 @@ class EventManagerGroupingTest(TestCase):
 
         assert event.group_id != event2.group_id
 
+    def test_puts_events_with_only_partial_message_match_in_different_groups(self):
+        # We had a regression which caused the default hash to just be 'event.message' instead of
+        # '[event.message]' which caused it to generate a hash per letter
+        event1 = save_new_event({"message": "Dogs are great!"}, self.project)
+        event2 = save_new_event({"message": "Dogs are really great!"}, self.project)
+
+        assert event1.group_id != event2.group_id
+
     def test_adds_default_fingerprint_if_none_in_event(self):
         event = save_new_event({"message": "Dogs are great!"}, self.project)
 

--- a/tests/sentry/event_manager/test_event_manager_grouping.py
+++ b/tests/sentry/event_manager/test_event_manager_grouping.py
@@ -110,6 +110,7 @@ class EventManagerGroupingTest(TestCase):
         assert group.times_seen == 1
         assert group.last_seen == event1.datetime
         assert group.message == event1.message
+        assert group.data.get("metadata").get("title") == event1.title
 
         # Normally this should go into a different group, since the messages don't match, but the
         # fingerprint takes precedence. (We need to make the messages different in order to show
@@ -124,6 +125,7 @@ class EventManagerGroupingTest(TestCase):
         assert group.times_seen == 2
         assert group.last_seen == event2.datetime
         assert group.message == event2.message
+        assert group.data.get("metadata").get("title") == event2.title
 
 
 class PlaceholderTitleTest(TestCase):

--- a/tests/sentry/grouping/test_seer.py
+++ b/tests/sentry/grouping/test_seer.py
@@ -15,7 +15,6 @@ from sentry.utils.types import NonNone
 
 
 class ShouldCallSeerTest(TestCase):
-    # TODO: Add tests for rate limits, killswitches, etc once those are in place
     def setUp(self):
         self.event_data = {
             "title": "FailedToFetchError('Charlie didn't bring the ball back')",

--- a/tests/sentry/seer/similarity/test_utils.py
+++ b/tests/sentry/seer/similarity/test_utils.py
@@ -655,6 +655,8 @@ class EventContentIsSeerEligibleTest(TestCase):
         assert event_content_is_seer_eligible(good_event) is True
         assert event_content_is_seer_eligible(bad_event) is False
 
+
+class SeerUtilsTest(TestCase):
     def test_filter_null_from_event_title(self):
         title_with_null = 'Title with null \x00, "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00" is null'
         assert filter_null_from_event_title(title_with_null) == 'Title with null , "" is null'

--- a/tests/sentry/tasks/test_backfill_seer_grouping_records.py
+++ b/tests/sentry/tasks/test_backfill_seer_grouping_records.py
@@ -98,7 +98,7 @@ class TestBackfillSeerGroupingRecords(SnubaTestCase, TestCase):
         rows, events = [], []
         function_names = [f"function_{str(i)}" for i in range(num)]
         type_names = [f"Error{str(i)}" for i in range(num)]
-        value_names = ["error with value" for i in range(num)]
+        value_names = ["error with value" for _ in range(num)]
         for i in range(num):
             data = {
                 "exception": self.create_exception_values(
@@ -121,7 +121,7 @@ class TestBackfillSeerGroupingRecords(SnubaTestCase, TestCase):
             GroupHash.objects.create(
                 project_id=event.group.project.id,
                 group_id=event.group.id,
-                hash="".join(choice(ascii_uppercase) for i in range(32)),
+                hash="".join(choice(ascii_uppercase) for _ in range(32)),
             )
 
         return {"rows": rows, "events": events}
@@ -172,7 +172,7 @@ class TestBackfillSeerGroupingRecords(SnubaTestCase, TestCase):
     def test_lookup_group_data_stacktrace_bulk_success(self, mock_metrics):
         """Test successful bulk group data and stacktrace lookup"""
         rows, events = self.bulk_rows, self.bulk_events
-        nodestore_results, group_hashes_dict = get_events_from_nodestore(
+        nodestore_results, _ = get_events_from_nodestore(
             self.project, rows, self.group_hashes.keys()
         )
 
@@ -245,9 +245,7 @@ class TestBackfillSeerGroupingRecords(SnubaTestCase, TestCase):
         rows.append({"event_id": event.event_id, "group_id": event.group_id})
         hashes.update({event.group_id: GroupHash.objects.get(group_id=event.group.id).hash})
 
-        nodestore_results, group_hashes_dict = get_events_from_nodestore(
-            self.project, rows, group_ids
-        )
+        nodestore_results, _ = get_events_from_nodestore(self.project, rows, group_ids)
         expected_group_data = [
             CreateGroupingRecordData(
                 group_id=event.group.id,
@@ -282,9 +280,7 @@ class TestBackfillSeerGroupingRecords(SnubaTestCase, TestCase):
         rows.append({"event_id": event.event_id, "group_id": event.group_id})
         hashes.update({event.group_id: GroupHash.objects.get(group_id=event.group.id).hash})
 
-        bulk_group_data_stacktraces, group_hashes_dict = get_events_from_nodestore(
-            self.project, rows, group_ids
-        )
+        bulk_group_data_stacktraces, _ = get_events_from_nodestore(self.project, rows, group_ids)
         expected_group_data = [
             CreateGroupingRecordData(
                 group_id=event.group.id,
@@ -309,7 +305,7 @@ class TestBackfillSeerGroupingRecords(SnubaTestCase, TestCase):
             self.bulk_events,
             self.group_hashes,
         )
-        bulk_group_data_stacktraces, group_hashes_dict = get_events_from_nodestore(
+        bulk_group_data_stacktraces, _ = get_events_from_nodestore(
             self.project, rows, self.group_hashes.keys()
         )
 
@@ -346,7 +342,7 @@ class TestBackfillSeerGroupingRecords(SnubaTestCase, TestCase):
         }
 
         rows, hashes = self.bulk_rows, self.group_hashes
-        bulk_group_data_stacktraces, group_hashes_dict = get_events_from_nodestore(
+        bulk_group_data_stacktraces, _ = get_events_from_nodestore(
             self.project, rows, self.group_hashes.keys()
         )
 
@@ -381,7 +377,7 @@ class TestBackfillSeerGroupingRecords(SnubaTestCase, TestCase):
         # Purposely change the event id of the last row to one that does not exist
         rows[-1]["event_id"] = 10000
 
-        bulk_group_data_stacktraces, group_hashes_dict = get_events_from_nodestore(
+        bulk_group_data_stacktraces, _ = get_events_from_nodestore(
             self.project, rows, self.group_hashes.keys()
         )
 
@@ -645,7 +641,7 @@ class TestBackfillSeerGroupingRecords(SnubaTestCase, TestCase):
 
         function_names = [f"new_function_{str(i)}" for i in range(5)]
         type_names = [f"NewError{str(i)}" for i in range(5)]
-        value_names = ["error with value" for i in range(5)]
+        value_names = ["error with value" for _ in range(5)]
         groups_seen_once = []
         for i in range(5):
             data = {
@@ -696,7 +692,7 @@ class TestBackfillSeerGroupingRecords(SnubaTestCase, TestCase):
         # The groups that will be similar to these groups, have times_seen = 5
         function_names = [f"another_function_{str(i)}" for i in range(5)]
         type_names = [f"AnotherError{str(i)}" for i in range(5)]
-        value_names = ["error with value" for i in range(5)]
+        value_names = ["error with value" for _ in range(5)]
         groups_with_neighbor = {}
         for i in range(5):
             data = {

--- a/tests/sentry/tasks/test_backfill_seer_grouping_records.py
+++ b/tests/sentry/tasks/test_backfill_seer_grouping_records.py
@@ -701,7 +701,6 @@ class TestBackfillSeerGroupingRecords(SnubaTestCase, TestCase):
                 ),
                 "title": "title",
                 "timestamp": iso_format(before_now(seconds=10)),
-                "title": "title",
             }
             event = self.store_event(data=data, project_id=self.project.id, assert_no_errors=False)
             event.group.times_seen = 2


### PR DESCRIPTION
This is a collection of small fixes to various grouping tests which have been piling up in my local repo. Specifically:

- Refactor and move and two grouping-related tests (`test_similar_message_prefix_doesnt_group` and  `test_auto_update_grouping`) from `test_event_manager.py` to `test_event_manager_grouping.py`. (The refactoring primarily involved using  the `save_new_event` helper to make them less verbose.)

- Remove `test_updates_group` from `test_event_manager.py` because it's a mirror of `test_updates_group_metadata` in `test_event_manager_grouping.py`. The one piece of data the former tested which the latter didn't (group title) has been added to the latter test.

- Move `test_filter_null_from_event_title` from `EventContentIsSeerEligibleTest` class to a new, more generic `SeerUtilsTest` class.

- Remove an obsolete TODO from the `ShouldCallSeerTest` class.

- Appease the linter by replacing unused values with `_` in backfill tests.

- Remove redundant `title` entry in test data in `test_backfill_seer_grouping_records_groups_have_neighbor` (it's in the dictionary twice). 