### PR TITLE
fix(slack): Fix error handling when fetching slack channel information

### DIFF
--- a/src/sentry/integrations/slack/utils/channel.py
+++ b/src/sentry/integrations/slack/utils/channel.py
@@ -111,6 +111,7 @@ def validate_channel_id(name: str, integration_id: int | None, input_channel_id:
                 "input_channel_id": input_channel_id,
             },
         )
+        raise ValidationError("Could not retrieve Slack channel information.") from e
 
     if not isinstance(results, dict):
         raise IntegrationError("Bad slack channel list response.")


### PR DESCRIPTION
Validation raise was missed in the refactor done in https://github.com/getsentry/sentry/pull/73966.

Fixes https://sentry.sentry.io/issues/5600493483/