### PR TITLE
ref: adjust typing so rate_limits can be a callable

### DIFF
--- a/src/sentry/api/base.py
+++ b/src/sentry/api/base.py
@@ -221,8 +221,8 @@ class Endpoint(APIView):
 
     owner: ApiOwner = ApiOwner.UNOWNED
     publish_status: dict[HTTP_METHOD_NAME, ApiPublishStatus] = {}
-    rate_limits: RateLimitConfig | dict[
-        str, dict[RateLimitCategory, RateLimit]
+    rate_limits: RateLimitConfig | dict[str, dict[RateLimitCategory, RateLimit]] | Callable[
+        ..., RateLimitConfig | dict[str, dict[RateLimitCategory, RateLimit]]
     ] = DEFAULT_RATE_LIMIT_CONFIG
     enforce_rate_limit: bool = settings.SENTRY_RATELIMITER_ENABLED
     snuba_methods: list[HTTP_METHOD_NAME] = []

--- a/tests/sentry/middleware/test_ratelimit_middleware.py
+++ b/tests/sentry/middleware/test_ratelimit_middleware.py
@@ -288,7 +288,8 @@ class CallableRateLimitConfigEndpoint(Endpoint):
     permission_classes = (AllowAny,)
     enforce_rate_limit = True
 
-    def rate_limits(request):
+    @staticmethod
+    def rate_limits(*a, **k):
         return {
             "GET": {
                 RateLimitCategory.IP: RateLimit(limit=20, window=1),

--- a/tests/sentry/ratelimits/utils/test_get_rate_limit_value.py
+++ b/tests/sentry/ratelimits/utils/test_get_rate_limit_value.py
@@ -88,31 +88,3 @@ class TestGetRateLimitValue(TestCase):
         assert get_rate_limit_value(
             "GET", RateLimitCategory.IP, rate_limit_config
         ) == get_default_rate_limits_for_group("foo", RateLimitCategory.IP)
-
-    def test_multiple_inheritance(self):
-        class ParentEndpoint(Endpoint):
-            rate_limits: RateLimitConfig | dict[str, dict[RateLimitCategory, RateLimit]]
-            rate_limits = {"GET": {RateLimitCategory.IP: RateLimit(limit=100, window=5)}}
-
-        class Mixin:
-            rate_limits: RateLimitConfig | dict[str, dict[RateLimitCategory, RateLimit]]
-            rate_limits = {"GET": {RateLimitCategory.IP: RateLimit(limit=2, window=4)}}
-
-        class ChildEndpoint(ParentEndpoint, Mixin):
-            pass
-
-        _child_endpoint = ChildEndpoint.as_view()
-        rate_limit_config = get_rate_limit_config(_child_endpoint.view_class)
-
-        class ChildEndpointReverse(Mixin, ParentEndpoint):
-            pass
-
-        _child_endpoint_reverse = ChildEndpointReverse.as_view()
-        rate_limit_config_reverse = get_rate_limit_config(_child_endpoint_reverse.view_class)
-
-        assert get_rate_limit_value("GET", RateLimitCategory.IP, rate_limit_config) == RateLimit(
-            100, 5
-        )
-        assert get_rate_limit_value(
-            "GET", RateLimitCategory.IP, rate_limit_config_reverse
-        ) == RateLimit(limit=2, window=4)


### PR DESCRIPTION
this fixes an error in mypy 1.11 -- it also fixes an error in a currently-ignored file which has a callable `rate_limits`

<!-- Describe your PR here. -->