### PR TITLE
ref(snuba): Refactor utils/snuba to allow for multiple referrers

### DIFF
--- a/src/sentry/testutils/pytest/metrics.py
+++ b/src/sentry/testutils/pytest/metrics.py
@@ -59,10 +59,10 @@ def control_metrics_access(monkeypatch, request, set_sentry_option):
         old_build_results = snuba._apply_cache_and_build_results
 
         def new_build_results(*args, **kwargs):
-            if isinstance(args[0][0][0], dict):
+            if isinstance(args[0][0].request, dict):
                 # We only support snql queries, and metrics only go through snql
                 return old_build_results(*args, **kwargs)
-            query = args[0][0][0].query
+            query = args[0][0].request.query
             is_performance_metrics = False
             is_metrics = False
             if not isinstance(query, MetricsQuery) and not isinstance(query.match, Join):

--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -854,7 +854,7 @@ Translator = Callable[[Any], Any]
 @dataclasses.dataclass(frozen=True)
 class SnubaRequest:
     request: Request
-    referrer: str | None  # this should use the referrer class
+    referrer: str | None  # TODO: this should use the referrer Enum
     forward: Translator
     reverse: Translator
 

--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import dataclasses
 import functools
 import logging
 import os
@@ -13,7 +14,7 @@ from contextlib import contextmanager
 from copy import deepcopy
 from datetime import datetime, timedelta, timezone
 from hashlib import sha1
-from typing import Any, Union
+from typing import Any
 from urllib.parse import urlparse
 
 import sentry_sdk
@@ -847,9 +848,32 @@ def raw_query(
     return bulk_raw_query([snuba_params], referrer=referrer, use_cache=use_cache)[0]
 
 
-SnubaQuery = Union[Request, MutableMapping[str, Any]]
 Translator = Callable[[Any], Any]
 RequestQueryBody = tuple[Request, Translator, Translator]
+
+
+@dataclasses.dataclass(frozen=True)
+class SnubaRequest:
+    referrer: str | None  # this should use the referrer class
+    request: Request
+    forward: Translator
+    reverse: Translator
+
+    def __post_init__(self) -> None:
+        self.validate()
+
+    def validate(self):
+        if self.referrer:
+            validate_referrer(self.referrer)
+
+    @property
+    def headers(self) -> Mapping[str, str]:
+        headers: MutableMapping[str, str] = {}
+        if self.referrer:
+            headers["referer"] = self.referrer
+        return headers
+
+
 LegacyQueryBody = tuple[MutableMapping[str, Any], Translator, Translator]
 # TODO: Would be nice to make this a concrete structure
 ResultSet = list[Mapping[str, Any]]
@@ -923,7 +947,7 @@ def bulk_raw_query(
     return _apply_cache_and_build_results(request_bodies, referrer=referrer, use_cache=use_cache)
 
 
-def get_cache_key(query: SnubaQuery) -> str:
+def get_cache_key(query: Request) -> str:
     if isinstance(query, Request):
         hashable = str(query)
     else:
@@ -938,34 +962,47 @@ def _apply_cache_and_build_results(
     referrer: str | None = None,
     use_cache: bool | None = False,
 ) -> ResultSet:
-    headers = {}
-    validate_referrer(referrer)
-    if referrer:
-        headers["referer"] = referrer
+    parent_api: str = "<missing>"
+    scope = sentry_sdk.Scope.get_current_scope()
+    if scope.transaction:
+        parent_api = scope.transaction.name
 
     # Store the original position of the query so that we can maintain the order
-    query_param_list = list(enumerate(snuba_param_list))
+    snuba_requests_list: list[tuple[int, SnubaRequest]] = []
+    for i, (request, forward, reverse) in enumerate(snuba_param_list):
+        request.parent_api = parent_api
+        snuba_request = SnubaRequest(
+            referrer=referrer,
+            request=request,
+            forward=forward,
+            reverse=reverse,
+        )
+        snuba_requests_list.append((i, snuba_request))
 
     results = []
 
+    to_query: list[tuple[int, RequestQueryBody, str | None]] = []
+
     if use_cache:
-        cache_keys = [get_cache_key(query_params[0]) for _, query_params in query_param_list]
+        cache_keys = [
+            get_cache_key(snuba_request.request) for _, snuba_request in snuba_requests_list
+        ]
         cache_data = cache.get_many(cache_keys)
-        to_query: list[tuple[int, RequestQueryBody, str | None]] = []
-        for (query_pos, query_params), cache_key in zip(query_param_list, cache_keys):
+        for (query_pos, snuba_request), cache_key in zip(snuba_requests_list, cache_keys):
             cached_result = cache_data.get(cache_key)
             metric_tags = {"referrer": referrer} if referrer else None
             if cached_result is None:
                 metrics.incr("snuba.query_cache.miss", tags=metric_tags)
-                to_query.append((query_pos, query_params, cache_key))
+                to_query.append((query_pos, snuba_request, cache_key))
             else:
                 metrics.incr("snuba.query_cache.hit", tags=metric_tags)
                 results.append((query_pos, json.loads(cached_result)))
     else:
-        to_query = [(query_pos, query_params, None) for query_pos, query_params in query_param_list]
+        for query_pos, snuba_request in snuba_requests_list:
+            to_query.append((query_pos, snuba_request, None))
 
     if to_query:
-        query_results = _bulk_snuba_query([item[1] for item in to_query], headers)
+        query_results = _bulk_snuba_query([item[1] for item in to_query])
         for result, (query_pos, _, opt_cache_key) in zip(query_results, to_query):
             if opt_cache_key:
                 cache.set(
@@ -979,40 +1016,23 @@ def _apply_cache_and_build_results(
     return [result[1] for result in results]
 
 
-def _bulk_snuba_query(
-    snuba_param_list: Sequence[RequestQueryBody],
-    headers: Mapping[str, str],
-) -> ResultSet:
-    query_referrer = headers.get("referer", "<unknown>")
+def _bulk_snuba_query(snuba_requests: Sequence[SnubaRequest]) -> ResultSet:
+    snuba_requests_list = list(snuba_requests)
 
-    with sentry_sdk.start_span(
-        op="snuba_query",
-        description=query_referrer,
-    ) as span:
-        span.set_tag("snuba.num_queries", len(snuba_param_list))
-        # We set both span + sdk level, this is cause 1 txn/error might query snuba more than once
-        # but we still want to know a general sense of how referrers impact performance
-        span.set_tag("query.referrer", query_referrer)
-        sentry_sdk.set_tag("query.referrer", query_referrer)
+    with sentry_sdk.start_span(op="snuba_query") as span:
+        span.set_tag("snuba.num_queries", len(snuba_requests_list))
 
-        parent_api: str = "<missing>"
-        scope = sentry_sdk.Scope.get_current_scope()
-        if scope.transaction:
-            parent_api = scope.transaction.name
-
-        if len(snuba_param_list) > 1:
+        if len(snuba_requests_list) > 1:
             query_results = list(
                 _query_thread_pool.map(
                     _snuba_query,
                     [
                         (
-                            params,
                             sentry_sdk.Scope.get_isolation_scope().fork(),
                             sentry_sdk.Scope.get_current_scope().fork(),
-                            headers,
-                            parent_api,
+                            snuba_request,
                         )
-                        for params in snuba_param_list
+                        for snuba_request in snuba_requests_list
                     ],
                 )
             )
@@ -1021,32 +1041,28 @@ def _bulk_snuba_query(
             query_results = [
                 _snuba_query(
                     (
-                        snuba_param_list[0],
                         sentry_sdk.Scope.get_isolation_scope().fork(),
                         sentry_sdk.Scope.get_current_scope().fork(),
-                        headers,
-                        parent_api,
+                        snuba_requests_list[0],
                     )
                 )
             ]
 
         results = []
         for index, item in enumerate(query_results):
-            response, _, reverse = item
+            referrer, response, _, reverse = item
             try:
                 body = json.loads(response.data)
                 if SNUBA_INFO:
                     if "sql" in body:
                         log_snuba_info(
                             "{}.sql:\n {}".format(
-                                headers.get("referer", "<unknown>"),
+                                referrer,
                                 sqlparse.format(body["sql"], reindent_aligned=True),
                             )
                         )
                     if "error" in body:
-                        log_snuba_info(
-                            "{}.err: {}".format(headers.get("referer", "<unknown>"), body["error"])
-                        )
+                        log_snuba_info("{}.err: {}".format(referrer, body["error"]))
             except ValueError:
                 if response.status != 200:
                     logger.exception(
@@ -1070,18 +1086,18 @@ def _bulk_snuba_query(
                     "throttled_by" in quota_allowance_summary
                     and quota_allowance_summary["throttled_by"]
                 ):
-                    metrics.incr("snuba.client.query.throttle", tags={"referrer": query_referrer})
+                    metrics.incr("snuba.client.query.throttle", tags={"referrer": referrer})
                     if random.random() < 0.01:
                         logger.warning("Query is throttled", extra={"response.data": response.data})
                         sentry_sdk.capture_message(
-                            f"Query from referrer {query_referrer} is throttled", level="info"
+                            f"Query from referrer {referrer} is throttled", level="info"
                         )
 
             if response.status != 200:
-                _log_request_query(snuba_param_list[index][0])
+                _log_request_query(snuba_requests_list[index].request)
                 metrics.incr(
                     "snuba.client.api.error",
-                    tags={"status_code": response.status, "referrer": query_referrer},
+                    tags={"status_code": response.status, "referrer": referrer},
                 )
                 if body.get("error"):
                     error = body["error"]
@@ -1119,37 +1135,50 @@ def _log_request_query(req: Request) -> None:
     )
 
 
-RawResult = tuple[urllib3.response.HTTPResponse, Callable[[Any], Any], Callable[[Any], Any]]
+RawResult = tuple[str, urllib3.response.HTTPResponse, Translator, Translator]
 
 
 def _snuba_query(
     params: tuple[
-        RequestQueryBody,
         sentry_sdk.Scope,
         sentry_sdk.Scope,
-        Mapping[str, str],
-        str,
+        SnubaRequest,
     ],
 ) -> RawResult:
     # Eventually we can get rid of this wrapper, but for now it's cleaner to unwrap
     # the params here than in the calling function. (bc of thread .map)
-    query_body, thread_isolation_scope, thread_current_scope, headers, parent_api = params
+    thread_isolation_scope, thread_current_scope, snuba_request = params
     with sentry_sdk.scope.use_isolation_scope(thread_isolation_scope):
         with sentry_sdk.scope.use_scope(thread_current_scope):
-            request, forward, reverse = query_body
-            request.parent_api = parent_api
+            headers = snuba_request.headers
+            request = snuba_request.request
             try:
                 referrer = headers.get("referer", "unknown")
+
                 if SNUBA_INFO:
                     import pprint
 
                     log_snuba_info(f"{referrer}.body:\n {pprint.pformat(request.to_dict())}")
                     request.flags.debug = True
 
-                if isinstance(request.query, MetricsQuery):
-                    return _raw_mql_query(request, headers), forward, reverse
+                # We set both span + sdk level, this is cause 1 txn/error might query snuba more than once
+                # but we still want to know a general sense of how referrers impact performance
+                sentry_sdk.set_tag("query.referrer", referrer)
 
-                return _raw_snql_query(request, headers), forward, reverse
+                if isinstance(request.query, MetricsQuery):
+                    return (
+                        referrer,
+                        _raw_mql_query(request, headers),
+                        snuba_request.forward,
+                        snuba_request.reverse,
+                    )
+
+                return (
+                    referrer,
+                    _raw_snql_query(request, headers),
+                    snuba_request.forward,
+                    snuba_request.reverse,
+                )
             except urllib3.exceptions.HTTPError as err:
                 raise SnubaError(err)
 
@@ -1158,6 +1187,7 @@ def _raw_mql_query(request: Request, headers: Mapping[str, str]) -> urllib3.resp
     # Enter hub such that http spans are properly nested
     with timer("mql_query"):
         referrer = headers.get("referer", "unknown")
+
         # TODO: This can be changed back to just `serialize` after we remove SnQL support for MetricsQuery
         serialized_req = request.serialize()
         with sentry_sdk.start_span(op="snuba_mql.validation", description=referrer) as span:
@@ -1175,6 +1205,7 @@ def _raw_snql_query(request: Request, headers: Mapping[str, str]) -> urllib3.res
     # Enter hub such that http spans are properly nested
     with timer("snql_query"):
         referrer = headers.get("referer", "<unknown>")
+
         serialized_req = request.serialize()
         with sentry_sdk.start_span(op="snuba_snql.validation", description=referrer) as span:
             span.set_tag("snuba.referrer", referrer)

--- a/tests/sentry/issues/test_attributes.py
+++ b/tests/sentry/issues/test_attributes.py
@@ -2,7 +2,6 @@ from collections.abc import Sequence
 from datetime import timedelta
 from unittest.mock import patch
 
-import sentry_sdk
 from django.utils import timezone
 from snuba_sdk.legacy import json_to_snql
 
@@ -19,8 +18,7 @@ from sentry.models.groupowner import GroupOwner, GroupOwnerType
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers import override_options
 from sentry.types.group import GroupSubStatus
-from sentry.utils import json
-from sentry.utils.snuba import _snuba_query
+from sentry.utils.snuba import raw_snql_query
 
 
 class GroupAttributesTest(TestCase):
@@ -237,14 +235,7 @@ class PostUpdateLogGroupAttributesChangedTest(TestCase):
             }
             request = json_to_snql(json_body, "group_attributes")
             request.validate()
-            identity = lambda x: x
-            isolation_scope = sentry_sdk.Scope.get_isolation_scope().fork()
-            current_scope = sentry_sdk.Scope.get_current_scope().fork()
-            resp = _snuba_query(
-                ((request, identity, identity), isolation_scope, current_scope, {}, "test_api")
-            )
-            assert resp[0].status == 200
-            stuff = json.loads(resp[0].data)
+            stuff = raw_snql_query(request)
             assert stuff["data"] == [
                 {"project_id": g.project_id, "group_id": g.id, **snuba_fields} for g in groups
             ]

--- a/tests/sentry/issues/test_attributes.py
+++ b/tests/sentry/issues/test_attributes.py
@@ -235,7 +235,7 @@ class PostUpdateLogGroupAttributesChangedTest(TestCase):
             }
             request = json_to_snql(json_body, "group_attributes")
             request.validate()
-            stuff = raw_snql_query(request)
-            assert stuff["data"] == [
+            result = raw_snql_query(request)
+            assert result["data"] == [
                 {"project_id": g.project_id, "group_id": g.id, **snuba_fields} for g in groups
             ]

--- a/tests/sentry/issues/test_group_attributes_dataset.py
+++ b/tests/sentry/issues/test_group_attributes_dataset.py
@@ -29,8 +29,8 @@ class DatasetTest(SnubaTestCase, TestCase):
         }
         request = json_to_snql(json_body, "group_attributes")
         request.validate()
-        stuff = raw_snql_query(request)
-        assert len(stuff["data"]) == 0
+        result = raw_snql_query(request)
+        assert len(result["data"]) == 0
 
     def test_insert_then_query(self) -> None:
         project = self.create_project()
@@ -56,5 +56,5 @@ class DatasetTest(SnubaTestCase, TestCase):
         }
         request = json_to_snql(json_body, "group_attributes")
         request.validate()
-        stuff = raw_snql_query(request)
-        assert len(stuff["data"]) == 1
+        result = raw_snql_query(request)
+        assert len(result["data"]) == 1

--- a/tests/sentry/issues/test_group_attributes_dataset.py
+++ b/tests/sentry/issues/test_group_attributes_dataset.py
@@ -1,4 +1,3 @@
-import sentry_sdk
 from sentry_kafka_schemas.schema_types.group_attributes_v1 import GroupAttributesSnapshot
 from snuba_sdk.legacy import json_to_snql
 
@@ -8,8 +7,7 @@ from sentry.issues.attributes import (
     produce_snapshot_to_kafka,
 )
 from sentry.testutils.cases import SnubaTestCase, TestCase
-from sentry.utils import json
-from sentry.utils.snuba import _snuba_query
+from sentry.utils.snuba import raw_snql_query
 
 
 class DatasetTest(SnubaTestCase, TestCase):
@@ -31,15 +29,7 @@ class DatasetTest(SnubaTestCase, TestCase):
         }
         request = json_to_snql(json_body, "group_attributes")
         request.validate()
-        identity = lambda x: x
-        isolation_scope = sentry_sdk.Scope.get_isolation_scope().fork()
-        current_scope = sentry_sdk.Scope.get_current_scope().fork()
-        resp = _snuba_query(
-            ((request, identity, identity), isolation_scope, current_scope, {}, "test_api")
-        )
-        assert resp[0].status == 200
-        stuff = json.loads(resp[0].data)
-
+        stuff = raw_snql_query(request)
         assert len(stuff["data"]) == 0
 
     def test_insert_then_query(self) -> None:
@@ -66,13 +56,5 @@ class DatasetTest(SnubaTestCase, TestCase):
         }
         request = json_to_snql(json_body, "group_attributes")
         request.validate()
-        identity = lambda x: x
-        isolation_scope = sentry_sdk.Scope.get_isolation_scope().fork()
-        current_scope = sentry_sdk.Scope.get_current_scope().fork()
-        resp = _snuba_query(
-            ((request, identity, identity), isolation_scope, current_scope, {}, "test_api")
-        )
-        assert resp[0].status == 200
-        stuff = json.loads(resp[0].data)
-
+        stuff = raw_snql_query(request)
         assert len(stuff["data"]) == 1

--- a/tests/sentry/issues/test_search_issues_dataset.py
+++ b/tests/sentry/issues/test_search_issues_dataset.py
@@ -1,11 +1,9 @@
 from datetime import datetime, timedelta
 
-import sentry_sdk
 from snuba_sdk.legacy import json_to_snql
 
 from sentry.testutils.cases import SnubaTestCase, TestCase
-from sentry.utils import json
-from sentry.utils.snuba import _snuba_query
+from sentry.utils.snuba import raw_snql_query
 
 
 class DatasetTest(SnubaTestCase, TestCase):
@@ -30,13 +28,5 @@ class DatasetTest(SnubaTestCase, TestCase):
         }
         request = json_to_snql(json_body, "search_issues")
         request.validate()
-        identity = lambda x: x
-        isolation_scope = sentry_sdk.Scope.get_isolation_scope().fork()
-        current_scope = sentry_sdk.Scope.get_current_scope().fork()
-        resp = _snuba_query(
-            ((request, identity, identity), isolation_scope, current_scope, {}, "test_api")
-        )
-        assert resp[0].status == 200
-        stuff = json.loads(resp[0].data)
-
+        stuff = raw_snql_query(request)
         assert len(stuff["data"]) == 0

--- a/tests/sentry/issues/test_search_issues_dataset.py
+++ b/tests/sentry/issues/test_search_issues_dataset.py
@@ -28,5 +28,5 @@ class DatasetTest(SnubaTestCase, TestCase):
         }
         request = json_to_snql(json_body, "search_issues")
         request.validate()
-        stuff = raw_snql_query(request)
-        assert len(stuff["data"]) == 0
+        result = raw_snql_query(request)
+        assert len(result["data"]) == 0

--- a/tests/snuba/tsdb/test_tsdb_backend.py
+++ b/tests/snuba/tsdb/test_tsdb_backend.py
@@ -618,8 +618,8 @@ class SnubaTSDBTest(TestCase, SnubaTestCase):
             end = self.now
             start = end + timedelta(days=-1, seconds=rollup)
             self.db.get_data(TSDBModel.group, [1, 2, 3, 4, 5], start, end, rollup=rollup)
-            assert snuba.call_args.args[0][0][0].query.limit == Limit(120)
-            assert snuba.call_args.args[0][0][0].flags.consistent is True
+            assert snuba.call_args.args[0][0].request.query.limit == Limit(120)
+            assert snuba.call_args.args[0][0].request.flags.consistent is True
 
 
 class SnubaTSDBGroupProfilingTest(TestCase, SnubaTestCase, SearchIssueTestMixin):


### PR DESCRIPTION
Snuba queries only allow for a single referrer for a batch of parallel queries. But sometimes, these queries have nothing to do with each other and using the same referrer is not ideal. This refactor prepares the utilities to allow callers to pass a referrer per query.