### PR TITLE
fix(query-builder): Fix overflow with long input values

### DIFF
--- a/static/app/components/searchQueryBuilder/tokens/freeText.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/freeText.tsx
@@ -528,6 +528,7 @@ const Row = styled('div')`
   display: flex;
   align-items: stretch;
   height: 24px;
+  max-width: 100%;
 
   &:last-child {
     flex-grow: 1;

--- a/static/app/views/issueList/issueSearchWithSavedSearches.tsx
+++ b/static/app/views/issueList/issueSearchWithSavedSearches.tsx
@@ -86,6 +86,7 @@ const StyledButton = styled(Button)`
 
 const StyledIssueListSearchBarWithButton = styled(IssueListSearchBar)`
   flex: 1;
+  min-width: 0;
 
   @media (min-width: ${p => p.theme.breakpoints.small}) {
     border-top-left-radius: 0;


### PR DESCRIPTION
Fixes a style issue where long input values would overflow:

![CleanShot 2024-07-16 at 13 00 19](https://github.com/user-attachments/assets/c694fa38-70fc-451a-94aa-9542d627acc2)
