### PR TITLE
feat(insights): add release markings to fullscreen insight charts

### DIFF
--- a/static/app/components/modals/insightChartModal.tsx
+++ b/static/app/components/modals/insightChartModal.tsx
@@ -5,7 +5,7 @@ import styled from '@emotion/styled';
 
 import type {ModalRenderProps} from 'sentry/actionCreators/modal';
 import {space} from 'sentry/styles/space';
-import {ChartHeightContext} from 'sentry/views/insights/common/components/chart';
+import {ChartRenderingContext} from 'sentry/views/insights/common/components/chart';
 
 export type InsightChartModalOptions = {
   children: React.ReactNode;
@@ -21,7 +21,9 @@ export default function InsightChartModal({Header, title, children}: Props) {
           <h3>{title}</h3>
         </Header>
 
-        <ChartHeightContext.Provider value={300}>{children}</ChartHeightContext.Provider>
+        <ChartRenderingContext.Provider value={{height: 300, isFullscreen: true}}>
+          {children}
+        </ChartRenderingContext.Provider>
       </Container>
     </Fragment>
   );
@@ -31,6 +33,7 @@ const Container = styled('div')<{height?: number | null}>`
   height: ${p => (p.height ? `${p.height}px` : 'auto')};
   position: relative;
   padding-bottom: ${space(3)};
+  z-index: 1000;
 `;
 
 export const modalCss = css`

--- a/static/app/views/insights/http/components/charts/durationChart.tsx
+++ b/static/app/views/insights/http/components/charts/durationChart.tsx
@@ -29,6 +29,8 @@ export function DurationChart({
 }: Props) {
   // TODO: This is duplicated from `DurationChart` in `SampleList`. Resolve the duplication
   const handleChartHighlight: EChartHighlightHandler = function (event) {
+    if (!event.batch) return;
+
     // TODO: Gross hack. Even though `scatterPlot` is a separate prop, it's just an array of `Series` that gets appended to the main series. To find the point that was hovered, we re-construct the correct series order. It would have been cleaner to just pass the scatter plot as its own, single series
     const allSeries = [...series, ...(scatterPlot ?? [])];
 

--- a/static/app/views/insights/http/components/charts/durationChart.tsx
+++ b/static/app/views/insights/http/components/charts/durationChart.tsx
@@ -29,6 +29,7 @@ export function DurationChart({
 }: Props) {
   // TODO: This is duplicated from `DurationChart` in `SampleList`. Resolve the duplication
   const handleChartHighlight: EChartHighlightHandler = function (event) {
+    // ignore mouse hovering over the chart legend
     if (!event.batch) return;
 
     // TODO: Gross hack. Even though `scatterPlot` is a separate prop, it's just an array of `Series` that gets appended to the main series. To find the point that was hovered, we re-construct the correct series order. It would have been cleaner to just pass the scatter plot as its own, single series


### PR DESCRIPTION
let's try https://github.com/getsentry/sentry/pull/74656 again

releases on span samples look like:
![image](https://github.com/user-attachments/assets/6a418e01-976d-495c-ac21-2c109372c76e)
