### PR TITLE
ref(slack): use sdk webhook client for webhook actions

### DIFF
--- a/src/sentry/integrations/slack/webhooks/action.py
+++ b/src/sentry/integrations/slack/webhooks/action.py
@@ -10,9 +10,9 @@ from django.urls import reverse
 from rest_framework import serializers
 from rest_framework.request import Request
 from rest_framework.response import Response
-from slack_sdk import WebhookClient
 from slack_sdk.errors import SlackApiError
 from slack_sdk.models.views import View
+from slack_sdk.webhook import WebhookClient
 
 from sentry import analytics, features
 from sentry.api import client
@@ -666,15 +666,26 @@ class SlackActionEndpoint(Endpoint):
             and "text" in response
         ):
             del response["text"]
-        slack_client = SlackClient(integration_id=slack_request.integration.id)
 
         if not slack_request.data.get("response_url"):
             # XXX: when you click an option in a modal dropdown it submits the request even though "Submit" has not been clicked
             return self.respond()
-        try:
-            slack_client.post(slack_request.data["response_url"], data=response, json=True)
-        except ApiError as e:
-            logger.error("slack.action.response-error", extra={"error": str(e)})
+
+        response_url = slack_request.data["response_url"]
+        if not features.has("organizations:slack-sdk-webhook-handling", group.project.organization):
+            slack_client = SlackClient(integration_id=slack_request.integration.id)
+            try:
+                slack_client.post(response_url, data=response, json=True)
+            except ApiError as e:
+                logger.error("slack.action.response-error", extra={"error": str(e)})
+
+        else:
+            json_blocks = orjson.dumps(response.get("blocks")).decode()
+            webhook_client = WebhookClient(response_url)
+            try:
+                webhook_client.send(blocks=json_blocks)
+            except SlackApiError as e:
+                logger.error("slack.webhook.update_status.response-error", extra={"error": str(e)})
 
         return self.respond(response)
 

--- a/tests/sentry/integrations/slack/test_message_builder.py
+++ b/tests/sentry/integrations/slack/test_message_builder.py
@@ -226,7 +226,7 @@ def build_test_message(
                 "name": "status",
                 "text": "Archive",
                 "type": "button",
-                "value": "ignored:until_escalating",
+                "value": "archived",
             },
             {
                 "option_groups": [

--- a/tests/sentry/integrations/slack/webhooks/actions/__init__.py
+++ b/tests/sentry/integrations/slack/webhooks/actions/__init__.py
@@ -25,7 +25,7 @@ class BaseEventTest(APITestCase):
     @pytest.fixture(autouse=True)
     def mock_webhook_send(self):
         with patch(
-            "slack_sdk.WebhookClient.send",
+            "slack_sdk.webhook.WebhookClient.send",
             return_value=WebhookResponse(
                 url="",
                 body='{"ok": True}',

--- a/tests/sentry/integrations/slack/webhooks/actions/test_status.py
+++ b/tests/sentry/integrations/slack/webhooks/actions/test_status.py
@@ -4,6 +4,7 @@ import orjson
 import responses
 from django.db import router
 from django.urls import reverse
+from slack_sdk.errors import SlackApiError
 from slack_sdk.web import SlackResponse
 
 from sentry.integrations.slack.views.link_identity import build_linking_url
@@ -566,6 +567,47 @@ class StatusActionTest(BaseEventTest, PerformanceIssueTestCase, HybridCloudTestM
             "assigneeType": "team",
             "integration": ActivityIntegration.SLACK.value,
         }
+
+    @with_feature("organizations:slack-sdk-webhook-handling")
+    @patch("sentry.integrations.slack.webhooks.action.logger")
+    def test_assign_issue_with_sdk_error(self, mock_logger):
+        mock_slack_response = SlackResponse(
+            client=None,
+            http_verb="POST",
+            api_url="https://slack.com/api/chat.postMessage",
+            req_args={},
+            data={"ok": False},
+            headers={},
+            status_code=200,
+        )
+
+        self.mock_post.side_effect = SlackApiError("error", mock_slack_response)
+
+        user2 = self.create_user(is_superuser=False)
+        self.create_member(user=user2, organization=self.organization, teams=[self.team])
+        original_message = self.get_original_message(self.group.id)
+
+        # Assign to user
+        resp = self.assign_issue(original_message, user2)
+        assert GroupAssignee.objects.filter(group=self.group, user_id=user2.id).exists()
+        expect_status = f"*Issue assigned to {user2.get_display_name()} by <@{self.external_id}>*"
+        assert self.notification_text in resp.data["blocks"][1]["text"]["text"]
+        assert resp.data["blocks"][2]["text"]["text"].endswith(expect_status), resp.data["text"]
+        assert ":white_circle:" in resp.data["blocks"][0]["text"]["text"]
+
+        # Assert group assignment activity recorded
+        group_activity = list(Activity.objects.filter(group=self.group))
+        assert group_activity[0].data == {
+            "assignee": str(user2.id),
+            "assigneeEmail": user2.email,
+            "assigneeType": "user",
+            "integration": ActivityIntegration.SLACK.value,
+        }
+
+        mock_logger.error.assert_called_with(
+            "slack.webhook.update_status.response-error",
+            extra={"error": "error\nThe server responded with: {'ok': False}"},
+        )
 
     def test_assign_issue_through_unfurl(self):
         user2 = self.create_user(is_superuser=False)

--- a/tests/sentry/integrations/slack/webhooks/actions/test_status.py
+++ b/tests/sentry/integrations/slack/webhooks/actions/test_status.py
@@ -271,30 +271,6 @@ class StatusActionTest(BaseEventTest, PerformanceIssueTestCase, HybridCloudTestM
         assert resp.data["response_type"] == "ephemeral"
         assert resp.data["text"] == LINK_IDENTITY_MESSAGE.format(associate_url=associate_url)
 
-    def test_archive_issue(self):
-        status_action = {
-            "name": "status",
-            "value": "ignored:archived_until_escalating",
-            "type": "button",
-        }
-
-        expect_status = f"Identity not found.\n*Issue archived by <@{self.external_id}>*"
-
-        resp = self.post_webhook(
-            action_data=[status_action],
-            original_message=self.original_message,
-            type="interactive_message",
-            callback_id=orjson.dumps({"issue": self.group.id}).decode(),
-        )
-        self.group = Group.objects.get(id=self.group.id)
-
-        assert resp.status_code == 200, resp.content
-        assert self.group.get_status() == GroupStatus.IGNORED
-        assert self.group.substatus == GroupSubStatus.UNTIL_ESCALATING
-        expect_status = f"*Issue archived by <@{self.external_id}>*"
-        assert self.notification_text in resp.data["blocks"][1]["text"]["text"]
-        assert resp.data["blocks"][2]["text"]["text"].endswith(expect_status)
-
     @responses.activate
     def test_archive_issue_until_escalating(self):
         original_message = self.get_original_message(self.group.id)
@@ -519,6 +495,43 @@ class StatusActionTest(BaseEventTest, PerformanceIssueTestCase, HybridCloudTestM
         assert resp.data["blocks"][2]["text"]["text"].endswith(expect_status)
 
     def test_assign_issue(self):
+        user2 = self.create_user(is_superuser=False)
+        self.create_member(user=user2, organization=self.organization, teams=[self.team])
+        original_message = self.get_original_message(self.group.id)
+
+        # Assign to user
+        resp = self.assign_issue(original_message, user2)
+        assert GroupAssignee.objects.filter(group=self.group, user_id=user2.id).exists()
+        expect_status = f"*Issue assigned to {user2.get_display_name()} by <@{self.external_id}>*"
+        assert self.notification_text in resp.data["blocks"][1]["text"]["text"]
+        assert resp.data["blocks"][2]["text"]["text"].endswith(expect_status), resp.data["text"]
+        assert ":white_circle:" in resp.data["blocks"][0]["text"]["text"]
+
+        # Assign to team
+        resp = self.assign_issue(original_message, self.team)
+        assert GroupAssignee.objects.filter(group=self.group, team=self.team).exists()
+        expect_status = f"*Issue assigned to #{self.team.slug} by <@{self.external_id}>*"
+        assert self.notification_text in resp.data["blocks"][1]["text"]["text"]
+        assert resp.data["blocks"][2]["text"]["text"].endswith(expect_status), resp.data["text"]
+        assert ":white_circle:" in resp.data["blocks"][0]["text"]["text"]
+
+        # Assert group assignment activity recorded
+        group_activity = list(Activity.objects.filter(group=self.group))
+        assert group_activity[0].data == {
+            "assignee": str(user2.id),
+            "assigneeEmail": user2.email,
+            "assigneeType": "user",
+            "integration": ActivityIntegration.SLACK.value,
+        }
+        assert group_activity[-1].data == {
+            "assignee": str(self.team.id),
+            "assigneeEmail": None,
+            "assigneeType": "team",
+            "integration": ActivityIntegration.SLACK.value,
+        }
+
+    @with_feature("organizations:slack-sdk-webhook-handling")
+    def test_assign_issue_with_sdk(self):
         user2 = self.create_user(is_superuser=False)
         self.create_member(user=user2, organization=self.organization, teams=[self.team])
         original_message = self.get_original_message(self.group.id)

--- a/tests/sentry/integrations/slack/webhooks/options_load/test_dynamic_assignment_dropdown.py
+++ b/tests/sentry/integrations/slack/webhooks/options_load/test_dynamic_assignment_dropdown.py
@@ -44,9 +44,9 @@ class DynamicAssignmentDropdownTest(BaseEventTest):
                         },
                         {
                             "type": "button",
-                            "action_id": "ignored:forever",
-                            "text": {"type": "plain_text", "text": "Ignore", "emoji": True},
-                            "value": "ignored:forever",
+                            "action_id": "archive_dialog",
+                            "text": {"type": "plain_text", "text": "Archive", "emoji": True},
+                            "value": "archive_dialog",
                         },
                         {
                             "type": "external_select",


### PR DESCRIPTION
Adds feature-flagged usage of the Slack SDK WebhookClient to update slack messages when actions are taken on them (archive, assign, resolve, etc).