### PR TITLE
feat(grouping): Remove changing the project grouping config setting

### DIFF
--- a/static/app/data/forms/projectIssueGrouping.tsx
+++ b/static/app/data/forms/projectIssueGrouping.tsx
@@ -1,51 +1,13 @@
 import {Fragment} from 'react';
 import styled from '@emotion/styled';
 
-import {GroupingConfigItem} from 'sentry/components/events/groupingInfo';
 import type {Field} from 'sentry/components/forms/types';
 import ExternalLink from 'sentry/components/links/externalLink';
 import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
-import marked from 'sentry/utils/marked';
 
 // Export route to make these forms searchable by label/help
 export const route = '/settings/:orgId/projects/:projectId/issue-grouping/';
-
-const groupingConfigField: Field = {
-  name: 'groupingConfig',
-  type: 'select',
-  label: t('Grouping Config'),
-  saveOnBlur: false,
-  saveMessageAlertType: 'info',
-  saveMessage: t(
-    'Changing grouping config will apply to future events only (can take up to a minute).'
-  ),
-  selectionInfoFunction: args => {
-    const {groupingConfigs, value} = args;
-    const selection = groupingConfigs.find(({id}) => id === value);
-    const changelog = selection?.changelog || '';
-    if (!changelog) {
-      return null;
-    }
-    return (
-      <Changelog>
-        <ChangelogTitle>
-          {tct('New in version [version]', {version: selection.id})}:
-        </ChangelogTitle>
-        <div dangerouslySetInnerHTML={{__html: marked(changelog)}} />
-      </Changelog>
-    );
-  },
-  choices: ({groupingConfigs}) =>
-    groupingConfigs.map(({id, hidden}) => [
-      id.toString(),
-      <GroupingConfigItem key={id} isHidden={hidden}>
-        {id}
-      </GroupingConfigItem>,
-    ]),
-  help: t('Sets the grouping algorithm to be used for new events.'),
-  visible: ({features}) => features.has('set-grouping-config'),
-};
 
 export const fields: Record<string, Field> = {
   fingerprintingRules: {
@@ -135,31 +97,6 @@ stack.function:mylibrary_* +app`}
     validate: () => [],
     visible: true,
   },
-  groupingConfig: groupingConfigField,
-  secondaryGroupingConfig: {
-    ...groupingConfigField,
-    name: 'secondaryGroupingConfig',
-    label: t('Fallback/Secondary Grouping Config'),
-    help: t(
-      'Sets the secondary grouping algorithm that should be run in addition to avoid creating too many new groups. Controlled by expiration date below.'
-    ),
-    saveMessage: t(
-      'Changing the secondary grouping strategy will affect how many new issues are created.'
-    ),
-  },
-  secondaryGroupingExpiry: {
-    name: 'secondaryGroupingExpiry',
-    type: 'number',
-    label: t('Expiration date of secondary grouping'),
-    help: t(
-      'If this UNIX timestamp is in the past, the secondary grouping configuration stops applying automatically.'
-    ),
-    saveOnBlur: false,
-    saveMessageAlertType: 'info',
-    saveMessage: t(
-      'Changing the expiration date will affect how many new issues are created.'
-    ),
-  },
 };
 
 const RuleDescription = styled('div')`
@@ -171,25 +108,4 @@ const RuleDescription = styled('div')`
 const RuleExample = styled('pre')`
   margin-bottom: ${space(1)};
   margin-right: 36px;
-`;
-
-const Changelog = styled('div')`
-  position: relative;
-  top: -1px;
-  margin-bottom: -1px;
-  padding: ${space(2)};
-  border-bottom: 1px solid ${p => p.theme.innerBorder};
-  background: ${p => p.theme.backgroundSecondary};
-  font-size: ${p => p.theme.fontSizeMedium};
-
-  &:last-child {
-    border: 0;
-    border-bottom-left-radius: ${p => p.theme.borderRadius};
-    border-bottom-right-radius: ${p => p.theme.borderRadius};
-  }
-`;
-
-const ChangelogTitle = styled('h3')`
-  font-size: ${p => p.theme.fontSizeMedium};
-  margin-bottom: ${space(0.75)} !important;
 `;

--- a/static/app/views/settings/projectIssueGrouping/index.tsx
+++ b/static/app/views/settings/projectIssueGrouping/index.tsx
@@ -1,7 +1,6 @@
 import type {RouteComponentProps} from 'react-router';
 
 import {hasEveryAccess} from 'sentry/components/acl/access';
-import Feature from 'sentry/components/acl/feature';
 import Form from 'sentry/components/forms/form';
 import JsonForm from 'sentry/components/forms/jsonForm';
 import ExternalLink from 'sentry/components/links/externalLink';
@@ -100,18 +99,6 @@ export default function ProjectIssueGrouping({organization, project, params}: Pr
           title={t('Stack Trace Rules')}
           fields={[fields.groupingEnhancements]}
         />
-
-        <Feature features="set-grouping-config" organization={organization}>
-          <JsonForm
-            {...jsonFormProps}
-            title={t('Change defaults')}
-            fields={[
-              fields.groupingConfig,
-              fields.secondaryGroupingConfig,
-              fields.secondaryGroupingExpiry,
-            ]}
-          />
-        </Feature>
       </Form>
     </SentryDocumentTitle>
   );


### PR DESCRIPTION
This UI is only available to staff and we do not intend to make use of it anymore.
![image](https://github.com/user-attachments/assets/479889be-5223-4328-a3a5-f67d9800dd95)
