### PR TITLE
ref(seer grouping): Add `module` values to Seer stacktrace strings

### DIFF
--- a/src/sentry/seer/similarity/utils.py
+++ b/src/sentry/seer/similarity/utils.py
@@ -62,7 +62,7 @@ def get_stacktrace_string(data: dict[str, Any]) -> str:
                 frame_count += len(contributing_frames)
 
                 for frame in contributing_frames:
-                    frame_dict = {"filename": "", "function": "", "context-line": ""}
+                    frame_dict = {"module": "", "filename": "", "function": "", "context-line": ""}
                     for frame_values in frame.get("values", []):
                         if frame_values.get("id") in frame_dict:
                             frame_dict[frame_values["id"]] = _get_value_if_exists(frame_values)
@@ -71,7 +71,7 @@ def get_stacktrace_string(data: dict[str, Any]) -> str:
                         found_non_snipped_context_line = True
 
                     frame_strings.append(
-                        f'  File "{frame_dict["filename"]}", function {frame_dict["function"]}\n    {frame_dict["context-line"]}\n'
+                        f'  Module "{frame_dict["module"]}", file "{frame_dict["filename"]}", function {frame_dict["function"]}\n    {frame_dict["context-line"]}\n'
                     )
         # Only exceptions have the type and value properties, so we don't need to handle the threads
         # case here

--- a/tests/sentry/api/endpoints/test_group_similar_issues_embeddings.py
+++ b/tests/sentry/api/endpoints/test_group_similar_issues_embeddings.py
@@ -17,7 +17,7 @@ from sentry.testutils.cases import APITestCase
 from sentry.testutils.helpers.eventprocessing import save_new_event
 from sentry.utils.types import NonNone
 
-EXPECTED_STACKTRACE_STRING = 'ZeroDivisionError: division by zero\n  File "python_onboarding.py", function divide_by_zero\n    divide = 1/0'
+EXPECTED_STACKTRACE_STRING = 'ZeroDivisionError: division by zero\n  Module "__main__", file "python_onboarding.py", function divide_by_zero\n    divide = 1/0'
 
 
 class GroupSimilarIssuesEmbeddingsTest(APITestCase):
@@ -87,6 +87,13 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
                     "id": "value",
                     "name": None,
                     "contributes": False,
+                    "hint": None,
+                    "values": [exception_value],
+                },
+                {
+                    "id": "module",
+                    "name": None,
+                    "contributes": True,
                     "hint": None,
                     "values": [exception_value],
                 },

--- a/tests/sentry/seer/similarity/test_utils.py
+++ b/tests/sentry/seer/similarity/test_utils.py
@@ -14,7 +14,7 @@ from sentry.testutils.cases import TestCase
 
 
 class GetStacktraceStringTest(TestCase):
-    EXPECTED_STACKTRACE_STRING = 'ZeroDivisionError: division by zero\n  File "python_onboarding.py", function divide_by_zero\n    divide = 1/0'
+    EXPECTED_STACKTRACE_STRING = 'ZeroDivisionError: division by zero\n  Module "__main__", file "python_onboarding.py", function divide_by_zero\n    divide = 1/0'
     BASE_APP_DATA: dict[str, Any] = {
         "app": {
             "type": "component",
@@ -418,6 +418,13 @@ class GetStacktraceStringTest(TestCase):
                     "hint": None,
                     "values": [
                         {
+                            "id": "module",
+                            "name": None,
+                            "contributes": contributes,
+                            "hint": None,
+                            "values": ["__main__"],
+                        },
+                        {
                             "id": "filename",
                             "name": None,
                             "contributes": contributes,
@@ -488,7 +495,11 @@ class GetStacktraceStringTest(TestCase):
     def test_chained(self):
         stacktrace_str = get_stacktrace_string(self.CHAINED_APP_DATA)
         expected_stacktrace_str = (
-            'Exception: Catch divide by zero error\n  File "python_onboarding.py", function <module>\n    divide_by_zero()\n  File "python_onboarding.py", function divide_by_zero\n    raise Exception("Catch divide by zero error")\n'
+            "Exception: Catch divide by zero error\n"
+            + '  Module "__main__", file "python_onboarding.py", function <module>\n'
+            + "    divide_by_zero()\n"
+            + '  Module "__main__", file "python_onboarding.py", function divide_by_zero\n'
+            + '    raise Exception("Catch divide by zero error")\n'
             + self.EXPECTED_STACKTRACE_STRING
         )
         assert stacktrace_str == expected_stacktrace_str
@@ -527,12 +538,12 @@ class GetStacktraceStringTest(TestCase):
         expected = "".join(
             ["OuterException: no way"]
             + [
-                f'\n  File "hello.py", function hello_there\n    outer line {i}'
+                f'\n  Module "__main__", file "hello.py", function hello_there\n    outer line {i}'
                 for i in range(1, 26)  #
             ]
             + ["\nMiddleException: un-uh"]
             + [
-                f'\n  File "hello.py", function hello_there\n    middle line {i}'
+                f'\n  Module "__main__", file "hello.py", function hello_there\n    middle line {i}'
                 for i in range(21, 26)
             ]
             + ["\nInnerException: nope"]
@@ -579,12 +590,12 @@ class GetStacktraceStringTest(TestCase):
         expected = "".join(
             ["OuterException: no way"]
             + [
-                f'\n  File "hello.py", function hello_there\n    {{snip}}outer line {i}{{snip}}'
+                f'\n  Module "__main__", file "hello.py", function hello_there\n    {{snip}}outer line {i}{{snip}}'
                 for i in range(1, 16)  #
             ]
             + ["\nMiddleException: un-uh"]
             + [
-                f'\n  File "hello.py", function hello_there\n    {{snip}}middle line {i}{{snip}}'
+                f'\n  Module "__main__", file "hello.py", function hello_there\n    {{snip}}middle line {i}{{snip}}'
                 for i in range(11, 16)
             ]
             + ["\nInnerException: nope"]
@@ -635,7 +646,7 @@ class GetStacktraceStringTest(TestCase):
 
     def test_thread(self):
         stacktrace_str = get_stacktrace_string(self.MOBILE_THREAD_DATA)
-        assert stacktrace_str == 'File "", function TestHandler'
+        assert stacktrace_str == 'Module "", file "", function TestHandler'
 
     def test_system(self):
         data_system = copy.deepcopy(self.BASE_APP_DATA)

--- a/tests/sentry/tasks/test_backfill_seer_grouping_records.py
+++ b/tests/sentry/tasks/test_backfill_seer_grouping_records.py
@@ -61,9 +61,7 @@ EXCEPTION = {
         }
     ],
 }
-EXCEPTION_STACKTRACE_STRING = (
-    'ZeroDivisionError: division by zero\n  File "python_onboarding.py", function divide_by_zero'
-)
+EXCEPTION_STACKTRACE_STRING = 'ZeroDivisionError: division by zero\n  Module "__main__", file "python_onboarding.py", function divide_by_zero'
 
 
 @django_db_all
@@ -187,7 +185,7 @@ class TestBackfillSeerGroupingRecords(SnubaTestCase, TestCase):
             for event in events
         ]
         expected_stacktraces = [
-            f'Error{i}: error with value\n  File "function_{i}.py", function function_{i}'
+            f'Error{i}: error with value\n  Module "__main__", file "function_{i}.py", function function_{i}'
             for i in range(5)
         ]
         assert nodestore_results["data"] == expected_group_data
@@ -216,7 +214,7 @@ class TestBackfillSeerGroupingRecords(SnubaTestCase, TestCase):
             for event in events
         ]
         expected_stacktraces = [
-            f'Error{i}: error with value\n  File "function_{i}.py", function function_{i}'
+            f'Error{i}: error with value\n  Module "__main__", file "function_{i}.py", function function_{i}'
             for i in range(5)
         ]
         assert nodestore_results["data"] == expected_group_data
@@ -286,7 +284,7 @@ class TestBackfillSeerGroupingRecords(SnubaTestCase, TestCase):
             for event in events
         ]
         expected_stacktraces = [
-            f'Error{i}: error with value\n  File "function_{i}.py", function function_{i}'
+            f'Error{i}: error with value\n  Module "__main__", file "function_{i}.py", function function_{i}'
             for i in range(2)
         ]
         # assert bulk_event_ids == {event.event_id for event in events}
@@ -321,7 +319,7 @@ class TestBackfillSeerGroupingRecords(SnubaTestCase, TestCase):
             for event in events
         ]
         expected_stacktraces = [
-            f'Error{i}: error with value\n  File "function_{i}.py", function function_{i}'
+            f'Error{i}: error with value\n  Module "__main__", file "function_{i}.py", function function_{i}'
             for i in range(2)
         ]
         assert bulk_group_data_stacktraces["data"] == expected_group_data
@@ -349,7 +347,7 @@ class TestBackfillSeerGroupingRecords(SnubaTestCase, TestCase):
             for event in events
         ]
         expected_stacktraces = [
-            f'Error{i}: error with value\n  File "function_{i}.py", function function_{i}'
+            f'Error{i}: error with value\n  Module "__main__", file "function_{i}.py", function function_{i}'
             for i in range(5)
         ]
         assert bulk_group_data_stacktraces["data"] == expected_group_data
@@ -387,7 +385,7 @@ class TestBackfillSeerGroupingRecords(SnubaTestCase, TestCase):
             for event in events
         ]
         expected_stacktraces = [
-            f'Error{i}: error with value\n  File "function_{i}.py", function function_{i}'
+            f'Error{i}: error with value\n  Module "__main__", file "function_{i}.py", function function_{i}'
             for i in range(5)
         ]
         assert bulk_group_data_stacktraces["data"] == expected_group_data
@@ -422,7 +420,7 @@ class TestBackfillSeerGroupingRecords(SnubaTestCase, TestCase):
             for event in events
         ]
         expected_stacktraces = [
-            f'Error{i}: error with value\n  File "function_{i}.py", function function_{i}'
+            f'Error{i}: error with value\n  Module "__main__", file "function_{i}.py", function function_{i}'
             for i in range(4)
         ]
         assert bulk_group_data_stacktraces["data"] == expected_group_data
@@ -575,8 +573,11 @@ class TestBackfillSeerGroupingRecords(SnubaTestCase, TestCase):
         group_hashes = GroupHash.objects.all().distinct("group_id")
         self.group_hashes = {group_hash.group_id: group_hash.hash for group_hash in group_hashes}
 
-        with TaskRunner(), override_settings(
-            SIMILARITY_BACKFILL_COHORT_MAP={"test": [self.project.id, project2.id]}
+        with (
+            TaskRunner(),
+            override_settings(
+                SIMILARITY_BACKFILL_COHORT_MAP={"test": [self.project.id, project2.id]}
+            ),
         ):
             backfill_seer_grouping_records_for_project(
                 current_project_id=self.project.id,


### PR DESCRIPTION
UPDATE: Our initial analysis seems to indicate that making this change could lead to a fair number of false (well, false according to the current logic, anyway) positives, so we're going to hold off merging this for now. Moving it back to draft until we're sure what we want to do.

--------------------

This PR adds each frame's `module` value to the stacktrace string we send to Seer, in hopes of increasing the accuracy of the model.