### PR TITLE
feat(apis): Pass query source to snuba - phase 2

### DIFF
--- a/src/sentry/api/endpoints/organization_events_meta.py
+++ b/src/sentry/api/endpoints/organization_events_meta.py
@@ -14,7 +14,9 @@ from sentry.api.helpers.group_index import build_query_params_from_request
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.group import GroupSerializer
 from sentry.api.utils import handle_query_errors
+from sentry.middleware import is_frontend_request
 from sentry.snuba import spans_indexed, spans_metrics
+from sentry.snuba.query_sources import QuerySource
 from sentry.snuba.referrer import Referrer
 
 
@@ -39,6 +41,10 @@ class OrganizationEventsMetaEndpoint(OrganizationEventsEndpointBase):
                 params=params,
                 query=request.query_params.get("query"),
                 referrer=Referrer.API_ORGANIZATION_EVENTS_META.value,
+                # TODO: @athena - add query_source when all datasets support it
+                # query_source=(
+                #     QuerySource.FRONTEND if is_frontend_request(request) else QuerySource.API
+                # ),
             )
 
         return Response({"count": result["data"][0]["count"]})
@@ -118,6 +124,7 @@ class OrganizationSpansSamplesEndpoint(OrganizationEventsEndpointBase):
     snuba_methods = ["GET"]
 
     def get(self, request: Request, organization) -> Response:
+        is_frontend = is_frontend_request(request)
         try:
             params = self.get_snuba_params(request, organization)
         except NoProjects:
@@ -148,6 +155,7 @@ class OrganizationSpansSamplesEndpoint(OrganizationEventsEndpointBase):
                 params=params,
                 query=request.query_params.get("query"),
                 referrer=Referrer.API_SPAN_SAMPLE_GET_BOUNDS.value,
+                query_source=(QuerySource.FRONTEND if is_frontend else QuerySource.API),
             )
             if len(bound_results["data"]) != 1:
                 raise ParseError("Could not find bounds")
@@ -169,6 +177,7 @@ class OrganizationSpansSamplesEndpoint(OrganizationEventsEndpointBase):
             params=params,
             query=request.query_params.get("query"),
             referrer=Referrer.API_SPAN_SAMPLE_GET_SPAN_IDS.value,
+            query_source=(QuerySource.FRONTEND if is_frontend else QuerySource.API),
         )
         span_ids = []
         for row in result["data"]:
@@ -192,5 +201,6 @@ class OrganizationSpansSamplesEndpoint(OrganizationEventsEndpointBase):
             query=query,
             limit=9,
             referrer=Referrer.API_SPAN_SAMPLE_GET_SPAN_DATA.value,
+            query_source=(QuerySource.FRONTEND if is_frontend else QuerySource.API),
         )
         return Response({"data": result["data"]})

--- a/src/sentry/api/endpoints/organization_events_stats.py
+++ b/src/sentry/api/endpoints/organization_events_stats.py
@@ -12,6 +12,7 @@ from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases import OrganizationEventsV2EndpointBase
 from sentry.constants import MAX_TOP_EVENTS
+from sentry.middleware import is_frontend_request
 from sentry.models.dashboard_widget import DashboardWidget, DashboardWidgetTypes
 from sentry.models.organization import Organization
 from sentry.snuba import (
@@ -25,6 +26,7 @@ from sentry.snuba import (
     transactions,
 )
 from sentry.snuba.metrics.extraction import MetricSpecType
+from sentry.snuba.query_sources import QuerySource
 from sentry.snuba.referrer import Referrer
 from sentry.utils.snuba import SnubaError, SnubaTSResult
 
@@ -75,6 +77,9 @@ METRICS_ENHANCED_REFERRERS: set[str] = {
 ALLOWED_EVENTS_STATS_REFERRERS: set[str] = {
     Referrer.API_ALERTS_ALERT_RULE_CHART.value,
     Referrer.API_ALERTS_CHARTCUTERIE.value,
+    Referrer.API_ENDPOINT_REGRESSION_ALERT_CHARTCUTERIE.value,
+    Referrer.API_FUNCTION_REGRESSION_ALERT_CHARTCUTERIE.value,
+    Referrer.DISCOVER_SLACK_UNFURL.value,
     Referrer.API_DASHBOARDS_WIDGET_AREA_CHART.value,
     Referrer.API_DASHBOARDS_WIDGET_BAR_CHART.value,
     Referrer.API_DASHBOARDS_WIDGET_LINE_CHART.value,
@@ -106,6 +111,14 @@ ALLOWED_EVENTS_STATS_REFERRERS: set[str] = {
     Referrer.API_PERFORMANCE_SPAN_SUMMARY_THROUGHPUT_CHART.value,
     Referrer.API_PERFORMANCE_SPAN_SUMMARY_TRANSACTION_THROUGHPUT_CHART.value,
 }
+
+
+SENTRY_BACKEND_REFERRERS = [
+    Referrer.API_ALERTS_CHARTCUTERIE.value,
+    Referrer.API_ENDPOINT_REGRESSION_ALERT_CHARTCUTERIE.value,
+    Referrer.API_FUNCTION_REGRESSION_ALERT_CHARTCUTERIE.value,
+    Referrer.DISCOVER_SLACK_UNFURL.value,
+]
 
 
 @region_silo_endpoint
@@ -167,6 +180,7 @@ class OrganizationEventsStatsEndpoint(OrganizationEventsV2EndpointBase):
         return has_data
 
     def get(self, request: Request, organization: Organization) -> Response:
+        query_source = QuerySource.FRONTEND if is_frontend_request(request) else QuerySource.API
         with sentry_sdk.start_span(op="discover.endpoint", description="filter_params") as span:
             span.set_data("organization", organization)
 
@@ -205,6 +219,8 @@ class OrganizationEventsStatsEndpoint(OrganizationEventsV2EndpointBase):
                 if referrer in ALLOWED_EVENTS_STATS_REFERRERS.union(METRICS_ENHANCED_REFERRERS)
                 else Referrer.API_ORGANIZATION_EVENT_STATS.value
             )
+            if referrer in SENTRY_BACKEND_REFERRERS:
+                query_source = QuerySource.SENTRY_BACKEND
             batch_features = self.get_features(organization, request)
             has_chart_interpolation = batch_features.get(
                 "organizations:performance-chart-interpolation", False
@@ -281,6 +297,7 @@ class OrganizationEventsStatsEndpoint(OrganizationEventsV2EndpointBase):
                     on_demand_metrics_enabled=use_on_demand_metrics,
                     on_demand_metrics_type=on_demand_metrics_type,
                     include_other=include_other,
+                    query_source=query_source,
                 )
 
             return scoped_dataset.timeseries_query(
@@ -306,6 +323,7 @@ class OrganizationEventsStatsEndpoint(OrganizationEventsV2EndpointBase):
                     )
                 ),
                 on_demand_metrics_type=on_demand_metrics_type,
+                query_source=query_source,
             )
 
         def get_event_stats_factory(scoped_dataset):

--- a/src/sentry/integrations/slack/unfurl/discover.py
+++ b/src/sentry/integrations/slack/unfurl/discover.py
@@ -21,6 +21,7 @@ from sentry.models.apikey import ApiKey
 from sentry.models.organization import Organization
 from sentry.models.user import User
 from sentry.search.events.filter import to_list
+from sentry.snuba.referrer import Referrer
 from sentry.utils.dates import (
     get_interval_from_range,
     parse_stats_period,
@@ -235,6 +236,7 @@ def unfurl_discover(
                 params.setlist("statsPeriod", [stats_period])
 
         endpoint = "events-stats/"
+        params["referrer"] = Referrer.DISCOVER_SLACK_UNFURL.value
 
         try:
             resp = client.get(

--- a/src/sentry/search/events/builder/base.py
+++ b/src/sentry/search/events/builder/base.py
@@ -59,6 +59,7 @@ from sentry.search.events.types import (
 from sentry.snuba.dataset import Dataset
 from sentry.snuba.metrics.utils import MetricMeta
 from sentry.users.services.user.service import user_service
+from sentry.snuba.query_sources import QuerySource
 from sentry.utils.dates import outside_retention_with_modified_start
 from sentry.utils.env import in_test_environment
 from sentry.utils.snuba import (
@@ -1509,10 +1510,12 @@ class BaseQueryBuilder:
             return None
         return value
 
-    def run_query(self, referrer: str | None, use_cache: bool = False) -> Any:
+    def run_query(
+        self, referrer: str | None, use_cache: bool = False, query_source: QuerySource | None = None
+    ) -> Any:
         if not referrer:
             InvalidSearchQuery("Query missing referrer.")
-        return raw_snql_query(self.get_snql_query(), referrer, use_cache)
+        return raw_snql_query(self.get_snql_query(), referrer, use_cache, query_source)
 
     def process_results(self, results: Any) -> EventsResponse:
         with sentry_sdk.start_span(op="QueryBuilder", description="process_results") as span:

--- a/src/sentry/search/events/builder/base.py
+++ b/src/sentry/search/events/builder/base.py
@@ -58,8 +58,8 @@ from sentry.search.events.types import (
 )
 from sentry.snuba.dataset import Dataset
 from sentry.snuba.metrics.utils import MetricMeta
-from sentry.users.services.user.service import user_service
 from sentry.snuba.query_sources import QuerySource
+from sentry.users.services.user.service import user_service
 from sentry.utils.dates import outside_retention_with_modified_start
 from sentry.utils.env import in_test_environment
 from sentry.utils.snuba import (

--- a/src/sentry/search/events/builder/metrics.py
+++ b/src/sentry/search/events/builder/metrics.py
@@ -1707,7 +1707,9 @@ class TimeseriesMetricQueryBuilder(MetricsQueryBuilder):
 
         return queries
 
-    def run_query(self, referrer: str, use_cache: bool = False) -> Any:
+    def run_query(
+        self, referrer: str, use_cache: bool = False, query_source: QuerySource | None = None
+    ) -> Any:
         if self.use_metrics_layer or self.use_on_demand:
             from sentry.snuba.metrics.datasource import get_series
             from sentry.snuba.metrics.mqb_query_transformer import (
@@ -1755,7 +1757,7 @@ class TimeseriesMetricQueryBuilder(MetricsQueryBuilder):
 
         queries = self.get_snql_query()
         if queries:
-            results = bulk_snuba_queries(queries, referrer, use_cache)
+            results = bulk_snuba_queries(queries, referrer, use_cache, query_source=query_source)
         else:
             results = []
 
@@ -1965,7 +1967,9 @@ class TopMetricsQueryBuilder(TimeseriesMetricQueryBuilder):
 
         return final_condition
 
-    def run_query(self, referrer: str, use_cache: bool = False) -> Any:
+    def run_query(
+        self, referrer: str, use_cache: bool = False, query_source: QuerySource | None = None
+    ) -> Any:
         result = {}
         results = []
         meta_dict = {}
@@ -2033,7 +2037,9 @@ class TopMetricsQueryBuilder(TimeseriesMetricQueryBuilder):
         else:
             queries = self.get_snql_query()
             if queries:
-                results = bulk_snuba_queries(queries, referrer, use_cache)
+                results = bulk_snuba_queries(
+                    queries, referrer, use_cache, query_source=query_source
+                )
 
             time_map: dict[str, dict[str, Any]] = defaultdict(dict)
             for current_result in results:

--- a/src/sentry/snuba/errors.py
+++ b/src/sentry/snuba/errors.py
@@ -56,6 +56,7 @@ def query(
     on_demand_metrics_enabled=False,
     on_demand_metrics_type: MetricSpecType | None = None,
     fallback_to_transactions=False,
+    query_source: QuerySource | None = None,
 ) -> EventsResponse:
     if not selected_columns:
         raise InvalidSearchQuery("No columns selected")
@@ -85,7 +86,7 @@ def query(
     )
     if conditions is not None:
         builder.add_conditions(conditions)
-    result = builder.process_results(builder.run_query(referrer))
+    result = builder.process_results(builder.run_query(referrer, query_source=query_source))
     result["meta"]["tips"] = transform_tips(builder.tips)
     return result
 
@@ -218,6 +219,7 @@ def top_events_timeseries(
     on_demand_metrics_enabled: bool = False,
     on_demand_metrics_type: MetricSpecType | None = None,
     dataset: Dataset = Dataset.Discover,
+    query_source: QuerySource | None = None,
 ) -> dict[str, SnubaTSResult] | SnubaTSResult:
     """
     High-level API for doing arbitrary user timeseries queries for a limited number of top events
@@ -259,6 +261,7 @@ def top_events_timeseries(
                 use_aggregate_conditions=True,
                 include_equation_fields=True,
                 skip_tag_resolution=True,
+                query_source=query_source,
             )
 
     top_events_builder = ErrorsTopEventsQueryBuilder(
@@ -293,6 +296,7 @@ def top_events_timeseries(
         result, other_result = bulk_snuba_queries(
             [top_events_builder.get_snql_query(), other_events_builder.get_snql_query()],
             referrer=referrer,
+            query_source=query_source,
         )
     else:
         result = top_events_builder.run_query(referrer)

--- a/src/sentry/snuba/errors.py
+++ b/src/sentry/snuba/errors.py
@@ -20,6 +20,7 @@ from sentry.search.events.types import EventsResponse, ParamsType, QueryBuilderC
 from sentry.snuba.dataset import Dataset
 from sentry.snuba.discover import OTHER_KEY, create_result_key, transform_tips, zerofill
 from sentry.snuba.metrics.extraction import MetricSpecType
+from sentry.snuba.query_sources import QuerySource
 from sentry.utils.snuba import SnubaTSResult, bulk_snuba_queries
 
 is_filter_translation = {}
@@ -104,6 +105,7 @@ def timeseries_query(
     use_metrics_layer=False,
     on_demand_metrics_enabled=False,
     on_demand_metrics_type: MetricSpecType | None = None,
+    query_source: QuerySource | None = None,
 ):
 
     if len(params) == 0 and snuba_params is not None:
@@ -144,7 +146,7 @@ def timeseries_query(
             query_list.append(comparison_builder)
 
         query_results = bulk_snuba_queries(
-            [query.get_snql_query() for query in query_list], referrer
+            [query.get_snql_query() for query in query_list], referrer, query_source=query_source
         )
 
     with sentry_sdk.start_span(op="errors", description="timeseries.transform_results"):

--- a/src/sentry/snuba/functions.py
+++ b/src/sentry/snuba/functions.py
@@ -15,6 +15,7 @@ from sentry.search.events.types import ParamsType, QueryBuilderConfig, SnubaPara
 from sentry.snuba.dataset import Dataset
 from sentry.snuba.discover import transform_tips, zerofill
 from sentry.snuba.metrics.extraction import MetricSpecType
+from sentry.snuba.query_sources import QuerySource
 from sentry.utils.snuba import SnubaTSResult
 
 logger = logging.getLogger(__name__)
@@ -43,6 +44,7 @@ def query(
     on_demand_metrics_enabled: bool = False,
     on_demand_metrics_type: MetricSpecType | None = None,
     fallback_to_transactions=False,
+    query_source: QuerySource | None = None,
 ) -> Any:
     if not selected_columns:
         raise InvalidSearchQuery("No columns selected")
@@ -67,7 +69,9 @@ def query(
     )
     if conditions is not None:
         builder.add_conditions(conditions)
-    result = builder.process_results(builder.run_query(referrer))
+    result = builder.process_results(
+        builder.run_query(referrer=referrer, query_source=query_source)
+    )
     result["meta"]["tips"] = transform_tips(builder.tips)
     return result
 
@@ -87,6 +91,7 @@ def timeseries_query(
     use_metrics_layer: bool = False,
     on_demand_metrics_enabled: bool = False,
     on_demand_metrics_type: MetricSpecType | None = None,
+    query_source: QuerySource | None = None,
 ) -> Any:
 
     if len(params) == 0 and snuba_params is not None:
@@ -103,20 +108,22 @@ def timeseries_query(
             functions_acl=functions_acl,
         ),
     )
-    results = builder.run_query(referrer)
+    results = builder.run_query(referrer=referrer, query_source=query_source)
     results = builder.strip_alias_prefix(results)
 
     return SnubaTSResult(
         {
-            "data": zerofill(
-                results["data"],
-                params["start"],
-                params["end"],
-                rollup,
-                ["time"],
-            )
-            if zerofill_results
-            else results["data"],
+            "data": (
+                zerofill(
+                    results["data"],
+                    params["start"],
+                    params["end"],
+                    rollup,
+                    ["time"],
+                )
+                if zerofill_results
+                else results["data"]
+            ),
             "meta": {
                 "fields": {
                     value["name"]: get_json_meta_type(value["name"], value.get("type"), builder)
@@ -150,6 +157,7 @@ def top_events_timeseries(
     result_key_order=None,
     on_demand_metrics_enabled: bool = False,
     on_demand_metrics_type: MetricSpecType | None = None,
+    query_source: QuerySource | None = None,
 ):
     assert not include_other, "Other is not supported"  # TODO: support other
 
@@ -166,6 +174,7 @@ def top_events_timeseries(
                 referrer=referrer,
                 auto_aggregations=True,
                 use_aggregate_conditions=True,
+                query_source=query_source,
             )
 
     top_functions_builder = ProfileTopFunctionsTimeseriesQueryBuilder(
@@ -188,7 +197,7 @@ def top_events_timeseries(
     if len(top_events["data"]) == limit and include_other:
         assert False, "Other is not supported"  # TODO: support other
 
-    result = top_functions_builder.run_query(referrer)
+    result = top_functions_builder.run_query(referrer=referrer, query_source=query_source)
 
     return format_top_events_timeseries_results(
         result,
@@ -224,9 +233,11 @@ def format_top_events_timeseries_results(
     if not allow_empty and not len(result.get("data", [])):
         return SnubaTSResult(
             {
-                "data": zerofill([], params["start"], params["end"], rollup, ["time"])
-                if zerofill_results
-                else [],
+                "data": (
+                    zerofill([], params["start"], params["end"], rollup, ["time"])
+                    if zerofill_results
+                    else []
+                ),
             },
             params["start"],
             params["end"],
@@ -263,9 +274,11 @@ def format_top_events_timeseries_results(
         return {
             key: SnubaTSResult(
                 {
-                    "data": zerofill(item["data"], params["start"], params["end"], rollup, ["time"])
-                    if zerofill_results
-                    else item["data"],
+                    "data": (
+                        zerofill(item["data"], params["start"], params["end"], rollup, ["time"])
+                        if zerofill_results
+                        else item["data"]
+                    ),
                     "order": item["order"],
                     "meta": {
                         "fields": {

--- a/src/sentry/snuba/issue_platform.py
+++ b/src/sentry/snuba/issue_platform.py
@@ -13,6 +13,7 @@ from sentry.search.events.types import EventsResponse, QueryBuilderConfig, Snuba
 from sentry.snuba.dataset import Dataset
 from sentry.snuba.discover import transform_tips, zerofill
 from sentry.snuba.metrics.extraction import MetricSpecType
+from sentry.snuba.query_sources import QuerySource
 from sentry.utils.snuba import SnubaTSResult, bulk_snuba_queries
 
 
@@ -120,6 +121,7 @@ def timeseries_query(
     use_metrics_layer=False,
     on_demand_metrics_enabled=False,
     on_demand_metrics_type: MetricSpecType | None = None,
+    query_source: QuerySource | None = None,
 ):
     """
     High-level API for doing arbitrary user timeseries queries against events.
@@ -181,7 +183,7 @@ def timeseries_query(
             query_list.append(comparison_builder)
 
         query_results = bulk_snuba_queries(
-            [query.get_snql_query() for query in query_list], referrer
+            [query.get_snql_query() for query in query_list], referrer, query_source=query_source
         )
 
     with sentry_sdk.start_span(op="issueplatform", description="timeseries.transform_results"):

--- a/src/sentry/snuba/metrics_enhanced_performance.py
+++ b/src/sentry/snuba/metrics_enhanced_performance.py
@@ -18,6 +18,7 @@ from sentry.snuba.metrics_performance import histogram_query as metrics_histogra
 from sentry.snuba.metrics_performance import query as metrics_query
 from sentry.snuba.metrics_performance import timeseries_query as metrics_timeseries_query
 from sentry.snuba.metrics_performance import top_events_timeseries as metrics_top_events_timeseries
+from sentry.snuba.query_sources import QuerySource
 from sentry.utils.snuba import SnubaTSResult
 
 
@@ -137,6 +138,7 @@ def timeseries_query(
     use_metrics_layer: bool = False,
     on_demand_metrics_enabled: bool = False,
     on_demand_metrics_type=None,
+    query_source: QuerySource | None = None,
 ) -> SnubaTSResult:
     """
     High-level API for doing arbitrary user timeseries queries against events.
@@ -164,6 +166,7 @@ def timeseries_query(
                 use_metrics_layer=use_metrics_layer,
                 on_demand_metrics_enabled=on_demand_metrics_enabled,
                 on_demand_metrics_type=on_demand_metrics_type,
+                query_source=query_source,
             )
         # raise Invalid Queries since the same thing will happen with discover
         except InvalidSearchQuery:
@@ -187,12 +190,15 @@ def timeseries_query(
             comparison_delta=comparison_delta,
             functions_acl=functions_acl,
             has_metrics=has_metrics,
+            query_source=query_source,
         )
     return SnubaTSResult(
         {
-            "data": discover.zerofill([], params["start"], params["end"], rollup, ["time"])
-            if zerofill_results
-            else [],
+            "data": (
+                discover.zerofill([], params["start"], params["end"], rollup, ["time"])
+                if zerofill_results
+                else []
+            ),
         },
         params["start"],
         params["end"],
@@ -219,6 +225,7 @@ def top_events_timeseries(
     functions_acl: list[str] | None = None,
     on_demand_metrics_enabled: bool = False,
     on_demand_metrics_type: MetricSpecType | None = None,
+    query_source: QuerySource | None = None,
 ) -> SnubaTSResult | dict[str, Any]:
     metrics_compatible = False
     equations, _ = categorize_columns(selected_columns)
@@ -249,6 +256,7 @@ def top_events_timeseries(
                 functions_acl,
                 on_demand_metrics_enabled=on_demand_metrics_enabled,
                 on_demand_metrics_type=on_demand_metrics_type,
+                query_source=query_source,
             )
         # raise Invalid Queries since the same thing will happen with discover
         except InvalidSearchQuery:
@@ -278,12 +286,15 @@ def top_events_timeseries(
             zerofill_results,
             include_other,
             functions_acl,
+            query_source=query_source,
         )
     return SnubaTSResult(
         {
-            "data": discover.zerofill([], params["start"], params["end"], rollup, ["time"])
-            if zerofill_results
-            else [],
+            "data": (
+                discover.zerofill([], params["start"], params["end"], rollup, ["time"])
+                if zerofill_results
+                else []
+            ),
         },
         params["start"],
         params["end"],

--- a/src/sentry/snuba/metrics_performance.py
+++ b/src/sentry/snuba/metrics_performance.py
@@ -109,7 +109,8 @@ def bulk_timeseries_query(
     groupby: Column | None = None,
     *,
     apply_formatting: Literal[False],
-) -> EventsResponse: ...
+) -> EventsResponse:
+    ...
 
 
 @overload
@@ -129,7 +130,8 @@ def bulk_timeseries_query(
     on_demand_metrics_enabled: bool = False,
     on_demand_metrics_type: MetricSpecType | None = None,
     groupby: Column | None = None,
-) -> SnubaTSResult: ...
+) -> SnubaTSResult:
+    ...
 
 
 def bulk_timeseries_query(

--- a/src/sentry/snuba/metrics_performance.py
+++ b/src/sentry/snuba/metrics_performance.py
@@ -21,6 +21,7 @@ from sentry.search.events.types import EventsResponse, ParamsType, QueryBuilderC
 from sentry.snuba import discover
 from sentry.snuba.dataset import Dataset
 from sentry.snuba.metrics.extraction import MetricSpecType
+from sentry.snuba.query_sources import QuerySource
 from sentry.utils.snuba import SnubaTSResult, bulk_snuba_queries
 
 logger = logging.getLogger(__name__)
@@ -51,6 +52,7 @@ def query(
     on_demand_metrics_type: MetricSpecType | None = None,
     granularity: int | None = None,
     fallback_to_transactions=False,
+    query_source: QuerySource | None = None,
 ):
     with sentry_sdk.start_span(op="mep", description="MetricQueryBuilder"):
         metrics_query = MetricsQueryBuilder(
@@ -78,7 +80,7 @@ def query(
             ),
         )
         metrics_referrer = referrer + ".metrics-enhanced"
-        results = metrics_query.run_query(metrics_referrer)
+        results = metrics_query.run_query(referrer=metrics_referrer, query_source=query_source)
     with sentry_sdk.start_span(op="mep", description="query.transform_results"):
         results = metrics_query.process_results(results)
         results["meta"]["isMetricsData"] = True
@@ -107,8 +109,7 @@ def bulk_timeseries_query(
     groupby: Column | None = None,
     *,
     apply_formatting: Literal[False],
-) -> EventsResponse:
-    ...
+) -> EventsResponse: ...
 
 
 @overload
@@ -128,8 +129,7 @@ def bulk_timeseries_query(
     on_demand_metrics_enabled: bool = False,
     on_demand_metrics_type: MetricSpecType | None = None,
     groupby: Column | None = None,
-) -> SnubaTSResult:
-    ...
+) -> SnubaTSResult: ...
 
 
 def bulk_timeseries_query(
@@ -256,6 +256,7 @@ def timeseries_query(
     on_demand_metrics_enabled: bool = False,
     on_demand_metrics_type: MetricSpecType | None = None,
     groupby: Column | None = None,
+    query_source: QuerySource | None = None,
 ) -> SnubaTSResult:
     """
     High-level API for doing arbitrary user timeseries queries against events.
@@ -285,7 +286,7 @@ def timeseries_query(
                 ),
             )
             metrics_referrer = referrer + ".metrics-enhanced"
-            result = metrics_query.run_query(metrics_referrer)
+            result = metrics_query.run_query(referrer=metrics_referrer, query_source=query_source)
         with sentry_sdk.start_span(op="mep", description="query.transform_results"):
             result = metrics_query.process_results(result)
             result["data"] = (
@@ -404,6 +405,7 @@ def top_events_timeseries(
     functions_acl=None,
     on_demand_metrics_enabled=False,
     on_demand_metrics_type: MetricSpecType | None = None,
+    query_source: QuerySource | None = None,
 ) -> SnubaTSResult | dict[str, Any]:
 
     if len(params) == 0 and snuba_params is not None:
@@ -423,6 +425,7 @@ def top_events_timeseries(
             use_aggregate_conditions=True,
             on_demand_metrics_enabled=on_demand_metrics_enabled,
             on_demand_metrics_type=on_demand_metrics_type,
+            query_source=query_source,
         )
 
     top_events_builder = TopMetricsQueryBuilder(
@@ -459,10 +462,10 @@ def top_events_timeseries(
         )
 
         # TODO: use bulk_snuba_queries
-        other_result = other_events_builder.run_query(referrer)
-        result = top_events_builder.run_query(referrer)
+        other_result = other_events_builder.run_query(referrer=referrer, query_source=query_source)
+        result = top_events_builder.run_query(referrer=referrer, query_source=query_source)
     else:
-        result = top_events_builder.run_query(referrer)
+        result = top_events_builder.run_query(referrer=referrer, query_source=query_source)
         other_result = {"data": []}
     if (
         not allow_empty

--- a/src/sentry/snuba/profiles.py
+++ b/src/sentry/snuba/profiles.py
@@ -11,6 +11,7 @@ from sentry.search.events.types import ParamsType, QueryBuilderConfig, SnubaPara
 from sentry.snuba.dataset import Dataset
 from sentry.snuba.discover import transform_tips, zerofill
 from sentry.snuba.metrics.extraction import MetricSpecType
+from sentry.snuba.query_sources import QuerySource
 from sentry.utils.snuba import SnubaTSResult
 
 
@@ -76,6 +77,7 @@ def timeseries_query(
     use_metrics_layer: bool = False,
     on_demand_metrics_enabled: bool = False,
     on_demand_metrics_type: MetricSpecType | None = None,
+    query_source: QuerySource | None = None,
 ) -> Any:
 
     if len(params) == 0 and snuba_params is not None:
@@ -92,19 +94,21 @@ def timeseries_query(
             functions_acl=functions_acl,
         ),
     )
-    results = builder.run_query(referrer)
+    results = builder.run_query(referrer=referrer, query_source=query_source)
 
     return SnubaTSResult(
         {
-            "data": zerofill(
-                results["data"],
-                params["start"],
-                params["end"],
-                rollup,
-                ["time"],
-            )
-            if zerofill_results
-            else results["data"],
+            "data": (
+                zerofill(
+                    results["data"],
+                    params["start"],
+                    params["end"],
+                    rollup,
+                    ["time"],
+                )
+                if zerofill_results
+                else results["data"]
+            ),
             "meta": {
                 "fields": {
                     value["name"]: get_json_meta_type(value["name"], value.get("type"), builder)

--- a/src/sentry/snuba/query_sources.py
+++ b/src/sentry/snuba/query_sources.py
@@ -4,3 +4,4 @@ from enum import Enum
 class QuerySource(Enum):
     FRONTEND = "frontend"
     API = "api"
+    SENTRY_BACKEND = "sentry_backend"

--- a/src/sentry/snuba/referrer.py
+++ b/src/sentry/snuba/referrer.py
@@ -599,6 +599,7 @@ class Referrer(Enum):
     DATA_EXPORT_TASKS_DISCOVER = "data_export.tasks.discover"
     DELETIONS_GROUP = "deletions.group"
     DISCOVER = "discover"
+    DISCOVER_SLACK_UNFURL = "discover.slack.unfurl"
     DYNAMIC_SAMPLING_DISTRIBUTION_FETCH_PROJECT_BREAKDOWN = (
         "dynamic-sampling.distribution.fetch-project-breakdown"
     )

--- a/src/sentry/snuba/spans_indexed.py
+++ b/src/sentry/snuba/spans_indexed.py
@@ -14,6 +14,7 @@ from sentry.search.events.types import QueryBuilderConfig, SnubaParams
 from sentry.snuba import discover
 from sentry.snuba.dataset import Dataset
 from sentry.snuba.metrics.extraction import MetricSpecType
+from sentry.snuba.query_sources import QuerySource
 from sentry.utils.snuba import SnubaTSResult, bulk_snuba_queries
 
 logger = logging.getLogger(__name__)
@@ -45,6 +46,7 @@ def query(
     on_demand_metrics_enabled=False,
     on_demand_metrics_type: MetricSpecType | None = None,
     fallback_to_transactions=False,
+    query_source: QuerySource | None = None,
 ):
     builder = SpansIndexedQueryBuilder(
         Dataset.SpansIndexed,
@@ -69,7 +71,9 @@ def query(
         ),
     )
 
-    result = builder.process_results(builder.run_query(referrer))
+    result = builder.process_results(
+        builder.run_query(referrer=referrer, query_source=query_source)
+    )
     return result
 
 
@@ -88,6 +92,7 @@ def timeseries_query(
     use_metrics_layer: bool = False,
     on_demand_metrics_enabled: bool = False,
     on_demand_metrics_type: MetricSpecType | None = None,
+    query_source: QuerySource | None = None,
 ) -> SnubaTSResult:
     """
     High-level API for doing arbitrary user timeseries queries against events.
@@ -110,7 +115,7 @@ def timeseries_query(
                 functions_acl=functions_acl,
             ),
         )
-        result = query.run_query(referrer)
+        result = query.run_query(referrer, query_source=query_source)
     with sentry_sdk.start_span(op="spans_indexed", description="query.transform_results"):
         result = query.process_results(result)
         result["data"] = (
@@ -155,6 +160,7 @@ def top_events_timeseries(
     functions_acl=None,
     on_demand_metrics_enabled: bool = False,
     on_demand_metrics_type: MetricSpecType | None = None,
+    query_source: QuerySource | None = None,
 ):
     """
     High-level API for doing arbitrary user timeseries queries for a limited number of top events
@@ -176,6 +182,7 @@ def top_events_timeseries(
                 use_aggregate_conditions=True,
                 include_equation_fields=True,
                 skip_tag_resolution=True,
+                query_source=query_source,
             )
 
     top_events_builder = TopEventsSpanIndexedQueryBuilder(
@@ -210,6 +217,7 @@ def top_events_timeseries(
         result, other_result = bulk_snuba_queries(
             [top_events_builder.get_snql_query(), other_events_builder.get_snql_query()],
             referrer=referrer,
+            query_source=query_source,
         )
     else:
         result = top_events_builder.run_query(referrer)

--- a/src/sentry/snuba/spans_metrics.py
+++ b/src/sentry/snuba/spans_metrics.py
@@ -13,6 +13,7 @@ from sentry.search.events.types import QueryBuilderConfig, SnubaParams
 from sentry.snuba import discover
 from sentry.snuba.dataset import Dataset
 from sentry.snuba.metrics.extraction import MetricSpecType
+from sentry.snuba.query_sources import QuerySource
 from sentry.utils.snuba import SnubaTSResult
 
 logger = logging.getLogger(__name__)
@@ -44,6 +45,7 @@ def query(
     on_demand_metrics_enabled=False,
     on_demand_metrics_type: MetricSpecType | None = None,
     fallback_to_transactions=False,
+    query_source: QuerySource | None = None,
 ):
     builder = SpansMetricsQueryBuilder(
         dataset=Dataset.PerformanceMetrics,
@@ -69,7 +71,9 @@ def query(
         ),
     )
 
-    result = builder.process_results(builder.run_query(referrer))
+    result = builder.process_results(
+        builder.run_query(referrer=referrer, query_source=query_source)
+    )
     return result
 
 
@@ -89,6 +93,7 @@ def timeseries_query(
     on_demand_metrics_enabled: bool = False,
     on_demand_metrics_type: MetricSpecType | None = None,
     groupby: Column | None = None,
+    query_source: QuerySource | None = None,
 ) -> SnubaTSResult:
     """
     High-level API for doing arbitrary user timeseries queries against events.
@@ -112,7 +117,7 @@ def timeseries_query(
             use_metrics_layer=use_metrics_layer,
         ),
     )
-    result = metrics_query.run_query(referrer)
+    result = metrics_query.run_query(referrer=referrer, query_source=query_source)
 
     result = metrics_query.process_results(result)
     result["data"] = (
@@ -160,6 +165,7 @@ def top_events_timeseries(
     functions_acl=None,
     on_demand_metrics_enabled=False,
     on_demand_metrics_type: MetricSpecType | None = None,
+    query_source: QuerySource | None = None,
 ):
     """
     High-level API for doing arbitrary user timeseries queries for a limited number of top events
@@ -201,6 +207,7 @@ def top_events_timeseries(
             use_aggregate_conditions=True,
             include_equation_fields=True,
             skip_tag_resolution=True,
+            query_source=query_source,
         )
 
     top_events_builder = TopSpansMetricsQueryBuilder(
@@ -232,10 +239,10 @@ def top_events_timeseries(
         )
 
         # TODO: use bulk_snuba_queries
-        other_result = other_events_builder.run_query(referrer)
-        result = top_events_builder.run_query(referrer)
+        other_result = other_events_builder.run_query(referrer=referrer, query_source=query_source)
+        result = top_events_builder.run_query(referrer=referrer, query_source=query_source)
     else:
-        result = top_events_builder.run_query(referrer)
+        result = top_events_builder.run_query(referrer=referrer, query_source=query_source)
         other_result = {"data": []}
     if (
         not allow_empty

--- a/src/sentry/snuba/transactions.py
+++ b/src/sentry/snuba/transactions.py
@@ -9,6 +9,7 @@ from sentry.search.events.types import EventsResponse, ParamsType, SnubaParams
 from sentry.snuba import discover
 from sentry.snuba.dataset import Dataset
 from sentry.snuba.metrics.extraction import MetricSpecType
+from sentry.snuba.query_sources import QuerySource
 from sentry.utils.snuba import SnubaTSResult
 
 logger = logging.getLogger(__name__)
@@ -87,6 +88,7 @@ def timeseries_query(
     use_metrics_layer=False,
     on_demand_metrics_enabled=False,
     on_demand_metrics_type=None,
+    query_source: QuerySource | None = None,
 ) -> SnubaTSResult:
     """
     High-level API for doing arbitrary user timeseries queries against events.
@@ -108,6 +110,7 @@ def timeseries_query(
         on_demand_metrics_enabled=on_demand_metrics_enabled,
         on_demand_metrics_type=on_demand_metrics_type,
         dataset=Dataset.Transactions,
+        query_source=query_source,
     )
 
 
@@ -130,6 +133,7 @@ def top_events_timeseries(
     functions_acl: list[str] | None = None,
     on_demand_metrics_enabled: bool = False,
     on_demand_metrics_type: MetricSpecType | None = None,
+    query_source: QuerySource | None = None,
 ) -> dict[str, SnubaTSResult] | SnubaTSResult:
     return discover.top_events_timeseries(
         timeseries_columns,
@@ -151,4 +155,5 @@ def top_events_timeseries(
         on_demand_metrics_enabled=on_demand_metrics_enabled,
         on_demand_metrics_type=on_demand_metrics_type,
         dataset=Dataset.Transactions,
+        query_source=query_source,
     )


### PR DESCRIPTION
Continuing https://github.com/getsentry/sentry/pull/73176 to pass query source to snuba for more debuggability. 

OrganizationSpansSamplesEndpoint
OrganizationsEventsMetaEndpoint
OrganizationsEventsStatsEndpoint
