### PR TITLE
analytics(replay): click tracking analytics for hydration diff modal

### DIFF
--- a/static/app/components/events/eventHydrationDiff/replayDiffContent.tsx
+++ b/static/app/components/events/eventHydrationDiff/replayDiffContent.tsx
@@ -44,6 +44,7 @@ export default function ReplayDiffContent({event, group, orgSlug, replaySlug}: P
           leftOffsetMs={leftOffsetMs}
           replay={replay}
           rightOffsetMs={rightOffsetMs}
+          surface={'issue-details'} // TODO: refactor once this component is used in more surfaces
           size="xs"
         >
           {t('Open Diff Viewer')}

--- a/static/app/components/events/eventHydrationDiff/replayDiffContent.tsx
+++ b/static/app/components/events/eventHydrationDiff/replayDiffContent.tsx
@@ -44,7 +44,7 @@ export default function ReplayDiffContent({event, group, orgSlug, replaySlug}: P
           leftOffsetMs={leftOffsetMs}
           replay={replay}
           rightOffsetMs={rightOffsetMs}
-          surface={'issue-details'} // TODO: refactor once this component is used in more surfaces
+          surface="issue-details" // TODO: refactor once this component is used in more surfaces
           size="xs"
         >
           {t('Open Diff Viewer')}

--- a/static/app/components/replays/breadcrumbs/breadcrumbItem.tsx
+++ b/static/app/components/replays/breadcrumbs/breadcrumbItem.tsx
@@ -207,6 +207,7 @@ function CrumbHydrationButton({
         replay={replay}
         leftOffsetMs={leftOffsetMs}
         rightOffsetMs={rightOffsetMs}
+        surface="replay-breadcrumbs"
         size="xs"
       >
         {t('Open Hydration Diff')}

--- a/static/app/components/replays/breadcrumbs/openReplayComparisonButton.tsx
+++ b/static/app/components/replays/breadcrumbs/openReplayComparisonButton.tsx
@@ -34,8 +34,8 @@ export function OpenReplayComparisonButton({
     <Button
       role="button"
       size={size}
-      analyticsEventKey="replay.details-hydration-modal-opened"
-      analyticsEventName="Replay Details Hydration Modal Opened"
+      analyticsEventKey="replay.hydration-modal.opened"
+      analyticsEventName="Hydration Modal Opened"
       analyticsParams={{url: getLocationHref()}}
       onClick={event => {
         event.stopPropagation();

--- a/static/app/components/replays/breadcrumbs/openReplayComparisonButton.tsx
+++ b/static/app/components/replays/breadcrumbs/openReplayComparisonButton.tsx
@@ -1,6 +1,5 @@
 import {Fragment, lazy, type ReactNode, Suspense} from 'react';
 import {css} from '@emotion/react';
-import {getLocationHref} from '@sentry/utils';
 
 import {openModal} from 'sentry/actionCreators/modal';
 import FeatureBadge from 'sentry/components/badge/featureBadge';
@@ -18,6 +17,7 @@ interface Props {
   leftOffsetMs: number;
   replay: null | ReplayReader;
   rightOffsetMs: number;
+  surface: string;
   size?: ButtonProps['size'];
 }
 
@@ -26,6 +26,7 @@ export function OpenReplayComparisonButton({
   leftOffsetMs,
   replay,
   rightOffsetMs,
+  surface,
   size,
 }: Props) {
   const organization = useOrganization();
@@ -36,7 +37,7 @@ export function OpenReplayComparisonButton({
       size={size}
       analyticsEventKey="replay.hydration-modal.opened"
       analyticsEventName="Hydration Modal Opened"
-      analyticsParams={{url: getLocationHref()}}
+      analyticsParams={{surface}}
       onClick={event => {
         event.stopPropagation();
         openModal(

--- a/static/app/components/replays/breadcrumbs/openReplayComparisonButton.tsx
+++ b/static/app/components/replays/breadcrumbs/openReplayComparisonButton.tsx
@@ -37,7 +37,7 @@ export function OpenReplayComparisonButton({
       size={size}
       analyticsEventKey="replay.hydration-modal.opened"
       analyticsEventName="Hydration Modal Opened"
-      analyticsParams={{surface}}
+      analyticsParams={{surface, organization}}
       onClick={event => {
         event.stopPropagation();
         openModal(

--- a/static/app/components/replays/breadcrumbs/openReplayComparisonButton.tsx
+++ b/static/app/components/replays/breadcrumbs/openReplayComparisonButton.tsx
@@ -1,5 +1,6 @@
 import {Fragment, lazy, type ReactNode, Suspense} from 'react';
 import {css} from '@emotion/react';
+import {getLocationHref} from '@sentry/utils';
 
 import {openModal} from 'sentry/actionCreators/modal';
 import FeatureBadge from 'sentry/components/badge/featureBadge';
@@ -35,6 +36,7 @@ export function OpenReplayComparisonButton({
       size={size}
       analyticsEventKey="replay.details-hydration-modal-opened"
       analyticsEventName="Replay Details Hydration Modal Opened"
+      analyticsParams={{url: getLocationHref()}}
       onClick={event => {
         event.stopPropagation();
         openModal(

--- a/static/app/components/replays/diff/replayDiffChooser.tsx
+++ b/static/app/components/replays/diff/replayDiffChooser.tsx
@@ -8,6 +8,7 @@ import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import type ReplayReader from 'sentry/utils/replays/replayReader';
+import useOrganization from 'sentry/utils/useOrganization';
 
 interface Props {
   leftOffsetMs: number;
@@ -30,8 +31,9 @@ export default function ReplayDiffChooser({
 }: Props) {
   const isSameTimestamp = leftOffsetMs === rightOffsetMs;
 
+  const organization = useOrganization();
   const onTabChange = (tabKey: DiffType) => {
-    trackAnalytics('replay.hydration-modal.tab-change', {tabKey, organization: null});
+    trackAnalytics('replay.hydration-modal.tab-change', {tabKey, organization});
   };
 
   return (

--- a/static/app/components/replays/diff/replayDiffChooser.tsx
+++ b/static/app/components/replays/diff/replayDiffChooser.tsx
@@ -6,6 +6,7 @@ import {ReplayTextDiff} from 'sentry/components/replays/diff/replayTextDiff';
 import {TabList, TabPanels, Tabs} from 'sentry/components/tabs';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
+import {trackAnalytics} from 'sentry/utils/analytics';
 import type ReplayReader from 'sentry/utils/replays/replayReader';
 
 interface Props {
@@ -29,8 +30,12 @@ export default function ReplayDiffChooser({
 }: Props) {
   const isSameTimestamp = leftOffsetMs === rightOffsetMs;
 
+  const onTabChange = (tabKey: DiffType) => {
+    trackAnalytics('replay.hydration-modal.tab-change', {tabKey, organization: null});
+  };
+
   return (
-    <Tabs<DiffType> defaultValue={defaultTab}>
+    <Tabs<DiffType> defaultValue={defaultTab} onChange={onTabChange}>
       {isSameTimestamp ? (
         <Alert type="warning" showIcon>
           {t(


### PR DESCRIPTION
Ref https://github.com/getsentry/sentry/issues/74456

1. Renames the "replay.details-hydration-modal-opened" event to "replay.hydration-modal.opened", and adds the `surface` param, which can be either "issue-details" or "replay-breadcrumbs"
2. Tracks analytics on changing tabs in the modal. Event name = "replay.hydration-modal.tab-change". Includes the tab type (html/slider/visual)