### PR TITLE
fix(apidocs): fix typos in release API docs

### DIFF
--- a/src/sentry/api/endpoints/organization_sessions.py
+++ b/src/sentry/api/endpoints/organization_sessions.py
@@ -67,10 +67,14 @@ class OrganizationSessionsEndpoint(OrganizationEndpoint):
     def get(self, request: Request, organization) -> Response:
         """
         Returns a time series of release health session statistics for projects bound to an organization.
-        \n\nThe interval and date range are subject to certain restrictions and rounding
-        rules.\n\nThe date range is rounded to align with the interval, and is rounded to at least one
+
+        The interval and date range are subject to certain restrictions and rounding rules.
+
+        The date range is rounded to align with the interval, and is rounded to at least one
         hour. The interval can at most be one day and at least one hour currently. It has to cleanly
-        divide one day, for rounding reasons.\n\nBecause of technical limitations, this endpoint returns
+        divide one day, for rounding reasons.
+
+        Because of technical limitations, this endpoint returns
         at most 10000 data points. For example, if you select a 90 day window grouped by releases,
         you will see at most `floor(10k / (90 + 1)) = 109` releases. To get more results, reduce the
         `statsPeriod`."

--- a/src/sentry/api/endpoints/organization_sessions.py
+++ b/src/sentry/api/endpoints/organization_sessions.py
@@ -66,14 +66,14 @@ class OrganizationSessionsEndpoint(OrganizationEndpoint):
     )
     def get(self, request: Request, organization) -> Response:
         """
-        Returns a time series of release health session statistics for projects bound to an "
-        "organization.\n\nThe interval and date range are subject to certain restrictions and rounding "
-        "rules.\n\nThe date range is rounded to align with the interval, and is rounded to at least one "
-        "hour. The interval can at most be one day and at least one hour currently. It has to cleanly "
-        "divide one day, for rounding reasons.\n\nBecause of technical limitations, this endpoint returns "
-        "at most 10000 data points. For example, if you select a 90 day window grouped by releases, "
-        "you will see at most `floor(10k / (90 + 1)) = 109` releases. To get more results, reduce the "
-        "`statsPeriod`."
+        Returns a time series of release health session statistics for projects bound to an organization.
+        \n\nThe interval and date range are subject to certain restrictions and rounding
+        rules.\n\nThe date range is rounded to align with the interval, and is rounded to at least one
+        hour. The interval can at most be one day and at least one hour currently. It has to cleanly
+        divide one day, for rounding reasons.\n\nBecause of technical limitations, this endpoint returns
+        at most 10000 data points. For example, if you select a 90 day window grouped by releases,
+        you will see at most `floor(10k / (90 + 1)) = 109` releases. To get more results, reduce the
+        `statsPeriod`."
         """
 
         def data_fn(offset: int, limit: int) -> SessionsQueryResult:

--- a/src/sentry/apidocs/parameters.py
+++ b/src/sentry/apidocs/parameters.py
@@ -547,12 +547,9 @@ class SessionsParams:
         required=True,
         type=str,
         many=True,
-        description="""The list of fields to query.\n\nThe available fields are\n  - `sum(session)`\n  - `count_unique("
-                    "user)`\n  - `avg`, `p50`, `p75`, `p90`, `p95`, `p99`, `max` applied to `session.duration`. For "
-                    "example, `p99(session.duration)`. Session duration is [no longer being recorded]("
-                    "https://github.com/getsentry/sentry/discussions/42716) as of on Jan 12, 2023. Returned data may "
-                    "be incomplete.\n  - `crash_rate`, `crash_free_rate` applied to `user` or `session`. For example, "
-                    "`crash_free_rate(user)`""",
+        description="""The list of fields to query.\n\nThe available fields are\n  - `sum(session)`\n  - `count_unique(user)`\n  - `avg`, `p50`, `p75`, `p90`, `p95`, `p99`, `max` applied to `session.duration`. For
+                    example, `p99(session.duration)`. Session duration is [no longer being recorded](https://github.com/getsentry/sentry/discussions/42716) as of on Jan 12, 2023. Returned data may be incomplete.\n  - `crash_rate`, `crash_free_rate` applied to `user` or `session`. For example,
+                    `crash_free_rate(user)`""",
     )
     INTERVAL = OpenApiParameter(
         name="interval",

--- a/src/sentry/apidocs/parameters.py
+++ b/src/sentry/apidocs/parameters.py
@@ -547,9 +547,14 @@ class SessionsParams:
         required=True,
         type=str,
         many=True,
-        description="""The list of fields to query.\n\nThe available fields are\n  - `sum(session)`\n  - `count_unique(user)`\n  - `avg`, `p50`, `p75`, `p90`, `p95`, `p99`, `max` applied to `session.duration`. For
-                    example, `p99(session.duration)`. Session duration is [no longer being recorded](https://github.com/getsentry/sentry/discussions/42716) as of on Jan 12, 2023. Returned data may be incomplete.\n  - `crash_rate`, `crash_free_rate` applied to `user` or `session`. For example,
-                    `crash_free_rate(user)`""",
+        description="""The list of fields to query.
+
+The available fields are
+- `sum(session)`
+- `count_unique(user)`
+- `avg`, `p50`, `p75`, `p90`, `p95`, `p99`, `max` applied to `session.duration`. For example, `p99(session.duration)`. Session duration is [no longer being recorded](https://github.com/getsentry/sentry/discussions/42716) as of on Jan 12, 2023. Returned data may be incomplete.
+- `crash_rate`, `crash_free_rate` applied to `user` or `session`. For example,`crash_free_rate(user)`
+""",
     )
     INTERVAL = OpenApiParameter(
         name="interval",


### PR DESCRIPTION
noticed some typos on https://docs.sentry.io/api/releases/retrieve-release-health-session-statistics/