### PR TITLE
feat(new-trace): Adding null check for trace node value.

### DIFF
--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/styles.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/styles.tsx
@@ -411,7 +411,7 @@ function NodeActions(props: {
 
   const profileLink = makeTraceContinuousProfilingLink(props.node, profilerId, {
     orgSlug: props.organization.slug,
-    projectSlug: props.node.value.project_slug,
+    projectSlug: props.node.value?.project_slug ?? '',
   });
 
   return (


### PR DESCRIPTION
`node.value` can be `null` for the empty / no data TraceNode.