### PR TITLE
feat(dashboard): Add support for events-stats in errors

### DIFF
--- a/static/app/views/dashboards/datasetConfig/errors.spec.tsx
+++ b/static/app/views/dashboards/datasetConfig/errors.spec.tsx
@@ -150,4 +150,49 @@ describe('ErrorsConfig', function () {
       );
     });
   });
+
+  describe('getSeriesRequest', function () {
+    let api, organization, mockEventsRequest;
+
+    beforeEach(function () {
+      MockApiClient.clearMockResponses();
+
+      api = new MockApiClient();
+      organization = OrganizationFixture();
+
+      mockEventsRequest = MockApiClient.addMockResponse({
+        url: '/organizations/org-slug/events-stats/',
+        body: {
+          data: [],
+        },
+      });
+    });
+
+    it('makes a request to the errors dataset', function () {
+      const pageFilters = PageFiltersFixture();
+      const widget = WidgetFixture({
+        queries: [
+          {
+            fields: ['count()'],
+            aggregates: ['count()'],
+            columns: [],
+            conditions: '',
+            name: '',
+            orderby: '',
+          },
+        ],
+      });
+
+      ErrorsConfig.getSeriesRequest!(api, widget, 0, organization, pageFilters);
+
+      expect(mockEventsRequest).toHaveBeenCalledWith(
+        '/organizations/org-slug/events-stats/',
+        expect.objectContaining({
+          query: expect.objectContaining({
+            dataset: DiscoverDatasets.ERRORS,
+          }),
+        })
+      );
+    });
+  });
 });

--- a/static/app/views/dashboards/datasetConfig/errors.tsx
+++ b/static/app/views/dashboards/datasetConfig/errors.tsx
@@ -232,7 +232,7 @@ function getErrorsSeriesRequest(
       field: [...widgetQuery.columns, ...widgetQuery.aggregates],
       includeAllArgs: true,
       topEvents: TOP_N,
-      queryExtras: {dataset: DiscoverDatasets.ERRORS},
+      dataset: DiscoverDatasets.ERRORS,
     };
     if (widgetQuery.orderby) {
       requestData.orderby = widgetQuery.orderby;
@@ -253,7 +253,7 @@ function getErrorsSeriesRequest(
       referrer,
       partial: true,
       includeAllArgs: true,
-      queryExtras: {dataset: DiscoverDatasets.ERRORS},
+      dataset: DiscoverDatasets.ERRORS,
     };
     if (widgetQuery.columns?.length !== 0) {
       requestData.topEvents = limit ?? TOP_N;

--- a/static/app/views/dashboards/datasetConfig/errors.tsx
+++ b/static/app/views/dashboards/datasetConfig/errors.tsx
@@ -1,3 +1,6 @@
+import trimStart from 'lodash/trimStart';
+
+import {doEventsRequest} from 'sentry/actionCreators/events';
 import type {Client} from 'sentry/api';
 import type {
   EventsStats,
@@ -15,26 +18,33 @@ import {
   AGGREGATIONS,
   ERROR_FIELDS,
   ERRORS_AGGREGATION_FUNCTIONS,
+  isEquation,
+  isEquationAlias,
 } from 'sentry/utils/discover/fields';
 import type {DiscoverQueryRequestParams} from 'sentry/utils/discover/genericDiscoverQuery';
 import {doDiscoverQuery} from 'sentry/utils/discover/genericDiscoverQuery';
-import {DiscoverDatasets} from 'sentry/utils/discover/types';
+import {DiscoverDatasets, TOP_N} from 'sentry/utils/discover/types';
 import type {AggregationKey} from 'sentry/utils/fields';
 import type {MEPState} from 'sentry/utils/performance/contexts/metricsEnhancedSetting';
 import type {OnDemandControlContext} from 'sentry/utils/performance/contexts/onDemandControl';
+import type {FieldValueOption} from 'sentry/views/discover/table/queryField';
 import {generateFieldOptions} from 'sentry/views/discover/utils';
 
 import type {Widget, WidgetQuery} from '../types';
 import {DisplayType} from '../types';
-import {eventViewFromWidget} from '../utils';
+import {eventViewFromWidget, getNumEquations, getWidgetInterval} from '../utils';
 import {EventsSearchBar} from '../widgetBuilder/buildSteps/filterResultsStep/eventsSearchBar';
 
 import {type DatasetConfig, handleOrderByReset} from './base';
 import {
   filterAggregateParams,
+  filterSeriesSortOptions,
+  filterYAxisAggregateParams, // TODO: Does this need to be overridden?
   getTableSortOptions,
+  getTimeseriesSortOptions,
   renderEventIdAsLinkable,
   renderTraceAsLinkable,
+  transformEventsResponseToSeries,
   transformEventsResponseToTable,
 } from './errorsAndTransactions';
 
@@ -60,15 +70,23 @@ export const ErrorsConfig: DatasetConfig<
   enableEquations: true,
   getCustomFieldRenderer: getCustomEventsFieldRenderer,
   SearchBar: EventsSearchBar,
-  // filterSeriesSortOptions,
-  // filterYAxisAggregateParams,
-  // filterYAxisOptions,
+  filterSeriesSortOptions,
+  filterYAxisAggregateParams,
+  filterYAxisOptions,
   getTableFieldOptions: getEventsTableFieldOptions,
-  // getTimeseriesSortOptions,
+  getTimeseriesSortOptions: (organization, widgetQuery, tags) =>
+    getTimeseriesSortOptions(organization, widgetQuery, tags, getEventsTableFieldOptions),
   getTableSortOptions,
   getGroupByFieldOptions: getEventsTableFieldOptions,
   handleOrderByReset,
-  supportedDisplayTypes: [DisplayType.TABLE],
+  supportedDisplayTypes: [
+    DisplayType.AREA,
+    DisplayType.BAR,
+    DisplayType.BIG_NUMBER,
+    DisplayType.LINE,
+    DisplayType.TABLE,
+    DisplayType.TOP_N,
+  ],
   getTableRequest: (
     api: Client,
     _widget: Widget,
@@ -91,7 +109,9 @@ export const ErrorsConfig: DatasetConfig<
       referrer
     );
   },
+  getSeriesRequest: getErrorsSeriesRequest,
   transformTable: transformEventsResponseToTable,
+  transformSeries: transformEventsResponseToSeries,
   filterAggregateParams,
 };
 
@@ -163,4 +183,114 @@ export function getEventsRequest(
       },
     }
   );
+}
+
+// The y-axis options are a strict set of available aggregates
+export function filterYAxisOptions(_displayType: DisplayType) {
+  return (option: FieldValueOption) => {
+    return ERRORS_AGGREGATION_FUNCTIONS.includes(
+      option.value.meta.name as AggregationKey
+    );
+  };
+}
+
+function getErrorsSeriesRequest(
+  api: Client,
+  widget: Widget,
+  queryIndex: number,
+  organization: Organization,
+  pageFilters: PageFilters,
+  _onDemandControlContext?: OnDemandControlContext,
+  referrer?: string,
+  _mepSetting?: MEPState | null
+) {
+  const widgetQuery = widget.queries[queryIndex];
+  const {displayType, limit} = widget;
+  const {environments, projects} = pageFilters;
+  const {start, end, period: statsPeriod} = pageFilters.datetime;
+  const interval = getWidgetInterval(
+    displayType,
+    {start, end, period: statsPeriod},
+    '1m'
+  );
+
+  let requestData;
+  if (displayType === DisplayType.TOP_N) {
+    requestData = {
+      organization,
+      interval,
+      start,
+      end,
+      project: projects,
+      environment: environments,
+      period: statsPeriod,
+      query: widgetQuery.conditions,
+      yAxis: widgetQuery.aggregates[widgetQuery.aggregates.length - 1],
+      includePrevious: false,
+      referrer,
+      partial: true,
+      field: [...widgetQuery.columns, ...widgetQuery.aggregates],
+      includeAllArgs: true,
+      topEvents: TOP_N,
+      queryExtras: {dataset: DiscoverDatasets.ERRORS},
+    };
+    if (widgetQuery.orderby) {
+      requestData.orderby = widgetQuery.orderby;
+    }
+  } else {
+    requestData = {
+      organization,
+      interval,
+      start,
+      end,
+      project: projects,
+      environment: environments,
+      period: statsPeriod,
+      query: widgetQuery.conditions,
+      yAxis: widgetQuery.aggregates,
+      orderby: widgetQuery.orderby,
+      includePrevious: false,
+      referrer,
+      partial: true,
+      includeAllArgs: true,
+      queryExtras: {dataset: DiscoverDatasets.ERRORS},
+    };
+    if (widgetQuery.columns?.length !== 0) {
+      requestData.topEvents = limit ?? TOP_N;
+      requestData.field = [...widgetQuery.columns, ...widgetQuery.aggregates];
+
+      // Compare field and orderby as aliases to ensure requestData has
+      // the orderby selected
+      // If the orderby is an equation alias, do not inject it
+      const orderby = trimStart(widgetQuery.orderby, '-');
+      if (
+        widgetQuery.orderby &&
+        !isEquationAlias(orderby) &&
+        !requestData.field.includes(orderby)
+      ) {
+        requestData.field.push(orderby);
+      }
+
+      // The "Other" series is only included when there is one
+      // y-axis and one widgetQuery
+      requestData.excludeOther =
+        widgetQuery.aggregates.length !== 1 || widget.queries.length !== 1;
+
+      if (isEquation(trimStart(widgetQuery.orderby, '-'))) {
+        const nextEquationIndex = getNumEquations(widgetQuery.aggregates);
+        const isDescending = widgetQuery.orderby.startsWith('-');
+        const prefix = isDescending ? '-' : '';
+
+        // Construct the alias form of the equation and inject it into the request
+        requestData.orderby = `${prefix}equation[${nextEquationIndex}]`;
+        requestData.field = [
+          ...widgetQuery.columns,
+          ...widgetQuery.aggregates,
+          trimStart(widgetQuery.orderby, '-'),
+        ];
+      }
+    }
+  }
+
+  return doEventsRequest<true>(api, requestData);
 }

--- a/static/app/views/dashboards/datasetConfig/errorsAndTransactions.tsx
+++ b/static/app/views/dashboards/datasetConfig/errorsAndTransactions.tsx
@@ -103,7 +103,8 @@ export const ErrorsAndTransactionsConfig: DatasetConfig<
   filterYAxisAggregateParams,
   filterYAxisOptions,
   getTableFieldOptions: getEventsTableFieldOptions,
-  getTimeseriesSortOptions,
+  getTimeseriesSortOptions: (organization, widgetQuery, tags) =>
+    getTimeseriesSortOptions(organization, widgetQuery, tags, getEventsTableFieldOptions),
   getTableSortOptions,
   getGroupByFieldOptions: getEventsTableFieldOptions,
   handleOrderByReset,
@@ -183,7 +184,7 @@ export function getTableSortOptions(
   return options;
 }
 
-function filterSeriesSortOptions(columns: Set<string>) {
+export function filterSeriesSortOptions(columns: Set<string>) {
   return (option: FieldValueOption) => {
     if (
       option.value.kind === FieldValueKind.FUNCTION ||
@@ -199,10 +200,11 @@ function filterSeriesSortOptions(columns: Set<string>) {
   };
 }
 
-function getTimeseriesSortOptions(
+export function getTimeseriesSortOptions(
   organization: Organization,
   widgetQuery: WidgetQuery,
-  tags?: TagCollection
+  tags?: TagCollection,
+  getFieldOptions: typeof getEventsTableFieldOptions = getEventsTableFieldOptions
 ) {
   const options: Record<string, SelectValue<FieldValue>> = {};
   options[`field:${CUSTOM_EQUATION_VALUE}`] = {
@@ -235,7 +237,7 @@ function getTimeseriesSortOptions(
       }
     });
 
-  const fieldOptions = getEventsTableFieldOptions(organization, tags);
+  const fieldOptions = getFieldOptions(organization, tags);
 
   return {...options, ...fieldOptions};
 }
@@ -275,7 +277,7 @@ export function transformEventsResponseToTable(
   return tableData as TableData;
 }
 
-function filterYAxisAggregateParams(
+export function filterYAxisAggregateParams(
   fieldValue: QueryFieldValue,
   displayType: DisplayType
 ) {
@@ -311,7 +313,7 @@ function filterYAxisAggregateParams(
   };
 }
 
-function filterYAxisOptions(displayType: DisplayType) {
+export function filterYAxisOptions(displayType: DisplayType) {
   return (option: FieldValueOption) => {
     // Only validate function names for timeseries widgets and
     // world map widgets.
@@ -333,7 +335,7 @@ function filterYAxisOptions(displayType: DisplayType) {
   };
 }
 
-function transformEventsResponseToSeries(
+export function transformEventsResponseToSeries(
   data: EventsStats | MultiSeriesEventsStats,
   widgetQuery: WidgetQuery
 ): Series[] {

--- a/static/app/views/dashboards/widgetBuilder/widgetBuilderDataset.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/widgetBuilderDataset.spec.tsx
@@ -16,6 +16,7 @@ import {resetMockDate, setMockDate} from 'sentry-test/utils';
 
 import ProjectsStore from 'sentry/stores/projectsStore';
 import TagStore from 'sentry/stores/tagStore';
+import {ERROR_FIELDS, ERRORS_AGGREGATION_FUNCTIONS} from 'sentry/utils/discover/fields';
 import type {DashboardDetails, Widget} from 'sentry/views/dashboards/types';
 import {
   DashboardWidgetSource,
@@ -1316,6 +1317,113 @@ describe('WidgetBuilder', function () {
         expect(
           within(screen.getByTestId('sort-by-step')).getByText('count()')
         ).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('Errors dataset', function () {
+    it('only shows the correct aggregates for timeseries charts', async function () {
+      renderTestComponent({
+        dashboard: {
+          ...testDashboard,
+          widgets: [
+            {
+              title: 'Errors Widget',
+              interval: '1d',
+              id: '1',
+              widgetType: WidgetType.ERRORS,
+              displayType: DisplayType.LINE,
+              queries: [
+                {
+                  conditions: '',
+                  name: '',
+                  fields: ['count()'],
+                  columns: [],
+                  aggregates: ['count()'],
+                  orderby: '-count()',
+                },
+              ],
+            },
+          ],
+        },
+        params: {
+          widgetIndex: '0',
+        },
+        orgFeatures: [...defaultOrgFeatures, 'performance-discover-dataset-selector'],
+      });
+
+      // Open the y-axis options dropdown
+      const yAxisStep = screen
+        .getByRole('heading', {name: /choose what to plot in the y-axis/i})
+        .closest('li');
+      await userEvent.click(within(yAxisStep!).getByText('count()'));
+
+      // Verify the error aggregates are present
+      expect(screen.getAllByRole('menuitemradio')).toHaveLength(
+        ERRORS_AGGREGATION_FUNCTIONS.length
+      );
+      ERRORS_AGGREGATION_FUNCTIONS.forEach(aggregation => {
+        expect(
+          screen.getByRole('menuitemradio', {name: new RegExp(`${aggregation}\\(…?\\)`)})
+        ).toBeInTheDocument();
+      });
+    });
+
+    it('only shows the correct aggregate params for timeseries charts', async function () {
+      MockApiClient.addMockResponse({
+        url: '/organizations/org-slug/tags/',
+        method: 'GET',
+        body: [],
+      });
+      renderTestComponent({
+        dashboard: {
+          ...testDashboard,
+          widgets: [
+            {
+              title: 'Errors Widget',
+              interval: '1d',
+              id: '1',
+              widgetType: WidgetType.ERRORS,
+              displayType: DisplayType.LINE,
+              queries: [
+                {
+                  conditions: '',
+                  name: '',
+                  fields: ['count_unique(user)'],
+                  columns: [],
+                  aggregates: ['count_unique(user)'],
+                  orderby: '-count_unique(user)',
+                },
+              ],
+            },
+          ],
+        },
+        params: {
+          widgetIndex: '0',
+        },
+        orgFeatures: [
+          ...defaultOrgFeatures,
+          'performance-discover-dataset-selector',
+          // TODO: This is an old flag, it should be removed to consistently
+          // show the device.class field
+          'device-classification',
+        ],
+      });
+
+      expect(await screen.findByText('Select group')).toBeInTheDocument();
+
+      // Open the aggregate parameter dropdown
+      const yAxisStep = screen
+        .getByRole('heading', {name: /choose what to plot in the y-axis/i})
+        .closest('li');
+      await userEvent.click(within(yAxisStep!).getByText('user'));
+
+      // Verify the error aggregate params are present
+      expect(screen.getAllByTestId('menu-list-item-label')).toHaveLength(
+        ERROR_FIELDS.length
+      );
+      ERROR_FIELDS.forEach(field => {
+        expect(screen.getByRole('menuitemradio', {name: field})).toBeInTheDocument();
       });
     });
   });


### PR DESCRIPTION
Adds the necessary functions to query `events-stats` for the errors dataset. I added a test to check the aggregate options for timeseries widgets and verify the options for aggregates as well.

I realized that `count_unique` defaults its value to `transaction.duration`, so we'll need to change that or override the default for errors widgets. That will be another PR.