### PR TITLE
fix(performance): Transaction summary layout

### DIFF
--- a/static/app/views/performance/transactionSummary/pageLayout.tsx
+++ b/static/app/views/performance/transactionSummary/pageLayout.tsx
@@ -322,15 +322,19 @@ const StyledAlert = styled(Alert)`
 `;
 
 const StyledBody = styled(Layout.Body)<{fillSpace?: boolean; hasError?: boolean}>`
+  ${p =>
+    p.fillSpace &&
+    `
   display: flex;
   flex-direction: column;
   gap: ${space(3)};
 
-  @media (min-width: ${p => p.theme.breakpoints.large}) {
+  @media (min-width: ${p.theme.breakpoints.large}) {
     display: flex;
     flex-direction: column;
     gap: ${space(3)};
   }
+  `}
 `;
 
 export function redirectToPerformanceHomepage(


### PR DESCRIPTION
The sidebar on the overview moved to the bottom so disable display flex when not needed.