### PR TITLE
ref(feedback): raise specific exception for vertex errors and don't log success

### DIFF
--- a/src/sentry/feedback/usecases/create_feedback.py
+++ b/src/sentry/feedback/usecases/create_feedback.py
@@ -198,7 +198,11 @@ def create_feedback_issue(event, project_id: int, source: FeedbackCreationSource
         except Exception:
             # until we have LLM error types ironed out, just catch all exceptions
             logger.exception("Error checking if message is spam")
-            metrics.incr("feedback.create_feedback_issue.spam_check_failed")
+        metrics.incr(
+            "feedback.create_feedback_issue.spam_detection",
+            tags={"is_spam": is_message_spam},
+            sample_rate=1.0,
+        )
 
     # Note that some of the fields below like title and subtitle
     # are not used by the feedback UI, but are required.

--- a/src/sentry/feedback/usecases/create_feedback.py
+++ b/src/sentry/feedback/usecases/create_feedback.py
@@ -198,6 +198,7 @@ def create_feedback_issue(event, project_id: int, source: FeedbackCreationSource
         except Exception:
             # until we have LLM error types ironed out, just catch all exceptions
             logger.exception("Error checking if message is spam")
+            metrics.incr("feedback.create_feedback_issue.spam_check_failed")
 
     # Note that some of the fields below like title and subtitle
     # are not used by the feedback UI, but are required.

--- a/src/sentry/feedback/usecases/spam_detection.py
+++ b/src/sentry/feedback/usecases/spam_detection.py
@@ -52,7 +52,6 @@ def is_spam(message: str):
             "trimmed_response": trimmed_response,
         },
     )
-    metrics.incr("spam-detection", tags={"is_spam": is_spam}, sample_rate=1.0)
     return is_spam
 
 

--- a/src/sentry/llm/exceptions.py
+++ b/src/sentry/llm/exceptions.py
@@ -15,10 +15,4 @@ class InvalidTemperature(ValueError):
 
 
 class VertexRequestFailed(RuntimeError):
-    status_code: int
-    message: str
-
-    def __init__(self, status_code, message):
-        super().__init__(self.message)
-        self.status_code = status_code
-        self.message = message
+    pass

--- a/src/sentry/llm/exceptions.py
+++ b/src/sentry/llm/exceptions.py
@@ -12,3 +12,13 @@ class InvalidModelError(ValueError):
 
 class InvalidTemperature(ValueError):
     pass
+
+
+class VertexRequestFailed(RuntimeError):
+    status_code: int
+    message: str
+
+    def __init__(self, status_code, message):
+        super().__init__(self.message)
+        self.status_code = status_code
+        self.message = message

--- a/src/sentry/llm/providers/vertex.py
+++ b/src/sentry/llm/providers/vertex.py
@@ -56,7 +56,7 @@ class VertexProvider(LlmModelBase):
                 "Request failed with status code and response text.",
                 extra={"status_code": response.status_code, "response_text": response.text},
             )
-            raise VertexRequestFailed(response.status_code, response.text)
+            raise VertexRequestFailed(f"Response {response.status_code}: response.text")
 
         return response.json()["predictions"][0]["content"]
 

--- a/src/sentry/llm/providers/vertex.py
+++ b/src/sentry/llm/providers/vertex.py
@@ -56,7 +56,7 @@ class VertexProvider(LlmModelBase):
                 "Request failed with status code and response text.",
                 extra={"status_code": response.status_code, "response_text": response.text},
             )
-            raise VertexRequestFailed(f"Response {response.status_code}: response.text")
+            raise VertexRequestFailed(f"Response {response.status_code}: {response.text}")
 
         return response.json()["predictions"][0]["content"]
 

--- a/src/sentry/llm/providers/vertex.py
+++ b/src/sentry/llm/providers/vertex.py
@@ -4,6 +4,7 @@ import google.auth
 import google.auth.transport.requests
 import requests
 
+from sentry.llm.exceptions import VertexRequestFailed
 from sentry.llm.providers.base import LlmModelBase
 from sentry.llm.types import UseCaseConfig
 
@@ -50,13 +51,12 @@ class VertexProvider(LlmModelBase):
 
         response = requests.post(vertex_url, headers=headers, json=payload)
 
-        if response.status_code == 200:
-            logger.info("Request successful.")
-        else:
-            logger.info(
+        if response.status_code != 200:
+            logger.error(
                 "Request failed with status code and response text.",
                 extra={"status_code": response.status_code, "response_text": response.text},
             )
+            raise VertexRequestFailed(response.status_code, response.text)
 
         return response.json()["predictions"][0]["content"]
 


### PR DESCRIPTION
The current code raises KeyError when a request to VertexAI fails. https://console.cloud.google.com/logs/query;cursorTimestamp=2024-06-28T13:19:08.894346671Z;duration=P1D;query=resource.type%3D%22k8s_container%22%0Alabels.name%3D~%22sentry.feedback.usecases.create%22%0Atimestamp%3D%222024-06-28T13:19:08.894346671Z%22%0AinsertId%3D%22ht87o5dzkxma0imr%22;summaryFields=:true:32:beginning?project=internal-sentry

Also moved the spam_detection counter to create_feedback_issue, so we can see with one metric the T + F + failed (None) decisions.