### PR TITLE
fix: lint `.ts` and `.js` files in CI

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -24,11 +24,11 @@ jobs:
     timeout-minutes: 3
     # Map a step output to a job output
     outputs:
-      lintable_prettier_modified: ${{ steps.changes.output.lintable_prettier_modified }}
-      lintable_prettier_modified_files: ${{ steps.changes.output.lintable_prettier_modified_files }}
+      lintable_prettier_modified: ${{ steps.changes.outputs.lintable_prettier_modified }}
+      lintable_prettier_modified_files: ${{ steps.changes.outputs.lintable_prettier_modified_files }}
       lintable_css_in_js_modified: ${{ steps.changes.outputs.lintable_css_in_js_modified }}
       lintable_css_in_js_modified_files: ${{ steps.changes.outputs.lintable_css_in_js_modified_files }}
-      lintable_css_in_js_rules_changed: ${{ steps.changes.output.lintable_css_in_js_rules_changed }}
+      lintable_css_in_js_rules_changed: ${{ steps.changes.outputs.lintable_css_in_js_rules_changed }}
       lintable_modified: ${{ steps.changes.outputs.lintable_modified }}
       lintable_modified_files: ${{ steps.changes.outputs.lintable_modified_files }}
       lintable_rules_changed: ${{ steps.changes.outputs.lintable_rules_changed }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -140,9 +140,9 @@ repos:
     rev: 'v3.1.0' # Use the sha or tag you want to point at
     hooks:
       - id: prettier
-        name: prettier (yaml, markdown, tsx, jsx, css)
+        name: prettier (yaml, markdown, ts, tsx, js, jsx, css)
         # TODO: Remove tsx and jsx when Biome supports styled CSS formatting.
-        types_or: [yaml, markdown, tsx, jsx, css]
+        types_or: [yaml, markdown, ts, tsx, javascript, jsx, css]
         # Override the default version of prettier since there isn't a tag with 3.2.5
         additional_dependencies: ['prettier@3.3.2']
         # https://pre-commit.com/#regular-expressions

--- a/static/app/views/insights/settings.ts
+++ b/static/app/views/insights/settings.ts
@@ -1,6 +1,6 @@
 import {t} from 'sentry/locale';
 import {MODULE_TITLE as RESOURCES_MODULE_TITLE} from 'sentry/views/insights/browser/resources/settings';
-import {  MODULE_TITLE as VITALS_MODULE_TITLE} from 'sentry/views/insights/browser/webVitals/settings';
+import {MODULE_TITLE as VITALS_MODULE_TITLE} from 'sentry/views/insights/browser/webVitals/settings';
 import {MODULE_TITLE as CACHE_MODULE_TITLE} from 'sentry/views/insights/cache/settings';
 import {MODULE_TITLE as DB_MODULE_TITLE} from 'sentry/views/insights/database/settings';
 import {MODULE_TITLE as HTTP_MODULE_TITLE} from 'sentry/views/insights/http/settings';

--- a/static/app/views/insights/settings.ts
+++ b/static/app/views/insights/settings.ts
@@ -1,6 +1,6 @@
 import {t} from 'sentry/locale';
 import {MODULE_TITLE as RESOURCES_MODULE_TITLE} from 'sentry/views/insights/browser/resources/settings';
-import {MODULE_TITLE as VITALS_MODULE_TITLE} from 'sentry/views/insights/browser/webVitals/settings';
+import {  MODULE_TITLE as VITALS_MODULE_TITLE} from 'sentry/views/insights/browser/webVitals/settings';
 import {MODULE_TITLE as CACHE_MODULE_TITLE} from 'sentry/views/insights/cache/settings';
 import {MODULE_TITLE as DB_MODULE_TITLE} from 'sentry/views/insights/database/settings';
 import {MODULE_TITLE as HTTP_MODULE_TITLE} from 'sentry/views/insights/http/settings';


### PR DESCRIPTION
We've been seeing issues lately where bad formatting in `.ts` files is making it into `master` and blocking deploys. This PR fixes the issue in `sentry`, `getsentry` PR coming separately but will look the same.

The flow is:

- someone makes a `.ts` change in an editor that doesn't run Prettier
- local `pre-commit` doesn't run Prettier on `.ts` files (Problem 1)
- the `pre-commit` PR check doesn't run Prettier on `.ts` files either, so there's no auto-fix
- the `prettier (changed files only)` task on the PR doesn't see any changed files, and doesn't run so there's no PR failure (Problem 2)
- the PR is merged into `master`. `typescript-and-lint` runs on _all_ files and finds the bad formatting

Problem 1: This PR updates the `pre-commit` config which will auto-lint the files before they're committed (in most cases) and make sure that `pre-commit` auto-fixes the files in the PR (in all cases)

Problem 2: This PR fixes a typo in the file names that prevented those names from being passed through to the tasks. With this fix, the `typescript-and-lint