### PR TITLE
Update AlertRuleMonitorType to be an IntEnum

### DIFF
--- a/src/sentry/incidents/logic.py
+++ b/src/sentry/incidents/logic.py
@@ -581,7 +581,7 @@ def create_alert_rule(
             include_all_projects=include_all_projects,
             comparison_delta=comparison_delta,
             owner=owner,
-            monitor_type=monitor_type.value,
+            monitor_type=monitor_type,
             description=description,
         )
 

--- a/src/sentry/incidents/logic.py
+++ b/src/sentry/incidents/logic.py
@@ -24,7 +24,7 @@ from sentry.incidents.models.alert_rule import (
     AlertRuleActivity,
     AlertRuleActivityType,
     AlertRuleExcludedProjects,
-    AlertRuleMonitorType,
+    AlertRuleMonitorTypeInt,
     AlertRuleProjects,
     AlertRuleStatus,
     AlertRuleTrigger,
@@ -513,7 +513,7 @@ def create_alert_rule(
     user=None,
     event_types=None,
     comparison_delta: int | None = None,
-    monitor_type: AlertRuleMonitorType = AlertRuleMonitorType.CONTINUOUS,
+    monitor_type: AlertRuleMonitorTypeInt = AlertRuleMonitorTypeInt.CONTINUOUS,
     activation_condition: AlertRuleActivationConditionType | None = None,
     description: str | None = None,
     **kwargs,
@@ -548,7 +548,7 @@ def create_alert_rule(
 
     :return: The created `AlertRule`
     """
-    if monitor_type == AlertRuleMonitorType.ACTIVATED and not activation_condition:
+    if monitor_type == AlertRuleMonitorTypeInt.ACTIVATED and not activation_condition:
         raise ValidationError("Activation condition required for activated alert rule")
 
     resolution = get_alert_resolution(time_window, organization)
@@ -607,7 +607,7 @@ def create_alert_rule(
             ]
             AlertRuleExcludedProjects.objects.bulk_create(exclusions)
 
-        if monitor_type == AlertRuleMonitorType.ACTIVATED and activation_condition:
+        if monitor_type == AlertRuleMonitorTypeInt.ACTIVATED and activation_condition:
             # NOTE: if monitor_type is activated, activation_condition is required
             AlertRuleActivationCondition.objects.create(
                 alert_rule=alert_rule, condition_type=activation_condition.value
@@ -694,7 +694,7 @@ def update_alert_rule(
     user=None,
     event_types=None,
     comparison_delta=NOT_SET,
-    monitor_type: AlertRuleMonitorType | None = None,
+    monitor_type: AlertRuleMonitorTypeInt | None = None,
     description: str | None = None,
     **kwargs,
 ):

--- a/src/sentry/incidents/models/alert_rule.py
+++ b/src/sentry/incidents/models/alert_rule.py
@@ -324,14 +324,14 @@ class AlertRule(Model):
             "Subscribing projects to alert rule",
             extra={
                 "alert_rule.monitor_type": self.monitor_type,
-                "conditional_monitor_type": monitor_type.value,
+                "conditional_monitor_type": monitor_type,
                 "query_extra": query_extra,
             },
         )
         # NOTE: AlertRuleMonitorType.ACTIVATED will be conditionally subscribed given activation triggers
         # On activated subscription, additional query parameters will be added to the constructed query in Snuba
         created_subscriptions = []
-        if self.monitor_type == monitor_type.value:
+        if self.monitor_type == monitor_type:
             # NOTE: QuerySubscriptions hold reference to Projects which should match the AlertRule's project reference
             created_subscriptions = bulk_create_snuba_subscriptions(
                 projects,

--- a/src/sentry/incidents/models/alert_rule.py
+++ b/src/sentry/incidents/models/alert_rule.py
@@ -4,7 +4,7 @@ import logging
 from collections import namedtuple
 from collections.abc import Callable
 from datetime import timedelta
-from enum import Enum, StrEnum
+from enum import Enum, IntEnum, StrEnum
 from typing import Any, ClassVar, Protocol, Self
 
 from django.conf import settings
@@ -148,7 +148,7 @@ class AlertRuleManager(BaseManager["AlertRule"]):
         try:
             project_alert_rules: QuerySet[AlertRule] = self.filter(
                 projects=project,
-                monitor_type=AlertRuleMonitorType.ACTIVATED.value,
+                monitor_type=AlertRuleMonitorType.ACTIVATED,
             )
             created_subscriptions = []
             for alert_rule in project_alert_rules:
@@ -225,7 +225,7 @@ class AlertRuleProjects(Model):
         unique_together = (("alert_rule", "project"),)
 
 
-class AlertRuleMonitorType(Enum):
+class AlertRuleMonitorType(IntEnum):
     CONTINUOUS = 0
     ACTIVATED = 1
 
@@ -267,7 +267,7 @@ class AlertRule(Model):
     comparison_delta = models.IntegerField(null=True)
     date_modified = models.DateTimeField(default=timezone.now)
     date_added = models.DateTimeField(default=timezone.now)
-    monitor_type = models.IntegerField(default=AlertRuleMonitorType.CONTINUOUS.value)
+    monitor_type = models.IntegerField(default=AlertRuleMonitorType.CONTINUOUS)
     description = models.CharField(max_length=1000, null=True)
 
     class Meta:
@@ -339,7 +339,7 @@ class AlertRule(Model):
                 self.snuba_query,
                 query_extra=query_extra,
             )
-            if self.monitor_type == AlertRuleMonitorType.ACTIVATED.value:
+            if self.monitor_type == AlertRuleMonitorType.ACTIVATED:
                 # NOTE: Activated Alert Rules are conditionally subscribed
                 # Meaning at time of subscription, the rule must have been activated
                 if not activator or activation_condition is None:

--- a/src/sentry/incidents/serializers/alert_rule.py
+++ b/src/sentry/incidents/serializers/alert_rule.py
@@ -28,7 +28,7 @@ from sentry.incidents.logic import (
 )
 from sentry.incidents.models.alert_rule import (
     AlertRule,
-    AlertRuleMonitorType,
+    AlertRuleMonitorTypeInt,
     AlertRuleThresholdType,
     AlertRuleTrigger,
 )
@@ -205,7 +205,7 @@ class AlertRuleSerializer(CamelSnakeModelSerializer[AlertRule]):
         ):
             raise serializers.ValidationError("Invalid monitor type")
 
-        return AlertRuleMonitorType(monitor_type)
+        return AlertRuleMonitorTypeInt(monitor_type)
 
     def validate_activation_condition(self, activation_condition):
         if activation_condition is None:

--- a/src/sentry/incidents/subscription_processor.py
+++ b/src/sentry/incidents/subscription_processor.py
@@ -659,13 +659,13 @@ class SubscriptionProcessor:
             # NOTE: `incident_triggers` is derived from `self.active_incident`
             incident_trigger = self.incident_trigger_map.get(trigger.id)
             if incident_trigger:
-                incident_trigger.status = TriggerStatus.ACTIVE
+                incident_trigger.status = TriggerStatus.ACTIVE.value
                 incident_trigger.save()
             else:
                 incident_trigger = IncidentTrigger.objects.create(
                     incident=self.active_incident,
                     alert_rule_trigger=trigger,
-                    status=TriggerStatus.ACTIVE,
+                    status=TriggerStatus.ACTIVE.value,
                 )
             self.handle_incident_severity_update()
             self.incident_trigger_map[trigger.id] = incident_trigger

--- a/src/sentry/incidents/subscription_processor.py
+++ b/src/sentry/incidents/subscription_processor.py
@@ -630,7 +630,7 @@ class SubscriptionProcessor:
             if not self.active_incident:
                 detected_at = self.calculate_event_date_from_update_date(self.last_update)
                 activation: AlertRuleActivations | None = None
-                if self.alert_rule.monitor_type == AlertRuleMonitorType.ACTIVATED.value:
+                if self.alert_rule.monitor_type == AlertRuleMonitorType.ACTIVATED:
                     activations = list(self.subscription.alertruleactivations_set.all())
                     if len(activations) != 1:
                         logger.error(
@@ -659,13 +659,13 @@ class SubscriptionProcessor:
             # NOTE: `incident_triggers` is derived from `self.active_incident`
             incident_trigger = self.incident_trigger_map.get(trigger.id)
             if incident_trigger:
-                incident_trigger.status = TriggerStatus.ACTIVE.value
+                incident_trigger.status = TriggerStatus.ACTIVE
                 incident_trigger.save()
             else:
                 incident_trigger = IncidentTrigger.objects.create(
                     incident=self.active_incident,
                     alert_rule_trigger=trigger,
-                    status=TriggerStatus.ACTIVE.value,
+                    status=TriggerStatus.ACTIVE,
                 )
             self.handle_incident_severity_update()
             self.incident_trigger_map[trigger.id] = incident_trigger

--- a/src/sentry/incidents/subscription_processor.py
+++ b/src/sentry/incidents/subscription_processor.py
@@ -24,7 +24,7 @@ from sentry.incidents.logic import (
 )
 from sentry.incidents.models.alert_rule import (
     AlertRule,
-    AlertRuleMonitorType,
+    AlertRuleMonitorTypeInt,
     AlertRuleThresholdType,
     AlertRuleTrigger,
     AlertRuleTriggerActionMethod,
@@ -503,7 +503,7 @@ class SubscriptionProcessor:
         # Current callback will update the activation metric values & delete querysubscription on finish
         # TODO: register over/under triggers as alert rule callbacks as well
         invoke_alert_subscription_callback(
-            AlertRuleMonitorType(self.alert_rule.monitor_type),
+            AlertRuleMonitorTypeInt(self.alert_rule.monitor_type),
             subscription=self.subscription,
             alert_rule=self.alert_rule,
             value=aggregation_value,
@@ -630,7 +630,7 @@ class SubscriptionProcessor:
             if not self.active_incident:
                 detected_at = self.calculate_event_date_from_update_date(self.last_update)
                 activation: AlertRuleActivations | None = None
-                if self.alert_rule.monitor_type == AlertRuleMonitorType.ACTIVATED:
+                if self.alert_rule.monitor_type == AlertRuleMonitorTypeInt.ACTIVATED:
                     activations = list(self.subscription.alertruleactivations_set.all())
                     if len(activations) != 1:
                         logger.error(

--- a/src/sentry/migrations/0651_enable_activated_alert_rules.py
+++ b/src/sentry/migrations/0651_enable_activated_alert_rules.py
@@ -45,7 +45,7 @@ class Migration(CheckedMigration):
                     model_name="alertrule",
                     name="monitor_type",
                     field=models.IntegerField(
-                        default=sentry.incidents.models.alert_rule.AlertRuleMonitorType.CONTINUOUS.value
+                        default=sentry.incidents.models.alert_rule.AlertRuleMonitorType.CONTINUOUS
                     ),
                 ),
             ],

--- a/src/sentry/migrations/0651_enable_activated_alert_rules.py
+++ b/src/sentry/migrations/0651_enable_activated_alert_rules.py
@@ -45,7 +45,7 @@ class Migration(CheckedMigration):
                     model_name="alertrule",
                     name="monitor_type",
                     field=models.IntegerField(
-                        default=sentry.incidents.models.alert_rule.AlertRuleMonitorType.CONTINUOUS
+                        default=sentry.incidents.models.alert_rule.AlertRuleMonitorTypeInt.CONTINUOUS
                     ),
                 ),
             ],

--- a/src/sentry/testutils/factories.py
+++ b/src/sentry/testutils/factories.py
@@ -41,7 +41,7 @@ from sentry.incidents.logic import (
 )
 from sentry.incidents.models.alert_rule import (
     AlertRule,
-    AlertRuleMonitorType,
+    AlertRuleMonitorTypeInt,
     AlertRuleThresholdType,
     AlertRuleTriggerAction,
 )
@@ -1522,7 +1522,7 @@ class Factories:
         user=None,
         event_types=None,
         comparison_delta=None,
-        monitor_type=AlertRuleMonitorType.CONTINUOUS,
+        monitor_type=AlertRuleMonitorTypeInt.CONTINUOUS,
         activation_condition=AlertRuleActivationConditionType.RELEASE_CREATION,
         description=None,
     ):

--- a/src/sentry/testutils/fixtures.py
+++ b/src/sentry/testutils/fixtures.py
@@ -9,7 +9,7 @@ from django.utils import timezone
 from django.utils.functional import cached_property
 
 from sentry.eventstore.models import Event
-from sentry.incidents.models.alert_rule import AlertRuleMonitorType
+from sentry.incidents.models.alert_rule import AlertRuleMonitorTypeInt
 from sentry.incidents.models.incident import IncidentActivityType
 from sentry.models.activity import Activity
 from sentry.models.grouprelease import GroupRelease
@@ -403,7 +403,7 @@ class Fixtures:
         alert_rule=None,
         query_subscriptions=None,
         project=None,
-        monitor_type=AlertRuleMonitorType.ACTIVATED,
+        monitor_type=AlertRuleMonitorTypeInt.ACTIVATED,
         activator=None,
         activation_condition=None,
         *args,

--- a/src/sentry/testutils/helpers/backups.py
+++ b/src/sentry/testutils/helpers/backups.py
@@ -42,7 +42,7 @@ from sentry.backup.imports import import_in_global_scope
 from sentry.backup.scopes import ExportScope
 from sentry.backup.validate import validate
 from sentry.db.models.paranoia import ParanoidModel
-from sentry.incidents.models.alert_rule import AlertRuleMonitorType
+from sentry.incidents.models.alert_rule import AlertRuleMonitorTypeInt
 from sentry.incidents.models.incident import (
     IncidentActivity,
     IncidentSnapshot,
@@ -485,7 +485,7 @@ class ExhaustiveFixtures(Fixtures):
         activated_alert = self.create_alert_rule(
             organization=org,
             projects=[project],
-            monitor_type=AlertRuleMonitorType.ACTIVATED,
+            monitor_type=AlertRuleMonitorTypeInt.ACTIVATED,
             activation_condition=AlertRuleActivationConditionType.RELEASE_CREATION,
         )
         self.create_alert_rule_activation(

--- a/src/sentry/web/frontend/debug/debug_incident_trigger_email_activated_alert.py
+++ b/src/sentry/web/frontend/debug/debug_incident_trigger_email_activated_alert.py
@@ -4,7 +4,7 @@ from uuid import uuid4
 from django.utils import timezone
 
 from sentry.incidents.action_handlers import generate_incident_trigger_email_context
-from sentry.incidents.models.alert_rule import AlertRule, AlertRuleMonitorType, AlertRuleTrigger
+from sentry.incidents.models.alert_rule import AlertRule, AlertRuleMonitorTypeInt, AlertRuleTrigger
 from sentry.incidents.models.alert_rule_activations import AlertRuleActivations
 from sentry.incidents.models.incident import Incident, IncidentStatus, TriggerStatus
 from sentry.incidents.utils.types import AlertRuleActivationConditionType
@@ -39,7 +39,7 @@ class DebugIncidentActivatedAlertTriggerEmailView(MailPreviewView):
             organization=organization,
             name="My Alert",
             snuba_query=query,
-            monitor_type=AlertRuleMonitorType.ACTIVATED,
+            monitor_type=AlertRuleMonitorTypeInt.ACTIVATED,
         )
         activation = AlertRuleActivations(
             alert_rule=alert_rule,

--- a/src/sentry/web/frontend/debug/debug_incident_trigger_email_activated_alert.py
+++ b/src/sentry/web/frontend/debug/debug_incident_trigger_email_activated_alert.py
@@ -39,7 +39,7 @@ class DebugIncidentActivatedAlertTriggerEmailView(MailPreviewView):
             organization=organization,
             name="My Alert",
             snuba_query=query,
-            monitor_type=AlertRuleMonitorType.ACTIVATED.value,
+            monitor_type=AlertRuleMonitorType.ACTIVATED,
         )
         activation = AlertRuleActivations(
             alert_rule=alert_rule,

--- a/tests/sentry/incidents/action_handlers/test_email.py
+++ b/tests/sentry/incidents/action_handlers/test_email.py
@@ -15,7 +15,7 @@ from sentry.incidents.action_handlers import (
 from sentry.incidents.charts import fetch_metric_alert_events_timeseries
 from sentry.incidents.logic import CRITICAL_TRIGGER_LABEL, WARNING_TRIGGER_LABEL
 from sentry.incidents.models.alert_rule import (
-    AlertRuleMonitorType,
+    AlertRuleMonitorTypeInt,
     AlertRuleThresholdType,
     AlertRuleTriggerAction,
 )
@@ -286,10 +286,10 @@ class EmailActionHandlerGenerateEmailContextTest(TestCase):
 
     def test_with_activated_alert(self):
         trigger_status = TriggerStatus.ACTIVE
-        alert_rule = self.create_alert_rule(monitor_type=AlertRuleMonitorType.ACTIVATED)
+        alert_rule = self.create_alert_rule(monitor_type=AlertRuleMonitorTypeInt.ACTIVATED)
         alert_rule.subscribe_projects(
             projects=[self.project],
-            monitor_type=AlertRuleMonitorType.ACTIVATED,
+            monitor_type=AlertRuleMonitorTypeInt.ACTIVATED,
             activation_condition=AlertRuleActivationConditionType.DEPLOY_CREATION,
             activator="testing",
         )
@@ -330,7 +330,7 @@ class EmailActionHandlerGenerateEmailContextTest(TestCase):
             "timezone": settings.SENTRY_DEFAULT_TIME_ZONE,
             "snooze_alert": True,
             "snooze_alert_url": alert_link + "&mute=1",
-            "monitor_type": AlertRuleMonitorType.ACTIVATED,
+            "monitor_type": AlertRuleMonitorTypeInt.ACTIVATED,
             "activator": "testing",
             "condition_type": AlertRuleActivationConditionType.DEPLOY_CREATION.value,
         }

--- a/tests/sentry/incidents/action_handlers/test_email.py
+++ b/tests/sentry/incidents/action_handlers/test_email.py
@@ -330,7 +330,7 @@ class EmailActionHandlerGenerateEmailContextTest(TestCase):
             "timezone": settings.SENTRY_DEFAULT_TIME_ZONE,
             "snooze_alert": True,
             "snooze_alert_url": alert_link + "&mute=1",
-            "monitor_type": AlertRuleMonitorType.ACTIVATED.value,
+            "monitor_type": AlertRuleMonitorType.ACTIVATED,
             "activator": "testing",
             "condition_type": AlertRuleActivationConditionType.DEPLOY_CREATION.value,
         }

--- a/tests/sentry/incidents/endpoints/serializers/test_alert_rule.py
+++ b/tests/sentry/incidents/endpoints/serializers/test_alert_rule.py
@@ -8,7 +8,7 @@ from sentry.incidents.endpoints.serializers.alert_rule import (
 from sentry.incidents.logic import create_alert_rule_trigger, create_alert_rule_trigger_action
 from sentry.incidents.models.alert_rule import (
     AlertRule,
-    AlertRuleMonitorType,
+    AlertRuleMonitorTypeInt,
     AlertRuleProjects,
     AlertRuleThresholdType,
     AlertRuleTriggerAction,
@@ -141,25 +141,25 @@ class AlertRuleSerializerTest(BaseAlertRuleSerializerTest, TestCase):
         assert result[1]["triggers"] == []
 
     def test_activations(self):
-        alert_rule = self.create_alert_rule(monitor_type=AlertRuleMonitorType.CONTINUOUS)
+        alert_rule = self.create_alert_rule(monitor_type=AlertRuleMonitorTypeInt.CONTINUOUS)
         other_alert_rule = self.create_alert_rule()
         activations = self.create_alert_rule_activation(
-            alert_rule=alert_rule, monitor_type=AlertRuleMonitorType.CONTINUOUS
+            alert_rule=alert_rule, monitor_type=AlertRuleMonitorTypeInt.CONTINUOUS
         )
         result = serialize([alert_rule, other_alert_rule])
         assert result[0]["activations"] == serialize(activations)
         assert result[1]["activations"] == []
 
     def test_truncated_activations(self):
-        alert_rule = self.create_alert_rule(monitor_type=AlertRuleMonitorType.CONTINUOUS)
-        alert_rule2 = self.create_alert_rule(monitor_type=AlertRuleMonitorType.CONTINUOUS)
+        alert_rule = self.create_alert_rule(monitor_type=AlertRuleMonitorTypeInt.CONTINUOUS)
+        alert_rule2 = self.create_alert_rule(monitor_type=AlertRuleMonitorTypeInt.CONTINUOUS)
         for i in range(11):
             self.create_alert_rule_activation(
-                alert_rule=alert_rule, monitor_type=AlertRuleMonitorType.CONTINUOUS
+                alert_rule=alert_rule, monitor_type=AlertRuleMonitorTypeInt.CONTINUOUS
             )
             if i % 2 == 0:
                 self.create_alert_rule_activation(
-                    alert_rule=alert_rule2, monitor_type=AlertRuleMonitorType.CONTINUOUS
+                    alert_rule=alert_rule2, monitor_type=AlertRuleMonitorTypeInt.CONTINUOUS
                 )
         result = serialize([alert_rule, alert_rule2])
         assert len(result[0]["activations"]) == 10
@@ -167,7 +167,9 @@ class AlertRuleSerializerTest(BaseAlertRuleSerializerTest, TestCase):
 
     def test_projects(self):
         regular_alert_rule = self.create_alert_rule()
-        activated_alert_rule = self.create_alert_rule(monitor_type=AlertRuleMonitorType.ACTIVATED)
+        activated_alert_rule = self.create_alert_rule(
+            monitor_type=AlertRuleMonitorTypeInt.ACTIVATED
+        )
         alert_rule_no_projects = self.create_alert_rule()
 
         AlertRuleProjects.objects.filter(alert_rule_id=alert_rule_no_projects.id).delete()

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_activations.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_activations.py
@@ -8,7 +8,7 @@ from sentry.api.serializers import serialize
 from sentry.incidents.endpoints.serializers.alert_rule_activations import (
     AlertRuleActivationsSerializer,
 )
-from sentry.incidents.models.alert_rule import AlertRuleMonitorType
+from sentry.incidents.models.alert_rule import AlertRuleMonitorTypeInt
 from sentry.testutils.abstract import Abstract
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.helpers.datetime import freeze_time
@@ -41,9 +41,9 @@ class AlertRuleActivationsBase(APITestCase):
 
 class AlertRuleActivationsListEndpointTest(AlertRuleActivationsBase):
     def test_simple(self):
-        alert_rule = self.create_alert_rule(monitor_type=AlertRuleMonitorType.CONTINUOUS)
+        alert_rule = self.create_alert_rule(monitor_type=AlertRuleMonitorTypeInt.CONTINUOUS)
         activation = self.create_alert_rule_activation(
-            alert_rule=alert_rule, monitor_type=AlertRuleMonitorType.CONTINUOUS
+            alert_rule=alert_rule, monitor_type=AlertRuleMonitorTypeInt.CONTINUOUS
         )
         with self.feature("organizations:incidents"):
             resp = self.get_success_response(self.organization.slug, alert_rule.id)
@@ -56,23 +56,23 @@ class AlertRuleActivationsListEndpointTest(AlertRuleActivationsBase):
         assert resp.status_code == 404
 
     def test_filter_by_start_end(self):
-        alert_rule = self.create_alert_rule(monitor_type=AlertRuleMonitorType.CONTINUOUS)
+        alert_rule = self.create_alert_rule(monitor_type=AlertRuleMonitorTypeInt.CONTINUOUS)
         now = timezone.now()
         yesterday = now - timedelta(days=1)
         last_week = now - timedelta(days=7)
         with freeze_time(last_week):
             old_activation = self.create_alert_rule_activation(
-                alert_rule=alert_rule, monitor_type=AlertRuleMonitorType.CONTINUOUS
+                alert_rule=alert_rule, monitor_type=AlertRuleMonitorTypeInt.CONTINUOUS
             )
 
         with freeze_time(yesterday):
             yesterday_activation = self.create_alert_rule_activation(
-                alert_rule=alert_rule, monitor_type=AlertRuleMonitorType.CONTINUOUS
+                alert_rule=alert_rule, monitor_type=AlertRuleMonitorTypeInt.CONTINUOUS
             )
 
         with freeze_time(now):
             new_activation = self.create_alert_rule_activation(
-                alert_rule=alert_rule, monitor_type=AlertRuleMonitorType.CONTINUOUS
+                alert_rule=alert_rule, monitor_type=AlertRuleMonitorTypeInt.CONTINUOUS
             )
 
         # NOTE: order matters here. API orders by date_added

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_details.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_details.py
@@ -461,7 +461,7 @@ class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase):
         self.login_as(self.user)
         alert_rule = self.alert_rule
         serialized_alert_rule = self.get_serialized_alert_rule()
-        serialized_alert_rule["monitorType"] = AlertRuleMonitorType.ACTIVATED.value
+        serialized_alert_rule["monitorType"] = AlertRuleMonitorType.ACTIVATED
         serialized_alert_rule[
             "activationCondition"
         ] = AlertRuleActivationConditionType.RELEASE_CREATION.value
@@ -473,14 +473,14 @@ class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase):
                 self.organization.slug, alert_rule.id, **serialized_alert_rule
             )
         alert_rule = AlertRule.objects.get(id=resp.data["id"])
-        alert_rule.monitorType = AlertRuleMonitorType.ACTIVATED.value
+        alert_rule.monitorType = AlertRuleMonitorType.ACTIVATED
         alert_rule.activationCondition = AlertRuleActivationConditionType.RELEASE_CREATION.value
         alert_rule.date_modified = resp.data["dateModified"]
         assert resp.data == serialize(alert_rule)
 
         # TODO: determine how to convert activated alert into continuous alert and vice versa (see logic.py)
         # requires creating/disabling activations accordingly
-        # assert resp.data["monitorType"] == AlertRuleMonitorType.ACTIVATED.value
+        # assert resp.data["monitorType"] == AlertRuleMonitorType.ACTIVATED
         # assert (
         #     resp.data["activationCondition"]
         #     == AlertRuleActivationConditionType.RELEASE_CREATION.value

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_details.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_details.py
@@ -18,7 +18,7 @@ from sentry.auth.access import OrganizationGlobalAccess
 from sentry.incidents.endpoints.serializers.alert_rule import DetailedAlertRuleSerializer
 from sentry.incidents.models.alert_rule import (
     AlertRule,
-    AlertRuleMonitorType,
+    AlertRuleMonitorTypeInt,
     AlertRuleStatus,
     AlertRuleTrigger,
     AlertRuleTriggerAction,
@@ -461,7 +461,7 @@ class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase):
         self.login_as(self.user)
         alert_rule = self.alert_rule
         serialized_alert_rule = self.get_serialized_alert_rule()
-        serialized_alert_rule["monitorType"] = AlertRuleMonitorType.ACTIVATED
+        serialized_alert_rule["monitorType"] = AlertRuleMonitorTypeInt.ACTIVATED
         serialized_alert_rule[
             "activationCondition"
         ] = AlertRuleActivationConditionType.RELEASE_CREATION.value
@@ -473,14 +473,14 @@ class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase):
                 self.organization.slug, alert_rule.id, **serialized_alert_rule
             )
         alert_rule = AlertRule.objects.get(id=resp.data["id"])
-        alert_rule.monitorType = AlertRuleMonitorType.ACTIVATED
+        alert_rule.monitorType = AlertRuleMonitorTypeInt.ACTIVATED
         alert_rule.activationCondition = AlertRuleActivationConditionType.RELEASE_CREATION.value
         alert_rule.date_modified = resp.data["dateModified"]
         assert resp.data == serialize(alert_rule)
 
         # TODO: determine how to convert activated alert into continuous alert and vice versa (see logic.py)
         # requires creating/disabling activations accordingly
-        # assert resp.data["monitorType"] == AlertRuleMonitorType.ACTIVATED
+        # assert resp.data["monitorType"] == AlertRuleMonitorTypeInt.ACTIVATED
         # assert (
         #     resp.data["activationCondition"]
         #     == AlertRuleActivationConditionType.RELEASE_CREATION.value

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
@@ -209,7 +209,7 @@ class AlertRuleCreateEndpointTest(AlertRuleIndexBase):
     def test_monitor_type_with_condition(self):
         data = {
             **self.alert_rule_dict,
-            "monitorType": AlertRuleMonitorType.ACTIVATED.value,
+            "monitorType": AlertRuleMonitorType.ACTIVATED,
             "activationCondition": AlertRuleActivationConditionType.RELEASE_CREATION.value,
         }
         with (

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
@@ -13,7 +13,7 @@ from sentry.api.helpers.constants import ALERT_RULES_COUNT_HEADER, MAX_QUERY_SUB
 from sentry.api.serializers import serialize
 from sentry.incidents.models.alert_rule import (
     AlertRule,
-    AlertRuleMonitorType,
+    AlertRuleMonitorTypeInt,
     AlertRuleThresholdType,
     AlertRuleTrigger,
     AlertRuleTriggerAction,
@@ -113,8 +113,8 @@ class AlertRuleListEndpointTest(AlertRuleIndexBase):
 
     def test_filter_by_monitor_type(self):
         self.create_team(organization=self.organization, members=[self.user])
-        alert_rule1 = self.create_alert_rule(monitor_type=AlertRuleMonitorType.ACTIVATED)
-        alert_rule2 = self.create_alert_rule(monitor_type=AlertRuleMonitorType.CONTINUOUS)
+        alert_rule1 = self.create_alert_rule(monitor_type=AlertRuleMonitorTypeInt.ACTIVATED)
+        alert_rule2 = self.create_alert_rule(monitor_type=AlertRuleMonitorTypeInt.CONTINUOUS)
         self.login_as(self.user)
 
         params = {"monitor_type": 1}
@@ -126,8 +126,8 @@ class AlertRuleListEndpointTest(AlertRuleIndexBase):
 
     def test_response_headers(self):
         self.create_team(organization=self.organization, members=[self.user])
-        self.create_alert_rule(monitor_type=AlertRuleMonitorType.ACTIVATED)
-        self.create_alert_rule(monitor_type=AlertRuleMonitorType.CONTINUOUS)
+        self.create_alert_rule(monitor_type=AlertRuleMonitorTypeInt.ACTIVATED)
+        self.create_alert_rule(monitor_type=AlertRuleMonitorTypeInt.CONTINUOUS)
         self.login_as(self.user)
 
         with self.feature("organizations:incidents"):
@@ -140,7 +140,7 @@ class AlertRuleListEndpointTest(AlertRuleIndexBase):
         self.create_team(organization=self.organization, members=[self.user])
         alert_rule = self.create_alert_rule()
         self.create_alert_rule_activation(
-            alert_rule=alert_rule, monitor_type=AlertRuleMonitorType.CONTINUOUS
+            alert_rule=alert_rule, monitor_type=AlertRuleMonitorTypeInt.CONTINUOUS
         )
 
         self.login_as(self.user)
@@ -209,7 +209,7 @@ class AlertRuleCreateEndpointTest(AlertRuleIndexBase):
     def test_monitor_type_with_condition(self):
         data = {
             **self.alert_rule_dict,
-            "monitorType": AlertRuleMonitorType.ACTIVATED,
+            "monitorType": AlertRuleMonitorTypeInt.ACTIVATED,
             "activationCondition": AlertRuleActivationConditionType.RELEASE_CREATION.value,
         }
         with (

--- a/tests/sentry/incidents/models/test_alert_rule.py
+++ b/tests/sentry/incidents/models/test_alert_rule.py
@@ -12,7 +12,7 @@ from sentry.incidents.models.alert_rule import (
     AlertRule,
     AlertRuleActivity,
     AlertRuleActivityType,
-    AlertRuleMonitorType,
+    AlertRuleMonitorTypeInt,
     AlertRuleStatus,
     AlertRuleTrigger,
     AlertRuleTriggerAction,
@@ -148,12 +148,12 @@ class AlertRuleTest(TestCase):
     @patch("sentry.incidents.models.alert_rule.bulk_create_snuba_subscriptions")
     def test_subscribes_projects_to_alert_rule(self, mock_bulk_create_snuba_subscriptions):
         # eg. creates QuerySubscription's/SnubaQuery's for AlertRule + Project
-        alert_rule = self.create_alert_rule(monitor_type=AlertRuleMonitorType.ACTIVATED)
+        alert_rule = self.create_alert_rule(monitor_type=AlertRuleMonitorTypeInt.ACTIVATED)
         assert mock_bulk_create_snuba_subscriptions.call_count == 0
 
         alert_rule.subscribe_projects(
             projects=[self.project],
-            monitor_type=AlertRuleMonitorType.ACTIVATED,
+            monitor_type=AlertRuleMonitorTypeInt.ACTIVATED,
             activator="testing",
             activation_condition=AlertRuleActivationConditionType.RELEASE_CREATION,
         )
@@ -164,7 +164,7 @@ class AlertRuleTest(TestCase):
         project = self.create_project(name="foo")
         self.create_alert_rule(
             projects=[project],
-            monitor_type=AlertRuleMonitorType.ACTIVATED,
+            monitor_type=AlertRuleMonitorTypeInt.ACTIVATED,
             activation_condition=AlertRuleActivationConditionType.DEPLOY_CREATION,
         )
         with self.tasks():
@@ -188,7 +188,7 @@ class AlertRuleTest(TestCase):
         project = self.create_project(name="foo")
         alert_rule = self.create_alert_rule(
             projects=[project],
-            monitor_type=AlertRuleMonitorType.ACTIVATED,
+            monitor_type=AlertRuleMonitorTypeInt.ACTIVATED,
             activation_condition=AlertRuleActivationConditionType.DEPLOY_CREATION,
         )
 
@@ -404,10 +404,10 @@ class AlertRuleActivityTest(TestCase):
 class UpdateAlertActivationsTest(TestCase):
     def test_updates_non_expired_alerts(self):
         with self.tasks():
-            alert_rule = self.create_alert_rule(monitor_type=AlertRuleMonitorType.ACTIVATED)
+            alert_rule = self.create_alert_rule(monitor_type=AlertRuleMonitorTypeInt.ACTIVATED)
             alert_rule.subscribe_projects(
                 projects=[self.project],
-                monitor_type=AlertRuleMonitorType.ACTIVATED,
+                monitor_type=AlertRuleMonitorTypeInt.ACTIVATED,
                 activation_condition=AlertRuleActivationConditionType.RELEASE_CREATION,
                 activator="testing",
             )
@@ -429,10 +429,10 @@ class UpdateAlertActivationsTest(TestCase):
 
     def test_cleans_expired_alerts(self):
         with self.tasks():
-            alert_rule = self.create_alert_rule(monitor_type=AlertRuleMonitorType.ACTIVATED)
+            alert_rule = self.create_alert_rule(monitor_type=AlertRuleMonitorTypeInt.ACTIVATED)
             alert_rule.subscribe_projects(
                 projects=[self.project],
-                monitor_type=AlertRuleMonitorType.ACTIVATED,
+                monitor_type=AlertRuleMonitorTypeInt.ACTIVATED,
                 activation_condition=AlertRuleActivationConditionType.RELEASE_CREATION,
                 activator="testing",
             )
@@ -454,21 +454,22 @@ class UpdateAlertActivationsTest(TestCase):
             assert activation.metric_value == expected_value
 
     def test_update_alerts_add_processor(self):
-        @register_alert_subscription_callback(AlertRuleMonitorType.CONTINUOUS)
+        @register_alert_subscription_callback(AlertRuleMonitorTypeInt.CONTINUOUS)
         def mock_processor(_subscription, alert_rule, value):
             # everything other than subscription is passed as a kwarg
             return True
 
-        assert AlertRuleMonitorType.CONTINUOUS in alert_subscription_callback_registry
+        assert AlertRuleMonitorTypeInt.CONTINUOUS in alert_subscription_callback_registry
         assert (
-            alert_subscription_callback_registry[AlertRuleMonitorType.CONTINUOUS] == mock_processor
+            alert_subscription_callback_registry[AlertRuleMonitorTypeInt.CONTINUOUS]
+            == mock_processor
         )
 
     def test_update_alerts_execute_processor(self):
-        alert_rule = self.create_alert_rule(monitor_type=AlertRuleMonitorType.CONTINUOUS)
+        alert_rule = self.create_alert_rule(monitor_type=AlertRuleMonitorTypeInt.CONTINUOUS)
         subscription = alert_rule.snuba_query.subscriptions.get()
 
-        callback = alert_subscription_callback_registry[AlertRuleMonitorType.CONTINUOUS]
+        callback = alert_subscription_callback_registry[AlertRuleMonitorTypeInt.CONTINUOUS]
         result = callback(subscription, alert_rule=alert_rule, value=10)
         assert result is True
 

--- a/tests/sentry/incidents/test_logic.py
+++ b/tests/sentry/incidents/test_logic.py
@@ -55,7 +55,7 @@ from sentry.incidents.logic import (
 )
 from sentry.incidents.models.alert_rule import (
     AlertRule,
-    AlertRuleMonitorType,
+    AlertRuleMonitorTypeInt,
     AlertRuleStatus,
     AlertRuleThresholdType,
     AlertRuleTrigger,
@@ -458,8 +458,8 @@ class CreateAlertRuleTest(TestCase, BaseIncidentsTest):
         # TODO: backfill projects so all monitor_types include 'projects' fk
         for monitor_type in [
             None,
-            AlertRuleMonitorType.CONTINUOUS,
-            AlertRuleMonitorType.ACTIVATED,
+            AlertRuleMonitorTypeInt.CONTINUOUS,
+            AlertRuleMonitorTypeInt.ACTIVATED,
         ]:
             name = "hello"
             query = "level:error"
@@ -519,7 +519,7 @@ class CreateAlertRuleTest(TestCase, BaseIncidentsTest):
         resolve_threshold = 10
         threshold_period = 1
         event_types = [SnubaQueryEventType.EventType.ERROR]
-        kwargs = {"monitor_type": AlertRuleMonitorType.ACTIVATED}
+        kwargs = {"monitor_type": AlertRuleMonitorTypeInt.ACTIVATED}
 
         with pytest.raises(ValidationError):
             create_alert_rule(

--- a/tests/sentry/incidents/test_subscription_processor.py
+++ b/tests/sentry/incidents/test_subscription_processor.py
@@ -19,7 +19,7 @@ from sentry.incidents.logic import (
 )
 from sentry.incidents.models.alert_rule import (
     AlertRule,
-    AlertRuleMonitorType,
+    AlertRuleMonitorTypeInt,
     AlertRuleThresholdType,
     AlertRuleTrigger,
     AlertRuleTriggerAction,
@@ -215,7 +215,7 @@ class ProcessUpdateTest(ProcessUpdateBaseClass):
             threshold_type=AlertRuleThresholdType.ABOVE,
             resolve_threshold=10,
             threshold_period=1,
-            monitor_type=AlertRuleMonitorType.CONTINUOUS,
+            monitor_type=AlertRuleMonitorTypeInt.CONTINUOUS,
             event_types=[
                 SnubaQueryEventType.EventType.ERROR,
                 SnubaQueryEventType.EventType.DEFAULT,
@@ -242,7 +242,7 @@ class ProcessUpdateTest(ProcessUpdateBaseClass):
             threshold_type=AlertRuleThresholdType.ABOVE,
             resolve_threshold=10,
             threshold_period=1,
-            monitor_type=AlertRuleMonitorType.ACTIVATED,
+            monitor_type=AlertRuleMonitorTypeInt.ACTIVATED,
             activation_condition=AlertRuleActivationConditionType.RELEASE_CREATION,
             event_types=[
                 SnubaQueryEventType.EventType.ERROR,
@@ -251,7 +251,7 @@ class ProcessUpdateTest(ProcessUpdateBaseClass):
         )
         rule.subscribe_projects(
             projects=[self.project],
-            monitor_type=AlertRuleMonitorType.ACTIVATED,
+            monitor_type=AlertRuleMonitorTypeInt.ACTIVATED,
             activation_condition=AlertRuleActivationConditionType.DEPLOY_CREATION,
             activator="testing",
         )
@@ -2348,7 +2348,7 @@ class ProcessUpdateTest(ProcessUpdateBaseClass):
 
     def test_invoke_alert_subscription_callback(self):
         mock = Mock()
-        alert_subscription_callback_registry[AlertRuleMonitorType.CONTINUOUS] = mock
+        alert_subscription_callback_registry[AlertRuleMonitorTypeInt.CONTINUOUS] = mock
 
         self.send_update(self.rule, 1, subscription=self.sub)
 

--- a/tests/sentry/models/releases/test_release_project.py
+++ b/tests/sentry/models/releases/test_release_project.py
@@ -2,7 +2,7 @@ from unittest.mock import call as mock_call
 from unittest.mock import patch
 
 from sentry.dynamic_sampling import ProjectBoostedReleases
-from sentry.incidents.models.alert_rule import AlertRule, AlertRuleMonitorType
+from sentry.incidents.models.alert_rule import AlertRule, AlertRuleMonitorTypeInt
 from sentry.incidents.utils.types import AlertRuleActivationConditionType
 from sentry.models.release import Release
 from sentry.models.releases.release_project import ReleaseProject, ReleaseProjectModelManager
@@ -115,7 +115,7 @@ class ReleaseProjectManagerTestCase(TransactionTestCase):
         release = Release.objects.create(organization_id=project.organization_id, version="42")
         self.create_alert_rule(
             projects=[project],
-            monitor_type=AlertRuleMonitorType.ACTIVATED,
+            monitor_type=AlertRuleMonitorTypeInt.ACTIVATED,
             activation_condition=AlertRuleActivationConditionType.RELEASE_CREATION,
         )
 

--- a/tests/sentry/models/test_releaseprojectenvironment.py
+++ b/tests/sentry/models/test_releaseprojectenvironment.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 
 from django.utils import timezone
 
-from sentry.incidents.models.alert_rule import AlertRule, AlertRuleMonitorType
+from sentry.incidents.models.alert_rule import AlertRule, AlertRuleMonitorTypeInt
 from sentry.incidents.utils.types import AlertRuleActivationConditionType
 from sentry.models.environment import Environment
 from sentry.models.release import Release
@@ -132,7 +132,7 @@ class GetOrCreateTest(TestCase):
         # release = Release.objects.create(organization_id=project.organization_id, version="42")
         self.create_alert_rule(
             projects=[self.project],
-            monitor_type=AlertRuleMonitorType.ACTIVATED,
+            monitor_type=AlertRuleMonitorTypeInt.ACTIVATED,
             activation_condition=AlertRuleActivationConditionType.DEPLOY_CREATION,
         )
 


### PR DESCRIPTION
# Description
Migrate the `AlertRuleMonitorType` to use an `IntEnum` as the base. This is possible because the `monitor_type` field is an [`IntegerField`](https://github.com/getsentry/sentry/blob/2256c3c7665ffccf02d58af987c0fc117bf6a2d5/src/sentry/incidents/models/alert_rule.py#L270), by doing this we can simplify how we use the enum in code, and improve typing.

### Review Callout
I wasn't sure if i should update the migration or not though (by updating it, we can support potential rollbacks. the risk i'm not sure of is if django or our ci will pick it up as a change and trigger any new migrations).