### PR TITLE
chore(trace-explorer): Cleanup enforce project selection flag in UI

### DIFF
--- a/static/app/views/traces/content.tsx
+++ b/static/app/views/traces/content.tsx
@@ -21,7 +21,6 @@ import Panel from 'sentry/components/panels/panel';
 import PanelHeader from 'sentry/components/panels/panelHeader';
 import PanelItem from 'sentry/components/panels/panelItem';
 import PerformanceDuration from 'sentry/components/performanceDuration';
-import {Tooltip} from 'sentry/components/tooltip';
 import {IconArrow} from 'sentry/icons/iconArrow';
 import {IconChevron} from 'sentry/icons/iconChevron';
 import {IconClose} from 'sentry/icons/iconClose';
@@ -62,7 +61,6 @@ import {
 import {TracesChart} from './tracesChart';
 import {TracesSearchBar} from './tracesSearchBar';
 import {
-  ALL_PROJECTS,
   areQueriesEmpty,
   getSecondaryNameFromSpan,
   getStylingSliceName,
@@ -186,22 +184,7 @@ export function Content() {
   return (
     <LayoutMain fullWidth>
       <PageFilterBar condensed>
-        {organization.features.includes('performance-trace-explorer-enforce-projects') ? (
-          <ProjectPageFilter />
-        ) : (
-          <Tooltip
-            title={tct(
-              "Traces stem across multiple projects. You'll need to narrow down which projects you'd like to include per span.[br](ex. [code:project:javascript])",
-              {
-                br: <br />,
-                code: <Code />,
-              }
-            )}
-            position="bottom"
-          >
-            <ProjectPageFilter disabled projectOverride={ALL_PROJECTS} />
-          </Tooltip>
-        )}
+        <ProjectPageFilter />
         <EnvironmentPageFilter />
         <DatePageFilter defaultPeriod="2h" />
       </PageFilterBar>
@@ -939,8 +922,4 @@ const StyledAlert = styled(Alert)`
 
 const StyledCloseButton = styled(IconClose)`
   cursor: pointer;
-`;
-
-const Code = styled('code')`
-  color: ${p => p.theme.red400};
 `;

--- a/static/app/views/traces/utils.tsx
+++ b/static/app/views/traces/utils.tsx
@@ -1,6 +1,5 @@
 import type {Location, LocationDescriptor} from 'history';
 
-import {ALL_ACCESS_PROJECTS} from 'sentry/constants/pageFilters';
 import type {Organization} from 'sentry/types/organization';
 
 import type {SpanResult, TraceResult} from './content';
@@ -99,5 +98,3 @@ export function getShortenedSdkName(sdkName: string | null) {
   }
   return sdkNameParts[sdkNameParts.length - 1];
 }
-
-export const ALL_PROJECTS = [ALL_ACCESS_PROJECTS];


### PR DESCRIPTION
Flag enabled by default now, we can remove this.