### PR TITLE
Add DELETE endpoint for project templates

### DIFF
--- a/src/sentry/api/endpoints/project_template_detail.py
+++ b/src/sentry/api/endpoints/project_template_detail.py
@@ -25,6 +25,7 @@ class OrganizationProjectTemplateDetailEndpoint(OrganizationEndpoint):
 
     publish_status = {
         "GET": ApiPublishStatus.PRIVATE,
+        "DELETE": ApiPublishStatus.PRIVATE,
     }
     permission_classes = (OrganizationPermission,)
 
@@ -46,3 +47,17 @@ class OrganizationProjectTemplateDetailEndpoint(OrganizationEndpoint):
                 ProjectTemplateSerializer(expand=[ProjectTemplateAttributes.OPTIONS]),
             )
         )
+
+    @ensure_rollout_enabled(PROJECT_TEMPLATE_FEATURE_FLAG)
+    def delete(self, request: Request, organization: Organization, template_id: str) -> Response:
+        """
+        Delete a project template by its ID.
+        """
+        project_template = get_object_or_404(
+            ProjectTemplate, id=template_id, organization=organization
+        )
+
+        project_template.delete()
+
+        # think about how to handle there being no remaining templates for an org?
+        return Response(status=204)

--- a/tests/sentry/api/endpoints/test_project_template_detail.py
+++ b/tests/sentry/api/endpoints/test_project_template_detail.py
@@ -1,6 +1,9 @@
+import pytest
 from rest_framework.exceptions import ErrorDetail
 
 from sentry.api.endpoints.project_templates_index import PROJECT_TEMPLATE_FEATURE_FLAG
+from sentry.models.options.project_template_option import ProjectTemplateOption
+from sentry.models.projecttemplate import ProjectTemplate
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.helpers import with_feature
 
@@ -63,3 +66,53 @@ class ProjectTemplateDetailTest(APITestCase):
         # Ensure this errors with 403, as the user does not have access to the organization
         response = self.get_error_response(org_two.id, project_template.id, status_code=403)
         assert response.status_code == 403
+
+
+class ProjectTemplateDetailDeleteTest(APITestCase):
+    endpoint = "sentry-api-0-organization-project-template-detail"
+    method = "delete"
+
+    def setUp(self):
+        super().setUp()
+        self.user = self.create_user()
+        self.organization = self.create_organization(owner=self.user)
+        self.team = self.create_team()
+
+        self.login_as(self.user)
+        self.project_template = self.create_project_template(organization=self.organization)
+
+    def test_delete__no_feature(self):
+        response = self.get_error_response(
+            self.organization.id, self.project_template.id, status_code=404
+        )
+        assert response.status_code == 404
+
+    @with_feature(PROJECT_TEMPLATE_FEATURE_FLAG)
+    def test_delete(self):
+        template_id = self.project_template.id
+        response = self.get_success_response(self.organization.id, template_id, status_code=204)
+        assert response.status_code == 204
+
+        with pytest.raises(ProjectTemplate.DoesNotExist):
+            ProjectTemplate.objects.get(id=template_id)
+
+    @with_feature(PROJECT_TEMPLATE_FEATURE_FLAG)
+    def test_delete__with_options(self):
+        template_id = self.project_template.id
+        self.project_template.options.create(
+            project_template=self.project_template, key="sentry:release_track", value="test"
+        )
+        self.project_template.options.create(
+            project_template=self.project_template, key="sentry:another_example", value="test"
+        )
+
+        # Ensure the options are created
+        assert ProjectTemplateOption.objects.filter(project_template_id=template_id).count() == 2
+
+        response = self.get_success_response(self.organization.id, template_id, status_code=204)
+        assert response.status_code == 204
+
+        # Ensure data is deleted
+        with pytest.raises(ProjectTemplate.DoesNotExist):
+            ProjectTemplate.objects.get(id=template_id)
+        assert ProjectTemplateOption.objects.filter(project_template_id=template_id).count() == 0

--- a/tests/sentry/api/endpoints/test_project_template_detail.py
+++ b/tests/sentry/api/endpoints/test_project_template_detail.py
@@ -4,24 +4,18 @@ from rest_framework.exceptions import ErrorDetail
 from sentry.api.endpoints.project_templates_index import PROJECT_TEMPLATE_FEATURE_FLAG
 from sentry.models.options.project_template_option import ProjectTemplateOption
 from sentry.models.projecttemplate import ProjectTemplate
-from sentry.testutils.cases import APITestCase
 from sentry.testutils.helpers import with_feature
 
+from .test_project_templates_index import ProjectTemplateAPIBase
 
-class ProjectTemplateDetailTest(APITestCase):
+
+class ProjectTemplateDetailTest(ProjectTemplateAPIBase):
     endpoint = "sentry-api-0-organization-project-template-detail"
 
-    def setUp(self):
-        super().setUp()
-        self.user = self.create_user()
-        self.org = self.create_organization()
-        self.team = self.create_team(organization=self.org, members=[self.user])
-
-        self.login_as(self.user)
-        self.project_template = self.create_project_template(organization=self.org)
-
     def test_get__no_feature(self):
-        response = self.get_error_response(self.org.id, self.project_template.id, status_code=404)
+        response = self.get_error_response(
+            self.organization.id, self.project_template.id, status_code=404
+        )
         assert response.status_code == 404
 
     @with_feature(PROJECT_TEMPLATE_FEATURE_FLAG)
@@ -29,14 +23,14 @@ class ProjectTemplateDetailTest(APITestCase):
         self.project_template.options.create(
             project_template=self.project_template, key="sentry:release_track", value="test"
         )
-        response = self.get_success_response(self.org.id, self.project_template.id)
+        response = self.get_success_response(self.organization.id, self.project_template.id)
 
         assert response.data["name"] == self.project_template.name
         assert response.data["options"] == {"sentry:release_track": "test"}
 
     @with_feature(PROJECT_TEMPLATE_FEATURE_FLAG)
     def test_get__not_found(self):
-        response = self.get_error_response(self.org.id, 100, status_code=404)
+        response = self.get_error_response(self.organization.id, 100, status_code=404)
         assert response.status_code == 404
         assert response.data == {
             "detail": ErrorDetail(
@@ -49,7 +43,9 @@ class ProjectTemplateDetailTest(APITestCase):
         org_two = self.create_organization()
         project_template = self.create_project_template(organization=org_two)
 
-        response = self.get_error_response(self.org.id, project_template.id, status_code=404)
+        response = self.get_error_response(
+            self.organization.id, project_template.id, status_code=404
+        )
         assert response.status_code == 404
         assert response.data == {
             "detail": ErrorDetail(
@@ -68,18 +64,9 @@ class ProjectTemplateDetailTest(APITestCase):
         assert response.status_code == 403
 
 
-class ProjectTemplateDetailDeleteTest(APITestCase):
+class ProjectTemplateDetailDeleteTest(ProjectTemplateAPIBase):
     endpoint = "sentry-api-0-organization-project-template-detail"
     method = "delete"
-
-    def setUp(self):
-        super().setUp()
-        self.user = self.create_user()
-        self.organization = self.create_organization(owner=self.user)
-        self.team = self.create_team()
-
-        self.login_as(self.user)
-        self.project_template = self.create_project_template(organization=self.organization)
 
     def test_delete__no_feature(self):
         response = self.get_error_response(

--- a/tests/sentry/api/endpoints/test_project_template_detail.py
+++ b/tests/sentry/api/endpoints/test_project_template_detail.py
@@ -116,3 +116,14 @@ class ProjectTemplateDetailDeleteTest(APITestCase):
         with pytest.raises(ProjectTemplate.DoesNotExist):
             ProjectTemplate.objects.get(id=template_id)
         assert ProjectTemplateOption.objects.filter(project_template_id=template_id).count() == 0
+
+    @with_feature(PROJECT_TEMPLATE_FEATURE_FLAG)
+    def test_delete__as_member_without_permission(self):
+        user = self.create_user()
+        self.create_member(user=user, organization=self.organization, role="member")
+        self.login_as(user)
+
+        response = self.get_error_response(
+            self.organization.id, self.project_template.id, status_code=403
+        )
+        assert response.status_code == 403


### PR DESCRIPTION
# Description
[Tech Spec](https://www.notion.so/sentry/Service-Settings-Templates-ca6fdb38b15f4a6db61d319bc342b86c?pvs=4#10e53faf34b649bfb393448e997cc1bf)

Adds ability to remove project templates by id through the api. `DELETE` to `/api/0/organizations/:slug_or_id/project_templates/:id/`
- Will remove all options as well because of the cascade on delete, wrote a test to ensure it's working as expected.
- [x] TODO update the tests with the base once the POST PR is merged