### PR TITLE
feat(uptime): Add project level setting for disabling automatic uptime checks

### DIFF
--- a/src/sentry/api/endpoints/project_details.py
+++ b/src/sentry/api/endpoints/project_details.py
@@ -126,6 +126,7 @@ class ProjectMemberSerializer(serializers.Serializer):
         "highlightContext",
         "highlightTags",
         "extrapolateMetrics",
+        "uptimeAutodetection",
     ]
 )
 class ProjectAdminSerializer(ProjectMemberSerializer):
@@ -212,6 +213,7 @@ class ProjectAdminSerializer(ProjectMemberSerializer):
     performanceIssueCreationThroughPlatform = serializers.BooleanField(required=False)
     performanceIssueSendToPlatform = serializers.BooleanField(required=False)
     extrapolateMetrics = serializers.BooleanField(required=False)
+    uptimeAutodetection = serializers.BooleanField(required=False)
 
     # DO NOT ADD MORE TO OPTIONS
     # Each param should be a field in the serializer like above.
@@ -758,6 +760,10 @@ class ProjectDetailsEndpoint(ProjectEndpoint):
             if project.update_option("sentry:extrapolate_metrics", result["extrapolateMetrics"]):
                 changed_proj_settings["sentry:extrapolate_metrics"] = result["extrapolateMetrics"]
 
+        if result.get("uptimeAutodetection") is not None:
+            if project.update_option("sentry:uptime_autodetection", result["uptimeAutodetection"]):
+                changed_proj_settings["sentry:uptime_autodetection"] = result["uptimeAutodetection"]
+
         if has_elevated_scopes:
             options = result.get("options", {})
             if "sentry:origins" in options:
@@ -901,6 +907,10 @@ class ProjectDetailsEndpoint(ProjectEndpoint):
             if "sentry:extrapolate_metrics" in options:
                 project.update_option(
                     "sentry:extrapolate_metrics", bool(options["sentry:extrapolate_metrics"])
+                )
+            if "sentry:uptime_autodetection" in options:
+                project.update_option(
+                    "sentry:uptime_autodetection", bool(options["sentry:uptime_autodetection"])
                 )
 
         self.create_audit_entry(

--- a/src/sentry/api/serializers/models/project.py
+++ b/src/sentry/api/serializers/models/project.py
@@ -901,6 +901,7 @@ class DetailedProjectResponse(ProjectWithTeamResponseDict):
     eventProcessing: dict[str, bool]
     symbolSources: str
     extrapolateMetrics: bool
+    uptimeAutodetection: bool
 
 
 class DetailedProjectSerializer(ProjectWithTeamSerializer):
@@ -1028,6 +1029,15 @@ class DetailedProjectSerializer(ProjectWithTeamSerializer):
                 {
                     "extrapolateMetrics": bool(
                         attrs["options"].get("sentry:extrapolate_metrics", False)
+                    )
+                }
+            )
+
+        if features.has("organizations:uptime-settings", obj.organization):
+            data.update(
+                {
+                    "uptimeAutodetection": bool(
+                        attrs["options"].get("sentry:uptime_autodetection", True)
                     )
                 }
             )

--- a/src/sentry/apidocs/examples/project_examples.py
+++ b/src/sentry/apidocs/examples/project_examples.py
@@ -174,6 +174,7 @@ DETAILED_PROJECT = {
     "secondaryGroupingConfig": "newstyle:2019-10-29",
     "groupingAutoUpdate": False,
     "fingerprintingRules": "",
+    "uptimeAutodetection": True,
     "organization": {
         "id": "1",
         "slug": "sentry",

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -468,6 +468,8 @@ def register_temporary_features(manager: FeatureManager):
     manager.add("organizations:transaction-name-sanitization", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
     # Enables automatic hostname detection in uptime
     manager.add("organizations:uptime-automatic-hostname-detection", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE)
+    # Enables uptime related settings for projects and orgs
+    manager.add('organizations:uptime-settings', OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE)
     manager.add("organizations:use-metrics-layer", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
     # Enable User Feedback v2 ingest
     manager.add("organizations:user-feedback-ingest", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)

--- a/src/sentry/models/options/project_option.py
+++ b/src/sentry/models/options/project_option.py
@@ -62,6 +62,7 @@ OPTION_KEYS = frozenset(
         "sentry:transaction_name_cluster_rules",
         "sentry:span_description_cluster_rules",
         "sentry:extrapolate_metrics",
+        "sentry:uptime_autodetection",
         "quotas:spike-protection-disabled",
         "feedback:branding",
         "digests:mail:minimum_delay",

--- a/tests/sentry/api/endpoints/test_project_details.py
+++ b/tests/sentry/api/endpoints/test_project_details.py
@@ -1340,6 +1340,17 @@ class ProjectUpdateTest(APITestCase):
         resp = self.get_response(self.org_slug, self.proj_slug, extrapolateMetrics=True)
         assert resp.status_code == 400
 
+    @with_feature("organizations:uptime-settings")
+    def test_uptime_settings(self):
+        # test when the value is set to False
+        resp = self.get_success_response(self.org_slug, self.proj_slug, uptimeAutodetection=False)
+        assert self.project.get_option("sentry:uptime_autodetection") is False
+        assert resp.data["uptimeAutodetection"] is False
+        # test when the value is set to True
+        resp = self.get_success_response(self.org_slug, self.proj_slug, uptimeAutodetection=True)
+        assert self.project.get_option("sentry:uptime_autodetection") is True
+        assert resp.data["uptimeAutodetection"] is True
+
 
 class CopyProjectSettingsTest(APITestCase):
     endpoint = "sentry-api-0-project-details"


### PR DESCRIPTION
Preparing for the EA of uptime, add an option for users to disable uptime checks

- We will also be placing this setting at the organization level in follow up PR