### PR TITLE
feat(loader-settings): Add default configuration hint to "Enable Performance" toggle

### DIFF
--- a/static/app/views/settings/project/projectKeys/details/loaderSettings.spec.tsx
+++ b/static/app/views/settings/project/projectKeys/details/loaderSettings.spec.tsx
@@ -302,4 +302,63 @@ describe('Loader Script Settings', function () {
       )
     ).not.toBeInTheDocument();
   });
+
+  it('shows performance message when it is enabled', function () {
+    const {organization, project} = initializeOrg();
+    const params = {
+      projectSlug: project.slug,
+      keyId: '1',
+    };
+
+    const data = {
+      ...(ProjectKeysFixture()[0] as ProjectKey),
+      dynamicSdkLoaderOptions: fullDynamicSdkLoaderOptions,
+    } as ProjectKey;
+
+    const {rerender} = render(
+      <LoaderSettings
+        updateData={jest.fn()}
+        orgSlug={organization.slug}
+        keyId={params.keyId}
+        project={project}
+        data={data}
+      />
+    );
+
+    expect(
+      screen.getByText('tracesSampleRate: 1.0', {
+        exact: false,
+      })
+    ).toBeInTheDocument();
+
+    expect(
+      screen.getByText('distributed tracing to same-origin requests', {
+        exact: false,
+      })
+    ).toBeInTheDocument();
+
+    data.dynamicSdkLoaderOptions.hasPerformance = false;
+
+    rerender(
+      <LoaderSettings
+        updateData={jest.fn()}
+        orgSlug={organization.slug}
+        keyId={params.keyId}
+        project={project}
+        data={data}
+      />
+    );
+
+    expect(
+      screen.queryByText('tracesSampleRate: 1.0', {
+        exact: false,
+      })
+    ).not.toBeInTheDocument();
+
+    expect(
+      screen.queryByText('distributed tracing to same-origin requests', {
+        exact: false,
+      })
+    ).not.toBeInTheDocument();
+  });
 });

--- a/static/app/views/settings/project/projectKeys/details/loaderSettings.tsx
+++ b/static/app/views/settings/project/projectKeys/details/loaderSettings.tsx
@@ -196,7 +196,17 @@ export function LoaderSettings({keyId, orgSlug, project, data, updateData}: Prop
             help={
               !sdkVersionSupportsPerformanceAndReplay(data.browserSdkVersion)
                 ? t('Only available in SDK version 7.x and above')
-                : undefined
+                : data.dynamicSdkLoaderOptions.hasPerformance
+                  ? tct(
+                      'The default configurations are [codeTracesSampleRate:tracesSampleRate: 1.0] and distributed tracing to same-origin requests. [configDocs:Read the docs] to learn how to configure this.',
+                      {
+                        codeTracesSampleRate: <code />,
+                        configDocs: (
+                          <ExternalLink href="https://docs.sentry.io/platforms/javascript/install/loader/#custom-configuration" />
+                        ),
+                      }
+                    )
+                  : undefined
             }
             disabledReason={
               !hasAccess


### PR DESCRIPTION
This PR adds a hint to the default configuration of tracing/performance monitoring to the loader settings. It will appear when "Enable Performance Monitoring" is toggled. Also adds a test for the message.

<img width="1165" alt="image" src="https://github.com/user-attachments/assets/8c772937-9023-4abe-bb5a-9743ee2c4ef3">

(motivation: while testing the loader, I noticed that we have such a hint for the Replay toggle but not for performance and I thought it makes sense to add it)
