### PR TITLE
chore(slack): remove old client from webhook handling code

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -399,8 +399,6 @@ def register_temporary_features(manager: FeatureManager):
     # Feature flags for migrating to the Slack SDK WebClient
     # Use new Slack SDK Client in get_channel_id_with_timeout
     manager.add("organizations:slack-sdk-get-channel-id", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE)
-    # Use new Slack SDK Client in SlackActionEndpoint
-    manager.add("organizations:slack-sdk-webhook-handling", OrganizationFeature, FeatureHandlerStrategy.OPTIONS)
     # Use new Slack SDK Client in SlackActionEndpoint's `view.open`
     manager.add("organizations:slack-sdk-action-view-open", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE)
     # Use new Slack SDK Client for SlackNotifyBasicMixin

--- a/src/sentry/integrations/slack/metrics.py
+++ b/src/sentry/integrations/slack/metrics.py
@@ -36,6 +36,12 @@ SLACK_WEBHOOK_DM_ENDPOINT_SUCCESS_DATADOG_METRIC = "sentry.integrations.slack.dm
 SLACK_WEBHOOK_DM_ENDPOINT_FAILURE_DATADOG_METRIC = "sentry.integrations.slack.dm_endpoint.failure"
 SLACK_EVENT_ENDPOINT_SUCCESS_DATADOG_METRIC = "sentry.integrations.slack.event_endpoint.success"
 SLACK_EVENT_ENDPOINT_FAILURE_DATADOG_METRIC = "sentry.integrations.slack.event_endpoint.failure"
+SLACK_WEBHOOK_GROUP_ACTIONS_SUCCESS_DATADOG_METRIC = (
+    "sentry.integrations.slack.group_actions.success"
+)
+SLACK_WEBHOOK_GROUP_ACTIONS_FAILURE_DATADOG_METRIC = (
+    "sentry.integrations.slack.group_actions.failure"
+)
 
 # Slack Commands
 SLACK_COMMANDS_ENDPOINT_SUCCESS_DATADOG_METRIC = (

--- a/src/sentry/integrations/slack/webhooks/action.py
+++ b/src/sentry/integrations/slack/webhooks/action.py
@@ -648,13 +648,6 @@ class SlackActionEndpoint(Endpoint):
                 webhook_client.send(
                     blocks=json_blocks, delete_original=False, replace_original=True
                 )
-                logger.info(
-                    "slack.webhook.view_submission.success",
-                    extra={
-                        "integration_id": slack_request.integration.id,
-                        "blocks": json_blocks,
-                    },
-                )
                 metrics.incr(
                     SLACK_WEBHOOK_GROUP_ACTIONS_SUCCESS_DATADOG_METRIC,
                     sample_rate=1.0,
@@ -667,7 +660,12 @@ class SlackActionEndpoint(Endpoint):
                     tags={"type": "submit_modal"},
                 )
                 logger.error(
-                    "slack.webhook.view_submission.response-error", extra={"error": str(e)}
+                    "slack.webhook.view_submission.response-error",
+                    extra={
+                        "error": str(e),
+                        "integration_id": slack_request.integration.id,
+                        "organization_id": group.project.organization_id,
+                    },
                 )
 
             return self.respond()


### PR DESCRIPTION
Remove the old slack client completely from Slack code that handles updating a group, specifically removing from the code the processes updates from the archive and resolve modals (and updates the Slack message).

Also adds metrics for all of the group update code in Slack, we also have another place in the same function that updates the Slack message for group updates not through the modal (e.g. mark the issue as ongoing)