### PR TITLE
nit(opsgenie): add config access requirement to error text

### DIFF
--- a/src/sentry/integrations/opsgenie/actions/form.py
+++ b/src/sentry/integrations/opsgenie/actions/form.py
@@ -113,7 +113,7 @@ class OpsgenieNotifyTeamForm(forms.Form):
             raise forms.ValidationError(
                 _(
                     'The provided API key is invalid. Please make sure that the Opsgenie API \
-                  key is an integration key of type "Sentry".'
+                  key is an integration key of type "Sentry" that has configuration access.'
                 ),
                 code="invalid_key",
                 params=params,


### PR DESCRIPTION
Users who set up their Opsgenie API keys via the Opsgenie API were experiencing problems due to a lack of configuration access. However, the error message that they encountered did not indicate that this was the problem, so this PR makes the issue more clear.