### PR TITLE
chore(issues): Add streamlined issue details flag

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -142,6 +142,8 @@ def register_temporary_features(manager: FeatureManager):
     manager.add("organizations:issue-details-autofix-ui", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
     # Enables a toggle for entering the new issue details UI
     manager.add("organizations:issue-details-new-experience-toggle", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
+    # Enables access to the streamlined issue details UI
+    manager.add("organizations:issue-details-streamline", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE)
     # Whether to allow issue only search on the issue list
     manager.add("organizations:issue-search-allow-postgres-only-search", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
     # Whether to make a side/parallel query against events -> group_attributes when searching issues

--- a/static/app/views/issueDetails/utils.tsx
+++ b/static/app/views/issueDetails/utils.tsx
@@ -9,6 +9,7 @@ import {useLegacyStore} from 'sentry/stores/useLegacyStore';
 import type {Group, GroupActivity} from 'sentry/types';
 import type {Event} from 'sentry/types/event';
 import {useLocation} from 'sentry/utils/useLocation';
+import useOrganization from 'sentry/utils/useOrganization';
 
 export function markEventSeen(
   api: Client,
@@ -232,4 +233,13 @@ export function getGroupEventDetailsQueryData({
   }
 
   return {...defaultParams, environment: environments};
+}
+
+export function useHasStreamlinedUI() {
+  const location = useLocation();
+  const organization = useOrganization();
+  return (
+    location.query.streamline === '1' ||
+    organization.features.includes('issue-details-streamline')
+  );
 }


### PR DESCRIPTION
This flag will be used for the ui changes on the issue details pages. The hook is unused so it should be safe to add.