### PR TITLE
feat(uptime): Change detection to be around the organization, so that we can enforce quota

### DIFF
--- a/src/sentry/uptime/detectors/ranking.py
+++ b/src/sentry/uptime/detectors/ranking.py
@@ -11,22 +11,23 @@ from rediscluster import RedisCluster
 from sentry.utils import redis
 
 if TYPE_CHECKING:
+    from sentry.models.organization import Organization
     from sentry.models.project import Project
 
 
-# How often should each project be flushed?
-PROJECT_FLUSH_FREQUENCY = timedelta(days=1)
+# How often should each organization be flushed?
+ORGANIZATION_FLUSH_FREQUENCY = timedelta(days=1)
 # How often do we want to run our task to flush the buckets?
 # XXX: This might actually belong in the task when we have that?
 BUCKET_FLUSH_FREQUENCY = timedelta(minutes=1)
-NUMBER_OF_BUCKETS = int(PROJECT_FLUSH_FREQUENCY / BUCKET_FLUSH_FREQUENCY)
+NUMBER_OF_BUCKETS = int(ORGANIZATION_FLUSH_FREQUENCY / BUCKET_FLUSH_FREQUENCY)
 # How often should we trim the ranked list?
 RANKED_TRIM_CHANCE = 0.01
 # How many urls should we trim the ranked list to?
 RANKED_MAX_SIZE = 20
 # Expiry we should set on all keys. Set the expiry to twice the flush frequency
 # so that we definitely have time to process.
-KEY_EXPIRY = PROJECT_FLUSH_FREQUENCY * 2
+KEY_EXPIRY = ORGANIZATION_FLUSH_FREQUENCY * 2
 
 
 def _get_cluster() -> RedisCluster | StrictRedis:
@@ -37,11 +38,12 @@ def add_base_url_to_rank(project: Project, base_url: str):
     """
     Takes a project and valid base url and stores ranking information about it in Redis.
 
-    We use two keys here: A hash set that stores a list of projects and the total number
-    of events with valid hostnames that they've seen, and a zset of hostnames seen in the
-    project ranked by the number of times they've been seen.
+    We use three keys here: A set that stores the list of organizations that have seen urls,
+    a sorted set that stores a list of projects ranked by the total number of events with valid hostnames
+    that they've seen, and a sorted set of hostnames seen in the project ranked by the number of times
+    they've been seen.
 
-    We partition the project into buckets determined by `PROJECT_FLUSH_FREQUENCY` and
+    We partition the organizations into buckets determined by `ORGANIZATION_FLUSH_FREQUENCY` and
     `BUCKET_FLUSH_FREQUENCY`. So if the flush frequency is one day, and bucket flush frequency
     is 1 minute, then we'll have 1440 buckets. This allows us to spread the load of
     these checks throughout the day instead of processing them all at the same time.
@@ -51,23 +53,52 @@ def add_base_url_to_rank(project: Project, base_url: str):
     trimming it on every call.
     """
     cluster = _get_cluster()
-    bucket_key = get_project_bucket_key(project)
+    org_projects_key = build_org_projects_key(project.organization)
     pipeline = cluster.pipeline()
-    pipeline.hincrby(bucket_key, str(project.id), 1)
+    pipeline.zincrby(org_projects_key, 1, str(project.id))
     rank_key = get_project_base_url_rank_key(project)
     pipeline.zincrby(rank_key, 1, base_url)
     if random.random() < RANKED_TRIM_CHANCE:
         pipeline.zremrangebyrank(rank_key, 0, -(RANKED_MAX_SIZE + 1))
     project_incr_result = pipeline.execute()[0]
     if project_incr_result == 1:
+        pipeline = cluster.pipeline()
+        # Avoid adding the org to this set constantly, and instead just do it once per project
+        bucket_key = get_organization_bucket_key(project.organization)
+        pipeline.sadd(bucket_key, str(project.organization_id))
+        pipeline.expire(bucket_key, KEY_EXPIRY)
         # We don't want to constantly set expire on these rows to avoid load on redis.
-        # Instead we just set it when we increment the project for the first time, so
+        # Instead, we just set it when we increment the project for the first time, so
         # that we know it's when we create the zset.
         pipeline.expire(rank_key, KEY_EXPIRY)
-        # We don't know if this has been expired yet, but doing it once per project
+        # We don't know if this key has been expired yet, but expiring it once per project
         # shouldn't be too heavy
-        pipeline.expire(bucket_key, KEY_EXPIRY)
+        pipeline.expire(org_projects_key, KEY_EXPIRY)
         pipeline.execute()
+
+
+def get_candidate_projects_for_org(org: Organization) -> list[tuple[int, int]]:
+    """
+    Gets all projects related to the organization that have seen urls. Returns a tuple of (project_id, total_urls_seen).
+    Project ids are sorted by `total_urls_seen` desc.
+    """
+    key = build_org_projects_key(org)
+    cluster = _get_cluster()
+    return [
+        (int(project_id), count)
+        for project_id, count in cluster.zrange(
+            key, 0, -1, desc=True, withscores=True, score_cast_func=int
+        )
+    ]
+
+
+def delete_candidate_projects_for_org(org: Organization) -> None:
+    """
+    Deletes candidate projects related to the organization that have seen urls.
+    """
+    key = build_org_projects_key(org)
+    cluster = _get_cluster()
+    cluster.delete(key)
 
 
 def get_candidate_urls_for_project(project: Project) -> list[tuple[str, int]]:
@@ -93,39 +124,48 @@ def get_project_base_url_rank_key(project: Project) -> str:
     return f"p:r:{project.id}"
 
 
-def build_project_bucket_key(bucket: int):
-    return f"p:{bucket}"
+def build_organization_bucket_key(bucket: int):
+    return f"o:{bucket}"
 
 
-def get_project_bucket_key(project: Project) -> str:
-    project_bucket = int(project.id % NUMBER_OF_BUCKETS)
-    return build_project_bucket_key(project_bucket)
+def get_organization_bucket_key(organization: Organization) -> str:
+    org_bucket = int(organization.id % NUMBER_OF_BUCKETS)
+    return build_organization_bucket_key(org_bucket)
 
 
-def get_project_bucket_key_for_datetime(bucket_datetime: datetime) -> str:
+def get_organization_bucket_key_for_datetime(bucket_datetime: datetime) -> str:
     date_bucket = int(
         bucket_datetime.replace(second=0, microsecond=0).timestamp() % NUMBER_OF_BUCKETS
     )
-    return build_project_bucket_key(date_bucket)
+    return build_organization_bucket_key(date_bucket)
 
 
-def get_project_bucket(bucket: datetime) -> dict[int, int]:
+def build_org_projects_key(organization: Organization) -> str:
+    return f"o-p:{organization.id}"
+
+
+def get_organization_bucket(bucket: datetime) -> set[int]:
     """
-    Fetch all projects from a specific datetime bucket. Returns a dict keyed by project id with the value as
-    the total count of seen valid urls
+    Fetch all organizations from a specific datetime bucket. Returns a set of organization ids
+    that have projects that have seen urls.
     """
-    key = get_project_bucket_key_for_datetime(bucket)
+    key = get_organization_bucket_key_for_datetime(bucket)
     cluster = _get_cluster()
-    return {int(key): int(val) for key, val in cluster.hgetall(key).items()}
+    return {int(organization_id) for organization_id in cluster.smembers(key)}
 
 
-def delete_project_bucket(bucket: datetime) -> None:
+def delete_organization_bucket(bucket: datetime) -> None:
     """
-    Delete all projects from a specific datetime bucket.
+    Delete all organizations from a specific datetime bucket.
     """
-    key = get_project_bucket_key_for_datetime(bucket)
+    key = get_organization_bucket_key_for_datetime(bucket)
     cluster = _get_cluster()
     cluster.delete(key)
+
+
+def should_detect_for_organization(organization: Organization) -> bool:
+    # TODO: Check setting here
+    return True
 
 
 def should_detect_for_project(project: Project) -> bool:

--- a/tests/sentry/tasks/test_post_process.py
+++ b/tests/sentry/tasks/test_post_process.py
@@ -43,6 +43,7 @@ from sentry.models.groupowner import (
 )
 from sentry.models.groupsnooze import GroupSnooze
 from sentry.models.integrations.integration import Integration
+from sentry.models.organization import Organization
 from sentry.models.projectownership import ProjectOwnership
 from sentry.models.projectteam import ProjectTeam
 from sentry.models.userreport import UserReport
@@ -75,7 +76,7 @@ from sentry.testutils.silo import assume_test_silo_mode
 from sentry.testutils.skips import requires_snuba
 from sentry.types.activity import ActivityType
 from sentry.types.group import GroupSubStatus, PriorityLevel
-from sentry.uptime.detectors.ranking import _get_cluster, get_project_bucket_key
+from sentry.uptime.detectors.ranking import _get_cluster, get_organization_bucket_key
 from sentry.users.services.user.service import user_service
 from sentry.utils import json
 from sentry.utils.cache import cache
@@ -2149,10 +2150,10 @@ class UserReportEventLinkTestMixin(BasePostProgressGroupMixin):
 
 
 class DetectBaseUrlsForUptimeTestMixin(BasePostProgressGroupMixin):
-    def assert_project_key(self, project, exists: bool) -> None:
-        key = get_project_bucket_key(project)
+    def assert_organization_key(self, organization: Organization, exists: bool) -> None:
+        key = get_organization_bucket_key(organization)
         cluster = _get_cluster()
-        assert exists == cluster.hexists(key, str(project.id))
+        assert exists == cluster.sismember(key, str(organization.id))
 
     @with_feature("organizations:uptime-automatic-hostname-detection")
     def test_uptime_detection_feature_url(self):
@@ -2166,7 +2167,7 @@ class DetectBaseUrlsForUptimeTestMixin(BasePostProgressGroupMixin):
             is_new_group_environment=False,
             event=event,
         )
-        self.assert_project_key(self.project, True)
+        self.assert_organization_key(self.organization, True)
 
     @with_feature("organizations:uptime-automatic-hostname-detection")
     def test_uptime_detection_feature_no_url(self):
@@ -2180,7 +2181,7 @@ class DetectBaseUrlsForUptimeTestMixin(BasePostProgressGroupMixin):
             is_new_group_environment=False,
             event=event,
         )
-        self.assert_project_key(self.project, False)
+        self.assert_organization_key(self.organization, False)
 
     def test_uptime_detection_no_feature(self):
         event = self.create_event(
@@ -2193,7 +2194,7 @@ class DetectBaseUrlsForUptimeTestMixin(BasePostProgressGroupMixin):
             is_new_group_environment=False,
             event=event,
         )
-        self.assert_project_key(self.project, False)
+        self.assert_organization_key(self.organization, False)
 
 
 class DetectNewEscalationTestMixin(BasePostProgressGroupMixin):

--- a/tests/sentry/uptime/detectors/test_detector.py
+++ b/tests/sentry/uptime/detectors/test_detector.py
@@ -1,27 +1,27 @@
-from sentry.models.project import Project
+from sentry.models.organization import Organization
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers import with_feature
 from sentry.uptime.detectors.detector import detect_base_url_for_project
-from sentry.uptime.detectors.ranking import _get_cluster, get_project_bucket_key
+from sentry.uptime.detectors.ranking import _get_cluster, get_organization_bucket_key
 
 
 class DetectBaseUrlForProjectTest(TestCase):
-    def assert_project_key(self, project: Project, exists: bool) -> None:
-        key = get_project_bucket_key(project)
+    def assert_organization_key(self, organization: Organization, exists: bool) -> None:
+        key = get_organization_bucket_key(organization)
         cluster = _get_cluster()
-        assert exists == cluster.hexists(key, str(project.id))
+        assert exists == cluster.sismember(key, str(organization.id))
 
     @with_feature("organizations:uptime-automatic-hostname-detection")
     def test(self):
         detect_base_url_for_project(self.project, "https://sentry.io")
-        self.assert_project_key(self.project, True)
+        self.assert_organization_key(self.organization, True)
 
     def test_no_feature(self):
         detect_base_url_for_project(self.project, "https://sentry.io")
-        self.assert_project_key(self.project, False)
+        self.assert_organization_key(self.organization, False)
 
     @with_feature("organizations:uptime-automatic-hostname-detection")
     def test_disabled_for_project(self):
         self.project.update_option("sentry:uptime_autodetection", False)
         detect_base_url_for_project(self.project, "https://sentry.io")
-        self.assert_project_key(self.project, False)
+        self.assert_organization_key(self.organization, False)

--- a/tests/sentry/uptime/detectors/test_ranking.py
+++ b/tests/sentry/uptime/detectors/test_ranking.py
@@ -1,18 +1,20 @@
 from datetime import datetime
 from unittest import mock
 
+from sentry.models.organization import Organization
 from sentry.models.project import Project
 from sentry.testutils.cases import TestCase
 from sentry.uptime.detectors.ranking import (
     NUMBER_OF_BUCKETS,
     _get_cluster,
     add_base_url_to_rank,
+    build_org_projects_key,
     delete_candidate_urls_for_project,
-    delete_project_bucket,
+    delete_organization_bucket,
+    get_candidate_projects_for_org,
     get_candidate_urls_for_project,
+    get_organization_bucket,
     get_project_base_url_rank_key,
-    get_project_bucket,
-    get_project_bucket_key,
     should_detect_for_project,
 )
 
@@ -21,13 +23,13 @@ class AddBaseUrlToRankTest(TestCase):
     def assert_project_count(
         self, project: Project, count: int | None, expiry: int | None
     ) -> int | None:
-        key = get_project_bucket_key(project)
+        key = build_org_projects_key(project.organization)
         cluster = _get_cluster()
         if count is None:
-            assert not cluster.hexists(key, str(project.id))
+            assert not cluster.zscore(key, str(project.id))
             return None
         else:
-            assert int(str(cluster.hget(key, str(project.id)))) == count
+            assert int(float(str(cluster.zscore(key, str(project.id))))) == count
             return self.check_expiry(key, expiry)
 
     def assert_url_count(
@@ -104,6 +106,22 @@ class AddBaseUrlToRankTest(TestCase):
             assert cluster.zrange(key, 0, -1) == [url_2, url_1]
 
 
+class GetCandidateProjectsForOrgTest(TestCase):
+    def test(self):
+        assert get_candidate_projects_for_org(self.organization) == []
+        url_1 = "https://sentry.io"
+        url_2 = "https://sentry.sentry.io"
+        add_base_url_to_rank(self.project, url_1)
+        assert get_candidate_projects_for_org(self.organization) == [(self.project.id, 1)]
+        add_base_url_to_rank(self.project, url_2)
+        project_2 = self.create_project()
+        add_base_url_to_rank(project_2, url_2)
+        assert get_candidate_projects_for_org(self.organization) == [
+            (self.project.id, 2),
+            (project_2.id, 1),
+        ]
+
+
 class GetCandidateUrlsForProjectTest(TestCase):
     def test(self):
         assert get_candidate_urls_for_project(self.project) == []
@@ -126,26 +144,28 @@ class DeleteCandidateUrlsForProjectTest(TestCase):
         assert get_candidate_urls_for_project(self.project) == []
 
 
-class GetProjectBucketTest(TestCase):
+class GetOrganizationBucketTest(TestCase):
     def test(self):
         bucket = datetime.now().replace(second=0, microsecond=0)
-        assert get_project_bucket(bucket) == {}
-        dummy_project_id = int(bucket.timestamp() % NUMBER_OF_BUCKETS)
-        self.project.id = dummy_project_id
+        assert get_organization_bucket(bucket) == set()
+        dummy_org_id = int(bucket.timestamp() % NUMBER_OF_BUCKETS)
+        self.project.organization = Organization(id=dummy_org_id)
+        self.project.organization_id = dummy_org_id
         add_base_url_to_rank(self.project, "https://sentry.io")
-        assert get_project_bucket(bucket) == {self.project.id: 1}
+        assert get_organization_bucket(bucket) == {self.project.organization_id}
 
 
-class DeleteProjectBucketTest(TestCase):
+class DeleteOrganizationBucketTest(TestCase):
     def test(self):
         bucket = datetime.now().replace(second=0, microsecond=0)
-        delete_project_bucket(bucket)
-        dummy_project_id = int(bucket.timestamp() % NUMBER_OF_BUCKETS)
-        self.project.id = dummy_project_id
+        delete_organization_bucket(bucket)
+        dummy_org_id = int(bucket.timestamp() % NUMBER_OF_BUCKETS)
+        self.project.organization = Organization(id=dummy_org_id)
+        self.project.organization_id = dummy_org_id
         add_base_url_to_rank(self.project, "https://sentry.io")
-        assert get_project_bucket(bucket) == {self.project.id: 1}
-        delete_project_bucket(bucket)
-        assert get_project_bucket(bucket) == {}
+        assert get_organization_bucket(bucket) == {self.project.organization_id}
+        delete_organization_bucket(bucket)
+        assert get_organization_bucket(bucket) == set()
 
 
 class ShouldDetectForProjectTest(TestCase):

--- a/tests/sentry/uptime/detectors/test_tasks.py
+++ b/tests/sentry/uptime/detectors/test_tasks.py
@@ -8,6 +8,7 @@ from urllib.robotparser import RobotFileParser
 from django.utils import timezone
 
 from sentry.locks import locks
+from sentry.models.organization import Organization
 from sentry.models.project import Project
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers import with_feature
@@ -16,7 +17,7 @@ from sentry.uptime.detectors.ranking import (
     NUMBER_OF_BUCKETS,
     _get_cluster,
     add_base_url_to_rank,
-    get_project_bucket,
+    get_organization_bucket,
 )
 from sentry.uptime.detectors.tasks import (
     LAST_PROCESSED_KEY,
@@ -26,6 +27,7 @@ from sentry.uptime.detectors.tasks import (
     monitor_url_for_project,
     process_candidate_url,
     process_detection_bucket,
+    process_organization_url_ranking,
     process_project_url_ranking,
     schedule_detections,
     set_failed_url,
@@ -90,28 +92,68 @@ class ScheduleDetectionsTest(TestCase):
 class ProcessDetectionBucketTest(TestCase):
     def test_empty_bucket(self):
         with mock.patch(
-            "sentry.uptime.detectors.tasks.process_project_url_ranking"
+            "sentry.uptime.detectors.tasks.process_organization_url_ranking"
         ) as mock_process_project_url_ranking:
             process_detection_bucket(timezone.now().replace(second=0, microsecond=0))
             mock_process_project_url_ranking.delay.assert_not_called()
 
     def test_bucket(self):
         bucket = timezone.now().replace(second=0, microsecond=0)
-        dummy_project_id = int(bucket.timestamp() % NUMBER_OF_BUCKETS)
-        self.project.id = dummy_project_id
-        other_project = Project(dummy_project_id + NUMBER_OF_BUCKETS)
+        dummy_organization_id = int(bucket.timestamp() % NUMBER_OF_BUCKETS)
+
+        self.project.organization = Organization(id=dummy_organization_id)
+
+        other_project = Project(
+            id=1245, organization=Organization(id=dummy_organization_id + NUMBER_OF_BUCKETS)
+        )
         add_base_url_to_rank(self.project, "https://sentry.io")
         add_base_url_to_rank(other_project, "https://sentry.io")
 
         with mock.patch(
-            "sentry.uptime.detectors.tasks.process_project_url_ranking"
-        ) as mock_process_project_url_ranking:
+            "sentry.uptime.detectors.tasks.process_organization_url_ranking"
+        ) as mock_process_organization_url_ranking:
             process_detection_bucket(bucket)
-            mock_process_project_url_ranking.delay.assert_has_calls(
-                [call(self.project.id, 1), call(other_project.id, 1)], any_order=True
+            mock_process_organization_url_ranking.delay.assert_has_calls(
+                [call(self.project.organization.id), call(other_project.organization.id)],
+                any_order=True,
             )
 
-        assert get_project_bucket(bucket) == {}
+        assert get_organization_bucket(bucket) == set()
+
+
+@freeze_time()
+class ProcessOrganizationUrlRankingTest(TestCase):
+    def test(self):
+        # TODO: Better testing for this function when we implement things that happen on success
+        url_1 = "https://sentry.io"
+        url_2 = "https://sentry.sentry.io"
+        project_2 = self.create_project()
+        add_base_url_to_rank(self.project, url_2)
+        add_base_url_to_rank(self.project, url_1)
+        add_base_url_to_rank(self.project, url_1)
+        add_base_url_to_rank(project_2, url_1)
+        with mock.patch(
+            "sentry.uptime.detectors.tasks.process_project_url_ranking",
+            return_value=False,
+        ) as mock_process_project_url_ranking:
+            process_organization_url_ranking(self.organization)
+            mock_process_project_url_ranking.assert_has_calls(
+                [
+                    call(self.project, 3),
+                    call(project_2, 1),
+                ]
+            )
+
+    def test_should_not_detect(self):
+        with mock.patch(
+            # TODO: Replace this mock with real tests when we implement this function properly
+            "sentry.uptime.detectors.tasks.should_detect_for_project",
+            return_value=False,
+        ), mock.patch(
+            "sentry.uptime.detectors.tasks.get_candidate_urls_for_project"
+        ) as mock_get_candidate_urls_for_project:
+            assert not process_project_url_ranking(self.project, 5)
+            mock_get_candidate_urls_for_project.assert_not_called()
 
 
 @freeze_time()
@@ -127,7 +169,7 @@ class ProcessProjectUrlRankingTest(TestCase):
             "sentry.uptime.detectors.tasks.process_candidate_url",
             return_value=False,
         ) as mock_process_candidate_url:
-            process_project_url_ranking(self.project.id, 5)
+            assert not process_project_url_ranking(self.project, 5)
             mock_process_candidate_url.assert_has_calls(
                 [
                     call(self.project, 5, url_1, 2),
@@ -140,7 +182,7 @@ class ProcessProjectUrlRankingTest(TestCase):
         with mock.patch(
             "sentry.uptime.detectors.tasks.get_candidate_urls_for_project"
         ) as mock_get_candidate_urls_for_project:
-            process_project_url_ranking(self.project.id, 5)
+            assert not process_project_url_ranking(self.project, 5)
             mock_get_candidate_urls_for_project.assert_not_called()
 
 


### PR DESCRIPTION
This changes detection to be keyed on organizations rather than projects. This means that we process detection for all projects in an organization at the same time.

This allows us to limit the number of automatically generated uptime subscriptions to the amount of quota available, and also lets us prioritise the highest volume project.
