### PR TITLE
feat(snuba-search): Add a feature flag to snuba-first search logic

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -158,7 +158,7 @@ def register_temporary_features(manager: FeatureManager):
     manager.add("organizations:issue-stream-empty-state-additional-platforms", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE)
     # Enable issue stream performance improvements
     manager.add("organizations:issue-stream-performance", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
-    manager.add("organizations:issue-search-snuba", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
+    manager.add("organizations:issue-search-snuba", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE)
     # Enable the new issue stream search bar UI
     manager.add("organizations:issue-stream-search-query-builder", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
     manager.add("organizations:large-debug-files", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -158,6 +158,7 @@ def register_temporary_features(manager: FeatureManager):
     manager.add("organizations:issue-stream-empty-state-additional-platforms", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE)
     # Enable issue stream performance improvements
     manager.add("organizations:issue-stream-performance", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
+    manager.add("organizations:issue-search-snuba", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
     # Enable the new issue stream search bar UI
     manager.add("organizations:issue-stream-search-query-builder", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
     manager.add("organizations:large-debug-files", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)

--- a/src/sentry/issues/endpoints/organization_group_index.py
+++ b/src/sentry/issues/endpoints/organization_group_index.py
@@ -179,6 +179,9 @@ class OrganizationGroupIndexEndpoint(OrganizationEndpoint):
             else:
 
                 def use_group_snuba_dataset() -> bool:
+                    if not features.has("organizations:issue-search-snuba", organization):
+                        return False
+
                     # if useGroupSnubaDataset we consider using the snuba dataset
                     if not request.GET.get("useGroupSnubaDataset"):
                         return False

--- a/tests/sentry/issues/endpoints/test_organization_group_index.py
+++ b/tests/sentry/issues/endpoints/test_organization_group_index.py
@@ -56,7 +56,7 @@ from sentry.silo.base import SiloMode
 from sentry.testutils.cases import APITestCase, SnubaTestCase
 from sentry.testutils.helpers import parse_link_header
 from sentry.testutils.helpers.datetime import before_now, iso_format
-from sentry.testutils.helpers.features import with_feature
+from sentry.testutils.helpers.features import apply_feature_flag_on_cls, with_feature
 from sentry.testutils.helpers.options import override_options
 from sentry.testutils.silo import assume_test_silo_mode
 from sentry.types.activity import ActivityType
@@ -65,6 +65,7 @@ from sentry.utils import json
 from tests.sentry.issues.test_utils import SearchIssueTestMixin
 
 
+@apply_feature_flag_on_cls("organizations:issue-search-snuba")
 class GroupListTest(APITestCase, SnubaTestCase, SearchIssueTestMixin):
     endpoint = "sentry-api-0-organization-group-index"
 


### PR DESCRIPTION
This logic is still gated using the `useGroupSnubaDataset` url param. This PR adds an additional org-based feature flag so we can enable this internally for all users. 