### PR TITLE
fix(insights): removes unneeded empty state logic from Web Vitals module

### DIFF
--- a/static/app/views/insights/browser/webVitals/views/webVitalsLandingPage.tsx
+++ b/static/app/views/insights/browser/webVitals/views/webVitalsLandingPage.tsx
@@ -55,10 +55,8 @@ export function WebVitalsLandingPage() {
   const {data: projectScores, isLoading: isProjectScoresLoading} =
     useProjectWebVitalsScoresQuery();
 
-  const noTransactions = !isLoading && !projectData?.data?.[0]?.['count()'];
-
   const projectScore =
-    isProjectScoresLoading || isLoading || noTransactions
+    isProjectScoresLoading || isLoading
       ? undefined
       : calculatePerformanceScoreFromStoredTableDataRow(projectScores?.data?.[0]);
 

--- a/static/app/views/performance/landing/widgets/widgets/performanceScoreWidget.tsx
+++ b/static/app/views/performance/landing/widgets/widgets/performanceScoreWidget.tsx
@@ -25,10 +25,8 @@ export function PerformanceScoreWidget(props: PerformanceWidgetProps) {
   const {data: projectScores, isLoading: isProjectScoresLoading} =
     useProjectWebVitalsScoresQuery();
 
-  const noTransactions = !isLoading && !projectData?.data?.[0]?.['count()'];
-
   const projectScore =
-    isProjectScoresLoading || isLoading || noTransactions
+    isProjectScoresLoading || isLoading
       ? undefined
       : calculatePerformanceScoreFromStoredTableDataRow(projectScores?.data?.[0]);
   const ringSegmentColors = theme.charts.getColorPalette(3);
@@ -77,7 +75,7 @@ export function PerformanceScoreWidget(props: PerformanceWidgetProps) {
         {
           component: () => (
             <Wrapper>
-              {projectScore && !noTransactions ? (
+              {projectScore ? (
                 <PerformanceScoreRingWithTooltips
                   inPerformanceWidget
                   projectScore={projectScore}


### PR DESCRIPTION
Deletes a redundant empty state from the Web Vitals module when no transactions are found. This is redundant and unneeded because we already have a different and better empty state when no score metrics are found

![image](https://github.com/getsentry/sentry/assets/83961295/3d3d2243-34ce-4e16-b044-56bb9fea3cb2)
