### PR TITLE
fix(query-builder): Improve selection behavior and consistency

### DIFF
--- a/static/app/components/searchQueryBuilder/hooks/useQueryBuilderGrid.tsx
+++ b/static/app/components/searchQueryBuilder/hooks/useQueryBuilderGrid.tsx
@@ -88,8 +88,11 @@ export function useQueryBuilderGrid({
       onKeyDownCapture: noop,
       onKeyDown,
       onFocus: (e: FocusEvent) => {
-        // If this element gets focused and there is a selection, focus the SelectionKeyHandler instead
-        if (e.target === ref.current && state.selectionManager.selectedKeys.size > 0) {
+        // This element should never take focus from the SelectionKeyHandler
+        if (
+          e.target === ref.current &&
+          e.relatedTarget === selectionKeyHandlerRef.current
+        ) {
           selectionKeyHandlerRef.current?.focus();
           return;
         }

--- a/static/app/components/searchQueryBuilder/selectionKeyHandler.tsx
+++ b/static/app/components/searchQueryBuilder/selectionKeyHandler.tsx
@@ -76,6 +76,8 @@ export const SelectionKeyHandler = forwardRef(
         switch (e.key) {
           case 'Backspace':
           case 'Delete': {
+            e.preventDefault();
+            e.stopPropagation();
             dispatch({
               type: 'REPLACE_TOKENS_WITH_TEXT',
               tokens: selectedTokens,
@@ -92,6 +94,8 @@ export const SelectionKeyHandler = forwardRef(
             return;
           }
           case 'ArrowRight':
+            e.preventDefault();
+            e.stopPropagation();
             state.selectionManager.clearSelection();
             state.selectionManager.setFocusedKey(
               findNearestFreeTextKey(
@@ -102,6 +106,8 @@ export const SelectionKeyHandler = forwardRef(
             );
             return;
           case 'ArrowLeft':
+            e.preventDefault();
+            e.stopPropagation();
             state.selectionManager.clearSelection();
             state.selectionManager.setFocusedKey(
               findNearestFreeTextKey(


### PR DESCRIPTION
This fixes a couple problems:

1. Sometimes the wrapper div would take focus from the selection key handler, which was causing all onKeyDown events to be ignored.
2. When there was a selection, arrow keys were not focusing the right elements because the events were not being prevented from propagating