### PR TITLE
feat(replay): Gap in replay timeline

### DIFF
--- a/static/app/components/replays/breadcrumbs/replayTimeline.tsx
+++ b/static/app/components/replays/breadcrumbs/replayTimeline.tsx
@@ -36,6 +36,7 @@ export default function ReplayTimeline() {
   const durationMs = replay.getDurationMs();
   const startTimestampMs = replay.getStartTimestampMs();
   const chapterFrames = replay.getChapterFrames();
+  const appFrames = replay.getAppFrames();
 
   // timeline is in the middle
   const initialTranslate = 0.5 / timelineScale;
@@ -65,7 +66,12 @@ export default function ReplayTimeline() {
       >
         <MinorGridlines durationMs={durationMs} width={width} />
         <MajorGridlines durationMs={durationMs} width={width} />
-        <TimelineGaps durationMs={durationMs} frames={chapterFrames} width={width} />
+        <TimelineGaps
+          durationMs={durationMs}
+          frames={appFrames}
+          totalFrames={chapterFrames.length}
+          width={width}
+        />
         <TimelineScrubber />
         <TimelineEventsContainer>
           <ReplayTimelineEvents

--- a/static/app/components/replays/breadcrumbs/replayTimeline.tsx
+++ b/static/app/components/replays/breadcrumbs/replayTimeline.tsx
@@ -9,6 +9,7 @@ import {
 } from 'sentry/components/replays/breadcrumbs/gridlines';
 import ReplayTimelineEvents from 'sentry/components/replays/breadcrumbs/replayTimelineEvents';
 import Stacked from 'sentry/components/replays/breadcrumbs/stacked';
+import TimelineGaps from 'sentry/components/replays/breadcrumbs/timelineGaps';
 import {TimelineScrubber} from 'sentry/components/replays/player/scrubber';
 import {useTimelineScrubberMouseTracking} from 'sentry/components/replays/player/useScrubberMouseTracking';
 import {useReplayContext} from 'sentry/components/replays/replayContext';
@@ -64,6 +65,7 @@ export default function ReplayTimeline() {
       >
         <MinorGridlines durationMs={durationMs} width={width} />
         <MajorGridlines durationMs={durationMs} width={width} />
+        <TimelineGaps durationMs={durationMs} frames={chapterFrames} width={width} />
         <TimelineScrubber />
         <TimelineEventsContainer>
           <ReplayTimelineEvents
@@ -88,4 +90,9 @@ const VisiblePanel = styled(Panel)`
 const TimelineEventsContainer = styled('div')`
   padding-top: 10px;
   padding-bottom: 10px;
+`;
+
+const Gap = styled('div')`
+  opacity: 0.16;
+  background: var(--Gray-400, #3e3446);
 `;

--- a/static/app/components/replays/breadcrumbs/replayTimeline.tsx
+++ b/static/app/components/replays/breadcrumbs/replayTimeline.tsx
@@ -91,8 +91,3 @@ const TimelineEventsContainer = styled('div')`
   padding-top: 10px;
   padding-bottom: 10px;
 `;
-
-const Gap = styled('div')`
-  opacity: 0.16;
-  background: var(--Gray-400, #3e3446);
-`;

--- a/static/app/components/replays/breadcrumbs/timelineGaps.tsx
+++ b/static/app/components/replays/breadcrumbs/timelineGaps.tsx
@@ -27,7 +27,8 @@ export default function TimelineGaps({durationMs, frames, width}: Props) {
   );
 
   // returns all numbers in the range
-  const range = (start, stop) => Array.from({length: stop - start}, (_, i) => start + i);
+  const range = (start, stop) =>
+    Array.from({length: stop - start}, (_, i) => start + i + 1);
 
   const gapCol: number[] = [];
 
@@ -56,11 +57,11 @@ export default function TimelineGaps({durationMs, frames, width}: Props) {
 
     // create gap if we found have start (background frame) and end (foreground frame)
     if (start !== -1 && end !== -1) {
-      gapCol.push(...range(start + 1, end + 1));
+      gapCol.push(...range(start, end));
     }
     // if we have start but no end, that means we have a gap until end of replay
     if (start !== -1 && end === -1) {
-      gapCol.push(...range(start + 1, totalColumns + 1));
+      gapCol.push(...range(start, totalColumns));
     }
   }
 
@@ -74,7 +75,7 @@ export default function TimelineGaps({durationMs, frames, width}: Props) {
 }
 
 const Gap = styled(Timeline.Col)<{column: number}>`
-  grid-column: ${p => Math.floor(p.column)};
+  grid-column: ${p => p.column};
   background: ${p => p.theme.red300};
   text-align: right;
   line-height: 14px;

--- a/static/app/components/replays/breadcrumbs/timelineGaps.tsx
+++ b/static/app/components/replays/breadcrumbs/timelineGaps.tsx
@@ -76,8 +76,7 @@ export default function TimelineGaps({durationMs, frames, width}: Props) {
 
 const Gap = styled(Timeline.Col)<{column: number}>`
   grid-column: ${p => p.column};
-  background: ${p => p.theme.red300};
-  text-align: right;
+  background: ${p => p.theme.gray400};
   line-height: 14px;
-  opacity: 50%;
+  opacity: 16%;
 `;

--- a/static/app/components/replays/breadcrumbs/timelineGaps.tsx
+++ b/static/app/components/replays/breadcrumbs/timelineGaps.tsx
@@ -26,7 +26,7 @@ export default function TimelineGaps({durationMs, frames, width}: Props) {
     totalColumns
   );
 
-  // returns all numbers in the range
+  // returns all numbers in the range, exclusive of start and inclusive of stop
   const range = (start, stop) =>
     Array.from({length: stop - start}, (_, i) => start + i + 1);
 

--- a/static/app/components/replays/breadcrumbs/timelineGaps.tsx
+++ b/static/app/components/replays/breadcrumbs/timelineGaps.tsx
@@ -1,0 +1,70 @@
+import styled from '@emotion/styled';
+
+import * as Timeline from 'sentry/components/replays/breadcrumbs/timeline';
+import {getFramesByColumn} from 'sentry/components/replays/utils';
+import {
+  isBackgroundFrame,
+  isForegroundFrame,
+  type ReplayFrame,
+} from 'sentry/utils/replays/types';
+
+interface Props {
+  durationMs: number;
+  frames: ReplayFrame[];
+  width: number;
+}
+
+export default function TimelineGaps({durationMs, frames, width}: Props) {
+  const markerWidth = frames.length < 200 ? 4 : frames.length < 500 ? 6 : 10;
+
+  const totalColumns = Math.floor(width / markerWidth);
+  const framesByColStart = getFramesByColumn(
+    durationMs,
+    frames.filter(f => isBackgroundFrame(f)),
+    totalColumns
+  );
+  const framesByColEnd = getFramesByColumn(
+    durationMs,
+    frames.filter(f => isForegroundFrame(f)),
+    totalColumns
+  );
+  const range = (start, stop) =>
+    Array.from({length: (stop - start) / 1}, (_, i) => start + i);
+
+  const gapCol: number[] = [];
+  const startKeys = framesByColStart.keys();
+  const endKeys = framesByColEnd.keys();
+  let start = startKeys.next();
+  let end = endKeys.next();
+
+  while (!start.done) {
+    while (start.value > end.value) {
+      console.log(start.value, end.value);
+      end = endKeys.next();
+      if (end.done) {
+        end.value = totalColumns - 1;
+      }
+    }
+    gapCol.push(...range(start.value, end.value ?? totalColumns));
+    console.log(range(start.value, end.value), start.value, end.value);
+    start = startKeys.next();
+    end = endKeys.next();
+  }
+
+  console.log(gapCol, framesByColStart, framesByColEnd);
+  return (
+    <Timeline.Columns totalColumns={totalColumns} remainder={0}>
+      {Array.from(gapCol).map(column => (
+        <Gap key={column} column={column} />
+      ))}
+    </Timeline.Columns>
+  );
+}
+
+const Gap = styled(Timeline.Col)<{column: number}>`
+  grid-column: ${p => Math.floor(p.column)};
+  background: ${p => p.theme.red300};
+  text-align: right;
+  line-height: 14px;
+  opacity: 50%;
+`;

--- a/static/app/components/replays/breadcrumbs/timelineGaps.tsx
+++ b/static/app/components/replays/breadcrumbs/timelineGaps.tsx
@@ -11,20 +11,16 @@ import {
 interface Props {
   durationMs: number;
   frames: ReplayFrame[];
+  totalFrames: number;
   width: number;
 }
 
 // create gaps in the timeline by finding all columns between a background frame and foreground frame
 // or background frame to end of replay
-export default function TimelineGaps({durationMs, frames, width}: Props) {
-  const markerWidth = frames.length < 200 ? 4 : frames.length < 500 ? 6 : 10;
-
+export default function TimelineGaps({durationMs, frames, totalFrames, width}: Props) {
+  const markerWidth = totalFrames < 200 ? 4 : totalFrames < 500 ? 6 : 10;
   const totalColumns = Math.floor(width / markerWidth);
-  const framesByCol = getFramesByColumn(
-    durationMs,
-    frames.filter(f => isBackgroundFrame(f) || isForegroundFrame(f)),
-    totalColumns
-  );
+  const framesByCol = getFramesByColumn(durationMs, frames, totalColumns);
 
   // returns all numbers in the range, exclusive of start and inclusive of stop
   const range = (start, stop) =>
@@ -44,11 +40,11 @@ export default function TimelineGaps({durationMs, frames, width}: Props) {
       const [column, colFrame] = currFrame.value;
       for (const frame of colFrame) {
         // only considered start of gap if background frame hasn't been found yet
-        if (start === -1 && 'category' in frame && frame.category === 'app.background') {
+        if (start === -1 && isBackgroundFrame(frame)) {
           start = column;
         }
         // gap only ends if background frame has been found
-        if (start !== -1 && 'category' in frame && frame.category === 'app.foreground') {
+        if (start !== -1 && isForegroundFrame(frame)) {
           end = column;
         }
       }

--- a/static/app/utils/replays/replayReader.tsx
+++ b/static/app/utils/replays/replayReader.tsx
@@ -36,8 +36,10 @@ import {
   BreadcrumbCategories,
   EventType,
   IncrementalSource,
+  isBackgroundFrame,
   isDeadClick,
   isDeadRageClick,
+  isForegroundFrame,
   isPaintFrame,
   isWebVitalFrame,
 } from 'sentry/utils/replays/types';
@@ -535,6 +537,12 @@ export default class ReplayReader {
       return this._sortedSpanFrames.filter(isWebVitalFrame);
     }
     return [];
+  });
+
+  getAppFrames = memoize(() => {
+    return this._sortedBreadcrumbFrames.filter(
+      frame => isBackgroundFrame(frame) || isForegroundFrame(frame)
+    );
   });
 
   getVideoEvents = () => this._videoEvents;

--- a/static/app/utils/replays/types.tsx
+++ b/static/app/utils/replays/types.tsx
@@ -193,6 +193,14 @@ export function isHydrationErrorFrame(
   return frame.category === 'replay.hydrate-error';
 }
 
+export function isBackgroundFrame(frame: ReplayFrame): frame is BreadcrumbFrame {
+  return frame && 'category' in frame && frame.category === 'app.background';
+}
+
+export function isForegroundFrame(frame: ReplayFrame): frame is BreadcrumbFrame {
+  return frame && 'category' in frame && frame.category === 'app.foreground';
+}
+
 type Overwrite<T, U> = Pick<T, Exclude<keyof T, keyof U>> & U;
 
 type HydratedTimestamp = {


### PR DESCRIPTION
Creates gaps in the timeline between `App in Background` and `App in Foreground` frames. If there's no `App in Foreground` frame after `App in Background`, the gap continues to the end of the replay.

Example gap:
<img width="1368" alt="image" src="https://github.com/getsentry/sentry/assets/55311782/53600ccf-bbf0-4360-9fcc-e211f9a340f1">

Example gap to end of replay:
<img width="1368" alt="image" src="https://github.com/getsentry/sentry/assets/55311782/e59fcb34-451e-47d2-96ad-00e7a37fa1c8">


Relates to https://github.com/getsentry/sentry/issues/71665