### PR TITLE
chore(slack): remove block kit flag for webhook no org access

### DIFF
--- a/src/sentry/integrations/slack/webhooks/action.py
+++ b/src/sentry/integrations/slack/webhooks/action.py
@@ -190,16 +190,14 @@ class SlackActionEndpoint(Endpoint):
         )
         channel_id = None
         response_url = None
-        view = None
-        if features.has("organizations:slack-block-kit", group.project.organization):
-            # the channel ID and response URL are in a different place if it's coming from a modal
-            view = slack_request.data.get("view")
-            if view:
-                private_metadata = view.get("private_metadata")
-                if private_metadata:
-                    data = orjson.loads(private_metadata)
-                    channel_id = data.get("channel_id")
-                    response_url = data.get("orig_response_url")
+        # the channel ID and response URL are in a different place if it's coming from a modal
+        view = slack_request.data.get("view")
+        if view:
+            private_metadata = view.get("private_metadata")
+            if private_metadata:
+                data = orjson.loads(private_metadata)
+                channel_id = data.get("channel_id")
+                response_url = data.get("orig_response_url")
 
         if error.status_code == 403:
             text = UNLINK_IDENTITY_MESSAGE.format(

--- a/tests/sentry/integrations/slack/test_unfurl.py
+++ b/tests/sentry/integrations/slack/test_unfurl.py
@@ -216,7 +216,6 @@ class UnfurlTest(TestCase):
             ).build()
         )
 
-    @with_feature("organizations:slack-block-kit")
     def test_unfurl_issues_block_kit(self):
         min_ago = iso_format(before_now(minutes=1))
         event = self.store_event(

--- a/tests/sentry/integrations/slack/webhooks/actions/test_link_clicked.py
+++ b/tests/sentry/integrations/slack/webhooks/actions/test_link_clicked.py
@@ -1,4 +1,3 @@
-from sentry.testutils.helpers.features import with_feature
 from tests.sentry.integrations.slack.webhooks.actions import BaseEventTest
 
 
@@ -42,7 +41,6 @@ class LinkClickedActionTest(BaseEventTest):
             ]
         }
 
-    @with_feature("organizations:slack-block-kit")
     def test_simple(self):
         resp = self.post_webhook(
             action_data=[{"name": "some_action", "value": "link_clicked"}],


### PR DESCRIPTION
Slowly breaking apart and merging #70207. Also added a test as this area previously had zero coverage