### PR TITLE
feat(options): Introduce a limit for metric extrapolation

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1466,6 +1466,12 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 
+register(
+    "sentry-metrics.extrapolation.duplication-limit",
+    default=0,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+
 # Performance issue option for *all* performance issues detection
 register("performance.issues.all.problem-detection", default=1.0, flags=FLAG_AUTOMATOR_MODIFIABLE)
 

--- a/src/sentry/relay/globalconfig.py
+++ b/src/sentry/relay/globalconfig.py
@@ -25,6 +25,7 @@ RELAY_OPTIONS: list[str] = [
     "feedback.ingest-topic.rollout-rate",
     "relay.span-extraction.sample-rate",
     "relay.compute-metrics-summaries.sample-rate",
+    "sentry-metrics.extrapolation.duplication-limit",
 ]
 
 


### PR DESCRIPTION
Relay duplicates distribution values for metrics extrapolation. This option
controls the maximum number of duplicates for safety reasons.

See https://github.com/getsentry/relay/pull/3753

