### PR TITLE
ref(breadcrumbs): Address early feedback

### DIFF
--- a/static/app/components/events/breadcrumbs/breadcrumbItemContent.spec.tsx
+++ b/static/app/components/events/breadcrumbs/breadcrumbItemContent.spec.tsx
@@ -42,7 +42,8 @@ describe('BreadcrumbItemContent', function () {
       screen.getByText(`${breadcrumb.data?.method}: [${breadcrumb.data?.status_code}]`)
     ).toBeInTheDocument();
     expect(screen.getByRole('link', {name: breadcrumb.data?.url})).toBeInTheDocument();
-    expect(screen.getByText('2 items')).toBeInTheDocument();
+    expect(screen.getByText('123')).toBeInTheDocument();
+    expect(screen.getByText('15080')).toBeInTheDocument();
   });
 
   it('renders SQL crumbs with all data', function () {

--- a/static/app/components/events/breadcrumbs/breadcrumbItemContent.tsx
+++ b/static/app/components/events/breadcrumbs/breadcrumbItemContent.tsx
@@ -37,7 +37,6 @@ export default function BreadcrumbItemContent({
 }: BreadcrumbItemContentProps) {
   const structuredDataProps = {
     ...DEFAULT_STRUCTURED_DATA_PROPS,
-    forceDefaultExpand: fullyExpanded,
     maxDefaultDepth: fullyExpanded
       ? 10000
       : DEFAULT_STRUCTURED_DATA_PROPS.maxDefaultDepth,

--- a/static/app/components/events/breadcrumbs/breadcrumbItemContent.tsx
+++ b/static/app/components/events/breadcrumbs/breadcrumbItemContent.tsx
@@ -44,9 +44,9 @@ export default function BreadcrumbItemContent({
   };
 
   const defaultMessage = defined(bc.message) ? (
-    <Timeline.Text>
+    <BreadcrumbText>
       <StructuredData value={bc.message} meta={meta?.message} {...structuredDataProps} />
-    </Timeline.Text>
+    </BreadcrumbText>
   ) : null;
   const defaultData = defined(bc.data) ? (
     <Timeline.Data>
@@ -110,7 +110,7 @@ function HTTPCrumbContent({
   return (
     <Fragment>
       {children}
-      <Timeline.Text>
+      <BreadcrumbText>
         {defined(method) && `${method}: `}
         {isValidUrl ? (
           <Link
@@ -123,7 +123,7 @@ function HTTPCrumbContent({
           <AnnotatedText value={url} meta={meta?.data?.url?.['']} />
         )}
         {defined(statusCode) && ` [${statusCode}]`}
-      </Timeline.Text>
+      </BreadcrumbText>
       {Object.keys(otherData).length > 0 ? (
         <Timeline.Data>
           <StructuredData value={otherData} meta={meta} {...structuredDataProps} />
@@ -175,10 +175,10 @@ function ExceptionCrumbContent({
   const {type, value, ...otherData} = breadcrumb?.data ?? {};
   return (
     <Fragment>
-      <Timeline.Text>
+      <BreadcrumbText>
         {type && type}
         {type ? value && `: ${value}` : value && value}
-      </Timeline.Text>
+      </BreadcrumbText>
       {children}
       {Object.keys(otherData).length > 0 ? (
         <Timeline.Data>
@@ -203,4 +203,9 @@ const LightenTextColor = styled('pre')`
     padding: ${space(0.25)} 0;
     font-size: ${p => p.theme.fontSizeSmall};
   }
+`;
+
+const BreadcrumbText = styled(Timeline.Text)`
+  white-space: pre;
+  font-family: ${p => p.theme.text.familyMono};
 `;

--- a/static/app/components/events/breadcrumbs/breadcrumbItemContent.tsx
+++ b/static/app/components/events/breadcrumbs/breadcrumbItemContent.tsx
@@ -190,7 +190,7 @@ function ExceptionCrumbContent({
 }
 
 const Link = styled('a')`
-  color: ${p => p.theme.subText};
+  color: ${p => p.theme.textColor};
   text-decoration: underline;
   text-decoration-style: dotted;
   word-break: break-all;
@@ -206,6 +206,8 @@ const LightenTextColor = styled('pre')`
 `;
 
 const BreadcrumbText = styled(Timeline.Text)`
-  white-space: pre;
+  white-space: pre-wrap;
   font-family: ${p => p.theme.text.familyMono};
+  font-size: ${p => p.theme.codeFontSize};
+  color: ${p => p.theme.textColor};
 `;

--- a/static/app/components/events/breadcrumbs/breadcrumbsDataSection.spec.tsx
+++ b/static/app/components/events/breadcrumbs/breadcrumbsDataSection.spec.tsx
@@ -75,28 +75,28 @@ describe('BreadcrumbsDataSection', function () {
     );
 
     // From virtual crumb
-    expect(screen.getByText('0ms')).toBeInTheDocument();
-    expect(screen.queryByText('06:01:48.762')).not.toBeInTheDocument();
+    expect(screen.getByText('06:01:48.762')).toBeInTheDocument();
+    expect(screen.queryByText('0ms')).not.toBeInTheDocument();
     // From event breadcrumb
-    expect(screen.getByText('-1min 2ms')).toBeInTheDocument();
-    expect(screen.queryByText('06:00:48.760')).not.toBeInTheDocument();
+    expect(screen.getByText('06:00:48.760')).toBeInTheDocument();
+    expect(screen.queryByText('-1min 2ms')).not.toBeInTheDocument();
 
     const timeControl = screen.getByRole('button', {
       name: 'Change Time Format for Breadcrumbs',
     });
     await userEvent.click(timeControl);
 
-    expect(screen.queryByText('0ms')).not.toBeInTheDocument();
-    expect(screen.getByText('06:01:48.762')).toBeInTheDocument();
-    expect(screen.queryByText('-1min 2ms')).not.toBeInTheDocument();
-    expect(screen.getByText('06:00:48.760')).toBeInTheDocument();
-
-    await userEvent.click(timeControl);
-
     expect(screen.getByText('0ms')).toBeInTheDocument();
     expect(screen.queryByText('06:01:48.762')).not.toBeInTheDocument();
     expect(screen.getByText('-1min 2ms')).toBeInTheDocument();
     expect(screen.queryByText('06:00:48.760')).not.toBeInTheDocument();
+
+    await userEvent.click(timeControl);
+
+    expect(screen.queryByText('0ms')).not.toBeInTheDocument();
+    expect(screen.getByText('06:01:48.762')).toBeInTheDocument();
+    expect(screen.queryByText('-1min 2ms')).not.toBeInTheDocument();
+    expect(screen.getByText('06:00:48.760')).toBeInTheDocument();
   });
 
   it('opens the drawer and focuses search when the search button is pressed', async function () {

--- a/static/app/components/events/breadcrumbs/breadcrumbsDataSection.spec.tsx
+++ b/static/app/components/events/breadcrumbs/breadcrumbsDataSection.spec.tsx
@@ -99,26 +99,19 @@ describe('BreadcrumbsDataSection', function () {
     expect(screen.queryByText('06:00:48.760')).not.toBeInTheDocument();
   });
 
-  it.each([
-    {action: 'Search', elementRole: 'textbox'},
-    {action: 'Filter', elementRole: 'button'},
-    {action: 'Sort', elementRole: 'button'},
-  ])(
-    'opens the drawer, and focuses $action $elementRole when $action button is pressed',
-    async ({action, elementRole}) => {
-      render(<BreadcrumbsDataSection {...MOCK_DATA_SECTION_PROPS} />);
+  it('opens the drawer and focuses search when the search button is pressed', async function () {
+    render(<BreadcrumbsDataSection {...MOCK_DATA_SECTION_PROPS} />);
 
-      const control = screen.getByRole('button', {name: `${action} Breadcrumbs`});
-      expect(control).toBeInTheDocument();
-      await userEvent.click(control);
-      expect(
-        screen.getByRole('complementary', {name: 'breadcrumb drawer'})
-      ).toBeInTheDocument();
-      const drawerControl = screen.getByRole(elementRole, {
-        name: `${action} All Breadcrumbs`,
-      });
-      expect(drawerControl).toBeInTheDocument();
-      expect(drawerControl).toHaveFocus();
-    }
-  );
+    const control = screen.getByRole('button', {name: 'Open Breadcrumb Search'});
+    expect(control).toBeInTheDocument();
+    await userEvent.click(control);
+    expect(
+      screen.getByRole('complementary', {name: 'breadcrumb drawer'})
+    ).toBeInTheDocument();
+    const drawerControl = screen.getByRole('textbox', {
+      name: 'Search All Breadcrumbs',
+    });
+    expect(drawerControl).toBeInTheDocument();
+    expect(drawerControl).toHaveFocus();
+  });
 });

--- a/static/app/components/events/breadcrumbs/breadcrumbsDataSection.tsx
+++ b/static/app/components/events/breadcrumbs/breadcrumbsDataSection.tsx
@@ -19,6 +19,10 @@ import {
   getSummaryBreadcrumbs,
 } from 'sentry/components/events/breadcrumbs/utils';
 import {EventDataSection} from 'sentry/components/events/eventDataSection';
+import {
+  BREADCRUMB_SORT_LOCALSTORAGE_KEY,
+  BreadcrumbSort,
+} from 'sentry/components/events/interfaces/breadcrumbs';
 import useFeedbackWidget from 'sentry/components/feedback/widget/useFeedbackWidget';
 import useDrawer from 'sentry/components/globalDrawer';
 import {
@@ -51,23 +55,27 @@ export default function BreadcrumbsDataSection({
 }: BreadcrumbsDataSectionProps) {
   const {openDrawer} = useDrawer();
   const organization = useOrganization();
-  // Use the local storage preferences, but allow the drawer to do updates
   const [timeDisplay, setTimeDisplay] = useLocalStorageState<BreadcrumbTimeDisplay>(
     BREADCRUMB_TIME_DISPLAY_LOCALSTORAGE_KEY,
     BreadcrumbTimeDisplay.ABSOLUTE
   );
+  // Use the local storage preferences, but allow the drawer to do updates
+  const [sort, _setSort] = useLocalStorageState<BreadcrumbSort>(
+    BREADCRUMB_SORT_LOCALSTORAGE_KEY,
+    BreadcrumbSort.NEWEST
+  );
 
   const enhancedCrumbs = useMemo(() => getEnhancedBreadcrumbs(event), [event]);
   const summaryCrumbs = useMemo(
-    () => getSummaryBreadcrumbs(enhancedCrumbs),
-    [enhancedCrumbs]
+    () => getSummaryBreadcrumbs(enhancedCrumbs, sort),
+    [enhancedCrumbs, sort]
   );
   const startTimeString = useMemo(
     () =>
       timeDisplay === BreadcrumbTimeDisplay.RELATIVE
-        ? enhancedCrumbs?.at(-1)?.breadcrumb?.timestamp
+        ? summaryCrumbs?.at(0)?.breadcrumb?.timestamp
         : undefined,
-    [enhancedCrumbs, timeDisplay]
+    [summaryCrumbs, timeDisplay]
   );
 
   const onViewAllBreadcrumbs = useCallback(

--- a/static/app/components/events/breadcrumbs/breadcrumbsDataSection.tsx
+++ b/static/app/components/events/breadcrumbs/breadcrumbsDataSection.tsx
@@ -162,7 +162,6 @@ export default function BreadcrumbsDataSection({
           startTimeString={startTimeString}
           // We want the timeline to appear connected to the 'View All' button
           showLastLine={hasViewAll}
-          isCompact
         />
         {hasViewAll && (
           <ViewAllContainer>

--- a/static/app/components/events/breadcrumbs/breadcrumbsDataSection.tsx
+++ b/static/app/components/events/breadcrumbs/breadcrumbsDataSection.tsx
@@ -5,7 +5,6 @@ import ProjectAvatar from 'sentry/components/avatar/projectAvatar';
 import {Breadcrumbs as NavigationBreadcrumbs} from 'sentry/components/breadcrumbs';
 import {Button} from 'sentry/components/button';
 import ButtonBar from 'sentry/components/buttonBar';
-import {CompactSelect} from 'sentry/components/compactSelect';
 import ErrorBoundary from 'sentry/components/errorBoundary';
 import {
   BreadcrumbControlOptions,
@@ -29,7 +28,7 @@ import {
   IconSearch,
   IconTimer,
 } from 'sentry/icons';
-import {t} from 'sentry/locale';
+import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {Event} from 'sentry/types/event';
 import type {Group} from 'sentry/types/group';
@@ -114,6 +113,11 @@ export default function BreadcrumbsDataSection({
     return null;
   }
 
+  const nextTimeDisplay =
+    timeDisplay === BreadcrumbTimeDisplay.ABSOLUTE
+      ? BreadcrumbTimeDisplay.RELATIVE
+      : BreadcrumbTimeDisplay.ABSOLUTE;
+
   const actions = (
     <ButtonBar gap={1}>
       <BreadcrumbsFeedback />
@@ -121,29 +125,29 @@ export default function BreadcrumbsDataSection({
         aria-label={t('Open Breadcrumb Search')}
         icon={<IconSearch size="xs" />}
         size="xs"
+        title={t('Open Search')}
         onClick={() => onViewAllBreadcrumbs(BreadcrumbControlOptions.SEARCH)}
-      >
-        {t('Open Search')}
-      </Button>
-      <CompactSelect
-        size="xs"
-        triggerProps={{
-          icon:
-            timeDisplay === BreadcrumbTimeDisplay.ABSOLUTE ? (
-              <IconClock />
-            ) : (
-              <IconTimer />
-            ),
-        }}
-        onChange={selectedOption => {
-          setTimeDisplay(selectedOption.value);
+      />
+      <Button
+        aria-label={t('Change Time Format for Breadcrumbs')}
+        title={tct('Use [format] Timestamps', {
+          format: BREADCRUMB_TIME_DISPLAY_OPTIONS[nextTimeDisplay].label,
+        })}
+        icon={
+          timeDisplay === BreadcrumbTimeDisplay.ABSOLUTE ? (
+            <IconClock size="xs" />
+          ) : (
+            <IconTimer size="xs" />
+          )
+        }
+        onClick={() => {
+          setTimeDisplay(nextTimeDisplay);
           trackAnalytics('breadcrumbs.issue_details.change_time_display', {
-            value: selectedOption.value,
+            value: nextTimeDisplay,
             organization,
           });
         }}
-        value={timeDisplay}
-        options={BREADCRUMB_TIME_DISPLAY_OPTIONS}
+        size="xs"
       />
     </ButtonBar>
   );

--- a/static/app/components/events/breadcrumbs/breadcrumbsDataSection.tsx
+++ b/static/app/components/events/breadcrumbs/breadcrumbsDataSection.tsx
@@ -5,6 +5,7 @@ import ProjectAvatar from 'sentry/components/avatar/projectAvatar';
 import {Breadcrumbs as NavigationBreadcrumbs} from 'sentry/components/breadcrumbs';
 import {Button} from 'sentry/components/button';
 import ButtonBar from 'sentry/components/buttonBar';
+import {CompactSelect} from 'sentry/components/compactSelect';
 import ErrorBoundary from 'sentry/components/errorBoundary';
 import {
   BreadcrumbControlOptions,
@@ -13,6 +14,7 @@ import {
 import BreadcrumbsTimeline from 'sentry/components/events/breadcrumbs/breadcrumbsTimeline';
 import {
   BREADCRUMB_TIME_DISPLAY_LOCALSTORAGE_KEY,
+  BREADCRUMB_TIME_DISPLAY_OPTIONS,
   BreadcrumbTimeDisplay,
   getEnhancedBreadcrumbs,
   getSummaryBreadcrumbs,
@@ -116,32 +118,32 @@ export default function BreadcrumbsDataSection({
     <ButtonBar gap={1}>
       <BreadcrumbsFeedback />
       <Button
-        aria-label={t('Search Breadcrumbs')}
+        aria-label={t('Open Breadcrumb Search')}
         icon={<IconSearch size="xs" />}
         size="xs"
         onClick={() => onViewAllBreadcrumbs(BreadcrumbControlOptions.SEARCH)}
-      />
-      <Button
-        aria-label={t('Change Time Format for Breadcrumbs')}
-        icon={
-          timeDisplay === BreadcrumbTimeDisplay.ABSOLUTE ? (
-            <IconClock size="xs" />
-          ) : (
-            <IconTimer size="xs" />
-          )
-        }
-        onClick={() => {
-          const nextTimeDisplay =
-            timeDisplay === BreadcrumbTimeDisplay.ABSOLUTE
-              ? BreadcrumbTimeDisplay.RELATIVE
-              : BreadcrumbTimeDisplay.ABSOLUTE;
-          setTimeDisplay(nextTimeDisplay);
+      >
+        {t('Open Search')}
+      </Button>
+      <CompactSelect
+        size="xs"
+        triggerProps={{
+          icon:
+            timeDisplay === BreadcrumbTimeDisplay.ABSOLUTE ? (
+              <IconClock />
+            ) : (
+              <IconTimer />
+            ),
+        }}
+        onChange={selectedOption => {
+          setTimeDisplay(selectedOption.value);
           trackAnalytics('breadcrumbs.issue_details.change_time_display', {
-            value: nextTimeDisplay,
+            value: selectedOption.value,
             organization,
           });
         }}
-        size="xs"
+        value={timeDisplay}
+        options={BREADCRUMB_TIME_DISPLAY_OPTIONS}
       />
     </ButtonBar>
   );

--- a/static/app/components/events/breadcrumbs/breadcrumbsDataSection.tsx
+++ b/static/app/components/events/breadcrumbs/breadcrumbsDataSection.tsx
@@ -23,10 +23,8 @@ import useDrawer from 'sentry/components/globalDrawer';
 import {
   IconClock,
   IconEllipsis,
-  IconFilter,
   IconMegaphone,
   IconSearch,
-  IconSort,
   IconTimer,
 } from 'sentry/icons';
 import {t} from 'sentry/locale';
@@ -81,23 +79,20 @@ export default function BreadcrumbsDataSection({
         ({Header, Body}) => (
           <Fragment>
             <Header>
-              <BreadcrumbHeader>
-                <NavigationCrumbs
-                  crumbs={[
-                    {
-                      label: (
-                        <CrumbContainer>
-                          <ProjectAvatar project={project} />
-                          <ShortId>{group.shortId}</ShortId>
-                        </CrumbContainer>
-                      ),
-                    },
-                    {label: getShortEventId(event.id)},
-                    {label: t('Breadcrumbs')},
-                  ]}
-                />
-                <BreadcrumbsFeedback />
-              </BreadcrumbHeader>
+              <NavigationCrumbs
+                crumbs={[
+                  {
+                    label: (
+                      <CrumbContainer>
+                        <ProjectAvatar project={project} />
+                        <ShortId>{group.shortId}</ShortId>
+                      </CrumbContainer>
+                    ),
+                  },
+                  {label: getShortEventId(event.id)},
+                  {label: t('Breadcrumbs')},
+                ]}
+              />
             </Header>
             <Body>
               <BreadcrumbsDrawerContent
@@ -107,7 +102,7 @@ export default function BreadcrumbsDataSection({
             </Body>
           </Fragment>
         ),
-        {ariaLabel: 'breadcrumb drawer', closeOnOutsideClick: false}
+        {ariaLabel: 'breadcrumb drawer'}
       );
     },
     [group, event, project, openDrawer, enhancedCrumbs, organization]
@@ -119,23 +114,12 @@ export default function BreadcrumbsDataSection({
 
   const actions = (
     <ButtonBar gap={1}>
+      <BreadcrumbsFeedback />
       <Button
         aria-label={t('Search Breadcrumbs')}
         icon={<IconSearch size="xs" />}
         size="xs"
         onClick={() => onViewAllBreadcrumbs(BreadcrumbControlOptions.SEARCH)}
-      />
-      <Button
-        aria-label={t('Filter Breadcrumbs')}
-        icon={<IconFilter size="xs" />}
-        size="xs"
-        onClick={() => onViewAllBreadcrumbs(BreadcrumbControlOptions.FILTER)}
-      />
-      <Button
-        aria-label={t('Sort Breadcrumbs')}
-        icon={<IconSort size="xs" />}
-        size="xs"
-        onClick={() => onViewAllBreadcrumbs(BreadcrumbControlOptions.SORT)}
       />
       <Button
         aria-label={t('Change Time Format for Breadcrumbs')}
@@ -221,12 +205,6 @@ function BreadcrumbsFeedback() {
     </Button>
   );
 }
-
-const BreadcrumbHeader = styled('div')`
-  width: 100%;
-  display: flex;
-  justify-content: space-between;
-`;
 
 const ViewAllContainer = styled('div')`
   position: relative;

--- a/static/app/components/events/breadcrumbs/breadcrumbsDataSection.tsx
+++ b/static/app/components/events/breadcrumbs/breadcrumbsDataSection.tsx
@@ -54,7 +54,7 @@ export default function BreadcrumbsDataSection({
   // Use the local storage preferences, but allow the drawer to do updates
   const [timeDisplay, setTimeDisplay] = useLocalStorageState<BreadcrumbTimeDisplay>(
     BREADCRUMB_TIME_DISPLAY_LOCALSTORAGE_KEY,
-    BreadcrumbTimeDisplay.RELATIVE
+    BreadcrumbTimeDisplay.ABSOLUTE
   );
 
   const enhancedCrumbs = useMemo(() => getEnhancedBreadcrumbs(event), [event]);
@@ -206,7 +206,7 @@ function BreadcrumbsFeedback() {
       icon={<IconMegaphone />}
       size={'xs'}
     >
-      {t('Feedback')}
+      {t('Give Feedback')}
     </Button>
   );
 }

--- a/static/app/components/events/breadcrumbs/breadcrumbsDrawerContent.spec.tsx
+++ b/static/app/components/events/breadcrumbs/breadcrumbsDrawerContent.spec.tsx
@@ -58,7 +58,9 @@ describe('BreadcrumbsDrawerContent', function () {
       expect(drawerScreen.getByText(level)).toBeInTheDocument();
       expect(drawerScreen.getByText(message)).toBeInTheDocument();
     }
-    expect(drawerScreen.getAllByText('-1min 2ms')).toHaveLength(MOCK_BREADCRUMBS.length);
+    expect(drawerScreen.getAllByText('06:00:48.760')).toHaveLength(
+      MOCK_BREADCRUMBS.length
+    );
   });
 
   it('allows search to affect displayed crumbs', async function () {
@@ -129,24 +131,25 @@ describe('BreadcrumbsDrawerContent', function () {
 
   it('allows time display dropdown to change all displayed crumbs', async function () {
     const drawerScreen = await renderBreadcrumbDrawer();
-    expect(drawerScreen.getAllByText('-1min 2ms')).toHaveLength(MOCK_BREADCRUMBS.length);
-    expect(drawerScreen.queryByText('06:00:48.760')).not.toBeInTheDocument();
-
+    expect(drawerScreen.getAllByText('06:00:48.760')).toHaveLength(
+      MOCK_BREADCRUMBS.length
+    );
+    expect(drawerScreen.queryByText('-1min 2ms')).not.toBeInTheDocument();
     const timeControl = drawerScreen.getByRole('button', {
       name: 'Change Time Format for All Breadcrumbs',
     });
     await userEvent.click(timeControl);
+    await userEvent.click(drawerScreen.getByRole('option', {name: 'Relative'}));
+
+    expect(drawerScreen.queryByText('06:00:48.760')).not.toBeInTheDocument();
+    expect(drawerScreen.getAllByText('-1min 2ms')).toHaveLength(MOCK_BREADCRUMBS.length);
+
+    await userEvent.click(timeControl);
     await userEvent.click(drawerScreen.getByRole('option', {name: 'Absolute'}));
 
-    expect(drawerScreen.queryByText('-1min 2ms')).not.toBeInTheDocument();
     expect(drawerScreen.getAllByText('06:00:48.760')).toHaveLength(
       MOCK_BREADCRUMBS.length
     );
-
-    await userEvent.click(timeControl);
-    await userEvent.click(drawerScreen.getByRole('option', {name: 'Relative'}));
-
-    expect(drawerScreen.getAllByText('-1min 2ms')).toHaveLength(MOCK_BREADCRUMBS.length);
-    expect(drawerScreen.queryByText('06:00:48.760')).not.toBeInTheDocument();
+    expect(drawerScreen.queryByText('-1min 2ms')).not.toBeInTheDocument();
   });
 });

--- a/static/app/components/events/breadcrumbs/breadcrumbsDrawerContent.tsx
+++ b/static/app/components/events/breadcrumbs/breadcrumbsDrawerContent.tsx
@@ -70,7 +70,7 @@ export function BreadcrumbsDrawerContent({
 
   const [timeDisplay, setTimeDisplay] = useLocalStorageState<BreadcrumbTimeDisplay>(
     BREADCRUMB_TIME_DISPLAY_LOCALSTORAGE_KEY,
-    BreadcrumbTimeDisplay.RELATIVE
+    BreadcrumbTimeDisplay.ABSOLUTE
   );
   const filterOptions = useMemo(
     () => getBreadcrumbFilterOptions(breadcrumbs),

--- a/static/app/components/events/breadcrumbs/breadcrumbsDrawerContent.tsx
+++ b/static/app/components/events/breadcrumbs/breadcrumbsDrawerContent.tsx
@@ -226,6 +226,7 @@ export function BreadcrumbsDrawerContent({
           <BreadcrumbsTimeline
             breadcrumbs={displayCrumbs}
             startTimeString={startTimeString}
+            fullyExpanded
           />
         )}
       </TimelineContainer>

--- a/static/app/components/events/breadcrumbs/breadcrumbsDrawerContent.tsx
+++ b/static/app/components/events/breadcrumbs/breadcrumbsDrawerContent.tsx
@@ -191,7 +191,7 @@ export function BreadcrumbsDrawerContent({
           });
         }}
         value={timeDisplay}
-        options={BREADCRUMB_TIME_DISPLAY_OPTIONS}
+        options={Object.values(BREADCRUMB_TIME_DISPLAY_OPTIONS)}
       />
     </ButtonBar>
   );

--- a/static/app/components/events/breadcrumbs/breadcrumbsDrawerContent.tsx
+++ b/static/app/components/events/breadcrumbs/breadcrumbsDrawerContent.tsx
@@ -192,9 +192,7 @@ export function BreadcrumbsDrawerContent({
         }}
         value={timeDisplay}
         options={BREADCRUMB_TIME_DISPLAY_OPTIONS}
-      >
-        {null}
-      </CompactSelect>
+      />
     </ButtonBar>
   );
 

--- a/static/app/components/events/breadcrumbs/breadcrumbsTimeline.tsx
+++ b/static/app/components/events/breadcrumbs/breadcrumbsTimeline.tsx
@@ -138,7 +138,7 @@ const Subtitle = styled('p')`
 `;
 
 const Timestamp = styled('div')`
-  margin: 0 ${space(1)};
+  margin-right: ${space(1)};
   color: ${p => p.theme.subText};
   font-size: ${p => p.theme.fontSizeSmall};
   span {

--- a/static/app/components/events/breadcrumbs/breadcrumbsTimeline.tsx
+++ b/static/app/components/events/breadcrumbs/breadcrumbsTimeline.tsx
@@ -18,9 +18,9 @@ import {shouldUse24Hours} from 'sentry/utils/dates';
 interface BreadcrumbsTimelineProps {
   breadcrumbs: EnhancedCrumb[];
   /**
-   * If false, expands the contents of the breadcrumb's data payload, adds padding.
+   * If true, expands the contents of the breadcrumbs' data payload
    */
-  isCompact?: boolean;
+  fullyExpanded?: boolean;
   /**
    * Shows the line after the last breadcrumbs icon.
    * Useful for connecting timeline to components rendered after it.
@@ -35,7 +35,7 @@ interface BreadcrumbsTimelineProps {
 export default function BreadcrumbsTimeline({
   breadcrumbs,
   startTimeString,
-  isCompact = false,
+  fullyExpanded = false,
   showLastLine = false,
 }: BreadcrumbsTimelineProps) {
   const containerRef = useRef<HTMLDivElement>(null);
@@ -81,7 +81,7 @@ export default function BreadcrumbsTimeline({
     ) : null;
 
     return (
-      <Timeline.Item
+      <BreadcrumbItem
         key={virtualizedRow.key}
         ref={virtualizer.measureElement}
         title={
@@ -96,17 +96,17 @@ export default function BreadcrumbsTimeline({
         timestamp={timestampComponent}
         // XXX: Only the virtual crumb can be marked as active for breadcrumbs
         isActive={isVirtualCrumb ?? false}
-        style={showLastLine ? {background: 'transparent'} : {}}
         data-index={virtualizedRow.index}
+        showLastLine={showLastLine}
       >
-        <ContentWrapper isCompact={isCompact}>
+        <ContentWrapper>
           <BreadcrumbItemContent
             breadcrumb={breadcrumb}
             meta={meta}
-            fullyExpanded={!isCompact}
+            fullyExpanded={fullyExpanded}
           />
         </ContentWrapper>
-      </Timeline.Item>
+      </BreadcrumbItem>
     );
   });
 
@@ -139,6 +139,18 @@ const Timestamp = styled('div')`
   }
 `;
 
-const ContentWrapper = styled('div')<{isCompact: boolean}>`
-  padding-bottom: ${p => space(p.isCompact ? 0.5 : 1.0)};
+const ContentWrapper = styled('div')`
+  padding-bottom: ${space(1)};
+`;
+
+const BreadcrumbItem = styled(Timeline.Item)`
+  border-bottom: 1px solid transparent;
+  &:not(:last-child) {
+    border-image: linear-gradient(
+        to right,
+        transparent 20px,
+        ${p => p.theme.translucentInnerBorder} 20px
+      )
+      100% 1;
+  }
 `;

--- a/static/app/components/events/breadcrumbs/breadcrumbsTimeline.tsx
+++ b/static/app/components/events/breadcrumbs/breadcrumbsTimeline.tsx
@@ -1,4 +1,4 @@
-import {Fragment, useRef} from 'react';
+import {useRef} from 'react';
 import styled from '@emotion/styled';
 import {useVirtualizer} from '@tanstack/react-virtual';
 import moment from 'moment-timezone';
@@ -85,11 +85,13 @@ export default function BreadcrumbsTimeline({
         key={virtualizedRow.key}
         ref={virtualizer.measureElement}
         title={
-          <Fragment>
-            {title}
-            {isVirtualCrumb && <Subtitle> - {t('This event')}</Subtitle>}
+          <Header>
+            <div>
+              {title}
+              {isVirtualCrumb && <Subtitle> - {t('This event')}</Subtitle>}
+            </div>
             {levelComponent}
-          </Fragment>
+          </Header>
         }
         colorConfig={colorConfig}
         icon={iconComponent}
@@ -122,6 +124,11 @@ export default function BreadcrumbsTimeline({
     </div>
   );
 }
+
+const Header = styled('div')`
+  display: flex;
+  justify-content: space-between;
+`;
 
 const Subtitle = styled('p')`
   margin: 0;

--- a/static/app/components/events/breadcrumbs/utils.tsx
+++ b/static/app/components/events/breadcrumbs/utils.tsx
@@ -172,7 +172,7 @@ function getBreadcrumbTitle(category: RawCrumb['category']) {
       return BREADCRUMB_TITLE_PLACEHOLDER;
     default:
       const titleCategory = category.split('.').join(' ');
-      return toTitleCase(titleCategory);
+      return toTitleCase(titleCategory, {allowInnerUpperCase: true});
   }
 }
 

--- a/static/app/components/events/breadcrumbs/utils.tsx
+++ b/static/app/components/events/breadcrumbs/utils.tsx
@@ -69,14 +69,14 @@ export function applyBreadcrumbSearch(
   search: string,
   crumbs: EnhancedCrumb[]
 ): EnhancedCrumb[] {
-  if (search === '') {
+  if (!search.trim()) {
     return crumbs;
   }
   return crumbs.filter(
     ({breadcrumb: c}) =>
       c.type.includes(search) ||
-      c.message?.includes(search) ||
       c.category?.includes(search) ||
+      c.message?.includes(search) ||
       (c.data && JSON.stringify(c.data)?.includes(search))
   );
 }
@@ -153,7 +153,7 @@ export function getEnhancedBreadcrumbs(event: Event): EnhancedCrumb[] {
   // Add display props
   return allCrumbs.map(ec => ({
     ...ec,
-    title: getBreadcrumbTitle(ec.breadcrumb.category),
+    title: getBreadcrumbTitle(ec.breadcrumb),
     colorConfig: getBreadcrumbColorConfig(ec.breadcrumb.type),
     filter: getBreadcrumbFilter(ec.breadcrumb.type),
     iconComponent: <BreadcrumbIcon type={ec.breadcrumb.type} />,
@@ -163,22 +163,24 @@ export function getEnhancedBreadcrumbs(event: Event): EnhancedCrumb[] {
   }));
 }
 
-function getBreadcrumbTitle(category: RawCrumb['category']) {
-  switch (category) {
+function getBreadcrumbTitle(crumb: RawCrumb) {
+  if (crumb?.type === BreadcrumbType.DEFAULT) {
+    return crumb?.category;
+  }
+
+  switch (crumb?.category) {
     case 'http':
     case 'xhr':
-      return category.toUpperCase();
-    case 'httplib':
-      return t('httplib');
+      return crumb?.category.toUpperCase();
     case 'ui.click':
       return t('UI Click');
     case 'ui.input':
       return t('UI Input');
     case null:
     case undefined:
-      return BREADCRUMB_TITLE_PLACEHOLDER;
+      return BREADCRUMB_TITLE_PLACEHOLDER.toLocaleLowerCase();
     default:
-      const titleCategory = category.split('.').join(' ');
+      const titleCategory = crumb?.category.split('.').join(' ');
       return toTitleCase(titleCategory, {allowInnerUpperCase: true});
   }
 }
@@ -240,7 +242,7 @@ function getBreadcrumbFilter(type?: BreadcrumbType) {
     case BreadcrumbType.NETWORK:
       return t('Network');
     default:
-      return t('Default');
+      return BREADCRUMB_TITLE_PLACEHOLDER;
   }
 }
 

--- a/static/app/components/events/breadcrumbs/utils.tsx
+++ b/static/app/components/events/breadcrumbs/utils.tsx
@@ -195,8 +195,9 @@ function getBreadcrumbColorConfig(type?: BreadcrumbType): ColorConfig {
     case BreadcrumbType.DEVICE:
     case BreadcrumbType.NETWORK:
       return {title: 'pink400', icon: 'pink400', iconBorder: 'pink200'};
-    case BreadcrumbType.DEBUG:
     case BreadcrumbType.INFO:
+      return {title: 'blue400', icon: 'blue300', iconBorder: 'blue200'};
+    case BreadcrumbType.DEBUG:
     default:
       return {title: 'gray400', icon: 'gray300', iconBorder: 'gray200'};
   }

--- a/static/app/components/events/breadcrumbs/utils.tsx
+++ b/static/app/components/events/breadcrumbs/utils.tsx
@@ -1,6 +1,7 @@
 import styled from '@emotion/styled';
 
 import type {SelectOption} from 'sentry/components/compactSelect';
+import {BreadcrumbSort} from 'sentry/components/events/interfaces/breadcrumbs';
 import type {BreadcrumbMeta} from 'sentry/components/events/interfaces/breadcrumbs/types';
 import {
   convertCrumbType,
@@ -61,8 +62,11 @@ const Color = styled('span')<{colorConfig: ColorConfig}>`
  * As of writing this, it just grabs a few, but in the future it may collapse,
  * or manipulate them in some way for a better summary.
  */
-export function getSummaryBreadcrumbs(crumbs: EnhancedCrumb[]) {
-  return [...crumbs].reverse().slice(0, BREADCRUMB_SUMMARY_COUNT);
+export function getSummaryBreadcrumbs(crumbs: EnhancedCrumb[], sort: BreadcrumbSort) {
+  const breadcrumbs = [...crumbs];
+  const sortedCrumbs =
+    sort === BreadcrumbSort.OLDEST ? breadcrumbs : breadcrumbs.reverse();
+  return sortedCrumbs.slice(0, BREADCRUMB_SUMMARY_COUNT);
 }
 
 export function applyBreadcrumbSearch(

--- a/static/app/components/events/breadcrumbs/utils.tsx
+++ b/static/app/components/events/breadcrumbs/utils.tsx
@@ -1,6 +1,5 @@
 import styled from '@emotion/styled';
 
-import Tag from 'sentry/components/badge/tag';
 import type {SelectOption} from 'sentry/components/compactSelect';
 import type {BreadcrumbMeta} from 'sentry/components/events/interfaces/breadcrumbs/types';
 import {
@@ -152,7 +151,9 @@ export function getEnhancedBreadcrumbs(event: Event): EnhancedCrumb[] {
     colorConfig: getBreadcrumbColorConfig(ec.breadcrumb.type),
     filter: getBreadcrumbFilter(ec.breadcrumb.type),
     iconComponent: <BreadcrumbIcon type={ec.breadcrumb.type} />,
-    levelComponent: <BreadcrumbLevel level={ec.breadcrumb.level} />,
+    levelComponent: (
+      <BreadcrumbLevel level={ec.breadcrumb.level}>{ec.breadcrumb.level}</BreadcrumbLevel>
+    ),
   }));
 }
 
@@ -272,24 +273,24 @@ function BreadcrumbIcon({type}: {type?: BreadcrumbType}) {
   }
 }
 
-function BreadcrumbLevel({level}: {level: BreadcrumbLevelType}) {
-  switch (level) {
-    case BreadcrumbLevelType.ERROR:
-    case BreadcrumbLevelType.FATAL:
-      return <StyledTag type="error">{level}</StyledTag>;
-    case BreadcrumbLevelType.WARNING:
-      return <StyledTag type="warning">{level}</StyledTag>;
-    case BreadcrumbLevelType.DEBUG:
-    case BreadcrumbLevelType.INFO:
-    case BreadcrumbLevelType.LOG:
-      return <StyledTag type="highlight">{level}</StyledTag>;
-    case BreadcrumbLevelType.UNDEFINED:
-    default:
-      return null;
-  }
-}
-
-const StyledTag = styled(Tag)`
+const BreadcrumbLevel = styled('div')<{level: BreadcrumbLevelType}>`
   margin: 0 ${space(1)};
   font-weight: normal;
+  border: 0;
+  background: none;
+  color: ${p => {
+    switch (p.level) {
+      case BreadcrumbLevelType.ERROR:
+      case BreadcrumbLevelType.FATAL:
+        return p.theme.red400;
+      case BreadcrumbLevelType.WARNING:
+        return p.theme.yellow400;
+      default:
+      case BreadcrumbLevelType.DEBUG:
+      case BreadcrumbLevelType.INFO:
+      case BreadcrumbLevelType.LOG:
+        return p.theme.gray300;
+    }
+  }};
+  display: ${p => (p.level === BreadcrumbLevelType.UNDEFINED ? 'none' : 'block')};
 `;

--- a/static/app/components/events/breadcrumbs/utils.tsx
+++ b/static/app/components/events/breadcrumbs/utils.tsx
@@ -40,10 +40,16 @@ export const enum BreadcrumbTimeDisplay {
   RELATIVE = 'relative',
   ABSOLUTE = 'absolute',
 }
-export const BREADCRUMB_TIME_DISPLAY_OPTIONS = [
-  {label: t('Relative'), value: BreadcrumbTimeDisplay.RELATIVE},
-  {label: t('Absolute'), value: BreadcrumbTimeDisplay.ABSOLUTE},
-];
+export const BREADCRUMB_TIME_DISPLAY_OPTIONS = {
+  [BreadcrumbTimeDisplay.RELATIVE]: {
+    label: t('Relative'),
+    value: BreadcrumbTimeDisplay.RELATIVE,
+  },
+  [BreadcrumbTimeDisplay.ABSOLUTE]: {
+    label: t('Absolute'),
+    value: BreadcrumbTimeDisplay.ABSOLUTE,
+  },
+};
 export const BREADCRUMB_TIME_DISPLAY_LOCALSTORAGE_KEY = 'event-breadcrumb-time-display';
 
 const Color = styled('span')<{colorConfig: ColorConfig}>`

--- a/static/app/components/timeline/index.tsx
+++ b/static/app/components/timeline/index.tsx
@@ -73,7 +73,7 @@ const Row = styled('div')<{showLastLine?: boolean}>`
   &:last-child {
     margin-bottom: 0;
     /* Show/hide connecting line from the last element of the timeline */
-    background: ${p => (p.showLastLine ? 'transparent' : p.theme.background)} !important;
+    background: ${p => (p.showLastLine ? 'transparent' : p.theme.background)};
   }
 `;
 

--- a/static/app/components/timeline/index.tsx
+++ b/static/app/components/timeline/index.tsx
@@ -22,6 +22,7 @@ export interface TimelineItemProps {
   onClick?: React.MouseEventHandler<HTMLDivElement>;
   onMouseEnter?: React.MouseEventHandler<HTMLDivElement>;
   onMouseLeave?: React.MouseEventHandler<HTMLDivElement>;
+  showLastLine?: boolean;
   style?: CSSProperties;
   timestamp?: React.ReactNode;
 }
@@ -34,21 +35,13 @@ export const Item = forwardRef(function _Item(
     colorConfig = {title: 'gray400', icon: 'gray300', iconBorder: 'gray200'},
     timestamp,
     isActive = false,
-    style,
     ...props
   }: TimelineItemProps,
   ref: React.ForwardedRef<HTMLDivElement>
 ) {
   const theme = useTheme();
   return (
-    <Row
-      style={{
-        borderBottom: `1px solid ${isActive ? theme[colorConfig.icon] : 'transparent'}`,
-        ...style,
-      }}
-      ref={ref}
-      {...props}
-    >
+    <Row ref={ref} {...props}>
       <IconWrapper
         style={{
           borderColor: isActive ? theme[colorConfig.iconBorder] : 'transparent',
@@ -60,21 +53,13 @@ export const Item = forwardRef(function _Item(
       </IconWrapper>
       <Title style={{color: theme[colorConfig.title]}}>{title}</Title>
       {timestamp ?? <div />}
-      <Spacer
-        style={{borderLeft: `1px solid ${isActive ? theme.border : 'transparent'}`}}
-      />
-      <Content
-        style={{
-          marginBottom: `${isActive ? space(1) : 0}`,
-        }}
-      >
-        {children}
-      </Content>
+      <Spacer />
+      <Content>{children}</Content>
     </Row>
   );
 });
 
-const Row = styled('div')`
+const Row = styled('div')<{showLastLine?: boolean}>`
   position: relative;
   color: ${p => p.theme.subText};
   display: grid;
@@ -87,7 +72,8 @@ const Row = styled('div')`
   }
   &:last-child {
     margin-bottom: 0;
-    background: ${p => p.theme.background};
+    /* Show/hide connecting line from the last element of the timeline */
+    background: ${p => (p.showLastLine ? 'transparent' : p.theme.background)} !important;
   }
 `;
 

--- a/static/app/utils/string/toTitleCase.spec.tsx
+++ b/static/app/utils/string/toTitleCase.spec.tsx
@@ -1,0 +1,21 @@
+import {toTitleCase} from 'sentry/utils/string/toTitleCase';
+
+describe('toTitleCase', () => {
+  it('capitalizes the first letter of each word', () => {
+    expect(toTitleCase('sentry: fix your code')).toEqual('Sentry: Fix Your Code');
+  });
+
+  it('treats non-word characters as the parts of the same word', () => {
+    expect(toTitleCase('sentry-code-breaks')).toEqual('Sentry-code-breaks');
+  });
+
+  it('flattens words with capitals in the middle', () => {
+    expect(toTitleCase('seNTRy: fIX youR Code')).toEqual('Sentry: Fix Your Code');
+  });
+
+  it("doesn't flatten inner capitals if specified", () => {
+    expect(toTitleCase('seNTRy: fIX youR Code', {allowInnerUpperCase: true})).toEqual(
+      'SeNTRy: FIX YouR Code'
+    );
+  });
+});

--- a/static/app/utils/string/toTitleCase.tsx
+++ b/static/app/utils/string/toTitleCase.tsx
@@ -1,6 +1,15 @@
-export function toTitleCase(str: string): string {
-  return str.replace(
-    /\w\S*/g,
-    txt => txt.charAt(0).toUpperCase() + txt.substring(1).toLowerCase()
+interface TitleCaseOptions {
+  /**
+   * If true, will allow capital letters in the middle of words.
+   * E.g. 'my testCase' -> 'My TestCase'
+   */
+  allowInnerUpperCase?: boolean;
+}
+
+export function toTitleCase(str: string, opts?: TitleCaseOptions): string {
+  return str.replace(/\w\S*/g, txt =>
+    opts?.allowInnerUpperCase
+      ? txt.charAt(0).toUpperCase() + txt.substring(1)
+      : txt.charAt(0).toUpperCase() + txt.substring(1).toLowerCase()
   );
 }


### PR DESCRIPTION
This PR addresses a wave a feedback for the new breadcrumbs design
- Larger, darker text for descriptions
- Monospace font and preserving whitespace for description
- Show message crumbs as blue
- Remove Sort/Filter on issue details
- Allow categories to contain upper case letters
- Unknown categories will be unchanged
- Absolute timestamp is being kept as the default
- Respect sort order on summary crumbs,


<img width="1145" alt="image" src="https://github.com/user-attachments/assets/c6a1dee0-4e09-421e-a5e0-53f9f58da523">


**todo**
- [x] Fix tests 
- [ ] Fix virtualization (deferring to future PR)
- [x] Remove text from control on main page