### PR TITLE
Do not allow crash rate value to be greater than 1

### DIFF
--- a/src/sentry/api/endpoints/organization_release_health_data.py
+++ b/src/sentry/api/endpoints/organization_release_health_data.py
@@ -63,6 +63,10 @@ class OrganizationReleaseHealthDataEndpoint(OrganizationEndpoint):
                 # due to possible data corruption crash_free_rate value can be less than 0,
                 # which is not valid behavior, so those values have to be bottom capped at 0
                 metrics.ensure_non_negative_crash_free_rate_value(data, request, organization)
+                # due to possible data corruption crash_rate value can be greater than 1,
+                # which is not valid behavior, so those values have to be capped at 1
+                metrics.ensure_crash_rate_not_greater_than_1(data, request, organization)
+
                 data["query"] = query.query
             except (
                 InvalidParams,

--- a/src/sentry/utils/metrics.py
+++ b/src/sentry/utils/metrics.py
@@ -30,7 +30,7 @@ __all__ = [
     "gauge",
     "backend",
     "MutableTags",
-    "ensure_non_negative_crash_free_rate_value",
+    "ensure_crash_rate_in_bounds",
 ]
 
 
@@ -264,14 +264,19 @@ def event(
         logger.exception("Unable to record backend metric")
 
 
-def ensure_non_negative_crash_free_rate_value(
-    data: Any, request: Request, organization, CRASH_FREE_RATE_METRIC_KEY="session.crash_free_rate"
+def ensure_crash_rate_in_bounds(
+    data: Any,
+    request: Request,
+    organization,
+    CRASH_RATE_METRIC_KEY: str,
+    lower_bound: float = 0.0,
+    upper_bound: float = 1.0,
 ):
     """
-    Ensures that crash_free_rate metric will never have negative
-    value returned to the customer by replacing all the negative values with 0.
-    Negative value of crash_free_metric can happen due to the
-    corrupted data that is used to calculate the metric
+    Ensures that crash rate metric will always have value in expected bounds, and
+    that invalid value is never returned to the customer by replacing all the invalid values with
+    the bound value.
+    Invalid crash rate can happen due to the corrupted data that is used to calculate the metric
     (see: https://github.com/getsentry/sentry/issues/73172)
 
     Example format of data argument:
@@ -288,67 +293,41 @@ def ensure_non_negative_crash_free_rate_value(
     for group in groups:
         if "series" in group:
             series = group["series"]
-            if CRASH_FREE_RATE_METRIC_KEY in series:
-                for i, value in enumerate(series[CRASH_FREE_RATE_METRIC_KEY]):
-                    try:
-                        value = float(value)
-                        if value < 0:
-                            with sentry_sdk.isolation_scope() as scope:
-                                scope.set_tag("organization", organization.id)
-                                scope.set_extra("crash_free_rate_in_series", value)
-                                scope.set_extra("request_query_params", request.query_params)
-                                sentry_sdk.capture_message("crash_free_rate in series is negative")
-                            series[CRASH_FREE_RATE_METRIC_KEY][i] = 0
-                    except TypeError:
-                        # value is not a number
-                        continue
-
-        if "totals" in group:
-            totals = group["totals"]
-            if (
-                CRASH_FREE_RATE_METRIC_KEY in totals
-                and totals[CRASH_FREE_RATE_METRIC_KEY] is not None
-                and totals[CRASH_FREE_RATE_METRIC_KEY] < 0
-            ):
-                with sentry_sdk.isolation_scope() as scope:
-                    scope.set_tag("organization", organization.id)
-                    scope.set_extra("crash_free_rate", totals[CRASH_FREE_RATE_METRIC_KEY])
-                    scope.set_extra("request_query_params", request.query_params)
-                    sentry_sdk.capture_message("crash_free_rate is negative")
-                totals[CRASH_FREE_RATE_METRIC_KEY] = 0
-
-
-def ensure_crash_rate_not_greater_than_1(
-    data: Any, request: Request, organization, CRASH_RATE_METRIC_KEY="session.crash_rate"
-):
-    groups = data["groups"]
-    for group in groups:
-        if "series" in group:
-            series = group["series"]
             if CRASH_RATE_METRIC_KEY in series:
                 for i, value in enumerate(series[CRASH_RATE_METRIC_KEY]):
                     try:
                         value = float(value)
-                        if value > 1:
+                        if value < lower_bound or value > upper_bound:
                             with sentry_sdk.isolation_scope() as scope:
                                 scope.set_tag("organization", organization.id)
-                                scope.set_extra("crash_rate_in_series", value)
+                                scope.set_extra(f"{CRASH_RATE_METRIC_KEY} value in series", value)
                                 scope.set_extra("request_query_params", request.query_params)
-                                sentry_sdk.capture_message("crash_rate in series is greater than 1")
-                            series[CRASH_RATE_METRIC_KEY][i] = 1
+                                sentry_sdk.capture_message(
+                                    f"{CRASH_RATE_METRIC_KEY} not in (f{lower_bound}, f{upper_bound})"
+                                )
+                            if value < lower_bound:
+                                series[CRASH_RATE_METRIC_KEY][i] = lower_bound
+                            else:
+                                series[CRASH_RATE_METRIC_KEY][i] = upper_bound
                     except TypeError:
                         # value is not a number
                         continue
+
         if "totals" in group:
             totals = group["totals"]
-            if (
-                CRASH_RATE_METRIC_KEY in totals
-                and totals[CRASH_RATE_METRIC_KEY] is not None
-                and totals[CRASH_RATE_METRIC_KEY] > 1
-            ):
+            if CRASH_RATE_METRIC_KEY not in totals or totals[CRASH_RATE_METRIC_KEY] is None:
+                # no action is needed
+                continue
+            value = totals[CRASH_RATE_METRIC_KEY]
+            if value < lower_bound or value > upper_bound:
                 with sentry_sdk.isolation_scope() as scope:
                     scope.set_tag("organization", organization.id)
-                    scope.set_extra("crash_rate", totals[CRASH_RATE_METRIC_KEY])
+                    scope.set_extra(f"{CRASH_RATE_METRIC_KEY} value", totals[CRASH_RATE_METRIC_KEY])
                     scope.set_extra("request_query_params", request.query_params)
-                    sentry_sdk.capture_message("crash_rate is greater than 1")
-                totals[CRASH_RATE_METRIC_KEY] = 1
+                    sentry_sdk.capture_message(
+                        f"{CRASH_RATE_METRIC_KEY} not in (f{lower_bound}, f{upper_bound})"
+                    )
+                if value < lower_bound:
+                    totals[CRASH_RATE_METRIC_KEY] = lower_bound
+                else:
+                    totals[CRASH_RATE_METRIC_KEY] = upper_bound

--- a/tests/sentry/api/endpoints/test_organization_release_health_data.py
+++ b/tests/sentry/api/endpoints/test_organization_release_health_data.py
@@ -2469,3 +2469,55 @@ class DerivedMetricsDataTest(MetricsAPIBaseTestCase):
         assert group["totals"]["session.crash_free_rate"] == 0.0
         for value in group["series"]["session.crash_free_rate"]:
             assert value is None or value >= 0
+
+    def test_do_not_return_crash_rate_value_greater_than_1(self):
+        """
+        Assert that value for crash_rate won't be greater than 1.
+        This can happen due to possible corruption of data.  This problem
+        happens during ingestion when 'e:session/crashed' metric is
+        ingested, but 'e:session/all' for some reason is not.
+        """
+
+        # ingesting 'e:session/all' and 'e:session/crashed'
+        self.build_and_store_session(
+            project_id=self.project.id,
+            minutes_before_now=1,
+            status="crashed",
+        )
+
+        # manually ingesting only 'e:session/crashed' metric
+        # to make sure that there are more 'e:session/crashed' metrics ingested
+        # than 'e:session/all'
+        for i in range(2):
+            session = self.build_session(
+                started=self.adjust_timestamp(
+                    self.now
+                    - timedelta(
+                        minutes=i,
+                    )
+                ).timestamp()
+            )
+            # ingesting only 'e:session/crashed'
+            self.store_metric(
+                self.organization.id,
+                self.project.id,
+                "counter",
+                SessionMRI.RAW_SESSION.value,
+                {"session.status": "crashed"},
+                int(session["started"]),
+                +1,
+                use_case_id=UseCaseID.SESSIONS,
+            )
+
+        response = self.get_success_response(
+            self.organization.slug,
+            field=["session.crash_rate", "session.all", "session.crashed"],
+            statsPeriod="6m",
+            interval="1m",
+        )
+        group = response.data["groups"][0]
+        assert group["totals"]["session.all"] == 1.0
+        assert group["totals"]["session.crashed"] == 3.0
+        assert group["totals"]["session.crash_rate"] == 1.0  # value is capped at 1.0
+        for value in group["series"]["session.crash_rate"]:
+            assert value is None or value <= 1

--- a/tests/sentry/api/endpoints/test_organization_release_health_data.py
+++ b/tests/sentry/api/endpoints/test_organization_release_health_data.py
@@ -2470,7 +2470,7 @@ class DerivedMetricsDataTest(MetricsAPIBaseTestCase):
         for value in group["series"]["session.crash_free_rate"]:
             assert value is None or value >= 0
 
-    def test_do_not_return_crash_rate_value_greater_than_1(self):
+    def test_do_not_return_crash_rate_value_greater_than_one(self):
         """
         Assert that value for crash_rate won't be greater than 1.
         This can happen due to possible corruption of data.  This problem


### PR DESCRIPTION
Sometimes due to the problems in other parts of the system, data gets
corrupted and `crash_rate` is returned as a value greater than 1 (which
should never happen)

This solution guards against corrupted data by returning 1 if the
calculated `crash_rate` is greater than 0

closes [#73563](https://github.com/getsentry/sentry/issues/73563)
