### PR TITLE
ref: copy signature of _request to plugin api client

### DIFF
--- a/src/sentry_plugins/client.py
+++ b/src/sentry_plugins/client.py
@@ -1,4 +1,12 @@
-from sentry.shared_integrations.client import BaseApiClient, BaseInternalApiClient
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Literal, overload
+
+from requests import PreparedRequest, Response
+
+from sentry.shared_integrations.client.base import BaseApiClient, BaseApiResponseX
+from sentry.shared_integrations.client.internal import BaseInternalApiClient
 from sentry.shared_integrations.exceptions import ApiUnauthorized
 from sentry.users.services.usersocialauth.service import usersocialauth_service
 
@@ -35,6 +43,44 @@ class AuthApiClient(ApiClient):
         token = self.auth.tokens["access_token"]
         kwargs["headers"]["Authorization"] = f"Bearer {token}"
         return kwargs
+
+    @overload
+    def _request(
+        self,
+        method: str,
+        path: str,
+        headers: Mapping[str, str] | None = None,
+        data: Mapping[str, str] | None = None,
+        params: Mapping[str, str] | None = None,
+        auth: tuple[str, str] | str | None = None,
+        json: bool = True,
+        allow_text: bool | None = None,
+        allow_redirects: bool | None = None,
+        timeout: int | None = None,
+        ignore_webhook_errors: bool = False,
+        prepared_request: PreparedRequest | None = None,
+        raw_response: Literal[True] = ...,
+    ) -> Response:
+        ...
+
+    @overload
+    def _request(
+        self,
+        method: str,
+        path: str,
+        headers: Mapping[str, str] | None = None,
+        data: Mapping[str, str] | None = None,
+        params: Mapping[str, str] | None = None,
+        auth: str | None = None,
+        json: bool = True,
+        allow_text: bool | None = None,
+        allow_redirects: bool | None = None,
+        timeout: int | None = None,
+        ignore_webhook_errors: bool = False,
+        prepared_request: PreparedRequest | None = None,
+        raw_response: bool = ...,
+    ) -> BaseApiResponseX:
+        ...
 
     def _request(self, method, path, **kwargs):
         headers = kwargs.setdefault("headers", {})


### PR DESCRIPTION
pretty annoying to need to copy the `overload` -- I'll be following up to remove the overload entirely since that union is mighty annoying everywhere!

<!-- Describe your PR here. -->