### PR TITLE
fix(insights): move useHasData to ModulePageProviders

### DIFF
--- a/static/app/views/insights/browser/resources/components/resourceView.tsx
+++ b/static/app/views/insights/browser/resources/components/resourceView.tsx
@@ -25,7 +25,6 @@ import {
   useResourceModuleFilters,
 } from 'sentry/views/insights/browser/resources/utils/useResourceFilters';
 import {useResourceSort} from 'sentry/views/insights/browser/resources/utils/useResourceSort';
-import {useHasDataTrackAnalytics} from 'sentry/views/insights/common/utils/useHasDataTrackAnalytics';
 import {QueryParameterNames} from 'sentry/views/insights/common/views/queryParameters';
 import {TransactionSelector} from 'sentry/views/insights/common/views/spans/selectors/transactionSelector';
 import {SpanTimeCharts} from 'sentry/views/insights/common/views/spans/spanTimeCharts';
@@ -54,8 +53,6 @@ function ResourceView() {
   };
 
   const extraQuery = getResourceTypeFilter(undefined, DEFAULT_RESOURCE_TYPES);
-
-  useHasDataTrackAnalytics(ModuleName.RESOURCE, 'insight.page_loads.assets');
 
   return (
     <Fragment>

--- a/static/app/views/insights/browser/resources/views/resourcesLandingPage.tsx
+++ b/static/app/views/insights/browser/resources/views/resourcesLandingPage.tsx
@@ -88,7 +88,11 @@ function ResourcesLandingPage() {
 
 function PageWithProviders() {
   return (
-    <ModulePageProviders moduleName="resource" features="insights-initial-modules">
+    <ModulePageProviders
+      moduleName="resource"
+      features="insights-initial-modules"
+      analyticEventName="insight.page_loads.assets"
+    >
       <ResourcesLandingPage />
     </ModulePageProviders>
   );

--- a/static/app/views/insights/browser/webVitals/views/webVitalsLandingPage.tsx
+++ b/static/app/views/insights/browser/webVitals/views/webVitalsLandingPage.tsx
@@ -33,7 +33,6 @@ import decodeBrowserTypes from 'sentry/views/insights/browser/webVitals/utils/qu
 import {ModulePageFilterBar} from 'sentry/views/insights/common/components/modulePageFilterBar';
 import {ModulePageProviders} from 'sentry/views/insights/common/components/modulePageProviders';
 import {ModulesOnboarding} from 'sentry/views/insights/common/components/modulesOnboarding';
-import {useHasDataTrackAnalytics} from 'sentry/views/insights/common/utils/useHasDataTrackAnalytics';
 import {useModuleBreadcrumbs} from 'sentry/views/insights/common/utils/useModuleBreadcrumbs';
 import {ModuleName, SpanIndexedField} from 'sentry/views/insights/types';
 
@@ -56,8 +55,6 @@ export function WebVitalsLandingPage() {
     isProjectScoresLoading || isLoading
       ? undefined
       : calculatePerformanceScoreFromStoredTableDataRow(projectScores?.data?.[0]);
-
-  useHasDataTrackAnalytics(ModuleName.VITAL, 'insight.page_loads.vital');
 
   const crumbs = useModuleBreadcrumbs('vital');
 
@@ -155,7 +152,11 @@ export function WebVitalsLandingPage() {
 
 function PageWithProviders() {
   return (
-    <ModulePageProviders moduleName="vital" features="insights-initial-modules">
+    <ModulePageProviders
+      moduleName="vital"
+      features="insights-initial-modules"
+      analyticEventName="insight.page_loads.vital"
+    >
       <WebVitalsLandingPage />
     </ModulePageProviders>
   );

--- a/static/app/views/insights/cache/views/cacheLandingPage.tsx
+++ b/static/app/views/insights/cache/views/cacheLandingPage.tsx
@@ -43,7 +43,6 @@ import {
 import {useSpanMetricsSeries} from 'sentry/views/insights/common/queries/useDiscoverSeries';
 import {useHasFirstSpan} from 'sentry/views/insights/common/queries/useHasFirstSpan';
 import {useOnboardingProject} from 'sentry/views/insights/common/queries/useOnboardingProject';
-import {useHasDataTrackAnalytics} from 'sentry/views/insights/common/utils/useHasDataTrackAnalytics';
 import {useModuleBreadcrumbs} from 'sentry/views/insights/common/utils/useModuleBreadcrumbs';
 import {QueryParameterNames} from 'sentry/views/insights/common/views/queryParameters';
 import {DataTitles} from 'sentry/views/insights/common/views/spans/types';
@@ -140,8 +139,6 @@ export function CacheLandingPage() {
 
   const onboardingProject = useOnboardingProject();
   const hasData = useHasFirstSpan(ModuleName.CACHE);
-
-  useHasDataTrackAnalytics(ModuleName.CACHE, 'insight.page_loads.cache');
 
   useEffect(() => {
     const hasMissingDataError =
@@ -248,7 +245,11 @@ export function CacheLandingPage() {
 
 function PageWithProviders() {
   return (
-    <ModulePageProviders moduleName="cache" features="insights-addon-modules">
+    <ModulePageProviders
+      moduleName="cache"
+      features="insights-addon-modules"
+      analyticEventName="insight.page_loads.cache"
+    >
       <PageAlertProvider>
         <CacheLandingPage />
       </PageAlertProvider>

--- a/static/app/views/insights/common/components/modulePageProviders.tsx
+++ b/static/app/views/insights/common/components/modulePageProviders.tsx
@@ -6,8 +6,10 @@ import * as Layout from 'sentry/components/layouts/thirds';
 import NoProjectMessage from 'sentry/components/noProjectMessage';
 import PageFiltersContainer from 'sentry/components/organizations/pageFilters/container';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
+import type {InsightEventKey} from 'sentry/utils/analytics/insightAnalyticEvents';
 import useOrganization from 'sentry/utils/useOrganization';
 import {NoAccess} from 'sentry/views/insights/common/components/noAccess';
+import {useHasDataTrackAnalytics} from 'sentry/views/insights/common/utils/useHasDataTrackAnalytics';
 import {INSIGHTS_TITLE, MODULE_TITLES} from 'sentry/views/insights/settings';
 import type {ModuleName} from 'sentry/views/insights/types';
 
@@ -18,11 +20,20 @@ interface Props {
   children: React.ReactNode;
   features: ComponentProps<typeof Feature>['features'];
   moduleName: TitleableModuleNames;
+  analyticEventName?: InsightEventKey;
   pageTitle?: string;
 }
 
-export function ModulePageProviders({moduleName, pageTitle, children, features}: Props) {
+export function ModulePageProviders({
+  moduleName,
+  pageTitle,
+  children,
+  features,
+  analyticEventName,
+}: Props) {
   const organization = useOrganization();
+
+  useHasDataTrackAnalytics(moduleName as ModuleName, analyticEventName);
 
   const moduleTitle = MODULE_TITLES[moduleName];
 

--- a/static/app/views/insights/common/utils/useHasDataTrackAnalytics.tsx
+++ b/static/app/views/insights/common/utils/useHasDataTrackAnalytics.tsx
@@ -7,9 +7,10 @@ import usePageFilters from 'sentry/utils/usePageFilters';
 import {useHasFirstSpan} from 'sentry/views/insights/common/queries/useHasFirstSpan';
 import type {ModuleName} from 'sentry/views/insights/types';
 
-export function useHasDataTrackAnalytics(module: ModuleName, analyticEvent: string) {
+export function useHasDataTrackAnalytics(module: ModuleName, analyticEvent?: string) {
   const organization = useOrganization();
   const pageFilters = usePageFilters();
+
   const hasEverSentData = useHasFirstSpan(module);
 
   Sentry.setTag(`insights.${module}.hasEverSentData`, hasEverSentData);
@@ -17,9 +18,11 @@ export function useHasDataTrackAnalytics(module: ModuleName, analyticEvent: stri
   const projects = JSON.stringify(pageFilters.selection.projects);
 
   useEffect(() => {
-    trackAnalytics(analyticEvent, {
-      organization,
-      has_ever_sent_data: hasEverSentData,
-    });
-  }, [organization, hasEverSentData, analyticEvent, projects]);
+    if (pageFilters.isReady && analyticEvent) {
+      trackAnalytics(analyticEvent, {
+        organization,
+        has_ever_sent_data: hasEverSentData,
+      });
+    }
+  }, [organization, hasEverSentData, analyticEvent, projects, pageFilters.isReady]);
 }

--- a/static/app/views/insights/database/views/databaseLandingPage.tsx
+++ b/static/app/views/insights/database/views/databaseLandingPage.tsx
@@ -24,7 +24,6 @@ import {useSpanMetrics} from 'sentry/views/insights/common/queries/useDiscover';
 import {useSpanMetricsSeries} from 'sentry/views/insights/common/queries/useDiscoverSeries';
 import {useHasFirstSpan} from 'sentry/views/insights/common/queries/useHasFirstSpan';
 import {useOnboardingProject} from 'sentry/views/insights/common/queries/useOnboardingProject';
-import {useHasDataTrackAnalytics} from 'sentry/views/insights/common/utils/useHasDataTrackAnalytics';
 import {useModuleBreadcrumbs} from 'sentry/views/insights/common/utils/useModuleBreadcrumbs';
 import {QueryParameterNames} from 'sentry/views/insights/common/views/queryParameters';
 import {ActionSelector} from 'sentry/views/insights/common/views/spans/selectors/actionSelector';
@@ -134,8 +133,6 @@ export function DatabaseLandingPage() {
     'api.starfish.span-landing-page-metrics-chart'
   );
 
-  useHasDataTrackAnalytics(ModuleName.DB, 'insight.page_loads.db');
-
   const isCriticalDataLoading =
     isThroughputDataLoading || isDurationDataLoading || queryListResponse.isLoading;
 
@@ -244,7 +241,11 @@ const LIMIT: number = 25;
 
 function PageWithProviders() {
   return (
-    <ModulePageProviders moduleName="db" features="insights-initial-modules">
+    <ModulePageProviders
+      moduleName="db"
+      features="insights-initial-modules"
+      analyticEventName="insight.page_loads.db"
+    >
       <DatabaseLandingPage />
     </ModulePageProviders>
   );

--- a/static/app/views/insights/http/views/httpLandingPage.tsx
+++ b/static/app/views/insights/http/views/httpLandingPage.tsx
@@ -21,7 +21,6 @@ import {ModulePageProviders} from 'sentry/views/insights/common/components/modul
 import {ModulesOnboarding} from 'sentry/views/insights/common/components/modulesOnboarding';
 import {useSpanMetrics} from 'sentry/views/insights/common/queries/useDiscover';
 import {useSpanMetricsSeries} from 'sentry/views/insights/common/queries/useDiscoverSeries';
-import {useHasDataTrackAnalytics} from 'sentry/views/insights/common/utils/useHasDataTrackAnalytics';
 import {useModuleBreadcrumbs} from 'sentry/views/insights/common/utils/useModuleBreadcrumbs';
 import {QueryParameterNames} from 'sentry/views/insights/common/views/queryParameters';
 import {DurationChart} from 'sentry/views/insights/http/components/charts/durationChart';
@@ -142,8 +141,6 @@ export function HTTPLandingPage() {
 
   useSynchronizeCharts([!isThroughputDataLoading && !isDurationDataLoading]);
 
-  useHasDataTrackAnalytics(ModuleName.HTTP, 'insight.page_loads.http');
-
   const crumbs = useModuleBreadcrumbs('http');
 
   return (
@@ -240,7 +237,11 @@ const DOMAIN_TABLE_ROW_COUNT = 10;
 
 function PageWithProviders() {
   return (
-    <ModulePageProviders moduleName="http" features="insights-initial-modules">
+    <ModulePageProviders
+      moduleName="http"
+      features="insights-initial-modules"
+      analyticEventName="insight.page_loads.http"
+    >
       <HTTPLandingPage />
     </ModulePageProviders>
   );

--- a/static/app/views/insights/llmMonitoring/views/llmMonitoringLandingPage.tsx
+++ b/static/app/views/insights/llmMonitoring/views/llmMonitoringLandingPage.tsx
@@ -11,7 +11,6 @@ import * as ModuleLayout from 'sentry/views/insights/common/components/moduleLay
 import {ModulePageFilterBar} from 'sentry/views/insights/common/components/modulePageFilterBar';
 import {ModulePageProviders} from 'sentry/views/insights/common/components/modulePageProviders';
 import {ModulesOnboarding} from 'sentry/views/insights/common/components/modulesOnboarding';
-import {useHasDataTrackAnalytics} from 'sentry/views/insights/common/utils/useHasDataTrackAnalytics';
 import {useModuleBreadcrumbs} from 'sentry/views/insights/common/utils/useModuleBreadcrumbs';
 import {
   NumberOfPipelinesChart,
@@ -30,8 +29,6 @@ export function LLMMonitoringPage() {
   const organization = useOrganization();
 
   const crumbs = useModuleBreadcrumbs('ai');
-
-  useHasDataTrackAnalytics(ModuleName.AI, 'insight.page_loads.ai');
 
   return (
     <Layout.Page>
@@ -84,7 +81,11 @@ export function LLMMonitoringPage() {
 
 function PageWithProviders() {
   return (
-    <ModulePageProviders moduleName="ai" features="insights-addon-modules">
+    <ModulePageProviders
+      moduleName="ai"
+      features="insights-addon-modules"
+      analyticEventName="insight.page_loads.ai"
+    >
       <LLMMonitoringPage />
     </ModulePageProviders>
   );

--- a/static/app/views/insights/mobile/appStarts/components/appStartup.tsx
+++ b/static/app/views/insights/mobile/appStarts/components/appStartup.tsx
@@ -18,7 +18,6 @@ import usePageFilters from 'sentry/utils/usePageFilters';
 import useRouter from 'sentry/utils/useRouter';
 import {useReleaseSelection} from 'sentry/views/insights/common/queries/useReleases';
 import {appendReleaseFilters} from 'sentry/views/insights/common/utils/releaseComparison';
-import {useHasDataTrackAnalytics} from 'sentry/views/insights/common/utils/useHasDataTrackAnalytics';
 import {AverageComparisonChart} from 'sentry/views/insights/mobile/appStarts/components/charts/averageComparisonChart';
 import {CountChart} from 'sentry/views/insights/mobile/appStarts/components/charts/countChart';
 import {COLD_START_TYPE} from 'sentry/views/insights/mobile/appStarts/components/startTypeSelector';
@@ -155,8 +154,6 @@ function AppStartup({additionalFilters, chartHeight}: Props) {
     enabled: !topTransactionsLoading,
     referrer: 'api.starfish.mobile-startup-bar-chart',
   });
-
-  useHasDataTrackAnalytics(ModuleName.APP_START, 'insight.page_loads.app_start');
 
   if (!defined(primaryRelease) && !isReleasesLoading) {
     return (

--- a/static/app/views/insights/mobile/appStarts/views/appStartsLandingPage.tsx
+++ b/static/app/views/insights/mobile/appStarts/views/appStartsLandingPage.tsx
@@ -24,7 +24,11 @@ export function InitializationModule() {
 
 function PageWithProviders() {
   return (
-    <ModulePageProviders moduleName="app_start" features="insights-initial-modules">
+    <ModulePageProviders
+      moduleName="app_start"
+      features="insights-initial-modules"
+      analyticEventName="insight.page_loads.app_start"
+    >
       <InitializationModule />
     </ModulePageProviders>
   );

--- a/static/app/views/insights/mobile/screenload/views/screenloadLandingPage.tsx
+++ b/static/app/views/insights/mobile/screenload/views/screenloadLandingPage.tsx
@@ -88,7 +88,11 @@ export function PageloadModule() {
 
 function PageWithProviders() {
   return (
-    <ModulePageProviders moduleName="screen_load" features="insights-initial-modules">
+    <ModulePageProviders
+      moduleName="screen_load"
+      features="insights-initial-modules"
+      analyticEventName="insight.page_loads.screen_load"
+    >
       <PageloadModule />
     </ModulePageProviders>
   );

--- a/static/app/views/insights/queues/views/queuesLandingPage.tsx
+++ b/static/app/views/insights/queues/views/queuesLandingPage.tsx
@@ -20,7 +20,6 @@ import * as ModuleLayout from 'sentry/views/insights/common/components/moduleLay
 import {ModulePageFilterBar} from 'sentry/views/insights/common/components/modulePageFilterBar';
 import {ModulePageProviders} from 'sentry/views/insights/common/components/modulePageProviders';
 import {ModulesOnboarding} from 'sentry/views/insights/common/components/modulesOnboarding';
-import {useHasDataTrackAnalytics} from 'sentry/views/insights/common/utils/useHasDataTrackAnalytics';
 import {useModuleBreadcrumbs} from 'sentry/views/insights/common/utils/useModuleBreadcrumbs';
 import {QueryParameterNames} from 'sentry/views/insights/common/views/queryParameters';
 import {LatencyChart} from 'sentry/views/insights/queues/charts/latencyChart';
@@ -80,8 +79,6 @@ function QueuesLandingPage() {
     ? `*${escapeFilterValue(query.destination)}*`
     : undefined;
 
-  useHasDataTrackAnalytics(ModuleName.QUEUE, 'insight.page_loads.queue');
-
   const crumbs = useModuleBreadcrumbs('queue');
 
   return (
@@ -138,7 +135,11 @@ function QueuesLandingPage() {
 
 function PageWithProviders() {
   return (
-    <ModulePageProviders moduleName="queue" features="insights-addon-modules">
+    <ModulePageProviders
+      moduleName="queue"
+      features="insights-addon-modules"
+      analyticEventName="insight.page_loads.queue"
+    >
       <QueuesLandingPage />
     </ModulePageProviders>
   );


### PR DESCRIPTION
Fixes issue where useHasData does not send any analytic events when has_data_ever_sent is False.