### PR TITLE
fix(stacktrace-link): Fix gitlab integration url being incorrectly generated

### DIFF
--- a/src/sentry/integrations/gitlab/integration.py
+++ b/src/sentry/integrations/gitlab/integration.py
@@ -127,6 +127,9 @@ class GitlabIntegration(
         base_url = self.model.metadata["base_url"]
         repo_name = repo.config["path"]
 
+        filepath = filepath.lstrip("/")
+        filepath = filepath.replace("\\", "/")
+
         # Must format the url ourselves since `check_file` is a head request
         # "https://gitlab.com/gitlab-org/gitlab/blob/master/README.md"
         return f"{base_url}/{repo_name}/blob/{branch}/{filepath}"

--- a/src/sentry/integrations/gitlab/integration.py
+++ b/src/sentry/integrations/gitlab/integration.py
@@ -127,9 +127,6 @@ class GitlabIntegration(
         base_url = self.model.metadata["base_url"]
         repo_name = repo.config["path"]
 
-        filepath = filepath.lstrip("/")
-        filepath = filepath.replace("\\", "/")
-
         # Must format the url ourselves since `check_file` is a head request
         # "https://gitlab.com/gitlab-org/gitlab/blob/master/README.md"
         return f"{base_url}/{repo_name}/blob/{branch}/{filepath}"

--- a/src/sentry/integrations/utils/code_mapping.py
+++ b/src/sentry/integrations/utils/code_mapping.py
@@ -387,8 +387,6 @@ def convert_stacktrace_frame_path_to_source_path(
     """
 
     stack_root = code_mapping.stack_root
-    if "\\" in code_mapping.stack_root:
-        stack_root = code_mapping.stack_root.replace("\\", "/")
 
     # In most cases, code mappings get applied to frame.filename, but some platforms such as Java
     # contain folder info in other parts of the frame (e.g. frame.module="com.example.app.MainActivity"
@@ -399,13 +397,21 @@ def convert_stacktrace_frame_path_to_source_path(
     )
 
     if stacktrace_path and stacktrace_path.startswith(code_mapping.stack_root):
-        return stacktrace_path.replace(stack_root, code_mapping.source_root, 1)
+        return (
+            stacktrace_path.replace(stack_root, code_mapping.source_root, 1)
+            .lstrip("/")
+            .replace("\\", "/")
+        )
 
     # Some platforms only provide the file's name without folder paths, so we
     # need to use the absolute path instead. If the code mapping has a non-empty
     # stack_root value and it matches the absolute path, we do the mapping on it.
     if frame.abs_path and frame.abs_path.startswith(code_mapping.stack_root):
-        return frame.abs_path.replace(stack_root, code_mapping.source_root, 1)
+        return (
+            frame.abs_path.replace(stack_root, code_mapping.source_root, 1)
+            .lstrip("/")
+            .replace("\\", "/")
+        )
 
     return None
 

--- a/src/sentry/integrations/utils/code_mapping.py
+++ b/src/sentry/integrations/utils/code_mapping.py
@@ -399,8 +399,8 @@ def convert_stacktrace_frame_path_to_source_path(
     if stacktrace_path and stacktrace_path.startswith(code_mapping.stack_root):
         return (
             stacktrace_path.replace(stack_root, code_mapping.source_root, 1)
-            .lstrip("/")
             .replace("\\", "/")
+            .lstrip("/")
         )
 
     # Some platforms only provide the file's name without folder paths, so we
@@ -409,8 +409,8 @@ def convert_stacktrace_frame_path_to_source_path(
     if frame.abs_path and frame.abs_path.startswith(code_mapping.stack_root):
         return (
             frame.abs_path.replace(stack_root, code_mapping.source_root, 1)
-            .lstrip("/")
             .replace("\\", "/")
+            .lstrip("/")
         )
 
     return None

--- a/tests/sentry/integrations/utils/test_code_mapping.py
+++ b/tests/sentry/integrations/utils/test_code_mapping.py
@@ -376,6 +376,13 @@ class TestConvertStacktraceFramePathToSourcePath(TestCase):
             stack_root="sentry/",
             source_root="src/sentry/",
         )
+        self.code_mapping_backslash = self.create_code_mapping(
+            organization_integration=self.oi,
+            project=self.project,
+            repo=self.repo,
+            stack_root="C:\\Users\\Foo\\",
+            source_root="/",
+        )
 
     def test_convert_stacktrace_frame_path_to_source_path_empty(self):
         assert (
@@ -410,6 +417,19 @@ class TestConvertStacktraceFramePathToSourcePath(TestCase):
                 sdk_name="sentry.java",
             )
             == "src/sentry/module/File.java"
+        )
+
+    def test_convert_stacktrace_frame_path_to_source_path_backslashes(self):
+        assert (
+            convert_stacktrace_frame_path_to_source_path(
+                EventFrame(
+                    filename="file.rs", abs_path="C:\\Users\\Foo\\src\\sentry\\folder\\file.rs"
+                ),
+                code_mapping=self.code_mapping_backslash,
+                platform="rust",
+                sdk_name="sentry.rust",
+            )
+            == "src/sentry/folder/file.rs"
         )
 
 

--- a/tests/sentry/tasks/test_commit_context.py
+++ b/tests/sentry/tasks/test_commit_context.py
@@ -726,15 +726,6 @@ class TestCommitContextAllFrames(TestCommitContextMixin):
             },
             {
                 "function": "something_else",
-                "abs_path": "/usr/src/sentry/src/sentry/invalid_1.py",
-                "module": "sentry.invalid_1",
-                "in_app": True,
-                # Bad path with backslashes
-                "filename": "sentry/invalid_1.py\\other",
-                "lineno": 39,
-            },
-            {
-                "function": "something_else",
                 "abs_path": "/usr/src/sentry/src/sentry/invalid_2.py",
                 "module": "sentry.invalid_2",
                 "in_app": True,
@@ -794,7 +785,7 @@ class TestCommitContextAllFrames(TestCommitContextMixin):
             group_id=self.event.group_id,
             event_id=self.event.event_id,
             # 1 was a duplicate, 2 filtered out because of missing properties
-            num_frames=3,
+            num_frames=2,
             num_unique_commits=1,
             num_unique_commit_authors=1,
             # Only 1 successfully mapped frame of the 6 total


### PR DESCRIPTION
Fixes an issue where gitlab urls were not being formatted correctly. Specifically:

* We were not stripping filepaths of their trailing slash
* We did change the url generation logic to parse backslashes correctly after Windows code mappings were supported