### PR TITLE
ref(replay): Insert the init breadcrumb to the front of the list

### DIFF
--- a/static/app/utils/replays/replayReader.tsx
+++ b/static/app/utils/replays/replayReader.tsx
@@ -248,7 +248,7 @@ export default class ReplayReader {
     this._optionFrame = optionFrame;
 
     // Insert extra records to satisfy minimum requirements for the UI
-    this._sortedBreadcrumbFrames.push(replayInitBreadcrumb(replayRecord));
+    this._sortedBreadcrumbFrames.unshift(replayInitBreadcrumb(replayRecord));
     this._sortedRRWebEvents.unshift(recordingStartFrame(replayRecord));
     this._sortedRRWebEvents.push(recordingEndFrame(replayRecord));
 


### PR DESCRIPTION
Breadcrumbs get sorted anyway before render, so nothing was super wrong before... but this seems better given the array is named `_sortedBreadcrumbFrames`. The init breadcrumb should be at the start at all times.