### PR TITLE
chore(profiling): Clean up existing flamegraph endpoint for continuou…

### DIFF
--- a/src/sentry/api/endpoints/organization_profiling_profiles.py
+++ b/src/sentry/api/endpoints/organization_profiling_profiles.py
@@ -15,7 +15,6 @@ from sentry.models.organization import Organization
 from sentry.profiles.flamegraph import (
     get_chunks_from_spans_metadata,
     get_profile_ids,
-    get_profile_ids_with_spans,
     get_profiles_with_function,
     get_spans_from_group,
 )
@@ -41,24 +40,17 @@ class OrganizationProfilingFlamegraphEndpoint(OrganizationProfilingBaseEndpoint)
         if len(project_ids) > 1:
             raise ParseError(detail="You cannot get a flamegraph from multiple projects.")
 
-        span_group = request.query_params.get("spans.group", None)
-        if span_group is not None:
-            sentry_sdk.set_tag("dataset", "spans")
-            profile_ids: object = get_profile_ids_with_spans(
-                organization.id,
-                project_ids[0],
-                params,
-                span_group,
-            )
-        elif request.query_params.get("fingerprint"):
+        if request.query_params.get("fingerprint"):
             sentry_sdk.set_tag("dataset", "functions")
             function_fingerprint = int(request.query_params["fingerprint"])
+
+            # getting profiles by function fingerprint does not support any filter conditions
+            # as it's a limited subset that is hard to expose in a user friendly way
             profile_ids = get_profiles_with_function(
                 organization.id,
                 project_ids[0],
                 function_fingerprint,
                 params,
-                request.GET.get("query", ""),
             )
         else:
             sentry_sdk.set_tag("dataset", "profiles")

--- a/src/sentry/api/endpoints/organization_profiling_profiles.py
+++ b/src/sentry/api/endpoints/organization_profiling_profiles.py
@@ -44,13 +44,12 @@ class OrganizationProfilingFlamegraphEndpoint(OrganizationProfilingBaseEndpoint)
             sentry_sdk.set_tag("dataset", "functions")
             function_fingerprint = int(request.query_params["fingerprint"])
 
-            # getting profiles by function fingerprint does not support any filter conditions
-            # as it's a limited subset that is hard to expose in a user friendly way
             profile_ids = get_profiles_with_function(
                 organization.id,
                 project_ids[0],
                 function_fingerprint,
                 params,
+                request.GET.get("query", ""),
             )
         else:
             sentry_sdk.set_tag("dataset", "profiles")

--- a/src/sentry/profiles/flamegraph.py
+++ b/src/sentry/profiles/flamegraph.py
@@ -64,12 +64,13 @@ def get_profiles_with_function(
     project_id: int,
     function_fingerprint: int,
     params: ParamsType,
+    query: str,
 ) -> ProfileIds:
-    query = f"fingerprint:{function_fingerprint}"
+    conditions = [query, f"fingerprint:{function_fingerprint}"]
 
     result = functions.query(
         selected_columns=["timestamp", "unique_examples()"],
-        query=query,
+        query=" ".join(cond for cond in conditions if cond),
         params=params,
         limit=100,
         orderby=["-timestamp"],

--- a/src/sentry/profiles/flamegraph.py
+++ b/src/sentry/profiles/flamegraph.py
@@ -26,18 +26,24 @@ from sentry.snuba.referrer import Referrer
 from sentry.utils.snuba import raw_snql_query
 
 
-def query_profiles_data(
+class StartEnd(TypedDict):
+    start: str
+    end: str
+
+
+class ProfileIds(TypedDict):
+    profile_ids: list[str]
+
+
+def get_profile_ids(
     params: ParamsType,
-    referrer: str,
-    selected_columns: list[str],
     query: str | None = None,
-    additional_conditions: list[Condition] | None = None,
-) -> list[dict[str, Any]]:
+) -> ProfileIds:
     builder = DiscoverQueryBuilder(
         dataset=Dataset.Discover,
         params=params,
         query=query,
-        selected_columns=selected_columns,
+        selected_columns=["profile.id"],
         limit=options.get("profiling.flamegraph.profile-set.size"),
     )
 
@@ -47,110 +53,10 @@ def query_profiles_data(
             Condition(Column("profile_id"), Op.IS_NOT_NULL),
         ]
     )
-    if additional_conditions is not None:
-        builder.add_conditions(additional_conditions)
 
-    snql_query = builder.get_snql_query()
-    return raw_snql_query(
-        snql_query,
-        referrer,
-    )["data"]
+    result = builder.run_query(Referrer.API_PROFILING_PROFILE_FLAMEGRAPH.value)
 
-
-def get_profile_ids(
-    params: ParamsType,
-    query: str | None = None,
-) -> dict[str, list[str]]:
-    data = query_profiles_data(
-        params,
-        Referrer.API_PROFILING_PROFILE_FLAMEGRAPH.value,
-        selected_columns=["profile.id"],
-        query=query,
-    )
-    return {"profile_ids": [row["profile.id"] for row in data]}
-
-
-class StartEnd(TypedDict):
-    start: str
-    end: str
-
-
-class ProfileIdsWithSpans(TypedDict):
-    profile_ids: list[str]
-    spans: list[list[StartEnd]]
-
-
-def get_profile_ids_with_spans(
-    organization_id: int,
-    project_id: int,
-    params: ParamsType,
-    span_group: str,
-) -> ProfileIdsWithSpans:
-    query = Query(
-        match=Entity(EntityKey.Spans.value),
-        select=[
-            Column("profile_id"),
-            Function(
-                "groupArray(100)",
-                parameters=[
-                    Function(
-                        "tuple",
-                        [
-                            Column("start_timestamp"),
-                            Column("start_ms"),
-                            Column("end_timestamp"),
-                            Column("end_ms"),
-                        ],
-                    )
-                ],
-                alias="intervals",
-            ),
-        ],
-        groupby=[
-            Column("profile_id"),
-        ],
-        where=[
-            Condition(Column("project_id"), Op.EQ, project_id),
-            Condition(Column("timestamp"), Op.GTE, params["start"]),
-            Condition(Column("timestamp"), Op.LT, params["end"]),
-            Condition(Column("group"), Op.EQ, span_group),
-            Condition(Column("profile_id"), Op.IS_NOT_NULL),
-        ],
-        limit=Limit(100),
-    )
-    request = Request(
-        dataset=Dataset.SpansIndexed.value,
-        app_id="default",
-        query=query,
-        tenant_ids={
-            "referrer": Referrer.API_STARFISH_PROFILE_FLAMEGRAPH.value,
-            "organization_id": organization_id,
-        },
-    )
-    data = raw_snql_query(
-        request,
-        referrer=Referrer.API_STARFISH_PROFILE_FLAMEGRAPH.value,
-    )["data"]
-    profile_ids = []
-    spans = []
-    for row in data:
-        transformed_intervals: list[StartEnd] = []
-        profile_ids.append(row["profile_id"].replace("-", ""))
-        for interval in row["intervals"]:
-            start_timestamp, start_ms, end_timestamp, end_ms = interval
-            start_ns = (int(datetime.fromisoformat(start_timestamp).timestamp()) * 10**9) + (
-                start_ms * 10**6
-            )
-            end_ns = (int(datetime.fromisoformat(end_timestamp).timestamp()) * 10**9) + (
-                end_ms * 10**6
-            )
-            transformed_intervals.append({"start": str(start_ns), "end": str(end_ns)})
-        spans.append(transformed_intervals)
-    return {"profile_ids": profile_ids, "spans": spans}
-
-
-class ProfileIds(TypedDict):
-    profile_ids: list[str]
+    return {"profile_ids": [row["profile.id"] for row in result["data"]]}
 
 
 def get_profiles_with_function(
@@ -158,13 +64,12 @@ def get_profiles_with_function(
     project_id: int,
     function_fingerprint: int,
     params: ParamsType,
-    query: str,
 ) -> ProfileIds:
-    conditions = [query, f"fingerprint:{function_fingerprint}"]
+    query = f"fingerprint:{function_fingerprint}"
 
     result = functions.query(
         selected_columns=["timestamp", "unique_examples()"],
-        query=" ".join(cond for cond in conditions if cond),
+        query=query,
         params=params,
         limit=100,
         orderby=["-timestamp"],

--- a/src/sentry/profiles/profile_chunks.py
+++ b/src/sentry/profiles/profile_chunks.py
@@ -35,7 +35,8 @@ def get_chunk_ids(
             Condition(Column("project_id"), Op.EQ, project_id),
             Condition(Column("profiler_id"), Op.EQ, profiler_id),
         ],
-        orderby=[OrderBy(Column("start_timestamp"), Direction.ASC)],
+        # We want the generate the flamegraph using the newest data
+        orderby=[OrderBy(Column("start_timestamp"), Direction.DESC)],
     ).set_limit(max_chunks)
 
     request = Request(

--- a/tests/sentry/api/endpoints/test_organization_profiling_profiles.py
+++ b/tests/sentry/api/endpoints/test_organization_profiling_profiles.py
@@ -27,7 +27,7 @@ class OrganizationProfilingFlamegraphTest(APITestCase):
 
     @patch("sentry.search.events.builder.base.raw_snql_query", wraps=raw_snql_query)
     def test_queries_functions(self, mock_raw_snql_query):
-        fingerprint = str(int(uuid4().hex[:16], 16))
+        fingerprint = int(uuid4().hex[:16], 16)
 
         with self.feature(self.features):
             response = self.client.get(
@@ -35,7 +35,7 @@ class OrganizationProfilingFlamegraphTest(APITestCase):
                 {
                     "project": [self.project.id],
                     "query": "transaction:foo",
-                    "fingerprint": fingerprint,
+                    "fingerprint": str(fingerprint),
                 },
             )
         assert response.status_code == 200
@@ -54,7 +54,7 @@ class OrganizationProfilingFlamegraphTest(APITestCase):
             )
             in snql_request.query.where
         )
-        assert Condition(Column("transaction"), Op.EQ, "foo") not in snql_request.query.where
+        assert Condition(Column("transaction_name"), Op.EQ, "foo") in snql_request.query.where
 
     @patch("sentry.search.events.builder.base.raw_snql_query", wraps=raw_snql_query)
     def test_queries_transactions(self, mock_raw_snql_query):


### PR DESCRIPTION
…s profiling

Remove some unused code around generating flamegraph from spans and add tests. Will follow up to support generating flamegraphs from both transaction and continuous profiles. In the future, we'll add back the span based flamegraphs.