### PR TITLE
fix(performance): Txn Summary's Duration Breakdown avg should be a duration

### DIFF
--- a/static/app/views/performance/transactionSummary/transactionOverview/durationChart/content.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/durationChart/content.tsx
@@ -18,7 +18,6 @@ import {
   getDurationUnit,
   tooltipFormatter,
 } from 'sentry/utils/discover/charts';
-import {aggregateOutputType} from 'sentry/utils/discover/fields';
 import getDynamicText from 'sentry/utils/getDynamicText';
 import {PerformanceAtScaleContext} from 'sentry/views/performance/transactionSummary/transactionOverview/performanceAtScaleContext';
 
@@ -113,8 +112,7 @@ function Content({
     },
     tooltip: {
       trigger: 'axis' as const,
-      valueFormatter: (value, label) =>
-        tooltipFormatter(value, aggregateOutputType(label)),
+      valueFormatter: (value, _label) => tooltipFormatter(value, 'duration'),
     },
     xAxis: timeFrame
       ? {


### PR DESCRIPTION
On the Transaction Summary page's Duration Breakdown widget, the `avg()` value was being treated as a `number` instead of a `duration`, so it was missing units when hovering on the timeseries.

Previously, the `AggregationOutputType` was calculated based on the label. For the percentile series (`p50()`, `p99()`, etc), this happened to work due to the logic in `aggregateFunctionOutputType` that uses the default value of an aggregate function's first argument if that argument is optional.

https://github.com/getsentry/sentry/blob/7db2272eec3eee938222b9a54e99464ec307de98/static/app/utils/discover/fields.tsx#L1142-L1148

For `avg()`, because the first parameter is required, this logic doesn't trigger and we end up with `null` returned (and therefore the default unit `number` is used).

The fundamental issue here is that the logic in `aggregateFunctionOutputType` that depends on the `AGGREGATIONS` definitions can only work if it's getting the actual function call sent in the query (`avg(transaction.duration)`), and not the friendly version being used in the UI (`avg()`).

There are two options that I can see here:

1. Move [the relabeling of the series data](https://github.com/getsentry/sentry/blob/20fbccd5cc2c943b6b69a3bc3a9eca8c70adfe6f/static/app/views/performance/transactionSummary/transactionOverview/durationChart/index.tsx#L148-L152) from `DurationChart` to its child `Content` so that `Content` has the original label and can pass that to the functions determining the unit

2. Skip the unit determination entirely and trust that the Transaction Duration Breakdown widget always shows durations

I chose to go with option 2 because it seems reasonable that all time series on a Duration chart will be durations, and it matches [the hardcoding of the y-axis label to `duration`](https://github.com/getsentry/sentry/blob/20fbccd5cc2c943b6b69a3bc3a9eca8c70adfe6f/static/app/views/performance/transactionSummary/transactionOverview/durationChart/content.tsx#L130).