### PR TITLE
chore(flagpole): Makes create_at field required, with no defaults

### DIFF
--- a/src/flagpole/__init__.py
+++ b/src/flagpole/__init__.py
@@ -95,9 +95,7 @@ class Feature(BaseModel):
     enabled: bool = Field(default=True, description="Whether or not the feature is enabled.")
     "Whether or not the feature is enabled."
 
-    created_at: datetime = Field(
-        description="The datetime when this feature was created.", default_factory=datetime.now
-    )
+    created_at: datetime = Field(description="The datetime when this feature was created.")
     "The datetime when this feature was created."
 
     def match(self, context: EvaluationContext) -> bool:

--- a/tests/flagpole/test_feature.py
+++ b/tests/flagpole/test_feature.py
@@ -18,12 +18,6 @@ class TestParseFeatureConfig:
     def get_is_true_context_builder(self, is_true_value: bool):
         return ContextBuilder().add_context_transformer(lambda _data: dict(is_true=is_true_value))
 
-    def test_valid_without_created_at(self):
-        feature = Feature.from_feature_config_json("foo", '{"owner": "test", "segments":[]}')
-        assert feature.name == "foo"
-        assert isinstance(feature.created_at, datetime)
-        assert feature.segments == []
-
     def test_feature_with_empty_segments(self):
         feature = Feature.from_feature_config_json(
             "foobar",
@@ -171,6 +165,7 @@ class TestParseFeatureConfig:
             """
             {
                 "owner": "test-user",
+                "created_at": "2023-10-12T00:00:00.000Z",
                 "segments": [{
                     "name": "always_pass_segment",
                     "rollout": 100,
@@ -195,6 +190,7 @@ class TestParseFeatureConfig:
             {
                 "owner": "test-user",
                 "enabled": false,
+                "created_at": "2023-12-12T00:00:00.000Z",
                 "segments": [{
                     "name": "always_pass_segment",
                     "rollout": 100,
@@ -218,6 +214,7 @@ class TestParseFeatureConfig:
             """
             {
                 "owner": "test-user",
+                "created_at": "2023-12-12T00:00:00.000Z",
                 "segments": [{
                     "name": "always_pass_segment",
                     "rollout": 100,


### PR DESCRIPTION
Removes the default value for `created_at` and marks the property as required. It doesn't make sense to allow features without these dates to be created, and we'll want to enforce this via the generated JSON schemas in our options automation work.
