### PR TITLE
ref/fix: more robust signature verification

### DIFF
--- a/src/sentry/integrations/github_enterprise/webhook.py
+++ b/src/sentry/integrations/github_enterprise/webhook.py
@@ -3,14 +3,17 @@ from __future__ import annotations
 import hashlib
 import hmac
 import logging
+import re
 
 import orjson
+import sentry_sdk
 from django.http import HttpRequest, HttpResponse
 from django.utils.crypto import constant_time_compare
 from django.utils.decorators import method_decorator
 from django.views.decorators.csrf import csrf_exempt
 from rest_framework.request import Request
 
+from sentry import options
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.integrations.github.webhook import (
@@ -30,11 +33,35 @@ from sentry.api.base import Endpoint, region_silo_endpoint
 from sentry.integrations.services.integration import integration_service
 from sentry.integrations.services.integration.model import RpcIntegration
 
+SHA1_PATTERN = r"^sha1=[0-9a-fA-F]{40}$"
+SHA256_PATTERN = r"^sha256=[0-9a-fA-F]{64}$"
 
-def get_host(request: HttpRequest) -> str | None:
+
+class MissingRequiredHeaderError(Exception):
+    pass
+
+
+class MissingWebhookPayloadError(Exception):
+    """Webhook payload not found"""
+
+
+class InvalidSignatureError(Exception):
+    """Provided signature does not match the computed body signature"""
+
+
+class MalformedSignatureError(Exception):
+    """Signature value does not match the expected format"""
+
+
+def get_host(request: HttpRequest) -> str:
     # XXX: There's lots of customers that are giving us an IP rather than a host name
     # Use HTTP_X_REAL_IP in a follow up PR (#42405)
-    return request.META.get("HTTP_X_GITHUB_ENTERPRISE_HOST")
+    host = request.headers.get("x-github-enterprise-host")
+
+    if not host:
+        raise MissingRequiredHeaderError("Missing X-GitHub-Enterprise-Host header")
+
+    return host
 
 
 def get_installation_metadata(event, host):
@@ -120,28 +147,35 @@ class GitHubEnterpriseWebhookBase(Endpoint):
         clear_tags_and_context()
         scope = Scope.get_isolation_scope()
 
-        meta = request.META
-        host = get_host(request=request)
-        if not host:
+        host = None
+        try:
+            host = get_host(request=request)
+        except MissingRequiredHeaderError as e:
             logger.warning("github_enterprise.webhook.missing-enterprise-host")
-            logger.error("Missing enterprise host.")
-            return HttpResponse(status=400)
+            sentry_sdk.capture_exception(e)
+            return HttpResponse(str(e), status=400)
 
         extra = {"host": host}
         # If we do tag the host early we can't even investigate
         scope.set_tag("host", host)
 
-        body = bytes(request.body)
-        if not body:
+        try:
+            body = bytes(request.body)
+        except MissingWebhookPayloadError as e:
             logger.warning("github_enterprise.webhook.missing-body", extra=extra)
-            return HttpResponse(status=400)
+            sentry_sdk.capture_exception(e)
+            return HttpResponse(str(e), status=400)
 
         try:
-            handler = self.get_handler(meta["HTTP_X_GITHUB_EVENT"])
-        except KeyError:
+            github_event = request.headers.get("x-github-event")
+            if not github_event:
+                raise MissingRequiredHeaderError("Missing X-GitHub-Event header")
+
+            handler = self.get_handler(github_event)
+        except MissingRequiredHeaderError as e:
             logger.warning("github_enterprise.webhook.missing-event", extra=extra)
-            logger.exception("Missing Github event in webhook.")
-            return HttpResponse(status=400)
+            sentry_sdk.capture_exception(e)
+            return HttpResponse(str(e), status=400)
 
         if not handler:
             return HttpResponse(status=204)
@@ -165,16 +199,76 @@ class GitHubEnterpriseWebhookBase(Endpoint):
             return HttpResponse(status=400)
 
         try:
-            # Attempt to validate the signature. Older versions of
-            # GitHub Enterprise do not send the signature so this is an optional step.
-            method, signature = meta["HTTP_X_HUB_SIGNATURE"].split("=", 1)
-            if not self.is_valid_signature(method, body, secret, signature):
-                logger.warning("github_enterprise.webhook.invalid-signature", extra=extra)
-                return HttpResponse(status=401)
-        except (KeyError, IndexError) as e:
-            extra["error"] = str(e)
-            logger.info("github_enterprise.webhook.missing-signature", extra=extra)
-            logger.exception("Missing webhook secret.")
+            sha256_signature = request.headers.get("x-hub-signature-256")
+            sha1_signature = request.headers.get("x-hub-signature")
+
+            if not sha256_signature and not sha1_signature:
+                raise MissingRequiredHeaderError(
+                    "Missing headers X-Hub-Signature-256 or X-Hub-Signature"
+                )
+
+            if sha256_signature:
+                if not re.match(SHA256_PATTERN, sha256_signature):
+                    # before we try to parse the parts of the signature, make sure it
+                    # looks as expected to avoid any IndexErrors when we split it
+                    raise InvalidSignatureError(
+                        "Provided signature does not match the computed body signature"
+                    )
+
+                _, signature = sha256_signature.split("=", 1)
+                extra["signature_algorithm"] = "sha256"
+                is_valid = self.is_valid_signature("sha256", body, secret, signature)
+                if not is_valid:
+                    raise MalformedSignatureError(
+                        "Signature value does not match the expected format"
+                    )
+
+            if sha1_signature:
+                if not re.match(SHA1_PATTERN, sha1_signature):
+                    # before we try to parse the parts of the signature, make sure it
+                    # looks as expected to avoid any IndexErrors when we split it
+                    raise MalformedSignatureError(
+                        "Signature value does not match the expected format"
+                    )
+
+                _, signature = sha1_signature.split("=", 1)
+                is_valid = self.is_valid_signature("sha1", body, secret, signature)
+                extra["signature_algorithm"] = "sha1"
+                if not is_valid:
+                    raise InvalidSignatureError(
+                        "Provided signature does not match the computed body signature"
+                    )
+
+        except InvalidSignatureError as e:
+            logger.warning("github_enterprise.webhook.invalid-signature", extra=extra)
+            sentry_sdk.capture_exception(e)
+
+            return HttpResponse(str(e), status=401)
+
+        except MissingRequiredHeaderError as e:
+            # older versions of GitHub 2.14.0 and older do not always send signature headers
+            # Setting a signature secret is optional in GitHub, but we require it on Sentry
+            # Only a small subset of legacy hosts are allowed to skip the signature verification
+            # at the moment.
+
+            allowed_legacy_hosts = options.get(
+                "github-enterprise-app.allowed-hosts-legacy-webhooks"
+            )
+
+            if host not in allowed_legacy_hosts:
+                # the host is not allowed to skip signature verification by omitting the headers
+                logger.warning("github_enterprise.webhook.missing-signature", extra=extra)
+                sentry_sdk.capture_exception(e)
+                return HttpResponse(str(e), status=400)
+            else:
+                # the host is allowed to skip signature verification
+                logger.info("github_enterprise.webhook.allowed-missing-signature", extra=extra)
+
+        except (MalformedSignatureError, IndexError) as e:
+            logger.warning("github_enterprise.webhook.malformed-signature", extra=extra)
+            sentry_sdk.capture_exception(e)
+            return HttpResponse(str(e), status=400)
+
         handler()(event, host)
         return HttpResponse(status=204)
 

--- a/src/sentry/integrations/github_enterprise/webhook.py
+++ b/src/sentry/integrations/github_enterprise/webhook.py
@@ -278,7 +278,7 @@ class GitHubEnterpriseWebhookBase(Endpoint):
                 return HttpResponse(MISSING_SIGNATURE_HEADERS_ERROR, status=400)
             else:
                 # the host is allowed to skip signature verification
-                logger.info("github_enterprise.webhook.allowed-missing-signature", extra=extra)
+                # log it, and continue on.
                 logger.info("github_enterprise.webhook.allowed-missing-signature", extra=extra)
 
         except (MalformedSignatureError, IndexError) as e:

--- a/src/sentry/integrations/github_enterprise/webhook.py
+++ b/src/sentry/integrations/github_enterprise/webhook.py
@@ -37,8 +37,8 @@ SHA1_PATTERN = r"^sha1=[0-9a-fA-F]{40}$"
 SHA256_PATTERN = r"^sha256=[0-9a-fA-F]{64}$"
 
 INVALID_SIGNATURE_ERROR = "Provided signature does not match the computed body signature"
-MALFORMED_SIGNATURE_ERROR = "Singature value does not match the expected format"
-UNSUPPORTED_SIGNATURE_ALGORITHM_ERROR = "Singature algorithm is unsupported"
+MALFORMED_SIGNATURE_ERROR = "Signature value does not match the expected format"
+UNSUPPORTED_SIGNATURE_ALGORITHM_ERROR = "Signature algorithm is unsupported"
 MISSING_WEBHOOK_PAYLOAD_ERROR = "Webhook payload not found"
 
 

--- a/src/sentry/integrations/github_enterprise/webhook.py
+++ b/src/sentry/integrations/github_enterprise/webhook.py
@@ -176,6 +176,8 @@ class GitHubEnterpriseWebhookBase(Endpoint):
 
         try:
             body = bytes(request.body)
+            if len(body) == 0:
+                raise MissingWebhookPayloadError()
         except MissingWebhookPayloadError as e:
             logger.warning("github_enterprise.webhook.missing-body", extra=extra)
             sentry_sdk.capture_exception(e)

--- a/src/sentry/integrations/github_enterprise/webhook.py
+++ b/src/sentry/integrations/github_enterprise/webhook.py
@@ -176,7 +176,7 @@ class GitHubEnterpriseWebhookBase(Endpoint):
         except MissingWebhookPayloadError as e:
             logger.warning("github_enterprise.webhook.missing-body", extra=extra)
             sentry_sdk.capture_exception(e)
-            return HttpResponse(str(e), status=400)
+            return HttpResponse(MISSING_WEBHOOK_PAYLOAD_ERROR, status=400)
 
         try:
             github_event = request.headers.get("x-github-event")

--- a/tests/sentry/integrations/github_enterprise/test_webhooks.py
+++ b/tests/sentry/integrations/github_enterprise/test_webhooks.py
@@ -15,6 +15,7 @@ from sentry.models.commitauthor import CommitAuthor
 from sentry.models.pullrequest import PullRequest
 from sentry.models.repository import Repository
 from sentry.testutils.cases import APITestCase
+from sentry.testutils.helpers import override_options
 
 
 class WebhookTest(APITestCase):
@@ -72,10 +73,44 @@ class WebhookTest(APITestCase):
             HTTP_X_GITHUB_DELIVERY=str(uuid4()),
         )
         assert response.status_code == 401
+        assert b"Provided signature does not match the computed body signature" in response.content
 
     @patch("sentry.integrations.github_enterprise.webhook.get_installation_metadata")
+    def test_malformed_signature_too_short(self, mock_installation):
+        mock_installation.return_value = self.metadata
+
+        response = self.client.post(
+            path=self.url,
+            data=PUSH_EVENT_EXAMPLE_INSTALLATION,
+            content_type="application/json",
+            HTTP_X_GITHUB_EVENT="push",
+            HTTP_X_GITHUB_ENTERPRISE_HOST="35.232.149.196",
+            HTTP_X_HUB_SIGNATURE="sha1=33521a2abfcf36fec",  # hash is too short
+            HTTP_X_GITHUB_DELIVERY=str(uuid4()),
+        )
+        assert response.status_code == 400
+        assert b"Signature value does not match the expected format" in response.content
+
+    @patch("sentry.integrations.github_enterprise.webhook.get_installation_metadata")
+    def test_malformed_signature_no_value(self, mock_installation):
+        mock_installation.return_value = self.metadata
+
+        response = self.client.post(
+            path=self.url,
+            data=PUSH_EVENT_EXAMPLE_INSTALLATION,
+            content_type="application/json",
+            HTTP_X_GITHUB_EVENT="push",
+            HTTP_X_GITHUB_ENTERPRISE_HOST="35.232.149.196",
+            HTTP_X_HUB_SIGNATURE="sha1=",
+            HTTP_X_GITHUB_DELIVERY=str(uuid4()),
+        )
+        assert response.status_code == 400
+        assert b"Signature value does not match the expected format" in response.content
+
+    @patch("sentry.integrations.github_enterprise.webhook.get_installation_metadata")
+    @override_options({"github-enterprise-app.allowed-hosts-legacy-webhooks": ["35.232.149.196"]})
     def test_missing_signature_ok(self, mock_installation):
-        # Old Github:e doesn't send a signature, so we have to accept that.
+        # Old Github:e doesn't send a signature, so we have to accept that, but only for specific hosts.
         mock_installation.return_value = self.metadata
 
         response = self.client.post(
@@ -87,6 +122,22 @@ class WebhookTest(APITestCase):
             HTTP_X_GITHUB_DELIVERY=str(uuid4()),
         )
         assert response.status_code == 204
+
+    @patch("sentry.integrations.github_enterprise.webhook.get_installation_metadata")
+    def test_missing_signature_fail_without_option_set(self, mock_installation):
+        # Old Github:e doesn't send a signature, so we have to accept that, but only for specific hosts.
+        mock_installation.return_value = self.metadata
+
+        response = self.client.post(
+            path=self.url,
+            data=PUSH_EVENT_EXAMPLE_INSTALLATION,
+            content_type="application/json",
+            HTTP_X_GITHUB_EVENT="push",
+            HTTP_X_GITHUB_ENTERPRISE_HOST="35.232.149.196",
+            HTTP_X_GITHUB_DELIVERY=str(uuid4()),
+        )
+        assert response.status_code == 400
+        assert b"Missing headers X-Hub-Signature-256 or X-Hub-Signature" in response.content
 
 
 class PushEventWebhookTest(APITestCase):
@@ -127,7 +178,11 @@ class PushEventWebhookTest(APITestCase):
             metadata={
                 "domain_name": "35.232.149.196/baxterthehacker",
                 "installation_id": "12345",
-                "installation": {"id": "2", "private_key": "private_key", "verify_ssl": True},
+                "installation": {
+                    "id": "2",
+                    "private_key": "private_key",
+                    "verify_ssl": True,
+                },
             },
         )
 
@@ -182,7 +237,11 @@ class PushEventWebhookTest(APITestCase):
             name="octocat",
             metadata={
                 "domain_name": "35.232.149.196/baxterthehacker",
-                "installation": {"id": "2", "private_key": "private_key", "verify_ssl": True},
+                "installation": {
+                    "id": "2",
+                    "private_key": "private_key",
+                    "verify_ssl": True,
+                },
             },
         )
 
@@ -250,7 +309,11 @@ class PushEventWebhookTest(APITestCase):
             metadata={
                 "domain_name": "35.232.149.196/baxterthehacker",
                 "installation_id": "12345",
-                "installation": {"id": "2", "private_key": "private_key", "verify_ssl": True},
+                "installation": {
+                    "id": "2",
+                    "private_key": "private_key",
+                    "verify_ssl": True,
+                },
             },
         )
 
@@ -325,7 +388,11 @@ class PullRequestEventWebhook(APITestCase):
             name="octocat",
             metadata={
                 "domain_name": "35.232.149.196/baxterthehacker",
-                "installation": {"id": "2", "private_key": "private_key", "verify_ssl": True},
+                "installation": {
+                    "id": "2",
+                    "private_key": "private_key",
+                    "verify_ssl": True,
+                },
             },
         )
         self.repo = Repository.objects.create(
@@ -369,7 +436,9 @@ class PullRequestEventWebhook(APITestCase):
         mock_get_installation_metadata.return_value = self.metadata
 
         pr = PullRequest.objects.create(
-            key="1", repository_id=self.repo.id, organization_id=self.project.organization.id
+            key="1",
+            repository_id=self.repo.id,
+            organization_id=self.project.organization.id,
         )
 
         response = self.client.post(

--- a/tests/sentry/integrations/github_enterprise/test_webhooks.py
+++ b/tests/sentry/integrations/github_enterprise/test_webhooks.py
@@ -120,22 +120,6 @@ class WebhookTest(APITestCase):
         assert b"Provided signature does not match the computed body signature" in response.content
 
     @patch("sentry.integrations.github_enterprise.webhook.get_installation_metadata")
-    def test_invalid_algorithm(self, mock_installation):
-        mock_installation.return_value = self.metadata
-
-        response = self.client.post(
-            path=self.url,
-            data=PUSH_EVENT_EXAMPLE_INSTALLATION,
-            content_type="application/json",
-            HTTP_X_GITHUB_EVENT="push",
-            HTTP_X_GITHUB_ENTERPRISE_HOST="35.232.149.196",
-            HTTP_X_HUB_SIGNATURE="sha3=33521abeaaf9a57c2abf486e0ccd54d23cf36fec",
-            HTTP_X_GITHUB_DELIVERY=str(uuid4()),
-        )
-        assert response.status_code == 400
-        assert b"Signature algorithm is unsupported" in response.content
-
-    @patch("sentry.integrations.github_enterprise.webhook.get_installation_metadata")
     def test_malformed_signature_too_short_sha1(self, mock_installation):
         mock_installation.return_value = self.metadata
 


### PR DESCRIPTION
Fix for H1 [2547600](https://hackerone.com/reports/2547600).

Increase the robustness of the GitHub Enterprise integration's webhook signature handling.

- Add support for SHA256 signature headers
- Verify the signature value looks as expected before continuing
- Support for legacy GitHub Enterprise installations that omit the header by setting their host value in an option (not the most secure, but we will deprecate use of this legacy method very soon)