### PR TITLE
fix: fix broken links to Performance docs pages

### DIFF
--- a/src/sentry/tasks/check_am2_compatibility.py
+++ b/src/sentry/tasks/check_am2_compatibility.py
@@ -428,9 +428,9 @@ class CheckAM2Compatibility:
 
     @classmethod
     def get_outdated_sdks(cls, found_sdks_per_project):
-        outdated_sdks_per_project: Mapping[
-            str, Mapping[str, set[tuple[str, str | None]]]
-        ] = defaultdict(lambda: defaultdict(set))
+        outdated_sdks_per_project: Mapping[str, Mapping[str, set[tuple[str, str | None]]]] = (
+            defaultdict(lambda: defaultdict(set))
+        )
 
         for project, found_sdks in found_sdks_per_project.items():
             for sdk_name, sdk_versions in found_sdks.items():

--- a/src/sentry/tasks/check_am2_compatibility.py
+++ b/src/sentry/tasks/check_am2_compatibility.py
@@ -428,9 +428,9 @@ class CheckAM2Compatibility:
 
     @classmethod
     def get_outdated_sdks(cls, found_sdks_per_project):
-        outdated_sdks_per_project: Mapping[str, Mapping[str, set[tuple[str, str | None]]]] = (
-            defaultdict(lambda: defaultdict(set))
-        )
+        outdated_sdks_per_project: Mapping[
+            str, Mapping[str, set[tuple[str, str | None]]]
+        ] = defaultdict(lambda: defaultdict(set))
 
         for project, found_sdks in found_sdks_per_project.items():
             for sdk_name, sdk_versions in found_sdks.items():

--- a/static/app/components/onboarding/productSelection.tsx
+++ b/static/app/components/onboarding/productSelection.tsx
@@ -434,7 +434,7 @@ export function ProductSelection({
             description={t(
               'Automatic performance issue detection across services and context on who is impacted, outliers, regressions, and the root cause of your slowdown.'
             )}
-            docLink="https://docs.sentry.io/platforms/javascript/guides/react/performance/"
+            docLink="https://docs.sentry.io/platforms/javascript/guides/react/tracing/"
             onClick={() => handleClickProduct(ProductSolution.PERFORMANCE_MONITORING)}
             disabled={disabledProducts[ProductSolution.PERFORMANCE_MONITORING]}
             checked={urlProducts.includes(ProductSolution.PERFORMANCE_MONITORING)}

--- a/static/app/components/quickTrace/index.tsx
+++ b/static/app/components/quickTrace/index.tsx
@@ -663,8 +663,8 @@ class MissingServiceNode extends Component<MissingServiceProps, MissingServiceSt
     const docPlatform = getDocsPlatform(platform, true);
     const docsHref =
       docPlatform === null || docPlatform === 'javascript'
-        ? 'https://docs.sentry.io/platforms/javascript/performance/connect-services/'
-        : `https://docs.sentry.io/platforms/${docPlatform}/performance/connect-services`;
+        ? 'https://docs.sentry.io/platforms/javascript/tracing/trace-propagation/'
+        : `https://docs.sentry.io/platforms/${docPlatform}/tracing/trace-propagation/`;
     return (
       <Fragment>
         {connectorSide === 'left' && <TraceConnector dashed />}

--- a/static/app/gettingStartedDocs/apple/ios.tsx
+++ b/static/app/gettingStartedDocs/apple/ios.tsx
@@ -425,13 +425,13 @@ const onboarding: OnboardingConfig<PlatformOptions> = {
                   <ExternalLink href="https://docs.sentry.io/platforms/apple/guides/ios/enriching-events/viewhierarchy/" />
                 ),
                 ttfd: (
-                  <ExternalLink href="https://docs.sentry.io/platforms/apple/guides/ios/performance/instrumentation/automatic-instrumentation/#time-to-full-display" />
+                  <ExternalLink href="https://docs.sentry.io/platforms/apple/guides/ios/tracing/instrumentation/automatic-instrumentation/#time-to-full-display" />
                 ),
                 metricKit: (
                   <ExternalLink href="https://docs.sentry.io/platforms/apple/guides/watchos/configuration/metric-kit/" />
                 ),
                 prewarmedAppStart: (
-                  <ExternalLink href="https://docs.sentry.io/platforms/apple/performance/instrumentation/automatic-instrumentation/#prewarmed-app-start-tracing" />
+                  <ExternalLink href="https://docs.sentry.io/platforms/apple/tracing/instrumentation/automatic-instrumentation/#prewarmed-app-start-tracing" />
                 ),
                 asyncStacktraces: (
                   <ExternalLink href="https://docs.sentry.io/platforms/apple/guides/ios/#stitch-together-swift-concurrency-stack-traces" />
@@ -502,7 +502,7 @@ const onboarding: OnboardingConfig<PlatformOptions> = {
       id: 'swiftui',
       name: t('SwiftUI'),
       description: t('Learn about our first class integration with SwiftUI.'),
-      link: 'https://docs.sentry.io/platforms/apple/performance/instrumentation/swiftui-instrumentation/',
+      link: 'https://docs.sentry.io/platforms/apple/tracing/instrumentation/swiftui-instrumentation/',
     },
     {
       id: 'profiling',

--- a/static/app/gettingStartedDocs/apple/macos.tsx
+++ b/static/app/gettingStartedDocs/apple/macos.tsx
@@ -213,7 +213,7 @@ const onboarding: OnboardingConfig = {
       id: 'swiftui',
       name: t('SwiftUI'),
       description: t('Learn about our first class integration with SwiftUI.'),
-      link: 'https://docs.sentry.io/platforms/apple/performance/instrumentation/swiftui-instrumentation/',
+      link: 'https://docs.sentry.io/platforms/apple/tracing/instrumentation/swiftui-instrumentation/',
     },
     {
       id: 'profiling',

--- a/static/app/gettingStartedDocs/bun/bun.tsx
+++ b/static/app/gettingStartedDocs/bun/bun.tsx
@@ -102,7 +102,7 @@ const onboarding: OnboardingConfig = {
             description: t(
               'Track down transactions to connect the dots between 10-second page loads and poor-performing API calls or slow database queries.'
             ),
-            link: 'https://docs.sentry.io/platforms/javascript/guides/bun/performance/',
+            link: 'https://docs.sentry.io/platforms/javascript/guides/bun/tracing/',
           },
         ],
 };

--- a/static/app/gettingStartedDocs/capacitor/capacitor.tsx
+++ b/static/app/gettingStartedDocs/capacitor/capacitor.tsx
@@ -259,7 +259,7 @@ const onboarding: OnboardingConfig<PlatformOptions> = {
           description: t(
             'Track down transactions to connect the dots between 10-second page loads and poor-performing API calls or slow database queries.'
           ),
-          link: 'https://docs.sentry.io/platforms/javascript/guides/capacitor/performance/',
+          link: 'https://docs.sentry.io/platforms/javascript/guides/capacitor/tracing/',
         },
     params.isReplaySelected
       ? null

--- a/static/app/gettingStartedDocs/dart/dart.tsx
+++ b/static/app/gettingStartedDocs/dart/dart.tsx
@@ -268,7 +268,7 @@ const onboarding: OnboardingConfig = {
             'To learn more about the API and automatic instrumentations, check out the [perfDocs: performance documentation].',
             {
               perfDocs: (
-                <ExternalLink href="https://docs.sentry.io/platforms/dart/performance/instrumentation/" />
+                <ExternalLink href="https://docs.sentry.io/platforms/dart/tracing/instrumentation/" />
               ),
             }
           ),

--- a/static/app/gettingStartedDocs/deno/deno.tsx
+++ b/static/app/gettingStartedDocs/deno/deno.tsx
@@ -111,7 +111,7 @@ const onboarding: OnboardingConfig = {
             description: t(
               'Track down transactions to connect the dots between 10-second page loads and poor-performing API calls or slow database queries.'
             ),
-            link: 'https://docs.sentry.io/platforms/javascript/guides/bun/performance/',
+            link: 'https://docs.sentry.io/platforms/javascript/guides/bun/tracing/',
           },
         ],
 };

--- a/static/app/gettingStartedDocs/dotnet/dotnet.tsx
+++ b/static/app/gettingStartedDocs/dotnet/dotnet.tsx
@@ -260,7 +260,7 @@ const onboarding: OnboardingConfig = {
               'Check out [link:the documentation] to learn more about the API and automatic instrumentations.',
               {
                 link: (
-                  <ExternalLink href="https://docs.sentry.io/platforms/dotnet/performance/instrumentation/" />
+                  <ExternalLink href="https://docs.sentry.io/platforms/dotnet/tracing/instrumentation/" />
                 ),
               }
             ),

--- a/static/app/gettingStartedDocs/dotnet/maui.tsx
+++ b/static/app/gettingStartedDocs/dotnet/maui.tsx
@@ -257,7 +257,7 @@ const onboarding: OnboardingConfig = {
                     'For some parts of your code, [automaticInstrumentationLink:automatic instrumentation] is available across all of our .NET SDKs, and can be used with MAUI as well:',
                     {
                       automaticInstrumentationLink: (
-                        <ExternalLink href="https://docs.sentry.io/platforms/dotnet/guides/maui/performance/instrumentation/automatic-instrumentation/" />
+                        <ExternalLink href="https://docs.sentry.io/platforms/dotnet/guides/maui/tracing/instrumentation/automatic-instrumentation/" />
                       ),
                     }
                   )}
@@ -284,7 +284,7 @@ const onboarding: OnboardingConfig = {
                         'For other parts of your code, you can use [customInstrumentationLink:custom instrumentation], such as in the following example:',
                         {
                           customInstrumentationLink: (
-                            <ExternalLink href="https://docs.sentry.io/platforms/dotnet/guides/maui/performance/instrumentation/custom-instrumentation/" />
+                            <ExternalLink href="https://docs.sentry.io/platforms/dotnet/guides/maui/tracing/instrumentation/custom-instrumentation/" />
                           ),
                         }
                       )}

--- a/static/app/gettingStartedDocs/dotnet/uwp.tsx
+++ b/static/app/gettingStartedDocs/dotnet/uwp.tsx
@@ -167,7 +167,7 @@ const onboarding: OnboardingConfig = {
         'Check out [link:the documentation] to learn more about the API and automatic instrumentations.',
         {
           link: (
-            <ExternalLink href="https://docs.sentry.io/platforms/dotnet/performance/instrumentation/" />
+            <ExternalLink href="https://docs.sentry.io/platforms/dotnet/tracing/instrumentation/" />
           ),
         }
       ),

--- a/static/app/gettingStartedDocs/dotnet/winforms.tsx
+++ b/static/app/gettingStartedDocs/dotnet/winforms.tsx
@@ -226,7 +226,7 @@ const onboarding: OnboardingConfig = {
               'Check out [link:the documentation] to learn more about the API and automatic instrumentations.',
               {
                 link: (
-                  <ExternalLink href="https://docs.sentry.io/platforms/dotnet/performance/instrumentation/" />
+                  <ExternalLink href="https://docs.sentry.io/platforms/dotnet/tracing/instrumentation/" />
                 ),
               }
             ),

--- a/static/app/gettingStartedDocs/dotnet/wpf.tsx
+++ b/static/app/gettingStartedDocs/dotnet/wpf.tsx
@@ -225,7 +225,7 @@ const onboarding: OnboardingConfig = {
               'Check out [link:the documentation] to learn more about the API and automatic instrumentations.',
               {
                 link: (
-                  <ExternalLink href="https://docs.sentry.io/platforms/dotnet/performance/instrumentation/" />
+                  <ExternalLink href="https://docs.sentry.io/platforms/dotnet/tracing/instrumentation/" />
                 ),
               }
             ),

--- a/static/app/gettingStartedDocs/dotnet/xamarin.tsx
+++ b/static/app/gettingStartedDocs/dotnet/xamarin.tsx
@@ -214,7 +214,7 @@ const onboarding: OnboardingConfig = {
         'Check out [link:the documentation] to learn more about the API and automatic instrumentations.',
         {
           link: (
-            <ExternalLink href="https://docs.sentry.io/platforms/dotnet/performance/instrumentation/" />
+            <ExternalLink href="https://docs.sentry.io/platforms/dotnet/tracing/instrumentation/" />
           ),
         }
       ),

--- a/static/app/gettingStartedDocs/flutter/flutter.tsx
+++ b/static/app/gettingStartedDocs/flutter/flutter.tsx
@@ -294,7 +294,7 @@ const onboarding: OnboardingConfig = {
                   'To learn more about the API and automatic instrumentations, check out the [perfDocs: performance documentation].',
                   {
                     perfDocs: (
-                      <ExternalLink href="https://docs.sentry.io/platforms/flutter/performance/instrumentation/" />
+                      <ExternalLink href="https://docs.sentry.io/platforms/flutter/tracing/instrumentation/" />
                     ),
                   }
                 ),

--- a/static/app/gettingStartedDocs/java/java.tsx
+++ b/static/app/gettingStartedDocs/java/java.tsx
@@ -292,7 +292,7 @@ const onboarding: OnboardingConfig<PlatformOptions> = {
       description: t(
         'Stay ahead of latency issues and trace every slow transaction to a poor-performing API call or database query.'
       ),
-      link: 'https://docs.sentry.io/platforms/java/performance/',
+      link: 'https://docs.sentry.io/platforms/java/tracing/',
     },
   ],
 };

--- a/static/app/gettingStartedDocs/java/spring-boot.tsx
+++ b/static/app/gettingStartedDocs/java/spring-boot.tsx
@@ -295,7 +295,7 @@ const onboarding: OnboardingConfig<PlatformOptions> = {
       description: t(
         'Stay ahead of latency issues and trace every slow transaction to a poor-performing API call or database query.'
       ),
-      link: 'https://docs.sentry.io/platforms/java/guides/spring-boot/performance/',
+      link: 'https://docs.sentry.io/platforms/java/guides/spring-boot/tracing/',
     },
   ],
 };

--- a/static/app/gettingStartedDocs/java/spring.tsx
+++ b/static/app/gettingStartedDocs/java/spring.tsx
@@ -367,7 +367,7 @@ const onboarding: OnboardingConfig<PlatformOptions> = {
       description: t(
         'Stay ahead of latency issues and trace every slow transaction to a poor-performing API call or database query.'
       ),
-      link: 'https://docs.sentry.io/platforms/java/guides/spring/performance/',
+      link: 'https://docs.sentry.io/platforms/java/guides/spring/tracing/',
     },
   ],
 };

--- a/static/app/gettingStartedDocs/javascript/angular.tsx
+++ b/static/app/gettingStartedDocs/javascript/angular.tsx
@@ -168,7 +168,7 @@ export const nextSteps = [
     description: t(
       'Track down transactions to connect the dots between 10-second page loads and poor-performing API calls or slow database queries.'
     ),
-    link: 'https://docs.sentry.io/platforms/javascript/guides/angular/performance/',
+    link: 'https://docs.sentry.io/platforms/javascript/guides/angular/tracing/',
   },
   {
     id: 'session-replay',

--- a/static/app/gettingStartedDocs/javascript/astro.tsx
+++ b/static/app/gettingStartedDocs/javascript/astro.tsx
@@ -195,7 +195,7 @@ const onboarding: OnboardingConfig = {
       description: t(
         'Track down transactions to connect the dots between 10-second page loads and poor-performing API calls or slow database queries.'
       ),
-      link: 'https://docs.sentry.io/platforms/javascript/guides/astro/performance/',
+      link: 'https://docs.sentry.io/platforms/javascript/guides/astro/tracing/',
     },
     {
       id: 'session-replay',

--- a/static/app/gettingStartedDocs/javascript/ember.tsx
+++ b/static/app/gettingStartedDocs/javascript/ember.tsx
@@ -150,7 +150,7 @@ const onboarding: OnboardingConfig = {
       description: t(
         'Track down transactions to connect the dots between 10-second page loads and poor-performing API calls or slow database queries.'
       ),
-      link: 'https://docs.sentry.io/platforms/javascript/guides/ember/performance/',
+      link: 'https://docs.sentry.io/platforms/javascript/guides/ember/tracing/',
     },
     {
       id: 'session-replay',

--- a/static/app/gettingStartedDocs/javascript/gatsby.tsx
+++ b/static/app/gettingStartedDocs/javascript/gatsby.tsx
@@ -182,7 +182,7 @@ const onboarding: OnboardingConfig = {
       description: t(
         'Track down transactions to connect the dots between 10-second page loads and poor-performing API calls or slow database queries.'
       ),
-      link: 'https://docs.sentry.io/platforms/javascript/guides/gatsby/performance/',
+      link: 'https://docs.sentry.io/platforms/javascript/guides/gatsby/tracing/',
     },
     {
       id: 'session-replay',

--- a/static/app/gettingStartedDocs/javascript/javascript.tsx
+++ b/static/app/gettingStartedDocs/javascript/javascript.tsx
@@ -151,7 +151,7 @@ const onboarding: OnboardingConfig = {
       description: t(
         'Track down transactions to connect the dots between 10-second page loads and poor-performing API calls or slow database queries.'
       ),
-      link: 'https://docs.sentry.io/platforms/javascript/performance/',
+      link: 'https://docs.sentry.io/platforms/javascript/tracing/',
     },
     {
       id: 'session-replay',

--- a/static/app/gettingStartedDocs/javascript/react.tsx
+++ b/static/app/gettingStartedDocs/javascript/react.tsx
@@ -174,7 +174,7 @@ const onboarding: OnboardingConfig = {
       description: t(
         'Track down transactions to connect the dots between 10-second page loads and poor-performing API calls or slow database queries.'
       ),
-      link: 'https://docs.sentry.io/platforms/javascript/guides/react/performance/',
+      link: 'https://docs.sentry.io/platforms/javascript/guides/react/tracing/',
     },
     {
       id: 'session-replay',

--- a/static/app/gettingStartedDocs/javascript/remix.tsx
+++ b/static/app/gettingStartedDocs/javascript/remix.tsx
@@ -128,7 +128,7 @@ const onboarding: OnboardingConfig = {
       description: t(
         'Track down transactions to connect the dots between 10-second page loads and poor-performing API calls or slow database queries.'
       ),
-      link: 'https://docs.sentry.io/platforms/javascript/guides/remix/performance/',
+      link: 'https://docs.sentry.io/platforms/javascript/guides/remix/tracing/',
     },
     {
       id: 'session-replay',

--- a/static/app/gettingStartedDocs/javascript/solid.tsx
+++ b/static/app/gettingStartedDocs/javascript/solid.tsx
@@ -176,7 +176,7 @@ const onboarding: OnboardingConfig = {
       description: t(
         'Track down transactions to connect the dots between 10-second page loads and poor-performing API calls or slow database queries.'
       ),
-      link: 'https://docs.sentry.io/platforms/javascript/guides/solid/performance/',
+      link: 'https://docs.sentry.io/platforms/javascript/guides/solid/tracing/',
     },
     {
       id: 'session-replay',

--- a/static/app/gettingStartedDocs/javascript/svelte.tsx
+++ b/static/app/gettingStartedDocs/javascript/svelte.tsx
@@ -173,7 +173,7 @@ const onboarding: OnboardingConfig = {
       description: t(
         'Track down transactions to connect the dots between 10-second page loads and poor-performing API calls or slow database queries.'
       ),
-      link: 'https://docs.sentry.io/platforms/javascript/guides/svelte/performance/',
+      link: 'https://docs.sentry.io/platforms/javascript/guides/svelte/tracing/',
     },
     {
       id: 'session-replay',

--- a/static/app/gettingStartedDocs/javascript/vue.tsx
+++ b/static/app/gettingStartedDocs/javascript/vue.tsx
@@ -189,7 +189,7 @@ export const nextSteps = [
     description: t(
       'Track down transactions to connect the dots between 10-second page loads and poor-performing API calls or slow database queries.'
     ),
-    link: 'https://docs.sentry.io/platforms/javascript/guides/vue/performance/',
+    link: 'https://docs.sentry.io/platforms/javascript/guides/vue/tracing/',
   },
   {
     id: 'session-replay',

--- a/static/app/gettingStartedDocs/kotlin/kotlin.tsx
+++ b/static/app/gettingStartedDocs/kotlin/kotlin.tsx
@@ -270,7 +270,7 @@ const onboarding: OnboardingConfig<PlatformOptions> = {
       description: t(
         'Stay ahead of latency issues and trace every slow transaction to a poor-performing API call or database query.'
       ),
-      link: 'https://docs.sentry.io/platforms/java/performance/',
+      link: 'https://docs.sentry.io/platforms/java/tracing/',
     },
   ],
 };

--- a/static/app/gettingStartedDocs/php/php.tsx
+++ b/static/app/gettingStartedDocs/php/php.tsx
@@ -100,7 +100,7 @@ const onboarding: OnboardingConfig = {
                 'To instrument certain regions of your code, you can [instrumentationLink:create transactions to capture them].',
                 {
                   instrumentationLink: (
-                    <ExternalLink href="https://docs.sentry.io/platforms/php/performance/instrumentation/custom-instrumentation/" />
+                    <ExternalLink href="https://docs.sentry.io/platforms/php/tracing/instrumentation/custom-instrumentation/" />
                   ),
                 }
               )}

--- a/static/app/gettingStartedDocs/powershell/powershell.tsx
+++ b/static/app/gettingStartedDocs/powershell/powershell.tsx
@@ -122,7 +122,7 @@ const onboarding: OnboardingConfig = {
         'Check out [link:the documentation] to learn more about the API and instrumentations.',
         {
           link: (
-            <ExternalLink href="https://docs.sentry.io/platforms/powershell/performance/instrumentation/" />
+            <ExternalLink href="https://docs.sentry.io/platforms/powershell/tracing/instrumentation/" />
           ),
         }
       ),

--- a/static/app/gettingStartedDocs/react-native/react-native.tsx
+++ b/static/app/gettingStartedDocs/react-native/react-native.tsx
@@ -155,7 +155,7 @@ const onboarding: OnboardingConfig = {
                 <ExternalLink href="https://docs.sentry.io/platforms/react-native/touchevents/" />
               ),
               automaticPerformanceMonitoringLink: (
-                <ExternalLink href="https://docs.sentry.io/platforms/react-native/performance/instrumentation/automatic-instrumentation/" />
+                <ExternalLink href="https://docs.sentry.io/platforms/react-native/tracing/instrumentation/automatic-instrumentation/" />
               ),
             }
           ),
@@ -206,18 +206,23 @@ const onboarding: OnboardingConfig = {
                 )}
                 <List symbol="bullet">
                   <ListItem>
-                    <ExternalLink href="https://docs.sentry.io/platforms/react-native/performance/instrumentation/automatic-instrumentation/#react-navigation">
+                    <ExternalLink href="https://docs.sentry.io/platforms/react-native/tracing/instrumentation/react-navigation/">
                       {t('React Navigation')}
                     </ExternalLink>
                   </ListItem>
                   <ListItem>
-                    <ExternalLink href="https://docs.sentry.io/platforms/react-native/performance/instrumentation/automatic-instrumentation/#react-navigation-v4">
+                    <ExternalLink href="https://docs.sentry.io/platforms/react-native/tracing/instrumentation/react-navigation-v4/">
                       {t('React Navigation V4 and prior')}
                     </ExternalLink>
                   </ListItem>
                   <ListItem>
-                    <ExternalLink href="https://docs.sentry.io/platforms/react-native/performance/instrumentation/automatic-instrumentation/#react-native-navigation">
+                    <ExternalLink href="https://docs.sentry.io/platforms/react-native/tracing/instrumentation/react-native-navigation/">
                       {t('React Native Navigation')}
+                    </ExternalLink>
+                  </ListItem>
+                  <ListItem>
+                    <ExternalLink href="https://docs.sentry.io/platforms/react-native/tracing/instrumentation/expo-router/">
+                      {t('Expo Router')}
                     </ExternalLink>
                   </ListItem>
                 </List>
@@ -235,7 +240,7 @@ const onboarding: OnboardingConfig = {
                   'For more information, please refer to the [docLink: Sentry React Native documentation].',
                   {
                     docLink: (
-                      <ExternalLink href="https://docs.sentry.io/platforms/react-native/performance/instrumentation/" />
+                      <ExternalLink href="https://docs.sentry.io/platforms/react-native/tracing/instrumentation/" />
                     ),
                   }
                 ),

--- a/static/app/utils/docs.tsx
+++ b/static/app/utils/docs.tsx
@@ -70,7 +70,7 @@ export function getConfigurePerformanceDocsLink(
   const docsPlatform = platform ? getDocsPlatform(platform, true) : null;
   return docsPlatform === null
     ? null // this platform does not support performance
-    : `https://docs.sentry.io/platforms/${docsPlatform}/performance/`;
+    : `https://docs.sentry.io/platforms/${docsPlatform}/tracing/`;
 }
 
 export function getConfigureIntegrationsDocsLink(

--- a/static/app/views/discover/results.tsx
+++ b/static/app/views/discover/results.tsx
@@ -564,7 +564,7 @@ export class Results extends Component<Props, State> {
             'These are unparameterized transactions. To better organize your transactions, [link:set transaction names manually].',
             {
               link: (
-                <ExternalLink href="https://docs.sentry.io/platforms/javascript/performance/instrumentation/automatic-instrumentation/#beforenavigate" />
+                <ExternalLink href="https://docs.sentry.io/platforms/javascript/tracing/instrumentation/automatic-instrumentation/#beforenavigate" />
               ),
             }
           )}

--- a/static/app/views/insights/mobile/screenload/components/tables/screensTable.tsx
+++ b/static/app/views/insights/mobile/screenload/components/tables/screensTable.tsx
@@ -130,8 +130,8 @@ export function ScreensTable({data, eventView, isLoading, pageLinks, onCursor}: 
     ) {
       const docsUrl =
         project?.platform === 'android'
-          ? 'https://docs.sentry.io/platforms/android/performance/instrumentation/automatic-instrumentation/#time-to-full-display'
-          : 'https://docs.sentry.io/platforms/apple/guides/ios/performance/instrumentation/automatic-instrumentation/#time-to-full-display';
+          ? 'https://docs.sentry.io/platforms/android/tracing/instrumentation/automatic-instrumentation/#time-to-full-display'
+          : 'https://docs.sentry.io/platforms/apple/guides/ios/tracing/instrumentation/automatic-instrumentation/#time-to-full-display';
       return (
         <div style={{textAlign: 'right'}}>
           <Tooltip

--- a/static/app/views/onboarding/setupDocsLoader.tsx
+++ b/static/app/views/onboarding/setupDocsLoader.tsx
@@ -315,7 +315,7 @@ Sentry.onLoad(function() {
           </li>
           {!products.includes(ProductSolution.PERFORMANCE_MONITORING) && (
             <li>
-              <ExternalLink href="https://docs.sentry.io/platforms/javascript/performance/">
+              <ExternalLink href="https://docs.sentry.io/platforms/javascript/tracing/">
                 {t('Performance Monitoring')}
               </ExternalLink>
               {': '}

--- a/static/app/views/performance/newTraceDetails/traceWarnings.tsx
+++ b/static/app/views/performance/newTraceDetails/traceWarnings.tsx
@@ -48,7 +48,7 @@ export function TraceWarnings({type}: TraceWarningsProps) {
     case TraceType.MULTIPLE_ROOTS:
       return (
         <Alert type="info" showIcon>
-          <ExternalLink href="https://docs.sentry.io/product/sentry-basics/tracing/trace-view/#multiple-roots">
+          <ExternalLink href="https://docs.sentry.io/concepts/key-terms/tracing/trace-view/#multiple-roots">
             {t('Multiple root transactions have been found with this trace ID.')}
           </ExternalLink>
         </Alert>

--- a/static/app/views/performance/traceDetails/content.tsx
+++ b/static/app/views/performance/traceDetails/content.tsx
@@ -309,7 +309,7 @@ class TraceDetailsContent extends Component<Props, State> {
     } else if (roots > 1) {
       warning = (
         <Alert type="info" showIcon>
-          <ExternalLink href="https://docs.sentry.io/product/sentry-basics/tracing/trace-view/#multiple-roots">
+          <ExternalLink href="https://docs.sentry.io/concepts/key-terms/tracing/trace-view/#multiple-roots">
             {t('Multiple root transactions have been found with this trace ID.')}
           </ExternalLink>
         </Alert>

--- a/static/app/views/performance/traceDetails/newTraceDetailsContent.tsx
+++ b/static/app/views/performance/traceDetails/newTraceDetailsContent.tsx
@@ -280,7 +280,7 @@ function NewTraceDetailsContent(props: Props) {
       case TraceType.MULTIPLE_ROOTS:
         warning = (
           <Alert type="info" showIcon>
-            <ExternalLink href="https://docs.sentry.io/product/sentry-basics/tracing/trace-view/#multiple-roots">
+            <ExternalLink href="https://docs.sentry.io/concepts/key-terms/tracing/trace-view/#multiple-roots">
               {t('Multiple root transactions have been found with this trace ID.')}
             </ExternalLink>
           </Alert>

--- a/static/app/views/replays/list/replayOnboardingPanel.tsx
+++ b/static/app/views/replays/list/replayOnboardingPanel.tsx
@@ -178,7 +178,7 @@ export function SetupReplaysCTA({
               'To learn more about how we’ve optimized our SDK, please visit [link:our docs].',
               {
                 link: (
-                  <ExternalLink href="https://docs.sentry.io/product/session-replay/performance-overhead/" />
+                  <ExternalLink href="https://docs.sentry.io/product/explore/session-replay/performance-overhead/" />
                 ),
               }
             )}

--- a/static/app/views/settings/projectPerformance/projectPerformance.tsx
+++ b/static/app/views/settings/projectPerformance/projectPerformance.tsx
@@ -933,7 +933,7 @@ class ProjectPerformance extends DeprecatedAsyncView<Props, State> {
                     <Actions>
                       <Button
                         external
-                        href="https://docs.sentry.io/product/performance/performance-at-scale/"
+                        href="https://docs.sentry.io/product/performance/tracing-at-scale/"
                       >
                         {t('Read docs')}
                       </Button>

--- a/static/app/views/settings/projectPerformance/projectPerformance.tsx
+++ b/static/app/views/settings/projectPerformance/projectPerformance.tsx
@@ -933,7 +933,7 @@ class ProjectPerformance extends DeprecatedAsyncView<Props, State> {
                     <Actions>
                       <Button
                         external
-                        href="https://docs.sentry.io/product/performance/tracing-at-scale/"
+                        href="https://docs.sentry.io/product/performance/performance-at-scale/"
                       >
                         {t('Read docs')}
                       </Button>


### PR DESCRIPTION
We renamed many `.../performance/...` URLs to `.../tracing/...` in our docs, leaving a number of broken links inside Sentry. Fixed as many as I could find.

Also added a link to the Expo Router page in the React Native onboarding config to match [the corresponding docs page](https://docs.sentry.io/platforms/react-native/tracing/instrumentation/automatic-instrumentation/#enable-routing-instrumentation).