### PR TITLE
feat(snuba-search): Add query handlers for priority and first_release 

### DIFF
--- a/src/sentry/issues/endpoints/organization_group_index.py
+++ b/src/sentry/issues/endpoints/organization_group_index.py
@@ -39,15 +39,13 @@ from sentry.models.groupinbox import GroupInbox
 from sentry.models.project import Project
 from sentry.search.events.constants import EQUALITY_OPERATORS
 from sentry.search.snuba.backend import assigned_or_suggested_filter
-from sentry.search.snuba.executors import get_search_filter
+from sentry.search.snuba.executors import FIRST_RELEASE_FILTERS, get_search_filter
 from sentry.snuba import discover
 from sentry.utils.cursors import Cursor, CursorResult
 from sentry.utils.validators import normalize_event_id
 
 ERR_INVALID_STATS_PERIOD = "Invalid stats_period. Valid choices are '', '24h', and '14d'"
 allowed_inbox_search_terms = frozenset(["date", "status", "for_review", "assigned_or_suggested"])
-
-FIRST_RELEASE_FILTERS = ["first_release", "firstRelease"]
 
 
 def inbox_search(

--- a/src/sentry/search/snuba/executors.py
+++ b/src/sentry/search/snuba/executors.py
@@ -1499,6 +1499,16 @@ class GroupAttributesPostgresSnubaQueryExecutor(PostgresSnubaQueryExecutor):
             1,
         )
 
+    def get_priority_condition(
+        self, search_filter: SearchFilter, joined_entity: Entity
+    ) -> Condition:
+        """
+        Returns the priority lookup for a search filter.
+        """
+        return Condition(
+            Column("group_priority", self.entities["attrs"]), Op.IN, search_filter.value.raw_value
+        )
+
     ISSUE_FIELD_NAME = "group_id"
 
     entities = {
@@ -1517,6 +1527,9 @@ class GroupAttributesPostgresSnubaQueryExecutor(PostgresSnubaQueryExecutor):
         "times_seen": (get_times_seen_filter, Clauses.HAVING),
         "error.handled": (get_handled_condition, Clauses.WHERE),
         "error.unhandled": (get_handled_condition, Clauses.WHERE),
+        "issue.priority": (get_priority_condition, Clauses.WHERE),
+        # "first_release": (get_basic_group_snuba_condition, Clauses.WHERE),
+        # "firstRelease": (get_basic_group_snuba_condition, Clauses.WHERE),
     }
     first_seen = Column("group_first_seen", entities["attrs"])
     times_seen_aggregation = Function("count", [], alias="times_seen")


### PR DESCRIPTION
Add handlers to support `issue.priority` and `first_release` queries in Snuba, using the `GroupAttributesPostgresSnubaQueryExecutor`. 

The `issue.priority` logic is fairly trivial, using a WHERE condition to search the `GroupAttributes.group_priority` field. For `first_release`, we have a bit more nuance:
- If the query has `environments` specified, the query will need to go through the Postgres executor to handle a join on GroupEnvironment, which isn't present in Clickhouse.
- If the query doesn't specify an `environment` we can use the `GroupAttributes.group_first_release` field and handle the search in Snuba.

All changes are still gated by the `useGroupSnubaDataset` url param to allow for testing without customer impact.