### PR TITLE
fix(dashboards): Check if widget type changed on update

### DIFF
--- a/static/app/views/dashboards/widgetCard/genericWidgetQueries.tsx
+++ b/static/app/views/dashboards/widgetCard/genericWidgetQueries.tsx
@@ -158,6 +158,7 @@ class GenericWidgetQueries<SeriesResponse, TableResponse> extends Component<
       customDidUpdateComparator
         ? customDidUpdateComparator(prevProps, this.props)
         : widget.limit !== prevProps.widget.limit ||
+          !isEqual(widget.widgetType, prevProps.widget.widgetType) ||
           !isEqual(widget.displayType, prevProps.widget.displayType) ||
           !isEqual(widget.interval, prevProps.widget.interval) ||
           !isEqual(new Set(widgetQueries), new Set(prevWidgetQueries)) ||


### PR DESCRIPTION
If it's the same default query on dataset switch, events request currently doesn't get triggered.