### PR TITLE
fix(minimetrics): skip span attribute attach if there is no span

### DIFF
--- a/src/sentry/metrics/minimetrics.py
+++ b/src/sentry/metrics/minimetrics.py
@@ -119,18 +119,10 @@ def _set_metric_on_span(key: str, value: float | int, op: str, tags: Tags | None
         return
 
     scope = sentry_sdk.Scope.get_current_scope()
-
     span_or_tx = getattr(scope, "_span", None)
 
-    if not span_or_tx:
-        with scope.start_transaction(op=f"minimetrics.{op}"):
-            with scope.start_span(op=f"minimetrics.{op}") as span:
-                return _add_metric_data_to_span(span, key, value, tags)
-    elif span_or_tx.parent_span_id is not None:
+    if span_or_tx and span_or_tx.parent_span_id is not None:
         return _add_metric_data_to_span(span_or_tx, key, value, tags)
-    else:
-        with scope.start_span(op=f"minimetrics.{op}") as span:
-            return _add_metric_data_to_span(span, key, value, tags)
 
 
 def _add_metric_data_to_span(

--- a/tests/sentry/metrics/test_minimetrics.py
+++ b/tests/sentry/metrics/test_minimetrics.py
@@ -375,17 +375,20 @@ def test_to_minimetrics_unit(unit, default, expected_result):
         "delightful_metrics.enable_code_locations": True,
     }
 )
-def test_span_attribute_is_correctly_if_no_transaction_exists(backend, scope):
+@override_options(
+    {
+        "delightful_metrics.enable_capture_envelope": True,
+        "delightful_metrics.enable_common_tags": True,
+        "delightful_metrics.enable_span_attributes": True,
+        "delightful_metrics.enable_code_locations": True,
+    }
+)
+def test_span_attributes_if_there_is_no_active_span(backend, scope):
     backend.incr(key="metric_withspan", tags={"x": "bar"})
     full_flush(scope)
 
     spans = scope.client.transport.get_spans()
-
-    assert len(spans) == 1
-    span = spans[0]
-    assert span["op"] == "minimetrics.incr"
-    assert span["tags"] == {"x": "bar"}
-    assert span["data"]["metric_withspan"] == 1
+    assert not spans
 
 
 @override_options(
@@ -396,29 +399,7 @@ def test_span_attribute_is_correctly_if_no_transaction_exists(backend, scope):
         "delightful_metrics.enable_code_locations": True,
     }
 )
-def test_span_attribute_is_correctly_if_no_span_exists(backend, scope):
-    with scope.start_transaction():
-        backend.incr(key="metric_withspan", tags={"x": "bar"})
-        full_flush(scope)
-
-    spans = scope.client.transport.get_spans()
-
-    assert len(spans) == 1
-    span = spans[0]
-    assert span["op"] == "minimetrics.incr"
-    assert span["tags"] == {"x": "bar"}
-    assert span["data"]["metric_withspan"] == 1
-
-
-@override_options(
-    {
-        "delightful_metrics.enable_capture_envelope": True,
-        "delightful_metrics.enable_common_tags": True,
-        "delightful_metrics.enable_span_attributes": True,
-        "delightful_metrics.enable_code_locations": True,
-    }
-)
-def test_span_attribute_is_correctly_if_span_exists(backend, scope):
+def test_span_attribute_is_attached_if_span_exists(backend, scope):
     with scope.start_transaction():
         with scope.start_span(op="test.incr"):
             backend.incr(key="metric_withspan", tags={"x": "bar"})


### PR DESCRIPTION
- closes #73930 
- removes code paths that created transactions/spans and just uses the current active span if one exists
