### PR TITLE
feat(uptime): Disable auto-detection for a project once we've starting monitoring a url for it

### DIFF
--- a/src/sentry/uptime/detectors/detector.py
+++ b/src/sentry/uptime/detectors/detector.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from sentry import features
-from sentry.uptime.detectors.ranking import add_base_url_to_rank
+from sentry.uptime.detectors.ranking import add_base_url_to_rank, should_detect_for_project
 from sentry.uptime.detectors.url_extraction import extract_base_url
 from sentry.utils import metrics
 
@@ -12,7 +12,11 @@ if TYPE_CHECKING:
 
 
 def detect_base_url_for_project(project: Project, url: str) -> None:
-    if not features.has("organizations:uptime-automatic-hostname-detection", project.organization):
+    # Note: We might end up removing the `should_detect_for_project` check here if/when we decide to use detected
+    # urls as suggestions as well.
+    if not features.has(
+        "organizations:uptime-automatic-hostname-detection", project.organization
+    ) or not should_detect_for_project(project):
         return
 
     base_url = extract_base_url(url)

--- a/src/sentry/uptime/detectors/ranking.py
+++ b/src/sentry/uptime/detectors/ranking.py
@@ -126,3 +126,7 @@ def delete_project_bucket(bucket: datetime) -> None:
     key = get_project_bucket_key_for_datetime(bucket)
     cluster = _get_cluster()
     cluster.delete(key)
+
+
+def should_detect_for_project(project: Project) -> bool:
+    return project.get_option("sentry:uptime_autodetection", True)

--- a/tests/sentry/uptime/detectors/test_detector.py
+++ b/tests/sentry/uptime/detectors/test_detector.py
@@ -19,3 +19,9 @@ class DetectBaseUrlForProjectTest(TestCase):
     def test_no_feature(self):
         detect_base_url_for_project(self.project, "https://sentry.io")
         self.assert_project_key(self.project, False)
+
+    @with_feature("organizations:uptime-automatic-hostname-detection")
+    def test_disabled_for_project(self):
+        self.project.update_option("sentry:uptime_autodetection", False)
+        detect_base_url_for_project(self.project, "https://sentry.io")
+        self.assert_project_key(self.project, False)

--- a/tests/sentry/uptime/detectors/test_ranking.py
+++ b/tests/sentry/uptime/detectors/test_ranking.py
@@ -13,6 +13,7 @@ from sentry.uptime.detectors.ranking import (
     get_project_base_url_rank_key,
     get_project_bucket,
     get_project_bucket_key,
+    should_detect_for_project,
 )
 
 
@@ -145,3 +146,12 @@ class DeleteProjectBucketTest(TestCase):
         assert get_project_bucket(bucket) == {self.project.id: 1}
         delete_project_bucket(bucket)
         assert get_project_bucket(bucket) == {}
+
+
+class ShouldDetectForProjectTest(TestCase):
+    def test(self):
+        assert should_detect_for_project(self.project)
+        self.project.update_option("sentry:uptime_autodetection", False)
+        assert not should_detect_for_project(self.project)
+        self.project.update_option("sentry:uptime_autodetection", True)
+        assert should_detect_for_project(self.project)

--- a/tests/sentry/uptime/detectors/test_tasks.py
+++ b/tests/sentry/uptime/detectors/test_tasks.py
@@ -136,11 +136,8 @@ class ProcessProjectUrlRankingTest(TestCase):
             )
 
     def test_should_not_detect(self):
+        self.project.update_option("sentry:uptime_autodetection", False)
         with mock.patch(
-            # TODO: Replace this mock with real tests when we implement this function properly
-            "sentry.uptime.detectors.tasks.should_detect_for_project",
-            return_value=False,
-        ), mock.patch(
             "sentry.uptime.detectors.tasks.get_candidate_urls_for_project"
         ) as mock_get_candidate_urls_for_project:
             process_project_url_ranking(self.project.id, 5)

--- a/tests/sentry/uptime/detectors/test_tasks.py
+++ b/tests/sentry/uptime/detectors/test_tasks.py
@@ -155,6 +155,7 @@ class ProcessCandidateUrlTest(TestCase):
         assert not is_url_auto_monitored_for_project(self.project, url)
         assert process_candidate_url(self.project, 100, url, 50)
         assert is_url_auto_monitored_for_project(self.project, url)
+        assert self.project.get_option("sentry:uptime_autodetection") is False
 
     def test_succeeds_new_no_feature(self):
         with mock.patch(
@@ -162,6 +163,7 @@ class ProcessCandidateUrlTest(TestCase):
         ) as mock_monitor_url_for_project:
             assert process_candidate_url(self.project, 100, "https://sentry.io", 50)
             mock_monitor_url_for_project.assert_not_called()
+            assert self.project.get_option("sentry:uptime_autodetection") is None
 
     @with_feature("organizations:uptime-automatic-subscription-creation")
     def test_succeeds_existing_subscription_other_project(self):
@@ -176,6 +178,7 @@ class ProcessCandidateUrlTest(TestCase):
         assert not is_url_auto_monitored_for_project(self.project, url)
         assert process_candidate_url(self.project, 100, url, 50)
         assert is_url_auto_monitored_for_project(self.project, url)
+        assert self.project.get_option("sentry:uptime_autodetection") is False
 
     @with_feature("organizations:uptime-automatic-subscription-creation")
     def test_succeeds_existing_subscription_this_project(self):
@@ -185,6 +188,7 @@ class ProcessCandidateUrlTest(TestCase):
         assert process_candidate_url(self.project, 100, url, 50)
         new_subscription = get_auto_monitored_subscriptions_for_project(self.project)[0]
         assert subscription.id == new_subscription.id
+        assert self.project.get_option("sentry:uptime_autodetection") is False
 
     def test_below_thresholds(self):
         assert not process_candidate_url(self.project, 500, "https://sentry.io", 1)


### PR DESCRIPTION
We want to disable detection for a project once we've started monitoring it. We may still use the ranking to keep track of suggested urls in the future, so we'll still keep a lot of this code around
