### PR TITLE
ref: replace CsvMixin with a typesafe alternative

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -617,6 +617,7 @@ module = [
     "sentry.utils.urls",
     "sentry.utils.uwsgi",
     "sentry.utils.zip",
+    "sentry.web.frontend.csv",
     "sentry_plugins.base",
     "tests.sentry.api.endpoints.issues.*",
     "tests.sentry.event_manager.test_event_manager",

--- a/src/sentry/web/frontend/csv.py
+++ b/src/sentry/web/frontend/csv.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import csv
+from collections.abc import Generator, Iterable
+from typing import Generic, TypeVar
+
+from django.http import StreamingHttpResponse
+
+T = TypeVar("T")
+
+
+# csv.writer doesn't provide a non-file interface
+# https://docs.djangoproject.com/en/1.9/howto/outputting-csv/#streaming-large-csv-files
+class Echo:
+    def write(self, value: str) -> str:
+        return value
+
+
+class CsvResponder(Generic[T]):
+    def get_header(self) -> tuple[str, ...]:
+        raise NotImplementedError
+
+    def get_row(self, item: T) -> tuple[str, ...]:
+        raise NotImplementedError
+
+    def respond(self, iterable: Iterable[T], filename: str) -> StreamingHttpResponse:
+        def row_iter() -> Generator[tuple[str, ...], None, None]:
+            header = self.get_header()
+            if header:
+                yield header
+            for item in iterable:
+                yield self.get_row(item)
+
+        pseudo_buffer = Echo()
+        writer = csv.writer(pseudo_buffer)
+        return StreamingHttpResponse(
+            (writer.writerow(r) for r in row_iter()),
+            content_type="text/csv",
+            headers={"Content-Disposition": f'attachment; filename="{filename}.csv"'},
+        )

--- a/src/sentry/web/frontend/mixins/csv.py
+++ b/src/sentry/web/frontend/mixins/csv.py
@@ -11,6 +11,8 @@ class Echo:
 
 
 class CsvMixin:
+    """deprecated: will be removed! use sentry.web.csv.CsvResponder instead!"""
+
     def get_header(self, **kwargs):
         return ()
 


### PR DESCRIPTION
mypy 1.11 points out that the approach here is unsafe

CsvMixin is used in getsentry so I'll follow up with deleting it after converting the getsentry usages over as well
<!-- Describe your PR here. -->