### PR TITLE
chore(slack): remove old client from SlackNotifyMixin

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -401,8 +401,8 @@ def register_temporary_features(manager: FeatureManager):
     # Feature flags for migrating to the Slack SDK WebClient
     # Use new Slack SDK Client in get_channel_id_with_timeout
     manager.add("organizations:slack-sdk-get-channel-id", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE)
-    # Use new Slack SDK Client for SlackNotifyBasicMixin
-    manager.add("organizations:slack-sdk-notify-mixin", OrganizationFeature, FeatureHandlerStrategy.OPTIONS)
+    # Use new Slack SDK Client in SlackActionEndpoint's `view.open`
+    manager.add("organizations:slack-sdk-action-view-open", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE)
     # Add regression chart as image to slack message
     manager.add("organizations:slack-endpoint-regression-image", OrganizationFeature, FeatureHandlerStrategy.OPTIONS)
     manager.add("organizations:slack-function-regression-image", OrganizationFeature, FeatureHandlerStrategy.OPTIONS)

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -401,8 +401,6 @@ def register_temporary_features(manager: FeatureManager):
     # Feature flags for migrating to the Slack SDK WebClient
     # Use new Slack SDK Client in get_channel_id_with_timeout
     manager.add("organizations:slack-sdk-get-channel-id", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE)
-    # Use new Slack SDK Client in SlackActionEndpoint's `view.open`
-    manager.add("organizations:slack-sdk-action-view-open", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE)
     # Add regression chart as image to slack message
     manager.add("organizations:slack-endpoint-regression-image", OrganizationFeature, FeatureHandlerStrategy.OPTIONS)
     manager.add("organizations:slack-function-regression-image", OrganizationFeature, FeatureHandlerStrategy.OPTIONS)

--- a/src/sentry/integrations/slack/integration.py
+++ b/src/sentry/integrations/slack/integration.py
@@ -9,7 +9,6 @@ from django.views import View
 from slack_sdk import WebClient
 from slack_sdk.errors import SlackApiError
 
-from sentry import features as sentry_features
 from sentry.identity.pipeline import IdentityProviderPipeline
 from sentry.integrations.base import (
     FeatureDescription,
@@ -26,7 +25,6 @@ from sentry.shared_integrations.exceptions import IntegrationError
 from sentry.tasks.integrations.slack import link_slack_user_identities
 from sentry.utils.http import absolute_uri
 
-from .client import SlackClient
 from .notifications import SlackNotifyBasicMixin
 from .utils import logger
 
@@ -73,10 +71,8 @@ metadata = IntegrationMetadata(
 
 
 class SlackIntegration(SlackNotifyBasicMixin, IntegrationInstallation):
-    def get_client(self) -> SlackClient | SlackSdkClient:
-        if sentry_features.has("organizations:slack-sdk-notify-mixin", self.organization):
-            return SlackSdkClient(integration_id=self.model.id)
-        return SlackClient(integration_id=self.model.id)
+    def get_client(self) -> SlackSdkClient:
+        return SlackSdkClient(integration_id=self.model.id)
 
     def get_config_data(self) -> Mapping[str, str]:
         metadata_ = self.model.metadata

--- a/src/sentry/integrations/slack/metrics.py
+++ b/src/sentry/integrations/slack/metrics.py
@@ -61,6 +61,9 @@ SLACK_COMMANDS_LINK_IDENTITY_FAILURE_DATADOG_METRIC = (
     "sentry.integrations.slack.commands_link_identity.failure"
 )
 
+SLACK_NOTIFY_MIXIN_SUCCESS_DATADOG_METRIC = "sentry.integrations.slack.notify_mixin.success"
+SLACK_NOTIFY_MIXIN_FAILURE_DATADOG_METRIC = "sentry.integrations.slack.notify_mixin.failure"
+
 # Utils
 SLACK_UTILS_GET_USER_LIST_SUCCESS_DATADOG_METRIC = "sentry.integrations.slack.utils.users.success"
 SLACK_UTILS_GET_USER_LIST_FAILURE_DATADOG_METRIC = "sentry.integrations.slack.utils.users.failure"

--- a/src/sentry/integrations/slack/notifications.py
+++ b/src/sentry/integrations/slack/notifications.py
@@ -9,12 +9,10 @@ from slack_sdk.errors import SlackApiError
 
 from sentry.integrations.mixins import NotifyBasicMixin
 from sentry.integrations.notifications import get_integrations_by_channel_by_recipient
-from sentry.integrations.slack.client import SlackClient
 from sentry.integrations.slack.service import SlackService
 from sentry.integrations.types import ExternalProviders
 from sentry.notifications.notifications.base import BaseNotification
 from sentry.notifications.notify import register_notification_provider
-from sentry.shared_integrations.exceptions import ApiError
 from sentry.types.actor import Actor
 from sentry.utils import metrics
 
@@ -24,31 +22,20 @@ SLACK_TIMEOUT = 5
 
 class SlackNotifyBasicMixin(NotifyBasicMixin):
     def send_message(self, channel_id: str, message: str) -> None:
-        payload = {"channel": channel_id, "text": message}
         client = self.get_client()
 
-        if isinstance(client, SlackClient):
-            try:
-                client.post("/chat.postMessage", data=payload, json=True)
-            except ApiError as e:
-                message = str(e)
-                if message not in ["Expired url", "channel_not_found"]:
-                    logger.exception(
-                        "slack.slash-notify.response-error",
-                        extra={"error": message},
-                    )
-        else:
-            try:
-                client.chat_postMessage(channel=channel_id, text=message)
-                logger.info("slack.slash-notify.success", extra={"channel_id": channel_id})
-            except SlackApiError as e:
-                error = str(e)
-                message = error.split("\n")[0]
-                if "Expired url" not in message and "channel_not_found" not in message:
-                    logger.exception(
-                        "slack.slash-response.error",
-                        extra={"error": error},
-                    )
+        try:
+            client.chat_postMessage(channel=channel_id, text=message)
+            logger.info("slack.slash-notify.success", extra={"channel_id": channel_id})
+        except SlackApiError as e:
+            error = str(e)
+            message = error.split("\n")[0]
+            # TODO: remove this
+            if "expired_url" not in message and "channel_not_found" not in message:
+                logger.exception(
+                    "slack.slash-response.error",
+                    extra={"error": error},
+                )
 
 
 @register_notification_provider(ExternalProviders.SLACK)

--- a/tests/sentry/integrations/slack/test_link_team.py
+++ b/tests/sentry/integrations/slack/test_link_team.py
@@ -3,9 +3,7 @@ from typing import Any, Optional
 from unittest.mock import patch
 from urllib.parse import urlencode
 
-import orjson
 import pytest
-import responses
 from django.db.models import QuerySet
 from django.http.response import HttpResponseBase
 from rest_framework import status
@@ -20,8 +18,8 @@ from sentry.models.organization import Organization
 from sentry.models.team import Team
 from sentry.silo.base import SiloMode
 from sentry.testutils.cases import TestCase
-from sentry.testutils.helpers import add_identity, get_response_text, install_slack, link_team
-from sentry.testutils.helpers.features import Feature, with_feature
+from sentry.testutils.helpers import add_identity, install_slack, link_team
+from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.silo import assume_test_silo_mode
 
 
@@ -39,21 +37,6 @@ class SlackIntegrationLinkTeamTestBase(TestCase):
 
         self.integration = install_slack(self.organization)
         self.idp = add_identity(self.integration, self.user, self.external_id)
-
-        responses.add(
-            method=responses.POST,
-            url=self.response_url,
-            body='{"ok": true}',
-            status=status.HTTP_200_OK,
-            content_type="application/json",
-        )
-        responses.add(
-            method=responses.POST,
-            url="https://slack.com/api/chat.postMessage",
-            body='{"ok": true}',
-            status=status.HTTP_200_OK,
-            content_type="application/json",
-        )
 
     def get_success_response(self, data: Mapping[str, Any] | None = None) -> HttpResponseBase:
         """This isn't in APITestCase so this isn't really an override."""
@@ -129,163 +112,22 @@ class SlackIntegrationLinkTeamTest(SlackIntegrationLinkTeamTestBase):
             organization=self.organization, name="Mariachi Band", members=[self.user]
         )
 
-    @responses.activate
-    def test_link_team(self):
-        """Test that we successfully link a team to a Slack channel"""
-        response = self.get_success_response()
-        self.assertTemplateUsed(response, "sentry/integrations/slack/link-team.html")
-
-        response = self.get_success_response(data={"team": self.team.id})
-        self.assertTemplateUsed(response, "sentry/integrations/slack/post-linked-team.html")
-
-        external_actors = self.get_linked_teams()
-        assert len(external_actors) == 1
-        assert external_actors[0].team_id == self.team.id
-
-        assert len(responses.calls) >= 1
-        data = orjson.loads(responses.calls[0].request.body)
-        assert (
-            f"The {self.team.slug} team will now receive issue alert notifications in the {external_actors[0].external_name} channel."
-            in get_response_text(data)
-        )
-
-        with assume_test_silo_mode(SiloMode.CONTROL):
-            team_settings = NotificationSettingProvider.objects.filter(
-                team_id=self.team.id,
-                provider="slack",
-                type="alerts",
-                scope_type="team",
-                scope_identifier=self.team.id,
-                value="always",
-            )
-            assert len(team_settings) == 1
-
-    @responses.activate
-    def test_link_team_valid_through_team_admin(self):
-        """Test that we successfully link a team to a Slack channel as a valid team admin"""
-        self._create_user_valid_through_team_admin()
-
-        self.test_link_team()
-
-    @responses.activate
-    def test_link_team_already_linked(self):
-        """Test that if a team has already been linked to a Slack channel when a user tries
-        to link them again, we reject the attempt and reply with the ALREADY_LINKED_MESSAGE"""
-        self.link_team()
-
-        response = self.get_success_response(data={"team": self.team.id})
-        self.assertTemplateUsed(response, "sentry/integrations/slack/post-linked-team.html")
-        assert len(responses.calls) >= 1
-        data = orjson.loads(responses.calls[0].request.body)
-        assert (
-            f"The {self.team.slug} team has already been linked to a Slack channel."
-            in get_response_text(data)
-        )
-
-    @responses.activate
-    def test_error_page(self):
-        """Test that we successfully render an error page when bad form data is sent."""
-        self.get_error_response(
-            data={"team": ["some", "garbage"]}, status_code=status.HTTP_400_BAD_REQUEST
-        )
-
-    @responses.activate
-    def test_link_team_multiple_organizations(self):
-        # Create another organization and team for this user that is linked through `self.integration`.
-        organization2 = self.create_organization(owner=self.user)
-        team2 = self.create_team(organization=organization2, members=[self.user])
-        with assume_test_silo_mode(SiloMode.CONTROL):
-            self.create_organization_integration(
-                organization_id=organization2.id, integration=self.integration
-            )
-
-        # Team order should not matter.
-        for team in (self.team, team2):
-            response = self.get_success_response(data={"team": team.id})
-            self.assertTemplateUsed(response, "sentry/integrations/slack/post-linked-team.html")
-
-            external_actors = self.get_linked_teams(
-                organization=team.organization, team_ids=[team.id]
-            )
-            assert len(external_actors) == 1
-
-    @responses.activate
-    @with_feature("organizations:team-workflow-notifications")
-    def test_message_includes_workflow(self):
-        self.get_success_response(data={"team": self.team.id})
-        external_actors = self.get_linked_teams()
-
-        assert len(responses.calls) >= 1
-        data = orjson.loads(responses.calls[0].request.body)
-        assert (
-            f"The {self.team.slug} team will now receive issue alert and workflow notifications in the {external_actors[0].external_name} channel."
-            in get_response_text(data)
-        )
-
-    @responses.activate
-    @with_feature("organizations:team-workflow-notifications")
-    def test_link_team_v2(self):
-        """Test that we successfully link a team to a Slack channel"""
-        response = self.get_success_response()
-        self.assertTemplateUsed(response, "sentry/integrations/slack/link-team.html")
-
-        response = self.get_success_response(data={"team": self.team.id})
-        self.assertTemplateUsed(response, "sentry/integrations/slack/post-linked-team.html")
-
-        external_actors = self.get_linked_teams()
-        assert len(external_actors) == 1
-        assert external_actors[0].team_id == self.team.id
-
-        assert len(responses.calls) >= 1
-        data = orjson.loads(responses.calls[0].request.body)
-        assert (
-            f"The {self.team.slug} team will now receive issue alert and workflow notifications in the {external_actors[0].external_name} channel."
-            in get_response_text(data)
-        )
-
-        # Test that we didn't make an NotificationSetting object
-        # Instead we will use the default in notificationcontroller.py
-        with assume_test_silo_mode(SiloMode.CONTROL):
-            team_settings = NotificationSettingProvider.objects.filter(
-                team_id=self.team.id,
-            )
-            assert len(team_settings) == 0
-
-
-class SlackIntegrationLinkTeamWithSdkTest(SlackIntegrationLinkTeamTestBase):
-    def setUp(self):
-        super().setUp()
-        self.url = build_team_linking_url(
-            integration=self.integration,
-            slack_id=self.external_id,
-            channel_id=self.channel_id,
-            channel_name=self.channel_name,
-            response_url=self.response_url,
-        )
-        self.team = self.create_team(
-            organization=self.organization, name="Mariachi Band", members=[self.user]
-        )
-
     @pytest.fixture(autouse=True)
     def mock_chat_postMessage(self):
-        with (
-            patch(
-                "slack_sdk.web.WebClient.chat_postMessage",
-                return_value=SlackResponse(
-                    client=None,
-                    http_verb="POST",
-                    api_url="https://slack.com/api/chat.postMessage",
-                    req_args={},
-                    data={"ok": True},
-                    headers={},
-                    status_code=200,
-                ),
-            ) as self.mock_post,
-            Feature("organizations:slack-sdk-notify-mixin"),
-        ):
+        with patch(
+            "slack_sdk.web.WebClient.chat_postMessage",
+            return_value=SlackResponse(
+                client=None,
+                http_verb="POST",
+                api_url="https://slack.com/api/chat.postMessage",
+                req_args={},
+                data={"ok": True},
+                headers={},
+                status_code=200,
+            ),
+        ) as self.mock_post:
             yield
 
-    @responses.activate
     def test_link_team(self):
         """Test that we successfully link a team to a Slack channel"""
         response = self.get_success_response()
@@ -316,14 +158,12 @@ class SlackIntegrationLinkTeamWithSdkTest(SlackIntegrationLinkTeamTestBase):
             )
             assert len(team_settings) == 1
 
-    @responses.activate
     def test_link_team_valid_through_team_admin(self):
         """Test that we successfully link a team to a Slack channel as a valid team admin"""
         self._create_user_valid_through_team_admin()
 
         self.test_link_team()
 
-    @responses.activate
     def test_link_team_already_linked(self):
         """Test that if a team has already been linked to a Slack channel when a user tries
         to link them again, we reject the attempt and reply with the ALREADY_LINKED_MESSAGE"""
@@ -335,14 +175,12 @@ class SlackIntegrationLinkTeamWithSdkTest(SlackIntegrationLinkTeamTestBase):
         text = self.mock_post.call_args.kwargs["text"]
         assert f"The {self.team.slug} team has already been linked to a Slack channel." in text
 
-    @responses.activate
     def test_error_page(self):
         """Test that we successfully render an error page when bad form data is sent."""
         self.get_error_response(
             data={"team": ["some", "garbage"]}, status_code=status.HTTP_400_BAD_REQUEST
         )
 
-    @responses.activate
     def test_link_team_multiple_organizations(self):
         # Create another organization and team for this user that is linked through `self.integration`.
         organization2 = self.create_organization(owner=self.user)
@@ -362,7 +200,6 @@ class SlackIntegrationLinkTeamWithSdkTest(SlackIntegrationLinkTeamTestBase):
             )
             assert len(external_actors) == 1
 
-    @responses.activate
     @with_feature("organizations:team-workflow-notifications")
     def test_message_includes_workflow(self):
         self.get_success_response(data={"team": self.team.id})
@@ -375,7 +212,6 @@ class SlackIntegrationLinkTeamWithSdkTest(SlackIntegrationLinkTeamTestBase):
             in text
         )
 
-    @responses.activate
     @with_feature("organizations:team-workflow-notifications")
     def test_link_team_v2(self):
         """Test that we successfully link a team to a Slack channel"""
@@ -403,126 +239,6 @@ class SlackIntegrationLinkTeamWithSdkTest(SlackIntegrationLinkTeamTestBase):
                 team_id=self.team.id,
             )
             assert len(team_settings) == 0
-
-
-class SlackIntegrationUnlinkTeamTest(SlackIntegrationLinkTeamTestBase):
-    def setUp(self):
-        super().setUp()
-
-        self.link_team()
-        self.url = build_team_unlinking_url(
-            integration=self.integration,
-            organization_id=self.organization.id,
-            slack_id=self.external_id,
-            channel_id=self.channel_id,
-            channel_name=self.channel_name,
-            response_url=self.response_url,
-        )
-
-    @responses.activate
-    def test_unlink_team(self):
-        """Test that a team can be unlinked from a Slack channel"""
-        response = self.get_success_response()
-        self.assertTemplateUsed(response, "sentry/integrations/slack/unlink-team.html")
-
-        response = self.get_success_response(data={})
-        self.assertTemplateUsed(response, "sentry/integrations/slack/unlinked-team.html")
-
-        external_actors = self.get_linked_teams()
-        assert len(external_actors) == 0
-
-        assert len(responses.calls) >= 1
-        data = orjson.loads(responses.calls[0].request.body)
-        assert (
-            f"This channel will no longer receive issue alert notifications for the {self.team.slug} team."
-            in get_response_text(data)
-        )
-
-        with assume_test_silo_mode(SiloMode.CONTROL):
-            team_settings = NotificationSettingProvider.objects.filter(team_id=self.team.id)
-        assert len(team_settings) == 0
-
-    @responses.activate
-    def test_unlink_team_valid_through_team_admin(self):
-        """Test that a team can be unlinked from a Slack channel as a valid team admin"""
-        self._create_user_valid_through_team_admin()
-
-        self.test_unlink_team()
-
-    @responses.activate
-    def test_unlink_multiple_teams(self):
-        """
-        Test that if you have linked multiple teams to a single channel, when
-        you type `/sentry unlink team`, we unlink all teams from that channel.
-        This should only apply to the one organization who did this before we
-        blocked users from doing so.
-        """
-        team2 = self.create_team(organization=self.organization, name="Team Hellboy")
-        self.link_team(team2)
-
-        external_actors = self.get_linked_teams([self.team.id, team2.id])
-        assert len(external_actors) == 2
-
-        response = self.get_success_response()
-        self.assertTemplateUsed(response, "sentry/integrations/slack/unlink-team.html")
-
-        response = self.get_success_response(data={})
-        self.assertTemplateUsed(response, "sentry/integrations/slack/unlinked-team.html")
-
-        external_actors = self.get_linked_teams([self.team.id, team2.id])
-        assert len(external_actors) == 0
-
-        assert len(responses.calls) >= 1
-        data = orjson.loads(responses.calls[0].request.body)
-        assert (
-            f"This channel will no longer receive issue alert notifications for the {self.team.slug} team."
-            in get_response_text(data)
-        )
-
-        with assume_test_silo_mode(SiloMode.CONTROL):
-            team_settings = NotificationSettingProvider.objects.filter(team_id=self.team.id)
-        assert len(team_settings) == 0
-
-    @responses.activate
-    def test_unlink_team_multiple_organizations(self):
-        # Create another organization and team for this user that is linked through `self.integration`.
-        organization2 = self.create_organization(owner=self.user)
-        team2 = self.create_team(organization=organization2, members=[self.user])
-        with assume_test_silo_mode(SiloMode.CONTROL):
-            self.create_organization_integration(
-                organization_id=organization2.id, integration=self.integration
-            )
-        self.link_team(team2)
-
-        # Team order should not matter.
-        for team in (self.team, team2):
-            external_actors = self.get_linked_teams(
-                organization=team.organization, team_ids=[team.id]
-            )
-            assert len(external_actors) == 1
-
-            # Override the URL.
-            self.url = build_team_unlinking_url(
-                integration=self.integration,
-                organization_id=team.organization.id,
-                slack_id=self.external_id,
-                channel_id=self.channel_id,
-                channel_name=self.channel_name,
-                response_url=self.response_url,
-            )
-            response = self.get_success_response(data={})
-            self.assertTemplateUsed(response, "sentry/integrations/slack/unlinked-team.html")
-
-            external_actors = self.get_linked_teams(
-                organization=team.organization, team_ids=[team.id]
-            )
-            assert len(external_actors) == 0
-
-    @responses.activate
-    def test_unlink_team_invalid_method(self):
-        """Test for an invalid method response"""
-        response = self.client.put(self.url, content_type="application/x-www-form-urlencoded")
-        assert response.status_code == status.HTTP_405_METHOD_NOT_ALLOWED
 
 
 class SlackIntegrationUnlinkTeamTestWithSdk(SlackIntegrationLinkTeamTestBase):
@@ -541,24 +257,20 @@ class SlackIntegrationUnlinkTeamTestWithSdk(SlackIntegrationLinkTeamTestBase):
 
     @pytest.fixture(autouse=True)
     def mock_chat_postMessage(self):
-        with (
-            patch(
-                "slack_sdk.web.WebClient.chat_postMessage",
-                return_value=SlackResponse(
-                    client=None,
-                    http_verb="POST",
-                    api_url="https://slack.com/api/chat.postMessage",
-                    req_args={},
-                    data={"ok": True},
-                    headers={},
-                    status_code=200,
-                ),
-            ) as self.mock_post,
-            Feature("organizations:slack-sdk-notify-mixin"),
-        ):
+        with patch(
+            "slack_sdk.web.WebClient.chat_postMessage",
+            return_value=SlackResponse(
+                client=None,
+                http_verb="POST",
+                api_url="https://slack.com/api/chat.postMessage",
+                req_args={},
+                data={"ok": True},
+                headers={},
+                status_code=200,
+            ),
+        ) as self.mock_post:
             yield
 
-    @responses.activate
     def test_unlink_team(self):
         """Test that a team can be unlinked from a Slack channel"""
         response = self.get_success_response()
@@ -581,14 +293,12 @@ class SlackIntegrationUnlinkTeamTestWithSdk(SlackIntegrationLinkTeamTestBase):
             team_settings = NotificationSettingProvider.objects.filter(team_id=self.team.id)
         assert len(team_settings) == 0
 
-    @responses.activate
     def test_unlink_team_valid_through_team_admin(self):
         """Test that a team can be unlinked from a Slack channel as a valid team admin"""
         self._create_user_valid_through_team_admin()
 
         self.test_unlink_team()
 
-    @responses.activate
     def test_unlink_multiple_teams(self):
         """
         Test that if you have linked multiple teams to a single channel, when
@@ -622,7 +332,6 @@ class SlackIntegrationUnlinkTeamTestWithSdk(SlackIntegrationLinkTeamTestBase):
             team_settings = NotificationSettingProvider.objects.filter(team_id=self.team.id)
         assert len(team_settings) == 0
 
-    @responses.activate
     def test_unlink_team_multiple_organizations(self):
         # Create another organization and team for this user that is linked through `self.integration`.
         organization2 = self.create_organization(owner=self.user)
@@ -657,7 +366,6 @@ class SlackIntegrationUnlinkTeamTestWithSdk(SlackIntegrationLinkTeamTestBase):
             )
             assert len(external_actors) == 0
 
-    @responses.activate
     def test_unlink_team_invalid_method(self):
         """Test for an invalid method response"""
         response = self.client.put(self.url, content_type="application/x-www-form-urlencoded")


### PR DESCRIPTION
Removes the usage of the in-house SlackClient from SlackNotifyMixin. This feature is GA-ed.