### PR TITLE
fix(discover): Update dataset with PUT on homepage query

### DIFF
--- a/src/sentry/discover/endpoints/discover_homepage_query.py
+++ b/src/sentry/discover/endpoints/discover_homepage_query.py
@@ -83,6 +83,7 @@ class DiscoverHomepageQueryEndpoint(OrganizationEndpoint):
                 name="",
                 query=data["query"],
                 version=data["version"],
+                dataset=data["query_dataset"],
             )
             previous_homepage.set_projects(data["project_ids"])
             return Response(serialize(previous_homepage), status=status.HTTP_200_OK)

--- a/tests/snuba/api/endpoints/test_discover_homepage_query.py
+++ b/tests/snuba/api/endpoints/test_discover_homepage_query.py
@@ -44,6 +44,7 @@ class DiscoverHomepageQueryTest(DiscoverSavedQueryBase):
             created_by_id=self.user.id,
             name="Test query",
             query=self.query,
+            dataset=DiscoverSavedQueryTypes.DISCOVER,
             is_homepage=True,
         )
         with self.feature(FEATURES):
@@ -53,6 +54,9 @@ class DiscoverHomepageQueryTest(DiscoverSavedQueryBase):
                     "name": "A new homepage query update",
                     "projects": self.project_ids,
                     "fields": ["field1", "field2"],
+                    "queryDataset": DiscoverSavedQueryTypes.get_type_name(
+                        DiscoverSavedQueryTypes.TRANSACTION_LIKE
+                    ),
                 },
             )
 
@@ -61,6 +65,7 @@ class DiscoverHomepageQueryTest(DiscoverSavedQueryBase):
         saved_query.refresh_from_db()
         assert response.data == serialize(saved_query)
         assert saved_query.query["fields"] == ["field1", "field2"]
+        assert saved_query.dataset == DiscoverSavedQueryTypes.TRANSACTION_LIKE
         assert set(saved_query.projects.values_list("id", flat=True)) == set(self.project_ids)
 
     def test_put_creates_new_discover_saved_query_if_none_exists(self):


### PR DESCRIPTION
Missed a spot - update dataset on homepage query too