### PR TITLE
ref(tags): Use new useApiQuery hooks to retrieve tag values using new dataset param

### DIFF
--- a/static/app/actionCreators/tags.tsx
+++ b/static/app/actionCreators/tags.tsx
@@ -290,7 +290,12 @@ export const makeFetchOrganizationTagKeyValues = ({
   query.includeSessions = includeSessions ? '1' : '0';
   query.includeTransactions = includeTransactions ? '1' : '0';
 
-  query.project = projectIds;
+  if (search) {
+    query.query = search;
+  }
+  if (projectIds) {
+    query.project = projectIds;
+  }
 
   if (statsPeriod) {
     query.statsPeriod = statsPeriod;
@@ -300,9 +305,6 @@ export const makeFetchOrganizationTagKeyValues = ({
   }
   if (end) {
     query.end = end;
-  }
-  if (search) {
-    query.search = search;
   }
   if (sort) {
     query.sort = sort;
@@ -318,10 +320,11 @@ export const useFetchOrganizationTagKeyValues = (
   params: FetchOrganizationTagKeyValuesParams,
   options: Partial<UseApiQueryOptions<TagValue[]>>
 ) => {
-  return useApiQuery<TagValue[]>(makeFetchOrganizationTagKeyValues(params), {
+  const a = useApiQuery<TagValue[]>(makeFetchOrganizationTagKeyValues(params), {
     staleTime: Infinity,
     keepPreviousData: params.keepPreviousData,
     enabled: params.enabled ?? true,
     ...options,
   });
+  return a;
 };

--- a/static/app/actionCreators/tags.tsx
+++ b/static/app/actionCreators/tags.tsx
@@ -249,3 +249,79 @@ export const useFetchOrganizationTags = (
     ...options,
   });
 };
+
+type FetchOrganizationTagKeyValuesParams = {
+  orgSlug: string;
+  tagKey: string;
+  dataset?: Dataset;
+  enabled?: boolean;
+  end?: string;
+  includeReplays?: boolean;
+  includeSessions?: boolean;
+  includeTransactions?: boolean;
+  keepPreviousData?: boolean;
+  projectIds?: string[];
+  search?: string;
+  sort?: string;
+  start?: string;
+  statsPeriod?: string | null;
+  useCache?: boolean;
+};
+
+export const makeFetchOrganizationTagKeyValues = ({
+  orgSlug,
+  tagKey,
+  dataset,
+  projectIds,
+  useCache = true,
+  statsPeriod,
+  start,
+  end,
+  search,
+  includeReplays,
+  includeSessions,
+  includeTransactions,
+  sort,
+}: FetchOrganizationTagKeyValuesParams): ApiQueryKey => {
+  const query: Query = {};
+
+  query.useCache = useCache ? '1' : '0';
+  query.includeReplays = includeReplays ? '1' : '0';
+  query.includeSessions = includeSessions ? '1' : '0';
+  query.includeTransactions = includeTransactions ? '1' : '0';
+
+  query.project = projectIds;
+
+  if (statsPeriod) {
+    query.statsPeriod = statsPeriod;
+  }
+  if (start) {
+    query.start = start;
+  }
+  if (end) {
+    query.end = end;
+  }
+  if (search) {
+    query.search = search;
+  }
+  if (sort) {
+    query.sort = sort;
+  }
+  if (dataset) {
+    query.dataset = dataset;
+  }
+
+  return [`/organizations/${orgSlug}/tags/${tagKey}/values/`, {query: query}];
+};
+
+export const useFetchOrganizationTagKeyValues = (
+  params: FetchOrganizationTagKeyValuesParams,
+  options: Partial<UseApiQueryOptions<TagValue[]>>
+) => {
+  return useApiQuery<TagValue[]>(makeFetchOrganizationTagKeyValues(params), {
+    staleTime: Infinity,
+    keepPreviousData: params.keepPreviousData,
+    enabled: params.enabled ?? true,
+    ...options,
+  });
+};

--- a/static/app/views/issueDetails/groupEvents.tsx
+++ b/static/app/views/issueDetails/groupEvents.tsx
@@ -4,7 +4,6 @@ import styled from '@emotion/styled';
 import orderBy from 'lodash/orderBy';
 
 import {useFetchIssueTags} from 'sentry/actionCreators/group';
-import {fetchTagValues} from 'sentry/actionCreators/tags';
 import EventSearchBar from 'sentry/components/events/searchBar';
 import * as Layout from 'sentry/components/layouts/thirds';
 import {SearchQueryBuilder} from 'sentry/components/searchQueryBuilder';
@@ -15,10 +14,10 @@ import type {Group, Tag, TagCollection} from 'sentry/types/group';
 import {browserHistory} from 'sentry/utils/browserHistory';
 import {FieldKind, ISSUE_EVENT_PROPERTY_FIELDS} from 'sentry/utils/fields';
 import normalizeUrl from 'sentry/utils/url/normalizeUrl';
-import useApi from 'sentry/utils/useApi';
 import useCleanQueryParamsOnRouteLeave from 'sentry/utils/useCleanQueryParamsOnRouteLeave';
 import useOrganization from 'sentry/utils/useOrganization';
-import {makeGetIssueTagValues} from 'sentry/views/issueList/utils/getIssueTagValues';
+import usePageFilters from 'sentry/utils/usePageFilters';
+import {makeGetIssueTagKeyValues} from 'sentry/views/issueList/utils/getIssueTagValues';
 
 import AllEventsTable from './allEventsTable';
 
@@ -75,8 +74,8 @@ function UpdatedSearchBar({
   handleSearch: (value: string) => void;
   query: string;
 }) {
-  const api = useApi();
   const organization = useOrganization();
+  const {selection: pageFilters} = usePageFilters();
 
   const {data = []} = useFetchIssueTags({
     orgSlug: organization.slug,
@@ -100,25 +99,9 @@ function UpdatedSearchBar({
     }, {});
   }, [data]);
 
-  const tagValueLoader = useCallback(
-    (key: string, search: string) => {
-      const orgSlug = organization.slug;
-      const projectIds = [group.project.id];
-
-      return fetchTagValues({
-        api,
-        orgSlug,
-        tagKey: key,
-        search,
-        projectIds,
-      });
-    },
-    [api, group.project.id, organization.slug]
-  );
-
   const getTagValues = useMemo(
-    () => makeGetIssueTagValues(tagValueLoader),
-    [tagValueLoader]
+    () => makeGetIssueTagKeyValues({organization, pageFilters}),
+    [organization, pageFilters]
   );
 
   const filterKeySections = useMemo(() => getFilterKeySections(filterKeys), [filterKeys]);

--- a/static/app/views/issueList/utils/getIssueTagValues.tsx
+++ b/static/app/views/issueList/utils/getIssueTagValues.tsx
@@ -21,8 +21,8 @@ export function makeGetIssueTagKeyValues({
   organization,
   pageFilters,
   useCache = true,
-}: FetchIssueTagValuesParams): (tag: Tag, query: string) => Promise<string[]> {
-  return async (tag: Tag, query: string): Promise<string[]> => {
+}: FetchIssueTagValuesParams): (tag: Tag, search: string) => Promise<string[]> {
+  return async (tag: Tag, search: string): Promise<string[]> => {
     const orgSlug = organization.slug;
     const projectIds = pageFilters.projects.map(id => id.toString());
     const endpointParams = {
@@ -34,11 +34,12 @@ export function makeGetIssueTagKeyValues({
         : undefined,
       statsPeriod: pageFilters.datetime.period,
     };
+
     const {data: eventsTagValues = []} = useFetchOrganizationTagKeyValues(
       {
         orgSlug,
         tagKey: tag.key,
-        search: query,
+        search,
         dataset: Dataset.ERRORS,
         useCache: useCache,
         projectIds,
@@ -51,7 +52,7 @@ export function makeGetIssueTagKeyValues({
       {
         orgSlug,
         tagKey: tag.key,
-        search: query,
+        search,
         dataset: Dataset.ISSUE_PLATFORM,
         useCache: useCache,
         projectIds,

--- a/static/app/views/issueList/utils/getIssueTagValues.tsx
+++ b/static/app/views/issueList/utils/getIssueTagValues.tsx
@@ -1,5 +1,15 @@
+import {useFetchOrganizationTagKeyValues} from 'sentry/actionCreators/tags';
+import type {Organization, PageFilters} from 'sentry/types';
 import type {Tag, TagValue} from 'sentry/types/group';
+import {getUtcDateString} from 'sentry/utils/dates';
 import {DEVICE_CLASS_TAG_VALUES, isDeviceClass} from 'sentry/utils/fields';
+import {Dataset} from 'sentry/views/alerts/rules/metric/types';
+
+type FetchIssueTagValuesParams = {
+  organization: Organization;
+  pageFilters: PageFilters;
+  useCache?: boolean;
+};
 
 /**
  * Returns a function that fetches tag values for a given tag key. Useful as
@@ -7,23 +17,78 @@ import {DEVICE_CLASS_TAG_VALUES, isDeviceClass} from 'sentry/utils/fields';
  *
  * Accepts a function that fetches tag values for a given tag key and search query.
  */
-export function makeGetIssueTagValues(
-  tagValueLoader: (key: string, search: string) => Promise<TagValue[]>
-) {
+export function makeGetIssueTagKeyValues({
+  organization,
+  pageFilters,
+  useCache = true,
+}: FetchIssueTagValuesParams): (tag: Tag, query: string) => Promise<string[]> {
   return async (tag: Tag, query: string): Promise<string[]> => {
+    const orgSlug = organization.slug;
+    const projectIds = pageFilters.projects.map(id => id.toString());
+    const endpointParams = {
+      start: pageFilters.datetime.start
+        ? getUtcDateString(pageFilters.datetime.start)
+        : undefined,
+      end: pageFilters.datetime.end
+        ? getUtcDateString(pageFilters.datetime.end)
+        : undefined,
+      statsPeriod: pageFilters.datetime.period,
+    };
+    const {data: eventsTagValues = []} = useFetchOrganizationTagKeyValues(
+      {
+        orgSlug,
+        tagKey: tag.key,
+        search: query,
+        dataset: Dataset.ERRORS,
+        useCache: useCache,
+        projectIds,
+        ...endpointParams,
+      },
+      {}
+    );
+
+    const {data: issuePlatformTagValues = []} = useFetchOrganizationTagKeyValues(
+      {
+        orgSlug,
+        tagKey: tag.key,
+        search: query,
+        dataset: Dataset.ISSUE_PLATFORM,
+        useCache: useCache,
+        projectIds,
+        ...endpointParams,
+      },
+      {}
+    );
+
     // device.class is stored as "numbers" in snuba, but we want to suggest high, medium,
     // and low search filter values because discover maps device.class to these values.
     if (isDeviceClass(tag.key)) {
-      return DEVICE_CLASS_TAG_VALUES;
+      return await Promise.resolve(DEVICE_CLASS_TAG_VALUES);
     }
-    const values = await tagValueLoader(tag.key, query);
-    return values.map(({value}) => {
-      // Truncate results to 5000 characters to avoid exceeding the max url query length
-      // The message attribute for example can be 8192 characters.
-      if (typeof value === 'string' && value.length > 5000) {
-        return value.substring(0, 5000);
-      }
-      return value;
+
+    const allTagValuesDict: Record<string, TagValue> = {};
+    eventsTagValues.forEach(value => {
+      allTagValuesDict[value.name] = value;
     });
+
+    issuePlatformTagValues.forEach(value => {
+      if (allTagValuesDict[value.name]) {
+        allTagValuesDict[value.name].count += value.count;
+      }
+      allTagValuesDict[value.name] = value;
+    });
+
+    const allTagValues = Object.values(allTagValuesDict);
+
+    return await Promise.resolve(
+      allTagValues.map(({value}) => {
+        // Truncate results to 5000 characters to avoid exceeding the max url query length
+        // The message attribute for example can be 8192 characters.
+        if (typeof value === 'string' && value.length > 5000) {
+          return value.substring(0, 5000);
+        }
+        return value;
+      })
+    );
   };
 }


### PR DESCRIPTION
This PR creates the new `useFetchOrganizationTagKeyValues` hook using `useApiQuery`. The reason for these changes are: 
1.  Replace the old `fetchTagValues` function in favor of a `useApiQuery` implementation
2. Utilize the new `Dataset` parameter to make faster and more accurate requests for tag values. 
