### PR TITLE
feat(api): Added Project ID in Body Support for Couple APIs

### DIFF
--- a/src/sentry/api/endpoints/organization_releases.py
+++ b/src/sentry/api/endpoints/organization_releases.py
@@ -466,16 +466,17 @@ class OrganizationReleasesEndpoint(
             result = serializer.validated_data
             scope.set_tag("version", result["version"])
 
+            # Get all projects that are available to the user/token
+            # Note: Does not use the "projects" data param from the request
             projects_from_request = self.get_projects(request, organization)
-            allowed_projects = {
-                k: project for project in projects_from_request for k in (project.slug, project.id)
-            }
+            allowed_projects = {project.slug: project for project in projects_from_request}
+            allowed_projects.update({project.id: project for project in projects_from_request})
 
             projects = []
-            for slug in result["projects"]:
-                if slug not in allowed_projects:
+            for id_or_slug in result["projects"]:
+                if id_or_slug not in allowed_projects:
                     return Response({"projects": ["Invalid project ids or slugs"]}, status=400)
-                projects.append(allowed_projects[slug])
+                projects.append(allowed_projects[id_or_slug])
 
             new_status = result.get("status")
             owner_id: int | None = None

--- a/src/sentry/api/endpoints/organization_releases.py
+++ b/src/sentry/api/endpoints/organization_releases.py
@@ -469,8 +469,10 @@ class OrganizationReleasesEndpoint(
             # Get all projects that are available to the user/token
             # Note: Does not use the "projects" data param from the request
             projects_from_request = self.get_projects(request, organization)
-            allowed_projects = {project.slug: project for project in projects_from_request}
-            allowed_projects.update({project.id: project for project in projects_from_request})
+            allowed_projects = {}
+            for project in projects_from_request:
+                allowed_projects[project.slug] = project
+                allowed_projects[project.id] = project
 
             projects = []
             for id_or_slug in result["projects"]:

--- a/src/sentry/api/endpoints/release_deploys.py
+++ b/src/sentry/api/endpoints/release_deploys.py
@@ -29,7 +29,7 @@ class DeploySerializer(serializers.Serializer):
     dateStarted = serializers.DateTimeField(required=False, allow_null=True)
     dateFinished = serializers.DateTimeField(required=False, allow_null=True)
     projects = serializers.ListField(
-        child=ProjectField(scope="project:read"), required=False, allow_empty=False
+        child=ProjectField(scope="project:read", id_allowed=True), required=False, allow_empty=False
     )
 
     def validate_environment(self, value):

--- a/src/sentry/api/serializers/rest_framework/project.py
+++ b/src/sentry/api/serializers/rest_framework/project.py
@@ -9,8 +9,9 @@ ValidationError = serializers.ValidationError
 
 @extend_schema_field(field=OpenApiTypes.STR)
 class ProjectField(serializers.Field):
-    def __init__(self, scope="project:write"):
+    def __init__(self, scope="project:write", id_allowed=False):
         self.scope = scope
+        self.id_allowed = id_allowed
         super().__init__()
 
     def to_representation(self, value):
@@ -18,7 +19,12 @@ class ProjectField(serializers.Field):
 
     def to_internal_value(self, data):
         try:
-            project = Project.objects.get(organization=self.context["organization"], slug=data)
+            if self.id_allowed:
+                project = Project.objects.get(
+                    organization=self.context["organization"], slug__id_or_slug=data
+                )
+            else:
+                project = Project.objects.get(organization=self.context["organization"], slug=data)
         except Project.DoesNotExist:
             raise ValidationError("Invalid project")
         if not self.context["access"].has_project_scope(project, self.scope):

--- a/tests/sentry/api/endpoints/test_release_deploys.py
+++ b/tests/sentry/api/endpoints/test_release_deploys.py
@@ -238,6 +238,57 @@ class ReleaseDeploysCreateTest(APITestCase):
         )
         assert rpe.last_deploy_id == deploy.id
 
+    def test_with_project_ids(self):
+        project_bar = self.create_project(organization=self.org, name="bar")
+        release = Release.objects.create(organization_id=self.org.id, version="1", total_deploys=0)
+        release.add_project(self.project)
+        release.add_project(project_bar)
+
+        environment = Environment.objects.create(organization_id=self.org.id, name="production")
+
+        url = reverse(
+            "sentry-api-0-organization-release-deploys",
+            kwargs={
+                "organization_id_or_slug": self.org.slug,
+                "version": release.version,
+            },
+        )
+
+        response = self.client.post(
+            url,
+            data={
+                "name": "foo_bar",
+                "environment": "production",
+                "url": "https://www.example.com",
+                "projects": [self.project.id, project_bar.id],
+            },
+        )
+        assert response.status_code == 201, response.content
+        assert response.data["name"] == "foo_bar"
+        assert response.data["url"] == "https://www.example.com"
+        assert response.data["environment"] == "production"
+
+        deploy = Deploy.objects.get(id=response.data["id"])
+
+        assert deploy.name == "foo_bar"
+        assert deploy.environment_id == environment.id
+        assert deploy.url == "https://www.example.com"
+        assert deploy.release == release
+
+        release = Release.objects.get(id=release.id)
+        assert release.total_deploys == 1
+        assert release.last_deploy_id == deploy.id
+
+        rpe = ReleaseProjectEnvironment.objects.get(
+            project=self.project, release=release, environment=environment
+        )
+        assert rpe.last_deploy_id == deploy.id
+
+        rpe = ReleaseProjectEnvironment.objects.get(
+            project=project_bar, release=release, environment=environment
+        )
+        assert rpe.last_deploy_id == deploy.id
+
     def test_with_invalid_project_slug(self):
         bar_project = self.create_project(organization=self.org, name="bar")
         release = Release.objects.create(organization_id=self.org.id, version="1", total_deploys=0)


### PR DESCRIPTION
I am working on getting all the commands in our Sentry CLI to support Ids as well as Slugs. [rough spec](https://www.notion.so/sentry/Supporting-IDs-and-Slugs-in-Sentry-CLI-35b805ea169e47348805672cdee41297?pm=c)

We have already gone through the effort of supporting ids and slugs in path parameters of all the APIs in our codebase. There are some endpoints that the CLI uses that pass in project slugs as body parameters, so we need to support Ids for those as well.