### PR TITLE
feat(new-trace): Fixed links to event in trace view with missing trace slugs.

### DIFF
--- a/static/app/components/events/interfaces/breadcrumbs/breadcrumb/data/default.tsx
+++ b/static/app/components/events/interfaces/breadcrumbs/breadcrumb/data/default.tsx
@@ -95,13 +95,14 @@ function FormatMessage({
     if (!maybeProject) {
       return content;
     }
+
     const projectSlug = maybeProject.slug;
     const description = transactionData ? (
       <Link
         to={generateLinkToEventInTraceView({
           eventId: message,
-          timestamp: event?.endTimestamp ?? '',
-          traceSlug: event?.contexts?.trace?.trace_id ?? '',
+          timestamp: transactionData.timestamp,
+          traceSlug: transactionData.trace,
           projectSlug,
           organization,
           location: {...location, query: {...location.query, referrer: 'breadcrumbs'}},

--- a/static/app/components/events/interfaces/breadcrumbs/breadcrumbs.tsx
+++ b/static/app/components/events/interfaces/breadcrumbs/breadcrumbs.tsx
@@ -149,7 +149,7 @@ function Breadcrumbs({
       {
         query: {
           query: `id:[${sentryTransactionIds}]`,
-          field: ['title'],
+          field: ['title', 'trace', 'timestamp'],
           project: [maybeProject?.id],
         },
       },

--- a/static/app/components/events/interfaces/breadcrumbs/types.tsx
+++ b/static/app/components/events/interfaces/breadcrumbs/types.tsx
@@ -11,5 +11,7 @@ export type BreadcrumbWithMeta = {
 export type BreadcrumbTransactionEvent = {
   id: string;
   'project.name': string;
+  timestamp: string;
   title: string;
+  trace: string;
 };

--- a/static/app/components/events/profileEventEvidence.spec.tsx
+++ b/static/app/components/events/profileEventEvidence.spec.tsx
@@ -20,6 +20,11 @@ describe('ProfileEventEvidence', function () {
           transactionName: 'SomeTransaction',
         },
       },
+      contexts: {
+        trace: {
+          trace_id: 'trace-id',
+        },
+      },
     }),
     group: GroupFixture({
       issueCategory: IssueCategory.PROFILE,

--- a/static/app/components/events/profileEventEvidence.tsx
+++ b/static/app/components/events/profileEventEvidence.tsx
@@ -25,7 +25,7 @@ export function ProfileEventEvidence({event, projectSlug}: ProfileEvidenceProps)
             subject: 'Transaction Name',
             key: 'Transaction Name',
             value: evidenceData.transactionName,
-            actionButton: (
+            actionButton: traceSlug ? (
               <Button
                 size="xs"
                 to={generateLinkToEventInTraceView({
@@ -39,7 +39,7 @@ export function ProfileEventEvidence({event, projectSlug}: ProfileEvidenceProps)
               >
                 {t('View Transaction')}
               </Button>
-            ),
+            ) : null,
           },
         ]
       : []),

--- a/static/app/utils/discover/urls.tsx
+++ b/static/app/utils/discover/urls.tsx
@@ -1,3 +1,4 @@
+import * as Sentry from '@sentry/react';
 import type {Location, LocationDescriptorObject} from 'history';
 
 import type {Organization, OrganizationSummary} from 'sentry/types/organization';
@@ -73,6 +74,14 @@ export function generateLinkToEventInTraceView({
   const dateSelection = _eventView.normalizeDateSelection(location);
   const normalizedTimestamp = getTimeStampFromTableDateField(timestamp);
   const eventSlug = generateEventSlug({id: eventId, project: projectSlug});
+
+  if (!traceSlug) {
+    Sentry.withScope(scope => {
+      scope.setExtras({traceSlug, source});
+      scope.setLevel('warning' as any);
+      Sentry.captureException(new Error('Trace slug is missing'));
+    });
+  }
 
   if (organization.features.includes('trace-view-v1')) {
     return getTraceDetailsUrl({


### PR DESCRIPTION
The two broken links were from issue detail: 
- Transaction row in Breadcrumbs.
<img width="902" alt="Screenshot 2024-07-15 at 2 10 27 PM" src="https://github.com/user-attachments/assets/2296d7f3-8636-43f1-b92b-27bd1d2fb1d0">

- Link to transaction from profile event evidence block. 
<img width="931" alt="Screenshot 2024-07-15 at 2 13 40 PM" src="https://github.com/user-attachments/assets/0c53fcd5-2b97-4389-9c63-4c4f9fb1738e">


