### PR TITLE
feat(web-vitals): change browser dropdown to multiselect

### DIFF
--- a/static/app/utils/analytics/insightAnalyticEvents.tsx
+++ b/static/app/utils/analytics/insightAnalyticEvents.tsx
@@ -33,7 +33,7 @@ export type InsightEventParameters = {
   'insight.vital.overview.open_transaction_summary': {};
   'insight.vital.overview.toggle_data_type': {type: string};
   'insight.vital.overview.toggle_tab': {tab: string};
-  'insight.vital.select_browser_value': {browser: string};
+  'insight.vital.select_browser_value': {browsers: string[]};
   'insight.vital.vital_sidebar_opened': {vital: string};
 };
 

--- a/static/app/utils/tokenizeSearch.tsx
+++ b/static/app/utils/tokenizeSearch.tsx
@@ -203,6 +203,26 @@ export class MutableSearch {
     return this;
   }
 
+  /**
+   * Adds the filter values separated by OR operators. This is in contrast to
+   * addFilterValues, which implicitly separates each filter value with an AND operator.
+   */
+  addDisjunctionFilterValues(key: string, values: string[], shouldEscape = true) {
+    if (values.length === 0) {
+      return this;
+    }
+
+    this.addOp('(');
+    for (let i = 0; i < values.length; i++) {
+      if (i > 0) {
+        this.addOp('OR');
+      }
+      this.addFilterValue(key, values[i], shouldEscape);
+    }
+    this.addOp(')');
+    return this;
+  }
+
   addFilterValue(key: string, value: string, shouldEscape = true) {
     // Filter values that we insert through the UI can contain special characters
     // that need to escaped. User entered filters should not be escaped.

--- a/static/app/views/insights/browser/webVitals/components/browserTypeSelector.tsx
+++ b/static/app/views/insights/browser/webVitals/components/browserTypeSelector.tsx
@@ -1,22 +1,21 @@
 import styled from '@emotion/styled';
 
-import {CompactSelect} from 'sentry/components/compactSelect';
+import {CompactSelect, type SelectOption} from 'sentry/components/compactSelect';
 import ContextIcon from 'sentry/components/events/contexts/contextIcon';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {browserHistory} from 'sentry/utils/browserHistory';
+import {decodeList} from 'sentry/utils/queryString';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
-import decodeBrowserType, {
-  BrowserType,
-} from 'sentry/views/insights/browser/webVitals/utils/queryParameterDecoders/browserType';
+import {BrowserType} from 'sentry/views/insights/browser/webVitals/utils/queryParameterDecoders/browserType';
 import {SpanIndexedField} from 'sentry/views/insights/types';
 
 const LabelContainer = styled('div')`
   display: flex;
   gap: ${space(1)};
-  min-width: 130px;
+  width: max-content;
 `;
 
 function optionToLabel(iconName: string, labelValue: string): React.ReactNode {
@@ -29,41 +28,76 @@ function optionToLabel(iconName: string, labelValue: string): React.ReactNode {
 }
 
 const browserOptions = [
-  {value: '', label: t('All')},
-  {value: BrowserType.CHROME, label: optionToLabel('chrome', 'Chrome')},
-  {value: BrowserType.SAFARI, label: optionToLabel('safari', 'Safari')},
-  {value: BrowserType.FIREFOX, label: optionToLabel('firefox', 'Firefox')},
-  {value: BrowserType.OPERA, label: optionToLabel('opera', 'Opera')},
-  {value: BrowserType.EDGE, label: optionToLabel('edge', 'Edge')},
-
-  {value: BrowserType.CHROME_MOBILE, label: optionToLabel('chrome', 'Chrome Mobile')},
-  {value: BrowserType.SAFARI_MOBILE, label: optionToLabel('safari', 'Safari Mobile')},
-  {value: BrowserType.FIREFOX_MOBILE, label: optionToLabel('firefox', 'Firefox Mobile')},
-  {value: BrowserType.OPERA_MOBILE, label: optionToLabel('opera', 'Opera Mobile')},
-  {value: BrowserType.EDGE_MOBILE, label: optionToLabel('edge', 'Edge Mobile')},
+  {
+    value: BrowserType.CHROME,
+    label: optionToLabel('chrome', 'Chrome'),
+    textValue: 'Chrome',
+  },
+  {
+    value: BrowserType.SAFARI,
+    label: optionToLabel('safari', 'Safari'),
+    textValue: 'Safari',
+  },
+  {
+    value: BrowserType.FIREFOX,
+    label: optionToLabel('firefox', 'Firefox'),
+    textValue: 'Firefox',
+  },
+  {value: BrowserType.OPERA, label: optionToLabel('opera', 'Opera'), textValue: 'Opera'},
+  {value: BrowserType.EDGE, label: optionToLabel('edge', 'Edge'), textValue: 'Edge'},
+  {
+    value: BrowserType.CHROME_MOBILE,
+    label: optionToLabel('chrome', 'Chrome Mobile'),
+    textValue: 'Chrome Mobile',
+  },
+  {
+    value: BrowserType.SAFARI_MOBILE,
+    label: optionToLabel('safari', 'Safari Mobile'),
+    textValue: 'Safari Mobile',
+  },
+  {
+    value: BrowserType.FIREFOX_MOBILE,
+    label: optionToLabel('firefox', 'Firefox Mobile'),
+    textValue: 'Firefox Mobile',
+  },
+  {
+    value: BrowserType.OPERA_MOBILE,
+    label: optionToLabel('opera', 'Opera Mobile'),
+    textValue: 'Opera Mobile',
+  },
+  {
+    value: BrowserType.EDGE_MOBILE,
+    label: optionToLabel('edge', 'Edge Mobile'),
+    textValue: 'Edge Mobile',
+  },
 ];
 
 export default function BrowserTypeSelector() {
   const organization = useOrganization();
   const location = useLocation();
 
-  const value = decodeBrowserType(location.query[SpanIndexedField.BROWSER_NAME]);
+  const value = decodeList(location.query[SpanIndexedField.BROWSER_NAME]);
 
   return (
     <CompactSelect
       triggerProps={{prefix: t('Browser Type')}}
+      multiple
+      clearable
       value={value}
+      triggerLabel={value.length === 0 ? 'All' : undefined}
+      menuTitle={'Filter Browsers'}
       options={browserOptions ?? []}
-      onChange={newValue => {
+      onChange={(selectedOptions: SelectOption<string>[]) => {
         trackAnalytics('insight.vital.select_browser_value', {
           organization,
-          browser: newValue.value,
+          browsers: selectedOptions.map(v => v.value),
         });
+
         browserHistory.push({
           ...location,
           query: {
             ...location.query,
-            [SpanIndexedField.BROWSER_NAME]: newValue.value,
+            [SpanIndexedField.BROWSER_NAME]: selectedOptions.map(option => option.value),
           },
         });
       }}

--- a/static/app/views/insights/browser/webVitals/components/charts/performanceScoreBreakdownChart.tsx
+++ b/static/app/views/insights/browser/webVitals/components/charts/performanceScoreBreakdownChart.tsx
@@ -20,7 +20,7 @@ import {useStaticWeightsSetting} from 'sentry/views/insights/browser/webVitals/u
 import Chart, {ChartType} from 'sentry/views/insights/common/components/chart';
 
 type Props = {
-  browserType?: BrowserType;
+  browserTypes?: BrowserType[];
   transaction?: string;
 };
 
@@ -46,16 +46,16 @@ export const formatTimeSeriesResultsToChartData = (
   });
 };
 
-export function PerformanceScoreBreakdownChart({transaction, browserType}: Props) {
+export function PerformanceScoreBreakdownChart({transaction, browserTypes}: Props) {
   const theme = useTheme();
   const segmentColors = [...theme.charts.getColorPalette(3).slice(0, 5)];
 
   const pageFilters = usePageFilters();
 
   const {data: timeseriesData, isLoading: isTimeseriesLoading} =
-    useProjectWebVitalsScoresTimeseriesQuery({transaction, browserType});
+    useProjectWebVitalsScoresTimeseriesQuery({transaction, browserTypes});
   const {data: projectScores, isLoading: isProjectScoresLoading} =
-    useProjectWebVitalsScoresQuery({transaction, browserType});
+    useProjectWebVitalsScoresQuery({transaction, browserTypes});
 
   const projectScore = isProjectScoresLoading
     ? undefined

--- a/static/app/views/insights/browser/webVitals/components/charts/performanceScoreChart.tsx
+++ b/static/app/views/insights/browser/webVitals/components/charts/performanceScoreChart.tsx
@@ -19,7 +19,7 @@ import type {
 import type {BrowserType} from 'sentry/views/insights/browser/webVitals/utils/queryParameterDecoders/browserType';
 
 type Props = {
-  browserType?: BrowserType;
+  browserTypes?: BrowserType[];
   isProjectScoreLoading?: boolean;
   projectScore?: ProjectScore;
   transaction?: string;
@@ -33,7 +33,7 @@ export function PerformanceScoreChart({
   webVital,
   transaction,
   isProjectScoreLoading,
-  browserType,
+  browserTypes,
 }: Props) {
   const theme = useTheme();
   const pageFilters = usePageFilters();
@@ -99,7 +99,7 @@ export function PerformanceScoreChart({
       </PerformanceScoreLabelContainer>
       <PerformanceScoreBreakdownChart
         transaction={transaction}
-        browserType={browserType}
+        browserTypes={browserTypes}
       />
     </Flex>
   );

--- a/static/app/views/insights/browser/webVitals/components/pageOverviewSidebar.tsx
+++ b/static/app/views/insights/browser/webVitals/components/pageOverviewSidebar.tsx
@@ -28,7 +28,7 @@ const CHART_HEIGHTS = 100;
 
 type Props = {
   transaction: string;
-  browserType?: BrowserType;
+  browserTypes?: BrowserType[];
   projectScore?: ProjectScore;
   projectScoreIsLoading?: boolean;
   search?: string;
@@ -38,7 +38,7 @@ export function PageOverviewSidebar({
   projectScore,
   transaction,
   projectScoreIsLoading,
-  browserType,
+  browserTypes,
 }: Props) {
   const theme = useTheme();
   const router = useRouter();
@@ -61,7 +61,7 @@ export function PageOverviewSidebar({
   const {data, isLoading: isLoading} = useProjectRawWebVitalsValuesTimeseriesQuery({
     transaction,
     datetime: doubledDatetime,
-    browserType,
+    browserTypes,
   });
 
   const {countDiff, currentSeries, currentCount, initialCount} = processSeriesData(

--- a/static/app/views/insights/browser/webVitals/components/pageOverviewWebVitalsDetailPanel.tsx
+++ b/static/app/views/insights/browser/webVitals/components/pageOverviewWebVitalsDetailPanel.tsx
@@ -36,7 +36,7 @@ import type {
   TransactionSampleRowWithScore,
   WebVitals,
 } from 'sentry/views/insights/browser/webVitals/types';
-import decodeBrowserType from 'sentry/views/insights/browser/webVitals/utils/queryParameterDecoders/browserType';
+import decodeBrowserTypes from 'sentry/views/insights/browser/webVitals/utils/queryParameterDecoders/browserType';
 import useProfileExists from 'sentry/views/insights/browser/webVitals/utils/useProfileExists';
 import DetailPanel from 'sentry/views/insights/common/components/detailPanel';
 import {SpanIndexedField} from 'sentry/views/insights/types';
@@ -88,7 +88,7 @@ export function PageOverviewWebVitalsDetailPanel({
   const routes = useRoutes();
   const {replayExists} = useReplayExists();
 
-  const browserType = decodeBrowserType(location.query[SpanIndexedField.BROWSER_NAME]);
+  const browserTypes = decodeBrowserTypes(location.query[SpanIndexedField.BROWSER_NAME]);
   const isInp = webVital === 'inp';
 
   const replayLinkGenerator = generateReplayLink(routes);
@@ -104,11 +104,11 @@ export function PageOverviewWebVitalsDetailPanel({
       : location.query.transaction
     : undefined;
 
-  const {data: projectData} = useProjectRawWebVitalsQuery({transaction, browserType});
+  const {data: projectData} = useProjectRawWebVitalsQuery({transaction, browserTypes});
   const {data: projectScoresData} = useProjectWebVitalsScoresQuery({
     weightWebVital: webVital ?? 'total',
     transaction,
-    browserType,
+    browserTypes,
   });
 
   const projectScore = calculatePerformanceScoreFromStoredTableDataRow(
@@ -120,14 +120,14 @@ export function PageOverviewWebVitalsDetailPanel({
       transaction: transaction ?? '',
       webVital,
       enabled: Boolean(webVital) && !isInp,
-      browserType,
+      browserTypes,
     });
 
   const {data: inpTableData, isLoading: isInteractionsLoading} =
     useInteractionsCategorizedSamplesQuery({
       transaction: transaction ?? '',
       enabled: Boolean(webVital) && isInp,
-      browserType,
+      browserTypes,
     });
 
   const {profileExists} = useProfileExists(
@@ -135,7 +135,7 @@ export function PageOverviewWebVitalsDetailPanel({
   );
 
   const {data: timeseriesData, isLoading: isTimeseriesLoading} =
-    useProjectRawWebVitalsValuesTimeseriesQuery({transaction, browserType});
+    useProjectRawWebVitalsValuesTimeseriesQuery({transaction, browserTypes});
 
   const webVitalData: LineChartSeries = {
     data:

--- a/static/app/views/insights/browser/webVitals/components/tables/pagePerformanceTable.tsx
+++ b/static/app/views/insights/browser/webVitals/components/tables/pagePerformanceTable.tsx
@@ -32,7 +32,7 @@ import {useTransactionWebVitalsScoresQuery} from 'sentry/views/insights/browser/
 import {MODULE_DOC_LINK} from 'sentry/views/insights/browser/webVitals/settings';
 import type {RowWithScoreAndOpportunity} from 'sentry/views/insights/browser/webVitals/types';
 import {SORTABLE_FIELDS} from 'sentry/views/insights/browser/webVitals/types';
-import decodeBrowserType from 'sentry/views/insights/browser/webVitals/utils/queryParameterDecoders/browserType';
+import decodeBrowserTypes from 'sentry/views/insights/browser/webVitals/utils/queryParameterDecoders/browserType';
 import {useStaticWeightsSetting} from 'sentry/views/insights/browser/webVitals/utils/useStaticWeightsSetting';
 import {useWebVitalsSort} from 'sentry/views/insights/browser/webVitals/utils/useWebVitalsSort';
 import {ModuleName, SpanIndexedField} from 'sentry/views/insights/types';
@@ -71,7 +71,7 @@ export function PagePerformanceTable() {
   const columnOrder = COLUMN_ORDER;
 
   const query = decodeScalar(location.query.query, '');
-  const browserType = decodeBrowserType(location.query[SpanIndexedField.BROWSER_NAME]);
+  const browserTypes = decodeBrowserTypes(location.query[SpanIndexedField.BROWSER_NAME]);
 
   const project = useMemo(
     () => projects.find(p => p.id === String(location.query.project)),
@@ -80,7 +80,7 @@ export function PagePerformanceTable() {
 
   const sort = useWebVitalsSort({defaultSort: DEFAULT_SORT});
   const {data: projectScoresData, isLoading: isProjectScoresLoading} =
-    useProjectWebVitalsScoresQuery({browserType});
+    useProjectWebVitalsScoresQuery({browserTypes});
 
   const {
     data,
@@ -91,7 +91,7 @@ export function PagePerformanceTable() {
     transaction: query !== '' ? `*${escapeFilterValue(query)}*` : undefined,
     defaultSort: DEFAULT_SORT,
     shouldEscapeFilters: false,
-    browserType,
+    browserTypes,
   });
 
   const scoreCount = projectScoresData?.data?.[0]?.[

--- a/static/app/views/insights/browser/webVitals/components/tables/pageSamplePerformanceTable.tsx
+++ b/static/app/views/insights/browser/webVitals/components/tables/pageSamplePerformanceTable.tsx
@@ -43,7 +43,7 @@ import {
   DEFAULT_INDEXED_SORT,
   SORTABLE_INDEXED_FIELDS,
 } from 'sentry/views/insights/browser/webVitals/types';
-import decodeBrowserType from 'sentry/views/insights/browser/webVitals/utils/queryParameterDecoders/browserType';
+import decodeBrowserTypes from 'sentry/views/insights/browser/webVitals/utils/queryParameterDecoders/browserType';
 import useProfileExists from 'sentry/views/insights/browser/webVitals/utils/useProfileExists';
 import {useWebVitalsSort} from 'sentry/views/insights/browser/webVitals/utils/useWebVitalsSort';
 import {SpanIndexedField} from 'sentry/views/insights/types';
@@ -101,7 +101,7 @@ export function PageSamplePerformanceTable({transaction, search, limit = 9}: Pro
   const routes = useRoutes();
   const router = useRouter();
 
-  const browserType = decodeBrowserType(location.query[SpanIndexedField.BROWSER_NAME]);
+  const browserTypes = decodeBrowserTypes(location.query[SpanIndexedField.BROWSER_NAME]);
   let datatype = Datatype.PAGELOADS;
   switch (decodeScalar(location.query[DATATYPE_KEY], 'pageloads')) {
     case 'interactions':
@@ -137,7 +137,7 @@ export function PageSamplePerformanceTable({transaction, search, limit = 9}: Pro
     query: search,
     withProfiles: true,
     enabled: datatype === Datatype.PAGELOADS,
-    browserType,
+    browserTypes,
   });
 
   const {
@@ -149,7 +149,7 @@ export function PageSamplePerformanceTable({transaction, search, limit = 9}: Pro
     enabled: datatype === Datatype.INTERACTIONS,
     limit,
     filters: new MutableSearch(query ?? '').filters,
-    browserType,
+    browserTypes,
   });
 
   const {profileExists} = useProfileExists(

--- a/static/app/views/insights/browser/webVitals/components/webVitalsDetailPanel.tsx
+++ b/static/app/views/insights/browser/webVitals/components/webVitalsDetailPanel.tsx
@@ -32,7 +32,7 @@ import type {
   RowWithScoreAndOpportunity,
   WebVitals,
 } from 'sentry/views/insights/browser/webVitals/types';
-import decodeBrowserType from 'sentry/views/insights/browser/webVitals/utils/queryParameterDecoders/browserType';
+import decodeBrowserTypes from 'sentry/views/insights/browser/webVitals/utils/queryParameterDecoders/browserType';
 import DetailPanel from 'sentry/views/insights/common/components/detailPanel';
 import {SpanIndexedField} from 'sentry/views/insights/types';
 
@@ -59,12 +59,12 @@ export function WebVitalsDetailPanel({
 }) {
   const location = useLocation();
   const organization = useOrganization();
-  const browserType = decodeBrowserType(location.query[SpanIndexedField.BROWSER_NAME]);
+  const browserTypes = decodeBrowserTypes(location.query[SpanIndexedField.BROWSER_NAME]);
 
-  const {data: projectData} = useProjectRawWebVitalsQuery({browserType});
+  const {data: projectData} = useProjectRawWebVitalsQuery({browserTypes});
   const {data: projectScoresData} = useProjectWebVitalsScoresQuery({
     weightWebVital: webVital ?? 'total',
-    browserType,
+    browserTypes,
   });
 
   const projectScore = calculatePerformanceScoreFromStoredTableDataRow(
@@ -84,7 +84,7 @@ export function WebVitalsDetailPanel({
       : {}),
     enabled: webVital !== null,
     sortName: 'webVitalsDetailPanelSort',
-    browserType,
+    browserTypes,
   });
 
   const dataByOpportunity = useMemo(() => {
@@ -116,7 +116,7 @@ export function WebVitalsDetailPanel({
   }, [data, projectScoresData?.data, webVital]);
 
   const {data: timeseriesData, isLoading: isTimeseriesLoading} =
-    useProjectRawWebVitalsValuesTimeseriesQuery({browserType});
+    useProjectRawWebVitalsValuesTimeseriesQuery({browserTypes});
 
   const webVitalData: LineChartSeries = {
     data:

--- a/static/app/views/insights/browser/webVitals/queries/rawWebVitalsQueries/useProjectRawWebVitalsQuery.tsx
+++ b/static/app/views/insights/browser/webVitals/queries/rawWebVitalsQueries/useProjectRawWebVitalsQuery.tsx
@@ -7,11 +7,11 @@ import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import {DEFAULT_QUERY_FILTER} from 'sentry/views/insights/browser/webVitals/settings';
-import {BrowserType} from 'sentry/views/insights/browser/webVitals/utils/queryParameterDecoders/browserType';
+import type {BrowserType} from 'sentry/views/insights/browser/webVitals/utils/queryParameterDecoders/browserType';
 import {SpanIndexedField} from 'sentry/views/insights/types';
 
 type Props = {
-  browserType?: BrowserType;
+  browserTypes?: BrowserType[];
   dataset?: DiscoverDatasets;
   tag?: Tag;
   transaction?: string;
@@ -21,7 +21,7 @@ export const useProjectRawWebVitalsQuery = ({
   transaction,
   tag,
   dataset,
-  browserType,
+  browserTypes,
 }: Props = {}) => {
   const organization = useOrganization();
   const pageFilters = usePageFilters();
@@ -33,8 +33,8 @@ export const useProjectRawWebVitalsQuery = ({
   if (tag) {
     search.addFilterValue(tag.key, tag.name);
   }
-  if (browserType !== undefined && browserType !== BrowserType.ALL) {
-    search.addFilterValue(SpanIndexedField.BROWSER_NAME, browserType);
+  if (browserTypes) {
+    search.addDisjunctionFilterValues(SpanIndexedField.BROWSER_NAME, browserTypes);
   }
 
   const projectEventView = EventView.fromNewQueryWithPageFilters(

--- a/static/app/views/insights/browser/webVitals/queries/rawWebVitalsQueries/useProjectRawWebVitalsValuesTimeseriesQuery.tsx
+++ b/static/app/views/insights/browser/webVitals/queries/rawWebVitalsQueries/useProjectRawWebVitalsValuesTimeseriesQuery.tsx
@@ -11,11 +11,11 @@ import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import {DEFAULT_QUERY_FILTER} from 'sentry/views/insights/browser/webVitals/settings';
-import {BrowserType} from 'sentry/views/insights/browser/webVitals/utils/queryParameterDecoders/browserType';
+import type {BrowserType} from 'sentry/views/insights/browser/webVitals/utils/queryParameterDecoders/browserType';
 import {SpanIndexedField} from 'sentry/views/insights/types';
 
 type Props = {
-  browserType?: BrowserType;
+  browserTypes?: BrowserType[];
   datetime?: PageFilters['datetime'];
   transaction?: string | null;
 };
@@ -23,7 +23,7 @@ type Props = {
 export const useProjectRawWebVitalsValuesTimeseriesQuery = ({
   transaction,
   datetime,
-  browserType,
+  browserTypes,
 }: Props) => {
   const pageFilters = usePageFilters();
   const location = useLocation();
@@ -32,8 +32,8 @@ export const useProjectRawWebVitalsValuesTimeseriesQuery = ({
   if (transaction) {
     search.addFilterValue('transaction', transaction);
   }
-  if (browserType !== undefined && browserType !== BrowserType.ALL) {
-    search.addFilterValue(SpanIndexedField.BROWSER_NAME, browserType);
+  if (browserTypes) {
+    search.addDisjunctionFilterValues(SpanIndexedField.BROWSER_NAME, browserTypes);
   }
   const projectTimeSeriesEventView = EventView.fromNewQueryWithPageFilters(
     {

--- a/static/app/views/insights/browser/webVitals/queries/storedScoreQueries/useProjectWebVitalsScoresQuery.tsx
+++ b/static/app/views/insights/browser/webVitals/queries/storedScoreQueries/useProjectWebVitalsScoresQuery.tsx
@@ -8,12 +8,12 @@ import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import {DEFAULT_QUERY_FILTER} from 'sentry/views/insights/browser/webVitals/settings';
 import type {WebVitals} from 'sentry/views/insights/browser/webVitals/types';
-import {BrowserType} from 'sentry/views/insights/browser/webVitals/utils/queryParameterDecoders/browserType';
+import type {BrowserType} from 'sentry/views/insights/browser/webVitals/utils/queryParameterDecoders/browserType';
 import {useStaticWeightsSetting} from 'sentry/views/insights/browser/webVitals/utils/useStaticWeightsSetting';
 import {SpanIndexedField} from 'sentry/views/insights/types';
 
 type Props = {
-  browserType?: BrowserType;
+  browserTypes?: BrowserType[];
   dataset?: DiscoverDatasets;
   enabled?: boolean;
   tag?: Tag;
@@ -27,7 +27,7 @@ export const useProjectWebVitalsScoresQuery = ({
   dataset,
   enabled = true,
   weightWebVital = 'total',
-  browserType,
+  browserTypes,
 }: Props = {}) => {
   const organization = useOrganization();
   const pageFilters = usePageFilters();
@@ -41,8 +41,8 @@ export const useProjectWebVitalsScoresQuery = ({
   if (tag) {
     search.addFilterValue(tag.key, tag.name);
   }
-  if (browserType !== undefined && browserType !== BrowserType.ALL) {
-    search.addFilterValue(SpanIndexedField.BROWSER_NAME, browserType);
+  if (browserTypes) {
+    search.addDisjunctionFilterValues(SpanIndexedField.BROWSER_NAME, browserTypes);
   }
 
   const projectEventView = EventView.fromNewQueryWithPageFilters(

--- a/static/app/views/insights/browser/webVitals/queries/storedScoreQueries/useProjectWebVitalsScoresTimeseriesQuery.tsx
+++ b/static/app/views/insights/browser/webVitals/queries/storedScoreQueries/useProjectWebVitalsScoresTimeseriesQuery.tsx
@@ -11,11 +11,11 @@ import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import {DEFAULT_QUERY_FILTER} from 'sentry/views/insights/browser/webVitals/settings';
-import {BrowserType} from 'sentry/views/insights/browser/webVitals/utils/queryParameterDecoders/browserType';
+import type {BrowserType} from 'sentry/views/insights/browser/webVitals/utils/queryParameterDecoders/browserType';
 import {SpanIndexedField} from 'sentry/views/insights/types';
 
 type Props = {
-  browserType?: BrowserType;
+  browserTypes?: BrowserType[];
   enabled?: boolean;
   tag?: Tag;
   transaction?: string | null;
@@ -43,7 +43,7 @@ export const useProjectWebVitalsScoresTimeseriesQuery = ({
   transaction,
   tag,
   enabled = true,
-  browserType,
+  browserTypes,
 }: Props) => {
   const pageFilters = usePageFilters();
   const location = useLocation();
@@ -55,8 +55,8 @@ export const useProjectWebVitalsScoresTimeseriesQuery = ({
   if (transaction) {
     search.addFilterValue('transaction', transaction);
   }
-  if (browserType !== undefined && browserType !== BrowserType.ALL) {
-    search.addFilterValue(SpanIndexedField.BROWSER_NAME, browserType);
+  if (browserTypes) {
+    search.addDisjunctionFilterValues(SpanIndexedField.BROWSER_NAME, browserTypes);
   }
   const projectTimeSeriesEventView = EventView.fromNewQueryWithPageFilters(
     {

--- a/static/app/views/insights/browser/webVitals/queries/storedScoreQueries/useTransactionSamplesWebVitalsScoresQuery.tsx
+++ b/static/app/views/insights/browser/webVitals/queries/storedScoreQueries/useTransactionSamplesWebVitalsScoresQuery.tsx
@@ -15,13 +15,13 @@ import {
   SORTABLE_INDEXED_FIELDS,
 } from 'sentry/views/insights/browser/webVitals/types';
 import {mapWebVitalToOrderBy} from 'sentry/views/insights/browser/webVitals/utils/mapWebVitalToOrderBy';
-import {BrowserType} from 'sentry/views/insights/browser/webVitals/utils/queryParameterDecoders/browserType';
+import type {BrowserType} from 'sentry/views/insights/browser/webVitals/utils/queryParameterDecoders/browserType';
 import {useWebVitalsSort} from 'sentry/views/insights/browser/webVitals/utils/useWebVitalsSort';
 import {SpanIndexedField} from 'sentry/views/insights/types';
 
 type Props = {
   transaction: string;
-  browserType?: BrowserType;
+  browserTypes?: BrowserType[];
   enabled?: boolean;
   limit?: number;
   orderBy?: WebVitals | null;
@@ -40,7 +40,7 @@ export const useTransactionSamplesWebVitalsScoresQuery = ({
   withProfiles,
   sortName,
   webVital,
-  browserType,
+  browserTypes,
 }: Props) => {
   const organization = useOrganization();
   const pageFilters = usePageFilters();
@@ -61,8 +61,8 @@ export const useTransactionSamplesWebVitalsScoresQuery = ({
   if (query) {
     mutableSearch.addStringMultiFilter(query);
   }
-  if (browserType !== undefined && browserType !== BrowserType.ALL) {
-    mutableSearch.addFilterValue(SpanIndexedField.BROWSER_NAME, browserType);
+  if (browserTypes) {
+    mutableSearch.addDisjunctionFilterValues(SpanIndexedField.BROWSER_NAME, browserTypes);
   }
 
   const eventView = EventView.fromNewQueryWithPageFilters(

--- a/static/app/views/insights/browser/webVitals/queries/storedScoreQueries/useTransactionWebVitalsScoresQuery.tsx
+++ b/static/app/views/insights/browser/webVitals/queries/storedScoreQueries/useTransactionWebVitalsScoresQuery.tsx
@@ -12,13 +12,13 @@ import type {
   RowWithScoreAndOpportunity,
   WebVitals,
 } from 'sentry/views/insights/browser/webVitals/types';
-import {BrowserType} from 'sentry/views/insights/browser/webVitals/utils/queryParameterDecoders/browserType';
+import type {BrowserType} from 'sentry/views/insights/browser/webVitals/utils/queryParameterDecoders/browserType';
 import {useStaticWeightsSetting} from 'sentry/views/insights/browser/webVitals/utils/useStaticWeightsSetting';
 import {useWebVitalsSort} from 'sentry/views/insights/browser/webVitals/utils/useWebVitalsSort';
 import {SpanIndexedField} from 'sentry/views/insights/types';
 
 type Props = {
-  browserType?: BrowserType;
+  browserTypes?: BrowserType[];
   defaultSort?: Sort;
   enabled?: boolean;
   limit?: number;
@@ -38,7 +38,7 @@ export const useTransactionWebVitalsScoresQuery = ({
   webVital = 'total',
   query,
   shouldEscapeFilters = true,
-  browserType,
+  browserTypes,
 }: Props) => {
   const organization = useOrganization();
   const pageFilters = usePageFilters();
@@ -62,8 +62,8 @@ export const useTransactionWebVitalsScoresQuery = ({
   if (transaction) {
     search.addFilterValue('transaction', transaction, shouldEscapeFilters);
   }
-  if (browserType !== undefined && browserType !== BrowserType.ALL) {
-    search.addFilterValue(SpanIndexedField.BROWSER_NAME, browserType);
+  if (browserTypes) {
+    search.addDisjunctionFilterValues(SpanIndexedField.BROWSER_NAME, browserTypes);
   }
   const eventView = EventView.fromNewQueryWithPageFilters(
     {

--- a/static/app/views/insights/browser/webVitals/queries/useInpSpanSamplesWebVitalsQuery.tsx
+++ b/static/app/views/insights/browser/webVitals/queries/useInpSpanSamplesWebVitalsQuery.tsx
@@ -4,7 +4,7 @@ import {
   type InteractionSpanSampleRowWithScore,
   SORTABLE_INDEXED_INTERACTION_FIELDS,
 } from 'sentry/views/insights/browser/webVitals/types';
-import {BrowserType} from 'sentry/views/insights/browser/webVitals/utils/queryParameterDecoders/browserType';
+import type {BrowserType} from 'sentry/views/insights/browser/webVitals/utils/queryParameterDecoders/browserType';
 import {useWebVitalsSort} from 'sentry/views/insights/browser/webVitals/utils/useWebVitalsSort';
 import {useSpansIndexed} from 'sentry/views/insights/common/queries/useDiscover';
 import {SpanIndexedField} from 'sentry/views/insights/types';
@@ -15,10 +15,10 @@ export function useInpSpanSamplesWebVitalsQuery({
   enabled,
   filters = {},
   sortName,
-  browserType,
+  browserTypes,
 }: {
   limit: number;
-  browserType?: BrowserType;
+  browserTypes?: BrowserType[];
   enabled?: boolean;
   filters?: {[key: string]: string[] | string | number | undefined};
   sortName?: string;
@@ -41,8 +41,8 @@ export function useInpSpanSamplesWebVitalsQuery({
   if (transaction !== undefined) {
     mutableSearch.addFilterValue(SpanIndexedField.ORIGIN_TRANSACTION, transaction);
   }
-  if (browserType !== undefined && browserType !== BrowserType.ALL) {
-    mutableSearch.addFilterValue(SpanIndexedField.BROWSER_NAME, browserType);
+  if (browserTypes) {
+    mutableSearch.addDisjunctionFilterValues(SpanIndexedField.BROWSER_NAME, browserTypes);
   }
 
   const {data, isLoading, ...rest} = useSpansIndexed(

--- a/static/app/views/insights/browser/webVitals/queries/useInteractionsCategorizedSamplesQuery.tsx
+++ b/static/app/views/insights/browser/webVitals/queries/useInteractionsCategorizedSamplesQuery.tsx
@@ -7,7 +7,7 @@ import {
 } from 'sentry/views/insights/browser/webVitals/utils/scoreThresholds';
 
 type Props = {
-  browserType: BrowserType;
+  browserTypes: BrowserType[];
   enabled: boolean;
   transaction: string;
 };
@@ -15,7 +15,7 @@ type Props = {
 export function useInteractionsCategorizedSamplesQuery({
   transaction,
   enabled,
-  browserType,
+  browserTypes,
 }: Props) {
   const {data: goodData, isFetching: isGoodDataLoading} = useInpSpanSamplesWebVitalsQuery(
     {
@@ -25,7 +25,7 @@ export function useInteractionsCategorizedSamplesQuery({
       filters: {
         'measurements.inp': `<${PERFORMANCE_SCORE_P90S.inp}`,
       },
-      browserType,
+      browserTypes,
     }
   );
   const {data: mehData, isFetching: isMehDataLoading} = useInpSpanSamplesWebVitalsQuery({
@@ -38,7 +38,7 @@ export function useInteractionsCategorizedSamplesQuery({
         `<${PERFORMANCE_SCORE_MEDIANS.inp}`,
       ],
     },
-    browserType,
+    browserTypes,
   });
   const {data: poorData, isFetching: isBadDataLoading} = useInpSpanSamplesWebVitalsQuery({
     transaction,
@@ -47,7 +47,7 @@ export function useInteractionsCategorizedSamplesQuery({
     filters: {
       'measurements.inp': `>=${PERFORMANCE_SCORE_MEDIANS.inp}`,
     },
-    browserType,
+    browserTypes,
   });
 
   const data = [...goodData, ...mehData, ...poorData];

--- a/static/app/views/insights/browser/webVitals/queries/useTransactionWebVitalsQuery.tsx
+++ b/static/app/views/insights/browser/webVitals/queries/useTransactionWebVitalsQuery.tsx
@@ -4,7 +4,7 @@ import type {WebVitals} from 'sentry/views/insights/browser/webVitals/types';
 import type {BrowserType} from 'sentry/views/insights/browser/webVitals/utils/queryParameterDecoders/browserType';
 
 type Props = {
-  browserType?: BrowserType;
+  browserTypes?: BrowserType[];
   defaultSort?: Sort;
   enabled?: boolean;
   limit?: number;
@@ -24,7 +24,7 @@ export const useTransactionWebVitalsQuery = ({
   enabled,
   query,
   shouldEscapeFilters = true,
-  browserType,
+  browserTypes,
 }: Props) => {
   const storedScoresResult = useTransactionWebVitalsScoresQuery({
     limit,
@@ -35,7 +35,7 @@ export const useTransactionWebVitalsQuery = ({
     webVital,
     query,
     shouldEscapeFilters,
-    browserType,
+    browserTypes,
   });
   return storedScoresResult;
 };

--- a/static/app/views/insights/browser/webVitals/queries/useTransactionsCategorizedSamplesQuery.tsx
+++ b/static/app/views/insights/browser/webVitals/queries/useTransactionsCategorizedSamplesQuery.tsx
@@ -10,7 +10,7 @@ import {
 } from 'sentry/views/insights/browser/webVitals/utils/scoreThresholds';
 
 type Props = {
-  browserType: BrowserType;
+  browserTypes: BrowserType[];
   enabled: boolean;
   transaction: string;
   webVital: WebVitals | null;
@@ -20,7 +20,7 @@ export function useTransactionsCategorizedSamplesQuery({
   transaction,
   webVital,
   enabled,
-  browserType,
+  browserTypes,
 }: Props) {
   const {data: goodData, isLoading: isGoodTransactionWebVitalsQueryLoading} =
     useTransactionSamplesWebVitalsScoresQuery({
@@ -33,7 +33,7 @@ export function useTransactionsCategorizedSamplesQuery({
       withProfiles: true,
       sortName: 'webVitalSort',
       webVital: webVital ?? undefined,
-      browserType,
+      browserTypes,
     });
 
   const {data: mehData, isLoading: isMehTransactionWebVitalsQueryLoading} =
@@ -47,7 +47,7 @@ export function useTransactionsCategorizedSamplesQuery({
       withProfiles: true,
       sortName: 'webVitalSort',
       webVital: webVital ?? undefined,
-      browserType,
+      browserTypes,
     });
 
   const {data: poorData, isLoading: isPoorTransactionWebVitalsQueryLoading} =
@@ -61,7 +61,7 @@ export function useTransactionsCategorizedSamplesQuery({
       withProfiles: true,
       sortName: 'webVitalSort',
       webVital: webVital ?? undefined,
-      browserType,
+      browserTypes,
     });
 
   const data = [...goodData, ...mehData, ...poorData];

--- a/static/app/views/insights/browser/webVitals/utils/queryParameterDecoders/browserType.tsx
+++ b/static/app/views/insights/browser/webVitals/utils/queryParameterDecoders/browserType.tsx
@@ -1,4 +1,4 @@
-import {decodeScalar} from 'sentry/utils/queryString';
+import {decodeList} from 'sentry/utils/queryString';
 
 // TODO: include both "Google Chrome" and "Chrome" when filtering by Chrome browser
 // Taken from: https://github.com/getsentry/relay/blob/ed2fc8c85b2732011e8262f4f598fa2c9857571d/relay-dynamic-config/src/defaults.rs#L146
@@ -16,16 +16,17 @@ export enum BrowserType {
   EDGE_MOBILE = 'Edge Mobile',
   OPERA_MOBILE = 'Opera Mobile',
 }
-const DEFAULT = BrowserType.ALL;
 
-export default function decode(value: string | string[] | undefined | null): BrowserType {
-  const decodedValue = decodeScalar(value, DEFAULT);
+export default function decode(
+  value: string | string[] | undefined | null
+): BrowserType[] {
+  const decodedList = decodeList(value);
 
-  if (isAValidOption(decodedValue)) {
-    return decodedValue;
+  if (decodedList.every(decodedValue => isAValidOption(decodedValue))) {
+    return decodedList;
   }
 
-  return DEFAULT;
+  return [];
 }
 
 function isAValidOption(maybeOption: string): maybeOption is BrowserType {

--- a/static/app/views/insights/browser/webVitals/views/pageOverview.tsx
+++ b/static/app/views/insights/browser/webVitals/views/pageOverview.tsx
@@ -35,7 +35,7 @@ import {useProjectRawWebVitalsQuery} from 'sentry/views/insights/browser/webVita
 import {calculatePerformanceScoreFromStoredTableDataRow} from 'sentry/views/insights/browser/webVitals/queries/storedScoreQueries/calculatePerformanceScoreFromStored';
 import {useProjectWebVitalsScoresQuery} from 'sentry/views/insights/browser/webVitals/queries/storedScoreQueries/useProjectWebVitalsScoresQuery';
 import type {WebVitals} from 'sentry/views/insights/browser/webVitals/types';
-import decodeBrowserType from 'sentry/views/insights/browser/webVitals/utils/queryParameterDecoders/browserType';
+import decodeBrowserTypes from 'sentry/views/insights/browser/webVitals/utils/queryParameterDecoders/browserType';
 import {ModulePageProviders} from 'sentry/views/insights/common/components/modulePageProviders';
 import {useModuleBreadcrumbs} from 'sentry/views/insights/common/utils/useModuleBreadcrumbs';
 import {useModuleURL} from 'sentry/views/insights/common/utils/useModuleURL';
@@ -94,14 +94,14 @@ export function PageOverview() {
   const crumbs = useModuleBreadcrumbs('vital');
 
   const query = decodeScalar(location.query.query);
-  const browserType = decodeBrowserType(location.query[SpanIndexedField.BROWSER_NAME]);
+  const browserTypes = decodeBrowserTypes(location.query[SpanIndexedField.BROWSER_NAME]);
 
   const {data: pageData, isLoading} = useProjectRawWebVitalsQuery({
     transaction,
-    browserType,
+    browserTypes,
   });
   const {data: projectScores, isLoading: isProjectScoresLoading} =
-    useProjectWebVitalsScoresQuery({transaction, browserType});
+    useProjectWebVitalsScoresQuery({transaction, browserTypes});
 
   if (transaction === undefined) {
     // redirect user to webvitals landing page
@@ -236,7 +236,7 @@ export function PageOverview() {
                 projectScore={projectScore}
                 transaction={transaction}
                 projectScoreIsLoading={isLoading}
-                browserType={browserType}
+                browserTypes={browserTypes}
               />
             </Layout.Side>
           </Layout.Body>

--- a/static/app/views/insights/browser/webVitals/views/webVitalsLandingPage.tsx
+++ b/static/app/views/insights/browser/webVitals/views/webVitalsLandingPage.tsx
@@ -34,7 +34,7 @@ import {
   MODULE_TITLE,
 } from 'sentry/views/insights/browser/webVitals/settings';
 import type {WebVitals} from 'sentry/views/insights/browser/webVitals/types';
-import decodeBrowserType from 'sentry/views/insights/browser/webVitals/utils/queryParameterDecoders/browserType';
+import decodeBrowserTypes from 'sentry/views/insights/browser/webVitals/utils/queryParameterDecoders/browserType';
 import {ModulePageProviders} from 'sentry/views/insights/common/components/modulePageProviders';
 import {useOnboardingProject} from 'sentry/views/insights/common/queries/useOnboardingProject';
 import {useHasDataTrackAnalytics} from 'sentry/views/insights/common/utils/useHasDataTrackAnalytics';
@@ -53,11 +53,11 @@ export function WebVitalsLandingPage() {
     webVital: (location.query.webVital as WebVitals) ?? null,
   });
 
-  const browserType = decodeBrowserType(location.query[SpanIndexedField.BROWSER_NAME]);
+  const browserTypes = decodeBrowserTypes(location.query[SpanIndexedField.BROWSER_NAME]);
 
-  const {data: projectData, isLoading} = useProjectRawWebVitalsQuery({browserType});
+  const {data: projectData, isLoading} = useProjectRawWebVitalsQuery({browserTypes});
   const {data: projectScores, isLoading: isProjectScoresLoading} =
-    useProjectWebVitalsScoresQuery({browserType});
+    useProjectWebVitalsScoresQuery({browserTypes});
 
   const projectScore =
     isProjectScoresLoading || isLoading
@@ -112,7 +112,7 @@ export function WebVitalsLandingPage() {
                   projectScore={projectScore}
                   isProjectScoreLoading={isLoading || isProjectScoresLoading}
                   webVital={state.webVital}
-                  browserType={browserType}
+                  browserTypes={browserTypes}
                 />
               </PerformanceScoreChartContainer>
               <WebVitalMetersContainer>


### PR DESCRIPTION
Changes the browser dropdown to multiselect. Also adds a `addDisjunctionFilterValues` helper function in `MutableSearch` which simplifies filtering by one-of-many values. 

Before:
![image](https://github.com/getsentry/sentry/assets/58920989/41242f5c-9a41-4286-96cd-140a71c024d2)


After:
<img width="688" alt="image" src="https://github.com/getsentry/sentry/assets/58920989/aa1c2858-5cc1-4185-ab54-c73c401460ed">
