### PR TITLE
feat(utils): Add core `CircuitBreaker` functionality

### DIFF
--- a/src/sentry/utils/circuit_breaker2.py
+++ b/src/sentry/utils/circuit_breaker2.py
@@ -182,6 +182,20 @@ class CircuitBreaker:
             )
             self.recovery_duration = default_recovery_duration
 
+    def should_allow_request(self) -> bool:
+        """
+        Determine, based on the current state of the breaker and the number of allowable errors
+        remaining, whether requests should be allowed through.
+        """
+        state, _ = self._get_state_and_remaining_time()
+
+        if state == CircuitBreakerState.BROKEN:
+            return False
+
+        controlling_quota = self._get_controlling_quota(state)
+
+        return self._get_remaining_error_quota(controlling_quota) > 0
+
     def _get_from_redis(self, keys: list[str]) -> Any:
         for key in keys:
             self.redis_pipeline.get(key)


### PR DESCRIPTION
This completes the work, started in https://github.com/getsentry/sentry/pull/74557 and https://github.com/getsentry/sentry/pull/74559, of adding a new, class-and-rate-limit-based circuit breaker implementation to the codebase. In this PR, the core `record_error` and `should_allow_request` methods are added to the `CircuitBreaker` class, along with accompaying tests.