### PR TITLE
feat(toolbar): add crash free rate to release panel

### DIFF
--- a/static/app/components/devtoolbar/components/alerts/alertsPanel.tsx
+++ b/static/app/components/devtoolbar/components/alerts/alertsPanel.tsx
@@ -43,7 +43,7 @@ export default function AlertsPanel() {
     <PanelLayout title="Alerts">
       <div css={[smallCss, panelSectionCss, panelInsetContentCss]}>
         <span css={[resetFlexRowCss, {gap: 'var(--space50)'}]}>
-          Active Alerts in{' '}
+          Active alerts in{' '}
           <SentryAppLink
             to={{url: `/projects/${projectSlug}/`}}
             onClick={() => {

--- a/static/app/components/devtoolbar/components/featureFlags/featureFlagsPanel.tsx
+++ b/static/app/components/devtoolbar/components/featureFlags/featureFlagsPanel.tsx
@@ -26,7 +26,9 @@ export default function FeatureFlagsPanel() {
   return (
     <PanelLayout title="Feature Flags">
       <div css={[smallCss, panelSectionCss, panelInsetContentCss]}>
-        <span>Flags enabled for {organizationSlug}</span>
+        <span>
+          Flags enabled for <code>{organizationSlug}</code>
+        </span>
       </div>
       <PanelTable
         headers={[

--- a/static/app/components/devtoolbar/components/releases/releasesPanel.tsx
+++ b/static/app/components/devtoolbar/components/releases/releasesPanel.tsx
@@ -143,8 +143,8 @@ function CrashFreeRate({
 
   const currCrashFreeRate = getCrashFreeRate(currSessionData);
   const prevCrashFreeRate = getCrashFreeRate(prevSessionData);
-  const diff = (currCrashFreeRate - prevCrashFreeRate).toFixed(2);
-  const sign = Math.sign(parseFloat(diff));
+  const diff = currCrashFreeRate - prevCrashFreeRate;
+  const sign = Math.sign(diff);
 
   return (
     <PanelItem>
@@ -160,7 +160,7 @@ function CrashFreeRate({
           <span css={resetFlexColumnCss}>
             Change
             {getDiff(
-              Math.abs(parseFloat(diff)) + '%',
+              Math.abs(diff).toFixed(2) + '%',
               sign === 0 ? 'black' : sign === 1 ? 'green400' : 'red400',
               sign === 0 ? undefined : sign === 1 ? 'up' : 'down'
             )}

--- a/static/app/components/devtoolbar/components/releases/releasesPanel.tsx
+++ b/static/app/components/devtoolbar/components/releases/releasesPanel.tsx
@@ -5,19 +5,25 @@ import useReleaseSessions from 'sentry/components/devtoolbar/components/releases
 import useToolbarRelease from 'sentry/components/devtoolbar/components/releases/useToolbarRelease';
 import SentryAppLink from 'sentry/components/devtoolbar/components/sentryAppLink';
 import {listItemPlaceholderWrapperCss} from 'sentry/components/devtoolbar/styles/listItem';
+import {infoHeaderCss} from 'sentry/components/devtoolbar/styles/releasesPanel';
 import {
   resetFlexColumnCss,
   resetFlexRowCss,
 } from 'sentry/components/devtoolbar/styles/reset';
 import ProjectBadge from 'sentry/components/idBadge/projectBadge';
+import PanelItem from 'sentry/components/panels/panelItem';
 import Placeholder from 'sentry/components/placeholder';
 import TextOverflow from 'sentry/components/textOverflow';
 import TimeSince from 'sentry/components/timeSince';
-import {SessionFieldWithOperation} from 'sentry/types/organization';
+import {IconArrow} from 'sentry/icons/iconArrow';
 import type {PlatformKey} from 'sentry/types/project';
 import type {Release} from 'sentry/types/release';
-import {getCrashFreeRate} from 'sentry/utils/sessions';
+import {defined} from 'sentry/utils';
 import {formatVersion} from 'sentry/utils/versions/formatVersion';
+import {
+  Change,
+  type ReleaseComparisonRow,
+} from 'sentry/views/releases/detail/overview/releaseComparisonChart';
 import {
   PackageName,
   ReleaseInfoHeader,
@@ -31,10 +37,32 @@ import {panelInsetContentCss, panelSectionCss} from '../../styles/panel';
 import {smallCss} from '../../styles/typography';
 import PanelLayout from '../panelLayout';
 
+function getCrashFreeRate(data) {
+  return ((data?.json.groups[0].totals['crash_free_rate(session)'] ?? 1) * 100).toFixed(
+    2
+  );
+}
+
+function getChartDiff(
+  diff: string,
+  diffColor: ReleaseComparisonRow['diffColor'],
+  diffDirection: 'up' | 'down' | undefined
+) {
+  return diff ? (
+    <Change
+      color={defined(diffColor) ? diffColor : 'black'}
+      css={[resetFlexRowCss, `align-items: center; gap: 3px`]}
+    >
+      {diff}
+      {defined(diffDirection) ? <IconArrow direction={diffDirection} size="xs" /> : null}
+    </Change>
+  ) : null;
+}
+
 function ReleaseHeader({release, orgSlug}: {orgSlug: string; release: Release}) {
   return (
-    <div style={{padding: '12px'}}>
-      <ReleaseInfoHeader>
+    <PanelItem style={{width: '100%', alignItems: 'flex-start'}}>
+      <ReleaseInfoHeader css={[infoHeaderCss]}>
         <SentryAppLink
           to={{
             url: `/organizations/${orgSlug}/releases/${encodeURIComponent(release.version)}/`,
@@ -48,7 +76,12 @@ function ReleaseHeader({release, orgSlug}: {orgSlug: string; release: Release}) 
         )}
       </ReleaseInfoHeader>
       <ReleaseInfoSubheader
-        style={{display: 'flex', flexDirection: 'column', alignItems: 'flex-start'}}
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'flex-start',
+          fontSize: '14px',
+        }}
       >
         {release.versionInfo?.package && (
           <PackageName>
@@ -63,23 +96,57 @@ function ReleaseHeader({release, orgSlug}: {orgSlug: string; release: Release}) 
             ` \u007C ${release.lastDeploy.environment}`}
         </span>
       </ReleaseInfoSubheader>
-    </div>
+    </PanelItem>
   );
 }
 
-function CrashFreeRate({releaseVersion}: {releaseVersion: string}) {
-  const {
-    data: sessionData,
-    isLoading: _isSessionDataLoading,
-    isError: _isSessionDataError,
-  } = useReleaseSessions({releaseVersion});
+function CrashFreeRate({
+  prevReleaseVersion,
+  currReleaseVersion,
+}: {
+  currReleaseVersion: string;
+  prevReleaseVersion: string;
+}) {
+  const {data: currSessionData, isLoading: isCurrLoading} = useReleaseSessions({
+    releaseVersion: currReleaseVersion,
+  });
+  const {data: prevSessionData, isLoading: isPrevLoading} = useReleaseSessions({
+    releaseVersion: prevReleaseVersion,
+  });
 
-  const crashFreeRate = getCrashFreeRate(
-    sessionData?.json.groups,
-    SessionFieldWithOperation.CRASH_FREE_RATE_SESSIONS
+  const currCrashFreeRate = getCrashFreeRate(currSessionData);
+  const prevCrashFreeRate = getCrashFreeRate(prevSessionData);
+  const diff = (parseFloat(currCrashFreeRate) - parseFloat(prevCrashFreeRate)).toFixed(2);
+  const diffIsZero = parseFloat(diff) === 0;
+  const posDiff = parseFloat(diff) > 0;
+
+  return (
+    <PanelItem>
+      <div css={[infoHeaderCss]}>Crash Free Session Rate</div>
+      <ReleaseInfoSubheader style={{fontSize: '14px'}}>
+        {isPrevLoading || isCurrLoading ? (
+          <Placeholder width="252px" height="40px" />
+        ) : (
+          <span style={{display: 'flex', gap: '16px', flexDirection: 'row'}}>
+            <span css={[resetFlexColumnCss]}>
+              <span>This release</span> {currCrashFreeRate}%
+            </span>
+            <span css={[resetFlexColumnCss]}>
+              <span>Prev release</span> {prevCrashFreeRate}%
+            </span>
+            <span css={[resetFlexColumnCss]}>
+              <span>Change</span>
+              {getChartDiff(
+                Math.abs(parseFloat(diff)) + '%',
+                diffIsZero ? 'black' : posDiff ? 'green400' : 'red400',
+                diffIsZero ? undefined : posDiff ? 'up' : 'down'
+              )}
+            </span>
+          </span>
+        )}
+      </ReleaseInfoSubheader>
+    </PanelItem>
   );
-
-  return <p>Crash Free Rate is {crashFreeRate}</p>;
 }
 
 export default function ReleasesPanel() {
@@ -92,11 +159,54 @@ export default function ReleasesPanel() {
   const {organizationSlug, projectSlug, projectId, projectPlatform, trackAnalytics} =
     useConfiguration();
 
-  const estimateSize = 515;
+  const estimateSize = 100;
   const placeholderHeight = `${estimateSize - 8}px`; // The real height of the items, minus the padding-block value
 
   return (
     <PanelLayout title="Latest Release">
+      <span
+        css={[
+          smallCss,
+          panelSectionCss,
+          panelInsetContentCss,
+          resetFlexRowCss,
+          {gap: 'var(--space50)', flexGrow: 0},
+        ]}
+      >
+        Latest release for{' '}
+        <SentryAppLink
+          to={{
+            url: `/releases/`,
+            query: {project: projectId},
+          }}
+          onClick={() => {
+            trackAnalytics?.({
+              eventKey: `devtoolbar.releases-list.header.click`,
+              eventName: `devtoolbar: Click releases-list header`,
+            });
+          }}
+        >
+          <div
+            css={[
+              resetFlexRowCss,
+              {display: 'inline-flex', gap: 'var(--space50)', alignItems: 'center'},
+            ]}
+          >
+            <ProjectBadge
+              css={css({'&& img': {boxShadow: 'none'}})}
+              project={{
+                slug: projectSlug,
+                id: projectId,
+                platform: projectPlatform as PlatformKey,
+              }}
+              avatarSize={16}
+              hideName
+              avatarProps={{hasTooltip: false}}
+            />
+            {projectSlug}
+          </div>
+        </SentryAppLink>
+      </span>
       {isReleaseDataLoading || isReleaseDataError ? (
         <div
           css={[
@@ -107,49 +217,16 @@ export default function ReleasesPanel() {
           ]}
         >
           <Placeholder height={placeholderHeight} />
+          <Placeholder height={placeholderHeight} />
         </div>
       ) : (
         <Fragment>
-          <div css={[smallCss, panelSectionCss, panelInsetContentCss]}>
-            <span css={[resetFlexRowCss, {gap: 'var(--space50)'}]}>
-              Latest release for{' '}
-              <SentryAppLink
-                to={{
-                  url: `/releases/`,
-                  query: {project: projectId},
-                }}
-                onClick={() => {
-                  trackAnalytics?.({
-                    eventKey: `devtoolbar.releases-list.header.click`,
-                    eventName: `devtoolbar: Click releases-list header`,
-                  });
-                }}
-              >
-                <div
-                  css={[
-                    resetFlexRowCss,
-                    {display: 'inline-flex', gap: 'var(--space50)', alignItems: 'center'},
-                  ]}
-                >
-                  <ProjectBadge
-                    css={css({'&& img': {boxShadow: 'none'}})}
-                    project={{
-                      slug: projectSlug,
-                      id: projectId,
-                      platform: projectPlatform as PlatformKey,
-                    }}
-                    avatarSize={16}
-                    hideName
-                    avatarProps={{hasTooltip: false}}
-                  />
-                  {projectSlug}
-                </div>
-              </SentryAppLink>
-            </span>
-          </div>
           <div style={{alignItems: 'start'}}>
             <ReleaseHeader release={releaseData.json[0]} orgSlug={organizationSlug} />
-            <CrashFreeRate releaseVersion={releaseData.json[0].version} />
+            <CrashFreeRate
+              currReleaseVersion={releaseData.json[0].version}
+              prevReleaseVersion={releaseData.json[1].version}
+            />
           </div>
         </Fragment>
       )}

--- a/static/app/components/devtoolbar/components/releases/releasesPanel.tsx
+++ b/static/app/components/devtoolbar/components/releases/releasesPanel.tsx
@@ -41,7 +41,7 @@ import {panelInsetContentCss, panelSectionCss} from '../../styles/panel';
 import {smallCss} from '../../styles/typography';
 import PanelLayout from '../panelLayout';
 
-const estimateSize = 85;
+const estimateSize = 81;
 const placeholderHeight = `${estimateSize - 8}px`; // The real height of the items, minus the padding-block value
 
 function getCrashFreeRate(data: ApiResult<SessionApiResponse>): number {
@@ -127,7 +127,7 @@ function CrashFreeRate({
 
   if (isCurrLoading || isPrevLoading) {
     return (
-      <PanelItem css={{width: '100%', padding: 'var(--space100)'}}>
+      <PanelItem css={{width: '100%', padding: 'var(--space150)'}}>
         <Placeholder
           height={placeholderHeight}
           css={[

--- a/static/app/components/devtoolbar/components/releases/useReleaseSessions.tsx
+++ b/static/app/components/devtoolbar/components/releases/useReleaseSessions.tsx
@@ -1,0 +1,34 @@
+import {useMemo} from 'react';
+
+import useConfiguration from 'sentry/components/devtoolbar/hooks/useConfiguration';
+import useFetchApiData from 'sentry/components/devtoolbar/hooks/useFetchApiData';
+import type {ApiEndpointQueryKey} from 'sentry/components/devtoolbar/types';
+import type {SessionApiResponse} from 'sentry/types/organization';
+
+export default function useReleaseSessions({
+  releaseVersion,
+}: {
+  releaseVersion: string | undefined;
+}) {
+  const {organizationSlug, projectId} = useConfiguration();
+  return useFetchApiData<SessionApiResponse>({
+    queryKey: useMemo(
+      (): ApiEndpointQueryKey => [
+        'io.sentry.toolbar',
+        `/organizations/${organizationSlug}/sessions/`,
+        {
+          query: {
+            queryReferrer: 'devtoolbar',
+            project: [projectId],
+            field: 'crash_free_rate(session)',
+            interval: '5m',
+            statsPeriod: '24h',
+            query: `release:${releaseVersion}`,
+          },
+        },
+      ],
+      [organizationSlug, projectId, releaseVersion]
+    ),
+    cacheTime: 5000,
+  });
+}

--- a/static/app/components/devtoolbar/components/releases/useReleaseSessions.tsx
+++ b/static/app/components/devtoolbar/components/releases/useReleaseSessions.tsx
@@ -21,7 +21,7 @@ export default function useReleaseSessions({
             queryReferrer: 'devtoolbar',
             project: [projectId],
             field: 'crash_free_rate(session)',
-            interval: '5m',
+            interval: '10m',
             statsPeriod: '24h',
             query: `release:${releaseVersion}`,
           },

--- a/static/app/components/devtoolbar/components/releases/useToolbarRelease.tsx
+++ b/static/app/components/devtoolbar/components/releases/useToolbarRelease.tsx
@@ -23,6 +23,6 @@ export default function useToolbarRelease() {
       ],
       [organizationSlug, projectSlug]
     ),
-    cacheTime: Infinity,
+    cacheTime: 5000,
   });
 }

--- a/static/app/components/devtoolbar/styles/releasesPanel.ts
+++ b/static/app/components/devtoolbar/styles/releasesPanel.ts
@@ -1,0 +1,6 @@
+import {css} from '@emotion/react';
+
+export const infoHeaderCss = css`
+  font-size: 16px;
+  font-weight: bold;
+`;

--- a/static/app/components/devtoolbar/styles/releasesPanel.ts
+++ b/static/app/components/devtoolbar/styles/releasesPanel.ts
@@ -4,3 +4,7 @@ export const infoHeaderCss = css`
   font-size: 16px;
   font-weight: bold;
 `;
+
+export const subtextCss = css`
+  font-size: 14px;
+`;

--- a/static/app/views/releases/detail/overview/releaseComparisonChart/index.tsx
+++ b/static/app/views/releases/detail/overview/releaseComparisonChart/index.tsx
@@ -17,18 +17,16 @@ import {Tooltip} from 'sentry/components/tooltip';
 import {IconArrow, IconChevron, IconList, IconWarning} from 'sentry/icons';
 import {t, tct, tn} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
-import type {
-  Organization,
-  PlatformKey,
-  ReleaseProject,
-  ReleaseWithHealth,
-  SessionApiResponse,
-} from 'sentry/types';
 import {
+  type PlatformKey,
   ReleaseComparisonChartType,
+  type ReleaseProject,
+  type ReleaseWithHealth,
+  type SessionApiResponse,
   SessionFieldWithOperation,
   SessionStatus,
 } from 'sentry/types';
+import type {Organization} from 'sentry/types/organization';
 import {defined} from 'sentry/utils';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {browserHistory} from 'sentry/utils/browserHistory';
@@ -1031,7 +1029,7 @@ const DescriptionCell = styled(Cell)`
   overflow: visible;
 `;
 
-const Change = styled('div')<{color?: Color}>`
+export const Change = styled('div')<{color?: Color}>`
   font-size: ${p => p.theme.fontSizeMedium};
   ${p => p.color && `color: ${p.theme[p.color]}`}
 `;


### PR DESCRIPTION
- closes https://github.com/getsentry/sentry/issues/74566
- relates to https://github.com/getsentry/sentry/issues/74565


https://github.com/user-attachments/assets/3de2b293-9491-43cb-8272-40fb064eee52



