### PR TITLE
fix(seer grouping): Make similarity request logs more readable

### DIFF
--- a/src/sentry/seer/similarity/similar_issues.py
+++ b/src/sentry/seer/similarity/similar_issues.py
@@ -46,7 +46,7 @@ def get_similarity_data_from_seer(
         similar_issues_request,
         keep_keys=["event_id", "project_id", "message", "hash", "referrer"],
     )
-    logger_extra["_message"] = logger_extra.pop("message", None)
+    logger_extra["message_value"] = logger_extra.pop("message", None)
     logger.info(
         "get_seer_similar_issues.request",
         extra=logger_extra,

--- a/tests/sentry/seer/similarity/test_similar_issues.py
+++ b/tests/sentry/seer/similarity/test_similar_issues.py
@@ -184,7 +184,7 @@ class GetSimilarityDataFromSeerTest(TestCase):
                     "event_id": "12312012041520130908201311212012",
                     "hash": "11212012123120120415201309082013",
                     "project_id": self.project.id,
-                    "_message": "Charlie didn't bring the ball back",
+                    "message_value": "Charlie didn't bring the ball back",
                 },
             )
             mock_metrics_incr.assert_any_call(


### PR DESCRIPTION
In https://github.com/getsentry/sentry/pull/73330, I fixed a bug (wherein the key `message` in a `logger` call's `extra` argument conflicted with the logger's internals in such a way as to make it crash) by changing the `extra` entry's key to `_message`. This worked to stop the crashing, but it's made the logs harder to parse at a glance, because the most important information - what the log is logging, a.k.a. the `event` value - shows up in different places in different rows:

![image](https://github.com/getsentry/sentry/assets/14812505/8f22ace0-6fdd-4cb1-a747-5b13727715f2)

(The reason this happens is that GCP sorts keys alphabetically, and the leading underscore makes `_message` come first.)

To fix this problem, this PR changes the key from `_message` to `message_value`, to force it later in the list of keys.