### PR TITLE
fix(metrics): always use unit none in span metrics, even for metrics with hard-coded units

### DIFF
--- a/src/sentry/sentry_metrics/extraction_rules.py
+++ b/src/sentry/sentry_metrics/extraction_rules.py
@@ -7,6 +7,7 @@ from sentry.sentry_metrics.configuration import (
     ALLOWED_TYPES,
     HARD_CODED_UNITS,
 )
+from sentry.sentry_metrics.models.spanattributeextractionrules import SPAN_ATTRIBUTE_PREFIX
 from sentry.sentry_metrics.use_case_utils import string_to_use_case_id
 
 METRICS_EXTRACTION_RULES_OPTION_KEY = "sentry:metrics_extraction_rules"
@@ -71,7 +72,7 @@ class MetricsExtractionRule:
     def generate_mri(self, use_case: str = "custom"):
         """Generate the Metric Resource Identifier (MRI) associated with the extraction rule."""
         use_case_id = string_to_use_case_id(use_case)
-        return f"{self.type}:{use_case_id.value}/span_attribute_{self.id}@none"
+        return f"{self.type}:{use_case_id.value}/{SPAN_ATTRIBUTE_PREFIX}{self.id}@none"
 
     def __hash__(self):
         return hash(self.generate_mri())

--- a/src/sentry/sentry_metrics/extraction_rules.py
+++ b/src/sentry/sentry_metrics/extraction_rules.py
@@ -71,10 +71,7 @@ class MetricsExtractionRule:
     def generate_mri(self, use_case: str = "custom"):
         """Generate the Metric Resource Identifier (MRI) associated with the extraction rule."""
         use_case_id = string_to_use_case_id(use_case)
-        if self.type in ("s", "c"):
-            return f"{self.type}:{use_case_id.value}/span_attribute_{self.id}@none"
-        else:
-            return f"{self.type}:{use_case_id.value}/span_attribute_{self.id}@{self.unit}"
+        return f"{self.type}:{use_case_id.value}/span_attribute_{self.id}@none"
 
     def __hash__(self):
         return hash(self.generate_mri())

--- a/src/sentry/sentry_metrics/extraction_rules.py
+++ b/src/sentry/sentry_metrics/extraction_rules.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import Any
@@ -7,10 +9,10 @@ from sentry.sentry_metrics.configuration import (
     ALLOWED_TYPES,
     HARD_CODED_UNITS,
 )
-from sentry.sentry_metrics.models.spanattributeextractionrules import SPAN_ATTRIBUTE_PREFIX
 from sentry.sentry_metrics.use_case_utils import string_to_use_case_id
 
 METRICS_EXTRACTION_RULES_OPTION_KEY = "sentry:metrics_extraction_rules"
+SPAN_ATTRIBUTE_PREFIX = "span_attribute_"
 
 
 class MetricsExtractionRuleValidationError(ValueError):

--- a/src/sentry/sentry_metrics/models/spanattributeextractionrules.py
+++ b/src/sentry/sentry_metrics/models/spanattributeextractionrules.py
@@ -39,7 +39,7 @@ class SpanAttributeExtractionRuleCondition(DefaultFieldsModel):
         mris = []
         metric_types = MetricsExtractionRule.infer_types(self.config.aggregates)
         for metric_type in metric_types:
-            mris.append(f"{metric_type}:custom/span_attribute_{self.id}@none")
+            mris.append(f"{metric_type}:custom/{SPAN_ATTRIBUTE_PREFIX}{self.id}@none")
         return mris
 
 

--- a/src/sentry/sentry_metrics/models/spanattributeextractionrules.py
+++ b/src/sentry/sentry_metrics/models/spanattributeextractionrules.py
@@ -10,9 +10,7 @@ from sentry.db.models import ArrayField, DefaultFieldsModel, FlexibleForeignKey,
 from sentry.db.models.fields.hybrid_cloud_foreign_key import HybridCloudForeignKey
 from sentry.models.project import Project
 from sentry.sentry_metrics.configuration import HARD_CODED_UNITS
-from sentry.sentry_metrics.extraction_rules import MetricsExtractionRule
-
-SPAN_ATTRIBUTE_PREFIX = "span_attribute_"
+from sentry.sentry_metrics.extraction_rules import SPAN_ATTRIBUTE_PREFIX, MetricsExtractionRule
 
 
 @region_silo_model

--- a/src/sentry/sentry_metrics/models/spanattributeextractionrules.py
+++ b/src/sentry/sentry_metrics/models/spanattributeextractionrules.py
@@ -39,7 +39,7 @@ class SpanAttributeExtractionRuleCondition(DefaultFieldsModel):
         mris = []
         metric_types = MetricsExtractionRule.infer_types(self.config.aggregates)
         for metric_type in metric_types:
-            mris.append(f"{metric_type}:custom/{SPAN_ATTRIBUTE_PREFIX}{self.id}@{self.config.unit}")
+            mris.append(f"{metric_type}:custom/span_attribute_{self.id}@none")
         return mris
 
 

--- a/src/sentry/snuba/metrics/naming_layer/mri.py
+++ b/src/sentry/snuba/metrics/naming_layer/mri.py
@@ -41,7 +41,7 @@ from typing import cast
 from sentry_kafka_schemas.codecs import ValidationError
 
 from sentry.exceptions import InvalidParams
-from sentry.sentry_metrics.models.spanattributeextractionrules import SPAN_ATTRIBUTE_PREFIX
+from sentry.sentry_metrics.extraction_rules import SPAN_ATTRIBUTE_PREFIX
 from sentry.sentry_metrics.use_case_id_registry import UseCaseID
 from sentry.snuba.dataset import EntityKey
 from sentry.snuba.metrics.units import format_value_using_unit_and_op

--- a/tests/sentry/api/endpoints/test_project_metrics_extraction_rules.py
+++ b/tests/sentry/api/endpoints/test_project_metrics_extraction_rules.py
@@ -183,9 +183,10 @@ class ProjectMetricsExtractionEndpointTestCase(APITestCase):
         data = response.data
         assert len(data) == 1
         assert data[0]["spanAttribute"] == "span.duration"
+        assert data[0]["unit"] == "millisecond"
         conditions = data[0]["conditions"]
-        assert conditions[0]["mris"][0].endswith("millisecond")
-        assert conditions[0]["mris"][1].endswith("millisecond")
+        assert conditions[0]["mris"][0].endswith("none")
+        assert conditions[0]["mris"][1].endswith("none")
 
     @django_db_all
     @with_feature("organizations:custom-metrics-extraction-rule")

--- a/tests/sentry/relay/config/test_metric_extraction.py
+++ b/tests/sentry/relay/config/test_metric_extraction.py
@@ -2188,7 +2188,7 @@ def test_get_span_attribute_metrics(default_project: Project) -> None:
                 "category": "span",
                 "condition": {"name": "span.data.bar", "op": "eq", "value": "baz"},
                 "field": "span.duration",
-                "mri": "d:custom/span_attribute_1@millisecond",
+                "mri": "d:custom/span_attribute_1@none",
                 "tags": [
                     {"field": "span.data.bar", "key": "bar"},
                     {"field": "span.data.foo", "key": "foo"},
@@ -2198,7 +2198,7 @@ def test_get_span_attribute_metrics(default_project: Project) -> None:
                 "category": "span",
                 "condition": {"name": "span.data.abc", "op": "eq", "value": "xyz"},
                 "field": "span.duration",
-                "mri": "d:custom/span_attribute_2@millisecond",
+                "mri": "d:custom/span_attribute_2@none",
                 "tags": [
                     {"field": "span.data.abc", "key": "abc"},
                     {"field": "span.data.foo", "key": "foo"},

--- a/tests/sentry/snuba/metrics/test_span_attribute_extraction.py
+++ b/tests/sentry/snuba/metrics/test_span_attribute_extraction.py
@@ -19,7 +19,7 @@ def test_convert_to_spec():
 
     expected_spec = {
         "category": "span",
-        "mri": "d:custom/span_attribute_1@millisecond",
+        "mri": "d:custom/span_attribute_1@none",
         "field": "span.duration",
         "tags": [
             {"key": "region", "field": "span.data.region"},


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry/issues/74412