### PR TITLE
ref(api): Migrate `configure_scope` in `src/sentry/api/bases/`

### DIFF
--- a/src/sentry/api/bases/doc_integrations.py
+++ b/src/sentry/api/bases/doc_integrations.py
@@ -11,7 +11,7 @@ from sentry.api.permissions import SentryPermission, StaffPermissionMixin
 from sentry.api.validators.doc_integration import METADATA_PROPERTIES
 from sentry.auth.superuser import is_active_superuser
 from sentry.models.integrations.doc_integration import DocIntegration
-from sentry.utils.sdk import configure_scope
+from sentry.utils.sdk import Scope
 
 
 class DocIntegrationsPermission(SentryPermission):
@@ -88,8 +88,7 @@ class DocIntegrationBaseEndpoint(DocIntegrationsBaseEndpoint):
 
         self.check_object_permissions(request, doc_integration)
 
-        with configure_scope() as scope:
-            scope.set_tag("doc_integration", doc_integration.slug)
+        Scope.get_isolation_scope().set_tag("doc_integration", doc_integration.slug)
 
         kwargs["doc_integration"] = doc_integration
         return (args, kwargs)

--- a/src/sentry/api/bases/group.py
+++ b/src/sentry/api/bases/group.py
@@ -12,7 +12,7 @@ from sentry.models.group import Group, GroupStatus, get_group_with_redirect
 from sentry.models.grouplink import GroupLink
 from sentry.models.organization import Organization
 from sentry.tasks.integrations import create_comment, update_comment
-from sentry.utils.sdk import bind_organization_context, configure_scope
+from sentry.utils.sdk import Scope, bind_organization_context
 
 logger = logging.getLogger(__name__)
 
@@ -78,8 +78,7 @@ class GroupEndpoint(Endpoint):
 
         self.check_object_permissions(request, group)
 
-        with configure_scope() as scope:
-            scope.set_tag("project", group.project_id)
+        Scope.get_isolation_scope().set_tag("project", group.project_id)
 
         # we didn't bind context above, so do it now
         if not organization:

--- a/src/sentry/api/bases/project.py
+++ b/src/sentry/api/bases/project.py
@@ -6,7 +6,6 @@ from typing import Any
 from rest_framework.permissions import BasePermission
 from rest_framework.request import Request
 from rest_framework.response import Response
-from sentry_sdk import Scope
 
 from sentry.api.base import Endpoint
 from sentry.api.exceptions import ProjectMoved, ResourceDoesNotExist
@@ -17,7 +16,7 @@ from sentry.constants import ObjectStatus
 from sentry.exceptions import InvalidParams
 from sentry.models.project import Project
 from sentry.models.projectredirect import ProjectRedirect
-from sentry.utils.sdk import bind_organization_context, configure_scope
+from sentry.utils.sdk import Scope, bind_organization_context
 
 from .organization import OrganizationPermission
 
@@ -175,8 +174,7 @@ class ProjectEndpoint(Endpoint):
 
         self.check_object_permissions(request, project)
 
-        with configure_scope() as scope:
-            scope.set_tag("project", project.id)
+        Scope.get_isolation_scope().set_tag("project", project.id)
 
         bind_organization_context(project.organization)
 

--- a/src/sentry/api/bases/sentryapps.py
+++ b/src/sentry/api/bases/sentryapps.py
@@ -28,7 +28,7 @@ from sentry.services.hybrid_cloud.organization import (
 )
 from sentry.services.hybrid_cloud.user import RpcUser
 from sentry.services.hybrid_cloud.user.service import user_service
-from sentry.utils.sdk import configure_scope
+from sentry.utils.sdk import Scope
 from sentry.utils.strings import to_single_line_str
 
 COMPONENT_TYPES = ["stacktrace-link", "issue-link"]
@@ -262,8 +262,7 @@ class SentryAppBaseEndpoint(IntegrationPlatformEndpoint):
 
         self.check_object_permissions(request, sentry_app)
 
-        with configure_scope() as scope:
-            scope.set_tag("sentry_app", sentry_app.slug)
+        Scope.get_isolation_scope().set_tag("sentry_app", sentry_app.slug)
 
         kwargs["sentry_app"] = sentry_app
         return (args, kwargs)
@@ -282,8 +281,7 @@ class RegionSentryAppBaseEndpoint(IntegrationPlatformEndpoint):
 
         self.check_object_permissions(request, sentry_app)
 
-        with configure_scope() as scope:
-            scope.set_tag("sentry_app", sentry_app.slug)
+        Scope.get_isolation_scope().set_tag("sentry_app", sentry_app.slug)
 
         kwargs["sentry_app"] = sentry_app
         return (args, kwargs)
@@ -406,8 +404,7 @@ class SentryAppInstallationBaseEndpoint(IntegrationPlatformEndpoint):
 
         self.check_object_permissions(request, installation)
 
-        with configure_scope() as scope:
-            scope.set_tag("sentry_app_installation", installation.uuid)
+        Scope.get_isolation_scope().set_tag("sentry_app_installation", installation.uuid)
 
         kwargs["installation"] = installation
         return (args, kwargs)


### PR DESCRIPTION
Replace deprecated `configure_scope` with new `Scope.get_isolation_scope()` API from Sentry SDK 2.0

ref #73430
