### PR TITLE
feat(issue-search): Remove `groups.enable-post-update-signal`

### DIFF
--- a/src/sentry/api/helpers/group_index/update.py
+++ b/src/sentry/api/helpers/group_index/update.py
@@ -10,13 +10,12 @@ from urllib.parse import urlparse
 import rest_framework
 from django.db import IntegrityError, router, transaction
 from django.db.models import Q
-from django.db.models.signals import post_save
 from django.utils import timezone as django_timezone
 from rest_framework import serializers
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from sentry import analytics, features, options
+from sentry import analytics, features
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.actor import ActorSerializer, ActorSerializerResponse
 from sentry.db.models.query import create_or_update
@@ -527,13 +526,6 @@ def update_groups(
                 group.status = GroupStatus.RESOLVED
                 group.substatus = None
                 group.resolved_at = now
-                if affected and not options.get("groups.enable-post-update-signal"):
-                    post_save.send(
-                        sender=Group,
-                        instance=group,
-                        created=False,
-                        update_fields=["resolved_at", "status", "substatus"],
-                    )
                 remove_group_from_inbox(
                     group, action=GroupInboxRemoveAction.RESOLVED, user=acting_user
                 )

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -15,7 +15,6 @@ from django.core.cache import cache
 from django.core.exceptions import ValidationError
 from django.db import IntegrityError, OperationalError, connection, router, transaction
 from django.db.models import Func, Max
-from django.db.models.signals import post_save
 from django.utils.encoding import force_str
 from urllib3.exceptions import MaxRetryError, TimeoutError
 from usageaccountant import UsageUnit
@@ -2156,13 +2155,6 @@ def _handle_regression(group: Group, event: BaseEvent, release: Release | None) 
             transition_type="automatic",
             sender="handle_regression",
         )
-        if not options.get("groups.enable-post-update-signal"):
-            post_save.send(
-                sender=Group,
-                instance=group,
-                created=False,
-                update_fields=["last_seen", "active_at", "status", "substatus"],
-            )
 
     follows_semver = False
     resolved_in_activity = None

--- a/src/sentry/issues/escalating.py
+++ b/src/sentry/issues/escalating.py
@@ -12,7 +12,6 @@ from datetime import datetime, timedelta
 from typing import Any, TypedDict
 
 import jsonschema
-from django.db.models.signals import post_save
 from snuba_sdk import (
     Column,
     Condition,
@@ -28,7 +27,7 @@ from snuba_sdk import (
 )
 from snuba_sdk.expressions import Granularity
 
-from sentry import features, options
+from sentry import features
 from sentry.eventstore.models import GroupEvent
 from sentry.issues.escalating_group_forecast import EscalatingGroupForecast
 from sentry.issues.escalating_issues_alg import GroupCount
@@ -507,13 +506,6 @@ def manage_issue_states(
         if updated:
             group.status = GroupStatus.UNRESOLVED
             group.substatus = GroupSubStatus.ESCALATING
-            if not options.get("groups.enable-post-update-signal"):
-                post_save.send(
-                    sender=Group,
-                    instance=group,
-                    created=False,
-                    update_fields=["status", "substatus"],
-                )
             add_group_to_inbox(group, GroupInboxReason.ESCALATING, snooze_details)
             record_group_history(group, GroupHistoryStatus.ESCALATING)
 
@@ -553,13 +545,6 @@ def manage_issue_states(
         if updated:
             group.status = GroupStatus.UNRESOLVED
             group.substatus = GroupSubStatus.ONGOING
-            if not options.get("groups.enable-post-update-signal"):
-                post_save.send(
-                    sender=Group,
-                    instance=group,
-                    created=False,
-                    update_fields=["status", "substatus"],
-                )
             add_group_to_inbox(group, GroupInboxReason.ONGOING, snooze_details)
             record_group_history(group, GroupHistoryStatus.ONGOING)
 
@@ -574,13 +559,6 @@ def manage_issue_states(
         if updated:
             group.status = GroupStatus.UNRESOLVED
             group.substatus = GroupSubStatus.ONGOING
-            if not options.get("groups.enable-post-update-signal"):
-                post_save.send(
-                    sender=Group,
-                    instance=group,
-                    created=False,
-                    update_fields=["status", "substatus"],
-                )
             add_group_to_inbox(group, GroupInboxReason.UNIGNORED, snooze_details)
             record_group_history(group, GroupHistoryStatus.UNIGNORED)
             Activity.objects.create_group_activity(

--- a/src/sentry/issues/ongoing.py
+++ b/src/sentry/issues/ongoing.py
@@ -2,9 +2,7 @@ from collections.abc import Mapping
 from typing import Any
 
 import sentry_sdk
-from django.db.models.signals import post_save
 
-from sentry import options
 from sentry.models.group import Group, GroupStatus
 from sentry.models.groupinbox import bulk_remove_groups_from_inbox
 from sentry.signals import issue_unresolved
@@ -53,13 +51,3 @@ def bulk_transition_group_to_ongoing(
 
     with sentry_sdk.start_span(description="bulk_remove_groups_from_inbox"):
         bulk_remove_groups_from_inbox(groups_to_transistion)
-
-    with sentry_sdk.start_span(description="post_save_send_robust"):
-        if not options.get("groups.enable-post-update-signal"):
-            for group in groups_to_transistion:
-                post_save.send_robust(
-                    sender=Group,
-                    instance=group,
-                    created=False,
-                    update_fields=["status", "substatus"],
-                )

--- a/src/sentry/issues/status_change.py
+++ b/src/sentry/issues/status_change.py
@@ -4,9 +4,6 @@ from collections import defaultdict, namedtuple
 from collections.abc import Sequence
 from typing import Any
 
-from django.db.models.signals import post_save
-
-from sentry import options
 from sentry.models.activity import Activity
 from sentry.models.group import Group, GroupStatus
 from sentry.models.grouphistory import record_group_history_from_activity_type
@@ -122,14 +119,6 @@ def handle_status_update(
         if new_status == GroupStatus.UNRESOLVED:
             kick_off_status_syncs.apply_async(
                 kwargs={"project_id": group.project_id, "group_id": group.id}
-            )
-
-        if not options.get("groups.enable-post-update-signal"):
-            post_save.send(
-                sender=Group,
-                instance=group,
-                created=False,
-                update_fields=["status", "substatus"],
             )
 
     return ActivityInfo(activity_type, activity_data)

--- a/src/sentry/models/activity.py
+++ b/src/sentry/models/activity.py
@@ -8,10 +8,8 @@ from typing import TYPE_CHECKING, Any, ClassVar
 from django.conf import settings
 from django.db import models
 from django.db.models import F
-from django.db.models.signals import post_save
 from django.utils import timezone
 
-from sentry import options
 from sentry.backup.scopes import RelocationScope
 from sentry.db.models import (
     BoundedPositiveIntegerField,
@@ -169,26 +167,14 @@ class Activity(Model):
 
         # HACK: support Group.num_comments
         if self.type == ActivityType.NOTE.value:
-            from sentry.models.group import Group
-
             self.group.update(num_comments=F("num_comments") + 1)
-            if not options.get("groups.enable-post-update-signal"):
-                post_save.send_robust(
-                    sender=Group, instance=self.group, created=True, update_fields=["num_comments"]
-                )
 
     def delete(self, *args, **kwargs):
         super().delete(*args, **kwargs)
 
         # HACK: support Group.num_comments
         if self.type == ActivityType.NOTE.value:
-            from sentry.models.group import Group
-
             self.group.update(num_comments=F("num_comments") - 1)
-            if not options.get("groups.enable-post-update-signal"):
-                post_save.send_robust(
-                    sender=Group, instance=self.group, created=True, update_fields=["num_comments"]
-                )
 
     def send_notification(self):
         activity.send_activity_notifications.delay(self.id)

--- a/src/sentry/models/group.py
+++ b/src/sentry/models/group.py
@@ -22,7 +22,7 @@ from django.utils.http import urlencode
 from django.utils.translation import gettext_lazy as _
 from snuba_sdk import Column, Condition, Op
 
-from sentry import eventstore, eventtypes, options, tagstore
+from sentry import eventstore, eventtypes, tagstore
 from sentry.backup.scopes import RelocationScope
 from sentry.constants import DEFAULT_LOGGER_NAME, LOG_LEVELS, MAX_CULPRIT_LENGTH
 from sentry.db.models import (
@@ -305,13 +305,6 @@ def get_recommended_event_for_environments(
 
 class GroupManager(BaseManager["Group"]):
     use_for_related_fields = True
-
-    def get_queryset(self):
-        return (
-            super()
-            .get_queryset()
-            .with_post_update_signal(options.get("groups.enable-post-update-signal"))
-        )
 
     def by_qualified_short_id(self, organization_id: int, short_id: str):
         return self.by_qualified_short_id_bulk(organization_id, [short_id])[0]

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -2374,7 +2374,7 @@ register(
 # Enable sending a post update signal after we update groups using a queryset update
 register(
     "groups.enable-post-update-signal",
-    default=False,
+    default=True,
     flags=FLAG_BOOL | FLAG_AUTOMATOR_MODIFIABLE,
 )
 

--- a/tests/sentry/issues/test_attributes.py
+++ b/tests/sentry/issues/test_attributes.py
@@ -224,12 +224,7 @@ class PostUpdateLogGroupAttributesChangedTest(TestCase):
         with patch(
             "sentry.issues.attributes._log_group_attributes_changed"
         ) as _log_group_attributes_changed:
-            with override_options(
-                {
-                    "groups.enable-post-update-signal": True,
-                    "issues.group_attributes.send_kafka": True,
-                }
-            ):
+            with override_options({"issues.group_attributes.send_kafka": True}):
                 Group.objects.filter(id__in=[g.id for g in groups]).update(**update_fields)
             _log_group_attributes_changed.assert_called_with(
                 Operation.UPDATED, "group", expected_str


### PR DESCRIPTION
Remove references to `groups.enable-post-update-signal` and enable the option globally. This allows us to stop sending custom post-update signals since the call to `.update` will send the signal inherently. 

The option configurations will be removed in followup PR after which the option can be unregistered. 