### PR TITLE
fix(spans): Handle short span ids

### DIFF
--- a/src/sentry/search/events/builder/base.py
+++ b/src/sentry/search/events/builder/base.py
@@ -1304,6 +1304,7 @@ class BaseQueryBuilder:
         if (
             search_filter.operator in ("!=", "NOT IN")
             and not search_filter.key.is_tag
+            and not is_tag
             and name not in self.config.non_nullable_keys
         ):
             # Handle null columns on inequality comparisons. Any comparison

--- a/src/sentry/search/events/datasets/spans_indexed.py
+++ b/src/sentry/search/events/datasets/spans_indexed.py
@@ -29,6 +29,7 @@ from sentry.search.utils import DEVICE_CLASS
 class SpansIndexedDatasetConfig(DatasetConfig):
     optimize_wildcard_searches = True
     subscriptables_with_index = {"tags"}
+    non_nullable_keys = {"id", "span_id", "trace", "trace_id", "profile.id", "profile_id"}
 
     def __init__(self, builder: BaseQueryBuilder):
         self.builder = builder

--- a/src/sentry/utils/validators.py
+++ b/src/sentry/utils/validators.py
@@ -11,7 +11,7 @@ INVALID_SPAN_ID = (
     "`{}` must be a valid 16 character hex (containing only digits, or a-f characters)"
 )
 
-HEXADECIMAL_16_DIGITS = re.compile("^[0-9a-fA-F]{16}$")
+HEXADECIMAL_16_DIGITS = re.compile("^[0-9a-fA-F]{1,16}$")
 
 
 def normalize_event_id(value):

--- a/tests/sentry/utils/test_validators.py
+++ b/tests/sentry/utils/test_validators.py
@@ -50,11 +50,14 @@ def test_is_span_id():
     assert is_span_id("202AB439bb9c4f31")
     assert is_span_id(b"202AB439bb9c4f31")
 
+    # Relaxing the constraint so we only require it
+    # to be a hex string between 1 and 16 chars long.
+    assert is_span_id("202ab439")
+    assert is_span_id(4711)
+
     assert not is_span_id("")
     assert not is_span_id("202a-b439-bb9c-4f31")
     assert not is_span_id("ZZZZZZZZZZZZZZZZ")
     assert not is_span_id("202ab439bb9c4f31AAAAAAAAAA")
-    assert not is_span_id("202ab439")
-    assert not is_span_id(4711)
     assert not is_span_id(False)
     assert not is_span_id(None)

--- a/tests/snuba/api/endpoints/test_organization_events_spans_performance.py
+++ b/tests/snuba/api/endpoints/test_organization_events_spans_performance.py
@@ -870,7 +870,7 @@ class OrganizationEventsSpansPerformanceEndpointTest(OrganizationEventsSpansEndp
                 self.url,
                 data={
                     "project": self.project.id,
-                    "spanGroup": "cd",
+                    "spanGroup": "foo",
                 },
                 format="json",
             )
@@ -1189,7 +1189,7 @@ class OrganizationEventsSpansExamplesEndpointTest(OrganizationEventsSpansEndpoin
         with self.feature(self.FEATURES):
             response = self.client.get(
                 self.url,
-                data={"project": self.project.id, "span": ["http.server:ab"]},
+                data={"project": self.project.id, "span": ["http.server:foo"]},
                 format="json",
             )
 
@@ -1816,7 +1816,7 @@ class OrganizationEventsSpansStatsEndpointTest(OrganizationEventsSpansEndpointTe
         with self.feature(self.FEATURES):
             response = self.client.get(
                 self.url,
-                data={"project": self.project.id, "span": ["http.server:ab"]},
+                data={"project": self.project.id, "span": ["http.server:foo"]},
                 format="json",
             )
 


### PR DESCRIPTION
Not a great solution but this relaxes the `is_span_id` check to allow for hex strings shorter than 16 chars. This is because it's very easy to accidentally get a hex string of 15 chars if the leading character is a 0. While we can be strict and require 16 chars, it's an easy to miss edge case so here we choose to allow it.

Fixes SENTRY-3BXV