### PR TITLE
feat(query-builder): Add support for percentage filters

### DIFF
--- a/static/app/components/searchQueryBuilder/index.spec.tsx
+++ b/static/app/components/searchQueryBuilder/index.spec.tsx
@@ -1,4 +1,5 @@
 import type {ComponentProps} from 'react';
+import {destroyAnnouncer} from '@react-aria/live-announcer';
 
 import {
   render,
@@ -99,6 +100,9 @@ describe('SearchQueryBuilder', function () {
   beforeEach(() => {
     // `useDimensions` is used to hide things when the component is too small, so we need to mock a large width
     Object.defineProperty(Element.prototype, 'clientWidth', {value: 1000});
+
+    // Combobox announcements will pollute the test output if we don't clear them
+    destroyAnnouncer();
   });
 
   afterEach(function () {
@@ -1479,6 +1483,113 @@ describe('SearchQueryBuilder', function () {
         expect(
           await screen.findByRole('row', {name: 'duration:>100ms'})
         ).toBeInTheDocument();
+        expect(mockOnChange).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('percentage', function () {
+      const percentageFilterKeys: TagCollection = {
+        rate: {
+          key: 'rate',
+          name: 'rate',
+        },
+      };
+
+      const fieldDefinitionGetter: FieldDefinitionGetter = () => ({
+        valueType: FieldValueType.PERCENTAGE,
+        kind: FieldKind.FIELD,
+      });
+
+      const percentageProps: SearchQueryBuilderProps = {
+        ...defaultProps,
+        filterKeys: percentageFilterKeys,
+        filterKeySections: [],
+        fieldDefinitionGetter,
+      };
+
+      it('new percentage filters start with greater than operator and default value', async function () {
+        render(<SearchQueryBuilder {...percentageProps} />);
+        await userEvent.click(getLastInput());
+        await userEvent.click(screen.getByRole('option', {name: 'rate'}));
+
+        // Should start with the > operator and a value of 50%
+        expect(await screen.findByRole('row', {name: 'rate:>0.5'})).toBeInTheDocument();
+      });
+
+      it('percentage filters have the correct operator options', async function () {
+        render(<SearchQueryBuilder {...percentageProps} initialQuery="rate:>0.5" />);
+        await userEvent.click(
+          screen.getByRole('button', {name: 'Edit operator for filter: rate'})
+        );
+
+        expect(await screen.findByRole('option', {name: 'rate is'})).toBeInTheDocument();
+        expect(screen.getByRole('option', {name: 'rate is not'})).toBeInTheDocument();
+        expect(screen.getByRole('option', {name: 'rate >'})).toBeInTheDocument();
+        expect(screen.getByRole('option', {name: 'rate <'})).toBeInTheDocument();
+        expect(screen.getByRole('option', {name: 'rate >='})).toBeInTheDocument();
+        expect(screen.getByRole('option', {name: 'rate <='})).toBeInTheDocument();
+      });
+
+      it('percentage filters can change operator', async function () {
+        render(<SearchQueryBuilder {...percentageProps} initialQuery="rate:>0.5" />);
+        await userEvent.click(
+          screen.getByRole('button', {name: 'Edit operator for filter: rate'})
+        );
+
+        await userEvent.click(await screen.findByRole('option', {name: 'rate <='}));
+
+        expect(await screen.findByRole('row', {name: 'rate:<=0.5'})).toBeInTheDocument();
+      });
+
+      it('percentage filters do not allow invalid values', async function () {
+        render(<SearchQueryBuilder {...percentageProps} initialQuery="rate:>0.5" />);
+        await userEvent.click(
+          screen.getByRole('button', {name: 'Edit value for filter: rate'})
+        );
+
+        await userEvent.keyboard('a{Enter}');
+
+        // Should have the same value because "a" is not a numeric value
+        expect(screen.getByRole('row', {name: 'rate:>0.5'})).toBeInTheDocument();
+
+        await userEvent.keyboard('{Backspace}0.2{Enter}');
+
+        // Should accept "0.2" as a valid value
+        expect(await screen.findByRole('row', {name: 'rate:>0.2'})).toBeInTheDocument();
+      });
+
+      it('percentage filters will convert values with % to ratio', async function () {
+        render(<SearchQueryBuilder {...percentageProps} initialQuery="rate:>0.5" />);
+        await userEvent.click(
+          screen.getByRole('button', {name: 'Edit value for filter: rate'})
+        );
+
+        await userEvent.keyboard('70%{Enter}');
+
+        // 70% should be accepted and converted to 0.7
+        expect(await screen.findByRole('row', {name: 'rate:>0.7'})).toBeInTheDocument();
+      });
+
+      it('keeps previous value when confirming empty value', async function () {
+        const mockOnChange = jest.fn();
+        render(
+          <SearchQueryBuilder
+            {...percentageProps}
+            onChange={mockOnChange}
+            initialQuery="rate:>0.5"
+          />
+        );
+
+        await userEvent.click(
+          screen.getByRole('button', {name: 'Edit value for filter: rate'})
+        );
+        await userEvent.clear(
+          await screen.findByRole('combobox', {name: 'Edit filter value'})
+        );
+        await userEvent.keyboard('{enter}');
+
+        // Should have the same value
+        expect(await screen.findByRole('row', {name: 'rate:>0.5'})).toBeInTheDocument();
         expect(mockOnChange).not.toHaveBeenCalled();
       });
     });

--- a/static/app/components/searchQueryBuilder/index.stories.tsx
+++ b/static/app/components/searchQueryBuilder/index.stories.tsx
@@ -7,7 +7,7 @@ import type {FilterKeySection} from 'sentry/components/searchQueryBuilder/types'
 import SizingWindow from 'sentry/components/stories/sizingWindow';
 import storyBook from 'sentry/stories/storyBook';
 import type {TagCollection} from 'sentry/types/group';
-import {FieldKey, FieldKind, WebVital} from 'sentry/utils/fields';
+import {FieldKey, FieldKind, MobileVital, WebVital} from 'sentry/utils/fields';
 
 const FILTER_KEYS: TagCollection = {
   [FieldKey.AGE]: {key: FieldKey.AGE, name: 'Age', kind: FieldKind.FIELD},
@@ -54,6 +54,11 @@ const FILTER_KEYS: TagCollection = {
     name: 'lcp',
     kind: FieldKind.FIELD,
   },
+  [MobileVital.FRAMES_SLOW_RATE]: {
+    key: MobileVital.FRAMES_SLOW_RATE,
+    name: 'framesSlowRate',
+    kind: FieldKind.FIELD,
+  },
   custom_tag_name: {
     key: 'custom_tag_name',
     name: 'Custom_Tag_Name',
@@ -71,6 +76,7 @@ const FITLER_KEY_SECTIONS: FilterKeySection[] = [
       FieldKey.IS,
       FieldKey.TIMES_SEEN,
       WebVital.LCP,
+      MobileVital.FRAMES_SLOW_RATE,
     ],
   },
   {

--- a/static/app/components/searchQueryBuilder/tokens/filter/parsers/percentage/grammar.pegjs
+++ b/static/app/components/searchQueryBuilder/tokens/filter/parsers/percentage/grammar.pegjs
@@ -1,0 +1,11 @@
+value = percentage_format
+
+percentage_format
+  = value:numeric unit:"%"? {
+      return {
+        value,
+        unit,
+      }
+    }
+
+numeric = [0-9]+ ("." [0-9]*)? { return text(); }

--- a/static/app/components/searchQueryBuilder/tokens/filter/parsers/percentage/parser.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/parsers/percentage/parser.tsx
@@ -1,0 +1,20 @@
+import grammar from './grammar.pegjs';
+
+type DurationTokenValue = {
+  value: string;
+  unit?: string;
+};
+
+/**
+ * This parser is specifically meant for parsing the value of a percentage filter.
+ * This should mostly mirror the grammar used for search syntax, but is a little
+ * more lenient. This parser still returns a valid result even if the percentage
+ * does not contain "%".
+ */
+export function parseFilterValuePercentage(query: string): DurationTokenValue | null {
+  try {
+    return grammar.parse(query);
+  } catch (e) {
+    return null;
+  }
+}

--- a/static/app/components/searchQueryBuilder/tokens/filter/valueCombobox.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/valueCombobox.tsx
@@ -10,6 +10,7 @@ import {useSearchQueryBuilder} from 'sentry/components/searchQueryBuilder/contex
 import {SearchQueryBuilderCombobox} from 'sentry/components/searchQueryBuilder/tokens/combobox';
 import {parseFilterValueDate} from 'sentry/components/searchQueryBuilder/tokens/filter/parsers/date/parser';
 import {parseFilterValueDuration} from 'sentry/components/searchQueryBuilder/tokens/filter/parsers/duration/parser';
+import {parseFilterValuePercentage} from 'sentry/components/searchQueryBuilder/tokens/filter/parsers/percentage/parser';
 import SpecificDatePicker from 'sentry/components/searchQueryBuilder/tokens/filter/specificDatePicker';
 import {
   escapeTagValue,
@@ -379,6 +380,8 @@ function getPredefinedValues({
         return getNumericSuggestions(filterValue);
       case FieldValueType.DURATION:
         return getDurationSuggestions(filterValue, token);
+      case FieldValueType.PERCENTAGE:
+        return [];
       case FieldValueType.BOOLEAN:
         return DEFAULT_BOOLEAN_SUGGESTIONS;
       case FieldValueType.DATE:
@@ -479,6 +482,18 @@ function cleanFilterValue(
         return `${parsed.value}ms`;
       }
       return value;
+    }
+    case FieldValueType.PERCENTAGE: {
+      const parsed = parseFilterValuePercentage(value);
+      if (!parsed) {
+        return null;
+      }
+      // If the user passes "50%", convert to 0.5
+      if (parsed.unit) {
+        const numericValue = parseFloat(parsed.value);
+        return isNaN(numericValue) ? parsed.value : (numericValue / 100).toString();
+      }
+      return parsed.value;
     }
     case FieldValueType.DATE:
       const parsed = parseFilterValueDate(value);

--- a/static/app/components/searchQueryBuilder/tokens/freeText.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/freeText.tsx
@@ -99,6 +99,7 @@ function getInitialFilterText(key: string, fieldDefinition: FieldDefinition | nu
     case FieldValueType.INTEGER:
     case FieldValueType.NUMBER:
     case FieldValueType.DURATION:
+    case FieldValueType.PERCENTAGE:
       return `${key}:>${defaultValue}`;
     case FieldValueType.STRING:
     default:

--- a/static/app/components/searchQueryBuilder/tokens/utils.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/utils.tsx
@@ -63,6 +63,8 @@ export function getDefaultFilterValue({
       return '-24h';
     case FieldValueType.DURATION:
       return '10ms';
+    case FieldValueType.PERCENTAGE:
+      return '0.5';
     case FieldValueType.STRING:
     default:
       return '""';

--- a/static/app/components/searchQueryBuilder/utils.tsx
+++ b/static/app/components/searchQueryBuilder/utils.tsx
@@ -24,6 +24,7 @@ function getSearchConfigFromKeys(
     numericKeys: new Set<string>(),
     dateKeys: new Set<string>(),
     durationKeys: new Set<string>(),
+    percentageKeys: new Set<string>(),
   } satisfies Partial<SearchConfig>;
 
   for (const key in keys) {
@@ -42,6 +43,7 @@ function getSearchConfigFromKeys(
         break;
       case FieldValueType.NUMBER:
       case FieldValueType.INTEGER:
+      case FieldValueType.PERCENTAGE:
         config.numericKeys.add(key);
         break;
       case FieldValueType.DATE:


### PR DESCRIPTION
Closes https://github.com/getsentry/sentry/issues/74305

Turns out that percentage filters, as we use them now, are actually numeric filters under the hood. Therefore, the behavior I'm adding allows the user to input `%` values but converts them to a ratio. See this comment for more info: https://github.com/getsentry/sentry/issues/74305#issuecomment-2237207619

https://github.com/user-attachments/assets/05c99ccd-f1c0-48fc-a6e7-e6021f47b33b

