### PR TITLE
fix(discover): Handle project.name alias

### DIFF
--- a/src/sentry/search/events/builder/discover.py
+++ b/src/sentry/search/events/builder/discover.py
@@ -335,7 +335,7 @@ class TopEventsQueryBuilder(TimeseriesQueryBuilder):
         conditions = []
         for field in self.fields:
             # If we have a project field, we need to limit results by project so we don't hit the result limit
-            if field in ["project", "project.id"] and top_events:
+            if field in ["project", "project.id", "project.name"] and top_events:
                 # Iterate through the existing conditions to find the project one
                 # the project condition is a requirement of queries so there should always be one
                 project_condition = [
@@ -345,9 +345,9 @@ class TopEventsQueryBuilder(TimeseriesQueryBuilder):
                     and condition.lhs == self.column("project_id")
                 ][0]
                 self.where.remove(project_condition)
-                if field == "project":
+                if field in ["project", "project.name"]:
                     projects = list(
-                        {self.params.project_slug_map[event["project"]] for event in top_events}
+                        {self.params.project_slug_map[event[field]] for event in top_events}
                     )
                 else:
                     projects = list({event["project.id"] for event in top_events})


### PR DESCRIPTION
- The special project handling for top events didn't include the project.name alias
- This fixes SENTRY-3CB0