### PR TITLE
fix(csp): Add safari-web-extension to default filter list

### DIFF
--- a/src/sentry/interfaces/security.py
+++ b/src/sentry/interfaces/security.py
@@ -19,6 +19,7 @@ DEFAULT_DISALLOWED_SOURCES = (
     "chromenull://*",
     "data:text/html,chromewebdata",
     "safari-extension://*",
+    "safari-web-extension://*",
     "mxaddon-pkg://*",
     "jar://*",
     "webviewprogressproxy://*",

--- a/tests/sentry/relay/snapshots/test_config/test_get_project_config/REGION.pysnap
+++ b/tests/sentry/relay/snapshots/test_config/test_get_project_config/REGION.pysnap
@@ -34,6 +34,7 @@ config:
       - chromenull://*
       - data:text/html,chromewebdata
       - safari-extension://*
+      - safari-web-extension://*
       - mxaddon-pkg://*
       - jar://*
       - webviewprogressproxy://*


### PR DESCRIPTION
Fixes #74828 and adds `safari-web-extension` to the filter list.