### PR TITLE
fix(trace) limit max button height

### DIFF
--- a/static/app/views/performance/newTraceDetails/traceDrawer/traceDrawer.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/traceDrawer.tsx
@@ -807,6 +807,8 @@ const TabIconButton = styled(Button)<{active: boolean}>`
   box-shadow: none;
   transition: none !important;
   opacity: ${p => (p.active ? 0.7 : 0.5)};
+  height: 24px;
+  max-height: 24px;
 
   &:not(:last-child) {
     margin-right: ${space(1)};


### PR DESCRIPTION
Seems like the button had increased in size and can overlap with the indicator (by 2px).