### PR TITLE
chore(tags): Set sentry tag for dataset in tag key value endpoint

### DIFF
--- a/src/sentry/api/endpoints/organization_tagkey_values.py
+++ b/src/sentry/api/endpoints/organization_tagkey_values.py
@@ -36,8 +36,15 @@ class OrganizationTagKeyValuesEndpoint(OrganizationEventsEndpointBase):
         if request.GET.get("dataset"):
             try:
                 dataset = Dataset(request.GET.get("dataset"))
+                sentry_sdk.set_tag("dataset", dataset.value)
             except ValueError:
                 raise ParseError(detail="Invalid dataset parameter")
+        elif request.GET.get("includeTransactions") == "1":
+            sentry_sdk.set_tag("dataset", Dataset.Discover.value)
+        elif request.GET.get("includeReplays") == "1":
+            sentry_sdk.set_tag("dataset", Dataset.Replays.value)
+        else:
+            sentry_sdk.set_tag("dataset", Dataset.Events.value)
 
         try:
             # still used by events v1 which doesn't require global views


### PR DESCRIPTION
This endpoint was [recently updated](https://github.com/getsentry/sentry/pull/74525) to allow for a specific dataset to be queried. We'd like to track that information to see how big of an improvement this customizability makes. 