### PR TITLE
fix(uptime): Fix actual_check_time(_ms) timestamps

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -62,7 +62,7 @@ rfc3339-validator>=0.1.2
 rfc3986-validator>=0.1.1
 # [end] jsonschema format validators
 sentry-arroyo>=2.16.5
-sentry-kafka-schemas>=0.1.93
+sentry-kafka-schemas>=0.1.101
 sentry-ophio==0.2.7
 sentry-redis-tools>=0.1.7
 sentry-relay>=0.8.67

--- a/requirements-dev-frozen.txt
+++ b/requirements-dev-frozen.txt
@@ -182,7 +182,7 @@ sentry-cli==2.16.0
 sentry-devenv==1.6.2
 sentry-forked-django-stubs==5.0.2.post4
 sentry-forked-djangorestframework-stubs==3.15.0.post1
-sentry-kafka-schemas==0.1.93
+sentry-kafka-schemas==0.1.101
 sentry-ophio==0.2.7
 sentry-redis-tools==0.1.7
 sentry-relay==0.8.67

--- a/requirements-frozen.txt
+++ b/requirements-frozen.txt
@@ -123,7 +123,7 @@ rpds-py==0.15.2
 rsa==4.8
 s3transfer==0.10.0
 sentry-arroyo==2.16.5
-sentry-kafka-schemas==0.1.93
+sentry-kafka-schemas==0.1.101
 sentry-ophio==0.2.7
 sentry-redis-tools==0.1.7
 sentry-relay==0.8.67

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -3251,7 +3251,9 @@ class UptimeTestCase(TestCase):
             "status": CHECKSTATUS_FAILURE,
             "status_reason": {"type": CHECKSTATUSREASONTYPE_TIMEOUT, "description": "it timed out"},
             "trace_id": uuid.uuid4().hex,
-            "scheduled_check_time_ms": int(datetime.now().replace(microsecond=0).timestamp() * 1000),
+            "scheduled_check_time_ms": int(
+                datetime.now().replace(microsecond=0).timestamp() * 1000
+            ),
             "actual_check_time_ms": int(datetime.now().replace(microsecond=0).timestamp() * 1000),
             "duration_ms": 100,
             "request_info": {"request_type": REQUESTTYPE_HEAD, "http_status_code": 500},

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -3251,8 +3251,8 @@ class UptimeTestCase(TestCase):
             "status": CHECKSTATUS_FAILURE,
             "status_reason": {"type": CHECKSTATUSREASONTYPE_TIMEOUT, "description": "it timed out"},
             "trace_id": uuid.uuid4().hex,
-            "scheduled_check_time": datetime.now().timestamp(),
-            "actual_check_time": datetime.now().timestamp(),
+            "scheduled_check_time_ms": int(datetime.now().replace(microsecond=0).timestamp() * 1000),
+            "actual_check_time_ms": int(datetime.now().replace(microsecond=0).timestamp() * 1000),
             "duration_ms": 100,
             "request_info": {"request_type": REQUESTTYPE_HEAD, "http_status_code": 500},
         }

--- a/src/sentry/uptime/issue_platform.py
+++ b/src/sentry/uptime/issue_platform.py
@@ -82,7 +82,7 @@ def build_event_data_for_occurrence(result: CheckResult, occurrence: IssueOccurr
         "platform": "other",
         "project_id": occurrence.project_id,
         # We set this to the time that the check was performed
-        "received": datetime.fromtimestamp(result["actual_check_time"]),
+        "received": datetime.fromtimestamp(result["actual_check_time_ms"] / 1000),
         "sdk": None,
         "tags": {
             "subscription_id": result["subscription_id"],

--- a/tests/sentry/uptime/test_issue_platform.py
+++ b/tests/sentry/uptime/test_issue_platform.py
@@ -100,7 +100,7 @@ class BuildEventDataForOccurrenceTest(UptimeTestCase):
             "fingerprint": fingerprint,
             "platform": "other",
             "project_id": settings.UPTIME_POC_PROJECT_ID,
-            "received": datetime.datetime.now(),
+            "received": datetime.datetime.now().replace(microsecond=0),
             "sdk": None,
             "tags": {"subscription_id": result["subscription_id"]},
             "timestamp": occurrence.detection_time.isoformat(),


### PR DESCRIPTION
Requires https://github.com/getsentry/uptime-checker/pull/94

This will cause sentry to fail for a bit, but that's OK.

Fixes [SENTRY-FOR-SENTRY-9E1](https://sentry-st.sentry.io/issues/5560116993/)