### PR TITLE
feat(trace): Add profile id to trace response

### DIFF
--- a/src/sentry/api/endpoints/organization_events_trace.py
+++ b/src/sentry/api/endpoints/organization_events_trace.py
@@ -59,6 +59,8 @@ SnubaTransaction = TypedDict(
         "root": str,
         "project.id": int,
         "project": str,
+        "profile.profile_id": str,
+        "profiler.id": str,
         "issue.ids": list[int],
         "occurrence_to_issue_id": dict[str, list[int]],
     },
@@ -138,6 +140,7 @@ FullResponse = TypedDict(
         "parent_span_id": Optional[str],
         "parent_event_id": Optional[str],
         "profile_id": Optional[str],
+        "profiler_id": Optional[str],
         "sdk_name": Optional[str],
         "generation": Optional[int],
         "errors": list[TraceError],
@@ -383,6 +386,7 @@ class TraceEvent:
             result["timestamp"] = self.event["precise.finish_ts"]
             result["start_timestamp"] = self.event["precise.start_ts"]
             result["profile_id"] = self.event["profile.id"]
+            result["profiler_id"] = self.event["profile.profiler_id"]
             result["sdk_name"] = self.event["sdk.name"]
             # TODO: once we're defaulting measurements we don't need this check
             if "measurements" in self.event:
@@ -396,6 +400,7 @@ class TraceEvent:
             profile_id = contexts.get("profile", {}).get("profile_id")
             if profile_id is not None:
                 result["profile_id"] = profile_id
+            result["profiler_id"] = self.event["profile.profiler_id"]
 
             if detailed:
                 if "measurements" in self.nodestore_event.data:
@@ -560,6 +565,7 @@ def query_trace_data(
         "project",
         "project.id",
         "profile.id",
+        "profile.profiler_id",
         "sdk.name",
         "trace.span",
         "trace.parent_span",

--- a/src/sentry/snuba/events.py
+++ b/src/sentry/snuba/events.py
@@ -754,6 +754,14 @@ class Columns(Enum):
         issue_platform_name="profile_id",
         alias="profile.id",
     )
+    PROFILE_PROFILER_ID = Column(
+        group_name="events.contexts[profile.profiler_id]",
+        event_name="contexts[profile.profiler_id]",
+        transaction_name="contexts[profile.profiler_id]",
+        discover_name="contexts[profile.profiler_id]",
+        issue_platform_name="contexts[profile.profiler_id]",
+        alias="profile.profiler_id",
+    )
 
     REPLAY_ID = Column(
         group_name=None,


### PR DESCRIPTION
- This adds the profiler.profile_id to the trace response, this is still slightly untested cause we don't have any sample events with this data yet