### PR TITLE
fix(metrics): Allow upper and lower cases in equation field

### DIFF
--- a/static/app/components/metrics/equationInput/index.tsx
+++ b/static/app/components/metrics/equationInput/index.tsx
@@ -56,7 +56,7 @@ export function EquationInput({
 
   const validateVariable = useCallback(
     (variable: string): string | null => {
-      if (!availableVariables.has(variable)) {
+      if (!availableVariables.has(variable.toLowerCase())) {
         return t('Unknown query "%s"', variable);
       }
       return null;
@@ -156,7 +156,7 @@ export function EquationInput({
         monospace
         hasError={showErrors && errors.length > 0}
         defaultValue={value}
-        placeholder="e.g. (a / b) * 100"
+        placeholder="e.g. (A / B) * 100"
         onChange={e => {
           setValue(e.target.value);
           handleChange(e);

--- a/static/app/components/metrics/equationInput/syntax/equation.pegjs
+++ b/static/app/components/metrics/equationInput/syntax/equation.pegjs
@@ -10,7 +10,7 @@ coefficient = number / variable / open_paren _ expression _ close_paren
 
 
 number              = [0-9]+('.'[0-9]+)? { return { type: "number", content: text()}}
-variable            = [a-z]+ { return { type: "variable", content: text()}}
+variable            = [a-zA-Z]+ { return { type: "variable", content: text()}}
 _                   = " "* { return { type: "whitespace", content: text()}}
 
 open_paren          = "(" { return { type: "openParen", content: text()}}


### PR DESCRIPTION
### Goal

The UI now displays the Query's symbols in uppercase, so we should allow users to also use uppercase symbols. This PR fixes it.

closes https://github.com/getsentry/sentry/issues/74632