### PR TITLE
chore(trace-explorer): Remove experimental sorting of traces query

### DIFF
--- a/src/sentry/api/endpoints/organization_traces.py
+++ b/src/sentry/api/endpoints/organization_traces.py
@@ -1,10 +1,8 @@
 import dataclasses
 import math
-import time
 from collections import defaultdict
 from collections.abc import Callable, Generator, Mapping, MutableMapping, Sequence
 from contextlib import contextmanager
-from dataclasses import replace
 from datetime import datetime, timedelta
 from typing import Any, Literal, NotRequired, TypedDict, cast
 
@@ -93,7 +91,6 @@ class OrganizationTracesSerializer(serializers.Serializer):
     query = serializers.ListField(
         required=False, allow_empty=True, child=serializers.CharField(allow_blank=True)
     )
-    sort = serializers.CharField(required=False)
 
 
 @contextmanager
@@ -132,10 +129,6 @@ class OrganizationTracesEndpoint(OrganizationTracesEndpointBase):
             return Response(serializer.errors, status=400)
         serialized = serializer.validated_data
 
-        allow_sorting = features.has(
-            "organizations:performance-trace-explorer-sorting", organization, actor=request.user
-        )
-
         executor = TracesExecutor(
             params=cast(ParamsType, params),
             snuba_params=snuba_params,
@@ -147,7 +140,6 @@ class OrganizationTracesEndpoint(OrganizationTracesEndpointBase):
             mri=serialized.get("mri"),
             limit=self.get_per_page(request),
             breakdown_slices=serialized["breakdownSlices"],
-            sort=serialized.get("sort") if allow_sorting else None,
             get_all_projects=lambda: self.get_projects(
                 request,
                 organization,
@@ -320,7 +312,6 @@ class TracesExecutor:
         mri: str | None,
         limit: int,
         breakdown_slices: int,
-        sort: str | None,
         get_all_projects: Callable[[], list[Project]],
     ):
         self.params = params
@@ -333,11 +324,7 @@ class TracesExecutor:
         self.mri = mri
         self.limit = limit
         self.breakdown_slices = breakdown_slices
-        self.sort = sort
         self.get_all_projects = get_all_projects
-
-        if self.sort is not None:
-            sentry_sdk.set_tag("sort_key", self.sort)
 
     def params_with_all_projects(self) -> tuple[ParamsType, SnubaParams]:
         all_projects_snuba_params = dataclasses.replace(
@@ -434,15 +421,6 @@ class TracesExecutor:
             sentry_sdk.set_tag("mri", self.mri)
             return self.get_traces_matching_metric_conditions(params, snuba_params)
 
-        if self.sort is not None:
-            if self.sort == "-timestamp":  # only support timestamp descing for now
-                return self.get_traces_matching_span_conditions_timestamp_order(
-                    params, snuba_params
-                )
-            with sentry_sdk.isolation_scope() as scope:
-                scope.set_extra("sort", {"sort": self.sort})
-                sentry_sdk.capture_message("Unsupported sort specified")
-
         return self.get_traces_matching_span_conditions(params, snuba_params)
 
     def get_traces_matching_metric_conditions(
@@ -510,40 +488,6 @@ class TracesExecutor:
                 max_timestamp = max(max_timestamp, timestamp)
 
         return min_timestamp, max_timestamp, trace_ids
-
-    def get_traces_matching_span_conditions_timestamp_order(
-        self,
-        params: ParamsType,
-        snuba_params: SnubaParams,
-        trace_ids: list[str] | None = None,
-    ) -> tuple[datetime, datetime, list[str]]:
-        assert self.sort is not None
-
-        builder, timestamp_column = self.get_traces_matching_span_conditions_query(
-            params,
-            snuba_params,
-            sort=self.sort,
-        )
-
-        executor = OrderedTracesExecutor(
-            params=params,
-            snuba_params=snuba_params,
-            builder=builder,
-            limit=self.limit,
-            timestamp_column=timestamp_column,
-            max_block_size_hours=options.get(
-                "performance.traces.trace-explorer-scan-max-block-size-hours"
-            ),
-            max_batches=options.get("performance.traces.trace-explorer-scan-max-batches"),
-            max_execution_seconds=options.get(
-                "performance.traces.trace-explorer-scan-max-execution-seconds"
-            ),
-            max_parallel_queries=options.get(
-                "performance.traces.trace-explorer-scan-max-parallel-queries"
-            ),
-        )
-
-        return executor.execute()
 
     def get_traces_matching_span_conditions(
         self,
@@ -768,13 +712,6 @@ class TracesExecutor:
         traces_occurrences_results,
         traces_breakdown_projects_results,
     ) -> list[TraceResult]:
-        if self.sort == "-timestamp":
-            traces_metas_results["data"].sort(
-                key=lambda row: row["last_seen()"],
-                reverse=True,
-            )
-
-        # mapping of trace id to a tuple of start/finish times
         traces_range = {
             row["trace"]: {
                 "start": row["first_seen()"],
@@ -1025,137 +962,6 @@ class TracesExecutor:
         )
 
         return query, Referrer.API_TRACE_EXPLORER_TRACES_OCCURRENCES
-
-
-class OrderedTracesExecutor:
-    # There needs to be an overlap between blocks to handle
-    # traces to happen to lie on the block boundaries.
-    buffer_size = timedelta(minutes=5)
-
-    def __init__(
-        self,
-        *,
-        params: ParamsType,
-        snuba_params: SnubaParams,
-        builder: BaseQueryBuilder,
-        limit: int,
-        timestamp_column: str,
-        max_block_size_hours: int,
-        max_batches: int,
-        max_execution_seconds: int,
-        max_parallel_queries: int,
-    ):
-        self.params = params
-        self.snuba_params = snuba_params
-        self.builder = builder
-        self.limit = limit
-        self.timestamp_column = timestamp_column
-
-        assert snuba_params.start is not None
-        assert snuba_params.end is not None
-
-        self.unscanned_start = snuba_params.start
-        self.unscanned_end = snuba_params.end
-
-        self.block_size = min(
-            self.unscanned_end - self.unscanned_start,
-            timedelta(hours=max_block_size_hours),
-        )
-        self.max_batches = max_batches
-        self.max_execution_seconds = max_execution_seconds
-        self.max_parallel_queries = max_parallel_queries
-
-    def has_more_to_scan(self) -> bool:
-        return self.unscanned_end > self.unscanned_start
-
-    def execute(self) -> tuple[datetime, datetime, list[str]]:
-        batches = 0
-
-        start_time = time.monotonic()
-
-        trace_ids: list[str] = []
-        seen_trace_ids: set[str] = set()
-        min_timestamp = self.snuba_params.end
-        max_timestamp = self.snuba_params.start
-        assert min_timestamp is not None
-        assert max_timestamp is not None
-
-        while (
-            len(trace_ids) < self.limit  # Not enough entries in result
-            and self.has_more_to_scan()
-            and batches < self.max_batches  # Still within the max batches limit
-            and time.monotonic() - start_time
-            < self.max_execution_seconds  # Still within the max execution limit
-        ):
-            batches += 1
-
-            data = self.query_next_batch()
-
-            for row in data:
-                trace_id = row["trace"]
-
-                if trace_id in seen_trace_ids:
-                    continue
-
-                trace_ids.append(trace_id)
-                seen_trace_ids.add(trace_id)
-
-                timestamp = datetime.fromisoformat(row[self.timestamp_column])
-                min_timestamp = min(min_timestamp, timestamp)
-                max_timestamp = max(max_timestamp, timestamp)
-
-                # Got enough results
-                if len(trace_ids) >= self.limit:
-                    break
-
-        # If this didn't find any matching traces but there's
-        # still more to scan, we treat it as if it timed out.
-        if not trace_ids and self.has_more_to_scan():
-            raise InvalidSearchQuery(TIMEOUT_SPAN_ERROR_MESSAGE)
-
-        return min_timestamp, max_timestamp, trace_ids
-
-    def query_next_batch(self):
-        base_request = self.builder.get_snql_query()
-
-        batch_queries = []
-
-        for _ in range(self.max_parallel_queries):
-            block_end: datetime = self.unscanned_end
-
-            # The last block is going to be queried in the next batch.
-            # Move the unscanned_end to indicate this.
-            self.unscanned_end -= self.block_size
-            self.unscanned_end = max(self.unscanned_end, self.unscanned_start)
-
-            # Include a small buffer in case the trace crosses the block boundary.
-            block_start: datetime = self.unscanned_end - self.buffer_size
-            block_start = max(block_start, self.unscanned_start)
-
-            if block_start >= block_end:  # empty block, no need to query it
-                break
-
-            # Make sure to copy the where list as it's a shared reference.
-            where = list(base_request.query.where) if base_request.query.where else []
-            where.append(Condition(self.builder.column("timestamp"), Op.GTE, block_start))
-            where.append(Condition(self.builder.column("timestamp"), Op.LT, block_end))
-            request = replace(base_request, query=base_request.query.set_where(where))
-
-            batch_queries.append(request)
-
-        if not batch_queries:
-            return
-
-        batch_results = bulk_snuba_queries(
-            [query for query in batch_queries],
-            Referrer.API_TRACE_EXPLORER_SPANS_LIST_SORTED.value,
-        )
-
-        data = []
-        for result in batch_results:
-            result = self.builder.process_results(result)
-            data.extend(result["data"])
-        return data
 
 
 class TraceSpansExecutor:

--- a/tests/sentry/api/endpoints/test_organization_traces.py
+++ b/tests/sentry/api/endpoints/test_organization_traces.py
@@ -7,11 +7,9 @@ from django.urls import reverse
 from rest_framework.exceptions import ErrorDetail
 
 from sentry.api.endpoints.organization_traces import process_breakdowns
-from sentry.search.events.constants import TIMEOUT_SPAN_ERROR_MESSAGE
 from sentry.snuba.metrics.naming_layer.mri import SpanMRI, TransactionMRI
 from sentry.testutils.cases import APITestCase, BaseSpansTestCase
 from sentry.testutils.helpers.datetime import before_now
-from sentry.testutils.helpers.options import override_options
 from sentry.utils.samples import load_data
 
 
@@ -370,9 +368,7 @@ class OrganizationTracesEndpointTest(OrganizationTracesEndpointTestBase):
             "project": [],
             "field": ["id", "parent_span", "span.duration"],
             "query": "foo:[bar, baz]",
-            "suggestedQuery": "foo:baz span.duration:>0s",
             "maxSpansPerTrace": 3,
-            "sort": ["-span.duration"],
         }
 
         response = self.do_request(query)
@@ -464,7 +460,6 @@ class OrganizationTracesEndpointTest(OrganizationTracesEndpointTestBase):
             "field": ["id", "parent_span", "span.duration"],
             "query": "",
             "maxSpansPerTrace": 3,
-            "sort": ["-span.duration"],
         }
 
         response = self.do_request(query)
@@ -540,7 +535,6 @@ class OrganizationTracesEndpointTest(OrganizationTracesEndpointTestBase):
             "field": ["id", "parent_span", "span.duration"],
             "query": "",
             "maxSpansPerTrace": 3,
-            "sort": ["-span.duration"],
         }
 
         response = self.do_request(query)
@@ -596,7 +590,6 @@ class OrganizationTracesEndpointTest(OrganizationTracesEndpointTestBase):
             query = {
                 "project": [self.project.id],
                 "field": ["id", "parent_span", "span.duration"],
-                "sort": ["-span.duration"],
             }
 
             response = self.do_request(query)
@@ -641,9 +634,7 @@ class OrganizationTracesEndpointTest(OrganizationTracesEndpointTestBase):
                     "project": [project_2.id],
                     "field": ["id", "parent_span", "span.duration"],
                     "query": q,
-                    "suggestedQuery": "foo:baz span.duration:>0s",
                     "maxSpansPerTrace": 4,
-                    "sort": ["-span.duration"],
                 }
 
                 response = self.do_request(query, features=features)
@@ -740,200 +731,6 @@ class OrganizationTracesEndpointTest(OrganizationTracesEndpointTestBase):
                     },
                 ]
 
-    def test_sorted(self):
-        (
-            _,
-            _,
-            trace_id_1,
-            trace_id_2,
-            trace_id_3,
-            _,
-            _,
-        ) = self.create_mock_traces()
-
-        for trace_ids in [
-            [trace_id_1, trace_id_2, trace_id_3],
-            [trace_id_1, trace_id_2],
-            [trace_id_1, trace_id_3],
-            [trace_id_2, trace_id_3],
-        ]:
-            query = {
-                "query": [f"trace:[{','.join(trace_ids)}]"],
-                "sort": "-timestamp",
-            }
-
-            response = self.do_request(
-                query,
-                features=[
-                    "organizations:performance-trace-explorer",
-                    "organizations:performance-trace-explorer-sorting",
-                ],
-            )
-            assert response.status_code == 200, response.data
-
-            assert response.data["meta"] == {
-                "dataset": "unknown",
-                "datasetReason": "unchanged",
-                "fields": {},
-                "isMetricsData": False,
-                "isMetricsExtractedData": False,
-                "tips": {},
-                "units": {},
-            }
-
-            assert [row["trace"] for row in response.data["data"]] == trace_ids
-
-    def test_sorted_by_trace_last_seen(self):
-        """
-        trace 1
-        [ span 1 - 70s       ]
-                          [ span 2 - 60s    ]
-
-        trace 2
-                 [ span 3 - 60s       ]
-
-        The query will match spans 1 and 3 using `foo:bar`, but the ordering
-        of the traces should be determined by spans 2 and 3. And since span 2
-        ends after span 3, trace 1 should come before trace 2 in the results.
-        """
-
-        trace_id_1 = uuid4().hex
-        trace_id_2 = uuid4().hex
-
-        span_ids = ["1" + uuid4().hex[:15] for _ in range(3)]
-
-        now = before_now().replace(hour=0, minute=0, second=0, microsecond=0)
-
-        self.double_write_segment(
-            project_id=self.project.id,
-            trace_id=trace_id_1,
-            transaction_id=uuid4().hex,
-            span_id=span_ids[0],
-            timestamp=now - timedelta(days=1, minutes=1),
-            duration=70_000,
-            exclusive_time=70_000,
-            tags={"foo": "bar"},
-        )
-
-        self.double_write_segment(
-            project_id=self.project.id,
-            trace_id=trace_id_1,
-            transaction_id=uuid4().hex,
-            span_id=span_ids[1],
-            parent_span_id=span_ids[0],
-            timestamp=now - timedelta(days=1),
-            duration=60_000,
-            exclusive_time=60_000,
-        )
-
-        self.double_write_segment(
-            project_id=self.project.id,
-            trace_id=trace_id_2,
-            transaction_id=uuid4().hex,
-            span_id=span_ids[2],
-            timestamp=now - timedelta(days=1, seconds=30),
-            duration=60_000,
-            exclusive_time=60_000,
-            tags={"foo": "bar"},
-        )
-
-        for q in [
-            ["foo:bar"],
-            ["foo:bar", f"project:{self.project.slug}"],
-        ]:
-            query = {
-                "query": q,
-                "sort": "-timestamp",
-            }
-
-            response = self.do_request(
-                query,
-                features=[
-                    "organizations:performance-trace-explorer",
-                    "organizations:performance-trace-explorer-sorting",
-                ],
-            )
-            assert response.status_code == 200, response.data
-
-            assert response.data["meta"] == {
-                "dataset": "unknown",
-                "datasetReason": "unchanged",
-                "fields": {},
-                "isMetricsData": False,
-                "isMetricsExtractedData": False,
-                "tips": {},
-                "units": {},
-            }
-
-            assert [row["trace"] for row in response.data["data"]] == [trace_id_1, trace_id_2]
-
-    def test_sorted_early_exit(self):
-        (
-            _,
-            _,
-            trace_id_1,
-            trace_id_2,
-            trace_id_3,
-            _,
-            _,
-        ) = self.create_mock_traces()
-
-        trace_ids = [trace_id_1, trace_id_2, trace_id_3]
-        query = {
-            "query": [f"trace:[{','.join(trace_ids)}]"],
-            "sort": "-timestamp",
-            "per_page": 2,
-        }
-
-        response = self.do_request(
-            query,
-            features=[
-                "organizations:performance-trace-explorer",
-                "organizations:performance-trace-explorer-sorting",
-            ],
-        )
-        assert response.status_code == 200, response.data
-
-        assert response.data["meta"] == {
-            "dataset": "unknown",
-            "datasetReason": "unchanged",
-            "fields": {},
-            "isMetricsData": False,
-            "isMetricsExtractedData": False,
-            "tips": {},
-            "units": {},
-        }
-
-        # even though we searched for 3, it should exit after 2
-        assert [row["trace"] for row in response.data["data"]] == [trace_id_1, trace_id_2]
-
-    @override_options(
-        {
-            "performance.traces.trace-explorer-scan-max-block-size-hours": 1,
-            "performance.traces.trace-explorer-scan-max-batches": 1,
-            "performance.traces.trace-explorer-scan-max-parallel-queries": 1,
-        }
-    )
-    def test_sorted_timeout(self):
-        self.create_mock_traces()
-
-        query = {
-            "sort": "-timestamp",
-        }
-
-        response = self.do_request(
-            query,
-            features=[
-                "organizations:performance-trace-explorer",
-                "organizations:performance-trace-explorer-sorting",
-            ],
-        )
-        assert response.status_code == 400, response.data
-
-        assert response.data == {
-            "detail": ErrorDetail(string=TIMEOUT_SPAN_ERROR_MESSAGE, code="parse_error"),
-        }
-
     def test_matching_tag_metrics(self):
         (
             project_1,
@@ -967,9 +764,7 @@ class OrganizationTracesEndpointTest(OrganizationTracesEndpointTestBase):
                     "metricsQuery": ["foo:qux"],
                     "project": [],
                     "field": ["id", "parent_span", "span.duration"],
-                    "suggestedQuery": ["foo:qux"],
                     "maxSpansPerTrace": 3,
-                    "sort": ["-span.duration"],
                     "per_page": 1,
                 }
                 if user_query:
@@ -1042,9 +837,7 @@ class OrganizationTracesEndpointTest(OrganizationTracesEndpointTestBase):
                     "project": [self.project.id],
                     "field": ["id", "parent_span", "span.duration"],
                     "query": "foo:foobar",
-                    "suggestedQuery": ["foo:qux"],
                     "maxSpansPerTrace": 3,
-                    "sort": ["-span.duration"],
                 }
 
                 response = self.do_request(query)


### PR DESCRIPTION
This experimental sorting was timing out too frequently, so removing it until we have a better solution.