### PR TITLE
ref(profiling) remove percentile duration chart from continuous profiling UI

### DIFF
--- a/static/app/views/profiling/content.tsx
+++ b/static/app/views/profiling/content.tsx
@@ -213,12 +213,16 @@ function ProfilingContent({location}: ProfilingContentProps) {
                     'profiling-global-suspect-functions'
                   ) ? (
                     <Fragment>
-                      <ProfilesChartWidget
-                        chartHeight={150}
-                        referrer="api.profiling.landing-chart"
-                        userQuery={query}
-                        selection={selection}
-                      />
+                      {organization.features.includes(
+                        'continuous-profiling-ui'
+                      ) ? null : (
+                        <ProfilesChartWidget
+                          chartHeight={150}
+                          referrer="api.profiling.landing-chart"
+                          userQuery={query}
+                          selection={selection}
+                        />
+                      )}
                       <WidgetsContainer>
                         <LandingWidgetSelector
                           cursorName={LEFT_WIDGET_CURSOR}


### PR DESCRIPTION
Removes the profile duration chart that we have on the profiling landing page as it will be removed with the release of continuous profiling