### PR TITLE
ref(feedback): add visualization for non-image attachments and allow download

### DIFF
--- a/static/app/components/feedback/feedbackItem/feedbackScreenshot.tsx
+++ b/static/app/components/feedback/feedbackItem/feedbackScreenshot.tsx
@@ -50,7 +50,7 @@ export default function FeedbackScreenshot({
       {onClick ? <StyledImageButton onClick={onClick}>{img}</StyledImageButton> : img}
     </StyledPanel>
   ) : (
-    <File>
+    <File onClick={onClick}>
       <NoPreviewFound>
         <IconImage />
         {t('No preview found')}

--- a/static/app/components/feedback/feedbackItem/feedbackScreenshot.tsx
+++ b/static/app/components/feedback/feedbackItem/feedbackScreenshot.tsx
@@ -27,7 +27,8 @@ export default function FeedbackScreenshot({
   onClick,
 }: Props) {
   const [isLoading, setIsLoading] = useState(true);
-  const isImage = screenshot.mimetype.includes('image');
+  const isImage =
+    screenshot.mimetype.includes('image') || screenshot.mimetype.includes('png');
 
   const img = (
     <StyledImageVisualization

--- a/static/app/components/feedback/feedbackItem/feedbackScreenshot.tsx
+++ b/static/app/components/feedback/feedbackItem/feedbackScreenshot.tsx
@@ -27,8 +27,9 @@ export default function FeedbackScreenshot({
   onClick,
 }: Props) {
   const [isLoading, setIsLoading] = useState(true);
-  const isImage =
-    screenshot.mimetype.includes('image') || screenshot.mimetype.includes('png');
+  // since we can't trust mimetype, we'll try to load all attachments as images
+  // if it fails, then set that here, and render a default preview instead.
+  const [imgLoadError, setImgLoadError] = useState(false);
 
   const img = (
     <StyledImageVisualization
@@ -36,12 +37,17 @@ export default function FeedbackScreenshot({
       orgId={organization.slug}
       projectSlug={projectSlug}
       eventId={screenshot.event_id}
-      onLoad={() => setIsLoading(false)}
-      onError={() => setIsLoading(false)}
+      onLoad={() => {
+        setIsLoading(false);
+      }}
+      onError={() => {
+        setIsLoading(false);
+        setImgLoadError(true);
+      }}
     />
   );
 
-  return isImage ? (
+  return !imgLoadError ? (
     <StyledPanel className={className}>
       {isLoading && (
         <StyledLoadingIndicator>

--- a/static/app/components/feedback/feedbackItem/feedbackScreenshot.tsx
+++ b/static/app/components/feedback/feedbackItem/feedbackScreenshot.tsx
@@ -4,6 +4,11 @@ import styled from '@emotion/styled';
 import ImageVisualization from 'sentry/components/events/eventTagsAndScreenshot/screenshot/imageVisualization';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import Panel from 'sentry/components/panels/panel';
+import TextOverflow from 'sentry/components/textOverflow';
+import {Tooltip} from 'sentry/components/tooltip';
+import {IconImage} from 'sentry/icons';
+import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
 import type {EventAttachment, Organization, Project} from 'sentry/types';
 
 type Props = {
@@ -22,6 +27,8 @@ export default function FeedbackScreenshot({
   onClick,
 }: Props) {
   const [isLoading, setIsLoading] = useState(true);
+  const isImage = screenshot.mimetype.includes('image');
+
   const img = (
     <StyledImageVisualization
       attachment={screenshot}
@@ -33,7 +40,7 @@ export default function FeedbackScreenshot({
     />
   );
 
-  return (
+  return isImage ? (
     <StyledPanel className={className}>
       {isLoading && (
         <StyledLoadingIndicator>
@@ -42,6 +49,20 @@ export default function FeedbackScreenshot({
       )}
       {onClick ? <StyledImageButton onClick={onClick}>{img}</StyledImageButton> : img}
     </StyledPanel>
+  ) : (
+    <File>
+      <NoPreviewFound>
+        <IconImage />
+        {t('No preview found')}
+      </NoPreviewFound>
+      <Tooltip position="right" title={t('Click to download')}>
+        <FileDownload
+          href={`/api/0/projects/${organization.slug}/${projectSlug}/events/${screenshot.event_id}/attachments/${screenshot.id}/?download=1`}
+        >
+          <TextOverflow>{screenshot.name}</TextOverflow>
+        </FileDownload>
+      </Tooltip>
+    </File>
   );
 }
 
@@ -80,4 +101,30 @@ const StyledImageVisualization = styled(ImageVisualization)`
     width: auto;
     height: auto;
   }
+`;
+const FileDownload = styled('a')`
+  cursor: pointer;
+  padding: ${space(1)};
+  text-decoration: underline;
+  color: inherit;
+  :hover {
+    color: inherit;
+    text-decoration: underline;
+  }
+`;
+
+const File = styled(StyledPanel)`
+  background: ${p => p.theme.purple100};
+  padding: ${space(2)};
+  max-width: 300px;
+`;
+
+const NoPreviewFound = styled('p')`
+  color: ${p => p.theme.gray300};
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: ${space(0.5)};
+  justify-content: center;
+  margin: 0;
 `;

--- a/static/app/components/feedback/feedbackItem/feedbackScreenshot.tsx
+++ b/static/app/components/feedback/feedbackItem/feedbackScreenshot.tsx
@@ -57,7 +57,7 @@ export default function FeedbackScreenshot({
       </NoPreviewFound>
       <Tooltip position="right" title={t('Click to download')}>
         <FileDownload
-          className="feedback-attachment-download-button"
+          aria-label="feedback-attachment-download-button"
           href={`/api/0/projects/${organization.slug}/${projectSlug}/events/${screenshot.event_id}/attachments/${screenshot.id}/?download=1`}
         >
           <TextOverflow>{screenshot.name}</TextOverflow>

--- a/static/app/components/feedback/feedbackItem/feedbackScreenshot.tsx
+++ b/static/app/components/feedback/feedbackItem/feedbackScreenshot.tsx
@@ -57,6 +57,7 @@ export default function FeedbackScreenshot({
       </NoPreviewFound>
       <Tooltip position="right" title={t('Click to download')}>
         <FileDownload
+          className="feedback-attachment-download-button"
           href={`/api/0/projects/${organization.slug}/${projectSlug}/events/${screenshot.event_id}/attachments/${screenshot.id}/?download=1`}
         >
           <TextOverflow>{screenshot.name}</TextOverflow>

--- a/static/app/components/feedback/feedbackItem/screenshotsModal.tsx
+++ b/static/app/components/feedback/feedbackItem/screenshotsModal.tsx
@@ -53,7 +53,7 @@ export default function ScreenshotsModal({
           </PaginationWrapper>
         )}
       </Header>
-      <Body>
+      <Body style={{display: 'flex', justifyContent: 'center'}}>
         <FeedbackScreenshot
           organization={organization}
           screenshot={currentScreenshot}


### PR DESCRIPTION
- closes https://github.com/getsentry/sentry/issues/74731
- adds support for downloading non-image files
- attempt to load all attachments as images first. if `<img>` gives an error, then send that to our screenshot renderer, and tell it to use the default "no preview found" renderer instead.

before: 
<img width="817" alt="SCR-20240723-nrth" src="https://github.com/user-attachments/assets/3810f031-ace6-4c63-a437-d0371805af83">

after: "no preview found" text along with option to download the item:
<img width="806" alt="SCR-20240723-nrjc" src="https://github.com/user-attachments/assets/9c7cdaa4-325c-4b63-81c4-f3c0fb979bd0">

<img width="573" alt="SCR-20240723-nuzb" src="https://github.com/user-attachments/assets/b3b3d193-4f33-4f0e-ac02-6dfae2b986da">


all the attachments show up in the modal as well and work as expected with the pagination.
<img width="1110" alt="SCR-20240723-obyr" src="https://github.com/user-attachments/assets/0965fe0a-70e2-4805-8b32-14087eea512d">
<img width="1108" alt="SCR-20240723-obxj" src="https://github.com/user-attachments/assets/97792bea-d3f1-4423-8b39-500b353ce8ec">

works with the example @c298lee brought up where the `mimetype` was incorrectly set:
<img width="544" alt="SCR-20240724-jsua" src="https://github.com/user-attachments/assets/0c3c7a2d-253f-49de-a969-8e6c6479122f">
