### PR TITLE
fix(trace-explorer): Multi user condition ordered traces

### DIFF
--- a/src/sentry/search/events/builder/discover.py
+++ b/src/sentry/search/events/builder/discover.py
@@ -1482,10 +1482,12 @@ class BaseQueryBuilder:
                     for column, function_details in self.function_alias_map.items()
                 }
 
-                self.function_alias_map = {
-                    translated_columns.get(column, column): function_details
-                    for column, function_details in self.function_alias_map.items()
-                }
+                for column in list(self.function_alias_map):
+                    translated_column = translated_columns.get(column, column)
+                    if translated_column in self.function_alias_map:
+                        continue
+                    self.function_alias_map[translated_column] = self.function_alias_map.get(column)
+
                 if self.raw_equations:
                     for index, equation in enumerate(self.raw_equations):
                         translated_columns[f"equation[{index}]"] = f"equation|{equation}"

--- a/tests/sentry/api/endpoints/test_organization_traces.py
+++ b/tests/sentry/api/endpoints/test_organization_traces.py
@@ -793,31 +793,35 @@ class OrganizationTracesEndpointTest(OrganizationTracesEndpointTestBase):
             tags={"foo": "bar"},
         )
 
-        query = {
-            "query": "foo:bar",
-            "sort": "-timestamp",
-        }
+        for q in [
+            ["foo:bar"],
+            ["foo:bar", f"project:{self.project.slug}"],
+        ]:
+            query = {
+                "query": q,
+                "sort": "-timestamp",
+            }
 
-        response = self.do_request(
-            query,
-            features=[
-                "organizations:performance-trace-explorer",
-                "organizations:performance-trace-explorer-sorting",
-            ],
-        )
-        assert response.status_code == 200, response.data
+            response = self.do_request(
+                query,
+                features=[
+                    "organizations:performance-trace-explorer",
+                    "organizations:performance-trace-explorer-sorting",
+                ],
+            )
+            assert response.status_code == 200, response.data
 
-        assert response.data["meta"] == {
-            "dataset": "unknown",
-            "datasetReason": "unchanged",
-            "fields": {},
-            "isMetricsData": False,
-            "isMetricsExtractedData": False,
-            "tips": {},
-            "units": {},
-        }
+            assert response.data["meta"] == {
+                "dataset": "unknown",
+                "datasetReason": "unchanged",
+                "fields": {},
+                "isMetricsData": False,
+                "isMetricsExtractedData": False,
+                "tips": {},
+                "units": {},
+            }
 
-        assert [row["trace"] for row in response.data["data"]] == [trace_id_1, trace_id_2]
+            assert [row["trace"] for row in response.data["data"]] == [trace_id_1, trace_id_2]
 
     def test_sorted_early_exit(self):
         (


### PR DESCRIPTION
When there are multiple user conditions for ordered traces, we need to order by a different column.