### PR TITLE
fix(profiling): Negative regression score is not a must

### DIFF
--- a/static/app/components/events/eventStatisticalDetector/transactionsDeltaProvider.tsx
+++ b/static/app/components/events/eventStatisticalDetector/transactionsDeltaProvider.tsx
@@ -65,7 +65,7 @@ export function TransactionsDeltaProvider(props: TransactionsDeltaProviderProps)
       key: regressionScore,
       order: 'desc',
     },
-    query: `fingerprint:${fingerprint} ${regressionScore}:>0`,
+    query: `fingerprint:${fingerprint}`,
     projects: [props.project.id],
     limit: TRANSACTIONS_LIMIT,
     referrer: 'api.profiling.functions.regression.transactions',


### PR DESCRIPTION
A negative regression score is not a must as it's just a proxy ranking. So being negative doesn't mean it's irrelevant, just that it should be ranked lower.