### PR TITLE
metrics(feedback): additional user report counters

### DIFF
--- a/src/sentry/ingest/userreport.py
+++ b/src/sentry/ingest/userreport.py
@@ -119,7 +119,6 @@ def save_userreport(
                 "ingest.user_report.shim_to_feedback",
                 extra={"project_id": project.id, "event_id": report["event_id"]},
             )
-
             shim_to_feedback(report, event, project, source)
 
         return report_instance

--- a/src/sentry/ingest/userreport.py
+++ b/src/sentry/ingest/userreport.py
@@ -89,6 +89,8 @@ def save_userreport(
             )
             report_instance = existing_report
 
+            metrics.incr("user_report.create_user_report.overwrite_duplicate")
+
         else:
             if report_instance.group_id:
                 report_instance.notify()
@@ -107,11 +109,17 @@ def save_userreport(
                 "has_feedback_ingest": has_feedback_ingest,
             },
         )
+        metrics.incr(
+            "user_report.create_user_report.saved",
+            tags={"has_event": bool(event), "has_feedback_ingest": has_feedback_ingest},
+        )
+
         if has_feedback_ingest and event:
             logger.info(
                 "ingest.user_report.shim_to_feedback",
                 extra={"project_id": project.id, "event_id": report["event_id"]},
             )
+
             shim_to_feedback(report, event, project, source)
 
         return report_instance

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -1427,7 +1427,10 @@ def link_event_to_user_report(job: PostProcessJob) -> None:
         )
 
         if user_reports_updated:
-            metrics.incr("event_manager.save._update_user_reports_with_event_link_updated")
+            metrics.incr(
+                "event_manager.save._update_user_reports_with_event_link_updated",
+                amount=user_reports_updated.count(),
+            )
 
     else:
         UserReport.objects.filter(project_id=project.id, event_id=job["event"].event_id).update(

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -1421,16 +1421,14 @@ def link_event_to_user_report(job: PostProcessJob) -> None:
                 project,
                 FeedbackCreationSource.USER_REPORT_ENVELOPE,
             )
+            metrics.incr("event_manager.save._update_user_reports_with_event_link.shim_to_feedback")
 
         user_reports_updated = user_reports_without_group.update(
             group_id=group.id, environment_id=event.get_environment().id
         )
 
         if user_reports_updated:
-            metrics.incr(
-                "event_manager.save._update_user_reports_with_event_link_updated",
-                amount=user_reports_updated.count(),
-            )
+            metrics.incr("event_manager.save._update_user_reports_with_event_link_updated")
 
     else:
         UserReport.objects.filter(project_id=project.id, event_id=job["event"].event_id).update(


### PR DESCRIPTION
- Gives more detailed metrics on how many user reports are missing an event or blocked from new feedback. I tried querying gcp logs, but get different results each time I run the same query: https://cloudlogging.app.goo.gl/6MisKjx12nqxWCjV6
- Tracks the exact #reports updated by post process 