### PR TITLE
chore(hybrid-cloud): TEMP BRANCH: Updates Pydantic to v2.7

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -10,7 +10,7 @@ on:
 # https://docs.github.com/en/actions/using-jobs/using-concurrency#example-using-a-fallback-value
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 # hack for https://github.com/actions/cache/issues/810#issuecomment-1222550359
 env:

--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -45,7 +45,7 @@ python-rapidjson>=1.4
 psutil>=5.9.2
 psycopg2-binary>=2.9.9
 PyJWT>=2.4.0
-pydantic>=1.10.17,<2
+pydantic>=2.5.0
 python-dateutil>=2.9.0
 pymemcache
 python-u2flib-server>=5.0.0

--- a/requirements-dev-frozen.txt
+++ b/requirements-dev-frozen.txt
@@ -137,7 +137,7 @@ pyasn1-modules==0.2.4
 pycodestyle==2.11.0
 pycountry==17.5.14
 pycparser==2.21
-pydantic==1.10.17
+pydantic==2.5.2
 pyflakes==3.2.0
 pyjwt==2.4.0
 pymemcache==4.0.0

--- a/requirements-dev-frozen.txt
+++ b/requirements-dev-frozen.txt
@@ -7,6 +7,7 @@
 --index-url https://pypi.devinfra.sentry.io/simple
 
 amqp==5.2.0
+annotated-types==0.7.0
 anyio==3.7.1
 asgiref==3.7.2
 attrs==23.1.0
@@ -137,7 +138,8 @@ pyasn1-modules==0.2.4
 pycodestyle==2.11.0
 pycountry==17.5.14
 pycparser==2.21
-pydantic==1.10.17
+pydantic==2.7.4
+pydantic-core==2.18.4
 pyflakes==3.2.0
 pyjwt==2.4.0
 pymemcache==4.0.0

--- a/requirements-dev-frozen.txt
+++ b/requirements-dev-frozen.txt
@@ -137,7 +137,7 @@ pyasn1-modules==0.2.4
 pycodestyle==2.11.0
 pycountry==17.5.14
 pycparser==2.21
-pydantic==2.5.2
+pydantic==1.10.17
 pyflakes==3.2.0
 pyjwt==2.4.0
 pymemcache==4.0.0

--- a/requirements-frozen.txt
+++ b/requirements-frozen.txt
@@ -7,6 +7,7 @@
 --index-url https://pypi.devinfra.sentry.io/simple
 
 amqp==5.2.0
+annotated-types==0.7.0
 anyio==3.7.1
 asgiref==3.7.2
 attrs==23.1.0
@@ -96,7 +97,8 @@ pyasn1==0.4.5
 pyasn1-modules==0.2.4
 pycountry==17.5.14
 pycparser==2.21
-pydantic==1.10.17
+pydantic==2.7.4
+pydantic-core==2.18.4
 pyjwt==2.4.0
 pymemcache==4.0.0
 pyparsing==3.0.9

--- a/requirements-frozen.txt
+++ b/requirements-frozen.txt
@@ -96,7 +96,7 @@ pyasn1==0.4.5
 pyasn1-modules==0.2.4
 pycountry==17.5.14
 pycparser==2.21
-pydantic==2.5.2
+pydantic==1.10.17
 pyjwt==2.4.0
 pymemcache==4.0.0
 pyparsing==3.0.9

--- a/requirements-frozen.txt
+++ b/requirements-frozen.txt
@@ -96,7 +96,7 @@ pyasn1==0.4.5
 pyasn1-modules==0.2.4
 pycountry==17.5.14
 pycparser==2.21
-pydantic==1.10.17
+pydantic==2.5.2
 pyjwt==2.4.0
 pymemcache==4.0.0
 pyparsing==3.0.9

--- a/src/flagpole/__init__.py
+++ b/src/flagpole/__init__.py
@@ -157,7 +157,7 @@ class Feature(BaseModel):
         return features
 
     def to_dict(self) -> dict[str, Any]:
-        json_dict = dict(orjson.loads(self.json()))
+        json_dict = dict(orjson.loads(self.model_dump_json()))
         json_dict.pop("name")
         return {self.name: json_dict}
 

--- a/src/sentry/api/endpoints/group_notes.py
+++ b/src/sentry/api/endpoints/group_notes.py
@@ -51,7 +51,7 @@ class GroupNotesEndpoint(GroupEndpoint):
 
         data = dict(serializer.validated_data)
         if "mentions" in data:
-            data["mentions"] = [m.dict() for m in data["mentions"]]
+            data["mentions"] = [m.model_dump() for m in data["mentions"]]
 
         if Activity.objects.filter(
             group=group,

--- a/src/sentry/api/endpoints/internal/rpc.py
+++ b/src/sentry/api/endpoints/internal/rpc.py
@@ -53,7 +53,7 @@ class InternalRpcServiceEndpoint(Endpoint):
                 # includes an authenticated user that will be injected into the global request context
                 # for compatibility.  Notably, this authentication context is *trusted* as the request comes
                 # from within the privileged RPC channel.
-                auth_context = AuthenticationContext.parse_obj(auth_context_json)
+                auth_context = AuthenticationContext.model_validate(auth_context_json)
             except pydantic.ValidationError as e:
                 capture_exception()
                 raise ParseError from e

--- a/src/sentry/hybridcloud/rpc/__init__.py
+++ b/src/sentry/hybridcloud/rpc/__init__.py
@@ -44,7 +44,10 @@ class ValueEqualityEnum(Enum):
 class RpcModel(pydantic.BaseModel):
     """A serializable object that may be part of an RPC schema."""
 
-    model_config = ConfigDict(from_attributes=True, use_enum_values=True)
+    # TODO(Hybrid-Cloud): Remove number coercion after pydantic V2 stabilized
+    model_config = ConfigDict(
+        from_attributes=True, use_enum_values=True, coerce_numbers_to_str=True
+    )
 
     @classmethod
     def get_field_names(cls) -> Iterable[str]:

--- a/src/sentry/hybridcloud/rpc/__init__.py
+++ b/src/sentry/hybridcloud/rpc/__init__.py
@@ -44,12 +44,12 @@ class RpcModel(pydantic.BaseModel):
     """A serializable object that may be part of an RPC schema."""
 
     class Config:
-        orm_mode = True
+        from_attributes = True
         use_enum_values = True
 
     @classmethod
     def get_field_names(cls) -> Iterable[str]:
-        return iter(cls.__fields__.keys())
+        return iter(cls.model_fields.keys())
 
     @classmethod
     def serialize_by_field_name(

--- a/src/sentry/hybridcloud/rpc/__init__.py
+++ b/src/sentry/hybridcloud/rpc/__init__.py
@@ -11,6 +11,7 @@ from typing import Any, Generic, Protocol, Self, TypeVar, cast
 import pydantic
 from django.db import router, transaction
 from django.db.models import Model
+from pydantic import ConfigDict
 
 from sentry.silo.base import SiloMode
 from sentry.utils.env import in_test_environment
@@ -43,9 +44,7 @@ class ValueEqualityEnum(Enum):
 class RpcModel(pydantic.BaseModel):
     """A serializable object that may be part of an RPC schema."""
 
-    class Config:
-        from_attributes = True
-        use_enum_values = True
+    model_config = ConfigDict(from_attributes=True, use_enum_values=True)
 
     @classmethod
     def get_field_names(cls) -> Iterable[str]:

--- a/src/sentry/hybridcloud/rpc/caching/service.py
+++ b/src/sentry/hybridcloud/rpc/caching/service.py
@@ -190,7 +190,9 @@ class SiloCacheManyBackedCallable(Generic[_R]):
                 continue
             cache_key = keys[record_id]
             record_version = missing[record_id]
-            _consume_generator(_set_cache(cache_key, record.json(), record_version, self.timeout))
+            _consume_generator(
+                _set_cache(cache_key, record.model_dump_json(), record_version, self.timeout)
+            )
             found[record_id] = record
 
         return [found[id] for id in ids if id in found]

--- a/src/sentry/hybridcloud/rpc/caching/service.py
+++ b/src/sentry/hybridcloud/rpc/caching/service.py
@@ -96,7 +96,7 @@ class SiloCacheBackedCallable(Generic[_R]):
         metrics.incr("hybridcloud.caching.one.rpc", tags={"base_key": self.base_key})
         r = self.cb(i)
         if r is not None:
-            _consume_generator(_set_cache(key, r.json(), version, self.timeout))
+            _consume_generator(_set_cache(key, r.model_dump_json(), version, self.timeout))
         return r
 
     def get_one(self, object_id: int) -> _R | None:

--- a/src/sentry/hybridcloud/rpc/service.py
+++ b/src/sentry/hybridcloud/rpc/service.py
@@ -446,7 +446,7 @@ def dispatch_to_local_service(
 
     def result_to_dict(value: Any) -> Any:
         if isinstance(value, RpcModel):
-            return value.dict()
+            return value.model_dump()
 
         if isinstance(value, dict):
             return {key: result_to_dict(val) for key, val in value.items()}

--- a/src/sentry/hybridcloud/rpc/sig.py
+++ b/src/sentry/hybridcloud/rpc/sig.py
@@ -127,16 +127,16 @@ class SerializableFunctionSignature:
             model_instance = self._parameter_model(**raw_arguments)
         except Exception as e:
             raise SerializableFunctionValueException(self, "Could not serialize arguments") from e
-        return model_instance.dict()
+        return model_instance.model_dump()
 
     def deserialize_arguments(self, serial_arguments: ArgumentDict) -> pydantic.BaseModel:
         try:
-            return self._parameter_model.parse_obj(serial_arguments)
+            return self._parameter_model.model_validate(serial_arguments)
         except Exception as e:
             raise SerializableFunctionValueException(self, "Could not deserialize arguments") from e
 
     def deserialize_return_value(self, value: Any) -> Any:
-        parsed = self._return_model.parse_obj({self._RETURN_MODEL_ATTR: value})
+        parsed = self._return_model.model_validate({self._RETURN_MODEL_ATTR: value})
         return getattr(parsed, self._RETURN_MODEL_ATTR)
 
     def get_schemas(self) -> tuple[type[pydantic.BaseModel], type[pydantic.BaseModel]]:

--- a/src/sentry/hybridcloud/rpc/sig.py
+++ b/src/sentry/hybridcloud/rpc/sig.py
@@ -7,6 +7,7 @@ from typing import Any
 
 import pydantic
 from django.utils.functional import LazyObject
+from pydantic import ConfigDict
 
 from sentry.hybridcloud.rpc import ArgumentDict
 
@@ -81,7 +82,10 @@ class SerializableFunctionSignature:
         if self.is_instance_method:
             parameters = parameters[1:]  # exclude `self` argument
         field_definitions = {p.name: create_field(p) for p in parameters}
-        return pydantic.create_model(model_name, **field_definitions)  # type: ignore[call-overload]
+
+        # TODO(Hybrid-Cloud): Remove number coercion after pydantic V2 stabilized
+        config = ConfigDict(coerce_numbers_to_str=True)
+        return pydantic.create_model(model_name, __config__=config, **field_definitions)  # type: ignore[call-overload]
 
     _RETURN_MODEL_ATTR = "value"
 

--- a/src/sentry/hybridcloud/services/control_organization_provisioning/impl.py
+++ b/src/sentry/hybridcloud/services/control_organization_provisioning/impl.py
@@ -50,7 +50,7 @@ def create_organization_provisioning_outbox(
     region_name: str,
     org_provision_payload: OrganizationProvisioningOptions | None,
 ) -> ControlOutbox:
-    payload = org_provision_payload.dict() if org_provision_payload is not None else None
+    payload = org_provision_payload.model_dump() if org_provision_payload is not None else None
     return ControlOutbox(
         region_name=region_name,
         shard_scope=OutboxScope.PROVISION_SCOPE,

--- a/src/sentry/hybridcloud/services/control_organization_provisioning/model.py
+++ b/src/sentry/hybridcloud/services/control_organization_provisioning/model.py
@@ -1,7 +1,7 @@
-import pydantic
+from sentry.hybridcloud.rpc import RpcModel
 
 
-class RpcOrganizationSlugReservation(pydantic.BaseModel):
+class RpcOrganizationSlugReservation(RpcModel):
     id: int
     organization_id: int
     user_id: int | None

--- a/src/sentry/hybridcloud/services/region_organization_provisioning/impl.py
+++ b/src/sentry/hybridcloud/services/region_organization_provisioning/impl.py
@@ -26,7 +26,7 @@ def create_post_provision_outbox(
         shard_identifier=org_id,
         category=OutboxCategory.POST_ORGANIZATION_PROVISION,
         object_identifier=org_id,
-        payload=provisioning_options.post_provision_options.dict(),
+        payload=provisioning_options.post_provision_options.model_dump(),
     )
 
 

--- a/src/sentry/integrations/services/repository/impl.py
+++ b/src/sentry/integrations/services/repository/impl.py
@@ -81,7 +81,7 @@ class DatabaseBackedRepositoryService(RepositoryService):
             if repository is None:
                 return
 
-            update_dict = update.dict()
+            update_dict = update.model_dump()
             del update_dict["id"]
 
             for field_name, field_value in update_dict.items():

--- a/src/sentry/integrations/services/repository/impl.py
+++ b/src/sentry/integrations/services/repository/impl.py
@@ -67,7 +67,7 @@ class DatabaseBackedRepositoryService(RepositoryService):
         try:
             with enforce_constraints(transaction.atomic(router.db_for_write(Repository))):
                 repository = Repository.objects.create(
-                    organization_id=organization_id, **create.dict()
+                    organization_id=organization_id, **create.model_dump()
                 )
                 return serialize_repository(repository)
         except IntegrityError:

--- a/src/sentry/models/organizationmember.py
+++ b/src/sentry/models/organizationmember.py
@@ -638,7 +638,7 @@ class OrganizationMember(ReplicatedRegionModel):
         )
 
     def handle_async_replication(self, shard_identifier: int) -> None:
-        rpc_org_member_update = RpcOrganizationMemberMappingUpdate.from_orm(self)
+        rpc_org_member_update = RpcOrganizationMemberMappingUpdate.model_validate(self)
 
         organizationmember_mapping_service.upsert_mapping(
             organizationmember_id=self.id,

--- a/src/sentry/plugins/providers/integration_repository.py
+++ b/src/sentry/plugins/providers/integration_repository.py
@@ -144,7 +144,7 @@ class IntegrationRepositoryProvider:
             repo.status = ObjectStatus.ACTIVE
             repository_service.update_repository(organization_id=organization.id, update=repo)
         else:
-            create_repository = RpcCreateRepository.parse_obj(
+            create_repository = RpcCreateRepository.model_validate(
                 {**repo_update_params, "status": ObjectStatus.ACTIVE}
             )
             new_repository = repository_service.create_repository(

--- a/src/sentry/relocation/services/relocation_export/impl.py
+++ b/src/sentry/relocation/services/relocation_export/impl.py
@@ -149,7 +149,7 @@ class ProxyingRelocationExportService(ControlRelocationExportService):
             replying_region_name=replying_region_name,
             org_slug=org_slug,
             encrypt_with_public_key=encrypt_with_public_key,
-        ).dict()
+        ).model_dump()
         ControlOutbox(
             region_name=replying_region_name,
             shard_scope=OutboxScope.RELOCATION_SCOPE,
@@ -193,7 +193,7 @@ class ProxyingRelocationExportService(ControlRelocationExportService):
             requesting_region_name=requesting_region_name,
             replying_region_name=replying_region_name,
             org_slug=org_slug,
-        ).dict()
+        ).model_dump()
         ControlOutbox(
             region_name=requesting_region_name,
             shard_scope=OutboxScope.RELOCATION_SCOPE,

--- a/src/sentry/runner/commands/rpcschema.py
+++ b/src/sentry/runner/commands/rpcschema.py
@@ -80,7 +80,7 @@ def rpcschema(diagnose: bool, partial: bool) -> None:
         entries = [RpcSchemaEntry(sig) for sig in signatures]
         path_dict = {entry.api_path: entry.build_api_entry() for entry in entries}
 
-        spec = OpenAPI.parse_obj(
+        spec = OpenAPI.model_validate(
             dict(
                 info=dict(
                     title="Sentry Internal RPC APIs",

--- a/src/sentry/services/organization/model.py
+++ b/src/sentry/services/organization/model.py
@@ -13,8 +13,8 @@ class OrganizationOptions(pydantic.BaseModel):
 
 
 class PostProvisionOptions(pydantic.BaseModel):
-    sentry_options: Any | None  # Placeholder for any sentry post-provisioning data
-    getsentry_options: Any | None  # Reserved for getsentry post-provisioning data
+    sentry_options: Any | None = None  # Placeholder for any sentry post-provisioning data
+    getsentry_options: Any | None = None  # Reserved for getsentry post-provisioning data
 
 
 class OrganizationProvisioningOptions(pydantic.BaseModel):

--- a/src/sentry/services/organization/provisioning.py
+++ b/src/sentry/services/organization/provisioning.py
@@ -224,7 +224,7 @@ def process_provision_organization_outbox(
     object_identifier: int, region_name: str, payload: Any, **kwds: Any
 ):
     try:
-        provision_payload = OrganizationProvisioningOptions.parse_obj(payload)
+        provision_payload = OrganizationProvisioningOptions.model_validate(payload)
     except ValidationError as e:
         # The provisioning payload is likely malformed and cannot be processed.
         capture_exception(e)

--- a/src/sentry/tasks/relocation.py
+++ b/src/sentry/tasks/relocation.py
@@ -375,7 +375,7 @@ def fulfill_cross_region_export_request(
             requesting_region_name=requesting_region_name,
             replying_region_name=replying_region_name,
             org_slug=org_slug,
-        ).dict(),
+        ).model_dump(),
     ).save()
 
 

--- a/src/sentry/types/region.py
+++ b/src/sentry/types/region.py
@@ -156,13 +156,13 @@ def _parse_raw_config(region_config: Any) -> Iterable[Region]:
         config_values = region_config
 
     if not isinstance(config_values, (list, tuple)):
-        config_values = [config_values]  # type: ignore[unreachable]
+        config_values = [config_values]
 
     for config_value in config_values:
         if isinstance(config_value, Region):
             yield config_value
         else:
-            category = config_value["category"]  # type: ignore[unreachable]
+            category = config_value["category"]
             config_value["category"] = (
                 category if isinstance(category, RegionCategory) else RegionCategory[category]
             )

--- a/src/sentry/types/region.py
+++ b/src/sentry/types/region.py
@@ -8,8 +8,8 @@ from urllib.parse import urljoin
 import sentry_sdk
 from django.conf import settings
 from django.http import HttpRequest
+from pydantic import TypeAdapter
 from pydantic.dataclasses import dataclass
-from pydantic.tools import parse_obj_as
 
 from sentry import options
 from sentry.silo.base import SiloMode, SingleProcessSiloModeState, control_silo_function
@@ -151,7 +151,8 @@ class RegionDirectory:
 def _parse_raw_config(region_config: Any) -> Iterable[Region]:
     if isinstance(region_config, (str, bytes)):
         json_config_values = json.loads(region_config)
-        config_values = parse_obj_as(list[Region], json_config_values)
+        adapter = TypeAdapter(list[Region])
+        config_values = adapter.validate_python(json_config_values)
     else:
         config_values = region_config
 

--- a/src/sentry/users/services/lost_password_hash/model.py
+++ b/src/sentry/users/services/lost_password_hash/model.py
@@ -3,7 +3,10 @@
 # in modules such as this one where hybrid cloud data models or service classes are
 # defined, because we want to reflect on type annotations and avoid forward references.
 
-import datetime
+from datetime import datetime
+
+from django.utils import timezone
+from pydantic import Field
 
 from sentry.hybridcloud.rpc import RpcModel
 from sentry.models.lostpasswordhash import LostPasswordHash
@@ -13,7 +16,7 @@ class RpcLostPasswordHash(RpcModel):
     id: int = -1
     user_id: int = -1
     hash: str = ""
-    date_added = datetime.datetime
+    date_added: datetime = Field(default_factory=timezone.now)
 
     def get_absolute_url(self, mode: str = "recover") -> str:
         return LostPasswordHash.get_lostpassword_url(self.user_id, self.hash, mode)

--- a/src/sentry/users/services/user/model.py
+++ b/src/sentry/users/services/user/model.py
@@ -79,7 +79,7 @@ class RpcUser(RpcUserProfile):
     def by_email(self, email: str) -> "RpcUser":
         if email == self.email:
             return self
-        return self.copy(update=dict(email=email))
+        return self.model_copy(update=dict(email=email))
 
     def has_unverified_emails(self) -> bool:
         return len(self.get_unverified_emails()) > 0

--- a/src/sentry/users/services/user/serial.py
+++ b/src/sentry/users/services/user/serial.py
@@ -36,7 +36,7 @@ def serialize_generic_user(user: Any) -> RpcUser | None:
 def _serialize_from_user_fields(user: User) -> dict[str, Any]:
     args = {
         field_name: getattr(user, field_name)
-        for field_name in RpcUserProfile.__fields__
+        for field_name in RpcUserProfile.model_fields
         if hasattr(user, field_name)
     }
     args["pk"] = user.pk

--- a/src/social_auth/utils.py
+++ b/src/social_auth/utils.py
@@ -100,7 +100,7 @@ def model_to_ctype(val):
     if isinstance(val, Model):
         return {"pk": val.pk, "ctype": ContentType.objects.get_for_model(val).pk}
     if isinstance(val, RpcModel):
-        return val.dict()
+        return val.model_dump()
     return val
 
 
@@ -113,7 +113,7 @@ def ctype_to_model(val):
         return ModelClass.objects.get(pk=val["pk"])
 
     if isinstance(val, dict) and "username" in val and "name" in val:
-        return RpcUser.parse_obj(val)
+        return RpcUser.model_validate(val)
     return val
 
 

--- a/tests/flagpole/test_conditions.py
+++ b/tests/flagpole/test_conditions.py
@@ -38,7 +38,7 @@ def assert_valid_types(condition: type[ConditionBase], expected_types: list[Any]
         condition_dict = dict(property="test", value=value)
         json_condition = json.dumps(condition_dict)
         try:
-            parsed_condition = condition.parse_raw(json_condition)
+            parsed_condition = condition.model_validate_json(json_condition)
         except ValidationError as exc:
             raise AssertionError(
                 f"Expected value `{value}` to be a valid value for condition '{condition}'"
@@ -51,7 +51,7 @@ def assert_invalid_types(condition: type[ConditionBase], invalid_types: list[Any
         json_dict = dict(value=value)
         condition_json = json.dumps(json_dict)
         try:
-            condition.parse_raw(condition_json)
+            condition.model_validate_json(condition_json)
         except ValidationError:
             continue
 

--- a/tests/flagpole/test_feature.py
+++ b/tests/flagpole/test_feature.py
@@ -229,7 +229,7 @@ class TestParseFeatureConfig:
             """,
         )
 
-        parsed_json = orjson.loads(feature.json())
+        parsed_json = orjson.loads(feature.model_dump_json())
         parsed_yaml = dict(yaml.safe_load(feature.to_yaml_str()))
         assert "foo" in parsed_yaml
         parsed_json.pop("name")

--- a/tests/sentry/api/endpoints/test_event_ai_suggested_fix.py
+++ b/tests/sentry/api/endpoints/test_event_ai_suggested_fix.py
@@ -34,7 +34,7 @@ def openai_mock(monkeypatch):
                     finish_reason="stop",
                 )
             ],
-            created=time.time(),
+            created=int(time.time()),
             model="gpt3.5-trubo",
             object="chat.completion",
         )

--- a/tests/sentry/api/endpoints/test_rpc.py
+++ b/tests/sentry/api/endpoints/test_rpc.py
@@ -122,7 +122,7 @@ class RpcServiceEndpointTest(APITestCase):
         assert response.data
         assert "meta" in response.data
 
-        response_obj = RpcUserOrganizationContext.parse_obj(response.data["value"])
+        response_obj = RpcUserOrganizationContext.model_validate(response.data["value"])
         assert response_obj.organization.id == organization.id
         assert response_obj.organization.slug == organization.slug
         assert response_obj.organization.name == organization.name

--- a/tests/sentry/feedback/usecases/test_create_feedback.py
+++ b/tests/sentry/feedback/usecases/test_create_feedback.py
@@ -64,7 +64,7 @@ def create_dummy_response(*args, **kwargs):
                 finish_reason="stop",
             )
         ],
-        created=time.time(),
+        created=int(time.time()),
         model="gpt3.5-trubo",
         object="chat.completion",
     )

--- a/tests/sentry/hybridcloud/rpc/test_rpc_model.py
+++ b/tests/sentry/hybridcloud/rpc/test_rpc_model.py
@@ -12,7 +12,7 @@ class RpcModelTest(TestCase):
     def test_schema_generation(self) -> None:
         for api_type in self._get_rpc_model_subclasses():
             # We're mostly interested in whether an error occurs
-            schema = api_type.schema_json()
+            schema = api_type.model_json_schema()
             assert schema
 
     def _get_rpc_model_subclasses(self) -> set[type[RpcModel]]:

--- a/tests/sentry/hybridcloud/test_organizationmembermapping.py
+++ b/tests/sentry/hybridcloud/test_organizationmembermapping.py
@@ -66,7 +66,7 @@ class OrganizationMappingTest(TransactionTestCase, HybridCloudTestMixin):
         rpc_orgmember_mapping = organizationmember_mapping_service.upsert_mapping(
             organization_id=self.organization.id,
             organizationmember_id=111111,
-            mapping=RpcOrganizationMemberMappingUpdate.from_orm(om),
+            mapping=RpcOrganizationMemberMappingUpdate.model_validate(om),
         )
 
         assert rpc_orgmember_mapping is not None
@@ -80,7 +80,7 @@ class OrganizationMappingTest(TransactionTestCase, HybridCloudTestMixin):
         rpc_orgmember_mapping = organizationmember_mapping_service.upsert_mapping(
             organization_id=self.organization.id,
             organizationmember_id=111111,
-            mapping=RpcOrganizationMemberMappingUpdate.from_orm(om),
+            mapping=RpcOrganizationMemberMappingUpdate.model_validate(om),
         )
 
         assert rpc_orgmember_mapping is not None

--- a/tests/sentry/hybridcloud/test_rpc.py
+++ b/tests/sentry/hybridcloud/test_rpc.py
@@ -104,7 +104,7 @@ class RpcServiceTest(TestCase):
             organization_id=serial_org.id,
             default_org_role=serial_org.default_role,
             user_id=user.id,
-            flags=RpcOrganizationMemberFlags().dict(),
+            flags=RpcOrganizationMemberFlags().model_dump(),
             role=None,
         )
 
@@ -155,7 +155,9 @@ class DispatchRemoteCallTest(TestCase):
         org = self.create_organization()
 
         response_value = RpcUserOrganizationContext(organization=serialize_rpc_organization(org))
-        self._set_up_mock_response("organization/get_organization_by_id", response_value.dict())
+        self._set_up_mock_response(
+            "organization/get_organization_by_id", response_value.model_dump()
+        )
 
         result = dispatch_remote_call(
             None, "organization", "get_organization_by_id", {"id": org.id}
@@ -177,7 +179,7 @@ class DispatchRemoteCallTest(TestCase):
         user = self.create_user()
         serial = serialize_rpc_user(user)
         self._set_up_mock_response(
-            "user/get_first_superuser", serial.dict(), address="http://na.sentry.io"
+            "user/get_first_superuser", serial.model_dump(), address="http://na.sentry.io"
         )
 
         result = dispatch_remote_call(_REGIONS[0], "user", "get_first_superuser", {})
@@ -189,7 +191,7 @@ class DispatchRemoteCallTest(TestCase):
     def test_region_to_control_with_list_result(self) -> None:
         users = [self.create_user() for _ in range(3)]
         serial = [serialize_rpc_user(user) for user in users]
-        self._set_up_mock_response("user/get_many", [m.dict() for m in serial])
+        self._set_up_mock_response("user/get_many", [m.model_dump() for m in serial])
 
         result = dispatch_remote_call(None, "user", "get_many", {"filter": {}})
         assert result == serial

--- a/tests/sentry/test_dependencies.py
+++ b/tests/sentry/test_dependencies.py
@@ -1,8 +1,0 @@
-import pydantic
-
-
-def test_pydantic_1x_compiled() -> None:
-    if not pydantic.VERSION.startswith("1."):
-        raise AssertionError("delete this test, it only applies to pydantic 1.x")
-    # pydantic is horribly slow when not cythonized
-    assert pydantic.__file__.endswith(".so")

--- a/tests/social_auth/test_utils.py
+++ b/tests/social_auth/test_utils.py
@@ -21,7 +21,7 @@ class TestSocialAuthUtils(TestCase):
 
         rpc_user = serialize_rpc_user(user)
         val = model_to_ctype(rpc_user)
-        assert val == rpc_user.dict()
+        assert val == rpc_user.model_dump()
 
     def test_ctype_to_model(self):
         val = ctype_to_model(1)
@@ -35,4 +35,4 @@ class TestSocialAuthUtils(TestCase):
         assert ctype_to_model(ctype_val) == user
 
         rpc_user = serialize_rpc_user(user)
-        assert ctype_to_model(rpc_user.dict()) == rpc_user
+        assert ctype_to_model(rpc_user.model_dump()) == rpc_user


### PR DESCRIPTION
Continuation of #74246:
Updates Pydantic to v2.5 as per dependabot's suggestion. This also replaces a number of now deprecated calls on our pydantic models. Mainly using this to check for CI runs for now, but I'll update this branch once I conclude my local testing + rebase once the parent branch merges.

## Summary of Deprecated Calls:
- `dict` -> `model_dump`
- `json` -> `model_dump_json`
- `parse_obj` -> `model_validate`
- `from_orm` -> `model_validate`

## Deprecated Features:
- `Config` class for configuration has been replaced by a class attribute named `model_config: pydantic.ConfigDict`
- Automatic coercion of numbers -> strings has been defaulted to False, but is configurable
