### PR TITLE
[CapMan visibility] Separates rejecting policy and throttling policy in Sentry tags and spans

### DIFF
--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -1110,11 +1110,11 @@ def _bulk_snuba_query(snuba_requests: Sequence[SnubaRequest]) -> ResultSet:
                     quota_allowance_summary["threads_used"],
                 )
                 for k, v in quota_allowance_summary["throttled_by"].items():
-                    k = allocation_policy_prefix + k
+                    k = allocation_policy_prefix + "throttling_policy." + k
                     span.set_tag(k, v)
                     sentry_sdk.set_tag(k, v)
                 for k, v in quota_allowance_summary["rejected_by"].items():
-                    k = allocation_policy_prefix + k
+                    k = allocation_policy_prefix + "rejecting_policy." + k
                     span.set_tag(k, v)
                     sentry_sdk.set_tag(k, v)
 


### PR DESCRIPTION
It's possible for a query to be in the throttling zone for an allocation policy in Snuba, and also in another allocation policy's rejection zone. In which case we see the following:

![Screenshot 2024-07-23 at 9 33 17 AM](https://github.com/user-attachments/assets/1e473f02-e3b2-4365-b0d5-c9a2ec3da101)

How could the `throttle_threshold` be higher than the `rejection_threshold`? This is due to the query being throttled by an allocation policy with a throttle threshold of 292000000000, but it's also rejected by `ConcurrentRateLimitAllocationPolicy` The mismatch is caused by not separating out the rejection policy and the throttle policy when creating Sentry tags and spans. 