### PR TITLE
Allow AI to be nullable

### DIFF
--- a/src/sentry/search/events/datasets/spans_metrics.py
+++ b/src/sentry/search/events/datasets/spans_metrics.py
@@ -30,6 +30,8 @@ class SpansMetricsDatasetConfig(DatasetConfig):
     nullable_metrics = {
         constants.SPAN_MESSAGING_LATENCY,
         constants.SPAN_METRICS_MAP["cache.item_size"],
+        constants.SPAN_METRICS_MAP["ai.total_cost"],
+        constants.SPAN_METRICS_MAP["ai.total_tokens.used"],
     }
 
     def __init__(self, builder: spans_metrics.SpansMetricsQueryBuilder):


### PR DESCRIPTION
AI is not currently nullable, it would be nice if it was.

This makes ai.total_tokens.used display properly in the frontend if ai.total_cost has never been sent as a metric