### PR TITLE
ref(issues): Show priority indicator even if stats are disabled

### DIFF
--- a/static/app/views/issueDetails/header.spec.tsx
+++ b/static/app/views/issueDetails/header.spec.tsx
@@ -218,16 +218,35 @@ describe('GroupHeader', () => {
         url: '/organizations/org-slug/prompts-activity/',
         body: {data: {dismissed_ts: null}},
       });
+      MockApiClient.addMockResponse({
+        url: '/organizations/org-slug/replay-count/',
+        body: {},
+      });
+    });
+
+    it('shows priority even if stats is off', async () => {
+      render(
+        <GroupHeader
+          baseUrl=""
+          organization={OrganizationFixture()}
+          group={GroupFixture({
+            priority: PriorityLevel.HIGH,
+            // Setting an issue category where stats are turned off
+            issueCategory: IssueCategory.UPTIME,
+          })}
+          project={ProjectFixture()}
+          groupReprocessingStatus={ReprocessingStatus.NO_STATUS}
+        />
+      );
+
+      expect(await screen.findByText('Priority')).toBeInTheDocument();
+      expect(await screen.findByText('High')).toBeInTheDocument();
     });
 
     it('can change priority', async () => {
       const mockModifyIssue = MockApiClient.addMockResponse({
         url: `/organizations/org-slug/issues/`,
         method: 'PUT',
-        body: {},
-      });
-      MockApiClient.addMockResponse({
-        url: '/organizations/org-slug/replay-count/',
         body: {},
       });
 

--- a/static/app/views/issueDetails/header.tsx
+++ b/static/app/views/issueDetails/header.tsx
@@ -1,4 +1,4 @@
-import {useMemo} from 'react';
+import {Fragment, useMemo} from 'react';
 import styled from '@emotion/styled';
 import type {LocationDescriptor} from 'history';
 import omit from 'lodash/omit';
@@ -284,35 +284,37 @@ function GroupHeader({
               showUnhandled={group.isUnhandled}
             />
           </TitleWrapper>
-          {issueTypeConfig.stats.enabled && (
-            <StatsWrapper>
-              <GuideAnchor target="issue_header_stats">
+          <StatsWrapper>
+            {issueTypeConfig.stats.enabled && (
+              <Fragment>
+                <GuideAnchor target="issue_header_stats">
+                  <div className="count">
+                    <h6 className="nav-header">{t('Events')}</h6>
+                    <Link disabled={disableActions} to={eventRoute}>
+                      <Count className="count" value={group.count} />
+                    </Link>
+                  </div>
+                </GuideAnchor>
                 <div className="count">
-                  <h6 className="nav-header">{t('Events')}</h6>
-                  <Link disabled={disableActions} to={eventRoute}>
-                    <Count className="count" value={group.count} />
-                  </Link>
+                  <h6 className="nav-header">{t('Users')}</h6>
+                  {userCount !== 0 ? (
+                    <Link
+                      disabled={disableActions}
+                      to={`${baseUrl}tags/user/${location.search}`}
+                    >
+                      <Count className="count" value={userCount} />
+                    </Link>
+                  ) : (
+                    <span>0</span>
+                  )}
                 </div>
-              </GuideAnchor>
-              <div className="count">
-                <h6 className="nav-header">{t('Users')}</h6>
-                {userCount !== 0 ? (
-                  <Link
-                    disabled={disableActions}
-                    to={`${baseUrl}tags/user/${location.search}`}
-                  >
-                    <Count className="count" value={userCount} />
-                  </Link>
-                ) : (
-                  <span>0</span>
-                )}
-              </div>
-              <PriorityContainer>
-                <h6 className="nav-header">{t('Priority')}</h6>
-                <GroupPriority group={group} />
-              </PriorityContainer>
-            </StatsWrapper>
-          )}
+              </Fragment>
+            )}
+            <PriorityContainer>
+              <h6 className="nav-header">{t('Priority')}</h6>
+              <GroupPriority group={group} />
+            </PriorityContainer>
+          </StatsWrapper>
         </HeaderRow>
         {/* Environment picker for mobile */}
         <HeaderRow className="hidden-sm hidden-md hidden-lg">


### PR DESCRIPTION
After speaking with Vu, Rachel, Matt it seems that priority should exist on all issues regardless if they have stats enabled. Making this change so that future uptime issues will have a priority associated

Before:
<img width="1265" alt="image" src="https://github.com/user-attachments/assets/49707b41-98b9-49ab-b0d1-99204df33fa4">

After:
<img width="1243" alt="image" src="https://github.com/user-attachments/assets/204aafd3-3469-46a6-a14b-be00461031ce">
