### PR TITLE
fix(inbound-filters): Use correct field name

### DIFF
--- a/src/sentry/ingest/inbound_filters.py
+++ b/src/sentry/ingest/inbound_filters.py
@@ -327,7 +327,7 @@ def _error_message_condition(values: Sequence[tuple[str | None, str | None]]) ->
         RuleCondition,
         {
             "op": "any",
-            "name": "event.exceptions",
+            "name": "event.exception.values",
             "inner": {
                 "op": "or",
                 "inner": conditions,


### PR DESCRIPTION
This PR fixes the wrong usage of field name for the generic inbound filter on error messages.