### PR TITLE
ref(api): Migrate `configure_scope` in Sentry app authorizations endpoint

### DIFF
--- a/src/sentry/api/endpoints/integrations/sentry_apps/authorizations.py
+++ b/src/sentry/api/endpoints/integrations/sentry_apps/authorizations.py
@@ -26,34 +26,35 @@ class SentryAppAuthorizationsEndpoint(SentryAppAuthorizationsBaseEndpoint):
     }
 
     def post(self, request: Request, installation) -> Response:
-        with sentry_sdk.configure_scope() as scope:
-            scope.set_tag("organization", installation.organization_id)
-            scope.set_tag("sentry_app_id", installation.sentry_app.id)
-            scope.set_tag("sentry_app_slug", installation.sentry_app.slug)
+        scope = sentry_sdk.Scope.get_isolation_scope()
 
-            try:
-                if request.json_body.get("grant_type") == GrantTypes.AUTHORIZATION:
-                    token = GrantExchanger.run(
-                        install=installation,
-                        code=request.json_body.get("code"),
-                        client_id=request.json_body.get("client_id"),
-                        user=promote_request_api_user(request),
-                    )
-                elif request.json_body.get("grant_type") == GrantTypes.REFRESH:
-                    token = Refresher.run(
-                        install=installation,
-                        refresh_token=request.json_body.get("refresh_token"),
-                        client_id=request.json_body.get("client_id"),
-                        user=promote_request_api_user(request),
-                    )
-                else:
-                    return Response({"error": "Invalid grant_type"}, status=403)
-            except APIUnauthorized as e:
-                logger.warning(e, exc_info=True)
-                return Response({"error": e.msg or "Unauthorized"}, status=403)
+        scope.set_tag("organization", installation.organization_id)
+        scope.set_tag("sentry_app_id", installation.sentry_app.id)
+        scope.set_tag("sentry_app_slug", installation.sentry_app.slug)
 
-            attrs = {"state": request.json_body.get("state"), "application": None}
+        try:
+            if request.json_body.get("grant_type") == GrantTypes.AUTHORIZATION:
+                token = GrantExchanger.run(
+                    install=installation,
+                    code=request.json_body.get("code"),
+                    client_id=request.json_body.get("client_id"),
+                    user=promote_request_api_user(request),
+                )
+            elif request.json_body.get("grant_type") == GrantTypes.REFRESH:
+                token = Refresher.run(
+                    install=installation,
+                    refresh_token=request.json_body.get("refresh_token"),
+                    client_id=request.json_body.get("client_id"),
+                    user=promote_request_api_user(request),
+                )
+            else:
+                return Response({"error": "Invalid grant_type"}, status=403)
+        except APIUnauthorized as e:
+            logger.warning(e, exc_info=True)
+            return Response({"error": e.msg or "Unauthorized"}, status=403)
 
-            body = ApiTokenSerializer().serialize(token, attrs, promote_request_api_user(request))
+        attrs = {"state": request.json_body.get("state"), "application": None}
 
-            return Response(body, status=201)
+        body = ApiTokenSerializer().serialize(token, attrs, promote_request_api_user(request))
+
+        return Response(body, status=201)


### PR DESCRIPTION
Replace deprecated `configure_scope` with new `Scope.get_isolation_scope()` API from Sentry SDK 2.0

ref #73430
