### PR TITLE
ref(metrics): Update extrapolation toggle copies

### DIFF
--- a/static/app/views/settings/projectMetrics/extrapolationField.tsx
+++ b/static/app/views/settings/projectMetrics/extrapolationField.tsx
@@ -42,14 +42,14 @@ export function ExtrapolationField({project}: ExtrapolationFieldProps) {
       });
     },
     onMutate: () => {
-      addLoadingMessage(t('Toggling metrics extrapolation'));
+      addLoadingMessage(t('Toggling sampled mode'));
     },
     onSuccess: updatedProject => {
-      addSuccessMessage(t('Successfully toggled metrics extrapolation'));
+      addSuccessMessage(t('Successfully toggled sampled mode'));
       ProjectsStore.onUpdateSuccess(updatedProject);
     },
     onError: () => {
-      addErrorMessage(t('Failed to toggle metrics extrapolation'));
+      addErrorMessage(t('Failed to toggle sampled mode'));
     },
   });
 
@@ -61,9 +61,9 @@ export function ExtrapolationField({project}: ExtrapolationFieldProps) {
           value={isToggleEnabled}
           name="metrics-extrapolation-toggle"
           disabled={!project.access.includes('project:write')} // admin, manager and owner of an organization will be able to edit this field
-          label={t('Metrics Extrapolation')}
+          label={t('Sampled Mode')}
           help={tct(
-            'Enables metrics extrapolation from sampled data, providing more reliable and comprehensive metrics for your project. To learn more about metrics extrapolation, [link:read the docs]',
+            'Typically, Sentry uses weights to approximate original volume and correct sampling skew. Enable sampled mode to view raw event data, where sample rates are ignored in calculations. [link:Read the docs] to learn more.',
             {
               // TODO(telemetry-experience): Add link to metrics extrapolation docs when available
               link: <ExternalLink href="https://docs.sentry.io/product/metrics/" />,


### PR DESCRIPTION
### Goal

This PR just updates the copies we have decided on for the metrics extrapolation toggle. Now we call it 'Sampled Mode'

![image](https://github.com/user-attachments/assets/a9344d1a-8c4a-481e-ad5b-6ffed67445b6)

closes https://github.com/getsentry/sentry/issues/74126