### PR TITLE
fix(replay): Video player plays correct clip time

### DIFF
--- a/static/app/components/replays/videoReplayer.tsx
+++ b/static/app/components/replays/videoReplayer.tsx
@@ -446,8 +446,10 @@ export class VideoReplayer {
 
   protected setVideoTime(video: HTMLVideoElement, timeMs: number) {
     // If 'ended' is true, the current time will be overwritten to 0 after hitting play.
-    // This ensures that ended is reset to false so current time doesn't get overwritten
+    // Setting currentTime will cause a side-effect of resetting 'ended' to false.
+    // The additional assignment of currentTime is required to make sure ended is reset before we assign the actual currentTime
     if (video.ended && timeMs > 0) {
+      // we set it to 1ms before to reduce flickering
       video.currentTime = (timeMs - 1) / 1000;
     }
 

--- a/static/app/components/replays/videoReplayer.tsx
+++ b/static/app/components/replays/videoReplayer.tsx
@@ -447,7 +447,10 @@ export class VideoReplayer {
   protected setVideoTime(video: HTMLVideoElement, timeMs: number) {
     // If 'ended' is true, the current time will be overwritten to 0 after hitting play.
     // This ensures that ended is reset to false so current time doesn't get overwritten
-    video.currentTime = 0;
+    if (timeMs > 0) {
+      video.currentTime = (timeMs - 1) / 1000;
+    }
+
     // Needs to be in seconds
     video.currentTime = timeMs / 1000;
   }

--- a/static/app/components/replays/videoReplayer.tsx
+++ b/static/app/components/replays/videoReplayer.tsx
@@ -445,6 +445,9 @@ export class VideoReplayer {
   }
 
   protected setVideoTime(video: HTMLVideoElement, timeMs: number) {
+    // If 'ended' is true, the current time will be overwritten to 0 after hitting play.
+    // This ensures that ended is reset to false so current time doesn't get overwritten
+    video.currentTime = 0;
     // Needs to be in seconds
     video.currentTime = timeMs / 1000;
   }

--- a/static/app/components/replays/videoReplayer.tsx
+++ b/static/app/components/replays/videoReplayer.tsx
@@ -447,7 +447,7 @@ export class VideoReplayer {
   protected setVideoTime(video: HTMLVideoElement, timeMs: number) {
     // If 'ended' is true, the current time will be overwritten to 0 after hitting play.
     // This ensures that ended is reset to false so current time doesn't get overwritten
-    if (timeMs > 0) {
+    if (video.ended && timeMs > 0) {
       video.currentTime = (timeMs - 1) / 1000;
     }
 


### PR DESCRIPTION
**The problem:**
When pausing and playing a video replay near the end of the segment, the video's `ended` state changes from false to true. This state tells us if the video has ended, and when it's `true`, if the video is played, it will overwrite the video's current time to 0 and play that segment from the beginning instead.
When pausing and playing the video, the `ended` state should be `false`.

**This fix:**
Since the `ended` state is `true` when playing the video after pausing, we want to reset to state to `false` so that we can play the video from the current time instead of having the current time overwritten to 0. The `ended` state changes to `false` when the video's current time changes, so we initially set the current time to a millisecond before the current time we want, which would reduce flickering from the video changing.

**Example replay:**
Correct video play through:

https://github.com/getsentry/sentry/assets/55311782/f6fc0fdc-831a-42d8-b952-d835b1208681

Before when pausing at end of video segment results in playing clip from beginning:

https://github.com/getsentry/sentry/assets/55311782/0edd0595-53d4-4f3a-8ed7-a9b9921de800

After fix: 

https://github.com/getsentry/sentry/assets/55311782/5e17f60f-3288-41f0-a936-78f4267b233c


Relates to https://github.com/getsentry/sentry/issues/70687