### PR TITLE
fix(issues): Reduce shift when switching replays

### DIFF
--- a/static/app/components/container/negativeSpaceContainer.stories.tsx
+++ b/static/app/components/container/negativeSpaceContainer.stories.tsx
@@ -19,7 +19,7 @@ export default storyBook(NegativeSpaceContainer, story => {
       <p>Here's one with nothing inside it:</p>
       <NegativeSpaceContainer
         style={{width: '100%', height: '100px'}}
-        testId="empty-container"
+        data-test-id="empty-container"
       />
     </Fragment>
   ));

--- a/static/app/components/container/negativeSpaceContainer.tsx
+++ b/static/app/components/container/negativeSpaceContainer.tsx
@@ -1,25 +1,6 @@
-import type {CSSProperties, ForwardedRef, ReactNode} from 'react';
-import {forwardRef} from 'react';
 import styled from '@emotion/styled';
 
-interface Props {
-  children?: ReactNode;
-  className?: string;
-  style?: CSSProperties;
-  testId?: string;
-}
-
-const NegativeSpaceContainer = styled(
-  forwardRef(
-    ({children, testId, style, className}: Props, ref: ForwardedRef<HTMLDivElement>) => {
-      return (
-        <div data-test-id={testId} style={style} className={className} ref={ref}>
-          {children}
-        </div>
-      );
-    }
-  )
-)`
+const NegativeSpaceContainer = styled('div')`
   width: 100%;
   display: flex;
   flex-grow: 1;

--- a/static/app/components/events/eventHydrationDiff/replayDiffSection.tsx
+++ b/static/app/components/events/eventHydrationDiff/replayDiffSection.tsx
@@ -36,7 +36,7 @@ export function ReplayDiffSection({event, group, replayId}: Props) {
           LazyComponent={ReplayDiffContent}
           loadingFallback={
             <EventDataSection type="hydration-diff" title={t('Hydration Error Diff')}>
-              <StyledNegativeSpaceContainer testId="replay-diff-loading-placeholder">
+              <StyledNegativeSpaceContainer data-test-id="replay-diff-loading-placeholder">
                 <LoadingIndicator />
               </StyledNegativeSpaceContainer>
             </EventDataSection>

--- a/static/app/components/events/eventReplay/replayClipPreviewPlayer.tsx
+++ b/static/app/components/events/eventReplay/replayClipPreviewPlayer.tsx
@@ -94,7 +94,10 @@ function ReplayClipPreviewPlayer({
 
   if (fetching || !replayRecord || !replay) {
     return (
-      <StyledNegativeSpaceContainer testId="replay-loading-placeholder" isLarge={isLarge}>
+      <StyledNegativeSpaceContainer
+        data-test-id="replay-loading-placeholder"
+        isLarge={isLarge}
+      >
         <LoadingIndicator />
       </StyledNegativeSpaceContainer>
     );
@@ -146,7 +149,7 @@ const PlayerContainer = styled(FluidHeight)<{isLarge?: boolean}>`
 
 const StyledNegativeSpaceContainer = styled(NegativeSpaceContainer)<{isLarge?: boolean}>`
   height: ${p => (p.isLarge ? REPLAY_LOADING_HEIGHT_LARGE : REPLAY_LOADING_HEIGHT)}px;
-  margin-bottom: ${space(2)};
+  border-radius: ${p => p.theme.borderRadius};
 `;
 
 export default ReplayClipPreviewPlayer;

--- a/static/app/components/events/eventReplay/replayClipSection.tsx
+++ b/static/app/components/events/eventReplay/replayClipSection.tsx
@@ -101,7 +101,7 @@ export function ReplayClipSection({event, group, replayId}: Props) {
                 },
               }}
               loadingFallback={
-                <StyledNegativeSpaceContainer testId="replay-loading-placeholder">
+                <StyledNegativeSpaceContainer data-test-id="replay-loading-placeholder">
                   <LoadingIndicator />
                 </StyledNegativeSpaceContainer>
               }

--- a/static/app/components/events/eventReplay/replayPreview.tsx
+++ b/static/app/components/events/eventReplay/replayPreview.tsx
@@ -93,7 +93,7 @@ function ReplayPreview({
 
   if (fetching || !replayRecord || !replay) {
     return (
-      <StyledNegativeSpaceContainer testId="replay-loading-placeholder">
+      <StyledNegativeSpaceContainer data-test-id="replay-loading-placeholder">
         <LoadingIndicator />
       </StyledNegativeSpaceContainer>
     );

--- a/static/app/views/issueDetails/groupReplays/groupReplays.tsx
+++ b/static/app/views/issueDetails/groupReplays/groupReplays.tsx
@@ -64,6 +64,7 @@ function GroupReplays({group}: Props) {
   }, []);
 
   if (!eventView) {
+    // Shown on load and no replay data available
     return (
       <StyledLayoutPage withPadding>
         <ReplayCountHeader>

--- a/static/app/views/issueDetails/groupReplays/groupReplays.tsx
+++ b/static/app/views/issueDetails/groupReplays/groupReplays.tsx
@@ -68,7 +68,11 @@ function GroupReplays({group}: Props) {
       <StyledLayoutPage withPadding>
         <ReplayCountHeader>
           <IconUser size="sm" />
-          <Placeholder height="16px" width="400px" />
+          {isFetching ? (
+            <Placeholder height="18px" width="400px" />
+          ) : (
+            t('No replay data available.')
+          )}
         </ReplayCountHeader>
         <ReplayTable
           fetchError={fetchError}

--- a/static/app/views/issueDetails/groupReplays/groupReplays.tsx
+++ b/static/app/views/issueDetails/groupReplays/groupReplays.tsx
@@ -4,10 +4,11 @@ import type {Location} from 'history';
 
 import {Button} from 'sentry/components/button';
 import * as Layout from 'sentry/components/layouts/thirds';
+import Placeholder from 'sentry/components/placeholder';
 import {StaticReplayPreferences} from 'sentry/components/replays/preferences/replayPreferences';
 import {Provider as ReplayContextProvider} from 'sentry/components/replays/replayContext';
 import {IconPlay, IconUser} from 'sentry/icons';
-import {t} from 'sentry/locale';
+import {t, tn} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {Group} from 'sentry/types/group';
 import type {Organization} from 'sentry/types/organization';
@@ -65,6 +66,10 @@ function GroupReplays({group}: Props) {
   if (!eventView) {
     return (
       <StyledLayoutPage withPadding>
+        <ReplayCountHeader>
+          <IconUser size="sm" />
+          <Placeholder height="16px" width="400px" />
+        </ReplayCountHeader>
         <ReplayTable
           fetchError={fetchError}
           isFetching={isFetching}
@@ -242,11 +247,11 @@ function GroupReplaysTable({
   return (
     <StyledLayoutPage withPadding>
       <ReplayCountHeader>
-        <StyledIconUser size="sm" />
+        <IconUser size="sm" />
         {t(
-          'Replay captured %s users experiencing this issue across %s events.',
-          replayCount,
-          group.count
+          'Replay captured %s experiencing this issue across %s.',
+          tn('%s user', '%s users', replayCount ?? 0),
+          tn('%s event', '%s events', group.count)
         )}
       </ReplayCountHeader>
       {inner}
@@ -264,12 +269,6 @@ const ReplayCountHeader = styled('div')`
   display: flex;
   align-items: center;
   gap: ${space(1)};
-`;
-
-const StyledIconUser = styled(IconUser)`
-  margin-right: ${p => p.theme.grid}px;
-  height: 16px;
-  width: 16px;
 `;
 
 const OverlayText = styled('div')`


### PR DESCRIPTION
Reduces layout shift when switching between replays on the issue replays tab.

Adds a placeholder for some text that appears after load
![image](https://github.com/getsentry/sentry/assets/1400464/80f9438d-3c31-4b23-8c3d-18f546ea4971)
