### PR TITLE
feat(profiling) create continuous profiler span link helper

### DIFF
--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -1984,6 +1984,19 @@ function buildRoutes() {
           component={make(() => import('sentry/views/profiling/profileFlamechart'))}
         />
       </Route>
+      <Route
+        path="profile/:projectId/"
+        component={make(
+          () => import('sentry/views/profiling/continuousProfilesProvider')
+        )}
+      >
+        <Route
+          path="flamegraph/"
+          component={make(
+            () => import('sentry/views/profiling/continuousProfileFlamechart')
+          )}
+        />
+      </Route>
     </Route>
   );
 

--- a/static/app/types/event.tsx
+++ b/static/app/types/event.tsx
@@ -632,10 +632,12 @@ export interface ThreadPoolInfoContext {
 
 export enum ProfileContextKey {
   PROFILE_ID = 'profile_id',
+  PROFILER_ID = 'profiler_id',
 }
 
 export interface ProfileContext {
   [ProfileContextKey.PROFILE_ID]?: string;
+  [ProfileContextKey.PROFILER_ID]?: string;
 }
 
 export enum ReplayContextKey {

--- a/static/app/utils/profiling/routes.tsx
+++ b/static/app/utils/profiling/routes.tsx
@@ -30,6 +30,16 @@ export function generateProfileFlamechartRoute({
   return `/organizations/${orgSlug}/profiling/profile/${projectSlug}/${profileId}/flamegraph/`;
 }
 
+export function generateContinuousProfileFlamechartRoute({
+  orgSlug,
+  projectSlug,
+}: {
+  orgSlug: Organization['slug'];
+  projectSlug: Project['slug'];
+}): string {
+  return `/organizations/${orgSlug}/profiling/profile/${projectSlug}/flamegraph/`;
+}
+
 export function generateProfileDifferentialFlamegraphRoute({
   orgSlug,
   projectSlug,
@@ -135,6 +145,30 @@ export function generateProfileFlamechartRouteWithQuery({
   return {
     pathname,
     query: {
+      ...query,
+    },
+  };
+}
+
+export function generateContinuousProfileFlamechartRouteWithQuery(
+  orgSlug: Organization['slug'],
+  projectSlug: Project['slug'],
+  profilerId: string,
+  start: string,
+  end: string,
+  query: Location['query']
+): LocationDescriptor {
+  const pathname = generateContinuousProfileFlamechartRoute({
+    orgSlug,
+    projectSlug,
+  });
+
+  return {
+    pathname,
+    query: {
+      profilerId,
+      start,
+      end,
       ...query,
     },
   };

--- a/static/app/views/performance/newTraceDetails/index.tsx
+++ b/static/app/views/performance/newTraceDetails/index.tsx
@@ -895,7 +895,7 @@ export function TraceViewWaterfall(props: TraceViewWaterfallProps) {
   }, [tree, projects, props.organization]);
 
   useLayoutEffect(() => {
-    if (!tree.root.space || tree.type !== 'trace') {
+    if (tree.type !== 'trace') {
       return undefined;
     }
 

--- a/static/app/views/performance/newTraceDetails/index.tsx
+++ b/static/app/views/performance/newTraceDetails/index.tsx
@@ -895,7 +895,7 @@ export function TraceViewWaterfall(props: TraceViewWaterfallProps) {
   }, [tree, projects, props.organization]);
 
   useLayoutEffect(() => {
-    if (!tree.root?.space || tree.type !== 'trace') {
+    if (!tree.root.space || tree.type !== 'trace') {
       return undefined;
     }
 

--- a/static/app/views/performance/newTraceDetails/trace.tsx
+++ b/static/app/views/performance/newTraceDetails/trace.tsx
@@ -491,7 +491,7 @@ export function Trace({
   });
 
   const traceNode = trace.root.children[0];
-  const traceStartTimestamp = traceNode.space[0];
+  const traceStartTimestamp = traceNode?.space[0];
 
   return (
     <TraceStylingWrapper

--- a/static/app/views/performance/newTraceDetails/trace.tsx
+++ b/static/app/views/performance/newTraceDetails/trace.tsx
@@ -491,13 +491,13 @@ export function Trace({
   });
 
   const traceNode = trace.root.children[0];
-  const traceStartTimestamp = traceNode?.space?.[0];
+  const traceStartTimestamp = traceNode.space[0];
 
   return (
     <TraceStylingWrapper
       ref={manager.registerContainerRef}
       className={`
-        ${trace?.root?.space?.[1] === 0 ? 'Empty' : ''}
+        ${trace.root.space[1] === 0 ? 'Empty' : ''}
         ${trace.indicators.length > 0 ? 'WithIndicators' : ''}
         ${trace.type !== 'trace' || scrollQueueRef.current ? 'Loading' : ''}
         ${ConfigStore.get('theme')}`}

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/index.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/index.tsx
@@ -40,14 +40,13 @@ function SpanNodeDetailHeader({
   project: Project | undefined;
 }) {
   const span = node.value;
-  const {event} = span;
 
   return (
     <TraceDrawerComponents.HeaderContainer>
       <TraceDrawerComponents.Title>
-        <Tooltip title={event.projectSlug}>
+        <Tooltip title={span.event.projectSlug}>
           <ProjectBadge
-            project={project ? project : {slug: event.projectSlug || ''}}
+            project={project ? project : {slug: span.event.projectSlug || ''}}
             avatarSize={30}
             hideName
           />

--- a/static/app/views/performance/newTraceDetails/traceDrawer/traceProfilingLink.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/traceProfilingLink.spec.tsx
@@ -64,43 +64,6 @@ describe('traceProfilingLink', () => {
       ).toBeNull();
     });
   });
-  it('handles invalid date', () => {
-    const event = TransactionEventFixture({
-      startTimestamp: new Date().getTime() / 1e3,
-      endTimestamp: new Date().getTime() / 1e3 + 1000,
-      contexts: {
-        profile: {
-          profiler_id: 'profiler',
-        },
-      },
-    });
-
-    // @ts-expect-error
-    event.endTimestamp = 'invalid';
-    // @ts-expect-error
-    event.startTimestamp = 'invalid';
-
-    expect(
-      makeTraceContinuousProfilingLink(
-        new TraceTreeNode(
-          null,
-          makeTransaction({
-            start_timestamp: undefined,
-            timestamp: undefined,
-          }),
-          {
-            project_slug: '',
-            event_id: '',
-          }
-        ),
-        event,
-        {
-          projectSlug: 'project',
-          orgSlug: 'sentry',
-        }
-      )
-    ).toBeNull();
-  });
 
   it('creates a window of time around end timestamp', () => {
     const event = TransactionEventFixture({
@@ -112,6 +75,7 @@ describe('traceProfilingLink', () => {
     });
 
     const timestamp = new Date().getTime();
+
     const node = new TraceTreeNode(
       null,
       makeTransaction({start_timestamp: undefined, timestamp: timestamp / 1e3}),
@@ -131,8 +95,8 @@ describe('traceProfilingLink', () => {
     );
 
     // @ts-expect-error mismatch in types?
-    expect(link.query.start).toBe(new Date(timestamp - 1000).toISOString());
+    expect(link.query.start).toBe(new Date(timestamp - 100).toISOString());
     // @ts-expect-error mismatch in types?
-    expect(link.query.end).toBe(new Date(timestamp + 1000).toISOString());
+    expect(link.query.end).toBe(new Date(timestamp + 100).toISOString());
   });
 });

--- a/static/app/views/performance/newTraceDetails/traceDrawer/traceProfilingLink.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/traceProfilingLink.spec.tsx
@@ -1,0 +1,138 @@
+import type {LocationDescriptor} from 'history';
+import {TransactionEventFixture} from 'sentry-fixture/event';
+
+import type {TraceTree} from 'sentry/views/performance/newTraceDetails/traceModels/traceTree';
+import {TraceTreeNode} from 'sentry/views/performance/newTraceDetails/traceModels/traceTree';
+
+import {makeTraceContinuousProfilingLink} from './traceProfilingLink';
+
+function makeTransaction(
+  overrides: Partial<TraceTree.Transaction> = {}
+): TraceTree.Transaction {
+  return {
+    children: [],
+    sdk_name: '',
+    start_timestamp: 0,
+    timestamp: 1,
+    transaction: 'transaction',
+    'transaction.op': '',
+    'transaction.status': '',
+    performance_issues: [],
+    errors: [],
+    ...overrides,
+  } as TraceTree.Transaction;
+}
+
+describe('traceProfilingLink', () => {
+  describe('required params', () => {
+    const node = new TraceTreeNode(null, makeTransaction(), {
+      project_slug: '',
+      event_id: '',
+    });
+
+    it('requires projectSlug', () => {
+      const event = TransactionEventFixture();
+      expect(
+        makeTraceContinuousProfilingLink(node, event, {
+          projectSlug: 'project',
+          orgSlug: '',
+        })
+      ).toBeNull();
+    });
+    it('requires orgSlug', () => {
+      const event = TransactionEventFixture();
+      expect(
+        makeTraceContinuousProfilingLink(node, event, {
+          projectSlug: '',
+          orgSlug: 'sentry',
+        })
+      ).toBeNull();
+    });
+    it('requires profilerId', () => {
+      const event = TransactionEventFixture({
+        contexts: {
+          profile: {
+            profiler_id: undefined,
+          },
+        },
+      });
+      expect(
+        makeTraceContinuousProfilingLink(node, event, {
+          projectSlug: 'project',
+          orgSlug: 'sentry',
+        })
+      ).toBeNull();
+    });
+  });
+  it('handles invalid date', () => {
+    const event = TransactionEventFixture({
+      startTimestamp: new Date().getTime() / 1e3,
+      endTimestamp: new Date().getTime() / 1e3 + 1000,
+      contexts: {
+        profile: {
+          profiler_id: 'profiler',
+        },
+      },
+    });
+
+    // @ts-expect-error
+    event.endTimestamp = 'invalid';
+    // @ts-expect-error
+    event.startTimestamp = 'invalid';
+
+    expect(
+      makeTraceContinuousProfilingLink(
+        new TraceTreeNode(
+          null,
+          makeTransaction({
+            start_timestamp: undefined,
+            timestamp: undefined,
+          }),
+          {
+            project_slug: '',
+            event_id: '',
+          }
+        ),
+        event,
+        {
+          projectSlug: 'project',
+          orgSlug: 'sentry',
+        }
+      )
+    ).toBeNull();
+  });
+
+  it('creates a window of time around end timestamp', () => {
+    const event = TransactionEventFixture({
+      contexts: {
+        profile: {
+          profiler_id: 'profiler',
+        },
+      },
+    });
+
+    const timestamp = new Date().getTime();
+    const node = new TraceTreeNode(
+      null,
+      makeTransaction({start_timestamp: undefined, timestamp: timestamp / 1e3}),
+      {
+        project_slug: '',
+        event_id: '',
+      }
+    );
+
+    const link: LocationDescriptor | null = makeTraceContinuousProfilingLink(
+      node,
+      event,
+      {
+        projectSlug: 'project',
+        orgSlug: 'sentry',
+      }
+    );
+
+    // @ts-expect-error mismatch in types?
+    expect(link.query.start).toBe(new Date(timestamp - 1000).toISOString());
+    // @ts-expect-error mismatch in types?
+    expect(link.query.end).toBe(new Date(timestamp + 1000).toISOString());
+  });
+});

--- a/static/app/views/performance/newTraceDetails/traceDrawer/traceProfilingLink.ts
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/traceProfilingLink.ts
@@ -1,0 +1,72 @@
+import type {Location,LocationDescriptor} from 'history';
+
+import type {EventTransaction} from 'sentry/types';
+import {generateContinuousProfileFlamechartRouteWithQuery} from 'sentry/utils/profiling/routes';
+import type {
+  TraceTree,
+  TraceTreeNode,
+} from 'sentry/views/performance/newTraceDetails/traceModels/traceTree';
+
+function toDate(value: unknown): Date | null {
+  if (typeof value !== 'string' && typeof value !== 'number') {
+    return null;
+  }
+
+  const dateObj = new Date(value);
+
+  if (isNaN(dateObj.getTime())) {
+    return null;
+  }
+
+  return dateObj;
+}
+
+/**
+ * Generates a link to a continuous profile for a given trace element type
+ */
+export function makeTraceContinuousProfilingLink(
+  value: TraceTreeNode<TraceTree.NodeValue>,
+  transaction: EventTransaction,
+  options: {
+    orgSlug: string;
+    projectSlug: string;
+  },
+  query: Location['query'] = {}
+): LocationDescriptor | null {
+  if (!options.projectSlug || !options.orgSlug) {
+    return null;
+  }
+
+  let start: Date | null = toDate(value.space[0]);
+  let end: Date | null = toDate(value.space[0] + value.space[1]);
+  const profilerId: string | null =
+    transaction.contexts?.profile?.profiler_id ?? null;
+
+  // End timestamp is required to generate a link
+  if (end === null || profilerId === null) {
+    return null;
+  }
+
+  // If we have an end, but no start, then we'll generate a window of time around end timestamp
+  // so that we can show context around the event.
+  if (end && end.getTime() === start?.getTime()) {
+    const PRE_CONTEXT_WINDOW_MS = 100;
+    const POST_CONTEXT_WINDOW_MS = 100;
+    start = new Date(start.getTime() - PRE_CONTEXT_WINDOW_MS);
+    end = new Date(end.getTime() + POST_CONTEXT_WINDOW_MS);
+  }
+
+  // We require a full time range to open a flamechart
+  if (start === null) {
+    return null;
+  }
+
+  return generateContinuousProfileFlamechartRouteWithQuery(
+    options.orgSlug,
+    options.projectSlug,
+    profilerId,
+    start.toISOString(),
+    end.toISOString(),
+    query
+  );
+}

--- a/static/app/views/performance/newTraceDetails/traceModels/traceTree.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/traceTree.tsx
@@ -1531,7 +1531,7 @@ export class TraceTreeNode<T extends TraceTree.NodeValue = TraceTree.NodeValue> 
   profiles: TraceTree.Profile[] = [];
 
   multiplier: number;
-  space: [number, number] | null = null;
+  space: [number, number] = [0, 0];
 
   private unit = 'milliseconds' as const;
   private _depth: number | undefined;
@@ -1545,7 +1545,13 @@ export class TraceTreeNode<T extends TraceTree.NodeValue = TraceTree.NodeValue> 
     this.metadata = metadata;
     this.multiplier = this.unit === 'milliseconds' ? 1e3 : 1;
 
-    if (value && 'timestamp' in value && 'start_timestamp' in value) {
+    if (
+      value &&
+      'timestamp' in value &&
+      'start_timestamp' in value &&
+      typeof value.timestamp === 'number' &&
+      typeof value.start_timestamp === 'number'
+    ) {
       this.space = [
         value.start_timestamp * this.multiplier,
         (value.timestamp - value.start_timestamp) * this.multiplier,

--- a/static/app/views/profiling/continuousProfileFlamechart.tsx
+++ b/static/app/views/profiling/continuousProfileFlamechart.tsx
@@ -1,0 +1,7 @@
+interface ContinuousProfileFlamechartProps {}
+
+export function ContinuousProfileFlamechart(
+  _props: ContinuousProfileFlamechartProps
+): React.ReactNode {
+  return null;
+}

--- a/static/app/views/profiling/continuousProfileFlamechart.tsx
+++ b/static/app/views/profiling/continuousProfileFlamechart.tsx
@@ -1,6 +1,6 @@
 interface ContinuousProfileFlamechartProps {}
 
-export function ContinuousProfileFlamechart(
+export default function ContinuousProfileFlamechart(
   _props: ContinuousProfileFlamechartProps
 ): React.ReactNode {
   return null;

--- a/static/app/views/profiling/continuousProfilesProvider.tsx
+++ b/static/app/views/profiling/continuousProfilesProvider.tsx
@@ -1,6 +1,8 @@
 interface ContinuousProfilesProviderProps {
   children: React.ReactNode;
 }
-export function ContinuousProfilesProvider({children}: ContinuousProfilesProviderProps) {
+export default function ContinuousProfilesProvider({
+  children,
+}: ContinuousProfilesProviderProps) {
   return children;
 }

--- a/static/app/views/profiling/continuousProfilesProvider.tsx
+++ b/static/app/views/profiling/continuousProfilesProvider.tsx
@@ -1,0 +1,6 @@
+interface ContinuousProfilesProviderProps {
+  children: React.ReactNode;
+}
+export function ContinuousProfilesProvider({children}: ContinuousProfilesProviderProps) {
+  return children;
+}


### PR DESCRIPTION
Since we conveniently already create start and end timestamps for all tree nodes so that we can place them on a timeline, just piggyback off that logic for a start/end params when linking to events on a continuous profiling trace. 

If an event is a 0 duration event (like for example some errors), just create a window of 100ms before and after the event. Tbd how useful errors are for profiles anyways, but it wont hurt if we can at least keep the UI consistent with showing the view profile button