### PR TITLE
fix(sdk-crashes): Ignore current stacktrace

### DIFF
--- a/fixtures/sdk_crash_detection/crash_event_dart.py
+++ b/fixtures/sdk_crash_detection/crash_event_dart.py
@@ -88,7 +88,7 @@ def get_crash_event_with_frames(frames: Sequence[Mapping[str, str]], **kwargs) -
                 "type": "os",
             },
         },
-        "sdk": {"name": "sentry.dart.flutter", "version": "8.2.0"},
+        "sdk": {"name": "sentry.dart.flutter", "version": "8.2.1"},
         "timestamp": time.time(),
         "type": "error",
     }

--- a/src/sentry/utils/sdk_crashes/sdk_crash_detection_config.py
+++ b/src/sentry/utils/sdk_crashes/sdk_crash_detection_config.py
@@ -275,7 +275,7 @@ def build_sdk_crash_detection_configs() -> Sequence[SDKCrashDetectionConfig]:
             sdk_names=["sentry.dart", "sentry.dart.flutter"],
             # Since 8.2.0 the Dart SDK sends SDK frames, which is required;
             # see https://github.com/getsentry/sentry-dart/releases/tag/8.2.0
-            min_sdk_version="8.2.0",
+            min_sdk_version="8.2.1",
             report_fatal_errors=True,
             system_library_path_patterns={
                 # Dart
@@ -301,9 +301,11 @@ def build_sdk_crash_detection_configs() -> Sequence[SDKCrashDetectionConfig]:
                 },
                 path_replacer=KeepFieldPathReplacer(fields={"package", "filename", "abs_path"}),
             ),
-            # SentryExceptionFactory.getSentryException is always part of the stacktrace when
-            # users capture exceptions and would cause false positives. Therefore, we ignore it.
-            sdk_crash_ignore_functions_matchers={"SentryExceptionFactory.getSentryException"},
+            # getCurrentStackTrace is always part of the stacktrace when the SDK captures the stacktrace,
+            # and would cause false positives. Therefore, we ignore it.
+            sdk_crash_ignore_functions_matchers={
+                "getCurrentStackTrace",
+            },
         )
         configs.append(dart_config)
 

--- a/tests/sentry/utils/sdk_crashes/test_sdk_crash_detection_dart.py
+++ b/tests/sentry/utils/sdk_crashes/test_sdk_crash_detection_dart.py
@@ -178,8 +178,8 @@ def test_sdk_crash_is_reported_with_flutter_paths(
 
 
 @decorators
-def test_ignore_get_sentry_exception(mock_sdk_crash_reporter, mock_random, store_event, configs):
-    event_data = get_crash_event(sdk_function="SentryExceptionFactory.getSentryException")
+def test_ignore_get_current_stack_trace(mock_sdk_crash_reporter, mock_random, store_event, configs):
+    event_data = get_crash_event(sdk_function="getCurrentStackTrace")
     event = store_event(data=event_data)
 
     configs[1].organization_allowlist = [event.project.organization_id]
@@ -195,7 +195,7 @@ def test_ignore_get_sentry_exception(mock_sdk_crash_reporter, mock_random, store
 @decorators
 def test_beta_sdk_version_detected(mock_sdk_crash_reporter, mock_random, store_event, configs):
     event_data = get_crash_event()
-    set_path(event_data, "sdk", "version", value="8.2.1-beta.0")
+    set_path(event_data, "sdk", "version", value="8.2.2-beta.0")
     event = store_event(data=event_data)
 
     configs[1].organization_allowlist = [event.project.organization_id]


### PR DESCRIPTION
Ignore the wrapper function getCurrentStackTrace instead of getSentryException. getCurrentStackTrace is the wrapper function for getting the current stacktrace, and getSentryException uses that function. This was changed with
https://github.com/getsentry/sentry-dart/pull/2072 and shipped in sentry-dart 8.2.1.
