### PR TITLE
ref(replay): render obj strings properly in StructuredEventData

### DIFF
--- a/static/app/components/structuredEventData/index.tsx
+++ b/static/app/components/structuredEventData/index.tsx
@@ -185,7 +185,7 @@ export function StructuredData({
     );
   }
 
-  if (typeof value === 'string' || config?.isString?.(value)) {
+  if (typeof value === 'string') {
     if (config?.isString?.(value)) {
       const stringValue = config.renderString?.(value) ?? value;
 

--- a/static/app/components/structuredEventData/index.tsx
+++ b/static/app/components/structuredEventData/index.tsx
@@ -185,7 +185,7 @@ export function StructuredData({
     );
   }
 
-  if (typeof value === 'string') {
+  if (typeof value === 'string' || config?.isString?.(value)) {
     if (config?.isString?.(value)) {
       const stringValue = config.renderString?.(value) ?? value;
 

--- a/static/app/views/replays/detail/network/details/sections.tsx
+++ b/static/app/views/replays/detail/network/details/sections.tsx
@@ -39,6 +39,12 @@ export type SectionProps = {
   startTimestampMs: number;
 };
 
+const config = {
+  isString: (v: any) => {
+    return typeof v === 'string';
+  },
+};
+
 const UNKNOWN_STATUS = 'unknown';
 
 export function GeneralSection({item, startTimestampMs}: SectionProps) {
@@ -183,6 +189,7 @@ export function QueryParamsSection({item}: SectionProps) {
           showCopyButton
           forceDefaultExpand
           maxDefaultDepth={3}
+          config={config}
         />
       </Indent>
     </SectionItem>
@@ -218,6 +225,7 @@ export function RequestPayloadSection({item}: SectionProps) {
             forceDefaultExpand
             maxDefaultDepth={2}
             showCopyButton
+            config={config}
           />
         ) : (
           t('Request body not found.')
@@ -256,6 +264,7 @@ export function ResponsePayloadSection({item}: SectionProps) {
             forceDefaultExpand
             maxDefaultDepth={2}
             showCopyButton
+            config={config}
           />
         ) : (
           t('Response body not found.')


### PR DESCRIPTION
relates to https://github.com/getsentry/sentry/issues/70042

render strings properly with quotations in the `StructuredEventData` component in the network tab.

strings in objects now look like this:
<img width="411" alt="SCR-20240711-iwfj" src="https://github.com/getsentry/sentry/assets/56095982/98eb18d1-db3a-456d-b78e-1790af40e84b">
