### PR TITLE
ref(ui): add copy button to `StructuredEventData`

### DIFF
--- a/static/app/components/structuredEventData/index.stories.tsx
+++ b/static/app/components/structuredEventData/index.stories.tsx
@@ -1,5 +1,6 @@
 import {Fragment} from 'react';
 
+import {addSuccessMessage} from 'sentry/actionCreators/indicator';
 import JSXNode from 'sentry/components/stories/jsxNode';
 import JSXProperty from 'sentry/components/stories/jsxProperty';
 import StructuredEventData from 'sentry/components/structuredEventData';
@@ -53,6 +54,25 @@ export default storyBook(StructuredEventData, story => {
           config={{
             renderNull: () => 'nulllllll',
             isBoolean: value => value === 'this_should_look_like_a_boolean',
+          }}
+        />
+      </Fragment>
+    );
+  });
+
+  story('Allow copy to clipboard', () => {
+    return (
+      <Fragment>
+        <p>
+          Using the <JSXProperty name="showCopyButton" value /> property and
+          <JSXProperty name="onCopy" value /> callback, you can customize whether to show
+          a copy to clipboard button, and what happens when copy is pressed.
+        </p>
+        <StructuredEventData
+          data={{red: 'fish', blue: 'fish'}}
+          showCopyButton
+          onCopy={() => {
+            addSuccessMessage('Copied successfully!');
           }}
         />
       </Fragment>

--- a/static/app/components/structuredEventData/index.tsx
+++ b/static/app/components/structuredEventData/index.tsx
@@ -334,7 +334,17 @@ export default function StructuredEventData({
   ...props
 }: StructuredEventDataProps) {
   return (
-    <Fragment>
+    <pre {...props} style={{position: 'relative'}}>
+      <StructuredData
+        config={config}
+        value={data}
+        depth={0}
+        maxDefaultDepth={maxDefaultDepth}
+        meta={meta}
+        withAnnotatedText={withAnnotatedText}
+        forceDefaultExpand={forceDefaultExpand}
+      />
+      {children}
       {showCopyButton && (
         <StyledCopyButton
           borderless
@@ -344,19 +354,7 @@ export default function StructuredEventData({
           text={JSON.stringify(data, null, '\t')}
         />
       )}
-      <pre {...props}>
-        <StructuredData
-          config={config}
-          value={data}
-          depth={0}
-          maxDefaultDepth={maxDefaultDepth}
-          meta={meta}
-          withAnnotatedText={withAnnotatedText}
-          forceDefaultExpand={forceDefaultExpand}
-        />
-        {children}
-      </pre>
-    </Fragment>
+    </pre>
   );
 }
 
@@ -402,6 +400,5 @@ const ValueObjectKey = styled('span')`
 const StyledCopyButton = styled(CopyToClipboardButton)`
   position: absolute;
   right: ${space(1.5)};
-  z-index: 2;
-  margin: ${space(0.75)} ${space(1)};
+  top: ${space(0.75)};
 `;

--- a/static/app/components/structuredEventData/index.tsx
+++ b/static/app/components/structuredEventData/index.tsx
@@ -401,7 +401,7 @@ const ValueObjectKey = styled('span')`
 
 const StyledCopyButton = styled(CopyToClipboardButton)`
   position: absolute;
-  right: ${space(0.5)};
+  right: ${space(1.5)};
   z-index: 2;
-  margin: ${space(0.75)} ${space(1.5)};
+  margin: ${space(0.75)} ${space(1)};
 `;

--- a/static/app/components/structuredEventData/index.tsx
+++ b/static/app/components/structuredEventData/index.tsx
@@ -2,11 +2,13 @@ import {Fragment, isValidElement} from 'react';
 import styled from '@emotion/styled';
 
 import {openNavigateToExternalLinkModal} from 'sentry/actionCreators/modal';
+import {CopyToClipboardButton} from 'sentry/components/copyToClipboardButton';
 import {AnnotatedText} from 'sentry/components/events/meta/annotatedText';
 import ExternalLink from 'sentry/components/links/externalLink';
 import {CollapsibleValue} from 'sentry/components/structuredEventData/collapsibleValue';
 import {IconOpen} from 'sentry/icons';
 import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
 import {defined} from 'sentry/utils';
 import {isUrl} from 'sentry/utils/string/isUrl';
 
@@ -43,6 +45,8 @@ export type StructuredEventDataProps = {
   forceDefaultExpand?: boolean;
   maxDefaultDepth?: number;
   meta?: Record<any, any>;
+  onCopy?: (copiedCode: string) => void;
+  showCopyButton?: boolean;
   withAnnotatedText?: boolean;
 };
 
@@ -107,6 +111,7 @@ export function StructuredData({
   config?: StructedEventDataConfig;
   forceDefaultExpand?: boolean;
   objectKey?: string;
+  showCopyButton?: boolean;
   // TODO(TS): What possible types can `value` be?
   value?: any;
   withOnlyFormattedText?: boolean;
@@ -324,21 +329,34 @@ export default function StructuredEventData({
   data = null,
   withAnnotatedText = false,
   forceDefaultExpand,
+  showCopyButton,
+  onCopy,
   ...props
 }: StructuredEventDataProps) {
   return (
-    <pre {...props}>
-      <StructuredData
-        config={config}
-        value={data}
-        depth={0}
-        maxDefaultDepth={maxDefaultDepth}
-        meta={meta}
-        withAnnotatedText={withAnnotatedText}
-        forceDefaultExpand={forceDefaultExpand}
-      />
-      {children}
-    </pre>
+    <Fragment>
+      {showCopyButton && (
+        <StyledCopyButton
+          borderless
+          iconSize="xs"
+          onCopy={onCopy}
+          size="xs"
+          text={JSON.stringify(data, null, '\t')}
+        />
+      )}
+      <pre {...props}>
+        <StructuredData
+          config={config}
+          value={data}
+          depth={0}
+          maxDefaultDepth={maxDefaultDepth}
+          meta={meta}
+          withAnnotatedText={withAnnotatedText}
+          forceDefaultExpand={forceDefaultExpand}
+        />
+        {children}
+      </pre>
+    </Fragment>
   );
 }
 
@@ -379,4 +397,11 @@ const ValueNumber = styled('span')`
 
 const ValueObjectKey = styled('span')`
   color: var(--prism-keyword);
+`;
+
+const StyledCopyButton = styled(CopyToClipboardButton)`
+  position: absolute;
+  right: ${space(0.5)};
+  z-index: 2;
+  margin: ${space(0.75)} ${space(1.5)};
 `;

--- a/static/app/components/structuredEventData/index.tsx
+++ b/static/app/components/structuredEventData/index.tsx
@@ -334,7 +334,7 @@ export default function StructuredEventData({
   ...props
 }: StructuredEventDataProps) {
   return (
-    <pre {...props} style={{position: 'relative'}}>
+    <StructuredDataWrapper {...props}>
       <StructuredData
         config={config}
         value={data}
@@ -354,7 +354,7 @@ export default function StructuredEventData({
           text={JSON.stringify(data, null, '\t')}
         />
       )}
-    </pre>
+    </StructuredDataWrapper>
   );
 }
 
@@ -401,4 +401,8 @@ const StyledCopyButton = styled(CopyToClipboardButton)`
   position: absolute;
   right: ${space(1.5)};
   top: ${space(0.75)};
+`;
+
+const StructuredDataWrapper = styled('pre')`
+  position: relative;
 `;


### PR DESCRIPTION
**motivation:** 
we want to replace our replay `ObjectInspector` usages in replay details with the issues `StructuredEventData` component. in replay, our component makes use of a copy to clipboard button, so i added this same functionality onto the `StructuredEventData` component as an optional prop (with option to specify `onCopy` callback).

behavior (using `StructuredEventData` here):



https://github.com/getsentry/sentry/assets/56095982/4cafda13-c763-425d-9f36-3429b5b6299f

relates to https://github.com/getsentry/sentry/issues/70042

