### PR TITLE
fix(issue-stream): Fix styling on priority button

### DIFF
--- a/static/app/components/badge/groupPriority.tsx
+++ b/static/app/components/badge/groupPriority.tsx
@@ -262,7 +262,7 @@ const DropdownButton = styled(Button)`
   border: none;
   padding: 0;
   height: unset;
-  border-radius: 10px;
+  border-radius: 20px;
   box-shadow: none;
 `;
 


### PR DESCRIPTION
this pr fixes a minor style problem with the priority button

before: 
<img width="195" alt="Screenshot 2024-07-24 at 11 35 23 AM" src="https://github.com/user-attachments/assets/f264d679-3066-4f0e-8091-0a1797db0108">


after: 
<img width="206" alt="Screenshot 2024-07-24 at 11 39 47 AM" src="https://github.com/user-attachments/assets/8609d0e4-7072-4f1d-baa0-1a72f3b81168">
