### PR TITLE
ref(replay): Pull some stuff out of components/replays/utils.tsx

### DIFF
--- a/static/app/components/replays/breadcrumbs/breadcrumbItem.tsx
+++ b/static/app/components/replays/breadcrumbs/breadcrumbItem.tsx
@@ -13,12 +13,12 @@ import PanelItem from 'sentry/components/panels/panelItem';
 import {OpenReplayComparisonButton} from 'sentry/components/replays/breadcrumbs/openReplayComparisonButton';
 import {useReplayContext} from 'sentry/components/replays/replayContext';
 import {useReplayGroupContext} from 'sentry/components/replays/replayGroupContext';
-import {showPlayerTime} from 'sentry/components/replays/utils';
 import Timeline from 'sentry/components/timeline';
 import {useHasNewTimelineUI} from 'sentry/components/timeline/utils';
 import {Tooltip} from 'sentry/components/tooltip';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
+import formatReplayDuration from 'sentry/utils/duration/formatReplayDuration';
 import type {Extraction} from 'sentry/utils/replays/extractDomNodes';
 import {getReplayDiffOffsetsFromFrame} from 'sentry/utils/replays/getDiffTimestamps';
 import getFrameDetails from 'sentry/utils/replays/getFrameDetails';
@@ -132,7 +132,7 @@ function BreadcrumbItem({
         colorConfig={{primary: color, secondary: color}}
         timeString={timeString}
         renderTimestamp={(_ts, _sts) =>
-          showPlayerTime(frame.timestampMs, startTimestampMs, false)
+          formatReplayDuration(Math.abs(frame.timestampMs - startTimestampMs), false)
         }
         startTimeString={startTimeString}
         data-is-error-frame={isErrorFrame(frame)}

--- a/static/app/components/replays/breadcrumbs/replayTimeline.tsx
+++ b/static/app/components/replays/breadcrumbs/replayTimeline.tsx
@@ -12,7 +12,7 @@ import Stacked from 'sentry/components/replays/breadcrumbs/stacked';
 import {TimelineScrubber} from 'sentry/components/replays/player/scrubber';
 import {useTimelineScrubberMouseTracking} from 'sentry/components/replays/player/useScrubberMouseTracking';
 import {useReplayContext} from 'sentry/components/replays/replayContext';
-import {divide} from 'sentry/components/replays/utils';
+import divide from 'sentry/utils/number/divide';
 import toPercent from 'sentry/utils/number/toPercent';
 import {useDimensions} from 'sentry/utils/useDimensions';
 

--- a/static/app/components/replays/player/scrubber.tsx
+++ b/static/app/components/replays/player/scrubber.tsx
@@ -6,9 +6,10 @@ import SliderAndInputWrapper from 'sentry/components/forms/controls/rangeSlider/
 import TimelineTooltip from 'sentry/components/replays/breadcrumbs/replayTimelineTooltip';
 import * as Progress from 'sentry/components/replays/progress';
 import {useReplayContext} from 'sentry/components/replays/replayContext';
-import {divide, formatTime} from 'sentry/components/replays/utils';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
+import formatReplayDuration from 'sentry/utils/duration/formatReplayDuration';
+import divide from 'sentry/utils/number/divide';
 import toPercent from 'sentry/utils/number/toPercent';
 
 type Props = {
@@ -58,7 +59,7 @@ function Scrubber({className, showZoomIndicators = false}: Props) {
       <Meter>
         {currentHoverTime ? (
           <div>
-            <TimelineTooltip labelText={formatTime(currentHoverTime)} />
+            <TimelineTooltip labelText={formatReplayDuration(currentHoverTime)} />
             <MouseTrackingValue
               style={{
                 width: toPercent(hoverPlace),

--- a/static/app/components/replays/player/useScrubberMouseTracking.tsx
+++ b/static/app/components/replays/player/useScrubberMouseTracking.tsx
@@ -2,7 +2,7 @@ import type {RefObject} from 'react';
 import {useCallback} from 'react';
 
 import {useReplayContext} from 'sentry/components/replays/replayContext';
-import {divide} from 'sentry/components/replays/utils';
+import divide from 'sentry/utils/number/divide';
 import useMouseTracking from 'sentry/utils/replays/hooks/useMouseTracking';
 
 type Opts<T extends Element> = {

--- a/static/app/components/replays/timeAndScrubberGrid.tsx
+++ b/static/app/components/replays/timeAndScrubberGrid.tsx
@@ -7,10 +7,10 @@ import ReplayTimeline from 'sentry/components/replays/breadcrumbs/replayTimeline
 import {PlayerScrubber} from 'sentry/components/replays/player/scrubber';
 import useScrubberMouseTracking from 'sentry/components/replays/player/useScrubberMouseTracking';
 import {useReplayContext} from 'sentry/components/replays/replayContext';
-import {formatTime} from 'sentry/components/replays/utils';
 import {IconAdd, IconSubtract} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
+import formatReplayDuration from 'sentry/utils/duration/formatReplayDuration';
 
 type TimeAndScrubberGridProps = {
   isCompact?: boolean;
@@ -61,7 +61,7 @@ function TimeAndScrubberGrid({
 
   return (
     <Grid id="replay-timeline-player" isCompact={isCompact}>
-      <Time style={{gridArea: 'currentTime'}}>{formatTime(currentTime)}</Time>
+      <Time style={{gridArea: 'currentTime'}}>{formatReplayDuration(currentTime)}</Time>
       <div style={{gridArea: 'timeline'}}>
         <ReplayTimeline />
       </div>
@@ -72,7 +72,7 @@ function TimeAndScrubberGrid({
         <PlayerScrubber showZoomIndicators={showZoom} />
       </StyledScrubber>
       <Time style={{gridArea: 'duration'}}>
-        {durationMs ? formatTime(durationMs) : '--:--'}
+        {durationMs ? formatReplayDuration(durationMs) : '--:--'}
       </Time>
     </Grid>
   );

--- a/static/app/components/replays/utils.spec.tsx
+++ b/static/app/components/replays/utils.spec.tsx
@@ -4,27 +4,14 @@ import {ReplayRecordFixture} from 'sentry-fixture/replayRecord';
 
 import {
   countColumns,
-  divide,
   findVideoSegmentIndex,
   flattenFrames,
-  formatTime,
   getFramesByColumn,
-  showPlayerTime,
 } from 'sentry/components/replays/utils';
 import hydrateErrors from 'sentry/utils/replays/hydrateErrors';
 import hydrateSpans from 'sentry/utils/replays/hydrateSpans';
 
 const SECOND = 1000;
-
-describe('formatTime', () => {
-  it.each([
-    ['seconds', 15 * 1000, '00:15'],
-    ['minutes', 2.5 * 60 * 1000, '02:30'],
-    ['hours', 75 * 60 * 1000, '01:15:00'],
-  ])('should format a %s long duration into a string', (_desc, duration, expected) => {
-    expect(formatTime(duration)).toEqual(expected);
-  });
-});
 
 describe('countColumns', () => {
   it('should divide 27s by 2700px to find twentyseven 1s columns, with some fraction remaining', () => {
@@ -260,27 +247,6 @@ describe('flattenFrames', () => {
         startTimestamp: 10000,
       },
     ]);
-  });
-
-  const diffMs = 1652309918676;
-  describe('showPlayerTime', () => {
-    it('returns time formatted for player', () => {
-      expect(showPlayerTime('2022-05-11T23:04:27.576000Z', diffMs)).toEqual('05:48');
-    });
-
-    it('returns 0:00 if timestamp is malformed', () => {
-      expect(showPlayerTime('20223:04:27.576000Z', diffMs)).toEqual('00:00');
-    });
-  });
-
-  describe('divide', () => {
-    it('divides numbers safely', () => {
-      expect(divide(81, 9)).toEqual(9);
-    });
-
-    it('dividing by zero returns zero', () => {
-      expect(divide(81, 0)).toEqual(0);
-    });
   });
 });
 

--- a/static/app/components/replays/utils.tsx
+++ b/static/app/components/replays/utils.tsx
@@ -1,30 +1,8 @@
-import {formatSecondsToClock} from 'sentry/utils/duration/formatSecondsToClock';
 import type {ReplayFrame, SpanFrame, VideoEvent} from 'sentry/utils/replays/types';
 
 const SECOND = 1000;
 const MINUTE = 60 * SECOND;
 const HOUR = 60 * MINUTE;
-
-export function showPlayerTime(
-  timestamp: ConstructorParameters<typeof Date>[0],
-  relativeTimeMs: number,
-  showMs: boolean = false
-): string {
-  return formatTime(Math.abs(new Date(timestamp).getTime() - relativeTimeMs), showMs);
-}
-
-export function formatTime(ms: number, showMs?: boolean): string {
-  if (ms <= 0 || isNaN(ms)) {
-    if (showMs) {
-      return '00:00.000';
-    }
-
-    return '00:00';
-  }
-
-  const seconds = ms / 1000;
-  return formatSecondsToClock(showMs ? seconds : Math.floor(seconds));
-}
 
 /**
  * Figure out how many ticks to show in an area.
@@ -175,16 +153,6 @@ export function flattenFrames(frames: SpanFrame[]): FlattenedSpanRange[] {
     }
   }
   return flattened;
-}
-
-/**
- * Divide two numbers safely
- */
-export function divide(numerator: number, denominator: number | undefined) {
-  if (denominator === undefined || isNaN(denominator) || denominator === 0) {
-    return 0;
-  }
-  return numerator / denominator;
 }
 
 /**

--- a/static/app/utils/duration/formatReplayDuration.spec.tsx
+++ b/static/app/utils/duration/formatReplayDuration.spec.tsx
@@ -1,0 +1,11 @@
+import formatReplayDuration from 'sentry/utils/duration/formatReplayDuration';
+
+describe('formatReplayDuration', () => {
+  it.each([
+    ['seconds', 15 * 1000, '00:15'],
+    ['minutes', 2.5 * 60 * 1000, '02:30'],
+    ['hours', 75 * 60 * 1000, '01:15:00'],
+  ])('should format a %s long duration into a string', (_desc, duration, expected) => {
+    expect(formatReplayDuration(duration)).toEqual(expected);
+  });
+});

--- a/static/app/utils/duration/formatReplayDuration.tsx
+++ b/static/app/utils/duration/formatReplayDuration.tsx
@@ -1,0 +1,14 @@
+import {formatSecondsToClock} from 'sentry/utils/duration/formatSecondsToClock';
+
+export default function formatReplayDuration(ms: number, showMs?: boolean): string {
+  if (ms <= 0 || isNaN(ms)) {
+    if (showMs) {
+      return '00:00.000';
+    }
+
+    return '00:00';
+  }
+
+  const seconds = ms / 1000;
+  return formatSecondsToClock(showMs ? seconds : Math.floor(seconds));
+}

--- a/static/app/utils/number/divide.spec.tsx
+++ b/static/app/utils/number/divide.spec.tsx
@@ -1,0 +1,11 @@
+import divide from 'sentry/utils/number/divide';
+
+describe('divide', () => {
+  it('divides numbers safely', () => {
+    expect(divide(81, 9)).toEqual(9);
+  });
+
+  it('dividing by zero returns zero', () => {
+    expect(divide(81, 0)).toEqual(0);
+  });
+});

--- a/static/app/utils/number/divide.tsx
+++ b/static/app/utils/number/divide.tsx
@@ -1,0 +1,9 @@
+/**
+ * Divide two numbers safely
+ */
+export default function divide(numerator: number, denominator: number | undefined) {
+  if (denominator === undefined || isNaN(denominator) || denominator === 0) {
+    return 0;
+  }
+  return numerator / denominator;
+}

--- a/static/app/views/replays/detail/accessibility/accessibilityRefetchBanner.tsx
+++ b/static/app/views/replays/detail/accessibility/accessibilityRefetchBanner.tsx
@@ -4,10 +4,10 @@ import styled from '@emotion/styled';
 import {Button} from 'sentry/components/button';
 import {Flex} from 'sentry/components/container/flex';
 import {useReplayContext} from 'sentry/components/replays/replayContext';
-import {showPlayerTime} from 'sentry/components/replays/utils';
 import Well from 'sentry/components/well';
 import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
+import formatReplayDuration from 'sentry/utils/duration/formatReplayDuration';
 import TimestampButton from 'sentry/views/replays/detail/timestampButton';
 
 interface Props {
@@ -32,8 +32,7 @@ export default function AccessibilityRefetchBanner({initialOffsetMs, refetch}: P
     setCurrentTime(lastOffsetMs);
   }, [setCurrentTime, lastOffsetMs]);
 
-  const now = showPlayerTime(startTimestampMs + currentTime, startTimestampMs, false);
-
+  const now = formatReplayDuration(currentTime, false);
   return (
     <StyledWell>
       <Flex

--- a/static/app/views/replays/detail/memoryPanel/domNodesChart.tsx
+++ b/static/app/views/replays/detail/memoryPanel/domNodesChart.tsx
@@ -8,13 +8,13 @@ import {computeChartTooltip} from 'sentry/components/charts/components/tooltip';
 import XAxis from 'sentry/components/charts/components/xAxis';
 import YAxis from 'sentry/components/charts/components/yAxis';
 import type {useReplayContext} from 'sentry/components/replays/replayContext';
-import {formatTime} from 'sentry/components/replays/utils';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import toArray from 'sentry/utils/array/toArray';
 import {getFormattedDate} from 'sentry/utils/dates';
 import {axisLabelFormatter} from 'sentry/utils/discover/charts';
 import domId from 'sentry/utils/domId';
+import formatReplayDuration from 'sentry/utils/duration/formatReplayDuration';
 import type {DomNodeChartDatapoint} from 'sentry/utils/replays/countDomNodes';
 
 interface Props
@@ -70,7 +70,7 @@ export default function DomNodesChart({
               ${t('Date: %s', getFormattedDate(startTimestampMs + firstValue.axisValue, 'MMM D, YYYY hh:mm:ss A z', {local: false}))}
             </div>
             <div class="tooltip-footer" style="border: none;">
-              ${t('Time within replay: %s', formatTime(firstValue.axisValue))}
+              ${t('Time within replay: %s', formatReplayDuration(firstValue.axisValue))}
             </div>
           <div class="tooltip-arrow"></div>
         `;
@@ -81,7 +81,7 @@ export default function DomNodesChart({
       xAxis: XAxis({
         type: 'time',
         axisLabel: {
-          formatter: (time: number) => formatTime(time),
+          formatter: (time: number) => formatReplayDuration(time),
         },
         theme,
       }),

--- a/static/app/views/replays/detail/memoryPanel/memoryChart.tsx
+++ b/static/app/views/replays/detail/memoryPanel/memoryChart.tsx
@@ -8,13 +8,13 @@ import {computeChartTooltip} from 'sentry/components/charts/components/tooltip';
 import XAxis from 'sentry/components/charts/components/xAxis';
 import YAxis from 'sentry/components/charts/components/yAxis';
 import type {useReplayContext} from 'sentry/components/replays/replayContext';
-import {formatTime} from 'sentry/components/replays/utils';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import toArray from 'sentry/utils/array/toArray';
 import {formatBytesBase2} from 'sentry/utils/bytes/formatBytesBase2';
 import {getFormattedDate} from 'sentry/utils/dates';
 import domId from 'sentry/utils/domId';
+import formatReplayDuration from 'sentry/utils/duration/formatReplayDuration';
 import type {MemoryFrame} from 'sentry/utils/replays/types';
 
 interface Props
@@ -69,7 +69,7 @@ export default function MemoryChart({
                 ${t('Date: %s', getFormattedDate(startTimestampMs + firstValue.axisValue, 'MMM D, YYYY hh:mm:ss A z', {local: false}))}
               </div>
               <div class="tooltip-footer" style="border: none;">
-                ${t('Time within replay: %s', formatTime(firstValue.axisValue))}
+                ${t('Time within replay: %s', formatReplayDuration(firstValue.axisValue))}
               </div>
             <div class="tooltip-arrow"></div>
           `;
@@ -80,7 +80,7 @@ export default function MemoryChart({
       xAxis: XAxis({
         type: 'time',
         axisLabel: {
-          formatter: (time: number) => formatTime(time),
+          formatter: (time: number) => formatReplayDuration(time),
         },
         theme,
       }),

--- a/static/app/views/replays/detail/timestampButton.tsx
+++ b/static/app/views/replays/detail/timestampButton.tsx
@@ -2,10 +2,10 @@ import type {MouseEvent} from 'react';
 import styled from '@emotion/styled';
 
 import {DateTime} from 'sentry/components/dateTime';
-import {showPlayerTime} from 'sentry/components/replays/utils';
 import {Tooltip} from 'sentry/components/tooltip';
 import {IconPlay} from 'sentry/icons';
 import {space} from 'sentry/styles/space';
+import formatReplayDuration from 'sentry/utils/duration/formatReplayDuration';
 
 type Props = {
   startTimestampMs: number;
@@ -30,7 +30,10 @@ function TimestampButton({
         className={className}
       >
         <IconPlay size="xs" />
-        {showPlayerTime(timestampMs, startTimestampMs, format === 'mm:ss.SSS')}
+        {formatReplayDuration(
+          Math.abs(new Date(timestampMs).getTime() - startTimestampMs),
+          format === 'mm:ss.SSS'
+        )}
       </StyledButton>
     </Tooltip>
   );

--- a/static/app/views/replays/replayTable/tableCell.tsx
+++ b/static/app/views/replays/replayTable/tableCell.tsx
@@ -9,7 +9,6 @@ import {DropdownMenu} from 'sentry/components/dropdownMenu';
 import Link from 'sentry/components/links/link';
 import ContextIcon from 'sentry/components/replays/contextIcon';
 import ReplayPlayPauseButton from 'sentry/components/replays/replayPlayPauseButton';
-import {formatTime} from 'sentry/components/replays/utils';
 import ScoreBar from 'sentry/components/scoreBar';
 import TimeSince from 'sentry/components/timeSince';
 import {Tooltip} from 'sentry/components/tooltip';
@@ -30,6 +29,7 @@ import {trackAnalytics} from 'sentry/utils/analytics';
 import {browserHistory} from 'sentry/utils/browserHistory';
 import type EventView from 'sentry/utils/discover/eventView';
 import {spanOperationRelativeBreakdownRenderer} from 'sentry/utils/discover/fieldRenderers';
+import formatReplayDuration from 'sentry/utils/duration/formatReplayDuration';
 import {getShortEventId} from 'sentry/utils/events';
 import {decodeScalar} from 'sentry/utils/queryString';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
@@ -526,7 +526,7 @@ export function DurationCell({replay, showDropdownFilters}: Props) {
   return (
     <Item>
       <Container>
-        <Time>{formatTime(replay.duration.asMilliseconds())}</Time>
+        <Time>{formatReplayDuration(replay.duration.asMilliseconds())}</Time>
         {showDropdownFilters ? (
           <NumericDropdownFilter type="duration" val={replay.duration.asSeconds()} />
         ) : null}


### PR DESCRIPTION
These date and number related things are not really specific to replay, so i'll move them out into utils/*. I removed some useless duration formatting stuff, putting `formatReplayDuration` into utils/ should make it easier to find and de-duplicate similar code 