### PR TITLE
fix(migrations): Fix `update-migration` to work on migrations in other modules

### DIFF
--- a/bin/update-migration
+++ b/bin/update-migration
@@ -132,7 +132,9 @@ def main(migration: str, app_label: str):
 
     # Rename test if it exists.
     test_file_prefix = f"*{migration_meta.number}*"
-    migration_test_path = os.path.join(app_path, "..", "..", "tests", "sentry", "migrations")
+    migration_test_path = os.path.join(
+        settings.PROJECT_ROOT, os.path.pardir, os.path.pardir, "tests", "sentry", "migrations"
+    )
     matches = list(pathlib.Path(migration_test_path).glob(test_file_prefix))
     if len(matches) == 1:
         click.echo("> Updating migration test file to & from attributes")

--- a/bin/update-migration
+++ b/bin/update-migration
@@ -7,6 +7,7 @@ import re
 
 import click
 from django.apps import apps
+from django.conf import settings
 
 from sentry.runner import configure
 
@@ -121,7 +122,7 @@ def main(migration: str, app_label: str):
     click.echo("> Migration file rename complete")
 
     # Update lockfile
-    lockfile = os.path.join(app_path, "..", "..", "migrations_lockfile.txt")
+    lockfile = os.path.join(settings.MIGRATIONS_LOCKFILE_PATH, "migrations_lockfile.txt")
     with open(lockfile) as f:
         contents = f.read()
         contents = contents.replace(current_head.full_name, new_name)


### PR DESCRIPTION
If the path depth is different for a migration folder then we fail to update the lockfile. This uses the path from settings to fetch it in a more consistent way. Fixes the same bug for migration tests as well
