### PR TITLE
ref: add threadId to continuous profile link

### DIFF
--- a/static/app/views/performance/newTraceDetails/traceApi/useTransaction.tsx
+++ b/static/app/views/performance/newTraceDetails/traceApi/useTransaction.tsx
@@ -6,14 +6,14 @@ import type {
 } from 'sentry/views/performance/newTraceDetails/traceModels/traceTree';
 
 interface UseTransactionProps {
-  node: TraceTreeNode<TraceTree.Transaction>;
+  node: TraceTreeNode<TraceTree.Transaction> | null;
   organization: Organization;
 }
 
 export function useTransaction(props: UseTransactionProps) {
   return useApiQuery<EventTransaction>(
     [
-      `/organizations/${props.organization.slug}/events/${props.node.value.project_slug}:${props.node.value.event_id}/`,
+      `/organizations/${props.organization.slug}/events/${props.node?.value?.project_slug}:${props?.node?.value.event_id}/`,
       {
         query: {
           referrer: 'trace-details-summary',

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/index.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/index.tsx
@@ -76,12 +76,12 @@ export function SpanNodeDetails({
 }: TraceTreeNodeDetailsProps<TraceTreeNode<TraceTree.Span>>) {
   const location = useLocation();
   const {projects} = useProjects();
-  const {event} = node.value;
   const issues = useMemo(() => {
     return [...node.errors, ...node.performance_issues];
   }, [node.errors, node.performance_issues]);
-  const project = projects.find(proj => proj.slug === event?.projectSlug);
-  const profileId = event?.contexts?.profile?.profile_id ?? null;
+
+  const project = projects.find(proj => proj.slug === node.value.event?.projectSlug);
+  const profileId = node.value.event?.contexts?.profile?.profile_id ?? null;
 
   return (
     <TraceDrawerComponents.DetailContainer>
@@ -91,10 +91,10 @@ export function SpanNodeDetails({
         project={project}
         onTabScrollToNode={onTabScrollToNode}
       />
-      {event.projectSlug ? (
+      {node.value.event.projectSlug ? (
         <ProfilesProvider
           orgSlug={organization.slug}
-          projectSlug={event.projectSlug}
+          projectSlug={node.value.event.projectSlug}
           profileId={profileId || ''}
         >
           <ProfileContext.Consumer>
@@ -129,9 +129,9 @@ export function SpanNodeDetails({
                     startTimestamp={node.value.start_timestamp}
                   />
                 </TraceDrawerComponents.SectionCardGroup>
-                <EventContexts event={event} />
+                <EventContexts event={node.value.event} />
                 {organization.features.includes('profiling') ? (
-                  <SpanProfileDetails span={node.value} event={event} />
+                  <SpanProfileDetails span={node.value} event={node.value.event} />
                 ) : null}
               </ProfileGroupProvider>
             )}

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/styles.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/styles.tsx
@@ -38,6 +38,7 @@ import {
   isTransactionNode,
 } from 'sentry/views/performance/newTraceDetails/guards';
 import {traceAnalytics} from 'sentry/views/performance/newTraceDetails/traceAnalytics';
+import {useTransaction} from 'sentry/views/performance/newTraceDetails/traceApi/useTransaction';
 import {makeTraceContinuousProfilingLink} from 'sentry/views/performance/newTraceDetails/traceDrawer/traceProfilingLink';
 import type {
   MissingInstrumentationNode,
@@ -329,6 +330,21 @@ const ValueTd = styled('td')`
   position: relative;
 `;
 
+function getThreadIdFromNode(
+  node: TraceTreeNode<TraceTree.NodeValue>,
+  transaction: EventTransaction | undefined
+): string | undefined {
+  if (isSpanNode(node) && node.value.data['thread.id']) {
+    return node.value.data['thread.id'];
+  }
+
+  if (transaction) {
+    return transaction.context?.trace?.data?.['thread.id'];
+  }
+
+  return undefined;
+}
+
 function NodeActions(props: {
   node: TraceTreeNode<any>;
   onTabScrollToNode: (
@@ -409,12 +425,17 @@ function NodeActions(props: {
     return '';
   }, [props]);
 
-  const params = useParams<{traceSlug?: string}>();
+  const {data: transaction} = useTransaction({
+    node: isTransactionNode(props.node) ? props.node : null,
+    organization,
+  });
 
+  const params = useParams<{traceSlug?: string}>();
   const profileLink = makeTraceContinuousProfilingLink(props.node, profilerId, {
     orgSlug: props.organization.slug,
     projectSlug: props.node.metadata.project_slug ?? '',
     traceId: params.traceSlug ?? '',
+    threadId: getThreadIdFromNode(props.node, transaction),
   });
 
   return (

--- a/static/app/views/performance/newTraceDetails/traceDrawer/traceProfilingLink.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/traceProfilingLink.spec.tsx
@@ -37,6 +37,7 @@ describe('traceProfilingLink', () => {
           projectSlug: 'project',
           orgSlug: '',
           traceId: '',
+          threadId: '0',
         })
       ).toBeNull();
     });
@@ -47,6 +48,7 @@ describe('traceProfilingLink', () => {
           projectSlug: '',
           orgSlug: 'sentry',
           traceId: '',
+          threadId: '0',
         })
       ).toBeNull();
     });
@@ -84,6 +86,7 @@ describe('traceProfilingLink', () => {
         projectSlug: 'project',
         orgSlug: 'sentry',
         traceId: 'trace',
+        threadId: '0',
       }
     );
 

--- a/static/app/views/performance/newTraceDetails/traceDrawer/traceProfilingLink.ts
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/traceProfilingLink.ts
@@ -51,6 +51,7 @@ export function makeTraceContinuousProfilingLink(
   options: {
     orgSlug: string;
     projectSlug: string;
+    threadId: string | undefined;
     traceId: string;
   },
   query: Location['query'] = {}
@@ -94,15 +95,19 @@ export function makeTraceContinuousProfilingLink(
     return null;
   }
 
-  const queryWithSpanIdAndTraceId: Record<string, string> = {
+  const queryWithEventData: Record<string, string> = {
     ...query,
     eventId,
     traceId: options.traceId,
   };
 
+  if (typeof options.threadId === 'string') {
+    queryWithEventData.tid = options.threadId;
+  }
+
   const spanId = getNodeId(node);
   if (spanId) {
-    queryWithSpanIdAndTraceId.spanId = spanId;
+    queryWithEventData.spanId = spanId;
   }
 
   return generateContinuousProfileFlamechartRouteWithQuery(
@@ -111,6 +116,6 @@ export function makeTraceContinuousProfilingLink(
     profilerId,
     start.toISOString(),
     end.toISOString(),
-    queryWithSpanIdAndTraceId
+    queryWithEventData
   );
 }

--- a/static/app/views/performance/newTraceDetails/traceModels/traceTree.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/traceTree.tsx
@@ -119,11 +119,12 @@ import {TraceType} from '../traceType';
 type ArgumentTypes<F> = F extends (...args: infer A) => any ? A : never;
 
 export declare namespace TraceTree {
+  interface RawSpan extends RawSpanType {}
   interface Transaction extends TraceFullDetailed {
     profiler_id: string;
     sdk_name: string;
   }
-  interface Span extends RawSpanType {
+  interface Span extends RawSpan {
     childTransactions: TraceTreeNode<TraceTree.Transaction>[];
     event: EventTransaction;
     measurements?: Record<string, Measurement>;
@@ -138,14 +139,14 @@ export declare namespace TraceTree {
     timestamp: number;
     type: 'missing_instrumentation';
   }
-  interface SiblingAutogroup extends RawSpanType {
+  interface SiblingAutogroup extends RawSpan {
     autogrouped_by: {
       description: string;
       op: string;
     };
   }
 
-  interface ChildrenAutogroup extends RawSpanType {
+  interface ChildrenAutogroup extends RawSpan {
     autogrouped_by: {
       op: string;
     };
@@ -861,7 +862,7 @@ export class TraceTree {
   static FromSpans(
     parent: TraceTreeNode<TraceTree.NodeValue>,
     data: Event,
-    spans: RawSpanType[],
+    spans: TraceTree.RawSpan[],
     options: {sdk: string | undefined} | undefined
   ): [TraceTreeNode<TraceTree.NodeValue>, [number, number] | null] {
     parent.invalidate(parent);
@@ -872,7 +873,7 @@ export class TraceTree {
 
     const parentIsSpan = isSpanNode(parent);
     const lookuptable: Record<
-      RawSpanType['span_id'],
+      TraceTree.RawSpan['span_id'],
       TraceTreeNode<TraceTree.Span | TraceTree.Transaction>
     > = {};
 
@@ -2483,7 +2484,7 @@ export function computeAutogroupedBarSegments(
 
 // Returns a list of errors related to the txn with ids matching the span id
 function getRelatedSpanErrorsFromTransaction(
-  span: RawSpanType,
+  span: TraceTree.RawSpan,
   node?: TraceTreeNode<TraceTree.NodeValue>
 ): TraceErrorType[] {
   if (!node || !node.value || !isTransactionNode(node)) {
@@ -2505,7 +2506,7 @@ function getRelatedSpanErrorsFromTransaction(
 
 // Returns a list of performance errors related to the txn with ids matching the span id
 function getRelatedPerformanceIssuesFromTransaction(
-  span: RawSpanType,
+  span: TraceTree.RawSpan,
   node?: TraceTreeNode<TraceTree.NodeValue>
 ): TraceTree.TracePerformanceIssue[] {
   if (!node || !node.value || !isTransactionNode(node)) {


### PR DESCRIPTION
We need tid (being added to be response) to be able to link to the correct segment in the code where the span/even occurred.