### PR TITLE
chore(trace-explorer): Do not sort traces again when sorting by newest

### DIFF
--- a/static/app/views/traces/content.tsx
+++ b/static/app/views/traces/content.tsx
@@ -174,9 +174,8 @@ export function Content() {
   const isLoading = tracesQuery.isFetching;
   const isError = !isLoading && tracesQuery.isError;
   const isEmpty = !isLoading && !isError && (tracesQuery?.data?.data?.length ?? 0) === 0;
-  const data = normalizeTraces(
-    !isLoading && !isError ? tracesQuery?.data?.data : undefined
-  );
+  const rawData = !isLoading && !isError ? tracesQuery?.data?.data : undefined;
+  const data = sortByTimestamp ? rawData : normalizeTraces(rawData);
 
   return (
     <LayoutMain fullWidth>


### PR DESCRIPTION
If the backend is sorting the traces, we should not apply another sort.