### PR TITLE
chore(replay): Add HE events to replayAnalyticsEvents definition

### DIFF
--- a/static/app/utils/analytics/replayAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/replayAnalyticsEvents.tsx
@@ -60,6 +60,16 @@ export type ReplayEventParameters = {
   'replay.frame-after-background': {
     frame: string;
   };
+
+  'replay.hydration-error.issue-details-opened': {};
+  'replay.hydration-modal.opened': {
+    surface: string;
+  };
+  'replay.hydration-modal.slider-interaction': {};
+  'replay.hydration-modal.tab-change': {
+    tabKey: string;
+  };
+
   // similar purpose as "replay.details-viewed", however we're capturing the navigation action
   // in order to also include a project platform
   'replay.list-navigate-to-details': {
@@ -134,6 +144,10 @@ export const replayEventMap: Record<ReplayEventKey, string | null> = {
   'replay.details-tab-changed': 'Changed Replay Details Tab',
   'replay.details-time-spent': 'Time Spent Viewing Replay Details',
   'replay.frame-after-background': 'Replay Frame Following Background Frame',
+  'replay.hydration-error.issue-details-opened': 'Hydration Issue Details Opened',
+  'replay.hydration-modal.opened': 'Hydration Modal Opened',
+  'replay.hydration-modal.slider-interaction': 'Hydration Modal Slider Clicked',
+  'replay.hydration-modal.tab-change': 'Hydration Modal Tab Changed',
   'replay.list-navigate-to-details': 'Replays List Navigate to Replay Details',
   'replay.list-paginated': 'Paginated Replay List',
   'replay.list-sorted': 'Sorted Replay List',

--- a/static/app/utils/analytics/replayAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/replayAnalyticsEvents.tsx
@@ -62,9 +62,6 @@ export type ReplayEventParameters = {
   };
 
   'replay.hydration-error.issue-details-opened': {};
-  'replay.hydration-modal.opened': {
-    surface: string;
-  };
   'replay.hydration-modal.slider-interaction': {};
   'replay.hydration-modal.tab-change': {
     tabKey: string;
@@ -145,7 +142,6 @@ export const replayEventMap: Record<ReplayEventKey, string | null> = {
   'replay.details-time-spent': 'Time Spent Viewing Replay Details',
   'replay.frame-after-background': 'Replay Frame Following Background Frame',
   'replay.hydration-error.issue-details-opened': 'Hydration Issue Details Opened',
-  'replay.hydration-modal.opened': 'Hydration Modal Opened',
   'replay.hydration-modal.slider-interaction': 'Hydration Modal Slider Clicked',
   'replay.hydration-modal.tab-change': 'Hydration Modal Tab Changed',
   'replay.list-navigate-to-details': 'Replays List Navigate to Replay Details',


### PR DESCRIPTION
Ref https://github.com/getsentry/sentry/issues/74456. The `trackAnalytics` calls were added last week in the 2 PRs linked in this issue. We have a dashboard in redash but events don't get sent to amplitude unless we add these