### PR TITLE
fix(archived-link): Fix archived banner docs link

### DIFF
--- a/static/app/components/archivedBox.tsx
+++ b/static/app/components/archivedBox.tsx
@@ -29,7 +29,7 @@ function ArchivedBox({substatus, statusDetails, organization}: ArchivedBoxProps)
       return t(
         "This issue has been archived. It'll return to your inbox if it escalates. To learn more, %s",
         <ExternalLink
-          href="https://docs.sentry.io/product/accounts/early-adopter-features/issue-archiving/"
+          href="https://docs.sentry.io/product/issues/states-triage/#archive"
           onClick={trackDocsClick}
         >
           {t('read the docs')}


### PR DESCRIPTION
Fixes #73260

The `read the docs` link that appears in the banner after archiving an issue redirects to an outdated link. This PR changes the link to the #archive section in the issue status page ([here](https://docs.sentry.io/product/issues/states-triage/#archive))