### PR TITLE
ref: use tuples for loops over disparate model classes

### DIFF
--- a/src/sentry/models/user.py
+++ b/src/sentry/models/user.py
@@ -377,7 +377,7 @@ class User(Model, AbstractBaseUser):
         # While it would be nice to make the following changes in a transaction, there are too many
         # unique constraints to make this feasible. Instead, we just do it sequentially and ignore
         # the `IntegrityError`s.
-        user_related_models: tuple[type[Model], ...] = (
+        user_related_models = (
             Authenticator,
             Identity,
             UserAvatar,

--- a/src/sentry/runner/commands/cleanup.py
+++ b/src/sentry/runner/commands/cleanup.py
@@ -248,7 +248,7 @@ def cleanup(
             expired_threshold = timezone.now() - timedelta(days=days)
             models.OrganizationMember.objects.delete_expired(expired_threshold)
 
-        for model_tp in [models.ApiGrant, models.ApiToken]:
+        for model_tp in (models.ApiGrant, models.ApiToken):
             debug_output(f"Removing expired values for {model_tp.__name__}")
 
             if is_filtered(model_tp):
@@ -273,8 +273,8 @@ def cleanup(
         if is_filtered(ExportedData):
             debug_output(">> Skipping ExportedData files")
         else:
-            queryset = ExportedData.objects.filter(date_expired__lt=(timezone.now()))
-            for item in queryset:
+            export_data_queryset = ExportedData.objects.filter(date_expired__lt=(timezone.now()))
+            for item in export_data_queryset:
                 item.delete_file()
 
         project_id = None

--- a/src/sentry/testutils/helpers/backups.py
+++ b/src/sentry/testutils/helpers/backups.py
@@ -610,7 +610,7 @@ class ExhaustiveFixtures(Fixtures):
             user_id=owner_id,
             type=1,
         )
-        for group_model in {GroupAssignee, GroupBookmark, GroupSeen, GroupShare, GroupSubscription}:
+        for group_model in (GroupAssignee, GroupBookmark, GroupSeen, GroupShare, GroupSubscription):
             group_model.objects.create(
                 project=project,
                 group=group,


### PR DESCRIPTION
- mypy 1.11 improved `for t in (A, B, C)` to decay to `t: type[A | B | C]` instead of `t: Model`
- `Model.object.x(...)` with models checked in `django-stubs` does not understand any fields
- changing them to tuples allows it to check each model class in the union for correctness

<!-- Describe your PR here. -->