### PR TITLE
feat(discover): Add split decision in meta response

### DIFF
--- a/src/sentry/api/endpoints/organization_events.py
+++ b/src/sentry/api/endpoints/organization_events.py
@@ -398,7 +398,20 @@ class OrganizationEventsEndpoint(OrganizationEventsV2EndpointBase):
                     else:
                         split_dataset = discover
 
-                    return _data_fn(split_dataset, offset, limit, scoped_query)
+                    response = _data_fn(split_dataset, offset, limit, scoped_query)
+
+                    if widget.discover_widget_split == DashboardWidgetTypes.ERROR_EVENTS:
+                        response["meta"][
+                            "discoverSplitDecision"
+                        ] = DashboardWidgetTypes.get_type_name(DashboardWidgetTypes.ERROR_EVENTS)
+                    elif widget.discover_widget_split == DashboardWidgetTypes.TRANSACTION_LIKE:
+                        response["meta"][
+                            "discoverSplitDecision"
+                        ] = DashboardWidgetTypes.get_type_name(
+                            DashboardWidgetTypes.TRANSACTION_LIKE
+                        )
+
+                    return response
 
                 try:
                     error_results = _data_fn(errors, offset, limit, scoped_query)

--- a/src/sentry/api/endpoints/organization_events.py
+++ b/src/sentry/api/endpoints/organization_events.py
@@ -398,20 +398,7 @@ class OrganizationEventsEndpoint(OrganizationEventsV2EndpointBase):
                     else:
                         split_dataset = discover
 
-                    response = _data_fn(split_dataset, offset, limit, scoped_query)
-
-                    if widget.discover_widget_split == DashboardWidgetTypes.ERROR_EVENTS:
-                        response["meta"][
-                            "discoverSplitDecision"
-                        ] = DashboardWidgetTypes.get_type_name(DashboardWidgetTypes.ERROR_EVENTS)
-                    elif widget.discover_widget_split == DashboardWidgetTypes.TRANSACTION_LIKE:
-                        response["meta"][
-                            "discoverSplitDecision"
-                        ] = DashboardWidgetTypes.get_type_name(
-                            DashboardWidgetTypes.TRANSACTION_LIKE
-                        )
-
-                    return response
+                    return _data_fn(split_dataset, offset, limit, scoped_query)
 
                 try:
                     error_results = _data_fn(errors, offset, limit, scoped_query)

--- a/src/sentry/api/endpoints/organization_events.py
+++ b/src/sentry/api/endpoints/organization_events.py
@@ -431,8 +431,14 @@ class OrganizationEventsEndpoint(OrganizationEventsV2EndpointBase):
                 if decision == DashboardWidgetTypes.DISCOVER:
                     return _data_fn(discover, offset, limit, scoped_query)
                 elif decision == DashboardWidgetTypes.TRANSACTION_LIKE:
+                    original_results["meta"][
+                        "discoverSplitDecision"
+                    ] = DashboardWidgetTypes.get_type_name(DashboardWidgetTypes.TRANSACTION_LIKE)
                     return original_results
                 elif decision == DashboardWidgetTypes.ERROR_EVENTS and error_results:
+                    error_results["meta"][
+                        "discoverSplitDecision"
+                    ] = DashboardWidgetTypes.get_type_name(DashboardWidgetTypes.ERROR_EVENTS)
                     return error_results
                 else:
                     return original_results

--- a/tests/snuba/api/endpoints/test_organization_events_mep.py
+++ b/tests/snuba/api/endpoints/test_organization_events_mep.py
@@ -3672,6 +3672,9 @@ class OrganizationEventsMetricsEnhancedPerformanceEndpointTestWithOnDemandMetric
         )
 
         assert response.status_code == 200, response.content
+        assert response.data.get("meta").get(
+            "discoverSplitDecision"
+        ) is DashboardWidgetTypes.get_type_name(DashboardWidgetTypes.ERROR_EVENTS)
         mock_errors_query.assert_called_once()
 
     @mock.patch("sentry.snuba.metrics_enhanced_performance.query")
@@ -3702,6 +3705,9 @@ class OrganizationEventsMetricsEnhancedPerformanceEndpointTestWithOnDemandMetric
         )
 
         assert response.status_code == 200, response.content
+        assert response.data.get("meta").get(
+            "discoverSplitDecision"
+        ) is DashboardWidgetTypes.get_type_name(DashboardWidgetTypes.TRANSACTION_LIKE)
         mock_mep_query.assert_called_once()
 
     def test_split_decision_for_errors_widget(self):

--- a/tests/snuba/api/endpoints/test_organization_events_mep.py
+++ b/tests/snuba/api/endpoints/test_organization_events_mep.py
@@ -3728,6 +3728,9 @@ class OrganizationEventsMetricsEnhancedPerformanceEndpointTestWithOnDemandMetric
         )
 
         assert response.status_code == 200, response.content
+        assert response.data.get("meta").get(
+            "discoverSplitDecision"
+        ) is DashboardWidgetTypes.get_type_name(DashboardWidgetTypes.ERROR_EVENTS)
 
         widget.refresh_from_db()
         assert widget.discover_widget_split == DashboardWidgetTypes.ERROR_EVENTS
@@ -3757,6 +3760,9 @@ class OrganizationEventsMetricsEnhancedPerformanceEndpointTestWithOnDemandMetric
         )
 
         assert response.status_code == 200, response.content
+        assert response.data.get("meta").get(
+            "discoverSplitDecision"
+        ) is DashboardWidgetTypes.get_type_name(DashboardWidgetTypes.TRANSACTION_LIKE)
 
         widget.refresh_from_db()
         assert widget.discover_widget_split == DashboardWidgetTypes.TRANSACTION_LIKE
@@ -3781,6 +3787,7 @@ class OrganizationEventsMetricsEnhancedPerformanceEndpointTestWithOnDemandMetric
         )
 
         assert response.status_code == 200, response.content
+        assert response.data.get("meta").get("discoverSplitDecision") is None
 
         widget.refresh_from_db()
         assert widget.discover_widget_split is None
@@ -3824,6 +3831,7 @@ class OrganizationEventsMetricsEnhancedPerformanceEndpointTestWithOnDemandMetric
         )
 
         assert response.status_code == 200, response.content
+        assert response.data.get("meta").get("discoverSplitDecision") is None
 
         widget.refresh_from_db()
         assert widget.discover_widget_split is DashboardWidgetTypes.DISCOVER

--- a/tests/snuba/api/endpoints/test_organization_events_mep.py
+++ b/tests/snuba/api/endpoints/test_organization_events_mep.py
@@ -3672,9 +3672,6 @@ class OrganizationEventsMetricsEnhancedPerformanceEndpointTestWithOnDemandMetric
         )
 
         assert response.status_code == 200, response.content
-        assert response.data.get("meta").get(
-            "discoverSplitDecision"
-        ) is DashboardWidgetTypes.get_type_name(DashboardWidgetTypes.ERROR_EVENTS)
         mock_errors_query.assert_called_once()
 
     @mock.patch("sentry.snuba.metrics_enhanced_performance.query")
@@ -3705,9 +3702,6 @@ class OrganizationEventsMetricsEnhancedPerformanceEndpointTestWithOnDemandMetric
         )
 
         assert response.status_code == 200, response.content
-        assert response.data.get("meta").get(
-            "discoverSplitDecision"
-        ) is DashboardWidgetTypes.get_type_name(DashboardWidgetTypes.TRANSACTION_LIKE)
         mock_mep_query.assert_called_once()
 
     def test_split_decision_for_errors_widget(self):


### PR DESCRIPTION
Adds the split decision to requests on widgets that already have a split decision made, and ones that are making the decision for the first time. I only tagged errors and transactions specifically, the other cases are ambiguous or we need the user to determine which dataset they want.