### PR TITLE
fix(search): Stop sending invalid start/end dates to tag values endpoint

### DIFF
--- a/static/app/views/issueList/searchBar.tsx
+++ b/static/app/views/issueList/searchBar.tsx
@@ -90,8 +90,12 @@ function IssueListSearchBar({organization, tags, ...props}: Props) {
       const orgSlug = organization.slug;
       const projectIds = pageFilters.projects.map(id => id.toString());
       const endpointParams = {
-        start: getUtcDateString(pageFilters.datetime.start),
-        end: getUtcDateString(pageFilters.datetime.end),
+        start: pageFilters.datetime.start
+          ? getUtcDateString(pageFilters.datetime.start)
+          : undefined,
+        end: pageFilters.datetime.end
+          ? getUtcDateString(pageFilters.datetime.end)
+          : undefined,
         statsPeriod: pageFilters.datetime.period,
       };
 


### PR DESCRIPTION
A long existing bug, we've been sending "Invalid date" when there are no start/end dates:

![CleanShot 2024-07-01 at 08 54 47](https://github.com/getsentry/sentry/assets/10888943/d22a0e1f-0e56-493c-82c2-0736e70fd1f6)
