### PR TITLE
feat(option): Add option to control MEP flag in STs

### DIFF
--- a/src/sentry/api/serializers/models/organization.py
+++ b/src/sentry/api/serializers/models/organization.py
@@ -10,7 +10,7 @@ from rest_framework import serializers
 from sentry_relay.auth import PublicKey
 from sentry_relay.exceptions import RelayError
 
-from sentry import features, onboarding_tasks, quotas, roles
+from sentry import features, onboarding_tasks, options, quotas, roles
 from sentry.api.fields.sentry_slug import SentrySerializerSlugField
 from sentry.api.serializers import Serializer, register, serialize
 from sentry.api.serializers.models.project import ProjectSerializerResponse
@@ -302,6 +302,8 @@ class OrganizationSerializer(Serializer):
         if not getattr(obj.flags, "disable_shared_issues"):
             feature_set.add("shared-issues")
         if "dynamic-sampling" not in feature_set and "mep-rollout-flag" in feature_set:
+            feature_set.remove("mep-rollout-flag")
+        if options.get("performance.hide-metrics-ui") and "mep-rollout-flag" in feature_set:
             feature_set.remove("mep-rollout-flag")
 
         return feature_set

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1781,6 +1781,10 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 
+# In Single Tenant with 100% DS, we may need to reverse the UI change made by dynamic-sampling
+# if metrics extraction isn't ready.
+register("performance.hide-metrics-ui", type=Bool, default=False, flags=FLAG_AUTOMATOR_MODIFIABLE)
+
 # Used for enabling flags in ST. Should be removed once Flagpole works in all STs.
 register(
     "performance.use_metrics.orgs_allowlist",


### PR DESCRIPTION
### Summary
This will allow us to remove mep-rollout-flag from the serialized features, not providing it to the UI, essentially hiding it. This is for Single Tenants where we may not want to display metrics extraction.
