### PR TITLE
ref: Remove calls to process_event_proguard

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -667,6 +667,7 @@ register(
 
 # The fraction of prooguard events that will be routed to the
 # separate `store.process_event_proguard` queue
+# TODO: Unused, remove this.
 register(
     "store.separate-proguard-queue-rate",
     default=0.0,

--- a/src/sentry/tasks/store.py
+++ b/src/sentry/tasks/store.py
@@ -17,7 +17,6 @@ from sentry.attachments import attachment_cache
 from sentry.constants import DEFAULT_STORE_NORMALIZER_ARGS
 from sentry.datascrubbing import scrub_data
 from sentry.eventstore import processing
-from sentry.features.rollout import in_random_rollout
 from sentry.feedback.usecases.create_feedback import FeedbackCreationSource, create_feedback_issue
 from sentry.killswitches import killswitch_matches_context
 from sentry.lang.native.symbolicator import SymbolicatorTaskKind
@@ -64,13 +63,9 @@ def submit_process(
     data_has_changed: bool = False,
     from_symbolicate: bool = False,
     has_attachments: bool = False,
-    is_proguard: bool = False,
 ) -> None:
     if from_reprocessing:
         task = process_event_from_reprocessing
-    elif is_proguard and in_random_rollout("store.separate-proguard-queue-rate"):
-        # route *some* proguard events to a separate queue
-        task = process_event_proguard
     else:
         task = process_event
     task.delay(
@@ -126,7 +121,6 @@ def _do_preprocess_event(
     project: Project | None,
     has_attachments: bool = False,
 ) -> None:
-    from sentry.lang.java.utils import has_proguard_file
     from sentry.stacktraces.processing import find_stacktraces_in_data
     from sentry.tasks.symbolication import (
         get_symbolication_function_for_platform,
@@ -206,7 +200,6 @@ def _do_preprocess_event(
             start_time=start_time,
             data_has_changed=False,
             has_attachments=has_attachments,
-            is_proguard=has_proguard_file(data),
         )
         return
 
@@ -466,6 +459,7 @@ def process_event(
     )
 
 
+# TODO: Unused, remove this.
 @instrumented_task(
     name="sentry.tasks.store.process_event_proguard",
     queue="events.process_event_proguard",


### PR DESCRIPTION
This is a partial revert of https://github.com/getsentry/sentry/pull/64946. In that PR, we introduced a separate proguard queue to stop slow proguard events from bogging down the whole processing pipeline. The proguad situation is much improved, so hopefully we won't need this for much longer.

Turning the option down to 10% had no discernible effect (as expected, since the process-event-proguard workers have nothing to do anyway). I think it is safe to remove this logic.

Follow-ups:
* Remove the task
* Remove the queue
* Remove the option