### PR TITLE
chore(slack): remove old slack client from link commands

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -396,8 +396,6 @@ def register_temporary_features(manager: FeatureManager):
     # Feature flags for migrating to the Slack SDK WebClient
     # Use new Slack SDK Client in get_channel_id_with_timeout
     manager.add("organizations:slack-sdk-get-channel-id", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE)
-    # Use new Slack SDK Client to respond to link commands
-    manager.add("organizations:slack-sdk-link-commands", OrganizationFeature, FeatureHandlerStrategy.OPTIONS)
     # Use new Slack SDK Client in SlackActionEndpoint
     manager.add("organizations:slack-sdk-webhook-handling", OrganizationFeature, FeatureHandlerStrategy.OPTIONS)
     # Use new Slack SDK Client for SlackNotifyBasicMixin

--- a/src/sentry/integrations/slack/metrics.py
+++ b/src/sentry/integrations/slack/metrics.py
@@ -44,3 +44,9 @@ SLACK_COMMANDS_ENDPOINT_SUCCESS_DATADOG_METRIC = (
 SLACK_COMMANDS_ENDPOINT_FAILURE_DATADOG_METRIC = (
     "sentry.integrations.slack.commands_endpoint.failure"
 )
+SLACK_COMMANDS_LINK_IDENTITY_SUCCESS_DATADOG_METRIC = (
+    "sentry.integrations.slack.commands_link_identity.success"
+)
+SLACK_COMMANDS_LINK_IDENTITY_FAILURE_DATADOG_METRIC = (
+    "sentry.integrations.slack.commands_link_identity.failure"
+)

--- a/src/sentry/integrations/slack/utils/__init__.py
+++ b/src/sentry/integrations/slack/utils/__init__.py
@@ -4,7 +4,6 @@ __all__ = (
     "logger",
     "RedisRuleStatus",
     "send_incident_alert_notification",
-    "send_slack_response",
     "set_signing_secret",
     "SLACK_RATE_LIMITED_MESSAGE",
     "strip_channel_name",
@@ -18,7 +17,7 @@ logger = logging.getLogger("sentry.integrations.slack")
 
 from .auth import is_valid_role, set_signing_secret
 from .channel import get_channel_id, strip_channel_name, validate_channel_id
-from .notifications import send_incident_alert_notification, send_slack_response
+from .notifications import send_incident_alert_notification
 from .rule_status import RedisRuleStatus
 
 SLACK_RATE_LIMITED_MESSAGE = "Requests to Slack exceeded the rate limit. Please try again later."

--- a/src/sentry/integrations/slack/utils/notifications.py
+++ b/src/sentry/integrations/slack/utils/notifications.py
@@ -18,16 +18,16 @@ from sentry.integrations.repository.metric_alert import (
     NewMetricAlertNotificationMessage,
 )
 from sentry.integrations.services.integration import integration_service
-from sentry.integrations.slack.client import SlackClient
 from sentry.integrations.slack.message_builder.incidents import SlackIncidentsMessageBuilder
 from sentry.integrations.slack.metrics import (
+    SLACK_COMMANDS_LINK_IDENTITY_FAILURE_DATADOG_METRIC,
+    SLACK_COMMANDS_LINK_IDENTITY_SUCCESS_DATADOG_METRIC,
     SLACK_METRIC_ALERT_FAILURE_DATADOG_METRIC,
     SLACK_METRIC_ALERT_SUCCESS_DATADOG_METRIC,
 )
 from sentry.integrations.slack.sdk_client import SlackSdkClient
 from sentry.integrations.slack.views.types import IdentityParams
 from sentry.models.options.organization_option import OrganizationOption
-from sentry.shared_integrations.exceptions import ApiError
 from sentry.utils import metrics
 
 from . import logger
@@ -169,14 +169,24 @@ def respond_to_slack_command(
 ) -> None:
     log = "slack.link-identity." if command == "link" else "slack.unlink-identity."
 
-    # TODO: ignore expired url errors
     if params.response_url:
         logger.info(log + "respond-webhook", extra={"response_url": params.response_url})
         try:
             webhook_client = WebhookClient(params.response_url)
             webhook_client.send(text=text, replace_original=False, response_type="ephemeral")
+            metrics.incr(
+                SLACK_COMMANDS_LINK_IDENTITY_SUCCESS_DATADOG_METRIC,
+                sample_rate=1.0,
+                tags={"type": "webhook", "command": command},
+            )
         except (SlackApiError, SlackRequestError) as e:
-            logger.exception(log + "error", extra={"error": str(e)})
+            if "Expired url" not in str(e):
+                metrics.incr(
+                    SLACK_COMMANDS_LINK_IDENTITY_FAILURE_DATADOG_METRIC,
+                    sample_rate=1.0,
+                    tags={"type": "webhook", "command": command},
+                )
+                logger.exception(log + "error", extra={"error": str(e)})
     else:
         logger.info(log + "respond-ephemeral")
         try:
@@ -187,53 +197,16 @@ def respond_to_slack_command(
                 replace_original=False,
                 response_type="ephemeral",
             )
-        except SlackApiError as e:
-            logger.exception(log + "error", extra={"error": str(e)})
-
-
-def send_slack_response(
-    params: IdentityParams,
-    text: str,
-    command: str,
-) -> None:
-    integration = params.integration
-    payload = {
-        "replace_original": False,
-        "response_type": "ephemeral",
-        "text": text,
-    }
-    default_path = "/chat.postMessage"
-
-    client = SlackClient(integration_id=integration.id)
-
-    if not params.response_url:
-        logger.info(
-            "slack.send_slack_response.no-response-url",
-            extra={"integration_id": integration.id, "payload": payload},
-        )
-
-    if params.response_url:
-        path = params.response_url
-
-    else:
-        # Command has been invoked in a DM, not as a slash command
-        # we do not have a response URL in this case
-        payload["channel"] = params.slack_id
-        path = default_path
-
-    try:
-        client.post(path, data=payload, json=True)
-    except ApiError as e:
-        message = str(e)
-        # If the user took their time to link their slack account, we may no
-        # longer be able to respond, and we're not guaranteed able to post into
-        # the channel. Ignore Expired url errors.
-        #
-        # XXX(epurkhiser): Yes the error string has a space in it.
-        if message != "Expired url":
-            log_message = (
-                "slack.link-notify.response-error"
-                if command == "link"
-                else "slack.unlink-notify.response-error"
+            metrics.incr(
+                SLACK_COMMANDS_LINK_IDENTITY_SUCCESS_DATADOG_METRIC,
+                sample_rate=1.0,
+                tags={"type": "ephemeral", "command": command},
             )
-            logger.error(log_message, extra={"error": message})
+        except SlackApiError as e:
+            if "Expired url" not in str(e):
+                metrics.incr(
+                    SLACK_COMMANDS_LINK_IDENTITY_FAILURE_DATADOG_METRIC,
+                    sample_rate=1.0,
+                    tags={"type": "ephemeral", "command": command},
+                )
+                logger.exception(log + "error", extra={"error": str(e)})

--- a/src/sentry/integrations/slack/views/link_identity.py
+++ b/src/sentry/integrations/slack/views/link_identity.py
@@ -7,7 +7,6 @@ from django.http.response import HttpResponseBase
 from django.utils.decorators import method_decorator
 from rest_framework.request import Request
 
-from sentry import features
 from sentry.integrations.services.integration.model import RpcIntegration
 from sentry.integrations.slack.metrics import (
     SLACK_BOT_COMMAND_LINK_IDENTITY_FAILURE_DATADOG_METRIC,
@@ -26,7 +25,6 @@ from sentry.utils.signing import unsign
 from sentry.web.frontend.base import BaseView, control_silo_view
 from sentry.web.helpers import render_to_response
 
-from ..utils import send_slack_response
 from . import build_linking_url as base_build_linking_url
 from . import never_cache
 
@@ -140,10 +138,7 @@ class SlackLinkIdentityView(BaseView):
             )
             raise Http404
 
-        if features.has("organizations:slack-sdk-link-commands", params.organization):
-            respond_to_slack_command(params, SUCCESS_LINKED_MESSAGE, command="link")
-        else:
-            send_slack_response(params, SUCCESS_LINKED_MESSAGE, command="link")
+        respond_to_slack_command(params, SUCCESS_LINKED_MESSAGE, command="link")
 
         controller = NotificationController(
             recipients=[request.user],

--- a/src/sentry/integrations/slack/views/unlink_identity.py
+++ b/src/sentry/integrations/slack/views/unlink_identity.py
@@ -7,15 +7,11 @@ from django.http.response import HttpResponseBase
 from django.utils.decorators import method_decorator
 from rest_framework.request import Request
 
-from sentry import features
 from sentry.integrations.slack.metrics import (
     SLACK_BOT_COMMAND_UNLINK_IDENTITY_FAILURE_DATADOG_METRIC,
     SLACK_BOT_COMMAND_UNLINK_IDENTITY_SUCCESS_DATADOG_METRIC,
 )
-from sentry.integrations.slack.utils.notifications import (
-    respond_to_slack_command,
-    send_slack_response,
-)
+from sentry.integrations.slack.utils.notifications import respond_to_slack_command
 from sentry.integrations.slack.views import build_linking_url as base_build_linking_url
 from sentry.integrations.slack.views import never_cache, render_error_page
 from sentry.integrations.slack.views.types import IdentityParams
@@ -129,10 +125,7 @@ class SlackUnlinkIdentityView(BaseView):
             )
             raise Http404
 
-        if features.has("organizations:slack-sdk-link-commands", params.organization):
-            respond_to_slack_command(params, SUCCESS_UNLINKED_MESSAGE, command="link")
-        else:
-            send_slack_response(params, SUCCESS_UNLINKED_MESSAGE, command="unlink")
+        respond_to_slack_command(params, SUCCESS_UNLINKED_MESSAGE, command="link")
 
         metrics.incr(self._METRICS_SUCCESS_KEY + ".post.unlink_identity", sample_rate=1.0)
 

--- a/tests/sentry/integrations/slack/webhooks/commands/__init__.py
+++ b/tests/sentry/integrations/slack/webhooks/commands/__init__.py
@@ -2,12 +2,16 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 from typing import Any
+from unittest.mock import patch
 from urllib.parse import urlencode
 
 import orjson
+import pytest
 from django.http.response import HttpResponse
 from django.urls import reverse
 from rest_framework import status
+from slack_sdk.web import SlackResponse
+from slack_sdk.webhook import WebhookResponse
 
 from sentry import options
 from sentry.integrations.slack.utils import set_signing_secret
@@ -81,3 +85,32 @@ class SlackCommandsTest(APITestCase, TestCase):
         )
         assert response.status_code == (status_code or status.HTTP_200_OK)
         return response
+
+    @pytest.fixture(autouse=True)
+    def mock_webhook_send(self):
+        with patch(
+            "slack_sdk.webhook.WebhookClient.send",
+            return_value=WebhookResponse(
+                url="",
+                body='{"ok": true}',
+                headers={},
+                status_code=200,
+            ),
+        ) as self.mock_webhook:
+            yield
+
+    @pytest.fixture(autouse=True)
+    def mock_chat_postMessage(self):
+        with patch(
+            "slack_sdk.web.WebClient.chat_postMessage",
+            return_value=SlackResponse(
+                client=None,
+                http_verb="POST",
+                api_url="https://slack.com/api/chat.postMessage",
+                req_args={},
+                data={"ok": True},
+                headers={},
+                status_code=200,
+            ),
+        ) as self.mock_post:
+            yield

--- a/tests/sentry/integrations/slack/webhooks/commands/test_link_user.py
+++ b/tests/sentry/integrations/slack/webhooks/commands/test_link_user.py
@@ -1,6 +1,3 @@
-import orjson
-import responses
-
 from sentry.integrations.slack.views.link_identity import SUCCESS_LINKED_MESSAGE, build_linking_url
 from sentry.integrations.slack.views.unlink_identity import (
     SUCCESS_UNLINKED_MESSAGE,
@@ -18,7 +15,6 @@ from tests.sentry.integrations.slack.webhooks.commands import SlackCommandsTest
 class SlackLinkIdentityViewTest(SlackCommandsTest):
     """Slack Linking Views are returned on Control Silo"""
 
-    @responses.activate
     def test_link_user_identity(self):
         linking_url = build_linking_url(
             self.integration, self.external_id, self.channel_id, self.response_url
@@ -27,15 +23,14 @@ class SlackLinkIdentityViewTest(SlackCommandsTest):
         response = self.client.post(linking_url)
         assert response.status_code == 200
 
-        assert len(responses.calls) >= 1
-        data = orjson.loads(responses.calls[0].request.body)
-        assert SUCCESS_LINKED_MESSAGE in get_response_text(data)
+        assert self.mock_webhook.call_count == 1
+        text = self.mock_webhook.call_args.kwargs["text"]
+        assert text == SUCCESS_LINKED_MESSAGE
 
 
 class SlackCommandsLinkUserTest(SlackCommandsTest):
     """Slash commands results are generated on Region Silo"""
 
-    @responses.activate
     def test_link_command(self):
         data = self.send_slack_message("link")
         assert "Link your Slack identity" in get_response_text(data)
@@ -50,7 +45,6 @@ class SlackCommandsLinkUserTest(SlackCommandsTest):
 class SlackUnlinkIdentityViewTest(SlackCommandsTest):
     """Slack Linking Views are returned on Control Silo"""
 
-    @responses.activate
     def test_unlink_user_identity_auth(self):
         self.link_user()
 
@@ -68,7 +62,6 @@ class SlackUnlinkIdentityViewTest(SlackCommandsTest):
             in response.content.decode("utf-8")
         )
 
-    @responses.activate
     def test_unlink_user_identity(self):
         self.link_user()
 
@@ -82,9 +75,9 @@ class SlackUnlinkIdentityViewTest(SlackCommandsTest):
         response = self.client.post(unlinking_url)
         assert response.status_code == 200
 
-        assert len(responses.calls) >= 1
-        data = orjson.loads(responses.calls[0].request.body)
-        assert SUCCESS_UNLINKED_MESSAGE in get_response_text(data)
+        assert self.mock_webhook.call_count == 1
+        text = self.mock_webhook.call_args.kwargs["text"]
+        assert text == SUCCESS_UNLINKED_MESSAGE
         assert not Identity.objects.filter(external_id=self.slack_id).exists()
 
     def test_404(self):


### PR DESCRIPTION
Default to using the new Slack SDK Client when somebody tries to link / unlink a team through the Slack command. Also adds metrics for the success / failures of these calls (either through the webhook client or chat_postMessage).

Added logic to ignore the error if the url has expired, that's on the user for not clicking soon enough.