### PR TITLE
fix(feedback): Improve feedback queryKey construction to prevent missing statsPeriod or start/end times

### DIFF
--- a/static/app/components/feedback/useFeedbackListQueryKey.tsx
+++ b/static/app/components/feedback/useFeedbackListQueryKey.tsx
@@ -2,7 +2,7 @@ import {useMemo} from 'react';
 
 import decodeMailbox from 'sentry/components/feedback/decodeMailbox';
 import type {Organization} from 'sentry/types/organization';
-import {intervalToMilliseconds} from 'sentry/utils/duration/intervalToMilliseconds';
+import coaleseIssueStatsPeriodQuery from 'sentry/utils/feedback/coaleseIssueStatsPeriodQuery';
 import type {ApiQueryKey} from 'sentry/utils/queryClient';
 import {decodeList, decodeScalar} from 'sentry/utils/queryString';
 import useLocationQuery from 'sentry/utils/url/useLocationQuery';
@@ -14,7 +14,6 @@ interface Props {
 }
 
 const PER_PAGE = 25;
-const ONE_DAY_MS = intervalToMilliseconds('1d');
 
 export default function useFeedbackListQueryKey({
   listHeadTime,
@@ -37,41 +36,16 @@ export default function useFeedbackListQueryKey({
     },
   });
 
-  const queryViewWithStatsPeriod = useMemo(() => {
-    // We don't want to use `statsPeriod` directly, because that will mean the
-    // start time of our infinite list will change, shifting the index/page
-    // where items appear if we invalidate the cache and refetch specific pages.
-    // So we'll convert statsPeriod into start/end time here, and use that. When
-    // the user wants to see fresher content (like, after the page has been open
-    // for a while) they can trigger that specifically.
-
-    // The issues endpoint cannot handle when statsPeroid has a value of "", so
-    // we remove that from the rest and do not use it to query.
-    const {statsPeriod, ...rest} = queryView;
-
-    // Usually we want to fetch starting from `now` and looking back in time.
-    // `prefetch` in this case changes the mode: instead of looking back, we want
-    // to look forward for new data, and fetch it before it's time to render.
-    // Note: The ApiQueryKey that we return isn't actually for a full page of
-    // prefetched data, it's just one row actually.
-    if (prefetch) {
-      if (!statsPeriod) {
-        // We shouldn't prefetch if the query uses an absolute date range
-        return undefined;
-      }
-      // Look 1 day into the future, from the time the page is loaded for new
-      // feedbacks to come in.
-      const intervalMS = ONE_DAY_MS;
-      const start = new Date(listHeadTime).toISOString();
-      const end = new Date(listHeadTime + intervalMS).toISOString();
-      return statsPeriod ? {...rest, limit: 1, start, end} : undefined;
-    }
-
-    const intervalMS = intervalToMilliseconds(statsPeriod);
-    const start = new Date(listHeadTime - intervalMS).toISOString();
-    const end = new Date(listHeadTime).toISOString();
-    return statsPeriod ? {...rest, start, end} : rest;
-  }, [listHeadTime, prefetch, queryView]);
+  const queryViewWithStatsPeriod = useMemo(
+    () =>
+      coaleseIssueStatsPeriodQuery({
+        defaultStatsPeriod: '0d',
+        listHeadTime,
+        prefetch,
+        queryView,
+      }),
+    [listHeadTime, prefetch, queryView]
+  );
 
   return useMemo(() => {
     if (!queryViewWithStatsPeriod) {

--- a/static/app/components/feedback/useFeedbackQueryKeys.tsx
+++ b/static/app/components/feedback/useFeedbackQueryKeys.tsx
@@ -39,9 +39,9 @@ export function FeedbackQueryKeys({children, organization}: Props) {
   // the list (the head element in the array); the same time as when we loaded
   // the page. It can be updated without loading the page, when we want to see
   // fresh list items.
-  const [listHeadTime, setHeadTime] = useState(() => Date.now());
+  const [listHeadTime, setHeadTimeMs] = useState(() => Date.now());
   const resetListHeadTime = useCallback(() => {
-    setHeadTime(Date.now());
+    setHeadTimeMs(Date.now());
   }, []);
 
   const itemQueryKeyRef = useRef<Map<string, ItemQueryKeys>>(new Map());

--- a/static/app/utils/feedback/coaleseIssueStatsPeriodQuery.spec.tsx
+++ b/static/app/utils/feedback/coaleseIssueStatsPeriodQuery.spec.tsx
@@ -1,0 +1,47 @@
+import coaleseIssueStatsPeriodQuery from 'sentry/utils/feedback/coaleseIssueStatsPeriodQuery';
+
+const Jan1st = new Date('2024-01-01');
+const Oct31 = new Date('2024-10-31');
+
+describe('coaleseIssueStatsPeriodQuery', () => {
+  it('should convert a statsPeriod into start+end fields', () => {
+    const result = coaleseIssueStatsPeriodQuery({
+      listHeadTime: Oct31.getTime(),
+      queryView: {statsPeriod: '14d'},
+    });
+    expect(result).toEqual({
+      start: '2024-10-17T00:00:00.000Z', // Oct 18, 14 days earlier
+      end: '2024-10-31T00:00:00.000Z', // Oct 31
+    });
+  });
+
+  it('should default to 0d when statsPeriod is missing', () => {
+    const result = coaleseIssueStatsPeriodQuery({
+      listHeadTime: Oct31.getTime(),
+      queryView: {statsPeriod: ''},
+    });
+    expect(result).toEqual({});
+  });
+
+  it('should ignore statsPeriod and start+end fields that have 1 day between them when prefetch is true', () => {
+    const result = coaleseIssueStatsPeriodQuery({
+      listHeadTime: Jan1st.getTime(),
+      queryView: {statsPeriod: '14d'},
+      prefetch: true,
+    });
+    expect(result).toEqual({
+      limit: 1,
+      start: '2024-01-01T00:00:00.000Z', // Jan 1st
+      end: '2024-01-02T00:00:00.000Z', // Jan 2nd, one day laters
+    });
+  });
+
+  it('should undefined when there is no statsPeriod and prefetch is true', () => {
+    const result = coaleseIssueStatsPeriodQuery({
+      listHeadTime: Jan1st.getTime(),
+      queryView: {statsPeriod: ''},
+      prefetch: true,
+    });
+    expect(result).toBeUndefined();
+  });
+});

--- a/static/app/utils/feedback/coaleseIssueStatsPeriodQuery.tsx
+++ b/static/app/utils/feedback/coaleseIssueStatsPeriodQuery.tsx
@@ -1,0 +1,49 @@
+import {intervalToMilliseconds} from 'sentry/utils/duration/intervalToMilliseconds';
+
+const ONE_DAY_MS = intervalToMilliseconds('1d');
+
+interface Props<QueryView extends {statsPeriod: string}> {
+  listHeadTime: number;
+  queryView: QueryView;
+  defaultStatsPeriod?: string;
+  prefetch?: boolean;
+}
+
+export default function coaleseIssueStatsPeriodQuery<
+  QueryView extends {statsPeriod: string},
+>({queryView, listHeadTime, defaultStatsPeriod, prefetch = false}: Props<QueryView>) {
+  // We don't want to use `statsPeriod` directly, because that will mean the
+  // start time of our infinite list will change, shifting the index/page
+  // where items appear if we invalidate the cache and refetch specific pages.
+  // So we'll convert statsPeriod into start/end time here, and use that. When
+  // the user wants to see fresher content (like, after the page has been open
+  // for a while) they can trigger that specifically.
+
+  // The issues endpoint cannot handle when statsPeroid has a value of "", so
+  // we remove that from the rest and do not use it to query.
+
+  // Usually we want to fetch starting from `now` and looking back in time.
+  // `prefetch` in this case changes the mode: instead of looking back, we want
+  // to look forward for new data, and fetch it before it's time to render.
+  // Note: The ApiQueryKey that we return isn't actually for a full page of
+  // prefetched data, it's just one row actually.
+  if (prefetch) {
+    const {statsPeriod, ...rest} = queryView;
+    if (!statsPeriod) {
+      // We shouldn't prefetch if the query uses an absolute date range
+      return undefined;
+    }
+    // Look 1 day into the future, from the time the page is loaded for new
+    // feedbacks to come in.
+    const intervalMS = ONE_DAY_MS;
+    const start = new Date(listHeadTime).toISOString();
+    const end = new Date(listHeadTime + intervalMS).toISOString();
+    return statsPeriod ? {...rest, limit: 1, start, end} : undefined;
+  }
+
+  const {statsPeriod = defaultStatsPeriod, ...rest} = queryView;
+  const intervalMS = intervalToMilliseconds(statsPeriod ?? '');
+  const start = new Date(listHeadTime - intervalMS).toISOString();
+  const end = new Date(listHeadTime).toISOString();
+  return statsPeriod ? {...rest, start, end} : rest;
+}


### PR DESCRIPTION
Sometimes we were seeing the `/issues/` endpoint return`{"detail":"Invalid statsPeriod: ''"}`, usually from the mailbox-count query. Related sometimes the issue-list query is missing start/end date bounds, resulting in huge table scans which are either unnecessary, but always slower than what we expect. 

This applies some queryKey checks to the mailbox-count query, and tries to prevent unbounded (in time) queries from happening, by applying a default statsPeriod if needed.

Related to https://github.com/getsentry/sentry/issues/67412