### PR TITLE
fix(metrics): Default metric selection

### DIFF
--- a/static/app/components/metrics/queryBuilder.tsx
+++ b/static/app/components/metrics/queryBuilder.tsx
@@ -114,6 +114,7 @@ export const QueryBuilder = memo(function QueryBuilder({
         queryChanges.aggregation = getDefaultAggregation(mriValue);
       }
 
+      // If it is a virtual MRI we need to check for the new conditions and aggregations
       if (newMRI.type === 'v') {
         const spanConditions = getConditions(mriValue);
         const virtualMeta = getVirtualMeta(mriValue);

--- a/static/app/utils/metrics/constants.tsx
+++ b/static/app/utils/metrics/constants.tsx
@@ -42,6 +42,7 @@ export const emptyMetricsQueryWidget: MetricsQueryWidget = {
   id: NO_QUERY_ID,
   mri: 'd:transactions/duration@millisecond' satisfies MRI,
   aggregation: 'avg',
+  condition: undefined,
   query: '',
   groupBy: [],
   sort: DEFAULT_SORT_STATE,

--- a/static/app/utils/metrics/useMetricsQuery.tsx
+++ b/static/app/utils/metrics/useMetricsQuery.tsx
@@ -1,8 +1,12 @@
 import {useMemo} from 'react';
 
 import type {PageFilters} from 'sentry/types/core';
-import {getDateTimeParams, getMetricsInterval} from 'sentry/utils/metrics';
-import {getUseCaseFromMRI, MRIToField, parseMRI} from 'sentry/utils/metrics/mri';
+import {
+  getDateTimeParams,
+  getMetricsInterval,
+  isVirtualMetric,
+} from 'sentry/utils/metrics';
+import {getUseCaseFromMRI, MRIToField} from 'sentry/utils/metrics/mri';
 import {useVirtualMetricsContext} from 'sentry/utils/metrics/virtualMetricsContext';
 import {useApiQuery} from 'sentry/utils/queryClient';
 import useOrganization from 'sentry/utils/useOrganization';
@@ -200,9 +204,7 @@ export function useMetricsQuery(
         if (isMetricFormula(query)) {
           return query;
         }
-        const {type} = parseMRI(query.mri);
-
-        if (type !== 'v' || !query.condition) {
+        if (!isVirtualMetric(query) || !query.condition) {
           return query;
         }
         const {mri, aggregation} = resolveVirtualMRI(

--- a/static/app/utils/metrics/useMetricsQuery.tsx
+++ b/static/app/utils/metrics/useMetricsQuery.tsx
@@ -200,20 +200,26 @@ export function useMetricsQuery(
 
   const resolvedQueries = useMemo(
     () =>
-      queries.map(query => {
-        if (isMetricFormula(query)) {
-          return query;
-        }
-        if (!isVirtualMetric(query) || !query.condition) {
-          return query;
-        }
-        const {mri, aggregation} = resolveVirtualMRI(
-          query.mri,
-          query.condition,
-          query.aggregation
-        );
-        return {...query, mri, aggregation};
-      }),
+      queries
+        .map(query => {
+          if (isMetricFormula(query)) {
+            return query;
+          }
+          if (!isVirtualMetric(query)) {
+            return query;
+          }
+          if (!query.condition) {
+            // Invalid state. A virtual metric always need to have a condition
+            return null;
+          }
+          const {mri, aggregation} = resolveVirtualMRI(
+            query.mri,
+            query.condition,
+            query.aggregation
+          );
+          return {...query, mri, aggregation};
+        })
+        .filter(query => query !== null),
     [queries, resolveVirtualMRI]
   );
 

--- a/static/app/views/metrics/utils/getNewMetricsWidget.spec.tsx
+++ b/static/app/views/metrics/utils/getNewMetricsWidget.spec.tsx
@@ -1,0 +1,80 @@
+import * as Sentry from '@sentry/react';
+
+import type {MetricAggregation, MetricMeta, MetricType} from 'sentry/types/metrics';
+import {emptyMetricsQueryWidget} from 'sentry/utils/metrics/constants';
+import {getNewMetricsWidget} from 'sentry/views/metrics/utils/getNewMetricsWidget';
+
+describe('getNewMetricsWidget', () => {
+  it('creates a default widget', () => {
+    expect(getNewMetricsWidget()).toEqual(emptyMetricsQueryWidget);
+  });
+
+  it('creates a widget for a count metric', () => {
+    const meta = createMeta('c');
+    expect(getNewMetricsWidget(meta)).toEqual({
+      ...emptyMetricsQueryWidget,
+      mri: meta.mri,
+      aggregation: 'sum',
+    });
+  });
+
+  it('creates a widget for a set metric', () => {
+    const meta = createMeta('s');
+    expect(getNewMetricsWidget(meta)).toEqual({
+      ...emptyMetricsQueryWidget,
+      mri: meta.mri,
+      aggregation: 'count_unique',
+    });
+  });
+
+  it('creates a widget for a gauge metric', () => {
+    const meta = createMeta('g');
+    expect(getNewMetricsWidget(meta)).toEqual({
+      ...emptyMetricsQueryWidget,
+      mri: meta.mri,
+      aggregation: 'avg',
+    });
+  });
+
+  it('creates a widget for a distribution metric', () => {
+    const meta = createMeta('d');
+    expect(getNewMetricsWidget(meta)).toEqual({
+      ...emptyMetricsQueryWidget,
+      mri: meta.mri,
+      aggregation: 'avg',
+    });
+  });
+
+  it('creates a widget for a virtual metric', () => {
+    const meta = createMeta('v', ['p99', 'min'] as const);
+    expect(getNewMetricsWidget(meta, 23)).toEqual({
+      ...emptyMetricsQueryWidget,
+      mri: meta.mri,
+      // Uses the first available aggregation
+      aggregation: 'p99',
+      condition: 23,
+    });
+  });
+
+  it('logs message and falls back to default if there is no condition for virtual metrics', () => {
+    const sentrySpy = jest.spyOn(Sentry, 'captureMessage');
+    const meta = createMeta('v', ['p99', 'min'] as const);
+    expect(getNewMetricsWidget(meta)).toEqual(emptyMetricsQueryWidget);
+
+    expect(sentrySpy).toHaveBeenCalledTimes(1);
+    expect(sentrySpy).toHaveBeenCalledWith(
+      'Metrics: Trying to create widget from virtual MRI without condition'
+    );
+  });
+});
+
+function createMeta(type: MetricType, operations: MetricAggregation[] = []): MetricMeta {
+  return {
+    mri: `${type}:custom/my-metrics@none`,
+    operations,
+    blockingStatus: [],
+    projectIds: [],
+    type,
+    unit: 'none',
+  };
+}

--- a/static/app/views/metrics/utils/getNewMetricsWidget.spec.tsx
+++ b/static/app/views/metrics/utils/getNewMetricsWidget.spec.tsx
@@ -66,6 +66,17 @@ describe('getNewMetricsWidget', () => {
       'Metrics: Trying to create widget from virtual MRI without condition'
     );
   });
+
+  it('logs message and falls back to default if there is no allowed aggregation', () => {
+    const sentrySpy = jest.spyOn(Sentry, 'captureMessage');
+    const meta = createMeta('v', ['max_timestamp' as MetricAggregation] as const);
+    expect(getNewMetricsWidget(meta, 42)).toEqual(emptyMetricsQueryWidget);
+
+    expect(sentrySpy).toHaveBeenCalledTimes(1);
+    expect(sentrySpy).toHaveBeenCalledWith(
+      'Metrics: No allowed aggregations available for virtual metric found'
+    );
+  });
 });
 
 function createMeta(type: MetricType, operations: MetricAggregation[] = []): MetricMeta {

--- a/static/app/views/metrics/utils/getNewMetricsWidget.tsx
+++ b/static/app/views/metrics/utils/getNewMetricsWidget.tsx
@@ -1,0 +1,37 @@
+import * as Sentry from '@sentry/react';
+
+import type {MetricMeta} from 'sentry/types/metrics';
+import {getDefaultAggregation, isVirtualMetric} from 'sentry/utils/metrics';
+import {emptyMetricsQueryWidget} from 'sentry/utils/metrics/constants';
+
+/**
+ * Creates a new widget, can be passed a metrics meta object to base the new widget on it
+ * @param metricsMeta metrics meta on which the widget should be based
+ * @param defaultCondition selected condition. only needed for virtual metrics
+ * @returns
+ */
+export function getNewMetricsWidget(metricsMeta?: MetricMeta, defaultCondition?: number) {
+  const mri = metricsMeta?.mri || emptyMetricsQueryWidget.mri;
+  let condition = emptyMetricsQueryWidget.condition;
+  let aggregation = getDefaultAggregation(mri);
+
+  if (metricsMeta && isVirtualMetric(metricsMeta)) {
+    if (!defaultCondition) {
+      Sentry.captureMessage(
+        'Metrics: Trying to create widget from virtual MRI without condition'
+      );
+      // Invalid data -> falling back to default
+      return emptyMetricsQueryWidget;
+    }
+
+    condition = defaultCondition;
+    aggregation = metricsMeta.operations[0];
+  }
+
+  return {
+    ...emptyMetricsQueryWidget,
+    mri,
+    condition,
+    aggregation,
+  };
+}

--- a/static/app/views/metrics/utils/parseMetricWidgetsQueryParam.spec.tsx
+++ b/static/app/views/metrics/utils/parseMetricWidgetsQueryParam.spec.tsx
@@ -1,4 +1,3 @@
-import {emptyMetricsQueryWidget} from 'sentry/utils/metrics/constants';
 import {
   MetricChartOverlayType,
   MetricDisplayType,
@@ -12,17 +11,14 @@ function testParsing(input: any, result: MetricsWidget[]) {
 }
 
 describe('parseMetricWidgetsQueryParam', () => {
-  const defaultState = [{...emptyMetricsQueryWidget, id: 0}];
-  it('returns default widget for invalid param', () => {
-    testParsing(undefined, defaultState);
-    testParsing({}, defaultState);
-    testParsing(true, defaultState);
-    testParsing(2, defaultState);
-    testParsing('', defaultState);
-    testParsing('test', defaultState);
-
-    // empty array is not valid
-    testParsing([], defaultState);
+  it('returns empty array for invalid param', () => {
+    testParsing(undefined, []);
+    testParsing({}, []);
+    testParsing(true, []);
+    testParsing(2, []);
+    testParsing('', []);
+    testParsing('test', []);
+    testParsing([], []);
   });
 
   it('returns a single widget', () => {
@@ -285,7 +281,7 @@ describe('parseMetricWidgetsQueryParam', () => {
     );
   });
 
-  it('returns default widget if there is no valid widget', () => {
+  it('returns empty array if there is no valid widget', () => {
     testParsing(
       // INPUT
       [
@@ -298,7 +294,7 @@ describe('parseMetricWidgetsQueryParam', () => {
         },
       ],
       // RESULT
-      defaultState
+      []
     );
   });
 

--- a/static/app/views/metrics/utils/parseMetricWidgetsQueryParam.tsx
+++ b/static/app/views/metrics/utils/parseMetricWidgetsQueryParam.tsx
@@ -1,10 +1,6 @@
-import type {MetricAggregation, MRI} from 'sentry/types/metrics';
+import type {MetricAggregation} from 'sentry/types/metrics';
 import {getDefaultAggregation} from 'sentry/utils/metrics';
-import {
-  DEFAULT_SORT_STATE,
-  emptyMetricsQueryWidget,
-  NO_QUERY_ID,
-} from 'sentry/utils/metrics/constants';
+import {DEFAULT_SORT_STATE, NO_QUERY_ID} from 'sentry/utils/metrics/constants';
 import {isMRI} from 'sentry/utils/metrics/mri';
 import {
   type BaseWidgetParams,
@@ -205,14 +201,7 @@ function fillIds(
   return entries;
 }
 
-export function parseMetricWidgetsQueryParam(
-  queryParam?: string,
-  defaultValues: {
-    aggregation?: MetricAggregation;
-    condition?: number;
-    mri?: MRI;
-  } = {}
-): MetricsWidget[] {
+export function parseMetricWidgetsQueryParam(queryParam?: string): MetricsWidget[] {
   let currentWidgets: unknown = undefined;
 
   try {
@@ -299,21 +288,6 @@ export function parseMetricWidgetsQueryParam(
         break;
     }
   });
-
-  // Iterate over the widgets without an id and assign them a unique one
-
-  if (queries.length === 0) {
-    const mri = defaultValues.mri || emptyMetricsQueryWidget.mri;
-    const condition = defaultValues.condition || emptyMetricsQueryWidget.condition;
-    const aggregation = defaultValues.aggregation || getDefaultAggregation(mri);
-
-    queries.push({
-      ...emptyMetricsQueryWidget,
-      mri,
-      condition,
-      aggregation,
-    });
-  }
 
   // We can reset the id if there is only one widget
   if (queries.length === 1) {

--- a/static/app/views/metrics/utils/parseMetricWidgetsQueryParam.tsx
+++ b/static/app/views/metrics/utils/parseMetricWidgetsQueryParam.tsx
@@ -207,7 +207,11 @@ function fillIds(
 
 export function parseMetricWidgetsQueryParam(
   queryParam?: string,
-  defaultMRI?: MRI
+  defaultValues: {
+    aggregation?: MetricAggregation;
+    condition?: number;
+    mri?: MRI;
+  } = {}
 ): MetricsWidget[] {
   let currentWidgets: unknown = undefined;
 
@@ -299,12 +303,15 @@ export function parseMetricWidgetsQueryParam(
   // Iterate over the widgets without an id and assign them a unique one
 
   if (queries.length === 0) {
-    const mri = defaultMRI || emptyMetricsQueryWidget.mri;
+    const mri = defaultValues.mri || emptyMetricsQueryWidget.mri;
+    const condition = defaultValues.condition || emptyMetricsQueryWidget.condition;
+    const aggregation = defaultValues.aggregation || getDefaultAggregation(mri);
 
     queries.push({
       ...emptyMetricsQueryWidget,
       mri,
-      aggregation: getDefaultAggregation(mri),
+      condition,
+      aggregation,
     });
   }
 


### PR DESCRIPTION
Pre-fill the correct condition and aggregation on setting the default selected metric.

---

Changes after revert of [original PR](https://github.com/getsentry/sentry/pull/74011):
- Extract and test logic for creating a new widget.
- Add logging for invalid data.
- Filter unresolvable virtual metrics from the `metrics/query` request.