### PR TITLE
Add ability to get options if project has a template

### DIFF
--- a/src/sentry/models/options/project_option.py
+++ b/src/sentry/models/options/project_option.py
@@ -152,6 +152,9 @@ class ProjectOptionManager(OptionManager["ProjectOption"]):
     def post_delete(self, instance: ProjectOption, **kwargs: Any) -> None:
         self.reload_cache(instance.project_id, "projectoption.post_delete")
 
+    def isset(self, project: Project, key: str) -> bool:
+        return self.get_value(project, key, default=Ellipsis) is not Ellipsis
+
 
 @region_silo_model
 class ProjectOption(Model):

--- a/src/sentry/models/project.py
+++ b/src/sentry/models/project.py
@@ -418,9 +418,9 @@ class Project(Model, PendingDeletionMixin):
         self, key: str, default: Any | None = None, validate: Callable[[object], bool] | None = None
     ) -> Any:
         # don't pass the default, we need to check the template if it doesn't exist
-        option = self.option_manager.get_value(self, key, None, validate)
+        option = self.option_manager.get_value(self, key, default, validate)
 
-        if option is None and self.template is not None:
+        if option == default and self.template is not None:
             return self.template_manager.get_value(self.template, key, default, validate)
 
         # check if the option is set, if not return the default

--- a/src/sentry/models/project.py
+++ b/src/sentry/models/project.py
@@ -417,14 +417,11 @@ class Project(Model, PendingDeletionMixin):
     def get_option(
         self, key: str, default: Any | None = None, validate: Callable[[object], bool] | None = None
     ) -> Any:
-        # don't pass the default, we need to check the template if it doesn't exist
-        option = self.option_manager.get_value(self, key, default, validate)
-
-        if option == default and self.template is not None:
+        # if the option is not set, check the template
+        if not self.option_manager.isset(self, key) and self.template is not None:
             return self.template_manager.get_value(self.template, key, default, validate)
 
-        # check if the option is set, if not return the default
-        return default if option is None else option
+        return self.option_manager.get_value(self, key, default, validate)
 
     def update_option(self, key: str, value: Any) -> bool:
         projectoptions.update_rev_for_option(self)

--- a/src/sentry/projectoptions/manager.py
+++ b/src/sentry/projectoptions/manager.py
@@ -59,9 +59,7 @@ class ProjectOptionsManager:
         return project.get_option(key, default=Ellipsis) is not Ellipsis
 
     def get(self, project, key, default=None, validate=None):
-        from sentry.models.options.project_option import ProjectOption
-
-        return ProjectOption.objects.get_value(project, key, default, validate=validate)
+        return project.get_option(key, default=default, validate=validate)
 
     def delete(self, project, key):
         from sentry.models.options.project_option import ProjectOption

--- a/src/sentry/testutils/factories.py
+++ b/src/sentry/testutils/factories.py
@@ -118,6 +118,7 @@ from sentry.models.platformexternalissue import PlatformExternalIssue
 from sentry.models.project import Project
 from sentry.models.projectbookmark import ProjectBookmark
 from sentry.models.projectcodeowners import ProjectCodeOwners
+from sentry.models.projecttemplate import ProjectTemplate
 from sentry.models.release import Release
 from sentry.models.releasecommit import ReleaseCommit
 from sentry.models.releaseenvironment import ReleaseEnvironment
@@ -492,6 +493,17 @@ class Factories:
                     project=project, user=AnonymousUser(), default_rules=True, sender=Factories
                 )
         return project
+
+    @staticmethod
+    @assume_test_silo_mode(SiloMode.REGION)
+    def create_project_template(project=None, organization=None, **kwargs) -> ProjectTemplate:
+        if not kwargs.get("name"):
+            kwargs["name"] = petname.generate(2, " ", letters=10).title()
+
+        with transaction.atomic(router.db_for_write(Project)):
+            project_template = ProjectTemplate.objects.create(organization=organization, **kwargs)
+
+        return project_template
 
     @staticmethod
     @assume_test_silo_mode(SiloMode.REGION)

--- a/src/sentry/testutils/fixtures.py
+++ b/src/sentry/testutils/fixtures.py
@@ -20,8 +20,8 @@ from sentry.models.organization import Organization
 from sentry.models.organizationmember import OrganizationMember
 from sentry.models.organizationmemberteam import OrganizationMemberTeam
 from sentry.models.project import Project
-from sentry.models.rule import Rule
 from sentry.models.projecttemplate import ProjectTemplate
+from sentry.models.rule import Rule
 from sentry.models.user import User
 from sentry.monitors.models import Monitor, MonitorType, ScheduleType
 from sentry.organizations.services.organization import RpcOrganization

--- a/src/sentry/testutils/fixtures.py
+++ b/src/sentry/testutils/fixtures.py
@@ -21,6 +21,7 @@ from sentry.models.organizationmember import OrganizationMember
 from sentry.models.organizationmemberteam import OrganizationMemberTeam
 from sentry.models.project import Project
 from sentry.models.rule import Rule
+from sentry.models.projecttemplate import ProjectTemplate
 from sentry.models.user import User
 from sentry.monitors.models import Monitor, MonitorType, ScheduleType
 from sentry.organizations.services.organization import RpcOrganization
@@ -165,6 +166,9 @@ class Fixtures:
         if "teams" not in kwargs:
             kwargs["teams"] = [self.team]
         return Factories.create_project(**kwargs)
+
+    def create_project_template(self, **kwargs) -> ProjectTemplate:
+        return Factories.create_project_template(**kwargs)
 
     def create_project_bookmark(self, project=None, *args, **kwargs):
         if project is None:

--- a/tests/sentry/models/test_project.py
+++ b/tests/sentry/models/test_project.py
@@ -6,6 +6,8 @@ from sentry.models.environment import Environment, EnvironmentProject
 from sentry.models.grouplink import GroupLink
 from sentry.models.integrations.external_issue import ExternalIssue
 from sentry.models.notificationsettingoption import NotificationSettingOption
+from sentry.models.options.project_option import ProjectOption
+from sentry.models.options.project_template_option import ProjectTemplateOption
 from sentry.models.options.user_option import UserOption
 from sentry.models.organizationmember import OrganizationMember
 from sentry.models.organizationmemberteam import OrganizationMemberTeam
@@ -405,6 +407,55 @@ class ProjectTest(APITestCase, TestCase):
         alert_rule.refresh_from_db()
         assert alert_rule.team_id is None
         assert alert_rule.user_id is None
+
+
+class ProjectSettings(TestCase):
+    def setUp(self):
+        super().setUp()
+        self.option_key = "sentry:test_data"
+        self.project = self.create_project()
+
+        self.project_template = self.create_project_template(organization=self.project.organization)
+        self.project.template = self.project_template
+
+    def tearDown(self):
+        super().tearDown()
+
+        self.project_template.delete()
+        self.project.delete()
+
+    def test_get_option(self):
+        assert self.project.get_option(self.option_key) is None
+        ProjectOption.objects.set_value(self.project, self.option_key, True)
+        assert self.project.get_option(self.option_key) is True
+
+    def test_get_template_option(self):
+        assert self.project.get_option(self.option_key) is None
+        ProjectTemplateOption.objects.set_value(self.project_template, self.option_key, "test")
+        assert self.project.get_option(self.option_key) == "test"
+
+    def test_get_option__overide_template(self):
+        assert self.project.get_option(self.option_key) is None
+        ProjectOption.objects.set_value(self.project, self.option_key, True)
+        ProjectTemplateOption.objects.set_value(self.project_template, self.option_key, "test")
+
+        assert self.project.get_option(self.option_key) is True
+
+    def test_get_option__without_template(self):
+        self.project.template = None
+        assert self.project.get_option(self.option_key) is None
+        ProjectTemplateOption.objects.set_value(self.project_template, self.option_key, "test")
+
+        assert self.project.get_option(self.option_key) is None
+
+    def test_get_option__without_template_and_value(self):
+        self.project.template = None
+        assert self.project.get_option(self.option_key) is None
+
+        ProjectOption.objects.set_value(self.project, self.option_key, True)
+        ProjectTemplateOption.objects.set_value(self.project_template, self.option_key, "test")
+
+        assert self.project.get_option(self.option_key) is True
 
 
 class CopyProjectSettingsTest(TestCase):

--- a/tests/sentry/models/test_project.py
+++ b/tests/sentry/models/test_project.py
@@ -409,7 +409,20 @@ class ProjectTest(APITestCase, TestCase):
         assert alert_rule.user_id is None
 
 
-class ProjectSettings(TestCase):
+class ProjectOptionsTests(TestCase):
+    """
+    These tests validate that the project model well correctly merge the
+    options from the project and the project template.
+
+    When returning getting options for a project the following hierarchy is used:
+    - Project
+    - Project Template
+    - Default
+
+    If a project has a template option set, it will override the default.
+    If a project has an option set, it will override the template option.
+    """
+
     def setUp(self):
         super().setUp()
         self.option_key = "sentry:test_data"
@@ -434,7 +447,7 @@ class ProjectSettings(TestCase):
         ProjectTemplateOption.objects.set_value(self.project_template, self.option_key, "test")
         assert self.project.get_option(self.option_key) == "test"
 
-    def test_get_option__overide_template(self):
+    def test_get_option__override_template(self):
         assert self.project.get_option(self.option_key) is None
         ProjectOption.objects.set_value(self.project, self.option_key, True)
         ProjectTemplateOption.objects.set_value(self.project_template, self.option_key, "test")

--- a/tests/sentry/models/test_project.py
+++ b/tests/sentry/models/test_project.py
@@ -411,7 +411,7 @@ class ProjectTest(APITestCase, TestCase):
 
 class ProjectOptionsTests(TestCase):
     """
-    These tests validate that the project model well correctly merge the
+    These tests validate that the project model will correctly merge the
     options from the project and the project template.
 
     When returning getting options for a project the following hierarchy is used:

--- a/tests/sentry/projectoptions/test_basic.py
+++ b/tests/sentry/projectoptions/test_basic.py
@@ -1,6 +1,8 @@
 from unittest import mock
 
 from sentry.models.options.project_option import ProjectOption
+from sentry.models.options.project_template_option import ProjectTemplateOption
+from sentry.models.projecttemplate import ProjectTemplate
 from sentry.projectoptions import default_manager, defaults
 from sentry.projectoptions.manager import WellKnownProjectOption
 from sentry.testutils.pytest.fixtures import django_db_all
@@ -71,3 +73,21 @@ def test_isset_differentiates_unset_from_set_to_default(default_project):
     default_project.update_option("best_dogs", "all dogs")
     assert default_project.get_option("best_dogs") == "all dogs"
     assert default_manager.isset(default_project, "best_dogs") is True
+
+
+@django_db_all
+def test_project_template_options(default_project):
+    default_manager.register("test_option", default="default")
+    assert default_project.get_option("test_option") == "default"
+
+    template = ProjectTemplate.objects.create(
+        name="Test Template",
+        organization=default_project.organization,
+        project=default_project,
+    )
+
+    default_project.template = template
+    ProjectTemplateOption.objects.create(
+        project_template=template, key="test_option", value="template"
+    )
+    assert default_project.get_option("test_option") == "template"


### PR DESCRIPTION
# Descriptions
Add a `template_manager` which mimics the `option_manager`, except with templated values. When using `get_value` from a project, this will now check for a template association. if there is a template and there isn't an option set, check to see if the template has that option.

[Tech spec](https://www.notion.so/sentry/Service-Settings-Templates-ca6fdb38b15f4a6db61d319bc342b86c?pvs=4#2f0d1c466f684c9aa735224e854ecf1d)