### PR TITLE
chore(slack): Fix Bug when Slack Rate Limits in `get_channel_id`

### DIFF
--- a/src/sentry/integrations/slack/utils/channel.py
+++ b/src/sentry/integrations/slack/utils/channel.py
@@ -228,8 +228,10 @@ def check_user_with_timeout(
             # TODO: This is a problem if we don't go through all the users and eventually run in to someone with duplicate display name
             if time.time() > time_to_quit:
                 return SlackChannelIdData(prefix=_prefix, channel_id=None, timed_out=True)
-    except SlackApiError:
+    except SlackApiError as e:
         _logger.exception("rule.slack.user_check_error", extra=logger_params)
+        if "ratelimited" in str(e):
+            raise ApiRateLimitedError("Slack rate limited") from e
 
     return SlackChannelIdData(prefix=_prefix, channel_id=_channel_id, timed_out=False)
 


### PR DESCRIPTION
There was a small regression in `get_channel_id`. When Slack Rate Limits, the previous implementation forced the caller handles the exception, in the rewrite, we weren't raising it so I fixed it. 

Previous logic:
https://github.com/getsentry/sentry/blob/master/src/sentry/integrations/slack/utils/channel.py#L323-L328

Surprised we haven't run into this, but this probably cause people aren't abusing alerts creation.

I also made the tests reflect the Rate Limiting logic.