### PR TITLE
fix(metrics): span.duration counter condition

### DIFF
--- a/src/sentry/snuba/metrics/span_attribute_extraction.py
+++ b/src/sentry/snuba/metrics/span_attribute_extraction.py
@@ -149,7 +149,7 @@ def _get_rule_condition(
 
 def _get_counter_rule_condition(
     extraction_rule: MetricsExtractionRule, parsed_conditions: Sequence[QueryToken]
-) -> RuleCondition:
+) -> RuleCondition | None:
     is_top_level = extraction_rule.span_attribute in _TOP_LEVEL_SPAN_ATTRIBUTES
 
     if not parsed_conditions:

--- a/tests/sentry/relay/config/test_metric_extraction.py
+++ b/tests/sentry/relay/config/test_metric_extraction.py
@@ -2155,16 +2155,7 @@ def test_get_span_attribute_metrics(default_project: Project) -> None:
         assert sorted(config["metrics"], key=lambda x: x["mri"]) == [
             {
                 "category": "span",
-                "condition": {
-                    "inner": [
-                        {"name": "span.data.bar", "op": "eq", "value": "baz"},
-                        {
-                            "inner": {"name": "span.duration", "op": "eq", "value": None},
-                            "op": "not",
-                        },
-                    ],
-                    "op": "and",
-                },
+                "condition": {"name": "span.data.bar", "op": "eq", "value": "baz"},
                 "field": None,
                 "mri": "c:custom/span_attribute_1@none",
                 "tags": [
@@ -2174,16 +2165,7 @@ def test_get_span_attribute_metrics(default_project: Project) -> None:
             },
             {
                 "category": "span",
-                "condition": {
-                    "inner": [
-                        {"name": "span.data.abc", "op": "eq", "value": "xyz"},
-                        {
-                            "inner": {"name": "span.duration", "op": "eq", "value": None},
-                            "op": "not",
-                        },
-                    ],
-                    "op": "and",
-                },
+                "condition": {"name": "span.data.abc", "op": "eq", "value": "xyz"},
                 "field": None,
                 "mri": "c:custom/span_attribute_2@none",
                 "tags": [

--- a/tests/sentry/snuba/metrics/test_span_attribute_extraction.py
+++ b/tests/sentry/snuba/metrics/test_span_attribute_extraction.py
@@ -170,6 +170,22 @@ def test_counter_extends_conditions():
     }
 
 
+def test_span_duration_counter_not_extends_conditions():
+    rule = MetricsExtractionRule(
+        span_attribute="span.duration", type="c", unit="none", tags=set(), condition="abc:xyz", id=1
+    )
+
+    metric_spec = convert_to_metric_spec(rule)
+
+    assert not metric_spec["field"]
+    assert metric_spec["mri"] == "c:custom/span_attribute_1@none"
+    assert metric_spec["condition"] == {
+        "op": "eq",
+        "name": "span.data.abc",
+        "value": "xyz",
+    }
+
+
 def test_empty_conditions():
     rule = MetricsExtractionRule(
         span_attribute="foobar", type="d", unit="none", tags=set(), condition="", id=1


### PR DESCRIPTION
Provides a workaround for `span.duration` counter metrics