### PR TITLE
feat(query-builder): Allow comparison operators for release keys

### DIFF
--- a/static/app/components/searchQueryBuilder/index.spec.tsx
+++ b/static/app/components/searchQueryBuilder/index.spec.tsx
@@ -1233,6 +1233,38 @@ describe('SearchQueryBuilder', function () {
           await screen.findByRole('row', {name: 'browser.name:[foo,bar]'})
         ).toBeInTheDocument();
       });
+
+      it('displays comparison operator values with allowAllOperators: true', async function () {
+        const filterKeys = {
+          [FieldKey.RELEASE_VERSION]: {
+            key: FieldKey.RELEASE_VERSION,
+            name: '',
+            allowAllOperators: true,
+          },
+        };
+        render(
+          <SearchQueryBuilder
+            {...defaultProps}
+            filterKeys={filterKeys}
+            filterKeySections={[]}
+            initialQuery="release.version:1.0"
+          />
+        );
+
+        await userEvent.click(
+          screen.getByRole('button', {name: 'Edit operator for filter: release.version'})
+        );
+
+        // Normally text filters only have 'is' and 'is not' as options
+        expect(
+          await screen.findByRole('option', {name: 'release.version >'})
+        ).toBeInTheDocument();
+        await userEvent.click(screen.getByRole('option', {name: 'release.version >'}));
+
+        expect(
+          await screen.findByRole('row', {name: 'release.version:>1.0'})
+        ).toBeInTheDocument();
+      });
     });
 
     describe('numeric', function () {

--- a/static/app/components/searchQueryBuilder/tokens/filter/utils.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/utils.tsx
@@ -1,4 +1,5 @@
 import {
+  allOperators,
   filterTypeConfig,
   interchangeableFilterOperators,
   type TermOperator,
@@ -7,12 +8,19 @@ import {
 } from 'sentry/components/searchSyntax/parser';
 import {t} from 'sentry/locale';
 import {escapeDoubleQuotes} from 'sentry/utils';
+import {getFieldDefinition} from 'sentry/utils/fields';
 
 const SHOULD_ESCAPE_REGEX = /[\s"()]/;
 
 export function getValidOpsForFilter(
   filterToken: TokenResult<Token.FILTER>
 ): readonly TermOperator[] {
+  const fieldDefinition = getFieldDefinition(filterToken.key.text);
+
+  if (fieldDefinition?.allowComparisonOperators) {
+    return allOperators;
+  }
+
   // If the token is invalid we want to use the possible expected types as our filter type
   const validTypes = filterToken.invalid?.expectedType ?? [filterToken.filter];
 

--- a/static/app/components/searchQueryBuilder/utils.tsx
+++ b/static/app/components/searchQueryBuilder/utils.tsx
@@ -15,6 +15,7 @@ export const INTERFACE_TYPE_LOCALSTORAGE_KEY = 'search-query-builder-interface';
 
 function getSearchConfigFromKeys(keys: TagCollection): Partial<SearchConfig> {
   const config = {
+    textOperatorKeys: new Set<string>(),
     booleanKeys: new Set<string>(),
     numericKeys: new Set<string>(),
     dateKeys: new Set<string>(),
@@ -25,6 +26,10 @@ function getSearchConfigFromKeys(keys: TagCollection): Partial<SearchConfig> {
     const fieldDef = getFieldDefinition(key);
     if (!fieldDef) {
       continue;
+    }
+
+    if (fieldDef.allowComparisonOperators) {
+      config.textOperatorKeys.add(key);
     }
 
     switch (fieldDef.valueType) {

--- a/static/app/utils/fields/index.ts
+++ b/static/app/utils/fields/index.ts
@@ -229,6 +229,12 @@ export interface FieldDefinition {
   kind: FieldKind;
   valueType: FieldValueType | null;
   /**
+   * Allow all comparison operators to be used with this field.
+   * Useful for fields like `release.version` which accepts text, but
+   * can also be used with operators like `>=` or `<`.
+   */
+  allowComparisonOperators?: boolean;
+  /**
    * Is this field being deprecated
    */
   deprecated?: boolean;
@@ -847,21 +853,25 @@ const EVENT_FIELD_DEFINITIONS: Record<AllEventFieldKeys, FieldDefinition> = {
     desc: t('The full version number that identifies the iteration'),
     kind: FieldKind.FIELD,
     valueType: FieldValueType.STRING,
+    allowComparisonOperators: true,
   },
   [FieldKey.RELEASE_PACKAGE]: {
     desc: t('The identifier unique to the project or application'),
     kind: FieldKind.FIELD,
     valueType: FieldValueType.STRING,
+    allowComparisonOperators: true,
   },
   [FieldKey.RELEASE_STAGE]: {
     desc: t('Stage of usage (i.e., adopted, replaced, low)'),
     kind: FieldKind.FIELD,
     valueType: FieldValueType.STRING,
+    allowComparisonOperators: true,
   },
   [FieldKey.RELEASE_VERSION]: {
     desc: t('An abbreviated version number of the build'),
     kind: FieldKind.FIELD,
     valueType: FieldValueType.STRING,
+    allowComparisonOperators: true,
   },
   [FieldKey.REPLAY_ID]: {
     desc: t('The ID of an associated Session Replay'),


### PR DESCRIPTION
The search config already calls out these keys as ones which should allow extra operators: https://github.com/getsentry/sentry/blob/8bc5e3d18e0ef6ae3a888afd7e96a210d8879a83/static/app/components/searchSyntax/parser.tsx#L1265-L1270

I've decided to add this to the field definition so that we can both pass it to the search parser config _and_ use it in the searchbar component. We can remove these default config entries once the SmartSearchBar is fully removed.

Before:

![CleanShot 2024-07-16 at 11 39 34](https://github.com/user-attachments/assets/89bfc0bb-24d4-4afe-8b28-8dff19da8dda)

After:

![CleanShot 2024-07-16 at 11 39 45](https://github.com/user-attachments/assets/cd734de3-3ff6-4072-b09e-45af9587eecc)
