### PR TITLE
ref(feedback): clarify user report notification setting

### DIFF
--- a/static/app/data/forms/userFeedback.tsx
+++ b/static/app/data/forms/userFeedback.tsx
@@ -28,7 +28,7 @@ const formGroups: JsonFormObject[] = [
         label: t('Enable Crash Report Notifications'),
         help: () =>
           tct(
-            'Get notified on [crashReportModalDocsLink: Crash Report Modal and User Report API submissions]. [feedbackWidgetDocsLink: Feedback widget] notifications are not affected by this setting and are on by default.',
+            'Get notified on [crashReportModalDocsLink: Crash Report Modal] and User Feedback API (SDK v7.X and older) submissions. [feedbackWidgetDocsLink: Feedback widget] notifications are not affected by this setting and are on by default.',
             {
               crashReportModalDocsLink: (
                 <a href="https://docs.sentry.io/platforms/javascript/user-feedback/#crash-report-modal" />

--- a/static/app/data/forms/userFeedback.tsx
+++ b/static/app/data/forms/userFeedback.tsx
@@ -28,7 +28,7 @@ const formGroups: JsonFormObject[] = [
         label: t('Enable Crash Report Notifications'),
         help: () =>
           tct(
-            'Get notified on [crashReportModalDocsLink: Crash Report Modal] and User Feedback API (SDK v7.X and older) submissions. [feedbackWidgetDocsLink: Feedback widget] notifications are not affected by this setting and are on by default.',
+            'Get notified on [crashReportModalDocsLink: Crash Report Modal] and User Feedback API (web endpoint and pre-SDK v8) submissions. [feedbackWidgetDocsLink: Feedback widget] notifications are not affected by this setting and are on by default.',
             {
               crashReportModalDocsLink: (
                 <a href="https://docs.sentry.io/platforms/javascript/user-feedback/#crash-report-modal" />

--- a/static/app/data/forms/userFeedback.tsx
+++ b/static/app/data/forms/userFeedback.tsx
@@ -28,13 +28,16 @@ const formGroups: JsonFormObject[] = [
         label: t('Enable Crash Report Notifications'),
         help: () =>
           tct(
-            'Get notified on [crashReportModalDocsLink: Crash Report Modal] and User Feedback API (web endpoint and pre-SDK v8) submissions. [feedbackWidgetDocsLink: Feedback widget] notifications are not affected by this setting and are on by default.',
+            'Get notified on feedback submissions from the [crashReportModalDocsLink: Crash Report Modal], [webApiEndpointLink: web endpoint], and JS SDK (pre-v8). [feedbackWidgetDocsLink: Feedback widget] notifications are not affected by this setting and are on by default.',
             {
               crashReportModalDocsLink: (
                 <a href="https://docs.sentry.io/platforms/javascript/user-feedback/#crash-report-modal" />
               ),
               feedbackWidgetDocsLink: (
                 <a href="https://docs.sentry.io/product/user-feedback/#user-feedback-widget" />
+              ),
+              webApiEndpointLink: (
+                <a href="https://docs.sentry.io/api/projects/submit-user-feedback/" />
               ),
             }
           ),


### PR DESCRIPTION
Displayed in user-feedback project settings. IMO the old title is confusing because both "crash report" and "user report" link to crash report docs. Also the "User Report API" isn't really mentioned in our docs, since it's deprecated. Correct me if I'm wrong about any of this, including the SDK version