### PR TITLE
fix(useFeedbackForm): Cleanup after form is closed or submitted

### DIFF
--- a/static/app/utils/useFeedbackForm.spec.tsx
+++ b/static/app/utils/useFeedbackForm.spec.tsx
@@ -7,6 +7,7 @@ import {GlobalFeedbackForm, useFeedbackForm} from 'sentry/utils/useFeedbackForm'
 const mockForm = {
   appendToDom: jest.fn(),
   open: jest.fn(),
+  close: jest.fn(),
   removeFromDom: jest.fn(),
 };
 
@@ -28,6 +29,7 @@ describe('useFeedbackForm', function () {
     jest
       .spyOn(useFeedback, 'useFeedback')
       .mockReturnValue({feedback: mockFeedback, options: defaultOptions});
+    jest.clearAllMocks();
   });
 
   it('can open the form using useFeedbackForm', async function () {


### PR DESCRIPTION
Without these changes, the form after being closed still prevented the page from scrolling. I'm not sure if this is intended or is a bug with the SDK, but I was able to fix this by removing from the DOM when the form was closed or submitted.