### PR TITLE
fix(replay): fix flickering when play/pause mobile replay

### DIFF
--- a/static/app/components/replays/videoReplayer.tsx
+++ b/static/app/components/replays/videoReplayer.tsx
@@ -318,13 +318,15 @@ export class VideoReplayer {
     }
 
     // Final check in case replay was stopped immediately after a video
-    if (!this._isPlaying) {
+    if (!this._isPlaying && nextIndex !== this._currentIndex) {
       // we can get here if we play/pause into a gap at the end of the video segment
       // to avoid showing flickering states when the user pauses,
       // (e.g., showing the next frame too eagerly), we want to stay on the last old
       // frame until it's time to show the next frame.
       const currSeg = this.getSegment(nextIndex - 1);
-      await this.loadSegment(nextIndex - 1, {segmentOffsetMs: currSeg!.duration - 1000});
+      await this.loadSegment(nextIndex - 1, {
+        segmentOffsetMs: currSeg!.duration - 1000,
+      });
       return;
     }
 

--- a/static/app/components/replays/videoReplayer.tsx
+++ b/static/app/components/replays/videoReplayer.tsx
@@ -319,6 +319,12 @@ export class VideoReplayer {
 
     // Final check in case replay was stopped immediately after a video
     if (!this._isPlaying) {
+      // we can get here if we play/pause into a gap at the end of the video segment
+      // to avoid showing flickering states when the user pauses,
+      // (e.g., showing the next frame too eagerly), we want to stay on the last old
+      // frame until it's time to show the next frame.
+      const currSeg = this.getSegment(nextIndex - 1);
+      await this.loadSegment(nextIndex - 1, {segmentOffsetMs: currSeg!.duration - 1000});
       return;
     }
 

--- a/static/app/components/replays/videoReplayer.tsx
+++ b/static/app/components/replays/videoReplayer.tsx
@@ -321,7 +321,7 @@ export class VideoReplayer {
     if (!this._isPlaying && nextIndex !== this._currentIndex) {
       // we can get here if we play/pause into a gap at the end of the video segment
       // to avoid showing flickering states when the user pauses,
-      // (e.g., showing the next frame too eagerly), we want to stay on the last old
+      // (e.g., showing a different frame too eagerly), we want to stay on the last old
       // frame until it's time to show the next frame.
       const currSeg = this.getSegment(nextIndex - 1);
       await this.loadSegment(nextIndex - 1, {


### PR DESCRIPTION
- relates to https://github.com/getsentry/sentry/issues/70687
- this fixes some of the bugs where playing/pausing a mobile replay results in two different frames being shown
- this one was happening because we were seeking into a part of the replay where the segment ends, and we didn't put in any sort of buffer. ex. the video duration is sent in as 5000ms but the segment ends before that, so we run out of content to show.


before: notice the flickering

https://github.com/getsentry/sentry/assets/56095982/846f99d5-2145-480c-9081-be228e0c6a9c

after:



https://github.com/getsentry/sentry/assets/56095982/21c26ebe-64c2-405d-8ec6-8b60abe42c2b



another example before:


https://github.com/getsentry/sentry/assets/56095982/98f837d7-ce30-4fdc-b946-8b2bf6346ace





after:



https://github.com/getsentry/sentry/assets/56095982/c50d30cc-d073-4f34-8382-571e96233cfd

