### PR TITLE
chore(deletions) Fix project deletions

### DIFF
--- a/src/sentry/deletions/__init__.py
+++ b/src/sentry/deletions/__init__.py
@@ -95,6 +95,7 @@ def load_defaults():
     )
     from sentry.models.commitfilechange import CommitFileChange
     from sentry.monitors import models as monitor_models
+    from sentry.snuba import models as snuba_models
 
     from . import defaults
 
@@ -148,6 +149,7 @@ def load_defaults():
     default_manager.register(models.ProjectBookmark, BulkModelDeletionTask)
     default_manager.register(models.ProjectKey, BulkModelDeletionTask)
     default_manager.register(models.PullRequest, defaults.PullRequestDeletionTask)
+    default_manager.register(snuba_models.QuerySubscription, defaults.QuerySubscriptionDeletionTask)
     default_manager.register(models.Release, defaults.ReleaseDeletionTask)
     default_manager.register(models.ReleaseCommit, BulkModelDeletionTask)
     default_manager.register(models.ReleaseEnvironment, BulkModelDeletionTask)

--- a/src/sentry/deletions/defaults/__init__.py
+++ b/src/sentry/deletions/defaults/__init__.py
@@ -14,6 +14,7 @@ from .organizationmember import *  # noqa: F401,F403
 from .platform_external_issue import *  # noqa: F401,F403
 from .project import *  # noqa: F401,F403
 from .pullrequest import *  # noqa: F401,F403
+from .querysubscription import *  # noqa: F401,F403
 from .release import *  # noqa: F401,F403
 from .repository import *  # noqa: F401,F403
 from .repositoryprojectpathconfig import *  # noqa: F401,F403

--- a/src/sentry/deletions/defaults/project.py
+++ b/src/sentry/deletions/defaults/project.py
@@ -84,11 +84,12 @@ class ProjectDeletionTask(ModelDeletionTask):
             ProguardArtifactRelease,
             DiscoverSavedQueryProject,
             IncidentProject,
-            QuerySubscription,
         ):
             relations.append(ModelRelation(m, {"project_id": instance.id}, BulkModelDeletionTask))
+
         relations.append(ModelRelation(Monitor, {"project_id": instance.id}))
         relations.append(ModelRelation(Group, {"project_id": instance.id}))
+        relations.append(ModelRelation(QuerySubscription, {"project_id": instance.id}))
         relations.append(
             ModelRelation(
                 AlertRule,

--- a/src/sentry/deletions/defaults/querysubscription.py
+++ b/src/sentry/deletions/defaults/querysubscription.py
@@ -1,0 +1,12 @@
+from sentry.snuba.models import QuerySubscription
+
+from ..base import ModelDeletionTask
+
+
+class QuerySubscriptionDeletionTask(ModelDeletionTask):
+    def delete_instance(self, instance: QuerySubscription) -> None:
+        from sentry.incidents.models.incident import Incident
+
+        # Clear the foreign key as the schema was created without a cascade clause
+        Incident.objects.filter(subscription_id=instance.id).update(subscription_id=None)
+        super().delete_instance(instance)

--- a/tests/sentry/deletions/test_project.py
+++ b/tests/sentry/deletions/test_project.py
@@ -26,6 +26,7 @@ from sentry.monitors.models import (
     MonitorType,
     ScheduleType,
 )
+from sentry.snuba.models import QuerySubscription, SnubaQuery
 from sentry.tasks.deletion.scheduled import run_scheduled_deletions
 from sentry.testutils.cases import APITestCase, TransactionTestCase
 from sentry.testutils.helpers.datetime import before_now, iso_format
@@ -108,11 +109,27 @@ class DeleteProjectTest(APITestCase, TransactionTestCase, HybridCloudTestMixin):
             date_added=monitor.date_added,
             status=CheckInStatus.OK,
         )
+        snuba_query = SnubaQuery.objects.create(
+            environment=env,
+            type=0,
+            query="title:ohno",
+            aggregate="",
+            time_window=3600,
+            resolution=60,
+        )
+        query_sub = QuerySubscription.objects.create(
+            project=project,
+            snuba_query=snuba_query,
+            status=0,
+            subscription_id="a-snuba-id-maybe",
+            query_extra="",
+        )
         incident = self.create_incident(
             organization=project.organization,
             projects=[project],
             alert_rule=metric_alert_rule,
             title="Something bad happened",
+            subscription=query_sub,
         )
 
         rule_snooze = self.snooze_rule(user_id=self.user.id, alert_rule=metric_alert_rule)
@@ -131,12 +148,14 @@ class DeleteProjectTest(APITestCase, TransactionTestCase, HybridCloudTestMixin):
         assert Release.objects.filter(id=release.id).exists()
         assert ReleaseCommit.objects.filter(release_id=release.id).exists()
         assert Commit.objects.filter(id=commit.id).exists()
+        assert SnubaQuery.objects.filter(id=snuba_query.id).exists()
         assert not ProjectDebugFile.objects.filter(id=dif.id).exists()
         assert not File.objects.filter(id=file.id).exists()
         assert not ServiceHook.objects.filter(id=hook.id).exists()
         assert not Monitor.objects.filter(id=monitor.id).exists()
         assert not MonitorEnvironment.objects.filter(id=monitor_env.id).exists()
         assert not MonitorCheckIn.objects.filter(id=checkin.id).exists()
+        assert not QuerySubscription.objects.filter(id=query_sub.id).exists()
 
         incident.refresh_from_db()
         assert len(incident.projects.all()) == 0, "Project relation should be removed"


### PR DESCRIPTION
Fix stuck deletions caused by foreign key constraints. The QuerySubscription -> Incident relation is blocking deletions. Setting Incident.subscription_id = null will unblock deletions and lets the incident outlive the project.

Fixes SENTRY-3AVB