### PR TITLE
ref(seer grouping): Improve tracking of Seer similarity calls

### DIFF
--- a/src/sentry/api/endpoints/group_similar_issues_embeddings.py
+++ b/src/sentry/api/endpoints/group_similar_issues_embeddings.py
@@ -75,12 +75,14 @@ class GroupSimilarIssuesEmbeddingsEndpoint(GroupEndpoint):
             return Response([])  # No exception, stacktrace or in-app frames, or event
 
         similar_issues_params: SimilarIssuesEmbeddingsRequest = {
+            "event_id": latest_event.event_id,
             "hash": latest_event.get_primary_hash(),
             "project_id": group.project.id,
             "stacktrace": stacktrace_string,
             "message": group.message,
             "exception_type": get_path(latest_event.data, "exception", "values", -1, "type"),
             "read_only": True,
+            "referrer": "similar_issues",
         }
         # Add optional parameters
         if request.GET.get("k"):

--- a/src/sentry/grouping/ingest/seer.py
+++ b/src/sentry/grouping/ingest/seer.py
@@ -7,7 +7,6 @@ from sentry.eventstore.models import Event
 from sentry.grouping.grouping_info import get_grouping_info_from_variants
 from sentry.grouping.result import CalculatedHashes
 from sentry.models.group import Group
-from sentry.models.grouphash import GroupHash
 from sentry.models.project import Project
 from sentry.seer.similarity.similar_issues import get_similarity_data_from_seer
 from sentry.seer.similarity.types import SeerSimilarIssuesMetadata, SimilarIssuesEmbeddingsRequest
@@ -220,26 +219,6 @@ def get_seer_similar_issues(
 
     # Similar issues are returned with the closest match first
     seer_results = get_similarity_data_from_seer(request_data)
-    logger.info(
-        "get_seer_similar_issues.request",
-        extra={"event_id": event.event_id, "payload": request_data},
-    )
-    # TODO: This is temporary, to debug Seer being called on existing hashes
-    existing_grouphash = GroupHash.objects.filter(
-        hash=event_hash, project_id=event.project.id
-    ).first()
-    if existing_grouphash and existing_grouphash.group_id:
-        logger.warning(
-            "get_seer_similar_issues.hash_exists",
-            extra={
-                "event_id": event.event_id,
-                "project_id": event.project.id,
-                "hash": event_hash,
-                "grouphash_id": existing_grouphash.id,
-                "group_id": existing_grouphash.group_id,
-            },
-        )
-
     similar_issues_metadata = asdict(
         SeerSimilarIssuesMetadata(request_hash=event_hash, results=seer_results)
     )

--- a/src/sentry/grouping/ingest/seer.py
+++ b/src/sentry/grouping/ingest/seer.py
@@ -208,12 +208,14 @@ def get_seer_similar_issues(
     )
 
     request_data: SimilarIssuesEmbeddingsRequest = {
+        "event_id": event.event_id,
         "hash": event_hash,
         "project_id": event.project.id,
         "stacktrace": stacktrace_string,
         "message": filter_null_from_event_title(event.title),
         "exception_type": get_path(event.data, "exception", "values", -1, "type"),
         "k": num_neighbors,
+        "referrer": "ingest",
     }
 
     # Similar issues are returned with the closest match first

--- a/src/sentry/grouping/ingest/seer.py
+++ b/src/sentry/grouping/ingest/seer.py
@@ -238,7 +238,7 @@ def get_seer_similar_issues(
             "event_id": event.event_id,
             "project_id": event.project.id,
             "hash": event_hash,
-            "results": similar_issues_metadata,
+            "results": similar_issues_metadata["results"],
             "group_returned": bool(parent_group),
         },
     )

--- a/src/sentry/seer/similarity/similar_issues.py
+++ b/src/sentry/seer/similarity/similar_issues.py
@@ -3,6 +3,7 @@ import logging
 from django.conf import settings
 
 from sentry.conf.server import SEER_MAX_GROUPING_DISTANCE, SEER_SIMILAR_ISSUES_URL
+from sentry.models.grouphash import GroupHash
 from sentry.net.http import connection_from_url
 from sentry.seer.signed_seer_api import make_signed_seer_api_request
 from sentry.seer.similarity.types import (
@@ -35,6 +36,26 @@ def get_similarity_data_from_seer(
     Request similar issues data from seer and normalize the results. Returns similar groups
     sorted in order of descending similarity.
     """
+    logger.info(
+        "get_seer_similar_issues.request",
+        extra={"payload": similar_issues_request},
+    )
+    # TODO: This is temporary, to debug Seer being called on existing hashes
+    existing_grouphash = GroupHash.objects.filter(
+        hash=similar_issues_request["hash"], project_id=similar_issues_request["project_id"]
+    ).first()
+    if existing_grouphash and existing_grouphash.group_id:
+        logger.warning(
+            "get_seer_similar_issues.hash_exists",
+            extra={
+                "event_id": similar_issues_request["event_id"],
+                "project_id": similar_issues_request["project_id"],
+                "hash": similar_issues_request["hash"],
+                "grouphash_id": existing_grouphash.id,
+                "group_id": existing_grouphash.group_id,
+                "referrer": similar_issues_request.get("referrer"),
+            },
+        )
 
     response = make_signed_seer_api_request(
         seer_grouping_connection_pool,

--- a/src/sentry/seer/similarity/similar_issues.py
+++ b/src/sentry/seer/similarity/similar_issues.py
@@ -13,7 +13,7 @@ from sentry.seer.similarity.types import (
     SimilarIssuesEmbeddingsRequest,
 )
 from sentry.utils import json, metrics
-from sentry.utils.json import JSONDecodeError
+from sentry.utils.json import JSONDecodeError, apply_key_filter
 
 logger = logging.getLogger(__name__)
 
@@ -38,7 +38,10 @@ def get_similarity_data_from_seer(
     """
     logger.info(
         "get_seer_similar_issues.request",
-        extra={"payload": similar_issues_request},
+        extra=apply_key_filter(
+            similar_issues_request,
+            keep_keys=["event_id", "project_id", "message", "hash", "referrer"],
+        ),
     )
     # TODO: This is temporary, to debug Seer being called on existing hashes
     existing_grouphash = GroupHash.objects.filter(

--- a/src/sentry/seer/similarity/similar_issues.py
+++ b/src/sentry/seer/similarity/similar_issues.py
@@ -36,6 +36,9 @@ def get_similarity_data_from_seer(
     Request similar issues data from seer and normalize the results. Returns similar groups
     sorted in order of descending similarity.
     """
+    referrer = similar_issues_request.get("referrer")
+    metric_tags: dict[str, str | int] = {"referrer": referrer} if referrer else {}
+
     logger.info(
         "get_seer_similar_issues.request",
         extra=apply_key_filter(
@@ -68,7 +71,7 @@ def get_similarity_data_from_seer(
         ),
     )
 
-    metric_tags: dict[str, str | int] = {"response_status": response.status}
+    metric_tags["response_status"] = response.status
 
     if response.status > 200:
         redirect = response.get_redirect_location()

--- a/src/sentry/seer/similarity/types.py
+++ b/src/sentry/seer/similarity/types.py
@@ -27,6 +27,8 @@ class SimilarIssuesEmbeddingsRequest(TypedDict):
     k: NotRequired[int]  # how many neighbors to find
     threshold: NotRequired[float]
     read_only: NotRequired[bool]
+    event_id: NotRequired[str]
+    referrer: NotRequired[str]
 
 
 class RawSeerSimilarIssueData(TypedDict):

--- a/tests/sentry/api/endpoints/test_group_similar_issues_embeddings.py
+++ b/tests/sentry/api/endpoints/test_group_similar_issues_embeddings.py
@@ -219,12 +219,14 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
 
         expected_seer_request_params = {
             "threshold": 0.01,
+            "event_id": self.group.get_latest_event().event_id,
             "hash": NonNone(self.event.get_primary_hash()),
             "project_id": self.project.id,
             "stacktrace": EXPECTED_STACKTRACE_STRING,
             "message": self.group.message,
             "exception_type": "ZeroDivisionError",
             "read_only": True,
+            "referrer": "similar_issues",
             "k": 1,
         }
 
@@ -245,6 +247,7 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
             tags={
                 "response_status": 200,
                 "outcome": "matching_group_found",
+                "referrer": "similar_issues",
             },
         )
 
@@ -333,12 +336,14 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
             "Seer similar issues response entry missing key 'parent_hash'",
             extra={
                 "request_params": {
+                    "event_id": self.group.get_latest_event().event_id,
                     "hash": NonNone(self.event.get_primary_hash()),
                     "project_id": self.project.id,
                     "stacktrace": EXPECTED_STACKTRACE_STRING,
                     "message": self.group.message,
                     "exception_type": "ZeroDivisionError",
                     "read_only": True,
+                    "referrer": "similar_issues",
                 },
                 "raw_similar_issue_data": {
                     "message_distance": 0.05,
@@ -354,6 +359,7 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
                 "response_status": 200,
                 "outcome": "error",
                 "error": "IncompleteSeerDataError",
+                "referrer": "similar_issues",
             },
         )
 
@@ -397,6 +403,7 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
                 "response_status": 200,
                 "outcome": "error",
                 "error": "SimilarGroupNotFoundError",
+                "referrer": "similar_issues",
             },
         )
         assert response.data == self.get_expected_response(
@@ -531,12 +538,14 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
             body=orjson.dumps(
                 {
                     "threshold": 0.01,
+                    "event_id": self.group.get_latest_event().event_id,
                     "hash": NonNone(self.event.get_primary_hash()),
                     "project_id": self.project.id,
                     "stacktrace": EXPECTED_STACKTRACE_STRING,
                     "message": self.group.message,
                     "exception_type": "ZeroDivisionError",
                     "read_only": True,
+                    "referrer": "similar_issues",
                 },
             ),
             headers={"content-type": "application/json;charset=utf-8"},
@@ -557,12 +566,14 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
             body=orjson.dumps(
                 {
                     "threshold": 0.01,
+                    "event_id": self.group.get_latest_event().event_id,
                     "hash": NonNone(self.event.get_primary_hash()),
                     "project_id": self.project.id,
                     "stacktrace": EXPECTED_STACKTRACE_STRING,
                     "message": self.group.message,
                     "exception_type": "ZeroDivisionError",
                     "read_only": True,
+                    "referrer": "similar_issues",
                     "k": 1,
                 },
             ),
@@ -584,12 +595,14 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
             body=orjson.dumps(
                 {
                     "threshold": 0.01,
+                    "event_id": self.group.get_latest_event().event_id,
                     "hash": NonNone(self.event.get_primary_hash()),
                     "project_id": self.project.id,
                     "stacktrace": EXPECTED_STACKTRACE_STRING,
                     "message": self.group.message,
                     "exception_type": "ZeroDivisionError",
                     "read_only": True,
+                    "referrer": "similar_issues",
                 },
             ),
             headers={"content-type": "application/json;charset=utf-8"},

--- a/tests/sentry/grouping/test_seer.py
+++ b/tests/sentry/grouping/test_seer.py
@@ -210,12 +210,14 @@ class GetSeerSimilarIssuesTest(TestCase):
 
             mock_get_similarity_data.assert_called_with(
                 {
+                    "event_id": "12312012112120120908201304152013",
                     "hash": "20130809201315042012311220122111",
                     "project_id": self.project.id,
                     "stacktrace": "<stacktrace string>",
                     "message": "FailedToFetchError('Charlie didn't bring the ball back')",
                     "exception_type": "FailedToFetchError",
                     "k": 1,
+                    "referrer": "ingest",
                 }
             )
 


### PR DESCRIPTION
This improves our tracking of requests to the Seer similarity endpoint in a few ways:

- Move the logging of requests to the endpoint from `get_seer_similar_issues` (only called during ingest) to its helper `get_similarity_data_from_seer` (which is called both from ingest and the similar issues tab), so the tab's requests are logged, too.

- Add `event_id` and `referrer` to the extra data sent with that log. At the same time, stop logging extra data which is big (the stacktrace string) and/or not that useful (the threshold, number of neighbors to find, and the read-only value, none of which ever vary once you know the referrer, and the exception type, which is included in `message`, since it's actually the event title).

- Also add `event_id` and `referrer` as optional parameters in the payload sent to Seer. That way, if we want to log either piece of data on the Seer side, we can.

- Add `referrer` as a tag on the request metric.

- Unwrap results data in logging of response from Seer to ingest calls, so we have to do less clicking in GCP to see the data.