### PR TITLE
ref(seer): Refactor Seer request helper tests

### DIFF
--- a/tests/sentry/seer/test_signed_seer_api.py
+++ b/tests/sentry/seer/test_signed_seer_api.py
@@ -10,7 +10,7 @@ REQUEST_BODY = b'{"b": 12, "thing": "thing"}'
 PATH = "/v0/some/url"
 
 
-def run_test_case(timeout: int | None = None):
+def run_test_case(path: str = PATH, timeout: int | None = None):
     """
     Make a mock connection pool, call `make_signed_seer_api_request` on it, and return the
     pool's `urlopen` method, so we can make assertions on how `make_signed_seer_api_request`
@@ -23,7 +23,7 @@ def run_test_case(timeout: int | None = None):
     with override_settings(SEER_API_SHARED_SECRET="secret-one"):
         make_signed_seer_api_request(
             mock,
-            path=PATH,
+            path=path,
             body=REQUEST_BODY,
             timeout=timeout,
         )

--- a/tests/sentry/seer/test_signed_seer_api.py
+++ b/tests/sentry/seer/test_signed_seer_api.py
@@ -7,6 +7,7 @@ from sentry.seer.signed_seer_api import make_signed_seer_api_request
 from sentry.testutils.helpers import override_options
 
 REQUEST_BODY = b'{"b": 12, "thing": "thing"}'
+PATH = "/v0/some/url"
 
 
 def run_test_case(timeout: int | None = None):
@@ -22,7 +23,7 @@ def run_test_case(timeout: int | None = None):
     with override_settings(SEER_API_SHARED_SECRET="secret-one"):
         make_signed_seer_api_request(
             mock,
-            path="/v0/some/url",
+            path=PATH,
             body=REQUEST_BODY,
             timeout=timeout,
         )
@@ -35,7 +36,7 @@ def test_simple():
     mock_url_open = run_test_case()
     mock_url_open.assert_called_once_with(
         "POST",
-        "/v0/some/url",
+        PATH,
         body=REQUEST_BODY,
         headers={"content-type": "application/json;charset=utf-8"},
     )
@@ -46,7 +47,7 @@ def test_uses_given_timeout():
     mock_url_open = run_test_case(timeout=5)
     mock_url_open.assert_called_once_with(
         "POST",
-        "/v0/some/url",
+        PATH,
         body=REQUEST_BODY,
         headers={"content-type": "application/json;charset=utf-8"},
         timeout=5,
@@ -59,7 +60,7 @@ def test_uses_shared_secret():
         mock_url_open = run_test_case()
         mock_url_open.assert_called_once_with(
             "POST",
-            "/v0/some/url",
+            PATH,
             body=REQUEST_BODY,
             headers={
                 "content-type": "application/json;charset=utf-8",

--- a/tests/sentry/seer/test_signed_seer_api.py
+++ b/tests/sentry/seer/test_signed_seer_api.py
@@ -12,6 +12,11 @@ def test_make_signed_seer_api_request():
     body = b'{"b": 12, "thing": "thing"}'
 
     def run_test_case(timeout: int | None = None):
+        """
+        Make a mock connection pool, call `make_signed_seer_api_request` on it, and return the
+        pool's `urlopen` method, so we can make assertions on how `make_signed_seer_api_request`
+        used it.
+        """
         mock = Mock()
         mock.host = "localhost"
         mock.port = None

--- a/tests/sentry/seer/test_signed_seer_api.py
+++ b/tests/sentry/seer/test_signed_seer_api.py
@@ -26,14 +26,16 @@ def test_make_signed_seer_api_request():
 
         return mock.urlopen
 
-    url_request().assert_called_once_with(
+    mock_url_open = url_request()
+    mock_url_open.assert_called_once_with(
         "POST",
         "/v0/some/url",
         body=body,
         headers={"content-type": "application/json;charset=utf-8"},
     )
 
-    url_request(timeout=5).assert_called_once_with(
+    mock_url_open = url_request(timeout=5)
+    mock_url_open.assert_called_once_with(
         "POST",
         "/v0/some/url",
         body=body,
@@ -42,7 +44,8 @@ def test_make_signed_seer_api_request():
     )
 
     with override_options({"seer.api.use-shared-secret": 1.0}):
-        url_request().assert_called_once_with(
+        mock_url_open = url_request()
+        mock_url_open.assert_called_once_with(
             "POST",
             "/v0/some/url",
             body=body,

--- a/tests/sentry/seer/test_signed_seer_api.py
+++ b/tests/sentry/seer/test_signed_seer_api.py
@@ -11,7 +11,7 @@ from sentry.testutils.helpers import override_options
 def test_make_signed_seer_api_request():
     body = b'{"b": 12, "thing": "thing"}'
 
-    def url_request(timeout: int | None = None):
+    def run_test_case(timeout: int | None = None):
         mock = Mock()
         mock.host = "localhost"
         mock.port = None
@@ -26,7 +26,7 @@ def test_make_signed_seer_api_request():
 
         return mock.urlopen
 
-    mock_url_open = url_request()
+    mock_url_open = run_test_case()
     mock_url_open.assert_called_once_with(
         "POST",
         "/v0/some/url",
@@ -34,7 +34,7 @@ def test_make_signed_seer_api_request():
         headers={"content-type": "application/json;charset=utf-8"},
     )
 
-    mock_url_open = url_request(timeout=5)
+    mock_url_open = run_test_case(timeout=5)
     mock_url_open.assert_called_once_with(
         "POST",
         "/v0/some/url",
@@ -44,7 +44,7 @@ def test_make_signed_seer_api_request():
     )
 
     with override_options({"seer.api.use-shared-secret": 1.0}):
-        mock_url_open = url_request()
+        mock_url_open = run_test_case()
         mock_url_open.assert_called_once_with(
             "POST",
             "/v0/some/url",

--- a/tests/sentry/seer/test_signed_seer_api.py
+++ b/tests/sentry/seer/test_signed_seer_api.py
@@ -31,7 +31,7 @@ def run_test_case(timeout: int | None = None):
 
 
 @pytest.mark.django_db
-def test_make_signed_seer_api_request():
+def test_simple():
     mock_url_open = run_test_case()
     mock_url_open.assert_called_once_with(
         "POST",
@@ -40,6 +40,9 @@ def test_make_signed_seer_api_request():
         headers={"content-type": "application/json;charset=utf-8"},
     )
 
+
+@pytest.mark.django_db
+def test_uses_given_timeout():
     mock_url_open = run_test_case(timeout=5)
     mock_url_open.assert_called_once_with(
         "POST",
@@ -49,6 +52,9 @@ def test_make_signed_seer_api_request():
         timeout=5,
     )
 
+
+@pytest.mark.django_db
+def test_uses_shared_secret():
     with override_options({"seer.api.use-shared-secret": 1.0}):
         mock_url_open = run_test_case()
         mock_url_open.assert_called_once_with(

--- a/tests/sentry/seer/test_signed_seer_api.py
+++ b/tests/sentry/seer/test_signed_seer_api.py
@@ -6,7 +6,7 @@ from django.test import override_settings
 from sentry.seer.signed_seer_api import make_signed_seer_api_request
 from sentry.testutils.helpers import override_options
 
-body = b'{"b": 12, "thing": "thing"}'
+REQUEST_BODY = b'{"b": 12, "thing": "thing"}'
 
 
 def run_test_case(timeout: int | None = None):
@@ -23,7 +23,7 @@ def run_test_case(timeout: int | None = None):
         make_signed_seer_api_request(
             mock,
             path="/v0/some/url",
-            body=body,
+            body=REQUEST_BODY,
             timeout=timeout,
         )
 
@@ -36,7 +36,7 @@ def test_make_signed_seer_api_request():
     mock_url_open.assert_called_once_with(
         "POST",
         "/v0/some/url",
-        body=body,
+        body=REQUEST_BODY,
         headers={"content-type": "application/json;charset=utf-8"},
     )
 
@@ -44,7 +44,7 @@ def test_make_signed_seer_api_request():
     mock_url_open.assert_called_once_with(
         "POST",
         "/v0/some/url",
-        body=body,
+        body=REQUEST_BODY,
         headers={"content-type": "application/json;charset=utf-8"},
         timeout=5,
     )
@@ -54,7 +54,7 @@ def test_make_signed_seer_api_request():
         mock_url_open.assert_called_once_with(
             "POST",
             "/v0/some/url",
-            body=body,
+            body=REQUEST_BODY,
             headers={
                 "content-type": "application/json;charset=utf-8",
                 "Authorization": "Rpcsignature rpc0:96f23d5b3df807a9dc91f090078a46c00e17fe8b0bc7ef08c9391fa8b37a66b5",


### PR DESCRIPTION
This makes a number of changes to the existing tests for `make_signed_seer_api_request`, both for clarity and in anticipation of new tests being added.

Changes:

- The helper function `url_request` has been renamed `run_test_case`, given a docstring, moved up to the module level, and given the ability to use a custom path when making mock requests.
- The mock returned from said function is now captured before it's asserted on, primarily to give it a name so it's clearer what it is.
- The default path and body values have been pulled into constants.
- The single generically-named test testing three cases has been split into three separate tests, named according to what they're testing.