### PR TITLE
ref(grouping): Strip querystrings from stacktrace filenames

### DIFF
--- a/src/sentry/stacktraces/processing.py
+++ b/src/sentry/stacktraces/processing.py
@@ -4,12 +4,14 @@ import logging
 from collections.abc import Callable, Mapping, MutableMapping, Sequence
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any, NamedTuple
+from urllib.parse import urlparse
 
 import sentry_sdk
 
 from sentry.models.project import Project
 from sentry.models.release import Release
 from sentry.stacktraces.functions import set_in_app, trim_function_name
+from sentry.utils import metrics
 from sentry.utils.cache import cache
 from sentry.utils.hashlib import hash_values
 from sentry.utils.safe import get_path, safe_execute
@@ -298,7 +300,7 @@ def normalize_stacktraces_for_grouping(
 ) -> None:
     """
     Applies grouping enhancement rules and ensure in_app is set on all frames.
-    This also trims functions if necessary.
+    This also trims functions and pulls query strings off of filenames if necessary.
     """
 
     stacktrace_frames = []
@@ -323,9 +325,25 @@ def normalize_stacktraces_for_grouping(
     # otherwise stored in `function` to not make the payload larger
     # unnecessarily.
     with sentry_sdk.start_span(op=op, description="iterate_frames"):
+        stripped_querystring = False
         for frames in stacktrace_frames:
             for frame in frames:
                 _update_frame(frame, platform)
+
+                if platform == "javascript":
+                    try:
+                        parsed_filename = urlparse(frame.get("filename", ""))
+                        if parsed_filename.query:
+                            stripped_querystring = True
+                            frame["filename"] = frame["filename"].replace(
+                                f"?{parsed_filename.query}", ""
+                            )
+                    # ignore unparsable filenames
+                    except Exception:
+                        pass
+        if stripped_querystring:
+            # Fires once per event, regardless of how many frames' filenames were stripped
+            metrics.incr("sentry.grouping.stripped_filename_querystrings")
 
     # If a grouping config is available, run grouping enhancers
     if grouping_config is not None:

--- a/tests/sentry/stacktraces/test_filename.py
+++ b/tests/sentry/stacktraces/test_filename.py
@@ -1,0 +1,50 @@
+from typing import Any
+from unittest import TestCase
+
+from sentry.stacktraces.processing import normalize_stacktraces_for_grouping
+
+
+def _make_event_data(filenames: list[str], platform: str = "") -> dict[str, Any]:
+    return {
+        "exception": {
+            "values": [
+                {
+                    "stacktrace": {
+                        "frames": [{"filename": filename} for filename in filenames],
+                    },
+                }
+            ]
+        },
+        "platform": platform,
+    }
+
+
+def _get_filenames(event_data: dict[str, Any]) -> list[str]:
+    frames = event_data["exception"]["values"][0]["stacktrace"]["frames"]
+    return [frame["filename"] for frame in frames]
+
+
+class FilenameNormalizationTest(TestCase):
+    def test_leaves_non_js_events_alone(self):
+        filenames = ["whos_a_good_girl?.py", "maisey.py"]
+        event_data = _make_event_data(filenames, "python")
+
+        normalize_stacktraces_for_grouping(event_data)
+
+        assert _get_filenames(event_data) == filenames
+
+    def test_leaves_non_querystringed_js_filenames_alone(self):
+        filenames = ["maisey.js", "charlie.js"]
+        event_data = _make_event_data(filenames, "javascript")
+
+        normalize_stacktraces_for_grouping(event_data)
+
+        assert _get_filenames(event_data) == filenames
+
+    def test_strips_querystrings_from_files_in_js_events(self):
+        filenames = ["maisey.js?good=duh", "charlie.html"]
+        event_data = _make_event_data(filenames, "javascript")
+
+        normalize_stacktraces_for_grouping(event_data)
+
+        assert _get_filenames(event_data) == ["maisey.js", "charlie.html"]


### PR DESCRIPTION
In cases where a stacktrace frame's `filename` is the basename of a URL, we sometimes end up with querystring nonsense on the end of it. This both makes the stacktrace hard to read and forces Seer to tokenize a whole bunch of meaningless stuff. Here's a recent example of such a stacktrace:

```python
"frames": [
    {
      "filename": "index.html?__geo_region=jp&loc=eyjrawqioiiydks4rjniyvrlwekwovb5yxdrrno4iiwiywxnijoirvmyntyifq.eyjzdwiioijhmvpdmevvnuuilcjhdwqioijndxj1z3vydsisimnvdw50cnkioijkucisimnyzwf0zwqioje3mtk4otu0mzisimlzcyi6imcxmjmtyxv0acisimn1cnjlbmn5ijoislbziiwizxhwijoxnzixmjy5nzuylcjyzwdpb24ioijkucisimxhbmcioijqysisimlhdci6mtcymta5njk1miwianrpijoicgnfnelbovpovel1cfrhsllncemyce9lwij9.wefd0fvomovr_gjrcquzatrsmstgrvzqew7uhuyiibajhas7m_hyceqkigikwyybvlsqxhdqrwywsrxqthmjeq&lang=jp&platform=jorp1&mode=0",
      "function": "t",
      "context_line": '<!DOCTYPE HTML><html><head><meta charset="utf-8"><title></title><meta name="viewport" content="width=device-width,initial-scale=1,minimum-sc {snip}'
    },
    # and about 50 more frames just like this
]
```

This PR therefore adds querystring stripping for JavaScript events to `normalize_stacktraces_for_grouping`, along with a metric tracking how often we do it.

It's technically possible that this could end up occasionally biting us - if the querystring is both meaningful and enough to change grouping, and now we're ditching it - but given that most often querystrings show up in the names of HTML files, which tend to contain ungroupable garbage in any case, the risk seems low. If we discover it's causing problems, we can tighten the criteria for filename stripping beyond just "be from a JS event" and "have a querystring."