### PR TITLE
chore(features) Remove feature for issue-details-tag-improvements

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1450,7 +1450,6 @@ SENTRY_EARLY_FEATURES = {
     "organizations:gitlab-disable-on-broken": "Enable disabling gitlab integrations when broken is detected",
     "organizations:grouping-stacktrace-ui": "Enable experimental new version of stacktrace component where additional data related to grouping is shown on each frame",
     "organizations:grouping-title-ui": "Enable tweaks to group title in relation to hierarchical grouping.",
-    "organizations:issue-details-tag-improvements": "Enable tag improvements in the issue details page",
     "organizations:mobile-cpu-memory-in-transactions": "Display CPU and memory metrics in transactions with profiles",
     "organizations:performance-metrics-backed-transaction-summary": "Enable metrics-backed transaction summary view",
     "organizations:performance-new-trends": "Enable new trends",

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -142,8 +142,6 @@ def register_temporary_features(manager: FeatureManager):
     manager.add("organizations:issue-details-autofix-ui", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
     # Enables a toggle for entering the new issue details UI
     manager.add("organizations:issue-details-new-experience-toggle", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
-    # Enable tag improvements in the issue details page
-    manager.add("organizations:issue-details-tag-improvements", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
     # Whether to allow issue only search on the issue list
     manager.add("organizations:issue-search-allow-postgres-only-search", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
     # Whether to make a side/parallel query against events -> group_attributes when searching issues

--- a/static/app/views/issueDetails/groupSidebar.spec.tsx
+++ b/static/app/views/issueDetails/groupSidebar.spec.tsx
@@ -259,10 +259,7 @@ describe('GroupSidebar', function () {
         <GroupSidebar
           group={group}
           project={{...project, platform: 'react-native'}}
-          organization={{
-            ...organization,
-            features: [...organization.features, 'issue-details-tag-improvements'],
-          }}
+          organization={organization}
           event={EventFixture()}
           environments={[environment]}
         />
@@ -278,10 +275,7 @@ describe('GroupSidebar', function () {
         <GroupSidebar
           group={group}
           project={project}
-          organization={{
-            ...organization,
-            features: [...organization.features, 'issue-details-tag-improvements'],
-          }}
+          organization={organization}
           event={EventFixture()}
           environments={[environment]}
         />


### PR DESCRIPTION
This feature has a partial rollout, and is causing noise when comparing flagr and flagpole results. Turns out this feature has already been mainlined/removed.