### PR TITLE
chore(metrics): Add observability into different event builders

### DIFF
--- a/src/sentry/search/events/builder/discover.py
+++ b/src/sentry/search/events/builder/discover.py
@@ -365,7 +365,7 @@ class BaseQueryBuilder:
             self.config = DiscoverDatasetConfig(self)
         elif self.dataset == Dataset.Sessions:
             self.config = SessionsDatasetConfig(self)
-            metrics.incr("search.events.builder.load_config", tags={"dataset": "session_metrics"})
+            metrics.incr(EVENTS_BUILDER_METRIC_NAME, tags={"dataset": "session_metrics"})
         elif self.dataset in [Dataset.Metrics, Dataset.PerformanceMetrics]:
             if self.spans_metrics_builder:
                 # For now, we won't support the metrics layer for spans since it needs some work,


### PR DESCRIPTION
There are different dataset builders which use metrics. Would like to get some observability into the usage pattern of different builders in order to determine how often each one of them is used. The insights could influence the decision on how to approach query migration strategy when no indexer is involved.