### PR TITLE
feat(lookup-field) Add custom lookup field `element_contains` for ArrayField

### DIFF
--- a/src/sentry/db/models/fields/array.py
+++ b/src/sentry/db/models/fields/array.py
@@ -73,5 +73,4 @@ class ArrayField(models.Field):
         return [self.of.to_python(x) for x in value]
 
 
-ArrayField.register_lookup(ArrayElementContainsLookup)
 DjangoArrayField.register_lookup(ArrayElementContainsLookup)

--- a/src/sentry/db/models/fields/array.py
+++ b/src/sentry/db/models/fields/array.py
@@ -6,7 +6,7 @@ from django.contrib.postgres.fields import ArrayField as DjangoArrayField
 from django.db import models
 
 from sentry.db.models.utils import Creator
-from sentry.db.postgres.lookups import ArrayElementContainsLookup
+from sentry.db.postgres.lookups.array_element_contains import ArrayElementContainsLookup
 from sentry.utils import json
 
 

--- a/src/sentry/db/models/fields/array.py
+++ b/src/sentry/db/models/fields/array.py
@@ -2,9 +2,11 @@ from __future__ import annotations
 
 import ast
 
+from django.contrib.postgres.fields import ArrayField as DjangoArrayField
 from django.db import models
 
 from sentry.db.models.utils import Creator
+from sentry.db.postgres.lookups import ArrayElementContainsLookup
 from sentry.utils import json
 
 
@@ -69,3 +71,7 @@ class ArrayField(models.Field):
                     assert "\\" not in value, "Unexpected ArrayField format"
                     value = value[1:-1].split(",")
         return [self.of.to_python(x) for x in value]
+
+
+ArrayField.register_lookup(ArrayElementContainsLookup)
+DjangoArrayField.register_lookup(ArrayElementContainsLookup)

--- a/src/sentry/db/postgres/__init__.py
+++ b/src/sentry/db/postgres/__init__.py
@@ -1,1 +1,0 @@
-from .lookups import *  # NOQA

--- a/src/sentry/db/postgres/__init__.py
+++ b/src/sentry/db/postgres/__init__.py
@@ -1,0 +1,1 @@
+from .lookups import *  # NOQA

--- a/src/sentry/db/postgres/lookups/__init__.py
+++ b/src/sentry/db/postgres/lookups/__init__.py
@@ -1,3 +1,3 @@
-from .array_element_contains import ArrayElementContains  # NOQA
+from .array_element_contains import ArrayElementContainsLookup
 
-__all__ = ["ArrayElementContains"]
+__all__ = ["ArrayElementContainsLookup"]

--- a/src/sentry/db/postgres/lookups/__init__.py
+++ b/src/sentry/db/postgres/lookups/__init__.py
@@ -1,1 +1,3 @@
 from .array_element_contains import ArrayElementContains  # NOQA
+
+__all__ = ["ArrayElementContains"]

--- a/src/sentry/db/postgres/lookups/__init__.py
+++ b/src/sentry/db/postgres/lookups/__init__.py
@@ -1,0 +1,1 @@
+from .array_element_contains import ArrayElementContains  # NOQA

--- a/src/sentry/db/postgres/lookups/__init__.py
+++ b/src/sentry/db/postgres/lookups/__init__.py
@@ -1,3 +1,0 @@
-from .array_element_contains import ArrayElementContainsLookup
-
-__all__ = ["ArrayElementContainsLookup"]

--- a/src/sentry/db/postgres/lookups/array_element_contains.py
+++ b/src/sentry/db/postgres/lookups/array_element_contains.py
@@ -2,7 +2,7 @@ from django.db.backends.base.base import BaseDatabaseWrapper
 from django.db.models import Lookup
 from django.db.models.sql.compiler import SQLCompiler
 
-__all__ = ["ArrayElementContainsLookup"]
+__all__ = ("ArrayElementContainsLookup",)
 
 
 class ArrayElementContainsLookup(Lookup):

--- a/src/sentry/db/postgres/lookups/array_element_contains.py
+++ b/src/sentry/db/postgres/lookups/array_element_contains.py
@@ -19,10 +19,10 @@ class ArrayElementContainsLookup(Lookup):
         rhs, rhs_params = self.process_rhs(compiler, connection)
         params = lhs_params + rhs_params
 
-        return (
-            f"""EXISTS (
-            SELECT * FROM UNNEST({lhs}) AS elem
-            WHERE elem LIKE '%%' || {rhs} || '%%'
-        )""",
-            params,
-        )
+        clause = f"""\
+EXISTS (
+    SELECT * FROM UNNEST({lhs}) AS elem
+    WHERE elem LIKE '%%' || {rhs} || '%%'
+)
+"""
+        return clause, params

--- a/src/sentry/db/postgres/lookups/array_element_contains.py
+++ b/src/sentry/db/postgres/lookups/array_element_contains.py
@@ -1,4 +1,4 @@
-from django.db.backends.postgresql.base import DatabaseWrapper
+from django.db.backends.base.base import BaseDatabaseWrapper
 from django.db.models import Lookup
 from django.db.models.sql.compiler import SQLCompiler
 
@@ -9,7 +9,7 @@ class ArrayElementContainsLookup(Lookup):
     lookup_name = "element_contains"
 
     def as_sql(
-        self, compiler: SQLCompiler, connection: DatabaseWrapper
+        self, compiler: SQLCompiler, connection: BaseDatabaseWrapper
     ) -> tuple[str, list[int | str]]:
         """
         Custom lookup for checking if an element of the array contains a value.

--- a/src/sentry/db/postgres/lookups/array_element_contains.py
+++ b/src/sentry/db/postgres/lookups/array_element_contains.py
@@ -1,4 +1,3 @@
-from django.contrib.postgres.fields import ArrayField
 from django.db.backends.postgresql.base import DatabaseWrapper
 from django.db.models import Lookup
 from django.db.models.sql.compiler import SQLCompiler
@@ -27,6 +26,3 @@ class ArrayElementContainsLookup(Lookup):
         )""",
             params,
         )
-
-
-ArrayField.register_lookup(ArrayElementContainsLookup)

--- a/src/sentry/db/postgres/lookups/array_element_contains.py
+++ b/src/sentry/db/postgres/lookups/array_element_contains.py
@@ -3,6 +3,8 @@ from typing import Any
 from django.contrib.postgres.fields import ArrayField
 from django.db.models import Lookup
 
+__all__ = ["ArrayElementContains"]
+
 
 class ArrayElementContains(Lookup):
     lookup_name = "element_contains"

--- a/src/sentry/db/postgres/lookups/array_element_contains.py
+++ b/src/sentry/db/postgres/lookups/array_element_contains.py
@@ -8,6 +8,10 @@ class ArrayElementContains(Lookup):
     lookup_name = "element_contains"
 
     def as_sql(self, compiler: Any, connection: Any) -> Any:
+        """
+        Custom lookup for checking if an element of the array contains a value.
+        """
+
         lhs, lhs_params = self.process_lhs(compiler, connection)
         rhs, rhs_params = self.process_rhs(compiler, connection)
         params = lhs_params + rhs_params

--- a/src/sentry/db/postgres/lookups/array_element_contains.py
+++ b/src/sentry/db/postgres/lookups/array_element_contains.py
@@ -1,0 +1,26 @@
+from typing import Any
+
+from django.contrib.postgres.fields import ArrayField
+from django.db.models import Lookup
+
+
+class ArrayElementContains(Lookup):
+    lookup_name = "element_contains"
+
+    def as_sql(self, compiler: Any, connection: Any) -> Any:
+        lhs, lhs_params = self.process_lhs(compiler, connection)
+        rhs, rhs_params = self.process_rhs(compiler, connection)
+        params = lhs_params + rhs_params
+
+        return (
+            """EXISTS (
+            SELECT * FROM UNNEST({}) AS elem
+            WHERE elem LIKE '%%' || {} || '%%'
+        )""".format(
+                lhs, rhs
+            ),
+            params,
+        )
+
+
+ArrayField.register_lookup(ArrayElementContains)

--- a/tests/sentry/db/postgres/lookups/test_array_element_contains.py
+++ b/tests/sentry/db/postgres/lookups/test_array_element_contains.py
@@ -1,30 +1,51 @@
-from unittest.mock import Mock, patch
+import pytest
+from django.contrib.postgres.fields import ArrayField as DjangoArrayField
+from django.db import models
 
-from sentry.db.postgres.lookups.array_element_contains import ArrayElementContainsLookup
+
+class ArrayElementContainsLookupTestModel(models.Model):
+    id = models.AutoField(primary_key=True)
+    array_filed = DjangoArrayField(models.TextField(), null=True)
+
+    class Meta:
+        app_label = "fixtures"
 
 
-def test_as_sql_basic_usage():
-    with (
-        patch(
-            "sentry.db.postgres.lookups.array_element_contains.ArrayElementContainsLookup.process_lhs"
-        ) as mock_process_lhs,
-        patch(
-            "sentry.db.postgres.lookups.array_element_contains.ArrayElementContainsLookup.process_rhs"
-        ) as mock_process_rhs,
-    ):
-        lhs = "column_name"
-        rhs = "%s"
-        mock_process_lhs.return_value = (lhs, [])
-        mock_process_rhs.return_value = (rhs, ["value"])
+@pytest.fixture
+def array_element_contains_db():
+    ArrayElementContainsLookupTestModel.objects.bulk_create(
+        [
+            ArrayElementContainsLookupTestModel(array_filed=["foo", "bar", "baz"]),
+            ArrayElementContainsLookupTestModel(array_filed=["foo", "bar"]),
+            ArrayElementContainsLookupTestModel(array_filed=[]),
+            ArrayElementContainsLookupTestModel(array_filed=None),
+        ]
+    )
+    yield
+    ArrayElementContainsLookupTestModel.objects.all().delete()
 
-        lookup = ArrayElementContainsLookup(lhs, rhs)
-        sql, params = lookup.as_sql(Mock(), Mock())
 
-        assert (
-            sql
-            == """EXISTS (
-            SELECT * FROM UNNEST(column_name) AS elem
-            WHERE elem LIKE '%%' || %s || '%%'
-        )"""
-        )
-        assert params == ["value"]
+@pytest.mark.django_db
+def test_basic_usage_for_array_field(array_element_contains_db):
+    assert (
+        ArrayElementContainsLookupTestModel.objects.filter(
+            array_filed__element_contains="foo"
+        ).count()
+        == 2
+    )
+
+    result = ArrayElementContainsLookupTestModel.objects.filter(array_filed__element_contains="baz")
+    assert len(result) == 1
+    assert result[0].array_filed == ["foo", "bar", "baz"]
+
+    assert (
+        ArrayElementContainsLookupTestModel.objects.filter(
+            array_filed__element_contains="qux"
+        ).count()
+        == 0
+    )
+
+    assert (
+        ArrayElementContainsLookupTestModel.objects.filter(array_filed__element_contains="").count()
+        == 2
+    )  # only non empty arrays are considered, and it's elements are checked if they contain ''

--- a/tests/sentry/db/postgres/lookups/test_array_element_contains.py
+++ b/tests/sentry/db/postgres/lookups/test_array_element_contains.py
@@ -1,24 +1,24 @@
 from unittest.mock import Mock, patch
 
-from sentry.db.postgres.lookups import ArrayElementContains
-from sentry.testutils.cases import TestCase
+from sentry.db.postgres.lookups import ArrayElementContainsLookup
 
 
-class TestArrayElementContains(TestCase):
-    def setUp(self) -> None:
-        self.compiler = Mock()
-        self.connection = Mock()
-
-    @patch("sentry.db.postgres.lookups.array_element_contains.ArrayElementContains.process_lhs")
-    @patch("sentry.db.postgres.lookups.array_element_contains.ArrayElementContains.process_rhs")
-    def test_as_sql_basic_usage(self, mock_process_rhs, mock_process_lhs):
+def test_as_sql_basic_usage():
+    with (
+        patch(
+            "sentry.db.postgres.lookups.array_element_contains.ArrayElementContainsLookup.process_lhs"
+        ) as mock_process_lhs,
+        patch(
+            "sentry.db.postgres.lookups.array_element_contains.ArrayElementContainsLookup.process_rhs"
+        ) as mock_process_rhs,
+    ):
         lhs = "column_name"
         rhs = "%s"
         mock_process_lhs.return_value = (lhs, [])
-        mock_process_rhs.return_value = (rhs, [])
+        mock_process_rhs.return_value = (rhs, ["value"])
 
-        lookup = ArrayElementContains(lhs, rhs)
-        sql, params = lookup.as_sql(self.compiler, self.connection)
+        lookup = ArrayElementContainsLookup(lhs, rhs)
+        sql, params = lookup.as_sql(Mock(), Mock())
 
         assert (
             sql
@@ -27,4 +27,4 @@ class TestArrayElementContains(TestCase):
             WHERE elem LIKE '%%' || %s || '%%'
         )"""
         )
-        assert params == []
+        assert params == ["value"]

--- a/tests/sentry/db/postgres/lookups/test_array_element_contains.py
+++ b/tests/sentry/db/postgres/lookups/test_array_element_contains.py
@@ -1,6 +1,6 @@
 from unittest.mock import Mock, patch
 
-from sentry.db.postgres.lookups import ArrayElementContainsLookup
+from sentry.db.postgres.lookups.array_element_contains import ArrayElementContainsLookup
 
 
 def test_as_sql_basic_usage():

--- a/tests/sentry/db/postgres/lookups/test_array_element_contains.py
+++ b/tests/sentry/db/postgres/lookups/test_array_element_contains.py
@@ -1,0 +1,30 @@
+from unittest.mock import Mock, patch
+
+from sentry.db.postgres.lookups import ArrayElementContains
+from sentry.testutils.cases import TestCase
+
+
+class TestArrayElementContains(TestCase):
+    def setUp(self) -> None:
+        self.compiler = Mock()
+        self.connection = Mock()
+
+    @patch("sentry.db.postgres.lookups.array_element_contains.ArrayElementContains.process_lhs")
+    @patch("sentry.db.postgres.lookups.array_element_contains.ArrayElementContains.process_rhs")
+    def test_as_sql_basic_usage(self, mock_process_rhs, mock_process_lhs):
+        lhs = "column_name"
+        rhs = "%s"
+        mock_process_lhs.return_value = (lhs, [])
+        mock_process_rhs.return_value = (rhs, [])
+
+        lookup = ArrayElementContains(lhs, rhs)
+        sql, params = lookup.as_sql(self.compiler, self.connection)
+
+        assert (
+            sql
+            == """EXISTS (
+            SELECT * FROM UNNEST(column_name) AS elem
+            WHERE elem LIKE '%%' || %s || '%%'
+        )"""
+        )
+        assert params == []

--- a/tests/sentry/db/postgres/lookups/test_array_element_contains.py
+++ b/tests/sentry/db/postgres/lookups/test_array_element_contains.py
@@ -5,7 +5,7 @@ from django.db import models
 
 class ArrayElementContainsLookupTestModel(models.Model):
     id = models.AutoField(primary_key=True)
-    array_filed = DjangoArrayField(models.TextField(), null=True)
+    array_field = DjangoArrayField(models.TextField(), null=True)
 
     class Meta:
         app_label = "fixtures"
@@ -15,10 +15,10 @@ class ArrayElementContainsLookupTestModel(models.Model):
 def array_element_contains_db():
     ArrayElementContainsLookupTestModel.objects.bulk_create(
         [
-            ArrayElementContainsLookupTestModel(array_filed=["foo", "bar", "baz"]),
-            ArrayElementContainsLookupTestModel(array_filed=["foo", "bar"]),
-            ArrayElementContainsLookupTestModel(array_filed=[]),
-            ArrayElementContainsLookupTestModel(array_filed=None),
+            ArrayElementContainsLookupTestModel(array_field=["foo", "bar", "baz"]),
+            ArrayElementContainsLookupTestModel(array_field=["foo", "bar"]),
+            ArrayElementContainsLookupTestModel(array_field=[]),
+            ArrayElementContainsLookupTestModel(array_field=None),
         ]
     )
     yield
@@ -29,23 +29,23 @@ def array_element_contains_db():
 def test_basic_usage_for_array_field(array_element_contains_db):
     assert (
         ArrayElementContainsLookupTestModel.objects.filter(
-            array_filed__element_contains="foo"
+            array_field__element_contains="foo"
         ).count()
         == 2
     )
 
-    result = ArrayElementContainsLookupTestModel.objects.filter(array_filed__element_contains="baz")
+    result = ArrayElementContainsLookupTestModel.objects.filter(array_field__element_contains="baz")
     assert len(result) == 1
-    assert result[0].array_filed == ["foo", "bar", "baz"]
+    assert result[0].array_field == ["foo", "bar", "baz"]
 
     assert (
         ArrayElementContainsLookupTestModel.objects.filter(
-            array_filed__element_contains="qux"
+            array_field__element_contains="qux"
         ).count()
         == 0
     )
 
     assert (
-        ArrayElementContainsLookupTestModel.objects.filter(array_filed__element_contains="").count()
+        ArrayElementContainsLookupTestModel.objects.filter(array_field__element_contains="").count()
         == 2
     )  # only non empty arrays are considered, and it's elements are checked if they contain ''


### PR DESCRIPTION
Current Django ORM is limited if there is a need for a check if the element of the array field contains some value.
This custom lookup fields works in a similar way to Django ORM `contains` lookup field, but it is applied to the every element of the array field.

## Use case
This is semi-pseudo code:
```
class CustomModel(models.Model):
    field = ArrayField()

CustomModel.objects.filter(field__element_contains="<value>")
```
