### PR TITLE
fix(spans): Validate id fields on spans query builders

### DIFF
--- a/src/sentry/search/events/builder/base.py
+++ b/src/sentry/search/events/builder/base.py
@@ -1212,21 +1212,21 @@ class BaseQueryBuilder:
         name = search_filter.key.name
         value = search_filter.value
 
-        if label := self.uuid_fields.get(name):
+        if name in self.uuid_fields:
             if value.is_wildcard():
-                raise InvalidSearchQuery(WILDCARD_NOT_ALLOWED.format(label))
+                raise InvalidSearchQuery(WILDCARD_NOT_ALLOWED.format(name))
             if not value.is_event_id():
-                raise InvalidSearchQuery(INVALID_ID_DETAILS.format(label))
+                raise InvalidSearchQuery(INVALID_ID_DETAILS.format(name))
 
     def validate_span_id_like_filters(self, search_filter: event_search.SearchFilter):
         name = search_filter.key.name
         value = search_filter.value
 
-        if label := self.span_id_fields.get(name):
+        if name in self.span_id_fields:
             if value.is_wildcard():
-                raise InvalidSearchQuery(WILDCARD_NOT_ALLOWED.format(label))
+                raise InvalidSearchQuery(WILDCARD_NOT_ALLOWED.format(name))
             if not value.is_span_id():
-                raise InvalidSearchQuery(INVALID_SPAN_ID.format(label))
+                raise InvalidSearchQuery(INVALID_SPAN_ID.format(name))
 
     def default_filter_converter(
         self, search_filter: event_search.SearchFilter

--- a/src/sentry/search/events/builder/base.py
+++ b/src/sentry/search/events/builder/base.py
@@ -84,7 +84,11 @@ class BaseQueryBuilder:
     entity: Entity | None = None
     config_class: type[DatasetConfig] | None = None
     duration_fields: set[str] = set()
+    """A mapping of the uuid fields to a human readable label.
+    Used in the validation error messages"""
     uuid_fields: Mapping[str, str] = {}
+    """A mapping of the span id fields to a human readable label.
+    Used in the validation error messages"""
     span_id_fields: Mapping[str, str] = {}
 
     def get_middle(self):

--- a/src/sentry/search/events/builder/base.py
+++ b/src/sentry/search/events/builder/base.py
@@ -84,12 +84,8 @@ class BaseQueryBuilder:
     entity: Entity | None = None
     config_class: type[DatasetConfig] | None = None
     duration_fields: set[str] = set()
-    """A mapping of the uuid fields to a human readable label.
-    Used in the validation error messages"""
-    uuid_fields: Mapping[str, str] = {}
-    """A mapping of the span id fields to a human readable label.
-    Used in the validation error messages"""
-    span_id_fields: Mapping[str, str] = {}
+    uuid_fields: set[str] = set()
+    span_id_fields: set[str] = set()
 
     def get_middle(self):
         """Get the middle for comparison functions"""

--- a/src/sentry/search/events/builder/base.py
+++ b/src/sentry/search/events/builder/base.py
@@ -77,7 +77,6 @@ from sentry.utils.snuba import (
 class BaseQueryBuilder:
     requires_organization_condition: bool = False
     organization_column: str = "organization.id"
-    uuid_fields = {"id", "trace", "profile.id", "replay.id"}
     function_alias_prefix: str | None = None
     spans_metrics_builder = False
     profile_functions_metrics_builder = False

--- a/src/sentry/search/events/builder/discover.py
+++ b/src/sentry/search/events/builder/discover.py
@@ -41,14 +41,14 @@ class DiscoverQueryBuilder(BaseQueryBuilder):
     """Builds a discover query"""
 
     uuid_fields = {
-        "id": "Filter ID",
-        "trace": "Filter Trace ID",
-        "profile.id": "Filter Profile ID",
-        "replay.id": "Filter Replay ID",
+        "id",
+        "trace",
+        "profile.id",
+        "replay.id",
     }
     span_id_fields = {
-        "trace.span": "Filter Trace Span ID",
-        "trace.parent_span": "Filter Trace Parent Span ID",
+        "trace.span",
+        "trace.parent_span",
     }
     duration_fields = {"transaction.duration"}
 

--- a/src/sentry/search/events/builder/discover.py
+++ b/src/sentry/search/events/builder/discover.py
@@ -41,6 +41,7 @@ from sentry.utils.validators import INVALID_ID_DETAILS, INVALID_SPAN_ID, WILDCAR
 class DiscoverQueryBuilder(BaseQueryBuilder):
     """Builds a discover query"""
 
+    uuid_fields = {"id", "trace", "profile.id", "replay.id"}
     duration_fields = {"transaction.duration"}
 
     def load_config(

--- a/src/sentry/search/events/builder/spans_indexed.py
+++ b/src/sentry/search/events/builder/spans_indexed.py
@@ -9,14 +9,14 @@ from sentry.search.events.fields import custom_time_processor
 from sentry.search.events.types import SelectType
 
 SPAN_UUID_FIELDS = {
-    "trace": "Filter Trace ID",
-    "trace_id": "Filter Trace ID",
-    "transaction.id": "Filter Transaction ID",
-    "transaction_id": "Filter Transaction ID",
-    "profile.id": "Filter Profile ID",
-    "profile_id": "Filter Profile ID",
-    "replay.id": "Filter Replay ID",
-    "replay_id": "Filter Replay ID",
+    "trace",
+    "trace_id",
+    "transaction.id",
+    "transaction_id",
+    "profile.id",
+    "profile_id",
+    "replay.id",
+    "replay_id",
 }
 
 

--- a/src/sentry/search/events/builder/spans_indexed.py
+++ b/src/sentry/search/events/builder/spans_indexed.py
@@ -21,12 +21,12 @@ SPAN_UUID_FIELDS = {
 
 
 SPAN_ID_FIELDS = {
-    "id": "Filter Span ID",
-    "span_id": "Filter Span ID",
-    "parent_span": "Filter Parent Span ID",
-    "parent_span_id": "Filter Parent Span ID",
-    "segment.id": "Filter Segment ID",
-    "segment_id": "Filter Segment ID",
+    "id",
+    "span_id",
+    "parent_span",
+    "parent_span_id",
+    "segment.id",
+    "segment_id",
 }
 
 

--- a/src/sentry/search/events/builder/spans_indexed.py
+++ b/src/sentry/search/events/builder/spans_indexed.py
@@ -1,12 +1,15 @@
 from sentry_relay.consts import SPAN_STATUS_CODE_TO_NAME
 from snuba_sdk import Column, Function
 
+from sentry.api.event_search import SearchFilter
+from sentry.exceptions import InvalidSearchQuery
 from sentry.search.events import constants
 from sentry.search.events.builder.base import BaseQueryBuilder
 from sentry.search.events.builder.discover import TimeseriesQueryBuilder, TopEventsQueryBuilder
 from sentry.search.events.datasets.spans_indexed import SpansIndexedDatasetConfig
 from sentry.search.events.fields import custom_time_processor
-from sentry.search.events.types import SelectType
+from sentry.search.events.types import SelectType, WhereType
+from sentry.utils.validators import INVALID_ID_DETAILS, INVALID_SPAN_ID, WILDCARD_NOT_ALLOWED
 
 
 class SpansIndexedQueryBuilderMixin:
@@ -32,9 +35,17 @@ class SpansIndexedQueryBuilder(SpansIndexedQueryBuilderMixin, BaseQueryBuilder):
             constants.SPAN_STATUS
         ] = lambda status: SPAN_STATUS_CODE_TO_NAME.get(status)
 
+    def default_filter_converter(self, search_filter: SearchFilter) -> WhereType | None:
+        validate_id_like_search_filter(search_filter)
+        return super().default_filter_converter(search_filter)
+
 
 class TimeseriesSpanIndexedQueryBuilder(SpansIndexedQueryBuilderMixin, TimeseriesQueryBuilder):
     config_class = SpansIndexedDatasetConfig
+
+    def default_filter_converter(self, search_filter: SearchFilter) -> WhereType | None:
+        validate_id_like_search_filter(search_filter)
+        return super().default_filter_converter(search_filter)
 
     @property
     def time_column(self) -> SelectType:
@@ -46,8 +57,49 @@ class TimeseriesSpanIndexedQueryBuilder(SpansIndexedQueryBuilderMixin, Timeserie
 class TopEventsSpanIndexedQueryBuilder(SpansIndexedQueryBuilderMixin, TopEventsQueryBuilder):
     config_class = SpansIndexedDatasetConfig
 
+    def default_filter_converter(self, search_filter: SearchFilter) -> WhereType | None:
+        validate_id_like_search_filter(search_filter)
+        return super().default_filter_converter(search_filter)
+
     @property
     def time_column(self) -> SelectType:
         return custom_time_processor(
             self.interval, Function("toUInt32", [Column("start_timestamp")])
         )
+
+
+SPAN_ID_FIELDS = {
+    "id": "Filter Span ID",
+    "span_id": "Filter Span ID",
+    "parent_span": "Filter Parent Span ID",
+    "parent_span_id": "Filter Parent Span ID",
+    "segment.id": "Filter Segment ID",
+    "segment_id": "Filter Segment ID",
+}
+
+UUID_FIELDS = {
+    "trace": "Filter Trace ID",
+    "trace_id": "Filter Trace ID",
+    "transaction.id": "Filter Transaction ID",
+    "transaction_id": "Filter Transaction ID",
+    "profile.id": "Filter Profile ID",
+    "profile_id": "Filter Profile ID",
+    "replay.id": "Filter Replay ID",
+    "replay_id": "Filter Replay ID",
+}
+
+
+def validate_id_like_search_filter(search_filter: SearchFilter):
+    name = search_filter.key.name
+
+    if label := SPAN_ID_FIELDS.get(name):
+        if search_filter.value.is_wildcard():
+            raise InvalidSearchQuery(WILDCARD_NOT_ALLOWED.format(label))
+        if not search_filter.value.is_span_id():
+            raise InvalidSearchQuery(INVALID_SPAN_ID.format(label))
+
+    if label := UUID_FIELDS.get(name):
+        if search_filter.value.is_wildcard():
+            raise InvalidSearchQuery(WILDCARD_NOT_ALLOWED.format(label))
+        if not search_filter.value.is_event_id():
+            raise InvalidSearchQuery(INVALID_ID_DETAILS.format(label))

--- a/src/sentry/search/events/builder/spans_indexed.py
+++ b/src/sentry/search/events/builder/spans_indexed.py
@@ -1,15 +1,33 @@
 from sentry_relay.consts import SPAN_STATUS_CODE_TO_NAME
 from snuba_sdk import Column, Function
 
-from sentry.api.event_search import SearchFilter
-from sentry.exceptions import InvalidSearchQuery
 from sentry.search.events import constants
 from sentry.search.events.builder.base import BaseQueryBuilder
 from sentry.search.events.builder.discover import TimeseriesQueryBuilder, TopEventsQueryBuilder
 from sentry.search.events.datasets.spans_indexed import SpansIndexedDatasetConfig
 from sentry.search.events.fields import custom_time_processor
-from sentry.search.events.types import SelectType, WhereType
-from sentry.utils.validators import INVALID_ID_DETAILS, INVALID_SPAN_ID, WILDCARD_NOT_ALLOWED
+from sentry.search.events.types import SelectType
+
+SPAN_UUID_FIELDS = {
+    "trace": "Filter Trace ID",
+    "trace_id": "Filter Trace ID",
+    "transaction.id": "Filter Transaction ID",
+    "transaction_id": "Filter Transaction ID",
+    "profile.id": "Filter Profile ID",
+    "profile_id": "Filter Profile ID",
+    "replay.id": "Filter Replay ID",
+    "replay_id": "Filter Replay ID",
+}
+
+
+SPAN_ID_FIELDS = {
+    "id": "Filter Span ID",
+    "span_id": "Filter Span ID",
+    "parent_span": "Filter Parent Span ID",
+    "parent_span_id": "Filter Parent Span ID",
+    "segment.id": "Filter Segment ID",
+    "segment_id": "Filter Segment ID",
+}
 
 
 class SpansIndexedQueryBuilderMixin:
@@ -26,7 +44,8 @@ class SpansIndexedQueryBuilderMixin:
 
 class SpansIndexedQueryBuilder(SpansIndexedQueryBuilderMixin, BaseQueryBuilder):
     requires_organization_condition = False
-    uuid_fields = {"transaction.id", "replay.id", "profile.id", "trace"}
+    uuid_fields = SPAN_UUID_FIELDS
+    span_id_fields = SPAN_ID_FIELDS
     config_class = SpansIndexedDatasetConfig
 
     def __init__(self, *args, **kwargs):
@@ -35,17 +54,11 @@ class SpansIndexedQueryBuilder(SpansIndexedQueryBuilderMixin, BaseQueryBuilder):
             constants.SPAN_STATUS
         ] = lambda status: SPAN_STATUS_CODE_TO_NAME.get(status)
 
-    def default_filter_converter(self, search_filter: SearchFilter) -> WhereType | None:
-        validate_id_like_search_filter(search_filter)
-        return super().default_filter_converter(search_filter)
-
 
 class TimeseriesSpanIndexedQueryBuilder(SpansIndexedQueryBuilderMixin, TimeseriesQueryBuilder):
     config_class = SpansIndexedDatasetConfig
-
-    def default_filter_converter(self, search_filter: SearchFilter) -> WhereType | None:
-        validate_id_like_search_filter(search_filter)
-        return super().default_filter_converter(search_filter)
+    uuid_fields = SPAN_UUID_FIELDS
+    span_id_fields = SPAN_ID_FIELDS
 
     @property
     def time_column(self) -> SelectType:
@@ -56,50 +69,11 @@ class TimeseriesSpanIndexedQueryBuilder(SpansIndexedQueryBuilderMixin, Timeserie
 
 class TopEventsSpanIndexedQueryBuilder(SpansIndexedQueryBuilderMixin, TopEventsQueryBuilder):
     config_class = SpansIndexedDatasetConfig
-
-    def default_filter_converter(self, search_filter: SearchFilter) -> WhereType | None:
-        validate_id_like_search_filter(search_filter)
-        return super().default_filter_converter(search_filter)
+    uuid_fields = SPAN_UUID_FIELDS
+    span_id_fields = SPAN_ID_FIELDS
 
     @property
     def time_column(self) -> SelectType:
         return custom_time_processor(
             self.interval, Function("toUInt32", [Column("start_timestamp")])
         )
-
-
-SPAN_ID_FIELDS = {
-    "id": "Filter Span ID",
-    "span_id": "Filter Span ID",
-    "parent_span": "Filter Parent Span ID",
-    "parent_span_id": "Filter Parent Span ID",
-    "segment.id": "Filter Segment ID",
-    "segment_id": "Filter Segment ID",
-}
-
-UUID_FIELDS = {
-    "trace": "Filter Trace ID",
-    "trace_id": "Filter Trace ID",
-    "transaction.id": "Filter Transaction ID",
-    "transaction_id": "Filter Transaction ID",
-    "profile.id": "Filter Profile ID",
-    "profile_id": "Filter Profile ID",
-    "replay.id": "Filter Replay ID",
-    "replay_id": "Filter Replay ID",
-}
-
-
-def validate_id_like_search_filter(search_filter: SearchFilter):
-    name = search_filter.key.name
-
-    if label := SPAN_ID_FIELDS.get(name):
-        if search_filter.value.is_wildcard():
-            raise InvalidSearchQuery(WILDCARD_NOT_ALLOWED.format(label))
-        if not search_filter.value.is_span_id():
-            raise InvalidSearchQuery(INVALID_SPAN_ID.format(label))
-
-    if label := UUID_FIELDS.get(name):
-        if search_filter.value.is_wildcard():
-            raise InvalidSearchQuery(WILDCARD_NOT_ALLOWED.format(label))
-        if not search_filter.value.is_event_id():
-            raise InvalidSearchQuery(INVALID_ID_DETAILS.format(label))

--- a/src/sentry/utils/validators.py
+++ b/src/sentry/utils/validators.py
@@ -3,11 +3,13 @@ import uuid
 
 from django.utils.encoding import force_str
 
-INVALID_ID_DETAILS = "{} must be a valid UUID hex (32-36 characters long, containing only digits, dashes, or a-f characters)"
+INVALID_ID_DETAILS = "`{}` must be a valid UUID hex (32-36 characters long, containing only digits, dashes, or a-f characters)"
 
 WILDCARD_NOT_ALLOWED = "Wildcard conditions are not permitted on `{}` field"
 
-INVALID_SPAN_ID = "{} must be a valid 16 character hex (containing only digits, or a-f characters)"
+INVALID_SPAN_ID = (
+    "`{}` must be a valid 16 character hex (containing only digits, or a-f characters)"
+)
 
 HEXADECIMAL_16_DIGITS = re.compile("^[0-9a-fA-F]{16}$")
 

--- a/tests/sentry/search/events/builder/test_discover.py
+++ b/tests/sentry/search/events/builder/test_discover.py
@@ -847,9 +847,7 @@ class DiscoverQueryBuilderTest(TestCase):
             )
 
     def test_id_filter_non_uuid(self):
-        with pytest.raises(
-            InvalidSearchQuery, match=re.escape(INVALID_ID_DETAILS.format("Filter ID"))
-        ):
+        with pytest.raises(InvalidSearchQuery, match=re.escape(INVALID_ID_DETAILS.format("id"))):
             DiscoverQueryBuilder(
                 Dataset.Discover,
                 self.params,
@@ -858,9 +856,7 @@ class DiscoverQueryBuilderTest(TestCase):
             )
 
     def test_trace_id_filter_non_uuid(self):
-        with pytest.raises(
-            InvalidSearchQuery, match=re.escape(INVALID_ID_DETAILS.format("Filter Trace ID"))
-        ):
+        with pytest.raises(InvalidSearchQuery, match=re.escape(INVALID_ID_DETAILS.format("trace"))):
             DiscoverQueryBuilder(
                 Dataset.Discover,
                 self.params,
@@ -870,7 +866,7 @@ class DiscoverQueryBuilderTest(TestCase):
 
     def test_profile_id_filter_non_uuid(self):
         with pytest.raises(
-            InvalidSearchQuery, match=re.escape(INVALID_ID_DETAILS.format("Filter Profile ID"))
+            InvalidSearchQuery, match=re.escape(INVALID_ID_DETAILS.format("profile.id"))
         ):
             DiscoverQueryBuilder(
                 Dataset.Discover,

--- a/tests/sentry/search/events/builder/test_spans_indexed.py
+++ b/tests/sentry/search/events/builder/test_spans_indexed.py
@@ -403,38 +403,36 @@ def test_free_text_search(params, query, expected):
 
 
 @pytest.mark.parametrize(
-    ["column", "query", "message", "label"],
+    ["column", "query", "message"],
     [
-        pytest.param(column, f"{column}:bad_span_id", "valid 16 character hex", label, id=column)
-        for column, label in SPAN_ID_FIELDS.items()
+        pytest.param(column, f"{column}:bad_span_id", "valid 16 character hex", id=column)
+        for column in SPAN_ID_FIELDS
     ]
     + [
         pytest.param(
             column,
             f"{column}:*wild*card*",
             "Wildcard conditions are not permitted",
-            label,
             id=column,
         )
-        for column, label in SPAN_ID_FIELDS.items()
+        for column in SPAN_ID_FIELDS
     ]
     + [
-        pytest.param(column, f"{column}:bad_span_id", "valid UUID hex", label, id=column)
-        for column, label in SPAN_UUID_FIELDS.items()
+        pytest.param(column, f"{column}:bad_span_id", "valid UUID hex", id=column)
+        for column in SPAN_UUID_FIELDS
     ]
     + [
         pytest.param(
             column,
             f"{column}:*wild*card*",
             "Wildcard conditions are not permitted",
-            label,
             id=column,
         )
-        for column, label in SPAN_UUID_FIELDS.items()
+        for column in SPAN_UUID_FIELDS
     ],
 )
 @django_db_all
-def test_column_validation_failed(params, column, query, message, label):
+def test_column_validation_failed(params, column, query, message):
     with pytest.raises(InvalidSearchQuery) as err:
         SpansIndexedQueryBuilder(
             Dataset.SpansIndexed,
@@ -444,4 +442,4 @@ def test_column_validation_failed(params, column, query, message, label):
         )
 
     assert message in str(err)
-    assert label in str(err)
+    assert f"`{column}`" in str(err)

--- a/tests/sentry/search/events/builder/test_spans_indexed.py
+++ b/tests/sentry/search/events/builder/test_spans_indexed.py
@@ -6,7 +6,7 @@ from snuba_sdk import AliasedExpression, And, Column, Condition, Function, Op
 from sentry.exceptions import InvalidSearchQuery
 from sentry.search.events.builder.spans_indexed import (
     SPAN_ID_FIELDS,
-    UUID_FIELDS,
+    SPAN_UUID_FIELDS,
     SpansIndexedQueryBuilder,
 )
 from sentry.snuba.dataset import Dataset
@@ -420,7 +420,7 @@ def test_free_text_search(params, query, expected):
     ]
     + [
         pytest.param(column, f"{column}:bad_span_id", "valid UUID hex", label, id=column)
-        for column, label in UUID_FIELDS.items()
+        for column, label in SPAN_UUID_FIELDS.items()
     ]
     + [
         pytest.param(
@@ -430,7 +430,7 @@ def test_free_text_search(params, query, expected):
             label,
             id=column,
         )
-        for column, label in UUID_FIELDS.items()
+        for column, label in SPAN_UUID_FIELDS.items()
     ],
 )
 @django_db_all

--- a/tests/snuba/api/endpoints/test_organization_events.py
+++ b/tests/snuba/api/endpoints/test_organization_events.py
@@ -189,7 +189,7 @@ class OrganizationEventsEndpointTest(OrganizationEventsEndpointTestBase, Perform
         assert response.status_code == 400, response.content
         assert (
             response.data["detail"]
-            == "trace.span must be a valid 16 character hex (containing only digits, or a-f characters)"
+            == "`trace.span` must be a valid 16 character hex (containing only digits, or a-f characters)"
         )
 
         query = {"field": ["id"], "query": "trace.parent_span:invalid"}
@@ -197,7 +197,7 @@ class OrganizationEventsEndpointTest(OrganizationEventsEndpointTestBase, Perform
         assert response.status_code == 400, response.content
         assert (
             response.data["detail"]
-            == "trace.parent_span must be a valid 16 character hex (containing only digits, or a-f characters)"
+            == "`trace.parent_span` must be a valid 16 character hex (containing only digits, or a-f characters)"
         )
 
         query = {"field": ["id"], "query": "trace.span:*"}

--- a/tests/snuba/api/endpoints/test_organization_events_spans_performance.py
+++ b/tests/snuba/api/endpoints/test_organization_events_spans_performance.py
@@ -879,7 +879,7 @@ class OrganizationEventsSpansPerformanceEndpointTest(OrganizationEventsSpansEndp
         assert response.data == {
             "spanGroup": [
                 ErrorDetail(
-                    "spanGroup must be a valid 16 character hex (containing only digits, or a-f characters)",
+                    "`spanGroup` must be a valid 16 character hex (containing only digits, or a-f characters)",
                     code="invalid",
                 )
             ]
@@ -1197,7 +1197,7 @@ class OrganizationEventsSpansExamplesEndpointTest(OrganizationEventsSpansEndpoin
         assert response.data == {
             "span": [
                 ErrorDetail(
-                    "spanGroup must be a valid 16 character hex (containing only digits, or a-f characters)",
+                    "`spanGroup` must be a valid 16 character hex (containing only digits, or a-f characters)",
                     code="invalid",
                 )
             ]
@@ -1824,7 +1824,7 @@ class OrganizationEventsSpansStatsEndpointTest(OrganizationEventsSpansEndpointTe
         assert response.data == {
             "span": [
                 ErrorDetail(
-                    "spanGroup must be a valid 16 character hex (containing only digits, or a-f characters)",
+                    "`spanGroup` must be a valid 16 character hex (containing only digits, or a-f characters)",
                     code="invalid",
                 )
             ]


### PR DESCRIPTION
Not sure when this validation disappeared but let's add it back to the spans query builders first.