### PR TITLE
fix(trace-explorer): Render traces span chart errors

### DIFF
--- a/static/app/views/traces/tracesChart.tsx
+++ b/static/app/views/traces/tracesChart.tsx
@@ -59,13 +59,32 @@ export function TracesChart({}: Props) {
     (enabled[1] && secondCountSeries.isLoading) ||
     (enabled[2] && thirdCountSeries.isLoading);
 
+  const error = useMemo(() => {
+    const errors = [
+      firstCountSeries.error,
+      secondCountSeries.error,
+      thirdCountSeries.error,
+    ];
+
+    for (let i = 0; i < errors.length; i++) {
+      if (!enabled[i]) {
+        continue;
+      }
+
+      if (errors[i]) {
+        return errors[i];
+      }
+    }
+    return null;
+  }, [enabled, firstCountSeries, secondCountSeries, thirdCountSeries]);
+
   const chartData = useMemo<Series[]>(() => {
     const series = [firstCountSeries.data, secondCountSeries.data, thirdCountSeries.data];
 
     const allData: Series[] = [];
 
     for (let i = 0; i < series.length; i++) {
-      if (!enabled[i]) {
+      if (!enabled[i] || error) {
         continue;
       }
       const data = series[i]['count()'];
@@ -79,6 +98,7 @@ export function TracesChart({}: Props) {
   }, [
     enabled,
     queries,
+    error,
     firstCountSeries.data,
     secondCountSeries.data,
     thirdCountSeries.data,
@@ -98,6 +118,7 @@ export function TracesChart({}: Props) {
             bottom: '0',
           }}
           data={chartData}
+          error={error}
           loading={seriesAreLoading}
           chartColors={CHART_PALETTE[2]}
           type={ChartType.LINE}


### PR DESCRIPTION
Render error on chart when any time series query fails.