### PR TITLE
feat(discover): Show the banner if forced split decision

### DIFF
--- a/static/app/types/organization.tsx
+++ b/static/app/types/organization.tsx
@@ -1,6 +1,10 @@
 import type {Project} from 'sentry/types/project';
 import type {AggregationOutputType} from 'sentry/utils/discover/fields';
-import type {DiscoverDatasets, SavedQueryDatasets} from 'sentry/utils/discover/types';
+import type {
+  DatasetSource,
+  DiscoverDatasets,
+  SavedQueryDatasets,
+} from 'sentry/utils/discover/types';
 
 import type {Actor, Avatar, ObjectStatus, Scope} from './core';
 import type {OrgExperiments} from './experiments';
@@ -243,6 +247,7 @@ export interface NewQuery {
   version: SavedQueryVersions;
   createdBy?: User;
   dataset?: DiscoverDatasets;
+  datasetSource?: DatasetSource;
   display?: string;
   end?: string | Date;
   environment?: Readonly<string[]>;

--- a/static/app/utils/discover/types.tsx
+++ b/static/app/utils/discover/types.tsx
@@ -29,6 +29,13 @@ export enum SavedQueryDatasets {
   TRANSACTIONS = 'transaction-like',
 }
 
+export enum DatasetSource {
+  USER = 'user',
+  UNKNOWN = 'unknown',
+  INFERRED = 'inferred',
+  FORCED = 'forced',
+}
+
 export const TOP_EVENT_MODES: string[] = [DisplayModes.TOP5, DisplayModes.DAILYTOP5];
 
 // The modes that support the interval selector


### PR DESCRIPTION
In a follow up, I'd like to set dataset source to USER if the user
dismisses the alert so it doesn't keep popping up.