### PR TITLE
Remove extra commas from the pipelines table

### DIFF
--- a/static/app/views/insights/llmMonitoring/components/tables/pipelinesTable.tsx
+++ b/static/app/views/insights/llmMonitoring/components/tables/pipelinesTable.tsx
@@ -127,7 +127,10 @@ export function PipelinesTable() {
   const {data: tokensUsedData, isLoading: tokensUsedLoading} = useSpanMetrics(
     {
       search: new MutableSearch(
-        `span.category:ai span.ai.pipeline.group:[${(data as Row[])?.map(x => x['span.group']).join(',')}]`
+        `span.category:ai span.ai.pipeline.group:[${(data as Row[])
+          ?.map(x => x['span.group'])
+          ?.filter(x => !!x)
+          .join(',')}]`
       ),
       fields: [
         'span.ai.pipeline.group',


### PR DESCRIPTION
This breaks if a user sends bad data which causes a category not to have a group.