### PR TITLE
fix: Simplfy appStoreConnect validation errors as its going away

### DIFF
--- a/src/sentry/lang/native/sources.py
+++ b/src/sentry/lang/native/sources.py
@@ -328,6 +328,9 @@ def validate_sources(sources, schema=SOURCES_SCHEMA):
     try:
         jsonschema.validate(sources, schema)
     except jsonschema.ValidationError as e:
+        if sources.get("type") == "appStoreConnect":
+            raise InvalidSourcesError("appStoreConnect is being decomissioned")
+
         raise InvalidSourcesError(f"{e}")
 
     ids = set()


### PR DESCRIPTION
This is meant to help prevent logspew related to this canary CI failure: https://sentry.slack.com/archives/CUHS29QJ0/p1720650225471529
