### PR TITLE
ref(crons): Use new broken monitor notif setting

### DIFF
--- a/src/sentry/monitors/tasks/detect_broken_monitor_envs.py
+++ b/src/sentry/monitors/tasks/detect_broken_monitor_envs.py
@@ -115,7 +115,7 @@ def get_user_emails_from_monitor(monitor: Monitor, project: Project):
     user_ids = get_user_ids_to_notify_from_monitor(monitor, project)
     actors = [Actor.from_id(user_id=id) for id in user_ids]
     recipients = notifications_service.get_notification_recipients(
-        type=NotificationSettingEnum.APPROVAL,
+        type=NotificationSettingEnum.BROKEN_MONITORS,
         recipients=actors,
         organization_id=project.organization_id,
         project_ids=[project.id],

--- a/tests/sentry/monitors/tasks/test_detect_broken_monitor_envs.py
+++ b/tests/sentry/monitors/tasks/test_detect_broken_monitor_envs.py
@@ -614,7 +614,7 @@ class MonitorDetectBrokenMonitorEnvTaskTest(TestCase):
         # Disable Nudges for this disabled_owner
         with assume_test_silo_mode(SiloMode.CONTROL):
             NotificationSettingOption.objects.create(
-                type="approval",
+                type="brokenMonitors",
                 scope_type="user",
                 scope_identifier=disabled_owner.id,
                 user_id=disabled_owner.id,


### PR DESCRIPTION
After https://github.com/getsentry/sentry/pull/74415 is merged, let's go ahead and switch over to using the new notification setting.