### PR TITLE
fix(trace-explorer): Feature check for projects

### DIFF
--- a/static/app/views/traces/content.tsx
+++ b/static/app/views/traces/content.tsx
@@ -183,9 +183,7 @@ export function Content() {
   return (
     <LayoutMain fullWidth>
       <PageFilterBar condensed>
-        {organization.features.includes(
-          'organizations:performance-trace-explorer-enforce-projects'
-        ) ? (
+        {organization.features.includes('performance-trace-explorer-enforce-projects') ? (
           <ProjectPageFilter />
         ) : (
           <Tooltip


### PR DESCRIPTION
Frontend feature checks should not be prefixed with `organizations:`.