### PR TITLE
fix(insights): use sentry_tags.category for module type

### DIFF
--- a/src/sentry/constants.py
+++ b/src/sentry/constants.py
@@ -615,9 +615,10 @@ class InsightModules(Enum):
 # each span filter takes in a span object and returns whether
 # the span belongs in the corresponding insight module
 INSIGHT_MODULE_SPAN_FILTERS = {
-    InsightModules.HTTP: lambda span: span.get("op") == "http.client"
-    and span.get("module") == "http",
-    InsightModules.DB: lambda span: span.get("module") == "db" and "description" in span.keys(),
+    InsightModules.HTTP: lambda span: span.get("sentry_tags", {}).get("category") == "http"
+    and span.get("op") == "http.client",
+    InsightModules.DB: lambda span: span.get("sentry_tags", {}).get("category") == "db"
+    and "description" in span.keys(),
     InsightModules.ASSETS: lambda span: span.get("op")
     in ["resource.script", "resource.css", "resource.font", "resource.img"],
     InsightModules.APP_START: lambda span: span.get("op").startswith("app.start."),


### PR DESCRIPTION
Fixes project has_insight_xx ingestion for HTTP and DB modules by checking `sentry_tags.category` instead of `span.module`.