### PR TITLE
feat(replay): Add beta badge for mobile replays

### DIFF
--- a/static/app/components/replays/header/detailsPageBreadcrumbs.tsx
+++ b/static/app/components/replays/header/detailsPageBreadcrumbs.tsx
@@ -1,10 +1,12 @@
 import {Fragment} from 'react';
+import styled from '@emotion/styled';
 
 import FeatureBadge from 'sentry/components/badge/featureBadge';
 import {Breadcrumbs} from 'sentry/components/breadcrumbs';
 import ProjectBadge from 'sentry/components/idBadge/projectBadge';
 import Placeholder from 'sentry/components/placeholder';
 import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
 import EventView from 'sentry/utils/discover/eventView';
 import {getShortEventId} from 'sentry/utils/events';
 import {useLocation} from 'sentry/utils/useLocation';
@@ -55,15 +57,15 @@ function DetailsPageBreadcrumbs({orgSlug, replayRecord, isVideoReplay}: Props) {
         },
         {
           label: isVideoReplay ? (
-            <span>
+            <StyledSpan>
               {labelTitle}
-              <FeatureBadge
+              <CenteredFeatureBadge
                 type="beta"
                 title={t(
                   'Session Replay for mobile apps is currently in beta. Beta features are still in progress and may have bugs.'
                 )}
               />
-            </span>
+            </StyledSpan>
           ) : (
             labelTitle
           ),
@@ -74,3 +76,11 @@ function DetailsPageBreadcrumbs({orgSlug, replayRecord, isVideoReplay}: Props) {
 }
 
 export default DetailsPageBreadcrumbs;
+
+const CenteredFeatureBadge = styled(FeatureBadge)`
+  height: ${space(2)};
+`;
+
+const StyledSpan = styled('span')`
+  display: flex;
+`;

--- a/static/app/components/replays/header/detailsPageBreadcrumbs.tsx
+++ b/static/app/components/replays/header/detailsPageBreadcrumbs.tsx
@@ -1,5 +1,6 @@
 import {Fragment} from 'react';
 
+import FeatureBadge from 'sentry/components/badge/featureBadge';
 import {Breadcrumbs} from 'sentry/components/breadcrumbs';
 import ProjectBadge from 'sentry/components/idBadge/projectBadge';
 import Placeholder from 'sentry/components/placeholder';
@@ -12,11 +13,12 @@ import {normalizeUrl} from 'sentry/utils/withDomainRequired';
 import type {ReplayRecord} from 'sentry/views/replays/types';
 
 type Props = {
+  isVideoReplay: boolean | undefined;
   orgSlug: string;
   replayRecord: ReplayRecord | undefined;
 };
 
-function DetailsPageBreadcrumbs({orgSlug, replayRecord}: Props) {
+function DetailsPageBreadcrumbs({orgSlug, replayRecord, isVideoReplay}: Props) {
   const location = useLocation();
   const eventView = EventView.fromLocation(location);
 
@@ -52,7 +54,17 @@ function DetailsPageBreadcrumbs({orgSlug, replayRecord}: Props) {
           ) : null,
         },
         {
-          label: labelTitle,
+          label: isVideoReplay ? (
+            <span>
+              {labelTitle}
+              <FeatureBadge
+                type="beta"
+                title="Session Replay for mobile apps is currently in beta. Beta features are still in progress and may have bugs."
+              />
+            </span>
+          ) : (
+            labelTitle
+          ),
         },
       ]}
     />

--- a/static/app/components/replays/header/detailsPageBreadcrumbs.tsx
+++ b/static/app/components/replays/header/detailsPageBreadcrumbs.tsx
@@ -59,7 +59,9 @@ function DetailsPageBreadcrumbs({orgSlug, replayRecord, isVideoReplay}: Props) {
               {labelTitle}
               <FeatureBadge
                 type="beta"
-                title={t('Session Replay for mobile apps is currently in beta. Beta features are still in progress and may have bugs.')}
+                title={t(
+                  'Session Replay for mobile apps is currently in beta. Beta features are still in progress and may have bugs.'
+                )}
               />
             </span>
           ) : (

--- a/static/app/components/replays/header/detailsPageBreadcrumbs.tsx
+++ b/static/app/components/replays/header/detailsPageBreadcrumbs.tsx
@@ -59,7 +59,7 @@ function DetailsPageBreadcrumbs({orgSlug, replayRecord, isVideoReplay}: Props) {
               {labelTitle}
               <FeatureBadge
                 type="beta"
-                title="Session Replay for mobile apps is currently in beta. Beta features are still in progress and may have bugs."
+                title={t('Session Replay for mobile apps is currently in beta. Beta features are still in progress and may have bugs.')}
               />
             </span>
           ) : (

--- a/static/app/views/replays/detail/page.tsx
+++ b/static/app/views/replays/detail/page.tsx
@@ -75,11 +75,19 @@ export default function Page({
 
   const header = replayRecord?.is_archived ? (
     <Header>
-      <DetailsPageBreadcrumbs orgSlug={orgSlug} replayRecord={replayRecord} />
+      <DetailsPageBreadcrumbs
+        orgSlug={orgSlug}
+        replayRecord={replayRecord}
+        isVideoReplay={isVideoReplay}
+      />
     </Header>
   ) : (
     <Header>
-      <DetailsPageBreadcrumbs orgSlug={orgSlug} replayRecord={replayRecord} />
+      <DetailsPageBreadcrumbs
+        orgSlug={orgSlug}
+        replayRecord={replayRecord}
+        isVideoReplay={isVideoReplay}
+      />
 
       <ButtonActionsWrapper>
         {isLoading ? (

--- a/static/app/views/replays/list.tsx
+++ b/static/app/views/replays/list.tsx
@@ -40,7 +40,9 @@ function ReplaysListContainer() {
             {allMobileProj ? (
               <FeatureBadge
                 type="beta"
-                title={t('Session Replay for mobile apps is currently in beta. Beta features are still in progress and may have bugs.')}
+                title={t(
+                  'Session Replay for mobile apps is currently in beta. Beta features are still in progress and may have bugs.'
+                )}
               />
             ) : null}
           </Layout.Title>

--- a/static/app/views/replays/list.tsx
+++ b/static/app/views/replays/list.tsx
@@ -1,6 +1,7 @@
 import {Fragment} from 'react';
 import styled from '@emotion/styled';
 
+import FeatureBadge from 'sentry/components/badge/featureBadge';
 import HookOrDefault from 'sentry/components/hookOrDefault';
 import * as Layout from 'sentry/components/layouts/thirds';
 import PageFiltersContainer from 'sentry/components/organizations/pageFilters/container';
@@ -10,6 +11,7 @@ import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import useReplayPageview from 'sentry/utils/replays/hooks/useReplayPageview';
 import useOrganization from 'sentry/utils/useOrganization';
+import useAllMobileProj from 'sentry/views/replays/detail/useAllMobileProj';
 import ListContent from 'sentry/views/replays/list/listContent';
 import ReplayTabs from 'sentry/views/replays/tabs';
 
@@ -21,6 +23,7 @@ const ReplayListPageHeaderHook = HookOrDefault({
 function ReplaysListContainer() {
   useReplayPageview('replay.list-time-spent');
   const organization = useOrganization();
+  const {allMobileProj} = useAllMobileProj();
 
   return (
     <SentryDocumentTitle title={`Session Replay — ${organization.slug}`}>
@@ -34,6 +37,12 @@ function ReplaysListContainer() {
               )}
               docsUrl="https://docs.sentry.io/product/session-replay/"
             />
+            {allMobileProj ? (
+              <FeatureBadge
+                type="beta"
+                title="Session Replay for mobile apps is currently in beta. Beta features are still in progress and may have bugs."
+              />
+            ) : null}
           </Layout.Title>
         </Layout.HeaderContent>
         <div /> {/* wraps the tabs below the page title */}

--- a/static/app/views/replays/list.tsx
+++ b/static/app/views/replays/list.tsx
@@ -40,7 +40,7 @@ function ReplaysListContainer() {
             {allMobileProj ? (
               <FeatureBadge
                 type="beta"
-                title="Session Replay for mobile apps is currently in beta. Beta features are still in progress and may have bugs."
+                title={t('Session Replay for mobile apps is currently in beta. Beta features are still in progress and may have bugs.')}
               />
             ) : null}
           </Layout.Title>


### PR DESCRIPTION
In replay list page if all mobile projects:
<img width="1066" alt="image" src="https://github.com/getsentry/sentry/assets/55311782/878017e3-c038-4ff0-8263-d56eb21dd00d">
In replay details page if mobile replay:
<img width="969" alt="image" src="https://github.com/getsentry/sentry/assets/55311782/1ef98392-926b-4611-8dcd-2a601786f237">

Closes https://github.com/getsentry/sentry/issues/73290
