### PR TITLE
ref(discover): Use the same helper for checking dataset

### DIFF
--- a/src/sentry/api/bases/organization_events.py
+++ b/src/sentry/api/bases/organization_events.py
@@ -234,32 +234,31 @@ class OrganizationEventsV2EndpointBase(OrganizationEventsEndpointBase):
 
         return use_on_demand_metrics, on_demand_metric_type
 
-    def get_split_decision(self, has_errors, has_transactions_data):
+    def save_dashboard_widget_split_decision(
+        self, widget, dataset_inferred_from_query, has_errors, has_transactions_data
+    ):
         """This can be removed once the discover dataset has been fully split"""
-        if has_errors and not has_transactions_data:
+        if dataset_inferred_from_query:
+            decision = dataset_inferred_from_query
+            sentry_sdk.set_tag("discover.split_reason", "inferred_from_query")
+        elif has_errors and not has_transactions_data:
             decision = DashboardWidgetTypes.ERROR_EVENTS
+            sentry_sdk.set_tag("discover.split_reason", "query_result")
         elif not has_errors and has_transactions_data:
             decision = DashboardWidgetTypes.TRANSACTION_LIKE
-        elif has_errors and has_transactions_data:
-            decision = DashboardWidgetTypes.DISCOVER
+            sentry_sdk.set_tag("discover.split_reason", "query_result")
         else:
             # In the case that neither side has data, we do not need to split this yet and can make multiple queries to check each time.
             # This will help newly created widgets or infrequent count widgets that shouldn't be prematurely assigned a side.
             decision = None
-        sentry_sdk.set_tag("split_decision", decision)
-        return decision
+            sentry_sdk.set_tag("discover.split_reason", "default")
 
-    def save_split_decision(self, widget, has_errors, has_transactions_data):
-        """This can be removed once the discover dataset has been fully split"""
-        new_discover_widget_split = self.get_split_decision(has_errors, has_transactions_data)
-        if (
-            new_discover_widget_split is not None
-            and widget.discover_widget_split != new_discover_widget_split
-        ):
-            widget.discover_widget_split = new_discover_widget_split
+        sentry_sdk.set_tag("discover.split_decision", decision)
+        if widget.discover_widget_split != decision:
+            widget.discover_widget_split = decision
             widget.save()
 
-        return new_discover_widget_split
+        return decision
 
     def save_discover_saved_query_split_decision(
         self, query, dataset_inferred_from_query, has_errors, has_transactions_data

--- a/src/sentry/api/bases/organization_events.py
+++ b/src/sentry/api/bases/organization_events.py
@@ -250,7 +250,7 @@ class OrganizationEventsV2EndpointBase(OrganizationEventsEndpointBase):
         else:
             # In the case that neither side has data, we do not need to split this yet and can make multiple queries to check each time.
             # This will help newly created widgets or infrequent count widgets that shouldn't be prematurely assigned a side.
-            decision = None
+            decision = DashboardWidgetTypes.DISCOVER
             sentry_sdk.set_tag("discover.split_reason", "default")
 
         sentry_sdk.set_tag("discover.split_decision", decision)

--- a/src/sentry/api/endpoints/organization_events.py
+++ b/src/sentry/api/endpoints/organization_events.py
@@ -383,8 +383,7 @@ class OrganizationEventsEndpoint(OrganizationEventsV2EndpointBase):
         ):
             try:
                 dataset_inferred_from_query = dataset_split_decision_inferred_from_query(
-                    self.get_field_list(organization, request),
-                    scoped_query,
+                    self.get_field_list(organization, request), scoped_query, type_enum
                 )
                 has_errors = False
                 has_transactions = False

--- a/src/sentry/api/endpoints/organization_events_stats.py
+++ b/src/sentry/api/endpoints/organization_events_stats.py
@@ -416,7 +416,10 @@ class OrganizationEventsStatsEndpoint(OrganizationEventsV2EndpointBase):
                         )
                         has_transactions = self.check_if_results_have_data(transaction_results)
 
-                    decision = self.save_split_decision(widget, has_errors, has_transactions)
+                    # TODO: Port over logic for interpreting split decision
+                    decision = self.save_dashboard_widget_split_decision(
+                        widget, None, has_errors, has_transactions
+                    )
 
                     if decision == DashboardWidgetTypes.DISCOVER:
                         # The user needs to be warned to split in this case.

--- a/src/sentry/snuba/utils.py
+++ b/src/sentry/snuba/utils.py
@@ -119,26 +119,26 @@ def build_query_strings(
     )
 
 
-def dataset_split_decision_inferred_from_query(columns, query):
+def dataset_split_decision_inferred_from_query(columns, query, enum=DiscoverSavedQueryTypes):
     """
     Infers split decision based on fields we know exclusively belong to one
     dataset or the other. Biases towards Errors dataset.
     """
     for field in ERROR_ONLY_FIELDS:
         if field in query:
-            return DiscoverSavedQueryTypes.ERROR_EVENTS
+            return enum.ERROR_EVENTS
 
     for field in TRANSACTION_ONLY_FIELDS:
         if field in query:
-            return DiscoverSavedQueryTypes.TRANSACTION_LIKE
+            return enum.TRANSACTION_LIKE
 
     for column in columns:
         for field in ERROR_ONLY_FIELDS:
             if field in column:
-                return DiscoverSavedQueryTypes.ERROR_EVENTS
+                return enum.ERROR_EVENTS
 
         for field in TRANSACTION_ONLY_FIELDS:
             if field in column:
-                return DiscoverSavedQueryTypes.TRANSACTION_LIKE
+                return enum.TRANSACTION_LIKE
 
     return None


### PR DESCRIPTION
There were two helpers for evaluating the split decisions for Discover and Dashboards. The necessary logic for both was very similar so I figured there was an opportunity to turn some of the differences into parameters that we could pass in and have the same logic.

Aside from renaming and moving around code, I updated the `save_dashboard_widget_split_decision` function to have the same logic and telemetry as `save_discover_saved_query_split_decision`. The only difference is that since we haven't decided on a default condition for dashboard widgets, I've left filling out the field as `None`

I'm relying on the previous tests for validity on this refactor. I will add more tests as the functionality changes.