### PR TITLE
dev(similarity): dont propogate traces through celery tasks

### DIFF
--- a/src/sentry/tasks/embeddings_grouping/backfill_seer_grouping_records_for_project.py
+++ b/src/sentry/tasks/embeddings_grouping/backfill_seer_grouping_records_for_project.py
@@ -245,6 +245,7 @@ def call_next_backfill(
                 last_processed_project_index,
                 only_delete,
             ],
+            headers={"sentry-propagate-traces": False},
         )
     else:
         # TODO: delete project redis key here if needed?
@@ -290,4 +291,5 @@ def call_next_backfill(
                 last_processed_project_index,
                 only_delete,
             ],
+            headers={"sentry-propagate-traces": False},
         )


### PR DESCRIPTION
makes the traces hard to look at as they end up way too big. make each backfill task its own trace.

docs on this header:
https://docs.sentry.io/platforms/python/integrations/celery/#distributed-traces