### PR TITLE
feat(insights): move useHasData to transaction-based

### DIFF
--- a/src/sentry/constants.py
+++ b/src/sentry/constants.py
@@ -612,31 +612,61 @@ class InsightModules(Enum):
     LLM_MONITORING = "llm_monitoring"
 
 
-# each span filter takes in a span object and returns whether
-# the span belongs in the corresponding insight module
-INSIGHT_MODULE_SPAN_FILTERS = {
-    InsightModules.HTTP: lambda span: span.get("sentry_tags", {}).get("category") == "http"
-    and span.get("op") == "http.client",
-    InsightModules.DB: lambda span: span.get("sentry_tags", {}).get("category") == "db"
-    and "description" in span.keys(),
-    InsightModules.ASSETS: lambda span: span.get("op")
-    in ["resource.script", "resource.css", "resource.font", "resource.img"],
-    InsightModules.APP_START: lambda span: span.get("op").startswith("app.start."),
-    InsightModules.SCREEN_LOAD: lambda span: span.get("sentry_tags", {}).get("transaction.op")
-    == "ui.load",
-    InsightModules.VITAL: lambda span: span.get("op")
-    in [
-        "ui.interaction.click",
-        "ui.interaction.hover",
-        "ui.interaction.drag",
-        "ui.interaction.press",
-    ],
-    InsightModules.CACHE: lambda span: span.get("op")
-    in ["cache.get_item", "cache.get", "cache.put"],
-    InsightModules.QUEUE: lambda span: span.get("op") in ["queue.process", "queue.publish"],
-    InsightModules.LLM_MONITORING: lambda span: span.get("op").startswith("ai.pipeline"),
+INSIGHT_MODULE_FILTERS = {
+    InsightModules.HTTP: lambda transaction: any(
+        [
+            span.get("sentry_tags", {}).get("category") == "http"
+            and span.get("op") == "http.client"
+            for span in transaction["spans"]
+        ]
+    ),
+    InsightModules.DB: lambda transaction: any(
+        [
+            span.get("sentry_tags", {}).get("category") == "db" and "description" in span.keys()
+            for span in transaction["spans"]
+        ]
+    ),
+    InsightModules.ASSETS: lambda transaction: any(
+        [
+            span.get("op") in ["resource.script", "resource.css", "resource.font", "resource.img"]
+            for span in transaction["spans"]
+        ]
+    ),
+    InsightModules.APP_START: lambda transaction: any(
+        [span.get("op").startswith("app.start.") for span in transaction["spans"]]
+    ),
+    InsightModules.SCREEN_LOAD: lambda transaction: any(
+        [
+            span.get("sentry_tags", {}).get("transaction.op") == "ui.load"
+            for span in transaction["spans"]
+        ]
+    ),
+    InsightModules.VITAL: lambda transaction: transaction.get("op") == "pageload"
+    or any(
+        [
+            span.get("op")
+            in [
+                "ui.interaction.click",
+                "ui.interaction.hover",
+                "ui.interaction.drag",
+                "ui.interaction.press",
+            ]
+            for span in transaction["spans"]
+        ]
+    ),
+    InsightModules.CACHE: lambda transaction: any(
+        [
+            span.get("op") in ["cache.get_item", "cache.get", "cache.put"]
+            for span in transaction["spans"]
+        ]
+    ),
+    InsightModules.QUEUE: lambda transaction: any(
+        [span.get("op") in ["queue.process", "queue.publish"] for span in transaction["spans"]]
+    ),
+    InsightModules.LLM_MONITORING: lambda transaction: any(
+        [span.get("op").startswith("ai.pipeline") for span in transaction["spans"]]
+    ),
 }
-
 
 StatsPeriod = namedtuple("StatsPeriod", ("segments", "interval"))
 

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -33,7 +33,7 @@ from sentry import (
 from sentry.attachments import CachedAttachment, MissingAttachmentChunks, attachment_cache
 from sentry.constants import (
     DEFAULT_STORE_NORMALIZER_ARGS,
-    INSIGHT_MODULE_SPAN_FILTERS,
+    INSIGHT_MODULE_FILTERS,
     LOG_LEVELS_MAP,
     MAX_TAG_VALUE_LENGTH,
     PLACEHOLDER_EVENT_TITLES,
@@ -499,10 +499,8 @@ class EventManager:
                     project=project, event=jobs[0]["event"], sender=Project
                 )
 
-            for module, is_module_span in INSIGHT_MODULE_SPAN_FILTERS.items():
-                if not get_project_insight_flag(project, module) and any(
-                    [is_module_span(span) for span in job["data"]["spans"]]
-                ):
+            for module, is_module in INSIGHT_MODULE_FILTERS.items():
+                if not get_project_insight_flag(project, module) and is_module(job["data"]):
                     first_insight_span_received.send_robust(
                         project=project, module=module, sender=Project
                     )


### PR DESCRIPTION
Moves useHasData to transaction-based filters so that we can filter by `transaction.op:pageload` for web vitals.