### PR TITLE
feat(autofix): Add status check for autofix runs and log an error if it fails

### DIFF
--- a/src/sentry/api/endpoints/group_ai_autofix.py
+++ b/src/sentry/api/endpoints/group_ai_autofix.py
@@ -210,7 +210,10 @@ class GroupAutofixEndpoint(GroupEndpoint):
     def get(self, request: Request, group: Group) -> Response:
         autofix_state = get_autofix_state(group_id=group.id)
 
+        response_state: dict[str, Any] | None = None
+
         if autofix_state:
+            response_state = autofix_state.dict()
             user_ids = autofix_state.actor_ids
             if user_ids:
                 users = user_service.serialize_many(
@@ -220,6 +223,6 @@ class GroupAutofixEndpoint(GroupEndpoint):
 
                 users_map = {user["id"]: user for user in users}
 
-                autofix_state.users = users_map
+                response_state["users"] = users_map
 
-        return Response({"autofix": autofix_state.dict() if autofix_state else None})
+        return Response({"autofix": response_state})

--- a/src/sentry/api/endpoints/group_ai_autofix.py
+++ b/src/sentry/api/endpoints/group_ai_autofix.py
@@ -186,8 +186,6 @@ class GroupAutofixEndpoint(GroupEndpoint):
                 data.get("instruction", data.get("additional_context", "")),
                 TIMEOUT_SECONDS,
             )
-
-            check_autofix_status.apply_async(args=[run_id], countdown=timedelta(minutes=20))
         except Exception as e:
             logger.exception(
                 "Failed to send autofix to seer",
@@ -202,6 +200,8 @@ class GroupAutofixEndpoint(GroupEndpoint):
                 "Autofix failed to start.",
                 500,
             )
+
+        check_autofix_status.apply_async(args=[run_id], countdown=timedelta(seconds=10).seconds)
 
         return Response(
             status=202,

--- a/src/sentry/api/endpoints/group_ai_autofix.py
+++ b/src/sentry/api/endpoints/group_ai_autofix.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import logging
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import Any
 
 import orjson
@@ -16,10 +16,11 @@ from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.group import GroupEndpoint
 from sentry.api.serializers import EventSerializer, serialize
-from sentry.autofix.utils import get_autofix_repos_from_project_code_mappings
+from sentry.autofix.utils import get_autofix_repos_from_project_code_mappings, get_autofix_state
 from sentry.models.group import Group
 from sentry.models.user import User
 from sentry.seer.signed_seer_api import sign_with_seer_secret
+from sentry.tasks.autofix import check_autofix_status
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
 from sentry.users.services.user.service import user_service
 
@@ -133,33 +134,7 @@ class GroupAutofixEndpoint(GroupEndpoint):
 
         response.raise_for_status()
 
-    def _call_get_autofix_state(self, group_id: int) -> dict[str, Any] | None:
-        path = "/v1/automation/autofix/state"
-        body = orjson.dumps(
-            {
-                "group_id": group_id,
-            }
-        )
-        response = requests.post(
-            f"{settings.SEER_AUTOFIX_URL}{path}",
-            data=body,
-            headers={
-                "content-type": "application/json;charset=utf-8",
-                **sign_with_seer_secret(
-                    url=f"{settings.SEER_AUTOFIX_URL}{path}",
-                    body=body,
-                ),
-            },
-        )
-
-        response.raise_for_status()
-
-        result = response.json()
-
-        if result and result["group_id"] == group_id:
-            return result["state"]
-
-        return None
+        return response.json().get("run_id")
 
     def post(self, request: Request, group: Group) -> Response:
         data = orjson.loads(request.body)
@@ -203,7 +178,7 @@ class GroupAutofixEndpoint(GroupEndpoint):
             )
 
         try:
-            self._call_autofix(
+            run_id = self._call_autofix(
                 request.user,
                 group,
                 repos,
@@ -211,6 +186,8 @@ class GroupAutofixEndpoint(GroupEndpoint):
                 data.get("instruction", data.get("additional_context", "")),
                 TIMEOUT_SECONDS,
             )
+
+            check_autofix_status.apply_async(args=[run_id], countdown=timedelta(minutes=20))
         except Exception as e:
             logger.exception(
                 "Failed to send autofix to seer",
@@ -231,10 +208,10 @@ class GroupAutofixEndpoint(GroupEndpoint):
         )
 
     def get(self, request: Request, group: Group) -> Response:
-        autofix_state = self._call_get_autofix_state(group.id)
+        autofix_state = get_autofix_state(group_id=group.id)
 
         if autofix_state:
-            user_ids = autofix_state.get("actor_ids", [])
+            user_ids = autofix_state.actor_ids
             if user_ids:
                 users = user_service.serialize_many(
                     filter={"user_ids": user_ids, "organization_id": request.organization.id},
@@ -243,6 +220,6 @@ class GroupAutofixEndpoint(GroupEndpoint):
 
                 users_map = {user["id"]: user for user in users}
 
-                autofix_state["users"] = users_map
+                autofix_state.users = users_map
 
-        return Response({"autofix": autofix_state})
+        return Response({"autofix": autofix_state.dict() if autofix_state else None})

--- a/src/sentry/api/endpoints/group_ai_autofix.py
+++ b/src/sentry/api/endpoints/group_ai_autofix.py
@@ -201,7 +201,7 @@ class GroupAutofixEndpoint(GroupEndpoint):
                 500,
             )
 
-        check_autofix_status.apply_async(args=[run_id], countdown=timedelta(seconds=10).seconds)
+        check_autofix_status.apply_async(args=[run_id], countdown=timedelta(minutes=15).seconds)
 
         return Response(
             status=202,

--- a/src/sentry/autofix/utils.py
+++ b/src/sentry/autofix/utils.py
@@ -1,7 +1,11 @@
+import datetime
+import enum
 from typing import TypedDict
 
+import orjson
 import requests
 from django.conf import settings
+from pydantic import BaseModel
 
 from sentry.integrations.utils.code_mapping import get_sorted_code_mapping_configs
 from sentry.models.project import Project
@@ -19,9 +23,24 @@ class AutofixRequest(TypedDict):
     issue: AutofixIssue
 
 
-class AutofixState(TypedDict):
+class AutofixStatus(enum.Enum):
+    COMPLETED = "COMPLETED"
+    ERROR = "ERROR"
+    PENDING = "PENDING"
+    PROCESSING = "PROCESSING"
+    NEED_MORE_INFORMATION = "NEED_MORE_INFORMATION"
+    CANCELLED = "CANCELLED"
+
+
+class AutofixState(BaseModel):
     run_id: int
     request: AutofixRequest
+    updated_at: datetime.datetime
+    status: AutofixStatus
+    actor_ids: list[str] | None = None
+
+    class Config:
+        extra = "allow"
 
 
 def get_autofix_repos_from_project_code_mappings(project: Project) -> list[dict]:
@@ -51,6 +70,44 @@ def get_autofix_repos_from_project_code_mappings(project: Project) -> list[dict]
     return list(repos.values())
 
 
+def get_autofix_state(
+    *, group_id: int | None = None, run_id: int | None = None
+) -> AutofixState | None:
+    path = "/v1/automation/autofix/state"
+    body = orjson.dumps(
+        {
+            "group_id": group_id,
+            "run_id": run_id,
+        }
+    )
+    response = requests.post(
+        f"{settings.SEER_AUTOFIX_URL}{path}",
+        data=body,
+        headers={
+            "content-type": "application/json;charset=utf-8",
+            **sign_with_seer_secret(
+                url=f"{settings.SEER_AUTOFIX_URL}{path}",
+                body=body,
+            ),
+        },
+    )
+
+    response.raise_for_status()
+
+    result = response.json()
+
+    if result:
+        if (
+            group_id is not None
+            and result["group_id"] == group_id
+            or run_id is not None
+            and result["run_id"] == run_id
+        ):
+            return AutofixState.validate(result["state"])
+
+    return None
+
+
 def get_autofix_state_from_pr_id(provider: str, pr_id: int) -> AutofixState | None:
     path = "/v1/automation/autofix/state/pr"
     body = json.dumps(
@@ -77,4 +134,4 @@ def get_autofix_state_from_pr_id(provider: str, pr_id: int) -> AutofixState | No
     if not result:
         return None
 
-    return result.get("state", None)
+    return AutofixState.validate(result.get("state", None))

--- a/src/sentry/autofix/utils.py
+++ b/src/sentry/autofix/utils.py
@@ -23,7 +23,7 @@ class AutofixRequest(TypedDict):
     issue: AutofixIssue
 
 
-class AutofixStatus(enum.Enum):
+class AutofixStatus(str, enum.Enum):
     COMPLETED = "COMPLETED"
     ERROR = "ERROR"
     PENDING = "PENDING"

--- a/src/sentry/autofix/webhooks.py
+++ b/src/sentry/autofix/webhooks.py
@@ -11,14 +11,14 @@ from sentry.utils import metrics
 def get_webhook_analytics_fields(autofix_state: AutofixState) -> dict[str, Any]:
     webhook_analytics_fields = {}
 
-    autofix_request = autofix_state.get("request", {})
+    autofix_request = autofix_state.request
 
     webhook_analytics_fields["project_id"] = autofix_request.get("project_id", None)
 
     issue = autofix_request.get("issue", None)
     webhook_analytics_fields["group_id"] = issue.get("id", None) if issue else None
 
-    webhook_analytics_fields["run_id"] = autofix_state.get("run_id", None)
+    webhook_analytics_fields["run_id"] = autofix_state.run_id
 
     return webhook_analytics_fields
 

--- a/src/sentry/tasks/autofix.py
+++ b/src/sentry/tasks/autofix.py
@@ -1,0 +1,22 @@
+import logging
+from datetime import datetime, timedelta
+
+from sentry.autofix.utils import AutofixStatus, get_autofix_state
+from sentry.tasks.base import instrumented_task
+
+logger = logging.getLogger(__name__)
+
+
+@instrumented_task(
+    name="sentry.tasks.autofix.check_autofix_status",
+    max_retries=1,
+)
+def check_autofix_status(run_id: int):
+    state = get_autofix_state(run_id=run_id)
+
+    if (
+        state
+        and state.status == AutofixStatus.PROCESSING
+        and state.updated_at < datetime.now() - timedelta(minutes=5)
+    ):
+        logger.error("Autofix run %s has been processing for more than 5 minutes", run_id)

--- a/src/sentry/tasks/autofix.py
+++ b/src/sentry/tasks/autofix.py
@@ -19,4 +19,7 @@ def check_autofix_status(run_id: int):
         and state.status == AutofixStatus.PROCESSING
         and state.updated_at < datetime.now() - timedelta(minutes=5)
     ):
-        logger.error("Autofix run %s has been processing for more than 5 minutes", run_id)
+        # This should log to sentry
+        logger.error(
+            "Autofix run has been processing for more than 5 minutes", extra={"run_id": run_id}
+        )

--- a/tests/sentry/api/endpoints/test_group_ai_autofix.py
+++ b/tests/sentry/api/endpoints/test_group_ai_autofix.py
@@ -1,6 +1,8 @@
+from datetime import datetime
 from unittest.mock import ANY, patch
 
 from sentry.api.endpoints.group_ai_autofix import TIMEOUT_SECONDS
+from sentry.autofix.utils import AutofixState, AutofixStatus
 from sentry.models.group import Group
 from sentry.testutils.cases import APITestCase, SnubaTestCase
 from sentry.testutils.helpers.datetime import before_now
@@ -16,12 +18,15 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
     def _get_url(self, group_id: int):
         return f"/api/0/issues/{group_id}/autofix/"
 
-    @patch(
-        "sentry.api.endpoints.group_ai_autofix.GroupAutofixEndpoint._call_get_autofix_state",
-        return_value={"status": "PROCESSING"},
-    )
-    def test_ai_autofix_get_endpoint_with_autofix(self, mock_autofix_state_call):
+    @patch("sentry.api.endpoints.group_ai_autofix.get_autofix_state")
+    def test_ai_autofix_get_endpoint_with_autofix(self, mock_get_autofix_state):
         group = self.create_group()
+        mock_get_autofix_state.return_value = AutofixState(
+            run_id=123,
+            request={"project_id": 456, "issue": {"id": 789}},
+            updated_at=datetime.strptime("2023-07-18T12:00:00Z", "%Y-%m-%dT%H:%M:%SZ"),
+            status=AutofixStatus.PROCESSING,
+        )
 
         self.login_as(user=self.user)
         response = self.client.get(self._get_url(group.id), format="json")
@@ -30,15 +35,12 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
         assert response.data["autofix"] is not None
         assert response.data["autofix"]["status"] == "PROCESSING"
 
-        mock_autofix_state_call.assert_called_once()
-        mock_autofix_state_call.assert_called_with(group.id)
+        mock_get_autofix_state.assert_called_once_with(group_id=group.id)
 
-    @patch(
-        "sentry.api.endpoints.group_ai_autofix.GroupAutofixEndpoint._call_get_autofix_state",
-        return_value=None,
-    )
-    def test_ai_autofix_get_endpoint_without_autofix(self, mock_autofix_state_call):
+    @patch("sentry.api.endpoints.group_ai_autofix.get_autofix_state")
+    def test_ai_autofix_get_endpoint_without_autofix(self, mock_get_autofix_state):
         group = self.create_group()
+        mock_get_autofix_state.return_value = None
 
         self.login_as(user=self.user)
         response = self.client.get(self._get_url(group.id), format="json")
@@ -46,11 +48,11 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
         assert response.status_code == 200
         assert response.data["autofix"] is None
 
-        mock_autofix_state_call.assert_called_once()
-        mock_autofix_state_call.assert_called_with(group.id)
+        mock_get_autofix_state.assert_called_once_with(group_id=group.id)
 
     @patch("sentry.api.endpoints.group_ai_autofix.GroupAutofixEndpoint._call_autofix")
-    def test_ai_autofix_post_endpoint(self, mock_call):
+    @patch("sentry.tasks.autofix.check_autofix_status.apply_async")
+    def test_ai_autofix_post_endpoint(self, mock_check_autofix_status, mock_call):
         release = self.create_release(project=self.project, version="1.0.0")
 
         repo = self.create_repo(
@@ -75,6 +77,8 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
 
         assert group is not None
         group.save()
+
+        mock_call.return_value = 123  # Mocking the run_id returned by _call_autofix
 
         self.login_as(user=self.user)
         response = self.client.post(
@@ -107,8 +111,11 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
         )
         assert response.status_code == 202
 
+        mock_check_autofix_status.assert_called_once_with(args=[123], countdown=10)
+
     @patch("sentry.api.endpoints.group_ai_autofix.GroupAutofixEndpoint._call_autofix")
-    def test_ai_autofix_post_without_event_id(self, mock_call):
+    @patch("sentry.tasks.autofix.check_autofix_status.apply_async")
+    def test_ai_autofix_post_without_event_id(self, mock_check_autofix_status, mock_call):
         release = self.create_release(project=self.project, version="1.0.0")
 
         repo = self.create_repo(
@@ -133,6 +140,8 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
 
         assert group is not None
         group.save()
+
+        mock_call.return_value = 123  # Mocking the run_id returned by _call_autofix
 
         self.login_as(user=self.user)
         response = self.client.post(
@@ -162,10 +171,15 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
             [entry.get("type") == "exception" for entry in serialized_event_arg.get("entries", [])]
         )
         assert response.status_code == 202
+
+        mock_check_autofix_status.assert_called_once_with(args=[123], countdown=10)
 
     @patch("sentry.models.Group.get_recommended_event_for_environments", return_value=None)
     @patch("sentry.api.endpoints.group_ai_autofix.GroupAutofixEndpoint._call_autofix")
-    def test_ai_autofix_post_without_event_id_no_recommended_event(self, mock_call, mock_event):
+    @patch("sentry.tasks.autofix.check_autofix_status.apply_async")
+    def test_ai_autofix_post_without_event_id_no_recommended_event(
+        self, mock_check_autofix_status, mock_call, mock_event
+    ):
         release = self.create_release(project=self.project, version="1.0.0")
 
         repo = self.create_repo(
@@ -190,6 +204,8 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
 
         assert group is not None
         group.save()
+
+        mock_call.return_value = 123  # Mocking the run_id returned by _call_autofix
 
         self.login_as(user=self.user)
         response = self.client.post(
@@ -220,6 +236,8 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
         )
 
         assert response.status_code == 202
+
+        mock_check_autofix_status.assert_called_once_with(args=[123], countdown=10)
 
     @patch("sentry.models.Group.get_recommended_event_for_environments", return_value=None)
     @patch("sentry.models.Group.get_latest_event", return_value=None)

--- a/tests/sentry/api/endpoints/test_group_ai_autofix.py
+++ b/tests/sentry/api/endpoints/test_group_ai_autofix.py
@@ -111,7 +111,7 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
         )
         assert response.status_code == 202
 
-        mock_check_autofix_status.assert_called_once_with(args=[123], countdown=10)
+        mock_check_autofix_status.assert_called_once_with(args=[123], countdown=900)
 
     @patch("sentry.api.endpoints.group_ai_autofix.GroupAutofixEndpoint._call_autofix")
     @patch("sentry.tasks.autofix.check_autofix_status.apply_async")
@@ -172,7 +172,7 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
         )
         assert response.status_code == 202
 
-        mock_check_autofix_status.assert_called_once_with(args=[123], countdown=10)
+        mock_check_autofix_status.assert_called_once_with(args=[123], countdown=900)
 
     @patch("sentry.models.Group.get_recommended_event_for_environments", return_value=None)
     @patch("sentry.api.endpoints.group_ai_autofix.GroupAutofixEndpoint._call_autofix")
@@ -237,7 +237,7 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
 
         assert response.status_code == 202
 
-        mock_check_autofix_status.assert_called_once_with(args=[123], countdown=10)
+        mock_check_autofix_status.assert_called_once_with(args=[123], countdown=900)
 
     @patch("sentry.models.Group.get_recommended_event_for_environments", return_value=None)
     @patch("sentry.models.Group.get_latest_event", return_value=None)

--- a/tests/sentry/autofix/test_utils.py
+++ b/tests/sentry/autofix/test_utils.py
@@ -1,10 +1,14 @@
+from datetime import datetime, timezone
 from unittest.mock import patch
 
 import pytest
 from django.conf import settings
 
 from sentry.autofix.utils import (
+    AutofixState,
+    AutofixStatus,
     get_autofix_repos_from_project_code_mappings,
+    get_autofix_state,
     get_autofix_state_from_pr_id,
 )
 from sentry.testutils.cases import TestCase
@@ -40,7 +44,12 @@ class TestGetAutofixStateFromPrId(TestCase):
         mock_response = mock_post.return_value
         mock_response.raise_for_status = lambda: None
         mock_response.json.return_value = {
-            "state": {"run_id": 123, "request": {"project_id": 456, "issue": {"id": 789}}}
+            "state": {
+                "run_id": 123,
+                "request": {"project_id": 456, "issue": {"id": 789}},
+                "updated_at": "2023-07-18T12:00:00Z",
+                "status": "PROCESSING",
+            }
         }
 
         # Call the function
@@ -48,7 +57,10 @@ class TestGetAutofixStateFromPrId(TestCase):
 
         # Assertions
         assert result is not None
-        assert result == {"run_id": 123, "request": {"project_id": 456, "issue": {"id": 789}}}
+        assert result.run_id == 123
+        assert result.request == {"project_id": 456, "issue": {"id": 789}}
+        assert result.updated_at == datetime(2023, 7, 18, 12, 0, tzinfo=timezone.utc)
+        assert result.status == AutofixStatus.PROCESSING
 
         mock_post.assert_called_once_with(
             f"{settings.SEER_AUTOFIX_URL}/v1/automation/autofix/state/pr",
@@ -78,6 +90,96 @@ class TestGetAutofixStateFromPrId(TestCase):
         # Call the function and expect an exception
         with pytest.raises(Exception) as context:
             get_autofix_state_from_pr_id("github", 1)
+
+        # Assertions
+        assert "HTTP Error" in str(context.value)
+
+
+class TestGetAutofixState(TestCase):
+    @patch("requests.post")
+    def test_get_autofix_state_success_with_group_id(self, mock_post):
+        # Setup mock response
+        mock_response = mock_post.return_value
+        mock_response.raise_for_status = lambda: None
+        mock_response.json.return_value = {
+            "group_id": 123,
+            "state": {
+                "run_id": 456,
+                "request": {"project_id": 789, "issue": {"id": 123}},
+                "updated_at": "2023-07-18T12:00:00Z",
+                "status": "PROCESSING",
+            },
+        }
+
+        # Call the function
+        result = get_autofix_state(group_id=123)
+
+        # Assertions
+        assert isinstance(result, AutofixState)
+        assert result.run_id == 456
+        assert result.request == {"project_id": 789, "issue": {"id": 123}}
+        assert result.updated_at == datetime(2023, 7, 18, 12, 0, tzinfo=timezone.utc)
+        assert result.status == AutofixStatus.PROCESSING
+
+        mock_post.assert_called_once_with(
+            f"{settings.SEER_AUTOFIX_URL}/v1/automation/autofix/state",
+            data=b'{"group_id":123,"run_id":null}',
+            headers={"content-type": "application/json;charset=utf-8"},
+        )
+
+    @patch("requests.post")
+    def test_get_autofix_state_success_with_run_id(self, mock_post):
+        # Setup mock response
+        mock_response = mock_post.return_value
+        mock_response.raise_for_status = lambda: None
+        mock_response.json.return_value = {
+            "run_id": 456,
+            "state": {
+                "run_id": 456,
+                "request": {"project_id": 789, "issue": {"id": 123}},
+                "updated_at": "2023-07-18T12:00:00Z",
+                "status": "COMPLETED",
+            },
+        }
+
+        # Call the function
+        result = get_autofix_state(run_id=456)
+
+        # Assertions
+        assert isinstance(result, AutofixState)
+        assert result.run_id == 456
+        assert result.request == {"project_id": 789, "issue": {"id": 123}}
+        assert result.updated_at == datetime(2023, 7, 18, 12, 0, tzinfo=timezone.utc)
+        assert result.status == AutofixStatus.COMPLETED
+
+        mock_post.assert_called_once_with(
+            f"{settings.SEER_AUTOFIX_URL}/v1/automation/autofix/state",
+            data=b'{"group_id":null,"run_id":456}',
+            headers={"content-type": "application/json;charset=utf-8"},
+        )
+
+    @patch("requests.post")
+    def test_get_autofix_state_no_result(self, mock_post):
+        # Setup mock response
+        mock_response = mock_post.return_value
+        mock_response.raise_for_status = lambda: None
+        mock_response.json.return_value = {}
+
+        # Call the function
+        result = get_autofix_state(group_id=123)
+
+        # Assertions
+        assert result is None
+
+    @patch("requests.post")
+    def test_get_autofix_state_http_error(self, mock_post):
+        # Setup mock response to raise HTTP error
+        mock_response = mock_post.return_value
+        mock_response.raise_for_status.side_effect = Exception("HTTP Error")
+
+        # Call the function and expect an exception
+        with pytest.raises(Exception) as context:
+            get_autofix_state(group_id=123)
 
         # Assertions
         assert "HTTP Error" in str(context.value)

--- a/tests/sentry/autofix/test_webhooks.py
+++ b/tests/sentry/autofix/test_webhooks.py
@@ -1,8 +1,10 @@
+from datetime import datetime, timezone
 from unittest.mock import call, patch
 
 from django.conf import settings
 from django.test import override_settings
 
+from sentry.autofix.utils import AutofixState, AutofixStatus
 from sentry.autofix.webhooks import handle_github_pr_webhook_for_autofix
 from sentry.testutils.cases import APITestCase
 
@@ -11,7 +13,12 @@ class AutofixPrWebhookTest(APITestCase):
     @override_settings(SEER_AUTOFIX_GITHUB_APP_USER_ID="12345")
     @patch(
         "sentry.autofix.webhooks.get_autofix_state_from_pr_id",
-        return_value={"run_id": 1, "request": {"project_id": 2, "issue": {"id": 3}}},
+        return_value=AutofixState(
+            run_id=1,
+            request={"project_id": 2, "issue": {"id": 3}},
+            updated_at=datetime.now(timezone.utc),
+            status=AutofixStatus.PROCESSING,
+        ),
     )
     @patch("sentry.autofix.webhooks.analytics.record")
     @patch("sentry.autofix.webhooks.metrics.incr")
@@ -38,7 +45,12 @@ class AutofixPrWebhookTest(APITestCase):
     @override_settings(SEER_AUTOFIX_GITHUB_APP_USER_ID="12345")
     @patch(
         "sentry.autofix.webhooks.get_autofix_state_from_pr_id",
-        return_value={"run_id": 1, "request": {"project_id": 2, "issue": {"id": 3}}},
+        return_value=AutofixState(
+            run_id=1,
+            request={"project_id": 2, "issue": {"id": 3}},
+            updated_at=datetime.now(timezone.utc),
+            status=AutofixStatus.PROCESSING,
+        ),
     )
     @patch("sentry.autofix.webhooks.analytics.record")
     @patch("sentry.autofix.webhooks.metrics.incr")
@@ -65,7 +77,12 @@ class AutofixPrWebhookTest(APITestCase):
     @override_settings(SEER_AUTOFIX_GITHUB_APP_USER_ID="12345")
     @patch(
         "sentry.autofix.webhooks.get_autofix_state_from_pr_id",
-        return_value={"run_id": 1, "request": {"project_id": 2, "issue": {"id": 3}}},
+        return_value=AutofixState(
+            run_id=1,
+            request={"project_id": 2, "issue": {"id": 3}},
+            updated_at=datetime.now(timezone.utc),
+            status=AutofixStatus.PROCESSING,
+        ),
     )
     @patch("sentry.autofix.webhooks.analytics.record")
     @patch("sentry.autofix.webhooks.metrics.incr")

--- a/tests/sentry/tasks/test_autofix.py
+++ b/tests/sentry/tasks/test_autofix.py
@@ -1,0 +1,76 @@
+from datetime import datetime, timedelta
+from unittest.mock import patch
+
+from django.test import TestCase
+
+from sentry.autofix.utils import AutofixState, AutofixStatus
+from sentry.tasks.autofix import check_autofix_status
+
+
+class TestCheckAutofixStatus(TestCase):
+    @patch("sentry.tasks.autofix.get_autofix_state")
+    @patch("sentry.tasks.autofix.logger.error")
+    def test_check_autofix_status_processing_too_long(self, mock_logger, mock_get_autofix_state):
+        # Mock the get_autofix_state function to return a state that's been processing for too long
+        mock_get_autofix_state.return_value = AutofixState(
+            run_id=123,
+            request={"project_id": 456, "issue": {"id": 789}},
+            updated_at=datetime.now() - timedelta(minutes=10),  # Naive datetime
+            status=AutofixStatus.PROCESSING,
+        )
+
+        # Call the task
+        check_autofix_status(123)
+
+        # Check that the logger.error was called
+        mock_logger.assert_called_once_with(
+            "Autofix run has been processing for more than 5 minutes", extra={"run_id": 123}
+        )
+
+    @patch("sentry.tasks.autofix.get_autofix_state")
+    @patch("sentry.tasks.autofix.logger.error")
+    def test_check_autofix_status_processing_within_time_limit(
+        self, mock_logger, mock_get_autofix_state
+    ):
+        # Mock the get_autofix_state function to return a state that's still within the time limit
+        mock_get_autofix_state.return_value = AutofixState(
+            run_id=123,
+            request={"project_id": 456, "issue": {"id": 789}},
+            updated_at=datetime.now() - timedelta(minutes=3),  # Naive datetime
+            status=AutofixStatus.PROCESSING,
+        )
+
+        # Call the task
+        check_autofix_status(123)
+
+        # Check that the logger.error was not called
+        mock_logger.assert_not_called()
+
+    @patch("sentry.tasks.autofix.get_autofix_state")
+    @patch("sentry.tasks.autofix.logger.error")
+    def test_check_autofix_status_completed(self, mock_logger, mock_get_autofix_state):
+        # Mock the get_autofix_state function to return a completed state
+        mock_get_autofix_state.return_value = AutofixState(
+            run_id=123,
+            request={"project_id": 456, "issue": {"id": 789}},
+            updated_at=datetime.now() - timedelta(minutes=10),  # Naive datetime
+            status=AutofixStatus.COMPLETED,
+        )
+
+        # Call the task
+        check_autofix_status(123)
+
+        # Check that the logger.error was not called
+        mock_logger.assert_not_called()
+
+    @patch("sentry.tasks.autofix.get_autofix_state")
+    @patch("sentry.tasks.autofix.logger.error")
+    def test_check_autofix_status_no_state(self, mock_logger, mock_get_autofix_state):
+        # Mock the get_autofix_state function to return None (no state found)
+        mock_get_autofix_state.return_value = None
+
+        # Call the task
+        check_autofix_status(123)
+
+        # Check that the logger.error was not called
+        mock_logger.assert_not_called()


### PR DESCRIPTION
Adds a celery task that will log an error to sentry if an autofix state has been processing and hasn't been updated in 5 minutes. Scheduled to run 15 minutes after the run has started.

This is in order to alert the ML team if Autofix is unresponsive again.