### PR TITLE
feat(query-builder): Improved search and sorting of search keys

### DIFF
--- a/static/app/components/searchQueryBuilder/combobox.tsx
+++ b/static/app/components/searchQueryBuilder/combobox.tsx
@@ -92,6 +92,11 @@ type SearchQueryBuilderComboboxProps<T extends SelectOptionOrSectionWithKey<stri
    * other elements.
    */
   shouldCloseOnInteractOutside?: (interactedElement: Element) => boolean;
+  /**
+   * Whether the menu should filter results based on the filterValue.
+   * Disable if the filtering should be handled by the caller.
+   */
+  shouldFilterResults?: boolean;
   tabIndex?: number;
 };
 
@@ -163,12 +168,14 @@ function useHiddenItems<T extends SelectOptionOrSectionWithKey<string>>({
   maxOptions,
   displayTabbedMenu,
   selectedSection,
+  shouldFilterResults,
 }: {
   filterValue: string;
   items: T[];
   selectedSection: Key | null;
   displayTabbedMenu?: boolean;
   maxOptions?: number;
+  shouldFilterResults?: boolean;
 }) {
   const hiddenOptions: Set<SelectKey> = useMemo(() => {
     if (displayTabbedMenu) {
@@ -187,8 +194,15 @@ function useHiddenItems<T extends SelectOptionOrSectionWithKey<string>>({
       return mergeSets(hiddenFromOtherSections, hiddenFromShownSection);
     }
 
-    return getHiddenOptions(items, filterValue, maxOptions);
-  }, [displayTabbedMenu, items, filterValue, maxOptions, selectedSection]);
+    return getHiddenOptions(items, shouldFilterResults ? filterValue : '', maxOptions);
+  }, [
+    displayTabbedMenu,
+    items,
+    shouldFilterResults,
+    filterValue,
+    maxOptions,
+    selectedSection,
+  ]);
 
   const disabledKeys: string[] = useMemo(
     () => [...getDisabledOptions(items), ...hiddenOptions].map(getEscapedKey),
@@ -427,6 +441,7 @@ function SearchQueryBuilderComboboxInner<T extends SelectOptionOrSectionWithKey<
     onFocus,
     tabIndex = -1,
     maxOptions,
+    shouldFilterResults = true,
     shouldCloseOnInteractOutside,
     onPaste,
     displayTabbedMenu,
@@ -447,6 +462,7 @@ function SearchQueryBuilderComboboxInner<T extends SelectOptionOrSectionWithKey<
     maxOptions,
     displayTabbedMenu,
     selectedSection,
+    shouldFilterResults,
   });
 
   const onSelectionChange = useCallback(

--- a/static/app/components/searchQueryBuilder/index.spec.tsx
+++ b/static/app/components/searchQueryBuilder/index.spec.tsx
@@ -312,6 +312,15 @@ describe('SearchQueryBuilder', function () {
       ).toBeInTheDocument();
     });
 
+    it('can search by key description', async function () {
+      render(<SearchQueryBuilder {...defaultProps} />);
+      await userEvent.click(screen.getByRole('combobox', {name: 'Add a search term'}));
+      await userEvent.keyboard('assignee');
+
+      // "assignee" is in the description of "assigned"
+      expect(await screen.findByRole('option', {name: 'assigned'})).toBeInTheDocument();
+    });
+
     it('can add a new token by clicking a key suggestion', async function () {
       render(<SearchQueryBuilder {...defaultProps} />);
 


### PR DESCRIPTION
Uses fuzzy searching to filter and sort keys when adding a new filter. This now searches the descriptions as well, and ranks better matches higher in the list.

Before:

![CleanShot 2024-07-02 at 14 31 58](https://github.com/getsentry/sentry/assets/10888943/e2686e34-8bcf-42f5-baa6-b4301de16562)

After:

![CleanShot 2024-07-02 at 14 31 53](https://github.com/getsentry/sentry/assets/10888943/d52db1b5-6832-46c4-b8b4-fdc498e8511f)
