### PR TITLE
fix(query-builder): Improve behavior when multi-selecting with checboxes

### DIFF
--- a/static/app/components/searchQueryBuilder/hooks/useQueryBuilderState.tsx
+++ b/static/app/components/searchQueryBuilder/hooks/useQueryBuilderState.tsx
@@ -318,7 +318,7 @@ function updateFilterMultipleValues(
     new Set(values.filter(value => value.length > 0))
   );
   if (uniqNonEmptyValues.length === 0) {
-    return {...state, query: replaceQueryToken(state.query, token.value, '')};
+    return {...state, query: replaceQueryToken(state.query, token.value, '""')};
   }
 
   const newValue =
@@ -349,10 +349,10 @@ function multiSelectTokenValue(
       if (tokenValue.text === action.value) {
         return updateFilterMultipleValues(state, action.token, ['']);
       }
-      return updateFilterMultipleValues(state, action.token, [
-        tokenValue.text,
-        action.value,
-      ]);
+      const newValue = tokenValue.value
+        ? [tokenValue.text, action.value]
+        : [action.value];
+      return updateFilterMultipleValues(state, action.token, newValue);
   }
 }
 

--- a/static/app/components/searchQueryBuilder/index.spec.tsx
+++ b/static/app/components/searchQueryBuilder/index.spec.tsx
@@ -1164,6 +1164,56 @@ describe('SearchQueryBuilder', function () {
         expect(within(valueButton).getByText('Chrome')).toBeInTheDocument();
       });
 
+      it('keeps focus inside value when multi-selecting with checkboxes', async function () {
+        render(
+          <SearchQueryBuilder {...defaultProps} initialQuery="browser.name:firefox" />
+        );
+
+        await userEvent.click(
+          screen.getByRole('button', {name: 'Edit value for filter: browser.name'})
+        );
+        // Input value should start with previous value and appended ','
+        await waitFor(() => {
+          expect(screen.getByRole('combobox', {name: 'Edit filter value'})).toHaveValue(
+            'firefox,'
+          );
+        });
+
+        // Toggling off the "firefox" option should:
+        // - Commit an empty string as the filter value
+        // - Input value should be cleared
+        // - Keep focus inside the input
+        await userEvent.click(
+          await screen.findByRole('checkbox', {name: 'Toggle firefox'})
+        );
+        expect(
+          await screen.findByRole('row', {name: 'browser.name:""'})
+        ).toBeInTheDocument();
+        await waitFor(() => {
+          expect(screen.getByRole('combobox', {name: 'Edit filter value'})).toHaveValue(
+            ''
+          );
+        });
+        expect(screen.getByRole('combobox', {name: 'Edit filter value'})).toHaveFocus();
+
+        // Toggling on the "Chrome" option should:
+        // - Commit the value "Chrome" to the filter
+        // - Input value should be "Chrome,"
+        // - Keep focus inside the input
+        await userEvent.click(
+          await screen.findByRole('checkbox', {name: 'Toggle Chrome'})
+        );
+        expect(
+          await screen.findByRole('row', {name: 'browser.name:Chrome'})
+        ).toBeInTheDocument();
+        await waitFor(() => {
+          expect(screen.getByRole('combobox', {name: 'Edit filter value'})).toHaveValue(
+            'Chrome,'
+          );
+        });
+        expect(screen.getByRole('combobox', {name: 'Edit filter value'})).toHaveFocus();
+      });
+
       it('collapses many selected options', function () {
         render(
           <SearchQueryBuilder

--- a/static/app/components/searchQueryBuilder/tokens/filter/valueCombobox.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/valueCombobox.tsx
@@ -675,7 +675,11 @@ function ItemCheckbox({
   const {dispatch} = useSearchQueryBuilder();
 
   return (
-    <TrailingWrap onPointerUp={e => e.stopPropagation()}>
+    <TrailingWrap
+      onPointerUp={e => e.stopPropagation()}
+      onMouseUp={e => e.stopPropagation()}
+      onClick={e => e.stopPropagation()}
+    >
       <CheckWrap visible={isFocused || selected} role="presentation">
         <Checkbox
           size="sm"
@@ -688,7 +692,7 @@ function ItemCheckbox({
               value: escapeTagValue(value),
             });
           }}
-          aria-label={t('Select %s', value)}
+          aria-label={t('Toggle %s', value)}
           tabIndex={-1}
         />
       </CheckWrap>


### PR DESCRIPTION
Fixes a couple issues related to using the checkboxes to toggle values: 

1. When using it to select the first value, it used to keep the empty value and would show `,value,`
2. When using it to toggle off all values, the filter would end up with no value at all (when it should have an empty string `""`)

Added a test that should prevent this from regressing