### PR TITLE
chore(ui-cleanup): the great px recession

### DIFF
--- a/static/app/components/panels/panel.tsx
+++ b/static/app/components/panels/panel.tsx
@@ -22,7 +22,7 @@ const Panel = styled(
   border-radius: ${p => p.theme.panelBorderRadius};
   border: 1px
     ${p => (p.dashedBorder ? 'dashed' + p.theme.gray300 : 'solid ' + p.theme.border)};
-  margin-bottom: ${space(2)};
+  margin-bottom: ${space(1)};
   position: relative;
 `;
 

--- a/static/app/views/organizationStats/index.tsx
+++ b/static/app/views/organizationStats/index.tsx
@@ -395,7 +395,7 @@ const HeadingSubtitle = styled('p')`
 const PageControl = styled('div')`
   display: grid;
   width: 100%;
-  margin-bottom: ${space(2)};
+  margin-bottom: ${space(1)};
   grid-template-columns: minmax(0, max-content);
   @media (max-width: ${p => p.theme.breakpoints.small}) {
     grid-template-columns: minmax(0, 1fr);

--- a/static/app/views/organizationStats/teamInsights/controls.tsx
+++ b/static/app/views/organizationStats/teamInsights/controls.tsx
@@ -240,8 +240,8 @@ export default TeamStatsControls;
 const ControlsWrapper = styled('div')<{showEnvironment?: boolean}>`
   display: grid;
   align-items: center;
-  gap: ${space(2)};
-  margin-bottom: ${space(2)};
+  gap: ${space(1)};
+  margin-bottom: ${space(1)};
 
   @media (min-width: ${p => p.theme.breakpoints.small}) {
     grid-template-columns: 246px ${p => (p.showEnvironment ? '246px' : '')} 1fr;


### PR DESCRIPTION
Reducing spacing between elements across the product from 16px to 8px

**Example of Before:**
![Screenshot 2024-07-23 at 4 14 32 PM](https://github.com/user-attachments/assets/a49b53b3-a885-4c6e-8d30-4bb1d896a09a)

**Example of After:**
![Screenshot 2024-07-23 at 4 15 33 PM](https://github.com/user-attachments/assets/a8a13ec6-f441-4141-8f26-a65798033466)