### PR TITLE
fix(tag): incorrect dataset queried tag

### DIFF
--- a/src/sentry/api/endpoints/organization_tags.py
+++ b/src/sentry/api/endpoints/organization_tags.py
@@ -59,7 +59,7 @@ class OrganizationTagsEndpoint(OrganizationEndpoint):
                     "custom_tags.count.grouped",
                     format_grouped_length(len(results), [1, 10, 50, 100]),
                 )
-                sentry_sdk.set_tag("dataset_queried", dataset)
+                sentry_sdk.set_tag("dataset_queried", dataset.value)
                 set_measurement("custom_tags.count", len(results))
 
         return Response(serialize(results, request.user))


### PR DESCRIPTION
Fixes dataset_queried tag being a class instance instead of a string

![image](https://github.com/user-attachments/assets/0bbefd19-2837-492c-a90e-3da86567f741)
