### PR TITLE
fix(queues): remove option for timing queued tasks

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1447,13 +1447,6 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 
-register(
-    "sentry-metrics.monitor-queue-time",
-    type=Bool,
-    default=False,
-    flags=FLAG_AUTOMATOR_MODIFIABLE,
-)
-
 # Performance issue option for *all* performance issues detection
 register("performance.issues.all.problem-detection", default=1.0, flags=FLAG_AUTOMATOR_MODIFIABLE)
 

--- a/src/sentry/tasks/base.py
+++ b/src/sentry/tasks/base.py
@@ -98,16 +98,6 @@ def instrumented_task(name, stat_suffix=None, silo_mode=None, record_timing=Fals
 
             # Use a try/catch here to contain the blast radius of an exception being unhandled through the options lib
             # Unhandled exception could cause all tasks to be effected and not work
-            try:
-                from sentry import options
-
-                # Use option to control default behavior of queue time monitoring
-                # Value can be dynamically updated, which is why the evaluation happens during function run-time
-                record_queue_wait_time = record_queue_wait_time or options.get(
-                    "sentry-metrics.monitor-queue-time"
-                )
-            except Exception:
-                pass
 
             # TODO(dcramer): we want to tag a transaction ID, but overriding
             # the base on app.task seems to cause problems w/ Celery internals


### PR DESCRIPTION
This is already default to `False` and the option has never been set. This also causes problems with `tests/sentry/tasks/test_options.py` because it's getting an option and polluting the calls to the mocked function.