### PR TITLE
chore(insights): Add Insights module `hasEverSentData` tag to Replays

### DIFF
--- a/static/app/views/insights/common/utils/useHasDataTrackAnalytics.tsx
+++ b/static/app/views/insights/common/utils/useHasDataTrackAnalytics.tsx
@@ -1,4 +1,5 @@
 import {useEffect} from 'react';
+import * as Sentry from '@sentry/react';
 
 import {trackAnalytics} from 'sentry/utils/analytics';
 import useOrganization from 'sentry/utils/useOrganization';
@@ -10,6 +11,10 @@ export function useHasDataTrackAnalytics(module: ModuleName, analyticEvent: stri
   const organization = useOrganization();
   const pageFilters = usePageFilters();
   const hasEverSentData = useHasFirstSpan(module);
+
+  Sentry.withScope(scope => {
+    scope.setTag(`insights.${module}.hasEverSentData`, hasEverSentData);
+  });
 
   const projects = JSON.stringify(pageFilters.selection.projects);
 


### PR DESCRIPTION
Adds a tag like `"insights.db.hasEverSentData"` tag to the Sentry scope. This should propagate the tag to the current Replay (if there is one), so we can search for Replays where the user opened a module with no data in it.
