### PR TITLE
feat(profiling): Render flamegraph in transaction summary

### DIFF
--- a/static/app/components/profiling/flamegraph/aggregateFlamegraphTreeTable.tsx
+++ b/static/app/components/profiling/flamegraph/aggregateFlamegraphTreeTable.tsx
@@ -106,12 +106,14 @@ interface AggregateFlamegraphTreeTableProps {
   frameFilter: 'system' | 'application' | 'all';
   recursion: 'collapsed' | null;
   expanded?: boolean;
+  withBorder?: boolean;
 }
 
 export function AggregateFlamegraphTreeTable({
   expanded,
   recursion,
   frameFilter,
+  withBorder,
 }: AggregateFlamegraphTreeTableProps) {
   const dispatch = useDispatchFlamegraphState();
   const profiles = useFlamegraphProfiles();
@@ -374,7 +376,7 @@ export function AggregateFlamegraphTreeTable({
   }, [setTreeView]);
 
   return (
-    <FrameBar>
+    <FrameBar withBorder={withBorder}>
       <CallTreeTable>
         <CallTreeTableHeader>
           <FrameWeightCell>
@@ -472,14 +474,19 @@ export function AggregateFlamegraphTreeTable({
   );
 }
 
-const FrameBar = styled('div')`
+const FrameBar = styled('div')<{withBorder?: boolean}>`
   overflow: auto;
   width: 100%;
   position: relative;
   background-color: ${p => p.theme.surface200};
   border-top: 1px solid ${p => p.theme.border};
   flex: 1 1 100%;
-  grid-area: table;
+  ${p =>
+    p.withBorder &&
+    `
+    border: 1px solid ${p.theme.border};
+    border-radius: ${p.theme.borderRadius};
+  `}
 `;
 
 const FrameWeightCell = styled('div')`

--- a/static/app/components/profiling/flamegraph/aggregateFlamegraphTreeTable.tsx
+++ b/static/app/components/profiling/flamegraph/aggregateFlamegraphTreeTable.tsx
@@ -106,14 +106,14 @@ interface AggregateFlamegraphTreeTableProps {
   frameFilter: 'system' | 'application' | 'all';
   recursion: 'collapsed' | null;
   expanded?: boolean;
-  withBorder?: boolean;
+  withoutBorders?: boolean;
 }
 
 export function AggregateFlamegraphTreeTable({
   expanded,
   recursion,
   frameFilter,
-  withBorder,
+  withoutBorders,
 }: AggregateFlamegraphTreeTableProps) {
   const dispatch = useDispatchFlamegraphState();
   const profiles = useFlamegraphProfiles();
@@ -376,7 +376,7 @@ export function AggregateFlamegraphTreeTable({
   }, [setTreeView]);
 
   return (
-    <FrameBar withBorder={withBorder}>
+    <FrameBar withoutBorders={withoutBorders}>
       <CallTreeTable>
         <CallTreeTableHeader>
           <FrameWeightCell>
@@ -474,19 +474,13 @@ export function AggregateFlamegraphTreeTable({
   );
 }
 
-const FrameBar = styled('div')<{withBorder?: boolean}>`
+const FrameBar = styled('div')<{withoutBorders?: boolean}>`
   overflow: auto;
   width: 100%;
   position: relative;
   background-color: ${p => p.theme.surface200};
-  border-top: 1px solid ${p => p.theme.border};
+  ${p => !p.withoutBorders && `border-top: 1px solid ${p.theme.border};`}
   flex: 1 1 100%;
-  ${p =>
-    p.withBorder &&
-    `
-    border: 1px solid ${p.theme.border};
-    border-radius: ${p.theme.borderRadius};
-  `}
 `;
 
 const FrameWeightCell = styled('div')`

--- a/static/app/views/performance/transactionSummary/pageLayout.tsx
+++ b/static/app/views/performance/transactionSummary/pageLayout.tsx
@@ -14,6 +14,7 @@ import PickProjectToContinue from 'sentry/components/pickProjectToContinue';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import {Tabs} from 'sentry/components/tabs';
 import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
 import type {Organization} from 'sentry/types/organization';
 import type {Project} from 'sentry/types/project';
 import {defined} from 'sentry/utils';
@@ -81,6 +82,7 @@ type Props = {
   projects: Project[];
   tab: Tab;
   features?: string[];
+  fillSpace?: boolean;
 };
 
 function PageLayout(props: Props) {
@@ -283,7 +285,7 @@ function PageLayout(props: Props) {
                   }}
                   metricsCardinality={metricsCardinality}
                 />
-                <Layout.Body>
+                <StyledBody fillSpace={props.fillSpace} hasError={defined(error)}>
                   {defined(error) && (
                     <StyledAlert type="error" showIcon>
                       {error}
@@ -300,7 +302,7 @@ function PageLayout(props: Props) {
                     transactionThreshold={transactionThreshold}
                     transactionThresholdMetric={transactionThresholdMetric}
                   />
-                </Layout.Body>
+                </StyledBody>
               </Layout.Page>
             </Tabs>
           </PageFiltersContainer>
@@ -317,6 +319,18 @@ export function NoAccess() {
 const StyledAlert = styled(Alert)`
   grid-column: 1/3;
   margin: 0;
+`;
+
+const StyledBody = styled(Layout.Body)<{fillSpace?: boolean; hasError?: boolean}>`
+  display: flex;
+  flex-direction: column;
+  gap: ${space(3)};
+
+  @media (min-width: ${p => p.theme.breakpoints.large}) {
+    display: flex;
+    flex-direction: column;
+    gap: ${space(3)};
+  }
 `;
 
 export function redirectToPerformanceHomepage(

--- a/static/app/views/performance/transactionSummary/transactionProfiles/index.tsx
+++ b/static/app/views/performance/transactionSummary/transactionProfiles/index.tsx
@@ -302,15 +302,6 @@ function Profiles({organization, transaction}: ProfilesProps) {
                         hideSystemFrames={false}
                         setHideSystemFrames={noop}
                       />
-                      {isLoading ? (
-                        <RequestStateMessageContainer>
-                          <LoadingIndicator />
-                        </RequestStateMessageContainer>
-                      ) : isError ? (
-                        <RequestStateMessageContainer>
-                          {t('There was an error loading the flamegraph.')}
-                        </RequestStateMessageContainer>
-                      ) : null}
                       <StyledPanel>
                         {visualization === 'flamegraph' ? (
                           <AggregateFlamegraph
@@ -327,6 +318,15 @@ function Profiles({organization, transaction}: ProfilesProps) {
                           />
                         )}
                       </StyledPanel>
+                      {isLoading ? (
+                        <RequestStateMessageContainer>
+                          <LoadingIndicator />
+                        </RequestStateMessageContainer>
+                      ) : isError ? (
+                        <RequestStateMessageContainer>
+                          {t('There was an error loading the flamegraph.')}
+                        </RequestStateMessageContainer>
+                      ) : null}
                     </FlamegraphProvider>
                   </FlamegraphThemeProvider>
                 </FlamegraphStateProvider>

--- a/static/app/views/performance/transactionSummary/transactionProfiles/index.tsx
+++ b/static/app/views/performance/transactionSummary/transactionProfiles/index.tsx
@@ -1,33 +1,60 @@
 import {useCallback, useMemo, useState} from 'react';
 import styled from '@emotion/styled';
 
+import {Button} from 'sentry/components/button';
+import {CompactSelect} from 'sentry/components/compactSelect';
+import type {SelectOption} from 'sentry/components/compactSelect/types';
 import SearchBar from 'sentry/components/events/searchBar';
 import * as Layout from 'sentry/components/layouts/thirds';
+import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {DatePageFilter} from 'sentry/components/organizations/datePageFilter';
 import {EnvironmentPageFilter} from 'sentry/components/organizations/environmentPageFilter';
 import PageFilterBar from 'sentry/components/organizations/pageFilterBar';
+import {AggregateFlamegraph} from 'sentry/components/profiling/flamegraph/aggregateFlamegraph';
+import {AggregateFlamegraphTreeTable} from 'sentry/components/profiling/flamegraph/aggregateFlamegraphTreeTable';
+import {FlamegraphSearch} from 'sentry/components/profiling/flamegraph/flamegraphToolbar/flamegraphSearch';
 import {ProfileEventsTable} from 'sentry/components/profiling/profileEventsTable';
+import {SegmentedControl} from 'sentry/components/segmentedControl';
 import type {SmartSearchBarProps} from 'sentry/components/smartSearchBar';
 import {MAX_QUERY_LENGTH} from 'sentry/constants';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
+import type {Organization} from 'sentry/types/organization';
+import type {DeepPartial} from 'sentry/types/utils';
 import {defined} from 'sentry/utils';
 import {browserHistory} from 'sentry/utils/browserHistory';
 import EventView from 'sentry/utils/discover/eventView';
+import type {CanvasScheduler} from 'sentry/utils/profiling/canvasScheduler';
+import {
+  CanvasPoolManager,
+  useCanvasScheduler,
+} from 'sentry/utils/profiling/canvasScheduler';
+import type {FlamegraphState} from 'sentry/utils/profiling/flamegraph/flamegraphStateProvider/flamegraphContext';
+import {FlamegraphStateProvider} from 'sentry/utils/profiling/flamegraph/flamegraphStateProvider/flamegraphContextProvider';
+import {FlamegraphThemeProvider} from 'sentry/utils/profiling/flamegraph/flamegraphThemeProvider';
+import type {Frame} from 'sentry/utils/profiling/frame';
+import {useAggregateFlamegraphQuery} from 'sentry/utils/profiling/hooks/useAggregateFlamegraphQuery';
 import {useProfileEvents} from 'sentry/utils/profiling/hooks/useProfileEvents';
 import {formatSort} from 'sentry/utils/profiling/hooks/utils';
 import {decodeScalar} from 'sentry/utils/queryString';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
+import {useLocalStorageState} from 'sentry/utils/useLocalStorageState';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
+import usePageFilters from 'sentry/utils/usePageFilters';
 import useProjects from 'sentry/utils/useProjects';
 import Tab from 'sentry/views/performance/transactionSummary/tabs';
+import {
+  FlamegraphProvider,
+  useFlamegraph,
+} from 'sentry/views/profiling/flamegraphProvider';
+import {ProfileGroupProvider} from 'sentry/views/profiling/profileGroupProvider';
 import type {ProfilingFieldType} from 'sentry/views/profiling/profileSummary/content';
 import {getProfilesTableFields} from 'sentry/views/profiling/profileSummary/content';
 
-import PageLayout from '../pageLayout';
+import PageLayout, {redirectToPerformanceHomepage} from '../pageLayout';
 
-function Profiles(): React.ReactElement {
+function ProfilesLegacy() {
   const location = useLocation();
   const organization = useOrganization();
   const projects = useProjects();
@@ -102,7 +129,7 @@ function Profiles(): React.ReactElement {
                 <DatePageFilter />
               </PageFilterBar>
               <SearchBar
-                searchSource="profile_landing"
+                searchSource="transaction_profiles"
                 organization={organization}
                 projectIds={projects.projects.map(p => parseInt(p.id, 10))}
                 query={query.formatString()}
@@ -125,6 +152,259 @@ function Profiles(): React.ReactElement {
   );
 }
 
+function ProfilesWrapper() {
+  const organization = useOrganization();
+  const location = useLocation();
+  const transaction = decodeScalar(location.query.transaction);
+
+  if (!transaction) {
+    redirectToPerformanceHomepage(organization, location);
+    return null;
+  }
+
+  return <Profiles organization={organization} transaction={transaction} />;
+}
+
+const DEFAULT_FLAMEGRAPH_PREFERENCES: DeepPartial<FlamegraphState> = {
+  preferences: {
+    sorting: 'alphabetical' satisfies FlamegraphState['preferences']['sorting'],
+  },
+};
+
+const noop = () => void 0;
+
+interface ProfilesProps {
+  organization: Organization;
+  transaction: string;
+}
+
+function Profiles({organization, transaction}: ProfilesProps) {
+  const location = useLocation();
+  const projects = useProjects();
+  const {selection} = usePageFilters();
+
+  // const query = decodeScalar(location.query.query, '');
+
+  // const conditions = useMemo(() => {
+  //   const c = new MutableSearch(query);
+  //   c.setFilterValues('event.type', ['transaction']);
+  //   c.setFilterValues('transaction', [transaction]);
+
+  //   Object.keys(c.filters).forEach(field => {
+  //     if (isAggregateField(field)) {
+  //       c.removeFilter(field);
+  //     }
+  //   });
+  // }, [transaction, query]);
+
+  // const handleSearch: SmartSearchBarProps['onSearch'] = useCallback(
+  //   (searchQuery: string) => {
+  //     browserHistory.push({
+  //       ...location,
+  //       query: {
+  //         ...location.query,
+  //         cursor: undefined,
+  //         query: searchQuery || undefined,
+  //       },
+  //     });
+  //   },
+  //   [location]
+  // );
+
+  const [visualization, setVisualization] = useLocalStorageState<
+    'flamegraph' | 'call tree'
+  >('flamegraph-visualization', 'flamegraph');
+
+  const onVisualizationChange = useCallback(
+    (value: 'flamegraph' | 'call tree') => {
+      setVisualization(value);
+    },
+    [setVisualization]
+  );
+
+  const [frameFilter, setFrameFilter] = useLocalStorageState<
+    'system' | 'application' | 'all'
+  >('flamegraph-frame-filter', 'application');
+
+  const onFrameFilterChange = useCallback(
+    (value: 'system' | 'application' | 'all') => {
+      setFrameFilter(value);
+    },
+    [setFrameFilter]
+  );
+
+  const flamegraphFrameFilter: ((frame: Frame) => boolean) | undefined = useMemo(() => {
+    if (frameFilter === 'all') {
+      return () => true;
+    }
+    if (frameFilter === 'application') {
+      return frame => frame.is_application;
+    }
+    return frame => !frame.is_application;
+  }, [frameFilter]);
+
+  const {data, isLoading, isError} = useAggregateFlamegraphQuery({
+    transaction,
+    environments: selection.environments,
+    projects: selection.projects,
+    datetime: selection.datetime,
+  });
+
+  const canvasPoolManager = useMemo(() => new CanvasPoolManager(), []);
+  const scheduler = useCanvasScheduler(canvasPoolManager);
+
+  return (
+    <PageLayout
+      location={location}
+      organization={organization}
+      projects={projects.projects}
+      tab={Tab.PROFILING}
+      generateEventView={() => EventView.fromLocation(location)}
+      getDocumentTitle={() => t(`Profile: %s`, transaction)}
+      fillSpace
+      childComponent={() => {
+        return (
+          <StyledMain fullWidth>
+            <FilterActions>
+              <PageFilterBar condensed>
+                <EnvironmentPageFilter />
+                <DatePageFilter />
+              </PageFilterBar>
+              {/* TODO: This doesn't actually search anything
+              <StyledSearchBar
+                searchSource="transaction_profiles"
+                organization={organization}
+                projectIds={projects.projects.map(p => parseInt(p.id, 10))}
+                query={query}
+                onSearch={handleSearch}
+                maxQueryLength={MAX_QUERY_LENGTH}
+              />
+              */}
+            </FilterActions>
+            <ProfileVisualization>
+              <ProfileGroupProvider
+                traceID=""
+                type="flamegraph"
+                input={data ?? null}
+                frameFilter={flamegraphFrameFilter}
+              >
+                <FlamegraphStateProvider initialState={DEFAULT_FLAMEGRAPH_PREFERENCES}>
+                  <FlamegraphThemeProvider>
+                    <FlamegraphProvider>
+                      <AggregateFlamegraphToolbar
+                        scheduler={scheduler}
+                        canvasPoolManager={canvasPoolManager}
+                        visualization={visualization}
+                        onVisualizationChange={onVisualizationChange}
+                        frameFilter={frameFilter}
+                        onFrameFilterChange={onFrameFilterChange}
+                        hideSystemFrames={false}
+                        setHideSystemFrames={noop}
+                      />
+                      {isLoading ? (
+                        <RequestStateMessageContainer>
+                          <LoadingIndicator />
+                        </RequestStateMessageContainer>
+                      ) : isError ? (
+                        <RequestStateMessageContainer>
+                          {t('There was an error loading the flamegraph.')}
+                        </RequestStateMessageContainer>
+                      ) : null}
+                      {visualization === 'flamegraph' ? (
+                        <AggregateFlamegraph
+                          canvasPoolManager={canvasPoolManager}
+                          scheduler={scheduler}
+                        />
+                      ) : (
+                        <AggregateFlamegraphTreeTable
+                          recursion={null}
+                          expanded={false}
+                          frameFilter={frameFilter}
+                          canvasPoolManager={canvasPoolManager}
+                          withBorder
+                        />
+                      )}
+                    </FlamegraphProvider>
+                  </FlamegraphThemeProvider>
+                </FlamegraphStateProvider>
+              </ProfileGroupProvider>
+            </ProfileVisualization>
+          </StyledMain>
+        );
+      }}
+    />
+  );
+}
+
+interface AggregateFlamegraphToolbarProps {
+  canvasPoolManager: CanvasPoolManager;
+  frameFilter: 'system' | 'application' | 'all';
+  hideSystemFrames: boolean;
+  onFrameFilterChange: (value: 'system' | 'application' | 'all') => void;
+  onVisualizationChange: (value: 'flamegraph' | 'call tree') => void;
+  scheduler: CanvasScheduler;
+  setHideSystemFrames: (value: boolean) => void;
+  visualization: 'flamegraph' | 'call tree';
+}
+
+function AggregateFlamegraphToolbar(props: AggregateFlamegraphToolbarProps) {
+  const flamegraph = useFlamegraph();
+  const flamegraphs = useMemo(() => [flamegraph], [flamegraph]);
+  const spans = useMemo(() => [], []);
+
+  const frameSelectOptions: SelectOption<'system' | 'application' | 'all'>[] =
+    useMemo(() => {
+      return [
+        {value: 'system', label: t('System Frames')},
+        {value: 'application', label: t('Application Frames')},
+        {value: 'all', label: t('All Frames')},
+      ];
+    }, []);
+
+  const onResetZoom = useCallback(() => {
+    props.scheduler.dispatch('reset zoom');
+  }, [props.scheduler]);
+
+  const onFrameFilterChange = useCallback(
+    (value: {value: 'application' | 'system' | 'all'}) => {
+      props.onFrameFilterChange(value.value);
+    },
+    [props]
+  );
+
+  return (
+    <AggregateFlamegraphToolbarContainer>
+      <ViewSelectContainer>
+        <SegmentedControl
+          aria-label={t('View')}
+          size="xs"
+          value={props.visualization}
+          onChange={props.onVisualizationChange}
+        >
+          <SegmentedControl.Item key="flamegraph">
+            {t('Flamegraph')}
+          </SegmentedControl.Item>
+          <SegmentedControl.Item key="call tree">{t('Call Tree')}</SegmentedControl.Item>
+        </SegmentedControl>
+      </ViewSelectContainer>
+      <AggregateFlamegraphSearch
+        spans={spans}
+        canvasPoolManager={props.canvasPoolManager}
+        flamegraphs={flamegraphs}
+      />
+      <Button size="xs" onClick={onResetZoom}>
+        {t('Reset Zoom')}
+      </Button>
+      <CompactSelect
+        onChange={onFrameFilterChange}
+        value={props.frameFilter}
+        size="xs"
+        options={frameSelectOptions}
+      />
+    </AggregateFlamegraphToolbarContainer>
+  );
+}
+
 const FilterActions = styled('div')`
   margin-bottom: ${space(2)};
   gap: ${space(2)};
@@ -132,4 +412,72 @@ const FilterActions = styled('div')`
   grid-template-columns: min-content 1fr;
 `;
 
-export default Profiles;
+// const StyledSearchBar = styled(SearchBar)`
+//   @media (min-width: ${p => p.theme.breakpoints.small}) {
+//     order: 1;
+//     grid-column: 1/4;
+//   }
+//
+//   @media (min-width: ${p => p.theme.breakpoints.xlarge}) {
+//     order: initial;
+//     grid-column: auto;
+//   }
+// `;
+
+const StyledMain = styled(Layout.Main)`
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+`;
+
+const ProfileVisualization = styled('div')`
+  display: grid;
+  grid-template-rows: min-content 1fr;
+  height: 100%;
+  flex: 1;
+`;
+
+const RequestStateMessageContainer = styled('div')`
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: 0;
+  bottom: 0;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  color: ${p => p.theme.subText};
+`;
+
+const AggregateFlamegraphToolbarContainer = styled('div')`
+  display: flex;
+  justify-content: space-between;
+  gap: ${space(1)};
+  padding-bottom: ${space(1)};
+  background-color: ${p => p.theme.background};
+  /*
+    force height to be the same as profile digest header,
+    but subtract 1px for the border that doesnt exist on the header
+   */
+  height: 41px;
+`;
+
+const ViewSelectContainer = styled('div')`
+  min-width: 160px;
+`;
+
+const AggregateFlamegraphSearch = styled(FlamegraphSearch)`
+  max-width: 300px;
+`;
+
+function ProfilesIndex() {
+  const organization = useOrganization();
+
+  if (organization.features.includes('continuous-profiling-compat')) {
+    return <ProfilesWrapper />;
+  }
+
+  return <ProfilesLegacy />;
+}
+
+export default ProfilesIndex;

--- a/static/app/views/performance/transactionSummary/transactionProfiles/index.tsx
+++ b/static/app/views/performance/transactionSummary/transactionProfiles/index.tsx
@@ -10,6 +10,7 @@ import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {DatePageFilter} from 'sentry/components/organizations/datePageFilter';
 import {EnvironmentPageFilter} from 'sentry/components/organizations/environmentPageFilter';
 import PageFilterBar from 'sentry/components/organizations/pageFilterBar';
+import Panel from 'sentry/components/panels/panel';
 import {AggregateFlamegraph} from 'sentry/components/profiling/flamegraph/aggregateFlamegraph';
 import {AggregateFlamegraphTreeTable} from 'sentry/components/profiling/flamegraph/aggregateFlamegraphTreeTable';
 import {FlamegraphSearch} from 'sentry/components/profiling/flamegraph/flamegraphToolbar/flamegraphSearch';
@@ -310,20 +311,22 @@ function Profiles({organization, transaction}: ProfilesProps) {
                           {t('There was an error loading the flamegraph.')}
                         </RequestStateMessageContainer>
                       ) : null}
-                      {visualization === 'flamegraph' ? (
-                        <AggregateFlamegraph
-                          canvasPoolManager={canvasPoolManager}
-                          scheduler={scheduler}
-                        />
-                      ) : (
-                        <AggregateFlamegraphTreeTable
-                          recursion={null}
-                          expanded={false}
-                          frameFilter={frameFilter}
-                          canvasPoolManager={canvasPoolManager}
-                          withBorder
-                        />
-                      )}
+                      <StyledPanel>
+                        {visualization === 'flamegraph' ? (
+                          <AggregateFlamegraph
+                            canvasPoolManager={canvasPoolManager}
+                            scheduler={scheduler}
+                          />
+                        ) : (
+                          <AggregateFlamegraphTreeTable
+                            recursion={null}
+                            expanded={false}
+                            frameFilter={frameFilter}
+                            canvasPoolManager={canvasPoolManager}
+                            withoutBorders
+                          />
+                        )}
+                      </StyledPanel>
                     </FlamegraphProvider>
                   </FlamegraphThemeProvider>
                 </FlamegraphStateProvider>
@@ -468,6 +471,11 @@ const ViewSelectContainer = styled('div')`
 
 const AggregateFlamegraphSearch = styled(FlamegraphSearch)`
   max-width: 300px;
+`;
+
+const StyledPanel = styled(Panel)`
+  overflow: hidden;
+  display: flex;
 `;
 
 function ProfilesIndex() {

--- a/static/app/views/profiling/profileSummary/index.tsx
+++ b/static/app/views/profiling/profileSummary/index.tsx
@@ -93,6 +93,7 @@ const DEFAULT_FLAMEGRAPH_PREFERENCES: DeepPartial<FlamegraphState> = {
     sorting: 'alphabetical' satisfies FlamegraphState['preferences']['sorting'],
   },
 };
+
 interface ProfileSummaryHeaderProps {
   location: Location;
   onViewChange: (newView: 'flamegraph' | 'profiles') => void;
@@ -102,6 +103,7 @@ interface ProfileSummaryHeaderProps {
   transaction: string;
   view: 'flamegraph' | 'profiles';
 }
+
 function ProfileSummaryHeader(props: ProfileSummaryHeaderProps) {
   const breadcrumbTrails: ProfilingBreadcrumbsProps['trails'] = useMemo(() => {
     return [
@@ -523,6 +525,7 @@ interface AggregateFlamegraphToolbarProps {
   setHideSystemFrames: (value: boolean) => void;
   visualization: 'flamegraph' | 'call tree';
 }
+
 function AggregateFlamegraphToolbar(props: AggregateFlamegraphToolbarProps) {
   const flamegraph = useFlamegraph();
   const flamegraphs = useMemo(() => [flamegraph], [flamegraph]);


### PR DESCRIPTION
As part of the effort to make the profiling pages compatible with both continuous profiling and transaction profiling, this moves the flamegraph from the profile summary page into a tab of the transaction summary page.