### PR TITLE
fix(getting-started): Add missing Node SDK import to verification snippet

### DIFF
--- a/static/app/gettingStartedDocs/node/node.tsx
+++ b/static/app/gettingStartedDocs/node/node.tsx
@@ -103,6 +103,8 @@ const onboarding: OnboardingConfig = {
           language: 'javascript',
           code: isPerformanceSelected
             ? `
+const Sentry = require("@sentry/node");
+
 Sentry.startSpan({
   op: "test",
   name: "My First Test Span",
@@ -114,13 +116,13 @@ Sentry.startSpan({
   }
 });`
             : `
-setTimeout(() => {
-  try {
-    foo();
-  } catch (e) {
-    Sentry.captureException(e);
-  }
-}, 99);`,
+const Sentry = require("@sentry/node");
+
+try {
+  foo();
+} catch (e) {
+  Sentry.captureException(e);
+}`,
         },
       ],
     },


### PR DESCRIPTION
This PR just adds a missing `require` call to the verification snippet
in the Node onboarding. Came up in internal feedback.

Also, I shortened the errors-only verification snippet. I don't think we
need the `setTimeout` call in there.
