### PR TITLE
feat(query-builder): Focus filter when pressing backspace and value input is empty

### DIFF
--- a/static/app/components/searchQueryBuilder/filter.tsx
+++ b/static/app/components/searchQueryBuilder/filter.tsx
@@ -23,11 +23,15 @@ import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {defined} from 'sentry/utils';
 
-type SearchQueryTokenProps = {
+interface SearchQueryTokenProps {
   item: Node<ParseResultToken>;
   state: ListState<ParseResultToken>;
   token: TokenResult<Token.FILTER>;
-};
+}
+
+interface FilterValueProps extends SearchQueryTokenProps {
+  filterRef: React.RefObject<HTMLDivElement>;
+}
 
 function FilterValueText({token}: {token: TokenResult<Token.FILTER>}) {
   const {size} = useSearchQueryBuilder();
@@ -77,7 +81,7 @@ function FilterValueText({token}: {token: TokenResult<Token.FILTER>}) {
   }
 }
 
-function FilterValue({token, state, item}: SearchQueryTokenProps) {
+function FilterValue({token, state, item, filterRef}: FilterValueProps) {
   const ref = useRef<HTMLDivElement>(null);
   const {dispatch, focusOverride} = useSearchQueryBuilder();
 
@@ -108,6 +112,11 @@ function FilterValue({token, state, item}: SearchQueryTokenProps) {
         <SearchQueryBuilderValueCombobox
           token={token}
           wrapperRef={ref}
+          onDelete={() => {
+            filterRef.current?.focus();
+            state.selectionManager.setFocusedKey(item.key);
+            setIsEditing(false);
+          }}
           onCommit={() => {
             setIsEditing(false);
             if (state.collection.getKeyAfter(item.key)) {
@@ -190,7 +199,7 @@ export function SearchQueryBuilderFilter({item, state, token}: SearchQueryTokenP
         <FilterKeyOperator token={token} state={state} item={item} />
       </BaseGridCell>
       <FilterValueGridCell {...gridCellProps}>
-        <FilterValue token={token} state={state} item={item} />
+        <FilterValue token={token} state={state} item={item} filterRef={ref} />
       </FilterValueGridCell>
       <BaseGridCell {...gridCellProps}>
         <FilterDelete token={token} state={state} item={item} />

--- a/static/app/components/searchQueryBuilder/index.spec.tsx
+++ b/static/app/components/searchQueryBuilder/index.spec.tsx
@@ -717,7 +717,7 @@ describe('SearchQueryBuilder', function () {
       ).toHaveFocus();
     });
 
-    it('backspace does nothing when input is empty', async function () {
+    it('backspace focuses filter when input is empty', async function () {
       const mockOnChange = jest.fn();
       render(
         <SearchQueryBuilder
@@ -734,8 +734,8 @@ describe('SearchQueryBuilder', function () {
 
       await userEvent.keyboard('{Backspace}');
 
-      // Input should still have focus, and no changes should have been made
-      expect(screen.getByRole('combobox', {name: 'Edit filter value'})).toHaveFocus();
+      // Filter should now have focus, and no changes should have been made
+      expect(screen.getByRole('row', {name: 'age:-24h'})).toHaveFocus();
       expect(mockOnChange).not.toHaveBeenCalled();
     });
 

--- a/static/app/components/searchQueryBuilder/valueCombobox.tsx
+++ b/static/app/components/searchQueryBuilder/valueCombobox.tsx
@@ -777,7 +777,7 @@ export function SearchQueryBuilderValueCombobox({
         e.continuePropagation();
       }
 
-      // If at the start of the input and backspace is pressed, delete the last selected value
+      // If there's nothing in the input and we hit a delete key, we should focus the filter
       if ((e.key === 'Backspace' || e.key === 'Delete') && !inputRef.current?.value) {
         onDelete();
       }


### PR DESCRIPTION
When editing a tag value, pressing backspace with an empty input used to do nothing. This modifies the behavior to focus the whole token, allowing easier deletion if you change your mind while creating a filter.

https://github.com/getsentry/sentry/assets/10888943/4d31a032-eeed-4b83-ad91-307e25f19655

