### PR TITLE
chore(insights): removes unused performance score flag checks 

### DIFF
--- a/src/sentry/relay/config/__init__.py
+++ b/src/sentry/relay/config/__init__.py
@@ -403,14 +403,7 @@ def _should_extract_abnormal_mechanism(project: Project) -> bool:
     )
 
 
-def _should_performance_profiles_web_vitals_be_optional(organization: Organization) -> bool:
-    return features.has(
-        "organizations:insights-browser-webvitals-optional-components", organization
-    )
-
-
 def _get_desktop_browser_performance_profiles(organization: Organization) -> list[dict[str, Any]]:
-    optional = _should_performance_profiles_web_vitals_be_optional(organization)
     return [
         {
             "name": "Chrome",
@@ -420,28 +413,28 @@ def _get_desktop_browser_performance_profiles(organization: Organization) -> lis
                     "weight": 0.15,
                     "p10": 900.0,
                     "p50": 1600.0,
-                    "optional": optional,
+                    "optional": True,
                 },
                 {
                     "measurement": "lcp",
                     "weight": 0.30,
                     "p10": 1200.0,
                     "p50": 2400.0,
-                    "optional": optional,
+                    "optional": True,
                 },
                 {
                     "measurement": "cls",
                     "weight": 0.15,
                     "p10": 0.1,
                     "p50": 0.25,
-                    "optional": optional,
+                    "optional": True,
                 },
                 {
                     "measurement": "ttfb",
                     "weight": 0.10,
                     "p10": 200.0,
                     "p50": 400.0,
-                    "optional": optional,
+                    "optional": True,
                 },
             ],
             "condition": {
@@ -458,7 +451,7 @@ def _get_desktop_browser_performance_profiles(organization: Organization) -> lis
                     "weight": 0.15,
                     "p10": 900.0,
                     "p50": 1600.0,
-                    "optional": optional,
+                    "optional": True,
                 },
                 {
                     "measurement": "lcp",
@@ -479,7 +472,7 @@ def _get_desktop_browser_performance_profiles(organization: Organization) -> lis
                     "weight": 0.10,
                     "p10": 200.0,
                     "p50": 400.0,
-                    "optional": optional,
+                    "optional": True,
                 },
             ],
             "condition": {
@@ -496,7 +489,7 @@ def _get_desktop_browser_performance_profiles(organization: Organization) -> lis
                     "weight": 0.15,
                     "p10": 900.0,
                     "p50": 1600.0,
-                    "optional": optional,
+                    "optional": True,
                 },
                 {
                     "measurement": "lcp",
@@ -517,7 +510,7 @@ def _get_desktop_browser_performance_profiles(organization: Organization) -> lis
                     "weight": 0.10,
                     "p10": 200.0,
                     "p50": 400.0,
-                    "optional": optional,
+                    "optional": True,
                 },
             ],
             "condition": {
@@ -534,28 +527,28 @@ def _get_desktop_browser_performance_profiles(organization: Organization) -> lis
                     "weight": 0.15,
                     "p10": 900.0,
                     "p50": 1600.0,
-                    "optional": optional,
+                    "optional": True,
                 },
                 {
                     "measurement": "lcp",
                     "weight": 0.30,
                     "p10": 1200.0,
                     "p50": 2400.0,
-                    "optional": optional,
+                    "optional": True,
                 },
                 {
                     "measurement": "cls",
                     "weight": 0.15,
                     "p10": 0.1,
                     "p50": 0.25,
-                    "optional": optional,
+                    "optional": True,
                 },
                 {
                     "measurement": "ttfb",
                     "weight": 0.10,
                     "p10": 200.0,
                     "p50": 400.0,
-                    "optional": optional,
+                    "optional": True,
                 },
             ],
             "condition": {
@@ -572,28 +565,28 @@ def _get_desktop_browser_performance_profiles(organization: Organization) -> lis
                     "weight": 0.15,
                     "p10": 900.0,
                     "p50": 1600.0,
-                    "optional": optional,
+                    "optional": True,
                 },
                 {
                     "measurement": "lcp",
                     "weight": 0.30,
                     "p10": 1200.0,
                     "p50": 2400.0,
-                    "optional": optional,
+                    "optional": True,
                 },
                 {
                     "measurement": "cls",
                     "weight": 0.15,
                     "p10": 0.1,
                     "p50": 0.25,
-                    "optional": optional,
+                    "optional": True,
                 },
                 {
                     "measurement": "ttfb",
                     "weight": 0.10,
                     "p10": 200.0,
                     "p50": 400.0,
-                    "optional": optional,
+                    "optional": True,
                 },
             ],
             "condition": {
@@ -667,7 +660,6 @@ def _get_desktop_browser_performance_profiles(organization: Organization) -> lis
 
 
 def _get_mobile_browser_performance_profiles(organization: Organization) -> list[dict[str, Any]]:
-    optional = _should_performance_profiles_web_vitals_be_optional(organization)
     return [
         {
             "name": "Chrome Mobile",
@@ -677,28 +669,28 @@ def _get_mobile_browser_performance_profiles(organization: Organization) -> list
                     "weight": 0.15,
                     "p10": 1800.0,
                     "p50": 3000.0,
-                    "optional": optional,
+                    "optional": True,
                 },
                 {
                     "measurement": "lcp",
                     "weight": 0.30,
                     "p10": 2500.0,
                     "p50": 4000.0,
-                    "optional": optional,
+                    "optional": True,
                 },
                 {
                     "measurement": "cls",
                     "weight": 0.15,
                     "p10": 0.1,
                     "p50": 0.25,
-                    "optional": optional,
+                    "optional": True,
                 },
                 {
                     "measurement": "ttfb",
                     "weight": 0.10,
                     "p10": 800.0,
                     "p50": 1800.0,
-                    "optional": optional,
+                    "optional": True,
                 },
             ],
             "condition": {
@@ -715,7 +707,7 @@ def _get_mobile_browser_performance_profiles(organization: Organization) -> list
                     "weight": 0.15,
                     "p10": 1800.0,
                     "p50": 3000.0,
-                    "optional": optional,
+                    "optional": True,
                 },
                 {
                     "measurement": "lcp",
@@ -736,7 +728,7 @@ def _get_mobile_browser_performance_profiles(organization: Organization) -> list
                     "weight": 0.10,
                     "p10": 800.0,
                     "p50": 1800.0,
-                    "optional": optional,
+                    "optional": True,
                 },
             ],
             "condition": {
@@ -753,7 +745,7 @@ def _get_mobile_browser_performance_profiles(organization: Organization) -> list
                     "weight": 0.15,
                     "p10": 1800.0,
                     "p50": 3000.0,
-                    "optional": optional,
+                    "optional": True,
                 },
                 {
                     "measurement": "lcp",
@@ -774,7 +766,7 @@ def _get_mobile_browser_performance_profiles(organization: Organization) -> list
                     "weight": 0.10,
                     "p10": 800.0,
                     "p50": 1800.0,
-                    "optional": optional,
+                    "optional": True,
                 },
             ],
             "condition": {
@@ -791,28 +783,28 @@ def _get_mobile_browser_performance_profiles(organization: Organization) -> list
                     "weight": 0.15,
                     "p10": 1800.0,
                     "p50": 3000.0,
-                    "optional": optional,
+                    "optional": True,
                 },
                 {
                     "measurement": "lcp",
                     "weight": 0.30,
                     "p10": 2500.0,
                     "p50": 4000.0,
-                    "optional": optional,
+                    "optional": True,
                 },
                 {
                     "measurement": "cls",
                     "weight": 0.15,
                     "p10": 0.1,
                     "p50": 0.25,
-                    "optional": optional,
+                    "optional": True,
                 },
                 {
                     "measurement": "ttfb",
                     "weight": 0.10,
                     "p10": 800.0,
                     "p50": 1800.0,
-                    "optional": optional,
+                    "optional": True,
                 },
             ],
             "condition": {
@@ -829,28 +821,28 @@ def _get_mobile_browser_performance_profiles(organization: Organization) -> list
                     "weight": 0.15,
                     "p10": 1800.0,
                     "p50": 3000.0,
-                    "optional": optional,
+                    "optional": True,
                 },
                 {
                     "measurement": "lcp",
                     "weight": 0.30,
                     "p10": 2500.0,
                     "p50": 4000.0,
-                    "optional": optional,
+                    "optional": True,
                 },
                 {
                     "measurement": "cls",
                     "weight": 0.15,
                     "p10": 0.1,
                     "p50": 0.25,
-                    "optional": optional,
+                    "optional": True,
                 },
                 {
                     "measurement": "ttfb",
                     "weight": 0.10,
                     "p10": 800.0,
                     "p50": 1800.0,
-                    "optional": optional,
+                    "optional": True,
                 },
             ],
             "condition": {
@@ -919,9 +911,6 @@ def _get_mobile_browser_performance_profiles(organization: Organization) -> list
 
 
 def _get_default_browser_performance_profiles(organization: Organization) -> list[dict[str, Any]]:
-    if not features.has("organizations:insights-default-performance-score-profiles", organization):
-        return []
-    optional = _should_performance_profiles_web_vitals_be_optional(organization)
     return [
         {
             "name": "Default",
@@ -931,28 +920,28 @@ def _get_default_browser_performance_profiles(organization: Organization) -> lis
                     "weight": 0.15,
                     "p10": 900.0,
                     "p50": 1600.0,
-                    "optional": optional,
+                    "optional": True,
                 },
                 {
                     "measurement": "lcp",
                     "weight": 0.30,
                     "p10": 1200.0,
                     "p50": 2400.0,
-                    "optional": optional,
+                    "optional": True,
                 },
                 {
                     "measurement": "cls",
                     "weight": 0.15,
                     "p10": 0.1,
                     "p50": 0.25,
-                    "optional": optional,
+                    "optional": True,
                 },
                 {
                     "measurement": "ttfb",
                     "weight": 0.10,
                     "p10": 200.0,
                     "p50": 400.0,
-                    "optional": optional,
+                    "optional": True,
                 },
             ],
             "condition": {

--- a/tests/sentry/relay/snapshots/test_config/test_get_project_config/REGION.pysnap
+++ b/tests/sentry/relay/snapshots/test_config/test_get_project_config/REGION.pysnap
@@ -150,22 +150,22 @@ config:
       name: Chrome
       scoreComponents:
       - measurement: fcp
-        optional: false
+        optional: true
         p10: 900.0
         p50: 1600.0
         weight: 0.15
       - measurement: lcp
-        optional: false
+        optional: true
         p10: 1200.0
         p50: 2400.0
         weight: 0.3
       - measurement: cls
-        optional: false
+        optional: true
         p10: 0.1
         p50: 0.25
         weight: 0.15
       - measurement: ttfb
-        optional: false
+        optional: true
         p10: 200.0
         p50: 400.0
         weight: 0.1
@@ -176,7 +176,7 @@ config:
       name: Firefox
       scoreComponents:
       - measurement: fcp
-        optional: false
+        optional: true
         p10: 900.0
         p50: 1600.0
         weight: 0.15
@@ -191,7 +191,7 @@ config:
         p50: 0.25
         weight: 0.0
       - measurement: ttfb
-        optional: false
+        optional: true
         p10: 200.0
         p50: 400.0
         weight: 0.1
@@ -202,7 +202,7 @@ config:
       name: Safari
       scoreComponents:
       - measurement: fcp
-        optional: false
+        optional: true
         p10: 900.0
         p50: 1600.0
         weight: 0.15
@@ -217,7 +217,7 @@ config:
         p50: 0.25
         weight: 0.0
       - measurement: ttfb
-        optional: false
+        optional: true
         p10: 200.0
         p50: 400.0
         weight: 0.1
@@ -228,22 +228,22 @@ config:
       name: Edge
       scoreComponents:
       - measurement: fcp
-        optional: false
+        optional: true
         p10: 900.0
         p50: 1600.0
         weight: 0.15
       - measurement: lcp
-        optional: false
+        optional: true
         p10: 1200.0
         p50: 2400.0
         weight: 0.3
       - measurement: cls
-        optional: false
+        optional: true
         p10: 0.1
         p50: 0.25
         weight: 0.15
       - measurement: ttfb
-        optional: false
+        optional: true
         p10: 200.0
         p50: 400.0
         weight: 0.1
@@ -254,22 +254,22 @@ config:
       name: Opera
       scoreComponents:
       - measurement: fcp
-        optional: false
+        optional: true
         p10: 900.0
         p50: 1600.0
         weight: 0.15
       - measurement: lcp
-        optional: false
+        optional: true
         p10: 1200.0
         p50: 2400.0
         weight: 0.3
       - measurement: cls
-        optional: false
+        optional: true
         p10: 0.1
         p50: 0.25
         weight: 0.15
       - measurement: ttfb
-        optional: false
+        optional: true
         p10: 200.0
         p50: 400.0
         weight: 0.1
@@ -318,22 +318,22 @@ config:
       name: Chrome Mobile
       scoreComponents:
       - measurement: fcp
-        optional: false
+        optional: true
         p10: 1800.0
         p50: 3000.0
         weight: 0.15
       - measurement: lcp
-        optional: false
+        optional: true
         p10: 2500.0
         p50: 4000.0
         weight: 0.3
       - measurement: cls
-        optional: false
+        optional: true
         p10: 0.1
         p50: 0.25
         weight: 0.15
       - measurement: ttfb
-        optional: false
+        optional: true
         p10: 800.0
         p50: 1800.0
         weight: 0.1
@@ -344,7 +344,7 @@ config:
       name: Firefox Mobile
       scoreComponents:
       - measurement: fcp
-        optional: false
+        optional: true
         p10: 1800.0
         p50: 3000.0
         weight: 0.15
@@ -359,7 +359,7 @@ config:
         p50: 0.25
         weight: 0.0
       - measurement: ttfb
-        optional: false
+        optional: true
         p10: 800.0
         p50: 1800.0
         weight: 0.1
@@ -370,7 +370,7 @@ config:
       name: Safari Mobile
       scoreComponents:
       - measurement: fcp
-        optional: false
+        optional: true
         p10: 1800.0
         p50: 3000.0
         weight: 0.15
@@ -385,7 +385,7 @@ config:
         p50: 0.25
         weight: 0.0
       - measurement: ttfb
-        optional: false
+        optional: true
         p10: 800.0
         p50: 1800.0
         weight: 0.1
@@ -396,22 +396,22 @@ config:
       name: Edge Mobile
       scoreComponents:
       - measurement: fcp
-        optional: false
+        optional: true
         p10: 1800.0
         p50: 3000.0
         weight: 0.15
       - measurement: lcp
-        optional: false
+        optional: true
         p10: 2500.0
         p50: 4000.0
         weight: 0.3
       - measurement: cls
-        optional: false
+        optional: true
         p10: 0.1
         p50: 0.25
         weight: 0.15
       - measurement: ttfb
-        optional: false
+        optional: true
         p10: 800.0
         p50: 1800.0
         weight: 0.1
@@ -422,22 +422,22 @@ config:
       name: Opera Mobile
       scoreComponents:
       - measurement: fcp
-        optional: false
+        optional: true
         p10: 1800.0
         p50: 3000.0
         weight: 0.15
       - measurement: lcp
-        optional: false
+        optional: true
         p10: 2500.0
         p50: 4000.0
         weight: 0.3
       - measurement: cls
-        optional: false
+        optional: true
         p10: 0.1
         p50: 0.25
         weight: 0.15
       - measurement: ttfb
-        optional: false
+        optional: true
         p10: 800.0
         p50: 1800.0
         weight: 0.1
@@ -470,6 +470,41 @@ config:
         op: eq
         value: Opera Mobile
       name: Opera Mobile INP
+      scoreComponents:
+      - measurement: inp
+        optional: false
+        p10: 200.0
+        p50: 500.0
+        weight: 1.0
+    - condition:
+        inner: []
+        op: and
+      name: Default
+      scoreComponents:
+      - measurement: fcp
+        optional: true
+        p10: 900.0
+        p50: 1600.0
+        weight: 0.15
+      - measurement: lcp
+        optional: true
+        p10: 1200.0
+        p50: 2400.0
+        weight: 0.3
+      - measurement: cls
+        optional: true
+        p10: 0.1
+        p50: 0.25
+        weight: 0.15
+      - measurement: ttfb
+        optional: true
+        p10: 200.0
+        p50: 400.0
+        weight: 0.1
+    - condition:
+        inner: []
+        op: and
+      name: Default INP
       scoreComponents:
       - measurement: inp
         optional: false

--- a/tests/sentry/relay/test_config.py
+++ b/tests/sentry/relay/test_config.py
@@ -766,10 +766,10 @@ def test_desktop_performance_calculate_score(default_project):
     assert performance_score[0] == {
         "name": "Chrome",
         "scoreComponents": [
-            {"measurement": "fcp", "weight": 0.15, "p10": 900, "p50": 1600, "optional": False},
-            {"measurement": "lcp", "weight": 0.3, "p10": 1200, "p50": 2400, "optional": False},
-            {"measurement": "cls", "weight": 0.15, "p10": 0.1, "p50": 0.25, "optional": False},
-            {"measurement": "ttfb", "weight": 0.1, "p10": 200, "p50": 400, "optional": False},
+            {"measurement": "fcp", "weight": 0.15, "p10": 900, "p50": 1600, "optional": True},
+            {"measurement": "lcp", "weight": 0.3, "p10": 1200, "p50": 2400, "optional": True},
+            {"measurement": "cls", "weight": 0.15, "p10": 0.1, "p50": 0.25, "optional": True},
+            {"measurement": "ttfb", "weight": 0.1, "p10": 200, "p50": 400, "optional": True},
         ],
         "condition": {
             "op": "eq",
@@ -786,7 +786,7 @@ def test_desktop_performance_calculate_score(default_project):
                 "weight": 0.15,
                 "p10": 900.0,
                 "p50": 1600.0,
-                "optional": False,
+                "optional": True,
             },
             {
                 "measurement": "lcp",
@@ -801,7 +801,7 @@ def test_desktop_performance_calculate_score(default_project):
                 "weight": 0.1,
                 "p10": 200.0,
                 "p50": 400.0,
-                "optional": False,
+                "optional": True,
             },
         ],
         "condition": {
@@ -819,7 +819,7 @@ def test_desktop_performance_calculate_score(default_project):
                 "weight": 0.15,
                 "p10": 900.0,
                 "p50": 1600.0,
-                "optional": False,
+                "optional": True,
             },
             {
                 "measurement": "lcp",
@@ -834,7 +834,7 @@ def test_desktop_performance_calculate_score(default_project):
                 "weight": 0.1,
                 "p10": 200.0,
                 "p50": 400.0,
-                "optional": False,
+                "optional": True,
             },
         ],
         "condition": {
@@ -847,10 +847,10 @@ def test_desktop_performance_calculate_score(default_project):
     assert performance_score[3] == {
         "name": "Edge",
         "scoreComponents": [
-            {"measurement": "fcp", "weight": 0.15, "p10": 900, "p50": 1600, "optional": False},
-            {"measurement": "lcp", "weight": 0.3, "p10": 1200, "p50": 2400, "optional": False},
-            {"measurement": "cls", "weight": 0.15, "p10": 0.1, "p50": 0.25, "optional": False},
-            {"measurement": "ttfb", "weight": 0.1, "p10": 200, "p50": 400, "optional": False},
+            {"measurement": "fcp", "weight": 0.15, "p10": 900, "p50": 1600, "optional": True},
+            {"measurement": "lcp", "weight": 0.3, "p10": 1200, "p50": 2400, "optional": True},
+            {"measurement": "cls", "weight": 0.15, "p10": 0.1, "p50": 0.25, "optional": True},
+            {"measurement": "ttfb", "weight": 0.1, "p10": 200, "p50": 400, "optional": True},
         ],
         "condition": {
             "op": "eq",
@@ -862,10 +862,10 @@ def test_desktop_performance_calculate_score(default_project):
     assert performance_score[4] == {
         "name": "Opera",
         "scoreComponents": [
-            {"measurement": "fcp", "weight": 0.15, "p10": 900, "p50": 1600, "optional": False},
-            {"measurement": "lcp", "weight": 0.3, "p10": 1200, "p50": 2400, "optional": False},
-            {"measurement": "cls", "weight": 0.15, "p10": 0.1, "p50": 0.25, "optional": False},
-            {"measurement": "ttfb", "weight": 0.1, "p10": 200, "p50": 400, "optional": False},
+            {"measurement": "fcp", "weight": 0.15, "p10": 900, "p50": 1600, "optional": True},
+            {"measurement": "lcp", "weight": 0.3, "p10": 1200, "p50": 2400, "optional": True},
+            {"measurement": "cls", "weight": 0.15, "p10": 0.1, "p50": 0.25, "optional": True},
+            {"measurement": "ttfb", "weight": 0.1, "p10": 200, "p50": 400, "optional": True},
         ],
         "condition": {
             "op": "eq",
@@ -935,10 +935,10 @@ def test_mobile_performance_calculate_score(default_project):
     assert performance_score[8] == {
         "name": "Chrome Mobile",
         "scoreComponents": [
-            {"measurement": "fcp", "weight": 0.15, "p10": 1800.0, "p50": 3000.0, "optional": False},
-            {"measurement": "lcp", "weight": 0.30, "p10": 2500.0, "p50": 4000.0, "optional": False},
-            {"measurement": "cls", "weight": 0.15, "p10": 0.1, "p50": 0.25, "optional": False},
-            {"measurement": "ttfb", "weight": 0.10, "p10": 800.0, "p50": 1800.0, "optional": False},
+            {"measurement": "fcp", "weight": 0.15, "p10": 1800.0, "p50": 3000.0, "optional": True},
+            {"measurement": "lcp", "weight": 0.30, "p10": 2500.0, "p50": 4000.0, "optional": True},
+            {"measurement": "cls", "weight": 0.15, "p10": 0.1, "p50": 0.25, "optional": True},
+            {"measurement": "ttfb", "weight": 0.10, "p10": 800.0, "p50": 1800.0, "optional": True},
         ],
         "condition": {
             "op": "eq",
@@ -950,10 +950,10 @@ def test_mobile_performance_calculate_score(default_project):
     assert performance_score[9] == {
         "name": "Firefox Mobile",
         "scoreComponents": [
-            {"measurement": "fcp", "weight": 0.15, "p10": 1800.0, "p50": 3000.0, "optional": False},
+            {"measurement": "fcp", "weight": 0.15, "p10": 1800.0, "p50": 3000.0, "optional": True},
             {"measurement": "lcp", "weight": 0.30, "p10": 2500.0, "p50": 4000.0, "optional": True},
             {"measurement": "cls", "weight": 0.0, "p10": 0.1, "p50": 0.25, "optional": False},
-            {"measurement": "ttfb", "weight": 0.10, "p10": 800.0, "p50": 1800.0, "optional": False},
+            {"measurement": "ttfb", "weight": 0.10, "p10": 800.0, "p50": 1800.0, "optional": True},
         ],
         "condition": {
             "op": "eq",
@@ -965,10 +965,10 @@ def test_mobile_performance_calculate_score(default_project):
     assert performance_score[10] == {
         "name": "Safari Mobile",
         "scoreComponents": [
-            {"measurement": "fcp", "weight": 0.15, "p10": 1800.0, "p50": 3000.0, "optional": False},
+            {"measurement": "fcp", "weight": 0.15, "p10": 1800.0, "p50": 3000.0, "optional": True},
             {"measurement": "lcp", "weight": 0.0, "p10": 2500.0, "p50": 4000.0, "optional": False},
             {"measurement": "cls", "weight": 0.0, "p10": 0.1, "p50": 0.25, "optional": False},
-            {"measurement": "ttfb", "weight": 0.10, "p10": 800.0, "p50": 1800.0, "optional": False},
+            {"measurement": "ttfb", "weight": 0.10, "p10": 800.0, "p50": 1800.0, "optional": True},
         ],
         "condition": {
             "op": "eq",
@@ -980,10 +980,10 @@ def test_mobile_performance_calculate_score(default_project):
     assert performance_score[11] == {
         "name": "Edge Mobile",
         "scoreComponents": [
-            {"measurement": "fcp", "weight": 0.15, "p10": 1800.0, "p50": 3000.0, "optional": False},
-            {"measurement": "lcp", "weight": 0.30, "p10": 2500.0, "p50": 4000.0, "optional": False},
-            {"measurement": "cls", "weight": 0.15, "p10": 0.1, "p50": 0.25, "optional": False},
-            {"measurement": "ttfb", "weight": 0.10, "p10": 800.0, "p50": 1800.0, "optional": False},
+            {"measurement": "fcp", "weight": 0.15, "p10": 1800.0, "p50": 3000.0, "optional": True},
+            {"measurement": "lcp", "weight": 0.30, "p10": 2500.0, "p50": 4000.0, "optional": True},
+            {"measurement": "cls", "weight": 0.15, "p10": 0.1, "p50": 0.25, "optional": True},
+            {"measurement": "ttfb", "weight": 0.10, "p10": 800.0, "p50": 1800.0, "optional": True},
         ],
         "condition": {
             "op": "eq",
@@ -996,10 +996,10 @@ def test_mobile_performance_calculate_score(default_project):
     assert performance_score[12] == {
         "name": "Opera Mobile",
         "scoreComponents": [
-            {"measurement": "fcp", "weight": 0.15, "p10": 1800.0, "p50": 3000.0, "optional": False},
-            {"measurement": "lcp", "weight": 0.30, "p10": 2500.0, "p50": 4000.0, "optional": False},
-            {"measurement": "cls", "weight": 0.15, "p10": 0.1, "p50": 0.25, "optional": False},
-            {"measurement": "ttfb", "weight": 0.10, "p10": 800.0, "p50": 1800.0, "optional": False},
+            {"measurement": "fcp", "weight": 0.15, "p10": 1800.0, "p50": 3000.0, "optional": True},
+            {"measurement": "lcp", "weight": 0.30, "p10": 2500.0, "p50": 4000.0, "optional": True},
+            {"measurement": "cls", "weight": 0.15, "p10": 0.1, "p50": 0.25, "optional": True},
+            {"measurement": "ttfb", "weight": 0.10, "p10": 800.0, "p50": 1800.0, "optional": True},
         ],
         "condition": {
             "op": "eq",


### PR DESCRIPTION
Removes `organizations:insights-browser-webvitals-optional-components` and `organizations:insights-default-performance-score-profiles` since these flags have been GA'd and no longer needed.