### PR TITLE
chore(integrations) Remove escalating-issues-msteams feature

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -106,8 +106,6 @@ def register_temporary_features(manager: FeatureManager):
     manager.add("organizations:ds-org-recalibration", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
     # Enables data secrecy mode
     manager.add("organizations:enterprise-data-secrecy", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
-    # Enable archive/escalating issue workflow in MS Teams
-    manager.add("organizations:escalating-issues-msteams", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
     # Enable archive/escalating issue workflow features in v2
     manager.add("organizations:escalating-issues-v2", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
     # Enable emiting escalating data to the metrics backend

--- a/src/sentry/integrations/msteams/card_builder/issues.py
+++ b/src/sentry/integrations/msteams/card_builder/issues.py
@@ -5,7 +5,6 @@ from collections.abc import Sequence
 from datetime import datetime
 from typing import Any
 
-from sentry import features
 from sentry.eventstore.models import Event
 from sentry.integrations.message_builder import (
     build_attachment_text,
@@ -190,9 +189,6 @@ class MSTeamsIssueMessageBuilder(MSTeamsMessageBuilder):
 
     def build_group_actions(self) -> ContainerBlock:
         status = self.group.get_status()
-        has_escalating = features.has(
-            "organizations:escalating-issues-msteams", self.group.project.organization
-        )
 
         resolve_action = self.create_issue_action_block(
             toggled=GroupStatus.RESOLVED == status,
@@ -210,20 +206,14 @@ class MSTeamsIssueMessageBuilder(MSTeamsMessageBuilder):
         ignore_action = self.create_issue_action_block(
             toggled=GroupStatus.IGNORED == status,
             action=ACTION_TYPE.IGNORE,
-            action_title=IssueConstants.ARCHIVE if has_escalating else IssueConstants.IGNORE,
+            action_title=IssueConstants.IGNORE,
             reverse_action=ACTION_TYPE.UNRESOLVE,
-            reverse_action_title=IssueConstants.STOP_ARCHIVE
-            if has_escalating
-            else IssueConstants.STOP_IGNORING,
+            reverse_action_title=IssueConstants.STOP_IGNORING,
             # card_kwargs
-            card_title=IssueConstants.ARCHIVE_INPUT_TITLE
-            if has_escalating
-            else IssueConstants.IGNORE_INPUT_TITLE,
-            submit_button_title=IssueConstants.ARCHIVE if has_escalating else IssueConstants.IGNORE,
+            card_title=IssueConstants.IGNORE_INPUT_TITLE,
+            submit_button_title=IssueConstants.IGNORE,
             input_id=IssueConstants.IGNORE_INPUT_ID,
-            choices=IssueConstants.ARCHIVE_INPUT_CHOICES
-            if has_escalating
-            else IssueConstants.IGNORE_INPUT_CHOICES,
+            choices=IssueConstants.IGNORE_INPUT_CHOICES,
         )
 
         teams_choices = self.get_teams_choices()
@@ -248,7 +238,6 @@ class MSTeamsIssueMessageBuilder(MSTeamsMessageBuilder):
                 "group_id": self.group.id,
                 "project_id": self.group.project.id,
                 "organization": self.group.project.organization.id,
-                "has_escalating": has_escalating,
                 "ignore_action": ignore_action,
             },
         )

--- a/src/sentry/integrations/msteams/webhook.py
+++ b/src/sentry/integrations/msteams/webhook.py
@@ -11,7 +11,7 @@ from django.http import HttpRequest, HttpResponse
 from django.views.decorators.csrf import csrf_exempt
 from rest_framework.exceptions import AuthenticationFailed, NotAuthenticated
 
-from sentry import analytics, audit_log, eventstore, features, options
+from sentry import analytics, audit_log, eventstore, options
 from sentry.api import client
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
@@ -488,7 +488,7 @@ class MsTeamsWebhookEndpoint(Endpoint, MsTeamsWebhookMixin):
         integration_service.delete_integration(integration_id=integration.id)
         return self.respond(status=204)
 
-    def make_action_data(self, data, user_id, has_escalating_issues=False):
+    def make_action_data(self, data, user_id):
         action_data = {}
         action_type = data["payload"]["actionType"]
         if action_type == ACTION_TYPE.UNRESOLVE:
@@ -509,8 +509,6 @@ class MsTeamsWebhookEndpoint(Endpoint, MsTeamsWebhookMixin):
             ignore_count = data.get("ignoreInput")
             if ignore_count:
                 action_data = {"status": "ignored"}
-                if has_escalating_issues:
-                    action_data.update({"substatus": "archived_until_condition_met"})
                 if int(ignore_count) > 0:
                     action_data.update({"statusDetails": {"ignoreCount": int(ignore_count)}})
         elif action_type == ACTION_TYPE.ASSIGN:
@@ -527,10 +525,6 @@ class MsTeamsWebhookEndpoint(Endpoint, MsTeamsWebhookMixin):
             organization_id=group.project.organization_id, scope_list=["event:write"]
         )
 
-        has_escalating_issues = features.has(
-            "organizations:escalating-issues-msteams", group.project.organization
-        )
-
         # undoing the enum structure of ACTION_TYPE to
         # get a more sensible analytics_event
         action_types = {
@@ -540,7 +534,7 @@ class MsTeamsWebhookEndpoint(Endpoint, MsTeamsWebhookMixin):
             ACTION_TYPE.UNRESOLVE: "unresolve",
             ACTION_TYPE.UNASSIGN: "unassign",
         }
-        action_data = self.make_action_data(data, identity.user_id, has_escalating_issues)
+        action_data = self.make_action_data(data, identity.user_id)
         status = action_types[data["payload"]["actionType"]]
         analytics_event = f"integrations.msteams.{status}"
         analytics.record(


### PR DESCRIPTION
This feature was built more than a year ago and was never finished or enabled for any customers. If we have no near term plans to finish it, I think we should remove the feature to reduce future maintenance effort.