### PR TITLE
feat(api): Support Project ID and Slugs in `OrganizationArtifactBundleAssembleEndpoint`

### DIFF
--- a/src/sentry/api/endpoints/organization_artifactbundle_assemble.py
+++ b/src/sentry/api/endpoints/organization_artifactbundle_assemble.py
@@ -57,7 +57,7 @@ class OrganizationArtifactBundleAssembleEndpoint(OrganizationReleasesBaseEndpoin
         except Exception:
             return Response({"error": "Invalid json body"}, status=400)
 
-        input_projects = set(data.get("projects", []))
+        input_projects = data.get("projects", [])
         if len(input_projects) == 0:
             return Response({"error": "You need to specify at least one project"}, status=400)
 
@@ -70,18 +70,16 @@ class OrganizationArtifactBundleAssembleEndpoint(OrganizationReleasesBaseEndpoin
             else:
                 input_project_slug.add(project)
 
-        project_ids = set(
-            Project.objects.filter(
-                (Q(id__in=input_project_id) | Q(slug__in=input_project_slug)),
-                organization=organization,
-                status=ObjectStatus.ACTIVE,
-            ).values_list("id", flat=True)
-        )
+        project_ids = Project.objects.filter(
+            (Q(id__in=input_project_id) | Q(slug__in=input_project_slug)),
+            organization=organization,
+            status=ObjectStatus.ACTIVE,
+        ).values_list("id", flat=True)
 
         if len(project_ids) != len(input_projects):
             return Response({"error": "One or more projects are invalid"}, status=400)
 
-        if not self.has_release_permission(request, organization, project_ids=project_ids):
+        if not self.has_release_permission(request, organization, project_ids=set(project_ids)):
             raise ResourceDoesNotExist
 
         checksum = data.get("checksum")

--- a/tests/sentry/api/endpoints/test_organization_artifactbundle_assemble.py
+++ b/tests/sentry/api/endpoints/test_organization_artifactbundle_assemble.py
@@ -221,8 +221,6 @@ class OrganizationArtifactBundleAssembleTest(APITestCase):
 
         self.assertEqual(response.status_code, 200)
 
-    # You can add more tests here following the same pattern to cover additional scenarios
-
     @patch("sentry.tasks.assemble.assemble_artifacts")
     def test_assemble_without_version_and_dist(self, mock_assemble_artifacts):
         bundle_file = self.create_artifact_bundle_zip(

--- a/tests/sentry/api/endpoints/test_organization_artifactbundle_assemble.py
+++ b/tests/sentry/api/endpoints/test_organization_artifactbundle_assemble.py
@@ -141,6 +141,88 @@ class OrganizationArtifactBundleAssembleTest(APITestCase):
         assert response.status_code == 400, response.content
         assert response.data["error"] == "One or more projects are invalid"
 
+    def test_assemble_with_valid_project_slugs(self):
+        # Test with all valid project slugs
+        valid_project = self.create_project()
+        another_valid_project = self.create_project()
+
+        bundle_file = self.create_artifact_bundle_zip(
+            org=self.organization.slug, release=self.release.version
+        )
+        total_checksum = sha1(bundle_file).hexdigest()
+
+        blob = FileBlob.from_file(ContentFile(bundle_file))
+        FileBlobOwner.objects.get_or_create(organization_id=self.organization.id, blob=blob)
+
+        response = self.client.post(
+            self.url,
+            data={
+                "checksum": total_checksum,
+                "chunks": [blob.checksum],
+                "projects": [valid_project.slug, another_valid_project.slug],
+            },
+            HTTP_AUTHORIZATION=f"Bearer {self.token.token}",
+        )
+
+        self.assertEqual(response.status_code, 200)
+
+    def test_assemble_with_valid_project_ids(self):
+        # Test with all valid project IDs
+        valid_project = self.create_project()
+        another_valid_project = self.create_project()
+
+        bundle_file = self.create_artifact_bundle_zip(
+            org=self.organization.slug, release=self.release.version
+        )
+        total_checksum = sha1(bundle_file).hexdigest()
+
+        blob = FileBlob.from_file(ContentFile(bundle_file))
+        FileBlobOwner.objects.get_or_create(organization_id=self.organization.id, blob=blob)
+
+        response = self.client.post(
+            self.url,
+            data={
+                "checksum": total_checksum,
+                "chunks": [blob.checksum],
+                "projects": [str(valid_project.id), str(another_valid_project.id)],
+            },
+            HTTP_AUTHORIZATION=f"Bearer {self.token.token}",
+        )
+
+        self.assertEqual(response.status_code, 200)
+
+    def test_assemble_with_mix_of_slugs_and_ids(self):
+        # Test with a mix of valid project slugs and IDs
+        valid_project = self.create_project()
+        another_valid_project = self.create_project()
+        third_valid_project = self.create_project()
+
+        bundle_file = self.create_artifact_bundle_zip(
+            org=self.organization.slug, release=self.release.version
+        )
+        total_checksum = sha1(bundle_file).hexdigest()
+
+        blob = FileBlob.from_file(ContentFile(bundle_file))
+        FileBlobOwner.objects.get_or_create(organization_id=self.organization.id, blob=blob)
+
+        response = self.client.post(
+            self.url,
+            data={
+                "checksum": total_checksum,
+                "chunks": [blob.checksum],
+                "projects": [
+                    valid_project.slug,
+                    str(another_valid_project.id),
+                    str(third_valid_project.id),
+                ],
+            },
+            HTTP_AUTHORIZATION=f"Bearer {self.token.token}",
+        )
+
+        self.assertEqual(response.status_code, 200)
+
+    # You can add more tests here following the same pattern to cover additional scenarios
+
     @patch("sentry.tasks.assemble.assemble_artifacts")
     def test_assemble_without_version_and_dist(self, mock_assemble_artifacts):
         bundle_file = self.create_artifact_bundle_zip(


### PR DESCRIPTION
I am working on getting all the commands in our Sentry CLI to support Ids as well as Slugs. [rough spec](https://www.notion.so/sentry/Supporting-IDs-and-Slugs-in-Sentry-CLI-35b805ea169e47348805672cdee41297?pm=c)

We have already gone through the effort of supporting ids and slugs in path parameters of all the APIs in our codebase. There are some endpoints that the CLI uses that pass in project slugs as _body parameters_, so we need to support Ids for those as well.

Here, I use the fact that ids are numeric and slugs aren't to process both type of identifiers.