### PR TITLE
ref(slack): return sdk client in get_client

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -406,6 +406,8 @@ def register_temporary_features(manager: FeatureManager):
     manager.add("organizations:slack-sdk-link-commands", OrganizationFeature, FeatureHandlerStrategy.OPTIONS)
     # Use new Slack SDK Client in SlackActionEndpoint
     manager.add("organizations:slack-sdk-webhook-handling", OrganizationFeature, FeatureHandlerStrategy.OPTIONS)
+    # Use new Slack SDK Client for SlackNotifyBasicMixin
+    manager.add("organizations:slack-sdk-notify-mixin", OrganizationFeature, FeatureHandlerStrategy.OPTIONS)
     # Add regression chart as image to slack message
     manager.add("organizations:slack-endpoint-regression-image", OrganizationFeature, FeatureHandlerStrategy.OPTIONS)
     manager.add("organizations:slack-function-regression-image", OrganizationFeature, FeatureHandlerStrategy.OPTIONS)

--- a/src/sentry/integrations/slack/integration.py
+++ b/src/sentry/integrations/slack/integration.py
@@ -9,6 +9,7 @@ from django.views import View
 from slack_sdk import WebClient
 from slack_sdk.errors import SlackApiError
 
+from sentry import features as sentry_features
 from sentry.identity.pipeline import IdentityProviderPipeline
 from sentry.integrations.base import (
     FeatureDescription,
@@ -17,6 +18,7 @@ from sentry.integrations.base import (
     IntegrationMetadata,
     IntegrationProvider,
 )
+from sentry.integrations.slack.sdk_client import SlackSdkClient
 from sentry.models.integrations.integration import Integration
 from sentry.pipeline import NestedPipelineView
 from sentry.services.hybrid_cloud.organization import RpcOrganizationSummary
@@ -71,8 +73,10 @@ metadata = IntegrationMetadata(
 
 
 class SlackIntegration(SlackNotifyBasicMixin, IntegrationInstallation):
-    def get_client(self) -> SlackClient:
-        return SlackClient(integration_id=self.model.id)
+    def get_client(self) -> SlackClient | SlackSdkClient:
+        # if sentry_features.has("organizations:slack-sdk-notify-mixin", self.organization):
+        return SlackSdkClient(integration_id=self.model.id)
+        # return SlackClient(integration_id=self.model.id)
 
     def get_config_data(self) -> Mapping[str, str]:
         metadata_ = self.model.metadata

--- a/src/sentry/integrations/slack/integration.py
+++ b/src/sentry/integrations/slack/integration.py
@@ -74,9 +74,9 @@ metadata = IntegrationMetadata(
 
 class SlackIntegration(SlackNotifyBasicMixin, IntegrationInstallation):
     def get_client(self) -> SlackClient | SlackSdkClient:
-        # if sentry_features.has("organizations:slack-sdk-notify-mixin", self.organization):
-        return SlackSdkClient(integration_id=self.model.id)
-        # return SlackClient(integration_id=self.model.id)
+        if sentry_features.has("organizations:slack-sdk-notify-mixin", self.organization):
+            return SlackSdkClient(integration_id=self.model.id)
+        return SlackClient(integration_id=self.model.id)
 
     def get_config_data(self) -> Mapping[str, str]:
         metadata_ = self.model.metadata

--- a/src/sentry/integrations/slack/notifications.py
+++ b/src/sentry/integrations/slack/notifications.py
@@ -50,11 +50,12 @@ class SlackNotifyBasicMixin(NotifyBasicMixin):
             try:
                 client.chat_postMessage(channel=channel_id, text=message)
             except SlackApiError as e:
-                message = str(e)
+                error = str(e)
+                message = error.split("\n")[0]
                 if "Expired url" not in message and "channel_not_found" not in message:
                     logger.exception(
                         "slack.slash-response.error",
-                        extra={"error": message},
+                        extra={"error": error},
                     )
 
 

--- a/tests/sentry/integrations/slack/test_link_team.py
+++ b/tests/sentry/integrations/slack/test_link_team.py
@@ -1,12 +1,15 @@
 from collections.abc import Mapping, Sequence
 from typing import Any, Optional
+from unittest.mock import patch
 from urllib.parse import urlencode
 
 import orjson
+import pytest
 import responses
 from django.db.models import QuerySet
 from django.http.response import HttpResponseBase
 from rest_framework import status
+from slack_sdk.web import SlackResponse
 
 from sentry.integrations.slack.views.link_team import build_team_linking_url
 from sentry.integrations.slack.views.unlink_team import build_team_unlinking_url
@@ -18,7 +21,7 @@ from sentry.models.team import Team
 from sentry.silo.base import SiloMode
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers import add_identity, get_response_text, install_slack, link_team
-from sentry.testutils.helpers.features import with_feature
+from sentry.testutils.helpers.features import Feature, with_feature
 from sentry.testutils.silo import assume_test_silo_mode
 
 
@@ -249,6 +252,159 @@ class SlackIntegrationLinkTeamTest(SlackIntegrationLinkTeamTestBase):
             assert len(team_settings) == 0
 
 
+class SlackIntegrationLinkTeamWithSdkTest(SlackIntegrationLinkTeamTestBase):
+    def setUp(self):
+        super().setUp()
+        self.url = build_team_linking_url(
+            integration=self.integration,
+            slack_id=self.external_id,
+            channel_id=self.channel_id,
+            channel_name=self.channel_name,
+            response_url=self.response_url,
+        )
+        self.team = self.create_team(
+            organization=self.organization, name="Mariachi Band", members=[self.user]
+        )
+
+    @pytest.fixture(autouse=True)
+    def mock_chat_postMessage(self):
+        with (
+            patch(
+                "slack_sdk.web.WebClient.chat_postMessage",
+                return_value=SlackResponse(
+                    client=None,
+                    http_verb="POST",
+                    api_url="https://slack.com/api/chat.postMessage",
+                    req_args={},
+                    data={"ok": True},
+                    headers={},
+                    status_code=200,
+                ),
+            ) as self.mock_post,
+            Feature("organizations:slack-sdk-notify-mixin"),
+        ):
+            yield
+
+    @responses.activate
+    def test_link_team(self):
+        """Test that we successfully link a team to a Slack channel"""
+        response = self.get_success_response()
+        self.assertTemplateUsed(response, "sentry/integrations/slack/link-team.html")
+
+        response = self.get_success_response(data={"team": self.team.id})
+        self.assertTemplateUsed(response, "sentry/integrations/slack/post-linked-team.html")
+
+        external_actors = self.get_linked_teams()
+        assert len(external_actors) == 1
+        assert external_actors[0].team_id == self.team.id
+
+        assert self.mock_post.call_count == 1
+        text = self.mock_post.call_args.kwargs["text"]
+        assert (
+            f"The {self.team.slug} team will now receive issue alert notifications in the {external_actors[0].external_name} channel."
+            in text
+        )
+
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            team_settings = NotificationSettingProvider.objects.filter(
+                team_id=self.team.id,
+                provider="slack",
+                type="alerts",
+                scope_type="team",
+                scope_identifier=self.team.id,
+                value="always",
+            )
+            assert len(team_settings) == 1
+
+    @responses.activate
+    def test_link_team_valid_through_team_admin(self):
+        """Test that we successfully link a team to a Slack channel as a valid team admin"""
+        self._create_user_valid_through_team_admin()
+
+        self.test_link_team()
+
+    @responses.activate
+    def test_link_team_already_linked(self):
+        """Test that if a team has already been linked to a Slack channel when a user tries
+        to link them again, we reject the attempt and reply with the ALREADY_LINKED_MESSAGE"""
+        self.link_team()
+
+        response = self.get_success_response(data={"team": self.team.id})
+        self.assertTemplateUsed(response, "sentry/integrations/slack/post-linked-team.html")
+        assert self.mock_post.call_count == 1
+        text = self.mock_post.call_args.kwargs["text"]
+        assert f"The {self.team.slug} team has already been linked to a Slack channel." in text
+
+    @responses.activate
+    def test_error_page(self):
+        """Test that we successfully render an error page when bad form data is sent."""
+        self.get_error_response(
+            data={"team": ["some", "garbage"]}, status_code=status.HTTP_400_BAD_REQUEST
+        )
+
+    @responses.activate
+    def test_link_team_multiple_organizations(self):
+        # Create another organization and team for this user that is linked through `self.integration`.
+        organization2 = self.create_organization(owner=self.user)
+        team2 = self.create_team(organization=organization2, members=[self.user])
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            self.create_organization_integration(
+                organization_id=organization2.id, integration=self.integration
+            )
+
+        # Team order should not matter.
+        for team in (self.team, team2):
+            response = self.get_success_response(data={"team": team.id})
+            self.assertTemplateUsed(response, "sentry/integrations/slack/post-linked-team.html")
+
+            external_actors = self.get_linked_teams(
+                organization=team.organization, team_ids=[team.id]
+            )
+            assert len(external_actors) == 1
+
+    @responses.activate
+    @with_feature("organizations:team-workflow-notifications")
+    def test_message_includes_workflow(self):
+        self.get_success_response(data={"team": self.team.id})
+        external_actors = self.get_linked_teams()
+
+        assert self.mock_post.call_count == 1
+        text = self.mock_post.call_args.kwargs["text"]
+        assert (
+            f"The {self.team.slug} team will now receive issue alert and workflow notifications in the {external_actors[0].external_name} channel."
+            in text
+        )
+
+    @responses.activate
+    @with_feature("organizations:team-workflow-notifications")
+    def test_link_team_v2(self):
+        """Test that we successfully link a team to a Slack channel"""
+        response = self.get_success_response()
+        self.assertTemplateUsed(response, "sentry/integrations/slack/link-team.html")
+
+        response = self.get_success_response(data={"team": self.team.id})
+        self.assertTemplateUsed(response, "sentry/integrations/slack/post-linked-team.html")
+
+        external_actors = self.get_linked_teams()
+        assert len(external_actors) == 1
+        assert external_actors[0].team_id == self.team.id
+
+        assert self.mock_post.call_count == 1
+        text = self.mock_post.call_args.kwargs["text"]
+        assert (
+            f"The {self.team.slug} team will now receive issue alert and workflow notifications in the {external_actors[0].external_name} channel."
+            in text
+        )
+
+        # Test that we didn't make an NotificationSetting object
+        # Instead we will use the default in notificationcontroller.py
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            team_settings = NotificationSettingProvider.objects.filter(
+                team_id=self.team.id,
+            )
+            assert len(team_settings) == 0
+
+
 class SlackIntegrationUnlinkTeamTest(SlackIntegrationLinkTeamTestBase):
     def setUp(self):
         super().setUp()
@@ -321,6 +477,145 @@ class SlackIntegrationUnlinkTeamTest(SlackIntegrationLinkTeamTestBase):
         assert (
             f"This channel will no longer receive issue alert notifications for the {self.team.slug} team."
             in get_response_text(data)
+        )
+
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            team_settings = NotificationSettingProvider.objects.filter(team_id=self.team.id)
+        assert len(team_settings) == 0
+
+    @responses.activate
+    def test_unlink_team_multiple_organizations(self):
+        # Create another organization and team for this user that is linked through `self.integration`.
+        organization2 = self.create_organization(owner=self.user)
+        team2 = self.create_team(organization=organization2, members=[self.user])
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            self.create_organization_integration(
+                organization_id=organization2.id, integration=self.integration
+            )
+        self.link_team(team2)
+
+        # Team order should not matter.
+        for team in (self.team, team2):
+            external_actors = self.get_linked_teams(
+                organization=team.organization, team_ids=[team.id]
+            )
+            assert len(external_actors) == 1
+
+            # Override the URL.
+            self.url = build_team_unlinking_url(
+                integration=self.integration,
+                organization_id=team.organization.id,
+                slack_id=self.external_id,
+                channel_id=self.channel_id,
+                channel_name=self.channel_name,
+                response_url=self.response_url,
+            )
+            response = self.get_success_response(data={})
+            self.assertTemplateUsed(response, "sentry/integrations/slack/unlinked-team.html")
+
+            external_actors = self.get_linked_teams(
+                organization=team.organization, team_ids=[team.id]
+            )
+            assert len(external_actors) == 0
+
+    @responses.activate
+    def test_unlink_team_invalid_method(self):
+        """Test for an invalid method response"""
+        response = self.client.put(self.url, content_type="application/x-www-form-urlencoded")
+        assert response.status_code == status.HTTP_405_METHOD_NOT_ALLOWED
+
+
+class SlackIntegrationUnlinkTeamTestWithSdk(SlackIntegrationLinkTeamTestBase):
+    def setUp(self):
+        super().setUp()
+
+        self.link_team()
+        self.url = build_team_unlinking_url(
+            integration=self.integration,
+            organization_id=self.organization.id,
+            slack_id=self.external_id,
+            channel_id=self.channel_id,
+            channel_name=self.channel_name,
+            response_url=self.response_url,
+        )
+
+    @pytest.fixture(autouse=True)
+    def mock_chat_postMessage(self):
+        with (
+            patch(
+                "slack_sdk.web.WebClient.chat_postMessage",
+                return_value=SlackResponse(
+                    client=None,
+                    http_verb="POST",
+                    api_url="https://slack.com/api/chat.postMessage",
+                    req_args={},
+                    data={"ok": True},
+                    headers={},
+                    status_code=200,
+                ),
+            ) as self.mock_post,
+            Feature("organizations:slack-sdk-notify-mixin"),
+        ):
+            yield
+
+    @responses.activate
+    def test_unlink_team(self):
+        """Test that a team can be unlinked from a Slack channel"""
+        response = self.get_success_response()
+        self.assertTemplateUsed(response, "sentry/integrations/slack/unlink-team.html")
+
+        response = self.get_success_response(data={})
+        self.assertTemplateUsed(response, "sentry/integrations/slack/unlinked-team.html")
+
+        external_actors = self.get_linked_teams()
+        assert len(external_actors) == 0
+
+        assert self.mock_post.call_count == 1
+        text = self.mock_post.call_args.kwargs["text"]
+        assert (
+            f"This channel will no longer receive issue alert notifications for the {self.team.slug} team."
+            in text
+        )
+
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            team_settings = NotificationSettingProvider.objects.filter(team_id=self.team.id)
+        assert len(team_settings) == 0
+
+    @responses.activate
+    def test_unlink_team_valid_through_team_admin(self):
+        """Test that a team can be unlinked from a Slack channel as a valid team admin"""
+        self._create_user_valid_through_team_admin()
+
+        self.test_unlink_team()
+
+    @responses.activate
+    def test_unlink_multiple_teams(self):
+        """
+        Test that if you have linked multiple teams to a single channel, when
+        you type `/sentry unlink team`, we unlink all teams from that channel.
+        This should only apply to the one organization who did this before we
+        blocked users from doing so.
+        """
+        team2 = self.create_team(organization=self.organization, name="Team Hellboy")
+        self.link_team(team2)
+
+        external_actors = self.get_linked_teams([self.team.id, team2.id])
+        assert len(external_actors) == 2
+
+        response = self.get_success_response()
+        self.assertTemplateUsed(response, "sentry/integrations/slack/unlink-team.html")
+
+        response = self.get_success_response(data={})
+        self.assertTemplateUsed(response, "sentry/integrations/slack/unlinked-team.html")
+
+        external_actors = self.get_linked_teams([self.team.id, team2.id])
+        assert len(external_actors) == 0
+
+        assert self.mock_post.call_count >= 1
+        text = self.mock_post.call_args_list[0].kwargs["text"]
+        assert (
+            f"This channel will no longer receive issue alert notifications for the {self.team.slug} team."
+            in text
         )
 
         with assume_test_silo_mode(SiloMode.CONTROL):


### PR DESCRIPTION
Adds feature-flagged usage of the Slack SDK WebClient in `SlackIntegration.get_client()`. This is used in `notify_remove_external_team` in `NotifyBasicMixin`, which `SlackIntegration` subclasses.