### PR TITLE
fix(insights): fix overlapping image and minor design changes module empty state

### DIFF
--- a/static/app/views/insights/common/components/modulesOnboarding.tsx
+++ b/static/app/views/insights/common/components/modulesOnboarding.tsx
@@ -182,6 +182,7 @@ const Sidebar = styled('div')`
 
 const PerfImage = styled('img')`
   max-width: 100%;
+  min-width: 200px;
 `;
 
 const OldPerfImage = styled('img')`
@@ -225,6 +226,7 @@ const SplitContainer = styled(Panel)`
 
 const ModuleInfo = styled('div')`
   flex: 5;
+  width: 100%;
 `;
 
 const ModulePreviewImage = styled('img')`
@@ -238,7 +240,6 @@ const ModulePreviewImage = styled('img')`
 const ModulePreviewContainer = styled('div')`
   flex: 2;
   width: 100%;
-  height: 100%;
   padding: ${space(3)};
   background-color: ${p => p.theme.backgroundSecondary};
 `;
@@ -253,6 +254,7 @@ const SupportedSdkContainer = styled('div')`
 
 const SupportedSdkList = styled('div')`
   display: flex;
+  flex-wrap: wrap;
   gap: ${space(0.5)};
 `;
 


### PR DESCRIPTION
Next PR after this one will be removing the flag and making this GA!

1. Add hover effect on supported SDK icons
<img width="144" alt="image" src="https://github.com/user-attachments/assets/e344ca5f-2b62-4a57-9645-ce90d995b037">

2. Fix image overlapping and some general responsive layout issues (matches layout of module upsells a lot more now).

| Before | After |
|--------|--------|
|<img width="1268" alt="image" src="https://github.com/user-attachments/assets/b212f8e4-3037-45c9-b795-0fbff43954d5">  | <img width="1277" alt="image" src="https://github.com/user-attachments/assets/d5e73e4e-aae1-400c-9c10-bfc46a268364"> |
|  <img width="839" alt="image" src="https://github.com/user-attachments/assets/2631903f-06c4-4643-8771-0049ef5b09f6"> | <img width="838" alt="image" src="https://github.com/user-attachments/assets/5e35526e-6c76-48d4-8b13-a53b78830b61"> | 
|  <img width="553" alt="image" src="https://github.com/user-attachments/assets/e0797513-0aac-46e5-aeac-e19a81774938"> | <img width="548" alt="image" src="https://github.com/user-attachments/assets/cb4f53d8-a075-4751-ac1d-83be4497d998"> | 
