### PR TITLE
fix(loader): Update wording for default config

### DIFF
--- a/static/app/views/settings/project/projectKeys/details/loaderSettings.tsx
+++ b/static/app/views/settings/project/projectKeys/details/loaderSettings.tsx
@@ -198,7 +198,7 @@ export function LoaderSettings({keyId, orgSlug, project, data, updateData}: Prop
                 ? t('Only available in SDK version 7.x and above')
                 : data.dynamicSdkLoaderOptions.hasPerformance
                   ? tct(
-                      'The default configurations are [codeTracesSampleRate:tracesSampleRate: 1.0] and distributed tracing to same-origin requests. [configDocs:Read the docs] to learn how to configure this.',
+                      'The default config is [codeTracesSampleRate:tracesSampleRate: 1.0] and distributed tracing to same-origin requests. [configDocs:Read the docs] to learn how to configure this.',
                       {
                         codeTracesSampleRate: <code />,
                         configDocs: (
@@ -236,7 +236,7 @@ export function LoaderSettings({keyId, orgSlug, project, data, updateData}: Prop
                 ? t('Only available in SDK version 7.x and above')
                 : data.dynamicSdkLoaderOptions.hasReplay
                   ? tct(
-                      `[es5Warning]The default configurations are [codeReplay:replaysSessionSampleRate: 0.1] and [codeError:replaysOnErrorSampleRate: 1]. [configDocs:Read the docs] to learn how to configure this.`,
+                      `[es5Warning]The default config is [codeReplay:replaysSessionSampleRate: 0.1] and [codeError:replaysOnErrorSampleRate: 1]. [configDocs:Read the docs] to learn how to configure this.`,
                       {
                         es5Warning:
                           // latest is deprecated but resolves to v7


### PR DESCRIPTION
I noticed that we use the wording `The default configurations` which I believe is not correct, as configuration is uncountable 🤔 So I'd reword this to use singular. I also changed it to `config` because this way the text fits nicely on the line:

![image](https://github.com/user-attachments/assets/54fb51a7-8400-4cd0-9142-d9c7e8c512cb)