### PR TITLE
pref(trace-explorer): Remove splitByChar trick for trace id

### DIFF
--- a/src/sentry/api/endpoints/organization_traces.py
+++ b/src/sentry/api/endpoints/organization_traces.py
@@ -604,15 +604,7 @@ class TracesExecutor:
             )
 
             # restrict the query to just this subset of trace ids
-            query.add_conditions(
-                [
-                    Condition(
-                        Column("trace_id"),
-                        Op.IN,
-                        Function("splitByChar", [",", ",".join(chunk)]),
-                    )
-                ]
-            )
+            query.add_conditions([Condition(Column("trace_id"), Op.IN, chunk)])
 
             all_queries.append(query)
 
@@ -884,15 +876,7 @@ class TracesExecutor:
         )
 
         # restrict the query to just this subset of trace ids
-        query.add_conditions(
-            [
-                Condition(
-                    Column("trace_id"),
-                    Op.IN,
-                    Function("splitByChar", [",", ",".join(trace_ids)]),
-                )
-            ]
-        )
+        query.add_conditions([Condition(Column("trace_id"), Op.IN, trace_ids)])
 
         return query, Referrer.API_TRACE_EXPLORER_TRACES_BREAKDOWNS
 
@@ -921,15 +905,7 @@ class TracesExecutor:
         )
 
         # restrict the query to just this subset of trace ids
-        query.add_conditions(
-            [
-                Condition(
-                    Column("trace_id"),
-                    Op.IN,
-                    Function("splitByChar", [",", ",".join(trace_ids)]),
-                )
-            ]
-        )
+        query.add_conditions([Condition(Column("trace_id"), Op.IN, trace_ids)])
 
         """
         We want to get a count of the number of matching spans. To do this, we have to
@@ -983,15 +959,7 @@ class TracesExecutor:
         )
 
         # restrict the query to just this subset of trace ids
-        query.add_conditions(
-            [
-                Condition(
-                    Column("trace_id"),
-                    Op.IN,
-                    Function("splitByChar", [",", ",".join(trace_ids)]),
-                )
-            ]
-        )
+        query.add_conditions([Condition(Column("trace_id"), Op.IN, trace_ids)])
 
         return query, Referrer.API_TRACE_EXPLORER_TRACES_ERRORS
 
@@ -1014,15 +982,7 @@ class TracesExecutor:
         )
 
         # restrict the query to just this subset of trace ids
-        query.add_conditions(
-            [
-                Condition(
-                    Column("trace_id"),
-                    Op.IN,
-                    Function("splitByChar", [",", ",".join(trace_ids)]),
-                )
-            ]
-        )
+        query.add_conditions([Condition(Column("trace_id"), Op.IN, trace_ids)])
 
         return query, Referrer.API_TRACE_EXPLORER_TRACES_OCCURRENCES
 


### PR DESCRIPTION
The splitByChar trick speeds up the parsing in snuba but it comes at a cost of not fully leveraging the index on the trace id because snuba transforms the trace_id column.