### PR TITLE
fix(insights): overlay insights charts on top of detail panel

### DIFF
--- a/static/app/components/slideOverPanel.tsx
+++ b/static/app/components/slideOverPanel.tsx
@@ -85,7 +85,7 @@ const _SlideOverPanel = styled(motion.div, {
   pointer-events: auto;
   overscroll-behavior: contain;
 
-  z-index: ${p => p.theme.zIndex.modal + 1};
+  z-index: ${p => p.theme.zIndex.modal - 1};
 
   box-shadow: ${p => p.theme.dropShadowHeavy};
   background: ${p => p.theme.background};


### PR DESCRIPTION
Overlays the full-screen insights chart on top of the side panel.

<img width="497" alt="image" src="https://github.com/user-attachments/assets/9c3a207c-bf55-4b3b-b29b-3eff211190c3">
