### PR TITLE
fix(slack): Update How we Iterate to Slack Response in `users.list`

### DIFF
--- a/src/sentry/integrations/slack/utils/channel.py
+++ b/src/sentry/integrations/slack/utils/channel.py
@@ -174,9 +174,14 @@ def check_user_with_timeout(
         "exclude_members": True,
         "types": "public_channel,private_channel",
     }
-    users = get_slack_user_data(integration, organization=None, kwargs=payload)
 
-    for user in users:
+    # Get each user from a page from the Slack API
+    page_generator = (
+        user
+        for page in get_slack_user_data(integration, organization=None, kwargs=payload)
+        for user in page
+    )
+    for user in page_generator:
         # The "name" field is unique (this is the username for users)
         # so we return immediately if we find a match.
         # convert to lower case since all names in Slack are lowercase

--- a/src/sentry/integrations/slack/utils/channel.py
+++ b/src/sentry/integrations/slack/utils/channel.py
@@ -9,7 +9,7 @@ from slack_sdk.errors import SlackApiError
 from sentry import features
 from sentry.integrations.slack.client import SlackClient
 from sentry.integrations.slack.sdk_client import SlackSdkClient
-from sentry.integrations.slack.utils.users import get_slack_user_data
+from sentry.integrations.slack.utils.users import get_slack_user_list
 from sentry.models.integrations.integration import Integration
 from sentry.models.organization import Organization
 from sentry.services.hybrid_cloud.integration import RpcIntegration
@@ -178,7 +178,7 @@ def check_user_with_timeout(
     # Get each user from a page from the Slack API
     page_generator = (
         user
-        for page in get_slack_user_data(integration, organization=None, kwargs=payload)
+        for page in get_slack_user_list(integration, organization=None, kwargs=payload)
         for user in page
     )
     for user in page_generator:

--- a/src/sentry/integrations/slack/utils/users.py
+++ b/src/sentry/integrations/slack/utils/users.py
@@ -113,7 +113,7 @@ def format_slack_data_by_user(
     return slack_data_by_user
 
 
-def get_slack_user_data(
+def get_slack_user_list(
     integration: Integration | RpcIntegration,
     organization: Organization | RpcOrganization | None = None,
     kwargs: dict[str, Any] | None = None,
@@ -146,5 +146,5 @@ def get_slack_data_by_user_via_sdk(
     organization: Organization | RpcOrganization,
     emails_by_user: Mapping[User, Sequence[str]],
 ) -> Iterable[Mapping[User, SlackUserData]]:
-    all_users = get_slack_user_data(integration, organization)
+    all_users = get_slack_user_list(integration, organization)
     yield from (format_slack_data_by_user(emails_by_user, users) for users in all_users)

--- a/tests/sentry/integrations/slack/test_utils.py
+++ b/tests/sentry/integrations/slack/test_utils.py
@@ -27,6 +27,33 @@ class GetChannelIdTest(TestCase):
 
         self.integration = install_slack(self.event.project.organization)
 
+        self.response_json = {
+            "ok": True,
+            "members": [
+                {
+                    "id": "UXXXXXXX1",
+                    "name": "patrick-jane",
+                },
+                {
+                    "id": "UXXXXXXX2",
+                    "name": "theresa-lisbon",
+                },
+                {
+                    "id": "UXXXXXXX3",
+                    "name": "kimball-cho",
+                },
+                {
+                    "id": "UXXXXXXX4",
+                    "name": "grace-van-pelt",
+                },
+                {
+                    "id": "UXXXXXXX4",
+                    "name": "wayne-rigsby",
+                },
+            ],
+            "response_metadata": {"next_cursor": ""},
+        }
+
     def tearDown(self):
         self.resp.__exit__(None, None, None)
 
@@ -198,3 +225,36 @@ class GetChannelIdTest(TestCase):
         )
         with pytest.raises(ApiRateLimitedError):
             get_channel_id(self.organization, self.integration, "@user")
+
+    @patch("slack_sdk.web.client.WebClient._perform_urllib_http_request")
+    @with_feature("organizations:slack-sdk-get-channel-id")
+    def test_user_list_pagination_sdk_client(self, mock_api_call):
+        self.response_json["response_metadata"] = {"next_cursor": "dXNlcjpVMEc5V0ZYTlo"}
+        mock_api_call.return_value = {
+            "body": orjson.dumps(self.response_json).decode(),
+            "headers": {},
+            "status": 200,
+        }
+
+        self.run_valid_test("@wayne-rigsby", MEMBER_PREFIX, "UXXXXXXX4", False)
+
+    @patch("slack_sdk.web.client.WebClient._perform_urllib_http_request")
+    @with_feature("organizations:slack-sdk-get-channel-id")
+    def test_user_list_pagination_failure_sdk_client(self, mock_api_call):
+        self.response_json["response_metadata"] = {"next_cursor": "dXNlcjpVMEc5V0ZYTlo"}
+        mock_api_call.side_effect = [
+            {
+                "body": orjson.dumps(self.response_json).decode(),
+                "headers": {},
+                "status": 200,
+            },
+            {
+                "body": orjson.dumps({"ok": False}).decode(),
+                "headers": {},
+                "status": 200,
+            },
+        ]
+
+        assert get_channel_id(
+            self.organization, self.integration, "@red-john"
+        ) == SlackChannelIdData(prefix="", channel_id=None, timed_out=False)

--- a/tests/sentry/integrations/slack/test_utils.py
+++ b/tests/sentry/integrations/slack/test_utils.py
@@ -240,6 +240,36 @@ class GetChannelIdTest(TestCase):
 
     @patch("slack_sdk.web.client.WebClient._perform_urllib_http_request")
     @with_feature("organizations:slack-sdk-get-channel-id")
+    def test_user_list_multi_pagination_sdk_client(self, mock_api_call):
+        self.response_json["response_metadata"] = {"next_cursor": "dXNlcjpVMEc5V0ZYTlo"}
+        mock_api_call.side_effect = [
+            {
+                "body": orjson.dumps(self.response_json).decode(),
+                "headers": {},
+                "status": 200,
+            },
+            {
+                "body": orjson.dumps(
+                    {
+                        "ok": True,
+                        "members": [
+                            {
+                                "id": "UXXXXXXX5",
+                                "name": "red-john",
+                            },
+                        ],
+                        "response_metadata": {"next_cursor": ""},
+                    }
+                ).decode(),
+                "headers": {},
+                "status": 200,
+            },
+        ]
+
+        self.run_valid_test("@red-john", MEMBER_PREFIX, "UXXXXXXX5", False)
+
+    @patch("slack_sdk.web.client.WebClient._perform_urllib_http_request")
+    @with_feature("organizations:slack-sdk-get-channel-id")
     def test_user_list_pagination_failure_sdk_client(self, mock_api_call):
         self.response_json["response_metadata"] = {"next_cursor": "dXNlcjpVMEc5V0ZYTlo"}
         mock_api_call.side_effect = [


### PR DESCRIPTION
Addresses https://sentry.sentry.io/issues/5539974714/events/2af1ab068807409ab8e23ffba33b260c/?project=1

Basically the generator itself returns a list of users, we need to iterate through them further to get an individual user. I tested this with my local Slack setup.

I wish we had smoke tests, would have caught this. 