### PR TITLE
feat(grouping): Deprecate mobile grouping config

### DIFF
--- a/src/sentry/grouping/ingest/config.py
+++ b/src/sentry/grouping/ingest/config.py
@@ -18,7 +18,9 @@ logger = logging.getLogger("sentry.events.grouping")
 Job = MutableMapping[str, Any]
 
 # We are moving all projects off these configuration without waiting for events
-CONFIGS_TO_DEPRECATE: list[str] = []
+CONFIGS_TO_DEPRECATE: list[str] = [
+    "mobile:2021-02-12",
+]
 
 
 def update_grouping_config_if_needed(project: Project) -> None:

--- a/tests/sentry/event_manager/test_event_manager_grouping.py
+++ b/tests/sentry/event_manager/test_event_manager_grouping.py
@@ -189,19 +189,8 @@ class EventManagerGroupingTest(TestCase):
         with override_settings(SENTRY_GROUPING_AUTO_UPDATE_ENABLED=True):
             update_grouping_config_if_needed(self.project)
             # Nothing changes
-            assert self.project.get_option("sentry:grouping_config") == "mobile:2021-02-12"
-            assert self.project.get_option("sentry:grouping_auto_update") is False
-
-            # XXX: In the future, once the mobile grouping is added to the list, we will remove this line
-            with mock.patch(
-                "sentry.grouping.ingest.config.CONFIGS_TO_DEPRECATE",
-                new=["mobile:2021-02-12"],
-            ):
-                update_grouping_config_if_needed(self.project)
-                # Even though auto update is disabled we have upgraded the project
-                assert self.project.get_option("sentry:grouping_config") == DEFAULT_GROUPING_CONFIG
-                # We have also updated the auto_update option
-                assert self.project.get_option("sentry:grouping_auto_update") is True
+            assert self.project.get_option("sentry:grouping_config") == DEFAULT_GROUPING_CONFIG
+            assert self.project.get_option("sentry:grouping_auto_update") is True
 
 
 class PlaceholderTitleTest(TestCase):


### PR DESCRIPTION
When events come in for projects with the mobile grouping config, they will start transitioning to the latest project config.

Once we can run the one-off script in GoCD, we can also transition projects without any events.

This takes advantage of the feature added in #74203.