### PR TITLE
ref(discover): Simplify split query logic for dashboards

### DIFF
--- a/src/sentry/api/endpoints/organization_events.py
+++ b/src/sentry/api/endpoints/organization_events.py
@@ -412,7 +412,6 @@ class OrganizationEventsEndpoint(OrganizationEventsV2EndpointBase):
                 if original_results.get("data"):
                     dataset_meta = original_results.get("meta", {})
                 else:
-                    # TODO: What use case does this serve? Is the .get("data") extra here as well?
                     dataset_meta = list(original_results.values())[0].get("data").get("meta", {})
                 using_metrics = dataset_meta.get("isMetricsData", False) or dataset_meta.get(
                     "isMetricsExtractedData", False

--- a/src/sentry/api/endpoints/organization_events.py
+++ b/src/sentry/api/endpoints/organization_events.py
@@ -412,8 +412,7 @@ class OrganizationEventsEndpoint(OrganizationEventsV2EndpointBase):
                 if original_results.get("data"):
                     dataset_meta = original_results.get("meta", {})
                 else:
-                    # TODO: This index is a little weird. What use case does it serve?
-                    # Is the .get("data") extra here as well?
+                    # TODO: What use case does this serve? Is the .get("data") extra here as well?
                     dataset_meta = list(original_results.values())[0].get("data").get("meta", {})
                 using_metrics = dataset_meta.get("isMetricsData", False) or dataset_meta.get(
                     "isMetricsExtractedData", False

--- a/src/sentry/api/endpoints/organization_events.py
+++ b/src/sentry/api/endpoints/organization_events.py
@@ -410,8 +410,10 @@ class OrganizationEventsEndpoint(OrganizationEventsV2EndpointBase):
 
                 original_results = _data_fn(scopedDataset, offset, limit, scoped_query)
                 if original_results.get("data"):
-                    dataset_meta = original_results.get("data").get("meta", {})
+                    dataset_meta = original_results.get("meta", {})
                 else:
+                    # TODO: This index is a little weird. What use case does it serve?
+                    # Is the .get("data") extra here as well?
                     dataset_meta = list(original_results.values())[0].get("data").get("meta", {})
                 using_metrics = dataset_meta.get("isMetricsData", False) or dataset_meta.get(
                     "isMetricsExtractedData", False

--- a/src/sentry/api/endpoints/organization_events.py
+++ b/src/sentry/api/endpoints/organization_events.py
@@ -23,7 +23,13 @@ from sentry.discover.models import DiscoverSavedQuery, DiscoverSavedQueryTypes
 from sentry.exceptions import InvalidParams
 from sentry.models.dashboard_widget import DashboardWidget, DashboardWidgetTypes
 from sentry.models.organization import Organization
-from sentry.snuba import discover, metrics_enhanced_performance, metrics_performance
+from sentry.snuba import (
+    discover,
+    errors,
+    metrics_enhanced_performance,
+    metrics_performance,
+    transactions,
+)
 from sentry.snuba.metrics.extraction import MetricSpecType
 from sentry.snuba.referrer import Referrer
 from sentry.snuba.utils import dataset_split_decision_inferred_from_query, get_dataset
@@ -384,33 +390,18 @@ class OrganizationEventsEndpoint(OrganizationEventsV2EndpointBase):
 
                 if does_widget_have_split and not has_override_feature:
                     # This is essentially cached behaviour and we skip the check
-                    split_query = scoped_query
                     if widget.discover_widget_split == DashboardWidgetTypes.ERROR_EVENTS:
-                        split_dataset = discover
-                        split_query = (
-                            f"({scoped_query}) AND !event.type:transaction"
-                            if scoped_query
-                            else "!event.type:transaction"
-                        )
+                        split_dataset = errors
                     elif widget.discover_widget_split == DashboardWidgetTypes.TRANSACTION_LIKE:
                         # We can't add event.type:transaction for now because of on-demand.
                         split_dataset = scopedDataset
                     else:
                         split_dataset = discover
 
-                    return _data_fn(split_dataset, offset, limit, split_query)
+                    return _data_fn(split_dataset, offset, limit, scoped_query)
 
                 try:
-                    error_results = _data_fn(
-                        discover,
-                        offset,
-                        limit,
-                        (
-                            f"({scoped_query}) AND !event.type:transaction"
-                            if scoped_query
-                            else "!event.type:transaction"
-                        ),
-                    )
+                    error_results = _data_fn(errors, offset, limit, scoped_query)
                     # Widget has not split the discover dataset yet, so we need to check if there are errors etc.
                     has_errors = len(error_results["data"]) > 0
                 except SnubaError:
@@ -432,12 +423,7 @@ class OrganizationEventsEndpoint(OrganizationEventsV2EndpointBase):
                 if has_errors and has_other_data and not using_metrics:
                     # In the case that the original request was not using the metrics dataset, we cannot be certain that other data is solely transactions.
                     sentry_sdk.set_tag("third_split_query", True)
-                    transactions_only_query = (
-                        f"({scoped_query}) AND event.type:transaction"
-                        if scoped_query
-                        else "event.type:transaction"
-                    )
-                    transaction_results = _data_fn(discover, offset, limit, transactions_only_query)
+                    transaction_results = _data_fn(transactions, offset, limit, scoped_query)
                     has_transactions = len(transaction_results["data"]) > 0
 
                 decision = self.save_split_decision(widget, has_errors, has_transactions)


### PR DESCRIPTION
We can just query errors and transactions directly instead of appending the event.type:X filter to discover. I added a number of tests to validate the split decision routing.

During that testing, I realized I had a case that was erroring out and it just seems like we were trying to access the meta results inside the data, but usually they're keys at the same level. I removed the extra `.get("data")` in the first block, but I'm not sure what the second block is doing and whether or not the `.get("data")` is a bug