### PR TITLE
feat(replay): Fix replay restarting not working

### DIFF
--- a/static/app/utils/replays/hydrateRRWebRecordingFrames.spec.tsx
+++ b/static/app/utils/replays/hydrateRRWebRecordingFrames.spec.tsx
@@ -1,27 +1,10 @@
 import {ReplayRecordFixture} from 'sentry-fixture/replayRecord';
 
-import {
-  recordingEndFrame,
-  recordingStartFrame,
-} from 'sentry/utils/replays/hydrateRRWebRecordingFrames';
+import {recordingEndFrame} from 'sentry/utils/replays/hydrateRRWebRecordingFrames';
 import type {RecordingFrame} from 'sentry/utils/replays/types';
 
 describe('hydrateRRWebRecordingFrames', () => {
   const replayRecord = ReplayRecordFixture();
-
-  describe('recordingStartFrame', () => {
-    it('should return a RecordingFrame', () => {
-      const frame: RecordingFrame = recordingStartFrame(replayRecord);
-      expect(frame).toStrictEqual({
-        type: 5,
-        timestamp: replayRecord.started_at.getTime(),
-        data: {
-          tag: 'replay.start',
-          payload: {},
-        },
-      });
-    });
-  });
 
   describe('recordingEndFrame', () => {
     it('should return a RecordingFrame', () => {

--- a/static/app/utils/replays/hydrateRRWebRecordingFrames.tsx
+++ b/static/app/utils/replays/hydrateRRWebRecordingFrames.tsx
@@ -2,17 +2,6 @@ import type {RecordingFrame} from 'sentry/utils/replays/types';
 import {EventType} from 'sentry/utils/replays/types';
 import type {ReplayRecord} from 'sentry/views/replays/types';
 
-export function recordingStartFrame(replayRecord: ReplayRecord): RecordingFrame {
-  return {
-    type: EventType.Custom,
-    timestamp: replayRecord.started_at.getTime(),
-    data: {
-      tag: 'replay.start',
-      payload: {},
-    },
-  };
-}
-
 export function recordingEndFrame(replayRecord: ReplayRecord): RecordingFrame {
   return {
     type: EventType.Custom,

--- a/static/app/utils/replays/replayReader.spec.tsx
+++ b/static/app/utils/replays/replayReader.spec.tsx
@@ -156,11 +156,6 @@ describe('ReplayReader', () => {
       {
         method: 'getRRWebFrames',
         expected: [
-          {
-            type: EventType.Custom,
-            timestamp: expect.any(Number),
-            data: {tag: 'replay.start', payload: {}},
-          },
           firstDiv,
           secondDiv,
           {
@@ -451,10 +446,6 @@ describe('ReplayReader', () => {
 
     it('should trim rrweb frames from the end but not the beginning', () => {
       expect(replay?.getRRWebFrames()).toEqual([
-        expect.objectContaining({
-          type: EventType.Custom,
-          data: {tag: 'replay.start', payload: {}},
-        }),
         expect.objectContaining({
           type: EventType.FullSnapshot,
           timestamp: rrwebFrame1.timestamp,

--- a/static/app/utils/replays/types.tsx
+++ b/static/app/utils/replays/types.tsx
@@ -353,7 +353,7 @@ export type ResourceFrame = HydratedSpan<
 >;
 
 // This list should match each of the operations used in `HydratedSpan` above
-// And any app-specific types that we hydrate (ie: replay.start & replay.end).
+// And any app-specific types that we hydrate (ie: replay.end).
 export const SpanOps = [
   'web-vital',
   'memory',
@@ -363,7 +363,6 @@ export const SpanOps = [
   'navigation.reload',
   'paint',
   'replay.end',
-  'replay.start',
   'resource.css',
   'resource.fetch',
   'resource.iframe',

--- a/static/app/views/replays/details.tsx
+++ b/static/app/views/replays/details.tsx
@@ -105,9 +105,9 @@ function ReplayDetails({params: {replaySlug}}: Props) {
   // The replay data takes a while to load in, which causes `isVideoReplay`
   // to return an early `false`, which used to cause UI jumping.
   // One way to check whether it's finished loading is by checking the length
-  // of the rrweb frames, which should always be > 2 for any given replay.
-  // By default, the 2 frames are replay.start and replay.end
-  const isLoading = !rrwebFrames || (rrwebFrames && rrwebFrames.length <= 2);
+  // of the rrweb frames, which should always be > 1 for any given replay.
+  // By default, the 1 frame is replay.end
+  const isLoading = !rrwebFrames || (rrwebFrames && rrwebFrames.length <= 1);
 
   if (replayRecord?.is_archived) {
     return (


### PR DESCRIPTION
The start of a replay does not always equal the start of the replay
_recording_. This is because we include buffered events in the replay
that occur before the recording is started. In order to align the start
and end times of the replay between the recording, the timeline, and
timestamps of the events inside of e.g. Network tab, we create a fake
rrweb event that occurs at relative timestamp "00:00" (when necessary).

However, this fake event would cause navigation to the start (00:00) and
"Restart Replay" functionality to be broken as the player expects the
snapshot event when this happens. Instead of the fake event, duplicate
the snapshot, but change timestamp to be at the start of the replay. It
is a bit misleading, but is actually similar to what happens now except
that restart works.

An alternative idea is to render a white screen which would illustrate
better that certain events occur before recording was started. However, I
anticipate more user confusion with this solution even though it is more
correct.

Fixes https://github.com/getsentry/sentry/issues/47963