### PR TITLE
chore(slack): move some floating functions into SlackService

### DIFF
--- a/src/sentry/integrations/slack/message_builder/__init__.py
+++ b/src/sentry/integrations/slack/message_builder/__init__.py
@@ -1,11 +1,10 @@
-from collections.abc import Mapping
 from typing import Any, Union
 
 from sentry.issues.grouptype import GroupCategory
 
 # TODO(mgaeta): Continue fleshing out these types.
-SlackAttachment = Mapping[str, Any]
-SlackBlock = Mapping[str, Any]
+SlackAttachment = dict[str, Any]
+SlackBlock = dict[str, Any]
 SlackBody = Union[SlackAttachment, SlackBlock, list[SlackAttachment]]
 
 # Attachment colors used for issues with no actions take.

--- a/src/sentry/integrations/slack/message_builder/base/block.py
+++ b/src/sentry/integrations/slack/message_builder/base/block.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
 from abc import ABC
-from collections.abc import Mapping, MutableMapping, Sequence
+from collections.abc import Mapping, Sequence
 from datetime import datetime
-from typing import Any, TypedDict
+from typing import Any
 
 from sentry.integrations.slack.message_builder import SlackBlock
 from sentry.integrations.slack.message_builder.base.base import SlackMessageBuilder
@@ -13,7 +13,7 @@ from sentry.notifications.utils.actions import MessageAction
 class BlockSlackMessageBuilder(SlackMessageBuilder, ABC):
     @staticmethod
     def get_image_block(url: str, title: str | None = None, alt: str | None = None) -> SlackBlock:
-        block: MutableMapping[str, Any] = {
+        block: dict[str, Any] = {
             "type": "image",
             "image_url": url,
         }
@@ -124,11 +124,7 @@ class BlockSlackMessageBuilder(SlackMessageBuilder, ABC):
 
     @staticmethod
     def get_action_block(actions: Sequence[tuple[str, str | None, str]]) -> SlackBlock:
-        class SlackBlockType(TypedDict):
-            type: str
-            elements: list[dict[str, Any]]
-
-        action_block: SlackBlockType = {"type": "actions", "elements": []}
+        elements = []
         for text, url, value in actions:
             button = {
                 "type": "button",
@@ -138,8 +134,9 @@ class BlockSlackMessageBuilder(SlackMessageBuilder, ABC):
             if url:
                 button["url"] = url
 
-            action_block["elements"].append(button)
+            elements.append(button)
 
+        action_block = {"type": "actions", "elements": elements}
         return action_block
 
     @staticmethod

--- a/src/sentry/integrations/slack/notifications.py
+++ b/src/sentry/integrations/slack/notifications.py
@@ -2,27 +2,19 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Iterable, Mapping
-from copy import copy
 from typing import Any
 
-import orjson
 import sentry_sdk
 from slack_sdk.errors import SlackApiError
 
 from sentry.integrations.mixins import NotifyBasicMixin
-from sentry.integrations.notifications import get_context, get_integrations_by_channel_by_recipient
+from sentry.integrations.notifications import get_integrations_by_channel_by_recipient
 from sentry.integrations.slack.client import SlackClient
-from sentry.integrations.slack.message_builder import SlackBlock
-from sentry.integrations.slack.message_builder.base.block import BlockSlackMessageBuilder
-from sentry.integrations.slack.message_builder.notifications import get_message_builder
+from sentry.integrations.slack.service import SlackService
 from sentry.integrations.types import ExternalProviders
-from sentry.models.integrations.integration import Integration
-from sentry.notifications.additional_attachment_manager import get_additional_attachment
 from sentry.notifications.notifications.base import BaseNotification
 from sentry.notifications.notify import register_notification_provider
 from sentry.shared_integrations.exceptions import ApiError
-from sentry.silo.base import SiloMode
-from sentry.tasks.integrations.slack import post_message, post_message_control
 from sentry.types.actor import Actor
 from sentry.utils import metrics
 
@@ -58,90 +50,6 @@ class SlackNotifyBasicMixin(NotifyBasicMixin):
                     )
 
 
-def _get_attachments(
-    notification: BaseNotification,
-    recipient: Actor,
-    shared_context: Mapping[str, Any],
-    extra_context_by_actor: Mapping[Actor, Mapping[str, Any]] | None,
-) -> SlackBlock:
-    extra_context = (
-        extra_context_by_actor[recipient] if extra_context_by_actor and recipient else {}
-    )
-    context = get_context(notification, recipient, shared_context, extra_context)
-    cls = get_message_builder(notification.message_builder)
-    attachments = cls(notification, context, recipient).build()
-    return attachments
-
-
-def _notify_recipient(
-    notification: BaseNotification,
-    recipient: Actor,
-    attachments: SlackBlock,
-    channel: str,
-    integration: Integration,
-    shared_context: Mapping[str, Any],
-) -> None:
-    with sentry_sdk.start_span(op="notification.send_slack", description="notify_recipient"):
-        # Make a local copy to which we can append.
-        local_attachments = copy(attachments)
-
-        text = notification.get_notification_title(ExternalProviders.SLACK, shared_context)
-
-        blocks = []
-        if text:
-            blocks.append(BlockSlackMessageBuilder.get_markdown_block(text))
-        attachment_blocks = local_attachments.get("blocks")
-        if attachment_blocks:
-            for attachment in attachment_blocks:
-                blocks.append(attachment)
-        if len(blocks) >= 2 and blocks[1].get("block_id"):
-            # block id needs to be in the first block
-            blocks[0]["block_id"] = blocks[1]["block_id"]
-            del blocks[1]["block_id"]
-        additional_attachment = get_additional_attachment(integration, notification.organization)
-        if additional_attachment:
-            for block in additional_attachment:
-                blocks.append(block)
-        if (
-            not text
-        ):  # if there isn't a notification title, try using message description as fallback
-            text = notification.get_message_description(recipient, ExternalProviders.SLACK)
-        payload = {
-            "channel": channel,
-            "unfurl_links": False,
-            "unfurl_media": False,
-            "text": text if text else "",
-            "blocks": orjson.dumps(blocks).decode(),
-        }
-        callback_id = local_attachments.get("callback_id")
-        if callback_id:
-            # callback_id is now at the same level as blocks, rather than within attachments
-            if isinstance(callback_id, str):
-                payload["callback_id"] = callback_id
-            else:
-                payload["callback_id"] = orjson.dumps(local_attachments.get("callback_id")).decode()
-
-        post_message_task = post_message
-        if SiloMode.get_current_mode() == SiloMode.CONTROL:
-            post_message_task = post_message_control
-
-        log_params = {
-            "notification": str(notification),
-            "recipient": recipient.id,
-            "channel_id": channel,
-        }
-        post_message_task.apply_async(
-            kwargs={
-                "integration_id": integration.id,
-                "payload": payload,
-                "log_error_message": "slack.notify_recipient.fail",
-                "log_params": log_params,
-            }
-        )
-    # recording data outside of span
-    notification.record_notification_sent(recipient, ExternalProviders.SLACK)
-
-
 @register_notification_provider(ExternalProviders.SLACK)
 def send_notification_as_slack(
     notification: BaseNotification,
@@ -151,6 +59,8 @@ def send_notification_as_slack(
 ) -> None:
     """Send an "activity" or "alert rule" notification to a Slack user or team, but NOT to a channel directly.
     Sending Slack notifications to a channel is in integrations/slack/actions/notification.py"""
+
+    service = SlackService.default()
     with sentry_sdk.start_span(
         op="notification.send_slack", description="gen_channel_integration_map"
     ):
@@ -161,7 +71,7 @@ def send_notification_as_slack(
     for recipient, integrations_by_channel in data.items():
         with sentry_sdk.start_span(op="notification.send_slack", description="send_one"):
             with sentry_sdk.start_span(op="notification.send_slack", description="gen_attachments"):
-                attachments = _get_attachments(
+                attachments = service.get_attachments(
                     notification,
                     recipient,
                     shared_context,
@@ -169,7 +79,7 @@ def send_notification_as_slack(
                 )
 
             for channel, integration in integrations_by_channel.items():
-                _notify_recipient(
+                service.notify_recipient(
                     notification=notification,
                     recipient=recipient,
                     attachments=attachments,

--- a/src/sentry/integrations/slack/service.py
+++ b/src/sentry/integrations/slack/service.py
@@ -323,6 +323,7 @@ class SlackService:
         return text_description
 
     def notify_recipient(
+        self,
         notification: BaseNotification,
         recipient: Actor,
         attachments: SlackBlock,

--- a/src/sentry/integrations/slack/service.py
+++ b/src/sentry/integrations/slack/service.py
@@ -16,8 +16,8 @@ from sentry.integrations.repository.issue_alert import (
     IssueAlertNotificationMessage,
     IssueAlertNotificationMessageRepository,
 )
-from sentry.integrations.slack import BlockSlackMessageBuilder
 from sentry.integrations.slack.message_builder import SlackBlock
+from sentry.integrations.slack.message_builder.base.block import BlockSlackMessageBuilder
 from sentry.integrations.slack.message_builder.notifications import get_message_builder
 from sentry.integrations.slack.metrics import (
     SLACK_ACTIVITY_THREAD_FAILURE_DATADOG_METRIC,
@@ -50,7 +50,6 @@ from sentry.notifications.notifications.activity.unassigned import UnassignedAct
 from sentry.notifications.notifications.activity.unresolved import UnresolvedActivityNotification
 from sentry.notifications.notifications.base import BaseNotification
 from sentry.silo.base import SiloMode
-from sentry.tasks.integrations.slack.post_message import post_message, post_message_control
 from sentry.types.activity import ActivityType
 from sentry.types.actor import Actor
 from sentry.utils import metrics
@@ -331,6 +330,8 @@ class SlackService:
         integration: Integration,
         shared_context: Mapping[str, Any],
     ) -> None:
+        from sentry.tasks.integrations.slack.post_message import post_message, post_message_control
+
         """Send an "activity" or "alert rule" notification to a Slack user or team, but NOT to a channel directly.
         This is used in the send_notification_as_slack function."""
         with sentry_sdk.start_span(op="notification.send_slack", description="notify_recipient"):

--- a/src/sentry/integrations/slack/service.py
+++ b/src/sentry/integrations/slack/service.py
@@ -1,31 +1,42 @@
 from __future__ import annotations
 
+from collections.abc import Mapping
+from copy import copy
 from logging import Logger, getLogger
+from typing import Any
 
 import orjson
+import sentry_sdk
 from slack_sdk.errors import SlackApiError
 
 from sentry.constants import ISSUE_ALERTS_THREAD_DEFAULT
+from sentry.integrations.notifications import get_context
 from sentry.integrations.repository import get_default_issue_alert_repository
 from sentry.integrations.repository.issue_alert import (
     IssueAlertNotificationMessage,
     IssueAlertNotificationMessageRepository,
 )
 from sentry.integrations.slack import BlockSlackMessageBuilder
+from sentry.integrations.slack.message_builder import SlackBlock
+from sentry.integrations.slack.message_builder.notifications import get_message_builder
 from sentry.integrations.slack.metrics import (
     SLACK_ACTIVITY_THREAD_FAILURE_DATADOG_METRIC,
     SLACK_ACTIVITY_THREAD_SUCCESS_DATADOG_METRIC,
+    SLACK_NOTIFY_RECIPIENT_FAILURE_DATADOG_METRIC,
+    SLACK_NOTIFY_RECIPIENT_SUCCESS_DATADOG_METRIC,
 )
 from sentry.integrations.slack.sdk_client import SlackSdkClient
 from sentry.integrations.slack.threads.activity_notifications import (
     AssignedActivityNotification,
     ExternalIssueCreatedActivityNotification,
 )
-from sentry.integrations.types import ExternalProviderEnum
+from sentry.integrations.types import ExternalProviderEnum, ExternalProviders
 from sentry.integrations.utils.common import get_active_integration_for_organization
 from sentry.models.activity import Activity
+from sentry.models.integrations.integration import Integration
 from sentry.models.options.organization_option import OrganizationOption
 from sentry.models.rule import Rule
+from sentry.notifications.additional_attachment_manager import get_additional_attachment
 from sentry.notifications.notifications.activity.archive import ArchiveActivityNotification
 from sentry.notifications.notifications.activity.base import ActivityNotification
 from sentry.notifications.notifications.activity.escalating import EscalatingActivityNotification
@@ -37,7 +48,11 @@ from sentry.notifications.notifications.activity.resolved_in_release import (
 )
 from sentry.notifications.notifications.activity.unassigned import UnassignedActivityNotification
 from sentry.notifications.notifications.activity.unresolved import UnresolvedActivityNotification
+from sentry.notifications.notifications.base import BaseNotification
+from sentry.silo.base import SiloMode
+from sentry.tasks.integrations.slack.post_message import post_message, post_message_control
 from sentry.types.activity import ActivityType
+from sentry.types.actor import Actor
 from sentry.utils import metrics
 
 _default_logger = getLogger(__name__)
@@ -307,3 +322,123 @@ class SlackService:
             return None
 
         return text_description
+
+    def notify_recipient(
+        notification: BaseNotification,
+        recipient: Actor,
+        attachments: SlackBlock,
+        channel: str,
+        integration: Integration,
+        shared_context: Mapping[str, Any],
+    ) -> None:
+        """Send an "activity" or "alert rule" notification to a Slack user or team, but NOT to a channel directly.
+        This is used in the send_notification_as_slack function."""
+        with sentry_sdk.start_span(op="notification.send_slack", description="notify_recipient"):
+            # Make a local copy to which we can append.
+            local_attachments = copy(attachments)
+
+            text = notification.get_notification_title(ExternalProviders.SLACK, shared_context)
+
+            blocks = []
+            if text:
+                blocks.append(BlockSlackMessageBuilder.get_markdown_block(text))
+            attachment_blocks = local_attachments.get("blocks")
+            if attachment_blocks:
+                for attachment in attachment_blocks:
+                    blocks.append(attachment)
+            if len(blocks) >= 2 and blocks[1].get("block_id"):
+                # block id needs to be in the first block
+                blocks[0]["block_id"] = blocks[1]["block_id"]
+                del blocks[1]["block_id"]
+            additional_attachment = get_additional_attachment(
+                integration, notification.organization
+            )
+            if additional_attachment:
+                for block in additional_attachment:
+                    blocks.append(block)
+            if (
+                not text
+            ):  # if there isn't a notification title, try using message description as fallback
+                text = notification.get_message_description(recipient, ExternalProviders.SLACK)
+            payload = {
+                "channel": channel,
+                "unfurl_links": False,
+                "unfurl_media": False,
+                "text": text if text else "",
+                "blocks": orjson.dumps(blocks).decode(),
+            }
+            callback_id = local_attachments.get("callback_id")
+            if callback_id:
+                # callback_id is now at the same level as blocks, rather than within attachments
+                if isinstance(callback_id, str):
+                    payload["callback_id"] = callback_id
+                else:
+                    payload["callback_id"] = orjson.dumps(
+                        local_attachments.get("callback_id")
+                    ).decode()
+
+            post_message_task = post_message
+            if SiloMode.get_current_mode() == SiloMode.CONTROL:
+                post_message_task = post_message_control
+
+            log_params = {
+                "notification": str(notification),
+                "recipient": recipient.id,
+                "channel_id": channel,
+            }
+            post_message_task.apply_async(
+                kwargs={
+                    "integration_id": integration.id,
+                    "payload": payload,
+                    "log_error_message": "slack.notify_recipient.fail",
+                    "log_params": log_params,
+                }
+            )
+        # recording data outside of span
+        notification.record_notification_sent(recipient, ExternalProviders.SLACK)
+
+    def get_attachments(
+        self,
+        notification: BaseNotification,
+        recipient: Actor,
+        shared_context: Mapping[str, Any],
+        extra_context_by_actor: Mapping[Actor, Mapping[str, Any]] | None,
+    ) -> SlackBlock:
+        """Get the message to send in notify_recipient"""
+
+        extra_context = (
+            extra_context_by_actor[recipient] if extra_context_by_actor and recipient else {}
+        )
+        context = get_context(notification, recipient, shared_context, extra_context)
+        cls = get_message_builder(notification.message_builder)
+        attachments = cls(notification, context, recipient).build()
+        return attachments
+
+    def send_message_to_slack_channel(
+        self,
+        integration_id: int,
+        payload: Mapping[str, Any],
+        log_error_message: str,
+        log_params: Mapping[str, Any],
+    ) -> None:
+        """Execution of send_notification_as_slack."""
+
+        client = SlackSdkClient(integration_id=integration_id)
+        try:
+            client.chat_postMessage(
+                blocks=str(payload.get("blocks", "")),
+                text=str(payload.get("text", "")),
+                channel=str(payload.get("channel", "")),
+                unfurl_links=False,
+                unfurl_media=False,
+                callback_id=str(payload.get("callback_id", "")),
+            )
+            metrics.incr(SLACK_NOTIFY_RECIPIENT_SUCCESS_DATADOG_METRIC, sample_rate=1.0)
+        except SlackApiError as e:
+            extra = {"error": str(e), **log_params}
+            self._logger.info(log_error_message, extra=extra)
+            metrics.incr(
+                SLACK_NOTIFY_RECIPIENT_FAILURE_DATADOG_METRIC,
+                sample_rate=1.0,
+                tags={"ok": e.response.get("ok", False), "status": e.response.status_code},
+            )

--- a/src/sentry/integrations/slack/service.py
+++ b/src/sentry/integrations/slack/service.py
@@ -341,7 +341,7 @@ class SlackService:
 
             text = notification.get_notification_title(ExternalProviders.SLACK, shared_context)
 
-            blocks = []
+            blocks: list[dict[str, Any]] = []
             if text:
                 blocks.append(BlockSlackMessageBuilder.get_markdown_block(text))
             attachment_blocks = local_attachments.get("blocks")
@@ -350,7 +350,8 @@ class SlackService:
                     blocks.append(attachment)
             if len(blocks) >= 2 and blocks[1].get("block_id"):
                 # block id needs to be in the first block
-                blocks[0]["block_id"] = blocks[1]["block_id"]
+                first_block = blocks[0]
+                first_block["block_id"] = blocks[1]["block_id"]
                 del blocks[1]["block_id"]
             additional_attachment = get_additional_attachment(
                 integration, notification.organization

--- a/src/sentry/integrations/slack/service.py
+++ b/src/sentry/integrations/slack/service.py
@@ -341,7 +341,7 @@ class SlackService:
 
             text = notification.get_notification_title(ExternalProviders.SLACK, shared_context)
 
-            blocks: list[dict[str, Any]] = []
+            blocks: list[SlackBlock] = []
             if text:
                 blocks.append(BlockSlackMessageBuilder.get_markdown_block(text))
             attachment_blocks = local_attachments.get("blocks")

--- a/src/sentry/integrations/slack/tasks/send_notifications_on_activity.py
+++ b/src/sentry/integrations/slack/tasks/send_notifications_on_activity.py
@@ -2,6 +2,7 @@ import logging
 
 from django.db import router, transaction
 
+from sentry.integrations.slack.service import SlackService
 from sentry.models.activity import Activity
 from sentry.models.organization import Organization
 from sentry.silo.base import SiloMode
@@ -22,8 +23,6 @@ _TASK_QUEUED_METRIC = (
     silo_mode=SiloMode.REGION,
 )
 def send_activity_notifications_to_slack_threads(activity_id) -> None:
-    from sentry.integrations.slack.service import SlackService
-
     log_params = {"activity_id": activity_id}
     _default_logger.debug("async processing for activity", extra=log_params)
 

--- a/src/sentry/integrations/slack/tasks/send_notifications_on_activity.py
+++ b/src/sentry/integrations/slack/tasks/send_notifications_on_activity.py
@@ -2,7 +2,6 @@ import logging
 
 from django.db import router, transaction
 
-from sentry.integrations.slack.service import SlackService
 from sentry.models.activity import Activity
 from sentry.models.organization import Organization
 from sentry.silo.base import SiloMode
@@ -23,6 +22,8 @@ _TASK_QUEUED_METRIC = (
     silo_mode=SiloMode.REGION,
 )
 def send_activity_notifications_to_slack_threads(activity_id) -> None:
+    from sentry.integrations.slack.service import SlackService
+
     log_params = {"activity_id": activity_id}
     _default_logger.debug("async processing for activity", extra=log_params)
 

--- a/src/sentry/notifications/additional_attachment_manager.py
+++ b/src/sentry/notifications/additional_attachment_manager.py
@@ -4,14 +4,14 @@ from collections.abc import Callable, MutableMapping
 
 from sentry.api.validators.integrations import validate_provider
 from sentry.integrations.services.integration import RpcIntegration
-from sentry.integrations.slack.message_builder import SlackAttachment
+from sentry.integrations.slack.message_builder import SlackBlock
 from sentry.integrations.types import ExternalProviders
 from sentry.models.integrations.integration import Integration
 from sentry.models.organization import Organization
 from sentry.organizations.services.organization import RpcOrganization
 
 GetAttachment = Callable[
-    [Integration | RpcIntegration, Organization | RpcOrganization], SlackAttachment
+    [Integration | RpcIntegration, Organization | RpcOrganization], list[SlackBlock]
 ]
 
 
@@ -28,7 +28,7 @@ class AdditionalAttachmentManager:
         self,
         integration: Integration | RpcIntegration,
         organization: Organization | RpcOrganization,
-    ) -> SlackAttachment | None:
+    ) -> list[SlackBlock] | None:
         # look up the generator by the provider but only accepting slack for now
         provider = validate_provider(integration.provider, {ExternalProviders.SLACK})
         attachment_generator = self.attachment_generators.get(provider)

--- a/tests/sentry/integrations/slack/test_notifications.py
+++ b/tests/sentry/integrations/slack/test_notifications.py
@@ -27,8 +27,8 @@ class SlackNotificationsTest(SlackActivityNotificationTest):
         super().setUp()
         self.notification = DummyNotification(self.organization)
 
-    @patch("sentry.tasks.integrations.slack.post_message.metrics")
-    def test_additional_attachment_block_kit(self, mock_metrics):
+    @patch("sentry.integrations.slack.service.metrics")
+    def test_additional_attachment(self, mock_metrics):
         with (
             patch.dict(
                 manager.attachment_generators,
@@ -73,8 +73,8 @@ class SlackNotificationsTest(SlackActivityNotificationTest):
             sample_rate=1.0,
         )
 
-    @patch("sentry.tasks.integrations.slack.post_message.metrics")
-    def test_no_additional_attachment_block_kit(self, mock_metrics):
+    @patch("sentry.integrations.slack.service.metrics")
+    def test_no_additional_attachment(self, mock_metrics):
         with self.tasks():
             send_notification_as_slack(self.notification, [self.user], {}, {})
 
@@ -105,7 +105,7 @@ class SlackNotificationsTest(SlackActivityNotificationTest):
             "type": "actions",
         }
 
-    @patch("sentry.tasks.integrations.slack.post_message.metrics")
+    @patch("sentry.integrations.slack.service.metrics")
     def test_send_notification_as_slack(self, mock_metrics):
         with patch.dict(
             manager.attachment_generators,
@@ -119,7 +119,7 @@ class SlackNotificationsTest(SlackActivityNotificationTest):
             sample_rate=1.0,
         )
 
-    @patch("sentry.tasks.integrations.slack.post_message.metrics")
+    @patch("sentry.integrations.slack.service.metrics")
     def test_send_notification_as_slack_error(self, mock_metrics):
         mock_slack_response = SlackResponse(
             client=None,

--- a/tests/sentry/integrations/slack/test_tasks.py
+++ b/tests/sentry/integrations/slack/test_tasks.py
@@ -415,7 +415,6 @@ class SlackTasksTest(TestCase):
                     "payload": {"blocks": ["hello"], "text": "text", "channel": "channel"},
                     "log_error_message": "my_message",
                     "log_params": {"log_key": "log_value"},
-                    "has_sdk_flag": True,
                 }
             )
 
@@ -440,7 +439,6 @@ class SlackTasksTest(TestCase):
                     },
                     "log_error_message": "my_message",
                     "log_params": {"log_key": "log_value"},
-                    "has_sdk_flag": True,
                 }
             )
 

--- a/tests/sentry/integrations/slack/webhooks/commands/__init__.py
+++ b/tests/sentry/integrations/slack/webhooks/commands/__init__.py
@@ -42,7 +42,7 @@ class SlackCommandsTest(APITestCase, TestCase):
             )
         self.login_as(self.user)
 
-    def send_slack_message(self, command: str, **kwargs: Any) -> Mapping[str, str]:
+    def send_slack_message(self, command: str, **kwargs: Any) -> dict[str, str]:
         response = self.get_slack_response(
             {
                 "text": command,


### PR DESCRIPTION
Move `_get_attachments`, `_notify_recipient`, and `_send_message_to_slack_channel` under SlackService, which were previously floating functions. We should centralize Slack logic where possible.

Also fixes typing for `SlackBlock` and `SlackAttachment` (which are literally the same thing), we should be using `dict` since we're mutating the result in `get_attachments` (typing is enforced in its home).