### PR TITLE
feat(insights): Query performance scores with hardcoded weights

### DIFF
--- a/src/sentry/search/events/constants.py
+++ b/src/sentry/search/events/constants.py
@@ -90,6 +90,14 @@ VITAL_THRESHOLDS: dict[str, ThresholdDict] = {
     },
 }
 
+WEB_VITALS_PERFORMANCE_SCORE_WEIGHTS: dict[str, float] = {
+    "lcp": 0.30,
+    "fcp": 0.15,
+    "cls": 0.15,
+    "ttfb": 0.10,
+    "inp": 0.30,
+}
+
 TAG_KEY_RE = re.compile(r"^(sentry_tags|tags)\[(?P<tag>.*)\]$")
 # Based on general/src/protocol/tags.rs in relay
 VALID_FIELD_PATTERN = re.compile(r"^[a-zA-Z0-9_.:-]*$")

--- a/src/sentry/search/events/datasets/metrics.py
+++ b/src/sentry/search/events/datasets/metrics.py
@@ -1892,27 +1892,23 @@ class MetricsDatasetConfig(DatasetConfig):
         _: Mapping[str, str | Column | SelectType | int | float],
         alias: str,
     ) -> SelectType:
-        lcp_metric_id = self.resolve_metric("measurements.score.lcp")
-        fcp_metric_id = self.resolve_metric("measurements.score.fcp")
-        cls_metric_id = self.resolve_metric("measurements.score.cls")
-        ttfb_metric_id = self.resolve_metric("measurements.score.ttfb")
-        inp_metric_id = self.resolve_metric("measurements.score.inp")
-
-        lcp = self._resolve_web_vital_score_function(
-            {"column": "measurements.score.lcp", "metric_id": lcp_metric_id}, None
-        )
-        fcp = self._resolve_web_vital_score_function(
-            {"column": "measurements.score.fcp", "metric_id": fcp_metric_id}, None
-        )
-        cls = self._resolve_web_vital_score_function(
-            {"column": "measurements.score.cls", "metric_id": cls_metric_id}, None
-        )
-        ttfb = self._resolve_web_vital_score_function(
-            {"column": "measurements.score.ttfb", "metric_id": ttfb_metric_id}, None
-        )
-        inp = self._resolve_web_vital_score_function(
-            {"column": "measurements.score.inp", "metric_id": inp_metric_id}, None
-        )
+        vitals = ["lcp", "fcp", "cls", "ttfb", "inp"]
+        scores = {
+            vital: Function(
+                "multiply",
+                [
+                    constants.WEB_VITALS_PERFORMANCE_SCORE_WEIGHTS[vital],
+                    self._resolve_web_vital_score_function(
+                        {
+                            "column": f"measurements.score.{vital}",
+                            "metric_id": self.resolve_metric(f"measurements.score.{vital}"),
+                        },
+                        None,
+                    ),
+                ],
+            )
+            for vital in vitals
+        }
 
         # TODO: Is there a way to sum more than 2 values at once?
         return Function(
@@ -1927,39 +1923,17 @@ class MetricsDatasetConfig(DatasetConfig):
                                 Function(
                                     "plus",
                                     [
-                                        Function(
-                                            "multiply",
-                                            [
-                                                lcp,
-                                                constants.WEB_VITALS_PERFORMANCE_SCORE_WEIGHTS[
-                                                    "lcp"
-                                                ],
-                                            ],
-                                        ),
-                                        Function(
-                                            "multiply",
-                                            [
-                                                fcp,
-                                                constants.WEB_VITALS_PERFORMANCE_SCORE_WEIGHTS[
-                                                    "fcp"
-                                                ],
-                                            ],
-                                        ),
+                                        scores["lcp"],
+                                        scores["fcp"],
                                     ],
                                 ),
-                                Function(
-                                    "multiply",
-                                    [cls, constants.WEB_VITALS_PERFORMANCE_SCORE_WEIGHTS["cls"]],
-                                ),
+                                scores["cls"],
                             ],
                         ),
-                        Function(
-                            "multiply",
-                            [ttfb, constants.WEB_VITALS_PERFORMANCE_SCORE_WEIGHTS["ttfb"]],
-                        ),
+                        scores["ttfb"],
                     ],
                 ),
-                Function("multiply", [inp, constants.WEB_VITALS_PERFORMANCE_SCORE_WEIGHTS["inp"]]),
+                scores["inp"],
             ],
             alias,
         )

--- a/tests/snuba/api/endpoints/test_organization_events_mep.py
+++ b/tests/snuba/api/endpoints/test_organization_events_mep.py
@@ -3077,6 +3077,85 @@ class OrganizationEventsMetricsEnhancedPerformanceEndpointTest(MetricsEnhancedPe
 
         assert meta["isMetricsData"]
 
+    def test_total_performance_score(self):
+        self.store_transaction_metric(
+            0.03,
+            metric="measurements.score.lcp",
+            tags={"transaction": "foo_transaction", "transaction.op": "pageload"},
+            timestamp=self.min_ago,
+        )
+        self.store_transaction_metric(
+            0.30,
+            metric="measurements.score.weight.lcp",
+            tags={"transaction": "foo_transaction", "transaction.op": "pageload"},
+            timestamp=self.min_ago,
+        )
+        self.store_transaction_metric(
+            0.15,
+            metric="measurements.score.fcp",
+            tags={"transaction": "foo_transaction", "transaction.op": "pageload"},
+            timestamp=self.min_ago,
+        )
+        self.store_transaction_metric(
+            0.15,
+            metric="measurements.score.weight.fcp",
+            tags={"transaction": "foo_transaction", "transaction.op": "pageload"},
+            timestamp=self.min_ago,
+        )
+        self.store_transaction_metric(
+            0.10,
+            metric="measurements.score.cls",
+            tags={"transaction": "foo_transaction", "transaction.op": "pageload"},
+            timestamp=self.min_ago,
+        )
+        self.store_transaction_metric(
+            0.15,
+            metric="measurements.score.weight.cls",
+            tags={"transaction": "foo_transaction", "transaction.op": "pageload"},
+            timestamp=self.min_ago,
+        )
+        self.store_transaction_metric(
+            0.05,
+            metric="measurements.score.ttfb",
+            tags={"transaction": "foo_transaction", "transaction.op": "pageload"},
+            timestamp=self.min_ago,
+        )
+        self.store_transaction_metric(
+            0.10,
+            metric="measurements.score.weight.ttfb",
+            tags={"transaction": "foo_transaction", "transaction.op": "pageload"},
+            timestamp=self.min_ago,
+        )
+        self.store_transaction_metric(
+            0.05,
+            metric="measurements.score.inp",
+            tags={"transaction": "foo_transaction", "transaction.op": "pageload"},
+            timestamp=self.min_ago,
+        )
+        self.store_transaction_metric(
+            0.10,
+            metric="measurements.score.weight.inp",
+            tags={"transaction": "foo_transaction", "transaction.op": "pageload"},
+            timestamp=self.min_ago,
+        )
+        response = self.do_request(
+            {
+                "field": [
+                    "transaction",
+                    "performance_score(measurements.score.total)",
+                ],
+                "query": "",
+                "dataset": "metrics",
+                "per_page": 50,
+            }
+        )
+        assert response.status_code == 200, response.content
+        assert len(response.data["data"]) == 1
+        data = response.data["data"]
+        meta = response.data["meta"]
+        assert data[0]["performance_score(measurements.score.total)"] == 0.48
+        assert meta["isMetricsData"]
+
     def test_count_scores(self):
         self.store_transaction_metric(
             0.1,
@@ -3546,7 +3625,11 @@ class OrganizationEventsMetricsEnhancedPerformanceEndpointTestWithMetricLayer(
 
     @pytest.mark.xfail(reason="Not implemented")
     def test_performance_score_boundaries(self):
-        super().test_performance_score()
+        super().test_performance_score_boundaries()
+
+    @pytest.mark.xfail(reason="Not implemented")
+    def test_total_performance_score(self):
+        super().test_total_performance_score()
 
     @pytest.mark.xfail(reason="Not implemented")
     def test_weighted_performance_score(self):


### PR DESCRIPTION
Updates the `performance_score` function in discover metrics to allow calculating total performance score with hardcoded weights. This may be useful in scenarios where certain webvitals are missing or low throughput which can cause issues when dynamically weighting vitals.