### PR TITLE
feat(uptime): Add downtime information to downtime issues

### DIFF
--- a/static/app/components/events/interfaces/uptime/uptimeDataSection.spec.tsx
+++ b/static/app/components/events/interfaces/uptime/uptimeDataSection.spec.tsx
@@ -1,0 +1,43 @@
+import {GroupFixture} from 'sentry-fixture/group';
+import {ProjectFixture} from 'sentry-fixture/project';
+
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import {UptimeDataSection} from 'sentry/components/events/interfaces/uptime/uptimeDataSection';
+import {
+  type GroupActivity,
+  GroupActivityType,
+  GroupStatus,
+  IssueCategory,
+} from 'sentry/types';
+
+describe('Uptime Data Section', function () {
+  it('displays downtime according to activity', function () {
+    const activity: GroupActivity[] = [
+      {
+        data: {},
+        id: '1',
+        dateCreated: '2024-06-20T20:36:51.884284Z',
+        project: ProjectFixture(),
+        type: GroupActivityType.FIRST_SEEN,
+      },
+      {
+        data: {},
+        id: '2',
+        dateCreated: '2024-06-21T20:36:51.884284Z',
+        project: ProjectFixture(),
+        type: GroupActivityType.SET_RESOLVED,
+      },
+    ];
+
+    const group = GroupFixture({
+      status: GroupStatus.RESOLVED,
+      issueCategory: IssueCategory.UPTIME,
+      activity,
+    });
+
+    render(<UptimeDataSection group={group} />);
+
+    expect(screen.getByText('1 day')).toBeInTheDocument();
+  });
+});

--- a/static/app/components/events/interfaces/uptime/uptimeDataSection.tsx
+++ b/static/app/components/events/interfaces/uptime/uptimeDataSection.tsx
@@ -1,0 +1,82 @@
+import {useRef} from 'react';
+import styled from '@emotion/styled';
+
+import DateTime from 'sentry/components/dateTime';
+import Duration from 'sentry/components/duration';
+import {EventDataSection} from 'sentry/components/events/eventDataSection';
+import {Tooltip} from 'sentry/components/tooltip';
+import {t, tct} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
+import {type Group, GroupActivityType, GroupStatus} from 'sentry/types';
+
+interface Props {
+  group: Group;
+}
+
+const DOWNTIME_START_TYPES = [
+  GroupActivityType.SET_UNRESOLVED,
+  GroupActivityType.FIRST_SEEN,
+];
+
+const DOWNTIME_TERMINAL_TYPES = [GroupActivityType.SET_RESOLVED];
+
+export function UptimeDataSection({group}: Props) {
+  const nowRef = useRef(new Date());
+  const downtimeStartActivity = group.activity.findLast(activity =>
+    DOWNTIME_START_TYPES.includes(activity.type)
+  );
+  const downtimeEndActivity = group.activity.findLast(activity =>
+    DOWNTIME_TERMINAL_TYPES.includes(activity.type)
+  );
+
+  const isResolved = group.status === GroupStatus.RESOLVED;
+  const startDate = new Date(downtimeStartActivity?.dateCreated ?? group.firstSeen);
+  const endDate = isResolved
+    ? new Date(downtimeEndActivity?.dateCreated ?? group.lastSeen)
+    : nowRef.current;
+
+  const durationMs = endDate.getTime() - startDate.getTime();
+
+  const duration = (
+    <Tooltip
+      title={
+        <DowntimeTooltipTitle>
+          <DowntimeLabel>{t('From:')}</DowntimeLabel>
+          <DateTime date={startDate} timeZone />
+          <DowntimeLabel>{t('To:')}</DowntimeLabel>
+          {isResolved ? <DateTime date={endDate} timeZone /> : t('Now')}
+        </DowntimeTooltipTitle>
+      }
+      showUnderline
+    >
+      <Duration seconds={durationMs / 1000} />
+    </Tooltip>
+  );
+
+  return (
+    <EventDataSection
+      title={t('Downtime Information')}
+      type="downtime"
+      help={t('Information about the detected downtime')}
+    >
+      {isResolved
+        ? tct('Domain was down for [duration]', {
+            duration,
+          })
+        : tct('Domain has been down for [duration]', {
+            duration,
+          })}
+    </EventDataSection>
+  );
+}
+
+const DowntimeTooltipTitle = styled('div')`
+  display: grid;
+  column-gap: ${space(1)};
+  grid-template-columns: max-content 1fr;
+  justify-items: start;
+`;
+
+const DowntimeLabel = styled('div')`
+  font-weight: ${p => p.theme.fontWeightBold};
+`;

--- a/static/app/views/issueDetails/groupEventDetails/groupEventDetailsContent.tsx
+++ b/static/app/views/issueDetails/groupEventDetails/groupEventDetailsContent.tsx
@@ -32,6 +32,7 @@ import {actionableItemsEnabled} from 'sentry/components/events/interfaces/crashC
 import {CronTimelineSection} from 'sentry/components/events/interfaces/crons/cronTimelineSection';
 import {AnrRootCause} from 'sentry/components/events/interfaces/performance/anrRootCause';
 import {SpanEvidenceSection} from 'sentry/components/events/interfaces/performance/spanEvidence';
+import {UptimeDataSection} from 'sentry/components/events/interfaces/uptime/uptimeDataSection';
 import {EventPackageData} from 'sentry/components/events/packageData';
 import {EventRRWebIntegration} from 'sentry/components/events/rrwebIntegration';
 import {DataSection} from 'sentry/components/events/styles';
@@ -159,6 +160,9 @@ function DefaultGroupEventDetailsContent({
           organization={organization}
         />
       ) : null}
+      {group.issueCategory === IssueCategory.UPTIME && (
+        <UptimeDataSection group={group} />
+      )}
       {group.issueCategory === IssueCategory.CRON && (
         <CronTimelineSection
           event={event}


### PR DESCRIPTION
Adding a section that looks like this for uptime issues:

<img width="640" alt="image" src="https://github.com/getsentry/sentry/assets/9372512/fc1ac45b-c64d-4ada-8615-c067db6dda56">

<img width="582" alt="image" src="https://github.com/getsentry/sentry/assets/9372512/361c0c16-4789-4eb9-8e69-d953aeaf9ac6">

Depends on: https://github.com/getsentry/sentry/pull/72918
