### PR TITLE
analytics(replay): analytics for hydration issue details and slider interactions

### DIFF
--- a/static/app/components/replays/diff/replaySliderDiff.tsx
+++ b/static/app/components/replays/diff/replaySliderDiff.tsx
@@ -1,4 +1,4 @@
-import {Fragment, useRef} from 'react';
+import {Fragment, useCallback, useRef, useState} from 'react';
 import styled from '@emotion/styled';
 
 import NegativeSpaceContainer from 'sentry/components/container/negativeSpaceContainer';
@@ -6,9 +6,11 @@ import ReplayIFrameRoot from 'sentry/components/replays/player/replayIFrameRoot'
 import {StaticReplayPreferences} from 'sentry/components/replays/preferences/replayPreferences';
 import {Provider as ReplayContextProvider} from 'sentry/components/replays/replayContext';
 import {space} from 'sentry/styles/space';
+import {trackAnalytics} from 'sentry/utils/analytics';
 import toPixels from 'sentry/utils/number/toPixels';
 import type ReplayReader from 'sentry/utils/replays/replayReader';
 import {useDimensions} from 'sentry/utils/useDimensions';
+import useOrganization from 'sentry/utils/useOrganization';
 import {useResizableDrawer} from 'sentry/utils/useResizableDrawer';
 
 interface Props {
@@ -44,7 +46,8 @@ export function ReplaySliderDiff({leftOffsetMs, replay, rightOffsetMs}: Props) {
 function DiffSides({leftOffsetMs, replay, rightOffsetMs, viewDimensions, width}) {
   const rightSideElem = useRef<HTMLDivElement>(null);
   const dividerElem = useRef<HTMLDivElement>(null);
-  const {onMouseDown} = useResizableDrawer({
+
+  const {onMouseDown: onDividerMouseDown} = useResizableDrawer({
     direction: 'left',
     initialSize: viewDimensions.width / 2,
     min: 0,
@@ -62,6 +65,23 @@ function DiffSides({leftOffsetMs, replay, rightOffsetMs, viewDimensions, width})
       }
     },
   });
+
+  const organization = useOrganization();
+  const [dividerClicked, setDividerClicked] = useState(false); // never flips back to false
+
+  const onDividerMouseDownWithAnalytics: React.MouseEventHandler<HTMLElement> =
+    useCallback(
+      (event: React.MouseEvent<HTMLElement>) => {
+        // tracks only the first mouseDown, since the first render
+        if (organization && !dividerClicked) {
+          trackAnalytics('replay.hydration-modal.slider-interaction', {organization});
+          setDividerClicked(true);
+        }
+
+        onDividerMouseDown(event);
+      },
+      [onDividerMouseDown, organization, dividerClicked, setDividerClicked]
+    );
 
   return (
     <Fragment>
@@ -91,7 +111,7 @@ function DiffSides({leftOffsetMs, replay, rightOffsetMs, viewDimensions, width})
           </ReplayContextProvider>
         </Placement>
       </Cover>
-      <Divider ref={dividerElem} onMouseDown={onMouseDown} />
+      <Divider ref={dividerElem} onMouseDown={onDividerMouseDownWithAnalytics} />
     </Fragment>
   );
 }

--- a/static/app/components/replays/diff/replaySliderDiff.tsx
+++ b/static/app/components/replays/diff/replaySliderDiff.tsx
@@ -72,12 +72,11 @@ function DiffSides({leftOffsetMs, replay, rightOffsetMs, viewDimensions, width})
   const onDividerMouseDownWithAnalytics: React.MouseEventHandler<HTMLElement> =
     useCallback(
       (event: React.MouseEvent<HTMLElement>) => {
-        // tracks only the first mouseDown, since the first render
+        // tracks only the first mouseDown since the last render
         if (organization && !dividerClickedRef.current) {
           trackAnalytics('replay.hydration-modal.slider-interaction', {organization});
           dividerClickedRef.current = true;
         }
-
         onDividerMouseDown(event);
       },
       [onDividerMouseDown, organization]

--- a/static/app/components/replays/diff/replaySliderDiff.tsx
+++ b/static/app/components/replays/diff/replaySliderDiff.tsx
@@ -1,4 +1,4 @@
-import {Fragment, useCallback, useRef, useState} from 'react';
+import {Fragment, useCallback, useRef} from 'react';
 import styled from '@emotion/styled';
 
 import NegativeSpaceContainer from 'sentry/components/container/negativeSpaceContainer';
@@ -67,20 +67,20 @@ function DiffSides({leftOffsetMs, replay, rightOffsetMs, viewDimensions, width})
   });
 
   const organization = useOrganization();
-  const [dividerClicked, setDividerClicked] = useState(false); // never flips back to false
+  const dividerClickedRef = useRef(false); // once set, never flips back to false
 
   const onDividerMouseDownWithAnalytics: React.MouseEventHandler<HTMLElement> =
     useCallback(
       (event: React.MouseEvent<HTMLElement>) => {
         // tracks only the first mouseDown, since the first render
-        if (organization && !dividerClicked) {
+        if (organization && !dividerClickedRef.current) {
           trackAnalytics('replay.hydration-modal.slider-interaction', {organization});
-          setDividerClicked(true);
+          dividerClickedRef.current = true;
         }
 
         onDividerMouseDown(event);
       },
-      [onDividerMouseDown, organization, dividerClicked, setDividerClicked]
+      [onDividerMouseDown, organization]
     );
 
   return (

--- a/static/app/views/issueDetails/header.tsx
+++ b/static/app/views/issueDetails/header.tsx
@@ -85,8 +85,8 @@ function GroupHeaderTabs({
   });
 
   useEffect(() => {
-    if (organization && group.issueType === IssueType.REPLAY_HYDRATION_ERROR) {
-      trackAnalytics('replay.hydration-error.issue-details', {organization});
+    if (group.issueType === IssueType.REPLAY_HYDRATION_ERROR) {
+      trackAnalytics('replay.hydration-error.issue-details-opened', {organization});
     }
   }, [group.issueType, organization]);
 

--- a/static/app/views/issueDetails/header.tsx
+++ b/static/app/views/issueDetails/header.tsx
@@ -1,4 +1,4 @@
-import {Fragment, useMemo} from 'react';
+import {Fragment, useEffect, useMemo} from 'react';
 import styled from '@emotion/styled';
 import type {LocationDescriptor} from 'history';
 import omit from 'lodash/omit';
@@ -20,7 +20,8 @@ import {IconChat} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {Event, Group, Organization, Project} from 'sentry/types';
-import {IssueCategory} from 'sentry/types/group';
+import {IssueCategory, IssueType} from 'sentry/types/group';
+import {trackAnalytics} from 'sentry/utils/analytics';
 import {getMessage} from 'sentry/utils/events';
 import {getConfigForIssueType} from 'sentry/utils/issueTypeConfig';
 import useReplayCountForIssues from 'sentry/utils/replayCount/useReplayCountForIssues';
@@ -82,6 +83,12 @@ function GroupHeaderTabs({
   useRouteAnalyticsParams({
     group_has_replay: (replaysCount ?? 0) > 0,
   });
+
+  useEffect(() => {
+    if (organization && group.issueType === IssueType.REPLAY_HYDRATION_ERROR) {
+      trackAnalytics('replay.hydration-error.issue-details', {organization});
+    }
+  }, [group.issueType, organization]);
 
   return (
     <StyledTabList hideBorder>


### PR DESCRIPTION
Ref https://github.com/getsentry/sentry/issues/74456

- Tracks first render of a hydrate error on issue details, after page load
- Tracks first click on the slider's divider bar, after the last render of the slider diff

Current behavior:
https://github.com/user-attachments/assets/0a6431d1-00a8-43fd-befb-0807d432518c