### PR TITLE
style(ui): Make delete account copy scarier (#73096)

### DIFF
--- a/static/app/views/settings/account/accountClose.spec.tsx
+++ b/static/app/views/settings/account/accountClose.spec.tsx
@@ -64,7 +64,7 @@ describe('AccountClose', function () {
 
     expect(
       screen.getByText(
-        'This is permanent and cannot be undone, are you really sure you want to do this?'
+        'WARNING! This is permanent and cannot be undone, are you really sure you want to do this?'
       )
     ).toBeInTheDocument();
     await userEvent.click(screen.getByText('Confirm'));

--- a/static/app/views/settings/account/accountClose.tsx
+++ b/static/app/views/settings/account/accountClose.tsx
@@ -14,7 +14,7 @@ import PanelAlert from 'sentry/components/panels/panelAlert';
 import PanelBody from 'sentry/components/panels/panelBody';
 import PanelHeader from 'sentry/components/panels/panelHeader';
 import PanelItem from 'sentry/components/panels/panelItem';
-import {t, tct} from 'sentry/locale';
+import {t} from 'sentry/locale';
 import type {Organization, OrganizationSummary} from 'sentry/types';
 import useApi from 'sentry/utils/useApi';
 import {ConfirmAccountClose} from 'sentry/views/settings/account/confirmAccountClose';
@@ -137,7 +137,10 @@ function AccountClose() {
       <SettingsPageHeader title={t('Close Account')} />
 
       <TextBlock>
-        {t('This will permanently remove all associated data for your user')}.
+        {t(
+          'This will permanently remove all associated data for your user. Any specified organizations will also be deleted'
+        )}
+        .
       </TextBlock>
 
       <Alert type="error" showIcon>
@@ -147,16 +150,17 @@ function AccountClose() {
       </Alert>
 
       <Panel>
-        <PanelHeader>{t('Remove the following organizations')}</PanelHeader>
+        <PanelHeader>{t('Delete the following organizations')}</PanelHeader>
         <PanelBody>
           <PanelAlert type="info">
+            <strong>{t('ORGANIZATIONS WITH CHECKED BOXES WILL BE DELETED')}</strong>
+            <br />
             {t(
               'Ownership will remain with other organization owners if an organization is not deleted.'
             )}
             <br />
-            {tct(
-              "Boxes which can't be unchecked mean that you are the only organization owner and the organization [strong:will be deleted].",
-              {strong: <strong />}
+            {t(
+              "Boxes which can't be unchecked mean that you are the only organization admin and will be deleted."
             )}
           </PanelAlert>
 

--- a/static/app/views/settings/account/accountClose.tsx
+++ b/static/app/views/settings/account/accountClose.tsx
@@ -138,9 +138,8 @@ function AccountClose() {
 
       <TextBlock>
         {t(
-          'This will permanently remove all associated data for your user. Any specified organizations will also be deleted'
+          'This will permanently remove all associated data for your user. Any specified organizations will also be deleted.'
         )}
-        .
       </TextBlock>
 
       <Alert type="error" showIcon>

--- a/static/app/views/settings/account/accountClose.tsx
+++ b/static/app/views/settings/account/accountClose.tsx
@@ -152,15 +152,15 @@ function AccountClose() {
       <Panel>
         <PanelHeader>{t('Delete the following organizations')}</PanelHeader>
         <PanelBody>
-          <PanelAlert type="info">
-            <strong>{t('ORGANIZATIONS WITH CHECKED BOXES WILL BE DELETED')}</strong>
+          <PanelAlert type="warning">
+            <strong>{t('ORGANIZATIONS WITH CHECKED BOXES WILL BE DELETED!')}</strong>
             <br />
             {t(
               'Ownership will remain with other organization owners if an organization is not deleted.'
             )}
             <br />
             {t(
-              "Boxes which can't be unchecked mean that you are the only organization admin and will be deleted."
+              "Boxes which can't be unchecked mean that you are the only organization owner and the organization will be deleted."
             )}
           </PanelAlert>
 

--- a/static/app/views/settings/account/confirmAccountClose.tsx
+++ b/static/app/views/settings/account/confirmAccountClose.tsx
@@ -11,7 +11,7 @@ export function ConfirmAccountClose({
     <Confirm
       priority="danger"
       message={t(
-        'This is permanent and cannot be undone, are you really sure you want to do this?'
+        'WARNING! This is permanent and cannot be undone, are you really sure you want to do this?'
       )}
       onConfirm={handleRemoveAccount}
     >


### PR DESCRIPTION
Changes delete user page to be clearer when deleting organizations alongside the user's account.

ref #73096

<!-- Describe your PR here. -->

Changes to delete user page text to be more explicit when deleting organizations
Before:
<img width="526" alt="image" src="https://github.com/getsentry/sentry/assets/60594860/89f245e0-2e4e-43ba-8402-840d27835ca7">


After:
![image](https://github.com/getsentry/sentry/assets/60594860/5159faae-1061-4ca9-ad46-5c936101837e)