### PR TITLE
fix(profiling): Do not emit accepted outcome for unsampled profiles

### DIFF
--- a/src/sentry/profiles/task.py
+++ b/src/sentry/profiles/task.py
@@ -182,13 +182,14 @@ def process_profile_task(
     if not _push_profile_to_vroom(profile, project):
         return
 
-    with metrics.timer("process_profile.track_outcome.accepted"):
-        try:
-            _track_duration_outcome(profile=profile, project=project)
-        except Exception as e:
-            sentry_sdk.capture_exception(e)
-        if profile.get("version") != "2":
-            _track_outcome(profile=profile, project=project, outcome=Outcome.ACCEPTED)
+    if sampled:
+        with metrics.timer("process_profile.track_outcome.accepted"):
+            try:
+                _track_duration_outcome(profile=profile, project=project)
+            except Exception as e:
+                sentry_sdk.capture_exception(e)
+            if profile.get("version") != "2":
+                _track_outcome(profile=profile, project=project, outcome=Outcome.ACCEPTED)
 
 
 JS_PLATFORMS = ["javascript", "node"]


### PR DESCRIPTION
Unsampled profiles do not get indexed. So even if they are successfully processed, do not emit an accepted outcome for them. This also has the implication that the first unsampled profile will not mark a project as having sent a profile which is to be expected.