### PR TITLE
feat(api): Dashboards widget details endpoint is private

### DIFF
--- a/src/sentry/api/endpoints/organization_dashboard_widget_details.py
+++ b/src/sentry/api/endpoints/organization_dashboard_widget_details.py
@@ -13,7 +13,7 @@ from sentry.api.serializers.rest_framework import DashboardWidgetSerializer
 @region_silo_endpoint
 class OrganizationDashboardWidgetDetailsEndpoint(OrganizationEndpoint):
     publish_status = {
-        "POST": ApiPublishStatus.UNKNOWN,
+        "POST": ApiPublishStatus.PRIVATE,
     }
     owner = ApiOwner.PERFORMANCE
     permission_classes = (OrganizationDashboardsPermission,)


### PR DESCRIPTION
Mark the dashboard widget details endpoint as private. It's only used to validate the UI before making a subsequent call to save a dashboard, which has its own validation. This is not necessary to expose as an API.