### PR TITLE
style(feedback): adjust some feedback list css

### DIFF
--- a/static/app/components/feedback/list/feedbackListHeader.tsx
+++ b/static/app/components/feedback/list/feedbackListHeader.tsx
@@ -96,7 +96,7 @@ const HeaderPanel = styled('div')`
 `;
 
 const HeaderPanelItem = styled('div')`
-  padding: ${space(1)} ${space(1.5)};
+  padding: ${space(1)} ${space(1.5)} ${space(1)} 18px;
   display: flex;
   gap: ${space(1)};
   align-items: center;

--- a/static/app/components/feedback/list/feedbackListItem.tsx
+++ b/static/app/components/feedback/list/feedbackListItem.tsx
@@ -11,7 +11,7 @@ import Link from 'sentry/components/links/link';
 import TextOverflow from 'sentry/components/textOverflow';
 import TimeSince from 'sentry/components/timeSince';
 import {Tooltip} from 'sentry/components/tooltip';
-import {IconChat, IconCircleFill, IconFatal, IconImage, IconPlay} from 'sentry/icons';
+import {IconChat, IconFatal, IconImage, IconPlay} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {Group} from 'sentry/types/group';
@@ -84,23 +84,21 @@ function FeedbackListItem({feedbackItem, isSelected, onSelect, style}: Props) {
         />
       </Row>
 
-      <TextOverflow style={{gridArea: 'user'}}>
-        <strong>
-          {feedbackItem.metadata.name ??
-            feedbackItem.metadata.contact_email ??
-            t('Anonymous User')}
-        </strong>
-      </TextOverflow>
+      <ContactRow style={{fontWeight: feedbackItem.hasSeen ? undefined : 'bold'}}>
+        {feedbackItem.metadata.name ??
+          feedbackItem.metadata.contact_email ??
+          t('Anonymous User')}
+      </ContactRow>
 
-      <TimeSince date={feedbackItem.firstSeen} style={{gridArea: 'time'}} />
+      <StyledTimeSince date={feedbackItem.firstSeen} />
 
-      {feedbackItem.hasSeen ? null : (
-        <DotRow style={{gridArea: 'unread'}}>
-          <IconCircleFill size="xs" color="purple400" />
-        </DotRow>
-      )}
-
-      <PreviewRow align="flex-start" justify="flex-start" style={{gridArea: 'message'}}>
+      <PreviewRow
+        align="flex-start"
+        justify="flex-start"
+        style={{
+          gridArea: 'message',
+        }}
+      >
         <StyledTextOverflow>{feedbackItem.metadata.message}</StyledTextOverflow>
       </PreviewRow>
 
@@ -108,11 +106,11 @@ function FeedbackListItem({feedbackItem, isSelected, onSelect, style}: Props) {
         <Row justify="flex-start" gap={space(0.75)}>
           <StyledProjectBadge
             project={feedbackItem.project}
-            avatarSize={16}
+            avatarSize={14}
             hideName
             avatarProps={{hasTooltip: false}}
           />
-          <TextOverflow>{feedbackItem.shortId}</TextOverflow>
+          <ShortId>{feedbackItem.shortId}</ShortId>
         </Row>
 
         <Row justify="flex-end" gap={space(1)}>
@@ -210,12 +208,7 @@ const StyledProjectBadge = styled(ProjectBadge)`
 const PreviewRow = styled(Row)`
   height: 2.8em;
   align-items: flex-start;
-`;
-
-const DotRow = styled(Row)`
-  height: 2.2em;
-  align-items: flex-start;
-  justify-content: center;
+  font-size: ${p => p.theme.fontSizeSmall};
 `;
 
 const StyledTextOverflow = styled(TextOverflow)`
@@ -226,4 +219,19 @@ const StyledTextOverflow = styled(TextOverflow)`
   -webkit-box-orient: vertical;
   line-height: ${p => p.theme.text.lineHeightBody};
 `;
+
+const ContactRow = styled(TextOverflow)`
+  font-size: ${p => p.theme.fontSizeMedium};
+  grid-area: 'user';
+`;
+
+const ShortId = styled(TextOverflow)`
+  font-size: ${p => p.theme.fontSizeSmall};
+`;
+
+const StyledTimeSince = styled(TimeSince)`
+  font-size: ${p => p.theme.fontSizeSmall};
+  grid-area: 'time';
+`;
+
 export default FeedbackListItem;

--- a/static/app/components/feedback/list/feedbackListItem.tsx
+++ b/static/app/components/feedback/list/feedbackListItem.tsx
@@ -11,7 +11,7 @@ import Link from 'sentry/components/links/link';
 import TextOverflow from 'sentry/components/textOverflow';
 import TimeSince from 'sentry/components/timeSince';
 import {Tooltip} from 'sentry/components/tooltip';
-import {IconChat, IconFatal, IconImage, IconPlay} from 'sentry/icons';
+import {IconChat, IconCircleFill, IconFatal, IconImage, IconPlay} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {Group} from 'sentry/types/group';
@@ -84,13 +84,19 @@ function FeedbackListItem({feedbackItem, isSelected, onSelect, style}: Props) {
         />
       </Row>
 
-      <ContactRow style={{fontWeight: feedbackItem.hasSeen ? undefined : 'bold'}}>
+      <ContactRow>
         {feedbackItem.metadata.name ??
           feedbackItem.metadata.contact_email ??
           t('Anonymous User')}
       </ContactRow>
 
       <StyledTimeSince date={feedbackItem.firstSeen} />
+
+      {feedbackItem.hasSeen ? null : (
+        <DotRow style={{gridArea: 'unread'}}>
+          <IconCircleFill size="xs" color="purple400" />
+        </DotRow>
+      )}
 
       <PreviewRow
         align="flex-start"
@@ -163,16 +169,9 @@ const LinkedFeedbackCard = styled(Link)`
   }
   &[data-selected='true'] {
     background: ${p => p.theme.purple100};
-  }
-  &[data-selected='true']::before {
-    content: '';
-    position: absolute;
-    left: 0;
-    top: 0;
-    height: 100%;
-    background: ${p => p.theme.purple300};
-    width: ${space(0.5)};
-    z-index: 10;
+    border: 1px solid ${p => p.theme.purple200};
+    border-radius: ${space(0.75)};
+    color: ${p => p.theme.purple300};
   }
 
   display: grid;
@@ -206,15 +205,21 @@ const StyledProjectBadge = styled(ProjectBadge)`
 `;
 
 const PreviewRow = styled(Row)`
-  height: 2.8em;
+  height: 1.4em;
   align-items: flex-start;
   font-size: ${p => p.theme.fontSizeSmall};
 `;
 
+const DotRow = styled(Row)`
+  height: 1.1em;
+  align-items: flex-start;
+  justify-content: center;
+`;
+
 const StyledTextOverflow = styled(TextOverflow)`
   white-space: initial;
-  height: 2.8em;
-  -webkit-line-clamp: 2;
+  height: 1.4em;
+  -webkit-line-clamp: 1;
   display: -webkit-box;
   -webkit-box-orient: vertical;
   line-height: ${p => p.theme.text.lineHeightBody};
@@ -223,6 +228,7 @@ const StyledTextOverflow = styled(TextOverflow)`
 const ContactRow = styled(TextOverflow)`
   font-size: ${p => p.theme.fontSizeMedium};
   grid-area: 'user';
+  font-weight: bold;
 `;
 
 const ShortId = styled(TextOverflow)`

--- a/static/app/components/feedback/list/feedbackListItem.tsx
+++ b/static/app/components/feedback/list/feedbackListItem.tsx
@@ -52,116 +52,118 @@ function FeedbackListItem({feedbackItem, isSelected, onSelect, style}: Props) {
   const hasComments = feedbackItem.numComments > 0;
 
   return (
-    <LinkedFeedbackCard
-      style={style}
-      data-selected={isOpen}
-      to={{
-        pathname: normalizeUrl(`/organizations/${organization.slug}/feedback/`),
-        query: {
-          ...location.query,
-          referrer: 'feedback_list_page',
-          feedbackSlug: `${feedbackItem.project.slug}:${feedbackItem.id}`,
-        },
-      }}
-      onClick={() => {
-        trackAnalytics('feedback.list-item-selected', {organization});
-      }}
-    >
-      <InteractionStateLayer />
-
-      <Row
-        style={{gridArea: 'checkbox'}}
-        onClick={e => {
-          e.stopPropagation();
+    <CardSpacing style={style}>
+      <LinkedFeedbackCard
+        data-selected={isOpen}
+        to={{
+          pathname: normalizeUrl(`/organizations/${organization.slug}/feedback/`),
+          query: {
+            ...location.query,
+            referrer: 'feedback_list_page',
+            feedbackSlug: `${feedbackItem.project.slug}:${feedbackItem.id}`,
+          },
+        }}
+        onClick={() => {
+          trackAnalytics('feedback.list-item-selected', {organization});
         }}
       >
-        <Checkbox
-          disabled={isSelected === 'all-selected'}
-          checked={isSelected !== false}
-          onChange={e => {
-            onSelect(e.target.checked);
+        <InteractionStateLayer />
+
+        <Row
+          style={{gridArea: 'checkbox'}}
+          onClick={e => {
+            e.stopPropagation();
           }}
-        />
-      </Row>
-
-      <ContactRow>
-        {feedbackItem.metadata.name ??
-          feedbackItem.metadata.contact_email ??
-          t('Anonymous User')}
-      </ContactRow>
-
-      <StyledTimeSince date={feedbackItem.firstSeen} />
-
-      {feedbackItem.hasSeen ? null : (
-        <DotRow style={{gridArea: 'unread'}}>
-          <IconCircleFill size="xs" color="purple400" />
-        </DotRow>
-      )}
-
-      <PreviewRow
-        align="flex-start"
-        justify="flex-start"
-        style={{
-          gridArea: 'message',
-        }}
-      >
-        <StyledTextOverflow>{feedbackItem.metadata.message}</StyledTextOverflow>
-      </PreviewRow>
-
-      <BottomGrid style={{gridArea: 'bottom'}}>
-        <Row justify="flex-start" gap={space(0.75)}>
-          <StyledProjectBadge
-            project={feedbackItem.project}
-            avatarSize={14}
-            hideName
-            avatarProps={{hasTooltip: false}}
+        >
+          <Checkbox
+            disabled={isSelected === 'all-selected'}
+            checked={isSelected !== false}
+            onChange={e => {
+              onSelect(e.target.checked);
+            }}
           />
-          <ShortId>{feedbackItem.shortId}</ShortId>
         </Row>
 
-        <Row justify="flex-end" gap={space(1)}>
-          <IssueTrackingSignals group={feedbackItem as unknown as Group} />
+        <ContactRow>
+          {feedbackItem.metadata.name ??
+            feedbackItem.metadata.contact_email ??
+            t('Anonymous User')}
+        </ContactRow>
 
-          {hasComments && (
-            <Tooltip title={t('Has Activity')} containerDisplayMode="flex">
-              <IconChat color="gray500" size="sm" />
-            </Tooltip>
-          )}
+        <StyledTimeSince date={feedbackItem.firstSeen} />
 
-          {(isCrashReport || isUserReportWithError) && (
-            <Tooltip title={t('Linked Error')} containerDisplayMode="flex">
-              <IconFatal color="red400" size="xs" />
-            </Tooltip>
-          )}
+        {feedbackItem.hasSeen ? null : (
+          <DotRow style={{gridArea: 'unread'}}>
+            <IconCircleFill size="xs" color="purple400" />
+          </DotRow>
+        )}
 
-          {hasReplayId && (
-            <Tooltip title={t('Linked Replay')} containerDisplayMode="flex">
-              <IconPlay size="xs" />
-            </Tooltip>
-          )}
+        <PreviewRow
+          align="flex-start"
+          justify="flex-start"
+          style={{
+            gridArea: 'message',
+          }}
+        >
+          <StyledTextOverflow>{feedbackItem.metadata.message}</StyledTextOverflow>
+        </PreviewRow>
 
-          {hasAttachments && (
-            <Tooltip title={t('Has Screenshot')} containerDisplayMode="flex">
-              <IconImage size="xs" />
-            </Tooltip>
-          )}
-
-          {feedbackItem.assignedTo && (
-            <ActorAvatar
-              actor={feedbackItem.assignedTo}
-              size={16}
-              tooltipOptions={{containerDisplayMode: 'flex'}}
+        <BottomGrid style={{gridArea: 'bottom'}}>
+          <Row justify="flex-start" gap={space(0.75)}>
+            <StyledProjectBadge
+              project={feedbackItem.project}
+              avatarSize={14}
+              hideName
+              avatarProps={{hasTooltip: false}}
             />
-          )}
-        </Row>
-      </BottomGrid>
-    </LinkedFeedbackCard>
+            <ShortId>{feedbackItem.shortId}</ShortId>
+          </Row>
+
+          <Row justify="flex-end" gap={space(1)}>
+            <IssueTrackingSignals group={feedbackItem as unknown as Group} />
+
+            {hasComments && (
+              <Tooltip title={t('Has Activity')} containerDisplayMode="flex">
+                <IconChat color="gray500" size="sm" />
+              </Tooltip>
+            )}
+
+            {(isCrashReport || isUserReportWithError) && (
+              <Tooltip title={t('Linked Error')} containerDisplayMode="flex">
+                <IconFatal color="red400" size="xs" />
+              </Tooltip>
+            )}
+
+            {hasReplayId && (
+              <Tooltip title={t('Linked Replay')} containerDisplayMode="flex">
+                <IconPlay size="xs" />
+              </Tooltip>
+            )}
+
+            {hasAttachments && (
+              <Tooltip title={t('Has Screenshot')} containerDisplayMode="flex">
+                <IconImage size="xs" />
+              </Tooltip>
+            )}
+
+            {feedbackItem.assignedTo && (
+              <ActorAvatar
+                actor={feedbackItem.assignedTo}
+                size={16}
+                tooltipOptions={{containerDisplayMode: 'flex'}}
+              />
+            )}
+          </Row>
+        </BottomGrid>
+      </LinkedFeedbackCard>
+    </CardSpacing>
   );
 }
 
 const LinkedFeedbackCard = styled(Link)`
   position: relative;
   padding: ${space(1)} ${space(3)} ${space(1)} ${space(1.5)};
+  border: 1px solid transparent;
 
   color: ${p => p.theme.textColor};
   &:hover {
@@ -205,9 +207,9 @@ const StyledProjectBadge = styled(ProjectBadge)`
 `;
 
 const PreviewRow = styled(Row)`
-  height: 1.6em;
   align-items: flex-start;
   font-size: ${p => p.theme.fontSizeSmall};
+  padding-bottom: ${space(0.75)};
 `;
 
 const DotRow = styled(Row)`
@@ -239,6 +241,10 @@ const ShortId = styled(TextOverflow)`
 const StyledTimeSince = styled(TimeSince)`
   font-size: ${p => p.theme.fontSizeSmall};
   grid-area: 'time';
+`;
+
+const CardSpacing = styled('div')`
+  padding: ${space(0.5)} ${space(0.5)} 0 ${space(0.5)};
 `;
 
 export default FeedbackListItem;

--- a/static/app/components/feedback/list/feedbackListItem.tsx
+++ b/static/app/components/feedback/list/feedbackListItem.tsx
@@ -181,7 +181,7 @@ const LinkedFeedbackCard = styled(Link)`
     'checkbox user time'
     'unread message message'
     '. bottom bottom';
-  gap: ${space(1)};
+  gap: ${space(0.5)} ${space(1)};
   place-items: stretch;
   align-items: center;
 `;
@@ -205,7 +205,7 @@ const StyledProjectBadge = styled(ProjectBadge)`
 `;
 
 const PreviewRow = styled(Row)`
-  height: 1.4em;
+  height: 1.6em;
   align-items: flex-start;
   font-size: ${p => p.theme.fontSizeSmall};
 `;
@@ -233,6 +233,7 @@ const ContactRow = styled(TextOverflow)`
 
 const ShortId = styled(TextOverflow)`
   font-size: ${p => p.theme.fontSizeSmall};
+  color: ${p => p.theme.gray300};
 `;
 
 const StyledTimeSince = styled(TimeSince)`


### PR DESCRIPTION
- closes https://github.com/getsentry/sentry/issues/73628
- adjust uf linked card styles so they align with the [figma designs](https://www.figma.com/design/DIlstrVINTYNJad4BS0f9L/Assets%3A-User-Feedback-Product-UI?node-id=2-2&t=30176FG9PWWaw0zS-0)

major changes:
- entire purple border when item selected (add back in card spacing)
- better spacing between grid
- updated font sizes
- we only show 1 line of preview now to have more consistent spacing

| before | after | figma |
| --- | --- | --- |
| <img width="420" alt="SCR-20240711-mhzt" src="https://github.com/getsentry/sentry/assets/56095982/3f2f9549-58ec-4bbb-a5b2-43e3047e8da5">| <img width="406" alt="SCR-20240711-mhui" src="https://github.com/getsentry/sentry/assets/56095982/f8a2df8d-ddf4-4303-8558-139e8be4c83b"> |  <img width="426" alt="SCR-20240711-mime" src="https://github.com/getsentry/sentry/assets/56095982/05e022fb-c44a-4b02-b906-5ceb1059eff1"> |



before:

https://github.com/getsentry/sentry/assets/56095982/f325a915-762b-4353-b710-ae3e452daed2

after:

https://github.com/getsentry/sentry/assets/56095982/b6c3caff-2fa7-42a2-93fa-e09a0fa9016f

