### PR TITLE
ref(replay): Remove rage click issue new banner

### DIFF
--- a/static/app/views/issueDetails/header.tsx
+++ b/static/app/views/issueDetails/header.tsx
@@ -243,6 +243,8 @@ function GroupHeader({
 
   const issueTypeConfig = getConfigForIssueType(group, project);
 
+  const NEW_ISSUE_TYPES = [IssueType.REPLAY_HYDRATION_ERROR]; // adds a "new" banner next to the title
+
   return (
     <Layout.Header>
       <div className={className}>
@@ -271,9 +273,7 @@ function GroupHeader({
         <HeaderRow>
           <TitleWrapper>
             <TitleHeading>
-              {group.issueCategory === IssueCategory.REPLAY && (
-                <StyledFeatureBadge type="new" />
-              )}
+              {group.issueType in NEW_ISSUE_TYPES && <StyledFeatureBadge type="new" />}
               <h3>
                 <StyledEventOrGroupTitle data={group} />
               </h3>


### PR DESCRIPTION
![Screenshot 2024-07-19 at 2 16 43 PM](https://github.com/user-attachments/assets/663916df-f106-43bb-ada4-d9f7cc44eee2)
Removes this. We still want it for hydration errors though