### PR TITLE
feat(assignee-selector): Make user searchable by email in dropdown

### DIFF
--- a/static/app/components/assigneeSelectorDropdown.spec.tsx
+++ b/static/app/components/assigneeSelectorDropdown.spec.tsx
@@ -501,6 +501,29 @@ describe('AssigneeSelectorDropdown', () => {
     expect(screen.getByTestId('assignee-selector')).toHaveTextContent('CD');
   });
 
+  it('filters users based on their email addres', async () => {
+    MemberListStore.loadInitialData([USER_1, USER_2, USER_3, USER_4]);
+    render(
+      <AssigneeSelectorDropdown
+        group={GROUP_2}
+        loading={false}
+        memberList={[USER_1, USER_2, USER_3, USER_4]}
+        onAssign={newAssignee => updateGroup(GROUP_2, newAssignee)}
+      />
+    );
+    await openMenu();
+    expect(screen.queryByTestId('loading-indicator')).not.toBeInTheDocument();
+
+    await userEvent.type(screen.getByRole('textbox'), 'github@example.com');
+
+    // 1 total item
+    await waitFor(() => {
+      expect(screen.getAllByRole('option')).toHaveLength(1);
+    });
+
+    expect(await screen.findByText(`${USER_4.name}`)).toBeInTheDocument();
+  });
+
   it('successfully shows suggested assignees and suggestion reason', async () => {
     jest.spyOn(GroupStore, 'get').mockImplementation(() => GROUP_2);
 

--- a/static/app/components/assigneeSelectorDropdown.spec.tsx
+++ b/static/app/components/assigneeSelectorDropdown.spec.tsx
@@ -501,7 +501,7 @@ describe('AssigneeSelectorDropdown', () => {
     expect(screen.getByTestId('assignee-selector')).toHaveTextContent('CD');
   });
 
-  it('filters users based on their email addres', async () => {
+  it('filters users based on their email address', async () => {
     MemberListStore.loadInitialData([USER_1, USER_2, USER_3, USER_4]);
     render(
       <AssigneeSelectorDropdown

--- a/static/app/components/assigneeSelectorDropdown.tsx
+++ b/static/app/components/assigneeSelectorDropdown.tsx
@@ -362,8 +362,7 @@ export default function AssigneeSelectorDropdown({
       ),
       // Jank way to pass assignee type (team or user) into each row
       value: `user:${user.id}`,
-      // This makes a user searchable by their email in the dropdown
-      textValue: user.email,
+      textValue: `${user.name}${user.email}`,
     };
   };
 

--- a/static/app/components/assigneeSelectorDropdown.tsx
+++ b/static/app/components/assigneeSelectorDropdown.tsx
@@ -362,7 +362,8 @@ export default function AssigneeSelectorDropdown({
       ),
       // Jank way to pass assignee type (team or user) into each row
       value: `user:${user.id}`,
-      textValue: userDisplay,
+      // This makes a user searchable by their email in the dropdown
+      textValue: user.email,
     };
   };
 


### PR DESCRIPTION
Fixes #73584

Makes users in the assignee dropdown searchable by their email address