### PR TITLE
feat(query-builder): Separate supported tags from tag sections in props

### DIFF
--- a/static/app/components/searchQueryBuilder/context.tsx
+++ b/static/app/components/searchQueryBuilder/context.tsx
@@ -11,10 +11,10 @@ import type {Tag, TagCollection} from 'sentry/types/group';
 interface ContextData {
   dispatch: Dispatch<QueryBuilderActions>;
   filterKeySections: FilterKeySection[];
+  filterKeys: TagCollection;
   focusOverride: FocusOverride | null;
   getTagValues: (tag: Tag, query: string) => Promise<string[]>;
   handleSearch: (query: string) => void;
-  keys: TagCollection;
   parsedQuery: ParseResult | null;
   query: string;
   searchSource: string;
@@ -27,7 +27,7 @@ export function useSearchQueryBuilder() {
 export const SearchQueryBuilerContext = createContext<ContextData>({
   query: '',
   focusOverride: null,
-  keys: {},
+  filterKeys: {},
   filterKeySections: [],
   getTagValues: () => Promise.resolve([]),
   dispatch: () => {},

--- a/static/app/components/searchQueryBuilder/index.spec.tsx
+++ b/static/app/components/searchQueryBuilder/index.spec.tsx
@@ -14,64 +14,72 @@ import {
   QueryInterfaceType,
 } from 'sentry/components/searchQueryBuilder/types';
 import {INTERFACE_TYPE_LOCALSTORAGE_KEY} from 'sentry/components/searchQueryBuilder/utils';
+import type {TagCollection} from 'sentry/types';
 import {FieldKey, FieldKind} from 'sentry/utils/fields';
 import localStorageWrapper from 'sentry/utils/localStorage';
+
+const FILTER_KEYS: TagCollection = {
+  [FieldKey.AGE]: {key: FieldKey.AGE, name: 'Age', kind: FieldKind.FIELD},
+  [FieldKey.ASSIGNED]: {
+    key: FieldKey.ASSIGNED,
+    name: 'Assigned To',
+    kind: FieldKind.FIELD,
+    predefined: true,
+    values: [
+      {
+        title: 'Suggested',
+        type: 'header',
+        icon: null,
+        children: [{value: 'me'}, {value: 'unassigned'}],
+      },
+      {
+        title: 'All',
+        type: 'header',
+        icon: null,
+        children: [{value: 'person1@sentry.io'}, {value: 'person2@sentry.io'}],
+      },
+    ],
+  },
+  [FieldKey.BROWSER_NAME]: {
+    key: FieldKey.BROWSER_NAME,
+    name: 'Browser Name',
+    kind: FieldKind.FIELD,
+    predefined: true,
+    values: ['Chrome', 'Firefox', 'Safari', 'Edge'],
+  },
+  [FieldKey.IS]: {
+    key: FieldKey.IS,
+    name: 'is',
+    predefined: true,
+    values: ['resolved', 'unresolved', 'ignored'],
+  },
+  [FieldKey.TIMES_SEEN]: {
+    key: FieldKey.TIMES_SEEN,
+    name: 'timesSeen',
+    kind: FieldKind.FIELD,
+  },
+  custom_tag_name: {
+    key: 'custom_tag_name',
+    name: 'Custom_Tag_Name',
+  },
+};
 
 const FITLER_KEY_SECTIONS: FilterKeySection[] = [
   {
     value: FieldKind.FIELD,
     label: 'Category 1',
     children: [
-      {key: FieldKey.AGE, name: 'Age', kind: FieldKind.FIELD},
-      {
-        key: FieldKey.ASSIGNED,
-        name: 'Assigned To',
-        kind: FieldKind.FIELD,
-        predefined: true,
-        values: [
-          {
-            title: 'Suggested',
-            type: 'header',
-            icon: null,
-            children: [{value: 'me'}, {value: 'unassigned'}],
-          },
-          {
-            title: 'All',
-            type: 'header',
-            icon: null,
-            children: [{value: 'person1@sentry.io'}, {value: 'person2@sentry.io'}],
-          },
-        ],
-      },
-      {
-        key: FieldKey.BROWSER_NAME,
-        name: 'Browser Name',
-        kind: FieldKind.FIELD,
-        predefined: true,
-        values: ['Chrome', 'Firefox', 'Safari', 'Edge'],
-      },
-      {
-        key: FieldKey.IS,
-        name: 'is',
-        predefined: true,
-        values: ['resolved', 'unresolved', 'ignored'],
-      },
-      {
-        key: FieldKey.TIMES_SEEN,
-        name: 'timesSeen',
-        kind: FieldKind.FIELD,
-      },
+      FieldKey.AGE,
+      FieldKey.ASSIGNED,
+      FieldKey.BROWSER_NAME,
+      FieldKey.IS,
+      FieldKey.TIMES_SEEN,
     ],
   },
   {
     value: FieldKind.TAG,
     label: 'Category 2',
-    children: [
-      {
-        key: 'custom_tag_name',
-        name: 'Custom_Tag_Name',
-      },
-    ],
+    children: ['custom_tag_name'],
   },
 ];
 
@@ -88,6 +96,7 @@ describe('SearchQueryBuilder', function () {
     getTagValues: jest.fn(),
     initialQuery: '',
     filterKeySections: FITLER_KEY_SECTIONS,
+    filterKeys: FILTER_KEYS,
     label: 'Query Builder',
     searchSource: '',
   };

--- a/static/app/components/searchQueryBuilder/index.stories.tsx
+++ b/static/app/components/searchQueryBuilder/index.stories.tsx
@@ -6,53 +6,71 @@ import {SearchQueryBuilder} from 'sentry/components/searchQueryBuilder';
 import type {FilterKeySection} from 'sentry/components/searchQueryBuilder/types';
 import SizingWindow from 'sentry/components/stories/sizingWindow';
 import storyBook from 'sentry/stories/storyBook';
+import type {TagCollection} from 'sentry/types/group';
 import {FieldKey, FieldKind} from 'sentry/utils/fields';
+
+const FILTER_KEYS: TagCollection = {
+  [FieldKey.AGE]: {key: FieldKey.AGE, name: 'Age', kind: FieldKind.FIELD},
+  [FieldKey.ASSIGNED]: {
+    key: FieldKey.ASSIGNED,
+    name: 'Assigned To',
+    kind: FieldKind.FIELD,
+    predefined: true,
+    values: [
+      {
+        title: 'Suggested',
+        type: 'header',
+        icon: null,
+        children: [{value: 'me'}, {value: 'unassigned'}],
+      },
+      {
+        title: 'All',
+        type: 'header',
+        icon: null,
+        children: [{value: 'person1@sentry.io'}, {value: 'person2@sentry.io'}],
+      },
+    ],
+  },
+  [FieldKey.BROWSER_NAME]: {
+    key: FieldKey.BROWSER_NAME,
+    name: 'Browser Name',
+    kind: FieldKind.FIELD,
+    predefined: true,
+    values: ['Chrome', 'Firefox', 'Safari', 'Edge'],
+  },
+  [FieldKey.IS]: {
+    key: FieldKey.IS,
+    name: 'is',
+    predefined: true,
+    values: ['resolved', 'unresolved', 'ignored'],
+  },
+  [FieldKey.TIMES_SEEN]: {
+    key: FieldKey.TIMES_SEEN,
+    name: 'timesSeen',
+    kind: FieldKind.FIELD,
+  },
+  custom_tag_name: {
+    key: 'custom_tag_name',
+    name: 'Custom_Tag_Name',
+  },
+};
 
 const FITLER_KEY_SECTIONS: FilterKeySection[] = [
   {
     value: FieldKind.FIELD,
     label: 'Category 1',
     children: [
-      {key: FieldKey.AGE, name: 'Age', kind: FieldKind.FIELD},
-      {
-        key: FieldKey.ASSIGNED,
-        name: 'Assigned To',
-        kind: FieldKind.FIELD,
-        predefined: true,
-        values: [
-          {
-            title: 'Suggested',
-            type: 'header',
-            icon: null,
-            children: [{value: 'me'}, {value: 'unassigned'}],
-          },
-          {
-            title: 'All',
-            type: 'header',
-            icon: null,
-            children: [{value: 'person1@sentry.io'}, {value: 'person2@sentry.io'}],
-          },
-        ],
-      },
-      {
-        key: FieldKey.BROWSER_NAME,
-        name: 'Browser Name',
-        kind: FieldKind.FIELD,
-        predefined: true,
-        values: ['Chrome', 'Firefox', 'Safari', 'Edge'],
-      },
+      FieldKey.AGE,
+      FieldKey.ASSIGNED,
+      FieldKey.BROWSER_NAME,
+      FieldKey.IS,
+      FieldKey.TIMES_SEEN,
     ],
   },
   {
     value: FieldKind.TAG,
     label: 'Category 2',
-    children: [
-      {
-        key: 'custom_tag_name',
-        name: 'Custom_Tag_Name',
-        values: ['tag value one', 'tag value two', 'tag value three'],
-      },
-    ],
+    children: ['custom_tag_name'],
   },
 ];
 
@@ -73,6 +91,7 @@ export default storyBook(SearchQueryBuilder, story => {
           <SearchQueryBuilder
             initialQuery="browser.name:Firefox assigned:me custom_tag_name:123"
             filterKeySections={FITLER_KEY_SECTIONS}
+            filterKeys={FILTER_KEYS}
             getTagValues={getTagValues}
             searchSource="storybook"
           />

--- a/static/app/components/searchQueryBuilder/input.tsx
+++ b/static/app/components/searchQueryBuilder/input.tsx
@@ -23,7 +23,7 @@ import {
 } from 'sentry/components/searchSyntax/parser';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
-import type {Tag} from 'sentry/types/group';
+import type {Tag, TagCollection} from 'sentry/types/group';
 import {FieldValueType, getFieldDefinition} from 'sentry/utils/fields';
 import {useFuzzySearch} from 'sentry/utils/fuzzySearch';
 import {isCtrlKeyPressed} from 'sentry/utils/isCtrlKeyPressed';
@@ -172,12 +172,12 @@ function createItem(tag: Tag): KeyItem {
   };
 }
 
-function createSection(section: FilterKeySection): KeySectionItem {
+function createSection(section: FilterKeySection, keys: TagCollection): KeySectionItem {
   return {
     key: section.value,
     value: section.value,
     title: section.label,
-    options: section.children.map(createItem),
+    options: section.children.map(key => createItem(keys[key])),
   };
 }
 
@@ -223,20 +223,23 @@ function useSortItems({
 }: {
   filterValue: string;
 }): Array<KeySectionItem | KeyItem> {
-  const {filterKeySections} = useSearchQueryBuilder();
+  const {filterKeys, filterKeySections} = useSearchQueryBuilder();
   const flatItems = useMemo<KeyItem[]>(
-    () => filterKeySections.flatMap(section => section.children.map(createItem)),
-    [filterKeySections]
+    () => Object.values(filterKeys).map(createItem),
+    [filterKeys]
   );
   const search = useFuzzySearch(flatItems, FUZZY_SEARCH_OPTIONS);
 
   return useMemo(() => {
     if (!filterValue || !search) {
-      return filterKeySections.map(createSection);
+      if (!filterKeySections.length) {
+        return flatItems;
+      }
+      return filterKeySections.map(section => createSection(section, filterKeys));
     }
 
     return search.search(filterValue).map(({item}) => item);
-  }, [filterKeySections, filterValue, search]);
+  }, [filterKeySections, filterKeys, filterValue, flatItems, search]);
 }
 
 function KeyDescription({tag}: {tag: Tag}) {
@@ -291,10 +294,11 @@ function SearchQueryBuilderInputInternal({
 
   const filterValue = getWordAtCursorPosition(inputValue, selectionIndex);
 
-  const {query, keys, dispatch, handleSearch} = useSearchQueryBuilder();
+  const {query, filterKeys, filterKeySections, dispatch, handleSearch} =
+    useSearchQueryBuilder();
   const aliasToKeyMap = useMemo(() => {
-    return Object.fromEntries(Object.values(keys).map(key => [key.alias, key.key]));
-  }, [keys]);
+    return Object.fromEntries(Object.values(filterKeys).map(key => [key.alias, key.key]));
+  }, [filterKeys]);
 
   const items = useSortItems({filterValue});
 
@@ -441,7 +445,7 @@ function SearchQueryBuilderInputInternal({
       tabIndex={tabIndex}
       maxOptions={50}
       onPaste={onPaste}
-      displayTabbedMenu={inputValue.length === 0}
+      displayTabbedMenu={inputValue.length === 0 && filterKeySections.length > 0}
       shouldFilterResults={false}
       shouldCloseOnInteractOutside={el => {
         if (rowRef.current?.contains(el)) {

--- a/static/app/components/searchQueryBuilder/types.tsx
+++ b/static/app/components/searchQueryBuilder/types.tsx
@@ -1,9 +1,7 @@
 import type {ReactNode} from 'react';
 
-import type {Tag} from 'sentry/types/group';
-
 export type FilterKeySection = {
-  children: Tag[];
+  children: string[];
   label: ReactNode;
   value: string;
 };

--- a/static/app/components/searchQueryBuilder/utils.tsx
+++ b/static/app/components/searchQueryBuilder/utils.tsx
@@ -62,12 +62,12 @@ function getSearchConfigFromKeys(keys: TagCollection): Partial<SearchConfig> {
 
 export function parseQueryBuilderValue(
   value: string,
-  options?: {keys: TagCollection}
+  options?: {filterKeys: TagCollection}
 ): ParseResult | null {
   return collapseTextTokens(
     parseSearch(value || ' ', {
       flattenParenGroups: true,
-      ...getSearchConfigFromKeys(options?.keys ?? {}),
+      ...getSearchConfigFromKeys(options?.filterKeys ?? {}),
     })
   );
 }

--- a/static/app/components/searchQueryBuilder/valueCombobox.tsx
+++ b/static/app/components/searchQueryBuilder/valueCombobox.tsx
@@ -500,14 +500,14 @@ function useFilterSuggestions({
   selectedValues: string[];
   token: TokenResult<Token.FILTER>;
 }) {
-  const {getTagValues, keys} = useSearchQueryBuilder();
-  const key = keys[token.key.text];
+  const {getTagValues, filterKeys} = useSearchQueryBuilder();
+  const key = filterKeys[token.key.text];
   const predefinedValues = useMemo(
     () => getPredefinedValues({key, filterValue, token}),
     [key, filterValue, token]
   );
   const shouldFetchValues = key && !key.predefined && !predefinedValues.length;
-  const canSelectMultipleValues = tokenSupportsMultipleValues(token, keys);
+  const canSelectMultipleValues = tokenSupportsMultipleValues(token, filterKeys);
 
   // TODO(malwilley): Display error states
   const {data, isFetching} = useQuery<string[]>({
@@ -635,8 +635,8 @@ export function SearchQueryBuilderValueCombobox({
 }: SearchQueryValueBuilderProps) {
   const ref = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
-  const {keys, dispatch} = useSearchQueryBuilder();
-  const canSelectMultipleValues = tokenSupportsMultipleValues(token, keys);
+  const {filterKeys, dispatch} = useSearchQueryBuilder();
+  const canSelectMultipleValues = tokenSupportsMultipleValues(token, filterKeys);
   const [inputValue, setInputValue] = useState(() => {
     if (isDateToken(token)) {
       return token.value.type === Token.VALUE_ISO_8601_DATE ? token.value.text : '';

--- a/static/app/views/issueList/searchBar.tsx
+++ b/static/app/views/issueList/searchBar.tsx
@@ -1,4 +1,4 @@
-import {useCallback} from 'react';
+import {useCallback, useMemo} from 'react';
 import styled from '@emotion/styled';
 import orderBy from 'lodash/orderBy';
 
@@ -40,7 +40,14 @@ const getSupportedTags = (supportedTags: TagCollection): TagCollection => {
   );
 };
 
-const getFilterKeySections = (tags: TagCollection): FilterKeySection[] => {
+const getFilterKeySections = (
+  tags: TagCollection,
+  organization: Organization
+): FilterKeySection[] => {
+  if (!organization.features.includes('issue-stream-search-query-builder')) {
+    return [];
+  }
+
   const allTags: Tag[] = Object.values(tags).filter(
     tag => !EXCLUDED_TAGS.includes(tag.key)
   );
@@ -48,15 +55,15 @@ const getFilterKeySections = (tags: TagCollection): FilterKeySection[] => {
     allTags.filter(tag => tag.kind === FieldKind.TAG),
     ['totalValues', 'key'],
     ['desc', 'asc']
-  );
+  ).map(tag => tag.key);
   const issueFields = orderBy(
     allTags.filter(tag => tag.kind === FieldKind.ISSUE_FIELD),
     ['key']
-  );
+  ).map(tag => tag.key);
   const eventFields = orderBy(
     allTags.filter(tag => tag.kind === FieldKind.EVENT_FIELD),
     ['key']
-  );
+  ).map(tag => tag.key);
 
   return [
     {
@@ -186,13 +193,18 @@ function IssueListSearchBar({organization, tags, ...props}: Props) {
     ],
   };
 
+  const filterKeySections = useMemo(() => {
+    return getFilterKeySections(tags, organization);
+  }, [organization, tags]);
+
   if (organization.features.includes('issue-stream-search-query-builder')) {
     return (
       <SearchQueryBuilder
         className={props.className}
         initialQuery={props.query ?? ''}
         getTagValues={getTagValues}
-        filterKeySections={getFilterKeySections(tags)}
+        filterKeySections={filterKeySections}
+        filterKeys={tags}
         onSearch={props.onSearch}
         onBlur={props.onBlur}
         onChange={value => {


### PR DESCRIPTION
Currently, the component accepts `filterKeySections` which is an organized list of sections which contain filter keys. It also defines what is shown in the empty state when adding a new filter. This PR changes the props so that we now accept `filterKeys` as a complete mapping of all available and valid keys, which is used as the source of truth when creating filters. `filterKeySections` is now an optional prop which defines what the empty state menu will look like.

By breaking these apart, we can show an abbreviated list of tags in the empty state menu, or not show that menu at all if it is not necessary.