### PR TITLE
feat(grouping): Remove set-grouping-config flag

### DIFF
--- a/src/sentry/apidocs/examples/project_examples.py
+++ b/src/sentry/apidocs/examples/project_examples.py
@@ -282,7 +282,6 @@ DETAILED_PROJECT = {
             "performance-slow-db-query-visible",
             "performance-n-plus-one-api-calls-visible",
             "profile-image-decode-main-thread-ingest",
-            "set-grouping-config",
             "event-attachments",
             "open-membership",
             "new-spike-protection",

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -407,8 +407,6 @@ def register_temporary_features(manager: FeatureManager):
     manager.add("organizations:session-replay-ui", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, default=True, api_expose=True)
     # Enable replay web vital breadcrumbs
     manager.add("organizations:session-replay-web-vitals", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, default=False, api_expose=True)
-    # Lets organizations manage grouping configs
-    manager.add("organizations:set-grouping-config", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, api_expose=True)
     # Enable description field in Slack metric alerts
     manager.add("organizations:slack-metric-alert-description", OrganizationFeature, FeatureHandlerStrategy.REMOTE, api_expose=False)
     # Enable improvements to Slack notifications


### PR DESCRIPTION
This flag is used internally to allow setting a project grouping config which is being removed in #75053

A `getsentry` PR is required before merging this one.