### PR TITLE
fix(dashboards): Revert querying dataset directly

### DIFF
--- a/src/sentry/api/endpoints/organization_events.py
+++ b/src/sentry/api/endpoints/organization_events.py
@@ -23,13 +23,7 @@ from sentry.discover.models import DiscoverSavedQuery, DiscoverSavedQueryTypes
 from sentry.exceptions import InvalidParams
 from sentry.models.dashboard_widget import DashboardWidget, DashboardWidgetTypes
 from sentry.models.organization import Organization
-from sentry.snuba import (
-    discover,
-    errors,
-    metrics_enhanced_performance,
-    metrics_performance,
-    transactions,
-)
+from sentry.snuba import discover, metrics_enhanced_performance, metrics_performance
 from sentry.snuba.metrics.extraction import MetricSpecType
 from sentry.snuba.referrer import Referrer
 from sentry.snuba.utils import dataset_split_decision_inferred_from_query, get_dataset
@@ -410,18 +404,33 @@ class OrganizationEventsEndpoint(OrganizationEventsV2EndpointBase):
 
                 if does_widget_have_split and not has_override_feature:
                     # This is essentially cached behaviour and we skip the check
+                    split_query = scoped_query
                     if widget.discover_widget_split == DashboardWidgetTypes.ERROR_EVENTS:
-                        split_dataset = errors
+                        split_dataset = discover
+                        split_query = (
+                            f"({scoped_query}) AND !event.type:transaction"
+                            if scoped_query
+                            else "!event.type:transaction"
+                        )
                     elif widget.discover_widget_split == DashboardWidgetTypes.TRANSACTION_LIKE:
                         # We can't add event.type:transaction for now because of on-demand.
                         split_dataset = scoped_dataset
                     else:
                         split_dataset = discover
 
-                    return _data_fn(split_dataset, offset, limit, scoped_query)
+                    return _data_fn(split_dataset, offset, limit, split_query)
 
                 try:
-                    error_results = _data_fn(errors, offset, limit, scoped_query)
+                    error_results = _data_fn(
+                        discover,
+                        offset,
+                        limit,
+                        (
+                            f"({scoped_query}) AND !event.type:transaction"
+                            if scoped_query
+                            else "!event.type:transaction"
+                        ),
+                    )
                     # Widget has not split the discover dataset yet, so we need to check if there are errors etc.
                     has_errors = len(error_results["data"]) > 0
                 except SnubaError:
@@ -443,7 +452,12 @@ class OrganizationEventsEndpoint(OrganizationEventsV2EndpointBase):
                 if has_errors and has_other_data and not using_metrics:
                     # In the case that the original request was not using the metrics dataset, we cannot be certain that other data is solely transactions.
                     sentry_sdk.set_tag("third_split_query", True)
-                    transaction_results = _data_fn(transactions, offset, limit, scoped_query)
+                    transactions_only_query = (
+                        f"({scoped_query}) AND event.type:transaction"
+                        if scoped_query
+                        else "event.type:transaction"
+                    )
+                    transaction_results = _data_fn(discover, offset, limit, transactions_only_query)
                     has_transactions = len(transaction_results["data"]) > 0
 
                 decision = self.save_split_decision(widget, has_errors, has_transactions)

--- a/tests/snuba/api/endpoints/test_organization_events_mep.py
+++ b/tests/snuba/api/endpoints/test_organization_events_mep.py
@@ -3649,61 +3649,6 @@ class OrganizationEventsMetricsEnhancedPerformanceEndpointTestWithOnDemandMetric
         self._assert_on_demand_response(response, expected_on_demand_query=True)
         assert response.data["data"] == [{"count_unique(user)": 2}]
 
-    @mock.patch("sentry.snuba.errors.query")
-    def test_errors_request_made_for_saved_error_dashboard_widget_type(self, mock_errors_query):
-        mock_errors_query.return_value = {
-            "data": [],
-            "meta": {},
-        }
-        _, widget, __ = create_widget(
-            ["count()"], "", self.project, discover_widget_split=DashboardWidgetTypes.ERROR_EVENTS
-        )
-
-        response = self.do_request(
-            {
-                "field": [
-                    "count()",
-                ],
-                "query": "",
-                "dataset": "metricsEnhanced",
-                "per_page": 50,
-                "dashboardWidgetId": widget.id,
-            }
-        )
-
-        assert response.status_code == 200, response.content
-        mock_errors_query.assert_called_once()
-
-    @mock.patch("sentry.snuba.metrics_enhanced_performance.query")
-    def test_metrics_enhanced_request_made_for_saved_transaction_like_dashboard_widget_type(
-        self, mock_mep_query
-    ):
-        mock_mep_query.return_value = {
-            "data": [],
-            "meta": {},
-        }
-        _, widget, __ = create_widget(
-            ["count()"],
-            "",
-            self.project,
-            discover_widget_split=DashboardWidgetTypes.TRANSACTION_LIKE,
-        )
-
-        response = self.do_request(
-            {
-                "field": [
-                    "count()",
-                ],
-                "query": "",
-                "dataset": "metricsEnhanced",
-                "per_page": 50,
-                "dashboardWidgetId": widget.id,
-            }
-        )
-
-        assert response.status_code == 200, response.content
-        mock_mep_query.assert_called_once()
-
     def test_split_decision_for_errors_widget(self):
         error_data = load_data("python", timestamp=before_now(minutes=1))
         self.store_event(


### PR DESCRIPTION
Uses discover and the event.type filter to choose the correct dataset. This is because there may be bugs with the querying the errors dataset directly.

Reverts https://github.com/getsentry/sentry/pull/74077/ but keeps some of the tests that are still compatible.