### PR TITLE
fix(project-creation): Reject project names with reserved slugs (#37410)

### DIFF
--- a/src/sentry/api/endpoints/team_projects.py
+++ b/src/sentry/api/endpoints/team_projects.py
@@ -19,7 +19,7 @@ from sentry.apidocs.examples.project_examples import ProjectExamples
 from sentry.apidocs.examples.team_examples import TeamExamples
 from sentry.apidocs.parameters import CursorQueryParam, GlobalParams
 from sentry.apidocs.utils import inline_sentry_response_serializer
-from sentry.constants import ObjectStatus
+from sentry.constants import RESERVED_PROJECT_SLUGS, ObjectStatus
 from sentry.models.project import Project
 from sentry.signals import project_created
 from sentry.utils.snowflake import MaxSnowflakeRetryError
@@ -55,6 +55,11 @@ their own alerts to be notified of new issues.
         if Project.is_valid_platform(value):
             return value
         raise serializers.ValidationError("Invalid platform")
+
+    def validate_name(self, value: str) -> str:
+        if value in RESERVED_PROJECT_SLUGS:
+            raise serializers.ValidationError(f'The name "{value}" is reserved and not allowed.')
+        return value
 
 
 # While currently the UI suggests teams are a parent of a project, in reality

--- a/tests/sentry/api/endpoints/test_team_projects.py
+++ b/tests/sentry/api/endpoints/test_team_projects.py
@@ -1,7 +1,7 @@
 from unittest.mock import Mock
 
 from sentry.api.endpoints.organization_projects_experiment import DISABLED_FEATURE_ERROR_STRING
-from sentry.constants import RESERVED_ORGANIZATION_SLUGS
+from sentry.constants import RESERVED_PROJECT_SLUGS
 from sentry.ingest import inbound_filters
 from sentry.models.project import Project
 from sentry.models.rule import Rule
@@ -99,17 +99,15 @@ class TeamProjectsCreateTest(APITestCase):
 
     def test_invalid_name(self):
 
+        invalid_name = list(RESERVED_PROJECT_SLUGS)[0]
         response = self.get_error_response(
             self.organization.slug,
             self.team.slug,
-            name=list(RESERVED_ORGANIZATION_SLUGS)[0],
+            name=invalid_name,
             platform="python",
             status_code=400,
         )
-        assert (
-            response.data["name"][0]
-            == f'The name "{RESERVED_ORGANIZATION_SLUGS[0]}" is reserved and not allowed.'
-        )
+        assert response.data["name"][0] == f'The name "{invalid_name}" is reserved and not allowed.'
 
     def test_duplicate_slug(self):
         self.create_project(slug="bar")

--- a/tests/sentry/api/endpoints/test_team_projects.py
+++ b/tests/sentry/api/endpoints/test_team_projects.py
@@ -1,6 +1,7 @@
 from unittest.mock import Mock
 
 from sentry.api.endpoints.organization_projects_experiment import DISABLED_FEATURE_ERROR_STRING
+from sentry.constants import RESERVED_ORGANIZATION_SLUGS
 from sentry.ingest import inbound_filters
 from sentry.models.project import Project
 from sentry.models.rule import Rule
@@ -97,16 +98,18 @@ class TeamProjectsCreateTest(APITestCase):
         assert response.data["platform"][0] == "Invalid platform"
 
     def test_invalid_name(self):
-        invalid_name = "auth"
 
         response = self.get_error_response(
             self.organization.slug,
             self.team.slug,
-            name=invalid_name,
+            name=list(RESERVED_ORGANIZATION_SLUGS)[0],
             platform="python",
             status_code=400,
         )
-        assert response.data["name"][0] == f'The name "{invalid_name}" is reserved and not allowed.'
+        assert (
+            response.data["name"][0]
+            == f'The name "{RESERVED_ORGANIZATION_SLUGS[0]}" is reserved and not allowed.'
+        )
 
     def test_duplicate_slug(self):
         self.create_project(slug="bar")

--- a/tests/sentry/api/endpoints/test_team_projects.py
+++ b/tests/sentry/api/endpoints/test_team_projects.py
@@ -96,6 +96,18 @@ class TeamProjectsCreateTest(APITestCase):
         )
         assert response.data["platform"][0] == "Invalid platform"
 
+    def test_invalid_name(self):
+        invalid_name = "auth"
+
+        response = self.get_error_response(
+            self.organization.slug,
+            self.team.slug,
+            name=invalid_name,
+            platform="python",
+            status_code=400,
+        )
+        assert response.data["name"][0] == f'The name "{invalid_name}" is reserved and not allowed.'
+
     def test_duplicate_slug(self):
         self.create_project(slug="bar")
         response = self.get_error_response(


### PR DESCRIPTION
Adds validation during project creation to check if the project name is any of the RESERVED_PROJECT_SLUGS

ref (#37410)

After:
![image](https://github.com/getsentry/sentry/assets/60594860/df2aa585-0252-4781-8989-357d0f3a7cd2)


