### PR TITLE
ref(proguard): Reset LPQ budget to base value

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -3073,17 +3073,16 @@ SENTRY_LPQ_OPTIONS = {
     # There is one budget for each of the symbolication platforms: native, js, and jvm.
     # The "project_budget" value exists for backward compatibility.
     #
-    # This has been arbitrarily chosen as `5.0` for native and js, which means an average of:
+    # This has been arbitrarily chosen as `5.0`, which means an average of:
     # -  1x 5-second event per second, or
     # -  5x 1-second events per second, or
     # - 10x 0.5-second events per second
     #
-    # For jvm events we use a higher budget of `7.5`.
     # Cost increases quadratically with symbolication time.
     "project_budget": 5.0,
     "project_budget_native": 5.0,
     "project_budget_js": 5.0,
-    "project_budget_jvm": 7.5,
+    "project_budget_jvm": 5.0,
 }
 
 # XXX(meredith): Temporary metrics indexer


### PR DESCRIPTION
As of https://github.com/getsentry/symbolicator/pull/1491 proguard processing times are much more reasonable. We can use the base value for LPQ time now.