### PR TITLE
feat(query-builder): Allow field definition getter to be defined by props

### DIFF
--- a/static/app/components/searchQueryBuilder/context.tsx
+++ b/static/app/components/searchQueryBuilder/context.tsx
@@ -7,12 +7,14 @@ import type {
 } from 'sentry/components/searchQueryBuilder/types';
 import type {ParseResult} from 'sentry/components/searchSyntax/parser';
 import type {SavedSearchType, Tag, TagCollection} from 'sentry/types/group';
+import type {FieldDefinition} from 'sentry/utils/fields';
 
 interface ContextData {
   dispatch: Dispatch<QueryBuilderActions>;
   filterKeySections: FilterKeySection[];
   filterKeys: TagCollection;
   focusOverride: FocusOverride | null;
+  getFieldDefinition: (key: string) => FieldDefinition | null;
   getTagValues: (tag: Tag, query: string) => Promise<string[]>;
   handleSearch: (query: string) => void;
   parsedQuery: ParseResult | null;
@@ -33,6 +35,7 @@ export const SearchQueryBuilerContext = createContext<ContextData>({
   focusOverride: null,
   filterKeys: {},
   filterKeySections: [],
+  getFieldDefinition: () => null,
   getTagValues: () => Promise.resolve([]),
   dispatch: () => {},
   parsedQuery: null,

--- a/static/app/components/searchQueryBuilder/hooks/useQueryBuilderState.tsx
+++ b/static/app/components/searchQueryBuilder/hooks/useQueryBuilderState.tsx
@@ -1,7 +1,11 @@
 import {type Reducer, useCallback, useReducer} from 'react';
 
+import {useSearchQueryBuilder} from 'sentry/components/searchQueryBuilder/context';
 import {parseFilterValueDate} from 'sentry/components/searchQueryBuilder/tokens/filter/parsers/date/parser';
-import type {FocusOverride} from 'sentry/components/searchQueryBuilder/types';
+import type {
+  FieldDefinitionGetter,
+  FocusOverride,
+} from 'sentry/components/searchQueryBuilder/types';
 import {
   isDateToken,
   makeTokenKey,
@@ -273,12 +277,13 @@ function updateFreeText(
 
 function replaceTokensWithText(
   state: QueryBuilderState,
-  action: ReplaceTokensWithTextAction
+  action: ReplaceTokensWithTextAction,
+  getFieldDefinition: FieldDefinitionGetter
 ): QueryBuilderState {
   const newQuery = replaceTokensWithPadding(state.query, action.tokens, action.text);
   const cursorPosition =
     (action.tokens[0]?.location.start.offset ?? 0) + action.text.length;
-  const newParsedQuery = parseQueryBuilderValue(newQuery);
+  const newParsedQuery = parseQueryBuilderValue(newQuery, getFieldDefinition);
   const focusedToken = newParsedQuery?.find(
     token => token.type === Token.FREE_TEXT && token.location.end.offset >= cursorPosition
   );
@@ -369,6 +374,7 @@ function deleteLastMultiSelectTokenValue(
 }
 
 export function useQueryBuilderState({initialQuery}: {initialQuery: string}) {
+  const {getFieldDefinition} = useSearchQueryBuilder();
   const initialState: QueryBuilderState = {query: initialQuery, focusOverride: null};
 
   const reducer: Reducer<QueryBuilderState, QueryBuilderActions> = useCallback(
@@ -403,7 +409,7 @@ export function useQueryBuilderState({initialQuery}: {initialQuery: string}) {
         case 'UPDATE_FREE_TEXT':
           return updateFreeText(state, action);
         case 'REPLACE_TOKENS_WITH_TEXT':
-          return replaceTokensWithText(state, action);
+          return replaceTokensWithText(state, action, getFieldDefinition);
         case 'UPDATE_FILTER_OP':
           return {
             ...state,
@@ -422,7 +428,7 @@ export function useQueryBuilderState({initialQuery}: {initialQuery: string}) {
           return state;
       }
     },
-    []
+    [getFieldDefinition]
   );
 
   const [state, dispatch] = useReducer(reducer, initialState);

--- a/static/app/components/searchQueryBuilder/tokens/freeText.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/freeText.tsx
@@ -16,6 +16,7 @@ import {
   useShiftFocusToChild,
 } from 'sentry/components/searchQueryBuilder/tokens/utils';
 import type {
+  FieldDefinitionGetter,
   FilterKeySection,
   FocusOverride,
 } from 'sentry/components/searchQueryBuilder/types';
@@ -28,7 +29,7 @@ import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {Tag, TagCollection} from 'sentry/types/group';
 import {trackAnalytics} from 'sentry/utils/analytics';
-import {FieldKind, FieldValueType, getFieldDefinition} from 'sentry/utils/fields';
+import {type FieldDefinition, FieldKind, FieldValueType} from 'sentry/utils/fields';
 import {useFuzzySearch} from 'sentry/utils/fuzzySearch';
 import {isCtrlKeyPressed} from 'sentry/utils/isCtrlKeyPressed';
 import {toTitleCase} from 'sentry/utils/string/toTitleCase';
@@ -91,12 +92,10 @@ function getWordAtCursorPosition(value: string, cursorPosition: number) {
   return value;
 }
 
-function getInitialFilterText(key: string) {
-  const defaultValue = getDefaultFilterValue({key});
+function getInitialFilterText(key: string, fieldDefinition: FieldDefinition | null) {
+  const defaultValue = getDefaultFilterValue({key, fieldDefinition});
 
-  const fieldDef = getFieldDefinition(key);
-
-  switch (fieldDef?.valueType) {
+  switch (fieldDefinition?.valueType) {
     case FieldValueType.INTEGER:
     case FieldValueType.NUMBER:
       return `${key}:>${defaultValue}`;
@@ -115,7 +114,8 @@ function getInitialFilterText(key: string) {
 function replaceFocusedWordWithFilter(
   value: string,
   cursorPosition: number,
-  key: string
+  key: string,
+  getFieldDefinition: FieldDefinitionGetter
 ) {
   const words = value.split(' ');
 
@@ -125,7 +125,7 @@ function replaceFocusedWordWithFilter(
     if (characterCount >= cursorPosition) {
       return (
         value.slice(0, characterCount - word.length - 1).trim() +
-        ` ${getInitialFilterText(key)} ` +
+        ` ${getInitialFilterText(key, getFieldDefinition(key))} ` +
         value.slice(characterCount).trim()
       ).trim();
     }
@@ -134,29 +134,7 @@ function replaceFocusedWordWithFilter(
   return value;
 }
 
-/**
- * Takes a string that contains a filter value `<key>:` and replaces with any aliases that may exist.
- *
- * Example:
- * replaceAliasedFilterKeys('foo issue: bar', {'status': 'is'}) => 'foo is: bar'
- */
-function replaceAliasedFilterKeys(value: string, aliasToKeyMap: Record<string, string>) {
-  const key = value.match(/(\S+):/);
-  const matchedKey = key?.[1];
-  if (matchedKey && aliasToKeyMap[matchedKey]) {
-    const actualKey = aliasToKeyMap[matchedKey];
-    const replacedValue = value.replace(
-      `${matchedKey}:`,
-      getInitialFilterText(actualKey)
-    );
-    return replacedValue;
-  }
-
-  return value;
-}
-
-function createItem(tag: Tag): KeyItem {
-  const fieldDefinition = getFieldDefinition(tag.key);
+function createItem(tag: Tag, fieldDefinition: FieldDefinition | null): KeyItem {
   const description = fieldDefinition?.desc;
 
   return {
@@ -171,12 +149,16 @@ function createItem(tag: Tag): KeyItem {
   };
 }
 
-function createSection(section: FilterKeySection, keys: TagCollection): KeySectionItem {
+function createSection(
+  section: FilterKeySection,
+  keys: TagCollection,
+  getFieldDefinition: FieldDefinitionGetter
+): KeySectionItem {
   return {
     key: section.value,
     value: section.value,
     title: section.label,
-    options: section.children.map(key => createItem(keys[key])),
+    options: section.children.map(key => createItem(keys[key], getFieldDefinition(key))),
   };
 }
 
@@ -222,10 +204,13 @@ function useSortItems({
 }: {
   filterValue: string;
 }): Array<KeySectionItem | KeyItem> {
-  const {filterKeys, filterKeySections} = useSearchQueryBuilder();
+  const {filterKeys, filterKeySections, getFieldDefinition} = useSearchQueryBuilder();
   const flatItems = useMemo<KeyItem[]>(
-    () => Object.values(filterKeys).map(createItem),
-    [filterKeys]
+    () =>
+      Object.values(filterKeys).map(filterKey =>
+        createItem(filterKey, getFieldDefinition(filterKey.key))
+      ),
+    [filterKeys, getFieldDefinition]
   );
   const search = useFuzzySearch(flatItems, FUZZY_SEARCH_OPTIONS);
 
@@ -234,14 +219,18 @@ function useSortItems({
       if (!filterKeySections.length) {
         return flatItems;
       }
-      return filterKeySections.map(section => createSection(section, filterKeys));
+      return filterKeySections.map(section =>
+        createSection(section, filterKeys, getFieldDefinition)
+      );
     }
 
     return search.search(filterValue).map(({item}) => item);
-  }, [filterKeySections, filterKeys, filterValue, flatItems, search]);
+  }, [filterKeySections, filterKeys, filterValue, flatItems, getFieldDefinition, search]);
 }
 
 function KeyDescription({tag}: {tag: Tag}) {
+  const {getFieldDefinition} = useSearchQueryBuilder();
+
   const fieldDefinition = getFieldDefinition(tag.key);
 
   if (!fieldDefinition || !fieldDefinition.desc) {
@@ -299,14 +288,12 @@ function SearchQueryBuilderInputInternal({
     filterKeys,
     filterKeySections,
     dispatch,
+    getFieldDefinition,
     handleSearch,
     placeholder,
     searchSource,
     savedSearchType,
   } = useSearchQueryBuilder();
-  const aliasToKeyMap = useMemo(() => {
-    return Object.fromEntries(Object.values(filterKeys).map(key => [key.alias, key.key]));
-  }, [filterKeys]);
 
   const items = useSortItems({filterValue});
 
@@ -378,11 +365,11 @@ function SearchQueryBuilderInputInternal({
       dispatch({
         type: 'REPLACE_TOKENS_WITH_TEXT',
         tokens: [token],
-        text: replaceAliasedFilterKeys(text, aliasToKeyMap),
+        text,
       });
       resetInputValue();
     },
-    [aliasToKeyMap, dispatch, resetInputValue, token]
+    [dispatch, resetInputValue, token]
   );
 
   const onClick = useCallback(() => {
@@ -398,7 +385,12 @@ function SearchQueryBuilderInputInternal({
         dispatch({
           type: 'UPDATE_FREE_TEXT',
           tokens: [token],
-          text: replaceFocusedWordWithFilter(inputValue, selectionIndex, value),
+          text: replaceFocusedWordWithFilter(
+            inputValue,
+            selectionIndex,
+            value,
+            getFieldDefinition
+          ),
           focusOverride: calculateNextFocusForFilter(state),
         });
         resetInputValue();
@@ -451,7 +443,7 @@ function SearchQueryBuilderInputInternal({
           dispatch({
             type: 'UPDATE_FREE_TEXT',
             tokens: [token],
-            text: replaceAliasedFilterKeys(e.target.value, aliasToKeyMap),
+            text: e.target.value,
             focusOverride: calculateNextFocusForFilter(state),
           });
           resetInputValue();

--- a/static/app/components/searchQueryBuilder/tokens/utils.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/utils.tsx
@@ -4,7 +4,7 @@ import type {ListState} from '@react-stately/list';
 import type {Node} from '@react-types/shared';
 
 import type {ParseResultToken} from 'sentry/components/searchSyntax/parser';
-import {FieldKey, FieldValueType, getFieldDefinition} from 'sentry/utils/fields';
+import {type FieldDefinition, FieldKey, FieldValueType} from 'sentry/utils/fields';
 
 export function shiftFocusToChild(
   element: HTMLElement,
@@ -38,10 +38,14 @@ export function useShiftFocusToChild(
   };
 }
 
-export function getDefaultFilterValue({key}: {key: string}): string {
-  const fieldDef = getFieldDefinition(key);
-
-  if (!fieldDef) {
+export function getDefaultFilterValue({
+  key,
+  fieldDefinition,
+}: {
+  fieldDefinition: FieldDefinition | null;
+  key: string;
+}): string {
+  if (!fieldDefinition) {
     return '""';
   }
 
@@ -49,7 +53,7 @@ export function getDefaultFilterValue({key}: {key: string}): string {
     return 'unresolved';
   }
 
-  switch (fieldDef.valueType) {
+  switch (fieldDefinition.valueType) {
     case FieldValueType.BOOLEAN:
       return 'true';
     case FieldValueType.INTEGER:

--- a/static/app/components/searchQueryBuilder/types.tsx
+++ b/static/app/components/searchQueryBuilder/types.tsx
@@ -1,5 +1,7 @@
 import type {ReactNode} from 'react';
 
+import type {FieldDefinition} from 'sentry/utils/fields';
+
 export type FilterKeySection = {
   children: string[];
   label: ReactNode;
@@ -15,3 +17,5 @@ export type FocusOverride = {
   itemKey: string;
   part?: 'value';
 };
+
+export type FieldDefinitionGetter = (key: string) => FieldDefinition | null;

--- a/static/app/components/searchQueryBuilder/utils.tsx
+++ b/static/app/components/searchQueryBuilder/utils.tsx
@@ -1,3 +1,4 @@
+import type {FieldDefinitionGetter} from 'sentry/components/searchQueryBuilder/types';
 import {
   BooleanOperator,
   FilterType,
@@ -9,11 +10,14 @@ import {
   type TokenResult,
 } from 'sentry/components/searchSyntax/parser';
 import type {TagCollection} from 'sentry/types/group';
-import {FieldValueType, getFieldDefinition} from 'sentry/utils/fields';
+import {FieldValueType} from 'sentry/utils/fields';
 
 export const INTERFACE_TYPE_LOCALSTORAGE_KEY = 'search-query-builder-interface';
 
-function getSearchConfigFromKeys(keys: TagCollection): Partial<SearchConfig> {
+function getSearchConfigFromKeys(
+  keys: TagCollection,
+  getFieldDefinition: FieldDefinitionGetter
+): Partial<SearchConfig> {
   const config = {
     booleanKeys: new Set<string>(),
     numericKeys: new Set<string>(),
@@ -51,6 +55,7 @@ function getSearchConfigFromKeys(keys: TagCollection): Partial<SearchConfig> {
 
 export function parseQueryBuilderValue(
   value: string,
+  getFieldDefinition: FieldDefinitionGetter,
   options?: {filterKeys: TagCollection; disallowLogicalOperators?: boolean}
 ): ParseResult | null {
   return collapseTextTokens(
@@ -60,7 +65,7 @@ export function parseQueryBuilderValue(
         ? new Set([BooleanOperator.AND, BooleanOperator.OR])
         : undefined,
       disallowParens: options?.disallowLogicalOperators,
-      ...getSearchConfigFromKeys(options?.filterKeys ?? {}),
+      ...getSearchConfigFromKeys(options?.filterKeys ?? {}, getFieldDefinition),
     })
   );
 }


### PR DESCRIPTION
Closes https://github.com/getsentry/sentry/issues/74309

No behavioral changes, but this does allow modifying the field definitions by passing `fieldDefinitionGetter`, similar to how it works with SmartSearchBar currently. Certain use cases like releases and replays need this in order to modify field descriptions and other parts of the definition.

The bulk of the work here is replacing calls to the util `getFieldDefinition` with the function that gets passed in.