### PR TITLE
fix(insights): Prevent awkward gap at the top of Queries module

### DIFF
--- a/static/app/views/insights/database/views/databaseLandingPage.tsx
+++ b/static/app/views/insights/database/views/databaseLandingPage.tsx
@@ -178,12 +178,10 @@ export function DatabaseLandingPage() {
         <Layout.Main fullWidth>
           <ModuleLayout.Layout>
             {!onboardingProject && !isCriticalDataLoading && (
-              <ModuleLayout.Full>
-                <NoDataMessage
-                  Wrapper={AlertBanner}
-                  isDataAvailable={isAnyCriticalDataAvailable}
-                />
-              </ModuleLayout.Full>
+              <NoDataMessage
+                Wrapper={AlertBanner}
+                isDataAvailable={isAnyCriticalDataAvailable}
+              />
             )}
 
             <ModuleLayout.Full>
@@ -262,7 +260,11 @@ const DEFAULT_SORT = {
 };
 
 function AlertBanner(props) {
-  return <Alert {...props} type="info" showIcon />;
+  return (
+    <ModuleLayout.Full>
+      <Alert {...props} type="info" showIcon />
+    </ModuleLayout.Full>
+  );
 }
 
 const FilterOptionsContainer = styled('div')`


### PR DESCRIPTION
The gap is caused by `NoDataMessage` being wrapped in `ModuleLayout.Full`. `ModuleLayout.Full` is a `div` which takes up a grid space, and creates a gap around itself, even if there's no `NoDataMessage`. With this change, the `ModuleLayout.Full` is pushed into `NoDataMessage`, so it's _only_ rendered if there's no data.

**Before:**
![Screenshot 2024-07-11 at 3 28 21 PM](https://github.com/getsentry/sentry/assets/989898/4893ebf5-c03e-4353-9223-4fde14297c7a)

**After:**
![Screenshot 2024-07-11 at 3 30 10 PM](https://github.com/getsentry/sentry/assets/989898/c5fa3e7e-fdee-4919-9dd1-05491b5c04d4)
