### PR TITLE
fix(metrics): don't implicitly tag comparative filters in span metric extraction

### DIFF
--- a/src/sentry/snuba/metrics/span_attribute_extraction.py
+++ b/src/sentry/snuba/metrics/span_attribute_extraction.py
@@ -94,7 +94,7 @@ def convert_to_metric_spec(extraction_rule: MetricsExtractionRule) -> SpanAttrib
         "category": "span",
         "mri": extraction_rule.generate_mri(),
         "field": _get_field(extraction_rule),
-        "tags": _get_tags(extraction_rule, parsed_search_query),
+        "tags": _get_tags(extraction_rule, extended_search_query),
         "condition": _get_rule_condition(extraction_rule, extended_search_query),
     }
 
@@ -126,7 +126,7 @@ def _flatten_query_tokens(parsed_search_query: Sequence[QueryToken]) -> list[Sea
     query_tokens: list[SearchFilter] = []
 
     for token in parsed_search_query:
-        if isinstance(token, SearchFilter):
+        if isinstance(token, SearchFilter) and token.operator not in (">", ">=", "<", "<="):
             query_tokens.append(token)
         elif isinstance(token, ParenExpression):
             query_tokens = query_tokens + _flatten_query_tokens(token.children)

--- a/tests/sentry/snuba/metrics/test_span_attribute_extraction.py
+++ b/tests/sentry/snuba/metrics/test_span_attribute_extraction.py
@@ -248,6 +248,8 @@ def test_greater_than_conditions():
             {"op": "lte", "name": "span.data.bar", "value": 456},
         ],
     }
+    tags = [tag["key"] for tag in metric_spec["tags"]]
+    assert "foo" not in tags
 
 
 def test_mixed_conditions():


### PR DESCRIPTION
Fixes the fact that https://github.com/getsentry/sentry/pull/74493 did not actually prevent span attributes from being implicitly tagged