### PR TITLE
fix(list-items): Prevent flex shrink on leading items

### DIFF
--- a/static/app/components/compactSelect/styles.tsx
+++ b/static/app/components/compactSelect/styles.tsx
@@ -153,7 +153,7 @@ export const CheckWrap = styled('div')<{isSelected: boolean; multiple: boolean}>
   display: flex;
   justify-content: center;
   align-items: center;
-  width: 1em;
+  min-width: 1em;
   height: 1.4em;
   padding-bottom: 1px;
   pointer-events: none;

--- a/static/app/components/menuListItem.tsx
+++ b/static/app/components/menuListItem.tsx
@@ -427,6 +427,7 @@ const LeadingItems = styled('div')<{
   gap: ${space(1)};
   margin-top: ${p => getVerticalPadding(p.size)};
   margin-right: ${space(1)};
+  flex-shrink: 0;
 
   ${p => p.disabled && `opacity: 0.5;`}
   ${p => p.spanFullHeight && `height: 100%;`}

--- a/static/app/components/metrics/mriSelect/index.tsx
+++ b/static/app/components/metrics/mriSelect/index.tsx
@@ -233,7 +233,7 @@ export const MRISelect = memo(function MRISelect({
               hideName
             />
           ) : (
-            <StyledIconProject key="generic-project" size="xs" />
+            <IconProject key="generic-project" size="xs" />
           );
         }
 
@@ -313,8 +313,4 @@ const CustomMetricInfoText = styled('span')`
 const MetricComboBox = styled(ComboBox<MRI>)`
   min-width: 200px;
   max-width: min(500px, 100%);
-`;
-
-const StyledIconProject = styled(IconProject)`
-  margin-left: -4px;
 `;


### PR DESCRIPTION
### Problem
The leading items would shrink in the flex layout, resulting in misaligned content.
![Screenshot 2024-07-17 at 14 14 47](https://github.com/user-attachments/assets/bccae750-3a4e-4693-a894-62c20c328474)

### Solution
Set `min-width` on checkbox placeholder and `flex-shrink: 0` on the trailing items container.
