### PR TITLE
ref(seer grouping): Consider half-snipped lines snipped for stacktrace string

### DIFF
--- a/src/sentry/seer/similarity/utils.py
+++ b/src/sentry/seer/similarity/utils.py
@@ -183,4 +183,4 @@ def _is_snipped_context_line(context_line: str) -> bool:
     # This check is implicitly restricted to JS (and friends) events by the fact that the `{snip]`
     # is only added in the JS processor. See
     # https://github.com/getsentry/sentry/blob/d077a5bb7e13a5927794b35d9ae667a4f181feb7/src/sentry/lang/javascript/utils.py#L72-L77.
-    return context_line.startswith("{snip}") and context_line.endswith("{snip}")
+    return context_line.startswith("{snip}") or context_line.endswith("{snip}")

--- a/tests/sentry/seer/similarity/test_utils.py
+++ b/tests/sentry/seer/similarity/test_utils.py
@@ -6,6 +6,7 @@ from uuid import uuid1
 from sentry.eventstore.models import Event
 from sentry.seer.similarity.utils import (
     SEER_ELIGIBLE_PLATFORMS,
+    _is_snipped_context_line,
     event_content_is_seer_eligible,
     filter_null_from_event_title,
     get_stacktrace_string,
@@ -711,6 +712,12 @@ class GetStacktraceStringTest(TestCase):
         data_no_exception["app"]["component"]["values"][0]["id"] = "not-exception"
         stacktrace_str = get_stacktrace_string(data_no_exception)
         assert stacktrace_str == ""
+
+    def test_recognizes_snip_at_start_or_end(self):
+        assert _is_snipped_context_line("{snip} dogs are great") is True
+        assert _is_snipped_context_line("dogs are great {snip}") is True
+        assert _is_snipped_context_line("{snip} dogs are great {snip}") is True
+        assert _is_snipped_context_line("dogs are great") is False
 
 
 class EventContentIsSeerEligibleTest(TestCase):


### PR DESCRIPTION
This relaxes our criterion for considering a context line minified for purposes of creating a stacktrace string to send to Seer. Until now, the line had to both start _and_ end with `{snip}`, but we're now allowing it to either start _or_ end with `{snip}`. 

This may occasionally yield false positives (non-minified lines being considered minified), but since the stacktrace string is only truncated if _all_ frames are minified, it would only make a difference in the highly unlikely scenario where we get a false positive for every frame in the entire stacktrace, a risk with which we're willing to live.