### PR TITLE
chore(features) Make pride-logo a permanent feature

### DIFF
--- a/src/sentry/features/permanent.py
+++ b/src/sentry/features/permanent.py
@@ -107,6 +107,8 @@ def register_permanent_features(manager: FeatureManager):
         # Prefix host with organization ID when giving users DSNs (can be
         # customized with SENTRY_ORG_SUBDOMAIN_TEMPLATE) eg. o123.ingest.us.sentry.io
         "organizations:org-ingest-subdomains": False,
+        # Replace the footer Sentry logo with a Sentry pride logo
+        "organizations:sentry-pride-logo-footer": False,
     }
 
     permanent_project_features = {

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -353,8 +353,6 @@ def register_temporary_features(manager: FeatureManager):
     manager.add("organizations:scim-team-roles", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
     # Enable detecting SDK crashes during event processing
     manager.add("organizations:sdk-crash-detection", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
-    # Replace the footer Sentry logo with a Sentry pride logo
-    manager.add("organizations:sentry-pride-logo-footer", OrganizationFeature, FeatureHandlerStrategy.REMOTE, api_expose=True)
     # Enable the Replay Details > Accessibility tab
     manager.add("organizations:session-replay-a11y-tab", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
     # Enable the accessibility issues endpoint


### PR DESCRIPTION
With the addition of the feature handler to getsentry we can make this feature flag a permanent one.