### PR TITLE
[CapMan visibility] Group together tags related to allocation policies

### DIFF
--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -1098,14 +1098,23 @@ def _bulk_snuba_query(snuba_requests: Sequence[SnubaRequest]) -> ResultSet:
                     raise SnubaError("Failed to parse snuba error response")
                 raise UnexpectedResponseError(f"Could not decode JSON response: {response.data!r}")
 
+            allocation_policy_prefix = "allocation_policy."
             if "quota_allowance" in body and "summary" in body["quota_allowance"]:
                 quota_allowance_summary = body["quota_allowance"]["summary"]
-                span.set_tag("threads_used", quota_allowance_summary["threads_used"])
-                sentry_sdk.set_tag("threads_used", quota_allowance_summary["threads_used"])
+                span.set_tag(
+                    f"{allocation_policy_prefix}threads_used",
+                    quota_allowance_summary["threads_used"],
+                )
+                sentry_sdk.set_tag(
+                    f"{allocation_policy_prefix}threads_used",
+                    quota_allowance_summary["threads_used"],
+                )
                 for k, v in quota_allowance_summary["throttled_by"].items():
+                    k = allocation_policy_prefix + k
                     span.set_tag(k, v)
                     sentry_sdk.set_tag(k, v)
                 for k, v in quota_allowance_summary["rejected_by"].items():
+                    k = allocation_policy_prefix + k
                     span.set_tag(k, v)
                     sentry_sdk.set_tag(k, v)
 


### PR DESCRIPTION
https://getsentry.atlassian.net/browse/SNS-2831

Following up on https://github.com/getsentry/sentry/pull/73331, this is what our tags look like in Sentry's UI:
![Screenshot 2024-07-17 at 4 03 28 PM](https://github.com/user-attachments/assets/51de8561-d3a4-4b6f-a69a-bd70309db3d9)

We want to group capman specific tags together, so it's clear to the user that those tags are related to capman