### PR TITLE
feat(metrics): Limit query operators

### DIFF
--- a/static/app/components/searchSyntax/parser.spec.tsx
+++ b/static/app/components/searchSyntax/parser.spec.tsx
@@ -208,6 +208,29 @@ describe('searchSyntax/parser', function () {
     });
   });
 
+  it('applies dissalowNegation', () => {
+    const result = parseSearch('!foo:bar', {
+      disallowNegation: true,
+      invalidMessages: {
+        [InvalidReason.NEGATION_NOT_ALLOWED]: 'Custom message',
+      },
+    });
+
+    // check with error to satisfy type checker
+    if (result === null) {
+      throw new Error('Parsed result as null');
+    }
+    expect(result).toHaveLength(3);
+
+    const foo = result[1] as TokenResult<Token.FILTER>;
+
+    expect(foo.negated).toEqual(true);
+    expect(foo.invalid).toEqual({
+      type: InvalidReason.NEGATION_NOT_ALLOWED,
+      reason: 'Custom message',
+    });
+  });
+
   describe('flattenParenGroups', () => {
     it('tokenizes mismatched parens with flattenParenGroups=true', () => {
       const result = parseSearch('foo(', {

--- a/static/app/components/searchSyntax/parser.spec.tsx
+++ b/static/app/components/searchSyntax/parser.spec.tsx
@@ -208,7 +208,7 @@ describe('searchSyntax/parser', function () {
     });
   });
 
-  it('applies dissallowNegation', () => {
+  it('applies disallowNegation', () => {
     const result = parseSearch('!foo:bar', {
       disallowNegation: true,
       invalidMessages: {

--- a/static/app/components/searchSyntax/parser.spec.tsx
+++ b/static/app/components/searchSyntax/parser.spec.tsx
@@ -208,7 +208,7 @@ describe('searchSyntax/parser', function () {
     });
   });
 
-  it('applies dissalowNegation', () => {
+  it('applies dissallowNegation', () => {
     const result = parseSearch('!foo:bar', {
       disallowNegation: true,
       invalidMessages: {

--- a/static/app/components/searchSyntax/parser.tsx
+++ b/static/app/components/searchSyntax/parser.tsx
@@ -259,6 +259,7 @@ export enum InvalidReason {
   WILDCARD_NOT_ALLOWED = 'wildcard-not-allowed',
   LOGICAL_OR_NOT_ALLOWED = 'logic-or-not-allowed',
   LOGICAL_AND_NOT_ALLOWED = 'logic-and-not-allowed',
+  NEGATION_NOT_ALLOWED = 'negation-not-allowed',
   MUST_BE_QUOTED = 'must-be-quoted',
   FILTER_MUST_HAVE_VALUE = 'filter-must-have-value',
   INVALID_BOOLEAN = 'invalid-boolean',
@@ -407,7 +408,7 @@ export class TokenConverter {
       value,
       negated,
       operator: operator ?? TermOperator.DEFAULT,
-      invalid: this.checkInvalidFilter(filter, key, value),
+      invalid: this.checkInvalidFilter(filter, key, value, negated),
       warning: this.checkFilterWarning(key),
     } as FilterResult;
 
@@ -748,7 +749,8 @@ export class TokenConverter {
   checkInvalidFilter = <T extends FilterType>(
     filter: T,
     key: FilterMap[T]['key'],
-    value: FilterMap[T]['value']
+    value: FilterMap[T]['value'],
+    negated: FilterMap[T]['negated']
   ) => {
     // Text filter is the "fall through" filter that will match when other
     // filter predicates fail.
@@ -760,6 +762,13 @@ export class TokenConverter {
       return {
         type: InvalidReason.INVALID_KEY,
         reason: t('Invalid key. "%s" is not a supported search key.', key.text),
+      };
+    }
+
+    if (this.config.disallowNegation && negated) {
+      return {
+        type: InvalidReason.NEGATION_NOT_ALLOWED,
+        reason: this.config.invalidMessages[InvalidReason.NEGATION_NOT_ALLOWED],
       };
     }
 
@@ -1165,6 +1174,10 @@ export type SearchConfig = {
    */
   disallowFreeText: boolean;
   /**
+   * Disallow negation for filters
+   */
+  disallowNegation: boolean;
+  /**
    * Disallow wildcards in free text search AND in tag values
    */
   disallowWildcard: boolean;
@@ -1260,6 +1273,7 @@ export const defaultConfig: SearchConfig = {
   disallowedLogicalOperators: new Set(),
   disallowFreeText: false,
   disallowWildcard: false,
+  disallowNegation: false,
   invalidMessages: {
     [InvalidReason.FREE_TEXT_NOT_ALLOWED]: t('Free text is not supported in this search'),
     [InvalidReason.WILDCARD_NOT_ALLOWED]: t('Wildcards not supported in search'),
@@ -1270,6 +1284,7 @@ export const defaultConfig: SearchConfig = {
       'The AND operator is not allowed in this search'
     ),
     [InvalidReason.MUST_BE_QUOTED]: t('Quotes must enclose text or be escaped'),
+    [InvalidReason.NEGATION_NOT_ALLOWED]: t('Negation is not allowed in this search.'),
     [InvalidReason.FILTER_MUST_HAVE_VALUE]: t('Filter must have a value'),
     [InvalidReason.INVALID_BOOLEAN]: t('Invalid boolean. Expected true, 1, false, or 0.'),
     [InvalidReason.INVALID_FILE_SIZE]: t(

--- a/static/app/components/smartSearchBar/index.tsx
+++ b/static/app/components/smartSearchBar/index.tsx
@@ -140,6 +140,7 @@ const pickParserOptions = (props: Props) => {
     disallowedLogicalOperators,
     disallowWildcard,
     disallowFreeText,
+    disallowNegation,
     invalidMessages,
   } = props;
 
@@ -157,6 +158,7 @@ const pickParserOptions = (props: Props) => {
     disallowedLogicalOperators,
     disallowWildcard,
     disallowFreeText,
+    disallowNegation,
     invalidMessages,
   } satisfies Partial<SearchConfig>;
 };
@@ -264,6 +266,10 @@ type Props = WithRouterProps &
      * Disables free text searches
      */
     disallowFreeText?: boolean;
+    /**
+     * Disables negation searches
+     */
+    disallowNegation?: boolean;
     /**
      * Disables wildcard searches (in freeText and in the value of key:value searches mode)
      */
@@ -1627,7 +1633,10 @@ class SmartSearchBar extends Component<DefaultProps & Props, State> {
 
         // show operator group if at beginning of value
         if (cursor === node.location.start.offset) {
-          const opGroup = generateOpAutocompleteGroup(getValidOps(cursorToken), tagName);
+          const opGroup = generateOpAutocompleteGroup(
+            getValidOps(cursorToken, !!this.props.disallowNegation),
+            tagName
+          );
           if (valueGroup?.type !== ItemType.INVALID_TAG && !isDate) {
             autocompleteGroups.unshift(opGroup);
           }
@@ -1645,7 +1654,10 @@ class SmartSearchBar extends Component<DefaultProps & Props, State> {
         const autocompleteGroups = [await this.generateTagAutocompleteGroup(tagName)];
         // show operator group if at end of key
         if (cursor === node.location.end.offset) {
-          const opGroup = generateOpAutocompleteGroup(getValidOps(cursorToken), tagName);
+          const opGroup = generateOpAutocompleteGroup(
+            getValidOps(cursorToken, !!this.props.disallowNegation),
+            tagName
+          );
           autocompleteGroups.unshift(opGroup);
         }
 
@@ -1660,7 +1672,10 @@ class SmartSearchBar extends Component<DefaultProps & Props, State> {
       }
 
       // show operator autocomplete group
-      const opGroup = generateOpAutocompleteGroup(getValidOps(cursorToken), tagName);
+      const opGroup = generateOpAutocompleteGroup(
+        getValidOps(cursorToken, !!this.props.disallowNegation),
+        tagName
+      );
       this.updateAutoCompleteStateMultiHeader([opGroup]);
       return;
     }

--- a/static/app/components/smartSearchBar/utils.tsx
+++ b/static/app/components/smartSearchBar/utils.tsx
@@ -318,7 +318,8 @@ export function generateOperatorEntryMap(tag: string) {
 }
 
 export function getValidOps(
-  filterToken: TokenResult<Token.FILTER>
+  filterToken: TokenResult<Token.FILTER>,
+  disallowNegation: boolean
 ): readonly TermOperator[] {
   // If the token is invalid we want to use the possible expected types as our filter type
   const validTypes = filterToken.invalid?.expectedType ?? [filterToken.filter];
@@ -335,6 +336,10 @@ export function getValidOps(
   const validOps = new Set<TermOperator>(
     allValidTypes.flatMap(type => filterTypeConfig[type].validOps)
   );
+
+  if (disallowNegation) {
+    validOps.delete(TermOperator.NOT_EQUAL);
+  }
 
   return [...validOps];
 }

--- a/static/app/views/settings/projectMetrics/metricsExtractionRuleForm.tsx
+++ b/static/app/views/settings/projectMetrics/metricsExtractionRuleForm.tsx
@@ -67,6 +67,20 @@ const TYPE_OPTIONS = [
   },
 ];
 
+const EMPTY_SET = new Set<never>();
+const SPAN_SEARCH_CONFIG = {
+  booleanKeys: EMPTY_SET,
+  dateKeys: EMPTY_SET,
+  durationKeys: EMPTY_SET,
+  numericKeys: EMPTY_SET,
+  percentageKeys: EMPTY_SET,
+  sizeKeys: EMPTY_SET,
+  textOperatorKeys: EMPTY_SET,
+  disallowFreeText: true,
+  disallowWildcard: true,
+  disallowNegation: true,
+};
+
 export function MetricsExtractionRuleForm({isEdit, project, onSubmit, ...props}: Props) {
   const [customAttributes, setCustomeAttributes] = useState<string[]>(() => {
     const {spanAttribute, tags} = props.initialData;
@@ -175,6 +189,7 @@ export function MetricsExtractionRuleForm({isEdit, project, onSubmit, ...props}:
                         <SearchWrapper hasPrefix={index !== 0}>
                           {index !== 0 && <ConditionLetter>{t('or')}</ConditionLetter>}
                           <SearchBar
+                            {...SPAN_SEARCH_CONFIG}
                             searchSource="metrics-extraction"
                             query={query}
                             onSearch={(queryString: string) =>


### PR DESCRIPTION
Make sure only `equal` and `in` can be used as operators in the query of a metric extraction rule.

Remove not equal from the list of suggested operators.
![Screenshot 2024-06-25 at 12 54 39](https://github.com/getsentry/sentry/assets/7033940/baef0535-8476-4b61-9488-20182ac8c6e2)

Mark filter as invalid when a negation is used.
![Screenshot 2024-06-25 at 12 54 46](https://github.com/getsentry/sentry/assets/7033940/35164071-d6f1-42f1-86f8-7e3b8c851270)


Closes https://github.com/getsentry/sentry/issues/73150