### PR TITLE
ref: Migrate `configure_scope` in `src/sentry/tasks`

### DIFF
--- a/src/sentry/tasks/assemble.py
+++ b/src/sentry/tasks/assemble.py
@@ -43,7 +43,7 @@ from sentry.tasks.base import instrumented_task
 from sentry.utils import metrics, redis
 from sentry.utils.db import atomic_transaction
 from sentry.utils.files import get_max_file_size
-from sentry.utils.sdk import bind_organization_context, configure_scope
+from sentry.utils.sdk import Scope, bind_organization_context
 
 logger = logging.getLogger(__name__)
 
@@ -232,8 +232,7 @@ def assemble_dif(project_id, name, checksum, chunks, debug_id=None, **kwargs):
     from sentry.models.debugfile import BadDif, create_dif_from_id, detect_dif_from_path
     from sentry.models.project import Project
 
-    with configure_scope() as scope:
-        scope.set_tag("project", project_id)
+    Scope.get_isolation_scope().set_tag("project", project_id)
 
     delete_file = False
 

--- a/src/sentry/tasks/base.py
+++ b/src/sentry/tasks/base.py
@@ -13,7 +13,7 @@ from django.db.models import Model
 from sentry.celery import app
 from sentry.silo.base import SiloLimit, SiloMode
 from sentry.utils import metrics
-from sentry.utils.sdk import capture_exception, configure_scope
+from sentry.utils.sdk import Scope, capture_exception
 
 ModelT = TypeVar("ModelT", bound=Model)
 
@@ -127,9 +127,9 @@ def instrumented_task(name, stat_suffix=None, silo_mode=None, record_timing=Fals
                     "jobs.queue_time", duration, instance=instance, unit="millisecond"
                 )
 
-            with configure_scope() as scope:
-                scope.set_tag("task_name", name)
-                scope.set_tag("transaction_id", transaction_id)
+            scope = Scope.get_isolation_scope()
+            scope.set_tag("task_name", name)
+            scope.set_tag("transaction_id", transaction_id)
 
             with (
                 metrics.timer(key, instance=instance),


### PR DESCRIPTION
Replace deprecated `configure_scope` with new `Scope.get_isolation_scope()` API from Sentry SDK 2.0.

ref #73430
