### PR TITLE
ref: fix erroneous `project=` passed to `ProjectTemplate`

### DIFF
--- a/tests/sentry/projectoptions/test_basic.py
+++ b/tests/sentry/projectoptions/test_basic.py
@@ -81,9 +81,7 @@ def test_project_template_options(default_project):
     assert default_project.get_option("test_option") == "default"
 
     template = ProjectTemplate.objects.create(
-        name="Test Template",
-        organization=default_project.organization,
-        project=default_project,
+        name="Test Template", organization=default_project.organization
     )
 
     default_project.template = template


### PR DESCRIPTION
once models are checked mypy notices that the `project=` argument goes nowhere here.  I'm surprised this works at runtime tbh

<!-- Describe your PR here. -->