### PR TITLE
ref(seer grouping): Make events with no stacktrace frames Seer-ineligible

### DIFF
--- a/src/sentry/seer/similarity/similar_issues.py
+++ b/src/sentry/seer/similarity/similar_issues.py
@@ -66,6 +66,29 @@ def get_similarity_data_from_seer(
                 "referrer": similar_issues_request.get("referrer"),
             },
         )
+    # TODO: This is temporary, to debug Seer being sent empty stacktraces (which will happen for
+    # ingest requests if the filter in `event_content_is_seer_eligible` for existence of frames
+    # isn't enough, or if the similar issues tab ever sends an empty stacktrace). If we want this
+    # check to become permanent, we should move it elsewhere.
+    if not similar_issues_request["stacktrace"]:
+        logger.warning(
+            "get_seer_similar_issues.empty_stacktrace",
+            extra={
+                "event_id": similar_issues_request["event_id"],
+                "project_id": similar_issues_request["project_id"],
+                "hash": similar_issues_request["hash"],
+                "referrer": similar_issues_request.get("referrer"),
+            },
+        )
+        metrics.incr(
+            "seer.similar_issues_request",
+            sample_rate=SIMILARITY_REQUEST_METRIC_SAMPLE_RATE,
+            tags={
+                **metric_tags,
+                "outcome": "empty_stacktrace",
+            },
+        )
+        return []
 
     response = make_signed_seer_api_request(
         seer_grouping_connection_pool,

--- a/src/sentry/seer/similarity/utils.py
+++ b/src/sentry/seer/similarity/utils.py
@@ -1,7 +1,6 @@
 import logging
 from typing import Any
 
-from sentry.constants import PLACEHOLDER_EVENT_TITLES
 from sentry.eventstore.models import Event
 from sentry.utils.safe import get_path
 
@@ -84,12 +83,11 @@ def event_content_is_seer_eligible(event: Event) -> bool:
     """
     # TODO: Determine if we want to filter out non-sourcemapped events
 
-    # If an event has no stacktrace, and only one of our placeholder titles ("<untitled>",
-    # "<unknown>", etc.), there's no data for Seer to analyze, so no point in making the API call.
-    if (
-        event.title in PLACEHOLDER_EVENT_TITLES
-        and not get_path(event.data, "exception", "values", -1, "stacktrace", "frames")
-        and not get_path(event.data, "threads", "values", -1, "stacktrace", "frames")
+    # If an event has no stacktrace, there's no data for Seer to analyze, so no point in making the
+    # API call. If we ever start analyzing message-only events, we'll need to add `event.title in
+    # PLACEHOLDER_EVENT_TITLES` to this check.
+    if not get_path(event.data, "exception", "values", -1, "stacktrace", "frames") and not get_path(
+        event.data, "threads", "values", -1, "stacktrace", "frames"
     ):
         return False
 

--- a/tests/sentry/seer/similarity/test_utils.py
+++ b/tests/sentry/seer/similarity/test_utils.py
@@ -614,7 +614,7 @@ class EventContentIsSeerEligibleTest(TestCase):
             "platform": "python",
         }
 
-    def test_no_stacktrace_no_title(self):
+    def test_no_stacktrace(self):
         good_event_data = self.get_eligible_event_data()
         good_event = Event(
             project_id=self.project.id,
@@ -623,7 +623,6 @@ class EventContentIsSeerEligibleTest(TestCase):
         )
 
         bad_event_data = self.get_eligible_event_data()
-        bad_event_data["title"] = "<untitled>"
         del bad_event_data["exception"]
         bad_event = Event(
             project_id=self.project.id,


### PR DESCRIPTION
This updates the `event_content_is_seer_eligible` helper function so that events with a valid title but no stacktrace frames no longer count as eligible. 

For debugging purposes, it also adds a temporary log to track any requests which nonetheless end up with an empty stacktrace. In theory this PR's change to `event_content_is_seer_eligible` should prevent that from ever happening, but if it doesn't, this will let us know so we can make further adjustments. (We may have to compute the stacktrace string earlier - before we know if we're going to make the seer call - so we can check it directly, for example. I didn't do that here because I didn't want to waste the cycles on events which aren't getting sent.)