### PR TITLE
feat(insights): add more supported sdks to empty state list

### DIFF
--- a/static/app/views/insights/common/components/modulesOnboarding.tsx
+++ b/static/app/views/insights/common/components/modulesOnboarding.tsx
@@ -2,7 +2,6 @@ import {Fragment, useState} from 'react';
 import styled from '@emotion/styled';
 import startCase from 'lodash/startCase';
 import {PlatformIcon} from 'platformicons';
-import type {PLATFORM_TO_ICON} from 'platformicons/build/platformIcon';
 
 import appStartPreviewImg from 'sentry-images/insights/module-upsells/insights-app-starts-module-charts.svg';
 import assetsPreviewImg from 'sentry-images/insights/module-upsells/insights-assets-module-charts.svg';
@@ -20,6 +19,7 @@ import Panel from 'sentry/components/panels/panel';
 import {Tooltip} from 'sentry/components/tooltip';
 import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
+import type {PlatformKey} from 'sentry/types/project';
 import useOrganization from 'sentry/utils/useOrganization';
 import * as ModuleLayout from 'sentry/views/insights/common/components/moduleLayout';
 import type {TitleableModuleNames} from 'sentry/views/insights/common/components/modulePageProviders';
@@ -32,8 +32,6 @@ import {
 } from 'sentry/views/insights/settings';
 import {ModuleName} from 'sentry/views/insights/types';
 import PerformanceOnboarding from 'sentry/views/performance/onboarding';
-
-type PlatformIcons = keyof typeof PLATFORM_TO_ICON;
 
 export function ModulesOnboarding({
   children,
@@ -109,7 +107,7 @@ type ModulePreviewProps = {moduleName: ModuleName};
 
 function ModulePreview({moduleName}: ModulePreviewProps) {
   const emptyStateContent = EMPTY_STATE_CONTENT[moduleName];
-  const [hoveredIcon, setHoveredIcon] = useState<PlatformIcons | null>(null);
+  const [hoveredIcon, setHoveredIcon] = useState<PlatformKey | null>(null);
 
   return (
     <ModulePreviewContainer>
@@ -118,7 +116,7 @@ function ModulePreview({moduleName}: ModulePreviewProps) {
         <SupportedSdkContainer>
           <div>{t('Supported Today: ')}</div>
           <SupportedSdkList>
-            {emptyStateContent.supportedSdks.map((sdk: PlatformIcons) => (
+            {emptyStateContent.supportedSdks.map((sdk: PlatformKey) => (
               <Tooltip title={startCase(sdk)} key={sdk} position="top">
                 <SupportedSdkIconContainer
                   onMouseOver={() => setHoveredIcon(sdk)}
@@ -203,6 +201,7 @@ const SupportedSdkList = styled('div')`
   display: flex;
   flex-wrap: wrap;
   gap: ${space(0.5)};
+  justify-content: center;
 `;
 
 const SupportedSdkIconContainer = styled('div')`
@@ -232,7 +231,7 @@ type EmptyStateContent = {
   imageSrc: any;
   valuePropDescription: React.ReactNode;
   valuePropPoints: React.ReactNode[];
-  supportedSdks?: PlatformIcons[];
+  supportedSdks?: PlatformKey[];
 };
 
 const EMPTY_STATE_CONTENT: Record<TitleableModuleNames, EmptyStateContent> = {
@@ -254,6 +253,7 @@ const EMPTY_STATE_CONTENT: Record<TitleableModuleNames, EmptyStateContent> = {
       t('Real user performance metrics.'),
     ],
     imageSrc: appStartPreviewImg,
+    supportedSdks: ['android', 'flutter', 'apple-ios', 'react-native'],
   },
   ai: {
     heading: t('Find out what your LLM model is actually saying'),
@@ -279,6 +279,7 @@ const EMPTY_STATE_CONTENT: Record<TitleableModuleNames, EmptyStateContent> = {
       }),
     ],
     imageSrc: llmPreviewImg,
+    supportedSdks: ['python'],
   },
   // Mobile UI is not released yet
   'mobile-ui': {
@@ -304,16 +305,7 @@ const EMPTY_STATE_CONTENT: Record<TitleableModuleNames, EmptyStateContent> = {
       t('Hit / miss ratio of keys accessed by your application.'),
     ],
     imageSrc: cachesPreviewImg,
-    supportedSdks: [
-      'ruby',
-      'python',
-      'javascript',
-      'java',
-      'dotnet',
-      'php-laravel',
-      'php-symfony',
-      'python-django',
-    ],
+    supportedSdks: ['python', 'javascript', 'php', 'java', 'ruby', 'dotnet'],
   },
   db: {
     heading: tct(
@@ -376,6 +368,19 @@ const EMPTY_STATE_CONTENT: Record<TitleableModuleNames, EmptyStateContent> = {
       }),
     ],
     imageSrc: assetsPreviewImg,
+    // TODO - this is a lot of manual work, and its duplicated between here and our docs, it would great if there's a single source of truth
+    supportedSdks: [
+      'javascript',
+      'javascript-angular',
+      'javascript-astro',
+      'javascript-ember',
+      'javascript-gatsby',
+      'javascript-nextjs',
+      'javascript-react',
+      'javascript-remix',
+      'javascript-svelte',
+      'javascript-sveltekit',
+    ],
   },
   vital: {
     heading: t('Finally answer, is this page slow for everyone or just me?'),
@@ -409,6 +414,7 @@ const EMPTY_STATE_CONTENT: Record<TitleableModuleNames, EmptyStateContent> = {
       t('Published vs., processed job volume.'),
     ],
     imageSrc: queuesPreviewImg,
+    supportedSdks: ['python', 'javascript', 'php', 'java', 'ruby', 'dotnet'],
   },
   screen_load: {
     heading: t(`Don’t lose your user's attention once your app loads`),
@@ -428,5 +434,6 @@ const EMPTY_STATE_CONTENT: Record<TitleableModuleNames, EmptyStateContent> = {
       t('Drill down to real user sessions.'),
     ],
     imageSrc: screenLoadsPreviewImg,
+    supportedSdks: ['android', 'flutter', 'apple-ios', 'react-native'],
   },
 };

--- a/static/app/views/insights/common/components/modulesOnboarding.tsx
+++ b/static/app/views/insights/common/components/modulesOnboarding.tsx
@@ -378,8 +378,10 @@ const EMPTY_STATE_CONTENT: Record<TitleableModuleNames, EmptyStateContent> = {
       'javascript-nextjs',
       'javascript-react',
       'javascript-remix',
+      'javascript-solid',
       'javascript-svelte',
       'javascript-sveltekit',
+      'javascript-vue',
     ],
   },
   vital: {


### PR DESCRIPTION
Add some more supported SDK into empty state page (based on what is in our product docs), there's a couple modules that I wasn't sure about (http, queries, and vitals)

If you're not familiar, supportedSdks get rendered out under "supported today" in each insight empty state. For example this one is for the assets module.
![image](https://github.com/user-attachments/assets/9c3d74ab-c607-44ab-a17b-82d034468fbb)


@edwardgou-sentry do you think its reasonable to copy the same list from the assets module? Or maybe we just put Javascript because its framework agnostic? 

@gggritso Any thoughts on what we can put for the http,queries module, i couldn't find anything in the docs besides the minimum sdk version list https://docs.sentry.io/product/insights/queries/#recommended-sdk-versions