### PR TITLE
chore(issues): removing Organization Activity brownout option

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -2597,20 +2597,6 @@ register(
 )
 
 
-# default brownout crontab for Organization Events API deprecations
-# TODO: remove once endpoint is removed
-register(
-    "api.organization-activity.brownout-cron",
-    default="*/3 * * * *",
-    type=String,
-    flags=FLAG_AUTOMATOR_MODIFIABLE,
-)
-# Brownout duration to be stored in ISO8601 format for durations (See https://en.wikipedia.org/wiki/ISO_8601#Durations)
-register(
-    "api.organization-activity.brownout-duration", default="PT1M", flags=FLAG_AUTOMATOR_MODIFIABLE
-)
-
-
 register(
     "sentry.save-event-attachments.project-per-5-minute-limit",
     type=Int,


### PR DESCRIPTION
Part 3 of the cleanup.

This should be merged only after both of this have merged: 
- https://github.com/getsentry/sentry/pull/74587  
- https://github.com/getsentry/sentry-options-automator/pull/1981 