### PR TITLE
feat(dashboards): Default widget split decision to errors

### DIFF
--- a/src/sentry/api/endpoints/organization_events.py
+++ b/src/sentry/api/endpoints/organization_events.py
@@ -438,7 +438,7 @@ class OrganizationEventsEndpoint(OrganizationEventsV2EndpointBase):
                     error_results = None
 
                 original_results = _data_fn(scoped_dataset, offset, limit, scoped_query)
-                if original_results.get("data"):
+                if original_results.get("data") is not None:
                     dataset_meta = original_results.get("meta", {})
                 else:
                     dataset_meta = list(original_results.values())[0].get("data").get("meta", {})

--- a/src/sentry/api/endpoints/organization_events.py
+++ b/src/sentry/api/endpoints/organization_events.py
@@ -460,7 +460,9 @@ class OrganizationEventsEndpoint(OrganizationEventsV2EndpointBase):
                     transaction_results = _data_fn(discover, offset, limit, transactions_only_query)
                     has_transactions = len(transaction_results["data"]) > 0
 
-                decision = self.save_split_decision(widget, has_errors, has_transactions)
+                decision = self.save_split_decision(
+                    widget, has_errors, has_transactions, organization, request.user
+                )
 
                 if decision == DashboardWidgetTypes.DISCOVER:
                     return _data_fn(discover, offset, limit, scoped_query)

--- a/src/sentry/api/endpoints/organization_events_stats.py
+++ b/src/sentry/api/endpoints/organization_events_stats.py
@@ -421,7 +421,9 @@ class OrganizationEventsStatsEndpoint(OrganizationEventsV2EndpointBase):
                         )
                         has_transactions = self.check_if_results_have_data(transaction_results)
 
-                    decision = self.save_split_decision(widget, has_errors, has_transactions)
+                    decision = self.save_split_decision(
+                        widget, has_errors, has_transactions, organization, request.user
+                    )
 
                     if decision == DashboardWidgetTypes.DISCOVER:
                         # The user needs to be warned to split in this case.

--- a/tests/snuba/api/endpoints/test_organization_events_mep.py
+++ b/tests/snuba/api/endpoints/test_organization_events_mep.py
@@ -3730,7 +3730,8 @@ class OrganizationEventsMetricsEnhancedPerformanceEndpointTestWithOnDemandMetric
                 "dataset": "metricsEnhanced",
                 "per_page": 50,
                 "dashboardWidgetId": widget.id,
-            }
+            },
+            features={"organizations:performance-discover-dataset-selector": True},
         )
 
         assert response.status_code == 200, response.content
@@ -3777,7 +3778,8 @@ class OrganizationEventsMetricsEnhancedPerformanceEndpointTestWithOnDemandMetric
                 "dataset": "metricsEnhanced",
                 "per_page": 50,
                 "dashboardWidgetId": widget.id,
-            }
+            },
+            features={"organizations:performance-discover-dataset-selector": True},
         )
 
         assert response.status_code == 200, response.content

--- a/tests/snuba/api/endpoints/test_organization_events_mep.py
+++ b/tests/snuba/api/endpoints/test_organization_events_mep.py
@@ -3788,7 +3788,7 @@ class OrganizationEventsMetricsEnhancedPerformanceEndpointTestWithOnDemandMetric
         ) == DashboardWidgetTypes.get_type_name(DashboardWidgetTypes.ERROR_EVENTS)
 
         widget.refresh_from_db()
-        assert widget.discover_widget_split is DashboardWidgetTypes.ERROR_EVENTS
+        assert widget.discover_widget_split == DashboardWidgetTypes.ERROR_EVENTS
         assert widget.dataset_source == DatasetSourcesTypes.FORCED.value
 
 

--- a/tests/snuba/api/endpoints/test_organization_events_mep.py
+++ b/tests/snuba/api/endpoints/test_organization_events_mep.py
@@ -3725,7 +3725,7 @@ class OrganizationEventsMetricsEnhancedPerformanceEndpointTestWithOnDemandMetric
 
         response = self.do_request(
             {
-                "field": ["count()", "transaction.name", "error.type"],
+                "field": ["count()", "transaction.op", "error.type"],
                 "query": "",
                 "dataset": "metricsEnhanced",
                 "per_page": 50,
@@ -3734,11 +3734,13 @@ class OrganizationEventsMetricsEnhancedPerformanceEndpointTestWithOnDemandMetric
         )
 
         assert response.status_code == 200, response.content
-        assert response.data.get("meta").get("discoverSplitDecision") is None
+        assert response.data.get("meta").get(
+            "discoverSplitDecision"
+        ) == DashboardWidgetTypes.get_type_name(DashboardWidgetTypes.ERROR_EVENTS)
 
         widget.refresh_from_db()
-        assert widget.discover_widget_split is None
-        assert widget.dataset_source == DatasetSourcesTypes.UNKNOWN.value
+        assert widget.discover_widget_split == DashboardWidgetTypes.ERROR_EVENTS
+        assert widget.dataset_source == DatasetSourcesTypes.FORCED.value
 
     def test_split_decision_for_ambiguous_widget_with_data(self):
         # Store a transaction
@@ -3779,10 +3781,13 @@ class OrganizationEventsMetricsEnhancedPerformanceEndpointTestWithOnDemandMetric
         )
 
         assert response.status_code == 200, response.content
-        assert response.data.get("meta").get("discoverSplitDecision") is None
+        assert response.data.get("meta").get(
+            "discoverSplitDecision"
+        ) == DashboardWidgetTypes.get_type_name(DashboardWidgetTypes.ERROR_EVENTS)
 
         widget.refresh_from_db()
-        assert widget.discover_widget_split is DashboardWidgetTypes.DISCOVER
+        assert widget.discover_widget_split is DashboardWidgetTypes.ERROR_EVENTS
+        assert widget.dataset_source == DatasetSourcesTypes.FORCED.value
 
 
 class OrganizationEventsMetricsEnhancedPerformanceEndpointTestWithMetricLayer(

--- a/tests/snuba/api/endpoints/test_organization_events_stats_mep.py
+++ b/tests/snuba/api/endpoints/test_organization_events_stats_mep.py
@@ -8,6 +8,7 @@ import pytest
 from django.urls import reverse
 from rest_framework.response import Response
 
+from sentry.discover.models import DatasetSourcesTypes
 from sentry.models.dashboard_widget import DashboardWidget, DashboardWidgetTypes
 from sentry.models.environment import Environment
 from sentry.sentry_metrics.use_case_id_registry import UseCaseID
@@ -791,6 +792,7 @@ class OrganizationEventsStatsMetricsEnhancedPerformanceEndpointTest(
 
         widget.refresh_from_db()
         assert widget.discover_widget_split == DashboardWidgetTypes.ERROR_EVENTS
+        assert widget.dataset_source == DatasetSourcesTypes.INFERRED.value
 
     def test_split_decision_for_transactions_widget(self):
         self.store_transaction_metric(
@@ -820,6 +822,7 @@ class OrganizationEventsStatsMetricsEnhancedPerformanceEndpointTest(
 
         widget.refresh_from_db()
         assert widget.discover_widget_split == DashboardWidgetTypes.TRANSACTION_LIKE
+        assert widget.dataset_source == DatasetSourcesTypes.INFERRED.value
 
     def test_split_decision_for_top_events_errors_widget(self):
         error_data = load_data("python", timestamp=before_now(minutes=1))
@@ -860,6 +863,7 @@ class OrganizationEventsStatsMetricsEnhancedPerformanceEndpointTest(
 
         widget.refresh_from_db()
         assert widget.discover_widget_split == DashboardWidgetTypes.ERROR_EVENTS
+        assert widget.dataset_source == DatasetSourcesTypes.INFERRED.value
 
     def test_split_decision_for_top_events_transactions_widget(self):
         self.store_transaction_metric(
@@ -896,6 +900,7 @@ class OrganizationEventsStatsMetricsEnhancedPerformanceEndpointTest(
 
         widget.refresh_from_db()
         assert widget.discover_widget_split == DashboardWidgetTypes.TRANSACTION_LIKE
+        assert widget.dataset_source == DatasetSourcesTypes.INFERRED.value
 
     def test_split_decision_for_ambiguous_widget_without_data(self):
         _, widget, __ = create_widget(
@@ -917,10 +922,13 @@ class OrganizationEventsStatsMetricsEnhancedPerformanceEndpointTest(
         )
 
         assert response.status_code == 200, response.content
-        assert response.data.get("meta").get("discoverSplitDecision") is None
+        assert response.data.get("meta").get(
+            "discoverSplitDecision"
+        ) == DashboardWidgetTypes.get_type_name(DashboardWidgetTypes.ERROR_EVENTS)
 
         widget.refresh_from_db()
-        assert widget.discover_widget_split is None
+        assert widget.discover_widget_split == DashboardWidgetTypes.ERROR_EVENTS
+        assert widget.dataset_source == DatasetSourcesTypes.FORCED.value
 
 
 class OrganizationEventsStatsMetricsEnhancedPerformanceEndpointTestWithMetricLayer(
@@ -1569,15 +1577,14 @@ class OrganizationEventsStatsMetricsEnhancedPerformanceEndpointTestWithOnDemandW
         )
 
         saved_widget = DashboardWidget.objects.get(id=widget.id)
-        assert saved_widget.discover_widget_split == DashboardWidgetTypes.DISCOVER
+        assert saved_widget.discover_widget_split == DashboardWidgetTypes.ERROR_EVENTS
 
         assert response.status_code == 200, response.content
 
         assert response.status_code == 200, response.content
         # Fell back to discover data which is empty for this test (empty group of '').
-        assert len(response.data.keys()) == 2
+        assert len(response.data.keys()) == 1
         assert bool(response.data["error_value,"])
-        assert bool(response.data["transaction_value,"])
 
     def test_top_events_with_transaction_on_demand_passing_widget_id_saved(self):
         field = "count()"

--- a/tests/snuba/api/endpoints/test_organization_events_stats_mep.py
+++ b/tests/snuba/api/endpoints/test_organization_events_stats_mep.py
@@ -918,7 +918,8 @@ class OrganizationEventsStatsMetricsEnhancedPerformanceEndpointTest(
                 "dataset": "metricsEnhanced",
                 "per_page": 50,
                 "dashboardWidgetId": widget.id,
-            }
+            },
+            features={"organizations:performance-discover-dataset-selector": True},
         )
 
         assert response.status_code == 200, response.content
@@ -1577,14 +1578,15 @@ class OrganizationEventsStatsMetricsEnhancedPerformanceEndpointTestWithOnDemandW
         )
 
         saved_widget = DashboardWidget.objects.get(id=widget.id)
-        assert saved_widget.discover_widget_split == DashboardWidgetTypes.ERROR_EVENTS
+        assert saved_widget.discover_widget_split == DashboardWidgetTypes.DISCOVER
 
         assert response.status_code == 200, response.content
 
         assert response.status_code == 200, response.content
         # Fell back to discover data which is empty for this test (empty group of '').
-        assert len(response.data.keys()) == 1
+        assert len(response.data.keys()) == 2
         assert bool(response.data["error_value,"])
+        assert bool(response.data["transaction_value,"])
 
     def test_top_events_with_transaction_on_demand_passing_widget_id_saved(self):
         field = "count()"


### PR DESCRIPTION
In the case that neither side has data, or both sides have data, force
the dataset to errors and record the reason in the source field. This
way we can ensure the split occurs and also warn the user that they may
need to select a dataset.

Note: To avoid changing behaviour for existing on-demand users by forcing the split to use errors, I feature flagged the default scenario so without the feature flag the default is still discover.