### PR TITLE
fix(seer grouping): Restrict log of buggy behavior to ingest

### DIFF
--- a/src/sentry/seer/similarity/similar_issues.py
+++ b/src/sentry/seer/similarity/similar_issues.py
@@ -51,22 +51,23 @@ def get_similarity_data_from_seer(
         "get_seer_similar_issues.request",
         extra=logger_extra,
     )
-    # TODO: This is temporary, to debug Seer being called on existing hashes
-    existing_grouphash = GroupHash.objects.filter(
-        hash=similar_issues_request["hash"], project_id=similar_issues_request["project_id"]
-    ).first()
-    if existing_grouphash and existing_grouphash.group_id:
-        logger.warning(
-            "get_seer_similar_issues.hash_exists",
-            extra={
-                "event_id": similar_issues_request["event_id"],
-                "project_id": similar_issues_request["project_id"],
-                "hash": similar_issues_request["hash"],
-                "grouphash_id": existing_grouphash.id,
-                "group_id": existing_grouphash.group_id,
-                "referrer": similar_issues_request.get("referrer"),
-            },
-        )
+    # TODO: This is temporary, to debug Seer being called on existing hashes during ingest
+    if similar_issues_request.get("referrer") == "ingest":
+        existing_grouphash = GroupHash.objects.filter(
+            hash=similar_issues_request["hash"], project_id=similar_issues_request["project_id"]
+        ).first()
+        if existing_grouphash and existing_grouphash.group_id:
+            logger.warning(
+                "get_seer_similar_issues.hash_exists",
+                extra={
+                    "event_id": similar_issues_request["event_id"],
+                    "project_id": similar_issues_request["project_id"],
+                    "hash": similar_issues_request["hash"],
+                    "grouphash_id": existing_grouphash.id,
+                    "group_id": existing_grouphash.group_id,
+                    "referrer": similar_issues_request.get("referrer"),
+                },
+            )
     # TODO: This is temporary, to debug Seer being sent empty stacktraces (which will happen for
     # ingest requests if the filter in `event_content_is_seer_eligible` for existence of frames
     # isn't enough, or if the similar issues tab ever sends an empty stacktrace). If we want this


### PR DESCRIPTION
In our initial testing of the Seer grouping feature, we've occasionally seen hashes being sent to Seer multiple times. It wasn't initially clear why  - at least as far as ingest goes, this should theoretically never happen, because we should only be sending a hash to Seer the first time we see it. To debug this, we added a log to track any time we send an existing hash to Seer, and we also started tracking whether our Seer requests were coming from ingest or the similar issues tab.

So far, every instance of this log has come from the similar issues tab - which actually makes a lot of sense, because it only operates on existing groups. In that case, seeing an existing hash isn't a problem at all. This PR therefore restricts the log to firing when the request is coming from ingest, so that if we see it, we know that we're actually seeing broken behavior. 