### PR TITLE
[CapMan visibility] emit a warning when a query gets throttled by the capacity management system

### DIFF
--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -1058,6 +1058,13 @@ def _bulk_snuba_query(
                     span.set_tag(k, v)
                     sentry_sdk.set_tag(k, v)
 
+                if (
+                    "throttled_by" in quota_allowance_summary
+                    and quota_allowance_summary["throttled_by"]
+                ):
+                    logger.warning("Query is throttled", extra={"response.data": response.data})
+                    sentry_sdk.capture_message("Query is throttled", level="warning")
+
             if response.status != 200:
                 _log_request_query(snuba_param_list[index][0])
                 metrics.incr(


### PR DESCRIPTION
https://getsentry.atlassian.net/browse/SNS-2799

Allocation policies are our mechanism for doing traffic management for Snuba queries. Currently, the result of applying allocation policies in the internal API is simply accept/reject/throttle, and Snuba sends back a payload to Sentry that contains metadata about those policy decisions. In the case of a throttled query, we want to emit a warning to GCP as well as a warning to Sentry Issues