### PR TITLE
Revert "feat(insights): Increase main site sidebar width slightly"

### DIFF
--- a/static/app/utils/theme.tsx
+++ b/static/app/utils/theme.tsx
@@ -780,7 +780,7 @@ const commonTheme = {
 
     containerWidth: '1440px',
     headerHeight: '61px',
-    sidebarWidth: '236px',
+    sidebarWidth: '220px',
   },
 
   sidebar: {
@@ -790,7 +790,7 @@ const commonTheme = {
     badgeSize: '22px',
     smallBadgeSize: '11px',
     collapsedWidth: '70px',
-    expandedWidth: '236px',
+    expandedWidth: '220px',
     mobileHeight: '54px',
     menuSpacing: '15px',
   },

--- a/static/less/variables.less
+++ b/static/less/variables.less
@@ -35,7 +35,7 @@
 // Sets up sidebar offsets
 
 @sidebar-collapsed-width: 70px;
-@sidebar-expanded-width: 236px;
+@sidebar-expanded-width: 220px;
 @sidebar-panel-width: 320px;
 @sidebar-mobile-height: 54px;
 


### PR DESCRIPTION
Reverts getsentry/sentry#71674. The "Beta" and "New" badges are gone, so there's enough room in the sidebar now. We can bring it back to its original width.