### PR TITLE
feat(uptime): Use organization level autodetection flag to gate whether we should run detection

### DIFF
--- a/src/sentry/uptime/detectors/detector.py
+++ b/src/sentry/uptime/detectors/detector.py
@@ -3,7 +3,11 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from sentry import features
-from sentry.uptime.detectors.ranking import add_base_url_to_rank, should_detect_for_project
+from sentry.uptime.detectors.ranking import (
+    add_base_url_to_rank,
+    should_detect_for_organization,
+    should_detect_for_project,
+)
 from sentry.uptime.detectors.url_extraction import extract_base_url
 from sentry.utils import metrics
 
@@ -14,9 +18,11 @@ if TYPE_CHECKING:
 def detect_base_url_for_project(project: Project, url: str) -> None:
     # Note: We might end up removing the `should_detect_for_project` check here if/when we decide to use detected
     # urls as suggestions as well.
-    if not features.has(
-        "organizations:uptime-automatic-hostname-detection", project.organization
-    ) or not should_detect_for_project(project):
+    if (
+        not features.has("organizations:uptime-automatic-hostname-detection", project.organization)
+        or not should_detect_for_project(project)
+        or not should_detect_for_organization(project.organization)
+    ):
         return
 
     base_url = extract_base_url(url)

--- a/src/sentry/uptime/detectors/ranking.py
+++ b/src/sentry/uptime/detectors/ranking.py
@@ -8,6 +8,7 @@ from django.conf import settings
 from redis.client import StrictRedis
 from rediscluster import RedisCluster
 
+from sentry.constants import UPTIME_AUTODETECTION
 from sentry.utils import redis
 
 if TYPE_CHECKING:
@@ -162,7 +163,8 @@ def delete_organization_bucket(bucket: datetime) -> None:
 
 
 def should_detect_for_organization(organization: Organization) -> bool:
-    # TODO: Check setting here
+    if not organization.get_option("sentry:uptime_autodetection", UPTIME_AUTODETECTION):
+        return False
     return True
 
 

--- a/tests/sentry/uptime/detectors/test_detector.py
+++ b/tests/sentry/uptime/detectors/test_detector.py
@@ -25,3 +25,9 @@ class DetectBaseUrlForProjectTest(TestCase):
         self.project.update_option("sentry:uptime_autodetection", False)
         detect_base_url_for_project(self.project, "https://sentry.io")
         self.assert_organization_key(self.organization, False)
+
+    @with_feature("organizations:uptime-automatic-hostname-detection")
+    def test_disabled_for_organization(self):
+        self.organization.update_option("sentry:uptime_autodetection", False)
+        detect_base_url_for_project(self.project, "https://sentry.io")
+        self.assert_organization_key(self.organization, False)

--- a/tests/sentry/uptime/detectors/test_ranking.py
+++ b/tests/sentry/uptime/detectors/test_ranking.py
@@ -14,6 +14,7 @@ from sentry.uptime.detectors.ranking import (
     get_candidate_urls_for_project,
     get_organization_bucket,
     get_project_base_url_rank_key,
+    should_detect_for_organization,
     should_detect_for_project,
 )
 
@@ -174,3 +175,12 @@ class ShouldDetectForProjectTest(TestCase):
         assert not should_detect_for_project(self.project)
         self.project.update_option("sentry:uptime_autodetection", True)
         assert should_detect_for_project(self.project)
+
+
+class ShouldDetectForOrgTest(TestCase):
+    def test(self):
+        assert should_detect_for_organization(self.organization)
+        self.organization.update_option("sentry:uptime_autodetection", False)
+        assert not should_detect_for_organization(self.organization)
+        self.organization.update_option("sentry:uptime_autodetection", True)
+        assert should_detect_for_organization(self.organization)


### PR DESCRIPTION
Respect the org level flag that controls whether to run detection or not.
