### PR TITLE
fix(settings): show new secondary email after saving

### DIFF
--- a/static/app/views/settings/account/accountEmails.spec.tsx
+++ b/static/app/views/settings/account/accountEmails.spec.tsx
@@ -106,29 +106,30 @@ describe('AccountEmails', function () {
     render(<AccountEmails />);
     expect(mock).not.toHaveBeenCalled();
 
+    const mockGetResponseBody = [
+      ...AccountEmailsFixture(),
+      {
+        email: 'test@example.com',
+        isPrimary: false,
+        isVerified: false,
+      },
+    ];
+
     const mockGet = MockApiClient.addMockResponse({
       url: ENDPOINT,
       method: 'GET',
       statusCode: 200,
-      body: [
-        ...AccountEmailsFixture(),
-        {
-          email: 'test@example.com',
-          isPrimary: false,
-          isVerified: false,
-        },
-      ],
+      body: mockGetResponseBody,
     });
 
     const textbox = await screen.findByRole('textbox');
-    const expectedSecondaryEmails = AccountEmailsFixture().length - 1;
     expect(screen.getAllByLabelText('Remove email')).toHaveLength(
-      expectedSecondaryEmails
+      AccountEmailsFixture().filter(email => !email.isPrimary).length
     );
 
     await userEvent.type(textbox, 'test@example.com{enter}');
     expect(screen.getAllByLabelText('Remove email')).toHaveLength(
-      expectedSecondaryEmails + 1
+      mockGetResponseBody.filter(email => !email.isPrimary).length
     );
 
     expect(mock).toHaveBeenCalledWith(

--- a/static/app/views/settings/account/accountEmails.spec.tsx
+++ b/static/app/views/settings/account/accountEmails.spec.tsx
@@ -106,7 +106,30 @@ describe('AccountEmails', function () {
     render(<AccountEmails />);
     expect(mock).not.toHaveBeenCalled();
 
-    await userEvent.type(screen.getByRole('textbox'), 'test@example.com{enter}');
+    const mockGet = MockApiClient.addMockResponse({
+      url: ENDPOINT,
+      method: 'GET',
+      statusCode: 200,
+      body: [
+        ...AccountEmailsFixture(),
+        {
+          email: 'test@example.com',
+          isPrimary: false,
+          isVerified: false,
+        },
+      ],
+    });
+
+    const textbox = await screen.findByRole('textbox');
+    const expectedSecondaryEmails = AccountEmailsFixture().length - 1;
+    expect(screen.getAllByLabelText('Remove email')).toHaveLength(
+      expectedSecondaryEmails
+    );
+
+    await userEvent.type(textbox, 'test@example.com{enter}');
+    expect(screen.getAllByLabelText('Remove email')).toHaveLength(
+      expectedSecondaryEmails + 1
+    );
 
     expect(mock).toHaveBeenCalledWith(
       ENDPOINT,
@@ -115,6 +138,13 @@ describe('AccountEmails', function () {
         data: {
           email: 'test@example.com',
         },
+      })
+    );
+
+    expect(mockGet).toHaveBeenCalledWith(
+      ENDPOINT,
+      expect.objectContaining({
+        method: 'GET',
       })
     );
   });

--- a/static/app/views/settings/account/accountEmails.tsx
+++ b/static/app/views/settings/account/accountEmails.tsx
@@ -23,14 +23,18 @@ import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {UserEmail} from 'sentry/types';
 import type {ApiQueryKey} from 'sentry/utils/queryClient';
-import {useApiQuery} from 'sentry/utils/queryClient';
+import {useApiQuery, useQueryClient} from 'sentry/utils/queryClient';
 import useApi from 'sentry/utils/useApi';
 import SettingsPageHeader from 'sentry/views/settings/components/settingsPageHeader';
 
 const ENDPOINT = '/users/me/emails/';
 
 function AccountEmails() {
+  const queryClient = useQueryClient();
+
   const handleSubmitSuccess: FormProps['onSubmitSuccess'] = (_change, model, id) => {
+    queryClient.invalidateQueries(makeEmailsEndpointKey());
+
     if (id === undefined) {
       return;
     }


### PR DESCRIPTION
Fixes a bug where a newly added secondary email was not visible on the Email Addresses page till page reload.
Now we invalidate the query client cache and make sure to fetch the correct list of email addresses from the backend.