### PR TITLE
feat(flagpole): Adds strict_equality flag to equals operator, loosens default strictness

### DIFF
--- a/src/flagpole/conditions.py
+++ b/src/flagpole/conditions.py
@@ -90,7 +90,14 @@ class ConditionBase(BaseModel):
 
         return value in create_case_insensitive_set_from_list(condition_property)
 
-    def _evaluate_equals(self, condition_property: Any, segment_name: str) -> bool:
+    def _evaluate_equals(
+        self, condition_property: Any, segment_name: str, strict_validation: bool = False
+    ) -> bool:
+        # Strict validation enforces that a property exists when used in an
+        # equals condition
+        if condition_property is None and not strict_validation:
+            return False
+
         if not isinstance(condition_property, type(self.value)):
             value_type = get_type_name(self.value)
             property_value = get_type_name(condition_property)
@@ -163,20 +170,26 @@ EqualsOperatorValueTypes = (
 class EqualsCondition(ConditionBase):
     operator: Literal[ConditionOperatorKind.EQUALS] = ConditionOperatorKind.EQUALS
     value: EqualsOperatorValueTypes
+    strict_validation: bool = False
 
     def _operator_match(self, condition_property: Any, segment_name: str):
         return self._evaluate_equals(
-            condition_property=condition_property, segment_name=segment_name
+            condition_property=condition_property,
+            segment_name=segment_name,
+            strict_validation=self.strict_validation,
         )
 
 
 class NotEqualsCondition(ConditionBase):
     operator: Literal[ConditionOperatorKind.NOT_EQUALS] = ConditionOperatorKind.NOT_EQUALS
     value: EqualsOperatorValueTypes
+    strict_validation: bool = False
 
     def _operator_match(self, condition_property: Any, segment_name: str):
         return not self._evaluate_equals(
-            condition_property=condition_property, segment_name=segment_name
+            condition_property=condition_property,
+            segment_name=segment_name,
+            strict_validation=self.strict_validation,
         )
 
 

--- a/tests/flagpole/test_conditions.py
+++ b/tests/flagpole/test_conditions.py
@@ -268,12 +268,24 @@ class TestEqualsConditions(TestCase):
 
     def test_with_missing_context_property(self):
         value = "foo"
-        condition = EqualsCondition(property="foo", value=value)
+        condition = EqualsCondition(property="foo", value=value, strict_validation=True)
 
         with pytest.raises(ConditionTypeMismatchException):
             condition.match(context=EvaluationContext({"bar": value}), segment_name="test")
 
-        not_condition = NotEqualsCondition(property="foo", value=value)
+        not_condition = NotEqualsCondition(property="foo", value=value, strict_validation=True)
 
         with pytest.raises(ConditionTypeMismatchException):
             not_condition.match(context=EvaluationContext({"bar": value}), segment_name="test")
+
+        # Test non-strict validation for both conditions
+        condition = EqualsCondition(property="foo", value=value)
+        assert (
+            condition.match(context=EvaluationContext({"bar": value}), segment_name="test") is False
+        )
+
+        not_condition = NotEqualsCondition(property="foo", value=value)
+        assert (
+            not_condition.match(context=EvaluationContext({"bar": value}), segment_name="test")
+            is True
+        )


### PR DESCRIPTION
Adds new `strict_equality` flag to `equals` and `not_equals` operators, making missing context properties not raise exceptions when set to False. We have been getting an excessive number of alerts about missing properties per flag evaluation, so this should lessen the impact and allow us to opt-in to this stricter validation when we stabilize our feature flags a bit more.
