### PR TITLE
flag(sampling): Add DS killswitch for ST AM1->AM2

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1841,6 +1841,12 @@ register(
     0,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
+
+# Stops dynamic sampling rules from being emitted in relay config.
+# This is required for ST instances that have flakey flags as we want to be able kill DS ruining customer data if necessary.
+# It is only a killswitch for behaviour, it may actually increase infra load if flipped for a user currently being sampled.
+register("dynamic-sampling.config.killswitch", default=False, flags=FLAG_AUTOMATOR_MODIFIABLE)
+
 # Controls the intensity of dynamic sampling transaction rebalancing. 0.0 = explict rebalancing
 # not performed, 1.0= full rebalancing (tries to bring everything to mean). Note that even at 0.0
 # there will still be some rebalancing between the explicit and implicit transactions ( so setting rebalancing

--- a/src/sentry/relay/config/__init__.py
+++ b/src/sentry/relay/config/__init__.py
@@ -351,6 +351,10 @@ def get_project_config(
 
 
 def get_dynamic_sampling_config(timeout: TimeChecker, project: Project) -> Mapping[str, Any] | None:
+    if options.get("dynamic-sampling.config.killswitch"):
+        # This killswitch will cause extra load, and should only be used for AM1->AM2 migration.
+        return None
+
     if features.has("organizations:dynamic-sampling", project.organization):
         return {"version": 2, "rules": generate_rules(project)}
 


### PR DESCRIPTION
The sampling flags are having inconsistencies on STs, this will let us immediately kill sampling if plan changes are not instant.

⚠️  Would like careful eyes on the logic here since it can effect on the pipeline.