### PR TITLE
ref(replay): show trace tab for internal sentry only and enable network tab for everyone

### DIFF
--- a/static/app/utils/replays/hooks/useActiveReplayTab.tsx
+++ b/static/app/utils/replays/hooks/useActiveReplayTab.tsx
@@ -20,6 +20,7 @@ function isReplayTab({tab, isVideoReplay}: {isVideoReplay: boolean; tab: string}
     TabKey.BREADCRUMBS,
     TabKey.NETWORK,
     TabKey.CONSOLE,
+    TabKey.TRACE,
   ];
 
   if (isVideoReplay) {

--- a/static/app/views/replays/detail/layout/focusTabs.tsx
+++ b/static/app/views/replays/detail/layout/focusTabs.tsx
@@ -26,18 +26,18 @@ function getReplayTabs({
   // useful logging context will come from breadcrumbs
   // A11y, trace, and memory aren't applicable for mobile
 
-  // Show the console tab if 1) it's a video replay and we have the FF enabled
+  // Show the console and trace tab if 1) it's a video replay and we have the FF enabled
   // or 2) it's not a video replay
-  const showConsoleTab = isVideoReplay
+  const showInternalOnlyTab = isVideoReplay
     ? organization.features.includes('session-replay-mobile-network-tab')
     : true;
 
   return {
     [TabKey.BREADCRUMBS]: t('Breadcrumbs'),
-    [TabKey.CONSOLE]: showConsoleTab ? t('Console') : null,
+    [TabKey.CONSOLE]: showInternalOnlyTab ? t('Console') : null,
     [TabKey.NETWORK]: t('Network'),
     [TabKey.ERRORS]: t('Errors'),
-    [TabKey.TRACE]: isVideoReplay ? null : t('Trace'),
+    [TabKey.TRACE]: showInternalOnlyTab ? t('Trace') : null,
     [TabKey.A11Y]: isVideoReplay ? null : (
       <Fragment>
         <Tooltip

--- a/static/app/views/replays/detail/layout/focusTabs.tsx
+++ b/static/app/views/replays/detail/layout/focusTabs.tsx
@@ -77,20 +77,11 @@ function FocusTabs({className, isVideoReplay}: Props) {
   const {getActiveTab, setActiveTab} = useActiveReplayTab({isVideoReplay});
   const activeTab = getActiveTab();
 
-  const isTabDisabled = (tab: string) => {
-    return (
-      tab === TabKey.NETWORK &&
-      isVideoReplay &&
-      !organization.features.includes('session-replay-mobile-network-tab')
-    );
-  };
-
   return (
     <ScrollableTabs className={className} underlined>
       {Object.entries(getReplayTabs({organization, isVideoReplay})).map(([tab, label]) =>
         label ? (
           <ListLink
-            disabled={isTabDisabled(tab)}
             data-test-id={`replay-details-${tab}-btn`}
             key={tab}
             isActive={() => tab === activeTab}
@@ -105,9 +96,7 @@ function FocusTabs({className, isVideoReplay}: Props) {
               });
             }}
           >
-            <Tooltip title={isTabDisabled(tab) ? t('This feature is coming soon') : null}>
-              {label}
-            </Tooltip>
+            {label}
           </ListLink>
         ) : null
       )}


### PR DESCRIPTION
on `sentry-sdks`:
<img width="894" alt="image" src="https://github.com/getsentry/sentry/assets/56095982/e8d1a028-394e-4641-a29c-56b53dd3b90b">

on customer org:
<img width="651" alt="SCR-20240709-lrqj" src="https://github.com/getsentry/sentry/assets/56095982/aa7654c5-7bc1-4e17-bf04-44d4d6f8b9bc">
