### PR TITLE
chore(similarity): Add re-queue for backfill task when worker is killed

### DIFF
--- a/src/sentry/tasks/embeddings_grouping/backfill_seer_grouping_records_for_project.py
+++ b/src/sentry/tasks/embeddings_grouping/backfill_seer_grouping_records_for_project.py
@@ -43,6 +43,7 @@ logger = logging.getLogger(__name__)
     soft_time_limit=60 * 15,
     time_limit=60 * 15 + 5,
     acks_late=True,
+    reject_on_worker_lost=True,
 )
 def backfill_seer_grouping_records_for_project(
     current_project_id: int,


### PR DESCRIPTION
Add reject_on_worker_lost [flag](https://docs.celeryq.dev/en/stable/userguide/configuration.html#task-reject-on-worker-lost) to re-queue the message if the worker is killed