### PR TITLE
ref(metrics): extract logic & introduce cleaner error handling for span attribute extraction rule endpoints

### DIFF
--- a/src/sentry/api/endpoints/project_metrics_extraction_rules.py
+++ b/src/sentry/api/endpoints/project_metrics_extraction_rules.py
@@ -77,7 +77,7 @@ class ProjectMetricsExtractionRulesEndpoint(ProjectEndpoint):
                     project_id=project.id, trigger="span_attribute_extraction_configs"
                 )
 
-        return Response(status=204)
+            return Response(status=204)
 
     def get(self, request: Request, project: Project) -> Response:
         """GET extraction rules for project. Returns 200 and a list of extraction rules on success."""
@@ -148,7 +148,7 @@ class ProjectMetricsExtractionRulesEndpoint(ProjectEndpoint):
                 SpanAttributeExtractionRuleConfigSerializer(),
             )
 
-        return Response(data=persisted_config, status=200)
+            return Response(data=persisted_config, status=200)
 
 
 def validate_number_of_extracted_metrics(project: Project):

--- a/src/sentry/sentry_metrics/span_attribute_extraction_rules.py
+++ b/src/sentry/sentry_metrics/span_attribute_extraction_rules.py
@@ -1,0 +1,56 @@
+from typing import Any
+
+from rest_framework.request import Request
+
+from sentry.models.project import Project
+from sentry.sentry_metrics.configuration import HARD_CODED_UNITS
+from sentry.sentry_metrics.models import (
+    SpanAttributeExtractionRuleCondition,
+    SpanAttributeExtractionRuleConfig,
+)
+
+
+def create_extraction_rule_config(request: Request, project: Project, config_update: Any):
+    configs = []
+    for obj in config_update:
+        configs.append(SpanAttributeExtractionRuleConfig.from_dict(obj, request.user.id, project))
+    return configs
+
+
+def delete_extraction_rule_config(project: Project, config_update: Any):
+    for obj in config_update:
+        SpanAttributeExtractionRuleConfig.objects.filter(
+            project=project, span_attribute=obj["spanAttribute"]
+        ).delete()
+
+
+def update_extraction_rule_config(request: Request, project: Project, config_update: Any):
+    configs = []
+    for obj in config_update:
+        config = SpanAttributeExtractionRuleConfig.objects.get(
+            project=project, span_attribute=obj["spanAttribute"]
+        )
+        config.aggregates = obj["aggregates"]
+        config.unit = HARD_CODED_UNITS.get(obj["spanAttribute"], obj["unit"])
+        config.tags = obj["tags"]
+        config.save()
+        config.refresh_from_db()
+        configs.append(config)
+
+        # delete conditions not present in update
+        included_conditions = [x["id"] for x in obj["conditions"] if "id" in x]
+        SpanAttributeExtractionRuleCondition.objects.filter(config=config).exclude(
+            id__in=included_conditions
+        ).delete()
+
+        for condition in obj["conditions"]:
+            condition_id = condition["id"] if "id" in condition else None
+            SpanAttributeExtractionRuleCondition.objects.update_or_create(
+                id=condition_id,
+                config=config,
+                defaults={
+                    "value": condition["value"],
+                    "created_by_id": request.user.id,
+                },
+            )
+    return configs


### PR DESCRIPTION
- Move logic from endpoint to sentry_metrics module
- Introduce a context manager for centralized error handling and a check for feature flag
