### PR TITLE
fix(performance): fix issue with mobile widget breaking due to non unique series names

### DIFF
--- a/static/app/views/insights/mobile/screenload/components/charts/screenCharts.tsx
+++ b/static/app/views/insights/mobile/screenload/components/charts/screenCharts.tsx
@@ -145,7 +145,7 @@ export function ScreenCharts({yAxes, additionalFilters}: Props) {
 
           const color = isPrimary ? CHART_PALETTE[3][0] : CHART_PALETTE[3][1];
           transformedReleaseSeries[yAxis][release] = {
-            seriesName: formatVersion(label),
+            seriesName: formatVersion(label, true),
             color,
             data,
           };

--- a/static/app/views/performance/landing/widgets/widgets/mobileReleaseComparisonListWidget.tsx
+++ b/static/app/views/performance/landing/widgets/widgets/mobileReleaseComparisonListWidget.tsx
@@ -266,6 +266,10 @@ function MobileReleaseComparisonListWidget(props: PerformanceWidgetProps) {
 
     const series = provided.widgetData.chart.data;
     if (defined(series)) {
+      // Semantic versions may overlap, in which case we need to append the package name to ensure a unique series name
+      const versionNamesOverlap =
+        new Set(series.map(({seriesName}) => formatVersion(seriesName))).size <
+        series.length;
       series.forEach(({seriesName: release, data}) => {
         const isPrimary = release === primaryRelease;
 
@@ -280,7 +284,7 @@ function MobileReleaseComparisonListWidget(props: PerformanceWidgetProps) {
 
         const color = isPrimary ? CHART_PALETTE[3][0] : CHART_PALETTE[3][1];
         transformedReleaseSeries[release] = {
-          seriesName: formatVersion(label),
+          seriesName: formatVersion(label, versionNamesOverlap),
           color,
           data: seriesData,
         };

--- a/static/app/views/performance/landing/widgets/widgets/mobileReleaseComparisonListWidget.tsx
+++ b/static/app/views/performance/landing/widgets/widgets/mobileReleaseComparisonListWidget.tsx
@@ -266,10 +266,6 @@ function MobileReleaseComparisonListWidget(props: PerformanceWidgetProps) {
 
     const series = provided.widgetData.chart.data;
     if (defined(series)) {
-      // Semantic versions may overlap, in which case we need to append the package name to ensure a unique series name
-      const versionNamesOverlap =
-        new Set(series.map(({seriesName}) => formatVersion(seriesName))).size <
-        series.length;
       series.forEach(({seriesName: release, data}) => {
         const isPrimary = release === primaryRelease;
 
@@ -284,7 +280,7 @@ function MobileReleaseComparisonListWidget(props: PerformanceWidgetProps) {
 
         const color = isPrimary ? CHART_PALETTE[3][0] : CHART_PALETTE[3][1];
         transformedReleaseSeries[release] = {
-          seriesName: formatVersion(label, versionNamesOverlap),
+          seriesName: formatVersion(label, true),
           color,
           data: seriesData,
         };


### PR DESCRIPTION
We use `formatVersion` to produce series name for the mobile performance widget, but `formatVersion` can produce the same string for different releases if they have the same semver. Updates to use `formatVersion` with the `withPackage` set to `true` to prevent this clashing.