### PR TITLE
fix(insights): Span sample panel search clobbers global filter selection

### DIFF
--- a/static/app/views/insights/cache/components/samplePanel.tsx
+++ b/static/app/views/insights/cache/components/samplePanel.tsx
@@ -235,7 +235,7 @@ export function CacheSamplePanel() {
     router.replace({
       pathname: location.pathname,
       query: {
-        ...query,
+        ...location.query,
         spanSearchQuery: newSpanSearchQuery,
       },
     });

--- a/static/app/views/insights/http/components/httpSamplesPanel.tsx
+++ b/static/app/views/insights/http/components/httpSamplesPanel.tsx
@@ -285,7 +285,7 @@ export function HTTPSamplesPanel() {
     router.replace({
       pathname: location.pathname,
       query: {
-        ...query,
+        ...location.query,
         spanSearchQuery: newSpanSearchQuery,
       },
     });

--- a/static/app/views/insights/queues/components/messageSpanSamplesPanel.tsx
+++ b/static/app/views/insights/queues/components/messageSpanSamplesPanel.tsx
@@ -228,7 +228,7 @@ export function MessageSpanSamplesPanel() {
     router.replace({
       pathname: location.pathname,
       query: {
-        ...query,
+        ...location.query,
         spanSearchQuery: newSpanSearchQuery,
       },
     });


### PR DESCRIPTION
The reported bug is that entering a query into the span sample panel search bar clobbers the global date and environment selection. The reason is that the `onSearch` handler of the search bar was omitting some URL parameters.

Always unsplat `location.query` into the URL. `location.query` has _all_ the URL query parameters. `query` only has a subset, depending on what was passed to `useLocationQuery`
