### PR TITLE
ref(similarity): Change location of deleted check in backfill

### DIFF
--- a/src/sentry/tasks/embeddings_grouping/utils.py
+++ b/src/sentry/tasks/embeddings_grouping/utils.py
@@ -17,7 +17,7 @@ from sentry.eventstore.models import Event
 from sentry.grouping.grouping_info import get_grouping_info
 from sentry.issues.grouptype import ErrorGroupType
 from sentry.issues.occurrence_consumer import EventLookupError
-from sentry.models.group import Group, GroupStatus
+from sentry.models.group import Group
 from sentry.models.project import Project
 from sentry.seer.similarity.grouping_records import (
     CreateGroupingRecordData,
@@ -138,7 +138,6 @@ def get_current_batch_groups_from_postgres(project, last_processed_group_index, 
             times_seen__gt=1,
             last_seen__gt=(datetime.now(UTC) - timedelta(days=90)),
         )
-        .exclude(status__in=[GroupStatus.PENDING_DELETION, GroupStatus.DELETION_IN_PROGRESS])
         .values_list("id", "data")
         .order_by("-times_seen", "id")
     )

--- a/tests/sentry/tasks/test_backfill_seer_grouping_records.py
+++ b/tests/sentry/tasks/test_backfill_seer_grouping_records.py
@@ -15,7 +15,7 @@ from snuba_sdk import Column, Condition, Entity, Limit, Op, Query, Request
 from sentry.conf.server import SEER_SIMILARITY_MODEL_VERSION
 from sentry.eventstore.models import Event
 from sentry.issues.occurrence_consumer import EventLookupError
-from sentry.models.group import Group
+from sentry.models.group import Group, GroupStatus
 from sentry.models.grouphash import GroupHash
 from sentry.seer.similarity.grouping_records import CreateGroupingRecordData
 from sentry.seer.similarity.types import RawSeerSimilarIssueData
@@ -1074,6 +1074,59 @@ class TestBackfillSeerGroupingRecords(SnubaTestCase, TestCase):
                 },
             ),
         ]
+
+    @with_feature("projects:similarity-embeddings-backfill")
+    @patch("sentry.tasks.embeddings_grouping.utils.post_bulk_grouping_records")
+    def test_backfill_seer_grouping_records_exclude_deleted_groups(
+        self, mock_post_bulk_grouping_records
+    ):
+        """
+        Test that groups that are pending deletion/in the process of being deleted are not included.
+        """
+        mock_post_bulk_grouping_records.return_value = {"success": True, "groups_with_neighbor": {}}
+
+        # Create groups pending deletion and in the process of being deleted
+        deleted_group_ids = []
+        data = {
+            "exception": self.create_exception_values("function name!", "type!", "value!"),
+            "title": "title",
+            "timestamp": iso_format(before_now(seconds=10)),
+        }
+        event = self.store_event(data=data, project_id=self.project.id, assert_no_errors=False)
+        event.group.times_seen = 2
+        event.group.status = GroupStatus.PENDING_DELETION
+        event.group.save()
+        deleted_group_ids.append(event.group.id)
+
+        data = {
+            "exception": self.create_exception_values("function name?", "type?", "value?"),
+            "title": "title",
+            "timestamp": iso_format(before_now(seconds=10)),
+        }
+        event = self.store_event(data=data, project_id=self.project.id, assert_no_errors=False)
+        event.group.times_seen = 2
+        event.group.status = GroupStatus.DELETION_IN_PROGRESS
+        event.group.save()
+        deleted_group_ids.append(event.group.id)
+
+        with TaskRunner():
+            backfill_seer_grouping_records_for_project(self.project.id, None)
+
+        groups = Group.objects.filter(project_id=self.project.id).exclude(id__in=deleted_group_ids)
+        for group in groups:
+            assert group.data["metadata"].get("seer_similarity") == {
+                "similarity_model_version": SEER_SIMILARITY_MODEL_VERSION,
+                "request_hash": self.group_hashes[group.id],
+            }
+        redis_client = redis.redis_clusters.get(settings.SENTRY_MONITORS_REDIS_CLUSTER)
+        last_processed_index = int(
+            redis_client.get(make_backfill_grouping_index_redis_key(self.project.id)) or 0
+        )
+        assert last_processed_index == len(Group.objects.filter(project_id=self.project.id))
+
+        # Assert metadata was not set for groups that will be deleted
+        for group in Group.objects.filter(project_id=self.project.id, id__in=deleted_group_ids):
+            assert group.data["metadata"].get("seer_similarity") is None
 
     @with_feature("projects:similarity-embeddings-backfill")
     @patch("sentry.tasks.embeddings_grouping.utils.logger")


### PR DESCRIPTION
The status index was sometimes being used in this query, causing it to take 30s +, however groups are very infrequently in this deletion status
Remove the filtering by status, and add the check to exclude it out of the postgres query
