### PR TITLE
feat(metrics-extraction): Support extracted metrics in dashboard

### DIFF
--- a/static/app/utils/metrics/useMetricsQuery.tsx
+++ b/static/app/utils/metrics/useMetricsQuery.tsx
@@ -185,6 +185,7 @@ export function useMetricsQuery(
           return query;
         }
         const {type} = parseMRI(query.mri);
+
         if (type !== 'v' || !query.condition) {
           return query;
         }

--- a/static/app/views/dashboards/metrics/types.tsx
+++ b/static/app/views/dashboards/metrics/types.tsx
@@ -11,6 +11,7 @@ export interface DashboardMetricsQuery {
   orderBy: Order;
   type: MetricExpressionType.QUERY;
   alias?: string;
+  condition?: number;
   groupBy?: string[];
   isQueryOnly?: boolean;
   limit?: number;

--- a/static/app/views/dashboards/metrics/widgetCard.tsx
+++ b/static/app/views/dashboards/metrics/widgetCard.tsx
@@ -15,6 +15,7 @@ import type {Organization} from 'sentry/types/organization';
 import {parseMRI} from 'sentry/utils/metrics/mri';
 import {MetricExpressionType} from 'sentry/utils/metrics/types';
 import {useMetricsQuery} from 'sentry/utils/metrics/useMetricsQuery';
+import {useVirtualMetricsContext} from 'sentry/utils/metrics/virtualMetricsContext';
 import {MetricBigNumberContainer} from 'sentry/views/dashboards/metrics/bigNumber';
 import {MetricChartContainer} from 'sentry/views/dashboards/metrics/chart';
 import {MetricTableContainer} from 'sentry/views/dashboards/metrics/table';
@@ -64,18 +65,23 @@ export function MetricWidgetCard({
   renderErrorMessage,
   showContextMenu = true,
 }: Props) {
+  const {getVirtualMRIQuery} = useVirtualMetricsContext();
+
   const metricQueries = useMemo(
-    () => expressionsToApiQueries(getMetricExpressions(widget, dashboardFilters)),
-    [widget, dashboardFilters]
+    () =>
+      expressionsToApiQueries(
+        getMetricExpressions(widget, dashboardFilters, getVirtualMRIQuery)
+      ),
+    [widget, dashboardFilters, getVirtualMRIQuery]
   );
   const hasSetMetric = useMemo(
     () =>
-      getMetricExpressions(widget, dashboardFilters).some(
+      getMetricExpressions(widget, dashboardFilters, getVirtualMRIQuery).some(
         expression =>
           expression.type === MetricExpressionType.QUERY &&
           parseMRI(expression.mri)!.type === 's'
       ),
-    [widget, dashboardFilters]
+    [widget, dashboardFilters, getVirtualMRIQuery]
   );
 
   const widgetMQL = useMemo(() => getWidgetTitle(metricQueries), [metricQueries]);

--- a/static/app/views/dashboards/widgetCard/index.tsx
+++ b/static/app/views/dashboards/widgetCard/index.tsx
@@ -26,6 +26,7 @@ import type {TableDataWithTitle} from 'sentry/utils/discover/discoverQuery';
 import type {AggregationOutputType} from 'sentry/utils/discover/fields';
 import {parseFunction} from 'sentry/utils/discover/fields';
 import {hasCustomMetrics} from 'sentry/utils/metrics/features';
+import {VirtualMetricsContextProvider} from 'sentry/utils/metrics/virtualMetricsContext';
 import {hasOnDemandMetricWidgetFeature} from 'sentry/utils/onDemandMetrics/features';
 import {ExtractedMetricsTag} from 'sentry/utils/performance/contexts/metricsEnhancedPerformanceDataContext';
 import {
@@ -274,21 +275,23 @@ class WidgetCard extends Component<Props, State> {
     if (widget.widgetType === WidgetType.METRICS) {
       if (hasCustomMetrics(organization)) {
         return (
-          <MetricWidgetCard
-            index={this.props.index}
-            isEditingDashboard={this.props.isEditingDashboard}
-            onEdit={this.props.onEdit}
-            onDelete={this.props.onDelete}
-            onDuplicate={this.props.onDuplicate}
-            router={this.props.router}
-            location={this.props.location}
-            organization={organization}
-            selection={selection}
-            widget={widget}
-            dashboardFilters={dashboardFilters}
-            renderErrorMessage={renderErrorMessage}
-            showContextMenu={this.props.showContextMenu}
-          />
+          <VirtualMetricsContextProvider>
+            <MetricWidgetCard
+              index={this.props.index}
+              isEditingDashboard={this.props.isEditingDashboard}
+              onEdit={this.props.onEdit}
+              onDelete={this.props.onDelete}
+              onDuplicate={this.props.onDuplicate}
+              router={this.props.router}
+              location={this.props.location}
+              organization={organization}
+              selection={selection}
+              widget={widget}
+              dashboardFilters={dashboardFilters}
+              renderErrorMessage={renderErrorMessage}
+              showContextMenu={this.props.showContextMenu}
+            />
+          </VirtualMetricsContextProvider>
         );
       }
     }


### PR DESCRIPTION
Support using extracted metrics in dashboard.
Handle deleted extraction rules.

<img width="1183" alt="Screenshot 2024-07-04 at 11 44 23" src="https://github.com/getsentry/sentry/assets/7033940/7f5c2239-354e-4365-bc50-1feb984f3337">

<img width="1183" alt="Screenshot 2024-07-04 at 11 52 29" src="https://github.com/getsentry/sentry/assets/7033940/f0713261-999f-413a-be4b-66453ab50267">

# Part of https://github.com/getsentry/sentry/issues/73418