### PR TITLE
feat(query-builder): Allow pasting without requiring user permissions

### DIFF
--- a/static/app/components/searchQueryBuilder/index.spec.tsx
+++ b/static/app/components/searchQueryBuilder/index.spec.tsx
@@ -517,7 +517,6 @@ describe('SearchQueryBuilder', function () {
       // jsdom does not support clipboard API
       Object.assign(navigator, {
         clipboard: {
-          readText: jest.fn().mockResolvedValue(''),
           writeText: jest.fn().mockResolvedValue(''),
         },
       });
@@ -757,8 +756,8 @@ describe('SearchQueryBuilder', function () {
         expect(token).toHaveAttribute('aria-selected', 'true');
       }
 
-      // Focus should be on the grid container
-      expect(screen.getByRole('grid')).toHaveFocus();
+      // Focus should be on the selection key handler input
+      expect(screen.getByTestId('selection-key-handler')).toHaveFocus();
 
       // Pressing delete should remove all selected tokens
       await userEvent.keyboard('{Backspace}');
@@ -816,7 +815,6 @@ describe('SearchQueryBuilder', function () {
     });
 
     it('replaces selection with pasted content with ctrl+v', async function () {
-      jest.spyOn(navigator.clipboard, 'readText').mockResolvedValue('foo');
       const mockOnChange = jest.fn();
       render(
         <SearchQueryBuilder
@@ -828,7 +826,7 @@ describe('SearchQueryBuilder', function () {
 
       await userEvent.click(getLastInput());
       await userEvent.keyboard('{Control>}a{/Control}');
-      await userEvent.keyboard('{Control>}v{/Control}');
+      await userEvent.paste('foo');
       expect(
         screen.queryByRole('row', {name: 'browser.name:firefox'})
       ).not.toBeInTheDocument();

--- a/static/app/components/searchQueryBuilder/selectionKeyHandler.tsx
+++ b/static/app/components/searchQueryBuilder/selectionKeyHandler.tsx
@@ -1,0 +1,182 @@
+import {type ForwardedRef, forwardRef, useCallback} from 'react';
+import {VisuallyHidden} from '@react-aria/visually-hidden';
+import type {ListState} from '@react-stately/list';
+import type {Key} from '@react-types/shared';
+
+import {useSearchQueryBuilder} from 'sentry/components/searchQueryBuilder/context';
+import {type ParseResultToken, Token} from 'sentry/components/searchSyntax/parser';
+import {defined} from 'sentry/utils';
+import {isCtrlKeyPressed} from 'sentry/utils/isCtrlKeyPressed';
+
+type SelectionKeyHandlerProps = {
+  state: ListState<ParseResultToken>;
+  undo: () => void;
+};
+
+function findNearestFreeTextKey(
+  state: ListState<ParseResultToken>,
+  startKey: Key | null,
+  direction: 'right' | 'left'
+): Key | null {
+  let key: Key | null = startKey;
+  while (key) {
+    const item = state.collection.getItem(key);
+    if (!item) {
+      break;
+    }
+    if (item.value?.type === Token.FREE_TEXT) {
+      return key;
+    }
+    key = (direction === 'right' ? item.nextKey : item.prevKey) ?? null;
+  }
+
+  if (key) {
+    return key;
+  }
+
+  return direction === 'right'
+    ? state.collection.getLastKey()
+    : state.collection.getFirstKey();
+}
+
+/**
+ * SelectionKeyHandler is used to handle keyboard events when a selection is
+ * active, which differ from default behavior. When the user has a selection,
+ * this component should be focused.
+ *
+ * We use an invisible input element in order to handle paste events. Without
+ * this, the browser will need to ask for clipboard permissions.
+ */
+export const SelectionKeyHandler = forwardRef(
+  ({state, undo}: SelectionKeyHandlerProps, ref: ForwardedRef<HTMLInputElement>) => {
+    const {dispatch} = useSearchQueryBuilder();
+
+    const selectedTokens = Array.from(state.selectionManager.selectedKeys)
+      .map(key => state.collection.getItem(key)?.value)
+      .filter(defined);
+
+    const onPaste = useCallback(
+      (e: React.ClipboardEvent<HTMLInputElement>) => {
+        e.preventDefault();
+        e.stopPropagation();
+
+        const text = e.clipboardData.getData('text/plain').replace('\n', '').trim();
+
+        dispatch({
+          type: 'REPLACE_TOKENS_WITH_TEXT',
+          tokens: selectedTokens,
+          text,
+        });
+      },
+      [dispatch, selectedTokens]
+    );
+
+    const onKeyDown = useCallback(
+      (e: React.KeyboardEvent<HTMLDivElement>) => {
+        switch (e.key) {
+          case 'Backspace':
+          case 'Delete': {
+            dispatch({
+              type: 'REPLACE_TOKENS_WITH_TEXT',
+              tokens: selectedTokens,
+              text: '',
+            });
+            state.selectionManager.setFocusedKey(
+              findNearestFreeTextKey(
+                state,
+                state.selectionManager.firstSelectedKey,
+                'left'
+              )
+            );
+            state.selectionManager.clearSelection();
+            return;
+          }
+          case 'ArrowRight':
+            state.selectionManager.clearSelection();
+            state.selectionManager.setFocusedKey(
+              findNearestFreeTextKey(
+                state,
+                state.selectionManager.lastSelectedKey,
+                'right'
+              )
+            );
+            return;
+          case 'ArrowLeft':
+            state.selectionManager.clearSelection();
+            state.selectionManager.setFocusedKey(
+              findNearestFreeTextKey(
+                state,
+                state.selectionManager.firstSelectedKey,
+                'left'
+              )
+            );
+            return;
+          default:
+            if (isCtrlKeyPressed(e)) {
+              const copySelectedTokens = () => {
+                const queryToCopy = selectedTokens
+                  .map(token => token.text)
+                  .join('')
+                  .trim();
+                navigator.clipboard.writeText(queryToCopy);
+              };
+
+              if (e.key === 'a') {
+                state.selectionManager.selectAll();
+                e.preventDefault();
+                e.stopPropagation();
+              } else if (e.key === 'z') {
+                state.selectionManager.clearSelection();
+                undo();
+                e.stopPropagation();
+                e.preventDefault();
+              } else if (e.key === 'x') {
+                state.selectionManager.clearSelection();
+                copySelectedTokens();
+                dispatch({
+                  type: 'REPLACE_TOKENS_WITH_TEXT',
+                  tokens: selectedTokens,
+                  text: '',
+                });
+                e.stopPropagation();
+                e.preventDefault();
+              } else if (e.key === 'c') {
+                copySelectedTokens();
+                e.preventDefault();
+                e.stopPropagation();
+              }
+              return;
+            }
+
+            // If th key pressed will generate a symbol, replace the selection with it
+            if (/^.$/u.test(e.key)) {
+              dispatch({
+                type: 'REPLACE_TOKENS_WITH_TEXT',
+                text: e.key,
+                tokens: selectedTokens,
+              });
+              e.preventDefault();
+              e.stopPropagation();
+            }
+
+            return;
+        }
+      },
+      [dispatch, selectedTokens, state, undo]
+    );
+
+    // Using VisuallyHidden because display: none will not allow the input to be focused
+    return (
+      <VisuallyHidden>
+        <input
+          aria-hidden
+          data-test-id="selection-key-handler"
+          ref={ref}
+          tabIndex={-1}
+          onPaste={onPaste}
+          onKeyDown={onKeyDown}
+        />
+      </VisuallyHidden>
+    );
+  }
+);

--- a/static/app/components/searchQueryBuilder/useQueryBuilderGrid.tsx
+++ b/static/app/components/searchQueryBuilder/useQueryBuilderGrid.tsx
@@ -2,13 +2,9 @@ import {type DOMAttributes, type FocusEvent, useCallback, useMemo} from 'react';
 import {type AriaGridListOptions, useGridList} from '@react-aria/gridlist';
 import {ListKeyboardDelegate} from '@react-aria/selection';
 import type {ListState} from '@react-stately/list';
-import {useListState} from '@react-stately/list';
-import type {CollectionChildren, Key} from '@react-types/shared';
+import type {CollectionChildren} from '@react-types/shared';
 
-import {useSearchQueryBuilder} from 'sentry/components/searchQueryBuilder/context';
-import {useUndoStack} from 'sentry/components/searchQueryBuilder/useUndoStack';
-import {type ParseResultToken, Token} from 'sentry/components/searchSyntax/parser';
-import {defined} from 'sentry/utils';
+import type {ParseResultToken} from 'sentry/components/searchSyntax/parser';
 import {isCtrlKeyPressed} from 'sentry/utils/isCtrlKeyPressed';
 
 interface UseQueryBuilderGridProps extends AriaGridListOptions<ParseResultToken> {
@@ -17,59 +13,26 @@ interface UseQueryBuilderGridProps extends AriaGridListOptions<ParseResultToken>
 
 const noop = () => {};
 
-function findNearestFreeTextKey(
-  state: ListState<ParseResultToken>,
-  startKey: Key | null,
-  direction: 'right' | 'left'
-): Key | null {
-  let key: Key | null = startKey;
-  while (key) {
-    const item = state.collection.getItem(key);
-    if (!item) {
-      break;
-    }
-    if (item.value?.type === Token.FREE_TEXT) {
-      return key;
-    }
-    key = (direction === 'right' ? item.nextKey : item.prevKey) ?? null;
-  }
-
-  if (key) {
-    return key;
-  }
-
-  return direction === 'right'
-    ? state.collection.getLastKey()
-    : state.collection.getFirstKey();
-}
-
 /**
  * Modified version React Aria's useGridList to support the search component.
  *
  * See https://react-spectrum.adobe.com/react-aria/useGridList.html
  */
-export function useQueryBuilderGrid(
-  props: UseQueryBuilderGridProps,
-  ref: React.RefObject<HTMLDivElement>
-): {
-  gridProps: DOMAttributes<HTMLDivElement>;
+export function useQueryBuilderGrid({
+  props,
+  state,
+  ref,
+  selectionKeyHandlerRef,
+  undo,
+}: {
+  props: UseQueryBuilderGridProps;
+  ref: React.RefObject<HTMLDivElement>;
+  selectionKeyHandlerRef: React.RefObject<HTMLInputElement>;
   state: ListState<ParseResultToken>;
+  undo: () => void;
+}): {
+  gridProps: DOMAttributes<HTMLDivElement>;
 } {
-  const {dispatch} = useSearchQueryBuilder();
-
-  const state = useListState<ParseResultToken>({
-    ...props,
-    selectionBehavior: 'replace',
-    onSelectionChange: selection => {
-      // When there is a selection, set focus to the grid itself.
-      if (selection === 'all' || selection.size > 0) {
-        ref.current?.focus();
-        state.selectionManager.setFocusedKey(null);
-        state.selectionManager.setFocused(true);
-      }
-    },
-  });
-
   // The default behavior uses vertical naviation, but we want horizontal navigation
   const delegate = new ListKeyboardDelegate({
     collection: state.collection,
@@ -89,124 +52,13 @@ export function useQueryBuilderGrid(
     ref
   );
 
-  const {undo} = useUndoStack(state);
-
   const onKeyDown = useCallback(
-    async (e: React.KeyboardEvent<HTMLDivElement>) => {
+    (e: React.KeyboardEvent<HTMLDivElement>) => {
       if (e.key === 'z' && isCtrlKeyPressed(e)) {
         undo();
         e.stopPropagation();
         e.preventDefault();
         return;
-      }
-
-      // When there is a selection, the grid will have focus and handle that behavior.
-      if (state.selectionManager.selectedKeys.size > 0) {
-        const selectedTokens = Array.from(state.selectionManager.selectedKeys)
-          .map(key => state.collection.getItem(key)?.value)
-          .filter(defined);
-
-        switch (e.key) {
-          case 'Backspace':
-          case 'Delete': {
-            dispatch({
-              type: 'REPLACE_TOKENS_WITH_TEXT',
-              tokens: selectedTokens,
-              text: '',
-            });
-            state.selectionManager.setFocusedKey(
-              findNearestFreeTextKey(
-                state,
-                state.selectionManager.firstSelectedKey,
-                'left'
-              )
-            );
-            state.selectionManager.clearSelection();
-            return;
-          }
-          case 'ArrowRight':
-            state.selectionManager.clearSelection();
-            state.selectionManager.setFocusedKey(
-              findNearestFreeTextKey(
-                state,
-                state.selectionManager.lastSelectedKey,
-                'right'
-              )
-            );
-            return;
-          case 'ArrowLeft':
-            state.selectionManager.clearSelection();
-            state.selectionManager.setFocusedKey(
-              findNearestFreeTextKey(
-                state,
-                state.selectionManager.firstSelectedKey,
-                'left'
-              )
-            );
-            return;
-          default:
-            if (isCtrlKeyPressed(e)) {
-              const copySelectedTokens = () => {
-                const queryToCopy = selectedTokens
-                  .map(token => token.text)
-                  .join('')
-                  .trim();
-                navigator.clipboard.writeText(queryToCopy);
-              };
-
-              if (e.key === 'a') {
-                state.selectionManager.selectAll();
-                e.preventDefault();
-                e.stopPropagation();
-              } else if (e.key === 'z') {
-                state.selectionManager.clearSelection();
-                undo();
-                e.stopPropagation();
-                e.preventDefault();
-              } else if (e.key === 'x') {
-                state.selectionManager.clearSelection();
-                copySelectedTokens();
-                dispatch({
-                  type: 'REPLACE_TOKENS_WITH_TEXT',
-                  tokens: selectedTokens,
-                  text: '',
-                });
-                e.stopPropagation();
-                e.preventDefault();
-              } else if (e.key === 'v') {
-                state.selectionManager.clearSelection();
-
-                // TODO(malwilley): Find a way to handle pasting without requiring user permissions
-                const text = await navigator.clipboard.readText();
-                const cleanedText = text.replace('\n', '').trim();
-                dispatch({
-                  type: 'REPLACE_TOKENS_WITH_TEXT',
-                  tokens: selectedTokens,
-                  text: cleanedText,
-                });
-                e.preventDefault();
-                e.stopPropagation();
-              } else if (e.key === 'c') {
-                copySelectedTokens();
-                e.preventDefault();
-                e.stopPropagation();
-              }
-              return;
-            }
-
-            // If th key pressed will generate a symbol, replace the selection with it
-            if (/^.$/u.test(e.key)) {
-              dispatch({
-                type: 'REPLACE_TOKENS_WITH_TEXT',
-                text: e.key,
-                tokens: selectedTokens,
-              });
-              e.preventDefault();
-              e.stopPropagation();
-            }
-
-            return;
-        }
       }
 
       if (e.target instanceof HTMLElement) {
@@ -225,7 +77,7 @@ export function useQueryBuilderGrid(
           originalGridProps.onKeyDown?.(e);
       }
     },
-    [dispatch, originalGridProps, state, undo]
+    [originalGridProps, undo]
   );
 
   const gridProps = useMemo(
@@ -235,7 +87,13 @@ export function useQueryBuilderGrid(
       // we want to handle ourselves.
       onKeyDownCapture: noop,
       onKeyDown,
-      onFocus: () => {
+      onFocus: (e: FocusEvent) => {
+        // If this element gets focused and there is a selection, focus the SelectionKeyHandler instead
+        if (e.target === ref.current && state.selectionManager.selectedKeys.size > 0) {
+          selectionKeyHandlerRef.current?.focus();
+          return;
+        }
+
         if (state.selectionManager.isFocused) {
           return;
         }
@@ -243,27 +101,39 @@ export function useQueryBuilderGrid(
         // Ensure that the state is updated correctly
         state.selectionManager.setFocused(true);
 
-        // If nothing is has been focused yet , default to last item
+        // If nothing is has been focused yet, default to last item
         if (!state.selectionManager.focusedKey) {
           state.selectionManager.setFocusedKey(state.collection.getLastKey());
         }
       },
       onBlur: (e: FocusEvent) => {
-        // Reset selection on any focus change, except when focus moves
-        // to the grid itself (which is what happens when there is a selection)
+        const nextFocusedElement = e.relatedTarget;
+
+        // If we're leaving the grid, update the focused state
+        if (!ref.current?.contains(nextFocusedElement)) {
+          state.selectionManager.setFocused(false);
+        }
+
+        // Reset selection on any focus change, except when focus moves to the
+        // SelectionKeyHandler (which is what happens when there is a selection).
         if (
-          e.relatedTarget !== ref.current &&
+          nextFocusedElement !== ref.current &&
+          nextFocusedElement !== selectionKeyHandlerRef.current &&
           state.selectionManager.selectedKeys.size > 0
         ) {
           state.selectionManager.clearSelection();
         }
       },
     }),
-    [onKeyDown, originalGridProps, ref, state.collection, state.selectionManager]
+    [
+      onKeyDown,
+      originalGridProps,
+      ref,
+      selectionKeyHandlerRef,
+      state.collection,
+      state.selectionManager,
+    ]
   );
 
-  return {
-    state,
-    gridProps,
-  };
+  return {gridProps};
 }


### PR DESCRIPTION
Currently when there is a selection, the focus is on the top-level grid div (because there is nowhere else for the focus to go). We have been listening for keydown events here, which works for everything _except_ pasting, because divs do not have the `onPaste` event. Currently we are accessing the clipboard with `navigator.clipboard.readText()`, but that requires the user to grant permission which is not a good experience.

To solve this, we now render an invisible input within the grid (`<SelectionKeyHandler />`), which receives focus when there is a selection. Since this input needs to handle the paste event, I also moved all the selection-specific keydown logic there as well.