### PR TITLE
[CapMan visibility] emit Sentry warning and GCP log for sampled throttled queries (generic)

### DIFF
--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import functools
 import logging
 import os
+import random
 import re
 import time
 from collections import namedtuple
@@ -1070,6 +1071,11 @@ def _bulk_snuba_query(
                     and quota_allowance_summary["throttled_by"]
                 ):
                     metrics.incr("snuba.client.query.throttle", tags={"referrer": query_referrer})
+                    if random.random() < 0.01:
+                        logger.warning("Query is throttled", extra={"response.data": response.data})
+                        sentry_sdk.capture_message(
+                            f"Query from referrer {query_referrer} is throttled", level="warning"
+                        )
 
             if response.status != 200:
                 _log_request_query(snuba_param_list[index][0])


### PR DESCRIPTION
Allocation policies are our mechanism for doing traffic management for Snuba queries. Currently, the result of applying multiple allocation policies in the internal API is simply accept/reject/throttle.

In a https://github.com/getsentry/sentry/pull/73442, we emit a Sentry warning and a GCP log for every query throttled by Snuba's capacity management system. However, we quickly realized [a large volume of queries were throttled](https://sentry.sentry.io/issues/5550501231/?project=1&query=&referrer=issue-stream&statsPeriod=24h&stream_index=5).

To address this, we sample the throttled queries such that we will only emit a Sentry warning and a GCP log for only 1% of all throttled queries, across all referrers and policies.