### PR TITLE
ref(api): Migrate `configure_scope` in `ProjectReleases` endpoint

### DIFF
--- a/src/sentry/api/endpoints/project_releases.py
+++ b/src/sentry/api/endpoints/project_releases.py
@@ -21,7 +21,7 @@ from sentry.plugins.interfaces.releasehook import ReleaseHook
 from sentry.ratelimits.config import SENTRY_RATELIMITER_GROUP_DEFAULTS, RateLimitConfig
 from sentry.signals import release_created
 from sentry.types.activity import ActivityType
-from sentry.utils.sdk import bind_organization_context, configure_scope
+from sentry.utils.sdk import Scope, bind_organization_context
 
 
 @region_silo_endpoint
@@ -118,96 +118,97 @@ class ProjectReleasesEndpoint(ProjectEndpoint, EnvironmentMixin):
             data=request.data, context={"organization": project.organization}
         )
 
-        with configure_scope() as scope:
-            if serializer.is_valid():
-                result = serializer.validated_data
-                scope.set_tag("version", result["version"])
+        scope = Scope.get_isolation_scope()
 
-                new_status = result.get("status")
+        if serializer.is_valid():
+            result = serializer.validated_data
+            scope.set_tag("version", result["version"])
 
-                # release creation is idempotent to simplify user
-                # experiences
-                owner_id: int | None = None
-                if owner := result.get("owner"):
-                    owner_id = owner.id
+            new_status = result.get("status")
 
-                try:
-                    with transaction.atomic(router.db_for_write(Release)):
-                        release, created = (
-                            Release.objects.create(
-                                organization_id=project.organization_id,
-                                version=result["version"],
-                                ref=result.get("ref"),
-                                url=result.get("url"),
-                                owner_id=owner_id,
-                                date_released=result.get("dateReleased"),
-                                status=new_status or ReleaseStatus.OPEN,
-                                user_agent=request.META.get("HTTP_USER_AGENT", ""),
-                            ),
-                            True,
-                        )
-                    was_released = False
-                except IntegrityError:
+            # release creation is idempotent to simplify user
+            # experiences
+            owner_id: int | None = None
+            if owner := result.get("owner"):
+                owner_id = owner.id
+
+            try:
+                with transaction.atomic(router.db_for_write(Release)):
                     release, created = (
-                        Release.objects.get(
-                            organization_id=project.organization_id, version=result["version"]
+                        Release.objects.create(
+                            organization_id=project.organization_id,
+                            version=result["version"],
+                            ref=result.get("ref"),
+                            url=result.get("url"),
+                            owner_id=owner_id,
+                            date_released=result.get("dateReleased"),
+                            status=new_status or ReleaseStatus.OPEN,
+                            user_agent=request.META.get("HTTP_USER_AGENT", ""),
                         ),
-                        False,
+                        True,
                     )
-                    was_released = bool(release.date_released)
-                else:
-                    release_created.send_robust(release=release, sender=self.__class__)
+                was_released = False
+            except IntegrityError:
+                release, created = (
+                    Release.objects.get(
+                        organization_id=project.organization_id, version=result["version"]
+                    ),
+                    False,
+                )
+                was_released = bool(release.date_released)
+            else:
+                release_created.send_robust(release=release, sender=self.__class__)
 
-                if not created and new_status is not None and new_status != release.status:
-                    release.status = new_status
-                    release.save()
+            if not created and new_status is not None and new_status != release.status:
+                release.status = new_status
+                release.save()
 
-                _, releaseproject_created = release.add_project(project)
+            _, releaseproject_created = release.add_project(project)
 
-                commit_list = result.get("commits")
-                if commit_list:
-                    hook = ReleaseHook(project)
-                    # TODO(dcramer): handle errors with release payloads
-                    hook.set_commits(release.version, commit_list)
+            commit_list = result.get("commits")
+            if commit_list:
+                hook = ReleaseHook(project)
+                # TODO(dcramer): handle errors with release payloads
+                hook.set_commits(release.version, commit_list)
 
-                if not was_released and release.date_released:
-                    Activity.objects.create(
-                        type=ActivityType.RELEASE.value,
-                        project=project,
-                        ident=Activity.get_version_ident(result["version"]),
-                        data={"version": result["version"]},
-                        datetime=release.date_released,
-                    )
-
-                if not releaseproject_created:
-                    # This is the closest status code that makes sense, and we want
-                    # a unique 2xx response code so people can understand when
-                    # behavior differs.
-                    #   208 Already Reported (WebDAV; RFC 5842)
-                    status = 208
-                else:
-                    status = 201
-
-                analytics.record(
-                    "release.created",
-                    user_id=request.user.id if request.user and request.user.id else None,
-                    organization_id=project.organization_id,
-                    project_ids=[project.id],
-                    user_agent=request.META.get("HTTP_USER_AGENT", "")[:256],
-                    created_status=status,
-                    auth_type=get_auth_api_token_type(request.auth),
+            if not was_released and release.date_released:
+                Activity.objects.create(
+                    type=ActivityType.RELEASE.value,
+                    project=project,
+                    ident=Activity.get_version_ident(result["version"]),
+                    data={"version": result["version"]},
+                    datetime=release.date_released,
                 )
 
-                if is_org_auth_token_auth(request.auth):
-                    update_org_auth_token_last_used(request.auth, [project.id])
+            if not releaseproject_created:
+                # This is the closest status code that makes sense, and we want
+                # a unique 2xx response code so people can understand when
+                # behavior differs.
+                #   208 Already Reported (WebDAV; RFC 5842)
+                status = 208
+            else:
+                status = 201
 
-                scope.set_tag("success_status", status)
+            analytics.record(
+                "release.created",
+                user_id=request.user.id if request.user and request.user.id else None,
+                organization_id=project.organization_id,
+                project_ids=[project.id],
+                user_agent=request.META.get("HTTP_USER_AGENT", "")[:256],
+                created_status=status,
+                auth_type=get_auth_api_token_type(request.auth),
+            )
 
-                # Disable snuba here as it often causes 429s when overloaded and
-                # a freshly created release won't have health data anyways.
-                return Response(
-                    serialize(release, request.user, no_snuba_for_release_creation=True),
-                    status=status,
-                )
-            scope.set_tag("failure_reason", "serializer_error")
-            return Response(serializer.errors, status=400)
+            if is_org_auth_token_auth(request.auth):
+                update_org_auth_token_last_used(request.auth, [project.id])
+
+            scope.set_tag("success_status", status)
+
+            # Disable snuba here as it often causes 429s when overloaded and
+            # a freshly created release won't have health data anyways.
+            return Response(
+                serialize(release, request.user, no_snuba_for_release_creation=True),
+                status=status,
+            )
+        scope.set_tag("failure_reason", "serializer_error")
+        return Response(serializer.errors, status=400)


### PR DESCRIPTION
Replace deprecated `configure_scope` with new `Scope.get_isolation_scope()` API from Sentry SDK 2.0

ref #73430
