### PR TITLE
feat(replays): Add tooltip to replay timeline gaps

### DIFF
--- a/static/app/components/replays/breadcrumbs/replayTimeline.tsx
+++ b/static/app/components/replays/breadcrumbs/replayTimeline.tsx
@@ -68,13 +68,13 @@ export default function ReplayTimeline() {
       >
         <MinorGridlines durationMs={durationMs} width={width} />
         <MajorGridlines durationMs={durationMs} width={width} />
+        <TimelineScrubber />
         <TimelineGaps
           durationMs={durationMs}
           frames={appFrames}
           totalFrames={chapterFrames.length}
           width={width}
         />
-        <TimelineScrubber />
         <TimelineEventsContainer>
           <ReplayTimelineEvents
             durationMs={durationMs}

--- a/static/app/components/replays/breadcrumbs/timelineGaps.tsx
+++ b/static/app/components/replays/breadcrumbs/timelineGaps.tsx
@@ -2,6 +2,8 @@ import styled from '@emotion/styled';
 
 import * as Timeline from 'sentry/components/replays/breadcrumbs/timeline';
 import {getFramesByColumn} from 'sentry/components/replays/utils';
+import {Tooltip} from 'sentry/components/tooltip';
+import {t} from 'sentry/locale';
 import {
   isBackgroundFrame,
   isForegroundFrame,
@@ -64,15 +66,23 @@ export default function TimelineGaps({durationMs, frames, totalFrames, width}: P
   return (
     <Timeline.Columns totalColumns={totalColumns} remainder={0}>
       {gapCol.map(column => (
-        <Gap key={column} column={column} />
+        <Column key={column} column={column}>
+          <Tooltip title={t('App is suspended')} isHoverable containerDisplayMode="grid">
+            <Gap style={{width: `${markerWidth}px`}} />
+          </Tooltip>
+        </Column>
       ))}
     </Timeline.Columns>
   );
 }
 
-const Gap = styled(Timeline.Col)<{column: number}>`
+const Column = styled(Timeline.Col)<{column: number}>`
   grid-column: ${p => p.column};
-  background: ${p => p.theme.gray400};
   line-height: 14px;
+`;
+
+const Gap = styled('span')`
+  background: ${p => p.theme.gray400};
   opacity: 16%;
+  height: 20px;
 `;


### PR DESCRIPTION
Adds tooltip to the timeline gap. Also prevents you from clicking on the timeline when there are gaps (only applies to timeline not scrubber)

![image](https://github.com/getsentry/sentry/assets/55311782/46205888-5ade-4584-a8b6-2b44bd135417)

Relates to https://github.com/getsentry/sentry/issues/71665
