### PR TITLE
nit(rollup): Use reverse instead of sorting

### DIFF
--- a/src/sentry/tsdb/base.py
+++ b/src/sentry/tsdb/base.py
@@ -275,6 +275,7 @@ class BaseTSDB(Service):
         while timestamp >= start:
             series.append(self.normalize_to_epoch(timestamp, rollup))
             timestamp = timestamp - timedelta(seconds=rollup)
+
         return rollup, series[::-1]
 
     def get_active_series(

--- a/src/sentry/tsdb/base.py
+++ b/src/sentry/tsdb/base.py
@@ -275,8 +275,7 @@ class BaseTSDB(Service):
         while timestamp >= start:
             series.append(self.normalize_to_epoch(timestamp, rollup))
             timestamp = timestamp - timedelta(seconds=rollup)
-
-        return rollup, sorted(series)
+        return rollup, series[::-1]
 
     def get_active_series(
         self,
@@ -355,7 +354,6 @@ class BaseTSDB(Service):
         count: int = 1,
         environment_id: int | None = None,
     ) -> None:
-
         """
         Increment project ID=1 and group ID=5:
 


### PR DESCRIPTION
We're creating the list of buckets in the series by appending going backwards in time, meaning the largest timestamp will be at the front of the list and the last item will be the smallest.

We can avoid sorting by just reversing the list.