### PR TITLE
feat(profiling) setup continuous profiling routes

### DIFF
--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -1984,6 +1984,19 @@ function buildRoutes() {
           component={make(() => import('sentry/views/profiling/profileFlamechart'))}
         />
       </Route>
+      <Route
+        path="profile/:projectId/"
+        component={make(
+          () => import('sentry/views/profiling/continuousProfilesProvider')
+        )}
+      >
+        <Route
+          path="flamegraph/"
+          component={make(
+            () => import('sentry/views/profiling/continuousProfileFlamechart')
+          )}
+        />
+      </Route>
     </Route>
   );
 

--- a/static/app/utils/profiling/routes.tsx
+++ b/static/app/utils/profiling/routes.tsx
@@ -30,6 +30,16 @@ export function generateProfileFlamechartRoute({
   return `/organizations/${orgSlug}/profiling/profile/${projectSlug}/${profileId}/flamegraph/`;
 }
 
+export function generateContinuousProfileFlamechartRoute({
+  orgSlug,
+  projectSlug,
+}: {
+  orgSlug: Organization['slug'];
+  projectSlug: Project['slug'];
+}): string {
+  return `/organizations/${orgSlug}/profiling/profile/${projectSlug}/flamegraph/`;
+}
+
 export function generateProfileDifferentialFlamegraphRoute({
   orgSlug,
   projectSlug,
@@ -135,6 +145,30 @@ export function generateProfileFlamechartRouteWithQuery({
   return {
     pathname,
     query: {
+      ...query,
+    },
+  };
+}
+
+export function generateContinuousProfileFlamechartRouteWithQuery(
+  orgSlug: Organization['slug'],
+  projectSlug: Project['slug'],
+  profilerId: string,
+  start: string,
+  end: string,
+  query: Location['query']
+): LocationDescriptor {
+  const pathname = generateContinuousProfileFlamechartRoute({
+    orgSlug,
+    projectSlug,
+  });
+
+  return {
+    pathname,
+    query: {
+      profilerId,
+      start,
+      end,
       ...query,
     },
   };

--- a/static/app/views/profiling/continuousProfileFlamechart.tsx
+++ b/static/app/views/profiling/continuousProfileFlamechart.tsx
@@ -1,0 +1,7 @@
+interface ContinuousProfileFlamechartProps {}
+
+export function ContinuousProfileFlamechart(
+  _props: ContinuousProfileFlamechartProps
+): React.ReactNode {
+  return null;
+}

--- a/static/app/views/profiling/continuousProfileFlamechart.tsx
+++ b/static/app/views/profiling/continuousProfileFlamechart.tsx
@@ -1,6 +1,6 @@
 interface ContinuousProfileFlamechartProps {}
 
-export function ContinuousProfileFlamechart(
+export default function ContinuousProfileFlamechart(
   _props: ContinuousProfileFlamechartProps
 ): React.ReactNode {
   return null;

--- a/static/app/views/profiling/continuousProfilesProvider.tsx
+++ b/static/app/views/profiling/continuousProfilesProvider.tsx
@@ -1,6 +1,8 @@
 interface ContinuousProfilesProviderProps {
   children: React.ReactNode;
 }
-export function ContinuousProfilesProvider({children}: ContinuousProfilesProviderProps) {
+export default function ContinuousProfilesProvider({
+  children,
+}: ContinuousProfilesProviderProps) {
   return children;
 }

--- a/static/app/views/profiling/continuousProfilesProvider.tsx
+++ b/static/app/views/profiling/continuousProfilesProvider.tsx
@@ -1,0 +1,6 @@
+interface ContinuousProfilesProviderProps {
+  children: React.ReactNode;
+}
+export function ContinuousProfilesProvider({children}: ContinuousProfilesProviderProps) {
+  return children;
+}


### PR DESCRIPTION
I've thought of the idea of adding a continuous profiling mode and modify the flow of the current flamechart and provider code, but I'd rather separate the code from the previous profiling model. 

In the same spirit, I dont think we'll be reusing the flamechart that encapsulates all of the components and instead wire it back up using the underlying components to fit this different data model.