### PR TITLE
ref(onboarding): add/request integrations button

### DIFF
--- a/static/app/views/alerts/rules/issue/addIntegrationRow.spec.tsx
+++ b/static/app/views/alerts/rules/issue/addIntegrationRow.spec.tsx
@@ -71,6 +71,22 @@ describe('AddIntegrationRow', function () {
     );
   });
 
+  it('renders request buttons when user does not have access', async () => {
+    org.access = ['org:read'];
+
+    const mock1 = MockApiClient.addMockResponse({
+      url: `/organizations/${org.slug}/config/integrations/?provider_key=${integrationSlug}`,
+      body: {
+        providers: providers,
+      },
+    });
+
+    render(getComponent());
+
+    expect(mock1).toHaveBeenCalled();
+    await screen.findByRole('button', {name: /request installation/i});
+  });
+
   it('handles API error', async () => {
     const setHasError = jest.fn();
 

--- a/static/app/views/alerts/rules/issue/addIntegrationRow.spec.tsx
+++ b/static/app/views/alerts/rules/issue/addIntegrationRow.spec.tsx
@@ -2,44 +2,47 @@ import {GitHubIntegrationProviderFixture} from 'sentry-fixture/githubIntegration
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {ProjectFixture} from 'sentry-fixture/project';
 
-import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
+import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
 import AddIntegrationRow from 'sentry/views/alerts/rules/issue/addIntegrationRow';
+import {IntegrationContext} from 'sentry/views/settings/organizationIntegrations/integrationContext';
 
 jest.mock('sentry/actionCreators/modal');
 
 describe('AddIntegrationRow', function () {
-  let project, org;
-  const integrationSlug = 'github';
-  const providers = [GitHubIntegrationProviderFixture()];
+  let hasAccess;
+  const project = ProjectFixture();
+  const org = OrganizationFixture();
+  const provider = GitHubIntegrationProviderFixture();
 
   beforeEach(function () {
     MockApiClient.clearMockResponses();
 
-    project = ProjectFixture();
-    org = OrganizationFixture();
+    hasAccess = true;
 
     jest.clearAllMocks();
   });
 
   const getComponent = () => (
-    <AddIntegrationRow
-      providerKey={integrationSlug}
-      organization={org}
-      project={project}
-      onClickHandler={jest.fn()}
-      setHasError={jest.fn()}
-    />
+    <IntegrationContext.Provider
+      value={{
+        provider: provider,
+        type: 'first_party',
+        organization: org,
+        userHasAccess: hasAccess,
+        installStatus: 'Not Installed',
+        analyticsParams: {
+          view: 'onboarding',
+          already_installed: false,
+        },
+        modalParams: {project: project.id},
+      }}
+    >
+      <AddIntegrationRow onClickHandler={jest.fn()} />
+    </IntegrationContext.Provider>
   );
 
   it('renders', async () => {
-    MockApiClient.addMockResponse({
-      url: `/organizations/${org.slug}/config/integrations/?provider_key=${integrationSlug}`,
-      body: {
-        providers: providers,
-      },
-    });
-
     render(getComponent());
 
     const button = await screen.findByRole('button', {name: /add integration/i});
@@ -52,16 +55,8 @@ describe('AddIntegrationRow', function () {
     // any is needed here because getSentry has different types for global
     (global as any).open = open;
 
-    const mock1 = MockApiClient.addMockResponse({
-      url: `/organizations/${org.slug}/config/integrations/?provider_key=${integrationSlug}`,
-      body: {
-        providers: providers,
-      },
-    });
-
     render(getComponent());
 
-    expect(mock1).toHaveBeenCalled();
     const button = await screen.findByRole('button', {name: /add integration/i});
     await userEvent.click(button);
     expect(open.mock.calls).toHaveLength(1);
@@ -71,43 +66,35 @@ describe('AddIntegrationRow', function () {
     );
   });
 
-  it('renders request buttons when user does not have access', async () => {
-    org.access = ['org:read'];
-
-    const mock1 = MockApiClient.addMockResponse({
-      url: `/organizations/${org.slug}/config/integrations/?provider_key=${integrationSlug}`,
-      body: {
-        providers: providers,
-      },
-    });
+  it('renders request button when user does not have access', async () => {
+    hasAccess = false;
 
     render(getComponent());
 
-    expect(mock1).toHaveBeenCalled();
     await screen.findByRole('button', {name: /request installation/i});
   });
 
-  it('handles API error', async () => {
-    const setHasError = jest.fn();
+  // it('handles API error', async () => {
+  //   const setHasError = jest.fn();
 
-    MockApiClient.addMockResponse({
-      url: `/organizations/${org.slug}/config/integrations/?provider_key=${integrationSlug}`,
-      statusCode: 400,
-      body: {error: 'internal error'},
-    });
+  //   MockApiClient.addMockResponse({
+  //     url: `/organizations/${org.slug}/config/integrations/?provider_key=${integrationSlug}`,
+  //     statusCode: 400,
+  //     body: {error: 'internal error'},
+  //   });
 
-    render(
-      <AddIntegrationRow
-        providerKey={integrationSlug}
-        organization={org}
-        project={project}
-        onClickHandler={jest.fn()}
-        setHasError={setHasError}
-      />
-    );
+  //   render(
+  //     <AddIntegrationRow
+  //       providerKey={integrationSlug}
+  //       organization={org}
+  //       project={project}
+  //       onClickHandler={jest.fn()}
+  //       setHasError={setHasError}
+  //     />
+  //   );
 
-    await waitFor(() => {
-      expect(setHasError).toHaveBeenCalled();
-    });
-  });
+  //   await waitFor(() => {
+  //     expect(setHasError).toHaveBeenCalled();
+  //   });
+  // });
 });

--- a/static/app/views/alerts/rules/issue/addIntegrationRow.spec.tsx
+++ b/static/app/views/alerts/rules/issue/addIntegrationRow.spec.tsx
@@ -10,16 +10,12 @@ import {IntegrationContext} from 'sentry/views/settings/organizationIntegrations
 jest.mock('sentry/actionCreators/modal');
 
 describe('AddIntegrationRow', function () {
-  let hasAccess;
+  let org;
   const project = ProjectFixture();
-  const org = OrganizationFixture();
   const provider = GitHubIntegrationProviderFixture();
 
   beforeEach(function () {
-    MockApiClient.clearMockResponses();
-
-    hasAccess = true;
-
+    org = OrganizationFixture();
     jest.clearAllMocks();
   });
 
@@ -28,8 +24,6 @@ describe('AddIntegrationRow', function () {
       value={{
         provider: provider,
         type: 'first_party',
-        organization: org,
-        userHasAccess: hasAccess,
         installStatus: 'Not Installed',
         analyticsParams: {
           view: 'onboarding',
@@ -38,7 +32,7 @@ describe('AddIntegrationRow', function () {
         modalParams: {project: project.id},
       }}
     >
-      <AddIntegrationRow onClickHandler={jest.fn()} />
+      <AddIntegrationRow organization={org} onClick={jest.fn()} />
     </IntegrationContext.Provider>
   );
 
@@ -67,34 +61,10 @@ describe('AddIntegrationRow', function () {
   });
 
   it('renders request button when user does not have access', async () => {
-    hasAccess = false;
+    org.access = ['org:read'];
 
     render(getComponent());
 
     await screen.findByRole('button', {name: /request installation/i});
   });
-
-  // it('handles API error', async () => {
-  //   const setHasError = jest.fn();
-
-  //   MockApiClient.addMockResponse({
-  //     url: `/organizations/${org.slug}/config/integrations/?provider_key=${integrationSlug}`,
-  //     statusCode: 400,
-  //     body: {error: 'internal error'},
-  //   });
-
-  //   render(
-  //     <AddIntegrationRow
-  //       providerKey={integrationSlug}
-  //       organization={org}
-  //       project={project}
-  //       onClickHandler={jest.fn()}
-  //       setHasError={setHasError}
-  //     />
-  //   );
-
-  //   await waitFor(() => {
-  //     expect(setHasError).toHaveBeenCalled();
-  //   });
-  // });
 });

--- a/static/app/views/alerts/rules/issue/addIntegrationRow.tsx
+++ b/static/app/views/alerts/rules/issue/addIntegrationRow.tsx
@@ -1,16 +1,19 @@
 import {useContext} from 'react';
 import styled from '@emotion/styled';
 
+import Access from 'sentry/components/acl/access';
 import PluginIcon from 'sentry/plugins/components/pluginIcon';
 import {space} from 'sentry/styles/space';
+import type {Organization} from 'sentry/types/organization';
 import IntegrationButton from 'sentry/views/settings/organizationIntegrations/integrationButton';
 import {IntegrationContext} from 'sentry/views/settings/organizationIntegrations/integrationContext';
 
 type Props = {
-  onClickHandler: () => void;
+  onClick: () => void;
+  organization: Organization;
 };
 
-function AddIntegrationRow({onClickHandler}: Props) {
+function AddIntegrationRow({organization, onClick}: Props) {
   const integration = useContext(IntegrationContext);
   if (!integration) {
     return null;
@@ -29,12 +32,20 @@ function AddIntegrationRow({onClickHandler}: Props) {
         <PluginIcon pluginId={provider.slug} size={40} />
         <NameHeader>Connect {provider.name}</NameHeader>
       </IconTextWrapper>
-      <StyledButton
-        onAddIntegration={onClickHandler}
-        onExternalClick={onClickHandler}
-        externalInstallText="Add Installation"
-        buttonProps={buttonProps}
-      />
+      <Access access={['org:integrations']} organization={organization}>
+        {({hasAccess}) => {
+          return (
+            <StyledButton
+              organization={organization}
+              userHasAccess={hasAccess}
+              onAddIntegration={onClick}
+              onExternalClick={onClick}
+              externalInstallText="Add Installation"
+              buttonProps={buttonProps}
+            />
+          );
+        }}
+      </Access>
     </RowWrapper>
   );
 }

--- a/static/app/views/alerts/rules/issue/addIntegrationRow.tsx
+++ b/static/app/views/alerts/rules/issue/addIntegrationRow.tsx
@@ -1,6 +1,7 @@
 import {useCallback, useEffect, useState} from 'react';
 import styled from '@emotion/styled';
 
+import Access from 'sentry/components/acl/access';
 import PluginIcon from 'sentry/plugins/components/pluginIcon';
 import {space} from 'sentry/styles/space';
 import type {IntegrationProvider} from 'sentry/types/integrations';
@@ -51,13 +52,10 @@ function AddIntegrationRow({
     return null;
   }
 
-  const {metadata} = provider;
-
   const buttonProps = {
     size: 'sm' as const,
     priority: 'primary' as const,
     'data-test-id': 'install-button',
-    organization,
   };
 
   return (
@@ -66,13 +64,28 @@ function AddIntegrationRow({
         <PluginIcon pluginId={providerKey} size={40} />
         <NameHeader>Connect {provider.name}</NameHeader>
       </IconTextWrapper>
-      <StyledButton
-        onAddIntegration={onClickHandler}
-        onExternalClick={onClickHandler}
-        organization={organization}
-        project={project}
-        provider={provider}
-      />
+      <Access access={['org:integrations']} organization={organization}>
+        {({hasAccess}) => {
+          return (
+            <StyledButton
+              onAddIntegration={onClickHandler}
+              onExternalClick={onClickHandler}
+              organization={organization}
+              provider={provider}
+              type="first_party"
+              userHasAccess={hasAccess}
+              installStatus="Not Installed"
+              analyticsParams={{
+                view: 'onboarding',
+                already_installed: false,
+              }}
+              externalInstallText="Add Installation"
+              modalParams={{project: project.id}}
+              buttonProps={buttonProps}
+            />
+          );
+        }}
+      </Access>
     </RowWrapper>
   );
 }

--- a/static/app/views/alerts/rules/issue/addIntegrationRow.tsx
+++ b/static/app/views/alerts/rules/issue/addIntegrationRow.tsx
@@ -1,91 +1,40 @@
-import {useCallback, useEffect, useState} from 'react';
+import {useContext} from 'react';
 import styled from '@emotion/styled';
 
-import Access from 'sentry/components/acl/access';
 import PluginIcon from 'sentry/plugins/components/pluginIcon';
 import {space} from 'sentry/styles/space';
-import type {IntegrationProvider} from 'sentry/types/integrations';
-import type {Organization} from 'sentry/types/organization';
-import type {Project} from 'sentry/types/project';
-import useApi from 'sentry/utils/useApi';
 import IntegrationButton from 'sentry/views/settings/organizationIntegrations/integrationButton';
+import {IntegrationContext} from 'sentry/views/settings/organizationIntegrations/integrationContext';
 
 type Props = {
   onClickHandler: () => void;
-  organization: Organization;
-  project: Project;
-  providerKey: string;
-  setHasError: (boolean) => void;
 };
 
-function AddIntegrationRow({
-  providerKey,
-  organization,
-  project,
-  onClickHandler,
-  setHasError,
-}: Props) {
-  const [provider, setProvider] = useState<IntegrationProvider | null>(null);
-
-  const api = useApi();
-  const fetchData = useCallback(() => {
-    if (!providerKey) {
-      return Promise.resolve();
-    }
-
-    const endpoint = `/organizations/${organization.slug}/config/integrations/?provider_key=${providerKey}`;
-    return api
-      .requestPromise(endpoint)
-      .then(integrations => {
-        setProvider(integrations.providers[0]);
-      })
-      .catch(() => {
-        setHasError(true);
-      });
-  }, [providerKey, api, organization.slug, setHasError]);
-
-  useEffect(() => {
-    fetchData();
-  }, [fetchData]);
-
-  if (!provider) {
+function AddIntegrationRow({onClickHandler}: Props) {
+  const integration = useContext(IntegrationContext);
+  if (!integration) {
     return null;
   }
+  const provider = integration.provider;
 
   const buttonProps = {
-    size: 'sm' as const,
-    priority: 'primary' as const,
+    size: 'sm',
+    priority: 'primary',
     'data-test-id': 'install-button',
   };
 
   return (
     <RowWrapper>
       <IconTextWrapper>
-        <PluginIcon pluginId={providerKey} size={40} />
+        <PluginIcon pluginId={provider.slug} size={40} />
         <NameHeader>Connect {provider.name}</NameHeader>
       </IconTextWrapper>
-      <Access access={['org:integrations']} organization={organization}>
-        {({hasAccess}) => {
-          return (
-            <StyledButton
-              onAddIntegration={onClickHandler}
-              onExternalClick={onClickHandler}
-              organization={organization}
-              provider={provider}
-              type="first_party"
-              userHasAccess={hasAccess}
-              installStatus="Not Installed"
-              analyticsParams={{
-                view: 'onboarding',
-                already_installed: false,
-              }}
-              externalInstallText="Add Installation"
-              modalParams={{project: project.id}}
-              buttonProps={buttonProps}
-            />
-          );
-        }}
-      </Access>
+      <StyledButton
+        onAddIntegration={onClickHandler}
+        onExternalClick={onClickHandler}
+        externalInstallText="Add Installation"
+        buttonProps={buttonProps}
+      />
     </RowWrapper>
   );
 }

--- a/static/app/views/alerts/rules/issue/addIntegrationRow.tsx
+++ b/static/app/views/alerts/rules/issue/addIntegrationRow.tsx
@@ -1,14 +1,13 @@
 import {useCallback, useEffect, useState} from 'react';
 import styled from '@emotion/styled';
 
-import {Button} from 'sentry/components/button';
 import PluginIcon from 'sentry/plugins/components/pluginIcon';
 import {space} from 'sentry/styles/space';
 import type {IntegrationProvider} from 'sentry/types/integrations';
 import type {Organization} from 'sentry/types/organization';
 import type {Project} from 'sentry/types/project';
 import useApi from 'sentry/utils/useApi';
-import {AddIntegrationButton} from 'sentry/views/settings/organizationIntegrations/addIntegrationButton';
+import IntegrationButton from 'sentry/views/settings/organizationIntegrations/integrationButton';
 
 type Props = {
   onClickHandler: () => void;
@@ -61,35 +60,19 @@ function AddIntegrationRow({
     organization,
   };
 
-  const close = () => onClickHandler;
-
-  // TODO(Mia): show request installation button if user does not have necessary permissions
-  const integrationButton = metadata.aspects.externalInstall ? (
-    <ExternalButton
-      href={metadata.aspects.externalInstall.url}
-      onClick={() => close}
-      external
-      {...buttonProps}
-    >
-      Add Installation
-    </ExternalButton>
-  ) : (
-    <InternalButton
-      provider={provider}
-      onAddIntegration={close}
-      analyticsParams={{view: 'onboarding', already_installed: false}}
-      modalParams={{projectId: project.id}}
-      {...buttonProps}
-    />
-  );
-
   return (
     <RowWrapper>
       <IconTextWrapper>
         <PluginIcon pluginId={providerKey} size={40} />
         <NameHeader>Connect {provider.name}</NameHeader>
       </IconTextWrapper>
-      {integrationButton}
+      <StyledButton
+        onAddIntegration={onClickHandler}
+        onExternalClick={onClickHandler}
+        organization={organization}
+        project={project}
+        provider={provider}
+      />
     </RowWrapper>
   );
 }
@@ -113,11 +96,7 @@ const NameHeader = styled('h6')`
   margin: 0;
 `;
 
-const ExternalButton = styled(Button)`
-  margin: 0;
-`;
-
-const InternalButton = styled(AddIntegrationButton)`
+const StyledButton = styled(IntegrationButton)`
   margin: 0;
 `;
 

--- a/static/app/views/alerts/rules/issue/messagingIntegrationModal.spec.tsx
+++ b/static/app/views/alerts/rules/issue/messagingIntegrationModal.spec.tsx
@@ -24,15 +24,14 @@ describe('MessagingIntegrationModal', function () {
     MockApiClient.clearMockResponses();
 
     project = ProjectFixture();
-    org = OrganizationFixture({
-      features: ['messaging-integration-onboarding'],
-    });
+    org = OrganizationFixture();
 
     jest.clearAllMocks();
   });
 
   const getComponent = (closeModal?, props = {}) => (
     <MessagingIntegrationModal
+      closeModal={closeModal ? closeModal : jest.fn()}
       Header={makeClosableHeader(() => {})}
       Body={ModalBody}
       headerContent={<h1>Connect with a messaging tool</h1>}
@@ -42,7 +41,6 @@ describe('MessagingIntegrationModal', function () {
       project={project}
       CloseButton={makeCloseButton(() => {})}
       Footer={ModalFooter}
-      closeModal={closeModal ? closeModal : jest.fn()}
       {...props}
     />
   );

--- a/static/app/views/alerts/rules/issue/messagingIntegrationModal.spec.tsx
+++ b/static/app/views/alerts/rules/issue/messagingIntegrationModal.spec.tsx
@@ -18,7 +18,9 @@ jest.mock('sentry/actionCreators/modal');
 describe('MessagingIntegrationModal', function () {
   let project, org;
   const providerKeys = ['slack', 'discord', 'msteams'];
-  const providers = [GitHubIntegrationProviderFixture()];
+  const providers = (providerKey: string) => [
+    GitHubIntegrationProviderFixture({key: providerKey}),
+  ];
 
   beforeEach(function () {
     MockApiClient.clearMockResponses();
@@ -51,7 +53,7 @@ describe('MessagingIntegrationModal', function () {
       mockResponses.push(
         MockApiClient.addMockResponse({
           url: `/organizations/${org.slug}/config/integrations/?provider_key=${providerKey}`,
-          body: {providers: providers},
+          body: {providers: providers(providerKey)},
         })
       );
     });

--- a/static/app/views/settings/organizationIntegrations/integrationButton.spec.tsx
+++ b/static/app/views/settings/organizationIntegrations/integrationButton.spec.tsx
@@ -1,0 +1,84 @@
+import {GitHubIntegrationProviderFixture} from 'sentry-fixture/githubIntegrationProvider';
+import {OrganizationFixture} from 'sentry-fixture/organization';
+import {ProjectFixture} from 'sentry-fixture/project';
+
+import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+import {IntegrationProvider} from 'sentry/types';
+import {Organization} from 'sentry/types/organization';
+
+import IntegrationButton from 'sentry/views/settings/organizationIntegrations/integrationButton';
+
+describe('AddIntegrationButton', function () {
+  let org: Organization, provider: IntegrationProvider;
+  const project = ProjectFixture();
+
+  beforeEach(function () {
+    provider = GitHubIntegrationProviderFixture();
+    org = OrganizationFixture();
+  });
+
+  it('Opens the setup dialog on click', async function () {
+    const focus = jest.fn();
+    const open = jest.fn().mockReturnValue({focus, close: jest.fn()});
+    // any is needed here because getSentry has different types for global
+    (global as any).open = open;
+
+    render(
+      <IntegrationButton
+        onAddIntegration={jest.fn()}
+        onExternalClick={jest.fn()}
+        organization={org}
+        project={project}
+        provider={provider}
+      />
+    );
+
+    await userEvent.click(screen.getByLabelText('Add Installation'));
+    expect(open.mock.calls).toHaveLength(1);
+    expect(focus.mock.calls).toHaveLength(1);
+    expect(open.mock.calls[0][2]).toBe(
+      'scrollbars=yes,width=100,height=100,top=334,left=462'
+    );
+  });
+
+  it.only('Renders request button when user does not have access', async function () {
+    org.access = ['org:read'];
+    const newOrg = OrganizationFixture({access: ['org:read']});
+
+    render(
+      <IntegrationButton
+        onAddIntegration={jest.fn()}
+        onExternalClick={jest.fn()}
+        organization={newOrg}
+        project={project}
+        provider={provider}
+      />
+    );
+
+    await userEvent.click(screen.getByLabelText('Request Installation'));
+  });
+
+  it('Handles external installations', async function () {
+    provider.metadata.aspects = {
+      externalInstall: {
+        url: 'https://teams.microsoft.com/l/app/',
+        buttonText: 'Teams Marketplace',
+        noticeText:
+          'Visit the Teams Marketplace to install this integration. After adding the integration to your team, you will get a welcome message in the General channel to complete installation.',
+      },
+    };
+
+    render(
+      <IntegrationButton
+        onAddIntegration={jest.fn()}
+        onExternalClick={jest.fn()}
+        organization={org}
+        project={project}
+        provider={provider}
+      />
+    );
+
+    console.log(org.access);
+    await userEvent.click(screen.getByLabelText('Add Installation'));
+  });
+});

--- a/static/app/views/settings/organizationIntegrations/integrationButton.spec.tsx
+++ b/static/app/views/settings/organizationIntegrations/integrationButton.spec.tsx
@@ -28,8 +28,6 @@ describe('AddIntegrationButton', function () {
       value={{
         provider: provider,
         type: 'first_party',
-        organization: org,
-        userHasAccess: hasAccess,
         installStatus: 'Not Installed',
         analyticsParams: {
           view: 'onboarding',
@@ -39,6 +37,8 @@ describe('AddIntegrationButton', function () {
       }}
     >
       <IntegrationButton
+        organization={org}
+        userHasAccess={hasAccess}
         onAddIntegration={jest.fn()}
         onExternalClick={jest.fn()}
         externalInstallText={externalInstallText}

--- a/static/app/views/settings/organizationIntegrations/integrationButton.spec.tsx
+++ b/static/app/views/settings/organizationIntegrations/integrationButton.spec.tsx
@@ -30,10 +30,10 @@ describe('AddIntegrationButton', function () {
         organization={org}
         project={project}
         provider={provider}
+        buttonProps={null}
       />
     );
-
-    await userEvent.click(screen.getByLabelText('Add Installation'));
+    await userEvent.click(screen.getByText(/add installation/i));
     expect(open.mock.calls).toHaveLength(1);
     expect(focus.mock.calls).toHaveLength(1);
     expect(open.mock.calls[0][2]).toBe(
@@ -41,7 +41,7 @@ describe('AddIntegrationButton', function () {
     );
   });
 
-  it.only('Renders request button when user does not have access', async function () {
+  it('Renders request button when user does not have access', async function () {
     org.access = ['org:read'];
     const newOrg = OrganizationFixture({access: ['org:read']});
 
@@ -52,10 +52,11 @@ describe('AddIntegrationButton', function () {
         organization={newOrg}
         project={project}
         provider={provider}
+        buttonProps={null}
       />
     );
 
-    await userEvent.click(screen.getByLabelText('Request Installation'));
+    await userEvent.click(screen.getByText('Request Installation'));
   });
 
   it('Handles external installations', async function () {
@@ -75,10 +76,11 @@ describe('AddIntegrationButton', function () {
         organization={org}
         project={project}
         provider={provider}
+        buttonProps={null}
       />
     );
 
     console.log(org.access);
-    await userEvent.click(screen.getByLabelText('Add Installation'));
+    await userEvent.click(screen.getByText(/add installation/i));
   });
 });

--- a/static/app/views/settings/organizationIntegrations/integrationButton.spec.tsx
+++ b/static/app/views/settings/organizationIntegrations/integrationButton.spec.tsx
@@ -4,9 +4,10 @@ import {ProjectFixture} from 'sentry-fixture/project';
 
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
-import type {IntegrationProvider} from 'sentry/types';
+import type {IntegrationProvider} from 'sentry/types/integrations';
 import type {Organization} from 'sentry/types/organization';
 import IntegrationButton from 'sentry/views/settings/organizationIntegrations/integrationButton';
+import {IntegrationContext} from 'sentry/views/settings/organizationIntegrations/integrationContext';
 
 describe('AddIntegrationButton', function () {
   let org: Organization,
@@ -23,22 +24,27 @@ describe('AddIntegrationButton', function () {
   });
 
   const getComponent = () => (
-    <IntegrationButton
-      onAddIntegration={jest.fn()}
-      onExternalClick={jest.fn()}
-      organization={org}
-      provider={provider}
-      type="first_party"
-      userHasAccess={hasAccess}
-      installStatus="Not Installed"
-      analyticsParams={{
-        view: 'onboarding',
-        already_installed: false,
+    <IntegrationContext.Provider
+      value={{
+        provider: provider,
+        type: 'first_party',
+        organization: org,
+        userHasAccess: hasAccess,
+        installStatus: 'Not Installed',
+        analyticsParams: {
+          view: 'onboarding',
+          already_installed: false,
+        },
+        modalParams: {project: project.id},
       }}
-      externalInstallText={externalInstallText}
-      modalParams={{project: project.id}}
-      buttonProps={null}
-    />
+    >
+      <IntegrationButton
+        onAddIntegration={jest.fn()}
+        onExternalClick={jest.fn()}
+        externalInstallText={externalInstallText}
+        buttonProps={null}
+      />
+    </IntegrationContext.Provider>
   );
 
   it('Opens the setup dialog on click', async function () {

--- a/static/app/views/settings/organizationIntegrations/integrationButton.spec.tsx
+++ b/static/app/views/settings/organizationIntegrations/integrationButton.spec.tsx
@@ -3,9 +3,9 @@ import {OrganizationFixture} from 'sentry-fixture/organization';
 import {ProjectFixture} from 'sentry-fixture/project';
 
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
-import {IntegrationProvider} from 'sentry/types';
-import {Organization} from 'sentry/types/organization';
 
+import type {IntegrationProvider} from 'sentry/types';
+import type {Organization} from 'sentry/types/organization';
 import IntegrationButton from 'sentry/views/settings/organizationIntegrations/integrationButton';
 
 describe('AddIntegrationButton', function () {

--- a/static/app/views/settings/organizationIntegrations/integrationButton.tsx
+++ b/static/app/views/settings/organizationIntegrations/integrationButton.tsx
@@ -1,10 +1,10 @@
-import {Project} from 'sentry/types/project';
-import {Organization} from 'sentry/types/organization';
-import {IntegrationProvider} from 'sentry/types/integrations';
-import {AddIntegrationButton} from 'sentry/views/settings/organizationIntegrations/addIntegrationButton';
-import {Button} from 'sentry/components/button';
-import RequestIntegrationButton from 'sentry/views/settings/organizationIntegrations/integrationRequest/RequestIntegrationButton';
 import Access from 'sentry/components/acl/access';
+import {Button} from 'sentry/components/button';
+import type {IntegrationProvider} from 'sentry/types/integrations';
+import type {Organization} from 'sentry/types/organization';
+import type {Project} from 'sentry/types/project';
+import {AddIntegrationButton} from 'sentry/views/settings/organizationIntegrations/addIntegrationButton';
+import RequestIntegrationButton from 'sentry/views/settings/organizationIntegrations/integrationRequest/RequestIntegrationButton';
 
 type Props = {
   onAddIntegration: () => void;

--- a/static/app/views/settings/organizationIntegrations/integrationButton.tsx
+++ b/static/app/views/settings/organizationIntegrations/integrationButton.tsx
@@ -1,35 +1,17 @@
-import {Fragment} from 'react';
+import {useContext} from 'react';
 
 import {Button} from 'sentry/components/button';
 import {IconOpen} from 'sentry/icons';
-import type {
-  Integration,
-  IntegrationProvider,
-  IntegrationType,
-} from 'sentry/types/integrations';
-import type {Organization} from 'sentry/types/organization';
+import type {Integration} from 'sentry/types/integrations';
 import {AddIntegrationButton} from 'sentry/views/settings/organizationIntegrations/addIntegrationButton';
+import {IntegrationContext} from 'sentry/views/settings/organizationIntegrations/integrationContext';
 import RequestIntegrationButton from 'sentry/views/settings/organizationIntegrations/integrationRequest/RequestIntegrationButton';
 
 type Props = {
-  analyticsParams: {
-    already_installed: boolean;
-    view:
-      | 'integrations_directory_integration_detail'
-      | 'integrations_directory'
-      | 'onboarding'
-      | 'project_creation';
-  };
   buttonProps: ButtonProps;
-  installStatus: string;
   onAddIntegration: (integration: Integration) => void;
   onExternalClick: () => void;
-  organization: Organization;
-  provider: IntegrationProvider;
-  type: IntegrationType;
-  userHasAccess: boolean;
   externalInstallText?: string;
-  modalParams?: {[key: string]: string};
 };
 
 type ButtonProps = {
@@ -42,16 +24,22 @@ type ButtonProps = {
 function IntegrationButton({
   onAddIntegration,
   onExternalClick,
-  organization,
-  provider,
-  type,
-  userHasAccess,
-  installStatus,
-  analyticsParams,
   externalInstallText,
-  modalParams = {},
   buttonProps,
 }: Props) {
+  const integration = useContext(IntegrationContext);
+  if (!integration) {
+    return null;
+  }
+  const {
+    provider,
+    type,
+    organization,
+    userHasAccess,
+    installStatus,
+    analyticsParams,
+    modalParams,
+  } = integration;
   const {metadata} = provider;
 
   if (!userHasAccess) {
@@ -92,7 +80,7 @@ function IntegrationButton({
       </Button>
     );
   }
-  return <Fragment />;
+  return null;
 }
 
 export default IntegrationButton;

--- a/static/app/views/settings/organizationIntegrations/integrationButton.tsx
+++ b/static/app/views/settings/organizationIntegrations/integrationButton.tsx
@@ -32,11 +32,9 @@ function IntegrationButton({
   externalInstallText,
   buttonProps,
 }: Props) {
-  const integration = useContext(IntegrationContext);
-  if (!integration) {
-    return null;
-  }
-  const {provider, type, installStatus, analyticsParams, modalParams} = integration;
+  const {provider, type, installStatus, analyticsParams, modalParams} =
+    useContext(IntegrationContext) ?? {};
+  if (!provider || !type) return null;
   const {metadata} = provider;
 
   if (!userHasAccess) {

--- a/static/app/views/settings/organizationIntegrations/integrationButton.tsx
+++ b/static/app/views/settings/organizationIntegrations/integrationButton.tsx
@@ -2,8 +2,8 @@ import {useContext} from 'react';
 
 import {Button} from 'sentry/components/button';
 import {IconOpen} from 'sentry/icons';
-import type {Organization} from 'sentry/types/organization';
 import type {Integration} from 'sentry/types/integrations';
+import type {Organization} from 'sentry/types/organization';
 import {AddIntegrationButton} from 'sentry/views/settings/organizationIntegrations/addIntegrationButton';
 import {IntegrationContext} from 'sentry/views/settings/organizationIntegrations/integrationContext';
 import RequestIntegrationButton from 'sentry/views/settings/organizationIntegrations/integrationRequest/RequestIntegrationButton';

--- a/static/app/views/settings/organizationIntegrations/integrationButton.tsx
+++ b/static/app/views/settings/organizationIntegrations/integrationButton.tsx
@@ -2,6 +2,7 @@ import {useContext} from 'react';
 
 import {Button} from 'sentry/components/button';
 import {IconOpen} from 'sentry/icons';
+import type {Organization} from 'sentry/types/organization';
 import type {Integration} from 'sentry/types/integrations';
 import {AddIntegrationButton} from 'sentry/views/settings/organizationIntegrations/addIntegrationButton';
 import {IntegrationContext} from 'sentry/views/settings/organizationIntegrations/integrationContext';
@@ -11,6 +12,8 @@ type Props = {
   buttonProps: ButtonProps;
   onAddIntegration: (integration: Integration) => void;
   onExternalClick: () => void;
+  organization: Organization;
+  userHasAccess: boolean;
   externalInstallText?: string;
 };
 
@@ -22,6 +25,8 @@ type ButtonProps = {
 } | null;
 
 function IntegrationButton({
+  organization,
+  userHasAccess,
   onAddIntegration,
   onExternalClick,
   externalInstallText,
@@ -31,15 +36,7 @@ function IntegrationButton({
   if (!integration) {
     return null;
   }
-  const {
-    provider,
-    type,
-    organization,
-    userHasAccess,
-    installStatus,
-    analyticsParams,
-    modalParams,
-  } = integration;
+  const {provider, type, installStatus, analyticsParams, modalParams} = integration;
   const {metadata} = provider;
 
   if (!userHasAccess) {

--- a/static/app/views/settings/organizationIntegrations/integrationButton.tsx
+++ b/static/app/views/settings/organizationIntegrations/integrationButton.tsx
@@ -1,0 +1,72 @@
+import {Project} from 'sentry/types/project';
+import {Organization} from 'sentry/types/organization';
+import {IntegrationProvider} from 'sentry/types/integrations';
+import {AddIntegrationButton} from 'sentry/views/settings/organizationIntegrations/addIntegrationButton';
+import {Button} from 'sentry/components/button';
+import RequestIntegrationButton from 'sentry/views/settings/organizationIntegrations/integrationRequest/RequestIntegrationButton';
+import Access from 'sentry/components/acl/access';
+
+type Props = {
+  onAddIntegration: () => void;
+  onExternalClick: () => void;
+  organization: Organization;
+  project: Project;
+  provider: IntegrationProvider;
+};
+
+function IntegrationButton({
+  onAddIntegration,
+  onExternalClick,
+  organization,
+  project,
+  provider,
+}: Props) {
+  const {metadata} = provider;
+
+  const buttonProps = {
+    size: 'sm' as const,
+    priority: 'primary' as const,
+    'data-test-id': 'install-button',
+    // disabled: disabledFromFeatures,
+    organization,
+  };
+  return (
+    <Access access={['org:integrations']}>
+      {({hasAccess}) => {
+        if (!hasAccess) {
+          return (
+            <RequestIntegrationButton
+              organization={organization}
+              name={provider.name}
+              slug={provider.slug}
+              type={'sentry_app'}
+            />
+          );
+        }
+        if (metadata.aspects.externalInstall) {
+          return (
+            <Button
+              href={metadata.aspects.externalInstall.url}
+              onClick={() => onExternalClick}
+              external
+              {...buttonProps}
+            >
+              Add Installation
+            </Button>
+          );
+        }
+        return (
+          <AddIntegrationButton
+            provider={provider}
+            onAddIntegration={onAddIntegration}
+            analyticsParams={{view: 'onboarding', already_installed: false}}
+            modalParams={{projectId: project.id}}
+            {...buttonProps}
+          />
+        );
+      }}
+    </Access>
+  );
+}
+
+export default IntegrationButton;

--- a/static/app/views/settings/organizationIntegrations/integrationButton.tsx
+++ b/static/app/views/settings/organizationIntegrations/integrationButton.tsx
@@ -12,7 +12,15 @@ type Props = {
   organization: Organization;
   project: Project;
   provider: IntegrationProvider;
+  buttonProps: buttonProps;
 };
+
+type buttonProps = {
+  style?;
+  size?;
+  priority?;
+  disabled?;
+} | null;
 
 function IntegrationButton({
   onAddIntegration,
@@ -20,18 +28,19 @@ function IntegrationButton({
   organization,
   project,
   provider,
+  buttonProps,
 }: Props) {
   const {metadata} = provider;
 
-  const buttonProps = {
-    size: 'sm' as const,
-    priority: 'primary' as const,
-    'data-test-id': 'install-button',
-    // disabled: disabledFromFeatures,
-    organization,
-  };
+  // const buttonProps = {
+  //   size: 'sm' as const,
+  //   priority: 'primary' as const,
+  //   'data-test-id': 'install-button',
+  //   // disabled: disabledFromFeatures,
+  //   organization,
+  // };
   return (
-    <Access access={['org:integrations']}>
+    <Access access={['org:integrations']} organization={organization}>
       {({hasAccess}) => {
         if (!hasAccess) {
           return (
@@ -61,6 +70,7 @@ function IntegrationButton({
             onAddIntegration={onAddIntegration}
             analyticsParams={{view: 'onboarding', already_installed: false}}
             modalParams={{projectId: project.id}}
+            organization={organization}
             {...buttonProps}
           />
         );

--- a/static/app/views/settings/organizationIntegrations/integrationContext.tsx
+++ b/static/app/views/settings/organizationIntegrations/integrationContext.tsx
@@ -1,7 +1,6 @@
 import {createContext} from 'react';
 
 import type {IntegrationProvider, IntegrationType} from 'sentry/types/integrations';
-import type {Organization} from 'sentry/types/organization';
 
 export type IntegrationContextProps = {
   analyticsParams: {
@@ -13,10 +12,8 @@ export type IntegrationContextProps = {
       | 'project_creation';
   };
   installStatus: string;
-  organization: Organization;
   provider: IntegrationProvider;
   type: IntegrationType;
-  userHasAccess: boolean;
   modalParams?: {[key: string]: string};
 };
 

--- a/static/app/views/settings/organizationIntegrations/integrationContext.tsx
+++ b/static/app/views/settings/organizationIntegrations/integrationContext.tsx
@@ -1,0 +1,25 @@
+import {createContext} from 'react';
+
+import type {IntegrationProvider, IntegrationType} from 'sentry/types/integrations';
+import type {Organization} from 'sentry/types/organization';
+
+export type IntegrationContextProps = {
+  analyticsParams: {
+    already_installed: boolean;
+    view:
+      | 'integrations_directory_integration_detail'
+      | 'integrations_directory'
+      | 'onboarding'
+      | 'project_creation';
+  };
+  installStatus: string;
+  organization: Organization;
+  provider: IntegrationProvider;
+  type: IntegrationType;
+  userHasAccess: boolean;
+  modalParams?: {[key: string]: string};
+};
+
+export const IntegrationContext = createContext<IntegrationContextProps | undefined>(
+  undefined
+);

--- a/static/app/views/settings/organizationIntegrations/integrationDetailedView.tsx
+++ b/static/app/views/settings/organizationIntegrations/integrationDetailedView.tsx
@@ -254,8 +254,6 @@ class IntegrationDetailedView extends AbstractIntegrationDetailedView<
         value={{
           provider: provider,
           type: this.integrationType,
-          organization: organization,
-          userHasAccess: userHasAccess,
           installStatus: this.installationStatus,
           analyticsParams: {
             view: 'integrations_directory_integration_detail',
@@ -264,6 +262,8 @@ class IntegrationDetailedView extends AbstractIntegrationDetailedView<
         }}
       >
         <StyledIntegrationButton
+          organization={organization}
+          userHasAccess={userHasAccess}
           onAddIntegration={this.onInstall}
           onExternalClick={this.handleExternalInstall}
           buttonProps={buttonProps}

--- a/static/app/views/settings/organizationIntegrations/integrationDetailedView.tsx
+++ b/static/app/views/settings/organizationIntegrations/integrationDetailedView.tsx
@@ -4,7 +4,6 @@ import styled from '@emotion/styled';
 import {addErrorMessage} from 'sentry/actionCreators/indicator';
 import type {RequestOptions} from 'sentry/api';
 import {Alert} from 'sentry/components/alert';
-import {Button} from 'sentry/components/button';
 import type DeprecatedAsyncComponent from 'sentry/components/deprecatedAsyncComponent';
 import Form from 'sentry/components/forms/form';
 import JsonForm from 'sentry/components/forms/jsonForm';
@@ -12,7 +11,6 @@ import type {Data, JsonFormObject} from 'sentry/components/forms/types';
 import HookOrDefault from 'sentry/components/hookOrDefault';
 import Panel from 'sentry/components/panels/panel';
 import PanelItem from 'sentry/components/panels/panelItem';
-import {IconOpen} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {Integration, IntegrationProvider, ObjectStatus} from 'sentry/types';
@@ -20,10 +18,10 @@ import {getAlertText, getIntegrationStatus} from 'sentry/utils/integrationUtil';
 import normalizeUrl from 'sentry/utils/url/normalizeUrl';
 import withOrganization from 'sentry/utils/withOrganization';
 import BreadcrumbTitle from 'sentry/views/settings/components/settingsBreadcrumb/breadcrumbTitle';
+import IntegrationButton from 'sentry/views/settings/organizationIntegrations/integrationButton';
 
 import type {Tab} from './abstractIntegrationDetailedView';
 import AbstractIntegrationDetailedView from './abstractIntegrationDetailedView';
-import {AddIntegrationButton} from './addIntegrationButton';
 import InstalledIntegration from './installedIntegration';
 
 // Show the features tab if the org has features for the integration
@@ -242,54 +240,31 @@ class IntegrationDetailedView extends AbstractIntegrationDetailedView<
   renderTopButton(disabledFromFeatures: boolean, userHasAccess: boolean) {
     const {organization} = this.props;
     const provider = this.provider;
-    const {metadata} = provider;
-
-    const size = 'sm' as const;
-    const priority = 'primary' as const;
 
     const buttonProps = {
       style: {marginBottom: space(1)},
-      size,
-      priority,
+      size: 'sm' as const,
+      priority: 'primary' as const,
       'data-test-id': 'install-button',
       disabled: disabledFromFeatures,
-      organization,
     };
 
-    if (!userHasAccess) {
-      return this.renderRequestIntegrationButton();
-    }
-
-    if (provider.canAdd) {
-      return (
-        <AddIntegrationButton
-          provider={provider}
-          onAddIntegration={this.onInstall}
-          installStatus={this.installationStatus}
-          analyticsParams={{
-            view: 'integrations_directory_integration_detail',
-            already_installed: this.installationStatus !== 'Not Installed',
-          }}
-          {...buttonProps}
-        />
-      );
-    }
-    if (metadata.aspects.externalInstall) {
-      return (
-        <Button
-          icon={<IconOpen />}
-          href={metadata.aspects.externalInstall.url}
-          onClick={this.handleExternalInstall}
-          external
-          {...buttonProps}
-        >
-          {metadata.aspects.externalInstall.buttonText}
-        </Button>
-      );
-    }
-
-    // This should never happen but we can't return undefined without some refactoring.
-    return <Fragment />;
+    return (
+      <IntegrationButton
+        onAddIntegration={this.onInstall}
+        onExternalClick={this.handleExternalInstall}
+        organization={organization}
+        provider={provider}
+        type={this.integrationType}
+        userHasAccess={userHasAccess}
+        installStatus={this.installationStatus}
+        analyticsParams={{
+          view: 'integrations_directory_integration_detail',
+          already_installed: this.installationStatus !== 'Not Installed',
+        }}
+        buttonProps={buttonProps}
+      />
+    );
   }
 
   renderConfigurations() {

--- a/static/app/views/settings/organizationIntegrations/integrationDetailedView.tsx
+++ b/static/app/views/settings/organizationIntegrations/integrationDetailedView.tsx
@@ -19,6 +19,7 @@ import normalizeUrl from 'sentry/utils/url/normalizeUrl';
 import withOrganization from 'sentry/utils/withOrganization';
 import BreadcrumbTitle from 'sentry/views/settings/components/settingsBreadcrumb/breadcrumbTitle';
 import IntegrationButton from 'sentry/views/settings/organizationIntegrations/integrationButton';
+import {IntegrationContext} from 'sentry/views/settings/organizationIntegrations/integrationContext';
 
 import type {Tab} from './abstractIntegrationDetailedView';
 import AbstractIntegrationDetailedView from './abstractIntegrationDetailedView';
@@ -242,28 +243,32 @@ class IntegrationDetailedView extends AbstractIntegrationDetailedView<
     const provider = this.provider;
 
     const buttonProps = {
-      style: {marginBottom: space(1)},
-      size: 'sm' as const,
-      priority: 'primary' as const,
+      size: 'sm',
+      priority: 'primary',
       'data-test-id': 'install-button',
       disabled: disabledFromFeatures,
     };
 
     return (
-      <IntegrationButton
-        onAddIntegration={this.onInstall}
-        onExternalClick={this.handleExternalInstall}
-        organization={organization}
-        provider={provider}
-        type={this.integrationType}
-        userHasAccess={userHasAccess}
-        installStatus={this.installationStatus}
-        analyticsParams={{
-          view: 'integrations_directory_integration_detail',
-          already_installed: this.installationStatus !== 'Not Installed',
+      <IntegrationContext.Provider
+        value={{
+          provider: provider,
+          type: this.integrationType,
+          organization: organization,
+          userHasAccess: userHasAccess,
+          installStatus: this.installationStatus,
+          analyticsParams: {
+            view: 'integrations_directory_integration_detail',
+            already_installed: this.installationStatus !== 'Not Installed',
+          },
         }}
-        buttonProps={buttonProps}
-      />
+      >
+        <StyledIntegrationButton
+          onAddIntegration={this.onInstall}
+          onExternalClick={this.handleExternalInstall}
+          buttonProps={buttonProps}
+        />
+      </IntegrationContext.Provider>
     );
   }
 
@@ -461,7 +466,10 @@ class IntegrationDetailedView extends AbstractIntegrationDetailedView<
 }
 
 export default withOrganization(IntegrationDetailedView);
-
 const CapitalizedLink = styled('a')`
   text-transform: capitalize;
+`;
+
+const StyledIntegrationButton = styled(IntegrationButton)`
+  margin-bottom: ${space(1)};
 `;


### PR DESCRIPTION
refactored `renderTopButton` method from `integrationsDetailedView` to be a separate shared `IntegrationButton` component which renders the appropriate button (add integration, request installation, or external installation)