### PR TITLE
fix(insights): Update dropdown selects

### DIFF
--- a/static/app/views/insights/browser/resources/components/renderBlockingSelector.tsx
+++ b/static/app/views/insights/browser/resources/components/renderBlockingSelector.tsx
@@ -4,7 +4,6 @@ import {trackAnalytics} from 'sentry/utils/analytics';
 import {browserHistory} from 'sentry/utils/browserHistory';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
-import type {Option} from 'sentry/views/insights/browser/resources/components/selectControlWithProps';
 import {QueryParameterNames} from 'sentry/views/insights/common/views/queryParameters';
 import {SpanMetricsField} from 'sentry/views/insights/types';
 
@@ -14,7 +13,7 @@ function RenderBlockingSelector({value}: {value?: string}) {
   const location = useLocation();
   const organization = useOrganization();
 
-  const options: Option[] = [
+  const options = [
     {value: '', label: 'All'},
     {value: 'non-blocking', label: t('No')},
     {value: 'blocking', label: t('Yes')},

--- a/static/app/views/insights/browser/resources/components/renderBlockingSelector.tsx
+++ b/static/app/views/insights/browser/resources/components/renderBlockingSelector.tsx
@@ -1,10 +1,10 @@
+import {CompactSelect} from 'sentry/components/compactSelect';
 import {t} from 'sentry/locale';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {browserHistory} from 'sentry/utils/browserHistory';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import type {Option} from 'sentry/views/insights/browser/resources/components/selectControlWithProps';
-import SelectControlWithProps from 'sentry/views/insights/browser/resources/components/selectControlWithProps';
 import {QueryParameterNames} from 'sentry/views/insights/common/views/queryParameters';
 import {SpanMetricsField} from 'sentry/views/insights/types';
 
@@ -21,10 +21,10 @@ function RenderBlockingSelector({value}: {value?: string}) {
   ];
 
   return (
-    <SelectControlWithProps
-      inFieldLabel={`${t('Blocking')}:`}
+    <CompactSelect
+      triggerProps={{prefix: `${t('Blocking')}`}}
       options={options}
-      value={value}
+      value={value ?? ''}
       onChange={newValue => {
         trackAnalytics('insight.asset.filter_by_blocking', {
           organization,

--- a/static/app/views/insights/browser/resources/components/resourceView.tsx
+++ b/static/app/views/insights/browser/resources/components/resourceView.tsx
@@ -10,7 +10,6 @@ import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import {getResourceTypeFilter} from 'sentry/views/insights/browser/common/queries/useResourcesQuery';
 import RenderBlockingSelector from 'sentry/views/insights/browser/resources/components/renderBlockingSelector';
-import SelectControlWithProps from 'sentry/views/insights/browser/resources/components/selectControlWithProps';
 import ResourceTable from 'sentry/views/insights/browser/resources/components/tables/resourceTable';
 import {
   FONT_FILE_EXTENSIONS,
@@ -69,14 +68,14 @@ function ResourceView() {
         />
       </SpanTimeChartsContainer>
 
-      <FilterOptionsContainer columnCount={3}>
+      <DropdownContainer>
         <ResourceTypeSelector value={filters[RESOURCE_TYPE] || ''} />
         <TransactionSelector
           value={filters[TRANSACTION] || ''}
           defaultResourceTypes={DEFAULT_RESOURCE_TYPES}
         />
         <RenderBlockingSelector value={filters[RESOURCE_RENDER_BLOCKING_STATUS] || ''} />
-      </FilterOptionsContainer>
+      </DropdownContainer>
       <ResourceTable sort={sort} defaultResourceTypes={DEFAULT_RESOURCE_TYPES} />
     </Fragment>
   );
@@ -132,6 +131,13 @@ function ResourceTypeSelector({value}: {value?: string}) {
 
 export const SpanTimeChartsContainer = styled('div')`
   margin-bottom: ${space(2)};
+`;
+
+const DropdownContainer = styled('div')`
+  display: flex;
+  gap: ${space(2)};
+  margin-bottom: ${space(2)};
+  flex-wrap: wrap;
 `;
 
 export const FilterOptionsContainer = styled('div')<{columnCount: number}>`

--- a/static/app/views/insights/browser/resources/components/resourceView.tsx
+++ b/static/app/views/insights/browser/resources/components/resourceView.tsx
@@ -105,27 +105,25 @@ function ResourceTypeSelector({value}: {value?: string}) {
   ];
 
   return (
-    <Fragment>
-      <CompactSelect
-        triggerProps={{prefix: `${t('Type')}`}}
-        options={options}
-        value={value ?? ''}
-        onChange={newValue => {
-          trackAnalytics('insight.asset.filter_by_type', {
-            organization,
-            filter: newValue?.value,
-          });
-          browserHistory.push({
-            ...location,
-            query: {
-              ...location.query,
-              [RESOURCE_TYPE]: newValue?.value,
-              [QueryParameterNames.SPANS_CURSOR]: undefined,
-            },
-          });
-        }}
-      />
-    </Fragment>
+    <CompactSelect
+      triggerProps={{prefix: `${t('Type')}`}}
+      options={options}
+      value={value ?? ''}
+      onChange={newValue => {
+        trackAnalytics('insight.asset.filter_by_type', {
+          organization,
+          filter: newValue?.value,
+        });
+        browserHistory.push({
+          ...location,
+          query: {
+            ...location.query,
+            [RESOURCE_TYPE]: newValue?.value,
+            [QueryParameterNames.SPANS_CURSOR]: undefined,
+          },
+        });
+      }}
+    />
   );
 }
 

--- a/static/app/views/insights/browser/resources/components/resourceView.tsx
+++ b/static/app/views/insights/browser/resources/components/resourceView.tsx
@@ -1,6 +1,7 @@
 import {Fragment} from 'react';
 import styled from '@emotion/styled';
 
+import {CompactSelect} from 'sentry/components/compactSelect';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {trackAnalytics} from 'sentry/utils/analytics';
@@ -105,25 +106,27 @@ function ResourceTypeSelector({value}: {value?: string}) {
   ];
 
   return (
-    <SelectControlWithProps
-      inFieldLabel={`${t('Type')}:`}
-      options={options}
-      value={value}
-      onChange={newValue => {
-        trackAnalytics('insight.asset.filter_by_type', {
-          organization,
-          filter: newValue?.value,
-        });
-        browserHistory.push({
-          ...location,
-          query: {
-            ...location.query,
-            [RESOURCE_TYPE]: newValue?.value,
-            [QueryParameterNames.SPANS_CURSOR]: undefined,
-          },
-        });
-      }}
-    />
+    <Fragment>
+      <CompactSelect
+        triggerProps={{prefix: `${t('Type')}`}}
+        options={options}
+        value={value ?? ''}
+        onChange={newValue => {
+          trackAnalytics('insight.asset.filter_by_type', {
+            organization,
+            filter: newValue?.value,
+          });
+          browserHistory.push({
+            ...location,
+            query: {
+              ...location.query,
+              [RESOURCE_TYPE]: newValue?.value,
+              [QueryParameterNames.SPANS_CURSOR]: undefined,
+            },
+          });
+        }}
+      />
+    </Fragment>
   );
 }
 

--- a/static/app/views/insights/browser/resources/components/resourceView.tsx
+++ b/static/app/views/insights/browser/resources/components/resourceView.tsx
@@ -106,6 +106,7 @@ function ResourceTypeSelector({value}: {value?: string}) {
 
   return (
     <CompactSelect
+      style={{maxWidth: '200px'}}
       triggerProps={{prefix: `${t('Type')}`}}
       options={options}
       value={value ?? ''}

--- a/static/app/views/insights/browser/resources/components/selectControlWithProps.tsx
+++ b/static/app/views/insights/browser/resources/components/selectControlWithProps.tsx
@@ -1,15 +1,6 @@
 import type {ReactElement} from 'react';
 
-import type {ControlProps} from 'sentry/components/forms/controls/selectControl';
-import SelectControl from 'sentry/components/forms/controls/selectControl';
-
 export type Option = {
   label: string | ReactElement;
   value: string;
 };
-
-function SelectControlWithProps(props: ControlProps & {options: Option[]}) {
-  return <SelectControl {...props} />;
-}
-
-export default SelectControlWithProps;

--- a/static/app/views/insights/browser/resources/components/selectControlWithProps.tsx
+++ b/static/app/views/insights/browser/resources/components/selectControlWithProps.tsx
@@ -1,6 +1,0 @@
-import type {ReactElement} from 'react';
-
-export type Option = {
-  label: string | ReactElement;
-  value: string;
-};

--- a/static/app/views/insights/common/views/spans/selectors/actionSelector.tsx
+++ b/static/app/views/insights/common/views/spans/selectors/actionSelector.tsx
@@ -69,6 +69,7 @@ export function ActionSelector({
 
   return (
     <CompactSelect
+      style={{maxWidth: '200px'}}
       triggerProps={{prefix: LABEL_FOR_MODULE_NAME[moduleName]}}
       options={options}
       value={value ?? ''}

--- a/static/app/views/insights/common/views/spans/selectors/actionSelector.tsx
+++ b/static/app/views/insights/common/views/spans/selectors/actionSelector.tsx
@@ -2,7 +2,7 @@ import type {ReactNode} from 'react';
 import type {Location} from 'history';
 import omit from 'lodash/omit';
 
-import SelectControl from 'sentry/components/forms/controls/selectControl';
+import {CompactSelect} from 'sentry/components/compactSelect';
 import {t} from 'sentry/locale';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {browserHistory} from 'sentry/utils/browserHistory';
@@ -68,10 +68,10 @@ export function ActionSelector({
       ];
 
   return (
-    <SelectControl
-      inFieldLabel={`${LABEL_FOR_MODULE_NAME[moduleName]}:`}
-      value={value}
-      options={options ?? []}
+    <CompactSelect
+      triggerProps={{prefix: LABEL_FOR_MODULE_NAME[moduleName]}}
+      options={options}
+      value={value ?? ''}
       onChange={newValue => {
         trackAnalytics('insight.general.select_action_value', {
           organization,
@@ -87,17 +87,9 @@ export function ActionSelector({
           },
         });
       }}
-      styles={{
-        control: provided => ({
-          ...provided,
-          minWidth: MIN_WIDTH,
-        }),
-      }}
     />
   );
 }
-
-const MIN_WIDTH = 230;
 
 const HTTP_ACTION_OPTIONS = [
   {value: '', label: 'All'},

--- a/static/app/views/insights/common/views/spans/selectors/domainSelector.tsx
+++ b/static/app/views/insights/common/views/spans/selectors/domainSelector.tsx
@@ -126,6 +126,7 @@ export function DomainSelector({
       loading={isLoading}
       searchable
       menuTitle={LABEL_FOR_MODULE_NAME[moduleName]}
+      maxMenuWidth={'500px'}
       onSearch={newValue => {
         if (!wasSearchSpaceExhausted) {
           debouncedSetSearch(newValue);

--- a/static/app/views/insights/common/views/spans/selectors/domainSelector.tsx
+++ b/static/app/views/insights/common/views/spans/selectors/domainSelector.tsx
@@ -4,7 +4,7 @@ import type {Location} from 'history';
 import debounce from 'lodash/debounce';
 import omit from 'lodash/omit';
 
-import SelectControl from 'sentry/components/forms/controls/selectControl';
+import {CompactSelect} from 'sentry/components/compactSelect';
 import {t} from 'sentry/locale';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {uniq} from 'sentry/utils/array/uniq';
@@ -46,7 +46,6 @@ export function DomainSelector({
   const organization = useOrganization();
   const pageFilters = usePageFilters();
 
-  const [searchInputValue, setSearchInputValue] = useState<string>(''); // Realtime domain search value in UI
   const [searchQuery, setSearchQuery] = useState<string>(''); // Debounced copy of `searchInputValue` used for the Discover query
 
   // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -119,18 +118,21 @@ export function DomainSelector({
   ];
 
   return (
-    <SelectControl
-      inFieldLabel={`${LABEL_FOR_MODULE_NAME[moduleName]}:`}
-      inputValue={searchInputValue}
+    <CompactSelect
+      style={{maxWidth: '300px'}}
       value={value}
       options={options}
-      isLoading={isLoading}
-      onInputChange={input => {
-        setSearchInputValue(input);
-
+      emptyMessage={t('No results')}
+      loading={isLoading}
+      searchable
+      menuTitle={LABEL_FOR_MODULE_NAME[moduleName]}
+      onSearch={newValue => {
         if (!wasSearchSpaceExhausted) {
-          debouncedSetSearch(input);
+          debouncedSetSearch(newValue);
         }
+      }}
+      triggerProps={{
+        prefix: LABEL_FOR_MODULE_NAME[moduleName],
       }}
       onChange={newValue => {
         trackAnalytics('insight.general.select_domain_value', {
@@ -146,18 +148,9 @@ export function DomainSelector({
           },
         });
       }}
-      noOptionsMessage={() => t('No results')}
-      styles={{
-        control: provided => ({
-          ...provided,
-          minWidth: MIN_WIDTH,
-        }),
-      }}
     />
   );
 }
-
-const MIN_WIDTH = 300;
 
 const LIMIT = 100;
 

--- a/static/app/views/insights/common/views/spans/selectors/transactionSelector.tsx
+++ b/static/app/views/insights/common/views/spans/selectors/transactionSelector.tsx
@@ -1,7 +1,7 @@
 import {useCallback, useEffect, useState} from 'react';
 import debounce from 'lodash/debounce';
 
-import SelectControl from 'sentry/components/forms/controls/selectControl';
+import {CompactSelect} from 'sentry/components/compactSelect';
 import {t} from 'sentry/locale';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {browserHistory} from 'sentry/utils/browserHistory';
@@ -25,7 +25,6 @@ export function TransactionSelector({
   const organization = useOrganization();
   const pageFilters = usePageFilters();
 
-  const [searchInputValue, setSearchInputValue] = useState<string>(''); // Realtime domain search value in UI
   const [searchQuery, setSearchQuery] = useState<string>(''); // Debounced copy of `searchInputValue` used for the Discover query
 
   // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -64,18 +63,21 @@ export function TransactionSelector({
   const options = [{value: '', label: 'All'}, ...transactionOptions];
 
   return (
-    <SelectControl
-      inFieldLabel={`${t('Page')}:`}
-      inputValue={searchInputValue}
+    <CompactSelect
       value={value}
       options={options}
-      isLoading={isLoading}
-      onInputChange={input => {
-        setSearchInputValue(input);
-
+      emptyMessage={t('No results')}
+      loading={isLoading}
+      searchable
+      style={{maxWidth: '400px'}}
+      menuTitle={t('Pages')}
+      onSearch={newValue => {
         if (!wasSearchSpaceExhausted) {
-          debouncedSetSearch(input);
+          debouncedSetSearch(newValue);
         }
+      }}
+      triggerProps={{
+        prefix: t('Page'),
       }}
       onChange={newValue => {
         trackAnalytics('insight.asset.filter_by_page', {
@@ -90,7 +92,6 @@ export function TransactionSelector({
           },
         });
       }}
-      noOptionsMessage={() => t('No results')}
     />
   );
 }

--- a/static/app/views/insights/common/views/spans/selectors/transactionSelector.tsx
+++ b/static/app/views/insights/common/views/spans/selectors/transactionSelector.tsx
@@ -71,6 +71,7 @@ export function TransactionSelector({
       loading={isLoading}
       searchable
       menuTitle={t('Page')}
+      maxMenuWidth={'600px'}
       onSearch={newValue => {
         if (!wasSearchSpaceExhausted) {
           debouncedSetSearch(newValue);

--- a/static/app/views/insights/common/views/spans/selectors/transactionSelector.tsx
+++ b/static/app/views/insights/common/views/spans/selectors/transactionSelector.tsx
@@ -70,7 +70,7 @@ export function TransactionSelector({
       emptyMessage={t('No results')}
       loading={isLoading}
       searchable
-      menuTitle={t('Pages')}
+      menuTitle={t('Page')}
       onSearch={newValue => {
         if (!wasSearchSpaceExhausted) {
           debouncedSetSearch(newValue);

--- a/static/app/views/insights/common/views/spans/selectors/transactionSelector.tsx
+++ b/static/app/views/insights/common/views/spans/selectors/transactionSelector.tsx
@@ -64,12 +64,12 @@ export function TransactionSelector({
 
   return (
     <CompactSelect
+      style={{maxWidth: '400px'}}
       value={value}
       options={options}
       emptyMessage={t('No results')}
       loading={isLoading}
       searchable
-      style={{maxWidth: '400px'}}
       menuTitle={t('Pages')}
       onSearch={newValue => {
         if (!wasSearchSpaceExhausted) {


### PR DESCRIPTION
Use `CompactSelect` instead of `SelectControl`. This has many benefits:

- better, nicer loading and search behaviour
- smart intrinsic widths
- design matches other dropdowns that are on the page

Part of https://github.com/getsentry/sentry/issues/74424

**Before:**
![Screenshot 2024-07-18 at 10 16 00 AM](https://github.com/user-attachments/assets/f4994751-39ed-48ac-a544-bb85f3d9f462)

**After:**
![Screenshot 2024-07-18 at 10 16 07 AM](https://github.com/user-attachments/assets/ce42beb8-7ff9-4792-8b00-142a408d754d)
