### PR TITLE
fix(query-builder): Fix filter value being reset on rerenders

### DIFF
--- a/static/app/components/searchQueryBuilder/tokens/filter/valueCombobox.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/valueCombobox.tsx
@@ -755,7 +755,9 @@ export function SearchQueryBuilderValueCombobox({
     if (canSelectMultipleValues) {
       setInputValue(getMultiSelectInputValue(token));
     }
-  }, [canSelectMultipleValues, token]);
+    // We want to avoid resetting the input value if the token text doesn't actually change
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [canSelectMultipleValues, token.text]);
 
   // On mount, scroll to the end of the input
   useEffect(() => {

--- a/static/app/views/issueList/searchBar.tsx
+++ b/static/app/views/issueList/searchBar.tsx
@@ -91,7 +91,7 @@ interface Props extends React.ComponentProps<typeof SmartSearchBar>, WithIssueTa
 
 const EXCLUDED_TAGS = ['environment'];
 
-function IssueListSearchBar({organization, tags, ...props}: Props) {
+function IssueListSearchBar({organization, tags, onClose, ...props}: Props) {
   const api = useApi();
   const {selection: pageFilters} = usePageFilters();
   const {tags: issueTags} = useFetchIssueTags({
@@ -195,6 +195,13 @@ function IssueListSearchBar({organization, tags, ...props}: Props) {
     return getFilterKeySections(issueTags, organization);
   }, [organization, issueTags]);
 
+  const onChange = useCallback(
+    (value: string) => {
+      onClose?.(value, {validSearch: true});
+    },
+    [onClose]
+  );
+
   if (organization.features.includes('issue-stream-search-query-builder')) {
     return (
       <SearchQueryBuilder
@@ -205,9 +212,7 @@ function IssueListSearchBar({organization, tags, ...props}: Props) {
         filterKeys={issueTags}
         onSearch={props.onSearch}
         onBlur={props.onBlur}
-        onChange={value => {
-          props.onClose?.(value, {validSearch: true});
-        }}
+        onChange={onChange}
         searchSource={props.searchSource ?? 'issues'}
         savedSearchType={SavedSearchType.ISSUE}
         disallowLogicalOperators
@@ -227,6 +232,7 @@ function IssueListSearchBar({organization, tags, ...props}: Props) {
       supportedTags={getSupportedTags(tags)}
       defaultSearchGroup={recommendedGroup}
       organization={organization}
+      onClose={onClose}
       {...props}
     />
   );

--- a/static/app/views/issueList/utils/useFetchIssueTags.tsx
+++ b/static/app/views/issueList/utils/useFetchIssueTags.tsx
@@ -1,3 +1,5 @@
+import {useMemo} from 'react';
+
 import {useFetchOrganizationTags} from 'sentry/actionCreators/tags';
 import {ItemType, type SearchGroup} from 'sentry/components/smartSearchBar/types';
 import {escapeTagValue} from 'sentry/components/smartSearchBar/utils';
@@ -73,67 +75,71 @@ export const useFetchIssueTags = ({
     {}
   );
 
-  const userTeams = teams.filter(team => team.isMember).map(team => `#${team.slug}`);
-  const usernames: string[] = members.map(getUsername);
-  const nonMemberTeams = teams
-    .filter(team => !team.isMember)
-    .map(team => `#${team.slug}`);
+  const allTags = useMemo(() => {
+    const userTeams = teams.filter(team => team.isMember).map(team => `#${team.slug}`);
+    const usernames: string[] = members.map(getUsername);
+    const nonMemberTeams = teams
+      .filter(team => !team.isMember)
+      .map(team => `#${team.slug}`);
 
-  const suggestedAssignees: string[] = [
-    'me',
-    'my_teams',
-    'none',
-    // New search builder only works with single value suggestions
-    ...(org.features.includes('issue-stream-search-query-builder')
-      ? []
-      : ['[me, my_teams, none]']),
-    ...userTeams,
-  ];
-  const assignedValues: SearchGroup[] | string[] = [
-    {
-      title: t('Suggested Values'),
-      type: 'header',
-      icon: <IconStar size="xs" />,
-      children: suggestedAssignees.map(convertToSearchItem),
-    },
-    {
-      title: t('All Values'),
-      type: 'header',
-      icon: <IconUser size="xs" />,
-      children: [
-        ...usernames.map(convertToSearchItem),
-        ...nonMemberTeams.map(convertToSearchItem),
-      ],
-    },
-  ];
-  const eventsTags: Tag[] = eventsTagsQuery.data || [];
-  const issuePlatformTags: Tag[] = issuePlatformTagsQuery.data || [];
+    const suggestedAssignees: string[] = [
+      'me',
+      'my_teams',
+      'none',
+      // New search builder only works with single value suggestions
+      ...(org.features.includes('issue-stream-search-query-builder')
+        ? []
+        : ['[me, my_teams, none]']),
+      ...userTeams,
+    ];
 
-  const allTagsCollection: TagCollection = eventsTags.reduce<TagCollection>(
-    (acc, tag) => {
-      acc[tag.key] = {...tag, kind: FieldKind.TAG};
-      return acc;
-    },
-    {}
-  );
-  issuePlatformTags.forEach(tag => {
-    if (allTagsCollection[tag.key]) {
-      allTagsCollection[tag.key].totalValues =
-        (allTagsCollection[tag.key].totalValues ?? 0) + (tag.totalValues ?? 0);
-    } else {
-      allTagsCollection[tag.key] = {...tag, kind: FieldKind.TAG};
-    }
-  });
+    const assignedValues: SearchGroup[] | string[] = [
+      {
+        title: t('Suggested Values'),
+        type: 'header',
+        icon: <IconStar size="xs" />,
+        children: suggestedAssignees.map(convertToSearchItem),
+      },
+      {
+        title: t('All Values'),
+        type: 'header',
+        icon: <IconUser size="xs" />,
+        children: [
+          ...usernames.map(convertToSearchItem),
+          ...nonMemberTeams.map(convertToSearchItem),
+        ],
+      },
+    ];
 
-  const additionalTags = builtInIssuesFields(org, allTagsCollection, assignedValues, [
-    'me',
-    ...usernames,
-  ]);
+    const eventsTags: Tag[] = eventsTagsQuery.data || [];
+    const issuePlatformTags: Tag[] = issuePlatformTagsQuery.data || [];
 
-  const allTags = {
-    ...allTagsCollection,
-    ...additionalTags,
-  };
+    const allTagsCollection: TagCollection = eventsTags.reduce<TagCollection>(
+      (acc, tag) => {
+        acc[tag.key] = {...tag, kind: FieldKind.TAG};
+        return acc;
+      },
+      {}
+    );
+    issuePlatformTags.forEach(tag => {
+      if (allTagsCollection[tag.key]) {
+        allTagsCollection[tag.key].totalValues =
+          (allTagsCollection[tag.key].totalValues ?? 0) + (tag.totalValues ?? 0);
+      } else {
+        allTagsCollection[tag.key] = {...tag, kind: FieldKind.TAG};
+      }
+    });
+
+    const additionalTags = builtInIssuesFields(org, allTagsCollection, assignedValues, [
+      'me',
+      ...usernames,
+    ]);
+
+    return {
+      ...allTagsCollection,
+      ...additionalTags,
+    };
+  }, [eventsTagsQuery.data, issuePlatformTagsQuery.data, members, org, teams]);
 
   return {
     tags: allTags,


### PR DESCRIPTION
A few changes to prevent the filter value from resetting when the page rerenders:

- Modifies a `useEffect` which had `token` as a dependency to use `token.text` instead
- Wrapped inputs to the component in `useMemo` and `useCallback`