### PR TITLE
fix(metrics) Separate tags and attributes options

### DIFF
--- a/static/app/views/settings/projectMetrics/metricsExtractionRuleForm.tsx
+++ b/static/app/views/settings/projectMetrics/metricsExtractionRuleForm.tsx
@@ -40,7 +40,7 @@ interface Props extends Omit<FormProps, 'onSubmit'> {
   ) => void;
 }
 
-const KNOWN_NUMERIC_FIELDS = new Set([
+const HIGH_CARDINALITY_TAGS = new Set([
   SpanIndexedField.SPAN_DURATION,
   SpanIndexedField.SPAN_SELF_TIME,
   SpanIndexedField.PROJECT_ID,
@@ -194,7 +194,7 @@ export function MetricsExtractionRuleForm({isEdit, project, onSubmit, ...props}:
     return allAttributeOptions
       .filter(
         // We don't want to suggest numeric fields as tags as they would explode cardinality
-        option => !KNOWN_NUMERIC_FIELDS.has(option as SpanIndexedField)
+        option => !HIGH_CARDINALITY_TAGS.has(option as SpanIndexedField)
       )
       .map(option => ({
         label: option,


### PR DESCRIPTION
Fix for a bug when span attributes which had extraction rule were showing as disabled in tags section.

## Before
![image](https://github.com/getsentry/sentry/assets/26199428/cda48413-0437-48b9-98ef-698f8ffbea0a)

## After
![image](https://github.com/getsentry/sentry/assets/26199428/211b2668-93a1-4f39-b32c-efd88718184d)

Order of items is different in images, but it can be seen that `browser.name` is not disabled anymore
