### PR TITLE
feat(query-builder): Add analytics for autocomplete actions

### DIFF
--- a/static/app/components/searchQueryBuilder/context.tsx
+++ b/static/app/components/searchQueryBuilder/context.tsx
@@ -6,7 +6,7 @@ import type {
 } from 'sentry/components/searchQueryBuilder/types';
 import type {QueryBuilderActions} from 'sentry/components/searchQueryBuilder/useQueryBuilderState';
 import type {ParseResult} from 'sentry/components/searchSyntax/parser';
-import type {Tag, TagCollection} from 'sentry/types/group';
+import type {SavedSearchType, Tag, TagCollection} from 'sentry/types/group';
 
 interface ContextData {
   dispatch: Dispatch<QueryBuilderActions>;
@@ -20,6 +20,7 @@ interface ContextData {
   searchSource: string;
   size: 'small' | 'normal';
   wrapperRef: React.RefObject<HTMLDivElement>;
+  savedSearchType?: SavedSearchType;
 }
 
 export function useSearchQueryBuilder() {

--- a/static/app/components/searchQueryBuilder/index.tsx
+++ b/static/app/components/searchQueryBuilder/index.tsx
@@ -126,6 +126,7 @@ export function SearchQueryBuilder({
       onSearch,
       wrapperRef,
       handleSearch,
+      savedSearchType,
       searchSource,
       size,
     };
@@ -138,6 +139,7 @@ export function SearchQueryBuilder({
     dispatch,
     onSearch,
     handleSearch,
+    savedSearchType,
     searchSource,
     size,
   ]);

--- a/static/app/utils/analytics/searchAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/searchAnalyticsEvents.tsx
@@ -41,11 +41,16 @@ export type SearchEventParameters = {
   'search.invalid_field': Omit<SearchEventBase, 'query'> & {attempted_field_name: string};
   'search.key_autocompleted': Omit<SearchEventBase, 'query'> & {
     item_name: string | undefined;
-    search_operator: string;
+    filtered?: boolean;
     item_kind?: string;
     item_type?: string;
+    item_value_type?: string;
+    search_operator?: string;
   };
-  'search.operator_autocompleted': SearchEventBase & {search_operator: string};
+  'search.operator_autocompleted': SearchEventBase & {
+    search_operator: string;
+    filter_key?: string;
+  };
   'search.pin': {
     action: 'pin' | 'unpin';
     search_type: string;
@@ -70,6 +75,19 @@ export type SearchEventParameters = {
   'search.shortcut_used': SearchEventBase & {
     shortcut_method: 'hotkey' | 'click';
     shortcut_type: ShortcutType;
+  };
+  'search.value_autocompleted': Omit<SearchEventBase, 'query'> & {
+    filter_key: string;
+    filter_operator: string;
+    filter_value: string;
+    filter_value_type: string;
+  };
+  'search.value_manual_submitted': Omit<SearchEventBase, 'query'> & {
+    filter_key: string;
+    filter_operator: string;
+    filter_value: string;
+    filter_value_type: string;
+    invalid: boolean;
   };
   'settings_search.open': OpenEvent;
   'settings_search.query': QueryEvent;
@@ -109,6 +127,8 @@ export const searchEventMap: Record<SearchEventKey, string | null> = {
   'search.pin': 'Search: Pin',
   'search.saved_search_create': 'Search: Saved Search Created',
   'search.saved_search_open_create_modal': 'Search: Saved Search Modal Opened',
+  'search.value_autocompleted': 'Search: Filter Value Autocompleted',
+  'search.value_manual_submitted': 'Search: Filter Value Submitted Manually',
   'search.saved_search_sidebar_toggle_clicked':
     'Search: Saved Search Sidebar Toggle Clicked',
   'omnisearch.open': 'Omnisearch: Open',


### PR DESCRIPTION
Adds the rest of the analytics events to match what we log in SmartSearchBar (plus a couple extra):

- When a filter key is autocompleted
- When an operator is changed in the dropdown
- When a filter value is autocompleted
- When a filter value is manually entered