### PR TITLE
ref(similarity): Add project option to enable ingestion after backfill

### DIFF
--- a/src/sentry/api/endpoints/project_backfill_similar_issues_embeddings_records.py
+++ b/src/sentry/api/endpoints/project_backfill_similar_issues_embeddings_records.py
@@ -33,7 +33,7 @@ class ProjectBackfillSimilarIssuesEmbeddingsRecords(ProjectEndpoint):
 
         last_processed_id = None
         only_delete = False
-        enable_ingestion = True
+        enable_ingestion = False
 
         if request.data.get("last_processed_id"):
             last_processed_id = int(request.data["last_processed_id"])

--- a/src/sentry/api/endpoints/project_backfill_similar_issues_embeddings_records.py
+++ b/src/sentry/api/endpoints/project_backfill_similar_issues_embeddings_records.py
@@ -33,15 +33,21 @@ class ProjectBackfillSimilarIssuesEmbeddingsRecords(ProjectEndpoint):
 
         last_processed_id = None
         only_delete = False
+        enable_ingestion = True
+
         if request.data.get("last_processed_id"):
             last_processed_id = int(request.data["last_processed_id"])
 
         if request.data.get("only_delete"):
             only_delete = True
 
+        if request.data.get("enable_ingestion"):
+            enable_ingestion = request.data["enable_ingestion"] == "true"
+
         backfill_seer_grouping_records_for_project.delay(
             current_project_id=project.id,
             last_processed_group_id_input=last_processed_id,
             only_delete=only_delete,
+            enable_ingestion=enable_ingestion,
         )
         return Response(status=204)

--- a/src/sentry/tasks/embeddings_grouping/backfill_seer_grouping_records_for_project.py
+++ b/src/sentry/tasks/embeddings_grouping/backfill_seer_grouping_records_for_project.py
@@ -50,7 +50,7 @@ def backfill_seer_grouping_records_for_project(
     cohort: str | list[int] | None = None,
     last_processed_project_index_input: int | None = None,
     only_delete: bool = False,
-    enable_ingestion: bool = True,
+    enable_ingestion: bool = False,
     *args: Any,
     **kwargs: Any,
 ) -> None:

--- a/src/sentry/tasks/embeddings_grouping/backfill_seer_grouping_records_for_project.py
+++ b/src/sentry/tasks/embeddings_grouping/backfill_seer_grouping_records_for_project.py
@@ -235,7 +235,7 @@ def call_next_backfill(
     last_processed_project_index: int,
     cohort: str | list[int] | None = None,
     only_delete: bool = False,
-    enable_ingestion: bool = True,
+    enable_ingestion: bool = False,
 ):
     if last_processed_group_id is not None:
         redis_client.set(

--- a/src/sentry/tasks/embeddings_grouping/backfill_seer_grouping_records_for_project.py
+++ b/src/sentry/tasks/embeddings_grouping/backfill_seer_grouping_records_for_project.py
@@ -49,7 +49,8 @@ def backfill_seer_grouping_records_for_project(
     last_processed_group_id_input: int | None,
     cohort: str | list[int] | None = None,
     last_processed_project_index_input: int | None = None,
-    only_delete=False,
+    only_delete: bool = False,
+    enable_ingestion: bool = True,
     *args: Any,
     **kwargs: Any,
 ) -> None:
@@ -105,6 +106,7 @@ def backfill_seer_grouping_records_for_project(
             last_processed_project_index=last_processed_project_index_input,
             cohort=cohort,
             only_delete=only_delete,
+            enable_ingestion=enable_ingestion,
         )
         return
 
@@ -121,13 +123,14 @@ def backfill_seer_grouping_records_for_project(
             last_processed_project_index=last_processed_project_index,
             cohort=cohort,
             only_delete=only_delete,
+            enable_ingestion=enable_ingestion,
         )
         return
 
     batch_size = options.get("embeddings-grouping.seer.backfill-batch-size")
 
     (groups_to_backfill_with_no_embedding, batch_end_id) = get_current_batch_groups_from_postgres(
-        project, last_processed_group_id, batch_size
+        project, last_processed_group_id, batch_size, enable_ingestion
     )
 
     if len(groups_to_backfill_with_no_embedding) == 0:
@@ -137,6 +140,7 @@ def backfill_seer_grouping_records_for_project(
             redis_client=redis_client,
             last_processed_project_index=last_processed_project_index,
             cohort=cohort,
+            enable_ingestion=enable_ingestion,
         )
         return
 
@@ -154,6 +158,7 @@ def backfill_seer_grouping_records_for_project(
             redis_client=redis_client,
             last_processed_project_index=last_processed_project_index,
             cohort=cohort,
+            enable_ingestion=enable_ingestion,
         )
         return
 
@@ -167,6 +172,7 @@ def backfill_seer_grouping_records_for_project(
             redis_client=redis_client,
             last_processed_project_index=last_processed_project_index,
             cohort=cohort,
+            enable_ingestion=enable_ingestion,
         )
         return
 
@@ -217,6 +223,7 @@ def backfill_seer_grouping_records_for_project(
         redis_client=redis_client,
         last_processed_project_index=last_processed_project_index,
         cohort=cohort,
+        enable_ingestion=enable_ingestion,
     )
 
 
@@ -228,6 +235,7 @@ def call_next_backfill(
     last_processed_project_index: int,
     cohort: str | list[int] | None = None,
     only_delete: bool = False,
+    enable_ingestion: bool = True,
 ):
     if last_processed_group_id is not None:
         redis_client.set(
@@ -249,6 +257,7 @@ def call_next_backfill(
                 cohort,
                 last_processed_project_index,
                 only_delete,
+                enable_ingestion,
             ],
             headers={"sentry-propagate-traces": False},
         )
@@ -295,6 +304,7 @@ def call_next_backfill(
                 cohort,
                 last_processed_project_index,
                 only_delete,
+                enable_ingestion,
             ],
             headers={"sentry-propagate-traces": False},
         )

--- a/src/sentry/tasks/embeddings_grouping/utils.py
+++ b/src/sentry/tasks/embeddings_grouping/utils.py
@@ -131,7 +131,7 @@ def initialize_backfill(
 
 @sentry_sdk.tracing.trace
 def get_current_batch_groups_from_postgres(
-    project, last_processed_group_id, batch_size, enable_ingestion
+    project, last_processed_group_id, batch_size, enable_ingestion: bool = False
 ):
     group_id_filter = Q()
     if last_processed_group_id is not None:

--- a/src/sentry/tasks/embeddings_grouping/utils.py
+++ b/src/sentry/tasks/embeddings_grouping/utils.py
@@ -181,7 +181,7 @@ def get_current_batch_groups_from_postgres(
                 "backfill_seer_grouping_records.enable_ingestion",
                 extra={"project_id": project.id},
             )
-            project.update_option("sentry:similarity_backfill_completed", True)
+            project.update_option("sentry:similarity_backfill_completed", int(time.time()))
 
         return (
             groups_to_backfill_batch,

--- a/src/sentry/tasks/embeddings_grouping/utils.py
+++ b/src/sentry/tasks/embeddings_grouping/utils.py
@@ -130,7 +130,9 @@ def initialize_backfill(
 
 
 @sentry_sdk.tracing.trace
-def get_current_batch_groups_from_postgres(project, last_processed_group_id, batch_size):
+def get_current_batch_groups_from_postgres(
+    project, last_processed_group_id, batch_size, enable_ingestion
+):
     group_id_filter = Q()
     if last_processed_group_id is not None:
         group_id_filter = Q(id__lt=last_processed_group_id)
@@ -174,6 +176,13 @@ def get_current_batch_groups_from_postgres(project, last_processed_group_id, bat
             "backfill_seer_grouping_records.no_more_groups",
             extra={"project_id": project.id},
         )
+        if enable_ingestion:
+            logger.info(
+                "backfill_seer_grouping_records.enable_ingestion",
+                extra={"project_id": project.id},
+            )
+            project.update_option("sentry:similarity_backfill_completed", True)
+
         return (
             groups_to_backfill_batch,
             None,

--- a/tests/sentry/api/endpoints/test_project_backfill_similar_issues_embeddings_records.py
+++ b/tests/sentry/api/endpoints/test_project_backfill_similar_issues_embeddings_records.py
@@ -50,6 +50,7 @@ class ProjectBackfillSimilarIssuesEmbeddingsRecordsTest(APITestCase):
             current_project_id=self.project.id,
             last_processed_group_id_input=None,
             only_delete=False,
+            enable_ingestion=True,
         )
 
     @patch(
@@ -66,6 +67,7 @@ class ProjectBackfillSimilarIssuesEmbeddingsRecordsTest(APITestCase):
             current_project_id=self.project.id,
             last_processed_group_id_input=None,
             only_delete=False,
+            enable_ingestion=True,
         )
 
     @patch(
@@ -85,6 +87,7 @@ class ProjectBackfillSimilarIssuesEmbeddingsRecordsTest(APITestCase):
             current_project_id=self.project.id,
             last_processed_group_id_input=8,
             only_delete=False,
+            enable_ingestion=True,
         )
 
     @patch(
@@ -106,4 +109,27 @@ class ProjectBackfillSimilarIssuesEmbeddingsRecordsTest(APITestCase):
             current_project_id=self.project.id,
             last_processed_group_id_input=8,
             only_delete=True,
+            enable_ingestion=True,
+        )
+
+    @patch(
+        "sentry.api.endpoints.project_backfill_similar_issues_embeddings_records.is_active_superuser",
+        return_value=True,
+    )
+    @patch(
+        "sentry.api.endpoints.project_backfill_similar_issues_embeddings_records.backfill_seer_grouping_records_for_project.delay"
+    )
+    @with_feature("projects:similarity-embeddings-backfill")
+    def test_post_success_no_enable_ingestion(
+        self, mock_backfill_seer_grouping_records, mock_is_active_superuser
+    ):
+        response = self.client.post(
+            self.url, data={"last_processed_id": "8", "enable_ingestion": "false"}
+        )
+        assert response.status_code == 204, response.content
+        mock_backfill_seer_grouping_records.assert_called_with(
+            current_project_id=self.project.id,
+            last_processed_group_id_input=8,
+            only_delete=False,
+            enable_ingestion=False,
         )

--- a/tests/sentry/api/endpoints/test_project_backfill_similar_issues_embeddings_records.py
+++ b/tests/sentry/api/endpoints/test_project_backfill_similar_issues_embeddings_records.py
@@ -50,7 +50,7 @@ class ProjectBackfillSimilarIssuesEmbeddingsRecordsTest(APITestCase):
             current_project_id=self.project.id,
             last_processed_group_id_input=None,
             only_delete=False,
-            enable_ingestion=True,
+            enable_ingestion=False,
         )
 
     @patch(
@@ -67,7 +67,7 @@ class ProjectBackfillSimilarIssuesEmbeddingsRecordsTest(APITestCase):
             current_project_id=self.project.id,
             last_processed_group_id_input=None,
             only_delete=False,
-            enable_ingestion=True,
+            enable_ingestion=False,
         )
 
     @patch(
@@ -87,7 +87,7 @@ class ProjectBackfillSimilarIssuesEmbeddingsRecordsTest(APITestCase):
             current_project_id=self.project.id,
             last_processed_group_id_input=8,
             only_delete=False,
-            enable_ingestion=True,
+            enable_ingestion=False,
         )
 
     @patch(
@@ -109,7 +109,7 @@ class ProjectBackfillSimilarIssuesEmbeddingsRecordsTest(APITestCase):
             current_project_id=self.project.id,
             last_processed_group_id_input=8,
             only_delete=True,
-            enable_ingestion=True,
+            enable_ingestion=False,
         )
 
     @patch(
@@ -120,16 +120,16 @@ class ProjectBackfillSimilarIssuesEmbeddingsRecordsTest(APITestCase):
         "sentry.api.endpoints.project_backfill_similar_issues_embeddings_records.backfill_seer_grouping_records_for_project.delay"
     )
     @with_feature("projects:similarity-embeddings-backfill")
-    def test_post_success_no_enable_ingestion(
+    def test_post_success_enable_ingestion(
         self, mock_backfill_seer_grouping_records, mock_is_active_superuser
     ):
         response = self.client.post(
-            self.url, data={"last_processed_id": "8", "enable_ingestion": "false"}
+            self.url, data={"last_processed_id": "8", "enable_ingestion": "true"}
         )
         assert response.status_code == 204, response.content
         mock_backfill_seer_grouping_records.assert_called_with(
             current_project_id=self.project.id,
             last_processed_group_id_input=8,
             only_delete=False,
-            enable_ingestion=False,
+            enable_ingestion=True,
         )

--- a/tests/sentry/tasks/test_backfill_seer_grouping_records.py
+++ b/tests/sentry/tasks/test_backfill_seer_grouping_records.py
@@ -1565,7 +1565,7 @@ class TestBackfillSeerGroupingRecords(SnubaTestCase, TestCase):
             "backfill_seer_grouping_records.enable_ingestion",
             extra={"project_id": self.project.id},
         )
-        assert self.project.get_option("sentry:similarity_backfill_completed") is True
+        assert self.project.get_option("sentry:similarity_backfill_completed") is not None
 
     @with_feature("projects:similarity-embeddings-backfill")
     @patch("sentry.tasks.embeddings_grouping.utils.logger")


### PR DESCRIPTION
Add enable ingestion flag to backfill endpoint
Add enable ingestion flag in backfill
If the flag is enabled, add `sentry:similarity_backfill_completed` to project options (to be checked in ingestion)