### PR TITLE
ref: Migrate `configure_scope` in `src/sentry/utils`

### DIFF
--- a/src/sentry/utils/appleconnect/appstore_connect.py
+++ b/src/sentry/utils/appleconnect/appstore_connect.py
@@ -142,8 +142,7 @@ def _get_appstore_json(
             except Exception:
                 err_info["text"] = response.text
 
-            with sentry_sdk.configure_scope() as scope:
-                scope.set_extra("http.appconnect.api", err_info)
+            sentry_sdk.Scope.get_isolation_scope().set_extra("http.appconnect.api", err_info)
 
             if response.status_code == HTTPStatus.UNAUTHORIZED:
                 raise UnauthorizedError(full_url)
@@ -460,8 +459,7 @@ def download_dsyms(
                 # The 315s is just above how long it would take a 4MB/s connection to download
                 # 2GB.
                 if (time.time() - start) > 315:
-                    with sdk.configure_scope() as scope:
-                        scope.set_extra("dSYM.bytes_fetched", bytes_count)
+                    sdk.Scope.get_isolation_scope().set_extra("dSYM.bytes_fetched", bytes_count)
                     raise Timeout("Timeout during dSYM download")
                 bytes_count += len(chunk)
                 fp.write(chunk)

--- a/src/sentry/utils/sdk.py
+++ b/src/sentry/utils/sdk.py
@@ -104,16 +104,16 @@ def is_current_event_safe():
     Tests the current stack for unsafe locations that would likely cause
     recursion if an attempt to send to Sentry was made.
     """
+    scope = Scope.get_isolation_scope()
 
-    with configure_scope() as scope:
-        # Scope was explicitly marked as unsafe
-        if scope._tags.get(UNSAFE_TAG):
-            return False
+    # Scope was explicitly marked as unsafe
+    if scope._tags.get(UNSAFE_TAG):
+        return False
 
-        project_id = scope._tags.get("processing_event_for_project")
+    project_id = scope._tags.get("processing_event_for_project")
 
-        if project_id and project_id == settings.SENTRY_PROJECT:
-            return False
+    if project_id and project_id == settings.SENTRY_PROJECT:
+        return False
 
     for filename in _current_stack_filenames():
         if filename.endswith(UNSAFE_FILES):
@@ -124,27 +124,27 @@ def is_current_event_safe():
 
 def mark_scope_as_unsafe():
     """
-    Set the unsafe tag on the SDK scope for outgoing crashes and transactions.
+    Set the unsafe tag on the SDK isolation scope for outgoing crashes and transactions.
 
     Marking a scope explicitly as unsafe allows the recursion breaker to
     decide early, before walking the stack and checking for unsafe files.
     """
-    with configure_scope() as scope:
-        scope.set_tag(UNSAFE_TAG, True)
+    Scope.get_isolation_scope().set_tag(UNSAFE_TAG, True)
 
 
 def set_current_event_project(project_id):
     """
-    Set the current project on the SDK scope for outgoing crash reports.
+    Set the current project on the SDK isolation scope for outgoing crash reports.
 
     This is a dedicated function because it is also important for the recursion
     breaker to work. You really should set the project in every task that is
     relevant to event processing, or that task may crash ingesting
     sentry-internal errors, causing infinite recursion.
     """
-    with configure_scope() as scope:
-        scope.set_tag("processing_event_for_project", project_id)
-        scope.set_tag("project", project_id)
+    scope = Scope.get_isolation_scope()
+
+    scope.set_tag("processing_event_for_project", project_id)
+    scope.set_tag("project", project_id)
 
 
 def get_project_key():
@@ -490,44 +490,43 @@ def check_tag_for_scope_bleed(
     # force the string version to prevent false positives
     expected_value = str(expected_value)
 
-    with configure_scope() as scope:
-        current_value = scope._tags.get(tag_key)
+    scope = Scope.get_isolation_scope()
 
-        if not current_value:
-            return
+    current_value = scope._tags.get(tag_key)
 
-        # ensure we're comparing apples to apples
-        current_value = str(current_value)
+    if not current_value:
+        return
 
-        # There are times where we can only narrow down the current org to a list, for example if
-        # we've derived it from an integration, since integrations can be shared across multiple orgs.
-        if tag_key == "organization.slug" and current_value == "[multiple orgs]":
-            # Currently, we don't have access in this function to the underlying slug list
-            # corresponding to an incoming "[multiple orgs]" tag, so we can't check it against the
-            # current list. Regardless of whether the lists would match, it's currently not flagged
-            # as scope bleed. (Fortunately, that version of scope bleed should be a pretty rare case,
-            # since only ~3% of integrations belong to multiple orgs, making the chance of it
-            # happening twice around 0.1%.) So for now, just skip that case.
-            if expected_value != "[multiple orgs]":
-                # If we've now figured out which of that list is correct, don't count it as a mismatch.
-                # But if it currently is a list and `expected_value` is something *not* in that list,
-                # we're almost certainly dealing with scope bleed, so we should continue with our check.
-                current_org_list = scope._contexts.get("organization", {}).get(
-                    "multiple possible", []
-                )
-                if current_org_list and expected_value in current_org_list:
-                    return
+    # ensure we're comparing apples to apples
+    current_value = str(current_value)
 
-        if current_value != expected_value:
-            extra = {
-                f"previous_{tag_key}_tag": current_value,
-                f"new_{tag_key}_tag": expected_value,
-            }
-            if add_to_scope:
-                scope.set_tag("possible_mistag", True)
-                scope.set_tag(f"scope_bleed.{tag_key}", True)
-                merge_context_into_scope("scope_bleed", extra, scope)
-            logger.warning("Tag already set and different (%s).", tag_key, extra=extra)
+    # There are times where we can only narrow down the current org to a list, for example if
+    # we've derived it from an integration, since integrations can be shared across multiple orgs.
+    if tag_key == "organization.slug" and current_value == "[multiple orgs]":
+        # Currently, we don't have access in this function to the underlying slug list
+        # corresponding to an incoming "[multiple orgs]" tag, so we can't check it against the
+        # current list. Regardless of whether the lists would match, it's currently not flagged
+        # as scope bleed. (Fortunately, that version of scope bleed should be a pretty rare case,
+        # since only ~3% of integrations belong to multiple orgs, making the chance of it
+        # happening twice around 0.1%.) So for now, just skip that case.
+        if expected_value != "[multiple orgs]":
+            # If we've now figured out which of that list is correct, don't count it as a mismatch.
+            # But if it currently is a list and `expected_value` is something *not* in that list,
+            # we're almost certainly dealing with scope bleed, so we should continue with our check.
+            current_org_list = scope._contexts.get("organization", {}).get("multiple possible", [])
+            if current_org_list and expected_value in current_org_list:
+                return
+
+    if current_value != expected_value:
+        extra = {
+            f"previous_{tag_key}_tag": current_value,
+            f"new_{tag_key}_tag": expected_value,
+        }
+        if add_to_scope:
+            scope.set_tag("possible_mistag", True)
+            scope.set_tag(f"scope_bleed.{tag_key}", True)
+            merge_context_into_scope("scope_bleed", extra, scope)
+        logger.warning("Tag already set and different (%s).", tag_key, extra=extra)
 
 
 def get_transaction_name_from_request(request: Request) -> str:
@@ -612,11 +611,10 @@ def bind_organization_context(organization: Organization | RpcOrganization) -> N
     # Callable to bind additional context for the Sentry SDK
     helper = settings.SENTRY_ORGANIZATION_CONTEXT_HELPER
 
+    scope = Scope.get_isolation_scope()
+
     # XXX(dcramer): this is duplicated in organizationContext.jsx on the frontend
-    # fmt: off
-    with configure_scope() as scope, \
-         sentry_sdk.start_span(op="other", description="bind_organization_context"):
-        # fmt: on
+    with sentry_sdk.start_span(op="other", description="bind_organization_context"):
         # This can be used to find errors that may have been mistagged
         check_tag_for_scope_bleed("organization.slug", organization.slug)
 
@@ -657,24 +655,25 @@ def bind_ambiguous_org_context(
     if len(orgs) > 50:
         org_slugs = org_slugs[:49] + [f"... ({len(orgs) - 49} more)"]
 
-    with configure_scope() as scope:
-        # It's possible we've already set the org context with one of the orgs in our list,
-        # somewhere we could narrow it down to one org. In that case, we don't want to overwrite
-        # that specific data with this ambiguous data.
-        current_org_slug_tag = scope._tags.get("organization.slug")
-        if current_org_slug_tag and current_org_slug_tag in org_slugs:
-            return
+    scope = Scope.get_isolation_scope()
 
-        # It's also possible that the org seems already to be set but it's just a case of scope
-        # bleed. In that case, we want to test for that and proceed.
-        check_tag_for_scope_bleed("organization.slug", MULTIPLE_ORGS_TAG)
+    # It's possible we've already set the org context with one of the orgs in our list,
+    # somewhere we could narrow it down to one org. In that case, we don't want to overwrite
+    # that specific data with this ambiguous data.
+    current_org_slug_tag = scope._tags.get("organization.slug")
+    if current_org_slug_tag and current_org_slug_tag in org_slugs:
+        return
 
-        scope.set_tag("organization", MULTIPLE_ORGS_TAG)
-        scope.set_tag("organization.slug", MULTIPLE_ORGS_TAG)
+    # It's also possible that the org seems already to be set but it's just a case of scope
+    # bleed. In that case, we want to test for that and proceed.
+    check_tag_for_scope_bleed("organization.slug", MULTIPLE_ORGS_TAG)
 
-        scope.set_context(
-            "organization", {"multiple possible": org_slugs, "source": source or "unknown"}
-        )
+    scope.set_tag("organization", MULTIPLE_ORGS_TAG)
+    scope.set_tag("organization.slug", MULTIPLE_ORGS_TAG)
+
+    scope.set_context(
+        "organization", {"multiple possible": org_slugs, "source": source or "unknown"}
+    )
 
 
 def set_measurement(measurement_name, value, unit=None):

--- a/tests/sentry/utils/test_sdk.py
+++ b/tests/sentry/utils/test_sdk.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import contextlib
 from unittest.mock import MagicMock, patch
 
+import sentry_sdk.scope
 from django.conf import settings
 from django.http import HttpRequest
 from rest_framework.request import Request
@@ -22,11 +23,16 @@ from sentry.utils.sdk import (
 
 
 @contextlib.contextmanager
-def patch_configure_scope_with_scope(mocked_function_name: str, scope: Scope):
-    with patch(mocked_function_name) as mock_configure_scope:
-        mock_configure_scope.return_value.__enter__.return_value = scope
+def patch_isolation_scope():
+    """
+    Generates and yields new Scope object, and patches sentry.utils.sdk.Scope.get_isolation_scope to return the same
+    scope within the fixture.
+    """
+    scope = Scope(ty=sentry_sdk.scope.ScopeType.ISOLATION)
+    with patch("sentry.utils.sdk.Scope.get_isolation_scope") as mock_get_isolation_scope:
+        mock_get_isolation_scope.return_value = scope
 
-        yield mock_configure_scope
+        yield scope
 
 
 class SDKUtilsTest(TestCase):
@@ -62,10 +68,8 @@ class SDKUtilsTest(TestCase):
 @patch("sentry.utils.sdk.logger.warning")
 class CheckTagForScopeBleedTest(TestCase):
     def test_no_existing_tag(self, mock_logger_warning: MagicMock):
-        mock_scope = Scope()
-        mock_scope._tags = {}
-
-        with patch_configure_scope_with_scope("sentry.utils.sdk.configure_scope", mock_scope):
+        with patch_isolation_scope() as mock_scope:
+            mock_scope._tags = {}
             check_tag_for_scope_bleed("org.slug", "squirrel_chasers")
 
         assert "possible_mistag" not in mock_scope._tags
@@ -74,10 +78,8 @@ class CheckTagForScopeBleedTest(TestCase):
         assert mock_logger_warning.call_count == 0
 
     def test_matching_existing_tag_single_org(self, mock_logger_warning: MagicMock):
-        mock_scope = Scope()
-        mock_scope._tags = {"org.slug": "squirrel_chasers"}
-
-        with patch_configure_scope_with_scope("sentry.utils.sdk.configure_scope", mock_scope):
+        with patch_isolation_scope() as mock_scope:
+            mock_scope._tags = {"org.slug": "squirrel_chasers"}
             check_tag_for_scope_bleed("org.slug", "squirrel_chasers")
 
         assert "possible_mistag" not in mock_scope._tags
@@ -86,11 +88,10 @@ class CheckTagForScopeBleedTest(TestCase):
         assert mock_logger_warning.call_count == 0
 
     def test_matching_existing_tag_multiple_orgs(self, mock_logger_warning: MagicMock):
-        mock_scope = Scope()
-        mock_scope._tags = {"organization.slug": "[multiple orgs]"}
         # We don't bother to add the underlying slug list here, since right now it's not checked
 
-        with patch_configure_scope_with_scope("sentry.utils.sdk.configure_scope", mock_scope):
+        with patch_isolation_scope() as mock_scope:
+            mock_scope._tags = {"organization.slug": "[multiple orgs]"}
             check_tag_for_scope_bleed("organization.slug", "[multiple orgs]")
 
         assert "possible_mistag" not in mock_scope._tags
@@ -99,10 +100,8 @@ class CheckTagForScopeBleedTest(TestCase):
         assert mock_logger_warning.call_count == 0
 
     def test_different_existing_tag_single_org(self, mock_logger_warning: MagicMock):
-        mock_scope = Scope()
-        mock_scope._tags = {"org.slug": "good_dogs"}
-
-        with patch_configure_scope_with_scope("sentry.utils.sdk.configure_scope", mock_scope):
+        with patch_isolation_scope() as mock_scope:
+            mock_scope._tags = {"org.slug": "good_dogs"}
             check_tag_for_scope_bleed("org.slug", "squirrel_chasers")
 
         extra = {
@@ -117,10 +116,8 @@ class CheckTagForScopeBleedTest(TestCase):
         )
 
     def test_different_existing_tag_incoming_is_multiple_orgs(self, mock_logger_warning: MagicMock):
-        mock_scope = Scope()
-        mock_scope._tags = {"organization.slug": "good_dogs"}
-
-        with patch_configure_scope_with_scope("sentry.utils.sdk.configure_scope", mock_scope):
+        with patch_isolation_scope() as mock_scope:
+            mock_scope._tags = {"organization.slug": "good_dogs"}
             check_tag_for_scope_bleed("organization.slug", "[multiple orgs]")
 
         extra = {
@@ -136,12 +133,13 @@ class CheckTagForScopeBleedTest(TestCase):
 
     def test_getting_more_specific_doesnt_count_as_mismatch(self, mock_logger_warning: MagicMock):
         orgs = [self.create_organization() for _ in [None] * 3]
-        mock_scope = Scope()
-        mock_scope.set_tag("organization.slug", "[multiple orgs]")
-        mock_scope.set_tag("organization", "[multiple orgs]")
-        mock_scope.set_context("organization", {"multiple possible": [org.slug for org in orgs]})
 
-        with patch_configure_scope_with_scope("sentry.utils.sdk.configure_scope", mock_scope):
+        with patch_isolation_scope() as mock_scope:
+            mock_scope.set_tag("organization.slug", "[multiple orgs]")
+            mock_scope.set_tag("organization", "[multiple orgs]")
+            mock_scope.set_context(
+                "organization", {"multiple possible": [org.slug for org in orgs]}
+            )
             check_tag_for_scope_bleed("organization.slug", orgs[1].slug)
 
         assert "possible_mistag" not in mock_scope._tags
@@ -153,12 +151,13 @@ class CheckTagForScopeBleedTest(TestCase):
         self, mock_logger_warning: MagicMock
     ):
         orgs = [self.create_organization() for _ in [None] * 3]
-        mock_scope = Scope()
-        mock_scope.set_tag("organization.slug", "[multiple orgs]")
-        mock_scope.set_tag("organization", "[multiple orgs]")
-        mock_scope.set_context("organization", {"multiple possible": [org.slug for org in orgs]})
 
-        with patch_configure_scope_with_scope("sentry.utils.sdk.configure_scope", mock_scope):
+        with patch_isolation_scope() as mock_scope:
+            mock_scope.set_tag("organization.slug", "[multiple orgs]")
+            mock_scope.set_tag("organization", "[multiple orgs]")
+            mock_scope.set_context(
+                "organization", {"multiple possible": [org.slug for org in orgs]}
+            )
             check_tag_for_scope_bleed("organization.slug", "squirrel_chasers")
 
         extra = {
@@ -173,10 +172,8 @@ class CheckTagForScopeBleedTest(TestCase):
         )
 
     def test_add_to_scope_being_false(self, mock_logger_warning: MagicMock):
-        mock_scope = Scope()
-        mock_scope._tags = {"org.slug": "good_dogs"}
-
-        with patch_configure_scope_with_scope("sentry.utils.sdk.configure_scope", mock_scope):
+        with patch_isolation_scope() as mock_scope:
+            mock_scope._tags = {"org.slug": "good_dogs"}
             check_tag_for_scope_bleed("org.slug", "squirrel_chasers", add_to_scope=False)
 
         extra = {
@@ -193,10 +190,8 @@ class CheckTagForScopeBleedTest(TestCase):
         )
 
     def test_string_vs_int(self, mock_logger_warning: MagicMock):
-        mock_scope = Scope()
-        mock_scope._tags = {"org.id": "12311121"}
-
-        with patch_configure_scope_with_scope("sentry.utils.sdk.configure_scope", mock_scope):
+        with patch_isolation_scope() as mock_scope:
+            mock_scope._tags = {"org.id": "12311121"}
             check_tag_for_scope_bleed("org.id", 12311121)
 
         assert "possible_mistag" not in mock_scope._tags
@@ -205,10 +200,8 @@ class CheckTagForScopeBleedTest(TestCase):
         assert mock_logger_warning.call_count == 0
 
     def test_int_vs_string(self, mock_logger_warning: MagicMock):
-        mock_scope = Scope()
-        mock_scope._tags = {"org.id": 12311121}
-
-        with patch_configure_scope_with_scope("sentry.utils.sdk.configure_scope", mock_scope):
+        with patch_isolation_scope() as mock_scope:
+            mock_scope._tags = {"org.id": 12311121}
             check_tag_for_scope_bleed("org.id", "12311121")
 
         assert "possible_mistag" not in mock_scope._tags
@@ -241,11 +234,9 @@ class CheckScopeTransactionTest(TestCase):
 
     @patch("sentry.utils.sdk.LEGACY_RESOLVER.resolve", return_value="/dogs/{name}/")
     def test_custom_transaction_name(self, mock_resolve: MagicMock):
-        mock_scope = Scope()
-        mock_scope._transaction = "/tricks/{trick_name}/"
-        mock_scope._transaction_info["source"] = "custom"
-
-        with patch_configure_scope_with_scope("sentry.utils.sdk.configure_scope", mock_scope):
+        with patch_isolation_scope() as mock_scope:
+            mock_scope._transaction = "/tricks/{trick_name}/"
+            mock_scope._transaction_info["source"] = "custom"
             mismatch = check_current_scope_transaction(Request(HttpRequest()))
             # custom transaction names shouldn't be flagged even if they don't match
             assert mismatch is None
@@ -377,9 +368,7 @@ class BindOrganizationContextTest(TestCase):
         self.org = self.create_organization()
 
     def test_simple(self):
-        mock_scope = Scope()
-
-        with patch_configure_scope_with_scope("sentry.utils.sdk.configure_scope", mock_scope):
+        with patch_isolation_scope() as mock_scope:
             bind_organization_context(self.org)
 
             assert mock_scope._tags == {
@@ -397,9 +386,8 @@ class BindOrganizationContextTest(TestCase):
         mock_context_helper = MagicMock(
             wraps=lambda scope, organization: scope.set_tag("organization.name", organization.name)
         )
-        mock_scope = Scope()
 
-        with patch_configure_scope_with_scope("sentry.utils.sdk.configure_scope", mock_scope):
+        with patch_isolation_scope() as mock_scope:
             with patch.object(settings, "SENTRY_ORGANIZATION_CONTEXT_HELPER", mock_context_helper):
                 bind_organization_context(self.org)
 
@@ -412,9 +400,8 @@ class BindOrganizationContextTest(TestCase):
 
     def test_handles_context_helper_error(self):
         mock_context_helper = MagicMock(side_effect=Exception)
-        mock_scope = Scope()
 
-        with patch_configure_scope_with_scope("sentry.utils.sdk.configure_scope", mock_scope):
+        with patch_isolation_scope() as mock_scope:
             with patch.object(settings, "SENTRY_ORGANIZATION_CONTEXT_HELPER", mock_context_helper):
                 bind_organization_context(self.org)
 
@@ -435,9 +422,8 @@ class BindAmbiguousOrgContextTest(TestCase):
 
     def test_simple(self):
         orgs = self.orgs[:3]
-        mock_scope = Scope()
 
-        with patch_configure_scope_with_scope("sentry.utils.sdk.configure_scope", mock_scope):
+        with patch_isolation_scope() as mock_scope:
             bind_ambiguous_org_context(orgs, "integration id=1231")
 
             assert mock_scope._tags == {
@@ -464,9 +450,8 @@ class BindAmbiguousOrgContextTest(TestCase):
                 "slug": single_org.slug,
             }
         }
-        mock_scope = Scope()
 
-        with patch_configure_scope_with_scope("sentry.utils.sdk.configure_scope", mock_scope):
+        with patch_isolation_scope() as mock_scope:
             # First add data from a single org in our list
             bind_organization_context(single_org)
 
@@ -484,9 +469,7 @@ class BindAmbiguousOrgContextTest(TestCase):
         other_org = self.create_organization()
         assert other_org.slug not in [org.slug for org in orgs]
 
-        mock_scope = Scope()
-
-        with patch_configure_scope_with_scope("sentry.utils.sdk.configure_scope", mock_scope):
+        with patch_isolation_scope() as mock_scope:
             # First add data from a single org not in our list
             bind_organization_context(other_org)
 
@@ -517,9 +500,8 @@ class BindAmbiguousOrgContextTest(TestCase):
 
     def test_truncates_list_at_50_entries(self):
         orgs = self.orgs
-        mock_scope = Scope()
 
-        with patch_configure_scope_with_scope("sentry.utils.sdk.configure_scope", mock_scope):
+        with patch_isolation_scope() as mock_scope:
             bind_ambiguous_org_context(orgs, "integration id=1231")
 
             slug_list_in_org_context = mock_scope._contexts["organization"]["multiple possible"]

--- a/tests/sentry/utils/test_sdk.py
+++ b/tests/sentry/utils/test_sdk.py
@@ -26,7 +26,7 @@ from sentry.utils.sdk import (
 def patch_isolation_scope():
     """
     Generates and yields new Scope object, and patches sentry.utils.sdk.Scope.get_isolation_scope to return the same
-    scope within the fixture.
+    scope within the context manager.
     """
     scope = Scope(ty=sentry_sdk.scope.ScopeType.ISOLATION)
     with patch("sentry.utils.sdk.Scope.get_isolation_scope") as mock_get_isolation_scope:


### PR DESCRIPTION
Replace deprecated `configure_scope` with new `Scope.get_isolation_scope()` API from Sentry SDK 2.0.

ref #73430
