### PR TITLE
fix(logging): updating logging 'throwaways' to Python 3.12 + adding Formatter fields

### DIFF
--- a/src/sentry/logging/handlers.py
+++ b/src/sentry/logging/handlers.py
@@ -9,26 +9,35 @@ from sentry.utils import json, metrics
 
 # These are values that come default from logging.LogRecord.
 # They are defined here:
-# https://github.com/python/cpython/blob/2.7/Lib/logging/__init__.py#L237-L310
+# https://github.com/python/cpython/blob/e6543daf12051e9c660a5c0437683e8d2706a3c7/Lib/logging/__init__.py#L286-L385
+# additionally Formatter injects `message` and `asctime` into the record.
+# https://github.com/python/cpython/blob/e6543daf12051e9c660a5c0437683e8d2706a3c7/Lib/logging/__init__.py#L711-L713
+
 throwaways = frozenset(
     (
-        "threadName",
-        "thread",
-        "created",
-        "process",
-        "processName",
-        "args",
-        "module",
-        "filename",
-        "levelno",
-        "exc_text",
+        "name",
         "msg",
+        "args",
+        "levelname",
+        "levelno",
         "pathname",
+        "filename",
+        "module",
+        "exc_info",
+        "exc_text",
+        "stack_info",
         "lineno",
         "funcName",
-        "relativeCreated",
-        "levelname",
+        "created",
         "msecs",
+        "relativeCreated",
+        "thread",
+        "threadName",
+        "processName",
+        "process",
+        "taskName",
+        "message",
+        "asctime",
     )
 )
 

--- a/src/sentry/logging/handlers.py
+++ b/src/sentry/logging/handlers.py
@@ -7,37 +7,38 @@ from structlog.processors import _json_fallback_handler
 
 from sentry.utils import json, metrics
 
-# These are values that come default from logging.LogRecord.
-# They are defined here:
+# These are values that come default from logging.LogRecord and are disallowed in `extra`
+# resulting in KeyError: "Attempt to overwrite '{key}' in LogRecord"
+# Most are defined here:
 # https://github.com/python/cpython/blob/e6543daf12051e9c660a5c0437683e8d2706a3c7/Lib/logging/__init__.py#L286-L385
-# additionally Formatter injects `message` and `asctime` into the record.
-# https://github.com/python/cpython/blob/e6543daf12051e9c660a5c0437683e8d2706a3c7/Lib/logging/__init__.py#L711-L713
+# additionally Formatter injects `message` and `asctime` into the record and are explicitly forbidden in `extra`
+# https://github.com/python/cpython/blob/e6543daf12051e9c660a5c0437683e8d2706a3c7/Lib/logging/__init__.py#L1630-L1631
 
 throwaways = frozenset(
     (
-        "name",
-        "msg",
         "args",
-        "levelname",
-        "levelno",
-        "pathname",
-        "filename",
-        "module",
+        "asctime",
+        "created",
         "exc_info",
         "exc_text",
-        "stack_info",
-        "lineno",
+        "filename",
         "funcName",
-        "created",
+        "levelname",
+        "levelno",
+        "lineno",
+        "message",
+        "module",
         "msecs",
+        "msg",
+        "name",
+        "pathname",
+        "process",
+        "processName",
         "relativeCreated",
+        "stack_info",
+        "taskName",
         "thread",
         "threadName",
-        "processName",
-        "process",
-        "taskName",
-        "message",
-        "asctime",
     )
 )
 


### PR DESCRIPTION
Underlying problem — `flake8-logging` does not fully catch these if they're coming for a dynamic dictionary rather than a literal.  

Changes:
- Updating the `throwaway` list of `extra` fields that class with `LogRecord` fields to Python 3;
- Adding `"message"` and `"asctime"` which are injected into `LogRecord` via `Formatter` and also cause clashes;
- Adding `"taskName"` for forwards compatibility with Python 3.12;

The list can be also be auto-generated via:
```python
_rec = logging.makeLogRecord({})
logging.Formatter("%(asctime)s:%(levelname)s:%(name)s:%(message)s").format(_rec)
throwaways = frozenset(rec.__dict__.keys())
``` 