### PR TITLE
feat(discover): Save query dataset source

### DIFF
--- a/src/sentry/api/bases/organization_events.py
+++ b/src/sentry/api/bases/organization_events.py
@@ -22,7 +22,7 @@ from sentry.api.helpers.teams import get_teams
 from sentry.api.serializers.snuba import BaseSnubaSerializer, SnubaTSResultSerializer
 from sentry.api.utils import handle_query_errors
 from sentry.discover.arithmetic import is_equation, strip_equation
-from sentry.discover.models import DiscoverSavedQueryTypes
+from sentry.discover.models import DatasetSourcesTypes, DiscoverSavedQueryTypes
 from sentry.exceptions import InvalidSearchQuery
 from sentry.models.dashboard_widget import DashboardWidgetTypes
 from sentry.models.group import Group
@@ -274,6 +274,7 @@ class OrganizationEventsV2EndpointBase(OrganizationEventsEndpointBase):
         If dataset is ambiguous (i.e., could be either transactions or errors),
         default to errors.
         """
+        dataset_source = DatasetSourcesTypes.INFERRED.value
         if dataset_inferred_from_query:
             decision = dataset_inferred_from_query
             sentry_sdk.set_tag("discover.split_reason", "inferred_from_query")
@@ -287,11 +288,13 @@ class OrganizationEventsV2EndpointBase(OrganizationEventsEndpointBase):
             # In the case that neither or both datasets return data,
             # default to Errors.
             decision = DiscoverSavedQueryTypes.ERROR_EVENTS
+            dataset_source = DatasetSourcesTypes.FORCED.value
             sentry_sdk.set_tag("discover.split_reason", "default")
 
         sentry_sdk.set_tag("discover.split_decision", decision)
         if query.dataset != decision:
             query.dataset = decision
+            query.dataset_source = dataset_source
             query.save()
 
         return decision

--- a/src/sentry/api/serializers/models/discoversavedquery.py
+++ b/src/sentry/api/serializers/models/discoversavedquery.py
@@ -3,9 +3,11 @@ from typing import DefaultDict
 
 from sentry.api.serializers import Serializer, register
 from sentry.constants import ALL_ACCESS_PROJECTS
-from sentry.discover.models import DiscoverSavedQuery, DiscoverSavedQueryTypes
+from sentry.discover.models import DatasetSourcesTypes, DiscoverSavedQuery, DiscoverSavedQueryTypes
 from sentry.users.services.user.service import user_service
 from sentry.utils.dates import outside_retention_with_modified_start, parse_timestamp
+
+DATASET_SOURCES = dict(DatasetSourcesTypes.as_choices())
 
 
 @register(DiscoverSavedQuery)
@@ -56,6 +58,7 @@ class DiscoverSavedQuerySerializer(Serializer):
             "projects": [project.id for project in obj.projects.all()],
             "version": obj.version or obj.query.get("version", 1),
             "queryDataset": DiscoverSavedQueryTypes.get_type_name(obj.dataset),
+            "datasetSource": DATASET_SOURCES[obj.dataset_source],
             "expired": False,
             "dateCreated": obj.date_created,
             "dateUpdated": obj.date_updated,

--- a/src/sentry/discover/endpoints/discover_homepage_query.py
+++ b/src/sentry/discover/endpoints/discover_homepage_query.py
@@ -13,7 +13,7 @@ from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.api.serializers import serialize
 from sentry.discover.endpoints.bases import DiscoverSavedQueryPermission
 from sentry.discover.endpoints.serializers import DiscoverSavedQuerySerializer
-from sentry.discover.models import DiscoverSavedQuery
+from sentry.discover.models import DatasetSourcesTypes, DiscoverSavedQuery
 
 
 def get_homepage_query(organization, user):
@@ -84,6 +84,7 @@ class DiscoverHomepageQueryEndpoint(OrganizationEndpoint):
                 query=data["query"],
                 version=data["version"],
                 dataset=data["query_dataset"],
+                dataset_source=DatasetSourcesTypes.UNKNOWN.value,
             )
             previous_homepage.set_projects(data["project_ids"])
             return Response(serialize(previous_homepage), status=status.HTTP_200_OK)
@@ -94,6 +95,7 @@ class DiscoverHomepageQueryEndpoint(OrganizationEndpoint):
             query=data["query"],
             version=data["version"],
             dataset=data["query_dataset"],
+            dataset_source=DatasetSourcesTypes.UNKNOWN.value,
             created_by_id=request.user.id,
             is_homepage=True,
         )

--- a/src/sentry/discover/endpoints/discover_saved_queries.py
+++ b/src/sentry/discover/endpoints/discover_saved_queries.py
@@ -14,7 +14,7 @@ from sentry.api.paginator import GenericOffsetPaginator
 from sentry.api.serializers import serialize
 from sentry.discover.endpoints.bases import DiscoverSavedQueryPermission
 from sentry.discover.endpoints.serializers import DiscoverSavedQuerySerializer
-from sentry.discover.models import DiscoverSavedQuery
+from sentry.discover.models import DatasetSourcesTypes, DiscoverSavedQuery
 from sentry.search.utils import tokenize_query
 
 
@@ -142,6 +142,7 @@ class DiscoverSavedQueriesEndpoint(OrganizationEndpoint):
             query=data["query"],
             version=data["version"],
             dataset=data["query_dataset"],
+            dataset_source=DatasetSourcesTypes.UNKNOWN.value,
             created_by_id=request.user.id if request.user.is_authenticated else None,
         )
 

--- a/src/sentry/discover/endpoints/discover_saved_query_detail.py
+++ b/src/sentry/discover/endpoints/discover_saved_query_detail.py
@@ -13,7 +13,7 @@ from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.api.serializers import serialize
 from sentry.discover.endpoints.bases import DiscoverSavedQueryPermission
 from sentry.discover.endpoints.serializers import DiscoverSavedQuerySerializer
-from sentry.discover.models import DiscoverSavedQuery
+from sentry.discover.models import DatasetSourcesTypes, DiscoverSavedQuery
 
 
 class DiscoverSavedQueryBase(OrganizationEndpoint):
@@ -89,6 +89,7 @@ class DiscoverSavedQueryDetailEndpoint(DiscoverSavedQueryBase):
             query=data["query"],
             version=data["version"],
             dataset=data["query_dataset"],
+            dataset_source=DatasetSourcesTypes.UNKNOWN.value,
         )
 
         query.set_projects(data["project_ids"])

--- a/tests/snuba/api/endpoints/test_discover_saved_query_detail.py
+++ b/tests/snuba/api/endpoints/test_discover_saved_query_detail.py
@@ -230,6 +230,7 @@ class DiscoverSavedQueryDetailTest(APITestCase, SnubaTestCase):
         assert response.status_code == 200, response.content
         assert response.data["id"] == str(model.id)
         assert response.data["queryDataset"] == "discover"
+        assert response.data["datasetSource"] == "unknown"
 
     def test_put_with_interval(self):
         with self.feature(self.feature_name):

--- a/tests/snuba/api/endpoints/test_organization_events.py
+++ b/tests/snuba/api/endpoints/test_organization_events.py
@@ -11,7 +11,12 @@ from django.utils import timezone
 from snuba_sdk.column import Column
 from snuba_sdk.function import Function
 
-from sentry.discover.models import DiscoverSavedQuery, DiscoverSavedQueryTypes, TeamKeyTransaction
+from sentry.discover.models import (
+    DatasetSourcesTypes,
+    DiscoverSavedQuery,
+    DiscoverSavedQueryTypes,
+    TeamKeyTransaction,
+)
 from sentry.issues.grouptype import ProfileFileIOGroupType
 from sentry.models.group import GroupStatus
 from sentry.models.project import Project
@@ -5700,6 +5705,7 @@ class OrganizationEventsEndpointTest(OrganizationEventsEndpointTestBase, Perform
         )
 
         assert model.dataset == DiscoverSavedQueryTypes.DISCOVER
+        assert model.dataset_source == DatasetSourcesTypes.UNKNOWN.value
 
         features = {
             "organizations:discover-basic": True,
@@ -5720,6 +5726,7 @@ class OrganizationEventsEndpointTest(OrganizationEventsEndpointTestBase, Perform
 
         model = DiscoverSavedQuery.objects.get(id=model.id)
         assert model.dataset == DiscoverSavedQueryTypes.DISCOVER
+        assert model.dataset_source == DatasetSourcesTypes.UNKNOWN.value
 
     def test_saves_discover_saved_query_split_transaction(self):
         self.store_event(self.transaction_data, project_id=self.project.id)
@@ -5755,6 +5762,7 @@ class OrganizationEventsEndpointTest(OrganizationEventsEndpointTestBase, Perform
 
         model = DiscoverSavedQuery.objects.get(id=model.id)
         assert model.dataset == DiscoverSavedQueryTypes.TRANSACTION_LIKE
+        assert model.dataset_source == DatasetSourcesTypes.INFERRED.value
 
     def test_saves_discover_saved_query_split_error(self):
         self.store_event(self.transaction_data, project_id=self.project.id)


### PR DESCRIPTION
Start tracking dataset source so we can distinguish between
user selected vs datasets inferred by us. Right now set everything
to `unknown`. Once the feature is released, new queries and updates
should set it to `user`.  