### PR TITLE
feat(uptime): Hook up subscription creation to the detector

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -468,6 +468,8 @@ def register_temporary_features(manager: FeatureManager):
     manager.add("organizations:transaction-name-sanitization", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
     # Enables automatic hostname detection in uptime
     manager.add("organizations:uptime-automatic-hostname-detection", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE)
+    # Enables automatic subscription creation in uptime
+    manager.add("organizations:uptime-automatic-subscription-creation", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE)
     # Enables uptime related settings for projects and orgs
     manager.add('organizations:uptime-settings', OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE)
     manager.add("organizations:use-metrics-layer", OrganizationFeature, FeatureHandlerStrategy.REMOTE)

--- a/src/sentry/testutils/factories.py
+++ b/src/sentry/testutils/factories.py
@@ -153,7 +153,11 @@ from sentry.testutils.silo import assume_test_silo_mode
 from sentry.types.activity import ActivityType
 from sentry.types.region import Region, get_local_region, get_region_by_name
 from sentry.types.token import AuthTokenType
-from sentry.uptime.models import ProjectUptimeSubscription, UptimeSubscription
+from sentry.uptime.models import (
+    ProjectUptimeSubscription,
+    ProjectUptimeSubscriptionMode,
+    UptimeSubscription,
+)
 from sentry.users.services.user import RpcUser
 from sentry.utils import loremipsum
 from sentry.utils.performance_issues.performance_problem import PerformanceProblem
@@ -1935,8 +1939,13 @@ class Factories:
         )
 
     @staticmethod
-    def create_project_uptime_subscription(project, uptime_subscription):
+    def create_project_uptime_subscription(
+        project: Project,
+        uptime_subscription: UptimeSubscription,
+        mode: ProjectUptimeSubscriptionMode,
+    ):
         return ProjectUptimeSubscription.objects.create(
             uptime_subscription=uptime_subscription,
             project=project,
+            mode=mode,
         )

--- a/src/sentry/testutils/fixtures.py
+++ b/src/sentry/testutils/fixtures.py
@@ -34,7 +34,11 @@ from sentry.testutils.silo import assume_test_silo_mode
 # all of the memoized fixtures are copypasta due to our inability to use pytest fixtures
 # on a per-class method basis
 from sentry.types.activity import ActivityType
-from sentry.uptime.models import ProjectUptimeSubscription, UptimeSubscription
+from sentry.uptime.models import (
+    ProjectUptimeSubscription,
+    ProjectUptimeSubscriptionMode,
+    UptimeSubscription,
+)
 from sentry.users.services.user import RpcUser
 
 
@@ -639,14 +643,17 @@ class Fixtures:
         )
 
     def create_project_uptime_subscription(
-        self, project: Project | None = None, uptime_subscription: UptimeSubscription | None = None
+        self,
+        project: Project | None = None,
+        uptime_subscription: UptimeSubscription | None = None,
+        mode=ProjectUptimeSubscriptionMode.AUTO_DETECTED_ACTIVE,
     ) -> ProjectUptimeSubscription:
         if project is None:
             project = self.project
 
         if uptime_subscription is None:
             uptime_subscription = self.create_uptime_subscription()
-        return Factories.create_project_uptime_subscription(project, uptime_subscription)
+        return Factories.create_project_uptime_subscription(project, uptime_subscription, mode)
 
     @pytest.fixture(autouse=True)
     def _init_insta_snapshot(self, insta_snapshot):

--- a/src/sentry/uptime/detectors/tasks.py
+++ b/src/sentry/uptime/detectors/tasks.py
@@ -14,7 +14,14 @@ from sentry.uptime.detectors.ranking import (
     get_candidate_urls_for_project,
     get_project_bucket,
 )
-from sentry.uptime.models import ProjectUptimeSubscription, UptimeSubscription
+from sentry.uptime.models import ProjectUptimeSubscriptionMode
+from sentry.uptime.subscriptions.subscriptions import (
+    create_project_uptime_subscription,
+    create_uptime_subscription,
+    delete_project_uptime_subscription,
+    get_auto_monitored_subscriptions_for_project,
+    is_url_auto_monitored_for_project,
+)
 from sentry.utils import metrics
 from sentry.utils.hashlib import md5_text
 from sentry.utils.locking import UnableToAcquireLock
@@ -24,6 +31,8 @@ SCHEDULER_LOCK_KEY = "uptime_detector_scheduler_lock"
 FAILED_URL_RETRY_FREQ = timedelta(days=7)
 URL_MIN_TIMES_SEEN = 5
 URL_MIN_PERCENT = 0.05
+ONBOARDING_SUBSCRIPTION_INTERVAL_SECONDS = int(timedelta(minutes=60).total_seconds())
+ONBOARDING_SUBSCRIPTION_TIMEOUT_MS = 1000
 
 logger = logging.getLogger("sentry.uptime-url-autodetection")
 
@@ -121,7 +130,7 @@ def process_candidate_url(
     Checks that:
      - URL has been seen at least `URL_MIN_TIMES_SEEN` times and is seen in at least `URL_MIN_PERCENT` of events with urls
      - URL hasn't already been checked and failed recently
-     - Whether we already have a subscription for this url in the system - If so, just link this project to that subscription
+     - Whether we are already monitoring this url for this project
      - Whether the url's robots.txt will allow us to monitor this url
 
     If the url passes, and we don't already have a subscription for it, then create a new remote subscription for the
@@ -141,34 +150,21 @@ def process_candidate_url(
     if url_count < URL_MIN_TIMES_SEEN or url_count / project_url_count < URL_MIN_PERCENT:
         return False
 
+    # See if we're already auto monitoring this url on this project
+    if is_url_auto_monitored_for_project(project, url):
+        # Just mark this successful so `process_project_url_ranking` will choose to not process urls for this project
+        # for a week
+        return True
+
     # Check whether we've recently attempted to monitor this url recently and failed.
     if is_failed_url(url):
         return False
-
-    # See if we're monitoring this url at all
-    try:
-        # TODO: We should have a column that lets us filter to detected urls
-        existing_subscription = UptimeSubscription.objects.get(url=url, interval_seconds=300)
-    except UptimeSubscription.DoesNotExist:
-        existing_subscription = None
-
-    if existing_subscription:
-        # Since we already have an existing subscription to this url, we don't need to perform any other checks
-        # The subscription will have already been created in the rust checker, so we can just link to the
-        # subscription here if we aren't already monitoring it in this project.
-        ProjectUptimeSubscription.objects.get_or_create(
-            project=project, uptime_subscription=existing_subscription
-        )
-        return True
 
     # Check robots.txt to see if it's ok for us to attempt to monitor this url
     if not check_url_robots_txt(url):
         set_failed_url(url)
         return False
 
-    # If we hit this point, then the url looks worth monitoring. Create an uptime subscription in monitor mode.
-    # Also check if there's already an existing auto detected monitor for this project. If so, delete it.
-    # TODO: Implement subscriptions
     logger.info(
         "uptime.url_autodetected",
         extra={
@@ -176,11 +172,28 @@ def process_candidate_url(
             "project": project.id,
         },
     )
+    # If we hit this point, then the url looks worth monitoring. Create an uptime subscription in monitor mode.
+    # Also check if there's already an existing auto-detected monitor for this project. If so, delete it.
+    monitor_url_for_project(project, url)
     return True
 
 
+def monitor_url_for_project(project: Project, url: str):
+    """
+    Start monitoring a url for a project. Creates a subscription using our onboarding interval and links the project to
+    it. Also deletes any other auto detected monitors since this one should replace them.
+    """
+    for monitored_subscription in get_auto_monitored_subscriptions_for_project(project):
+        delete_project_uptime_subscription(project, monitored_subscription.uptime_subscription)
+    subscription = create_uptime_subscription(
+        url, ONBOARDING_SUBSCRIPTION_INTERVAL_SECONDS, ONBOARDING_SUBSCRIPTION_TIMEOUT_MS
+    )
+    create_project_uptime_subscription(
+        project, subscription, ProjectUptimeSubscriptionMode.AUTO_DETECTED_ONBOARDING
+    )
+
+
 def is_failed_url(url: str) -> bool:
-    # TODO: Hash this
     key = get_failed_url_key(url)
     return _get_cluster().exists(key) == 1
 
@@ -190,7 +203,7 @@ def set_failed_url(url: str) -> None:
     If we failed to monitor a url for some reason, skip processing it for FAILED_URL_RETRY_FREQ
     """
     key = get_failed_url_key(url)
-    # TODO: Jitter
+    # TODO: Jitter the expiry here, so we don't retry all at the same time.
     _get_cluster().set(key, 1, ex=FAILED_URL_RETRY_FREQ)
 
 

--- a/src/sentry/uptime/models.py
+++ b/src/sentry/uptime/models.py
@@ -41,7 +41,7 @@ class UptimeSubscription(BaseRemoteSubscription, DefaultFieldsModel):
         ]
 
 
-class ProjectUptimeSubscriptionMode(enum.Enum):
+class ProjectUptimeSubscriptionMode(enum.IntEnum):
     # Manually created by a user
     MANUAL = 1
     # Auto-detected by our system and in the onboarding stage

--- a/src/sentry/uptime/subscriptions/subscriptions.py
+++ b/src/sentry/uptime/subscriptions/subscriptions.py
@@ -1,7 +1,11 @@
 import logging
 
 from sentry.models.project import Project
-from sentry.uptime.models import ProjectUptimeSubscription, UptimeSubscription
+from sentry.uptime.models import (
+    ProjectUptimeSubscription,
+    ProjectUptimeSubscriptionMode,
+    UptimeSubscription,
+)
 from sentry.uptime.subscriptions.tasks import (
     create_remote_uptime_subscription,
     delete_remote_uptime_subscription,
@@ -49,13 +53,17 @@ def delete_uptime_subscription(uptime_subscription: UptimeSubscription):
 
 
 def create_project_uptime_subscription(
-    project: Project, uptime_subscription: UptimeSubscription
+    project: Project,
+    uptime_subscription: UptimeSubscription,
+    mode: ProjectUptimeSubscriptionMode,
 ) -> ProjectUptimeSubscription:
     """
     Links a project to an uptime subscription so that it can process results.
     """
     return ProjectUptimeSubscription.objects.get_or_create(
-        project=project, uptime_subscription=uptime_subscription
+        project=project,
+        uptime_subscription=uptime_subscription,
+        mode=mode.value,
     )[0]
 
 
@@ -64,6 +72,7 @@ def delete_project_uptime_subscription(project: Project, uptime_subscription: Up
     Deletes the link from a project to an `UptimeSubscription`. Also checks to see if the subscription
     has been orphaned, and if so removes it as well.
     """
+    # TODO: Have a way to specify which mode(s) we should actually delete here.
     try:
         uptime_project_subscription = ProjectUptimeSubscription.objects.get(
             project=project, uptime_subscription=uptime_subscription
@@ -76,3 +85,28 @@ def delete_project_uptime_subscription(project: Project, uptime_subscription: Up
     # If the uptime subscription is no longer used, we also remove it.
     if not uptime_subscription.projectuptimesubscription_set.exists():
         delete_uptime_subscription(uptime_subscription)
+
+
+def is_url_auto_monitored_for_project(project: Project, url: str) -> bool:
+    return ProjectUptimeSubscription.objects.filter(
+        project=project,
+        mode__in=(
+            ProjectUptimeSubscriptionMode.AUTO_DETECTED_ONBOARDING.value,
+            ProjectUptimeSubscriptionMode.AUTO_DETECTED_ACTIVE.value,
+        ),
+        uptime_subscription__url=url,
+    ).exists()
+
+
+def get_auto_monitored_subscriptions_for_project(
+    project: Project,
+) -> list[ProjectUptimeSubscription]:
+    return list(
+        ProjectUptimeSubscription.objects.filter(
+            project=project,
+            mode__in=(
+                ProjectUptimeSubscriptionMode.AUTO_DETECTED_ONBOARDING.value,
+                ProjectUptimeSubscriptionMode.AUTO_DETECTED_ACTIVE.value,
+            ),
+        ).select_related("uptime_subscription")
+    )

--- a/tests/sentry/uptime/detectors/test_tasks.py
+++ b/tests/sentry/uptime/detectors/test_tasks.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from datetime import timedelta
 from unittest import mock
 from unittest.mock import call
@@ -16,15 +18,21 @@ from sentry.uptime.detectors.ranking import (
 )
 from sentry.uptime.detectors.tasks import (
     LAST_PROCESSED_KEY,
+    ONBOARDING_SUBSCRIPTION_INTERVAL_SECONDS,
     SCHEDULER_LOCK_KEY,
     is_failed_url,
+    monitor_url_for_project,
     process_candidate_url,
     process_detection_bucket,
     process_project_url_ranking,
     schedule_detections,
     set_failed_url,
 )
-from sentry.uptime.models import ProjectUptimeSubscription
+from sentry.uptime.models import ProjectUptimeSubscription, ProjectUptimeSubscriptionMode
+from sentry.uptime.subscriptions.subscriptions import (
+    get_auto_monitored_subscriptions_for_project,
+    is_url_auto_monitored_for_project,
+)
 
 
 @freeze_time()
@@ -140,43 +148,31 @@ class ProcessProjectUrlRankingTest(TestCase):
 @freeze_time()
 class ProcessCandidateUrlTest(TestCase):
     def test_succeeds_new(self):
+        url = "https://sentry.io"
+        assert not is_url_auto_monitored_for_project(self.project, url)
         assert process_candidate_url(self.project, 100, "https://sentry.io", 50)
+        assert is_url_auto_monitored_for_project(self.project, url)
 
     def test_succeeds_existing_subscription_other_project(self):
         other_project = self.create_project()
         url = "https://sentry.io"
-        uptime_subscription = self.create_uptime_subscription(url=url, interval_seconds=300)
+        uptime_subscription = self.create_uptime_subscription(
+            url=url, interval_seconds=ONBOARDING_SUBSCRIPTION_INTERVAL_SECONDS
+        )
         self.create_project_uptime_subscription(
             project=other_project, uptime_subscription=uptime_subscription
         )
-        assert (
-            ProjectUptimeSubscription.objects.filter(
-                project=self.project, uptime_subscription=uptime_subscription
-            ).count()
-            == 0
-        )
+        assert not is_url_auto_monitored_for_project(self.project, url)
         assert process_candidate_url(self.project, 100, url, 50)
-        assert (
-            ProjectUptimeSubscription.objects.filter(
-                project=self.project, uptime_subscription=uptime_subscription
-            ).count()
-            == 1
-        )
+        assert is_url_auto_monitored_for_project(self.project, url)
 
     def test_succeeds_existing_subscription_this_project(self):
         url = "https://sentry.io"
-        uptime_subscription = self.create_uptime_subscription(url=url, interval_seconds=300)
-        self.create_project_uptime_subscription(
-            project=self.project, uptime_subscription=uptime_subscription
-        )
         assert process_candidate_url(self.project, 100, url, 50)
-        assert (
-            ProjectUptimeSubscription.objects.filter(
-                project=self.project, uptime_subscription=uptime_subscription
-            ).count()
-            == 1
-        )
-        # TODO: Check no other subscriptions or anything made once we finish the rest of this func
+        subscription = get_auto_monitored_subscriptions_for_project(self.project)[0]
+        assert process_candidate_url(self.project, 100, url, 50)
+        new_subscription = get_auto_monitored_subscriptions_for_project(self.project)[0]
+        assert subscription.id == new_subscription.id
 
     def test_below_thresholds(self):
         assert not process_candidate_url(self.project, 500, "https://sentry.io", 1)
@@ -205,3 +201,35 @@ class TestFailedUrl(TestCase):
         set_failed_url(url)
         assert is_failed_url(url)
         assert not is_failed_url("https://sentry.sentry.io")
+
+
+class TestMonitorUrlForProject(TestCase):
+    def test(self):
+        url = "http://sentry.io"
+        assert not is_url_auto_monitored_for_project(self.project, url)
+        monitor_url_for_project(self.project, url)
+        assert is_url_auto_monitored_for_project(self.project, url)
+
+    def test_existing(self):
+        url = "http://sentry.io"
+        monitor_url_for_project(self.project, url)
+        assert is_url_auto_monitored_for_project(self.project, url)
+        url_2 = "http://santry.io"
+        monitor_url_for_project(self.project, url_2)
+        assert not is_url_auto_monitored_for_project(self.project, url)
+        assert is_url_auto_monitored_for_project(self.project, url_2)
+
+    def test_manual_existing(self):
+        manual_url = "https://sentry.io"
+        self.create_project_uptime_subscription(
+            uptime_subscription=self.create_uptime_subscription(url=manual_url),
+            mode=ProjectUptimeSubscriptionMode.MANUAL,
+        )
+        url = "http://santry.io"
+        monitor_url_for_project(self.project, url)
+        assert is_url_auto_monitored_for_project(self.project, url)
+        assert ProjectUptimeSubscription.objects.filter(
+            project=self.project,
+            mode=ProjectUptimeSubscriptionMode.MANUAL,
+            uptime_subscription__url=manual_url,
+        ).exists()

--- a/tests/sentry/uptime/subscriptions/test_subscriptions.py
+++ b/tests/sentry/uptime/subscriptions/test_subscriptions.py
@@ -2,13 +2,19 @@ import pytest
 
 from sentry.testutils.cases import TestCase
 from sentry.testutils.skips import requires_kafka
-from sentry.uptime.models import ProjectUptimeSubscription, UptimeSubscription
+from sentry.uptime.models import (
+    ProjectUptimeSubscription,
+    ProjectUptimeSubscriptionMode,
+    UptimeSubscription,
+)
 from sentry.uptime.subscriptions.subscriptions import (
     UPTIME_SUBSCRIPTION_TYPE,
     create_project_uptime_subscription,
     create_uptime_subscription,
     delete_project_uptime_subscription,
     delete_uptime_subscription,
+    get_auto_monitored_subscriptions_for_project,
+    is_url_auto_monitored_for_project,
 )
 
 pytestmark = [requires_kafka]
@@ -99,15 +105,23 @@ class DeleteUptimeSubscriptionTest(TestCase):
 class CreateProjectUptimeSubscriptionTest(TestCase):
     def test(self):
         uptime_sub = create_uptime_subscription("https://sentry.io", 3600, 1000)
-        create_project_uptime_subscription(self.project, uptime_sub)
+        create_project_uptime_subscription(
+            self.project, uptime_sub, ProjectUptimeSubscriptionMode.AUTO_DETECTED_ACTIVE
+        )
         assert ProjectUptimeSubscription.objects.filter(
-            project=self.project, uptime_subscription=uptime_sub
+            project=self.project,
+            uptime_subscription=uptime_sub,
+            mode=ProjectUptimeSubscriptionMode.AUTO_DETECTED_ACTIVE,
         ).exists()
 
     def test_already_exists(self):
         uptime_sub = create_uptime_subscription("https://sentry.io", 3600, 1000)
-        create_project_uptime_subscription(self.project, uptime_sub)
-        create_project_uptime_subscription(self.project, uptime_sub)
+        create_project_uptime_subscription(
+            self.project, uptime_sub, ProjectUptimeSubscriptionMode.AUTO_DETECTED_ACTIVE
+        )
+        create_project_uptime_subscription(
+            self.project, uptime_sub, ProjectUptimeSubscriptionMode.AUTO_DETECTED_ACTIVE
+        )
         assert (
             ProjectUptimeSubscription.objects.filter(
                 project=self.project, uptime_subscription=uptime_sub
@@ -115,13 +129,32 @@ class CreateProjectUptimeSubscriptionTest(TestCase):
             == 1
         )
 
+    def test_different_modes(self):
+        uptime_sub = create_uptime_subscription("https://sentry.io", 3600, 1000)
+        create_project_uptime_subscription(
+            self.project, uptime_sub, ProjectUptimeSubscriptionMode.AUTO_DETECTED_ACTIVE
+        )
+        create_project_uptime_subscription(
+            self.project, uptime_sub, ProjectUptimeSubscriptionMode.MANUAL
+        )
+        assert (
+            ProjectUptimeSubscription.objects.filter(
+                project=self.project, uptime_subscription=uptime_sub
+            ).count()
+            == 2
+        )
+
 
 class DeleteProjectUptimeSubscriptionTest(TestCase):
     def test_other_subscriptions(self):
         other_project = self.create_project()
         uptime_sub = create_uptime_subscription("https://sentry.io", 3600, 1000)
-        proj_sub = create_project_uptime_subscription(self.project, uptime_sub)
-        create_project_uptime_subscription(other_project, uptime_sub)
+        proj_sub = create_project_uptime_subscription(
+            self.project, uptime_sub, ProjectUptimeSubscriptionMode.AUTO_DETECTED_ACTIVE
+        )
+        create_project_uptime_subscription(
+            other_project, uptime_sub, ProjectUptimeSubscriptionMode.AUTO_DETECTED_ACTIVE
+        )
         with self.tasks():
             delete_project_uptime_subscription(self.project, uptime_sub)
 
@@ -132,7 +165,9 @@ class DeleteProjectUptimeSubscriptionTest(TestCase):
 
     def test_single_subscriptions(self):
         uptime_sub = create_uptime_subscription("https://sentry.io", 3600, 1000)
-        proj_sub = create_project_uptime_subscription(self.project, uptime_sub)
+        proj_sub = create_project_uptime_subscription(
+            self.project, uptime_sub, ProjectUptimeSubscriptionMode.AUTO_DETECTED_ACTIVE
+        )
         with self.tasks():
             delete_project_uptime_subscription(self.project, uptime_sub)
 
@@ -153,8 +188,73 @@ class DeleteProjectUptimeSubscriptionTest(TestCase):
     def test_does_not_exist_other_subs(self):
         other_project = self.create_project()
         uptime_sub = create_uptime_subscription("https://sentry.io", 3600, 1000)
-        create_project_uptime_subscription(other_project, uptime_sub)
+        create_project_uptime_subscription(
+            other_project, uptime_sub, ProjectUptimeSubscriptionMode.AUTO_DETECTED_ACTIVE
+        )
         with self.tasks():
             delete_project_uptime_subscription(self.project, uptime_sub)
 
         assert UptimeSubscription.objects.filter(id=uptime_sub.id).exists()
+
+
+class IsUrlMonitoredForProjectTest(TestCase):
+    def test_not_monitored(self):
+        assert not is_url_auto_monitored_for_project(self.project, "https://sentry.io")
+        subscription = self.create_project_uptime_subscription(
+            uptime_subscription=self.create_uptime_subscription(),
+            mode=ProjectUptimeSubscriptionMode.MANUAL,
+        )
+        assert not is_url_auto_monitored_for_project(
+            self.project, subscription.uptime_subscription.url
+        )
+
+    def test_monitored(self):
+        subscription = self.create_project_uptime_subscription(
+            uptime_subscription=self.create_uptime_subscription(),
+            mode=ProjectUptimeSubscriptionMode.AUTO_DETECTED_ACTIVE,
+        )
+        assert is_url_auto_monitored_for_project(self.project, subscription.uptime_subscription.url)
+
+    def test_monitored_other_project(self):
+        other_project = self.create_project()
+        subscription = self.create_project_uptime_subscription(
+            uptime_subscription=self.create_uptime_subscription(),
+            project=self.project,
+            mode=ProjectUptimeSubscriptionMode.AUTO_DETECTED_ACTIVE,
+        )
+        assert is_url_auto_monitored_for_project(self.project, subscription.uptime_subscription.url)
+        assert not is_url_auto_monitored_for_project(
+            other_project, subscription.uptime_subscription.url
+        )
+
+
+class GetAutoMonitoredSubscriptionsForProjectTest(TestCase):
+    def test_empty(self):
+        assert get_auto_monitored_subscriptions_for_project(self.project) == []
+
+    def test(self):
+        subscription = self.create_project_uptime_subscription(
+            uptime_subscription=self.create_uptime_subscription(),
+            mode=ProjectUptimeSubscriptionMode.AUTO_DETECTED_ACTIVE,
+        )
+        assert get_auto_monitored_subscriptions_for_project(self.project) == [subscription]
+        other_subscription = self.create_project_uptime_subscription(
+            uptime_subscription=self.create_uptime_subscription(url="https://santry.io"),
+            mode=ProjectUptimeSubscriptionMode.AUTO_DETECTED_ONBOARDING,
+        )
+        self.create_project_uptime_subscription(
+            uptime_subscription=self.create_uptime_subscription(url="https://sintry.io"),
+            mode=ProjectUptimeSubscriptionMode.MANUAL,
+        )
+        assert set(get_auto_monitored_subscriptions_for_project(self.project)) == {
+            subscription,
+            other_subscription,
+        }
+
+    def test_other_project(self):
+        other_project = self.create_project()
+        self.create_project_uptime_subscription(
+            uptime_subscription=self.create_uptime_subscription(),
+            mode=ProjectUptimeSubscriptionMode.AUTO_DETECTED_ACTIVE,
+        )
+        assert get_auto_monitored_subscriptions_for_project(other_project) == []

--- a/tests/sentry/uptime/subscriptions/test_tasks.py
+++ b/tests/sentry/uptime/subscriptions/test_tasks.py
@@ -54,7 +54,6 @@ class BaseUptimeSubscriptionTaskTest(ProducerTestMixin, TestCase, metaclass=abc.
 
     status_translations = {
         UptimeSubscription.Status.CREATING: "create",
-        UptimeSubscription.Status.UPDATING: "update",
         UptimeSubscription.Status.DELETING: "delete",
     }
 


### PR DESCRIPTION
This allows the detector to start creating subscriptions for valid urls. It also adds a mode column to the `ProjectUptimeSubscription` table. We put it on this table and not the `UptimeSubscription` table since we want each project to perform validation itself, and also because we don't necessarily know that the subscription has been validated before - possibly it's a manual subscription that a user set up.

This isn't fully complete but is directional. Should mostly need tests to validate behaviour
