### PR TITLE
feat(metrics-extraction): Hide known numeric tags from tag selection

### DIFF
--- a/static/app/views/settings/projectMetrics/metricsExtractionRuleForm.tsx
+++ b/static/app/views/settings/projectMetrics/metricsExtractionRuleForm.tsx
@@ -15,6 +15,7 @@ import type {MetricType} from 'sentry/types/metrics';
 import type {Project} from 'sentry/types/project';
 import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import useOrganization from 'sentry/utils/useOrganization';
+import {SpanIndexedField} from 'sentry/views/insights/types';
 import {useSpanFieldSupportedTags} from 'sentry/views/performance/utils/useSpanFieldSupportedTags';
 
 export interface FormData {
@@ -43,6 +44,20 @@ const ListItemDetails = styled('span')`
   text-align: right;
   line-height: 1.2;
 `;
+
+const KNOWN_NUMERIC_FIELDS = new Set([
+  SpanIndexedField.SPAN_DURATION,
+  SpanIndexedField.SPAN_SELF_TIME,
+  SpanIndexedField.PROJECT_ID,
+  SpanIndexedField.INP,
+  SpanIndexedField.INP_SCORE,
+  SpanIndexedField.INP_SCORE_WEIGHT,
+  SpanIndexedField.TOTAL_SCORE,
+  SpanIndexedField.CACHE_ITEM_SIZE,
+  SpanIndexedField.MESSAGING_MESSAGE_BODY_SIZE,
+  SpanIndexedField.MESSAGING_MESSAGE_RECEIVE_LATENCY,
+  SpanIndexedField.MESSAGING_MESSAGE_RETRY_COUNT,
+]);
 
 const TYPE_OPTIONS = [
   {
@@ -112,6 +127,13 @@ export function MetricsExtractionRuleForm({isEdit, project, onSubmit, ...props}:
       .sort((a, b) => a.label.localeCompare(b.label));
   }, [customAttributes, supportedTags]);
 
+  const tagOptions = useMemo(() => {
+    return attributeOptions.filter(
+      // We don't want to suggest numeric fields as tags as they would explode cardinality
+      option => !KNOWN_NUMERIC_FIELDS.has(option.value as SpanIndexedField)
+    );
+  }, [attributeOptions]);
+
   const handleSubmit = useCallback(
     (
       data: Record<string, any>,
@@ -169,7 +191,7 @@ export function MetricsExtractionRuleForm({isEdit, project, onSubmit, ...props}:
           />
           <SelectField
             name="tags"
-            options={attributeOptions}
+            options={tagOptions}
             label={t('Group and filter by')}
             multiple
             placeholder={t('Select tags')}


### PR DESCRIPTION
To lessen the likelihood of creating extraction rules with extremely high metric cardinality, we hide known numeric tags from the tag selection.