### PR TITLE
fix(hybrid-cloud): Fix private field for RpcOrganization model

### DIFF
--- a/src/sentry/organizations/services/organization/model.py
+++ b/src/sentry/organizations/services/organization/model.py
@@ -9,7 +9,7 @@ from typing import Any
 
 from django.dispatch import Signal
 from django.utils import timezone
-from pydantic import Field
+from pydantic import Field, PrivateAttr
 from typing_extensions import TypedDict
 
 from sentry import roles
@@ -249,7 +249,7 @@ class RpcOrganization(RpcOrganizationSummary):
 
     default_role: str = ""
     date_added: datetime = Field(default_factory=timezone.now)
-    _default_owner_id: int | None = None
+    _default_owner_id: int | None = PrivateAttr(default=None)
 
     def get_audit_log_data(self) -> dict[str, Any]:
         return {
@@ -286,7 +286,7 @@ class RpcOrganization(RpcOrganizationSummary):
 
         This mirrors the method on the Organization model.
         """
-        if not hasattr(self, "_default_owner_id"):
+        if getattr(self, "_default_owner_id") is None:
             owners = self.get_owners()
             if len(owners) == 0:
                 return None


### PR DESCRIPTION
Fields in RPC models that begin with underscores are automatically excluded: https://docs.pydantic.dev/1.10/usage/models/#automatically-excluded-attributes

To avoid this, we need to mark them with [`PrivateAttr()`](https://docs.pydantic.dev/1.10/usage/models/#private-model-attributes).

Otherwise, `RpcOrganization.default_owner_id` will always return `None`.

This is needed for https://github.com/getsentry/getsentry/pull/14709.