### PR TITLE
feat[apis]: Clean-up events endpoints

### DIFF
--- a/src/sentry/api/endpoints/organization_events.py
+++ b/src/sentry/api/endpoints/organization_events.py
@@ -194,6 +194,7 @@ class OrganizationEventsEndpoint(OrganizationEventsV2EndpointBase):
     publish_status = {
         "GET": ApiPublishStatus.PUBLIC,
     }
+    snuba_methods = ["GET"]
 
     enforce_rate_limit = True
 

--- a/src/sentry/api/endpoints/organization_events_meta.py
+++ b/src/sentry/api/endpoints/organization_events_meta.py
@@ -23,6 +23,7 @@ class OrganizationEventsMetaEndpoint(OrganizationEventsEndpointBase):
     publish_status = {
         "GET": ApiPublishStatus.PRIVATE,
     }
+    snuba_methods = ["GET"]
 
     def get(self, request: Request, organization) -> Response:
         try:
@@ -37,7 +38,7 @@ class OrganizationEventsMetaEndpoint(OrganizationEventsEndpointBase):
                 selected_columns=["count()"],
                 params=params,
                 query=request.query_params.get("query"),
-                referrer="api.organization-events-meta",
+                referrer=Referrer.API_ORGANIZATION_EVENTS_META.value,
             )
 
         return Response({"count": result["data"][0]["count"]})
@@ -114,6 +115,7 @@ class OrganizationSpansSamplesEndpoint(OrganizationEventsEndpointBase):
     publish_status = {
         "GET": ApiPublishStatus.PRIVATE,
     }
+    snuba_methods = ["GET"]
 
     def get(self, request: Request, organization) -> Response:
         try:

--- a/src/sentry/api/endpoints/organization_events_stats.py
+++ b/src/sentry/api/endpoints/organization_events_stats.py
@@ -111,6 +111,7 @@ class OrganizationEventsStatsEndpoint(OrganizationEventsV2EndpointBase):
     publish_status = {
         "GET": ApiPublishStatus.UNKNOWN,
     }
+    sunba_methods = ["GET"]
 
     def get_features(self, organization: Organization, request: Request) -> Mapping[str, bool]:
         feature_names = [

--- a/src/sentry/api/endpoints/organization_events_trends_v2.py
+++ b/src/sentry/api/endpoints/organization_events_trends_v2.py
@@ -65,6 +65,7 @@ class OrganizationEventsNewTrendsStatsEndpoint(OrganizationEventsV2EndpointBase)
             ),
         }
     }
+    snuba_methods = ["GET"]
 
     def has_feature(self, organization, request):
         return features.has(
@@ -203,15 +204,17 @@ class OrganizationEventsNewTrendsStatsEndpoint(OrganizationEventsV2EndpointBase)
             for key, item in results.items():
                 formatted_results[key] = SnubaTSResult(
                     {
-                        "data": zerofill(
-                            item["data"],
-                            pruned_params["start"],
-                            pruned_params["end"],
-                            rollup,
-                            "time",
-                        )
-                        if zerofill_results
-                        else item["data"],
+                        "data": (
+                            zerofill(
+                                item["data"],
+                                pruned_params["start"],
+                                pruned_params["end"],
+                                rollup,
+                                "time",
+                            )
+                            if zerofill_results
+                            else item["data"]
+                        ),
                         "project": item["project_id"],
                         "isMetricsData": True,
                         "order": item["order"],

--- a/src/sentry/incidents/charts.py
+++ b/src/sentry/incidents/charts.py
@@ -23,6 +23,7 @@ from sentry.models.user import User
 from sentry.snuba.dataset import Dataset
 from sentry.snuba.entity_subscription import apply_dataset_query_conditions
 from sentry.snuba.models import QuerySubscription, SnubaQuery
+from sentry.snuba.referrer import Referrer
 from sentry.snuba.utils import build_query_strings
 
 CRASH_FREE_SESSIONS = "percentage(sessions_crashed, sessions) AS _crash_rate_alert_aggregate"
@@ -100,7 +101,7 @@ def fetch_metric_alert_events_timeseries(
             path=f"/organizations/{organization.slug}/events-stats/",
             params={
                 "yAxis": rule_aggregate,
-                "referrer": "api.alerts.chartcuterie",
+                "referrer": Referrer.API_ALERTS_CHARTCUTERIE.value,
                 **query_params,
             },
         )

--- a/src/sentry/integrations/issue_alert_image_builder.py
+++ b/src/sentry/integrations/issue_alert_image_builder.py
@@ -94,7 +94,7 @@ class IssueAlertImageBuilder:
             path=f"/organizations/{organization.slug}/events-stats/",
             data={
                 "yAxis": ["count()", "p95(transaction.duration)"],
-                "referrer": Referrer.API_ALERTS_CHARTCUTERIE,
+                "referrer": Referrer.API_ENDPOINT_REGRESSION_ALERT_CHARTCUTERIE,
                 "query": f'event.type:transaction transaction:"{transaction_name}"',
                 "project": self.group.project.id,
                 "start": period["start"].strftime("%Y-%m-%d %H:%M:%S"),
@@ -125,7 +125,7 @@ class IssueAlertImageBuilder:
             path=f"/organizations/{organization.slug}/events-stats/",
             data={
                 "dataset": "profileFunctions",
-                "referrer": Referrer.API_ALERTS_CHARTCUTERIE,
+                "referrer": Referrer.API_FUNCTION_REGRESSION_ALERT_CHARTCUTERIE,
                 "project": self.group.project.id,
                 "start": period["start"].strftime("%Y-%m-%d %H:%M:%S"),
                 "end": period["end"].strftime("%Y-%m-%d %H:%M:%S"),

--- a/src/sentry/snuba/referrer.py
+++ b/src/sentry/snuba/referrer.py
@@ -15,6 +15,8 @@ class Referrer(Enum):
     API_ALERTS_ALERT_RULE_CHART_METRICS_ENHANCED = "api.alerts.alert-rule-chart.metrics-enhanced"
     API_ALERTS_ALERT_RULE_CHART = "api.alerts.alert-rule-chart"
     API_ALERTS_CHARTCUTERIE = "api.alerts.chartcuterie"
+    API_ENDPOINT_REGRESSION_ALERT_CHARTCUTERIE = "api.endpoint_regression_alerts.chartcuterie"
+    API_FUNCTION_REGRESSION_ALERT_CHARTCUTERIE = "api.function_regression_alerts.chartcuterie"
     API_AUTH_TOKEN_EVENTS_METRICS_ENHANCED_PRIMARY = (
         "api.auth-token.events.metrics-enhanced.primary"
     )
@@ -562,6 +564,7 @@ class Referrer(Enum):
     API_TRACE_VIEW_SPAN_DETAIL = "api.trace-view.span-detail"
     API_TRACE_VIEW_COUNT_PERFORMANCE_ISSUES = "api.trace-view.count-performance-issues"
     API_TRACE_VIEW_GET_PARENTS = "api.trace-view.get-parents"
+    API_TRACE_VIEW_GET_OCCURRENCE_IDS = "api.trace-view.get-occurrence-ids"
     API_TRENDS_GET_EVENT_STATS = "api.trends.get-event-stats"
     API_TRENDS_GET_EVENT_STATS_V2_TOP_EVENTS = "api.trends.get-event-statsv2.top-events"
     API_TRENDS_GET_EVENT_STATS_V2_TOP_EVENTS_PRIMARY = (


### PR DESCRIPTION
I'm auditing REST apis that query snuba with the goal of improving rate-limiting. This PR is just cleanup and has no logic change but my audit notes about them are [here](https://www.notion.so/sentry/c56df9a9e4bf43acb30ba8af9577fded?v=0d62ffdadc3c431eb92c306d14d0f29d) if you're curious.