### PR TITLE
fix(slack): get latest parent message to create a thread with

### DIFF
--- a/src/sentry/integrations/repository/issue_alert.py
+++ b/src/sentry/integrations/repository/issue_alert.py
@@ -108,10 +108,14 @@ class IssueAlertNotificationMessageRepository:
         """
         try:
             base_filter = self._parent_notification_message_base_filter()
-            instance: NotificationMessage = self._model.objects.filter(base_filter).get(
-                rule_fire_history__rule__id=rule_id,
-                rule_fire_history__group__id=group_id,
-                rule_action_uuid=rule_action_uuid,
+            instance: NotificationMessage = (
+                self._model.objects.filter(base_filter)
+                .filter(
+                    rule_fire_history__rule__id=rule_id,
+                    rule_fire_history__group__id=group_id,
+                    rule_action_uuid=rule_action_uuid,
+                )
+                .latest("date_added")
             )
             return IssueAlertNotificationMessage.from_model(instance=instance)
         except NotificationMessage.DoesNotExist:

--- a/tests/sentry/integrations/repository/issue_alert/test_issue_alert_notification_message_repository.py
+++ b/tests/sentry/integrations/repository/issue_alert/test_issue_alert_notification_message_repository.py
@@ -55,6 +55,31 @@ class TestGetParentNotificationMessage(BaseIssueAlertNotificationMessageReposito
             self.parent_notification_message
         )
 
+    def test_returns_latest_parent_notification_message(self) -> None:
+        # this can happen if somebody toggles threads on for the first time
+        rule_fire_history = RuleFireHistory.objects.create(
+            project=self.project,
+            rule=self.rule,
+            group=self.group,
+            event_id=self.event_id,
+            notification_uuid=self.notification_uuid,
+        )
+
+        latest = NotificationMessage.objects.create(
+            rule_fire_history=rule_fire_history,
+            rule_action_uuid=self.action_uuid,
+            message_identifier="abc123",
+        )
+
+        instance = self.repository.get_parent_notification_message(
+            rule_id=self.rule.id,
+            group_id=self.group.id,
+            rule_action_uuid=self.action_uuid,
+        )
+
+        assert instance is not None
+        assert instance == IssueAlertNotificationMessage.from_model(latest)
+
     def test_returns_none_when_filter_does_not_exist(self) -> None:
         instance = self.repository.get_parent_notification_message(
             rule_id=9999,


### PR DESCRIPTION
Fixes SENTRY-39PA

A parent message is a message you can create a thread with.

We are getting a `NotificationMessage.MultipleObjectsReturned` error when trying to fetch a single parent notification to start a thread with. We use the `rule_id` and `group_id` of the `rule_fire_history` object to get the `NotificationMessage` object, but this doesn't account for the case where a single rule can fire multiple times for an issue and create multiple `NotificationMessage` objects that match the filter.

If somebody doesn't have threads turned on, each firing of the same rule for 1 issue will be saved as a potential parent message. If somebody then turns the Slack threads feature on, this error will surface because we will now attempt to get 1 parent message from multiple. We need to pick one of these to start the thread with, here we can pick the _latest_ message.