### PR TITLE
ref(alerts): Rename alertRuleStatus

### DIFF
--- a/static/app/components/devtoolbar/components/alerts/alertsPanel.tsx
+++ b/static/app/components/devtoolbar/components/alerts/alertsPanel.tsx
@@ -9,7 +9,7 @@ import TimeSince from 'sentry/components/timeSince';
 import type {Actor} from 'sentry/types/core';
 import type {Organization} from 'sentry/types/organization';
 import type {PlatformKey} from 'sentry/types/project';
-import AlertRuleStatus from 'sentry/views/alerts/list/rules/alertRuleStatus';
+import ActivatedMetricAlertRuleStatus from 'sentry/views/alerts/list/rules/activatedMetricAlertRuleStatus';
 import type {Incident, MetricAlert} from 'sentry/views/alerts/types';
 import {CombinedAlertType} from 'sentry/views/alerts/types';
 import {alertDetailsLink} from 'sentry/views/alerts/utils';
@@ -172,7 +172,7 @@ function AlertListItem({item}: {item: Incident}) {
       </TextOverflow>
 
       <div css={smallCss} style={{gridArea: 'message'}}>
-        <AlertRuleStatus rule={rule} />
+        <ActivatedMetricAlertRuleStatus rule={rule} />
       </div>
 
       {teamActor ? (

--- a/static/app/views/alerts/list/rules/activatedMetricAlertRuleStatus.tsx
+++ b/static/app/views/alerts/list/rules/activatedMetricAlertRuleStatus.tsx
@@ -19,7 +19,7 @@ interface Props {
   rule: MetricAlert;
 }
 
-export default function AlertRuleStatus({rule}: Props): ReactNode {
+export default function ActivatedMetricAlertRuleStatus({rule}: Props): ReactNode {
   if (rule.snooze) {
     return (
       <IssueAlertStatusWrapper>

--- a/static/app/views/alerts/list/rules/activatedRuleRow.tsx
+++ b/static/app/views/alerts/list/rules/activatedRuleRow.tsx
@@ -23,7 +23,7 @@ import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {Actor, Project} from 'sentry/types';
 import {useUserTeams} from 'sentry/utils/useUserTeams';
-import AlertRuleStatus from 'sentry/views/alerts/list/rules/alertRuleStatus';
+import ActivatedMetricAlertRuleStatus from 'sentry/views/alerts/list/rules/activatedMetricAlertRuleStatus';
 
 import type {CombinedMetricIssueAlerts, MetricAlert} from '../../types';
 import {ActivationStatus, CombinedAlertType} from '../../types';
@@ -211,7 +211,7 @@ function ActivatedRuleListRow({
           </Tooltip>
         </FlexCenter>
         <MarginLeft>
-          <AlertRuleStatus rule={rule} />
+          <ActivatedMetricAlertRuleStatus rule={rule} />
         </MarginLeft>
       </FlexCenter>
       <FlexCenter>


### PR DESCRIPTION
Renaming this to avoid confusion as this is only for activated metric alerts. There is a `renderAlertRuleStatus` that I want to split out into a separate component, from the `rules/row.tsx` file as well