### PR TITLE
fix(utils): Specify redis cluster to use for circuit breaker rate limiter

### DIFF
--- a/src/sentry/utils/circuit_breaker2.py
+++ b/src/sentry/utils/circuit_breaker2.py
@@ -135,7 +135,9 @@ class CircuitBreaker:
             "recovery_duration", self.window * DEFAULT_RECOVERY_WINDOW_MULTIPLIER
         )
 
-        self.limiter = RedisSlidingWindowRateLimiter()
+        self.limiter = RedisSlidingWindowRateLimiter(
+            cluster=settings.SENTRY_RATE_LIMIT_REDIS_CLUSTER
+        )
         self.redis_pipeline = self.limiter.client.pipeline()
 
         self.primary_quota = Quota(


### PR DESCRIPTION
This changes the new `CircuitBreaker` class to use the `"ratelimiter"` redis cluster rather than the default one, which it appears may only work locally.