### PR TITLE
fix(snuba): Allow common suffixes when validating referrers

### DIFF
--- a/tests/snuba/test_referrer.py
+++ b/tests/snuba/test_referrer.py
@@ -31,6 +31,21 @@ class ReferrerTest(TestCase):
         assert warn_log.call_count == 1
 
     @patch("sentry.snuba.referrer.logger.warning")
+    def test_referrer_validate_common_suffixes(self, warn_log):
+        assert warn_log.call_count == 0
+        validate_referrer("api.performance.http.domain-summary-transactions-list")
+        validate_referrer("api.performance.http.domain-summary-transactions-list.primary")
+        validate_referrer("api.performance.http.domain-summary-transactions-list.secondary")
+        assert warn_log.call_count == 0
+
+    @patch("sentry.snuba.referrer.logger.warning")
+    def test_referrer_validate_uncommon_suffixes(self, warn_log):
+        assert warn_log.call_count == 0
+        validate_referrer("api.performance.http.domain-summary-transactions-list.special")
+        validate_referrer("api.performance.http.domain-summary-transactions-list.airyrpm")
+        assert warn_log.call_count == 2
+
+    @patch("sentry.snuba.referrer.logger.warning")
     def test_referrer_validate_tsdb_models(self, warn_log):
         assert warn_log.call_count == 0
         for model in TSDBModel:


### PR DESCRIPTION
The query builder adds `".primary"` and `".secondary"` to the query referrer string when it constructs compound queries (when fetching from multiple tables). It's a pain to have to declare both a primary _and_ a secondary _and_ a regular referrer for each of those cases, especially because the fields in the query can change for all kinds of reasons. Instead, add a list of common referrer suffixes that are considered valid. Closes https://github.com/getsentry/sentry/issues/71570

P.S. There are already a bunch of referrers defined with those suffixes, which I guess I could have removed, but I didn't bother in this PR. Should I trash 'em?
