### PR TITLE
ref(proguard): Deobfuscate view hierarchies as part of symbolication

### DIFF
--- a/src/sentry/lang/java/plugin.py
+++ b/src/sentry/lang/java/plugin.py
@@ -19,6 +19,6 @@ class JavaPlugin(Plugin2):
 
     def get_event_preprocessors(self, data: Mapping[str, Any]) -> Sequence[EventPreprocessor]:
         if has_proguard_file(data):
-            return [deobfuscate_exception_value, deobfuscate_view_hierarchy]
+            return [deobfuscate_exception_value]
         else:
             return []

--- a/src/sentry/lang/java/plugin.py
+++ b/src/sentry/lang/java/plugin.py
@@ -4,7 +4,7 @@ from collections.abc import Mapping, Sequence
 from typing import Any
 
 from sentry.lang.java.processing import deobfuscate_exception_value
-from sentry.lang.java.utils import deobfuscate_view_hierarchy, has_proguard_file
+from sentry.lang.java.utils import has_proguard_file
 from sentry.plugins.base.v2 import EventPreprocessor, Plugin2
 
 

--- a/src/sentry/lang/java/processing.py
+++ b/src/sentry/lang/java/processing.py
@@ -176,8 +176,11 @@ def _deobfuscate_view_hierarchy(view_hierarchy: Any, class_names: dict[str, str]
 
     while windows_to_deobfuscate:
         window = windows_to_deobfuscate.pop()
-        if window.get("type") is not None and class_names.get(window["type"]) is not None:
-            window["type"] = class_names.get(window["type"])
+        if (
+            window.get("type") is not None
+            and (mapped_type := class_names.get(window["type"])) is not None
+        ):
+            window["type"] = mapped_type
         if children := window.get("children"):
             windows_to_deobfuscate.extend(children)
 

--- a/src/sentry/lang/java/processing.py
+++ b/src/sentry/lang/java/processing.py
@@ -144,7 +144,10 @@ def _get_release_package(project: Project, release_name: str | None) -> str | No
     return release.package if release else None
 
 
-def _get_window_class_names(attachments: list[any]) -> list[str]:
+def _get_window_class_names(attachments: list[CachedAttachment]) -> list[str]:
+    """Returns the class names of all windows in all view hierarchies
+    contained in `attachments`."""
+
     class_names = []
     windows_to_deobfuscate = []
 
@@ -163,7 +166,12 @@ def _get_window_class_names(attachments: list[any]) -> list[str]:
     return class_names
 
 
-def _deobfuscate_view_hierarchy(view_hierarchy: Any, class_names: dict[str, str]):
+def _deobfuscate_view_hierarchy(view_hierarchy: Any, class_names: dict[str, str]) -> None:
+    """Deobfuscates a view hierarchy in-place.
+
+    The `class_names` dict is used to resolve obfuscated to deobfuscated names. If
+    an obfuscated class name isn't present in `class_names`, it is left unchanged."""
+
     windows_to_deobfuscate = [*view_hierarchy.get("windows")]
 
     while windows_to_deobfuscate:
@@ -174,7 +182,13 @@ def _deobfuscate_view_hierarchy(view_hierarchy: Any, class_names: dict[str, str]
             windows_to_deobfuscate.extend(children)
 
 
-def _deobfuscate_view_hierarchies(attachments: list[Any], class_names: dict[str, str]) -> list[Any]:
+def _deobfuscate_view_hierarchies(
+    attachments: list[CachedAttachment], class_names: dict[str, str]
+) -> list[CachedAttachment]:
+    """Deobfuscates all view hierarchies contained in `attachments`, returning a new list of attachments.
+
+    Non-view-hierarchy attachments are unchanged.
+    """
     new_attachments = []
     for attachment in attachments:
         if attachment.type == "event.view_hierarchy":
@@ -276,7 +290,7 @@ def process_jvm_stacktraces(symbolicator: Symbolicator, data: Any) -> Any:
         stacktraces=stacktraces,
         modules=modules,
         release_package=release_package,
-        class_names=window_class_names,
+        classes=window_class_names,
     )
 
     if not _handle_response_status(data, response):

--- a/src/sentry/lang/java/utils.py
+++ b/src/sentry/lang/java/utils.py
@@ -70,31 +70,6 @@ def get_proguard_mapper(uuid: str, project: Project):
     return mapper
 
 
-def _deobfuscate_view_hierarchy(event_data: dict[str, Any], project: Project, view_hierarchy):
-    """
-    Deobfuscates a view hierarchy in-place.
-
-    If we're unable to fetch a ProGuard uuid or unable to init the mapper,
-    then the view hierarchy remains unmodified.
-    """
-    proguard_uuids = get_proguard_images(event_data)
-    if len(proguard_uuids) == 0:
-        return
-
-    with sentry_sdk.start_span(op="proguard.deobfuscate_view_hierarchy_data"):
-        for proguard_uuid in proguard_uuids:
-            mapper = get_proguard_mapper(proguard_uuid, project)
-            if mapper is None:
-                return
-
-            windows_to_deobfuscate = [*view_hierarchy.get("windows")]
-            while windows_to_deobfuscate:
-                window = windows_to_deobfuscate.pop()
-                window["type"] = mapper.remap_class(window.get("type")) or window.get("type")
-                if children := window.get("children"):
-                    windows_to_deobfuscate.extend(children)
-
-
 @sentry_sdk.trace
 def deobfuscation_template(data, map_type, deobfuscation_fn):
     """
@@ -131,10 +106,6 @@ def deobfuscation_template(data, map_type, deobfuscation_fn):
             new_attachments.append(attachment)
 
     attachment_cache.set(cache_key, attachments=new_attachments, timeout=CACHE_TIMEOUT)
-
-
-def deobfuscate_view_hierarchy(data):
-    deobfuscation_template(data, "proguard", _deobfuscate_view_hierarchy)
 
 
 def is_jvm_event(data: Any, stacktraces: list[StacktraceInfo]) -> bool:

--- a/src/sentry/lang/java/utils.py
+++ b/src/sentry/lang/java/utils.py
@@ -149,9 +149,13 @@ def is_jvm_event(data: Any, stacktraces: list[StacktraceInfo]) -> bool:
         filter=lambda x: is_valid_jvm_image(x) or is_valid_proguard_image(x),
         default=(),
     )
-    if not images:
+    print(f"images: {images}\n")
+    if images:
+        return True
+    else:
         return False
 
+    print("platform: ", data.get("platform"))
     if data.get("platform") == "java":
         return True
 

--- a/src/sentry/lang/java/utils.py
+++ b/src/sentry/lang/java/utils.py
@@ -149,13 +149,11 @@ def is_jvm_event(data: Any, stacktraces: list[StacktraceInfo]) -> bool:
         filter=lambda x: is_valid_jvm_image(x) or is_valid_proguard_image(x),
         default=(),
     )
-    print(f"images: {images}\n")
     if images:
         return True
     else:
         return False
 
-    print("platform: ", data.get("platform"))
     if data.get("platform") == "java":
         return True
 

--- a/src/sentry/lang/native/symbolicator.py
+++ b/src/sentry/lang/native/symbolicator.py
@@ -241,6 +241,7 @@ class Symbolicator:
         stacktraces,
         modules,
         release_package,
+        class_names,
         apply_source_context=True,
     ):
         """
@@ -262,6 +263,7 @@ class Symbolicator:
             "exceptions": exceptions,
             "stacktraces": stacktraces,
             "modules": modules,
+            "class_names": class_names,
             "options": {"apply_source_context": apply_source_context},
         }
 

--- a/src/sentry/lang/native/symbolicator.py
+++ b/src/sentry/lang/native/symbolicator.py
@@ -241,7 +241,7 @@ class Symbolicator:
         stacktraces,
         modules,
         release_package,
-        class_names,
+        classes,
         apply_source_context=True,
     ):
         """
@@ -263,7 +263,7 @@ class Symbolicator:
             "exceptions": exceptions,
             "stacktraces": stacktraces,
             "modules": modules,
-            "class_names": class_names,
+            "classes": classes,
             "options": {"apply_source_context": apply_source_context},
         }
 

--- a/src/sentry/profiles/task.py
+++ b/src/sentry/profiles/task.py
@@ -489,6 +489,7 @@ def symbolicate(
             modules=modules,
             release_package=profile.get("transaction_metadata", {}).get("app.identifier"),
             apply_source_context=False,
+            classes=[],
         )
     return symbolicator.process_payload(
         stacktraces=stacktraces, modules=modules, apply_source_context=False

--- a/src/sentry/tasks/store.py
+++ b/src/sentry/tasks/store.py
@@ -162,6 +162,7 @@ def _do_preprocess_event(
     # one after the other, so we handle mixed stacktraces.
     stacktraces = find_stacktraces_in_data(data)
     symbolicate_platforms = get_symbolication_platforms(data, stacktraces)
+    print(f"symbolicate platforms: {symbolicate_platforms}\n")
     should_symbolicate = len(symbolicate_platforms) > 0
     if should_symbolicate:
         first_platform = symbolicate_platforms.pop(0)

--- a/src/sentry/tasks/store.py
+++ b/src/sentry/tasks/store.py
@@ -162,7 +162,6 @@ def _do_preprocess_event(
     # one after the other, so we handle mixed stacktraces.
     stacktraces = find_stacktraces_in_data(data)
     symbolicate_platforms = get_symbolication_platforms(data, stacktraces)
-    print(f"symbolicate platforms: {symbolicate_platforms}\n")
     should_symbolicate = len(symbolicate_platforms) > 0
     if should_symbolicate:
         first_platform = symbolicate_platforms.pop(0)

--- a/src/sentry/tasks/symbolication.py
+++ b/src/sentry/tasks/symbolication.py
@@ -109,7 +109,7 @@ def get_symbolication_platforms(
 
     platforms = []
 
-    if is_jvm_event(data, stacktraces):
+    if is_jvm_event(data):
         platforms.append(SymbolicatorPlatform.jvm)
     if is_js_event(data, stacktraces):
         platforms.append(SymbolicatorPlatform.js)

--- a/src/sentry/tasks/symbolication.py
+++ b/src/sentry/tasks/symbolication.py
@@ -104,6 +104,7 @@ def get_symbolication_platforms(
     """Returns a list of Symbolicator platforms
     that apply to this event."""
 
+    print("get_symbolication_platforms\n")
     from sentry.lang.java.utils import is_jvm_event
     from sentry.lang.javascript.utils import is_js_event
 
@@ -203,6 +204,7 @@ def _do_symbolicate_event(
         symbolication_function = None
 
     symbolication_function_name = getattr(symbolication_function, "__name__", "none")
+    print("symbolication function:", symbolication_function_name)
 
     if symbolication_function is None or killswitch_matches_context(
         "store.load-shed-symbolicate-event-projects",

--- a/src/sentry/tasks/symbolication.py
+++ b/src/sentry/tasks/symbolication.py
@@ -104,7 +104,6 @@ def get_symbolication_platforms(
     """Returns a list of Symbolicator platforms
     that apply to this event."""
 
-    print("get_symbolication_platforms\n")
     from sentry.lang.java.utils import is_jvm_event
     from sentry.lang.javascript.utils import is_js_event
 
@@ -204,7 +203,6 @@ def _do_symbolicate_event(
         symbolication_function = None
 
     symbolication_function_name = getattr(symbolication_function, "__name__", "none")
-    print("symbolication function:", symbolication_function_name)
 
     if symbolication_function is None or killswitch_matches_context(
         "store.load-shed-symbolicate-event-projects",

--- a/tests/relay_integration/lang/java/test_plugin.py
+++ b/tests/relay_integration/lang/java/test_plugin.py
@@ -1556,7 +1556,6 @@ class BasicResolvingIntegrationTest(RelayStoreHelper, TransactionTestCase):
 
     def test_is_jvm_event(self):
         from sentry.lang.java.utils import is_jvm_event
-        from sentry.stacktraces.processing import find_stacktraces_in_data
 
         event = {
             "user": {"ip_address": "31.172.207.97"},
@@ -1586,8 +1585,7 @@ class BasicResolvingIntegrationTest(RelayStoreHelper, TransactionTestCase):
             },
             "timestamp": iso_format(before_now(seconds=1)),
         }
-        stacktraces = find_stacktraces_in_data(event)
-        assert is_jvm_event(event, stacktraces)
+        assert is_jvm_event(event)
 
         event = {
             "user": {"ip_address": "31.172.207.97"},
@@ -1616,9 +1614,8 @@ class BasicResolvingIntegrationTest(RelayStoreHelper, TransactionTestCase):
             },
             "timestamp": iso_format(before_now(seconds=1)),
         }
-        stacktraces = find_stacktraces_in_data(event)
         # has no platform
-        assert not is_jvm_event(event, stacktraces)
+        assert not is_jvm_event(event)
 
         event = {
             "user": {"ip_address": "31.172.207.97"},
@@ -1648,6 +1645,5 @@ class BasicResolvingIntegrationTest(RelayStoreHelper, TransactionTestCase):
             },
             "timestamp": iso_format(before_now(seconds=1)),
         }
-        stacktraces = find_stacktraces_in_data(event)
         # has no modules
-        assert not is_jvm_event(event, stacktraces)
+        assert not is_jvm_event(event)

--- a/tests/relay_integration/lang/java/test_plugin.py
+++ b/tests/relay_integration/lang/java/test_plugin.py
@@ -1615,7 +1615,7 @@ class BasicResolvingIntegrationTest(RelayStoreHelper, TransactionTestCase):
             "timestamp": iso_format(before_now(seconds=1)),
         }
         # has no platform
-        assert not is_jvm_event(event)
+        assert is_jvm_event(event)
 
         event = {
             "user": {"ip_address": "31.172.207.97"},

--- a/tests/sentry/ingest/ingest_consumer/test_ingest_consumer_processing.py
+++ b/tests/sentry/ingest/ingest_consumer/test_ingest_consumer_processing.py
@@ -30,6 +30,7 @@ from sentry.models.userreport import UserReport
 from sentry.options import set
 from sentry.testutils.pytest.fixtures import django_db_all
 from sentry.testutils.skips import requires_snuba
+from sentry.testutils.skips import requires_symbolicator
 from sentry.usage_accountant import accountant
 from sentry.utils.eventuser import EventUser
 from sentry.utils.json import loads
@@ -324,6 +325,8 @@ def test_with_attachments(default_project, task_runner, missing_chunks, monkeypa
 
 
 @django_db_all
+@requires_symbolicator
+@pytest.mark.symbolicator
 def test_deobfuscate_view_hierarchy(default_project, task_runner):
     payload = get_normalized_event(
         {
@@ -397,6 +400,7 @@ def test_deobfuscate_view_hierarchy(default_project, task_runner):
     assert attachment.content_type == "application/json"
     assert attachment.name == "view_hierarchy.json"
     with attachment.getfile() as file:
+        print(file.read())
         assert file.read() == expected_response
 
 

--- a/tests/sentry/ingest/ingest_consumer/test_ingest_consumer_processing.py
+++ b/tests/sentry/ingest/ingest_consumer/test_ingest_consumer_processing.py
@@ -29,8 +29,7 @@ from sentry.models.eventattachment import EventAttachment
 from sentry.models.userreport import UserReport
 from sentry.options import set
 from sentry.testutils.pytest.fixtures import django_db_all
-from sentry.testutils.skips import requires_snuba
-from sentry.testutils.skips import requires_symbolicator
+from sentry.testutils.skips import requires_snuba, requires_symbolicator
 from sentry.usage_accountant import accountant
 from sentry.utils.eventuser import EventUser
 from sentry.utils.json import loads
@@ -327,81 +326,81 @@ def test_with_attachments(default_project, task_runner, missing_chunks, monkeypa
 @django_db_all
 @requires_symbolicator
 @pytest.mark.symbolicator
-def test_deobfuscate_view_hierarchy(default_project, task_runner):
-    payload = get_normalized_event(
-        {
-            "message": "hello world",
-            "debug_meta": {"images": [{"uuid": PROGUARD_UUID, "type": "proguard"}]},
-        },
-        default_project,
-    )
-    event_id = payload["event_id"]
-    attachment_id = "ca90fb45-6dd9-40a0-a18f-8693aa621abb"
-    project_id = default_project.id
-    start_time = time.time() - 3600
-
-    # Create the proguard file
-    with zipfile.ZipFile(BytesIO(), "w") as f:
-        f.writestr(f"proguard/{PROGUARD_UUID}.txt", PROGUARD_SOURCE)
-        create_files_from_dif_zip(f, project=default_project)
-
-    expected_response = b'{"rendering_system":"Test System","windows":[{"identifier":"parent","type":"org.slf4j.helpers.Util$ClassContextSecurityManager","children":[{"identifier":"child","type":"org.slf4j.helpers.Util$ClassContextSecurityManager"}]}]}'
-    obfuscated_view_hierarchy = {
-        "rendering_system": "Test System",
-        "windows": [
+def test_deobfuscate_view_hierarchy(default_project, task_runner, set_sentry_option, live_server):
+    with set_sentry_option("system.url-prefix", live_server.url):
+        payload = get_normalized_event(
             {
-                "identifier": "parent",
-                "type": "org.a.b.g$a",
-                "children": [
-                    {
-                        "identifier": "child",
-                        "type": "org.a.b.g$a",
-                    }
-                ],
-            }
-        ],
-    }
+                "message": "hello world",
+                "debug_meta": {"images": [{"uuid": PROGUARD_UUID, "type": "proguard"}]},
+            },
+            default_project,
+        )
+        event_id = payload["event_id"]
+        attachment_id = "ca90fb45-6dd9-40a0-a18f-8693aa621abb"
+        project_id = default_project.id
+        start_time = time.time() - 3600
 
-    process_attachment_chunk(
-        {
-            "payload": orjson.dumps(obfuscated_view_hierarchy),
-            "event_id": event_id,
-            "project_id": project_id,
-            "id": attachment_id,
-            "chunk_index": 0,
+        # Create the proguard file
+        with zipfile.ZipFile(BytesIO(), "w") as f:
+            f.writestr(f"proguard/{PROGUARD_UUID}.txt", PROGUARD_SOURCE)
+            create_files_from_dif_zip(f, project=default_project)
+
+        expected_response = b'{"rendering_system":"Test System","windows":[{"identifier":"parent","type":"org.slf4j.helpers.Util$ClassContextSecurityManager","children":[{"identifier":"child","type":"org.slf4j.helpers.Util$ClassContextSecurityManager"}]}]}'
+        obfuscated_view_hierarchy = {
+            "rendering_system": "Test System",
+            "windows": [
+                {
+                    "identifier": "parent",
+                    "type": "org.a.b.g$a",
+                    "children": [
+                        {
+                            "identifier": "child",
+                            "type": "org.a.b.g$a",
+                        }
+                    ],
+                }
+            ],
         }
-    )
 
-    with task_runner():
-        process_event(
+        process_attachment_chunk(
             {
-                "payload": orjson.dumps(payload).decode(),
-                "start_time": start_time,
+                "payload": orjson.dumps(obfuscated_view_hierarchy),
                 "event_id": event_id,
                 "project_id": project_id,
-                "remote_addr": "127.0.0.1",
-                "attachments": [
-                    {
-                        "id": attachment_id,
-                        "name": "view_hierarchy.json",
-                        "content_type": "application/json",
-                        "attachment_type": "event.view_hierarchy",
-                        "chunks": 1,
-                    }
-                ],
-            },
-            project=default_project,
+                "id": attachment_id,
+                "chunk_index": 0,
+            }
         )
 
-    persisted_attachments = list(
-        EventAttachment.objects.filter(project_id=project_id, event_id=event_id)
-    )
-    (attachment,) = persisted_attachments
-    assert attachment.content_type == "application/json"
-    assert attachment.name == "view_hierarchy.json"
-    with attachment.getfile() as file:
-        print(file.read())
-        assert file.read() == expected_response
+        with task_runner():
+            process_event(
+                {
+                    "payload": orjson.dumps(payload).decode(),
+                    "start_time": start_time,
+                    "event_id": event_id,
+                    "project_id": project_id,
+                    "remote_addr": "127.0.0.1",
+                    "attachments": [
+                        {
+                            "id": attachment_id,
+                            "name": "view_hierarchy.json",
+                            "content_type": "application/json",
+                            "attachment_type": "event.view_hierarchy",
+                            "chunks": 1,
+                        }
+                    ],
+                },
+                project=default_project,
+            )
+
+        persisted_attachments = list(
+            EventAttachment.objects.filter(project_id=project_id, event_id=event_id)
+        )
+        (attachment,) = persisted_attachments
+        assert attachment.content_type == "application/json"
+        assert attachment.name == "view_hierarchy.json"
+        with attachment.getfile() as file:
+            assert file.read() == expected_response
 
 
 @django_db_all


### PR DESCRIPTION
Depends on https://github.com/getsentry/symbolicator/pull/1496.

This moves view hierarchy deobfuscation out of the plugin/preprocessor and into symbolication. That allows us to remove proguard processing from Sentry entirely and only have it in Symbolicator.

Since this means we would potentially want to send JVM events to Symbolicator that don't have exceptions or stacktraces, we have to be more lenient when detecting such events (see the change to `is_jvm_event`). I don't think this presents a problem—we still check if the event contains anything that needs to be symbolicated before we actually send it.

~The bigger problem is that merely modifying the `attachment_cache` the way I'm doing right now doesn't appear to be enough to actually save the modified attachment. The current code where that happens in the preprocessor does just that, but I assume there is some point where the cache is persisted that we don't hit if we do this in symbolication. I need to understand this better.~ This was due to some trivial mistake or other that got fixed along the way.