### PR TITLE
ref(metrics): Make parseMRI type aware

### DIFF
--- a/static/app/utils/metrics/mri.tsx
+++ b/static/app/utils/metrics/mri.tsx
@@ -18,8 +18,10 @@ export function isMRI(mri?: unknown): mri is MRI {
   }
 }
 
-type ParseResult<T extends MRI | string> = T extends MRI ? ParsedMRI : ParsedMRI | null;
-export function parseMRI<T extends MRI | string>(mri?: T): ParseResult<T> {
+type ParseResult<T extends MRI | string | null> = T extends MRI
+  ? ParsedMRI
+  : ParsedMRI | null;
+export function parseMRI<T extends MRI | string | null>(mri?: T): ParseResult<T> {
   if (!mri) {
     // TODO: How can this be done without casting?
     return null as ParseResult<T>;

--- a/static/app/utils/metrics/mri.tsx
+++ b/static/app/utils/metrics/mri.tsx
@@ -7,10 +7,13 @@ export const DEFAULT_MRI: MRI = 'c:custom/sentry_metric@none';
 export const DEFAULT_METRIC_ALERT_FIELD = `sum(${DEFAULT_MRI})`;
 
 export function isMRI(mri?: unknown): mri is MRI {
+  if (typeof mri !== 'string') {
+    return false;
+  }
   try {
-    _parseMRI(mri as string);
+    _parseMRI(mri);
     return true;
-  } catch (e) {
+  } catch {
     return false;
   }
 }
@@ -23,7 +26,7 @@ export function parseMRI<T extends MRI | string>(mri?: T): ParseResult<T> {
   }
   try {
     return _parseMRI(mri) as ParseResult<T>;
-  } catch (e) {
+  } catch {
     return null as ParseResult<T>;
   }
 }

--- a/static/app/utils/metrics/mri.tsx
+++ b/static/app/utils/metrics/mri.tsx
@@ -7,21 +7,28 @@ export const DEFAULT_MRI: MRI = 'c:custom/sentry_metric@none';
 export const DEFAULT_METRIC_ALERT_FIELD = `sum(${DEFAULT_MRI})`;
 
 export function isMRI(mri?: unknown): mri is MRI {
-  return !!parseMRI(mri);
+  try {
+    _parseMRI(mri as string);
+    return true;
+  } catch (e) {
+    return false;
+  }
 }
 
-export function parseMRI(mri?: unknown): ParsedMRI | null {
+type ParseResult<T extends MRI | string> = T extends MRI ? ParsedMRI : ParsedMRI | null;
+export function parseMRI<T extends MRI | string>(mri?: T): ParseResult<T> {
   if (!mri) {
-    return null;
+    // TODO: How can this be done without casting?
+    return null as ParseResult<T>;
   }
   try {
-    return _parseMRI(mri as MRI);
+    return _parseMRI(mri) as ParseResult<T>;
   } catch (e) {
-    return null;
+    return null as ParseResult<T>;
   }
 }
 
-function _parseMRI(mri: MRI): ParsedMRI {
+function _parseMRI(mri: string): ParsedMRI {
   const mriArray = mri.split(new RegExp(/[:/@]/));
 
   if (mriArray.length !== 4) {


### PR DESCRIPTION
Make `parseMRI` type aware.
Its return type should be `ParseResult` if it is supplied with an MRI.

```ts
parseMRI(string) -> ParseResult | null;
parseMRI(MRI) -> ParseResult;
```

It will enable us to get rid of some casts in the code.