### PR TITLE
fix(performance): txn summary "has" queries should fall back

### DIFF
--- a/src/sentry/search/events/builder/metrics.py
+++ b/src/sentry/search/events/builder/metrics.py
@@ -709,17 +709,10 @@ class MetricsQueryBuilder(BaseQueryBuilder):
 
         # Handle checks for existence
         if search_filter.operator in ("=", "!=") and search_filter.value.value == "":
-            if name in constants.METRICS_MAP:
-                if search_filter.operator == "!=":
-                    return None
-                else:
-                    raise IncompatibleMetricsQuery("!has isn't compatible with metrics queries")
+            if name in constants.METRICS_MAP and search_filter.operator == "!=":
+                return None
             else:
-                return Condition(
-                    Function("has", [Column("tags.key"), self.resolve_metric_index(name)]),
-                    Op.EQ if search_filter.operator == "!=" else Op.NEQ,
-                    1,
-                )
+                raise IncompatibleMetricsQuery("has isn't compatible with metrics queries")
 
         if name in ["organization_id", "org_id"]:
             raise IncompatibleMetricsQuery(f"{name} isn't compatible with metrics queries")

--- a/tests/snuba/api/endpoints/test_organization_events_stats_mep.py
+++ b/tests/snuba/api/endpoints/test_organization_events_stats_mep.py
@@ -294,6 +294,8 @@ class OrganizationEventsStatsMetricsEnhancedPerformanceEndpointTest(
         assert get_mep(
             "event.type:transaction OR transaction:foo_transaction"
         ), "boolean with mep filter"
+        assert get_mep("has:transaction.duration"), "has a tag in the metrics dataset"
+        assert not get_mep("has:device"), "has a tag not in the metrics dataset"
 
     def test_having_condition_with_preventing_aggregates(self):
         response = self.do_request(


### PR DESCRIPTION
Currently, `has` queries in the Transaction Summary filter causes an empty Duration Breakdown, although samples are returned. This happens because the metrics dataset only contains a subset of tags (to make cardinality manageable), so only those tags will return metrics data with `has` queries.

Since the tags for each metric are inconsistent, instead remove support for `has` queries to the metrics dataset, which will cause a fallback to the transactions dataset instead. That way queries will return metric results from the indexed transaction data instead of empty results.

Fixes #73591