### PR TITLE
ref(devtoolbar): move code from getsentry

### DIFF
--- a/static/app/components/devtoolbar/README.md
+++ b/static/app/components/devtoolbar/README.md
@@ -2,10 +2,10 @@
 
 This folder contains a PoC for what a Dev Toolbar product would look like and what features it could have.
 
-This is not production ready. Only sentry employees should be able to see this code, while they're on sentry.io. In order for this to be production-ready for customers to install on their own website it would need to be bundled similar to the SDK or Spotlight. There are many steps remaining to get there.
+This is not production ready. Only Sentry employees should be able to see this code, while they're on sentry.io or running a development environment. In order for this to be production-ready for customers to install on their own website, it would need to be bundled similar to the SDK or Spotlight. There are many steps remaining to get there.
 
-Therefore, this is built with maximum portability in mind. It is a goal for this to have as few dependencies on sentry & getsentry as possible to make the majority of the code easy to port into a different repo when/if the PoC is successful. However, some code will not be portable, which is why we're leveraging getsentry to host the PoC. For example:
+Therefore, this is built with maximum portability in mind. It is a goal for this to have as few dependencies on sentry/getsentry as possible to make the majority of the code easy to port into a different repo when/if the PoC is successful. However, some code will not be portable, which is why we're leveraging sentry to host the PoC. For example:
 
-- The API calls themselves are not portable. We're using sentry & getsentry to explicitly avoid solving the API-Auth problem right now.
+- The API calls themselves are not portable. We're using sentry/getsentry to explicitly avoid solving the API-Auth problem right now.
 - Logo assets will need to be copied over, or inserted into platformicons
 - Any complex CSS that cannot be inlined. This folder prefers to use inline `style={}` attributes which gives us maximum flexibility to choose a style library when this is extracted. `styled()` calls are used sparingly.

--- a/static/app/components/devtoolbar/README.md
+++ b/static/app/components/devtoolbar/README.md
@@ -1,0 +1,11 @@
+# Dev Toolbar
+
+This folder contains a PoC for what a Dev Toolbar product would look like and what features it could have.
+
+This is not production ready. Only sentry employees should be able to see this code, while they're on sentry.io. In order for this to be production-ready for customers to install on their own website it would need to be bundled similar to the SDK or Spotlight. There are many steps remaining to get there.
+
+Therefore, this is built with maximum portability in mind. It is a goal for this to have as few dependencies on sentry & getsentry as possible to make the majority of the code easy to port into a different repo when/if the PoC is successful. However, some code will not be portable, which is why we're leveraging getsentry to host the PoC. For example:
+
+- The API calls themselves are not portable. We're using sentry & getsentry to explicitly avoid solving the API-Auth problem right now.
+- Logo assets will need to be copied over, or inserted into platformicons
+- Any complex CSS that cannot be inlined. This folder prefers to use inline `style={}` attributes which gives us maximum flexibility to choose a style library when this is extracted. `styled()` calls are used sparingly.

--- a/static/app/components/devtoolbar/components/app.tsx
+++ b/static/app/components/devtoolbar/components/app.tsx
@@ -1,0 +1,50 @@
+import {Fragment, Suspense} from 'react';
+import {Global} from '@emotion/react';
+
+import LoadingTriangle from 'sentry/components/loadingTriangle';
+import {useSessionStorage} from 'sentry/utils/useSessionStorage';
+
+import usePlacementCss from '../hooks/usePlacementCss';
+import {fixedContainerBaseCss} from '../styles/fixedContainer';
+import {avatarCss, globalCss, loadingIndicatorCss} from '../styles/global';
+import {resetFlexColumnCss} from '../styles/reset';
+
+import Navigation from './navigation';
+import PanelLayout from './panelLayout';
+import PanelRouter from './panelRouter';
+
+export default function App() {
+  const placement = usePlacementCss();
+  const [isHidden, setIsHidden] = useSessionStorage('hide_employee_devtoolbar', false);
+  if (isHidden) {
+    return null;
+  }
+
+  return (
+    <Fragment>
+      <Global styles={globalCss} />
+      <Global styles={loadingIndicatorCss} />
+      <Global styles={avatarCss} />
+      <div css={[fixedContainerBaseCss, placement.fixedContainer.css]}>
+        {isHidden ? null : (
+          <Fragment>
+            <Navigation setIsHidden={setIsHidden} />
+            <Suspense fallback={<LoadingPanel />}>
+              <PanelRouter />
+            </Suspense>
+          </Fragment>
+        )}
+      </div>
+    </Fragment>
+  );
+}
+
+function LoadingPanel() {
+  return (
+    <PanelLayout title="">
+      <div css={resetFlexColumnCss} style={{overflow: 'hidden', contain: 'strict'}}>
+        <LoadingTriangle />
+      </div>
+    </PanelLayout>
+  );
+}

--- a/static/app/components/devtoolbar/components/feedback/feedbackPanel.tsx
+++ b/static/app/components/devtoolbar/components/feedback/feedbackPanel.tsx
@@ -1,0 +1,197 @@
+import {useMemo} from 'react';
+import {css} from '@emotion/react';
+
+import ActorAvatar from 'sentry/components/avatar/actorAvatar';
+import ProjectBadge from 'sentry/components/idBadge/projectBadge';
+import Placeholder from 'sentry/components/placeholder';
+import TextOverflow from 'sentry/components/textOverflow';
+import TimeSince from 'sentry/components/timeSince';
+import {IconAdd, IconChat, IconFatal, IconImage, IconPlay} from 'sentry/icons';
+import useReplayCount from 'sentry/utils/replayCount/useReplayCount';
+
+import useConfiguration from '../../hooks/useConfiguration';
+import useCurrentTransactionName from '../../hooks/useCurrentTransactionName';
+import {useSDKFeedbackButton} from '../../hooks/useSDKFeedbackButton';
+import {
+  badgeWithLabelCss,
+  gridFlexEndCss,
+  listItemGridCss,
+  listItemPlaceholderWrapperCss,
+} from '../../styles/listItem';
+import {
+  panelHeadingRightCss,
+  panelInsetContentCss,
+  panelSectionCss,
+} from '../../styles/panel';
+import {resetButtonCss, resetFlexColumnCss} from '../../styles/reset';
+import {smallCss, textOverflowTwoLinesCss, xSmallCss} from '../../styles/typography';
+import type {FeedbackIssueListItem} from '../../types';
+import InfiniteListItems from '../infiniteListItems';
+import InfiniteListState from '../infiniteListState';
+import PanelLayout from '../panelLayout';
+import SentryAppLink from '../sentryAppLink';
+
+import useInfiniteFeedbackList from './useInfiniteFeedbackList';
+
+export default function FeedbackPanel() {
+  const buttonRef = useSDKFeedbackButton();
+  const transactionName = useCurrentTransactionName();
+  const queryResult = useInfiniteFeedbackList({
+    query: `url:*${transactionName}`,
+  });
+
+  const estimateSize = 108;
+  const placeholderHeight = `${estimateSize - 8}px`; // The real height of the items, minus the padding-block value
+
+  return (
+    <PanelLayout
+      title="User Feedback"
+      titleRight={
+        buttonRef ? (
+          <button
+            aria-label="Submit Feedback"
+            css={[resetButtonCss, panelHeadingRightCss]}
+            ref={buttonRef}
+            title="Submit Feedback"
+          >
+            <IconAdd size="xs" />
+          </button>
+        ) : null
+      }
+    >
+      <div css={[smallCss, panelSectionCss, panelInsetContentCss]}>
+        <span>
+          Unresolved feedback related to <code>{transactionName}</code>
+        </span>
+      </div>
+
+      <div css={resetFlexColumnCss}>
+        <InfiniteListState
+          queryResult={queryResult}
+          backgroundUpdatingMessage={() => null}
+          loadingMessage={() => (
+            <div
+              css={[
+                resetFlexColumnCss,
+                panelSectionCss,
+                panelInsetContentCss,
+                listItemPlaceholderWrapperCss,
+              ]}
+            >
+              <Placeholder height={placeholderHeight} />
+              <Placeholder height={placeholderHeight} />
+              <Placeholder height={placeholderHeight} />
+              <Placeholder height={placeholderHeight} />
+            </div>
+          )}
+        >
+          <InfiniteListItems
+            estimateSize={() => estimateSize}
+            queryResult={queryResult}
+            itemRenderer={props => <FeedbackListItem {...props} />}
+            emptyMessage={() => <p css={panelInsetContentCss}>No items to show</p>}
+          />
+        </InfiniteListState>
+      </div>
+    </PanelLayout>
+  );
+}
+
+function FeedbackListItem({item}: {item: FeedbackIssueListItem}) {
+  const {projectSlug, projectId, trackAnalytics} = useConfiguration();
+  const {feedbackHasReplay} = useReplayCountForFeedbacks();
+
+  const hasReplayId = feedbackHasReplay(item.id);
+  const isFatal = ['crash_report_embed_form', 'user_report_envelope'].includes(
+    item.metadata.source ?? ''
+  );
+  const hasAttachments = item.latestEventHasAttachments;
+  const hasComments = item.numComments > 0;
+
+  return (
+    <div css={listItemGridCss}>
+      <TextOverflow css={smallCss} style={{gridArea: 'name'}}>
+        <SentryAppLink
+          to={{
+            url: '/feedback/',
+            query: {project: projectId, feedbackSlug: `${projectSlug}:${item.id}`},
+          }}
+          onClick={() => {
+            trackAnalytics?.({
+              eventKey: `devtoolbar.feedback-list.item.click`,
+              eventName: `devtoolbar: Click feedback-list item`,
+            });
+          }}
+        >
+          <strong>
+            {item.metadata.name ?? item.metadata.contact_email ?? 'Anonymous User'}
+          </strong>
+        </SentryAppLink>
+      </TextOverflow>
+
+      <div
+        css={[gridFlexEndCss, xSmallCss]}
+        style={{gridArea: 'time', color: 'var(--gray300)'}}
+      >
+        <TimeSince date={item.firstSeen} unitStyle="extraShort" />
+      </div>
+
+      <div style={{gridArea: 'message'}}>
+        <TextOverflow css={[smallCss, textOverflowTwoLinesCss]}>
+          {item.metadata.message}
+        </TextOverflow>
+      </div>
+
+      <div css={[badgeWithLabelCss, xSmallCss]} style={{gridArea: 'project'}}>
+        <ProjectBadge
+          css={css({'&& img': {boxShadow: 'none'}})}
+          project={item.project}
+          avatarSize={16}
+          hideName
+          avatarProps={{hasTooltip: false}}
+        />
+        <TextOverflow>{item.shortId}</TextOverflow>
+      </div>
+
+      <div css={gridFlexEndCss} style={{gridArea: 'icons'}}>
+        {/* IssueTrackingSignals could have some refactoring so it doesn't
+            depend on useOrganization, and so the filenames match up better with
+            the exported functions */}
+        {/* <IssueTrackingSignals group={item as unknown as Group} /> */}
+
+        {hasComments ? <IconChat size="sm" /> : null}
+        {isFatal ? <IconFatal size="xs" color="red400" /> : null}
+        {hasReplayId ? <IconPlay size="xs" /> : null}
+        {hasAttachments ? <IconImage size="xs" /> : null}
+        {item.assignedTo ? (
+          <ActorAvatar
+            actor={item.assignedTo}
+            size={16}
+            tooltipOptions={{containerDisplayMode: 'flex'}}
+          />
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+// Copied from sentry, but we're passing in a fake `organization` object here.
+// TODO: refactor useReplayCountForFeedbacks to accept an org param
+function useReplayCountForFeedbacks() {
+  const {organizationSlug} = useConfiguration();
+  const {hasOne, hasMany} = useReplayCount({
+    bufferLimit: 25,
+    dataSource: 'search_issues',
+    fieldName: 'issue.id',
+    organization: {slug: organizationSlug} as any,
+    statsPeriod: '90d',
+  });
+
+  return useMemo(
+    () => ({
+      feedbackHasReplay: hasOne,
+      feedbacksHaveReplay: hasMany,
+    }),
+    [hasMany, hasOne]
+  );
+}

--- a/static/app/components/devtoolbar/components/feedback/useInfiniteFeedbackList.tsx
+++ b/static/app/components/devtoolbar/components/feedback/useInfiniteFeedbackList.tsx
@@ -1,0 +1,46 @@
+import {useMemo} from 'react';
+
+import useConfiguration from '../../hooks/useConfiguration';
+import useInfiniteApiData from '../../hooks/useInfiniteApiData';
+import type {FeedbackIssueListItem} from '../../types';
+
+interface Props {
+  query: string;
+}
+
+export default function useInfiniteFeedbackList({query}: Props) {
+  const {environment, organizationSlug, projectId} = useConfiguration();
+  const mailbox = 'unresolved';
+
+  return useInfiniteApiData<FeedbackIssueListItem[]>({
+    queryKey: useMemo(
+      () => [
+        `/organizations/${organizationSlug}/issues/`,
+        {
+          query: {
+            limit: 25,
+            queryReferrer: 'devtoolbar',
+            environment: Array.isArray(environment) ? environment : [environment],
+            project: projectId,
+            statsPeriod: '14d',
+            mailbox,
+
+            collapse: ['inbox'],
+            expand: [
+              'owners', // Gives us assignment
+              'stats', // Gives us `firstSeen`
+              // 'pluginActions', // Gives us plugin actions available
+              // 'pluginIssues', // Gives us plugin issues available
+              // 'integrationIssues', // Gives us integration issues available
+              // 'sentryAppIssues', // Gives us Sentry app issues available
+              'latestEventHasAttachments', // Gives us whether the feedback has screenshots
+            ],
+            shortIdLookup: 0,
+            query: `issue.category:feedback status:${mailbox} ${query}`,
+          },
+        },
+      ],
+      [environment, mailbox, organizationSlug, projectId, query]
+    ),
+  });
+}

--- a/static/app/components/devtoolbar/components/infiniteListItems.tsx
+++ b/static/app/components/devtoolbar/components/infiniteListItems.tsx
@@ -1,0 +1,106 @@
+import {useEffect, useRef} from 'react';
+import type {UseInfiniteQueryResult} from '@tanstack/react-query';
+import {useVirtualizer} from '@tanstack/react-virtual';
+
+import LoadingIndicator from 'sentry/components/loadingIndicator';
+
+import {
+  infiniteListFloatingMessageBottomCss,
+  infiniteListParentContainerCss,
+  infiniteListScollablePanelCss,
+  infiniteListScrollableWindowCss,
+} from '../styles/infiniteList';
+import type {ApiResult} from '../types';
+
+interface Props<Data> {
+  itemRenderer: ({item}: {item: Data}) => React.ReactNode;
+  queryResult: UseInfiniteQueryResult<ApiResult<Data[]>, Error>;
+  emptyMessage?: () => React.ReactNode;
+  estimateSize?: () => number;
+  loadingCompleteMessage?: () => React.ReactNode;
+  loadingMoreMessage?: () => React.ReactNode;
+  overscan?: number;
+}
+
+export default function InfiniteListItems<Data>({
+  estimateSize,
+  itemRenderer,
+  emptyMessage = EmptyMessage,
+  loadingCompleteMessage = LoadingCompleteMessage,
+  loadingMoreMessage = LoadingMoreMessage,
+  overscan,
+  queryResult,
+}: Props<Data>) {
+  const {data, hasNextPage, isFetchingNextPage, fetchNextPage} = queryResult;
+  const loadedRows = data ? data.pages.flatMap(d => d.json) : [];
+  const parentRef = useRef<HTMLDivElement>(null);
+
+  const rowVirtualizer = useVirtualizer({
+    count: hasNextPage ? loadedRows.length + 1 : loadedRows.length,
+    getScrollElement: () => parentRef.current,
+    estimateSize: estimateSize ?? (() => 100),
+    overscan: overscan ?? 5,
+  });
+  const items = rowVirtualizer.getVirtualItems();
+
+  useEffect(() => {
+    const lastItem = items.at(-1);
+    if (!lastItem) {
+      return;
+    }
+
+    if (lastItem.index >= loadedRows.length - 1 && hasNextPage && !isFetchingNextPage) {
+      fetchNextPage();
+    }
+  }, [hasNextPage, fetchNextPage, loadedRows.length, isFetchingNextPage, items]);
+
+  return (
+    <div ref={parentRef} css={infiniteListParentContainerCss}>
+      <div
+        css={infiniteListScollablePanelCss}
+        style={{height: rowVirtualizer.getTotalSize()}}
+      >
+        <ul
+          css={infiniteListScrollableWindowCss}
+          style={{transform: `translateY(${items[0]?.start ?? 0}px)`}}
+        >
+          {items.length ? null : emptyMessage()}
+          {items.map(virtualRow => {
+            const isLoaderRow = virtualRow.index > loadedRows.length - 1;
+            const item = loadedRows[virtualRow.index];
+
+            return (
+              <li
+                data-index={virtualRow.index}
+                key={virtualRow.index}
+                ref={rowVirtualizer.measureElement}
+              >
+                {isLoaderRow
+                  ? hasNextPage
+                    ? loadingMoreMessage()
+                    : loadingCompleteMessage()
+                  : itemRenderer({item})}
+              </li>
+            );
+          })}
+        </ul>
+      </div>
+    </div>
+  );
+}
+
+function EmptyMessage() {
+  return <p>No items to show</p>;
+}
+
+function LoadingMoreMessage() {
+  return (
+    <footer css={infiniteListFloatingMessageBottomCss} title="Loading more items...">
+      <LoadingIndicator mini />
+    </footer>
+  );
+}
+
+function LoadingCompleteMessage() {
+  return <p>Nothing more to load</p>;
+}

--- a/static/app/components/devtoolbar/components/infiniteListState.tsx
+++ b/static/app/components/devtoolbar/components/infiniteListState.tsx
@@ -1,0 +1,56 @@
+import {Fragment} from 'react';
+import type {UseInfiniteQueryResult, UseQueryResult} from '@tanstack/react-query';
+
+import type {ApiResult} from '../types';
+
+export interface Props<Data> {
+  children: React.ReactNode;
+  queryResult:
+    | UseQueryResult<ApiResult<Data>, Error>
+    | UseInfiniteQueryResult<ApiResult<Data[]>, Error>;
+  backgroundUpdatingMessage?: () => React.ReactNode;
+  errorMessage?: (props: {error: Error}) => React.ReactNode;
+  loadingMessage?: () => React.ReactNode;
+}
+
+export default function InfiniteListState<Data>({
+  backgroundUpdatingMessage = BackgroundUpdatingMessage,
+  children,
+  errorMessage = ErrorMessage,
+  loadingMessage = LoadingMessage,
+  queryResult,
+}: Props<Data>) {
+  const {status, error, isFetching} = queryResult;
+  if (status === 'loading') {
+    return loadingMessage();
+  }
+  if (status === 'error') {
+    return errorMessage({error: error as Error});
+  }
+
+  // It's fetching in the background if:
+  // - it's a regular QueryResult, and isFetching is true
+  // - it's an InfiniteQueryResult, and itFetching is true, but we're not fetching the next page
+  const isBackgroundUpdating =
+    isFetching &&
+    ('isFetchingNextPage' in queryResult ? !queryResult.isFetchingNextPage : true);
+
+  return (
+    <Fragment>
+      {children}
+      {isBackgroundUpdating ? backgroundUpdatingMessage() : null}
+    </Fragment>
+  );
+}
+
+function LoadingMessage() {
+  return <p>Loading...</p>;
+}
+
+function ErrorMessage({error}: {error: Error}) {
+  return <p>Error: {(error as Error).message}</p>;
+}
+
+function BackgroundUpdatingMessage() {
+  return <footer>Background Updating...</footer>;
+}

--- a/static/app/components/devtoolbar/components/issues/issuesPanel.tsx
+++ b/static/app/components/devtoolbar/components/issues/issuesPanel.tsx
@@ -1,0 +1,145 @@
+import {css} from '@emotion/react';
+
+import ActorAvatar from 'sentry/components/avatar/actorAvatar';
+import TimesTag from 'sentry/components/group/inboxBadges/timesTag';
+import ProjectBadge from 'sentry/components/idBadge/projectBadge';
+import Placeholder from 'sentry/components/placeholder';
+import TextOverflow from 'sentry/components/textOverflow';
+import TimeSince from 'sentry/components/timeSince';
+import type {Group} from 'sentry/types/group';
+
+import useConfiguration from '../../hooks/useConfiguration';
+import useCurrentTransactionName from '../../hooks/useCurrentTransactionName';
+import {
+  badgeWithLabelCss,
+  gridFlexEndCss,
+  listItemGridCss,
+  listItemPlaceholderWrapperCss,
+} from '../../styles/listItem';
+import {panelInsetContentCss, panelSectionCss} from '../../styles/panel';
+import {resetFlexColumnCss} from '../../styles/reset';
+import {smallCss, xSmallCss} from '../../styles/typography';
+import InfiniteListItems from '../infiniteListItems';
+import InfiniteListState from '../infiniteListState';
+import PanelLayout from '../panelLayout';
+import SentryAppLink from '../sentryAppLink';
+
+import useInfiniteIssuesList from './useInfiniteIssuesList';
+
+export default function FeedbackPanel() {
+  const transactionName = useCurrentTransactionName();
+  const queryResult = useInfiniteIssuesList({
+    query: `url:*${transactionName}`,
+  });
+
+  const estimateSize = 108;
+  const placeholderHeight = `${estimateSize - 8}px`; // The real height of the items, minus the padding-block value
+
+  return (
+    <PanelLayout title="Issues">
+      <div css={[smallCss, panelSectionCss, panelInsetContentCss]}>
+        <span>
+          Unresolved issues related to <code>{transactionName}</code>
+        </span>
+      </div>
+
+      <div css={resetFlexColumnCss}>
+        <InfiniteListState
+          queryResult={queryResult}
+          backgroundUpdatingMessage={() => null}
+          loadingMessage={() => (
+            <div
+              css={[
+                resetFlexColumnCss,
+                panelSectionCss,
+                panelInsetContentCss,
+                listItemPlaceholderWrapperCss,
+              ]}
+            >
+              <Placeholder height={placeholderHeight} />
+              <Placeholder height={placeholderHeight} />
+              <Placeholder height={placeholderHeight} />
+              <Placeholder height={placeholderHeight} />
+            </div>
+          )}
+        >
+          <InfiniteListItems
+            estimateSize={() => estimateSize}
+            queryResult={queryResult}
+            itemRenderer={props => <IssueListItem {...props} />}
+            emptyMessage={() => <p css={panelInsetContentCss}>No items to show</p>}
+          />
+        </InfiniteListState>
+      </div>
+    </PanelLayout>
+  );
+}
+
+function IssueListItem({item}: {item: Group}) {
+  const {projectSlug, projectId, trackAnalytics} = useConfiguration();
+
+  return (
+    <div css={listItemGridCss}>
+      <TextOverflow
+        css={[badgeWithLabelCss, smallCss]}
+        style={{gridArea: 'name', fontWeight: item.hasSeen ? 'bold' : 400}}
+      >
+        <SentryAppLink
+          to={{
+            url: `/issues/${item.id}/`,
+            query: {project: projectId, feedbackSlug: `${projectSlug}:${item.id}`},
+          }}
+          onClick={() => {
+            trackAnalytics?.({
+              eventKey: `devtoolbar.issue-list.item.click`,
+              eventName: `devtoolbar: Click issue-list item`,
+            });
+          }}
+        >
+          <strong>{item.metadata.type ?? '<unknown>'}</strong>
+        </SentryAppLink>
+      </TextOverflow>
+
+      <div
+        css={[gridFlexEndCss, xSmallCss]}
+        style={{gridArea: 'time', color: 'var(--gray300)'}}
+      >
+        <TimeSince date={item.firstSeen} unitStyle="extraShort" />
+      </div>
+
+      <div style={{gridArea: 'message'}}>
+        <TextOverflow css={[smallCss]}>{item.metadata.value}</TextOverflow>
+      </div>
+
+      <div css={[badgeWithLabelCss, xSmallCss]} style={{gridArea: 'project'}}>
+        <ProjectBadge
+          css={css({'&& img': {boxShadow: 'none'}})}
+          project={item.project}
+          avatarSize={16}
+          hideName
+          avatarProps={{hasTooltip: false}}
+        />
+        <TextOverflow>{item.shortId}</TextOverflow>
+      </div>
+
+      <div css={gridFlexEndCss} style={{gridArea: 'icons'}}>
+        {item.lifetime || item.firstSeen || item.lastSeen ? (
+          <div className="flex-row">
+            <TimesTag
+              lastSeen={item.lifetime?.lastSeen || item.lastSeen}
+              firstSeen={item.lifetime?.firstSeen || item.firstSeen}
+            />
+          </div>
+        ) : null}
+
+        {item.assignedTo ? (
+          <ActorAvatar
+            actor={item.assignedTo}
+            size={16}
+            tooltipOptions={{containerDisplayMode: 'flex'}}
+          />
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/static/app/components/devtoolbar/components/issues/useInfiniteIssuesList.tsx
+++ b/static/app/components/devtoolbar/components/issues/useInfiniteIssuesList.tsx
@@ -1,0 +1,47 @@
+import {useMemo} from 'react';
+
+import type {Group} from 'sentry/types/group';
+import {IssueCategory} from 'sentry/types/group';
+
+import useConfiguration from '../../hooks/useConfiguration';
+import useInfiniteApiData from '../../hooks/useInfiniteApiData';
+
+interface Props {
+  query: string;
+}
+
+export default function useInfiniteIssuesList({query}: Props) {
+  const {environment, organizationSlug, projectId} = useConfiguration();
+  const mailbox = 'unresolved';
+
+  return useInfiniteApiData<Group[]>({
+    queryKey: useMemo(
+      () => [
+        `/organizations/${organizationSlug}/issues/`,
+        {
+          query: {
+            limit: 25,
+            queryReferrer: 'devtoolbar',
+            environment: Array.isArray(environment) ? environment : [environment],
+            project: projectId,
+            statsPeriod: '14d',
+
+            collapse: ['inbox'],
+            expand: [
+              'owners', // Gives us assignment
+              'stats', // Gives us `firstSeen`
+              // 'pluginActions', // Gives us plugin actions available
+              // 'pluginIssues', // Gives us plugin issues available
+              // 'integrationIssues', // Gives us integration issues available
+              // 'sentryAppIssues', // Gives us Sentry app issues available
+              // 'latestEventHasAttachments', // Gives us whether the feedback has screenshots
+            ],
+            shortIdLookup: 0,
+            query: `issue.category:[${IssueCategory.ERROR},${IssueCategory.PERFORMANCE}] status:${mailbox} ${query}`,
+          },
+        },
+      ],
+      [environment, mailbox, organizationSlug, projectId, query]
+    ),
+  });
+}

--- a/static/app/components/devtoolbar/components/navigation.tsx
+++ b/static/app/components/devtoolbar/components/navigation.tsx
@@ -1,0 +1,102 @@
+import {css} from '@emotion/react';
+
+import useConfiguration from 'sentry/components/devtoolbar/hooks/useConfiguration';
+import InteractionStateLayer from 'sentry/components/interactionStateLayer';
+import {IconClose, IconIssues, IconMegaphone} from 'sentry/icons';
+
+import usePlacementCss from '../hooks/usePlacementCss';
+import useToolbarRoute from '../hooks/useToolbarRoute';
+import {navigationButtonCss, navigationCss} from '../styles/navigation';
+import {resetButtonCss, resetDialogCss} from '../styles/reset';
+
+export default function Navigation({setIsHidden}: {setIsHidden: (val: boolean) => void}) {
+  const {trackAnalytics} = useConfiguration();
+  const placement = usePlacementCss();
+
+  return (
+    <dialog
+      css={[
+        resetDialogCss,
+        navigationCss,
+        hideButtonContainerCss,
+        placement.navigation.css,
+      ]}
+    >
+      <NavButton panelName="issues" label={'Issues'} icon={<IconIssues />} />
+      <NavButton panelName="feedback" label={'User Feedback'} icon={<IconMegaphone />} />
+      <HideButton
+        onClick={() => {
+          setIsHidden(true);
+          trackAnalytics?.({
+            eventKey: `devtoolbar.nav.hide.click`,
+            eventName: `devtoolbar: Hide devtoolbar`,
+          });
+        }}
+      />
+    </dialog>
+  );
+}
+
+function NavButton({
+  icon,
+  label,
+  panelName,
+}: {
+  icon: React.ReactNode;
+  label: string;
+  panelName: ReturnType<typeof useToolbarRoute>['state']['activePanel'];
+}) {
+  const {trackAnalytics} = useConfiguration();
+  const {state, setActivePanel} = useToolbarRoute();
+
+  const isActive = state.activePanel === panelName;
+
+  return (
+    <button
+      aria-label={label}
+      css={[resetButtonCss, navigationButtonCss]}
+      data-active-route={isActive}
+      onClick={() => {
+        setActivePanel(isActive ? null : panelName);
+        trackAnalytics?.({
+          eventKey: `devtoolbar.nav.button.${label.replace(' ', '-')}.click`,
+          eventName: `devtoolbar: Toggle Nav Panel ${label} Click`,
+        });
+      }}
+      title={label}
+    >
+      <InteractionStateLayer />
+      {icon}
+    </button>
+  );
+}
+
+const hideButtonContainerCss = css`
+  :hover button {
+    visibility: visible;
+  }
+`;
+const hideButtonCss = css`
+  border-radius: 50%;
+  color: var(--gray300);
+  height: 1.6rem;
+  left: -10px;
+  position: absolute;
+  top: -10px;
+  visibility: hidden;
+  width: 1.6rem;
+  z-index: 1;
+`;
+
+function HideButton({onClick}: {onClick: () => void}) {
+  return (
+    <button
+      aria-label="Hide for this session"
+      css={[resetButtonCss, hideButtonCss]}
+      onClick={onClick}
+      title="Hide for this session"
+    >
+      <IconClose isCircled />
+    </button>
+  );
+}

--- a/static/app/components/devtoolbar/components/panelLayout.tsx
+++ b/static/app/components/devtoolbar/components/panelLayout.tsx
@@ -1,0 +1,28 @@
+import {buttonCss} from 'sentry/components/devtoolbar/styles/typography';
+
+import {panelCss, panelHeadingCss, panelSectionCss} from '../styles/panel';
+import {resetDialogCss, resetFlexColumnCss} from '../styles/reset';
+
+interface Props {
+  title: string;
+  children?: React.ReactNode;
+  titleLeft?: React.ReactNode;
+  titleRight?: React.ReactNode;
+}
+
+export default function PanelLayout({children, title, titleLeft, titleRight}: Props) {
+  return (
+    <dialog open css={[resetDialogCss, resetFlexColumnCss, panelCss]}>
+      {title ? (
+        <header css={panelSectionCss}>
+          {titleLeft}
+          {titleRight}
+          <h1 css={[buttonCss, panelHeadingCss]}>{title}</h1>
+        </header>
+      ) : null}
+      <section css={resetFlexColumnCss} style={{contain: 'strict'}}>
+        {children}
+      </section>
+    </dialog>
+  );
+}

--- a/static/app/components/devtoolbar/components/panelRouter.tsx
+++ b/static/app/components/devtoolbar/components/panelRouter.tsx
@@ -1,0 +1,19 @@
+import {lazy} from 'react';
+
+import useToolbarRoute from '../hooks/useToolbarRoute';
+
+const PanelFeedback = lazy(() => import('./feedback/feedbackPanel'));
+const PanelIssues = lazy(() => import('./issues/issuesPanel'));
+
+export default function PanelRouter() {
+  const {state} = useToolbarRoute();
+
+  switch (state.activePanel) {
+    case 'feedback':
+      return <PanelFeedback />;
+    case 'issues':
+      return <PanelIssues />;
+    default:
+      return null;
+  }
+}

--- a/static/app/components/devtoolbar/components/providers.tsx
+++ b/static/app/components/devtoolbar/components/providers.tsx
@@ -1,0 +1,44 @@
+import {useMemo} from 'react';
+import createCache from '@emotion/cache';
+import {CacheProvider, ThemeProvider} from '@emotion/react';
+import {QueryClient, QueryClientProvider} from '@tanstack/react-query';
+
+import {lightTheme} from 'sentry/utils/theme';
+
+import {ConfigurationContextProvider} from '../hooks/useConfiguration';
+import {ToolbarRouterContextProvider} from '../hooks/useToolbarRoute';
+import type {Configuration} from '../types';
+
+interface Props {
+  children: React.ReactNode;
+  config: Configuration;
+  container: ShadowRoot;
+}
+
+export default function Providers({children, config, container}: Props) {
+  const queryClient = useMemo(() => new QueryClient({}), []);
+  const myCache = useMemo(
+    () =>
+      createCache({
+        key: 'sentry-devtools',
+        stylisPlugins: [
+          /* your plugins here */
+        ],
+        container,
+        prepend: false,
+      }),
+    [container]
+  );
+
+  return (
+    <CacheProvider value={myCache}>
+      <ThemeProvider theme={lightTheme}>
+        <ConfigurationContextProvider config={config}>
+          <QueryClientProvider client={queryClient}>
+            <ToolbarRouterContextProvider>{children}</ToolbarRouterContextProvider>
+          </QueryClientProvider>
+        </ConfigurationContextProvider>
+      </ThemeProvider>
+    </CacheProvider>
+  );
+}

--- a/static/app/components/devtoolbar/components/sentryAppLink.tsx
+++ b/static/app/components/devtoolbar/components/sentryAppLink.tsx
@@ -1,0 +1,32 @@
+import type {MouseEvent} from 'react';
+import {stringifyUrl, type UrlObject} from 'query-string';
+
+import useConfiguration from '../hooks/useConfiguration';
+import {inlineLinkCss} from '../styles/link';
+
+interface Props {
+  children: React.ReactNode;
+  to: UrlObject;
+  onClick?: (event: MouseEvent) => void;
+}
+
+export default function SentryAppLink({children, to, onClick}: Props) {
+  const {organizationSlug} = useConfiguration();
+
+  const url = stringifyUrl({
+    url: `https://${organizationSlug}.sentry.io${to.url}`,
+    query: to.query,
+  });
+
+  return (
+    <a
+      css={inlineLinkCss}
+      onClick={onClick}
+      href={url}
+      target="_blank"
+      rel="noreferrer noopener"
+    >
+      {children}
+    </a>
+  );
+}

--- a/static/app/components/devtoolbar/hooks/useApiEndpoint.tsx
+++ b/static/app/components/devtoolbar/hooks/useApiEndpoint.tsx
@@ -1,0 +1,80 @@
+import {useMemo} from 'react';
+import {stringifyUrl} from 'query-string';
+
+import parseLinkHeader, {type ParsedHeader} from 'sentry/utils/parseLinkHeader';
+
+import type {ApiQueryKey, ApiResult} from '../types';
+
+import useConfiguration from './useConfiguration';
+
+function parsePageParam(dir: 'previous' | 'next') {
+  return ({headers}) => {
+    const parsed = parseLinkHeader(headers?.get('Link') ?? null);
+    return parsed[dir]?.results ? parsed[dir] : null;
+  };
+}
+
+const getNextPageParam = parsePageParam('next');
+const getPreviousPageParam = parsePageParam('previous');
+
+interface FetchParams {
+  queryKey: ApiQueryKey;
+}
+
+interface InfiniteFetchParams extends FetchParams {
+  pageParam?: ParsedHeader; // TODO: is this really optional?
+}
+
+export default function useApiEndpoint() {
+  const {apiPrefix} = useConfiguration();
+
+  const fetchFn = useMemo(
+    () =>
+      async <Data,>({
+        queryKey: [endpoint, options],
+      }: FetchParams): Promise<ApiResult<Data>> => {
+        const response = await fetch(
+          stringifyUrl({url: apiPrefix + endpoint, query: options?.query}),
+          {
+            body: options?.payload ? JSON.stringify(options?.payload) : undefined,
+            headers: options?.headers,
+            method: options?.method ?? 'GET',
+          }
+        );
+
+        if (!response.ok) {
+          throw new Error('Network response was not ok');
+        }
+
+        return {
+          json: await response.json(),
+          headers: response.headers,
+        };
+      },
+    [apiPrefix]
+  );
+
+  const fetchInfiniteFn = useMemo(
+    () =>
+      <Data,>({
+        queryKey: [endpoint, options],
+        pageParam,
+      }: InfiniteFetchParams): Promise<ApiResult<Data>> => {
+        const query = {
+          ...options?.query,
+          cursor: pageParam?.cursor,
+        };
+        return fetchFn<Data>({
+          queryKey: [endpoint, {...options, query}],
+        });
+      },
+    [fetchFn]
+  );
+
+  return {
+    fetchFn,
+    fetchInfiniteFn,
+    getNextPageParam,
+    getPreviousPageParam,
+  };
+}

--- a/static/app/components/devtoolbar/hooks/useConfiguration.tsx
+++ b/static/app/components/devtoolbar/hooks/useConfiguration.tsx
@@ -1,0 +1,26 @@
+import {createContext, useContext} from 'react';
+
+import type {Configuration} from '../types';
+
+const context = createContext<Configuration>({
+  apiPrefix: '',
+  environment: ['production'],
+  organizationSlug: '',
+  placement: 'right-edge',
+  projectId: 0,
+  projectSlug: '',
+});
+
+export function ConfigurationContextProvider({
+  children,
+  config,
+}: {
+  children: React.ReactNode;
+  config: Configuration;
+}) {
+  return <context.Provider value={config}>{children}</context.Provider>;
+}
+
+export default function useConfiguration() {
+  return useContext(context);
+}

--- a/static/app/components/devtoolbar/hooks/useCurrentTransactionName.tsx
+++ b/static/app/components/devtoolbar/hooks/useCurrentTransactionName.tsx
@@ -1,0 +1,8 @@
+import * as Sentry from '@sentry/react';
+
+export default function useCurrentTransactionName() {
+  const scope = Sentry.getCurrentScope();
+  const scopeData = scope.getScopeData();
+  const transactionName = `/${scopeData.transactionName}/`.replaceAll('//', '/');
+  return transactionName;
+}

--- a/static/app/components/devtoolbar/hooks/useInfiniteApiData.tsx
+++ b/static/app/components/devtoolbar/hooks/useInfiniteApiData.tsx
@@ -1,0 +1,24 @@
+import {useInfiniteQuery} from '@tanstack/react-query';
+
+import type {ApiQueryKey, ApiResult} from '../types';
+
+import useApiEndpoint from './useApiEndpoint';
+
+interface Props {
+  queryKey: ApiQueryKey;
+}
+
+export default function useInfiniteApiData<Data extends Array<unknown>>({
+  queryKey,
+}: Props) {
+  const {fetchInfiniteFn, getNextPageParam, getPreviousPageParam} = useApiEndpoint();
+
+  const infiniteQueryResult = useInfiniteQuery<ApiQueryKey, Error, ApiResult<Data>, any>({
+    queryKey,
+    queryFn: fetchInfiniteFn<Data>,
+    getNextPageParam,
+    getPreviousPageParam,
+  });
+
+  return infiniteQueryResult;
+}

--- a/static/app/components/devtoolbar/hooks/usePlacementCss.tsx
+++ b/static/app/components/devtoolbar/hooks/usePlacementCss.tsx
@@ -1,0 +1,36 @@
+import {
+  fixedContainerBottomRightCornderCss,
+  fixedContainerRightEdgeCss,
+} from '../styles/fixedContainer';
+import {
+  navigationBottomRightCornerCss,
+  navigationRightEdgeCss,
+} from '../styles/navigation';
+
+import useConfiguration from './useConfiguration';
+
+export default function usePlacementCss() {
+  const {placement} = useConfiguration();
+
+  switch (placement) {
+    case 'right-edge':
+      return {
+        fixedContainer: {
+          css: fixedContainerRightEdgeCss,
+        },
+        navigation: {
+          css: navigationRightEdgeCss,
+        },
+      };
+    case 'bottom-right-corner':
+    default:
+      return {
+        fixedContainer: {
+          css: fixedContainerBottomRightCornderCss,
+        },
+        navigation: {
+          css: navigationBottomRightCornerCss,
+        },
+      };
+  }
+}

--- a/static/app/components/devtoolbar/hooks/useSDKFeedbackButton.tsx
+++ b/static/app/components/devtoolbar/hooks/useSDKFeedbackButton.tsx
@@ -1,0 +1,18 @@
+import {useEffect, useRef} from 'react';
+
+import useConfiguration from './useConfiguration';
+
+export function useSDKFeedbackButton() {
+  const buttonRef = useRef<HTMLButtonElement>(null);
+  const {SentrySDK} = useConfiguration();
+  const feedback = SentrySDK && 'getFeedback' in SentrySDK && SentrySDK.getFeedback();
+
+  useEffect(() => {
+    if (feedback && buttonRef.current) {
+      return feedback.attachTo(buttonRef.current, {});
+    }
+    return () => {};
+  }, [feedback]);
+
+  return feedback ? buttonRef : undefined;
+}

--- a/static/app/components/devtoolbar/hooks/useToolbarRoute.tsx
+++ b/static/app/components/devtoolbar/hooks/useToolbarRoute.tsx
@@ -1,0 +1,34 @@
+import {createContext, useCallback, useContext, useState} from 'react';
+
+type State = {
+  activePanel: null | 'feedback' | 'issues';
+};
+
+const context = createContext<{
+  setActivePanel: (activePanel: State['activePanel']) => void;
+  state: State;
+}>({
+  setActivePanel(_activePanel: State['activePanel']) {},
+  state: {activePanel: null},
+});
+
+export function ToolbarRouterContextProvider({children}: {children: React.ReactNode}) {
+  // TODO: if state gets more complex, we can swtich to useReducer
+  const [state, setState] = useState<State>({activePanel: null});
+
+  const setActivePanel = useCallback(
+    (activePanel: State['activePanel']) => {
+      setState(prev => ({
+        ...prev,
+        activePanel,
+      }));
+    },
+    [setState]
+  );
+
+  return <context.Provider value={{setActivePanel, state}}>{children}</context.Provider>;
+}
+
+export default function useToolbarRoute() {
+  return useContext(context);
+}

--- a/static/app/components/devtoolbar/index.tsx
+++ b/static/app/components/devtoolbar/index.tsx
@@ -1,0 +1,13 @@
+import type {Configuration} from './types';
+
+interface InitProps extends Configuration {
+  rootNode?: HTMLElement;
+}
+
+const DevToolbar = {
+  async init({rootNode, ...config}: InitProps) {
+    const {default: mount} = await import('./mount');
+    return mount(rootNode ?? document.body, config);
+  },
+};
+export default DevToolbar;

--- a/static/app/components/devtoolbar/mount.tsx
+++ b/static/app/components/devtoolbar/mount.tsx
@@ -1,0 +1,32 @@
+import {StrictMode} from 'react';
+import {createRoot} from 'react-dom/client';
+
+import App from './components/app';
+import Providers from './components/providers';
+import type {Configuration} from './types';
+
+export default function mount(rootNode: HTMLElement, config: Configuration) {
+  const host = document.createElement('div');
+  host.id = config.domId ?? 'sentry-devtools';
+  const shadow = host.attachShadow({mode: 'open'});
+  const reactRoot = makeReactRoot(shadow, config);
+
+  rootNode.appendChild(host);
+
+  return () => {
+    host.remove();
+    reactRoot.unmount();
+  };
+}
+
+function makeReactRoot(shadow: ShadowRoot, config: Configuration) {
+  const root = createRoot(shadow);
+  root.render(
+    <StrictMode>
+      <Providers container={shadow} config={config}>
+        <App />
+      </Providers>
+    </StrictMode>
+  );
+  return root;
+}

--- a/static/app/components/devtoolbar/styles/fixedContainer.ts
+++ b/static/app/components/devtoolbar/styles/fixedContainer.ts
@@ -1,0 +1,27 @@
+import {css} from '@emotion/react';
+
+export const fixedContainerBaseCss = css`
+  display: flex;
+  gap: var(--space150);
+  inset: 0;
+  pointer-events: none;
+  position: fixed;
+  z-index: var(--z-index);
+
+  & > * {
+    pointer-events: all;
+  }
+`;
+
+export const fixedContainerRightEdgeCss = css`
+  flex-direction: row-reverse;
+  justify-content: flex-start;
+  place-items: center;
+`;
+
+export const fixedContainerBottomRightCornderCss = css`
+  flex-direction: column-reverse;
+  justify-content: flex-start;
+  padding: var(--space150);
+  place-items: flex-end;
+`;

--- a/static/app/components/devtoolbar/styles/global.ts
+++ b/static/app/components/devtoolbar/styles/global.ts
@@ -1,0 +1,218 @@
+import {css} from '@emotion/react';
+
+const SPACES = {
+  0: '0',
+  25: '2px',
+  50: '4px',
+  75: '6px',
+  100: '8px',
+  150: '12px',
+  200: '16px',
+  300: '20px',
+  400: '30px',
+} as const;
+
+export const globalCss = css`
+  :host {
+    ${Object.entries(SPACES)
+      .map(([size, px]) => `--space${size}: ${px};`)
+      .join('\n')}
+
+    --gray500: #2b2233;
+    --gray400: #3e3446;
+    --gray300: #80708f;
+    --gray200: #e0dce5;
+    --gray100: #f0ecf3;
+
+    --purple400: #6559c5;
+    --purple300: #6c5fc7;
+    --purple200: rgba(108, 95, 199, 0.5);
+    --purple100: rgba(108, 95, 199, 0.09);
+
+    --blue400: #2562d4;
+    --blue300: #3c74dd;
+    --blue200: rgba(60, 116, 221, 0.5);
+    --blue100: rgba(60, 116, 221, 0.09);
+
+    --z-index: 100000;
+
+    color: var(--gray400);
+    font-family: system-ui, 'Helvetica Neue', Arial, sans-serif;
+    font-size: 16px;
+    line-height: 1.4;
+
+    *::selection {
+      background: var(--blue200);
+    }
+
+    dialog {
+      color: inherit;
+    }
+  }
+
+  * {
+    box-sizing: border-box;
+  }
+
+  div {
+    display: flex;
+    flex-direction: column;
+  }
+
+  div.flex-row div {
+    flex-direction: row;
+  }
+
+  .ReactQueryDevtools,
+  .ReactQueryDevtools div {
+    display: initial;
+    flex-direction: initial;
+  }
+`;
+
+export const avatarCss = css`
+  .avatar {
+    width: 20px;
+    height: 20px;
+    vertical-align: middle;
+    position: relative;
+    display: inline-block;
+  }
+
+  .avatar img {
+    vertical-align: middle;
+    max-width: 100%;
+  }
+`;
+
+export const loadingIndicatorCss = css`
+  .loading {
+    --loader-size-big: 64px;
+
+    margin: 6em auto;
+    position: relative;
+
+    &.overlay {
+      position: absolute;
+      top: 0;
+      bottom: 0;
+      left: 0;
+      right: 0;
+      background-color: rgba(255, 255, 255, 0.8);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      margin: 0;
+
+      &.dark {
+        background-color: rgba(0, 0, 0, 0.6);
+      }
+    }
+
+    .loading-indicator {
+      position: relative;
+      border: 6px solid var(--gray100);
+      border-left-color: var(--purple300);
+      -webkit-animation: loading 0.5s infinite linear;
+      animation: loading 0.55s infinite linear;
+      margin: 0 auto;
+    }
+
+    .loading-indicator,
+    .loading-indicator:after {
+      border-radius: 50%;
+      width: var(--loader-size-big);
+      height: var(--loader-size-big);
+    }
+
+    .loading-message {
+      margin-top: 20px;
+      text-align: center;
+    }
+  }
+
+  @-webkit-keyframes loading {
+    0% {
+      -webkit-transform: rotate(0deg);
+      transform: rotate(0deg);
+    }
+
+    100% {
+      -webkit-transform: rotate(360deg);
+      transform: rotate(360deg);
+    }
+  }
+
+  @keyframes loading {
+    0% {
+      -webkit-transform: rotate(0deg);
+      transform: rotate(0deg);
+    }
+
+    100% {
+      -webkit-transform: rotate(360deg);
+      transform: rotate(360deg);
+    }
+  }
+
+  /**
+   * mini
+   */
+
+  .loading.mini {
+    --loader-size-mini: 24px;
+
+    margin: 4px 0;
+    font-size: 13px;
+    height: var(--loader-size-mini);
+
+    .loading-indicator {
+      margin: 0;
+      border-radius: 50%;
+      width: var(--loader-size-mini);
+      height: var(--loader-size-mini);
+      border-width: 2px;
+      position: absolute;
+      left: 0;
+      top: 0;
+
+      &.relative {
+        position: relative;
+        left: auto;
+        top: auto;
+      }
+    }
+
+    .loading-message {
+      padding-left: 30px;
+      margin-top: 1px;
+      display: inline-block;
+    }
+  }
+
+  /* Spinning logo icon loader */
+  .loading.triangle {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    width: 500px;
+    margin-top: -200px;
+    margin-left: -250px;
+
+    /* Nerf the styles of other loading indicators */
+    .loading-indicator {
+      height: 150px;
+      width: 150px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      background: #fff;
+
+      animation: none;
+      -webkit-animation: none;
+      border: 0;
+      overflow: hidden;
+      border-radius: 50%;
+    }
+  }
+`;

--- a/static/app/components/devtoolbar/styles/infiniteList.ts
+++ b/static/app/components/devtoolbar/styles/infiniteList.ts
@@ -1,0 +1,35 @@
+import {css} from '@emotion/react';
+
+import {resetUlCss} from './reset';
+
+export const infiniteListParentContainerCss = css`
+  contain: strict;
+  height: 100%;
+  overflow: auto;
+  overscroll-behavior: contain;
+  width: 100%;
+`;
+
+export const infiniteListScollablePanelCss = css`
+  width: 100%;
+  position: relative;
+`;
+
+export const infiniteListScrollableWindowCss = css`
+  ${resetUlCss}
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+`;
+
+export const infiniteListFloatingMessageBottomCss = css`
+  align-items: center;
+  bottom: 0;
+  display: flex;
+  flex-grow: 1;
+  justify-content: center;
+  position: absolute;
+  width: 100%;
+  z-index: 1;
+`;

--- a/static/app/components/devtoolbar/styles/link.ts
+++ b/static/app/components/devtoolbar/styles/link.ts
@@ -1,0 +1,23 @@
+import {css} from '@emotion/react';
+
+export const inlineLinkCss = css`
+  color: var(--blue300);
+  text-decoration: underline;
+  text-decoration-color: var(--blue100);
+  cursor: pointer;
+
+  &:hover {
+    text-decoration-color: var(--blue200);
+  }
+`;
+
+export const blockLinkCss = css`
+  color: var(--gray500);
+  text-decoration: none;
+  cursor: pointer;
+
+  &:hover {
+    text-decoration: underline;
+    text-decoration-color: var(--gray200);
+  }
+`;

--- a/static/app/components/devtoolbar/styles/listItem.ts
+++ b/static/app/components/devtoolbar/styles/listItem.ts
@@ -1,0 +1,40 @@
+import {css} from '@emotion/react';
+
+export const listItemPlaceholderWrapperCss = css`
+  display: flex;
+  gap: var(--space100);
+  margin: 0;
+  overflow: hidden;
+`;
+
+export const listItemGridCss = css`
+  contain: inline-size;
+  display: grid;
+  grid-template-areas:
+    'name time'
+    'message message'
+    'project icons';
+  grid-template-columns: 1fr max-content;
+
+  gap: var(--space50);
+  margin: 0 var(--space150);
+  padding-block: var(--space150);
+  padding-inline: 0;
+  border-bottom: 1px solid var(--gray100);
+`;
+
+export const badgeWithLabelCss = css`
+  align-items: center;
+  display: grid;
+  gap: var(--space50);
+  grid-auto-flow: column;
+  grid-template-columns: max-content 1fr;
+`;
+
+export const gridFlexEndCss = css`
+  align-items: center;
+  display: flex;
+  flex-direction: row;
+  gap: var(--space50);
+  justify-content: flex-end;
+`;

--- a/static/app/components/devtoolbar/styles/navigation.ts
+++ b/static/app/components/devtoolbar/styles/navigation.ts
@@ -1,0 +1,36 @@
+import {css} from '@emotion/react';
+
+export const navigationCss = css`
+  align-items: center;
+  background: white;
+  border: 1px solid var(--gray200);
+  border-radius: var(--space150);
+  display: flex;
+  gap: var(--space50);
+  padding: var(--space50);
+`;
+
+export const navigationRightEdgeCss = css`
+  border-end-end-radius: 0;
+  border-start-end-radius: 0;
+  flex-direction: column;
+`;
+
+export const navigationBottomRightCornerCss = css`
+  flex-direction: row;
+`;
+
+export const navigationButtonCss = css`
+  border: 1px solid transparent;
+  background: none;
+  color: var(--gray400);
+  padding: var(--space100) var(--space150);
+  border-radius: var(--space100);
+  gap: var(--space50);
+
+  &[data-active-route='true'] {
+    color: var(--purple300);
+    background: var(--purple100);
+    border-color: var(--purple100);
+  }
+`;

--- a/static/app/components/devtoolbar/styles/panel.ts
+++ b/static/app/components/devtoolbar/styles/panel.ts
@@ -1,0 +1,39 @@
+import {css} from '@emotion/react';
+
+export const panelCss = css`
+  background: white;
+  border-radius: 12px;
+  border: 1px solid var(--gray100);
+  height: 90vh;
+  max-height: 560px;
+  width: 320px;
+  max-width: 320px;
+  box-shadow: 0px 10px 15px -3px rgba(0, 0, 0, 0.1);
+`;
+
+export const panelHeadingCss = css`
+  margin: 0;
+  text-align: center;
+`;
+
+export const panelHeadingLeftCss = css`
+  position: absolute;
+  left: 0;
+`;
+
+export const panelHeadingRightCss = css`
+  position: absolute;
+  right: 0;
+`;
+
+export const panelSectionCss = css`
+  position: relative;
+  padding-block: var(--space100);
+  &:not(:last-child) {
+    border-bottom: 1px solid var(--gray200);
+  }
+`;
+
+export const panelInsetContentCss = css`
+  padding-inline: var(--space100);
+`;

--- a/static/app/components/devtoolbar/styles/reset.ts
+++ b/static/app/components/devtoolbar/styles/reset.ts
@@ -1,0 +1,34 @@
+import {css} from '@emotion/react';
+
+export const resetDialogCss = css`
+  background: transparent;
+  height: auto;
+  margin: 0;
+  padding: 0;
+  position: relative;
+  width: auto;
+`;
+
+export const resetFlexColumnCss = css`
+  display: flex;
+  flex-direction: column;
+  flex-grow: 1;
+`;
+
+export const resetUlCss = css`
+  padding: 0;
+  margin: 0;
+  list-style: none;
+`;
+
+export const resetButtonCss = css`
+  align-items: center;
+  background: none;
+  border: none;
+  display: flex;
+  &:not(:disabled) {
+    cursor: pointer;
+  }
+  line-height: 1em;
+  position: relative;
+`;

--- a/static/app/components/devtoolbar/styles/typography.ts
+++ b/static/app/components/devtoolbar/styles/typography.ts
@@ -1,0 +1,81 @@
+import {css} from '@emotion/react';
+
+export const heading1Css = css`
+  font-weight: 600;
+  font-size: 2.25rem;
+  line-height: 1.2;
+  letter-spacing: -0.02rem;
+`;
+
+export const heading2Css = css`
+  font-weight: 600;
+  font-size: 1.875rem;
+  line-height: 1.2;
+  letter-spacing: -0.016em;
+`;
+
+export const heading3Css = css`
+  font-weight: 600;
+  font-size: 1.625rem;
+  line-height: 1.2;
+  letter-spacing: -0.012em;
+`;
+
+export const heading4Css = css`
+  font-weight: 600;
+  font-size: 1.375rem;
+  line-height: 1.2;
+  letter-spacing: -0.008em;
+`;
+
+export const heading5Css = css`
+  font-weight: 600;
+  font-size: 1.25rem;
+  line-height: 1.2;
+  letter-spacing: -0.004em;
+`;
+
+export const heading6Css = css`
+  font-weight: 600;
+  font-size: 1.125rem;
+  line-height: 1.2;
+  letter-spacing: normal;
+`;
+
+export const paragraphCss = css`
+  font-weight: 400;
+  font-size: 1rem;
+  line-height: 1.4;
+  letter-spacing: normal;
+`;
+
+export const buttonCss = css`
+  font-weight: 600;
+  font-size: 1rem;
+  line-height: 1;
+  letter-spacing: normal;
+`;
+
+export const smallCss = css`
+  font-weight: 400;
+  font-size: 0.875rem;
+  line-height: 1.4;
+  letter-spacing: +0.01rem;
+`;
+
+export const xSmallCss = css`
+  font-weight: 400;
+  font-size: 0.75rem;
+  line-height: 1.4;
+  letter-spacing: +0.02rem;
+`;
+
+export const textOverflowTwoLinesCss = css`
+  margin: 0;
+  white-space: initial;
+  height: 2.8em;
+  -webkit-line-clamp: 2;
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  line-height: 1.2rem;
+`;

--- a/static/app/components/devtoolbar/types.ts
+++ b/static/app/components/devtoolbar/types.ts
@@ -1,0 +1,44 @@
+import type SentrySDK from '@sentry/react'; // TODO: change to `@sentry/browser` when we have our own package.json
+
+export type {FeedbackIssueListItem} from 'sentry/utils/feedback/types';
+
+export type Configuration = {
+  apiPrefix: string;
+  environment: string | string[];
+  organizationSlug: string;
+  placement: 'right-edge' | 'bottom-right-corner';
+  projectId: number;
+  projectSlug: string;
+  SentrySDK?: typeof SentrySDK;
+  domId?: string;
+  trackAnalytics?: (props: {eventKey: string; eventName: string}) => void;
+};
+
+type APIRequestMethod = 'POST' | 'GET' | 'DELETE' | 'PUT';
+
+type QueryKeyEndpointOptions<
+  Headers = Record<string, string>,
+  Query = Record<string, any>,
+  Payload = Record<string, any>,
+> = {
+  headers?: Headers;
+  method?: APIRequestMethod;
+  payload?: Payload;
+  query?: Query;
+};
+
+export type ApiQueryKey =
+  | readonly [url: string]
+  | readonly [
+      url: string,
+      options: QueryKeyEndpointOptions<
+        Record<string, string>,
+        Record<string, any>,
+        Record<string, any>
+      >,
+    ];
+
+export type ApiResult<Data = unknown> = {
+  headers: Headers;
+  json: Data;
+};

--- a/static/app/utils/useDevToolbar.tsx
+++ b/static/app/utils/useDevToolbar.tsx
@@ -1,0 +1,38 @@
+import {useEffect} from 'react';
+import * as Sentry from '@sentry/react';
+
+import DevToolbar from 'sentry/components/devtoolbar';
+import {rawTrackAnalyticsEvent} from 'sentry/utils/analytics';
+import useOrganization from 'sentry/utils/useOrganization';
+
+export default function useDevToolbar({enabled}: {enabled: boolean}) {
+  const organization = useOrganization();
+  useEffect(() => {
+    if (enabled) {
+      // TODO: this is insufficient and doesn't take into account control/silo endpoints
+      const apiPrefix = window.__SENTRY_DEV_UI ? '/region/us/api/0' : '/api/0';
+
+      const promise = DevToolbar.init({
+        rootNode: document.body,
+        placement: 'right-edge', // Could also be 'bottom-right-corner'
+
+        // The Settings we need to talk to the Sentry API
+        // What org/project/env should we read from?
+        SentrySDK: Sentry,
+        apiPrefix,
+        environment: ['prod'],
+        organizationSlug: 'sentry',
+        projectId: 11276,
+        projectSlug: 'javascript',
+
+        trackAnalytics: (props: {eventKey: string; eventName: string}) =>
+          rawTrackAnalyticsEvent({...props, organization}),
+      });
+
+      return () => {
+        promise.then(cleanup => cleanup());
+      };
+    }
+    return () => {};
+  }, [enabled, organization]);
+}

--- a/static/app/views/organizationLayout/index.tsx
+++ b/static/app/views/organizationLayout/index.tsx
@@ -3,6 +3,8 @@ import HookOrDefault from 'sentry/components/hookOrDefault';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import Sidebar from 'sentry/components/sidebar';
 import useRouteAnalyticsHookSetup from 'sentry/utils/routeAnalytics/useRouteAnalyticsHookSetup';
+import useDevToolbar from 'sentry/utils/useDevToolbar';
+import {useIsSentryEmployee} from 'sentry/utils/useIsSentryEmployee';
 import useOrganization from 'sentry/utils/useOrganization';
 import OrganizationContainer from 'sentry/views/organizationContainer';
 
@@ -15,6 +17,14 @@ interface Props {
 const OrganizationHeader = HookOrDefault({
   hookName: 'component:organization-header',
 });
+
+function DevToolInit() {
+  const isEmployee = useIsSentryEmployee();
+  const organization = useOrganization();
+  const showDevToolbar = organization.features.includes('devtoolbar');
+  useDevToolbar({enabled: showDevToolbar && isEmployee});
+  return null;
+}
 
 function OrganizationLayout({children}: Props) {
   useRouteAnalyticsHookSetup();
@@ -29,6 +39,7 @@ function OrganizationLayout({children}: Props) {
       <OrganizationContainer>
         <div className="app">
           {organization && <OrganizationHeader organization={organization} />}
+          {organization && <DevToolInit />}
           <Sidebar />
           <Body>{children}</Body>
           <Footer />


### PR DESCRIPTION
- this PR copies everything from the devtoolbar POC (https://github.com/getsentry/getsentry/pull/14420) but moves all files from `getsentry` to `sentry`. no files were changed, except for a few imports moved from `getsentry` to `sentry`, and a few rewordings in the readme. 
- this change means that sentry employees on the sentry org, running `dev-ui` from `sentry`, will be able to see the devtoolbar. previously, the devtoolbar was only visible when running `dev-ui` from `getsentry`. note that sentry employees on any other org will see the employee feedback button, which was the previous behavior.
- will follow up with a PR that deletes the duplicated code from `getsentry`. can also follow up with PRs to clean up this code/make any adjustments as needed.
- relates to https://github.com/getsentry/sentry/issues/74451

running `dev-ui` from `getsentry` and `sentry` on sentry org gives the devtoolbar:
<img width="1199" alt="SCR-20240717-obbs" src="https://github.com/user-attachments/assets/4c41c675-75de-4822-b847-15ec702c8dab">

on any other org gives the employee feedback button:
<img width="1196" alt="SCR-20240717-obsf" src="https://github.com/user-attachments/assets/98dd587a-40f5-4367-956a-8fceff37855c">

