### PR TITLE
Simplify attachment rate limiting `reason`

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -2858,7 +2858,7 @@ def save_attachment(
             project_id=project.id,
             key_id=key_id,
             outcome=Outcome.RATE_LIMITED,
-            reason=f"Too many attachments ({num_requests}) uploaded in a 5 minute window, will reset at {reset_time}",
+            reason="rate_limited",
             timestamp=timestamp,
             event_id=event_id,
             category=DataCategory.ATTACHMENT,


### PR DESCRIPTION
It turns out this `reason` is used as a metrics tag and leads to excessive cardinality.