### PR TITLE
feat(backup): Enable relocation hiding

### DIFF
--- a/src/sentry/backup/helpers.py
+++ b/src/sentry/backup/helpers.py
@@ -90,7 +90,7 @@ class ImportFlags(NamedTuple):
     """
 
     # If a username already exists, should we re-use that user, or create a new one with a randomly
-    # suffixed username (ex: "some-user" would become "some-user-ad21")
+    # suffixed username (ex: "some-user" would become "some-user-ad21")?
     merge_users: bool = False
 
     # If a global configuration value `ControlOption`/`Option` (as identified by its unique
@@ -103,3 +103,8 @@ class ImportFlags(NamedTuple):
     # is not provided, the import was called in a non-relocation context, like from the `sentry
     # import` CLI command.
     import_uuid: str | None = None
+
+    # Controls whether or not organizations have their `status` set to `RELOCATION_PENDING_APPROVAL`
+    # when being imported. This is primarily useful for SaaS -> SaaS relocations only, and is
+    # therefore not meant to be exposed to or settable from the command line via flags.
+    hide_organizations: bool = False

--- a/src/sentry/backup/services/import_export/model.py
+++ b/src/sentry/backup/services/import_export/model.py
@@ -121,12 +121,16 @@ class RpcImportFlags(RpcModel):
     merge_users: bool = False
     overwrite_configs: bool = False
     import_uuid: str | None = None
+    # TODO(azaslavsky): Remove `None` variant once rolled out, set default to `False` instead.
+    hide_organizations: bool | None = None
 
     def from_rpc(self) -> ImportFlags:
         return ImportFlags(
             merge_users=self.merge_users,
             overwrite_configs=self.overwrite_configs,
             import_uuid=self.import_uuid,
+            # TODO(azaslavsky): remove cast.
+            hide_organizations=bool(self.hide_organizations),
         )
 
     @classmethod
@@ -135,6 +139,10 @@ class RpcImportFlags(RpcModel):
             merge_users=base_flags.merge_users,
             overwrite_configs=base_flags.overwrite_configs,
             import_uuid=base_flags.import_uuid,
+            # TODO(azaslavsky): remove cast.
+            hide_organizations=(
+                None if not base_flags.hide_organizations else base_flags.hide_organizations
+            ),
         )
 
 


### PR DESCRIPTION
This PR adds a new flag to `sentry import`, called `hide_organizations`, which places organizations in a special "hidden" mode after an import, rendering them invisible to the UI (org dropdowns, etc).