### PR TITLE
feat(issue-search): Check `max_candidates` to push Postgres fields to post-filtering

### DIFF
--- a/src/sentry/search/snuba/executors.py
+++ b/src/sentry/search/snuba/executors.py
@@ -1665,7 +1665,10 @@ class GroupAttributesPostgresSnubaQueryExecutor(PostgresSnubaQueryExecutor):
             group_ids_to_pass_to_snuba = list(
                 group_queryset.using_replica().values_list("id", flat=True)[: max_candidates + 1]
             )
-        if len(group_ids_to_pass_to_snuba) > max_candidates:
+        if (
+            group_ids_to_pass_to_snuba is not None
+            and len(group_ids_to_pass_to_snuba) > max_candidates
+        ):
             metrics.incr("snuba.search.too_many_candidates", skip_internal=False)
             too_many_candidates = True
             group_ids_to_pass_to_snuba = []

--- a/src/sentry/search/snuba/executors.py
+++ b/src/sentry/search/snuba/executors.py
@@ -1614,8 +1614,16 @@ class GroupAttributesPostgresSnubaQueryExecutor(PostgresSnubaQueryExecutor):
         # Check if any search filters are in POSTGRES_ONLY_SEARCH_FIELDS
         search_filters = search_filters or ()
         group_ids_to_pass_to_snuba = None
+        too_many_candidates = False
         if any(sf.key.name in POSTGRES_ONLY_SEARCH_FIELDS for sf in search_filters):
-            group_ids_to_pass_to_snuba = list(group_queryset.values_list("id", flat=True))
+            max_candidates = options.get("snuba.search.max-pre-snuba-candidates")
+            group_ids_to_pass_to_snuba = list(
+                group_queryset.using_replica().values_list("id", flat=True)[: max_candidates + 1]
+            )
+        if len(group_ids_to_pass_to_snuba) > max_candidates:
+            metrics.incr("snuba.search.too_many_candidates", skip_internal=False)
+            too_many_candidates = True
+            group_ids_to_pass_to_snuba = []
 
         # remove the search filters that are only for postgres
         search_filters = [
@@ -1647,9 +1655,10 @@ class GroupAttributesPostgresSnubaQueryExecutor(PostgresSnubaQueryExecutor):
                 Condition(Column("timestamp", joined_entity), Op.GTE, start),
                 Condition(Column("timestamp", joined_entity), Op.LT, end),
             ]
+
             having = []
             # if we need to prefetch from postgres, we add filter by the group ids
-            if group_ids_to_pass_to_snuba is not None:
+            if group_ids_to_pass_to_snuba is not None and not too_many_candidates:
                 # will not find any matches, we can return early
                 if len(group_ids_to_pass_to_snuba) == 0:
                     return self.empty_result
@@ -1787,6 +1796,15 @@ class GroupAttributesPostgresSnubaQueryExecutor(PostgresSnubaQueryExecutor):
                 k += 1
                 count += bulk_result[k]["data"][0]["count"]
             k += 1
+
+        if too_many_candidates and group_ids_to_pass_to_snuba == []:
+            # If we had too many candidates to reasonably pass down to snuba,
+            # we need to apply the Postgres filter as a post-filtering step.
+            filtered_group_ids = group_queryset.filter(
+                id__in=[group["g.group_id"] for group in data]
+            ).values_list("id", flat=True)
+
+            data = [group for group in data if group["g.group_id"] in filtered_group_ids]
 
         paginator_results = SequencePaginator(
             [(row[self.sort_strategies[sort_by]], row["g.group_id"]) for row in data],

--- a/tests/sentry/issues/endpoints/test_organization_group_index.py
+++ b/tests/sentry/issues/endpoints/test_organization_group_index.py
@@ -3077,6 +3077,11 @@ class GroupListTest(APITestCase, SnubaTestCase, SearchIssueTestMixin):
     )
     @override_options({"issues.group_attributes.send_kafka": True})
     def test_snuba_query_unlinked(self, mock_query: MagicMock) -> None:
+        self.project = self.create_project(organization=self.organization)
+        event1 = self.store_event(
+            data={"fingerprint": ["group-1"], "message": "MyMessage"},
+            project_id=self.project.id,
+        )
         event2 = self.store_event(
             data={"fingerprint": ["group-2"], "message": "AnotherMessage"},
             project_id=self.project.id,

--- a/tests/sentry/issues/endpoints/test_organization_group_index.py
+++ b/tests/sentry/issues/endpoints/test_organization_group_index.py
@@ -2982,6 +2982,53 @@ class GroupListTest(APITestCase, SnubaTestCase, SearchIssueTestMixin):
         autospec=True,
     )
     @override_options({"issues.group_attributes.send_kafka": True})
+    def test_snuba_query_unlinked(self, mock_query: MagicMock) -> None:
+        self.project = self.create_project(organization=self.organization)
+        event1 = self.store_event(
+            data={"fingerprint": ["group-1"], "message": "MyMessage"},
+            project_id=self.project.id,
+        )
+        event2 = self.store_event(
+            data={"fingerprint": ["group-2"], "message": "AnotherMessage"},
+            project_id=self.project.id,
+        )
+        PlatformExternalIssue.objects.create(project_id=self.project.id, group_id=event1.group.id)
+        self.external_issue = ExternalIssue.objects.create(
+            organization_id=self.organization.id, integration_id=self.integration.id, key="123"
+        )
+        GroupLink.objects.create(
+            project_id=self.project.id,
+            group_id=event1.group.id,
+            linked_type=GroupLink.LinkedType.issue,
+            linked_id=self.external_issue.id,
+        )
+
+        self.login_as(user=self.user)
+        # give time for consumers to run and propogate changes to clickhouse
+        sleep(1)
+
+        response = self.get_success_response(
+            sort="new",
+            useGroupSnubaDataset=1,
+            query="is:linked",
+        )
+        assert len(response.data) == 1
+        assert int(response.data[0]["id"]) == event1.group.id
+
+        response = self.get_success_response(
+            sort="new",
+            useGroupSnubaDataset=1,
+            query="is:unlinked",
+        )
+        assert len(response.data) == 1
+        assert int(response.data[0]["id"]) == event2.group.id
+
+    @patch(
+        "sentry.search.snuba.executors.GroupAttributesPostgresSnubaQueryExecutor.query",
+        side_effect=GroupAttributesPostgresSnubaQueryExecutor.query,
+        autospec=True,
+    )
+    @override_options({"issues.group_attributes.send_kafka": True})
     def test_snuba_perf_issue(self, mock_query: MagicMock) -> None:
         self.project = self.create_project(organization=self.organization)
         # create a performance issue

--- a/tests/sentry/issues/endpoints/test_organization_group_index.py
+++ b/tests/sentry/issues/endpoints/test_organization_group_index.py
@@ -3069,7 +3069,7 @@ class GroupListTest(APITestCase, SnubaTestCase, SearchIssueTestMixin):
             )
             assert len(response.data) == len(expected_groups)
             assert {int(r["id"]) for r in response.data} == set(expected_groups)
-    
+
     @patch(
         "sentry.search.snuba.executors.GroupAttributesPostgresSnubaQueryExecutor.query",
         side_effect=GroupAttributesPostgresSnubaQueryExecutor.query,

--- a/tests/sentry/issues/endpoints/test_organization_group_index.py
+++ b/tests/sentry/issues/endpoints/test_organization_group_index.py
@@ -3007,21 +3007,23 @@ class GroupListTest(APITestCase, SnubaTestCase, SearchIssueTestMixin):
         # give time for consumers to run and propogate changes to clickhouse
         sleep(1)
 
-        response = self.get_success_response(
-            sort="new",
-            useGroupSnubaDataset=1,
-            query="is:linked",
-        )
-        assert len(response.data) == 1
-        assert int(response.data[0]["id"]) == event1.group.id
+        for value in [0, 5]:
+            with override_options({"snuba.search.max-pre-snuba-candidates": value}):
+                response = self.get_success_response(
+                    sort="new",
+                    useGroupSnubaDataset=1,
+                    query="is:linked",
+                )
+                assert len(response.data) == 1
+                assert int(response.data[0]["id"]) == event1.group.id
 
-        response = self.get_success_response(
-            sort="new",
-            useGroupSnubaDataset=1,
-            query="is:unlinked",
-        )
-        assert len(response.data) == 1
-        assert int(response.data[0]["id"]) == event2.group.id
+                response = self.get_success_response(
+                    sort="new",
+                    useGroupSnubaDataset=1,
+                    query="is:unlinked",
+                )
+                assert len(response.data) == 1
+                assert int(response.data[0]["id"]) == event2.group.id
 
     @patch(
         "sentry.search.snuba.executors.GroupAttributesPostgresSnubaQueryExecutor.query",


### PR DESCRIPTION
When applying query filters from Postgres, pre-filtering the results before passing the query to Snuba can break if it hits the max size that ClickHouse is able to process ([sentry issue](https://sentry.sentry.io/issues/5419972487/events/e14ff2501904443eb1c38f7600509b4f/?project=1&referrer=slack)). This also manifests as a possible [bug](https://sentry.sentry.io/issues/5419971969/events/9f65f1ff493a47858d91c2f9951e59a7/?referrer=issue_details.related_trace_issue) in the serializer, though that's more of a red herring since ClickHouse won't be able to handle the query either way. 

To work around this, I'm applying the  pattern used in the `PostgresSnubaQueryExecutor` to determine whether to pre- or post-filter the results based on the number of group_ids in the filter. If the number of groups in the pre-filter exceeds the `max_candidates`, we'll apply the filter after the Snuba query in a post-filtering step right before the pagination happens.

The tests confirm that the `is:linked` and `is:unlinked` queries work as a pre- and post-filter dependent on the value configured in `snuba.search.max-pre-snuba-candidates`.