### PR TITLE
ref(trace) use event emitter to schedule events

### DIFF
--- a/static/app/views/performance/newTraceDetails/index.tsx
+++ b/static/app/views/performance/newTraceDetails/index.tsx
@@ -44,6 +44,7 @@ import useOrganization from 'sentry/utils/useOrganization';
 import {useParams} from 'sentry/utils/useParams';
 import useProjects from 'sentry/utils/useProjects';
 import {traceAnalytics} from 'sentry/views/performance/newTraceDetails/traceAnalytics';
+import {TraceScheduler} from 'sentry/views/performance/newTraceDetails/traceRenderers/traceScheduler';
 import {
   type ViewManagerScrollAnchor,
   VirtualizedViewManager,
@@ -259,6 +260,7 @@ export function TraceViewWaterfall(props: TraceViewWaterfallProps) {
   const traceState = useTraceState();
   const traceDispatch = useTraceStateDispatch();
   const traceStateEmitter = useTraceStateEmitter();
+  const traceScheduler = useMemo(() => new TraceScheduler(), []);
 
   const forceRerender = useCallback(() => {
     flushSync(rerender);
@@ -804,11 +806,11 @@ export function TraceViewWaterfall(props: TraceViewWaterfallProps) {
         payload: list_width,
       });
     }
-    viewManager.on('divider resize end', onDividerResizeEnd);
+    traceScheduler.on('divider resize end', onDividerResizeEnd);
     return () => {
-      viewManager.off('divider resize end', onDividerResizeEnd);
+      traceScheduler.off('divider resize end', onDividerResizeEnd);
     };
-  }, [viewManager, traceDispatch]);
+  }, [traceScheduler, traceDispatch]);
 
   // Sync part of the state with the URL
   const traceQueryStateSync = useMemo(() => {
@@ -836,7 +838,6 @@ export function TraceViewWaterfall(props: TraceViewWaterfallProps) {
     }
 
     viewManager.initializeTraceSpace([tree.root.space[0], 0, tree.root.space[1], 1]);
-
     // Whenever the timeline changes, update the trace space
     const onTraceTimelineChange = (s: [number, number]) => {
       viewManager.updateTraceSpace(s[0], s[1]);

--- a/static/app/views/performance/newTraceDetails/trace.tsx
+++ b/static/app/views/performance/newTraceDetails/trace.tsx
@@ -499,7 +499,7 @@ export function Trace({
             >
               <div className="TraceIndicatorLabel">
                 {indicatorTimestamp > 0
-                  ? formatTraceDuration(manager.trace_view.x + indicatorTimestamp)
+                  ? formatTraceDuration(manager.view.trace_view.x + indicatorTimestamp)
                   : '0s'}
               </div>
               <div className="TraceIndicatorLine" />

--- a/static/app/views/performance/newTraceDetails/trace.tsx
+++ b/static/app/views/performance/newTraceDetails/trace.tsx
@@ -30,6 +30,10 @@ import {clamp} from 'sentry/utils/profiling/colors/utils';
 import useApi from 'sentry/utils/useApi';
 import useOrganization from 'sentry/utils/useOrganization';
 import useProjects from 'sentry/utils/useProjects';
+import type {
+  TraceEvents,
+  TraceScheduler,
+} from 'sentry/views/performance/newTraceDetails/traceRenderers/traceScheduler';
 import {
   useVirtualizedList,
   type VirtualizedRow,
@@ -158,6 +162,7 @@ interface TraceProps {
   ) => void;
   previouslyFocusedNodeRef: React.MutableRefObject<TraceTreeNode<TraceTree.NodeValue> | null>;
   rerender: () => void;
+  scheduler: TraceScheduler;
   scrollQueueRef: React.MutableRefObject<
     | {
         eventId?: string;
@@ -180,6 +185,7 @@ export function Trace({
   onTraceSearch,
   onTraceLoad,
   rerender,
+  scheduler,
   initializedRef,
   forceRerender,
 }: TraceProps) {
@@ -205,6 +211,43 @@ export function Trace({
 
   const traceStateRef = useRef<TraceReducerState>(traceState);
   traceStateRef.current = traceState;
+
+  useLayoutEffect(() => {
+    const onTraceViewChange: TraceEvents['set trace view'] = () => {
+      manager.recomputeTimelineIntervals();
+      manager.recomputeSpanToPXMatrix();
+      manager.draw();
+    };
+    const onPhysicalSpaceChange: TraceEvents['set container physical space'] = () => {
+      manager.recomputeTimelineIntervals();
+      manager.recomputeSpanToPXMatrix();
+      manager.draw();
+    };
+    const onTraceSpaceChange: TraceEvents['initialize trace space'] = () => {
+      manager.recomputeTimelineIntervals();
+      manager.recomputeSpanToPXMatrix();
+      manager.draw();
+    };
+    const onDividerResize: TraceEvents['divider resize'] = view => {
+      manager.recomputeTimelineIntervals();
+      manager.recomputeSpanToPXMatrix();
+      manager.draw(view);
+    };
+
+    scheduler.on('set trace view', onTraceViewChange);
+    scheduler.on('set trace space', onTraceSpaceChange);
+    scheduler.on('set container physical space', onPhysicalSpaceChange);
+    scheduler.on('initialize trace space', onTraceSpaceChange);
+    scheduler.on('divider resize', onDividerResize);
+
+    return () => {
+      scheduler.off('set trace view', onTraceViewChange);
+      scheduler.off('set trace space', onTraceSpaceChange);
+      scheduler.off('set container physical space', onPhysicalSpaceChange);
+      scheduler.off('initialize trace space', onTraceSpaceChange);
+      scheduler.off('divider resize', onDividerResize);
+    };
+  }, [manager, scheduler]);
 
   useLayoutEffect(() => {
     if (initializedRef.current) {
@@ -444,6 +487,7 @@ export function Trace({
     items: trace.list,
     container: scrollContainer,
     render: render,
+    scheduler,
   });
 
   const traceNode = trace.root.children[0];

--- a/static/app/views/performance/newTraceDetails/traceDrawer/traceDrawer.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/traceDrawer.tsx
@@ -131,8 +131,7 @@ export function TraceDrawer(props: TraceDrawerProps) {
         props.manager.container
       ) {
         const {width, height} = props.manager.container.getBoundingClientRect();
-        props.manager.initializePhysicalSpace(width, height);
-        props.manager.draw();
+        props.manager.view.initPhysicalSpace(width, height);
       }
 
       minimized = minimized ?? traceStateRef.current.preferences.drawer.minimized;

--- a/static/app/views/performance/newTraceDetails/traceDrawer/traceDrawer.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/traceDrawer.tsx
@@ -32,6 +32,7 @@ import {
   usePassiveResizableDrawer,
   type UsePassiveResizableDrawerOptions,
 } from 'sentry/views/performance/newTraceDetails/traceDrawer/usePassiveResizeableDrawer';
+import type {TraceScheduler} from 'sentry/views/performance/newTraceDetails/traceRenderers/traceScheduler';
 import type {VirtualizedViewManager} from 'sentry/views/performance/newTraceDetails/traceRenderers/virtualizedViewManager';
 import type {
   TraceReducerAction,
@@ -63,6 +64,7 @@ type TraceDrawerProps = {
   onTabScrollToNode: (node: TraceTreeNode<TraceTree.NodeValue>) => void;
   replayRecord: ReplayRecord | null;
   rootEventResults: UseApiQueryResult<EventTransaction, RequestError>;
+  scheduler: TraceScheduler;
   trace: TraceTree;
   traceEventView: EventView;
   traceGridRef: HTMLElement | null;
@@ -131,7 +133,7 @@ export function TraceDrawer(props: TraceDrawerProps) {
         props.manager.container
       ) {
         const {width, height} = props.manager.container.getBoundingClientRect();
-        props.manager.view.initPhysicalSpace(width, height);
+        props.scheduler.dispatch('set container physical space', [0, 0, width, height]);
       }
 
       minimized = minimized ?? traceStateRef.current.preferences.drawer.minimized;
@@ -188,7 +190,7 @@ export function TraceDrawer(props: TraceDrawerProps) {
         props.traceGridRef.style.gridTemplateRows = '1fr auto';
       }
     },
-    [props.traceGridRef, props.manager, traceDispatch]
+    [props.traceGridRef, props.manager, props.scheduler, traceDispatch]
   );
 
   const [drawerRef, setDrawerRef] = useState<HTMLDivElement | null>(null);

--- a/static/app/views/performance/newTraceDetails/traceRenderers/traceScheduler.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceRenderers/traceScheduler.spec.tsx
@@ -1,0 +1,41 @@
+import {TraceScheduler} from 'sentry/views/performance/newTraceDetails/traceRenderers/traceScheduler';
+
+describe('TraceScheduler', () => {
+  it('respects priority', () => {
+    const scheduler = new TraceScheduler();
+
+    const highPriority = jest.fn().mockImplementation(() => {
+      expect(lowPriority).not.toHaveBeenCalled();
+    });
+    const lowPriority = jest.fn().mockImplementation(() => {
+      expect(highPriority).toHaveBeenCalled();
+    });
+
+    // Enquee high priority after low priority
+    scheduler.on('draw', lowPriority, 10);
+    scheduler.on('draw', highPriority, 1);
+    scheduler.dispatch('draw');
+  });
+  it('once', () => {
+    const scheduler = new TraceScheduler();
+
+    const cb = jest.fn();
+    scheduler.once('draw', cb);
+
+    scheduler.dispatch('draw');
+    scheduler.dispatch('draw');
+
+    expect(cb).toHaveBeenCalledTimes(1);
+  });
+
+  it('off', () => {
+    const scheduler = new TraceScheduler();
+    const cb = jest.fn();
+
+    scheduler.on('draw', cb);
+    scheduler.off('draw', cb);
+
+    scheduler.dispatch('draw');
+    expect(cb).not.toHaveBeenCalled();
+  });
+});

--- a/static/app/views/performance/newTraceDetails/traceRenderers/traceScheduler.tsx
+++ b/static/app/views/performance/newTraceDetails/traceRenderers/traceScheduler.tsx
@@ -1,0 +1,48 @@
+type ArgumentTypes<F> = F extends (...args: infer A) => any ? A : never;
+type EventStore = {
+  [K in keyof TraceEvents]: Set<TraceEvents[K]>;
+};
+
+interface TraceEvents {
+  ['divider resize end']: (list_width: number) => void;
+}
+
+export class TraceScheduler {
+  events: EventStore = {
+    ['divider resize end']: new Set<TraceEvents['divider resize end']>(),
+  };
+
+  once<K extends keyof TraceEvents>(eventName: K, cb: Function) {
+    const wrapper = (...args: any[]) => {
+      cb(...args);
+      this.off(eventName, wrapper);
+    };
+    this.on(eventName, wrapper);
+  }
+
+  on<K extends keyof TraceEvents>(eventName: K, cb: TraceEvents[K]): void {
+    const set = this.events[eventName] as unknown as Set<TraceEvents[K]>;
+    if (set.has(cb)) {
+      return;
+    }
+    set.add(cb);
+  }
+
+  off<K extends keyof TraceEvents>(eventName: K, cb: TraceEvents[K]): void {
+    const set = this.events[eventName] as unknown as Set<TraceEvents[K]>;
+
+    if (set.has(cb)) {
+      set.delete(cb);
+    }
+  }
+
+  dispatch<K extends keyof TraceEvents>(
+    event: K,
+    ...args: ArgumentTypes<TraceEvents[K]>
+  ): void {
+    for (const handler of this.events[event]) {
+      // @ts-expect-error
+      handler(...args);
+    }
+  }
+}

--- a/static/app/views/performance/newTraceDetails/traceRenderers/traceScheduler.tsx
+++ b/static/app/views/performance/newTraceDetails/traceRenderers/traceScheduler.tsx
@@ -1,48 +1,93 @@
 type ArgumentTypes<F> = F extends (...args: infer A) => any ? A : never;
 type EventStore = {
-  [K in keyof TraceEvents]: Set<TraceEvents[K]>;
+  [K in keyof TraceEvents]: Array<[number, TraceEvents[K]]>;
 };
 
-interface TraceEvents {
+export enum TraceEventPriority {
+  LOW = 10,
+  MEDIUM = 5,
+  HIGH = 1,
+}
+export interface TraceEvents {
+  ['divider resize']: (view: {list: number; span_list: number}) => void;
   ['divider resize end']: (list_width: number) => void;
-  ['draw']: () => void;
+  ['draw']: (options?: {list?: number; span_list?: number}) => void;
+  ['initialize trace space']: (
+    space: [x: number, y: number, width: number, height: number]
+  ) => void;
+  ['initialize virtualized list']: () => void;
+  ['set container physical space']: (
+    container_space: [x: number, y: number, width: number, height: number]
+  ) => void;
+  ['set trace space']: (
+    space: [x: number, y: number, width: number, height: number]
+  ) => void;
+  ['set trace view']: (view: {width?: number; x?: number}) => void;
 }
 
 export class TraceScheduler {
   events: EventStore = {
-    ['divider resize end']: new Set<TraceEvents['divider resize end']>(),
-    ['draw']: new Set<TraceEvents['draw']>(),
+    ['initialize virtualized list']: new Array<
+      [TraceEventPriority, TraceEvents['initialize virtualized list']]
+    >(),
+    ['set container physical space']: new Array<
+      [TraceEventPriority, TraceEvents['set container physical space']]
+    >(),
+    ['initialize trace space']: new Array<
+      [TraceEventPriority, TraceEvents['initialize trace space']]
+    >(),
+    ['set trace space']: new Array<
+      [TraceEventPriority, TraceEvents['set trace space']]
+    >(),
+    ['divider resize end']: new Array<
+      [TraceEventPriority, TraceEvents['divider resize end']]
+    >(),
+    ['divider resize']: new Array<[TraceEventPriority, TraceEvents['divider resize']]>(),
+    ['set trace view']: new Array<[TraceEventPriority, TraceEvents['set trace view']]>(),
+    ['draw']: new Array<[TraceEventPriority, TraceEvents['draw']]>(),
   };
 
-  once<K extends keyof TraceEvents>(eventName: K, cb: Function) {
+  once<K extends keyof TraceEvents>(eventName: K, cb: TraceEvents[K]) {
     const wrapper = (...args: any[]) => {
+      // @ts-expect-error
       cb(...args);
       this.off(eventName, wrapper);
     };
+
     this.on(eventName, wrapper);
   }
 
-  on<K extends keyof TraceEvents>(eventName: K, cb: TraceEvents[K]): void {
-    const set = this.events[eventName] as unknown as Set<TraceEvents[K]>;
-    if (set.has(cb)) {
+  on<K extends keyof TraceEvents>(
+    eventName: K,
+    cb: TraceEvents[K],
+    priority: TraceEventPriority = 10
+  ): void {
+    const arr = this.events[eventName];
+    if (!arr || arr.some(a => a[1] === cb)) {
       return;
     }
-    set.add(cb);
+    arr.push([priority, cb]);
+    arr.sort((a, b) => a[0] - b[0]);
   }
 
   off<K extends keyof TraceEvents>(eventName: K, cb: TraceEvents[K]): void {
-    const set = this.events[eventName] as unknown as Set<TraceEvents[K]>;
+    const arr = this.events[eventName];
 
-    if (set.has(cb)) {
-      set.delete(cb);
+    if (!arr) {
+      return;
     }
+
+    // @ts-expect-error - filter out the callback
+    this.events[eventName] = arr.filter(a => a[1] !== cb) as unknown as Array<
+      [TraceEventPriority, K]
+    >;
   }
 
   dispatch<K extends keyof TraceEvents>(
-    event: K,
+    eventName: K,
     ...args: ArgumentTypes<TraceEvents[K]>
   ): void {
-    for (const handler of this.events[event]) {
+    for (const [_priority, handler] of this.events[eventName]) {
       // @ts-expect-error
       handler(...args);
     }

--- a/static/app/views/performance/newTraceDetails/traceRenderers/traceScheduler.tsx
+++ b/static/app/views/performance/newTraceDetails/traceRenderers/traceScheduler.tsx
@@ -5,11 +5,13 @@ type EventStore = {
 
 interface TraceEvents {
   ['divider resize end']: (list_width: number) => void;
+  ['draw']: () => void;
 }
 
 export class TraceScheduler {
   events: EventStore = {
     ['divider resize end']: new Set<TraceEvents['divider resize end']>(),
+    ['draw']: new Set<TraceEvents['draw']>(),
   };
 
   once<K extends keyof TraceEvents>(eventName: K, cb: Function) {

--- a/static/app/views/performance/newTraceDetails/traceRenderers/traceView.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceRenderers/traceView.spec.tsx
@@ -1,0 +1,42 @@
+import {TraceView} from './traceView';
+
+describe('TraceView', () => {
+  it('does not allow setting trace view width to 0', () => {
+    const view = new TraceView();
+
+    view.setTraceView({width: 0});
+    expect(view.trace_view.width).toBeGreaterThan(0);
+  });
+
+  describe('getConfigSpaceCursor', () => {
+    it('returns the correct x position', () => {
+      const view = new TraceView();
+
+      view.setTraceSpace([0, 0, 100, 1]);
+      view.setTracePhysicalSpace([0, 0, 1000, 1], [0, 0, 1000, 1]);
+
+      expect(view.getConfigSpaceCursor({x: 500, y: 0})).toEqual([50, 0]);
+    });
+
+    it('returns the correct x position when view scaled', () => {
+      const view = new TraceView();
+
+      view.setTraceSpace([0, 0, 100, 1]);
+      view.setTracePhysicalSpace([0, 0, 1000, 1], [0, 0, 1000, 1]);
+      view.setTraceView({x: 50, width: 50});
+
+      expect(view.getConfigSpaceCursor({x: 500, y: 0})).toEqual([75, 0]);
+    });
+
+    it('returns the correct x position when view is offset', () => {
+      const view = new TraceView();
+
+      view.setTraceSpace([0, 0, 100, 1]);
+      view.setTracePhysicalSpace([0, 0, 1000, 1], [0, 0, 1000, 1]);
+      view.setTraceView({x: 50, width: 50});
+
+      // Half of the right quadrant
+      expect(view.getConfigSpaceCursor({x: 500, y: 0})).toEqual([75, 0]);
+    });
+  });
+});

--- a/static/app/views/performance/newTraceDetails/traceRenderers/traceView.tsx
+++ b/static/app/views/performance/newTraceDetails/traceRenderers/traceView.tsx
@@ -1,8 +1,139 @@
 import {mat3} from 'gl-matrix';
 
+import clamp from 'sentry/utils/number/clamp';
+
 // Computes the transformation matrix that is used to render scaled
 // elements to the DOM and draw the view.
+
 export class TraceView {
+  // Represents the space of the entire trace, for example
+  // a trace starting at 0 and ending at 1000 would have a space of [0, 1000]
+  to_origin: number = 0;
+  trace_space: DOMView = DOMView.Empty();
+  // The view defines what the user is currently looking at, it is a subset
+  // of the trace space. For example, if the user is currently looking at the
+  // trace from 500 to 1000, the view would be represented by [x, width] = [500, 500]
+  trace_view: DOMView = DOMView.Empty();
+  // Represents the pixel space of the entire trace - this is the container
+  // that we render to. For example, if the container is 1000px wide, the
+  // pixel space would be [0, 1000]
+  trace_physical_space: DOMView = DOMView.Empty();
+  // the encapsulating container that the entire view is rendered to
+  trace_container_physical_space: DOMView = DOMView.Empty();
+
+  span_to_px: mat3 = mat3.create();
+
+  private readonly MAX_ZOOM_PRECISION_MS = 1;
+  private readonly span_matrix: [number, number, number, number, number, number] = [
+    1, 0, 0, 1, 0, 0,
+  ];
+
+  initConfigSpace() {
+    this.trace_space = new DOMView(0, 0, this.to_origin, 1);
+  }
+
+  // @todo: both init methods should recompute intervals
+  initTraceSpace(space: [x: number, y: number, width: number, height: number]) {
+    this.to_origin = space[0];
+
+    this.trace_space = new DOMView(0, 0, space[2], space[3]);
+    this.trace_view = new DOMView(0, 0, space[2], space[3]);
+
+    this.recomputeSpanToPxMatrix();
+  }
+
+  initPhysicalSpace(container_width: number, container_height: number) {
+    this.trace_container_physical_space = new DOMView(
+      0,
+      0,
+      container_width,
+      container_height
+    );
+    this.trace_physical_space = new DOMView(0, 0, container_width, container_height);
+
+    this.recomputeSpanToPxMatrix();
+  }
+
+  setTraceView(view: {width?: number; x?: number}) {
+    // In cases where a trace might have a single error, there is no concept of a timeline
+    if (this.trace_view.width === 0) {
+      return;
+    }
+
+    const x = view.x ?? this.trace_view.x;
+    const width = view.width ?? this.trace_view.width;
+
+    this.trace_view.width = clamp(
+      width,
+      this.MAX_ZOOM_PRECISION_MS,
+      this.trace_space.width - this.trace_view.x
+    );
+    this.trace_view.x = clamp(
+      x,
+      0,
+      Math.max(this.trace_space.width - width, this.MAX_ZOOM_PRECISION_MS)
+    );
+
+    this.recomputeSpanToPxMatrix();
+  }
+
+  updateTraceSpace(start: number, width: number) {
+    if (this.trace_space.width === width && this.to_origin === start) {
+      return;
+    }
+
+    this.to_origin = start;
+
+    // If view is scaled all the way out, then lets update it to match the new space, else
+    // we are implicitly zooming in, which may be even more confusing.
+    const preventImplicitZoom = this.trace_view.width === this.trace_space.width;
+    this.trace_space = new DOMView(0, 0, width, 1);
+    if (preventImplicitZoom) {
+      this.setTraceView({x: 0, width});
+    }
+
+    this.recomputeSpanToPxMatrix();
+  }
+
+  recomputeSpanToPxMatrix() {
+    const traceViewToSpace = this.trace_space.between(this.trace_view);
+    const tracePhysicalToView = this.trace_physical_space.between(this.trace_space);
+
+    this.span_to_px = mat3.multiply(
+      this.span_to_px,
+      traceViewToSpace,
+      tracePhysicalToView
+    );
+  }
+
+  computeSpanCSSMatrixTransform(
+    space: [number, number]
+  ): [number, number, number, number, number, number] {
+    const scale = space[1] / this.trace_view.width;
+    this.span_matrix[0] = Math.max(scale, this.span_to_px[0] / this.trace_view.width);
+    this.span_matrix[4] =
+      (space[0] - this.to_origin) / this.span_to_px[0] -
+      this.trace_view.x / this.span_to_px[0];
+
+    return this.span_matrix;
+  }
+
+  transformXFromTimestamp(timestamp: number): number {
+    return (timestamp - this.to_origin - this.trace_view.x) / this.span_to_px[0];
+  }
+
+  getConfigSpaceCursor(cursor: {x: number; y: number}): [number, number] {
+    const left_percentage = cursor.x / this.trace_physical_space.width;
+    const left_view = left_percentage * this.trace_view.width;
+
+    return [this.trace_view.x + left_view, 0];
+  }
+}
+
+/**
+ * Helper class that handles computing transformations between different views to and from DOM space
+ */
+class DOMView {
   public x: number;
   public y: number;
   public width: number;
@@ -15,18 +146,18 @@ export class TraceView {
     this.height = height;
   }
 
-  static From(view: TraceView): TraceView {
-    return new TraceView(view.x, view.y, view.width, view.height);
+  static From(view: DOMView): DOMView {
+    return new DOMView(view.x, view.y, view.width, view.height);
   }
-  static Empty(): TraceView {
-    return new TraceView(0, 0, 1000, 1);
+  static Empty(): DOMView {
+    return new DOMView(0, 0, 1000, 1);
   }
 
   serialize() {
     return [this.x, this.y, this.width, this.height];
   }
 
-  between(to: TraceView): mat3 {
+  between(to: DOMView): mat3 {
     return mat3.fromValues(
       to.width / this.width,
       0,

--- a/static/app/views/performance/newTraceDetails/traceRenderers/traceVirtualizedList.tsx
+++ b/static/app/views/performance/newTraceDetails/traceRenderers/traceVirtualizedList.tsx
@@ -5,6 +5,7 @@ import type {
   TraceTree,
   TraceTreeNode,
 } from 'sentry/views/performance/newTraceDetails/traceModels/traceTree';
+import type {TraceScheduler} from 'sentry/views/performance/newTraceDetails/traceRenderers/traceScheduler';
 import {
   VirtualizedList,
   type VirtualizedViewManager,
@@ -21,6 +22,7 @@ interface UseVirtualizedListProps {
   items: ReadonlyArray<TraceTreeNode<TraceTree.NodeValue>>;
   manager: VirtualizedViewManager;
   render: (item: VirtualizedRow) => React.ReactNode;
+  scheduler: TraceScheduler;
 }
 
 interface UseVirtualizedListResult {
@@ -148,6 +150,8 @@ export const useVirtualizedList = (
     scrollContainerRef.current!.style.willChange = 'transform';
     scrollContainerRef.current!.style.height = `${props.items.length * 24}px`;
 
+    props.scheduler.dispatch('initialize virtualized list');
+
     maybeToggleScrollbar(
       props.container,
       scrollHeightRef.current,
@@ -223,7 +227,7 @@ export const useVirtualizedList = (
     return () => {
       props.container?.removeEventListener('scroll', onScroll);
     };
-  }, [props.container, props.items, props.items.length, props.manager]);
+  }, [props.container, props.items, props.items.length, props.manager, props.scheduler]);
 
   useLayoutEffect(() => {
     if (!list.current || !styleCache.current || !renderCache.current) {

--- a/static/app/views/performance/newTraceDetails/traceRenderers/traceVirtualizedList.tsx
+++ b/static/app/views/performance/newTraceDetails/traceRenderers/traceVirtualizedList.tsx
@@ -148,8 +148,6 @@ export const useVirtualizedList = (
     scrollContainerRef.current!.style.willChange = 'transform';
     scrollContainerRef.current!.style.height = `${props.items.length * 24}px`;
 
-    managerRef.current.dispatch('virtualized list init');
-
     maybeToggleScrollbar(
       props.container,
       scrollHeightRef.current,

--- a/static/app/views/performance/newTraceDetails/traceRenderers/virtualizedViewManager.tsx
+++ b/static/app/views/performance/newTraceDetails/traceRenderers/virtualizedViewManager.tsx
@@ -662,7 +662,7 @@ export class VirtualizedViewManager {
     this.scheduler.dispatch('set trace view', {x, width});
   }
 
-  enqueueFOVQueryParamSync() {
+  enqueueFOVQueryParamSync(view: TraceView) {
     if (this.timers.onFovChange !== null) {
       window.cancelAnimationFrame(this.timers.onFovChange.id);
     }
@@ -672,7 +672,7 @@ export class VirtualizedViewManager {
         pathname: location.pathname,
         query: {
           ...qs.parse(location.search),
-          fov: `${this.view.trace_view.x},${this.view.trace_view.width}`,
+          fov: `${view.trace_view.x},${view.trace_view.width}`,
         },
       });
       this.timers.onFovChange = null;
@@ -926,12 +926,9 @@ export class VirtualizedViewManager {
   }
 
   animateScrollColumnTo(x: number, duration: number) {
-    const start = performance.now();
-
-    const startPosition = this.columns.list.translate[0];
-    const distance = x - startPosition;
-
     if (duration === 0) {
+      this.columns.list.translate[0] = x;
+
       const rows = Array.from(
         document.querySelectorAll('.TraceRow .TraceLeftColumn > div')
       ) as HTMLElement[];
@@ -940,13 +937,16 @@ export class VirtualizedViewManager {
         row.style.transform = `translateX(${this.columns.list.translate[0]}px)`;
       }
 
-      this.columns.list.translate[0] = x;
       if (this.horizontal_scrollbar_container) {
         this.horizontal_scrollbar_container.scrollLeft = -x;
       }
       dispatchJestScrollUpdate(this.horizontal_scrollbar_container!);
       return;
     }
+
+    const start = performance.now();
+    const startPosition = this.columns.list.translate[0];
+    const distance = x - startPosition;
 
     const animate = (now: number) => {
       const elapsed = now - start;

--- a/static/app/views/performance/newTraceDetails/traceRenderers/virtualizedViewManager.tsx
+++ b/static/app/views/performance/newTraceDetails/traceRenderers/virtualizedViewManager.tsx
@@ -1685,6 +1685,7 @@ function getIconTimestamps(
   span_space: [number, number],
   icon_width: number
 ) {
+<<<<<<< HEAD
   let min_icon_timestamp = span_space[0];
   let max_icon_timestamp = span_space[0] + span_space[1];
 
@@ -1692,6 +1693,15 @@ function getIconTimestamps(
     return [min_icon_timestamp, max_icon_timestamp];
   }
 
+=======
+  if (!node.errors.size && !node.performance_issues.size) {
+    return [span_space[0], span_space[0] + span_space[1]];
+  }
+
+  let min_icon_timestamp = span_space[0];
+  let max_icon_timestamp = span_space[0] + span_space[1];
+
+>>>>>>> 7d674571dd1 (fix(trace) fix icon positioning by extending the window)
   for (const issue of node.performance_issues) {
     // Perf issues render icons at the start timestamp
     if (typeof issue.start === 'number') {

--- a/static/app/views/performance/newTraceDetails/traceRenderers/virtualizedViewManager.tsx
+++ b/static/app/views/performance/newTraceDetails/traceRenderers/virtualizedViewManager.tsx
@@ -11,7 +11,9 @@ import type {
 } from 'sentry/views/performance/newTraceDetails/traceModels/traceTree';
 import {TraceRowWidthMeasurer} from 'sentry/views/performance/newTraceDetails/traceRenderers/traceRowWidthMeasurer';
 import {TraceTextMeasurer} from 'sentry/views/performance/newTraceDetails/traceRenderers/traceTextMeasurer';
-import {TraceView} from 'sentry/views/performance/newTraceDetails/traceRenderers/traceView';
+import type {TraceView} from 'sentry/views/performance/newTraceDetails/traceRenderers/traceView';
+
+import type {TraceScheduler} from './traceScheduler';
 
 const DIVIDER_WIDTH = 6;
 
@@ -46,20 +48,6 @@ type VerticalIndicator = {
 export type ViewManagerScrollAnchor = 'top' | 'center if outside' | 'center';
 
 export class VirtualizedViewManager {
-  // Represents the space of the entire trace, for example
-  // a trace starting at 0 and ending at 1000 would have a space of [0, 1000]
-  to_origin: number = 0;
-  trace_space: TraceView = TraceView.Empty();
-  // The view defines what the user is currently looking at, it is a subset
-  // of the trace space. For example, if the user is currently looking at the
-  // trace from 500 to 1000, the view would be represented by [x, width] = [500, 500]
-  trace_view: TraceView = TraceView.Empty();
-  // Represents the pixel space of the entire trace - this is the container
-  // that we render to. For example, if the container is 1000px wide, the
-  // pixel space would be [0, 1000]
-  trace_physical_space: TraceView = TraceView.Empty();
-  container_physical_space: TraceView = TraceView.Empty();
-
   row_measurer: TraceRowWidthMeasurer<TraceTreeNode<TraceTree.NodeValue>> =
     new TraceRowWidthMeasurer();
   indicator_label_measurer: TraceRowWidthMeasurer<TraceTree['indicators'][0]> =
@@ -89,6 +77,7 @@ export class VirtualizedViewManager {
   indicators: ({indicator: TraceTree['indicators'][0]; ref: HTMLElement} | undefined)[] =
     [];
   timeline_indicators: (HTMLElement | undefined)[] = [];
+  vertical_indicators: {[key: string]: VerticalIndicator} = {};
   span_bars: ({color: string; ref: HTMLElement; space: [number, number]} | undefined)[] =
     [];
   span_patterns: ({ref: HTMLElement; space: [number, number]} | undefined)[][] = [];
@@ -105,16 +94,12 @@ export class VirtualizedViewManager {
   span_text: ({ref: HTMLElement; space: [number, number]; text: string} | undefined)[] =
     [];
 
-  // Holds the span to px matrix so we dont keep recalculating it
-  span_to_px: mat3 = mat3.create();
   row_depth_padding: number = 22;
 
   // Smallest of time that can be displayed across the entire view.
   private readonly MAX_ZOOM_PRECISION = 1;
   private readonly ROW_PADDING_PX = 16;
   private scrollbar_width: number = 0;
-
-  vertical_indicators: {[key: string]: VerticalIndicator} = {};
 
   timers: {
     onFovChange: {id: number} | null;
@@ -132,11 +117,17 @@ export class VirtualizedViewManager {
 
   // Column configuration
   columns: Record<'list' | 'span_list', ViewColumn>;
+  scheduler: TraceScheduler;
+  view: TraceView;
 
-  constructor(columns: {
-    list: Pick<ViewColumn, 'width'>;
-    span_list: Pick<ViewColumn, 'width'>;
-  }) {
+  constructor(
+    columns: {
+      list: Pick<ViewColumn, 'width'>;
+      span_list: Pick<ViewColumn, 'width'>;
+    },
+    trace_scheduler: TraceScheduler,
+    trace_view: TraceView
+  ) {
     this.columns = {
       list: {...columns.list, column_nodes: [], column_refs: [], translate: [0, 0]},
       span_list: {
@@ -146,6 +137,8 @@ export class VirtualizedViewManager {
         translate: [0, 0],
       },
     };
+    this.scheduler = trace_scheduler;
+    this.view = trace_view;
 
     this.registerResetZoomRef = this.registerResetZoomRef.bind(this);
     this.registerContainerRef = this.registerContainerRef.bind(this);
@@ -165,48 +158,6 @@ export class VirtualizedViewManager {
     this.onHorizontalScrollbarScroll = this.onHorizontalScrollbarScroll.bind(this);
   }
 
-  updateTraceSpace(start: number, width: number) {
-    if (this.trace_space.width === width && this.to_origin === start) {
-      return;
-    }
-
-    this.to_origin = start;
-
-    // If view is scaled all the way out, then lets update it to match the new space, else
-    // we are implicitly zooming in, which may be even more confusing.
-    const preventImplicitZoom = this.trace_view.width === this.trace_space.width;
-    this.trace_space = new TraceView(0, 0, width, 1);
-    if (preventImplicitZoom) {
-      this.setTraceView({x: 0, width});
-    }
-
-    this.recomputeTimelineIntervals();
-    this.recomputeSpanToPxMatrix();
-  }
-
-  initializeTraceSpace(space: [x: number, y: number, width: number, height: number]) {
-    this.to_origin = space[0];
-
-    this.trace_space = new TraceView(0, 0, space[2], space[3]);
-    this.trace_view = new TraceView(0, 0, space[2], space[3]);
-
-    this.recomputeTimelineIntervals();
-    this.recomputeSpanToPxMatrix();
-  }
-
-  initializePhysicalSpace(width: number, height: number) {
-    this.container_physical_space = new TraceView(0, 0, width, height);
-    this.trace_physical_space = new TraceView(
-      0,
-      0,
-      width * this.columns.span_list.width,
-      height
-    );
-
-    this.recomputeTimelineIntervals();
-    this.recomputeSpanToPxMatrix();
-  }
-
   dividerScale: 1 | undefined = undefined;
   dividerStartVec: [number, number] | null = null;
   previousDividerClientVec: [number, number] | null = null;
@@ -216,7 +167,8 @@ export class VirtualizedViewManager {
       return;
     }
 
-    this.dividerScale = this.trace_view.width === this.trace_space.width ? 1 : undefined;
+    this.dividerScale =
+      this.view.trace_view.width === this.view.trace_space.width ? 1 : undefined;
     this.dividerStartVec = [event.clientX, event.clientY];
     this.previousDividerClientVec = [event.clientX, event.clientY];
 
@@ -236,7 +188,7 @@ export class VirtualizedViewManager {
 
     this.dividerScale = undefined;
     const distance = event.clientX - this.dividerStartVec[0];
-    const distancePercentage = distance / this.container_physical_space.width;
+    const distancePercentage = distance / this.view.trace_container_physical_space.width;
 
     this.columns.list.width = this.columns.list.width + distancePercentage;
     this.columns.span_list.width = this.columns.span_list.width - distancePercentage;
@@ -251,7 +203,7 @@ export class VirtualizedViewManager {
     document.removeEventListener('mouseup', this.onDividerMouseUp);
     document.removeEventListener('mousemove', this.onDividerMouseMove);
 
-    this.dispatch('divider resize end', this.columns.list.width);
+    this.scheduler.dispatch('divider resize end', this.columns.list.width);
   }
 
   onDividerMouseMove(event: MouseEvent) {
@@ -260,23 +212,23 @@ export class VirtualizedViewManager {
     }
 
     const distance = event.clientX - this.dividerStartVec[0];
-    const distancePercentage = distance / this.container_physical_space.width;
+    const distancePercentage = distance / this.view.trace_container_physical_space.width;
 
-    this.trace_physical_space.width =
+    this.view.trace_physical_space.width =
       (this.columns.span_list.width - distancePercentage) *
-      this.container_physical_space.width;
+      this.view.trace_container_physical_space.width;
 
     const physical_distance = this.previousDividerClientVec[0] - event.clientX;
-    const config_distance_pct = physical_distance / this.trace_physical_space.width;
-    const config_distance = this.trace_view.width * config_distance_pct;
+    const config_distance_pct = physical_distance / this.view.trace_physical_space.width;
+    const config_distance = this.view.trace_view.width * config_distance_pct;
 
     if (this.dividerScale) {
       // just recompute the draw matrix and let the view scale itself
-      this.recomputeSpanToPxMatrix();
+      this.view.recomputeSpanToPxMatrix();
     } else {
-      this.setTraceView({
-        x: this.trace_view.x - config_distance,
-        width: this.trace_view.width + config_distance,
+      this.view.setTraceView({
+        x: this.view.trace_view.x - config_distance,
+        width: this.view.trace_view.width + config_distance,
       });
     }
     this.recomputeTimelineIntervals();
@@ -293,7 +245,6 @@ export class VirtualizedViewManager {
       return;
     }
     this.scrollbar_width = width;
-    this.draw();
   }
 
   registerContainerRef(container: HTMLElement | null) {
@@ -385,7 +336,7 @@ export class VirtualizedViewManager {
     if (ref) {
       this.invisible_bars[index] = ref ? {ref, space} : undefined;
 
-      const span_transform = this.computeSpanCSSMatrixTransform(space);
+      const span_transform = this.view.computeSpanCSSMatrixTransform(space);
       ref.style.transform = `matrix(${span_transform.join(',')}`;
       const inverseScale = Math.round((1 / span_transform[0]) * 1e4) / 1e4;
       ref.style.setProperty(
@@ -443,7 +394,7 @@ export class VirtualizedViewManager {
       }
 
       ref.addEventListener('wheel', this.onWheel, {passive: false});
-      ref.style.transform = `translateX(${this.computeTransformXFromTimestamp(
+      ref.style.transform = `translateX(${this.view.transformXFromTimestamp(
         indicator.start
       )}px)`;
     }
@@ -479,13 +430,6 @@ export class VirtualizedViewManager {
     this.horizontal_scrollbar_container = ref;
   }
 
-  getConfigSpaceCursor(cursor: {x: number; y: number}): [number, number] {
-    const left_percentage = cursor.x / this.trace_physical_space.width;
-    const left_view = left_percentage * this.trace_view.width;
-
-    return [this.trace_view.x + left_view, 0];
-  }
-
   onWheel(event: WheelEvent) {
     if (event.metaKey || event.ctrlKey) {
       event.preventDefault();
@@ -503,7 +447,7 @@ export class VirtualizedViewManager {
 
       const scale = 1 - event.deltaY * 0.01 * -1;
       const x = offsetX > 0 ? event.clientX - offsetX : event.offsetX;
-      const configSpaceCursor = this.getConfigSpaceCursor({
+      const configSpaceCursor = this.view.getConfigSpaceCursor({
         x: x,
         y: 0,
       });
@@ -519,16 +463,15 @@ export class VirtualizedViewManager {
         vec2.fromValues(-center[0], 0)
       );
 
-      const newView = this.trace_view.transform(centerScaleMatrix);
+      const newView = this.view.trace_view.transform(centerScaleMatrix);
 
       // When users zoom in, the matrix will compute a width value that is lower than the min,
       // which results in the value of x being incorrectly set and the view moving to the right.
       // To prevent this, we will only update the x position if the new width is greater than the min zoom precision.
-      this.setTraceView({
-        x: newView[2] < this.MAX_ZOOM_PRECISION ? this.trace_view.x : newView[0],
+      this.view.setTraceView({
+        x: newView[2] < this.MAX_ZOOM_PRECISION ? this.view.trace_view.x : newView[0],
         width: newView[2],
       });
-      this.draw();
     } else {
       if (!this.timers.onWheelEnd) {
         this.onWheelStart();
@@ -547,13 +490,12 @@ export class VirtualizedViewManager {
         event.preventDefault();
       }
 
-      const physical_delta_pct = distance / this.trace_physical_space.width;
-      const view_delta = physical_delta_pct * this.trace_view.width;
+      const physical_delta_pct = distance / this.view.trace_physical_space.width;
+      const view_delta = physical_delta_pct * this.view.trace_view.width;
 
-      this.setTraceView({
-        x: this.trace_view.x + view_delta,
+      this.view.setTraceView({
+        x: this.view.trace_view.x + view_delta,
       });
-      this.draw();
     }
   }
 
@@ -563,33 +505,35 @@ export class VirtualizedViewManager {
       this.timers.onZoomIntoSpace = null;
     }
 
-    if (space[0] - this.to_origin > this.trace_view.x) {
+    if (space[0] - this.view.to_origin > this.view.trace_view.x) {
       this.onZoomIntoSpace([
-        space[0] + space[1] / 2 - this.trace_view.width / 2,
-        this.trace_view.width,
+        space[0] + space[1] / 2 - this.view.trace_view.width / 2,
+        this.view.trace_view.width,
       ]);
-    } else if (space[0] - this.to_origin < this.trace_view.x) {
+    } else if (space[0] - this.view.to_origin < this.view.trace_view.x) {
       this.onZoomIntoSpace([
-        space[0] + space[1] / 2 - this.trace_view.width / 2,
-        this.trace_view.width,
+        space[0] + space[1] / 2 - this.view.trace_view.width / 2,
+        this.view.trace_view.width,
       ]);
     }
   }
 
   animateViewTo(node_space: [number, number]) {
     const start = node_space[0];
-    const width = node_space[1] > 0 ? node_space[1] : this.trace_view.width;
+    const width = node_space[1] > 0 ? node_space[1] : this.view.trace_view.width;
     const margin = 0.2 * width;
 
-    this.setTraceView({x: start - margin - this.to_origin, width: width + margin * 2});
-    this.draw();
+    this.view.setTraceView({
+      x: start - margin - this.view.to_origin,
+      width: width + margin * 2,
+    });
   }
 
   onZoomIntoSpace(space: [number, number]) {
-    let distance_x = space[0] - this.to_origin - this.trace_view.x;
-    let final_x = space[0] - this.to_origin;
+    let distance_x = space[0] - this.view.to_origin - this.view.trace_view.x;
+    let final_x = space[0] - this.view.to_origin;
     let final_width = space[1];
-    const distance_width = this.trace_view.width - space[1];
+    const distance_width = this.view.trace_view.width - space[1];
 
     if (space[1] < this.MAX_ZOOM_PRECISION) {
       distance_x -= this.MAX_ZOOM_PRECISION / 2 - space[1] / 2;
@@ -597,8 +541,8 @@ export class VirtualizedViewManager {
       final_width = this.MAX_ZOOM_PRECISION;
     }
 
-    const start_x = this.trace_view.x;
-    const start_width = this.trace_view.width;
+    const start_x = this.view.trace_view.x;
+    const start_width = this.view.trace_view.width;
 
     const max_distance = Math.max(Math.abs(distance_x), Math.abs(distance_width));
     const p = max_distance !== 0 ? Math.log10(max_distance) : 1;
@@ -616,15 +560,13 @@ export class VirtualizedViewManager {
       const x = start_x + distance_x * eased;
       const width = start_width - distance_width * eased;
 
-      this.setTraceView({x, width});
-      this.draw();
+      this.view.setTraceView({x, width});
 
       if (progress < 1) {
         this.timers.onZoomIntoSpace = window.requestAnimationFrame(rafCallback);
       } else {
         this.timers.onZoomIntoSpace = null;
-        this.setTraceView({x: final_x, width: final_width});
-        this.draw();
+        this.view.setTraceView({x: final_x, width: final_width});
       }
     };
 
@@ -632,7 +574,7 @@ export class VirtualizedViewManager {
   }
 
   resetZoom() {
-    this.onZoomIntoSpace([this.to_origin, this.trace_space.width]);
+    this.onZoomIntoSpace([this.view.to_origin, this.view.trace_space.width]);
   }
 
   enqueueOnWheelEndRaf() {
@@ -701,40 +643,14 @@ export class VirtualizedViewManager {
       return;
     }
 
-    if (width <= 0 || width > this.trace_space.width) {
+    if (width <= 0 || width > this.view.trace_space.width) {
       return;
     }
 
-    if (x < 0 || x > this.trace_space.width) {
+    if (x < 0 || x > this.view.trace_space.width) {
       return;
     }
-    this.setTraceView({x, width});
-  }
-
-  setTraceView(view: {width?: number; x?: number}) {
-    // In cases where a trace might have a single error, there is no concept of a timeline
-    if (this.trace_view.width === 0) {
-      return;
-    }
-
-    const x = view.x ?? this.trace_view.x;
-    const width = view.width ?? this.trace_view.width;
-
-    this.trace_view.width = clamp(
-      width,
-      this.MAX_ZOOM_PRECISION,
-      this.trace_space.width - this.trace_view.x
-    );
-    this.trace_view.x = clamp(
-      x,
-      0,
-      Math.max(this.trace_space.width - width, this.MAX_ZOOM_PRECISION)
-    );
-
-    this.recomputeTimelineIntervals();
-    this.recomputeSpanToPxMatrix();
-    this.enqueueFOVQueryParamSync();
-    this.syncResetZoomButton();
+    this.view.setTraceView({x, width});
   }
 
   enqueueFOVQueryParamSync() {
@@ -747,7 +663,7 @@ export class VirtualizedViewManager {
         pathname: location.pathname,
         query: {
           ...qs.parse(location.search),
-          fov: `${this.trace_view.x},${this.trace_view.width}`,
+          fov: `${this.view.trace_view.x},${this.view.trace_view.width}`,
         },
       });
       this.timers.onFovChange = null;
@@ -771,7 +687,8 @@ export class VirtualizedViewManager {
   syncResetZoomButton() {
     if (!this.reset_zoom_button) return;
     this.reset_zoom_button.disabled =
-      this.trace_view.x === 0 && this.trace_view.width === this.trace_space.width;
+      this.view.trace_view.x === 0 &&
+      this.view.trace_view.width === this.view.trace_space.width;
   }
 
   maybeSyncViewWithVerticalIndicator(key: string) {
@@ -780,12 +697,11 @@ export class VirtualizedViewManager {
       return;
     }
 
-    const timestamp = indicator.timestamp - this.to_origin;
-    this.setTraceView({
-      x: timestamp - this.trace_view.width / 2,
-      width: this.trace_view.width,
+    const timestamp = indicator.timestamp - this.view.to_origin;
+    this.view.setTraceView({
+      x: timestamp - this.view.trace_view.width / 2,
+      width: this.view.trace_view.width,
     });
-    this.draw();
   }
 
   onHorizontalScrollbarScroll(_event: Event) {
@@ -865,7 +781,8 @@ export class VirtualizedViewManager {
   }
 
   clampRowTransform(transform: number): number {
-    const columnWidth = this.columns.list.width * this.container_physical_space.width;
+    const columnWidth =
+      this.columns.list.width * this.view.trace_container_physical_space.width;
     const max = this.row_measurer.max - columnWidth + this.ROW_PADDING_PX;
 
     if (this.row_measurer.queue.length > 0) {
@@ -929,7 +846,7 @@ export class VirtualizedViewManager {
         this.scrollRowIntoViewHorizontally(innerMostNode);
       } else if (
         translation + innerMostNode.depth * this.row_depth_padding >
-        this.columns.list.width * this.container_physical_space.width
+        this.columns.list.width * this.view.trace_container_physical_space.width
       ) {
         this.scrollRowIntoViewHorizontally(innerMostNode);
       }
@@ -948,7 +865,7 @@ export class VirtualizedViewManager {
     return (
       translation + node.depth * this.row_depth_padding < 0 ||
       translation + node.depth * this.row_depth_padding >
-        (this.columns.list.width * this.container_physical_space.width) / 2
+        (this.columns.list.width * this.view.trace_container_physical_space.width) / 2
     );
   }
 
@@ -1039,22 +956,10 @@ export class VirtualizedViewManager {
         throw new Error('ResizeObserver entry is undefined');
       }
 
-      this.initializePhysicalSpace(entry.contentRect.width, entry.contentRect.height);
-      this.draw();
+      this.view.initPhysicalSpace(entry.contentRect.width, entry.contentRect.height);
     });
 
     this.resize_observer.observe(container);
-  }
-
-  recomputeSpanToPxMatrix() {
-    const traceViewToSpace = this.trace_space.between(this.trace_view);
-    const tracePhysicalToView = this.trace_physical_space.between(this.trace_space);
-
-    this.span_to_px = mat3.multiply(
-      this.span_to_px,
-      traceViewToSpace,
-      tracePhysicalToView
-    );
   }
 
   computeRelativeLeftPositionFromOrigin(
@@ -1065,7 +970,7 @@ export class VirtualizedViewManager {
   }
 
   recomputeTimelineIntervals() {
-    if (this.trace_view.width === 0) {
+    if (this.view.trace_view.width === 0) {
       this.intervals[0] = 0;
       this.intervals[1] = 0;
       for (let i = 2; i < this.intervals.length; i++) {
@@ -1073,29 +978,15 @@ export class VirtualizedViewManager {
       }
       return;
     }
-    const tracePhysicalToView = this.trace_physical_space.between(this.trace_view);
+    const tracePhysicalToView = this.view.trace_physical_space.between(
+      this.view.trace_view
+    );
     const time_at_100 =
       tracePhysicalToView[0] * (100 * window.devicePixelRatio) +
       tracePhysicalToView[6] -
-      this.trace_view.x;
+      this.view.trace_view.x;
 
-    computeTimelineIntervals(this.trace_view, time_at_100, this.intervals);
-  }
-
-  readonly span_matrix: [number, number, number, number, number, number] = [
-    1, 0, 0, 1, 0, 0,
-  ];
-
-  computeSpanCSSMatrixTransform(
-    space: [number, number]
-  ): [number, number, number, number, number, number] {
-    const scale = space[1] / this.trace_view.width;
-    this.span_matrix[0] = Math.max(scale, this.span_to_px[0] / this.trace_view.width);
-    this.span_matrix[4] =
-      (space[0] - this.to_origin) / this.span_to_px[0] -
-      this.trace_view.x / this.span_to_px[0];
-
-    return this.span_matrix;
+    computeTimelineIntervals(this.view, time_at_100, this.intervals);
   }
 
   scrollToRow(index: number, anchor?: ViewManagerScrollAnchor) {
@@ -1105,10 +996,6 @@ export class VirtualizedViewManager {
     this.list.scrollToRow(index, anchor);
   }
 
-  computeTransformXFromTimestamp(timestamp: number): number {
-    return (timestamp - this.to_origin - this.trace_view.x) / this.span_to_px[0];
-  }
-
   computeSpanTextPlacement(
     node: TraceTreeNode<TraceTree.NodeValue>,
     span_space: [number, number],
@@ -1116,9 +1003,9 @@ export class VirtualizedViewManager {
   ): [number, number] {
     const TEXT_PADDING = 2;
 
-    const icon_width_config_space = (18 * this.span_to_px[0]) / 2;
+    const icon_width_config_space = (18 * this.view.span_to_px[0]) / 2;
     const text_anchor_left =
-      span_space[0] > this.to_origin + this.trace_space.width * 0.8;
+      span_space[0] > this.view.to_origin + this.view.trace_space.width * 0.8;
     const text_width = this.text_measurer.measure(text);
 
     const timestamps = getIconTimestamps(node, span_space, icon_width_config_space);
@@ -1127,54 +1014,54 @@ export class VirtualizedViewManager {
 
     // precompute all anchor points aot, so we make the control flow more readable.
     /// |---| text
-    const right_outside = this.computeTransformXFromTimestamp(text_right) + TEXT_PADDING;
+    const right_outside = this.view.transformXFromTimestamp(text_right) + TEXT_PADDING;
     // |---text|
     const right_inside =
-      this.computeTransformXFromTimestamp(span_space[0] + span_space[1]) -
+      this.view.transformXFromTimestamp(span_space[0] + span_space[1]) -
       text_width -
       TEXT_PADDING;
     // |text---|
-    const left_inside = this.computeTransformXFromTimestamp(span_space[0]) + TEXT_PADDING;
+    const left_inside = this.view.transformXFromTimestamp(span_space[0]) + TEXT_PADDING;
     /// text |---|
     const left_outside =
-      this.computeTransformXFromTimestamp(text_left) - TEXT_PADDING - text_width;
+      this.view.transformXFromTimestamp(text_left) - TEXT_PADDING - text_width;
 
     // Right edge of the window (when span extends beyond the view)
     const window_right =
-      this.computeTransformXFromTimestamp(
-        this.to_origin + this.trace_view.left + this.trace_view.width
+      this.view.transformXFromTimestamp(
+        this.view.to_origin + this.view.trace_view.left + this.view.trace_view.width
       ) -
       text_width -
       TEXT_PADDING;
     const window_left =
-      this.computeTransformXFromTimestamp(this.to_origin + this.trace_view.left) +
+      this.view.transformXFromTimestamp(this.view.to_origin + this.view.trace_view.left) +
       TEXT_PADDING;
 
-    const view_left = this.trace_view.x;
-    const view_right = view_left + this.trace_view.width;
+    const view_left = this.view.trace_view.x;
+    const view_right = view_left + this.view.trace_view.width;
 
-    const span_left = span_space[0] - this.to_origin;
+    const span_left = span_space[0] - this.view.to_origin;
     const span_right = span_left + span_space[1];
 
     const space_right = view_right - span_right;
     const space_left = span_left - view_left;
 
     // Span is completely outside of the view on the left side
-    if (span_right < this.trace_view.x) {
+    if (span_right < this.view.trace_view.x) {
       return text_anchor_left ? [1, right_inside] : [0, right_outside];
     }
 
     // Span is completely outside of the view on the right side
-    if (span_left > this.trace_view.right) {
+    if (span_left > this.view.trace_view.right) {
       return text_anchor_left ? [0, left_outside] : [1, left_inside];
     }
 
     // Span "spans" the entire view
-    if (span_left <= this.trace_view.x && span_right >= this.trace_view.right) {
+    if (span_left <= this.view.trace_view.x && span_right >= this.view.trace_view.right) {
       return text_anchor_left ? [1, window_left] : [1, window_right];
     }
 
-    const full_span_px_width = span_space[1] / this.span_to_px[0];
+    const full_span_px_width = span_space[1] / this.view.span_to_px[0];
 
     if (text_anchor_left) {
       // While we have space on the left, place the text there
@@ -1182,8 +1069,8 @@ export class VirtualizedViewManager {
         return [0, left_outside];
       }
 
-      const distance = span_right - this.trace_view.left;
-      const visible_width = distance / this.span_to_px[0] - TEXT_PADDING;
+      const distance = span_right - this.view.trace_view.left;
+      const visible_width = distance / this.view.span_to_px[0] - TEXT_PADDING;
 
       // If the text fits inside the visible portion of the span, anchor it to the left
       // side of the window so that it is visible while the user pans the view
@@ -1208,8 +1095,8 @@ export class VirtualizedViewManager {
         // of the view would have been to compute the scaling matrix for a non zoomed view at 0,0
         // origin and check if it fits into the distance of space right edge - span right edge. In practice
         // however, it seems that a magical number works just fine.
-        span_right > this.trace_space.right * 0.9 &&
-        space_right / this.span_to_px[0] < text_width
+        span_right > this.view.trace_space.right * 0.9 &&
+        space_right / this.view.span_to_px[0] < text_width
       ) {
         return [1, right_inside];
       }
@@ -1218,9 +1105,9 @@ export class VirtualizedViewManager {
 
     // If text fits inside the span
     if (full_span_px_width > text_width) {
-      const distance = span_right - this.trace_view.right;
+      const distance = span_right - this.view.trace_view.right;
       const visible_width =
-        (span_space[1] - distance) / this.span_to_px[0] - TEXT_PADDING;
+        (span_space[1] - distance) / this.view.span_to_px[0] - TEXT_PADDING;
 
       // If the text fits inside the visible portion of the span, anchor it to the right
       // side of the window so that it is visible while the user pans the view
@@ -1247,7 +1134,7 @@ export class VirtualizedViewManager {
     });
 
     // 60px error margin. ~52px is roughly the width of 500.00ms, we add a bit more, to be safe.
-    const error_margin = 60 * this.span_to_px[0];
+    const error_margin = 60 * this.view.span_to_px[0];
 
     for (let i = 0; i < this.columns.list.column_refs.length; i++) {
       const span = this.span_bars[i];
@@ -1257,9 +1144,10 @@ export class VirtualizedViewManager {
       }
 
       const outside_left =
-        span.space[0] - this.to_origin + span.space[1] < this.trace_view.x - error_margin;
+        span.space[0] - this.view.to_origin + span.space[1] <
+        this.view.trace_view.x - error_margin;
       const outside_right =
-        span.space[0] - this.to_origin - error_margin > this.trace_view.right;
+        span.space[0] - this.view.to_origin - error_margin > this.view.trace_view.right;
 
       if (outside_left || outside_right) {
         this.hideSpanBar(this.span_bars[i], this.span_text[i]);
@@ -1284,7 +1172,7 @@ export class VirtualizedViewManager {
         continue;
       }
 
-      if (indicator.indicator.start < this.to_origin + this.trace_view.left) {
+      if (indicator.indicator.start < this.view.to_origin + this.view.trace_view.left) {
         start_indicator++;
         continue;
       }
@@ -1298,7 +1186,10 @@ export class VirtualizedViewManager {
         end_indicator--;
         continue;
       }
-      if (last_indicator.indicator.start > this.to_origin + this.trace_view.right) {
+      if (
+        last_indicator.indicator.start >
+        this.view.to_origin + this.view.trace_view.right
+      ) {
         end_indicator--;
         continue;
       }
@@ -1319,10 +1210,10 @@ export class VirtualizedViewManager {
         continue;
       }
 
-      const transform = this.computeTransformXFromTimestamp(entry.indicator.start);
+      const transform = this.view.transformXFromTimestamp(entry.indicator.start);
       const label = entry.ref.children[0] as HTMLElement | undefined;
 
-      const indicator_max = this.trace_physical_space.width + 1;
+      const indicator_max = this.view.trace_physical_space.width + 1;
       const indicator_min = -1;
 
       const label_width = this.indicator_label_measurer.cache.get(entry.indicator);
@@ -1349,9 +1240,9 @@ export class VirtualizedViewManager {
           if (space_left < 0) {
             const left = -label_width / 2 + Math.abs(space_left);
             label.style.transform = `translateX(${left - 1}px)`;
-          } else if (space_right > this.trace_physical_space.width) {
+          } else if (space_right > this.view.trace_physical_space.width) {
             const right =
-              -label_width / 2 - (space_right - this.trace_physical_space.width) - 1;
+              -label_width / 2 - (space_right - this.view.trace_physical_space.width) - 1;
             label.style.transform = `translateX(${right}px)`;
           } else {
             label.style.transform = `translateX(${-label_width / 2}px)`;
@@ -1384,7 +1275,7 @@ export class VirtualizedViewManager {
   drawSpanBar(span_bar: this['span_bars'][0]) {
     if (!span_bar) return;
 
-    const span_transform = this.computeSpanCSSMatrixTransform(span_bar?.space);
+    const span_transform = this.view.computeSpanCSSMatrixTransform(span_bar?.space);
     span_bar.ref.style.transform = `matrix(${span_transform.join(',')}`;
     const inverseScale = Math.round((1 / span_transform[0]) * 1e4) / 1e4;
     span_bar.ref.style.setProperty(
@@ -1442,7 +1333,7 @@ export class VirtualizedViewManager {
       return;
     }
 
-    const placement = this.computeTransformXFromTimestamp(indicator.timestamp);
+    const placement = this.view.transformXFromTimestamp(indicator.timestamp);
     indicator.ref.style.opacity = '1';
     indicator.ref.style.transform = `translateX(${placement}px)`;
   }
@@ -1458,7 +1349,7 @@ export class VirtualizedViewManager {
       return;
     }
 
-    const placement = this.computeTransformXFromTimestamp(this.to_origin + interval);
+    const placement = this.view.transformXFromTimestamp(this.view.to_origin + interval);
 
     ref.style.opacity = '1';
     ref.style.transform = `translateX(${placement}px)`;
@@ -1503,7 +1394,7 @@ export class VirtualizedViewManager {
       // 43 px offset is the width of a 0.00ms label, since we usually anchor the label to the right
       // side of the indicator, we need to offset it by the width of the label to make it look like
       // it is at the end of the timeline
-      last.style.transform = `translateX(${this.trace_physical_space.width - 43}px)`;
+      last.style.transform = `translateX(${this.view.trace_physical_space.width - 43}px)`;
       const firstLabel = first.children[0] as HTMLElement | undefined;
       if (firstLabel) {
         firstLabel.textContent = '0.00ms';
@@ -1542,7 +1433,7 @@ export class VirtualizedViewManager {
 
     if (this.indicator_container) {
       const correction =
-        (this.scrollbar_width / this.container_physical_space.width) *
+        (this.scrollbar_width / this.view.trace_container_physical_space.width) *
         options.span_list_width;
       this.indicator_container.style.transform = `translateX(${-this.scrollbar_width}px)`;
       const new_indicator_container_width = options.span_list_width - correction;
@@ -1556,7 +1447,7 @@ export class VirtualizedViewManager {
     const dividerPosition =
       Math.round(
         (options.list_width *
-          (this.container_physical_space.width - this.scrollbar_width) -
+          (this.view.trace_container_physical_space.width - this.scrollbar_width) -
           DIVIDER_WIDTH / 2 -
           1) *
           10
@@ -1564,7 +1455,7 @@ export class VirtualizedViewManager {
 
     if (this.horizontal_scrollbar_container) {
       this.horizontal_scrollbar_container.style.width =
-        (dividerPosition / this.container_physical_space.width) * 100 + '%';
+        (dividerPosition / this.view.trace_container_physical_space.width) * 100 + '%';
     }
 
     if (this.divider) {
@@ -1581,7 +1472,9 @@ export class VirtualizedViewManager {
       const text = this.span_text[i];
 
       if (invisible_bar) {
-        const span_transform = this.computeSpanCSSMatrixTransform(invisible_bar?.space);
+        const span_transform = this.view.computeSpanCSSMatrixTransform(
+          invisible_bar?.space
+        );
         invisible_bar.ref.style.transform = `matrix(${span_transform.join(',')}`;
         const inverseScale = Math.round((1 / span_transform[0]) * 1e4) / 1e4;
         invisible_bar.ref.style.setProperty(
@@ -1629,7 +1522,6 @@ function getIconTimestamps(
   span_space: [number, number],
   icon_width: number
 ) {
-<<<<<<< HEAD
   let min_icon_timestamp = span_space[0];
   let max_icon_timestamp = span_space[0] + span_space[1];
 
@@ -1637,15 +1529,6 @@ function getIconTimestamps(
     return [min_icon_timestamp, max_icon_timestamp];
   }
 
-=======
-  if (!node.errors.size && !node.performance_issues.size) {
-    return [span_space[0], span_space[0] + span_space[1]];
-  }
-
-  let min_icon_timestamp = span_space[0];
-  let max_icon_timestamp = span_space[0] + span_space[1];
-
->>>>>>> 7d674571dd1 (fix(trace) fix icon positioning by extending the window)
   for (const issue of node.performance_issues) {
     // Perf issues render icons at the start timestamp
     if (typeof issue.start === 'number') {
@@ -1675,17 +1558,9 @@ function getIconTimestamps(
   return [min_icon_timestamp, max_icon_timestamp];
 }
 
-// Jest does not implement scroll updates, however since we have the
-// middleware to handle scroll updates, we can dispatch a scroll event ourselves
-function dispatchJestScrollUpdate(container: HTMLElement) {
-  if (!container) return;
-  if (process.env.NODE_ENV !== 'test') return;
-  // since we do not tightly control how browsers handle event dispatching, dispatch it async
-  window.requestAnimationFrame(() => {
-    container.dispatchEvent(new CustomEvent('scroll'));
-  });
-}
-
+/**
+ * Finds timeline intervals based off the current zoom level.
+ */
 function computeTimelineIntervals(
   view: TraceView,
   targetInterval: number,
@@ -1700,12 +1575,12 @@ function computeTimelineIntervals(
     interval *= 2;
   }
 
-  let x = Math.ceil(view.x / interval) * interval;
+  let x = Math.ceil(view.trace_view.x / interval) * interval;
   let idx = -1;
   if (x > 0) {
     x -= interval;
   }
-  while (x <= view.right) {
+  while (x <= view.trace_view.right) {
     results[++idx] = x;
     x += interval;
   }
@@ -1760,4 +1635,15 @@ export class VirtualizedList {
     this.container.scrollTop = position;
     dispatchJestScrollUpdate(this.container);
   }
+}
+
+// Jest does not implement scroll updates, however since we have the
+// middleware to handle scroll updates, we can dispatch a scroll event ourselves
+function dispatchJestScrollUpdate(container: HTMLElement) {
+  if (!container) return;
+  if (process.env.NODE_ENV !== 'test') return;
+  // since we do not tightly control how browsers handle event dispatching, dispatch it async
+  window.requestAnimationFrame(() => {
+    container.dispatchEvent(new CustomEvent('scroll'));
+  });
 }

--- a/static/app/views/replays/detail/trace/trace.tsx
+++ b/static/app/views/replays/detail/trace/trace.tsx
@@ -19,6 +19,7 @@ import {TraceViewWaterfall} from 'sentry/views/performance/newTraceDetails';
 import {useReplayTraceMeta} from 'sentry/views/performance/newTraceDetails/traceApi/useReplayTraceMeta';
 import {useTraceRootEvent} from 'sentry/views/performance/newTraceDetails/traceApi/useTraceRootEvent';
 import type {TracePreferencesState} from 'sentry/views/performance/newTraceDetails/traceState/tracePreferences';
+import {loadTraceViewPreferences} from 'sentry/views/performance/newTraceDetails/traceState/tracePreferences';
 import {TraceStateProvider} from 'sentry/views/performance/newTraceDetails/traceState/traceStateProvider';
 import TraceView, {
   StyledTracePanel,
@@ -31,8 +32,6 @@ import {
   useTransactionData,
 } from 'sentry/views/replays/detail/trace/replayTransactionContext';
 import type {ReplayRecord} from 'sentry/views/replays/types';
-
-import {loadTraceViewPreferences} from '../../../performance/newTraceDetails/traceState/tracePreferences';
 
 function TracesNotFound({performanceActive}: {performanceActive: boolean}) {
   // We want to send the 'trace_status' data if the project actively uses and has access to the performance monitoring.


### PR DESCRIPTION
Split the rendering logic to react to events emitted by the scheduler (very similar to how profiling works). This will allow us to add independent components that can react to view changes and rerender their state however they need to and avoid react lifecycle updates where they are not needed.

By doing this we also fix a race condition where we failed to scroll to the row in the list (because we can await virtualized list initialization on initial render)

This prepares the UI work for minimap as the timeline indicators can subscribe to updates and are decoupled from the main span view