### PR TITLE
fix(app-start): Show infinity symbol when change request returns NaN

### DIFF
--- a/static/app/views/insights/mobile/appStarts/components/tables/spanOperationTable.tsx
+++ b/static/app/views/insights/mobile/appStarts/components/tables/spanOperationTable.tsx
@@ -10,6 +10,7 @@ import type {CursorHandler} from 'sentry/components/pagination';
 import Pagination from 'sentry/components/pagination';
 import {t} from 'sentry/locale';
 import type {NewQuery} from 'sentry/types/organization';
+import {defined} from 'sentry/utils';
 import {browserHistory} from 'sentry/utils/browserHistory';
 import type {TableDataRow} from 'sentry/utils/discover/discoverQuery';
 import type {MetaType} from 'sentry/utils/discover/eventView';
@@ -174,7 +175,7 @@ export function SpanOperationTable({
     if (data.meta.fields[column.key] === 'percent_change') {
       return (
         <PercentChangeCell
-          deltaValue={parseFloat(row[column.key] as string)}
+          deltaValue={defined(row[column.key]) ? parseFloat(row[column.key]) : Infinity}
           preferredPolarity="-"
         />
       );


### PR DESCRIPTION
In this case, the backend has calculated `inf` for the change, but it is returned as `null` in the request. Handle the `null` in the frontend and display the infinity symbol.

Note: I'm aware the table prioritizes spans that have been removed over spans that have been added. I'm going to follow up and look at fixing how we resolve the function in the backend to handle this.

<img width="1461" alt="Screenshot 2024-07-02 at 5 39 49 PM" src="https://github.com/getsentry/sentry/assets/22846452/73a31e7b-48ee-485e-98f0-4850809c5c70">
