### PR TITLE
ref(replay): Move currentHoverTime into its own Context and hook

### DIFF
--- a/static/app/components/performance/waterfall/row.tsx
+++ b/static/app/components/performance/waterfall/row.tsx
@@ -5,6 +5,7 @@ import {ROW_HEIGHT} from 'sentry/components/performance/waterfall/constants';
 import {getBackgroundColor} from 'sentry/components/performance/waterfall/utils';
 import {useReplayContext} from 'sentry/components/replays/replayContext';
 import toPercent from 'sentry/utils/number/toPercent';
+import useCurrentHoverTime from 'sentry/utils/replays/playback/providers/useCurrentHoverTime';
 
 interface RowProps extends React.HTMLAttributes<HTMLDivElement> {
   cursor?: 'pointer' | 'default';
@@ -62,7 +63,8 @@ export const RowCell = styled('div')<RowCellProps>`
 `;
 
 export function RowReplayTimeIndicators() {
-  const {currentTime, currentHoverTime, replay} = useReplayContext();
+  const {currentTime, replay} = useReplayContext();
+  const [currentHoverTime] = useCurrentHoverTime();
   const durationMs = replay?.getDurationMs();
 
   if (!replay || !durationMs) {

--- a/static/app/components/replays/player/scrubber.tsx
+++ b/static/app/components/replays/player/scrubber.tsx
@@ -12,6 +12,7 @@ import formatReplayDuration from 'sentry/utils/duration/formatReplayDuration';
 import divide from 'sentry/utils/number/divide';
 import toPercent from 'sentry/utils/number/toPercent';
 import useTimelineScale from 'sentry/utils/replays/hooks/useTimelineScale';
+import useCurrentHoverTime from 'sentry/utils/replays/playback/providers/useCurrentHoverTime';
 
 type Props = {
   className?: string;
@@ -19,7 +20,8 @@ type Props = {
 };
 
 function Scrubber({className, showZoomIndicators = false}: Props) {
-  const {replay, currentHoverTime, currentTime, setCurrentTime} = useReplayContext();
+  const {replay, currentTime, setCurrentTime} = useReplayContext();
+  const [currentHoverTime] = useCurrentHoverTime();
   const [timelineScale] = useTimelineScale();
 
   const durationMs = replay?.getDurationMs() ?? 0;

--- a/static/app/components/replays/player/useScrubberMouseTracking.tsx
+++ b/static/app/components/replays/player/useScrubberMouseTracking.tsx
@@ -4,13 +4,15 @@ import {useCallback} from 'react';
 import {useReplayContext} from 'sentry/components/replays/replayContext';
 import divide from 'sentry/utils/number/divide';
 import useMouseTracking from 'sentry/utils/replays/hooks/useMouseTracking';
+import useCurrentHoverTime from 'sentry/utils/replays/playback/providers/useCurrentHoverTime';
 
 type Opts<T extends Element> = {
   elem: RefObject<T>;
 };
 
 export function useScrubberMouseTracking<T extends Element>({elem}: Opts<T>) {
-  const {replay, setCurrentHoverTime} = useReplayContext();
+  const {replay} = useReplayContext();
+  const [, setCurrentHoverTime] = useCurrentHoverTime();
   const durationMs = replay?.getDurationMs();
 
   const handlePositionChange = useCallback(
@@ -43,7 +45,8 @@ export function useTimelineScrubberMouseTracking<T extends Element>(
   {elem}: Opts<T>,
   scale: number
 ) {
-  const {replay, currentTime, setCurrentHoverTime} = useReplayContext();
+  const {replay, currentTime} = useReplayContext();
+  const [, setCurrentHoverTime] = useCurrentHoverTime();
   const durationMs = replay?.getDurationMs();
 
   const handlePositionChange = useCallback(

--- a/static/app/components/replays/replayContext.tsx
+++ b/static/app/components/replays/replayContext.tsx
@@ -12,6 +12,7 @@ import {trackAnalytics} from 'sentry/utils/analytics';
 import clamp from 'sentry/utils/number/clamp';
 import type useInitialOffsetMs from 'sentry/utils/replays/hooks/useInitialTimeOffsetMs';
 import useRAF from 'sentry/utils/replays/hooks/useRAF';
+import {ReplayCurrentTimeContextProvider} from 'sentry/utils/replays/playback/providers/useCurrentHoverTime';
 import type ReplayReader from 'sentry/utils/replays/replayReader';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePrevious from 'sentry/utils/usePrevious';
@@ -653,35 +654,37 @@ export function Provider({
   }, [isBuffering, buffer.target]);
 
   return (
-    <ReplayPlayerContext.Provider
-      value={{
-        analyticsContext,
-        clearAllHighlights,
-        currentTime,
-        dimensions,
-        fastForwardSpeed,
-        addHighlight,
-        setRoot,
-        isBuffering: isBuffering && !isVideoReplay,
-        isVideoBuffering,
-        isFetching,
-        isVideoReplay,
-        isFinished,
-        isPlaying,
-        isSkippingInactive,
-        removeHighlight,
-        replay,
-        restart,
-        setCurrentTime,
-        setSpeed,
-        speed,
-        togglePlayPause,
-        toggleSkipInactive,
-        ...value,
-      }}
-    >
-      {children}
-    </ReplayPlayerContext.Provider>
+    <ReplayCurrentTimeContextProvider>
+      <ReplayPlayerContext.Provider
+        value={{
+          analyticsContext,
+          clearAllHighlights,
+          currentTime,
+          dimensions,
+          fastForwardSpeed,
+          addHighlight,
+          setRoot,
+          isBuffering: isBuffering && !isVideoReplay,
+          isVideoBuffering,
+          isFetching,
+          isVideoReplay,
+          isFinished,
+          isPlaying,
+          isSkippingInactive,
+          removeHighlight,
+          replay,
+          restart,
+          setCurrentTime,
+          setSpeed,
+          speed,
+          togglePlayPause,
+          toggleSkipInactive,
+          ...value,
+        }}
+      >
+        {children}
+      </ReplayPlayerContext.Provider>
+    </ReplayCurrentTimeContextProvider>
   );
 }
 

--- a/static/app/components/replays/replayContext.tsx
+++ b/static/app/components/replays/replayContext.tsx
@@ -1,12 +1,4 @@
-import {
-  createContext,
-  useCallback,
-  useContext,
-  useEffect,
-  useLayoutEffect,
-  useRef,
-  useState,
-} from 'react';
+import {createContext, useCallback, useContext, useEffect, useRef, useState} from 'react';
 import {useTheme} from '@emotion/react';
 import {Replayer, ReplayerEvents} from '@sentry-internal/rrweb';
 
@@ -20,7 +12,6 @@ import {trackAnalytics} from 'sentry/utils/analytics';
 import clamp from 'sentry/utils/number/clamp';
 import type useInitialOffsetMs from 'sentry/utils/replays/hooks/useInitialTimeOffsetMs';
 import useRAF from 'sentry/utils/replays/hooks/useRAF';
-import {replayPlayerTimestampEmitter} from 'sentry/utils/replays/replayPlayerTimestampEmitter';
 import type ReplayReader from 'sentry/utils/replays/replayReader';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePrevious from 'sentry/utils/usePrevious';
@@ -42,13 +33,6 @@ interface ReplayPlayerContextProps extends HighlightCallbacks {
    * The context in which the replay is being viewed.
    */
   analyticsContext: string;
-
-  /**
-   * The time, in milliseconds, where the user focus is.
-   * The user focus can be reported by any collaborating object, usually on
-   * hover.
-   */
-  currentHoverTime: undefined | number;
 
   /**
    * The current time of the video, in milliseconds
@@ -115,12 +99,6 @@ interface ReplayPlayerContextProps extends HighlightCallbacks {
   restart: () => void;
 
   /**
-   * Set the currentHoverTime so collaborating components can highlight related
-   * information
-   */
-  setCurrentHoverTime: (time: undefined | number) => void;
-
-  /**
    * Jump the video to a specific time
    */
   setCurrentTime: (time: number) => void;
@@ -160,7 +138,6 @@ interface ReplayPlayerContextProps extends HighlightCallbacks {
 const ReplayPlayerContext = createContext<ReplayPlayerContextProps>({
   analyticsContext: '',
   clearAllHighlights: () => {},
-  currentHoverTime: undefined,
   currentTime: 0,
   dimensions: {height: 0, width: 0},
   fastForwardSpeed: 0,
@@ -175,7 +152,6 @@ const ReplayPlayerContext = createContext<ReplayPlayerContextProps>({
   removeHighlight: () => {},
   replay: null,
   restart: () => {},
-  setCurrentHoverTime: () => {},
   setCurrentTime: () => {},
   setRoot: () => {},
   setSpeed: () => {},
@@ -251,7 +227,6 @@ export function Provider({
   const hasNewEvents = events !== oldEvents;
   const replayerRef = useRef<Replayer>(null);
   const [dimensions, setDimensions] = useState<Dimensions>({height: 0, width: 0});
-  const [currentHoverTime, setCurrentHoverTime] = useState<undefined | number>();
   const [isPlaying, setIsPlaying] = useState(false);
   const [finishedAtMS, setFinishedAtMS] = useState<number>(-1);
   const [isSkippingInactive, setIsSkippingInactive] = useState(
@@ -671,13 +646,6 @@ export function Provider({
     }
   }, [isBuffering, events, applyInitialOffset]);
 
-  useLayoutEffect(() => {
-    replayPlayerTimestampEmitter.emit('replay timestamp change', {
-      currentTime,
-      currentHoverTime,
-    });
-  }, [currentTime, currentHoverTime]);
-
   useEffect(() => {
     if (!isBuffering && buffer.target !== -1) {
       setBufferTime({target: -1, previous: -1});
@@ -689,7 +657,6 @@ export function Provider({
       value={{
         analyticsContext,
         clearAllHighlights,
-        currentHoverTime,
         currentTime,
         dimensions,
         fastForwardSpeed,
@@ -705,7 +672,6 @@ export function Provider({
         removeHighlight,
         replay,
         restart,
-        setCurrentHoverTime,
         setCurrentTime,
         setSpeed,
         speed,

--- a/static/app/utils/replays/hooks/useCrumbHandlers.tsx
+++ b/static/app/utils/replays/hooks/useCrumbHandlers.tsx
@@ -1,6 +1,7 @@
 import {useCallback, useRef} from 'react';
 
 import {useReplayContext} from 'sentry/components/replays/replayContext';
+import useCurrentHoverTime from 'sentry/utils/replays/playback/providers/useCurrentHoverTime';
 
 type RecordType = {
   offsetMs: number;
@@ -41,14 +42,9 @@ function getNodeIdAndLabel(record: RecordType) {
 }
 
 function useCrumbHandlers() {
-  const {
-    replay,
-    clearAllHighlights,
-    addHighlight,
-    removeHighlight,
-    setCurrentTime,
-    setCurrentHoverTime,
-  } = useReplayContext();
+  const {replay, clearAllHighlights, addHighlight, removeHighlight, setCurrentTime} =
+    useReplayContext();
+  const [, setCurrentHoverTime] = useCurrentHoverTime();
   const startTimestampMs = replay?.getReplay()?.started_at?.getTime() || 0;
 
   const mouseEnterCallback = useRef<{

--- a/static/app/utils/replays/playback/hooks/useEmitTimestampChanges.tsx
+++ b/static/app/utils/replays/playback/hooks/useEmitTimestampChanges.tsx
@@ -1,0 +1,23 @@
+import {useLayoutEffect} from 'react';
+
+import {useReplayContext} from 'sentry/components/replays/replayContext';
+import useCurrentHoverTime from 'sentry/utils/replays/playback/providers/useCurrentHoverTime';
+import {replayPlayerTimestampEmitter} from 'sentry/utils/replays/replayPlayerTimestampEmitter';
+
+/**
+ * @deprecated This emitted sends some global state through a singleton.
+ * If there are multiple replay instances on the page values will be confusing.
+ * A better implementation would nest the consumer under the same
+ * <ReplayCurrentTimeContextProvider> ancestor node.
+ */
+export default function useEmitTimestampChanges() {
+  const {currentTime} = useReplayContext();
+  const [currentHoverTime] = useCurrentHoverTime();
+
+  useLayoutEffect(() => {
+    replayPlayerTimestampEmitter.emit('replay timestamp change', {
+      currentTime,
+      currentHoverTime,
+    });
+  }, [currentTime, currentHoverTime]);
+}

--- a/static/app/utils/replays/playback/hooks/useEmitTimestampChanges.tsx
+++ b/static/app/utils/replays/playback/hooks/useEmitTimestampChanges.tsx
@@ -5,7 +5,7 @@ import useCurrentHoverTime from 'sentry/utils/replays/playback/providers/useCurr
 import {replayPlayerTimestampEmitter} from 'sentry/utils/replays/replayPlayerTimestampEmitter';
 
 /**
- * @deprecated This emitted sends some global state through a singleton.
+ * @deprecated This emitter sends some global state through a singleton.
  * If there are multiple replay instances on the page values will be confusing.
  * A better implementation would nest the consumer under the same
  * <ReplayCurrentTimeContextProvider> ancestor node.

--- a/static/app/utils/replays/playback/providers/useCurrentHoverTime.tsx
+++ b/static/app/utils/replays/playback/providers/useCurrentHoverTime.tsx
@@ -1,0 +1,16 @@
+import type {Dispatch, ReactNode, SetStateAction} from 'react';
+import {createContext, useContext, useState} from 'react';
+
+type ContextType = [undefined | number, Dispatch<SetStateAction<number | undefined>>];
+
+const context = createContext<ContextType>([undefined, () => {}]);
+
+export function ReplayCurrentTimeContextProvider({children}: {children: ReactNode}) {
+  const state = useState<undefined | number>(undefined);
+
+  return <context.Provider value={state}>{children}</context.Provider>;
+}
+
+export default function useCurrentHoverTime() {
+  return useContext(context);
+}

--- a/static/app/utils/replays/replayPlayerTimestampEmitter.tsx
+++ b/static/app/utils/replays/replayPlayerTimestampEmitter.tsx
@@ -31,7 +31,7 @@ class ReplayPlayerTimestampEmitter {
 }
 
 /**
- * @deprecated This emitter is a singlton that sends some global state around.
+ * @deprecated This emitter is a singleton that sends some global state around.
  * If there are multiple replay instances on the page values will be confusing.
  * A better implementation would nest the consumer under the same
  * <ReplayCurrentTimeContextProvider> ancestor node.

--- a/static/app/utils/replays/replayPlayerTimestampEmitter.tsx
+++ b/static/app/utils/replays/replayPlayerTimestampEmitter.tsx
@@ -30,4 +30,10 @@ class ReplayPlayerTimestampEmitter {
   }
 }
 
+/**
+ * @deprecated This emitter is a singlton that sends some global state around.
+ * If there are multiple replay instances on the page values will be confusing.
+ * A better implementation would nest the consumer under the same
+ * <ReplayCurrentTimeContextProvider> ancestor node.
+ */
 export const replayPlayerTimestampEmitter = new ReplayPlayerTimestampEmitter();

--- a/static/app/views/replays/detail/accessibility/index.tsx
+++ b/static/app/views/replays/detail/accessibility/index.tsx
@@ -15,6 +15,7 @@ import {t} from 'sentry/locale';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import useA11yData from 'sentry/utils/replays/hooks/useA11yData';
 import useCrumbHandlers from 'sentry/utils/replays/hooks/useCrumbHandlers';
+import useCurrentHoverTime from 'sentry/utils/replays/playback/providers/useCurrentHoverTime';
 import useOrganization from 'sentry/utils/useOrganization';
 import AccessibilityFilters from 'sentry/views/replays/detail/accessibility/accessibilityFilters';
 import AccessibilityHeaderCell, {
@@ -43,7 +44,8 @@ const cellMeasurer = {
 
 function AccessibilityList() {
   const organization = useOrganization();
-  const {currentTime, currentHoverTime} = useReplayContext();
+  const {currentTime} = useReplayContext();
+  const [currentHoverTime] = useCurrentHoverTime();
   const {onMouseEnter, onMouseLeave, onClickTimestamp} = useCrumbHandlers();
 
   const {

--- a/static/app/views/replays/detail/breadcrumbs/breadcrumbRow.tsx
+++ b/static/app/views/replays/detail/breadcrumbs/breadcrumbRow.tsx
@@ -6,6 +6,7 @@ import BreadcrumbItem from 'sentry/components/replays/breadcrumbs/breadcrumbItem
 import {useReplayContext} from 'sentry/components/replays/replayContext';
 import type {Extraction} from 'sentry/utils/replays/extractDomNodes';
 import useCrumbHandlers from 'sentry/utils/replays/hooks/useCrumbHandlers';
+import useCurrentHoverTime from 'sentry/utils/replays/playback/providers/useCurrentHoverTime';
 import type {ReplayFrame} from 'sentry/utils/replays/types';
 
 interface Props {
@@ -35,7 +36,8 @@ export default function BreadcrumbRow({
   startTimestampMs,
   style,
 }: Props) {
-  const {currentTime, currentHoverTime} = useReplayContext();
+  const {currentTime} = useReplayContext();
+  const [currentHoverTime] = useCurrentHoverTime();
 
   const {onMouseEnter, onMouseLeave} = useCrumbHandlers();
 

--- a/static/app/views/replays/detail/console/index.tsx
+++ b/static/app/views/replays/detail/console/index.tsx
@@ -8,6 +8,7 @@ import {useReplayContext} from 'sentry/components/replays/replayContext';
 import useJumpButtons from 'sentry/components/replays/useJumpButtons';
 import {t} from 'sentry/locale';
 import useCrumbHandlers from 'sentry/utils/replays/hooks/useCrumbHandlers';
+import useCurrentHoverTime from 'sentry/utils/replays/playback/providers/useCurrentHoverTime';
 import ConsoleFilters from 'sentry/views/replays/detail/console/consoleFilters';
 import ConsoleLogRow from 'sentry/views/replays/detail/console/consoleLogRow';
 import useConsoleFilters from 'sentry/views/replays/detail/console/useConsoleFilters';
@@ -26,7 +27,8 @@ const cellMeasurer = {
 };
 
 function Console() {
-  const {currentTime, currentHoverTime, replay} = useReplayContext();
+  const {currentTime, replay} = useReplayContext();
+  const [currentHoverTime] = useCurrentHoverTime();
   const {onMouseEnter, onMouseLeave, onClickTimestamp} = useCrumbHandlers();
 
   const startTimestampMs = replay?.getReplay()?.started_at?.getTime() ?? 0;

--- a/static/app/views/replays/detail/errorList/index.tsx
+++ b/static/app/views/replays/detail/errorList/index.tsx
@@ -9,6 +9,7 @@ import {useReplayContext} from 'sentry/components/replays/replayContext';
 import useJumpButtons from 'sentry/components/replays/useJumpButtons';
 import {t} from 'sentry/locale';
 import useCrumbHandlers from 'sentry/utils/replays/hooks/useCrumbHandlers';
+import useCurrentHoverTime from 'sentry/utils/replays/playback/providers/useCurrentHoverTime';
 import ErrorFilters from 'sentry/views/replays/detail/errorList/errorFilters';
 import ErrorHeaderCell, {
   COLUMN_COUNT,
@@ -30,7 +31,8 @@ const cellMeasurer = {
 };
 
 function ErrorList() {
-  const {currentTime, currentHoverTime, replay} = useReplayContext();
+  const {currentTime, replay} = useReplayContext();
+  const [currentHoverTime] = useCurrentHoverTime();
   const {onMouseEnter, onMouseLeave, onClickTimestamp} = useCrumbHandlers();
 
   const errorFrames = replay?.getErrorFrames();

--- a/static/app/views/replays/detail/memoryPanel/domNodesChart.tsx
+++ b/static/app/views/replays/detail/memoryPanel/domNodesChart.tsx
@@ -1,3 +1,4 @@
+import type {Dispatch, SetStateAction} from 'react';
 import {useMemo, useRef} from 'react';
 import {useTheme} from '@emotion/react';
 
@@ -18,12 +19,11 @@ import formatReplayDuration from 'sentry/utils/duration/formatReplayDuration';
 import type {DomNodeChartDatapoint} from 'sentry/utils/replays/countDomNodes';
 
 interface Props
-  extends Pick<
-    ReturnType<typeof useReplayContext>,
-    'currentTime' | 'currentHoverTime' | 'setCurrentTime' | 'setCurrentHoverTime'
-  > {
+  extends Pick<ReturnType<typeof useReplayContext>, 'currentTime' | 'setCurrentTime'> {
+  currentHoverTime: undefined | number;
   datapoints: DomNodeChartDatapoint[];
   durationMs: number;
+  setCurrentHoverTime: Dispatch<SetStateAction<number | undefined>>;
   startTimestampMs: number;
 }
 

--- a/static/app/views/replays/detail/memoryPanel/index.tsx
+++ b/static/app/views/replays/detail/memoryPanel/index.tsx
@@ -8,6 +8,7 @@ import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {useQuery} from 'sentry/utils/queryClient';
 import countDomNodes from 'sentry/utils/replays/countDomNodes';
+import useCurrentHoverTime from 'sentry/utils/replays/playback/providers/useCurrentHoverTime';
 import type ReplayReader from 'sentry/utils/replays/replayReader';
 import DomNodesChart from 'sentry/views/replays/detail/memoryPanel/domNodesChart';
 import MemoryChart from 'sentry/views/replays/detail/memoryPanel/memoryChart';
@@ -26,14 +27,8 @@ function useCountDomNodes({replay}: {replay: null | ReplayReader}) {
 }
 
 export default function MemoryPanel() {
-  const {
-    currentTime,
-    currentHoverTime,
-    isFetching,
-    replay,
-    setCurrentHoverTime,
-    setCurrentTime,
-  } = useReplayContext();
+  const {currentTime, isFetching, replay, setCurrentTime} = useReplayContext();
+  const [currentHoverTime, setCurrentHoverTime] = useCurrentHoverTime();
 
   const memoryFrames = replay?.getMemoryFrames();
 

--- a/static/app/views/replays/detail/memoryPanel/memoryChart.tsx
+++ b/static/app/views/replays/detail/memoryPanel/memoryChart.tsx
@@ -1,3 +1,4 @@
+import type {Dispatch, SetStateAction} from 'react';
 import {useMemo, useRef} from 'react';
 import {useTheme} from '@emotion/react';
 
@@ -18,12 +19,11 @@ import formatReplayDuration from 'sentry/utils/duration/formatReplayDuration';
 import type {MemoryFrame} from 'sentry/utils/replays/types';
 
 interface Props
-  extends Pick<
-    ReturnType<typeof useReplayContext>,
-    'currentTime' | 'currentHoverTime' | 'setCurrentTime' | 'setCurrentHoverTime'
-  > {
+  extends Pick<ReturnType<typeof useReplayContext>, 'currentTime' | 'setCurrentTime'> {
+  currentHoverTime: undefined | number;
   durationMs: number;
   memoryFrames: MemoryFrame[];
+  setCurrentHoverTime: Dispatch<SetStateAction<number | undefined>>;
   startTimestampMs: number;
 }
 

--- a/static/app/views/replays/detail/network/index.tsx
+++ b/static/app/views/replays/detail/network/index.tsx
@@ -13,6 +13,7 @@ import useDetailsSplit from 'sentry/components/replays/virtualizedGrid/useDetail
 import {t} from 'sentry/locale';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import useCrumbHandlers from 'sentry/utils/replays/hooks/useCrumbHandlers';
+import useCurrentHoverTime from 'sentry/utils/replays/playback/providers/useCurrentHoverTime';
 import {getFrameMethod, getFrameStatus} from 'sentry/utils/replays/resourceFrame';
 import useOrganization from 'sentry/utils/useOrganization';
 import FilterLoadingIndicator from 'sentry/views/replays/detail/filterLoadingIndicator';
@@ -41,7 +42,8 @@ const cellMeasurer = {
 
 function NetworkList() {
   const organization = useOrganization();
-  const {currentTime, currentHoverTime, replay} = useReplayContext();
+  const {currentTime, replay} = useReplayContext();
+  const [currentHoverTime] = useCurrentHoverTime();
   const {onMouseEnter, onMouseLeave, onClickTimestamp} = useCrumbHandlers();
 
   const isNetworkDetailsSetup = Boolean(replay?.isNetworkDetailsSetup());

--- a/static/app/views/replays/detail/trace/replayTransactionContext.tsx
+++ b/static/app/views/replays/detail/trace/replayTransactionContext.tsx
@@ -25,6 +25,7 @@ import {
   getTraceRequestPayload,
   makeEventView,
 } from 'sentry/utils/performance/quickTrace/utils';
+import useEmitTimestampChanges from 'sentry/utils/replays/playback/hooks/useEmitTimestampChanges';
 import useApi from 'sentry/utils/useApi';
 import useOrganization from 'sentry/utils/useOrganization';
 import {getTraceSplitResults} from 'sentry/views/performance/traceDetails/utils';
@@ -82,6 +83,7 @@ const TxnContext = createContext<TxnContextProps>({
 function ReplayTransactionContext({children, replayRecord}: Options) {
   const api = useApi();
   const organization = useOrganization();
+  useEmitTimestampChanges();
 
   const [state, setState] = useState<InternalState>(INITIAL_STATE);
 

--- a/static/app/views/replays/details.tsx
+++ b/static/app/views/replays/details.tsx
@@ -20,7 +20,6 @@ import useLogReplayDataLoaded from 'sentry/utils/replays/hooks/useLogReplayDataL
 import useMarkReplayViewed from 'sentry/utils/replays/hooks/useMarkReplayViewed';
 import useReplayPageview from 'sentry/utils/replays/hooks/useReplayPageview';
 import useReplayReader from 'sentry/utils/replays/hooks/useReplayReader';
-import {ReplayCurrentTimeContextProvider} from 'sentry/utils/replays/playback/providers/useCurrentHoverTime';
 import useRouteAnalyticsEventNames from 'sentry/utils/routeAnalytics/useRouteAnalyticsEventNames';
 import useRouteAnalyticsParams from 'sentry/utils/routeAnalytics/useRouteAnalyticsParams';
 import {useLocation} from 'sentry/utils/useLocation';
@@ -184,32 +183,30 @@ function ReplayDetails({params: {replaySlug}}: Props) {
   );
 
   return (
-    <ReplayCurrentTimeContextProvider>
-      <ReplayContextProvider
-        analyticsContext="replay_details"
-        initialTimeOffsetMs={initialTimeOffsetMs}
-        isFetching={fetching}
-        prefsStrategy={LocalStorageReplayPreferences}
-        replay={replay}
-      >
-        <ReplayTransactionContext replayRecord={replayRecord}>
-          <Page
+    <ReplayContextProvider
+      analyticsContext="replay_details"
+      initialTimeOffsetMs={initialTimeOffsetMs}
+      isFetching={fetching}
+      prefsStrategy={LocalStorageReplayPreferences}
+      replay={replay}
+    >
+      <ReplayTransactionContext replayRecord={replayRecord}>
+        <Page
+          isVideoReplay={isVideoReplay}
+          orgSlug={orgSlug}
+          replayRecord={replayRecord}
+          projectSlug={projectSlug}
+          replayErrors={replayErrors}
+          isLoading={isLoading}
+        >
+          <ReplaysLayout
             isVideoReplay={isVideoReplay}
-            orgSlug={orgSlug}
             replayRecord={replayRecord}
-            projectSlug={projectSlug}
-            replayErrors={replayErrors}
             isLoading={isLoading}
-          >
-            <ReplaysLayout
-              isVideoReplay={isVideoReplay}
-              replayRecord={replayRecord}
-              isLoading={isLoading}
-            />
-          </Page>
-        </ReplayTransactionContext>
-      </ReplayContextProvider>
-    </ReplayCurrentTimeContextProvider>
+          />
+        </Page>
+      </ReplayTransactionContext>
+    </ReplayContextProvider>
   );
 }
 

--- a/static/app/views/replays/details.tsx
+++ b/static/app/views/replays/details.tsx
@@ -20,6 +20,7 @@ import useLogReplayDataLoaded from 'sentry/utils/replays/hooks/useLogReplayDataL
 import useMarkReplayViewed from 'sentry/utils/replays/hooks/useMarkReplayViewed';
 import useReplayPageview from 'sentry/utils/replays/hooks/useReplayPageview';
 import useReplayReader from 'sentry/utils/replays/hooks/useReplayReader';
+import {ReplayCurrentTimeContextProvider} from 'sentry/utils/replays/playback/providers/useCurrentHoverTime';
 import useRouteAnalyticsEventNames from 'sentry/utils/routeAnalytics/useRouteAnalyticsEventNames';
 import useRouteAnalyticsParams from 'sentry/utils/routeAnalytics/useRouteAnalyticsParams';
 import {useLocation} from 'sentry/utils/useLocation';
@@ -183,30 +184,32 @@ function ReplayDetails({params: {replaySlug}}: Props) {
   );
 
   return (
-    <ReplayContextProvider
-      analyticsContext="replay_details"
-      initialTimeOffsetMs={initialTimeOffsetMs}
-      isFetching={fetching}
-      prefsStrategy={LocalStorageReplayPreferences}
-      replay={replay}
-    >
-      <ReplayTransactionContext replayRecord={replayRecord}>
-        <Page
-          isVideoReplay={isVideoReplay}
-          orgSlug={orgSlug}
-          replayRecord={replayRecord}
-          projectSlug={projectSlug}
-          replayErrors={replayErrors}
-          isLoading={isLoading}
-        >
-          <ReplaysLayout
+    <ReplayCurrentTimeContextProvider>
+      <ReplayContextProvider
+        analyticsContext="replay_details"
+        initialTimeOffsetMs={initialTimeOffsetMs}
+        isFetching={fetching}
+        prefsStrategy={LocalStorageReplayPreferences}
+        replay={replay}
+      >
+        <ReplayTransactionContext replayRecord={replayRecord}>
+          <Page
             isVideoReplay={isVideoReplay}
+            orgSlug={orgSlug}
             replayRecord={replayRecord}
+            projectSlug={projectSlug}
+            replayErrors={replayErrors}
             isLoading={isLoading}
-          />
-        </Page>
-      </ReplayTransactionContext>
-    </ReplayContextProvider>
+          >
+            <ReplaysLayout
+              isVideoReplay={isVideoReplay}
+              replayRecord={replayRecord}
+              isLoading={isLoading}
+            />
+          </Page>
+        </ReplayTransactionContext>
+      </ReplayContextProvider>
+    </ReplayCurrentTimeContextProvider>
   );
 }
 


### PR DESCRIPTION
I'm slicing some non-critical stuff out of the main `useReplayContext()`, and the currentHoverTime has so few dependencies, it's a perfect candidate. 

