### PR TITLE
feat(testing): Mark some tests with querybuilder for smoke tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ markers = [
   "snuba_ci: test is run in snuba ci",
   "sentry_metrics: test requires access to sentry metrics",
   "symbolicator: test requires access to symbolicator",
+  "querybuilder: smoke tests for QueryBuilders",
 ]
 filterwarnings = [
   # Consider all warnings to be errors other than the ignored ones.

--- a/tests/sentry/search/events/builder/test_discover.py
+++ b/tests/sentry/search/events/builder/test_discover.py
@@ -43,6 +43,7 @@ class QueryBuilderTest(TestCase):
             Condition(Column("project_id"), Op.IN, self.projects),
         ]
 
+    @pytest.mark.querybuilder
     def test_simple_query(self):
         query = QueryBuilder(
             Dataset.Discover,

--- a/tests/sentry/search/events/builder/test_errors.py
+++ b/tests/sentry/search/events/builder/test_errors.py
@@ -19,6 +19,7 @@ class ErrorsQueryBuilderTest(TestCase):
     def setUp(self):
         self.projects = [self.project.id]
 
+    @pytest.mark.querybuilder
     def test_simple_query(self):
         query = ErrorsQueryBuilder(
             dataset=Dataset.Events,

--- a/tests/sentry/search/events/builder/test_metrics.py
+++ b/tests/sentry/search/events/builder/test_metrics.py
@@ -170,6 +170,7 @@ class MetricBuilderBaseTest(MetricsEnhancedPerformanceTestCase):
 
 
 class MetricQueryBuilderTest(MetricBuilderBaseTest):
+    @pytest.mark.querybuilder
     def test_default_conditions(self):
         query = MetricsQueryBuilder(
             self.params, query="", dataset=Dataset.PerformanceMetrics, selected_columns=[]
@@ -1676,6 +1677,7 @@ class MetricQueryBuilderTest(MetricBuilderBaseTest):
 
 
 class TimeseriesMetricQueryBuilderTest(MetricBuilderBaseTest):
+    @pytest.mark.querybuilder
     def test_get_query(self):
         orig_query = TimeseriesMetricQueryBuilder(
             self.params,

--- a/tests/sentry/search/events/builder/test_profile_functions.py
+++ b/tests/sentry/search/events/builder/test_profile_functions.py
@@ -49,6 +49,7 @@ def params(now, today):
             'package:""',
             Condition(Column("package"), Op("="), ""),
             id="empty package",
+            marks=pytest.mark.querybuilder,
         ),
         pytest.param(
             '!package:""',

--- a/tests/sentry/search/events/builder/test_profile_functions_metrics.py
+++ b/tests/sentry/search/events/builder/test_profile_functions_metrics.py
@@ -54,6 +54,7 @@ def params(now, today):
                 Function("has", parameters=[Column("tags.key"), 9223372036854776075]), Op("!="), 1
             ),
             id="empty package",
+            marks=pytest.mark.querybuilder,
         ),
         pytest.param(
             '!package:""',

--- a/tests/sentry/search/events/builder/test_span_metrics.py
+++ b/tests/sentry/search/events/builder/test_span_metrics.py
@@ -44,6 +44,7 @@ def create_condition(left_boundary, right_boundary, base_granularity, core_granu
 
 
 class MetricQueryBuilderTest(MetricsEnhancedPerformanceTestCase):
+    @pytest.mark.querybuilder
     def test_granularity(self):
         # Need to pick granularity based on the period
         def get_granularity(start, end):

--- a/tests/sentry/search/events/builder/test_spans_indexed.py
+++ b/tests/sentry/search/events/builder/test_spans_indexed.py
@@ -76,7 +76,10 @@ def test_field_alias(params, field, expected):
     ["condition", "expected"],
     [
         pytest.param(
-            "span.duration:1s", Condition(span_duration, Op.EQ, 1000), id="span.duration:1s"
+            "span.duration:1s",
+            Condition(span_duration, Op.EQ, 1000),
+            id="span.duration:1s",
+            marks=pytest.mark.querybuilder,
         ),
         pytest.param(
             "span.duration:>1s", Condition(span_duration, Op.GT, 1000), id="span.duration:>1s"

--- a/tests/snuba/api/endpoints/test_organization_events_histogram.py
+++ b/tests/snuba/api/endpoints/test_organization_events_histogram.py
@@ -83,6 +83,7 @@ class OrganizationEventsHistogramEndpointTest(APITestCase, SnubaTestCase):
         assert response.status_code == 200, response.content
         assert response.data == {}
 
+    @pytest.mark.querybuilder
     def test_good_params(self):
         for array_column in ARRAY_COLUMNS:
             alias = get_array_column_alias(array_column)

--- a/tests/snuba/api/endpoints/test_organization_events_mep.py
+++ b/tests/snuba/api/endpoints/test_organization_events_mep.py
@@ -412,6 +412,7 @@ class OrganizationEventsMetricsEnhancedPerformanceEndpointTest(MetricsEnhancedPe
         )
         assert response.status_code == 400, response.content
 
+    @pytest.mark.querybuilder
     def test_performance_homepage_query(self):
         self.store_transaction_metric(
             1,

--- a/tests/snuba/api/endpoints/test_organization_events_span_indexed.py
+++ b/tests/snuba/api/endpoints/test_organization_events_span_indexed.py
@@ -1,5 +1,7 @@
 import uuid
 
+import pytest
+
 from tests.snuba.api.endpoints.test_organization_events import OrganizationEventsEndpointTestBase
 
 
@@ -23,6 +25,7 @@ class OrganizationEventsSpanIndexedEndpointTest(OrganizationEventsEndpointTestBa
             "organizations:starfish-view": True,
         }
 
+    @pytest.mark.querybuilder
     def test_simple(self):
         self.store_spans(
             [

--- a/tests/snuba/api/endpoints/test_organization_events_span_metrics.py
+++ b/tests/snuba/api/endpoints/test_organization_events_span_metrics.py
@@ -59,6 +59,7 @@ class OrganizationEventsMetricsEnhancedPerformanceEndpointTest(MetricsEnhancedPe
         assert data[0]["p50()"] == 0
         assert meta["dataset"] == "spansMetrics"
 
+    @pytest.mark.querybuilder
     def test_count(self):
         self.store_span_metric(
             1,

--- a/tests/snuba/api/endpoints/test_organization_events_stats.py
+++ b/tests/snuba/api/endpoints/test_organization_events_stats.py
@@ -90,6 +90,7 @@ class OrganizationEventsStatsEndpointTest(APITestCase, SnubaTestCase, SearchIssu
         with self.feature(features):
             return self.client.get(self.url if url is None else url, data=data, format="json")
 
+    @pytest.mark.querybuilder
     def test_simple(self):
         response = self.do_request(
             {

--- a/tests/snuba/api/endpoints/test_organization_events_stats_mep.py
+++ b/tests/snuba/api/endpoints/test_organization_events_stats_mep.py
@@ -46,6 +46,7 @@ class OrganizationEventsStatsMetricsEnhancedPerformanceEndpointTest(
         self.additional_params = dict()
 
     # These throughput tests should roughly match the ones in OrganizationEventsStatsEndpointTest
+    @pytest.mark.querybuilder
     def test_throughput_epm_hour_rollup(self):
         # Each of these denotes how many events to create in each hour
         event_counts = [6, 0, 6, 3, 0, 3]

--- a/tests/snuba/api/endpoints/test_organization_events_stats_span_indexed.py
+++ b/tests/snuba/api/endpoints/test_organization_events_stats_span_indexed.py
@@ -31,6 +31,7 @@ class OrganizationEventsStatsSpansMetricsEndpointTest(OrganizationEventsEndpoint
             return self.client.get(self.url if url is None else url, data=data, format="json")
 
     # These throughput tests should roughly match the ones in OrganizationEventsStatsEndpointTest
+    @pytest.mark.querybuilder
     def test_throughput_epm_hour_rollup(self):
         # Each of these denotes how many events to create in each hour
         event_counts = [6, 0, 6, 3, 0, 3]

--- a/tests/snuba/api/endpoints/test_organization_events_stats_span_metrics.py
+++ b/tests/snuba/api/endpoints/test_organization_events_stats_span_metrics.py
@@ -39,6 +39,7 @@ class OrganizationEventsStatsSpansMetricsEndpointTest(MetricsEnhancedPerformance
             return self.client.get(self.url if url is None else url, data=data, format="json")
 
     # These throughput tests should roughly match the ones in OrganizationEventsStatsEndpointTest
+    @pytest.mark.querybuilder
     def test_throughput_epm_hour_rollup(self):
         # Each of these denotes how many events to create in each hour
         event_counts = [6, 0, 6, 3, 0, 3]

--- a/tests/snuba/api/endpoints/test_organization_events_trace.py
+++ b/tests/snuba/api/endpoints/test_organization_events_trace.py
@@ -1433,6 +1433,7 @@ class OrganizationEventsTraceEndpointTestUsingSpans(OrganizationEventsTraceEndpo
             assert perf_issue["start"] == expected["start_timestamp"]
             assert perf_issue["end"] == expected["timestamp"]
 
+    @pytest.mark.querybuilder
     def test_simple(self):
         self.load_trace()
         with self.feature(self.FEATURES):


### PR DESCRIPTION
- As i'm refactoring some querybuilder stuff I'm wasting a lot of time running the entire suite in CI, when some smoke tests locally would be significantly faster
- To run this quickly do `pytest -m querybuilder tests/snuba test/sentry/search` otherwise pytest will instantiate acceptance tests & need to collect way more items than needed