### PR TITLE
fix(minimetrics): use current scope for span attributes

### DIFF
--- a/src/sentry/metrics/minimetrics.py
+++ b/src/sentry/metrics/minimetrics.py
@@ -118,12 +118,12 @@ def _set_metric_on_span(key: str, value: float | int, op: str, tags: Tags | None
     if not options.get("delightful_metrics.enable_span_attributes"):
         return
 
-    scope = sentry_sdk.Scope.get_isolation_scope()
+    scope = sentry_sdk.Scope.get_current_scope()
 
     span_or_tx = getattr(scope, "_span", None)
 
     if not span_or_tx:
-        with scope.start_transaction():
+        with scope.start_transaction(op=f"minimetrics.{op}"):
             with scope.start_span(op=f"minimetrics.{op}") as span:
                 return _add_metric_data_to_span(span, key, value, tags)
     elif span_or_tx.parent_span_id is not None:

--- a/tests/sentry/metrics/test_minimetrics.py
+++ b/tests/sentry/metrics/test_minimetrics.py
@@ -78,7 +78,7 @@ class DummyTransport(Transport):
 @pytest.fixture(scope="function")
 def scope():
     scope = sentry_sdk.Scope(
-        ty=sentry_sdk.scope.ScopeType.ISOLATION,
+        ty=sentry_sdk.scope.ScopeType.CURRENT,
         client=Client(
             dsn="http://foo@example.invalid/42",
             transport=DummyTransport,
@@ -89,7 +89,7 @@ def scope():
             traces_sample_rate=1.0,
         ),
     )
-    with sentry_sdk.scope.use_isolation_scope(scope):
+    with sentry_sdk.scope.use_scope(scope):
         yield scope
 
 


### PR DESCRIPTION
- closes: #73930 
- uses current instead of isolation scope