### PR TITLE
feat(metrics) enable query filter for metrics extraction rules

### DIFF
--- a/src/sentry/api/endpoints/organization_metrics_extraction_rules.py
+++ b/src/sentry/api/endpoints/organization_metrics_extraction_rules.py
@@ -40,8 +40,12 @@ class OrganizationMetricsExtractionRulesEndpoint(OrganizationEndpoint):
                 {"detail": "You must supply at least one project to see its metrics"}, status=404
             )
 
+        query = request.GET.get("query")
+
         try:
             configs = SpanAttributeExtractionRuleConfig.objects.filter(project__in=projects)
+            if query:
+                configs = configs.filter(span_attribute__icontains=query)
 
         except Exception as e:
             return Response(status=500, data={"detail": str(e)})

--- a/src/sentry/api/endpoints/project_metrics_extraction_rules.py
+++ b/src/sentry/api/endpoints/project_metrics_extraction_rules.py
@@ -84,8 +84,12 @@ class ProjectMetricsExtractionRulesEndpoint(ProjectEndpoint):
         if not self.has_feature(project.organization, request):
             return Response(status=404)
 
+        query = request.GET.get("query")
+
         with handle_exceptions():
             configs = SpanAttributeExtractionRuleConfig.objects.filter(project=project)
+            if query:
+                configs = configs.filter(span_attribute__icontains=query)
 
             return self.paginate(
                 request,

--- a/tests/sentry/api/endpoints/test_organization_metrics_extraction_rules.py
+++ b/tests/sentry/api/endpoints/test_organization_metrics_extraction_rules.py
@@ -168,3 +168,50 @@ class ProjectMetricsExtractionEndpointTestCase(APITestCase):
             method="get",
         )
         assert response.status_code == 404
+
+    @django_db_all
+    @with_feature("organizations:custom-metrics-extraction-rule")
+    def test_query_filter_rules(self):
+        projects = []
+        configs = []
+        for i, span_attribute in zip(range(0, 3), ("count_clicks", "some_span", "count_views")):
+            project = self.create_project(organization=self.organization, name=f"project_{i}")
+            projects.append(project)
+            config = self.create_span_attribute_extraction_config(
+                dictionary={
+                    "spanAttribute": span_attribute,
+                    "aggregates": ["count", "p50", "p75", "p95", "p99"],
+                    "unit": "none",
+                    "tags": [f"tag{num}" for num in range(0, i)],
+                    "conditions": [
+                        {"value": f"foo:bar{i}"},
+                    ],
+                },
+                user_id=self.user.id,
+                project=project,
+            )
+            configs.append(config)
+
+        response = self.get_response(
+            self.organization.slug,
+            method="get",
+            query="count",
+            project=[p.id for p in projects],
+        )
+
+        assert response.status_code == 200
+        data = response.data
+        assert len(data) == 2
+        assert {el["spanAttribute"] for el in data} == {"count_clicks", "count_views"}
+
+        response = self.get_response(
+            self.organization.slug,
+            method="get",
+            query="span",
+            project=[p.id for p in projects],
+        )
+
+        assert response.status_code == 200
+        data = response.data
+        assert len(data) == 1
+        assert {el["spanAttribute"] for el in data} == {"some_span"}

--- a/tests/sentry/api/endpoints/test_organization_metrics_extraction_rules.py
+++ b/tests/sentry/api/endpoints/test_organization_metrics_extraction_rules.py
@@ -173,11 +173,10 @@ class ProjectMetricsExtractionEndpointTestCase(APITestCase):
     @with_feature("organizations:custom-metrics-extraction-rule")
     def test_query_filter_rules(self):
         projects = []
-        configs = []
         for i, span_attribute in zip(range(0, 3), ("count_clicks", "some_span", "count_views")):
             project = self.create_project(organization=self.organization, name=f"project_{i}")
             projects.append(project)
-            config = self.create_span_attribute_extraction_config(
+            self.create_span_attribute_extraction_config(
                 dictionary={
                     "spanAttribute": span_attribute,
                     "aggregates": ["count", "p50", "p75", "p95", "p99"],
@@ -190,7 +189,6 @@ class ProjectMetricsExtractionEndpointTestCase(APITestCase):
                 user_id=self.user.id,
                 project=project,
             )
-            configs.append(config)
 
         response = self.get_response(
             self.organization.slug,


### PR DESCRIPTION
Allow filtering of metric extraction rules on API endpoint using `query` parameter.

Part of: https://github.com/getsentry/sentry/issues/73179