### PR TITLE
ref(sdk): Remove `configure_scope` re-export from SDK utils

### DIFF
--- a/src/sentry/utils/sdk.py
+++ b/src/sentry/utils/sdk.py
@@ -14,7 +14,7 @@ from rest_framework.request import Request
 
 # Reexport sentry_sdk just in case we ever have to write another shim like we
 # did for raven
-from sentry_sdk import Scope, capture_exception, capture_message, configure_scope, isolation_scope
+from sentry_sdk import Scope, capture_exception, capture_message, isolation_scope
 from sentry_sdk.client import get_options
 from sentry_sdk.integrations.django.transactions import LEGACY_RESOLVER
 from sentry_sdk.transport import make_transport
@@ -700,7 +700,6 @@ __all__ = (
     "capture_message",
     "check_current_scope_transaction",
     "check_tag_for_scope_bleed",
-    "configure_scope",
     "configure_sdk",
     "get_options",
     "get_project_key",


### PR DESCRIPTION
We no longer use this re-export in Sentry, so we should remove it. Doing so hopefully will also discourage future code from using the deprecated `configure_scope`.

Requires https://github.com/getsentry/getsentry/pull/14522

ref #73430