### PR TITLE
feat(trace): Add span extraction date option

### DIFF
--- a/src/sentry/api/serializers/models/organization.py
+++ b/src/sentry/api/serializers/models/organization.py
@@ -350,6 +350,14 @@ class OrganizationSerializer(Serializer):
 
         if include_feature_flags:
             context["features"] = self.get_feature_set(obj, attrs, user, **kwargs)
+            context["extraOptions"] = {
+                "traces": {
+                    "spansExtractionDate": options.get("performance.traces.spans_extraction_date"),
+                    "checkSpanExtractionDate": options.get(
+                        "performance.traces.check_span_extraction_date"
+                    ),
+                }
+            }
 
         if "access" in kwargs:
             context["access"] = kwargs["access"].scopes

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1757,10 +1757,16 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 register(
+    "performance.traces.check_span_extraction_date",
+    type=Bool,
+    default=False,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+register(
     # the timestamp that spans extraction was enabled for this environment
     "performance.traces.spans_extraction_date",
     type=Int,
-    flags=FLAG_ALLOW_EMPTY | FLAG_AUTOMATOR_MODIFIABLE,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 
 register(

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1757,6 +1757,13 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 register(
+    # the timestamp that spans extraction was enabled for this environment
+    "performance.traces.spans_extraction_date",
+    type=Int,
+    flags=FLAG_ALLOW_EMPTY | FLAG_AUTOMATOR_MODIFIABLE,
+)
+
+register(
     "performance.spans-tags-key.sample-rate",
     type=Float,
     default=1.0,


### PR DESCRIPTION
- Add an option that the FE will use to enable/disable the useSpans option based on the timestamp of the trace so we can enable spans only after the current environment has started ingesting span data