### PR TITLE
ref(api): Migrate `configure_scope` in `ProjectReleaseDetails` endpoint

### DIFF
--- a/src/sentry/api/endpoints/project_release_details.py
+++ b/src/sentry/api/endpoints/project_release_details.py
@@ -15,7 +15,7 @@ from sentry.models.releases.exceptions import UnsafeReleaseDeletion
 from sentry.plugins.interfaces.releasehook import ReleaseHook
 from sentry.snuba.sessions import STATS_PERIODS
 from sentry.types.activity import ActivityType
-from sentry.utils.sdk import bind_organization_context, configure_scope
+from sentry.utils.sdk import Scope, bind_organization_context
 
 
 @region_silo_endpoint
@@ -94,58 +94,58 @@ class ProjectReleaseDetailsEndpoint(ProjectEndpoint, ReleaseAnalyticsMixin):
         :auth: required
         """
         bind_organization_context(project.organization)
-        with configure_scope() as scope:
-            scope.set_tag("version", version)
-            try:
-                release = Release.objects.get(
-                    organization_id=project.organization_id, projects=project, version=version
-                )
-            except Release.DoesNotExist:
-                scope.set_tag("failure_reason", "Release.DoesNotExist")
-                raise ResourceDoesNotExist
+        scope = Scope.get_isolation_scope()
+        scope.set_tag("version", version)
+        try:
+            release = Release.objects.get(
+                organization_id=project.organization_id, projects=project, version=version
+            )
+        except Release.DoesNotExist:
+            scope.set_tag("failure_reason", "Release.DoesNotExist")
+            raise ResourceDoesNotExist
 
-            serializer = ReleaseSerializer(data=request.data, partial=True)
+        serializer = ReleaseSerializer(data=request.data, partial=True)
 
-            if not serializer.is_valid():
-                scope.set_tag("failure_reason", "serializer_error")
-                return Response(serializer.errors, status=400)
+        if not serializer.is_valid():
+            scope.set_tag("failure_reason", "serializer_error")
+            return Response(serializer.errors, status=400)
 
-            result = serializer.validated_data
+        result = serializer.validated_data
 
-            was_released = bool(release.date_released)
+        was_released = bool(release.date_released)
 
-            kwargs = {}
-            if result.get("dateReleased"):
-                kwargs["date_released"] = result["dateReleased"]
-            if result.get("ref"):
-                kwargs["ref"] = result["ref"]
-            if result.get("url"):
-                kwargs["url"] = result["url"]
-            if result.get("status"):
-                kwargs["status"] = result["status"]
+        kwargs = {}
+        if result.get("dateReleased"):
+            kwargs["date_released"] = result["dateReleased"]
+        if result.get("ref"):
+            kwargs["ref"] = result["ref"]
+        if result.get("url"):
+            kwargs["url"] = result["url"]
+        if result.get("status"):
+            kwargs["status"] = result["status"]
 
-            if kwargs:
-                release.update(**kwargs)
+        if kwargs:
+            release.update(**kwargs)
 
-            commit_list = result.get("commits")
-            if commit_list:
-                hook = ReleaseHook(project)
-                # TODO(dcramer): handle errors with release payloads
-                hook.set_commits(release.version, commit_list)
-                self.track_set_commits_local(
-                    request, organization_id=project.organization_id, project_ids=[project.id]
-                )
+        commit_list = result.get("commits")
+        if commit_list:
+            hook = ReleaseHook(project)
+            # TODO(dcramer): handle errors with release payloads
+            hook.set_commits(release.version, commit_list)
+            self.track_set_commits_local(
+                request, organization_id=project.organization_id, project_ids=[project.id]
+            )
 
-            if not was_released and release.date_released:
-                Activity.objects.create(
-                    type=ActivityType.RELEASE.value,
-                    project=project,
-                    ident=Activity.get_version_ident(release.version),
-                    data={"version": release.version},
-                    datetime=release.date_released,
-                )
+        if not was_released and release.date_released:
+            Activity.objects.create(
+                type=ActivityType.RELEASE.value,
+                project=project,
+                ident=Activity.get_version_ident(release.version),
+                data={"version": release.version},
+                datetime=release.date_released,
+            )
 
-            return Response(serialize(release, request.user))
+        return Response(serialize(release, request.user))
 
     def delete(self, request: Request, project, version) -> Response:
         """


### PR DESCRIPTION
Replace deprecated `configure_scope` with new `Scope.get_isolation_scope()` API from Sentry SDK 2.0

ref #73430
