### PR TITLE
chore(traces): Hide `span.category` from suggested tags in search

### DIFF
--- a/static/app/utils/fields/index.ts
+++ b/static/app/utils/fields/index.ts
@@ -533,7 +533,6 @@ export const SPAN_OP_FIELDS: Record<SpanOpBreakdown, FieldDefinition> = {
 
 type TraceFields =
   | SpanIndexedField.SPAN_ACTION
-  | SpanIndexedField.SPAN_CATEGORY
   | SpanIndexedField.SPAN_DESCRIPTION
   | SpanIndexedField.SPAN_DOMAIN
   | SpanIndexedField.SPAN_DURATION
@@ -550,13 +549,6 @@ const TRACE_FIELD_DEFINITIONS: Record<TraceFields, FieldDefinition> = {
   [SpanIndexedField.SPAN_ACTION]: {
     desc: t(
       'The type of span action, e.g `SELECT` for a SQL span or `POST` for an HTTP span'
-    ),
-    kind: FieldKind.FIELD,
-    valueType: FieldValueType.STRING,
-  },
-  [SpanIndexedField.SPAN_CATEGORY]: {
-    desc: t(
-      'The Insights module that the span is associated with, e.g `cache`, `db`, `http`, etc.'
     ),
     kind: FieldKind.FIELD,
     valueType: FieldValueType.STRING,

--- a/static/app/views/performance/utils/useSpanFieldSupportedTags.tsx
+++ b/static/app/views/performance/utils/useSpanFieldSupportedTags.tsx
@@ -64,9 +64,13 @@ export function useSpanFieldSupportedTags(options?: {
   const {excludedTags = [], projects} = options || {};
   const {selection} = usePageFilters();
   const organization = useOrganization();
-  // we do not yet support span field search by SPAN_AI_PIPELINE_GROUP
+  // we do not yet support span field search by SPAN_AI_PIPELINE_GROUP and SPAN_CATEGORY should not be surfaced to users
   const staticTags = getSpanFieldSupportedTags(
-    [SpanIndexedField.SPAN_AI_PIPELINE_GROUP, ...excludedTags],
+    [
+      SpanIndexedField.SPAN_AI_PIPELINE_GROUP,
+      SpanIndexedField.SPAN_CATEGORY,
+      ...excludedTags,
+    ],
     DiscoverDatasets.SPANS_INDEXED
   );
 


### PR DESCRIPTION
Hides `span.category` as one of the suggested tags to search on spans, since it will be deprecated. Users should be searching via `span.module` instead