### PR TITLE
feat(metrics): Add option to control the rollout of the metrics summaries computation

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1099,6 +1099,11 @@ register("relay.force_full_normalization", default=False, flags=FLAG_AUTOMATOR_M
 # Controls whether processing relays should skip normalization.
 register("relay.disable_normalization.processing", default=False, flags=FLAG_AUTOMATOR_MODIFIABLE)
 
+# Controls the sample rate of metrics summaries computation in Relay.
+register(
+    "relay.compute-metrics-summaries.sample-rate", default=0.0, flags=FLAG_AUTOMATOR_MODIFIABLE
+)
+
 # Write new kafka headers in eventstream
 register("eventstream:kafka-headers", default=True, flags=FLAG_AUTOMATOR_MODIFIABLE)
 

--- a/src/sentry/relay/globalconfig.py
+++ b/src/sentry/relay/globalconfig.py
@@ -26,6 +26,7 @@ RELAY_OPTIONS: list[str] = [
     "relay.span-extraction.sample-rate",
     "relay.force_full_normalization",
     "relay.disable_normalization.processing",
+    "relay.compute-metrics-summaries.sample-rate",
 ]
 
 

--- a/tests/sentry/api/endpoints/test_relay_globalconfig_v3.py
+++ b/tests/sentry/api/endpoints/test_relay_globalconfig_v3.py
@@ -46,6 +46,7 @@ def call_endpoint(client, relay, private_key):
         "profiling.generic_metrics.functions_ingestion.enabled": True,
         "relay.disable_normalization.processing": True,
         "relay.force_full_normalization": True,
+        "relay.compute-metrics-summaries.sample-rate": 1.0,
         "relay.metric-bucket-distribution-encodings": {
             "custom": "array",
             "metric_stats": "array",


### PR DESCRIPTION
Related to: https://github.com/getsentry/relay/pull/3769