### PR TITLE
fix(aws-lambda-integration): Fix require paths for the SDK

### DIFF
--- a/src/sentry/integrations/aws_lambda/utils.py
+++ b/src/sentry/integrations/aws_lambda/utils.py
@@ -240,7 +240,7 @@ def enable_single_lambda(lambda_client, function, sentry_project_dsn, retries_le
         ):
             env_variables.update(
                 {
-                    "NODE_OPTIONS": "-r @sentry/serverless/dist/awslambda-auto",
+                    "NODE_OPTIONS": "-r @sentry/serverless/cjs/awslambda-auto",
                     **sentry_env_variables,
                 }
             )

--- a/src/sentry/integrations/aws_lambda/utils.py
+++ b/src/sentry/integrations/aws_lambda/utils.py
@@ -240,14 +240,14 @@ def enable_single_lambda(lambda_client, function, sentry_project_dsn, retries_le
         ):
             env_variables.update(
                 {
-                    "NODE_OPTIONS": "-r @sentry/serverless/cjs/awslambda-auto",
+                    "NODE_OPTIONS": "-r @sentry/serverless/dist/awslambda-auto",
                     **sentry_env_variables,
                 }
             )
         else:
             env_variables.update(
                 {
-                    "NODE_OPTIONS": "-r @sentry/aws-serverless/cjs/awslambda-auto",
+                    "NODE_OPTIONS": "-r @sentry/aws-serverless/awslambda-auto",
                     **sentry_env_variables,
                 }
             )


### PR DESCRIPTION
We set the wrong require paths: https://unpkg.com/browse/@sentry/aws-serverless@8.11.0/package.json (see `./awslambda-auto` export)