### PR TITLE
nit(gitlab): quiet invalid token sentry error

### DIFF
--- a/src/sentry/integrations/gitlab/webhooks.py
+++ b/src/sentry/integrations/gitlab/webhooks.py
@@ -31,7 +31,7 @@ from sentry.plugins.providers import IntegrationRepositoryProvider
 logger = logging.getLogger("sentry.webhooks")
 
 PROVIDER_NAME = "integrations:gitlab"
-GITHUB_WEBHOOK_SECRET_INVALID_ERROR = """"Gitlab's webhook secret does not match. Refresh token (or re-install the integration) by following this https://docs.sentry.io/organization/integrations/integration-platform/public-integration/#refreshing-tokens."""
+GITHUB_WEBHOOK_SECRET_INVALID_ERROR = """Gitlab's webhook secret does not match. Refresh token (or re-install the integration) by following this https://docs.sentry.io/organization/integrations/integration-platform/public-integration/#refreshing-tokens."""
 
 
 class Webhook:

--- a/src/sentry/integrations/gitlab/webhooks.py
+++ b/src/sentry/integrations/gitlab/webhooks.py
@@ -31,6 +31,7 @@ from sentry.plugins.providers import IntegrationRepositoryProvider
 logger = logging.getLogger("sentry.webhooks")
 
 PROVIDER_NAME = "integrations:gitlab"
+GITHUB_WEBHOOK_SECRET_INVALID_ERROR = """"Gitlab's webhook secret does not match. Refresh token (or re-install the integration) by following this https://docs.sentry.io/organization/integrations/integration-platform/public-integration/#refreshing-tokens."""
 
 
 class Webhook:
@@ -296,19 +297,12 @@ class GitlabWebhookEndpoint(Endpoint, GitlabWebhookMixin):
             },
         }
 
-        try:
-            if not constant_time_compare(secret, integration.metadata["webhook_secret"]):
-                # Summary and potential workaround mentioned here:
-                # https://github.com/getsentry/sentry/issues/34903#issuecomment-1262754478
-                # This forces a stack trace to be produced
-                raise Exception("The webhook secrets do not match.")
-        except Exception:
+        if not constant_time_compare(secret, integration.metadata["webhook_secret"]):
+            # Summary and potential workaround mentioned here:
+            # https://github.com/getsentry/sentry/issues/34903#issuecomment-1262754478
+            extra["reason"] = GITHUB_WEBHOOK_SECRET_INVALID_ERROR
             logger.info("gitlab.webhook.invalid-token-secret", extra=extra)
-            extra[
-                "reason"
-            ] = "Gitlab's webhook secret does not match. Refresh token (or re-install the integration) by following this https://docs.sentry.io/product/integrations/integration-platform/public-integration/#refreshing-tokens."
-            logger.exception(extra["reason"])
-            return HttpResponse(status=409, reason=extra["reason"])
+            return HttpResponse(status=409, reason=GITHUB_WEBHOOK_SECRET_INVALID_ERROR)
 
         try:
             event = orjson.loads(request.body)

--- a/tests/sentry/integrations/gitlab/test_webhook.py
+++ b/tests/sentry/integrations/gitlab/test_webhook.py
@@ -92,7 +92,7 @@ class WebhookTest(GitLabTestCase):
         assert response.status_code == 409
         assert (
             response.reason_phrase
-            == "Gitlab's webhook secret does not match. Refresh token (or re-install the integration) by following this https://docs.sentry.io/product/integrations/integration-platform/public-integration/#refreshing-tokens."
+            == "Gitlab's webhook secret does not match. Refresh token (or re-install the integration) by following this https://docs.sentry.io/organization/integrations/integration-platform/public-integration/#refreshing-tokens."
         )
 
     def test_invalid_payload(self):


### PR DESCRIPTION
This issue is not actionable on our side https://sentry.sentry.io/issues/3622378978/.

If Gitlab's webhook secret does not match, the user needs to refresh token (or re-install the integration) by following this https://docs.sentry.io/product/integrations/integration-platform/public-integration/#refreshing-tokens.