### PR TITLE
feat(discover): Set query source as user if flag is enabled

### DIFF
--- a/src/sentry/discover/endpoints/discover_homepage_query.py
+++ b/src/sentry/discover/endpoints/discover_homepage_query.py
@@ -13,7 +13,7 @@ from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.api.serializers import serialize
 from sentry.discover.endpoints.bases import DiscoverSavedQueryPermission
 from sentry.discover.endpoints.serializers import DiscoverSavedQuerySerializer
-from sentry.discover.models import DatasetSourcesTypes, DiscoverSavedQuery
+from sentry.discover.models import DatasetSourcesTypes, DiscoverSavedQuery, DiscoverSavedQueryTypes
 
 
 def get_homepage_query(organization, user):
@@ -77,6 +77,14 @@ class DiscoverHomepageQueryEndpoint(OrganizationEndpoint):
             raise ParseError(serializer.errors)
 
         data = serializer.validated_data
+        user_selected_dataset = (
+            features.has(
+                "organizations:performance-discover-dataset-selector",
+                organization,
+                actor=request.user,
+            )
+            and data["query_dataset"] != DiscoverSavedQueryTypes.DISCOVER
+        )
         if previous_homepage:
             previous_homepage.update(
                 organization=organization,
@@ -84,7 +92,11 @@ class DiscoverHomepageQueryEndpoint(OrganizationEndpoint):
                 query=data["query"],
                 version=data["version"],
                 dataset=data["query_dataset"],
-                dataset_source=DatasetSourcesTypes.UNKNOWN.value,
+                dataset_source=(
+                    DatasetSourcesTypes.USER.value
+                    if user_selected_dataset
+                    else DatasetSourcesTypes.UNKNOWN.value
+                ),
             )
             previous_homepage.set_projects(data["project_ids"])
             return Response(serialize(previous_homepage), status=status.HTTP_200_OK)
@@ -95,7 +107,11 @@ class DiscoverHomepageQueryEndpoint(OrganizationEndpoint):
             query=data["query"],
             version=data["version"],
             dataset=data["query_dataset"],
-            dataset_source=DatasetSourcesTypes.UNKNOWN.value,
+            dataset_source=(
+                DatasetSourcesTypes.USER.value
+                if user_selected_dataset
+                else DatasetSourcesTypes.UNKNOWN.value
+            ),
             created_by_id=request.user.id,
             is_homepage=True,
         )

--- a/src/sentry/discover/endpoints/discover_saved_queries.py
+++ b/src/sentry/discover/endpoints/discover_saved_queries.py
@@ -14,7 +14,7 @@ from sentry.api.paginator import GenericOffsetPaginator
 from sentry.api.serializers import serialize
 from sentry.discover.endpoints.bases import DiscoverSavedQueryPermission
 from sentry.discover.endpoints.serializers import DiscoverSavedQuerySerializer
-from sentry.discover.models import DatasetSourcesTypes, DiscoverSavedQuery
+from sentry.discover.models import DatasetSourcesTypes, DiscoverSavedQuery, DiscoverSavedQueryTypes
 from sentry.search.utils import tokenize_query
 
 
@@ -135,6 +135,14 @@ class DiscoverSavedQueriesEndpoint(OrganizationEndpoint):
             return Response(serializer.errors, status=400)
 
         data = serializer.validated_data
+        user_selected_dataset = (
+            features.has(
+                "organizations:performance-discover-dataset-selector",
+                organization,
+                actor=request.user,
+            )
+            and data["query_dataset"] != DiscoverSavedQueryTypes.DISCOVER
+        )
 
         model = DiscoverSavedQuery.objects.create(
             organization=organization,
@@ -142,7 +150,11 @@ class DiscoverSavedQueriesEndpoint(OrganizationEndpoint):
             query=data["query"],
             version=data["version"],
             dataset=data["query_dataset"],
-            dataset_source=DatasetSourcesTypes.UNKNOWN.value,
+            dataset_source=(
+                DatasetSourcesTypes.USER.value
+                if user_selected_dataset
+                else DatasetSourcesTypes.UNKNOWN.value
+            ),
             created_by_id=request.user.id if request.user.is_authenticated else None,
         )
 

--- a/src/sentry/discover/endpoints/discover_saved_query_detail.py
+++ b/src/sentry/discover/endpoints/discover_saved_query_detail.py
@@ -13,7 +13,7 @@ from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.api.serializers import serialize
 from sentry.discover.endpoints.bases import DiscoverSavedQueryPermission
 from sentry.discover.endpoints.serializers import DiscoverSavedQuerySerializer
-from sentry.discover.models import DatasetSourcesTypes, DiscoverSavedQuery
+from sentry.discover.models import DatasetSourcesTypes, DiscoverSavedQuery, DiscoverSavedQueryTypes
 
 
 class DiscoverSavedQueryBase(OrganizationEndpoint):
@@ -83,13 +83,26 @@ class DiscoverSavedQueryDetailEndpoint(DiscoverSavedQueryBase):
             return Response(serializer.errors, status=400)
 
         data = serializer.validated_data
+        user_selected_dataset = (
+            features.has(
+                "organizations:performance-discover-dataset-selector",
+                organization,
+                actor=request.user,
+            )
+            and data["query_dataset"] != DiscoverSavedQueryTypes.DISCOVER
+        )
+
         query.update(
             organization=organization,
             name=data["name"],
             query=data["query"],
             version=data["version"],
             dataset=data["query_dataset"],
-            dataset_source=DatasetSourcesTypes.UNKNOWN.value,
+            dataset_source=(
+                DatasetSourcesTypes.USER.value
+                if user_selected_dataset
+                else DatasetSourcesTypes.UNKNOWN.value
+            ),
         )
 
         query.set_projects(data["project_ids"])


### PR DESCRIPTION
Once the flag is enabled and queries are created/updated through the API
with anything other than Discover dataset, set as user created.