### PR TITLE
fix(insights): Fix `hasEverSentData` tag

### DIFF
--- a/static/app/views/insights/common/utils/useHasDataTrackAnalytics.tsx
+++ b/static/app/views/insights/common/utils/useHasDataTrackAnalytics.tsx
@@ -12,9 +12,7 @@ export function useHasDataTrackAnalytics(module: ModuleName, analyticEvent: stri
   const pageFilters = usePageFilters();
   const hasEverSentData = useHasFirstSpan(module);
 
-  Sentry.withScope(scope => {
-    scope.setTag(`insights.${module}.hasEverSentData`, hasEverSentData);
-  });
+  Sentry.setTag(`insights.${module}.hasEverSentData`, hasEverSentData);
 
   const projects = JSON.stringify(pageFilters.selection.projects);
 


### PR DESCRIPTION
Follow-up to https://github.com/getsentry/sentry/pull/74079. That PR didn't work because it creates a new scope that falls out before it's applied to any events, so none of the Replays got tagged. Instead, use the current isolation scope (which is global in the browser). My bad for mis-understanding a code snippet before shipping!
