### PR TITLE
feat(priority-alerts): Support alert previews for high priority alert conditions

### DIFF
--- a/src/sentry/rules/conditions/existing_high_priority_issue.py
+++ b/src/sentry/rules/conditions/existing_high_priority_issue.py
@@ -33,19 +33,24 @@ class ExistingHighPriorityIssueCondition(EventCondition):
                 project=self.project,
                 datetime__gte=start,
                 datetime__lt=end,
-                type__in=[ActivityType.SET_ESCALATING.value],
+                type__in=[ActivityType.SET_PRIORITY.value],
                 user_id=None,
             )
             .order_by("-datetime")[:limit]
             .values_list("group", "datetime", "data")
         )
 
+        activities = [
+            (group_id, timestamp, data)
+            for group_id, timestamp, data in activities
+            if data.get("priority") == "high"
+        ]
+
         return [
             ConditionActivity(
                 group_id=group_id,
-                type=ConditionActivityType.REAPPEARED,
+                type=ConditionActivityType.EXISTING_HIGH_PRIORITY_ISSUE,
                 timestamp=timestamp,
-                data=data,
             )
             for group_id, timestamp, data in activities
             if group_id is not None

--- a/src/sentry/rules/conditions/existing_high_priority_issue.py
+++ b/src/sentry/rules/conditions/existing_high_priority_issue.py
@@ -33,18 +33,13 @@ class ExistingHighPriorityIssueCondition(EventCondition):
                 project=self.project,
                 datetime__gte=start,
                 datetime__lt=end,
+                data={"priority": "high", "reason": "escalating"},
                 type__in=[ActivityType.SET_PRIORITY.value],
                 user_id=None,
             )
             .order_by("-datetime")[:limit]
             .values_list("group", "datetime", "data")
         )
-
-        activities = [
-            (group_id, timestamp, data)
-            for group_id, timestamp, data in activities
-            if data.get("priority") == "high"
-        ]
 
         return [
             ConditionActivity(

--- a/src/sentry/rules/conditions/new_high_priority_issue.py
+++ b/src/sentry/rules/conditions/new_high_priority_issue.py
@@ -2,11 +2,10 @@ from collections.abc import Sequence
 from datetime import datetime
 
 from sentry.eventstore.models import GroupEvent
-from sentry.models.activity import Activity
+from sentry.models.group import Group
 from sentry.receivers.rules import has_high_priority_issue_alerts
 from sentry.rules import EventState
 from sentry.rules.conditions.base import EventCondition
-from sentry.types.activity import ActivityType
 from sentry.types.condition_activity import ConditionActivity, ConditionActivityType
 from sentry.types.group import PriorityLevel
 
@@ -34,26 +33,19 @@ class NewHighPriorityIssueCondition(EventCondition):
     def get_activity(
         self, start: datetime, end: datetime, limit: int
     ) -> Sequence[ConditionActivity]:
-        # reappearances are recorded as SET_UNRESOLVED with no user
-        activities = (
-            Activity.objects.filter(
+        first_seen = (
+            Group.objects.filter(
                 project=self.project,
-                datetime__gte=start,
-                datetime__lt=end,
-                type__in=[ActivityType.SET_UNRESOLVED.value],
-                user_id=None,
+                first_seen__gte=start,
+                first_seen__lt=end,
+                priority=PriorityLevel.HIGH,
             )
-            .order_by("-datetime")[:limit]
-            .values_list("group", "datetime", "data")
+            .order_by("-first_seen")[:limit]
+            .values_list("id", "first_seen")
         )
-
         return [
             ConditionActivity(
-                group_id=group_id,
-                type=ConditionActivityType.REAPPEARED,
-                timestamp=timestamp,
-                data=data,
+                group_id=g[0], type=ConditionActivityType.NEW_HIGH_PRIORITY_ISSUE, timestamp=g[1]
             )
-            for group_id, timestamp, data in activities
-            if group_id is not None
+            for g in first_seen
         ]

--- a/src/sentry/rules/history/preview.py
+++ b/src/sentry/rules/history/preview.py
@@ -53,7 +53,9 @@ FREQUENCY_CONDITIONS = [
 # Most of the ISSUE_STATE_CONDITIONS are mutually exclusive, except for the following pairs.
 VALID_CONDITION_PAIRS = {
     "sentry.rules.conditions.first_seen_event.FirstSeenEventCondition": "sentry.rules.conditions.high_priority_issue.NewHighPriorityIssueCondition",
+    "sentry.rules.conditions.high_priority_issue.NewHighPriorityIssueCondition": "sentry.rules.conditions.first_seen_event.FirstSeenEventCondition",
     "sentry.rules.conditions.reappeared_event.ReappearedEventCondition": "sentry.rules.conditions.high_priority_issue.ExistingHighPriorityIssueCondition",
+    "sentry.rules.conditions.high_priority_issue.ExistingHighPriorityIssueCondition": "sentry.rules.conditions.reappeared_event.ReappearedEventCondition",
 }
 
 

--- a/src/sentry/rules/history/preview.py
+++ b/src/sentry/rules/history/preview.py
@@ -50,6 +50,12 @@ FREQUENCY_CONDITIONS = [
     "sentry.rules.conditions.event_frequency.EventFrequencyPercentCondition",
 ]
 
+# Most of the ISSUE_STATE_CONDITIONS are mutually exclusive, except for the following pairs.
+VALID_CONDITION_PAIRS = {
+    "sentry.rules.conditions.first_seen_event.FirstSeenEventCondition": "sentry.rules.conditions.high_priority_issue.NewHighPriorityIssueCondition",
+    "sentry.rules.conditions.reappeared_event.ReappearedEventCondition": "sentry.rules.conditions.high_priority_issue.ExistingHighPriorityIssueCondition",
+}
+
 
 def preview(
     project: Project,
@@ -64,13 +70,27 @@ def preview(
     Returns groups that would have triggered the given conditions and filters in the past 2 weeks
     """
     issue_state_conditions, frequency_conditions = categorize_conditions(conditions)
-
     # must have at least one condition to filter activity
     if not issue_state_conditions and not frequency_conditions:
         return None
-    # all the issue state conditions are mutually exclusive
     elif len(issue_state_conditions) > 1 and condition_match == "all":
-        return {}
+        # Of the supported conditions, any more than two would be mutually exclusive
+        if len(issue_state_conditions) > 2:
+            return {}
+
+        condition_ids = {condition["id"] for condition in issue_state_conditions}
+
+        # all the issue state conditions are mutually exclusive
+        if not any(condition in VALID_CONDITION_PAIRS for condition in condition_ids):
+            return {}
+
+        # if there are multiple issue state conditions, they must be one of the valid pairs
+        for condition in condition_ids:
+            if (
+                condition in VALID_CONDITION_PAIRS
+                and VALID_CONDITION_PAIRS[condition] not in condition_ids
+            ):
+                return {}
 
     if end is None:
         end = timezone.now()

--- a/src/sentry/rules/history/preview.py
+++ b/src/sentry/rules/history/preview.py
@@ -41,6 +41,8 @@ ISSUE_STATE_CONDITIONS = [
     "sentry.rules.conditions.first_seen_event.FirstSeenEventCondition",
     "sentry.rules.conditions.regression_event.RegressionEventCondition",
     "sentry.rules.conditions.reappeared_event.ReappearedEventCondition",
+    "sentry.rules.conditions.high_priority_issue.NewHighPriorityIssueCondition",
+    "sentry.rules.conditions.high_priority_issue.ExistingHighPriorityIssueCondition",
 ]
 FREQUENCY_CONDITIONS = [
     "sentry.rules.conditions.event_frequency.EventFrequencyCondition",

--- a/src/sentry/types/condition_activity.py
+++ b/src/sentry/types/condition_activity.py
@@ -14,6 +14,8 @@ class ConditionActivityType(Enum):
     REAPPEARED = 2
     # condition activity created from frequency condition buckets
     FREQUENCY_CONDITION = 3
+    NEW_HIGH_PRIORITY_ISSUE = 4
+    EXISTING_HIGH_PRIORITY_ISSUE = 5
 
 
 @dataclass


### PR DESCRIPTION
Add support for the alert preview for new and existing high priority alert conditions. The preview is populated using the `get_activity` method for these conditions, which needed some updates to accurately filter to the appropriate priority. 

The preview logic also has some short-circuit logic around mutually exclusive conditions. The high priority alert conditions are not mutually exclusive with all the previously supported conditions, so we're adding a map of explicitly supported pairings `VALID_CONDITION_PAIRS`. The mutual exclusivity check now checks if the multiple conditions are valid before possibly short circuiting to an empty result.

Fixes https://github.com/getsentry/sentry/issues/74819