### PR TITLE
analytics(replay): track render of missing replay alert

### DIFF
--- a/static/app/components/events/eventReplay/replayClipPreviewPlayer.tsx
+++ b/static/app/components/events/eventReplay/replayClipPreviewPlayer.tsx
@@ -94,7 +94,7 @@ function ReplayClipPreviewPlayer({
   if (fetchError) {
     trackAnalytics('replay.render-missing-replay-alert', {
       organization,
-      location: 'issue details - clip preview',
+      surface: 'issue details - clip preview',
     });
     return <MissingReplayAlert orgSlug={orgSlug} />;
   }

--- a/static/app/components/events/eventReplay/replayClipPreviewPlayer.tsx
+++ b/static/app/components/events/eventReplay/replayClipPreviewPlayer.tsx
@@ -17,10 +17,12 @@ import ReplayProcessingError from 'sentry/components/replays/replayProcessingErr
 import {IconDelete} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
+import {trackAnalytics} from 'sentry/utils/analytics';
 import type {TabKey} from 'sentry/utils/replays/hooks/useActiveReplayTab';
 import type useReplayReader from 'sentry/utils/replays/hooks/useReplayReader';
 import type RequestError from 'sentry/utils/requestError/requestError';
 import useRouteAnalyticsParams from 'sentry/utils/routeAnalytics/useRouteAnalyticsParams';
+import useOrganization from 'sentry/utils/useOrganization';
 import FluidHeight from 'sentry/views/replays/detail/layout/fluidHeight';
 import type {ReplayRecord} from 'sentry/views/replays/types';
 
@@ -76,6 +78,7 @@ function ReplayClipPreviewPlayer({
   useRouteAnalyticsParams({
     event_replay_status: getReplayAnalyticsStatus({fetchError, replayRecord}),
   });
+  const organization = useOrganization();
 
   if (replayRecord?.is_archived) {
     return (
@@ -89,6 +92,10 @@ function ReplayClipPreviewPlayer({
   }
 
   if (fetchError) {
+    trackAnalytics('replay.render-missing-replay-alert', {
+      organization,
+      location: 'issue details - clip preview',
+    });
     return <MissingReplayAlert orgSlug={orgSlug} />;
   }
 

--- a/static/app/components/events/eventReplay/replayPreview.tsx
+++ b/static/app/components/events/eventReplay/replayPreview.tsx
@@ -13,10 +13,12 @@ import MissingReplayAlert from 'sentry/components/replays/alerts/missingReplayAl
 import {IconDelete} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
+import {trackAnalytics} from 'sentry/utils/analytics';
 import type {TabKey} from 'sentry/utils/replays/hooks/useActiveReplayTab';
 import useReplayReader from 'sentry/utils/replays/hooks/useReplayReader';
 import type RequestError from 'sentry/utils/requestError/requestError';
 import useRouteAnalyticsParams from 'sentry/utils/routeAnalytics/useRouteAnalyticsParams';
+import useOrganization from 'sentry/utils/useOrganization';
 import type {ReplayRecord} from 'sentry/views/replays/types';
 
 type Props = {
@@ -62,6 +64,7 @@ function ReplayPreview({
     orgSlug,
     replaySlug,
   });
+  const organization = useOrganization();
 
   const startTimestampMs = replayRecord?.started_at?.getTime() ?? 0;
   const initialTimeOffsetMs = useMemo(() => {
@@ -88,6 +91,10 @@ function ReplayPreview({
   }
 
   if (fetchError) {
+    trackAnalytics('replay.render-missing-replay-alert', {
+      organization,
+      location: 'issue details - old preview',
+    });
     return <MissingReplayAlert orgSlug={orgSlug} />;
   }
 

--- a/static/app/components/events/eventReplay/replayPreview.tsx
+++ b/static/app/components/events/eventReplay/replayPreview.tsx
@@ -93,7 +93,7 @@ function ReplayPreview({
   if (fetchError) {
     trackAnalytics('replay.render-missing-replay-alert', {
       organization,
-      location: 'issue details - old preview',
+      surface: 'issue details - old preview',
     });
     return <MissingReplayAlert orgSlug={orgSlug} />;
   }

--- a/static/app/utils/analytics/replayAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/replayAnalyticsEvents.tsx
@@ -92,6 +92,9 @@ export type ReplayEventParameters = {
     platform: string | undefined;
     project_id: string | undefined;
   };
+  'replay.render-missing-replay-alert': {
+    location: string;
+  };
   'replay.render-player': {
     aspect_ratio: 'portrait' | 'landscape';
     context: string;
@@ -136,6 +139,7 @@ export const replayEventMap: Record<ReplayEventKey, string | null> = {
   'replay.rage-click-sdk-banner.dismissed': 'Replay Rage Click SDK Banner Dismissed',
   'replay.rage-click-sdk-banner.rendered': 'Replay Rage Click SDK Banner Rendered',
   'replay.render-issues-group-list': 'Render Issues Detail Replay List',
+  'replay.render-missing-replay-alert': 'Render Missing Replay Alert',
   'replay.render-player': 'Rendered ReplayPlayer',
   'replay.search': 'Searched Replay',
   'replay.toggle-fullscreen': 'Toggled Replay Fullscreen',

--- a/static/app/utils/analytics/replayAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/replayAnalyticsEvents.tsx
@@ -93,7 +93,7 @@ export type ReplayEventParameters = {
     project_id: string | undefined;
   };
   'replay.render-missing-replay-alert': {
-    location: string;
+    surface: string;
   };
   'replay.render-player': {
     aspect_ratio: 'portrait' | 'landscape';


### PR DESCRIPTION
track render of alert banner, which we currently only show on issue details. 

context: 
> I’m concerned this can happen more often than customers are comfortable with and we might need to dig into reasons and improve things somehow