### PR TITLE
fix(traces): fix capitalization in trace view

### DIFF
--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/transaction/sections/breadCrumbs.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/transaction/sections/breadCrumbs.tsx
@@ -43,7 +43,7 @@ export function BreadCrumbs({
         showPermalink={false}
         key={'breadcrumbs'}
         type={'breadcrumbs'}
-        title={t('BreadCrumbs')}
+        title={t('Breadcrumbs')}
         help={tct(
           'The trail of events that happened prior to an event. [link:Learn more]',
           {


### PR DESCRIPTION
this pr fixes the capitalization of "BreadCrumbs" -> "Breadcrumbs" to align it with the rest of Sentry