### PR TITLE
feat(query-builder): Collapse long and many filter values

### DIFF
--- a/static/app/components/searchQueryBuilder/filter.tsx
+++ b/static/app/components/searchQueryBuilder/filter.tsx
@@ -34,14 +34,27 @@ function FilterValueText({token}: {token: TokenResult<Token.FILTER>}) {
     case Token.VALUE_TEXT_LIST:
     case Token.VALUE_NUMBER_LIST:
       const items = token.value.items;
+
+      if (items.length === 1 && items[0].value) {
+        return (
+          <FilterValueSingleTruncatedValue>
+            {formatFilterValue(items[0].value)}
+          </FilterValueSingleTruncatedValue>
+        );
+      }
       return (
         <FilterValueList>
-          {items.map((item, index) => (
+          {items.slice(0, 3).map((item, index) => (
             <Fragment key={index}>
-              <span>{formatFilterValue(item.value)}</span>
-              {index !== items.length - 1 ? <FilterValueOr>or</FilterValueOr> : null}
+              <FilterMultiValueTruncated>
+                {formatFilterValue(item.value)}
+              </FilterMultiValueTruncated>
+              {index !== items.length - 1 && index < 2 ? (
+                <FilterValueOr>or</FilterValueOr>
+              ) : null}
             </Fragment>
           ))}
+          {items.length > 3 && <span>+{items.length - 3}</span>}
         </FilterValueList>
       );
     case Token.VALUE_ISO_8601_DATE:
@@ -51,7 +64,11 @@ function FilterValueText({token}: {token: TokenResult<Token.FILTER>}) {
         <DateTime date={token.value.value} dateOnly={!token.value.time} utc={isUtc} />
       );
     default:
-      return formatFilterValue(token.value);
+      return (
+        <FilterValueSingleTruncatedValue>
+          {formatFilterValue(token.value)}
+        </FilterValueSingleTruncatedValue>
+      );
   }
 }
 
@@ -255,9 +272,23 @@ const DeleteButton = styled(UnstyledButton)`
 const FilterValueList = styled('div')`
   display: flex;
   align-items: center;
+  flex-wrap: nowrap;
   gap: ${space(0.5)};
+  max-width: 400px;
 `;
 
 const FilterValueOr = styled('span')`
   color: ${p => p.theme.subText};
+`;
+
+const FilterMultiValueTruncated = styled('div')`
+  ${p => p.theme.overflowEllipsis};
+  max-width: 110px;
+  width: min-content;
+`;
+
+const FilterValueSingleTruncatedValue = styled('div')`
+  ${p => p.theme.overflowEllipsis};
+  max-width: 400px;
+  width: min-content;
 `;

--- a/static/app/components/searchQueryBuilder/index.spec.tsx
+++ b/static/app/components/searchQueryBuilder/index.spec.tsx
@@ -925,6 +925,25 @@ describe('SearchQueryBuilder', function () {
         expect(within(valueButton).getByText('Chrome')).toBeInTheDocument();
       });
 
+      it('collapses many selected options', function () {
+        render(
+          <SearchQueryBuilder
+            {...defaultProps}
+            initialQuery="browser.name:[one,two,three,four]"
+          />
+        );
+
+        const valueButton = screen.getByRole('button', {
+          name: 'Edit value for filter: browser.name',
+        });
+        expect(within(valueButton).getByText('one')).toBeInTheDocument();
+        expect(within(valueButton).getByText('two')).toBeInTheDocument();
+        expect(within(valueButton).getByText('three')).toBeInTheDocument();
+        expect(within(valueButton).getByText('+1')).toBeInTheDocument();
+        expect(within(valueButton).queryByText('four')).not.toBeInTheDocument();
+        expect(within(valueButton).getAllByText('or')).toHaveLength(2);
+      });
+
       it('escapes values with spaces and reserved characters', async function () {
         render(<SearchQueryBuilder {...defaultProps} initialQuery="" />);
         await userEvent.click(screen.getByRole('combobox', {name: 'Add a search term'}));


### PR DESCRIPTION
To prevent overflow, only three values at max are shown in the filters, and they are also truncated after a max width.

![CleanShot 2024-06-28 at 09 47 44](https://github.com/getsentry/sentry/assets/10888943/0b5fd446-425b-472c-9a27-787f8b8227de)

