### PR TITLE
ref(similarity): Use same feature flag for deletion

### DIFF
--- a/src/sentry/api/endpoints/project_details.py
+++ b/src/sentry/api/endpoints/project_details.py
@@ -984,7 +984,7 @@ class ProjectDetailsEndpoint(ProjectEndpoint):
             project.rename_on_pending_deletion()
 
             # Tell seer to delete all the project's grouping records
-            if features.has("projects:similarity-embeddings-delete-by-hash", project):
+            if features.has("projects:similarity-embeddings-grouping", project):
                 call_seer_delete_project_grouping_records.apply_async(args=[project.id])
 
         return Response(status=204)

--- a/src/sentry/seer/similarity/utils.py
+++ b/src/sentry/seer/similarity/utils.py
@@ -120,9 +120,7 @@ def event_content_is_seer_eligible(event: Event) -> bool:
     return True
 
 
-def killswitch_enabled(
-    project_id: int, event: Event | None = None, check_delete_killswitch: bool = False
-) -> bool:
+def killswitch_enabled(project_id: int, event: Event | None = None) -> bool:
     """
     Check both the global and similarity-specific Seer killswitches.
     """
@@ -153,11 +151,6 @@ def killswitch_enabled(
             sample_rate=1.0,
             tags={"call_made": False, "blocker": "similarity-killswitch"},
         )
-        return True
-
-    if check_delete_killswitch and options.get(
-        "seer.similarity-embeddings-delete-by-hash-killswitch.enabled"
-    ):
         return True
 
     return False

--- a/src/sentry/seer/similarity/utils.py
+++ b/src/sentry/seer/similarity/utils.py
@@ -120,7 +120,9 @@ def event_content_is_seer_eligible(event: Event) -> bool:
     return True
 
 
-def killswitch_enabled(project_id: int, event: Event | None = None) -> bool:
+def killswitch_enabled(
+    project_id: int, event: Event | None = None, check_delete_killswitch: bool = False
+) -> bool:
     """
     Check both the global and similarity-specific Seer killswitches.
     """
@@ -151,6 +153,11 @@ def killswitch_enabled(project_id: int, event: Event | None = None) -> bool:
             sample_rate=1.0,
             tags={"call_made": False, "blocker": "similarity-killswitch"},
         )
+        return True
+
+    if check_delete_killswitch and options.get(
+        "seer.similarity-embeddings-delete-by-hash-killswitch.enabled"
+    ):
         return True
 
     return False

--- a/src/sentry/tasks/delete_seer_grouping_records.py
+++ b/src/sentry/tasks/delete_seer_grouping_records.py
@@ -34,7 +34,7 @@ def delete_seer_grouping_records_by_hash(
     Task to delete seer grouping records by hash list.
     Calls the seer delete by hash endpoint with batches of hashes of size `BATCH_SIZE`.
     """
-    if killswitch_enabled(project_id):
+    if killswitch_enabled(project_id, check_delete_killswitch=True):
         return
 
     batch_size = options.get("embeddings-grouping.seer.delete-record-batch-size")
@@ -55,7 +55,7 @@ def call_delete_seer_grouping_records_by_hash(
     if (
         project
         and features.has("projects:similarity-embeddings-grouping", project)
-        and not killswitch_enabled(project.id)
+        and not killswitch_enabled(project.id, check_delete_killswitch=True)
     ):
         # TODO (jangjodi): once we store seer grouping info in GroupHash, we should filter by that here
         group_hash_objects = GroupHash.objects.filter(
@@ -83,7 +83,7 @@ def call_seer_delete_project_grouping_records(
     *args: Any,
     **kwargs: Any,
 ) -> None:
-    if killswitch_enabled(project_id):
+    if killswitch_enabled(project_id, check_delete_killswitch=True):
         return
 
     logger.info("calling seer delete records by project", extra={"project_id": project_id})

--- a/src/sentry/tasks/delete_seer_grouping_records.py
+++ b/src/sentry/tasks/delete_seer_grouping_records.py
@@ -34,7 +34,9 @@ def delete_seer_grouping_records_by_hash(
     Task to delete seer grouping records by hash list.
     Calls the seer delete by hash endpoint with batches of hashes of size `BATCH_SIZE`.
     """
-    if killswitch_enabled(project_id):
+    if killswitch_enabled(project_id) or options.get(
+        "seer.similarity-embeddings-delete-by-hash-killswitch.enabled"
+    ):
         return
 
     batch_size = options.get("embeddings-grouping.seer.delete-record-batch-size")
@@ -54,7 +56,8 @@ def call_delete_seer_grouping_records_by_hash(
         project = group.project if group else None
     if (
         project
-        and features.has("projects:similarity-embeddings-delete-by-hash", project)
+        and features.has("projects:similarity-embeddings-grouping", project)
+        and not options.get("seer.similarity-embeddings-delete-by-hash-killswitch.enabled")
         and not killswitch_enabled(project.id)
     ):
         # TODO (jangjodi): once we store seer grouping info in GroupHash, we should filter by that here
@@ -83,7 +86,9 @@ def call_seer_delete_project_grouping_records(
     *args: Any,
     **kwargs: Any,
 ) -> None:
-    if killswitch_enabled(project_id):
+    if killswitch_enabled(project_id) or options.get(
+        "seer.similarity-embeddings-delete-by-hash-killswitch.enabled"
+    ):
         return
 
     logger.info("calling seer delete records by project", extra={"project_id": project_id})

--- a/src/sentry/tasks/delete_seer_grouping_records.py
+++ b/src/sentry/tasks/delete_seer_grouping_records.py
@@ -34,7 +34,9 @@ def delete_seer_grouping_records_by_hash(
     Task to delete seer grouping records by hash list.
     Calls the seer delete by hash endpoint with batches of hashes of size `BATCH_SIZE`.
     """
-    if killswitch_enabled(project_id, check_delete_killswitch=True):
+    if killswitch_enabled(project_id) or options.get(
+        "seer.similarity-embeddings-delete-by-hash-killswitch.enabled"
+    ):
         return
 
     batch_size = options.get("embeddings-grouping.seer.delete-record-batch-size")
@@ -55,7 +57,8 @@ def call_delete_seer_grouping_records_by_hash(
     if (
         project
         and features.has("projects:similarity-embeddings-grouping", project)
-        and not killswitch_enabled(project.id, check_delete_killswitch=True)
+        and not killswitch_enabled(project.id)
+        and not options.get("seer.similarity-embeddings-delete-by-hash-killswitch.enabled")
     ):
         # TODO (jangjodi): once we store seer grouping info in GroupHash, we should filter by that here
         group_hash_objects = GroupHash.objects.filter(
@@ -83,7 +86,9 @@ def call_seer_delete_project_grouping_records(
     *args: Any,
     **kwargs: Any,
 ) -> None:
-    if killswitch_enabled(project_id, check_delete_killswitch=True):
+    if killswitch_enabled(project_id) or options.get(
+        "seer.similarity-embeddings-delete-by-hash-killswitch.enabled"
+    ):
         return
 
     logger.info("calling seer delete records by project", extra={"project_id": project_id})

--- a/src/sentry/tasks/delete_seer_grouping_records.py
+++ b/src/sentry/tasks/delete_seer_grouping_records.py
@@ -34,9 +34,7 @@ def delete_seer_grouping_records_by_hash(
     Task to delete seer grouping records by hash list.
     Calls the seer delete by hash endpoint with batches of hashes of size `BATCH_SIZE`.
     """
-    if killswitch_enabled(project_id) or options.get(
-        "seer.similarity-embeddings-delete-by-hash-killswitch.enabled"
-    ):
+    if killswitch_enabled(project_id):
         return
 
     batch_size = options.get("embeddings-grouping.seer.delete-record-batch-size")
@@ -57,7 +55,6 @@ def call_delete_seer_grouping_records_by_hash(
     if (
         project
         and features.has("projects:similarity-embeddings-grouping", project)
-        and not options.get("seer.similarity-embeddings-delete-by-hash-killswitch.enabled")
         and not killswitch_enabled(project.id)
     ):
         # TODO (jangjodi): once we store seer grouping info in GroupHash, we should filter by that here
@@ -86,9 +83,7 @@ def call_seer_delete_project_grouping_records(
     *args: Any,
     **kwargs: Any,
 ) -> None:
-    if killswitch_enabled(project_id) or options.get(
-        "seer.similarity-embeddings-delete-by-hash-killswitch.enabled"
-    ):
+    if killswitch_enabled(project_id):
         return
 
     logger.info("calling seer delete records by project", extra={"project_id": project_id})

--- a/tests/sentry/api/endpoints/test_project_details.py
+++ b/tests/sentry/api/endpoints/test_project_details.py
@@ -1606,7 +1606,7 @@ class ProjectDeleteTest(APITestCase):
             model_name="Project", object_id=self.project.id
         ).exists()
 
-    @with_feature("projects:similarity-embeddings-delete-by-hash")
+    @with_feature("projects:similarity-embeddings-grouping")
     @mock.patch(
         "sentry.tasks.delete_seer_grouping_records.call_seer_delete_project_grouping_records.apply_async"
     )

--- a/tests/sentry/api/helpers/test_group_index.py
+++ b/tests/sentry/api/helpers/test_group_index.py
@@ -1085,7 +1085,7 @@ class DeleteGroupsTest(TestCase):
         )
         assert send_robust.called
 
-    @with_feature("projects:similarity-embeddings-delete-by-hash")
+    @with_feature("projects:similarity-embeddings-grouping")
     @patch(
         "sentry.tasks.delete_seer_grouping_records.delete_seer_grouping_records_by_hash.apply_async"
     )

--- a/tests/sentry/deletions/test_group.py
+++ b/tests/sentry/deletions/test_group.py
@@ -136,7 +136,7 @@ class DeleteGroupTest(TestCase, SnubaTestCase):
 
         assert nodestore_delete_multi.call_count == 0
 
-    @with_feature("projects:similarity-embeddings-delete-by-hash")
+    @with_feature("projects:similarity-embeddings-grouping")
     @mock.patch(
         "sentry.tasks.delete_seer_grouping_records.delete_seer_grouping_records_by_hash.apply_async"
     )

--- a/tests/sentry/tasks/test_delete_seer_grouping_records.py
+++ b/tests/sentry/tasks/test_delete_seer_grouping_records.py
@@ -33,7 +33,7 @@ class TestDeleteSeerGroupingRecordsByHash(TestCase):
             "args": [project_id, hashes, 100]
         }
 
-    @with_feature("projects:similarity-embeddings-delete-by-hash")
+    @with_feature("projects:similarity-embeddings-grouping")
     @patch("sentry.tasks.delete_seer_grouping_records.logger")
     def test_call_delete_seer_grouping_records_by_hash_simple(self, mock_logger):
         group_ids, hashes = [], []
@@ -50,7 +50,7 @@ class TestDeleteSeerGroupingRecordsByHash(TestCase):
             extra={"project_id": self.project.id, "hashes": hashes},
         )
 
-    @with_feature("projects:similarity-embeddings-delete-by-hash")
+    @with_feature("projects:similarity-embeddings-grouping")
     @patch("sentry.tasks.delete_seer_grouping_records.delete_seer_grouping_records_by_hash")
     @patch("sentry.tasks.delete_seer_grouping_records.logger")
     def test_call_delete_seer_grouping_records_by_hash_no_hashes(


### PR DESCRIPTION
Switch from using `projects:similarity-embeddings-delete-by-hash` flag to `projects:similarity-embeddings-grouping` flag so that it can be called in ingestion and to LA this feature
Add feature level killswitch check

Will remove old flag from code in follow up PR once the option is removed