### PR TITLE
test(trace-explorer): Pin trace timestamps in the past

### DIFF
--- a/tests/sentry/api/endpoints/test_organization_traces.py
+++ b/tests/sentry/api/endpoints/test_organization_traces.py
@@ -83,7 +83,8 @@ class OrganizationTracesEndpointTestBase(BaseSpansTestCase, APITestCase):
         tags = ["", "bar", "bar", "baz", "", "bar", "baz"]
         timestamps = []
 
-        now = before_now().replace(hour=0, minute=0, second=0, microsecond=0)
+        # move this 3 days into the past to ensure less flakey tests
+        now = before_now().replace(hour=0, minute=0, second=0, microsecond=0) - timedelta(days=3)
 
         trace_id_1 = uuid4().hex
         timestamps.append(now - timedelta(minutes=10))


### PR DESCRIPTION
When it's close to midnight, the timeout tests tends to fail because it actually finds the trace since it was not far enough in the past.