### PR TITLE
fix(conditions): Include generic groups in result mapping

### DIFF
--- a/src/sentry/rules/conditions/event_frequency.py
+++ b/src/sentry/rules/conditions/event_frequency.py
@@ -658,38 +658,47 @@ class EventFrequencyPercentCondition(BaseEventFrequencyCondition):
     def batch_query_hook(
         self, group_ids: set[int], start: datetime, end: datetime, environment_id: int
     ) -> dict[int, int]:
-        batch_percents: dict[int, int] = defaultdict(int)
         groups = Group.objects.filter(id__in=group_ids).values(
             "id", "type", "project_id", "project__organization_id"
         )
         project_id = self.get_value_from_groups(groups, "project_id")
-        avg_sessions_in_interval = None
-        if project_id:
-            session_count_last_hour = self.get_session_count(project_id, environment_id, start, end)
-            avg_sessions_in_interval = self.get_session_interval(
-                session_count_last_hour, self.get_option("interval")
-            )
-        if avg_sessions_in_interval:
-            error_issue_ids, _ = self.get_error_and_generic_group_ids(groups)
-            organization_id = self.get_value_from_groups(groups, "project__organization_id")
-            if error_issue_ids and organization_id:
-                error_issue_count = self.get_chunked_result(
-                    tsdb_function=self.tsdb.get_sums,
-                    model=get_issue_tsdb_group_model(GroupCategory.ERROR),
-                    group_ids=error_issue_ids,
-                    organization_id=organization_id,
-                    start=start,
-                    end=end,
-                    environment_id=environment_id,
-                    referrer_suffix="batch_alert_event_frequency_percent",
-                )
-                for group_id, count in error_issue_count.items():
-                    percent: int = int(100 * round(count / avg_sessions_in_interval, 4))
-                    batch_percents[group_id] = percent
-        else:
-            percent = 0
-            for group in groups:
-                batch_percents[group.get("id")] = percent
+
+        if not project_id:
+            return {group.get("id"): 0 for group in groups}
+
+        session_count_last_hour = self.get_session_count(project_id, environment_id, start, end)
+        avg_sessions_in_interval = self.get_session_interval(
+            session_count_last_hour, self.get_option("interval")
+        )
+
+        if not avg_sessions_in_interval:
+            return {group.get("id"): 0 for group in groups}
+
+        error_issue_ids, generic_issue_ids = self.get_error_and_generic_group_ids(groups)
+        organization_id = self.get_value_from_groups(groups, "project__organization_id")
+
+        if not (error_issue_ids and organization_id):
+            return {group.get("id"): 0 for group in groups}
+
+        error_issue_count = self.get_chunked_result(
+            tsdb_function=self.tsdb.get_sums,
+            model=get_issue_tsdb_group_model(GroupCategory.ERROR),
+            group_ids=error_issue_ids,
+            organization_id=organization_id,
+            start=start,
+            end=end,
+            environment_id=environment_id,
+            referrer_suffix="batch_alert_event_frequency_percent",
+        )
+
+        batch_percents: dict[int, int] = {}
+        for group_id, count in error_issue_count.items():
+            percent: int = int(100 * round(count / avg_sessions_in_interval, 4))
+            batch_percents[group_id] = percent
+
+        # We do not have sessions for non-error issue types
+        for group in generic_issue_ids:
+            batch_percents[group] = 0
 
         return batch_percents
 

--- a/tests/snuba/rules/conditions/test_event_frequency.py
+++ b/tests/snuba/rules/conditions/test_event_frequency.py
@@ -206,6 +206,7 @@ class EventFrequencyPercentConditionQueryTest(
         assert batch_query == {
             self.event.group_id: percent_of_sessions,
             self.event2.group_id: percent_of_sessions,
+            self.perf_event.group_id: 0,
         }
         batch_query = self.condition_inst2.batch_query_hook(
             group_ids=[self.event3.group_id],


### PR DESCRIPTION
There's a small issue where we run into a KeyError when parsing `EventFrequencyPercentConditions`. This is b/c the relevant group that's raising the KeyError is missing from the results.
The condition is skipping adding generic (non-issue) groups to the results when it should be added with a percent of 0.
https://github.com/getsentry/sentry/blob/b78aefeee5a11b2abd669e74aabf45a7882bc6ae/src/sentry/rules/conditions/event_frequency.py#L673

Also switch `batch_query_hook` to use early return

Fixes [SENTRY-3CAW](https://sentry.sentry.io/issues/5637069028/)