### PR TITLE
fix(insights): Link "View Query Summary" button to Insights URL

### DIFF
--- a/static/app/components/events/interfaces/spans/spanDetail.spec.tsx
+++ b/static/app/components/events/interfaces/spans/spanDetail.spec.tsx
@@ -164,7 +164,7 @@ describe('SpanDetail', function () {
       ).toBeInTheDocument();
       expect(screen.getByRole('button', {name: 'View Query Summary'})).toHaveAttribute(
         'href',
-        '/organizations/org-slug/performance/database/spans/span/a7ebd21614897/?project=2'
+        '/organizations/org-slug/insights/database/spans/span/a7ebd21614897/?project=2'
       );
     });
   });

--- a/static/app/views/performance/transactionSummary/transactionSpans/spanDetails/utils.tsx
+++ b/static/app/views/performance/transactionSummary/transactionSpans/spanDetails/utils.tsx
@@ -52,7 +52,7 @@ export function generateQuerySummaryRoute({
   group: string;
   orgSlug: string;
 }): string {
-  return `/organizations/${orgSlug}/performance/database/spans/span/${group}/`;
+  return `/organizations/${orgSlug}/insights/database/spans/span/${group}/`;
 }
 
 export function querySummaryRouteWithQuery({


### PR DESCRIPTION
The `/performance/` URLs aren't active anymore! It should go to `/insights/`. Fixes https://github.com/getsentry/sentry/issues/73370