### PR TITLE
Use ``transaction`` for subtitle instead of deprecated ``culprit``

### DIFF
--- a/static/app/utils/events.tsx
+++ b/static/app/utils/events.tsx
@@ -42,7 +42,7 @@ export function getMessage(
     return event.culprit || '';
   }
 
-  const {metadata, type, culprit} = event;
+  const {metadata, type, transaction} = event;
 
   switch (type) {
     case EventOrGroupType.ERROR:
@@ -57,7 +57,7 @@ export function getMessage(
     case EventOrGroupType.GENERIC:
       return metadata.value;
     default:
-      return culprit || '';
+      return transaction || '';
   }
 }
 
@@ -125,7 +125,7 @@ export function getTitle(
   features: string[] = [],
   grouping = false
 ) {
-  const {metadata, type, culprit, title} = event;
+  const {metadata, type, transaction, title} = event;
   const customTitle = metadata?.title;
 
   switch (type) {
@@ -133,7 +133,7 @@ export function getTitle(
       if (customTitle && customTitle !== '<unlabeled event>') {
         return {
           title: customTitle,
-          subtitle: culprit,
+          subtitle: transaction,
           treeLabel: undefined,
         };
       }
@@ -147,13 +147,13 @@ export function getTitle(
 
       if (displayTitleWithTreeLabel) {
         return {
-          subtitle: culprit,
+          subtitle: transaction,
           ...computeTitleWithTreeLabel(metadata),
         };
       }
 
       return {
-        subtitle: culprit,
+        subtitle: transaction,
         title: metadata.type || metadata.function || '<unknown>',
         treeLabel: undefined,
       };
@@ -187,7 +187,7 @@ export function getTitle(
       const isIssue = !isTombstone(event) && defined(event.issueCategory);
       return {
         title: customTitle ?? title,
-        subtitle: isIssue ? culprit : '',
+        subtitle: isIssue ? transaction : '',
         treeLabel: undefined,
       };
     default:


### PR DESCRIPTION
<!-- Describe your PR here. -->

After digging into the code a bit I figured out this is why our Sentry project was no longer showing the correct subtitle after we switched to doing tracing through OpenTelemetry instead of using the Sentry based version.
We use the Python SDK which probably still sets the `culprit` key "correctly" whenever we are tracing. However, since there is no way to set this using the SDK we now have a lot of issues with incorrect subtitles. This makes it much harder to triage the issues.

As can be seen in the [documentation](https://develop.sentry.dev/sdk/event-payloads/types/#event) this key is deprecated and should probably not be used anymore.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
