### PR TITLE
chore(login): update the login banners

### DIFF
--- a/src/sentry/templates/sentry/partial/alerts.html
+++ b/src/sentry/templates/sentry/partial/alerts.html
@@ -78,7 +78,7 @@
   <div class="alert-banner">
     <div class="alert-message">
       {% if banner_choice == 0 %}
-      Join us June 25th to see a live demo on best practices for pre- and post-release using Sentry and Codecov. &nbsp<a target="_blank" href="https://sentry.io/resources/intro-to-sentry-and-codecov-live-demo/?utm_source=pendo&utm_medium=pendo&utm_campaign=general-fy25q2-sentrylivedemo&utm_content=workshop-live-demo-workshop-rsvp">Register now.</a>
+      Hear from founders and CEOs at Laravel, Prisma, and Supabase as they discuss the future of backend development on July 16th. &nbsp<a target="_blank" href="https://sentry.io/resources/behind-the-code-a-discussion-with-backend-experts/?utm_source=pendo&utm_medium=pendo&utm_campaign=backend-fy25q2-backend&utm_content=workshop-behind-the-code-backend-pros-rsvp">Register now.</a>
       {% elif banner_choice == 1 %}
       Join leaders at Laravel, Prisma, Supabase and Node as they discuss the future of backend development on July 16th. &nbsp<a target="_blank" href="https://sentry.io/resources/behind-the-code-a-discussion-with-backend-experts/?utm_source=pendo&utm_medium=pendo&utm_campaign=backend-fy25q2-backend&utm_content=workshop-behind-the-code-backend-pros-rsvp">Register now.</a>
       {% endif %}


### PR DESCRIPTION
Removes promoting the Sentry + CodeCov banner with the backend fireside chat.