### PR TITLE
chore(slack): Remove SlackClient Code from SlackEventsEndpoint

### DIFF
--- a/src/sentry/integrations/slack/webhooks/event.py
+++ b/src/sentry/integrations/slack/webhooks/event.py
@@ -10,12 +10,11 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 from slack_sdk.errors import SlackApiError
 
-from sentry import analytics, features, options
+from sentry import analytics, features
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import all_silo_endpoint
 from sentry.integrations.services.integration import integration_service
-from sentry.integrations.slack.client import SlackClient
 from sentry.integrations.slack.message_builder.help import SlackHelpMessageBuilder
 from sentry.integrations.slack.message_builder.prompt import SlackPromptLinkMessageBuilder
 from sentry.integrations.slack.metrics import (
@@ -28,7 +27,6 @@ from sentry.integrations.slack.sdk_client import SlackSdkClient
 from sentry.integrations.slack.unfurl import LinkType, UnfurlableUrl, link_handlers, match_link
 from sentry.integrations.slack.views.link_identity import build_linking_url
 from sentry.organizations.services.organization import organization_service
-from sentry.shared_integrations.exceptions import ApiError
 from sentry.utils import metrics
 
 from .base import SlackDMEndpoint
@@ -64,22 +62,12 @@ class SlackEventEndpoint(SlackDMEndpoint):
             "message": message,
         }
 
-        payload = {"channel": slack_request.channel_id, "text": message}
-        if options.get("slack.event-endpoint-sdk") or slack_request.integration.id in options.get(
-            "slack.event-endpoint-sdk-integration-ids"
-        ):
-            client = SlackSdkClient(integration_id=slack_request.integration.id)
-            try:
-                client.chat_postMessage(channel=slack_request.channel_id, text=message)
-            except SlackApiError:
-                _logger.exception("reply.post-message-error", extra=logger_params)
-                metrics.incr(self._METRIC_FAILURE_KEY + ".reply.post_message", sample_rate=1.0)
-        else:
-            client = SlackClient(integration_id=slack_request.integration.id)
-            try:
-                client.post("/chat.postMessage", data=payload, json=True)
-            except ApiError:
-                _logger.exception("slack.event.on-message-error")
+        client = SlackSdkClient(integration_id=slack_request.integration.id)
+        try:
+            client.chat_postMessage(channel=slack_request.channel_id, text=message)
+        except SlackApiError:
+            _logger.exception("reply.post-message-error", extra=logger_params)
+            metrics.incr(self._METRIC_FAILURE_KEY + ".reply.post_message", sample_rate=1.0)
 
         return self.respond()
 
@@ -119,28 +107,17 @@ class SlackEventEndpoint(SlackDMEndpoint):
             **payload,
         }
 
-        if options.get("slack.event-endpoint-sdk") or slack_request.integration.id in options.get(
-            "slack.event-endpoint-sdk-integration-ids"
-        ):
-            client = SlackSdkClient(integration_id=slack_request.integration.id)
-            try:
-                client.chat_postEphemeral(
-                    channel=slack_request.channel_id,
-                    user=slack_request.user_id,
-                    text=payload["text"],
-                    **SlackPromptLinkMessageBuilder(associate_url).as_payload(),
-                )
-            except SlackApiError:
-                _logger.exception("prompt_link.post-ephemeral-error", extra=logger_params)
-                metrics.incr(
-                    self._METRIC_FAILURE_KEY + ".prompt_link.post_ephemeral", sample_rate=1.0
-                )
-        else:
-            client = SlackClient(integration_id=slack_request.integration.id)
-            try:
-                client.post("/chat.postEphemeral", data=payload)
-            except ApiError as e:
-                _logger.exception("slack.event.unfurl-error", extra={"error": str(e)})
+        client = SlackSdkClient(integration_id=slack_request.integration.id)
+        try:
+            client.chat_postEphemeral(
+                channel=slack_request.channel_id,
+                user=slack_request.user_id,
+                text=payload["text"],
+                **SlackPromptLinkMessageBuilder(associate_url).as_payload(),
+            )
+        except SlackApiError:
+            _logger.exception("prompt_link.post-ephemeral-error", extra=logger_params)
+            metrics.incr(self._METRIC_FAILURE_KEY + ".prompt_link.post_ephemeral", sample_rate=1.0)
 
     def on_message(self, request: Request, slack_request: SlackDMRequest) -> Response:
         command = request.data.get("event", {}).get("text", "").lower()
@@ -160,24 +137,15 @@ class SlackEventEndpoint(SlackDMEndpoint):
             **payload,
         }
 
-        if options.get("slack.event-endpoint-sdk") or slack_request.integration.id in options.get(
-            "slack.event-endpoint-sdk-integration-ids"
-        ):
-            client = SlackSdkClient(integration_id=slack_request.integration.id)
-            try:
-                client.chat_postMessage(
-                    channel=slack_request.channel_id,
-                    **SlackHelpMessageBuilder(command).as_payload(),
-                )
-            except SlackApiError:
-                _logger.exception("on_message.post-message-error", extra=logger_params)
-                metrics.incr(self._METRIC_FAILURE_KEY + ".on_message.post_message", sample_rate=1.0)
-        else:
-            client = SlackClient(integration_id=slack_request.integration.id)
-            try:
-                client.post("/chat.postMessage", data=payload, json=True)
-            except ApiError:
-                _logger.exception("slack.event.on-message-error")
+        client = SlackSdkClient(integration_id=slack_request.integration.id)
+        try:
+            client.chat_postMessage(
+                channel=slack_request.channel_id,
+                **SlackHelpMessageBuilder(command).as_payload(),
+            )
+        except SlackApiError:
+            _logger.exception("on_message.post-message-error", extra=logger_params)
+            metrics.incr(self._METRIC_FAILURE_KEY + ".on_message.post_message", sample_rate=1.0)
 
         return self.respond()
 
@@ -278,27 +246,16 @@ class SlackEventEndpoint(SlackDMEndpoint):
             "unfurls": orjson.dumps(results).decode(),
         }
 
-        if options.get("slack.event-endpoint-sdk") or slack_request.integration.id in options.get(
-            "slack.event-endpoint-sdk-integration-ids"
-        ):
-            client = SlackSdkClient(integration_id=slack_request.integration.id)
-            try:
-                client.chat_unfurl(
-                    channel=data["channel"],
-                    ts=data["message_ts"],
-                    unfurls=payload["unfurls"],
-                )
-            except SlackApiError:
-                _logger.exception("on_link_shared.unfurl-error", extra=logger_params)
-                metrics.incr(self._METRIC_FAILURE_KEY + ".unfurl", sample_rate=1.0)
-        else:
-            client = SlackClient(integration_id=slack_request.integration.id)
-            try:
-                client.post("/chat.unfurl", data=payload)
-            except ApiError as e:
-                _logger.exception(
-                    "slack.event.unfurl-error", extra={"error": str(e), "payload": payload}
-                )
+        client = SlackSdkClient(integration_id=slack_request.integration.id)
+        try:
+            client.chat_unfurl(
+                channel=data["channel"],
+                ts=data["message_ts"],
+                unfurls=payload["unfurls"],
+            )
+        except SlackApiError:
+            _logger.exception("on_link_shared.unfurl-error", extra=logger_params)
+            metrics.incr(self._METRIC_FAILURE_KEY + ".unfurl", sample_rate=1.0)
 
         return True
 

--- a/tests/sentry/integrations/slack/webhooks/events/test_link_shared.py
+++ b/tests/sentry/integrations/slack/webhooks/events/test_link_shared.py
@@ -1,6 +1,5 @@
 import re
 from unittest.mock import Mock, patch
-from urllib.parse import parse_qsl
 
 import orjson
 import pytest
@@ -8,7 +7,6 @@ import responses
 from slack_sdk.web import SlackResponse
 
 from sentry.integrations.slack.unfurl import Handler, make_type_coercer
-from sentry.testutils.helpers.options import override_options
 
 from . import LINK_SHARED_EVENT, BaseEventTest, build_test_block
 
@@ -51,43 +49,6 @@ class LinkSharedEventTest(BaseEventTest):
             )
         },
     )
-    def test_share_links(self, mock_match_link):
-        responses.add(responses.POST, "https://slack.com/api/chat.unfurl", json={"ok": True})
-
-        resp = self.post_webhook(event_data=orjson.loads(LINK_SHARED_EVENT))
-        assert resp.status_code == 200, resp.content
-        assert len(mock_match_link.mock_calls) == 3
-
-        data = dict(parse_qsl(responses.calls[0].request.body))
-        unfurls = orjson.loads(data["unfurls"])
-
-        # We only have two unfurls since one link was duplicated
-        assert len(unfurls) == 2
-        assert unfurls["link1"] == "unfurl"
-        assert unfurls["link2"] == "unfurl"
-
-    @responses.activate
-    @patch(
-        "sentry.integrations.slack.webhooks.event.match_link",
-        # match_link will be called twice, for each our links. Resolve into
-        # two unique links and one duplicate.
-        side_effect=[
-            ("mock_link", {"arg1": "value1"}),
-            ("mock_link", {"arg1", "value2"}),
-            ("mock_link", {"arg1": "value1"}),
-        ],
-    )
-    @patch(
-        "sentry.integrations.slack.webhooks.event.link_handlers",
-        {
-            "mock_link": Handler(
-                matcher=[re.compile(r"test")],
-                arg_mapper=make_type_coercer({}),
-                fn=Mock(return_value={"link1": "unfurl", "link2": "unfurl"}),
-            )
-        },
-    )
-    @override_options({"slack.event-endpoint-sdk": True})
     def test_share_links_sdk(self, mock_match_link):
         resp = self.post_webhook(event_data=orjson.loads(LINK_SHARED_EVENT))
         assert resp.status_code == 200, resp.content
@@ -101,7 +62,6 @@ class LinkSharedEventTest(BaseEventTest):
         assert unfurls["link1"] == "unfurl"
         assert unfurls["link2"] == "unfurl"
 
-    @responses.activate
     @patch(
         "sentry.integrations.slack.webhooks.event.match_link",
         # match_link will be called twice, for each our links. Resolve into
@@ -127,51 +87,6 @@ class LinkSharedEventTest(BaseEventTest):
             )
         },
     )
-    def test_share_links_block_kit(self, mock_match_link):
-        responses.add(responses.POST, "https://slack.com/api/chat.unfurl", json={"ok": True})
-
-        resp = self.post_webhook(event_data=orjson.loads(LINK_SHARED_EVENT))
-        assert resp.status_code == 200, resp.content
-        assert len(mock_match_link.mock_calls) == 3
-
-        data = dict(parse_qsl(responses.calls[0].request.body))
-        unfurls = orjson.loads(data["unfurls"])
-
-        # We only have two unfurls since one link was duplicated
-        assert len(unfurls) == 2
-        result1 = build_test_block(LINK_SHARED_EVENT[0])
-        del result1["text"]
-        result2 = build_test_block(LINK_SHARED_EVENT[1])
-        del result2["text"]
-        assert unfurls["link1"] == result1
-        assert unfurls["link2"] == result2
-
-    @patch(
-        "sentry.integrations.slack.webhooks.event.match_link",
-        # match_link will be called twice, for each our links. Resolve into
-        # two unique links and one duplicate.
-        side_effect=[
-            ("mock_link", {"arg1": "value1"}),
-            ("mock_link", {"arg1", "value2"}),
-            ("mock_link", {"arg1": "value1"}),
-        ],
-    )
-    @patch(
-        "sentry.integrations.slack.webhooks.event.link_handlers",
-        {
-            "mock_link": Handler(
-                matcher=[re.compile(r"test")],
-                arg_mapper=make_type_coercer({}),
-                fn=Mock(
-                    return_value={
-                        "link1": build_test_block(LINK_SHARED_EVENT[0]),
-                        "link2": build_test_block(LINK_SHARED_EVENT[1]),
-                    }
-                ),
-            )
-        },
-    )
-    @override_options({"slack.event-endpoint-sdk": True})
     def test_share_links_block_kit_sdk(self, mock_match_link):
         resp = self.post_webhook(event_data=orjson.loads(LINK_SHARED_EVENT))
         assert resp.status_code == 200, resp.content

--- a/tests/sentry/integrations/slack/webhooks/events/test_message_im.py
+++ b/tests/sentry/integrations/slack/webhooks/events/test_message_im.py
@@ -75,16 +75,6 @@ class MessageIMEventTest(BaseEventTest, IntegratedApiTestCase):
         ) as self.mock_post:
             yield
 
-    @responses.activate
-    def test_identifying_channel_correctly(self):
-        responses.add(responses.POST, "https://slack.com/api/chat.postMessage", json={"ok": True})
-        event_data = orjson.loads(MESSAGE_IM_EVENT)
-        self.post_webhook(event_data=event_data)
-        request = responses.calls[0].request
-        data = orjson.loads(request.body)
-        assert data.get("channel") == event_data["channel"]
-
-    @override_options({"slack.event-endpoint-sdk": True})
     def test_identifying_channel_correctly_sdk(self):
         event_data = orjson.loads(MESSAGE_IM_EVENT)
         self.post_webhook(event_data=event_data)
@@ -98,24 +88,6 @@ class MessageIMEventTest(BaseEventTest, IntegratedApiTestCase):
             data = self.mock_post.call_args[1]
             assert data.get("channel") == event_data["channel"]
 
-    @responses.activate
-    def test_user_message_im_notification_platform(self):
-        responses.add(responses.POST, "https://slack.com/api/chat.postMessage", json={"ok": True})
-        resp = self.post_webhook(event_data=orjson.loads(MESSAGE_IM_EVENT))
-        assert resp.status_code == 200, resp.content
-
-        assert len(responses.calls) == 1
-        request = responses.calls[0].request
-        assert request.headers["Authorization"] == "Bearer xoxb-xxxxxxxxx-xxxxxxxxxx-xxxxxxxxxxxx"
-        data = orjson.loads(request.body)
-        heading, contents = self.get_block_section_text(data)
-        assert heading == "Unknown command: `helloo`"
-        assert (
-            contents
-            == "Here are the commands you can use. Commands not working? Re-install the app!"
-        )
-
-    @override_options({"slack.event-endpoint-sdk": True})
     def test_user_message_im_notification_platform_sdk(self):
         resp = self.post_webhook(event_data=orjson.loads(MESSAGE_IM_EVENT))
         assert resp.status_code == 200, resp.content
@@ -128,25 +100,6 @@ class MessageIMEventTest(BaseEventTest, IntegratedApiTestCase):
             == "Here are the commands you can use. Commands not working? Re-install the app!"
         )
 
-    @responses.activate
-    def test_user_message_link(self):
-        """
-        Test that when a user types in "link" to the DM we reply with the correct response.
-        """
-        with assume_test_silo_mode(SiloMode.CONTROL):
-            self.create_identity_provider(type="slack", external_id="TXXXXXXX1")
-
-        responses.add(responses.POST, "https://slack.com/api/chat.postMessage", json={"ok": True})
-        resp = self.post_webhook(event_data=orjson.loads(MESSAGE_IM_EVENT_LINK))
-        assert resp.status_code == 200, resp.content
-
-        assert len(responses.calls) == 1
-        request = responses.calls[0].request
-        assert request.headers["Authorization"] == "Bearer xoxb-xxxxxxxxx-xxxxxxxxxx-xxxxxxxxxxxx"
-        data = orjson.loads(request.body)
-        assert "Link your Slack identity" in get_response_text(data)
-
-    @override_options({"slack.event-endpoint-sdk": True})
     def test_user_message_link_sdk(self):
         """
         Test that when a user types in "link" to the DM we reply with the correct response.
@@ -160,33 +113,6 @@ class MessageIMEventTest(BaseEventTest, IntegratedApiTestCase):
         data = self.mock_post.call_args[1]
         assert "Link your Slack identity" in get_response_text(data)
 
-    @responses.activate
-    def test_user_message_already_linked(self):
-        """
-        Test that when a user who has already linked their identity types in
-        "link" to the DM we reply with the correct response.
-        """
-        with assume_test_silo_mode(SiloMode.CONTROL):
-            idp = self.create_identity_provider(type="slack", external_id="TXXXXXXX1")
-            Identity.objects.create(
-                external_id="UXXXXXXX1",
-                idp=idp,
-                user=self.user,
-                status=IdentityStatus.VALID,
-                scopes=[],
-            )
-
-        responses.add(responses.POST, "https://slack.com/api/chat.postMessage", json={"ok": True})
-        resp = self.post_webhook(event_data=orjson.loads(MESSAGE_IM_EVENT_LINK))
-        assert resp.status_code == 200, resp.content
-
-        assert len(responses.calls) == 1
-        request = responses.calls[0].request
-        assert request.headers["Authorization"] == "Bearer xoxb-xxxxxxxxx-xxxxxxxxxx-xxxxxxxxxxxx"
-        data = orjson.loads(request.body)
-        assert "You are already linked" in get_response_text(data)
-
-    @override_options({"slack.event-endpoint-sdk": True})
     def test_user_message_already_linked_sdk(self):
         """
         Test that when a user who has already linked their identity types in
@@ -208,32 +134,6 @@ class MessageIMEventTest(BaseEventTest, IntegratedApiTestCase):
         data = self.mock_post.call_args[1]
         assert "You are already linked" in get_response_text(data)
 
-    @responses.activate
-    def test_user_message_unlink(self):
-        """
-        Test that when a user types in "unlink" to the DM we reply with the correct response.
-        """
-        with assume_test_silo_mode(SiloMode.CONTROL):
-            idp = self.create_identity_provider(type="slack", external_id="TXXXXXXX1")
-            Identity.objects.create(
-                external_id="UXXXXXXX1",
-                idp=idp,
-                user=self.user,
-                status=IdentityStatus.VALID,
-                scopes=[],
-            )
-
-        responses.add(responses.POST, "https://slack.com/api/chat.postMessage", json={"ok": True})
-        resp = self.post_webhook(event_data=orjson.loads(MESSAGE_IM_EVENT_UNLINK))
-        assert resp.status_code == 200, resp.content
-
-        assert len(responses.calls) == 1
-        request = responses.calls[0].request
-        assert request.headers["Authorization"] == "Bearer xoxb-xxxxxxxxx-xxxxxxxxxx-xxxxxxxxxxxx"
-        data = orjson.loads(request.body)
-        assert "Click here to unlink your identity" in get_response_text(data)
-
-    @override_options({"slack.event-endpoint-sdk": True})
     def test_user_message_unlink_sdk(self):
         """
         Test that when a user types in "unlink" to the DM we reply with the correct response.
@@ -254,26 +154,6 @@ class MessageIMEventTest(BaseEventTest, IntegratedApiTestCase):
         data = self.mock_post.call_args[1]
         assert "Click here to unlink your identity" in get_response_text(data)
 
-    @responses.activate
-    def test_user_message_already_unlinked(self):
-        """
-        Test that when a user without an Identity types in "unlink" to the DM we
-        reply with the correct response.
-        """
-        with assume_test_silo_mode(SiloMode.CONTROL):
-            self.create_identity_provider(type="slack", external_id="TXXXXXXX1")
-
-        responses.add(responses.POST, "https://slack.com/api/chat.postMessage", json={"ok": True})
-        resp = self.post_webhook(event_data=orjson.loads(MESSAGE_IM_EVENT_UNLINK))
-        assert resp.status_code == 200, resp.content
-
-        assert len(responses.calls) == 1
-        request = responses.calls[0].request
-        assert request.headers["Authorization"] == "Bearer xoxb-xxxxxxxxx-xxxxxxxxxx-xxxxxxxxxxxx"
-        data = orjson.loads(request.body)
-        assert "You do not have a linked identity to unlink" in get_response_text(data)
-
-    @override_options({"slack.event-endpoint-sdk": True})
     def test_user_message_already_unlinked_sdk(self):
         """
         Test that when a user without an Identity types in "unlink" to the DM we
@@ -299,7 +179,6 @@ class MessageIMEventTest(BaseEventTest, IntegratedApiTestCase):
         assert resp.status_code == 200, resp.content
         assert len(responses.calls) == 0
 
-    @override_options({"slack.event-endpoint-sdk": True})
     def test_user_message_im_no_text_sdk(self):
         resp = self.post_webhook(event_data=orjson.loads(MESSAGE_IM_EVENT_NO_TEXT))
         assert resp.status_code == 200, resp.content


### PR DESCRIPTION
We GA'ed the Slack SDK, so performing housekeeping 