### PR TITLE
ref(replay): clean up replayer after stepping through `replayerStepper`

### DIFF
--- a/static/app/utils/replays/createHiddenPlayer.tsx
+++ b/static/app/utils/replays/createHiddenPlayer.tsx
@@ -2,7 +2,10 @@ import {Replayer} from '@sentry-internal/rrweb';
 
 import type {RecordingFrame} from 'sentry/utils/replays/types';
 
-export function createHiddenPlayer(rrwebEvents: RecordingFrame[]): Replayer {
+export function createHiddenPlayer(rrwebEvents: RecordingFrame[]): {
+  cleanupPlayer: () => void;
+  replayer: Replayer;
+} {
   const domRoot = document.createElement('div');
   domRoot.className = 'sentry-block';
   const {style} = domRoot;
@@ -23,14 +26,21 @@ export function createHiddenPlayer(rrwebEvents: RecordingFrame[]): Replayer {
     hiddenIframe.contentDocument.body.appendChild(domRoot);
   }
 
-  return new Replayer(rrwebEvents, {
-    root: domRoot,
-    loadTimeout: 1,
-    showWarning: false,
-    blockClass: 'sentry-block',
-    speed: 99999,
-    skipInactive: true,
-    triggerFocus: false,
-    mouseTail: false,
-  });
+  const cleanupPlayer = () => {
+    hiddenIframe.remove();
+  };
+
+  return {
+    replayer: new Replayer(rrwebEvents, {
+      root: domRoot,
+      loadTimeout: 1,
+      showWarning: false,
+      blockClass: 'sentry-block',
+      speed: 99999,
+      skipInactive: true,
+      triggerFocus: false,
+      mouseTail: false,
+    }),
+    cleanupPlayer,
+  };
 }

--- a/static/app/utils/replays/createHiddenPlayer.tsx
+++ b/static/app/utils/replays/createHiddenPlayer.tsx
@@ -3,7 +3,7 @@ import {Replayer} from '@sentry-internal/rrweb';
 import type {RecordingFrame} from 'sentry/utils/replays/types';
 
 export function createHiddenPlayer(rrwebEvents: RecordingFrame[]): {
-  cleanupPlayer: () => void;
+  cleanupReplayer: () => void;
   replayer: Replayer;
 } {
   const domRoot = document.createElement('div');
@@ -26,21 +26,24 @@ export function createHiddenPlayer(rrwebEvents: RecordingFrame[]): {
     hiddenIframe.contentDocument.body.appendChild(domRoot);
   }
 
-  const cleanupPlayer = () => {
+  const replayer = new Replayer(rrwebEvents, {
+    root: domRoot,
+    loadTimeout: 1,
+    showWarning: false,
+    blockClass: 'sentry-block',
+    speed: 99999,
+    skipInactive: true,
+    triggerFocus: false,
+    mouseTail: false,
+  });
+
+  const cleanupReplayer = () => {
     hiddenIframe.remove();
+    replayer.destroy();
   };
 
   return {
-    replayer: new Replayer(rrwebEvents, {
-      root: domRoot,
-      loadTimeout: 1,
-      showWarning: false,
-      blockClass: 'sentry-block',
-      speed: 99999,
-      skipInactive: true,
-      triggerFocus: false,
-      mouseTail: false,
-    }),
-    cleanupPlayer,
+    replayer,
+    cleanupReplayer,
   };
 }

--- a/static/app/utils/replays/replayerStepper.tsx
+++ b/static/app/utils/replays/replayerStepper.tsx
@@ -49,6 +49,11 @@ export default function replayerStepper<
       resolve(collection);
       replayer.off('pause', handlePause);
       replayer.destroy();
+      Array.from(document.getElementsByTagName('iframe')).forEach(el => {
+        if (el.style.display === 'none') {
+          el.parentNode?.removeChild(el);
+        }
+      });
     };
 
     const nextOrDone = () => {

--- a/static/app/utils/replays/replayerStepper.tsx
+++ b/static/app/utils/replays/replayerStepper.tsx
@@ -38,7 +38,7 @@ export default function replayerStepper<
       return;
     }
 
-    const replayer = createHiddenPlayer(rrwebEvents);
+    const {replayer, cleanupPlayer} = createHiddenPlayer(rrwebEvents);
 
     const nextFrame = (function () {
       let i = 0;
@@ -47,13 +47,10 @@ export default function replayerStepper<
 
     const onDone = () => {
       resolve(collection);
+      // to avoid recursion, since destroy() calls pause()
       replayer.off('pause', handlePause);
       replayer.destroy();
-      Array.from(document.getElementsByTagName('iframe')).forEach(el => {
-        if (el.style.display === 'none') {
-          el.parentNode?.removeChild(el);
-        }
-      });
+      cleanupPlayer();
     };
 
     const nextOrDone = () => {

--- a/static/app/utils/replays/replayerStepper.tsx
+++ b/static/app/utils/replays/replayerStepper.tsx
@@ -47,6 +47,8 @@ export default function replayerStepper<
 
     const onDone = () => {
       resolve(collection);
+      replayer.off('pause', handlePause);
+      replayer.destroy();
     };
 
     const nextOrDone = () => {

--- a/static/app/utils/replays/replayerStepper.tsx
+++ b/static/app/utils/replays/replayerStepper.tsx
@@ -38,7 +38,7 @@ export default function replayerStepper<
       return;
     }
 
-    const {replayer, cleanupPlayer} = createHiddenPlayer(rrwebEvents);
+    const {replayer, cleanupReplayer} = createHiddenPlayer(rrwebEvents);
 
     const nextFrame = (function () {
       let i = 0;
@@ -47,10 +47,9 @@ export default function replayerStepper<
 
     const onDone = () => {
       resolve(collection);
-      // to avoid recursion, since destroy() calls pause()
+      // to avoid recursion, since destroy() in cleanupReplayer() calls pause()
       replayer.off('pause', handlePause);
-      replayer.destroy();
-      cleanupPlayer();
+      cleanupReplayer();
     };
 
     const nextOrDone = () => {


### PR DESCRIPTION
relates to https://github.com/getsentry/team-replay/issues/450

we create a `Replayer` instance every time we call `replayerStepper`. This PR cleans up the replayer & hidden iframe after we finish stepping through, which helps clean up some memory.

