### PR TITLE
fix: support for declaring legacy hosts that omit github signature headers

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -517,6 +517,12 @@ register(
     default=False,
     flags=FLAG_MODIFIABLE_BOOL | FLAG_AUTOMATOR_MODIFIABLE,
 )
+register(
+    "github-enterprise-app.allowed-hosts-legacy-webhooks",
+    type=Sequence,
+    default=[],
+    flags=FLAG_ALLOW_EMPTY | FLAG_AUTOMATOR_MODIFIABLE,
+)
 
 # GitHub Auth
 register(


### PR DESCRIPTION
Older versions of GitHub Enterprise may omit signature headers in webhooks. They're technically optional on GitHub, but we require them on Sentry now.

This option will be used to phase out the backwards compatibility of the insecure no-signature webhooks. 