### PR TITLE
fix(autofix): update markdown rendering to be more readable

### DIFF
--- a/static/app/components/events/autofix/autofixSteps.tsx
+++ b/static/app/components/events/autofix/autofixSteps.tsx
@@ -111,13 +111,33 @@ function Progress({
   progress: AutofixProgressItem | AutofixStep;
   runId: string;
 }) {
+  function replaceHeadersWithBold(markdown) {
+    const headerRegex = /^(#{1,6})\s+(.*)$/gm;
+    const boldMarkdown = markdown.replace(headerRegex, (_match, _hashes, content) => {
+      return ` **${content}** `;
+    });
+
+    return boldMarkdown;
+  }
+
   if (isProgressLog(progress)) {
+    const html = progress.message.includes('\n')
+      ? marked(replaceHeadersWithBold(progress.message), {
+          breaks: true,
+          gfm: true,
+        })
+      : singleLineRenderer(replaceHeadersWithBold(progress.message), {
+          breaks: true,
+          gfm: true,
+        });
+
     return (
       <Fragment>
         <DateTime date={progress.timestamp} format="HH:mm:ss:SSS" />
         <div
+          style={{overflowX: 'scroll', overflowY: 'hidden'}}
           dangerouslySetInnerHTML={{
-            __html: marked(progress.message),
+            __html: html,
           }}
         />
       </Fragment>

--- a/static/app/components/events/autofix/autofixSteps.tsx
+++ b/static/app/components/events/autofix/autofixSteps.tsx
@@ -111,7 +111,7 @@ function Progress({
   progress: AutofixProgressItem | AutofixStep;
   runId: string;
 }) {
-  function replaceHeadersWithBold(markdown) {
+  function replaceHeadersWithBold(markdown: string) {
     const headerRegex = /^(#{1,6})\s+(.*)$/gm;
     const boldMarkdown = markdown.replace(headerRegex, (_match, _hashes, content) => {
       return ` **${content}** `;


### PR DESCRIPTION
Remove big headers from markdown in logs, remove huge padding, and allow horizontal scrolling for code snippets and logs that overflow off screen.