### PR TITLE
chore(slack): remove integration auto disable

### DIFF
--- a/src/sentry/shared_integrations/client/base.py
+++ b/src/sentry/shared_integrations/client/base.py
@@ -11,7 +11,7 @@ from requests.exceptions import ConnectionError, HTTPError, Timeout
 
 from sentry.exceptions import RestrictedIPAddress
 from sentry.http import build_session
-from sentry.integrations.base import disable_integration, is_response_error, is_response_success
+from sentry.integrations.base import is_response_error, is_response_success
 from sentry.integrations.request_buffer import IntegrationRequestBuffer
 from sentry.net.http import SafeSession
 from sentry.utils import json, metrics
@@ -395,7 +395,14 @@ class BaseApiClient(TrackResponseMixin):
             if is_response_error(response):
                 buffer.record_error()
         if buffer.is_integration_broken():
-            disable_integration(buffer, redis_key, self.integration_id)
+            # disable_integration(buffer, redis_key, self.integration_id)
+            self.logger.info(
+                "integration.should_disable",
+                extra={
+                    "integration_id": self.integration_id,
+                    "broken_range_day_counts": buffer._get_broken_range_from_buffer(),
+                },
+            )
 
     def record_error(self, error: Exception):
         redis_key = self._get_redis_key()
@@ -407,4 +414,11 @@ class BaseApiClient(TrackResponseMixin):
         else:
             buffer.record_error()
         if buffer.is_integration_broken():
-            disable_integration(buffer, redis_key, self.integration_id)
+            # disable_integration(buffer, redis_key, self.integration_id)
+            self.logger.info(
+                "integration.should_disable",
+                extra={
+                    "integration_id": self.integration_id,
+                    "broken_range_day_counts": buffer._get_broken_range_from_buffer(),
+                },
+            )

--- a/tests/sentry/integrations/github/test_client.py
+++ b/tests/sentry/integrations/github/test_client.py
@@ -648,6 +648,7 @@ class GitHubClientFileBlameIntegrationDisableTest(TestCase):
             code_mapping=None,  # type: ignore[arg-type]
         )
 
+    @pytest.mark.skip("Feature is temporarily disabled")
     @mock.patch("sentry.integrations.github.client.get_jwt", return_value=ApiError)
     @responses.activate
     def test_fatal_and_disable_integration(self, get_jwt):
@@ -751,6 +752,7 @@ class GitHubClientFileBlameIntegrationDisableTest(TestCase):
         self.integration.refresh_from_db()
         assert self.integration.status == ObjectStatus.ACTIVE
 
+    @pytest.mark.skip("Feature is temporarily disabled")
     @responses.activate
     @freeze_time("2022-01-01 03:30:00")
     def test_a_slow_integration_is_broken(self):

--- a/tests/sentry/integrations/gitlab/test_client.py
+++ b/tests/sentry/integrations/gitlab/test_client.py
@@ -607,6 +607,7 @@ class GitLabBlameForFilesTest(GitLabClientTest):
 
 @control_silo_test
 class GitLabUnhappyPathTest(GitLabClientTest):
+    @pytest.mark.skip("Feature is temporarily disabled")
     @responses.activate
     @patch.object(IntegrationRequestBuffer, "is_integration_broken", return_value=True)
     def test_unreachable_host(self, mock_is_integration_broken):

--- a/tests/sentry/integrations/slack/test_disable.py
+++ b/tests/sentry/integrations/slack/test_disable.py
@@ -47,6 +47,7 @@ class SlackClientDisable(TestCase):
     def tearDown(self):
         self.resp.__exit__(None, None, None)
 
+    @pytest.mark.skip("Feature is temporarily disabled")
     @responses.activate
     def test_fatal_and_disable_integration(self):
         """


### PR DESCRIPTION
This feature is buggy. We've seen two reported cases where this is not behaving as expected. Removing the part of disabling the integration and logging the broken range to debug.