### PR TITLE
feat(useFeedbackWidget): Add a more flexible hook for opening feedback forms

### DIFF
--- a/static/app/components/feedback/widget/useFeedback.tsx
+++ b/static/app/components/feedback/widget/useFeedback.tsx
@@ -1,0 +1,36 @@
+import {useMemo} from 'react';
+import * as Sentry from '@sentry/react';
+
+import {t} from 'sentry/locale';
+import ConfigStore from 'sentry/stores/configStore';
+import {useLegacyStore} from 'sentry/stores/useLegacyStore';
+import useAsyncSDKIntegrationStore from 'sentry/views/app/asyncSDKIntegrationProvider';
+
+type FeedbackIntegration = NonNullable<ReturnType<typeof Sentry.getFeedback>>;
+
+export type UseFeedbackOptions = {
+  formTitle?: string;
+  messagePlaceholder?: string;
+};
+
+export function useFeedback({formTitle, messagePlaceholder}: UseFeedbackOptions) {
+  const config = useLegacyStore(ConfigStore);
+  const {state} = useAsyncSDKIntegrationStore();
+
+  // TODO(ryan953): remove the fallback `?? Sentry.getFeedback()` after
+  // getsentry is calling `store.add(feedback);`
+  const feedback =
+    (state.Feedback as FeedbackIntegration | undefined) ?? Sentry.getFeedback();
+
+  const options = useMemo(() => {
+    return {
+      colorScheme: config.theme === 'dark' ? ('dark' as const) : ('light' as const),
+      buttonLabel: t('Give Feedback'),
+      submitButtonLabel: t('Send Feedback'),
+      messagePlaceholder: messagePlaceholder ?? t('What did you expect?'),
+      formTitle: formTitle ?? t('Give Feedback'),
+    };
+  }, [config.theme, formTitle, messagePlaceholder]);
+
+  return {feedback, options};
+}

--- a/static/app/components/feedback/widget/useFeedback.tsx
+++ b/static/app/components/feedback/widget/useFeedback.tsx
@@ -1,5 +1,5 @@
 import {useMemo} from 'react';
-import * as Sentry from '@sentry/react';
+import type * as Sentry from '@sentry/react';
 
 import {t} from 'sentry/locale';
 import ConfigStore from 'sentry/stores/configStore';
@@ -17,10 +17,7 @@ export function useFeedback({formTitle, messagePlaceholder}: UseFeedbackOptions)
   const config = useLegacyStore(ConfigStore);
   const {state} = useAsyncSDKIntegrationStore();
 
-  // TODO(ryan953): remove the fallback `?? Sentry.getFeedback()` after
-  // getsentry is calling `store.add(feedback);`
-  const feedback =
-    (state.Feedback as FeedbackIntegration | undefined) ?? Sentry.getFeedback();
+  const feedback = state.Feedback as FeedbackIntegration | undefined;
 
   const options = useMemo(() => {
     return {

--- a/static/app/components/feedback/widget/useFeedbackForm.tsx
+++ b/static/app/components/feedback/widget/useFeedbackForm.tsx
@@ -1,0 +1,22 @@
+import {useCallback} from 'react';
+
+import {
+  useFeedback,
+  type UseFeedbackOptions,
+} from 'sentry/components/feedback/widget/useFeedback';
+
+export function useFeedbackForm(props: UseFeedbackOptions) {
+  const {feedback, options} = useFeedback(props);
+
+  const openForm = useCallback(async () => {
+    if (!feedback) {
+      return;
+    }
+
+    const form = await feedback.createForm(options);
+    form.appendToDom();
+    form.open();
+  }, [feedback, options]);
+
+  return {feedback, openForm};
+}

--- a/static/app/components/feedback/widget/useFeedbackWidget.tsx
+++ b/static/app/components/feedback/widget/useFeedbackWidget.tsx
@@ -1,13 +1,7 @@
 import type {RefObject} from 'react';
 import {useEffect} from 'react';
-import * as Sentry from '@sentry/react';
 
-import {t} from 'sentry/locale';
-import ConfigStore from 'sentry/stores/configStore';
-import {useLegacyStore} from 'sentry/stores/useLegacyStore';
-import useAsyncSDKIntegrationStore from 'sentry/views/app/asyncSDKIntegrationProvider';
-
-type FeedbackIntegration = NonNullable<ReturnType<typeof Sentry.getFeedback>>;
+import {useFeedback} from 'sentry/components/feedback/widget/useFeedback';
 
 interface Props {
   buttonRef?: RefObject<HTMLButtonElement> | RefObject<HTMLAnchorElement>;
@@ -20,26 +14,12 @@ export default function useFeedbackWidget({
   formTitle,
   messagePlaceholder,
 }: Props) {
-  const config = useLegacyStore(ConfigStore);
-  const {state} = useAsyncSDKIntegrationStore();
-
-  // TODO(ryan953): remove the fallback `?? Sentry.getFeedback()` after
-  // getsentry is calling `store.add(feedback);`
-  const feedback =
-    (state.Feedback as FeedbackIntegration | undefined) ?? Sentry.getFeedback();
+  const {feedback, options} = useFeedback({formTitle, messagePlaceholder});
 
   useEffect(() => {
     if (!feedback) {
       return undefined;
     }
-
-    const options = {
-      colorScheme: config.theme === 'dark' ? ('dark' as const) : ('light' as const),
-      buttonLabel: t('Give Feedback'),
-      submitButtonLabel: t('Send Feedback'),
-      messagePlaceholder: messagePlaceholder ?? t('What did you expect?'),
-      formTitle: formTitle ?? t('Give Feedback'),
-    };
 
     if (buttonRef) {
       if (buttonRef.current) {
@@ -53,7 +33,7 @@ export default function useFeedbackWidget({
     }
 
     return undefined;
-  }, [buttonRef, config.theme, feedback, formTitle, messagePlaceholder]);
+  }, [buttonRef, feedback, options]);
 
   return feedback;
 }


### PR DESCRIPTION
Adds a new `useFeedbackForm()` hook which simply returns a `openForm()` function which opens the form.

While doing so, extracted the `feedback` and `options` creation to `useFeedback()` which is now used by both `useFeedbackForm()` and `useFeedbackWidget()`