### PR TITLE
fix(inbound-filters): Fix audit logs for inbound filters

### DIFF
--- a/src/sentry/api/endpoints/project_filter_details.py
+++ b/src/sentry/api/endpoints/project_filter_details.py
@@ -97,14 +97,14 @@ class ProjectFilterDetailsEndpoint(ProjectEndpoint):
             if removed == 1:
                 audit_log_state = audit_log.get_event_id("PROJECT_DISABLE")
 
-        if isinstance(returned_state, Iterable):
+        if isinstance(returned_state, Iterable) and not isinstance(returned_state, str):
             returned_state = list(returned_state)
         self.create_audit_entry(
             request=request,
             organization=project.organization,
             target_object=project.id,
             event=audit_log_state,
-            data={"state": returned_state},
+            data={"state": returned_state, "slug": project.slug},
         )
 
         return Response(status=204)

--- a/src/sentry/audit_log/events.py
+++ b/src/sentry/audit_log/events.py
@@ -168,12 +168,17 @@ class ProjectPerformanceDetectionSettingsAuditLogEvent(AuditLogEvent):
 def render_project_action(audit_log_entry: AuditLogEntry, action: str):
     # Most logs will just be name of the filter, but legacy browser changes can be bool, str, list, or sets
     filter_name = audit_log_entry.data["state"]
+    slug = audit_log_entry.data.get("slug")
+
+    message = f"{action} project filter {filter_name}"
+
     if filter_name in ("0", "1") or isinstance(filter_name, (bool, list, set)):
         message = f"{action} project filter legacy-browsers"
         if isinstance(filter_name, (list, set)):
             message += ": {}".format(", ".join(sorted(filter_name)))
-        return message
-    return f"{action} project filter {filter_name}"
+    if slug:
+        message += f" for project {slug}"
+    return message
 
 
 class ProjectEnableAuditLogEvent(AuditLogEvent):


### PR DESCRIPTION
this pr fixes the audit logs for some of the inbound filters. right now, it checks if the filter state is an iterable, calls `list` on it, which is useful for when the state is a set of legacy browsers. but because the other filters have the state as just the filter name ("browser-extensions" for example) and since strings are also iterables, the result in the audit log is seemingly a random string of letters with the incorrect inbound filter (they all said legacy browser). this pr fixes this behavior while also showing what project the filters were edited for. 


before: 
<img width="1021" alt="Screenshot 2024-06-25 at 10 47 13 AM" src="https://github.com/getsentry/sentry/assets/46740234/2751bc9d-a57e-409d-bddb-1f365d9f42a7">

after:
<img width="585" alt="Screenshot 2024-06-25 at 10 53 23 AM" src="https://github.com/getsentry/sentry/assets/46740234/ddc5640f-dd8b-4a4f-9b14-b50724d7e978">
