### PR TITLE
feat(insights): remove module upsell tooltips

### DIFF
--- a/static/app/components/sidebar/sidebarItem.tsx
+++ b/static/app/components/sidebar/sidebarItem.tsx
@@ -218,63 +218,61 @@ function SidebarItem({
       position={placement}
     >
       <SidebarNavigationItemHook id={id}>
-        {({disabled, additionalContent, Wrapper}) => (
-          <Wrapper>
-            <StyledSidebarItem
-              {...props}
-              id={`sidebar-item-${id}`}
-              isInFloatingAccordion={isInFloatingAccordion}
-              active={isActive ? 'true' : undefined}
-              to={disabled ? '' : toProps}
-              disabled={!hasLink && isInFloatingAccordion}
-              className={className}
-              aria-current={isActive ? 'page' : undefined}
-              onClick={handleItemClick}
-            >
-              <InteractionStateLayer isPressed={isActive} color="white" higherOpacity />
-              <SidebarItemWrapper collapsed={isInCollapsedState}>
-                {!isInFloatingAccordion && <SidebarItemIcon>{icon}</SidebarItemIcon>}
-                {!isInCollapsedState && !isTop && (
-                  <SidebarItemLabel
-                    isInFloatingAccordion={isInFloatingAccordion}
-                    isNested={isNested}
-                  >
-                    <LabelHook id={id}>
-                      <TruncatedLabel>{label}</TruncatedLabel>
-                      {additionalContent ?? badges}
-                    </LabelHook>
-                  </SidebarItemLabel>
-                )}
-                {isInCollapsedState && showIsNew && (
-                  <CollapsedFeatureBadge
-                    type="new"
-                    variant="indicator"
-                    tooltipProps={tooltipDisabledProps}
-                  />
-                )}
-                {isInCollapsedState && isBeta && (
-                  <CollapsedFeatureBadge
-                    type="beta"
-                    variant="indicator"
-                    tooltipProps={tooltipDisabledProps}
-                  />
-                )}
-                {isInCollapsedState && isAlpha && (
-                  <CollapsedFeatureBadge
-                    type="alpha"
-                    variant="indicator"
-                    tooltipProps={tooltipDisabledProps}
-                  />
-                )}
-                {badge !== undefined && badge > 0 && (
-                  <SidebarItemBadge collapsed={isInCollapsedState}>
-                    {badge}
-                  </SidebarItemBadge>
-                )}
-                {trailingItems}
-              </SidebarItemWrapper>
-            </StyledSidebarItem>
-          </Wrapper>
+        {({additionalContent}) => (
+          <StyledSidebarItem
+            {...props}
+            id={`sidebar-item-${id}`}
+            isInFloatingAccordion={isInFloatingAccordion}
+            active={isActive ? 'true' : undefined}
+            to={toProps}
+            disabled={!hasLink && isInFloatingAccordion}
+            className={className}
+            aria-current={isActive ? 'page' : undefined}
+            onClick={handleItemClick}
+          >
+            <InteractionStateLayer isPressed={isActive} color="white" higherOpacity />
+            <SidebarItemWrapper collapsed={isInCollapsedState}>
+              {!isInFloatingAccordion && <SidebarItemIcon>{icon}</SidebarItemIcon>}
+              {!isInCollapsedState && !isTop && (
+                <SidebarItemLabel
+                  isInFloatingAccordion={isInFloatingAccordion}
+                  isNested={isNested}
+                >
+                  <LabelHook id={id}>
+                    <TruncatedLabel>{label}</TruncatedLabel>
+                    {additionalContent ?? badges}
+                  </LabelHook>
+                </SidebarItemLabel>
+              )}
+              {isInCollapsedState && showIsNew && (
+                <CollapsedFeatureBadge
+                  type="new"
+                  variant="indicator"
+                  tooltipProps={tooltipDisabledProps}
+                />
+              )}
+              {isInCollapsedState && isBeta && (
+                <CollapsedFeatureBadge
+                  type="beta"
+                  variant="indicator"
+                  tooltipProps={tooltipDisabledProps}
+                />
+              )}
+              {isInCollapsedState && isAlpha && (
+                <CollapsedFeatureBadge
+                  type="alpha"
+                  variant="indicator"
+                  tooltipProps={tooltipDisabledProps}
+                />
+              )}
+              {badge !== undefined && badge > 0 && (
+                <SidebarItemBadge collapsed={isInCollapsedState}>
+                  {badge}
+                </SidebarItemBadge>
+              )}
+              {trailingItems}
+            </SidebarItemWrapper>
+          </StyledSidebarItem>
         )}
       </SidebarNavigationItemHook>
     </Tooltip>


### PR DESCRIPTION
This PR enables the full screen module page upsells.

We removed the upsell tooltips and no longer disable the sidebar buttons (in favour of the full screen module page upsells, https://github.com/getsentry/getsentry/pull/14519)

The only use of the sidebar hook is to display the buisness icon now, so i'll create a followup that removes the tooltip content iteself.


