### PR TITLE
fix(replay): Include timestamps in the useExtractedPageHtml cache key

### DIFF
--- a/static/app/utils/replays/hooks/useExtractedPageHtml.tsx
+++ b/static/app/utils/replays/hooks/useExtractedPageHtml.tsx
@@ -9,7 +9,7 @@ interface Props {
 
 export default function useExtractedPageHtml({replay, offsetMsToStopAt}: Props) {
   return useQuery(
-    ['extactPageHtml', replay],
+    ['extactPageHtml', replay, offsetMsToStopAt],
     () =>
       extractPageHtml({
         offsetMsToStopAt,


### PR DESCRIPTION
We should build a cache-key based on all the function arguments

Followup to the comment: https://github.com/getsentry/sentry/pull/73607#discussion_r1662888806

Related to https://github.com/getsentry/sentry/pull/73607