### PR TITLE
fix(empty-states): Fix empty state style

### DIFF
--- a/static/app/components/updatedEmptyState.tsx
+++ b/static/app/components/updatedEmptyState.tsx
@@ -409,8 +409,4 @@ const CodeSnippetWrapper = styled('div')`
 
 const DescriptionWrapper = styled('div')`
   margin-bottom: ${space(1)};
-  display: flex;
-  align-items: center;
-  flex-direction: row;
-  gap: ${space(0.5)};
 `;


### PR DESCRIPTION
this pr fixes a bug introduced in https://github.com/getsentry/sentry/pull/73771 with regards to flex box. 