### PR TITLE
feat(relay): Expose metric extrapolation config

### DIFF
--- a/src/sentry/relay/config/metric_extraction.py
+++ b/src/sentry/relay/config/metric_extraction.py
@@ -126,7 +126,7 @@ def get_metric_extraction_config(
     }
 
 
-def get_extrapolation_config(project):
+def get_extrapolation_config(project: Project) -> object:
     if not features.has("organizations:metrics-extrapolation", project.organization):
         return {}
 

--- a/tests/sentry/relay/test_config.py
+++ b/tests/sentry/relay/test_config.py
@@ -743,6 +743,7 @@ def test_alert_metric_extraction_rules(default_project, factories):
                     "tags": [{"key": "query_hash", "value": ANY}],
                 }
             ],
+            "extrapolate": {},
         }
 
         normalized = normalize_project_config(config)

--- a/tests/sentry/relay/test_config.py
+++ b/tests/sentry/relay/test_config.py
@@ -743,7 +743,6 @@ def test_alert_metric_extraction_rules(default_project, factories):
                     "tags": [{"key": "query_hash", "value": ANY}],
                 }
             ],
-            "extrapolate": {},
         }
 
         normalized = normalize_project_config(config)


### PR DESCRIPTION
Exposes feature-flagged options for metrics extrapolation to Relay. See
https://github.com/getsentry/relay/pull/3753 for Relay-side implementation.

Closes #73623

