### PR TITLE
Fix creating crash free session alerts

### DIFF
--- a/static/app/views/alerts/wizard/index.tsx
+++ b/static/app/views/alerts/wizard/index.tsx
@@ -60,10 +60,8 @@ function AlertWizard({organization, params, location, projectId}: AlertWizardPro
     const isMetricAlert = !!metricRuleTemplate;
     const isTransactionDataset = metricRuleTemplate?.dataset === Dataset.TRANSACTIONS;
 
-    if (
-      organization.features.includes('alert-crash-free-metrics') &&
-      metricRuleTemplate?.dataset === Dataset.SESSIONS
-    ) {
+    // If theres anything using the legacy sessions dataset, we need to convert it to metrics
+    if (metricRuleTemplate?.dataset === Dataset.SESSIONS) {
       metricRuleTemplate = {...metricRuleTemplate, dataset: Dataset.METRICS};
     }
 

--- a/static/app/views/alerts/wizard/options.tsx
+++ b/static/app/views/alerts/wizard/options.tsx
@@ -65,14 +65,13 @@ export enum MEPAlertsDataset {
 export type MetricAlertType = Exclude<AlertType, 'issues'>;
 
 export const DatasetMEPAlertQueryTypes: Record<
-  Exclude<Dataset, 'search_issues'>, // IssuePlatform (search_issues) is not used in alerts, so we can exclude it here
+  Exclude<Dataset, 'search_issues' | Dataset.SESSIONS>, // IssuePlatform (search_issues) is not used in alerts, so we can exclude it here
   MEPAlertsQueryType
 > = {
   [Dataset.ERRORS]: MEPAlertsQueryType.ERROR,
   [Dataset.TRANSACTIONS]: MEPAlertsQueryType.PERFORMANCE,
   [Dataset.GENERIC_METRICS]: MEPAlertsQueryType.PERFORMANCE,
   [Dataset.METRICS]: MEPAlertsQueryType.CRASH_RATE,
-  [Dataset.SESSIONS]: MEPAlertsQueryType.CRASH_RATE,
 };
 
 export const AlertWizardAlertNames: Record<AlertType, string> = {
@@ -227,14 +226,12 @@ export const AlertWizardRuleTemplates: Record<
   },
   crash_free_sessions: {
     aggregate: SessionsAggregate.CRASH_FREE_SESSIONS,
-    // TODO(scttcper): Use Dataset.Metric on GA of alert-crash-free-metrics
-    dataset: Dataset.SESSIONS,
+    dataset: Dataset.METRICS,
     eventTypes: EventTypes.SESSION,
   },
   crash_free_users: {
     aggregate: SessionsAggregate.CRASH_FREE_USERS,
-    // TODO(scttcper): Use Dataset.Metric on GA of alert-crash-free-metrics
-    dataset: Dataset.SESSIONS,
+    dataset: Dataset.METRICS,
     eventTypes: EventTypes.USER,
   },
 };

--- a/static/app/views/alerts/wizard/utils.spec.tsx
+++ b/static/app/views/alerts/wizard/utils.spec.tsx
@@ -75,7 +75,7 @@ describe('Wizard utils', function () {
     expect(
       getAlertTypeFromAggregateDataset({
         aggregate: SessionsAggregate.CRASH_FREE_SESSIONS,
-        dataset: Dataset.SESSIONS,
+        dataset: Dataset.METRICS,
       })
     ).toEqual('crash_free_sessions');
   });
@@ -84,7 +84,7 @@ describe('Wizard utils', function () {
     expect(
       getAlertTypeFromAggregateDataset({
         aggregate: SessionsAggregate.CRASH_FREE_USERS,
-        dataset: Dataset.SESSIONS,
+        dataset: Dataset.METRICS,
       })
     ).toEqual('crash_free_users');
   });


### PR DESCRIPTION
# Description
Fixes #74716 

A user reported an issue making crash free session rate alerts, upon investigation it was using a deprecated dataset. This updates the alert UI to use the correct dataset (which fixes the save issue)