### PR TITLE
fix(replay): skip replay count query if no projects specified

### DIFF
--- a/src/sentry/replays/usecases/replay_counts.py
+++ b/src/sentry/replays/usecases/replay_counts.py
@@ -101,10 +101,9 @@ def _get_replay_id_mappings(
             snuba_params,
             projects=[group.project for group in groups],
         )
-
-    # Saves a snuba query. Discover queries raise an error if projects is empty.
-    if not snuba_params.projects:
-        return {}
+        # Discover queries raise an error if projects is empty, so we skip Snuba in this case.
+        if not snuba_params.projects:
+            return {}
 
     results = search_query_func(
         params={},

--- a/src/sentry/replays/usecases/replay_counts.py
+++ b/src/sentry/replays/usecases/replay_counts.py
@@ -102,6 +102,10 @@ def _get_replay_id_mappings(
             projects=[group.project for group in groups],
         )
 
+    # Saves a snuba query. Discover queries raise an error if projects is empty.
+    if not snuba_params.projects:
+        return {}
+
     results = search_query_func(
         params={},
         snuba_params=snuba_params,


### PR DESCRIPTION
Fixes [SENTRY-38FG](https://sentry.sentry.io/issues/5255562353/). There's an edge case where the optimization in `_get_replay_id_mappings` results in empty projects.