### PR TITLE
chore(tests): Auto-format `rawContent` tests

### DIFF
--- a/static/app/components/events/interfaces/crashContent/stackTrace/rawContent.spec.tsx
+++ b/static/app/components/events/interfaces/crashContent/stackTrace/rawContent.spec.tsx
@@ -7,9 +7,9 @@ import displayRawContent, {
 } from 'sentry/components/events/interfaces/crashContent/stackTrace/rawContent';
 import type {StacktraceType} from 'sentry/types';
 
-describe('RawStacktraceContent', function () {
-  describe('getJavaFrame()', function () {
-    it('should render java frames', function () {
+describe('RawStacktraceContent', () => {
+  describe('getJavaFrame()', () => {
+    it('should render java frames', () => {
       expect(
         getJavaFrame(
           FrameFixture({
@@ -51,7 +51,7 @@ describe('RawStacktraceContent', function () {
     });
   });
 
-  describe('getJavaPreamble()', function () {
+  describe('getJavaPreamble()', () => {
     it('takes a type and value', () => {
       expect(
         getJavaPreamble(
@@ -77,7 +77,7 @@ describe('RawStacktraceContent', function () {
     });
   });
 
-  describe('render()', function () {
+  describe('render()', () => {
     const exception = ExceptionValueFixture({
       module: 'example.application',
       type: 'Error',


### PR DESCRIPTION
A bit of auto-formatting I pulled out of a recent PR to make it easier to review.