### PR TITLE
ref: Migrate remaining `configure_scope` to new API

### DIFF
--- a/src/sentry/hybridcloud/rpc/service.py
+++ b/src/sentry/hybridcloud/rpc/service.py
@@ -594,9 +594,9 @@ class _RemoteSiloCall:
 
     def _raise_from_response_status_error(self, response: requests.Response) -> NoReturn:
         rpc_method = f"{self.service_name}.{self.method_name}"
-        with sentry_sdk.configure_scope() as scope:
-            scope.set_tag("rpc_method", rpc_method)
-            scope.set_tag("rpc_status_code", response.status_code)
+        scope = sentry_sdk.Scope.get_isolation_scope()
+        scope.set_tag("rpc_method", rpc_method)
+        scope.set_tag("rpc_status_code", response.status_code)
 
         if in_test_environment():
             if response.status_code == 500:

--- a/src/sentry/middleware/integrations/classifications.py
+++ b/src/sentry/middleware/integrations/classifications.py
@@ -124,12 +124,12 @@ class IntegrationClassification(BaseClassification):
 
         parser_class = self.integration_parsers.get(provider)
         if not parser_class:
-            with sentry_sdk.configure_scope() as scope:
-                scope.set_tag("provider", provider)
-                scope.set_tag("path", request.path)
-                sentry_sdk.capture_exception(
-                    Exception("Unknown provider was extracted from integration extension url")
-                )
+            scope = sentry_sdk.Scope.get_isolation_scope()
+            scope.set_tag("provider", provider)
+            scope.set_tag("path", request.path)
+            sentry_sdk.capture_exception(
+                Exception("Unknown provider was extracted from integration extension url")
+            )
             return self.response_handler(request)
 
         parser = parser_class(

--- a/src/sentry/monitors/endpoints/base.py
+++ b/src/sentry/monitors/endpoints/base.py
@@ -14,7 +14,7 @@ from sentry.models.environment import Environment
 from sentry.models.organization import Organization
 from sentry.models.project import Project
 from sentry.monitors.models import CheckInStatus, Monitor, MonitorCheckIn, MonitorEnvironment
-from sentry.utils.sdk import bind_organization_context, configure_scope
+from sentry.utils.sdk import Scope, bind_organization_context
 
 DEPRECATED_INGEST_API_MESSAGE = "We have removed this deprecated API. Please migrate to using DSN instead: https://docs.sentry.io/product/crons/legacy-endpoint-migration/#am-i-using-legacy-endpoints"
 
@@ -85,8 +85,7 @@ class MonitorEndpoint(Endpoint):
 
         self.check_object_permissions(request, project)
 
-        with configure_scope() as scope:
-            scope.set_tag("project", project.id)
+        Scope.get_isolation_scope().set_tag("project", project.id)
 
         bind_organization_context(project.organization)
 

--- a/src/sentry/monitors/endpoints/monitor_ingest_checkin_attachment.py
+++ b/src/sentry/monitors/endpoints/monitor_ingest_checkin_attachment.py
@@ -5,7 +5,7 @@ from uuid import UUID
 from django.core.files.uploadedfile import UploadedFile
 from rest_framework.request import Request
 from rest_framework.response import Response
-from sentry_sdk import configure_scope
+from sentry_sdk import Scope
 
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
@@ -150,8 +150,7 @@ class MonitorIngestCheckinAttachmentEndpoint(Endpoint):
         # Check project permission. Required for Token style authentication
         self.check_object_permissions(request, project)
 
-        with configure_scope() as scope:
-            scope.set_tag("project", project.id)
+        Scope.get_isolation_scope().set_tag("project", project.id)
 
         bind_organization_context(project.organization)
 

--- a/src/sentry/reprocessing2.py
+++ b/src/sentry/reprocessing2.py
@@ -371,10 +371,10 @@ def buffered_delete_old_primary_hash(
             old_primary_hashes.add(old_primary_hash)
             reprocessing_store.add_hash(project_id, group_id, old_primary_hash)
 
-    with sentry_sdk.configure_scope() as scope:
-        scope.set_tag("project_id", project_id)
-        scope.set_tag("old_group_id", group_id)
-        scope.set_tag("old_primary_hash", old_primary_hash)
+    scope = sentry_sdk.Scope.get_isolation_scope()
+    scope.set_tag("project_id", project_id)
+    scope.set_tag("old_group_id", group_id)
+    scope.set_tag("old_primary_hash", old_primary_hash)
 
     with sentry_sdk.start_span(
         op="sentry.reprocessing2.buffered_delete_old_primary_hash.flush_events"

--- a/src/sentry/shared_integrations/client/base.py
+++ b/src/sentry/shared_integrations/client/base.py
@@ -202,9 +202,8 @@ class BaseApiClient(TrackResponseMixin):
             tags={str(self.integration_type): self.name},
         )
 
-        with sentry_sdk.configure_scope() as scope:
-            if self.integration_type:
-                scope.set_tag(self.integration_type, self.name)
+        if self.integration_type:
+            sentry_sdk.Scope.get_isolation_scope().set_tag(self.integration_type, self.name)
 
         request = Request(
             method=method.upper(),


### PR DESCRIPTION
Replace deprecated `configure_scope` with new `Scope.get_isolation_scope()` API from Sentry SDK 2.0. This PR addresses all remaining `configure_scope` calls outside the tests, which will remain after merging #73647, #73651, #73652, #73653, and #73654.

ref #73430
