### PR TITLE
Revert "ref(metrics): Add metrics for script run times (#72223)"

### DIFF
--- a/requirements-dev-frozen.txt
+++ b/requirements-dev-frozen.txt
@@ -178,7 +178,7 @@ rsa==4.8
 s3transfer==0.10.0
 selenium==4.16.0
 sentry-arroyo==2.16.5
-sentry-cli==2.32.0
+sentry-cli==2.16.0
 sentry-devenv==1.6.2
 sentry-forked-django-stubs==5.0.2.post4
 sentry-forked-djangorestframework-stubs==3.15.0.post1

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -18,7 +18,7 @@ pytest-sentry>=0.3.0
 pytest-xdist>=3
 responses>=0.23.1
 selenium>=4.16.0
-sentry-cli>=2.32.0
+sentry-cli>=2.16.0
 
 # pre-commit dependencies
 pre-commit>=3.3

--- a/scripts/do.sh
+++ b/scripts/do.sh
@@ -13,15 +13,4 @@ source "${HERE}/lib.sh"
 # a venv can avoid enabling this by setting SENTRY_NO_VENV_CHECK
 [ -z "${SENTRY_NO_VENV_CHECK+x}" ] && eval "${HERE}/ensure-venv.sh"
 # If you call this script
-start=`date +%s`
 "$@"
-end=`date +%s`
-duration=$(($end-$start))
-
-# If we're not in CI, send a metric of the script's execution time
-if [ -z "${CI+x}" ]; then
-    configure-sentry-cli
-    # DSN for `sentry-devservices` project in the Sentry SDKs org. Used as authentication for sentry-cli.
-    export SENTRY_DSN=https://8ae521d2441786bb405b3b3705bb9dc1@o447951.ingest.us.sentry.io/4507346183716864
-    "${venv_name}"/bin/sentry-cli send-metric distribution -n script_execution_time -v $duration -u second -t script:$1
-fi

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -34,21 +34,6 @@ require() {
     command -v "$1" >/dev/null 2>&1
 }
 
-configure-sentry-cli() {
-    if [ -f "${venv_name}/bin/sentry-cli" ]; then
-        return 0
-    elif [ -f "${venv_name}/bin/pip" ]; then
-        pip-install sentry-cli
-    else
-        cat <<EOF
-${red}${bold}
-ERROR: sentry-cli could not be installed, please run "devenv sync".
-${reset}
-EOF
-        return 1
-    fi
-}
-
 query-valid-python-version() {
     python_version=$(python3 -V 2>&1 | awk '{print $2}')
     if [[ -n "${SENTRY_PYTHON_VERSION:-}" ]]; then


### PR DESCRIPTION
This reverts commit 09cdabf95781c69013f4dfddf4d1ef5d55f15b0e. Wasn't roll forwardable anyways since `make instlal-py-dev` goes through do.sh, which I plan on removing.

Functionality will be preserved as part of https://github.com/getsentry/devenv/pull/124 where span durations would work.