### PR TITLE
fix(sources): Filter appStoreConnect sources

### DIFF
--- a/src/sentry/api/endpoints/project_details.py
+++ b/src/sentry/api/endpoints/project_details.py
@@ -310,7 +310,8 @@ class ProjectAdminSerializer(ProjectMemberSerializer):
             # We should really only grab and parse if there are sources in sources_json whose
             # secrets are set to {"hidden-secret":true}
             orig_sources = parse_sources(
-                self.context["project"].get_option("sentry:symbol_sources")
+                self.context["project"].get_option("sentry:symbol_sources"),
+                filter_appconnect=True,
             )
             sources = parse_backfill_sources(sources_json.strip(), orig_sources)
         except InvalidSourcesError as e:
@@ -706,7 +707,7 @@ class ProjectDetailsEndpoint(ProjectEndpoint):
                 # Redact secrets so they don't get logged directly to the Audit Log
                 sources_json = result["symbolSources"] or None
                 try:
-                    sources = parse_sources(sources_json)
+                    sources = parse_sources(sources_json, filter_appconnect=True)
                 except Exception:
                     sources = []
                 redacted_sources = redact_source_secrets(sources)

--- a/src/sentry/api/endpoints/project_symbol_sources.py
+++ b/src/sentry/api/endpoints/project_symbol_sources.py
@@ -21,7 +21,6 @@ from sentry.apidocs.parameters import GlobalParams, ProjectParams
 from sentry.lang.native.sources import (
     REDACTED_SOURCE_SCHEMA,
     REDACTED_SOURCES_SCHEMA,
-    SOURCES_WITHOUT_APPSTORE_CONNECT,
     VALID_CASINGS,
     VALID_LAYOUTS,
     InvalidSourcesError,
@@ -287,7 +286,7 @@ class ProjectSymbolSourcesEndpoint(ProjectEndpoint):
         sources.append(source)
 
         try:
-            validate_sources(sources, schema=SOURCES_WITHOUT_APPSTORE_CONNECT)
+            validate_sources(sources)
         except InvalidSourcesError:
             return Response(status=400)
 

--- a/src/sentry/api/endpoints/project_symbol_sources.py
+++ b/src/sentry/api/endpoints/project_symbol_sources.py
@@ -21,6 +21,7 @@ from sentry.apidocs.parameters import GlobalParams, ProjectParams
 from sentry.lang.native.sources import (
     REDACTED_SOURCE_SCHEMA,
     REDACTED_SOURCES_SCHEMA,
+    SOURCES_WITHOUT_APPSTORE_CONNECT,
     VALID_CASINGS,
     VALID_LAYOUTS,
     InvalidSourcesError,
@@ -212,7 +213,7 @@ class ProjectSymbolSourcesEndpoint(ProjectEndpoint):
         """
         id = request.GET.get("id")
         custom_symbol_sources_json = project.get_option("sentry:symbol_sources") or []
-        sources = parse_sources(custom_symbol_sources_json)
+        sources = parse_sources(custom_symbol_sources_json, filter_appconnect=False)
         redacted = redact_source_secrets(sources)
 
         if id:
@@ -244,7 +245,7 @@ class ProjectSymbolSourcesEndpoint(ProjectEndpoint):
         id = request.GET.get("id")
         custom_symbol_sources_json = project.get_option("sentry:symbol_sources") or []
 
-        sources = parse_sources(custom_symbol_sources_json)
+        sources = parse_sources(custom_symbol_sources_json, filter_appconnect=False)
 
         if id:
             filtered_sources = [src for src in sources if src["id"] != id]
@@ -273,7 +274,7 @@ class ProjectSymbolSourcesEndpoint(ProjectEndpoint):
         Add a custom symbol source to a project.
         """
         custom_symbol_sources_json = project.get_option("sentry:symbol_sources") or []
-        sources = parse_sources(custom_symbol_sources_json)
+        sources = parse_sources(custom_symbol_sources_json, filter_appconnect=False)
 
         source = request.data
 
@@ -286,7 +287,7 @@ class ProjectSymbolSourcesEndpoint(ProjectEndpoint):
         sources.append(source)
 
         try:
-            validate_sources(sources)
+            validate_sources(sources, schema=SOURCES_WITHOUT_APPSTORE_CONNECT)
         except InvalidSourcesError:
             return Response(status=400)
 
@@ -320,7 +321,7 @@ class ProjectSymbolSourcesEndpoint(ProjectEndpoint):
         source = request.data
 
         custom_symbol_sources_json = project.get_option("sentry:symbol_sources") or []
-        sources = parse_sources(custom_symbol_sources_json)
+        sources = parse_sources(custom_symbol_sources_json, filter_appconnect=False)
 
         if id is None:
             return Response(data={"error": "Missing source id"}, status=404)

--- a/src/sentry/api/serializers/models/project.py
+++ b/src/sentry/api/serializers/models/project.py
@@ -1034,7 +1034,7 @@ class DetailedProjectSerializer(ProjectWithTeamSerializer):
 
         custom_symbol_sources_json = attrs["options"].get("sentry:symbol_sources")
         try:
-            sources = parse_sources(custom_symbol_sources_json)
+            sources = parse_sources(custom_symbol_sources_json, filter_appconnect=False)
         except Exception:
             # In theory sources stored on the project should be valid. If they are invalid, we don't
             # want to abort serialization just for sources, so just return an empty list instead of

--- a/src/sentry/lang/native/sources.py
+++ b/src/sentry/lang/native/sources.py
@@ -55,6 +55,33 @@ COMMON_SOURCE_PROPERTIES = {
     "filetypes": {"type": "array", "items": {"type": "string", "enum": list(VALID_FILE_TYPES)}},
 }
 
+APP_STORE_CONNECT_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "type": {"type": "string", "enum": ["appStoreConnect"]},
+        "id": {"type": "string", "minLength": 1},
+        "name": {"type": "string"},
+        "appconnectIssuer": {"type": "string", "minLength": 36, "maxLength": 36},
+        "appconnectKey": {"type": "string", "minLength": 2, "maxLength": 20},
+        "appconnectPrivateKey": {"type": "string"},
+        "appName": {"type": "string", "minLength": 1, "maxLength": 512},
+        "appId": {"type": "string", "minLength": 1},
+        "bundleId": {"type": "string", "minLength": 1},
+    },
+    "required": [
+        "type",
+        "id",
+        "name",
+        "appconnectIssuer",
+        "appconnectKey",
+        "appconnectPrivateKey",
+        "appName",
+        "appId",
+        "bundleId",
+    ],
+    "additionalProperties": False,
+}
+
 HTTP_SOURCE_SCHEMA = {
     "type": "object",
     "properties": dict(
@@ -102,6 +129,7 @@ SOURCE_SCHEMA = {
         HTTP_SOURCE_SCHEMA,
         S3_SOURCE_SCHEMA,
         GCS_SOURCE_SCHEMA,
+        APP_STORE_CONNECT_SCHEMA,
     ]
 }
 
@@ -109,6 +137,20 @@ SOURCES_SCHEMA = {
     "type": "array",
     "items": SOURCE_SCHEMA,
 }
+
+# TODO(@anonrig): Remove this when AppStore connect integration is sunset.
+# Ref: https://github.com/getsentry/sentry/issues/51994
+SOURCES_WITHOUT_APPSTORE_CONNECT = {
+    "type": "array",
+    "items": {
+        "oneOf": [
+            HTTP_SOURCE_SCHEMA,
+            S3_SOURCE_SCHEMA,
+            GCS_SOURCE_SCHEMA,
+        ]
+    },
+}
+
 
 # Schemas for sources with redacted secrets
 HIDDEN_SECRET_SCHEMA = {
@@ -135,6 +177,9 @@ def _redact_schema(schema: dict, keys_to_redact: list[str]) -> dict:
     return copy
 
 
+REDACTED_APP_STORE_CONNECT_SCHEMA = _redact_schema(
+    APP_STORE_CONNECT_SCHEMA, ["appConnectPrivateKey"]
+)
 REDACTED_HTTP_SOURCE_SCHEMA = _redact_schema(HTTP_SOURCE_SCHEMA, ["password"])
 REDACTED_S3_SOURCE_SCHEMA = _redact_schema(S3_SOURCE_SCHEMA, ["secret_key"])
 REDACTED_GCS_SOURCE_SCHEMA = _redact_schema(GCS_SOURCE_SCHEMA, ["private_key"])
@@ -144,6 +189,7 @@ REDACTED_SOURCE_SCHEMA = {
         REDACTED_HTTP_SOURCE_SCHEMA,
         REDACTED_S3_SOURCE_SCHEMA,
         REDACTED_GCS_SOURCE_SCHEMA,
+        REDACTED_APP_STORE_CONNECT_SCHEMA,
     ]
 }
 
@@ -311,7 +357,9 @@ def secret_fields(source_type):
     """
     Returns a string list of all of the fields that contain a secret in a given source.
     """
-    if source_type == "http":
+    if source_type == "appStoreConnect":
+        yield from ["appconnectPrivateKey"]
+    elif source_type == "http":
         yield "password"
     elif source_type == "s3":
         yield "secret_key"
@@ -328,9 +376,6 @@ def validate_sources(sources, schema=SOURCES_SCHEMA):
     try:
         jsonschema.validate(sources, schema)
     except jsonschema.ValidationError as e:
-        if sources.get("type") == "appStoreConnect":
-            raise InvalidSourcesError("appStoreConnect is being decomissioned")
-
         raise InvalidSourcesError(f"{e}")
 
     ids = set()
@@ -342,7 +387,7 @@ def validate_sources(sources, schema=SOURCES_SCHEMA):
         ids.add(source["id"])
 
 
-def parse_sources(config):
+def parse_sources(config, filter_appconnect):
     """
     Parses the given sources in the config string (from JSON).
     """
@@ -358,7 +403,9 @@ def parse_sources(config):
     validate_sources(sources)
 
     # TODO(@anonrig): Remove this when AppStore connect related datas are removed.
-    filter(lambda src: src.get("type") != "appStoreConnect", sources)
+    # remove App Store Connect sources (we don't need them in Symbolicator)
+    if filter_appconnect:
+        filter(lambda src: src.get("type") != "appStoreConnect", sources)
 
     return sources
 
@@ -451,7 +498,7 @@ def get_sources_for_project(project):
 
     if sources_config:
         try:
-            custom_sources = parse_sources(sources_config)
+            custom_sources = parse_sources(sources_config, filter_appconnect=True)
             sources.extend(
                 normalize_user_source(source)
                 for source in custom_sources

--- a/src/sentry/lang/native/sources.py
+++ b/src/sentry/lang/native/sources.py
@@ -426,7 +426,7 @@ def parse_backfill_sources(sources_json, original_sources):
     for source in sources:
         backfill_source(source, orig_by_id)
 
-    validate_sources(sources, schema=SOURCE_SCHEMA)
+    validate_sources(sources, schema=SOURCES_SCHEMA)
 
     return sources
 

--- a/src/sentry/lang/native/sources.py
+++ b/src/sentry/lang/native/sources.py
@@ -400,7 +400,7 @@ def parse_sources(config, filter_appconnect):
 
     # remove App Store Connect sources (we don't need them in Symbolicator)
     if filter_appconnect:
-        filter(lambda src: src.get("type") != "appStoreConnect", sources)
+        sources = [src for src in sources if src.get("type") != "appStoreConnect"]
 
     validate_sources(sources)
 

--- a/src/sentry/lang/native/sources.py
+++ b/src/sentry/lang/native/sources.py
@@ -138,8 +138,6 @@ SOURCES_SCHEMA = {
     "items": SOURCE_SCHEMA,
 }
 
-# TODO(@anonrig): Remove this when AppStore connect integration is sunset.
-# Ref: https://github.com/getsentry/sentry/issues/51994
 SOURCES_WITHOUT_APPSTORE_CONNECT = {
     "type": "array",
     "items": {
@@ -400,7 +398,6 @@ def parse_sources(config, filter_appconnect):
     except Exception as e:
         raise InvalidSourcesError("Sources are not valid serialised JSON") from e
 
-    # TODO(@anonrig): Remove this when AppStore connect related datas are removed.
     # remove App Store Connect sources (we don't need them in Symbolicator)
     if filter_appconnect:
         filter(lambda src: src.get("type") != "appStoreConnect", sources)
@@ -503,7 +500,6 @@ def get_sources_for_project(project):
                 normalize_user_source(source)
                 for source in custom_sources
                 if source["type"] != "appStoreConnect"
-                # TODO(@anonrig): Remove this when all AppStore data is removed.
             )
         except InvalidSourcesError:
             # Source configs should be validated when they are saved. If this

--- a/src/sentry/lang/native/sources.py
+++ b/src/sentry/lang/native/sources.py
@@ -368,7 +368,7 @@ def secret_fields(source_type):
     yield from []
 
 
-def validate_sources(sources, schema=SOURCES_SCHEMA):
+def validate_sources(sources, schema=SOURCES_WITHOUT_APPSTORE_CONNECT):
     """
     Validates sources against the JSON schema and checks that
     their IDs are ok.
@@ -400,12 +400,12 @@ def parse_sources(config, filter_appconnect):
     except Exception as e:
         raise InvalidSourcesError("Sources are not valid serialised JSON") from e
 
-    validate_sources(sources)
-
     # TODO(@anonrig): Remove this when AppStore connect related datas are removed.
     # remove App Store Connect sources (we don't need them in Symbolicator)
     if filter_appconnect:
         filter(lambda src: src.get("type") != "appStoreConnect", sources)
+
+    validate_sources(sources)
 
     return sources
 
@@ -429,7 +429,7 @@ def parse_backfill_sources(sources_json, original_sources):
     for source in sources:
         backfill_source(source, orig_by_id)
 
-    validate_sources(sources)
+    validate_sources(sources, schema=SOURCE_SCHEMA)
 
     return sources
 

--- a/tests/sentry/lang/native/test_symbolicator.py
+++ b/tests/sentry/lang/native/test_symbolicator.py
@@ -16,6 +16,16 @@ CUSTOM_SOURCE_CONFIG = """
     "id": "custom",
     "layout": {"type": "symstore"},
     "url": "https://msdl.microsoft.com/download/symbols/"
+},{
+    "type": "appStoreConnect",
+    "id": "asc",
+    "name": "appconnect-disabled",
+    "appconnectIssuer": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+    "appconnectKey": "foobar",
+    "appconnectPrivateKey": "quux",
+    "appName": "test",
+    "appId": "test",
+    "bundleId": "test"
 }]
 """
 
@@ -88,6 +98,7 @@ def test_sources_custom(default_project):
         sources = get_sources_for_project(default_project)
 
     # XXX: The order matters here! Project is always first, then custom sources
+    # The appStoreConnect source should be filtered out.
     source_ids = list(map(lambda s: s["id"], sources))
     assert source_ids == ["sentry:project", "custom"]
 


### PR DESCRIPTION
This partially reverts commit 22949020628adf77c01f67f227f5ce2868de47c8. In that commit, extant appStoreConnect sources were erroneously validated against the appStoreConnect-less schema when sending them to Symbolicator, causing errors.