### PR TITLE
feat(u2f): Register fallback promises

### DIFF
--- a/static/app/utils/getPreloadedData.spec.tsx
+++ b/static/app/utils/getPreloadedData.spec.tsx
@@ -1,0 +1,22 @@
+import {getPreloadedDataPromise} from './getPreloadedData';
+
+describe('getPreloadedDataPromise', () => {
+  beforeEach(() => {
+    (window as any).__sentry_preload = {
+      orgSlug: 'slug',
+    };
+  });
+  it('should register fallback promise', async () => {
+    const fallback = jest.fn(() => Promise.resolve('fallback'));
+    const result = await getPreloadedDataPromise('name', 'slug', fallback);
+    expect(result).toBe('fallback');
+    expect((window as any).__sentry_preload.name_fallback).toBeInstanceOf(Promise);
+  });
+  it('should only call fallback on failure', async () => {
+    (window as any).__sentry_preload.name = Promise.resolve('success');
+    const fallback = jest.fn();
+    const result = await getPreloadedDataPromise('name', 'slug', fallback, true);
+    expect(result).toBe('success');
+    expect(fallback).not.toHaveBeenCalled();
+  });
+});

--- a/static/app/utils/getPreloadedData.ts
+++ b/static/app/utils/getPreloadedData.ts
@@ -12,7 +12,9 @@ export async function getPreloadedDataPromise(
   const wrappedFallback = () => {
     const fallbackAttribute = `${name}_fallback`;
     const promise = fallback();
-    data[fallbackAttribute] = promise;
+    if (data) {
+      data[fallbackAttribute] = promise;
+    }
     return promise;
   };
 

--- a/static/app/utils/getPreloadedData.ts
+++ b/static/app/utils/getPreloadedData.ts
@@ -4,8 +4,19 @@ export async function getPreloadedDataPromise(
   fallback: () => Promise<any>,
   usePreload?: boolean
 ) {
+  const data = (window as any).__sentry_preload;
+  /**
+   * Save the fallback promise to `__sentry_preload` to allow the sudo modal to wait
+   * for the promise to resolve
+   */
+  const wrappedFallback = () => {
+    const fallbackAttribute = `${name}_fallback`;
+    const promise = fallback();
+    data[fallbackAttribute] = promise;
+    return promise;
+  };
+
   try {
-    const data = (window as any).__sentry_preload;
     if (
       !usePreload ||
       !data ||
@@ -14,15 +25,15 @@ export async function getPreloadedDataPromise(
       !data[name] ||
       !data[name].then
     ) {
-      return await fallback();
+      return await wrappedFallback();
     }
-    const result = await data[name].catch(fallback);
+    const result = await data[name].catch(() => null);
     if (!result) {
-      return await fallback();
+      return await wrappedFallback();
     }
     return await result;
   } catch (_) {
     //
   }
-  return await fallback();
+  return await wrappedFallback();
 }


### PR DESCRIPTION
in https://github.com/getsentry/sentry/blob/master/static/app/actionCreators/organization.tsx#L82-L92 we use `getPreloadedDataPromise` to make a followup request if the first one fails. Register the fallbacks to the __sentry_preload object so we can wait for the fallback promises to finish.

when testing locally they seem to be registered in time 

follow up to #73315
