### PR TITLE
chore(hybrid-cloud): Moves majority of RPC Model TypedDicts to typing_extensions impl

### DIFF
--- a/src/sentry/identity/services/identity/model.py
+++ b/src/sentry/identity/services/identity/model.py
@@ -2,7 +2,9 @@
 #     from __future__ import annotations
 # in modules such as this one where hybrid cloud data models or service classes are
 # defined, because we want to reflect on type annotations and avoid forward references.
-from typing import TYPE_CHECKING, Any, TypedDict
+from typing import TYPE_CHECKING, Any
+
+from typing_extensions import TypedDict
 
 from sentry.hybridcloud.rpc import RpcModel
 

--- a/src/sentry/organizations/services/organization/model.py
+++ b/src/sentry/organizations/services/organization/model.py
@@ -5,11 +5,12 @@
 from collections.abc import Callable, Iterable, Mapping, Sequence
 from datetime import datetime
 from enum import IntEnum
-from typing import Any, TypedDict
+from typing import Any
 
 from django.dispatch import Signal
 from django.utils import timezone
 from pydantic import Field
+from typing_extensions import TypedDict
 
 from sentry import roles
 from sentry.hybridcloud.rpc import RpcModel

--- a/src/sentry/projects/services/project/model.py
+++ b/src/sentry/projects/services/project/model.py
@@ -4,9 +4,10 @@
 # defined, because we want to reflect on type annotations and avoid forward references.
 
 from collections.abc import Callable
-from typing import Any, TypedDict
+from typing import Any
 
 from pydantic.fields import Field
+from typing_extensions import TypedDict
 
 from sentry.constants import ObjectStatus
 from sentry.hybridcloud.rpc import OptionValue, RpcModel

--- a/src/sentry/sdk_updates.py
+++ b/src/sentry/sdk_updates.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
 import logging
-from typing import TypedDict
 
 from django.conf import settings
 from django.core.cache import cache
 from packaging.version import Version
+from typing_extensions import TypedDict
 
 from sentry.tasks.release_registry import SDK_INDEX_CACHE_KEY
 from sentry.utils.safe import get_path

--- a/src/sentry/sentry_apps/services/app/model.py
+++ b/src/sentry/sentry_apps/services/app/model.py
@@ -7,9 +7,10 @@ import datetime
 import hmac
 from collections.abc import MutableMapping
 from hashlib import sha256
-from typing import Any, Protocol, TypedDict
+from typing import Any, Protocol
 
 from pydantic.fields import Field
+from typing_extensions import TypedDict
 
 from sentry.constants import SentryAppInstallationStatus
 from sentry.hybridcloud.rpc import RpcModel, RpcModelProtocolMeta

--- a/src/sentry/services/organization/model.py
+++ b/src/sentry/services/organization/model.py
@@ -9,7 +9,7 @@ class OrganizationOptions(pydantic.BaseModel):
     owning_user_id: int | None = None
     owning_email: str | None = None
     create_default_team: bool = True
-    is_test = False
+    is_test: bool = False
 
 
 class PostProvisionOptions(pydantic.BaseModel):

--- a/src/sentry/users/services/user/model.py
+++ b/src/sentry/users/services/user/model.py
@@ -5,9 +5,10 @@
 
 import datetime
 from enum import IntEnum
-from typing import Any, TypedDict
+from typing import Any
 
 from pydantic.fields import Field
+from typing_extensions import TypedDict
 
 from sentry.hybridcloud.rpc import DEFAULT_DATE, RpcModel
 

--- a/src/sentry/users/services/user_option/model.py
+++ b/src/sentry/users/services/user_option/model.py
@@ -3,7 +3,9 @@
 # in modules such as this one where hybrid cloud data models or service classes are
 # defined, because we want to reflect on type annotations and avoid forward references.
 
-from typing import Any, TypedDict
+from typing import Any
+
+from typing_extensions import TypedDict
 
 from sentry.hybridcloud.rpc import RpcModel
 

--- a/src/sentry/users/services/usersocialauth/model.py
+++ b/src/sentry/users/services/usersocialauth/model.py
@@ -3,7 +3,9 @@
 # in modules such as this one where hybrid cloud data models or service classes are
 # defined, because we want to reflect on type annotations and avoid forward references.
 
-from typing import Any, TypedDict
+from typing import Any
+
+from typing_extensions import TypedDict
 
 from sentry.hybridcloud.rpc import RpcModel
 from social_auth.backends import BaseAuth


### PR DESCRIPTION
This PR is in preparation for the Pydantic v2 upgrade. As per the [Pydantic documentation](https://docs.pydantic.dev/latest/api/standard_library_types/#typeddict), I've converted all `TypedDict` references for our RPC models to use the `typing_extensions` package implementation instead of the base `typing` `TypedDict`.

Once we upgrade to Python 3.12+, we should be able to safely use the `typing` package's implementation again.
