### PR TITLE
feat(query-builder): Visually mark boolean ops and parens as invalid in the issue search

### DIFF
--- a/static/app/components/searchQueryBuilder/boolean.tsx
+++ b/static/app/components/searchQueryBuilder/boolean.tsx
@@ -20,7 +20,13 @@ export function SearchQueryBuilderBoolean({
   token,
 }: SearchQueryBuilderBooleanProps) {
   return (
-    <DeletableToken item={item} state={state} token={token} label={token.value}>
+    <DeletableToken
+      item={item}
+      state={state}
+      token={token}
+      label={token.value}
+      invalid={token.invalid}
+    >
       {token.text}
     </DeletableToken>
   );

--- a/static/app/components/searchQueryBuilder/index.spec.tsx
+++ b/static/app/components/searchQueryBuilder/index.spec.tsx
@@ -1474,4 +1474,71 @@ describe('SearchQueryBuilder', function () {
       });
     });
   });
+
+  describe('disallowLogicalOperators', function () {
+    it('should mark AND invalid', async function () {
+      render(
+        <SearchQueryBuilder
+          {...defaultProps}
+          disallowLogicalOperators
+          initialQuery="and"
+        />
+      );
+
+      expect(screen.getByRole('row', {name: 'and'})).toHaveAttribute(
+        'aria-invalid',
+        'true'
+      );
+
+      await userEvent.click(screen.getByRole('row', {name: 'and'}));
+      expect(
+        await screen.findByText('The AND operator is not allowed in this search')
+      ).toBeInTheDocument();
+    });
+
+    it('should mark OR invalid', async function () {
+      render(
+        <SearchQueryBuilder
+          {...defaultProps}
+          disallowLogicalOperators
+          initialQuery="or"
+        />
+      );
+
+      expect(screen.getByRole('row', {name: 'or'})).toHaveAttribute(
+        'aria-invalid',
+        'true'
+      );
+
+      await userEvent.click(screen.getByRole('row', {name: 'or'}));
+      expect(
+        await screen.findByText('The OR operator is not allowed in this search')
+      ).toBeInTheDocument();
+    });
+
+    it('should mark parens invalid', async function () {
+      render(
+        <SearchQueryBuilder
+          {...defaultProps}
+          disallowLogicalOperators
+          initialQuery="()"
+        />
+      );
+
+      expect(screen.getByRole('row', {name: '('})).toHaveAttribute(
+        'aria-invalid',
+        'true'
+      );
+
+      expect(screen.getByRole('row', {name: ')'})).toHaveAttribute(
+        'aria-invalid',
+        'true'
+      );
+
+      await userEvent.click(screen.getByRole('row', {name: '('}));
+      expect(
+        await screen.findByText('Parentheses are not supported in this search')
+      ).toBeInTheDocument();
+    });
+  });
 });

--- a/static/app/components/searchQueryBuilder/index.tsx
+++ b/static/app/components/searchQueryBuilder/index.tsx
@@ -39,6 +39,10 @@ interface SearchQueryBuilderProps {
   searchSource: string;
   className?: string;
   /**
+   * When true, parens and logical operators (AND, OR) will be marked as invalid.
+   */
+  disallowLogicalOperators?: boolean;
+  /**
    * When provided, displays a tabbed interface for discovering filter keys.
    * Sections and filter keys are displayed in the order they are provided.
    */
@@ -78,6 +82,7 @@ function ActionButtons() {
 
 export function SearchQueryBuilder({
   className,
+  disallowLogicalOperators,
   label,
   initialQuery,
   filterKeys,
@@ -94,8 +99,8 @@ export function SearchQueryBuilder({
   const {state, dispatch} = useQueryBuilderState({initialQuery});
 
   const parsedQuery = useMemo(
-    () => parseQueryBuilderValue(state.query, {filterKeys}),
-    [filterKeys, state.query]
+    () => parseQueryBuilderValue(state.query, {disallowLogicalOperators, filterKeys}),
+    [disallowLogicalOperators, filterKeys, state.query]
   );
 
   useEffectAfterFirstRender(() => {

--- a/static/app/components/searchQueryBuilder/paren.tsx
+++ b/static/app/components/searchQueryBuilder/paren.tsx
@@ -21,7 +21,13 @@ export function SearchQueryBuilderParen({
   token,
 }: SearchQueryBuilderParenProps) {
   return (
-    <DeletableToken item={item} state={state} token={token} label={token.value}>
+    <DeletableToken
+      item={item}
+      state={state}
+      token={token}
+      label={token.value}
+      invalid={token.invalid}
+    >
       <IconParenthesis
         side={token.type === Token.L_PAREN ? 'left' : 'right'}
         height={26}

--- a/static/app/components/searchQueryBuilder/utils.tsx
+++ b/static/app/components/searchQueryBuilder/utils.tsx
@@ -4,6 +4,7 @@ import type {ListState} from '@react-stately/list';
 import type {Node} from '@react-types/shared';
 
 import {
+  BooleanOperator,
   FilterType,
   filterTypeConfig,
   interchangeableFilterOperators,
@@ -62,11 +63,15 @@ function getSearchConfigFromKeys(keys: TagCollection): Partial<SearchConfig> {
 
 export function parseQueryBuilderValue(
   value: string,
-  options?: {filterKeys: TagCollection}
+  options?: {filterKeys: TagCollection; disallowLogicalOperators?: boolean}
 ): ParseResult | null {
   return collapseTextTokens(
     parseSearch(value || ' ', {
       flattenParenGroups: true,
+      disallowedLogicalOperators: options?.disallowLogicalOperators
+        ? new Set([BooleanOperator.AND, BooleanOperator.OR])
+        : undefined,
+      disallowParens: options?.disallowLogicalOperators,
       ...getSearchConfigFromKeys(options?.filterKeys ?? {}),
     })
   );

--- a/static/app/components/searchSyntax/parser.tsx
+++ b/static/app/components/searchSyntax/parser.tsx
@@ -269,6 +269,7 @@ export enum InvalidReason {
   INVALID_KEY = 'invalid-key',
   INVALID_DURATION = 'invalid-duration',
   INVALID_DATE_FORMAT = 'invalid-date-format',
+  PARENS_NOT_ALLOWED = 'parens-not-allowed',
 }
 
 /**
@@ -422,12 +423,14 @@ export class TokenConverter {
     ...this.defaultTokenFields,
     type: Token.L_PAREN as const,
     value,
+    invalid: this.checkInvalidParen(),
   });
 
   tokenRParen = (value: ')') => ({
     ...this.defaultTokenFields,
     type: Token.R_PAREN as const,
     value,
+    invalid: this.checkInvalidParen(),
   });
 
   tokenFreeText = (value: string, quoted: boolean) => ({
@@ -736,6 +739,20 @@ export class TokenConverter {
     }
 
     return null;
+  };
+
+  /**
+   * Checks the validity of a parens based on the provided search configuration
+   */
+  checkInvalidParen = () => {
+    if (!this.config.disallowParens) {
+      return null;
+    }
+
+    return {
+      type: InvalidReason.PARENS_NOT_ALLOWED,
+      reason: this.config.invalidMessages[InvalidReason.PARENS_NOT_ALLOWED],
+    };
   };
 
   /**
@@ -1186,6 +1203,10 @@ export type SearchConfig = {
    */
   disallowNegation: boolean;
   /**
+   * Disallow parens in search
+   */
+  disallowParens: boolean;
+  /**
    * Disallow wildcards in free text search AND in tag values
    */
   disallowWildcard: boolean;
@@ -1282,6 +1303,7 @@ export const defaultConfig: SearchConfig = {
   disallowFreeText: false,
   disallowWildcard: false,
   disallowNegation: false,
+  disallowParens: false,
   invalidMessages: {
     [InvalidReason.FREE_TEXT_NOT_ALLOWED]: t('Free text is not supported in this search'),
     [InvalidReason.WILDCARD_NOT_ALLOWED]: t('Wildcards not supported in search'),
@@ -1304,6 +1326,7 @@ export const defaultConfig: SearchConfig = {
     [InvalidReason.EMPTY_VALUE_IN_LIST_NOT_ALLOWED]: t(
       'Lists should not have empty values'
     ),
+    [InvalidReason.PARENS_NOT_ALLOWED]: t('Parentheses are not supported in this search'),
   },
 };
 

--- a/static/app/views/issueList/searchBar.tsx
+++ b/static/app/views/issueList/searchBar.tsx
@@ -212,6 +212,7 @@ function IssueListSearchBar({organization, tags, ...props}: Props) {
         }}
         searchSource={props.searchSource ?? 'issues'}
         savedSearchType={SavedSearchType.ISSUE}
+        disallowLogicalOperators
       />
     );
   }


### PR DESCRIPTION
- Adds an option to the syntax parser to consider parentheses invalid (there already exists one for boolean ops)
- Adds a prop to SearchQueryBuilder to disable logical operations
- When invalid, shows the token as red and displays a tooltip when focused or hovered

![CleanShot 2024-07-10 at 15 50 39](https://github.com/getsentry/sentry/assets/10888943/2390dd0f-c4a9-4ca4-ac03-23c10f8c4a7d)

![CleanShot 2024-07-10 at 15 50 20](https://github.com/getsentry/sentry/assets/10888943/5ffc570a-af1b-478e-8953-3646c3cfbaf9)
