### PR TITLE
chore(autofix): Use repo_external_id in autofix change

### DIFF
--- a/static/app/components/events/autofix/autofixChanges.tsx
+++ b/static/app/components/events/autofix/autofixChanges.tsx
@@ -50,7 +50,7 @@ function CreatePullRequestButton({
           run_id: autofixData?.run_id,
           payload: {
             type: 'create_pr',
-            repo_id: change.repo_id,
+            repo_external_id: change.repo_external_id,
           },
         },
       });
@@ -243,7 +243,7 @@ export function AutofixChanges({
   return (
     <Content>
       {step.changes.map((change, i) => (
-        <Fragment key={change.repo_id}>
+        <Fragment key={change.repo_external_id}>
           {i > 0 && <Separator />}
           <AutofixRepoChange change={change} groupId={groupId} isLastStep={isLastStep} />
         </Fragment>

--- a/static/app/components/events/autofix/autofixChanges.tsx
+++ b/static/app/components/events/autofix/autofixChanges.tsx
@@ -51,6 +51,7 @@ function CreatePullRequestButton({
           payload: {
             type: 'create_pr',
             repo_external_id: change.repo_external_id,
+            repo_id: change.repo_id, // The repo_id is only here for temporary backwards compatibility for LA customers, and we should remove it soon.
           },
         },
       });

--- a/static/app/components/events/autofix/index.spec.tsx
+++ b/static/app/components/events/autofix/index.spec.tsx
@@ -212,7 +212,7 @@ describe('Autofix', () => {
                 {
                   title: 'Test PR Title',
                   description: 'Test PR Description',
-                  repo_id: 1,
+                  repo_external_id: '1',
                   repo_name: 'getsentry/sentry',
                   diff: [],
                 },

--- a/static/app/components/events/autofix/types.ts
+++ b/static/app/components/events/autofix/types.ts
@@ -103,11 +103,12 @@ export interface AutofixRootCauseStep extends BaseStep {
 export type AutofixCodebaseChange = {
   description: string;
   diff: FilePatch[];
-  repo_external_id: string;
   repo_name: string;
   title: string;
   diff_str?: string;
   pull_request?: AutofixPullRequestDetails;
+  repo_external_id?: string;
+  repo_id?: number; // The repo_id is only here for temporary backwards compatibility for LA customers, and we should remove it soon. Use repo_external_id instead.
 };
 
 export interface AutofixChangesStep extends BaseStep {

--- a/static/app/components/events/autofix/types.ts
+++ b/static/app/components/events/autofix/types.ts
@@ -103,7 +103,7 @@ export interface AutofixRootCauseStep extends BaseStep {
 export type AutofixCodebaseChange = {
   description: string;
   diff: FilePatch[];
-  repo_id: number;
+  repo_external_id: string;
   repo_name: string;
   title: string;
   diff_str?: string;

--- a/tests/js/fixtures/autofixCodebaseChangeData.ts
+++ b/tests/js/fixtures/autofixCodebaseChangeData.ts
@@ -8,7 +8,7 @@ export function AutofixCodebaseChangeData(
   return {
     description: '',
     diff: [AutofixDiffFilePatch()],
-    repo_id: 100,
+    repo_external_id: "100",
     repo_name: 'owner/hello-world',
     title: 'Add error handling',
     pull_request: { pr_number: 200, pr_url: 'https://github.com/owner/hello-world/pull/200' },


### PR DESCRIPTION
In `AutofixCodebaseChange`, use the repo external id instead. Depends on https://github.com/getsentry/seer/pull/832
