### PR TITLE
fix(metrics): adjust settings labels

### DIFF
--- a/static/app/components/modals/metricWidgetViewerModal/queries.tsx
+++ b/static/app/components/modals/metricWidgetViewerModal/queries.tsx
@@ -293,7 +293,7 @@ function QueryContextMenu({
     const settingsItem = {
       leadingItems: [<IconSettings key="icon" />],
       key: 'settings',
-      label: t('Metric Settings'),
+      label: t('Configure Metric'),
       disabled: !customMetric,
       onAction: () => {
         navigateTo(

--- a/static/app/views/metrics/layout.spec.tsx
+++ b/static/app/views/metrics/layout.spec.tsx
@@ -52,9 +52,9 @@ describe('Metrics Layout', function () {
 
     render(<MetricsLayout />, {organization});
 
-    // Button: Create metric
+    // Button: Create Metric
     expect(
-      await screen.findByRole('button', {name: 'Create metric'})
+      await screen.findByRole('button', {name: 'Create Metric'})
     ).toBeInTheDocument();
 
     // Alert: No alert shall be rendered
@@ -85,8 +85,8 @@ describe('Metrics Layout', function () {
     // Button: Set Up Tracing
     expect(screen.getByRole('button', {name: 'Set Up Tracing'})).toBeInTheDocument();
 
-    // Not in the page: Create metric
-    expect(screen.queryByRole('button', {name: 'Create metric'})).not.toBeInTheDocument();
+    // Not in the page: Create Metric
+    expect(screen.queryByRole('button', {name: 'Create Metric'})).not.toBeInTheDocument();
   });
 
   it('not using performance and have old custom metrics', async function () {
@@ -104,8 +104,8 @@ describe('Metrics Layout', function () {
       await screen.findByText(/Metrics using with the old API will stop being ingested/i)
     ).toBeInTheDocument();
 
-    // Button: Create metric
-    expect(screen.getByRole('button', {name: 'Create metric'})).toBeInTheDocument();
+    // Button: Create Metric
+    expect(screen.getByRole('button', {name: 'Create Metric'})).toBeInTheDocument();
 
     // Main View: Does not display the empty state.
     expect(screen.queryByText(/track and solve what matters/i)).not.toBeInTheDocument();

--- a/static/app/views/metrics/pageHeaderActions.spec.tsx
+++ b/static/app/views/metrics/pageHeaderActions.spec.tsx
@@ -27,7 +27,7 @@ describe('Metrics Page Header Actions', function () {
       expect(addCustomMetric).toHaveBeenCalled();
     });
 
-    it('display "Create metric" button', async function () {
+    it('display "Create Metric" button', async function () {
       render(
         <PageHeaderActions showAddMetricButton addCustomMetric={() => jest.fn()} />,
         {
@@ -41,7 +41,7 @@ describe('Metrics Page Header Actions', function () {
       );
       renderGlobalModal();
 
-      const button = screen.getByRole('button', {name: 'Create metric'});
+      const button = screen.getByRole('button', {name: 'Create Metric'});
 
       expect(button).toBeInTheDocument();
 

--- a/static/app/views/metrics/pageHeaderActions.tsx
+++ b/static/app/views/metrics/pageHeaderActions.tsx
@@ -99,8 +99,8 @@ export function PageHeaderActions({showAddMetricButton, addCustomMetric}: Props)
       },
       {
         leadingItems: [<IconSettings key="icon" />],
-        key: 'configure-metric',
-        label: t('Configure Metric'),
+        key: 'Metrics Settings',
+        label: t('Metrics Settings'),
         onAction: () => navigateTo(`/settings/projects/:projectId/metrics/`, router),
       },
     ],
@@ -154,7 +154,7 @@ export function PageHeaderActions({showAddMetricButton, addCustomMetric}: Props)
             onClick={() => openExtractionRuleCreateModal({})}
             size="sm"
           >
-            {t('Create metric')}
+            {t('Create Metric')}
           </Button>
         ) : (
           <Button priority="primary" onClick={() => addCustomMetric()} size="sm">


### PR DESCRIPTION
- closes: #75038 
- Renames top level _Configure Metric_ to _Metrics Settings_
- Renames query option _Metric Settings_ to _Configure Metric_
- Fixes casing for _Create metric_ button