### PR TITLE
ref(ddm): Add an option to disable legacy metrics

### DIFF
--- a/src/sentry/metrics/minimetrics.py
+++ b/src/sentry/metrics/minimetrics.py
@@ -140,6 +140,10 @@ class MiniMetricsMetricsBackend(MetricsBackend):
         return random.random() < sample_rate
 
     @staticmethod
+    def _legacy_enabled() -> bool:
+        return not options.get("delightful_metrics.minimetrics_disable_legacy")
+
+    @staticmethod
     def _to_minimetrics_unit(unit: str | None, default: str | None = None) -> str:
         if unit is None:
             if default is not None:
@@ -160,13 +164,14 @@ class MiniMetricsMetricsBackend(MetricsBackend):
         stacklevel: int = 0,
     ) -> None:
         if self._keep_metric(sample_rate):
-            sentry_sdk.metrics.incr(
-                key=self._get_key(key),
-                value=amount,
-                tags=tags,
-                unit=self._to_minimetrics_unit(unit=unit),
-                stacklevel=stacklevel + 1,
-            )
+            if self._legacy_enabled():
+                sentry_sdk.metrics.incr(
+                    key=self._get_key(key),
+                    value=amount,
+                    tags=tags,
+                    unit=self._to_minimetrics_unit(unit=unit),
+                    stacklevel=stacklevel + 1,
+                )
 
             _set_metric_on_span(key=key, value=amount, op="incr", tags=tags)
 
@@ -180,14 +185,15 @@ class MiniMetricsMetricsBackend(MetricsBackend):
         stacklevel: int = 0,
     ) -> None:
         if self._keep_metric(sample_rate):
-            sentry_sdk.metrics.distribution(
-                key=self._get_key(key),
-                value=value,
-                tags=tags,
-                # Timing is defaulted to seconds.
-                unit="second",
-                stacklevel=stacklevel + 1,
-            )
+            if self._legacy_enabled():
+                sentry_sdk.metrics.distribution(
+                    key=self._get_key(key),
+                    value=value,
+                    tags=tags,
+                    # Timing is defaulted to seconds.
+                    unit="second",
+                    stacklevel=stacklevel + 1,
+                )
 
             _set_metric_on_span(key=key, value=value, op="timing", tags=tags)
 
@@ -202,22 +208,23 @@ class MiniMetricsMetricsBackend(MetricsBackend):
         stacklevel: int = 0,
     ) -> None:
         if self._keep_metric(sample_rate):
-            if options.get("delightful_metrics.emit_gauges"):
-                sentry_sdk.metrics.gauge(
-                    key=self._get_key(key),
-                    value=value,
-                    tags=tags,
-                    unit=self._to_minimetrics_unit(unit=unit),
-                    stacklevel=stacklevel + 1,
-                )
-            else:
-                sentry_sdk.metrics.incr(
-                    key=self._get_key(key),
-                    value=value,
-                    tags=tags,
-                    unit=self._to_minimetrics_unit(unit=unit),
-                    stacklevel=stacklevel + 1,
-                )
+            if self._legacy_enabled():
+                if options.get("delightful_metrics.emit_gauges"):
+                    sentry_sdk.metrics.gauge(
+                        key=self._get_key(key),
+                        value=value,
+                        tags=tags,
+                        unit=self._to_minimetrics_unit(unit=unit),
+                        stacklevel=stacklevel + 1,
+                    )
+                else:
+                    sentry_sdk.metrics.incr(
+                        key=self._get_key(key),
+                        value=value,
+                        tags=tags,
+                        unit=self._to_minimetrics_unit(unit=unit),
+                        stacklevel=stacklevel + 1,
+                    )
 
             _set_metric_on_span(key=key, value=value, op="gauge", tags=tags)
 
@@ -232,13 +239,14 @@ class MiniMetricsMetricsBackend(MetricsBackend):
         stacklevel: int = 0,
     ) -> None:
         if self._keep_metric(sample_rate):
-            sentry_sdk.metrics.distribution(
-                key=self._get_key(key),
-                value=value,
-                tags=tags,
-                unit=self._to_minimetrics_unit(unit=unit),
-                stacklevel=stacklevel + 1,
-            )
+            if self._legacy_enabled():
+                sentry_sdk.metrics.distribution(
+                    key=self._get_key(key),
+                    value=value,
+                    tags=tags,
+                    unit=self._to_minimetrics_unit(unit=unit),
+                    stacklevel=stacklevel + 1,
+                )
 
             _set_metric_on_span(key=key, value=value, op="distribution", tags=tags)
 

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -2054,6 +2054,12 @@ register(
 )
 
 register(
+    "delightful_metrics.minimetrics_disable_legacy",
+    default=False,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+
+register(
     "delightful_metrics.enable_capture_envelope",
     default=False,
     flags=FLAG_AUTOMATOR_MODIFIABLE,

--- a/tests/sentry/metrics/test_minimetrics.py
+++ b/tests/sentry/metrics/test_minimetrics.py
@@ -110,6 +110,7 @@ def backend():
         "delightful_metrics.enable_common_tags": True,
         "delightful_metrics.enable_code_locations": True,
         "delightful_metrics.enable_span_attributes": False,
+        "delightful_metrics.minimetrics_disable_legacy": False,
     }
 )
 def test_incr_called_with_no_tags(backend, scope):
@@ -135,6 +136,7 @@ def test_incr_called_with_no_tags(backend, scope):
         "delightful_metrics.enable_common_tags": False,
         "delightful_metrics.enable_code_locations": True,
         "delightful_metrics.enable_span_attributes": False,
+        "delightful_metrics.minimetrics_disable_legacy": False,
     }
 )
 def test_incr_called_with_no_tags_and_no_common_tags(backend, scope):
@@ -160,6 +162,7 @@ def test_incr_called_with_no_tags_and_no_common_tags(backend, scope):
         "delightful_metrics.enable_common_tags": True,
         "delightful_metrics.enable_code_locations": True,
         "delightful_metrics.enable_span_attributes": False,
+        "delightful_metrics.minimetrics_disable_legacy": False,
     }
 )
 def test_incr_called_with_tag_value_as_list(backend, scope):
@@ -183,6 +186,7 @@ def test_incr_called_with_tag_value_as_list(backend, scope):
         "delightful_metrics.emit_gauges": False,
         "delightful_metrics.enable_code_locations": True,
         "delightful_metrics.enable_span_attributes": False,
+        "delightful_metrics.minimetrics_disable_legacy": False,
     }
 )
 def test_gauge_as_count(backend, scope):
@@ -207,6 +211,7 @@ def test_gauge_as_count(backend, scope):
         "delightful_metrics.emit_gauges": True,
         "delightful_metrics.enable_code_locations": True,
         "delightful_metrics.enable_span_attributes": False,
+        "delightful_metrics.minimetrics_disable_legacy": False,
     }
 )
 def test_gauge(backend, scope):
@@ -231,6 +236,7 @@ def test_gauge(backend, scope):
         "delightful_metrics.minimetrics_sample_rate": 1.0,
         "delightful_metrics.enable_code_locations": True,
         "delightful_metrics.enable_span_attributes": False,
+        "delightful_metrics.minimetrics_disable_legacy": False,
     }
 )
 def test_composite_backend_does_not_recurse(scope):
@@ -268,6 +274,7 @@ def test_composite_backend_does_not_recurse(scope):
     {
         "delightful_metrics.minimetrics_sample_rate": 1.0,
         "delightful_metrics.enable_span_attributes": False,
+        "delightful_metrics.minimetrics_disable_legacy": False,
     }
 )
 @patch("sentry.metrics.minimetrics.sentry_sdk")
@@ -293,6 +300,7 @@ def test_unit_is_correctly_propagated_for_incr(sentry_sdk, unit, expected_unit):
     {
         "delightful_metrics.minimetrics_sample_rate": 1.0,
         "delightful_metrics.enable_span_attributes": False,
+        "delightful_metrics.minimetrics_disable_legacy": False,
     }
 )
 @patch("sentry.metrics.minimetrics.sentry_sdk")
@@ -315,6 +323,7 @@ def test_unit_is_correctly_propagated_for_timing(sentry_sdk, unit, expected_unit
         "delightful_metrics.minimetrics_sample_rate": 1.0,
         "delightful_metrics.emit_gauges": True,
         "delightful_metrics.enable_span_attributes": False,
+        "delightful_metrics.minimetrics_disable_legacy": False,
     }
 )
 @patch("sentry.metrics.minimetrics.sentry_sdk")
@@ -336,6 +345,7 @@ def test_unit_is_correctly_propagated_for_gauge(sentry_sdk, unit, expected_unit)
     {
         "delightful_metrics.minimetrics_sample_rate": 1.0,
         "delightful_metrics.enable_span_attributes": False,
+        "delightful_metrics.minimetrics_disable_legacy": False,
     }
 )
 @patch("sentry.metrics.minimetrics.sentry_sdk")
@@ -373,14 +383,7 @@ def test_to_minimetrics_unit(unit, default, expected_result):
         "delightful_metrics.enable_common_tags": True,
         "delightful_metrics.enable_span_attributes": True,
         "delightful_metrics.enable_code_locations": True,
-    }
-)
-@override_options(
-    {
-        "delightful_metrics.enable_capture_envelope": True,
-        "delightful_metrics.enable_common_tags": True,
-        "delightful_metrics.enable_span_attributes": True,
-        "delightful_metrics.enable_code_locations": True,
+        "delightful_metrics.minimetrics_disable_legacy": False,
     }
 )
 def test_span_attributes_if_there_is_no_active_span(backend, scope):
@@ -397,6 +400,7 @@ def test_span_attributes_if_there_is_no_active_span(backend, scope):
         "delightful_metrics.enable_common_tags": True,
         "delightful_metrics.enable_span_attributes": True,
         "delightful_metrics.enable_code_locations": True,
+        "delightful_metrics.minimetrics_disable_legacy": False,
     }
 )
 def test_span_attribute_is_attached_if_span_exists(backend, scope):


### PR DESCRIPTION
Sentry's own metrics are now tracked as span attributes or spans rather than
direct metrics, given they are being deprecated. This PR introduces an option
that disables the legacy metrics.

Cleanup of all DDM-related options and tests will be in a follow-up PR.
