### PR TITLE
fix(email): remove ! in confirmation email

### DIFF
--- a/src/sentry/templates/sentry/emails/confirm_email.html
+++ b/src/sentry/templates/sentry/emails/confirm_email.html
@@ -5,7 +5,7 @@
 {% block main %}
     <h3>Confirm Email</h3>
     {% if is_new_user %}
-        <p>Thanks for signing up for Sentry!</p>
+        <p>Thanks for signing up for Sentry</p>
     {% endif %}
     <p>Please confirm your email ({{ confirm_email }}) by clicking the button below. This link will expire in 48 hours.</p>
     <p><a href="{{ url }}" class="btn">Confirm</a></p>


### PR DESCRIPTION
Removes `!` from email.

## Before
![Screenshot 2024-07-25 at 11 04 27 AM](https://github.com/user-attachments/assets/bdb049da-3aba-45b9-bee5-985d4b18a19d)

## After
![Screenshot 2024-07-25 at 10 38 43 AM](https://github.com/user-attachments/assets/e8e9b9b9-ff55-4681-8d5b-84c9aca52642)
