### PR TITLE
fix(dashboards): Bind state setter

### DIFF
--- a/static/app/views/dashboards/detail.tsx
+++ b/static/app/views/dashboards/detail.tsx
@@ -733,7 +733,7 @@ class DashboardDetail extends Component<Props, State> {
               splitDecision,
               dashboard,
               modifiedDashboard,
-              stateSetter: this.setState,
+              stateSetter: this.setState.bind(this),
               onDashboardUpdate,
             });
           },


### PR DESCRIPTION
I forgot that when you pass along functions like this, you need to call `.bind(this)`, because `this` changes depending on the callsite.