### PR TITLE
fix(feedback): Sometimes events can be missing fields, we should guard against it

### DIFF
--- a/static/app/components/feedback/feedbackItem/feedbackItem.tsx
+++ b/static/app/components/feedback/feedbackItem/feedbackItem.tsx
@@ -30,8 +30,8 @@ interface Props {
 export default function FeedbackItem({feedbackItem, eventData, tags}: Props) {
   const organization = useOrganization();
   const url =
-    eventData?.contexts.feedback?.url ??
-    eventData?.tags.find(tag => tag.key === 'url')?.value;
+    eventData?.contexts?.feedback?.url ??
+    eventData?.tags?.find(tag => tag.key === 'url')?.value;
   const crashReportId = eventData?.contexts?.feedback?.associated_event_id;
   const theme = useTheme();
 
@@ -47,7 +47,7 @@ export default function FeedbackItem({feedbackItem, eventData, tags}: Props) {
 
   const URL_NOT_FOUND = t('URL not found');
   const displayUrl =
-    eventData?.contexts.feedback || eventData?.tags ? url ?? URL_NOT_FOUND : '';
+    eventData?.contexts?.feedback || eventData?.tags ? url ?? URL_NOT_FOUND : '';
   const urlIsLink = displayUrl.length && displayUrl !== URL_NOT_FOUND;
 
   return (


### PR DESCRIPTION
We've got optional chaining in all the other places, but missed these lines. I think the TS types are not as helpful as they should be when it comes to Event and Group types, so many things are optional but not typed that way. We'll have to address this across the app somehow.

Related to https://github.com/getsentry/sentry/issues/67412#issuecomment-2205473937