### PR TITLE
feat(seer grouping): Call seer deletion task when parent group not found

### DIFF
--- a/src/sentry/seer/similarity/similar_issues.py
+++ b/src/sentry/seer/similarity/similar_issues.py
@@ -13,6 +13,7 @@ from sentry.seer.similarity.types import (
     SimilarGroupNotFoundError,
     SimilarIssuesEmbeddingsRequest,
 )
+from sentry.tasks.delete_seer_grouping_records import delete_seer_grouping_records_by_hash
 from sentry.utils import json, metrics
 from sentry.utils.json import JSONDecodeError, apply_key_filter
 
@@ -200,19 +201,19 @@ def get_similarity_data_from_seer(
                 },
             )
         except SimilarGroupNotFoundError:
-            # This will similarly mark the entire request as errored even if it's only one group
-            # that we can't find, but again, we're okay with that because a group being missing
-            # implies there's something wrong with our deletion logic, which is a problem to which
-            # we want to pay attention.
-            #
-            # TODO: The deletion logic (tell Seer to delete hashes as soon as they're deleted on the
-            # Sentry side) comes with an inherent slight delay - the request to Seer happens async, and
-            # requests between services aren't instantaneous. It's therefore possible for us to land
-            # in a race condition, where Seer recommends a hash it doesn't know it's about to be
-            # asked to delete, and we come up empty because on the Sentry side the hash has already
-            # been deleted.
             parent_hash = raw_similar_issue_data.get("parent_hash")
 
+            # Tell Seer to delete the hash from its database, so it doesn't keep suggesting a group
+            # which doesn't exist
+            delete_seer_grouping_records_by_hash.delay(project_id, [parent_hash])
+
+            # As with the `IncompleteSeerDataError` above, this will mark the entire request as
+            # errored even if it's only one group that we can't find. The extent to which that's
+            # inaccurate will be quite small, though, as the vast majority of calls to this function
+            # come from ingest (where we're only requesting one matching group, making "one's
+            # missing" the same thing as "they're all missing"). We should also almost never land
+            # here in any case, since deleting the group on the Sentry side should already have
+            # triggered a request to Seer to delete the corresponding hashes.
             metric_tags.update({"outcome": "error", "error": "SimilarGroupNotFoundError"})
             logger.warning(
                 "get_similarity_data_from_seer.parent_group_not_found",


### PR DESCRIPTION
In theory, the Seer database should never contain outdated hashes (that is, hashes whose corresponding group no longer exists on the Sentry side), because group deletion in Sentry triggers a call to the hash deletion endpoint in Seer. That said, things happen.

If/when they do, one potential outcome is that the Seer similarity endpoint will respond with an outdated hash rather than the closest still-existing one. In case this happens, we want to let Seer know so it can delete the hash. This PR therefore adds a call to the Seer hash-deletion task which will fire whenever `get_similarity_data_from_seer` encounters a `SimilarGroupNotFoundError`.