### PR TITLE
chore(empty-states): Add additional analytics event

### DIFF
--- a/static/app/components/updatedEmptyState.tsx
+++ b/static/app/components/updatedEmptyState.tsx
@@ -1,4 +1,4 @@
-import {Fragment} from 'react';
+import {Fragment, useEffect} from 'react';
 import styled from '@emotion/styled';
 
 import waitingForEventImg from 'sentry-images/spot/waiting-for-event.svg';
@@ -14,6 +14,7 @@ import platforms from 'sentry/data/platforms';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {PlatformIntegration, Project} from 'sentry/types/project';
+import {trackAnalytics} from 'sentry/utils/analytics';
 import useOrganization from 'sentry/utils/useOrganization';
 import FirstEventIndicator from 'sentry/views/onboarding/components/firstEventIndicator';
 
@@ -27,6 +28,13 @@ export default function UpdatedEmptyState({project}: {project?: Project}) {
   const currentPlatform = platforms.find(
     p => p.id === currentPlatformKey
   ) as PlatformIntegration;
+
+  useEffect(() => {
+    trackAnalytics('issue_stream.updated_empty_state_viewed', {
+      organization,
+      platform: currentPlatformKey,
+    });
+  }, [organization, currentPlatformKey]);
 
   const loadGettingStarted = useLoadGettingStarted({
     platform: currentPlatform,

--- a/static/app/utils/analytics/workflowAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/workflowAnalyticsEvents.tsx
@@ -140,6 +140,7 @@ export type TeamInsightsEventParameters = {
   'issue_details.tab_changed': IssueDetailsWithAlert & {
     tab: Tab;
   };
+  'issue_stream.updated_empty_state_viewed': {platform: string};
   'project_creation_page.created': {
     issue_alert: 'Default' | 'Custom' | 'No Rule';
     project_id: string;
@@ -207,6 +208,7 @@ export const workflowEventMap: Record<TeamInsightsEventKey, string | null> = {
     'Issue Details: Suspect Pull Request Clicked',
   'issue_details.tab_changed': 'Issue Details: Tab Changed',
   'issue_details.merged_tab.unmerge_clicked': 'Issue Details: Unmerge Clicked',
+  'issue_stream.updated_empty_state_viewed': 'Issue Stream: Updated Empty State Viewed',
   'project_creation_page.created': 'Project Create: Project Created',
   'project_detail.open_issues': 'Project Detail: Open issues from project detail',
   'project_detail.open_discover': 'Project Detail: Open discover from project detail',


### PR DESCRIPTION
this pr adds an additional analytics event to track if the updated empty state is actually seen 