### PR TITLE
fix(metrics) do not allow generic metric without operation

### DIFF
--- a/src/sentry/api/endpoints/organization_release_health_data.py
+++ b/src/sentry/api/endpoints/organization_release_health_data.py
@@ -11,6 +11,7 @@ from sentry.exceptions import InvalidParams
 from sentry.sentry_metrics.use_case_utils import get_use_case_id
 from sentry.snuba.metrics import DerivedMetricException, QueryDefinition, get_series
 from sentry.snuba.metrics.naming_layer import SessionMetricKey
+from sentry.snuba.metrics.query_builder import parse_field
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
 from sentry.utils import metrics
 from sentry.utils.cursors import Cursor, CursorResult
@@ -44,8 +45,35 @@ class OrganizationReleaseHealthDataEndpoint(OrganizationEndpoint):
     # Number of groups returned for each page (applies to old endpoint).
     default_per_page = 50
 
+    def _validate_fields(self, request: Request):
+        """
+        Validates fields request parameter.
+        Checks if metric field is public (InvalidParams exception is raised if it is not),
+        and checks if every generic metric that is requested has operation assigned, because
+        it is not possible to query generic metrics without assigned operation.
+
+        NOTE 'd:sessions/duration.exited@second' is a derived metric but for unknown
+        reason entity is not 'e', so we do extra check just for that metric.
+        """
+        fields = request.GET.getlist("field", [])
+        for field in fields:
+            try:
+                metric_field = parse_field(field, allow_mri=True)
+                if (
+                    metric_field.op is None
+                    and not metric_field.metric_mri.startswith("e:")
+                    and metric_field.metric_mri
+                    != "d:sessions/duration.exited@second"  # this is special case, derived metric without 'e' as entity
+                ):
+                    raise ParseError(
+                        detail="You can not use generic metric public field without operation"
+                    )
+            except InvalidParams as exc:
+                raise ParseError(detail=str(exc))
+
     def get(self, request: Request, organization) -> Response:
         projects = self.get_projects(request, organization)
+        self._validate_fields(request)
 
         def data_fn(offset: int, limit: int):
             try:

--- a/tests/sentry/api/endpoints/test_organization_release_health_data.py
+++ b/tests/sentry/api/endpoints/test_organization_release_health_data.py
@@ -18,6 +18,7 @@ from sentry.snuba.metrics.naming_layer.public import (
     TransactionStatusTagValue,
     TransactionTagsKey,
 )
+from sentry.snuba.metrics.query import MetricField
 from sentry.testutils.cases import MetricsAPIBaseTestCase
 from sentry.testutils.helpers.datetime import freeze_time
 from sentry.utils.cursors import Cursor
@@ -1647,8 +1648,10 @@ class DerivedMetricsDataTest(MetricsAPIBaseTestCase):
     @patch("sentry.snuba.metrics.fields.base.get_public_name_from_mri")
     @patch("sentry.snuba.metrics.query_builder.get_mri")
     @patch("sentry.snuba.metrics.query.get_public_name_from_mri")
+    @patch("sentry.api.endpoints.organization_release_health_data.parse_field")
     def test_derived_metric_incorrectly_defined_as_singular_entity(
         self,
+        mocked_parse_field,
         mocked_get_public_name_from_mri,
         mocked_get_mri_query,
         mocked_reverse_mri,
@@ -1658,6 +1661,8 @@ class DerivedMetricsDataTest(MetricsAPIBaseTestCase):
         mocked_get_mri_query.return_value = "crash_free_fake"
         mocked_reverse_mri.return_value = "crash_free_fake"
         mocked_parse_mri.return_value = ParsedMRI("e", "sessions", "crash_free_fake", "none")
+        mocked_parse_field.return_value = MetricField(None, "e:sessions/crashed_free_fake@none")
+
         for status in ["ok", "crashed"]:
             for minute in range(4):
                 self.build_and_store_session(
@@ -2521,3 +2526,37 @@ class DerivedMetricsDataTest(MetricsAPIBaseTestCase):
         assert group["totals"]["session.crash_rate"] == 1.0  # value is capped at 1.0
         for value in group["series"]["session.crash_rate"]:
             assert value is None or value <= 1
+
+    def test_metric_without_operation_is_not_allowed(self):
+        """
+        Do not allow to query for a metric without operation.
+        For example:
+            - querying for `sentry.sessions.session` is not valid because operation is missing
+            - querying for `sum(sentry.sessions.session)` is valid because operation `sum` exists
+        """
+        self.build_and_store_session(
+            project_id=self.project.id,
+            minutes_before_now=1,
+            status="crashed",
+        )
+
+        response = self.get_error_response(
+            self.organization.slug,
+            field=["sentry.sessions.session"],
+            includeSeries=0,
+            statsPeriod="6m",
+            interval="1m",
+            status_code=400,
+        )
+        result = response.json()
+        assert "detail" in result
+        assert result["detail"] == "You can not use generic metric public field without operation"
+
+        response = self.get_success_response(
+            self.organization.slug,
+            field=["sum(sentry.sessions.session)"],
+            includeSeries=0,
+            statsPeriod="6m",
+            interval="1m",
+        )
+        assert response.status_code == 200


### PR DESCRIPTION
 Do not allow to query for a generic metric without operation.
For example:
    - querying for `sentry.sessions.session` is not valid because operation is missing
    - querying for `sum(sentry.sessions.session)` is valid because operation `sum` exists

Closes https://github.com/getsentry/sentry/issues/73364