### PR TITLE
fix(snuba): Check for "summary" quota_allowance

### DIFF
--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -1047,7 +1047,7 @@ def _bulk_snuba_query(
                     raise SnubaError("Failed to parse snuba error response")
                 raise UnexpectedResponseError(f"Could not decode JSON response: {response.data!r}")
 
-            if "quota_allowance" in body and body["quota_allowance"]:
+            if "quota_allowance" in body and "summary" in body["quota_allowance"]:
                 quota_allowance_summary = body["quota_allowance"]["summary"]
                 span.set_tag("threads_used", quota_allowance_summary["threads_used"])
                 sentry_sdk.set_tag("threads_used", quota_allowance_summary["threads_used"])


### PR DESCRIPTION
Not sure if this can be reproduced in prod, but it causes exceptions on a newly bootstrapped devserver.

Fixes change from https://github.com/getsentry/sentry/pull/73449