### PR TITLE
fix: attach activations to incidents on trigger

### DIFF
--- a/src/sentry/incidents/subscription_processor.py
+++ b/src/sentry/incidents/subscription_processor.py
@@ -630,7 +630,7 @@ class SubscriptionProcessor:
             if not self.active_incident:
                 detected_at = self.calculate_event_date_from_update_date(self.last_update)
                 activation: AlertRuleActivations | None = None
-                if self.alert_rule.monitor_type == AlertRuleMonitorType.ACTIVATED:
+                if self.alert_rule.monitor_type == AlertRuleMonitorType.ACTIVATED.value:
                     activations = list(self.subscription.alertruleactivations_set)
                     if len(activations) != 1:
                         logger.error(

--- a/src/sentry/incidents/subscription_processor.py
+++ b/src/sentry/incidents/subscription_processor.py
@@ -631,7 +631,7 @@ class SubscriptionProcessor:
                 detected_at = self.calculate_event_date_from_update_date(self.last_update)
                 activation: AlertRuleActivations | None = None
                 if self.alert_rule.monitor_type == AlertRuleMonitorType.ACTIVATED.value:
-                    activations = list(self.subscription.alertruleactivations_set)
+                    activations = list(self.subscription.alertruleactivations_set.all())
                     if len(activations) != 1:
                         logger.error(
                             "activated alert rule subscription has unexpected activation instances",

--- a/tests/sentry/incidents/test_subscription_processor.py
+++ b/tests/sentry/incidents/test_subscription_processor.py
@@ -43,6 +43,7 @@ from sentry.incidents.subscription_processor import (
     partition,
     update_alert_rule_stats,
 )
+from sentry.incidents.utils.types import AlertRuleActivationConditionType
 from sentry.sentry_metrics.configuration import UseCaseKey
 from sentry.sentry_metrics.indexer.postgres.models import MetricsKeyIndexer
 from sentry.sentry_metrics.utils import resolve_tag_key, resolve_tag_value
@@ -196,6 +197,10 @@ class ProcessUpdateTest(ProcessUpdateBaseClass):
         return self.rule.snuba_query.subscriptions.filter(project=self.project).get()
 
     @cached_property
+    def activated_sub(self):
+        return self.activated_rule.snuba_query.subscriptions.filter(project=self.project).get()
+
+    @cached_property
     def other_sub(self):
         return self.rule.snuba_query.subscriptions.filter(project=self.other_project).get()
 
@@ -215,6 +220,40 @@ class ProcessUpdateTest(ProcessUpdateBaseClass):
                 SnubaQueryEventType.EventType.ERROR,
                 SnubaQueryEventType.EventType.DEFAULT,
             ],
+        )
+        # Make sure the trigger exists
+        trigger = create_alert_rule_trigger(rule, CRITICAL_TRIGGER_LABEL, 100)
+        create_alert_rule_trigger_action(
+            trigger,
+            AlertRuleTriggerAction.Type.EMAIL,
+            AlertRuleTriggerAction.TargetType.USER,
+            str(self.user.id),
+        )
+        return rule
+
+    @cached_property
+    def activated_rule(self):
+        rule = self.create_alert_rule(
+            projects=[self.project, self.other_project],
+            name="some rule",
+            query="",
+            aggregate="count()",
+            time_window=1,
+            threshold_type=AlertRuleThresholdType.ABOVE,
+            resolve_threshold=10,
+            threshold_period=1,
+            monitor_type=AlertRuleMonitorType.ACTIVATED,
+            activation_condition=AlertRuleActivationConditionType.RELEASE_CREATION,
+            event_types=[
+                SnubaQueryEventType.EventType.ERROR,
+                SnubaQueryEventType.EventType.DEFAULT,
+            ],
+        )
+        rule.subscribe_projects(
+            projects=[self.project],
+            monitor_type=AlertRuleMonitorType.ACTIVATED,
+            activation_condition=AlertRuleActivationConditionType.DEPLOY_CREATION,
+            activator="testing",
         )
         # Make sure the trigger exists
         trigger = create_alert_rule_trigger(rule, CRITICAL_TRIGGER_LABEL, 100)
@@ -251,8 +290,16 @@ class ProcessUpdateTest(ProcessUpdateBaseClass):
         return self.rule.alertruletrigger_set.get()
 
     @cached_property
+    def activated_trigger(self):
+        return self.activated_rule.alertruletrigger_set.get()
+
+    @cached_property
     def action(self):
         return self.trigger.alertruletriggeraction_set.get()
+
+    @cached_property
+    def activated_action(self):
+        return self.activated_trigger.alertruletriggeraction_set.get()
 
     def build_subscription_update(self, subscription, time_delta=None, value=EMPTY):
         if time_delta is not None:
@@ -380,6 +427,33 @@ class ProcessUpdateTest(ProcessUpdateBaseClass):
             [self.action],
             [(trigger.alert_threshold + 1, IncidentStatus.CRITICAL, uuid)],
         )
+
+    def test_activated_alert(self):
+        # Verify that an alert rule that only expects a single update to be over the
+        # alert threshold triggers correctly
+        rule = self.activated_rule
+        trigger = self.activated_trigger
+        subscription = self.activated_sub
+        processor = self.send_update(
+            rule=rule, value=trigger.alert_threshold + 1, subscription=subscription
+        )
+        self.assert_trigger_counts(processor, self.activated_trigger, 0, 0)
+        incident = self.assert_active_incident(rule=rule, subscription=subscription)
+        assert incident.date_started == (
+            timezone.now().replace(microsecond=0) - timedelta(seconds=rule.snuba_query.time_window)
+        )
+        self.assert_trigger_exists_with_status(
+            incident, self.activated_trigger, TriggerStatus.ACTIVE
+        )
+        latest_activity = self.latest_activity(incident)
+        uuid = str(latest_activity.notification_uuid)
+        self.assert_actions_fired_for_incident(
+            incident,
+            [self.activated_action],
+            [(trigger.alert_threshold + 1, IncidentStatus.CRITICAL, uuid)],
+        )
+        # assert that an incident was created _with_ an activation!
+        assert incident.activation
 
     def test_alert_dedupe(self):
         # Verify that an alert rule that only expects a single update to be over the


### PR DESCRIPTION
nit - check the `monitor_type` to the enum `value` rather than the enum itself

Update tests