### PR TITLE
ref(metrics): Change `push_scope` to `new_scope`

### DIFF
--- a/src/sentry/sentry_metrics/span_attribute_extraction_rules.py
+++ b/src/sentry/sentry_metrics/span_attribute_extraction_rules.py
@@ -20,7 +20,7 @@ def create_extraction_rule_config(request: Request, project: Project, config_upd
             or len(obj["conditions"]) == 0
             or (len(obj["conditions"]) == 1 and obj["conditions"][0] == "")
         ):
-            with sentry_sdk.push_scope() as scope:
+            with sentry_sdk.new_scope() as scope:
                 scope.set_tag("project", project.slug)
                 sentry_sdk.capture_message(
                     "A MetricExtractionRuleConfig without conditions was created.",


### PR DESCRIPTION
`sentry_sdk.push_scope` is soft-deprecated, and will soon be hard- deprecated (see [sentry-python#3347](https://github.com/getsentry/sentry-python/issues/3347)), so replace the `push_scope` calls with appropriate new API. Here, we use `sentry_sdk.new_scope`, since we are setting tags for a `capture_message` call.

Closes #74938