### PR TITLE
ref(metric-extraction): Increase timeout for experimental config

### DIFF
--- a/src/sentry/relay/config/experimental.py
+++ b/src/sentry/relay/config/experimental.py
@@ -44,7 +44,7 @@ class ExperimentalConfigBuilder(Protocol):
 
 
 #: Timeout for an experimental feature build.
-_FEATURE_BUILD_TIMEOUT = timedelta(seconds=15)
+_FEATURE_BUILD_TIMEOUT = timedelta(seconds=20)
 
 
 def add_experimental_config(


### PR DESCRIPTION
### Summary
The only one going over is widget specs, looks to be by a small amount (1-2 seconds), but it's been creeping up over the last few weeks.

We need a bit of time to investigate, but in the meantime this should lower any trouble caused by timeouts.
