### PR TITLE
chore: Guard against bad imports related to devtoolbar

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -26,6 +26,17 @@ module.exports = {
       'error',
       {additionalHooks: '(useEffectAfterFirstRender|useMemoWithPrevious)'},
     ],
+    'no-restricted-imports': [
+      'error',
+      {
+        patterns: [
+          {
+            group: ['sentry/components/devtoolbar/*'],
+            message: 'Do not depend on toolbar internals',
+          },
+        ],
+      },
+    ],
 
     // TODO(@anonrig): Remove this from eslint-sentry-config
     'space-infix-ops': 'off',
@@ -44,6 +55,23 @@ module.exports = {
   // and formatting these files.
   ignorePatterns: ['*.json'],
   overrides: [
+    {
+      files: ['static/app/components/devtoolbar/**/*.{ts,tsx}'],
+      rules: {
+        'no-restricted-imports': [
+          'error',
+          {
+            paths: [
+              {
+                name: 'sentry/utils/queryClient',
+                message:
+                  'Import from `@tanstack/react-query` and `./hooks/useFetchApiData` or `./hooks/useFetchInfiniteApiData` instead.',
+              },
+            ],
+          },
+        ],
+      },
+    },
     {
       files: ['static/**/*.spec.{ts,js}', 'tests/js/**/*.{ts,js}'],
       extends: ['plugin:testing-library/react', 'sentry-app/strict'],


### PR DESCRIPTION
The toolbar is a little world, we shouldn't import from it (but it's re-using things from all over sentry!)

Also, there's some specific spots that it shouldn't be importing from. Right now just queryClient, but over time that list will probably grow as they get further apart.

The getsentry version of this is https://github.com/getsentry/getsentry/pull/14747