### PR TITLE
ref(proguard): Remove separate queue

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -866,7 +866,6 @@ CELERY_QUEUES_REGION = [
     Queue("email.inbound", routing_key="email.inbound"),
     Queue("events.preprocess_event", routing_key="events.preprocess_event"),
     Queue("events.process_event", routing_key="events.process_event"),
-    Queue("events.process_event_proguard", routing_key="events.process_event_proguard"),
     Queue(
         "events.reprocessing.preprocess_event", routing_key="events.reprocessing.preprocess_event"
     ),

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -644,15 +644,6 @@ register(
     flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
 )
 
-# The fraction of prooguard events that will be routed to the
-# separate `store.process_event_proguard` queue
-# TODO: Unused, remove this.
-register(
-    "store.separate-proguard-queue-rate",
-    default=0.0,
-    flags=FLAG_AUTOMATOR_MODIFIABLE | FLAG_MODIFIABLE_RATE,
-)
-
 # Query and supply Bundle Indexes to Symbolicator SourceMap processing
 register(
     "symbolicator.sourcemaps-bundle-index-sample-rate", default=0.0, flags=FLAG_AUTOMATOR_MODIFIABLE

--- a/src/sentry/tasks/store.py
+++ b/src/sentry/tasks/store.py
@@ -459,42 +459,6 @@ def process_event(
     )
 
 
-# TODO: Unused, remove this.
-@instrumented_task(
-    name="sentry.tasks.store.process_event_proguard",
-    queue="events.process_event_proguard",
-    time_limit=65,
-    soft_time_limit=60,
-    silo_mode=SiloMode.REGION,
-)
-def process_event_proguard(
-    cache_key: str,
-    start_time: float | None = None,
-    event_id: str | None = None,
-    data_has_changed: bool = False,
-    from_symbolicate: bool = False,
-    has_attachments: bool = False,
-    **kwargs: Any,
-) -> None:
-    """
-    Handles event processing (for those events that need it)
-
-    :param string cache_key: the cache key for the event data
-    :param int start_time: the timestamp when the event was ingested
-    :param string event_id: the event identifier
-    :param boolean data_has_changed: set to True if the event data was changed in previous tasks
-    """
-    return do_process_event(
-        cache_key=cache_key,
-        start_time=start_time,
-        event_id=event_id,
-        from_reprocessing=False,
-        data_has_changed=data_has_changed,
-        from_symbolicate=from_symbolicate,
-        has_attachments=has_attachments,
-    )
-
-
 @instrumented_task(
     name="sentry.tasks.store.process_event_from_reprocessing",
     queue="events.reprocessing.process_event",


### PR DESCRIPTION
We stopped routing events to the `process_event_proguard` task (and therefore the `events.process_event_proguard` queue) in https://github.com/getsentry/sentry/pull/74075. The `store.separate-proguard-queue-rate` option was removed from the options automator in https://github.com/getsentry/sentry-options-automator/pull/1895.