### PR TITLE
ref(replay): clamp tap duration to min time

### DIFF
--- a/static/app/components/replays/videoReplayerWithInteractions.tsx
+++ b/static/app/components/replays/videoReplayerWithInteractions.tsx
@@ -66,8 +66,25 @@ export class VideoReplayerWithInteractions {
 
     root?.classList.add('video-replayer');
 
+    const isTouchStart = (e: eventWithTime) => {
+      return e.type === 3 && 'type' in e.data && e.data.type === 7;
+    };
+
+    const isTouchEnd = (e: eventWithTime) => {
+      return e.type === 3 && 'type' in e.data && e.data.type === 9;
+    };
+
     const eventsWithSnapshots: eventWithTime[] = [];
-    events.forEach(e => {
+    events.forEach((e, index) => {
+      // For taps, sometimes the timestamp difference between TouchStart
+      // and TouchEnd is too small. This clamps the tap to a min time
+      // if the difference is less, so that the rrweb tap is visible and obvious.
+      if (isTouchStart(e) && index < events.length - 2) {
+        const nextEvent = events[index + 1];
+        if (isTouchEnd(nextEvent) && nextEvent.timestamp - e.timestamp < 500) {
+          nextEvent.timestamp = e.timestamp + 500;
+        }
+      }
       eventsWithSnapshots.push(e);
       if (e.type === 4) {
         // Create a mock full snapshot event, in order to render rrweb gestures properly

--- a/static/app/components/replays/videoReplayerWithInteractions.tsx
+++ b/static/app/components/replays/videoReplayerWithInteractions.tsx
@@ -81,8 +81,8 @@ export class VideoReplayerWithInteractions {
       // if the difference is less, so that the rrweb tap is visible and obvious.
       if (isTouchStart(e) && index < events.length - 2) {
         const nextEvent = events[index + 1];
-        if (isTouchEnd(nextEvent) && nextEvent.timestamp - e.timestamp < 500) {
-          nextEvent.timestamp = e.timestamp + 500;
+        if (isTouchEnd(nextEvent)) {
+          nextEvent.timestamp = Math.max(nextEvent.timestamp, e.timestamp + 500);
         }
       }
       eventsWithSnapshots.push(e);


### PR DESCRIPTION
sometimes, tap events happen too quickly in the rrweb events. a tap starts with a `TouchStart` and ends with a `TouchEnd` (this is how rrweb knows to clean up a tap -- when it sees a `TouchEnd` event.)

since it can be hard/non-obvious to see a tap event if the time difference between a `TouchStart` and `TouchEnd` is too small (e.g. just a couple ms), this PR clamps the tap to a minimum time (0.5 s, 500 ms) so that the tap is still obvious. it only affects rrweb events that are _only_ taps with no mousetail. it doesn't affect timestamps of any other rrweb events.

after clamping to min duration, tap is more obvious:

https://github.com/getsentry/sentry/assets/56095982/0b1863fb-3a67-4967-bd0f-6bafb503b8ce

before, the tap is hard to see (can only really see clearly once you slow down the video):

https://github.com/getsentry/sentry/assets/56095982/112afa5d-dc32-458f-aea1-24d91ebc473f


