### PR TITLE
fix(rules): Use the right comparison interval mapping

### DIFF
--- a/src/sentry/rules/processing/delayed_processing.py
+++ b/src/sentry/rules/processing/delayed_processing.py
@@ -15,6 +15,7 @@ from sentry.models.rule import Rule
 from sentry.models.rulesnooze import RuleSnooze
 from sentry.rules import history, rules
 from sentry.rules.conditions.event_frequency import (
+    COMPARISON_INTERVALS,
     DEFAULT_COMPARISON_INTERVAL,
     BaseEventFrequencyCondition,
     ComparisonType,
@@ -189,7 +190,7 @@ def get_condition_group_results(
         # The comparison interval is only set for the second query of a percent
         # comparison condition.
         comparison_interval = (
-            condition_inst.intervals[unique_condition.comparison_interval][1]
+            COMPARISON_INTERVALS[unique_condition.comparison_interval][1]
             if unique_condition.comparison_interval
             else None
         )

--- a/tests/sentry/rules/processing/test_delayed_processing.py
+++ b/tests/sentry/rules/processing/test_delayed_processing.py
@@ -736,8 +736,8 @@ class ProcessDelayedAlertConditionsTest(
     def test_apply_delayed_event_frequency_percent_comparison_interval(self):
         """
         Test that the event frequency percent condition with a percent
-        comparison uses the right comparison interval mapping and does not fail
-        with a KeyError.
+        comparison is using the COMPARISON_INTERVALS for it's
+        comparison_interval and does not fail with a KeyError.
         """
         percent_condition = self.create_event_frequency_condition(
             id="EventFrequencyPercentCondition",

--- a/tests/sentry/rules/processing/test_delayed_processing.py
+++ b/tests/sentry/rules/processing/test_delayed_processing.py
@@ -733,6 +733,40 @@ class ProcessDelayedAlertConditionsTest(
         assert (percent_comparison_rule.id, group5.id) in rule_fire_histories
         self.assert_buffer_cleared(project_id=self.project.id)
 
+    def test_apply_delayed_event_frequency_percent_comparison_interval(self):
+        """
+        Test that the event frequency percent condition with a percent
+        comparison uses the right comparison interval mapping and does not fail
+        with a KeyError.
+        """
+        percent_condition = self.create_event_frequency_condition(
+            id="EventFrequencyPercentCondition",
+            interval="1h",
+            value=50,
+            comparison_type=ComparisonType.PERCENT,
+            comparison_interval="1d",
+        )
+        percent_comparison_rule = self.create_project_rule(
+            project=self.project,
+            condition_match=[percent_condition],
+        )
+
+        event5 = self.create_event(self.project.id, FROZEN_TIME, "group-5")
+        self.push_to_hash(
+            self.project.id, percent_comparison_rule.id, event5.group.id, event5.event_id
+        )
+
+        project_ids = buffer.backend.get_sorted_set(
+            PROJECT_ID_BUFFER_LIST_KEY, 0, self.buffer_timestamp
+        )
+        apply_delayed(project_ids[0][0])
+
+        assert not RuleFireHistory.objects.filter(
+            rule__in=[percent_comparison_rule],
+            project=self.project,
+        ).exists()
+        self.assert_buffer_cleared(project_id=self.project.id)
+
     def _setup_count_percent_test(self) -> int:
         fires_percent_condition = self.create_event_frequency_condition(
             interval="1h",


### PR DESCRIPTION
`EventFrequencyPercentCondition` with a percent comparison would fail with a KeyError when trying to get the timedelta for the `comparison_interval`. This is b/c we were using the class variable `intervals`
https://github.com/getsentry/sentry/blob/3b3b250b5268263577ba9189f0b707d299b11d58/src/sentry/rules/processing/delayed_processing.py#L192 instead of the `COMPARISON_INTERVALS` which is used correctly when not bulk querying:
https://github.com/getsentry/sentry/blob/3b3b250b5268263577ba9189f0b707d299b11d58/src/sentry/rules/conditions/event_frequency.py#L176


`EventFrequencyPercentCondition` has different class `intervals` that's missing some keys from `COMPARISON_INTERVALS`, causing the `KeyError` to occur. For example, if `comparison_interval` was `"1d"` or `"1w"`.
https://github.com/getsentry/sentry/blob/3b3b250b5268263577ba9189f0b707d299b11d58/src/sentry/rules/conditions/event_frequency.py#L490-L496

Fixes SENTRY-3BB5
Fixes ALRT-123