### PR TITLE
ref(replay): append DOM root inside hidden iframe in createHiddenPlayer

### DIFF
--- a/static/app/utils/replays/createHiddenPlayer.tsx
+++ b/static/app/utils/replays/createHiddenPlayer.tsx
@@ -15,11 +15,13 @@ export function createHiddenPlayer(rrwebEvents: RecordingFrame[]): Replayer {
 
   // create a hidden iframe
   const hiddenIframe = document.createElement('iframe');
-  hiddenIframe.style.visibility = 'hidden';
+  hiddenIframe.style.display = 'none';
   document.body.appendChild(hiddenIframe);
 
   // append the DOM root inside the iframe
-  hiddenIframe.appendChild(domRoot);
+  if (hiddenIframe.contentDocument) {
+    hiddenIframe.contentDocument.body.appendChild(domRoot);
+  }
 
   return new Replayer(rrwebEvents, {
     root: domRoot,

--- a/static/app/utils/replays/createHiddenPlayer.tsx
+++ b/static/app/utils/replays/createHiddenPlayer.tsx
@@ -13,7 +13,13 @@ export function createHiddenPlayer(rrwebEvents: RecordingFrame[]): Replayer {
   style.height = '0';
   style.overflow = 'hidden';
 
-  document.body.appendChild(domRoot);
+  // create a hidden iframe
+  const hiddenIframe = document.createElement('iframe');
+  hiddenIframe.style.visibility = 'hidden';
+  document.body.appendChild(hiddenIframe);
+
+  // append the DOM root inside the iframe
+  hiddenIframe.appendChild(domRoot);
 
   return new Replayer(rrwebEvents, {
     root: domRoot,


### PR DESCRIPTION
relates to performance issues described in https://github.com/getsentry/team-replay/issues/450

**context:**
we want to alleviate the amount of [layout thrashing](https://web.dev/articles/avoid-large-complex-layouts-and-layout-thrashing?utm_source=devtools#avoid-forced-synchronous-layouts) happening (purple gaps in pic below), which is causing performance slowdowns on the breadcrumbs tab and causing certain replays to crash. adding a hidden iframe means it won't affect the main DOM layout. we don't care how the DOM root/Replayer instance renders because in practice, we are just using it to generate the HTML to display in the breadcrumbs tab.

![image](https://github.com/user-attachments/assets/86ad617c-5691-468c-8fd2-19865bc5dada)
taken from the below image, from a crashed replay:
![image](https://github.com/user-attachments/assets/f2862a7b-8145-4be6-9785-9d1201ff11a4)

new iframe in the hierarchy:

<img width="474" alt="SCR-20240716-mfqa" src="https://github.com/user-attachments/assets/533925bd-3d07-48f2-8d67-5b518b9f280b">

