### PR TITLE
ref(slack): retry link slack user identities task

### DIFF
--- a/src/sentry/integrations/slack/utils/users.py
+++ b/src/sentry/integrations/slack/utils/users.py
@@ -76,6 +76,7 @@ def get_slack_user_list(
                 "integration_id": integration.id,
             },
         )
+        raise
 
 
 def get_slack_data_by_user(

--- a/src/sentry/tasks/integrations/slack/link_slack_user_identities.py
+++ b/src/sentry/tasks/integrations/slack/link_slack_user_identities.py
@@ -22,16 +22,20 @@ logger = logging.getLogger("sentry.integrations.slack.tasks")
     name="sentry.integrations.slack.link_users_identities",
     queue="integrations.control",
     silo_mode=SiloMode.CONTROL,
+    max_retries=3,
 )
 def link_slack_user_identities(
-    integration_id: int | None = None,
-    organization_id: int | None = None,
+    integration_id: int,
+    organization_id: int,
 ) -> None:
-    if integration_id is not None:
-        integration = integration_service.get_integration(integration_id=integration_id)
-    if organization_id is not None:
-        organization = organization_service.get_organization_by_id(id=organization_id).organization
-    assert organization is not None and integration is not None
+    integration = integration_service.get_integration(integration_id=integration_id)
+    organization = organization_service.get_organization_by_id(id=organization_id).organization
+    if organization is None or integration is None:
+        logger.error(
+            "slack.post_install.link_identities.invalid_params",
+            extra={"organization": organization_id, "integration": integration_id},
+        )
+        return None
 
     emails_by_user = UserEmail.objects.get_emails_by_user(organization=organization)
     idp = IdentityProvider.objects.get(
@@ -80,7 +84,7 @@ def update_identities(slack_data_by_user: Mapping[User, SlackUserData], idp: Ide
         # the Identity matching that idp/external_id combo is linked to a different user
         if not created:
             logger.info(
-                "post_install.identity_linked_different_user",
+                "slack.post_install.identity_linked_different_user",
                 extra={
                     "idp_id": idp.id,
                     "external_id": slack_id,

--- a/tests/sentry/integrations/slack/test_integration.py
+++ b/tests/sentry/integrations/slack/test_integration.py
@@ -2,8 +2,10 @@ from unittest.mock import patch
 from urllib.parse import parse_qs, urlencode, urlparse
 
 import orjson
+import pytest
 import responses
 from responses.matchers import query_string_matcher
+from slack_sdk.errors import SlackApiError
 from slack_sdk.web import SlackResponse
 
 from sentry import audit_log
@@ -134,7 +136,7 @@ class SlackIntegrationTest(IntegrationTestCase):
         self.assertDialogSuccess(resp)
 
     @responses.activate
-    def test_bot_flow_slack_sdk(self, mock_api_call):
+    def test_bot_flow(self, mock_api_call):
         with self.tasks():
             self.assert_setup_flow()
 
@@ -429,7 +431,7 @@ class SlackIntegrationPostInstallTest(APITestCase):
             teams=[self.team],
         )
 
-        with self.tasks():
+        with self.tasks(), pytest.raises(SlackApiError):
             SlackIntegrationProvider().post_install(self.integration, self.organization)
 
         user5_identity = Identity.objects.filter(user=user5).first()

--- a/tests/sentry/integrations/slack/test_utils.py
+++ b/tests/sentry/integrations/slack/test_utils.py
@@ -198,9 +198,8 @@ class GetChannelIdTest(TestCase):
         assert get_channel_id(self.organization, self.integration, "@fake-user").channel_id is None
 
     @with_feature("organizations:slack-sdk-get-channel-id")
-    @patch("sentry.integrations.slack.sdk_client.metrics")
     @patch("slack_sdk.web.client.WebClient._perform_urllib_http_request")
-    def test_invalid_channel_selected_sdk(self, mock_api_call, mock_metrics):
+    def test_invalid_channel_selected_sdk(self, mock_api_call):
         # Tests chat_scheduleMessage and chat_deleteScheduledMessage
         mock_api_call.return_value = {
             "body": orjson.dumps({"ok": False, "error": "channel_not_found"}).decode(),


### PR DESCRIPTION
Add retries for the Slack link user identities task, and bubble up any `SlackApiErrors` so we can retry if that happens rather than exit and potentially never link certain users.

This is for the INFRA-1 task for Slack messaging refactor.