### PR TITLE
fix(hybrid-cloud): Resubmission: adds defaults to provisioning model fields, lost_password_hash model (#74766)

### DIFF
--- a/src/sentry/hybridcloud/services/control_organization_provisioning/model.py
+++ b/src/sentry/hybridcloud/services/control_organization_provisioning/model.py
@@ -1,7 +1,7 @@
-import pydantic
+from sentry.hybridcloud.rpc import RpcModel
 
 
-class RpcOrganizationSlugReservation(pydantic.BaseModel):
+class RpcOrganizationSlugReservation(RpcModel):
     id: int
     organization_id: int
     user_id: int | None

--- a/src/sentry/services/organization/model.py
+++ b/src/sentry/services/organization/model.py
@@ -13,8 +13,8 @@ class OrganizationOptions(pydantic.BaseModel):
 
 
 class PostProvisionOptions(pydantic.BaseModel):
-    sentry_options: Any | None  # Placeholder for any sentry post-provisioning data
-    getsentry_options: Any | None  # Reserved for getsentry post-provisioning data
+    sentry_options: Any | None = None  # Placeholder for any sentry post-provisioning data
+    getsentry_options: Any | None = None  # Reserved for getsentry post-provisioning data
 
 
 class OrganizationProvisioningOptions(pydantic.BaseModel):

--- a/src/sentry/users/services/lost_password_hash/model.py
+++ b/src/sentry/users/services/lost_password_hash/model.py
@@ -3,7 +3,10 @@
 # in modules such as this one where hybrid cloud data models or service classes are
 # defined, because we want to reflect on type annotations and avoid forward references.
 
-import datetime
+from datetime import datetime
+
+from django.utils import timezone
+from pydantic import Field
 
 from sentry.hybridcloud.rpc import RpcModel
 from sentry.models.lostpasswordhash import LostPasswordHash
@@ -13,7 +16,7 @@ class RpcLostPasswordHash(RpcModel):
     id: int = -1
     user_id: int = -1
     hash: str = ""
-    date_added = datetime.datetime
+    date_added: datetime = Field(default_factory=timezone.now)
 
     def get_absolute_url(self, mode: str = "recover") -> str:
         return LostPasswordHash.get_lostpassword_url(self.user_id, self.hash, mode)

--- a/tests/sentry/api/endpoints/test_event_ai_suggested_fix.py
+++ b/tests/sentry/api/endpoints/test_event_ai_suggested_fix.py
@@ -34,7 +34,7 @@ def openai_mock(monkeypatch):
                     finish_reason="stop",
                 )
             ],
-            created=time.time(),
+            created=int(time.time()),
             model="gpt3.5-trubo",
             object="chat.completion",
         )

--- a/tests/sentry/feedback/usecases/test_create_feedback.py
+++ b/tests/sentry/feedback/usecases/test_create_feedback.py
@@ -64,7 +64,7 @@ def create_dummy_response(*args, **kwargs):
                 finish_reason="stop",
             )
         ],
-        created=time.time(),
+        created=int(time.time()),
         model="gpt3.5-trubo",
         object="chat.completion",
     )


### PR DESCRIPTION
This reverts commit bb8249209a69858cc03c6c1367f38c91d5f49ba7 which reverted #74766

The fix had some deploy issues due to silo mismatches between DE and US, which have since settled.


