### PR TITLE
ref(grouping): Rewrite hierarchical grouping tests

### DIFF
--- a/tests/sentry/event_manager/test_hierarchical_hashes.py
+++ b/tests/sentry/event_manager/test_hierarchical_hashes.py
@@ -203,21 +203,13 @@ def test_partial_move(default_project, fast_save):
 
 class EventManagerGroupingTest(TestCase):
     def test_can_upgrade_to_hierarchical_config(self):
-        hierarchical_hashes = [
-            "be778d6d6543432ae89b3e0f94ebff80",
-            "4e536cc423da0e1e2101b30688aab6b1",
-        ]
         self.set_options("legacy:2019-03-12")  # Starting configuration
         event = self.save_event()
-        assert event.get_hashes().hashes == ["8b1a9953c4611296a827abf8c47804d7"]
-        assert event.get_hashes().hierarchical_hashes == []
 
         self.transition_to_new_config("mobile:2021-02-12")
         # This event will have two sets of hashes
         event2 = self.save_event()
-        # The hashes propery gets the last hierarchical hash assigned
-        assert event2.get_hashes().hashes == [hierarchical_hashes[-1]]
-        assert event2.get_hashes().hierarchical_hashes == hierarchical_hashes
+
         # The hashes property between the two events do not intersect
         assert not set(event.get_hashes().hashes) & set(event2.get_hashes().hashes)
         # They both belong to the same group be
@@ -234,22 +226,14 @@ class EventManagerGroupingTest(TestCase):
         assert event3.group_id == event2.group_id
 
     def test_can_downgrade_from_hierarchical_config(self):
-        hierarchical_hashes = [
-            "be778d6d6543432ae89b3e0f94ebff80",
-            "4e536cc423da0e1e2101b30688aab6b1",
-        ]
         self.set_options("mobile:2021-02-12")  # Starting configuration
+
         event = self.save_event()
-        assert event.get_hashes().hashes == ["4e536cc423da0e1e2101b30688aab6b1"]
-        assert event.get_hashes().hierarchical_hashes == hierarchical_hashes
 
         self.transition_to_new_config("legacy:2019-03-12")
         # This event will have two sets of hashes
         event2 = self.save_event()
 
-        # The hashes propery gets the last hierarchical hash assigned
-        assert event2.get_hashes().hashes == ["8b1a9953c4611296a827abf8c47804d7"]
-        assert event2.get_hashes().hierarchical_hashes == []
         # The hashes property between the two events do not intersect
         assert not set(event.get_hashes().hashes) & set(event2.get_hashes().hashes)
         # They both belong to the same group be

--- a/tests/sentry/event_manager/test_hierarchical_hashes.py
+++ b/tests/sentry/event_manager/test_hierarchical_hashes.py
@@ -208,12 +208,13 @@ class EventManagerGroupingTest(TestCase):
         event = self.save_event()
 
         self.transition_to_new_config("mobile:2021-02-12")
+
         # This event will have two sets of hashes
         event2 = self.save_event()
 
         # The hashes property between the two events do not intersect
         assert not set(event.get_hashes().hashes) & set(event2.get_hashes().hashes)
-        # They both belong to the same group be
+        # They are both grouped together
         assert event.group_id == event2.group_id
 
         group = Group.objects.get(id=event.group_id)
@@ -232,12 +233,13 @@ class EventManagerGroupingTest(TestCase):
         event = self.save_event()
 
         self.transition_to_new_config("legacy:2019-03-12")
+
         # This event will have two sets of hashes
         event2 = self.save_event()
 
         # The hashes property between the two events do not intersect
         assert not set(event.get_hashes().hashes) & set(event2.get_hashes().hashes)
-        # They both belong to the same group be
+        # They are both grouped together
         assert event.group_id == event2.group_id
 
         group = Group.objects.get(id=event.group_id)

--- a/tests/sentry/event_manager/test_hierarchical_hashes.py
+++ b/tests/sentry/event_manager/test_hierarchical_hashes.py
@@ -204,6 +204,7 @@ def test_partial_move(default_project, fast_save):
 class EventManagerGroupingTest(TestCase):
     def test_can_upgrade_to_hierarchical_config(self):
         self.set_options("legacy:2019-03-12")  # Starting configuration
+
         event = self.save_event()
 
         self.transition_to_new_config("mobile:2021-02-12")

--- a/tests/sentry/event_manager/test_hierarchical_hashes.py
+++ b/tests/sentry/event_manager/test_hierarchical_hashes.py
@@ -202,9 +202,6 @@ def test_partial_move(default_project, fast_save):
 
 
 class EventManagerGroupingTest(TestCase):
-    def setUp(self):
-        super().setUp()
-
     def save_event(self):
         manager = EventManager(
             make_event(


### PR DESCRIPTION
This makes the tests a little easier to understand and prepares for my next set of changes.