### PR TITLE
Delayed Processing Unit Tests::get_group_to_groupevent

### DIFF
--- a/src/sentry/rules/processing/delayed_processing.py
+++ b/src/sentry/rules/processing/delayed_processing.py
@@ -384,14 +384,13 @@ def get_group_to_groupevent(
     bulk_occurrence_id_to_occurrence = {
         occurrence.id: occurrence for occurrence in bulk_occurrences if occurrence
     }
-    group_to_groupevent = build_group_to_groupevent(
+    return build_group_to_groupevent(
         parsed_rulegroup_to_event_data,
         bulk_event_id_to_events,
         bulk_occurrence_id_to_occurrence,
         group_id_to_group,
         project_id,
     )
-    return group_to_groupevent
 
 
 def bucket_num_groups(num_groups: int) -> str:

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -1269,7 +1269,7 @@ class SnubaTestCase(BaseTestCase):
         self.snuba_eventstream = SnubaEventStream()
         self.snuba_tagstore = SnubaTagStorage()
 
-    def store_event(self, *args, **kwargs):
+    def store_event(self, *args, **kwargs) -> Event:
         """
         Simulates storing an event for testing.
 

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -1269,7 +1269,7 @@ class SnubaTestCase(BaseTestCase):
         self.snuba_eventstream = SnubaEventStream()
         self.snuba_tagstore = SnubaTagStorage()
 
-    def store_event(self, *args, **kwargs) -> Event:
+    def store_event(self, *args, **kwargs):
         """
         Simulates storing an event for testing.
 

--- a/tests/sentry/rules/processing/test_delayed_processing.py
+++ b/tests/sentry/rules/processing/test_delayed_processing.py
@@ -313,18 +313,17 @@ class GetGroupToGroupEventTest(CreateEventTestCase):
                 **self.occurrence2,
             },
         }
+        self.group_ids = {self.group1.id, self.group2.id}
 
     def test_basic(self):
-        group_ids = {self.group1.id, self.group2.id}
         self.parsed_data.pop((self.rule.id, self.group2.id))
-        result = get_group_to_groupevent(self.parsed_data, self.project.id, group_ids)
+        result = get_group_to_groupevent(self.parsed_data, self.project.id, {self.group1.id})
 
         assert len(result) == 1
         assert result[self.group1] == self.event1
 
     def test_many(self):
-        group_ids = {self.group1.id, self.group2.id}
-        result = get_group_to_groupevent(self.parsed_data, self.project.id, group_ids)
+        result = get_group_to_groupevent(self.parsed_data, self.project.id, self.group_ids)
 
         assert len(result) == 2
         assert result[self.group1] == self.event1
@@ -342,48 +341,22 @@ class GetGroupToGroupEventTest(CreateEventTestCase):
             },
         }
 
-        group_ids = {self.group1.id, self.group2.id}
-        result = get_group_to_groupevent(parsed_data, self.project.id, group_ids)
+        result = get_group_to_groupevent(parsed_data, self.project.id, self.group_ids)
 
         assert len(result) == 1
         assert result[self.group1] == self.event1
 
-    def test_missing_occurrence(self):
-        """
-        We don't use the occurrence_id in the GroupEvent, so it's okay if it's missing.
-        """
-        parsed_data = {
-            (self.rule.id, self.group1.id): {
-                "event_id": self.event1.event_id,
-                "occurrence_id": "0",
-            },
-            (self.rule.id, self.group2.id): {
-                "event_id": self.event2.event_id,
-                **self.occurrence2,
-            },
-        }
-        group_ids = {self.group1.id, self.group2.id}
-        result = get_group_to_groupevent(parsed_data, self.project.id, group_ids)
+    def test_invalid_project_id(self):
+        result = get_group_to_groupevent(self.parsed_data, 0, self.group_ids)
+        assert len(result) == 0
 
-        assert len(result) == 2
-        assert self.group1 in result
-        assert self.group2 in result
-        assert result[self.group1] == self.event1
-        assert result[self.group2] == self.event2
-
-    def test_empty_input(self):
+    def test_empty_group_ids(self):
         parsed_data: dict[tuple[str, str], dict[str, str]] = {}
         result = get_group_to_groupevent(parsed_data, self.project.id, set())
         assert len(result) == 0
 
-    def test_invalid_project_id(self):
-        group_ids = {self.group1.id}
-        result = get_group_to_groupevent(self.parsed_data, 0, group_ids)
-        assert len(result) == 0
-
     def test_invalid_group_ids(self):
-        group_ids = {0}
-        result = get_group_to_groupevent(self.parsed_data, self.project.id, group_ids)
+        result = get_group_to_groupevent(self.parsed_data, self.project.id, {0})
         assert len(result) == 0
 
 

--- a/tests/sentry/rules/processing/test_delayed_processing.py
+++ b/tests/sentry/rules/processing/test_delayed_processing.py
@@ -303,7 +303,21 @@ class GetGroupToGroupEventTest(CreateEventTestCase):
         self.occurrence1 = {"occurrence_id": "occ1"}
         self.occurrence2 = {"occurrence_id": "occ2"}
 
-    def test_get_group_to_groupevent_basic(self):
+    def test_basic(self):
+        group_ids = {self.group1.id, self.group2.id}
+        parsed_data = {
+            (self.rule.id, self.group1.id): {
+                "event_id": self.event1.event_id,
+                "occurrence_id": self.occurrence1["occurrence_id"],
+            },
+        }
+
+        result = get_group_to_groupevent(parsed_data, self.project.id, group_ids)
+
+        assert len(result) == 1
+        assert result[self.group1] == self.event1
+
+    def test_many(self):
         group_ids = {self.group1.id, self.group2.id}
         parsed_data = {
             (self.rule.id, self.group1.id): {
@@ -319,10 +333,10 @@ class GetGroupToGroupEventTest(CreateEventTestCase):
         result = get_group_to_groupevent(parsed_data, self.project.id, group_ids)
 
         assert len(result) == 2
-        assert result[self.group1].event_id == self.event1.event_id
+        assert result[self.group1] == self.event1
         assert result[self.group2] == self.event2
 
-    def test_get_group_to_groupevent_missing_event(self):
+    def test_missing_event(self):
         parsed_data = {
             (self.rule.id, self.group1.id): {
                 "event_id": self.event1.event_id,
@@ -340,7 +354,7 @@ class GetGroupToGroupEventTest(CreateEventTestCase):
         assert len(result) == 1
         assert result[self.group1] == self.event1
 
-    def test_get_group_to_groupevent_missing_occurrence(self):
+    def test_missing_occurrence(self):
         """
         We don't use the occurrence_id in the GroupEvent, so it's okay if it's missing.
         """
@@ -363,10 +377,32 @@ class GetGroupToGroupEventTest(CreateEventTestCase):
         assert result[self.group1] == self.event1
         assert result[self.group2] == self.event2
 
-    def test_get_group_to_groupevent_empty_input(self):
+    def test_empty_input(self):
         parsed_data: dict[tuple[str, str], dict[str, str]] = {}
         result = get_group_to_groupevent(parsed_data, self.project.id, set())
 
+        assert len(result) == 0
+
+    def test_invalid_project_id(self):
+        parsed_data = {
+            (self.rule.id, self.group1.id): {
+                "event_id": self.event1.event_id,
+                "occurrence_id": self.occurrence1["occurrence_id"],
+            },
+        }
+        group_ids = {self.group1.id}
+        result = get_group_to_groupevent(parsed_data, 0, group_ids)
+        assert len(result) == 0
+
+    def test_invalid_group_ids(self):
+        parsed_data = {
+            (self.rule.id, self.group1.id): {
+                "event_id": self.event1.event_id,
+                "occurrence_id": self.occurrence1["occurrence_id"],
+            },
+        }
+        group_ids = {0}
+        result = get_group_to_groupevent(parsed_data, self.project.id, group_ids)
         assert len(result) == 0
 
 

--- a/tests/sentry/rules/processing/test_delayed_processing.py
+++ b/tests/sentry/rules/processing/test_delayed_processing.py
@@ -308,7 +308,7 @@ class GetGroupToGroupEventTest(CreateEventTestCase):
         parsed_data = {
             (self.rule.id, self.group1.id): {
                 "event_id": self.event1.event_id,
-                "occurrence_id": self.occurrence1["occurrence_id"],
+                **self.occurrence1,
             },
         }
 
@@ -322,11 +322,11 @@ class GetGroupToGroupEventTest(CreateEventTestCase):
         parsed_data = {
             (self.rule.id, self.group1.id): {
                 "event_id": self.event1.event_id,
-                "occurrence_id": self.occurrence1["occurrence_id"],
+                **self.occurrence1,
             },
             (self.rule.id, self.group2.id): {
                 "event_id": self.event2.event_id,
-                "occurrence_id": self.occurrence2["occurrence_id"],
+                **self.occurrence2,
             },
         }
 
@@ -340,11 +340,11 @@ class GetGroupToGroupEventTest(CreateEventTestCase):
         parsed_data = {
             (self.rule.id, self.group1.id): {
                 "event_id": self.event1.event_id,
-                "occurrence_id": self.occurrence1["occurrence_id"],
+                **self.occurrence1,
             },
             (self.rule.id, self.group2.id): {
                 "event_id": "0",
-                "occurrence_id": self.occurrence2["occurrence_id"],
+                **self.occurrence2,
             },
         }
 
@@ -361,7 +361,7 @@ class GetGroupToGroupEventTest(CreateEventTestCase):
         parsed_data = {
             (self.rule.id, self.group1.id): {
                 "event_id": self.event1.event_id,
-                "occurrence_id": self.occurrence1["occurrence_id"],
+                **self.occurrence1,
             },
             (self.rule.id, self.group2.id): {
                 "event_id": self.event2.event_id,
@@ -387,7 +387,7 @@ class GetGroupToGroupEventTest(CreateEventTestCase):
         parsed_data = {
             (self.rule.id, self.group1.id): {
                 "event_id": self.event1.event_id,
-                "occurrence_id": self.occurrence1["occurrence_id"],
+                **self.occurrence1,
             },
         }
         group_ids = {self.group1.id}
@@ -398,7 +398,7 @@ class GetGroupToGroupEventTest(CreateEventTestCase):
         parsed_data = {
             (self.rule.id, self.group1.id): {
                 "event_id": self.event1.event_id,
-                "occurrence_id": self.occurrence1["occurrence_id"],
+                **self.occurrence1,
             },
         }
         group_ids = {0}

--- a/tests/sentry/rules/processing/test_delayed_processing.py
+++ b/tests/sentry/rules/processing/test_delayed_processing.py
@@ -303,23 +303,7 @@ class GetGroupToGroupEventTest(CreateEventTestCase):
         self.occurrence1 = {"occurrence_id": "occ1"}
         self.occurrence2 = {"occurrence_id": "occ2"}
 
-    def test_basic(self):
-        group_ids = {self.group1.id, self.group2.id}
-        parsed_data = {
-            (self.rule.id, self.group1.id): {
-                "event_id": self.event1.event_id,
-                **self.occurrence1,
-            },
-        }
-
-        result = get_group_to_groupevent(parsed_data, self.project.id, group_ids)
-
-        assert len(result) == 1
-        assert result[self.group1] == self.event1
-
-    def test_many(self):
-        group_ids = {self.group1.id, self.group2.id}
-        parsed_data = {
+        self.parsed_data = {
             (self.rule.id, self.group1.id): {
                 "event_id": self.event1.event_id,
                 **self.occurrence1,
@@ -330,7 +314,17 @@ class GetGroupToGroupEventTest(CreateEventTestCase):
             },
         }
 
-        result = get_group_to_groupevent(parsed_data, self.project.id, group_ids)
+    def test_basic(self):
+        group_ids = {self.group1.id, self.group2.id}
+        self.parsed_data.pop((self.rule.id, self.group2.id))
+        result = get_group_to_groupevent(self.parsed_data, self.project.id, group_ids)
+
+        assert len(result) == 1
+        assert result[self.group1] == self.event1
+
+    def test_many(self):
+        group_ids = {self.group1.id, self.group2.id}
+        result = get_group_to_groupevent(self.parsed_data, self.project.id, group_ids)
 
         assert len(result) == 2
         assert result[self.group1] == self.event1
@@ -361,11 +355,11 @@ class GetGroupToGroupEventTest(CreateEventTestCase):
         parsed_data = {
             (self.rule.id, self.group1.id): {
                 "event_id": self.event1.event_id,
-                **self.occurrence1,
+                "occurrence_id": "0",
             },
             (self.rule.id, self.group2.id): {
                 "event_id": self.event2.event_id,
-                "occurrence_id": "0",
+                **self.occurrence2,
             },
         }
         group_ids = {self.group1.id, self.group2.id}
@@ -380,29 +374,16 @@ class GetGroupToGroupEventTest(CreateEventTestCase):
     def test_empty_input(self):
         parsed_data: dict[tuple[str, str], dict[str, str]] = {}
         result = get_group_to_groupevent(parsed_data, self.project.id, set())
-
         assert len(result) == 0
 
     def test_invalid_project_id(self):
-        parsed_data = {
-            (self.rule.id, self.group1.id): {
-                "event_id": self.event1.event_id,
-                **self.occurrence1,
-            },
-        }
         group_ids = {self.group1.id}
-        result = get_group_to_groupevent(parsed_data, 0, group_ids)
+        result = get_group_to_groupevent(self.parsed_data, 0, group_ids)
         assert len(result) == 0
 
     def test_invalid_group_ids(self):
-        parsed_data = {
-            (self.rule.id, self.group1.id): {
-                "event_id": self.event1.event_id,
-                **self.occurrence1,
-            },
-        }
         group_ids = {0}
-        result = get_group_to_groupevent(parsed_data, self.project.id, group_ids)
+        result = get_group_to_groupevent(self.parsed_data, self.project.id, group_ids)
         assert len(result) == 0
 
 

--- a/tests/sentry/rules/processing/test_delayed_processing.py
+++ b/tests/sentry/rules/processing/test_delayed_processing.py
@@ -331,13 +331,13 @@ class GetGroupToGroupEventTest(CreateEventTestCase):
 
     def test_missing_event(self):
         parsed_data = {
-            (self.rule.id, self.group1.id): {
-                "event_id": self.event1.event_id,
-                **self.occurrence1,
-            },
             (self.rule.id, self.group2.id): {
                 "event_id": "0",
                 **self.occurrence2,
+            },
+            (self.rule.id, self.group1.id): {
+                "event_id": self.event1.event_id,
+                **self.occurrence1,
             },
         }
 


### PR DESCRIPTION
# Description
- ~Fixes the testutils return type to be an `Event` - this then correctly breaks other typing issues.~ will do this separately as it broke lots of stuff.
- Fix the GroupEvent -> Event typing
- Add tests to ensure the `get_group_to_groupevent` works as expected in more scenarios.