### PR TITLE
fix(perf): broken docs links in trace view

### DIFF
--- a/static/app/views/performance/newTraceDetails/traceWarnings.tsx
+++ b/static/app/views/performance/newTraceDetails/traceWarnings.tsx
@@ -24,7 +24,7 @@ export function TraceWarnings({type}: TraceWarningsProps) {
     case TraceType.NO_ROOT:
       return (
         <Alert type="info" showIcon>
-          <ExternalLink href="https://docs.sentry.io/product/performance/trace-view/#orphan-traces-and-broken-subtraces">
+          <ExternalLink href="https://docs.sentry.io/concepts/key-terms/tracing/trace-view/#orphan-traces-and-broken-subtraces">
             {t(
               'A root transaction is missing. Transactions linked by a dashed line have been orphaned and cannot be directly linked to the root.'
             )}
@@ -34,7 +34,7 @@ export function TraceWarnings({type}: TraceWarningsProps) {
     case TraceType.BROKEN_SUBTRACES:
       return (
         <Alert type="info" showIcon>
-          <ExternalLink href="https://docs.sentry.io/product/performance/trace-view/#orphan-traces-and-broken-subtraces">
+          <ExternalLink href="https://docs.sentry.io/concepts/key-terms/tracing/trace-view/#orphan-traces-and-broken-subtraces">
             {t(
               'This trace has broken subtraces. Transactions linked by a dashed line have been orphaned and cannot be directly linked to the root.'
             )}

--- a/static/app/views/performance/traceDetails/content.tsx
+++ b/static/app/views/performance/traceDetails/content.tsx
@@ -289,7 +289,7 @@ class TraceDetailsContent extends Component<Props, State> {
     if (roots === 0 && orphans > 0) {
       warning = (
         <Alert type="info" showIcon>
-          <ExternalLink href="https://docs.sentry.io/product/performance/trace-view/#orphan-traces-and-broken-subtraces">
+          <ExternalLink href="https://docs.sentry.io/concepts/key-terms/tracing/trace-view/#orphan-traces-and-broken-subtraces">
             {t(
               'A root transaction is missing. Transactions linked by a dashed line have been orphaned and cannot be directly linked to the root.'
             )}
@@ -299,7 +299,7 @@ class TraceDetailsContent extends Component<Props, State> {
     } else if (roots === 1 && orphans > 0) {
       warning = (
         <Alert type="info" showIcon>
-          <ExternalLink href="https://docs.sentry.io/product/performance/trace-view/#orphan-traces-and-broken-subtraces">
+          <ExternalLink href="https://docs.sentry.io/concepts/key-terms/tracing/trace-view/#orphan-traces-and-broken-subtraces">
             {t(
               'This trace has broken subtraces. Transactions linked by a dashed line have been orphaned and cannot be directly linked to the root.'
             )}

--- a/static/app/views/performance/traceDetails/newTraceDetailsContent.tsx
+++ b/static/app/views/performance/traceDetails/newTraceDetailsContent.tsx
@@ -258,7 +258,7 @@ function NewTraceDetailsContent(props: Props) {
       case TraceType.NO_ROOT:
         warning = (
           <Alert type="info" showIcon>
-            <ExternalLink href="https://docs.sentry.io/product/performance/trace-view/#orphan-traces-and-broken-subtraces">
+            <ExternalLink href="https://docs.sentry.io/concepts/key-terms/tracing/trace-view/#orphan-traces-and-broken-subtraces">
               {t(
                 'A root transaction is missing. Transactions linked by a dashed line have been orphaned and cannot be directly linked to the root.'
               )}
@@ -269,7 +269,7 @@ function NewTraceDetailsContent(props: Props) {
       case TraceType.BROKEN_SUBTRACES:
         warning = (
           <Alert type="info" showIcon>
-            <ExternalLink href="https://docs.sentry.io/product/performance/trace-view/#orphan-traces-and-broken-subtraces">
+            <ExternalLink href="https://docs.sentry.io/concepts/key-terms/tracing/trace-view/#orphan-traces-and-broken-subtraces">
               {t(
                 'This trace has broken subtraces. Transactions linked by a dashed line have been orphaned and cannot be directly linked to the root.'
               )}


### PR DESCRIPTION
The links to the "Orphan Traces and Broken Subtraces" docs for Trace View were broken in the last docs shuffle. Fixed the links.

This issue was pointed out in https://github.com/getsentry/sentry-docs/issues/10715 (which I'm leaving open despite this fix, to track adding a redirect to docs).