### PR TITLE
fix(settings): Fix redirect for settings search

### DIFF
--- a/static/app/data/forms/organizationGeneralSettings.tsx
+++ b/static/app/data/forms/organizationGeneralSettings.tsx
@@ -6,7 +6,7 @@ import type {BaseRole} from 'sentry/types/organization';
 import slugify from 'sentry/utils/slugify';
 
 // Export route to make these forms searchable by label/help
-export const route = '/settings/:orgId/';
+export const route = '/settings/organization/:orgId';
 
 const formGroups: JsonFormObject[] = [
   {


### PR DESCRIPTION
this pr fixes [an issue](https://github.com/getsentry/sentry/issues/73692) with redirecting that came up with the search results for anything on the general organization settings page. since the route didn't include "organization", it was sending users to the wrong place