### PR TITLE
fix(trace-view): Profile link from span should be call order

### DIFF
--- a/static/app/components/events/interfaces/spans/spanProfileDetails.tsx
+++ b/static/app/components/events/interfaces/spans/spanProfileDetails.tsx
@@ -151,6 +151,7 @@ export function SpanProfileDetails({
       query: {
         tid: String(profile.threadId),
         spanId: span.span_id,
+        sorting: 'call order',
       },
     });
 


### PR DESCRIPTION
### Summary
If you're on another sorting algo then the transaction waterfall and span waterfall won't line up, since spans are always call order. This sets the profile link from the trace view to always be call order, since that's the most likely use case when comparing frames inside a span.

#### Screenshot
![Screenshot 2024-07-04 at 2 53 42 PM](https://github.com/getsentry/sentry/assets/6111995/0b7a8226-2d4e-46c7-ab30-6652b04fa39c)
