### PR TITLE
ref(profiling) query parent transaction

### DIFF
--- a/static/app/views/performance/newTraceDetails/traceDrawer/traceProfilingLink.ts
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/traceProfilingLink.ts
@@ -24,11 +24,6 @@ function toDate(value: unknown): Date | null {
   return dateObj;
 }
 
-function getTimeOffsetForDuration(duration: number): number {
-  // 100ms window for spans shorter than 100ms, otherwise 10% of the duration capped at 2s
-  return duration < 100 ? 100 : Math.min(duration * 0.1, 2_000);
-}
-
 function getNodeId(node: TraceTreeNode<TraceTree.NodeValue>): string | undefined {
   if (isTransactionNode(node)) {
     return node.value.event_id;
@@ -66,9 +61,12 @@ export function makeTraceContinuousProfilingLink(
 
   // We compute a time offset based on the duration of the span so that
   // users can see some context of things that occurred before and after the span.
-  const timeOffset = getTimeOffsetForDuration(node.space[1]);
-  let start: Date | null = toDate(node.space[0] - timeOffset);
-  let end: Date | null = toDate(node.space[0] + node.space[1] + timeOffset);
+  const transaction = isTransactionNode(node) ? node : node.parent_transaction;
+  if (!transaction) {
+    return null;
+  }
+  let start: Date | null = toDate(transaction.space[0]);
+  let end: Date | null = toDate(transaction.space[0] + transaction.space[1]);
 
   // End timestamp is required to generate a link
   if (end === null || typeof profilerId !== 'string' || profilerId === '') {


### PR DESCRIPTION
Always query for start and end of the nearest parent transaction