### PR TITLE
chore(slack): update response message metrics

### DIFF
--- a/src/sentry/integrations/slack/metrics.py
+++ b/src/sentry/integrations/slack/metrics.py
@@ -54,12 +54,17 @@ SLACK_COMMANDS_ENDPOINT_SUCCESS_DATADOG_METRIC = (
 SLACK_COMMANDS_ENDPOINT_FAILURE_DATADOG_METRIC = (
     "sentry.integrations.slack.commands_endpoint.failure"
 )
-SLACK_COMMANDS_LINK_IDENTITY_SUCCESS_DATADOG_METRIC = (
-    "sentry.integrations.slack.commands_link_identity.success"
+
+# Sending messages upon linking/unlinking
+SLACK_LINK_IDENTITY_MSG_SUCCESS_DATADOG_METRIC = (
+    "sentry.integrations.slack.link_identity_msg.success"
 )
-SLACK_COMMANDS_LINK_IDENTITY_FAILURE_DATADOG_METRIC = (
-    "sentry.integrations.slack.commands_link_identity.failure"
+SLACK_LINK_IDENTITY_MSG_FAILURE_DATADOG_METRIC = (
+    "sentry.integrations.slack.link_identity_msg.failure"
 )
+SLACK_LINK_TEAM_MSG_SUCCESS_DATADOG_METRIC = "sentry.integrations.slack.link_team_msg.success"
+SLACK_LINK_TEAM_MSG_FAILURE_DATADOG_METRIC = "sentry.integrations.slack.link_team_msg.failure"
+
 
 SLACK_NOTIFY_MIXIN_SUCCESS_DATADOG_METRIC = "sentry.integrations.slack.notify_mixin.success"
 SLACK_NOTIFY_MIXIN_FAILURE_DATADOG_METRIC = "sentry.integrations.slack.notify_mixin.failure"

--- a/src/sentry/integrations/slack/utils/notifications.py
+++ b/src/sentry/integrations/slack/utils/notifications.py
@@ -20,8 +20,8 @@ from sentry.integrations.repository.metric_alert import (
 from sentry.integrations.services.integration import integration_service
 from sentry.integrations.slack.message_builder.incidents import SlackIncidentsMessageBuilder
 from sentry.integrations.slack.metrics import (
-    SLACK_COMMANDS_LINK_IDENTITY_FAILURE_DATADOG_METRIC,
-    SLACK_COMMANDS_LINK_IDENTITY_SUCCESS_DATADOG_METRIC,
+    SLACK_LINK_IDENTITY_MSG_FAILURE_DATADOG_METRIC,
+    SLACK_LINK_IDENTITY_MSG_SUCCESS_DATADOG_METRIC,
     SLACK_METRIC_ALERT_FAILURE_DATADOG_METRIC,
     SLACK_METRIC_ALERT_SUCCESS_DATADOG_METRIC,
 )
@@ -175,14 +175,14 @@ def respond_to_slack_command(
             webhook_client = WebhookClient(params.response_url)
             webhook_client.send(text=text, replace_original=False, response_type="ephemeral")
             metrics.incr(
-                SLACK_COMMANDS_LINK_IDENTITY_SUCCESS_DATADOG_METRIC,
+                SLACK_LINK_IDENTITY_MSG_SUCCESS_DATADOG_METRIC,
                 sample_rate=1.0,
                 tags={"type": "webhook", "command": command},
             )
         except (SlackApiError, SlackRequestError) as e:
             if "Expired url" not in str(e):
                 metrics.incr(
-                    SLACK_COMMANDS_LINK_IDENTITY_FAILURE_DATADOG_METRIC,
+                    SLACK_LINK_IDENTITY_MSG_FAILURE_DATADOG_METRIC,
                     sample_rate=1.0,
                     tags={"type": "webhook", "command": command},
                 )
@@ -198,14 +198,14 @@ def respond_to_slack_command(
                 response_type="ephemeral",
             )
             metrics.incr(
-                SLACK_COMMANDS_LINK_IDENTITY_SUCCESS_DATADOG_METRIC,
+                SLACK_LINK_IDENTITY_MSG_SUCCESS_DATADOG_METRIC,
                 sample_rate=1.0,
                 tags={"type": "ephemeral", "command": command},
             )
         except SlackApiError as e:
             if "Expired url" not in str(e):
                 metrics.incr(
-                    SLACK_COMMANDS_LINK_IDENTITY_FAILURE_DATADOG_METRIC,
+                    SLACK_LINK_IDENTITY_MSG_FAILURE_DATADOG_METRIC,
                     sample_rate=1.0,
                     tags={"type": "ephemeral", "command": command},
                 )

--- a/src/sentry/integrations/slack/views/link_team.py
+++ b/src/sentry/integrations/slack/views/link_team.py
@@ -10,6 +10,7 @@ from django.core.signing import BadSignature, SignatureExpired
 from django.http.response import HttpResponseBase
 from django.utils.decorators import method_decorator
 from rest_framework.request import Request
+from slack_sdk.errors import SlackApiError
 
 from sentry import analytics, features
 from sentry.identity.services.identity import identity_service
@@ -17,7 +18,10 @@ from sentry.integrations.services.integration import RpcIntegration, integration
 from sentry.integrations.slack.metrics import (
     SLACK_BOT_COMMAND_LINK_TEAM_FAILURE_DATADOG_METRIC,
     SLACK_BOT_COMMAND_LINK_TEAM_SUCCESS_DATADOG_METRIC,
+    SLACK_LINK_TEAM_MSG_FAILURE_DATADOG_METRIC,
+    SLACK_LINK_TEAM_MSG_SUCCESS_DATADOG_METRIC,
 )
+from sentry.integrations.slack.sdk_client import SlackSdkClient
 from sentry.integrations.slack.views.types import TeamLinkRequest
 from sentry.integrations.types import ExternalProviderEnum, ExternalProviders
 from sentry.models.integrations.external_actor import ExternalActor
@@ -213,12 +217,15 @@ class SlackLinkTeamView(BaseView):
             message = ALREADY_LINKED_MESSAGE.format(slug=team.slug)
             metrics.incr(self._METRICS_FAILURE_KEY + ".team_already_linked", sample_rate=1.0)
 
-            integration_service.send_message(
-                integration_id=integration.id,
-                organization_id=team.organization_id,
-                channel=channel_id,
-                message=message,
-            )
+            try:
+                client = SlackSdkClient(integration_id=integration.id)
+                client.chat_postMessage(channel=channel_id, message=message)
+                metrics.incr(SLACK_LINK_TEAM_MSG_SUCCESS_DATADOG_METRIC, sample_rate=1.0)
+            except SlackApiError:
+                # whether or not we send a Slack message, the team is already linked
+                metrics.incr(SLACK_LINK_TEAM_MSG_FAILURE_DATADOG_METRIC, sample_rate=1.0)
+                pass
+
             return render_to_response(
                 "sentry/integrations/slack/post-linked-team.html",
                 request=request,
@@ -248,12 +255,14 @@ class SlackLinkTeamView(BaseView):
             channel_name=channel_name,
         )
 
-        integration_service.send_message(
-            integration_id=integration.id,
-            organization_id=team.organization_id,
-            channel=channel_id,
-            message=message,
-        )
+        try:
+            client = SlackSdkClient(integration_id=integration.id)
+            client.chat_postMessage(channel=channel_id, message=message)
+            metrics.incr(SLACK_LINK_TEAM_MSG_SUCCESS_DATADOG_METRIC, sample_rate=1.0)
+        except SlackApiError:
+            # whether or not we send a Slack message, the team was linked successfully
+            metrics.incr(SLACK_LINK_TEAM_MSG_FAILURE_DATADOG_METRIC, sample_rate=1.0)
+            pass
 
         metrics.incr(self._METRICS_SUCCESS_KEY + ".link_team", sample_rate=1.0)
 

--- a/src/sentry/integrations/slack/views/link_team.py
+++ b/src/sentry/integrations/slack/views/link_team.py
@@ -219,7 +219,7 @@ class SlackLinkTeamView(BaseView):
 
             try:
                 client = SlackSdkClient(integration_id=integration.id)
-                client.chat_postMessage(channel=channel_id, message=message)
+                client.chat_postMessage(channel=channel_id, text=message)
                 metrics.incr(SLACK_LINK_TEAM_MSG_SUCCESS_DATADOG_METRIC, sample_rate=1.0)
             except SlackApiError:
                 # whether or not we send a Slack message, the team is already linked
@@ -257,7 +257,7 @@ class SlackLinkTeamView(BaseView):
 
         try:
             client = SlackSdkClient(integration_id=integration.id)
-            client.chat_postMessage(channel=channel_id, message=message)
+            client.chat_postMessage(channel=channel_id, text=message)
             metrics.incr(SLACK_LINK_TEAM_MSG_SUCCESS_DATADOG_METRIC, sample_rate=1.0)
         except SlackApiError:
             # whether or not we send a Slack message, the team was linked successfully

--- a/tests/sentry/integrations/slack/test_link_team.py
+++ b/tests/sentry/integrations/slack/test_link_team.py
@@ -38,6 +38,22 @@ class SlackIntegrationLinkTeamTestBase(TestCase):
         self.integration = install_slack(self.organization)
         self.idp = add_identity(self.integration, self.user, self.external_id)
 
+    @pytest.fixture(autouse=True)
+    def mock_chat_postMessage(self):
+        with patch(
+            "slack_sdk.web.WebClient.chat_postMessage",
+            return_value=SlackResponse(
+                client=None,
+                http_verb="POST",
+                api_url="https://slack.com/api/chat.postMessage",
+                req_args={},
+                data={"ok": True},
+                headers={},
+                status_code=200,
+            ),
+        ) as self.mock_post:
+            yield
+
     def get_success_response(self, data: Mapping[str, Any] | None = None) -> HttpResponseBase:
         """This isn't in APITestCase so this isn't really an override."""
         if data is not None:
@@ -111,22 +127,6 @@ class SlackIntegrationLinkTeamTest(SlackIntegrationLinkTeamTestBase):
         self.team = self.create_team(
             organization=self.organization, name="Mariachi Band", members=[self.user]
         )
-
-    @pytest.fixture(autouse=True)
-    def mock_chat_postMessage(self):
-        with patch(
-            "slack_sdk.web.WebClient.chat_postMessage",
-            return_value=SlackResponse(
-                client=None,
-                http_verb="POST",
-                api_url="https://slack.com/api/chat.postMessage",
-                req_args={},
-                data={"ok": True},
-                headers={},
-                status_code=200,
-            ),
-        ) as self.mock_post:
-            yield
 
     def test_link_team(self):
         """Test that we successfully link a team to a Slack channel"""


### PR DESCRIPTION
We send Slack messages to the user upon successful identity / team linking and unlinking. Whether or not this occurs successfully is not indicative of whether the user or team was successfully linked or unlinked.

I added metrics for now to be thorough, but I'm thinking we can remove them when we consolidate because these are unactionable and don't occur very often. If somebody's integration was broken we'd see it much faster through other avenues (like alerts messages in a channel or DM).