### PR TITLE
ref(snuba): Replace `push_scope` in `mri.py`

### DIFF
--- a/src/sentry/snuba/metrics/naming_layer/mri.py
+++ b/src/sentry/snuba/metrics/naming_layer/mri.py
@@ -270,7 +270,7 @@ def format_mri_field(field: str) -> str:
                     config = condition.config
                     return f'{parsed.op}({config.span_attribute}) filtered by "{condition.value}"'
                 except SpanAttributeExtractionRuleCondition.DoesNotExist:
-                    with sentry_sdk.push_scope() as scope:
+                    with sentry_sdk.new_scope() as scope:
                         scope.set_tag("field", field)
                         sentry_sdk.capture_message(
                             "Trying to format MRI field for non-existent span metric."
@@ -304,7 +304,7 @@ def format_mri_field_value(field: str, value: str) -> str:
                 condition = SpanAttributeExtractionRuleCondition.objects.get(id=condition_id)
                 unit = cast(MetricUnit, condition.config.unit)
             except SpanAttributeExtractionRuleCondition.DoesNotExist:
-                with sentry_sdk.push_scope() as scope:
+                with sentry_sdk.new_scope() as scope:
                     scope.set_tag("field", field)
                     sentry_sdk.capture_message(
                         "Trying to format MRI field for non-existent span metric."


### PR DESCRIPTION
`sentry_sdk.push_scope` is soft-deprecated, and will soon be hard- deprecated (see [sentry-python#3347](https://github.com/getsentry/sentry-python/issues/3347)), so replace the `push_scope` calls with appropriate new API. Here, we use `sentry_sdk.new_scope`, since we are setting tags for a `capture_message` call.

See #74938