### PR TITLE
feat(new-trace): Route to traceView if traceSlug from query is not null.

### DIFF
--- a/static/app/views/discover/table/tableView.tsx
+++ b/static/app/views/discover/table/tableView.tsx
@@ -190,7 +190,7 @@ function TableView(props: TableViewProps) {
 
       let target;
 
-      if (dataRow.trace === null) {
+      if (dataRow.trace == null) {
         if (dataRow['event.type'] === 'transaction') {
           throw new Error(
             'Transaction event should always have a trace associated with it.'
@@ -198,7 +198,6 @@ function TableView(props: TableViewProps) {
         }
 
         const project = dataRow.project || dataRow['project.name'];
-
         target = {
           // NOTE: This uses a legacy redirect for project event to the issue group event link
           // This only works with dev-server or production.
@@ -322,7 +321,7 @@ function TableView(props: TableViewProps) {
     if (columnKey === 'id') {
       let target;
 
-      if (dataRow.trace === null) {
+      if (dataRow.trace == null) {
         if (dataRow['event.type'] === 'transaction') {
           throw new Error(
             'Transaction event should always have a trace associated with it.'

--- a/static/app/views/discover/table/tableView.tsx
+++ b/static/app/views/discover/table/tableView.tsx
@@ -202,7 +202,9 @@ function TableView(props: TableViewProps) {
         target = {
           // NOTE: This uses a legacy redirect for project event to the issue group event link
           // This only works with dev-server or production.
-          pathname: `/${organization.slug}/${project}/events/${dataRow.id}/`,
+          pathname: normalizeUrl(
+            `/${organization.slug}/${project}/events/${dataRow.id}/`
+          ),
           query: {...location.query, referrer: 'discover-events-table'},
         };
       } else {
@@ -332,7 +334,9 @@ function TableView(props: TableViewProps) {
         target = {
           // NOTE: This uses a legacy redirect for project event to the issue group event link.
           // This only works with dev-server or production.
-          pathname: `/${organization.slug}/${project}/events/${dataRow.id}/`,
+          pathname: normalizeUrl(
+            `/${organization.slug}/${project}/events/${dataRow.id}/`
+          ),
           query: {...location.query, referrer: 'discover-events-table'},
         };
       } else {

--- a/static/app/views/discover/table/tableView.tsx
+++ b/static/app/views/discover/table/tableView.tsx
@@ -189,13 +189,22 @@ function TableView(props: TableViewProps) {
       }
 
       let target;
-      if (dataRow['event.type'] === 'transaction') {
-        if (dataRow.trace === null) {
+
+      if (dataRow.trace === null) {
+        if (dataRow['event.type'] === 'transaction') {
           throw new Error(
             'Transaction event should always have a trace associated with it.'
           );
         }
 
+        const project = dataRow.project || dataRow['project.name'];
+
+        target = {
+          // NOTE: This uses a legacy redirect for project event to the issue group event link
+          pathname: `/${organization.slug}/${project}/events/${dataRow.id}/`,
+          query: {...location.query, referrer: 'discover-events-table'},
+        };
+      } else {
         target = generateLinkToEventInTraceView({
           traceSlug: dataRow.trace,
           eventId: dataRow.id,
@@ -208,14 +217,6 @@ function TableView(props: TableViewProps) {
           type: 'discover',
           source: TraceViewSources.DISCOVER,
         });
-      } else {
-        const project = dataRow.project || dataRow['project.name'];
-
-        target = {
-          // NOTE: This uses a legacy redirect for project event to the issue group event link
-          pathname: `/${organization.slug}/${project}/events/${dataRow.id}/`,
-          query: {...location.query, referrer: 'discover-events-table'},
-        };
       }
 
       const eventIdLink = (
@@ -318,13 +319,22 @@ function TableView(props: TableViewProps) {
     if (columnKey === 'id') {
       let target;
 
-      if (dataRow['event.type'] === 'transaction') {
-        if (dataRow.trace === null) {
+      if (dataRow.trace === null) {
+        if (dataRow['event.type'] === 'transaction') {
           throw new Error(
             'Transaction event should always have a trace associated with it.'
           );
         }
 
+        const project = dataRow.project || dataRow['project.name'];
+
+        target = {
+          // NOTE: This uses a legacy redirect for project event to the issue group event link.
+          // This only works with dev-server or production.
+          pathname: `/${organization.slug}/${project}/events/${dataRow.id}/`,
+          query: {...location.query, referrer: 'discover-events-table'},
+        };
+      } else {
         target = generateLinkToEventInTraceView({
           traceSlug: dataRow.trace?.toString(),
           eventId: dataRow.id,
@@ -337,14 +347,6 @@ function TableView(props: TableViewProps) {
           type: 'discover',
           source: TraceViewSources.DISCOVER,
         });
-      } else {
-        const project = dataRow.project || dataRow['project.name'];
-
-        target = {
-          // NOTE: This uses a legacy redirect for project event to the issue group event link
-          pathname: `/${organization.slug}/${project}/events/${dataRow.id}/`,
-          query: {...location.query, referrer: 'discover-events-table'},
-        };
       }
 
       const idLink = (

--- a/static/app/views/discover/table/tableView.tsx
+++ b/static/app/views/discover/table/tableView.tsx
@@ -201,6 +201,7 @@ function TableView(props: TableViewProps) {
 
         target = {
           // NOTE: This uses a legacy redirect for project event to the issue group event link
+          // This only works with dev-server or production.
           pathname: `/${organization.slug}/${project}/events/${dataRow.id}/`,
           query: {...location.query, referrer: 'discover-events-table'},
         };


### PR DESCRIPTION
Initially we were only routing to the trace from when the event_id was associated to a transaction.