### PR TITLE
ref(transactions/replay): fix replay tab query error

### DIFF
--- a/static/app/views/performance/transactionSummary/transactionReplays/useReplaysFromTransaction.tsx
+++ b/static/app/views/performance/transactionSummary/transactionReplays/useReplaysFromTransaction.tsx
@@ -89,7 +89,7 @@ function useReplaysFromTransaction({
       version: 2,
       fields: REPLAY_LIST_FIELDS,
       projects: [],
-      query: `id:[${String(response.replayIds)}]`,
+      query: response.replayIds.length ? `id:[${String(response.replayIds)}]` : undefined,
       orderby: decodeScalar(location.query.sort, DEFAULT_SORT),
     });
   }, [location.query.sort, response.replayIds]);


### PR DESCRIPTION
- fixes https://github.com/getsentry/sentry/issues/73373
- the query `id:[]` was breaking our search endpoint, so this PR removes that from the query string

before:

<img width="958" alt="SCR-20240626-ndil" src="https://github.com/getsentry/sentry/assets/56095982/7aeb7305-e759-4a79-b056-3c1e1027c8f3">

after: 

<img width="940" alt="SCR-20240626-ndhj" src="https://github.com/getsentry/sentry/assets/56095982/933a5307-6ba4-4157-a012-52bbacdcc2ab">
