### PR TITLE
feat(stats): Add switch button field for client discard legend

### DIFF
--- a/static/app/views/organizationStats/index.tsx
+++ b/static/app/views/organizationStats/index.tsx
@@ -344,7 +344,12 @@ export class OrganizationStats extends Component<OrganizationStatsProps> {
   }
 }
 
-export default withPageFilters(withOrganization(OrganizationStats));
+const HookOrgStats = HookOrDefault({
+  hookName: 'component:enhanced-org-stats',
+  defaultComponent: OrganizationStats,
+});
+
+export default withPageFilters(withOrganization(HookOrgStats));
 
 const DropdownDataCategory = styled(CompactSelect)`
   width: auto;

--- a/static/app/views/organizationStats/index.tsx
+++ b/static/app/views/organizationStats/index.tsx
@@ -52,6 +52,8 @@ export const PAGE_QUERY_PARAMS = [
   'query',
   'cursor',
   'spikeCursor',
+  // From show data discarded on client toggle
+  'clientDiscard',
 ];
 
 export type OrganizationStatsProps = {
@@ -117,6 +119,10 @@ export class OrganizationStats extends Component<OrganizationStatsProps> {
     }
 
     return {period: DEFAULT_STATS_PERIOD};
+  }
+
+  get clientDiscard(): boolean {
+    return this.props.location?.query?.clientDiscard === 'true';
   }
 
   // Validation and type-casting should be handled by chart
@@ -186,6 +192,7 @@ export class OrganizationStats extends Component<OrganizationStatsProps> {
    */
   setStateOnUrl = (
     nextState: {
+      clientDiscard?: boolean;
       cursor?: string;
       dataCategory?: DataCategoryInfo['plural'];
       query?: string;
@@ -273,6 +280,7 @@ export class OrganizationStats extends Component<OrganizationStatsProps> {
         dataCategoryApiName={this.dataCategoryInfo.apiName}
         dataDatetime={this.dataDatetime}
         chartTransform={this.chartTransform}
+        clientDiscard={this.clientDiscard}
         handleChangeState={this.setStateOnUrl}
         router={router}
         location={location}
@@ -336,12 +344,7 @@ export class OrganizationStats extends Component<OrganizationStatsProps> {
   }
 }
 
-const HookOrgStats = HookOrDefault({
-  hookName: 'component:enhanced-org-stats',
-  defaultComponent: OrganizationStats,
-});
-
-export default withPageFilters(withOrganization(HookOrgStats));
+export default withPageFilters(withOrganization(OrganizationStats));
 
 const DropdownDataCategory = styled(CompactSelect)`
   width: auto;

--- a/static/app/views/organizationStats/usageChart/index.tsx
+++ b/static/app/views/organizationStats/usageChart/index.tsx
@@ -161,10 +161,14 @@ export type UsageChartProps = {
   isLoading?: boolean;
 
   /**
+   * Selected map of each legend item.
+   * Default to be selected if item is not in the map
+   */
+  legendSelected?: Record<string, boolean>;
+  /**
    * Intervals between the x-axis values
    */
   usageDateInterval?: IntervalPeriod;
-
   /**
    * Display datetime in UTC
    */
@@ -339,6 +343,7 @@ function UsageChartBody({
   usageDateShowUtc = true,
   yAxisFormatter,
   handleDataTransformation = cumulativeTotalDataTransformation,
+  legendSelected,
 }: UsageChartProps) {
   const theme = useTheme();
 
@@ -520,14 +525,7 @@ function UsageChartBody({
         top: 5,
         data: chartLegendData(),
         theme,
-        selected: {
-          [SeriesTypes.ACCEPTED]: true,
-          [SeriesTypes.FILTERED]: true,
-          [SeriesTypes.RATE_LIMITED]: true,
-          [SeriesTypes.INVALID]: true,
-          [SeriesTypes.CLIENT_DISCARD]: false,
-          [SeriesTypes.PROJECTED]: true,
-        },
+        selected: legendSelected,
       })}
     />
   );

--- a/static/app/views/organizationStats/usageChart/index.tsx
+++ b/static/app/views/organizationStats/usageChart/index.tsx
@@ -7,7 +7,7 @@ import type {
   TooltipComponentOption,
 } from 'echarts';
 
-import BaseChart from 'sentry/components/charts/baseChart';
+import BaseChart, {type BaseChartProps} from 'sentry/components/charts/baseChart';
 import Legend from 'sentry/components/charts/components/legend';
 import xAxis from 'sentry/components/charts/components/xAxis';
 import barSeries from 'sentry/components/charts/series/barSeries';
@@ -119,9 +119,10 @@ export type UsageChartProps = {
   dataCategory: DataCategoryInfo['plural'];
 
   dataTransform: ChartDataTransform;
-  usageDateEnd: string;
 
+  usageDateEnd: string;
   usageDateStart: string;
+
   /**
    * Usage data to draw on chart
    */
@@ -131,20 +132,20 @@ export type UsageChartProps = {
    * Override chart colors for each outcome
    */
   categoryColors?: string[];
-
   /**
    * Config for category dropdown options
    */
   categoryOptions?: CategoryOption[];
+
   /**
    * Additional data to draw on the chart alongside usage
    */
   chartSeries?: SeriesOption[];
-
   /**
    * Replace default tooltip
    */
   chartTooltip?: TooltipComponentOption;
+
   errors?: Record<string, Error>;
 
   /**
@@ -156,15 +157,15 @@ export type UsageChartProps = {
     stats: Readonly<ChartStats>,
     transform: Readonly<ChartDataTransform>
   ) => ChartStats;
-
   isError?: boolean;
-  isLoading?: boolean;
 
+  isLoading?: boolean;
   /**
    * Selected map of each legend item.
    * Default to be selected if item is not in the map
    */
   legendSelected?: Record<string, boolean>;
+  onLegendSelectChanged?: BaseChartProps['onLegendSelectChanged'];
   /**
    * Intervals between the x-axis values
    */
@@ -344,6 +345,7 @@ function UsageChartBody({
   yAxisFormatter,
   handleDataTransformation = cumulativeTotalDataTransformation,
   legendSelected,
+  onLegendSelectChanged,
 }: UsageChartProps) {
   const theme = useTheme();
 
@@ -519,7 +521,7 @@ function UsageChartBody({
               valueFormatter: tooltipValueFormatter,
             }
       }
-      onLegendSelectChanged={() => {}}
+      onLegendSelectChanged={onLegendSelectChanged}
       legend={Legend({
         right: 10,
         top: 5,

--- a/static/app/views/organizationStats/usageChart/index.tsx
+++ b/static/app/views/organizationStats/usageChart/index.tsx
@@ -117,17 +117,13 @@ export const enum SeriesTypes {
 
 export type UsageChartProps = {
   dataCategory: DataCategoryInfo['plural'];
-
   dataTransform: ChartDataTransform;
-
   usageDateEnd: string;
   usageDateStart: string;
-
   /**
    * Usage data to draw on chart
    */
   usageStats: ChartStats;
-
   /**
    * Override chart colors for each outcome
    */
@@ -136,7 +132,6 @@ export type UsageChartProps = {
    * Config for category dropdown options
    */
   categoryOptions?: CategoryOption[];
-
   /**
    * Additional data to draw on the chart alongside usage
    */
@@ -145,9 +140,7 @@ export type UsageChartProps = {
    * Replace default tooltip
    */
   chartTooltip?: TooltipComponentOption;
-
   errors?: Record<string, Error>;
-
   /**
    * Modify the usageStats using the transformation method selected.
    * If the parent component will handle the data transformation, you should
@@ -158,7 +151,6 @@ export type UsageChartProps = {
     transform: Readonly<ChartDataTransform>
   ) => ChartStats;
   isError?: boolean;
-
   isLoading?: boolean;
   /**
    * Selected map of each legend item.

--- a/static/app/views/organizationStats/usageStatsOrg.tsx
+++ b/static/app/views/organizationStats/usageStatsOrg.tsx
@@ -277,7 +277,7 @@ class UsageStatsOrganization<
         subLabels: chartSubLabels,
         skipZeroValuedSubLabels: true,
       },
-      legendSelected: !clientDiscard ? {[SeriesTypes.CLIENT_DISCARD]: false} : undefined,
+      legendSelected: {[SeriesTypes.CLIENT_DISCARD]: !!clientDiscard},
       onLegendSelectChanged: ({name, selected}) => {
         if (name === SeriesTypes.CLIENT_DISCARD) {
           handleChangeState({clientDiscard: selected[name]});

--- a/static/app/views/organizationStats/usageStatsOrg.tsx
+++ b/static/app/views/organizationStats/usageStatsOrg.tsx
@@ -245,7 +245,7 @@ class UsageStatsOrganization<
   }
 
   get chartProps(): UsageChartProps {
-    const {dataCategory, clientDiscard} = this.props;
+    const {dataCategory, clientDiscard, handleChangeState} = this.props;
     const {error, errors, loading} = this.state;
     const {
       chartStats,
@@ -278,6 +278,11 @@ class UsageStatsOrganization<
         skipZeroValuedSubLabels: true,
       },
       legendSelected: !clientDiscard ? {[SeriesTypes.CLIENT_DISCARD]: false} : undefined,
+      onLegendSelectChanged: ({name, selected}) => {
+        if (name === SeriesTypes.CLIENT_DISCARD) {
+          handleChangeState({clientDiscard: selected[name]});
+        }
+      },
     } as UsageChartProps;
 
     return chartProps;


### PR DESCRIPTION
### Goal

The "Client Discard" outcome is now shown in the stats chart. Since it can have a high volume, we want to disable it by default so customers can focus on other stats. See [feedback](https://github.com/getsentry/sentry/pull/73869#discussion_r1673847988).

While users can enable or disable it by clicking on the chart's legend, this option is not very noticeable. To make it easier, we are adding a more prominent switch button at the bottom of the chart.

This switch button updates the URL with the 'clientDiscard' parameter, which controls whether the chart shows or hides the outcome.

**Preview**


https://github.com/user-attachments/assets/d1182ac7-7e6c-49e7-945b-a592f268ca23



### Note

Customers are still able to hide/show the client discard outcome by clicking on the chart's legend