### PR TITLE
Add PUT request for project templates

### DIFF
--- a/src/sentry/api/endpoints/project_template_detail.py
+++ b/src/sentry/api/endpoints/project_template_detail.py
@@ -81,17 +81,16 @@ class OrganizationProjectTemplateDetailEndpoint(OrganizationEndpoint):
             ProjectTemplate, id=template_id, organization=organization
         )
 
-        name = data.get("name", None)
+        name = data.get("name")
         if name is not None:
             project_template.name = name
             project_template.save()
 
         options = data.get("options", {})
-        if options:
-            for key, value in options.items():
-                project_template.options.create_or_update(
-                    project_template=project_template, key=key, value=value
-                )
+        for key, value in options.items():
+            project_template.options.create_or_update(
+                project_template=project_template, key=key, value=value
+            )
 
         return Response(
             serialize(

--- a/src/sentry/api/endpoints/project_template_detail.py
+++ b/src/sentry/api/endpoints/project_template_detail.py
@@ -64,6 +64,7 @@ class OrganizationProjectTemplateDetailEndpoint(OrganizationEndpoint):
         # think about how to handle there being no remaining templates for an org?
         return Response(status=204)
 
+    @ensure_rollout_enabled(PROJECT_TEMPLATE_FEATURE_FLAG)
     def put(self, request: Request, organization: Organization, template_id: str) -> Response:
         """
         Update the project template name or options.

--- a/tests/sentry/api/endpoints/test_project_template_detail.py
+++ b/tests/sentry/api/endpoints/test_project_template_detail.py
@@ -80,16 +80,13 @@ class ProjectTemplateUpdateTest(ProjectTemplateAPIBase):
             self.organization.id,
             self.project_template.id,
             name="Updated",
-            options={"sentry:release_track": "test"},
         )
 
         assert response.data["name"] == "Updated"
-        assert response.data["options"] == {"sentry:release_track": "test"}
 
         # validate db is updated
         self.project_template.refresh_from_db()
         assert self.project_template.name == "Updated"
-        assert self.project_template.options.get(key="sentry:release_track").value == "test"
 
     @with_feature(PROJECT_TEMPLATE_FEATURE_FLAG)
     def test_put__only_options(self):

--- a/tests/sentry/api/endpoints/test_project_template_detail.py
+++ b/tests/sentry/api/endpoints/test_project_template_detail.py
@@ -64,72 +64,9 @@ class ProjectTemplateDetailTest(ProjectTemplateAPIBase):
         assert response.status_code == 403
 
 
-class ProjectTemplateDetailDeleteTest(ProjectTemplateAPIBase):
-    endpoint = "sentry-api-0-organization-project-template-detail"
-    method = "delete"
-
-    def test_delete__no_feature(self):
-        response = self.get_error_response(
-            self.organization.id, self.project_template.id, status_code=404
-        )
-        assert response.status_code == 404
-
-    @with_feature(PROJECT_TEMPLATE_FEATURE_FLAG)
-    def test_delete(self):
-        template_id = self.project_template.id
-        response = self.get_success_response(self.organization.id, template_id, status_code=204)
-        assert response.status_code == 204
-
-        with pytest.raises(ProjectTemplate.DoesNotExist):
-            ProjectTemplate.objects.get(id=template_id)
-
-    @with_feature(PROJECT_TEMPLATE_FEATURE_FLAG)
-    def test_delete__with_options(self):
-        template_id = self.project_template.id
-        self.project_template.options.create(
-            project_template=self.project_template, key="sentry:release_track", value="test"
-        )
-        self.project_template.options.create(
-            project_template=self.project_template, key="sentry:another_example", value="test"
-        )
-
-        # Ensure the options are created
-        assert ProjectTemplateOption.objects.filter(project_template_id=template_id).count() == 2
-
-        response = self.get_success_response(self.organization.id, template_id, status_code=204)
-        assert response.status_code == 204
-
-        # Ensure data is deleted
-        with pytest.raises(ProjectTemplate.DoesNotExist):
-            ProjectTemplate.objects.get(id=template_id)
-        assert ProjectTemplateOption.objects.filter(project_template_id=template_id).count() == 0
-
-    @with_feature(PROJECT_TEMPLATE_FEATURE_FLAG)
-    def test_delete__as_member_without_permission(self):
-        user = self.create_user()
-        self.create_member(user=user, organization=self.organization, role="member")
-        self.login_as(user)
-
-        response = self.get_error_response(
-            self.organization.id, self.project_template.id, status_code=403
-        )
-        assert response.status_code == 403
-
-
-class ProjectTemplateUpdateTest(APITestCase):
+class ProjectTemplateUpdateTest(ProjectTemplateAPIBase):
     endpoint = "sentry-api-0-organization-project-template-detail"
     method = "put"
-
-    def setUp(self):
-        super().setUp()
-        self.user = self.create_user()
-        self.organization = self.create_organization(owner=self.user)
-        self.team = self.create_team(organization=self.organization, members=[self.user])
-
-        self.login_as(self.user)
-        self.project_template = self.create_project_template(
-            organization=self.organization, name="Test"
-        )
 
     def test_put__no_feature(self):
         response = self.get_error_response(
@@ -200,3 +137,55 @@ class ProjectTemplateUpdateTest(APITestCase):
                 string="No ProjectTemplate matches the given query.", code="not_found"
             )
         }
+
+
+class ProjectTemplateDetailDeleteTest(ProjectTemplateAPIBase):
+    endpoint = "sentry-api-0-organization-project-template-detail"
+    method = "delete"
+
+    def test_delete__no_feature(self):
+        response = self.get_error_response(
+            self.organization.id, self.project_template.id, status_code=404
+        )
+        assert response.status_code == 404
+
+    @with_feature(PROJECT_TEMPLATE_FEATURE_FLAG)
+    def test_delete(self):
+        template_id = self.project_template.id
+        response = self.get_success_response(self.organization.id, template_id, status_code=204)
+        assert response.status_code == 204
+
+        with pytest.raises(ProjectTemplate.DoesNotExist):
+            ProjectTemplate.objects.get(id=template_id)
+
+    @with_feature(PROJECT_TEMPLATE_FEATURE_FLAG)
+    def test_delete__with_options(self):
+        template_id = self.project_template.id
+        self.project_template.options.create(
+            project_template=self.project_template, key="sentry:release_track", value="test"
+        )
+        self.project_template.options.create(
+            project_template=self.project_template, key="sentry:another_example", value="test"
+        )
+
+        # Ensure the options are created
+        assert ProjectTemplateOption.objects.filter(project_template_id=template_id).count() == 2
+
+        response = self.get_success_response(self.organization.id, template_id, status_code=204)
+        assert response.status_code == 204
+
+        # Ensure data is deleted
+        with pytest.raises(ProjectTemplate.DoesNotExist):
+            ProjectTemplate.objects.get(id=template_id)
+        assert ProjectTemplateOption.objects.filter(project_template_id=template_id).count() == 0
+
+    @with_feature(PROJECT_TEMPLATE_FEATURE_FLAG)
+    def test_delete__as_member_without_permission(self):
+        user = self.create_user()
+        self.create_member(user=user, organization=self.organization, role="member")
+        self.login_as(user)
+
+        response = self.get_error_response(
+            self.organization.id, self.project_template.id, status_code=403
+        )
+        assert response.status_code == 403


### PR DESCRIPTION
# Description
[Tech Spec](https://www.notion.so/sentry/Service-Settings-Templates-ca6fdb38b15f4a6db61d319bc342b86c?pvs=4#a49242f3a1094cc68f6fe1e893450e36)

- [x] Merge the POST request and update the target branch
- Setup the PUT request for `/api/0/organizations/:slug_or_id/project_templates/:id/` that supports updating the project template and it's options.