### PR TITLE
feat(toolbar): add linkout to gh code search from feature flag panel

### DIFF
--- a/static/app/components/devtoolbar/components/featureFlags/featureFlagsPanel.tsx
+++ b/static/app/components/devtoolbar/components/featureFlags/featureFlagsPanel.tsx
@@ -43,7 +43,7 @@ export default function FeatureFlagsPanel() {
           .map(flag => {
             return (
               <Cell key={flag} style={{alignItems: 'flex-start'}}>
-                {featureFlagTemplateUrl ? (
+                {featureFlagTemplateUrl?.(flag) ? (
                   <ExternalLink
                     style={{textDecoration: 'inherit', color: 'inherit'}}
                     href={featureFlagTemplateUrl(flag)}

--- a/static/app/components/devtoolbar/components/featureFlags/featureFlagsPanel.tsx
+++ b/static/app/components/devtoolbar/components/featureFlags/featureFlagsPanel.tsx
@@ -6,6 +6,7 @@ import {
   panelScrollableCss,
 } from 'sentry/components/devtoolbar/styles/infiniteList';
 import Input from 'sentry/components/input';
+import ExternalLink from 'sentry/components/links/externalLink';
 import {PanelTable} from 'sentry/components/panels/panelTable';
 import {Cell} from 'sentry/components/replays/virtualizedGrid/bodyCell';
 
@@ -17,7 +18,7 @@ import PanelLayout from '../panelLayout';
 
 export default function FeatureFlagsPanel() {
   const featureFlags = useEnabledFeatureFlags();
-  const {organizationSlug} = useConfiguration();
+  const {organizationSlug, featureFlagTemplateUrl, trackAnalytics} = useConfiguration();
   const [searchTerm, setSearchTerm] = useState('');
   const searchInput = useRef<HTMLInputElement>(null);
 
@@ -42,7 +43,22 @@ export default function FeatureFlagsPanel() {
           .map(flag => {
             return (
               <Cell key={flag} style={{alignItems: 'flex-start'}}>
-                {flag}
+                {featureFlagTemplateUrl ? (
+                  <ExternalLink
+                    style={{textDecoration: 'inherit', color: 'inherit'}}
+                    href={featureFlagTemplateUrl(flag)}
+                    onClick={() => {
+                      trackAnalytics?.({
+                        eventKey: `devtoolbar.feature-flag-list.item.click`,
+                        eventName: `devtoolbar: Click feature-flag-list item`,
+                      });
+                    }}
+                  >
+                    {flag}
+                  </ExternalLink>
+                ) : (
+                  <span>{flag}</span>
+                )}
               </Cell>
             );
           })}

--- a/static/app/components/devtoolbar/hooks/useConfiguration.tsx
+++ b/static/app/components/devtoolbar/hooks/useConfiguration.tsx
@@ -10,6 +10,7 @@ const context = createContext<Configuration>({
   projectId: 0,
   projectSlug: '',
   featureFlags: [],
+  featureFlagTemplateUrl: _flag => '',
 });
 
 export function ConfigurationContextProvider({

--- a/static/app/components/devtoolbar/hooks/useConfiguration.tsx
+++ b/static/app/components/devtoolbar/hooks/useConfiguration.tsx
@@ -10,7 +10,7 @@ const context = createContext<Configuration>({
   projectId: 0,
   projectSlug: '',
   featureFlags: [],
-  featureFlagTemplateUrl: _flag => '',
+  featureFlagTemplateUrl: undefined,
 });
 
 export function ConfigurationContextProvider({

--- a/static/app/components/devtoolbar/types.ts
+++ b/static/app/components/devtoolbar/types.ts
@@ -11,6 +11,7 @@ export type Configuration = {
   projectSlug: string;
   SentrySDK?: typeof SentrySDK;
   domId?: string;
+  featureFlagTemplateUrl?: (flag: string) => string;
   featureFlags?: string[];
   trackAnalytics?: (props: {eventKey: string; eventName: string}) => void;
 };

--- a/static/app/components/devtoolbar/types.ts
+++ b/static/app/components/devtoolbar/types.ts
@@ -11,7 +11,7 @@ export type Configuration = {
   projectSlug: string;
   SentrySDK?: typeof SentrySDK;
   domId?: string;
-  featureFlagTemplateUrl?: (flag: string) => string;
+  featureFlagTemplateUrl?: undefined | ((flag: string) => string | undefined);
   featureFlags?: string[];
   trackAnalytics?: (props: {eventKey: string; eventName: string}) => void;
 };

--- a/static/app/utils/useDevToolbar.tsx
+++ b/static/app/utils/useDevToolbar.tsx
@@ -25,6 +25,8 @@ export default function useDevToolbar({enabled}: {enabled: boolean}) {
         projectId: 11276,
         projectSlug: 'javascript',
         featureFlags: organization.features,
+        featureFlagTemplateUrl: flag =>
+          `https://github.com/search?q=repo%3Agetsentry%2Fsentry-options-automator+OR+repo%3Agetsentry%2Fsentry+${flag}&type=code`,
 
         trackAnalytics: (props: {eventKey: string; eventName: string}) =>
           rawTrackAnalyticsEvent({...props, organization}),


### PR DESCRIPTION
clicking on a feature flag now links to code search for `sentry-options-automator` and `sentry`:


https://github.com/user-attachments/assets/914b7166-dec9-4bfd-b7a7-7512b46abbba

