### PR TITLE
ref(flag): Move performance-use-metrics to flagpole

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -288,7 +288,7 @@ def register_temporary_features(manager: FeatureManager):
     manager.add("organizations:performance-trends-issues", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
     # Bypass 30 day date range selection when fetching new trends data
     manager.add("organizations:performance-trends-new-data-date-range-default", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
-    manager.add("organizations:performance-use-metrics", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
+    manager.add("organizations:performance-use-metrics", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE)
     # Enable showing INP web vital in default views
     manager.add("organizations:performance-vitals-inp", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
     # Enable profiling


### PR DESCRIPTION
### Summary
We need this to be options backed since we're testing with it in STs. Moves the flag to flagpole.
