### PR TITLE
feat(new-trace): Updated logic for routing upon event id click from discover

### DIFF
--- a/static/app/views/discover/table/tableView.tsx
+++ b/static/app/views/discover/table/tableView.tsx
@@ -190,7 +190,10 @@ function TableView(props: TableViewProps) {
 
       let target;
 
-      if (dataRow.trace === null || dataRow.trace === undefined) {
+      if (
+        !dataRow.trace ||
+        ['error', 'default'].includes(dataRow['event.type'].toString())
+      ) {
         if (dataRow['event.type'] === 'transaction') {
           throw new Error(
             'Transaction event should always have a trace associated with it.'
@@ -321,7 +324,10 @@ function TableView(props: TableViewProps) {
     if (columnKey === 'id') {
       let target;
 
-      if (dataRow.trace === null || dataRow.trace === undefined) {
+      if (
+        !dataRow.trace ||
+        ['error', 'default'].includes(dataRow['event.type'].toString())
+      ) {
         if (dataRow['event.type'] === 'transaction') {
           throw new Error(
             'Transaction event should always have a trace associated with it.'

--- a/static/app/views/discover/table/tableView.tsx
+++ b/static/app/views/discover/table/tableView.tsx
@@ -190,7 +190,7 @@ function TableView(props: TableViewProps) {
 
       let target;
 
-      if (dataRow['event.type'].toString() !== 'transaction') {
+      if (dataRow['event.type'] !== 'transaction') {
         const project = dataRow.project || dataRow['project.name'];
         target = {
           // NOTE: This uses a legacy redirect for project event to the issue group event link
@@ -321,7 +321,7 @@ function TableView(props: TableViewProps) {
     if (columnKey === 'id') {
       let target;
 
-      if (dataRow['event.type'].toString() !== 'transaction') {
+      if (dataRow['event.type'] !== 'transaction') {
         const project = dataRow.project || dataRow['project.name'];
 
         target = {

--- a/static/app/views/discover/table/tableView.tsx
+++ b/static/app/views/discover/table/tableView.tsx
@@ -190,16 +190,7 @@ function TableView(props: TableViewProps) {
 
       let target;
 
-      if (
-        !dataRow.trace ||
-        ['error', 'default'].includes(dataRow['event.type'].toString())
-      ) {
-        if (dataRow['event.type'] === 'transaction') {
-          throw new Error(
-            'Transaction event should always have a trace associated with it.'
-          );
-        }
-
+      if (dataRow['event.type'].toString() !== 'transaction') {
         const project = dataRow.project || dataRow['project.name'];
         target = {
           // NOTE: This uses a legacy redirect for project event to the issue group event link
@@ -210,6 +201,12 @@ function TableView(props: TableViewProps) {
           query: {...location.query, referrer: 'discover-events-table'},
         };
       } else {
+        if (!dataRow.trace) {
+          throw new Error(
+            'Transaction event should always have a trace associated with it.'
+          );
+        }
+
         target = generateLinkToEventInTraceView({
           traceSlug: dataRow.trace,
           eventId: dataRow.id,
@@ -324,16 +321,7 @@ function TableView(props: TableViewProps) {
     if (columnKey === 'id') {
       let target;
 
-      if (
-        !dataRow.trace ||
-        ['error', 'default'].includes(dataRow['event.type'].toString())
-      ) {
-        if (dataRow['event.type'] === 'transaction') {
-          throw new Error(
-            'Transaction event should always have a trace associated with it.'
-          );
-        }
-
+      if (dataRow['event.type'].toString() !== 'transaction') {
         const project = dataRow.project || dataRow['project.name'];
 
         target = {
@@ -345,6 +333,12 @@ function TableView(props: TableViewProps) {
           query: {...location.query, referrer: 'discover-events-table'},
         };
       } else {
+        if (!dataRow.trace) {
+          throw new Error(
+            'Transaction event should always have a trace associated with it.'
+          );
+        }
+
         target = generateLinkToEventInTraceView({
           traceSlug: dataRow.trace?.toString(),
           eventId: dataRow.id,


### PR DESCRIPTION
We should route to issue details for events that are not of type `transaction` or are not associated to a `trace` id