### PR TITLE
perf(trace-explorer): Narrow time range of spans query

### DIFF
--- a/static/app/views/traces/content.tsx
+++ b/static/app/views/traces/content.tsx
@@ -3,6 +3,7 @@ import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 import debounce from 'lodash/debounce';
 import omit from 'lodash/omit';
+import moment from 'moment';
 
 import {Alert} from 'sentry/components/alert';
 import {Button} from 'sentry/components/button';
@@ -32,6 +33,7 @@ import type {MRI} from 'sentry/types/metrics';
 import type {Organization} from 'sentry/types/organization';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {browserHistory} from 'sentry/utils/browserHistory';
+import {getUtcDateString} from 'sentry/utils/dates';
 import {getFormattedMQL} from 'sentry/utils/metrics';
 import {useApiQuery} from 'sentry/utils/queryClient';
 import {decodeInteger, decodeList, decodeScalar} from 'sentry/utils/queryString';
@@ -67,6 +69,7 @@ import {
 const DEFAULT_PER_PAGE = 50;
 const SPAN_PROPS_DOCS_URL =
   'https://docs.sentry.io/concepts/search/searchable-properties/spans/';
+const ONE_MINUTE = 60 * 1000; // in milliseconds
 
 function usePageParams(location) {
   const queries = useMemo(() => {
@@ -412,6 +415,13 @@ function SpanTable({
         field.startsWith('-') ? (field.substring(1) as Field) : (field as Field)
       ),
     ],
+    datetime: {
+      // give a 1 minute buffer on each side so that start != end
+      start: getUtcDateString(moment(trace.start - ONE_MINUTE)),
+      end: getUtcDateString(moment(trace.end + ONE_MINUTE)),
+      period: null,
+      utc: true,
+    },
     limit: 10,
     query: queries,
     sort: SORTS,
@@ -737,7 +747,6 @@ function useTraceSpans<F extends string>({
 
   const endpointOptions = {
     query: {
-      project: selection.projects,
       environment: selection.environments,
       ...(datetime ?? normalizeDateTimeParams(selection.datetime)),
       field: fields,


### PR DESCRIPTION
We have the start/end of the trace already so use that information to narrow down the time range of the spans query for better performance.