### PR TITLE
fix(metrics): Duplicate name warning spanning use cases

### DIFF
--- a/static/app/components/metrics/mriSelect/index.spec.tsx
+++ b/static/app/components/metrics/mriSelect/index.spec.tsx
@@ -1,10 +1,14 @@
-import type {MetricMeta} from 'sentry/types/metrics';
+import type {MetricMeta, UseCase} from 'sentry/types/metrics';
 
 import {getMetricsWithDuplicateNames} from '.';
 
-function createMetricMeta(name: string, unit: string): MetricMeta {
+function createMetricMeta(
+  name: string,
+  unit: string,
+  useCase: UseCase = 'custom'
+): MetricMeta {
   return {
-    mri: `d:custom/${name}@${unit}`,
+    mri: `d:${useCase}/${name}@${unit}`,
     blockingStatus: [],
     operations: [],
     projectIds: [],
@@ -55,5 +59,17 @@ describe('getMetricsWithDuplicateNames', () => {
     ];
     const result = getMetricsWithDuplicateNames(metrics);
     expect(result).toEqual(new Set());
+  });
+
+  it('should return empty set for duplicates across use cases', () => {
+    const metrics: MetricMeta[] = [
+      createMetricMeta('metric1', 'none', 'custom'),
+      createMetricMeta('metric1', 'seconds', 'metric_stats'),
+      createMetricMeta('metric1', 'milliseconds', 'sessions'),
+      createMetricMeta('metric1', 'bytes', 'spans'),
+      createMetricMeta('metric1', 'bits', 'transactions'),
+    ];
+    const result = getMetricsWithDuplicateNames(metrics);
+    expect(result).toEqual(new Set([]));
   });
 });

--- a/static/app/components/metrics/mriSelect/index.tsx
+++ b/static/app/components/metrics/mriSelect/index.tsx
@@ -66,7 +66,7 @@ export function getMetricsWithDuplicateNames(metrics: MetricMeta[]): Set<MRI> {
 
   for (const metric of metrics) {
     const parsedMri = parseMRI(metric.mri);
-    // Include the use case to avaoid warning of conflicts between different use cases
+    // Include the use case to avoid warning of conflicts between different use cases
     const metricName = `${parsedMri?.useCase}_${parsedMri?.name}`;
     if (!metricName) {
       continue;

--- a/static/app/components/metrics/mriSelect/index.tsx
+++ b/static/app/components/metrics/mriSelect/index.tsx
@@ -65,7 +65,9 @@ export function getMetricsWithDuplicateNames(metrics: MetricMeta[]): Set<MRI> {
   const duplicateNames: string[] = [];
 
   for (const metric of metrics) {
-    const metricName = parseMRI(metric.mri)?.name;
+    const parsedMri = parseMRI(metric.mri);
+    // Include the use case to avaoid warning of conflicts between different use cases
+    const metricName = `${parsedMri?.useCase}_${parsedMri?.name}`;
     if (!metricName) {
       continue;
     }

--- a/static/app/components/metrics/mriSelect/index.tsx
+++ b/static/app/components/metrics/mriSelect/index.tsx
@@ -67,10 +67,7 @@ export function getMetricsWithDuplicateNames(metrics: MetricMeta[]): Set<MRI> {
   for (const metric of metrics) {
     const parsedMri = parseMRI(metric.mri);
     // Include the use case to avoid warning of conflicts between different use cases
-    const metricName = `${parsedMri?.useCase}_${parsedMri?.name}`;
-    if (!metricName) {
-      continue;
-    }
+    const metricName = `${parsedMri.useCase}_${parsedMri.name}`;
 
     if (metricNameMap.has(metricName)) {
       const mapEntry = metricNameMap.get(metricName);
@@ -183,7 +180,7 @@ export const MRISelect = memo(function MRISelect({
 
     // Add the selected metric to the top of the list if it's not already there
     if (result[0]?.mri !== value) {
-      const parsedMri = parseMRI(value)!;
+      const parsedMri = parseMRI(value);
       return [
         {
           mri: value,
@@ -216,7 +213,7 @@ export const MRISelect = memo(function MRISelect({
         if (isDuplicateWithDifferentUnit) {
           trailingItems.push(<IconWarning key="warning" size="xs" color="yellow400" />);
         }
-        if (parseMRI(metric.mri)?.useCase === 'custom' && !mriMode) {
+        if (parseMRI(metric.mri).useCase === 'custom' && !mriMode) {
           trailingItems.push(
             <CustomMetricInfoText key="text">{t('Custom')}</CustomMetricInfoText>
           );


### PR DESCRIPTION
Avoid displaying duplication warnings if the affected metrics are from different use cases. 

Closes https://github.com/getsentry/sentry/issues/73149