### PR TITLE
ref(metrics): Remove permission warning

### DIFF
--- a/static/app/views/settings/projectMetrics/projectMetrics.tsx
+++ b/static/app/views/settings/projectMetrics/projectMetrics.tsx
@@ -67,7 +67,9 @@ function ProjectMetrics({project}: Props) {
         )}
       </TextBlock>
 
-      <PermissionAlert project={project} />
+      {hasMetricsExtrapolationFeature(organization) ? null : (
+        <PermissionAlert project={project} />
+      )}
 
       {hasMetricsExtrapolationFeature(organization) ? (
         <ExtrapolationField project={project} />

--- a/static/app/views/settings/projectMetrics/projectMetrics.tsx
+++ b/static/app/views/settings/projectMetrics/projectMetrics.tsx
@@ -67,9 +67,7 @@ function ProjectMetrics({project}: Props) {
         )}
       </TextBlock>
 
-      {hasMetricsExtrapolationFeature(organization) ? null : (
-        <PermissionAlert project={project} />
-      )}
+      {hasExtractionRules ? null : <PermissionAlert project={project} />}
 
       {hasMetricsExtrapolationFeature(organization) ? (
         <ExtrapolationField project={project} />


### PR DESCRIPTION
### Goal

The banner shall be displayed only for the old experience, when users need the minium admin permission to edit the metrics configuration