### PR TITLE
fix(query-builder): Better support for adding filter keys by typing

### DIFF
--- a/static/app/components/searchQueryBuilder/tokens/freeText.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/freeText.tsx
@@ -24,6 +24,7 @@ import type {
 import {
   InvalidReason,
   type ParseResultToken,
+  parseSearch,
   Token,
   type TokenResult,
 } from 'sentry/components/searchSyntax/parser';
@@ -489,7 +490,16 @@ function SearchQueryBuilderInputInternal({
         token={token}
         inputLabel={t('Add a search term')}
         onInputChange={e => {
-          if (e.target.value.includes('(') || e.target.value.includes(')')) {
+          // Parse text to see if this keystroke would have created any tokens.
+          // Add a trailing quote in case the user wants to wrap with quotes.
+          const parsedText = parseSearch(e.target.value + '"');
+
+          if (
+            parsedText?.some(
+              textToken =>
+                textToken.type === Token.L_PAREN || textToken.type === Token.R_PAREN
+            )
+          ) {
             dispatch({
               type: 'UPDATE_FREE_TEXT',
               tokens: [token],
@@ -500,14 +510,36 @@ function SearchQueryBuilderInputInternal({
             return;
           }
 
-          if (e.target.value.includes(':')) {
+          if (
+            parsedText?.some(
+              textToken =>
+                textToken.type === Token.FILTER && textToken.key.text === filterValue
+            )
+          ) {
+            const filterKey = filterValue;
+            const key = filterKeys[filterKey];
             dispatch({
               type: 'UPDATE_FREE_TEXT',
               tokens: [token],
-              text: e.target.value,
+              text: replaceFocusedWordWithFilter(
+                inputValue,
+                selectionIndex,
+                filterKey,
+                getFieldDefinition
+              ),
               focusOverride: calculateNextFocusForFilter(state),
             });
             resetInputValue();
+            trackAnalytics('search.key_manually_typed', {
+              organization,
+              search_type: savedSearchType === 0 ? 'issues' : 'events',
+              search_source: searchSource,
+              item_name: filterKey,
+              item_kind: key?.kind ?? FieldKind.FIELD,
+              item_value_type:
+                getFieldDefinition(filterKey)?.valueType ?? FieldValueType.STRING,
+              new_experience: true,
+            });
             return;
           }
 

--- a/static/app/utils/analytics/searchAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/searchAnalyticsEvents.tsx
@@ -47,6 +47,11 @@ export type SearchEventParameters = {
     item_value_type?: string;
     search_operator?: string;
   };
+  'search.key_manually_typed': Omit<SearchEventBase, 'query'> & {
+    item_kind: string;
+    item_name: string;
+    item_value_type: string;
+  };
   'search.operator_autocompleted': SearchEventBase & {
     search_operator: string;
     filter_key?: string;
@@ -103,6 +108,7 @@ export const searchEventMap: Record<SearchEventKey, string | null> = {
   'search.searched': 'Search: Performed search',
   'search.searched_filter': 'Search: Performed search filter',
   'search.key_autocompleted': 'Search: Key Autocompleted',
+  'search.key_manually_typed': 'Search: Key Manually Typed',
   'search.shortcut_used': 'Search: Shortcut Used',
   'search.docs_opened': 'Search: Docs Opened',
   'search.search_with_invalid': 'Search: Attempted Invalid Search',


### PR DESCRIPTION
When selecting a filter key through the menu, we add a default value in the `replaceFocusedWordWithFilter()` function. When typing (`<filter>:`) we don't do that, which results in a filter without a value. This wasn't as apparent before because we weren't highlighting invalid filters.

These changes will ensure that this function gets called when we detect a filter after `:` is typed.

Also added an analytics event so that we can track how common this is. 

Before:

https://github.com/user-attachments/assets/a1df978f-de3d-4ed7-8557-97d8a3765a61


After:

https://github.com/user-attachments/assets/560aeb08-8e82-4b69-a03c-8a89ec47bf0c

