### PR TITLE
feat(trace): expand tree if there are less than 3 transaction

### DIFF
--- a/static/app/views/performance/newTraceDetails/index.tsx
+++ b/static/app/views/performance/newTraceDetails/index.tsx
@@ -343,8 +343,7 @@ export function TraceViewWaterfall(props: TraceViewWaterfallProps) {
 
     if (props.trace) {
       const trace = TraceTree.FromTrace(props.trace, props.replayRecord);
-
-      if (props.trace.transactions.length < 3) {
+      if (trace.list.length < 3) {
         for (const c of trace.list) {
           if (c.canFetch) {
             trace.zoomIn(c, true, {api, organization}).then(rerender);
@@ -358,8 +357,8 @@ export function TraceViewWaterfall(props: TraceViewWaterfallProps) {
     props.traceSlug,
     props.trace,
     props.status,
-    projects,
     props.replayRecord,
+    projects,
     api,
     organization,
   ]);

--- a/static/app/views/performance/newTraceDetails/index.tsx
+++ b/static/app/views/performance/newTraceDetails/index.tsx
@@ -324,6 +324,7 @@ export function TraceViewWaterfall(props: TraceViewWaterfallProps) {
       props.trace?.orphan_errors.length === 0
     ) {
       setTree(TraceTree.Empty());
+      return;
     }
 
     if (props.status === 'loading') {
@@ -344,15 +345,17 @@ export function TraceViewWaterfall(props: TraceViewWaterfallProps) {
     if (props.trace) {
       const trace = TraceTree.FromTrace(props.trace, props.replayRecord);
       // Root frame + 2 nodes
+      const promises: Promise<void>[] = [];
       if (trace.list.length < 4) {
         for (const c of trace.list) {
           if (c.canFetch) {
-            trace.zoomIn(c, true, {api, organization}).then(rerender);
+            promises.push(trace.zoomIn(c, true, {api, organization}).then(rerender));
           }
         }
       }
-
-      setTree(trace);
+      Promise.allSettled(promises).finally(() => {
+        setTree(trace);
+      });
     }
   }, [
     props.traceSlug,

--- a/static/app/views/performance/newTraceDetails/index.tsx
+++ b/static/app/views/performance/newTraceDetails/index.tsx
@@ -343,7 +343,8 @@ export function TraceViewWaterfall(props: TraceViewWaterfallProps) {
 
     if (props.trace) {
       const trace = TraceTree.FromTrace(props.trace, props.replayRecord);
-      if (trace.list.length < 3) {
+      // Root frame + 2 nodes
+      if (trace.list.length < 4) {
         for (const c of trace.list) {
           if (c.canFetch) {
             trace.zoomIn(c, true, {api, organization}).then(rerender);

--- a/static/app/views/performance/newTraceDetails/trace.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/trace.spec.tsx
@@ -1129,7 +1129,7 @@ describe('trace view', () => {
       await searchToUpdate();
 
       expect(await screen.findByTestId('trace-search-result-iterator')).toHaveTextContent(
-        '1/1'
+        '1/2'
       );
 
       const highlighted_row = value.container.querySelector(ACTIVE_SEARCH_HIGHLIGHT_ROW);

--- a/static/app/views/performance/newTraceDetails/trace.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/trace.spec.tsx
@@ -1097,12 +1097,30 @@ describe('trace view', () => {
               transaction: 'transaction-name-0',
               'transaction.op': 'transaction-op-0',
             }),
+            makeTransaction({
+              span_id: '1',
+              event_id: '1',
+              transaction: 'transaction-name-1',
+              'transaction.op': 'transaction-op-1',
+            }),
+            makeTransaction({
+              span_id: '2',
+              event_id: '2',
+              transaction: 'transaction-name-2',
+              'transaction.op': 'transaction-op-2',
+            }),
+            makeTransaction({
+              span_id: '3',
+              event_id: '3',
+              transaction: 'transaction-name-3',
+              'transaction.op': 'transaction-op-3',
+            }),
           ],
           orphan_errors: [],
         },
       });
 
-      mockSpansResponse(
+      const spansRequest = mockSpansResponse(
         '0',
         {},
         {
@@ -1129,13 +1147,16 @@ describe('trace view', () => {
       await searchToUpdate();
 
       expect(await screen.findByTestId('trace-search-result-iterator')).toHaveTextContent(
-        '1/2'
+        '1/1'
       );
 
       const highlighted_row = value.container.querySelector(ACTIVE_SEARCH_HIGHLIGHT_ROW);
-      await userEvent.click(await screen.findByRole('button', {name: '+'}));
+      const open = await screen.findAllByRole('button', {name: '+'});
+      await userEvent.click(open[0]);
       expect(await screen.findByText('span-description')).toBeInTheDocument();
       await searchToUpdate();
+
+      expect(spansRequest).toHaveBeenCalled();
 
       // The search is retriggered, but highlighting of current row is preserved
       expect(value.container.querySelector(ACTIVE_SEARCH_HIGHLIGHT_ROW)).toBe(

--- a/static/app/views/performance/newTraceDetails/traceModels/traceTree.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/traceTree.spec.tsx
@@ -2835,7 +2835,6 @@ describe('TraceTree', () => {
       });
 
       await waitFor(() => tree.list.length === 4);
-      tree.print();
 
       const pageloadTransaction = tree.list[1];
       const serverHandlerTransaction = tree.list[3];

--- a/static/app/views/performance/newTraceDetails/traceModels/traceTree.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/traceTree.tsx
@@ -1592,13 +1592,6 @@ export class TraceTree {
         // The user may have collapsed the node before the promise resolved. When that
         // happens, dont update the tree with the resolved data. Alternatively, we could implement
         // a cancellable promise and avoid this cumbersome heuristic.
-        node.fetchStatus = 'resolved';
-        if (!node.expanded) {
-          return data;
-        }
-
-        const spans = data.entries.find(s => s.type === 'spans') ?? {data: []};
-
         // Remove existing entries from the list
         let index = this._list.indexOf(node);
 
@@ -1612,6 +1605,14 @@ export class TraceTree {
             return data;
           }
         }
+
+        node = this._list[index];
+        node.fetchStatus = 'resolved';
+        if (!node.expanded) {
+          return data;
+        }
+
+        const spans = data.entries.find(s => s.type === 'spans') ?? {data: []};
 
         if (node.expanded) {
           const childrenCount = node.getVisibleChildrenCount();

--- a/static/app/views/performance/newTraceDetails/traceModels/traceTree.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/traceTree.tsx
@@ -1594,6 +1594,7 @@ export class TraceTree {
         // a cancellable promise and avoid this cumbersome heuristic.
         // Remove existing entries from the list
         let index = this._list.indexOf(node);
+        node.fetchStatus = 'resolved';
 
         // Some nodes may have gotten cloned and their reference lost due to the fact
         // that we are really maintaining a txn tree as well as a span tree. When this
@@ -1604,10 +1605,10 @@ export class TraceTree {
           if (index === -1) {
             return data;
           }
+          node = this._list[index];
+          node.fetchStatus = 'resolved';
         }
 
-        node = this._list[index];
-        node.fetchStatus = 'resolved';
         if (!node.expanded) {
           return data;
         }


### PR DESCRIPTION
When coming to small traces, the UI looks empty as we are not expanding the transactions by default. This implements automatic expanding of traces with less than 3 transactions