### PR TITLE
feat(grouping): Method to upgrade deprecated configs

### DIFF
--- a/src/sentry/grouping/ingest/config.py
+++ b/src/sentry/grouping/ingest/config.py
@@ -38,9 +38,9 @@ def _project_should_update_grouping(project: Project) -> bool:
     should_update_org = (
         project.organization_id % 1000 < float(settings.SENTRY_GROUPING_AUTO_UPDATE_ENABLED) * 1000
     )
-    deprecated_config = project.get_option("sentry:grouping_config") in CONFIGS_TO_DEPRECATE
+    is_deprecated_config = project.get_option("sentry:grouping_config") in CONFIGS_TO_DEPRECATE
     auto_update = bool(project.get_option("sentry:grouping_auto_update"))
-    return deprecated_config or (auto_update and should_update_org)
+    return is_deprecated_config or (auto_update and should_update_org)
 
 
 def _config_update_happened_recently(project: Project, tolerance: int) -> bool:

--- a/src/sentry/grouping/ingest/config.py
+++ b/src/sentry/grouping/ingest/config.py
@@ -18,7 +18,7 @@ logger = logging.getLogger("sentry.events.grouping")
 Job = MutableMapping[str, Any]
 
 # We are moving all projects off these configuration without waiting for events
-CONFIGS_TO_DEPRECATE = []
+CONFIGS_TO_DEPRECATE: list[str] = []
 
 
 def upgrade_deprecated_configs():

--- a/src/sentry/grouping/ingest/config.py
+++ b/src/sentry/grouping/ingest/config.py
@@ -85,7 +85,7 @@ def _auto_update_grouping(project: Project) -> None:
             "sentry:grouping_config": new_config,
         }
         # Any project on deprecated configs may be there only because auto updates are
-        # disabled (not because they want to use that specific config). This will reduce the 
+        # disabled (not because they want to use that specific config). This will reduce the
         # chance of that happening unintentionally.
         if current_config in CONFIGS_TO_DEPRECATE:
             changes["sentry:grouping_auto_update"] = True

--- a/src/sentry/grouping/ingest/config.py
+++ b/src/sentry/grouping/ingest/config.py
@@ -84,8 +84,9 @@ def _auto_update_grouping(project: Project) -> None:
             "sentry:secondary_grouping_expiry": expiry,
             "sentry:grouping_config": new_config,
         }
-        # Any project on deprecated configs may have disabled auto updates and
-        # this will reduce the chance of happening unintentionally.
+        # Any project on deprecated configs may be there only because auto updates are
+        # disabled (not because they want to use that specific config). This will reduce the 
+        # chance of that happening unintentionally.
         if current_config in CONFIGS_TO_DEPRECATE:
             changes["sentry:grouping_auto_update"] = True
 

--- a/src/sentry/grouping/ingest/config.py
+++ b/src/sentry/grouping/ingest/config.py
@@ -21,14 +21,6 @@ Job = MutableMapping[str, Any]
 CONFIGS_TO_DEPRECATE: list[str] = []
 
 
-def upgrade_deprecated_configs():
-    queryset = Project.objects.filter(
-        projectoption__key="sentry:grouping_config", projectoption__value__in=CONFIGS_TO_DEPRECATE
-    )
-    for project in queryset:
-        _auto_update_grouping(project)
-
-
 def update_grouping_config_if_needed(project: Project) -> None:
     if _project_should_update_grouping(project):
         _auto_update_grouping(project)

--- a/tests/sentry/event_manager/test_event_manager_grouping.py
+++ b/tests/sentry/event_manager/test_event_manager_grouping.py
@@ -12,7 +12,7 @@ from sentry import audit_log
 from sentry.conf.server import SENTRY_GROUPING_UPDATE_MIGRATION_PHASE
 from sentry.event_manager import _get_updated_group_title
 from sentry.eventtypes.base import DefaultEvent
-from sentry.grouping.ingest.config import upgrade_deprecated_configs
+from sentry.grouping.ingest.config import update_grouping_config_if_needed
 from sentry.grouping.result import CalculatedHashes
 from sentry.models.auditlogentry import AuditLogEntry
 from sentry.models.group import Group
@@ -187,7 +187,7 @@ class EventManagerGroupingTest(TestCase):
         self.project.update_option("sentry:grouping_auto_update", False)
 
         with override_settings(SENTRY_GROUPING_AUTO_UPDATE_ENABLED=True):
-            upgrade_deprecated_configs()
+            update_grouping_config_if_needed(self.project)
             # Nothing changes
             assert self.project.get_option("sentry:grouping_config") == "mobile:2021-02-12"
             assert self.project.get_option("sentry:grouping_auto_update") is False
@@ -197,7 +197,7 @@ class EventManagerGroupingTest(TestCase):
                 "sentry.grouping.ingest.config.CONFIGS_TO_DEPRECATE",
                 new=["mobile:2021-02-12"],
             ):
-                upgrade_deprecated_configs()
+                update_grouping_config_if_needed(self.project)
                 # Even though auto update is disabled we have upgraded the project
                 assert self.project.get_option("sentry:grouping_config") == DEFAULT_GROUPING_CONFIG
                 # We have also updated the auto_update option


### PR DESCRIPTION
This will allow upgrading projects with a grouping configuration marked as deprecated. The project will also get the auto updates config set to `True` to prevent them from falling behind.

This [PR](https://github.com/getsentry/getsentry/pull/14616) is to run the upgrades.