### PR TITLE
fix(occurence-consumer): emergency woraroung for INC-811

### DIFF
--- a/src/sentry/issues/occurrence_consumer.py
+++ b/src/sentry/issues/occurrence_consumer.py
@@ -422,6 +422,7 @@ def process_occurrence_group(items: list[Mapping[str, Any]]) -> None:
     except Exception:
         logger.exception("Failed to fetch project or organization")
         organization = None
+
     if organization and features.has(
         "organizations:occurence-consumer-prune-status-changes", organization
     ):


### PR DESCRIPTION
This is needed to clear 177K messages from the backlog and unblock other clients. 
