### PR TITLE
fix: ghe integration - add additional details in log and capture message

### DIFF
--- a/src/sentry/integrations/github_enterprise/webhook.py
+++ b/src/sentry/integrations/github_enterprise/webhook.py
@@ -282,7 +282,12 @@ class GitHubEnterpriseWebhookBase(Endpoint):
             else:
                 # the host is allowed to skip signature verification
                 # log it, and continue on.
+                extra["github_enterprise_version"] = request.headers.get(
+                    "x-github-enterprise-version"
+                )
+                extra["ip_address"] = request.headers.get("x-real-ip")
                 logger.info("github_enterprise.webhook.allowed-missing-signature", extra=extra)
+                sentry_sdk.capture_message("Allowed missing signature")
 
         except (MalformedSignatureError, IndexError) as e:
             logger.warning("github_enterprise.webhook.malformed-signature", extra=extra)

--- a/src/sentry/integrations/github_enterprise/webhook.py
+++ b/src/sentry/integrations/github_enterprise/webhook.py
@@ -173,7 +173,7 @@ class GitHubEnterpriseWebhookBase(Endpoint):
             sentry_sdk.capture_exception(e)
             return HttpResponse(MISSING_GITHUB_ENTERPRISE_HOST_ERROR, status=400)
 
-        extra = {"host": host}
+        extra: dict[str, str | None] = {"host": host}
         # If we do tag the host early we can't even investigate
         scope.set_tag("host", host)
 


### PR DESCRIPTION
For hosts that bypass the signature check:

- add additional details to the log output
- capture a message and send it to Sentry