### PR TITLE
feat(metrics-summary-table): Dynamic aggreagate columns

### DIFF
--- a/static/app/types/metrics.tsx
+++ b/static/app/types/metrics.tsx
@@ -10,6 +10,7 @@ export type MetricAggregation =
   | 'min'
   | 'p50'
   | 'p75'
+  | 'p90'
   | 'p95'
   | 'p99';
 

--- a/static/app/utils/metrics/extractionRules.tsx
+++ b/static/app/utils/metrics/extractionRules.tsx
@@ -15,6 +15,7 @@ export const aggregationToMetricType: Record<MetricAggregation, MetricType> = {
   avg: 'g',
   p50: 'd',
   p75: 'd',
+  p90: 'd',
   p95: 'd',
   p99: 'd',
 };

--- a/static/app/utils/metrics/index.tsx
+++ b/static/app/utils/metrics/index.tsx
@@ -162,6 +162,25 @@ export function getDefaultAggregation(mri: MRI): MetricAggregation {
   return DEFAULT_AGGREGATES[parsedMRI.type] || fallbackAggregate;
 }
 
+// Using Records to ensure all MetricAggregations are covered
+const metricAggregationsCheck: Record<MetricAggregation, boolean> = {
+  count: true,
+  count_unique: true,
+  sum: true,
+  avg: true,
+  min: true,
+  max: true,
+  p50: true,
+  p75: true,
+  p90: true,
+  p95: true,
+  p99: true,
+};
+
+export function isMetricsAggregation(value: string): value is MetricAggregation {
+  return !!metricAggregationsCheck[value as MetricAggregation];
+}
+
 export function isAllowedAggregation(aggregation: MetricAggregation) {
   return !['max_timestamp', 'min_timestamp', 'histogram'].includes(aggregation);
 }

--- a/static/app/utils/metrics/types.tsx
+++ b/static/app/utils/metrics/types.tsx
@@ -12,7 +12,7 @@ export type MetricTag = {
 };
 
 export type SortState = {
-  name: 'name' | 'avg' | 'min' | 'max' | 'sum' | 'total' | undefined;
+  name: 'name' | MetricAggregation | undefined;
   order: 'asc' | 'desc';
 };
 

--- a/static/app/views/metrics/summaryTable.tsx
+++ b/static/app/views/metrics/summaryTable.tsx
@@ -12,6 +12,7 @@ import {Tooltip} from 'sentry/components/tooltip';
 import {IconArrow, IconFilter, IconLightning, IconReleases} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
+import type {MetricAggregation} from 'sentry/types/metrics';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {getUtcDateString} from 'sentry/utils/dates';
 import {DEFAULT_SORT_STATE} from 'sentry/utils/metrics/constants';
@@ -49,6 +50,7 @@ export const SummaryTable = memo(function SummaryTable({
   const {selection} = usePageFilters();
   const organization = useOrganization();
 
+  const totalColumns = getTotalColumns(series);
   const canFilter = series.length > 1 && !!onRowFilter;
   const hasActions = series.some(s => s.release || s.transaction) || canFilter;
   const hasMultipleSeries = series.length > 1;
@@ -144,7 +146,7 @@ export const SummaryTable = memo(function SummaryTable({
     .map(s => {
       return {
         ...s,
-        ...getValues(s),
+        ...getTotals(s),
       };
     })
     // Filter series with no data
@@ -167,29 +169,23 @@ export const SummaryTable = memo(function SummaryTable({
     });
 
   return (
-    <SummaryTableWrapper hasActions={hasActions}>
+    <SummaryTableWrapper hasActions={hasActions} totalColumnsCount={totalColumns.length}>
       <HeaderCell disabled />
       <HeaderCell disabled />
       <SortableHeaderCell onClick={changeSort} sortState={sort} name="name">
         {t('Name')}
       </SortableHeaderCell>
-      <SortableHeaderCell onClick={changeSort} sortState={sort} name="avg" right>
-        {t('Avg')}
-      </SortableHeaderCell>
-      <SortableHeaderCell onClick={changeSort} sortState={sort} name="min" right>
-        {t('Min')}
-      </SortableHeaderCell>
-      <SortableHeaderCell onClick={changeSort} sortState={sort} name="max" right>
-        {t('Max')}
-      </SortableHeaderCell>
-      <SortableHeaderCell onClick={changeSort} sortState={sort} name="sum" right>
-        {t('Sum')}
-      </SortableHeaderCell>
-      <SortableHeaderCell onClick={changeSort} sortState={sort} name="total" right>
-        <Tooltip title={t('Selected aggregation over the whole time period')}>
-          {t('Value')}
-        </Tooltip>
-      </SortableHeaderCell>
+      {totalColumns.map(aggregate => (
+        <SortableHeaderCell
+          key={aggregate}
+          onClick={changeSort}
+          sortState={sort}
+          name={aggregate}
+          right
+        >
+          {aggregate}
+        </SortableHeaderCell>
+      ))}
       {hasActions && <HeaderCell disabled right />}
       <HeaderCell disabled />
       <TableBodyWrapper
@@ -200,107 +196,93 @@ export const SummaryTable = memo(function SummaryTable({
           }
         }}
       >
-        {rows.map(
-          ({
-            seriesName,
-            id,
-            groupBy,
-            color,
-            hidden,
-            unit,
-            transaction,
-            release,
-            avg,
-            min,
-            max,
-            sum,
-            total,
-            isEquationSeries,
-            queryIndex,
-          }) => {
-            return (
-              <Fragment key={id}>
-                <Row
-                  onClick={() => {
+        {rows.map(row => {
+          return (
+            <Fragment key={row.id}>
+              <Row
+                onClick={() => {
+                  if (hasMultipleSeries) {
+                    onRowClick(row);
+                  }
+                }}
+                onMouseEnter={() => {
+                  if (hasMultipleSeries) {
+                    onRowHover?.(row.id);
+                  }
+                }}
+              >
+                <PaddingCell />
+                <Cell
+                  onClick={event => {
+                    event.stopPropagation();
                     if (hasMultipleSeries) {
-                      onRowClick({
-                        id,
-                        groupBy,
-                      });
-                    }
-                  }}
-                  onMouseEnter={() => {
-                    if (hasMultipleSeries) {
-                      onRowHover?.(id);
+                      onColorDotClick?.(row);
                     }
                   }}
                 >
-                  <PaddingCell />
-                  <Cell
-                    onClick={event => {
-                      event.stopPropagation();
-                      if (hasMultipleSeries) {
-                        onColorDotClick?.({
-                          id,
-                          groupBy,
-                        });
-                      }
+                  <ColorDot
+                    color={row.color}
+                    isHidden={!!row.hidden}
+                    style={{
+                      backgroundColor: row.hidden
+                        ? 'transparent'
+                        : colorFn(row.color).alpha(1).string(),
                     }}
+                  />
+                </Cell>
+                <TextOverflowCell>
+                  <Tooltip
+                    title={
+                      <FullSeriesName seriesName={row.seriesName} groupBy={row.groupBy} />
+                    }
+                    delay={500}
+                    overlayStyle={{maxWidth: '80vw'}}
                   >
-                    <ColorDot
-                      color={color}
-                      isHidden={!!hidden}
-                      style={{
-                        backgroundColor: hidden
-                          ? 'transparent'
-                          : colorFn(color).alpha(1).string(),
-                      }}
-                    />
-                  </Cell>
-                  <TextOverflowCell>
-                    <Tooltip
-                      title={<FullSeriesName seriesName={seriesName} groupBy={groupBy} />}
-                      delay={500}
-                      overlayStyle={{maxWidth: '80vw'}}
-                    >
-                      <TextOverflow>{seriesName}</TextOverflow>
-                    </Tooltip>
-                  </TextOverflowCell>
-                  <NumberCell>{formatMetricUsingUnit(avg, unit)}</NumberCell>
-                  <NumberCell>{formatMetricUsingUnit(min, unit)}</NumberCell>
-                  <NumberCell>{formatMetricUsingUnit(max, unit)}</NumberCell>
-                  <NumberCell>{formatMetricUsingUnit(sum, unit)}</NumberCell>
-                  <NumberCell>{formatMetricUsingUnit(total, unit)}</NumberCell>
+                    <TextOverflow>{row.seriesName}</TextOverflow>
+                  </Tooltip>
+                </TextOverflowCell>
+                {totalColumns.map(aggregate => (
+                  <NumberCell key={aggregate}>
+                    {row[aggregate]
+                      ? formatMetricUsingUnit(row[aggregate], row.unit)
+                      : '–'}
+                  </NumberCell>
+                ))}
 
-                  {hasActions && (
-                    <CenterCell>
-                      <ButtonBar gap={0.5}>
-                        {transaction && (
-                          <div>
-                            <Tooltip title={t('Open Transaction Summary')}>
-                              <LinkButton
-                                to={transactionTo(transaction)}
-                                size="zero"
-                                borderless
-                              >
-                                <IconLightning size="sm" />
-                              </LinkButton>
-                            </Tooltip>
-                          </div>
-                        )}
+                {hasActions && (
+                  <CenterCell>
+                    <ButtonBar gap={0.5}>
+                      {row.transaction && (
+                        <div>
+                          <Tooltip title={t('Open Transaction Summary')}>
+                            <LinkButton
+                              to={transactionTo(row.transaction)}
+                              size="zero"
+                              borderless
+                            >
+                              <IconLightning size="sm" />
+                            </LinkButton>
+                          </Tooltip>
+                        </div>
+                      )}
 
-                        {release && (
-                          <div>
-                            <Tooltip title={t('Open Release Details')}>
-                              <LinkButton to={releaseTo(release)} size="zero" borderless>
-                                <IconReleases size="sm" />
-                              </LinkButton>
-                            </Tooltip>
-                          </div>
-                        )}
+                      {row.release && (
+                        <div>
+                          <Tooltip title={t('Open Release Details')}>
+                            <LinkButton
+                              to={releaseTo(row.release)}
+                              size="zero"
+                              borderless
+                            >
+                              <IconReleases size="sm" />
+                            </LinkButton>
+                          </Tooltip>
+                        </div>
+                      )}
 
-                        {/* do not show add/exclude filter if there's no groupby or if this is an equation */}
-                        {Object.keys(groupBy ?? {}).length > 0 && !isEquationSeries && (
+                      {/* do not show add/exclude filter if there's no groupby or if this is an equation */}
+                      {Object.keys(row.groupBy ?? {}).length > 0 &&
+                        !row.isEquationSeries && (
                           <DropdownMenu
                             items={[
                               {
@@ -309,11 +291,8 @@ export const SummaryTable = memo(function SummaryTable({
                                 size: 'sm',
                                 onAction: () => {
                                   handleRowFilter(
-                                    queryIndex,
-                                    {
-                                      id,
-                                      groupBy,
-                                    },
+                                    row.queryIndex,
+                                    row,
                                     MetricSeriesFilterUpdateType.ADD
                                   );
                                 },
@@ -324,11 +303,8 @@ export const SummaryTable = memo(function SummaryTable({
                                 size: 'sm',
                                 onAction: () => {
                                   handleRowFilter(
-                                    queryIndex,
-                                    {
-                                      id,
-                                      groupBy,
-                                    },
+                                    row.queryIndex,
+                                    row,
                                     MetricSeriesFilterUpdateType.EXCLUDE
                                   );
                                 },
@@ -351,16 +327,15 @@ export const SummaryTable = memo(function SummaryTable({
                             )}
                           />
                         )}
-                      </ButtonBar>
-                    </CenterCell>
-                  )}
+                    </ButtonBar>
+                  </CenterCell>
+                )}
 
-                  <PaddingCell />
-                </Row>
-              </Fragment>
-            );
-          }
-        )}
+                <PaddingCell />
+              </Row>
+            </Fragment>
+          );
+        })}
       </TableBodyWrapper>
     </SummaryTableWrapper>
   );
@@ -438,7 +413,23 @@ function SortableHeaderCell({
   );
 }
 
-function getValues(series: Series) {
+// These aggregates can always be shown as we can calculate them on the frontend
+const DEFAULT_TOTALS: MetricAggregation[] = ['avg', 'min', 'max', 'sum'];
+// Count and count_unique will always match the sum column
+const TOTALS_BLOCKLIST: MetricAggregation[] = ['count', 'count_unique'];
+
+function getTotalColumns(series: Series[]) {
+  const totals = new Set<MetricAggregation>();
+  series.forEach(({aggregate}) => {
+    if (!DEFAULT_TOTALS.includes(aggregate) && !TOTALS_BLOCKLIST.includes(aggregate)) {
+      totals.add(aggregate);
+    }
+  });
+
+  return DEFAULT_TOTALS.concat(Array.from(totals).sort((a, b) => a.localeCompare(b)));
+}
+
+function getTotals(series: Series) {
   const {data, total, aggregate} = series;
   if (!data) {
     return {min: null, max: null, avg: null, sum: null};
@@ -459,25 +450,29 @@ function getValues(series: Series) {
     {min: Infinity, max: -Infinity, sum: 0, definedDatapoints: 0}
   );
 
-  const values = {
+  const values: Partial<Record<MetricAggregation, number>> = {
     min: res.min,
     max: res.max,
     sum: res.sum,
     avg: res.sum / res.definedDatapoints,
   };
 
-  if (aggregate in values) {
-    values[aggregate] = total;
-  }
+  values[aggregate] = total;
 
   return values;
 }
 
-const SummaryTableWrapper = styled(`div`)<{hasActions: boolean}>`
+const SummaryTableWrapper = styled(`div`)<{
+  hasActions: boolean;
+  totalColumnsCount: number;
+}>`
   display: grid;
   /* padding | color dot | name | avg | min | max | sum | total | actions | padding */
   grid-template-columns:
-    ${space(0.75)} ${space(3)} 8fr repeat(${p => (p.hasActions ? 6 : 5)}, max-content)
+    ${space(0.75)} ${space(3)} 8fr repeat(
+      ${p => (p.hasActions ? p.totalColumnsCount + 1 : p.totalColumnsCount)},
+      max-content
+    )
     ${space(0.75)};
 
   max-height: 200px;

--- a/static/app/views/metrics/utils/parseMetricWidgetsQueryParam.tsx
+++ b/static/app/views/metrics/utils/parseMetricWidgetsQueryParam.tsx
@@ -1,5 +1,5 @@
 import type {MetricAggregation} from 'sentry/types/metrics';
-import {getDefaultAggregation} from 'sentry/utils/metrics';
+import {getDefaultAggregation, isMetricsAggregation} from 'sentry/utils/metrics';
 import {DEFAULT_SORT_STATE, NO_QUERY_ID} from 'sentry/utils/metrics/constants';
 import {isMRI} from 'sentry/utils/metrics/mri';
 import {
@@ -98,14 +98,7 @@ function parseSortParam(widget: Record<string, unknown>, key: string): SortState
       ? sort.order
       : DEFAULT_SORT_STATE.order;
 
-  if (
-    name === 'name' ||
-    name === 'avg' ||
-    name === 'min' ||
-    name === 'max' ||
-    name === 'sum' ||
-    name === 'total'
-  ) {
+  if (name && (name === 'name' || isMetricsAggregation(name))) {
     return {name, order};
   }
 

--- a/static/app/views/settings/projectMetrics/metricsExtractionRuleForm.tsx
+++ b/static/app/views/settings/projectMetrics/metricsExtractionRuleForm.tsx
@@ -87,7 +87,7 @@ export function explodeAggregateGroup(group: AggregateGroup): MetricAggregation[
     case 'min_max':
       return ['min', 'max', 'sum', 'avg'];
     case 'percentiles':
-      return ['p50', 'p75', 'p95', 'p99'];
+      return ['p50', 'p75', 'p90', 'p95', 'p99'];
     default:
       throw new Error(`Unknown aggregate group: ${group}`);
   }
@@ -107,7 +107,13 @@ export function aggregatesToGroups(aggregates: MetricAggregation[]): AggregateGr
     groups.push('min_max');
   }
 
-  const percentileAggregates = new Set<MetricAggregation>(['p50', 'p75', 'p95', 'p99']);
+  const percentileAggregates = new Set<MetricAggregation>([
+    'p50',
+    'p75',
+    'p90',
+    'p95',
+    'p99',
+  ]);
   if (aggregates.find(aggregate => percentileAggregates.has(aggregate))) {
     groups.push('percentiles');
   }


### PR DESCRIPTION
Add missing p90 aggregate in type and definitions.
Display additional aggregate columns for percentiles.

https://github.com/user-attachments/assets/03ba318f-3fac-4814-8f8a-307a366e896f

Closes https://github.com/getsentry/sentry/issues/74543