### PR TITLE
ref(related_issues): Fix naming

### DIFF
--- a/static/app/views/issueDetails/traceTimeline/traceIssue.tsx
+++ b/static/app/views/issueDetails/traceTimeline/traceIssue.tsx
@@ -19,7 +19,7 @@ export function TraceIssueEvent({event}: TraceIssueEventProps) {
   const organization = useOrganization();
   const project = useProjectFromSlug({organization, projectSlug: event['project.name']});
   const issueId = event['issue.id'];
-  const {title, subtitle} = getTitleSubtitle(event);
+  const {title, subtitle, message} = getTitleSubtitleMessage(event);
   const avatarSize = parseInt(space(4), 10);
 
   const referrer = 'issue_details.related_trace_issue';
@@ -59,26 +59,29 @@ export function TraceIssueEvent({event}: TraceIssueEventProps) {
         <TraceIssueDetailsContainer>
           <NoOverflowDiv>
             <TraceIssueEventTitle>{title}</TraceIssueEventTitle>
-            <TraceIssueEventTransaction>{event.transaction}</TraceIssueEventTransaction>
+            <TraceIssueEventSubtitle>{subtitle}</TraceIssueEventSubtitle>
           </NoOverflowDiv>
-          <NoOverflowDiv>{subtitle}</NoOverflowDiv>
+          <NoOverflowDiv>{message}</NoOverflowDiv>
         </TraceIssueDetailsContainer>
       </TraceIssueLinkContainer>
     </Fragment>
   );
 }
 
-function getTitleSubtitle(event: TimelineEvent) {
+function getTitleSubtitleMessage(event: TimelineEvent) {
   let title;
-  let subtitle;
+  // XXX: This is not fully correct but it will make this first PR easier to review
+  const subtitle = event.transaction;
+  let message = event.message;
   if (event['event.type'] === 'error') {
     title = event.title.split(':')[0];
-    subtitle = event.message;
   } else {
     title = event.title;
-    subtitle = event.message.replace(event.transaction, '').replace(title, '');
+    // It is suspected that this value is calculated somewhere in Relay
+    // and we deconstruct it here to match what the Issue details page shows
+    message = event.message.replace(event.transaction, '').replace(title, '');
   }
-  return {title, subtitle};
+  return {title, subtitle, message};
 }
 
 const TraceIssueLinkContainer = styled(Link)`
@@ -123,6 +126,6 @@ const TraceIssueEventTitle = styled('span')`
   margin-right: ${space(1)};
 `;
 
-const TraceIssueEventTransaction = styled('span')`
+const TraceIssueEventSubtitle = styled('span')`
   color: ${p => p.theme.subText};
 `;

--- a/static/app/views/issueDetails/traceTimeline/useTraceTimelineEvents.tsx
+++ b/static/app/views/issueDetails/traceTimeline/useTraceTimelineEvents.tsx
@@ -17,11 +17,11 @@ interface BaseEvent {
   transaction: string;
 }
 
-export interface TimelineDiscoverEvent extends BaseEvent {
+interface TimelineDiscoverEvent extends BaseEvent {}
+interface TimelineIssuePlatformEvent extends BaseEvent {
   'event.type': string;
   'stack.function': string[];
 }
-interface TimelineIssuePlatformEvent extends BaseEvent {}
 
 export type TimelineEvent = TimelineDiscoverEvent | TimelineIssuePlatformEvent;
 

--- a/static/app/views/issueDetails/traceTimeline/useTraceTimelineEvents.tsx
+++ b/static/app/views/issueDetails/traceTimeline/useTraceTimelineEvents.tsx
@@ -17,11 +17,11 @@ interface BaseEvent {
   transaction: string;
 }
 
-interface TimelineDiscoverEvent extends BaseEvent {}
-interface TimelineIssuePlatformEvent extends BaseEvent {
+export interface TimelineDiscoverEvent extends BaseEvent {
   'event.type': string;
   'stack.function': string[];
 }
+interface TimelineIssuePlatformEvent extends BaseEvent {}
 
 export type TimelineEvent = TimelineDiscoverEvent | TimelineIssuePlatformEvent;
 

--- a/static/app/views/issueDetails/traceTimelineOrRelatedIssue.spec.tsx
+++ b/static/app/views/issueDetails/traceTimelineOrRelatedIssue.spec.tsx
@@ -207,7 +207,7 @@ describe('TraceTimeline & TraceRelated Issue', () => {
 
     // Instead of a timeline, we should see the other related issue
     expect(await screen.findByText('Slow DB Query')).toBeInTheDocument(); // The title
-    expect(await screen.findByText('/api/slow')).toBeInTheDocument(); // The subtitle/transaction
+    expect(await screen.findByText('/api/slow/')).toBeInTheDocument(); // The subtitle/transaction
     expect(
       await screen.findByText('One other issue appears in the same trace.')
     ).toBeInTheDocument();

--- a/static/app/views/issueDetails/traceTimelineOrRelatedIssue.spec.tsx
+++ b/static/app/views/issueDetails/traceTimelineOrRelatedIssue.spec.tsx
@@ -21,11 +21,10 @@ describe('TraceTimeline & TraceRelated Issue', () => {
   const organization = OrganizationFixture({
     features: ['global-views'],
   });
-  const firstEventTimestamp = '2024-01-24T09:09:01+00:00';
   // This creates the ApiException event
   const event = EventFixture({
     // This is used to determine the presence of seconds
-    dateCreated: firstEventTimestamp,
+    dateCreated: '2024-01-24T09:09:01+00:00',
     contexts: {
       trace: {
         // This is used to determine if we should attempt
@@ -40,7 +39,7 @@ describe('TraceTimeline & TraceRelated Issue', () => {
   const issuePlatformBody: TraceEventResponse = {
     data: [
       {
-        // In issuePlatform, we store the subtitle within the message
+        // In issuePlatform, the message stores the title and the transaction
         message: '/api/slow/ Slow DB Query SELECT "sentry_monitorcheckin"."monitor_id"',
         timestamp: '2024-01-24T09:09:03+00:00',
         'issue.id': 1000,
@@ -54,8 +53,8 @@ describe('TraceTimeline & TraceRelated Issue', () => {
     meta: {fields: {}, units: {}},
   };
   const mainError = {
-    message: 'This is the subtitle of the issue',
-    timestamp: firstEventTimestamp,
+    message: 'This is the message for the issue',
+    timestamp: '2024-01-24T09:09:01+00:00',
     'issue.id': event['issue.id'],
     project: project.slug,
     'project.name': project.name,
@@ -206,12 +205,13 @@ describe('TraceTimeline & TraceRelated Issue', () => {
     render(<TraceTimeLineOrRelatedIssue event={event} />, {organization});
 
     // Instead of a timeline, we should see the other related issue
-    expect(await screen.findByText('Slow DB Query')).toBeInTheDocument();
+    expect(await screen.findByText('Slow DB Query')).toBeInTheDocument(); // The title
+    expect(await screen.findByText('/api/slow')).toBeInTheDocument(); // The subtitle/transaction
     expect(
       await screen.findByText('One other issue appears in the same trace.')
     ).toBeInTheDocument();
     expect(
-      await screen.findByText('SELECT "sentry_monitorcheckin"."monitor_id"')
+      await screen.findByText('SELECT "sentry_monitorcheckin"."monitor_id"') // The message
     ).toBeInTheDocument();
     expect(screen.queryByLabelText('Current Event')).not.toBeInTheDocument();
 

--- a/static/app/views/issueDetails/traceTimelineOrRelatedIssue.spec.tsx
+++ b/static/app/views/issueDetails/traceTimelineOrRelatedIssue.spec.tsx
@@ -21,10 +21,11 @@ describe('TraceTimeline & TraceRelated Issue', () => {
   const organization = OrganizationFixture({
     features: ['global-views'],
   });
+  const firstEventTimestamp = '2024-01-24T09:09:01+00:00';
   // This creates the ApiException event
   const event = EventFixture({
     // This is used to determine the presence of seconds
-    dateCreated: '2024-01-24T09:09:01+00:00',
+    dateCreated: firstEventTimestamp,
     contexts: {
       trace: {
         // This is used to determine if we should attempt
@@ -39,7 +40,7 @@ describe('TraceTimeline & TraceRelated Issue', () => {
   const issuePlatformBody: TraceEventResponse = {
     data: [
       {
-        // In issuePlatform, the message stores the title and the transaction
+        // In issuePlatform, the message contains the title and the transaction
         message: '/api/slow/ Slow DB Query SELECT "sentry_monitorcheckin"."monitor_id"',
         timestamp: '2024-01-24T09:09:03+00:00',
         'issue.id': 1000,
@@ -54,7 +55,7 @@ describe('TraceTimeline & TraceRelated Issue', () => {
   };
   const mainError = {
     message: 'This is the message for the issue',
-    timestamp: '2024-01-24T09:09:01+00:00',
+    timestamp: firstEventTimestamp,
     'issue.id': event['issue.id'],
     project: project.slug,
     'project.name': project.name,


### PR DESCRIPTION
My original code uses incorrect naming (subtitle <-> message).

This is a no-op change.

Issue Details ([code](https://github.com/getsentry/sentry/blob/fb4c0e3df5e80c06a0397fcaa4774477f43d1adc/static/app/components/eventOrGroupHeader.tsx#L126-L133), [code](https://github.com/getsentry/sentry/blob/fb4c0e3df5e80c06a0397fcaa4774477f43d1adc/static/app/components/eventOrGroupHeader.tsx#L61-L69) & [code](https://github.com/getsentry/sentry/blob/fb4c0e3df5e80c06a0397fcaa4774477f43d1adc/static/app/components/eventOrGroupTitle.tsx#L32)):
![image](https://github.com/getsentry/sentry/assets/44410/e9f8b7aa-71cb-48eb-8ef8-b47340bb0255)

Trace Issue Event:
![image](https://github.com/getsentry/sentry/assets/44410/3781f833-86a2-4839-8600-8235db4c79f4)
