### PR TITLE
feat(dashboards): Add errors dataset to dashboards

### DIFF
--- a/static/app/views/dashboards/datasetConfig/base.tsx
+++ b/static/app/views/dashboards/datasetConfig/base.tsx
@@ -19,6 +19,7 @@ import type {DisplayType, Widget, WidgetQuery} from '../types';
 import {WidgetType} from '../types';
 import {getNumEquations} from '../utils';
 
+import {ErrorsConfig} from './errors';
 import {ErrorsAndTransactionsConfig} from './errorsAndTransactions';
 import {IssuesConfig} from './issues';
 import {ReleasesConfig} from './releases';
@@ -215,16 +216,24 @@ export function getDatasetConfig<T extends WidgetType | undefined>(
   ? typeof IssuesConfig
   : T extends WidgetType.RELEASE
     ? typeof ReleasesConfig
-    : typeof ErrorsAndTransactionsConfig;
+    : T extends WidgetType.ERRORS
+      ? typeof ErrorsConfig
+      : typeof ErrorsAndTransactionsConfig;
 
 export function getDatasetConfig(
   widgetType?: WidgetType
-): typeof IssuesConfig | typeof ReleasesConfig | typeof ErrorsAndTransactionsConfig {
+):
+  | typeof IssuesConfig
+  | typeof ReleasesConfig
+  | typeof ErrorsAndTransactionsConfig
+  | typeof ErrorsConfig {
   switch (widgetType) {
     case WidgetType.ISSUE:
       return IssuesConfig;
     case WidgetType.RELEASE:
       return ReleasesConfig;
+    case WidgetType.ERRORS:
+      return ErrorsConfig;
     case WidgetType.DISCOVER:
     default:
       return ErrorsAndTransactionsConfig;

--- a/static/app/views/dashboards/datasetConfig/errors.spec.tsx
+++ b/static/app/views/dashboards/datasetConfig/errors.spec.tsx
@@ -1,0 +1,153 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+import {PageFiltersFixture} from 'sentry-fixture/pageFilters';
+import {ProjectFixture} from 'sentry-fixture/project';
+import {UserFixture} from 'sentry-fixture/user';
+import {WidgetFixture} from 'sentry-fixture/widget';
+
+import {initializeOrg} from 'sentry-test/initializeOrg';
+import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+
+import type {EventViewOptions} from 'sentry/utils/discover/eventView';
+import EventView from 'sentry/utils/discover/eventView';
+import {DiscoverDatasets} from 'sentry/utils/discover/types';
+import {ErrorsConfig} from 'sentry/views/dashboards/datasetConfig/errors';
+
+describe('ErrorsConfig', function () {
+  describe('getCustomFieldRenderer', function () {
+    const {organization, router} = initializeOrg();
+
+    const baseEventViewOptions: EventViewOptions = {
+      start: undefined,
+      end: undefined,
+      createdBy: UserFixture(),
+      display: undefined,
+      fields: [],
+      sorts: [],
+      query: '',
+      project: [],
+      environment: [],
+      yAxis: 'count()',
+      id: undefined,
+      name: undefined,
+      statsPeriod: '14d',
+      team: [],
+      topEvents: undefined,
+    };
+
+    it('links trace ids to performance', async function () {
+      const customFieldRenderer = ErrorsConfig.getCustomFieldRenderer!('trace', {});
+      render(
+        customFieldRenderer!(
+          {trace: 'abcd'},
+          {
+            organization,
+            location: router.location,
+            eventView: new EventView({
+              ...baseEventViewOptions,
+              fields: [{field: 'trace'}],
+            }),
+          }
+        ) as React.ReactElement<any, any>,
+        {router}
+      );
+      await userEvent.click(await screen.findByText('abcd'));
+      expect(router.push).toHaveBeenCalledWith({
+        pathname: '/organizations/org-slug/performance/trace/abcd/',
+        query: {
+          pageEnd: undefined,
+          pageStart: undefined,
+          statsPeriod: '14d',
+        },
+      });
+    });
+
+    it('links event ids to event details', async function () {
+      const project = ProjectFixture();
+      const customFieldRenderer = ErrorsConfig.getCustomFieldRenderer!('id', {});
+      render(
+        customFieldRenderer!(
+          {id: 'defg', 'project.name': project.slug},
+          {
+            organization,
+            location: router.location,
+            eventView: new EventView({
+              ...baseEventViewOptions,
+              fields: [{field: 'id'}],
+              project: [parseInt(project.id, 10)],
+            }),
+          }
+        ) as React.ReactElement<any, any>,
+        {router}
+      );
+
+      await userEvent.click(await screen.findByText('defg'));
+      expect(router.push).toHaveBeenCalledWith({
+        pathname: `/organizations/org-slug/discover/${project.slug}:defg/`,
+        query: {
+          display: undefined,
+          environment: [],
+          field: ['id'],
+          id: undefined,
+          interval: undefined,
+          name: undefined,
+          project: [parseInt(project.id, 10)],
+          query: '',
+          sort: [],
+          topEvents: undefined,
+          widths: [],
+          yAxis: 'count()',
+          pageEnd: undefined,
+          pageStart: undefined,
+          statsPeriod: '14d',
+        },
+      });
+    });
+  });
+
+  describe('getEventsRequest', function () {
+    let api, organization, mockEventsRequest;
+
+    beforeEach(function () {
+      MockApiClient.clearMockResponses();
+
+      api = new MockApiClient();
+      organization = OrganizationFixture();
+
+      mockEventsRequest = MockApiClient.addMockResponse({
+        url: '/organizations/org-slug/events/',
+        body: {
+          data: [],
+        },
+      });
+    });
+
+    it('makes a request to the errors dataset', function () {
+      const pageFilters = PageFiltersFixture();
+      const widget = WidgetFixture();
+
+      ErrorsConfig.getTableRequest!(
+        api,
+        widget,
+        {
+          fields: ['count()'],
+          aggregates: ['count()'],
+          columns: [],
+          conditions: '',
+          name: '',
+          orderby: '',
+        },
+        organization,
+        pageFilters
+      );
+
+      expect(mockEventsRequest).toHaveBeenCalledWith(
+        '/organizations/org-slug/events/',
+        expect.objectContaining({
+          query: expect.objectContaining({
+            dataset: DiscoverDatasets.ERRORS,
+          }),
+        })
+      );
+    });
+  });
+});

--- a/static/app/views/dashboards/datasetConfig/errors.tsx
+++ b/static/app/views/dashboards/datasetConfig/errors.tsx
@@ -1,0 +1,334 @@
+import type {Client} from 'sentry/api';
+import Link from 'sentry/components/links/link';
+import {Tooltip} from 'sentry/components/tooltip';
+import {t} from 'sentry/locale';
+import type {
+  EventsStats,
+  MultiSeriesEventsStats,
+  Organization,
+  PageFilters,
+  TagCollection,
+} from 'sentry/types';
+import type {Series} from 'sentry/types/echarts';
+import type {CustomMeasurementCollection} from 'sentry/utils/customMeasurements/customMeasurements';
+import {getTimeStampFromTableDateField} from 'sentry/utils/dates';
+import type {EventsTableData, TableData} from 'sentry/utils/discover/discoverQuery';
+import type {MetaType} from 'sentry/utils/discover/eventView';
+import type {RenderFunctionBaggage} from 'sentry/utils/discover/fieldRenderers';
+import {getFieldRenderer} from 'sentry/utils/discover/fieldRenderers';
+import type {AggregationOutputType, QueryFieldValue} from 'sentry/utils/discover/fields';
+import type {
+  DiscoverQueryExtras,
+  DiscoverQueryRequestParams,
+} from 'sentry/utils/discover/genericDiscoverQuery';
+import {doDiscoverQuery} from 'sentry/utils/discover/genericDiscoverQuery';
+import {Container} from 'sentry/utils/discover/styles';
+import {
+  eventDetailsRouteWithEventView,
+  generateEventSlug,
+} from 'sentry/utils/discover/urls';
+import {getShortEventId} from 'sentry/utils/events';
+import {FieldKey} from 'sentry/utils/fields';
+import type {MEPState} from 'sentry/utils/performance/contexts/metricsEnhancedSetting';
+import type {OnDemandControlContext} from 'sentry/utils/performance/contexts/onDemandControl';
+import {shouldUseOnDemandMetrics} from 'sentry/utils/performance/contexts/onDemandControl';
+import type {FieldValueOption} from 'sentry/views/discover/table/queryField';
+import {FieldValueKind} from 'sentry/views/discover/table/types';
+import {generateFieldOptions} from 'sentry/views/discover/utils';
+import {getTraceDetailsUrl} from 'sentry/views/performance/traceDetails/utils';
+
+import type {Widget, WidgetQuery} from '../types';
+import {DisplayType} from '../types';
+import {eventViewFromWidget} from '../utils';
+import {EventsSearchBar} from '../widgetBuilder/buildSteps/filterResultsStep/eventsSearchBar';
+
+import type {DatasetConfig} from './base';
+import {handleOrderByReset} from './base';
+import {getTableSortOptions} from './errorsAndTransactions';
+
+const DEFAULT_WIDGET_QUERY: WidgetQuery = {
+  name: '',
+  fields: ['count()'],
+  columns: [],
+  fieldAliases: [],
+  aggregates: ['count()'],
+  conditions: '',
+  orderby: '-count()',
+};
+
+export type SeriesWithOrdering = [order: number, series: Series];
+
+export const ErrorsConfig: DatasetConfig<
+  EventsStats | MultiSeriesEventsStats,
+  TableData | EventsTableData
+> = {
+  defaultWidgetQuery: DEFAULT_WIDGET_QUERY,
+  enableEquations: true,
+  getCustomFieldRenderer: getCustomEventsFieldRenderer,
+  SearchBar: EventsSearchBar,
+  filterSeriesSortOptions,
+  filterYAxisAggregateParams,
+  filterYAxisOptions,
+  getTableFieldOptions: getEventsTableFieldOptions,
+  getTimeseriesSortOptions,
+  getTableSortOptions,
+  getGroupByFieldOptions: getEventsTableFieldOptions,
+  handleOrderByReset,
+  supportedDisplayTypes: [DisplayType.TABLE],
+  getTableRequest: (
+    api: Client,
+    widget: Widget,
+    query: WidgetQuery,
+    organization: Organization,
+    pageFilters: PageFilters,
+    onDemandControlContext?: OnDemandControlContext,
+    limit?: number,
+    cursor?: string,
+    referrer?: string,
+    mepSetting?: MEPState | null
+  ) => {
+    const url = `/organizations/${organization.slug}/events/`;
+
+    const useOnDemandMetrics = shouldUseOnDemandMetrics(
+      organization,
+      widget,
+      onDemandControlContext
+    );
+    const queryExtras = {
+      useOnDemandMetrics,
+      ...getQueryExtraForSplittingDiscover(widget, organization, !!useOnDemandMetrics),
+      onDemandType: 'dynamic_query',
+      dataset: 'errors',
+    };
+    return getEventsRequest(
+      url,
+      api,
+      query,
+      organization,
+      pageFilters,
+      limit,
+      cursor,
+      referrer,
+      mepSetting,
+      queryExtras
+    );
+  },
+  getSeriesRequest: getEventsSeriesRequest,
+  transformSeries: transformEventsResponseToSeries,
+  transformTable: transformEventsResponseToTable,
+  filterAggregateParams,
+  getSeriesResultType,
+};
+
+function getEventsTableFieldOptions(
+  organization: Organization,
+  tags?: TagCollection,
+  _customMeasurements?: CustomMeasurementCollection
+) {
+  return generateFieldOptions({
+    organization,
+    tagKeys: Object.values(tags ?? {}).map(({key}) => key),
+  });
+}
+
+function transformEventsResponseToTable(
+  data: TableData | EventsTableData,
+  _widgetQuery: WidgetQuery
+): TableData {
+  let tableData = data;
+  // events api uses a different response format so we need to construct tableData differently
+  const {fields, ...otherMeta} = (data as EventsTableData).meta ?? {};
+  tableData = {
+    ...data,
+    meta: {...fields, ...otherMeta},
+  } as TableData;
+  return tableData as TableData;
+}
+
+function renderEventIdAsLinkable(data, {eventView, organization}: RenderFunctionBaggage) {
+  const id: string | unknown = data?.id;
+  if (!eventView || typeof id !== 'string') {
+    return null;
+  }
+
+  const eventSlug = generateEventSlug(data);
+
+  const target = eventDetailsRouteWithEventView({
+    orgSlug: organization.slug,
+    eventSlug,
+    eventView,
+  });
+
+  return (
+    <Tooltip title={t('View Event')}>
+      <Link data-test-id="view-event" to={target}>
+        <Container>{getShortEventId(id)}</Container>
+      </Link>
+    </Tooltip>
+  );
+}
+
+function renderTraceAsLinkable(
+  data,
+  {eventView, organization, location}: RenderFunctionBaggage
+) {
+  const id: string | unknown = data?.trace;
+  if (!eventView || typeof id !== 'string') {
+    return null;
+  }
+  const dateSelection = eventView.normalizeDateSelection(location);
+  const target = getTraceDetailsUrl({
+    organization,
+    traceSlug: String(data.trace),
+    dateSelection,
+    timestamp: getTimeStampFromTableDateField(data.timestamp),
+    location,
+  });
+
+  return (
+    <Tooltip title={t('View Trace')}>
+      <Link data-test-id="view-trace" to={target}>
+        <Container>{getShortEventId(id)}</Container>
+      </Link>
+    </Tooltip>
+  );
+}
+
+export function getCustomEventsFieldRenderer(field: string, meta: MetaType) {
+  if (field === 'id') {
+    return renderEventIdAsLinkable;
+  }
+
+  if (field === 'trace') {
+    return renderTraceAsLinkable;
+  }
+
+  return getFieldRenderer(field, meta, false);
+}
+
+function getEventsRequest(
+  url: string,
+  api: Client,
+  query: WidgetQuery,
+  _organization: Organization,
+  pageFilters: PageFilters,
+  limit?: number,
+  cursor?: string,
+  referrer?: string,
+  _mepSetting?: MEPState | null,
+  queryExtras?: DiscoverQueryExtras
+) {
+  const eventView = eventViewFromWidget('', query, pageFilters);
+
+  const params: DiscoverQueryRequestParams = {
+    per_page: limit,
+    cursor,
+    referrer,
+    ...queryExtras,
+  };
+
+  if (query.orderby) {
+    params.sort = typeof query.orderby === 'string' ? [query.orderby] : query.orderby;
+  }
+
+  return doDiscoverQuery<EventsTableData>(
+    api,
+    url,
+    {
+      ...eventView.generateQueryStringObject(),
+      ...params,
+    },
+    // Tries events request up to 3 times on rate limit
+    {
+      retry: {
+        statusCodes: [429],
+        tries: 3,
+      },
+    }
+  );
+}
+
+// Checks fieldValue to see what function is being used and only allow supported custom measurements
+function filterAggregateParams(option: FieldValueOption, fieldValue?: QueryFieldValue) {
+  if (
+    (option.value.kind === FieldValueKind.CUSTOM_MEASUREMENT &&
+      fieldValue?.kind === 'function' &&
+      fieldValue?.function &&
+      !option.value.meta.functions.includes(fieldValue.function[0])) ||
+    option.value.meta.name === FieldKey.TOTAL_COUNT
+  ) {
+    return false;
+  }
+  return true;
+}
+
+const shouldSendWidgetForSplittingDiscover = (organization: Organization) => {
+  return organization.features.includes('performance-discover-dataset-selector');
+};
+
+const getQueryExtraForSplittingDiscover = (
+  widget: Widget,
+  organization: Organization,
+  useOnDemandMetrics: boolean
+) => {
+  if (!useOnDemandMetrics || !shouldSendWidgetForSplittingDiscover(organization)) {
+    return {};
+  }
+  if (widget.id) {
+    return {dashboardWidgetId: widget.id};
+  }
+  return {};
+};
+
+// TODO: Implement these functions to support events-stats requests
+// and update the return type
+function filterSeriesSortOptions(_columns: Set<string>): any {
+  throw new Error('Not implemented');
+}
+
+function getTimeseriesSortOptions(
+  _organization: Organization,
+  _widgetQuery: WidgetQuery,
+  _tags?: TagCollection
+): any {
+  throw new Error('Not implemented');
+}
+
+function filterYAxisAggregateParams(
+  _fieldValue: QueryFieldValue,
+  _displayType: DisplayType
+): any {
+  throw new Error('Not implemented');
+}
+
+function filterYAxisOptions(_displayType: DisplayType): any {
+  throw new Error('Not implemented');
+}
+
+function transformEventsResponseToSeries(
+  _data: EventsStats | MultiSeriesEventsStats,
+  _widgetQuery: WidgetQuery
+): Series[] {
+  throw new Error('Not implemented');
+}
+
+// Get the series result type from the EventsStats meta
+function getSeriesResultType(
+  _data: EventsStats | MultiSeriesEventsStats,
+  _widgetQuery: WidgetQuery
+): Record<string, AggregationOutputType> {
+  throw new Error('Not implemented');
+}
+
+function getEventsSeriesRequest(
+  _api: Client,
+  _widget: Widget,
+  _queryIndex: number,
+  _organization: Organization,
+  _pageFilters: PageFilters,
+  _onDemandControlContext?: OnDemandControlContext,
+  _referrer?: string,
+  _mepSetting?: MEPState | null
+): any {
+  throw new Error('Not implemented');
+}

--- a/static/app/views/dashboards/datasetConfig/errors.tsx
+++ b/static/app/views/dashboards/datasetConfig/errors.tsx
@@ -17,12 +17,10 @@ import type {MetaType} from 'sentry/utils/discover/eventView';
 import type {RenderFunctionBaggage} from 'sentry/utils/discover/fieldRenderers';
 import {getFieldRenderer} from 'sentry/utils/discover/fieldRenderers';
 import type {QueryFieldValue} from 'sentry/utils/discover/fields';
-import type {
-  DiscoverQueryExtras,
-  DiscoverQueryRequestParams,
-} from 'sentry/utils/discover/genericDiscoverQuery';
+import type {DiscoverQueryRequestParams} from 'sentry/utils/discover/genericDiscoverQuery';
 import {doDiscoverQuery} from 'sentry/utils/discover/genericDiscoverQuery';
 import {Container} from 'sentry/utils/discover/styles';
+import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import {
   eventDetailsRouteWithEventView,
   generateEventSlug,
@@ -41,8 +39,7 @@ import {DisplayType} from '../types';
 import {eventViewFromWidget} from '../utils';
 import {EventsSearchBar} from '../widgetBuilder/buildSteps/filterResultsStep/eventsSearchBar';
 
-import type {DatasetConfig} from './base';
-import {handleOrderByReset} from './base';
+import {type DatasetConfig, handleOrderByReset} from './base';
 import {getTableSortOptions} from './errorsAndTransactions';
 
 const DEFAULT_WIDGET_QUERY: WidgetQuery = {
@@ -86,7 +83,7 @@ export const ErrorsConfig: DatasetConfig<
     limit?: number,
     cursor?: string,
     referrer?: string,
-    mepSetting?: MEPState | null
+    _mepSetting?: MEPState | null
   ) => {
     return getEventsRequest(
       api,
@@ -95,8 +92,7 @@ export const ErrorsConfig: DatasetConfig<
       pageFilters,
       limit,
       cursor,
-      referrer,
-      mepSetting
+      referrer
     );
   },
   transformTable: transformEventsResponseToTable,
@@ -189,16 +185,14 @@ export function getCustomEventsFieldRenderer(field: string, meta: MetaType) {
   return getFieldRenderer(field, meta, false);
 }
 
-function getEventsRequest(
+export function getEventsRequest(
   api: Client,
   query: WidgetQuery,
   organization: Organization,
   pageFilters: PageFilters,
   limit?: number,
   cursor?: string,
-  referrer?: string,
-  _mepSetting?: MEPState | null,
-  queryExtras?: DiscoverQueryExtras
+  referrer?: string
 ) {
   const url = `/organizations/${organization.slug}/events/`;
   const eventView = eventViewFromWidget('', query, pageFilters);
@@ -207,7 +201,7 @@ function getEventsRequest(
     per_page: limit,
     cursor,
     referrer,
-    ...queryExtras,
+    dataset: DiscoverDatasets.ERRORS,
   };
 
   if (query.orderby) {

--- a/static/app/views/dashboards/datasetConfig/errors.tsx
+++ b/static/app/views/dashboards/datasetConfig/errors.tsx
@@ -1,7 +1,4 @@
 import type {Client} from 'sentry/api';
-import Link from 'sentry/components/links/link';
-import {Tooltip} from 'sentry/components/tooltip';
-import {t} from 'sentry/locale';
 import type {
   EventsStats,
   MultiSeriesEventsStats,
@@ -11,28 +8,15 @@ import type {
 } from 'sentry/types';
 import type {Series} from 'sentry/types/echarts';
 import type {CustomMeasurementCollection} from 'sentry/utils/customMeasurements/customMeasurements';
-import {getTimeStampFromTableDateField} from 'sentry/utils/dates';
 import type {EventsTableData, TableData} from 'sentry/utils/discover/discoverQuery';
 import type {MetaType} from 'sentry/utils/discover/eventView';
-import type {RenderFunctionBaggage} from 'sentry/utils/discover/fieldRenderers';
 import {getFieldRenderer} from 'sentry/utils/discover/fieldRenderers';
-import type {QueryFieldValue} from 'sentry/utils/discover/fields';
 import type {DiscoverQueryRequestParams} from 'sentry/utils/discover/genericDiscoverQuery';
 import {doDiscoverQuery} from 'sentry/utils/discover/genericDiscoverQuery';
-import {Container} from 'sentry/utils/discover/styles';
 import {DiscoverDatasets} from 'sentry/utils/discover/types';
-import {
-  eventDetailsRouteWithEventView,
-  generateEventSlug,
-} from 'sentry/utils/discover/urls';
-import {getShortEventId} from 'sentry/utils/events';
-import {FieldKey} from 'sentry/utils/fields';
 import type {MEPState} from 'sentry/utils/performance/contexts/metricsEnhancedSetting';
 import type {OnDemandControlContext} from 'sentry/utils/performance/contexts/onDemandControl';
-import type {FieldValueOption} from 'sentry/views/discover/table/queryField';
-import {FieldValueKind} from 'sentry/views/discover/table/types';
 import {generateFieldOptions} from 'sentry/views/discover/utils';
-import {getTraceDetailsUrl} from 'sentry/views/performance/traceDetails/utils';
 
 import type {Widget, WidgetQuery} from '../types';
 import {DisplayType} from '../types';
@@ -40,7 +24,13 @@ import {eventViewFromWidget} from '../utils';
 import {EventsSearchBar} from '../widgetBuilder/buildSteps/filterResultsStep/eventsSearchBar';
 
 import {type DatasetConfig, handleOrderByReset} from './base';
-import {getTableSortOptions} from './errorsAndTransactions';
+import {
+  filterAggregateParams,
+  getTableSortOptions,
+  renderEventIdAsLinkable,
+  renderTraceAsLinkable,
+  transformEventsResponseToTable,
+} from './errorsAndTransactions';
 
 const DEFAULT_WIDGET_QUERY: WidgetQuery = {
   name: '',
@@ -110,69 +100,6 @@ function getEventsTableFieldOptions(
   });
 }
 
-function transformEventsResponseToTable(
-  data: TableData | EventsTableData,
-  _widgetQuery: WidgetQuery
-): TableData {
-  let tableData = data;
-  // events api uses a different response format so we need to construct tableData differently
-  const {fields, ...otherMeta} = (data as EventsTableData).meta ?? {};
-  tableData = {
-    ...data,
-    meta: {...fields, ...otherMeta},
-  } as TableData;
-  return tableData as TableData;
-}
-
-function renderEventIdAsLinkable(data, {eventView, organization}: RenderFunctionBaggage) {
-  const id: string | unknown = data?.id;
-  if (!eventView || typeof id !== 'string') {
-    return null;
-  }
-
-  const eventSlug = generateEventSlug(data);
-
-  const target = eventDetailsRouteWithEventView({
-    orgSlug: organization.slug,
-    eventSlug,
-    eventView,
-  });
-
-  return (
-    <Tooltip title={t('View Event')}>
-      <Link data-test-id="view-event" to={target}>
-        <Container>{getShortEventId(id)}</Container>
-      </Link>
-    </Tooltip>
-  );
-}
-
-function renderTraceAsLinkable(
-  data,
-  {eventView, organization, location}: RenderFunctionBaggage
-) {
-  const id: string | unknown = data?.trace;
-  if (!eventView || typeof id !== 'string') {
-    return null;
-  }
-  const dateSelection = eventView.normalizeDateSelection(location);
-  const target = getTraceDetailsUrl({
-    organization,
-    traceSlug: String(data.trace),
-    dateSelection,
-    timestamp: getTimeStampFromTableDateField(data.timestamp),
-    location,
-  });
-
-  return (
-    <Tooltip title={t('View Trace')}>
-      <Link data-test-id="view-trace" to={target}>
-        <Container>{getShortEventId(id)}</Container>
-      </Link>
-    </Tooltip>
-  );
-}
-
 export function getCustomEventsFieldRenderer(field: string, meta: MetaType) {
   if (field === 'id') {
     return renderEventIdAsLinkable;
@@ -223,18 +150,4 @@ export function getEventsRequest(
       },
     }
   );
-}
-
-// Checks fieldValue to see what function is being used and only allow supported custom measurements
-function filterAggregateParams(option: FieldValueOption, fieldValue?: QueryFieldValue) {
-  if (
-    (option.value.kind === FieldValueKind.CUSTOM_MEASUREMENT &&
-      fieldValue?.kind === 'function' &&
-      fieldValue?.function &&
-      !option.value.meta.functions.includes(fieldValue.function[0])) ||
-    option.value.meta.name === FieldKey.TOTAL_COUNT
-  ) {
-    return false;
-  }
-  return true;
 }

--- a/static/app/views/dashboards/datasetConfig/errorsAndTransactions.tsx
+++ b/static/app/views/dashboards/datasetConfig/errorsAndTransactions.tsx
@@ -159,7 +159,10 @@ export const ErrorsAndTransactionsConfig: DatasetConfig<
   getSeriesResultType,
 };
 
-function getTableSortOptions(_organization: Organization, widgetQuery: WidgetQuery) {
+export function getTableSortOptions(
+  _organization: Organization,
+  widgetQuery: WidgetQuery
+) {
   const {columns, aggregates} = widgetQuery;
   const options: SelectValue<string>[] = [];
   let equations = 0;

--- a/static/app/views/dashboards/datasetConfig/errorsAndTransactions.tsx
+++ b/static/app/views/dashboards/datasetConfig/errorsAndTransactions.tsx
@@ -261,7 +261,7 @@ function getEventsTableFieldOptions(
   });
 }
 
-function transformEventsResponseToTable(
+export function transformEventsResponseToTable(
   data: TableData | EventsTableData,
   _widgetQuery: WidgetQuery
 ): TableData {
@@ -395,7 +395,10 @@ function getSeriesResultType(
   return resultTypes;
 }
 
-function renderEventIdAsLinkable(data, {eventView, organization}: RenderFunctionBaggage) {
+export function renderEventIdAsLinkable(
+  data,
+  {eventView, organization}: RenderFunctionBaggage
+) {
   const id: string | unknown = data?.id;
   if (!eventView || typeof id !== 'string') {
     return null;
@@ -418,7 +421,7 @@ function renderEventIdAsLinkable(data, {eventView, organization}: RenderFunction
   );
 }
 
-function renderTraceAsLinkable(
+export function renderTraceAsLinkable(
   data,
   {eventView, organization, location}: RenderFunctionBaggage
 ) {
@@ -666,7 +669,10 @@ async function doOnDemandMetricsRequest(
 }
 
 // Checks fieldValue to see what function is being used and only allow supported custom measurements
-function filterAggregateParams(option: FieldValueOption, fieldValue?: QueryFieldValue) {
+export function filterAggregateParams(
+  option: FieldValueOption,
+  fieldValue?: QueryFieldValue
+) {
   if (
     (option.value.kind === FieldValueKind.CUSTOM_MEASUREMENT &&
       fieldValue?.kind === 'function' &&

--- a/static/app/views/dashboards/types.tsx
+++ b/static/app/views/dashboards/types.tsx
@@ -26,6 +26,7 @@ export enum WidgetType {
   ISSUE = 'issue',
   RELEASE = 'metrics', // TODO(metrics): rename RELEASE to 'release', and METRICS to 'metrics'
   METRICS = 'custom-metrics',
+  ERRORS = 'error-events',
 }
 
 // These only pertain to on-demand warnings at this point in time

--- a/static/app/views/dashboards/widgetBuilder/buildSteps/dataSetStep.tsx
+++ b/static/app/views/dashboards/widgetBuilder/buildSteps/dataSetStep.tsx
@@ -5,16 +5,12 @@ import RadioGroup from 'sentry/components/forms/controls/radioGroup';
 import ExternalLink from 'sentry/components/links/externalLink';
 import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
+import useOrganization from 'sentry/utils/useOrganization';
 import {DisplayType} from 'sentry/views/dashboards/types';
 
 import {DataSet} from '../utils';
 
 import {BuildStep} from './buildStep';
-
-// const DATASET_CHOICES: [DataSet, string][] = [
-//   [DataSet.EVENTS, t('Errors and Transactions')],
-//   [DataSet.ISSUES, t('Issues (States, Assignment, Time, etc.)')],
-// ];
 
 interface Props {
   dataSet: DataSet;
@@ -29,6 +25,7 @@ export function DataSetStep({
   hasReleaseHealthFeature,
   displayType,
 }: Props) {
+  const organization = useOrganization();
   const disabledChoices: RadioGroupProps<string>['disabledChoices'] = [];
 
   if (displayType !== DisplayType.TABLE) {
@@ -39,6 +36,12 @@ export function DataSetStep({
   }
 
   const datasetChoices = new Map<string, string>();
+
+  if (organization.features.includes('performance-discover-dataset-selector')) {
+    // TODO: Finalize description copy
+    datasetChoices.set(DataSet.ERRORS, t('Errors (TypeError, InvalidSearchQuery, etc)'));
+  }
+
   datasetChoices.set(DataSet.EVENTS, t('Errors and Transactions'));
   datasetChoices.set(DataSet.ISSUES, t('Issues (States, Assignment, Time, etc.)'));
 

--- a/static/app/views/dashboards/widgetBuilder/utils.tsx
+++ b/static/app/views/dashboards/widgetBuilder/utils.tsx
@@ -40,6 +40,7 @@ export enum DataSet {
   ISSUES = 'issues',
   RELEASES = 'releases',
   METRICS = 'metrics',
+  ERRORS = 'error-events',
 }
 
 export enum SortDirection {

--- a/static/app/views/dashboards/widgetBuilder/widgetBuilder.tsx
+++ b/static/app/views/dashboards/widgetBuilder/widgetBuilder.tsx
@@ -101,6 +101,7 @@ const WIDGET_TYPE_TO_DATA_SET = {
   [WidgetType.ISSUE]: DataSet.ISSUES,
   [WidgetType.RELEASE]: DataSet.RELEASES,
   [WidgetType.METRICS]: DataSet.METRICS,
+  [WidgetType.ERRORS]: DataSet.ERRORS,
 };
 
 export const DATA_SET_TO_WIDGET_TYPE = {
@@ -108,6 +109,7 @@ export const DATA_SET_TO_WIDGET_TYPE = {
   [DataSet.ISSUES]: WidgetType.ISSUE,
   [DataSet.RELEASES]: WidgetType.RELEASE,
   [DataSet.METRICS]: WidgetType.METRICS,
+  [DataSet.ERRORS]: WidgetType.ERRORS,
 };
 
 interface RouteParams {

--- a/static/app/views/dashboards/widgetCard/widgetQueries.tsx
+++ b/static/app/views/dashboards/widgetCard/widgetQueries.tsx
@@ -17,9 +17,9 @@ import type {MetricsResultsMetaMapKey} from 'sentry/utils/performance/contexts/m
 import {useMetricsResultsMeta} from 'sentry/utils/performance/contexts/metricsEnhancedPerformanceDataContext';
 import {useMEPSettingContext} from 'sentry/utils/performance/contexts/metricsEnhancedSetting';
 import {OnDemandControlConsumer} from 'sentry/utils/performance/contexts/onDemandControl';
+import {getDatasetConfig} from 'sentry/views/dashboards/datasetConfig/base';
 
-import {ErrorsAndTransactionsConfig} from '../datasetConfig/errorsAndTransactions';
-import type {DashboardFilters, Widget} from '../types';
+import type {DashboardFilters, Widget, WidgetType} from '../types';
 
 import {DashboardsMEPContext} from './dashboardsMEPContext';
 import type {
@@ -132,7 +132,10 @@ function WidgetQueries({
   limit,
   onDataFetched,
 }: Props) {
-  const config = ErrorsAndTransactionsConfig;
+  // Discover and Errors datasets are the only datasets processed in this component
+  const config = getDatasetConfig(
+    widget.widgetType as WidgetType.DISCOVER | WidgetType.ERRORS
+  );
   const context = useContext(DashboardsMEPContext);
   const metricsMeta = useMetricsResultsMeta();
   const mepSettingContext = useMEPSettingContext();


### PR DESCRIPTION
This adds the first part of the config for the errors dataset to dashboards. It focuses on the widget builder and accomplishes the following:

1. Surfacing the error radio button in the widget builder
2. When selected, a request is made using `dataset=errors`

The basis for the config was from the `errorsAndTransactions.tsx` config, but where applicable I've removed logic relating to on demand metrics and split decisions because with this dataset, the split decision is explicit and there's no need to send the dashboard widget ID.

I am aware that the fields being presented are not errors only, I want to make another PR to specifically split apart the errors from transactions fields/aggregates so this PR doesn't get too confusing.