### PR TITLE
feat(js): Upgrade @sentry/status-page-list to 0.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "@sentry/node": "^8.12.0-beta.0",
     "@sentry/react": "^8.12.0-beta.0",
     "@sentry/release-parser": "^1.3.1",
-    "@sentry/status-page-list": "^0.2.0",
+    "@sentry/status-page-list": "^0.3.0",
     "@sentry/types": "^8.12.0-beta.0",
     "@sentry/utils": "^8.12.0-beta.0",
     "@spotlightjs/spotlight": "^2.0.0-alpha.1",
@@ -264,7 +264,9 @@
       "last 3 iOS major versions",
       "Firefox ESR"
     ],
-    "test": ["current node"]
+    "test": [
+      "current node"
+    ]
   },
   "volta": {
     "extends": ".volta.json"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3243,10 +3243,10 @@
   resolved "https://registry.yarnpkg.com/@sentry/release-parser/-/release-parser-1.3.1.tgz#0ab8be23fd494d80dd0e4ec8ae5f3d13f805b13d"
   integrity sha512-/dGpCq+j3sJhqQ14RNEEL45Ot/rgq3jAlZDD/8ufeqq+W8p4gUhSrbGWCRL82NEIWY9SYwxYXGXjRcVPSHiA1Q==
 
-"@sentry/status-page-list@^0.2.0":
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/@sentry/status-page-list/-/status-page-list-0.2.0.tgz#f82dec256ccf412cc97d71245bd87300ec56deca"
-  integrity sha512-Ulu7dhQrkB8zDA1f6nDPGOB4nIQj7QBI3Mk3fHn9W9KMVYeY7wi+0u01aV2aO7JnCkXHihzRnuLyTgulVJuQWg==
+"@sentry/status-page-list@^0.3.0":
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/@sentry/status-page-list/-/status-page-list-0.3.0.tgz#d5520057007be1a021933aae26dfa6a4a3981c40"
+  integrity sha512-v/MkVOvs48QioXt7Ex8gmZEFGvjukWqx2DlIej+Ac4pVQJAfzF6/DFFVT3IK8/owIqv/IdEhY0XzHOcIB0yBIA==
 
 "@sentry/types@8.12.0-beta.0", "@sentry/types@^8.12.0-beta.0":
   version "8.12.0-beta.0"


### PR DESCRIPTION
https://github.com/getsentry/status-page-list/releases/tag/0.3.0

> This release adds entries for Chief Tools, Hex, Laravel, Make, and Python.