### PR TITLE
chore(insights): Remove "New" badges from Caches and Queues

### DIFF
--- a/static/app/components/sidebar/index.tsx
+++ b/static/app/components/sidebar/index.tsx
@@ -51,11 +51,8 @@ import {useLocation} from 'sentry/utils/useLocation';
 import useMedia from 'sentry/utils/useMedia';
 import useOrganization from 'sentry/utils/useOrganization';
 import useProjects from 'sentry/utils/useProjects';
-import {releaseLevelAsBadgeProps as CacheModuleBadgeProps} from 'sentry/views/insights/cache/settings';
 import {useModuleURLBuilder} from 'sentry/views/insights/common/utils/useModuleURL';
 import {MODULE_SIDEBAR_TITLE as HTTP_MODULE_SIDEBAR_TITLE} from 'sentry/views/insights/http/settings';
-import {releaseLevelAsBadgeProps as LLMModuleBadgeProps} from 'sentry/views/insights/llmMonitoring/settings';
-import {releaseLevelAsBadgeProps as QueuesModuleBadgeProps} from 'sentry/views/insights/queues/settings';
 import {MODULE_TITLES} from 'sentry/views/insights/settings';
 import MetricsOnboardingSidebar from 'sentry/views/metrics/ddmOnboarding/sidebar';
 
@@ -276,7 +273,6 @@ function Sidebar() {
         to={`/organizations/${organization.slug}/${moduleURLBuilder('cache')}/`}
         id="performance-cache"
         icon={<SubitemDot collapsed />}
-        {...CacheModuleBadgeProps}
       />
     </Feature>
   );
@@ -302,7 +298,6 @@ function Sidebar() {
         label={
           <GuideAnchor target="performance-queues">{MODULE_TITLES.queue}</GuideAnchor>
         }
-        {...QueuesModuleBadgeProps}
         to={`/organizations/${organization.slug}/${moduleURLBuilder('queue')}/`}
         id="performance-queues"
         icon={<SubitemDot collapsed />}
@@ -386,7 +381,6 @@ function Sidebar() {
         {...sidebarItemProps}
         icon={<SubitemDot collapsed />}
         label={MODULE_TITLES.ai}
-        {...LLMModuleBadgeProps}
         to={`/organizations/${organization.slug}/${moduleURLBuilder('ai')}/`}
         id="llm-monitoring"
       />
@@ -559,7 +553,6 @@ function Sidebar() {
         label={<GuideAnchor target="insights">{t('Insights')}</GuideAnchor>}
         id="insights"
         initiallyExpanded={false}
-        isNew
         exact={!shouldAccordionFloat}
       >
         {requests}

--- a/static/app/views/insights/cache/settings.ts
+++ b/static/app/views/insights/cache/settings.ts
@@ -6,11 +6,6 @@ export const BASE_URL = 'caches';
 export const DATA_TYPE = t('Cache');
 export const DATA_TYPE_PLURAL = t('Caches');
 
-// NOTE: Awkward typing, but without it `RELEASE_LEVEL` is narrowed and the comparison is not allowed
-export const releaseLevelAsBadgeProps = {
-  isNew: true,
-};
-
 export const CHART_HEIGHT = 160;
 
 export const CACHE_BASE_URL = `/performance/${BASE_URL}`;

--- a/static/app/views/insights/llmMonitoring/settings.ts
+++ b/static/app/views/insights/llmMonitoring/settings.ts
@@ -9,8 +9,4 @@ export const DATA_TYPE_PLURAL = t('LLMs');
 
 export const RELEASE_LEVEL: BadgeType = 'beta';
 
-export const releaseLevelAsBadgeProps = {
-  isNew: true,
-};
-
 export const MODULE_DOC_LINK = 'https://docs.sentry.io/product/insights/llm-monitoring/';

--- a/static/app/views/insights/queues/settings.ts
+++ b/static/app/views/insights/queues/settings.ts
@@ -9,10 +9,6 @@ export const CHART_HEIGHT = 160;
 
 export const DESTINATION_TITLE = t('Destination Summary');
 
-export const releaseLevelAsBadgeProps = {
-  isNew: true,
-};
-
 export const DEFAULT_QUERY_FILTER = 'span.op:[queue.process,queue.publish]';
 export const CONSUMER_QUERY_FILTER = 'span.op:queue.process';
 export const PRODUCER_QUERY_FILTER = 'span.op:queue.publish';


### PR DESCRIPTION
They've been out about a month, time to remove the "New"
