### PR TITLE
fix(similarity): cache project on event

### DIFF
--- a/src/sentry/tasks/embeddings_grouping/utils.py
+++ b/src/sentry/tasks/embeddings_grouping/utils.py
@@ -270,6 +270,7 @@ def get_events_from_nodestore(
     invalid_event_group_ids = []
     bulk_event_ids = set()
     for group_id, event in nodestore_events.items():
+        event._project_cache = project
         if event and event.data and event.data.get("exception"):
             grouping_info = get_grouping_info(None, project=project, event=event)
             stacktrace_string = get_stacktrace_string(grouping_info)


### PR DESCRIPTION
looking at simliarty backfill traces:
https://sentry.sentry.io/performance/trace/d7f08f5127ec4dab964ab59e15249d34/?colorCoding=by+system+vs+application+frame&fov=1180890880%2C45%2C1950379136%2C20&node=txn-03de2d8864774e9e95df51c370bde99e&query=&sorting=call+order&statsPeriod=14d&tid=136232533691264&timestamp=1719516107.713996&view=top+down

we notice that within the grouping config call, we make a database call to the same project many times.

the profile tracks this down to the Event._project_cache call.

https://sentry.sentry.io/profiling/profile/sentry/e8283c535ef34964a025755378b4dd86/flamegraph/?colorCoding=by+system+vs+application+frame&fov=1180890880%2C45%2C1950379136%2C20&query=&sorting=call+order&tid=136232533691264&view=top+down

we set the project cache prior to calling grouping config.


As a sidenote, i'm really curious if the _project_cache on the event could take advantage of `Project.objects.get_from_cache`. will try following up with that change at a later point.
