### PR TITLE
feat(flagpole): Adds sentry CLI command for generating new flagpole features

### DIFF
--- a/src/flagpole/__init__.py
+++ b/src/flagpole/__init__.py
@@ -68,7 +68,7 @@ import orjson
 import yaml
 from pydantic import BaseModel, Field, ValidationError, constr
 
-from flagpole.conditions import Segment
+from flagpole.conditions import ConditionBase, Segment
 from flagpole.evaluation_context import ContextBuilder, EvaluationContext
 
 
@@ -156,4 +156,11 @@ class Feature(BaseModel):
         return orjson.dumps(self.to_dict()).decode()
 
 
-__all__ = ["Feature", "InvalidFeatureFlagConfiguration", "ContextBuilder", "EvaluationContext"]
+__all__ = [
+    "Feature",
+    "InvalidFeatureFlagConfiguration",
+    "ContextBuilder",
+    "EvaluationContext",
+    "Segment",
+    "ConditionBase",
+]

--- a/src/sentry/runner/commands/createflag.py
+++ b/src/sentry/runner/commands/createflag.py
@@ -1,0 +1,141 @@
+import click
+
+from flagpole import Feature, Segment
+from flagpole.conditions import (
+    ConditionBase,
+    ConditionOperatorKind,
+    ContainsCondition,
+    EqualsCondition,
+    InCondition,
+    NotContainsCondition,
+    NotEqualsCondition,
+    NotInCondition,
+)
+from sentry.runner.decorators import configuration
+
+valid_scopes = ["organization", "project"]
+hardcoded_segment_properties = {
+    "organization_id",
+    "organization_slug",
+    "organization_is-early-adopter",
+    "project_id",
+    "project_slug",
+    "project_name",
+    "user_id",
+    "user_email",
+}
+
+feature_scopes_choices = click.Choice(valid_scopes)
+condition_type_choices = click.Choice([op.value for op in ConditionOperatorKind])
+
+
+def condition_wizard(display_sample_condition_properties: bool = False) -> ConditionBase:
+    operator_kind = click.prompt("Operator type", type=condition_type_choices, show_choices=True)
+    if display_sample_condition_properties:
+        click.echo("Here are some example condition properties available:\n")
+        for property_name in hardcoded_segment_properties:
+            click.echo(f"{property_name}")
+        click.echo("")
+
+    property_name = click.prompt("Context property name", type=str)
+    if operator_kind == ConditionOperatorKind.IN:
+        return InCondition(value=[], property=property_name)
+    elif operator_kind == ConditionOperatorKind.NOT_IN:
+        return NotInCondition(value=[], property=property_name)
+    elif operator_kind == ConditionOperatorKind.EQUALS:
+        return EqualsCondition(value="", property=property_name)
+    elif operator_kind == ConditionOperatorKind.NOT_EQUALS:
+        return NotEqualsCondition(value="", property=property_name)
+    elif operator_kind == ConditionOperatorKind.CONTAINS:
+        return ContainsCondition(value="", property=property_name)
+    elif operator_kind == ConditionOperatorKind.NOT_CONTAINS:
+        return NotContainsCondition(value="", property=property_name)
+
+    raise Exception("An unknown condition operator was provided")
+
+
+def segment_wizard() -> list[Segment]:
+    done_creating_segments = not click.confirm(
+        "Would you like to create a new segment?", default=True
+    )
+    segments = []
+    while not done_creating_segments:
+        name = click.prompt("Name", type=str)
+        rollout_percentage = click.prompt("Rollout percentage", type=int, default=100)
+        conditions = []
+
+        if should_create_conditions := click.confirm(
+            "Would you like to create some conditions?", default=True
+        ):
+            should_display_options = True
+            while should_create_conditions:
+                condition = condition_wizard(
+                    display_sample_condition_properties=should_display_options
+                )
+                should_display_options = False
+                conditions.append(condition)
+                should_create_conditions = click.confirm("Continue creating conditions?")
+
+        segment = Segment(name=name, rollout=rollout_percentage, conditions=conditions)
+        segments.append(segment)
+
+        done_creating_segments = not click.confirm("Continue creating segments?", default=False)
+
+    return segments
+
+
+@click.command()
+@click.option(
+    "--blank", default=False, is_flag=True, help="If true, will create a blank flag config"
+)
+@click.option("--name", default=None, help="The name of the feature.")
+@click.option(
+    "--scope",
+    default=None,
+    help="The feature's scope. Must be either 'project' or 'organization'",
+)
+@click.option("--owner", default=None, help="The team name or email address of the feature owner.")
+@configuration
+def createflag(
+    blank: bool | None,
+    name: str | None,
+    scope: str | None,
+    owner: str | None,
+) -> None:
+    try:
+        if not owner:
+            entered_owner = click.prompt("Owner (team name or email address)", type=str)
+            owner = entered_owner.strip()
+
+        if not name:
+            name = click.prompt("Feature name", type=str)
+
+        assert name, "Feature must have a non-empty string as a name"
+        name = name.strip().lower().replace(" ", "-")
+
+        if not scope:
+            scope = click.prompt(
+                "Feature scope",
+                type=feature_scopes_choices,
+                default="organization",
+                show_choices=True,
+            )
+
+        assert scope, "A feature scope must be provided"
+        scope = scope.lower().strip()
+        if scope not in valid_scopes:
+            raise click.ClickException(
+                f"Scope must be either 'organization' or 'project', received '{scope}'"
+            )
+
+        segments = []
+
+        if not blank:
+            segments = segment_wizard()
+        feature = Feature(name=f"feature.{scope}:{name}", owner=owner, segments=segments)
+    except Exception as err:
+        raise click.ClickException(f"{err}")
+
+    click.echo("")
+    click.echo("=== GENERATED YAML ===\n")
+    click.echo(feature.to_yaml_str())

--- a/src/sentry/runner/commands/createflag.py
+++ b/src/sentry/runner/commands/createflag.py
@@ -14,7 +14,7 @@ from flagpole.conditions import (
 from sentry.runner.decorators import configuration
 
 valid_scopes = ["organization", "project"]
-hardcoded_segment_properties = {
+hardcoded_condition_properties = {
     "organization_id",
     "organization_slug",
     "organization_is-early-adopter",
@@ -33,7 +33,7 @@ def condition_wizard(display_sample_condition_properties: bool = False) -> Condi
     operator_kind = click.prompt("Operator type", type=condition_type_choices, show_choices=True)
     if display_sample_condition_properties:
         click.echo("Here are some example condition properties available:\n")
-        for property_name in hardcoded_segment_properties:
+        for property_name in hardcoded_condition_properties:
             click.echo(f"{property_name}")
         click.echo("")
 
@@ -60,7 +60,7 @@ def segment_wizard() -> list[Segment]:
     )
     segments = []
     while not done_creating_segments:
-        name = click.prompt("Name", type=str)
+        name = click.prompt("Name", type=str).strip()
         rollout_percentage = click.prompt("Rollout percentage", type=int, default=100)
         conditions = []
 

--- a/src/sentry/runner/main.py
+++ b/src/sentry/runner/main.py
@@ -43,6 +43,7 @@ for cmd in map(
         "sentry.runner.commands.cleanup.cleanup",
         "sentry.runner.commands.config.config",
         "sentry.runner.commands.configoptions.configoptions",
+        "sentry.runner.commands.createflag.createflag",
         "sentry.runner.commands.createuser.createuser",
         "sentry.runner.commands.devserver.devserver",
         "sentry.runner.commands.django.django",

--- a/tests/sentry/runner/commands/test_createflag.py
+++ b/tests/sentry/runner/commands/test_createflag.py
@@ -6,7 +6,7 @@ from sentry.testutils.cases import CliTestCase
 
 class TestCreateFlag(CliTestCase):
     command = createflag
-    default_args = []
+    default_args: list[str] = []
 
     def convert_output_to_feature(self, output: str) -> Feature:
         split_output = output.split("=== GENERATED YAML ===\n")

--- a/tests/sentry/runner/commands/test_createflag.py
+++ b/tests/sentry/runner/commands/test_createflag.py
@@ -58,8 +58,11 @@ class TestCreateFlag(CliTestCase):
             conditions_tuples.append(condition_data)
             cli_input.extend(condition_data)
 
-        # Change last input type to
+        # Change last input to No to discontinue creating conditions
         cli_input[len(cli_input) - 1] = "n"
+
+        # Skip creating more segments
+        cli_input.append("n")
 
         rv = self.invoke(
             "--name=new flag",

--- a/tests/sentry/runner/commands/test_createflag.py
+++ b/tests/sentry/runner/commands/test_createflag.py
@@ -1,0 +1,88 @@
+from flagpole import Feature
+from flagpole.conditions import ConditionOperatorKind
+from sentry.runner.commands.createflag import createflag
+from sentry.testutils.cases import CliTestCase
+
+
+class TestCreateFlag(CliTestCase):
+    command = createflag
+    default_args = []
+
+    def convert_output_to_feature(self, output: str) -> Feature:
+        split_output = output.split("=== GENERATED YAML ===\n")
+        assert len(split_output) == 2
+        return Feature.from_bulk_yaml(split_output[1])[0]
+
+    def test_blank_options_only(self):
+        rv = self.invoke("--blank", "--name=new flag", "--scope=organizations", "--owner=test")
+        assert rv.exit_code == 0
+        parsed_feature = self.convert_output_to_feature(rv.output)
+        assert parsed_feature.name == "feature.organizations:new-flag"
+        assert parsed_feature.segments == []
+        assert parsed_feature.owner == "test"
+
+    def test_no_segments(self):
+        cli_input = ["new Flag", "Test Owner", "projects", "n"]
+        rv = self.invoke(input="\n".join(cli_input))
+        assert rv.exit_code == 0
+        parsed_feature = self.convert_output_to_feature(rv.output)
+        assert parsed_feature.name == "feature.projects:new-flag"
+        assert parsed_feature.segments == []
+        assert parsed_feature.owner == "Test Owner"
+
+    def test_no_conditions_in_segment(self):
+        cli_input = ["y", "New segment", "50", "n"]
+        rv = self.invoke(
+            "--name=new flag",
+            "--scope=organizations",
+            "--owner=Test Owner",
+            input="\n".join(cli_input),
+        )
+        assert rv.exit_code == 0
+        parsed_feature = self.convert_output_to_feature(rv.output)
+        assert parsed_feature.name == "feature.organizations:new-flag"
+        assert parsed_feature.owner == "Test Owner"
+
+        assert len(parsed_feature.segments) == 1
+        new_segment = parsed_feature.segments[0]
+        assert new_segment.name == "New segment"
+        assert new_segment.rollout == 50
+        assert new_segment.conditions == []
+
+    def test_all_condition_types(self):
+        cli_input = ["", "New segment", "", "y"]
+        conditions_tuples = []
+
+        for condition_type in ConditionOperatorKind:
+            condition_data = (f"c_prop_{condition_type.value}", f"{condition_type.value}", "y")
+            conditions_tuples.append(condition_data)
+            cli_input.extend(condition_data)
+
+        # Change last input type to
+        cli_input[len(cli_input) - 1] = "n"
+
+        rv = self.invoke(
+            "--name=new flag",
+            "--scope=organizations",
+            "--owner=Test Owner",
+            input="\n".join(cli_input),
+        )
+        assert rv.exit_code == 0
+        parsed_feature = self.convert_output_to_feature(rv.output)
+        assert parsed_feature.name == "feature.organizations:new-flag"
+        assert parsed_feature.owner == "Test Owner"
+
+        assert len(parsed_feature.segments) == 1
+        new_segment = parsed_feature.segments[0]
+
+        assert new_segment.name == "New segment"
+        assert new_segment.rollout == 100
+
+        assert len(new_segment.conditions) == 6
+
+        for c_idx in range(len(conditions_tuples)):
+            condition_tuple = conditions_tuples[c_idx]
+            condition = new_segment.conditions[c_idx]
+
+            assert condition.property == condition_tuple[0]
+            assert condition.operator == condition_tuple[1]


### PR DESCRIPTION
Adds a new CLI command `getsentry createflag` for generating skeleton feature yaml. By default, the CLI will prompt a user to enter a name, owner name, and a default segment, although this can be skipped in a number of ways.

Includes the following options:
`--name`: Provide a name via the CLI invocation. If not provided, the user will be prompted for one.
`--scope`: Provide a scope ('organization' or 'project'). If not provided, the user will be prompted for one.
`--owner`: Provide a feature owner field. If not provided, the user will be prompted for one.
`--blank`: Skip generating any segments and directly print the yaml template for the flag.

The only major things the CLI currently does not handle:
- Autofilling or showing all possible context properties a developer can match against.
- Providing prompts to enter values for each generated condition.

The hope is that this is enough to easily scaffold new feature flag yaml for use in flagpole, without prompting for too many fields or being overly burdensome.

Here's an example CLI invocation for a new feature with a couple of segments:
```
$ sentry createflag
Owner (team name or email address): Hybrid Cloud
Feature name: Super New Feature
Feature scope (organization, project) [organization]: organization
Would you like to create a new segment? [Y/n]:
Name: GA Segment
Rollout percentage [100]:
Would you like to create some conditions? [Y/n]: n
Continue creating segments? [y/N]: y
Name: Early Access Segment
Rollout percentage [100]:
Would you like to create some conditions? [Y/n]: y
Operator type (in, not_in, contains, not_contains, equals, not_equals): equals
Here are some example condition properties available:

project_slug
project_id
project_name
user_email
organization_is-early-adopter
user_id
organization_slug
organization_id

Context property name: organization_is-early-adopter
Continue creating conditions? [y/N]:
Continue creating segments? [y/N]:

=== GENERATED YAML ===

feature.organization:super-new-feature:
  created_at: '2024-07-03T04:42:04.575683'
  enabled: true
  owner: Hybrid Cloud
  segments:
  - conditions: []
    name: GA Segment
    rollout: 100
  - conditions:
    - operator: equals
      property: organization_is-early-adopter
      strict_validation: false
      value: ''
    name: Early Access Segment
    rollout: 100
```
