### PR TITLE
feat(dashboards): Add timeseries support to transactions config

### DIFF
--- a/static/app/components/events/searchBar.tsx
+++ b/static/app/components/events/searchBar.tsx
@@ -243,7 +243,8 @@ function SearchBar(props: SearchBarProps) {
     const combinedTags: TagCollection =
       dataset === DiscoverDatasets.ERRORS
         ? Object.assign({}, functionTags, STATIC_FIELD_TAGS_WITHOUT_TRANSACTION_FIELDS)
-        : dataset === DiscoverDatasets.TRANSACTIONS
+        : dataset === DiscoverDatasets.TRANSACTIONS ||
+            dataset === DiscoverDatasets.METRICS_ENHANCED
           ? Object.assign(
               {},
               measurementsWithKind,

--- a/static/app/views/dashboards/datasetConfig/base.tsx
+++ b/static/app/views/dashboards/datasetConfig/base.tsx
@@ -10,6 +10,7 @@ import type {MetaType} from 'sentry/utils/discover/eventView';
 import type {getFieldRenderer} from 'sentry/utils/discover/fieldRenderers';
 import type {AggregationOutputType, QueryFieldValue} from 'sentry/utils/discover/fields';
 import {isEquation} from 'sentry/utils/discover/fields';
+import type {DiscoverDatasets} from 'sentry/utils/discover/types';
 import type {MEPState} from 'sentry/utils/performance/contexts/metricsEnhancedSetting';
 import type {OnDemandControlContext} from 'sentry/utils/performance/contexts/onDemandControl';
 import type {FieldValueOption} from 'sentry/views/discover/table/queryField';
@@ -32,6 +33,7 @@ export type WidgetBuilderSearchBarProps = {
   organization: Organization;
   pageFilters: PageFilters;
   widgetQuery: WidgetQuery;
+  dataset?: DiscoverDatasets;
 };
 
 export interface DatasetConfig<SeriesResponse, TableResponse> {

--- a/static/app/views/dashboards/datasetConfig/errorsAndTransactions.tsx
+++ b/static/app/views/dashboards/datasetConfig/errorsAndTransactions.tsx
@@ -183,7 +183,7 @@ export function getTableSortOptions(
   return options;
 }
 
-function filterSeriesSortOptions(columns: Set<string>) {
+export function filterSeriesSortOptions(columns: Set<string>) {
   return (option: FieldValueOption) => {
     if (
       option.value.kind === FieldValueKind.FUNCTION ||
@@ -199,7 +199,7 @@ function filterSeriesSortOptions(columns: Set<string>) {
   };
 }
 
-function getTimeseriesSortOptions(
+export function getTimeseriesSortOptions(
   organization: Organization,
   widgetQuery: WidgetQuery,
   tags?: TagCollection
@@ -275,7 +275,7 @@ export function transformEventsResponseToTable(
   return tableData as TableData;
 }
 
-function filterYAxisAggregateParams(
+export function filterYAxisAggregateParams(
   fieldValue: QueryFieldValue,
   displayType: DisplayType
 ) {
@@ -311,7 +311,7 @@ function filterYAxisAggregateParams(
   };
 }
 
-function filterYAxisOptions(displayType: DisplayType) {
+export function filterYAxisOptions(displayType: DisplayType) {
   return (option: FieldValueOption) => {
     // Only validate function names for timeseries widgets and
     // world map widgets.
@@ -333,7 +333,7 @@ function filterYAxisOptions(displayType: DisplayType) {
   };
 }
 
-function transformEventsResponseToSeries(
+export function transformEventsResponseToSeries(
   data: EventsStats | MultiSeriesEventsStats,
   widgetQuery: WidgetQuery
 ): Series[] {
@@ -636,7 +636,7 @@ function getEventsSeriesRequest(
   return doEventsRequest<true>(api, requestData);
 }
 
-async function doOnDemandMetricsRequest(
+export async function doOnDemandMetricsRequest(
   api,
   requestData
 ): Promise<

--- a/static/app/views/dashboards/datasetConfig/errorsAndTransactions.tsx
+++ b/static/app/views/dashboards/datasetConfig/errorsAndTransactions.tsx
@@ -480,7 +480,7 @@ export function getCustomEventsFieldRenderer(field: string, meta: MetaType) {
   return getFieldRenderer(field, meta, false);
 }
 
-function getEventsRequest(
+export function getEventsRequest(
   url: string,
   api: Client,
   query: WidgetQuery,

--- a/static/app/views/dashboards/datasetConfig/transactions.spec.tsx
+++ b/static/app/views/dashboards/datasetConfig/transactions.spec.tsx
@@ -3,17 +3,20 @@ import {PageFiltersFixture} from 'sentry-fixture/pageFilters';
 import {WidgetFixture} from 'sentry-fixture/widget';
 
 import {DiscoverDatasets} from 'sentry/utils/discover/types';
+import {MEPState} from 'sentry/utils/performance/contexts/metricsEnhancedSetting';
 import {TransactionsConfig} from 'sentry/views/dashboards/datasetConfig/transactions';
 
 describe('TransactionsConfig', function () {
   describe('getEventsRequest', function () {
-    let api, organization, mockEventsRequest;
+    let api, organization, mockEventsRequest, mockEventsStatsRequest;
 
     beforeEach(function () {
       MockApiClient.clearMockResponses();
 
       api = new MockApiClient();
-      organization = OrganizationFixture();
+      organization = OrganizationFixture({
+        features: ['on-demand-metrics-extraction', 'on-demand-metrics-ui-widgets'],
+      });
 
       mockEventsRequest = MockApiClient.addMockResponse({
         url: '/organizations/org-slug/events/',
@@ -21,9 +24,16 @@ describe('TransactionsConfig', function () {
           data: [],
         },
       });
+
+      mockEventsStatsRequest = MockApiClient.addMockResponse({
+        url: '/organizations/org-slug/events-stats/',
+        body: {
+          data: [],
+        },
+      });
     });
 
-    it('makes a request to the metrics enhanced dataset', function () {
+    it('makes table request to the transactions dataset', function () {
       const pageFilters = PageFiltersFixture();
       const widget = WidgetFixture();
 
@@ -46,7 +56,155 @@ describe('TransactionsConfig', function () {
         '/organizations/org-slug/events/',
         expect.objectContaining({
           query: expect.objectContaining({
+            dataset: DiscoverDatasets.TRANSACTIONS,
+            useOnDemandMetrics: false,
+          }),
+        })
+      );
+    });
+
+    it('makes table request to the metrics enhanced dataset with the correct mep state', function () {
+      const pageFilters = PageFiltersFixture();
+      const widget = WidgetFixture();
+
+      TransactionsConfig.getTableRequest!(
+        api,
+        widget,
+        {
+          fields: ['count()'],
+          aggregates: ['count()'],
+          columns: [],
+          conditions: '',
+          name: '',
+          orderby: '',
+        },
+        organization,
+        pageFilters,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        MEPState.AUTO
+      );
+
+      expect(mockEventsRequest).toHaveBeenCalledWith(
+        '/organizations/org-slug/events/',
+        expect.objectContaining({
+          query: expect.objectContaining({
             dataset: DiscoverDatasets.METRICS_ENHANCED,
+            useOnDemandMetrics: false,
+          }),
+        })
+      );
+    });
+
+    it('makes table request with on demand', function () {
+      const pageFilters = PageFiltersFixture();
+      const widget = WidgetFixture();
+
+      TransactionsConfig.getTableRequest!(
+        api,
+        widget,
+        {
+          fields: ['count()'],
+          aggregates: ['count()'],
+          columns: [],
+          conditions: '',
+          name: '',
+          orderby: '',
+        },
+        organization,
+        pageFilters,
+        {
+          setForceOnDemand: () => {},
+          forceOnDemand: true,
+          isControlEnabled: true,
+        },
+        undefined,
+        undefined,
+        undefined,
+        MEPState.AUTO
+      );
+
+      expect(mockEventsRequest).toHaveBeenCalledWith(
+        '/organizations/org-slug/events/',
+        expect.objectContaining({
+          query: expect.objectContaining({
+            dataset: DiscoverDatasets.METRICS_ENHANCED,
+            useOnDemandMetrics: true,
+            onDemandType: 'dynamic_query',
+          }),
+        })
+      );
+    });
+
+    it('makes series request to the transactions dataset', function () {
+      const pageFilters = PageFiltersFixture();
+      const widget = WidgetFixture();
+
+      TransactionsConfig.getSeriesRequest!(api, widget, 0, organization, pageFilters);
+
+      expect(mockEventsStatsRequest).toHaveBeenCalledWith(
+        '/organizations/org-slug/events-stats/',
+        expect.objectContaining({
+          query: expect.objectContaining({
+            dataset: DiscoverDatasets.TRANSACTIONS,
+          }),
+        })
+      );
+    });
+
+    it('makes series request to the metrics enhanced dataset', function () {
+      const pageFilters = PageFiltersFixture();
+      const widget = WidgetFixture();
+
+      TransactionsConfig.getSeriesRequest!(
+        api,
+        widget,
+        0,
+        organization,
+        pageFilters,
+        undefined,
+        undefined,
+        MEPState.AUTO
+      );
+
+      expect(mockEventsStatsRequest).toHaveBeenCalledWith(
+        '/organizations/org-slug/events-stats/',
+        expect.objectContaining({
+          query: expect.objectContaining({
+            dataset: DiscoverDatasets.METRICS_ENHANCED,
+          }),
+        })
+      );
+    });
+
+    it('makes series request with on demand', function () {
+      const pageFilters = PageFiltersFixture();
+      const widget = WidgetFixture();
+
+      TransactionsConfig.getSeriesRequest!(
+        api,
+        widget,
+        0,
+        organization,
+        pageFilters,
+        {
+          setForceOnDemand: () => {},
+          forceOnDemand: true,
+          isControlEnabled: true,
+        },
+        undefined,
+        MEPState.AUTO
+      );
+
+      expect(mockEventsStatsRequest).toHaveBeenCalledWith(
+        '/organizations/org-slug/events-stats/',
+        expect.objectContaining({
+          query: expect.objectContaining({
+            dataset: DiscoverDatasets.METRICS_ENHANCED,
+            onDemandType: 'dynamic_query',
+            useOnDemandMetrics: true,
           }),
         })
       );

--- a/static/app/views/dashboards/datasetConfig/transactions.tsx
+++ b/static/app/views/dashboards/datasetConfig/transactions.tsx
@@ -1,3 +1,6 @@
+import trimStart from 'lodash/trimStart';
+
+import {doEventsRequest} from 'sentry/actionCreators/events';
 import type {Client} from 'sentry/api';
 import type {
   EventsStats,
@@ -9,25 +12,42 @@ import type {
 import type {Series} from 'sentry/types/echarts';
 import type {CustomMeasurementCollection} from 'sentry/utils/customMeasurements/customMeasurements';
 import type {EventsTableData, TableData} from 'sentry/utils/discover/discoverQuery';
-import {SPAN_OP_BREAKDOWN_FIELDS, TRANSACTION_FIELDS} from 'sentry/utils/discover/fields';
-import type {DiscoverQueryRequestParams} from 'sentry/utils/discover/genericDiscoverQuery';
+import {
+  isEquation,
+  isEquationAlias,
+  SPAN_OP_BREAKDOWN_FIELDS,
+  TRANSACTION_FIELDS,
+} from 'sentry/utils/discover/fields';
+import type {
+  DiscoverQueryExtras,
+  DiscoverQueryRequestParams,
+} from 'sentry/utils/discover/genericDiscoverQuery';
 import {doDiscoverQuery} from 'sentry/utils/discover/genericDiscoverQuery';
-import {DiscoverDatasets} from 'sentry/utils/discover/types';
+import {DiscoverDatasets, TOP_N} from 'sentry/utils/discover/types';
 import {getMeasurements} from 'sentry/utils/measurements/measurements';
 import type {MEPState} from 'sentry/utils/performance/contexts/metricsEnhancedSetting';
-import type {OnDemandControlContext} from 'sentry/utils/performance/contexts/onDemandControl';
+import {
+  type OnDemandControlContext,
+  shouldUseOnDemandMetrics,
+} from 'sentry/utils/performance/contexts/onDemandControl';
 import {generateFieldOptions} from 'sentry/views/discover/utils';
 
 import type {Widget, WidgetQuery} from '../types';
 import {DisplayType} from '../types';
-import {eventViewFromWidget} from '../utils';
+import {eventViewFromWidget, getNumEquations, getWidgetInterval} from '../utils';
 import {EventsSearchBar} from '../widgetBuilder/buildSteps/filterResultsStep/eventsSearchBar';
 
 import {type DatasetConfig, handleOrderByReset} from './base';
 import {
+  doOnDemandMetricsRequest,
   filterAggregateParams,
+  filterSeriesSortOptions,
+  filterYAxisAggregateParams,
+  filterYAxisOptions,
   getCustomEventsFieldRenderer,
   getTableSortOptions,
+  getTimeseriesSortOptions,
+  transformEventsResponseToSeries,
   transformEventsResponseToTable,
 } from './errorsAndTransactions';
 
@@ -53,27 +73,43 @@ export const TransactionsConfig: DatasetConfig<
   enableEquations: true,
   getCustomFieldRenderer: getCustomEventsFieldRenderer,
   SearchBar: EventsSearchBar,
-  // filterSeriesSortOptions,
-  // filterYAxisAggregateParams,
-  // filterYAxisOptions,
+  filterSeriesSortOptions,
+  filterYAxisAggregateParams,
+  filterYAxisOptions,
   getTableFieldOptions: getEventsTableFieldOptions,
-  // getTimeseriesSortOptions,
+  getTimeseriesSortOptions,
   getTableSortOptions,
   getGroupByFieldOptions: getEventsTableFieldOptions,
   handleOrderByReset,
-  supportedDisplayTypes: [DisplayType.TABLE],
+  supportedDisplayTypes: [
+    DisplayType.AREA,
+    DisplayType.BAR,
+    DisplayType.BIG_NUMBER,
+    DisplayType.LINE,
+    DisplayType.TABLE,
+    DisplayType.TOP_N,
+  ],
   getTableRequest: (
     api: Client,
-    _widget: Widget,
+    widget: Widget,
     query: WidgetQuery,
     organization: Organization,
     pageFilters: PageFilters,
-    _onDemandControlContext?: OnDemandControlContext,
+    onDemandControlContext?: OnDemandControlContext,
     limit?: number,
     cursor?: string,
     referrer?: string,
-    _mepSetting?: MEPState | null
+    mepSetting?: MEPState | null
   ) => {
+    const useOnDemandMetrics = shouldUseOnDemandMetrics(
+      organization,
+      widget,
+      onDemandControlContext
+    );
+    const queryExtras = {
+      useOnDemandMetrics,
+      onDemandType: 'dynamic_query',
+    };
     return getEventsRequest(
       api,
       query,
@@ -81,9 +117,13 @@ export const TransactionsConfig: DatasetConfig<
       pageFilters,
       limit,
       cursor,
-      referrer
+      referrer,
+      mepSetting,
+      queryExtras
     );
   },
+  getSeriesRequest: getEventsSeriesRequest,
+  transformSeries: transformEventsResponseToSeries,
   transformTable: transformEventsResponseToTable,
   filterAggregateParams,
 };
@@ -117,7 +157,9 @@ function getEventsRequest(
   pageFilters: PageFilters,
   limit?: number,
   cursor?: string,
-  referrer?: string
+  referrer?: string,
+  _mepSetting?: MEPState | null,
+  queryExtras?: DiscoverQueryExtras
 ) {
   const url = `/organizations/${organization.slug}/events/`;
   const eventView = eventViewFromWidget('', query, pageFilters);
@@ -127,6 +169,7 @@ function getEventsRequest(
     cursor,
     referrer,
     dataset: DiscoverDatasets.METRICS_ENHANCED,
+    ...queryExtras,
   };
 
   if (query.orderby) {
@@ -148,4 +191,109 @@ function getEventsRequest(
       },
     }
   );
+}
+
+function getEventsSeriesRequest(
+  api: Client,
+  widget: Widget,
+  queryIndex: number,
+  organization: Organization,
+  pageFilters: PageFilters,
+  onDemandControlContext?: OnDemandControlContext,
+  referrer?: string,
+  _mepSetting?: MEPState | null
+) {
+  const widgetQuery = widget.queries[queryIndex];
+  const {displayType, limit} = widget;
+  const {environments, projects} = pageFilters;
+  const {start, end, period: statsPeriod} = pageFilters.datetime;
+  const interval = getWidgetInterval(
+    displayType,
+    {start, end, period: statsPeriod},
+    '1m'
+  );
+
+  let requestData;
+  if (displayType === DisplayType.TOP_N) {
+    requestData = {
+      organization,
+      interval,
+      start,
+      end,
+      project: projects,
+      environment: environments,
+      period: statsPeriod,
+      query: widgetQuery.conditions,
+      yAxis: widgetQuery.aggregates[widgetQuery.aggregates.length - 1],
+      includePrevious: false,
+      referrer,
+      partial: true,
+      field: [...widgetQuery.columns, ...widgetQuery.aggregates],
+      includeAllArgs: true,
+      topEvents: TOP_N,
+      dataset: DiscoverDatasets.METRICS_ENHANCED,
+    };
+    if (widgetQuery.orderby) {
+      requestData.orderby = widgetQuery.orderby;
+    }
+  } else {
+    requestData = {
+      organization,
+      interval,
+      start,
+      end,
+      project: projects,
+      environment: environments,
+      period: statsPeriod,
+      query: widgetQuery.conditions,
+      yAxis: widgetQuery.aggregates,
+      orderby: widgetQuery.orderby,
+      includePrevious: false,
+      referrer,
+      partial: true,
+      includeAllArgs: true,
+      dataset: DiscoverDatasets.METRICS_ENHANCED,
+    };
+    if (widgetQuery.columns?.length !== 0) {
+      requestData.topEvents = limit ?? TOP_N;
+      requestData.field = [...widgetQuery.columns, ...widgetQuery.aggregates];
+
+      // Compare field and orderby as aliases to ensure requestData has
+      // the orderby selected
+      // If the orderby is an equation alias, do not inject it
+      const orderby = trimStart(widgetQuery.orderby, '-');
+      if (
+        widgetQuery.orderby &&
+        !isEquationAlias(orderby) &&
+        !requestData.field.includes(orderby)
+      ) {
+        requestData.field.push(orderby);
+      }
+
+      // The "Other" series is only included when there is one
+      // y-axis and one widgetQuery
+      requestData.excludeOther =
+        widgetQuery.aggregates.length !== 1 || widget.queries.length !== 1;
+
+      if (isEquation(trimStart(widgetQuery.orderby, '-'))) {
+        const nextEquationIndex = getNumEquations(widgetQuery.aggregates);
+        const isDescending = widgetQuery.orderby.startsWith('-');
+        const prefix = isDescending ? '-' : '';
+
+        // Construct the alias form of the equation and inject it into the request
+        requestData.orderby = `${prefix}equation[${nextEquationIndex}]`;
+        requestData.field = [
+          ...widgetQuery.columns,
+          ...widgetQuery.aggregates,
+          trimStart(widgetQuery.orderby, '-'),
+        ];
+      }
+    }
+  }
+
+  if (shouldUseOnDemandMetrics(organization, widget, onDemandControlContext)) {
+    return doOnDemandMetricsRequest(api, requestData);
+  }
+
+  return doEventsRequest<true>(api, requestData);
 }

--- a/static/app/views/dashboards/types.tsx
+++ b/static/app/views/dashboards/types.tsx
@@ -27,7 +27,7 @@ export enum WidgetType {
   RELEASE = 'metrics', // TODO(metrics): rename RELEASE to 'release', and METRICS to 'metrics'
   METRICS = 'custom-metrics',
   ERRORS = 'error-events',
-  TRANSACTIONS = 'transactions',
+  TRANSACTIONS = 'transaction-like',
 }
 
 // These only pertain to on-demand warnings at this point in time

--- a/static/app/views/dashboards/widgetBuilder/buildSteps/filterResultsStep/eventsSearchBar.tsx
+++ b/static/app/views/dashboards/widgetBuilder/buildSteps/filterResultsStep/eventsSearchBar.tsx
@@ -6,6 +6,7 @@ import {MAX_QUERY_LENGTH} from 'sentry/constants';
 import type {Organization, PageFilters} from 'sentry/types';
 import {SavedSearchType} from 'sentry/types';
 import {generateAggregateFields} from 'sentry/utils/discover/fields';
+import type {DiscoverDatasets} from 'sentry/utils/discover/types';
 import useCustomMeasurements from 'sentry/utils/useCustomMeasurements';
 import type {WidgetQuery} from 'sentry/views/dashboards/types';
 import {eventViewFromWidget} from 'sentry/views/dashboards/utils';
@@ -20,6 +21,7 @@ interface Props {
   organization: Organization;
   pageFilters: PageFilters;
   widgetQuery: WidgetQuery;
+  dataset?: DiscoverDatasets;
 }
 
 export function EventsSearchBar({
@@ -28,6 +30,7 @@ export function EventsSearchBar({
   getFilterWarning,
   onClose,
   widgetQuery,
+  dataset,
 }: Props) {
   const {customMeasurements} = useCustomMeasurements();
   const projectIds = pageFilters.projects;
@@ -51,6 +54,7 @@ export function EventsSearchBar({
       maxMenuHeight={MAX_MENU_HEIGHT}
       savedSearchType={SavedSearchType.EVENT}
       customMeasurements={customMeasurements}
+      dataset={dataset}
     />
   );
 }

--- a/static/app/views/dashboards/widgetBuilder/buildSteps/filterResultsStep/index.tsx
+++ b/static/app/views/dashboards/widgetBuilder/buildSteps/filterResultsStep/index.tsx
@@ -35,6 +35,7 @@ import {
   type WidgetQuery,
   type WidgetType,
 } from 'sentry/views/dashboards/types';
+import {getDiscoverDatasetFromWidgetType} from 'sentry/views/dashboards/widgetBuilder/utils';
 
 import {BuildStep, SubHeading} from '../buildStep';
 
@@ -177,6 +178,7 @@ export function FilterResultsStep({
                   onClose={handleClose(queryIndex)}
                   onSearch={handleSearch(queryIndex)}
                   widgetQuery={query}
+                  dataset={getDiscoverDatasetFromWidgetType(widgetType)}
                 />
                 {shouldDisplayOnDemandWidgetWarning(query, widgetType, organization) && (
                   <WidgetOnDemandQueryWarning

--- a/static/app/views/dashboards/widgetBuilder/utils.tsx
+++ b/static/app/views/dashboards/widgetBuilder/utils.tsx
@@ -15,6 +15,7 @@ import {
   stripDerivedMetricsPrefix,
   stripEquationPrefix,
 } from 'sentry/utils/discover/fields';
+import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import type {MeasurementCollection} from 'sentry/utils/measurements/measurements';
 import type {Widget, WidgetQuery} from 'sentry/views/dashboards/types';
 import {DisplayType, WidgetType} from 'sentry/views/dashboards/types';
@@ -41,7 +42,7 @@ export enum DataSet {
   RELEASES = 'releases',
   METRICS = 'metrics',
   ERRORS = 'error-events',
-  TRANSACTIONS = 'transactions',
+  TRANSACTIONS = 'transaction-like"',
 }
 
 export enum SortDirection {
@@ -61,6 +62,17 @@ export const displayTypes = {
   [DisplayType.TABLE]: t('Table'),
   [DisplayType.BIG_NUMBER]: t('Big Number'),
 };
+
+export function getDiscoverDatasetFromWidgetType(widgetType: WidgetType) {
+  switch (widgetType) {
+    case WidgetType.TRANSACTIONS:
+      return DiscoverDatasets.METRICS_ENHANCED;
+    case WidgetType.ERRORS:
+      return DiscoverDatasets.ERRORS;
+    default:
+      return undefined;
+  }
+}
 
 export function mapErrors(
   data: ValidationError,

--- a/tests/js/fixtures/widget.ts
+++ b/tests/js/fixtures/widget.ts
@@ -1,3 +1,4 @@
+import { WidgetQueryFixture } from 'sentry-fixture/widgetQuery';
 import type {Widget} from 'sentry/views/dashboards/types';
 import {DisplayType} from 'sentry/views/dashboards/types';
 
@@ -5,7 +6,7 @@ export function WidgetFixture(params: Partial<Widget> = {}): Widget {
   return {
     displayType: DisplayType.LINE,
     interval: '1d',
-    queries: [],
+    queries: [WidgetQueryFixture()],
     title: 'Widget',
     ...params,
   };

--- a/tests/js/fixtures/widgetQuery.ts
+++ b/tests/js/fixtures/widgetQuery.ts
@@ -3,9 +3,9 @@ import type {WidgetQuery} from 'sentry/views/dashboards/types';
 export function WidgetQueryFixture(params: Partial<WidgetQuery> = {}): WidgetQuery {
   return {
     name: '',
-    fields: ['title', 'count()', 'count_unique(user)', 'epm()', 'count()'],
+    fields: ['title', 'count()', 'count_unique(user)', 'epm()'],
     columns: ['title'],
-    aggregates: ['count()', 'count_unique(user)', 'epm()', 'count()'],
+    aggregates: ['count()', 'count_unique(user)', 'epm()'],
     conditions: 'tag:value',
     orderby: '',
     ...params,

--- a/tests/js/fixtures/widgetQuery.ts
+++ b/tests/js/fixtures/widgetQuery.ts
@@ -1,0 +1,13 @@
+import type {WidgetQuery} from 'sentry/views/dashboards/types';
+
+export function WidgetQueryFixture(params: Partial<WidgetQuery> = {}): WidgetQuery {
+  return {
+    name: '',
+    fields: ['title', 'count()', 'count_unique(user)', 'epm()', 'count()'],
+    columns: ['title'],
+    aggregates: ['count()', 'count_unique(user)', 'epm()', 'count()'],
+    conditions: 'tag:value',
+    orderby: '',
+    ...params,
+  };
+}


### PR DESCRIPTION
This PR does a couple things:
1. Adds timeseries support for transactions 
2. Updates the search bar suggestions according to the selected dataset
3. Added back some on-demand logic to table request