### PR TITLE
feat(auto-import): Enable default vscode auto-import for Sentry BE

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -102,5 +102,8 @@
   "python.testing.pytestEnabled": true,
   "python.testing.unittestEnabled": false,
   "python.testing.pytestPath": "${workspaceFolder}/.venv/bin/pytest",
-  "python.testing.pytestArgs": ["tests"]
+  "python.testing.pytestArgs": [
+    "tests"
+  ],
+  "python.analysis.autoImportCompletions": true
 }


### PR DESCRIPTION
This PR turns on the `python.analysis.autoImportCompletions` setting in `.vscode/settings.json`, enabling auto-import functionality for Python files in Sentry. 