### PR TITLE
chore(deps): Bump sentry-relay to 0.9.0

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -65,7 +65,7 @@ sentry-arroyo>=2.16.5
 sentry-kafka-schemas>=0.1.101
 sentry-ophio==0.2.7
 sentry-redis-tools>=0.1.7
-sentry-relay>=0.8.67
+sentry-relay>=0.9.0
 sentry-sdk>=2.7.0
 slack-sdk>=3.27.2
 snuba-sdk>=2.0.33

--- a/requirements-dev-frozen.txt
+++ b/requirements-dev-frozen.txt
@@ -185,7 +185,7 @@ sentry-forked-djangorestframework-stubs==3.15.0.post1
 sentry-kafka-schemas==0.1.101
 sentry-ophio==0.2.7
 sentry-redis-tools==0.1.7
-sentry-relay==0.8.67
+sentry-relay==0.9.0
 sentry-sdk==2.7.0
 sentry-usage-accountant==0.0.10
 simplejson==3.17.6

--- a/requirements-frozen.txt
+++ b/requirements-frozen.txt
@@ -126,7 +126,7 @@ sentry-arroyo==2.16.5
 sentry-kafka-schemas==0.1.101
 sentry-ophio==0.2.7
 sentry-redis-tools==0.1.7
-sentry-relay==0.8.67
+sentry-relay==0.9.0
 sentry-sdk==2.7.0
 sentry-usage-accountant==0.0.10
 simplejson==3.17.6


### PR DESCRIPTION
This contains the necessary changes for `profiler_id` to be normalized in the event schema.