### PR TITLE
feat(metrics): Remove code locations from metrics page

### DIFF
--- a/static/app/views/metrics/widgetDetails.tsx
+++ b/static/app/views/metrics/widgetDetails.tsx
@@ -1,8 +1,7 @@
-import {Fragment, useCallback, useMemo, useState} from 'react';
+import {Fragment, useCallback, useMemo} from 'react';
 import styled from '@emotion/styled';
 
 import Feature from 'sentry/components/acl/feature';
-import GuideAnchor from 'sentry/components/assistant/guideAnchor';
 import {Button} from 'sentry/components/button';
 import HookOrDefault from 'sentry/components/hookOrDefault';
 import {
@@ -11,30 +10,20 @@ import {
   SearchableMetricSamplesTable,
 } from 'sentry/components/metrics/metricSamplesTable';
 import {normalizeDateTimeParams} from 'sentry/components/organizations/pageFilters/parse';
-import {TabList, TabPanels, Tabs} from 'sentry/components/tabs';
-import {Tooltip} from 'sentry/components/tooltip';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {PageFilters} from 'sentry/types/core';
 import type {MetricAggregation, MRI} from 'sentry/types/metrics';
 import {defined} from 'sentry/utils';
-import {trackAnalytics} from 'sentry/utils/analytics';
-import {isCustomMetric} from 'sentry/utils/metrics';
 import type {FocusedMetricsSeries, MetricsWidget} from 'sentry/utils/metrics/types';
 import {isMetricsEquationWidget} from 'sentry/utils/metrics/types';
 import type {MetricsSamplesResults} from 'sentry/utils/metrics/useMetricsSamples';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
-import {CodeLocations} from 'sentry/views/metrics/codeLocations';
 import type {FocusAreaProps} from 'sentry/views/metrics/context';
 import {useMetricsContext} from 'sentry/views/metrics/context';
 import {extendQueryWithGroupBys} from 'sentry/views/metrics/utils';
 import {generateTracesRouteWithQuery} from 'sentry/views/traces/utils';
-
-enum Tab {
-  SAMPLES = 'samples',
-  CODE_LOCATIONS = 'codeLocations',
-}
 
 export function WidgetDetails() {
   const {
@@ -101,14 +90,6 @@ export function MetricDetails({
   const {selection} = usePageFilters();
   const organization = useOrganization();
 
-  const [selectedTab, setSelectedTab] = useState(Tab.SAMPLES);
-
-  const isCodeLocationsDisabled = mri && !isCustomMetric({mri});
-
-  if (isCodeLocationsDisabled && selectedTab === Tab.CODE_LOCATIONS) {
-    setSelectedTab(Tab.SAMPLES);
-  }
-
   const queryWithFocusedSeries = useMemo(
     () =>
       focusedSeries &&
@@ -117,18 +98,6 @@ export function MetricDetails({
         focusedSeries.map(s => s.groupBy)
       ),
     [focusedSeries, query]
-  );
-
-  const handleTabChange = useCallback(
-    (tab: Tab) => {
-      if (tab === Tab.CODE_LOCATIONS) {
-        trackAnalytics('ddm.code-locations', {
-          organization,
-        });
-      }
-      setSelectedTab(tab);
-    },
-    [organization]
   );
 
   const selectionRange = focusArea?.selection?.range;
@@ -161,74 +130,45 @@ export function MetricDetails({
 
   return (
     <TrayWrapper>
-      <Tabs value={selectedTab} onChange={handleTabChange}>
-        <TabsAndAction>
-          <TabList>
-            <TabList.Item textValue={t('Span Samples')} key={Tab.SAMPLES}>
-              <GuideAnchor target="metrics_table" position="top">
-                {t('Span Samples')}
-              </GuideAnchor>
-            </TabList.Item>
-            <TabList.Item
-              textValue={t('Code Location')}
-              key={Tab.CODE_LOCATIONS}
-              disabled={isCodeLocationsDisabled}
-            >
-              <Tooltip
-                title={t(
-                  'This metric is automatically collected by Sentry. It is not bound to a specific line of your code.'
-                )}
-                disabled={!isCodeLocationsDisabled}
-              >
-                <span style={{pointerEvents: 'all'}}>{t('Code Location')}</span>
-              </Tooltip>
-            </TabList.Item>
-          </TabList>
-          <Feature
-            features={[
-              'performance-trace-explorer-with-metrics',
-              'performance-trace-explorer',
-            ]}
-            requireAll
-          >
-            <OpenInTracesButton to={tracesTarget} size="sm">
-              {t('Open in Traces')}
-            </OpenInTracesButton>
-          </Feature>
-        </TabsAndAction>
-        <ContentWrapper>
-          <TabPanels>
-            <TabPanels.Item key={Tab.SAMPLES}>
-              <MetricSampleTableWrapper organization={organization}>
-                {organization.features.includes('metrics-samples-list-search') ? (
-                  <SearchableMetricSamplesTable
-                    focusArea={selectionRange}
-                    mri={mri}
-                    onRowHover={onRowHover}
-                    aggregation={aggregation}
-                    query={queryWithFocusedSeries}
-                    setMetricsSamples={setMetricsSamples}
-                    hasPerformance={hasPerformanceMetrics}
-                  />
-                ) : (
-                  <MetricSamplesTable
-                    focusArea={selectionRange}
-                    mri={mri}
-                    onRowHover={onRowHover}
-                    aggregation={aggregation}
-                    query={queryWithFocusedSeries}
-                    setMetricsSamples={setMetricsSamples}
-                    hasPerformance={hasPerformanceMetrics}
-                  />
-                )}
-              </MetricSampleTableWrapper>
-            </TabPanels.Item>
-            <TabPanels.Item key={Tab.CODE_LOCATIONS}>
-              <CodeLocations mri={mri} {...focusArea?.selection?.range} />
-            </TabPanels.Item>
-          </TabPanels>
-        </ContentWrapper>
-      </Tabs>
+      <TabsAndAction>
+        <Heading>{t('Span Samples')}</Heading>
+        <Feature
+          features={[
+            'performance-trace-explorer-with-metrics',
+            'performance-trace-explorer',
+          ]}
+          requireAll
+        >
+          <OpenInTracesButton to={tracesTarget} size="sm">
+            {t('Open in Traces')}
+          </OpenInTracesButton>
+        </Feature>
+      </TabsAndAction>
+      <ContentWrapper>
+        <MetricSampleTableWrapper organization={organization}>
+          {organization.features.includes('metrics-samples-list-search') ? (
+            <SearchableMetricSamplesTable
+              focusArea={selectionRange}
+              mri={mri}
+              onRowHover={onRowHover}
+              aggregation={aggregation}
+              query={queryWithFocusedSeries}
+              setMetricsSamples={setMetricsSamples}
+              hasPerformance={hasPerformanceMetrics}
+            />
+          ) : (
+            <MetricSamplesTable
+              focusArea={selectionRange}
+              mri={mri}
+              onRowHover={onRowHover}
+              aggregation={aggregation}
+              query={queryWithFocusedSeries}
+              setMetricsSamples={setMetricsSamples}
+              hasPerformance={hasPerformanceMetrics}
+            />
+          )}
+        </MetricSampleTableWrapper>
+      </ContentWrapper>
     </TrayWrapper>
   );
 }
@@ -238,6 +178,10 @@ const MetricSampleTableWrapper = HookOrDefault({
   defaultComponent: ({children}) => <Fragment>{children}</Fragment>,
 });
 
+const Heading = styled('h6')`
+  margin-bottom: ${space(0.5)};
+`;
+
 const TrayWrapper = styled('div')`
   padding-top: ${space(4)};
   display: grid;
@@ -246,16 +190,14 @@ const TrayWrapper = styled('div')`
 
 const ContentWrapper = styled('div')`
   position: relative;
-  padding-top: ${space(2)};
+  padding-top: ${space(1)};
 `;
 
-const OpenInTracesButton = styled(Button)`
-  margin-top: ${space(0.75)};
-`;
+const OpenInTracesButton = styled(Button)``;
 
 const TabsAndAction = styled('div')`
   display: grid;
   grid-template-columns: 1fr auto;
   gap: ${space(4)};
-  align-items: center;
+  align-items: end;
 `;


### PR DESCRIPTION
Remove code locations from the metrics page.

### Background
They stop working with span based metrics and were of little use on this page in the past.
For legacy custom metrics they are still available in the metric's settings.
