### PR TITLE
ref(breadcrumbs): Remove drawer components from render props

### DIFF
--- a/static/app/components/events/breadcrumbs/breadcrumbsDataSection.tsx
+++ b/static/app/components/events/breadcrumbs/breadcrumbsDataSection.tsx
@@ -1,15 +1,13 @@
-import {Fragment, useCallback, useMemo, useRef} from 'react';
+import {useCallback, useMemo, useRef} from 'react';
 import styled from '@emotion/styled';
 
-import ProjectAvatar from 'sentry/components/avatar/projectAvatar';
-import {Breadcrumbs as NavigationBreadcrumbs} from 'sentry/components/breadcrumbs';
 import {Button} from 'sentry/components/button';
 import ButtonBar from 'sentry/components/buttonBar';
 import ErrorBoundary from 'sentry/components/errorBoundary';
 import {
   BreadcrumbControlOptions,
-  BreadcrumbsDrawerContent,
-} from 'sentry/components/events/breadcrumbs/breadcrumbsDrawerContent';
+  BreadcrumbsDrawer,
+} from 'sentry/components/events/breadcrumbs/breadcrumbsDrawer';
 import BreadcrumbsTimeline from 'sentry/components/events/breadcrumbs/breadcrumbsTimeline';
 import {
   BREADCRUMB_TIME_DISPLAY_LOCALSTORAGE_KEY,
@@ -38,7 +36,6 @@ import type {Event} from 'sentry/types/event';
 import type {Group} from 'sentry/types/group';
 import type {Project} from 'sentry/types/project';
 import {trackAnalytics} from 'sentry/utils/analytics';
-import {getShortEventId} from 'sentry/utils/events';
 import {useLocalStorageState} from 'sentry/utils/useLocalStorageState';
 import useOrganization from 'sentry/utils/useOrganization';
 
@@ -85,31 +82,14 @@ export default function BreadcrumbsDataSection({
         organization,
       });
       openDrawer(
-        ({Header, Body}) => (
-          <Fragment>
-            <Header>
-              <NavigationCrumbs
-                crumbs={[
-                  {
-                    label: (
-                      <CrumbContainer>
-                        <ProjectAvatar project={project} />
-                        <ShortId>{group.shortId}</ShortId>
-                      </CrumbContainer>
-                    ),
-                  },
-                  {label: getShortEventId(event.id)},
-                  {label: t('Breadcrumbs')},
-                ]}
-              />
-            </Header>
-            <Body>
-              <BreadcrumbsDrawerContent
-                breadcrumbs={enhancedCrumbs}
-                focusControl={focusControl}
-              />
-            </Body>
-          </Fragment>
+        () => (
+          <BreadcrumbsDrawer
+            breadcrumbs={enhancedCrumbs}
+            focusControl={focusControl}
+            project={project}
+            event={event}
+            group={group}
+          />
         ),
         {ariaLabel: 'breadcrumb drawer'}
       );
@@ -244,21 +224,4 @@ const VerticalEllipsis = styled(IconEllipsis)`
 
 const ViewAllButton = styled(Button)`
   padding: ${space(0.75)} ${space(1)};
-`;
-
-const NavigationCrumbs = styled(NavigationBreadcrumbs)`
-  margin: 0;
-  padding: 0;
-`;
-
-const CrumbContainer = styled('div')`
-  display: flex;
-  gap: ${space(1)};
-  align-items: center;
-`;
-
-const ShortId = styled('div')`
-  font-family: ${p => p.theme.text.family};
-  font-size: ${p => p.theme.fontSizeMedium};
-  line-height: 1;
 `;

--- a/static/app/components/events/breadcrumbs/breadcrumbsDrawer.spec.tsx
+++ b/static/app/components/events/breadcrumbs/breadcrumbsDrawer.spec.tsx
@@ -26,7 +26,7 @@ async function renderBreadcrumbDrawer() {
   return within(screen.getByRole('complementary', {name: 'breadcrumb drawer'}));
 }
 
-describe('BreadcrumbsDrawerContent', function () {
+describe('BreadcrumbsDrawer', function () {
   it('renders the drawer as expected', async function () {
     const drawerScreen = await renderBreadcrumbDrawer();
     expect(drawerScreen.getByRole('button', {name: 'Close Drawer'})).toBeInTheDocument();

--- a/static/app/components/globalDrawer/index.spec.tsx
+++ b/static/app/components/globalDrawer/index.spec.tsx
@@ -10,6 +10,7 @@ import {
 
 import type {DrawerConfig} from 'sentry/components/globalDrawer';
 import useDrawer from 'sentry/components/globalDrawer';
+import {DrawerBody, DrawerHeader} from 'sentry/components/globalDrawer/components';
 
 function GlobalDrawerTestComponent({config}: {config: DrawerConfig}) {
   const {openDrawer, closeDrawer} = useDrawer();
@@ -38,8 +39,8 @@ describe('GlobalDrawer', function () {
     render(
       <GlobalDrawerTestComponent
         config={{
-          renderer: ({Body}) => (
-            <Body data-test-id="drawer-test-content">useDrawer hook</Body>
+          renderer: () => (
+            <DrawerBody data-test-id="drawer-test-content">useDrawer hook</DrawerBody>
           ),
           options: {ariaLabel},
         }}
@@ -72,10 +73,10 @@ describe('GlobalDrawer', function () {
     render(
       <GlobalDrawerTestComponent
         config={{
-          renderer: ({Body, Header}) => (
+          renderer: () => (
             <Fragment>
-              <Header />
-              <Body data-test-id="drawer-test-content">onClose button</Body>
+              <DrawerHeader />
+              <DrawerBody data-test-id="drawer-test-content">onClose button</DrawerBody>
             </Fragment>
           ),
           options: {onClose: closeSpy, ariaLabel},
@@ -100,8 +101,10 @@ describe('GlobalDrawer', function () {
     render(
       <GlobalDrawerTestComponent
         config={{
-          renderer: ({Body}) => (
-            <Body data-test-id="drawer-test-content">onClose outside click</Body>
+          renderer: () => (
+            <DrawerBody data-test-id="drawer-test-content">
+              onClose outside click
+            </DrawerBody>
           ),
           options: {onClose: closeSpy, ariaLabel},
         }}
@@ -153,10 +156,12 @@ describe('GlobalDrawer', function () {
     render(
       <GlobalDrawerTestComponent
         config={{
-          renderer: ({Body, Header}) => (
+          renderer: () => (
             <Fragment>
-              <Header />
-              <Body data-test-id="drawer-test-content">ignore close events</Body>
+              <DrawerHeader />
+              <DrawerBody data-test-id="drawer-test-content">
+                ignore close events
+              </DrawerBody>
             </Fragment>
           ),
           options: {
@@ -196,10 +201,10 @@ describe('GlobalDrawer', function () {
     render(
       <GlobalDrawerTestComponent
         config={{
-          renderer: ({Body, Header}) => (
+          renderer: () => (
             <Fragment>
-              <Header>{customHeader}</Header>
-              <Body data-test-id="drawer-test-content">custom header</Body>
+              <DrawerHeader>{customHeader}</DrawerHeader>
+              <DrawerBody data-test-id="drawer-test-content">custom header</DrawerBody>
             </Fragment>
           ),
           options: {ariaLabel, onClose: closeSpy},

--- a/static/app/components/globalDrawer/index.stories.tsx
+++ b/static/app/components/globalDrawer/index.stories.tsx
@@ -4,6 +4,7 @@ import styled from '@emotion/styled';
 import {Button} from 'sentry/components/button';
 import {CodeSnippet} from 'sentry/components/codeSnippet';
 import useDrawer from 'sentry/components/globalDrawer';
+import {DrawerBody, DrawerHeader} from 'sentry/components/globalDrawer/components';
 import storyBook from 'sentry/stories/storyBook';
 
 export default storyBook('GlobalDrawer', story => {
@@ -19,6 +20,7 @@ export default storyBook('GlobalDrawer', story => {
       </p>
     </Fragment>
   ));
+
   story('Empty Example', () => {
     const {openDrawer, closeDrawer} = useDrawer();
     return (
@@ -35,36 +37,6 @@ export default storyBook('GlobalDrawer', story => {
           {`<Button onClick={closeDrawer}>Close Drawer</Button>`}
         </CodeSnippet>
         <LeftButton onClick={closeDrawer}>Close Drawer</LeftButton>
-      </Fragment>
-    );
-  });
-
-  story('<Body /> Example', () => {
-    const {openDrawer} = useDrawer();
-    return (
-      <Fragment>
-        <CodeSnippet language="jsx">
-          {`<Button onClick={() => openDrawer(({Body}) => <Body>Lorem, ipsum...</Body>, {ariaLabel: 'test drawer'})}>
-  Open Drawer
-</Button>`}
-        </CodeSnippet>
-        <LeftButton
-          onClick={() =>
-            openDrawer(
-              ({Body}) => (
-                <Body>
-                  Lorem, ipsum dolor sit amet consectetur adipisicing elit. Temporibus
-                  cupiditate voluptates nostrum voluptatibus ab provident eius accusamus
-                  corporis, nesciunt possimus consectetur sapiente velit alias cum nemo
-                  beatae doloribus sed accusantium?
-                </Body>
-              ),
-              {ariaLabel: 'test drawer'}
-            )
-          }
-        >
-          Open Drawer
-        </LeftButton>
       </Fragment>
     );
   });
@@ -112,6 +84,50 @@ export default storyBook('GlobalDrawer', story => {
           }
         >
           Neither, must click Close Button
+        </LeftButton>
+      </Fragment>
+    );
+  });
+
+  story('Helper Components Example', () => {
+    const {openDrawer} = useDrawer();
+    return (
+      <Fragment>
+        <CodeSnippet language="jsx">
+          {`import {DrawerBody, DrawerHeader} from 'sentry/components/globalDrawer/components';
+
+<Button onClick={() => openDrawer(
+  () => (
+    <Fragment>
+      <DrawerHeader>My Drawer</DrawerHeader>
+      <DrawerBody>Lorem, ipsum...</DrawerBody>
+    </Fragment>
+  ),
+  {ariaLabel: 'test drawer', onClose: () => alert('Called my handler!')}
+)}>
+  Open Drawer
+</Button>`}
+        </CodeSnippet>
+        <LeftButton
+          onClick={() =>
+            openDrawer(
+              () => (
+                <Fragment>
+                  <DrawerHeader>My Drawer</DrawerHeader>
+                  <DrawerBody>
+                    Lorem, ipsum dolor sit amet consectetur adipisicing elit. Temporibus
+                    cupiditate voluptates nostrum voluptatibus ab provident eius accusamus
+                    corporis, nesciunt possimus consectetur sapiente velit alias cum nemo
+                    beatae doloribus sed accusantium?
+                  </DrawerBody>
+                </Fragment>
+              ),
+              // eslint-disable-next-line no-alert
+              {ariaLabel: 'test drawer', onClose: () => alert('Called my handler!')}
+            )
+          }
+        >
+          Open Drawer
         </LeftButton>
       </Fragment>
     );

--- a/static/app/components/globalDrawer/index.tsx
+++ b/static/app/components/globalDrawer/index.tsx
@@ -44,14 +44,6 @@ export interface DrawerOptions {
 
 interface DrawerRenderProps {
   /**
-   * Body container for the drawer
-   */
-  Body: typeof DrawerComponents.DrawerBody;
-  /**
-   * Header with a close button for the drawer
-   */
-  Header: typeof DrawerComponents.DrawerHeader;
-  /**
    * Close the drawer
    */
   closeDrawer: () => void;
@@ -120,8 +112,6 @@ export function GlobalDrawer({children}) {
 
   const renderedChild = currentDrawerConfig?.renderer
     ? currentDrawerConfig.renderer({
-        Body: DrawerComponents.DrawerBody,
-        Header: DrawerComponents.DrawerHeader,
         closeDrawer: handleClose,
       })
     : null;
@@ -156,7 +146,7 @@ export function GlobalDrawer({children}) {
  * The `openDrawer` function accepts a renderer, and options. By default, the drawer will close
  * on outside clicks, and 'Escape' key presses. For example:
  * ```
- * openDrawer((Body) => <Body><MyComponent /></Body>, {closeOnOutsideClick: false})
+ * openDrawer(() => <DrawerBody><MyComponent /></DrawerBody>, {closeOnOutsideClick: false})
  * ```
  *
  * The `closeDrawer` function accepts no parameters and closes the drawer, unmounting its contents.


### PR DESCRIPTION
Since the drawer components can access any state they'll need  through the context provider, there's no need to pass them as props. Anyone implementing `openDrawer` can just import the components they care about. See https://github.com/getsentry/sentry/pull/74034#discussion_r1672804668

Also made the change to the one call site with a bit of a refactor.