### PR TITLE
ref(insights): Extract `Ribbon` component

### DIFF
--- a/static/app/views/insights/browser/resources/components/resourceInfo.tsx
+++ b/static/app/views/insights/browser/resources/components/resourceInfo.tsx
@@ -1,14 +1,13 @@
 import {Fragment} from 'react';
-import styled from '@emotion/styled';
 
 import Alert from 'sentry/components/alert';
 import {t, tct} from 'sentry/locale';
-import {space} from 'sentry/styles/space';
 import {formatBytesBase2} from 'sentry/utils/bytes/formatBytesBase2';
 import {DurationUnit, SizeUnit} from 'sentry/utils/discover/fields';
 import getDynamicText from 'sentry/utils/getDynamicText';
 import {RESOURCE_THROUGHPUT_UNIT} from 'sentry/views/insights/browser/resources/settings';
 import {MetricReadout} from 'sentry/views/insights/common/components/metricReadout';
+import {Ribbon} from 'sentry/views/insights/common/components/ribbon';
 import {getTimeSpentExplanation} from 'sentry/views/insights/common/components/tableCells/timeSpentCell';
 import {
   DataTitles,
@@ -68,7 +67,7 @@ function ResourceInfo(props: Props) {
 
   return (
     <Fragment>
-      <MetricsRibbon>
+      <Ribbon>
         <MetricReadout
           align="left"
           title={getThroughputTitle('resource')}
@@ -114,7 +113,7 @@ function ResourceInfo(props: Props) {
           unit={DurationUnit.MILLISECOND}
           tooltip={getTimeSpentExplanation(timeSpentPercentage, 'resource')}
         />
-      </MetricsRibbon>
+      </Ribbon>
 
       {hasNoData && (
         <Alert style={{width: '100%'}} type="warning" showIcon>
@@ -126,11 +125,5 @@ function ResourceInfo(props: Props) {
     </Fragment>
   );
 }
-
-const MetricsRibbon = styled('div')`
-  display: flex;
-  flex-wrap: wrap;
-  gap: ${space(4)};
-`;
 
 export default ResourceInfo;

--- a/static/app/views/insights/cache/components/samplePanel.tsx
+++ b/static/app/views/insights/cache/components/samplePanel.tsx
@@ -32,6 +32,7 @@ import {BASE_FILTERS} from 'sentry/views/insights/cache/settings';
 import DetailPanel from 'sentry/views/insights/common/components/detailPanel';
 import {MetricReadout} from 'sentry/views/insights/common/components/metricReadout';
 import * as ModuleLayout from 'sentry/views/insights/common/components/moduleLayout';
+import {Ribbon} from 'sentry/views/insights/common/components/ribbon';
 import {getTimeSpentExplanation} from 'sentry/views/insights/common/components/tableCells/timeSpentCell';
 import {
   useMetrics,
@@ -299,7 +300,7 @@ export function CacheSamplePanel() {
           </ModuleLayout.Full>
 
           <ModuleLayout.Full>
-            <MetricsRibbon>
+            <Ribbon>
               <MetricReadout
                 align="left"
                 title={DataTitles[`avg(${SpanMetricsField.CACHE_ITEM_SIZE})`]}
@@ -351,7 +352,7 @@ export function CacheSamplePanel() {
                 )}
                 isLoading={areCacheTransactionMetricsFetching}
               />
-            </MetricsRibbon>
+            </Ribbon>
           </ModuleLayout.Full>
           <ModuleLayout.Full>
             <CompactSelect
@@ -497,10 +498,4 @@ const Title = styled('h4')`
   text-overflow: ellipsis;
   white-space: nowrap;
   margin: 0;
-`;
-
-const MetricsRibbon = styled('div')`
-  display: flex;
-  flex-wrap: wrap;
-  gap: ${space(4)};
 `;

--- a/static/app/views/insights/common/components/ribbon.tsx
+++ b/static/app/views/insights/common/components/ribbon.tsx
@@ -1,0 +1,9 @@
+import styled from '@emotion/styled';
+
+import {space} from 'sentry/styles/space';
+
+export const Ribbon = styled('div')`
+  display: flex;
+  flex-wrap: wrap;
+  gap: ${space(4)};
+`;

--- a/static/app/views/insights/common/views/spanSummaryPage/sampleList/sampleInfo/index.tsx
+++ b/static/app/views/insights/common/views/spanSummaryPage/sampleList/sampleInfo/index.tsx
@@ -1,10 +1,8 @@
-import styled from '@emotion/styled';
-
-import {space} from 'sentry/styles/space';
 import {DurationUnit, RateUnit} from 'sentry/utils/discover/fields';
 import {usePageAlert} from 'sentry/utils/performance/contexts/pageAlert';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {MetricReadout} from 'sentry/views/insights/common/components/metricReadout';
+import {Ribbon} from 'sentry/views/insights/common/components/ribbon';
 import {getTimeSpentExplanation} from 'sentry/views/insights/common/components/tableCells/timeSpentCell';
 import {useSpanMetrics} from 'sentry/views/insights/common/queries/useDiscover';
 import {
@@ -56,7 +54,7 @@ function SampleInfo(props: Props) {
   }
 
   return (
-    <MetricsRibbon>
+    <Ribbon>
       <MetricReadout
         title={getThroughputTitle(spanMetrics?.[SpanMetricsField.SPAN_OP])}
         align="left"
@@ -84,14 +82,8 @@ function SampleInfo(props: Props) {
         )}
         isLoading={isLoading}
       />
-    </MetricsRibbon>
+    </Ribbon>
   );
 }
-
-const MetricsRibbon = styled('div')`
-  display: flex;
-  flex-wrap: wrap;
-  gap: ${space(4)};
-`;
 
 export default SampleInfo;

--- a/static/app/views/insights/database/views/databaseSpanSummaryPage.tsx
+++ b/static/app/views/insights/database/views/databaseSpanSummaryPage.tsx
@@ -19,6 +19,7 @@ import {useSynchronizeCharts} from 'sentry/views/insights/common/components/char
 import {MetricReadout} from 'sentry/views/insights/common/components/metricReadout';
 import * as ModuleLayout from 'sentry/views/insights/common/components/moduleLayout';
 import {ModulePageProviders} from 'sentry/views/insights/common/components/modulePageProviders';
+import {Ribbon} from 'sentry/views/insights/common/components/ribbon';
 import {DatabaseSpanDescription} from 'sentry/views/insights/common/components/spanDescription';
 import {getTimeSpentExplanation} from 'sentry/views/insights/common/components/tableCells/timeSpentCell';
 import {useSpanMetrics} from 'sentry/views/insights/common/queries/useDiscover';
@@ -184,7 +185,7 @@ export function DatabaseSpanSummaryPage({params}: Props) {
               <DatePageFilter />
             </PageFilterBar>
 
-            <MetricsRibbon>
+            <Ribbon>
               <MetricReadout
                 title={getThroughputTitle('db')}
                 value={spanMetrics?.[`${SpanFunction.SPM}()`]}
@@ -209,7 +210,7 @@ export function DatabaseSpanSummaryPage({params}: Props) {
                 )}
                 isLoading={areSpanMetricsLoading}
               />
-            </MetricsRibbon>
+            </Ribbon>
           </HeaderContainer>
 
           <ModuleLayout.Layout>
@@ -296,12 +297,6 @@ const HeaderContainer = styled('div')`
 
 const DescriptionContainer = styled(ModuleLayout.Full)`
   line-height: 1.2;
-`;
-
-const MetricsRibbon = styled('div')`
-  display: flex;
-  flex-wrap: wrap;
-  gap: ${space(4)};
 `;
 
 function PageWithProviders(props) {

--- a/static/app/views/insights/http/components/httpSamplesPanel.tsx
+++ b/static/app/views/insights/http/components/httpSamplesPanel.tsx
@@ -32,6 +32,7 @@ import {computeAxisMax} from 'sentry/views/insights/common/components/chart';
 import DetailPanel from 'sentry/views/insights/common/components/detailPanel';
 import {MetricReadout} from 'sentry/views/insights/common/components/metricReadout';
 import * as ModuleLayout from 'sentry/views/insights/common/components/moduleLayout';
+import {Ribbon} from 'sentry/views/insights/common/components/ribbon';
 import {getTimeSpentExplanation} from 'sentry/views/insights/common/components/tableCells/timeSpentCell';
 import {
   useSpanMetrics,
@@ -354,7 +355,7 @@ export function HTTPSamplesPanel() {
           </ModuleLayout.Full>
 
           <ModuleLayout.Full>
-            <MetricsRibbon>
+            <Ribbon>
               <MetricReadout
                 align="left"
                 title={getThroughputTitle('http')}
@@ -410,7 +411,7 @@ export function HTTPSamplesPanel() {
                 )}
                 isLoading={areDomainTransactionMetricsFetching}
               />
-            </MetricsRibbon>
+            </Ribbon>
           </ModuleLayout.Full>
 
           <ModuleLayout.Full>
@@ -631,12 +632,6 @@ const Title = styled('h4')`
   text-overflow: ellipsis;
   white-space: nowrap;
   margin: 0;
-`;
-
-const MetricsRibbon = styled('div')`
-  display: flex;
-  flex-wrap: wrap;
-  gap: ${space(4)};
 `;
 
 const PanelControls = styled('div')`

--- a/static/app/views/insights/http/views/httpDomainSummaryPage.tsx
+++ b/static/app/views/insights/http/views/httpDomainSummaryPage.tsx
@@ -12,7 +12,6 @@ import {DatePageFilter} from 'sentry/components/organizations/datePageFilter';
 import {EnvironmentPageFilter} from 'sentry/components/organizations/environmentPageFilter';
 import PageFilterBar from 'sentry/components/organizations/pageFilterBar';
 import {t, tct} from 'sentry/locale';
-import {space} from 'sentry/styles/space';
 import {DurationUnit, RateUnit} from 'sentry/utils/discover/fields';
 import {decodeScalar, decodeSorts} from 'sentry/utils/queryString';
 import {
@@ -27,6 +26,7 @@ import {useSynchronizeCharts} from 'sentry/views/insights/common/components/char
 import {MetricReadout} from 'sentry/views/insights/common/components/metricReadout';
 import * as ModuleLayout from 'sentry/views/insights/common/components/moduleLayout';
 import {ModulePageProviders} from 'sentry/views/insights/common/components/modulePageProviders';
+import {Ribbon} from 'sentry/views/insights/common/components/ribbon';
 import {getTimeSpentExplanation} from 'sentry/views/insights/common/components/tableCells/timeSpentCell';
 import {useSpanMetrics} from 'sentry/views/insights/common/queries/useDiscover';
 import {useSpanMetricsSeries} from 'sentry/views/insights/common/queries/useDiscoverSeries';
@@ -213,7 +213,7 @@ export function HTTPDomainSummaryPage() {
                   <DatePageFilter />
                 </PageFilterBar>
 
-                <MetricsRibbon>
+                <Ribbon>
                   <MetricReadout
                     title={getThroughputTitle('http')}
                     value={domainMetrics?.[0]?.[`${SpanFunction.SPM}()`]}
@@ -261,7 +261,7 @@ export function HTTPDomainSummaryPage() {
                     )}
                     isLoading={areDomainMetricsLoading}
                   />
-                </MetricsRibbon>
+                </Ribbon>
               </HeaderContainer>
             </ModuleLayout.Full>
 
@@ -333,12 +333,6 @@ const HeaderContainer = styled('div')`
   display: flex;
   justify-content: space-between;
   flex-wrap: wrap;
-`;
-
-const MetricsRibbon = styled('div')`
-  display: flex;
-  flex-wrap: wrap;
-  gap: ${space(4)};
 `;
 
 function PageWithProviders() {

--- a/static/app/views/insights/llmMonitoring/views/llmMonitoringDetailsPage.tsx
+++ b/static/app/views/insights/llmMonitoring/views/llmMonitoringDetailsPage.tsx
@@ -18,6 +18,7 @@ import useOrganization from 'sentry/utils/useOrganization';
 import {MetricReadout} from 'sentry/views/insights/common/components/metricReadout';
 import * as ModuleLayout from 'sentry/views/insights/common/components/moduleLayout';
 import {ModulePageProviders} from 'sentry/views/insights/common/components/modulePageProviders';
+import {Ribbon} from 'sentry/views/insights/common/components/ribbon';
 import {useSpanMetrics} from 'sentry/views/insights/common/queries/useDiscover';
 import {useModuleBreadcrumbs} from 'sentry/views/insights/common/utils/useModuleBreadcrumbs';
 import {
@@ -115,7 +116,7 @@ export function LLMMonitoringPage({params}: Props) {
                     <EnvironmentPageFilter />
                     <DatePageFilter />
                   </PageFilterBar>
-                  <MetricsRibbon>
+                  <Ribbon>
                     <MetricReadout
                       title={t('Total Tokens Used')}
                       value={tokenUsedMetric['sum(ai.total_tokens.used)']}
@@ -143,7 +144,7 @@ export function LLMMonitoringPage({params}: Props) {
                       unit={RateUnit.PER_MINUTE}
                       isLoading={areSpanMetricsLoading}
                     />
-                  </MetricsRibbon>
+                  </Ribbon>
                 </SpaceBetweenWrap>
               </ModuleLayout.Full>
               <ModuleLayout.Third>
@@ -185,10 +186,4 @@ const SpaceBetweenWrap = styled('div')`
   justify-content: space-between;
   flex-wrap: wrap;
   gap: ${space(2)};
-`;
-
-const MetricsRibbon = styled('div')`
-  display: flex;
-  flex-wrap: wrap;
-  gap: ${space(4)};
 `;

--- a/static/app/views/insights/mobile/appStarts/views/screenSummaryPage.tsx
+++ b/static/app/views/insights/mobile/appStarts/views/screenSummaryPage.tsx
@@ -29,7 +29,7 @@ import {
   StartTypeSelector,
 } from 'sentry/views/insights/mobile/appStarts/components/startTypeSelector';
 import {SpanSamplesPanel} from 'sentry/views/insights/mobile/common/components/spanSamplesPanel';
-import {MetricsRibbon} from 'sentry/views/insights/mobile/screenload/components/metricsRibbon';
+import {MobileMetricsRibbon} from 'sentry/views/insights/mobile/screenload/components/metricsRibbon';
 import {ModuleName, SpanMetricsField} from 'sentry/views/insights/types';
 
 import AppStartWidgets from '../components/widgets';
@@ -105,7 +105,7 @@ export function ScreenSummary() {
                 <ReleaseComparisonSelector />
                 <StartTypeSelector />
               </ControlsContainer>
-              <MetricsRibbon
+              <MobileMetricsRibbon
                 dataset={DiscoverDatasets.SPANS_METRICS}
                 filters={[
                   `transaction:${transactionName}`,

--- a/static/app/views/insights/mobile/common/components/spanSamplesPanelContainer.tsx
+++ b/static/app/views/insights/mobile/common/components/spanSamplesPanelContainer.tsx
@@ -155,7 +155,7 @@ export function SpanSamplesContainer({
         )}
       </PaddedTitle>
 
-      <Container>
+      <MetricsRibbon>
         <MetricReadout
           title={DataTitles.avg}
           align="left"
@@ -168,7 +168,7 @@ export function SpanSamplesContainer({
           value={spanMetrics?.['count()'] ?? 0}
           unit="count"
         />
-      </Container>
+      </MetricsRibbon>
 
       <DurationChart
         spanSearch={spanSearch}
@@ -251,8 +251,10 @@ const PaddedTitle = styled('div')`
   margin-bottom: ${space(1)};
 `;
 
-const Container = styled('div')`
+const MetricsRibbon = styled('div')`
   display: flex;
+  flex-wrap: wrap;
+  gap: ${space(4)};
 `;
 
 const StyledSearchBar = styled(SearchBar)`

--- a/static/app/views/insights/mobile/common/components/spanSamplesPanelContainer.tsx
+++ b/static/app/views/insights/mobile/common/components/spanSamplesPanelContainer.tsx
@@ -20,6 +20,7 @@ import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import useRouter from 'sentry/utils/useRouter';
 import {MetricReadout} from 'sentry/views/insights/common/components/metricReadout';
+import {Ribbon} from 'sentry/views/insights/common/components/ribbon';
 import {useSpanMetrics} from 'sentry/views/insights/common/queries/useDiscover';
 import {formatVersionAndCenterTruncate} from 'sentry/views/insights/common/utils/centerTruncate';
 import {DataTitles} from 'sentry/views/insights/common/views/spans/types';
@@ -155,7 +156,7 @@ export function SpanSamplesContainer({
         )}
       </PaddedTitle>
 
-      <MetricsRibbon>
+      <Ribbon>
         <MetricReadout
           title={DataTitles.avg}
           align="left"
@@ -168,7 +169,7 @@ export function SpanSamplesContainer({
           value={spanMetrics?.['count()'] ?? 0}
           unit="count"
         />
-      </MetricsRibbon>
+      </Ribbon>
 
       <DurationChart
         spanSearch={spanSearch}
@@ -249,12 +250,6 @@ const SectionTitle = styled('div')`
 
 const PaddedTitle = styled('div')`
   margin-bottom: ${space(1)};
-`;
-
-const MetricsRibbon = styled('div')`
-  display: flex;
-  flex-wrap: wrap;
-  gap: ${space(4)};
 `;
 
 const StyledSearchBar = styled(SearchBar)`

--- a/static/app/views/insights/mobile/screenload/components/metricsRibbon.spec.tsx
+++ b/static/app/views/insights/mobile/screenload/components/metricsRibbon.spec.tsx
@@ -6,7 +6,7 @@ import {render, screen} from 'sentry-test/reactTestingLibrary';
 import {DurationUnit} from 'sentry/utils/discover/fields';
 import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import usePageFilters from 'sentry/utils/usePageFilters';
-import {MetricsRibbon} from 'sentry/views/insights/mobile/screenload/components/metricsRibbon';
+import {MobileMetricsRibbon} from 'sentry/views/insights/mobile/screenload/components/metricsRibbon';
 
 jest.mock('sentry/utils/usePageFilters');
 
@@ -56,7 +56,7 @@ describe('MetricsRibbon', function () {
     });
 
     render(
-      <MetricsRibbon
+      <MobileMetricsRibbon
         dataset={DiscoverDatasets.SPANS_METRICS}
         filters={[
           'duration:>0',

--- a/static/app/views/insights/mobile/screenload/components/metricsRibbon.tsx
+++ b/static/app/views/insights/mobile/screenload/components/metricsRibbon.tsx
@@ -1,9 +1,7 @@
 import type {ComponentProps} from 'react';
 import {useMemo} from 'react';
-import styled from '@emotion/styled';
 
 import type {Polarity} from 'sentry/components/percentChange';
-import {space} from 'sentry/styles/space';
 import type {NewQuery} from 'sentry/types/organization';
 import type {TableData, TableDataRow} from 'sentry/utils/discover/discoverQuery';
 import EventView from 'sentry/utils/discover/eventView';
@@ -12,6 +10,7 @@ import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {useLocation} from 'sentry/utils/useLocation';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import {MetricReadout} from 'sentry/views/insights/common/components/metricReadout';
+import {Ribbon} from 'sentry/views/insights/common/components/ribbon';
 import {useReleaseSelection} from 'sentry/views/insights/common/queries/useReleases';
 import {appendReleaseFilters} from 'sentry/views/insights/common/utils/releaseComparison';
 import useCrossPlatformProject from 'sentry/views/insights/mobile/common/queries/useCrossPlatformProject';
@@ -25,7 +24,7 @@ interface BlockProps {
   preferredPolarity?: Polarity;
 }
 
-export function MetricsRibbon({
+export function MobileMetricsRibbon({
   filters,
   blocks,
   fields,
@@ -81,7 +80,7 @@ export function MetricsRibbon({
   });
 
   return (
-    <BlockContainer>
+    <Ribbon>
       {blocks.map(({title, dataKey, unit, preferredPolarity}) => (
         <MetricsBlock
           key={title}
@@ -93,7 +92,7 @@ export function MetricsRibbon({
           preferredPolarity={preferredPolarity}
         />
       ))}
-    </BlockContainer>
+    </Ribbon>
   );
 }
 
@@ -129,8 +128,3 @@ function MetricsBlock({
     />
   );
 }
-
-const BlockContainer = styled('div')`
-  display: flex;
-  gap: ${space(2)};
-`;

--- a/static/app/views/insights/mobile/screenload/views/screenLoadSpansPage.tsx
+++ b/static/app/views/insights/mobile/screenload/views/screenLoadSpansPage.tsx
@@ -32,7 +32,7 @@ import {
   YAxis,
 } from 'sentry/views/insights/mobile/screenload/components/charts/screenCharts';
 import {ScreenLoadEventSamples} from 'sentry/views/insights/mobile/screenload/components/eventSamples';
-import {MetricsRibbon} from 'sentry/views/insights/mobile/screenload/components/metricsRibbon';
+import {MobileMetricsRibbon} from 'sentry/views/insights/mobile/screenload/components/metricsRibbon';
 import {PlatformSelector} from 'sentry/views/insights/mobile/screenload/components/platformSelector';
 import {ScreenLoadSpansTable} from 'sentry/views/insights/mobile/screenload/components/tables/screenLoadSpansTable';
 import {
@@ -103,7 +103,7 @@ function ScreenLoadSpans() {
                 </PageFilterBar>
                 <ReleaseComparisonSelector />
               </FilterContainer>
-              <MetricsRibbon
+              <MobileMetricsRibbon
                 dataset={DiscoverDatasets.METRICS}
                 filters={[
                   'event.type:transaction',

--- a/static/app/views/insights/queues/components/messageSpanSamplesPanel.tsx
+++ b/static/app/views/insights/queues/components/messageSpanSamplesPanel.tsx
@@ -1,4 +1,4 @@
-import {Fragment, useCallback} from 'react';
+import {useCallback} from 'react';
 import styled from '@emotion/styled';
 import * as qs from 'query-string';
 
@@ -27,6 +27,7 @@ import {computeAxisMax} from 'sentry/views/insights/common/components/chart';
 import DetailPanel from 'sentry/views/insights/common/components/detailPanel';
 import {MetricReadout} from 'sentry/views/insights/common/components/metricReadout';
 import * as ModuleLayout from 'sentry/views/insights/common/components/moduleLayout';
+import {Ribbon} from 'sentry/views/insights/common/components/ribbon';
 import {useSpanMetricsSeries} from 'sentry/views/insights/common/queries/useDiscoverSeries';
 import {AverageValueMarkLine} from 'sentry/views/insights/common/utils/averageValueMarkLine';
 import {useSampleScatterPlotSeries} from 'sentry/views/insights/common/views/spanSummaryPage/sampleList/durationChart/useSampleScatterPlotSeries';
@@ -427,7 +428,7 @@ function ProducerMetricsRibbon({
 }) {
   const errorRate = 1 - (metrics[0]?.['trace_status_rate(ok)'] ?? 0);
   return (
-    <Fragment>
+    <Ribbon>
       <MetricReadout
         align="left"
         title={t('Published')}
@@ -442,7 +443,7 @@ function ProducerMetricsRibbon({
         unit={'percentage'}
         isLoading={isLoading}
       />
-    </Fragment>
+    </Ribbon>
   );
 }
 
@@ -455,7 +456,7 @@ function ConsumerMetricsRibbon({
 }) {
   const errorRate = 1 - (metrics[0]?.['trace_status_rate(ok)'] ?? 0);
   return (
-    <Fragment>
+    <Ribbon>
       <MetricReadout
         align="left"
         title={t('Processed')}
@@ -482,7 +483,7 @@ function ConsumerMetricsRibbon({
         unit={DurationUnit.MILLISECOND}
         isLoading={false}
       />
-    </Fragment>
+    </Ribbon>
   );
 }
 

--- a/static/app/views/insights/queues/views/destinationSummaryPage.tsx
+++ b/static/app/views/insights/queues/views/destinationSummaryPage.tsx
@@ -18,6 +18,7 @@ import useOrganization from 'sentry/utils/useOrganization';
 import {MetricReadout} from 'sentry/views/insights/common/components/metricReadout';
 import * as ModuleLayout from 'sentry/views/insights/common/components/moduleLayout';
 import {ModulePageProviders} from 'sentry/views/insights/common/components/modulePageProviders';
+import {Ribbon} from 'sentry/views/insights/common/components/ribbon';
 import {getTimeSpentExplanation} from 'sentry/views/insights/common/components/tableCells/timeSpentCell';
 import {useOnboardingProject} from 'sentry/views/insights/common/queries/useOnboardingProject';
 import {useModuleBreadcrumbs} from 'sentry/views/insights/common/utils/useModuleBreadcrumbs';
@@ -79,7 +80,7 @@ function DestinationSummaryPage() {
                 </PageFilterBar>
 
                 {!onboardingProject && (
-                  <MetricsRibbon>
+                  <Ribbon>
                     <MetricReadout
                       title={t('Avg Time In Queue')}
                       value={data[0]?.['avg(messaging.message.receive.latency)']}
@@ -119,7 +120,7 @@ function DestinationSummaryPage() {
                       )}
                       isLoading={isLoading}
                     />
-                  </MetricsRibbon>
+                  </Ribbon>
                 )}
               </HeaderContainer>
             </ModuleLayout.Full>
@@ -176,12 +177,6 @@ const Flex = styled('div')`
   display: flex;
   flex-direction: column;
   gap: ${space(2)};
-`;
-
-const MetricsRibbon = styled('div')`
-  display: flex;
-  flex-wrap: wrap;
-  gap: ${space(4)};
 `;
 
 const HeaderContainer = styled('div')`


### PR DESCRIPTION
Finally resolving this duplication. Adding a generic, logic-less `Ribbon` component to wrap all these metrics ribbons in, instead of containers all over the place.
