### PR TITLE
fix(metrics): enable MetricsSummaries search by project

### DIFF
--- a/src/sentry/search/events/datasets/filter_aliases.py
+++ b/src/sentry/search/events/datasets/filter_aliases.py
@@ -102,7 +102,7 @@ def project_slug_converter(
         # Create a new search filter with the correct values
         converted_filter = builder.convert_search_filter_to_condition(
             SearchFilter(
-                SearchKey("project.id"),
+                SearchKey("project_id"),
                 search_filter.operator,
                 SearchValue(project_ids if search_filter.is_in_filter else project_ids[0]),
             )

--- a/src/sentry/search/events/datasets/filter_aliases.py
+++ b/src/sentry/search/events/datasets/filter_aliases.py
@@ -102,7 +102,7 @@ def project_slug_converter(
         # Create a new search filter with the correct values
         converted_filter = builder.convert_search_filter_to_condition(
             SearchFilter(
-                SearchKey("project_id"),
+                SearchKey(constants.PROJECT_ID_ALIAS),
                 search_filter.operator,
                 SearchValue(project_ids if search_filter.is_in_filter else project_ids[0]),
             )

--- a/src/sentry/search/events/datasets/filter_aliases.py
+++ b/src/sentry/search/events/datasets/filter_aliases.py
@@ -102,7 +102,7 @@ def project_slug_converter(
         # Create a new search filter with the correct values
         converted_filter = builder.convert_search_filter_to_condition(
             SearchFilter(
-                SearchKey(constants.PROJECT_ID_ALIAS),
+                SearchKey("project.id"),
                 search_filter.operator,
                 SearchValue(project_ids if search_filter.is_in_filter else project_ids[0]),
             )

--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -174,6 +174,7 @@ SPAN_COLUMN_MAP = {
 
 METRICS_SUMMARIES_COLUMN_MAP = {
     "project": "project_id",
+    "project.id": "project_id",
     "id": "span_id",
     "trace": "trace_id",
     "metric": "metric_mri",


### PR DESCRIPTION
The current implementation of project_slug_converter in filter_aliases.py converts a project:{slug} filter into a query condition on tags[project.id], which does not work. This PR fixes this by querying not for tags[project.id], but for the project_id column instead.