### PR TITLE
feat(insights): add browser dropdown to web vitals landing page

### DIFF
--- a/static/app/views/insights/browser/webVitals/components/browserTypeSelector.tsx
+++ b/static/app/views/insights/browser/webVitals/components/browserTypeSelector.tsx
@@ -1,5 +1,9 @@
+import styled from '@emotion/styled';
+
 import {CompactSelect} from 'sentry/components/compactSelect';
+import ContextIcon from 'sentry/components/events/contexts/contextIcon';
 import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
 import {browserHistory} from 'sentry/utils/browserHistory';
 import {decodeScalar} from 'sentry/utils/queryString';
 import {useLocation} from 'sentry/utils/useLocation';
@@ -22,18 +26,33 @@ export enum BrowserType {
   OPERA_MOBILE = 'Opera Mobile',
 }
 
+const LabelContainer = styled('div')`
+  display: flex;
+  gap: ${space(1)};
+`;
+
+function optionToLabel(iconName: string, labelValue: string): React.ReactNode {
+  return (
+    <LabelContainer>
+      <ContextIcon name={iconName} size="md" />
+      <div>{labelValue}</div>
+    </LabelContainer>
+  );
+}
+
 const browserOptions = [
   {value: '', label: t('All')},
-  {value: BrowserType.CHROME, label: t('Chrome')},
-  {value: BrowserType.SAFARI, label: t('Safari')},
-  {value: BrowserType.FIREFOX, label: t('Firefox')},
-  {value: BrowserType.OPERA, label: t('Opera')},
-  {value: BrowserType.EDGE, label: t('Edge')},
-  {value: BrowserType.CHROME_MOBILE, label: t('Chrome Mobile')},
-  {value: BrowserType.FIREFOX_MOBILE, label: t('Firefox Mobile')},
-  {value: BrowserType.SAFARI_MOBILE, label: t('Safari Mobile')},
-  {value: BrowserType.EDGE_MOBILE, label: t('Edge Mobile')},
-  {value: BrowserType.OPERA_MOBILE, label: t('Opera Mobile')},
+  {value: BrowserType.CHROME, label: optionToLabel('chrome', 'Chrome')},
+  {value: BrowserType.SAFARI, label: optionToLabel('safari', 'Safari')},
+  {value: BrowserType.FIREFOX, label: optionToLabel('firefox', 'Firefox')},
+  {value: BrowserType.OPERA, label: optionToLabel('opera', 'Opera')},
+  {value: BrowserType.EDGE, label: optionToLabel('edge', 'Edge')},
+
+  {value: BrowserType.CHROME_MOBILE, label: optionToLabel('chrome', 'Chrome Mobile')},
+  {value: BrowserType.SAFARI_MOBILE, label: optionToLabel('safari', 'Safari Mobile')},
+  {value: BrowserType.FIREFOX_MOBILE, label: optionToLabel('firefox', 'Firefox Mobile')},
+  {value: BrowserType.OPERA_MOBILE, label: optionToLabel('opera', 'Opera Mobile')},
+  {value: BrowserType.EDGE_MOBILE, label: optionToLabel('edge', 'Edge Mobile')},
 ];
 
 export default function BrowserTypeSelector() {

--- a/static/app/views/insights/browser/webVitals/components/browserTypeSelector.tsx
+++ b/static/app/views/insights/browser/webVitals/components/browserTypeSelector.tsx
@@ -1,0 +1,60 @@
+import {CompactSelect} from 'sentry/components/compactSelect';
+import {t} from 'sentry/locale';
+import {browserHistory} from 'sentry/utils/browserHistory';
+import {decodeScalar} from 'sentry/utils/queryString';
+import {useLocation} from 'sentry/utils/useLocation';
+import {SpanIndexedField} from 'sentry/views/insights/types';
+
+// TODO: include both "Google Chrome" and "Chrome" when filtering by Chrome browser
+// Taken from: https://github.com/getsentry/relay/blob/ed2fc8c85b2732011e8262f4f598fa2c9857571d/relay-dynamic-config/src/defaults.rs#L146
+export enum BrowserType {
+  ALL = '',
+  CHROME = 'Chrome',
+  SAFARI = 'Safari',
+  FIREFOX = 'Firefox',
+  OPERA = 'Opera',
+  EDGE = 'Edge',
+  CHROME_MOBILE = 'Chrome Mobile',
+  FIREFOX_MOBILE = 'Firefox Mobile',
+  // Note that Safari uses "Mobile Safari" instead of "Safari Mobile"
+  SAFARI_MOBILE = 'Mobile Safari',
+  EDGE_MOBILE = 'Edge Mobile',
+  OPERA_MOBILE = 'Opera Mobile',
+}
+
+const browserOptions = [
+  {value: '', label: t('All')},
+  {value: BrowserType.CHROME, label: t('Chrome')},
+  {value: BrowserType.SAFARI, label: t('Safari')},
+  {value: BrowserType.FIREFOX, label: t('Firefox')},
+  {value: BrowserType.OPERA, label: t('Opera')},
+  {value: BrowserType.EDGE, label: t('Edge')},
+  {value: BrowserType.CHROME_MOBILE, label: t('Chrome Mobile')},
+  {value: BrowserType.FIREFOX_MOBILE, label: t('Firefox Mobile')},
+  {value: BrowserType.SAFARI_MOBILE, label: t('Safari Mobile')},
+  {value: BrowserType.EDGE_MOBILE, label: t('Edge Mobile')},
+  {value: BrowserType.OPERA_MOBILE, label: t('Opera Mobile')},
+];
+
+export default function BrowserTypeSelector() {
+  const location = useLocation();
+
+  const value = decodeScalar(location.query[SpanIndexedField.BROWSER_NAME]) ?? '';
+
+  return (
+    <CompactSelect
+      triggerProps={{prefix: t('Browser Type')}}
+      value={value}
+      options={browserOptions ?? []}
+      onChange={newValue => {
+        browserHistory.push({
+          ...location,
+          query: {
+            ...location.query,
+            [SpanIndexedField.BROWSER_NAME]: newValue.value,
+          },
+        });
+      }}
+    />
+  );
+}

--- a/static/app/views/insights/browser/webVitals/components/charts/performanceScoreBreakdownChart.tsx
+++ b/static/app/views/insights/browser/webVitals/components/charts/performanceScoreBreakdownChart.tsx
@@ -6,6 +6,7 @@ import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {Series} from 'sentry/types/echarts';
 import usePageFilters from 'sentry/utils/usePageFilters';
+import type {BrowserType} from 'sentry/views/insights/browser/webVitals/components/browserTypeSelector';
 import {ORDER} from 'sentry/views/insights/browser/webVitals/components/charts/performanceScoreChart';
 import {calculatePerformanceScoreFromStoredTableDataRow} from 'sentry/views/insights/browser/webVitals/queries/storedScoreQueries/calculatePerformanceScoreFromStored';
 import {useProjectWebVitalsScoresQuery} from 'sentry/views/insights/browser/webVitals/queries/storedScoreQueries/useProjectWebVitalsScoresQuery';
@@ -18,6 +19,7 @@ import {PERFORMANCE_SCORE_WEIGHTS} from 'sentry/views/insights/browser/webVitals
 import Chart, {ChartType} from 'sentry/views/insights/common/components/chart';
 
 type Props = {
+  browserType?: BrowserType;
   transaction?: string;
 };
 
@@ -43,16 +45,16 @@ export const formatTimeSeriesResultsToChartData = (
   });
 };
 
-export function PerformanceScoreBreakdownChart({transaction}: Props) {
+export function PerformanceScoreBreakdownChart({transaction, browserType}: Props) {
   const theme = useTheme();
   const segmentColors = [...theme.charts.getColorPalette(3).slice(0, 5)];
 
   const pageFilters = usePageFilters();
 
   const {data: timeseriesData, isLoading: isTimeseriesLoading} =
-    useProjectWebVitalsScoresTimeseriesQuery({transaction});
+    useProjectWebVitalsScoresTimeseriesQuery({transaction, browserType});
   const {data: projectScores, isLoading: isProjectScoresLoading} =
-    useProjectWebVitalsScoresQuery({transaction});
+    useProjectWebVitalsScoresQuery({transaction, browserType});
 
   const projectScore = isProjectScoresLoading
     ? undefined

--- a/static/app/views/insights/browser/webVitals/components/charts/performanceScoreChart.tsx
+++ b/static/app/views/insights/browser/webVitals/components/charts/performanceScoreChart.tsx
@@ -9,6 +9,7 @@ import {DEFAULT_RELATIVE_PERIODS} from 'sentry/constants';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import usePageFilters from 'sentry/utils/usePageFilters';
+import type {BrowserType} from 'sentry/views/insights/browser/webVitals/components/browserTypeSelector';
 import {PerformanceScoreBreakdownChart} from 'sentry/views/insights/browser/webVitals/components/charts/performanceScoreBreakdownChart';
 import PerformanceScoreRingWithTooltips from 'sentry/views/insights/browser/webVitals/components/performanceScoreRingWithTooltips';
 import {MODULE_DOC_LINK} from 'sentry/views/insights/browser/webVitals/settings';
@@ -18,6 +19,7 @@ import type {
 } from 'sentry/views/insights/browser/webVitals/types';
 
 type Props = {
+  browserType?: BrowserType;
   isProjectScoreLoading?: boolean;
   projectScore?: ProjectScore;
   transaction?: string;
@@ -31,6 +33,7 @@ export function PerformanceScoreChart({
   webVital,
   transaction,
   isProjectScoreLoading,
+  browserType,
 }: Props) {
   const theme = useTheme();
   const pageFilters = usePageFilters();
@@ -94,7 +97,10 @@ export function PerformanceScoreChart({
           </EmptyStateWarning>
         )}
       </PerformanceScoreLabelContainer>
-      <PerformanceScoreBreakdownChart transaction={transaction} />
+      <PerformanceScoreBreakdownChart
+        transaction={transaction}
+        browserType={browserType}
+      />
     </Flex>
   );
 }

--- a/static/app/views/insights/browser/webVitals/components/tables/pagePerformanceTable.tsx
+++ b/static/app/views/insights/browser/webVitals/components/tables/pagePerformanceTable.tsx
@@ -32,8 +32,9 @@ import {useTransactionWebVitalsScoresQuery} from 'sentry/views/insights/browser/
 import {MODULE_DOC_LINK} from 'sentry/views/insights/browser/webVitals/settings';
 import type {RowWithScoreAndOpportunity} from 'sentry/views/insights/browser/webVitals/types';
 import {SORTABLE_FIELDS} from 'sentry/views/insights/browser/webVitals/types';
+import decodeBrowserType from 'sentry/views/insights/browser/webVitals/utils/queryParameterDecoders/browserType';
 import {useWebVitalsSort} from 'sentry/views/insights/browser/webVitals/utils/useWebVitalsSort';
-import {ModuleName} from 'sentry/views/insights/types';
+import {ModuleName, SpanIndexedField} from 'sentry/views/insights/types';
 
 type Column = GridColumnHeader<keyof RowWithScoreAndOpportunity>;
 
@@ -68,6 +69,7 @@ export function PagePerformanceTable() {
   const columnOrder = COLUMN_ORDER;
 
   const query = decodeScalar(location.query.query, '');
+  const browserType = decodeBrowserType(location.query[SpanIndexedField.BROWSER_NAME]);
 
   const project = useMemo(
     () => projects.find(p => p.id === String(location.query.project)),
@@ -76,7 +78,7 @@ export function PagePerformanceTable() {
 
   const sort = useWebVitalsSort({defaultSort: DEFAULT_SORT});
   const {data: projectScoresData, isLoading: isProjectScoresLoading} =
-    useProjectWebVitalsScoresQuery();
+    useProjectWebVitalsScoresQuery({browserType});
 
   const {
     data,
@@ -87,6 +89,7 @@ export function PagePerformanceTable() {
     transaction: query !== '' ? `*${escapeFilterValue(query)}*` : undefined,
     defaultSort: DEFAULT_SORT,
     shouldEscapeFilters: false,
+    browserType,
   });
 
   const scoreCount = projectScoresData?.data?.[0]?.[

--- a/static/app/views/insights/browser/webVitals/components/webVitalsDetailPanel.tsx
+++ b/static/app/views/insights/browser/webVitals/components/webVitalsDetailPanel.tsx
@@ -32,7 +32,9 @@ import type {
   RowWithScoreAndOpportunity,
   WebVitals,
 } from 'sentry/views/insights/browser/webVitals/types';
+import decodeBrowserType from 'sentry/views/insights/browser/webVitals/utils/queryParameterDecoders/browserType';
 import DetailPanel from 'sentry/views/insights/common/components/detailPanel';
+import {SpanIndexedField} from 'sentry/views/insights/types';
 
 type Column = GridColumnHeader;
 
@@ -57,10 +59,12 @@ export function WebVitalsDetailPanel({
 }) {
   const location = useLocation();
   const organization = useOrganization();
+  const browserType = decodeBrowserType(location.query[SpanIndexedField.BROWSER_NAME]);
 
-  const {data: projectData} = useProjectRawWebVitalsQuery({});
+  const {data: projectData} = useProjectRawWebVitalsQuery({browserType});
   const {data: projectScoresData} = useProjectWebVitalsScoresQuery({
     weightWebVital: webVital ?? 'total',
+    browserType,
   });
 
   const projectScore = calculatePerformanceScoreFromStoredTableDataRow(
@@ -80,6 +84,7 @@ export function WebVitalsDetailPanel({
       : {}),
     enabled: webVital !== null,
     sortName: 'webVitalsDetailPanelSort',
+    browserType,
   });
 
   const dataByOpportunity = useMemo(() => {
@@ -111,7 +116,7 @@ export function WebVitalsDetailPanel({
   }, [data, projectScoresData?.data, webVital]);
 
   const {data: timeseriesData, isLoading: isTimeseriesLoading} =
-    useProjectRawWebVitalsValuesTimeseriesQuery({});
+    useProjectRawWebVitalsValuesTimeseriesQuery({browserType});
 
   const webVitalData: LineChartSeries = {
     data:

--- a/static/app/views/insights/browser/webVitals/queries/rawWebVitalsQueries/useProjectRawWebVitalsQuery.tsx
+++ b/static/app/views/insights/browser/webVitals/queries/rawWebVitalsQueries/useProjectRawWebVitalsQuery.tsx
@@ -6,15 +6,23 @@ import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
+import {BrowserType} from 'sentry/views/insights/browser/webVitals/components/browserTypeSelector';
 import {DEFAULT_QUERY_FILTER} from 'sentry/views/insights/browser/webVitals/settings';
+import {SpanIndexedField} from 'sentry/views/insights/types';
 
 type Props = {
+  browserType?: BrowserType;
   dataset?: DiscoverDatasets;
   tag?: Tag;
   transaction?: string;
 };
 
-export const useProjectRawWebVitalsQuery = ({transaction, tag, dataset}: Props = {}) => {
+export const useProjectRawWebVitalsQuery = ({
+  transaction,
+  tag,
+  dataset,
+  browserType,
+}: Props = {}) => {
   const organization = useOrganization();
   const pageFilters = usePageFilters();
   const location = useLocation();
@@ -24,6 +32,9 @@ export const useProjectRawWebVitalsQuery = ({transaction, tag, dataset}: Props =
   }
   if (tag) {
     search.addFilterValue(tag.key, tag.name);
+  }
+  if (browserType !== undefined && browserType !== BrowserType.ALL) {
+    search.addFilterValue(SpanIndexedField.BROWSER_NAME, browserType);
   }
 
   const projectEventView = EventView.fromNewQueryWithPageFilters(

--- a/static/app/views/insights/browser/webVitals/queries/rawWebVitalsQueries/useProjectRawWebVitalsValuesTimeseriesQuery.tsx
+++ b/static/app/views/insights/browser/webVitals/queries/rawWebVitalsQueries/useProjectRawWebVitalsValuesTimeseriesQuery.tsx
@@ -10,9 +10,12 @@ import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
+import {BrowserType} from 'sentry/views/insights/browser/webVitals/components/browserTypeSelector';
 import {DEFAULT_QUERY_FILTER} from 'sentry/views/insights/browser/webVitals/settings';
+import {SpanIndexedField} from 'sentry/views/insights/types';
 
 type Props = {
+  browserType?: BrowserType;
   datetime?: PageFilters['datetime'];
   transaction?: string | null;
 };
@@ -20,6 +23,7 @@ type Props = {
 export const useProjectRawWebVitalsValuesTimeseriesQuery = ({
   transaction,
   datetime,
+  browserType,
 }: Props) => {
   const pageFilters = usePageFilters();
   const location = useLocation();
@@ -27,6 +31,9 @@ export const useProjectRawWebVitalsValuesTimeseriesQuery = ({
   const search = new MutableSearch([]);
   if (transaction) {
     search.addFilterValue('transaction', transaction);
+  }
+  if (browserType !== undefined && browserType !== BrowserType.ALL) {
+    search.addFilterValue(SpanIndexedField.BROWSER_NAME, browserType);
   }
   const projectTimeSeriesEventView = EventView.fromNewQueryWithPageFilters(
     {

--- a/static/app/views/insights/browser/webVitals/queries/storedScoreQueries/useProjectWebVitalsScoresQuery.tsx
+++ b/static/app/views/insights/browser/webVitals/queries/storedScoreQueries/useProjectWebVitalsScoresQuery.tsx
@@ -6,10 +6,13 @@ import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
+import {BrowserType} from 'sentry/views/insights/browser/webVitals/components/browserTypeSelector';
 import {DEFAULT_QUERY_FILTER} from 'sentry/views/insights/browser/webVitals/settings';
 import type {WebVitals} from 'sentry/views/insights/browser/webVitals/types';
+import {SpanIndexedField} from 'sentry/views/insights/types';
 
 type Props = {
+  browserType?: BrowserType;
   dataset?: DiscoverDatasets;
   enabled?: boolean;
   tag?: Tag;
@@ -23,6 +26,7 @@ export const useProjectWebVitalsScoresQuery = ({
   dataset,
   enabled = true,
   weightWebVital = 'total',
+  browserType,
 }: Props = {}) => {
   const organization = useOrganization();
   const pageFilters = usePageFilters();
@@ -35,6 +39,10 @@ export const useProjectWebVitalsScoresQuery = ({
   if (tag) {
     search.addFilterValue(tag.key, tag.name);
   }
+  if (browserType !== undefined && browserType !== BrowserType.ALL) {
+    search.addFilterValue(SpanIndexedField.BROWSER_NAME, browserType);
+  }
+
   const projectEventView = EventView.fromNewQueryWithPageFilters(
     {
       fields: [

--- a/static/app/views/insights/browser/webVitals/queries/storedScoreQueries/useProjectWebVitalsScoresTimeseriesQuery.tsx
+++ b/static/app/views/insights/browser/webVitals/queries/storedScoreQueries/useProjectWebVitalsScoresTimeseriesQuery.tsx
@@ -10,9 +10,12 @@ import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
+import {BrowserType} from 'sentry/views/insights/browser/webVitals/components/browserTypeSelector';
 import {DEFAULT_QUERY_FILTER} from 'sentry/views/insights/browser/webVitals/settings';
+import {SpanIndexedField} from 'sentry/views/insights/types';
 
 type Props = {
+  browserType?: BrowserType;
   enabled?: boolean;
   tag?: Tag;
   transaction?: string | null;
@@ -40,6 +43,7 @@ export const useProjectWebVitalsScoresTimeseriesQuery = ({
   transaction,
   tag,
   enabled = true,
+  browserType,
 }: Props) => {
   const pageFilters = usePageFilters();
   const location = useLocation();
@@ -50,6 +54,9 @@ export const useProjectWebVitalsScoresTimeseriesQuery = ({
   ]);
   if (transaction) {
     search.addFilterValue('transaction', transaction);
+  }
+  if (browserType !== undefined && browserType !== BrowserType.ALL) {
+    search.addFilterValue(SpanIndexedField.BROWSER_NAME, browserType);
   }
   const projectTimeSeriesEventView = EventView.fromNewQueryWithPageFilters(
     {

--- a/static/app/views/insights/browser/webVitals/queries/storedScoreQueries/useTransactionWebVitalsScoresQuery.tsx
+++ b/static/app/views/insights/browser/webVitals/queries/storedScoreQueries/useTransactionWebVitalsScoresQuery.tsx
@@ -6,6 +6,7 @@ import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
+import {BrowserType} from 'sentry/views/insights/browser/webVitals/components/browserTypeSelector';
 import {calculatePerformanceScoreFromStoredTableDataRow} from 'sentry/views/insights/browser/webVitals/queries/storedScoreQueries/calculatePerformanceScoreFromStored';
 import {DEFAULT_QUERY_FILTER} from 'sentry/views/insights/browser/webVitals/settings';
 import type {
@@ -13,8 +14,10 @@ import type {
   WebVitals,
 } from 'sentry/views/insights/browser/webVitals/types';
 import {useWebVitalsSort} from 'sentry/views/insights/browser/webVitals/utils/useWebVitalsSort';
+import {SpanIndexedField} from 'sentry/views/insights/types';
 
 type Props = {
+  browserType?: BrowserType;
   defaultSort?: Sort;
   enabled?: boolean;
   limit?: number;
@@ -34,6 +37,7 @@ export const useTransactionWebVitalsScoresQuery = ({
   webVital = 'total',
   query,
   shouldEscapeFilters = true,
+  browserType,
 }: Props) => {
   const organization = useOrganization();
   const pageFilters = usePageFilters();
@@ -47,6 +51,9 @@ export const useTransactionWebVitalsScoresQuery = ({
   ]);
   if (transaction) {
     search.addFilterValue('transaction', transaction, shouldEscapeFilters);
+  }
+  if (browserType !== undefined && browserType !== BrowserType.ALL) {
+    search.addFilterValue(SpanIndexedField.BROWSER_NAME, browserType);
   }
   const eventView = EventView.fromNewQueryWithPageFilters(
     {

--- a/static/app/views/insights/browser/webVitals/utils/queryParameterDecoders/browserType.tsx
+++ b/static/app/views/insights/browser/webVitals/utils/queryParameterDecoders/browserType.tsx
@@ -1,0 +1,19 @@
+import {decodeScalar} from 'sentry/utils/queryString';
+import {BrowserType} from 'sentry/views/insights/browser/webVitals/components/browserTypeSelector';
+
+const DEFAULT = BrowserType.ALL;
+
+export default function decode(value: string | string[] | undefined | null): BrowserType {
+  const decodedValue = decodeScalar(value, DEFAULT);
+
+  if (isAValidOption(decodedValue)) {
+    return decodedValue;
+  }
+
+  return DEFAULT;
+}
+
+function isAValidOption(maybeOption: string): maybeOption is BrowserType {
+  // Manually widen to allow the comparison to string
+  return Object.values(BrowserType).includes(maybeOption as BrowserType);
+}

--- a/static/app/views/insights/browser/webVitals/views/webVitalsLandingPage.tsx
+++ b/static/app/views/insights/browser/webVitals/views/webVitalsLandingPage.tsx
@@ -15,7 +15,6 @@ import PageFilterBar from 'sentry/components/organizations/pageFilterBar';
 import {ProjectPageFilter} from 'sentry/components/organizations/projectPageFilter';
 import {PageHeadingQuestionTooltip} from 'sentry/components/pageHeadingQuestionTooltip';
 import {Tooltip} from 'sentry/components/tooltip';
-import {IconGoogle} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {useLocation} from 'sentry/utils/useLocation';
@@ -99,7 +98,6 @@ export function WebVitalsLandingPage() {
               <DatePageFilter />
             </PageFilterBar>
             <BrowserTypeSelector />
-            <IconGoogle />
           </TopMenuContainer>
 
           {onboardingProject && (

--- a/static/app/views/insights/browser/webVitals/views/webVitalsLandingPage.tsx
+++ b/static/app/views/insights/browser/webVitals/views/webVitalsLandingPage.tsx
@@ -20,7 +20,6 @@ import {space} from 'sentry/styles/space';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import useRouter from 'sentry/utils/useRouter';
-import BrowserTypeSelector from 'sentry/views/insights/browser/webVitals/components/browserTypeSelector';
 import {PerformanceScoreChart} from 'sentry/views/insights/browser/webVitals/components/charts/performanceScoreChart';
 import {PagePerformanceTable} from 'sentry/views/insights/browser/webVitals/components/tables/pagePerformanceTable';
 import WebVitalMeters from 'sentry/views/insights/browser/webVitals/components/webVitalMeters';
@@ -97,7 +96,8 @@ export function WebVitalsLandingPage() {
               <EnvironmentPageFilter />
               <DatePageFilter />
             </PageFilterBar>
-            <BrowserTypeSelector />
+            {/* TODO: add browser selector once changes are made to both webVitalsLandingPage and webVitalsDetail */}
+            {/* <BrowserTypeSelector /> */}
           </TopMenuContainer>
 
           {onboardingProject && (

--- a/static/app/views/insights/browser/webVitals/views/webVitalsLandingPage.tsx
+++ b/static/app/views/insights/browser/webVitals/views/webVitalsLandingPage.tsx
@@ -15,11 +15,13 @@ import PageFilterBar from 'sentry/components/organizations/pageFilterBar';
 import {ProjectPageFilter} from 'sentry/components/organizations/projectPageFilter';
 import {PageHeadingQuestionTooltip} from 'sentry/components/pageHeadingQuestionTooltip';
 import {Tooltip} from 'sentry/components/tooltip';
+import {IconGoogle} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import useRouter from 'sentry/utils/useRouter';
+import BrowserTypeSelector from 'sentry/views/insights/browser/webVitals/components/browserTypeSelector';
 import {PerformanceScoreChart} from 'sentry/views/insights/browser/webVitals/components/charts/performanceScoreChart';
 import {PagePerformanceTable} from 'sentry/views/insights/browser/webVitals/components/tables/pagePerformanceTable';
 import WebVitalMeters from 'sentry/views/insights/browser/webVitals/components/webVitalMeters';
@@ -33,11 +35,12 @@ import {
   MODULE_TITLE,
 } from 'sentry/views/insights/browser/webVitals/settings';
 import type {WebVitals} from 'sentry/views/insights/browser/webVitals/types';
+import decodeBrowserType from 'sentry/views/insights/browser/webVitals/utils/queryParameterDecoders/browserType';
 import {ModulePageProviders} from 'sentry/views/insights/common/components/modulePageProviders';
 import {useOnboardingProject} from 'sentry/views/insights/common/queries/useOnboardingProject';
 import {useHasDataTrackAnalytics} from 'sentry/views/insights/common/utils/useHasDataTrackAnalytics';
 import {useModuleBreadcrumbs} from 'sentry/views/insights/common/utils/useModuleBreadcrumbs';
-import {ModuleName} from 'sentry/views/insights/types';
+import {ModuleName, SpanIndexedField} from 'sentry/views/insights/types';
 import Onboarding from 'sentry/views/performance/onboarding';
 
 export function WebVitalsLandingPage() {
@@ -51,9 +54,11 @@ export function WebVitalsLandingPage() {
     webVital: (location.query.webVital as WebVitals) ?? null,
   });
 
-  const {data: projectData, isLoading} = useProjectRawWebVitalsQuery({});
+  const browserType = decodeBrowserType(location.query[SpanIndexedField.BROWSER_NAME]);
+
+  const {data: projectData, isLoading} = useProjectRawWebVitalsQuery({browserType});
   const {data: projectScores, isLoading: isProjectScoresLoading} =
-    useProjectWebVitalsScoresQuery();
+    useProjectWebVitalsScoresQuery({browserType});
 
   const projectScore =
     isProjectScoresLoading || isLoading
@@ -93,6 +98,8 @@ export function WebVitalsLandingPage() {
               <EnvironmentPageFilter />
               <DatePageFilter />
             </PageFilterBar>
+            <BrowserTypeSelector />
+            <IconGoogle />
           </TopMenuContainer>
 
           {onboardingProject && (
@@ -107,6 +114,7 @@ export function WebVitalsLandingPage() {
                   projectScore={projectScore}
                   isProjectScoreLoading={isLoading || isProjectScoresLoading}
                   webVital={state.webVital}
+                  browserType={browserType}
                 />
               </PerformanceScoreChartContainer>
               <WebVitalMetersContainer>
@@ -174,6 +182,7 @@ export default PageWithProviders;
 
 const TopMenuContainer = styled('div')`
   display: flex;
+  gap: ${space(2)};
 `;
 
 const PerformanceScoreChartContainer = styled('div')`


### PR DESCRIPTION
Adds a browser filter dropdown to the web vitals landing page.

<img width="1271" alt="image" src="https://github.com/getsentry/sentry/assets/58920989/8b3b7ce9-e1ff-4fa0-8406-6c04436e0f86">


**Note**: this PR adds all necessary logic/components, but **does not actually add the browser dropdown to the UI**. That will be done after we've made the necessary changes to `webVitalsDetailPanel`.

The next PR will update `pageOverview.tsx` and clean up the dropdown.