### PR TITLE
feat(insights): add release markings to fullscreen insight charts

### DIFF
--- a/static/app/components/modals/insightChartModal.tsx
+++ b/static/app/components/modals/insightChartModal.tsx
@@ -5,7 +5,7 @@ import styled from '@emotion/styled';
 
 import type {ModalRenderProps} from 'sentry/actionCreators/modal';
 import {space} from 'sentry/styles/space';
-import {ChartHeightContext} from 'sentry/views/insights/common/components/chart';
+import {ChartIsFullScreenContext} from 'sentry/views/insights/common/components/chart';
 
 export type InsightChartModalOptions = {
   children: React.ReactNode;
@@ -21,7 +21,9 @@ export default function InsightChartModal({Header, title, children}: Props) {
           <h3>{title}</h3>
         </Header>
 
-        <ChartHeightContext.Provider value={300}>{children}</ChartHeightContext.Provider>
+        <ChartIsFullScreenContext.Provider value>
+          {children}
+        </ChartIsFullScreenContext.Provider>
       </Container>
     </Fragment>
   );

--- a/static/app/views/insights/browser/resources/views/resourcesLandingPage.spec.tsx
+++ b/static/app/views/insights/browser/resources/views/resourcesLandingPage.spec.tsx
@@ -272,4 +272,17 @@ const setupMockRequests = (organization: Organization) => {
       },
     },
   });
+
+  MockApiClient.addMockResponse({
+    url: `/organizations/${organization.slug}/releases/stats/`,
+    method: 'GET',
+    body: {
+      data: [
+        {
+          version: '123456',
+          date: '2024-07-22T19:14:05.457044Z',
+        },
+      ],
+    },
+  });
 };

--- a/static/app/views/insights/browser/webVitals/components/charts/performanceScoreBreakdownChart.spec.tsx
+++ b/static/app/views/insights/browser/webVitals/components/charts/performanceScoreBreakdownChart.spec.tsx
@@ -53,6 +53,18 @@ describe('PerformanceScoreBreakdownChart', function () {
       url: `/organizations/${organization.slug}/events-stats/`,
       body: {},
     });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/releases/stats/`,
+      method: 'GET',
+      body: {
+        data: [
+          {
+            version: '123456',
+            date: '2024-07-22T19:14:05.457044Z',
+          },
+        ],
+      },
+    });
   });
 
   afterEach(function () {

--- a/static/app/views/insights/browser/webVitals/views/pageOverview.spec.tsx
+++ b/static/app/views/insights/browser/webVitals/views/pageOverview.spec.tsx
@@ -56,6 +56,18 @@ describe('PageOverview', function () {
       url: `/organizations/${organization.slug}/spans-aggregation/`,
       body: {},
     });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/releases/stats/`,
+      method: 'GET',
+      body: {
+        data: [
+          {
+            version: '123456',
+            date: '2024-07-22T19:14:05.457044Z',
+          },
+        ],
+      },
+    });
   });
 
   afterEach(function () {

--- a/static/app/views/insights/browser/webVitals/views/webVitalsLandingPage.spec.tsx
+++ b/static/app/views/insights/browser/webVitals/views/webVitalsLandingPage.spec.tsx
@@ -66,6 +66,18 @@ describe('WebVitalsLandingPage', function () {
       },
     });
     MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/releases/stats/`,
+      method: 'GET',
+      body: {
+        data: [
+          {
+            version: '123456',
+            date: '2024-07-22T19:14:05.457044Z',
+          },
+        ],
+      },
+    });
+    MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/events-stats/`,
       body: {},
     });

--- a/static/app/views/insights/cache/views/cacheLandingPage.spec.tsx
+++ b/static/app/views/insights/cache/views/cacheLandingPage.spec.tsx
@@ -397,4 +397,17 @@ const setRequestMocks = (organization: Organization) => {
     method: 'GET',
     body: [],
   });
+
+  MockApiClient.addMockResponse({
+    url: `/organizations/${organization.slug}/releases/stats/`,
+    method: 'GET',
+    body: {
+      data: [
+        {
+          version: '123456',
+          date: '2024-07-22T19:14:05.457044Z',
+        },
+      ],
+    },
+  });
 };

--- a/static/app/views/insights/common/components/chart.spec.tsx
+++ b/static/app/views/insights/common/components/chart.spec.tsx
@@ -5,6 +5,18 @@ import MarkLine from 'sentry/components/charts/components/markLine';
 import type {Series} from 'sentry/types/echarts';
 import Chart, {ChartType} from 'sentry/views/insights/common/components/chart';
 
+jest.mock('sentry/components/charts/releaseSeries', () => {
+  return jest.fn().mockImplementation(({children}) => children({releaseSeries: []}));
+});
+jest.mock('sentry/components/charts/baseChart', () => {
+  return jest.fn().mockImplementation(() => <div />);
+});
+jest.mock('react', () => {
+  return {
+    ...jest.requireActual('react'),
+    useRef: jest.fn(),
+  };
+});
 // XXX: Mocking useRef throws an error for AnimatePrecense, so it must be mocked as well
 jest.mock('framer-motion', () => {
   return {
@@ -14,23 +26,6 @@ jest.mock('framer-motion', () => {
 });
 
 describe('Chart', function () {
-  beforeEach(() => {
-    jest.clearAllMocks();
-
-    MockApiClient.addMockResponse({
-      url: `/organizations/org-slug/releases/stats/`,
-      method: 'GET',
-      body: {
-        data: [
-          {
-            version: '123456',
-            date: '2024-07-22T19:14:05.457044Z',
-          },
-        ],
-      },
-    });
-  });
-
   test('it shows an error panel if an error prop is supplied', function () {
     const parsingError = new Error('Could not parse chart data');
 

--- a/static/app/views/insights/common/components/chart.spec.tsx
+++ b/static/app/views/insights/common/components/chart.spec.tsx
@@ -5,15 +5,6 @@ import MarkLine from 'sentry/components/charts/components/markLine';
 import type {Series} from 'sentry/types/echarts';
 import Chart, {ChartType} from 'sentry/views/insights/common/components/chart';
 
-jest.mock('sentry/components/charts/baseChart', () => {
-  return jest.fn().mockImplementation(() => <div />);
-});
-jest.mock('react', () => {
-  return {
-    ...jest.requireActual('react'),
-    useRef: jest.fn(),
-  };
-});
 // XXX: Mocking useRef throws an error for AnimatePrecense, so it must be mocked as well
 jest.mock('framer-motion', () => {
   return {
@@ -23,6 +14,23 @@ jest.mock('framer-motion', () => {
 });
 
 describe('Chart', function () {
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/org-slug/releases/stats/`,
+      method: 'GET',
+      body: {
+        data: [
+          {
+            version: '123456',
+            date: '2024-07-22T19:14:05.457044Z',
+          },
+        ],
+      },
+    });
+  });
+
   test('it shows an error panel if an error prop is supplied', function () {
     const parsingError = new Error('Could not parse chart data');
 

--- a/static/app/views/insights/common/components/chart.tsx
+++ b/static/app/views/insights/common/components/chart.tsx
@@ -395,16 +395,6 @@ function Chart({
           onMouseOver={onMouseOver}
           onHighlight={onHighlight}
           series={[
-            ...(releaseSeries ?? []).map(({seriesName, data: seriesData, ...options}) =>
-              LineSeries({
-                ...options,
-                name: seriesName,
-                data: seriesData?.map(({value, name}) => [name, value]),
-                animation: false,
-                animationThreshold: 1,
-                animationDuration: 0,
-              })
-            ),
             ...series.map(({seriesName, data: seriesData, ...options}) =>
               LineSeries({
                 ...options,
@@ -424,6 +414,16 @@ function Chart({
               })
             ),
             ...incompleteSeries.map(({seriesName, data: seriesData, ...options}) =>
+              LineSeries({
+                ...options,
+                name: seriesName,
+                data: seriesData?.map(({value, name}) => [name, value]),
+                animation: false,
+                animationThreshold: 1,
+                animationDuration: 0,
+              })
+            ),
+            ...(releaseSeries ?? []).map(({seriesName, data: seriesData, ...options}) =>
               LineSeries({
                 ...options,
                 name: seriesName,
@@ -492,7 +492,7 @@ function Chart({
         forwardedRef={chartRef}
         height={height}
         {...zoomRenderProps}
-        series={[...series, ...(releaseSeries ?? []), ...incompleteSeries]}
+        series={[...series, ...incompleteSeries, ...(releaseSeries ?? [])]}
         previousPeriod={previousData}
         additionalSeries={transformedThroughput}
         xAxis={xAxis}

--- a/static/app/views/insights/database/views/databaseSpanSummaryPage.spec.tsx
+++ b/static/app/views/insights/database/views/databaseSpanSummaryPage.spec.tsx
@@ -137,6 +137,19 @@ describe('DatabaseSpanSummaryPage', function () {
       },
     });
 
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/releases/stats/`,
+      method: 'GET',
+      body: {
+        data: [
+          {
+            version: '123456',
+            date: '2024-07-22T19:14:05.457044Z',
+          },
+        ],
+      },
+    });
+
     render(
       <DatabaseSpanSummaryPage
         {...RouteComponentPropsFixture()}

--- a/static/app/views/insights/http/components/charts/responseCodeCountChart.tsx
+++ b/static/app/views/insights/http/components/charts/responseCodeCountChart.tsx
@@ -14,7 +14,7 @@ export function ResponseCodeCountChart({series, isLoading, error}: Props) {
   return (
     <ChartPanel title={t('Top 5 Response Codes')}>
       <Chart
-        showLegend
+        chartShowLegend
         height={CHART_HEIGHT}
         grid={{
           left: '4px',

--- a/static/app/views/insights/http/components/charts/responseRateChart.tsx
+++ b/static/app/views/insights/http/components/charts/responseRateChart.tsx
@@ -20,7 +20,7 @@ export function ResponseRateChart({series, isLoading, error}: Props) {
   return (
     <ChartPanel title={DataTitles.unsuccessfulHTTPCodes}>
       <Chart
-        showLegend
+        chartShowLegend
         height={CHART_HEIGHT}
         grid={{
           left: '4px',

--- a/static/app/views/insights/http/components/httpSamplesPanel.spec.tsx
+++ b/static/app/views/insights/http/components/httpSamplesPanel.spec.tsx
@@ -88,6 +88,18 @@ describe('HTTPSamplesPanel', () => {
         },
       },
     });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/releases/stats/`,
+      method: 'GET',
+      body: {
+        data: [
+          {
+            version: '123456',
+            date: '2024-07-22T19:14:05.457044Z',
+          },
+        ],
+      },
+    });
   });
 
   afterAll(() => {

--- a/static/app/views/insights/http/views/httpDomainSummaryPage.spec.tsx
+++ b/static/app/views/insights/http/views/httpDomainSummaryPage.spec.tsx
@@ -79,6 +79,19 @@ describe('HTTPSummaryPage', function () {
         },
       ],
     });
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/releases/stats/`,
+      method: 'GET',
+      body: {
+        data: [
+          {
+            version: '123456',
+            date: '2024-07-22T19:14:05.457044Z',
+          },
+        ],
+      },
+    });
   });
 
   afterAll(function () {

--- a/static/app/views/insights/http/views/httpLandingPage.spec.tsx
+++ b/static/app/views/insights/http/views/httpLandingPage.spec.tsx
@@ -91,6 +91,19 @@ describe('HTTPLandingPage', function () {
       },
     });
 
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/releases/stats/`,
+      method: 'GET',
+      body: {
+        data: [
+          {
+            version: '123456',
+            date: '2024-07-22T19:14:05.457044Z',
+          },
+        ],
+      },
+    });
+
     spanListRequestMock = MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/events/`,
       method: 'GET',

--- a/static/app/views/insights/mobile/appStarts/components/charts/countChart.tsx
+++ b/static/app/views/insights/mobile/appStarts/components/charts/countChart.tsx
@@ -141,7 +141,7 @@ export function CountChart({chartHeight}: Props) {
           top: space(2),
           bottom: '0',
         }}
-        showLegend
+        chartShowLegend
         definedAxisTicks={2}
         type={ChartType.LINE}
         aggregateOutputFormat={OUTPUT_TYPE[YAxis.COUNT]}

--- a/static/app/views/insights/mobile/appStarts/components/startDurationWidget.spec.tsx
+++ b/static/app/views/insights/mobile/appStarts/components/startDurationWidget.spec.tsx
@@ -66,6 +66,18 @@ describe('StartDurationWidget', () => {
         data: [],
       },
     });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/releases/stats/`,
+      method: 'GET',
+      body: {
+        data: [
+          {
+            version: '123456',
+            date: '2024-07-22T19:14:05.457044Z',
+          },
+        ],
+      },
+    });
   });
 
   afterEach(function () {

--- a/static/app/views/insights/mobile/appStarts/components/startDurationWidget.tsx
+++ b/static/app/views/insights/mobile/appStarts/components/startDurationWidget.tsx
@@ -148,7 +148,7 @@ function StartDurationWidget({additionalFilters, chartHeight}: Props) {
           top: space(2),
           bottom: '0',
         }}
-        showLegend
+        chartShowLegend
         definedAxisTicks={2}
         type={ChartType.LINE}
         aggregateOutputFormat="duration"

--- a/static/app/views/insights/mobile/appStarts/views/screenSummaryPage.spec.tsx
+++ b/static/app/views/insights/mobile/appStarts/views/screenSummaryPage.spec.tsx
@@ -73,6 +73,18 @@ describe('Screen Summary', function () {
       eventsMock = MockApiClient.addMockResponse({
         url: `/organizations/${organization.slug}/events/`,
       });
+      MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/releases/stats/`,
+        method: 'GET',
+        body: {
+          data: [
+            {
+              version: '123456',
+              date: '2024-07-22T19:14:05.457044Z',
+            },
+          ],
+        },
+      });
     });
 
     afterEach(() => {

--- a/static/app/views/insights/mobile/screenload/components/charts/screenCharts.tsx
+++ b/static/app/views/insights/mobile/screenload/components/charts/screenCharts.tsx
@@ -247,7 +247,7 @@ export function ScreenCharts({yAxes, additionalFilters}: Props) {
                       top: '8px',
                       bottom: '0',
                     }}
-                    showLegend
+                    chartShowLegend
                     definedAxisTicks={2}
                     type={ChartType.LINE}
                     aggregateOutputFormat={OUTPUT_TYPE[YAxis.TTID]}
@@ -315,7 +315,7 @@ export function ScreenCharts({yAxes, additionalFilters}: Props) {
                       top: '8px',
                       bottom: '0',
                     }}
-                    showLegend
+                    chartShowLegend
                     definedAxisTicks={2}
                     type={ChartType.LINE}
                     aggregateOutputFormat={OUTPUT_TYPE[YAxis.TTFD]}
@@ -357,7 +357,7 @@ export function ScreenCharts({yAxes, additionalFilters}: Props) {
                   top: '8px',
                   bottom: '0',
                 }}
-                showLegend
+                chartShowLegend
                 definedAxisTicks={2}
                 type={ChartType.LINE}
                 aggregateOutputFormat={OUTPUT_TYPE[YAxis.COUNT]}

--- a/static/app/views/insights/mobile/screenload/views/screenLoadSpansPage.spec.tsx
+++ b/static/app/views/insights/mobile/screenload/views/screenLoadSpansPage.spec.tsx
@@ -104,6 +104,18 @@ function mockResponses(organization, project) {
       ],
     },
   });
+  MockApiClient.addMockResponse({
+    url: `/organizations/${organization.slug}/releases/stats/`,
+    method: 'GET',
+    body: {
+      data: [
+        {
+          version: '123456',
+          date: '2024-07-22T19:14:05.457044Z',
+        },
+      ],
+    },
+  });
 }
 
 describe('Screen Summary', function () {

--- a/static/app/views/insights/queues/charts/latencyChart.spec.tsx
+++ b/static/app/views/insights/queues/charts/latencyChart.spec.tsx
@@ -18,6 +18,18 @@ describe('latencyChart', () => {
         data: [],
       },
     });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/releases/stats/`,
+      method: 'GET',
+      body: {
+        data: [
+          {
+            version: '123456',
+            date: '2024-07-22T19:14:05.457044Z',
+          },
+        ],
+      },
+    });
   });
   it('renders', async () => {
     render(

--- a/static/app/views/insights/queues/charts/latencyChart.tsx
+++ b/static/app/views/insights/queues/charts/latencyChart.tsx
@@ -44,7 +44,7 @@ export function LatencyChart({error, destination, referrer}: Props) {
         error={error}
         chartColors={CHART_PALETTE[2].slice(1)}
         type={ChartType.AREA}
-        showLegend
+        chartShowLegend
         stacked
         aggregateOutputFormat="duration"
       />

--- a/static/app/views/insights/queues/charts/throughputChart.spec.tsx
+++ b/static/app/views/insights/queues/charts/throughputChart.spec.tsx
@@ -18,6 +18,18 @@ describe('throughputChart', () => {
         data: [],
       },
     });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/releases/stats/`,
+      method: 'GET',
+      body: {
+        data: [
+          {
+            version: '123456',
+            date: '2024-07-22T19:14:05.457044Z',
+          },
+        ],
+      },
+    });
   });
   it('renders', async () => {
     render(<ThroughputChart referrer={Referrer.QUEUES_SUMMARY_CHARTS} />, {organization});

--- a/static/app/views/insights/queues/charts/throughputChart.tsx
+++ b/static/app/views/insights/queues/charts/throughputChart.tsx
@@ -57,7 +57,7 @@ export function ThroughputChart({error, destination, referrer}: Props) {
         tooltipFormatterOptions={{
           valueFormatter: value => formatRate(value, RateUnit.PER_MINUTE),
         }}
-        showLegend
+        chartShowLegend
       />
     </ChartPanel>
   );

--- a/static/app/views/insights/queues/components/messageSpanSamplesPanel.spec.tsx
+++ b/static/app/views/insights/queues/components/messageSpanSamplesPanel.spec.tsx
@@ -95,6 +95,19 @@ describe('messageSpanSamplesPanel', () => {
       },
     });
 
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/releases/stats/`,
+      method: 'GET',
+      body: {
+        data: [
+          {
+            version: '123456',
+            date: '2024-07-22T19:14:05.457044Z',
+          },
+        ],
+      },
+    });
+
     samplesRequestMock = MockApiClient.addMockResponse({
       url: `/api/0/organizations/${organization.slug}/spans-samples/`,
       method: 'GET',

--- a/static/app/views/insights/queues/views/destinationSummaryPage.spec.tsx
+++ b/static/app/views/insights/queues/views/destinationSummaryPage.spec.tsx
@@ -82,6 +82,18 @@ describe('destinationSummaryPage', () => {
         },
       ],
     });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/releases/stats/`,
+      method: 'GET',
+      body: {
+        data: [
+          {
+            version: '123456',
+            date: '2024-07-22T19:14:05.457044Z',
+          },
+        ],
+      },
+    });
   });
 
   it('renders', async () => {

--- a/static/app/views/insights/queues/views/queuesLandingPage.spec.tsx
+++ b/static/app/views/insights/queues/views/queuesLandingPage.spec.tsx
@@ -71,6 +71,19 @@ describe('queuesLandingPage', () => {
       method: 'GET',
       body: {data: []},
     });
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/releases/stats/`,
+      method: 'GET',
+      body: {
+        data: [
+          {
+            version: '123456',
+            date: '2024-07-22T19:14:05.457044Z',
+          },
+        ],
+      },
+    });
   });
 
   it('renders', async () => {

--- a/static/app/views/performance/landing/widgets/widgets/mobileReleaseComparisonListWidget.tsx
+++ b/static/app/views/performance/landing/widgets/widgets/mobileReleaseComparisonListWidget.tsx
@@ -306,7 +306,7 @@ function MobileReleaseComparisonListWidget(props: PerformanceWidgetProps) {
         }}
         error={provided.widgetData.chart.error}
         disableXAxis
-        showLegend={false}
+        chartShowLegend={false}
       />
     );
   };

--- a/static/app/views/performance/transactionSummary/transactionSpans/spanSummary/content.spec.tsx
+++ b/static/app/views/performance/transactionSummary/transactionSpans/spanSummary/content.spec.tsx
@@ -181,6 +181,19 @@ describe('SpanSummaryPage', function () {
       },
     });
 
+    releaseSeriesRequestMock = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/releases/stats/`,
+      method: 'GET',
+      body: {
+        data: [
+          {
+            version: '123456',
+            date: '2024-07-22T19:14:05.457044Z',
+          },
+        ],
+      },
+    });
+
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/events/',
       body: {

--- a/static/app/views/traces/tracesChart.tsx
+++ b/static/app/views/traces/tracesChart.tsx
@@ -102,7 +102,7 @@ export function TracesChart({}: Props) {
           chartColors={CHART_PALETTE[2]}
           type={ChartType.LINE}
           aggregateOutputFormat="number"
-          showLegend
+          chartShowLegend
           tooltipFormatterOptions={{
             valueFormatter: value => tooltipFormatter(value),
           }}


### PR DESCRIPTION
Adds release markings to the insights charts on fullscreen. This is similar to how we currently display releases on the performance page charts.

<img width="1063" alt="image" src="https://github.com/user-attachments/assets/d87ce2af-1b23-4c34-bfc0-b2a2fd668b32">

