### PR TITLE
ref(breadcrumbs): Increase default display to 5 crumbs.

### DIFF
--- a/static/app/components/events/breadcrumbs/breadcrumbsDataSection.spec.tsx
+++ b/static/app/components/events/breadcrumbs/breadcrumbsDataSection.spec.tsx
@@ -30,6 +30,8 @@ describe('BreadcrumbsDataSection', function () {
     // Only summary crumbs should be visible by default
     const summaryCrumbTitles = [
       'Exception',
+      MOCK_BREADCRUMBS[5].category,
+      MOCK_BREADCRUMBS[4].category,
       MOCK_BREADCRUMBS[3].category,
       MOCK_BREADCRUMBS[2].category,
     ];

--- a/static/app/components/events/breadcrumbs/testUtils.tsx
+++ b/static/app/components/events/breadcrumbs/testUtils.tsx
@@ -35,6 +35,20 @@ export const MOCK_BREADCRUMBS = [
     type: BreadcrumbType.QUERY,
     timestamp: oneMinuteBeforeEventFixture,
   },
+  {
+    message: 'my logger',
+    category: 'custom.logger',
+    level: BreadcrumbLevelType.UNDEFINED,
+    type: BreadcrumbType.DEFAULT,
+    timestamp: oneMinuteBeforeEventFixture,
+  },
+  {
+    message: 'my analytics',
+    category: 'analytics.event',
+    level: BreadcrumbLevelType.INFO,
+    type: BreadcrumbType.DEFAULT,
+    timestamp: oneMinuteBeforeEventFixture,
+  },
 ];
 const MOCK_BREADCRUMB_ENTRY = {
   type: EntryType.BREADCRUMBS,

--- a/static/app/components/events/breadcrumbs/utils.tsx
+++ b/static/app/components/events/breadcrumbs/utils.tsx
@@ -35,7 +35,7 @@ import {EntryType, type Event} from 'sentry/types/event';
 import {toTitleCase} from 'sentry/utils/string/toTitleCase';
 
 const BREADCRUMB_TITLE_PLACEHOLDER = t('Generic');
-const BREADCRUMB_SUMMARY_COUNT = 3;
+const BREADCRUMB_SUMMARY_COUNT = 5;
 
 export const enum BreadcrumbTimeDisplay {
   RELATIVE = 'relative',


### PR DESCRIPTION
In the new UI, we'll now display 5 crumbs instead of 3 on the issue details page. The rest will still be accessible in the drawer.