### PR TITLE
feat(replay): add before/after labels and tooltips to slider diff

### DIFF
--- a/static/app/components/replays/diff/replaySliderDiff.tsx
+++ b/static/app/components/replays/diff/replaySliderDiff.tsx
@@ -27,7 +27,7 @@ export function ReplaySliderDiff({leftOffsetMs, replay, rightOffsetMs}: Props) {
   return (
     <Fragment>
       <Header>
-        <Tooltip title={t('How the initial server-rendered page looked like.')}>
+        <Tooltip title={t('How the initial server-rendered page looked.')}>
           <div style={{color: 'red'}}>{t('Before')}</div>
         </Tooltip>
         <Tooltip

--- a/static/app/components/replays/diff/replaySliderDiff.tsx
+++ b/static/app/components/replays/diff/replaySliderDiff.tsx
@@ -5,6 +5,8 @@ import NegativeSpaceContainer from 'sentry/components/container/negativeSpaceCon
 import ReplayIFrameRoot from 'sentry/components/replays/player/replayIFrameRoot';
 import {StaticReplayPreferences} from 'sentry/components/replays/preferences/replayPreferences';
 import {Provider as ReplayContextProvider} from 'sentry/components/replays/replayContext';
+import {Tooltip} from 'sentry/components/tooltip';
+import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import toPixels from 'sentry/utils/number/toPixels';
 import type ReplayReader from 'sentry/utils/replays/replayReader';
@@ -23,23 +25,43 @@ export function ReplaySliderDiff({leftOffsetMs, replay, rightOffsetMs}: Props) {
 
   const width = toPixels(viewDimensions.width);
   return (
-    <WithPadding>
-      <Positioned ref={positionedRef}>
-        {viewDimensions.width ? (
-          <DiffSides
-            leftOffsetMs={leftOffsetMs}
-            replay={replay}
-            rightOffsetMs={rightOffsetMs}
-            viewDimensions={viewDimensions}
-            width={width}
-          />
-        ) : (
-          <div />
-        )}
-      </Positioned>
-    </WithPadding>
+    <Fragment>
+      <Header>
+        <Tooltip title={t('How the initial server-rendered page looked like.')}>
+          <div style={{color: 'red'}}>{t('Before')}</div>
+        </Tooltip>
+        <Tooltip
+          title={t(
+            'How React re-rendered the page on your browser, after detecting a hydration error.'
+          )}
+        >
+          <div style={{color: 'green'}}>{t('After')}</div>
+        </Tooltip>
+      </Header>
+      <WithPadding>
+        <Positioned ref={positionedRef}>
+          {viewDimensions.width ? (
+            <DiffSides
+              leftOffsetMs={leftOffsetMs}
+              replay={replay}
+              rightOffsetMs={rightOffsetMs}
+              viewDimensions={viewDimensions}
+              width={width}
+            />
+          ) : (
+            <div />
+          )}
+        </Positioned>
+      </WithPadding>
+    </Fragment>
   );
 }
+
+const Header = styled('div')`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+`;
 
 function DiffSides({leftOffsetMs, replay, rightOffsetMs, viewDimensions, width}) {
   const rightSideElem = useRef<HTMLDivElement>(null);

--- a/static/app/components/replays/diff/replaySliderDiff.tsx
+++ b/static/app/components/replays/diff/replaySliderDiff.tsx
@@ -57,12 +57,6 @@ export function ReplaySliderDiff({leftOffsetMs, replay, rightOffsetMs}: Props) {
   );
 }
 
-const Header = styled('div')`
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-`;
-
 function DiffSides({leftOffsetMs, replay, rightOffsetMs, viewDimensions, width}) {
   const rightSideElem = useRef<HTMLDivElement>(null);
   const dividerElem = useRef<HTMLDivElement>(null);
@@ -185,4 +179,10 @@ const Divider = styled('div')`
     bottom: 0;
     transform: translate(calc(var(--handle-size) / -2 + var(--line-width) / 2), 100%);
   }
+`;
+
+const Header = styled('div')`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
 `;


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry/issues/74458
The Before tooltip has been changed to "How the initial server-rendered page looked."
![Screenshot 2024-07-19 at 12 05 55 PM](https://github.com/user-attachments/assets/8abdc894-b13b-4eb9-9247-0ed6877e4fd1)
![Screenshot 2024-07-19 at 12 06 07 PM](https://github.com/user-attachments/assets/5f707ce6-fedf-4277-b712-1e42fce42a27)
