### PR TITLE
feat(query-builder): Add feedback button

### DIFF
--- a/static/app/components/feedback/widget/useFeedback.tsx
+++ b/static/app/components/feedback/widget/useFeedback.tsx
@@ -6,14 +6,17 @@ import ConfigStore from 'sentry/stores/configStore';
 import {useLegacyStore} from 'sentry/stores/useLegacyStore';
 import useAsyncSDKIntegrationStore from 'sentry/views/app/asyncSDKIntegrationProvider';
 
+type ArgumentTypes<F extends Function> = F extends (...args: infer A) => any ? A : never;
+
 export type FeedbackIntegration = NonNullable<ReturnType<typeof Sentry.getFeedback>>;
 
-export type UseFeedbackOptions = {
-  formTitle?: string;
-  messagePlaceholder?: string;
-};
+export type UseFeedbackOptions = ArgumentTypes<FeedbackIntegration['createForm']>[0];
 
-export function useFeedback({formTitle, messagePlaceholder}: UseFeedbackOptions) {
+export function useFeedback({
+  formTitle,
+  messagePlaceholder,
+  tags,
+}: NonNullable<UseFeedbackOptions>) {
   const config = useLegacyStore(ConfigStore);
   const {state} = useAsyncSDKIntegrationStore();
 
@@ -26,8 +29,9 @@ export function useFeedback({formTitle, messagePlaceholder}: UseFeedbackOptions)
       submitButtonLabel: t('Send Feedback'),
       messagePlaceholder: messagePlaceholder ?? t('What did you expect?'),
       formTitle: formTitle ?? t('Give Feedback'),
+      tags,
     };
-  }, [config.theme, formTitle, messagePlaceholder]);
+  }, [config.theme, formTitle, messagePlaceholder, tags]);
 
   return {feedback, options};
 }

--- a/static/app/components/feedback/widget/useFeedback.tsx
+++ b/static/app/components/feedback/widget/useFeedback.tsx
@@ -6,11 +6,9 @@ import ConfigStore from 'sentry/stores/configStore';
 import {useLegacyStore} from 'sentry/stores/useLegacyStore';
 import useAsyncSDKIntegrationStore from 'sentry/views/app/asyncSDKIntegrationProvider';
 
-type ArgumentTypes<F extends Function> = F extends (...args: infer A) => any ? A : never;
-
 export type FeedbackIntegration = NonNullable<ReturnType<typeof Sentry.getFeedback>>;
 
-export type UseFeedbackOptions = ArgumentTypes<FeedbackIntegration['createForm']>[0];
+export type UseFeedbackOptions = Parameters<FeedbackIntegration['createForm']>[0];
 
 export function useFeedback({
   formTitle,

--- a/static/app/components/searchQueryBuilder/combobox.tsx
+++ b/static/app/components/searchQueryBuilder/combobox.tsx
@@ -34,11 +34,14 @@ import {
 import {GrowingInput} from 'sentry/components/growingInput';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {Overlay} from 'sentry/components/overlay';
+import {useSearchQueryBuilder} from 'sentry/components/searchQueryBuilder/context';
 import type {Token, TokenResult} from 'sentry/components/searchSyntax/parser';
+import {IconMegaphone} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {defined} from 'sentry/utils';
 import mergeRefs from 'sentry/utils/mergeRefs';
+import {useFeedbackForm} from 'sentry/utils/useFeedbackForm';
 import useOverlay from 'sentry/utils/useOverlay';
 import usePrevious from 'sentry/utils/usePrevious';
 
@@ -273,6 +276,35 @@ function ListBoxSectionButton({
   );
 }
 
+function FeedbackFooter() {
+  const {searchSource} = useSearchQueryBuilder();
+  const openForm = useFeedbackForm();
+
+  if (!openForm) {
+    return null;
+  }
+
+  return (
+    <SectionedOverlayFooter>
+      <Button
+        size="xs"
+        icon={<IconMegaphone />}
+        onClick={() =>
+          openForm({
+            messagePlaceholder: t('How can we make search better for you?'),
+            tags: {
+              feedback_source: 'search_query_builder',
+              search_source: searchSource,
+            },
+          })
+        }
+      >
+        {t('Give Feedback')}
+      </Button>
+    </SectionedOverlayFooter>
+  );
+}
+
 function SectionedListBox<T extends SelectOptionOrSectionWithKey<string>>({
   popoverRef,
   listBoxRef,
@@ -344,6 +376,7 @@ function SectionedListBox<T extends SelectOptionOrSectionWithKey<string>>({
               size="sm"
             />
           </SectionedListBoxPane>
+          <FeedbackFooter />
         </Fragment>
       ) : null}
     </SectionedOverlay>
@@ -705,8 +738,21 @@ const SectionedOverlay = styled(Overlay)`
   overflow: hidden;
   display: grid;
   grid-template-columns: 120px 240px;
+  grid-template-rows: 1fr auto;
+  grid-template-areas:
+    'left right'
+    'footer footer';
   height: 400px;
   width: 360px;
+`;
+
+const SectionedOverlayFooter = styled('div')`
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  grid-area: footer;
+  padding: ${space(1)};
+  border-top: 1px solid ${p => p.theme.innerBorder};
 `;
 
 const SectionedListBoxPane = styled('div')`

--- a/static/app/utils/useFeedbackForm.spec.tsx
+++ b/static/app/utils/useFeedbackForm.spec.tsx
@@ -20,6 +20,7 @@ const defaultOptions = {
   submitButtonLabel: '',
   messagePlaceholder: '',
   formTitle: '',
+  tags: {},
 };
 
 describe('useFeedbackForm', function () {


### PR DESCRIPTION
- Modifies `useFeedback` to accept `tags` so we can pass that info into the form
- Adds a footer with a feedback button to the empty state key explorer 

![CleanShot 2024-07-10 at 16 50 04](https://github.com/getsentry/sentry/assets/10888943/57e8359b-aa0c-4e86-849b-427eaa930a0e)
