### PR TITLE
fix: transaction_id check during project transfer

### DIFF
--- a/src/sentry/api/endpoints/project_transfer.py
+++ b/src/sentry/api/endpoints/project_transfer.py
@@ -12,6 +12,7 @@ from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.project import ProjectEndpoint, ProjectPermission
 from sentry.api.decorators import sudo_required
+from sentry.models.options.project_option import ProjectOption
 from sentry.models.organizationmember import OrganizationMember
 from sentry.utils.email import MessageBuilder
 from sentry.utils.http import absolute_uri
@@ -77,6 +78,10 @@ class ProjectTransferEndpoint(ProjectEndpoint):
             project_id=project.id,
             user_id=owner.user_id,
             transaction_id=transaction_id,
+        )
+
+        ProjectOption.objects.set_value(
+            project, "sentry:project-transfer-transaction-id", transaction_id
         )
 
         context = {

--- a/tests/sentry/api/endpoints/test_project_transfer.py
+++ b/tests/sentry/api/endpoints/test_project_transfer.py
@@ -1,6 +1,7 @@
 from django.core import mail
 from django.urls import reverse
 
+from sentry.models.options.project_option import ProjectOption
 from sentry.testutils.cases import APITestCase
 
 
@@ -46,6 +47,10 @@ class ProjectTransferTest(APITestCase):
             assert response.status_code == 204
             assert len(mail.outbox) == 1
             assert "http://testserver/accept-transfer/?" in mail.outbox[0].body
+            assert (
+                ProjectOption.objects.get_value(project, "sentry:project-transfer-transaction-id")
+                is not None
+            )
 
     def test_transfer_project_to_invalid_user(self):
         project = self.create_project()


### PR DESCRIPTION
Make sure the project transfer request URL could be used only once.