### PR TITLE
feat(metrics-extraction): Allow defining unit

### DIFF
--- a/static/app/views/metrics/metricQueryContextMenu.tsx
+++ b/static/app/views/metrics/metricQueryContextMenu.tsx
@@ -165,7 +165,6 @@ export function MetricQueryContextMenu({
             if (extractionRule) {
               openExtractionRuleEditModal({
                 metricExtractionRule: extractionRule,
-                // TODO: Remove virtual MRI as identifier
                 onSubmitSuccess: data => {
                   // Keep the unit of the MRI in sync with the unit of the extraction rule
                   // TODO: Remove this once we have a better way to handle this

--- a/static/app/views/metrics/metricQueryContextMenu.tsx
+++ b/static/app/views/metrics/metricQueryContextMenu.tsx
@@ -32,6 +32,7 @@ import {
   isMetricsQueryWidget,
   type MetricDisplayType,
   type MetricsQuery,
+  type MetricsQueryWidget,
 } from 'sentry/utils/metrics/types';
 import {useVirtualMetricsContext} from 'sentry/utils/metrics/virtualMetricsContext';
 import useOrganization from 'sentry/utils/useOrganization';
@@ -57,7 +58,7 @@ export function MetricQueryContextMenu({
   const organization = useOrganization();
   const router = useRouter();
 
-  const {removeWidget, duplicateWidget, widgets} = useMetricsContext();
+  const {removeWidget, duplicateWidget, widgets, updateWidget} = useMetricsContext();
   const createAlert = useMemo(
     () => getCreateAlert(organization, metricsQuery),
     [metricsQuery, organization]
@@ -164,6 +165,15 @@ export function MetricQueryContextMenu({
             if (extractionRule) {
               openExtractionRuleEditModal({
                 metricExtractionRule: extractionRule,
+                // TODO: Remove virtual MRI as identifier
+                onSubmitSuccess: data => {
+                  // Keep the unit of the MRI in sync with the unit of the extraction rule
+                  // TODO: Remove this once we have a better way to handle this
+                  const newMRI = metricsQuery.mri.replace(/@.*$/, `@${data.unit}`);
+                  updateWidget(widgetIndex, {
+                    mri: newMRI,
+                  } as Partial<MetricsQueryWidget>);
+                },
               });
             }
           }
@@ -191,6 +201,7 @@ export function MetricQueryContextMenu({
       widgetIndex,
       router,
       getExtractionRule,
+      updateWidget,
       removeWidget,
     ]
   );

--- a/static/app/views/settings/projectMetrics/metricsExtractionRuleCreateModal.tsx
+++ b/static/app/views/settings/projectMetrics/metricsExtractionRuleCreateModal.tsx
@@ -33,6 +33,7 @@ interface Props {
 
 const INITIAL_DATA: FormData = {
   spanAttribute: null,
+  unit: 'none',
   aggregates: ['count'],
   tags: ['release', 'environment'],
   conditions: [createCondition()],
@@ -165,7 +166,7 @@ function FormWrapper({
         spanAttribute: data.spanAttribute!,
         tags: data.tags,
         aggregates: data.aggregates.flatMap(explodeAggregateGroup),
-        unit: 'none',
+        unit: data.unit,
         conditions: data.conditions,
         projectId: Number(projectId),
         // Will be set by the backend

--- a/static/app/views/settings/projectMetrics/metricsExtractionRuleEditModal.tsx
+++ b/static/app/views/settings/projectMetrics/metricsExtractionRuleEditModal.tsx
@@ -22,6 +22,7 @@ import {useUpdateMetricsExtractionRules} from 'sentry/views/settings/projectMetr
 
 interface Props {
   metricExtractionRule: MetricsExtractionRule;
+  onSubmitSuccess?: (data: FormData) => void;
 }
 
 export function MetricsExtractionRuleEditModal({
@@ -30,6 +31,7 @@ export function MetricsExtractionRuleEditModal({
   closeModal,
   CloseButton,
   metricExtractionRule,
+  onSubmitSuccess: onSubmitSuccessProp,
 }: Props & ModalRenderProps) {
   const organization = useOrganization();
   const updateExtractionRuleMutation = useUpdateMetricsExtractionRules(
@@ -44,6 +46,7 @@ export function MetricsExtractionRuleEditModal({
   const initialData: FormData = useMemo(() => {
     return {
       spanAttribute: metricExtractionRule.spanAttribute,
+      unit: metricExtractionRule.unit,
       aggregates: aggregatesToGroups(metricExtractionRule.aggregates),
       tags: metricExtractionRule.tags,
       conditions: metricExtractionRule.conditions.length
@@ -63,7 +66,7 @@ export function MetricsExtractionRuleEditModal({
         spanAttribute: data.spanAttribute!,
         tags: data.tags,
         aggregates: data.aggregates.flatMap(explodeAggregateGroup),
-        unit: 'none',
+        unit: data.unit,
         conditions: data.conditions,
       };
 
@@ -74,6 +77,7 @@ export function MetricsExtractionRuleEditModal({
         {
           onSuccess: () => {
             onSubmitSuccess(data);
+            onSubmitSuccessProp?.(data);
             addSuccessMessage(t('Metric extraction rule updated'));
             closeModal();
           },
@@ -88,7 +92,7 @@ export function MetricsExtractionRuleEditModal({
       );
       onSubmitSuccess(data);
     },
-    [closeModal, metricExtractionRule, updateExtractionRuleMutation]
+    [closeModal, metricExtractionRule, onSubmitSuccessProp, updateExtractionRuleMutation]
   );
 
   return (

--- a/static/app/views/settings/projectMetrics/metricsExtractionRuleForm.tsx
+++ b/static/app/views/settings/projectMetrics/metricsExtractionRuleForm.tsx
@@ -324,6 +324,14 @@ export function MetricsExtractionRuleForm({
               setCustomeAttributes(curr => [...curr, value]);
               model.setValue('spanAttribute', value);
             }}
+            onChange={value => {
+              if (value in FIXED_UNITS_BY_ATTRIBUTE) {
+                model.setValue('unit', FIXED_UNITS_BY_ATTRIBUTE[value]);
+                setIsUnitDisabled(true);
+              } else {
+                setIsUnitDisabled(false);
+              }
+            }}
             required
           />
           <SelectField
@@ -334,14 +342,6 @@ export function MetricsExtractionRuleForm({
             placeholder={t('Select a unit')}
             creatable
             formatCreateLabel={value => `Custom: "${value}"`}
-            onChange={value => {
-              if (value in FIXED_UNITS_BY_ATTRIBUTE) {
-                model.setValue('unit', FIXED_UNITS_BY_ATTRIBUTE[value]);
-                setIsUnitDisabled(true);
-              } else {
-                setIsUnitDisabled(false);
-              }
-            }}
             onCreateOption={value => {
               setCustomUnit(value);
               model.setValue('unit', value);

--- a/static/app/views/settings/projectMetrics/metricsExtractionRuleForm.tsx
+++ b/static/app/views/settings/projectMetrics/metricsExtractionRuleForm.tsx
@@ -12,6 +12,7 @@ import {Tooltip} from 'sentry/components/tooltip';
 import {IconAdd, IconClose, IconWarning} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
+import type {SelectValue} from 'sentry/types/core';
 import type {MetricAggregation, MetricsExtractionCondition} from 'sentry/types/metrics';
 import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import {DEFAULT_METRICS_CARDINALITY_LIMIT} from 'sentry/utils/metrics/constants';
@@ -26,6 +27,7 @@ export interface FormData {
   conditions: MetricsExtractionCondition[];
   spanAttribute: string | null;
   tags: string[];
+  unit: string;
 }
 
 interface Props extends Omit<FormProps, 'onSubmit'> {
@@ -128,6 +130,38 @@ export function createCondition(): MetricsExtractionCondition {
   };
 }
 
+const SUPPORTED_UNITS = [
+  'none',
+  'nanosecond',
+  'microsecond',
+  'millisecond',
+  'second',
+  'minute',
+  'hour',
+  'day',
+  'week',
+  'ratio',
+  'percent',
+  'bit',
+  'byte',
+  'kibibyte',
+  'kilobyte',
+  'mebibyte',
+  'megabyte',
+  'gibibyte',
+  'gigabyte',
+  'tebibyte',
+  'terabyte',
+  'pebibyte',
+  'petabyte',
+  'exbibyte',
+  'exabyte',
+] as const;
+
+const isSupportedUnit = (unit: string): unit is (typeof SUPPORTED_UNITS)[number] => {
+  return SUPPORTED_UNITS.includes(unit as (typeof SUPPORTED_UNITS)[number]);
+};
+
 const EMPTY_SET = new Set<never>();
 const SPAN_SEARCH_CONFIG = {
   booleanKeys: EMPTY_SET,
@@ -142,6 +176,10 @@ const SPAN_SEARCH_CONFIG = {
   disallowNegation: true,
 };
 
+const FIXED_UNITS_BY_ATTRIBUTE: Record<string, (typeof SUPPORTED_UNITS)[number]> = {
+  [SpanIndexedField.SPAN_DURATION]: 'millisecond',
+};
+
 export function MetricsExtractionRuleForm({
   isEdit,
   projectId,
@@ -154,6 +192,16 @@ export function MetricsExtractionRuleForm({
   const [customAttributes, setCustomeAttributes] = useState<string[]>(() => {
     const {spanAttribute, tags} = props.initialData;
     return [...new Set(spanAttribute ? [...tags, spanAttribute] : tags)];
+  });
+
+  const [customUnit, setCustomUnit] = useState<string | null>(() => {
+    const {unit} = props.initialData;
+    return unit && !isSupportedUnit(unit) ? unit : null;
+  });
+
+  const [isUnitDisabled, setIsUnitDisabled] = useState(() => {
+    const {spanAttribute} = props.initialData;
+    return !!(spanAttribute && spanAttribute in FIXED_UNITS_BY_ATTRIBUTE);
   });
 
   const {data: extractionRules} = useMetricsExtractionRules({
@@ -182,7 +230,7 @@ export function MetricsExtractionRuleForm({
 
     return (
       allAttributeOptions
-        .map(key => ({
+        .map<SelectValue<string>>(key => ({
           label: key,
           value: key,
           disabled: disabledKeys.has(key),
@@ -204,11 +252,25 @@ export function MetricsExtractionRuleForm({
         // We don't want to suggest numeric fields as tags as they would explode cardinality
         option => !HIGH_CARDINALITY_TAGS.has(option as SpanIndexedField)
       )
-      .map(option => ({
+      .map<SelectValue<string>>(option => ({
         label: option,
         value: option,
       }));
   }, [allAttributeOptions]);
+
+  const unitOptions = useMemo(() => {
+    const options: SelectValue<string>[] = SUPPORTED_UNITS.map(unit => ({
+      label: unit,
+      value: unit,
+    }));
+    if (customUnit) {
+      options.push({
+        label: customUnit,
+        value: customUnit,
+      });
+    }
+    return options;
+  }, [customUnit]);
 
   const handleSubmit = useCallback(
     (
@@ -261,6 +323,28 @@ export function MetricsExtractionRuleForm({
             onCreateOption={value => {
               setCustomeAttributes(curr => [...curr, value]);
               model.setValue('spanAttribute', value);
+            }}
+            required
+          />
+          <SelectField
+            name="unit"
+            options={unitOptions}
+            disabled={isUnitDisabled}
+            label={t('Unit')}
+            placeholder={t('Select a unit')}
+            creatable
+            formatCreateLabel={value => `Custom: "${value}"`}
+            onChange={value => {
+              if (value in FIXED_UNITS_BY_ATTRIBUTE) {
+                model.setValue('unit', FIXED_UNITS_BY_ATTRIBUTE[value]);
+                setIsUnitDisabled(true);
+              } else {
+                setIsUnitDisabled(false);
+              }
+            }}
+            onCreateOption={value => {
+              setCustomUnit(value);
+              model.setValue('unit', value);
             }}
             required
           />


### PR DESCRIPTION
Add field for editing the unit to the metrics extraction form.
Keep unit of selected virtual MRI in sync after edit on metrics page.


https://github.com/user-attachments/assets/274169d8-46a2-447d-9e5b-c11bb5f8322f



**Note:** The current UI is just a minimal implementation to make the feature work. We will improve on this when implementing the [re-design](https://github.com/getsentry/sentry/issues/74486) of the modal.

Closes https://github.com/getsentry/sentry/issues/73925
Requires https://github.com/getsentry/sentry/pull/74418