### PR TITLE
fix: disable edit token in custom integrations page

### DIFF
--- a/static/app/views/settings/account/apiTokenRow.spec.tsx
+++ b/static/app/views/settings/account/apiTokenRow.spec.tsx
@@ -10,13 +10,30 @@ import {
 import ApiTokenRow from 'sentry/views/settings/account/apiTokenRow';
 
 describe('ApiTokenRow', () => {
-  it('renders', () => {
-    render(<ApiTokenRow onRemove={() => {}} token={ApiTokenFixture()} />);
+  it('renders link when can edit', () => {
+    render(
+      <ApiTokenRow
+        onRemove={() => {}}
+        token={ApiTokenFixture({id: '1', name: 'token1'})}
+        canEdit
+      />
+    );
+    screen.getByRole('link', {name: /token1/i});
+  });
+
+  it('renders text when cannot edit', () => {
+    render(
+      <ApiTokenRow
+        onRemove={() => {}}
+        token={ApiTokenFixture({id: '1', name: 'token1'})}
+      />
+    );
+    screen.getByRole('heading', {name: /token1/i});
   });
 
   it('calls onRemove callback when trash can is clicked', async () => {
     const cb = jest.fn();
-    render(<ApiTokenRow onRemove={cb} token={ApiTokenFixture()} />);
+    render(<ApiTokenRow onRemove={cb} token={ApiTokenFixture()} canEdit />);
     renderGlobalModal();
 
     await userEvent.click(screen.getByLabelText('Remove'));
@@ -29,7 +46,7 @@ describe('ApiTokenRow', () => {
     token.tokenLastCharacters = 'a1b2c3d4';
 
     const cb = jest.fn();
-    render(<ApiTokenRow onRemove={cb} token={token} />);
+    render(<ApiTokenRow onRemove={cb} token={token} canEdit />);
     expect(screen.queryByLabelText('Token preview')).toBeInTheDocument();
   });
 });

--- a/static/app/views/settings/account/apiTokenRow.tsx
+++ b/static/app/views/settings/account/apiTokenRow.tsx
@@ -15,25 +15,30 @@ import {tokenPreview} from 'sentry/views/settings/organizationAuthTokens';
 type Props = {
   onRemove: (token: InternalAppApiToken) => void;
   token: InternalAppApiToken;
+  canEdit?: boolean;
   tokenPrefix?: string;
 };
 
-function ApiTokenRow({token, onRemove, tokenPrefix = ''}: Props) {
+function ApiTokenRow({token, onRemove, tokenPrefix = '', canEdit = false}: Props) {
   return (
     <StyledPanelItem>
       <Controls>
-        <LinkWrapper name={token.name}>
-          <Link to={`/settings/account/api/auth-tokens/${token.id}/`}>
-            {token.name ? token.name : 'Token created on '}
-            <DateTime
-              date={getDynamicText({
-                value: token.dateCreated,
-                fixed: new Date(1508208080000), // National Pasta Day
-              })}
-              hidden={!!token.name}
-            />
-          </Link>
-        </LinkWrapper>
+        {canEdit ? (
+          <LinkWrapper name={token.name}>
+            <Link to={`/settings/account/api/auth-tokens/${token.id}/`}>
+              {token.name ? token.name : 'Token created on '}
+              <DateTime
+                date={getDynamicText({
+                  value: token.dateCreated,
+                  fixed: new Date(1508208080000), // National Pasta Day
+                })}
+                hidden={!!token.name}
+              />
+            </Link>
+          </LinkWrapper>
+        ) : (
+          <h1>{token.name ? token.name : ''}</h1>
+        )}
         <ButtonWrapper>
           <Confirm
             onConfirm={() => onRemove(token)}

--- a/static/app/views/settings/account/apiTokens.tsx
+++ b/static/app/views/settings/account/apiTokens.tsx
@@ -134,7 +134,7 @@ export function ApiTokens() {
           )}
 
           {tokenList?.map(token => (
-            <ApiTokenRow key={token.id} token={token} onRemove={deleteToken} />
+            <ApiTokenRow key={token.id} token={token} onRemove={deleteToken} canEdit />
           ))}
         </PanelBody>
       </Panel>


### PR DESCRIPTION
Removed link to edit token name on custom integrations page

![Screenshot 2024-07-25 at 4 05 13 PM](https://github.com/user-attachments/assets/0b8ed719-00fc-4927-83b4-246abba643cd)

