### PR TITLE
ref(minimetrics): Remove use of sentry_sdk.metrics

### DIFF
--- a/src/sentry/metrics/minimetrics.py
+++ b/src/sentry/metrics/minimetrics.py
@@ -1,122 +1,13 @@
 import random
-from collections.abc import Iterable
-from functools import wraps
-from typing import Any
 
 import sentry_sdk
-from sentry_sdk.metrics import Metric, MetricsAggregator, metrics_noop
+from sentry_sdk.metrics import metrics_noop
 
-from sentry import options
-from sentry.features.rollout import in_random_rollout
 from sentry.metrics.base import MetricsBackend, Tags
-from sentry.utils import metrics
-
-
-def patch_sentry_sdk():
-    real_add = MetricsAggregator.add
-    real_emit = MetricsAggregator._emit
-
-    @metrics_noop
-    def report_tracked_add(ty):
-        metrics.incr(
-            key="minimetrics.add",
-            amount=1,
-            tags={"metric_type": ty},
-            sample_rate=1.0,
-        )
-
-    @wraps(real_add)
-    def tracked_add(
-        self,
-        ty,
-        key,
-        value,
-        unit,
-        tags,
-        timestamp=None,
-        local_aggregator=None,
-        stacklevel=0,
-    ):
-        self._enable_code_locations = options.get("delightful_metrics.enable_code_locations")
-        real_add(self, ty, key, value, unit, tags, timestamp, local_aggregator, stacklevel + 1)
-        report_tracked_add(ty)
-
-    @wraps(real_emit)
-    def patched_emit(
-        self, flushable_buckets: Iterable[tuple[int, dict[Any, Metric]]], code_locations: Any
-    ):
-        if not flushable_buckets and not code_locations:
-            return
-
-        flushable_metrics = []
-        stats_by_type: Any = {}
-        for buckets_timestamp, buckets in flushable_buckets:
-            for bucket_key, metric in buckets.items():
-                flushable_metric = (buckets_timestamp, bucket_key, metric)
-                flushable_metrics.append(flushable_metric)
-                (prev_buckets_count, prev_buckets_weight) = stats_by_type.get(bucket_key[0], (0, 0))
-                stats_by_type[bucket_key[0]] = (
-                    prev_buckets_count + 1,
-                    prev_buckets_weight + metric.weight,
-                )
-
-        for metric_type, (buckets_count, buckets_weight) in stats_by_type.items():
-            metrics.distribution(
-                key="minimetrics.flushed_buckets",
-                value=buckets_count,
-                tags={"metric_type": metric_type},
-                sample_rate=1.0,
-            )
-            metrics.incr(
-                key="minimetrics.flushed_buckets_counter",
-                amount=buckets_count,
-                tags={"metric_type": metric_type},
-                sample_rate=1.0,
-            )
-            metrics.distribution(
-                key="minimetrics.flushed_buckets_weight",
-                value=buckets_weight,
-                tags={"metric_type": metric_type},
-                sample_rate=1.0,
-            )
-            metrics.incr(
-                key="minimetrics.flushed_buckets_weight_counter",
-                amount=buckets_weight,
-                tags={"metric_type": metric_type},
-                sample_rate=1.0,
-            )
-
-        if options.get("delightful_metrics.enable_capture_envelope"):
-            envelope = real_emit(self, flushable_buckets, code_locations)
-            if envelope is not None:
-                metrics.distribution(
-                    key="minimetrics.encoded_metrics_size",
-                    value=len(envelope.items[0].payload.get_bytes()),
-                    sample_rate=1.0,
-                    unit="byte",
-                )
-
-    MetricsAggregator.add = tracked_add  # type: ignore[method-assign]
-    MetricsAggregator._emit = patched_emit  # type: ignore[method-assign]
-
-
-def before_emit_metric(key: str, value: int | float | str, unit: str, tags: dict[str, Any]) -> bool:
-    if not options.get("delightful_metrics.enable_common_tags"):
-        tags.pop("transaction", None)
-        tags.pop("release", None)
-        tags.pop("environment", None)
-    return True
-
-
-def should_summarize_metric(key: str, tags: dict[str, Any]) -> bool:
-    return in_random_rollout("delightful_metrics.metrics_summary_sample_rate")
 
 
 @metrics_noop
 def _set_metric_on_span(key: str, value: float | int, op: str, tags: Tags | None = None) -> None:
-    if not options.get("delightful_metrics.enable_span_attributes"):
-        return
-
     span_or_tx = sentry_sdk.get_current_span()
     if span_or_tx is None:
         return
@@ -131,10 +22,6 @@ class MiniMetricsMetricsBackend(MetricsBackend):
     @staticmethod
     def _keep_metric(sample_rate: float) -> bool:
         return random.random() < sample_rate
-
-    @staticmethod
-    def _legacy_enabled() -> bool:
-        return not options.get("delightful_metrics.minimetrics_disable_legacy")
 
     @staticmethod
     def _to_minimetrics_unit(unit: str | None, default: str | None = None) -> str:
@@ -157,15 +44,6 @@ class MiniMetricsMetricsBackend(MetricsBackend):
         stacklevel: int = 0,
     ) -> None:
         if self._keep_metric(sample_rate):
-            if self._legacy_enabled():
-                sentry_sdk.metrics.incr(
-                    key=self._get_key(key),
-                    value=amount,
-                    tags=tags,
-                    unit=self._to_minimetrics_unit(unit=unit),
-                    stacklevel=stacklevel + 1,
-                )
-
             _set_metric_on_span(key=key, value=amount, op="incr", tags=tags)
 
     def timing(
@@ -178,16 +56,6 @@ class MiniMetricsMetricsBackend(MetricsBackend):
         stacklevel: int = 0,
     ) -> None:
         if self._keep_metric(sample_rate):
-            if self._legacy_enabled():
-                sentry_sdk.metrics.distribution(
-                    key=self._get_key(key),
-                    value=value,
-                    tags=tags,
-                    # Timing is defaulted to seconds.
-                    unit="second",
-                    stacklevel=stacklevel + 1,
-                )
-
             _set_metric_on_span(key=key, value=value, op="timing", tags=tags)
 
     def gauge(
@@ -201,24 +69,6 @@ class MiniMetricsMetricsBackend(MetricsBackend):
         stacklevel: int = 0,
     ) -> None:
         if self._keep_metric(sample_rate):
-            if self._legacy_enabled():
-                if options.get("delightful_metrics.emit_gauges"):
-                    sentry_sdk.metrics.gauge(
-                        key=self._get_key(key),
-                        value=value,
-                        tags=tags,
-                        unit=self._to_minimetrics_unit(unit=unit),
-                        stacklevel=stacklevel + 1,
-                    )
-                else:
-                    sentry_sdk.metrics.incr(
-                        key=self._get_key(key),
-                        value=value,
-                        tags=tags,
-                        unit=self._to_minimetrics_unit(unit=unit),
-                        stacklevel=stacklevel + 1,
-                    )
-
             _set_metric_on_span(key=key, value=value, op="gauge", tags=tags)
 
     def distribution(
@@ -232,15 +82,6 @@ class MiniMetricsMetricsBackend(MetricsBackend):
         stacklevel: int = 0,
     ) -> None:
         if self._keep_metric(sample_rate):
-            if self._legacy_enabled():
-                sentry_sdk.metrics.distribution(
-                    key=self._get_key(key),
-                    value=value,
-                    tags=tags,
-                    unit=self._to_minimetrics_unit(unit=unit),
-                    stacklevel=stacklevel + 1,
-                )
-
             _set_metric_on_span(key=key, value=value, op="distribution", tags=tags)
 
     def event(

--- a/src/sentry/replays/endpoints/project_replay_accessibility_issues.py
+++ b/src/sentry/replays/endpoints/project_replay_accessibility_issues.py
@@ -8,7 +8,6 @@ import requests
 from rest_framework.exceptions import ParseError
 from rest_framework.request import Request
 from rest_framework.response import Response
-from sentry_sdk import metrics
 
 from sentry import features, options
 from sentry.api.api_owners import ApiOwner
@@ -23,6 +22,7 @@ from sentry.replays.usecases.reader import (
 )
 from sentry.replays.usecases.segment import query_segment_storage_meta_by_timestamp
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
+from sentry.utils import metrics
 from sentry.utils.cursors import Cursor, CursorResult
 
 REFERRER = "replays.query.query_replay_clicks_dataset"

--- a/src/sentry/utils/sdk.py
+++ b/src/sentry/utils/sdk.py
@@ -427,8 +427,6 @@ def configure_sdk():
     from sentry_sdk.integrations.redis import RedisIntegration
     from sentry_sdk.integrations.threading import ThreadingIntegration
 
-    from sentry.metrics import minimetrics
-
     # exclude monitors with sub-minute schedules from using crons
     exclude_beat_tasks = [
         "deliver-from-outbox-control",
@@ -439,16 +437,6 @@ def configure_sdk():
         "schedule-digests",
         "check-symbolicator-lpq-project-eligibility",  # defined in getsentry
     ]
-
-    # turn on minimetrics
-    sdk_options.setdefault("_experiments", {}).update(
-        enable_metrics=True,
-        metric_code_locations=options.get("delightful_metrics.enable_code_locations"),
-        before_emit_metric=minimetrics.before_emit_metric,
-        # turn summaries on, but filter them dynamically in the callback
-        metrics_summary_sample_rate=1.0,
-        should_summarize_metric=minimetrics.should_summarize_metric,
-    )
 
     enable_cache_spans = os.getenv("SENTRY_URL_PREFIX") == "sentry.my.sentry.io"
 
@@ -473,8 +461,6 @@ def configure_sdk():
         spotlight=settings.IS_DEV and not settings.NO_SPOTLIGHT,
         **sdk_options,
     )
-
-    minimetrics.patch_sentry_sdk()
 
 
 def check_tag_for_scope_bleed(

--- a/tests/sentry/metrics/test_minimetrics.py
+++ b/tests/sentry/metrics/test_minimetrics.py
@@ -111,15 +111,6 @@ def backend():
         yield rv
 
 
-@override_options(
-    {
-        "delightful_metrics.enable_capture_envelope": True,
-        "delightful_metrics.enable_common_tags": True,
-        "delightful_metrics.enable_code_locations": True,
-        "delightful_metrics.enable_span_attributes": False,
-        "delightful_metrics.minimetrics_disable_legacy": False,
-    }
-)
 def test_incr_called_with_no_tags(backend, scope):
     backend.incr(key="foo", tags={"x": "y"})
     full_flush(scope)
@@ -137,15 +128,6 @@ def test_incr_called_with_no_tags(backend, scope):
     assert len(scope.client.metrics_aggregator.buckets) == 0
 
 
-@override_options(
-    {
-        "delightful_metrics.enable_capture_envelope": True,
-        "delightful_metrics.enable_common_tags": False,
-        "delightful_metrics.enable_code_locations": True,
-        "delightful_metrics.enable_span_attributes": False,
-        "delightful_metrics.minimetrics_disable_legacy": False,
-    }
-)
 def test_incr_called_with_no_tags_and_no_common_tags(backend, scope):
     backend.incr(key="foo", tags={"x": "y"})
     full_flush(scope)
@@ -163,15 +145,6 @@ def test_incr_called_with_no_tags_and_no_common_tags(backend, scope):
     assert len(scope.client.metrics_aggregator.buckets) == 0
 
 
-@override_options(
-    {
-        "delightful_metrics.enable_capture_envelope": True,
-        "delightful_metrics.enable_common_tags": True,
-        "delightful_metrics.enable_code_locations": True,
-        "delightful_metrics.enable_span_attributes": False,
-        "delightful_metrics.minimetrics_disable_legacy": False,
-    }
-)
 def test_incr_called_with_tag_value_as_list(backend, scope):
     # The minimetrics backend supports the list type.
     backend.incr(key="foo", tags={"x": ["bar", "baz"]})
@@ -186,16 +159,6 @@ def test_incr_called_with_tag_value_as_list(backend, scope):
     assert len(scope.client.metrics_aggregator.buckets) == 0
 
 
-@override_options(
-    {
-        "delightful_metrics.enable_capture_envelope": True,
-        "delightful_metrics.enable_common_tags": True,
-        "delightful_metrics.emit_gauges": False,
-        "delightful_metrics.enable_code_locations": True,
-        "delightful_metrics.enable_span_attributes": False,
-        "delightful_metrics.minimetrics_disable_legacy": False,
-    }
-)
 def test_gauge_as_count(backend, scope):
     # The minimetrics backend supports the list type.
     backend.gauge(key="foo", value=42.0)
@@ -211,16 +174,6 @@ def test_gauge_as_count(backend, scope):
     assert len(scope.client.metrics_aggregator.buckets) == 0
 
 
-@override_options(
-    {
-        "delightful_metrics.enable_capture_envelope": True,
-        "delightful_metrics.enable_common_tags": True,
-        "delightful_metrics.emit_gauges": True,
-        "delightful_metrics.enable_code_locations": True,
-        "delightful_metrics.enable_span_attributes": False,
-        "delightful_metrics.minimetrics_disable_legacy": False,
-    }
-)
 def test_gauge(backend, scope):
     # The minimetrics backend supports the list type.
     backend.gauge(key="foo", value=42.0)
@@ -238,12 +191,7 @@ def test_gauge(backend, scope):
 
 @override_options(
     {
-        "delightful_metrics.enable_capture_envelope": True,
-        "delightful_metrics.enable_common_tags": True,
         "delightful_metrics.minimetrics_sample_rate": 1.0,
-        "delightful_metrics.enable_code_locations": True,
-        "delightful_metrics.enable_span_attributes": False,
-        "delightful_metrics.minimetrics_disable_legacy": False,
     }
 )
 def test_composite_backend_does_not_recurse(scope):
@@ -280,8 +228,6 @@ def test_composite_backend_does_not_recurse(scope):
 @override_options(
     {
         "delightful_metrics.minimetrics_sample_rate": 1.0,
-        "delightful_metrics.enable_span_attributes": False,
-        "delightful_metrics.minimetrics_disable_legacy": False,
     }
 )
 @patch("sentry.metrics.minimetrics.sentry_sdk")
@@ -306,8 +252,6 @@ def test_unit_is_correctly_propagated_for_incr(sentry_sdk, unit, expected_unit):
 @override_options(
     {
         "delightful_metrics.minimetrics_sample_rate": 1.0,
-        "delightful_metrics.enable_span_attributes": False,
-        "delightful_metrics.minimetrics_disable_legacy": False,
     }
 )
 @patch("sentry.metrics.minimetrics.sentry_sdk")
@@ -328,9 +272,6 @@ def test_unit_is_correctly_propagated_for_timing(sentry_sdk, unit, expected_unit
 @override_options(
     {
         "delightful_metrics.minimetrics_sample_rate": 1.0,
-        "delightful_metrics.emit_gauges": True,
-        "delightful_metrics.enable_span_attributes": False,
-        "delightful_metrics.minimetrics_disable_legacy": False,
     }
 )
 @patch("sentry.metrics.minimetrics.sentry_sdk")
@@ -351,8 +292,6 @@ def test_unit_is_correctly_propagated_for_gauge(sentry_sdk, unit, expected_unit)
 @override_options(
     {
         "delightful_metrics.minimetrics_sample_rate": 1.0,
-        "delightful_metrics.enable_span_attributes": False,
-        "delightful_metrics.minimetrics_disable_legacy": False,
     }
 )
 @patch("sentry.metrics.minimetrics.sentry_sdk")
@@ -384,15 +323,6 @@ def test_to_minimetrics_unit(unit, default, expected_result):
     assert result == expected_result
 
 
-@override_options(
-    {
-        "delightful_metrics.enable_capture_envelope": True,
-        "delightful_metrics.enable_common_tags": True,
-        "delightful_metrics.enable_span_attributes": True,
-        "delightful_metrics.enable_code_locations": True,
-        "delightful_metrics.minimetrics_disable_legacy": False,
-    }
-)
 def test_span_attributes_if_there_is_no_active_span(backend, scope):
     backend.incr(key="metric_withspan", tags={"x": "bar"})
     full_flush(scope)
@@ -401,15 +331,6 @@ def test_span_attributes_if_there_is_no_active_span(backend, scope):
     assert not spans
 
 
-@override_options(
-    {
-        "delightful_metrics.enable_capture_envelope": True,
-        "delightful_metrics.enable_common_tags": True,
-        "delightful_metrics.enable_span_attributes": True,
-        "delightful_metrics.enable_code_locations": True,
-        "delightful_metrics.minimetrics_disable_legacy": False,
-    }
-)
 def test_span_attribute_is_attached_if_span_exists(backend, scope):
     with scope.start_transaction():
         with scope.start_span(op="test.incr"):

--- a/tests/sentry/metrics/test_minimetrics.py
+++ b/tests/sentry/metrics/test_minimetrics.py
@@ -1,6 +1,5 @@
-from typing import Any
+from datetime import datetime, timedelta
 from unittest import mock
-from unittest.mock import patch
 
 import pytest
 import sentry_sdk
@@ -8,7 +7,7 @@ import sentry_sdk.scope
 from sentry_sdk import Client, Transport
 
 from sentry.metrics.composite_experimental import CompositeExperimentalMetricsBackend
-from sentry.metrics.minimetrics import MiniMetricsMetricsBackend, before_emit_metric
+from sentry.metrics.minimetrics import MiniMetricsMetricsBackend
 from sentry.testutils.helpers import override_options
 
 
@@ -19,37 +18,6 @@ def full_flush(scope):
     # second flush should really not do anything unless the first
     # flush accidentally created more metrics
     scope.client.flush()
-
-
-def parse_metrics(bytes: bytes):
-    rv = []
-    for line in bytes.splitlines():
-        pieces = line.decode("utf-8").split("|")
-        payload = pieces[0].split(":")
-        name = payload[0]
-        values = payload[1:]
-        ty = pieces[1]
-        ts = None
-        tags: dict[str, Any] = {}
-        for piece in pieces[2:]:
-            if piece[0] == "#":
-                for pair in piece[1:].split(","):
-                    k, v = pair.split(":", 1)
-                    old = tags.get(k)
-                    if old is not None:
-                        if isinstance(old, list):
-                            old.append(v)
-                        else:
-                            tags[k] = [old, v]
-                    else:
-                        tags[k] = v
-            elif piece[0] == "T":
-                ts = int(piece[1:])
-            else:
-                raise ValueError(f"unknown piece {piece!r}")
-        rv.append((ts, name, ty, values, tags))
-    rv.sort(key=lambda x: (x[0], x[1], tuple(sorted(tags.items()))))
-    return rv
 
 
 class DummyTransport(Transport):
@@ -72,15 +40,6 @@ class DummyTransport(Transport):
                 if item.headers.get("type") == "transaction":
                     return item.payload.json
 
-    def get_metrics(self):
-        result = []
-        for envelope in self.captured:
-            for item in envelope.items:
-                if item.headers.get("type") == "statsd":
-                    result.extend(parse_metrics(item.payload.get_bytes()))
-        result.sort(key=lambda x: (x[0], x[1], x[2]))
-        return result
-
 
 @pytest.fixture(scope="function")
 def scope():
@@ -89,10 +48,6 @@ def scope():
         client=Client(
             dsn="http://foo@example.invalid/42",
             transport=DummyTransport,
-            _experiments={
-                "enable_metrics": True,
-                "before_emit_metric": before_emit_metric,  # type: ignore[typeddict-item]
-            },
             traces_sample_rate=1.0,
         ),
     )
@@ -111,89 +66,113 @@ def backend():
         yield rv
 
 
-def test_incr_called_with_no_tags(backend, scope):
-    backend.incr(key="foo", tags={"x": "y"})
+def test_incr(backend, scope):
+    with scope.start_transaction():
+        with scope.start_span(op="test"):
+            backend.incr(key="foo")
+
     full_flush(scope)
+    (span,) = scope.client.transport.get_spans()
 
-    metrics = scope.client.transport.get_metrics()
-
-    assert len(metrics) == 1
-    assert metrics[0][1] == "sentrytest.foo@none"
-    assert metrics[0][2] == "c"
-    assert metrics[0][3] == ["1.0"]
-    assert metrics[0][4]["release"] != ""
-    assert metrics[0][4]["environment"] != ""
-    assert metrics[0][4]["x"] == "y"
-
-    assert len(scope.client.metrics_aggregator.buckets) == 0
+    assert span["op"] == "test"
+    assert span["data"]["foo"] == 1
 
 
-def test_incr_called_with_no_tags_and_no_common_tags(backend, scope):
-    backend.incr(key="foo", tags={"x": "y"})
+def test_incr_with_tag(backend, scope):
+    with scope.start_transaction():
+        with scope.start_span(op="test"):
+            backend.incr(key="foo", tags={"x": "y"})
+
     full_flush(scope)
+    (span,) = scope.client.transport.get_spans()
 
-    metrics = scope.client.transport.get_metrics()
-
-    assert len(metrics) == 1
-    assert metrics[0][1] == "sentrytest.foo@none"
-    assert metrics[0][2] == "c"
-    assert metrics[0][3] == ["1.0"]
-    assert metrics[0][4].get("release") is None
-    assert metrics[0][4].get("environment") is None
-    assert metrics[0][4]["x"] == "y"
-
-    assert len(scope.client.metrics_aggregator.buckets) == 0
+    assert span["op"] == "test"
+    assert span["tags"] == {"x": "y"}
+    assert span["data"]["foo"] == 1
 
 
-def test_incr_called_with_tag_value_as_list(backend, scope):
-    # The minimetrics backend supports the list type.
-    backend.incr(key="foo", tags={"x": ["bar", "baz"]})
+def test_incr_multi(backend, scope):
+    with scope.start_transaction():
+        with scope.start_span(op="test"):
+            backend.incr(key="foo", tags={"x": "y"})
+            backend.incr(key="foo", tags={"x": "z"})
+
     full_flush(scope)
+    (span,) = scope.client.transport.get_spans()
 
-    metrics = scope.client.transport.get_metrics()
-
-    assert len(metrics) == 1
-    assert metrics[0][1] == "sentrytest.foo@none"
-    assert metrics[0][4]["x"] == ["bar", "baz"]
-
-    assert len(scope.client.metrics_aggregator.buckets) == 0
-
-
-def test_gauge_as_count(backend, scope):
-    # The minimetrics backend supports the list type.
-    backend.gauge(key="foo", value=42.0)
-    full_flush(scope)
-
-    metrics = scope.client.transport.get_metrics()
-
-    assert len(metrics) == 1
-    assert metrics[0][1] == "sentrytest.foo@none"
-    assert metrics[0][2] == "c"
-    assert metrics[0][3] == ["42.0"]
-
-    assert len(scope.client.metrics_aggregator.buckets) == 0
+    assert span["op"] == "test"
+    assert span["tags"] == {"x": "z"}  # NB: Restriction of the interface
+    assert span["data"]["foo"] == 1  # NB: SDK has no get_data() -> incr impossible
 
 
 def test_gauge(backend, scope):
-    # The minimetrics backend supports the list type.
-    backend.gauge(key="foo", value=42.0)
+    with scope.start_transaction():
+        with scope.start_span(op="test"):
+            backend.gauge(key="foo", value=0)
+            backend.gauge(key="foo", value=42.0)
+
     full_flush(scope)
+    (span,) = scope.client.transport.get_spans()
 
-    metrics = scope.client.transport.get_metrics()
-
-    assert len(metrics) == 1
-    assert metrics[0][1] == "sentrytest.foo@none"
-    assert metrics[0][2] == "g"
-    assert metrics[0][3] == ["42.0", "42.0", "42.0", "42.0", "1"]
-
-    assert len(scope.client.metrics_aggregator.buckets) == 0
+    assert span["op"] == "test"
+    assert span["data"]["foo"] == 42.0
 
 
-@override_options(
-    {
-        "delightful_metrics.minimetrics_sample_rate": 1.0,
-    }
-)
+def test_distribution(backend, scope):
+    with scope.start_transaction():
+        with scope.start_span(op="test"):
+            backend.distribution(key="foo", value=0)
+            backend.distribution(key="foo", value=42.0)
+
+    full_flush(scope)
+    (span,) = scope.client.transport.get_spans()
+
+    assert span["op"] == "test"
+    assert span["data"]["foo"] == 42.0
+
+
+def test_timing(backend, scope):
+    with scope.start_transaction():
+        with scope.start_span(op="test"):
+            backend.timing(key="foo", value=42.1, tags={"x": "y"})
+
+    full_flush(scope)
+    (parent, child) = scope.client.transport.get_spans()
+
+    assert parent["op"] == "test"
+    assert child["op"] == "foo"
+    assert child["tags"] == {"x": "y"}
+
+    duration = datetime.fromisoformat(child["timestamp"]) - datetime.fromisoformat(
+        child["start_timestamp"]
+    )
+    assert duration == timedelta(seconds=42.1)
+
+
+def test_timing_duplicate(backend, scope):
+    with scope.start_transaction():
+        # We often manually track a span + a timer with same name. In this case
+        # we want no additional span.
+        with scope.start_span(op="test"):
+            backend.timing(key="test", value=42.0, tags={"x": "y"})
+
+    full_flush(scope)
+    (span,) = scope.client.transport.get_spans()
+
+    assert span["op"] == "test"
+    assert span["tags"] == {"x": "y"}
+    assert "test" not in span["data"]
+    # NB: Explicit timing is discarded
+
+
+def test_no_transaction(backend, scope):
+    backend.incr(key="foo")
+
+    full_flush(scope)
+    assert not scope.client.transport.get_spans()
+
+
+@override_options({"delightful_metrics.minimetrics_sample_rate": 1.0})
 def test_composite_backend_does_not_recurse(scope):
     composite_backend = CompositeExperimentalMetricsBackend(
         primary_backend="sentry.metrics.dummy.DummyMetricsBackend"
@@ -202,145 +181,16 @@ def test_composite_backend_does_not_recurse(scope):
 
     class TrackingCompositeBackend:
         def __getattr__(self, name):
+            assert name not in accessed
             accessed.add(name)
             return getattr(composite_backend, name)
 
     # make sure the backend feeds back to itself
-    with mock.patch("sentry.utils.metrics.backend", new=TrackingCompositeBackend()):
-        composite_backend.incr(key="sentrytest.composite", tags={"x": "bar"})
+    with mock.patch("sentry.utils.metrics.backend", new=TrackingCompositeBackend()) as backend:
+        with scope.start_transaction():
+            with scope.start_span(op="test"):
+                backend.incr(key="sentrytest.composite", tags={"x": "bar"})
         full_flush(scope)
 
-    # make sure that we did actually internally forward to the composite
-    # backend so the test does not accidentally succeed.
-    assert "incr" in accessed
-    assert "distribution" in accessed
-
-    metrics = scope.client.transport.get_metrics()
-
-    # the minimetrics.add metric must not show up
-    assert len(metrics) == 1
-    assert metrics[0][1] == "sentry.sentrytest.composite@none"
-    assert metrics[0][4]["x"] == "bar"
-
-    assert len(scope.client.metrics_aggregator.buckets) == 0
-
-
-@override_options(
-    {
-        "delightful_metrics.minimetrics_sample_rate": 1.0,
-    }
-)
-@patch("sentry.metrics.minimetrics.sentry_sdk")
-@pytest.mark.parametrize("unit,expected_unit", [(None, "none"), ("second", "second")])
-def test_unit_is_correctly_propagated_for_incr(sentry_sdk, unit, expected_unit):
-    backend = MiniMetricsMetricsBackend(prefix="")
-
-    params = {"key": "sentrytest.unit", "value": 10.0, "tags": {"x": "bar"}, "unit": unit}
-
-    # We want to mutate the params since `value` is passed as `amount`.
-    incr_params = params.copy()
-    del incr_params["value"]
-    incr_params["amount"] = params["value"]
-    backend.incr(**incr_params)
-    assert sentry_sdk.metrics.incr.call_args.kwargs == {
-        **params,
-        "unit": expected_unit,
-        "stacklevel": 1,
-    }
-
-
-@override_options(
-    {
-        "delightful_metrics.minimetrics_sample_rate": 1.0,
-    }
-)
-@patch("sentry.metrics.minimetrics.sentry_sdk")
-@pytest.mark.parametrize("unit,expected_unit", [(None, "second"), ("second", "second")])
-def test_unit_is_correctly_propagated_for_timing(sentry_sdk, unit, expected_unit):
-    backend = MiniMetricsMetricsBackend(prefix="")
-
-    params = {"key": "sentrytest.unit", "value": 10.0, "tags": {"x": "bar"}}
-
-    backend.timing(**params)  # type: ignore[arg-type]
-    assert sentry_sdk.metrics.distribution.call_args.kwargs == {
-        **params,
-        "unit": expected_unit,
-        "stacklevel": 1,
-    }
-
-
-@override_options(
-    {
-        "delightful_metrics.minimetrics_sample_rate": 1.0,
-    }
-)
-@patch("sentry.metrics.minimetrics.sentry_sdk")
-@pytest.mark.parametrize("unit,expected_unit", [(None, "none"), ("second", "second")])
-def test_unit_is_correctly_propagated_for_gauge(sentry_sdk, unit, expected_unit):
-    backend = MiniMetricsMetricsBackend(prefix="")
-
-    params = {"key": "sentrytest.unit", "value": 10.0, "tags": {"x": "bar"}, "unit": unit}
-
-    backend.gauge(**params)
-    assert sentry_sdk.metrics.gauge.call_args.kwargs == {
-        **params,
-        "unit": expected_unit,
-        "stacklevel": 1,
-    }
-
-
-@override_options(
-    {
-        "delightful_metrics.minimetrics_sample_rate": 1.0,
-    }
-)
-@patch("sentry.metrics.minimetrics.sentry_sdk")
-@pytest.mark.parametrize("unit,expected_unit", [(None, "none"), ("second", "second")])
-def test_unit_is_correctly_propagated_for_distribution(sentry_sdk, unit, expected_unit):
-    backend = MiniMetricsMetricsBackend(prefix="")
-
-    params = {"key": "sentrytest.unit", "value": 15.0, "tags": {"x": "bar"}, "unit": unit}
-
-    backend.distribution(**params)
-    assert sentry_sdk.metrics.distribution.call_args.kwargs == {
-        **params,
-        "unit": expected_unit,
-        "stacklevel": 1,
-    }
-
-
-@pytest.mark.parametrize(
-    "unit,default,expected_result",
-    [
-        (None, None, "none"),
-        (None, "my_default", "my_default"),
-        ("second", None, "second"),
-        ("second", "my_default", "second"),
-    ],
-)
-def test_to_minimetrics_unit(unit, default, expected_result):
-    result = MiniMetricsMetricsBackend._to_minimetrics_unit(unit, default)
-    assert result == expected_result
-
-
-def test_span_attributes_if_there_is_no_active_span(backend, scope):
-    backend.incr(key="metric_withspan", tags={"x": "bar"})
-    full_flush(scope)
-
-    spans = scope.client.transport.get_spans()
-    assert not spans
-
-
-def test_span_attribute_is_attached_if_span_exists(backend, scope):
-    with scope.start_transaction():
-        with scope.start_span(op="test.incr"):
-            backend.incr(key="metric_withspan", tags={"x": "bar"})
-            full_flush(scope)
-
-    spans = scope.client.transport.get_spans()
-
-    assert len(spans) == 1
-    span = spans[0]
-    assert span["op"] == "test.incr"
-    assert span["tags"] == {"x": "bar"}
-    assert span["data"]["metric_withspan"] == 1
+    (span,) = scope.client.transport.get_spans()
+    assert span["data"]["sentrytest.composite"] == 1


### PR DESCRIPTION
Removes all use of `sentry_sdk.metrics` in favor of span attributes.

Based on #75054. Tests still need to be adapted.
