### PR TITLE
fix(similarity): Call seer delete record before hash deletion

### DIFF
--- a/src/sentry/tasks/delete_seer_grouping_records.py
+++ b/src/sentry/tasks/delete_seer_grouping_records.py
@@ -58,7 +58,8 @@ def call_delete_seer_grouping_records_by_hash(
             "calling seer record deletion by hash",
             extra={"project_id": project.id, "hashes": group_hashes},
         )
-        delete_seer_grouping_records_by_hash.apply_async(args=[project.id, group_hashes, 0])
+        if group_hashes:
+            delete_seer_grouping_records_by_hash.apply_async(args=[project.id, group_hashes, 0])
 
 
 @instrumented_task(

--- a/tests/sentry/api/helpers/test_group_index.py
+++ b/tests/sentry/api/helpers/test_group_index.py
@@ -5,6 +5,7 @@ import pytest
 from django.http import QueryDict
 
 from sentry.api.helpers.group_index import update_groups, validate_search_filter_permissions
+from sentry.api.helpers.group_index.delete import delete_groups
 from sentry.api.helpers.group_index.update import (
     handle_assigned_to,
     handle_has_seen,
@@ -18,6 +19,7 @@ from sentry.models.activity import Activity
 from sentry.models.group import Group, GroupStatus
 from sentry.models.groupassignee import GroupAssignee
 from sentry.models.groupbookmark import GroupBookmark
+from sentry.models.grouphash import GroupHash
 from sentry.models.groupinbox import GroupInbox, GroupInboxReason, add_group_to_inbox
 from sentry.models.groupseen import GroupSeen
 from sentry.models.groupshare import GroupShare
@@ -1055,3 +1057,61 @@ class TestHandleAssignedTo(TestCase):
             user_id=user2.id,
             reason=GroupSubscriptionReason.assigned,
         ).exists()
+
+
+class DeleteGroupsTest(TestCase):
+    @patch("sentry.signals.issue_deleted.send_robust")
+    def test_delete_groups_simple(self, send_robust: Mock):
+        groups = [self.create_group(), self.create_group()]
+        group_ids = [group.id for group in groups]
+        request = self.make_request(user=self.user, method="GET")
+        request.user = self.user
+        request.GET = QueryDict(f"id={group_ids[0]}&id={group_ids[1]}")
+        hashes = ["0" * 32, "1" * 32]
+        for i, group in enumerate(groups):
+            GroupHash.objects.create(project=self.project, group=group, hash=hashes[i])
+            add_group_to_inbox(group, GroupInboxReason.NEW)
+
+        search_fn = Mock()
+        delete_groups(request, [self.project], self.organization.id, search_fn)
+
+        assert (
+            len(GroupHash.objects.filter(project_id=self.project.id, group_id__in=group_ids).all())
+            == 0
+        )
+        assert (
+            len(GroupInbox.objects.filter(project_id=self.project.id, group_id__in=group_ids).all())
+            == 0
+        )
+        assert send_robust.called
+
+    @with_feature("projects:similarity-embeddings-delete-by-hash")
+    @patch("sentry.tasks.delete_seer_grouping_records.logger")
+    @patch("sentry.signals.issue_deleted.send_robust")
+    def test_delete_groups_deletes_seer_records_by_hash(self, send_robust: Mock, mock_logger: Mock):
+        groups = [self.create_group(), self.create_group()]
+        group_ids = [group.id for group in groups]
+        request = self.make_request(user=self.user, method="GET")
+        request.user = self.user
+        request.GET = QueryDict(f"id={group_ids[0]}&id={group_ids[1]}")
+        hashes = ["0" * 32, "1" * 32]
+        for i, group in enumerate(groups):
+            GroupHash.objects.create(project=self.project, group=group, hash=hashes[i])
+            add_group_to_inbox(group, GroupInboxReason.NEW)
+
+        search_fn = Mock()
+        delete_groups(request, [self.project], self.organization.id, search_fn)
+
+        assert (
+            len(GroupHash.objects.filter(project_id=self.project.id, group_id__in=group_ids).all())
+            == 0
+        )
+        assert (
+            len(GroupInbox.objects.filter(project_id=self.project.id, group_id__in=group_ids).all())
+            == 0
+        )
+        assert send_robust.called
+        mock_logger.info.assert_called_with(
+            "calling seer record deletion by hash",
+            extra={"project_id": self.project.id, "hashes": hashes},
+        )

--- a/tests/sentry/tasks/test_delete_seer_grouping_records.py
+++ b/tests/sentry/tasks/test_delete_seer_grouping_records.py
@@ -50,6 +50,23 @@ class TestDeleteSeerGroupingRecordsByHash(TestCase):
             extra={"project_id": self.project.id, "hashes": hashes},
         )
 
+    @with_feature("projects:similarity-embeddings-delete-by-hash")
+    @patch("sentry.tasks.delete_seer_grouping_records.delete_seer_grouping_records_by_hash")
+    @patch("sentry.tasks.delete_seer_grouping_records.logger")
+    def test_call_delete_seer_grouping_records_by_hash_no_hashes(
+        self, mock_logger, mock_delete_seer_grouping_records_by_hash
+    ):
+        group_ids = []
+        for _ in range(5):
+            group = self.create_group(project=self.project)
+            group_ids.append(group.id)
+        call_delete_seer_grouping_records_by_hash(group_ids)
+        mock_logger.info.assert_called_with(
+            "calling seer record deletion by hash",
+            extra={"project_id": self.project.id, "hashes": []},
+        )
+        mock_delete_seer_grouping_records_by_hash.assert_not_called()
+
     @patch("sentry.tasks.delete_seer_grouping_records.logger")
     def test_call_delete_seer_grouping_records_by_hash_no_group_ids(self, mock_logger):
         call_delete_seer_grouping_records_by_hash([])


### PR DESCRIPTION
Before:
- Call to delete seer records was only called [here](https://github.com/getsentry/sentry/pull/new/jodi/fix-delete-records-by-hash), however hashes corresponding to these groups are already deleted [here](https://github.com/getsentry/sentry/compare/jodi/fix-delete-records-by-hash?expand=1#diff-c6570c132b6f37f9f29502555693ca55c2440059eda7edc4bce455ddf607bdc1L49) if called by the group deletion endpoint
- This only worked for cases where group deletion was called from elsewhere

Now:
- Call delete seer records before we delete the hashes in the group deletion endpoint