### PR TITLE
fix(metrics): wrap span metric alerts formatting in try/except for model DoesNotExist

### DIFF
--- a/src/sentry/snuba/metrics/naming_layer/mri.py
+++ b/src/sentry/snuba/metrics/naming_layer/mri.py
@@ -264,9 +264,12 @@ def format_mri_field(field: str) -> str:
 
         if parsed:
             if condition_id := parsed.mri.span_attribute_rule_id:
-                condition = SpanAttributeExtractionRuleCondition.objects.get(id=condition_id)
-                config = condition.config
-                return f'{parsed.op}({config.span_attribute}) filtered by "{condition.value}"'
+                try:
+                    condition = SpanAttributeExtractionRuleCondition.objects.get(id=condition_id)
+                    config = condition.config
+                    return f'{parsed.op}({config.span_attribute}) filtered by "{condition.value}"'
+                except SpanAttributeExtractionRuleCondition.DoesNotExist:
+                    return field
 
             return str(parsed)
 
@@ -291,8 +294,12 @@ def format_mri_field_value(field: str, value: str) -> str:
             return value
 
         if condition_id := parsed_mri_field.mri.span_attribute_rule_id:
-            condition = SpanAttributeExtractionRuleCondition.objects.get(id=condition_id)
-            unit = cast(MetricUnit, condition.config.unit)
+            try:
+                condition = SpanAttributeExtractionRuleCondition.objects.get(id=condition_id)
+                unit = cast(MetricUnit, condition.config.unit)
+            except SpanAttributeExtractionRuleCondition.DoesNotExist:
+                return value
+
         else:
             unit = cast(MetricUnit, parsed_mri_field.mri.unit)
 

--- a/src/sentry/snuba/metrics/naming_layer/mri.py
+++ b/src/sentry/snuba/metrics/naming_layer/mri.py
@@ -38,6 +38,7 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import cast
 
+import sentry_sdk
 from sentry_kafka_schemas.codecs import ValidationError
 
 from sentry.exceptions import InvalidParams
@@ -269,6 +270,11 @@ def format_mri_field(field: str) -> str:
                     config = condition.config
                     return f'{parsed.op}({config.span_attribute}) filtered by "{condition.value}"'
                 except SpanAttributeExtractionRuleCondition.DoesNotExist:
+                    with sentry_sdk.push_scope() as scope:
+                        scope.set_tag("field", field)
+                        sentry_sdk.capture_message(
+                            "Trying to format MRI field for non-existent span metric."
+                        )
                     return field
 
             return str(parsed)
@@ -298,6 +304,11 @@ def format_mri_field_value(field: str, value: str) -> str:
                 condition = SpanAttributeExtractionRuleCondition.objects.get(id=condition_id)
                 unit = cast(MetricUnit, condition.config.unit)
             except SpanAttributeExtractionRuleCondition.DoesNotExist:
+                with sentry_sdk.push_scope() as scope:
+                    scope.set_tag("field", field)
+                    sentry_sdk.capture_message(
+                        "Trying to format MRI field for non-existent span metric."
+                    )
                 return value
 
         else:

--- a/tests/snuba/metrics/naming_layer/test_mri.py
+++ b/tests/snuba/metrics/naming_layer/test_mri.py
@@ -67,3 +67,29 @@ class TestMRIUtils(TestCase):
             format_mri_field_value(f"avg(c:custom/span_attribute_{condition_id}@none)", "1000")
             == "1 s"
         )
+
+    def test_span_metric_does_not_exist(self):
+        config = {
+            "spanAttribute": "my_duration",
+            "aggregates": ["avg", "min", "max", "sum"],
+            "unit": "millisecond",
+            "tags": [],
+            "conditions": [
+                {"value": "browser.name:Chrome or browser.name:Firefox"},
+            ],
+        }
+        project = self.create_project(organization=self.organization, name="my new project")
+        self.create_span_attribute_extraction_config(
+            dictionary=config, user_id=self.user.id, project=project
+        )
+        non_existent_id = 65537
+
+        assert (
+            format_mri_field_value(f"avg(c:custom/span_attribute_{non_existent_id}@none)", "1000")
+            == "1000"
+        )
+
+        assert (
+            format_mri_field(f"avg(c:custom/span_attribute_{non_existent_id}@none)")
+            == f"avg(c:custom/span_attribute_{non_existent_id}@none)"
+        )


### PR DESCRIPTION
Fixes [SENTRY-3CCT](https://sentry.sentry.io/issues/5642599130/)
Fixes [SENTRY-3CCV](https://sentry.sentry.io/issues/5642599365/)
