### PR TITLE
fix(insights): Update "Requests" module page header

### DIFF
--- a/static/app/components/sidebar/index.tsx
+++ b/static/app/components/sidebar/index.tsx
@@ -53,6 +53,7 @@ import useProjects from 'sentry/utils/useProjects';
 import {normalizeUrl} from 'sentry/utils/withDomainRequired';
 import {releaseLevelAsBadgeProps as CacheModuleBadgeProps} from 'sentry/views/insights/cache/settings';
 import {useModuleURLBuilder} from 'sentry/views/insights/common/utils/useModuleURL';
+import {MODULE_SIDEBAR_TITLE as HTTP_MODULE_SIDEBAR_TITLE} from 'sentry/views/insights/http/settings';
 import {releaseLevelAsBadgeProps as LLMModuleBadgeProps} from 'sentry/views/insights/llmMonitoring/settings';
 import {releaseLevelAsBadgeProps as QueuesModuleBadgeProps} from 'sentry/views/insights/queues/settings';
 import {MODULE_TITLES} from 'sentry/views/insights/settings';
@@ -255,7 +256,9 @@ function Sidebar() {
     <Feature key="http" features="insights-entry-points" organization={organization}>
       <SidebarItem
         {...sidebarItemProps}
-        label={<GuideAnchor target="performance-http">{MODULE_TITLES.http}</GuideAnchor>}
+        label={
+          <GuideAnchor target="performance-http">{HTTP_MODULE_SIDEBAR_TITLE}</GuideAnchor>
+        }
         to={`/organizations/${organization.slug}/${moduleURLBuilder('http')}/`}
         id="performance-http"
         icon={<SubitemDot collapsed />}

--- a/static/app/views/insights/http/settings.ts
+++ b/static/app/views/insights/http/settings.ts
@@ -1,7 +1,8 @@
 import {t} from 'sentry/locale';
 import {ModuleName} from 'sentry/views/insights/types';
 
-export const MODULE_TITLE = t('Requests');
+export const MODULE_TITLE = t('Outbound API Requests');
+export const MODULE_SIDEBAR_TITLE = t('Requests');
 export const DATA_TYPE = t('Request');
 export const DATA_TYPE_PLURAL = t('Requests');
 export const BASE_URL = 'http';

--- a/static/app/views/insights/http/views/httpLandingPage.spec.tsx
+++ b/static/app/views/insights/http/views/httpLandingPage.spec.tsx
@@ -274,6 +274,10 @@ describe('HTTPLandingPage', function () {
 
     await waitForElementToBeRemoved(() => screen.queryAllByTestId('loading-indicator'));
 
+    expect(screen.getByRole('heading', {level: 1})).toHaveTextContent(
+      'Outbound API Requests'
+    );
+
     expect(screen.getByRole('table', {name: 'Domains'})).toBeInTheDocument();
 
     expect(screen.getByRole('columnheader', {name: 'Domain'})).toBeInTheDocument();


### PR DESCRIPTION
By request (no pun intended) from Product, since almost all customers are confused by what the module actually contains. Changes the page header from "Requests" to "Outbound API Requests" The sidebar link is unchanged!

**e.g.,**

<img width="581" alt="Screenshot 2024-07-03 at 11 01 54 AM" src="https://github.com/getsentry/sentry/assets/989898/76002d05-0c1c-490a-8998-2cbe09085688">
