### PR TITLE
feat(metrics-extraction): Introduce virtual metrics

### DIFF
--- a/static/app/components/metrics/queryBuilder.tsx
+++ b/static/app/components/metrics/queryBuilder.tsx
@@ -17,7 +17,7 @@ import {getDefaultAggregation, isAllowedAggregation} from 'sentry/utils/metrics'
 import {parseMRI} from 'sentry/utils/metrics/mri';
 import type {MetricsQuery} from 'sentry/utils/metrics/types';
 import {useIncrementQueryMetric} from 'sentry/utils/metrics/useIncrementQueryMetric';
-import {useMetricsMeta} from 'sentry/utils/metrics/useMetricsMeta';
+import {useVirtualizedMetricsMeta} from 'sentry/utils/metrics/useMetricsMeta';
 import {useMetricsTags} from 'sentry/utils/metrics/useMetricsTags';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
@@ -43,7 +43,7 @@ export const QueryBuilder = memo(function QueryBuilder({
     isLoading: isMetaLoading,
     isRefetching: isMetaRefetching,
     refetch: refetchMeta,
-  } = useMetricsMeta(pageFilters.selection);
+  } = useVirtualizedMetricsMeta(pageFilters.selection);
 
   const {data: tagsData = [], isLoading: tagsIsLoading} = useMetricsTags(
     metricsQuery.mri,

--- a/static/app/types/metrics.tsx
+++ b/static/app/types/metrics.tsx
@@ -12,7 +12,16 @@ export type MetricAggregation =
   | 'p95'
   | 'p99';
 
-export type MetricType = 'c' | 'd' | 'g' | 'e' | 's';
+export type MetricType =
+  | 'c'
+  | 'd'
+  | 'g'
+  | 'e'
+  | 's'
+  // Virtual metrics combine multiple metrics into one, to hide the internal complexity
+  // of span based metrics.
+  // Created and used only in the frontend
+  | 'v';
 
 export type UseCase = 'custom' | 'transactions' | 'sessions' | 'spans' | 'metric_stats';
 

--- a/static/app/utils/metrics/formatters.tsx
+++ b/static/app/utils/metrics/formatters.tsx
@@ -17,7 +17,7 @@ import {
 } from 'sentry/utils/formatters';
 import {formatNumberWithDynamicDecimalPoints} from 'sentry/utils/number/formatNumberWithDynamicDecimalPoints';
 
-const metricTypeToReadable: Record<MetricType, string> = {
+const metricTypeToReadable: Record<Exclude<MetricType, 'v'>, string> = {
   c: t('counter'),
   g: t('gauge'),
   d: t('distribution'),

--- a/static/app/utils/metrics/index.spec.tsx
+++ b/static/app/utils/metrics/index.spec.tsx
@@ -7,6 +7,7 @@ import {
   getDefaultAggregation,
   getFormattedMQL,
   getMetricsInterval,
+  isExtractedCustomMetric,
   isFormattedMQL,
 } from 'sentry/utils/metrics';
 import {DEFAULT_AGGREGATES} from 'sentry/utils/metrics/constants';
@@ -86,6 +87,22 @@ describe('getFormattedMQL', () => {
     });
 
     expect(result).toEqual('');
+  });
+});
+
+describe('isExtractedCustomMetric', () => {
+  it('should return true if the metric name is prefixed', () => {
+    expect(isExtractedCustomMetric({mri: 'c:custom/span_attribute_123@none'})).toBe(true);
+    expect(isExtractedCustomMetric({mri: 's:custom/span_attribute_foo@none'})).toBe(true);
+    expect(isExtractedCustomMetric({mri: 'd:custom/span_attribute_bar@none'})).toBe(true);
+    expect(isExtractedCustomMetric({mri: 'g:custom/span_attribute_baz@none'})).toBe(true);
+  });
+
+  it('should return false if the metric name is not prefixed', () => {
+    expect(isExtractedCustomMetric({mri: 'c:custom/12span_attribute_@none'})).toBe(false);
+    expect(isExtractedCustomMetric({mri: 's:custom/foo@none'})).toBe(false);
+    expect(isExtractedCustomMetric({mri: 'd:custom/_span_attribute_@none'})).toBe(false);
+    expect(isExtractedCustomMetric({mri: 'g:custom/span_attributebaz@none'})).toBe(false);
   });
 });
 

--- a/static/app/utils/metrics/index.tsx
+++ b/static/app/utils/metrics/index.tsx
@@ -332,6 +332,11 @@ export function isCustomMetric({mri}: {mri: MRI}) {
   return mri.includes(':custom/');
 }
 
+export function isExtractedCustomMetric({mri}: {mri: MRI}) {
+  // Extraced metrics are prefixed with `span_attribute_`
+  return mri.substring(1).startsWith(':custom/span_attribute_');
+}
+
 export function isSpanDuration({mri}: {mri: MRI}) {
   return mri === 'd:spans/duration@millisecond';
 }

--- a/static/app/utils/metrics/virtualMetricsContext.tsx
+++ b/static/app/utils/metrics/virtualMetricsContext.tsx
@@ -1,0 +1,21 @@
+import {createContext, useContext} from 'react';
+
+import type {MetricMeta, MRI} from 'sentry/types/metrics';
+
+const Context = createContext<{
+  getVirtualMRI: (mri: MRI) => MRI | null;
+  getVirtualMeta: (mri: MRI) => MetricMeta;
+  isLoading: boolean;
+}>({
+  getVirtualMRI: () => null,
+  getVirtualMeta: () => {
+    throw new Error('Not implemented');
+  },
+  isLoading: false,
+});
+
+export function useVirtualMetricsContext() {
+  return useContext(Context);
+}
+
+// TODO(aknaus): Write a provider

--- a/static/app/views/alerts/rules/metric/mriField.tsx
+++ b/static/app/views/alerts/rules/metric/mriField.tsx
@@ -16,7 +16,7 @@ import {
   parseField,
   parseMRI,
 } from 'sentry/utils/metrics/mri';
-import {useMetricsMeta} from 'sentry/utils/metrics/useMetricsMeta';
+import {useVirtualizedMetricsMeta} from 'sentry/utils/metrics/useMetricsMeta';
 import {middleEllipsis} from 'sentry/utils/string/middleEllipsis';
 
 interface Props {
@@ -30,9 +30,10 @@ function filterAndSortAggregations(aggregations: MetricAggregation[]) {
 }
 
 function MriField({aggregate, project, onChange}: Props) {
-  const {data: meta, isLoading} = useMetricsMeta({projects: [parseInt(project.id, 10)]}, [
-    'custom',
-  ]);
+  const {data: meta, isLoading} = useVirtualizedMetricsMeta(
+    {projects: [parseInt(project.id, 10)]},
+    ['custom']
+  );
 
   const metaArr = useMemo(() => {
     return meta.map(

--- a/static/app/views/settings/projectMetrics/customMetricsTable.tsx
+++ b/static/app/views/settings/projectMetrics/customMetricsTable.tsx
@@ -13,6 +13,7 @@ import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {MetricMeta} from 'sentry/types/metrics';
 import type {Project} from 'sentry/types/project';
+import {isExtractedCustomMetric} from 'sentry/utils/metrics';
 import {DEFAULT_METRICS_CARDINALITY_LIMIT} from 'sentry/utils/metrics/constants';
 import {hasCustomMetricsExtractionRules} from 'sentry/utils/metrics/features';
 import {getReadableMetricType} from 'sentry/utils/metrics/formatters';
@@ -59,11 +60,14 @@ export function CustomMetricsTable({project}: Props) {
       return [];
     }
 
+    // Do not show internal extracted metrics in this table
+    const filteredMeta = metricsMeta.data.filter(meta => !isExtractedCustomMetric(meta));
+
     if (!metricsCardinality.data) {
-      return metricsMeta.data.map(meta => ({...meta, cardinality: 0}));
+      return filteredMeta.map(meta => ({...meta, cardinality: 0}));
     }
 
-    return metricsMeta.data
+    return filteredMeta
       .map(({mri, ...rest}) => {
         return {
           mri,


### PR DESCRIPTION
Add the metrics type `v`
Add a new hook `useVirtualizedMetricsMeta` to fetch metric meta and map span based metrics to virtual ones.
Add a stub implementation of the virtual metrics context.

### Background

Introduce virtual metrics as a concept to hide the internal complexity of span-based metrics from the user.
The additional metric type `v` (virtual) can be used to distinguish them from other metrics. Via a context provider (still TODO) we will be able to inject callbacks to map between virtual metrics and span-based metrics wherever necessary.

Part of https://github.com/getsentry/sentry/issues/73418
