### PR TITLE
chore(utils): Add deprecation notice to legacy circuit breaker

### DIFF
--- a/src/sentry/utils/circuit_breaker.py
+++ b/src/sentry/utils/circuit_breaker.py
@@ -1,3 +1,8 @@
+"""
+NOTE: This circuit breaker implementation is deprecated and is slated to eventually be removed. Use
+the `CircuitBreaker` class found in `circuit_breaker2.py` instead.
+"""
+
 from collections.abc import Callable
 from typing import ParamSpec, TypedDict, TypeVar
 


### PR DESCRIPTION
Now that the final PR adding the new `CircuitBreaker` class has been merged, we can deprecate the legacy circuit breaker. This adds a deprecation notice to its module, and then once the new breaker has had a chance to run for a while and we're sure everything's good, we can switch to using it everywhere and delete the legacy module entirely.