### PR TITLE
feat(breadcrumbs): Add feedback to drawer

### DIFF
--- a/static/app/components/events/breadcrumbs/breadcrumbsDataSection.tsx
+++ b/static/app/components/events/breadcrumbs/breadcrumbsDataSection.tsx
@@ -1,4 +1,4 @@
-import {Fragment, useCallback, useMemo} from 'react';
+import {Fragment, useCallback, useMemo, useRef} from 'react';
 import styled from '@emotion/styled';
 
 import ProjectAvatar from 'sentry/components/avatar/projectAvatar';
@@ -18,11 +18,13 @@ import {
   getSummaryBreadcrumbs,
 } from 'sentry/components/events/breadcrumbs/utils';
 import {EventDataSection} from 'sentry/components/events/eventDataSection';
+import useFeedbackWidget from 'sentry/components/feedback/widget/useFeedbackWidget';
 import useDrawer from 'sentry/components/globalDrawer';
 import {
   IconClock,
   IconEllipsis,
   IconFilter,
+  IconMegaphone,
   IconSearch,
   IconSort,
   IconTimer,
@@ -79,20 +81,23 @@ export default function BreadcrumbsDataSection({
         ({Header, Body}) => (
           <Fragment>
             <Header>
-              <NavigationCrumbs
-                crumbs={[
-                  {
-                    label: (
-                      <CrumbContainer>
-                        <ProjectAvatar project={project} />
-                        <ShortId>{group.shortId}</ShortId>
-                      </CrumbContainer>
-                    ),
-                  },
-                  {label: getShortEventId(event.id)},
-                  {label: t('Breadcrumbs')},
-                ]}
-              />
+              <BreadcrumbHeader>
+                <NavigationCrumbs
+                  crumbs={[
+                    {
+                      label: (
+                        <CrumbContainer>
+                          <ProjectAvatar project={project} />
+                          <ShortId>{group.shortId}</ShortId>
+                        </CrumbContainer>
+                      ),
+                    },
+                    {label: getShortEventId(event.id)},
+                    {label: t('Breadcrumbs')},
+                  ]}
+                />
+                <BreadcrumbsFeedback />
+              </BreadcrumbHeader>
             </Header>
             <Body>
               <BreadcrumbsDrawerContent
@@ -193,6 +198,35 @@ export default function BreadcrumbsDataSection({
     </EventDataSection>
   );
 }
+
+function BreadcrumbsFeedback() {
+  const buttonRef = useRef<HTMLButtonElement>(null);
+  const feedback = useFeedbackWidget({
+    buttonRef,
+    messagePlaceholder: t('How can we make breadcrumbs more useful to you?'),
+  });
+
+  if (!feedback) {
+    return null;
+  }
+
+  return (
+    <Button
+      ref={buttonRef}
+      aria-label={t('Give Feedback')}
+      icon={<IconMegaphone />}
+      size={'xs'}
+    >
+      {t('Feedback')}
+    </Button>
+  );
+}
+
+const BreadcrumbHeader = styled('div')`
+  width: 100%;
+  display: flex;
+  justify-content: space-between;
+`;
 
 const ViewAllContainer = styled('div')`
   position: relative;

--- a/static/app/components/events/breadcrumbs/breadcrumbsDataSection.tsx
+++ b/static/app/components/events/breadcrumbs/breadcrumbsDataSection.tsx
@@ -1,4 +1,4 @@
-import {Fragment, useCallback, useMemo} from 'react';
+import {Fragment, useCallback, useMemo, useRef} from 'react';
 import styled from '@emotion/styled';
 
 import ProjectAvatar from 'sentry/components/avatar/projectAvatar';
@@ -18,6 +18,7 @@ import {
   getSummaryBreadcrumbs,
 } from 'sentry/components/events/breadcrumbs/utils';
 import {EventDataSection} from 'sentry/components/events/eventDataSection';
+import useFeedbackWidget from 'sentry/components/feedback/widget/useFeedbackWidget';
 import useDrawer from 'sentry/components/globalDrawer';
 import {
   IconClock,
@@ -35,7 +36,6 @@ import type {Group} from 'sentry/types/group';
 import type {Project} from 'sentry/types/project';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {getShortEventId} from 'sentry/utils/events';
-import {useFeedbackForm} from 'sentry/utils/useFeedbackForm';
 import {useLocalStorageState} from 'sentry/utils/useLocalStorageState';
 import useOrganization from 'sentry/utils/useOrganization';
 
@@ -51,7 +51,6 @@ export default function BreadcrumbsDataSection({
   project,
 }: BreadcrumbsDataSectionProps) {
   const {openDrawer} = useDrawer();
-  const openForm = useFeedbackForm();
   const organization = useOrganization();
   // Use the local storage preferences, but allow the drawer to do updates
   const [timeDisplay, setTimeDisplay] = useLocalStorageState<BreadcrumbTimeDisplay>(
@@ -97,25 +96,7 @@ export default function BreadcrumbsDataSection({
                     {label: t('Breadcrumbs')},
                   ]}
                 />
-                {openForm && (
-                  <Button
-                    aria-label={t('Give Feedback')}
-                    icon={<IconMegaphone />}
-                    size={'xs'}
-                    onClick={() => {
-                      openForm({
-                        messagePlaceholder: t(
-                          'How can we make breadcrumbs more useful to you?'
-                        ),
-                        tags: {
-                          feedback_source: 'issue_breadcrumbs',
-                        },
-                      });
-                    }}
-                  >
-                    {t('Feedback')}
-                  </Button>
-                )}
+                <BreadcrumbsFeedback />
               </BreadcrumbHeader>
             </Header>
             <Body>
@@ -129,7 +110,7 @@ export default function BreadcrumbsDataSection({
         {ariaLabel: 'breadcrumb drawer', closeOnOutsideClick: false}
       );
     },
-    [group, event, project, openDrawer, openForm, enhancedCrumbs, organization]
+    [group, event, project, openDrawer, enhancedCrumbs, organization]
   );
 
   if (enhancedCrumbs.length === 0) {
@@ -215,6 +196,29 @@ export default function BreadcrumbsDataSection({
         )}
       </ErrorBoundary>
     </EventDataSection>
+  );
+}
+
+function BreadcrumbsFeedback() {
+  const buttonRef = useRef<HTMLButtonElement>(null);
+  const feedback = useFeedbackWidget({
+    buttonRef,
+    messagePlaceholder: t('How can we make breadcrumbs more useful to you?'),
+  });
+
+  if (!feedback) {
+    return null;
+  }
+
+  return (
+    <Button
+      ref={buttonRef}
+      aria-label={t('Give Feedback')}
+      icon={<IconMegaphone />}
+      size={'xs'}
+    >
+      {t('Feedback')}
+    </Button>
   );
 }
 

--- a/static/app/components/events/breadcrumbs/breadcrumbsDataSection.tsx
+++ b/static/app/components/events/breadcrumbs/breadcrumbsDataSection.tsx
@@ -1,4 +1,4 @@
-import {Fragment, useCallback, useMemo, useRef} from 'react';
+import {Fragment, useCallback, useMemo} from 'react';
 import styled from '@emotion/styled';
 
 import ProjectAvatar from 'sentry/components/avatar/projectAvatar';
@@ -18,7 +18,6 @@ import {
   getSummaryBreadcrumbs,
 } from 'sentry/components/events/breadcrumbs/utils';
 import {EventDataSection} from 'sentry/components/events/eventDataSection';
-import useFeedbackWidget from 'sentry/components/feedback/widget/useFeedbackWidget';
 import useDrawer from 'sentry/components/globalDrawer';
 import {
   IconClock,
@@ -36,6 +35,7 @@ import type {Group} from 'sentry/types/group';
 import type {Project} from 'sentry/types/project';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {getShortEventId} from 'sentry/utils/events';
+import {useFeedbackForm} from 'sentry/utils/useFeedbackForm';
 import {useLocalStorageState} from 'sentry/utils/useLocalStorageState';
 import useOrganization from 'sentry/utils/useOrganization';
 
@@ -51,6 +51,7 @@ export default function BreadcrumbsDataSection({
   project,
 }: BreadcrumbsDataSectionProps) {
   const {openDrawer} = useDrawer();
+  const openForm = useFeedbackForm();
   const organization = useOrganization();
   // Use the local storage preferences, but allow the drawer to do updates
   const [timeDisplay, setTimeDisplay] = useLocalStorageState<BreadcrumbTimeDisplay>(
@@ -96,7 +97,25 @@ export default function BreadcrumbsDataSection({
                     {label: t('Breadcrumbs')},
                   ]}
                 />
-                <BreadcrumbsFeedback />
+                {openForm && (
+                  <Button
+                    aria-label={t('Give Feedback')}
+                    icon={<IconMegaphone />}
+                    size={'xs'}
+                    onClick={() => {
+                      openForm({
+                        messagePlaceholder: t(
+                          'How can we make breadcrumbs more useful to you?'
+                        ),
+                        tags: {
+                          feedback_source: 'issue_breadcrumbs',
+                        },
+                      });
+                    }}
+                  >
+                    {t('Feedback')}
+                  </Button>
+                )}
               </BreadcrumbHeader>
             </Header>
             <Body>
@@ -110,7 +129,7 @@ export default function BreadcrumbsDataSection({
         {ariaLabel: 'breadcrumb drawer', closeOnOutsideClick: false}
       );
     },
-    [group, event, project, openDrawer, enhancedCrumbs, organization]
+    [group, event, project, openDrawer, openForm, enhancedCrumbs, organization]
   );
 
   if (enhancedCrumbs.length === 0) {
@@ -196,29 +215,6 @@ export default function BreadcrumbsDataSection({
         )}
       </ErrorBoundary>
     </EventDataSection>
-  );
-}
-
-function BreadcrumbsFeedback() {
-  const buttonRef = useRef<HTMLButtonElement>(null);
-  const feedback = useFeedbackWidget({
-    buttonRef,
-    messagePlaceholder: t('How can we make breadcrumbs more useful to you?'),
-  });
-
-  if (!feedback) {
-    return null;
-  }
-
-  return (
-    <Button
-      ref={buttonRef}
-      aria-label={t('Give Feedback')}
-      icon={<IconMegaphone />}
-      size={'xs'}
-    >
-      {t('Feedback')}
-    </Button>
   );
 }
 

--- a/static/app/components/events/breadcrumbs/breadcrumbsDataSection.tsx
+++ b/static/app/components/events/breadcrumbs/breadcrumbsDataSection.tsx
@@ -107,7 +107,7 @@ export default function BreadcrumbsDataSection({
             </Body>
           </Fragment>
         ),
-        {ariaLabel: 'breadcrumb drawer'}
+        {ariaLabel: 'breadcrumb drawer', closeOnOutsideClick: false}
       );
     },
     [group, event, project, openDrawer, enhancedCrumbs, organization]

--- a/static/app/components/events/breadcrumbs/breadcrumbsItemContent.tsx
+++ b/static/app/components/events/breadcrumbs/breadcrumbsItemContent.tsx
@@ -54,7 +54,11 @@ export default function BreadcrumbsItemContent({
 
   if (bc?.type === BreadcrumbType.HTTP) {
     return (
-      <HTTPCrumbContent breadcrumb={bc} meta={meta} fullyExpanded={fullyExpanded}>
+      <HTTPCrumbContent
+        breadcrumb={bc}
+        meta={meta}
+        structuredDataProps={structuredDataProps}
+      >
         {defaultMessage}
       </HTTPCrumbContent>
     );
@@ -84,11 +88,11 @@ function HTTPCrumbContent({
   breadcrumb,
   meta,
   children = null,
-  fullyExpanded,
+  structuredDataProps,
 }: {
   breadcrumb: BreadcrumbTypeHTTP;
   children: React.ReactNode;
-  fullyExpanded: boolean;
+  structuredDataProps: typeof DEFAULT_STRUCTURED_DATA_PROPS;
   meta?: Record<string, any>;
 }) {
   const {method, url, status_code: statusCode, ...otherData} = breadcrumb?.data ?? {};
@@ -109,12 +113,7 @@ function HTTPCrumbContent({
       </Timeline.Text>
       {Object.keys(otherData).length > 0 ? (
         <Timeline.Data>
-          <StructuredData
-            value={otherData}
-            meta={meta}
-            {...DEFAULT_STRUCTURED_DATA_PROPS}
-            forceDefaultExpand={fullyExpanded}
-          />
+          <StructuredData value={otherData} meta={meta} {...structuredDataProps} />
         </Timeline.Data>
       ) : null}
     </Fragment>

--- a/static/app/components/events/breadcrumbs/utils.tsx
+++ b/static/app/components/events/breadcrumbs/utils.tsx
@@ -48,7 +48,7 @@ export const BREADCRUMB_TIME_DISPLAY_OPTIONS = [
 export const BREADCRUMB_TIME_DISPLAY_LOCALSTORAGE_KEY = 'event-breadcrumb-time-display';
 
 const Color = styled('span')<{colorConfig: ColorConfig}>`
-  color: ${p => p.theme[p.colorConfig.primary]};
+  color: ${p => p.theme[p.colorConfig.icon]};
 `;
 
 /**
@@ -179,26 +179,26 @@ function getBreadcrumbTitle(category: RawCrumb['category']) {
 function getBreadcrumbColorConfig(type?: BreadcrumbType): ColorConfig {
   switch (type) {
     case BreadcrumbType.ERROR:
-      return {primary: 'red400', secondary: 'red200'};
+      return {title: 'red400', icon: 'red400', iconBorder: 'red200'};
     case BreadcrumbType.WARNING:
-      return {primary: 'yellow400', secondary: 'yellow200'};
+      return {title: 'yellow400', icon: 'yellow400', iconBorder: 'yellow200'};
     case BreadcrumbType.NAVIGATION:
     case BreadcrumbType.HTTP:
     case BreadcrumbType.QUERY:
     case BreadcrumbType.TRANSACTION:
-      return {primary: 'green400', secondary: 'green200'};
+      return {title: 'green400', icon: 'green400', iconBorder: 'green200'};
     case BreadcrumbType.USER:
     case BreadcrumbType.UI:
-      return {primary: 'purple400', secondary: 'purple200'};
+      return {title: 'purple400', icon: 'purple400', iconBorder: 'purple200'};
     case BreadcrumbType.SYSTEM:
     case BreadcrumbType.SESSION:
     case BreadcrumbType.DEVICE:
     case BreadcrumbType.NETWORK:
-      return {primary: 'pink400', secondary: 'pink200'};
+      return {title: 'pink400', icon: 'pink400', iconBorder: 'pink200'};
     case BreadcrumbType.DEBUG:
     case BreadcrumbType.INFO:
     default:
-      return {primary: 'gray300', secondary: 'gray200'};
+      return {title: 'gray400', icon: 'gray300', iconBorder: 'gray200'};
   }
 }
 

--- a/static/app/components/globalDrawer/components.tsx
+++ b/static/app/components/globalDrawer/components.tsx
@@ -118,7 +118,7 @@ const Header = styled('header')`
   padding-left: 24px;
 `;
 
-export const DrawerBody = styled('section')`
+export const DrawerBody = styled('aside')`
   padding: ${space(2)} 24px;
   font-size: ${p => p.theme.fontSizeMedium};
 `;
@@ -128,7 +128,6 @@ const DrawerContainer = styled('div')`
   inset: 0;
   z-index: ${p => p.theme.zIndex.drawer};
   pointer-events: none;
-  display: relative;
 `;
 
 export const DrawerComponents = {

--- a/static/app/components/replays/breadcrumbs/breadcrumbItem.tsx
+++ b/static/app/components/replays/breadcrumbs/breadcrumbItem.tsx
@@ -131,7 +131,7 @@ function BreadcrumbItem({
       <StyledTimelineItem
         icon={icon}
         title={title}
-        colorConfig={{primary: darkColor, secondary: color}}
+        colorConfig={{title: darkColor, icon: darkColor, iconBorder: color}}
         timestamp={
           <ReplayTimestamp>
             <TimestampButton

--- a/static/app/components/timeline/index.stories.tsx
+++ b/static/app/components/timeline/index.stories.tsx
@@ -41,8 +41,9 @@ export default storyBook('Timeline (Updated 06/17/24)', story => {
         icon={<IconFire size="xs" />}
         timestamp={<DateTime date={now} />}
         colorConfig={{
-          primary: 'red400',
-          secondary: 'red200',
+          title: 'red400',
+          icon: 'red400',
+          iconBorder: 'red200',
         }}
         isActive
       >
@@ -73,8 +74,9 @@ export default storyBook('Timeline (Updated 06/17/24)', story => {
         icon={<IconSort rotated size="xs" />}
         timestamp={<DateTime date={now} />}
         colorConfig={{
-          primary: 'green400',
-          secondary: 'green200',
+          title: 'green400',
+          icon: 'green400',
+          iconBorder: 'green200',
         }}
       >
         <Timeline.Data>
@@ -134,16 +136,18 @@ export default storyBook('Timeline (Updated 06/17/24)', story => {
         icon={<IconFire size="xs" />}
         timestamp={<span style={{color: 'blue'}}>my cool timestamp</span>}
         colorConfig={{
-          primary: 'red400',
-          secondary: 'red200',
+          title: 'red400',
+          icon: 'red400',
+          iconBorder: 'red200',
         }}
       />
       <Timeline.Item
         title={'Active Item'}
         icon={<IconCursorArrow size="xs" />}
         colorConfig={{
-          primary: 'blue400',
-          secondary: 'blue200',
+          title: 'blue400',
+          icon: 'blue400',
+          iconBorder: 'blue200',
         }}
         isActive
       >
@@ -160,8 +164,9 @@ export default storyBook('Timeline (Updated 06/17/24)', story => {
           </Button>
         }
         colorConfig={{
-          primary: 'pink400',
-          secondary: 'pink200',
+          title: 'pink400',
+          icon: 'pink400',
+          iconBorder: 'pink200',
         }}
       >
         <Timeline.Data>
@@ -179,8 +184,9 @@ export default storyBook('Timeline (Updated 06/17/24)', story => {
         title={'Another Event'}
         icon={<IconClock size="xs" />}
         colorConfig={{
-          primary: 'purple400',
-          secondary: 'purple200',
+          title: 'purple400',
+          icon: 'purple400',
+          iconBorder: 'purple200',
         }}
       >
         <Timeline.Text>This is a description of the error</Timeline.Text>
@@ -201,8 +207,9 @@ export default storyBook('Timeline (Updated 06/17/24)', story => {
           title={'Error'}
           icon={<IconFire size="xs" />}
           colorConfig={{
-            primary: 'red400',
-            secondary: 'red200',
+            title: 'red400',
+            icon: 'red400',
+            iconBorder: 'red200',
           }}
         >
           <Timeline.Text>This is a description of the error</Timeline.Text>
@@ -213,8 +220,9 @@ export default storyBook('Timeline (Updated 06/17/24)', story => {
           icon={<IconSort rotated size="xs" />}
           timestamp={<DateTime date={now} />}
           colorConfig={{
-            primary: 'green400',
-            secondary: 'green200',
+            title: 'green400',
+            icon: 'green400',
+            iconBorder: 'green200',
           }}
         >
           {' '}
@@ -235,8 +243,9 @@ export default storyBook('Timeline (Updated 06/17/24)', story => {
           icon={<IconCursorArrow size="xs" />}
           timestamp={<DateTime date={now} />}
           colorConfig={{
-            primary: 'blue400',
-            secondary: 'blue200',
+            title: 'blue400',
+            icon: 'blue400',
+            iconBorder: 'blue200',
           }}
         >
           <Timeline.Text>{'div.abc123 > xyz > somethingsomething'}</Timeline.Text>
@@ -247,8 +256,9 @@ export default storyBook('Timeline (Updated 06/17/24)', story => {
           icon={<IconSentry size="xs" />}
           timestamp={<DateTime date={now} />}
           colorConfig={{
-            primary: 'purple400',
-            secondary: 'purple200',
+            title: 'purple400',
+            icon: 'purple400',
+            iconBorder: 'purple200',
           }}
         >
           <Timeline.Text>

--- a/static/app/components/timeline/index.tsx
+++ b/static/app/components/timeline/index.tsx
@@ -7,8 +7,9 @@ import {space} from 'sentry/styles/space';
 import type {Color} from 'sentry/utils/theme';
 
 export interface ColorConfig {
-  primary: Color;
-  secondary: Color;
+  icon: Color;
+  iconBorder: Color;
+  title: Color;
 }
 
 export interface TimelineItemProps {
@@ -30,7 +31,7 @@ export const Item = forwardRef(function _Item(
     title,
     children,
     icon,
-    colorConfig = {primary: 'gray300', secondary: 'gray200'},
+    colorConfig = {title: 'gray400', icon: 'gray300', iconBorder: 'gray200'},
     timestamp,
     isActive = false,
     style,
@@ -39,12 +40,10 @@ export const Item = forwardRef(function _Item(
   ref: React.ForwardedRef<HTMLDivElement>
 ) {
   const theme = useTheme();
-  const {primary, secondary} = colorConfig;
   return (
     <Row
-      color={secondary}
       style={{
-        borderBottom: `1px solid ${isActive ? theme[secondary] : 'transparent'}`,
+        borderBottom: `1px solid ${isActive ? theme[colorConfig.icon] : 'transparent'}`,
         ...style,
       }}
       ref={ref}
@@ -52,14 +51,14 @@ export const Item = forwardRef(function _Item(
     >
       <IconWrapper
         style={{
-          borderColor: isActive ? theme[secondary] : 'transparent',
-          color: theme[primary],
+          borderColor: isActive ? theme[colorConfig.iconBorder] : 'transparent',
+          color: theme[colorConfig.icon],
         }}
         className="icon-wrapper"
       >
         {icon}
       </IconWrapper>
-      <Title style={{color: theme[primary]}}>{title}</Title>
+      <Title style={{color: theme[colorConfig.title]}}>{title}</Title>
       {timestamp ?? <div />}
       <Spacer
         style={{borderLeft: `1px solid ${isActive ? theme.border : 'transparent'}`}}


### PR DESCRIPTION
Adds the feedback widget to the header of the drawer. Adding it here instead of the base page since if the drawer is open, they've seen the entire new experience prior to writing in.

To allow feedback to be submitted properly, I had to prevent outside clicks from closing the drawer. That said, the close button is sticky now, so users should always be able to quickly close the drawer if they need.

Also fixes a bug where HTTP crumbs would not expand the default depth size of 2 on the base page.

![image](https://github.com/getsentry/sentry/assets/35509934/2acec617-00bc-4e71-a565-43deba83fe08)

**todo**
- [x] Double check that this doesn't act funky with the drawer in getsentry