### PR TITLE
feat(seer-priority): Add a temporary feature flag to control seer-based priority

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -2366,6 +2366,12 @@ def _get_severity_metadata_for_group(
     """
     from sentry.receivers.rules import PLATFORMS_WITH_PRIORITY_ALERTS
 
+    organization_supports_severity = features.has(
+        "organizations:seer-based-priority", event.project.organization, actor=None
+    )
+    if not organization_supports_severity:
+        return {}
+
     if killswitch_matches_context("issues.skip-seer-requests", {"project_id": event.project_id}):
         logger.warning(
             "get_severity_metadata_for_group.seer_killswitch_enabled",

--- a/src/sentry/features/permanent.py
+++ b/src/sentry/features/permanent.py
@@ -109,8 +109,6 @@ def register_permanent_features(manager: FeatureManager):
         "organizations:org-ingest-subdomains": False,
         # Replace the footer Sentry logo with a Sentry pride logo
         "organizations:sentry-pride-logo-footer": False,
-        # Enable priority alerts using the Seer calculations
-        "organizations:seer-based-priority": False,
     }
 
     permanent_project_features = {

--- a/src/sentry/features/permanent.py
+++ b/src/sentry/features/permanent.py
@@ -109,6 +109,8 @@ def register_permanent_features(manager: FeatureManager):
         "organizations:org-ingest-subdomains": False,
         # Replace the footer Sentry logo with a Sentry pride logo
         "organizations:sentry-pride-logo-footer": False,
+        # Enable priority alerts using the Seer calculations
+        "organizations:seer-based-priority": False,
     }
 
     permanent_project_features = {

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -417,6 +417,8 @@ def register_temporary_features(manager: FeatureManager):
     manager.add("organizations:insights-browser-webvitals-optional-components", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Add default browser performance score profile for fallback when no or unknown browser name is provided
     manager.add("organizations:insights-default-performance-score-profiles", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
+    # Enable priority alerts using the Seer calculations. This flag will move to a permanent flag before we release.
+    manager.add("organizations:seer-based-priority", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable standalone span ingestion
     manager.add("organizations:standalone-span-ingestion", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, api_expose=False)
     # Enable the aggregate span waterfall view

--- a/tests/sentry/event_manager/test_priority.py
+++ b/tests/sentry/event_manager/test_priority.py
@@ -17,6 +17,7 @@ pytestmark = [requires_snuba]
 
 @region_silo_test
 @apply_feature_flag_on_cls("projects:first-event-severity-calculation")
+@apply_feature_flag_on_cls("organizations:seer-based-priority")
 class TestEventManagerPriority(TestCase):
     @patch("sentry.event_manager._get_severity_score", return_value=(0.1121, "ml"))
     def test_flag_on(self, mock_get_severity_score: MagicMock):

--- a/tests/sentry/event_manager/test_severity.py
+++ b/tests/sentry/event_manager/test_severity.py
@@ -36,6 +36,7 @@ def make_event(**kwargs) -> dict[str, Any]:
     return result
 
 
+@apply_feature_flag_on_cls("organizations:seer-based-priority")
 class TestGetEventSeverity(TestCase):
     @patch(
         "sentry.event_manager.severity_connection_pool.urlopen",
@@ -323,6 +324,7 @@ class TestGetEventSeverity(TestCase):
         assert cache.get(SEER_ERROR_COUNT_KEY) == 1
 
 
+@apply_feature_flag_on_cls("organizations:seer-based-priority")
 @apply_feature_flag_on_cls("projects:first-event-severity-calculation")
 class TestEventManagerSeverity(TestCase):
     @patch("sentry.event_manager._get_severity_score", return_value=(0.1121, "ml"))
@@ -345,6 +347,24 @@ class TestEventManagerSeverity(TestCase):
     @patch("sentry.event_manager._get_severity_score", return_value=(0.1121, "ml"))
     def test_flag_off(self, mock_get_severity_score: MagicMock):
         with self.feature({"projects:first-event-severity-calculation": False}):
+            manager = EventManager(
+                make_event(
+                    exception={"values": [{"type": "NopeError", "value": "Nopey McNopeface"}]},
+                    platform="python",
+                )
+            )
+            event = manager.save(self.project.id)
+
+            mock_get_severity_score.assert_not_called()
+            assert (
+                event.group
+                and "severity" not in event.group.get_event_metadata()
+                and "severity.reason" not in event.group.get_event_metadata()
+            )
+
+    @patch("sentry.event_manager._get_severity_score", return_value=(0.1121, "ml"))
+    def test_permanent_flag_off(self, mock_get_severity_score: MagicMock):
+        with self.feature({"organizations:seer-based-priority": False}):
             manager = EventManager(
                 make_event(
                     exception={"values": [{"type": "NopeError", "value": "Nopey McNopeface"}]},


### PR DESCRIPTION
Adding a new org-level flag to determine if priority should factor in calculations from Seer and the severity microservice. This flag will need to be moved to `features/permanent.py` and out of flagpole before we release.

Fixes https://github.com/getsentry/sentry/issues/74757