### PR TITLE
fix(uptime): Catch errors when we fail to parse robots.txt

### DIFF
--- a/src/sentry/uptime/detectors/tasks.py
+++ b/src/sentry/uptime/detectors/tasks.py
@@ -232,7 +232,11 @@ def get_failed_url_key(url: str) -> str:
 
 
 def check_url_robots_txt(url: str) -> bool:
-    return get_robots_txt_parser(url).can_fetch(UPTIME_USER_AGENT, url)
+    try:
+        return get_robots_txt_parser(url).can_fetch(UPTIME_USER_AGENT, url)
+    except Exception:
+        logger.warning("Failed to check robots.txt", exc_info=True)
+        return False
 
 
 def get_robots_txt_parser(url: str) -> RobotFileParser:


### PR DESCRIPTION
There are lots of cases where fetching robots can fail. If we can't fetch it, we just want to assume we shouldn't monitor the url.

Fixes SENTRY-3C3P
Fixes SENTRY-3C3Q
Fixes SENTRY-3C3S
Fixes SENTRY-3C42
Fixes SENTRY-3C3Z
