### PR TITLE
chore: separate salt for slack integration signatures, step 1

### DIFF
--- a/src/sentry/integrations/slack/views/__init__.py
+++ b/src/sentry/integrations/slack/views/__init__.py
@@ -10,6 +10,8 @@ from sentry.utils.signing import sign
 from sentry.web.decorators import EndpointFunc
 from sentry.web.helpers import render_to_response
 
+SALT = "sentry-slack-integration"
+
 
 def never_cache(view_func: EndpointFunc) -> EndpointFunc:
     """TODO(mgaeta): Remove cast once Django has a typed version."""
@@ -19,7 +21,7 @@ def never_cache(view_func: EndpointFunc) -> EndpointFunc:
 
 def build_linking_url(endpoint: str, **kwargs: Any) -> str:
     """TODO(mgaeta): Remove cast once sentry/utils/http.py is typed."""
-    url: str = absolute_uri(reverse(endpoint, kwargs={"signed_params": sign(**kwargs)}))
+    url: str = absolute_uri(reverse(endpoint, kwargs={"signed_params": sign(salt=SALT, **kwargs)}))
     return url
 
 

--- a/src/sentry/integrations/slack/views/__init__.py
+++ b/src/sentry/integrations/slack/views/__init__.py
@@ -21,7 +21,7 @@ def never_cache(view_func: EndpointFunc) -> EndpointFunc:
 
 def build_linking_url(endpoint: str, **kwargs: Any) -> str:
     """TODO(mgaeta): Remove cast once sentry/utils/http.py is typed."""
-    url: str = absolute_uri(reverse(endpoint, kwargs={"signed_params": sign(salt=SALT, **kwargs)}))
+    url: str = absolute_uri(reverse(endpoint, kwargs={"signed_params": sign(**kwargs)}))
     return url
 
 

--- a/src/sentry/integrations/slack/views/link_identity.py
+++ b/src/sentry/integrations/slack/views/link_identity.py
@@ -25,6 +25,7 @@ from sentry.utils.signing import unsign
 from sentry.web.frontend.base import BaseView, control_silo_view
 from sentry.web.helpers import render_to_response
 
+from . import SALT
 from . import build_linking_url as base_build_linking_url
 from . import never_cache
 
@@ -59,7 +60,7 @@ class SlackLinkIdentityView(BaseView):
     @method_decorator(never_cache)
     def dispatch(self, request: HttpRequest, signed_params: str) -> HttpResponseBase:
         try:
-            params = unsign(signed_params)
+            params = unsign(signed_params, salt=SALT)
         except (SignatureExpired, BadSignature) as e:
             _logger.warning("dispatch.signature_error", exc_info=e)
             metrics.incr(self._METRICS_FAILURE_KEY, tags={"error": str(e)}, sample_rate=1.0)

--- a/src/sentry/integrations/slack/views/link_team.py
+++ b/src/sentry/integrations/slack/views/link_team.py
@@ -36,6 +36,7 @@ from sentry.web.frontend.base import BaseView, region_silo_view
 from sentry.web.helpers import render_to_response
 
 from ..utils import is_valid_role
+from . import SALT
 from . import build_linking_url as base_build_linking_url
 from . import never_cache, render_error_page
 
@@ -91,7 +92,7 @@ class SlackLinkTeamView(BaseView):
             return render_error_page(request, status=405, body_text="HTTP 405: Method not allowed")
 
         try:
-            converted = unsign(signed_params)
+            converted = unsign(signed_params, salt=SALT)
             link_team_request = TeamLinkRequest(**converted)
         except (SignatureExpired, BadSignature) as e:
             _logger.warning("handle.signature_error", exc_info=e)

--- a/src/sentry/integrations/slack/views/unlink_identity.py
+++ b/src/sentry/integrations/slack/views/unlink_identity.py
@@ -23,6 +23,8 @@ from sentry.utils.signing import unsign
 from sentry.web.frontend.base import BaseView, control_silo_view
 from sentry.web.helpers import render_to_response
 
+from . import SALT
+
 SUCCESS_UNLINKED_MESSAGE = "Your Slack identity has been unlinked from your Sentry account."
 
 _logger = logging.getLogger(__name__)
@@ -52,7 +54,7 @@ class SlackUnlinkIdentityView(BaseView):
     @method_decorator(never_cache)
     def dispatch(self, request: HttpRequest, signed_params: str) -> HttpResponseBase:
         try:
-            params = unsign(signed_params)
+            params = unsign(signed_params, salt=SALT)
         except (SignatureExpired, BadSignature) as e:
             _logger.warning("dispatch.signature_error", exc_info=e)
             metrics.incr(self._METRICS_FAILURE_KEY, tags={"error": str(e)}, sample_rate=1.0)

--- a/src/sentry/integrations/slack/views/unlink_team.py
+++ b/src/sentry/integrations/slack/views/unlink_team.py
@@ -24,6 +24,7 @@ from sentry.web.frontend.base import BaseView, region_silo_view
 from sentry.web.helpers import render_to_response
 
 from ..utils import is_valid_role
+from . import SALT
 from . import build_linking_url as base_build_linking_url
 from . import never_cache, render_error_page
 
@@ -70,7 +71,7 @@ class SlackUnlinkTeamView(BaseView):
             return HttpResponse(status=405)
 
         try:
-            converted = unsign(signed_params)
+            converted = unsign(signed_params, salt=SALT)
             unlink_team_request = TeamUnlinkRequest(**converted)
         except (SignatureExpired, BadSignature) as e:
             _logger.warning("dispatch.signature_error", exc_info=e)

--- a/src/sentry/middleware/integrations/parsers/slack.py
+++ b/src/sentry/middleware/integrations/parsers/slack.py
@@ -15,6 +15,7 @@ from sentry.integrations.middleware.hybrid_cloud.parser import (
 )
 from sentry.integrations.slack.requests.base import SlackRequestError
 from sentry.integrations.slack.requests.event import is_event_challenge
+from sentry.integrations.slack.views import SALT
 from sentry.integrations.slack.views.link_identity import SlackLinkIdentityView
 from sentry.integrations.slack.views.link_team import SlackLinkTeamView
 from sentry.integrations.slack.views.unlink_identity import SlackUnlinkIdentityView
@@ -114,7 +115,7 @@ class SlackRequestParser(BaseRequestParser):
 
         elif self.view_class in self.django_views:
             # Parse the signed params to identify the associated integration
-            params = unsign(self.match.kwargs.get("signed_params"))
+            params = unsign(self.match.kwargs.get("signed_params"), salt=SALT)
             return Integration.objects.filter(id=params.get("integration_id")).first()
 
         return None


### PR DESCRIPTION
Slack integration features will use a separate salt value for signing payloads.
Uses https://github.com/getsentry/sentry/pull/74839.