### PR TITLE
feat(dashboards): Default dataset should be events when editing

### DIFF
--- a/static/app/views/dashboards/widgetBuilder/widgetBuilder.tsx
+++ b/static/app/views/dashboards/widgetBuilder/widgetBuilder.tsx
@@ -220,16 +220,14 @@ function WidgetBuilder({
     DashboardWidgetSource.ISSUE_DETAILS,
   ].includes(source);
 
-  const defaultWidgetType = organization.features.includes(
-    'performance-discover-dataset-selector'
-  )
-    ? WidgetType.ERRORS
-    : WidgetType.DISCOVER;
-  const defaultDataset = organization.features.includes(
-    'performance-discover-dataset-selector'
-  )
-    ? DataSet.ERRORS
-    : DataSet.EVENTS;
+  const defaultWidgetType =
+    organization.features.includes('performance-discover-dataset-selector') && !isEditing // i.e. creating
+      ? WidgetType.ERRORS
+      : WidgetType.DISCOVER;
+  const defaultDataset =
+    organization.features.includes('performance-discover-dataset-selector') && !isEditing // i.e. creating
+      ? DataSet.ERRORS
+      : DataSet.EVENTS;
   const dataSet = dataset ? dataset : defaultDataset;
 
   const api = useApi();


### PR DESCRIPTION
Since the split only happens on existing widgets, we need to open up the widget builder with the events default or else the split decision won't be triggered. New widgets can be opened with Errors as the default.