### PR TITLE
feat(dashboards): Show alert banner when split decision is available

### DIFF
--- a/static/app/views/dashboards/types.tsx
+++ b/static/app/views/dashboards/types.tsx
@@ -1,6 +1,7 @@
 import type {Layout} from 'react-grid-layout';
 
 import type {User} from 'sentry/types/user';
+import type {DatasetSource} from 'sentry/utils/discover/types';
 
 import type {ThresholdsConfig} from './widgetBuilder/buildSteps/thresholdsStep/thresholdsStep';
 
@@ -81,6 +82,7 @@ export type Widget = {
   interval: string;
   queries: WidgetQuery[];
   title: string;
+  datasetSource?: DatasetSource;
   description?: string;
   id?: string;
   layout?: WidgetLayout | null;

--- a/static/app/views/dashboards/widgetBuilder/buildSteps/dataSetStep.tsx
+++ b/static/app/views/dashboards/widgetBuilder/buildSteps/dataSetStep.tsx
@@ -69,11 +69,7 @@ export function DataSetStep({
   const disabledChoices: RadioGroupProps<string>['disabledChoices'] = [];
 
   useEffect(() => {
-    if (splitDecision) {
-      setShowSplitAlert(true);
-      return;
-    }
-    setShowSplitAlert(false);
+    setShowSplitAlert(!!splitDecision);
   }, [splitDecision]);
 
   if (displayType !== DisplayType.TABLE) {

--- a/static/app/views/dashboards/widgetBuilder/buildSteps/dataSetStep.tsx
+++ b/static/app/views/dashboards/widgetBuilder/buildSteps/dataSetStep.tsx
@@ -12,6 +12,7 @@ import {space} from 'sentry/styles/space';
 import {DatasetSource} from 'sentry/utils/discover/types';
 import useOrganization from 'sentry/utils/useOrganization';
 import {DisplayType, type WidgetType} from 'sentry/views/dashboards/types';
+import {hasDatasetSelector} from 'sentry/views/dashboards/utils';
 import {DATASET_LABEL_MAP} from 'sentry/views/discover/savedQuery/datasetSelector';
 
 import {DataSet} from '../utils';
@@ -67,6 +68,7 @@ export function DataSetStep({
   );
   const organization = useOrganization();
   const disabledChoices: RadioGroupProps<string>['disabledChoices'] = [];
+  const hasDatasetSelectorFeature = hasDatasetSelector(organization);
 
   useEffect(() => {
     setShowSplitAlert(!!splitDecision);
@@ -81,13 +83,13 @@ export function DataSetStep({
 
   const datasetChoices = new Map<string, string>();
 
-  if (organization.features.includes('performance-discover-dataset-selector')) {
+  if (hasDatasetSelectorFeature) {
     // TODO: Finalize description copy
     datasetChoices.set(DataSet.ERRORS, t('Errors (TypeError, InvalidSearchQuery, etc)'));
     datasetChoices.set(DataSet.TRANSACTIONS, t('Transactions'));
   }
 
-  if (!organization.features.includes('performance-discover-dataset-selector')) {
+  if (!hasDatasetSelectorFeature) {
     datasetChoices.set(DataSet.EVENTS, t('Errors and Transactions'));
   }
   datasetChoices.set(DataSet.ISSUES, t('Issues (States, Assignment, Time, etc.)'));
@@ -108,7 +110,7 @@ export function DataSetStep({
         }
       )}
     >
-      {showSplitAlert && (
+      {showSplitAlert && hasDatasetSelectorFeature && (
         <DiscoverSplitAlert
           onDismiss={() => setShowSplitAlert(false)}
           splitDecision={splitDecision}

--- a/static/app/views/dashboards/widgetBuilder/buildSteps/dataSetStep.tsx
+++ b/static/app/views/dashboards/widgetBuilder/buildSteps/dataSetStep.tsx
@@ -21,7 +21,7 @@ import {BuildStep} from './buildStep';
 function DiscoverSplitAlert({onDismiss, splitDecision}) {
   const splitAlertMessage = splitDecision
     ? tct(
-        "We're splitting our datasets up to make it a bit easier to digest. We defaulted this query to [splitDecision]. Edit as you see fit.",
+        "We're splitting our datasets up to make it a bit easier to digest. We defaulted this widget to [splitDecision]. Edit as you see fit.",
         {splitDecision: DATASET_LABEL_MAP[splitDecision]}
       )
     : null;

--- a/static/app/views/dashboards/widgetBuilder/widgetBuilder.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/widgetBuilder.spec.tsx
@@ -1745,7 +1745,7 @@ describe('WidgetBuilder', function () {
         );
         expect(
           await screen.findByText(
-            "We're splitting our datasets up to make it a bit easier to digest. We defaulted this query to Errors. Edit as you see fit."
+            "We're splitting our datasets up to make it a bit easier to digest. We defaulted this widget to Errors. Edit as you see fit."
           )
         ).toBeInTheDocument();
       });
@@ -1781,7 +1781,7 @@ describe('WidgetBuilder', function () {
         );
         expect(
           await screen.findByText(
-            "We're splitting our datasets up to make it a bit easier to digest. We defaulted this query to Transactions. Edit as you see fit."
+            "We're splitting our datasets up to make it a bit easier to digest. We defaulted this widget to Transactions. Edit as you see fit."
           )
         ).toBeInTheDocument();
       });
@@ -1839,7 +1839,7 @@ describe('WidgetBuilder', function () {
         );
         expect(
           await screen.findByText(
-            "We're splitting our datasets up to make it a bit easier to digest. We defaulted this query to Errors. Edit as you see fit."
+            "We're splitting our datasets up to make it a bit easier to digest. We defaulted this widget to Errors. Edit as you see fit."
           )
         ).toBeInTheDocument();
       });
@@ -1875,7 +1875,7 @@ describe('WidgetBuilder', function () {
         );
         expect(
           await screen.findByText(
-            "We're splitting our datasets up to make it a bit easier to digest. We defaulted this query to Transactions. Edit as you see fit."
+            "We're splitting our datasets up to make it a bit easier to digest. We defaulted this widget to Transactions. Edit as you see fit."
           )
         ).toBeInTheDocument();
       });
@@ -1970,7 +1970,7 @@ describe('WidgetBuilder', function () {
         });
         expect(
           await screen.findByText(
-            "We're splitting our datasets up to make it a bit easier to digest. We defaulted this query to Errors. Edit as you see fit."
+            "We're splitting our datasets up to make it a bit easier to digest. We defaulted this widget to Errors. Edit as you see fit."
           )
         ).toBeInTheDocument();
       });

--- a/static/app/views/dashboards/widgetBuilder/widgetBuilder.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/widgetBuilder.spec.tsx
@@ -1713,6 +1713,7 @@ describe('WidgetBuilder', function () {
 
         dashboard = mockDashboard({widgets: [widget]});
       });
+
       it('selects the error discover split type as the dataset when the events request completes', async function () {
         eventsMock = MockApiClient.addMockResponse({
           url: '/organizations/org-slug/events/',
@@ -1784,41 +1785,6 @@ describe('WidgetBuilder', function () {
           )
         ).toBeInTheDocument();
       });
-      it('does not show the alert if the widget type is already split', async function () {
-        widget = {
-          displayType: DisplayType.TABLE,
-          interval: '1d',
-          queries: [
-            {
-              name: 'Test Widget',
-              fields: ['count()', 'count_unique(user)', 'epm()', 'project'],
-              columns: ['project'],
-              aggregates: ['count()', 'count_unique(user)', 'epm()'],
-              conditions: '',
-              orderby: '',
-            },
-          ],
-          title: 'errors',
-          id: '1',
-          widgetType: 'error-events',
-        };
-
-        dashboard = mockDashboard({widgets: [widget]});
-        renderTestComponent({
-          orgFeatures: [...defaultOrgFeatures, 'performance-discover-dataset-selector'],
-          dashboard,
-          params: {
-            widgetIndex: '0',
-          },
-        });
-
-        await waitFor(() => {
-          expect(screen.getByRole('radio', {name: /errors/i})).toBeChecked();
-        });
-        expect(
-          screen.queryByText(/we're splitting our datasets/i)
-        ).not.toBeInTheDocument();
-      });
     });
 
     describe('events-stats', function () {
@@ -1842,6 +1808,7 @@ describe('WidgetBuilder', function () {
 
         dashboard = mockDashboard({widgets: [widget]});
       });
+
       it('selects the error discover split type as the dataset when the request completes', async function () {
         eventsStatsMock = MockApiClient.addMockResponse({
           url: '/organizations/org-slug/events-stats/',
@@ -1912,6 +1879,9 @@ describe('WidgetBuilder', function () {
           )
         ).toBeInTheDocument();
       });
+    });
+
+    describe('discover split warning', function () {
       it('does not show the alert if the widget type is already split', async function () {
         widget = {
           displayType: DisplayType.LINE,
@@ -1955,6 +1925,54 @@ describe('WidgetBuilder', function () {
         expect(
           screen.queryByText(/we're splitting our datasets/i)
         ).not.toBeInTheDocument();
+      });
+
+      it('shows the alert if the widget is split but the decision is forced', async function () {
+        widget = {
+          displayType: DisplayType.LINE,
+          interval: '1d',
+          queries: [
+            {
+              name: 'Test Widget',
+              fields: ['count()', 'count_unique(user)', 'epm()', 'project'],
+              columns: ['project'],
+              aggregates: ['count()', 'count_unique(user)', 'epm()'],
+              conditions: '',
+              orderby: '',
+            },
+          ],
+          title: 'Transactions',
+          id: '1',
+          widgetType: 'error-events',
+          datasetSource: 'forced',
+        };
+
+        dashboard = mockDashboard({widgets: [widget]});
+        eventsStatsMock = MockApiClient.addMockResponse({
+          url: '/organizations/org-slug/events-stats/',
+          method: 'GET',
+          statusCode: 200,
+          body: {
+            meta: {},
+            data: [],
+          },
+        });
+        renderTestComponent({
+          orgFeatures: [...defaultOrgFeatures, 'performance-discover-dataset-selector'],
+          dashboard,
+          params: {
+            widgetIndex: '0',
+          },
+        });
+
+        await waitFor(() => {
+          expect(screen.getByRole('radio', {name: /errors/i})).toBeChecked();
+        });
+        expect(
+          await screen.findByText(
+            "We're splitting our datasets up to make it a bit easier to digest. We defaulted this query to Errors. Edit as you see fit."
+          )
+        ).toBeInTheDocument();
       });
     });
   });

--- a/static/app/views/dashboards/widgetBuilder/widgetBuilder.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/widgetBuilder.spec.tsx
@@ -1742,6 +1742,11 @@ describe('WidgetBuilder', function () {
           '1',
           WidgetType.ERRORS
         );
+        expect(
+          await screen.findByText(
+            "We're splitting our datasets up to make it a bit easier to digest. We defaulted this query to Errors. Edit as you see fit."
+          )
+        ).toBeInTheDocument();
       });
 
       it('selects the transaction discover split type as the dataset when the events request completes', async function () {
@@ -1773,6 +1778,46 @@ describe('WidgetBuilder', function () {
           '1',
           WidgetType.TRANSACTIONS
         );
+        expect(
+          await screen.findByText(
+            "We're splitting our datasets up to make it a bit easier to digest. We defaulted this query to Transactions. Edit as you see fit."
+          )
+        ).toBeInTheDocument();
+      });
+      it('does not show the alert if the widget type is already split', async function () {
+        widget = {
+          displayType: DisplayType.TABLE,
+          interval: '1d',
+          queries: [
+            {
+              name: 'Test Widget',
+              fields: ['count()', 'count_unique(user)', 'epm()', 'project'],
+              columns: ['project'],
+              aggregates: ['count()', 'count_unique(user)', 'epm()'],
+              conditions: '',
+              orderby: '',
+            },
+          ],
+          title: 'errors',
+          id: '1',
+          widgetType: 'error-events',
+        };
+
+        dashboard = mockDashboard({widgets: [widget]});
+        renderTestComponent({
+          orgFeatures: [...defaultOrgFeatures, 'performance-discover-dataset-selector'],
+          dashboard,
+          params: {
+            widgetIndex: '0',
+          },
+        });
+
+        await waitFor(() => {
+          expect(screen.getByRole('radio', {name: /errors/i})).toBeChecked();
+        });
+        expect(
+          screen.queryByText(/we're splitting our datasets/i)
+        ).not.toBeInTheDocument();
       });
     });
 
@@ -1825,6 +1870,11 @@ describe('WidgetBuilder', function () {
           '1',
           WidgetType.ERRORS
         );
+        expect(
+          await screen.findByText(
+            "We're splitting our datasets up to make it a bit easier to digest. We defaulted this query to Errors. Edit as you see fit."
+          )
+        ).toBeInTheDocument();
       });
 
       it('selects the transaction discover split type as the dataset when the request completes', async function () {
@@ -1856,6 +1906,55 @@ describe('WidgetBuilder', function () {
           '1',
           WidgetType.TRANSACTIONS
         );
+        expect(
+          await screen.findByText(
+            "We're splitting our datasets up to make it a bit easier to digest. We defaulted this query to Transactions. Edit as you see fit."
+          )
+        ).toBeInTheDocument();
+      });
+      it('does not show the alert if the widget type is already split', async function () {
+        widget = {
+          displayType: DisplayType.LINE,
+          interval: '1d',
+          queries: [
+            {
+              name: 'Test Widget',
+              fields: ['count()', 'count_unique(user)', 'epm()', 'project'],
+              columns: ['project'],
+              aggregates: ['count()', 'count_unique(user)', 'epm()'],
+              conditions: '',
+              orderby: '',
+            },
+          ],
+          title: 'Transactions',
+          id: '1',
+          widgetType: 'transaction-like',
+        };
+
+        dashboard = mockDashboard({widgets: [widget]});
+        eventsStatsMock = MockApiClient.addMockResponse({
+          url: '/organizations/org-slug/events-stats/',
+          method: 'GET',
+          statusCode: 200,
+          body: {
+            meta: {},
+            data: [],
+          },
+        });
+        renderTestComponent({
+          orgFeatures: [...defaultOrgFeatures, 'performance-discover-dataset-selector'],
+          dashboard,
+          params: {
+            widgetIndex: '0',
+          },
+        });
+
+        await waitFor(() => {
+          expect(screen.getByRole('radio', {name: /transactions/i})).toBeChecked();
+        });
+        expect(
+          screen.queryByText(/we're splitting our datasets/i)
+        ).not.toBeInTheDocument();
       });
     });
   });

--- a/static/app/views/dashboards/widgetBuilder/widgetBuilder.tsx
+++ b/static/app/views/dashboards/widgetBuilder/widgetBuilder.tsx
@@ -70,7 +70,7 @@ import {
 
 import {BuildStep} from './buildSteps/buildStep';
 import {ColumnsStep} from './buildSteps/columnsStep';
-import {DataSetStep} from './buildSteps/dataSetStep';
+import DataSetStep from './buildSteps/dataSetStep';
 import {FilterResultsStep} from './buildSteps/filterResultsStep';
 import {GroupByStep} from './buildSteps/groupByStep';
 import {SortByStep} from './buildSteps/sortByStep';
@@ -296,6 +296,8 @@ function WidgetBuilder({
   const [latestLibrarySelectionTitle, setLatestLibrarySelectionTitle] = useState<
     string | null
   >(null);
+
+  const [splitDecision, setSplitDecision] = useState<WidgetType | undefined>(undefined);
 
   useEffect(() => {
     trackAnalytics('dashboards_views.widget_builder.opened', {
@@ -1011,16 +1013,17 @@ function WidgetBuilder({
     });
   }
 
-  function handleUpdateWidgetSplitDecision(splitDecision: WidgetType) {
+  function handleUpdateWidgetSplitDecision(decision: WidgetType) {
     setState(prevState => {
-      return {...cloneDeep(prevState), dataSet: WIDGET_TYPE_TO_DATA_SET[splitDecision]};
+      return {...cloneDeep(prevState), dataSet: WIDGET_TYPE_TO_DATA_SET[decision]};
     });
 
     if (currentWidget.id) {
       // Update the dashboard state with the split decision, in case
       // the user cancels editing the widget after the decision was made
-      updateDashboardSplitDecision?.(currentWidget.id, splitDecision);
+      updateDashboardSplitDecision?.(currentWidget.id, decision);
     }
+    setSplitDecision(decision);
   }
 
   function isFormInvalid() {
@@ -1180,6 +1183,7 @@ function WidgetBuilder({
                                     displayType={state.displayType}
                                     onChange={handleDataSetChange}
                                     hasReleaseHealthFeature={hasReleaseHealthFeature}
+                                    splitDecision={splitDecision}
                                   />
                                   {isTabularChart && (
                                     <DashboardsMEPConsumer>

--- a/static/app/views/dashboards/widgetBuilder/widgetBuilder.tsx
+++ b/static/app/views/dashboards/widgetBuilder/widgetBuilder.tsx
@@ -33,6 +33,7 @@ import {
   getColumnsAndAggregates,
   getColumnsAndAggregatesAsStrings,
 } from 'sentry/utils/discover/fields';
+import {DatasetSource} from 'sentry/utils/discover/types';
 import {isEmptyObject} from 'sentry/utils/object/isEmptyObject';
 import {MetricsCardinalityProvider} from 'sentry/utils/performance/contexts/metricsCardinality';
 import {MetricsResultsMetaProvider} from 'sentry/utils/performance/contexts/metricsEnhancedPerformanceDataContext';
@@ -70,7 +71,7 @@ import {
 
 import {BuildStep} from './buildSteps/buildStep';
 import {ColumnsStep} from './buildSteps/columnsStep';
-import DataSetStep from './buildSteps/dataSetStep';
+import {DataSetStep} from './buildSteps/dataSetStep';
 import {FilterResultsStep} from './buildSteps/filterResultsStep';
 import {GroupByStep} from './buildSteps/groupByStep';
 import {SortByStep} from './buildSteps/sortByStep';
@@ -1088,6 +1089,13 @@ function WidgetBuilder({
     );
   }
 
+  const widgetDiscoverSplitSource = isValidWidgetIndex
+    ? dashboard.widgets[widgetIndexNum].datasetSource
+    : undefined;
+  const originalWidgetType = isValidWidgetIndex
+    ? dashboard.widgets[widgetIndexNum].widgetType
+    : undefined;
+
   return (
     <SentryDocumentTitle title={dashboard.title} orgSlug={orgSlug}>
       <PageFiltersContainer
@@ -1183,7 +1191,14 @@ function WidgetBuilder({
                                     displayType={state.displayType}
                                     onChange={handleDataSetChange}
                                     hasReleaseHealthFeature={hasReleaseHealthFeature}
-                                    splitDecision={splitDecision}
+                                    splitDecision={
+                                      splitDecision ??
+                                      // The original widget type is used for a forced split decision
+                                      (widgetDiscoverSplitSource === DatasetSource.FORCED
+                                        ? originalWidgetType
+                                        : undefined)
+                                    }
+                                    source={widgetDiscoverSplitSource}
                                   />
                                   {isTabularChart && (
                                     <DashboardsMEPConsumer>


### PR DESCRIPTION
Sets a warning banner to let the user know the widget was evaluated and we selected a dataset for them based on the results. This works for split decisions as well as forced decisions, i.e. from a future migration.