### PR TITLE
fix(insights): Fix bad padding on Asset Summary page

### DIFF
--- a/static/app/views/insights/browser/resources/components/charts/resourceSummaryCharts.tsx
+++ b/static/app/views/insights/browser/resources/components/charts/resourceSummaryCharts.tsx
@@ -1,3 +1,5 @@
+import {Fragment} from 'react';
+
 import {t, tct} from 'sentry/locale';
 import {formatBytesBase2} from 'sentry/utils/bytes/formatBytesBase2';
 import {formatRate} from 'sentry/utils/formatters';
@@ -12,16 +14,13 @@ import {useResourceModuleFilters} from 'sentry/views/insights/browser/resources/
 import {AVG_COLOR, THROUGHPUT_COLOR} from 'sentry/views/insights/colors';
 import Chart, {ChartType} from 'sentry/views/insights/common/components/chart';
 import ChartPanel from 'sentry/views/insights/common/components/chartPanel';
+import * as ModuleLayout from 'sentry/views/insights/common/components/moduleLayout';
 import {useSpanMetricsSeries} from 'sentry/views/insights/common/queries/useDiscoverSeries';
 import {
   DataTitles,
   getDurationChartTitle,
   getThroughputChartTitle,
 } from 'sentry/views/insights/common/views/spans/types';
-import {
-  Block,
-  BlockContainer,
-} from 'sentry/views/insights/common/views/spanSummaryPage/block';
 import {SpanMetricsField} from 'sentry/views/insights/types';
 
 const {
@@ -69,8 +68,8 @@ function ResourceSummaryCharts(props: {groupId: string}) {
   }
 
   return (
-    <BlockContainer>
-      <Block>
+    <Fragment>
+      <ModuleLayout.Third>
         <ChartPanel title={getThroughputChartTitle('http', RESOURCE_THROUGHPUT_UNIT)}>
           <Chart
             height={160}
@@ -88,8 +87,9 @@ function ResourceSummaryCharts(props: {groupId: string}) {
             }}
           />
         </ChartPanel>
-      </Block>
-      <Block>
+      </ModuleLayout.Third>
+
+      <ModuleLayout.Third>
         <ChartPanel title={getDurationChartTitle('http')}>
           <Chart
             height={160}
@@ -100,8 +100,9 @@ function ResourceSummaryCharts(props: {groupId: string}) {
             definedAxisTicks={4}
           />
         </ChartPanel>
-      </Block>
-      <Block>
+      </ModuleLayout.Third>
+
+      <ModuleLayout.Third>
         <ChartPanel title={tct('Average [dataType] Size', {dataType: DATA_TYPE})}>
           <Chart
             height={160}
@@ -125,8 +126,8 @@ function ResourceSummaryCharts(props: {groupId: string}) {
             }}
           />
         </ChartPanel>
-      </Block>
-    </BlockContainer>
+      </ModuleLayout.Third>
+    </Fragment>
   );
 }
 

--- a/static/app/views/insights/browser/resources/views/resourceSummaryPage.tsx
+++ b/static/app/views/insights/browser/resources/views/resourceSummaryPage.tsx
@@ -24,6 +24,7 @@ import {Referrer} from 'sentry/views/insights/browser/resources/referrer';
 import {DATA_TYPE} from 'sentry/views/insights/browser/resources/settings';
 import {ResourceSpanOps} from 'sentry/views/insights/browser/resources/types';
 import {useResourceModuleFilters} from 'sentry/views/insights/browser/resources/utils/useResourceFilters';
+import * as ModuleLayout from 'sentry/views/insights/common/components/moduleLayout';
 import {ModulePageProviders} from 'sentry/views/insights/common/components/modulePageProviders';
 import {useSpanMetrics} from 'sentry/views/insights/common/queries/useDiscover';
 import {useModuleBreadcrumbs} from 'sentry/views/insights/common/utils/useModuleBreadcrumbs';
@@ -109,41 +110,55 @@ function ResourceSummary() {
 
       <Layout.Body>
         <Layout.Main fullWidth>
-          <HeaderContainer>
-            <FilterOptionsContainer columnCount={2}>
-              <PageFilterBar condensed>
-                <ProjectPageFilter />
-                <EnvironmentPageFilter />
-                <DatePageFilter />
-              </PageFilterBar>
-              <RenderBlockingSelector
-                value={filters[RESOURCE_RENDER_BLOCKING_STATUS] || ''}
+          <ModuleLayout.Layout>
+            <ModuleLayout.Full>
+              <HeaderContainer>
+                <FilterOptionsContainer columnCount={2}>
+                  <PageFilterBar condensed>
+                    <ProjectPageFilter />
+                    <EnvironmentPageFilter />
+                    <DatePageFilter />
+                  </PageFilterBar>
+                  <RenderBlockingSelector
+                    value={filters[RESOURCE_RENDER_BLOCKING_STATUS] || ''}
+                  />
+                </FilterOptionsContainer>
+                <ResourceInfo
+                  avgContentLength={spanMetrics[`avg(${HTTP_RESPONSE_CONTENT_LENGTH})`]}
+                  avgDecodedContentLength={
+                    spanMetrics[`avg(${HTTP_DECODED_RESPONSE_CONTENT_LENGTH})`]
+                  }
+                  avgTransferSize={spanMetrics[`avg(${HTTP_RESPONSE_TRANSFER_SIZE})`]}
+                  avgDuration={spanMetrics[`avg(${SPAN_SELF_TIME})`]}
+                  throughput={spanMetrics['spm()']}
+                  timeSpentTotal={spanMetrics[`sum(${SPAN_SELF_TIME})`]}
+                  timeSpentPercentage={spanMetrics[`time_spent_percentage()`]}
+                />
+              </HeaderContainer>
+            </ModuleLayout.Full>
+
+            {isImage && (
+              <ModuleLayout.Full>
+                <SampleImages groupId={groupId} projectId={data?.[0]?.['project.id']} />
+              </ModuleLayout.Full>
+            )}
+
+            <ResourceSummaryCharts groupId={groupId} />
+
+            <ModuleLayout.Full>
+              <ResourceSummaryTable />
+            </ModuleLayout.Full>
+
+            <ModuleLayout.Full>
+              <SampleList
+                transactionRoute={webVitalsModuleURL}
+                groupId={groupId}
+                moduleName={ModuleName.RESOURCE}
+                transactionName={transaction as string}
+                referrer={TraceViewSources.ASSETS_MODULE}
               />
-            </FilterOptionsContainer>
-            <ResourceInfo
-              avgContentLength={spanMetrics[`avg(${HTTP_RESPONSE_CONTENT_LENGTH})`]}
-              avgDecodedContentLength={
-                spanMetrics[`avg(${HTTP_DECODED_RESPONSE_CONTENT_LENGTH})`]
-              }
-              avgTransferSize={spanMetrics[`avg(${HTTP_RESPONSE_TRANSFER_SIZE})`]}
-              avgDuration={spanMetrics[`avg(${SPAN_SELF_TIME})`]}
-              throughput={spanMetrics['spm()']}
-              timeSpentTotal={spanMetrics[`sum(${SPAN_SELF_TIME})`]}
-              timeSpentPercentage={spanMetrics[`time_spent_percentage()`]}
-            />
-          </HeaderContainer>
-          {isImage && (
-            <SampleImages groupId={groupId} projectId={data?.[0]?.['project.id']} />
-          )}
-          <ResourceSummaryCharts groupId={groupId} />
-          <ResourceSummaryTable />
-          <SampleList
-            transactionRoute={webVitalsModuleURL}
-            groupId={groupId}
-            moduleName={ModuleName.RESOURCE}
-            transactionName={transaction as string}
-            referrer={TraceViewSources.ASSETS_MODULE}
-          />
+            </ModuleLayout.Full>
+          </ModuleLayout.Layout>
         </Layout.Main>
       </Layout.Body>
     </React.Fragment>


### PR DESCRIPTION
Some elements were mashing into each other, or had incorrect spacing. Use `ModuleLayout` to for consistent spacing between elements.

**Before:**
![Screenshot 2024-07-11 at 3 19 47 PM](https://github.com/getsentry/sentry/assets/989898/5c997424-de3b-40da-97b0-fab15c0d9821)

**After:**
![Screenshot 2024-07-11 at 3 19 36 PM](https://github.com/getsentry/sentry/assets/989898/ca9f30a3-fd3c-4c47-afd6-c0d5bfd54ca2)
