### PR TITLE
chore(insights): removes no longer needed webvitals weighted score calculation workaround

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -427,8 +427,6 @@ def register_temporary_features(manager: FeatureManager):
     manager.add("organizations:starfish-browser-webvitals-pageoverview-v2", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
     # Enable INP in the browser starfish webvitals module
     manager.add("organizations:starfish-browser-webvitals-replace-fid-with-inp", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
-    # Uses a computed total count to calculate the score in the browser starfish webvitals module, instead of measurements.score.total
-    manager.add("organizations:starfish-browser-webvitals-score-computed-total", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
     # Update Web Vitals UI to display aggregate web vital values as avg instead of p75
     manager.add("organizations:performance-webvitals-avg", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
     # Enable browser starfish webvitals module to use backend provided performance scores

--- a/src/sentry/search/events/datasets/metrics.py
+++ b/src/sentry/search/events/datasets/metrics.py
@@ -5,7 +5,6 @@ from collections.abc import Callable, Mapping
 from django.utils.functional import cached_property
 from snuba_sdk import Column, Condition, Function, Op, OrderBy
 
-from sentry import features
 from sentry.api.event_search import SearchFilter
 from sentry.exceptions import IncompatibleMetricsQuery, InvalidSearchQuery
 from sentry.search.events import builder, constants, fields
@@ -683,14 +682,7 @@ class MetricsDatasetConfig(DatasetConfig):
                         )
                     ],
                     calculated_args=[resolve_metric_id],
-                    snql_distribution=(
-                        self._resolve_weighted_web_vital_score_with_computed_total_count_function
-                        if features.has(
-                            "organizations:starfish-browser-webvitals-score-computed-total",
-                            self.builder.params.organization,
-                        )
-                        else self._resolve_weighted_web_vital_score_function
-                    ),
+                    snql_distribution=self._resolve_weighted_web_vital_score_function,
                     default_result_type="number",
                 ),
                 fields.MetricsFunction(
@@ -1618,160 +1610,6 @@ class MetricsDatasetConfig(DatasetConfig):
                                                         Column("metric_id"),
                                                         self.resolve_metric(
                                                             "measurements.score.total"
-                                                        ),
-                                                    ],
-                                                ),
-                                            ],
-                                        ),
-                                    ],
-                                ),
-                                0.0,
-                            ],
-                        ),
-                        1.0,
-                    ],
-                ),
-                0.0,
-            ],
-            alias,
-        )
-
-    # TODO: This function uses the sum of ttfb and inp score counts as the denominator because
-    # measurements.score.total was incorrectly double counting due to the issue described here:
-    # https://github.com/getsentry/relay/pull/3324
-    # Update this function to use measurements.score.total as the denominator once the issue is
-    # resolved and any historic data is out of retention.
-    def _resolve_weighted_web_vital_score_with_computed_total_count_function(
-        self,
-        args: Mapping[str, str | Column | SelectType | int | float],
-        alias: str,
-    ) -> SelectType:
-        column = args["column"]
-        metric_id = args["metric_id"]
-
-        if column not in [
-            "measurements.score.lcp",
-            "measurements.score.fcp",
-            "measurements.score.fid",
-            "measurements.score.inp",
-            "measurements.score.cls",
-            "measurements.score.ttfb",
-        ]:
-            raise InvalidSearchQuery("performance_score only supports measurements")
-
-        return Function(
-            "greatest",
-            [
-                Function(
-                    "least",
-                    [
-                        Function(
-                            "if",
-                            [
-                                Function(
-                                    "and",
-                                    [
-                                        Function(
-                                            "greater",
-                                            [
-                                                Function(
-                                                    "sumIf",
-                                                    [
-                                                        Column("value"),
-                                                        Function(
-                                                            "equals",
-                                                            [Column("metric_id"), metric_id],
-                                                        ),
-                                                    ],
-                                                ),
-                                                0,
-                                            ],
-                                        ),
-                                        Function(
-                                            "greater",
-                                            [
-                                                Function(
-                                                    "plus",
-                                                    [
-                                                        Function(
-                                                            "countIf",
-                                                            [
-                                                                Column("value"),
-                                                                Function(
-                                                                    "equals",
-                                                                    [
-                                                                        Column("metric_id"),
-                                                                        self.resolve_metric(
-                                                                            "measurements.score.ttfb"
-                                                                        ),
-                                                                    ],
-                                                                ),
-                                                            ],
-                                                        ),
-                                                        Function(
-                                                            "countIf",
-                                                            [
-                                                                Column("value"),
-                                                                Function(
-                                                                    "equals",
-                                                                    [
-                                                                        Column("metric_id"),
-                                                                        self.resolve_metric(
-                                                                            "measurements.score.inp"
-                                                                        ),
-                                                                    ],
-                                                                ),
-                                                            ],
-                                                        ),
-                                                    ],
-                                                ),
-                                                0,
-                                            ],
-                                        ),
-                                    ],
-                                ),
-                                Function(
-                                    "divide",
-                                    [
-                                        Function(
-                                            "sumIf",
-                                            [
-                                                Column("value"),
-                                                Function(
-                                                    "equals", [Column("metric_id"), metric_id]
-                                                ),
-                                            ],
-                                        ),
-                                        Function(
-                                            "plus",
-                                            [
-                                                Function(
-                                                    "countIf",
-                                                    [
-                                                        Column("value"),
-                                                        Function(
-                                                            "equals",
-                                                            [
-                                                                Column("metric_id"),
-                                                                self.resolve_metric(
-                                                                    "measurements.score.ttfb"
-                                                                ),
-                                                            ],
-                                                        ),
-                                                    ],
-                                                ),
-                                                Function(
-                                                    "countIf",
-                                                    [
-                                                        Column("value"),
-                                                        Function(
-                                                            "equals",
-                                                            [
-                                                                Column("metric_id"),
-                                                                self.resolve_metric(
-                                                                    "measurements.score.inp"
-                                                                ),
-                                                            ],
                                                         ),
                                                     ],
                                                 ),

--- a/tests/snuba/api/endpoints/test_organization_events_mep.py
+++ b/tests/snuba/api/endpoints/test_organization_events_mep.py
@@ -2880,19 +2880,18 @@ class OrganizationEventsMetricsEnhancedPerformanceEndpointTest(MetricsEnhancedPe
             timestamp=self.min_ago,
         )
 
-        with self.feature({"organizations:starfish-browser-webvitals-score-computed-total": True}):
-            response = self.do_request(
-                {
-                    "field": [
-                        "transaction",
-                        "weighted_performance_score(measurements.score.ttfb)",
-                        "weighted_performance_score(measurements.score.inp)",
-                    ],
-                    "query": "event.type:transaction",
-                    "dataset": "metrics",
-                    "per_page": 50,
-                }
-            )
+        response = self.do_request(
+            {
+                "field": [
+                    "transaction",
+                    "weighted_performance_score(measurements.score.ttfb)",
+                    "weighted_performance_score(measurements.score.inp)",
+                ],
+                "query": "event.type:transaction",
+                "dataset": "metrics",
+                "per_page": 50,
+            }
+        )
         assert response.status_code == 200, response.content
         assert len(response.data["data"]) == 1
         data = response.data["data"]

--- a/tests/snuba/api/endpoints/test_organization_events_mep.py
+++ b/tests/snuba/api/endpoints/test_organization_events_mep.py
@@ -2855,13 +2855,6 @@ class OrganizationEventsMetricsEnhancedPerformanceEndpointTest(MetricsEnhancedPe
         )
 
         self.store_transaction_metric(
-            0.00,
-            metric="measurements.score.total",
-            tags={"transaction": "foo_transaction"},
-            timestamp=self.min_ago,
-        )
-
-        self.store_transaction_metric(
             0.80,
             metric="measurements.score.inp",
             tags={"transaction": "foo_transaction"},


### PR DESCRIPTION
It has been over 90 days since we fixed an issue with double counting transactions (https://github.com/getsentry/relay/pull/3324), so we no longer need this score calculation workaround.