### PR TITLE
[CapMan visibility] emit Sentry warning and GCP log for sampled throttled queries

### DIFF
--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -1116,7 +1116,7 @@ def _bulk_snuba_query(snuba_requests: Sequence[SnubaRequest]) -> ResultSet:
                     if random.random() < 0.01:
                         logger.warning("Query is throttled", extra={"response.data": response.data})
                         sentry_sdk.capture_message(
-                            f"Query from referrer {referrer} is throttled", level="info"
+                            f"Query from referrer {referrer} is throttled", level="warning"
                         )
 
             if response.status != 200:


### PR DESCRIPTION
Redeploying https://github.com/getsentry/sentry/pull/73709 after https://github.com/getsentry/getsentry/pull/14526