### PR TITLE
feat(replay): add playback speed for mobile

### DIFF
--- a/static/app/components/replays/replayContext.tsx
+++ b/static/app/components/replays/replayContext.tsx
@@ -539,6 +539,7 @@ export function Provider({
         },
         clipWindow,
         durationMs,
+        speed: savedReplayConfigRef.current.playbackSpeed,
         // rrweb specific
         theme,
         events: events ?? [],

--- a/static/app/components/replays/replayController.tsx
+++ b/static/app/components/replays/replayController.tsx
@@ -20,7 +20,7 @@ const COMPACT_WIDTH_BREAKPOINT = 500;
 
 interface Props {
   toggleFullscreen: () => void;
-  disableSettings?: boolean;
+  disableFastForward?: boolean;
   isLoading?: boolean;
   speedOptions?: number[];
 }
@@ -63,10 +63,10 @@ function ReplayPlayPauseBar() {
 
 function ReplayOptionsMenu({
   speedOptions,
-  disableSettings,
+  disableFastForward,
   isLoading,
 }: {
-  disableSettings: boolean;
+  disableFastForward: boolean;
   speedOptions: number[];
   isLoading?: boolean;
 }) {
@@ -79,14 +79,12 @@ function ReplayOptionsMenu({
         <Button
           {...triggerProps}
           size="sm"
-          title={
-            disableSettings ? t('Playback settings are not available yet') : t('Settings')
-          }
+          title={t('Settings')}
           aria-label={t('Settings')}
           icon={<IconSettings size="sm" />}
         />
       )}
-      disabled={isLoading || disableSettings}
+      disabled={isLoading}
     >
       <CompositeSelect.Region
         label={t('Playback Speed')}
@@ -97,27 +95,29 @@ function ReplayOptionsMenu({
           value: option,
         }))}
       />
-      <CompositeSelect.Region
-        aria-label={t('Fast-Forward Inactivity')}
-        multiple
-        value={isSkippingInactive ? [SKIP_OPTION_VALUE] : []}
-        onChange={opts => {
-          toggleSkipInactive(opts.length > 0);
-        }}
-        options={[
-          {
-            label: t('Fast-forward inactivity'),
-            value: SKIP_OPTION_VALUE,
-          },
-        ]}
-      />
+      {disableFastForward ? null : (
+        <CompositeSelect.Region
+          aria-label={t('Fast-Forward Inactivity')}
+          multiple
+          value={isSkippingInactive ? [SKIP_OPTION_VALUE] : []}
+          onChange={opts => {
+            toggleSkipInactive(opts.length > 0);
+          }}
+          options={[
+            {
+              label: t('Fast-forward inactivity'),
+              value: SKIP_OPTION_VALUE,
+            },
+          ]}
+        />
+      )}
     </CompositeSelect>
   );
 }
 
 function ReplayControls({
   toggleFullscreen,
-  disableSettings = false,
+  disableFastForward = false,
   speedOptions = [0.1, 0.25, 0.5, 1, 2, 4, 8, 16],
   isLoading,
 }: Props) {
@@ -147,7 +147,7 @@ function ReplayControls({
         <ReplayOptionsMenu
           isLoading={isLoading}
           speedOptions={speedOptions}
-          disableSettings={disableSettings}
+          disableFastForward={disableFastForward}
         />
         <ReplayFullscreenButton toggleFullscreen={toggleFullscreen} />
       </ButtonBar>

--- a/static/app/components/replays/replayView.tsx
+++ b/static/app/components/replays/replayView.tsx
@@ -70,7 +70,7 @@ function ReplayView({toggleFullscreen, isLoading}: Props) {
       {isFullscreen ? (
         <ReplayController
           toggleFullscreen={toggleFullscreen}
-          disableSettings={isVideoReplay}
+          disableFastForward={isVideoReplay}
         />
       ) : null}
     </Fragment>

--- a/static/app/components/replays/videoReplayer.spec.tsx
+++ b/static/app/components/replays/videoReplayer.spec.tsx
@@ -88,6 +88,7 @@ describe('VideoReplayer - no starting gap', () => {
       onLoaded: jest.fn(),
       onBuffer: jest.fn(),
       durationMs: 40000,
+      config: {skipInactive: false, speed: 1.0},
     });
     // @ts-expect-error private
     expect(inst._currentIndex).toEqual(0);
@@ -114,6 +115,7 @@ describe('VideoReplayer - no starting gap', () => {
       onLoaded: jest.fn(),
       onBuffer: jest.fn(),
       durationMs: 40000,
+      config: {skipInactive: false, speed: 1.0},
     });
     const playPromise = inst.play(18100);
     // @ts-expect-error private
@@ -143,6 +145,7 @@ describe('VideoReplayer - no starting gap', () => {
       onLoaded: jest.fn(),
       onBuffer: jest.fn(),
       durationMs: 40000,
+      config: {skipInactive: false, speed: 1.0},
     });
     const playPromise = inst.play(50000);
     // 15000 -> 20000 is a gap, so player should start playing @ index 3, from
@@ -166,6 +169,7 @@ describe('VideoReplayer - no starting gap', () => {
       onLoaded: jest.fn(),
       onBuffer: jest.fn(),
       durationMs: 40000,
+      config: {skipInactive: false, speed: 1.0},
     });
     const playPromise = inst.play(0);
     jest.advanceTimersByTime(2500);
@@ -186,6 +190,7 @@ describe('VideoReplayer - no starting gap', () => {
       onLoaded: jest.fn(),
       onBuffer: jest.fn(),
       durationMs: 50000,
+      config: {skipInactive: false, speed: 1.0},
     });
     // play at segment 7
     const playPromise = inst.play(45_003);
@@ -221,6 +226,7 @@ describe('VideoReplayer - no starting gap', () => {
       onLoaded: jest.fn(),
       onBuffer: jest.fn(),
       durationMs: 55000,
+      config: {skipInactive: false, speed: 1.0},
     });
     // play at segment 7
     const playPromise = inst.play(45_003);
@@ -295,6 +301,7 @@ describe('VideoReplayer - with starting gap', () => {
       onLoaded: jest.fn(),
       onBuffer: jest.fn(),
       durationMs: 40000,
+      config: {skipInactive: false, speed: 1.0},
     });
     // @ts-expect-error private
     expect(inst._currentIndex).toEqual(0);
@@ -319,6 +326,7 @@ describe('VideoReplayer - with starting gap', () => {
       onLoaded: jest.fn(),
       onBuffer: jest.fn(),
       durationMs: 40000,
+      config: {skipInactive: false, speed: 1.0},
     });
     const playPromise = inst.play(18100);
     // @ts-expect-error private
@@ -348,6 +356,7 @@ describe('VideoReplayer - with starting gap', () => {
       onLoaded: jest.fn(),
       onBuffer: jest.fn(),
       durationMs: 40000,
+      config: {skipInactive: false, speed: 1.0},
     });
     const playPromise = inst.play(50000);
     // 15000 -> 20000 is a gap, so player should start playing @ index 3, from
@@ -413,6 +422,7 @@ describe('VideoReplayer - with ending gap', () => {
       onLoaded: jest.fn(),
       onBuffer: jest.fn(),
       durationMs: 50000,
+      config: {skipInactive: false, speed: 1.0},
     });
     // actual length of the segments is 40s
     // 10s gap at the end
@@ -451,6 +461,7 @@ describe('VideoReplayer - with ending gap', () => {
       onLoaded: jest.fn(),
       onBuffer: jest.fn(),
       durationMs: 50000,
+      config: {skipInactive: false, speed: 1.0},
     });
     // actual length of the segments is 40s
     // 10s gap at the end

--- a/static/app/components/replays/videoReplayer.tsx
+++ b/static/app/components/replays/videoReplayer.tsx
@@ -14,6 +14,7 @@ interface OffsetOptions {
 }
 
 interface VideoReplayerOptions {
+  config: VideoReplayerConfig;
   durationMs: number;
   onBuffer: (isBuffering: boolean) => void;
   onFinished: () => void;
@@ -58,10 +59,7 @@ export class VideoReplayer {
   private _videoApiPrefix: string;
   private _clipDuration: number | undefined;
   private _durationMs: number;
-  public config: VideoReplayerConfig = {
-    skipInactive: false,
-    speed: 1.0,
-  };
+  public config: VideoReplayerConfig;
   public wrapper: HTMLElement;
   public iframe = {};
 
@@ -76,6 +74,7 @@ export class VideoReplayer {
       onLoaded,
       clipWindow,
       durationMs,
+      config,
     }: VideoReplayerOptions
   ) {
     this._attachments = attachments;
@@ -90,6 +89,7 @@ export class VideoReplayer {
     this._videos = new Map<any, HTMLVideoElement>();
     this._clipDuration = undefined;
     this._durationMs = durationMs;
+    this.config = config;
 
     this.wrapper = document.createElement('div');
     if (root) {
@@ -204,7 +204,6 @@ export class VideoReplayer {
     el.setAttribute('muted', '');
     el.setAttribute('playinline', '');
     el.setAttribute('preload', 'auto');
-    // TODO: Timer needs to also account for playback speed
     el.setAttribute('playbackRate', `${this.config.speed}`);
     el.appendChild(sourceEl);
 
@@ -677,6 +676,7 @@ export class VideoReplayer {
         return;
       }
       currentVideo.playbackRate = this.config.speed;
+      this._timer.setSpeed(this.config.speed);
     }
   }
 }

--- a/static/app/components/replays/videoReplayerWithInteractions.tsx
+++ b/static/app/components/replays/videoReplayerWithInteractions.tsx
@@ -16,6 +16,7 @@ interface VideoReplayerWithInteractionsOptions {
   onFinished: () => void;
   onLoaded: (event: any) => void;
   root: RootElem;
+  speed: number;
   start: number;
   theme: Theme;
   videoApiPrefix: string;
@@ -28,10 +29,7 @@ interface VideoReplayerWithInteractionsOptions {
  * We need both instances in order to render the video playback alongside gestures.
  */
 export class VideoReplayerWithInteractions {
-  public config: VideoReplayerConfig = {
-    skipInactive: false,
-    speed: 1.0,
-  };
+  public config: VideoReplayerConfig;
   private videoReplayer: VideoReplayer;
   private replayer: Replayer;
 
@@ -47,7 +45,13 @@ export class VideoReplayerWithInteractions {
     clipWindow,
     durationMs,
     theme,
+    speed,
   }: VideoReplayerWithInteractionsOptions) {
+    this.config = {
+      skipInactive: false,
+      speed,
+    };
+
     this.videoReplayer = new VideoReplayer(videoEvents, {
       videoApiPrefix,
       root,
@@ -57,6 +61,7 @@ export class VideoReplayerWithInteractions {
       onBuffer,
       clipWindow,
       durationMs,
+      config: this.config,
     });
 
     root?.classList.add('video-replayer');
@@ -111,6 +116,11 @@ export class VideoReplayerWithInteractions {
       plugins: [],
       skipInactive: false,
       speed: this.config.speed,
+    });
+
+    this.setConfig({
+      skipInactive: false,
+      speed,
     });
   }
 

--- a/static/app/utils/replays/timer.tsx
+++ b/static/app/utils/replays/timer.tsx
@@ -34,7 +34,7 @@ export class Timer extends EventTarget {
    */
   start(seconds?: number) {
     this._pausedAt = 0;
-    this._start = window.performance.now() - (seconds ?? 0);
+    this._start = window.performance.now() - (seconds ?? 0) / this._speed;
     this.resume();
     this.step();
   }

--- a/static/app/utils/replays/timer.tsx
+++ b/static/app/utils/replays/timer.tsx
@@ -9,13 +9,14 @@ export class Timer extends EventTarget {
   private _pausedAt: number = 0;
   private _additionalTime: number = 0;
   private _callbacks: Map<number, (() => void)[]> = new Map();
+  private _speed: number = 1;
 
   step = () => {
     if (!this._active) {
       return;
     }
 
-    this._time = window.performance.now() - this._start;
+    this._time = (window.performance.now() - this._start) * this._speed;
     // We don't expect _callbacks to be very large, so we can deal with a
     // linear search
     this._callbacks.forEach((value, key, callbacks) => {
@@ -108,5 +109,9 @@ export class Timer extends EventTarget {
     const callbacksAtOffset = this._callbacks.get(offset)!;
     callbacksAtOffset.push(callback);
     this._callbacks.set(offset, callbacksAtOffset);
+  }
+
+  setSpeed(speed: number) {
+    this._speed = speed;
   }
 }

--- a/static/app/utils/replays/timer.tsx
+++ b/static/app/utils/replays/timer.tsx
@@ -34,6 +34,9 @@ export class Timer extends EventTarget {
    */
   start(seconds?: number) {
     this._pausedAt = 0;
+    // we're dividing by the speed here because we mutiply
+    // by the same factor up in step(). doing the math,
+    // you'll see that this._time turns out to be just `seconds`.
     this._start = window.performance.now() - (seconds ?? 0) / this._speed;
     this.resume();
     this.step();

--- a/static/app/utils/replays/timer.tsx
+++ b/static/app/utils/replays/timer.tsx
@@ -34,7 +34,7 @@ export class Timer extends EventTarget {
    */
   start(seconds?: number) {
     this._pausedAt = 0;
-    // we're dividing by the speed here because we mutiply
+    // we're dividing by the speed here because we multiply
     // by the same factor up in step(). doing the math,
     // you'll see that this._time turns out to be just `seconds`.
     this._start = window.performance.now() - (seconds ?? 0) / this._speed;

--- a/static/app/views/replays/detail/layout/index.tsx
+++ b/static/app/views/replays/detail/layout/index.tsx
@@ -57,7 +57,7 @@ function ReplayLayout({
       <ReplayController
         isLoading={isLoading}
         toggleFullscreen={toggleFullscreen}
-        disableSettings={isVideoReplay}
+        disableFastForward={isVideoReplay}
       />
     </ErrorBoundary>
   );


### PR DESCRIPTION
- closes https://github.com/getsentry/sentry/issues/67842
- i disabled fast forward for now
- tested a bunch of scenarios:

playing all the way through on 8x:

https://github.com/getsentry/sentry/assets/56095982/01d9562d-bb74-4350-bedc-370ad6f281aa

seeking through the replay, pausing, and trying various speeds:

https://github.com/getsentry/sentry/assets/56095982/5496fa7c-3d8e-4a77-822a-99bf8944c684

seeking throughout the video on one speed:


https://github.com/getsentry/sentry/assets/56095982/5db16aea-de91-4a5f-b7c0-30a3910acd0b

playing thru video with various speeds (no pause):


https://github.com/getsentry/sentry/assets/56095982/b1cb5c4c-783e-4678-97a6-24861f0e8b4c

