### PR TITLE
fix(query-builder): Prevent filter values from being empty

### DIFF
--- a/static/app/components/searchQueryBuilder/input.tsx
+++ b/static/app/components/searchQueryBuilder/input.tsx
@@ -15,7 +15,10 @@ import type {
 } from 'sentry/components/searchQueryBuilder/types';
 import {useQueryBuilderGridItem} from 'sentry/components/searchQueryBuilder/useQueryBuilderGridItem';
 import {replaceTokensWithPadding} from 'sentry/components/searchQueryBuilder/useQueryBuilderState';
-import {useShiftFocusToChild} from 'sentry/components/searchQueryBuilder/utils';
+import {
+  getDefaultFilterValue,
+  useShiftFocusToChild,
+} from 'sentry/components/searchQueryBuilder/utils';
 import {
   type ParseResultToken,
   Token,
@@ -89,23 +92,17 @@ function getWordAtCursorPosition(value: string, cursorPosition: number) {
 }
 
 function getInitialFilterText(key: string) {
+  const defaultValue = getDefaultFilterValue({key});
+
   const fieldDef = getFieldDefinition(key);
 
-  if (!fieldDef) {
-    return `${key}:`;
-  }
-
-  switch (fieldDef.valueType) {
-    case FieldValueType.BOOLEAN:
-      return `${key}:true`;
+  switch (fieldDef?.valueType) {
     case FieldValueType.INTEGER:
     case FieldValueType.NUMBER:
-      return `${key}:>100`;
-    case FieldValueType.DATE:
-      return `${key}:-24h`;
+      return `${key}:>${defaultValue}`;
     case FieldValueType.STRING:
     default:
-      return `${key}:`;
+      return `${key}:${defaultValue}`;
   }
 }
 

--- a/static/app/components/searchQueryBuilder/utils.tsx
+++ b/static/app/components/searchQueryBuilder/utils.tsx
@@ -19,7 +19,7 @@ import {
 import {t} from 'sentry/locale';
 import type {Tag, TagCollection} from 'sentry/types';
 import {escapeDoubleQuotes} from 'sentry/utils';
-import {FieldValueType, getFieldDefinition} from 'sentry/utils/fields';
+import {FieldKey, FieldValueType, getFieldDefinition} from 'sentry/utils/fields';
 
 export const INTERFACE_TYPE_LOCALSTORAGE_KEY = 'search-query-builder-interface';
 
@@ -198,6 +198,31 @@ export function formatFilterValue(token: TokenResult<Token.FILTER>['value']): st
       return t('%s', `${token.value}${token.unit} ago`);
     default:
       return token.text;
+  }
+}
+
+export function getDefaultFilterValue({key}: {key: string}): string {
+  const fieldDef = getFieldDefinition(key);
+
+  if (!fieldDef) {
+    return '""';
+  }
+
+  if (key === FieldKey.IS) {
+    return 'unresolved';
+  }
+
+  switch (fieldDef.valueType) {
+    case FieldValueType.BOOLEAN:
+      return 'true';
+    case FieldValueType.INTEGER:
+    case FieldValueType.NUMBER:
+      return '100';
+    case FieldValueType.DATE:
+      return '-24h';
+    case FieldValueType.STRING:
+    default:
+      return '""';
   }
 }
 

--- a/static/app/components/searchQueryBuilder/valueCombobox.tsx
+++ b/static/app/components/searchQueryBuilder/valueCombobox.tsx
@@ -13,6 +13,7 @@ import SpecificDatePicker from 'sentry/components/searchQueryBuilder/specificDat
 import {
   escapeTagValue,
   formatFilterValue,
+  getDefaultFilterValue,
   isDateToken,
   unescapeTagValue,
 } from 'sentry/components/searchQueryBuilder/utils';
@@ -415,11 +416,7 @@ function tokenSupportsMultipleValues(
 
       const fieldDef = getFieldDefinition(key.key);
 
-      return [
-        FieldValueType.STRING,
-        FieldValueType.NUMBER,
-        FieldValueType.INTEGER,
-      ].includes(fieldDef?.valueType ?? FieldValueType.STRING);
+      return !fieldDef?.valueType || fieldDef.valueType === FieldValueType.STRING;
     case FilterType.NUMERIC:
       if (token.operator === TermOperator.DEFAULT) {
         return true;
@@ -727,7 +724,7 @@ export function SearchQueryBuilderValueCombobox({
       const cleanedValue = cleanFilterValue(token.key.text, value);
 
       // TODO(malwilley): Add visual feedback for invalid values
-      if (!cleanedValue) {
+      if (cleanedValue === null) {
         trackAnalytics('search.value_manual_submitted', {
           ...analyticsData,
           filter_value: value,
@@ -816,7 +813,20 @@ export function SearchQueryBuilderValueCombobox({
 
   const handleInputValueConfirmed = useCallback(
     (value: string) => {
-      if (value === getInitialInputValue(token, canSelectMultipleValues)) {
+      const isUnchanged = value === getInitialInputValue(token, canSelectMultipleValues);
+
+      // If there's no user input and the token has no value, set a default one
+      if (!value && !token.value.text) {
+        dispatch({
+          type: 'UPDATE_TOKEN_VALUE',
+          token: token,
+          value: getDefaultFilterValue({key: token.key.text}),
+        });
+        onCommit();
+        return;
+      }
+
+      if (isUnchanged) {
         onCommit();
         return;
       }
@@ -828,11 +838,13 @@ export function SearchQueryBuilderValueCombobox({
           value: prepareInputValueForSaving(token, value),
         });
         onCommit();
-        trackAnalytics('search.value_manual_submitted', {
-          ...analyticsData,
-          filter_value: value,
-          invalid: false,
-        });
+        if (!isUnchanged) {
+          trackAnalytics('search.value_manual_submitted', {
+            ...analyticsData,
+            filter_value: value,
+            invalid: false,
+          });
+        }
         return;
       }
 


### PR DESCRIPTION
Before it was possible to create a filter with no value:

![CleanShot 2024-07-12 at 11 19 31](https://github.com/user-attachments/assets/bc5c24a3-40d8-4314-bc3e-0da3bf5e0efd)

Now you will at least have an empty string (or other default value):

![CleanShot 2024-07-12 at 11 20 49](https://github.com/user-attachments/assets/2bb234d1-9910-4db1-8a88-18f7aca28f70)
