### PR TITLE
fix(metrics): enable new conditions without ids in metrics extraction rules

### DIFF
--- a/src/sentry/api/endpoints/project_metrics_extraction_rules.py
+++ b/src/sentry/api/endpoints/project_metrics_extraction_rules.py
@@ -145,7 +145,7 @@ class ProjectMetricsExtractionRulesEndpoint(ProjectEndpoint):
                     configs.append(config)
 
                     # delete conditions not present in update
-                    included_conditions = [x["id"] for x in obj["conditions"]]
+                    included_conditions = [x["id"] for x in obj["conditions"] if "id" in x]
                     SpanAttributeExtractionRuleCondition.objects.filter(config=config).exclude(
                         id__in=included_conditions
                     ).delete()

--- a/tests/sentry/api/endpoints/test_project_metrics_extraction_rules.py
+++ b/tests/sentry/api/endpoints/test_project_metrics_extraction_rules.py
@@ -553,6 +553,27 @@ class ProjectMetricsExtractionEndpointTestCase(APITestCase):
 
         assert response.status_code == 400
 
+        rule = {
+            "metricsExtractionRules": [
+                {
+                    "spanAttribute": "my_span_attribute",
+                    "aggregates": ["count"],
+                    "unit": "none",
+                    "tags": ["tag1", "tag2", "tag3"],
+                    "conditions": [{"value": "new:condition"}],
+                }
+            ]
+        }
+
+        response = self.get_response(
+            self.organization.slug,
+            self.project.slug,
+            method="put",
+            **rule,
+        )
+
+        assert response.status_code == 200
+
         response = self.get_response(
             self.organization.slug,
             self.project.slug,
@@ -560,7 +581,9 @@ class ProjectMetricsExtractionEndpointTestCase(APITestCase):
             **rule,
         )
         assert response.status_code == 200
-        assert len(response.data[0]["conditions"]) == 2
+        assert len(response.data[0]["conditions"]) == 1
+        assert response.data[0]["conditions"][0]["value"] == "new:condition"
+        assert response.data[0]["conditions"][0]["id"] is not None
 
     @django_db_all
     @with_feature("organizations:custom-metrics-extraction-rule")


### PR DESCRIPTION
Fixes SENTRY-3BC3