### PR TITLE
chore(slack): track timeout errors from sdk WebClient

### DIFF
--- a/src/sentry/integrations/slack/sdk_client.py
+++ b/src/sentry/integrations/slack/sdk_client.py
@@ -76,6 +76,13 @@ def wrapper(method: FunctionType):
             else:
                 logger.info("slack_sdk.missing_error_response", extra={"error": str(e)})
             raise
+        except TimeoutError:
+            metrics.incr(
+                SLACK_DATADOG_METRIC,
+                sample_rate=1.0,
+                tags={"status": "timeout"},
+            )
+            raise
 
         return response
 


### PR DESCRIPTION
These are already very occasionally being emitted as Sentry errors, but it would be good to look at them relative to all Slack responses being recorded in DD. This error is emitted from Slack, and is not due to us.