### PR TITLE
fix(similarity): up retries

### DIFF
--- a/src/sentry/tasks/embeddings_grouping/backfill_seer_grouping_records_for_project.py
+++ b/src/sentry/tasks/embeddings_grouping/backfill_seer_grouping_records_for_project.py
@@ -35,7 +35,7 @@ logger = logging.getLogger(__name__)
 @instrumented_task(
     name="sentry.tasks.backfill_seer_grouping_records",
     queue="backfill_seer_grouping_records",
-    max_retries=0,
+    max_retries=5,
     silo_mode=SiloMode.REGION,
     soft_time_limit=60 * 15,
     time_limit=60 * 15 + 5,


### PR DESCRIPTION
observed this happen and our backfill terminating. need to allow for retries as sometimes the celery worker will get killed https://sentry.sentry.io/issues/2733785806/?project=1&referrer=tag-distribution-meter&sort=date