### PR TITLE
feat(query-builder): Handle all keyboard actions while there is a selection

### DIFF
--- a/static/app/components/searchQueryBuilder/input.tsx
+++ b/static/app/components/searchQueryBuilder/input.tsx
@@ -14,7 +14,7 @@ import type {
   FocusOverride,
 } from 'sentry/components/searchQueryBuilder/types';
 import {useQueryBuilderGridItem} from 'sentry/components/searchQueryBuilder/useQueryBuilderGridItem';
-import {replaceTokenWithPadding} from 'sentry/components/searchQueryBuilder/useQueryBuilderState';
+import {replaceTokensWithPadding} from 'sentry/components/searchQueryBuilder/useQueryBuilderState';
 import {useShiftFocusToChild} from 'sentry/components/searchQueryBuilder/utils';
 import {
   type ParseResultToken,
@@ -368,8 +368,8 @@ function SearchQueryBuilderInputInternal({
       const text = e.clipboardData.getData('text/plain').replace('\n', '').trim();
 
       dispatch({
-        type: 'PASTE_FREE_TEXT',
-        token,
+        type: 'REPLACE_TOKENS_WITH_TEXT',
+        tokens: [token],
         text: replaceAliasedFilterKeys(text, aliasToKeyMap),
       });
       resetInputValue();
@@ -388,27 +388,27 @@ function SearchQueryBuilderInputInternal({
       onOptionSelected={value => {
         dispatch({
           type: 'UPDATE_FREE_TEXT',
-          token,
+          tokens: [token],
           text: replaceFocusedWordWithFilter(inputValue, selectionIndex, value),
           focusOverride: calculateNextFocusForFilter(state),
         });
         resetInputValue();
       }}
       onCustomValueBlurred={value => {
-        dispatch({type: 'UPDATE_FREE_TEXT', token, text: value});
+        dispatch({type: 'UPDATE_FREE_TEXT', tokens: [token], text: value});
         resetInputValue();
       }}
       onCustomValueCommitted={value => {
-        dispatch({type: 'UPDATE_FREE_TEXT', token, text: value});
+        dispatch({type: 'UPDATE_FREE_TEXT', tokens: [token], text: value});
         resetInputValue();
 
         // Because the query does not change until a subsequent render,
         // we need to do the replacement that is does in the reducer here
-        handleSearch(replaceTokenWithPadding(query, token, value));
+        handleSearch(replaceTokensWithPadding(query, [token], value));
       }}
       onExit={() => {
         if (inputValue !== token.value.trim()) {
-          dispatch({type: 'UPDATE_FREE_TEXT', token, text: inputValue});
+          dispatch({type: 'UPDATE_FREE_TEXT', tokens: [token], text: inputValue});
           resetInputValue();
         }
       }}
@@ -419,7 +419,7 @@ function SearchQueryBuilderInputInternal({
         if (e.target.value.includes('(') || e.target.value.includes(')')) {
           dispatch({
             type: 'UPDATE_FREE_TEXT',
-            token,
+            tokens: [token],
             text: e.target.value,
             focusOverride: calculateNextFocusForParen(item),
           });
@@ -430,7 +430,7 @@ function SearchQueryBuilderInputInternal({
         if (e.target.value.includes(':')) {
           dispatch({
             type: 'UPDATE_FREE_TEXT',
-            token,
+            tokens: [token],
             text: replaceAliasedFilterKeys(e.target.value, aliasToKeyMap),
             focusOverride: calculateNextFocusForFilter(state),
           });

--- a/static/app/components/searchQueryBuilder/useQueryBuilderState.tsx
+++ b/static/app/components/searchQueryBuilder/useQueryBuilderState.tsx
@@ -44,15 +44,15 @@ type DeleteTokensAction = {
 
 type UpdateFreeTextAction = {
   text: string;
-  token: TokenResult<Token.FREE_TEXT> | TokenResult<Token.SPACES>;
+  tokens: ParseResultToken[];
   type: 'UPDATE_FREE_TEXT';
   focusOverride?: FocusOverride;
 };
 
-type PasteFreeTextAction = {
+type ReplaceTokensWithTextAction = {
   text: string;
-  token: TokenResult<Token.FREE_TEXT> | TokenResult<Token.SPACES>;
-  type: 'PASTE_FREE_TEXT';
+  tokens: ParseResultToken[];
+  type: 'REPLACE_TOKENS_WITH_TEXT';
 };
 
 type UpdateFilterOpAction = {
@@ -85,7 +85,7 @@ export type QueryBuilderActions =
   | DeleteTokenAction
   | DeleteTokensAction
   | UpdateFreeTextAction
-  | PasteFreeTextAction
+  | ReplaceTokensWithTextAction
   | UpdateFilterOpAction
   | UpdateTokenValueAction
   | MultiSelectFilterValueAction
@@ -209,15 +209,27 @@ function modifyFilterValueDate(
   return replaceQueryToken(query, token, `${token.key.text}:${newValue}`);
 }
 
+function replaceQueryTokens(
+  query: string,
+  tokens: TokenResult<Token>[],
+  value: string
+): string {
+  if (tokens.length === 0) {
+    return query;
+  }
+
+  const start = query.substring(0, tokens[0].location.start.offset);
+  const end = query.substring(tokens.at(-1)!.location.end.offset);
+
+  return start + value + end;
+}
+
 function replaceQueryToken(
   query: string,
   token: TokenResult<Token>,
   value: string
 ): string {
-  const start = query.substring(0, token.location.start.offset);
-  const end = query.substring(token.location.end.offset);
-
-  return start + value + end;
+  return replaceQueryTokens(query, [token], value);
 }
 
 function removeExcessWhitespaceFromParts(...parts: string[]): string {
@@ -230,13 +242,17 @@ function removeExcessWhitespaceFromParts(...parts: string[]): string {
 
 // Ensures that the replaced token is separated from the rest of the query
 // and cleans up any extra whitespace
-export function replaceTokenWithPadding(
+export function replaceTokensWithPadding(
   query: string,
-  token: TokenResult<Token>,
+  tokens: TokenResult<Token>[],
   value: string
 ): string {
-  const start = query.substring(0, token.location.start.offset);
-  const end = query.substring(token.location.end.offset);
+  if (tokens.length === 0) {
+    return query;
+  }
+
+  const start = query.substring(0, tokens[0].location.start.offset);
+  const end = query.substring(tokens.at(-1)!.location.end.offset);
 
   return removeExcessWhitespaceFromParts(start, value, end);
 }
@@ -245,7 +261,7 @@ function updateFreeText(
   state: QueryBuilderState,
   action: UpdateFreeTextAction
 ): QueryBuilderState {
-  const newQuery = replaceTokenWithPadding(state.query, action.token, action.text);
+  const newQuery = replaceTokensWithPadding(state.query, action.tokens, action.text);
 
   return {
     ...state,
@@ -255,17 +271,18 @@ function updateFreeText(
   };
 }
 
-function pasteFreeText(
+function replaceTokensWithText(
   state: QueryBuilderState,
-  action: PasteFreeTextAction
+  action: ReplaceTokensWithTextAction
 ): QueryBuilderState {
-  const newQuery = replaceTokenWithPadding(state.query, action.token, action.text);
-  const cursorPosition = action.token.location.start.offset + action.text.length;
+  const newQuery = replaceTokensWithPadding(state.query, action.tokens, action.text);
+  const cursorPosition =
+    (action.tokens[0]?.location.start.offset ?? 0) + action.text.length;
   const newParsedQuery = parseQueryBuilderValue(newQuery);
   const focusedToken = newParsedQuery?.find(
-    token =>
-      token.type === Token.FREE_TEXT && token.location.start.offset >= cursorPosition
+    token => token.type === Token.FREE_TEXT && token.location.end.offset >= cursorPosition
   );
+
   const focusedItemKey = focusedToken ? makeTokenKey(focusedToken, newParsedQuery) : null;
 
   return {
@@ -385,8 +402,8 @@ export function useQueryBuilderState({initialQuery}: {initialQuery: string}) {
           return deleteQueryTokens(state, action);
         case 'UPDATE_FREE_TEXT':
           return updateFreeText(state, action);
-        case 'PASTE_FREE_TEXT':
-          return pasteFreeText(state, action);
+        case 'REPLACE_TOKENS_WITH_TEXT':
+          return replaceTokensWithText(state, action);
         case 'UPDATE_FILTER_OP':
           return {
             ...state,


### PR DESCRIPTION
Prior to this change, only a few keys were implemented like cmd+c, backspace, and the arrow keys. You weren't able to immediately replace a selection without first deleting it.

- Add handling for cut and paste when there is a selection
- Replace the selection with a typed character
- Rename `PASTE_FREE_TEXT` action to `REPLACE_TOKENS_WITH_TEXT` because the logic is now used across multiple actions

https://github.com/getsentry/sentry/assets/10888943/e2c6d969-159b-4d9b-8b28-4844540afd19
