### PR TITLE
fix(query-builder): Exclude environment tag from results

### DIFF
--- a/static/app/views/issueList/searchBar.tsx
+++ b/static/app/views/issueList/searchBar.tsx
@@ -41,7 +41,9 @@ const getSupportedTags = (supportedTags: TagCollection): TagCollection => {
 };
 
 const getFilterKeySections = (tags: TagCollection): FilterKeySection[] => {
-  const allTags: Tag[] = Object.values(tags);
+  const allTags: Tag[] = Object.values(tags).filter(
+    tag => !EXCLUDED_TAGS.includes(tag.key)
+  );
   const eventTags = orderBy(
     allTags.filter(tag => tag.kind === FieldKind.TAG),
     ['totalValues', 'key'],


### PR DESCRIPTION
Removes the environment tag from the search suggestions. This is already done for the current search because we want users to use the page filters instead.