### PR TITLE
feat(crons): Add new notification type

### DIFF
--- a/src/sentry/notifications/defaults.py
+++ b/src/sentry/notifications/defaults.py
@@ -26,6 +26,7 @@ NOTIFICATION_SETTINGS_TYPE_DEFAULTS = {
     NotificationSettingEnum.QUOTA_THRESHOLDS: NotificationSettingsOptionEnum.ALWAYS,
     NotificationSettingEnum.SPIKE_PROTECTION: NotificationSettingsOptionEnum.ALWAYS,
     NotificationSettingEnum.REPORTS: NotificationSettingsOptionEnum.ALWAYS,
+    NotificationSettingEnum.BROKEN_MONITORS: NotificationSettingsOptionEnum.ALWAYS,
 }
 
 

--- a/src/sentry/notifications/types.py
+++ b/src/sentry/notifications/types.py
@@ -33,6 +33,7 @@ class NotificationSettingEnum(ValueEqualityEnum):
     SPIKE_PROTECTION = "spikeProtection"
     MISSING_MEMBERS = "missingMembers"
     REPORTS = "reports"
+    BROKEN_MONITORS = "brokenMonitors"
 
 
 class NotificationSettingsOptionEnum(ValueEqualityEnum):
@@ -143,6 +144,10 @@ VALID_VALUES_FOR_KEY = {
         NotificationSettingsOptionEnum.NEVER,
     },
     NotificationSettingEnum.REPORTS: {
+        NotificationSettingsOptionEnum.ALWAYS,
+        NotificationSettingsOptionEnum.NEVER,
+    },
+    NotificationSettingEnum.BROKEN_MONITORS: {
         NotificationSettingsOptionEnum.ALWAYS,
         NotificationSettingsOptionEnum.NEVER,
     },

--- a/tests/sentry/api/endpoints/test_notification_defaults.py
+++ b/tests/sentry/api/endpoints/test_notification_defaults.py
@@ -30,5 +30,6 @@ class NotificationDefaultTest(APITestCase):
                 "reports": "always",
                 "spikeProtection": "always",
                 "workflow": "subscribe_only",
+                "brokenMonitors": "always",
             },
         }


### PR DESCRIPTION
Right now crons is borrowing from the "Nudges" category for broken monitor notifications, but we have received feedback from multiple sources that we should just separate into our own category for clarity.