### PR TITLE
ref(proguard): Remove filestore throttling logic

### DIFF
--- a/src/sentry/models/debugfile.py
+++ b/src/sentry/models/debugfile.py
@@ -6,7 +6,6 @@ import hashlib
 import logging
 import os
 import os.path
-import random
 import re
 import shutil
 import tempfile
@@ -626,16 +625,6 @@ class DIFCache:
         """Given some ids returns an id to path mapping for where the
         debug symbol files are on the FS.
         """
-
-        # If this call is for proguard purposes, we probabilistically cut this function short
-        # right here so we don't overload filestore.
-        # Note: this random rollout is reversed because it is an early return
-        if features is not None:
-            if "mapping" in features and random.random() >= options.get(
-                "filestore.proguard-throttle"
-            ):
-                return {}
-
         debug_ids = [str(debug_id).lower() for debug_id in debug_ids]
         difs = ProjectDebugFile.objects.find_by_debug_ids(project, debug_ids, features)
 


### PR DESCRIPTION
As far as I can tell this knob has not been touched since we introduced it in response to INC-635
(see https://github.com/getsentry/sentry/pull/64866). Might as well be rid of it.

I'll remove the option itself in a follow-up.