### PR TITLE
fix(ui) Allow ngrok domains through webpack proxy

### DIFF
--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -536,13 +536,16 @@ if (
     headers: {
       'Document-Policy': 'js-profiling',
     },
-    // Cover the various environments we use (vercel, getsentry-dev, localhost)
+    // Cover the various environments we use (vercel, getsentry-dev, localhost, ngrok)
     allowedHosts: [
       '.sentry.dev',
       '.dev.getsentry.net',
       '.localhost',
       '127.0.0.1',
       '.docker.internal',
+      '.ngrok.dev',
+      '.ngrok.io',
+      '.ngrok.app',
     ],
     static: {
       directory: './src/sentry/static/sentry',


### PR DESCRIPTION
When running sentry with multi-region enabled, we need to allow acme.person.ngrok.io style URLs through webpack's proxy. ngrok has multiple TLD's and I've added the most frequently used ones.

Refs getsentry/sentry#14423