### PR TITLE
test: Fix integration endpoint test

### DIFF
--- a/tests/sentry/api/bases/test_integration.py
+++ b/tests/sentry/api/bases/test_integration.py
@@ -15,7 +15,7 @@ class IntegrationEndpointTest(TestCase):
     # Since both `IntegrationEndpoint.handle_exception` and `Endpoint.handle_exception` potentially
     # run, and they both call their own module's copy of `capture_exception`, in order to prove that
     # neither one is not called, we assert on the underlying method from the SDK
-    @patch("sentry_sdk.Hub.capture_exception")
+    @patch("sentry_sdk.Scope.capture_exception")
     def test_handle_rest_framework_exception(
         self, mock_capture_exception: MagicMock, mock_stderror_write: MagicMock
     ):


### PR DESCRIPTION
The `test_handle_rest_framework_exception` has not been testing what it is meant to test since we bumped the SDK to version 2.0.0 because the SDK no longer internally calls `sentry_sdk.Hub.capture_exception`. Rather, the SDK uses `sentry_sdk.Scope.capture_exception` to capture exceptions.

We should consider whether it makes sense to rewrite this test in a way that does not depend on SDK implementation details, but such a change probably belongs in a separate PR.

ref #73263