### PR TITLE
feat(discover): Optionally pass dataset to mini card queries

### DIFF
--- a/static/app/views/discover/miniGraph.tsx
+++ b/static/app/views/discover/miniGraph.tsx
@@ -91,6 +91,7 @@ class MiniGraph extends Component<Props> {
       expired: eventView.expired,
       name: eventView.name,
       display,
+      dataset: eventView.dataset,
     };
   }
 
@@ -141,6 +142,7 @@ class MiniGraph extends Component<Props> {
       expired,
       name,
       display,
+      dataset,
     } = this.getRefreshProps(this.props);
 
     return (
@@ -162,6 +164,7 @@ class MiniGraph extends Component<Props> {
         expired={expired}
         name={name}
         referrer={referrer}
+        dataset={dataset}
         hideError
         partial
       >

--- a/static/app/views/discover/queryList.spec.tsx
+++ b/static/app/views/discover/queryList.spec.tsx
@@ -121,6 +121,65 @@ describe('Discover > QueryList', function () {
     await waitFor(() => {
       expect(screen.getAllByTestId(/card-.*/)).toHaveLength(5);
     });
+
+    expect(eventsStatsMock).toHaveBeenCalledWith(
+      '/organizations/org-slug/events-stats/',
+      expect.objectContaining({
+        query: {
+          environment: [],
+          interval: '30m',
+          partial: '1',
+          project: [],
+          query: '',
+          referrer: 'api.discover.default-chart',
+          statsPeriod: '14d',
+          yAxis: ['count()'],
+        },
+      })
+    );
+  });
+
+  it('passes dataset to the query if flag is enabled', async function () {
+    const org = OrganizationFixture({
+      features: [
+        'discover-basic',
+        'discover-query',
+        'performance-discover-dataset-selector',
+      ],
+    });
+    render(
+      <QueryList
+        savedQuerySearchQuery=""
+        router={RouterFixture()}
+        organization={org}
+        savedQueries={savedQueries}
+        renderPrebuilt
+        pageLinks=""
+        onQueryChange={queryChangeMock}
+        location={location}
+      />
+    );
+
+    await waitFor(() => {
+      expect(screen.getAllByTestId(/card-.*/)).toHaveLength(5);
+    });
+
+    expect(eventsStatsMock).toHaveBeenCalledWith(
+      '/organizations/org-slug/events-stats/',
+      expect.objectContaining({
+        query: {
+          environment: [],
+          interval: '30m',
+          partial: '1',
+          project: [],
+          query: '',
+          referrer: 'api.discover.default-chart',
+          statsPeriod: '14d',
+          yAxis: ['count()'],
+          dataset: 'transactions',
+        },
+      })
+    );
   });
 
   it('can duplicate and trigger change callback', async function () {

--- a/static/app/views/discover/queryList.tsx
+++ b/static/app/views/discover/queryList.tsx
@@ -25,6 +25,7 @@ import {decodeList} from 'sentry/utils/queryString';
 import withApi from 'sentry/utils/withApi';
 
 import {
+  getSavedQueryWithDataset,
   handleCreateQuery,
   handleDeleteQuery,
   handleUpdateHomepageQuery,
@@ -233,7 +234,12 @@ class QueryList extends Component<Props> {
       return [];
     }
 
-    return savedQueries.map((savedQuery, index) => {
+    return savedQueries.map((query, index) => {
+      const savedQuery = organization.features.includes(
+        'performance-discover-dataset-selector'
+      )
+        ? (getSavedQueryWithDataset(query) as SavedQuery)
+        : query;
       const eventView = EventView.fromSavedQuery(savedQuery);
       const recentTimeline = t('Last ') + eventView.statsPeriod;
       const customTimeline =

--- a/tests/js/fixtures/discover.ts
+++ b/tests/js/fixtures/discover.ts
@@ -1,4 +1,5 @@
 import type {SavedQuery} from 'sentry/types/organization';
+import { SavedQueryDatasets } from 'sentry/utils/discover/types';
 
 export function DiscoverSavedQueryFixture(params = {}): SavedQuery {
   return {
@@ -8,6 +9,7 @@ export function DiscoverSavedQueryFixture(params = {}): SavedQuery {
     dateUpdated: '2018-09-24T00:00:00.000Z',
     fields: ['test'],
     version: 2,
+    queryDataset: SavedQueryDatasets.TRANSACTIONS,
     ...params,
   };
 }


### PR DESCRIPTION
Also pass down dataset to mini query cards if flag is enabled