### PR TITLE
[CapMan visibility] remove Sentry warnings and GCP logs for throttled queries

### DIFF
--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -1069,8 +1069,6 @@ def _bulk_snuba_query(
                     "throttled_by" in quota_allowance_summary
                     and quota_allowance_summary["throttled_by"]
                 ):
-                    logger.warning("Query is throttled", extra={"response.data": response.data})
-                    sentry_sdk.capture_message("Query is throttled", level="warning")
                     metrics.incr("snuba.client.query.throttle", tags={"referrer": query_referrer})
 
             if response.status != 200:


### PR DESCRIPTION
Snuba throttles queries in the magnitude of 10k-20k. A [previous PR](https://github.com/getsentry/sentry/pull/73442) emits a warning to Sentry and logs to GCP for every throttled query, and thus has the potential to overwhelm Sentry/GCP. This PR removes the warnings and logs in case we have an incident.