### PR TITLE
feat(ui): Update Loader Script UI to accomodate v8

### DIFF
--- a/static/app/views/settings/project/projectKeys/details/loaderSettings.tsx
+++ b/static/app/views/settings/project/projectKeys/details/loaderSettings.tsx
@@ -226,8 +226,12 @@ export function LoaderSettings({keyId, orgSlug, project, data, updateData}: Prop
                 ? t('Only available in SDK version 7.x and above')
                 : data.dynamicSdkLoaderOptions.hasReplay
                   ? tct(
-                      'When using Replay, the loader will load the ES6 bundle instead of the ES5 bundle. The default configurations are [codeReplay:replaysSessionSampleRate: 0.1] and [codeError:replaysOnErrorSampleRate: 1]. [configDocs:Read the docs] to learn how to configure this.',
+                      `[es5Warning]The default configurations are [codeReplay:replaysSessionSampleRate: 0.1] and [codeError:replaysOnErrorSampleRate: 1]. [configDocs:Read the docs] to learn how to configure this.`,
                       {
+                        es5Warning:
+                          data.browserSdkVersion !== '8.x'
+                            ? 'When using Replay, the loader will load the ES6 bundle instead of the ES5 bundle. '
+                            : '',
                         codeReplay: <code />,
                         codeError: <code />,
                         configDocs: (
@@ -265,5 +269,5 @@ export function LoaderSettings({keyId, orgSlug, project, data, updateData}: Prop
 }
 
 function sdkVersionSupportsPerformanceAndReplay(sdkVersion: string): boolean {
-  return sdkVersion === 'latest' || sdkVersion === '7.x';
+  return sdkVersion === 'latest' || sdkVersion === '7.x' || sdkVersion === '8.x';
 }

--- a/static/app/views/settings/project/projectKeys/details/loaderSettings.tsx
+++ b/static/app/views/settings/project/projectKeys/details/loaderSettings.tsx
@@ -229,8 +229,12 @@ export function LoaderSettings({keyId, orgSlug, project, data, updateData}: Prop
                       `[es5Warning]The default configurations are [codeReplay:replaysSessionSampleRate: 0.1] and [codeError:replaysOnErrorSampleRate: 1]. [configDocs:Read the docs] to learn how to configure this.`,
                       {
                         es5Warning:
-                          data.browserSdkVersion !== '8.x'
-                            ? 'When using Replay, the loader will load the ES6 bundle instead of the ES5 bundle. '
+                          // latest is deprecated but resolves to v7
+                          data.browserSdkVersion === '7.x' ||
+                          data.browserSdkVersion === 'latest'
+                            ? t(
+                                'When using Replay, the loader will load the ES6 bundle instead of the ES5 bundle.'
+                              ) + ' '
                             : '',
                         codeReplay: <code />,
                         codeError: <code />,


### PR DESCRIPTION
This updates the UI of the loader script settings to accomodate v8.

Part of https://github.com/getsentry/sentry-javascript/issues/12187