### PR TITLE
feat(uptime): Enforce a basic quota of 1 uptime monitor per organization

### DIFF
--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -26,7 +26,6 @@ from sentry.signals import event_processed, issue_unignored, transaction_process
 from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task
 from sentry.types.group import GroupSubStatus
-from sentry.uptime.detectors.detector import detect_base_url_for_project
 from sentry.utils import json, metrics
 from sentry.utils.cache import cache
 from sentry.utils.event_frames import get_sdk_name
@@ -1515,6 +1514,8 @@ def detect_new_escalation(job: PostProcessJob):
 
 
 def detect_base_urls_for_uptime(job: PostProcessJob):
+    from sentry.uptime.detectors.detector import detect_base_url_for_project
+
     url = get_path(job["event"].data, "request", "url")
     detect_base_url_for_project(job["event"].project, url)
 

--- a/src/sentry/uptime/detectors/ranking.py
+++ b/src/sentry/uptime/detectors/ranking.py
@@ -9,6 +9,8 @@ from redis.client import StrictRedis
 from rediscluster import RedisCluster
 
 from sentry.constants import UPTIME_AUTODETECTION
+from sentry.uptime.models import get_active_monitor_count_for_org
+from sentry.uptime.subscriptions.subscriptions import MAX_SUBSCRIPTIONS_PER_ORG
 from sentry.utils import metrics, redis
 
 if TYPE_CHECKING:
@@ -165,6 +167,9 @@ def delete_organization_bucket(bucket: datetime) -> None:
 
 def should_detect_for_organization(organization: Organization) -> bool:
     if not organization.get_option("sentry:uptime_autodetection", UPTIME_AUTODETECTION):
+        return False
+
+    if get_active_monitor_count_for_org(organization) >= MAX_SUBSCRIPTIONS_PER_ORG:
         return False
     return True
 

--- a/src/sentry/uptime/detectors/tasks.py
+++ b/src/sentry/uptime/detectors/tasks.py
@@ -114,7 +114,6 @@ def process_organization_url_ranking(organization_id: int):
         "uptime.process_organization",
         extra={"organization_id": org.id},
     )
-    # TODO: Check quota available for org
     should_detect = should_detect_for_organization(org)
 
     for project_id, project_count in get_candidate_projects_for_org(org):

--- a/src/sentry/uptime/subscriptions/subscriptions.py
+++ b/src/sentry/uptime/subscriptions/subscriptions.py
@@ -14,6 +14,7 @@ from sentry.uptime.subscriptions.tasks import (
 logger = logging.getLogger(__name__)
 
 UPTIME_SUBSCRIPTION_TYPE = "uptime_monitor"
+MAX_SUBSCRIPTIONS_PER_ORG = 1
 
 
 def create_uptime_subscription(

--- a/tests/sentry/uptime/detectors/test_ranking.py
+++ b/tests/sentry/uptime/detectors/test_ranking.py
@@ -184,3 +184,10 @@ class ShouldDetectForOrgTest(TestCase):
         assert not should_detect_for_organization(self.organization)
         self.organization.update_option("sentry:uptime_autodetection", True)
         assert should_detect_for_organization(self.organization)
+
+    def test_quota(self):
+        assert should_detect_for_organization(self.organization)
+        uptime_monitor = self.create_project_uptime_subscription()
+        assert not should_detect_for_organization(self.organization)
+        uptime_monitor.delete()
+        assert should_detect_for_organization(self.organization)


### PR DESCRIPTION
This limits each organization to 1 uptime monitor. We're not using the official quota system yet, but will just keep track of how many uptime monitors exist in the org.

<!-- Describe your PR here. -->