### PR TITLE
ref(dataset): Update FE Dataset enum to include IssuePlatform

### DIFF
--- a/static/app/actionCreators/tags.tsx
+++ b/static/app/actionCreators/tags.tsx
@@ -13,6 +13,7 @@ import {
   useApiQuery,
   type UseApiQueryOptions,
 } from 'sentry/utils/queryClient';
+import type {Dataset} from 'sentry/views/alerts/rules/metric/types';
 
 const MAX_TAGS = 1000;
 
@@ -200,8 +201,7 @@ export function fetchSpanFieldValues({
 
 type FetchOrganizationTagsParams = {
   orgSlug: string;
-  // TODO: Change this to Dataset type once IssuePlatform is added
-  dataset?: string;
+  dataset?: Dataset;
   enabled?: boolean;
   end?: string;
   keepPreviousData?: boolean;

--- a/static/app/views/alerts/rules/metric/types.tsx
+++ b/static/app/views/alerts/rules/metric/types.tsx
@@ -37,6 +37,7 @@ export enum Dataset {
   SESSIONS = 'sessions',
   /** Also used for crash free alerts */
   METRICS = 'metrics',
+  ISSUE_PLATFORM = 'search_issues',
 }
 
 export enum EventTypes {

--- a/static/app/views/alerts/wizard/options.tsx
+++ b/static/app/views/alerts/wizard/options.tsx
@@ -64,7 +64,10 @@ export enum MEPAlertsDataset {
 
 export type MetricAlertType = Exclude<AlertType, 'issues'>;
 
-export const DatasetMEPAlertQueryTypes: Record<Dataset, MEPAlertsQueryType> = {
+export const DatasetMEPAlertQueryTypes: Record<
+  Exclude<Dataset, 'search_issues'>, // IssuePlatform (search_issues) is not used in alerts, so we can exclude it here
+  MEPAlertsQueryType
+> = {
   [Dataset.ERRORS]: MEPAlertsQueryType.ERROR,
   [Dataset.TRANSACTIONS]: MEPAlertsQueryType.PERFORMANCE,
   [Dataset.GENERIC_METRICS]: MEPAlertsQueryType.PERFORMANCE,

--- a/static/app/views/alerts/wizard/utils.tsx
+++ b/static/app/views/alerts/wizard/utils.tsx
@@ -8,7 +8,10 @@ import {Dataset, SessionsAggregate} from 'sentry/views/alerts/rules/metric/types
 import type {MetricAlertType, WizardRuleTemplate} from './options';
 
 // A set of unique identifiers to be able to tie aggregate and dataset back to a wizard alert type
-const alertTypeIdentifiers: Record<Dataset, Partial<Record<MetricAlertType, string>>> = {
+const alertTypeIdentifiers: Record<
+  Exclude<Dataset, 'search_issues'>, // IssuePlatform (search_issues) is not used in alerts, so we can exclude it here
+  Partial<Record<MetricAlertType, string>>
+> = {
   [Dataset.ERRORS]: {
     num_errors: 'count()',
     users_experiencing_errors: 'count_unique(user)',
@@ -62,7 +65,7 @@ export function getAlertTypeFromAggregateDataset({
 
   const identifierForDataset = alertTypeIdentifiers[dataset];
   const matchingAlertTypeEntry = Object.entries(identifierForDataset).find(
-    ([_alertType, identifier]) => identifier && aggregate.includes(identifier)
+    ([_alertType, identifier]) => identifier && aggregate.includes(identifier as string)
   );
   const alertType =
     matchingAlertTypeEntry && (matchingAlertTypeEntry[0] as MetricAlertType);

--- a/static/app/views/issueList/utils/useFetchIssueTags.tsx
+++ b/static/app/views/issueList/utils/useFetchIssueTags.tsx
@@ -64,7 +64,7 @@ export const useFetchIssueTags = ({
     {
       orgSlug: org.slug,
       projectIds,
-      dataset: 'search_issues',
+      dataset: Dataset.ISSUE_PLATFORM,
       useCache,
       enabled,
       keepPreviousData,


### PR DESCRIPTION
Adds the IssuePlatform dataset to the FE dataset enum and updates the typing on the tags endpoint. 

There were also a couple of alerts related Record types that required an entry for each dataset - I have excluded IssuePlatform from these types since IssuePlatform is not used in the Alerts wizard 