### PR TITLE
add tests for parse rulegroup to event data

### DIFF
--- a/tests/sentry/rules/processing/test_delayed_processing.py
+++ b/tests/sentry/rules/processing/test_delayed_processing.py
@@ -575,19 +575,17 @@ class ParseRuleGroupToEventDataTest(TestCase):
             "occurrence_id": "1",
         }
 
-        self.input_data = {
+    def test_parse_rulegroup(self):
+        input_data = {
             f"{self.rule.id}:{self.group.id}": json.dumps(self.event_data),
             f"{self.rule_two.id}:{self.group_two.id}": json.dumps(self.event_data),
         }
 
-        self.expected = {
+        result = parse_rulegroup_to_event_data(input_data)
+        assert result == {
             (str(self.rule.id), str(self.group.id)): self.event_data,
             (str(self.rule_two.id), str(self.group_two.id)): self.event_data,
         }
-
-    def test_parse_rulegroup(self):
-        result = parse_rulegroup_to_event_data(self.input_data)
-        assert result == self.expected
 
     def test_parse_rulegroup_empty(self):
         input_data: dict[str, str] = {}

--- a/tests/sentry/rules/processing/test_delayed_processing.py
+++ b/tests/sentry/rules/processing/test_delayed_processing.py
@@ -32,6 +32,7 @@ from sentry.rules.processing.delayed_processing import (
     get_rules_to_groups,
     get_rules_to_slow_conditions,
     get_slow_conditions,
+    parse_rulegroup_to_event_data,
     process_delayed_alert_conditions,
 )
 from sentry.rules.processing.processor import PROJECT_ID_BUFFER_LIST_KEY
@@ -562,8 +563,46 @@ class GetSlowConditionsTest(RuleTestCase):
 
 
 class ParseRuleGroupToEventDataTest(TestCase):
-    def test_parse_rulegroup_to_event_data(self):
-        pass
+    def setUp(self):
+        self.project = self.create_project()
+        self.group = self.create_group(self.project)
+        self.group_two = self.create_group(self.project)
+        self.rule = self.create_alert_rule(self.organization, [self.project])
+        self.rule_two = self.create_alert_rule(self.organization, [self.project])
+
+        self.event_data = {
+            "event_id": "1",
+            "occurrence_id": "1",
+        }
+
+        self.input_data = {
+            f"{self.rule.id}:{self.group.id}": json.dumps(self.event_data),
+            f"{self.rule_two.id}:{self.group_two.id}": json.dumps(self.event_data),
+        }
+
+        self.expected = {
+            (str(self.rule.id), str(self.group.id)): self.event_data,
+            (str(self.rule_two.id), str(self.group_two.id)): self.event_data,
+        }
+
+    def test_parse_rulegroup(self):
+        result = parse_rulegroup_to_event_data(self.input_data)
+        assert result == self.expected
+
+    def test_parse_rulegroup_empty(self):
+        input_data: dict[str, str] = {}
+        result = parse_rulegroup_to_event_data(input_data)
+        assert result == {}
+
+    def test_parse_rulegroup_basic(self):
+        input_data = {f"{self.rule.id}:{self.group.id}": json.dumps(self.event_data)}
+        result = parse_rulegroup_to_event_data(input_data)
+        assert result == {(str(self.rule.id), str(self.group.id)): self.event_data}
+
+    def test_parse_rulegroup_invalid_json(self):
+        input_data = {f"{self.rule.id}:{self.group.id}": "}"}
+        with pytest.raises(json.JSONDecodeError):
+            parse_rulegroup_to_event_data(input_data)
 
 
 class ProcessDelayedAlertConditionsTest(CreateEventTestCase, PerformanceIssueTestCase):


### PR DESCRIPTION
## Description
Moar tests for 666, this is for the `parse_rulegroup_to_event_data` method - one more to go after this!