### PR TITLE
ref(metrics): Make red banner dismissible for 2 weeks

### DIFF
--- a/static/app/views/metrics/metricsIngestionStopAlert.tsx
+++ b/static/app/views/metrics/metricsIngestionStopAlert.tsx
@@ -1,10 +1,36 @@
 import Alert from 'sentry/components/alert';
+import {Button} from 'sentry/components/button';
 import ExternalLink from 'sentry/components/links/externalLink';
-import {tct} from 'sentry/locale';
+import {IconClose} from 'sentry/icons/iconClose';
+import {t, tct} from 'sentry/locale';
+import useDismissAlert from 'sentry/utils/useDismissAlert';
+
+const LOCAL_STORAGE_KEY = 'custom-metrics-stop-being-ingested-alert-dismissed';
 
 export function MetricsStopIngestionAlert() {
+  const {dismiss, isDismissed} = useDismissAlert({
+    key: LOCAL_STORAGE_KEY,
+    expirationDays: 14, // 2 weeks
+  });
+
+  if (isDismissed) {
+    return null;
+  }
+
   return (
-    <Alert type="error" showIcon>
+    <Alert
+      type="error"
+      showIcon
+      trailingItems={
+        <Button
+          aria-label={t('Dismiss banner')}
+          icon={<IconClose />}
+          onClick={dismiss}
+          size="zero"
+          borderless
+        />
+      }
+    >
       {
         // the exact date will be provided later
         tct(


### PR DESCRIPTION
closes https://github.com/getsentry/sentry/issues/73915


### Note

We have decided against implementing a condition to check for the presence of custom metrics in at least one project within an organization, which would be necessary to display the banner. This would require informing the metrics/meta endpoint of all project IDs within the organization and then looping through the data to detect any custom metrics. We have concluded that the effort involved is not justified.
