### PR TITLE
fix(issues): Only inspect in-app frames for ownership

### DIFF
--- a/src/sentry/ownership/grammar.py
+++ b/src/sentry/ownership/grammar.py
@@ -121,7 +121,7 @@ class Matcher(namedtuple("Matcher", "type pattern")):
         keys = ["filename", "abs_path"]
         platform = data.get("platform")
         sdk_name = get_sdk_name(data)
-        frames = find_stack_frames(data)
+        frames = _find_in_app_stack_frames(data)
         if platform:
             munged = munged_filename_and_frames(platform, frames, "munged_filename", sdk_name)
             if munged:
@@ -204,6 +204,10 @@ class Matcher(namedtuple("Matcher", "type pattern")):
             ):
                 return True
         return False
+
+
+def _find_in_app_stack_frames(data: PathSearchable) -> Sequence[Mapping[str, Any]]:
+    return [frame for frame in find_stack_frames(data) if frame.get("in_app", True)]
 
 
 class Owner(namedtuple("Owner", "type identifier")):

--- a/tests/sentry/ownership/test_grammar.py
+++ b/tests/sentry/ownership/test_grammar.py
@@ -346,8 +346,8 @@ def test_matcher_test_platform_react_native():
     assert Matcher("codeowners", "*.tsx").test(data)
     assert not Matcher("url", "*.tsx").test(data)
 
-    # external lib matching still works
-    assert Matcher("path", "**/Libraries/BatchedBridge/MessageQueue.js").test(data)
+    # external lib should not match
+    assert not Matcher("path", "**/Libraries/BatchedBridge/MessageQueue.js").test(data)
 
     # we search on filename and abs_path, if a user explicitly tests on the abs_path, we let them
     assert Matcher("path", "app:///src/screens/EndToEndTestsScreen.tsx").test(data)
@@ -415,8 +415,8 @@ def test_matcher_test_platform_other_flutter():
     assert Matcher("codeowners", "*.dart").test(data)
     assert not Matcher("url", "*.dart").test(data)
 
-    # non in-app/user code still works here,
-    assert Matcher("path", "src/material/ink_well.dart").test(data)
+    # non in-app/user code should not match
+    assert not Matcher("path", "src/material/ink_well.dart").test(data)
 
     # we search on filename and abs_path, if a user explicitly tests on the abs_path, we let them
     assert Matcher("path", "package:sentry_flutter_example/a/b/test.dart").test(data)


### PR DESCRIPTION
https://docs.sentry.io/product/issues/ownership-rules/#evaluation-flow

TODO: This change needs to be feature flagged for rollout since it has a wide potential impact.