### PR TITLE
fix(replays): Fixes flickering when replaying a mobile replay

### DIFF
--- a/static/app/components/replays/videoReplayer.tsx
+++ b/static/app/components/replays/videoReplayer.tsx
@@ -412,6 +412,10 @@ export class VideoReplayer {
     // This is the soon-to-be previous video that needs to be hidden
     if (this._currentVideo) {
       this._currentVideo.style.display = 'none';
+      // resets the soon-to-be previous video to the beginning if it's ended so it starts from the beginning on replay
+      if (this._currentVideo.ended) {
+        this.setVideoTime(this._currentVideo, 0);
+      }
     }
 
     nextVideo.style.display = 'block';

--- a/static/app/components/replays/videoReplayer.tsx
+++ b/static/app/components/replays/videoReplayer.tsx
@@ -412,7 +412,7 @@ export class VideoReplayer {
     // This is the soon-to-be previous video that needs to be hidden
     if (this._currentVideo) {
       this._currentVideo.style.display = 'none';
-      // resets the soon-to-be previous video to the beginning if it's ended so it starts from the beginning on replay
+      // resets the soon-to-be previous video to the beginning if it's ended so it starts from the beginning on restart
       if (this._currentVideo.ended) {
         this.setVideoTime(this._currentVideo, 0);
       }


### PR DESCRIPTION
When replaying a replay, the video flickers between segments. When you slow down the video, you notice the flickering is caused by the last frame of the next video showing, before it quickly changes to the first frame of the next video when the video is played. 
To fix this, when a video ends, we reset it to the beginning to ensure that the last frame isn't shown when replaying.

Before:

https://github.com/user-attachments/assets/5ec8d1a0-03e6-4a26-b028-cc9d4cad02fd

After:

https://github.com/user-attachments/assets/eec76606-b36f-4d03-9478-2f7b3ba78a74


Closes https://github.com/getsentry/sentry/issues/70687 