### PR TITLE
feat(query-builder): Add config for disabling wildcard tokens

### DIFF
--- a/static/app/components/compactSelect/control.tsx
+++ b/static/app/components/compactSelect/control.tsx
@@ -172,6 +172,10 @@ export interface ControlProps
    */
   onClear?: () => void;
   /**
+   * Called when the menu is opened or closed.
+   */
+  onOpenChange?: (newOpenState: boolean) => void;
+  /**
    * Called when the search input's value changes (applicable only when `searchable`
    * is true).
    */
@@ -233,6 +237,7 @@ export function Control({
   menuHeaderTrailingItems,
   menuBody,
   menuFooter,
+  onOpenChange,
 
   // Select props
   size = 'md',
@@ -327,6 +332,8 @@ export function Control({
     preventOverflowOptions,
     flipOptions,
     onOpenChange: open => {
+      onOpenChange?.(open);
+
       nextFrameCallback(() => {
         if (open) {
           // Focus on search box if present

--- a/static/app/components/searchQueryBuilder/index.spec.tsx
+++ b/static/app/components/searchQueryBuilder/index.spec.tsx
@@ -1969,4 +1969,45 @@ describe('SearchQueryBuilder', function () {
       ).toBeInTheDocument();
     });
   });
+
+  describe('disallowWildcard', function () {
+    it('should mark tokens with wildcards invalid', async function () {
+      render(
+        <SearchQueryBuilder
+          {...defaultProps}
+          disallowWildcard
+          initialQuery="browser.name:Firefox*"
+        />
+      );
+
+      expect(screen.getByRole('row', {name: 'browser.name:Firefox*'})).toHaveAttribute(
+        'aria-invalid',
+        'true'
+      );
+
+      // Put focus into token, should show error message
+      await userEvent.click(getLastInput());
+      await userEvent.keyboard('{ArrowLeft}');
+
+      expect(
+        await screen.findByText('Wildcards not supported in search')
+      ).toBeInTheDocument();
+    });
+
+    it('should mark free text with wildcards invalid', async function () {
+      render(
+        <SearchQueryBuilder {...defaultProps} disallowWildcard initialQuery="foo*" />
+      );
+
+      expect(screen.getByRole('row', {name: 'foo*'})).toHaveAttribute(
+        'aria-invalid',
+        'true'
+      );
+
+      await userEvent.click(getLastInput());
+      expect(
+        await screen.findByText('Wildcards not supported in search')
+      ).toBeInTheDocument();
+    });
+  });
 });

--- a/static/app/components/searchQueryBuilder/index.stories.tsx
+++ b/static/app/components/searchQueryBuilder/index.stories.tsx
@@ -1,7 +1,8 @@
-import {Fragment} from 'react';
+import {Fragment, useState} from 'react';
 import styled from '@emotion/styled';
 
 import Alert from 'sentry/components/alert';
+import MultipleCheckbox from 'sentry/components/forms/controls/multipleCheckbox';
 import {SearchQueryBuilder} from 'sentry/components/searchQueryBuilder';
 import type {FilterKeySection} from 'sentry/components/searchQueryBuilder/types';
 import SizingWindow from 'sentry/components/stories/sizingWindow';
@@ -108,6 +109,45 @@ export default storyBook(SearchQueryBuilder, story => {
             searchSource="storybook"
           />
         </MinHeightSizingWindow>
+      </Fragment>
+    );
+  });
+
+  story('Config Options', () => {
+    const configs = ['disallowLogicalOperators', 'disallowWildcard'];
+
+    const [enabledConfigs, setEnabledConfigs] = useState<string[]>([...configs]);
+    const queryBuilderOptions = enabledConfigs.reduce((acc, config) => {
+      acc[config] = true;
+      return acc;
+    }, {});
+
+    return (
+      <Fragment>
+        <p>
+          There are some config options which allow you to customize which types of syntax
+          are considered valid. This should be used when the search backend does not
+          support certain operators like boolean logic or wildcards.
+        </p>
+        <MultipleCheckbox
+          onChange={setEnabledConfigs}
+          value={enabledConfigs}
+          name="enabled configs"
+        >
+          {configs.map(config => (
+            <MultipleCheckbox.Item key={config} value={config}>
+              {config}
+            </MultipleCheckbox.Item>
+          ))}
+        </MultipleCheckbox>
+        <SearchQueryBuilder
+          initialQuery="(browser.name:Firefox OR browser.name:Internet*) TypeError*"
+          filterKeySections={FITLER_KEY_SECTIONS}
+          filterKeys={FILTER_KEYS}
+          getTagValues={getTagValues}
+          searchSource="storybook"
+          {...queryBuilderOptions}
+        />
       </Fragment>
     );
   });

--- a/static/app/components/searchQueryBuilder/index.tsx
+++ b/static/app/components/searchQueryBuilder/index.tsx
@@ -45,6 +45,10 @@ export interface SearchQueryBuilderProps {
    */
   disallowLogicalOperators?: boolean;
   /**
+   * When true, the wildcard (*) in filter values or free text will be marked as invalid.
+   */
+  disallowWildcard?: boolean;
+  /**
    * The lookup strategy for field definitions.
    * Each SearchQueryBuilder instance can support a different list of fields and
    * tags, their definitions may not overlap.
@@ -92,6 +96,7 @@ function ActionButtons() {
 export function SearchQueryBuilder({
   className,
   disallowLogicalOperators,
+  disallowWildcard,
   label,
   initialQuery,
   fieldDefinitionGetter = getFieldDefinition,
@@ -113,9 +118,16 @@ export function SearchQueryBuilder({
     () =>
       parseQueryBuilderValue(state.query, fieldDefinitionGetter, {
         disallowLogicalOperators,
+        disallowWildcard,
         filterKeys,
       }),
-    [disallowLogicalOperators, fieldDefinitionGetter, filterKeys, state.query]
+    [
+      disallowLogicalOperators,
+      disallowWildcard,
+      fieldDefinitionGetter,
+      filterKeys,
+      state.query,
+    ]
   );
 
   useEffectAfterFirstRender(() => {

--- a/static/app/components/searchQueryBuilder/tokenizedQueryGrid.tsx
+++ b/static/app/components/searchQueryBuilder/tokenizedQueryGrid.tsx
@@ -86,7 +86,6 @@ function Grid(props: GridProps) {
               />
             );
           case Token.FREE_TEXT:
-          case Token.SPACES:
             return (
               <SearchQueryBuilderFreeText
                 key={item.key}

--- a/static/app/components/searchQueryBuilder/tokens/deletableToken.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/deletableToken.tsx
@@ -8,6 +8,7 @@ import type {Node} from '@react-types/shared';
 import InteractionStateLayer from 'sentry/components/interactionStateLayer';
 import {useSearchQueryBuilder} from 'sentry/components/searchQueryBuilder/context';
 import {useQueryBuilderGridItem} from 'sentry/components/searchQueryBuilder/hooks/useQueryBuilderGridItem';
+import {InvalidTokenTooltip} from 'sentry/components/searchQueryBuilder/tokens/invalidTokenTooltip';
 import {
   shiftFocusToChild,
   useShiftFocusToChild,
@@ -16,7 +17,6 @@ import type {
   InvalidReason,
   ParseResultToken,
 } from 'sentry/components/searchSyntax/parser';
-import {Tooltip} from 'sentry/components/tooltip';
 import {IconClose} from 'sentry/icons';
 import {t} from 'sentry/locale';
 
@@ -55,8 +55,6 @@ export function DeletableToken({
     shiftFocusToChild(e.currentTarget, item, state);
   };
 
-  const isFocused =
-    state.selectionManager.isFocused && state.selectionManager.focusedKey === item.key;
   const isInvalid = Boolean(invalid);
 
   return (
@@ -66,13 +64,7 @@ export function DeletableToken({
       ref={ref}
     >
       {children}
-      <Tooltip
-        skipWrapper
-        disabled={!isInvalid}
-        forceVisible={isFocused ? true : undefined}
-        position="bottom"
-        title={invalid?.reason ?? t('This token is invalid')}
-      >
+      <InvalidTokenTooltip token={token} state={state} item={item}>
         <HoverFocusBorder>
           <FloatingCloseButton
             {...gridCellProps}
@@ -87,7 +79,7 @@ export function DeletableToken({
             <IconClose legacySize="10px" />
           </FloatingCloseButton>
         </HoverFocusBorder>
-      </Tooltip>
+      </InvalidTokenTooltip>
     </Wrapper>
   );
 }

--- a/static/app/components/searchQueryBuilder/tokens/filter/filterKeyOperator.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/filterKeyOperator.tsx
@@ -24,6 +24,7 @@ import useOrganization from 'sentry/utils/useOrganization';
 
 type FilterOperatorProps = {
   item: Node<ParseResultToken>;
+  onOpenChange: (isOpen: boolean) => void;
   state: ListState<ParseResultToken>;
   token: TokenResult<Token.FILTER>;
 };
@@ -185,7 +186,12 @@ function getOperatorInfo(token: TokenResult<Token.FILTER>): {
   };
 }
 
-export function FilterKeyOperator({token, state, item}: FilterOperatorProps) {
+export function FilterKeyOperator({
+  token,
+  state,
+  item,
+  onOpenChange,
+}: FilterOperatorProps) {
   const organization = useOrganization();
   const {dispatch, searchSource, query, savedSearchType} = useSearchQueryBuilder();
   const filterButtonProps = useFilterButtonProps({state, item});
@@ -206,6 +212,7 @@ export function FilterKeyOperator({token, state, item}: FilterOperatorProps) {
       size="sm"
       options={options}
       value={operator}
+      onOpenChange={onOpenChange}
       onChange={option => {
         trackAnalytics('search.operator_autocompleted', {
           organization,

--- a/static/app/components/searchQueryBuilder/tokens/invalidTokenTooltip.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/invalidTokenTooltip.tsx
@@ -1,0 +1,61 @@
+import type {ReactNode} from 'react';
+import type {ListState} from '@react-stately/list';
+import type {Node} from '@react-types/shared';
+
+import type {ParseResultToken} from 'sentry/components/searchSyntax/parser';
+import {Tooltip, type TooltipProps} from 'sentry/components/tooltip';
+import {t} from 'sentry/locale';
+import {defined} from 'sentry/utils';
+
+interface InvalidTokenTooltipProps extends Omit<TooltipProps, 'title'> {
+  children: ReactNode;
+  item: Node<ParseResultToken>;
+  state: ListState<ParseResultToken>;
+  token: ParseResultToken;
+}
+
+function getForceVisible({
+  isFocused,
+  isInvalid,
+  forceVisible,
+}: {
+  isFocused: boolean;
+  isInvalid: boolean;
+  forceVisible?: boolean;
+}) {
+  if (!isInvalid) {
+    return false;
+  }
+
+  if (defined(forceVisible)) {
+    return forceVisible;
+  }
+
+  return isFocused ? true : undefined;
+}
+
+export function InvalidTokenTooltip({
+  children,
+  token,
+  state,
+  item,
+  forceVisible,
+  ...tooltipProps
+}: InvalidTokenTooltipProps) {
+  const invalid = 'invalid' in token ? token.invalid : null;
+  const isInvalid = Boolean(invalid);
+  const isFocused =
+    state.selectionManager.isFocused && state.selectionManager.focusedKey === item.key;
+
+  return (
+    <Tooltip
+      skipWrapper
+      forceVisible={getForceVisible({isFocused, isInvalid, forceVisible})}
+      position="bottom"
+      title={invalid?.reason ?? t('This token is invalid')}
+      {...tooltipProps}
+    >
+      {children}
+    </Tooltip>
+  );
+}

--- a/static/app/components/searchQueryBuilder/utils.tsx
+++ b/static/app/components/searchQueryBuilder/utils.tsx
@@ -63,11 +63,16 @@ function getSearchConfigFromKeys(
 export function parseQueryBuilderValue(
   value: string,
   getFieldDefinition: FieldDefinitionGetter,
-  options?: {filterKeys: TagCollection; disallowLogicalOperators?: boolean}
+  options?: {
+    filterKeys: TagCollection;
+    disallowLogicalOperators?: boolean;
+    disallowWildcard?: boolean;
+  }
 ): ParseResult | null {
   return collapseTextTokens(
     parseSearch(value || ' ', {
       flattenParenGroups: true,
+      disallowWildcard: options?.disallowWildcard,
       disallowedLogicalOperators: options?.disallowLogicalOperators
         ? new Set([BooleanOperator.AND, BooleanOperator.OR])
         : undefined,
@@ -124,9 +129,16 @@ function collapseTextTokens(tokens: ParseResult | null) {
     const lastToken = acc[acc.length - 1];
 
     if (isSimpleTextToken(token) && isSimpleTextToken(lastToken)) {
-      lastToken.value += token.value;
-      lastToken.text += token.text;
-      lastToken.location.end = token.location.end;
+      const freeTextToken = lastToken as TokenResult<Token.FREE_TEXT>;
+      freeTextToken.value += token.value;
+      freeTextToken.text += token.text;
+      freeTextToken.location.end = token.location.end;
+
+      if (token.type === Token.FREE_TEXT) {
+        freeTextToken.quoted = freeTextToken.quoted || token.quoted;
+        freeTextToken.invalid = freeTextToken.invalid ?? token.invalid;
+      }
+
       return acc;
     }
 


### PR DESCRIPTION
Closes https://github.com/getsentry/sentry/issues/74350

Adds `disallowWildcard` config option. Will mark invalid tokens and free text as red and display a tooltip explaining the issue.

Can play around with the config option in the new section I've added to the story: `/stories/?name=app/components/searchQueryBuilder/index.stories.tsx`

![CleanShot 2024-07-22 at 14 25 14](https://github.com/user-attachments/assets/d5f983d1-c030-4b95-9a3e-5b043142f61e)
