### PR TITLE
chore(slack): remove old slack client from update message after action taken

### DIFF
--- a/src/sentry/integrations/slack/notifications.py
+++ b/src/sentry/integrations/slack/notifications.py
@@ -40,6 +40,7 @@ class SlackNotifyBasicMixin(NotifyBasicMixin):
         else:
             try:
                 client.chat_postMessage(channel=channel_id, text=message)
+                logger.info("slack.slash-notify.success", extra={"channel_id": channel_id})
             except SlackApiError as e:
                 error = str(e)
                 message = error.split("\n")[0]

--- a/src/sentry/integrations/slack/webhooks/action.py
+++ b/src/sentry/integrations/slack/webhooks/action.py
@@ -750,26 +750,16 @@ class SlackActionEndpoint(Endpoint):
             return self.respond()
 
         response_url = slack_request.data["response_url"]
-        if not features.has("organizations:slack-sdk-webhook-handling", group.project.organization):
-            slack_client = SlackClient(integration_id=slack_request.integration.id)
-            try:
-                slack_client.post(response_url, data=response, json=True)
-            except ApiError as e:
-                logger.error("slack.action.response-error", extra={"error": str(e)})
-
-        else:
-            json_blocks = orjson.dumps(response.get("blocks")).decode()
-            webhook_client = WebhookClient(response_url)
-            try:
-                webhook_client.send(
-                    blocks=json_blocks, delete_original=False, replace_original=True
-                )
-                logger.info(
-                    "slack.webhook.update_status.success",
-                    extra={"integration_id": slack_request.integration.id, "blocks": json_blocks},
-                )
-            except SlackApiError as e:
-                logger.error("slack.webhook.update_status.response-error", extra={"error": str(e)})
+        json_blocks = orjson.dumps(response.get("blocks")).decode()
+        webhook_client = WebhookClient(response_url)
+        try:
+            webhook_client.send(blocks=json_blocks, delete_original=False, replace_original=True)
+            logger.info(
+                "slack.webhook.update_status.success",
+                extra={"integration_id": slack_request.integration.id, "blocks": json_blocks},
+            )
+        except SlackApiError as e:
+            logger.error("slack.webhook.update_status.response-error", extra={"error": str(e)})
 
         return self.respond(response)
 

--- a/src/sentry/integrations/slack/webhooks/action.py
+++ b/src/sentry/integrations/slack/webhooks/action.py
@@ -753,7 +753,12 @@ class SlackActionEndpoint(Endpoint):
         json_blocks = orjson.dumps(response.get("blocks")).decode()
         webhook_client = WebhookClient(response_url)
         try:
-            webhook_client.send(blocks=json_blocks, delete_original=False, replace_original=True)
+            webhook_client.send(
+                blocks=json_blocks,
+                text=response.get("text"),
+                delete_original=False,
+                replace_original=True,
+            )
             logger.info(
                 "slack.webhook.update_status.success",
                 extra={"integration_id": slack_request.integration.id, "blocks": json_blocks},

--- a/tests/sentry/integrations/slack/webhooks/actions/test_status.py
+++ b/tests/sentry/integrations/slack/webhooks/actions/test_status.py
@@ -701,9 +701,11 @@ class StatusActionTest(BaseEventTest, PerformanceIssueTestCase, HybridCloudTestM
         assert self.group.get_status() == GroupStatus.UNRESOLVED
         assert self.group.substatus == GroupSubStatus.NEW  # the issue is less than 7 days old
 
+        blocks = orjson.loads(self.mock_post.call_args.kwargs["blocks"])
+
         expect_status = f"*Issue re-opened by <@{self.external_id}>*"
-        assert self.notification_text in resp.data["blocks"][1]["text"]["text"]
-        assert resp.data["blocks"][2]["text"]["text"].endswith(expect_status)
+        assert self.notification_text in blocks[1]["text"]["text"]
+        assert blocks[2]["text"]["text"].endswith(expect_status)
 
     def test_unarchive_issue_through_unfurl(self):
         self.group.status = GroupStatus.IGNORED
@@ -723,9 +725,11 @@ class StatusActionTest(BaseEventTest, PerformanceIssueTestCase, HybridCloudTestM
         assert self.group.get_status() == GroupStatus.UNRESOLVED
         assert self.group.substatus == GroupSubStatus.NEW  # the issue is less than 7 days old
 
+        blocks = orjson.loads(self.mock_post.call_args.kwargs["blocks"])
+
         expect_status = f"*Issue re-opened by <@{self.external_id}>*"
-        assert self.notification_text in resp.data["blocks"][1]["text"]["text"]
-        assert resp.data["blocks"][2]["text"]["text"].endswith(expect_status)
+        assert self.notification_text in blocks[1]["text"]["text"]
+        assert blocks[2]["text"]["text"].endswith(expect_status)
 
     def test_assign_issue(self):
         user2 = self.create_user(is_superuser=False)
@@ -733,20 +737,24 @@ class StatusActionTest(BaseEventTest, PerformanceIssueTestCase, HybridCloudTestM
         original_message = self.get_original_message(self.group.id)
 
         # Assign to user
-        resp = self.assign_issue(original_message, user2)
+        self.assign_issue(original_message, user2)
         assert GroupAssignee.objects.filter(group=self.group, user_id=user2.id).exists()
+        blocks = orjson.loads(self.mock_post.call_args.kwargs["blocks"])
+        text = self.mock_post.call_args.kwargs["text"]
         expect_status = f"*Issue assigned to {user2.get_display_name()} by <@{self.external_id}>*"
-        assert self.notification_text in resp.data["blocks"][1]["text"]["text"]
-        assert resp.data["blocks"][2]["text"]["text"].endswith(expect_status), resp.data["text"]
-        assert ":white_circle:" in resp.data["blocks"][0]["text"]["text"]
+        assert self.notification_text in blocks[1]["text"]["text"]
+        assert blocks[2]["text"]["text"].endswith(expect_status), text
+        assert ":white_circle:" in blocks[0]["text"]["text"]
 
         # Assign to team
-        resp = self.assign_issue(original_message, self.team)
+        self.assign_issue(original_message, self.team)
         assert GroupAssignee.objects.filter(group=self.group, team=self.team).exists()
+        blocks = orjson.loads(self.mock_post.call_args.kwargs["blocks"])
+        text = self.mock_post.call_args.kwargs["text"]
         expect_status = f"*Issue assigned to #{self.team.slug} by <@{self.external_id}>*"
-        assert self.notification_text in resp.data["blocks"][1]["text"]["text"]
-        assert resp.data["blocks"][2]["text"]["text"].endswith(expect_status), resp.data["text"]
-        assert ":white_circle:" in resp.data["blocks"][0]["text"]["text"]
+        assert self.notification_text in blocks[1]["text"]["text"]
+        assert blocks[2]["text"]["text"].endswith(expect_status), text
+        assert ":white_circle:" in blocks[0]["text"]["text"]
 
         # Assert group assignment activity recorded
         group_activity = list(Activity.objects.filter(group=self.group))
@@ -763,42 +771,42 @@ class StatusActionTest(BaseEventTest, PerformanceIssueTestCase, HybridCloudTestM
             "integration": ActivityIntegration.SLACK.value,
         }
 
-    @with_feature("organizations:slack-sdk-webhook-handling")
-    def test_assign_issue_with_sdk(self):
-        user2 = self.create_user(is_superuser=False)
-        self.create_member(user=user2, organization=self.organization, teams=[self.team])
-        original_message = self.get_original_message(self.group.id)
+    # @with_feature("organizations:slack-sdk-webhook-handling")
+    # def test_assign_issue_with_sdk(self):
+    #     user2 = self.create_user(is_superuser=False)
+    #     self.create_member(user=user2, organization=self.organization, teams=[self.team])
+    #     original_message = self.get_original_message(self.group.id)
 
-        # Assign to user
-        resp = self.assign_issue(original_message, user2)
-        assert GroupAssignee.objects.filter(group=self.group, user_id=user2.id).exists()
-        expect_status = f"*Issue assigned to {user2.get_display_name()} by <@{self.external_id}>*"
-        assert self.notification_text in resp.data["blocks"][1]["text"]["text"]
-        assert resp.data["blocks"][2]["text"]["text"].endswith(expect_status), resp.data["text"]
-        assert ":white_circle:" in resp.data["blocks"][0]["text"]["text"]
+    #     # Assign to user
+    #     resp = self.assign_issue(original_message, user2)
+    #     assert GroupAssignee.objects.filter(group=self.group, user_id=user2.id).exists()
+    #     expect_status = f"*Issue assigned to {user2.get_display_name()} by <@{self.external_id}>*"
+    #     assert self.notification_text in resp.data["blocks"][1]["text"]["text"]
+    #     assert resp.data["blocks"][2]["text"]["text"].endswith(expect_status), resp.data["text"]
+    #     assert ":white_circle:" in resp.data["blocks"][0]["text"]["text"]
 
-        # Assign to team
-        resp = self.assign_issue(original_message, self.team)
-        assert GroupAssignee.objects.filter(group=self.group, team=self.team).exists()
-        expect_status = f"*Issue assigned to #{self.team.slug} by <@{self.external_id}>*"
-        assert self.notification_text in resp.data["blocks"][1]["text"]["text"]
-        assert resp.data["blocks"][2]["text"]["text"].endswith(expect_status), resp.data["text"]
-        assert ":white_circle:" in resp.data["blocks"][0]["text"]["text"]
+    #     # Assign to team
+    #     resp = self.assign_issue(original_message, self.team)
+    #     assert GroupAssignee.objects.filter(group=self.group, team=self.team).exists()
+    #     expect_status = f"*Issue assigned to #{self.team.slug} by <@{self.external_id}>*"
+    #     assert self.notification_text in resp.data["blocks"][1]["text"]["text"]
+    #     assert resp.data["blocks"][2]["text"]["text"].endswith(expect_status), resp.data["text"]
+    #     assert ":white_circle:" in resp.data["blocks"][0]["text"]["text"]
 
-        # Assert group assignment activity recorded
-        group_activity = list(Activity.objects.filter(group=self.group))
-        assert group_activity[0].data == {
-            "assignee": str(user2.id),
-            "assigneeEmail": user2.email,
-            "assigneeType": "user",
-            "integration": ActivityIntegration.SLACK.value,
-        }
-        assert group_activity[-1].data == {
-            "assignee": str(self.team.id),
-            "assigneeEmail": None,
-            "assigneeType": "team",
-            "integration": ActivityIntegration.SLACK.value,
-        }
+    #     # Assert group assignment activity recorded
+    #     group_activity = list(Activity.objects.filter(group=self.group))
+    #     assert group_activity[0].data == {
+    #         "assignee": str(user2.id),
+    #         "assigneeEmail": user2.email,
+    #         "assigneeType": "user",
+    #         "integration": ActivityIntegration.SLACK.value,
+    #     }
+    #     assert group_activity[-1].data == {
+    #         "assignee": str(self.team.id),
+    #         "assigneeEmail": None,
+    #         "assigneeType": "team",
+    #         "integration": ActivityIntegration.SLACK.value,
+    #     }
 
     @with_feature("organizations:slack-sdk-webhook-handling")
     @patch("sentry.integrations.slack.webhooks.action.logger")
@@ -848,18 +856,22 @@ class StatusActionTest(BaseEventTest, PerformanceIssueTestCase, HybridCloudTestM
         payload_data = self.get_unfurl_data(original_message["blocks"])
 
         # Assign to user
-        resp = self.assign_issue(original_message, user2, payload_data)
+        self.assign_issue(original_message, user2, payload_data)
         assert GroupAssignee.objects.filter(group=self.group, user_id=user2.id).exists()
+        blocks = orjson.loads(self.mock_post.call_args.kwargs["blocks"])
+        text = self.mock_post.call_args.kwargs["text"]
         expect_status = f"*Issue assigned to {user2.get_display_name()} by <@{self.external_id}>*"
-        assert self.notification_text in resp.data["blocks"][1]["text"]["text"]
-        assert resp.data["blocks"][2]["text"]["text"].endswith(expect_status), resp.data["text"]
+        assert self.notification_text in blocks[1]["text"]["text"]
+        assert blocks[2]["text"]["text"].endswith(expect_status), text
 
         # Assign to team
-        resp = self.assign_issue(original_message, self.team, payload_data)
+        self.assign_issue(original_message, self.team, payload_data)
         assert GroupAssignee.objects.filter(group=self.group, team=self.team).exists()
+        blocks = orjson.loads(self.mock_post.call_args.kwargs["blocks"])
+        text = self.mock_post.call_args.kwargs["text"]
         expect_status = f"*Issue assigned to #{self.team.slug} by <@{self.external_id}>*"
-        assert self.notification_text in resp.data["blocks"][1]["text"]["text"]
-        assert resp.data["blocks"][2]["text"]["text"].endswith(expect_status), resp.data["text"]
+        assert self.notification_text in blocks[1]["text"]["text"]
+        assert blocks[2]["text"]["text"].endswith(expect_status), text
 
         # Assert group assignment activity recorded
         group_activity = list(Activity.objects.filter(group=self.group))
@@ -912,14 +924,17 @@ class StatusActionTest(BaseEventTest, PerformanceIssueTestCase, HybridCloudTestM
             user=user2,
         )
         original_message = self.get_original_message(self.group.id)
-        resp = self.assign_issue(original_message, user2)
+        self.assign_issue(original_message, user2)
         assert GroupAssignee.objects.filter(group=self.group, user_id=user2.id).exists()
+
+        blocks = orjson.loads(self.mock_post.call_args.kwargs["blocks"])
+        text = self.mock_post.call_args.kwargs["text"]
 
         expect_status = (
             f"*Issue assigned to <@{user2_identity.external_id}> by <@{self.external_id}>*"
         )
-        assert self.notification_text in resp.data["blocks"][1]["text"]["text"]
-        assert resp.data["blocks"][2]["text"]["text"].endswith(expect_status), resp.data["text"]
+        assert self.notification_text in blocks[1]["text"]["text"]
+        assert blocks[2]["text"]["text"].endswith(expect_status), text
 
     def test_assign_issue_user_has_identity_through_unfurl(self):
         user2 = self.create_user(is_superuser=False)
@@ -932,14 +947,16 @@ class StatusActionTest(BaseEventTest, PerformanceIssueTestCase, HybridCloudTestM
         )
         original_message = self.get_original_message(self.group.id)
         payload_data = self.get_unfurl_data(original_message["blocks"])
-        resp = self.assign_issue(original_message, user2, payload_data)
+        self.assign_issue(original_message, user2, payload_data)
         assert GroupAssignee.objects.filter(group=self.group, user_id=user2.id).exists()
 
+        blocks = orjson.loads(self.mock_post.call_args.kwargs["blocks"])
+        text = self.mock_post.call_args.kwargs["text"]
         expect_status = (
             f"*Issue assigned to <@{user2_identity.external_id}> by <@{self.external_id}>*"
         )
-        assert self.notification_text in resp.data["blocks"][1]["text"]["text"]
-        assert resp.data["blocks"][2]["text"]["text"].endswith(expect_status), resp.data["text"]
+        assert self.notification_text in blocks[1]["text"]["text"]
+        assert blocks[2]["text"]["text"].endswith(expect_status), text
 
     def test_assign_user_with_multiple_identities(self):
         org2 = self.create_organization(owner=None)
@@ -956,14 +973,16 @@ class StatusActionTest(BaseEventTest, PerformanceIssueTestCase, HybridCloudTestM
             user=self.user,
         )
         original_message = self.get_original_message(self.group.id)
-        resp = self.assign_issue(original_message, self.user)
+        self.assign_issue(original_message, self.user)
         assert GroupAssignee.objects.filter(group=self.group, user_id=self.user.id).exists()
 
+        blocks = orjson.loads(self.mock_post.call_args.kwargs["blocks"])
+        text = self.mock_post.call_args.kwargs["text"]
         expect_status = "*Issue assigned to <@{assignee}> by <@{assignee}>*".format(
             assignee=self.external_id
         )
-        assert self.notification_text in resp.data["blocks"][1]["text"]["text"]
-        assert resp.data["blocks"][2]["text"]["text"].endswith(expect_status), resp.data["text"]
+        assert self.notification_text in blocks[1]["text"]["text"]
+        assert blocks[2]["text"]["text"].endswith(expect_status), text
 
     def test_assign_user_with_multiple_identities_through_unfurl(self):
         org2 = self.create_organization(owner=None)
@@ -981,14 +1000,16 @@ class StatusActionTest(BaseEventTest, PerformanceIssueTestCase, HybridCloudTestM
         )
         original_message = self.get_original_message(self.group.id)
         payload_data = self.get_unfurl_data(original_message["blocks"])
-        resp = self.assign_issue(original_message, self.user, payload_data)
+        self.assign_issue(original_message, self.user, payload_data)
         assert GroupAssignee.objects.filter(group=self.group, user_id=self.user.id).exists()
 
+        blocks = orjson.loads(self.mock_post.call_args.kwargs["blocks"])
+        text = self.mock_post.call_args.kwargs["text"]
         expect_status = "*Issue assigned to <@{assignee}> by <@{assignee}>*".format(
             assignee=self.external_id
         )
-        assert self.notification_text in resp.data["blocks"][1]["text"]["text"]
-        assert resp.data["blocks"][2]["text"]["text"].endswith(expect_status), resp.data["text"]
+        assert self.notification_text in blocks[1]["text"]["text"]
+        assert blocks[2]["text"]["text"].endswith(expect_status), text
 
     @responses.activate
     @with_feature("organizations:slack-sdk-webhook-handling")

--- a/tests/sentry/integrations/slack/webhooks/actions/test_status.py
+++ b/tests/sentry/integrations/slack/webhooks/actions/test_status.py
@@ -771,43 +771,6 @@ class StatusActionTest(BaseEventTest, PerformanceIssueTestCase, HybridCloudTestM
             "integration": ActivityIntegration.SLACK.value,
         }
 
-    # @with_feature("organizations:slack-sdk-webhook-handling")
-    # def test_assign_issue_with_sdk(self):
-    #     user2 = self.create_user(is_superuser=False)
-    #     self.create_member(user=user2, organization=self.organization, teams=[self.team])
-    #     original_message = self.get_original_message(self.group.id)
-
-    #     # Assign to user
-    #     resp = self.assign_issue(original_message, user2)
-    #     assert GroupAssignee.objects.filter(group=self.group, user_id=user2.id).exists()
-    #     expect_status = f"*Issue assigned to {user2.get_display_name()} by <@{self.external_id}>*"
-    #     assert self.notification_text in resp.data["blocks"][1]["text"]["text"]
-    #     assert resp.data["blocks"][2]["text"]["text"].endswith(expect_status), resp.data["text"]
-    #     assert ":white_circle:" in resp.data["blocks"][0]["text"]["text"]
-
-    #     # Assign to team
-    #     resp = self.assign_issue(original_message, self.team)
-    #     assert GroupAssignee.objects.filter(group=self.group, team=self.team).exists()
-    #     expect_status = f"*Issue assigned to #{self.team.slug} by <@{self.external_id}>*"
-    #     assert self.notification_text in resp.data["blocks"][1]["text"]["text"]
-    #     assert resp.data["blocks"][2]["text"]["text"].endswith(expect_status), resp.data["text"]
-    #     assert ":white_circle:" in resp.data["blocks"][0]["text"]["text"]
-
-    #     # Assert group assignment activity recorded
-    #     group_activity = list(Activity.objects.filter(group=self.group))
-    #     assert group_activity[0].data == {
-    #         "assignee": str(user2.id),
-    #         "assigneeEmail": user2.email,
-    #         "assigneeType": "user",
-    #         "integration": ActivityIntegration.SLACK.value,
-    #     }
-    #     assert group_activity[-1].data == {
-    #         "assignee": str(self.team.id),
-    #         "assigneeEmail": None,
-    #         "assigneeType": "team",
-    #         "integration": ActivityIntegration.SLACK.value,
-    #     }
-
     @with_feature("organizations:slack-sdk-webhook-handling")
     @patch("sentry.integrations.slack.webhooks.action.logger")
     def test_assign_issue_with_sdk_error(self, mock_logger):


### PR DESCRIPTION
Note that sometimes updating an issue through a Slack message unfurl is timing out on prod and not updating the Slack message, however I'm not seeing the same issue when doing the same action on my local server. This might have to do with the feature flag check taking longer and the server having more load in prod.