### PR TITLE
feat(issue-details): Add new search component to all events tab

### DIFF
--- a/static/app/views/issueDetails/groupEvents.tsx
+++ b/static/app/views/issueDetails/groupEvents.tsx
@@ -1,23 +1,33 @@
-import {useCallback} from 'react';
+import {useCallback, useMemo} from 'react';
 import type {RouteComponentProps} from 'react-router';
 import styled from '@emotion/styled';
+import orderBy from 'lodash/orderBy';
 
+import {useFetchIssueTags} from 'sentry/actionCreators/group';
+import {fetchTagValues} from 'sentry/actionCreators/tags';
 import EventSearchBar from 'sentry/components/events/searchBar';
 import * as Layout from 'sentry/components/layouts/thirds';
+import {SearchQueryBuilder} from 'sentry/components/searchQueryBuilder';
+import type {FilterKeySection} from 'sentry/components/searchQueryBuilder/types';
+import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
-import type {Group} from 'sentry/types/group';
+import type {Group, Tag, TagCollection} from 'sentry/types/group';
 import {browserHistory} from 'sentry/utils/browserHistory';
+import {FieldKind, ISSUE_EVENT_PROPERTY_FIELDS} from 'sentry/utils/fields';
 import normalizeUrl from 'sentry/utils/url/normalizeUrl';
+import useApi from 'sentry/utils/useApi';
 import useCleanQueryParamsOnRouteLeave from 'sentry/utils/useCleanQueryParamsOnRouteLeave';
 import useOrganization from 'sentry/utils/useOrganization';
+import {makeGetIssueTagValues} from 'sentry/views/issueList/utils/getIssueTagValues';
 
 import AllEventsTable from './allEventsTable';
 
 interface Props extends RouteComponentProps<{groupId: string}, {}> {
+  environments: string[];
   group: Group;
 }
 
-const excludedTags = [
+const EXCLUDED_TAGS = [
   'environment',
   'issue',
   'issue.id',
@@ -26,7 +36,107 @@ const excludedTags = [
   'transaction.status',
 ];
 
-function GroupEvents({params, location, group}: Props) {
+function getFilterKeySections(tags: TagCollection): FilterKeySection[] {
+  const allTags: Tag[] = Object.values(tags).filter(
+    tag => !EXCLUDED_TAGS.includes(tag.key)
+  );
+  const eventFields = orderBy(
+    allTags.filter(tag => tag.kind === FieldKind.EVENT_FIELD),
+    ['key']
+  ).map(tag => tag.key);
+  const eventTags = orderBy(
+    allTags.filter(tag => tag.kind === FieldKind.TAG),
+    ['totalValues', 'key'],
+    ['desc', 'asc']
+  ).map(tag => tag.key);
+
+  return [
+    {
+      value: FieldKind.EVENT_FIELD,
+      label: t('Event Filters'),
+      children: eventFields,
+    },
+    {
+      value: FieldKind.TAG,
+      label: t('Event Tags'),
+      children: eventTags,
+    },
+  ];
+}
+
+function UpdatedSearchBar({
+  query,
+  group,
+  environments,
+  handleSearch,
+}: {
+  environments: string[];
+  group: Group;
+  handleSearch: (value: string) => void;
+  query: string;
+}) {
+  const api = useApi();
+  const organization = useOrganization();
+
+  const {data = []} = useFetchIssueTags({
+    orgSlug: organization.slug,
+    groupId: group.id,
+    environment: environments,
+  });
+
+  const filterKeys = useMemo<TagCollection>(() => {
+    const tags = [
+      ...data.map(tag => ({...tag, kind: FieldKind.TAG})),
+      ...ISSUE_EVENT_PROPERTY_FIELDS.map(tag => ({
+        key: tag,
+        name: tag,
+        kind: FieldKind.EVENT_FIELD,
+      })),
+    ].filter(tag => !EXCLUDED_TAGS.includes(tag.key));
+
+    return tags.reduce<TagCollection>((acc, tag) => {
+      acc[tag.key] = tag;
+      return acc;
+    }, {});
+  }, [data]);
+
+  const tagValueLoader = useCallback(
+    (key: string, search: string) => {
+      const orgSlug = organization.slug;
+      const projectIds = [group.project.id];
+
+      return fetchTagValues({
+        api,
+        orgSlug,
+        tagKey: key,
+        search,
+        projectIds,
+      });
+    },
+    [api, group.project.id, organization.slug]
+  );
+
+  const getTagValues = useMemo(
+    () => makeGetIssueTagValues(tagValueLoader),
+    [tagValueLoader]
+  );
+
+  const filterKeySections = useMemo(() => getFilterKeySections(filterKeys), [filterKeys]);
+
+  return (
+    <SearchQueryBuilder
+      initialQuery={query}
+      onSearch={handleSearch}
+      filterKeys={filterKeys}
+      filterKeySections={filterKeySections}
+      getTagValues={getTagValues}
+      placeholder={t('Search events...')}
+      searchSource="issue_events_tab"
+    />
+  );
+}
+
+function GroupEvents({params, location, group, environments}: Props) {
   const organization = useOrganization();
 
   const {groupId} = params;
@@ -47,25 +157,37 @@ function GroupEvents({params, location, group}: Props) {
     [location, organization, groupId]
   );
 
+  const query = location.query?.query ?? '';
+
   return (
     <Layout.Body>
       <Layout.Main fullWidth>
         <AllEventsFilters>
-          <EventSearchBar
-            organization={organization}
-            defaultQuery=""
-            onSearch={handleSearch}
-            excludedTags={excludedTags}
-            query={location.query?.query ?? ''}
-            hasRecentSearches={false}
-          />
+          {organization.features.includes('issue-stream-search-query-builder') ? (
+            <UpdatedSearchBar
+              environments={environments}
+              group={group}
+              handleSearch={handleSearch}
+              query={query}
+            />
+          ) : (
+            <EventSearchBar
+              organization={organization}
+              defaultQuery=""
+              onSearch={handleSearch}
+              excludedTags={EXCLUDED_TAGS}
+              query={query}
+              hasRecentSearches={false}
+              searchSource="issue_events_tab"
+            />
+          )}
         </AllEventsFilters>
         <AllEventsTable
           issueId={group.id}
           location={location}
           organization={organization}
           group={group}
-          excludedTags={excludedTags}
+          excludedTags={EXCLUDED_TAGS}
         />
       </Layout.Main>
     </Layout.Body>

--- a/static/app/views/issueList/utils/getIssueTagValues.tsx
+++ b/static/app/views/issueList/utils/getIssueTagValues.tsx
@@ -1,0 +1,29 @@
+import type {Tag, TagValue} from 'sentry/types/group';
+import {DEVICE_CLASS_TAG_VALUES, isDeviceClass} from 'sentry/utils/fields';
+
+/**
+ * Returns a function that fetches tag values for a given tag key. Useful as
+ * an input to the SearchQueryBuilder component.
+ *
+ * Accepts a function that fetches tag values for a given tag key and search query.
+ */
+export function makeGetIssueTagValues(
+  tagValueLoader: (key: string, search: string) => Promise<TagValue[]>
+) {
+  return async (tag: Tag, query: string): Promise<string[]> => {
+    // device.class is stored as "numbers" in snuba, but we want to suggest high, medium,
+    // and low search filter values because discover maps device.class to these values.
+    if (isDeviceClass(tag.key)) {
+      return DEVICE_CLASS_TAG_VALUES;
+    }
+    const values = await tagValueLoader(tag.key, query);
+    return values.map(({value}) => {
+      // Truncate results to 5000 characters to avoid exceeding the max url query length
+      // The message attribute for example can be 8192 characters.
+      if (typeof value === 'string' && value.length > 5000) {
+        return value.substring(0, 5000);
+      }
+      return value;
+    });
+  };
+}


### PR DESCRIPTION
Under the `issue-stream-search-query-builder` flag, replaces the old SmartSearchBar component with the new one.

To load the available tags, it uses the same group tags endpoint that loads the tags summary on issue details. This is an improvement over what existed prior, since it was loading all available organization tags event if they did not exist in the issue you're looking at.

![CleanShot 2024-07-18 at 09 23 45@2x](https://github.com/user-attachments/assets/f10cef03-bbd3-4d4f-ae87-54f7d9b3a17e)
