### PR TITLE
ref: Replace `push_scope` with `isolation_scope` in all remaining places

### DIFF
--- a/src/sentry/auth/helper.py
+++ b/src/sentry/auth/helper.py
@@ -134,7 +134,7 @@ class AuthIdentityHandler:
 
     @staticmethod
     def warn_about_ambiguous_email(email: str, users: Collection[User], chosen_user: User) -> None:
-        with sentry_sdk.push_scope() as scope:
+        with sentry_sdk.isolation_scope() as scope:
             scope.set_level("warning")
             scope.set_tag("email", email)
             scope.set_extra("user_ids", [user.id for user in users])

--- a/src/sentry/consumers/validate_schema.py
+++ b/src/sentry/consumers/validate_schema.py
@@ -45,7 +45,7 @@ class ValidateSchema(ProcessingStrategy[KafkaPayload]):
         else:
             now = time.time()
             if self.__last_record_time is None or self.__last_record_time + 1.0 < now:
-                with sentry_sdk.push_scope() as scope:
+                with sentry_sdk.isolation_scope() as scope:
                     scope.add_attachment(bytes=message.payload.value, filename="message.txt")
                     scope.set_tag("topic", self.__topic)
 

--- a/src/sentry/dynamic_sampling/tasks/common.py
+++ b/src/sentry/dynamic_sampling/tasks/common.py
@@ -666,7 +666,7 @@ def compute_sliding_window_sample_rate(
         state.num_iterations += 1
         context.set_function_state(func_name, state)
     if extrapolated_volume is None:
-        with sentry_sdk.push_scope() as scope:
+        with sentry_sdk.isolation_scope() as scope:
             scope.set_extra("org_id", org_id)
             scope.set_extra("window_size", window_size)
             sentry_sdk.capture_message("The volume of the current month can't be extrapolated.")

--- a/src/sentry/hybridcloud/tasks/deliver_webhooks.py
+++ b/src/sentry/hybridcloud/tasks/deliver_webhooks.py
@@ -403,7 +403,7 @@ def perform_request(payload: WebhookPayload) -> None:
             "hybridcloud.deliver_webhooks.failure",
             tags={"reason": "host_error", "destination_region": region.name},
         )
-        with sentry_sdk.push_scope() as scope:
+        with sentry_sdk.isolation_scope() as scope:
             scope.set_context(
                 "region",
                 {

--- a/src/sentry/search/events/builder/metrics.py
+++ b/src/sentry/search/events/builder/metrics.py
@@ -193,7 +193,7 @@ class MetricsQueryBuilder(BaseQueryBuilder):
             dashboard_widget_query__widget__dashboard__organization_id=self.organization_id,
         )
         if any(not entry.extraction_enabled() for entry in on_demand_entries):
-            with sentry_sdk.push_scope() as scope:
+            with sentry_sdk.isolation_scope() as scope:
                 scope.set_extra("entries", on_demand_entries)
                 scope.set_extra("hash", query_hash)
                 sentry_sdk.capture_message(

--- a/src/sentry/seer/breakpoints.py
+++ b/src/sentry/seer/breakpoints.py
@@ -87,7 +87,7 @@ def detect_breakpoints(breakpoint_request: BreakpointRequest) -> BreakpointRespo
             sentry_sdk.capture_exception(e)
             return {"data": []}
 
-    with sentry_sdk.push_scope() as scope:
+    with sentry_sdk.isolation_scope() as scope:
         scope.set_context(
             "seer_response",
             {

--- a/src/sentry/sentry_apps/apps.py
+++ b/src/sentry/sentry_apps/apps.py
@@ -12,7 +12,7 @@ from django.db.models import Q
 from django.http.request import HttpRequest
 from django.utils import timezone
 from rest_framework.exceptions import ValidationError
-from sentry_sdk.api import push_scope
+from sentry_sdk.api import isolation_scope
 
 from sentry import analytics, audit_log
 from sentry.api.helpers.slugs import sentry_slugify
@@ -399,7 +399,7 @@ class SentryAppCreator:
                     target_type=IntegrationTypes.SENTRY_APP.value,
                 )
         except IntegrityError:
-            with push_scope() as scope:
+            with isolation_scope() as scope:
                 scope.set_tag("sentry_app", sentry_app.slug)
                 sentry_sdk.capture_message("IntegrityError while creating IntegrationFeature")
 

--- a/src/sentry/sentry_metrics/querying/data/execution.py
+++ b/src/sentry/sentry_metrics/querying/data/execution.py
@@ -547,7 +547,7 @@ class QueryResult:
             # It can happen that the groups in series are not matching the groups in totals, due to Snuba bugs or just
             # limiting taking place in queries. Since this is a problem, we want to keep track of it.
             if indexes is None:
-                with sentry_sdk.push_scope() as scope:
+                with sentry_sdk.isolation_scope() as scope:
                     scope.set_tag("organization_id", organization.id)
                     scope.set_extra("totals_query", self.totals_query)
                     scope.set_extra("series_query", self.series_query)

--- a/src/sentry/snuba/query_subscriptions/consumer.py
+++ b/src/sentry/snuba/query_subscriptions/consumer.py
@@ -76,7 +76,7 @@ def handle_message(
     :param message:
     :return:
     """
-    with sentry_sdk.push_scope() as scope:
+    with sentry_sdk.isolation_scope() as scope:
         try:
             with metrics.timer(
                 "snuba_query_subscriber.parse_message_value", tags={"dataset": dataset}


### PR DESCRIPTION
This PR covers all remaining `push_scope` calls after all PRs listed under #73423's implementing PRs have been merged.

ref #73423
