### PR TITLE
fix(useDimensions): Block render until dimensions are recorded

### DIFF
--- a/static/app/utils/useDimensions.tsx
+++ b/static/app/utils/useDimensions.tsx
@@ -1,5 +1,5 @@
 import type {RefObject} from 'react';
-import {useCallback, useState} from 'react';
+import {useCallback, useLayoutEffect, useState} from 'react';
 import {useResizeObserver} from '@react-aria/utils';
 
 interface Props<Element extends HTMLElement> {
@@ -13,6 +13,14 @@ export function useDimensions<Element extends HTMLElement>({elementRef}: Props<E
   const [dimensions, setDimensions] = useState({height: 0, width: 0});
 
   const element = elementRef.current;
+
+  // Ensures that dimensions are set before the browser paints on first render
+  useLayoutEffect(() => {
+    setDimensions({
+      height: element?.clientHeight || 0,
+      width: element?.clientWidth || 0,
+    });
+  }, [element]);
 
   const onResize = useCallback(() => {
     setDimensions({


### PR DESCRIPTION
I wanted to use this hook but noticed that it was rendering with 0 height/width before the `onResize` kicked in and updated the dimensions. It looks like [useResizeObserver](https://github.com/adobe/react-spectrum/blob/main/packages/@react-aria/utils/src/useResizeObserver.ts) uses `useEffect` which is why we see this. I've added a `useLayoutEffect` on first render to ensure that the dimensions have been recorded first before painting. There is a slight performance hit here, but since the resizes are still in a useEffect, this only impacts the first render.

Here's an example of this working poorly in the issue trace timeline:

Before (see that the dots shift when it appears for the first time):

https://github.com/getsentry/sentry/assets/10888943/0f81d8f5-96c6-4232-9adc-218527f2f5f9

After (no shift)

https://github.com/getsentry/sentry/assets/10888943/0d6dcb06-9ece-4731-9b4a-fc1c3e7b2b06

