### PR TITLE
chore(slack): Cleanup Tests & Code for Culprit Block

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -394,8 +394,6 @@ def register_temporary_features(manager: FeatureManager):
     manager.add("organizations:session-replay-web-vitals", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, default=False)
     # Lets organizations manage grouping configs
     manager.add("organizations:set-grouping-config", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
-    # Enable Culprit Blocks in Slack Notifications
-    manager.add("organizations:slack-culprit-blocks", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE)
     # Enable description field in Slack metric alerts
     manager.add("organizations:slack-metric-alert-description", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
     # Enable improvements to Slack notifications

--- a/src/sentry/integrations/slack/message_builder/issues.py
+++ b/src/sentry/integrations/slack/message_builder/issues.py
@@ -9,7 +9,7 @@ import orjson
 from django.core.exceptions import ObjectDoesNotExist
 from sentry_relay.processing import parse_release
 
-from sentry import features, tagstore
+from sentry import tagstore
 from sentry.api.endpoints.group_details import get_group_global_count
 from sentry.constants import LOG_LEVELS_MAP
 from sentry.eventstore.models import GroupEvent
@@ -607,9 +607,7 @@ class SlackIssuesMessageBuilder(BlockSlackMessageBuilder):
 
         blocks = [self.get_title_block(rule_id, notification_uuid, obj, has_action)]
 
-        if features.has("organizations:slack-culprit-blocks", project.organization) and (
-            culprit_block := self.get_culprit_block(obj)
-        ):
+        if culprit_block := self.get_culprit_block(obj):
             blocks.append(culprit_block)
 
         # build up text block

--- a/tests/sentry/integrations/slack/notifications/test_issue_alert.py
+++ b/tests/sentry/integrations/slack/notifications/test_issue_alert.py
@@ -104,7 +104,7 @@ class SlackIssueAlertNotificationTest(SlackActivityNotificationTest, Performance
         return_value=TEST_PERF_ISSUE_OCCURRENCE,
         new_callable=mock.PropertyMock,
     )
-    def test_performance_issue_alert_user_block_with_culprit_blocks(self, occurrence):
+    def test_performance_issue_alert_user_block(self, occurrence):
         """
         Test that performance issue alerts are sent to a Slack user with the proper payload when
         block kit is enabled.
@@ -350,7 +350,7 @@ class SlackIssueAlertNotificationTest(SlackActivityNotificationTest, Performance
         )
 
     @responses.activate
-    def test_issue_alert_team_issue_owners_block_with_culprit_blocks(self):
+    def test_issue_alert_team_issue_owners_block(self):
         """
         Test that issue alerts are sent to a team in Slack via an Issue Owners rule action with the
         proper payload when block kit is enabled.

--- a/tests/sentry/integrations/slack/notifications/test_issue_alert.py
+++ b/tests/sentry/integrations/slack/notifications/test_issue_alert.py
@@ -30,7 +30,6 @@ from sentry.plugins.base import Notification
 from sentry.silo.base import SiloMode
 from sentry.tasks.digests import deliver_digest
 from sentry.testutils.cases import PerformanceIssueTestCase, SlackActivityNotificationTest
-from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.helpers.notifications import TEST_ISSUE_OCCURRENCE, TEST_PERF_ISSUE_OCCURRENCE
 from sentry.testutils.silo import assume_test_silo_mode
 from sentry.testutils.skips import requires_snuba
@@ -99,51 +98,12 @@ class SlackIssueAlertNotificationTest(SlackActivityNotificationTest, Performance
         )
 
     @responses.activate
-    @patch("sentry.integrations.slack.message_builder.issues.get_tags", new=fake_get_tags)
-    @patch(
-        "sentry.eventstore.models.GroupEvent.occurrence",
-        return_value=TEST_PERF_ISSUE_OCCURRENCE,
-        new_callable=mock.PropertyMock,
-    )
-    def test_performance_issue_alert_user_block(self, occurrence):
-        """
-        Test that performance issue alerts are sent to a Slack user with the proper payload when
-        block kit is enabled.
-        """
-
-        event = self.create_performance_issue()
-        # this is a PerformanceNPlusOneGroupType event
-        notification = AlertRuleNotification(
-            Notification(event=event, rule=self.rule), ActionTargetType.MEMBER, self.user.id
-        )
-        with self.tasks():
-            notification.send()
-
-        blocks = orjson.loads(self.mock_post.call_args.kwargs["blocks"])
-        fallback_text = self.mock_post.call_args.kwargs["text"]
-        assert (
-            fallback_text
-            == f"Alert triggered <http://testserver/organizations/{event.organization.slug}/alerts/rules/{event.project.slug}/{self.rule.id}/details/|ja rule>"
-        )
-        assert blocks[0]["text"]["text"] == fallback_text
-        self.assert_performance_issue_blocks(
-            blocks,
-            event.organization,
-            event.project.slug,
-            event.group,
-            "issue_alert-slack",
-            alert_type=FineTuningAPIKey.ALERTS,
-            issue_link_extra_params=f"&alert_rule_id={self.rule.id}&alert_type=issue",
-        )
-
-    @responses.activate
     @mock.patch("sentry.integrations.slack.message_builder.issues.get_tags", new=fake_get_tags)
     @mock.patch(
         "sentry.eventstore.models.GroupEvent.occurrence",
         return_value=TEST_PERF_ISSUE_OCCURRENCE,
         new_callable=mock.PropertyMock,
     )
-    @with_feature("organizations:slack-culprit-blocks")
     def test_performance_issue_alert_user_block_with_culprit_blocks(self, occurrence):
         """
         Test that performance issue alerts are sent to a Slack user with the proper payload when
@@ -389,106 +349,7 @@ class SlackIssueAlertNotificationTest(SlackActivityNotificationTest, Performance
             == f"{event.project.slug} | {environment.name} | <http://testserver/settings/account/notifications/alerts/?referrer=issue_alert-slack-user&notification_uuid={notification_uuid}&organizationId={event.organization.id}|Notification Settings>"
         )
 
-    def test_issue_alert_team_issue_owners_block(self):
-        """
-        Test that issue alerts are sent to a team in Slack via an Issue Owners rule action with the
-        proper payload when block kit is enabled.
-        """
-
-        # add a second user to the team so we can be sure it's only
-        # sent once (to the team, and not to each individual user)
-        user2 = self.create_user(is_superuser=False)
-        self.create_member(teams=[self.team], user=user2, organization=self.organization)
-        with assume_test_silo_mode(SiloMode.CONTROL):
-            self.idp = self.create_identity_provider(type="slack", external_id="TXXXXXXX2")
-            self.identity = Identity.objects.create(
-                external_id="UXXXXXXX2",
-                idp=self.idp,
-                user=user2,
-                status=IdentityStatus.VALID,
-                scopes=[],
-            )
-        # update the team's notification settings
-        ExternalActor.objects.create(
-            team_id=self.team.id,
-            organization=self.organization,
-            integration_id=self.integration.id,
-            provider=ExternalProviders.SLACK.value,
-            external_name="goma",
-            external_id="CXXXXXXX2",
-        )
-        with assume_test_silo_mode(SiloMode.CONTROL):
-            # provider is disabled by default
-            NotificationSettingProvider.objects.create(
-                team_id=self.team.id,
-                scope_type="team",
-                scope_identifier=self.team.id,
-                provider="slack",
-                type="alerts",
-                value="always",
-            )
-
-        g_rule = GrammarRule(Matcher("path", "*"), [Owner("team", self.team.slug)])
-        ProjectOwnership.objects.create(project_id=self.project.id, schema=dump_schema([g_rule]))
-
-        event = self.store_event(
-            data={
-                "message": "Hello world",
-                "level": "error",
-                "stacktrace": {"frames": [{"filename": "foo.py"}]},
-            },
-            project_id=self.project.id,
-        )
-
-        action_data = {
-            "id": "sentry.mail.actions.NotifyEmailAction",
-            "targetType": "IssueOwners",
-            "targetIdentifier": "",
-        }
-        rule = Rule.objects.create(
-            project=self.project,
-            label="ja rule",
-            data={
-                "match": "all",
-                "actions": [action_data],
-            },
-        )
-
-        notification = AlertRuleNotification(
-            Notification(event=event, rule=rule), ActionTargetType.ISSUE_OWNERS, self.team.id
-        )
-
-        with self.tasks():
-            notification.send()
-
-        # check that only one was sent out - more would mean each user is being notified
-        # rather than the team
-        assert self.mock_post.call_count == 1
-
-        # check that the team got a notification
-        assert self.mock_post.call_args.kwargs["channel"] == "CXXXXXXX2"
-        blocks = orjson.loads(self.mock_post.call_args.kwargs["blocks"])
-        fallback_text = self.mock_post.call_args.kwargs["text"]
-        notification_uuid = notification.notification_uuid
-
-        assert (
-            fallback_text
-            == f"Alert triggered <http://testserver/organizations/{event.organization.slug}/alerts/rules/{event.project.slug}/{rule.id}/details/|ja rule>"
-        )
-        assert blocks[0]["text"]["text"] == fallback_text
-        assert event.group
-        assert (
-            blocks[1]["text"]["text"]
-            == f":red_circle: <http://testserver/organizations/{event.organization.slug}/issues/{event.group.id}/?referrer=issue_alert-slack&notification_uuid={notification_uuid}&alert_rule_id={rule.id}&alert_type=issue|*Hello world*>"
-        )
-        assert blocks[5]["elements"][0]["text"] == f"Suggested Assignees: #{self.team.slug}"
-        assert (
-            blocks[6]["elements"][0]["text"]
-            == f"{event.project.slug} | <http://testserver/settings/{event.organization.slug}/teams/{self.team.slug}/notifications/?referrer=issue_alert-slack-team&notification_uuid={notification_uuid}|Notification Settings>"
-        )
-
     @responses.activate
-    @with_feature("organizations:slack-culprit-blocks")
     def test_issue_alert_team_issue_owners_block_with_culprit_blocks(self):
         """
         Test that issue alerts are sent to a team in Slack via an Issue Owners rule action with the

--- a/tests/sentry/integrations/slack/notifications/test_regression.py
+++ b/tests/sentry/integrations/slack/notifications/test_regression.py
@@ -5,7 +5,6 @@ import orjson
 from sentry.models.activity import Activity
 from sentry.notifications.notifications.activity.regression import RegressionActivityNotification
 from sentry.testutils.cases import PerformanceIssueTestCase, SlackActivityNotificationTest
-from sentry.testutils.helpers import with_feature
 from sentry.testutils.helpers.notifications import TEST_ISSUE_OCCURRENCE, TEST_PERF_ISSUE_OCCURRENCE
 from sentry.testutils.skips import requires_snuba
 from sentry.types.activity import ActivityType
@@ -73,33 +72,6 @@ class SlackRegressionNotificationTest(SlackActivityNotificationTest, Performance
         return_value=TEST_PERF_ISSUE_OCCURRENCE,
         new_callable=mock.PropertyMock,
     )
-    def test_regression_performance_issue_block(self, occurrence):
-        """
-        Test that a Slack message is sent with the expected payload when a performance issue regresses
-        and block kit is enabled.
-        """
-        event = self.create_performance_issue()
-        with self.tasks():
-            self.create_notification(event.group).send()
-
-        blocks = orjson.loads(self.mock_post.call_args.kwargs["blocks"])
-        fallback_text = self.mock_post.call_args.kwargs["text"]
-        assert fallback_text == "Issue marked as regression"
-        assert blocks[0]["text"]["text"] == fallback_text
-        self.assert_performance_issue_blocks(
-            blocks,
-            event.organization,
-            event.project.slug,
-            event.group,
-            "regression_activity-slack",
-        )
-
-    @mock.patch(
-        "sentry.eventstore.models.GroupEvent.occurrence",
-        return_value=TEST_PERF_ISSUE_OCCURRENCE,
-        new_callable=mock.PropertyMock,
-    )
-    @with_feature("organizations:slack-culprit-blocks")
     def test_regression_performance_issue_block_with_culprit_blocks(self, occurrence):
         """
         Test that a Slack message is sent with the expected payload when a performance issue regresses
@@ -126,43 +98,6 @@ class SlackRegressionNotificationTest(SlackActivityNotificationTest, Performance
         return_value=TEST_ISSUE_OCCURRENCE,
         new_callable=mock.PropertyMock,
     )
-    def test_regression_generic_issue_block(self, occurrence):
-        """
-        Test that a Slack message is sent with the expected payload when a generic issue type regresses
-        and block kit is enabled.
-        """
-        event = self.store_event(
-            data={
-                "message": "Hellboy's world",
-                "level": "error",
-                "culprit": "raven.tasks.run_a_test",
-            },
-            project_id=self.project.id,
-        )
-        group_event = event.for_group(event.groups[0])
-
-        with self.tasks():
-            self.create_notification(group_event.group).send()
-
-        blocks = orjson.loads(self.mock_post.call_args.kwargs["blocks"])
-        fallback_text = self.mock_post.call_args.kwargs["text"]
-        assert fallback_text == "Issue marked as regression"
-        assert blocks[0]["text"]["text"] == fallback_text
-        self.assert_generic_issue_blocks(
-            blocks,
-            group_event.organization,
-            group_event.project.slug,
-            group_event.group,
-            "regression_activity-slack",
-            with_culprit=False,
-        )
-
-    @mock.patch(
-        "sentry.eventstore.models.GroupEvent.occurrence",
-        return_value=TEST_ISSUE_OCCURRENCE,
-        new_callable=mock.PropertyMock,
-    )
-    @with_feature("organizations:slack-culprit-blocks")
     def test_regression_generic_issue_block_with_culprit_blocks(self, occurrence):
         """
         Test that a Slack message is sent with the expected payload when a generic issue type regresses

--- a/tests/sentry/integrations/slack/notifications/test_unassigned.py
+++ b/tests/sentry/integrations/slack/notifications/test_unassigned.py
@@ -6,7 +6,6 @@ import responses
 from sentry.models.activity import Activity
 from sentry.notifications.notifications.activity.unassigned import UnassignedActivityNotification
 from sentry.testutils.cases import PerformanceIssueTestCase, SlackActivityNotificationTest
-from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.helpers.notifications import TEST_ISSUE_OCCURRENCE, TEST_PERF_ISSUE_OCCURRENCE
 from sentry.testutils.skips import requires_snuba
 from sentry.types.activity import ActivityType
@@ -48,40 +47,12 @@ class SlackUnassignedNotificationTest(SlackActivityNotificationTest, Performance
             == f"{self.project.slug} | <http://testserver/settings/account/notifications/workflow/?referrer=unassigned_activity-slack-user&notification_uuid={notification_uuid}&organizationId={self.organization.id}|Notification Settings>"
         )
 
-    @mock.patch(
-        "sentry.eventstore.models.GroupEvent.occurrence",
-        return_value=TEST_PERF_ISSUE_OCCURRENCE,
-        new_callable=mock.PropertyMock,
-    )
-    def test_unassignment_performance_issue_block(self, occurrence):
-        """
-        Test that a Slack message is sent with the expected payload when a performance issue is unassigned
-        and block kit is enabled.
-        """
-        event = self.create_performance_issue()
-        with self.tasks():
-            self.create_notification(event.group).send()
-
-        blocks = orjson.loads(self.mock_post.call_args.kwargs["blocks"])
-        fallback_text = self.mock_post.call_args.kwargs["text"]
-
-        assert fallback_text == f"Issue unassigned by {self.name}"
-        assert blocks[0]["text"]["text"] == fallback_text
-        self.assert_performance_issue_blocks(
-            blocks,
-            event.organization,
-            event.project.slug,
-            event.group,
-            "unassigned_activity-slack",
-        )
-
     @responses.activate
     @mock.patch(
         "sentry.eventstore.models.GroupEvent.occurrence",
         return_value=TEST_PERF_ISSUE_OCCURRENCE,
         new_callable=mock.PropertyMock,
     )
-    @with_feature("organizations:slack-culprit-blocks")
     def test_unassignment_performance_issue_block_with_culprit_blocks(self, occurrence):
         """
         Test that a Slack message is sent with the expected payload when a performance issue is unassigned

--- a/tests/sentry/integrations/slack/test_message_builder.py
+++ b/tests/sentry/integrations/slack/test_message_builder.py
@@ -88,6 +88,18 @@ def build_test_message_blocks(
             "block_id": f'{{"issue":{group.id}}}',
         },
     ]
+    if group.culprit:
+        blocks.append(
+            {
+                "type": "context",
+                "elements": [
+                    {
+                        "type": "mrkdwn",
+                        "text": f"{group.culprit}",
+                    }
+                ],
+            }
+        )
     if text:
         new_text = text.lstrip(" ")
         if new_text:
@@ -773,7 +785,7 @@ class BuildGroupAttachmentTest(TestCase, PerformanceIssueTestCase, OccurrenceTes
         assert "N+1 Query" in blocks["blocks"][0]["text"]["text"]
         assert (
             "db - SELECT `books_author`.`id`, `books_author`.`name` FROM `books_author` WHERE `books_author`.`id` = %s LIMIT 21"
-            in blocks["blocks"][1]["text"]["text"]
+            in blocks["blocks"][2]["text"]["text"]
         )
         assert blocks["text"] == f"[{self.project.slug}] N+1 Query"
 

--- a/tests/sentry/integrations/slack/webhooks/actions/test_status.py
+++ b/tests/sentry/integrations/slack/webhooks/actions/test_status.py
@@ -28,7 +28,6 @@ from sentry.silo.base import SiloMode
 from sentry.silo.safety import unguarded_write
 from sentry.testutils.cases import PerformanceIssueTestCase
 from sentry.testutils.helpers.datetime import before_now, freeze_time, iso_format
-from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.hybrid_cloud import HybridCloudTestMixin
 from sentry.testutils.silo import assume_test_silo_mode
 from sentry.testutils.skips import requires_snuba
@@ -345,7 +344,6 @@ class StatusActionTest(BaseEventTest, PerformanceIssueTestCase, HybridCloudTestM
         assert resp.data["text"] == LINK_IDENTITY_MESSAGE.format(associate_url=associate_url)
 
     @responses.activate
-    @with_feature("organizations:slack-sdk-action-view-open")
     def test_archive_issue_until_escalating_sdk(self):
         original_message = self.get_original_message(self.group.id)
         self.archive_issue_sdk(original_message, "ignored:archived_until_escalating")
@@ -363,7 +361,6 @@ class StatusActionTest(BaseEventTest, PerformanceIssueTestCase, HybridCloudTestM
         assert ":white_circle:" in blocks[0]["text"]["text"]
 
     @responses.activate
-    @with_feature("organizations:slack-sdk-action-view-open")
     def test_archive_issue_until_escalating_through_unfurl_sdk(self):
         original_message = self.get_original_message(self.group.id)
         payload_data = self.get_unfurl_data(original_message["blocks"])
@@ -380,7 +377,6 @@ class StatusActionTest(BaseEventTest, PerformanceIssueTestCase, HybridCloudTestM
         assert blocks[2]["text"]["text"].endswith(expect_status)
 
     @responses.activate
-    @with_feature("organizations:slack-sdk-action-view-open")
     def test_archive_issue_until_condition_met_sdk(self):
         original_message = self.get_original_message(self.group.id)
         self.archive_issue_sdk(original_message, "ignored:archived_until_condition_met:10")
@@ -398,7 +394,6 @@ class StatusActionTest(BaseEventTest, PerformanceIssueTestCase, HybridCloudTestM
         assert blocks[2]["text"]["text"].endswith(expect_status)
 
     @responses.activate
-    @with_feature("organizations:slack-sdk-action-view-open")
     def test_archive_issue_until_condition_met_through_unfurl_sdk(self):
         original_message = self.get_original_message(self.group.id)
         payload_data = self.get_unfurl_data(original_message["blocks"])
@@ -419,7 +414,6 @@ class StatusActionTest(BaseEventTest, PerformanceIssueTestCase, HybridCloudTestM
         assert blocks[2]["text"]["text"].endswith(expect_status)
 
     @responses.activate
-    @with_feature("organizations:slack-sdk-action-view-open")
     def test_archive_issue_forever_with_sdk(self):
         original_message = self.get_original_message(self.group.id)
         self.archive_issue_sdk(original_message, "ignored:archived_forever")
@@ -436,7 +430,6 @@ class StatusActionTest(BaseEventTest, PerformanceIssueTestCase, HybridCloudTestM
 
     @responses.activate
     @patch("sentry.models.organization.Organization.has_access", return_value=False)
-    @with_feature("organizations:slack-sdk-action-view-open")
     def test_archive_issue_forever_error_sdk(self, mock_access):
         original_message = self.get_original_message(self.group.id)
 
@@ -451,7 +444,6 @@ class StatusActionTest(BaseEventTest, PerformanceIssueTestCase, HybridCloudTestM
         assert self.group.substatus == GroupSubStatus.ONGOING
 
     @responses.activate
-    @with_feature("organizations:slack-sdk-action-view-open")
     def test_archive_issue_forever_through_unfurl_sdk(self):
         original_message = self.get_original_message(self.group.id)
         payload_data = self.get_unfurl_data(original_message["blocks"])
@@ -468,7 +460,6 @@ class StatusActionTest(BaseEventTest, PerformanceIssueTestCase, HybridCloudTestM
         assert blocks[2]["text"]["text"].endswith(expect_status)
 
     @responses.activate
-    @with_feature("organizations:slack-sdk-action-view-open")
     def test_archive_issue_with_additional_user_auth_sdk(self):
         """
         Ensure that we can act as a user even when the organization has SSO enabled
@@ -493,7 +484,6 @@ class StatusActionTest(BaseEventTest, PerformanceIssueTestCase, HybridCloudTestM
         assert blocks[2]["text"]["text"].endswith(expect_status)
 
     @responses.activate
-    @with_feature("organizations:slack-sdk-action-view-open")
     def test_archive_issue_with_additional_user_auth_through_unfurl_sdk(self):
         """
         Ensure that we can act as a user even when the organization has SSO enabled
@@ -565,7 +555,6 @@ class StatusActionTest(BaseEventTest, PerformanceIssueTestCase, HybridCloudTestM
         assert blocks[2]["text"]["text"].endswith(expect_status)
 
     @responses.activate
-    @with_feature("organizations:slack-sdk-action-view-open")
     def test_resolve_issue(self):
         original_message = self.get_original_message(self.group.id)
         self.resolve_issue_sdk(original_message, "resolved")
@@ -582,7 +571,6 @@ class StatusActionTest(BaseEventTest, PerformanceIssueTestCase, HybridCloudTestM
         assert ":white_circle:" in blocks[0]["text"]["text"]
 
     @responses.activate
-    @with_feature("organizations:slack-sdk-action-view-open")
     def test_resolve_perf_issue_sdk(self):
         group_fingerprint = f"{PerformanceNPlusOneGroupType.type_id}-group1"
 
@@ -609,31 +597,12 @@ class StatusActionTest(BaseEventTest, PerformanceIssueTestCase, HybridCloudTestM
         expect_status = f"*Issue resolved by <@{self.external_id}>*"
         assert (
             "db - SELECT `books_author`.`id`, `books_author`.`name` FROM `books_author` WHERE `books_author`.`id` = %s LIMIT 21"
-            in update_data["blocks"][2]["text"]["text"]
+            in blocks[2]["text"]["text"]
         )
-        assert update_data["blocks"][3]["text"]["text"] == expect_status
-        assert (
-            ":white_circle: :chart_with_upwards_trend:" in update_data["blocks"][0]["text"]["text"]
-        )
+        assert blocks[3]["text"]["text"] == expect_status
+        assert ":white_circle: :chart_with_upwards_trend:" in blocks[0]["text"]["text"]
 
     @responses.activate
-    def test_resolve_issue_through_unfurl(self):
-        original_message = self.get_original_message(self.group.id)
-        payload_data = self.get_unfurl_data(original_message["blocks"])
-        self.resolve_issue(original_message, "resolved", payload_data)
-
-        self.group = Group.objects.get(id=self.group.id)
-        assert self.group.get_status() == GroupStatus.RESOLVED
-        assert not GroupResolution.objects.filter(group=self.group)
-
-        update_data = orjson.loads(responses.calls[1].request.body)
-
-        expect_status = f"*Issue resolved by <@{self.external_id}>*"
-        assert self.notification_text in update_data["blocks"][1]["text"]["text"]
-        assert update_data["blocks"][2]["text"]["text"] == expect_status
-
-    @responses.activate
-    @with_feature("organizations:slack-sdk-action-view-open")
     def test_resolve_issue_through_unfurl_sdk(self):
         original_message = self.get_original_message(self.group.id)
         payload_data = self.get_unfurl_data(original_message["blocks"])
@@ -650,7 +619,6 @@ class StatusActionTest(BaseEventTest, PerformanceIssueTestCase, HybridCloudTestM
         assert blocks[2]["text"]["text"] == expect_status
 
     @responses.activate
-    @with_feature("organizations:slack-sdk-action-view-open")
     def test_resolve_issue_in_current_release_sdk(self):
         release = Release.objects.create(
             organization_id=self.organization.id,
@@ -674,7 +642,6 @@ class StatusActionTest(BaseEventTest, PerformanceIssueTestCase, HybridCloudTestM
         assert blocks[2]["text"]["text"].endswith(expect_status)
 
     @responses.activate
-    @with_feature("organizations:slack-sdk-action-view-open")
     def test_resolve_issue_in_current_release_through_unfurl_sdk(self):
         release = Release.objects.create(
             organization_id=self.organization.id,
@@ -699,7 +666,6 @@ class StatusActionTest(BaseEventTest, PerformanceIssueTestCase, HybridCloudTestM
         assert blocks[2]["text"]["text"].endswith(expect_status)
 
     @responses.activate
-    @with_feature("organizations:slack-sdk-action-view-open")
     def test_resolve_in_next_release_sdk(self):
         release = Release.objects.create(
             organization_id=self.organization.id,
@@ -722,7 +688,6 @@ class StatusActionTest(BaseEventTest, PerformanceIssueTestCase, HybridCloudTestM
         assert blocks[2]["text"]["text"].endswith(expect_status)
 
     @responses.activate
-    @with_feature("organizations:slack-sdk-action-view-open")
     def test_resolve_in_next_release_through_unfurl_sdk(self):
         release = Release.objects.create(
             organization_id=self.organization.id,
@@ -758,7 +723,6 @@ class StatusActionTest(BaseEventTest, PerformanceIssueTestCase, HybridCloudTestM
             status_code=200,
         ),
     )
-    @with_feature("organizations:slack-sdk-action-view-open")
     def test_response_differs_on_bot_message_sdk(self, mock_views_open):
         status_action = self.get_archive_status_action()
         original_message = self.get_original_message(self.group.id)
@@ -881,7 +845,6 @@ class StatusActionTest(BaseEventTest, PerformanceIssueTestCase, HybridCloudTestM
         )
 
     @responses.activate
-    @with_feature("organizations:slack-sdk-action-view-open")
     @patch(
         "slack_sdk.web.WebClient.views_open",
         return_value=SlackResponse(
@@ -953,7 +916,6 @@ class StatusActionTest(BaseEventTest, PerformanceIssueTestCase, HybridCloudTestM
         )
 
     @freeze_time("2021-01-14T12:27:28.303Z")
-    @with_feature("organizations:slack-sdk-action-view-open")
     @patch(
         "slack_sdk.web.WebClient.views_open",
         return_value=SlackResponse(
@@ -1022,7 +984,6 @@ class StatusActionTest(BaseEventTest, PerformanceIssueTestCase, HybridCloudTestM
         )
 
     @freeze_time("2021-01-14T12:27:28.303Z")
-    @with_feature("organizations:slack-sdk-action-view-open")
     @patch(
         "slack_sdk.web.WebClient.views_open",
         return_value=SlackResponse(


### PR DESCRIPTION
We GA'ed culprit blocks in our slack notifications, so i am cleaning up tests and code here. 