### PR TITLE
chore(trace-explorer): Put back project selector

### DIFF
--- a/static/app/views/traces/content.tsx
+++ b/static/app/views/traces/content.tsx
@@ -59,7 +59,6 @@ import {
 import {TracesChart} from './tracesChart';
 import {TracesSearchBar} from './tracesSearchBar';
 import {
-  ALL_PROJECTS,
   areQueriesEmpty,
   getSecondaryNameFromSpan,
   getStylingSliceName,
@@ -193,7 +192,7 @@ export function Content() {
           )}
           position="bottom"
         >
-          <ProjectPageFilter disabled projectOverride={ALL_PROJECTS} />
+          <ProjectPageFilter />
         </Tooltip>
         <EnvironmentPageFilter />
         <DatePageFilter defaultPeriod="2h" />
@@ -750,6 +749,7 @@ function useTraceSpans<F extends string>({
 
   const endpointOptions = {
     query: {
+      project: selection.projects,
       environment: selection.environments,
       ...(datetime ?? normalizeDateTimeParams(selection.datetime)),
       field: fields,

--- a/static/app/views/traces/tracesSearchBar.tsx
+++ b/static/app/views/traces/tracesSearchBar.tsx
@@ -9,9 +9,8 @@ import {SavedSearchType} from 'sentry/types/group';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import useOrganization from 'sentry/utils/useOrganization';
+import usePageFilters from 'sentry/utils/usePageFilters';
 import {useSpanFieldSupportedTags} from 'sentry/views/performance/utils/useSpanFieldSupportedTags';
-
-import {ALL_PROJECTS} from './utils';
 
 interface TracesSearchBarProps {
   handleClearSearch: (index: number) => boolean;
@@ -33,16 +32,14 @@ export function TracesSearchBar({
   handleSearch,
   handleClearSearch,
 }: TracesSearchBarProps) {
-  // TODO: load tags for autocompletion
+  const {selection} = usePageFilters();
   const organization = useOrganization();
   const canAddMoreQueries = queries.length <= 2;
   const localQueries = queries.length ? queries : [''];
 
   // Since trace explorer permits cross project searches,
   // autocompletion should also be cross projects.
-  const supportedTags = useSpanFieldSupportedTags({
-    projects: ALL_PROJECTS,
-  });
+  const supportedTags = useSpanFieldSupportedTags();
 
   return (
     <TraceSearchBarsContainer>
@@ -58,7 +55,7 @@ export function TracesSearchBar({
             metricAlert={false}
             supportedTags={supportedTags}
             dataset={DiscoverDatasets.SPANS_INDEXED}
-            projectIds={ALL_PROJECTS}
+            projectIds={selection.projects}
             savedSearchType={SavedSearchType.SPAN}
           />
           <StyledButton


### PR DESCRIPTION
Reverting this decision, the project selector will be put back and we'll go with an UX solution to explain the trace root coming from a different project.