### PR TITLE
Project Template API - POST

### DIFF
--- a/src/sentry/api/endpoints/project_templates_index.py
+++ b/src/sentry/api/endpoints/project_templates_index.py
@@ -70,9 +70,11 @@ class OrganizationProjectTemplatesIndexEndpoint(OrganizationEndpoint):
     @ensure_rollout_enabled(PROJECT_TEMPLATE_FEATURE_FLAG)
     def post(self, request: Request, organization: Organization) -> Response:
         """
-        Create a new Project Template.
+        Create a new Project Template for the organization.
 
-        Create a new project template for the organization.
+        The Request body should be a JSON object with the following keys:
+        - name: string
+        - options: {key: 'value'} - optional - creates a ProjectTemplateOption for each key-value pair
         """
         serializer = ProjectTemplateWriteSerializer(data=request.data)
         if not serializer.is_valid():

--- a/src/sentry/api/endpoints/project_templates_index.py
+++ b/src/sentry/api/endpoints/project_templates_index.py
@@ -42,7 +42,9 @@ class OrganizationProjectTemplatesIndexEndpoint(OrganizationEndpoint):
 
     publish_status = {
         "GET": ApiPublishStatus.PRIVATE,
+        "POST": ApiPublishStatus.PRIVATE,
     }
+
     permission_classes = (OrganizationPermission,)
 
     @ensure_rollout_enabled(PROJECT_TEMPLATE_FEATURE_FLAG)

--- a/src/sentry/api/endpoints/project_templates_index.py
+++ b/src/sentry/api/endpoints/project_templates_index.py
@@ -76,7 +76,7 @@ class OrganizationProjectTemplatesIndexEndpoint(OrganizationEndpoint):
         if name is None:
             return Response(status=400, data={"detail": "Template name is required"})
 
-        # TODO - Rate Limiting
+        # TODO @saponifi3d - Rate Limiting once we know the limits
 
         project_template = ProjectTemplate.objects.create(
             name=name,

--- a/src/sentry/api/serializers/models/project_template.py
+++ b/src/sentry/api/serializers/models/project_template.py
@@ -4,6 +4,8 @@ from datetime import datetime
 from enum import StrEnum
 from typing import Any, TypedDict
 
+from rest_framework import serializers
+
 from sentry.api.serializers import Serializer, register
 from sentry.models.options.project_template_option import TProjectOptions
 from sentry.models.projecttemplate import ProjectTemplate
@@ -63,3 +65,12 @@ class ProjectTemplateSerializer(Serializer):
             response["options"] = options
 
         return response
+
+
+class ProjectTemplateWriteSerializer(serializers.Serializer):
+    id = serializers.IntegerField(required=False)
+    name = serializers.CharField(required=True)
+    options = serializers.DictField(required=False)
+
+    def validate(self, data):
+        return data

--- a/src/sentry/audit_log/register.py
+++ b/src/sentry/audit_log/register.py
@@ -535,3 +535,12 @@ default_manager.add(
         template="Deleted span-based metric for span attribute {span_attribute} for project {project_slug}",
     )
 )
+
+default_manager.add(
+    AuditLogEvent(
+        event_id=190,
+        name="PROJECT_TEMPLATE_CREATED",
+        api_name="project_template.create",
+        template="Created project template {template_name} for organization {organization_id}",
+    )
+)

--- a/src/sentry/audit_log/register.py
+++ b/src/sentry/audit_log/register.py
@@ -541,6 +541,6 @@ default_manager.add(
         event_id=190,
         name="PROJECT_TEMPLATE_CREATED",
         api_name="project_template.create",
-        template="Created project template {template_name} for organization {organization_id}",
+        template="Created project template {name} for organization {organization_id}",
     )
 )

--- a/src/sentry/models/projecttemplate.py
+++ b/src/sentry/models/projecttemplate.py
@@ -28,3 +28,6 @@ class ProjectTemplate(DefaultFieldsModel):
         ]
 
     __repr__ = sane_repr("name", "organization_id")
+
+    def get_audit_log_data(self):
+        return {"name": self.name, "organization_id": self.organization_id}

--- a/tests/sentry/api/endpoints/test_project_templates_index.py
+++ b/tests/sentry/api/endpoints/test_project_templates_index.py
@@ -70,18 +70,24 @@ class ProjectTemplateIndexPostTest(ProjectTemplateAPIBase):
         assert response.status_code == 404
 
     @with_feature(PROJECT_TEMPLATE_FEATURE_FLAG)
-    def test_post__as_member(self):
+    def test_post(self):
+        response = self.get_success_response(self.organization.id, name="Test Project Template")
+        assert response.status_code == 201
+
+    @with_feature(PROJECT_TEMPLATE_FEATURE_FLAG)
+    def test_post__as_member_without_permission(self):
+        """
+        Test that a member is part of the organization, but does not have the required
+        permissions to create a project template.
+
+        The user is a member of the organization, but does not have write access to the org.
+        """
         org_two = self.create_organization()
         self.create_team(organization=org_two, members=[self.user])
         self.create_project_template(organization=org_two)
 
         response = self.get_error_response(org_two.id, status_code=403)
         assert response.status_code == 403
-
-    @with_feature(PROJECT_TEMPLATE_FEATURE_FLAG)
-    def test_post(self):
-        response = self.get_success_response(self.organization.id, name="Test Project Template")
-        assert response.status_code == 201
 
     @with_feature(PROJECT_TEMPLATE_FEATURE_FLAG)
     def test_post__with_options(self):

--- a/tests/sentry/api/endpoints/test_project_templates_index.py
+++ b/tests/sentry/api/endpoints/test_project_templates_index.py
@@ -14,21 +14,21 @@ class ProjectTemplateIndexTest(APITestCase):
     def setUp(self):
         super().setUp()
         self.user = self.create_user()
-        self.org = self.create_organization()
-        self.team = self.create_team(organization=self.org, members=[self.user])
+        self.organization = self.create_organization()
+        self.team = self.create_team(members=[self.user])
 
         self.login_as(self.user)
 
-        self.project_template = self.create_project_template(organization=self.org)
-        self.project_template_two = self.create_project_template(organization=self.org)
+        self.project_template = self.create_project_template(organization=self.organization)
+        self.project_template_two = self.create_project_template(organization=self.organization)
 
     def test_get__no_feature(self):
-        response = self.get_error_response(self.org.id, status_code=404)
+        response = self.get_error_response(self.organization.id, status_code=404)
         assert response.status_code == 404
 
     @with_feature(PROJECT_TEMPLATE_FEATURE_FLAG)
     def test_get(self):
-        response = self.get_success_response(self.org.id)
+        response = self.get_success_response(self.organization.id)
         assert len(response.data) == 2
 
         # Ensure the project templates are sorted by date_added
@@ -41,7 +41,7 @@ class ProjectTemplateIndexTest(APITestCase):
         self.project_template.delete()
         self.project_template_two.delete()
 
-        response = self.get_success_response(self.org.id)
+        response = self.get_success_response(self.organization.id)
         assert len(response.data) == 0
 
     @mark.skip("TODO Implement tests for pagination")
@@ -66,20 +66,20 @@ class ProjectTemplateIndexPostTest(APITestCase):
     def setUp(self):
         super().setUp()
         self.user = self.create_user()
-        self.org = self.create_organization(owner=self.user)
-        self.team = self.create_team(organization=self.org, members=[self.user])
+        self.organization = self.create_organization(owner=self.user)
+        self.team = self.create_team(members=[self.user])
 
         self.login_as(self.user)
 
-        self.project_template = self.create_project_template(organization=self.org)
-        self.project_template_two = self.create_project_template(organization=self.org)
+        self.project_template = self.create_project_template(organization=self.organization)
+        self.project_template_two = self.create_project_template(organization=self.organization)
 
     def test_post__no_feature(self):
-        response = self.get_error_response(self.org.id, method="POST", status_code=404)
+        response = self.get_error_response(self.organization.id, method="POST", status_code=404)
         assert response.status_code == 404
 
     @with_feature(PROJECT_TEMPLATE_FEATURE_FLAG)
-    def test_post__non_admin(self):
+    def test_post__as_member(self):
         org_two = self.create_organization()
         self.create_team(organization=org_two, members=[self.user])
         self.create_project_template(organization=org_two)
@@ -90,7 +90,7 @@ class ProjectTemplateIndexPostTest(APITestCase):
     @with_feature(PROJECT_TEMPLATE_FEATURE_FLAG)
     def test_post(self):
         response = self.get_success_response(
-            self.org.id, method="POST", name="Test Project Template"
+            self.organization.id, method="POST", name="Test Project Template"
         )
         assert response.status_code == 201
 
@@ -98,7 +98,7 @@ class ProjectTemplateIndexPostTest(APITestCase):
     def test_post__with_options(self):
         test_options = {"test-key": "value"}
         response = self.get_success_response(
-            self.org.id,
+            self.organization.id,
             method="POST",
             name="Test Project Template",
             options=test_options,
@@ -111,14 +111,14 @@ class ProjectTemplateIndexPostTest(APITestCase):
 
     @with_feature(PROJECT_TEMPLATE_FEATURE_FLAG)
     def test_post__no_name(self):
-        response = self.get_error_response(self.org.id, method="POST", status_code=400)
+        response = self.get_error_response(self.organization.id, method="POST", status_code=400)
         assert response.status_code == 400
 
     @with_feature(PROJECT_TEMPLATE_FEATURE_FLAG)
     @patch("sentry.api.base.create_audit_entry")
     def test_post__audit_log(self, mock_audit):
         self.get_success_response(
-            self.org.id,
+            self.organization.id,
             method="POST",
             name="Test Project Template",
         )

--- a/tests/sentry/api/endpoints/test_project_templates_index.py
+++ b/tests/sentry/api/endpoints/test_project_templates_index.py
@@ -15,7 +15,7 @@ class ProjectTemplateAPIBase(APITestCase):
         super().setUp()
         self.user = self.create_user()
         self.organization = self.create_organization(owner=self.user)
-        self.team = self.create_team(members=[self.user])
+        self.team = self.create_team()
 
         self.login_as(self.user)
 

--- a/tests/sentry/audit_log/test_register.py
+++ b/tests/sentry/audit_log/test_register.py
@@ -34,6 +34,7 @@ class AuditLogEventRegisterTest(TestCase):
             "project.enable",
             "project.disable",
             "project.ownership-rule.edit",
+            "project_template.create",
             "tagkey.remove",
             "projectkey.create",
             "projectkey.edit",


### PR DESCRIPTION
# Description
Add ability to create a Project Template in API

## Callouts
- Audit Logging when creating a new project template
- TODO - Rate Limiting, these numbers aren't clear yet so just leaving it as a TODO