### PR TITLE
feat(metrics): redesign extraction rule modal

### DIFF
--- a/static/app/views/metrics/layout.spec.tsx
+++ b/static/app/views/metrics/layout.spec.tsx
@@ -52,9 +52,9 @@ describe('Metrics Layout', function () {
 
     render(<MetricsLayout />, {organization});
 
-    // Button: Add New Metric
+    // Button: Create metric
     expect(
-      await screen.findByRole('button', {name: 'Add New Metric'})
+      await screen.findByRole('button', {name: 'Create metric'})
     ).toBeInTheDocument();
 
     // Alert: No alert shall be rendered
@@ -85,10 +85,8 @@ describe('Metrics Layout', function () {
     // Button: Set Up Tracing
     expect(screen.getByRole('button', {name: 'Set Up Tracing'})).toBeInTheDocument();
 
-    // Not in the page: Add New Metric
-    expect(
-      screen.queryByRole('button', {name: 'Add New Metric'})
-    ).not.toBeInTheDocument();
+    // Not in the page: Create metric
+    expect(screen.queryByRole('button', {name: 'Create metric'})).not.toBeInTheDocument();
   });
 
   it('not using performance and have old custom metrics', async function () {
@@ -106,8 +104,8 @@ describe('Metrics Layout', function () {
       await screen.findByText(/Metrics using with the old API will stop being ingested/i)
     ).toBeInTheDocument();
 
-    // Button: Add New Metric
-    expect(screen.getByRole('button', {name: 'Add New Metric'})).toBeInTheDocument();
+    // Button: Create metric
+    expect(screen.getByRole('button', {name: 'Create metric'})).toBeInTheDocument();
 
     // Main View: Does not display the empty state.
     expect(screen.queryByText(/track and solve what matters/i)).not.toBeInTheDocument();

--- a/static/app/views/metrics/pageHeaderActions.spec.tsx
+++ b/static/app/views/metrics/pageHeaderActions.spec.tsx
@@ -48,7 +48,7 @@ describe('Metrics Page Header Actions', function () {
       await userEvent.click(button);
 
       expect(
-        await screen.findByRole('heading', {name: /Configure Metric/})
+        await screen.findByRole('heading', {name: 'Create Metric'})
       ).toBeInTheDocument();
     });
   });

--- a/static/app/views/metrics/pageHeaderActions.spec.tsx
+++ b/static/app/views/metrics/pageHeaderActions.spec.tsx
@@ -27,7 +27,7 @@ describe('Metrics Page Header Actions', function () {
       expect(addCustomMetric).toHaveBeenCalled();
     });
 
-    it('display "add new metric" button', async function () {
+    it('display "Create metric" button', async function () {
       render(
         <PageHeaderActions showAddMetricButton addCustomMetric={() => jest.fn()} />,
         {
@@ -41,7 +41,7 @@ describe('Metrics Page Header Actions', function () {
       );
       renderGlobalModal();
 
-      const button = screen.getByRole('button', {name: 'Add New Metric'});
+      const button = screen.getByRole('button', {name: 'Create metric'});
 
       expect(button).toBeInTheDocument();
 

--- a/static/app/views/metrics/pageHeaderActions.tsx
+++ b/static/app/views/metrics/pageHeaderActions.tsx
@@ -150,7 +150,7 @@ export function PageHeaderActions({showAddMetricButton, addCustomMetric}: Props)
             onClick={() => openExtractionRuleCreateModal({})}
             size="sm"
           >
-            {t('Add New Metric')}
+            {t('Create metric')}
           </Button>
         ) : (
           <Button priority="primary" onClick={() => addCustomMetric()} size="sm">

--- a/static/app/views/settings/projectMetrics/metricsExtractionRuleCreateModal.tsx
+++ b/static/app/views/settings/projectMetrics/metricsExtractionRuleCreateModal.tsx
@@ -109,7 +109,7 @@ export function MetricsExtractionRuleCreateModal({
   return (
     <Fragment>
       <Header>
-        <h4>{t('Configure Metric')}</h4>
+        <h4>{t('Create Metric')}</h4>
       </Header>
       <CloseButton />
       <Body>
@@ -122,6 +122,7 @@ export function MetricsExtractionRuleCreateModal({
               options={projectOptions}
               value={projectId}
               onChange={({value}) => setProjectId(value)}
+              stacked={false}
             />
           </ProjectSelectionWrapper>
         ) : null}
@@ -213,9 +214,9 @@ function FormWrapper({
 
 const ProjectSelectionWrapper = styled('div')`
   padding-bottom: ${space(2)};
-  padding-left: ${space(2)};
-  :not(:last-child) {
-    border-bottom: 1px solid ${p => p.theme.innerBorder};
+
+  & > label {
+    color: ${p => p.theme.gray300};
   }
 `;
 

--- a/static/app/views/settings/projectMetrics/metricsExtractionRuleCreateModal.tsx
+++ b/static/app/views/settings/projectMetrics/metricsExtractionRuleCreateModal.tsx
@@ -208,6 +208,7 @@ function FormWrapper({
       onCancel={closeModal}
       onSubmit={handleSubmit}
       cardinality={cardinality}
+      submitDisabled={createExtractionRuleMutation.isLoading}
     />
   );
 }

--- a/static/app/views/settings/projectMetrics/metricsExtractionRuleEditModal.tsx
+++ b/static/app/views/settings/projectMetrics/metricsExtractionRuleEditModal.tsx
@@ -98,7 +98,7 @@ export function MetricsExtractionRuleEditModal({
   return (
     <Fragment>
       <Header>
-        <h4>{metricExtractionRule.spanAttribute}</h4>
+        <h4>{t('Edit Metric')}</h4>
       </Header>
       <CloseButton />
       <Body>

--- a/static/app/views/settings/projectMetrics/metricsExtractionRuleEditModal.tsx
+++ b/static/app/views/settings/projectMetrics/metricsExtractionRuleEditModal.tsx
@@ -110,6 +110,7 @@ export function MetricsExtractionRuleEditModal({
           onCancel={closeModal}
           onSubmit={handleSubmit}
           cardinality={cardinality}
+          submitDisabled={updateExtractionRuleMutation.isLoading}
           isEdit
           requireChanges
         />

--- a/static/app/views/settings/projectMetrics/metricsExtractionRulesTable.spec.tsx
+++ b/static/app/views/settings/projectMetrics/metricsExtractionRulesTable.spec.tsx
@@ -116,9 +116,7 @@ describe('Metrics Extraction Rules Table', function () {
     const editButtons = await screen.findAllByLabelText('Edit metric');
     await userEvent.click(editButtons[1]);
 
-    expect(
-      await screen.findByRole('heading', {name: /span.duration/})
-    ).toBeInTheDocument();
+    expect(await screen.findByRole('heading', {name: 'Edit Metric'})).toBeInTheDocument();
   });
 
   it('shall display cardinality limit warning', async function () {


### PR DESCRIPTION
- closes: #74486 
![image](https://github.com/user-attachments/assets/0acd7098-090e-4c5a-9450-5b3fc10ca864)
![image](https://github.com/user-attachments/assets/c9598c8c-a591-4ba2-aa4a-144cc485c1f6)

- note: Red Alert indicating breaking dependant Alerts and widgets will be done in a followup
