### PR TITLE
feat: Allow to select v8 in Loader Script

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -159,6 +159,8 @@ def register_temporary_features(manager: FeatureManager):
     # Enable the new issue stream search bar UI
     manager.add("organizations:issue-stream-search-query-builder", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
     manager.add("organizations:large-debug-files", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
+    # Enable v8 support for the Loader Script
+    manager.add("organizations:js-sdk-loader-v8", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
     # Enabled latest adopted release filter for issue alerts
     manager.add("organizations:latest-adopted-release-filter", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
     manager.add("organizations:mep-rollout-flag", OrganizationFeature, FeatureHandlerStrategy.REMOTE)

--- a/src/sentry/loader/browsersdkversion.py
+++ b/src/sentry/loader/browsersdkversion.py
@@ -8,6 +8,7 @@ from django.conf import settings
 from packaging.version import Version
 
 import sentry
+from sentry import features
 
 logger = logging.getLogger("sentry")
 
@@ -37,8 +38,7 @@ def get_highest_browser_sdk_version(versions):
 
 
 def get_all_browser_sdk_version_versions():
-    # todo: v8 add version
-    return ["latest", "7.x", "6.x", "5.x", "4.x"]
+    return ["latest", "8.x", "7.x", "6.x", "5.x", "4.x"]
 
 
 def get_all_browser_sdk_version_choices():
@@ -98,4 +98,9 @@ def get_default_sdk_version_for_project(project):
 
 
 def get_available_sdk_versions_for_project(project):
-    return project.get_option("sentry:loader_available_sdk_versions")
+    versions = project.get_option("sentry:loader_available_sdk_versions")
+
+    if features.has("organizations:js-sdk-loader-v8", project.organization, actor=None):
+        return versions + ["8.x"]
+
+    return versions


### PR DESCRIPTION
This adds a feature flag `organizations:js-sdj-loader-v8` that can be set that will add `8.x` to the selectable options for the Loader Script.

Part of https://github.com/getsentry/sentry-javascript/issues/12187