### PR TITLE
ref(api): Migrate `configure_scope` in `OrganizationReleases` endpoint

### DIFF
--- a/src/sentry/api/endpoints/organization_releases.py
+++ b/src/sentry/api/endpoints/organization_releases.py
@@ -46,7 +46,7 @@ from sentry.signals import release_created
 from sentry.snuba.sessions import STATS_PERIODS
 from sentry.types.activity import ActivityType
 from sentry.utils.cache import cache
-from sentry.utils.sdk import bind_organization_context, configure_scope
+from sentry.utils.sdk import Scope, bind_organization_context
 
 ERR_INVALID_STATS_PERIOD = "Invalid %s. Valid choices are %s"
 
@@ -459,132 +459,130 @@ class OrganizationReleasesEndpoint(
             data=request.data, context={"organization": organization}
         )
 
-        with configure_scope() as scope:
-            if serializer.is_valid():
-                result = serializer.validated_data
-                scope.set_tag("version", result["version"])
+        scope = Scope.get_isolation_scope()
+        if serializer.is_valid():
+            result = serializer.validated_data
+            scope.set_tag("version", result["version"])
 
-                allowed_projects = {p.slug: p for p in self.get_projects(request, organization)}
+            allowed_projects = {p.slug: p for p in self.get_projects(request, organization)}
 
-                projects = []
-                for slug in result["projects"]:
-                    if slug not in allowed_projects:
-                        return Response({"projects": ["Invalid project slugs"]}, status=400)
-                    projects.append(allowed_projects[slug])
+            projects = []
+            for slug in result["projects"]:
+                if slug not in allowed_projects:
+                    return Response({"projects": ["Invalid project slugs"]}, status=400)
+                projects.append(allowed_projects[slug])
 
-                new_status = result.get("status")
-                owner_id: int | None = None
-                if owner := result.get("owner"):
-                    owner_id = owner.id
+            new_status = result.get("status")
+            owner_id: int | None = None
+            if owner := result.get("owner"):
+                owner_id = owner.id
 
-                # release creation is idempotent to simplify user
-                # experiences
-                created = False
-                try:
-                    release, created = Release.objects.get_or_create(
-                        organization_id=organization.id,
-                        version=result["version"],
-                        defaults={
-                            "ref": result.get("ref"),
-                            "url": result.get("url"),
-                            "owner_id": owner_id,
-                            "date_released": result.get("dateReleased"),
-                            "status": new_status or ReleaseStatus.OPEN,
-                            "user_agent": request.META.get("HTTP_USER_AGENT", "")[:256],
-                        },
-                    )
-                except IntegrityError:
-                    raise ConflictError(
-                        "Could not create the release it conflicts with existing data",
-                    )
-                if created:
-                    release_created.send_robust(release=release, sender=self.__class__)
-
-                if not created and new_status is not None and new_status != release.status:
-                    release.status = new_status
-                    release.save()
-
-                new_releaseprojects = []
-                for project in projects:
-                    _, releaseproject_created = release.add_project(project)
-                    if releaseproject_created:
-                        new_releaseprojects.append(project)
-
-                if release.date_released:
-                    for project in new_releaseprojects:
-                        Activity.objects.create(
-                            type=ActivityType.RELEASE.value,
-                            project=project,
-                            ident=Activity.get_version_ident(result["version"]),
-                            data={"version": result["version"]},
-                            datetime=release.date_released,
-                        )
-
-                commit_list = result.get("commits")
-                if commit_list:
-                    try:
-                        release.set_commits(commit_list)
-                        self.track_set_commits_local(
-                            request,
-                            organization_id=organization.id,
-                            project_ids=[project.id for project in projects],
-                        )
-                    except ReleaseCommitError:
-                        raise ConflictError("Release commits are currently being processed")
-
-                refs = result.get("refs")
-                if not refs:
-                    refs = [
-                        {
-                            "repository": r["repository"],
-                            "previousCommit": r.get("previousId"),
-                            "commit": r["currentId"],
-                        }
-                        for r in result.get("headCommits", [])
-                    ]
-                scope.set_tag("has_refs", bool(refs))
-                if refs:
-                    if not request.user.is_authenticated and not request.auth:
-                        scope.set_tag("failure_reason", "user_not_authenticated")
-                        return Response(
-                            {"refs": ["You must use an authenticated API token to fetch refs"]},
-                            status=400,
-                        )
-                    fetch_commits = not commit_list
-                    try:
-                        release.set_refs(refs, request.user.id, fetch=fetch_commits)
-                    except InvalidRepository as e:
-                        scope.set_tag("failure_reason", "InvalidRepository")
-                        return Response({"refs": [str(e)]}, status=400)
-
-                if not created and not new_releaseprojects:
-                    # This is the closest status code that makes sense, and we want
-                    # a unique 2xx response code so people can understand when
-                    # behavior differs.
-                    #   208 Already Reported (WebDAV; RFC 5842)
-                    status = 208
-                else:
-                    status = 201
-
-                analytics.record(
-                    "release.created",
-                    user_id=request.user.id if request.user and request.user.id else None,
+            # release creation is idempotent to simplify user
+            # experiences
+            created = False
+            try:
+                release, created = Release.objects.get_or_create(
                     organization_id=organization.id,
-                    project_ids=[project.id for project in projects],
-                    user_agent=request.META.get("HTTP_USER_AGENT", ""),
-                    created_status=status,
-                    auth_type=get_auth_api_token_type(request.auth),
+                    version=result["version"],
+                    defaults={
+                        "ref": result.get("ref"),
+                        "url": result.get("url"),
+                        "owner_id": owner_id,
+                        "date_released": result.get("dateReleased"),
+                        "status": new_status or ReleaseStatus.OPEN,
+                        "user_agent": request.META.get("HTTP_USER_AGENT", "")[:256],
+                    },
                 )
+            except IntegrityError:
+                raise ConflictError(
+                    "Could not create the release it conflicts with existing data",
+                )
+            if created:
+                release_created.send_robust(release=release, sender=self.__class__)
 
-                if is_org_auth_token_auth(request.auth):
-                    update_org_auth_token_last_used(
-                        request.auth, [project.id for project in projects]
+            if not created and new_status is not None and new_status != release.status:
+                release.status = new_status
+                release.save()
+
+            new_releaseprojects = []
+            for project in projects:
+                _, releaseproject_created = release.add_project(project)
+                if releaseproject_created:
+                    new_releaseprojects.append(project)
+
+            if release.date_released:
+                for project in new_releaseprojects:
+                    Activity.objects.create(
+                        type=ActivityType.RELEASE.value,
+                        project=project,
+                        ident=Activity.get_version_ident(result["version"]),
+                        data={"version": result["version"]},
+                        datetime=release.date_released,
                     )
 
-                scope.set_tag("success_status", status)
-                return Response(serialize(release, request.user), status=status)
-            scope.set_tag("failure_reason", "serializer_error")
-            return Response(serializer.errors, status=400)
+            commit_list = result.get("commits")
+            if commit_list:
+                try:
+                    release.set_commits(commit_list)
+                    self.track_set_commits_local(
+                        request,
+                        organization_id=organization.id,
+                        project_ids=[project.id for project in projects],
+                    )
+                except ReleaseCommitError:
+                    raise ConflictError("Release commits are currently being processed")
+
+            refs = result.get("refs")
+            if not refs:
+                refs = [
+                    {
+                        "repository": r["repository"],
+                        "previousCommit": r.get("previousId"),
+                        "commit": r["currentId"],
+                    }
+                    for r in result.get("headCommits", [])
+                ]
+            scope.set_tag("has_refs", bool(refs))
+            if refs:
+                if not request.user.is_authenticated and not request.auth:
+                    scope.set_tag("failure_reason", "user_not_authenticated")
+                    return Response(
+                        {"refs": ["You must use an authenticated API token to fetch refs"]},
+                        status=400,
+                    )
+                fetch_commits = not commit_list
+                try:
+                    release.set_refs(refs, request.user.id, fetch=fetch_commits)
+                except InvalidRepository as e:
+                    scope.set_tag("failure_reason", "InvalidRepository")
+                    return Response({"refs": [str(e)]}, status=400)
+
+            if not created and not new_releaseprojects:
+                # This is the closest status code that makes sense, and we want
+                # a unique 2xx response code so people can understand when
+                # behavior differs.
+                #   208 Already Reported (WebDAV; RFC 5842)
+                status = 208
+            else:
+                status = 201
+
+            analytics.record(
+                "release.created",
+                user_id=request.user.id if request.user and request.user.id else None,
+                organization_id=organization.id,
+                project_ids=[project.id for project in projects],
+                user_agent=request.META.get("HTTP_USER_AGENT", ""),
+                created_status=status,
+                auth_type=get_auth_api_token_type(request.auth),
+            )
+
+            if is_org_auth_token_auth(request.auth):
+                update_org_auth_token_last_used(request.auth, [project.id for project in projects])
+
+            scope.set_tag("success_status", status)
+            return Response(serialize(release, request.user), status=status)
+        scope.set_tag("failure_reason", "serializer_error")
+        return Response(serializer.errors, status=400)
 
 
 @region_silo_endpoint


### PR DESCRIPTION
Replace deprecated `configure_scope` with new `Scope.get_isolation_scope()` API from Sentry SDK 2.0

ref #73430
