### PR TITLE
feat(profiling): Add setting to enable continuous profiling

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -2539,6 +2539,13 @@ SENTRY_PROFILER_MODE: Final = "sleep"
 # profiler. For example, only on the web server.
 SENTRY_PROFILING_ENABLED = os.environ.get("SENTRY_PROFILING_ENABLED", False)
 
+# To have finer control over which process will have continuous profiling enabled,
+# this environment variable will be required to enable continuous profiling.
+#
+# This setting takes precedence over `SENTRY_PROFILING_ENABLED` forcing the SDK
+# to operate under the continuous profiling model.
+SENTRY_CONTINUOUS_PROFILING_ENABLED = os.environ.get("SENTRY_CONTINUOUS_PROFILING_ENABLED", False)
+
 # Callable to bind additional context for the Sentry SDK
 #
 # def get_org_context(scope, organization, **kwargs):

--- a/src/sentry/utils/sdk.py
+++ b/src/sentry/utils/sdk.py
@@ -302,7 +302,11 @@ def configure_sdk():
     else:
         sentry_saas_transport = None
 
-    if settings.SENTRY_PROFILING_ENABLED:
+    if settings.SENTRY_CONTINUOUS_PROFILING_ENABLED:
+        sdk_options.setdefault("_experiments", {}).update(
+            continuous_profiling_auto_start=True,
+        )
+    elif settings.SENTRY_PROFILING_ENABLED:
         sdk_options["profiles_sampler"] = profiles_sampler
         sdk_options["profiler_mode"] = settings.SENTRY_PROFILER_MODE
 


### PR DESCRIPTION
This adds a setting to enable continuous profiling via the environment variable `SENTRY_CONTINUOUS_PROFILING_ENABLE`.