### PR TITLE
ref(metrics): Add edit route

### DIFF
--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -550,6 +550,10 @@ function buildRoutes() {
             () => import('sentry/views/settings/projectMetrics/projectMetricsDetails')
           )}
         />
+        <Route
+          path=":spanAttribute/edit/"
+          component={make(() => import('sentry/views/settings/projectMetrics'))}
+        />
       </Route>
       <Route
         path="replays/"

--- a/static/app/views/metrics/metricQueryContextMenu.tsx
+++ b/static/app/views/metrics/metricQueryContextMenu.tsx
@@ -152,8 +152,14 @@ export function MetricQueryContextMenu({
             organization,
           });
           Sentry.metrics.increment('ddm.widget.settings');
+
+          const {useCase, name} = parseMRI(metricsQuery.mri) ?? {};
+
+          const isSpanBasedMetric = useCase === 'spans';
+
           if (
             !hasCustomMetricsExtractionRules(organization) ||
+            !isSpanBasedMetric ||
             isCustomMetric({mri: metricsQuery.mri})
           ) {
             navigateTo(
@@ -163,7 +169,6 @@ export function MetricQueryContextMenu({
               router
             );
           } else {
-            const {name} = parseMRI(metricsQuery.mri) ?? {};
             navigateTo(`/settings/projects/:projectId/metrics/${name}/edit/`, router);
           }
         },

--- a/static/app/views/metrics/metricQueryContextMenu.tsx
+++ b/static/app/views/metrics/metricQueryContextMenu.tsx
@@ -32,6 +32,7 @@ import {
   hasCustomMetricsExtractionRules,
   hasMetricAlertFeature,
 } from 'sentry/utils/metrics/features';
+import {parseMRI} from 'sentry/utils/metrics/mri';
 import {
   isMetricsQueryWidget,
   type MetricDisplayType,
@@ -162,8 +163,8 @@ export function MetricQueryContextMenu({
               router
             );
           } else {
-            // TODO(telemetry-experience): As soon as the span-based-metrics data has an unique identifier, we should use it here
-            navigateTo(`/settings/projects/:projectId/metrics/`, router);
+            const {name} = parseMRI(metricsQuery.mri) ?? {};
+            navigateTo(`/settings/projects/:projectId/metrics/${name}/edit/`, router);
           }
         },
       },

--- a/static/app/views/settings/projectMetrics/metricsExtractionRulesTable.spec.tsx
+++ b/static/app/views/settings/projectMetrics/metricsExtractionRulesTable.spec.tsx
@@ -1,0 +1,96 @@
+import {initializeOrg} from 'sentry-test/initializeOrg';
+import {
+  render,
+  renderGlobalModal,
+  screen,
+  userEvent,
+} from 'sentry-test/reactTestingLibrary';
+
+import * as useNavigate from 'sentry/utils/useNavigate';
+
+import {MetricsExtractionRulesTable} from './metricsExtractionRulesTable';
+
+const MockNavigate = jest.fn();
+jest.mock('sentry/utils/useNavigate', () => ({
+  useNavigate: () => MockNavigate,
+}));
+describe('Metrics Extraction Rules Table', function () {
+  const {router, project, organization} = initializeOrg();
+
+  beforeEach(function () {
+    MockApiClient.addMockResponse({
+      url: `/projects/${organization.slug}/${project.slug}/metrics/extraction-rules/`,
+      method: 'GET',
+      body: [
+        {
+          spanAttribute: 'span.duration',
+          aggregates: [
+            'count',
+            'count_unique',
+            'min',
+            'max',
+            'sum',
+            'avg',
+            'p50',
+            'p75',
+            'p95',
+            'p99',
+          ],
+          unit: 'millisecond',
+          tags: ['release', 'environment', 'sdk.name', 'span.op'],
+          conditions: [
+            {
+              id: 1,
+              value: '',
+              mris: [
+                'g:custom/span_attribute_1@millisecond',
+                's:custom/span_attribute_1@millisecond',
+                'd:custom/span_attribute_1@millisecond',
+                'c:custom/span_attribute_1@millisecond',
+              ],
+            },
+          ],
+        },
+      ],
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/spans/fields/`,
+      body: [],
+    });
+  });
+
+  it('shall open the modal to edit a rule by clicking on edit', async function () {
+    jest.spyOn(useNavigate, 'useNavigate');
+
+    render(<MetricsExtractionRulesTable project={project} />);
+
+    const editButton = await screen.findByLabelText('Edit metric');
+    await userEvent.click(editButton);
+
+    expect(MockNavigate).toHaveBeenCalledWith(
+      `/settings/projects/${project.slug}/metrics/span.duration/edit/`
+    );
+  });
+
+  it('shall open the modal to edit a rule if edit path in URL', async function () {
+    jest.spyOn(useNavigate, 'useNavigate');
+
+    render(<MetricsExtractionRulesTable project={project} />, {
+      router: {
+        location: {
+          ...router.location,
+          pathname: `/settings/projects/${project.slug}/metrics/span.duration/edit/`,
+        },
+        params: {
+          spanAttribute: 'span.duration',
+        },
+      },
+    });
+
+    renderGlobalModal();
+
+    expect(
+      await screen.findByRole('heading', {name: /span.duration/})
+    ).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
### Goal

- When users are on the metrics page and a span attribute is selected, clicking the three-dot button will redirect them to the metrics settings. This action will open the metrics rule modal, with all information pre-filled.

- Users on the metrics page by clicking on the edit icon, shall see the metric rule modal, with all information pre-filled.

**Preview:**





https://github.com/getsentry/sentry/assets/29228205/e1102409-a45f-480e-b458-9b33fc016bab







closes https://github.com/getsentry/sentry/issues/73420
