### PR TITLE
feat(query-builder): Modify invalid filter styles

### DIFF
--- a/static/app/components/searchQueryBuilder/tokens/filter/filter.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/filter.tsx
@@ -248,12 +248,13 @@ const FilterWrapper = styled('div')`
     outline: none;
   }
 
-  &[aria-selected='true'] {
-    background-color: ${p => p.theme.gray100};
+  &[aria-invalid='true'] {
+    border-color: ${p => p.theme.red200};
+    background-color: ${p => p.theme.red100};
   }
 
-  &[aria-invalid='true'] {
-    border-color: ${p => p.theme.red400};
+  &[aria-selected='true'] {
+    background-color: ${p => p.theme.gray100};
   }
 `;
 


### PR DESCRIPTION
Per Vu, adding a red background and different border color for invalid filters:

![CleanShot 2024-07-23 at 15 06 08@2x](https://github.com/user-attachments/assets/fb67b0e2-cf80-4c77-b81a-4dd5dd5c8d65)
