### PR TITLE
feat(uptime): Handle uptime check results when subscription is in onboarding mode

### DIFF
--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -3243,19 +3243,22 @@ class MonitorIngestTestCase(MonitorTestCase):
 
 class UptimeTestCase(TestCase):
     def create_uptime_result(
-        self, subscription_id: str | None = None, status: str = CHECKSTATUS_FAILURE
+        self,
+        subscription_id: str | None = None,
+        status: str = CHECKSTATUS_FAILURE,
+        scheduled_check_time: datetime = None,
     ) -> CheckResult:
         if subscription_id is None:
             subscription_id = uuid.uuid4().hex
+        if scheduled_check_time is None:
+            scheduled_check_time = datetime.now().replace(microsecond=0)
         return {
             "guid": uuid.uuid4().hex,
             "subscription_id": subscription_id,
             "status": status,
             "status_reason": {"type": CHECKSTATUSREASONTYPE_TIMEOUT, "description": "it timed out"},
             "trace_id": uuid.uuid4().hex,
-            "scheduled_check_time_ms": int(
-                datetime.now().replace(microsecond=0).timestamp() * 1000
-            ),
+            "scheduled_check_time_ms": int(scheduled_check_time.timestamp() * 1000),
             "actual_check_time_ms": int(datetime.now().replace(microsecond=0).timestamp() * 1000),
             "duration_ms": 100,
             "request_info": {"request_type": REQUESTTYPE_HEAD, "http_status_code": 500},

--- a/src/sentry/uptime/detectors/tasks.py
+++ b/src/sentry/uptime/detectors/tasks.py
@@ -187,7 +187,14 @@ def monitor_url_for_project(project: Project, url: str):
     it. Also deletes any other auto-detected monitors since this one should replace them.
     """
     for monitored_subscription in get_auto_monitored_subscriptions_for_project(project):
-        delete_project_uptime_subscription(project, monitored_subscription.uptime_subscription)
+        delete_project_uptime_subscription(
+            project,
+            monitored_subscription.uptime_subscription,
+            modes=[
+                ProjectUptimeSubscriptionMode.AUTO_DETECTED_ONBOARDING,
+                ProjectUptimeSubscriptionMode.AUTO_DETECTED_ACTIVE,
+            ],
+        )
     subscription = create_uptime_subscription(
         url, ONBOARDING_SUBSCRIPTION_INTERVAL_SECONDS, ONBOARDING_SUBSCRIPTION_TIMEOUT_MS
     )

--- a/src/sentry/uptime/subscriptions/subscriptions.py
+++ b/src/sentry/uptime/subscriptions/subscriptions.py
@@ -88,7 +88,7 @@ def delete_project_uptime_subscription(
 
 def remove_uptime_subscription_if_unused(uptime_subscription: UptimeSubscription):
     """
-    Determines if an uptime subscription is no longer used and removes it if so
+    Determines if an uptime subscription is no longer used by any `ProjectUptimeSubscriptions` and removes it if so
     """
     # If the uptime subscription is no longer used, we also remove it.
     if not uptime_subscription.projectuptimesubscription_set.exists():

--- a/src/sentry/uptime/subscriptions/subscriptions.py
+++ b/src/sentry/uptime/subscriptions/subscriptions.py
@@ -67,21 +67,29 @@ def create_project_uptime_subscription(
     )[0]
 
 
-def delete_project_uptime_subscription(project: Project, uptime_subscription: UptimeSubscription):
+def delete_project_uptime_subscription(
+    project: Project,
+    uptime_subscription: UptimeSubscription,
+    modes: list[ProjectUptimeSubscriptionMode],
+):
     """
     Deletes the link from a project to an `UptimeSubscription`. Also checks to see if the subscription
     has been orphaned, and if so removes it as well.
     """
-    # TODO: Have a way to specify which mode(s) we should actually delete here.
-    try:
-        uptime_project_subscription = ProjectUptimeSubscription.objects.get(
-            project=project, uptime_subscription=uptime_subscription
-        )
-    except ProjectUptimeSubscription.DoesNotExist:
-        pass
-    else:
+    for uptime_project_subscription in ProjectUptimeSubscription.objects.filter(
+        project=project,
+        uptime_subscription=uptime_subscription,
+        mode__in=modes,
+    ):
         uptime_project_subscription.delete()
 
+    remove_uptime_subscription_if_unused(uptime_subscription)
+
+
+def remove_uptime_subscription_if_unused(uptime_subscription: UptimeSubscription):
+    """
+    Determines if an uptime subscription is no longer used and removes it if so
+    """
     # If the uptime subscription is no longer used, we also remove it.
     if not uptime_subscription.projectuptimesubscription_set.exists():
         delete_uptime_subscription(uptime_subscription)

--- a/tests/sentry/uptime/consumers/test_results_consumers.py
+++ b/tests/sentry/uptime/consumers/test_results_consumers.py
@@ -22,7 +22,7 @@ from sentry.models.group import Group
 from sentry.remote_subscriptions.consumers.result_consumer import FAKE_SUBSCRIPTION_ID
 from sentry.testutils.cases import UptimeTestCase
 from sentry.uptime.consumers.results_consumer import (
-    AUTO_DETECTED_ACTIVE_SUBSCRIPTION_INTERVAL_SECONDS,
+    AUTO_DETECTED_ACTIVE_SUBSCRIPTION_INTERVAL,
     ONBOARDING_MONITOR_PERIOD,
     UptimeResultsStrategyFactory,
     build_last_update_key,
@@ -259,8 +259,7 @@ class ProcessResultTest(UptimeTestCase):
         with pytest.raises(UptimeSubscription.DoesNotExist):
             uptime_subscription.refresh_from_db()
         new_uptime_subscription = self.project_subscription.uptime_subscription
-        assert (
-            new_uptime_subscription.interval_seconds
-            == AUTO_DETECTED_ACTIVE_SUBSCRIPTION_INTERVAL_SECONDS
+        assert new_uptime_subscription.interval_seconds == int(
+            AUTO_DETECTED_ACTIVE_SUBSCRIPTION_INTERVAL.total_seconds()
         )
         assert uptime_subscription.url == new_uptime_subscription.url

--- a/tests/sentry/uptime/consumers/test_results_consumers.py
+++ b/tests/sentry/uptime/consumers/test_results_consumers.py
@@ -1,5 +1,5 @@
 import uuid
-from datetime import datetime
+from datetime import datetime, timedelta, timezone
 from hashlib import md5
 from unittest import mock
 from unittest.mock import call
@@ -12,6 +12,7 @@ from django.test import override_settings
 from sentry_kafka_schemas.schema_types.uptime_results_v1 import (
     CHECKSTATUS_FAILURE,
     CHECKSTATUS_MISSED_WINDOW,
+    CHECKSTATUS_SUCCESS,
     CheckResult,
 )
 
@@ -21,10 +22,19 @@ from sentry.models.group import Group
 from sentry.remote_subscriptions.consumers.result_consumer import FAKE_SUBSCRIPTION_ID
 from sentry.testutils.cases import UptimeTestCase
 from sentry.uptime.consumers.results_consumer import (
+    AUTO_DETECTED_ACTIVE_SUBSCRIPTION_INTERVAL_SECONDS,
+    ONBOARDING_MONITOR_PERIOD,
     UptimeResultsStrategyFactory,
     build_last_update_key,
+    build_onboarding_failure_key,
 )
 from sentry.uptime.detectors.ranking import _get_cluster
+from sentry.uptime.detectors.tasks import is_failed_url
+from sentry.uptime.models import (
+    ProjectUptimeSubscription,
+    ProjectUptimeSubscriptionMode,
+    UptimeSubscription,
+)
 
 
 class ProcessResultTest(UptimeTestCase):
@@ -86,11 +96,11 @@ class ProcessResultTest(UptimeTestCase):
                 [
                     call(
                         "uptime.result_processor.handle_result_for_project",
-                        tags={"status": CHECKSTATUS_FAILURE},
+                        tags={"status": CHECKSTATUS_FAILURE, "mode": "auto_detected_active"},
                     ),
                     call(
                         "uptime.result_processor.skipping_already_processed_update",
-                        tags={"status": CHECKSTATUS_FAILURE},
+                        tags={"status": CHECKSTATUS_FAILURE, "mode": "auto_detected_active"},
                     ),
                 ]
             )
@@ -110,7 +120,7 @@ class ProcessResultTest(UptimeTestCase):
             self.send_result(result)
             metrics.incr.assert_called_once_with(
                 "uptime.result_processor.handle_result_for_project",
-                tags={"status": CHECKSTATUS_MISSED_WINDOW},
+                tags={"status": CHECKSTATUS_MISSED_WINDOW, "mode": "auto_detected_active"},
             )
             logger.info.assert_any_call(
                 "handle_result_for_project.missed",
@@ -119,3 +129,138 @@ class ProcessResultTest(UptimeTestCase):
         hashed_fingerprint = md5(str(self.project_subscription.id).encode("utf-8")).hexdigest()
         with pytest.raises(Group.DoesNotExist):
             Group.objects.get(grouphash__hash=hashed_fingerprint)
+
+    def test_onboarding_failure(self):
+        self.project_subscription.update(
+            mode=ProjectUptimeSubscriptionMode.AUTO_DETECTED_ONBOARDING
+        )
+        result = self.create_uptime_result(
+            self.subscription.subscription_id,
+            status=CHECKSTATUS_FAILURE,
+            scheduled_check_time=datetime.now() - timedelta(minutes=5),
+        )
+        redis = _get_cluster()
+        key = build_onboarding_failure_key(self.project_subscription)
+        assert redis.get(key) is None
+        with mock.patch("sentry.uptime.consumers.results_consumer.metrics") as metrics:
+            self.send_result(result)
+            metrics.incr.assert_has_calls(
+                [
+                    call(
+                        "uptime.result_processor.handle_result_for_project",
+                        tags={"status": CHECKSTATUS_FAILURE, "mode": "auto_detected_onboarding"},
+                    ),
+                ]
+            )
+        assert redis.get(key) == "1"
+
+        hashed_fingerprint = md5(str(self.project_subscription.id).encode("utf-8")).hexdigest()
+        with pytest.raises(Group.DoesNotExist):
+            Group.objects.get(grouphash__hash=hashed_fingerprint)
+
+        result = self.create_uptime_result(
+            self.subscription.subscription_id,
+            status=CHECKSTATUS_FAILURE,
+            scheduled_check_time=datetime.now() - timedelta(minutes=4),
+        )
+        with (
+            mock.patch("sentry.uptime.consumers.results_consumer.metrics") as metrics,
+            mock.patch(
+                "sentry.uptime.consumers.results_consumer.ONBOARDING_FAILURE_THRESHOLD", new=2
+            ),
+            self.tasks(),
+        ):
+            self.send_result(result)
+            metrics.incr.assert_has_calls(
+                [
+                    call(
+                        "uptime.result_processor.handle_result_for_project",
+                        tags={"status": CHECKSTATUS_FAILURE, "mode": "auto_detected_onboarding"},
+                    ),
+                    call("uptime.result_processor.autodetection.failed_onboarding"),
+                ]
+            )
+        assert not redis.exists(key)
+        assert is_failed_url(self.subscription.url)
+
+        hashed_fingerprint = md5(str(self.project_subscription.id).encode("utf-8")).hexdigest()
+        with pytest.raises(Group.DoesNotExist):
+            Group.objects.get(grouphash__hash=hashed_fingerprint)
+        with pytest.raises(UptimeSubscription.DoesNotExist):
+            self.subscription.refresh_from_db()
+        with pytest.raises(ProjectUptimeSubscription.DoesNotExist):
+            self.project_subscription.refresh_from_db()
+
+    def test_onboarding_success_ongoing(self):
+        self.project_subscription.update(
+            mode=ProjectUptimeSubscriptionMode.AUTO_DETECTED_ONBOARDING,
+            date_added=datetime.now(timezone.utc) - timedelta(minutes=5),
+        )
+        result = self.create_uptime_result(
+            self.subscription.subscription_id,
+            status=CHECKSTATUS_SUCCESS,
+            scheduled_check_time=datetime.now() - timedelta(minutes=5),
+        )
+        redis = _get_cluster()
+        key = build_onboarding_failure_key(self.project_subscription)
+        assert redis.get(key) is None
+        with mock.patch("sentry.uptime.consumers.results_consumer.metrics") as metrics:
+            self.send_result(result)
+            metrics.incr.assert_has_calls(
+                [
+                    call(
+                        "uptime.result_processor.handle_result_for_project",
+                        tags={"status": CHECKSTATUS_SUCCESS, "mode": "auto_detected_onboarding"},
+                    ),
+                ]
+            )
+        assert not redis.exists(key)
+
+        hashed_fingerprint = md5(str(self.project_subscription.id).encode("utf-8")).hexdigest()
+        with pytest.raises(Group.DoesNotExist):
+            Group.objects.get(grouphash__hash=hashed_fingerprint)
+
+    def test_onboarding_success_graduate(self):
+        self.project_subscription.update(
+            mode=ProjectUptimeSubscriptionMode.AUTO_DETECTED_ONBOARDING,
+            date_added=datetime.now(timezone.utc)
+            - (ONBOARDING_MONITOR_PERIOD + timedelta(minutes=5)),
+        )
+        uptime_subscription = self.project_subscription.uptime_subscription
+        result = self.create_uptime_result(
+            self.subscription.subscription_id,
+            status=CHECKSTATUS_SUCCESS,
+            scheduled_check_time=datetime.now() - timedelta(minutes=2),
+        )
+        redis = _get_cluster()
+        key = build_onboarding_failure_key(self.project_subscription)
+        assert redis.get(key) is None
+        with mock.patch(
+            "sentry.uptime.consumers.results_consumer.metrics"
+        ) as metrics, self.tasks():
+            self.send_result(result)
+            metrics.incr.assert_has_calls(
+                [
+                    call(
+                        "uptime.result_processor.handle_result_for_project",
+                        tags={"status": CHECKSTATUS_SUCCESS, "mode": "auto_detected_onboarding"},
+                    ),
+                    call("uptime.result_processor.autodetection.graduated_onboarding"),
+                ]
+            )
+        assert not redis.exists(key)
+
+        hashed_fingerprint = md5(str(self.project_subscription.id).encode("utf-8")).hexdigest()
+        with pytest.raises(Group.DoesNotExist):
+            Group.objects.get(grouphash__hash=hashed_fingerprint)
+
+        self.project_subscription.refresh_from_db()
+        assert self.project_subscription.mode == ProjectUptimeSubscriptionMode.AUTO_DETECTED_ACTIVE
+        with pytest.raises(UptimeSubscription.DoesNotExist):
+            uptime_subscription.refresh_from_db()
+        new_uptime_subscription = self.project_subscription.uptime_subscription
+        assert (
+            new_uptime_subscription.interval_seconds
+            == AUTO_DETECTED_ACTIVE_SUBSCRIPTION_INTERVAL_SECONDS
+        )
+        assert uptime_subscription.url == new_uptime_subscription.url


### PR DESCRIPTION
This handles the lifecycle of a subscription when it's in onboarding mode. If successes are received, they're ignored unless the subscription has existed for long enough. If failures are received, we keep track of the number of failures, and if we hit too many we kill the subscription and disable checking the url for a while.
