### PR TITLE
Clean up inline-attachments options

### DIFF
--- a/src/sentry/models/eventattachment.py
+++ b/src/sentry/models/eventattachment.py
@@ -16,7 +16,6 @@ from sentry.attachments.base import CachedAttachment
 from sentry.backup.scopes import RelocationScope
 from sentry.db.models import BoundedBigIntegerField, Model, region_silo_model, sane_repr
 from sentry.db.models.fields.bounded import BoundedIntegerField
-from sentry.features.rollout import in_random_rollout
 from sentry.models.files.utils import get_size_and_checksum, get_storage
 
 # Attachment file types that are considered a crash report (PII relevant)
@@ -180,7 +179,7 @@ class EventAttachment(Model):
 
         size, checksum = get_size_and_checksum(blob)
 
-        if can_store_inline(data) and in_random_rollout("eventattachments.store-small-inline"):
+        if can_store_inline(data):
             blob_path = ":" + data.decode()
         else:
             blob_path = "eventattachments/v1/" + FileBlob.generate_unique_path()

--- a/src/sentry/relay/globalconfig.py
+++ b/src/sentry/relay/globalconfig.py
@@ -26,7 +26,6 @@ RELAY_OPTIONS: list[str] = [
     "relay.span-extraction.sample-rate",
     "relay.force_full_normalization",
     "relay.disable_normalization.processing",
-    "relay.inline-attachments.rollout-rate",
 ]
 
 

--- a/tests/sentry/api/endpoints/test_event_attachment_details.py
+++ b/tests/sentry/api/endpoints/test_event_attachment_details.py
@@ -87,24 +87,6 @@ class EventAttachmentDetailsTest(APITestCase, CreateAttachmentMixin):
         assert response.get("Content-Type") == "image/png"
         assert close_streaming_response(response) == ATTACHMENT_CONTENT
 
-        with self.options(
-            {
-                "eventattachments.store-small-inline": 1,
-            }
-        ):
-            self.create_attachment(content=b"a small inline attachment")
-
-        path2 = f"/api/0/projects/{self.organization.slug}/{self.project.slug}/events/{self.event.event_id}/attachments/{self.attachment.id}/?download"
-        assert path1 is not path2
-
-        response = self.client.get(path2)
-
-        assert response.status_code == 200, response.content
-        assert response.get("Content-Disposition") == 'attachment; filename="hello.png"'
-        assert response.get("Content-Length") == str(self.attachment.size)
-        assert response.get("Content-Type") == "image/png"
-        assert close_streaming_response(response) == b"a small inline attachment"
-
     @with_feature("organizations:event-attachments")
     def test_zero_sized_attachment(self):
         self.login_as(user=self.user)


### PR DESCRIPTION
Usage of the option downstream in relay was removed in https://github.com/getsentry/relay/pull/3711

Inlining small attachments in `EventAttachment` was also turned on for quite a while, so lets hardcode it now and remove the option later.