### PR TITLE
feat(uptime): Add uptime alert row to alert list

### DIFF
--- a/static/app/views/alerts/list/rules/alertRulesList.tsx
+++ b/static/app/views/alerts/list/rules/alertRulesList.tsx
@@ -33,8 +33,8 @@ import useOrganization from 'sentry/utils/useOrganization';
 import useRouter from 'sentry/utils/useRouter';
 
 import FilterBar from '../../filterBar';
-import type {CombinedMetricIssueAlerts} from '../../types';
-import {AlertRuleType} from '../../types';
+import type {CombinedAlerts, CombinedMetricIssueAlerts} from '../../types';
+import {AlertRuleType, CombinedAlertType} from '../../types';
 import {getTeamParams, isIssueAlert} from '../../utils';
 import AlertHeader from '../header';
 
@@ -81,7 +81,7 @@ function AlertRulesList() {
     getResponseHeader,
     isLoading,
     isError,
-  } = useApiQuery<Array<CombinedMetricIssueAlerts | null>>(
+  } = useApiQuery<Array<CombinedAlerts | null>>(
     getAlertListQueryKey(organization.slug, location.query),
     {
       staleTime: 0,
@@ -112,9 +112,14 @@ function AlertRulesList() {
 
   const handleOwnerChange = (
     projectId: string,
-    rule: CombinedMetricIssueAlerts,
+    rule: CombinedAlerts,
     ownerValue: string
   ) => {
+    // TODO(davidenwang): Once we have edit apis for uptime alerts, fill this in
+    if (rule.type === CombinedAlertType.UPTIME) {
+      return;
+    }
+
     const endpoint =
       rule.type === 'alert_rule'
         ? `/organizations/${organization.slug}/alert-rules/${rule.id}`
@@ -133,7 +138,12 @@ function AlertRulesList() {
     });
   };
 
-  const handleDeleteRule = async (projectId: string, rule: CombinedMetricIssueAlerts) => {
+  const handleDeleteRule = async (projectId: string, rule: CombinedAlerts) => {
+    // TODO(davidenwang): Once we have edit apis for uptime alerts, fill this in
+    if (rule.type === CombinedAlertType.UPTIME) {
+      return;
+    }
+
     try {
       await api.requestPromise(
         isIssueAlert(rule)
@@ -158,7 +168,11 @@ function AlertRulesList() {
   const hasEditAccess = organization.access.includes('alerts:write');
 
   const ruleList = ruleListResponse.filter(defined);
-  const projectsFromResults = uniq(ruleList.flatMap(({projects}) => projects));
+  const projectsFromResults = uniq(
+    ruleList.flatMap(rule =>
+      rule.type === CombinedAlertType.UPTIME ? [rule.projectSlug] : rule.projects
+    )
+  );
   const ruleListPageLinks = getResponseHeader?.('Link');
 
   const sort: {asc: boolean; field: SortField} = {

--- a/static/app/views/alerts/list/rules/combinedAlertBadge.tsx
+++ b/static/app/views/alerts/list/rules/combinedAlertBadge.tsx
@@ -2,15 +2,17 @@ import AlertBadge from 'sentry/components/badge/alertBadge';
 import {Tooltip} from 'sentry/components/tooltip';
 import {t, tct} from 'sentry/locale';
 import {MonitorType} from 'sentry/types/alerts';
+import {UptimeMonitorStatus} from 'sentry/views/alerts/rules/uptime/types';
 import {
   ActivationStatus,
-  type CombinedMetricIssueAlerts,
+  type CombinedAlerts,
+  CombinedAlertType,
   IncidentStatus,
 } from 'sentry/views/alerts/types';
 import {isIssueAlert} from 'sentry/views/alerts/utils';
 
 interface Props {
-  rule: CombinedMetricIssueAlerts;
+  rule: CombinedAlerts;
 }
 
 const IncidentStatusText: Record<IncidentStatus, string> = {
@@ -20,13 +22,32 @@ const IncidentStatusText: Record<IncidentStatus, string> = {
   [IncidentStatus.OPENED]: t('Open'),
 };
 
+const UptimeStatusText: Record<
+  UptimeMonitorStatus,
+  {incidentStatus: IncidentStatus; statusText: string}
+> = {
+  [UptimeMonitorStatus.OK]: {statusText: t('Up'), incidentStatus: IncidentStatus.CLOSED},
+  [UptimeMonitorStatus.FAILED]: {
+    statusText: t('Down'),
+    incidentStatus: IncidentStatus.WARNING,
+  },
+};
+
 /**
  * Takes in an alert rule (activated metric, metric, issue) and renders the
  * appropriate tooltip and AlertBadge
  */
 export default function CombinedAlertBadge({rule}: Props) {
-  const isIssueAlertInstance = isIssueAlert(rule);
+  if (rule.type === CombinedAlertType.UPTIME) {
+    const {statusText, incidentStatus} = UptimeStatusText[rule.status];
+    return (
+      <Tooltip title={tct('Uptime Alert Status: [statusText]', {statusText})}>
+        <AlertBadge status={incidentStatus} />
+      </Tooltip>
+    );
+  }
 
+  const isIssueAlertInstance = isIssueAlert(rule);
   if (!isIssueAlertInstance && rule.monitorType === MonitorType.ACTIVATED) {
     const isWaiting =
       !rule.activations?.length ||

--- a/static/app/views/alerts/list/rules/utils.tsx
+++ b/static/app/views/alerts/list/rules/utils.tsx
@@ -1,8 +1,23 @@
-import {type CombinedMetricIssueAlerts, IncidentStatus} from 'sentry/views/alerts/types';
+import type {Actor} from 'sentry/types';
+import {
+  type CombinedAlerts,
+  CombinedAlertType,
+  type CombinedMetricIssueAlerts,
+  IncidentStatus,
+} from 'sentry/views/alerts/types';
 
 export function hasActiveIncident(rule: CombinedMetricIssueAlerts): boolean {
   return (
     rule.latestIncident?.status !== undefined &&
     [IncidentStatus.CRITICAL, IncidentStatus.WARNING].includes(rule.latestIncident.status)
   );
+}
+
+export function getActor(rule: CombinedAlerts): Actor | null {
+  if (rule.type === CombinedAlertType.UPTIME) {
+    return rule.owner;
+  }
+
+  const ownerId = rule.owner?.split(':')[1];
+  return ownerId ? {type: 'team' as Actor['type'], id: ownerId, name: ''} : null;
 }

--- a/static/app/views/alerts/rules/uptime/types.tsx
+++ b/static/app/views/alerts/rules/uptime/types.tsx
@@ -1,0 +1,24 @@
+import type {Actor} from 'sentry/types/core';
+
+export enum UptimeMonitorStatus {
+  OK = 1,
+  FAILED = 2,
+}
+
+export enum UptimeMonitorMode {
+  MANUAL = 1,
+  AUTO_DETECTED_ONBOARDING = 2,
+  AUTO_DETECTED_ACTIVE = 3,
+}
+
+export interface UptimeRule {
+  id: string;
+  intervalSeconds: number;
+  mode: UptimeMonitorMode;
+  name: string;
+  owner: Actor;
+  projectSlug: string;
+  status: UptimeMonitorStatus;
+  timeoutMs: number;
+  url: string;
+}

--- a/static/app/views/alerts/types.tsx
+++ b/static/app/views/alerts/types.tsx
@@ -1,6 +1,7 @@
 import type {AlertRuleActivation, IssueAlertRule} from 'sentry/types/alerts';
 import type {User} from 'sentry/types/user';
 import type {MetricRule} from 'sentry/views/alerts/rules/metric/types';
+import type {UptimeRule} from 'sentry/views/alerts/rules/uptime/types';
 
 type Data = [number, {count: number}[]][];
 
@@ -91,6 +92,7 @@ export enum AlertRuleStatus {
 export enum CombinedAlertType {
   METRIC = 'alert_rule',
   ISSUE = 'rule',
+  UPTIME = 'uptime',
 }
 
 interface IssueAlert extends IssueAlertRule {
@@ -102,4 +104,10 @@ export interface MetricAlert extends MetricRule {
   type: CombinedAlertType.METRIC;
 }
 
+export interface UptimeAlert extends UptimeRule {
+  type: CombinedAlertType.UPTIME;
+}
+
 export type CombinedMetricIssueAlerts = IssueAlert | MetricAlert;
+
+export type CombinedAlerts = CombinedMetricIssueAlerts | UptimeAlert;

--- a/static/app/views/alerts/utils/index.tsx
+++ b/static/app/views/alerts/utils/index.tsx
@@ -18,7 +18,7 @@ import {
 } from 'sentry/views/alerts/rules/metric/types';
 import {isCustomMetricAlert} from 'sentry/views/alerts/rules/metric/utils/isCustomMetricAlert';
 
-import type {CombinedMetricIssueAlerts, Incident, IncidentStats} from '../types';
+import type {CombinedAlerts, Incident, IncidentStats} from '../types';
 import {AlertRuleStatus, CombinedAlertType} from '../types';
 
 /**
@@ -33,7 +33,7 @@ export function getStartEndFromStats(stats: IncidentStats) {
   return {start, end};
 }
 
-export function isIssueAlert(data: CombinedMetricIssueAlerts) {
+export function isIssueAlert(data: CombinedAlerts) {
   return data.type === CombinedAlertType.ISSUE;
 }
 


### PR DESCRIPTION
Modifies existing alert rule row components to make room for the new uptime alert rule row. Currently uptime alert objects are feature flagged out of the api according to `organizations:uptime-rule-api` so these changes are not visible to any users yet.

**Stack of dependent PRs**:
- #75080
- #75036
- #75035
- #74969