### PR TITLE
chore(<DraggableTabs>): Make new draggableTabs directory, copied from tabs directory

### DIFF
--- a/static/app/components/draggableTabs/draggableTab.tsx
+++ b/static/app/components/draggableTabs/draggableTab.tsx
@@ -1,0 +1,236 @@
+import {forwardRef, useCallback} from 'react';
+import type {Theme} from '@emotion/react';
+import styled from '@emotion/styled';
+import type {AriaTabProps} from '@react-aria/tabs';
+import {useTab} from '@react-aria/tabs';
+import {useObjectRef} from '@react-aria/utils';
+import type {TabListState} from '@react-stately/tabs';
+import type {Node, Orientation} from '@react-types/shared';
+
+import InteractionStateLayer from 'sentry/components/interactionStateLayer';
+import Link from 'sentry/components/links/link';
+import {space} from 'sentry/styles/space';
+
+import {tabsShouldForwardProp} from './utils';
+
+interface TabProps extends AriaTabProps {
+  item: Node<any>;
+  orientation: Orientation;
+  /**
+   * Whether this tab is overflowing the TabList container. If so, the tab
+   * needs to be visually hidden. Users can instead select it via an overflow
+   * menu.
+   */
+  overflowing: boolean;
+  state: TabListState<any>;
+}
+
+/**
+ * Stops event propagation if the command/ctrl/shift key is pressed, in effect
+ * preventing any state change. This is useful because when a user
+ * command/ctrl/shift-clicks on a tab link, the intention is to view the tab
+ * in a new browser tab/window, not to update the current view.
+ */
+function handleLinkClick(e: React.PointerEvent<HTMLAnchorElement>) {
+  if (e.metaKey || e.ctrlKey || e.shiftKey) {
+    e.stopPropagation();
+  }
+}
+
+/**
+ * Renders a single tab item. This should not be imported directly into any
+ * page/view – it's only meant to be used by <TabsList />. See the correct
+ * usage in tabs.stories.js
+ */
+function BaseTab(
+  {item, state, orientation, overflowing}: TabProps,
+  forwardedRef: React.ForwardedRef<HTMLLIElement>
+) {
+  const ref = useObjectRef(forwardedRef);
+
+  const {
+    key,
+    rendered,
+    props: {to, hidden},
+  } = item;
+  const {tabProps, isSelected} = useTab({key, isDisabled: hidden}, state, ref);
+
+  const InnerWrap = useCallback(
+    ({children}) =>
+      to ? (
+        <TabLink
+          to={to}
+          onMouseDown={handleLinkClick}
+          onPointerDown={handleLinkClick}
+          orientation={orientation}
+          tabIndex={-1}
+        >
+          {children}
+        </TabLink>
+      ) : (
+        <TabInnerWrap orientation={orientation}>{children}</TabInnerWrap>
+      ),
+    [to, orientation]
+  );
+
+  return (
+    <TabWrap
+      {...tabProps}
+      hidden={hidden}
+      selected={isSelected}
+      overflowing={overflowing}
+      ref={ref}
+    >
+      <InnerWrap>
+        <StyledInteractionStateLayer
+          orientation={orientation}
+          higherOpacity={isSelected}
+        />
+        <FocusLayer orientation={orientation} />
+        {rendered}
+        <TabSelectionIndicator orientation={orientation} selected={isSelected} />
+      </InnerWrap>
+    </TabWrap>
+  );
+}
+
+export const Tab = forwardRef(BaseTab);
+
+const TabWrap = styled('li', {shouldForwardProp: tabsShouldForwardProp})<{
+  overflowing: boolean;
+  selected: boolean;
+}>`
+  color: ${p => (p.selected ? p.theme.activeText : p.theme.textColor)};
+  white-space: nowrap;
+  cursor: pointer;
+
+  &:hover {
+    color: ${p => (p.selected ? p.theme.activeText : p.theme.headingColor)};
+  }
+
+  &:focus {
+    outline: none;
+  }
+
+  &[aria-disabled],
+  &[aria-disabled]:hover {
+    color: ${p => p.theme.subText};
+    pointer-events: none;
+    cursor: default;
+  }
+
+  ${p =>
+    p.overflowing &&
+    `
+      opacity: 0;
+      pointer-events: none;
+    `}
+`;
+
+const innerWrapStyles = ({
+  theme,
+  orientation,
+}: {
+  orientation: Orientation;
+  theme: Theme;
+}) => `
+  display: flex;
+  align-items: center;
+  position: relative;
+  height: calc(
+    ${theme.form.sm.height}px +
+      ${orientation === 'horizontal' ? space(0.75) : '0px'}
+  );
+  border-radius: ${theme.borderRadius};
+  transform: translateY(1px);
+
+  ${
+    orientation === 'horizontal'
+      ? `
+        /* Extra padding + negative margin trick, to expand click area */
+        padding: ${space(0.75)} ${space(1)} ${space(1.5)};
+        margin-left: -${space(1)};
+        margin-right: -${space(1)};
+      `
+      : `padding: ${space(0.75)} ${space(2)};`
+  };
+`;
+
+const TabLink = styled(Link)<{orientation: Orientation}>`
+  ${innerWrapStyles}
+
+  &,
+  &:hover {
+    color: inherit;
+  }
+`;
+
+const TabInnerWrap = styled('span')<{orientation: Orientation}>`
+  ${innerWrapStyles}
+`;
+
+const StyledInteractionStateLayer = styled(InteractionStateLayer)<{
+  orientation: Orientation;
+}>`
+  position: absolute;
+  width: auto;
+  height: auto;
+  transform: none;
+  left: 0;
+  right: 0;
+  top: 0;
+  bottom: ${p => (p.orientation === 'horizontal' ? space(0.75) : 0)};
+`;
+
+const FocusLayer = styled('div')<{orientation: Orientation}>`
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: 0;
+  bottom: ${p => (p.orientation === 'horizontal' ? space(0.75) : 0)};
+
+  pointer-events: none;
+  border-radius: inherit;
+  z-index: 0;
+  transition: box-shadow 0.1s ease-out;
+
+  li:focus-visible & {
+    box-shadow:
+      ${p => p.theme.focusBorder} 0 0 0 1px,
+      inset ${p => p.theme.focusBorder} 0 0 0 1px;
+  }
+`;
+
+const TabSelectionIndicator = styled('div')<{
+  orientation: Orientation;
+  selected: boolean;
+}>`
+  position: absolute;
+  border-radius: 2px;
+  pointer-events: none;
+  background: ${p => (p.selected ? p.theme.active : 'transparent')};
+  transition: background 0.1s ease-out;
+
+  li[aria-disabled='true'] & {
+    background: ${p => (p.selected ? p.theme.subText : 'transparent')};
+  }
+
+  ${p =>
+    p.orientation === 'horizontal'
+      ? `
+        width: calc(100% - ${space(2)});
+        height: 3px;
+
+        bottom: 0;
+        left: 50%;
+        transform: translateX(-50%);
+      `
+      : `
+        width: 3px;
+        height: 50%;
+
+        left: 0;
+        top: 50%;
+        transform: translateY(-50%);
+      `};
+`;

--- a/static/app/components/draggableTabs/draggableTabList.tsx
+++ b/static/app/components/draggableTabs/draggableTabList.tsx
@@ -1,0 +1,300 @@
+import {useContext, useEffect, useMemo, useRef, useState} from 'react';
+import styled from '@emotion/styled';
+import type {AriaTabListOptions} from '@react-aria/tabs';
+import {useTabList} from '@react-aria/tabs';
+import {useCollection} from '@react-stately/collections';
+import {ListCollection} from '@react-stately/list';
+import type {TabListStateOptions} from '@react-stately/tabs';
+import {useTabListState} from '@react-stately/tabs';
+import type {Node, Orientation} from '@react-types/shared';
+
+import type {SelectOption} from 'sentry/components/compactSelect';
+import {CompactSelect} from 'sentry/components/compactSelect';
+import DropdownButton from 'sentry/components/dropdownButton';
+import {IconEllipsis} from 'sentry/icons';
+import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
+import {browserHistory} from 'sentry/utils/browserHistory';
+
+import {Tab} from './draggableTab';
+import {TabsContext} from './index';
+import type {TabListItemProps} from './item';
+import {Item} from './item';
+import {tabsShouldForwardProp} from './utils';
+
+/**
+ * Uses IntersectionObserver API to detect overflowing tabs. Returns an array
+ * containing of keys of overflowing tabs.
+ */
+function useOverflowTabs({
+  tabListRef,
+  tabItemsRef,
+  tabItems,
+}: {
+  tabItems: TabListItemProps[];
+  tabItemsRef: React.RefObject<Record<string | number, HTMLLIElement | null>>;
+  tabListRef: React.RefObject<HTMLUListElement>;
+}) {
+  const [overflowTabs, setOverflowTabs] = useState<Array<string | number>>([]);
+
+  useEffect(() => {
+    const options = {
+      root: tabListRef.current,
+      // Nagative right margin to account for overflow menu's trigger button
+      rootMargin: `0px -42px 1px ${space(1)}`,
+      // Use 0.95 rather than 1 because of a bug in Edge (Windows) where the intersection
+      // ratio may unexpectedly drop to slightly below 1 (0.999…) on page scroll.
+      threshold: 0.95,
+    };
+
+    const callback: IntersectionObserverCallback = entries => {
+      entries.forEach(entry => {
+        const {target} = entry;
+        const {key} = (target as HTMLElement).dataset;
+        if (!key) {
+          return;
+        }
+
+        if (!entry.isIntersecting) {
+          setOverflowTabs(prev => prev.concat([key]));
+          return;
+        }
+
+        setOverflowTabs(prev => prev.filter(k => k !== key));
+      });
+    };
+
+    const observer = new IntersectionObserver(callback, options);
+    Object.values(tabItemsRef.current ?? {}).forEach(
+      element => element && observer.observe(element)
+    );
+
+    return () => observer.disconnect();
+  }, [tabListRef, tabItemsRef]);
+
+  const tabItemKeyToHiddenMap = tabItems.reduce(
+    (acc, next) => ({
+      ...acc,
+      [next.key]: next.hidden,
+    }),
+    {}
+  );
+
+  // Tabs that are hidden will be rendered with display: none so won't intersect,
+  // but we don't want to show them in the overflow menu
+  return overflowTabs.filter(tabKey => !tabItemKeyToHiddenMap[tabKey]);
+}
+
+export interface TabListProps
+  extends AriaTabListOptions<TabListItemProps>,
+    TabListStateOptions<TabListItemProps> {
+  className?: string;
+  hideBorder?: boolean;
+  outerWrapStyles?: React.CSSProperties;
+}
+
+interface BaseTabListProps extends TabListProps {
+  items: TabListItemProps[];
+}
+
+function BaseTabList({
+  hideBorder = false,
+  className,
+  outerWrapStyles,
+  ...props
+}: BaseTabListProps) {
+  const tabListRef = useRef<HTMLUListElement>(null);
+  const {rootProps, setTabListState} = useContext(TabsContext);
+  const {
+    value,
+    defaultValue,
+    onChange,
+    disabled,
+    orientation = 'horizontal',
+    keyboardActivation = 'manual',
+    ...otherRootProps
+  } = rootProps;
+
+  // Load up list state
+  const ariaProps = {
+    selectedKey: value,
+    defaultSelectedKey: defaultValue,
+    onSelectionChange: key => {
+      onChange?.(key);
+
+      // If the newly selected tab is a tab link, then navigate to the specified link
+      const linkTo = [...(props.items ?? [])].find(item => item.key === key)?.to;
+      if (!linkTo) {
+        return;
+      }
+      browserHistory.push(linkTo);
+    },
+    isDisabled: disabled,
+    keyboardActivation,
+    ...otherRootProps,
+    ...props,
+  };
+
+  const state = useTabListState(ariaProps);
+  const {tabListProps} = useTabList({orientation, ...ariaProps}, state, tabListRef);
+  useEffect(() => {
+    setTabListState(state);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [state.disabledKeys, state.selectedItem, state.selectedKey, props.children]);
+
+  // Detect tabs that overflow from the wrapper and put them in an overflow menu
+  const tabItemsRef = useRef<Record<string | number, HTMLLIElement | null>>({});
+  const overflowTabs = useOverflowTabs({
+    tabListRef,
+    tabItemsRef,
+    tabItems: props.items,
+  });
+
+  const overflowMenuItems = useMemo(() => {
+    // Sort overflow items in the order that they appear in TabList
+    const sortedKeys = [...state.collection].map(item => item.key);
+    const sortedOverflowTabs = overflowTabs.sort(
+      (a, b) => sortedKeys.indexOf(a) - sortedKeys.indexOf(b)
+    );
+
+    return sortedOverflowTabs.flatMap<SelectOption<string | number>>(key => {
+      const item = state.collection.getItem(key);
+
+      if (!item) {
+        return [];
+      }
+
+      return {
+        value: key,
+        label: item.props.children,
+        disabled: item.props.disabled,
+        textValue: item.textValue,
+      };
+    });
+  }, [state.collection, overflowTabs]);
+
+  return (
+    <TabListOuterWrap style={outerWrapStyles}>
+      <TabListWrap
+        {...tabListProps}
+        orientation={orientation}
+        hideBorder={hideBorder}
+        className={className}
+        ref={tabListRef}
+      >
+        {[...state.collection].map(item => (
+          <Tab
+            key={item.key}
+            item={item}
+            state={state}
+            orientation={orientation}
+            overflowing={orientation === 'horizontal' && overflowTabs.includes(item.key)}
+            ref={element => (tabItemsRef.current[item.key] = element)}
+          />
+        ))}
+      </TabListWrap>
+
+      {orientation === 'horizontal' && overflowMenuItems.length > 0 && (
+        <TabListOverflowWrap>
+          <CompactSelect
+            options={overflowMenuItems}
+            value={[...state.selectionManager.selectedKeys][0]}
+            onChange={opt => state.setSelectedKey(opt.value)}
+            disabled={disabled}
+            position="bottom-end"
+            size="sm"
+            offset={4}
+            trigger={triggerProps => (
+              <OverflowMenuTrigger
+                {...triggerProps}
+                size="sm"
+                borderless
+                showChevron={false}
+                icon={<IconEllipsis />}
+                aria-label={t('More tabs')}
+              />
+            )}
+          />
+        </TabListOverflowWrap>
+      )}
+    </TabListOuterWrap>
+  );
+}
+
+const collectionFactory = (nodes: Iterable<Node<any>>) => new ListCollection(nodes);
+
+/**
+ * To be used as a direct child of the <Tabs /> component. See example usage
+ * in tabs.stories.js
+ */
+export function TabList({items, ...props}: TabListProps) {
+  /**
+   * Initial, unfiltered list of tab items.
+   */
+  const collection = useCollection({items, ...props}, collectionFactory);
+
+  const parsedItems = useMemo(
+    () => [...collection].map(({key, props: itemProps}) => ({key, ...itemProps})),
+    [collection]
+  );
+
+  /**
+   * List of keys of disabled items (those with a `disbled` prop) to be passed
+   * into `BaseTabList`.
+   */
+  const disabledKeys = useMemo(
+    () => parsedItems.filter(item => item.disabled).map(item => item.key),
+    [parsedItems]
+  );
+
+  return (
+    <BaseTabList items={parsedItems} disabledKeys={disabledKeys} {...props}>
+      {item => <Item {...item} />}
+    </BaseTabList>
+  );
+}
+
+TabList.Item = Item;
+
+const TabListOuterWrap = styled('div')`
+  position: relative;
+`;
+
+const TabListWrap = styled('ul', {shouldForwardProp: tabsShouldForwardProp})<{
+  hideBorder: boolean;
+  orientation: Orientation;
+}>`
+  position: relative;
+  display: grid;
+  padding: 0;
+  margin: 0;
+  list-style-type: none;
+  flex-shrink: 0;
+
+  ${p =>
+    p.orientation === 'horizontal'
+      ? `
+        grid-auto-flow: column;
+        justify-content: start;
+        gap: ${space(2)};
+        ${!p.hideBorder && `border-bottom: solid 1px ${p.theme.border};`}
+      `
+      : `
+        height: 100%;
+        grid-auto-flow: row;
+        align-content: start;
+        gap: 1px;
+        padding-right: ${space(2)};
+        ${!p.hideBorder && `border-right: solid 1px ${p.theme.border};`}
+      `};
+`;
+
+const TabListOverflowWrap = styled('div')`
+  position: absolute;
+  right: 0;
+  bottom: ${space(0.75)};
+`;
+const OverflowMenuTrigger = styled(DropdownButton)`
+  padding-left: ${space(1)};
+  padding-right: ${space(1)};
+`;

--- a/static/app/components/draggableTabs/draggableTabPanels.tsx
+++ b/static/app/components/draggableTabs/draggableTabPanels.tsx
@@ -1,0 +1,99 @@
+import {useContext, useRef} from 'react';
+import styled from '@emotion/styled';
+import type {AriaTabPanelProps} from '@react-aria/tabs';
+import {useTabPanel} from '@react-aria/tabs';
+import {useCollection} from '@react-stately/collections';
+import {ListCollection} from '@react-stately/list';
+import type {TabListState} from '@react-stately/tabs';
+import type {CollectionBase, Node, Orientation} from '@react-types/shared';
+
+import {TabsContext} from './index';
+import {Item} from './item';
+import {tabsShouldForwardProp} from './utils';
+
+const collectionFactory = (nodes: Iterable<Node<any>>) => new ListCollection(nodes);
+
+interface TabPanelsProps extends AriaTabPanelProps, CollectionBase<any> {
+  className?: string;
+}
+
+/**
+ * To be used as a direct child of the <Tabs /> component. See example usage
+ * in tabs.stories.js
+ */
+export function TabPanels(props: TabPanelsProps) {
+  const {
+    rootProps: {orientation, items},
+    tabListState,
+  } = useContext(TabsContext);
+
+  // Parse child tab panels from props and identify the selected panel
+  const collection = useCollection({items, ...props}, collectionFactory, {
+    suppressTextValueWarning: true,
+  });
+  const selectedPanel = tabListState
+    ? collection.getItem(tabListState.selectedKey)
+    : null;
+
+  if (!tabListState) {
+    return null;
+  }
+
+  return (
+    <TabPanel
+      {...props}
+      state={tabListState}
+      orientation={orientation}
+      key={tabListState?.selectedKey}
+    >
+      {selectedPanel?.props.children}
+    </TabPanel>
+  );
+}
+
+TabPanels.Item = Item;
+
+interface TabPanelProps extends AriaTabPanelProps {
+  state: TabListState<any>;
+  children?: React.ReactNode;
+  className?: string;
+  orientation?: Orientation;
+}
+
+function TabPanel({
+  state,
+  orientation = 'horizontal',
+  className,
+  children,
+  ...props
+}: TabPanelProps) {
+  const ref = useRef<HTMLDivElement>(null);
+  const {tabPanelProps} = useTabPanel(props, state, ref);
+
+  return (
+    <TabPanelWrap
+      {...tabPanelProps}
+      orientation={orientation}
+      className={className}
+      ref={ref}
+    >
+      {children}
+    </TabPanelWrap>
+  );
+}
+
+const TabPanelWrap = styled('div', {shouldForwardProp: tabsShouldForwardProp})<{
+  orientation: Orientation;
+}>`
+  border-radius: ${p => p.theme.borderRadius};
+
+  ${p => (p.orientation === 'horizontal' ? `height: 100%;` : `width: 100%;`)};
+
+  &:focus-visible {
+    outline: none;
+    box-shadow:
+      inset ${p => p.theme.focusBorder} 0 0 0 1px,
+      ${p => p.theme.focusBorder} 0 0 0 1px;
+    z-index: 1;
+  }
+`;

--- a/static/app/components/draggableTabs/index.tsx
+++ b/static/app/components/draggableTabs/index.tsx
@@ -1,0 +1,91 @@
+import 'intersection-observer'; // polyfill
+
+import {createContext, useState} from 'react';
+import styled from '@emotion/styled';
+import type {AriaTabListOptions} from '@react-aria/tabs';
+import type {TabListState, TabListStateOptions} from '@react-stately/tabs';
+import type {Orientation} from '@react-types/shared';
+
+import {tabsShouldForwardProp} from './utils';
+
+export interface TabsProps<T>
+  extends Omit<
+      AriaTabListOptions<any>,
+      'selectedKey' | 'defaultSelectedKey' | 'onSelectionChange' | 'isDisabled'
+    >,
+    Omit<
+      TabListStateOptions<any>,
+      | 'children'
+      | 'selectedKey'
+      | 'defaultSelectedKey'
+      | 'onSelectionChange'
+      | 'isDisabled'
+    > {
+  children?: React.ReactNode;
+  className?: string;
+  /**
+   * [Uncontrolled] Default selected tab. Must match the `key` prop on the
+   * selected tab item.
+   */
+  defaultValue?: T;
+  disabled?: boolean;
+  /**
+   * Callback when the selected tab changes.
+   */
+  onChange?: (key: T) => void;
+  /**
+   * [Controlled] Selected tab . Must match the `key` prop on the selected tab
+   * item.
+   */
+  value?: T;
+}
+
+interface TabContext {
+  rootProps: Omit<TabsProps<any>, 'children' | 'className'>;
+  setTabListState: (state: TabListState<any>) => void;
+  tabListState?: TabListState<any>;
+}
+
+export const TabsContext = createContext<TabContext>({
+  rootProps: {orientation: 'horizontal'},
+  setTabListState: () => {},
+});
+
+/**
+ * Root tabs component. Provides the necessary data (via React context) for
+ * child components (TabList and TabPanels) to work together. See example
+ * usage in tabs.stories.js
+ */
+export function Tabs<T extends string | number>({
+  orientation = 'horizontal',
+  className,
+  children,
+  ...props
+}: TabsProps<T>) {
+  const [tabListState, setTabListState] = useState<TabListState<any>>();
+
+  return (
+    <TabsContext.Provider
+      value={{rootProps: {...props, orientation}, tabListState, setTabListState}}
+    >
+      <TabsWrap orientation={orientation} className={className}>
+        {children}
+      </TabsWrap>
+    </TabsContext.Provider>
+  );
+}
+
+const TabsWrap = styled('div', {shouldForwardProp: tabsShouldForwardProp})<{
+  orientation: Orientation;
+}>`
+  display: flex;
+  flex-direction: ${p => (p.orientation === 'horizontal' ? 'column' : 'row')};
+  flex-grow: 1;
+
+  ${p =>
+    p.orientation === 'vertical' &&
+    `
+      height: 100%;
+      align-items: stretch;
+    `};
+`;

--- a/static/app/components/draggableTabs/item.tsx
+++ b/static/app/components/draggableTabs/item.tsx
@@ -1,0 +1,12 @@
+import {Item as _Item} from '@react-stately/collections';
+import type {ItemProps} from '@react-types/shared';
+import type {LocationDescriptor} from 'history';
+
+export interface TabListItemProps extends ItemProps<any> {
+  key: string | number;
+  disabled?: boolean;
+  hidden?: boolean;
+  to?: LocationDescriptor;
+}
+
+export const Item = _Item as (props: TabListItemProps) => JSX.Element;

--- a/static/app/components/draggableTabs/utils.tsx
+++ b/static/app/components/draggableTabs/utils.tsx
@@ -1,0 +1,4 @@
+import isPropValid from '@emotion/is-prop-valid';
+
+export const tabsShouldForwardProp = (prop: string) =>
+  typeof prop === 'string' && isPropValid(prop) && prop !== 'orientation';


### PR DESCRIPTION
This PR duplicates all files from the `sentry/app/components/tabs` directory to a new directory, `sentry/app/components/draggableTabs`. There are **no public changes** to this PR, and the sole purpose of this PR is to make reviewing the PR that actually implements the drag-and-drop tabs components easier. That PR (currently drafted [here](https://github.com/getsentry/sentry/pull/73239)) is at nearly +1000 lines of code, and the vast majority of the changes simply copied over from `.../tabs`. This PR would make the diff in that PR significantly more readable and intuitive. 

The contents of each file in `.../draggableTabs` have **not** been modified, but the names of any files starting with `tab` has been changes to `draggableTab` to reflect the future behavior of these components. I have also removed the `.spec.tsx` file and the `stories` file since these will be significantly different for drag and drop tabs compared to regular tabs. 