### PR TITLE
feat(profiling): remove profile id from transaction id endpoint

### DIFF
--- a/src/sentry/api/endpoints/project_profiling_profile.py
+++ b/src/sentry/api/endpoints/project_profiling_profile.py
@@ -42,18 +42,6 @@ class ProjectProfilingBaseEndpoint(ProjectEndpoint):
 
 
 @region_silo_endpoint
-class ProjectProfilingTransactionIDProfileIDEndpoint(ProjectProfilingBaseEndpoint):
-    def get(self, request: Request, project: Project, transaction_id: str) -> HttpResponse:
-        if not features.has("organizations:profiling", project.organization, actor=request.user):
-            return Response(status=404)
-        kwargs: dict[str, Any] = {
-            "method": "GET",
-            "path": f"/organizations/{project.organization_id}/projects/{project.id}/transactions/{transaction_id}",
-        }
-        return proxy_profiling_service(**kwargs)
-
-
-@region_silo_endpoint
 class ProjectProfilingProfileEndpoint(ProjectProfilingBaseEndpoint):
     def get(self, request: Request, project: Project, profile_id: str) -> HttpResponse:
         if not features.has("organizations:profiling", project.organization, actor=request.user):

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -552,7 +552,6 @@ from .endpoints.project_profiling_profile import (
     ProjectProfilingEventEndpoint,
     ProjectProfilingProfileEndpoint,
     ProjectProfilingRawProfileEndpoint,
-    ProjectProfilingTransactionIDProfileIDEndpoint,
 )
 from .endpoints.project_release_commits import ProjectReleaseCommitsEndpoint
 from .endpoints.project_release_details import ProjectReleaseDetailsEndpoint
@@ -2731,11 +2730,6 @@ PROJECT_URLS: list[URLPattern | URLResolver] = [
         r"^(?P<organization_id_or_slug>[^\/]+)/(?P<project_id_or_slug>[^\/]+)/profiling/raw_profiles/(?P<profile_id>(?:\d+|[A-Fa-f0-9-]{32,36}))/$",
         ProjectProfilingRawProfileEndpoint.as_view(),
         name="sentry-api-0-project-profiling-raw-profile",
-    ),
-    re_path(
-        r"^(?P<organization_id_or_slug>[^\/]+)/(?P<project_id_or_slug>[^\/]+)/profiling/transactions/(?P<transaction_id>(?:\d+|[A-Fa-f0-9-]{32,36}))/$",
-        ProjectProfilingTransactionIDProfileIDEndpoint.as_view(),
-        name="sentry-api-0-project-profiling-transactions",
     ),
     re_path(
         r"^(?P<organization_id_or_slug>[^\/]+)/(?P<project_id_or_slug>[^\/]+)/statistical-detector/$",


### PR DESCRIPTION
related to https://github.com/getsentry/vroom/pull/491

@JonasBa @Zylphrex , please could you confirm if this is still used anywhere in the front-end?

If not I can simply merge this and remove it altogether, otherwise I'll refactor this to read directly from Sentry and we can still proceed with removing the endpoint in `vroom` (see linked PR)