### PR TITLE
chore(seer grouping): Remove metadata flag and killswitch

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -537,8 +537,6 @@ def register_temporary_features(manager: FeatureManager):
     manager.add("projects:similarity-embeddings-delete-by-hash", ProjectFeature, FeatureHandlerStrategy.OPTIONS, api_expose=False)
     # Enable similarity embeddings grouping
     manager.add("projects:similarity-embeddings-grouping", ProjectFeature, FeatureHandlerStrategy.INTERNAL, default=False, api_expose=False)
-    # Enable adding seer grouping metadata to new groups
-    manager.add("projects:similarity-embeddings-metadata", ProjectFeature, FeatureHandlerStrategy.INTERNAL, default=False, api_expose=False)
     manager.add("projects:similarity-indexing", ProjectFeature, FeatureHandlerStrategy.INTERNAL, api_expose=False)
     manager.add("projects:similarity-view", ProjectFeature, FeatureHandlerStrategy.INTERNAL, api_expose=True)
     # Starfish: extract metrics from the spans

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -843,12 +843,6 @@ register(
     flags=FLAG_MODIFIABLE_BOOL | FLAG_AUTOMATOR_MODIFIABLE,
 )
 register(
-    "seer.similarity-embeddings-metadata-killswitch.enabled",
-    default=False,
-    type=Bool,
-    flags=FLAG_MODIFIABLE_BOOL | FLAG_AUTOMATOR_MODIFIABLE,
-)
-register(
     "seer.similarity-embeddings-delete-by-hash-killswitch.enabled",
     default=False,
     type=Bool,


### PR DESCRIPTION
This removes the `projects:similarity-embeddings-metadata` flag, which we [no longer use](https://github.com/getsentry/sentry/pull/74914) and whose feature handler [has also been removed](https://github.com/getsentry/getsentry/pull/14743), and the `seer.similarity-embeddings-metadata-killswitch.enabled` option, which we've never actually used.