### PR TITLE
nit(fe): update project name change warning

### DIFF
--- a/static/app/data/forms/projectGeneralSettings.tsx
+++ b/static/app/data/forms/projectGeneralSettings.tsx
@@ -66,7 +66,7 @@ export const fields: Record<string, Field> = {
     saveOnBlur: false,
     saveMessageAlertType: 'warning',
     saveMessage: t(
-      'Changing a project's name will also change the project slug. This can break your build scripts! Please proceed carefully.'
+      "Changing a project's name will also change the project slug. This can break your build scripts! Please proceed carefully."
     ),
   },
 

--- a/static/app/data/forms/projectGeneralSettings.tsx
+++ b/static/app/data/forms/projectGeneralSettings.tsx
@@ -64,8 +64,10 @@ export const fields: Record<string, Field> = {
     },
 
     saveOnBlur: false,
-    saveMessageAlertType: 'info',
-    saveMessage: t('You will be redirected to the new project slug after saving'),
+    saveMessageAlertType: 'warning',
+    saveMessage: t(
+      'Changing project name will change your project slug too and can break your build scripts. Are you sure you want to change name?'
+    ),
   },
 
   platform: {

--- a/static/app/data/forms/projectGeneralSettings.tsx
+++ b/static/app/data/forms/projectGeneralSettings.tsx
@@ -66,7 +66,7 @@ export const fields: Record<string, Field> = {
     saveOnBlur: false,
     saveMessageAlertType: 'warning',
     saveMessage: t(
-      'Changing project name will change your project slug too and can break your build scripts. Are you sure you want to change name?'
+      'Changing a project's name will also change the project slug. This can break your build scripts! Please proceed carefully.'
     ),
   },
 


### PR DESCRIPTION
closes https://github.com/getsentry/sentry/issues/67153

updated warning message when project name is changed

BEFORE:
![image](https://github.com/getsentry/sentry/assets/55610339/0b019052-284a-4692-8db1-95e5db8ada12)

AFTER:
![image](https://github.com/getsentry/sentry/assets/55610339/f5f5b5a3-fd11-48b7-b228-df93616cd0ec)
