### PR TITLE
perf(similarity): in backfill lower time bounds

### DIFF
--- a/src/sentry/tasks/embeddings_grouping/utils.py
+++ b/src/sentry/tasks/embeddings_grouping/utils.py
@@ -212,12 +212,12 @@ def get_data_from_snuba(project, groups_to_backfill_with_no_embedding):
                     Condition(
                         Column("timestamp", entity=events_entity),
                         Op.GTE,
-                        group.last_seen - timedelta(minutes=5),
+                        group.last_seen - timedelta(minutes=1),
                     ),
                     Condition(
                         Column("timestamp", entity=events_entity),
                         Op.LT,
-                        group.last_seen + timedelta(minutes=5),
+                        group.last_seen + timedelta(minutes=1),
                     ),
                 ],
                 limit=Limit(1),


### PR DESCRIPTION
lower time bounds to 1 minute, as we'll scan less data, and i think this should be plenty of range for it to find the last event sent.