### PR TITLE
feat(tabs): Add new tab variant for draggable tabs

### DIFF
--- a/static/app/components/interactionStateLayer.tsx
+++ b/static/app/components/interactionStateLayer.tsx
@@ -7,6 +7,10 @@ import {defined} from 'sentry/utils';
 interface StateLayerProps extends React.HTMLAttributes<HTMLSpanElement> {
   as?: React.ElementType;
   color?: string;
+  /**
+   * Controls if the opacity is increased when the element is in a
+   * selected or expanded state (aria-selected='true' or aria-expanded='true')
+   */
   hasSelectedBackground?: boolean;
   higherOpacity?: boolean;
   isHovered?: boolean;

--- a/static/app/components/interactionStateLayer.tsx
+++ b/static/app/components/interactionStateLayer.tsx
@@ -7,6 +7,7 @@ import {defined} from 'sentry/utils';
 interface StateLayerProps extends React.HTMLAttributes<HTMLSpanElement> {
   as?: React.ElementType;
   color?: string;
+  hasSelectedBackground?: boolean;
   higherOpacity?: boolean;
   isHovered?: boolean;
   isPressed?: boolean;
@@ -65,11 +66,16 @@ const InteractionStateLayer = styled(
         `
       : // If isPressed is undefined, then fallback to default press selectors
         css`
-          *:active > &&,
-          *[aria-expanded='true'] > &&,
-          *[aria-selected='true'] > && {
+          *:active > && {
             opacity: ${p.higherOpacity ? 0.12 : 0.09};
           }
+          ${p.hasSelectedBackground &&
+          css`
+            *[aria-expanded='true'] > &&,
+            *[aria-selected='true'] > && {
+              opacity: ${p.higherOpacity ? 0.12 : 0.09};
+            }
+          `}
         `}
 
 
@@ -78,5 +84,9 @@ const InteractionStateLayer = styled(
     opacity: 0;
   }
 `;
+
+InteractionStateLayer.defaultProps = {
+  hasSelectedBackground: true,
+};
 
 export default InteractionStateLayer;

--- a/static/app/components/tabs/index.stories.tsx
+++ b/static/app/components/tabs/index.stories.tsx
@@ -192,7 +192,8 @@ export default storyBook(Tabs, story => {
     <div>
       <p>
         Use the variant prop to control which tab design to use. The default, "flat", is
-        used in the above examples, but you can also use "filled" variant, as shown here:
+        used in the above examples, but you can also use "filled" variant, as shown below.
+        Note that the "filled" variant does not work when the oritentation is vertical
       </p>
       <SizingWindow>
         <Tabs>

--- a/static/app/components/tabs/index.stories.tsx
+++ b/static/app/components/tabs/index.stories.tsx
@@ -120,29 +120,6 @@ export default storyBook(Tabs, story => {
     );
   });
 
-  story('Variants', () => (
-    <div>
-      <p>
-        Use the variant prop to control which tab design to use. The default, "flat", is
-        used in the above examples, but you can also use "filled" variant, as shown here:
-      </p>
-      <SizingWindow>
-        <Tabs>
-          <TabList variant={'filled'}>
-            {TABS.map(tab => (
-              <TabList.Item key={tab.key}>{tab.label}</TabList.Item>
-            ))}
-          </TabList>
-          <TabPanels>
-            {TABS.map(tab => (
-              <TabPanels.Item key={tab.key}>{tab.content}</TabPanels.Item>
-            ))}
-          </TabPanels>
-        </Tabs>
-      </SizingWindow>
-    </div>
-  ));
-
   story('Rendering', () => (
     <Matrix<TabsProps<string> & TabListProps>
       render={props => (
@@ -209,5 +186,28 @@ export default storyBook(Tabs, story => {
         </SizingWindow>
       </div>
     </SideBySide>
+  ));
+
+  story('Variants', () => (
+    <div>
+      <p>
+        Use the variant prop to control which tab design to use. The default, "flat", is
+        used in the above examples, but you can also use "filled" variant, as shown here:
+      </p>
+      <SizingWindow>
+        <Tabs>
+          <TabList variant={'filled'}>
+            {TABS.map(tab => (
+              <TabList.Item key={tab.key}>{tab.label}</TabList.Item>
+            ))}
+          </TabList>
+          <TabPanels>
+            {TABS.map(tab => (
+              <TabPanels.Item key={tab.key}>{tab.content}</TabPanels.Item>
+            ))}
+          </TabPanels>
+        </Tabs>
+      </SizingWindow>
+    </div>
   ));
 });

--- a/static/app/components/tabs/index.stories.tsx
+++ b/static/app/components/tabs/index.stories.tsx
@@ -187,4 +187,28 @@ export default storyBook(Tabs, story => {
       </div>
     </SideBySide>
   ));
+
+  story('Variants', () => (
+    <div>
+      <p>
+        Use the variant prop to control which tab design to use. The default, "vanilla",
+        is used in the above examples, but you can also use "draggable" variant, as shown
+        here:
+      </p>
+      <SizingWindow>
+        <Tabs>
+          <TabList variant={'draggable'}>
+            {TABS.map(tab => (
+              <TabList.Item key={tab.key}>{tab.label}</TabList.Item>
+            ))}
+          </TabList>
+          <TabPanels>
+            {TABS.map(tab => (
+              <TabPanels.Item key={tab.key}>{tab.content}</TabPanels.Item>
+            ))}
+          </TabPanels>
+        </Tabs>
+      </SizingWindow>
+    </div>
+  ));
 });

--- a/static/app/components/tabs/index.stories.tsx
+++ b/static/app/components/tabs/index.stories.tsx
@@ -120,6 +120,29 @@ export default storyBook(Tabs, story => {
     );
   });
 
+  story('Variants', () => (
+    <div>
+      <p>
+        Use the variant prop to control which tab design to use. The default, "flat", is
+        used in the above examples, but you can also use "filled" variant, as shown here:
+      </p>
+      <SizingWindow>
+        <Tabs>
+          <TabList variant={'filled'}>
+            {TABS.map(tab => (
+              <TabList.Item key={tab.key}>{tab.label}</TabList.Item>
+            ))}
+          </TabList>
+          <TabPanels>
+            {TABS.map(tab => (
+              <TabPanels.Item key={tab.key}>{tab.content}</TabPanels.Item>
+            ))}
+          </TabPanels>
+        </Tabs>
+      </SizingWindow>
+    </div>
+  ));
+
   story('Rendering', () => (
     <Matrix<TabsProps<string> & TabListProps>
       render={props => (
@@ -186,28 +209,5 @@ export default storyBook(Tabs, story => {
         </SizingWindow>
       </div>
     </SideBySide>
-  ));
-
-  story('Variants', () => (
-    <div>
-      <p>
-        Use the variant prop to control which tab design to use. The default, "flat", is
-        used in the above examples, but you can also use "filled" variant, as shown here:
-      </p>
-      <SizingWindow>
-        <Tabs>
-          <TabList variant={'filled'}>
-            {TABS.map(tab => (
-              <TabList.Item key={tab.key}>{tab.label}</TabList.Item>
-            ))}
-          </TabList>
-          <TabPanels>
-            {TABS.map(tab => (
-              <TabPanels.Item key={tab.key}>{tab.content}</TabPanels.Item>
-            ))}
-          </TabPanels>
-        </Tabs>
-      </SizingWindow>
-    </div>
   ));
 });

--- a/static/app/components/tabs/index.stories.tsx
+++ b/static/app/components/tabs/index.stories.tsx
@@ -191,13 +191,12 @@ export default storyBook(Tabs, story => {
   story('Variants', () => (
     <div>
       <p>
-        Use the variant prop to control which tab design to use. The default, "vanilla",
-        is used in the above examples, but you can also use "draggable" variant, as shown
-        here:
+        Use the variant prop to control which tab design to use. The default, "flat", is
+        used in the above examples, but you can also use "filled" variant, as shown here:
       </p>
       <SizingWindow>
         <Tabs>
-          <TabList variant={'draggable'}>
+          <TabList variant={'filled'}>
             {TABS.map(tab => (
               <TabList.Item key={tab.key}>{tab.label}</TabList.Item>
             ))}

--- a/static/app/components/tabs/tab.tsx
+++ b/static/app/components/tabs/tab.tsx
@@ -55,9 +55,13 @@ export interface BaseTabProps {
    * by <DraggableTab> to pass in props used for drag-and-drop functionality.
    */
   additionalProps?: React.HTMLAttributes<HTMLElement>;
+  /**
+   * This controls the border style of the tab. Only active when
+   * `variant=filled` since other variants do not have a border
+   */
   borderStyle?: 'solid' | 'dashed';
   to?: string;
-  variant?: 'vanilla' | 'draggable';
+  variant?: 'flat' | 'filled';
 }
 
 export const BaseTab = forwardRef(
@@ -70,7 +74,7 @@ export const BaseTab = forwardRef(
       hidden,
       isSelected,
       additionalProps,
-      variant = 'vanilla',
+      variant = 'flat',
       borderStyle = 'solid',
     } = props;
 
@@ -92,7 +96,7 @@ export const BaseTab = forwardRef(
         ),
       [to, orientation]
     );
-    if (variant === 'draggable') {
+    if (variant === 'filled') {
       return (
         <DraggableTabWrap
           {...mergeProps(tabProps, additionalProps)}

--- a/static/app/components/tabs/tab.tsx
+++ b/static/app/components/tabs/tab.tsx
@@ -28,6 +28,7 @@ interface TabProps extends AriaTabProps {
    */
   overflowing: boolean;
   state: TabListState<any>;
+  variant?: BaseTabProps['variant'];
 }
 
 /**
@@ -42,7 +43,7 @@ function handleLinkClick(e: React.PointerEvent<HTMLAnchorElement>) {
   }
 }
 
-interface BaseTabProps {
+export interface BaseTabProps {
   children: React.ReactNode;
   hidden: boolean;
   isSelected: boolean;
@@ -134,7 +135,7 @@ export const BaseTab = forwardRef(
  */
 export const Tab = forwardRef(
   (
-    {item, state, orientation, overflowing}: TabProps,
+    {item, state, orientation, overflowing, variant}: TabProps,
     forwardedRef: React.ForwardedRef<HTMLLIElement>
   ) => {
     const ref = useObjectRef(forwardedRef);
@@ -155,6 +156,7 @@ export const Tab = forwardRef(
         orientation={orientation}
         overflowing={overflowing}
         ref={ref}
+        variant={variant}
       >
         {rendered}
       </BaseTab>

--- a/static/app/components/tabs/tab.tsx
+++ b/static/app/components/tabs/tab.tsx
@@ -175,21 +175,23 @@ const DraggableTabWrap = styled('li', {shouldForwardProp: tabsShouldForwardProp}
   &[aria-selected='true'] {
     ${p =>
       `
-        border-radius: 6px 6px 1px 1px;
         border-top: 1px ${p.borderStyle} ${p.theme.border};
         border-left: 1px ${p.borderStyle} ${p.theme.border};
         border-right: 1px ${p.borderStyle} ${p.theme.border};
-        background-color: ${p.theme.white};
+        background-color: ${p.theme.background};
         font-weight: ${p.theme.fontWeightBold};
       `}
+    border-radius: 6px 6px 1px 1px;
+    padding: ${space(0.5)} ${space(1)};
   }
 
   &[aria-selected='false'] {
     border-top: 1px solid transparent;
+    padding-top: ${space(0.5)};
+    padding-bottom: ${space(0.5)};
   }
 
   transform: translateY(1px);
-  padding: 5px 10px;
 
   cursor: pointer;
 

--- a/static/app/components/tabs/tab.tsx
+++ b/static/app/components/tabs/tab.tsx
@@ -3,7 +3,7 @@ import type {Theme} from '@emotion/react';
 import styled from '@emotion/styled';
 import type {AriaTabProps} from '@react-aria/tabs';
 import {useTab} from '@react-aria/tabs';
-import {mergeProps, useObjectRef} from '@react-aria/utils';
+import {useObjectRef} from '@react-aria/utils';
 import type {TabListState} from '@react-stately/tabs';
 import type {
   DOMAttributes,
@@ -51,11 +51,6 @@ export interface BaseTabProps {
   overflowing: boolean;
   tabProps: DOMAttributes<FocusableElement>;
   /**
-   * Additional props to be merged with `tabProps`. This is used
-   * by <DraggableTab> to pass in props used for drag-and-drop functionality.
-   */
-  additionalProps?: React.HTMLAttributes<HTMLElement>;
-  /**
    * This controls the border style of the tab. Only active when
    * `variant=filled` since other variants do not have a border
    */
@@ -73,7 +68,6 @@ export const BaseTab = forwardRef(
       tabProps,
       hidden,
       isSelected,
-      additionalProps,
       variant = 'flat',
       borderStyle = 'solid',
     } = props;
@@ -99,7 +93,7 @@ export const BaseTab = forwardRef(
     if (variant === 'filled') {
       return (
         <FilledTabWrap
-          {...mergeProps(tabProps, additionalProps)}
+          {...tabProps}
           hidden={hidden}
           overflowing={overflowing}
           borderStyle={borderStyle}
@@ -114,7 +108,7 @@ export const BaseTab = forwardRef(
 
     return (
       <TabWrap
-        {...mergeProps(tabProps, additionalProps)}
+        {...tabProps}
         hidden={hidden}
         selected={isSelected}
         overflowing={overflowing}

--- a/static/app/components/tabs/tab.tsx
+++ b/static/app/components/tabs/tab.tsx
@@ -174,8 +174,7 @@ const DraggableTabWrap = styled('li', {shouldForwardProp: tabsShouldForwardProp}
         border-left: 1px ${p.borderStyle} ${p.theme.border};
         border-right: 1px ${p.borderStyle} ${p.theme.border};
         background-color: ${p.theme.white};
-        color: ${p.theme.fontWeightBold};
-        font-weight: 600;
+        font-weight: ${p.theme.fontWeightBold};
       `}
   }
 
@@ -185,8 +184,6 @@ const DraggableTabWrap = styled('li', {shouldForwardProp: tabsShouldForwardProp}
 
   transform: translateY(1px);
   padding: 5px 10px;
-
-  opacity: 0px;
 
   cursor: pointer;
 

--- a/static/app/components/tabs/tab.tsx
+++ b/static/app/components/tabs/tab.tsx
@@ -105,6 +105,8 @@ export const BaseTab = forwardRef(
           borderStyle={borderStyle}
           ref={ref}
         >
+          <FilledStyledInteractionStateLayer hasSelectedBackground={false} />
+          <FilledFocusLayer />
           {props.children}
         </FilledTabWrap>
       );
@@ -180,9 +182,10 @@ const FilledTabWrap = styled('li', {shouldForwardProp: tabsShouldForwardProp})<{
         border-right: 1px ${p.borderStyle} ${p.theme.border};
         background-color: ${p.theme.background};
         font-weight: ${p.theme.fontWeightBold};
-      `}
-    border-radius: 6px 6px 1px 1px;
+    `}
   }
+
+  border-radius: 6px 6px 1px 1px;
 
   &[aria-selected='false'] {
     border-top: 1px solid transparent;
@@ -292,12 +295,42 @@ const StyledInteractionStateLayer = styled(InteractionStateLayer)<{
   bottom: ${p => (p.orientation === 'horizontal' ? space(0.75) : 0)};
 `;
 
+const FilledStyledInteractionStateLayer = styled(InteractionStateLayer)`
+  position: absolute;
+  width: auto;
+  height: auto;
+  transform: none;
+  left: 0;
+  right: 0;
+  top: 0;
+  bottom: 0;
+`;
+
 const FocusLayer = styled('div')<{orientation: Orientation}>`
   position: absolute;
   left: 0;
   right: 0;
   top: 0;
   bottom: ${p => (p.orientation === 'horizontal' ? space(0.75) : 0)};
+
+  pointer-events: none;
+  border-radius: inherit;
+  z-index: 0;
+  transition: box-shadow 0.1s ease-out;
+
+  li:focus-visible & {
+    box-shadow:
+      ${p => p.theme.focusBorder} 0 0 0 1px,
+      inset ${p => p.theme.focusBorder} 0 0 0 1px;
+  }
+`;
+
+const FilledFocusLayer = styled('div')`
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: 0;
+  bottom: 0;
 
   pointer-events: none;
   border-radius: inherit;

--- a/static/app/components/tabs/tab.tsx
+++ b/static/app/components/tabs/tab.tsx
@@ -98,7 +98,7 @@ export const BaseTab = forwardRef(
     );
     if (variant === 'filled') {
       return (
-        <DraggableTabWrap
+        <FilledTabWrap
           {...mergeProps(tabProps, additionalProps)}
           hidden={hidden}
           overflowing={overflowing}
@@ -106,7 +106,7 @@ export const BaseTab = forwardRef(
           ref={ref}
         >
           {props.children}
-        </DraggableTabWrap>
+        </FilledTabWrap>
       );
     }
 
@@ -168,7 +168,7 @@ export const Tab = forwardRef(
   }
 );
 
-const DraggableTabWrap = styled('li', {shouldForwardProp: tabsShouldForwardProp})<{
+const FilledTabWrap = styled('li', {shouldForwardProp: tabsShouldForwardProp})<{
   borderStyle: 'dashed' | 'solid';
   overflowing: boolean;
 }>`
@@ -182,14 +182,13 @@ const DraggableTabWrap = styled('li', {shouldForwardProp: tabsShouldForwardProp}
         font-weight: ${p.theme.fontWeightBold};
       `}
     border-radius: 6px 6px 1px 1px;
-    padding: ${space(0.5)} ${space(1)};
   }
 
   &[aria-selected='false'] {
     border-top: 1px solid transparent;
-    padding-top: ${space(0.5)};
-    padding-bottom: ${space(0.5)};
   }
+
+  padding: ${space(0.5)} ${space(1)};
 
   transform: translateY(1px);
 

--- a/static/app/components/tabs/tabList.tsx
+++ b/static/app/components/tabs/tabList.tsx
@@ -19,7 +19,7 @@ import {browserHistory} from 'sentry/utils/browserHistory';
 import {TabsContext} from './index';
 import type {TabListItemProps} from './item';
 import {Item} from './item';
-import {Tab} from './tab';
+import {type BaseTabProps, Tab} from './tab';
 import {tabsShouldForwardProp} from './utils';
 
 /**
@@ -117,16 +117,19 @@ export interface TabListProps
   className?: string;
   hideBorder?: boolean;
   outerWrapStyles?: React.CSSProperties;
+  variant?: BaseTabProps['variant'];
 }
 
 interface BaseTabListProps extends TabListProps {
   items: TabListItemProps[];
+  variant?: BaseTabProps['variant'];
 }
 
 function BaseTabList({
   hideBorder = false,
   className,
   outerWrapStyles,
+  variant,
   ...props
 }: BaseTabListProps) {
   const tabListRef = useRef<HTMLUListElement>(null);
@@ -216,6 +219,7 @@ function BaseTabList({
             orientation={orientation}
             overflowing={orientation === 'horizontal' && overflowTabs.includes(item.key)}
             ref={element => (tabItemsRef.current[item.key] = element)}
+            variant={variant}
           />
         ))}
       </TabListWrap>
@@ -237,7 +241,7 @@ const collectionFactory = (nodes: Iterable<Node<any>>) => new ListCollection(nod
  * To be used as a direct child of the <Tabs /> component. See example usage
  * in tabs.stories.js
  */
-export function TabList({items, ...props}: TabListProps) {
+export function TabList({items, variant, ...props}: TabListProps) {
   /**
    * Initial, unfiltered list of tab items.
    */
@@ -258,7 +262,12 @@ export function TabList({items, ...props}: TabListProps) {
   );
 
   return (
-    <BaseTabList items={parsedItems} disabledKeys={disabledKeys} {...props}>
+    <BaseTabList
+      items={parsedItems}
+      disabledKeys={disabledKeys}
+      variant={variant}
+      {...props}
+    >
       {item => <Item {...item} />}
     </BaseTabList>
   );

--- a/static/app/components/tabs/tabList.tsx
+++ b/static/app/components/tabs/tabList.tsx
@@ -129,7 +129,7 @@ function BaseTabList({
   hideBorder = false,
   className,
   outerWrapStyles,
-  variant,
+  variant = 'flat',
   ...props
 }: BaseTabListProps) {
   const tabListRef = useRef<HTMLUListElement>(null);
@@ -210,6 +210,7 @@ function BaseTabList({
         hideBorder={hideBorder}
         className={className}
         ref={tabListRef}
+        variant={variant}
       >
         {[...state.collection].map(item => (
           <Tab
@@ -282,6 +283,7 @@ const TabListOuterWrap = styled('div')`
 const TabListWrap = styled('ul', {shouldForwardProp: tabsShouldForwardProp})<{
   hideBorder: boolean;
   orientation: Orientation;
+  variant: BaseTabProps['variant'];
 }>`
   position: relative;
   display: grid;
@@ -295,7 +297,7 @@ const TabListWrap = styled('ul', {shouldForwardProp: tabsShouldForwardProp})<{
       ? `
         grid-auto-flow: column;
         justify-content: start;
-        gap: ${space(2)};
+        gap: ${p.variant === 'filled' ? space(0) : space(2)};
         ${!p.hideBorder && `border-bottom: solid 1px ${p.theme.border};`}
       `
       : `

--- a/static/app/components/tabs/tabList.tsx
+++ b/static/app/components/tabs/tabList.tsx
@@ -85,6 +85,32 @@ function useOverflowTabs({
   return overflowTabs.filter(tabKey => !tabItemKeyToHiddenMap[tabKey]);
 }
 
+export function OverflowMenu({state, overflowMenuItems, disabled}) {
+  return (
+    <TabListOverflowWrap>
+      <CompactSelect
+        options={overflowMenuItems}
+        value={[...state.selectionManager.selectedKeys][0]}
+        onChange={opt => state.setSelectedKey(opt.value)}
+        disabled={disabled}
+        position="bottom-end"
+        size="sm"
+        offset={4}
+        trigger={triggerProps => (
+          <OverflowMenuTrigger
+            {...triggerProps}
+            size="sm"
+            borderless
+            showChevron={false}
+            icon={<IconEllipsis />}
+            aria-label={t('More tabs')}
+          />
+        )}
+      />
+    </TabListOverflowWrap>
+  );
+}
+
 export interface TabListProps
   extends AriaTabListOptions<TabListItemProps>,
     TabListStateOptions<TabListItemProps> {
@@ -195,27 +221,11 @@ function BaseTabList({
       </TabListWrap>
 
       {orientation === 'horizontal' && overflowMenuItems.length > 0 && (
-        <TabListOverflowWrap>
-          <CompactSelect
-            options={overflowMenuItems}
-            value={[...state.selectionManager.selectedKeys][0]}
-            onChange={opt => state.setSelectedKey(opt.value)}
-            disabled={disabled}
-            position="bottom-end"
-            size="sm"
-            offset={4}
-            trigger={triggerProps => (
-              <OverflowMenuTrigger
-                {...triggerProps}
-                size="sm"
-                borderless
-                showChevron={false}
-                icon={<IconEllipsis />}
-                aria-label={t('More tabs')}
-              />
-            )}
-          />
-        </TabListOverflowWrap>
+        <OverflowMenu
+          state={state}
+          overflowMenuItems={overflowMenuItems}
+          disabled={disabled}
+        />
       )}
     </TabListOuterWrap>
   );


### PR DESCRIPTION
This PR makes non-visible changes to the tabs component in anticipation of future changes being made for custom views. Specifically, it separates the `<Tab/>` and `<BaseTab/>` variants and adds a new `variant` prop that controls which group of styles are being applied to the baseTab component. 

It also reorganizes the component structure of the `<TabList>` to allow for the overflow menu to be reusable, since it will be used in the future draggable tabs component. 