### PR TITLE
fix(slack): set delete_original to False when responding to webhooks

### DIFF
--- a/src/sentry/integrations/slack/webhooks/action.py
+++ b/src/sentry/integrations/slack/webhooks/action.py
@@ -566,7 +566,9 @@ class SlackActionEndpoint(Endpoint):
                 try:
                     private_metadata = orjson.loads(view.private_metadata)
                     webhook_client = WebhookClient(private_metadata["orig_response_url"])
-                    webhook_client.send(blocks=json_blocks, delete_original=False)
+                    webhook_client.send(
+                        blocks=json_blocks, delete_original=False, replace_original=True
+                    )
                     logger.info(
                         "slack.webhook.view_submission.success",
                         extra={
@@ -690,7 +692,9 @@ class SlackActionEndpoint(Endpoint):
             json_blocks = orjson.dumps(response.get("blocks")).decode()
             webhook_client = WebhookClient(response_url)
             try:
-                webhook_client.send(blocks=json_blocks, delete_original=False)
+                webhook_client.send(
+                    blocks=json_blocks, delete_original=False, replace_original=True
+                )
                 logger.info(
                     "slack.webhook.update_status.success",
                     extra={"integration_id": slack_request.integration.id, "blocks": json_blocks},

--- a/src/sentry/integrations/slack/webhooks/action.py
+++ b/src/sentry/integrations/slack/webhooks/action.py
@@ -566,10 +566,13 @@ class SlackActionEndpoint(Endpoint):
                 try:
                     private_metadata = orjson.loads(view.private_metadata)
                     webhook_client = WebhookClient(private_metadata["orig_response_url"])
-                    webhook_client.send(blocks=json_blocks)
+                    webhook_client.send(blocks=json_blocks, delete_original=False)
                     logger.info(
                         "slack.webhook.view_submission.success",
-                        extra={"integration_id": slack_request.integration.id},
+                        extra={
+                            "integration_id": slack_request.integration.id,
+                            "blocks": json_blocks,
+                        },
                     )
                 except SlackApiError as e:
                     logger.error(
@@ -687,10 +690,10 @@ class SlackActionEndpoint(Endpoint):
             json_blocks = orjson.dumps(response.get("blocks")).decode()
             webhook_client = WebhookClient(response_url)
             try:
-                webhook_client.send(blocks=json_blocks)
+                webhook_client.send(blocks=json_blocks, delete_original=False)
                 logger.info(
                     "slack.webhook.update_status.success",
-                    extra={"integration_id": slack_request.integration.id},
+                    extra={"integration_id": slack_request.integration.id, "blocks": json_blocks},
                 )
             except SlackApiError as e:
                 logger.error("slack.webhook.update_status.response-error", extra={"error": str(e)})


### PR DESCRIPTION
Seeing that issue alerts are being deleted when interacting with them, it seems like delete_original is True for webhook responses? 

https://github.com/slackapi/python-slack-sdk/blob/v3.4.x/slack_sdk/webhook/client.py#L83-L84
>         :param replace_original: True if you use this option for response_url requests
>         :param delete_original: True if you use this option for response_url requests