### PR TITLE
ref(various): Small fixes

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1310,8 +1310,8 @@ BGTASKS = {
     },
 }
 
-# Sentry logs to two major places: stdout, and it's internal project.
-# To disable logging to the internal project, add a logger who's only
+# Sentry logs to two major places: stdout, and its internal project.
+# To disable logging to the internal project, add a logger whose only
 # handler is 'console' and disable propagating upwards.
 # Additionally, Sentry has the ability to override logger levels by
 # providing the cli with -l/--loglevel or the SENTRY_LOG_LEVEL env var.

--- a/src/sentry/grouping/strategies/newstyle.py
+++ b/src/sentry/grouping/strategies/newstyle.py
@@ -700,6 +700,7 @@ def chained_exception(
         )
     except Exception:
         # We shouldn't have exceptions here. But if we do, just record it and continue with the original list.
+        # TODO: Except we do, as it turns out. See https://github.com/getsentry/sentry/issues/73592.
         logging.exception(
             "Failed to filter exceptions for exception groups. Continuing with original list."
         )

--- a/src/sentry/grouping/variants.py
+++ b/src/sentry/grouping/variants.py
@@ -96,7 +96,7 @@ class PerformanceProblemVariant(BaseVariant):
 
 class ComponentVariant(BaseVariant):
     """A component variant is a variant that produces a hash from the
-    `GroupComponent` it encloses.
+    `GroupingComponent` it encloses.
     """
 
     type = "component"

--- a/src/sentry/seer/similarity/similar_issues.py
+++ b/src/sentry/seer/similarity/similar_issues.py
@@ -37,6 +37,8 @@ def get_similarity_data_from_seer(
     Request similar issues data from seer and normalize the results. Returns similar groups
     sorted in order of descending similarity.
     """
+    project_id = similar_issues_request["project_id"]
+    request_hash = similar_issues_request["hash"]
     referrer = similar_issues_request.get("referrer")
     metric_tags: dict[str, str | int] = {"referrer": referrer} if referrer else {}
 
@@ -54,15 +56,15 @@ def get_similarity_data_from_seer(
     # TODO: This is temporary, to debug Seer being called on existing hashes during ingest
     if similar_issues_request.get("referrer") == "ingest":
         existing_grouphash = GroupHash.objects.filter(
-            hash=similar_issues_request["hash"], project_id=similar_issues_request["project_id"]
+            hash=request_hash, project_id=project_id
         ).first()
         if existing_grouphash and existing_grouphash.group_id:
             logger.warning(
                 "get_seer_similar_issues.hash_exists",
                 extra={
                     "event_id": similar_issues_request["event_id"],
-                    "project_id": similar_issues_request["project_id"],
-                    "hash": similar_issues_request["hash"],
+                    "project_id": project_id,
+                    "hash": request_hash,
                     "grouphash_id": existing_grouphash.id,
                     "group_id": existing_grouphash.group_id,
                     "referrer": similar_issues_request.get("referrer"),
@@ -77,8 +79,8 @@ def get_similarity_data_from_seer(
             "get_seer_similar_issues.empty_stacktrace",
             extra={
                 "event_id": similar_issues_request["event_id"],
-                "project_id": similar_issues_request["project_id"],
-                "hash": similar_issues_request["hash"],
+                "project_id": project_id,
+                "hash": request_hash,
                 "referrer": similar_issues_request.get("referrer"),
             },
         )
@@ -174,9 +176,7 @@ def get_similarity_data_from_seer(
 
     for raw_similar_issue_data in response_data:
         try:
-            normalized = SeerSimilarIssueData.from_raw(
-                similar_issues_request["project_id"], raw_similar_issue_data
-            )
+            normalized = SeerSimilarIssueData.from_raw(project_id, raw_similar_issue_data)
 
             if (
                 normalized.should_group
@@ -211,13 +211,15 @@ def get_similarity_data_from_seer(
             # in a race condition, where Seer recommends a hash it doesn't know it's about to be
             # asked to delete, and we come up empty because on the Sentry side the hash has already
             # been deleted.
+            parent_hash = raw_similar_issue_data.get("parent_hash")
+
             metric_tags.update({"outcome": "error", "error": "SimilarGroupNotFoundError"})
             logger.warning(
                 "get_similarity_data_from_seer.parent_group_not_found",
                 extra={
-                    "hash": similar_issues_request["hash"],
-                    "parent_hash": raw_similar_issue_data.get("parent_hash"),
-                    "project_id": similar_issues_request["project_id"],
+                    "hash": request_hash,
+                    "parent_hash": parent_hash,
+                    "project_id": project_id,
                 },
             )
 

--- a/src/sentry/seer/similarity/similar_issues.py
+++ b/src/sentry/seer/similarity/similar_issues.py
@@ -40,12 +40,12 @@ def get_similarity_data_from_seer(
     referrer = similar_issues_request.get("referrer")
     metric_tags: dict[str, str | int] = {"referrer": referrer} if referrer else {}
 
-    # We have to rename the key `message` because it conflicts with the `LogRecord` attribute of the
-    # same name
     logger_extra = apply_key_filter(
         similar_issues_request,
         keep_keys=["event_id", "project_id", "message", "hash", "referrer"],
     )
+    # We have to rename the key `message` because it conflicts with the `LogRecord` attribute of the
+    # same name
     logger_extra["message_value"] = logger_extra.pop("message", None)
     logger.info(
         "get_seer_similar_issues.request",

--- a/src/sentry/seer/similarity/similar_issues.py
+++ b/src/sentry/seer/similarity/similar_issues.py
@@ -141,7 +141,7 @@ def get_similarity_data_from_seer(
     except (
         AttributeError,  # caused by a response with no data and therefore no `.decode` method
         UnicodeError,
-        JSONDecodeError,
+        JSONDecodeError,  # caused by Seer erroring out and sending back the error page HTML
     ) as e:
         logger.exception(
             "Failed to parse seer similar issues response",

--- a/src/sentry/seer/similarity/similar_issues.py
+++ b/src/sentry/seer/similarity/similar_issues.py
@@ -204,6 +204,13 @@ def get_similarity_data_from_seer(
             # that we can't find, but again, we're okay with that because a group being missing
             # implies there's something wrong with our deletion logic, which is a problem to which
             # we want to pay attention.
+            #
+            # TODO: The deletion logic (tell Seer to delete hashes as soon as they're deleted on the
+            # Sentry side) comes with an inherent slight delay - the request to Seer happens async, and
+            # requests between services aren't instantaneous. It's therefore possible for us to land
+            # in a race condition, where Seer recommends a hash it doesn't know it's about to be
+            # asked to delete, and we come up empty because on the Sentry side the hash has already
+            # been deleted.
             metric_tags.update({"outcome": "error", "error": "SimilarGroupNotFoundError"})
             logger.warning(
                 "get_similarity_data_from_seer.parent_group_not_found",

--- a/src/sentry/seer/similarity/utils.py
+++ b/src/sentry/seer/similarity/utils.py
@@ -39,6 +39,8 @@ def get_stacktrace_string(data: dict[str, Any]) -> str:
     found_non_snipped_context_line = False
     result_parts = []
 
+    # Reverse the list of exceptions in order to prioritize the outermost/most recent ones in cases
+    # where there are chained exceptions and we end up truncating
     for exception in reversed(exceptions):
         if exception.get("id") not in ["exception", "threads"] or not exception.get("contributes"):
             continue

--- a/tests/sentry/seer/similarity/test_similar_issues.py
+++ b/tests/sentry/seer/similarity/test_similar_issues.py
@@ -31,7 +31,7 @@ class GetSimilarityDataFromSeerTest(TestCase):
             "hash": "11212012123120120415201309082013",
             "project_id": self.project.id,
             "stacktrace": "<stringified stacktrace>",
-            "message": "Charlie didn't bring the ball back",
+            "message": "FailedToFetchError('Charlie didn't bring the ball back')",
             "exception_type": "FailedToFetchError",
         }
 
@@ -184,7 +184,7 @@ class GetSimilarityDataFromSeerTest(TestCase):
                     "event_id": "12312012041520130908201311212012",
                     "hash": "11212012123120120415201309082013",
                     "project_id": self.project.id,
-                    "message_value": "Charlie didn't bring the ball back",
+                    "message_value": "FailedToFetchError('Charlie didn't bring the ball back')",
                 },
             )
             mock_metrics_incr.assert_any_call(


### PR DESCRIPTION
This is another collection of small fixes which I either kept out of other PRs (for ease of reviewing) or just came across in my travels. No behavior changes here - just some typo fixes and docstring/comment additions and tweaks, along with a tiny refactoring of `get_similarity_data_from_seer` to pull a few values out into their own variables.