### PR TITLE
ref(ingest): Remove old sampled flag from trace function

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -707,7 +707,7 @@ register(
     "store.race-free-group-creation-force-disable", default=False, flags=FLAG_AUTOMATOR_MODIFIABLE
 )
 
-# TEMPORARY: Use traces_sampler instead of manual sampling for ingest-consumer.
+# TODO: Remove this once removed from options-automator
 register("store.use-traces-sampler", default=False, flags=FLAG_AUTOMATOR_MODIFIABLE)
 
 # Enable calling the severity modeling API on group creation


### PR DESCRIPTION
Removes the legacy code-path, follow-up to https://github.com/getsentry/sentry/pull/74413
