### PR TITLE
style(alerts): Change copy of mute alert link

### DIFF
--- a/src/sentry/templates/sentry/emails/digests/body.html
+++ b/src/sentry/templates/sentry/emails/digests/body.html
@@ -34,7 +34,7 @@
       <div class="container">
         {% with rule_details=rules_details|get_item:rule.id snooze_alert_url=snooze_alert_urls|get_item:rule.id %}
         {% if snooze_alert %}
-            <a class="mute" href="{% absolute_uri snooze_alert_url %}">Mute this alert</a>
+            <a class="mute" href="{% absolute_uri snooze_alert_url %}">Mute this alert for everyone</a>
         {% endif %}
             This email was triggered by <a href="{% absolute_uri rule_details.status_url %}">{{ rule_details.label }}</a>
         {% endwith %}

--- a/src/sentry/templates/sentry/emails/feedback.html
+++ b/src/sentry/templates/sentry/emails/feedback.html
@@ -191,7 +191,7 @@
 
     <p class="info-box">
       {% if snooze_alert %}
-         <a class='mute' href="{% absolute_uri snooze_alert_url %}">Mute this alert</a>
+         <a class='mute' href="{% absolute_uri snooze_alert_url %}">Mute this alert for everyone</a>
       {% endif %}
       This email was triggered by
       {% for rule in rules %}

--- a/src/sentry/templates/sentry/emails/incidents/trigger.html
+++ b/src/sentry/templates/sentry/emails/incidents/trigger.html
@@ -83,7 +83,7 @@
 
       <p class="info-box">
         {% if snooze_alert %}
-           <a class='mute' href="{{ snooze_alert_url }}">Mute this alert</a>
+           <a class='mute' href="{{ snooze_alert_url }}">Mute this alert for everyone</a>
         {% endif %}
         This email was triggered by
             <a href="{{ link }}">{{ incident_name }}</a>

--- a/src/sentry/templates/sentry/emails/issue_alert_base.html
+++ b/src/sentry/templates/sentry/emails/issue_alert_base.html
@@ -296,7 +296,7 @@
 
     <p class="info-box">
       {% if snooze_alert %}
-         <a class='mute' href="{% absolute_uri snooze_alert_url %}">Mute this alert</a>
+         <a class='mute' href="{% absolute_uri snooze_alert_url %}">Mute this alert for everyone</a>
       {% endif %}
       This email was triggered by
       {% for rule in rules %}


### PR DESCRIPTION
Change the link text for muting email alerts from "Mute this alert" to "Mute this alert for everyone."

Fixes GH-69792
