### PR TITLE
feat(query-builder): Add analytics when pressing enter to search

### DIFF
--- a/static/app/components/modals/savedSearchModal/savedSearchModalContent.tsx
+++ b/static/app/components/modals/savedSearchModal/savedSearchModalContent.tsx
@@ -68,6 +68,7 @@ export function SavedSearchModalContent({organization}: SavedSearchModalContentP
             useFormWrapper={false}
             disabled={disabled}
             query={value}
+            searchSource="saved_searches_modal"
           />
         )}
       </FormField>

--- a/static/app/components/searchQueryBuilder/context.tsx
+++ b/static/app/components/searchQueryBuilder/context.tsx
@@ -13,10 +13,11 @@ interface ContextData {
   filterKeySections: FilterKeySection[];
   focusOverride: FocusOverride | null;
   getTagValues: (tag: Tag, query: string) => Promise<string[]>;
+  handleSearch: (query: string) => void;
   keys: TagCollection;
   parsedQuery: ParseResult | null;
   query: string;
-  onSearch?: (query: string) => void;
+  searchSource: string;
 }
 
 export function useSearchQueryBuilder() {
@@ -31,5 +32,6 @@ export const SearchQueryBuilerContext = createContext<ContextData>({
   getTagValues: () => Promise.resolve([]),
   dispatch: () => {},
   parsedQuery: null,
-  onSearch: () => {},
+  handleSearch: () => {},
+  searchSource: '',
 });

--- a/static/app/components/searchQueryBuilder/index.spec.tsx
+++ b/static/app/components/searchQueryBuilder/index.spec.tsx
@@ -89,6 +89,7 @@ describe('SearchQueryBuilder', function () {
     initialQuery: '',
     filterKeySections: FITLER_KEY_SECTIONS,
     label: 'Query Builder',
+    searchSource: '',
   };
 
   describe('callbacks', function () {

--- a/static/app/components/searchQueryBuilder/index.stories.tsx
+++ b/static/app/components/searchQueryBuilder/index.stories.tsx
@@ -74,6 +74,7 @@ export default storyBook(SearchQueryBuilder, story => {
             initialQuery="browser.name:Firefox assigned:me custom_tag_name:123"
             filterKeySections={FITLER_KEY_SECTIONS}
             getTagValues={getTagValues}
+            searchSource="storybook"
           />
         </MinHeightSizingWindow>
       </Fragment>

--- a/static/app/components/searchQueryBuilder/input.tsx
+++ b/static/app/components/searchQueryBuilder/input.tsx
@@ -291,7 +291,7 @@ function SearchQueryBuilderInputInternal({
 
   const filterValue = getWordAtCursorPosition(inputValue, selectionIndex);
 
-  const {query, keys, dispatch, onSearch} = useSearchQueryBuilder();
+  const {query, keys, dispatch, handleSearch} = useSearchQueryBuilder();
   const aliasToKeyMap = useMemo(() => {
     return Object.fromEntries(Object.values(keys).map(key => [key.alias, key.key]));
   }, [keys]);
@@ -399,8 +399,8 @@ function SearchQueryBuilderInputInternal({
         resetInputValue();
 
         // Because the query does not change until a subsequent render,
-        // we need to do the replacement that is does in the ruducer here
-        onSearch?.(replaceTokenWithPadding(query, token, value));
+        // we need to do the replacement that is does in the reducer here
+        handleSearch(replaceTokenWithPadding(query, token, value));
       }}
       onExit={() => {
         if (inputValue !== token.value.trim()) {

--- a/static/app/components/searchQueryBuilder/plainTextQueryInput.tsx
+++ b/static/app/components/searchQueryBuilder/plainTextQueryInput.tsx
@@ -18,7 +18,7 @@ interface PlainTextQueryInputProps {
 
 export function PlainTextQueryInput({label}: PlainTextQueryInputProps) {
   const inputRef = useRef<HTMLTextAreaElement>(null);
-  const {query, parsedQuery, dispatch, onSearch} = useSearchQueryBuilder();
+  const {query, parsedQuery, dispatch, handleSearch} = useSearchQueryBuilder();
   const [cursorPosition, setCursorPosition] = useState(0);
 
   const setCursorPositionOnEvent = (event: SyntheticEvent<HTMLTextAreaElement>) => {
@@ -43,10 +43,10 @@ export function PlainTextQueryInput({label}: PlainTextQueryInputProps) {
 
       if (e.key === 'Enter') {
         e.preventDefault();
-        onSearch?.(query);
+        handleSearch(query);
       }
     },
-    [onSearch, query]
+    [handleSearch, query]
   );
 
   return (

--- a/static/app/components/searchQueryBuilder/useHandleSearch.tsx
+++ b/static/app/components/searchQueryBuilder/useHandleSearch.tsx
@@ -1,0 +1,83 @@
+import {useCallback} from 'react';
+import * as Sentry from '@sentry/react';
+
+import {saveRecentSearch} from 'sentry/actionCreators/savedSearches';
+import type {Client} from 'sentry/api';
+import {tokenIsInvalid} from 'sentry/components/searchQueryBuilder/utils';
+import type {ParseResult} from 'sentry/components/searchSyntax/parser';
+import type {Organization} from 'sentry/types/organization';
+import {trackAnalytics} from 'sentry/utils/analytics';
+import useApi from 'sentry/utils/useApi';
+import useOrganization from 'sentry/utils/useOrganization';
+
+type UseHandleSearchProps = {
+  parsedQuery: ParseResult | null;
+  savedSearchType: any;
+  searchSource: string;
+  onSearch?: (query: string) => void;
+};
+
+async function saveAsRecentSearch({
+  savedSearchType,
+  query,
+  api,
+  organization,
+}: {
+  api: Client;
+  organization: Organization;
+  query: string;
+  savedSearchType: any;
+}) {
+  // Only save recent search query if we have a savedSearchType (also 0 is a valid value)
+  // Do not save empty string queries (i.e. if they clear search)
+  if (typeof savedSearchType === 'undefined' || !query) {
+    return;
+  }
+
+  try {
+    await saveRecentSearch(api, organization.slug, savedSearchType, query);
+  } catch (err) {
+    // Silently capture errors if it fails to save
+    Sentry.captureException(err);
+  }
+}
+
+export function useHandleSearch({
+  parsedQuery,
+  savedSearchType,
+  searchSource,
+  onSearch,
+}: UseHandleSearchProps) {
+  const api = useApi();
+  const organization = useOrganization();
+
+  return useCallback(
+    (query: string) => {
+      onSearch?.(query);
+
+      const searchType = savedSearchType === 0 ? 'issues' : 'events';
+
+      if (parsedQuery?.some(token => tokenIsInvalid(token))) {
+        trackAnalytics('search.search_with_invalid', {
+          organization,
+          query,
+          search_type: searchType,
+          search_source: searchSource,
+          new_experience: true,
+        });
+        return;
+      }
+
+      trackAnalytics('search.searched', {
+        organization,
+        query,
+        search_type: searchType,
+        search_source: searchSource,
+        new_experience: true,
+      });
+
+      saveAsRecentSearch({api, organization, query, savedSearchType});
+    },
+    [api, onSearch, organization, parsedQuery, savedSearchType, searchSource]
+  );
+}

--- a/static/app/components/searchQueryBuilder/utils.tsx
+++ b/static/app/components/searchQueryBuilder/utils.tsx
@@ -133,6 +133,18 @@ export function collapseTextTokens(tokens: ParseResult | null) {
   }, []);
 }
 
+export function tokenIsInvalid(token: TokenResult<Token>) {
+  if (
+    token.type !== Token.FILTER &&
+    token.type !== Token.FREE_TEXT &&
+    token.type !== Token.LOGIC_BOOLEAN
+  ) {
+    return false;
+  }
+
+  return Boolean(token.invalid);
+}
+
 export function getValidOpsForFilter(
   filterToken: TokenResult<Token.FILTER>
 ): readonly TermOperator[] {

--- a/static/app/utils/analytics/searchAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/searchAnalyticsEvents.tsx
@@ -4,6 +4,7 @@ type SearchEventBase = {
   query: string;
   search_type: string;
   is_multi_project?: boolean;
+  new_experience?: boolean;
   search_source?: string;
 };
 

--- a/static/app/views/issueList/searchBar.tsx
+++ b/static/app/views/issueList/searchBar.tsx
@@ -198,6 +198,8 @@ function IssueListSearchBar({organization, tags, ...props}: Props) {
         onChange={value => {
           props.onClose?.(value, {validSearch: true});
         }}
+        searchSource={props.searchSource ?? 'issues'}
+        savedSearchType={SavedSearchType.ISSUE}
       />
     );
   }


### PR DESCRIPTION
This follows the same logic that exists in SmartSearchBar, which executes some extra logic whenever the enter key is pressed:

- Records `searched.searched` analytic event  if all is valid
- Records `search.search_with_invalid` analytic event if there are any invalid tokens
- Saves the query as a recent search (if you've passed in a savedSearchType)