### PR TITLE
feat(autofix): Remove codebase indexing setup step if flag enabled

### DIFF
--- a/static/app/components/events/autofix/autofixSetupModal.tsx
+++ b/static/app/components/events/autofix/autofixSetupModal.tsx
@@ -231,7 +231,7 @@ function AutofixGithubIntegrationStep({
               disabled={!canStartAutofix}
               onClick={closeModal}
             >
-              {t('Skip & enable Autofix')}
+              {t('Skip & Enable Autofix')}
             </Button>
           )}
         </GuidedSteps.StepButtons>
@@ -266,7 +266,7 @@ function AutofixGithubIntegrationStep({
             disabled={!canStartAutofix}
             onClick={closeModal}
           >
-            {t('Skip & enable Autofix')}
+            {t('Skip & Enable Autofix')}
           </Button>
         )}
       </GuidedSteps.StepButtons>

--- a/static/app/components/events/autofix/autofixSetupModal.tsx
+++ b/static/app/components/events/autofix/autofixSetupModal.tsx
@@ -144,8 +144,14 @@ export function GitRepoLink({repo}: {repo: AutofixSetupRepoDefinition}) {
 
 function AutofixGithubIntegrationStep({
   autofixSetup,
+  canStartAutofix,
+  closeModal,
+  isLastStep,
 }: {
   autofixSetup: AutofixSetupResponse;
+  canStartAutofix: boolean;
+  closeModal: () => void;
+  isLastStep?: boolean;
 }) {
   const sortedRepos = useMemo(
     () =>
@@ -176,7 +182,18 @@ function AutofixGithubIntegrationStep({
             <GitRepoLink key={`${repo.owner}/${repo.name}`} repo={repo} />
           ))}
         </RepoLinkUl>
-        <GuidedSteps.StepButtons />
+        <GuidedSteps.StepButtons>
+          {isLastStep && (
+            <Button
+              priority="primary"
+              size="sm"
+              disabled={!canStartAutofix}
+              onClick={closeModal}
+            >
+              {t("Let's Go!")}
+            </Button>
+          )}
+        </GuidedSteps.StepButtons>
       </Fragment>
     );
   }
@@ -206,7 +223,18 @@ function AutofixGithubIntegrationStep({
             'Without this, Autofix can still provide root analysis and suggested code changes.'
           )}
         </p>
-        <GuidedSteps.StepButtons />
+        <GuidedSteps.StepButtons>
+          {isLastStep && (
+            <Button
+              priority="primary"
+              size="sm"
+              disabled={!canStartAutofix}
+              onClick={closeModal}
+            >
+              {t('Skip & enable Autofix')}
+            </Button>
+          )}
+        </GuidedSteps.StepButtons>
       </Fragment>
     );
   }
@@ -230,7 +258,18 @@ function AutofixGithubIntegrationStep({
           'Without this, Autofix can still provide root analysis and suggested code changes.'
         )}
       </p>
-      <GuidedSteps.StepButtons />
+      <GuidedSteps.StepButtons>
+        {isLastStep && (
+          <Button
+            priority="primary"
+            size="sm"
+            disabled={!canStartAutofix}
+            onClick={closeModal}
+          >
+            {t('Skip & enable Autofix')}
+          </Button>
+        )}
+      </GuidedSteps.StepButtons>
     </Fragment>
   );
 }
@@ -287,12 +326,20 @@ function AutofixSetupSteps({
   groupId,
   autofixSetup,
   closeModal,
+  canStartAutofix,
 }: {
   autofixSetup: AutofixSetupResponse;
+  canStartAutofix: boolean;
   closeModal: () => void;
   groupId: string;
   projectId: string;
 }) {
+  const organization = useOrganization();
+
+  const hideCodebaseIndexingStep = organization.features.includes(
+    'autofix-disable-codebase-indexing'
+  );
+
   return (
     <GuidedSteps>
       <ConsentStep hasConsented={autofixSetup.genAIConsent.ok} />
@@ -309,20 +356,27 @@ function AutofixSetupSteps({
         isCompleted={autofixSetup.githubWriteIntegration.ok}
         optional
       >
-        <AutofixGithubIntegrationStep autofixSetup={autofixSetup} />
-      </GuidedSteps.Step>
-      <GuidedSteps.Step
-        stepKey="codebaseIndexing"
-        title={t('Enable Autofix')}
-        isCompleted={autofixSetup.codebaseIndexing.ok}
-      >
-        <AutofixCodebaseIndexingStep
-          groupId={groupId}
-          projectId={projectId}
+        <AutofixGithubIntegrationStep
           autofixSetup={autofixSetup}
+          canStartAutofix={canStartAutofix}
           closeModal={closeModal}
+          isLastStep={hideCodebaseIndexingStep}
         />
       </GuidedSteps.Step>
+      {hideCodebaseIndexingStep ? null : (
+        <GuidedSteps.Step
+          stepKey="codebaseIndexing"
+          title={t('Enable Autofix')}
+          isCompleted={autofixSetup.codebaseIndexing.ok}
+        >
+          <AutofixCodebaseIndexingStep
+            groupId={groupId}
+            projectId={projectId}
+            autofixSetup={autofixSetup}
+            closeModal={closeModal}
+          />
+        </GuidedSteps.Step>
+      )}
     </GuidedSteps>
   );
 }
@@ -367,23 +421,12 @@ function AutofixSetupContent({
     return <LoadingError message={t('Failed to fetch Autofix setup progress.')} />;
   }
 
-  if (canStartAutofix) {
-    return (
-      <AutofixSetupDone>
-        <DoneIcon color="success" size="xxl" isCircled />
-        <p>{t("You've successfully configured Autofix!")}</p>
-        <Button onClick={closeModal} priority="primary">
-          {t("Let's go")}
-        </Button>
-      </AutofixSetupDone>
-    );
-  }
-
   return (
     <AutofixSetupSteps
       groupId={groupId}
       projectId={projectId}
       autofixSetup={data}
+      canStartAutofix={canStartAutofix}
       closeModal={closeModal}
     />
   );
@@ -420,10 +463,6 @@ export const AutofixSetupDone = styled('div')`
   flex-direction: column;
   padding: 40px;
   font-size: ${p => p.theme.fontSizeLarge};
-`;
-
-const DoneIcon = styled(IconCheckmark)`
-  margin-bottom: ${space(4)};
 `;
 
 const RepoLinkUl = styled('ul')`

--- a/static/app/components/guidedSteps/guidedSteps.tsx
+++ b/static/app/components/guidedSteps/guidedSteps.tsx
@@ -17,7 +17,10 @@ import {space} from 'sentry/styles/space';
 import usePrevious from 'sentry/utils/usePrevious';
 
 type GuidedStepsProps = {
-  children: React.ReactElement<StepProps> | React.ReactElement<StepProps>[];
+  children:
+    | React.ReactElement<StepProps>
+    | (React.ReactElement<StepProps> | null)[]
+    | null;
   className?: string;
   onStepChange?: (step: number) => void;
 };

--- a/static/app/components/guidedSteps/guidedSteps.tsx
+++ b/static/app/components/guidedSteps/guidedSteps.tsx
@@ -17,10 +17,7 @@ import {space} from 'sentry/styles/space';
 import usePrevious from 'sentry/utils/usePrevious';
 
 type GuidedStepsProps = {
-  children:
-    | React.ReactElement<StepProps>
-    | (React.ReactElement<StepProps> | null)[]
-    | null;
+  children: React.ReactNode;
   className?: string;
   onStepChange?: (step: number) => void;
 };


### PR DESCRIPTION
In the autofix setup modal, if the `organizations:autofix-disable-codebase-indexing` is enabled, does not show the codebase indexing setup step and allows skipping of the write integration step if needed.

<img width="690" alt="Screenshot 2024-07-03 at 2 13 53 AM" src="https://github.com/getsentry/sentry/assets/30991498/ea3195ef-b24d-4d31-91e0-6979215aa13d">
