### PR TITLE
fix(insights): transaction names with quotes break caches

### DIFF
--- a/static/app/views/insights/cache/views/cacheLandingPage.tsx
+++ b/static/app/views/insights/cache/views/cacheLandingPage.tsx
@@ -134,7 +134,7 @@ export function CacheLandingPage() {
     isFetching: isTransactionDurationFetching,
   } = useMetrics(
     {
-      search: `transaction:[${transactionsList.map(({transaction}) => `"${transaction}"`).join(',')}]`,
+      search: `transaction:[${transactionsList.map(({transaction}) => `"${transaction.replaceAll('"', '\\"')}"`).join(',')}]`,
       fields: [`avg(transaction.duration)`, 'transaction'],
       enabled: !isTransactionsListFetching && transactionsList.length > 0,
     },


### PR DESCRIPTION
fixes #74554 

The above issue was a result in the transaction duration query sending the list of transactions without the quotes escaped .