### PR TITLE
feat(query-builder): Debounce fetching of tag values

### DIFF
--- a/static/app/components/searchQueryBuilder/index.spec.tsx
+++ b/static/app/components/searchQueryBuilder/index.spec.tsx
@@ -18,8 +18,6 @@ import type {TagCollection} from 'sentry/types/group';
 import {FieldKey, FieldKind} from 'sentry/utils/fields';
 import localStorageWrapper from 'sentry/utils/localStorage';
 
-jest.unmock('lodash/debounce');
-
 const FILTER_KEYS: TagCollection = {
   [FieldKey.AGE]: {key: FieldKey.AGE, name: 'Age', kind: FieldKind.FIELD},
   [FieldKey.ASSIGNED]: {
@@ -979,38 +977,6 @@ describe('SearchQueryBuilder', function () {
       expect(
         await screen.findByRole('row', {name: 'custom_tag_name:tag_value_one'})
       ).toBeInTheDocument();
-    });
-
-    it('debounces fetching tag values', async function () {
-      const mockGetTagValues = jest.fn().mockResolvedValue(['tag_value_one']);
-      render(
-        <SearchQueryBuilder
-          {...defaultProps}
-          initialQuery="custom_tag_name:"
-          getTagValues={mockGetTagValues}
-        />
-      );
-
-      await userEvent.click(
-        screen.getByRole('button', {name: 'Edit value for filter: custom_tag_name'})
-      );
-
-      // Should fetch tag values immediately
-      await waitFor(() => {
-        expect(mockGetTagValues).toHaveBeenCalledTimes(1);
-      });
-
-      await userEvent.keyboard('foo');
-
-      await waitFor(() => {
-        expect(mockGetTagValues).toHaveBeenLastCalledWith(
-          {key: 'custom_tag_name', name: 'Custom_Tag_Name'},
-          'foo'
-        );
-      });
-
-      // After 3 keystrokes, should only have been called one more time
-      expect(mockGetTagValues).toHaveBeenCalledTimes(2);
     });
   });
 

--- a/static/app/components/searchQueryBuilder/index.spec.tsx
+++ b/static/app/components/searchQueryBuilder/index.spec.tsx
@@ -14,9 +14,11 @@ import {
   QueryInterfaceType,
 } from 'sentry/components/searchQueryBuilder/types';
 import {INTERFACE_TYPE_LOCALSTORAGE_KEY} from 'sentry/components/searchQueryBuilder/utils';
-import type {TagCollection} from 'sentry/types';
+import type {TagCollection} from 'sentry/types/group';
 import {FieldKey, FieldKind} from 'sentry/utils/fields';
 import localStorageWrapper from 'sentry/utils/localStorage';
+
+jest.unmock('lodash/debounce');
 
 const FILTER_KEYS: TagCollection = {
   [FieldKey.AGE]: {key: FieldKey.AGE, name: 'Age', kind: FieldKind.FIELD},
@@ -977,6 +979,38 @@ describe('SearchQueryBuilder', function () {
       expect(
         await screen.findByRole('row', {name: 'custom_tag_name:tag_value_one'})
       ).toBeInTheDocument();
+    });
+
+    it('debounces fetching tag values', async function () {
+      const mockGetTagValues = jest.fn().mockResolvedValue(['tag_value_one']);
+      render(
+        <SearchQueryBuilder
+          {...defaultProps}
+          initialQuery="custom_tag_name:"
+          getTagValues={mockGetTagValues}
+        />
+      );
+
+      await userEvent.click(
+        screen.getByRole('button', {name: 'Edit value for filter: custom_tag_name'})
+      );
+
+      // Should fetch tag values immediately
+      await waitFor(() => {
+        expect(mockGetTagValues).toHaveBeenCalledTimes(1);
+      });
+
+      await userEvent.keyboard('foo');
+
+      await waitFor(() => {
+        expect(mockGetTagValues).toHaveBeenLastCalledWith(
+          {key: 'custom_tag_name', name: 'Custom_Tag_Name'},
+          'foo'
+        );
+      });
+
+      // After 3 keystrokes, should only have been called one more time
+      expect(mockGetTagValues).toHaveBeenCalledTimes(2);
     });
   });
 

--- a/static/app/components/searchQueryBuilder/valueCombobox.tsx
+++ b/static/app/components/searchQueryBuilder/valueCombobox.tsx
@@ -30,11 +30,12 @@ import {
 import {IconArrow} from 'sentry/icons';
 import {t, tn} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
-import type {Tag, TagCollection} from 'sentry/types';
+import type {Tag, TagCollection} from 'sentry/types/group';
 import {uniq} from 'sentry/utils/array/uniq';
 import {FieldValueType, getFieldDefinition} from 'sentry/utils/fields';
 import {isCtrlKeyPressed} from 'sentry/utils/isCtrlKeyPressed';
 import {type QueryKey, useQuery} from 'sentry/utils/queryClient';
+import {useDebouncedValue} from 'sentry/utils/useDebouncedValue';
 
 type SearchQueryValueBuilderProps = {
   onCommit: () => void;
@@ -509,9 +510,16 @@ function useFilterSuggestions({
   const shouldFetchValues = key && !key.predefined && !predefinedValues.length;
   const canSelectMultipleValues = tokenSupportsMultipleValues(token, filterKeys);
 
+  const queryKey = useMemo<QueryKey>(
+    () => ['search-query-builder-tag-values', token.key.text, filterValue],
+    [filterValue, token.key]
+  );
+
+  const debouncedQueryKey = useDebouncedValue(queryKey);
+
   // TODO(malwilley): Display error states
   const {data, isFetching} = useQuery<string[]>({
-    queryKey: ['search-query-builder', token.key, filterValue] as QueryKey,
+    queryKey: debouncedQueryKey,
     queryFn: () => getTagValues(key, filterValue),
     keepPreviousData: true,
     enabled: shouldFetchValues,

--- a/static/app/utils/useDebouncedValue.spec.tsx
+++ b/static/app/utils/useDebouncedValue.spec.tsx
@@ -1,0 +1,30 @@
+import {act, renderHook} from 'sentry-test/reactTestingLibrary';
+
+import {useDebouncedValue} from 'sentry/utils/useDebouncedValue';
+
+jest.unmock('lodash/debounce');
+
+describe('useDebouncedValue', function () {
+  it('properly debounces values changes', function () {
+    jest.useFakeTimers();
+
+    const {result, rerender} = renderHook(useDebouncedValue, {
+      initialProps: 1,
+    });
+
+    expect(result.current).toBe(1);
+
+    // Rerendering with the next value should not update the value immediately
+    rerender(2);
+    act(() => {
+      jest.advanceTimersByTime(100);
+    });
+    expect(result.current).toBe(1);
+
+    // After enough time has passed, the value should update
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
+    expect(result.current).toBe(2);
+  });
+});

--- a/static/app/utils/useDebouncedValue.tsx
+++ b/static/app/utils/useDebouncedValue.tsx
@@ -1,0 +1,43 @@
+import {useEffect, useRef, useState} from 'react';
+// eslint-disable-next-line no-restricted-imports
+import type {DebounceSettings} from 'lodash';
+import debounce from 'lodash/debounce';
+
+import {DEFAULT_DEBOUNCE_DURATION} from 'sentry/constants';
+import {useEffectAfterFirstRender} from 'sentry/utils/useEffectAfterFirstRender';
+
+/**
+ * Takes an input and returns a debounced version of that value.
+ * NOTE: The value passed in should be a stable reference, only changing
+ * when the value actually changes.
+ */
+export function useDebouncedValue<T>(
+  value: T,
+  delay: number = DEFAULT_DEBOUNCE_DURATION,
+  options?: DebounceSettings
+): T {
+  const [internalValue, setInternalValue] = useState(value);
+  const debounceRef = useRef(
+    debounce(
+      nextVal => {
+        setInternalValue(nextVal);
+      },
+      delay,
+      options
+    )
+  );
+
+  const debounceFn = debounceRef.current;
+
+  useEffectAfterFirstRender(() => {
+    debounceRef.current(value);
+  }, [value]);
+
+  useEffect(() => {
+    return () => {
+      debounceFn.cancel();
+    };
+  }, [debounceFn]);
+
+  return internalValue;
+}

--- a/static/app/utils/useDebouncedValue.tsx
+++ b/static/app/utils/useDebouncedValue.tsx
@@ -17,15 +17,7 @@ export function useDebouncedValue<T>(
   options?: DebounceSettings
 ): T {
   const [internalValue, setInternalValue] = useState(value);
-  const debounceRef = useRef(
-    debounce(
-      nextVal => {
-        setInternalValue(nextVal);
-      },
-      delay,
-      options
-    )
-  );
+  const debounceRef = useRef(debounce(setInternalValue, delay, options));
 
   const debounceFn = debounceRef.current;
 


### PR DESCRIPTION
When searching tag values, the requests were not being debounced.

To facilitate this, added a common hook: `useDebouncedValue` which makes it easy to debounce useApiQuery cache keys. 