### PR TITLE
perf(spans): Use bf index on tag keys

### DIFF
--- a/src/sentry/search/events/datasets/base.py
+++ b/src/sentry/search/events/datasets/base.py
@@ -20,6 +20,7 @@ class DatasetConfig(abc.ABC):
     non_nullable_keys: set[str] = set()
     missing_function_error: ClassVar[type[Exception]] = InvalidSearchQuery
     optimize_wildcard_searches = False
+    subscriptables_with_index: set[str] = set()
 
     def __init__(self, builder: BaseQueryBuilder):
         pass

--- a/src/sentry/search/events/datasets/spans_indexed.py
+++ b/src/sentry/search/events/datasets/spans_indexed.py
@@ -27,6 +27,7 @@ from sentry.search.utils import DEVICE_CLASS
 
 class SpansIndexedDatasetConfig(DatasetConfig):
     optimize_wildcard_searches = True
+    subscriptables_with_index = {"tags"}
 
     def __init__(self, builder: builder.QueryBuilder):
         self.builder = builder

--- a/tests/sentry/search/events/builder/test_spans_indexed.py
+++ b/tests/sentry/search/events/builder/test_spans_indexed.py
@@ -1,7 +1,7 @@
 from datetime import datetime, timedelta, timezone
 
 import pytest
-from snuba_sdk import AliasedExpression, Column, Condition, Function, Op
+from snuba_sdk import AliasedExpression, And, Column, Condition, Function, Op
 
 from sentry.search.events.builder import SpansIndexedQueryBuilder
 from sentry.snuba.dataset import Dataset
@@ -76,6 +76,10 @@ def tags(key, column="tags"):
     return Function("ifNull", [Column(f"{column}[{key}]"), ""])
 
 
+def has_tag(key, column="tags"):
+    return Condition(Function("has", [Column("tags.key"), key]), Op.EQ, 1)
+
+
 @pytest.mark.parametrize(
     ["condition", "expected"],
     [
@@ -122,52 +126,114 @@ def tags(key, column="tags"):
         ),
         pytest.param(
             "foo:*bar*",
-            Condition(Function("positionCaseInsensitive", [tags("foo"), "bar"]), Op.NEQ, 0),
+            And(
+                conditions=[
+                    Condition(Function("positionCaseInsensitive", [tags("foo"), "bar"]), Op.NEQ, 0),
+                    has_tag("foo"),
+                ],
+            ),
             id="foo:*bar*",
         ),
         pytest.param(
             "!foo:*bar*",
-            Condition(Function("positionCaseInsensitive", [tags("foo"), "bar"]), Op.EQ, 0),
+            And(
+                conditions=[
+                    Condition(Function("positionCaseInsensitive", [tags("foo"), "bar"]), Op.EQ, 0),
+                    has_tag("foo"),
+                ],
+            ),
             id="!foo:*bar*",
         ),
         pytest.param(
             r"foo:Bar*",
-            Condition(Function("startsWith", [Function("lower", [tags("foo")]), "bar"]), Op.EQ, 1),
+            And(
+                conditions=[
+                    Condition(
+                        Function("startsWith", [Function("lower", [tags("foo")]), "bar"]), Op.EQ, 1
+                    ),
+                    has_tag("foo"),
+                ],
+            ),
             id=r"foo:Bar*",
         ),
         pytest.param(
             r"!foo:Bar*",
-            Condition(Function("startsWith", [Function("lower", [tags("foo")]), "bar"]), Op.NEQ, 1),
+            And(
+                conditions=[
+                    Condition(
+                        Function("startsWith", [Function("lower", [tags("foo")]), "bar"]), Op.NEQ, 1
+                    ),
+                    has_tag("foo"),
+                ],
+            ),
             id=r"!foo:Bar*",
         ),
         pytest.param(
             r"foo:*Bar",
-            Condition(Function("endsWith", [Function("lower", [tags("foo")]), "bar"]), Op.EQ, 1),
+            And(
+                conditions=[
+                    Condition(
+                        Function("endsWith", [Function("lower", [tags("foo")]), "bar"]), Op.EQ, 1
+                    ),
+                    has_tag("foo"),
+                ],
+            ),
             id=r"foo:*Bar",
         ),
         pytest.param(
             r"!foo:*Bar",
-            Condition(Function("endsWith", [Function("lower", [tags("foo")]), "bar"]), Op.NEQ, 1),
+            And(
+                conditions=[
+                    Condition(
+                        Function("endsWith", [Function("lower", [tags("foo")]), "bar"]), Op.NEQ, 1
+                    ),
+                    has_tag("foo"),
+                ],
+            ),
             id=r"!foo:*Bar",
         ),
         pytest.param(
             r"foo:*Bar\*",
-            Condition(Function("endsWith", [Function("lower", [tags("foo")]), "bar*"]), Op.EQ, 1),
+            And(
+                conditions=[
+                    Condition(
+                        Function("endsWith", [Function("lower", [tags("foo")]), "bar*"]), Op.EQ, 1
+                    ),
+                    has_tag("foo"),
+                ],
+            ),
             id=r"foo:*Bar\*",
         ),
         pytest.param(
             r"!foo:*Bar\*",
-            Condition(Function("endsWith", [Function("lower", [tags("foo")]), "bar*"]), Op.NEQ, 1),
+            And(
+                conditions=[
+                    Condition(
+                        Function("endsWith", [Function("lower", [tags("foo")]), "bar*"]), Op.NEQ, 1
+                    ),
+                    has_tag("foo"),
+                ],
+            ),
             id=r"!foo:*Bar\*",
         ),
         pytest.param(
             r"foo:*b*a*r*",
-            Condition(Function("match", [tags("foo"), "(?i)^.*b.*a.*r.*$"]), Op.EQ, 1),
+            And(
+                conditions=[
+                    Condition(Function("match", [tags("foo"), "(?i)^.*b.*a.*r.*$"]), Op.EQ, 1),
+                    has_tag("foo"),
+                ],
+            ),
             id=r"foo:*b*a*r*",
         ),
         pytest.param(
             r"!foo:*b*a*r*",
-            Condition(Function("match", [tags("foo"), "(?i)^.*b.*a.*r.*$"]), Op.NEQ, 1),
+            And(
+                conditions=[
+                    Condition(Function("match", [tags("foo"), "(?i)^.*b.*a.*r.*$"]), Op.NEQ, 1),
+                    has_tag("foo"),
+                ],
+            ),
             id=r"!foo:*b*a*r*",
         ),
     ],


### PR DESCRIPTION
The spans table has a bloom filter index on the tag keys. Make sure to add the right condition to make sure the index is applied.