### PR TITLE
fix(query-builder): Fix issue with multiple menus being open at once

### DIFF
--- a/static/app/components/searchQueryBuilder/combobox.tsx
+++ b/static/app/components/searchQueryBuilder/combobox.tsx
@@ -521,6 +521,7 @@ function SearchQueryBuilderComboboxInner<T extends SelectOptionOrSectionWithKey<
 
   const state = useComboBoxState<T>({
     children,
+    allowsEmptyCollection: true,
     // We handle closing on blur ourselves to prevent the combobox from closing
     // when the user clicks inside the tabbed menu
     shouldCloseOnBlur: false,


### PR DESCRIPTION
Another small fix - when adding a key that does not exist in the menu, two menus could show simultaneously. Adding `allowsEmptyCollection: true` fixes this. We already handle hiding the menu when there are no items, so `useComboboxState()` actually ends up hurting us here with that config being off.