### PR TITLE
fix(jira) Don't set x-frame-options for jira endpoints

### DIFF
--- a/src/sentry/middleware/security.py
+++ b/src/sentry/middleware/security.py
@@ -9,7 +9,7 @@ class SecurityHeadersMiddleware(MiddlewareMixin):
     """
 
     def process_response(self, request: Request, response: Response) -> Response:
-        if not request.path.startswith("/extensions/jira/issue/"):
+        if not request.path.startswith("/extensions/jira/"):
             response.setdefault("X-Frame-Options", "deny")
         response.setdefault("X-Content-Type-Options", "nosniff")
         response.setdefault("X-XSS-Protection", "1; mode=block")


### PR DESCRIPTION
All jira endpoints should not have x-frame-options set, this prevents setup views from being blocked.

Fixes #74937
