### PR TITLE
ref(seer grouping): Only send 20 frames if stacktrace is fully minified

### DIFF
--- a/src/sentry/seer/similarity/utils.py
+++ b/src/sentry/seer/similarity/utils.py
@@ -52,12 +52,10 @@ def get_stacktrace_string(data: dict[str, Any]) -> str:
                     for frame in exception_value["values"]
                     if frame.get("id") == "frame" and frame.get("contributes")
                 ]
-                num_frames = len(contributing_frames)
-                if frame_count + num_frames > MAX_FRAME_COUNT:
-                    remaining_frame_count = MAX_FRAME_COUNT - frame_count
-                    contributing_frames = contributing_frames[-remaining_frame_count:]
-                    num_frames = remaining_frame_count
-                frame_count += num_frames
+                contributing_frames = _discard_excess_frames(
+                    contributing_frames, MAX_FRAME_COUNT, frame_count
+                )
+                frame_count += len(contributing_frames)
 
                 for frame in contributing_frames:
                     frame_dict = {"filename": "", "function": "", "context-line": ""}

--- a/tests/sentry/seer/similarity/test_utils.py
+++ b/tests/sentry/seer/similarity/test_utils.py
@@ -1,6 +1,6 @@
 import copy
 from collections.abc import Callable
-from typing import Any, Literal
+from typing import Any, Literal, cast
 from uuid import uuid1
 
 from sentry.eventstore.models import Event
@@ -539,6 +539,100 @@ class GetStacktraceStringTest(TestCase):
         )
         assert stacktrace_str == expected
 
+    def test_chained_too_many_frames_all_minified_js(self):
+        data_chained_exception = copy.deepcopy(self.CHAINED_APP_DATA)
+        data_chained_exception["app"]["component"]["values"][0]["values"] = [
+            self.create_exception(
+                exception_type_str="InnerException",
+                exception_value="nope",
+                frames=self.create_frames(
+                    num_frames=15,
+                    context_line_factory=lambda i: f"inner line {i}",
+                    minified_frames="all",
+                ),
+            ),
+            self.create_exception(
+                exception_type_str="MiddleException",
+                exception_value="un-uh",
+                frames=self.create_frames(
+                    num_frames=15,
+                    context_line_factory=lambda i: f"middle line {i}",
+                    minified_frames="all",
+                ),
+            ),
+            self.create_exception(
+                exception_type_str="OuterException",
+                exception_value="no way",
+                frames=self.create_frames(
+                    num_frames=15,
+                    context_line_factory=lambda i: f"outer line {i}",
+                    minified_frames="all",
+                ),
+            ),
+        ]
+        stacktrace_str = get_stacktrace_string(data_chained_exception)
+
+        # The stacktrace string should be:
+        #    15 frames from OuterExcepton (with lines counting up from 1 to 15), followed by
+        #    5 frames from MiddleExcepton (with lines counting up from 11 to 15), followed by
+        #    no frames from InnerExcepton (though the type and value are in there)
+        expected = "".join(
+            ["OuterException: no way"]
+            + [
+                f'\n  File "hello.py", function hello_there\n    {{snip}}outer line {i}{{snip}}'
+                for i in range(1, 16)  #
+            ]
+            + ["\nMiddleException: un-uh"]
+            + [
+                f'\n  File "hello.py", function hello_there\n    {{snip}}middle line {i}{{snip}}'
+                for i in range(11, 16)
+            ]
+            + ["\nInnerException: nope"]
+        )
+        assert stacktrace_str == expected
+
+    def test_chained_too_many_frames_minified_js_frame_limit(self):
+        """Test that we restrict fully-minified stacktraces to 20 frames, and all other stacktraces to 50 frames."""
+        for minified_frames, expected_frame_count in [("all", 20), ("some", 50), ("none", 50)]:
+            data_chained_exception = copy.deepcopy(self.CHAINED_APP_DATA)
+            data_chained_exception["app"]["component"]["values"][0]["values"] = [
+                self.create_exception(
+                    exception_type_str="InnerException",
+                    exception_value="nope",
+                    frames=self.create_frames(
+                        num_frames=30,
+                        context_line_factory=lambda i: f"inner line {i}",
+                        minified_frames=cast(Literal["all", "some", "none"], minified_frames),
+                    ),
+                ),
+                self.create_exception(
+                    exception_type_str="MiddleException",
+                    exception_value="un-uh",
+                    frames=self.create_frames(
+                        num_frames=30,
+                        context_line_factory=lambda i: f"middle line {i}",
+                        minified_frames=cast(Literal["all", "some", "none"], minified_frames),
+                    ),
+                ),
+                self.create_exception(
+                    exception_type_str="OuterException",
+                    exception_value="no way",
+                    frames=self.create_frames(
+                        num_frames=30,
+                        context_line_factory=lambda i: f"outer line {i}",
+                        minified_frames=cast(Literal["all", "some", "none"], minified_frames),
+                    ),
+                ),
+            ]
+            stacktrace_str = get_stacktrace_string(data_chained_exception)
+
+            assert (
+                stacktrace_str.count("outer line")
+                + stacktrace_str.count("middle line")
+                + stacktrace_str.count("inner line")
+                == expected_frame_count
+            )
+
     def test_thread(self):
         stacktrace_str = get_stacktrace_string(self.MOBILE_THREAD_DATA)
         assert stacktrace_str == 'File "", function TestHandler'
@@ -594,6 +688,23 @@ class GetStacktraceStringTest(TestCase):
             num_frames += 1
             assert ("test = " + str(i) + "!") in stacktrace_str
         assert num_frames == 50
+
+    def test_too_many_frames_minified_js_frame_limit(self):
+        """Test that we restrict fully-minified stacktraces to 20 frames, and all other stacktraces to 50 frames."""
+        for minified_frames, expected_frame_count in [("all", 20), ("some", 50), ("none", 50)]:
+            data_frames = copy.deepcopy(self.BASE_APP_DATA)
+            data_frames["app"]["component"]["values"] = [
+                self.create_exception(
+                    frames=self.create_frames(
+                        num_frames=60,
+                        context_line_factory=lambda i: f"context line {i}",
+                        minified_frames=cast(Literal["all", "some", "none"], minified_frames),
+                    ),
+                ),
+            ]
+            stacktrace_str = get_stacktrace_string(data_frames)
+
+            assert stacktrace_str.count("context line") == expected_frame_count
 
     def test_no_exception(self):
         data_no_exception = copy.deepcopy(self.BASE_APP_DATA)


### PR DESCRIPTION
When creating embeddings, Seer first has to tokenize the stacktrace string it's sent, and the number of tokens it finds is one of the strongest predictors of its performance. 

In non-minified code, there is generally one instruction per line, resulting in a handful of tokens. In minified code, however, not only are multiple instructions squished onto the same line, but all the nice, however-many-characters-long, human-readable function and variable names have been replaced by one- or two-character names, making even more instructions fit into a single context line. (We truncate context lines to roughly 140 characters, which saves us from collecting an entire bundled script as the context line, but that still can let in a fair number of instructions, given they all look like `if x:`, `te+=1`, `m=e(q,d)`, etc.)

Minified code is therefore significantly more token-dense than non-minified code. This - combined with the fact that minified code groups terribly and therefore events consisting of it are more likely to be sent to Seer in the first place, making them a disproportionate share of Seer's workload - means that it becomes much easier for Seer to get overloaded.

To prevent this, this PR lowers the maximum number of frames in a Seer stacktrace string from 50 to 20 in cases where we have a fully minified stacktrace. (An analysis comparing the results before and after this change showed no significant drop in accuracy.)