### PR TITLE
fix(insights): Add redirects for Insights sub-routes

### DIFF
--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -1468,8 +1468,8 @@ function buildRoutes() {
         moduleBaseURL && (
           <Redirect
             key={moduleBaseURL}
-            from={`${moduleBaseURL}`}
-            to={`/${INSIGHTS_BASE_URL}/${moduleBaseURL}/`}
+            from={`${moduleBaseURL}/*`}
+            to={`/${INSIGHTS_BASE_URL}/${moduleBaseURL}/:splat`}
           />
         )
     )


### PR DESCRIPTION
https://github.com/getsentry/sentry/pull/72881 added "proper" redirects for all Insights module from `/performance/` to `/insights/` URLs, but it missed sub-routes! URLs like `/performance/http/domains/?domain=sentry.io` weren't getting redirected.

The wildcard and `:splat` match creates redirects for all sub-routes.
