### PR TITLE
fix(alerts): fixes aggregate selector not functioning correctly for metric alerts

### DIFF
--- a/static/app/views/alerts/rules/metric/mriField.spec.tsx
+++ b/static/app/views/alerts/rules/metric/mriField.spec.tsx
@@ -1,0 +1,57 @@
+import {initializeOrg} from 'sentry-test/initializeOrg';
+import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
+
+import MriField from 'sentry/views/alerts/rules/metric/mriField';
+
+describe('MRIField', () => {
+  beforeEach(() => {
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/metrics/meta/',
+      body: [
+        {
+          type: 'd',
+          name: 'sentry.distribution.metric',
+          unit: 'second',
+          mri: 'd:custom/sentry.distribution.metric@second',
+          operations: [
+            'avg',
+            'count',
+            'histogram',
+            'max',
+            'max_timestamp',
+            'min',
+            'min_timestamp',
+            'p50',
+            'p75',
+            'p90',
+            'p95',
+            'p99',
+            'sum',
+          ],
+          projectIds: [1],
+          blockingStatus: [],
+        },
+      ],
+    });
+  });
+  it('should call onChange with the new aggregate string when switching aggregates', async () => {
+    const {project} = initializeOrg();
+    const onChange = jest.fn();
+    render(
+      <MriField
+        aggregate={'sum(d:custom/sentry.distribution.metric@second)'}
+        onChange={onChange}
+        project={project}
+      />
+    );
+    await screen.findByText('Select an operation');
+    userEvent.click(screen.getByText('sum'));
+    userEvent.click(await screen.findByText('p95'));
+    await waitFor(() =>
+      expect(onChange).toHaveBeenCalledWith(
+        'p95(d:custom/sentry.distribution.metric@second)',
+        {}
+      )
+    );
+  });
+});

--- a/static/app/views/alerts/rules/metric/mriField.tsx
+++ b/static/app/views/alerts/rules/metric/mriField.tsx
@@ -163,8 +163,8 @@ function MriField({aggregate, project, onChange}: Props) {
         options={operationOptions}
         value={selectedValues?.aggregation}
         onChange={option => {
-          if (selectedValues?.aggregation) {
-            onChange(MRIToField(option.value, selectedValues?.aggregation), {});
+          if (selectedMriOption?.value) {
+            onChange(MRIToField(selectedMriOption.value, option.value), {});
           }
         }}
       />


### PR DESCRIPTION
Fixes an issue with the aggregate selector not handling change properly on Custom Metric based alerts. Updates to pass the correct MRI + Aggregate string to the onChange handler.

<img width="1089" alt="image" src="https://github.com/user-attachments/assets/08e43d3b-1679-42b8-9153-3a4d27d23701">
