### PR TITLE
feat(frontend): Add timestamp on issue public share page

### DIFF
--- a/static/app/views/sharedGroupDetails/index.spec.tsx
+++ b/static/app/views/sharedGroupDetails/index.spec.tsx
@@ -81,5 +81,6 @@ describe('SharedGroupDetails', function () {
       {router}
     );
     await waitFor(() => expect(screen.getByText('Details')).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByTestId('sgh-timestamp')).toBeInTheDocument());
   });
 });

--- a/static/app/views/sharedGroupDetails/sharedGroupHeader.tsx
+++ b/static/app/views/sharedGroupDetails/sharedGroupHeader.tsx
@@ -51,7 +51,7 @@ function SharedGroupHeader({group}: Props) {
                   title={<EventCreatedTooltip event={event} />}
                   overlayStyle={{maxWidth: 300}}
                 >
-                  <DateTime date={date.toLocaleString()} />
+                  <DateTime date={date} />
                 </Tooltip>
               </EventTimeLabel>
             </TimeStamp>

--- a/static/app/views/sharedGroupDetails/sharedGroupHeader.tsx
+++ b/static/app/views/sharedGroupDetails/sharedGroupHeader.tsx
@@ -20,7 +20,7 @@ type Props = {
 
 function SharedGroupHeader({group}: Props) {
   const date = group.latestEvent?.dateReceived ?? group.latestEvent?.dateCreated;
-  const d = new Date(date as string);
+  const date_obj = new Date(date as string);
   const event = group.latestEvent as Event;
   return (
     <Wrapper>
@@ -55,7 +55,7 @@ function SharedGroupHeader({group}: Props) {
                       title={<EventCreatedTooltip event={event} />}
                       overlayStyle={{maxWidth: 300}}
                     >
-                      <DateTime date={d.toLocaleString()} />
+                      <DateTime date={date_obj.toLocaleString()} />
                     </Tooltip>
                   ),
                 })}

--- a/static/app/views/sharedGroupDetails/sharedGroupHeader.tsx
+++ b/static/app/views/sharedGroupDetails/sharedGroupHeader.tsx
@@ -8,10 +8,8 @@ import ShortId from 'sentry/components/shortId';
 import {Tooltip} from 'sentry/components/tooltip';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
-import type {Event} from 'sentry/types/event';
 import type {Group} from 'sentry/types/group';
 import {IssueCategory} from 'sentry/types/group';
-import getDynamicText from 'sentry/utils/getDynamicText';
 import EventCreatedTooltip from 'sentry/views/issueDetails/eventCreatedTooltip';
 
 type Props = {
@@ -19,9 +17,11 @@ type Props = {
 };
 
 function SharedGroupHeader({group}: Props) {
-  const date = group.latestEvent?.dateReceived ?? group.latestEvent?.dateCreated;
-  const date_obj = new Date(date as string);
-  const event = group.latestEvent as Event;
+  const date = new Date(
+    (group.latestEvent?.dateCreated ?? group.latestEvent?.dateReceived) as string
+  );
+  const event = group.latestEvent;
+
   return (
     <Wrapper>
       <Details>
@@ -41,27 +41,22 @@ function SharedGroupHeader({group}: Props) {
               />
             )}
           </ShortIdWrapper>
+          {event && (event.dateCreated ?? event.dateReceived) && (
+            <TimeStamp data-test-id="sgh-timestamp">
+              {t('Last seen ')}
 
-          <TimeStamp data-test-id="sgh-timestamp">
-            {t('Last seen ')}
-            {(event.dateCreated ?? event.dateReceived) && (
               <EventTimeLabel>
-                {getDynamicText({
-                  fixed: 'Jan 1, 12:00 AM',
-                  value: (
-                    <Tooltip
-                      isHoverable
-                      showUnderline
-                      title={<EventCreatedTooltip event={event} />}
-                      overlayStyle={{maxWidth: 300}}
-                    >
-                      <DateTime date={date_obj.toLocaleString()} />
-                    </Tooltip>
-                  ),
-                })}
+                <Tooltip
+                  isHoverable
+                  showUnderline
+                  title={<EventCreatedTooltip event={event} />}
+                  overlayStyle={{maxWidth: 300}}
+                >
+                  <DateTime date={date.toLocaleString()} />
+                </Tooltip>
               </EventTimeLabel>
-            )}
-          </TimeStamp>
+            </TimeStamp>
+          )}
         </TitleWrap>
         <EventMessage
           showUnhandled={group.isUnhandled}

--- a/static/app/views/sharedGroupDetails/sharedGroupHeader.tsx
+++ b/static/app/views/sharedGroupDetails/sharedGroupHeader.tsx
@@ -115,7 +115,6 @@ const TimeStamp = styled('div')`
   color: ${p => p.theme.headingColor};
   font-size: ${p => p.theme.fontSizeMedium};
   line-height: ${p => p.theme.text.lineHeightHeading};
-  margin-top: ${space(0)};
 `;
 
 const EventTimeLabel = styled('span')`

--- a/static/app/views/sharedGroupDetails/sharedGroupHeader.tsx
+++ b/static/app/views/sharedGroupDetails/sharedGroupHeader.tsx
@@ -56,7 +56,6 @@ function SharedGroupHeader({group}: Props) {
                 </Tooltip>
               </EventTimeLabel>
               {'Last seen '}
-
               <EventTimeLabel>
                 <Tooltip
                   isHoverable

--- a/static/app/views/sharedGroupDetails/sharedGroupHeader.tsx
+++ b/static/app/views/sharedGroupDetails/sharedGroupHeader.tsx
@@ -44,18 +44,6 @@ function SharedGroupHeader({group}: Props) {
           {event && (event.dateCreated ?? event.dateReceived) && (
             <TimeStamp data-test-id="sgh-timestamp">
               {t('Last seen ')}
-
-              <EventTimeLabel>
-                <Tooltip
-                  isHoverable
-                  showUnderline
-                  title={<EventCreatedTooltip event={event} />}
-                  overlayStyle={{maxWidth: 300}}
-                >
-                  <DateTime date={date.toLocaleString()} />
-                </Tooltip>
-              </EventTimeLabel>
-              {'Last seen '}
               <EventTimeLabel>
                 <Tooltip
                   isHoverable

--- a/static/app/views/sharedGroupDetails/sharedGroupHeader.tsx
+++ b/static/app/views/sharedGroupDetails/sharedGroupHeader.tsx
@@ -1,6 +1,7 @@
 import styled from '@emotion/styled';
 
 import FeatureBadge from 'sentry/components/badge/featureBadge';
+// import {DateTime} from 'sentry/components/dateTime';
 import EventMessage from 'sentry/components/events/eventMessage';
 import ProjectBadge from 'sentry/components/idBadge/projectBadge';
 import ShortId from 'sentry/components/shortId';
@@ -14,6 +15,7 @@ type Props = {
 };
 
 function SharedGroupHeader({group}: Props) {
+  const date = group.latestEvent?.dateReceived ?? group.latestEvent?.dateCreated;
   return (
     <Wrapper>
       <Details>
@@ -33,6 +35,15 @@ function SharedGroupHeader({group}: Props) {
               />
             )}
           </ShortIdWrapper>
+
+          <TimeStamp>
+            {'Last Seen: '}
+            {(date as string).toLocaleString()}
+            {/* <DateTime
+              // date={group.latestEvent?.dateReceived ?? group.latestEvent?.dateCreated}
+              date = {(date as string).toLocaleString()}
+            /> */}
+          </TimeStamp>
         </TitleWrap>
         <EventMessage
           showUnhandled={group.isUnhandled}
@@ -80,4 +91,11 @@ const Title = styled('h3')`
   @media (min-width: ${props => props.theme.breakpoints.small}) {
     font-size: ${p => p.theme.headerFontSize};
   }
+`;
+
+const TimeStamp = styled('div')`
+  color: ${p => p.theme.headingColor};
+  font-size: ${p => p.theme.fontSizeMedium};
+  line-height: ${p => p.theme.text.lineHeightHeading};
+  margin-top: ${space(0)};
 `;

--- a/static/app/views/sharedGroupDetails/sharedGroupHeader.tsx
+++ b/static/app/views/sharedGroupDetails/sharedGroupHeader.tsx
@@ -55,6 +55,18 @@ function SharedGroupHeader({group}: Props) {
                   <DateTime date={date.toLocaleString()} />
                 </Tooltip>
               </EventTimeLabel>
+              {'Last seen '}
+
+              <EventTimeLabel>
+                <Tooltip
+                  isHoverable
+                  showUnderline
+                  title={<EventCreatedTooltip event={event} />}
+                  overlayStyle={{maxWidth: 300}}
+                >
+                  <DateTime date={date.toLocaleString()} />
+                </Tooltip>
+              </EventTimeLabel>
             </TimeStamp>
           )}
         </TitleWrap>

--- a/static/app/views/sharedGroupDetails/sharedGroupHeader.tsx
+++ b/static/app/views/sharedGroupDetails/sharedGroupHeader.tsx
@@ -1,14 +1,18 @@
 import styled from '@emotion/styled';
 
 import FeatureBadge from 'sentry/components/badge/featureBadge';
-// import {DateTime} from 'sentry/components/dateTime';
+import {DateTime} from 'sentry/components/dateTime';
 import EventMessage from 'sentry/components/events/eventMessage';
 import ProjectBadge from 'sentry/components/idBadge/projectBadge';
 import ShortId from 'sentry/components/shortId';
+import {Tooltip} from 'sentry/components/tooltip';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
+import type {Event} from 'sentry/types/event';
 import type {Group} from 'sentry/types/group';
 import {IssueCategory} from 'sentry/types/group';
+import getDynamicText from 'sentry/utils/getDynamicText';
+import EventCreatedTooltip from 'sentry/views/issueDetails/eventCreatedTooltip';
 
 type Props = {
   group: Group;
@@ -16,6 +20,8 @@ type Props = {
 
 function SharedGroupHeader({group}: Props) {
   const date = group.latestEvent?.dateReceived ?? group.latestEvent?.dateCreated;
+  const d = new Date(date as string);
+  const event = group.latestEvent as Event;
   return (
     <Wrapper>
       <Details>
@@ -37,12 +43,25 @@ function SharedGroupHeader({group}: Props) {
           </ShortIdWrapper>
 
           <TimeStamp>
-            {'Last Seen: '}
-            {(date as string).toLocaleString()}
-            {/* <DateTime
-              // date={group.latestEvent?.dateReceived ?? group.latestEvent?.dateCreated}
-              date = {(date as string).toLocaleString()}
-            /> */}
+            {'Last seen '}
+            {(event.dateCreated ?? event.dateReceived) && (
+              <EventTimeLabel>
+                {getDynamicText({
+                  fixed: 'Jan 1, 12:00 AM',
+                  value: (
+                    <Tooltip
+                      isHoverable
+                      showUnderline
+                      title={<EventCreatedTooltip event={event} />}
+                      overlayStyle={{maxWidth: 300}}
+                    >
+                      <DateTime date={d.toLocaleString()} />
+                      {/* {d.toLocaleString('default', {month: 'long'})} */}
+                    </Tooltip>
+                  ),
+                })}
+              </EventTimeLabel>
+            )}
           </TimeStamp>
         </TitleWrap>
         <EventMessage
@@ -98,4 +117,8 @@ const TimeStamp = styled('div')`
   font-size: ${p => p.theme.fontSizeMedium};
   line-height: ${p => p.theme.text.lineHeightHeading};
   margin-top: ${space(0)};
+`;
+
+const EventTimeLabel = styled('span')`
+  color: ${p => p.theme.subText};
 `;

--- a/static/app/views/sharedGroupDetails/sharedGroupHeader.tsx
+++ b/static/app/views/sharedGroupDetails/sharedGroupHeader.tsx
@@ -42,7 +42,7 @@ function SharedGroupHeader({group}: Props) {
             )}
           </ShortIdWrapper>
 
-          <TimeStamp>
+          <TimeStamp data-test-id="sgh-timestamp">
             {'Last seen '}
             {(event.dateCreated ?? event.dateReceived) && (
               <EventTimeLabel>
@@ -56,7 +56,6 @@ function SharedGroupHeader({group}: Props) {
                       overlayStyle={{maxWidth: 300}}
                     >
                       <DateTime date={d.toLocaleString()} />
-                      {/* {d.toLocaleString('default', {month: 'long'})} */}
                     </Tooltip>
                   ),
                 })}

--- a/static/app/views/sharedGroupDetails/sharedGroupHeader.tsx
+++ b/static/app/views/sharedGroupDetails/sharedGroupHeader.tsx
@@ -43,7 +43,7 @@ function SharedGroupHeader({group}: Props) {
           </ShortIdWrapper>
 
           <TimeStamp data-test-id="sgh-timestamp">
-            {'Last seen '}
+            {t('Last seen ')}
             {(event.dateCreated ?? event.dateReceived) && (
               <EventTimeLabel>
                 {getDynamicText({

--- a/static/app/views/sharedGroupDetails/sharedGroupHeader.tsx
+++ b/static/app/views/sharedGroupDetails/sharedGroupHeader.tsx
@@ -109,8 +109,10 @@ const TimeStamp = styled('div')`
   color: ${p => p.theme.headingColor};
   font-size: ${p => p.theme.fontSizeMedium};
   line-height: ${p => p.theme.text.lineHeightHeading};
+  margin-top: ${space(0.25)};
 `;
 
 const EventTimeLabel = styled('span')`
   color: ${p => p.theme.subText};
+  margin-left: ${space(0.25)};
 `;


### PR DESCRIPTION
Added timestamp of latest event on the issue public share page. ![image](https://github.com/getsentry/sentry/assets/173110007/5d4eaea6-f940-430f-82e5-20323b716d7c)
The timestamp shows local time, and a tooltip with date occurred and date received in UTC appears on hover. 

resolves #71642