### PR TITLE
ref: Migrate `configure_scope` in `src/sentry/web`

### DIFF
--- a/src/sentry/web/frontend/csrf_failure.py
+++ b/src/sentry/web/frontend/csrf_failure.py
@@ -11,16 +11,17 @@ from sentry.web.helpers import render_to_response
 @csrf_exempt
 def view(request: HttpRequest, reason: str = "") -> HttpResponse:
     context = {"no_referer": reason == REASON_NO_REFERER}
-    with sentry_sdk.configure_scope() as scope:
-        # Emit a sentry request that the incoming request is rejected by the CSRF protection.
-        if hasattr(request, "user") and request.user.is_authenticated:
-            is_staff = request.user.is_staff
-            is_superuser = request.user.is_superuser
-            if is_staff:
-                scope.set_tag("is_staff", "yes")
-            if is_superuser:
-                scope.set_tag("is_superuser", "yes")
-            if is_staff or is_superuser:
-                scope.set_tag("csrf_failure", "yes")
-                logging.error("CSRF failure for staff or superuser")
+    scope = sentry_sdk.Scope.get_isolation_scope()
+
+    # Emit a sentry request that the incoming request is rejected by the CSRF protection.
+    if hasattr(request, "user") and request.user.is_authenticated:
+        is_staff = request.user.is_staff
+        is_superuser = request.user.is_superuser
+        if is_staff:
+            scope.set_tag("is_staff", "yes")
+        if is_superuser:
+            scope.set_tag("is_superuser", "yes")
+        if is_staff or is_superuser:
+            scope.set_tag("csrf_failure", "yes")
+            logging.error("CSRF failure for staff or superuser")
     return render_to_response("sentry/403-csrf-failure.html", context, request, status=403)


### PR DESCRIPTION
Replace deprecated `configure_scope` with new `Scope.get_isolation_scope()` API from Sentry SDK 2.0.

ref #73430
