### PR TITLE
fix(flagpole): Makes system:multi-region flag internal only

### DIFF
--- a/src/sentry/features/permanent.py
+++ b/src/sentry/features/permanent.py
@@ -133,4 +133,6 @@ def register_permanent_features(manager: FeatureManager):
         )
 
     # Enable support for multiple regions, and org slug subdomains (customer-domains).
-    manager.add("system:multi-region", SystemFeature, default=False)
+    manager.add(
+        "system:multi-region", SystemFeature, FeatureHandlerStrategy.INTERNAL, default=False
+    )


### PR DESCRIPTION
This feature is being incorrectly checked as a remote flag, fix this to be internal only.
