### PR TITLE
feat(metrics-extraction): Simplify metrics meta stitching

### DIFF
--- a/static/app/components/metrics/queryBuilder.tsx
+++ b/static/app/components/metrics/queryBuilder.tsx
@@ -67,9 +67,12 @@ export const QueryBuilder = memo(function QueryBuilder({
     resolveVirtualMRI,
   ]);
 
-  const {data: tagsData = [], isLoading: tagsIsLoading} = useMetricsTags(resolvedMRI, {
-    projects: projectIds,
-  });
+  const {data: tagsData = [], isLoading: tagsIsLoading} = useMetricsTags(
+    metricsQuery.mri,
+    {
+      projects: projectIds,
+    }
+  );
 
   const groupByOptions = useMemo(() => {
     return uniqBy(tagsData, 'key').map(tag => ({

--- a/static/app/utils/metrics/useMetricsMeta.tsx
+++ b/static/app/utils/metrics/useMetricsMeta.tsx
@@ -75,11 +75,8 @@ export const useVirtualizedMetricsMeta = (
   isRefetching: boolean;
   refetch: () => void;
 } => {
-  const {
-    getVirtualMRI,
-    getVirtualMeta,
-    isLoading: isVirtualMetricsContextLoading,
-  } = useVirtualMetricsContext();
+  const {virtualMeta, isLoading: isVirtualMetricsContextLoading} =
+    useVirtualMetricsContext();
 
   const {data, isLoading, isRefetching, refetch} = useMetricsMeta(
     pageFilters,
@@ -89,28 +86,13 @@ export const useVirtualizedMetricsMeta = (
   );
 
   const newMeta = useMemo(() => {
-    const virtualMetrics = new Set<MRI>();
-    // Filter all extracted custom metrics and map them to virtual metrics
+    // Filter all extracted custom metrics and mix them in from the virtual context
     const otherMetrics = data.filter(meta => {
-      if (!isExtractedCustomMetric(meta)) {
-        return true;
-      }
-
-      const virtualMRI = getVirtualMRI(meta.mri);
-      // If there is no virtual MRI, we don't want to show this metric
-      if (!virtualMRI) {
-        return false;
-      }
-
-      virtualMetrics.add(virtualMRI);
-      return false;
+      return !isExtractedCustomMetric(meta);
     });
 
-    // Add virtual metrics to the list and sort the array again
-    const virtualMeta = Array.from(virtualMetrics).map(mri => getVirtualMeta(mri));
-
     return sortMeta([...otherMetrics, ...virtualMeta]);
-  }, [data, getVirtualMRI, getVirtualMeta]);
+  }, [data, virtualMeta]);
 
   return {
     data: newMeta,

--- a/static/app/utils/metrics/virtualMetricsContext.spec.tsx
+++ b/static/app/utils/metrics/virtualMetricsContext.spec.tsx
@@ -1,7 +1,4 @@
-import {
-  createMRIToVirtualMap,
-  createSpanAttributeProjectIdMap,
-} from 'sentry/utils/metrics/virtualMetricsContext';
+import {createMRIToVirtualMap} from 'sentry/utils/metrics/virtualMetricsContext';
 
 describe('createMRIToVirtualMap', () => {
   it('creates a mapping', () => {
@@ -42,48 +39,6 @@ describe('createMRIToVirtualMap', () => {
         ['c:custom/mri2@none', 'v:custom/span1|1@none'],
         ['c:custom/mri3@none', 'v:custom/span2|2@millisecond'],
         ['c:custom/mri4@none', 'v:custom/span2|2@millisecond'],
-      ])
-    );
-  });
-});
-
-describe('createSpanAttributeProjectIdMap', () => {
-  it('creates a mapping', () => {
-    const rules = [
-      {
-        spanAttribute: 'span1',
-        projectId: 1,
-        aggregates: [],
-        tags: [],
-        unit: 'none',
-        conditions: [
-          {
-            id: 1,
-            value: 'value',
-            mris: ['c:custom/mri1@none' as const, 'c:custom/mri2@none' as const],
-          },
-        ],
-      },
-      {
-        spanAttribute: 'span2',
-        projectId: 2,
-        aggregates: [],
-        tags: [],
-        unit: 'none',
-        conditions: [
-          {
-            id: 2,
-            value: 'value',
-            mris: ['c:custom/mri3@none' as const, 'c:custom/mri4@none' as const],
-          },
-        ],
-      },
-    ];
-    const result = createSpanAttributeProjectIdMap(rules);
-    expect(result).toEqual(
-      new Map([
-        ['span1', [1]],
-        ['span2', [2]],
       ])
     );
   });


### PR DESCRIPTION
Use the extraction rules as single source of truth for custom metrics.
Fix a bug where a custom metrics would be associated with multiple projects.

Note: This has the effect that metrics are immediately visible after rule creation, even if there is no data yet.