### PR TITLE
fix(uptime): Fix detector buckets

### DIFF
--- a/src/sentry/uptime/detectors/ranking.py
+++ b/src/sentry/uptime/detectors/ranking.py
@@ -134,9 +134,7 @@ def get_organization_bucket_key(organization: Organization) -> str:
 
 
 def get_organization_bucket_key_for_datetime(bucket_datetime: datetime) -> str:
-    date_bucket = int(
-        bucket_datetime.replace(second=0, microsecond=0).timestamp() % NUMBER_OF_BUCKETS
-    )
+    date_bucket = int((bucket_datetime.timestamp() // 60) % NUMBER_OF_BUCKETS)
     return build_organization_bucket_key(date_bucket)
 
 

--- a/tests/sentry/uptime/detectors/test_ranking.py
+++ b/tests/sentry/uptime/detectors/test_ranking.py
@@ -5,7 +5,6 @@ from sentry.models.organization import Organization
 from sentry.models.project import Project
 from sentry.testutils.cases import TestCase
 from sentry.uptime.detectors.ranking import (
-    NUMBER_OF_BUCKETS,
     _get_cluster,
     add_base_url_to_rank,
     build_org_projects_key,
@@ -157,9 +156,9 @@ class GetOrganizationBucketTest(TestCase):
 
 class DeleteOrganizationBucketTest(TestCase):
     def test(self):
-        bucket = datetime.now().replace(second=0, microsecond=0)
+        bucket = datetime(2024, 7, 18, 0, 47)
         delete_organization_bucket(bucket)
-        dummy_org_id = int(bucket.timestamp() % NUMBER_OF_BUCKETS)
+        dummy_org_id = 1487
         self.project.organization = Organization(id=dummy_org_id)
         self.project.organization_id = dummy_org_id
         add_base_url_to_rank(self.project, "https://sentry.io")

--- a/tests/sentry/uptime/detectors/test_ranking.py
+++ b/tests/sentry/uptime/detectors/test_ranking.py
@@ -146,9 +146,9 @@ class DeleteCandidateUrlsForProjectTest(TestCase):
 
 class GetOrganizationBucketTest(TestCase):
     def test(self):
-        bucket = datetime.now().replace(second=0, microsecond=0)
+        bucket = datetime(2024, 7, 18, 0, 47)
         assert get_organization_bucket(bucket) == set()
-        dummy_org_id = int(bucket.timestamp() % NUMBER_OF_BUCKETS)
+        dummy_org_id = 47
         self.project.organization = Organization(id=dummy_org_id)
         self.project.organization_id = dummy_org_id
         add_base_url_to_rank(self.project, "https://sentry.io")

--- a/tests/sentry/uptime/detectors/test_tasks.py
+++ b/tests/sentry/uptime/detectors/test_tasks.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import timedelta
+from datetime import datetime, timedelta
 from unittest import mock
 from unittest.mock import call
 from urllib.robotparser import RobotFileParser
@@ -98,8 +98,8 @@ class ProcessDetectionBucketTest(TestCase):
             mock_process_project_url_ranking.delay.assert_not_called()
 
     def test_bucket(self):
-        bucket = timezone.now().replace(second=0, microsecond=0)
-        dummy_organization_id = int(bucket.timestamp() % NUMBER_OF_BUCKETS)
+        bucket = datetime(2024, 7, 18, 0, 21)
+        dummy_organization_id = 21
 
         self.project.organization = Organization(id=dummy_organization_id)
 


### PR DESCRIPTION
Fixes bug pointed out by @vartec here: https://github.com/getsentry/sentry/pull/74482#discussion_r1681925941

Previously we wouldn't have run detection correctly for most orgs, since we'd only run it for specific buckets.

<!-- Describe your PR here. -->