### PR TITLE
fix(toolbar): hide feedback panel when submit feedback form opens

### DIFF
--- a/static/app/components/devtoolbar/components/app.tsx
+++ b/static/app/components/devtoolbar/components/app.tsx
@@ -5,6 +5,7 @@ import LoadingTriangle from 'sentry/components/loadingTriangle';
 import {useSessionStorage} from 'sentry/utils/useSessionStorage';
 
 import usePlacementCss from '../hooks/usePlacementCss';
+import useVisibility from '../hooks/useVisibility';
 import {fixedContainerBaseCss} from '../styles/fixedContainer';
 import {avatarCss, globalCss, loadingIndicatorCss} from '../styles/global';
 import {resetFlexColumnCss} from '../styles/reset';
@@ -15,6 +16,7 @@ import PanelRouter from './panelRouter';
 
 export default function App() {
   const placement = usePlacementCss();
+  const [visibility] = useVisibility();
   const [isHidden, setIsHidden] = useSessionStorage('hide_employee_devtoolbar', false);
   if (isHidden) {
     return null;
@@ -25,7 +27,7 @@ export default function App() {
       <Global styles={globalCss} />
       <Global styles={loadingIndicatorCss} />
       <Global styles={avatarCss} />
-      <div css={[fixedContainerBaseCss, placement.fixedContainer.css]}>
+      <div css={[fixedContainerBaseCss, placement.fixedContainer.css, {visibility}]}>
         {isHidden ? null : (
           <Fragment>
             <Navigation setIsHidden={setIsHidden} />

--- a/static/app/components/devtoolbar/components/app.tsx
+++ b/static/app/components/devtoolbar/components/app.tsx
@@ -17,8 +17,11 @@ import PanelRouter from './panelRouter';
 export default function App() {
   const placement = usePlacementCss();
   const [visibility] = useVisibility();
-  const [isHidden, setIsHidden] = useSessionStorage('hide_employee_devtoolbar', false);
-  if (isHidden) {
+  const [isDisabled, setIsDisabled] = useSessionStorage(
+    'hide_employee_devtoolbar',
+    false
+  );
+  if (isDisabled) {
     return null;
   }
 
@@ -28,9 +31,9 @@ export default function App() {
       <Global styles={loadingIndicatorCss} />
       <Global styles={avatarCss} />
       <div css={[fixedContainerBaseCss, placement.fixedContainer.css, {visibility}]}>
-        {isHidden ? null : (
+        {isDisabled ? null : (
           <Fragment>
-            <Navigation setIsHidden={setIsHidden} />
+            <Navigation setIsDisabled={setIsDisabled} />
             <Suspense fallback={<LoadingPanel />}>
               <PanelRouter />
             </Suspense>

--- a/static/app/components/devtoolbar/components/feedback/feedbackPanel.tsx
+++ b/static/app/components/devtoolbar/components/feedback/feedbackPanel.tsx
@@ -1,4 +1,4 @@
-import {useMemo, useState} from 'react';
+import {useMemo} from 'react';
 import {css} from '@emotion/react';
 
 import ActorAvatar from 'sentry/components/avatar/actorAvatar';
@@ -12,6 +12,7 @@ import useReplayCount from 'sentry/utils/replayCount/useReplayCount';
 import useConfiguration from '../../hooks/useConfiguration';
 import useCurrentTransactionName from '../../hooks/useCurrentTransactionName';
 import {useSDKFeedbackButton} from '../../hooks/useSDKFeedbackButton';
+import useVisibility from '../../hooks/useVisibility';
 import {
   badgeWithLabelCss,
   gridFlexEndCss,
@@ -34,11 +35,17 @@ import SentryAppLink from '../sentryAppLink';
 import useInfiniteFeedbackList from './useInfiniteFeedbackList';
 
 export default function FeedbackPanel() {
-  const [visible, setVisible] = useState(true);
-  const buttonRef = useSDKFeedbackButton({
-    onFormOpen: () => setVisible(false),
-    onFormClose: () => setVisible(true),
-  });
+  const [, setVisible] = useVisibility();
+
+  const buttonRef = useSDKFeedbackButton(
+    useMemo(
+      () => ({
+        onFormOpen: () => setVisible('hidden'),
+        onFormClose: () => setVisible('visible'),
+      }),
+      [setVisible]
+    )
+  );
   const transactionName = useCurrentTransactionName();
   const queryResult = useInfiniteFeedbackList({
     query: `url:*${transactionName}`,
@@ -62,7 +69,6 @@ export default function FeedbackPanel() {
           </button>
         ) : null
       }
-      visible={visible}
     >
       <div css={[smallCss, panelSectionCss, panelInsetContentCss]}>
         <span>

--- a/static/app/components/devtoolbar/components/feedback/feedbackPanel.tsx
+++ b/static/app/components/devtoolbar/components/feedback/feedbackPanel.tsx
@@ -1,4 +1,4 @@
-import {useMemo} from 'react';
+import {useMemo, useState} from 'react';
 import {css} from '@emotion/react';
 
 import ActorAvatar from 'sentry/components/avatar/actorAvatar';
@@ -34,7 +34,11 @@ import SentryAppLink from '../sentryAppLink';
 import useInfiniteFeedbackList from './useInfiniteFeedbackList';
 
 export default function FeedbackPanel() {
-  const buttonRef = useSDKFeedbackButton();
+  const [visible, setVisible] = useState(true);
+  const buttonRef = useSDKFeedbackButton({
+    onFormOpen: () => setVisible(false),
+    onFormClose: () => setVisible(true),
+  });
   const transactionName = useCurrentTransactionName();
   const queryResult = useInfiniteFeedbackList({
     query: `url:*${transactionName}`,
@@ -58,6 +62,7 @@ export default function FeedbackPanel() {
           </button>
         ) : null
       }
+      visible={visible}
     >
       <div css={[smallCss, panelSectionCss, panelInsetContentCss]}>
         <span>

--- a/static/app/components/devtoolbar/components/navigation.tsx
+++ b/static/app/components/devtoolbar/components/navigation.tsx
@@ -9,7 +9,11 @@ import useToolbarRoute from '../hooks/useToolbarRoute';
 import {navigationButtonCss, navigationCss} from '../styles/navigation';
 import {resetButtonCss, resetDialogCss} from '../styles/reset';
 
-export default function Navigation({setIsHidden}: {setIsHidden: (val: boolean) => void}) {
+export default function Navigation({
+  setIsDisabled,
+}: {
+  setIsDisabled: (val: boolean) => void;
+}) {
   const {trackAnalytics} = useConfiguration();
   const placement = usePlacementCss();
 
@@ -26,7 +30,7 @@ export default function Navigation({setIsHidden}: {setIsHidden: (val: boolean) =
       <NavButton panelName="feedback" label={'User Feedback'} icon={<IconMegaphone />} />
       <HideButton
         onClick={() => {
-          setIsHidden(true);
+          setIsDisabled(true);
           trackAnalytics?.({
             eventKey: `devtoolbar.nav.hide.click`,
             eventName: `devtoolbar: Hide devtoolbar`,

--- a/static/app/components/devtoolbar/components/panelLayout.tsx
+++ b/static/app/components/devtoolbar/components/panelLayout.tsx
@@ -1,3 +1,5 @@
+import {css} from '@emotion/react';
+
 import {buttonCss} from 'sentry/components/devtoolbar/styles/typography';
 
 import {panelCss, panelHeadingCss, panelSectionCss} from '../styles/panel';
@@ -8,11 +10,28 @@ interface Props {
   children?: React.ReactNode;
   titleLeft?: React.ReactNode;
   titleRight?: React.ReactNode;
+  visible?: boolean;
 }
 
-export default function PanelLayout({children, title, titleLeft, titleRight}: Props) {
+export default function PanelLayout({
+  children,
+  title,
+  titleLeft,
+  titleRight,
+  visible = true,
+}: Props) {
   return (
-    <dialog open css={[resetDialogCss, resetFlexColumnCss, panelCss]}>
+    <dialog
+      open
+      css={[
+        resetDialogCss,
+        resetFlexColumnCss,
+        panelCss,
+        css`
+          visibility: ${visible ? 'visible' : 'hidden'};
+        `,
+      ]}
+    >
       {title ? (
         <header css={panelSectionCss}>
           {titleLeft}

--- a/static/app/components/devtoolbar/components/panelLayout.tsx
+++ b/static/app/components/devtoolbar/components/panelLayout.tsx
@@ -1,5 +1,3 @@
-import {css} from '@emotion/react';
-
 import {buttonCss} from 'sentry/components/devtoolbar/styles/typography';
 
 import {panelCss, panelHeadingCss, panelSectionCss} from '../styles/panel';
@@ -10,28 +8,11 @@ interface Props {
   children?: React.ReactNode;
   titleLeft?: React.ReactNode;
   titleRight?: React.ReactNode;
-  visible?: boolean;
 }
 
-export default function PanelLayout({
-  children,
-  title,
-  titleLeft,
-  titleRight,
-  visible = true,
-}: Props) {
+export default function PanelLayout({children, title, titleLeft, titleRight}: Props) {
   return (
-    <dialog
-      open
-      css={[
-        resetDialogCss,
-        resetFlexColumnCss,
-        panelCss,
-        css`
-          visibility: ${visible ? 'visible' : 'hidden'};
-        `,
-      ]}
-    >
+    <dialog open css={[resetDialogCss, resetFlexColumnCss, panelCss]}>
       {title ? (
         <header css={panelSectionCss}>
           {titleLeft}

--- a/static/app/components/devtoolbar/components/providers.tsx
+++ b/static/app/components/devtoolbar/components/providers.tsx
@@ -7,6 +7,7 @@ import {lightTheme} from 'sentry/utils/theme';
 
 import {ConfigurationContextProvider} from '../hooks/useConfiguration';
 import {ToolbarRouterContextProvider} from '../hooks/useToolbarRoute';
+import {VisibilityContextProvider} from '../hooks/useVisibility';
 import type {Configuration} from '../types';
 
 interface Props {
@@ -35,7 +36,9 @@ export default function Providers({children, config, container}: Props) {
       <ThemeProvider theme={lightTheme}>
         <ConfigurationContextProvider config={config}>
           <QueryClientProvider client={queryClient}>
-            <ToolbarRouterContextProvider>{children}</ToolbarRouterContextProvider>
+            <VisibilityContextProvider>
+              <ToolbarRouterContextProvider>{children}</ToolbarRouterContextProvider>
+            </VisibilityContextProvider>
           </QueryClientProvider>
         </ConfigurationContextProvider>
       </ThemeProvider>

--- a/static/app/components/devtoolbar/hooks/useSDKFeedbackButton.tsx
+++ b/static/app/components/devtoolbar/hooks/useSDKFeedbackButton.tsx
@@ -2,17 +2,23 @@ import {useEffect, useRef} from 'react';
 
 import useConfiguration from './useConfiguration';
 
-export function useSDKFeedbackButton() {
+export function useSDKFeedbackButton({
+  onFormClose,
+  onFormOpen,
+}: {
+  onFormClose?: () => void;
+  onFormOpen?: () => void;
+}) {
   const buttonRef = useRef<HTMLButtonElement>(null);
   const {SentrySDK} = useConfiguration();
   const feedback = SentrySDK && 'getFeedback' in SentrySDK && SentrySDK.getFeedback();
 
   useEffect(() => {
     if (feedback && buttonRef.current) {
-      return feedback.attachTo(buttonRef.current, {});
+      return feedback.attachTo(buttonRef.current, {onFormOpen, onFormClose});
     }
     return () => {};
-  }, [feedback]);
+  }, [feedback, onFormOpen, onFormClose]);
 
   return feedback ? buttonRef : undefined;
 }

--- a/static/app/components/devtoolbar/hooks/useVisibility.tsx
+++ b/static/app/components/devtoolbar/hooks/useVisibility.tsx
@@ -1,0 +1,20 @@
+import type {Dispatch, ReactNode, SetStateAction} from 'react';
+import {createContext, useContext, useState} from 'react';
+
+type State = 'visible' | 'hidden';
+
+const VisibilityContext = createContext<[State, Dispatch<SetStateAction<State>>]>([
+  'visible',
+  () => {},
+]);
+
+export function VisibilityContextProvider({children}: {children: ReactNode}) {
+  const state = useState<State>('visible');
+  return (
+    <VisibilityContext.Provider value={state}>{children}</VisibilityContext.Provider>
+  );
+}
+
+export default function useVisibility() {
+  return useContext(VisibilityContext);
+}

--- a/static/app/components/devtoolbar/hooks/useVisibility.tsx
+++ b/static/app/components/devtoolbar/hooks/useVisibility.tsx
@@ -1,7 +1,7 @@
-import type {Dispatch, ReactNode, SetStateAction} from 'react';
+import type {CSSProperties, Dispatch, ReactNode, SetStateAction} from 'react';
 import {createContext, useContext, useState} from 'react';
 
-type State = 'visible' | 'hidden';
+type State = CSSProperties['visibility'];
 
 const VisibilityContext = createContext<[State, Dispatch<SetStateAction<State>>]>([
   'visible',


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry/issues/74156 so the toolbar will be totally hidden when submitting feedback / taking a screenshot.



https://github.com/user-attachments/assets/6f733424-5520-495a-b06f-b17c6be50117


