### PR TITLE
ref(hc): Refactor "convert to async response" tasks

### DIFF
--- a/src/sentry/middleware/integrations/tasks.py
+++ b/src/sentry/middleware/integrations/tasks.py
@@ -53,6 +53,8 @@ class _AsyncRegionDispatcher(ABC):
         )
 
         if successes:
+            # Typically we expect only one request to be made or only one successful
+            # response. If there are multiple, forward one arbitrarily.
             return self._forward_response(successes[-1])
         else:
             return None

--- a/src/sentry/middleware/integrations/tasks.py
+++ b/src/sentry/middleware/integrations/tasks.py
@@ -1,5 +1,7 @@
 import logging
-from collections.abc import MutableMapping
+from abc import ABC, abstractmethod
+from collections.abc import Iterable
+from dataclasses import dataclass
 from typing import Any, cast
 
 import orjson
@@ -11,9 +13,98 @@ from rest_framework import status
 from sentry.silo.base import SiloMode
 from sentry.silo.client import RegionSiloClient
 from sentry.tasks.base import instrumented_task
-from sentry.types.region import get_region_by_name
+from sentry.types.region import Region, get_region_by_name
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class _AsyncResult:
+    region: Region
+    response: Response
+
+    def was_successful(self) -> bool:
+        return 200 <= self.response.status_code < 300
+
+
+@dataclass(frozen=True)
+class _AsyncRegionDispatcher(ABC):
+    request_payload: dict[str, Any]
+    response_url: str
+
+    @property
+    @abstractmethod
+    def log_code(self) -> str:
+        raise NotImplementedError
+
+    def log_message(self, tag: str) -> str:
+        return f"{self.log_code}.{tag}"
+
+    def dispatch(self, region_names: Iterable[str]) -> Response | None:
+        results = [self._dispatch_to_region(name) for name in region_names]
+        successes = [r for r in results if r.was_successful()]
+
+        logger.info(
+            self.log_message("async_region_response"),
+            extra={
+                "regions": [r.region.name for r in successes],
+                "response_map": {r.region.name: r.response.status_code for r in results},
+            },
+        )
+
+        if successes:
+            return self._forward_response(successes[-1])
+        else:
+            return None
+
+    @abstractmethod
+    def unpack_payload(self, response: Response) -> Any:
+        raise NotImplementedError
+
+    def _dispatch_to_region(self, region_name: str) -> _AsyncResult:
+        region = get_region_by_name(region_name)
+        client = RegionSiloClient(region=region)
+        response = client.request(
+            method=self.request_payload["method"],
+            path=self.request_payload["path"],
+            headers=self.request_payload["headers"],
+            data=self.request_payload["body"].encode("utf-8"),
+            json=False,
+            raw_response=True,
+        )
+        return _AsyncResult(region, cast(Response, response))
+
+    def _forward_response(self, result: _AsyncResult) -> Response | None:
+        if not result.was_successful():
+            raise ValueError("Cannot forward a failed result")
+        try:
+            response_payload = self.unpack_payload(result.response)
+            if response_payload is None:
+                return None
+            integration_response = requests.post(self.response_url, json=response_payload)
+        except Exception as exc:
+            sentry_sdk.capture_exception(exc)
+            return None
+        else:
+            logger.info(
+                "discord.async_integration_response",
+                extra={
+                    "path": self.request_payload["path"],
+                    "region": result.region.name,
+                    "region_status_code": result.response.status_code,
+                    "integration_status_code": integration_response.status_code,
+                },
+            )
+            return integration_response
+
+
+class _AsyncSlackDispatcher(_AsyncRegionDispatcher):
+    @property
+    def log_code(self) -> str:
+        return "slack"
+
+    def unpack_payload(self, response: Response) -> Any:
+        return orjson.loads(response.content)
 
 
 @instrumented_task(
@@ -29,65 +120,20 @@ def convert_to_async_slack_response(
     payload: dict[str, Any],
     response_url: str,
 ):
-    regions = [get_region_by_name(rn) for rn in region_names]
-    region_to_response_map: MutableMapping[str, Response] = {}
-    result: MutableMapping[str, Any] = {"response": None, "region": None}
-    for region in regions:
-        region_response = RegionSiloClient(region=region).request(
-            method=payload["method"],
-            path=payload["path"],
-            headers=payload["headers"],
-            data=payload["body"].encode("utf-8"),
-            json=False,
-            raw_response=True,
-        )
-        region_response = cast(Response, region_response)
-        region_to_response_map[region.name] = region_response
-        if region_response.status_code >= 200 and region_response.status_code < 300:
-            result["response"] = region_response
-            result["region"] = region
+    _AsyncSlackDispatcher(payload, response_url).dispatch(region_names)
 
-    logger.info(
-        "slack.async_region_response",
-        extra={
-            "region": result["region"],
-            "response_map": {
-                region_name: response.status_code
-                for region_name, response in region_to_response_map.items()
-            },
-        },
-    )
-    if not result["response"]:
-        return
 
-    response_body = result["response"].content
-    if response_body == b"":
-        logger.info(
-            "slack.async_empty_body",
-            {
-                "path": payload["path"],
-                "region": result["region"],
-                "response_status": result["response"].status_code,
-            },
-        )
-        return
+class _AsyncDiscordDispatcher(_AsyncRegionDispatcher):
+    @property
+    def log_code(self) -> str:
+        return "discord"
 
-    response_payload = {}
-    try:
-        response_payload = orjson.loads(response_body)
-    except Exception as exc:
-        sentry_sdk.capture_exception(exc)
-
-    integration_response = requests.post(response_url, json=response_payload)
-    logger.info(
-        "slack.async_integration_response",
-        extra={
-            "path": payload["path"],
-            "region": result["region"],
-            "region_status_code": result["response"].status_code,
-            "integration_status_code": integration_response.status_code,
-        },
-    )
+    def unpack_payload(self, response: Response) -> Any:
+        # Region will return a response assuming it's meant to go directly to Discord. Since we're
+        # handling the request asynchronously, we extract only the data, and post it to the webhook
+        # that discord provides.
+        # https://discord.com/developers/docs/interactions/receiving-and-responding#followup-messages
+        return orjson.loads(response.content).get("data")
 
 
 @instrumented_task(
@@ -101,7 +147,7 @@ def convert_to_async_discord_response(
     region_names: list[str],
     payload: dict[str, Any],
     response_url: str,
-):
+) -> None:
     """
     This task asks relevant region silos for response data to send asynchronously to Discord. It
     assumes Discord has received a callback of type:5 (DEFERRED_CHANNEL_MESSAGE_WITH_SOURCE).
@@ -109,55 +155,7 @@ def convert_to_async_discord_response(
 
     In the event this task finishes prior to returning the above type, the outbound post will fail.
     """
-    regions = [get_region_by_name(rn) for rn in region_names]
-    region_to_response_map: MutableMapping[str, Response] = {}
-    result: MutableMapping[str, Any] = {"response": None, "region": None}
-    for region in regions:
-        region_response = RegionSiloClient(region=region).request(
-            method=payload["method"],
-            path=payload["path"],
-            headers=payload["headers"],
-            data=payload["body"].encode("utf-8"),
-            json=False,
-            raw_response=True,
-        )
-        region_response = cast(Response, region_response)
-        region_to_response_map[region.name] = region_response
-        if region_response.status_code >= 200 and region_response.status_code < 300:
-            result["response"] = region_response
-            result["region"] = region
+    response = _AsyncDiscordDispatcher(payload, response_url).dispatch(region_names)
 
-    logger.info(
-        "discord.async_region_response",
-        extra={
-            "region": result["region"],
-            "response_map": {
-                region_name: response.status_code
-                for region_name, response in region_to_response_map.items()
-            },
-        },
-    )
-    if not result["response"]:
-        return
-
-    response_payload = {}
-    try:
-        # Region will return a response assuming it's meant to go directly to Discord. Since we're
-        # handling the request asynchronously, we extract only the data, and post it to the webhook
-        # that discord provides.
-        # https://discord.com/developers/docs/interactions/receiving-and-responding#followup-messages
-        response_payload = orjson.loads(result["response"].content).get("data")
-    except Exception as e:
-        sentry_sdk.capture_exception(e)
-    integration_response = requests.post(response_url, json=response_payload)
-    logger.info(
-        "discord.async_integration_response",
-        extra={
-            "path": payload["path"],
-            "region": result["region"].name,
-            "region_status_code": result["response"].status_code,
-            "integration_status_code": integration_response.status_code,
-        },
-    )
-    if integration_response.status_code == status.HTTP_404_NOT_FOUND:
+    if response is not None and response.status_code == status.HTTP_404_NOT_FOUND:
         raise Exception("Discord hook is not ready.")


### PR DESCRIPTION
Refactor duplicated code out of the two tasks (for Slack and Discord) into a new abstract base class. Replace typed dicts with a new `_AsyncResult` dataclass.