### PR TITLE
ref(traces): Add 'open in metrics' button

### DIFF
--- a/static/app/components/keyValueData/index.tsx
+++ b/static/app/components/keyValueData/index.tsx
@@ -1,5 +1,6 @@
 import {Children, isValidElement, type ReactNode, useRef, useState} from 'react';
 import React from 'react';
+import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import {useIssueDetailsColumnCount} from 'sentry/components/events/eventTags/util';
@@ -89,12 +90,11 @@ export function Content({
         {hasSuffix && (
           <div>
             {hasErrors && <AnnotatedTextErrors errors={errors} />}
-            {actionButton &&
-              (actionButtonAlwaysVisible ? (
-                actionButton
-              ) : (
-                <ActionButtonWrapper>{actionButton}</ActionButtonWrapper>
-              ))}
+            {actionButton && (
+              <ActionButtonWrapper actionButtonAlwaysVisible={actionButtonAlwaysVisible}>
+                {actionButton}
+              </ActionButtonWrapper>
+            )}
           </div>
         )}
       </ValueSection>
@@ -288,11 +288,15 @@ const ValueLink = styled(Link)`
   text-decoration: ${p => p.theme.linkUnderline} underline dotted;
 `;
 
-const ActionButtonWrapper = styled('div')`
-  visibility: hidden;
-  ${ContentWrapper}:hover & {
-    visibility: visible;
-  }
+const ActionButtonWrapper = styled('div')<{actionButtonAlwaysVisible?: boolean}>`
+  ${p =>
+    !p.actionButtonAlwaysVisible &&
+    css`
+      visibility: hidden;
+      ${ContentWrapper}:hover & {
+        visibility: visible;
+      }
+    `}
 `;
 
 export const KeyValueData = {

--- a/static/app/components/keyValueData/index.tsx
+++ b/static/app/components/keyValueData/index.tsx
@@ -47,7 +47,14 @@ export function Content({
   disableFormattedData = false,
   ...props
 }: KeyValueDataContentProps) {
-  const {subject, subjectNode, value: contextValue, action = {}, actionButton} = item;
+  const {
+    subject,
+    subjectNode,
+    value: contextValue,
+    action = {},
+    actionButton,
+    actionButtonAlwaysVisible,
+  } = item;
 
   const hasErrors = errors.length > 0;
   const hasSuffix = !!(hasErrors || actionButton);
@@ -82,7 +89,12 @@ export function Content({
         {hasSuffix && (
           <div>
             {hasErrors && <AnnotatedTextErrors errors={errors} />}
-            {actionButton && <ActionButtonWrapper>{actionButton}</ActionButtonWrapper>}
+            {actionButton &&
+              (actionButtonAlwaysVisible ? (
+                actionButton
+              ) : (
+                <ActionButtonWrapper>{actionButton}</ActionButtonWrapper>
+              ))}
           </div>
         )}
       </ValueSection>

--- a/static/app/types/group.tsx
+++ b/static/app/types/group.tsx
@@ -902,6 +902,9 @@ export type KeyValueListDataItem = {
     link?: string | LocationDescriptor;
   };
   actionButton?: React.ReactNode;
+  /**
+   * If true, the action button will always be visible, not just on hover.
+   */
   actionButtonAlwaysVisible?: boolean;
   isContextData?: boolean;
   isMultiValue?: boolean;

--- a/static/app/types/group.tsx
+++ b/static/app/types/group.tsx
@@ -902,6 +902,7 @@ export type KeyValueListDataItem = {
     link?: string | LocationDescriptor;
   };
   actionButton?: React.ReactNode;
+  actionButtonAlwaysVisible?: boolean;
   isContextData?: boolean;
   isMultiValue?: boolean;
   meta?: Meta;

--- a/static/app/utils/metrics/virtualMetricsContext.tsx
+++ b/static/app/utils/metrics/virtualMetricsContext.tsx
@@ -57,7 +57,7 @@ interface Props {
   children: React.ReactNode;
 }
 
-function createVirtualMRI(rule: MetricsExtractionRule): MRI {
+export function createVirtualMRI(rule: MetricsExtractionRule): MRI {
   return `v:custom/${rule.spanAttribute}|${rule.projectId}@${rule.unit}`;
 }
 

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/sections/keys.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/sections/keys.tsx
@@ -1,6 +1,7 @@
 import {Fragment, useMemo} from 'react';
+import {Link} from 'react-router';
 
-import {Button, LinkButton} from 'sentry/components/button';
+import {Button} from 'sentry/components/button';
 import {
   rawSpanKeys,
   type RawSpanType,
@@ -90,7 +91,7 @@ function getSpanTimeWindow(timestamp: number) {
   };
 }
 
-function getNonSizeKeyActionButtonData({
+function getNonSizeKeyActionData({
   organization,
   extractionRules,
   spanAttribute,
@@ -113,11 +114,10 @@ function getNonSizeKeyActionButtonData({
 
   if (extractionRule) {
     const virtualMRI = createVirtualMRI(extractionRule);
-    const spanTimeWindow = getSpanTimeWindow(spanTimestamp);
+    const spanTimeWindow = getSpanTimeWindow(spanTimestamp * 1000);
     return {
       actionButton: (
-        <LinkButton
-          size="xs"
+        <Link
           to={getMetricsUrl(organization.slug, {
             start: getUtcDateString(spanTimeWindow.startTime),
             end: getUtcDateString(spanTimeWindow.endTime),
@@ -135,7 +135,7 @@ function getNonSizeKeyActionButtonData({
           })}
         >
           {t('Open in Metrics')}
-        </LinkButton>
+        </Link>
       ),
       actionButtonAlwaysVisible: true,
     };
@@ -246,12 +246,12 @@ export function SpanKeys({
         key: key,
         subject: key,
         value: value as string | number,
-        ...getNonSizeKeyActionButtonData({
+        ...getNonSizeKeyActionData({
           organization,
           extractionRules,
           spanAttribute: key,
           projectId,
-          spanTimestamp: span.timestamp * 1000,
+          spanTimestamp: span.timestamp,
         }),
       });
     }

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/sections/keys.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/sections/keys.tsx
@@ -1,5 +1,4 @@
 import {Fragment, useMemo} from 'react';
-import Link from 'sentry/components/links/link';
 
 import {Button} from 'sentry/components/button';
 import {
@@ -14,6 +13,7 @@ import {
 import {OpsDot} from 'sentry/components/events/opsBreakdown';
 import FileSize from 'sentry/components/fileSize';
 import ExternalLink from 'sentry/components/links/externalLink';
+import Link from 'sentry/components/links/link';
 import {IconAdd} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/sections/keys.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/sections/keys.tsx
@@ -1,5 +1,5 @@
 import {Fragment, useMemo} from 'react';
-import {Link} from 'react-router';
+import Link from 'sentry/components/links/link';
 
 import {Button} from 'sentry/components/button';
 import {


### PR DESCRIPTION
### Goal
On the traces pages, we display a '+' button that allows users to add a new metric based on the span attribute when rendering the additional data card. This PR introduces a new button, 'Open in Metrics', which appears when an existing metrics rule is already defined for the span attribute. By clicking this button, users will be directed to the metrics page, pre-filtered with the first condition (query) and the first aggregation (agg by).

**Preview**




https://github.com/user-attachments/assets/cab3cd06-7087-43e9-b777-5ecfbc96c743



### Note:

~We typically render a very large button for 'Open in Discover'. However, this might be too much. I have configured the 'Open in Metrics' button to be 'xs' but feedback is welcome :)~ Now its a link 

closes https://github.com/getsentry/sentry/issues/74622