### PR TITLE
ref(integrations): Migrate `configure_scope` in remaining integration code

### DIFF
--- a/src/sentry/integrations/base.py
+++ b/src/sentry/integrations/base.py
@@ -44,7 +44,7 @@ from sentry.shared_integrations.exceptions import (
     UnsupportedResponseType,
 )
 from sentry.utils.audit import create_audit_entry, create_system_audit_entry
-from sentry.utils.sdk import configure_scope
+from sentry.utils.sdk import Scope
 
 if TYPE_CHECKING:
     from sentry.integrations.services.integration import RpcOrganizationIntegration
@@ -393,10 +393,10 @@ class IntegrationInstallation:
             filter={"id": self.org_integration.default_auth_id}
         )
         if identity is None:
-            with configure_scope() as scope:
-                scope.set_tag("integration_provider", self.model.get_provider().name)
-                scope.set_tag("org_integration_id", self.org_integration.id)
-                scope.set_tag("default_auth_id", self.org_integration.default_auth_id)
+            scope = Scope.get_isolation_scope()
+            scope.set_tag("integration_provider", self.model.get_provider().name)
+            scope.set_tag("org_integration_id", self.org_integration.id)
+            scope.set_tag("default_auth_id", self.org_integration.default_auth_id)
             raise Identity.DoesNotExist
         return identity
 

--- a/src/sentry/integrations/mixins/repositories.py
+++ b/src/sentry/integrations/mixins/repositories.py
@@ -4,7 +4,6 @@ from collections.abc import Collection, Mapping, Sequence
 from typing import Any
 
 import sentry_sdk
-from sentry_sdk import configure_scope
 
 from sentry.auth.exceptions import IdentityNotValid
 from sentry.integrations.services.integration import integration_service
@@ -82,16 +81,16 @@ class RepositoryMixin:
         If no file was found return `None`, and re-raise for non-"Not Found"
         errors, like 403 "Account Suspended".
         """
-        with configure_scope() as scope:
-            scope.set_tag("stacktrace_link.tried_version", False)
-            if version:
-                scope.set_tag("stacktrace_link.tried_version", True)
-                source_url = self.check_file(repo, filepath, version)
-                if source_url:
-                    scope.set_tag("stacktrace_link.used_version", True)
-                    return source_url
-            scope.set_tag("stacktrace_link.used_version", False)
-            source_url = self.check_file(repo, filepath, default)
+        scope = sentry_sdk.Scope.get_isolation_scope()
+        scope.set_tag("stacktrace_link.tried_version", False)
+        if version:
+            scope.set_tag("stacktrace_link.tried_version", True)
+            source_url = self.check_file(repo, filepath, version)
+            if source_url:
+                scope.set_tag("stacktrace_link.used_version", True)
+                return source_url
+        scope.set_tag("stacktrace_link.used_version", False)
+        source_url = self.check_file(repo, filepath, default)
 
         return source_url
 

--- a/src/sentry/integrations/utils/scope.py
+++ b/src/sentry/integrations/utils/scope.py
@@ -4,7 +4,7 @@ import logging
 from collections.abc import Mapping
 from typing import Any
 
-from sentry_sdk import configure_scope
+import sentry_sdk
 
 from sentry.integrations.services.integration import integration_service
 from sentry.integrations.services.integration.model import RpcOrganizationIntegration
@@ -24,18 +24,19 @@ logger = logging.getLogger(__name__)
 def clear_tags_and_context() -> None:
     """Clear certain tags and context since it should not be set."""
     reset_values = False
-    with configure_scope() as scope:
-        for tag in ["organization", "organization.slug"]:
-            if tag in scope._tags:
-                reset_values = True
-                del scope._tags[tag]
+    scope = sentry_sdk.Scope.get_isolation_scope()
 
-        if "organization" in scope._contexts:
+    for tag in ["organization", "organization.slug"]:
+        if tag in scope._tags:
             reset_values = True
-            del scope._contexts["organization"]
+            del scope._tags[tag]
 
-        if reset_values:
-            logger.info("We've reset the context and tags.")
+    if "organization" in scope._contexts:
+        reset_values = True
+        del scope._contexts["organization"]
+
+    if reset_values:
+        logger.info("We've reset the context and tags.")
 
 
 def get_org_integrations(


### PR DESCRIPTION
Replace deprecated `configure_scope` with new `Scope.get_isolation_scope()` API from Sentry SDK 2.0. This PR addresses all remaining code in `src/sentry/integrations` after #73639, #73641, and #73642 are merged.

ref #73430
