### PR TITLE
ref(StructuredEventData): Rewrite expand/collapse state into a provider

### DIFF
--- a/static/app/components/structuredEventData/collapsibleValue.tsx
+++ b/static/app/components/structuredEventData/collapsibleValue.tsx
@@ -24,7 +24,6 @@ export function CollapsibleValue({
 }: Props) {
   const {collapse, expand, isExpanded: isInitiallyExpanded} = useExpandedState({path});
   const [isExpanded, setIsExpanded] = useState(isInitiallyExpanded);
-  // const isExpanded = expandedPaths.includes(path);
 
   const numChildren = Children.count(children);
 

--- a/static/app/components/structuredEventData/collapsibleValue.tsx
+++ b/static/app/components/structuredEventData/collapsibleValue.tsx
@@ -1,4 +1,4 @@
-import {Children, type ReactNode} from 'react';
+import {Children, type ReactNode, useState} from 'react';
 import styled from '@emotion/styled';
 
 import {Button} from 'sentry/components/button';
@@ -22,8 +22,9 @@ export function CollapsibleValue({
   path,
   prefix = null,
 }: Props) {
-  const {collapse, expand, expandedPaths} = useExpandedState();
-  const isExpanded = expandedPaths.includes(path);
+  const {collapse, expand, isExpanded: isInitiallyExpanded} = useExpandedState({path});
+  const [isExpanded, setIsExpanded] = useState(isInitiallyExpanded);
+  // const isExpanded = expandedPaths.includes(path);
 
   const numChildren = Children.count(children);
 
@@ -40,7 +41,15 @@ export function CollapsibleValue({
         <ToggleButton
           size="zero"
           aria-label={isExpanded ? t('Collapse') : t('Expand')}
-          onClick={() => (isExpanded ? collapse(path) : expand(path))}
+          onClick={() => {
+            if (isExpanded) {
+              collapse();
+              setIsExpanded(false);
+            } else {
+              expand();
+              setIsExpanded(true);
+            }
+          }}
           icon={
             <IconChevron direction={isExpanded ? 'down' : 'right'} legacySize="10px" />
           }
@@ -51,7 +60,13 @@ export function CollapsibleValue({
       {prefix}
       <span>{openTag}</span>
       {shouldShowToggleButton && !isExpanded ? (
-        <NumItemsButton size="zero" onClick={() => expand(path)}>
+        <NumItemsButton
+          size="zero"
+          onClick={() => {
+            expand();
+            setIsExpanded(true);
+          }}
+        >
           {tn('%s item', '%s items', numChildren)}
         </NumItemsButton>
       ) : null}

--- a/static/app/components/structuredEventData/collapsibleValue.tsx
+++ b/static/app/components/structuredEventData/collapsibleValue.tsx
@@ -1,44 +1,34 @@
-import {Children, useState} from 'react';
+import {Children, type ReactNode} from 'react';
 import styled from '@emotion/styled';
 
 import {Button} from 'sentry/components/button';
+import useExpandedState from 'sentry/components/structuredEventData/useExpandedState';
 import {IconChevron} from 'sentry/icons';
 import {t, tn} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 
-type CollapsibleValueProps = {
-  children: React.ReactNode;
+interface Props {
+  children: ReactNode;
   closeTag: string;
-  depth: number;
-  maxDefaultDepth: number;
   openTag: string;
-  /**
-   * Forces the value to start expanded, otherwise it will expand if there are
-   * less than 5 (MAX_ITEMS_BEFORE_AUTOCOLLAPSE) items
-   */
-  forceDefaultExpand?: boolean;
-  prefix?: React.ReactNode;
-};
-
-const MAX_ITEMS_BEFORE_AUTOCOLLAPSE = 5;
+  path: string;
+  prefix?: ReactNode;
+}
 
 export function CollapsibleValue({
   children,
-  openTag,
   closeTag,
+  openTag,
+  path,
   prefix = null,
-  depth,
-  maxDefaultDepth,
-  forceDefaultExpand,
-}: CollapsibleValueProps) {
+}: Props) {
+  const {collapse, expand, expandedPaths} = useExpandedState();
+  const isExpanded = expandedPaths.includes(path);
+
   const numChildren = Children.count(children);
-  const [isExpanded, setIsExpanded] = useState(
-    forceDefaultExpand ??
-      (numChildren <= MAX_ITEMS_BEFORE_AUTOCOLLAPSE && depth < maxDefaultDepth)
-  );
 
   const shouldShowToggleButton = numChildren > 0;
-  const isBaseLevel = depth === 0;
+  const isBaseLevel = path === '$';
 
   // Toggle buttons get placed to the left of the open tag, but if this is the
   // base level there is no room for it. So we add padding in this case.
@@ -50,7 +40,7 @@ export function CollapsibleValue({
         <ToggleButton
           size="zero"
           aria-label={isExpanded ? t('Collapse') : t('Expand')}
-          onClick={() => setIsExpanded(oldValue => !oldValue)}
+          onClick={() => (isExpanded ? collapse(path) : expand(path))}
           icon={
             <IconChevron direction={isExpanded ? 'down' : 'right'} legacySize="10px" />
           }
@@ -61,7 +51,7 @@ export function CollapsibleValue({
       {prefix}
       <span>{openTag}</span>
       {shouldShowToggleButton && !isExpanded ? (
-        <NumItemsButton size="zero" onClick={() => setIsExpanded(true)}>
+        <NumItemsButton size="zero" onClick={() => expand(path)}>
           {tn('%s item', '%s items', numChildren)}
         </NumItemsButton>
       ) : null}

--- a/static/app/components/structuredEventData/index.stories.tsx
+++ b/static/app/components/structuredEventData/index.stories.tsx
@@ -1,4 +1,4 @@
-import {Fragment} from 'react';
+import {Fragment, useState} from 'react';
 
 import {addSuccessMessage} from 'sentry/actionCreators/indicator';
 import {CodeSnippet} from 'sentry/components/codeSnippet';
@@ -97,6 +97,28 @@ export default storyBook(StructuredEventData, story => {
           />
         </div>
       </SideBySide>
+    );
+  });
+
+  story('onToggleExpand', () => {
+    const [state, setState] = useState<string[]>();
+    return (
+      <Fragment>
+        <p>
+          You can keep track of the expanded/collapsed state so the component looks the
+          same even if it's re-rendered on the screen at a later time (like in a virtual
+          scrolling list).
+        </p>
+        <p>
+          The <JSXProperty name="onToggleExpand" value={Function} /> callback is not
+          triggered on mount.
+        </p>
+        <p>Current expanded state: {JSON.stringify(state, null, '\t')}</p>
+        <StructuredEventData
+          data={{foo: 'bar', arr: [1, 2, 3, 4, 5, 6]}}
+          onToggleExpand={expandedPaths => setState(expandedPaths)}
+        />
+      </Fragment>
     );
   });
 

--- a/static/app/components/structuredEventData/index.stories.tsx
+++ b/static/app/components/structuredEventData/index.stories.tsx
@@ -5,6 +5,7 @@ import {CodeSnippet} from 'sentry/components/codeSnippet';
 import JSXNode from 'sentry/components/stories/jsxNode';
 import JSXProperty from 'sentry/components/stories/jsxProperty';
 import Matrix from 'sentry/components/stories/matrix';
+import SideBySide from 'sentry/components/stories/sideBySide';
 import StructuredEventData from 'sentry/components/structuredEventData';
 import storyBook from 'sentry/stories/storyBook';
 
@@ -51,6 +52,53 @@ export default storyBook(StructuredEventData, story => {
       selectedProps={['forceDefaultExpand', 'maxDefaultDepth']}
     />
   ));
+
+  story('Manually expanded items', () => {
+    const data = {
+      foo: 'bar',
+      'the_real_world?': {
+        the_city: {
+          the_hotel: {
+            the_fortress: 'a pinwheel',
+          },
+        },
+      },
+      arr5: [1, 2, 3, 4, 5],
+      arr6: [1, 2, 3, 4, 5, 6],
+    };
+    return (
+      <SideBySide>
+        <div>
+          <p>Nothing</p>
+          <StructuredEventData data={data} initialExpandedPaths={[]} />
+        </div>
+        <div>
+          <p>Root only</p>
+          <StructuredEventData data={data} initialExpandedPaths={['$']} />
+        </div>
+        <div>
+          <p>1st level</p>
+          <StructuredEventData
+            data={data}
+            initialExpandedPaths={['$', '$.the_real_world?', '$.arr5', '$.arr6']}
+          />
+        </div>
+        <div>
+          <p>Depth first</p>
+          <StructuredEventData
+            data={data}
+            initialExpandedPaths={[
+              '$',
+              '$.the_real_world?',
+              '$.the_real_world?.the_city',
+              '$.the_real_world?.the_city.the_hotel',
+              '$.the_real_world?.the_city.the_hotel.the_fortress',
+            ]}
+          />
+        </div>
+      </SideBySide>
+    );
+  });
 
   story('Annotations', () => {
     return (

--- a/static/app/components/structuredEventData/index.tsx
+++ b/static/app/components/structuredEventData/index.tsx
@@ -58,8 +58,8 @@ interface BaseProps {
    * Pass this into `initialExpandedPaths` to re-render a previous expanded state
    */
   onToggleExpand?: (
-    path: string,
     expandedPaths: string[],
+    path: string,
     state: 'expanded' | 'collapsed'
   ) => void;
 }

--- a/static/app/components/structuredEventData/index.tsx
+++ b/static/app/components/structuredEventData/index.tsx
@@ -1,7 +1,10 @@
+import {useCallback} from 'react';
 import styled from '@emotion/styled';
 
 import {CopyToClipboardButton} from 'sentry/components/copyToClipboardButton';
 import {RecursiveStructuredData} from 'sentry/components/structuredEventData/recursiveStructuredData';
+import {ExpandedStateContextProvider} from 'sentry/components/structuredEventData/useExpandedState';
+import {getDefaultExpanded} from 'sentry/components/structuredEventData/utils';
 import {space} from 'sentry/styles/space';
 
 export type StructedEventDataConfig = {
@@ -15,12 +18,55 @@ export type StructedEventDataConfig = {
   renderString?: (value: string) => string;
 };
 
-interface StructuredDataProps {
-  maxDefaultDepth: number;
-  withAnnotatedText: boolean;
+interface BaseProps {
+  /**
+   * Allows customization of how values are rendered
+   */
   config?: StructedEventDataConfig;
+
+  /**
+   * Enables auto-expansion of items on initial render.
+   */
   forceDefaultExpand?: boolean;
+
+  /**
+   * Array of the paths to expand, can be arbitrarily deep. Only takes effect on
+   * mount.
+   *
+   * Overrides `forceDefaultExpand` and `maxDefaultDepth`.
+   *
+   * paths is a "." concatenated list of array-indexes and object-keys starting
+   * from '$' as the root.
+   * example: "$.users.0" would expand  `{users: [{name: 'cramer'}]}`
+   */
+  initialExpandedPaths?: string[];
+
+  /**
+   * Set the max depth to expand items. Default: 2
+   *
+   * Only items with 5 or fewer children can be auto-expanded.
+   *
+   * Only takes affect when `forceDefaultExpand` is `true` or `undefined`
+   */
+  maxDefaultDepth?: number;
+
   meta?: Record<any, any>;
+
+  /**
+   * A callback to keep track of expanded items.
+   *
+   * Pass this into `initialExpandedPaths` to re-render a previous expanded state
+   */
+  onToggleExpand?: (
+    path: string,
+    expandedPaths: string[],
+    state: 'expanded' | 'collapsed'
+  ) => void;
+}
+
+interface StructuredDataProps extends BaseProps {
+  maxDefaultDepth: NonNullable<BaseProps['maxDefaultDepth']>;
+  withAnnotatedText: boolean;
   objectKey?: string;
   // TODO(TS): What possible types can `value` be?
   value?: any;
@@ -29,73 +75,85 @@ interface StructuredDataProps {
 
 export function StructuredData({
   config,
-  value = null,
+  forceDefaultExpand,
+  initialExpandedPaths,
   maxDefaultDepth,
-  withAnnotatedText,
-  withOnlyFormattedText = false,
   meta,
   objectKey,
-  forceDefaultExpand,
+  onToggleExpand,
+  value = null,
+  withAnnotatedText,
+  withOnlyFormattedText = false,
 }: StructuredDataProps) {
+  const getInitialExpandedPaths = useCallback(() => {
+    return (
+      initialExpandedPaths ??
+      (forceDefaultExpand === false ||
+      (forceDefaultExpand === undefined && !maxDefaultDepth)
+        ? []
+        : getDefaultExpanded(Math.max(1, maxDefaultDepth), value))
+    );
+
+    // No need to update if expand/collapse props changes, we're not going to
+    // re-render based on those.
+  }, [value]); // eslint-disable-line react-hooks/exhaustive-deps
+
   return (
-    <RecursiveStructuredData
-      config={config}
-      depth={0}
-      value={value}
-      maxDefaultDepth={maxDefaultDepth}
-      withAnnotatedText={withAnnotatedText}
-      withOnlyFormattedText={withOnlyFormattedText}
-      meta={meta}
-      objectKey={objectKey}
-      forceDefaultExpand={forceDefaultExpand}
-    />
+    <ExpandedStateContextProvider
+      initialExpandedPaths={getInitialExpandedPaths}
+      onToggleExpand={onToggleExpand}
+    >
+      <RecursiveStructuredData
+        config={config}
+        meta={meta}
+        objectKey={objectKey}
+        path="$"
+        value={value}
+        withAnnotatedText={withAnnotatedText}
+        withOnlyFormattedText={withOnlyFormattedText}
+      />
+    </ExpandedStateContextProvider>
   );
 }
 
-export interface StructuredEventDataProps {
+export interface StructuredEventDataProps extends BaseProps {
   children?: React.ReactNode;
   className?: string;
-  /**
-   * Allows customization of how values are rendered
-   */
-  config?: StructedEventDataConfig;
   // TODO(TS): What possible types can `data` be?
   data?: any;
   'data-test-id'?: string;
-  /**
-   * Forces objects to default to expanded when rendered
-   */
-  forceDefaultExpand?: boolean;
-  maxDefaultDepth?: number;
-  meta?: Record<any, any>;
   onCopy?: (copiedCode: string) => void;
   showCopyButton?: boolean;
   withAnnotatedText?: boolean;
 }
 
 export default function StructuredEventData({
-  config,
   children,
-  meta,
-  maxDefaultDepth = 2,
+  config,
   data = null,
-  withAnnotatedText = false,
   forceDefaultExpand,
-  showCopyButton,
+  initialExpandedPaths,
+  maxDefaultDepth = 2,
+  meta,
   onCopy,
+  onToggleExpand,
+  showCopyButton,
+  withAnnotatedText = false,
   ...props
 }: StructuredEventDataProps) {
   return (
     <StructuredDataWrapper {...props}>
-      <RecursiveStructuredData
+      <StructuredData
         config={config}
-        value={data}
-        depth={0}
+        forceDefaultExpand={forceDefaultExpand}
+        initialExpandedPaths={initialExpandedPaths}
         maxDefaultDepth={maxDefaultDepth}
         meta={meta}
+        onToggleExpand={onToggleExpand}
+        value={data}
         withAnnotatedText={withAnnotatedText}
-        forceDefaultExpand={forceDefaultExpand}
       />
+
       {children}
       {showCopyButton && (
         <StyledCopyButton

--- a/static/app/components/structuredEventData/recursiveStructuredData.tsx
+++ b/static/app/components/structuredEventData/recursiveStructuredData.tsx
@@ -5,10 +5,10 @@ import AnnotatedValue from 'sentry/components/structuredEventData/annotatedValue
 import {CollapsibleValue} from 'sentry/components/structuredEventData/collapsibleValue';
 import LinkHint from 'sentry/components/structuredEventData/linkHint';
 import {
-  looksLikeMultiLineString,
   looksLikeStrippedValue,
   naturalCaseInsensitiveSort,
 } from 'sentry/components/structuredEventData/utils';
+import containsCRLF from 'sentry/utils/string/containsCRLF';
 
 type Config = {
   isBoolean?: (value: unknown) => boolean;
@@ -146,7 +146,7 @@ export function RecursiveStructuredData({
       );
     }
 
-    if (looksLikeMultiLineString(value)) {
+    if (containsCRLF(value)) {
       return (
         <Wrapper>
           <ValueMultiLineString data-test-id="value-multiline-string">

--- a/static/app/components/structuredEventData/recursiveStructuredData.tsx
+++ b/static/app/components/structuredEventData/recursiveStructuredData.tsx
@@ -22,12 +22,10 @@ type Config = {
 };
 
 interface Props {
-  depth: number;
-  maxDefaultDepth: number;
   meta: Record<any, any> | undefined;
+  path: string;
   withAnnotatedText: boolean;
   config?: Config;
-  forceDefaultExpand?: boolean;
   objectKey?: string;
   // TODO(TS): What possible types can `value` be?
   value?: any;
@@ -36,14 +34,12 @@ interface Props {
 
 export function RecursiveStructuredData({
   config,
-  depth,
-  value = null,
-  maxDefaultDepth,
-  withAnnotatedText,
-  withOnlyFormattedText = false,
   meta,
   objectKey,
-  forceDefaultExpand,
+  path,
+  value = null,
+  withAnnotatedText,
+  withOnlyFormattedText = false,
 }: Props) {
   let i = 0;
 
@@ -188,24 +184,17 @@ export function RecursiveStructuredData({
         <div key={i}>
           <RecursiveStructuredData
             config={config}
-            value={value[i]}
-            depth={depth + 1}
-            withAnnotatedText={withAnnotatedText}
             meta={meta?.[i]}
-            maxDefaultDepth={maxDefaultDepth}
+            path={path + '.' + i}
+            value={value[i]}
+            withAnnotatedText={withAnnotatedText}
           />
           {i < value.length - 1 ? <span>{','}</span> : null}
         </div>
       );
     }
     return (
-      <CollapsibleValue
-        openTag="["
-        closeTag="]"
-        prefix={formattedObjectKey}
-        maxDefaultDepth={maxDefaultDepth}
-        depth={depth}
-      >
+      <CollapsibleValue closeTag="]" openTag="[" path={path} prefix={formattedObjectKey}>
         {children}
       </CollapsibleValue>
     );
@@ -224,12 +213,11 @@ export function RecursiveStructuredData({
       <div key={key}>
         <RecursiveStructuredData
           config={config}
-          value={value[key]}
-          depth={depth + 1}
-          withAnnotatedText={withAnnotatedText}
           meta={meta?.[key]}
-          maxDefaultDepth={maxDefaultDepth}
           objectKey={key}
+          path={path + '.' + key}
+          value={value[key]}
+          withAnnotatedText={withAnnotatedText}
         />
         {i < keys.length - 1 ? <span>{','}</span> : null}
       </div>
@@ -237,14 +225,7 @@ export function RecursiveStructuredData({
   }
 
   return (
-    <CollapsibleValue
-      openTag="{"
-      closeTag="}"
-      prefix={formattedObjectKey}
-      maxDefaultDepth={maxDefaultDepth}
-      depth={depth}
-      forceDefaultExpand={forceDefaultExpand}
-    >
+    <CollapsibleValue closeTag="}" openTag="{" path={path} prefix={formattedObjectKey}>
       {children}
     </CollapsibleValue>
   );

--- a/static/app/components/structuredEventData/useExpandedState.tsx
+++ b/static/app/components/structuredEventData/useExpandedState.tsx
@@ -1,0 +1,59 @@
+import type {ReactNode} from 'react';
+import {createContext, useCallback, useContext, useMemo, useState} from 'react';
+
+import {uniq} from 'sentry/utils/array/uniq';
+
+type State = 'expanded' | 'collapsed';
+
+const context = createContext<{
+  collapse: (path: string) => void;
+  expand: (path: string) => void;
+  expandedPaths: string[];
+}>({
+  collapse: () => {},
+  expand: () => {},
+  expandedPaths: [],
+});
+
+interface Props {
+  children: ReactNode;
+  initialExpandedPaths: string[] | (() => string[]);
+  onToggleExpand?: (path: string, expandedPaths: string[], state: State) => void;
+}
+
+export function ExpandedStateContextProvider({
+  children,
+  initialExpandedPaths,
+  onToggleExpand,
+}: Props) {
+  const [expandedPaths, setState] = useState<string[]>(initialExpandedPaths);
+
+  const expand = useCallback(
+    path => {
+      const newState = uniq(expandedPaths.concat(path));
+      setState(newState);
+      onToggleExpand?.(path, newState, 'expanded');
+    },
+    [expandedPaths, onToggleExpand]
+  );
+
+  const collapse = useCallback(
+    path => {
+      const newState = expandedPaths.filter(prevPath => path !== prevPath);
+      setState(newState);
+      onToggleExpand?.(path, newState, 'collapsed');
+    },
+    [expandedPaths, onToggleExpand]
+  );
+
+  const value = useMemo(
+    () => ({collapse, expand, expandedPaths}),
+    [collapse, expand, expandedPaths]
+  );
+
+  return <context.Provider value={value}>{children}</context.Provider>;
+}
+
+export default function useExpandedState() {
+  return useContext(context);
+}

--- a/static/app/components/structuredEventData/utils.tsx
+++ b/static/app/components/structuredEventData/utils.tsx
@@ -1,35 +1,6 @@
 import isPlainObject from 'lodash/isPlainObject';
 
-const STRIPPED_VALUE_REGEX = /^['"]?\*{8,}['"]?$/;
-
-export function looksLikeObjectRepr(value: string) {
-  const a = value[0];
-  const z = value[value.length - 1];
-
-  if (a === '<' && z === '>') {
-    return true;
-  }
-
-  if (a === '[' && z === ']') {
-    return true;
-  }
-
-  if (a === '(' && z === ')') {
-    return true;
-  }
-
-  if (z === ')' && value.match(/^[\w\d._-]+\(/)) {
-    return true;
-  }
-
-  return false;
-}
-
-export function looksLikeMultiLineString(value: string) {
-  return !!value.match(/[\r\n]/);
-}
-
-export function padNumbersInString(string: string) {
+function padNumbersInString(string: string) {
   return string.replace(/(\d+)/g, (num: string) => {
     let isNegative = false;
     let realNum = parseInt(num, 10);
@@ -51,6 +22,8 @@ export function naturalCaseInsensitiveSort(a: string, b: string) {
   b = padNumbersInString(b).toLowerCase();
   return a === b ? 0 : a < b ? -1 : 1;
 }
+
+const STRIPPED_VALUE_REGEX = /^['"]?\*{8,}['"]?$/;
 
 export function looksLikeStrippedValue(value: string) {
   return STRIPPED_VALUE_REGEX.test(value);

--- a/static/app/components/structuredEventData/utils.tsx
+++ b/static/app/components/structuredEventData/utils.tsx
@@ -1,3 +1,5 @@
+import isPlainObject from 'lodash/isPlainObject';
+
 const STRIPPED_VALUE_REGEX = /^['"]?\*{8,}['"]?$/;
 
 export function looksLikeObjectRepr(value: string) {
@@ -52,4 +54,34 @@ export function naturalCaseInsensitiveSort(a: string, b: string) {
 
 export function looksLikeStrippedValue(value: string) {
   return STRIPPED_VALUE_REGEX.test(value);
+}
+
+export function getDefaultExpanded(depth: number, value: any) {
+  const MAX_ITEMS_BEFORE_AUTOCOLLAPSE = 5;
+
+  function recurse(prefix: string, levels: number, val: any) {
+    if (!levels) {
+      return [];
+    }
+
+    if (Array.isArray(val) && val.length <= MAX_ITEMS_BEFORE_AUTOCOLLAPSE) {
+      return [
+        prefix,
+        ...val.flatMap((v, i) => {
+          return recurse(`${prefix}.${i}`, levels - 1, v);
+        }),
+      ];
+    }
+    if (isPlainObject(val) && Object.keys(val).length <= MAX_ITEMS_BEFORE_AUTOCOLLAPSE) {
+      return [
+        prefix,
+        ...Object.entries(val).flatMap(([k, v]) => {
+          return recurse(`${prefix}.${k}`, levels - 1, v);
+        }),
+      ];
+    }
+    return [];
+  }
+
+  return recurse('$', depth, value);
 }

--- a/static/app/utils/replays/countDomNodes.tsx
+++ b/static/app/utils/replays/countDomNodes.tsx
@@ -1,6 +1,5 @@
 import replayerStepper from 'sentry/utils/replays/replayerStepper';
 import type {RecordingFrame} from 'sentry/utils/replays/types';
-import useOrganization from 'sentry/utils/useOrganization';
 
 export type DomNodeChartDatapoint = {
   added: number;
@@ -27,7 +26,6 @@ export default function countDomNodes({
   const frameStep = Math.max(Math.round(length * 0.007), 1);
 
   let prevIds: number[] = [];
-  useOrganization();
 
   return replayerStepper<RecordingFrame, DomNodeChartDatapoint>({
     frames,

--- a/static/app/utils/replays/countDomNodes.tsx
+++ b/static/app/utils/replays/countDomNodes.tsx
@@ -1,5 +1,6 @@
 import replayerStepper from 'sentry/utils/replays/replayerStepper';
 import type {RecordingFrame} from 'sentry/utils/replays/types';
+import useOrganization from 'sentry/utils/useOrganization';
 
 export type DomNodeChartDatapoint = {
   added: number;
@@ -26,6 +27,7 @@ export default function countDomNodes({
   const frameStep = Math.max(Math.round(length * 0.007), 1);
 
   let prevIds: number[] = [];
+  useOrganization();
 
   return replayerStepper<RecordingFrame, DomNodeChartDatapoint>({
     frames,

--- a/static/app/utils/string/containsCRLF.ts
+++ b/static/app/utils/string/containsCRLF.ts
@@ -1,0 +1,5 @@
+const CRLF_REGEXP = /[\r\n]/;
+
+export default function containsCRLF(value: string) {
+  return !!value.match(CRLF_REGEXP);
+}


### PR DESCRIPTION
Pushed the expand/collapse state into a provider, which accepts a callback so external systems can save the state and pass it back in on mount so that the component will render fresh with the state from an old component.

There's a `useRef` to track the overall state of things in the provider, and each `<CollapsibleValue>` has it's own `setState` so when something is toggled we don't endup having react look at the whole tree.