### PR TITLE
feat(metrics): allow wildcards in metrics search bar

### DIFF
--- a/static/app/components/metrics/metricSearchBar.tsx
+++ b/static/app/components/metrics/metricSearchBar.tsx
@@ -129,7 +129,6 @@ export function MetricSearchBar({
       placeholder={t('Filter by tags')}
       query={query}
       savedSearchType={SavedSearchType.METRIC}
-      disallowWildcard
       {...searchConfig}
       {...props}
     />


### PR DESCRIPTION
Wildcards were previously dis-allowed in https://github.com/getsentry/sentry/pull/69644 due to https://github.com/getsentry/sentry/issues/69387
With https://github.com/getsentry/snuba/pull/5972 being merged, wildcards now work and can be re-allowed in the UI