### PR TITLE
fix(seer grouping): Fix flaky feature enablement test

### DIFF
--- a/tests/sentry/grouping/ingest/test_seer.py
+++ b/tests/sentry/grouping/ingest/test_seer.py
@@ -59,11 +59,15 @@ class ShouldCallSeerTest(TestCase):
             (False, True, 11211231, True),
             (True, True, 11211231, True),
         ]:
-            with Feature(
-                {
-                    "projects:similarity-embeddings-metadata": metadata_flag,
-                    "projects:similarity-embeddings-grouping": grouping_flag,
-                }
+            with (
+                Feature(
+                    {
+                        "projects:similarity-embeddings-metadata": metadata_flag,
+                        "projects:similarity-embeddings-grouping": grouping_flag,
+                    }
+                ),
+                # Having too many cases above makes us hit the project rate limit if we don't patch this
+                patch("sentry.grouping.ingest.seer._ratelimiting_enabled", return_value=False),
             ):
                 self.project.update_option(
                     "sentry:similarity_backfill_completed", backfill_completed_option


### PR DESCRIPTION
In the `test_obeys_feature_enablement_check` test, we currently check 8 cases, and if those checks happen fast enough, we end up hitting the project rate limit of 5 requests/sec. They sometimes do and sometimes don't, making the test flaky. This patches the rate limit check to always return `False` to get rid of the flake.