### PR TITLE
fix(rules): Fix environment fetch

### DIFF
--- a/src/sentry/rules/actions/utils.py
+++ b/src/sentry/rules/actions/utils.py
@@ -126,7 +126,7 @@ def get_changed_data(
     if rule_data_before.get("environment_id") and not rule_data.get("environment_id"):
         environment = None
         try:
-            environment = Environment.objects.get(id=rule_data_before.get("environment_id"))
+            environment = Environment.objects.get(id=rule_data_before["environment_id"])
         except Environment.DoesNotExist:
             pass
 

--- a/src/sentry/rules/actions/utils.py
+++ b/src/sentry/rules/actions/utils.py
@@ -126,7 +126,7 @@ def get_changed_data(
     if rule_data_before.get("environment_id") and not rule_data.get("environment_id"):
         environment = None
         try:
-            environment = Environment.objects.get(id=rule_data.get("environment_id"))
+            environment = Environment.objects.get(id=rule_data_before.get("environment_id"))
         except Environment.DoesNotExist:
             pass
 

--- a/src/sentry/rules/actions/utils.py
+++ b/src/sentry/rules/actions/utils.py
@@ -116,7 +116,7 @@ def get_changed_data(
     if rule_data.get("environment_id") and not rule_data_before.get("environment_id"):
         environment = None
         try:
-            environment = Environment.objects.get(id=rule_data.get("environment_id"))
+            environment = Environment.objects.get(id=rule_data["environment_id"])
         except Environment.DoesNotExist:
             pass
 

--- a/tests/sentry/api/endpoints/test_project_rule_details.py
+++ b/tests/sentry/api/endpoints/test_project_rule_details.py
@@ -1,3 +1,4 @@
+
 from __future__ import annotations
 
 from collections.abc import Mapping


### PR DESCRIPTION
Copy/paste bug where the `.get()` was on the wrong variable for the environment and was always returning None so if an environment was present on the rule and then was removed, it wouldn't be added to the confirmation notification. See https://github.com/getsentry/sentry/pull/66847/files#r1662799957