### PR TITLE
fix(sentry-sdk): Correctly fork the scope for the thread pool

### DIFF
--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -1004,7 +1004,13 @@ def _bulk_snuba_query(
                 _query_thread_pool.map(
                     _snuba_query,
                     [
-                        (params, sentry_sdk.Scope.get_isolation_scope().fork(), headers, parent_api)
+                        (
+                            params,
+                            sentry_sdk.Scope.get_isolation_scope().fork(),
+                            sentry_sdk.Scope.get_current_scope().fork(),
+                            headers,
+                            parent_api,
+                        )
                         for params in snuba_param_list
                     ],
                 )
@@ -1016,6 +1022,7 @@ def _bulk_snuba_query(
                     (
                         snuba_param_list[0],
                         sentry_sdk.Scope.get_isolation_scope().fork(),
+                        sentry_sdk.Scope.get_current_scope().fork(),
                         headers,
                         parent_api,
                     )
@@ -1107,70 +1114,61 @@ def _snuba_query(
     params: tuple[
         RequestQueryBody,
         sentry_sdk.Scope,
+        sentry_sdk.Scope,
         Mapping[str, str],
         str,
     ],
 ) -> RawResult:
     # Eventually we can get rid of this wrapper, but for now it's cleaner to unwrap
     # the params here than in the calling function. (bc of thread .map)
-    query_body, thread_isolation_scope, headers, parent_api = params
-    request, forward, reverse = query_body
-    request.parent_api = parent_api
-    try:
-        referrer = headers.get("referer", "unknown")
-        if SNUBA_INFO:
-            import pprint
+    query_body, thread_isolation_scope, thread_current_scope, headers, parent_api = params
+    with sentry_sdk.scope.use_isolation_scope(thread_isolation_scope):
+        with sentry_sdk.scope.use_scope(thread_current_scope):
+            request, forward, reverse = query_body
+            request.parent_api = parent_api
+            try:
+                referrer = headers.get("referer", "unknown")
+                if SNUBA_INFO:
+                    import pprint
 
-            log_snuba_info(f"{referrer}.body:\n {pprint.pformat(request.to_dict())}")
-            request.flags.debug = True
+                    log_snuba_info(f"{referrer}.body:\n {pprint.pformat(request.to_dict())}")
+                    request.flags.debug = True
 
-        if isinstance(request.query, MetricsQuery):
-            return _raw_mql_query(request, thread_isolation_scope, headers), forward, reverse
+                if isinstance(request.query, MetricsQuery):
+                    return _raw_mql_query(request, headers), forward, reverse
 
-        return _raw_snql_query(request, thread_isolation_scope, headers), forward, reverse
-    except urllib3.exceptions.HTTPError as err:
-        raise SnubaError(err)
+                return _raw_snql_query(request, headers), forward, reverse
+            except urllib3.exceptions.HTTPError as err:
+                raise SnubaError(err)
 
 
-def _raw_mql_query(
-    request: Request, thread_isolation_scope: sentry_sdk.Scope, headers: Mapping[str, str]
-) -> urllib3.response.HTTPResponse:
+def _raw_mql_query(request: Request, headers: Mapping[str, str]) -> urllib3.response.HTTPResponse:
     # Enter hub such that http spans are properly nested
-    with sentry_sdk.scope.use_isolation_scope(thread_isolation_scope), timer("mql_query"):
+    with timer("mql_query"):
         referrer = headers.get("referer", "unknown")
         # TODO: This can be changed back to just `serialize` after we remove SnQL support for MetricsQuery
         serialized_req = request.serialize()
-        with thread_isolation_scope.start_span(
-            op="snuba_mql.validation", description=referrer
-        ) as span:
+        with sentry_sdk.start_span(op="snuba_mql.validation", description=referrer) as span:
             span.set_tag("snuba.referrer", referrer)
             body = serialized_req
 
-        with thread_isolation_scope.start_span(
-            op="snuba_mql.run", description=serialized_req
-        ) as span:
+        with sentry_sdk.start_span(op="snuba_mql.run", description=serialized_req) as span:
             span.set_tag("snuba.referrer", referrer)
             return _snuba_pool.urlopen(
                 "POST", f"/{request.dataset}/mql", body=body, headers=headers
             )
 
 
-def _raw_snql_query(
-    request: Request, thread_isolation_scope: sentry_sdk.Scope, headers: Mapping[str, str]
-) -> urllib3.response.HTTPResponse:
+def _raw_snql_query(request: Request, headers: Mapping[str, str]) -> urllib3.response.HTTPResponse:
     # Enter hub such that http spans are properly nested
-    with sentry_sdk.scope.use_isolation_scope(thread_isolation_scope), timer("snql_query"):
+    with timer("snql_query"):
         referrer = headers.get("referer", "<unknown>")
         serialized_req = request.serialize()
-        with thread_isolation_scope.start_span(
-            op="snuba_snql.validation", description=referrer
-        ) as span:
+        with sentry_sdk.start_span(op="snuba_snql.validation", description=referrer) as span:
             span.set_tag("snuba.referrer", referrer)
             body = serialized_req
 
-        with thread_isolation_scope.start_span(
-            op="snuba_snql.run", description=serialized_req
-        ) as span:
+        with sentry_sdk.start_span(op="snuba_snql.run", description=serialized_req) as span:
             span.set_tag("snuba.referrer", referrer)
             return _snuba_pool.urlopen(
                 "POST", f"/{request.dataset}/snql", body=body, headers=headers

--- a/tests/sentry/issues/test_attributes.py
+++ b/tests/sentry/issues/test_attributes.py
@@ -238,8 +238,11 @@ class PostUpdateLogGroupAttributesChangedTest(TestCase):
             request = json_to_snql(json_body, "group_attributes")
             request.validate()
             identity = lambda x: x
-            forked_scope = sentry_sdk.Scope.get_isolation_scope().fork()
-            resp = _snuba_query(((request, identity, identity), forked_scope, {}, "test_api"))
+            isolation_scope = sentry_sdk.Scope.get_isolation_scope().fork()
+            current_scope = sentry_sdk.Scope.get_current_scope().fork()
+            resp = _snuba_query(
+                ((request, identity, identity), isolation_scope, current_scope, {}, "test_api")
+            )
             assert resp[0].status == 200
             stuff = json.loads(resp[0].data)
             assert stuff["data"] == [

--- a/tests/sentry/issues/test_group_attributes_dataset.py
+++ b/tests/sentry/issues/test_group_attributes_dataset.py
@@ -32,8 +32,11 @@ class DatasetTest(SnubaTestCase, TestCase):
         request = json_to_snql(json_body, "group_attributes")
         request.validate()
         identity = lambda x: x
-        forked_scope = sentry_sdk.Scope.get_isolation_scope().fork()
-        resp = _snuba_query(((request, identity, identity), forked_scope, {}, "test_api"))
+        isolation_scope = sentry_sdk.Scope.get_isolation_scope().fork()
+        current_scope = sentry_sdk.Scope.get_current_scope().fork()
+        resp = _snuba_query(
+            ((request, identity, identity), isolation_scope, current_scope, {}, "test_api")
+        )
         assert resp[0].status == 200
         stuff = json.loads(resp[0].data)
 
@@ -64,8 +67,11 @@ class DatasetTest(SnubaTestCase, TestCase):
         request = json_to_snql(json_body, "group_attributes")
         request.validate()
         identity = lambda x: x
-        forked_scope = sentry_sdk.Scope.get_isolation_scope().fork()
-        resp = _snuba_query(((request, identity, identity), forked_scope, {}, "test_api"))
+        isolation_scope = sentry_sdk.Scope.get_isolation_scope().fork()
+        current_scope = sentry_sdk.Scope.get_current_scope().fork()
+        resp = _snuba_query(
+            ((request, identity, identity), isolation_scope, current_scope, {}, "test_api")
+        )
         assert resp[0].status == 200
         stuff = json.loads(resp[0].data)
 

--- a/tests/sentry/issues/test_search_issues_dataset.py
+++ b/tests/sentry/issues/test_search_issues_dataset.py
@@ -31,8 +31,11 @@ class DatasetTest(SnubaTestCase, TestCase):
         request = json_to_snql(json_body, "search_issues")
         request.validate()
         identity = lambda x: x
-        forked_scope = sentry_sdk.Scope.get_isolation_scope().fork()
-        resp = _snuba_query(((request, identity, identity), forked_scope, {}, "test_api"))
+        isolation_scope = sentry_sdk.Scope.get_isolation_scope().fork()
+        current_scope = sentry_sdk.Scope.get_current_scope().fork()
+        resp = _snuba_query(
+            ((request, identity, identity), isolation_scope, current_scope, {}, "test_api")
+        )
         assert resp[0].status == 200
         stuff = json.loads(resp[0].data)
 


### PR DESCRIPTION
I'm not sure I fully understand isolation vs current scopes in the sdk yet but this is adapted from https://github.com/getsentry/sentry-python/blob/b38f9c707e0b0ca42587a20cc1498b575fa4f895/sentry_sdk/integrations/threading.py.

The current implementation causing the validation and run spans to not be attached to the transaction. I believe what's happening is that the transaction is only on the current scope and not the isolation scope (I don't know why). As a result, when starting a span in the thread pool function, it's not attached to the transaction. This mimicks what the threading integration does and passes both the isolation and current scopes and sets them in the thread pool function.