### PR TITLE
fix(new-trace): Updated trace null or undefined check to be more clear

### DIFF
--- a/static/app/views/discover/table/tableView.tsx
+++ b/static/app/views/discover/table/tableView.tsx
@@ -190,7 +190,7 @@ function TableView(props: TableViewProps) {
 
       let target;
 
-      if (dataRow.trace == null) {
+      if (dataRow.trace === null || dataRow.trace === undefined) {
         if (dataRow['event.type'] === 'transaction') {
           throw new Error(
             'Transaction event should always have a trace associated with it.'
@@ -321,7 +321,7 @@ function TableView(props: TableViewProps) {
     if (columnKey === 'id') {
       let target;
 
-      if (dataRow.trace == null) {
+      if (dataRow.trace === null || dataRow.trace === undefined) {
         if (dataRow['event.type'] === 'transaction') {
           throw new Error(
             'Transaction event should always have a trace associated with it.'


### PR DESCRIPTION
The `==` syntax can be confusing 