### PR TITLE
feat[apis]: Clean-up spans, traces, metrics endpoints

### DIFF
--- a/src/sentry/api/endpoints/organization_metrics_query.py
+++ b/src/sentry/api/endpoints/organization_metrics_query.py
@@ -33,6 +33,7 @@ class OrganizationMetricsQueryEndpoint(OrganizationEndpoint):
     publish_status = {
         "POST": ApiPublishStatus.EXPERIMENTAL,
     }
+    snuba_methods = ["POST"]
     owner = ApiOwner.TELEMETRY_EXPERIENCE
     permission_classes = (OrganizationMetricsPermission,)
 

--- a/src/sentry/api/endpoints/organization_metrics_samples.py
+++ b/src/sentry/api/endpoints/organization_metrics_samples.py
@@ -40,6 +40,7 @@ class OrganizationMetricsSamplesEndpoint(OrganizationEventsV2EndpointBase):
         "GET": ApiPublishStatus.EXPERIMENTAL,
     }
     owner = ApiOwner.TELEMETRY_EXPERIENCE
+    snuba_methods = ["GET"]
 
     def get(self, request: Request, organization: Organization) -> Response:
         try:

--- a/src/sentry/api/endpoints/organization_on_demand_metrics_estimation_stats.py
+++ b/src/sentry/api/endpoints/organization_on_demand_metrics_estimation_stats.py
@@ -57,6 +57,7 @@ class OrganizationOnDemandMetricsEstimationStatsEndpoint(OrganizationEventsV2End
     }
     owner = ApiOwner.TELEMETRY_EXPERIENCE
     """Gets the estimated volume of an organization's metric events."""
+    snuba_methods = ["GET"]
 
     def get(self, request: Request, organization: Organization) -> Response:
         measurement = request.GET.get("yAxis")

--- a/src/sentry/api/endpoints/organization_profiling_functions.py
+++ b/src/sentry/api/endpoints/organization_profiling_functions.py
@@ -71,6 +71,7 @@ class OrganizationProfilingFunctionTrendsEndpoint(OrganizationEventsV2EndpointBa
     publish_status = {
         "GET": ApiPublishStatus.PRIVATE,
     }
+    snuba_methods = ["GET"]
 
     def has_feature(self, organization: Organization, request: Request):
         return features.has(

--- a/src/sentry/api/endpoints/organization_spans_aggregation.py
+++ b/src/sentry/api/endpoints/organization_spans_aggregation.py
@@ -335,6 +335,7 @@ class OrganizationSpansAggregationEndpoint(OrganizationEventsEndpointBase):
     publish_status = {
         "GET": ApiPublishStatus.EXPERIMENTAL,
     }
+    snuba_methods = ["GET"]
 
     def get(self, request: Request, organization: Organization) -> Response:
         if not features.has(

--- a/src/sentry/api/endpoints/organization_spans_fields.py
+++ b/src/sentry/api/endpoints/organization_spans_fields.py
@@ -37,6 +37,7 @@ class OrganizationSpansFieldsEndpoint(OrganizationSpansFieldsEndpointBase):
         "GET": ApiPublishStatus.PRIVATE,
     }
     owner = ApiOwner.PERFORMANCE
+    snuba_methods = ["GET"]
 
     def get(self, request: Request, organization) -> Response:
         if not features.has(
@@ -100,6 +101,7 @@ class OrganizationSpansFieldValuesEndpoint(OrganizationSpansFieldsEndpointBase):
         "GET": ApiPublishStatus.PRIVATE,
     }
     owner = ApiOwner.PERFORMANCE
+    snuba_methods = ["GET"]
 
     def get(self, request: Request, organization, key: str) -> Response:
         if not features.has(

--- a/src/sentry/api/endpoints/organization_spans_trace.py
+++ b/src/sentry/api/endpoints/organization_spans_trace.py
@@ -32,6 +32,7 @@ class OrganizationSpansTraceEndpoint(OrganizationEventsV2EndpointBase):
     publish_status = {
         "GET": ApiPublishStatus.PRIVATE,
     }
+    snuba_methods = ["GET"]
 
     @sentry_sdk.tracing.trace
     def query_trace_data(self, params: ParamsType, trace_id: str) -> list[SnubaTrace]:

--- a/src/sentry/api/endpoints/organization_traces.py
+++ b/src/sentry/api/endpoints/organization_traces.py
@@ -142,6 +142,8 @@ class OrganizationTracesEndpointBase(OrganizationEventsV2EndpointBase):
 
 @region_silo_endpoint
 class OrganizationTracesEndpoint(OrganizationTracesEndpointBase):
+    snuba_methods = ["GET"]
+
     def get(self, request: Request, organization: Organization) -> Response:
         if not features.has(
             "organizations:performance-trace-explorer", organization, actor=request.user
@@ -206,6 +208,8 @@ class OrganizationTraceSpansSerializer(serializers.Serializer):
 
 @region_silo_endpoint
 class OrganizationTraceSpansEndpoint(OrganizationTracesEndpointBase):
+    snuba_methods = ["GET"]
+
     def get(self, request: Request, organization: Organization, trace_id: str) -> Response:
         if not features.has(
             "organizations:performance-trace-explorer", organization, actor=request.user
@@ -259,6 +263,8 @@ class OrganizationTracesStatsSerializer(serializers.Serializer):
 
 @region_silo_endpoint
 class OrganizationTracesStatsEndpoint(OrganizationTracesEndpointBase):
+    snuba_methods = ["GET"]
+
     def get(self, request: Request, organization: Organization) -> Response:
         if not features.has(
             "organizations:performance-trace-explorer", organization, actor=request.user


### PR DESCRIPTION
I'm auditing REST apis that query snuba with the goal of improving rate-limiting. This PR is just cleanup and has no logic change but my audit notes about them are [here](https://www.notion.so/sentry/c56df9a9e4bf43acb30ba8af9577fded?v=0d62ffdadc3c431eb92c306d14d0f29d) if you're curious.