### PR TITLE
feat(uptime): Guard against processing duplicate results in the result consumer

### DIFF
--- a/src/sentry/uptime/consumers/results_consumer.py
+++ b/src/sentry/uptime/consumers/results_consumer.py
@@ -19,7 +19,7 @@ from sentry.utils import metrics
 from sentry.utils.hashlib import md5_text
 
 logger = logging.getLogger(__name__)
-REDIS_TTL = timedelta(days=7)
+LAST_UPDATE_REDIS_TTL = timedelta(days=7)
 
 
 def build_last_update_key(project_subscription: ProjectUptimeSubscription) -> str:
@@ -85,7 +85,7 @@ class UptimeResultProcessor(ResultProcessor[CheckResult, UptimeSubscription]):
         cluster.set(
             build_last_update_key(project_subscription),
             int(result["scheduled_check_time_ms"]),
-            ex=REDIS_TTL,
+            ex=LAST_UPDATE_REDIS_TTL,
         )
 
 

--- a/src/sentry/uptime/consumers/results_consumer.py
+++ b/src/sentry/uptime/consumers/results_consumer.py
@@ -72,7 +72,9 @@ class UptimeResultProcessor(ResultProcessor[CheckResult, UptimeSubscription]):
         try:
             if result["scheduled_check_time_ms"] <= last_update_ms:
                 # If the scheduled check time is older than the most recent update then we've already processed it.
-                # Skip and log
+                # We can end up with duplicates due to Kafka replaying tuples, or due to the uptime checker processing
+                # the same check multiple times and sending duplicate results.
+                # We only ever want to process the first value related to each check, so we just skip and log here
                 metrics.incr("uptime.result_processor.skipping_already_processed_update")
                 return
 

--- a/src/sentry/uptime/consumers/results_consumer.py
+++ b/src/sentry/uptime/consumers/results_consumer.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+from datetime import timedelta
 
 from django.conf import settings
 from sentry_kafka_schemas.schema_types.uptime_results_v1 import CHECKSTATUS_FAILURE, CheckResult
@@ -11,10 +12,18 @@ from sentry.remote_subscriptions.consumers.result_consumer import (
     ResultProcessor,
     ResultsStrategyFactory,
 )
+from sentry.uptime.detectors.ranking import _get_cluster
 from sentry.uptime.issue_platform import create_issue_platform_occurrence
 from sentry.uptime.models import ProjectUptimeSubscription, UptimeSubscription
+from sentry.utils import metrics
+from sentry.utils.hashlib import md5_text
 
 logger = logging.getLogger(__name__)
+REDIS_TTL = timedelta(days=7)
+
+
+def build_last_update_key(project_subscription: ProjectUptimeSubscription) -> str:
+    return f"project-sub-last-update:{md5_text(project_subscription.id).hexdigest()}"
 
 
 class UptimeResultProcessor(ResultProcessor[CheckResult, UptimeSubscription]):
@@ -27,7 +36,8 @@ class UptimeResultProcessor(ResultProcessor[CheckResult, UptimeSubscription]):
     def handle_result(self, subscription: UptimeSubscription, result: CheckResult):
         project_subscriptions = list(subscription.projectuptimesubscription_set.all())
         if not project_subscriptions:
-            # XXX: Hack for now, just create a fake row
+            # XXX: Hack for now, just create a fake row. Once we remove this, we should instead
+            # drop the uptime subscription
             try:
                 project = Project.objects.get(id=settings.UPTIME_POC_PROJECT_ID)
             except Project.DoesNotExist:
@@ -41,11 +51,42 @@ class UptimeResultProcessor(ResultProcessor[CheckResult, UptimeSubscription]):
                     )
                 ]
 
-        for project_subscription in project_subscriptions:
-            if result["status"] == CHECKSTATUS_FAILURE:
-                create_issue_platform_occurrence(result, project_subscription)
+        cluster = _get_cluster()
+        last_updates: list[str | None] = cluster.mget(
+            build_last_update_key(sub) for sub in project_subscriptions
+        )
+
+        for last_update_raw, project_subscription in zip(last_updates, project_subscriptions):
+            last_update_ms = 0 if last_update_raw is None else int(last_update_raw)
+            self.handle_result_for_project(project_subscription, result, last_update_ms)
 
         logger.info("process_result", extra=result)
+
+    def handle_result_for_project(
+        self,
+        project_subscription: ProjectUptimeSubscription,
+        result: CheckResult,
+        last_update_ms: int,
+    ):
+        cluster = _get_cluster()
+        try:
+            if result["scheduled_check_time_ms"] <= last_update_ms:
+                # If the scheduled check time is older than the most recent update then we've already processed it.
+                # Skip and log
+                metrics.incr("uptime.result_processor.skipping_already_processed_update")
+                return
+
+            if result["status"] == CHECKSTATUS_FAILURE:
+                create_issue_platform_occurrence(result, project_subscription)
+        except Exception:
+            logger.exception("Failed to process result for uptime project subscription")
+
+        # Now that we've processed the result for this project subscription we track the last update date
+        cluster.set(
+            build_last_update_key(project_subscription),
+            int(result["scheduled_check_time_ms"]),
+            ex=REDIS_TTL,
+        )
 
 
 class UptimeResultsStrategyFactory(ResultsStrategyFactory[CheckResult, UptimeSubscription]):

--- a/tests/sentry/uptime/consumers/test_results_consumers.py
+++ b/tests/sentry/uptime/consumers/test_results_consumers.py
@@ -3,33 +3,36 @@ from datetime import datetime
 from hashlib import md5
 from unittest import mock
 
+import pytest
 from arroyo import Message
 from arroyo.backends.kafka import KafkaPayload
 from arroyo.types import BrokerValue, Partition, Topic
 from django.test import override_settings
+from sentry_kafka_schemas.schema_types.uptime_results_v1 import CheckResult
 
 from sentry.conf.types import kafka_definition
 from sentry.issues.grouptype import UptimeDomainCheckFailure
 from sentry.models.group import Group
 from sentry.remote_subscriptions.consumers.result_consumer import FAKE_SUBSCRIPTION_ID
 from sentry.testutils.cases import UptimeTestCase
-from sentry.uptime.consumers.results_consumer import UptimeResultsStrategyFactory
+from sentry.uptime.consumers.results_consumer import (
+    UptimeResultsStrategyFactory,
+    build_last_update_key,
+)
+from sentry.uptime.detectors.ranking import _get_cluster
 
 
 class ProcessResultTest(UptimeTestCase):
     def setUp(self):
         super().setUp()
         self.partition = Partition(Topic("test"), 0)
-
-    def test(self):
-        subscription_id = uuid.uuid4().hex
-        subscription = self.create_uptime_subscription(subscription_id=subscription_id)
-        project_subscription = self.create_project_uptime_subscription(
-            uptime_subscription=subscription
+        self.subscription = self.create_uptime_subscription(subscription_id=uuid.uuid4().hex)
+        self.project_subscription = self.create_project_uptime_subscription(
+            uptime_subscription=self.subscription
         )
-        result = self.create_uptime_result(subscription_id)
-        codec = kafka_definition.get_topic_codec(kafka_definition.Topic.UPTIME_RESULTS)
 
+    def send_result(self, result: CheckResult):
+        codec = kafka_definition.get_topic_codec(kafka_definition.Topic.UPTIME_RESULTS)
         message = Message(
             BrokerValue(
                 KafkaPayload(None, codec.encode(result), []),
@@ -38,46 +41,46 @@ class ProcessResultTest(UptimeTestCase):
                 datetime.now(),
             )
         )
-        project = self.project
-        # TODO: Remove this once we have a subscription
-        with override_settings(UPTIME_POC_PROJECT_ID=project.id), self.feature(
-            UptimeDomainCheckFailure.build_ingest_feature_name()
-        ):
+        with self.feature(UptimeDomainCheckFailure.build_ingest_feature_name()):
             factory = UptimeResultsStrategyFactory()
             commit = mock.Mock()
 
             consumer = factory.create_with_partitions(commit, {self.partition: 0})
             consumer.submit(message)
 
-        hashed_fingerprint = md5(str(project_subscription.id).encode("utf-8")).hexdigest()
-
+    def test(self):
+        result = self.create_uptime_result(self.subscription.subscription_id)
+        self.send_result(result)
+        hashed_fingerprint = md5(str(self.project_subscription.id).encode("utf-8")).hexdigest()
         group = Group.objects.get(grouphash__hash=hashed_fingerprint)
         assert group.issue_type == UptimeDomainCheckFailure
 
     def test_no_subscription(self):
         # Temporary test to make sure hack fake subscription keeps working
+        other_project = self.create_project()
         subscription_id = uuid.uuid4().hex
         result = self.create_uptime_result(subscription_id)
-        codec = kafka_definition.get_topic_codec(kafka_definition.Topic.UPTIME_RESULTS)
-        message = Message(
-            BrokerValue(
-                KafkaPayload(None, codec.encode(result), []),
-                Partition(Topic("test"), 1),
-                1,
-                datetime.now(),
-            )
-        )
-        project = self.project
         # TODO: Remove this once we have a subscription
-        with override_settings(UPTIME_POC_PROJECT_ID=project.id), self.feature(
-            UptimeDomainCheckFailure.build_ingest_feature_name()
-        ):
-            factory = UptimeResultsStrategyFactory()
-            commit = mock.Mock()
-            consumer = factory.create_with_partitions(commit, {self.partition: 0})
-            consumer.submit(message)
+        with override_settings(UPTIME_POC_PROJECT_ID=other_project.id):
+            self.send_result(result)
 
         hashed_fingerprint = md5(str(FAKE_SUBSCRIPTION_ID).encode("utf-8")).hexdigest()
 
         group = Group.objects.get(grouphash__hash=hashed_fingerprint)
         assert group.issue_type == UptimeDomainCheckFailure
+
+    def test_skip_already_processed(self):
+        result = self.create_uptime_result(self.subscription.subscription_id)
+        _get_cluster().set(
+            build_last_update_key(self.project_subscription),
+            int(result["scheduled_check_time_ms"]),
+        )
+        with mock.patch("sentry.uptime.consumers.results_consumer.metrics") as metrics:
+            self.send_result(result)
+            metrics.incr.assert_called_once_with(
+                "uptime.result_processor.skipping_already_processed_update"
+            )
+
+        hashed_fingerprint = md5(str(self.project_subscription.id).encode("utf-8")).hexdigest()
+        with pytest.raises(Group.DoesNotExist):
+            Group.objects.get(grouphash__hash=hashed_fingerprint)


### PR DESCRIPTION
We only want to process each result one time. Since we guarantee receiving results in order from the uptime checker we can just use the scheduled time of each result to maintain a watermark of the last processed result.
