### PR TITLE
fix(issues): Parameterize multi-second durations

### DIFF
--- a/src/sentry/grouping/parameterization.py
+++ b/src/sentry/grouping/parameterization.py
@@ -153,7 +153,7 @@ DEFAULT_PARAMETERIZATION_REGEXES = [
             (datetime.datetime\(.*?\))
         """,
     ),
-    ParameterizationRegex(name="duration", raw_pattern=r"""\b(\d+ms) | (\d(\.\d+)?s)\b"""),
+    ParameterizationRegex(name="duration", raw_pattern=r"""\b(\d+ms) | (\d+(\.\d+)?s)\b"""),
     ParameterizationRegex(name="hex", raw_pattern=r"""\b0[xX][0-9a-fA-F]+\b"""),
     ParameterizationRegex(name="float", raw_pattern=r"""-\d+\.\d+\b | \b\d+\.\d+\b"""),
     ParameterizationRegex(name="int", raw_pattern=r"""-\d+\b | \b\d+\b"""),

--- a/tests/sentry/grouping/test_parameterization.py
+++ b/tests/sentry/grouping/test_parameterization.py
@@ -134,8 +134,13 @@ def parameterizer():
         ("bool", """blah a=true had a problem""", """blah a=<bool> had a problem"""),
         (
             "Duration - ms",
-            """blah connection failed after 12345ms 1.899s 3s""",
-            """blah connection failed after <duration> <duration> <duration>""",
+            """connection failed after 1ms 23ms 4567890ms""",
+            """connection failed after <duration> <duration> <duration>""",
+        ),
+        (
+            "Duration - s",
+            """connection failed after 1.234s 56s 78.90s""",
+            """connection failed after <duration> <duration> <duration>""",
         ),
         (
             "Hostname - 2 levels",


### PR DESCRIPTION
Previously these were incorrectly only including the last digit (ex: `12s` -> `1<duration>`).

This also splits out the `ms` and `s` duration tests since the behavior for each is slightly different.