### PR TITLE
feat(onboarding): add messaging onboarding button

### DIFF
--- a/static/app/views/alerts/rules/issue/setupAlertIntegrationButton.spec.tsx
+++ b/static/app/views/alerts/rules/issue/setupAlertIntegrationButton.spec.tsx
@@ -7,8 +7,11 @@ import SetupAlertIntegrationButton from 'sentry/views/alerts/rules/issue/setupAl
 
 describe('SetupAlertIntegrationButton', function () {
   const organization = OrganizationFixture();
+  const featureOrg = OrganizationFixture({
+    features: ['messaging-integration-onboarding'],
+  });
   const project = ProjectFixture();
-  it('renders button if no alert integrations', function () {
+  it('renders slack button if no alert integrations when feature flag is off', function () {
     MockApiClient.addMockResponse({
       url: `/projects/${organization.slug}/${project.slug}/?expand=hasAlertIntegration`,
       body: {
@@ -24,7 +27,7 @@ describe('SetupAlertIntegrationButton', function () {
     );
     expect(container).toHaveTextContent('Set Up Slack Now');
   });
-  it('does not renders button if alert integration installed', function () {
+  it('does not render button if alert integration installed when feature flag is off', function () {
     MockApiClient.addMockResponse({
       url: `/projects/${organization.slug}/${project.slug}/?expand=hasAlertIntegration`,
       body: {
@@ -39,5 +42,31 @@ describe('SetupAlertIntegrationButton', function () {
       />
     );
     expect(container).not.toHaveTextContent('Set Up Slack Now');
+  });
+  it('renders connect to messaging button when feature flag is on', function () {
+    MockApiClient.addMockResponse({
+      url: `/projects/${featureOrg.slug}/${project.slug}/?expand=hasAlertIntegration`,
+      body: {
+        ...project,
+        hasAlertIntegrationInstalled: false,
+      },
+    });
+    const {container} = render(
+      <SetupAlertIntegrationButton projectSlug={project.slug} organization={featureOrg} />
+    );
+    expect(container).toHaveTextContent('Connect to messaging');
+  });
+  it('does not render button if alert integration installed when feature flag is on', function () {
+    MockApiClient.addMockResponse({
+      url: `/projects/${featureOrg.slug}/${project.slug}/?expand=hasAlertIntegration`,
+      body: {
+        ...project,
+        hasAlertIntegrationInstalled: true,
+      },
+    });
+    const {container} = render(
+      <SetupAlertIntegrationButton projectSlug={project.slug} organization={featureOrg} />
+    );
+    expect(container).not.toHaveTextContent('Connect to messaging');
   });
 });

--- a/static/app/views/alerts/rules/issue/setupAlertIntegrationButton.tsx
+++ b/static/app/views/alerts/rules/issue/setupAlertIntegrationButton.tsx
@@ -1,9 +1,13 @@
+import styled from '@emotion/styled';
+
+import {openModal} from 'sentry/actionCreators/modal';
 import {Button} from 'sentry/components/button';
 import DeprecatedAsyncComponent from 'sentry/components/deprecatedAsyncComponent';
 import {Tooltip} from 'sentry/components/tooltip';
 import {t} from 'sentry/locale';
 import PluginIcon from 'sentry/plugins/components/pluginIcon';
 import ConfigStore from 'sentry/stores/configStore';
+import {space} from 'sentry/styles/space';
 import type {Organization} from 'sentry/types/organization';
 import type {Project} from 'sentry/types/project';
 
@@ -54,6 +58,38 @@ export default class SetupAlertIntegrationButton extends DeprecatedAsyncComponen
       return null;
     }
 
+    if (organization.features.includes('messaging-integration-onboarding')) {
+      return (
+        <Tooltip
+          title={t('Send alerts to your messaging service. Install the integration now.')}
+        >
+          <Button
+            size="sm"
+            icon={
+              <IconWrapper>
+                <PluginIcon pluginId="slack" size={16} />
+                <PluginIcon pluginId="msteams" size={16} />
+                <PluginIcon pluginId="discord" size={16} />
+              </IconWrapper>
+            }
+            onClick={() =>
+              openModal(({closeModal, Header, Body}) => (
+                <div>
+                  <Header>Connect with a messaging tool</Header>
+                  <Body>
+                    <div>Receive alerts and digests right where you work.</div>
+                    <Button onClick={closeModal}>Close</Button>
+                  </Body>
+                </div>
+              ))
+            }
+          >
+            {t('Connect to messaging')}
+          </Button>
+        </Tooltip>
+      );
+    }
+
     const {isSelfHosted} = ConfigStore.getState();
     // link to docs to set up Slack for self-hosted folks
     const referrerQuery = '?referrer=issue-alert-builder';
@@ -64,7 +100,6 @@ export default class SetupAlertIntegrationButton extends DeprecatedAsyncComponen
       : {
           to: `/settings/${organization.slug}/integrations/slack/${referrerQuery}`,
         };
-
     // TOOD(Steve): need to use the Tooltip component because adding a title to the button
     // puts the tooltip in the upper left hand corner of the page instead of the button
     return (
@@ -80,3 +115,8 @@ export default class SetupAlertIntegrationButton extends DeprecatedAsyncComponen
     );
   }
 }
+
+const IconWrapper = styled('div')`
+  display: flex;
+  gap: ${space(1)};
+`;

--- a/static/app/views/alerts/rules/issue/setupAlertIntegrationButton.tsx
+++ b/static/app/views/alerts/rules/issue/setupAlertIntegrationButton.tsx
@@ -60,6 +60,7 @@ export default class SetupAlertIntegrationButton extends DeprecatedAsyncComponen
     }
 
     if (organization.features.includes('messaging-integration-onboarding')) {
+      // TODO(Mia): only render if organization has team plan and above
       return (
         <Tooltip
           title={t('Send alerts to your messaging service. Install the integration now.')}

--- a/static/app/views/alerts/rules/issue/setupAlertIntegrationButton.tsx
+++ b/static/app/views/alerts/rules/issue/setupAlertIntegrationButton.tsx
@@ -10,6 +10,7 @@ import ConfigStore from 'sentry/stores/configStore';
 import {space} from 'sentry/styles/space';
 import type {Organization} from 'sentry/types/organization';
 import type {Project} from 'sentry/types/project';
+import SetupAlertIntegrationModal from 'sentry/views/alerts/rules/issue/setupAlertIntegrationModal';
 
 type Props = DeprecatedAsyncComponent['props'] & {
   organization: Organization;
@@ -73,15 +74,9 @@ export default class SetupAlertIntegrationButton extends DeprecatedAsyncComponen
               </IconWrapper>
             }
             onClick={() =>
-              openModal(({closeModal, Header, Body}) => (
-                <div>
-                  <Header>Connect with a messaging tool</Header>
-                  <Body>
-                    <div>Receive alerts and digests right where you work.</div>
-                    <Button onClick={closeModal}>Close</Button>
-                  </Body>
-                </div>
-              ))
+              openModal(deps => <SetupAlertIntegrationModal {...deps} />, {
+                closeEvents: 'escape-key',
+              })
             }
           >
             {t('Connect to messaging')}

--- a/static/app/views/alerts/rules/issue/setupAlertIntegrationModal.tsx
+++ b/static/app/views/alerts/rules/issue/setupAlertIntegrationModal.tsx
@@ -1,0 +1,16 @@
+import {Fragment} from 'react';
+
+import type {ModalRenderProps} from 'sentry/actionCreators/modal';
+
+function SetupAlertIntegrationModal({Header, Body}: ModalRenderProps) {
+  return (
+    <Fragment>
+      <Header closeButton>Connect with a messaging tool</Header>
+      <Body>
+        <div>Receive alerts and digests right where you work.</div>
+      </Body>
+    </Fragment>
+  );
+}
+
+export default SetupAlertIntegrationModal;


### PR DESCRIPTION
added messaging integration onboarding button

Button on Alerts page
![Screenshot 2024-07-17 at 3 46 56 PM](https://github.com/user-attachments/assets/a090f82e-8e67-4274-be7e-70c0d7fd131b)

Modal (in progress, will be updated to include buttons to add integrations)
![Screenshot 2024-07-17 at 3 46 45 PM](https://github.com/user-attachments/assets/61546939-9475-4a27-a5c9-af2d02402fc3)
