### PR TITLE
test(minimetrics): Replace `Hub` with `Scope`

### DIFF
--- a/tests/sentry/metrics/test_minimetrics.py
+++ b/tests/sentry/metrics/test_minimetrics.py
@@ -3,20 +3,22 @@ from unittest import mock
 from unittest.mock import patch
 
 import pytest
-from sentry_sdk import Client, Hub, Transport
+import sentry_sdk
+import sentry_sdk.scope
+from sentry_sdk import Client, Transport
 
 from sentry.metrics.composite_experimental import CompositeExperimentalMetricsBackend
 from sentry.metrics.minimetrics import MiniMetricsMetricsBackend, before_emit_metric
 from sentry.testutils.helpers import override_options
 
 
-def full_flush(hub):
+def full_flush(scope):
     # first flush flushes the metrics
-    hub.client.flush()
+    scope.client.flush()
 
     # second flush should really not do anything unless the first
     # flush accidentally created more metrics
-    hub.client.flush()
+    scope.client.flush()
 
 
 def parse_metrics(bytes: bytes):
@@ -68,19 +70,20 @@ class DummyTransport(Transport):
 
 
 @pytest.fixture(scope="function")
-def hub():
-    hub = Hub(
-        Client(
+def scope():
+    scope = sentry_sdk.Scope(
+        ty=sentry_sdk.scope.ScopeType.ISOLATION,
+        client=Client(
             dsn="http://foo@example.invalid/42",
             transport=DummyTransport,
             _experiments={
                 "enable_metrics": True,
                 "before_emit_metric": before_emit_metric,  # type: ignore[typeddict-item]
             },
-        )
+        ),
     )
-    with hub:
-        yield hub
+    with sentry_sdk.scope.use_isolation_scope(scope):
+        yield scope
 
 
 @pytest.fixture(scope="function")
@@ -101,11 +104,11 @@ def backend():
         "delightful_metrics.enable_code_locations": True,
     }
 )
-def test_incr_called_with_no_tags(backend, hub):
+def test_incr_called_with_no_tags(backend, scope):
     backend.incr(key="foo", tags={"x": "y"})
-    full_flush(hub)
+    full_flush(scope)
 
-    metrics = hub.client.transport.get_metrics()
+    metrics = scope.client.transport.get_metrics()
 
     assert len(metrics) == 1
     assert metrics[0][1] == "sentrytest.foo@none"
@@ -115,7 +118,7 @@ def test_incr_called_with_no_tags(backend, hub):
     assert metrics[0][4]["environment"] != ""
     assert metrics[0][4]["x"] == "y"
 
-    assert len(hub.client.metrics_aggregator.buckets) == 0
+    assert len(scope.client.metrics_aggregator.buckets) == 0
 
 
 @override_options(
@@ -125,11 +128,11 @@ def test_incr_called_with_no_tags(backend, hub):
         "delightful_metrics.enable_code_locations": True,
     }
 )
-def test_incr_called_with_no_tags_and_no_common_tags(backend, hub):
+def test_incr_called_with_no_tags_and_no_common_tags(backend, scope):
     backend.incr(key="foo", tags={"x": "y"})
-    full_flush(hub)
+    full_flush(scope)
 
-    metrics = hub.client.transport.get_metrics()
+    metrics = scope.client.transport.get_metrics()
 
     assert len(metrics) == 1
     assert metrics[0][1] == "sentrytest.foo@none"
@@ -139,7 +142,7 @@ def test_incr_called_with_no_tags_and_no_common_tags(backend, hub):
     assert metrics[0][4].get("environment") is None
     assert metrics[0][4]["x"] == "y"
 
-    assert len(hub.client.metrics_aggregator.buckets) == 0
+    assert len(scope.client.metrics_aggregator.buckets) == 0
 
 
 @override_options(
@@ -149,18 +152,18 @@ def test_incr_called_with_no_tags_and_no_common_tags(backend, hub):
         "delightful_metrics.enable_code_locations": True,
     }
 )
-def test_incr_called_with_tag_value_as_list(backend, hub):
+def test_incr_called_with_tag_value_as_list(backend, scope):
     # The minimetrics backend supports the list type.
     backend.incr(key="foo", tags={"x": ["bar", "baz"]})
-    full_flush(hub)
+    full_flush(scope)
 
-    metrics = hub.client.transport.get_metrics()
+    metrics = scope.client.transport.get_metrics()
 
     assert len(metrics) == 1
     assert metrics[0][1] == "sentrytest.foo@none"
     assert metrics[0][4]["x"] == ["bar", "baz"]
 
-    assert len(hub.client.metrics_aggregator.buckets) == 0
+    assert len(scope.client.metrics_aggregator.buckets) == 0
 
 
 @override_options(
@@ -171,19 +174,19 @@ def test_incr_called_with_tag_value_as_list(backend, hub):
         "delightful_metrics.enable_code_locations": True,
     }
 )
-def test_gauge_as_count(backend, hub):
+def test_gauge_as_count(backend, scope):
     # The minimetrics backend supports the list type.
     backend.gauge(key="foo", value=42.0)
-    full_flush(hub)
+    full_flush(scope)
 
-    metrics = hub.client.transport.get_metrics()
+    metrics = scope.client.transport.get_metrics()
 
     assert len(metrics) == 1
     assert metrics[0][1] == "sentrytest.foo@none"
     assert metrics[0][2] == "c"
     assert metrics[0][3] == ["42.0"]
 
-    assert len(hub.client.metrics_aggregator.buckets) == 0
+    assert len(scope.client.metrics_aggregator.buckets) == 0
 
 
 @override_options(
@@ -194,19 +197,19 @@ def test_gauge_as_count(backend, hub):
         "delightful_metrics.enable_code_locations": True,
     }
 )
-def test_gauge(backend, hub):
+def test_gauge(backend, scope):
     # The minimetrics backend supports the list type.
     backend.gauge(key="foo", value=42.0)
-    full_flush(hub)
+    full_flush(scope)
 
-    metrics = hub.client.transport.get_metrics()
+    metrics = scope.client.transport.get_metrics()
 
     assert len(metrics) == 1
     assert metrics[0][1] == "sentrytest.foo@none"
     assert metrics[0][2] == "g"
     assert metrics[0][3] == ["42.0", "42.0", "42.0", "42.0", "1"]
 
-    assert len(hub.client.metrics_aggregator.buckets) == 0
+    assert len(scope.client.metrics_aggregator.buckets) == 0
 
 
 @override_options(
@@ -217,7 +220,7 @@ def test_gauge(backend, hub):
         "delightful_metrics.enable_code_locations": True,
     }
 )
-def test_composite_backend_does_not_recurse(hub):
+def test_composite_backend_does_not_recurse(scope):
     composite_backend = CompositeExperimentalMetricsBackend(
         primary_backend="sentry.metrics.dummy.DummyMetricsBackend"
     )
@@ -231,21 +234,21 @@ def test_composite_backend_does_not_recurse(hub):
     # make sure the backend feeds back to itself
     with mock.patch("sentry.utils.metrics.backend", new=TrackingCompositeBackend()):
         composite_backend.incr(key="sentrytest.composite", tags={"x": "bar"})
-        full_flush(hub)
+        full_flush(scope)
 
     # make sure that we did actually internally forward to the composite
     # backend so the test does not accidentally succeed.
     assert "incr" in accessed
     assert "distribution" in accessed
 
-    metrics = hub.client.transport.get_metrics()
+    metrics = scope.client.transport.get_metrics()
 
     # the minimetrics.add metric must not show up
     assert len(metrics) == 1
     assert metrics[0][1] == "sentry.sentrytest.composite@none"
     assert metrics[0][4]["x"] == "bar"
 
-    assert len(hub.client.metrics_aggregator.buckets) == 0
+    assert len(scope.client.metrics_aggregator.buckets) == 0
 
 
 @override_options(


### PR DESCRIPTION
Since the `Hub` API is deprecated, replace all uses of the `Hub` API in the minimetrics tests with the equivalent `Scope` API.

ref #73263