### PR TITLE
fix(web-vitals): do not truncate browser selector

### DIFF
--- a/static/app/views/insights/browser/webVitals/components/browserTypeSelector.tsx
+++ b/static/app/views/insights/browser/webVitals/components/browserTypeSelector.tsx
@@ -16,6 +16,7 @@ import {SpanIndexedField} from 'sentry/views/insights/types';
 const LabelContainer = styled('div')`
   display: flex;
   gap: ${space(1)};
+  min-width: 130px;
 `;
 
 function optionToLabel(iconName: string, labelValue: string): React.ReactNode {


### PR DESCRIPTION
Before:
![image](https://github.com/getsentry/sentry/assets/58920989/3c4cd919-a553-48ee-8e91-df8aa8a5f5ab)

After:

![image](https://github.com/getsentry/sentry/assets/58920989/c96c1693-8bcb-48f2-9f9e-e6ad6d433a1a)
