### PR TITLE
fix(metrics): add Echarts brush end check

### DIFF
--- a/static/app/components/metrics/chart/useFocusArea.tsx
+++ b/static/app/components/metrics/chart/useFocusArea.tsx
@@ -89,11 +89,12 @@ export function useFocusArea({
       startBrush();
     };
 
-    // Handle mouse up is called after onBrushEnd
-    // We can use it for a final reliable cleanup as onBrushEnd is not always called (e.g. when simply clicking the chart)
+    // Handle mouse up is called after onBrushEnd. We can use it for a final reliable
+    // cleanup as onBrushEnd is not always called (e.g. when simply clicking the chart)
     const handleMouseUp = () => {
       isDrawingRef.current = false;
     };
+
     chartElement?.addEventListener('mousedown', handleMouseDown, {capture: true});
     window.addEventListener('mouseup', handleMouseUp);
 
@@ -108,18 +109,20 @@ export function useFocusArea({
       if (isDisabled || !isDrawingRef.current) {
         return;
       }
+
       const rect = brushEnd.areas[0];
-      if (!rect) {
+      if (!rect || !rect.coordRange) {
         return;
       }
-      const range = getSelectionRange(brushEnd, !!useFullYAxis, getValueRect(chartRef));
+
+      const range = getSelectionRange(rect, !!useFullYAxis, getValueRect(chartRef));
       onAdd?.({
         widgetIndex,
         range,
       });
 
-      // Remove brush from echarts immediately after adding the focus area
-      // since brushes get added to all charts in the group by default and then randomly
+      // Remove brush from echarts immediately after adding the focus area since
+      // brushes get added to all charts in the group by default and then randomly
       // render in the wrong place
       chartRef.current?.getEchartsInstance().dispatchAction({
         type: 'brush',
@@ -340,12 +343,10 @@ const getDateString = (timestamp: number): string =>
 const getTimestamp = (date: DateString) => moment.utc(date).valueOf();
 
 const getSelectionRange = (
-  params: BrushEndResult,
+  rect: BrushEndResult['areas'][0],
   useFullYAxis: boolean,
   boundingRect: ValueRect
 ): SelectionRange => {
-  const rect = params.areas[0];
-
   const startTimestamp = Math.min(...rect.coordRange[0]);
   const endTimestamp = Math.max(...rect.coordRange[0]);
 


### PR DESCRIPTION
- Checks that `brushEnd` result contains a rect with `coordRange` before calling `getSelectionRange`
- closes #73362 