### PR TITLE
fix(context): Hide profile, replay and trace buttons on issue details

### DIFF
--- a/static/app/components/events/contexts/profile/index.spec.tsx
+++ b/static/app/components/events/contexts/profile/index.spec.tsx
@@ -47,6 +47,6 @@ describe('profile event context', function () {
 
     expect(screen.getByText('Profile ID')).toBeInTheDocument();
     expect(screen.getByText(profileId)).toBeInTheDocument();
-    expect(screen.getByRole('button', {name: 'View Profile'})).toBeInTheDocument();
+    expect(screen.getByRole('link', {name: profileId})).toBeInTheDocument();
   });
 });

--- a/static/app/components/events/contexts/profile/index.tsx
+++ b/static/app/components/events/contexts/profile/index.tsx
@@ -1,5 +1,4 @@
 import Feature from 'sentry/components/acl/feature';
-import {Button} from 'sentry/components/button';
 import ErrorBoundary from 'sentry/components/errorBoundary';
 import KeyValueList from 'sentry/components/events/interfaces/keyValueList';
 import {t} from 'sentry/locale';
@@ -7,7 +6,6 @@ import type {Event, ProfileContext} from 'sentry/types/event';
 import {ProfileContextKey} from 'sentry/types/event';
 import type {Organization} from 'sentry/types/organization';
 import type {Project} from 'sentry/types/project';
-import {trackAnalytics} from 'sentry/utils/analytics';
 import {generateProfileFlamechartRoute} from 'sentry/utils/profiling/routes';
 import useOrganization from 'sentry/utils/useOrganization';
 import useProjects from 'sentry/utils/useProjects';
@@ -103,7 +101,7 @@ function getProfileKnownDataDetails({
         return undefined;
       }
 
-      const target = project?.slug
+      const link = project?.slug
         ? generateProfileFlamechartRoute({
             orgSlug: organization.slug,
             projectSlug: project?.slug,
@@ -114,21 +112,7 @@ function getProfileKnownDataDetails({
       return {
         subject: t('Profile ID'),
         value: data.profile_id,
-        action: {link: target},
-        actionButton: target && (
-          <Button
-            size="xs"
-            to={target}
-            onClick={() =>
-              trackAnalytics('profiling_views.go_to_flamegraph', {
-                organization,
-                source: 'events.profile_event_context',
-              })
-            }
-          >
-            {t('View Profile')}
-          </Button>
-        ),
+        action: {link},
       };
     }
     default:

--- a/static/app/components/events/contexts/replay/index.spec.tsx
+++ b/static/app/components/events/contexts/replay/index.spec.tsx
@@ -19,6 +19,6 @@ describe('replay event context', function () {
 
     expect(screen.getByText('Replay ID')).toBeInTheDocument();
     expect(screen.getByText(replayId)).toBeInTheDocument();
-    expect(screen.getByRole('button', {name: 'View Replay'})).toBeInTheDocument();
+    expect(screen.getByRole('link', {name: replayId})).toBeInTheDocument();
   });
 });

--- a/static/app/components/events/contexts/replay/index.tsx
+++ b/static/app/components/events/contexts/replay/index.tsx
@@ -1,4 +1,3 @@
-import {LinkButton} from 'sentry/components/button';
 import ErrorBoundary from 'sentry/components/errorBoundary';
 import KeyValueList from 'sentry/components/events/interfaces/keyValueList';
 import {t} from 'sentry/locale';
@@ -90,18 +89,10 @@ function getReplayKnownDataDetails({
         return undefined;
       }
       const link = `/organizations/${organization.slug}/replays/${encodeURIComponent(replayId)}/`;
-
       return {
         subject: t('Replay ID'),
         value: replayId,
-        action: {
-          link,
-        },
-        actionButton: link && (
-          <LinkButton size="xs" href={link}>
-            {t('View Replay')}
-          </LinkButton>
-        ),
+        action: {link},
       };
     }
     default:

--- a/static/app/components/events/contexts/trace/getTraceKnownDataDetails.tsx
+++ b/static/app/components/events/contexts/trace/getTraceKnownDataDetails.tsx
@@ -1,6 +1,5 @@
 import type {Location} from 'history';
 
-import {LinkButton} from 'sentry/components/button';
 import type {KnownDataDetails} from 'sentry/components/events/contexts/utils';
 import {generateTraceTarget} from 'sentry/components/quickTrace/utils';
 import {t} from 'sentry/locale';
@@ -46,11 +45,6 @@ export function getTraceKnownDataDetails({
         subject: t('Trace ID'),
         value: traceId,
         action: {link},
-        actionButton: (
-          <LinkButton size="xs" to={link}>
-            {t('Search by Trace')}
-          </LinkButton>
-        ),
       };
     }
 
@@ -99,7 +93,7 @@ export function getTraceKnownDataDetails({
         };
       }
 
-      const to = transactionSummaryRouteWithQuery({
+      const link = transactionSummaryRouteWithQuery({
         orgSlug: organization.slug,
         transaction: transactionName,
         projectID: event.projectID,
@@ -109,12 +103,7 @@ export function getTraceKnownDataDetails({
       return {
         subject: t('Transaction'),
         value: transactionName,
-        action: {link: to},
-        actionButton: (
-          <LinkButton size="xs" to={to}>
-            {t('View Summary')}
-          </LinkButton>
-        ),
+        action: {link},
       };
     }
 

--- a/static/app/components/events/interfaces/keyValueList/index.tsx
+++ b/static/app/components/events/interfaces/keyValueList/index.tsx
@@ -3,6 +3,7 @@ import styled from '@emotion/styled';
 import classNames from 'classnames';
 import sortBy from 'lodash/sortBy';
 
+import {ValueLink} from 'sentry/components/keyValueData';
 import {space} from 'sentry/styles/space';
 import type {KeyValueListData} from 'sentry/types';
 import {defined} from 'sentry/utils';
@@ -51,6 +52,7 @@ function KeyValueList({
               meta,
               subjectIcon,
               subjectDataTestId,
+              action,
               actionButton,
               isContextData: valueIsContextData,
               isMultiValue,
@@ -65,11 +67,17 @@ function KeyValueList({
               raw,
             };
 
+            const valueItem = action?.link ? (
+              <ValueLink to={action.link}>{<Value {...valueProps} />}</ValueLink>
+            ) : (
+              <Value {...valueProps} />
+            );
+
             const valueContainer =
               isMultiValue && Array.isArray(value) ? (
                 <MultiValueContainer values={value} />
               ) : (
-                <Value {...valueProps} />
+                valueItem
               );
 
             return (

--- a/static/app/components/keyValueData/index.tsx
+++ b/static/app/components/keyValueData/index.tsx
@@ -19,7 +19,8 @@ export interface KeyValueDataContentProps {
    * Specifies the item to display.
    * - If set, item.subjectNode will override displaying item.subject.
    * - If item.subjectNode is null, the value section will span the whole card.
-   * - The only displayed action is item.action.link, not item.actionButton
+   * - If item.action.link is specified, the value will appear as a link.
+   * - If item.actionButton is specified, the button will be rendered inline with the value.
    */
   item: KeyValueListDataItem;
   /**

--- a/static/app/components/keyValueData/index.tsx
+++ b/static/app/components/keyValueData/index.tsx
@@ -285,7 +285,7 @@ const CardColumn = styled('div')`
   grid-column: span 1;
 `;
 
-const ValueLink = styled(Link)`
+export const ValueLink = styled(Link)`
   text-decoration: ${p => p.theme.linkUnderline} underline dotted;
 `;
 


### PR DESCRIPTION
The `actionButton` for the trace context was previously used to display buttons in line with the rows of KeyValueList components. With the context redesign we omitted using `actionButton` in favour of `action.link`. [A recent change](https://github.com/getsentry/sentry/pull/74405) allowed for `actionButton` to be rendered in the new design, which consequently them to be rendered for the existing context that hadn't had those button specs removed yet.

This PR removes the action buttons from the context rendered on issue details so that it can continue using the new component without rendering a button alongside them.

Even though the `<Chunk />` component design (which uses `KeyValueList`) is deprecated, until it is removed I didn't feel comfortable removing the buttons without first modifying KeyValueList to read the new `action.link` property, just in case they're still used somewhere in the app.