### PR TITLE
feat(performance): Implement new breadcrumb view in trace drawer

### DIFF
--- a/static/app/components/events/breadcrumbs/breadcrumbsDataSection.tsx
+++ b/static/app/components/events/breadcrumbs/breadcrumbsDataSection.tsx
@@ -52,7 +52,6 @@ export default function BreadcrumbsDataSection({
 }: BreadcrumbsDataSectionProps) {
   const {openDrawer} = useDrawer();
   const organization = useOrganization();
-  // Use the local storage preferences, but allow the drawer to do updates
   const [timeDisplay, setTimeDisplay] = useLocalStorageState<BreadcrumbTimeDisplay>(
     BREADCRUMB_TIME_DISPLAY_LOCALSTORAGE_KEY,
     BreadcrumbTimeDisplay.RELATIVE

--- a/static/app/components/events/breadcrumbs/breadcrumbsTimeline.tsx
+++ b/static/app/components/events/breadcrumbs/breadcrumbsTimeline.tsx
@@ -20,6 +20,10 @@ interface BreadcrumbsTimelineProps {
   /**
    * If false, expands the contents of the breadcrumb's data payload, adds padding.
    */
+  fixedHeight?: number;
+  /**
+   * If false, expands the contents of the breadcrumb's data payload, adds padding.
+   */
   isCompact?: boolean;
   /**
    * Shows the line after the last breadcrumbs icon.
@@ -36,6 +40,7 @@ export default function BreadcrumbsTimeline({
   breadcrumbs,
   startTimeString,
   isCompact = false,
+  fixedHeight,
   showLastLine = false,
 }: BreadcrumbsTimelineProps) {
   const containerRef = useRef<HTMLDivElement>(null);
@@ -53,6 +58,7 @@ export default function BreadcrumbsTimeline({
   }
 
   const virtualItems = virtualizer.getVirtualItems();
+
   const items = virtualItems.map(virtualizedRow => {
     const {breadcrumb, raw, title, meta, iconComponent, colorConfig, levelComponent} =
       breadcrumbs[virtualizedRow.index];
@@ -114,11 +120,21 @@ export default function BreadcrumbsTimeline({
     <div
       ref={containerRef}
       style={{
-        height: virtualizer.getTotalSize(),
-        contain: 'layout size',
+        height: fixedHeight,
+        overflowY: fixedHeight ? 'auto' : undefined,
+        paddingRight: fixedHeight ? space(2) : undefined,
       }}
     >
-      <Timeline.Container>{items}</Timeline.Container>
+      <div
+        style={{
+          height: virtualizer.getTotalSize(),
+          contain: 'layout size',
+        }}
+      >
+        <VirtualOffset offset={virtualItems[0]?.start ?? 0}>
+          <Timeline.Container>{items}</Timeline.Container>
+        </VirtualOffset>
+      </div>
     </div>
   );
 }
@@ -142,3 +158,19 @@ const Timestamp = styled('div')`
 const ContentWrapper = styled('div')<{isCompact: boolean}>`
   padding-bottom: ${p => space(p.isCompact ? 0.5 : 1.0)};
 `;
+
+function VirtualOffset(p: {children: React.ReactNode; offset: number}) {
+  return (
+    <div
+      style={{
+        position: 'absolute',
+        top: 0,
+        left: 0,
+        width: '100%',
+        transform: `translateY(${p.offset}px)`,
+      }}
+    >
+      {p.children}
+    </div>
+  );
+}

--- a/static/app/utils/analytics/issueAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/issueAnalyticsEvents.tsx
@@ -58,6 +58,7 @@ export type IssueEventParameters = {
   'breadcrumbs.drawer.action': {control: string; value?: string};
   'breadcrumbs.issue_details.change_time_display': {value: string};
   'breadcrumbs.issue_details.drawer_opened': {control: string};
+  'breadcrumbs.trace_view.action': {control: string; value?: string};
   'device.classification.high.end.android.device': {
     processor_count: number;
     processor_frequency: number;
@@ -300,6 +301,7 @@ export const issueEventMap: Record<IssueEventKey, string | null> = {
   'breadcrumbs.issue_details.change_time_display': 'Breadcrumb Time Display Toggled',
   'breadcrumbs.issue_details.drawer_opened': 'Breadcrumb Drawer Opened',
   'breadcrumbs.drawer.action': 'Breadcrumb Drawer Action Taken',
+  'breadcrumbs.trace_view.action': 'Breadcrumb Trace View Action Taken',
   'event_cause.viewed': null,
   'event_cause.docs_clicked': 'Event Cause Docs Clicked',
   'event_cause.snoozed': 'Event Cause Snoozed',

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/transaction/index.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/transaction/index.tsx
@@ -10,6 +10,7 @@ import type {LazyRenderProps} from 'sentry/components/lazyRender';
 import LoadingError from 'sentry/components/loadingError';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {CustomMetricsEventData} from 'sentry/components/metrics/customMetricsEventData';
+import {useHasNewTimelineUI} from 'sentry/components/timeline/utils';
 import {Tooltip} from 'sentry/components/tooltip';
 import {t} from 'sentry/locale';
 import type {EventTransaction} from 'sentry/types/event';
@@ -23,6 +24,7 @@ import type {SpanMetricsQueryFilters} from 'sentry/views/insights/types';
 import {Referrer} from 'sentry/views/performance/newTraceDetails/referrers';
 import {useTransaction} from 'sentry/views/performance/newTraceDetails/traceApi/useTransaction';
 import {CacheMetrics} from 'sentry/views/performance/newTraceDetails/traceDrawer/details/transaction/sections/cacheMetrics';
+import {TraceBreadcrumbs} from 'sentry/views/performance/newTraceDetails/traceDrawer/details/transaction/sections/traceBreadcrumbs';
 import type {TraceTreeNodeDetailsProps} from 'sentry/views/performance/newTraceDetails/traceDrawer/tabs/traceTreeNodeDetails';
 import type {
   TraceTree,
@@ -97,6 +99,8 @@ export function TransactionNodeDetails({
 }: TraceTreeNodeDetailsProps<TraceTreeNode<TraceTree.Transaction>>) {
   const location = useLocation();
   const {projects} = useProjects();
+  const hasNewTimelineUI = useHasNewTimelineUI();
+
   const issues = useMemo(() => {
     return [...node.errors, ...node.performance_issues];
   }, [node.errors, node.performance_issues]);
@@ -183,8 +187,11 @@ export function TransactionNodeDetails({
       {project ? <EventEvidence event={event} project={project} /> : null}
 
       {replayRecord ? null : <ReplayPreview event={event} organization={organization} />}
-
-      <BreadCrumbs event={event} organization={organization} />
+      {hasNewTimelineUI ? (
+        <TraceBreadcrumbs event={event} organization={organization} />
+      ) : (
+        <BreadCrumbs event={event} organization={organization} />
+      )}
 
       {event.projectSlug ? (
         <EventAttachments event={event} projectSlug={event.projectSlug} />

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/transaction/sections/traceBreadcrumbs.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/transaction/sections/traceBreadcrumbs.tsx
@@ -1,0 +1,202 @@
+import {useMemo} from 'react';
+import {useTheme} from '@emotion/react';
+
+import {Button} from 'sentry/components/button';
+import ButtonBar from 'sentry/components/buttonBar';
+import {CompactSelect} from 'sentry/components/compactSelect';
+import ErrorBoundary from 'sentry/components/errorBoundary';
+import {
+  BreadcrumbControlOptions,
+  EmptyBreadcrumbMessage,
+  useBreadcrumbControls,
+} from 'sentry/components/events/breadcrumbs/breadcrumbsDrawerContent';
+import BreadcrumbsTimeline from 'sentry/components/events/breadcrumbs/breadcrumbsTimeline';
+import {
+  BREADCRUMB_TIME_DISPLAY_OPTIONS,
+  BreadcrumbTimeDisplay,
+  getEnhancedBreadcrumbs,
+} from 'sentry/components/events/breadcrumbs/utils';
+import {EventDataSection} from 'sentry/components/events/eventDataSection';
+import {BREADCRUMB_SORT_OPTIONS} from 'sentry/components/events/interfaces/breadcrumbs';
+import {InputGroup} from 'sentry/components/inputGroup';
+import {LazyRender} from 'sentry/components/lazyRender';
+import ExternalLink from 'sentry/components/links/externalLink';
+import {IconClock, IconFilter, IconSearch, IconSort, IconTimer} from 'sentry/icons';
+import {t, tct} from 'sentry/locale';
+import type {EventTransaction, Organization} from 'sentry/types';
+import {trackAnalytics} from 'sentry/utils/analytics';
+
+import {TraceDrawerComponents} from '../../styles';
+
+export function TraceBreadcrumbs({
+  event,
+  organization,
+}: {
+  event: EventTransaction;
+  organization: Organization;
+}) {
+  const theme = useTheme();
+  const enhancedCrumbs = useMemo(() => getEnhancedBreadcrumbs(event), [event]);
+
+  const {
+    search,
+    setSearch,
+    filterSet,
+    setFilterSet,
+    filterOptions,
+    sort,
+    setSort,
+    timeDisplay,
+    setTimeDisplay,
+    displayCrumbs,
+    startTimeString,
+  } = useBreadcrumbControls({enhancedCrumbs});
+
+  if (enhancedCrumbs.length === 0) {
+    return null;
+  }
+
+  const actions = (
+    <ButtonBar gap={1}>
+      <InputGroup>
+        <InputGroup.Input
+          size="xs"
+          value={search}
+          onChange={e => {
+            setSearch(e.target.value);
+            trackAnalytics('breadcrumbs.drawer.action', {
+              control: BreadcrumbControlOptions.SEARCH,
+              organization,
+            });
+          }}
+          aria-label={t('Search All Breadcrumbs')}
+        />
+        <InputGroup.TrailingItems disablePointerEvents>
+          <IconSearch size="xs" />
+        </InputGroup.TrailingItems>
+      </InputGroup>
+      <CompactSelect
+        size="xs"
+        onChange={options => {
+          const newFilters = options.map(({value}) => value);
+          setFilterSet(new Set(newFilters));
+          trackAnalytics('breadcrumbs.trace_view.action', {
+            control: BreadcrumbControlOptions.FILTER,
+            organization,
+          });
+        }}
+        multiple
+        options={filterOptions}
+        maxMenuHeight={400}
+        trigger={props => (
+          <Button
+            size="xs"
+            style={{background: filterSet.size > 0 ? theme.purple100 : 'transparent'}}
+            icon={<IconFilter />}
+            aria-label={t('Filter All Breadcrumbs')}
+            {...props}
+          >
+            {filterSet.size > 0 ? filterSet.size : null}
+          </Button>
+        )}
+      />
+      <CompactSelect
+        size="xs"
+        trigger={props => (
+          <Button
+            size="xs"
+            icon={<IconSort />}
+            aria-label={t('Sort All Breadcrumbs')}
+            {...props}
+          />
+        )}
+        onChange={selectedOption => {
+          setSort(selectedOption.value);
+          trackAnalytics('breadcrumbs.trace_view.action', {
+            control: BreadcrumbControlOptions.SORT,
+            value: selectedOption.value,
+            organization,
+          });
+        }}
+        value={sort}
+        options={BREADCRUMB_SORT_OPTIONS}
+      />
+      <CompactSelect
+        size="xs"
+        trigger={props => (
+          <Button
+            size="xs"
+            icon={
+              timeDisplay === BreadcrumbTimeDisplay.ABSOLUTE ? (
+                <IconClock size="xs" />
+              ) : (
+                <IconTimer size="xs" />
+              )
+            }
+            aria-label={t('Change Time Format for All Breadcrumbs')}
+            {...props}
+          />
+        )}
+        onChange={selectedOption => {
+          setTimeDisplay(selectedOption.value);
+          trackAnalytics('breadcrumbs.trace_view.action', {
+            control: 'time_display',
+            value: selectedOption.value,
+            organization,
+          });
+        }}
+        value={timeDisplay}
+        options={BREADCRUMB_TIME_DISPLAY_OPTIONS}
+      />
+    </ButtonBar>
+  );
+
+  return (
+    <LazyRender {...TraceDrawerComponents.LAZY_RENDER_PROPS} containerHeight={200}>
+      <EventDataSection
+        showPermalink={false}
+        key="breadcrumbs"
+        type="breadcrumbs"
+        title={t('Breadcrumbs')}
+        help={tct(
+          'The trail of events that happened prior to an event. [link:Learn more]',
+          {
+            link: (
+              <ExternalLink
+                openInNewTab
+                href={'https://docs.sentry.io/product/issues/issue-details/breadcrumbs/'}
+              />
+            ),
+          }
+        )}
+        isHelpHoverable
+        actions={actions}
+      >
+        <ErrorBoundary
+          mini
+          message={t('There was an error loading the event breadcrumbs')}
+        >
+          {displayCrumbs.length === 0 ? (
+            <EmptyBreadcrumbMessage
+              onClear={() => {
+                setFilterSet(new Set());
+                setSearch('');
+                trackAnalytics('breadcrumbs.trace_view.action', {
+                  control: 'clear_filters',
+                  organization,
+                });
+              }}
+            />
+          ) : (
+            <BreadcrumbsTimeline
+              breadcrumbs={displayCrumbs}
+              startTimeString={startTimeString}
+              fixedHeight={400}
+              isCompact
+            />
+          )}
+        </ErrorBoundary>
+      </EventDataSection>
+    </LazyRender>
+  );
+}


### PR DESCRIPTION
## What's in this PR

Okay so this allows the new UI to appear in the trace explorer, but with a few caveats. The controls look a bit different than in the drawer and it has a fixed height and inner scroll.

This was sort of a rush job since I start vacation soon and wanted there to at least be an option for the team while I'm out but I'm not super pleased with this user experience, since we still have the inner scroll that the whole redesign pointedly removes.

<img width="1070" alt="image" src="https://github.com/user-attachments/assets/e9d8a02a-4082-4c96-a106-b21f96b27dd0">

It also creates some code duplication since the buttons used in the drawer are similar, but not the same, since the controls weren't designed with the trace drawer in mind.  I tried to reduce the duplication with a wrapping hook, but it's a bit messy.


## An alternative

IF we're open to the idea of popping open the drawer experience, we can get away with dropping it in _really_ easily with no code smell:

```jsx
// static/app/views/performance/newTraceDetails/traceDrawer/details/transaction/index.tsx

 {hasNewTimelineUI ? (
// Provided we refactor to omit `group` prop, or find one from the trace (I didn't look into this)
  <BreadcrumbsDataSection event={event}   />
) : (
  <BreadCrumbs event={event} organization={organization} />
)}
```
This would make the two components **_identical_**, at the cost of covering the rest of the trace drawer with the global drawer when the user prompts it. Not sure how people feel about it, though so I'll leave this PR up for discussion.
<img width="1079" alt="image" src="https://github.com/user-attachments/assets/b15d5977-9795-471b-8962-f04377ff84c8">

If we decide the alternative is a better call, please close out this PR.


Feel free to modify this PR to make appropriate changes as we see fit since I'll be away for a bit.