### PR TITLE
feat(dashboards): Update dashboard state on split decision

### DIFF
--- a/static/app/views/dashboards/detail.spec.tsx
+++ b/static/app/views/dashboards/detail.spec.tsx
@@ -20,6 +20,7 @@ import * as modals from 'sentry/actionCreators/modal';
 import ProjectsStore from 'sentry/stores/projectsStore';
 import {browserHistory} from 'sentry/utils/browserHistory';
 import CreateDashboard from 'sentry/views/dashboards/create';
+import {handleUpdateDashboardSplit} from 'sentry/views/dashboards/detail';
 import * as types from 'sentry/views/dashboards/types';
 import ViewEditDashboard from 'sentry/views/dashboards/view';
 import {OrganizationContext} from 'sentry/views/organizationContext';
@@ -1627,6 +1628,61 @@ describe('Dashboards > Detail', function () {
       // Validate that after search is cleared, search result still appears
       expect(await screen.findByText('Latest Release(s)')).toBeInTheDocument();
       expect(screen.getByRole('option', {name: 'search-result'})).toBeInTheDocument();
+    });
+
+    describe('discover split', function () {
+      it('calls the dashboard callbacks with the correct widgetType for discover split', function () {
+        const widget = {
+          displayType: types.DisplayType.TABLE,
+          interval: '1d',
+          queries: [
+            {
+              name: 'Test Widget',
+              fields: ['count()', 'count_unique(user)', 'epm()', 'project'],
+              columns: ['project'],
+              aggregates: ['count()', 'count_unique(user)', 'epm()'],
+              conditions: '',
+              orderby: '',
+            },
+          ],
+          title: 'Transactions',
+          id: '1',
+          widgetType: types.WidgetType.DISCOVER,
+        };
+        const mockDashboard = DashboardFixture([widget], {
+          id: '1',
+          title: 'Custom Errors',
+        });
+        const mockModifiedDashboard = DashboardFixture([widget], {
+          id: '1',
+          title: 'Custom Errors',
+        });
+
+        const mockOnDashboardUpdate = jest.fn();
+        const mockStateSetter = jest
+          .fn()
+          .mockImplementation(fn => fn({modifiedDashboard: mockModifiedDashboard}));
+
+        handleUpdateDashboardSplit({
+          widgetId: '1',
+          splitDecision: types.WidgetType.ERRORS,
+          dashboard: mockDashboard,
+          modifiedDashboard: mockModifiedDashboard,
+          onDashboardUpdate: mockOnDashboardUpdate,
+          stateSetter: mockStateSetter,
+        });
+
+        expect(mockOnDashboardUpdate).toHaveBeenCalledWith({
+          ...mockDashboard,
+          widgets: [{...widget, widgetType: types.WidgetType.ERRORS}],
+        });
+        expect(mockStateSetter).toHaveReturnedWith({
+          modifiedDashboard: {
+            ...mockModifiedDashboard,
+            widgets: [{...widget, widgetType: types.WidgetType.ERRORS}],
+          },
+        });
+      });
     });
   });
 });

--- a/static/app/views/dashboards/detail.tsx
+++ b/static/app/views/dashboards/detail.tsx
@@ -120,6 +120,48 @@ type State = {
   widgetLimitReached: boolean;
 } & WidgetViewerContextProps;
 
+export function handleUpdateDashboardSplit({
+  widgetId,
+  splitDecision,
+  dashboard,
+  onDashboardUpdate,
+  modifiedDashboard,
+  stateSetter,
+}: {
+  dashboard: DashboardDetails;
+  modifiedDashboard: DashboardDetails | null;
+  splitDecision: WidgetType;
+  stateSetter: Component<Props, State, any>['setState'];
+  widgetId: string;
+  onDashboardUpdate?: (updatedDashboard: DashboardDetails) => void;
+}) {
+  // The underlying dashboard needs to be updated with the split decision
+  // because the backend has evaluated the query and stored that value
+  const updatedDashboard = cloneDashboard(dashboard);
+  const widgetIndex = updatedDashboard.widgets.findIndex(
+    widget => widget.id === widgetId
+  );
+
+  if (widgetIndex >= 0) {
+    updatedDashboard.widgets[widgetIndex].widgetType = splitDecision;
+  }
+  onDashboardUpdate?.(updatedDashboard);
+
+  // The modified dashboard also needs to be updated because that dashboard
+  // is rendered instead of the original dashboard when editing
+  if (modifiedDashboard) {
+    stateSetter(state => ({
+      ...state,
+      modifiedDashboard: {
+        ...state.modifiedDashboard!,
+        widgets: state.modifiedDashboard!.widgets.map(widget =>
+          widget.id === widgetId ? {...widget, widgetType: splitDecision} : widget
+        ),
+      },
+    }));
+  }
+}
+
 class DashboardDetail extends Component<Props, State> {
   state: State = {
     dashboardState: this.props.initialState,
@@ -686,33 +728,14 @@ class DashboardDetail extends Component<Props, State> {
             ? this.onUpdateWidget
             : this.handleUpdateWidgetList,
           updateDashboardSplitDecision: (widgetId: string, splitDecision: WidgetType) => {
-            // The underlying dashboard needs to be updated with the split decision
-            // because the backend has evaluated the query and stored that value
-            const updatedDashboard = cloneDashboard(dashboard);
-            const widgetIndex = updatedDashboard.widgets.findIndex(
-              widget => widget.id === widgetId
-            );
-
-            if (widgetIndex >= 0) {
-              updatedDashboard.widgets[widgetIndex].widgetType = splitDecision;
-            }
-            onDashboardUpdate?.(updatedDashboard);
-
-            // The modified dashboard also needs to be updated because that dashboard
-            // is rendered instead of the original dashboard when editing
-            if (modifiedDashboard) {
-              this.setState(state => ({
-                ...state,
-                modifiedDashboard: {
-                  ...state.modifiedDashboard!,
-                  widgets: state.modifiedDashboard!.widgets.map(widget =>
-                    widget.id === widgetId
-                      ? {...widget, widgetType: splitDecision}
-                      : widget
-                  ),
-                },
-              }));
-            }
+            handleUpdateDashboardSplit({
+              widgetId,
+              splitDecision,
+              dashboard,
+              modifiedDashboard,
+              stateSetter: this.setState,
+              onDashboardUpdate,
+            });
           },
         })
       : children;

--- a/static/app/views/dashboards/detail.tsx
+++ b/static/app/views/dashboards/detail.tsx
@@ -676,7 +676,7 @@ class DashboardDetail extends Component<Props, State> {
   };
 
   renderWidgetBuilder() {
-    const {children, dashboard} = this.props;
+    const {children, dashboard, onDashboardUpdate} = this.props;
     const {modifiedDashboard} = this.state;
 
     return isValidElement(children)
@@ -685,6 +685,35 @@ class DashboardDetail extends Component<Props, State> {
           onSave: this.isEditingDashboard
             ? this.onUpdateWidget
             : this.handleUpdateWidgetList,
+          updateDashboardSplitDecision: (widgetId: string, splitDecision: WidgetType) => {
+            // The underlying dashboard needs to be updated with the split decision
+            // because the backend has evaluated the query and stored that value
+            const updatedDashboard = cloneDashboard(dashboard);
+            const widgetIndex = updatedDashboard.widgets.findIndex(
+              widget => widget.id === widgetId
+            );
+
+            if (widgetIndex >= 0) {
+              updatedDashboard.widgets[widgetIndex].widgetType = splitDecision;
+            }
+            onDashboardUpdate?.(updatedDashboard);
+
+            // The modified dashboard also needs to be updated because that dashboard
+            // is rendered instead of the original dashboard when editing
+            if (modifiedDashboard) {
+              this.setState(state => ({
+                ...state,
+                modifiedDashboard: {
+                  ...state.modifiedDashboard!,
+                  widgets: state.modifiedDashboard!.widgets.map(widget =>
+                    widget.id === widgetId
+                      ? {...widget, widgetType: splitDecision}
+                      : widget
+                  ),
+                },
+              }));
+            }
+          },
         })
       : children;
   }

--- a/static/app/views/dashboards/widgetBuilder/widgetBuilder.tsx
+++ b/static/app/views/dashboards/widgetBuilder/widgetBuilder.tsx
@@ -137,6 +137,7 @@ interface Props extends RouteComponentProps<RouteParams, {}> {
   end?: DateString;
   start?: DateString;
   statsPeriod?: string | null;
+  updateDashboardSplitDecision?: (widgetId: string, splitDecision: WidgetType) => void;
 }
 
 interface State {
@@ -173,6 +174,7 @@ function WidgetBuilder({
   route,
   router,
   tags,
+  updateDashboardSplitDecision,
 }: Props) {
   const {widgetIndex, orgId, dashboardId} = params;
   const {source, displayType, defaultTitle, limit, dataset} = location.query;
@@ -1015,6 +1017,12 @@ function WidgetBuilder({
     setState(prevState => {
       return {...cloneDeep(prevState), dataSet: WIDGET_TYPE_TO_DATA_SET[splitDecision]};
     });
+
+    if (currentWidget.id) {
+      // Update the dashboard state with the split decision, in case
+      // the user cancels editing the widget after the decision was made
+      updateDashboardSplitDecision?.(currentWidget.id, splitDecision);
+    }
   }
 
   function isFormInvalid() {


### PR DESCRIPTION
Updates the dashboard state at the same time the widget builder state is updated. This is necessary because the user may have opened the widget builder and triggered a split decision, but they cancelled editing. The parent dashboard state needs to update to reflect that this decision was made.

We need to update the dashboard prop using the `onDashboardUpdate` prop from the org dashboards, as well as the modified dashboard state. Because this has no UI changes, I extracted the helper method to make it easier for me to test the state change. It will mock the state updaters and verify they were called correctly. I also verified in the widget builder that it passes the correct data to this helper