### PR TITLE
feat(query-builder): Allow multi-selected items to be edited

### DIFF
--- a/static/app/components/searchQueryBuilder/combobox.tsx
+++ b/static/app/components/searchQueryBuilder/combobox.tsx
@@ -1,6 +1,7 @@
 import {
   type ForwardedRef,
   forwardRef,
+  Fragment,
   type MouseEventHandler,
   type ReactNode,
   useCallback,
@@ -82,6 +83,7 @@ type SearchQueryBuilderComboboxProps<T extends SelectOptionOrSectionWithKey<stri
   onFocus?: (e: React.FocusEvent<HTMLInputElement>) => void;
   onInputChange?: React.ChangeEventHandler<HTMLInputElement>;
   onKeyDown?: (e: KeyboardEvent) => void;
+  onKeyUp?: (e: KeyboardEvent) => void;
   onPaste?: (e: React.ClipboardEvent<HTMLInputElement>) => void;
   openOnFocus?: boolean;
   placeholder?: string;
@@ -290,41 +292,45 @@ function SectionedListBox<T extends SelectOptionOrSectionWithKey<string>>({
 
   return (
     <SectionedOverlay ref={popoverRef}>
-      <SectionedListBoxTabPane>
-        <ListBoxSectionButton
-          selected={selectedSection === null}
-          onClick={() => {
-            setSelectedSection(null);
-            state.selectionManager.setFocusedKey(null);
-          }}
-        >
-          {t('All')}
-        </ListBoxSectionButton>
-        {sections.map(node => (
-          <ListBoxSectionButton
-            key={node.key}
-            selected={selectedSection === node.key}
-            onClick={() => {
-              setSelectedSection(node.key);
-              state.selectionManager.setFocusedKey(null);
-            }}
-          >
-            {node.props.title}
-          </ListBoxSectionButton>
-        ))}
-      </SectionedListBoxTabPane>
-      <SectionedListBoxPane>
-        <ListBox
-          {...listBoxProps}
-          ref={listBoxRef}
-          listState={state}
-          hasSearch={!sectionHasHiddenOptions}
-          hiddenOptions={hiddenOptions}
-          keyDownHandler={() => true}
-          overlayIsOpen={isOpen}
-          size="sm"
-        />
-      </SectionedListBoxPane>
+      {isOpen ? (
+        <Fragment>
+          <SectionedListBoxTabPane>
+            <ListBoxSectionButton
+              selected={selectedSection === null}
+              onClick={() => {
+                setSelectedSection(null);
+                state.selectionManager.setFocusedKey(null);
+              }}
+            >
+              {t('All')}
+            </ListBoxSectionButton>
+            {sections.map(node => (
+              <ListBoxSectionButton
+                key={node.key}
+                selected={selectedSection === node.key}
+                onClick={() => {
+                  setSelectedSection(node.key);
+                  state.selectionManager.setFocusedKey(null);
+                }}
+              >
+                {node.props.title}
+              </ListBoxSectionButton>
+            ))}
+          </SectionedListBoxTabPane>
+          <SectionedListBoxPane>
+            <ListBox
+              {...listBoxProps}
+              ref={listBoxRef}
+              listState={state}
+              hasSearch={!sectionHasHiddenOptions}
+              hiddenOptions={hiddenOptions}
+              keyDownHandler={() => true}
+              overlayIsOpen={isOpen}
+              size="sm"
+            />
+          </SectionedListBoxPane>
+        </Fragment>
+      ) : null}
     </SectionedOverlay>
   );
 }
@@ -412,6 +418,7 @@ function SearchQueryBuilderComboboxInner<T extends SelectOptionOrSectionWithKey<
     inputLabel,
     onExit,
     onKeyDown,
+    onKeyUp,
     onInputChange,
     autoFocus,
     openOnFocus,
@@ -507,9 +514,17 @@ function SearchQueryBuilderComboboxInner<T extends SelectOptionOrSectionWithKey<
             return;
         }
       },
+      onKeyUp,
     },
     state
   );
+
+  const previousInputValue = usePrevious(inputValue);
+  useEffect(() => {
+    if (inputValue !== previousInputValue) {
+      state.selectionManager.setFocusedKey(null);
+    }
+  }, [inputValue, previousInputValue, state.selectionManager]);
 
   const totalOptions = items.reduce(
     (acc, item) => acc + (itemIsSection(item) ? item.options.length : 1),
@@ -535,7 +550,7 @@ function SearchQueryBuilderComboboxInner<T extends SelectOptionOrSectionWithKey<
     type: 'listbox',
     isOpen,
     position: 'bottom-start',
-    offset: [0, 8],
+    offset: [-12, 8],
     isKeyboardDismissDisabled: true,
     shouldCloseOnBlur: true,
     shouldCloseOnInteractOutside: el => {

--- a/static/app/components/searchQueryBuilder/index.spec.tsx
+++ b/static/app/components/searchQueryBuilder/index.spec.tsx
@@ -273,159 +273,6 @@ describe('SearchQueryBuilder', function () {
         ).getByText('is not')
       ).toBeInTheDocument();
     });
-
-    it('can modify operator for filter with multiple values', async function () {
-      render(
-        <SearchQueryBuilder
-          {...defaultProps}
-          initialQuery="browser.name:[firefox,chrome]"
-        />
-      );
-
-      // Should display as "is" to start
-      expect(
-        within(
-          screen.getByRole('button', {name: 'Edit operator for filter: browser.name'})
-        ).getByText('is')
-      ).toBeInTheDocument();
-
-      await userEvent.click(
-        screen.getByRole('button', {name: 'Edit operator for filter: browser.name'})
-      );
-      await userEvent.click(screen.getByRole('option', {name: 'is not'}));
-
-      // Token should be modified to be negated
-      expect(
-        screen.getByRole('row', {name: '!browser.name:[firefox,chrome]'})
-      ).toBeInTheDocument();
-
-      // Should now have "is not" label
-      expect(
-        within(
-          screen.getByRole('button', {name: 'Edit operator for filter: browser.name'})
-        ).getByText('is not')
-      ).toBeInTheDocument();
-    });
-
-    it('can modify the value by clicking into it (single-select)', async function () {
-      // `is` only accepts single values
-      render(<SearchQueryBuilder {...defaultProps} initialQuery="is:unresolved" />);
-
-      // Should display as "unresolved" to start
-      expect(
-        within(screen.getByRole('button', {name: 'Edit value for filter: is'})).getByText(
-          'unresolved'
-        )
-      ).toBeInTheDocument();
-
-      await userEvent.click(
-        screen.getByRole('button', {name: 'Edit value for filter: is'})
-      );
-      // Should have placeholder text of previous value
-      expect(screen.getByRole('combobox', {name: 'Edit filter value'})).toHaveAttribute(
-        'placeholder',
-        'unresolved'
-      );
-
-      // Clicking the "resolved" option should update the value
-      await userEvent.click(await screen.findByRole('option', {name: 'resolved'}));
-      expect(screen.getByRole('row', {name: 'is:resolved'})).toBeInTheDocument();
-      expect(
-        within(screen.getByRole('button', {name: 'Edit value for filter: is'})).getByText(
-          'resolved'
-        )
-      ).toBeInTheDocument();
-    });
-
-    it('can modify the value by clicking into it (multi-select)', async function () {
-      // `browser.name` is a string filter which accepts multiple values
-      render(
-        <SearchQueryBuilder {...defaultProps} initialQuery="browser.name:firefox" />
-      );
-
-      // Should display as "firefox" to start
-      expect(
-        within(
-          screen.getByRole('button', {name: 'Edit value for filter: browser.name'})
-        ).getByText('firefox')
-      ).toBeInTheDocument();
-
-      await userEvent.click(
-        screen.getByRole('button', {name: 'Edit value for filter: browser.name'})
-      );
-      // Previous value should be rendered before the input
-      expect(
-        within(screen.getByRole('row', {name: 'browser.name:firefox'})).getByText(
-          'firefox,'
-        )
-      ).toBeInTheDocument();
-
-      // Clicking the "Chrome option should add it to the list and commit changes
-      await userEvent.click(screen.getByRole('option', {name: 'Chrome'}));
-      expect(
-        screen.getByRole('row', {name: 'browser.name:[firefox,Chrome]'})
-      ).toBeInTheDocument();
-      const valueButton = screen.getByRole('button', {
-        name: 'Edit value for filter: browser.name',
-      });
-      expect(within(valueButton).getByText('firefox')).toBeInTheDocument();
-      expect(within(valueButton).getByText('or')).toBeInTheDocument();
-      expect(within(valueButton).getByText('Chrome')).toBeInTheDocument();
-    });
-
-    it('escapes values with spaces and reserved characters', async function () {
-      render(<SearchQueryBuilder {...defaultProps} initialQuery="" />);
-      await userEvent.click(screen.getByRole('combobox', {name: 'Add a search term'}));
-      await userEvent.type(
-        screen.getByRole('combobox', {name: 'Add a search term'}),
-        'assigned:some" value{enter}'
-      );
-      // Value should be surrounded by quotes and escaped
-      expect(
-        screen.getByRole('row', {name: 'assigned:"some\\" value"'})
-      ).toBeInTheDocument();
-      // Display text should be display the original value
-      expect(
-        within(
-          screen.getByRole('button', {name: 'Edit value for filter: assigned'})
-        ).getByText('some" value')
-      ).toBeInTheDocument();
-    });
-
-    it('opens the value suggestions menu when clicking anywhere in the filter value', async function () {
-      render(
-        <SearchQueryBuilder
-          {...defaultProps}
-          initialQuery="browser.name:[Chrome,Firefox]"
-        />
-      );
-
-      // Start editing value
-      await userEvent.click(
-        screen.getByRole('button', {name: 'Edit value for filter: browser.name'})
-      );
-      // Click in the filter value area, should open the menu
-      await userEvent.click(screen.getByTestId('filter-value-editing'));
-      expect(await screen.findByRole('option', {name: 'Chrome'})).toBeInTheDocument();
-    });
-
-    it('can remove parens by clicking the delete button', async function () {
-      render(<SearchQueryBuilder {...defaultProps} initialQuery="(" />);
-
-      expect(screen.getByRole('row', {name: '('})).toBeInTheDocument();
-      await userEvent.click(screen.getByRole('gridcell', {name: 'Delete ('}));
-
-      expect(screen.queryByRole('row', {name: '('})).not.toBeInTheDocument();
-    });
-
-    it('can remove boolean ops by clicking the delete button', async function () {
-      render(<SearchQueryBuilder {...defaultProps} initialQuery="OR" />);
-
-      expect(screen.getByRole('row', {name: 'OR'})).toBeInTheDocument();
-      await userEvent.click(screen.getByRole('gridcell', {name: 'Delete OR'}));
-
-      expect(screen.queryByRole('row', {name: 'OR'})).not.toBeInTheDocument();
-    });
   });
 
   describe('new search tokens', function () {
@@ -943,6 +790,166 @@ describe('SearchQueryBuilder', function () {
   });
 
   describe('filter types', function () {
+    describe('is', function () {
+      it('can modify the value by clicking into it', async function () {
+        // `is` only accepts single values
+        render(<SearchQueryBuilder {...defaultProps} initialQuery="is:unresolved" />);
+
+        // Should display as "unresolved" to start
+        expect(
+          within(
+            screen.getByRole('button', {name: 'Edit value for filter: is'})
+          ).getByText('unresolved')
+        ).toBeInTheDocument();
+
+        await userEvent.click(
+          screen.getByRole('button', {name: 'Edit value for filter: is'})
+        );
+        // Should have placeholder text of previous value
+        expect(screen.getByRole('combobox', {name: 'Edit filter value'})).toHaveAttribute(
+          'placeholder',
+          'unresolved'
+        );
+
+        // Clicking the "resolved" option should update the value
+        await userEvent.click(await screen.findByRole('option', {name: 'resolved'}));
+        expect(screen.getByRole('row', {name: 'is:resolved'})).toBeInTheDocument();
+        expect(
+          within(
+            screen.getByRole('button', {name: 'Edit value for filter: is'})
+          ).getByText('resolved')
+        ).toBeInTheDocument();
+      });
+    });
+
+    describe('string', function () {
+      it('can modify operator for filter with multiple values', async function () {
+        render(
+          <SearchQueryBuilder
+            {...defaultProps}
+            initialQuery="browser.name:[firefox,chrome]"
+          />
+        );
+
+        // Should display as "is" to start
+        expect(
+          within(
+            screen.getByRole('button', {name: 'Edit operator for filter: browser.name'})
+          ).getByText('is')
+        ).toBeInTheDocument();
+
+        await userEvent.click(
+          screen.getByRole('button', {name: 'Edit operator for filter: browser.name'})
+        );
+        await userEvent.click(screen.getByRole('option', {name: 'is not'}));
+
+        // Token should be modified to be negated
+        expect(
+          screen.getByRole('row', {name: '!browser.name:[firefox,chrome]'})
+        ).toBeInTheDocument();
+
+        // Should now have "is not" label
+        expect(
+          within(
+            screen.getByRole('button', {name: 'Edit operator for filter: browser.name'})
+          ).getByText('is not')
+        ).toBeInTheDocument();
+      });
+
+      it('can modify the value by clicking into it (multi-select)', async function () {
+        render(
+          <SearchQueryBuilder {...defaultProps} initialQuery="browser.name:firefox" />
+        );
+
+        // Should display as "firefox" to start
+        expect(
+          within(
+            screen.getByRole('button', {name: 'Edit value for filter: browser.name'})
+          ).getByText('firefox')
+        ).toBeInTheDocument();
+
+        await userEvent.click(
+          screen.getByRole('button', {name: 'Edit value for filter: browser.name'})
+        );
+        // Should start with previous values and an appended ',' for the next value
+        await waitFor(() => {
+          expect(screen.getByRole('combobox', {name: 'Edit filter value'})).toHaveValue(
+            'firefox,'
+          );
+        });
+
+        // Clicking the "Chrome option should add it to the list and commit changes
+        await userEvent.click(screen.getByRole('option', {name: 'Chrome'}));
+        expect(
+          screen.getByRole('row', {name: 'browser.name:[firefox,Chrome]'})
+        ).toBeInTheDocument();
+        const valueButton = screen.getByRole('button', {
+          name: 'Edit value for filter: browser.name',
+        });
+        expect(within(valueButton).getByText('firefox')).toBeInTheDocument();
+        expect(within(valueButton).getByText('or')).toBeInTheDocument();
+        expect(within(valueButton).getByText('Chrome')).toBeInTheDocument();
+      });
+
+      it('escapes values with spaces and reserved characters', async function () {
+        render(<SearchQueryBuilder {...defaultProps} initialQuery="" />);
+        await userEvent.click(screen.getByRole('combobox', {name: 'Add a search term'}));
+        await userEvent.type(
+          screen.getByRole('combobox', {name: 'Add a search term'}),
+          'assigned:some" value{enter}'
+        );
+        // Value should be surrounded by quotes and escaped
+        expect(
+          await screen.findByRole('row', {name: 'assigned:"some\\" value"'})
+        ).toBeInTheDocument();
+        // Display text should be display the original value
+        expect(
+          within(
+            screen.getByRole('button', {name: 'Edit value for filter: assigned'})
+          ).getByText('some" value')
+        ).toBeInTheDocument();
+      });
+
+      it('can replace a value with a new one', async function () {
+        render(
+          <SearchQueryBuilder {...defaultProps} initialQuery="browser.name:[1,c,3]" />
+        );
+
+        await userEvent.click(
+          screen.getByRole('button', {name: 'Edit value for filter: browser.name'})
+        );
+        await waitFor(() => {
+          expect(screen.getByRole('combobox', {name: 'Edit filter value'})).toHaveValue(
+            '1,c,3,'
+          );
+        });
+
+        // Arrow left three times to put cursor inside "c" value
+        await userEvent.keyboard('{ArrowLeft}{ArrowLeft}{ArrowLeft}');
+
+        // When on c value, should show options matching "c"
+        const chromeOption = await screen.findByRole('option', {name: 'Chrome'});
+
+        // Clicking the "Chrome option should replace "c" with "Chrome" and commit chagnes
+        await userEvent.click(chromeOption);
+        expect(
+          await screen.findByRole('row', {name: 'browser.name:[1,Chrome,3]'})
+        ).toBeInTheDocument();
+      });
+
+      it('can enter a custom value', async function () {
+        render(<SearchQueryBuilder {...defaultProps} initialQuery="browser.name:" />);
+
+        await userEvent.click(
+          screen.getByRole('button', {name: 'Edit value for filter: browser.name'})
+        );
+        await userEvent.keyboard('foo,bar{enter}');
+        expect(
+          await screen.findByRole('row', {name: 'browser.name:[foo,bar]'})
+        ).toBeInTheDocument();
+      });
+    });
+
     describe('numeric', function () {
       it('new numeric filters start with a value', async function () {
         render(<SearchQueryBuilder {...defaultProps} />);

--- a/static/app/components/searchQueryBuilder/utils.tsx
+++ b/static/app/components/searchQueryBuilder/utils.tsx
@@ -154,6 +154,10 @@ export function getValidOpsForFilter(
 }
 
 export function escapeTagValue(value: string): string {
+  if (!value) {
+    return '';
+  }
+
   // Wrap in quotes if there is a space
   return value.includes(' ') || value.includes('"')
     ? `"${escapeDoubleQuotes(value)}"`
@@ -166,8 +170,13 @@ export function unescapeTagValue(value: string): string {
 
 export function formatFilterValue(token: TokenResult<Token.FILTER>['value']): string {
   switch (token.type) {
-    case Token.VALUE_TEXT:
-      return unescapeTagValue(token.value);
+    case Token.VALUE_TEXT: {
+      if (!token.value) {
+        return token.text;
+      }
+
+      return token.quoted ? unescapeTagValue(token.value) : token.text;
+    }
     case Token.VALUE_RELATIVE_DATE:
       return t('%s', `${token.value}${token.unit} ago`);
     default:

--- a/static/app/components/searchQueryBuilder/valueCombobox.tsx
+++ b/static/app/components/searchQueryBuilder/valueCombobox.tsx
@@ -1,8 +1,7 @@
-import {type ReactNode, useCallback, useMemo, useRef, useState} from 'react';
+import {type ReactNode, useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import styled from '@emotion/styled';
 import {Item, Section} from '@react-stately/collections';
 import type {KeyboardEvent} from '@react-types/shared';
-import orderBy from 'lodash/orderBy';
 
 import Checkbox from 'sentry/components/checkbox';
 import type {SelectOptionWithKey} from 'sentry/components/compactSelect/types';
@@ -32,6 +31,7 @@ import {IconArrow} from 'sentry/icons';
 import {t, tn} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {Tag, TagCollection} from 'sentry/types';
+import {uniq} from 'sentry/utils/array/uniq';
 import {FieldValueType, getFieldDefinition} from 'sentry/utils/fields';
 import {isCtrlKeyPressed} from 'sentry/utils/isCtrlKeyPressed';
 import {type QueryKey, useQuery} from 'sentry/utils/queryClient';
@@ -105,6 +105,87 @@ function getDefaultAbsoluteDateValue(token: TokenResult<Token.FILTER>) {
   }
 
   return '';
+}
+
+function getMultiSelectInputValue(token: TokenResult<Token.FILTER>) {
+  if (
+    token.value.type !== Token.VALUE_TEXT_LIST &&
+    token.value.type !== Token.VALUE_NUMBER_LIST
+  ) {
+    const value = token.value.value;
+    return value ? value + ',' : '';
+  }
+
+  const items = token.value.items.map(item => item.value.value);
+
+  if (items.length === 0) {
+    return '';
+  }
+
+  return items.join(',') + ',';
+}
+
+function prepareInputValueForSaving(
+  token: TokenResult<Token.FILTER>,
+  inputValue: string
+) {
+  const values = uniq(
+    inputValue
+      .split(',')
+      .map(v => cleanFilterValue(token.key.text, v.trim()))
+      .filter(v => v.length > 0)
+  );
+
+  return values.length > 1 ? `[${values.join(',')}]` : values[0] ?? '""';
+}
+
+function getSelectedValuesFromText(text: string) {
+  return text
+    .split(',')
+    .map(v => unescapeTagValue(v.trim()))
+    .filter(v => v.length > 0);
+}
+
+function getValueAtCursorPosition(text: string, cursorPosition: number | null) {
+  if (cursorPosition === null) {
+    return '';
+  }
+
+  const items = text.split(',');
+
+  let characterCount = 0;
+  for (const item of items) {
+    characterCount += item.length + 1;
+    if (characterCount > cursorPosition) {
+      return item.trim();
+    }
+  }
+
+  return '';
+}
+/**
+ * Replaces the focused filter value (at cursorPosition) with the new value.
+ *
+ * Example:
+ * replaceValueAtPosition('foo,bar,baz', 5, 'new') => 'foo,new,baz'
+ */
+function replaceValueAtPosition(
+  value: string,
+  cursorPosition: number | null,
+  replacement: string
+) {
+  const items = value.split(',');
+
+  let characterCount = 0;
+  for (let i = 0; i < items.length; i++) {
+    characterCount += items[i].length + 1;
+    if (characterCount > (cursorPosition ?? value.length + 1)) {
+      const newItems = [...items.slice(0, i), replacement, ...items.slice(i + 1)];
+      return newItems.map(item => item.trim()).join(',');
+    }
+  }
+
+  return value;
 }
 
 function getRelativeDateSign(token: TokenResult<Token.FILTER>) {
@@ -240,10 +321,10 @@ function getSuggestionDescription(group: SearchGroup | SearchItem) {
 
 function getPredefinedValues({
   key,
-  inputValue,
+  filterValue,
   token,
 }: {
-  inputValue: string;
+  filterValue: string;
   token: TokenResult<Token.FILTER>;
   key?: Tag;
 }): SuggestionSection[] {
@@ -256,14 +337,14 @@ function getPredefinedValues({
   if (!key.values?.length) {
     switch (fieldDef?.valueType) {
       case FieldValueType.NUMBER:
-        return getNumericSuggestions(inputValue);
+        return getNumericSuggestions(filterValue);
       case FieldValueType.DURATION:
-        return getDurationSuggestions(inputValue);
+        return getDurationSuggestions(filterValue);
       case FieldValueType.BOOLEAN:
         return DEFAULT_BOOLEAN_SUGGESTIONS;
       // TODO(malwilley): Better date suggestions
       case FieldValueType.DATE:
-        return getRelativeDateSuggestions(inputValue, token);
+        return getRelativeDateSuggestions(filterValue, token);
       default:
         return [];
     }
@@ -334,24 +415,6 @@ function tokenSupportsMultipleValues(
   }
 }
 
-function getOtherSelectedValues(token: TokenResult<Token.FILTER>): string[] {
-  switch (token.value.type) {
-    case Token.VALUE_TEXT:
-      if (!token.value.value) {
-        return [];
-      }
-      return [unescapeTagValue(token.value.value)];
-    case Token.VALUE_NUMBER:
-      return token.value.text ? [token.value.text] : [];
-    case Token.VALUE_NUMBER_LIST:
-      return token.value.items.map(item => item.value?.text ?? '');
-    case Token.VALUE_TEXT_LIST:
-      return token.value.items.map(item => unescapeTagValue(item.value?.value ?? ''));
-    default:
-      return [];
-  }
-}
-
 function cleanFilterValue(key: string, value: string): string {
   const fieldDef = getFieldDefinition(key);
   if (!fieldDef) {
@@ -377,32 +440,65 @@ function cleanFilterValue(key: string, value: string): string {
       }
       return value;
     default:
-      return escapeTagValue(value);
+      return escapeTagValue(value).trim();
   }
+}
+
+function useSelectionIndex({
+  inputRef,
+  inputValue,
+  canSelectMultipleValues,
+}: {
+  canSelectMultipleValues: boolean;
+  inputRef: React.RefObject<HTMLInputElement>;
+  inputValue: string;
+}) {
+  const [selectionIndex, setSelectionIndex] = useState<number | null>(
+    () => inputValue.length
+  );
+
+  useEffect(() => {
+    if (canSelectMultipleValues) {
+      setSelectionIndex(inputValue.length);
+    }
+  }, [canSelectMultipleValues, inputValue]);
+
+  const updateSelectionIndex = useCallback(() => {
+    if (inputRef.current?.selectionStart !== inputRef.current?.selectionEnd) {
+      setSelectionIndex(null);
+    } else {
+      setSelectionIndex(inputRef.current?.selectionStart ?? null);
+    }
+  }, [inputRef]);
+
+  return {
+    selectionIndex,
+    updateSelectionIndex,
+  };
 }
 
 function useFilterSuggestions({
   token,
-  inputValue,
+  filterValue,
   selectedValues,
 }: {
-  inputValue: string;
+  filterValue: string;
   selectedValues: string[];
   token: TokenResult<Token.FILTER>;
 }) {
   const {getTagValues, keys} = useSearchQueryBuilder();
   const key = keys[token.key.text];
   const predefinedValues = useMemo(
-    () => getPredefinedValues({key, inputValue, token}),
-    [key, inputValue, token]
+    () => getPredefinedValues({key, filterValue, token}),
+    [key, filterValue, token]
   );
   const shouldFetchValues = key && !key.predefined && !predefinedValues.length;
   const canSelectMultipleValues = tokenSupportsMultipleValues(token, keys);
 
   // TODO(malwilley): Display error states
   const {data, isFetching} = useQuery<string[]>({
-    queryKey: ['search-query-builder', token.key, inputValue] as QueryKey,
-    queryFn: () => getTagValues(key, inputValue),
+    queryKey: ['search-query-builder', token.key, filterValue] as QueryKey,
+    queryFn: () => getTagValues(key, filterValue),
     keepPreviousData: true,
     enabled: shouldFetchValues,
   });
@@ -525,12 +621,23 @@ export function SearchQueryBuilderValueCombobox({
 }: SearchQueryValueBuilderProps) {
   const ref = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
+  const {keys, dispatch} = useSearchQueryBuilder();
+  const canSelectMultipleValues = tokenSupportsMultipleValues(token, keys);
   const [inputValue, setInputValue] = useState(() => {
     if (isDateToken(token)) {
       return token.value.type === Token.VALUE_ISO_8601_DATE ? token.value.text : '';
     }
+    if (canSelectMultipleValues) {
+      return getMultiSelectInputValue(token);
+    }
     return '';
   });
+  const {selectionIndex, updateSelectionIndex} = useSelectionIndex({
+    inputRef,
+    inputValue,
+    canSelectMultipleValues,
+  });
+
   const [showDatePicker, setShowDatePicker] = useState(() => {
     if (isDateToken(token)) {
       return token.value.type === Token.VALUE_ISO_8601_DATE;
@@ -538,22 +645,35 @@ export function SearchQueryBuilderValueCombobox({
     return false;
   });
 
-  const {keys, dispatch} = useSearchQueryBuilder();
-  const canSelectMultipleValues = tokenSupportsMultipleValues(token, keys);
+  const filterValue = canSelectMultipleValues
+    ? getValueAtCursorPosition(inputValue, selectionIndex)
+    : inputValue;
+
   const selectedValues = useMemo(
-    () =>
-      canSelectMultipleValues
-        ? orderBy(getOtherSelectedValues(token), 'value', 'asc')
-        : [],
-    [canSelectMultipleValues, token]
+    () => (canSelectMultipleValues ? getSelectedValuesFromText(inputValue) : []),
+    [canSelectMultipleValues, inputValue]
   );
+
+  useEffect(() => {
+    if (canSelectMultipleValues) {
+      setInputValue(getMultiSelectInputValue(token));
+    }
+  }, [canSelectMultipleValues, token]);
+
+  // On mount, scroll to the end of the input
+  useEffect(() => {
+    if (inputRef.current) {
+      inputRef.current.scrollLeft = inputRef.current.scrollWidth;
+    }
+  }, []);
+
   const {items, suggestionSectionItems, isFetching} = useFilterSuggestions({
     token,
-    inputValue,
+    filterValue,
     selectedValues,
   });
 
-  const handleSelectValue = useCallback(
+  const handleOptionSelected = useCallback(
     (value: string) => {
       if (isDateToken(token) && value === 'absolute_date') {
         setShowDatePicker(true);
@@ -569,16 +689,33 @@ export function SearchQueryBuilderValueCombobox({
       }
 
       if (canSelectMultipleValues) {
-        dispatch({
-          type: 'TOGGLE_FILTER_VALUE',
-          token: token,
-          value: cleanedValue,
-        });
+        if (selectedValues.includes(value)) {
+          const newValue = prepareInputValueForSaving(
+            token,
+            selectedValues.filter(v => v !== value).join(',')
+          );
+          dispatch({
+            type: 'UPDATE_TOKEN_VALUE',
+            token: token,
+            value: newValue,
+          });
 
-        // If toggling off a value, keep focus inside the value
-        if (!selectedValues.includes(value)) {
-          onCommit();
+          if (newValue && newValue !== '""') {
+            onCommit();
+          }
+
+          return;
         }
+
+        dispatch({
+          type: 'UPDATE_TOKEN_VALUE',
+          token: token,
+          value: prepareInputValueForSaving(
+            token,
+            replaceValueAtPosition(inputValue, selectionIndex, value)
+          ),
+        });
+        onCommit();
       } else {
         dispatch({
           type: 'UPDATE_TOKEN_VALUE',
@@ -588,7 +725,31 @@ export function SearchQueryBuilderValueCombobox({
         onCommit();
       }
     },
-    [canSelectMultipleValues, dispatch, onCommit, selectedValues, token]
+    [
+      canSelectMultipleValues,
+      dispatch,
+      inputValue,
+      onCommit,
+      selectedValues,
+      selectionIndex,
+      token,
+    ]
+  );
+
+  const handleInputValueConfirmed = useCallback(
+    (value: string) => {
+      if (canSelectMultipleValues) {
+        dispatch({
+          type: 'UPDATE_TOKEN_VALUE',
+          token,
+          value: prepareInputValueForSaving(token, value),
+        });
+        onCommit();
+      } else {
+        handleOptionSelected(value);
+      }
+    },
+    [canSelectMultipleValues, dispatch, handleOptionSelected, onCommit, token]
   );
 
   const onKeyDown = useCallback(
@@ -613,15 +774,13 @@ export function SearchQueryBuilderValueCombobox({
     [canSelectMultipleValues, dispatch, token]
   );
 
-  // Clicking anywhere in the value editing area should focus the input
-  const onClick: React.MouseEventHandler<HTMLDivElement> = useCallback(e => {
-    if (e.target === e.currentTarget) {
-      e.preventDefault();
-      e.stopPropagation();
-      inputRef.current?.click();
-      inputRef.current?.focus();
-    }
-  }, []);
+  const onKeyUp = useCallback(() => {
+    updateSelectionIndex();
+  }, [updateSelectionIndex]);
+
+  const onClick = useCallback(() => {
+    updateSelectionIndex();
+  }, [updateSelectionIndex]);
 
   // Ensure that the menu stays open when clicking on the selected items
   const shouldCloseOnInteractOutside = useCallback(
@@ -666,23 +825,23 @@ export function SearchQueryBuilderValueCombobox({
   }, [dispatch, inputValue, onCommit, showDatePicker, token]);
 
   return (
-    <ValueEditing ref={ref} onClick={onClick} data-test-id="filter-value-editing">
-      {selectedValues.map(value => (
-        <SelectedValue key={value}>{value},</SelectedValue>
-      ))}
+    <ValueEditing ref={ref} data-test-id="filter-value-editing">
       <SearchQueryBuilderCombobox
         ref={inputRef}
         items={items}
-        onOptionSelected={handleSelectValue}
-        onCustomValueBlurred={handleSelectValue}
-        onCustomValueCommitted={handleSelectValue}
+        onOptionSelected={handleOptionSelected}
+        onCustomValueBlurred={handleInputValueConfirmed}
+        onCustomValueCommitted={handleInputValueConfirmed}
         onExit={onCommit}
         inputValue={inputValue}
+        filterValue={filterValue}
         placeholder={canSelectMultipleValues ? '' : formatFilterValue(token.value)}
         token={token}
         inputLabel={t('Edit filter value')}
         onInputChange={e => setInputValue(e.target.value)}
         onKeyDown={onKeyDown}
+        onKeyUp={onKeyUp}
+        onClick={onClick}
         autoFocus
         maxOptions={50}
         openOnFocus
@@ -708,12 +867,7 @@ const ValueEditing = styled('div')`
   display: flex;
   height: 100%;
   align-items: center;
-  gap: ${space(0.25)};
-`;
-
-const SelectedValue = styled('span')`
-  pointer-events: none;
-  user-select: none;
+  max-width: 400px;
 `;
 
 const TrailingWrap = styled('div')`

--- a/static/app/components/searchQueryBuilder/valueCombobox.tsx
+++ b/static/app/components/searchQueryBuilder/valueCombobox.tsx
@@ -774,14 +774,6 @@ export function SearchQueryBuilderValueCombobox({
     [canSelectMultipleValues, dispatch, token]
   );
 
-  const onKeyUp = useCallback(() => {
-    updateSelectionIndex();
-  }, [updateSelectionIndex]);
-
-  const onClick = useCallback(() => {
-    updateSelectionIndex();
-  }, [updateSelectionIndex]);
-
   // Ensure that the menu stays open when clicking on the selected items
   const shouldCloseOnInteractOutside = useCallback(
     (el: Element) => {
@@ -840,8 +832,8 @@ export function SearchQueryBuilderValueCombobox({
         inputLabel={t('Edit filter value')}
         onInputChange={e => setInputValue(e.target.value)}
         onKeyDown={onKeyDown}
-        onKeyUp={onKeyUp}
-        onClick={onClick}
+        onKeyUp={updateSelectionIndex}
+        onClick={updateSelectionIndex}
         autoFocus
         maxOptions={50}
         openOnFocus


### PR DESCRIPTION
Addresses the issue where already selected values were difficult to edit. Now multi-selectable filters will render an input with all values separated by commas, allowing the user to go back and edit at will.

https://github.com/getsentry/sentry/assets/10888943/e90da0b1-9f02-4bea-8b06-562144b33009

