### PR TITLE
chore(slack): remove old slack client from get_users during integration setup

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -391,8 +391,6 @@ def register_temporary_features(manager: FeatureManager):
     # Enable improvements to Slack notifications
     manager.add("organizations:slack-improvements", OrganizationFeature, FeatureHandlerStrategy.OPTIONS)
     # Feature flags for migrating to the Slack SDK WebClient
-    # Use new Slack SDK Client for getting users
-    manager.add("organizations:slack-sdk-get-users", OrganizationFeature, FeatureHandlerStrategy.OPTIONS)
     # Use new Slack SDK Client in _notify_recipient
     manager.add("organizations:slack-sdk-notify-recipient", OrganizationFeature, FeatureHandlerStrategy.OPTIONS)
     # Use new Slack SDK Client in get_channel_id_with_timeout

--- a/src/sentry/integrations/slack/utils/__init__.py
+++ b/src/sentry/integrations/slack/utils/__init__.py
@@ -1,7 +1,5 @@
 __all__ = (
     "get_channel_id",
-    "get_slack_data_by_user",
-    "get_users",
     "is_valid_role",
     "logger",
     "RedisRuleStatus",
@@ -22,6 +20,5 @@ from .auth import is_valid_role, set_signing_secret
 from .channel import get_channel_id, strip_channel_name, validate_channel_id
 from .notifications import send_incident_alert_notification, send_slack_response
 from .rule_status import RedisRuleStatus
-from .users import get_slack_data_by_user, get_users
 
 SLACK_RATE_LIMITED_MESSAGE = "Requests to Slack exceeded the rate limit. Please try again later."

--- a/src/sentry/integrations/slack/utils/users.py
+++ b/src/sentry/integrations/slack/utils/users.py
@@ -6,14 +6,12 @@ from typing import Any
 
 from slack_sdk.errors import SlackApiError
 
-from sentry.integrations.slack.client import SlackClient
 from sentry.integrations.slack.sdk_client import SlackSdkClient
 from sentry.models.integrations.integration import Integration
 from sentry.models.organization import Organization
 from sentry.models.user import User
 from sentry.services.hybrid_cloud.integration import RpcIntegration
 from sentry.services.hybrid_cloud.organization import RpcOrganization
-from sentry.shared_integrations.exceptions import ApiError
 
 from ..utils import logger
 
@@ -26,67 +24,6 @@ class SlackUserData:
     email: str
     team_id: str
     slack_id: str
-
-
-def get_users(integration: Integration, organization: Organization) -> Sequence[Mapping[str, Any]]:
-    user_list = []
-    next_cursor = None
-
-    client = SlackClient(integration_id=integration.id)
-
-    for _ in range(SLACK_GET_USERS_PAGE_LIMIT):
-        try:
-            next_users = client.get(
-                "/users.list",
-                params={"limit": SLACK_GET_USERS_PAGE_SIZE, "cursor": next_cursor},
-            )
-        except ApiError as e:
-            logger.info(
-                "post_install.fail.slack_users.list",
-                extra={
-                    "error": str(e),
-                    "organization": organization.slug,
-                    "integration_id": integration.id,
-                },
-            )
-            break
-        user_list += next_users["members"]
-
-        next_cursor = next_users["response_metadata"]["next_cursor"]
-        if not next_cursor:
-            break
-
-    return user_list
-
-
-def get_slack_info_by_email(
-    integration: Integration, organization: Organization
-) -> Mapping[str, SlackUserData]:
-    return {
-        member["profile"]["email"]: SlackUserData(
-            email=member["profile"]["email"], team_id=member["team_id"], slack_id=member["id"]
-        )
-        for member in get_users(integration, organization)
-        if not member["deleted"] and member["profile"].get("email")
-    }
-
-
-def get_slack_data_by_user(
-    integration: Integration | RpcIntegration,
-    organization: Organization | RpcOrganization,
-    emails_by_user: Mapping[User, Sequence[str]],
-) -> Mapping[User, SlackUserData]:
-    slack_info_by_email = get_slack_info_by_email(integration, organization)
-    slack_data_by_user: MutableMapping[User, SlackUserData] = {}
-    for user, emails in emails_by_user.items():
-        for email in emails:
-            if email in slack_info_by_email:
-                slack_data_by_user[user] = slack_info_by_email[email]
-                break
-    return slack_data_by_user
-
-
-# USING SDK CLIENT
 
 
 def format_slack_info_by_email(users: dict[str, Any]) -> dict[str, SlackUserData]:
@@ -141,7 +78,7 @@ def get_slack_user_data(
         )
 
 
-def get_slack_data_by_user_via_sdk(
+def get_slack_data_by_user(
     integration: Integration | RpcIntegration,
     organization: Organization | RpcOrganization,
     emails_by_user: Mapping[User, Sequence[str]],

--- a/src/sentry/tasks/integrations/slack/link_slack_user_identities.py
+++ b/src/sentry/tasks/integrations/slack/link_slack_user_identities.py
@@ -5,9 +5,7 @@ from collections.abc import Mapping
 
 from django.utils import timezone
 
-from sentry import features
-from sentry.integrations.slack.utils import get_slack_data_by_user
-from sentry.integrations.slack.utils.users import SlackUserData, get_slack_data_by_user_via_sdk
+from sentry.integrations.slack.utils.users import SlackUserData, get_slack_data_by_user
 from sentry.integrations.utils import get_identities_by_user
 from sentry.models.identity import Identity, IdentityProvider, IdentityStatus
 from sentry.models.user import User
@@ -41,11 +39,6 @@ def link_slack_user_identities(
         external_id=integration.external_id,
     )
 
-    if not features.has("organizations:slack-sdk-get-users", organization):
-        slack_data_by_user = get_slack_data_by_user(integration, organization, emails_by_user)
-        update_identities(slack_data_by_user, idp)
-        return None
-
     logger.info(
         "slack.post_install.link_identities.start",
         extra={
@@ -53,7 +46,7 @@ def link_slack_user_identities(
             "integration_id": integration.id,
         },
     )
-    slack_data_by_user = get_slack_data_by_user_via_sdk(integration, organization, emails_by_user)
+    slack_data_by_user = get_slack_data_by_user(integration, organization, emails_by_user)
     for data in slack_data_by_user:
         logger.info(
             "slack.post_install.link_identities.paginate",
@@ -66,7 +59,6 @@ def link_slack_user_identities(
         update_identities(data, idp)
 
 
-# has different typing for slack_data_by_user, need to grab slack_id from a dataclass
 def update_identities(slack_data_by_user: Mapping[User, SlackUserData], idp: IdentityProvider):
     date_verified = timezone.now()
     identities_by_user = get_identities_by_user(idp, slack_data_by_user.keys())

--- a/tests/sentry/integrations/slack/test_integration.py
+++ b/tests/sentry/integrations/slack/test_integration.py
@@ -4,6 +4,7 @@ from urllib.parse import parse_qs, urlencode, urlparse
 import orjson
 import responses
 from responses.matchers import query_string_matcher
+from slack_sdk.web import SlackResponse
 
 from sentry import audit_log
 from sentry.integrations.slack import SlackIntegration, SlackIntegrationProvider
@@ -13,7 +14,6 @@ from sentry.models.identity import Identity, IdentityProvider, IdentityStatus
 from sentry.models.integrations.integration import Integration
 from sentry.models.integrations.organization_integration import OrganizationIntegration
 from sentry.testutils.cases import APITestCase, IntegrationTestCase, TestCase
-from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.silo import control_silo_test
 
 
@@ -36,6 +36,9 @@ from sentry.testutils.silo import control_silo_test
 )
 class SlackIntegrationTest(IntegrationTestCase):
     provider = SlackIntegrationProvider
+
+    def setUp(self):
+        super().setUp()
 
     def assert_setup_flow(
         self,
@@ -78,37 +81,46 @@ class SlackIntegrationTest(IntegrationTestCase):
         }
         responses.add(responses.POST, "https://slack.com/api/oauth.v2.access", json=access_json)
 
-        responses.add(
-            method=responses.GET,
-            url="https://slack.com/api/users.list",
-            match=[query_string_matcher(f"limit={SLACK_GET_USERS_PAGE_SIZE}")],
-            json={
-                "ok": True,
-                "members": [
-                    {
-                        "id": authorizing_user_id,
-                        "team_id": team_id,
-                        "deleted": False,
-                        "profile": {
-                            "email": self.user.email,
-                            "team": team_id,
-                        },
+        response_json = {
+            "ok": True,
+            "members": [
+                {
+                    "id": authorizing_user_id,
+                    "team_id": team_id,
+                    "deleted": False,
+                    "profile": {
+                        "email": self.user.email,
+                        "team": team_id,
                     },
-                ],
-                "response_metadata": {"next_cursor": ""},
-            },
-        )
-        resp = self.client.get(
-            "{}?{}".format(
-                self.setup_path,
-                urlencode({"code": "oauth-code", "state": authorize_params["state"]}),
+                },
+            ],
+            "response_metadata": {"next_cursor": ""},
+        }
+        with patch(
+            "slack_sdk.web.client.WebClient.users_list",
+            return_value=SlackResponse(
+                client=None,
+                http_verb="GET",
+                api_url="https://slack.com/api/users.list",
+                req_args={},
+                data=response_json,
+                headers={},
+                status_code=200,
+            ),
+        ) as self.mock_post:
+            resp = self.client.get(
+                "{}?{}".format(
+                    self.setup_path,
+                    urlencode({"code": "oauth-code", "state": authorize_params["state"]}),
+                )
             )
-        )
 
-        if customer_domain:
-            assert resp.status_code == 302
-            assert resp["Location"].startswith(f"http://{customer_domain}/extensions/slack/setup/")
-            resp = self.client.get(resp["Location"], **kwargs)
+            if customer_domain:
+                assert resp.status_code == 302
+                assert resp["Location"].startswith(
+                    f"http://{customer_domain}/extensions/slack/setup/"
+                )
+                resp = self.client.get(resp["Location"], **kwargs)
 
         mock_request = responses.calls[0].request
         req_params = parse_qs(mock_request.body)
@@ -222,6 +234,7 @@ class SlackIntegrationTest(IntegrationTestCase):
         assert identity.external_id == "UXXXXXXX2"
 
 
+@patch("slack_sdk.web.client.WebClient._perform_urllib_http_request")
 @control_silo_test
 class SlackIntegrationPostInstallTest(APITestCase):
     def setUp(self):
@@ -317,28 +330,11 @@ class SlackIntegrationPostInstallTest(APITestCase):
         )
 
     @responses.activate
-    def test_link_multiple_users(self):
+    def test_link_multiple_users(self, mock_api_call):
         """
         Test that with an organization with multiple users, we create Identity records for them
         if their Sentry email matches their Slack email
         """
-        with self.tasks():
-            SlackIntegrationProvider().post_install(self.integration, self.organization)
-
-        user1_identity = Identity.objects.get(user=self.user)
-        assert user1_identity
-        assert user1_identity.external_id == "UXXXXXXX1"
-        assert user1_identity.user.email == "admin@localhost"
-
-        user2_identity = Identity.objects.get(user=self.user2)
-        assert user2_identity
-        assert user2_identity.external_id == "UXXXXXXX2"
-        assert user2_identity.user.email == "foo@example.com"
-
-    @patch("slack_sdk.web.client.WebClient._perform_urllib_http_request")
-    @with_feature("organizations:slack-sdk-get-users")
-    @responses.activate
-    def test_link_multiple_users_sdk_client(self, mock_api_call):
         mock_api_call.return_value = {
             "body": orjson.dumps(self.response_json).decode(),
             "headers": {},
@@ -358,10 +354,8 @@ class SlackIntegrationPostInstallTest(APITestCase):
         assert user2_identity.external_id == "UXXXXXXX2"
         assert user2_identity.user.email == "foo@example.com"
 
-    @patch("slack_sdk.web.client.WebClient._perform_urllib_http_request")
-    @with_feature("organizations:slack-sdk-get-users")
     @responses.activate
-    def test_link_multiple_users_sdk_client_pagination(self, mock_api_call):
+    def test_link_multiple_users_pagination(self, mock_api_call):
         self.response_json["response_metadata"] = {"next_cursor": "dXNlcjpVMEc5V0ZYTlo"}
         mock_api_call.side_effect = [
             {
@@ -409,10 +403,8 @@ class SlackIntegrationPostInstallTest(APITestCase):
         assert user5_identity.external_id == "UXXXXXXX5"
         assert user5_identity.user.email == "hello@example.com"
 
-    @patch("slack_sdk.web.client.WebClient._perform_urllib_http_request")
-    @with_feature("organizations:slack-sdk-get-users")
     @responses.activate
-    def test_link_multiple_users_sdk_client_pagination_error(self, mock_api_call):
+    def test_link_multiple_users_pagination_error(self, mock_api_call):
         self.response_json["response_metadata"] = {"next_cursor": "dXNlcjpVMEc5V0ZYTlo"}
         mock_api_call.side_effect = [
             {
@@ -444,10 +436,16 @@ class SlackIntegrationPostInstallTest(APITestCase):
         assert user5_identity is None
 
     @responses.activate
-    def test_email_no_match(self):
+    def test_email_no_match(self, mock_api_call):
         """
         Test that a user whose email does not match does not have an Identity created
         """
+        mock_api_call.return_value = {
+            "body": orjson.dumps(self.response_json).decode(),
+            "headers": {},
+            "status": 200,
+        }
+
         with self.tasks():
             SlackIntegrationProvider().post_install(self.integration, self.organization)
 
@@ -455,11 +453,17 @@ class SlackIntegrationPostInstallTest(APITestCase):
         assert identities.count() == 3
 
     @responses.activate
-    def test_update_identity(self):
+    def test_update_identity(self, mock_api_call):
         """
         Test that when an additional user who already has an Identity's Slack external ID
         changes, that we update the Identity's external ID to match
         """
+        mock_api_call.return_value = {
+            "body": orjson.dumps(self.response_json).decode(),
+            "headers": {},
+            "status": 200,
+        }
+
         with self.tasks():
             SlackIntegrationProvider().post_install(self.integration, self.organization)
 


### PR DESCRIPTION
This feature has been GA'd! https://github.com/getsentry/sentry-options-automator/pull/1704