### PR TITLE
feat(tags): Add dataset param to OrganizationTagKeyValues endpoint

### DIFF
--- a/src/sentry/api/endpoints/organization_tagkey_values.py
+++ b/src/sentry/api/endpoints/organization_tagkey_values.py
@@ -10,6 +10,7 @@ from sentry.api.bases import NoProjects, OrganizationEventsEndpointBase
 from sentry.api.paginator import SequencePaginator
 from sentry.api.serializers import serialize
 from sentry.api.utils import handle_query_errors
+from sentry.snuba.dataset import Dataset
 from sentry.tagstore.base import TAG_KEY_RE
 
 
@@ -31,6 +32,13 @@ class OrganizationTagKeyValuesEndpoint(OrganizationEventsEndpointBase):
 
         sentry_sdk.set_tag("query.tag_key", key)
 
+        dataset = None
+        if request.GET.get("dataset"):
+            try:
+                dataset = Dataset(request.GET.get("dataset"))
+            except ValueError:
+                raise ParseError(detail="Invalid dataset parameter")
+
         try:
             # still used by events v1 which doesn't require global views
             filter_params = self.get_snuba_params(request, organization, check_global_views=False)
@@ -47,6 +55,7 @@ class OrganizationTagKeyValuesEndpoint(OrganizationEventsEndpointBase):
                     key,
                     filter_params["start"],
                     filter_params["end"],
+                    dataset=dataset,
                     query=request.GET.get("query"),
                     order_by=validate_sort_field(request.GET.get("sort", "-last_seen")),
                     include_transactions=request.GET.get("includeTransactions") == "1",

--- a/src/sentry/tagstore/base.py
+++ b/src/sentry/tagstore/base.py
@@ -232,6 +232,7 @@ class TagStorage(Service):
         key,
         start=None,
         end=None,
+        dataset: Dataset | None = None,
         query=None,
         order_by="-last_seen",
         include_transactions: bool = False,

--- a/src/sentry/tagstore/snuba/backend.py
+++ b/src/sentry/tagstore/snuba/backend.py
@@ -1176,6 +1176,7 @@ class SnubaTagStorage(TagStorage):
         key,
         start=None,
         end=None,
+        dataset: Dataset = None,
         query: str | None = None,
         order_by="-last_seen",
         include_transactions: bool = False,
@@ -1193,11 +1194,12 @@ class SnubaTagStorage(TagStorage):
         if order_by == "-count":
             order_by = "-times_seen"
 
-        dataset = Dataset.Events
-        if include_transactions:
-            dataset = Dataset.Discover
-        if include_replays:
-            dataset = Dataset.Replays
+        if not dataset:
+            dataset = Dataset.Events
+            if include_transactions:
+                dataset = Dataset.Discover
+            if include_replays:
+                dataset = Dataset.Replays
 
         snuba_key = snuba.get_snuba_column_name(key, dataset=dataset)
 


### PR DESCRIPTION
This PR adds a dataset parameter to the OrganizationTagKeyValues endpoint, allowing full control over which dataset will be queried. Our frontend currently queries the Discover dataset to retrieve tag values for the issue stream - we need this control to query only the Events and IssuePlatform datasets. 