### PR TITLE
feat(insights): Adds a default browser performance score profile for fallback

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -419,6 +419,8 @@ def register_temporary_features(manager: FeatureManager):
     manager.add("organizations:insights-browser-webvitals-static-weights", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE)
     # Sets all web vitals to optional when calculating performance scores
     manager.add("organizations:insights-browser-webvitals-optional-components", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE)
+    # Add default browser performance score profile for fallback when no or unknown browser name is provided
+    manager.add("organizations:insights-default-performance-score-profiles", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE)
     # Enable standalone span ingestion
     manager.add("organizations:standalone-span-ingestion", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
     # Enable the aggregate span waterfall view

--- a/src/sentry/relay/config/__init__.py
+++ b/src/sentry/relay/config/__init__.py
@@ -911,6 +911,67 @@ def _get_mobile_browser_performance_profiles(organization: Organization) -> list
     ]
 
 
+def _get_default_browser_performance_profiles(organization: Organization) -> list[dict[str, Any]]:
+    if not features.has("organizations:insights-default-performance-score-profiles", organization):
+        return []
+    optional = _should_performance_profiles_web_vitals_be_optional(organization)
+    return [
+        {
+            "name": "Default",
+            "scoreComponents": [
+                {
+                    "measurement": "fcp",
+                    "weight": 0.15,
+                    "p10": 900.0,
+                    "p50": 1600.0,
+                    "optional": optional,
+                },
+                {
+                    "measurement": "lcp",
+                    "weight": 0.30,
+                    "p10": 1200.0,
+                    "p50": 2400.0,
+                    "optional": optional,
+                },
+                {
+                    "measurement": "cls",
+                    "weight": 0.15,
+                    "p10": 0.1,
+                    "p50": 0.25,
+                    "optional": optional,
+                },
+                {
+                    "measurement": "ttfb",
+                    "weight": 0.10,
+                    "p10": 200.0,
+                    "p50": 400.0,
+                    "optional": optional,
+                },
+            ],
+            "condition": {
+                "op": "and",
+                "inner": [],
+            },
+        },
+        {
+            "name": "Default INP",
+            "scoreComponents": [
+                {
+                    "measurement": "inp",
+                    "weight": 1.0,
+                    "p10": 200.0,
+                    "p50": 500.0,
+                    "optional": False,
+                },
+            ],
+            "condition": {
+                "op": "and",
+                "inner": [],
+            },
+        },
+    ]
+
+
 def _get_mobile_performance_profiles(organization: Organization) -> list[dict[str, Any]]:
     if not features.has(
         "organizations:performance-calculate-mobile-perf-score-relay", organization
@@ -1052,6 +1113,7 @@ def _get_project_config(
         *_get_desktop_browser_performance_profiles(project.organization),
         *_get_mobile_browser_performance_profiles(project.organization),
         *_get_mobile_performance_profiles(project.organization),
+        *_get_default_browser_performance_profiles(project.organization),
     ]
     if performance_score_profiles:
         config["performanceScore"] = {"profiles": performance_score_profiles}


### PR DESCRIPTION
Adds default browser performance score profiles for pageloads and inps. Performance score calculation will fallback to these default profiles if no matching conditions are found on any of the other profiles. This is to support when no browser name tag is provided or when the browser name is unknown.