### PR TITLE
feat(metrics-extraction): Disable used attributes

### DIFF
--- a/static/app/views/settings/projectMetrics/metricsExtractionRuleForm.tsx
+++ b/static/app/views/settings/projectMetrics/metricsExtractionRuleForm.tsx
@@ -167,19 +167,23 @@ export function MetricsExtractionRuleForm({isEdit, project, onSubmit, ...props}:
       keys = [...new Set(keys.concat(customAttributes))];
     }
 
-    return keys
-      .map(key => ({
-        label: key,
-        value: key,
-        disabled: disabledKeys.has(key),
-        tooltip: disabledKeys.has(key)
-          ? t(
-              'This attribute is already in use. Please select another one or edit the existing metric.'
-            )
-          : undefined,
-        tooltipOptions: {position: 'left'},
-      }))
-      .sort((a, b) => a.label.localeCompare(b.label));
+    return (
+      keys
+        .map(key => ({
+          label: key,
+          value: key,
+          disabled: disabledKeys.has(key),
+          tooltip: disabledKeys.has(key)
+            ? t(
+                'This attribute is already in use. Please select another one or edit the existing metric.'
+              )
+            : undefined,
+          tooltipOptions: {position: 'left'},
+        }))
+        .sort((a, b) => a.label.localeCompare(b.label))
+        // Sort disabled attributes to bottom
+        .sort((a, b) => Number(a.disabled) - Number(b.disabled))
+    );
   }, [customAttributes, supportedTags, extractionRules]);
 
   const tagOptions = useMemo(() => {


### PR DESCRIPTION
Disable span attributes that are already used in an extraction rule.

![Screenshot 2024-07-02 at 15 23 48](https://github.com/getsentry/sentry/assets/7033940/8292f8b3-177e-4721-a125-cdb8481a688e)
