### PR TITLE
fix(insights): Cache page alert re-rendering

### DIFF
--- a/static/app/utils/performance/contexts/pageAlert.tsx
+++ b/static/app/utils/performance/contexts/pageAlert.tsx
@@ -1,5 +1,5 @@
 import type React from 'react';
-import {createContext, Fragment, useContext, useState} from 'react';
+import {createContext, Fragment, useCallback, useContext, useState} from 'react';
 import type {Theme} from '@emotion/react';
 
 import {Alert} from 'sentry/components/alert';
@@ -45,24 +45,25 @@ const pageErrorContext = createContext<{
 export function PageAlertProvider({children}: {children: React.ReactNode}) {
   const [pageAlert, setPageAlert] = useState<PageAlertOptions | undefined>();
 
-  const setPageInfo: PageAlertSetter = (message, options) => {
+  const setPageInfo: PageAlertSetter = useCallback((message, options) => {
     setPageAlert({message, type: 'info', ...options});
-  };
-  const setPageMuted: PageAlertSetter = (message, options) => {
+  }, []);
+
+  const setPageMuted: PageAlertSetter = useCallback((message, options) => {
     setPageAlert({message, type: 'muted', ...options});
-  };
+  }, []);
 
-  const setPageSuccess: PageAlertSetter = (message, options) => {
+  const setPageSuccess: PageAlertSetter = useCallback((message, options) => {
     setPageAlert({message, type: 'success', ...options});
-  };
+  }, []);
 
-  const setPageWarning: PageAlertSetter = (message, options) => {
+  const setPageWarning: PageAlertSetter = useCallback((message, options) => {
     setPageAlert({message, type: 'warning', ...options});
-  };
+  }, []);
 
-  const setPageError: PageAlertSetter = (message, options) => {
+  const setPageError: PageAlertSetter = useCallback((message, options) => {
     setPageAlert({message, type: 'error', ...options});
-  };
+  }, []);
 
   return (
     <pageErrorContext.Provider

--- a/static/app/views/insights/cache/views/cacheLandingPage.tsx
+++ b/static/app/views/insights/cache/views/cacheLandingPage.tsx
@@ -12,6 +12,7 @@ import PageFilterBar from 'sentry/components/organizations/pageFilterBar';
 import {ProjectPageFilter} from 'sentry/components/organizations/projectPageFilter';
 import {PageHeadingQuestionTooltip} from 'sentry/components/pageHeadingQuestionTooltip';
 import {t} from 'sentry/locale';
+import {defined} from 'sentry/utils';
 import type {EventsMetaType} from 'sentry/utils/discover/eventView';
 import {
   DismissId,
@@ -151,7 +152,7 @@ export function CacheLandingPage() {
       cacheMissRateError?.message === CACHE_ERROR_MESSAGE ||
       transactionsListError?.message === CACHE_ERROR_MESSAGE;
 
-    if (onboardingProject || !hasData) {
+    if (defined(pageAlert?.message) && (onboardingProject || !hasData)) {
       setPageInfo(undefined);
       return;
     }

--- a/static/app/views/insights/cache/views/cacheLandingPage.tsx
+++ b/static/app/views/insights/cache/views/cacheLandingPage.tsx
@@ -12,7 +12,6 @@ import PageFilterBar from 'sentry/components/organizations/pageFilterBar';
 import {ProjectPageFilter} from 'sentry/components/organizations/projectPageFilter';
 import {PageHeadingQuestionTooltip} from 'sentry/components/pageHeadingQuestionTooltip';
 import {t} from 'sentry/locale';
-import {defined} from 'sentry/utils';
 import type {EventsMetaType} from 'sentry/utils/discover/eventView';
 import {
   DismissId,
@@ -152,7 +151,7 @@ export function CacheLandingPage() {
       cacheMissRateError?.message === CACHE_ERROR_MESSAGE ||
       transactionsListError?.message === CACHE_ERROR_MESSAGE;
 
-    if (defined(pageAlert?.message) && (onboardingProject || !hasData)) {
+    if (onboardingProject || !hasData) {
       setPageInfo(undefined);
       return;
     }


### PR DESCRIPTION
~We should only be triggering the set state for the alert to `undefined` if we're not already `undefined`, i.e. prevents an infinite loop of renders.~

The page alert context provides setters that were getting re-created each time the state changed. Wrap the setters in `useCallback` so the reference to the functions are always the same. This way, hooks that list these functions as dependencies don't go rampant.