### PR TITLE
fix(metrics-extraction): Streamline copy to span based metrics

### DIFF
--- a/static/app/views/settings/projectMetrics/metricsExtractionRulesTable.tsx
+++ b/static/app/views/settings/projectMetrics/metricsExtractionRulesTable.tsx
@@ -92,7 +92,7 @@ export function MetricsExtractionRulesTable({project}: Props) {
         <h6>{t('Span-based Metrics')}</h6>
         <FlexSpacer />
         <SearchBar
-          placeholder={t('Search Extraction Rules')}
+          placeholder={t('Search Metrics')}
           onChange={setQuery}
           query={query}
           size="sm"
@@ -156,8 +156,8 @@ function RulesTable({
       ]}
       emptyMessage={
         hasSearch
-          ? t('No extraction rules match the query.')
-          : t('You have not created any extraction rules yet.')
+          ? t('No metrics match the query.')
+          : t('You have not created any span-based metrics yet.')
       }
       isEmpty={extractionRules.length === 0}
       isLoading={isLoading}
@@ -193,14 +193,14 @@ function RulesTable({
             </Cell>
             <Cell right>
               <Button
-                aria-label={t('Delete rule')}
+                aria-label={t('Delete metric')}
                 size="xs"
                 icon={<IconDelete />}
                 borderless
                 onClick={() => onDelete(rule)}
               />
               <Button
-                aria-label={t('Edit rule')}
+                aria-label={t('Edit metric')}
                 size="xs"
                 icon={<IconEdit />}
                 borderless


### PR DESCRIPTION
Update some translations that still referenced `extraction rules`.