### PR TITLE
dev(nodestore): add more spans to nodestore and bigtable

### DIFF
--- a/src/sentry/nodestore/bigtable/backend.py
+++ b/src/sentry/nodestore/bigtable/backend.py
@@ -66,6 +66,7 @@ class BigtableNodeStorage(NodeStorage):
     def _get_bytes(self, id: str) -> bytes | None:
         return self.store.get(id)
 
+    @sentry_sdk.tracing.trace
     def _get_bytes_multi(self, id_list: list[str]) -> dict[str, bytes | None]:
         rv: dict[str, bytes | None] = {id: None for id in id_list}
         rv.update(self.store.get_many(id_list))

--- a/src/sentry/tasks/embeddings_grouping/utils.py
+++ b/src/sentry/tasks/embeddings_grouping/utils.py
@@ -378,6 +378,7 @@ def update_groups(project, seer_response, group_id_batch_filtered, group_hashes_
 
 
 @metrics.wraps(f"{BACKFILL_NAME}.lookup_event_bulk", sample_rate=1.0)
+@sentry_sdk.tracing.trace
 def lookup_group_data_stacktrace_bulk(
     project: Project, rows: list[GroupEventRow]
 ) -> dict[int, Event]:


### PR DESCRIPTION
<img width="915" alt="Screenshot 2024-06-25 at 3 57 42 PM" src="https://github.com/getsentry/sentry/assets/1976777/6fb841f7-446c-4463-b87b-a1033c967915">
right now we don't get a lot of info from this span. i'd like to see within it, what takes the majority of the time. adds more sentry spans.