### PR TITLE
feat(prompts): support a visible status for un-hiding components

### DIFF
--- a/src/sentry/api/endpoints/prompts_activity.py
+++ b/src/sentry/api/endpoints/prompts_activity.py
@@ -1,4 +1,5 @@
 import calendar
+from typing import Any
 
 from django.db import IntegrityError, router, transaction
 from django.db.models import Q
@@ -100,7 +101,7 @@ class PromptsActivityEndpoint(Endpoint):
         else:
             fields["organization_id"] = 0
 
-        data = {}
+        data: dict[str, Any] = {}
         now = calendar.timegm(timezone.now().utctimetuple())
         if status == "snoozed":
             data["snoozed_ts"] = now

--- a/src/sentry/api/endpoints/prompts_activity.py
+++ b/src/sentry/api/endpoints/prompts_activity.py
@@ -16,7 +16,7 @@ from sentry.models.project import Project
 from sentry.models.promptsactivity import PromptsActivity
 from sentry.utils.prompts import prompt_config
 
-VALID_STATUSES = frozenset(("snoozed", "dismissed"))
+VALID_STATUSES = frozenset(("snoozed", "dismissed", "visible"))
 
 
 # Endpoint to retrieve multiple PromptsActivity at once
@@ -106,6 +106,9 @@ class PromptsActivityEndpoint(Endpoint):
             data["snoozed_ts"] = now
         elif status == "dismissed":
             data["dismissed_ts"] = now
+        elif status == "visible":
+            data["snoozed_ts"] = None
+            data["dismissed_ts"] = None
 
         try:
             with transaction.atomic(router.db_for_write(PromptsActivity)):

--- a/tests/sentry/api/endpoints/test_prompts_activity.py
+++ b/tests/sentry/api/endpoints/test_prompts_activity.py
@@ -149,6 +149,46 @@ class PromptsActivityTest(APITestCase):
         assert resp.data["data"].get("dismissed_ts") is None
         assert resp.data["data"].get("snoozed_ts") is None
 
+    def test_visible_legacy_path(self):
+        self.path = reverse("sentry-api-0-prompts-activity")
+        self.test_visible()
+
+    def test_visible_after_dismiss(self):
+        data = {
+            "organization_id": self.org.id,
+            "project_id": self.project.id,
+            "feature": "releases",
+        }
+        resp = self.client.get(self.path, data)
+        assert resp.status_code == 200
+        assert resp.data.get("data", None) is None
+
+        self.client.put(
+            self.path,
+            {
+                "organization_id": self.org.id,
+                "project_id": self.project.id,
+                "feature": "releases",
+                "status": "dismiss",
+            },
+        )
+
+        self.client.put(
+            self.path,
+            {
+                "organization_id": self.org.id,
+                "project_id": self.project.id,
+                "feature": "releases",
+                "status": "visible",
+            },
+        )
+
+        resp = self.client.get(self.path, data)
+        assert resp.status_code == 200
+        assert "data" in resp.data
+        assert resp.data["data"].get("dismissed_ts") is None
+        assert resp.data["data"].get("snoozed_ts") is None
+
     def test_batched(self):
         data = {
             "organization_id": self.org.id,

--- a/tests/sentry/api/endpoints/test_prompts_activity.py
+++ b/tests/sentry/api/endpoints/test_prompts_activity.py
@@ -123,6 +123,32 @@ class PromptsActivityTest(APITestCase):
         self.path = reverse("sentry-api-0-prompts-activity")
         self.test_snooze()
 
+    def test_visible(self):
+        data = {
+            "organization_id": self.org.id,
+            "project_id": self.project.id,
+            "feature": "releases",
+        }
+        resp = self.client.get(self.path, data)
+        assert resp.status_code == 200
+        assert resp.data.get("data", None) is None
+
+        self.client.put(
+            self.path,
+            {
+                "organization_id": self.org.id,
+                "project_id": self.project.id,
+                "feature": "releases",
+                "status": "visible",
+            },
+        )
+
+        resp = self.client.get(self.path, data)
+        assert resp.status_code == 200
+        assert "data" in resp.data
+        assert resp.data["data"].get("dismissed_ts") is None
+        assert resp.data["data"].get("snoozed_ts") is None
+
     def test_batched(self):
         data = {
             "organization_id": self.org.id,


### PR DESCRIPTION
Needed for https://github.com/getsentry/sentry/issues/74209. We're using the prompt backend to persist a user's decision to hide/unhide user feedback in the issue details page. The goal is to be able to toggle between [promptIsDismissed](https://github.com/getsentry/sentry/blob/539945981a00bc93a9525e61e052563df701757a/static/app/utils/promptIsDismissed.tsx#L18) = true/false.