### PR TITLE
ref(metrics) Remove duplicate __all__ export in metrics utils

### DIFF
--- a/src/sentry/utils/metrics.py
+++ b/src/sentry/utils/metrics.py
@@ -1,6 +1,3 @@
-__all__ = ["timing", "incr"]
-
-
 import functools
 import logging
 import time


### PR DESCRIPTION
`__all__` has been exported twice (second one is on line 24)

#refactorFriday