### PR TITLE
ref(tags): Update tag key-value request to use new dataset param

### DIFF
--- a/static/app/actionCreators/tags.tsx
+++ b/static/app/actionCreators/tags.tsx
@@ -102,10 +102,12 @@ export function fetchTagValues({
   projectIds,
   search,
   sort,
+  dataset,
 }: {
   api: Client;
   orgSlug: string;
   tagKey: string;
+  dataset?: Dataset;
   endpointParams?: Query;
   includeReplays?: boolean;
   includeSessions?: boolean;
@@ -149,6 +151,10 @@ export function fetchTagValues({
 
   if (sort) {
     query.sort = sort;
+  }
+
+  if (dataset) {
+    query.dataset = dataset;
   }
 
   return api.requestPromise(url, {

--- a/static/app/views/issueDetails/groupEvents.tsx
+++ b/static/app/views/issueDetails/groupEvents.tsx
@@ -19,7 +19,7 @@ import useApi from 'sentry/utils/useApi';
 import useCleanQueryParamsOnRouteLeave from 'sentry/utils/useCleanQueryParamsOnRouteLeave';
 import useOrganization from 'sentry/utils/useOrganization';
 import {Dataset} from 'sentry/views/alerts/rules/metric/types';
-import {mergeTagValues} from 'sentry/views/issueDetails/utils';
+import {mergeAndSortTagValues} from 'sentry/views/issueDetails/utils';
 import {makeGetIssueTagValues} from 'sentry/views/issueList/utils/getIssueTagValues';
 
 import AllEventsTable from './allEventsTable';
@@ -124,7 +124,7 @@ function UpdatedSearchBar({
         projectIds,
         dataset: Dataset.ISSUE_PLATFORM,
       });
-      return mergeTagValues(eventsDatasetValues, issuePlatformDatasetValues);
+      return mergeAndSortTagValues(eventsDatasetValues, issuePlatformDatasetValues);
     },
     [api, group.project.id, organization.slug]
   );

--- a/static/app/views/issueDetails/groupEvents.tsx
+++ b/static/app/views/issueDetails/groupEvents.tsx
@@ -107,7 +107,7 @@ function UpdatedSearchBar({
       const orgSlug = organization.slug;
       const projectIds = [group.project.id];
 
-      const eventsDatasetValues = await fetchTagValues({
+      const eventsDatasetValues = fetchTagValues({
         api,
         orgSlug,
         tagKey: key,
@@ -116,7 +116,7 @@ function UpdatedSearchBar({
         dataset: Dataset.ERRORS,
       });
 
-      const issuePlatformDatasetValues = await fetchTagValues({
+      const issuePlatformDatasetValues = fetchTagValues({
         api,
         orgSlug,
         tagKey: key,
@@ -124,7 +124,10 @@ function UpdatedSearchBar({
         projectIds,
         dataset: Dataset.ISSUE_PLATFORM,
       });
-      return mergeAndSortTagValues(eventsDatasetValues, issuePlatformDatasetValues);
+
+      return await Promise.all([eventsDatasetValues, issuePlatformDatasetValues]).then(
+        tagValues => mergeAndSortTagValues(tagValues[0], tagValues[1])
+      );
     },
     [api, group.project.id, organization.slug]
   );

--- a/static/app/views/issueDetails/groupEvents.tsx
+++ b/static/app/views/issueDetails/groupEvents.tsx
@@ -107,27 +107,26 @@ function UpdatedSearchBar({
       const orgSlug = organization.slug;
       const projectIds = [group.project.id];
 
-      const eventsDatasetValues = fetchTagValues({
-        api,
-        orgSlug,
-        tagKey: key,
-        search,
-        projectIds,
-        dataset: Dataset.ERRORS,
-      });
+      const [eventsDatasetValues, issuePlatformDatasetValues] = await Promise.all([
+        fetchTagValues({
+          api,
+          orgSlug,
+          tagKey: key,
+          search,
+          projectIds,
+          dataset: Dataset.ERRORS,
+        }),
+        fetchTagValues({
+          api,
+          orgSlug,
+          tagKey: key,
+          search,
+          projectIds,
+          dataset: Dataset.ISSUE_PLATFORM,
+        }),
+      ]);
 
-      const issuePlatformDatasetValues = fetchTagValues({
-        api,
-        orgSlug,
-        tagKey: key,
-        search,
-        projectIds,
-        dataset: Dataset.ISSUE_PLATFORM,
-      });
-
-      return await Promise.all([eventsDatasetValues, issuePlatformDatasetValues]).then(
-        tagValues => mergeAndSortTagValues(tagValues[0], tagValues[1])
-      );
+      return mergeAndSortTagValues(eventsDatasetValues, issuePlatformDatasetValues);
     },
     [api, group.project.id, organization.slug]
   );

--- a/static/app/views/issueDetails/utils.tsx
+++ b/static/app/views/issueDetails/utils.tsx
@@ -66,10 +66,7 @@ export function mergeAndSortTagValues(
   tagValues2.forEach(tagValue => {
     if (tagValueCollection[tagValue.value]) {
       tagValueCollection[tagValue.value].count += tagValue.count;
-      if (
-        new Date(tagValue.lastSeen) >
-        new Date(tagValueCollection[tagValue.value].lastSeen)
-      ) {
+      if (tagValue.lastSeen > tagValueCollection[tagValue.value].lastSeen) {
         tagValueCollection[tagValue.value].lastSeen = tagValue.lastSeen;
       }
     } else {

--- a/static/app/views/issueDetails/utils.tsx
+++ b/static/app/views/issueDetails/utils.tsx
@@ -6,7 +6,7 @@ import {Client} from 'sentry/api';
 import {t} from 'sentry/locale';
 import ConfigStore from 'sentry/stores/configStore';
 import {useLegacyStore} from 'sentry/stores/useLegacyStore';
-import type {Group, GroupActivity} from 'sentry/types';
+import type {Group, GroupActivity, TagValue} from 'sentry/types';
 import type {Event} from 'sentry/types/event';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
@@ -47,6 +47,30 @@ export function useDefaultIssueEvent() {
   const user = useLegacyStore(ConfigStore).user;
   const options = user ? user.options : null;
   return options?.defaultIssueEvent ?? 'recommended';
+}
+/**
+ * Combines two TagValue arrays and combines TagValue.count upon conflict
+ */
+export function mergeTagValues(
+  tagValues1: TagValue[],
+  tagValues2: TagValue[]
+): TagValue[] {
+  const tagValueCollection = tagValues1.reduce<Record<string, TagValue>>(
+    (acc, tagValue) => {
+      acc[tagValue.name] = tagValue;
+      return acc;
+    },
+    {}
+  );
+  tagValues2.forEach(tagValue => {
+    if (tagValueCollection[tagValue.name]) {
+      tagValueCollection[tagValue.name].count += tagValue.count;
+    } else {
+      tagValueCollection[tagValue.name] = tagValue;
+    }
+  });
+
+  return Object.values(tagValueCollection);
 }
 
 /**

--- a/static/app/views/issueDetails/utils.tsx
+++ b/static/app/views/issueDetails/utils.tsx
@@ -77,9 +77,7 @@ export function mergeAndSortTagValues(
   if (sort === 'count') {
     allTagValues.sort((a, b) => b.count - a.count);
   } else {
-    allTagValues.sort(
-      (a, b) => new Date(b.lastSeen).getTime() - new Date(a.lastSeen).getTime()
-    );
+    allTagValues.sort((a, b) => (b.lastSeen < a.lastSeen ? -1 : 1));
   }
   return allTagValues;
 }

--- a/static/app/views/issueList/searchBar.spec.tsx
+++ b/static/app/views/issueList/searchBar.spec.tsx
@@ -1,7 +1,7 @@
 import {TagsFixture} from 'sentry-fixture/tags';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
-import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import TagStore from 'sentry/stores/tagStore';
 import {IsFieldValues} from 'sentry/utils/fields';
@@ -205,8 +205,6 @@ describe('IssueListSearchBar', function () {
         body: [{key: 'someTag', name: 'Some Tag'}],
       });
 
-      defaultProps.organization.features = ['issue-stream-search-query-builder'];
-
       render(<IssueListSearchBar {...newDefaultProps} />, {
         router: routerWithFlag,
       });
@@ -236,6 +234,46 @@ describe('IssueListSearchBar', function () {
       );
 
       expect(await screen.findByRole('option', {name: 'someTag'})).toBeInTheDocument();
+    });
+  });
+
+  describe('Tag Values', function () {
+    const {router: routerWithFlag, organization: orgWithFlag} = initializeOrg();
+    orgWithFlag.features = ['issue-stream-search-query-builder'];
+
+    const newDefaultProps = {
+      organization: orgWithFlag,
+      query: '',
+      statsPeriod: '7d',
+      onSearch: jest.fn(),
+    };
+
+    it('displays the correct tag values for a key', async () => {
+      MockApiClient.addMockResponse({
+        url: '/organizations/org-slug/tags/',
+        method: 'GET',
+        body: [],
+      });
+      const tagKey = 'random';
+      const tagValueMock = MockApiClient.addMockResponse({
+        url: `/organizations/org-slug/tags/${tagKey}/values/`,
+        method: 'GET',
+        body: [],
+      });
+
+      render(<IssueListSearchBar {...newDefaultProps} />, {
+        router: routerWithFlag,
+      });
+
+      await userEvent.click(screen.getByRole('combobox', {name: 'Add a search term'}));
+      await userEvent.paste(tagKey, {delay: null});
+      await userEvent.click(screen.getByRole('row', {name: tagKey}));
+
+      waitFor(() => {
+        // Expected twice since we make one request for values in events dataset
+        // and another for values in IssuePlatform dataset.
+        expect(tagValueMock).toHaveBeenCalledTimes(2);
+      });
     });
   });
 });

--- a/static/app/views/issueList/searchBar.spec.tsx
+++ b/static/app/views/issueList/searchBar.spec.tsx
@@ -4,6 +4,7 @@ import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import TagStore from 'sentry/stores/tagStore';
+import type {Tag, TagValue} from 'sentry/types';
 import {IsFieldValues} from 'sentry/utils/fields';
 import IssueListSearchBar from 'sentry/views/issueList/searchBar';
 
@@ -249,16 +250,35 @@ describe('IssueListSearchBar', function () {
     };
 
     it('displays the correct tag values for a key', async () => {
+      const tagKey = 'random';
+      const tagValue = 'randomValue';
+      const tagValueResponse: TagValue[] = [
+        {
+          name: tagValue,
+          value: tagValue,
+          count: 1,
+          firstSeen: '2021-01-01T00:00:00Z',
+          lastSeen: '2021-01-01T00:00:00Z',
+          email: 'a@sentry.io',
+          username: 'a',
+          id: '1',
+          ip_address: '1',
+        },
+      ];
+      const tag: Tag = {
+        key: tagKey,
+        name: tagKey,
+      };
+
       MockApiClient.addMockResponse({
         url: '/organizations/org-slug/tags/',
         method: 'GET',
-        body: [],
+        body: [tag],
       });
-      const tagKey = 'random';
       const tagValueMock = MockApiClient.addMockResponse({
         url: `/organizations/org-slug/tags/${tagKey}/values/`,
         method: 'GET',
-        body: [],
+        body: tagValueResponse,
       });
 
       render(<IssueListSearchBar {...newDefaultProps} />, {
@@ -267,9 +287,10 @@ describe('IssueListSearchBar', function () {
 
       await userEvent.click(screen.getByRole('combobox', {name: 'Add a search term'}));
       await userEvent.paste(tagKey, {delay: null});
-      await userEvent.click(screen.getByRole('row', {name: tagKey}));
+      await userEvent.click(screen.getByRole('option', {name: tagKey}));
+      expect(await screen.findByRole('option', {name: tagValue})).toBeInTheDocument();
 
-      waitFor(() => {
+      await waitFor(() => {
         // Expected twice since we make one request for values in events dataset
         // and another for values in IssuePlatform dataset.
         expect(tagValueMock).toHaveBeenCalledTimes(2);

--- a/static/app/views/issueList/searchBar.tsx
+++ b/static/app/views/issueList/searchBar.tsx
@@ -123,29 +123,29 @@ function IssueListSearchBar({organization, tags, onClose, ...props}: Props) {
           : undefined,
         statsPeriod: pageFilters.datetime.period,
       };
-      const eventsDatasetValues = fetchTagValues({
-        api,
-        orgSlug,
-        tagKey: key,
-        search,
-        projectIds,
-        endpointParams,
-        dataset: Dataset.ERRORS,
-      });
 
-      const issuePlatformDatasetValues = fetchTagValues({
-        api,
-        orgSlug,
-        tagKey: key,
-        search,
-        projectIds,
-        endpointParams,
-        dataset: Dataset.ISSUE_PLATFORM,
-      });
+      const [eventsDatasetValues, issuePlatformDatasetValues] = await Promise.all([
+        fetchTagValues({
+          api,
+          orgSlug,
+          tagKey: key,
+          search,
+          projectIds,
+          endpointParams,
+          dataset: Dataset.ERRORS,
+        }),
+        fetchTagValues({
+          api,
+          orgSlug,
+          tagKey: key,
+          search,
+          projectIds,
+          endpointParams,
+          dataset: Dataset.ISSUE_PLATFORM,
+        }),
+      ]);
 
-      return await Promise.all([eventsDatasetValues, issuePlatformDatasetValues]).then(
-        tagValues => mergeAndSortTagValues(tagValues[0], tagValues[1])
-      );
+      return mergeAndSortTagValues(eventsDatasetValues, issuePlatformDatasetValues);
     },
     [
       api,

--- a/static/app/views/issueList/searchBar.tsx
+++ b/static/app/views/issueList/searchBar.tsx
@@ -123,7 +123,7 @@ function IssueListSearchBar({organization, tags, onClose, ...props}: Props) {
           : undefined,
         statsPeriod: pageFilters.datetime.period,
       };
-      const eventsDatasetValues = await fetchTagValues({
+      const eventsDatasetValues = fetchTagValues({
         api,
         orgSlug,
         tagKey: key,
@@ -133,7 +133,7 @@ function IssueListSearchBar({organization, tags, onClose, ...props}: Props) {
         dataset: Dataset.ERRORS,
       });
 
-      const issuePlatformDatasetValues = await fetchTagValues({
+      const issuePlatformDatasetValues = fetchTagValues({
         api,
         orgSlug,
         tagKey: key,
@@ -143,7 +143,9 @@ function IssueListSearchBar({organization, tags, onClose, ...props}: Props) {
         dataset: Dataset.ISSUE_PLATFORM,
       });
 
-      return mergeTagValues(eventsDatasetValues, issuePlatformDatasetValues);
+      return await Promise.all([eventsDatasetValues, issuePlatformDatasetValues]).then(
+        tagValues => mergeTagValues(tagValues[0], tagValues[1])
+      );
     },
     [
       api,

--- a/static/app/views/issueList/searchBar.tsx
+++ b/static/app/views/issueList/searchBar.tsx
@@ -25,7 +25,7 @@ import usePageFilters from 'sentry/utils/usePageFilters';
 import type {WithIssueTagsProps} from 'sentry/utils/withIssueTags';
 import withIssueTags from 'sentry/utils/withIssueTags';
 import {Dataset} from 'sentry/views/alerts/rules/metric/types';
-import {mergeTagValues} from 'sentry/views/issueDetails/utils';
+import {mergeAndSortTagValues} from 'sentry/views/issueDetails/utils';
 import {makeGetIssueTagValues} from 'sentry/views/issueList/utils/getIssueTagValues';
 import {useFetchIssueTags} from 'sentry/views/issueList/utils/useFetchIssueTags';
 
@@ -144,7 +144,7 @@ function IssueListSearchBar({organization, tags, onClose, ...props}: Props) {
       });
 
       return await Promise.all([eventsDatasetValues, issuePlatformDatasetValues]).then(
-        tagValues => mergeTagValues(tagValues[0], tagValues[1])
+        tagValues => mergeAndSortTagValues(tagValues[0], tagValues[1])
       );
     },
     [

--- a/static/app/views/issueList/searchBar.tsx
+++ b/static/app/views/issueList/searchBar.tsx
@@ -24,6 +24,8 @@ import useApi from 'sentry/utils/useApi';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import type {WithIssueTagsProps} from 'sentry/utils/withIssueTags';
 import withIssueTags from 'sentry/utils/withIssueTags';
+import {Dataset} from 'sentry/views/alerts/rules/metric/types';
+import {mergeTagValues} from 'sentry/views/issueDetails/utils';
 import {makeGetIssueTagValues} from 'sentry/views/issueList/utils/getIssueTagValues';
 import {useFetchIssueTags} from 'sentry/views/issueList/utils/useFetchIssueTags';
 
@@ -109,7 +111,7 @@ function IssueListSearchBar({organization, tags, onClose, ...props}: Props) {
   });
 
   const tagValueLoader = useCallback(
-    (key: string, search: string) => {
+    async (key: string, search: string) => {
       const orgSlug = organization.slug;
       const projectIds = pageFilters.projects.map(id => id.toString());
       const endpointParams = {
@@ -121,15 +123,27 @@ function IssueListSearchBar({organization, tags, onClose, ...props}: Props) {
           : undefined,
         statsPeriod: pageFilters.datetime.period,
       };
-
-      return fetchTagValues({
+      const eventsDatasetValues = await fetchTagValues({
         api,
         orgSlug,
         tagKey: key,
         search,
         projectIds,
         endpointParams,
+        dataset: Dataset.ERRORS,
       });
+
+      const issuePlatformDatasetValues = await fetchTagValues({
+        api,
+        orgSlug,
+        tagKey: key,
+        search,
+        projectIds,
+        endpointParams,
+        dataset: Dataset.ISSUE_PLATFORM,
+      });
+
+      return mergeTagValues(eventsDatasetValues, issuePlatformDatasetValues);
     },
     [
       api,

--- a/static/app/views/issueList/utils.spec.tsx
+++ b/static/app/views/issueList/utils.spec.tsx
@@ -1,3 +1,6 @@
+import type {TagValue} from 'sentry/types';
+import {mergeAndSortTagValues} from 'sentry/views/issueDetails/utils';
+
 import {getTabs} from './utils';
 
 describe('getTabs', () => {
@@ -15,6 +18,141 @@ describe('getTabs', () => {
       ['is:escalating', expect.objectContaining({name: 'Escalating'})],
       ['is:archived', expect.objectContaining({name: 'Archived'})],
       ['is:reprocessing', expect.objectContaining({name: 'Reprocessing'})],
+    ]);
+  });
+
+  it('merges and sorts tagValues by count correctly', () => {
+    const defaultTagValueFields = {
+      email: '',
+      id: '',
+      name: '',
+      username: '',
+      ip_address: '',
+    };
+    const tagValues1: TagValue[] = [
+      {
+        value: 'a',
+        count: 1,
+        lastSeen: '2021-01-01T00:00:00',
+        firstSeen: '2021-01-01T00:00:00',
+        ...defaultTagValueFields,
+      },
+      {
+        value: 'b',
+        count: 1,
+        lastSeen: '2021-01-02T00:00:00',
+        firstSeen: '2021-01-02T00:00:00',
+        ...defaultTagValueFields,
+      },
+    ];
+
+    const tagValues2: TagValue[] = [
+      {
+        value: 'a',
+        count: 1,
+        lastSeen: '2021-01-01T00:00:00',
+        firstSeen: '2021-01-01T00:00:00',
+        ...defaultTagValueFields,
+      },
+      {
+        value: 'c',
+        count: 3,
+        lastSeen: '2021-01-03T00:00:00',
+        firstSeen: '2021-01-03T00:00:00',
+        ...defaultTagValueFields,
+      },
+    ];
+    const sortByCount = mergeAndSortTagValues(tagValues1, tagValues2, 'count');
+    expect(sortByCount).toEqual([
+      {
+        value: 'c',
+        count: 3,
+        lastSeen: '2021-01-03T00:00:00',
+        firstSeen: '2021-01-03T00:00:00',
+        ...defaultTagValueFields,
+      },
+      {
+        value: 'a',
+        count: 2,
+        lastSeen: '2021-01-01T00:00:00',
+        firstSeen: '2021-01-01T00:00:00',
+        ...defaultTagValueFields,
+      },
+      {
+        value: 'b',
+        count: 1,
+        lastSeen: '2021-01-02T00:00:00',
+        firstSeen: '2021-01-02T00:00:00',
+        ...defaultTagValueFields,
+      },
+    ]);
+  });
+
+  it('merges and sorts tagValues by lastSeen correctly', () => {
+    const defaultTagValueFields = {
+      email: '',
+      id: '',
+      name: '',
+      username: '',
+      ip_address: '',
+    };
+    const tagValues1: TagValue[] = [
+      {
+        value: 'a',
+        count: 1,
+        lastSeen: '2021-01-01T00:00:00',
+        firstSeen: '2021-01-01T00:00:00',
+        ...defaultTagValueFields,
+      },
+      {
+        value: 'b',
+        count: 1,
+        lastSeen: '2021-01-02T00:00:00',
+        firstSeen: '2021-01-02T00:00:00',
+        ...defaultTagValueFields,
+      },
+    ];
+
+    const tagValues2: TagValue[] = [
+      {
+        value: 'a',
+        count: 1,
+        lastSeen: '2021-01-01T00:00:00',
+        firstSeen: '2021-01-01T00:00:00',
+        ...defaultTagValueFields,
+      },
+      {
+        value: 'c',
+        count: 3,
+        lastSeen: '2021-01-03T00:00:00',
+        firstSeen: '2021-01-03T00:00:00',
+        ...defaultTagValueFields,
+      },
+    ];
+
+    const sortByLastSeen = mergeAndSortTagValues(tagValues1, tagValues2, 'lastSeen');
+    expect(sortByLastSeen).toEqual([
+      {
+        value: 'c',
+        count: 3,
+        lastSeen: '2021-01-03T00:00:00',
+        firstSeen: '2021-01-03T00:00:00',
+        ...defaultTagValueFields,
+      },
+      {
+        value: 'b',
+        count: 1,
+        lastSeen: '2021-01-02T00:00:00',
+        firstSeen: '2021-01-02T00:00:00',
+        ...defaultTagValueFields,
+      },
+      {
+        value: 'a',
+        count: 2,
+        lastSeen: '2021-01-01T00:00:00',
+        firstSeen: '2021-01-01T00:00:00',
+        ...defaultTagValueFields,
+      },
     ]);
   });
 });


### PR DESCRIPTION
This PR updates the fetch made to the `organization/<slug>/tags/<key>/values/` endpoint on the frontend within the issue stream search bar and the issue details page. Specifically, it makes the request twice now, and utilizes the extra `dataset` query parameter (which was added in [this PR](https://github.com/getsentry/sentry/pull/74525)) to query only the tag values from the Errors and IssuePlatform datasets. This is in an effort to make the requests faster and more accurate. 

Should be merged after #74696 so we can track the performance improvements of these changes. 