### PR TITLE
ref(alerts): Refactor out AlertRuleStatus

### DIFF
--- a/static/app/views/alerts/list/rules/activatedMetricAlertRuleStatus.tsx
+++ b/static/app/views/alerts/list/rules/activatedMetricAlertRuleStatus.tsx
@@ -5,6 +5,7 @@ import {IconArrow, IconMute} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {ColorOrAlias} from 'sentry/utils/theme';
+import {hasActiveIncident} from 'sentry/views/alerts/list/rules/utils';
 import {getThresholdUnits} from 'sentry/views/alerts/rules/metric/constants';
 import {
   AlertRuleComparisonType,
@@ -29,11 +30,7 @@ export default function ActivatedMetricAlertRuleStatus({rule}: Props): ReactNode
     );
   }
 
-  const isUnhealthy =
-    rule.latestIncident?.status !== undefined &&
-    [IncidentStatus.CRITICAL, IncidentStatus.WARNING].includes(
-      rule.latestIncident.status
-    );
+  const isUnhealthy = hasActiveIncident(rule);
 
   let iconColor: ColorOrAlias = 'successText';
   let iconDirection: 'up' | 'down' =

--- a/static/app/views/alerts/list/rules/alertRuleStatus.tsx
+++ b/static/app/views/alerts/list/rules/alertRuleStatus.tsx
@@ -1,0 +1,124 @@
+import styled from '@emotion/styled';
+
+import {IconArrow, IconMute, IconNot} from 'sentry/icons';
+import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
+import type {ColorOrAlias} from 'sentry/utils/theme';
+import {hasActiveIncident} from 'sentry/views/alerts/list/rules/utils';
+import {getThresholdUnits} from 'sentry/views/alerts/rules/metric/constants';
+import {
+  AlertRuleComparisonType,
+  AlertRuleThresholdType,
+  AlertRuleTriggerType,
+} from 'sentry/views/alerts/rules/metric/types';
+import {type CombinedMetricIssueAlerts, IncidentStatus} from 'sentry/views/alerts/types';
+import {isIssueAlert} from 'sentry/views/alerts/utils';
+
+interface Props {
+  rule: CombinedMetricIssueAlerts;
+}
+
+export default function AlertRuleStatus({rule}: Props) {
+  const activeIncident = hasActiveIncident(rule);
+
+  function renderSnoozeStatus(): React.ReactNode {
+    return (
+      <IssueAlertStatusWrapper>
+        <IconMute size="sm" color="subText" />
+        {t('Muted')}
+      </IssueAlertStatusWrapper>
+    );
+  }
+
+  if (isIssueAlert(rule)) {
+    if (rule.status === 'disabled') {
+      return (
+        <IssueAlertStatusWrapper>
+          <IconNot size="sm" color="subText" />
+          {t('Disabled')}
+        </IssueAlertStatusWrapper>
+      );
+    }
+    if (rule.snooze) {
+      return renderSnoozeStatus();
+    }
+    return null;
+  }
+
+  if (rule.snooze) {
+    return renderSnoozeStatus();
+  }
+
+  const criticalTrigger = rule.triggers.find(
+    ({label}) => label === AlertRuleTriggerType.CRITICAL
+  );
+  const warningTrigger = rule.triggers.find(
+    ({label}) => label === AlertRuleTriggerType.WARNING
+  );
+  const resolvedTrigger = rule.resolveThreshold;
+
+  const trigger =
+    activeIncident && rule.latestIncident?.status === IncidentStatus.CRITICAL
+      ? criticalTrigger
+      : warningTrigger ?? criticalTrigger;
+
+  let iconColor: ColorOrAlias = 'successText';
+  let iconDirection: 'up' | 'down' | undefined;
+  let thresholdTypeText =
+    activeIncident && rule.thresholdType === AlertRuleThresholdType.ABOVE
+      ? t('Above')
+      : t('Below');
+
+  if (activeIncident) {
+    iconColor =
+      trigger?.label === AlertRuleTriggerType.CRITICAL
+        ? 'errorText'
+        : trigger?.label === AlertRuleTriggerType.WARNING
+          ? 'warningText'
+          : 'successText';
+    iconDirection = rule.thresholdType === AlertRuleThresholdType.ABOVE ? 'up' : 'down';
+  } else {
+    // Use the Resolved threshold type, which is opposite of Critical
+    iconDirection = rule.thresholdType === AlertRuleThresholdType.ABOVE ? 'down' : 'up';
+    thresholdTypeText =
+      rule.thresholdType === AlertRuleThresholdType.ABOVE ? t('Below') : t('Above');
+  }
+
+  return (
+    <FlexCenter>
+      <IconArrow color={iconColor} direction={iconDirection} />
+      <TriggerText>
+        {`${thresholdTypeText} ${
+          rule.latestIncident || (!rule.latestIncident && !resolvedTrigger)
+            ? trigger?.alertThreshold?.toLocaleString()
+            : resolvedTrigger?.toLocaleString()
+        }`}
+        {getThresholdUnits(
+          rule.aggregate,
+          rule.comparisonDelta
+            ? AlertRuleComparisonType.CHANGE
+            : AlertRuleComparisonType.COUNT
+        )}
+      </TriggerText>
+    </FlexCenter>
+  );
+}
+
+const IssueAlertStatusWrapper = styled('div')`
+  display: flex;
+  align-items: center;
+  gap: ${space(1)};
+  line-height: 2;
+`;
+
+const TriggerText = styled('div')`
+  margin-left: ${space(1)};
+  white-space: nowrap;
+  font-variant-numeric: tabular-nums;
+`;
+
+// TODO: explore utilizing the FlexContainer from app/components/container/flex.tsx
+const FlexCenter = styled('div')`
+  display: flex;
+  align-items: center;
+`;

--- a/static/app/views/alerts/list/rules/utils.tsx
+++ b/static/app/views/alerts/list/rules/utils.tsx
@@ -1,0 +1,8 @@
+import {type CombinedMetricIssueAlerts, IncidentStatus} from 'sentry/views/alerts/types';
+
+export function hasActiveIncident(rule: CombinedMetricIssueAlerts): boolean {
+  return (
+    rule.latestIncident?.status !== undefined &&
+    [IncidentStatus.CRITICAL, IncidentStatus.WARNING].includes(rule.latestIncident.status)
+  );
+}


### PR DESCRIPTION
Refactors out the `renderAlertRuleStatus()` function into its own component. Additionally refactor out the activeIncident boolean logic into a utils help function

The reasoning for this change is to abstract out the individual components of an `AlertRuleRow`, so that the alert rule row can basically act as a layout component for each type of alert which right now are
- Activated Alert Rule Statuses
- Metric/Issue Alert Rule Statuses
- Uptime Alert Rule Statuses (happening in the very near future)

related to: https://github.com/getsentry/team-core-product-foundations/issues/289