### PR TITLE
fix(relocation): Exclude `getsentry` models from relocation

### DIFF
--- a/src/sentry/backup/dependencies.py
+++ b/src/sentry/backup/dependencies.py
@@ -427,7 +427,10 @@ def dependencies() -> dict[NormalizedModelName, ModelRelations]:
         for model in model_iterator:
             # Ignore some native Django models, since other models don't reference them and we don't
             # really use them for business logic.
-            if model._meta.app_label in {"sessions", "sites", "test"}:
+            #
+            # Also, exclude `getsentry`, since data in those tables should never be backed up or
+            # checked.
+            if model._meta.app_label in {"sessions", "sites", "test", "getsentry"}:
                 continue
 
             foreign_keys: dict[str, ForeignField] = dict()

--- a/src/sentry/db/models/base.py
+++ b/src/sentry/db/models/base.py
@@ -363,6 +363,15 @@ def __model_class_prepared(sender: Any, **kwargs: Any) -> None:
             f"`Excluded`, which does not make sense. `Excluded` must always be a standalone value."
         )
 
+    if (
+        getattr(sender._meta, "app_label", None) == "getsentry"
+        and sender.__relocation_scope__ != RelocationScope.Excluded
+    ):
+        raise ValueError(
+            f"{sender!r} model is in the `getsentry` app, and therefore cannot be exported. "
+            f"Please set `__relocation_scope__ = RelocationScope.Excluded` on the model definition."
+        )
+
     from .outboxes import ReplicatedControlModel, ReplicatedRegionModel
 
     if issubclass(sender, ReplicatedControlModel):


### PR DESCRIPTION
Relocation validation has been failing because a `getsentry` model received a relocation scope, which caused the `clear_databases` step during validation to fail when it tried to delete a table that does not exist in `self-hosted`. We now proactively exclude all `app_label == "getsentry"` models from the runtime `dependencies()` calculation that is used to generate this list of tables. Additionally, an app-startup time check has been added to ensure that no `getsentry` models accidentally get non-`Excluded` scopes added to them in the future.

A partner PR is landing in the `getsentry` repo to fix the offending model.

