### PR TITLE
fix(metrics-extraction): Alert details

### DIFF
--- a/static/app/utils/metrics/extractionRules.tsx
+++ b/static/app/utils/metrics/extractionRules.tsx
@@ -1,4 +1,10 @@
-import type {MetricAggregation, MetricType} from 'sentry/types/metrics';
+import type {
+  MetricAggregation,
+  MetricsExtractionCondition,
+  MetricsExtractionRule,
+  MetricType,
+  MRI,
+} from 'sentry/types/metrics';
 
 export const aggregationToMetricType: Record<MetricAggregation, MetricType> = {
   count: 'c',
@@ -12,3 +18,17 @@ export const aggregationToMetricType: Record<MetricAggregation, MetricType> = {
   p95: 'd',
   p99: 'd',
 };
+
+export function findExtractionRuleCondition(
+  mri: MRI,
+  extractionRules: MetricsExtractionRule[]
+): MetricsExtractionCondition | undefined {
+  for (const rule of extractionRules) {
+    for (const condition of rule.conditions) {
+      if (condition.mris.includes(mri)) {
+        return condition;
+      }
+    }
+  }
+  return undefined;
+}

--- a/static/app/utils/metrics/useMetricsQuery.tsx
+++ b/static/app/utils/metrics/useMetricsQuery.tsx
@@ -209,7 +209,7 @@ export function useMetricsQuery(
             return query;
           }
           if (!query.condition) {
-            // Invalid state. A virtual metric always need to have a condition
+            // Invalid state. A virtual metric always needs to have a condition
             return null;
           }
           const {mri, aggregation} = resolveVirtualMRI(


### PR DESCRIPTION
Map extracted metrics to virtual ones when reading the URL params on the metrics page.
Display the filter condition on alert details.
![Screenshot 2024-07-19 at 07 37 14](https://github.com/user-attachments/assets/7af2761a-3d32-47b9-8b56-d4097167c7f5)

Closes https://github.com/getsentry/sentry/issues/74419