### PR TITLE
feat(metrics) paginate on real queryset

### DIFF
--- a/src/sentry/api/endpoints/project_metrics_extraction_rules.py
+++ b/src/sentry/api/endpoints/project_metrics_extraction_rules.py
@@ -68,21 +68,19 @@ class ProjectMetricsExtractionRulesEndpoint(ProjectEndpoint):
 
         try:
             configs = SpanAttributeExtractionRuleConfig.objects.filter(project=project)
-
         except Exception as e:
             return Response(status=500, data={"detail": str(e)})
 
-        # TODO(metrics): do real pagination using the database
         return self.paginate(
             request,
-            queryset=list(configs),
+            queryset=configs,
+            order_by="id",
             paginator_cls=OffsetPaginator,
             on_results=lambda x: serialize(
                 x, user=request.user, serializer=SpanAttributeExtractionRuleConfigSerializer()
             ),
-            default_per_page=1000,
-            max_per_page=1000,
-            max_limit=1000,  # overrides default max_limit of 100 when creating paginator object
+            default_per_page=25,
+            max_per_page=25,
         )
 
     def post(self, request: Request, project: Project) -> Response:

--- a/tests/sentry/api/endpoints/test_project_metrics_extraction_rules.py
+++ b/tests/sentry/api/endpoints/test_project_metrics_extraction_rules.py
@@ -383,7 +383,7 @@ class ProjectMetricsExtractionEndpointTestCase(APITestCase):
         json_payload = {
             "metricsExtractionRules": [
                 {
-                    "spanAttribute": f"count_clicks_{i:04d}",
+                    "spanAttribute": f"count_clicks_{i:02d}",
                     "aggregates": ["count", "p50", "p75", "p95", "p99"],
                     "unit": "none",
                     "tags": ["tag1", "tag2", "tag3"],
@@ -392,7 +392,7 @@ class ProjectMetricsExtractionEndpointTestCase(APITestCase):
                         {"id": str(uuid.uuid4()), "value": "baz:faz"},
                     ],
                 }
-                for i in range(0, 2050)
+                for i in range(0, 60)
             ]
         }
 
@@ -409,29 +409,29 @@ class ProjectMetricsExtractionEndpointTestCase(APITestCase):
         )
         assert response.status_code == 200
         span_attributes = [x["spanAttribute"] for x in response.data]
-        assert len(span_attributes) == 1000
-        assert min(span_attributes) == "count_clicks_0000"
-        assert max(span_attributes) == "count_clicks_0999"
+        assert len(span_attributes) == 25
+        assert min(span_attributes) == "count_clicks_00"
+        assert max(span_attributes) == "count_clicks_24"
         assert len(set(span_attributes)) == len(span_attributes)
 
         response = self.get_success_response(
-            self.organization.slug, self.project.slug, method="get", cursor="1000:1:0"
+            self.organization.slug, self.project.slug, method="get", cursor="25:1:0"
         )
         assert response.status_code == 200
         span_attributes = [x["spanAttribute"] for x in response.data]
-        assert len(span_attributes) == 1000
-        assert min(span_attributes) == "count_clicks_1000"
-        assert max(span_attributes) == "count_clicks_1999"
+        assert len(span_attributes) == 25
+        assert min(span_attributes) == "count_clicks_25"
+        assert max(span_attributes) == "count_clicks_49"
         assert len(set(span_attributes)) == len(span_attributes)
 
         response = self.get_success_response(
-            self.organization.slug, self.project.slug, method="get", cursor="1000:2:0"
+            self.organization.slug, self.project.slug, method="get", cursor="25:2:0"
         )
         assert response.status_code == 200
         span_attributes = [x["spanAttribute"] for x in response.data]
-        assert len(span_attributes) == 50
-        assert min(span_attributes) == "count_clicks_2000"
-        assert max(span_attributes) == "count_clicks_2049"
+        assert len(span_attributes) == 10
+        assert min(span_attributes) == "count_clicks_50"
+        assert max(span_attributes) == "count_clicks_59"
         assert len(set(span_attributes)) == len(span_attributes)
 
     @django_db_all


### PR DESCRIPTION
2 things done inside the PR:
- page size is set to 25 (1000 was temporal hack)
- pagination is done on DB level