### PR TITLE
ref(querybuilder): Remove ParamsType from tasks

### DIFF
--- a/src/sentry/search/events/builder/discover.py
+++ b/src/sentry/search/events/builder/discover.py
@@ -294,6 +294,7 @@ class TopEventsQueryBuilder(TimeseriesQueryBuilder):
         super().__init__(
             dataset,
             params,
+            snuba_params=snuba_params,
             interval=interval,
             query=query,
             selected_columns=list(set(selected_columns + timeseries_functions)),

--- a/src/sentry/search/events/builder/discover.py
+++ b/src/sentry/search/events/builder/discover.py
@@ -32,6 +32,7 @@ from sentry.search.events.types import (
     ParamsType,
     QueryBuilderConfig,
     SelectType,
+    SnubaParams,
     WhereType,
 )
 from sentry.snuba.dataset import Dataset
@@ -159,6 +160,7 @@ class TimeseriesQueryBuilder(UnresolvedQuery):
         dataset: Dataset,
         params: ParamsType,
         interval: int,
+        snuba_params: SnubaParams | None = None,
         query: str | None = None,
         selected_columns: list[str] | None = None,
         equations: list[str] | None = None,
@@ -171,6 +173,7 @@ class TimeseriesQueryBuilder(UnresolvedQuery):
         super().__init__(
             dataset,
             params,
+            snuba_params=snuba_params,
             query=query,
             selected_columns=selected_columns,
             equations=equations,
@@ -275,6 +278,7 @@ class TopEventsQueryBuilder(TimeseriesQueryBuilder):
         params: ParamsType,
         interval: int,
         top_events: list[dict[str, Any]],
+        snuba_params: SnubaParams | None = None,
         other: bool = False,
         query: str | None = None,
         selected_columns: list[str] | None = None,

--- a/src/sentry/search/events/builder/profile_functions.py
+++ b/src/sentry/search/events/builder/profile_functions.py
@@ -86,6 +86,7 @@ class ProfileTopFunctionsTimeseriesQueryBuilder(ProfileFunctionsTimeseriesQueryB
         params: ParamsType,
         interval: int,
         top_events: list[dict[str, Any]],
+        snuba_params: SnubaParams | None = None,
         other: bool = False,
         query: str | None = None,
         selected_columns: list[str] | None = None,
@@ -100,6 +101,7 @@ class ProfileTopFunctionsTimeseriesQueryBuilder(ProfileFunctionsTimeseriesQueryB
         super().__init__(
             dataset,
             params,
+            snuba_params=snuba_params,
             interval=interval,
             query=query,
             selected_columns=list(set(selected_columns + timeseries_functions)),

--- a/src/sentry/search/events/types.py
+++ b/src/sentry/search/events/types.py
@@ -92,6 +92,8 @@ class SnubaParams:
             self.end = self.end.replace(tzinfo=timezone.utc)
         if self.start is None and self.end is None:
             self.parse_stats_period()
+        if self.organization is None and len(self.projects) > 0:
+            self.organization = self.projects[0].organization
 
         # Only used in the trend query builder
         self.aliases: dict[str, Alias] | None = {}

--- a/src/sentry/search/events/types.py
+++ b/src/sentry/search/events/types.py
@@ -3,10 +3,11 @@ from __future__ import annotations
 from collections import namedtuple
 from collections.abc import Mapping, Sequence
 from copy import deepcopy
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import Any, NotRequired, Optional, TypedDict, Union
 
+from django.utils import timezone as django_timezone
 from snuba_sdk.aliased_expression import AliasedExpression
 from snuba_sdk.column import Column
 from snuba_sdk.conditions import BooleanCondition, Condition
@@ -74,23 +75,33 @@ class EventsResponse(TypedDict):
 
 @dataclass
 class SnubaParams:
-    start: datetime | None
-    end: datetime | None
+    start: datetime | None = None
+    end: datetime | None = None
+    stats_period: str | None = None
     # The None value in this sequence is because the filter params could include that
-    environments: Sequence[Environment | None]
-    projects: Sequence[Project]
-    user: RpcUser | None
-    teams: Sequence[Team]
-    organization: Organization | None
+    environments: Sequence[Environment | None] = field(default_factory=list)
+    projects: Sequence[Project] = field(default_factory=list)
+    user: RpcUser | None = None
+    teams: Sequence[Team] = field(default_factory=list)
+    organization: Organization | None = None
 
     def __post_init__(self) -> None:
         if self.start:
             self.start = self.start.replace(tzinfo=timezone.utc)
         if self.end:
             self.end = self.end.replace(tzinfo=timezone.utc)
+        if self.start is None and self.end is None:
+            self.parse_stats_period()
 
         # Only used in the trend query builder
         self.aliases: dict[str, Alias] | None = {}
+
+    def parse_stats_period(self) -> None:
+        if self.stats_period is not None:
+            self.end = django_timezone.now()
+            from sentry.api.utils import get_datetime_from_stats_period
+
+            self.start = get_datetime_from_stats_period(self.stats_period, self.end)
 
     @property
     def environment_names(self) -> Sequence[str]:
@@ -121,6 +132,33 @@ class SnubaParams:
         if self.start and self.end:
             return (self.end - self.start).total_seconds()
         return None
+
+    @property
+    def organization_id(self) -> int | None:
+        if self.organization is not None:
+            return self.organization.id
+        return None
+
+    @property
+    def filter_params(self) -> ParamsType:
+        # Compatibility function so we can switch over to this dataclass more easily
+        filter_params: ParamsType = {
+            "project_id": list(self.project_ids),
+            "projects": list(self.projects),
+            "project_objects": list(self.projects),
+            "environment": list(self.environment_names),
+            "team_id": list(self.team_ids),
+            "environment_objects": [env for env in self.environments if env is not None],
+        }
+        if self.organization_id:
+            filter_params["organization_id"] = self.organization_id
+        if self.start:
+            filter_params["start"] = self.start
+        if self.end:
+            filter_params["end"] = self.end
+        if self.stats_period:
+            filter_params["statsPeriod"] = self.stats_period
+        return filter_params
 
     def copy(self) -> SnubaParams:
         return deepcopy(self)

--- a/src/sentry/snuba/functions.py
+++ b/src/sentry/snuba/functions.py
@@ -133,6 +133,7 @@ def top_events_timeseries(
     rollup,
     limit,
     organization,
+    snuba_params=None,
     equations=None,
     referrer=None,
     top_events=None,
@@ -152,6 +153,7 @@ def top_events_timeseries(
                 selected_columns,
                 query=user_query,
                 params=params,
+                snuba_params=snuba_params,
                 equations=equations,
                 orderby=orderby,
                 limit=limit,
@@ -163,6 +165,7 @@ def top_events_timeseries(
     top_functions_builder = ProfileTopFunctionsTimeseriesQueryBuilder(
         dataset=Dataset.Functions,
         params=params,
+        snuba_params=snuba_params,
         interval=rollup,
         top_events=top_events["data"],
         other=False,
@@ -186,6 +189,7 @@ def top_events_timeseries(
         top_functions_builder,
         params,
         rollup,
+        snuba_params=snuba_params,
         top_events=top_events,
         allow_empty=allow_empty,
         zerofill_results=zerofill_results,
@@ -198,6 +202,7 @@ def format_top_events_timeseries_results(
     query_builder,
     params,
     rollup,
+    snuba_params=None,
     top_events=None,
     allow_empty=True,
     zerofill_results=True,
@@ -205,6 +210,9 @@ def format_top_events_timeseries_results(
 ):
     if top_events is None:
         assert top_events, "Need to provide top events"  # TODO: support this use case
+    if snuba_params is not None and len(params) == 0:
+        # Compatibility so its easier to convert to SnubaParams
+        params = snuba_params.filter_params
 
     if not allow_empty and not len(result.get("data", [])):
         return SnubaTSResult(

--- a/src/sentry/tasks/on_demand_metrics.py
+++ b/src/sentry/tasks/on_demand_metrics.py
@@ -8,7 +8,6 @@ from celery.exceptions import SoftTimeLimitExceeded
 from django.utils import timezone
 
 from sentry import options
-from sentry.api.utils import get_date_range_from_params
 from sentry.models.dashboard_widget import (
     DashboardWidgetQuery,
     DashboardWidgetQueryOnDemand,
@@ -24,7 +23,7 @@ from sentry.relay.config.metric_extraction import (
 )
 from sentry.search.events import fields
 from sentry.search.events.builder.discover import DiscoverQueryBuilder
-from sentry.search.events.types import EventsResponse, ParamsType, QueryBuilderConfig
+from sentry.search.events.types import EventsResponse, QueryBuilderConfig, SnubaParams
 from sentry.snuba.dataset import Dataset
 from sentry.snuba.metrics.extraction import OnDemandMetricSpecVersioning
 from sentry.snuba.referrer import Referrer
@@ -467,21 +466,19 @@ def _query_cardinality(
     # Restrict period down to an allowlist so we're not slamming snuba with giant queries
     if period not in [TASK_QUERY_PERIOD, DASHBOARD_QUERY_PERIOD]:
         raise Exception("Cardinality can only be queried with 1h or 30m")
-    params: ParamsType = {
-        "statsPeriod": period,
-        "organization_id": organization.id,
-        "project_objects": list(Project.objects.filter(organization=organization)),
-    }
-    start, end = get_date_range_from_params(params)
-    params["start"] = start
-    params["end"] = end
+    params = SnubaParams(
+        stats_period=period,
+        organization=organization,
+        projects=list(Project.objects.filter(organization=organization)),
+    )
 
     columns_to_check = [column for column in query_columns if not fields.is_function(column)]
     unique_columns = [f"count_unique({column})" for column in columns_to_check]
 
     query_builder = DiscoverQueryBuilder(
         dataset=Dataset.Discover,
-        params=params,
+        params={},
+        snuba_params=params,
         selected_columns=unique_columns,
         config=QueryBuilderConfig(
             transform_alias_to_input_format=True,

--- a/src/sentry/tasks/statistical_detectors.py
+++ b/src/sentry/tasks/statistical_detectors.py
@@ -34,7 +34,7 @@ from sentry.models.options.project_option import ProjectOption
 from sentry.models.project import Project
 from sentry.models.statistical_detectors import RegressionType
 from sentry.profiles.utils import get_from_profiling_service
-from sentry.search.events.types import ParamsType
+from sentry.search.events.types import SnubaParams
 from sentry.seer.breakpoints import BreakpointData
 from sentry.sentry_metrics import indexer
 from sentry.sentry_metrics.use_case_id_registry import UseCaseID
@@ -503,12 +503,11 @@ def emit_function_regression_issue(
     project_ids = [int(regression["project"]) for regression in regressions]
     projects = [projects_by_id[project_id] for project_id in project_ids]
 
-    params: ParamsType = {
-        "start": start,
-        "end": start + timedelta(minutes=1),
-        "project_id": project_ids,
-        "project_objects": projects,
-    }
+    params = SnubaParams(
+        start=start,
+        end=start + timedelta(minutes=1),
+        projects=projects,
+    )
 
     conditions = [
         And(
@@ -523,7 +522,8 @@ def emit_function_regression_issue(
     result = functions.query(
         selected_columns=["project.id", "fingerprint", "examples()"],
         query="is_application:1",
-        params=params,
+        params={},
+        snuba_params=params,
         orderby=["project.id"],
         limit=len(regressions),
         referrer=Referrer.API_PROFILING_FUNCTIONS_STATISTICAL_DETECTOR_EXAMPLE.value,
@@ -878,12 +878,11 @@ def query_functions(projects: list[Project], start: datetime) -> list[DetectorPa
     # we just need to query for the 1 minute of data.
     start = start - timedelta(hours=1)
     start = start.replace(minute=0, second=0, microsecond=0)
-    params: ParamsType = {
-        "start": start,
-        "end": start + timedelta(minutes=1),
-        "project_id": [project.id for project in projects],
-        "project_objects": projects,
-    }
+    params = SnubaParams(
+        start=start,
+        end=start + timedelta(minutes=1),
+        projects=projects,
+    )
 
     # TODOs: handle any errors
     query_results = functions.query(
@@ -895,7 +894,8 @@ def query_functions(projects: list[Project], start: datetime) -> list[DetectorPa
             "p95()",
         ],
         query="is_application:1",
-        params=params,
+        params={},
+        snuba_params=params,
         orderby=["project.id", "-count()"],
         limitby=("project.id", FUNCTIONS_PER_PROJECT),
         limit=FUNCTIONS_PER_PROJECT * len(projects),
@@ -924,16 +924,14 @@ def query_functions_timeseries(
     agg_function: str,
 ) -> Generator[tuple[int, int | str, SnubaTSResult], None, None]:
     projects = [project for project, _ in functions_list]
-    project_ids = [project.id for project in projects]
 
     # take the last 14 days as our window
     end = start.replace(minute=0, second=0, microsecond=0) + timedelta(hours=1)
-    params: ParamsType = {
-        "start": end - timedelta(days=14),
-        "end": end,
-        "project_id": project_ids,
-        "project_objects": projects,
-    }
+    params = SnubaParams(
+        start=end - timedelta(days=14),
+        end=end,
+        projects=projects,
+    )
     interval = 3600  # 1 hour
 
     chunk: list[dict[str, Any]] = [
@@ -948,7 +946,8 @@ def query_functions_timeseries(
         timeseries_columns=[agg_function],
         selected_columns=["project.id", "fingerprint"],
         user_query="is_application:1",
-        params=params,
+        params={},
+        snuba_params=params,
         orderby=None,  # unused because top events is specified
         rollup=interval,
         limit=len(chunk),

--- a/tests/sentry/tasks/test_statistical_detectors.py
+++ b/tests/sentry/tasks/test_statistical_detectors.py
@@ -260,9 +260,9 @@ def test_detect_function_trends_query_timerange(functions_query, timestamp, proj
         detect_function_trends([project.id], timestamp)
 
     assert functions_query.called
-    params = functions_query.mock_calls[0].kwargs["params"]
-    assert params["start"] == datetime(2023, 8, 1, 11, 0, tzinfo=UTC)
-    assert params["end"] == datetime(2023, 8, 1, 11, 1, tzinfo=UTC)
+    params = functions_query.mock_calls[0].kwargs["snuba_params"]
+    assert params.start == datetime(2023, 8, 1, 11, 0, tzinfo=UTC)
+    assert params.end == datetime(2023, 8, 1, 11, 1, tzinfo=UTC)
 
 
 @mock.patch("sentry.tasks.statistical_detectors.query_transactions")


### PR DESCRIPTION
- This removes the usage of ParamsType from tasks in favour of SnubaParams
- Added stats_period as an option to SnubaParams as a way to define start and end
- Added a filter_params property on SnubaParams to make this switchover easy so I'm impacting less code (eg. don't have to change the params references in `format_top_events_timeseries_results` even though `params={}` now)