### PR TITLE
ref(breadcrumbs): Update breadcrumbs drawer from feedback

### DIFF
--- a/static/app/components/events/breadcrumbs/breadcrumbsDataSection.spec.tsx
+++ b/static/app/components/events/breadcrumbs/breadcrumbsDataSection.spec.tsx
@@ -76,10 +76,10 @@ describe('BreadcrumbsDataSection', function () {
 
     // From virtual crumb
     expect(screen.getByText('0ms')).toBeInTheDocument();
-    expect(screen.queryByText('18:01:48')).not.toBeInTheDocument();
+    expect(screen.queryByText('06:01:48.762')).not.toBeInTheDocument();
     // From event breadcrumb
-    expect(screen.getByText('-1min')).toBeInTheDocument();
-    expect(screen.queryByText('18:00:48')).not.toBeInTheDocument();
+    expect(screen.getByText('-1min 2ms')).toBeInTheDocument();
+    expect(screen.queryByText('06:00:48.760')).not.toBeInTheDocument();
 
     const timeControl = screen.getByRole('button', {
       name: 'Change Time Format for Breadcrumbs',
@@ -87,16 +87,16 @@ describe('BreadcrumbsDataSection', function () {
     await userEvent.click(timeControl);
 
     expect(screen.queryByText('0ms')).not.toBeInTheDocument();
-    expect(screen.getByText('18:01:48')).toBeInTheDocument();
-    expect(screen.queryByText('-1min')).not.toBeInTheDocument();
-    expect(screen.getByText('18:00:48')).toBeInTheDocument();
+    expect(screen.getByText('06:01:48.762')).toBeInTheDocument();
+    expect(screen.queryByText('-1min 2ms')).not.toBeInTheDocument();
+    expect(screen.getByText('06:00:48.760')).toBeInTheDocument();
 
     await userEvent.click(timeControl);
 
     expect(screen.getByText('0ms')).toBeInTheDocument();
-    expect(screen.queryByText('18:01:48')).not.toBeInTheDocument();
-    expect(screen.getByText('-1min')).toBeInTheDocument();
-    expect(screen.queryByText('18:00:48')).not.toBeInTheDocument();
+    expect(screen.queryByText('06:01:48.762')).not.toBeInTheDocument();
+    expect(screen.getByText('-1min 2ms')).toBeInTheDocument();
+    expect(screen.queryByText('06:00:48.760')).not.toBeInTheDocument();
   });
 
   it.each([

--- a/static/app/components/events/breadcrumbs/breadcrumbsDataSection.tsx
+++ b/static/app/components/events/breadcrumbs/breadcrumbsDataSection.tsx
@@ -1,4 +1,4 @@
-import {useCallback, useMemo} from 'react';
+import {Fragment, useCallback, useMemo} from 'react';
 import styled from '@emotion/styled';
 
 import ProjectAvatar from 'sentry/components/avatar/projectAvatar';
@@ -33,6 +33,7 @@ import type {Event} from 'sentry/types/event';
 import type {Group} from 'sentry/types/group';
 import type {Project} from 'sentry/types/project';
 import {trackAnalytics} from 'sentry/utils/analytics';
+import {getShortEventId} from 'sentry/utils/events';
 import {useLocalStorageState} from 'sentry/utils/useLocalStorageState';
 import useOrganization from 'sentry/utils/useOrganization';
 
@@ -75,35 +76,33 @@ export default function BreadcrumbsDataSection({
         organization,
       });
       openDrawer(
-        ({Body}) => (
-          <Body>
-            <BreadcrumbsDrawerContent
-              breadcrumbs={enhancedCrumbs}
-              focusControl={focusControl}
-            />
-          </Body>
+        ({Header, Body}) => (
+          <Fragment>
+            <Header>
+              <NavigationCrumbs
+                crumbs={[
+                  {
+                    label: (
+                      <CrumbContainer>
+                        <ProjectAvatar project={project} />
+                        <ShortId>{group.shortId}</ShortId>
+                      </CrumbContainer>
+                    ),
+                  },
+                  {label: getShortEventId(event.id)},
+                  {label: t('Breadcrumbs')},
+                ]}
+              />
+            </Header>
+            <Body>
+              <BreadcrumbsDrawerContent
+                breadcrumbs={enhancedCrumbs}
+                focusControl={focusControl}
+              />
+            </Body>
+          </Fragment>
         ),
-        {
-          ariaLabel: 'breadcrumb drawer',
-          headerContent: (
-            <NavigationCrumbs
-              crumbs={[
-                {
-                  label: (
-                    <CrumbContainer>
-                      <ProjectAvatar project={project} />
-                      <GroupShortId>{group.shortId}</GroupShortId>
-                    </CrumbContainer>
-                  ),
-                },
-                {
-                  label: <GroupShortId>{event.id.substring(0, 8)}</GroupShortId>,
-                },
-                {label: t('Breadcrumbs')},
-              ]}
-            />
-          ),
-        }
+        {ariaLabel: 'breadcrumb drawer'}
       );
     },
     [group, event, project, openDrawer, enhancedCrumbs, organization]
@@ -174,6 +173,7 @@ export default function BreadcrumbsDataSection({
           startTimeString={startTimeString}
           // We want the timeline to appear connected to the 'View All' button
           showLastLine={hasViewAll}
+          isCompact
         />
         {hasViewAll && (
           <ViewAllContainer>
@@ -232,7 +232,7 @@ const CrumbContainer = styled('div')`
   align-items: center;
 `;
 
-const GroupShortId = styled('div')`
+const ShortId = styled('div')`
   font-family: ${p => p.theme.text.family};
   font-size: ${p => p.theme.fontSizeMedium};
   line-height: 1;

--- a/static/app/components/events/breadcrumbs/breadcrumbsDataSection.tsx
+++ b/static/app/components/events/breadcrumbs/breadcrumbsDataSection.tsx
@@ -17,7 +17,14 @@ import {
 } from 'sentry/components/events/breadcrumbs/utils';
 import {EventDataSection} from 'sentry/components/events/eventDataSection';
 import useDrawer from 'sentry/components/globalDrawer';
-import {IconClock, IconEllipsis, IconFilter, IconSearch, IconSort} from 'sentry/icons';
+import {
+  IconClock,
+  IconEllipsis,
+  IconFilter,
+  IconSearch,
+  IconSort,
+  IconTimer,
+} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {Event} from 'sentry/types/event';
@@ -109,7 +116,13 @@ export default function BreadcrumbsDataSection({
       />
       <Button
         aria-label={t('Change Time Format for Breadcrumbs')}
-        icon={<IconClock size="xs" />}
+        icon={
+          timeDisplay === BreadcrumbTimeDisplay.ABSOLUTE ? (
+            <IconClock size="xs" />
+          ) : (
+            <IconTimer size="xs" />
+          )
+        }
         onClick={() => {
           const nextTimeDisplay =
             timeDisplay === BreadcrumbTimeDisplay.ABSOLUTE

--- a/static/app/components/events/breadcrumbs/breadcrumbsDataSection.tsx
+++ b/static/app/components/events/breadcrumbs/breadcrumbsDataSection.tsx
@@ -1,6 +1,8 @@
 import {useCallback, useMemo} from 'react';
 import styled from '@emotion/styled';
 
+import ProjectAvatar from 'sentry/components/avatar/projectAvatar';
+import {Breadcrumbs as NavigationBreadcrumbs} from 'sentry/components/breadcrumbs';
 import {Button} from 'sentry/components/button';
 import ButtonBar from 'sentry/components/buttonBar';
 import ErrorBoundary from 'sentry/components/errorBoundary';
@@ -77,14 +79,31 @@ export default function BreadcrumbsDataSection({
           <Body>
             <BreadcrumbsDrawerContent
               breadcrumbs={enhancedCrumbs}
-              group={group}
-              event={event}
-              project={project}
               focusControl={focusControl}
             />
           </Body>
         ),
-        {ariaLabel: 'breadcrumb drawer'}
+        {
+          ariaLabel: 'breadcrumb drawer',
+          headerContent: (
+            <NavigationCrumbs
+              crumbs={[
+                {
+                  label: (
+                    <CrumbContainer>
+                      <ProjectAvatar project={project} />
+                      <GroupShortId>{group.shortId}</GroupShortId>
+                    </CrumbContainer>
+                  ),
+                },
+                {
+                  label: <GroupShortId>{event.id.substring(0, 8)}</GroupShortId>,
+                },
+                {label: t('Breadcrumbs')},
+              ]}
+            />
+          ),
+        }
       );
     },
     [group, event, project, openDrawer, enhancedCrumbs, organization]
@@ -200,4 +219,21 @@ const VerticalEllipsis = styled(IconEllipsis)`
 
 const ViewAllButton = styled(Button)`
   padding: ${space(0.75)} ${space(1)};
+`;
+
+const NavigationCrumbs = styled(NavigationBreadcrumbs)`
+  margin: 0;
+  padding: 0;
+`;
+
+const CrumbContainer = styled('div')`
+  display: flex;
+  gap: ${space(1)};
+  align-items: center;
+`;
+
+const GroupShortId = styled('div')`
+  font-family: ${p => p.theme.text.family};
+  font-size: ${p => p.theme.fontSizeMedium};
+  line-height: 1;
 `;

--- a/static/app/components/events/breadcrumbs/breadcrumbsDrawerContent.spec.tsx
+++ b/static/app/components/events/breadcrumbs/breadcrumbsDrawerContent.spec.tsx
@@ -58,7 +58,7 @@ describe('BreadcrumbsDrawerContent', function () {
       expect(drawerScreen.getByText(level)).toBeInTheDocument();
       expect(drawerScreen.getByText(message)).toBeInTheDocument();
     }
-    expect(drawerScreen.getAllByText('-1min')).toHaveLength(MOCK_BREADCRUMBS.length);
+    expect(drawerScreen.getAllByText('-1min 2ms')).toHaveLength(MOCK_BREADCRUMBS.length);
   });
 
   it('allows search to affect displayed crumbs', async function () {
@@ -129,9 +129,8 @@ describe('BreadcrumbsDrawerContent', function () {
 
   it('allows time display dropdown to change all displayed crumbs', async function () {
     const drawerScreen = await renderBreadcrumbDrawer();
-
-    expect(drawerScreen.getAllByText('-1min')).toHaveLength(MOCK_BREADCRUMBS.length);
-    expect(drawerScreen.queryByText('18:00:48')).not.toBeInTheDocument();
+    expect(drawerScreen.getAllByText('-1min 2ms')).toHaveLength(MOCK_BREADCRUMBS.length);
+    expect(drawerScreen.queryByText('06:00:48.760')).not.toBeInTheDocument();
 
     const timeControl = drawerScreen.getByRole('button', {
       name: 'Change Time Format for All Breadcrumbs',
@@ -139,13 +138,15 @@ describe('BreadcrumbsDrawerContent', function () {
     await userEvent.click(timeControl);
     await userEvent.click(drawerScreen.getByRole('option', {name: 'Absolute'}));
 
-    expect(drawerScreen.queryByText('-1min')).not.toBeInTheDocument();
-    expect(drawerScreen.getAllByText('18:00:48')).toHaveLength(MOCK_BREADCRUMBS.length);
+    expect(drawerScreen.queryByText('-1min 2ms')).not.toBeInTheDocument();
+    expect(drawerScreen.getAllByText('06:00:48.760')).toHaveLength(
+      MOCK_BREADCRUMBS.length
+    );
 
     await userEvent.click(timeControl);
     await userEvent.click(drawerScreen.getByRole('option', {name: 'Relative'}));
 
-    expect(drawerScreen.getAllByText('-1min')).toHaveLength(MOCK_BREADCRUMBS.length);
-    expect(drawerScreen.queryByText('18:00:48')).not.toBeInTheDocument();
+    expect(drawerScreen.getAllByText('-1min 2ms')).toHaveLength(MOCK_BREADCRUMBS.length);
+    expect(drawerScreen.queryByText('06:00:48.760')).not.toBeInTheDocument();
   });
 });

--- a/static/app/components/events/breadcrumbs/breadcrumbsDrawerContent.tsx
+++ b/static/app/components/events/breadcrumbs/breadcrumbsDrawerContent.tsx
@@ -33,6 +33,21 @@ export const enum BreadcrumbControlOptions {
   SORT = 'sort',
 }
 
+function useFocusControl(initialFocusControl?: BreadcrumbControlOptions) {
+  const [focusControl, setFocusControl] = useState(initialFocusControl);
+  // If the focused control element is blurred, unset the state to remove styles
+  // This will allow us to simulate :focus-visible on the button elements.
+  const getFocusProps = useCallback(
+    (option: BreadcrumbControlOptions) => {
+      return option === focusControl
+        ? {autoFocus: true, onBlur: () => setFocusControl(undefined)}
+        : {};
+    },
+    [focusControl]
+  );
+  return {getFocusProps};
+}
+
 interface BreadcrumbsDrawerContentProps {
   breadcrumbs: EnhancedCrumb[];
   focusControl?: BreadcrumbControlOptions;
@@ -51,8 +66,7 @@ export function BreadcrumbsDrawerContent({
     BREADCRUMB_SORT_LOCALSTORAGE_KEY,
     BreadcrumbSort.NEWEST
   );
-
-  const [focusControl, setFocusControl] = useState(initialFocusControl);
+  const {getFocusProps} = useFocusControl(initialFocusControl);
 
   const [timeDisplay, setTimeDisplay] = useLocalStorageState<BreadcrumbTimeDisplay>(
     BREADCRUMB_TIME_DISPLAY_LOCALSTORAGE_KEY,
@@ -79,17 +93,6 @@ export function BreadcrumbsDrawerContent({
         ? displayCrumbs?.at(0)?.breadcrumb?.timestamp
         : undefined,
     [displayCrumbs, timeDisplay]
-  );
-
-  // If the focused control element is blurred, unset the state to remove styles
-  // This will allow us to simulate :focus-visible on the button elements.
-  const getFocusProps = useCallback(
-    (option: BreadcrumbControlOptions) => {
-      return option === focusControl
-        ? {autoFocus: true, onBlur: () => setFocusControl(undefined)}
-        : {};
-    },
-    [focusControl]
   );
 
   const actions = (
@@ -223,7 +226,6 @@ export function BreadcrumbsDrawerContent({
           <BreadcrumbsTimeline
             breadcrumbs={displayCrumbs}
             startTimeString={startTimeString}
-            fullyExpanded
           />
         )}
       </TimelineContainer>

--- a/static/app/components/events/breadcrumbs/breadcrumbsDrawerContent.tsx
+++ b/static/app/components/events/breadcrumbs/breadcrumbsDrawerContent.tsx
@@ -20,7 +20,7 @@ import {
   BreadcrumbSort,
 } from 'sentry/components/events/interfaces/breadcrumbs';
 import {InputGroup} from 'sentry/components/inputGroup';
-import {IconClock, IconFilter, IconSearch, IconSort} from 'sentry/icons';
+import {IconClock, IconFilter, IconSearch, IconSort, IconTimer} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {trackAnalytics} from 'sentry/utils/analytics';
@@ -168,7 +168,13 @@ export function BreadcrumbsDrawerContent({
           <Button
             size="xs"
             borderless
-            icon={<IconClock />}
+            icon={
+              timeDisplay === BreadcrumbTimeDisplay.ABSOLUTE ? (
+                <IconClock size="xs" />
+              ) : (
+                <IconTimer size="xs" />
+              )
+            }
             aria-label={t('Change Time Format for All Breadcrumbs')}
             {...props}
           />

--- a/static/app/components/events/breadcrumbs/breadcrumbsDrawerContent.tsx
+++ b/static/app/components/events/breadcrumbs/breadcrumbsDrawerContent.tsx
@@ -2,8 +2,6 @@ import {Fragment, useMemo, useState} from 'react';
 import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 
-import ProjectAvatar from 'sentry/components/avatar/projectAvatar';
-import {Breadcrumbs as NavigationBreadcrumbs} from 'sentry/components/breadcrumbs';
 import {Button} from 'sentry/components/button';
 import ButtonBar from 'sentry/components/buttonBar';
 import {CompactSelect} from 'sentry/components/compactSelect';
@@ -26,9 +24,6 @@ import {InputGroup} from 'sentry/components/inputGroup';
 import {IconClock, IconFilter, IconSearch, IconSort} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
-import type {Event} from 'sentry/types/event';
-import type {Group} from 'sentry/types/group';
-import type {Project} from 'sentry/types/project';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {useLocalStorageState} from 'sentry/utils/useLocalStorageState';
 import useOrganization from 'sentry/utils/useOrganization';
@@ -41,16 +36,10 @@ export const enum BreadcrumbControlOptions {
 
 interface BreadcrumbsDrawerContentProps {
   breadcrumbs: EnhancedCrumb[];
-  event: Event;
-  group: Group;
-  project: Project;
   focusControl?: BreadcrumbControlOptions;
 }
 
 export function BreadcrumbsDrawerContent({
-  event,
-  group,
-  project,
   breadcrumbs,
   focusControl,
 }: BreadcrumbsDrawerContentProps) {
@@ -194,22 +183,6 @@ export function BreadcrumbsDrawerContent({
 
   return (
     <Fragment>
-      <NavigationCrumbs
-        crumbs={[
-          {
-            label: (
-              <CrumbContainer>
-                <ProjectAvatar project={project} />
-                <GroupShortId>{group.shortId}</GroupShortId>
-              </CrumbContainer>
-            ),
-          },
-          {
-            label: <GroupShortId>{event.id.substring(0, 8)}</GroupShortId>,
-          },
-          {label: t('Breadcrumbs')},
-        ]}
-      />
       <HeaderGrid>
         <Header>{t('Breadcrumbs')}</Header>
         {actions}
@@ -244,18 +217,6 @@ export function BreadcrumbsDrawerContent({
   );
 }
 
-const CrumbContainer = styled('div')`
-  display: flex;
-  gap: ${space(1)};
-  align-items: center;
-`;
-
-const GroupShortId = styled('div')`
-  font-family: ${p => p.theme.text.family};
-  font-size: ${p => p.theme.fontSizeMedium};
-  line-height: 1;
-`;
-
 const HeaderGrid = styled('div')`
   display: grid;
   grid-template-columns: 1fr auto;
@@ -275,10 +236,6 @@ const SearchInput = styled(InputGroup.Input)`
   border: 0;
   box-shadow: unset;
   color: inherit;
-`;
-
-const NavigationCrumbs = styled(NavigationBreadcrumbs)`
-  margin: 0;
 `;
 
 const TimelineContainer = styled('div')`

--- a/static/app/components/events/breadcrumbs/breadcrumbsItemContent.tsx
+++ b/static/app/components/events/breadcrumbs/breadcrumbsItemContent.tsx
@@ -24,33 +24,37 @@ interface BreadcrumbsItemContentProps {
   meta?: Record<string, any>;
 }
 
+const DEFAULT_STRUCTURED_DATA_PROPS = {
+  depth: 0,
+  maxDefaultDepth: 1,
+  withAnnotatedText: true,
+  withOnlyFormattedText: true,
+};
+
 export default function BreadcrumbsItemContent({
   breadcrumb: bc,
   meta,
-  fullyExpanded,
+  fullyExpanded = false,
 }: BreadcrumbsItemContentProps) {
-  const maxDefaultDepth = fullyExpanded ? 10000 : 1;
-  const structureProps = {
-    depth: 0,
-    maxDefaultDepth,
-    withAnnotatedText: true,
-    withOnlyFormattedText: true,
+  const structuredDataProps = {
+    ...DEFAULT_STRUCTURED_DATA_PROPS,
+    forceDefaultExpand: fullyExpanded,
   };
 
   const defaultMessage = defined(bc.message) ? (
     <Timeline.Text>
-      <StructuredData value={bc.message} meta={meta?.message} {...structureProps} />
+      <StructuredData value={bc.message} meta={meta?.message} {...structuredDataProps} />
     </Timeline.Text>
   ) : null;
   const defaultData = defined(bc.data) ? (
     <Timeline.Data>
-      <StructuredData value={bc.data} meta={meta?.data} {...structureProps} />
+      <StructuredData value={bc.data} meta={meta?.data} {...structuredDataProps} />
     </Timeline.Data>
   ) : null;
 
   if (bc?.type === BreadcrumbType.HTTP) {
     return (
-      <HTTPCrumbContent breadcrumb={bc} meta={meta}>
+      <HTTPCrumbContent breadcrumb={bc} meta={meta} fullyExpanded={fullyExpanded}>
         {defaultMessage}
       </HTTPCrumbContent>
     );
@@ -80,9 +84,11 @@ function HTTPCrumbContent({
   breadcrumb,
   meta,
   children = null,
+  fullyExpanded,
 }: {
   breadcrumb: BreadcrumbTypeHTTP;
-  children?: React.ReactNode;
+  children: React.ReactNode;
+  fullyExpanded: boolean;
   meta?: Record<string, any>;
 }) {
   const {method, url, status_code: statusCode, ...otherData} = breadcrumb?.data ?? {};
@@ -106,10 +112,8 @@ function HTTPCrumbContent({
           <StructuredData
             value={otherData}
             meta={meta}
-            depth={0}
-            maxDefaultDepth={2}
-            withAnnotatedText
-            withOnlyFormattedText
+            {...DEFAULT_STRUCTURED_DATA_PROPS}
+            forceDefaultExpand={fullyExpanded}
           />
         </Timeline.Data>
       ) : null}

--- a/static/app/components/events/breadcrumbs/breadcrumbsItemContent.tsx
+++ b/static/app/components/events/breadcrumbs/breadcrumbsItemContent.tsx
@@ -26,7 +26,7 @@ interface BreadcrumbsItemContentProps {
 
 const DEFAULT_STRUCTURED_DATA_PROPS = {
   depth: 0,
-  maxDefaultDepth: 1,
+  maxDefaultDepth: 2,
   withAnnotatedText: true,
   withOnlyFormattedText: true,
 };
@@ -38,7 +38,7 @@ export default function BreadcrumbsItemContent({
 }: BreadcrumbsItemContentProps) {
   const structuredDataProps = {
     ...DEFAULT_STRUCTURED_DATA_PROPS,
-    forceDefaultExpand: fullyExpanded,
+    maxDefaultDepth: fullyExpanded ? 10000 : 1,
   };
 
   const defaultMessage = defined(bc.message) ? (

--- a/static/app/components/events/breadcrumbs/breadcrumbsTimeline.tsx
+++ b/static/app/components/events/breadcrumbs/breadcrumbsTimeline.tsx
@@ -80,9 +80,16 @@ export default function BreadcrumbsTimeline({
   });
 
   return (
-    <Timeline.Container ref={containerRef} style={{height: virtualizer.getTotalSize()}}>
-      {items}
-    </Timeline.Container>
+    <div
+      ref={containerRef}
+      style={{
+        height: virtualizer.getTotalSize(),
+
+        contain: 'layout size',
+      }}
+    >
+      <Timeline.Container>{items}</Timeline.Container>
+    </div>
   );
 }
 

--- a/static/app/components/events/breadcrumbs/breadcrumbsTimeline.tsx
+++ b/static/app/components/events/breadcrumbs/breadcrumbsTimeline.tsx
@@ -18,9 +18,9 @@ import {shouldUse24Hours} from 'sentry/utils/dates';
 interface BreadcrumbsTimelineProps {
   breadcrumbs: EnhancedCrumb[];
   /**
-   * Fully expands the contents of the breadcrumb's data payload.
+   * If false, expands the contents of the breadcrumb's data payload, adds padding.
    */
-  fullyExpanded?: boolean;
+  isCompact?: boolean;
   /**
    * Shows the line after the last breadcrumbs icon.
    * Useful for connecting timeline to components rendered after it.
@@ -35,7 +35,7 @@ interface BreadcrumbsTimelineProps {
 export default function BreadcrumbsTimeline({
   breadcrumbs,
   startTimeString,
-  fullyExpanded = false,
+  isCompact = false,
   showLastLine = false,
 }: BreadcrumbsTimelineProps) {
   const containerRef = useRef<HTMLDivElement>(null);
@@ -99,11 +99,13 @@ export default function BreadcrumbsTimeline({
         style={showLastLine ? {background: 'transparent'} : {}}
         data-index={virtualizedRow.index}
       >
-        <BreadcrumbsItemContent
-          breadcrumb={breadcrumb}
-          meta={meta}
-          fullyExpanded={fullyExpanded}
-        />
+        <ContentWrapper isCompact={isCompact}>
+          <BreadcrumbsItemContent
+            breadcrumb={breadcrumb}
+            meta={meta}
+            fullyExpanded={!isCompact}
+          />
+        </ContentWrapper>
       </Timeline.Item>
     );
   });
@@ -133,6 +135,10 @@ const Timestamp = styled('div')`
   color: ${p => p.theme.subText};
   font-size: ${p => p.theme.fontSizeSmall};
   span {
-    text-decoration: underline dashed ${p => p.theme.subText};
+    text-decoration: underline dashed ${p => p.theme.translucentBorder};
   }
+`;
+
+const ContentWrapper = styled('div')<{isCompact: boolean}>`
+  padding-bottom: ${p => space(p.isCompact ? 0.5 : 1.5)};
 `;

--- a/static/app/components/events/breadcrumbs/breadcrumbsTimeline.tsx
+++ b/static/app/components/events/breadcrumbs/breadcrumbsTimeline.tsx
@@ -1,15 +1,19 @@
 import {Fragment, useRef} from 'react';
 import styled from '@emotion/styled';
 import {useVirtualizer} from '@tanstack/react-virtual';
+import moment from 'moment';
 
+import DateTime from 'sentry/components/dateTime';
+import Duration from 'sentry/components/duration';
 import BreadcrumbsItemContent from 'sentry/components/events/breadcrumbs/breadcrumbsItemContent';
-import {
-  BREADCRUMB_TIMESTAMP_PLACEHOLDER,
-  type EnhancedCrumb,
-} from 'sentry/components/events/breadcrumbs/utils';
-import Timeline, {type TimelineItemProps} from 'sentry/components/timeline';
+import type {EnhancedCrumb} from 'sentry/components/events/breadcrumbs/utils';
+import Timeline from 'sentry/components/timeline';
+import {Tooltip} from 'sentry/components/tooltip';
 import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
 import {defined} from 'sentry/utils';
+import isValidDate from 'sentry/utils/date/isValidDate';
+import {shouldUse24Hours} from 'sentry/utils/dates';
 
 interface BreadcrumbsTimelineProps {
   breadcrumbs: EnhancedCrumb[];
@@ -22,7 +26,10 @@ interface BreadcrumbsTimelineProps {
    * Useful for connecting timeline to components rendered after it.
    */
   showLastLine?: boolean;
-  startTimeString?: TimelineItemProps['startTimeString'];
+  /**
+   * If specified, will display time relatively.
+   */
+  startTimeString?: string;
 }
 
 export default function BreadcrumbsTimeline({
@@ -50,6 +57,29 @@ export default function BreadcrumbsTimeline({
     const {breadcrumb, raw, title, meta, iconComponent, colorConfig, levelComponent} =
       breadcrumbs[virtualizedRow.index];
     const isVirtualCrumb = !defined(raw);
+
+    const timeDate = new Date(breadcrumb.timestamp ?? '');
+    const startTimeDate = new Date(startTimeString ?? '');
+
+    const absoluteFormat = shouldUse24Hours() ? 'HH:mm:ss.SSS' : 'hh:mm:ss.SSS';
+    const timestampComponent = isValidDate(timeDate) ? (
+      <Timestamp>
+        <Tooltip
+          title={<DateTime date={timeDate} format={`ll - ${absoluteFormat} (z)`} />}
+        >
+          {isValidDate(startTimeDate) ? (
+            <Duration
+              seconds={moment(timeDate).diff(moment(startTimeDate), 's', true)}
+              exact
+              abbreviation
+            />
+          ) : (
+            <DateTime date={timeDate} format={absoluteFormat} />
+          )}
+        </Tooltip>
+      </Timestamp>
+    ) : null;
+
     return (
       <Timeline.Item
         key={virtualizedRow.key}
@@ -63,8 +93,7 @@ export default function BreadcrumbsTimeline({
         }
         colorConfig={colorConfig}
         icon={iconComponent}
-        timeString={breadcrumb.timestamp ?? BREADCRUMB_TIMESTAMP_PLACEHOLDER}
-        startTimeString={startTimeString}
+        timestamp={timestampComponent}
         // XXX: Only the virtual crumb can be marked as active for breadcrumbs
         isActive={isVirtualCrumb ?? false}
         style={showLastLine ? {background: 'transparent'} : {}}
@@ -84,7 +113,6 @@ export default function BreadcrumbsTimeline({
       ref={containerRef}
       style={{
         height: virtualizer.getTotalSize(),
-
         contain: 'layout size',
       }}
     >
@@ -98,4 +126,13 @@ const Subtitle = styled('p')`
   font-weight: normal;
   font-size: ${p => p.theme.fontSizeSmall};
   display: inline;
+`;
+
+const Timestamp = styled('div')`
+  margin: 0 ${space(1)};
+  color: ${p => p.theme.subText};
+  font-size: ${p => p.theme.fontSizeSmall};
+  span {
+    text-decoration: underline dashed ${p => p.theme.subText};
+  }
 `;

--- a/static/app/components/events/breadcrumbs/utils.tsx
+++ b/static/app/components/events/breadcrumbs/utils.tsx
@@ -9,6 +9,7 @@ import {
 } from 'sentry/components/events/interfaces/breadcrumbs/utils';
 import type {ColorConfig} from 'sentry/components/timeline';
 import {
+  IconCode,
   IconCursorArrow,
   IconFire,
   IconFix,
@@ -19,9 +20,9 @@ import {
   IconSort,
   IconSpan,
   IconStack,
-  IconTerminal,
   IconUser,
   IconWarning,
+  IconWifi,
 } from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
@@ -191,6 +192,8 @@ function getBreadcrumbColorConfig(type?: BreadcrumbType): ColorConfig {
       return {primary: 'purple400', secondary: 'purple200'};
     case BreadcrumbType.SYSTEM:
     case BreadcrumbType.SESSION:
+    case BreadcrumbType.DEVICE:
+    case BreadcrumbType.NETWORK:
       return {primary: 'pink400', secondary: 'pink200'};
     case BreadcrumbType.DEBUG:
     case BreadcrumbType.INFO:
@@ -224,6 +227,10 @@ function getBreadcrumbFilter(type?: BreadcrumbType) {
       return t('Session');
     case BreadcrumbType.TRANSACTION:
       return t('Transaction');
+    case BreadcrumbType.DEVICE:
+      return t('Device');
+    case BreadcrumbType.NETWORK:
+      return t('Network');
     default:
       return t('Default');
   }
@@ -255,8 +262,12 @@ function BreadcrumbIcon({type}: {type?: BreadcrumbType}) {
       return <IconRefresh size="xs" />;
     case BreadcrumbType.TRANSACTION:
       return <IconSpan size="xs" />;
+    case BreadcrumbType.DEVICE:
+      return <IconMobile size="xs" />;
+    case BreadcrumbType.NETWORK:
+      return <IconWifi size="xs" />;
     default:
-      return <IconTerminal size="xs" />;
+      return <IconCode size="xs" />;
   }
 }
 

--- a/static/app/components/events/breadcrumbs/utils.tsx
+++ b/static/app/components/events/breadcrumbs/utils.tsx
@@ -34,7 +34,6 @@ import {
 import {EntryType, type Event} from 'sentry/types/event';
 import {toTitleCase} from 'sentry/utils/string/toTitleCase';
 
-export const BREADCRUMB_TIMESTAMP_PLACEHOLDER = '--';
 const BREADCRUMB_TITLE_PLACEHOLDER = t('Generic');
 const BREADCRUMB_SUMMARY_COUNT = 3;
 
@@ -97,6 +96,7 @@ export function getBreadcrumbFilterOptions(crumbs: EnhancedCrumb[]) {
   });
   return filterOptions.sort((a, b) => a.value.localeCompare(b.value));
 }
+
 export interface EnhancedCrumb {
   // Mutated crumb where we change types or virtual crumb
   breadcrumb: RawCrumb;

--- a/static/app/components/events/interfaces/breadcrumbs/utils.tsx
+++ b/static/app/components/events/interfaces/breadcrumbs/utils.tsx
@@ -24,9 +24,15 @@ export function convertCrumbType(breadcrumb: RawCrumb): RawCrumb {
     }
     switch (category) {
       case 'console':
+      case 'Logcat':
         return {...breadcrumb, type: BreadcrumbType.DEBUG};
       case 'session':
         return {...breadcrumb, type: BreadcrumbType.NAVIGATION};
+      case 'graphql':
+      case 'mutation':
+      case 'subscription':
+      case 'data_loader':
+        return {...breadcrumb, type: BreadcrumbType.QUERY};
       case 'sentry':
         if (subcategory === 'transaction' || subcategory === 'event') {
           return {...breadcrumb, type: BreadcrumbType.TRANSACTION};

--- a/static/app/components/globalDrawer/components.tsx
+++ b/static/app/components/globalDrawer/components.tsx
@@ -1,4 +1,4 @@
-import {forwardRef} from 'react';
+import {forwardRef, Fragment} from 'react';
 import styled from '@emotion/styled';
 
 import {Button} from 'sentry/components/button';
@@ -10,12 +10,13 @@ import {space} from 'sentry/styles/space';
 
 interface DrawerPanelProps {
   children: React.ReactNode;
+  headerContent: React.ReactNode;
   onClose: DrawerOptions['onClose'];
   ariaLabel?: SlideOverPanelProps['ariaLabel'];
 }
 
 export const DrawerPanel = forwardRef(function _DrawerPanel(
-  {ariaLabel, children, onClose}: DrawerPanelProps,
+  {ariaLabel, children, headerContent, onClose}: DrawerPanelProps,
   ref: React.ForwardedRef<HTMLDivElement>
 ) {
   return (
@@ -37,6 +38,12 @@ export const DrawerPanel = forwardRef(function _DrawerPanel(
           >
             {t('Close')}
           </CloseButton>
+          {headerContent && (
+            <Fragment>
+              <HeaderBar />
+              {headerContent}
+            </Fragment>
+          )}
         </DrawerHeader>
         {children}
       </SlideOverPanel>
@@ -50,8 +57,16 @@ const CloseButton = styled(Button)`
     color: ${p => p.theme.textColor};
   }
 `;
+const HeaderBar = styled('div')`
+  margin: 0 ${space(2)};
+  border-right: 1px solid ${p => p.theme.border};
+`;
 
 const DrawerHeader = styled('header')`
+  position: sticky;
+  top: 0;
+  z-index: ${p => p.theme.zIndex.drawer + 1};
+  background: ${p => p.theme.background};
   justify-content: flex-start;
   display: flex;
   padding: ${space(1.5)};
@@ -69,6 +84,7 @@ const DrawerContainer = styled('div')`
   inset: 0;
   z-index: ${p => p.theme.zIndex.drawer};
   pointer-events: none;
+  display: relative;
 `;
 
 export const DrawerComponents = {

--- a/static/app/components/globalDrawer/components.tsx
+++ b/static/app/components/globalDrawer/components.tsx
@@ -1,22 +1,36 @@
-import {forwardRef, Fragment} from 'react';
+import {createContext, forwardRef, Fragment, useContext} from 'react';
 import styled from '@emotion/styled';
 
 import {Button} from 'sentry/components/button';
 import type {DrawerOptions} from 'sentry/components/globalDrawer';
-import SlideOverPanel, {type SlideOverPanelProps} from 'sentry/components/slideOverPanel';
+import SlideOverPanel from 'sentry/components/slideOverPanel';
 import {IconClose} from 'sentry/icons/iconClose';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 
+interface DrawerContentContextType {
+  ariaLabel: string;
+  onClose: DrawerOptions['onClose'];
+}
+
+const DrawerContentContext = createContext<DrawerContentContextType>({
+  onClose: () => {},
+  ariaLabel: 'slide out drawer',
+});
+
+function useDrawerContentContext() {
+  return useContext(DrawerContentContext);
+}
+
 interface DrawerPanelProps {
+  ariaLabel: DrawerContentContextType['ariaLabel'];
   children: React.ReactNode;
   headerContent: React.ReactNode;
-  onClose: DrawerOptions['onClose'];
-  ariaLabel?: SlideOverPanelProps['ariaLabel'];
+  onClose: DrawerContentContextType['onClose'];
 }
 
 export const DrawerPanel = forwardRef(function _DrawerPanel(
-  {ariaLabel, children, headerContent, onClose}: DrawerPanelProps,
+  {ariaLabel, children, onClose}: DrawerPanelProps,
   ref: React.ForwardedRef<HTMLDivElement>
 ) {
   return (
@@ -27,7 +41,41 @@ export const DrawerPanel = forwardRef(function _DrawerPanel(
         collapsed={false}
         ref={ref}
       >
-        <DrawerHeader>
+        {/*
+          This provider allows data passed to openDrawer to be accessed by drawer components.
+          For example: <DrawerHeader />, will trigger the custom onClose callback set in openDrawer
+          when it's button is pressed.
+        */}
+        <DrawerContentContext.Provider value={{onClose, ariaLabel}}>
+          {children}
+        </DrawerContentContext.Provider>
+      </SlideOverPanel>
+    </DrawerContainer>
+  );
+});
+
+interface DrawerHeaderProps {
+  children?: React.ReactNode;
+  /**
+   * If true, hides the spacer bar separating close button from custom header content
+   */
+  hideBar?: boolean;
+  /**
+   * If true, hides the close button
+   */
+  hideCloseButton?: boolean;
+}
+
+export const DrawerHeader = forwardRef(function _DrawerHeader(
+  {children = null, hideBar = false, hideCloseButton = false}: DrawerHeaderProps,
+  ref: React.ForwardedRef<HTMLHeadingElement>
+) {
+  const {onClose} = useDrawerContentContext();
+
+  return (
+    <Header ref={ref}>
+      {!hideCloseButton && (
+        <Fragment>
           <CloseButton
             priority="link"
             size="xs"
@@ -38,16 +86,11 @@ export const DrawerPanel = forwardRef(function _DrawerPanel(
           >
             {t('Close')}
           </CloseButton>
-          {headerContent && (
-            <Fragment>
-              <HeaderBar />
-              {headerContent}
-            </Fragment>
-          )}
-        </DrawerHeader>
-        {children}
-      </SlideOverPanel>
-    </DrawerContainer>
+          {!hideBar && <HeaderBar />}
+        </Fragment>
+      )}
+      {children}
+    </Header>
   );
 });
 
@@ -57,12 +100,13 @@ const CloseButton = styled(Button)`
     color: ${p => p.theme.textColor};
   }
 `;
+
 const HeaderBar = styled('div')`
   margin: 0 ${space(2)};
   border-right: 1px solid ${p => p.theme.border};
 `;
 
-const DrawerHeader = styled('header')`
+const Header = styled('header')`
   position: sticky;
   top: 0;
   z-index: ${p => p.theme.zIndex.drawer + 1};
@@ -89,6 +133,7 @@ const DrawerContainer = styled('div')`
 
 export const DrawerComponents = {
   DrawerBody,
+  DrawerHeader,
   DrawerPanel,
 };
 

--- a/static/app/components/globalDrawer/index.spec.tsx
+++ b/static/app/components/globalDrawer/index.spec.tsx
@@ -1,3 +1,5 @@
+import {Fragment} from 'react';
+
 import {
   render,
   screen,
@@ -52,6 +54,8 @@ describe('GlobalDrawer', function () {
 
     expect(await screen.findByTestId('drawer-test-content')).toBeInTheDocument();
     expect(screen.getByRole('complementary', {name: ariaLabel})).toBeInTheDocument();
+    // Doesn't render header with close button unless provided to renderer
+    expect(screen.queryByRole('button', {name: 'Close Drawer'})).not.toBeInTheDocument();
 
     await userEvent.click(screen.getByTestId('drawer-test-close'));
     await waitForDrawerToHide(ariaLabel);
@@ -68,8 +72,11 @@ describe('GlobalDrawer', function () {
     render(
       <GlobalDrawerTestComponent
         config={{
-          renderer: ({Body}) => (
-            <Body data-test-id="drawer-test-content">onClose button</Body>
+          renderer: ({Body, Header}) => (
+            <Fragment>
+              <Header />
+              <Body data-test-id="drawer-test-content">onClose button</Body>
+            </Fragment>
           ),
           options: {onClose: closeSpy, ariaLabel},
         }}
@@ -146,8 +153,11 @@ describe('GlobalDrawer', function () {
     render(
       <GlobalDrawerTestComponent
         config={{
-          renderer: ({Body}) => (
-            <Body data-test-id="drawer-test-content">ignore close events</Body>
+          renderer: ({Body, Header}) => (
+            <Fragment>
+              <Header />
+              <Body data-test-id="drawer-test-content">ignore close events</Body>
+            </Fragment>
           ),
           options: {
             onClose: closeSpy,
@@ -181,14 +191,18 @@ describe('GlobalDrawer', function () {
   });
 
   it('renders custom header content when specified', async function () {
+    const closeSpy = jest.fn();
     const customHeader = 'Look at my neat drawer header';
     render(
       <GlobalDrawerTestComponent
         config={{
-          renderer: ({Body}) => (
-            <Body data-test-id="drawer-test-content">custom header</Body>
+          renderer: ({Body, Header}) => (
+            <Fragment>
+              <Header>{customHeader}</Header>
+              <Body data-test-id="drawer-test-content">custom header</Body>
+            </Fragment>
           ),
-          options: {ariaLabel, headerContent: customHeader},
+          options: {ariaLabel, onClose: closeSpy},
         }}
       />
     );
@@ -207,6 +221,7 @@ describe('GlobalDrawer', function () {
     await userEvent.click(closeButton);
     await waitForDrawerToHide(ariaLabel);
 
+    expect(closeSpy).toHaveBeenCalled();
     expect(drawer).not.toBeInTheDocument();
   });
 });

--- a/static/app/components/globalDrawer/index.spec.tsx
+++ b/static/app/components/globalDrawer/index.spec.tsx
@@ -3,6 +3,7 @@ import {
   screen,
   userEvent,
   waitForDrawerToHide,
+  within,
 } from 'sentry-test/reactTestingLibrary';
 
 import type {DrawerConfig} from 'sentry/components/globalDrawer';
@@ -177,5 +178,35 @@ describe('GlobalDrawer', function () {
 
     expect(closeSpy).toHaveBeenCalled();
     expect(content).not.toBeInTheDocument();
+  });
+
+  it('renders custom header content when specified', async function () {
+    const customHeader = 'Look at my neat drawer header';
+    render(
+      <GlobalDrawerTestComponent
+        config={{
+          renderer: ({Body}) => (
+            <Body data-test-id="drawer-test-content">custom header</Body>
+          ),
+          options: {ariaLabel, headerContent: customHeader},
+        }}
+      />
+    );
+
+    await userEvent.click(screen.getByTestId('drawer-test-open'));
+
+    expect(await screen.findByTestId('drawer-test-content')).toBeInTheDocument();
+    const drawer = screen.getByRole('complementary', {name: ariaLabel});
+    expect(drawer).toBeInTheDocument();
+
+    // Has close button + custom header
+    const closeButton = within(drawer).getByRole('button', {name: 'Close Drawer'});
+    expect(closeButton).toBeInTheDocument();
+    expect(within(drawer).getByText(customHeader)).toBeInTheDocument();
+
+    await userEvent.click(closeButton);
+    await waitForDrawerToHide(ariaLabel);
+
+    expect(drawer).not.toBeInTheDocument();
   });
 });

--- a/static/app/components/globalDrawer/index.tsx
+++ b/static/app/components/globalDrawer/index.tsx
@@ -29,6 +29,10 @@ export interface DrawerOptions {
    */
   closeOnOutsideClick?: boolean;
   /**
+   * Custom content for the header of the drawer
+   */
+  headerContent?: React.ReactNode;
+  /**
    * Callback for when the drawer closes
    */
   onClose?: () => void;
@@ -126,6 +130,7 @@ export function GlobalDrawer({children}) {
               ariaLabel={currentDrawerConfig.options.ariaLabel}
               onClose={handleClose}
               ref={panelRef}
+              headerContent={currentDrawerConfig?.options?.headerContent ?? null}
             >
               {renderedChild}
             </DrawerComponents.DrawerPanel>

--- a/static/app/components/globalDrawer/index.tsx
+++ b/static/app/components/globalDrawer/index.tsx
@@ -48,6 +48,10 @@ interface DrawerRenderProps {
    */
   Body: typeof DrawerComponents.DrawerBody;
   /**
+   * Header with a close button for the drawer
+   */
+  Header: typeof DrawerComponents.DrawerHeader;
+  /**
    * Close the drawer
    */
   closeDrawer: () => void;
@@ -117,6 +121,7 @@ export function GlobalDrawer({children}) {
   const renderedChild = currentDrawerConfig?.renderer
     ? currentDrawerConfig.renderer({
         Body: DrawerComponents.DrawerBody,
+        Header: DrawerComponents.DrawerHeader,
         closeDrawer: handleClose,
       })
     : null;

--- a/static/app/components/replays/breadcrumbs/breadcrumbItem.tsx
+++ b/static/app/components/replays/breadcrumbs/breadcrumbItem.tsx
@@ -122,8 +122,6 @@ function BreadcrumbItem({
   }, [frame]);
 
   const hasNewTimelineUI = useHasNewTimelineUI();
-  const timeString = new Date(frame.timestampMs).toISOString();
-  const startTimeString = new Date(startTimestampMs).toISOString();
   if (hasNewTimelineUI) {
     // Coerce previous design colors into new ones. After 'new-timeline-ui' is GA, we can modify
     // the mapper directly.
@@ -134,16 +132,14 @@ function BreadcrumbItem({
         icon={icon}
         title={title}
         colorConfig={{primary: darkColor, secondary: color}}
-        timeString={timeString}
-        renderTimestamp={(_ts, _sts) => (
+        timestamp={
           <ReplayTimestamp>
             <TimestampButton
               startTimestampMs={startTimestampMs}
               timestampMs={frame.timestampMs}
             />
           </ReplayTimestamp>
-        )}
-        startTimeString={startTimeString}
+        }
         data-is-error-frame={isErrorFrame(frame)}
         style={style}
         className={className}

--- a/static/app/components/replays/breadcrumbs/breadcrumbItem.tsx
+++ b/static/app/components/replays/breadcrumbs/breadcrumbItem.tsx
@@ -34,6 +34,7 @@ import {
   isFeedbackFrame,
   isHydrationErrorFrame,
 } from 'sentry/utils/replays/types';
+import type {Color} from 'sentry/utils/theme';
 import useOrganization from 'sentry/utils/useOrganization';
 import useProjectFromSlug from 'sentry/utils/useProjectFromSlug';
 import IconWrapper from 'sentry/views/replays/detail/iconWrapper';
@@ -124,11 +125,15 @@ function BreadcrumbItem({
   const timeString = new Date(frame.timestampMs).toISOString();
   const startTimeString = new Date(startTimestampMs).toISOString();
   if (hasNewTimelineUI) {
+    // Coerce previous design colors into new ones. After 'new-timeline-ui' is GA, we can modify
+    // the mapper directly.
+    const darkColor =
+      color === 'gray300' ? color : (color.replace('300', '400') as Color);
     return (
       <StyledTimelineItem
         icon={icon}
         title={title}
-        colorConfig={{primary: color, secondary: color}}
+        colorConfig={{primary: darkColor, secondary: color}}
         timeString={timeString}
         renderTimestamp={(_ts, _sts) => (
           <ReplayTimestamp>
@@ -299,6 +304,9 @@ const StyledTimelineItem = styled(Timeline.Item)`
   margin: 0;
   &:hover {
     background: ${p => p.theme.translucentSurface200};
+    .icon-wrapper {
+      background: ${p => p.theme.translucentSurface200};
+    }
   }
   cursor: pointer;
   /* vertical line connecting items */

--- a/static/app/components/replays/breadcrumbs/breadcrumbItem.tsx
+++ b/static/app/components/replays/breadcrumbs/breadcrumbItem.tsx
@@ -18,7 +18,6 @@ import {useHasNewTimelineUI} from 'sentry/components/timeline/utils';
 import {Tooltip} from 'sentry/components/tooltip';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
-import formatReplayDuration from 'sentry/utils/duration/formatReplayDuration';
 import type {Extraction} from 'sentry/utils/replays/extractDomNodes';
 import {getReplayDiffOffsetsFromFrame} from 'sentry/utils/replays/getDiffTimestamps';
 import getFrameDetails from 'sentry/utils/replays/getFrameDetails';
@@ -131,9 +130,14 @@ function BreadcrumbItem({
         title={title}
         colorConfig={{primary: color, secondary: color}}
         timeString={timeString}
-        renderTimestamp={(_ts, _sts) =>
-          formatReplayDuration(Math.abs(frame.timestampMs - startTimestampMs), false)
-        }
+        renderTimestamp={(_ts, _sts) => (
+          <ReplayTimestamp>
+            <TimestampButton
+              startTimestampMs={startTimestampMs}
+              timestampMs={frame.timestampMs}
+            />
+          </ReplayTimestamp>
+        )}
         startTimeString={startTimeString}
         data-is-error-frame={isErrorFrame(frame)}
         style={style}
@@ -311,6 +315,12 @@ const StyledTimelineItem = styled(Timeline.Item)`
   &:first-child::before {
     top: 4px;
   }
+`;
+
+const ReplayTimestamp = styled('div')`
+  color: ${p => p.theme.textColor};
+  font-size: ${p => p.theme.fontSizeSmall};
+  align-self: flex-start;
 `;
 
 const CrumbItem = styled(PanelItem)<{isErrorFrame?: boolean}>`

--- a/static/app/components/slideOverPanel.tsx
+++ b/static/app/components/slideOverPanel.tsx
@@ -20,7 +20,7 @@ const COLLAPSED_STYLES = {
   right: {opacity: 0, x: PANEL_WIDTH, y: 0},
 };
 
-export type SlideOverPanelProps = {
+type SlideOverPanelProps = {
   children: React.ReactNode;
   collapsed: boolean;
   ariaLabel?: string;

--- a/static/app/components/timeline/index.stories.tsx
+++ b/static/app/components/timeline/index.stories.tsx
@@ -1,6 +1,8 @@
 import {Fragment} from 'react';
 
+import {Button} from 'sentry/components/button';
 import {CodeSnippet} from 'sentry/components/codeSnippet';
+import DateTime from 'sentry/components/dateTime';
 import {StructuredData} from 'sentry/components/structuredEventData';
 import Timeline from 'sentry/components/timeline';
 import {
@@ -37,7 +39,7 @@ export default storyBook('Timeline (Updated 06/17/24)', story => {
       <Timeline.Item
         title={'SyntaxError'}
         icon={<IconFire size="xs" />}
-        timeString={now.toISOString()}
+        timestamp={<DateTime date={now} />}
         colorConfig={{
           primary: 'red400',
           secondary: 'red200',
@@ -69,7 +71,7 @@ export default storyBook('Timeline (Updated 06/17/24)', story => {
       <Timeline.Item
         title={'Navigation'}
         icon={<IconSort rotated size="xs" />}
-        timeString={now.toISOString()}
+        timestamp={<DateTime date={now} />}
         colorConfig={{
           primary: 'green400',
           secondary: 'green200',
@@ -101,17 +103,14 @@ export default storyBook('Timeline (Updated 06/17/24)', story => {
           recommended.
         </li>
         <li>
-          <code>timeString</code> - ISO time string detailing the moment the item happened
-        </li>
-        <li>
           <code>title</code> - The header to appear on the item
         </li>
       </ul>
       <h6>Optional Props</h6>
       <ul>
         <li>
-          <code>startTimeString</code> - If provided, time will be displayed relative to
-          start time.
+          <code>timestamp</code> - A component to render as the timestamp, if null, an
+          empty div is used for spacing.
         </li>
         <li>
           <code>colorConfig</code> - A mapping of colors to use for emphasizing the item
@@ -133,7 +132,7 @@ export default storyBook('Timeline (Updated 06/17/24)', story => {
       <Timeline.Item
         title={'SyntaxError'}
         icon={<IconFire size="xs" />}
-        timeString={now.toISOString()}
+        timestamp={<span style={{color: 'blue'}}>my cool timestamp</span>}
         colorConfig={{
           primary: 'red400',
           secondary: 'red200',
@@ -142,19 +141,24 @@ export default storyBook('Timeline (Updated 06/17/24)', story => {
       <Timeline.Item
         title={'Active Item'}
         icon={<IconCursorArrow size="xs" />}
-        timeString={now.toISOString()}
         colorConfig={{
           primary: 'blue400',
           secondary: 'blue200',
         }}
         isActive
       >
-        <Timeline.Text>This is a description of the error</Timeline.Text>
+        <Timeline.Text>
+          This is a description of the error. I have no timestamp.
+        </Timeline.Text>
       </Timeline.Item>
       <Timeline.Item
         title={'Data'}
         icon={<IconDashboard size="xs" />}
-        timeString={now.toISOString()}
+        timestamp={
+          <Button size="xs" style={{marginBottom: 4}}>
+            Button Timestamp!
+          </Button>
+        }
         colorConfig={{
           primary: 'pink400',
           secondary: 'pink200',
@@ -172,10 +176,8 @@ export default storyBook('Timeline (Updated 06/17/24)', story => {
         </Timeline.Data>
       </Timeline.Item>
       <Timeline.Item
-        title={'Relative Event'}
+        title={'Another Event'}
         icon={<IconClock size="xs" />}
-        timeString={now.toISOString()}
-        startTimeString={before.toISOString()}
         colorConfig={{
           primary: 'purple400',
           secondary: 'purple200',
@@ -198,7 +200,6 @@ export default storyBook('Timeline (Updated 06/17/24)', story => {
         <Timeline.Item
           title={'Error'}
           icon={<IconFire size="xs" />}
-          timeString={now.toISOString()}
           colorConfig={{
             primary: 'red400',
             secondary: 'red200',
@@ -210,7 +211,7 @@ export default storyBook('Timeline (Updated 06/17/24)', story => {
         <Timeline.Item
           title={'HTTP'}
           icon={<IconSort rotated size="xs" />}
-          timeString={now.toISOString()}
+          timestamp={<DateTime date={now} />}
           colorConfig={{
             primary: 'green400',
             secondary: 'green200',
@@ -232,7 +233,7 @@ export default storyBook('Timeline (Updated 06/17/24)', story => {
         <Timeline.Item
           title={'UI Click'}
           icon={<IconCursorArrow size="xs" />}
-          timeString={now.toISOString()}
+          timestamp={<DateTime date={now} />}
           colorConfig={{
             primary: 'blue400',
             secondary: 'blue200',
@@ -244,7 +245,7 @@ export default storyBook('Timeline (Updated 06/17/24)', story => {
         <Timeline.Item
           title={'Sentry Event'}
           icon={<IconSentry size="xs" />}
-          timeString={now.toISOString()}
+          timestamp={<DateTime date={now} />}
           colorConfig={{
             primary: 'purple400',
             secondary: 'purple200',
@@ -270,4 +271,3 @@ const JSONPayload: Record<string, any> = {
 };
 
 const now = new Date();
-const before = new Date('2024-06-15');

--- a/static/app/components/timeline/index.tsx
+++ b/static/app/components/timeline/index.tsx
@@ -1,12 +1,9 @@
-import {type CSSProperties, useRef} from 'react';
+import type {CSSProperties} from 'react';
 import {forwardRef} from 'react';
 import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 
-import {Tooltip} from 'sentry/components/tooltip';
 import {space} from 'sentry/styles/space';
-import {defined} from 'sentry/utils';
-import {getFormattedTimestamp} from 'sentry/utils/date/getFormattedTimestamp';
 import type {Color} from 'sentry/utils/theme';
 
 export interface ColorConfig {
@@ -16,7 +13,7 @@ export interface ColorConfig {
 
 export interface TimelineItemProps {
   icon: React.ReactNode;
-  timeString: string;
+  timestamp: React.ReactNode;
   title: React.ReactNode;
   children?: React.ReactNode;
   className?: string;
@@ -25,11 +22,6 @@ export interface TimelineItemProps {
   onClick?: React.MouseEventHandler<HTMLDivElement>;
   onMouseEnter?: React.MouseEventHandler<HTMLDivElement>;
   onMouseLeave?: React.MouseEventHandler<HTMLDivElement>;
-  renderTimestamp?: (
-    timeString: TimelineItemProps['timeString'],
-    startTimeString: TimelineItemProps['startTimeString']
-  ) => React.ReactNode;
-  startTimeString?: string;
   style?: CSSProperties;
 }
 
@@ -38,10 +30,8 @@ export const Item = forwardRef(function _Item(
     title,
     children,
     icon,
-    timeString,
     colorConfig = {primary: 'gray300', secondary: 'gray200'},
-    startTimeString,
-    renderTimestamp,
+    timestamp,
     isActive = false,
     style,
     ...props
@@ -49,17 +39,7 @@ export const Item = forwardRef(function _Item(
   ref: React.ForwardedRef<HTMLDivElement>
 ) {
   const theme = useTheme();
-  const placeholderTime = useRef(new Date().toTimeString()).current;
   const {primary, secondary} = colorConfig;
-  const hasRelativeTime = defined(startTimeString);
-  const {
-    displayTime,
-    date,
-    timeWithMilliseconds: preciseTime,
-  } = hasRelativeTime
-    ? getFormattedTimestamp(timeString, startTimeString, true)
-    : getFormattedTimestamp(timeString, placeholderTime);
-
   return (
     <Row
       color={secondary}
@@ -80,15 +60,7 @@ export const Item = forwardRef(function _Item(
         {icon}
       </IconWrapper>
       <Title style={{color: theme[primary]}}>{title}</Title>
-      {renderTimestamp ? (
-        renderTimestamp(timeString, startTimeString)
-      ) : (
-        <Timestamp>
-          <Tooltip title={`${preciseTime} - ${date}`} skipWrapper>
-            {displayTime}
-          </Tooltip>
-        </Timestamp>
-      )}
+      {timestamp ?? <div />}
       <Spacer
         style={{borderLeft: `1px solid ${isActive ? theme.border : 'transparent'}`}}
       />
@@ -137,13 +109,6 @@ const Title = styled('div')`
   text-align: left;
   grid-column: span 1;
   font-size: ${p => p.theme.fontSizeMedium};
-`;
-
-const Timestamp = styled('div')`
-  margin: 0 ${space(1)};
-  color: ${p => p.theme.subText};
-  text-decoration: underline dashed ${p => p.theme.subText};
-  font-size: ${p => p.theme.fontSizeSmall};
 `;
 
 const Spacer = styled('div')`

--- a/static/app/components/timeline/index.tsx
+++ b/static/app/components/timeline/index.tsx
@@ -13,7 +13,6 @@ export interface ColorConfig {
 
 export interface TimelineItemProps {
   icon: React.ReactNode;
-  timestamp: React.ReactNode;
   title: React.ReactNode;
   children?: React.ReactNode;
   className?: string;
@@ -23,6 +22,7 @@ export interface TimelineItemProps {
   onMouseEnter?: React.MouseEventHandler<HTMLDivElement>;
   onMouseLeave?: React.MouseEventHandler<HTMLDivElement>;
   style?: CSSProperties;
+  timestamp?: React.ReactNode;
 }
 
 export const Item = forwardRef(function _Item(

--- a/static/app/components/timeline/index.tsx
+++ b/static/app/components/timeline/index.tsx
@@ -75,6 +75,7 @@ export const Item = forwardRef(function _Item(
           borderColor: isActive ? theme[secondary] : 'transparent',
           color: theme[primary],
         }}
+        className="icon-wrapper"
       >
         {icon}
       </IconWrapper>

--- a/static/app/components/timeline/index.tsx
+++ b/static/app/components/timeline/index.tsx
@@ -79,11 +79,15 @@ export const Item = forwardRef(function _Item(
         {icon}
       </IconWrapper>
       <Title style={{color: theme[primary]}}>{title}</Title>
-      <Timestamp>
-        <Tooltip title={`${preciseTime} - ${date}`} skipWrapper>
-          {renderTimestamp ? renderTimestamp(timeString, startTimeString) : displayTime}
-        </Tooltip>
-      </Timestamp>
+      {renderTimestamp ? (
+        renderTimestamp(timeString, startTimeString)
+      ) : (
+        <Timestamp>
+          <Tooltip title={`${preciseTime} - ${date}`} skipWrapper>
+            {displayTime}
+          </Tooltip>
+        </Timestamp>
+      )}
       <Spacer
         style={{borderLeft: `1px solid ${isActive ? theme.border : 'transparent'}`}}
       />
@@ -134,10 +138,11 @@ const Title = styled('div')`
   font-size: ${p => p.theme.fontSizeMedium};
 `;
 
-const Timestamp = styled('p')`
+const Timestamp = styled('div')`
   margin: 0 ${space(1)};
   color: ${p => p.theme.subText};
   text-decoration: underline dashed ${p => p.theme.subText};
+  font-size: ${p => p.theme.fontSizeSmall};
 `;
 
 const Spacer = styled('div')`

--- a/static/app/types/breadcrumbs.tsx
+++ b/static/app/types/breadcrumbs.tsx
@@ -27,6 +27,8 @@ export enum BreadcrumbType {
   SESSION = 'session',
   TRANSACTION = 'transaction',
   INIT = 'init',
+  NETWORK = 'network',
+  DEVICE = 'device',
 }
 
 export enum BreadcrumbMessageFormat {

--- a/static/app/utils/duration/getExactDuration.spec.tsx
+++ b/static/app/utils/duration/getExactDuration.spec.tsx
@@ -17,13 +17,13 @@ describe('getExactDuration', () => {
   });
 
   it('should format negative durations', () => {
-    expect(getExactDuration(-2.030043848568126)).toEqual('-2 seconds -30 milliseconds');
+    expect(getExactDuration(-2.030043848568126)).toEqual('-2 seconds 30 milliseconds');
     expect(getExactDuration(-0.2)).toEqual('-200 milliseconds');
     expect(getExactDuration(-13)).toEqual('-13 seconds');
     expect(getExactDuration(-60)).toEqual('-1 minute');
-    expect(getExactDuration(-121)).toEqual('-2 minutes -1 second');
+    expect(getExactDuration(-121)).toEqual('-2 minutes 1 second');
     expect(getExactDuration(-234235435)).toEqual(
-      '-387 weeks -2 days -1 hour -23 minutes -55 seconds'
+      '-387 weeks 2 days 1 hour 23 minutes 55 seconds'
     );
   });
 

--- a/static/app/utils/duration/getExactDuration.tsx
+++ b/static/app/utils/duration/getExactDuration.tsx
@@ -18,7 +18,7 @@ const SUFFIX_ABBR = {
  * Returns a human readable exact duration.
  * 'precision' arg will truncate the results to the specified suffix
  *
- * e.g. 1 hour 25 minutes 15 seconds
+ * e.g. 1 hour 25 minutes 15 seconds, -1m 50s 294ms
  */
 export function getExactDuration(
   seconds: number,
@@ -35,7 +35,8 @@ export function getExactDuration(
     const divideBy = (time: number) => {
       return {
         quotient: msValue < 0 ? Math.ceil(msValue / time) : Math.floor(msValue / time),
-        remainder: msValue % time,
+        // Remainder should always be positive so that only largest unit appears negative
+        remainder: Math.abs(msValue % time),
       };
     };
 


### PR DESCRIPTION
Lots of fixes here:

- Clicking the icon from issue details will show some focus styles for the control. Currently we cant open the menu as the tooltip will be incorrectly positioned as it tries to appear while the drawer is animating onto the page. For now it at least draws attention to the correct part of the drawer.

<img width="201" alt="focus icon" src="https://github.com/getsentry/sentry/assets/35509934/4bd3d957-91b6-445f-9b9c-c64dcab9e413">


- The default crumbs have a new icon

<img width="478" alt="new default icon" src="https://github.com/getsentry/sentry/assets/35509934/b43bf3ce-0c8f-4cfb-907f-4e8ad2a68f6c">

- The replay colors match those chosen for issues.

<img width="1054" alt="replay colors and time" src="https://github.com/getsentry/sentry/assets/35509934/324cd9f9-e450-4639-ad7b-c67b5ce018e1">

- HTTP items will fully expand by default in the drawer

<img width="414" alt="expand http items" src="https://github.com/getsentry/sentry/assets/35509934/06a53e21-2841-46b6-8c2c-2e3f22a3a19c">

- The header is sticky and now contains the nav crumbs in it

<img width="956" alt="custom sticky header" src="https://github.com/getsentry/sentry/assets/35509934/21e9b5e2-9864-43ce-985d-9fd43ab0da7a">

- There is no excess space/line on the breadcrumb list for longer entries anymore

<img width="388" alt="no excess line on breadcrumb list" src="https://github.com/getsentry/sentry/assets/35509934/2aeed8a3-5dd3-4578-9ca0-8e0405591ea4">

-  The display time icon changes when toggled.

<img width="313" alt="relative icon" src="https://github.com/getsentry/sentry/assets/35509934/1973040f-bd17-4dfc-b1da-7cc033c90efb">

- [Update] More accurate timestamps that respect user preferences (for 24h clocks, and timezone)

<img width="690" alt="timestamps" src="https://github.com/getsentry/sentry/assets/35509934/8994536b-d490-4ff4-b9a8-ecc2f1647cf5">
