### PR TITLE
ref(seer grouping): Use new `CircuitBreaker` class for circuit breaking

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -3423,6 +3423,7 @@ SEER_PROJECT_GROUPING_RECORDS_DELETE_URL = (
 SEER_HASH_GROUPING_RECORDS_DELETE_URL = (
     f"/{SEER_SIMILARITY_MODEL_VERSION}/issues/similar-issues/grouping-record/delete-by-hash"
 )
+SEER_SIMILARITY_CIRCUIT_BREAKER_KEY = "seer.similarity"
 
 SIMILARITY_BACKFILL_COHORT_MAP: dict[str, list[int]] = {}
 

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -1528,6 +1528,13 @@ def _save_aggregate(
                 seer_matched_group = None
 
                 if should_call_seer_for_grouping(event, primary_hashes):
+                    metrics.incr(
+                        "grouping.similarity.did_call_seer",
+                        # TODO: Consider lowering this (in all the spots this metric is
+                        # collected) once we roll Seer grouping out more widely
+                        sample_rate=1.0,
+                        tags={"call_made": True, "blocker": "none"},
+                    )
                     try:
                         # If the `projects:similarity-embeddings-grouping` feature is disabled,
                         # we'll still get back result metadata, but `seer_matched_group` will be None
@@ -1543,21 +1550,8 @@ def _save_aggregate(
                                 "seer_similarity"
                             ] = seer_response_data
 
-                        metrics.incr(
-                            "grouping.similarity.did_call_seer",
-                            # TODO: Consider lowering this (in all the spots this metric is
-                            # collected) once we roll Seer grouping out more widely
-                            sample_rate=1.0,
-                            tags={"call_made": True, "blocker": "none"},
-                        )
-
                     # Insurance - in theory we shouldn't ever land here
                     except Exception as e:
-                        metrics.incr(
-                            "grouping.similarity.did_call_seer",
-                            sample_rate=1.0,
-                            tags={"call_made": True, "blocker": "none"},
-                        )
                         sentry_sdk.capture_exception(
                             e, tags={"event": event.event_id, "project": project.id}
                         )

--- a/src/sentry/grouping/ingest/seer.py
+++ b/src/sentry/grouping/ingest/seer.py
@@ -8,7 +8,10 @@ from sentry.grouping.grouping_info import get_grouping_info_from_variants
 from sentry.grouping.result import CalculatedHashes
 from sentry.models.group import Group
 from sentry.models.project import Project
-from sentry.seer.similarity.similar_issues import get_similarity_data_from_seer
+from sentry.seer.similarity.similar_issues import (
+    get_similarity_data_from_seer,
+    seer_similarity_circuit_breaker,
+)
 from sentry.seer.similarity.types import SeerSimilarIssuesMetadata, SimilarIssuesEmbeddingsRequest
 from sentry.seer.similarity.utils import (
     event_content_is_seer_eligible,
@@ -45,12 +48,11 @@ def should_call_seer_for_grouping(event: Event, primary_hashes: CalculatedHashes
     # (Checking the rate limit for calling Seer also increments the counter of how many times we've
     # tried to call it, and if we fail any of the other checks, it shouldn't count as an attempt.
     # Thus we only want to run the rate limit check if every other check has already succeeded.)
-    #
-    # Note: The circuit breaker check which might naturally be here alongside its killswitch
-    # and rate limiting friends instead happens in the `with_circuit_breaker` helper used where
-    # `get_seer_similar_issues` is actually called. (It has to be there in order for it to track
-    # errors arising from that call.)
-    if killswitch_enabled(project.id, event) or _ratelimiting_enabled(event, project):
+    if (
+        killswitch_enabled(project.id, event)
+        or _circuit_breaker_broken(event, project)
+        or _ratelimiting_enabled(event, project)
+    ):
         return False
 
     return True
@@ -155,6 +157,30 @@ def _ratelimiting_enabled(event: Event, project: Project) -> bool:
         return True
 
     return False
+
+
+def _circuit_breaker_broken(event: Event, project: Project) -> bool:
+    circuit_broken = not seer_similarity_circuit_breaker.should_allow_request()
+
+    if circuit_broken:
+        logger.warning(
+            "should_call_seer_for_grouping.circuit_breaker_tripped",
+            extra={
+                "event_id": event.event_id,
+                "project_id": project.id,
+                **options.get("seer.similarity.circuit-breaker-config"),
+            },
+        )
+        metrics.incr(
+            "grouping.similarity.circuit_breaker_tripped",
+        )
+        metrics.incr(
+            "grouping.similarity.did_call_seer",
+            sample_rate=1.0,
+            tags={"call_made": False, "blocker": "circuit-breaker"},
+        )
+
+    return circuit_broken
 
 
 def get_seer_similar_issues(

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -892,12 +892,21 @@ register(
     flags=FLAG_ALLOW_EMPTY | FLAG_AUTOMATOR_MODIFIABLE,
 )
 
+# TODO: The default error limit here was estimated based on EA traffic. (In an average 10 min
+# period, there are roughly 35K events without matching hashes. About 2% of orgs are EA, so for
+# simplicity, assume 2% of those events are from EA orgs. If we're willing to tolerate up to a 95%
+# failure rate, then we need 35K * 0.02 * 0.95 events to fail to trip the breaker.)
+#
+# When we GA, we should multiply both the limits by 50 (to remove the 2% part of the current
+# calculation), and remove this TODO.
 register(
     "seer.similarity.circuit-breaker-config",
     type=Dict,
-    # TODO: For now we're using the defaults for everything but `allow_passthrough`. We may want to
-    # revisit that choice in the future.
-    default={"allow_passthrough": True},
+    default={
+        "error_limit": 666,
+        "error_limit_window": 600,  # 10 min
+        "broken_state_duration": 300,  # 5 min
+    },
     flags=FLAG_ALLOW_EMPTY | FLAG_AUTOMATOR_MODIFIABLE,
 )
 

--- a/src/sentry/seer/similarity/similar_issues.py
+++ b/src/sentry/seer/similarity/similar_issues.py
@@ -122,6 +122,7 @@ def get_similarity_data_from_seer(
             sample_rate=SIMILARITY_REQUEST_METRIC_SAMPLE_RATE,
             tags={**metric_tags, "outcome": "error", "error": type(e).__name__},
         )
+        seer_similarity_circuit_breaker.record_error()
         return []
 
     metric_tags["response_status"] = response.status
@@ -147,6 +148,9 @@ def get_similarity_data_from_seer(
                 "error": "Redirect" if redirect else "RequestError",
             },
         )
+
+        if response.status >= 500:
+            seer_similarity_circuit_breaker.record_error()
 
         return []
 

--- a/src/sentry/seer/similarity/similar_issues.py
+++ b/src/sentry/seer/similarity/similar_issues.py
@@ -3,7 +3,12 @@ import logging
 from django.conf import settings
 from urllib3.exceptions import MaxRetryError, TimeoutError
 
-from sentry.conf.server import SEER_MAX_GROUPING_DISTANCE, SEER_SIMILAR_ISSUES_URL
+from sentry import options
+from sentry.conf.server import (
+    SEER_MAX_GROUPING_DISTANCE,
+    SEER_SIMILAR_ISSUES_URL,
+    SEER_SIMILARITY_CIRCUIT_BREAKER_KEY,
+)
 from sentry.models.grouphash import GroupHash
 from sentry.net.http import connection_from_url
 from sentry.seer.signed_seer_api import make_signed_seer_api_request
@@ -15,6 +20,7 @@ from sentry.seer.similarity.types import (
 )
 from sentry.tasks.delete_seer_grouping_records import delete_seer_grouping_records_by_hash
 from sentry.utils import json, metrics
+from sentry.utils.circuit_breaker2 import CircuitBreaker
 from sentry.utils.json import JSONDecodeError, apply_key_filter
 
 logger = logging.getLogger(__name__)
@@ -28,6 +34,11 @@ SIMILARITY_REQUEST_METRIC_SAMPLE_RATE = 1.0
 seer_grouping_connection_pool = connection_from_url(
     settings.SEER_GROUPING_URL,
     timeout=settings.SEER_GROUPING_TIMEOUT,
+)
+
+seer_similarity_circuit_breaker = CircuitBreaker(
+    SEER_SIMILARITY_CIRCUIT_BREAKER_KEY,
+    options.get("seer.similarity.circuit-breaker-config"),
 )
 
 

--- a/tests/sentry/event_manager/grouping/test_seer_grouping.py
+++ b/tests/sentry/event_manager/grouping/test_seer_grouping.py
@@ -10,7 +10,6 @@ from sentry.testutils.helpers import Feature
 from sentry.testutils.helpers.eventprocessing import save_new_event
 from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.pytest.mocking import capture_results
-from sentry.utils.circuit_breaker import with_circuit_breaker
 from sentry.utils.types import NonNone
 
 
@@ -151,23 +150,6 @@ class SeerEventManagerGroupingTest(TestCase):
                 # Parent group returned and used
                 assert get_seer_similar_issues_return_values[0][1] == existing_event.group
                 assert new_event.group_id == existing_event.group_id
-
-    @patch("sentry.event_manager.should_call_seer_for_grouping", return_value=True)
-    @patch("sentry.event_manager.with_circuit_breaker", wraps=with_circuit_breaker)
-    @patch("sentry.event_manager.get_seer_similar_issues", return_value=({}, None))
-    def test_obeys_circult_breaker(
-        self, mock_get_seer_similar_issues: MagicMock, mock_with_circuit_breaker: MagicMock, _
-    ):
-        with patch("sentry.utils.circuit_breaker._should_call_callback", return_value=True):
-            save_new_event({"message": "Dogs are great!"}, self.project)
-            assert mock_with_circuit_breaker.call_count == 1
-            assert mock_get_seer_similar_issues.call_count == 1
-
-        with patch("sentry.utils.circuit_breaker._should_call_callback", return_value=False):
-            save_new_event({"message": "Adopt don't shop"}, self.project)
-
-            assert mock_with_circuit_breaker.call_count == 2  # increased
-            assert mock_get_seer_similar_issues.call_count == 1  # didn't increase
 
     @patch("sentry.event_manager.should_call_seer_for_grouping", return_value=True)
     @patch("sentry.event_manager.get_seer_similar_issues", return_value=({}, None))

--- a/tests/sentry/grouping/ingest/test_seer.py
+++ b/tests/sentry/grouping/ingest/test_seer.py
@@ -138,6 +138,18 @@ class ShouldCallSeerTest(TestCase):
                 )
 
     @with_feature("projects:similarity-embeddings-grouping")
+    def test_obeys_circuit_breaker(self):
+        for request_allowed, expected_result in [(True, True), (False, False)]:
+            with patch(
+                "sentry.grouping.ingest.seer.seer_similarity_circuit_breaker.should_allow_request",
+                return_value=request_allowed,
+            ):
+                assert (
+                    should_call_seer_for_grouping(self.event, self.primary_hashes)
+                    is expected_result
+                )
+
+    @with_feature("projects:similarity-embeddings-grouping")
     def test_obeys_customized_fingerprint_check(self):
         default_fingerprint_event = Event(
             project_id=self.project.id,


### PR DESCRIPTION
The current implementation of circuit breaking for Seer similarity requests, using `with_circuit_breaker`, doesn't work because any errors the breaker might track are caught much farther down the call stack and never make it to the breaker. This fixes that by switching from using `with_circuit_breaker` to using an instance of the new `CircuitBreaker` class, which allows us to track the errors at a low level, before they're caught, while still using the breaker to decide whether to make the request at a much higher level.