### PR TITLE
fix(grouping): Fix missing system-only stacktraces in similar issues diff view

### DIFF
--- a/static/app/components/events/interfaces/crashContent/stackTrace/rawContent.tsx
+++ b/static/app/components/events/interfaces/crashContent/stackTrace/rawContent.tsx
@@ -170,16 +170,18 @@ export default function displayRawContent(
   exception?: ExceptionValue,
   hasSimilarityEmbeddingsFeature: boolean = false
 ) {
-  const frames: string[] = [];
+  const rawFrames = data?.frames || [];
 
-  (data?.frames ?? []).forEach((frame, frameIdx) => {
-    if (
-      !hasSimilarityEmbeddingsFeature ||
-      (frame.inApp && hasSimilarityEmbeddingsFeature)
-    ) {
-      frames.push(getFrame(frame, frameIdx, platform));
-    }
-  });
+  const hasInAppFrames = rawFrames.some(frame => frame.inApp);
+  const shouldFilterOutSystemFrames = hasSimilarityEmbeddingsFeature && hasInAppFrames;
+
+  const framesToUse = shouldFilterOutSystemFrames
+    ? rawFrames.filter(frame => frame.inApp)
+    : rawFrames;
+
+  const frames = framesToUse.map((frame, frameIdx) =>
+    getFrame(frame, frameIdx, platform)
+  );
 
   if (platform !== 'python') {
     frames.reverse();


### PR DESCRIPTION
As reported in https://github.com/getsentry/sentry/issues/72607, sometimes the diff view (used on both the merged and similar issues tabs of the issue details page) shows no stacktraces, even when the events being compared do in fact have them.

The culprit turns out to be the check [here](https://github.com/getsentry/sentry/blob/ff5efb59a42e5936507bcbc2a36888bc966742a8/static/app/components/events/interfaces/crashContent/stackTrace/rawContent.tsx#L176-L179), which filters the frames based on in-app status when the Seer similar issues flag is on. On an individual frame level, this works great, but it can leave the stacktrace overall in a bad state, with no frames to show, which happens whenever the flag is on and the stacktrace consists of nothing but system frames.

This fixes that by filtering the stacktrace as a whole before passing frames to `getFrame`, so we can recover if it turns out said filtering would leave us with no frames. It also refactors the tests a bit to make sure we're covering all cases. 

Fixes https://github.com/getsentry/sentry/issues/72607.