### PR TITLE
feat(insights): Updates Web Vitals performance score ring and charts to use static weights

### DIFF
--- a/static/app/views/insights/browser/webVitals/components/performanceScoreRingWithTooltips.tsx
+++ b/static/app/views/insights/browser/webVitals/components/performanceScoreRingWithTooltips.tsx
@@ -17,6 +17,7 @@ import type {
   WebVitals,
 } from 'sentry/views/insights/browser/webVitals/types';
 import {PERFORMANCE_SCORE_WEIGHTS} from 'sentry/views/insights/browser/webVitals/utils/scoreThresholds';
+import {useStaticWeightsSetting} from 'sentry/views/insights/browser/webVitals/utils/useStaticWeightsSetting';
 import {useModuleURL} from 'sentry/views/insights/common/utils/useModuleURL';
 
 import {getFormattedDuration} from './webVitalMeters';
@@ -162,21 +163,19 @@ function PerformanceScoreRingWithTooltips({
     });
   }
 
-  const weights = [
-    'lcpWeight',
-    'fcpWeight',
-    'inpWeight',
-    'clsWeight',
-    'ttfbWeight',
-  ].every(key => projectScore[key] === 0)
-    ? PERFORMANCE_SCORE_WEIGHTS
-    : {
-        lcp: projectScore.lcpWeight,
-        fcp: projectScore.fcpWeight,
-        inp: projectScore.inpWeight,
-        cls: projectScore.clsWeight,
-        ttfb: projectScore.ttfbWeight,
-      };
+  const shouldUseStaticWeights = useStaticWeightsSetting();
+  const weights =
+    ['lcpWeight', 'fcpWeight', 'inpWeight', 'clsWeight', 'ttfbWeight'].every(
+      key => projectScore[key] === 0
+    ) || shouldUseStaticWeights
+      ? PERFORMANCE_SCORE_WEIGHTS
+      : {
+          lcp: projectScore.lcpWeight,
+          fcp: projectScore.fcpWeight,
+          inp: projectScore.inpWeight,
+          cls: projectScore.clsWeight,
+          ttfb: projectScore.ttfbWeight,
+        };
 
   const commonWebVitalLabelProps = {
     organization,

--- a/static/app/views/insights/browser/webVitals/utils/applyStaticWeightsToTimeseries.spec.tsx
+++ b/static/app/views/insights/browser/webVitals/utils/applyStaticWeightsToTimeseries.spec.tsx
@@ -1,0 +1,64 @@
+import {applyStaticWeightsToTimeseries} from 'sentry/views/insights/browser/webVitals/utils/applyStaticWeightsToTimeseries';
+
+describe('applyStaticWeightsToTimeseries', function () {
+  it('updates timeseries scores with static weighing', function () {
+    const timeseriesData = {
+      lcp: [],
+      fcp: [],
+      cls: [],
+      ttfb: [],
+      inp: [],
+      unweightedLcp: [
+        {name: '2024-07-01T00:00:00.000Z', value: 90},
+        {name: '2024-07-02T00:00:00.000Z', value: 40},
+      ],
+      unweightedFcp: [
+        {name: '2024-07-01T00:00:00.000Z', value: 30},
+        {name: '2024-07-02T00:00:00.000Z', value: 20},
+      ],
+      unweightedCls: [
+        {name: '2024-07-01T00:00:00.000Z', value: 10},
+        {name: '2024-07-02T00:00:00.000Z', value: 90},
+      ],
+      unweightedTtfb: [
+        {name: '2024-07-01T00:00:00.000Z', value: 22},
+        {name: '2024-07-02T00:00:00.000Z', value: 43},
+      ],
+      unweightedInp: [
+        {name: '2024-07-01T00:00:00.000Z', value: 100},
+        {name: '2024-07-02T00:00:00.000Z', value: 0},
+      ],
+      total: [
+        {name: '2024-07-01T00:00:00.000Z', value: 50},
+        {name: '2024-07-02T00:00:00.000Z', value: 50},
+      ],
+    };
+    const result = applyStaticWeightsToTimeseries(timeseriesData);
+    expect(result).toEqual({
+      lcp: [
+        {name: '2024-07-01T00:00:00.000Z', value: 90 * 0.3},
+        {name: '2024-07-02T00:00:00.000Z', value: 40 * 0.3},
+      ],
+      fcp: [
+        {name: '2024-07-01T00:00:00.000Z', value: 30 * 0.15},
+        {name: '2024-07-02T00:00:00.000Z', value: 20 * 0.15},
+      ],
+      cls: [
+        {name: '2024-07-01T00:00:00.000Z', value: 10 * 0.15},
+        {name: '2024-07-02T00:00:00.000Z', value: 90 * 0.15},
+      ],
+      ttfb: [
+        {name: '2024-07-01T00:00:00.000Z', value: 22 * 0.1},
+        {name: '2024-07-02T00:00:00.000Z', value: 43 * 0.1},
+      ],
+      inp: [
+        {name: '2024-07-01T00:00:00.000Z', value: 100 * 0.3},
+        {name: '2024-07-02T00:00:00.000Z', value: 0 * 0.3},
+      ],
+      total: [
+        {name: '2024-07-01T00:00:00.000Z', value: 50},
+        {name: '2024-07-02T00:00:00.000Z', value: 50},
+      ],
+    });
+  });
+});

--- a/static/app/views/insights/browser/webVitals/utils/applyStaticWeightsToTimeseries.tsx
+++ b/static/app/views/insights/browser/webVitals/utils/applyStaticWeightsToTimeseries.tsx
@@ -1,0 +1,23 @@
+import type {
+  UnweightedWebVitalsScoreBreakdown,
+  WebVitalsScoreBreakdown,
+} from 'sentry/views/insights/browser/webVitals/queries/storedScoreQueries/useProjectWebVitalsScoresTimeseriesQuery';
+import {PERFORMANCE_SCORE_WEIGHTS} from 'sentry/views/insights/browser/webVitals/utils/scoreThresholds';
+
+// Returns a weighed score timeseries with each interval calculated from applying hardcoded weights to unweighted scores
+export function applyStaticWeightsToTimeseries(
+  timeseriesData: WebVitalsScoreBreakdown & UnweightedWebVitalsScoreBreakdown
+) {
+  return {
+    ...Object.keys(PERFORMANCE_SCORE_WEIGHTS).reduce((acc, webVital) => {
+      acc[webVital] = timeseriesData[
+        `unweighted${webVital.charAt(0).toUpperCase()}${webVital.slice(1)}`
+      ].map(({name, value}) => ({
+        name,
+        value: value * PERFORMANCE_SCORE_WEIGHTS[webVital] * 0.01,
+      }));
+      return acc;
+    }, {}),
+    total: timeseriesData.total,
+  } as WebVitalsScoreBreakdown & UnweightedWebVitalsScoreBreakdown;
+}

--- a/static/app/views/insights/browser/webVitals/utils/useStaticWeightsSetting.tsx
+++ b/static/app/views/insights/browser/webVitals/utils/useStaticWeightsSetting.tsx
@@ -1,0 +1,6 @@
+import useOrganization from 'sentry/utils/useOrganization';
+
+export function useStaticWeightsSetting(): boolean {
+  const organization = useOrganization();
+  return organization.features.includes('insights-browser-webvitals-static-weights');
+}

--- a/static/app/views/performance/landing/widgets/widgets/performanceScoreListWidget.tsx
+++ b/static/app/views/performance/landing/widgets/widgets/performanceScoreListWidget.tsx
@@ -22,6 +22,8 @@ import {useProjectWebVitalsScoresTimeseriesQuery} from 'sentry/views/insights/br
 import {useTransactionWebVitalsScoresQuery} from 'sentry/views/insights/browser/webVitals/queries/storedScoreQueries/useTransactionWebVitalsScoresQuery';
 import {MODULE_DOC_LINK} from 'sentry/views/insights/browser/webVitals/settings';
 import type {RowWithScoreAndOpportunity} from 'sentry/views/insights/browser/webVitals/types';
+import {applyStaticWeightsToTimeseries} from 'sentry/views/insights/browser/webVitals/utils/applyStaticWeightsToTimeseries';
+import {useStaticWeightsSetting} from 'sentry/views/insights/browser/webVitals/utils/useStaticWeightsSetting';
 import Chart, {ChartType} from 'sentry/views/insights/common/components/chart';
 import {useModuleURL} from 'sentry/views/insights/common/utils/useModuleURL';
 
@@ -62,6 +64,12 @@ export function PerformanceScoreListWidget(props: PerformanceWidgetProps) {
 
   const order = ORDER;
 
+  const shouldUseStaticWeights = useStaticWeightsSetting();
+
+  const weightedTimeseriesData = shouldUseStaticWeights
+    ? applyStaticWeightsToTimeseries(timeseriesData)
+    : timeseriesData;
+
   const getAreaChart = _ => {
     const segmentColors = theme.charts.getColorPalette(3).slice(0, 5);
     return (
@@ -69,7 +77,7 @@ export function PerformanceScoreListWidget(props: PerformanceWidgetProps) {
         stacked
         height={props.chartHeight}
         data={formatTimeSeriesResultsToChartData(
-          timeseriesData,
+          weightedTimeseriesData,
           segmentColors,
           false,
           order


### PR DESCRIPTION
Updates the performance score ring and and score breakdown chart to use hardcoded static weights when feature flagged
<img width="878" alt="image" src="https://github.com/getsentry/sentry/assets/83961295/3cac9234-42db-4429-8942-a8cf19326eef">
