### PR TITLE
feat(breadcrumbs): Allow formatting for SQL queries, HTTP requests and errors/warnings

### DIFF
--- a/static/app/components/events/breadcrumbs/breadcrumbsDataSection.spec.tsx
+++ b/static/app/components/events/breadcrumbs/breadcrumbsDataSection.spec.tsx
@@ -10,6 +10,19 @@ import {
 } from 'sentry/components/events/breadcrumbs/testUtils';
 import {EntryType} from 'sentry/types';
 
+// Needed to mock useVirtualizer lists.
+jest.spyOn(window.Element.prototype, 'getBoundingClientRect').mockImplementation(() => ({
+  x: 0,
+  y: 0,
+  width: 0,
+  height: 30,
+  left: 0,
+  top: 0,
+  right: 0,
+  bottom: 0,
+  toJSON: jest.fn(),
+}));
+
 describe('BreadcrumbsDataSection', function () {
   it('renders a summary of breadcrumbs with a button to view them all', async function () {
     render(<BreadcrumbsDataSection {...MOCK_DATA_SECTION_PROPS} />);

--- a/static/app/components/events/breadcrumbs/breadcrumbsDataSection.tsx
+++ b/static/app/components/events/breadcrumbs/breadcrumbsDataSection.tsx
@@ -15,7 +15,10 @@ import {
   getSummaryBreadcrumbs,
 } from 'sentry/components/events/breadcrumbs/utils';
 import {EventDataSection} from 'sentry/components/events/eventDataSection';
-import {getVirtualCrumb} from 'sentry/components/events/interfaces/breadcrumbs/utils';
+import {
+  convertCrumbType,
+  getVirtualCrumb,
+} from 'sentry/components/events/interfaces/breadcrumbs/utils';
 import useDrawer from 'sentry/components/globalDrawer';
 import {IconClock, IconEllipsis, IconFilter, IconSearch, IconSort} from 'sentry/icons';
 import {t} from 'sentry/locale';
@@ -51,11 +54,15 @@ export default function BreadcrumbsDataSection({
       // Mapping of breadcrumb index -> breadcrumb meta
       const _meta: Record<number, any> =
         event._meta?.entries?.[breadcrumbEntryIndex]?.data?.values;
+      // Converts breadcrumbs into other types if sufficient data is present.
+      const convertedCrumbs = breadcrumbs.map(convertCrumbType);
 
       // The virtual crumb is a representation of this event, displayed alongside
       // the rest of the breadcrumbs for more additional context.
       const _virtualCrumb = getVirtualCrumb(event);
-      const _allCrumbs = _virtualCrumb ? [...breadcrumbs, _virtualCrumb] : breadcrumbs;
+      const _allCrumbs = _virtualCrumb
+        ? [...convertedCrumbs, _virtualCrumb]
+        : convertedCrumbs;
       return {
         allCrumbs: _allCrumbs,
         isEmpty: breadcrumbEntryIndex === -1 || breadcrumbs.length === 0,

--- a/static/app/components/events/breadcrumbs/breadcrumbsDataSection.tsx
+++ b/static/app/components/events/breadcrumbs/breadcrumbsDataSection.tsx
@@ -115,6 +115,8 @@ export default function BreadcrumbsDataSection({
     </ButtonBar>
   );
 
+  const hasViewAll = summaryCrumbs.length !== enhancedCrumbs.length;
+
   return (
     <EventDataSection
       key="breadcrumbs"
@@ -127,8 +129,10 @@ export default function BreadcrumbsDataSection({
         <BreadcrumbsTimeline
           breadcrumbs={summaryCrumbs}
           startTimeString={startTimeString}
+          // We want the timeline to appear connected to the 'View All' button
+          showLastLine={hasViewAll}
         />
-        {summaryCrumbs.length !== enhancedCrumbs.length && (
+        {hasViewAll && (
           <ViewAllContainer>
             <VerticalEllipsis />
             <div>

--- a/static/app/components/events/breadcrumbs/breadcrumbsDrawerContent.spec.tsx
+++ b/static/app/components/events/breadcrumbs/breadcrumbsDrawerContent.spec.tsx
@@ -7,6 +7,20 @@ import {
 } from 'sentry/components/events/breadcrumbs/testUtils';
 
 async function renderBreadcrumbDrawer() {
+  // Needed to mock useVirtualizer lists.
+  jest
+    .spyOn(window.Element.prototype, 'getBoundingClientRect')
+    .mockImplementation(() => ({
+      x: 0,
+      y: 0,
+      width: 0,
+      height: 30,
+      left: 0,
+      top: 0,
+      right: 0,
+      bottom: 0,
+      toJSON: jest.fn(),
+    }));
   render(<BreadcrumbsDataSection {...MOCK_DATA_SECTION_PROPS} />);
   await userEvent.click(screen.getByRole('button', {name: 'View All Breadcrumbs'}));
   return within(screen.getByRole('complementary', {name: 'breadcrumb drawer'}));

--- a/static/app/components/events/breadcrumbs/breadcrumbsDrawerContent.spec.tsx
+++ b/static/app/components/events/breadcrumbs/breadcrumbsDrawerContent.spec.tsx
@@ -39,9 +39,10 @@ describe('BreadcrumbsDrawerContent', function () {
     ).toBeInTheDocument();
 
     // Contents
-    for (const {message, category} of MOCK_BREADCRUMBS) {
-      expect(drawerScreen.getByText(message)).toBeInTheDocument();
+    for (const {category, level, message} of MOCK_BREADCRUMBS) {
       expect(drawerScreen.getByText(category)).toBeInTheDocument();
+      expect(drawerScreen.getByText(level)).toBeInTheDocument();
+      expect(drawerScreen.getByText(message)).toBeInTheDocument();
     }
     expect(drawerScreen.getAllByText('-1min')).toHaveLength(MOCK_BREADCRUMBS.length);
   });

--- a/static/app/components/events/breadcrumbs/breadcrumbsDrawerContent.tsx
+++ b/static/app/components/events/breadcrumbs/breadcrumbsDrawerContent.tsx
@@ -29,7 +29,9 @@ import {space} from 'sentry/styles/space';
 import type {Event} from 'sentry/types/event';
 import type {Group} from 'sentry/types/group';
 import type {Project} from 'sentry/types/project';
+import {trackAnalytics} from 'sentry/utils/analytics';
 import {useLocalStorageState} from 'sentry/utils/useLocalStorageState';
+import useOrganization from 'sentry/utils/useOrganization';
 
 export const enum BreadcrumbControlOptions {
   SEARCH = 'search',
@@ -52,6 +54,7 @@ export function BreadcrumbsDrawerContent({
   breadcrumbs,
   focusControl,
 }: BreadcrumbsDrawerContentProps) {
+  const organization = useOrganization();
   const theme = useTheme();
   const [search, setSearch] = useState('');
   const [filterSet, setFilterSet] = useState(new Set<string>());
@@ -92,7 +95,13 @@ export function BreadcrumbsDrawerContent({
         <SearchInput
           size="xs"
           value={search}
-          onChange={e => setSearch(e.target.value)}
+          onChange={e => {
+            setSearch(e.target.value);
+            trackAnalytics('breadcrumbs.drawer.action', {
+              control: BreadcrumbControlOptions.SEARCH,
+              organization,
+            });
+          }}
           autoFocus={focusControl === BreadcrumbControlOptions.SEARCH}
           aria-label={t('Search All Breadcrumbs')}
         />
@@ -105,6 +114,10 @@ export function BreadcrumbsDrawerContent({
         onChange={options => {
           const newFilters = options.map(({value}) => value);
           setFilterSet(new Set(newFilters));
+          trackAnalytics('breadcrumbs.drawer.action', {
+            control: BreadcrumbControlOptions.FILTER,
+            organization,
+          });
         }}
         multiple
         options={filterOptions}
@@ -139,7 +152,14 @@ export function BreadcrumbsDrawerContent({
             {...props}
           />
         )}
-        onChange={selectedOption => setSort(selectedOption.value)}
+        onChange={selectedOption => {
+          setSort(selectedOption.value);
+          trackAnalytics('breadcrumbs.drawer.action', {
+            control: BreadcrumbControlOptions.SORT,
+            value: selectedOption.value,
+            organization,
+          });
+        }}
         value={sort}
         options={BREADCRUMB_SORT_OPTIONS}
       />
@@ -156,7 +176,14 @@ export function BreadcrumbsDrawerContent({
             {...props}
           />
         )}
-        onChange={selectedOption => setTimeDisplay(selectedOption.value)}
+        onChange={selectedOption => {
+          setTimeDisplay(selectedOption.value);
+          trackAnalytics('breadcrumbs.drawer.action', {
+            control: 'time_display',
+            value: selectedOption.value,
+            organization,
+          });
+        }}
         value={timeDisplay}
         options={BREADCRUMB_TIME_DISPLAY_OPTIONS}
       >
@@ -196,6 +223,10 @@ export function BreadcrumbsDrawerContent({
               onClick={() => {
                 setFilterSet(new Set());
                 setSearch('');
+                trackAnalytics('breadcrumbs.drawer.action', {
+                  control: 'clear_filters',
+                  organization,
+                });
               }}
             >
               {t('Clear Filters?')}

--- a/static/app/components/events/breadcrumbs/breadcrumbsDrawerContent.tsx
+++ b/static/app/components/events/breadcrumbs/breadcrumbsDrawerContent.tsx
@@ -14,6 +14,7 @@ import {
   BREADCRUMB_TIME_DISPLAY_LOCALSTORAGE_KEY,
   BREADCRUMB_TIME_DISPLAY_OPTIONS,
   BreadcrumbTimeDisplay,
+  getBreadcrumbFilter,
   getBreadcrumbFilters,
 } from 'sentry/components/events/breadcrumbs/utils';
 import {
@@ -77,7 +78,7 @@ export function BreadcrumbsDrawerContent({
     const sortedCrumbs =
       sort === BreadcrumbSort.OLDEST ? allBreadcrumbs : [...allBreadcrumbs].reverse();
     const filteredCrumbs = sortedCrumbs.filter(bc =>
-      filterSet.size === 0 ? true : filterSet.has(bc.type)
+      filterSet.size === 0 ? true : filterSet.has(getBreadcrumbFilter(bc.type))
     );
     const searchedCrumbs = applyBreadcrumbSearch(search, filteredCrumbs);
     return searchedCrumbs;

--- a/static/app/components/events/breadcrumbs/breadcrumbsDrawerContent.tsx
+++ b/static/app/components/events/breadcrumbs/breadcrumbsDrawerContent.tsx
@@ -14,8 +14,8 @@ import {
   BREADCRUMB_TIME_DISPLAY_LOCALSTORAGE_KEY,
   BREADCRUMB_TIME_DISPLAY_OPTIONS,
   BreadcrumbTimeDisplay,
-  getBreadcrumbFilter,
-  getBreadcrumbFilters,
+  type EnhancedCrumb,
+  getBreadcrumbFilterOptions,
 } from 'sentry/components/events/breadcrumbs/utils';
 import {
   BREADCRUMB_SORT_LOCALSTORAGE_KEY,
@@ -26,7 +26,6 @@ import {InputGroup} from 'sentry/components/inputGroup';
 import {IconClock, IconFilter, IconSearch, IconSort} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
-import type {RawCrumb} from 'sentry/types/breadcrumbs';
 import type {Event} from 'sentry/types/event';
 import type {Group} from 'sentry/types/group';
 import type {Project} from 'sentry/types/project';
@@ -39,23 +38,18 @@ export const enum BreadcrumbControlOptions {
 }
 
 interface BreadcrumbsDrawerContentProps {
-  /**
-   * Assumes crumbs are sorted from oldest to newest.
-   */
-  allBreadcrumbs: RawCrumb[];
+  breadcrumbs: EnhancedCrumb[];
   event: Event;
   group: Group;
   project: Project;
   focusControl?: BreadcrumbControlOptions;
-  meta?: Record<string, any>;
 }
 
 export function BreadcrumbsDrawerContent({
   event,
   group,
   project,
-  allBreadcrumbs,
-  meta,
+  breadcrumbs,
   focusControl,
 }: BreadcrumbsDrawerContentProps) {
   const theme = useTheme();
@@ -70,24 +64,24 @@ export function BreadcrumbsDrawerContent({
     BreadcrumbTimeDisplay.RELATIVE
   );
   const filterOptions = useMemo(
-    () => getBreadcrumbFilters(allBreadcrumbs),
-    [allBreadcrumbs]
+    () => getBreadcrumbFilterOptions(breadcrumbs),
+    [breadcrumbs]
   );
 
   const displayCrumbs = useMemo(() => {
     const sortedCrumbs =
-      sort === BreadcrumbSort.OLDEST ? allBreadcrumbs : [...allBreadcrumbs].reverse();
-    const filteredCrumbs = sortedCrumbs.filter(bc =>
-      filterSet.size === 0 ? true : filterSet.has(getBreadcrumbFilter(bc.type))
+      sort === BreadcrumbSort.OLDEST ? breadcrumbs : [...breadcrumbs].reverse();
+    const filteredCrumbs = sortedCrumbs.filter(ec =>
+      filterSet.size === 0 ? true : filterSet.has(ec.filter)
     );
     const searchedCrumbs = applyBreadcrumbSearch(search, filteredCrumbs);
     return searchedCrumbs;
-  }, [allBreadcrumbs, sort, filterSet, search]);
+  }, [breadcrumbs, sort, filterSet, search]);
 
   const startTimeString = useMemo(
     () =>
       timeDisplay === BreadcrumbTimeDisplay.RELATIVE
-        ? displayCrumbs?.at(0)?.timestamp
+        ? displayCrumbs?.at(0)?.breadcrumb?.timestamp
         : undefined,
     [displayCrumbs, timeDisplay]
   );
@@ -210,7 +204,6 @@ export function BreadcrumbsDrawerContent({
         ) : (
           <BreadcrumbsTimeline
             breadcrumbs={displayCrumbs}
-            meta={meta}
             startTimeString={startTimeString}
             fullyExpanded
           />

--- a/static/app/components/events/breadcrumbs/breadcrumbsItemContent.tsx
+++ b/static/app/components/events/breadcrumbs/breadcrumbsItemContent.tsx
@@ -2,6 +2,7 @@ import {Fragment} from 'react';
 import styled from '@emotion/styled';
 
 import {openNavigateToExternalLinkModal} from 'sentry/actionCreators/modal';
+import {AnnotatedText} from 'sentry/components/events/meta/annotatedText';
 import {StructuredData} from 'sentry/components/structuredEventData';
 import Timeline from 'sentry/components/timeline';
 import {space} from 'sentry/styles/space';
@@ -85,19 +86,20 @@ function HTTPCrumbContent({
   meta?: Record<string, any>;
 }) {
   const {method, url, status_code: statusCode, ...otherData} = breadcrumb?.data ?? {};
+  const isValidUrl = !meta && defined(url) && isUrl(url);
   return (
     <Fragment>
       {children}
       <Timeline.Text>
-        {method && `${method}: `}
-        {url && isUrl(url) ? (
+        {defined(method) && `${method}: `}
+        {isValidUrl ? (
           <Link onClick={() => openNavigateToExternalLinkModal({linkText: url})}>
             {url}
           </Link>
         ) : (
-          url
+          <AnnotatedText value={url} meta={meta?.data?.url?.['']} />
         )}
-        {` [${statusCode}]`}
+        {defined(statusCode) && ` [${statusCode}]`}
       </Timeline.Text>
       {Object.keys(otherData).length > 0 ? (
         <Timeline.Data>

--- a/static/app/components/events/breadcrumbs/breadcrumbsItemContent.tsx
+++ b/static/app/components/events/breadcrumbs/breadcrumbsItemContent.tsx
@@ -2,9 +2,9 @@ import {Fragment} from 'react';
 import styled from '@emotion/styled';
 
 import {openNavigateToExternalLinkModal} from 'sentry/actionCreators/modal';
-import {Sql} from 'sentry/components/events/interfaces/breadcrumbs/breadcrumb/data/sql';
 import {StructuredData} from 'sentry/components/structuredEventData';
 import Timeline from 'sentry/components/timeline';
+import {space} from 'sentry/styles/space';
 import {
   BreadcrumbMessageFormat,
   BreadcrumbType,
@@ -15,6 +15,7 @@ import {
 } from 'sentry/types/breadcrumbs';
 import {defined} from 'sentry/utils';
 import {isUrl} from 'sentry/utils/string/isUrl';
+import {usePrismTokens} from 'sentry/utils/usePrismTokens';
 
 interface BreadcrumbsItemContentProps {
   breadcrumb: RawCrumb;
@@ -119,10 +120,19 @@ function SQLCrumbContent({
 }: {
   breadcrumb: BreadcrumbTypeDefault | BreadcrumbTypeNavigation;
 }) {
+  const tokens = usePrismTokens({code: breadcrumb?.message ?? '', language: 'sql'});
   return (
     <Timeline.Data>
-      <LightenTextColor>
-        <Sql breadcrumb={breadcrumb} searchTerm="" />
+      <LightenTextColor className="language-sql">
+        {tokens.map((line, i) => (
+          <div key={i}>
+            {line.map((token, j) => (
+              <span key={j} className={token.className}>
+                {token.children}
+              </span>
+            ))}
+          </div>
+        ))}
       </LightenTextColor>
     </Timeline.Data>
   );
@@ -153,8 +163,11 @@ const Link = styled('a')`
   word-break: break-all;
 `;
 
-const LightenTextColor = styled('div')`
-  .token {
+const LightenTextColor = styled('pre')`
+  margin: 0;
+  &.language-sql {
     color: ${p => p.theme.subText};
+    padding: ${space(0.25)} 0;
+    font-size: ${p => p.theme.fontSizeSmall};
   }
 `;

--- a/static/app/components/events/breadcrumbs/breadcrumbsItemContent.tsx
+++ b/static/app/components/events/breadcrumbs/breadcrumbsItemContent.tsx
@@ -1,0 +1,160 @@
+import {Fragment} from 'react';
+import styled from '@emotion/styled';
+
+import {openNavigateToExternalLinkModal} from 'sentry/actionCreators/modal';
+import {Sql} from 'sentry/components/events/interfaces/breadcrumbs/breadcrumb/data/sql';
+import {StructuredData} from 'sentry/components/structuredEventData';
+import Timeline from 'sentry/components/timeline';
+import {
+  BreadcrumbMessageFormat,
+  BreadcrumbType,
+  type BreadcrumbTypeDefault,
+  type BreadcrumbTypeHTTP,
+  type BreadcrumbTypeNavigation,
+  type RawCrumb,
+} from 'sentry/types/breadcrumbs';
+import {defined} from 'sentry/utils';
+import {isUrl} from 'sentry/utils/string/isUrl';
+
+interface BreadcrumbsItemContentProps {
+  breadcrumb: RawCrumb;
+  fullyExpanded?: boolean;
+  meta?: Record<string, any>;
+}
+
+export default function BreadcrumbsItemContent({
+  breadcrumb: bc,
+  meta,
+  fullyExpanded,
+}: BreadcrumbsItemContentProps) {
+  const maxDefaultDepth = fullyExpanded ? 10000 : 1;
+  const structureProps = {
+    depth: 0,
+    maxDefaultDepth,
+    withAnnotatedText: true,
+    withOnlyFormattedText: true,
+  };
+
+  const defaultMessage = defined(bc.message) ? (
+    <Timeline.Text>
+      <StructuredData value={bc.message} meta={meta?.message} {...structureProps} />
+    </Timeline.Text>
+  ) : null;
+  const defaultData = defined(bc.data) ? (
+    <Timeline.Data>
+      <StructuredData value={bc.data} meta={meta?.data} {...structureProps} />
+    </Timeline.Data>
+  ) : null;
+
+  if (bc?.type === BreadcrumbType.HTTP) {
+    return (
+      <HTTPCrumbContent breadcrumb={bc} meta={meta}>
+        {defaultMessage}
+      </HTTPCrumbContent>
+    );
+  }
+
+  if (
+    !defined(meta) &&
+    bc?.message &&
+    bc?.messageFormat === BreadcrumbMessageFormat.SQL
+  ) {
+    return <SQLCrumbContent breadcrumb={bc} />;
+  }
+
+  if (bc?.type === BreadcrumbType.WARNING || bc?.type === BreadcrumbType.ERROR) {
+    return <ErrorCrumbContent breadcrumb={bc}>{defaultMessage}</ErrorCrumbContent>;
+  }
+
+  return (
+    <Fragment>
+      {defaultMessage}
+      {defaultData}
+    </Fragment>
+  );
+}
+
+function HTTPCrumbContent({
+  breadcrumb,
+  meta,
+  children = null,
+}: {
+  breadcrumb: BreadcrumbTypeHTTP;
+  children?: React.ReactNode;
+  meta?: Record<string, any>;
+}) {
+  const {method, url, status_code: statusCode, ...otherData} = breadcrumb?.data ?? {};
+  return (
+    <Fragment>
+      {children}
+      <Timeline.Text>
+        {method && `${method}: `}
+        {url && isUrl(url) ? (
+          <Link onClick={() => openNavigateToExternalLinkModal({linkText: url})}>
+            {url}
+          </Link>
+        ) : (
+          url
+        )}
+        {` [${statusCode}]`}
+      </Timeline.Text>
+      {Object.keys(otherData).length > 0 ? (
+        <Timeline.Data>
+          <StructuredData
+            value={otherData}
+            meta={meta}
+            depth={0}
+            maxDefaultDepth={2}
+            withAnnotatedText
+            withOnlyFormattedText
+          />
+        </Timeline.Data>
+      ) : null}
+    </Fragment>
+  );
+}
+
+function SQLCrumbContent({
+  breadcrumb,
+}: {
+  breadcrumb: BreadcrumbTypeDefault | BreadcrumbTypeNavigation;
+}) {
+  return (
+    <Timeline.Data>
+      <LightenTextColor>
+        <Sql breadcrumb={breadcrumb} searchTerm="" />
+      </LightenTextColor>
+    </Timeline.Data>
+  );
+}
+
+function ErrorCrumbContent({
+  breadcrumb,
+  children = null,
+}: {
+  breadcrumb: BreadcrumbTypeDefault;
+  children?: React.ReactNode;
+}) {
+  return (
+    <Fragment>
+      <Timeline.Text>
+        {breadcrumb?.data?.type && `${breadcrumb?.data?.type}: `}
+        {breadcrumb?.data?.value}
+      </Timeline.Text>
+      {children}
+    </Fragment>
+  );
+}
+
+const Link = styled('a')`
+  color: ${p => p.theme.subText};
+  text-decoration: underline;
+  text-decoration-style: dotted;
+  word-break: break-all;
+`;
+
+const LightenTextColor = styled('div')`
+  .token {
+    color: ${p => p.theme.subText};
+  }
+`;

--- a/static/app/components/events/breadcrumbs/breadcrumbsTimeline.tsx
+++ b/static/app/components/events/breadcrumbs/breadcrumbsTimeline.tsx
@@ -1,5 +1,6 @@
-import {Fragment} from 'react';
+import {Fragment, useRef} from 'react';
 import styled from '@emotion/styled';
+import {useVirtualizer} from '@tanstack/react-virtual';
 
 import BreadcrumbsItemContent from 'sentry/components/events/breadcrumbs/breadcrumbsItemContent';
 import {
@@ -12,7 +13,15 @@ import {defined} from 'sentry/utils';
 
 interface BreadcrumbsTimelineProps {
   breadcrumbs: EnhancedCrumb[];
+  /**
+   * Fully expands the contents of the breadcrumb's data payload.
+   */
   fullyExpanded?: boolean;
+  /**
+   * Shows the line after the last breadcrumbs icon.
+   * Useful for connecting timeline to components rendered after it.
+   */
+  showLastLine?: boolean;
   startTimeString?: TimelineItemProps['startTimeString'];
 }
 
@@ -20,43 +29,66 @@ export default function BreadcrumbsTimeline({
   breadcrumbs,
   startTimeString,
   fullyExpanded = false,
+  showLastLine = false,
 }: BreadcrumbsTimelineProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const virtualizer = useVirtualizer({
+    count: breadcrumbs.length,
+    getScrollElement: () => containerRef.current,
+    estimateSize: () => 35,
+    debug: true,
+    // Must match rendered item margins.
+    gap: 8,
+  });
+
   if (!breadcrumbs.length) {
     return null;
   }
 
-  const items = breadcrumbs.map(
-    ({breadcrumb, raw, title, meta, iconComponent, colorConfig, levelComponent}, i) => {
-      const isVirtualCrumb = !defined(raw);
-      return (
-        <Timeline.Item
-          key={i}
-          title={
-            <Fragment>
-              {title}
-              {isVirtualCrumb && <Subtitle> - {t('This event')}</Subtitle>}
-              {levelComponent}
-            </Fragment>
-          }
-          colorConfig={colorConfig}
-          icon={iconComponent}
-          timeString={breadcrumb.timestamp ?? BREADCRUMB_TIMESTAMP_PLACEHOLDER}
-          startTimeString={startTimeString}
-          // XXX: Only the virtual crumb can be marked as active for breadcrumbs
-          isActive={isVirtualCrumb ?? false}
-          style={{background: 'transparent'}}
-        >
-          <BreadcrumbsItemContent
-            breadcrumb={breadcrumb}
-            meta={meta}
-            fullyExpanded={fullyExpanded}
-          />
-        </Timeline.Item>
-      );
-    }
-  );
+  const virtualItems = virtualizer.getVirtualItems();
+  const items = virtualItems.map(virtualizedRow => {
+    const {breadcrumb, raw, title, meta, iconComponent, colorConfig, levelComponent} =
+      breadcrumbs[virtualizedRow.index];
+    const isVirtualCrumb = !defined(raw);
+    return (
+      <Timeline.Item
+        key={virtualizedRow.key}
+        ref={virtualizer.measureElement}
+        title={
+          <Fragment>
+            {title}
+            {isVirtualCrumb && <Subtitle> - {t('This event')}</Subtitle>}
+            {levelComponent}
+          </Fragment>
+        }
+        colorConfig={colorConfig}
+        icon={iconComponent}
+        timeString={breadcrumb.timestamp ?? BREADCRUMB_TIMESTAMP_PLACEHOLDER}
+        startTimeString={startTimeString}
+        // XXX: Only the virtual crumb can be marked as active for breadcrumbs
+        isActive={isVirtualCrumb ?? false}
+        style={showLastLine ? {background: 'transparent'} : {}}
+        data-index={virtualizedRow.index}
+      >
+        <BreadcrumbsItemContent
+          breadcrumb={breadcrumb}
+          meta={meta}
+          fullyExpanded={fullyExpanded}
+        />
+      </Timeline.Item>
+    );
+  });
 
-  return <Timeline.Container>{items}</Timeline.Container>;
+  return (
+    <Timeline.Container
+      ref={containerRef}
+      style={{
+        height: virtualizer.getTotalSize(),
+      }}
+    >
+      {items}
+    </Timeline.Container>
+  );
 }
 
 const Subtitle = styled('p')`

--- a/static/app/components/events/breadcrumbs/breadcrumbsTimeline.tsx
+++ b/static/app/components/events/breadcrumbs/breadcrumbsTimeline.tsx
@@ -1,7 +1,7 @@
 import {Fragment} from 'react';
 import styled from '@emotion/styled';
 
-import {openNavigateToExternalLinkModal} from 'sentry/actionCreators/modal';
+import BreadcrumbsItemContent from 'sentry/components/events/breadcrumbs/breadcrumbsItemContent';
 import {
   BREADCRUMB_TIMESTAMP_PLACEHOLDER,
   BreadcrumbIcon,
@@ -9,17 +9,10 @@ import {
   getBreadcrumbColorConfig,
   getBreadcrumbTitle,
 } from 'sentry/components/events/breadcrumbs/utils';
-import {Sql} from 'sentry/components/events/interfaces/breadcrumbs/breadcrumb/data/sql';
-import {StructuredData} from 'sentry/components/structuredEventData';
 import Timeline, {type TimelineItemProps} from 'sentry/components/timeline';
 import {t} from 'sentry/locale';
-import {
-  BreadcrumbMessageFormat,
-  BreadcrumbType,
-  type RawCrumb,
-} from 'sentry/types/breadcrumbs';
+import type {RawCrumb} from 'sentry/types/breadcrumbs';
 import {defined} from 'sentry/utils';
-import {isUrl} from 'sentry/utils/string/isUrl';
 
 interface BreadcrumbsTimelineProps {
   breadcrumbs: RawCrumb[];
@@ -73,114 +66,9 @@ export default function BreadcrumbsTimeline({
   return <Timeline.Container>{items}</Timeline.Container>;
 }
 
-interface BreadcrumbsItemContentProps {
-  breadcrumb: RawCrumb;
-  fullyExpanded?: boolean;
-  meta?: Record<string, any>;
-}
-
-function BreadcrumbsItemContent({
-  breadcrumb: bc,
-  meta,
-  fullyExpanded,
-}: BreadcrumbsItemContentProps) {
-  const maxDefaultDepth = fullyExpanded ? 10000 : 1;
-  const structureProps = {
-    depth: 0,
-    maxDefaultDepth,
-    withAnnotatedText: true,
-    withOnlyFormattedText: true,
-  };
-
-  const defaultMessage = defined(bc.message) ? (
-    <Timeline.Text>
-      <StructuredData value={bc.message} meta={meta?.message} {...structureProps} />
-    </Timeline.Text>
-  ) : null;
-  const defaultData = defined(bc.data) ? (
-    <Timeline.Data>
-      <StructuredData value={bc.data} meta={meta?.data} {...structureProps} />
-    </Timeline.Data>
-  ) : null;
-
-  if (bc?.type === BreadcrumbType.HTTP) {
-    const {method, url, status_code: statusCode, ...otherData} = bc.data;
-
-    return (
-      <Fragment>
-        {defaultMessage}
-        <Timeline.Text>
-          {method && `${method}: `}
-          {url && isUrl(url) ? (
-            <Link onClick={() => openNavigateToExternalLinkModal({linkText: url})}>
-              {url}
-            </Link>
-          ) : (
-            url
-          )}
-          {` [${statusCode}]`}
-        </Timeline.Text>
-        {defined(bc.data) ? (
-          <Timeline.Data>
-            <StructuredData value={otherData} meta={meta?.data} {...structureProps} />
-          </Timeline.Data>
-        ) : null}
-      </Fragment>
-    );
-  }
-
-  if (
-    !defined(meta) &&
-    bc?.message &&
-    bc?.messageFormat === BreadcrumbMessageFormat.SQL
-  ) {
-    return (
-      <Timeline.Data>
-        <LightenTextColor>
-          <Sql breadcrumb={bc} searchTerm="" />
-        </LightenTextColor>
-      </Timeline.Data>
-    );
-  }
-  if (
-    (!defined(meta) && bc?.type === BreadcrumbType.WARNING) ||
-    bc?.type === BreadcrumbType.ERROR
-  ) {
-    return (
-      <Fragment>
-        <Timeline.Text>
-          {bc?.data?.type && `${bc?.data?.type}: `}
-          {bc?.data?.value}
-        </Timeline.Text>
-        {defaultMessage}
-      </Fragment>
-    );
-  }
-
-  return (
-    <Fragment>
-      {defaultMessage}
-      {defaultData}
-    </Fragment>
-  );
-}
-
 const Subtitle = styled('p')`
   margin: 0;
   font-weight: normal;
   font-size: ${p => p.theme.fontSizeSmall};
   display: inline;
-`;
-
-const Link = styled('a')`
-  color: ${p => p.theme.subText};
-  text-decoration: underline;
-  text-decoration-style: dotted;
-  word-break: break-all;
-`;
-
-const LightenTextColor = styled('div')`
-  .token {
-    color: ${p => p.theme.subText};
-  }
 `;

--- a/static/app/components/events/breadcrumbs/breadcrumbsTimeline.tsx
+++ b/static/app/components/events/breadcrumbs/breadcrumbsTimeline.tsx
@@ -36,9 +36,9 @@ export default function BreadcrumbsTimeline({
     count: breadcrumbs.length,
     getScrollElement: () => containerRef.current,
     estimateSize: () => 35,
-    debug: true,
     // Must match rendered item margins.
     gap: 8,
+    overscan: 10,
   });
 
   if (!breadcrumbs.length) {
@@ -80,12 +80,7 @@ export default function BreadcrumbsTimeline({
   });
 
   return (
-    <Timeline.Container
-      ref={containerRef}
-      style={{
-        height: virtualizer.getTotalSize(),
-      }}
-    >
+    <Timeline.Container ref={containerRef} style={{height: virtualizer.getTotalSize()}}>
       {items}
     </Timeline.Container>
   );

--- a/static/app/components/events/breadcrumbs/breadcrumbsTimeline.tsx
+++ b/static/app/components/events/breadcrumbs/breadcrumbsTimeline.tsx
@@ -1,14 +1,25 @@
+import {Fragment} from 'react';
+import styled from '@emotion/styled';
+
+import {openNavigateToExternalLinkModal} from 'sentry/actionCreators/modal';
 import {
   BREADCRUMB_TIMESTAMP_PLACEHOLDER,
   BreadcrumbIcon,
+  BreadcrumbTag,
   getBreadcrumbColorConfig,
   getBreadcrumbTitle,
 } from 'sentry/components/events/breadcrumbs/utils';
-import {convertCrumbType} from 'sentry/components/events/interfaces/breadcrumbs/utils';
+import {Sql} from 'sentry/components/events/interfaces/breadcrumbs/breadcrumb/data/sql';
 import {StructuredData} from 'sentry/components/structuredEventData';
 import Timeline, {type TimelineItemProps} from 'sentry/components/timeline';
-import type {RawCrumb} from 'sentry/types/breadcrumbs';
+import {t} from 'sentry/locale';
+import {
+  BreadcrumbMessageFormat,
+  BreadcrumbType,
+  type RawCrumb,
+} from 'sentry/types/breadcrumbs';
 import {defined} from 'sentry/utils';
+import {isUrl} from 'sentry/utils/string/isUrl';
 
 interface BreadcrumbsTimelineProps {
   breadcrumbs: RawCrumb[];
@@ -29,15 +40,19 @@ export default function BreadcrumbsTimeline({
     return null;
   }
 
-  const items = breadcrumbs.map((breadcrumb, i) => {
-    const bc = convertCrumbType(breadcrumb);
+  const items = breadcrumbs.map((bc, i) => {
     const bcMeta = meta[i];
     const isVirtualCrumb = defined(virtualCrumbIndex) && i === virtualCrumbIndex;
-    const defaultDepth = fullyExpanded ? 10000 : 1;
     return (
       <Timeline.Item
         key={i}
-        title={getBreadcrumbTitle(bc.category)}
+        title={
+          <Fragment>
+            {getBreadcrumbTitle(bc.category)}
+            {isVirtualCrumb && <Subtitle> - {t('This event')}</Subtitle>}
+            <BreadcrumbTag level={bc.level} />
+          </Fragment>
+        }
         colorConfig={getBreadcrumbColorConfig(bc.type)}
         icon={<BreadcrumbIcon type={bc.type} />}
         timeString={bc.timestamp ?? BREADCRUMB_TIMESTAMP_PLACEHOLDER}
@@ -46,33 +61,126 @@ export default function BreadcrumbsTimeline({
         isActive={isVirtualCrumb ?? false}
         style={{background: 'transparent'}}
       >
-        {defined(bc.message) && (
-          <Timeline.Text>
-            <StructuredData
-              value={bc.message}
-              depth={0}
-              maxDefaultDepth={defaultDepth}
-              meta={bcMeta?.message}
-              withAnnotatedText
-              withOnlyFormattedText
-            />
-          </Timeline.Text>
-        )}
-        {defined(bc.data) && (
-          <Timeline.Data>
-            <StructuredData
-              value={bc.data}
-              depth={0}
-              maxDefaultDepth={defaultDepth}
-              meta={bcMeta?.data}
-              withAnnotatedText
-              withOnlyFormattedText
-            />
-          </Timeline.Data>
-        )}
+        <BreadcrumbsItemContent
+          breadcrumb={bc}
+          meta={bcMeta}
+          fullyExpanded={fullyExpanded}
+        />
       </Timeline.Item>
     );
   });
 
   return <Timeline.Container>{items}</Timeline.Container>;
 }
+
+interface BreadcrumbsItemContentProps {
+  breadcrumb: RawCrumb;
+  fullyExpanded?: boolean;
+  meta?: Record<string, any>;
+}
+
+function BreadcrumbsItemContent({
+  breadcrumb: bc,
+  meta,
+  fullyExpanded,
+}: BreadcrumbsItemContentProps) {
+  const maxDefaultDepth = fullyExpanded ? 10000 : 1;
+  const structureProps = {
+    depth: 0,
+    maxDefaultDepth,
+    withAnnotatedText: true,
+    withOnlyFormattedText: true,
+  };
+
+  const defaultMessage = defined(bc.message) ? (
+    <Timeline.Text>
+      <StructuredData value={bc.message} meta={meta?.message} {...structureProps} />
+    </Timeline.Text>
+  ) : null;
+  const defaultData = defined(bc.data) ? (
+    <Timeline.Data>
+      <StructuredData value={bc.data} meta={meta?.data} {...structureProps} />
+    </Timeline.Data>
+  ) : null;
+
+  if (bc?.type === BreadcrumbType.HTTP) {
+    const {method, url, status_code: statusCode, ...otherData} = bc.data;
+
+    return (
+      <Fragment>
+        {defaultMessage}
+        <Timeline.Text>
+          {method && `${method}: `}
+          {url && isUrl(url) ? (
+            <Link onClick={() => openNavigateToExternalLinkModal({linkText: url})}>
+              {url}
+            </Link>
+          ) : (
+            url
+          )}
+          {` [${statusCode}]`}
+        </Timeline.Text>
+        {defined(bc.data) ? (
+          <Timeline.Data>
+            <StructuredData value={otherData} meta={meta?.data} {...structureProps} />
+          </Timeline.Data>
+        ) : null}
+      </Fragment>
+    );
+  }
+
+  if (
+    !defined(meta) &&
+    bc?.message &&
+    bc?.messageFormat === BreadcrumbMessageFormat.SQL
+  ) {
+    return (
+      <Timeline.Data>
+        <LightenTextColor>
+          <Sql breadcrumb={bc} searchTerm="" />
+        </LightenTextColor>
+      </Timeline.Data>
+    );
+  }
+  if (
+    (!defined(meta) && bc?.type === BreadcrumbType.WARNING) ||
+    bc?.type === BreadcrumbType.ERROR
+  ) {
+    return (
+      <Fragment>
+        <Timeline.Text>
+          {bc?.data?.type && `${bc?.data?.type}: `}
+          {bc?.data?.value}
+        </Timeline.Text>
+        {defaultMessage}
+      </Fragment>
+    );
+  }
+
+  return (
+    <Fragment>
+      {defaultMessage}
+      {defaultData}
+    </Fragment>
+  );
+}
+
+const Subtitle = styled('p')`
+  margin: 0;
+  font-weight: normal;
+  font-size: ${p => p.theme.fontSizeSmall};
+  display: inline;
+`;
+
+const Link = styled('a')`
+  color: ${p => p.theme.subText};
+  text-decoration: underline;
+  text-decoration-style: dotted;
+  word-break: break-all;
+`;
+
+const LightenTextColor = styled('div')`
+  .token {
+    color: ${p => p.theme.subText};
+  }
+`;

--- a/static/app/components/events/breadcrumbs/breadcrumbsTimeline.tsx
+++ b/static/app/components/events/breadcrumbs/breadcrumbsTimeline.tsx
@@ -4,64 +4,57 @@ import styled from '@emotion/styled';
 import BreadcrumbsItemContent from 'sentry/components/events/breadcrumbs/breadcrumbsItemContent';
 import {
   BREADCRUMB_TIMESTAMP_PLACEHOLDER,
-  BreadcrumbIcon,
-  BreadcrumbTag,
-  getBreadcrumbColorConfig,
-  getBreadcrumbTitle,
+  type EnhancedCrumb,
 } from 'sentry/components/events/breadcrumbs/utils';
 import Timeline, {type TimelineItemProps} from 'sentry/components/timeline';
 import {t} from 'sentry/locale';
-import type {RawCrumb} from 'sentry/types/breadcrumbs';
 import {defined} from 'sentry/utils';
 
 interface BreadcrumbsTimelineProps {
-  breadcrumbs: RawCrumb[];
+  breadcrumbs: EnhancedCrumb[];
   fullyExpanded?: boolean;
-  meta?: Record<string, any>;
   startTimeString?: TimelineItemProps['startTimeString'];
-  virtualCrumbIndex?: number;
 }
 
 export default function BreadcrumbsTimeline({
   breadcrumbs,
   startTimeString,
-  virtualCrumbIndex,
-  meta = {},
   fullyExpanded = false,
 }: BreadcrumbsTimelineProps) {
   if (!breadcrumbs.length) {
     return null;
   }
 
-  const items = breadcrumbs.map((bc, i) => {
-    const bcMeta = meta[i];
-    const isVirtualCrumb = defined(virtualCrumbIndex) && i === virtualCrumbIndex;
-    return (
-      <Timeline.Item
-        key={i}
-        title={
-          <Fragment>
-            {getBreadcrumbTitle(bc.category)}
-            {isVirtualCrumb && <Subtitle> - {t('This event')}</Subtitle>}
-            <BreadcrumbTag level={bc.level} />
-          </Fragment>
-        }
-        colorConfig={getBreadcrumbColorConfig(bc.type)}
-        icon={<BreadcrumbIcon type={bc.type} />}
-        timeString={bc.timestamp ?? BREADCRUMB_TIMESTAMP_PLACEHOLDER}
-        startTimeString={startTimeString}
-        // XXX: Only the virtual crumb can be marked as active for breadcrumbs
-        isActive={isVirtualCrumb ?? false}
-        style={{background: 'transparent'}}
-      >
-        <BreadcrumbsItemContent
-          breadcrumb={bc}
-          meta={bcMeta}
-          fullyExpanded={fullyExpanded}
-        />
-      </Timeline.Item>
-    );
-  });
+  const items = breadcrumbs.map(
+    ({breadcrumb, raw, title, meta, iconComponent, colorConfig, levelComponent}, i) => {
+      const isVirtualCrumb = !defined(raw);
+      return (
+        <Timeline.Item
+          key={i}
+          title={
+            <Fragment>
+              {title}
+              {isVirtualCrumb && <Subtitle> - {t('This event')}</Subtitle>}
+              {levelComponent}
+            </Fragment>
+          }
+          colorConfig={colorConfig}
+          icon={iconComponent}
+          timeString={breadcrumb.timestamp ?? BREADCRUMB_TIMESTAMP_PLACEHOLDER}
+          startTimeString={startTimeString}
+          // XXX: Only the virtual crumb can be marked as active for breadcrumbs
+          isActive={isVirtualCrumb ?? false}
+          style={{background: 'transparent'}}
+        >
+          <BreadcrumbsItemContent
+            breadcrumb={breadcrumb}
+            meta={meta}
+            fullyExpanded={fullyExpanded}
+          />
+        </Timeline.Item>
+      );
+    }
+  );
 
   return <Timeline.Container>{items}</Timeline.Container>;
 }

--- a/static/app/components/events/breadcrumbs/testUtils.tsx
+++ b/static/app/components/events/breadcrumbs/testUtils.tsx
@@ -8,30 +8,30 @@ import {BreadcrumbLevelType, BreadcrumbType} from 'sentry/types/breadcrumbs';
 const oneMinuteBeforeEventFixture = '2019-05-21T18:00:48.76Z';
 export const MOCK_BREADCRUMBS = [
   {
-    message: 'warning',
+    message: 'warning message',
     category: 'Warning Category',
     level: BreadcrumbLevelType.WARNING,
     type: BreadcrumbType.INFO,
     timestamp: oneMinuteBeforeEventFixture,
   },
   {
-    message: 'log',
+    message: 'log message',
     category: 'Log Category',
     level: BreadcrumbLevelType.LOG,
     type: BreadcrumbType.INFO,
     timestamp: oneMinuteBeforeEventFixture,
   },
   {
-    message: 'request',
-    category: 'Request Category',
-    level: BreadcrumbLevelType.INFO,
+    message: 'navigation message',
+    category: 'Navigation Category',
+    level: BreadcrumbLevelType.FATAL,
     type: BreadcrumbType.NAVIGATION,
     timestamp: oneMinuteBeforeEventFixture,
   },
   {
-    message: 'query',
+    message: 'query message',
     category: 'Query Category',
-    level: BreadcrumbLevelType.INFO,
+    level: BreadcrumbLevelType.DEBUG,
     type: BreadcrumbType.QUERY,
     timestamp: oneMinuteBeforeEventFixture,
   },

--- a/static/app/components/events/breadcrumbs/utils.tsx
+++ b/static/app/components/events/breadcrumbs/utils.tsx
@@ -1,5 +1,6 @@
 import styled from '@emotion/styled';
 
+import Tag from 'sentry/components/badge/tag';
 import type {SelectOption} from 'sentry/components/compactSelect';
 import type {ColorConfig} from 'sentry/components/timeline';
 import {
@@ -18,7 +19,12 @@ import {
   IconWarning,
 } from 'sentry/icons';
 import {t} from 'sentry/locale';
-import {BreadcrumbType, type RawCrumb} from 'sentry/types/breadcrumbs';
+import {space} from 'sentry/styles/space';
+import {
+  BreadcrumbLevelType,
+  BreadcrumbType,
+  type RawCrumb,
+} from 'sentry/types/breadcrumbs';
 import {toTitleCase} from 'sentry/utils/string/toTitleCase';
 
 export const BREADCRUMB_TIMESTAMP_PLACEHOLDER = '--';
@@ -67,15 +73,18 @@ export function getBreadcrumbFilters(crumbs: RawCrumb[]) {
     return crumbTypeSet;
   }, new Set<BreadcrumbType>());
 
-  const filters: SelectOption<string>[] = [...uniqueCrumbTypes].map(crumbType => ({
-    value: crumbType,
-    leadingItems: (
-      <Color colorConfig={getBreadcrumbColorConfig(crumbType)}>
-        <BreadcrumbIcon type={crumbType} />
-      </Color>
-    ),
-    label: toTitleCase(crumbType),
-  }));
+  const filters: SelectOption<string>[] = [...uniqueCrumbTypes].map(crumbType => {
+    const crumbFilter = getBreadcrumbFilter(crumbType);
+    return {
+      value: crumbFilter,
+      label: crumbFilter,
+      leadingItems: (
+        <Color colorConfig={getBreadcrumbColorConfig(crumbType)}>
+          <BreadcrumbIcon type={crumbType} />
+        </Color>
+      ),
+    };
+  });
 
   return filters;
 }
@@ -124,8 +133,38 @@ export function getBreadcrumbColorConfig(type?: BreadcrumbType): ColorConfig {
   }
 }
 
-export function BreadcrumbIcon(props: {type?: BreadcrumbType}) {
-  switch (props.type) {
+export function getBreadcrumbFilter(type?: BreadcrumbType) {
+  switch (type) {
+    case BreadcrumbType.USER:
+    case BreadcrumbType.UI:
+      return t('User Action');
+    case BreadcrumbType.NAVIGATION:
+      return t('Navigation');
+    case BreadcrumbType.DEBUG:
+      return t('Debug');
+    case BreadcrumbType.INFO:
+      return t('Info');
+    case BreadcrumbType.ERROR:
+      return t('Error');
+    case BreadcrumbType.HTTP:
+      return t('HTTP request');
+    case BreadcrumbType.WARNING:
+      return t('Warning');
+    case BreadcrumbType.QUERY:
+      return t('Query');
+    case BreadcrumbType.SYSTEM:
+      return t('System');
+    case BreadcrumbType.SESSION:
+      return t('Session');
+    case BreadcrumbType.TRANSACTION:
+      return t('Transaction');
+    default:
+      return t('Default');
+  }
+}
+
+export function BreadcrumbIcon({type}: {type?: BreadcrumbType}) {
+  switch (type) {
     case BreadcrumbType.USER:
       return <IconUser size="xs" />;
     case BreadcrumbType.UI:
@@ -154,3 +193,25 @@ export function BreadcrumbIcon(props: {type?: BreadcrumbType}) {
       return <IconTerminal size="xs" />;
   }
 }
+
+export function BreadcrumbTag({level}: {level: BreadcrumbLevelType}) {
+  switch (level) {
+    case BreadcrumbLevelType.ERROR:
+    case BreadcrumbLevelType.FATAL:
+      return <StyledTag type="error">{level}</StyledTag>;
+    case BreadcrumbLevelType.WARNING:
+      return <StyledTag type="warning">{level}</StyledTag>;
+    case BreadcrumbLevelType.DEBUG:
+    case BreadcrumbLevelType.INFO:
+    case BreadcrumbLevelType.LOG:
+      return <StyledTag type="highlight">{level}</StyledTag>;
+    case BreadcrumbLevelType.UNDEFINED:
+    default:
+      return null;
+  }
+}
+
+const StyledTag = styled(Tag)`
+  margin: 0 ${space(1)};
+  font-weight: normal;
+`;

--- a/static/app/components/events/breadcrumbs/utils.tsx
+++ b/static/app/components/events/breadcrumbs/utils.tsx
@@ -2,6 +2,11 @@ import styled from '@emotion/styled';
 
 import Tag from 'sentry/components/badge/tag';
 import type {SelectOption} from 'sentry/components/compactSelect';
+import type {BreadcrumbMeta} from 'sentry/components/events/interfaces/breadcrumbs/types';
+import {
+  convertCrumbType,
+  getVirtualCrumb,
+} from 'sentry/components/events/interfaces/breadcrumbs/utils';
 import type {ColorConfig} from 'sentry/components/timeline';
 import {
   IconCursorArrow,
@@ -25,6 +30,7 @@ import {
   BreadcrumbType,
   type RawCrumb,
 } from 'sentry/types/breadcrumbs';
+import {EntryType, type Event} from 'sentry/types/event';
 import {toTitleCase} from 'sentry/utils/string/toTitleCase';
 
 export const BREADCRUMB_TIMESTAMP_PLACEHOLDER = '--';
@@ -50,16 +56,19 @@ const Color = styled('span')<{colorConfig: ColorConfig}>`
  * As of writing this, it just grabs a few, but in the future it may collapse,
  * or manipulate them in some way for a better summary.
  */
-export function getSummaryBreadcrumbs(crumbs: RawCrumb[]) {
+export function getSummaryBreadcrumbs(crumbs: EnhancedCrumb[]) {
   return [...crumbs].reverse().slice(0, BREADCRUMB_SUMMARY_COUNT);
 }
 
-export function applyBreadcrumbSearch(search: string, crumbs: RawCrumb[]): RawCrumb[] {
+export function applyBreadcrumbSearch(
+  search: string,
+  crumbs: EnhancedCrumb[]
+): EnhancedCrumb[] {
   if (search === '') {
     return crumbs;
   }
   return crumbs.filter(
-    c =>
+    ({breadcrumb: c}) =>
       c.type.includes(search) ||
       c.message?.includes(search) ||
       c.category?.includes(search) ||
@@ -67,13 +76,13 @@ export function applyBreadcrumbSearch(search: string, crumbs: RawCrumb[]): RawCr
   );
 }
 
-export function getBreadcrumbFilters(crumbs: RawCrumb[]) {
-  const uniqueCrumbTypes = crumbs.reduce((crumbTypeSet, crumb) => {
+export function getBreadcrumbFilterOptions(crumbs: EnhancedCrumb[]) {
+  const uniqueCrumbTypes = crumbs.reduce((crumbTypeSet, {breadcrumb: crumb}) => {
     crumbTypeSet.add(crumb.type);
     return crumbTypeSet;
   }, new Set<BreadcrumbType>());
 
-  const filters: SelectOption<string>[] = [...uniqueCrumbTypes].map(crumbType => {
+  const filterOptions: SelectOption<string>[] = [...uniqueCrumbTypes].map(crumbType => {
     const crumbFilter = getBreadcrumbFilter(crumbType);
     return {
       value: crumbFilter,
@@ -85,14 +94,72 @@ export function getBreadcrumbFilters(crumbs: RawCrumb[]) {
       ),
     };
   });
-
-  return filters;
+  return filterOptions.sort((a, b) => a.value.localeCompare(b.value));
+}
+export interface EnhancedCrumb {
+  // Mutated crumb where we change types or virtual crumb
+  breadcrumb: RawCrumb;
+  colorConfig: ReturnType<typeof getBreadcrumbColorConfig>;
+  filter: ReturnType<typeof getBreadcrumbFilter>;
+  iconComponent: ReturnType<typeof BreadcrumbIcon>;
+  levelComponent: ReturnType<typeof BreadcrumbLevel>;
+  // Display props
+  title: ReturnType<typeof getBreadcrumbTitle>;
+  meta?: BreadcrumbMeta;
+  // Exact crumb extracted from the event. If raw is missing, crumb is virtual.
+  raw?: RawCrumb;
 }
 
-export function getBreadcrumbTitle(category: RawCrumb['category']) {
+/**
+ * This is necessary to keep breadcrumbs with their associated meta annotations. The meta object for
+ * crumbs on the event uses an array index, but in practice we append to the list (with virtual crumbs),
+ * change the sort, and filter it. To avoid having to mutate the meta indeces, keep them together from the start.
+ *
+ * Display props are also added to reduce repeated iterations.
+ */
+export function getEnhancedBreadcrumbs(event: Event): EnhancedCrumb[] {
+  const breadcrumbEntryIndex =
+    event.entries?.findIndex(entry => entry.type === EntryType.BREADCRUMBS) ?? -1;
+  const breadcrumbs = event.entries?.[breadcrumbEntryIndex]?.data?.values ?? [];
+
+  if (breadcrumbs.length === 0) {
+    return [];
+  }
+
+  // Mapping of breadcrumb index -> breadcrumb meta
+  const meta: Record<number, any> =
+    event._meta?.entries?.[breadcrumbEntryIndex]?.data?.values ?? {};
+
+  const enhancedCrumbs: EnhancedCrumb[] = breadcrumbs.map((raw, i) => ({
+    raw,
+    meta: meta[i],
+    // Converts breadcrumbs into other types if sufficient data is present.
+    breadcrumb: convertCrumbType(raw),
+  }));
+
+  // The virtual crumb is a representation of this event, displayed alongside
+  // the rest of the breadcrumbs for more additional context.
+  const virtualCrumb = getVirtualCrumb(event);
+  const allCrumbs = virtualCrumb
+    ? [...enhancedCrumbs, {breadcrumb: virtualCrumb}]
+    : enhancedCrumbs;
+
+  // Add display props
+  return allCrumbs.map(ec => ({
+    ...ec,
+    title: getBreadcrumbTitle(ec.breadcrumb.category),
+    colorConfig: getBreadcrumbColorConfig(ec.breadcrumb.type),
+    filter: getBreadcrumbFilter(ec.breadcrumb.type),
+    iconComponent: <BreadcrumbIcon type={ec.breadcrumb.type} />,
+    levelComponent: <BreadcrumbLevel level={ec.breadcrumb.level} />,
+  }));
+}
+
+function getBreadcrumbTitle(category: RawCrumb['category']) {
   switch (category) {
     case 'http':
-      return t('HTTP');
+    case 'xhr':
+      return category.toUpperCase();
     case 'httplib':
       return t('httplib');
     case 'ui.click':
@@ -108,7 +175,7 @@ export function getBreadcrumbTitle(category: RawCrumb['category']) {
   }
 }
 
-export function getBreadcrumbColorConfig(type?: BreadcrumbType): ColorConfig {
+function getBreadcrumbColorConfig(type?: BreadcrumbType): ColorConfig {
   switch (type) {
     case BreadcrumbType.ERROR:
       return {primary: 'red400', secondary: 'red200'};
@@ -116,24 +183,23 @@ export function getBreadcrumbColorConfig(type?: BreadcrumbType): ColorConfig {
       return {primary: 'yellow400', secondary: 'yellow200'};
     case BreadcrumbType.NAVIGATION:
     case BreadcrumbType.HTTP:
-      return {primary: 'green400', secondary: 'green200'};
-    case BreadcrumbType.INFO:
     case BreadcrumbType.QUERY:
-    case BreadcrumbType.UI:
-      return {primary: 'blue400', secondary: 'blue200'};
+    case BreadcrumbType.TRANSACTION:
+      return {primary: 'green400', secondary: 'green200'};
     case BreadcrumbType.USER:
-    case BreadcrumbType.DEBUG:
+    case BreadcrumbType.UI:
       return {primary: 'purple400', secondary: 'purple200'};
     case BreadcrumbType.SYSTEM:
     case BreadcrumbType.SESSION:
-    case BreadcrumbType.TRANSACTION:
       return {primary: 'pink400', secondary: 'pink200'};
+    case BreadcrumbType.DEBUG:
+    case BreadcrumbType.INFO:
     default:
       return {primary: 'gray300', secondary: 'gray200'};
   }
 }
 
-export function getBreadcrumbFilter(type?: BreadcrumbType) {
+function getBreadcrumbFilter(type?: BreadcrumbType) {
   switch (type) {
     case BreadcrumbType.USER:
     case BreadcrumbType.UI:
@@ -147,7 +213,7 @@ export function getBreadcrumbFilter(type?: BreadcrumbType) {
     case BreadcrumbType.ERROR:
       return t('Error');
     case BreadcrumbType.HTTP:
-      return t('HTTP request');
+      return t('HTTP Request');
     case BreadcrumbType.WARNING:
       return t('Warning');
     case BreadcrumbType.QUERY:
@@ -163,7 +229,7 @@ export function getBreadcrumbFilter(type?: BreadcrumbType) {
   }
 }
 
-export function BreadcrumbIcon({type}: {type?: BreadcrumbType}) {
+function BreadcrumbIcon({type}: {type?: BreadcrumbType}) {
   switch (type) {
     case BreadcrumbType.USER:
       return <IconUser size="xs" />;
@@ -194,7 +260,7 @@ export function BreadcrumbIcon({type}: {type?: BreadcrumbType}) {
   }
 }
 
-export function BreadcrumbTag({level}: {level: BreadcrumbLevelType}) {
+function BreadcrumbLevel({level}: {level: BreadcrumbLevelType}) {
   switch (level) {
     case BreadcrumbLevelType.ERROR:
     case BreadcrumbLevelType.FATAL:

--- a/static/app/components/events/interfaces/breadcrumbs/breadcrumb/data/sql.tsx
+++ b/static/app/components/events/interfaces/breadcrumbs/breadcrumb/data/sql.tsx
@@ -22,13 +22,11 @@ export function Sql({breadcrumb, searchTerm}: Props) {
         <code>
           {tokens.map((line, i) => (
             <div key={i}>
-              <div>
-                {line.map((token, j) => (
-                  <span key={j} className={token.className}>
-                    <Highlight text={searchTerm}>{token.children}</Highlight>
-                  </span>
-                ))}
-              </div>
+              {line.map((token, j) => (
+                <span key={j} className={token.className}>
+                  <Highlight text={searchTerm}>{token.children}</Highlight>
+                </span>
+              ))}
             </div>
           ))}
         </code>

--- a/static/app/components/events/interfaces/breadcrumbs/utils.tsx
+++ b/static/app/components/events/interfaces/breadcrumbs/utils.tsx
@@ -5,54 +5,40 @@ import type {Event} from 'sentry/types/event';
 import {EntryType} from 'sentry/types/event';
 import {defined} from 'sentry/utils';
 
+/**
+ * RawCrumb.type is used for filtering, icons and color. This function converts crumbs
+ * that have known categories into better types.
+ */
 export function convertCrumbType(breadcrumb: RawCrumb): RawCrumb {
   if (breadcrumb.type === BreadcrumbType.EXCEPTION) {
-    return {
-      ...breadcrumb,
-      type: BreadcrumbType.ERROR,
-    };
+    return {...breadcrumb, type: BreadcrumbType.ERROR};
   }
-  // special case for 'ui.' and `sentry.` category breadcrumbs
-  // TODO: find a better way to customize UI around non-schema data
+  const breadcrumbTypeSet = new Set<BreadcrumbType>(Object.values(BreadcrumbType));
+
   if (breadcrumb.type === BreadcrumbType.DEFAULT && defined(breadcrumb?.category)) {
     const [category, subcategory] = breadcrumb.category.split('.');
-    if (category === 'ui') {
-      return {
-        ...breadcrumb,
-        type: BreadcrumbType.UI,
-      };
+    if (breadcrumbTypeSet.has(category as BreadcrumbType)) {
+      // XXX: Type hack, instead of manually adding cases for BreadcrumbType.x when BreadcrumbType.x's
+      // enum value is the category, we just say it's the default and set it.
+      return {...breadcrumb, type: category as BreadcrumbType.DEFAULT};
     }
-
-    if (category === 'console') {
-      return {
-        ...breadcrumb,
-        type: BreadcrumbType.DEBUG,
-      };
-    }
-
-    if (category === 'navigation') {
-      return {
-        ...breadcrumb,
-        type: BreadcrumbType.NAVIGATION,
-      };
-    }
-
-    if (
-      category === 'sentry' &&
-      (subcategory === 'transaction' || subcategory === 'event')
-    ) {
-      return {
-        ...breadcrumb,
-        type: BreadcrumbType.TRANSACTION,
-      };
+    switch (category) {
+      case 'console':
+        return {...breadcrumb, type: BreadcrumbType.DEBUG};
+      case 'session':
+        return {...breadcrumb, type: BreadcrumbType.NAVIGATION};
+      case 'sentry':
+        if (subcategory === 'transaction' || subcategory === 'event') {
+          return {...breadcrumb, type: BreadcrumbType.TRANSACTION};
+        }
+        break;
+      default:
+        break;
     }
   }
 
-  if (!Object.values(BreadcrumbType).includes(breadcrumb.type)) {
-    return {
-      ...breadcrumb,
-      type: BreadcrumbType.DEFAULT,
-    };
+  if (!breadcrumbTypeSet.has(breadcrumb.type)) {
+    return {...breadcrumb, type: BreadcrumbType.DEFAULT};
   }
 
   return breadcrumb;

--- a/static/app/components/timeline/index.tsx
+++ b/static/app/components/timeline/index.tsx
@@ -1,4 +1,5 @@
 import {type CSSProperties, useRef} from 'react';
+import {forwardRef} from 'react';
 import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 
@@ -32,18 +33,21 @@ export interface TimelineItemProps {
   style?: CSSProperties;
 }
 
-export function Item({
-  title,
-  children,
-  icon,
-  timeString,
-  colorConfig = {primary: 'gray300', secondary: 'gray200'},
-  startTimeString,
-  renderTimestamp,
-  isActive = false,
-  style,
-  ...props
-}: TimelineItemProps) {
+export const Item = forwardRef(function _Item(
+  {
+    title,
+    children,
+    icon,
+    timeString,
+    colorConfig = {primary: 'gray300', secondary: 'gray200'},
+    startTimeString,
+    renderTimestamp,
+    isActive = false,
+    style,
+    ...props
+  }: TimelineItemProps,
+  ref: React.ForwardedRef<HTMLDivElement>
+) {
   const theme = useTheme();
   const placeholderTime = useRef(new Date().toTimeString()).current;
   const {primary, secondary} = colorConfig;
@@ -63,6 +67,7 @@ export function Item({
         borderBottom: `1px solid ${isActive ? theme[secondary] : 'transparent'}`,
         ...style,
       }}
+      ref={ref}
       {...props}
     >
       <IconWrapper
@@ -91,29 +96,7 @@ export function Item({
       </Content>
     </Row>
   );
-}
-
-interface GroupProps {
-  children: React.ReactNode;
-}
-
-export function Container({children}: GroupProps) {
-  return <Wrapper>{children}</Wrapper>;
-}
-
-const Wrapper = styled('div')`
-  position: relative;
-  /* vertical line connecting items */
-  &::before {
-    content: '';
-    position: absolute;
-    left: 10.5px;
-    width: 1px;
-    top: 0;
-    bottom: 0;
-    background: ${p => p.theme.border};
-  }
-`;
+});
 
 const Row = styled('div')`
   position: relative;
@@ -192,6 +175,20 @@ export const Data = styled('div')`
   position: relative;
   &:only-child {
     margin-top: 0;
+  }
+`;
+
+export const Container = styled('div')`
+  position: relative;
+  /* vertical line connecting items */
+  &::before {
+    content: '';
+    position: absolute;
+    left: 10.5px;
+    width: 1px;
+    top: 0;
+    bottom: 0;
+    background: ${p => p.theme.border};
   }
 `;
 

--- a/static/app/components/timeline/index.tsx
+++ b/static/app/components/timeline/index.tsx
@@ -59,7 +59,6 @@ export function Item({
   return (
     <Row
       color={secondary}
-      hasLowerBorder={isActive}
       style={{
         borderBottom: `1px solid ${isActive ? theme[secondary] : 'transparent'}`,
         ...style,
@@ -83,7 +82,13 @@ export function Item({
       <Spacer
         style={{borderLeft: `1px solid ${isActive ? theme.border : 'transparent'}`}}
       />
-      <Content>{children}</Content>
+      <Content
+        style={{
+          marginBottom: `${isActive ? space(1) : 0}`,
+        }}
+      >
+        {children}
+      </Content>
     </Row>
   );
 }
@@ -110,7 +115,7 @@ const Wrapper = styled('div')`
   }
 `;
 
-const Row = styled('div')<{hasLowerBorder: boolean}>`
+const Row = styled('div')`
   position: relative;
   color: ${p => p.theme.subText};
   display: grid;
@@ -124,10 +129,6 @@ const Row = styled('div')<{hasLowerBorder: boolean}>`
   &:last-child {
     margin-bottom: 0;
     background: ${p => p.theme.background};
-  }
-  &:last-child > :last-child,
-  &:first-child > :last-child {
-    margin-bottom: ${p => (p.hasLowerBorder ? space(1) : 0)};
   }
 `;
 
@@ -145,7 +146,6 @@ const IconWrapper = styled('div')`
 
 const Title = styled('div')`
   font-weight: bold;
-  text-transform: capitalize;
   text-align: left;
   grid-column: span 1;
   font-size: ${p => p.theme.fontSizeMedium};

--- a/static/app/components/timeline/index.tsx
+++ b/static/app/components/timeline/index.tsx
@@ -143,8 +143,7 @@ const IconWrapper = styled('div')`
   }
 `;
 
-const Title = styled('p')`
-  margin: 0;
+const Title = styled('div')`
   font-weight: bold;
   text-transform: capitalize;
   text-align: left;

--- a/static/app/utils/analytics/issueAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/issueAnalyticsEvents.tsx
@@ -55,6 +55,9 @@ export type IssueEventParameters = {
     setup_integration: boolean;
     setup_write_integration: boolean;
   };
+  'breadcrumbs.drawer.action': {control: string; value?: string};
+  'breadcrumbs.issue_details.change_time_display': {value: string};
+  'breadcrumbs.issue_details.drawer_opened': {control: string};
   'device.classification.high.end.android.device': {
     processor_count: number;
     processor_frequency: number;
@@ -294,6 +297,9 @@ export type IssueEventKey = keyof IssueEventParameters;
 
 export const issueEventMap: Record<IssueEventKey, string | null> = {
   'autofix.setup_modal_viewed': 'Autofix: Setup Modal Viewed',
+  'breadcrumbs.issue_details.change_time_display': 'Breadcrumb Time Display Toggled',
+  'breadcrumbs.issue_details.drawer_opened': 'Breadcrumb Drawer Opened',
+  'breadcrumbs.drawer.action': 'Breadcrumb Drawer Action Taken',
   'event_cause.viewed': null,
   'event_cause.docs_clicked': 'Event Cause Docs Clicked',
   'event_cause.snoozed': 'Event Cause Snoozed',


### PR DESCRIPTION
Relates to https://github.com/getsentry/sentry/issues/72504

These match the current design for breadcrumbs contents:

**Errors:**
<img width="1119" alt="image" src="https://github.com/getsentry/sentry/assets/35509934/d6eb99f1-9045-4ea9-802f-7339c586bdc3">
<img width="1130" alt="image" src="https://github.com/getsentry/sentry/assets/35509934/6468c78e-0c28-4e99-97e1-198586b69774">

**HTTP Requests:**
<img width="1072" alt="image" src="https://github.com/getsentry/sentry/assets/35509934/17cbf94c-5cdf-4f51-84b4-7ad582836b67">
<img width="1072" alt="image" src="https://github.com/getsentry/sentry/assets/35509934/14ff8e7c-e2cb-4891-9a18-9f0e1993fa93">

**SQL Queries:**
<img width="1112" alt="image" src="https://github.com/getsentry/sentry/assets/35509934/f10b3d68-fbea-466e-a01b-a90e88859f7f">
<img width="837" alt="image" src="https://github.com/getsentry/sentry/assets/35509934/e8da77eb-d6bb-446d-b02e-5a6eca67b971">

There's also a bit of a refactor here to fix an issue with meta values. The `meta` map is keyed on the original index of the breadcrumb on the event payload, which meant that adding virtual crumbs and resorting/filtering would make it inaccessible. With this 'EnhancedBreadcrumb' type, all of the data associated with the crumb stays with it, making it easier to change in the future.