### PR TITLE
feat(performance): UI updates to regression emails

### DIFF
--- a/src/sentry/templates/sentry/emails/issue_alert_base.html
+++ b/src/sentry/templates/sentry/emails/issue_alert_base.html
@@ -190,14 +190,13 @@
                 <td>{{ environment }}</td>
               </tr>
             {% endif %}
-            {% if not is_new_design %}
+            {% if is_new_design %}
               <tr>
-                <th>Level</th>
-                <td>{{ group.get_level_display }}</td>
-              </tr>
-            {% else %}
-              <tr>
-                <th>Transaction</th>
+                {% if issue_type == "Endpoint Regression" %}
+                  <th>Endpoint</th>
+                {% elif issue_type == "Function Regression" %}
+                  <th>Function</th>
+                {% endif %}
                 <td>{{ event.transaction }}</td>
               </tr>
               <tr>
@@ -213,6 +212,11 @@
                     {{ event.datetime|date:"N j, Y, g:i:s a e"}}
                   {% endif %}
                 </td>
+              </tr>
+            {% else %}
+              <tr>
+                <th>Level</th>
+                <td>{{ group.get_level_display }}</td>
               </tr>
             {% endif %}
           </tbody>

--- a/src/sentry/templates/sentry/emails/issue_alert_base.html
+++ b/src/sentry/templates/sentry/emails/issue_alert_base.html
@@ -148,8 +148,8 @@
                         <span class="event-subtitle">{{ transaction }}</span>
                       {% endif %}
                       <br />
-                      {% if subtitle %}
-                      <small>{{ subtitle|truncatechars:40|soft_break:40 }}</small>
+                      {% if subtitle and not is_new_design %}
+                        <small>{{ subtitle|truncatechars:40|soft_break:40 }}</small>
                       {% endif %}
                     </h3>
                   </div>
@@ -160,14 +160,16 @@
         </tr>
       </table>
 
-      <div class="event">
-        <div class="event-id">ID: {{ event.event_id }}</div>
-        {% if timezone %}
-            <div class="event-date">{{ event.datetime|timezone:timezone|date:"N j, Y, g:i:s a e"}}</div>
-        {% else %}
-            <div class="event-date">{{ event.datetime|date:"N j, Y, g:i:s a e"}}</div>
-        {% endif %}
-      </div>
+      {% if not is_new_design %}
+        <div class="event">
+          <div class="event-id">ID: {{ event.event_id }}</div>
+            {% if timezone %}
+                <div class="event-date">{{ event.datetime|timezone:timezone|date:"N j, Y, g:i:s a e"}}</div>
+            {% else %}
+                <div class="event-date">{{ event.datetime|date:"N j, Y, g:i:s a e"}}</div>
+            {% endif %}
+        </div>
+      {% endif %}
 
       {% if chart_image %}
         <img src="{{chart_image}}" alt="{{issue_title}} Chart" />
@@ -179,7 +181,7 @@
           </colgroup>
           <tbody>
             <tr>
-              <th>project</th>
+              <th>Project</th>
               <td><a href="{{group.project.get_absolute_url}}">{{ project_label }}</a></td>
             </tr>
             {% if environment %}
@@ -188,10 +190,31 @@
                 <td>{{ environment }}</td>
               </tr>
             {% endif %}
-            <tr>
-              <th>level</th>
-              <td>{{ group.get_level_display }}</td>
-            </tr>
+            {% if not is_new_design %}
+              <tr>
+                <th>Level</th>
+                <td>{{ group.get_level_display }}</td>
+              </tr>
+            {% else %}
+              <tr>
+                <th>Transaction</th>
+                <td>{{ event.transaction }}</td>
+              </tr>
+              <tr>
+                <th>Change</th>
+                <td>{{ subtitle }}</td>
+              </tr>
+              <tr>
+                <th>Start Time</th>
+                <td>
+                  {% if timezone %}
+                    {{ event.datetime|timezone:timezone|date:"N j, Y, g:i:s a e"}}
+                  {% else %}
+                    {{ event.datetime|date:"N j, Y, g:i:s a e"}}
+                  {% endif %}
+                </td>
+              </tr>
+            {% endif %}
           </tbody>
         </table>
       </div>


### PR DESCRIPTION
Updating UI for regression emails so the more important information gets more visibility. Also regression emails have no span so removing span section from the email which currently always empty.

Some notes: 
* styles between the two image are different because before is from a real email. I didn't change any styling. 
* Ignore the data mismatch in the image, I just rendered fake data

Before:
<img width="462" alt="Screenshot 2024-06-25 at 11 50 59 AM" src="https://github.com/getsentry/sentry/assets/132939361/a5f73c66-3868-4b10-9236-207254b00fc4">


After:
<img width="519" alt="Screenshot 2024-06-25 at 11 50 27 AM" src="https://github.com/getsentry/sentry/assets/132939361/b4ca65e7-eccf-4521-8bab-ebcd01218c54">
