### PR TITLE
feat(metrics-extraction): Display created by

### DIFF
--- a/static/app/types/metrics.tsx
+++ b/static/app/types/metrics.tsx
@@ -135,6 +135,9 @@ export interface MetricsExtractionCondition {
 export interface MetricsExtractionRule {
   aggregates: MetricAggregation[];
   conditions: MetricsExtractionCondition[];
+  createdById: number | null;
+  dateAdded: string;
+  dateUpdated: string;
   projectId: number;
   spanAttribute: string;
   tags: string[];

--- a/static/app/utils/metrics/virtualMetricsContext.spec.tsx
+++ b/static/app/utils/metrics/virtualMetricsContext.spec.tsx
@@ -1,3 +1,4 @@
+import type {MetricsExtractionRule} from 'sentry/types/metrics';
 import {createMRIToVirtualMap} from 'sentry/utils/metrics/virtualMetricsContext';
 
 describe('createMRIToVirtualMap', () => {
@@ -6,6 +7,9 @@ describe('createMRIToVirtualMap', () => {
       {
         spanAttribute: 'span1',
         projectId: 1,
+        createdById: null,
+        dateAdded: '2021-09-29T20:00:00',
+        dateUpdated: '2021-09-29T20:00:00',
         aggregates: [],
         tags: [],
         unit: 'none',
@@ -16,10 +20,13 @@ describe('createMRIToVirtualMap', () => {
             mris: ['c:custom/mri1@none' as const, 'c:custom/mri2@none' as const],
           },
         ],
-      },
+      } satisfies MetricsExtractionRule,
       {
         spanAttribute: 'span2',
         projectId: 2,
+        createdById: null,
+        dateAdded: '2021-09-29T20:00:00',
+        dateUpdated: '2021-09-29T20:00:00',
         aggregates: [],
         tags: [],
         unit: 'millisecond',
@@ -30,7 +37,7 @@ describe('createMRIToVirtualMap', () => {
             mris: ['c:custom/mri3@none' as const, 'c:custom/mri4@none' as const],
           },
         ],
-      },
+      } satisfies MetricsExtractionRule,
     ];
     const result = createMRIToVirtualMap(rules);
     expect(result).toEqual(

--- a/static/app/views/settings/projectMetrics/metricsExtractionRuleCreateModal.tsx
+++ b/static/app/views/settings/projectMetrics/metricsExtractionRuleCreateModal.tsx
@@ -151,6 +151,10 @@ function FormWrapper({
         unit: 'none',
         conditions: data.conditions,
         projectId: Number(projectId),
+        // Will be set by the backend
+        createdById: null,
+        dateAdded: '',
+        dateUpdated: '',
       };
 
       createExtractionRuleMutation.mutate(

--- a/static/app/views/settings/projectMetrics/metricsExtractionRuleEditModal.tsx
+++ b/static/app/views/settings/projectMetrics/metricsExtractionRuleEditModal.tsx
@@ -59,12 +59,12 @@ export function MetricsExtractionRuleEditModal({
       onSubmitError: (error: any) => void
     ) => {
       const extractionRule: MetricsExtractionRule = {
+        ...metricExtractionRule,
         spanAttribute: data.spanAttribute!,
         tags: data.tags,
         aggregates: data.aggregates.flatMap(explodeAggregateGroup),
         unit: 'none',
         conditions: data.conditions,
-        projectId: metricExtractionRule.projectId,
       };
 
       updateExtractionRuleMutation.mutate(
@@ -88,7 +88,7 @@ export function MetricsExtractionRuleEditModal({
       );
       onSubmitSuccess(data);
     },
-    [closeModal, metricExtractionRule.projectId, updateExtractionRuleMutation]
+    [closeModal, metricExtractionRule, updateExtractionRuleMutation]
   );
 
   return (

--- a/static/app/views/settings/projectMetrics/metricsExtractionRulesTable.spec.tsx
+++ b/static/app/views/settings/projectMetrics/metricsExtractionRulesTable.spec.tsx
@@ -21,6 +21,9 @@ describe('Metrics Extraction Rules Table', function () {
         {
           spanAttribute: 'span.duration',
           projectId: Number(project.id),
+          createdById: null,
+          dateAdded: '2021-09-29T20:00:00',
+          dateUpdated: '2021-09-29T20:00:00',
           aggregates: [
             'count',
             'count_unique',

--- a/static/app/views/settings/projectMetrics/metricsExtractionRulesTable.tsx
+++ b/static/app/views/settings/projectMetrics/metricsExtractionRulesTable.tsx
@@ -4,6 +4,8 @@ import styled from '@emotion/styled';
 import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicator';
 import {Button} from 'sentry/components/button';
 import {openConfirmModal} from 'sentry/components/confirm';
+import {DateTime} from 'sentry/components/dateTime';
+import UserBadge from 'sentry/components/idBadge/userBadge';
 import {PanelTable} from 'sentry/components/panels/panelTable';
 import SearchBar from 'sentry/components/searchBar';
 import {Tooltip} from 'sentry/components/tooltip';
@@ -17,6 +19,7 @@ import type {MetricsExtractionRule} from 'sentry/types/metrics';
 import type {Project} from 'sentry/types/project';
 import {DEFAULT_METRICS_CARDINALITY_LIMIT} from 'sentry/utils/metrics/constants';
 import {useMetricsCardinality} from 'sentry/utils/metrics/useMetricsCardinality';
+import {useMembers} from 'sentry/utils/useMembers';
 import useOrganization from 'sentry/utils/useOrganization';
 import {openExtractionRuleCreateModal} from 'sentry/views/settings/projectMetrics/metricsExtractionRuleCreateModal';
 import {openExtractionRuleEditModal} from 'sentry/views/settings/projectMetrics/metricsExtractionRuleEditModal';
@@ -120,11 +123,7 @@ function RulesTable({
   onEdit,
   hasSearch,
 }: RulesTableProps) {
-  const getTotalCardinality = (rule: MetricsExtractionRule) => {
-    const mris = rule.conditions.flatMap(condition => condition.mris);
-    return mris.reduce((acc, mri) => acc + (cardinality[mri] || 0), 0);
-  };
-
+  const {members} = useMembers();
   const getMaxCardinality = (rule: MetricsExtractionRule) => {
     const mris = rule.conditions.flatMap(condition => condition.mris);
     return mris.reduce((acc, mri) => Math.max(acc, cardinality[mri] || 0), 0);
@@ -137,11 +136,9 @@ function RulesTable({
           <IconArrow size="xs" direction="down" />
           {t('Span attribute')}
         </Cell>,
-        <Cell right key="cardinality">
-          {t('Cardinality')}
-        </Cell>,
-        <Cell right key="filters">
-          {t('Filters')}
+        <Cell key="createdBy">{t('Created by')}</Cell>,
+        <Cell right key="createdBy">
+          {t('Created at')}
         </Cell>,
         <Cell right key="actions">
           {t('Actions')}
@@ -157,49 +154,54 @@ function RulesTable({
     >
       {extractionRules
         .toSorted((a, b) => a?.spanAttribute?.localeCompare(b?.spanAttribute))
-        .map(rule => (
-          <Fragment key={rule.spanAttribute + rule.unit}>
-            <Cell>{rule.spanAttribute}</Cell>
-            <Cell right>
-              {getTotalCardinality(rule)}
-              {/* TODO: Retrieve limit from BE */}
-              {getMaxCardinality(rule) >= DEFAULT_METRICS_CARDINALITY_LIMIT ? (
-                <Tooltip
-                  title={t(
-                    'Some of your defined queries are exeeding the cardinality limit. Remove tags or add filters to receive accurate data.'
-                  )}
-                >
-                  <IconWarning size="xs" color="yellow300" />
-                </Tooltip>
-              ) : null}
-            </Cell>
-            <Cell right>
-              {rule.conditions.length ? (
-                <Button priority="link" onClick={() => onEdit(rule)}>
-                  {rule.conditions.length}
-                </Button>
-              ) : (
-                <NoValue>{t('(none)')}</NoValue>
-              )}
-            </Cell>
-            <Cell right>
-              <Button
-                aria-label={t('Edit metric')}
-                size="xs"
-                icon={<IconEdit />}
-                borderless
-                onClick={() => onEdit(rule)}
-              />
-              <Button
-                aria-label={t('Delete metric')}
-                size="xs"
-                icon={<IconDelete />}
-                borderless
-                onClick={() => onDelete(rule)}
-              />
-            </Cell>
-          </Fragment>
-        ))}
+        .map(rule => {
+          const createdByUser = members.find(
+            member => member.id === String(rule.createdById)
+          );
+          return (
+            <Fragment key={rule.spanAttribute + rule.unit}>
+              <Cell>
+                {getMaxCardinality(rule) >= DEFAULT_METRICS_CARDINALITY_LIMIT ? (
+                  <Tooltip
+                    title={t(
+                      'Some of your defined queries are exeeding the cardinality limit. Remove tags or add filters to receive accurate data.'
+                    )}
+                  >
+                    <IconWarning size="xs" color="yellow300" />
+                  </Tooltip>
+                ) : null}
+                {rule.spanAttribute}
+              </Cell>
+              <Cell>
+                <UserBadge
+                  displayName={createdByUser?.name ?? t('Unknown')}
+                  user={createdByUser}
+                  hideEmail
+                  avatarSize={24}
+                />
+              </Cell>
+              <Cell>
+                <DateTime date={rule.dateAdded} />
+              </Cell>
+              <Cell right>
+                <Button
+                  aria-label={t('Edit metric')}
+                  size="xs"
+                  icon={<IconEdit />}
+                  borderless
+                  onClick={() => onEdit(rule)}
+                />
+                <Button
+                  aria-label={t('Delete metric')}
+                  size="xs"
+                  icon={<IconDelete />}
+                  borderless
+                  onClick={() => onDelete(rule)}
+                />
+              </Cell>
+            </Fragment>
+          );
+        })}
     </ExtractionRulesPanelTable>
   );
 }
@@ -221,7 +223,7 @@ const FlexSpacer = styled('div')`
 `;
 
 const ExtractionRulesPanelTable = styled(PanelTable)`
-  grid-template-columns: 1fr repeat(3, min-content);
+  grid-template-columns: 1fr repeat(3, max-content);
 `;
 
 const Cell = styled('div')<{right?: boolean}>`
@@ -230,8 +232,4 @@ const Cell = styled('div')<{right?: boolean}>`
   align-self: stretch;
   gap: ${space(0.5)};
   justify-content: ${p => (p.right ? 'flex-end' : 'flex-start')};
-`;
-
-const NoValue = styled('span')`
-  color: ${p => p.theme.subText};
 `;


### PR DESCRIPTION
Add columns for `created by` and `created at`.
Remove columns for `cardinality` and `filters`.

<img width="959" alt="Screenshot 2024-07-11 at 09 31 06" src="https://github.com/getsentry/sentry/assets/7033940/173e0eb2-79a4-43f7-8d1d-703c1cbecad9">

Closes https://github.com/getsentry/sentry/issues/73919