### PR TITLE
feat(tags): Make dataset a parameter in organization_tags endpoint 

### DIFF
--- a/src/sentry/api/endpoints/organization_tags.py
+++ b/src/sentry/api/endpoints/organization_tags.py
@@ -38,7 +38,6 @@ class OrganizationTagsEndpoint(OrganizationEndpoint):
         with sentry_sdk.start_span(op="tagstore", description="get_tag_keys_for_projects"):
             with handle_query_errors():
                 results = tagstore.backend.get_tag_keys_for_projects(
-                    organization.id,
                     filter_params["project_id"],
                     filter_params.get("environment"),
                     filter_params["start"],

--- a/src/sentry/api/endpoints/organization_tags.py
+++ b/src/sentry/api/endpoints/organization_tags.py
@@ -33,7 +33,7 @@ class OrganizationTagsEndpoint(OrganizationEndpoint):
             try:
                 dataset = Dataset(request.GET.get("dataset", "discover"))
             except ValueError:
-                raise ParseError("Invalid dataset parameter")
+                raise ParseError(detail="Invalid dataset parameter")
 
         with sentry_sdk.start_span(op="tagstore", description="get_tag_keys_for_projects"):
             with handle_query_errors():

--- a/src/sentry/api/endpoints/organization_tags.py
+++ b/src/sentry/api/endpoints/organization_tags.py
@@ -29,12 +29,16 @@ class OrganizationTagsEndpoint(OrganizationEndpoint):
         except NoProjects:
             return Response([])
 
-        if request.GET.get("dataset") and request.GET.get("dataset") not in Dataset:
-            raise ParseError("Invalid dataset parameter")
+        if request.GET.get("dataset"):
+            try:
+                Dataset(request.GET.get("dataset"))
+            except ValueError:
+                raise ParseError("Invalid dataset parameter")
 
         with sentry_sdk.start_span(op="tagstore", description="get_tag_keys_for_projects"):
             with handle_query_errors():
                 results = tagstore.backend.get_tag_keys_for_projects(
+                    organization.id,
                     filter_params["project_id"],
                     filter_params.get("environment"),
                     filter_params["start"],

--- a/src/sentry/api/endpoints/organization_tags.py
+++ b/src/sentry/api/endpoints/organization_tags.py
@@ -31,9 +31,11 @@ class OrganizationTagsEndpoint(OrganizationEndpoint):
 
         if request.GET.get("dataset"):
             try:
-                dataset = Dataset(request.GET.get("dataset", "discover"))
+                dataset = Dataset(request.GET.get("dataset"))
             except ValueError:
                 raise ParseError(detail="Invalid dataset parameter")
+        else:
+            dataset = Dataset.Discover
 
         with sentry_sdk.start_span(op="tagstore", description="get_tag_keys_for_projects"):
             with handle_query_errors():

--- a/src/sentry/api/endpoints/organization_tags.py
+++ b/src/sentry/api/endpoints/organization_tags.py
@@ -54,6 +54,7 @@ class OrganizationTagsEndpoint(OrganizationEndpoint):
                     "custom_tags.count.grouped",
                     format_grouped_length(len(results), [1, 10, 50, 100]),
                 )
+                sentry_sdk.set_tag("dataset_queried", request.GET.get("dataset", "discover"))
                 set_measurement("custom_tags.count", len(results))
 
         return Response(serialize(results, request.user))

--- a/src/sentry/api/endpoints/organization_tags.py
+++ b/src/sentry/api/endpoints/organization_tags.py
@@ -31,7 +31,7 @@ class OrganizationTagsEndpoint(OrganizationEndpoint):
 
         if request.GET.get("dataset"):
             try:
-                Dataset(request.GET.get("dataset"))
+                dataset = Dataset(request.GET.get("dataset", "discover"))
             except ValueError:
                 raise ParseError("Invalid dataset parameter")
 
@@ -43,7 +43,7 @@ class OrganizationTagsEndpoint(OrganizationEndpoint):
                     filter_params["start"],
                     filter_params["end"],
                     use_cache=request.GET.get("use_cache", "0") == "1",
-                    dataset=Dataset(request.GET.get("dataset", "discover")),
+                    dataset=dataset,
                     tenant_ids={"organization_id": organization.id},
                 )
 
@@ -57,7 +57,7 @@ class OrganizationTagsEndpoint(OrganizationEndpoint):
                     "custom_tags.count.grouped",
                     format_grouped_length(len(results), [1, 10, 50, 100]),
                 )
-                sentry_sdk.set_tag("dataset_queried", request.GET.get("dataset", "discover"))
+                sentry_sdk.set_tag("dataset_queried", dataset)
                 set_measurement("custom_tags.count", len(results))
 
         return Response(serialize(results, request.user))

--- a/src/sentry/tagstore/base.py
+++ b/src/sentry/tagstore/base.py
@@ -143,7 +143,6 @@ class TagStorage(Service):
         dataset: Dataset = Dataset.Events,
         status=TagKeyStatus.ACTIVE,
         use_cache: bool = False,
-        include_transactions: bool = False,
         tenant_ids=None,
     ):
         """

--- a/src/sentry/tagstore/base.py
+++ b/src/sentry/tagstore/base.py
@@ -1,6 +1,7 @@
 import re
 
 from sentry.constants import TAG_LABELS
+from sentry.snuba.dataset import Dataset
 from sentry.utils.services import Service
 
 # Valid pattern for tag key names
@@ -139,6 +140,7 @@ class TagStorage(Service):
         environments,
         start,
         end,
+        dataset: Dataset = Dataset.Events,
         status=TagKeyStatus.ACTIVE,
         use_cache: bool = False,
         include_transactions: bool = False,

--- a/src/sentry/tagstore/snuba/backend.py
+++ b/src/sentry/tagstore/snuba/backend.py
@@ -218,7 +218,7 @@ class SnubaTagStorage(TagStorage):
         limit=1000,
         keys=None,
         include_values_seen=True,
-        include_transactions=False,
+        dataset: Dataset = Dataset.Events,
         denylist=None,
         tenant_ids=None,
         **kwargs,
@@ -232,7 +232,7 @@ class SnubaTagStorage(TagStorage):
             limit,
             keys,
             include_values_seen=include_values_seen,
-            include_transactions=include_transactions,
+            dataset=dataset,
             denylist=denylist,
             tenant_ids=tenant_ids,
         )
@@ -248,9 +248,8 @@ class SnubaTagStorage(TagStorage):
         keys=None,
         include_values_seen=True,
         use_cache=False,
-        include_transactions=False,
         denylist=None,
-        dataset: Dataset = Dataset.Events,
+        dataset: Dataset = Dataset.Discover,
         **kwargs,
     ):
         """Query snuba for tag keys based on projects
@@ -273,11 +272,6 @@ class SnubaTagStorage(TagStorage):
         if end is None:
             end = default_end
 
-        # If include_transactions is true, then the dataset parameter
-        # will be overwritten with Discover.
-        if include_transactions:
-            dataset = Dataset.Discover
-
         conditions = []
         aggregations = [["count()", "", "count"]]
 
@@ -285,7 +279,7 @@ class SnubaTagStorage(TagStorage):
         if environments:
             filters["environment"] = sorted(environments)
         if group is not None:
-            # We override dataset changes from `include_transactions` here. They aren't relevant
+            # We override dataset changes from `dataset` here. They aren't relevant
             # when filtering by a group.
             dataset, conditions, filters = self.apply_group_filters_conditions(
                 group, conditions, filters
@@ -434,7 +428,6 @@ class SnubaTagStorage(TagStorage):
         dataset: Dataset = Dataset.Events,
         status=TagKeyStatus.ACTIVE,
         use_cache: bool = False,
-        include_transactions: bool = False,
         tenant_ids=None,
     ):
         max_unsampled_projects = _max_unsampled_projects
@@ -457,7 +450,7 @@ class SnubaTagStorage(TagStorage):
             dataset=dataset,
             include_values_seen=False,
             use_cache=use_cache,
-            include_transactions=include_transactions,
+            dataset=dataset,
             tenant_ids=tenant_ids,
             **optimize_kwargs,
         )

--- a/src/sentry/tagstore/snuba/backend.py
+++ b/src/sentry/tagstore/snuba/backend.py
@@ -450,7 +450,6 @@ class SnubaTagStorage(TagStorage):
             dataset=dataset,
             include_values_seen=False,
             use_cache=use_cache,
-            dataset=dataset,
             tenant_ids=tenant_ids,
             **optimize_kwargs,
         )

--- a/src/sentry/tagstore/snuba/backend.py
+++ b/src/sentry/tagstore/snuba/backend.py
@@ -250,6 +250,7 @@ class SnubaTagStorage(TagStorage):
         use_cache=False,
         include_transactions=False,
         denylist=None,
+        dataset: Dataset = Dataset.Events,
         **kwargs,
     ):
         """Query snuba for tag keys based on projects
@@ -272,9 +273,11 @@ class SnubaTagStorage(TagStorage):
         if end is None:
             end = default_end
 
-        dataset = Dataset.Events
+        # If include_transactions is true, then the dataset parameter
+        # will be overwritten with Discover.
         if include_transactions:
             dataset = Dataset.Discover
+
         conditions = []
         aggregations = [["count()", "", "count"]]
 
@@ -428,6 +431,7 @@ class SnubaTagStorage(TagStorage):
         environments,
         start,
         end,
+        dataset: Dataset = Dataset.Events,
         status=TagKeyStatus.ACTIVE,
         use_cache: bool = False,
         include_transactions: bool = False,
@@ -450,6 +454,7 @@ class SnubaTagStorage(TagStorage):
             environments,
             start,
             end,
+            dataset=dataset,
             include_values_seen=False,
             use_cache=use_cache,
             include_transactions=include_transactions,

--- a/tests/snuba/api/endpoints/test_organization_tags.py
+++ b/tests/snuba/api/endpoints/test_organization_tags.py
@@ -1,14 +1,15 @@
+import uuid
 from unittest import mock
 
 from django.urls import reverse
 
+from sentry.testutils.cases import APITestCase, SnubaTestCase
 from sentry.testutils.helpers.datetime import before_now, iso_format
-from tests.snuba.api.endpoints.test_organization_events_facets_performance_histogram import (
-    OrganizationEventsFacetsPerformanceHistogramEndpointTest,
-)
+from sentry.utils.samples import load_data
+from tests.sentry.issues.test_utils import OccurrenceTestMixin
 
 
-class OrganizationTagsTest(OrganizationEventsFacetsPerformanceHistogramEndpointTest):
+class OrganizationTagsTest(APITestCase, OccurrenceTestMixin, SnubaTestCase):
     def setUp(self):
         super().setUp()
         self.min_ago = iso_format(before_now(minutes=1))
@@ -57,7 +58,7 @@ class OrganizationTagsTest(OrganizationEventsFacetsPerformanceHistogramEndpointT
             {"name": "Some Tag", "key": "some_tag", "totalValues": 1},
         ]
 
-    def test_dataset_param(self):
+    def test_dataset_events(self):
         user = self.create_user()
         org = self.create_organization()
         team = self.create_team(organization=org)
@@ -71,31 +72,97 @@ class OrganizationTagsTest(OrganizationEventsFacetsPerformanceHistogramEndpointT
             project_id=project.id,
         )
 
-        self.store_transaction(
-            project_id=self.project.id,
-            tags=[("stone_fruit", "cherry")],
-            user_id=user.id,
+        url = reverse(
+            "sentry-api-0-organization-tags", kwargs={"organization_id_or_slug": org.slug}
+        )
+
+        response = self.client.get(url, {"statsPeriod": "14d", "dataset": "events"}, format="json")
+
+        assert response.status_code == 200, response.content
+        data = response.data
+        data.sort(key=lambda val: val["name"])
+        assert data == [
+            {"name": "Berry", "key": "berry", "totalValues": 1},
+            {"name": "Level", "key": "level", "totalValues": 1},
+        ]
+
+    def test_dataset_discover(self):
+        user = self.create_user()
+        org = self.create_organization()
+        team = self.create_team(organization=org)
+        self.create_member(organization=org, user=user, teams=[team])
+
+        self.login_as(user=user)
+
+        project = self.create_project(organization=org, teams=[team])
+
+        url = reverse(
+            "sentry-api-0-organization-tags", kwargs={"organization_id_or_slug": org.slug}
+        )
+
+        event = load_data("transaction")
+        event["tags"].extend([["apple", "fuji"]])
+        event.update(
+            {
+                "transaction": "example_transaction",
+                "event_id": uuid.uuid4().hex,
+                "start_timestamp": self.min_ago,
+                "timestamp": self.min_ago,
+            }
+        )
+        event["measurements"]["lcp"]["value"] = 5000
+        self.store_event(data=event, project_id=project.id)
+
+        discoverResponse = self.client.get(
+            url,
+            {"statsPeriod": "14d", "dataset": "discover"},
+            format="json",
+        )
+        assert discoverResponse.status_code == 200, discoverResponse.content
+        assert {"name": "Apple", "key": "apple", "totalValues": 1} in discoverResponse.data
+
+    def test_dataset_issue_platform(self):
+        user = self.create_user()
+        org = self.create_organization()
+        team = self.create_team(organization=org)
+        self.create_member(organization=org, user=user, teams=[team])
+
+        self.login_as(user=user)
+
+        project = self.create_project(organization=org, teams=[team])
+
+        self.store_event(
+            data={"event_id": "a" * 32, "tags": {"berry": "raspberry"}, "timestamp": self.min_ago},
+            project_id=project.id,
+        )
+
+        self.process_occurrence(
+            event_id=uuid.uuid4().hex,
+            project_id=project.id,
+            event_data={
+                "title": "some problem",
+                "platform": "python",
+                "tags": {"stone_fruit": "cherry"},
+                "timestamp": before_now(minutes=1).isoformat(),
+                "received": before_now(minutes=1).isoformat(),
+            },
         )
 
         url = reverse(
             "sentry-api-0-organization-tags", kwargs={"organization_id_or_slug": org.slug}
         )
 
-        eventsResponse = self.client.get(
-            url, {"statsPeriod": "14d", "dataset": "events"}, format="json"
+        response = self.client.get(
+            url, {"statsPeriod": "14d", "dataset": "search_issues"}, format="json"
         )
-        assert eventsResponse.status_code == 200, eventsResponse.content
-        eventsData = eventsResponse.data
-        eventsData.sort(key=lambda val: val["name"])
-        assert eventsData == [
-            {"name": "Berry", "key": "berry", "totalValues": 1},
-            {"name": "Level", "key": "level", "totalValues": 1},
-        ]
 
-        # Performance dataset
-        # spansResponse = self.client.get(
-        #     url, {"statsPeriod": "14d", "dataset": "search_issues"}, format="json"
-        # )
+        assert response.status_code == 200, response.content
+        data = response.data
+        data.sort(key=lambda val: val["name"])
+        assert data == [
+            {"name": "Level", "key": "level", "totalValues": 1},
+            {"name": "Stone Fruit", "key": "stone_fruit", "totalValues": 1},
+        ]
 
     def test_no_projects(self):
         user = self.create_user()


### PR DESCRIPTION
Fixes #73699

This PR replaces the `include_transaction` parameter with a `dataset` parameter in the `organization_tags` endpoint. Previously, the `include_transactions` was used to control whether to pull tags from snuba's `Discover` dataset (if `include_transactions=1`, or `Events` dataset (if `include_transactions=0`). Replacing this "toggle" with an explicit Dataset parameter will enable full control over which dataset is being queried, which is useful for Issues search since it needs Events and IssuePlatform tags, but not Performance tags (included in Discover dataset). 