### PR TITLE
feat(issue-details): Add event actions to updated event navigation

### DIFF
--- a/static/app/views/issueDetails/eventNavigation.tsx
+++ b/static/app/views/issueDetails/eventNavigation.tsx
@@ -203,7 +203,7 @@ export default function EventNavigation({event, group}: EventNavigationProps) {
             </Button>
             <DropdownMenu
               triggerProps={{
-                'aria-label': t('Short-ID copy actions'),
+                'aria-label': t('Event actions'),
                 icon: <Chevron direction="down" />,
                 size: 'zero',
                 borderless: true,


### PR DESCRIPTION
this pr adds in the actions for copying event id + a dropdown for json and copy the link to the event, which are no longer buttons in the updated design