### PR TITLE
Still display tokens used if no token cost metric has been sent

### DIFF
--- a/static/app/views/insights/llmMonitoring/components/tables/pipelinesTable.tsx
+++ b/static/app/views/insights/llmMonitoring/components/tables/pipelinesTable.tsx
@@ -134,7 +134,11 @@ export function PipelinesTable() {
     'api.performance.ai-analytics.token-usage-chart'
   );
 
-  const {data: tokenCostData, isLoading: tokenCostLoading, error: tokenCostError} = useSpanMetrics(
+  const {
+    data: tokenCostData,
+    isLoading: tokenCostLoading,
+    error: tokenCostError,
+  } = useSpanMetrics(
     {
       search: new MutableSearch(
         `span.category:ai span.ai.pipeline.group:[${(data as Row[])?.map(x => x['span.group']).join(',')}]`

--- a/static/app/views/insights/llmMonitoring/components/tables/pipelinesTable.tsx
+++ b/static/app/views/insights/llmMonitoring/components/tables/pipelinesTable.tsx
@@ -163,7 +163,9 @@ export function PipelinesTable() {
       const tokenCostDataPoint = tokenCostData.find(
         tokenRow => tokenRow['span.ai.pipeline.group'] === row['span.group']
       );
-      row['sum(ai.total_cost)'] = tokenCostDataPoint['sum(ai.total_cost)'];
+      if (tokenCostDataPoint) {
+        row['sum(ai.total_cost)'] = tokenCostDataPoint['sum(ai.total_cost)'];
+      }
     }
     return row;
   });

--- a/static/app/views/insights/llmMonitoring/components/tables/pipelinesTable.tsx
+++ b/static/app/views/insights/llmMonitoring/components/tables/pipelinesTable.tsx
@@ -134,7 +134,7 @@ export function PipelinesTable() {
     'api.performance.ai-analytics.token-usage-chart'
   );
 
-  const {data: tokenCostData, isLoading: tokenCostLoading} = useSpanMetrics(
+  const {data: tokenCostData, isLoading: tokenCostLoading, error: tokenCostError} = useSpanMetrics(
     {
       search: new MutableSearch(
         `span.category:ai span.ai.pipeline.group:[${(data as Row[])?.map(x => x['span.group']).join(',')}]`
@@ -159,7 +159,7 @@ export function PipelinesTable() {
           tokenUsedDataPoint['sum(ai.total_tokens.used)'];
       }
     }
-    if (!tokenCostLoading) {
+    if (!tokenCostLoading && !tokenCostError) {
       const tokenCostDataPoint = tokenCostData.find(
         tokenRow => tokenRow['span.ai.pipeline.group'] === row['span.group']
       );

--- a/static/app/views/insights/llmMonitoring/components/tables/pipelinesTable.tsx
+++ b/static/app/views/insights/llmMonitoring/components/tables/pipelinesTable.tsx
@@ -129,11 +129,17 @@ export function PipelinesTable() {
       search: new MutableSearch(
         `span.category:ai span.ai.pipeline.group:[${(data as Row[])?.map(x => x['span.group']).join(',')}]`
       ),
-      fields: [
-        'span.ai.pipeline.group',
-        'sum(ai.total_tokens.used)',
-        'sum(ai.total_cost)',
-      ],
+      fields: ['span.ai.pipeline.group', 'sum(ai.total_tokens.used)'],
+    },
+    'api.performance.ai-analytics.token-usage-chart'
+  );
+
+  const {data: tokenCostData, isLoading: tokenCostLoading} = useSpanMetrics(
+    {
+      search: new MutableSearch(
+        `span.category:ai span.ai.pipeline.group:[${(data as Row[])?.map(x => x['span.group']).join(',')}]`
+      ),
+      fields: ['span.ai.pipeline.group', 'sum(ai.total_cost)'],
     },
     'api.performance.ai-analytics.token-usage-chart'
   );
@@ -151,8 +157,13 @@ export function PipelinesTable() {
       if (tokenUsedDataPoint) {
         row['sum(ai.total_tokens.used)'] =
           tokenUsedDataPoint['sum(ai.total_tokens.used)'];
-        row['sum(ai.total_cost)'] = tokenUsedDataPoint['sum(ai.total_cost)'];
       }
+    }
+    if (!tokenCostLoading) {
+      const tokenCostDataPoint = tokenCostData.find(
+        tokenRow => tokenRow['span.ai.pipeline.group'] === row['span.group']
+      );
+      row['sum(ai.total_cost)'] = tokenCostDataPoint['sum(ai.total_cost)'];
     }
     return row;
   });


### PR DESCRIPTION
If you have never sent a span with ai.model_id, the span metric ai.total_cost will never be extracted, and then the indexer will throw an error if you try to look for it.

This separates the "ai.total_cost" and "ai.total_tokens.used" table entries 
