### PR TITLE
feat(dashboards): Add split source field to API response

### DIFF
--- a/src/sentry/api/bases/organization_events.py
+++ b/src/sentry/api/bases/organization_events.py
@@ -25,6 +25,7 @@ from sentry.discover.arithmetic import is_equation, strip_equation
 from sentry.discover.models import DatasetSourcesTypes, DiscoverSavedQueryTypes
 from sentry.exceptions import InvalidSearchQuery
 from sentry.models.dashboard_widget import DashboardWidgetTypes
+from sentry.models.dashboard_widget import DatasetSourcesTypes as DashboardDatasetSourcesTypes
 from sentry.models.group import Group
 from sentry.models.organization import Organization
 from sentry.models.project import Project
@@ -262,7 +263,7 @@ class OrganizationEventsV2EndpointBase(OrganizationEventsEndpointBase):
             and widget.discover_widget_split != new_discover_widget_split
         ):
             widget.discover_widget_split = new_discover_widget_split
-            widget.dataset_source = DatasetSourcesTypes.INFERRED.value
+            widget.dataset_source = DashboardDatasetSourcesTypes.INFERRED.value
             widget.save()
 
         return new_discover_widget_split

--- a/src/sentry/api/bases/organization_events.py
+++ b/src/sentry/api/bases/organization_events.py
@@ -262,6 +262,7 @@ class OrganizationEventsV2EndpointBase(OrganizationEventsEndpointBase):
             and widget.discover_widget_split != new_discover_widget_split
         ):
             widget.discover_widget_split = new_discover_widget_split
+            widget.dataset_source = DatasetSourcesTypes.INFERRED.value
             widget.save()
 
         return new_discover_widget_split

--- a/src/sentry/api/serializers/models/dashboard.py
+++ b/src/sentry/api/serializers/models/dashboard.py
@@ -5,6 +5,7 @@ import orjson
 from sentry import features
 from sentry.api.serializers import Serializer, register, serialize
 from sentry.constants import ALL_ACCESS_PROJECTS
+from sentry.discover.models import DatasetSourcesTypes
 from sentry.models.dashboard import Dashboard
 from sentry.models.dashboard_widget import (
     DashboardWidget,
@@ -16,6 +17,8 @@ from sentry.models.dashboard_widget import (
 from sentry.snuba.metrics.extraction import OnDemandMetricSpecVersioning
 from sentry.users.services.user.service import user_service
 from sentry.utils.dates import outside_retention_with_modified_start, parse_timestamp
+
+DATASET_SOURCES = dict(DatasetSourcesTypes.as_choices())
 
 
 @register(DashboardWidget)
@@ -67,6 +70,7 @@ class DashboardWidgetSerializer(Serializer):
             # Default to discover type if null
             "widgetType": widget_type,
             "layout": obj.detail.get("layout") if obj.detail else None,
+            "datasetSource": DATASET_SOURCES[obj.dataset_source],
         }
 
 

--- a/tests/snuba/api/endpoints/test_organization_events_mep.py
+++ b/tests/snuba/api/endpoints/test_organization_events_mep.py
@@ -5,7 +5,7 @@ import pytest
 from django.urls import reverse
 from rest_framework.response import Response
 
-from sentry.discover.models import TeamKeyTransaction
+from sentry.discover.models import DatasetSourcesTypes, TeamKeyTransaction
 from sentry.models.dashboard_widget import DashboardWidgetTypes
 from sentry.models.projectteam import ProjectTeam
 from sentry.models.transaction_threshold import (
@@ -3679,6 +3679,7 @@ class OrganizationEventsMetricsEnhancedPerformanceEndpointTestWithOnDemandMetric
 
         widget.refresh_from_db()
         assert widget.discover_widget_split == DashboardWidgetTypes.ERROR_EVENTS
+        assert widget.dataset_source == DatasetSourcesTypes.INFERRED.value
 
     def test_split_decision_for_transactions_widget(self):
         transaction_data = load_data("transaction", timestamp=before_now(minutes=1))
@@ -3711,6 +3712,7 @@ class OrganizationEventsMetricsEnhancedPerformanceEndpointTestWithOnDemandMetric
 
         widget.refresh_from_db()
         assert widget.discover_widget_split == DashboardWidgetTypes.TRANSACTION_LIKE
+        assert widget.dataset_source == DatasetSourcesTypes.INFERRED.value
 
     def test_split_decision_for_ambiguous_widget_without_data(self):
         _, widget, __ = create_widget(
@@ -3736,6 +3738,7 @@ class OrganizationEventsMetricsEnhancedPerformanceEndpointTestWithOnDemandMetric
 
         widget.refresh_from_db()
         assert widget.discover_widget_split is None
+        assert widget.dataset_source == DatasetSourcesTypes.UNKNOWN.value
 
     def test_split_decision_for_ambiguous_widget_with_data(self):
         # Store a transaction


### PR DESCRIPTION
Adds a dataset_source field to the dashboard API response to show how the source was set. Will be useful when showing alerts in the UI for the user when a dataset was automatically selected for them.

For now I only add the INFERRED enum when there's a new split decision. I'll put up a different PR for the forced dataset changes.
