### PR TITLE
feat(autofix): Add feature flag to disable codebase indexing

### DIFF
--- a/src/sentry/api/endpoints/group_ai_autofix.py
+++ b/src/sentry/api/endpoints/group_ai_autofix.py
@@ -110,12 +110,11 @@ class GroupAutofixEndpoint(GroupEndpoint):
                     else None
                 ),
                 "options": {
-                    # "disable_codebase_indexing": features.has(
-                    #     "organizations:autofix-disable-codebase-indexing",
-                    #     group.organization,
-                    #     actor=user,
-                    # )
-                    "disable_codebase_indexing": True
+                    "disable_codebase_indexing": features.has(
+                        "organizations:autofix-disable-codebase-indexing",
+                        group.organization,
+                        actor=user,
+                    )
                 },
             },
             option=orjson.OPT_NON_STR_KEYS,

--- a/src/sentry/api/endpoints/group_ai_autofix.py
+++ b/src/sentry/api/endpoints/group_ai_autofix.py
@@ -109,6 +109,14 @@ class GroupAutofixEndpoint(GroupEndpoint):
                     if not isinstance(user, AnonymousUser)
                     else None
                 ),
+                "options": {
+                    # "disable_codebase_indexing": features.has(
+                    #     "organizations:autofix-disable-codebase-indexing",
+                    #     group.organization,
+                    #     actor=user,
+                    # )
+                    "disable_codebase_indexing": True
+                },
             },
             option=orjson.OPT_NON_STR_KEYS,
         )

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -62,6 +62,8 @@ def register_temporary_features(manager: FeatureManager):
     manager.add("organizations:api-organization_events-rate-limit-reduced-rollout", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
     # Enables the cron job to auto-enable codecov integrations.
     manager.add("organizations:auto-enable-codecov", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
+    # Autofix use new strategy without codebase indexing
+    manager.add("organizations:autofix-disable-codebase-indexing", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, default=False)
     # Enables getting commit sha from git blame for codecov.
     manager.add("organizations:codecov-commit-sha-from-git-blame", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
     # Disables legacy cron ingest endpoints


### PR DESCRIPTION
Adds a flagpole-controlled flag for autofix codebase index disabling and sends it on the autofix call.

Relevant options automator pr: https://github.com/getsentry/sentry-options-automator/pull/1731