### PR TITLE
chore(slack): Add Use SDK Client for Spike Protection

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -400,8 +400,8 @@ def register_temporary_features(manager: FeatureManager):
     # Enable improvements to Slack notifications
     manager.add("organizations:slack-improvements", OrganizationFeature, FeatureHandlerStrategy.OPTIONS, api_expose=False)
     # Feature flags for migrating to the Slack SDK WebClient
-    # Use new Slack SDK Client in get_channel_id_with_timeout
-    manager.add("organizations:slack-sdk-get-channel-id", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
+    # Use new Slack SDK Client for spike protection message
+    manager.add("organizations:slack-sdk-spike-protection", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Add regression chart as image to slack message
     manager.add("organizations:slack-endpoint-regression-image", OrganizationFeature, FeatureHandlerStrategy.OPTIONS, api_expose=False)
     manager.add("organizations:slack-function-regression-image", OrganizationFeature, FeatureHandlerStrategy.OPTIONS, api_expose=False)

--- a/tests/sentry/integrations/slack/test_tasks.py
+++ b/tests/sentry/integrations/slack/test_tasks.py
@@ -19,7 +19,6 @@ from sentry.tasks.integrations.slack import (
 )
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers import install_slack
-from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.skips import requires_snuba
 from tests.sentry.integrations.slack.utils.test_mock_slack_response import mock_slack_response
 
@@ -283,7 +282,6 @@ class SlackTasksTest(TestCase):
         "sentry.integrations.slack.utils.channel.get_channel_id_with_timeout",
         return_value=SlackChannelIdData("#", "chan-id", False),
     )
-    @with_feature("organizations:slack-sdk-get-channel-id")
     def test_task_existing_metric_alert_with_sdk(self, mock_get_channel_id, mock_set_value):
         alert_rule_data = self.metric_alert_data()
         alert_rule = self.create_alert_rule(


### PR DESCRIPTION
Need to use SDK Client in Spike Protection, so a FF for that.

Also cleaning up an old FF from an older SDK Client usage that we already GA'ed.