### PR TITLE
fix(ui): replace/point link to existing doc

### DIFF
--- a/static/app/components/archivedBox.tsx
+++ b/static/app/components/archivedBox.tsx
@@ -29,7 +29,7 @@ function ArchivedBox({substatus, statusDetails, organization}: ArchivedBoxProps)
       return t(
         "This issue has been archived. It'll return to your inbox if it escalates. To learn more, %s",
         <ExternalLink
-          href="https://docs.sentry.io/product/accounts/early-adopter-features/issue-archiving/"
+          href="https://docs.sentry.io/product/issues/states-triage/#archive"
           onClick={trackDocsClick}
         >
           {t('read the docs')}


### PR DESCRIPTION
Replace the link such that it points to an existing location.

Fixes #73260

### Further improvements

The phrasing and linking could further be improved by linking to the escalation documentation as well. I personally encountered the dead link because I worked with an issue in sentry my first time and wanted to know what "escalation" actually means in this context.

This would however include adding to the translations which I cannot/do not want to do in a PR. A patch could look like this:

```
--- a/static/app/components/archivedBox.tsx
+++ b/static/app/components/archivedBox.tsx
@@ -27,7 +27,19 @@ function ArchivedBox({substatus, statusDetails, organization}: ArchivedBoxProps)

     if (substatus === GroupSubstatus.ARCHIVED_UNTIL_ESCALATING) {
       return t(
-        "This issue has been archived. It'll return to your inbox if it escalates. To learn more, %s",
+        "This issue has been %s. It'll return to your inbox if it %s. To learn more, %s",
+        <ExternalLink
+          href="https://docs.sentry.io/product/issues/states-triage/#archive"
+          onClick={trackDocsClick}
+        >
+          {t('archived')}
+        </ExternalLink>,
+        <ExternalLink
+          href="https://docs.sentry.io/product/issues/states-triage/escalating-issues/"
+          onClick={trackDocsClick}
+        >
+          {t('escalates')}
+        </ExternalLink>,
         <ExternalLink
           href="https://docs.sentry.io/product/issues/states-triage/#archive"
           onClick={trackDocsClick}
```
### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
