### PR TITLE
feat(metrics): add better error messages to project metrics extraction rules endpoint

### DIFF
--- a/src/sentry/api/endpoints/project_metrics_extraction_rules.py
+++ b/src/sentry/api/endpoints/project_metrics_extraction_rules.py
@@ -1,7 +1,7 @@
 import logging
 
 import sentry_sdk
-from django.db import router, transaction
+from django.db import IntegrityError, router, transaction
 from rest_framework.request import Request
 from rest_framework.response import Response
 
@@ -116,11 +116,15 @@ class ProjectMetricsExtractionRulesEndpoint(ProjectEndpoint):
                 )
 
             persisted_config = serialize(
-                configs,
-                request.user,
-                SpanAttributeExtractionRuleConfigSerializer(),
+                configs, request.user, SpanAttributeExtractionRuleConfigSerializer()
             )
             return Response(data=persisted_config, status=200)
+
+        except IntegrityError:
+            return Response(status=409, data={"detail": "Resource already exists."})
+
+        except KeyError as e:
+            return Response(status=400, data={"detail": f"Missing field in input data: {str(e)}"})
 
         except MetricsExtractionRuleValidationError as e:
             logger.warning("Failed to update extraction rule", exc_info=True)

--- a/src/sentry/api/endpoints/project_metrics_extraction_rules.py
+++ b/src/sentry/api/endpoints/project_metrics_extraction_rules.py
@@ -188,6 +188,9 @@ class ProjectMetricsExtractionRulesEndpoint(ProjectEndpoint):
 
             return Response(data=persisted_config, status=200)
 
+        except KeyError as e:
+            return Response(status=400, data={"detail": f"Missing field in input data: {str(e)}"})
+
         except MetricsExtractionRuleValidationError as e:
             logger.warning("Failed to update extraction rule", exc_info=True)
             return Response(status=400, data={"detail": str(e)})

--- a/tests/sentry/api/endpoints/test_project_metrics_extraction_rules.py
+++ b/tests/sentry/api/endpoints/test_project_metrics_extraction_rules.py
@@ -319,7 +319,7 @@ class ProjectMetricsExtractionEndpointTestCase(APITestCase):
             method="post",
             **rule,
         )
-        assert response.status_code == 400
+        assert response.status_code == 409
 
     @django_db_all
     @with_feature("organizations:custom-metrics-extraction-rule")


### PR DESCRIPTION
Return HTTP 409 when a config already exists.
Return HTTP 400 when input object is missing a required field.