### PR TITLE
chore(features) Remove FeatureManager.has_for_batch

### DIFF
--- a/src/sentry/api/serializers/models/project.py
+++ b/src/sentry/api/serializers/models/project.py
@@ -179,7 +179,7 @@ def get_environments_by_projects(projects: Sequence[Project]) -> MutableMapping[
 def get_features_for_projects(
     all_projects: Sequence[Project], user: User, filter_unused_on_frontend_features: bool = False
 ) -> MutableMapping[Project, list[str]]:
-    # Arrange to call features.has_for_batch rather than features.has
+    # Arrange to call features.batch_has rather than features.has
     # for performance's sake
     projects_by_org = defaultdict(list)
     for project in all_projects:
@@ -220,9 +220,8 @@ def get_features_for_projects(
             continue
         abbreviated_feature = feature_name[len(_PROJECT_SCOPE_PREFIX) :]
         for organization, projects in projects_by_org.items():
-            result = features.has_for_batch(feature_name, organization, projects, user)
-            for project, flag in result.items():
-                if flag:
+            if features.has(feature_name, organization, projects, user):
+                for project in projects:
                     features_by_project[project].append(abbreviated_feature)
 
     for project in all_projects:

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -73,4 +73,3 @@ batch_has = default_manager.batch_has
 all = default_manager.all
 add_handler = default_manager.add_handler
 add_entity_handler = default_manager.add_entity_handler
-has_for_batch = default_manager.has_for_batch

--- a/src/sentry/features/handler.py
+++ b/src/sentry/features/handler.py
@@ -10,7 +10,6 @@ from sentry.users.services.user import RpcUser
 
 if TYPE_CHECKING:
     from sentry.features.base import Feature
-    from sentry.features.manager import FeatureCheckBatch
     from sentry.models.organization import Organization
     from sentry.models.project import Project
     from sentry.models.user import User
@@ -30,13 +29,6 @@ class FeatureHandler:
         self, feature: Feature, actor: User | RpcUser, skip_entity: bool | None = False
     ) -> bool | None:
         raise NotImplementedError
-
-    def has_for_batch(self, batch: FeatureCheckBatch) -> Mapping[Project, bool | None]:
-        # If not overridden, iterate over objects in the batch individually.
-        return {
-            obj: self.has(feature, batch.actor)
-            for (obj, feature) in batch.get_feature_objects().items()
-        }
 
     @abc.abstractmethod
     def batch_has(
@@ -65,7 +57,3 @@ class BatchFeatureHandler(FeatureHandler):
 
     def has(self, feature: Feature, actor: User, skip_entity: bool | None = False) -> bool | None:
         return self._check_for_batch(feature.name, feature.get_subject(), actor)
-
-    def has_for_batch(self, batch: FeatureCheckBatch) -> Mapping[Project, bool | None]:
-        flag = self._check_for_batch(batch.feature_name, batch.subject, batch.actor)
-        return {obj: flag for obj in batch.objects}

--- a/tests/sentry/api/serializers/test_project.py
+++ b/tests/sentry/api/serializers/test_project.py
@@ -204,7 +204,6 @@ class ProjectSerializerTest(TestCase):
         mock_features.all = test_features.all
         mock_features.has = test_features.has
         mock_features.batch_has = test_features.batch_has
-        mock_features.has_for_batch = test_features.has_for_batch
 
         early_flag = "projects:TEST_early"
         red_flag = "projects:TEST_red"

--- a/tests/sentry/features/test_manager.py
+++ b/tests/sentry/features/test_manager.py
@@ -155,10 +155,6 @@ class FeatureManagerTest(TestCase):
         assert manager.has(project_flag, p3, actor=test_user) is True
         assert manager.has(project_flag, p4, actor=test_user) is False
 
-        assert manager.has_for_batch(
-            project_flag, mock.sentinel.organization, [p1, p2, p3, p4], actor=test_user
-        ) == {p1: True, p2: False, p3: True, p4: False}
-
     def test_entity_handler(self):
         test_org = self.create_organization()
         # Add a registered handler
@@ -197,62 +193,6 @@ class FeatureManagerTest(TestCase):
         with mock.patch.dict(settings.SENTRY_FEATURES, {"organizations:settings-feature": "test"}):
             assert manager.has("organizations:settings-feature", test_org) == "test"
             assert len(entity_handler.mock_calls) == 2
-
-    def test_has_for_batch(self):
-        test_user = self.create_user()
-        test_org = self.create_organization()
-
-        projects = [self.create_project(organization=test_org) for i in range(5)]
-
-        def create_handler(flags, result):
-            class OrganizationTestHandler(features.BatchFeatureHandler):
-                features = set(flags)
-
-                def __init__(self):
-                    self.hit_counter = 0
-
-                def _check_for_batch(self, feature_name, organization, actor):
-                    assert feature_name in self.features
-                    assert organization == test_org
-                    assert actor == test_user
-
-                    self.hit_counter += 1
-                    return result
-
-                def batch_has(self, *a, **k):
-                    raise NotImplementedError("unreachable")
-
-            return OrganizationTestHandler()
-
-        yes_flag = "organizations:yes"
-        no_flag = "organizations:no"
-
-        null_handler = create_handler([yes_flag, no_flag], None)
-        yes_handler = create_handler([yes_flag], True)
-        after_yes_handler = create_handler([yes_flag], False)
-        no_handler = create_handler([no_flag], False)
-        after_no_handler = create_handler([no_flag], True)
-
-        manager = features.FeatureManager()
-        for flag in (yes_flag, no_flag):
-            manager.add(flag, OrganizationFeature)
-
-        for handler in (null_handler, yes_handler, after_yes_handler, no_handler, after_no_handler):
-            manager.add_handler(handler)
-
-        assert manager.has_for_batch(yes_flag, test_org, projects, actor=test_user) == {
-            p: True for p in projects
-        }
-        assert yes_handler.hit_counter == 1  # as opposed to len(projects)
-        assert after_yes_handler.hit_counter == 0
-
-        assert manager.has_for_batch(no_flag, test_org, projects, actor=test_user) == {
-            p: False for p in projects
-        }
-        assert no_handler.hit_counter == 1
-        assert after_no_handler.hit_counter == 0
-
-        assert null_handler.hit_counter == 2
 
     def test_batch_has(self):
         manager = features.FeatureManager()


### PR DESCRIPTION
This method is rarely used and `batch_has` fulfils the same role and is more widely used.