### PR TITLE
chore(trace-explorer): Remove experimental sorting of traces

### DIFF
--- a/static/app/views/traces/content.tsx
+++ b/static/app/views/traces/content.tsx
@@ -20,7 +20,6 @@ import Panel from 'sentry/components/panels/panel';
 import PanelHeader from 'sentry/components/panels/panelHeader';
 import PanelItem from 'sentry/components/panels/panelItem';
 import PerformanceDuration from 'sentry/components/performanceDuration';
-import {IconArrow} from 'sentry/icons/iconArrow';
 import {IconChevron} from 'sentry/icons/iconChevron';
 import {IconClose} from 'sentry/icons/iconClose';
 import {IconWarning} from 'sentry/icons/iconWarning';
@@ -75,8 +74,6 @@ const ONE_MINUTE = 60 * 1000; // in milliseconds
 
 export function Content() {
   const location = useLocation();
-
-  const organization = useOrganization();
 
   const limit = useMemo(() => {
     return decodeInteger(location.query.perPage, DEFAULT_PER_PAGE);
@@ -140,14 +137,9 @@ export function Content() {
     [location, queries]
   );
 
-  const sortByTimestamp = organization.features.includes(
-    'performance-trace-explorer-sorting'
-  );
-
   const tracesQuery = useTraces({
     limit,
     query: queries,
-    sort: sortByTimestamp ? '-timestamp' : undefined,
     mri: hasMetric ? mri : undefined,
     metricsMax: hasMetric ? metricsMax : undefined,
     metricsMin: hasMetric ? metricsMin : undefined,
@@ -159,7 +151,7 @@ export function Content() {
   const isError = !isLoading && tracesQuery.isError;
   const isEmpty = !isLoading && !isError && (tracesQuery?.data?.data?.length ?? 0) === 0;
   const rawData = !isLoading && !isError ? tracesQuery?.data?.data : undefined;
-  const data = sortByTimestamp ? rawData : normalizeTraces(rawData);
+  const data = normalizeTraces(rawData);
 
   return (
     <LayoutMain fullWidth>
@@ -220,7 +212,6 @@ export function Content() {
           </StyledPanelHeader>
           <StyledPanelHeader align="right" lightText>
             {t('Timestamp')}
-            {sortByTimestamp ? <IconArrow size="xs" direction="down" /> : null}
           </StyledPanelHeader>
           <StyledPanelHeader align="right" lightText>
             {t('Issues')}

--- a/static/app/views/traces/hooks/useTraces.tsx
+++ b/static/app/views/traces/hooks/useTraces.tsx
@@ -63,7 +63,6 @@ interface UseTracesOptions {
   metricsQuery?: string;
   mri?: string;
   query?: string | string[];
-  sort?: '-timestamp';
 }
 
 export function useTraces({
@@ -76,7 +75,6 @@ export function useTraces({
   metricsOp,
   metricsQuery,
   query,
-  sort,
 }: UseTracesOptions) {
   const organization = useOrganization();
   const {projects} = useProjects();
@@ -90,7 +88,6 @@ export function useTraces({
       environment: selection.environments,
       ...(datetime ?? normalizeDateTimeParams(selection.datetime)),
       query,
-      sort,
       per_page: limit,
       breakdownSlices: BREAKDOWN_SLICES,
       mri,


### PR DESCRIPTION
This sorting timedout very often because the table was not meant to be query in small chunks like this. Removing this until we're ready to try again.