### PR TITLE
chore(profiling): Remove unused endpoint for profiling filters

### DIFF
--- a/src/sentry/api/endpoints/organization_profiling_profiles.py
+++ b/src/sentry/api/endpoints/organization_profiling_profiles.py
@@ -1,5 +1,3 @@
-from typing import Any
-
 import sentry_sdk
 from django.http import HttpResponse
 from rest_framework.exceptions import ParseError
@@ -12,8 +10,7 @@ from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 
 # from sentry.api.bases.organization import OrganizationEndpoint
-from sentry.api.bases import NoProjects, OrganizationEventsV2EndpointBase
-from sentry.exceptions import InvalidSearchQuery
+from sentry.api.bases import OrganizationEventsV2EndpointBase
 from sentry.models.organization import Organization
 from sentry.profiles.flamegraph import (
     get_chunks_from_spans_metadata,
@@ -23,7 +20,7 @@ from sentry.profiles.flamegraph import (
     get_spans_from_group,
 )
 from sentry.profiles.profile_chunks import get_chunk_ids
-from sentry.profiles.utils import parse_profile_filters, proxy_profiling_service
+from sentry.profiles.utils import proxy_profiling_service
 
 
 class OrganizationProfilingBaseEndpoint(OrganizationEventsV2EndpointBase):
@@ -31,32 +28,6 @@ class OrganizationProfilingBaseEndpoint(OrganizationEventsV2EndpointBase):
     publish_status = {
         "GET": ApiPublishStatus.PRIVATE,
     }
-
-    def get_profiling_params(self, request: Request, organization: Organization) -> dict[str, Any]:
-        try:
-            params: dict[str, Any] = parse_profile_filters(request.query_params.get("query", ""))
-        except InvalidSearchQuery as err:
-            raise ParseError(detail=str(err))
-
-        params.update(self.get_filter_params(request, organization))
-
-        return params
-
-
-@region_silo_endpoint
-class OrganizationProfilingFiltersEndpoint(OrganizationProfilingBaseEndpoint):
-    def get(self, request: Request, organization: Organization) -> HttpResponse:
-        if not features.has("organizations:profiling", organization, actor=request.user):
-            return Response(status=404)
-
-        try:
-            params = self.get_profiling_params(request, organization)
-        except NoProjects:
-            return Response([])
-
-        return proxy_profiling_service(
-            "GET", f"/organizations/{organization.id}/filters", params=params
-        )
 
 
 @region_silo_endpoint

--- a/src/sentry/api/endpoints/project_profiling_profile.py
+++ b/src/sentry/api/endpoints/project_profiling_profile.py
@@ -1,4 +1,3 @@
-from abc import ABC, abstractmethod
 from typing import Any
 
 import orjson
@@ -13,7 +12,6 @@ from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.project import ProjectEndpoint
-from sentry.api.paginator import GenericOffsetPaginator
 from sentry.api.serializers import serialize
 from sentry.api.utils import generate_organization_url
 from sentry.exceptions import InvalidSearchQuery
@@ -41,34 +39,6 @@ class ProjectProfilingBaseEndpoint(ProjectEndpoint):
         params.update(self.get_filter_params(request, project))
 
         return params
-
-
-class ProjectProfilingPaginatedBaseEndpoint(ProjectProfilingBaseEndpoint, ABC):
-    DEFAULT_PER_PAGE = 50
-    MAX_PER_PAGE = 500
-
-    @abstractmethod
-    def get_data_fn(self, request: Request, project: Project, kwargs: dict[str, Any]) -> Any:
-        raise NotImplementedError
-
-    def get_on_result(self) -> Any:
-        return None
-
-    def get(self, request: Request, project: Project) -> Response:
-        if not features.has("organizations:profiling", project.organization, actor=request.user):
-            return Response(status=404)
-
-        params = self.get_profiling_params(request, project)
-
-        kwargs = {"params": params}
-
-        return self.paginate(
-            request,
-            paginator=GenericOffsetPaginator(data_fn=self.get_data_fn(request, project, kwargs)),
-            default_per_page=self.DEFAULT_PER_PAGE,
-            max_per_page=self.MAX_PER_PAGE,
-            on_results=self.get_on_result(),
-        )
 
 
 @region_silo_endpoint

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -452,7 +452,6 @@ from .endpoints.organization_profiling_functions import OrganizationProfilingFun
 from .endpoints.organization_profiling_profiles import (
     OrganizationProfilingChunksEndpoint,
     OrganizationProfilingChunksFlamegraphEndpoint,
-    OrganizationProfilingFiltersEndpoint,
     OrganizationProfilingFlamegraphEndpoint,
 )
 from .endpoints.organization_projects import (
@@ -2101,11 +2100,6 @@ ORGANIZATION_URLS = [
         r"^(?P<organization_id_or_slug>[^/]+)/profiling/",
         include(
             [
-                re_path(
-                    r"^filters/$",
-                    OrganizationProfilingFiltersEndpoint.as_view(),
-                    name="sentry-api-0-organization-profiling-filters",
-                ),
                 re_path(
                     r"^flamegraph/$",
                     OrganizationProfilingFlamegraphEndpoint.as_view(),

--- a/tests/sentry/api/endpoints/test_organization_profiling_profiles.py
+++ b/tests/sentry/api/endpoints/test_organization_profiling_profiles.py
@@ -10,32 +10,6 @@ from sentry.testutils.cases import APITestCase
 from sentry.testutils.helpers.datetime import freeze_time
 
 
-class OrganizationProfilingFiltersTest(APITestCase):
-    endpoint = "sentry-api-0-organization-profiling-filters"
-    features = {"organizations:profiling": True}
-
-    def setUp(self):
-        self.login_as(user=self.user)
-        self.url = reverse(self.endpoint, args=(self.organization.slug,))
-
-    def test_feature_flag_disabled(self):
-        response = self.client.get(self.url)
-        assert response.status_code == 404
-
-    def test_bad_filter(self):
-        with self.feature(self.features):
-            response = self.client.get(self.url, {"query": "foo:bar"})
-        assert response.status_code == 400
-        assert response.data == {
-            "detail": ErrorDetail(string="Invalid query: foo is not supported", code="parse_error")
-        }
-
-    def test_no_projects(self):
-        with self.feature(self.features):
-            response = self.client.get(self.url)
-        assert response.status_code == 200
-
-
 class OrganizationProfilingChunksTest(APITestCase):
     endpoint = "sentry-api-0-organization-profiling-chunks"
     features = {"organizations:continuous-profiling": True, "organizations:global-views": True}


### PR DESCRIPTION
Having migrated to the transactions table, this is no longer needed.

Continuation of #74306