### PR TITLE
feat(uptime): Add feature flag to prevent creating issue platform issues for uptime

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -469,6 +469,8 @@ def register_temporary_features(manager: FeatureManager):
     manager.add("organizations:uptime-automatic-subscription-creation", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE)
     # Enabled returning uptime monitors from the rule api
     manager.add("organizations:uptime-rule-api", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE)
+    # Enable creating issues via the issue platform
+    manager.add("organizations:uptime-create-issues", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE)
     # Enables uptime related settings for projects and orgs
     manager.add('organizations:uptime-settings', OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE)
     manager.add("organizations:use-metrics-layer", OrganizationFeature, FeatureHandlerStrategy.REMOTE)


### PR DESCRIPTION
This adds a flag to control whether uptime monitors will create issues in the issue platform
