### PR TITLE
feat(uptime): Handle miss results in the uptime result consumer

### DIFF
--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -3242,13 +3242,15 @@ class MonitorIngestTestCase(MonitorTestCase):
 
 
 class UptimeTestCase(TestCase):
-    def create_uptime_result(self, subscription_id: str | None = None) -> CheckResult:
+    def create_uptime_result(
+        self, subscription_id: str | None = None, status: str = CHECKSTATUS_FAILURE
+    ) -> CheckResult:
         if subscription_id is None:
             subscription_id = uuid.uuid4().hex
         return {
             "guid": uuid.uuid4().hex,
             "subscription_id": subscription_id,
-            "status": CHECKSTATUS_FAILURE,
+            "status": status,
             "status_reason": {"type": CHECKSTATUSREASONTYPE_TIMEOUT, "description": "it timed out"},
             "trace_id": uuid.uuid4().hex,
             "scheduled_check_time_ms": int(


### PR DESCRIPTION
This implements handling for misses in the uptime result consumer. We don't take any action on a miss - we just record stats and log information for debugging
