### PR TITLE
fix(query-builder): Send correct payload to value fetching endpoint when key is unknown

### DIFF
--- a/static/app/components/searchQueryBuilder/valueCombobox.tsx
+++ b/static/app/components/searchQueryBuilder/valueCombobox.tsx
@@ -505,7 +505,7 @@ function useFilterSuggestions({
   token: TokenResult<Token.FILTER>;
 }) {
   const {getTagValues, filterKeys} = useSearchQueryBuilder();
-  const key = filterKeys[token.key.text];
+  const key: Tag | undefined = filterKeys[token.key.text];
   const predefinedValues = useMemo(
     () => getPredefinedValues({key, filterValue, token}),
     [key, filterValue, token]
@@ -523,7 +523,8 @@ function useFilterSuggestions({
   // TODO(malwilley): Display error states
   const {data, isFetching} = useQuery<string[]>({
     queryKey: debouncedQueryKey,
-    queryFn: () => getTagValues(key, filterValue),
+    queryFn: () =>
+      getTagValues(key ? key : {key: token.key.text, name: token.key.text}, filterValue),
     keepPreviousData: true,
     enabled: shouldFetchValues,
   });


### PR DESCRIPTION
A small bug was caused because we do not enable `noUncheckedIndexedAccess` in our typescript config. We were keying into `filterKeys` with an unknown key and it returned undefined but the types did not reflect that. (This is an ongoing discussion in the frontend TSC but it's quite a bit of work to enable that config).

This was fixed by providing a fallback when sending the key to `getTagValues()`.