### PR TITLE
feat(query-builder): Sort tag values by count instead of last_seen

### DIFF
--- a/static/app/actionCreators/tags.tsx
+++ b/static/app/actionCreators/tags.tsx
@@ -114,7 +114,7 @@ export function fetchTagValues({
   includeTransactions?: boolean;
   projectIds?: string[];
   search?: string;
-  sort?: string;
+  sort?: '-last_seen' | '-count';
 }): Promise<TagValue[]> {
   const url = `/organizations/${orgSlug}/tags/${tagKey}/values/`;
 

--- a/static/app/views/issueList/searchBar.tsx
+++ b/static/app/views/issueList/searchBar.tsx
@@ -124,28 +124,32 @@ function IssueListSearchBar({organization, tags, onClose, ...props}: Props) {
         statsPeriod: pageFilters.datetime.period,
       };
 
+      const fetchTagValuesPayload = {
+        api,
+        orgSlug,
+        tagKey: key,
+        search,
+        projectIds,
+        endpointParams,
+        sort: '-count' as const,
+      };
+
       const [eventsDatasetValues, issuePlatformDatasetValues] = await Promise.all([
         fetchTagValues({
-          api,
-          orgSlug,
-          tagKey: key,
-          search,
-          projectIds,
-          endpointParams,
+          ...fetchTagValuesPayload,
           dataset: Dataset.ERRORS,
         }),
         fetchTagValues({
-          api,
-          orgSlug,
-          tagKey: key,
-          search,
-          projectIds,
-          endpointParams,
+          ...fetchTagValuesPayload,
           dataset: Dataset.ISSUE_PLATFORM,
         }),
       ]);
 
-      return mergeAndSortTagValues(eventsDatasetValues, issuePlatformDatasetValues);
+      return mergeAndSortTagValues(
+        eventsDatasetValues,
+        issuePlatformDatasetValues,
+        'count'
+      );
     },
     [
       api,


### PR DESCRIPTION
A more stable and useful sort. 

Before:

![CleanShot 2024-07-26 at 12 56 49](https://github.com/user-attachments/assets/3d9e032e-dd96-4ece-9daf-7ffaa0c5c554)

After:

![CleanShot 2024-07-26 at 12 55 28](https://github.com/user-attachments/assets/347db1ba-1416-4490-b642-8789c5f08650)
