### PR TITLE
feat(insights): Set desktop and mobile browser performance score components to optional

### DIFF
--- a/src/sentry/relay/config/__init__.py
+++ b/src/sentry/relay/config/__init__.py
@@ -409,7 +409,14 @@ def _should_extract_abnormal_mechanism(project: Project) -> bool:
     )
 
 
+def _should_performance_profiles_web_vitals_be_optional(organization: Organization) -> bool:
+    return features.has(
+        "organizations:insights-browser-webvitals-optional-components", organization
+    )
+
+
 def _get_desktop_browser_performance_profiles(organization: Organization) -> list[dict[str, Any]]:
+    optional = _should_performance_profiles_web_vitals_be_optional(organization)
     return [
         {
             "name": "Chrome",
@@ -419,28 +426,28 @@ def _get_desktop_browser_performance_profiles(organization: Organization) -> lis
                     "weight": 0.15,
                     "p10": 900.0,
                     "p50": 1600.0,
-                    "optional": False,
+                    "optional": optional,
                 },
                 {
                     "measurement": "lcp",
                     "weight": 0.30,
                     "p10": 1200.0,
                     "p50": 2400.0,
-                    "optional": False,
+                    "optional": optional,
                 },
                 {
                     "measurement": "cls",
                     "weight": 0.15,
                     "p10": 0.1,
                     "p50": 0.25,
-                    "optional": False,
+                    "optional": optional,
                 },
                 {
                     "measurement": "ttfb",
                     "weight": 0.10,
                     "p10": 200.0,
                     "p50": 400.0,
-                    "optional": False,
+                    "optional": optional,
                 },
             ],
             "condition": {
@@ -457,14 +464,14 @@ def _get_desktop_browser_performance_profiles(organization: Organization) -> lis
                     "weight": 0.15,
                     "p10": 900.0,
                     "p50": 1600.0,
-                    "optional": False,
+                    "optional": optional,
                 },
                 {
                     "measurement": "lcp",
                     "weight": 0.30,
                     "p10": 1200.0,
                     "p50": 2400.0,
-                    "optional": True,
+                    "optional": True,  # Only available on Firefox 122 and beyond
                 },
                 {
                     "measurement": "cls",
@@ -478,7 +485,7 @@ def _get_desktop_browser_performance_profiles(organization: Organization) -> lis
                     "weight": 0.10,
                     "p10": 200.0,
                     "p50": 400.0,
-                    "optional": False,
+                    "optional": optional,
                 },
             ],
             "condition": {
@@ -495,7 +502,7 @@ def _get_desktop_browser_performance_profiles(organization: Organization) -> lis
                     "weight": 0.15,
                     "p10": 900.0,
                     "p50": 1600.0,
-                    "optional": False,
+                    "optional": optional,
                 },
                 {
                     "measurement": "lcp",
@@ -516,7 +523,7 @@ def _get_desktop_browser_performance_profiles(organization: Organization) -> lis
                     "weight": 0.10,
                     "p10": 200.0,
                     "p50": 400.0,
-                    "optional": False,
+                    "optional": optional,
                 },
             ],
             "condition": {
@@ -533,28 +540,28 @@ def _get_desktop_browser_performance_profiles(organization: Organization) -> lis
                     "weight": 0.15,
                     "p10": 900.0,
                     "p50": 1600.0,
-                    "optional": False,
+                    "optional": optional,
                 },
                 {
                     "measurement": "lcp",
                     "weight": 0.30,
                     "p10": 1200.0,
                     "p50": 2400.0,
-                    "optional": False,
+                    "optional": optional,
                 },
                 {
                     "measurement": "cls",
                     "weight": 0.15,
                     "p10": 0.1,
                     "p50": 0.25,
-                    "optional": False,
+                    "optional": optional,
                 },
                 {
                     "measurement": "ttfb",
                     "weight": 0.10,
                     "p10": 200.0,
                     "p50": 400.0,
-                    "optional": False,
+                    "optional": optional,
                 },
             ],
             "condition": {
@@ -571,28 +578,28 @@ def _get_desktop_browser_performance_profiles(organization: Organization) -> lis
                     "weight": 0.15,
                     "p10": 900.0,
                     "p50": 1600.0,
-                    "optional": False,
+                    "optional": optional,
                 },
                 {
                     "measurement": "lcp",
                     "weight": 0.30,
                     "p10": 1200.0,
                     "p50": 2400.0,
-                    "optional": False,
+                    "optional": optional,
                 },
                 {
                     "measurement": "cls",
                     "weight": 0.15,
                     "p10": 0.1,
                     "p50": 0.25,
-                    "optional": False,
+                    "optional": optional,
                 },
                 {
                     "measurement": "ttfb",
                     "weight": 0.10,
                     "p10": 200.0,
                     "p50": 400.0,
-                    "optional": False,
+                    "optional": optional,
                 },
             ],
             "condition": {
@@ -666,6 +673,7 @@ def _get_desktop_browser_performance_profiles(organization: Organization) -> lis
 
 
 def _get_mobile_browser_performance_profiles(organization: Organization) -> list[dict[str, Any]]:
+    optional = _should_performance_profiles_web_vitals_be_optional(organization)
     return [
         {
             "name": "Chrome Mobile",
@@ -675,28 +683,28 @@ def _get_mobile_browser_performance_profiles(organization: Organization) -> list
                     "weight": 0.15,
                     "p10": 1800.0,
                     "p50": 3000.0,
-                    "optional": False,
+                    "optional": optional,
                 },
                 {
                     "measurement": "lcp",
                     "weight": 0.30,
                     "p10": 2500.0,
                     "p50": 4000.0,
-                    "optional": False,
+                    "optional": optional,
                 },
                 {
                     "measurement": "cls",
                     "weight": 0.15,
                     "p10": 0.1,
                     "p50": 0.25,
-                    "optional": False,
+                    "optional": optional,
                 },
                 {
                     "measurement": "ttfb",
                     "weight": 0.10,
                     "p10": 800.0,
                     "p50": 1800.0,
-                    "optional": False,
+                    "optional": optional,
                 },
             ],
             "condition": {
@@ -713,14 +721,14 @@ def _get_mobile_browser_performance_profiles(organization: Organization) -> list
                     "weight": 0.15,
                     "p10": 1800.0,
                     "p50": 3000.0,
-                    "optional": False,
+                    "optional": optional,
                 },
                 {
                     "measurement": "lcp",
                     "weight": 0.30,
                     "p10": 2500.0,
                     "p50": 4000.0,
-                    "optional": False,
+                    "optional": True,  # Only available on Firefox 122 and beyond
                 },
                 {
                     "measurement": "cls",
@@ -734,7 +742,7 @@ def _get_mobile_browser_performance_profiles(organization: Organization) -> list
                     "weight": 0.10,
                     "p10": 800.0,
                     "p50": 1800.0,
-                    "optional": False,
+                    "optional": optional,
                 },
             ],
             "condition": {
@@ -751,7 +759,7 @@ def _get_mobile_browser_performance_profiles(organization: Organization) -> list
                     "weight": 0.15,
                     "p10": 1800.0,
                     "p50": 3000.0,
-                    "optional": False,
+                    "optional": optional,
                 },
                 {
                     "measurement": "lcp",
@@ -772,7 +780,7 @@ def _get_mobile_browser_performance_profiles(organization: Organization) -> list
                     "weight": 0.10,
                     "p10": 800.0,
                     "p50": 1800.0,
-                    "optional": False,
+                    "optional": optional,
                 },
             ],
             "condition": {
@@ -789,28 +797,28 @@ def _get_mobile_browser_performance_profiles(organization: Organization) -> list
                     "weight": 0.15,
                     "p10": 1800.0,
                     "p50": 3000.0,
-                    "optional": False,
+                    "optional": optional,
                 },
                 {
                     "measurement": "lcp",
                     "weight": 0.30,
                     "p10": 2500.0,
                     "p50": 4000.0,
-                    "optional": False,
+                    "optional": optional,
                 },
                 {
                     "measurement": "cls",
                     "weight": 0.15,
                     "p10": 0.1,
                     "p50": 0.25,
-                    "optional": False,
+                    "optional": optional,
                 },
                 {
                     "measurement": "ttfb",
                     "weight": 0.10,
                     "p10": 800.0,
                     "p50": 1800.0,
-                    "optional": False,
+                    "optional": optional,
                 },
             ],
             "condition": {
@@ -827,28 +835,28 @@ def _get_mobile_browser_performance_profiles(organization: Organization) -> list
                     "weight": 0.15,
                     "p10": 1800.0,
                     "p50": 3000.0,
-                    "optional": False,
+                    "optional": optional,
                 },
                 {
                     "measurement": "lcp",
                     "weight": 0.30,
                     "p10": 2500.0,
                     "p50": 4000.0,
-                    "optional": False,
+                    "optional": optional,
                 },
                 {
                     "measurement": "cls",
                     "weight": 0.15,
                     "p10": 0.1,
                     "p50": 0.25,
-                    "optional": False,
+                    "optional": optional,
                 },
                 {
                     "measurement": "ttfb",
                     "weight": 0.10,
                     "p10": 800.0,
                     "p50": 1800.0,
-                    "optional": False,
+                    "optional": optional,
                 },
             ],
             "condition": {

--- a/tests/sentry/relay/snapshots/test_config/test_get_project_config/REGION.pysnap
+++ b/tests/sentry/relay/snapshots/test_config/test_get_project_config/REGION.pysnap
@@ -349,7 +349,7 @@ config:
         p50: 3000.0
         weight: 0.15
       - measurement: lcp
-        optional: false
+        optional: true
         p10: 2500.0
         p50: 4000.0
         weight: 0.3

--- a/tests/sentry/relay/test_config.py
+++ b/tests/sentry/relay/test_config.py
@@ -951,7 +951,7 @@ def test_mobile_performance_calculate_score(default_project):
         "name": "Firefox Mobile",
         "scoreComponents": [
             {"measurement": "fcp", "weight": 0.15, "p10": 1800.0, "p50": 3000.0, "optional": False},
-            {"measurement": "lcp", "weight": 0.30, "p10": 2500.0, "p50": 4000.0, "optional": False},
+            {"measurement": "lcp", "weight": 0.30, "p10": 2500.0, "p50": 4000.0, "optional": True},
             {"measurement": "cls", "weight": 0.0, "p10": 0.1, "p50": 0.25, "optional": False},
             {"measurement": "ttfb", "weight": 0.10, "p10": 800.0, "p50": 1800.0, "optional": False},
         ],


### PR DESCRIPTION
Sets desktop and mobile browser performance score components to optional if flagged. This will enable performance score calculation on pageloads even if some web vitals are missing.