### PR TITLE
feat(security): allow custom `salt` value in `utils.signing`

### DIFF
--- a/src/sentry/utils/signing.py
+++ b/src/sentry/utils/signing.py
@@ -4,9 +4,10 @@ Generic way to sign and unsign data for use in urls.
 
 import base64
 
-from django.core.signing import TimestampSigner
+from django.core.signing import BadSignature, TimestampSigner
 from django.utils.encoding import force_bytes, force_str
 
+from sentry.utils import metrics
 from sentry.utils.json import dumps, loads
 
 SALT = "sentry-generic-signing"
@@ -17,20 +18,45 @@ def sign(**kwargs):
     Signs all passed kwargs and produces a base64 string which may be passed to
     unsign which will verify the string has not been tampered with.
     """
+    salt = SALT
+    if "salt" in kwargs:
+        salt = kwargs["salt"]
+        del kwargs["salt"]
+
     return force_str(
         base64.urlsafe_b64encode(
-            TimestampSigner(salt=SALT).sign(dumps(kwargs)).encode("utf-8")
+            TimestampSigner(salt=salt).sign(dumps(kwargs)).encode("utf-8")
         ).rstrip(b"=")
     )
 
 
-def unsign(data, max_age=60 * 60 * 24 * 2):
+def unsign(data, salt=SALT, max_age=60 * 60 * 24 * 2):
     """
     Unsign a signed base64 string. Accepts the base64 value as a string or bytes
     """
-    return loads(
-        TimestampSigner(salt=SALT).unsign(urlsafe_b64decode(data).decode("utf-8"), max_age=max_age)
-    )
+    if salt == SALT:
+        return loads(
+            TimestampSigner(salt=SALT).unsign(
+                urlsafe_b64decode(data).decode("utf-8"), max_age=max_age
+            )
+        )
+
+    result = None
+    try:
+        result = loads(
+            TimestampSigner(salt=salt).unsign(
+                urlsafe_b64decode(data).decode("utf-8"), max_age=max_age
+            )
+        )
+    except BadSignature:
+        result = loads(
+            TimestampSigner(salt=SALT).unsign(
+                urlsafe_b64decode(data).decode("utf-8"), max_age=max_age
+            )
+        )
+
+    metrics.incr("utils.signing.salt_compatibility_mode", tags={"salt": salt})
+    return result
 
 
 def urlsafe_b64decode(b64string):

--- a/tests/sentry/utils/test_signing.py
+++ b/tests/sentry/utils/test_signing.py
@@ -1,0 +1,28 @@
+import pytest
+from django.core.signing import BadSignature
+
+from sentry.testutils.cases import TestCase
+from sentry.utils.signing import sign, unsign
+
+
+class SigningTestCase(TestCase):
+    def test_sign(self):
+        with self.settings(SECRET_KEY="a"):
+            # standard case
+            assert unsign(sign(foo="bar")) == {"foo": "bar"}
+
+            # sign with aaa, unsign with aaa
+            assert unsign(sign(foo="bar", salt="aaa"), salt="aaa") == {"foo": "bar"}
+
+            # sign with aaa, unsign with bbb
+            with pytest.raises(BadSignature):
+                unsign(sign(foo="bar", salt="aaa"), salt="bbb")
+
+    def test_backward_compatible_sign(self):
+        with self.settings(SECRET_KEY="a"):
+            # sign with old salt, unsign with new (transitional period)
+            assert unsign(sign(foo="bar"), salt="new") == {"foo": "bar"}
+
+            # sign with new salt, unsign with old
+            with pytest.raises(BadSignature):
+                unsign(sign(foo="bar", salt="new"))


### PR DESCRIPTION
This will allow to use a custom `salt` value for sign/unsign operations, while maintaining backward compatibility during a transitional period (default max_age is 2 days).