### PR TITLE
feat(feedback): rm unused post-process-group flag from test

### DIFF
--- a/tests/sentry/feedback/usecases/test_create_feedback.py
+++ b/tests/sentry/feedback/usecases/test_create_feedback.py
@@ -683,7 +683,6 @@ def test_create_feedback_spam_detection_set_status_ignored(
             "organizations:user-feedback-spam-filter-actions": True,
             "organizations:user-feedback-spam-filter-ingest": True,
             "organizations:feedback-ingest": True,
-            "organizations:feedback-post-process-group": True,
         }
     ):
         event = {


### PR DESCRIPTION
No references anywhere else in sentry and getsentry