### PR TITLE
ref(metrics): Combine flags to show extrapolate field

### DIFF
--- a/static/app/views/settings/projectMetrics/projectMetrics.tsx
+++ b/static/app/views/settings/projectMetrics/projectMetrics.tsx
@@ -69,7 +69,7 @@ function ProjectMetrics({project}: Props) {
 
       {hasExtractionRules ? null : <PermissionAlert project={project} />}
 
-      {hasMetricsExtrapolationFeature(organization) ? (
+      {hasExtractionRules && hasMetricsExtrapolationFeature(organization) ? (
         <ExtrapolationField project={project} />
       ) : null}
 


### PR DESCRIPTION
### Goal
We want to display the extrapolation field only when the `metrics-extrapolation` feature flag is enabled, along with the `custom-metrics-extraction-rule` and `custom-metrics-extraction-rule-ui` feature flags.