### PR TITLE
feat(alerts): add idiomatic time duration formatting for metric alerts

### DIFF
--- a/src/sentry/incidents/utils/format_duration.py
+++ b/src/sentry/incidents/utils/format_duration.py
@@ -29,3 +29,4 @@ def format_duration_idiomatic(minutes: int) -> str:
             literal = f"{value:d}" if value != 1 else ""
             unit_str = f" {unit}{pluralize(value)}"
             return f"{literal}{unit_str}".strip()
+    return f"{minutes} minutes"

--- a/src/sentry/incidents/utils/format_duration.py
+++ b/src/sentry/incidents/utils/format_duration.py
@@ -1,0 +1,31 @@
+from django.template.defaultfilters import pluralize
+
+
+def format_duration_idiomatic(minutes: int) -> str:
+    """
+    Format minutes into an idiomatic duration string for the purpose of these alerts.
+    For
+
+    For usage like
+    "in the past 5 minutes"
+    "in the past hour"
+    "in the past day"
+    "in the past 14 minutes"
+    "in the past 2 hours"
+    "in the past 2 hours and 14 minutes"
+    "in the past 2 days and 4 hours"
+    "in the past week"
+    "in the past 9 days"
+    "in the past month"
+    """
+
+    literal = ""
+    unit = ""
+    limits = {"month": 30 * 24 * 60, "week": 7 * 24 * 60, "day": 24 * 60, "hour": 60, "minute": 1}
+
+    for unit, limit in limits.items():
+        if minutes >= limit:
+            value = int(minutes // limit)
+            literal = f"{value:d}" if value != 1 else ""
+            unit_str = f" {unit}{pluralize(value)}"
+            return f"{literal}{unit_str}".strip()

--- a/src/sentry/incidents/utils/format_duration.py
+++ b/src/sentry/incidents/utils/format_duration.py
@@ -4,7 +4,6 @@ from django.template.defaultfilters import pluralize
 def format_duration_idiomatic(minutes: int) -> str:
     """
     Format minutes into an idiomatic duration string for the purpose of these alerts.
-    For
 
     For usage like
     "in the past 5 minutes"

--- a/src/sentry/integrations/metric_alerts.py
+++ b/src/sentry/integrations/metric_alerts.py
@@ -6,7 +6,6 @@ from django.urls import reverse
 from django.utils.translation import gettext as _
 
 from sentry.constants import CRASH_RATE_ALERT_AGGREGATE_ALIAS
-from sentry.incidents.action_handlers import format_duration
 from sentry.incidents.logic import get_incident_aggregates
 from sentry.incidents.models.alert_rule import AlertRule, AlertRuleThresholdType
 from sentry.incidents.models.incident import (
@@ -15,6 +14,7 @@ from sentry.incidents.models.incident import (
     IncidentStatus,
     IncidentTrigger,
 )
+from sentry.incidents.utils.format_duration import format_duration_idiomatic
 from sentry.snuba.metrics import format_mri_field, format_mri_field_value, is_mri_field
 from sentry.utils.assets import get_asset_url
 from sentry.utils.http import absolute_uri
@@ -92,11 +92,11 @@ def get_incident_status_text(alert_rule: AlertRule, metric_value: str) -> str:
             comparison_delta_minutes, f"same time {comparison_delta_minutes} minutes ago"
         )
         return _(
-            f"{metric_and_agg_text} {higher_or_lower} in the last {format_duration(time_window)} "
+            f"{metric_and_agg_text} {higher_or_lower} in the last {format_duration_idiomatic(time_window)} "
             f"compared to the {comparison_string}"
         )
 
-    return _(f"{metric_and_agg_text} in the last {format_duration(time_window)}")
+    return _(f"{metric_and_agg_text} in the last {format_duration_idiomatic(time_window)}")
 
 
 def incident_attachment_info(

--- a/src/sentry/integrations/metric_alerts.py
+++ b/src/sentry/integrations/metric_alerts.py
@@ -6,6 +6,7 @@ from django.urls import reverse
 from django.utils.translation import gettext as _
 
 from sentry.constants import CRASH_RATE_ALERT_AGGREGATE_ALIAS
+from sentry.incidents.action_handlers import format_duration
 from sentry.incidents.logic import get_incident_aggregates
 from sentry.incidents.models.alert_rule import AlertRule, AlertRuleThresholdType
 from sentry.incidents.models.incident import (
@@ -80,7 +81,6 @@ def get_incident_status_text(alert_rule: AlertRule, metric_value: str) -> str:
         metric_and_agg_text = f"{metric_value} {agg_text}"
 
     time_window = alert_rule.snuba_query.time_window // 60
-    interval = "minute" if time_window == 1 else "minutes"
     # % change alerts have a comparison delta
     if alert_rule.comparison_delta:
         metric_and_agg_text = f"{agg_text.capitalize()} {int(float(metric_value))}%"
@@ -92,15 +92,11 @@ def get_incident_status_text(alert_rule: AlertRule, metric_value: str) -> str:
             comparison_delta_minutes, f"same time {comparison_delta_minutes} minutes ago"
         )
         return _(
-            f"{metric_and_agg_text} {higher_or_lower} in the last {time_window} {interval} "
+            f"{metric_and_agg_text} {higher_or_lower} in the last {format_duration(time_window)} "
             f"compared to the {comparison_string}"
         )
 
-    return _("%(metric_and_agg_text)s in the last %(time_window)d %(interval)s") % {
-        "metric_and_agg_text": metric_and_agg_text,
-        "time_window": time_window,
-        "interval": interval,
-    }
+    return _(f"{metric_and_agg_text} in the last {format_duration(time_window)}")
 
 
 def incident_attachment_info(

--- a/tests/sentry/incidents/utils/test_format_duration.py
+++ b/tests/sentry/incidents/utils/test_format_duration.py
@@ -3,6 +3,8 @@ import pytest
 from sentry.incidents.utils.format_duration import format_duration_idiomatic
 
 TEST_CASES = [
+    (0, "0 minutes"),
+    (1, "minute"),
     (5, "5 minutes"),
     (59, "59 minutes"),
     (60, "hour"),

--- a/tests/sentry/incidents/utils/test_format_duration.py
+++ b/tests/sentry/incidents/utils/test_format_duration.py
@@ -1,0 +1,23 @@
+import pytest
+
+from sentry.incidents.utils.format_duration import format_duration_idiomatic
+
+TEST_CASES = [
+    (5, "5 minutes"),
+    (59, "59 minutes"),
+    (60, "hour"),
+    (61, "hour"),
+    (115, "hour"),
+    (120, "2 hours"),
+    (121, "2 hours"),
+    (1440, "day"),
+    (1440 * 7, "week"),
+    (1440 * 14, "2 weeks"),
+    (1440 * 30, "month"),
+    (1440 * 31, "month"),
+]
+
+
+@pytest.mark.parametrize("minutes, expected_str", TEST_CASES)
+def test_format_duration(minutes, expected_str):
+    assert expected_str == format_duration_idiomatic(minutes)

--- a/tests/sentry/integrations/test_metric_alerts.py
+++ b/tests/sentry/integrations/test_metric_alerts.py
@@ -242,7 +242,7 @@ class IncidentAttachmentInfoTestForCrashRateAlerts(TestCase, BaseMetricsTestCase
 
         assert data["title"] == f"Critical: {self.alert_rule.name}"
         assert data["status"] == "Critical"
-        assert data["text"] == "92% sessions crash free rate in the last 60 minutes"
+        assert data["text"] == "92% sessions crash free rate in the last hour"
         assert data["ts"] == self.date_started
         assert (
             data["logo_url"]
@@ -254,7 +254,7 @@ class IncidentAttachmentInfoTestForCrashRateAlerts(TestCase, BaseMetricsTestCase
         data = incident_attachment_info(self.incident, IncidentStatus.CLOSED)
         assert data["title"] == f"Resolved: {self.alert_rule.name}"
         assert data["status"] == "Resolved"
-        assert data["text"] == "100.0% sessions crash free rate in the last 60 minutes"
+        assert data["text"] == "100.0% sessions crash free rate in the last hour"
         assert data["ts"] == self.date_started
         assert (
             data["logo_url"]
@@ -266,7 +266,7 @@ class IncidentAttachmentInfoTestForCrashRateAlerts(TestCase, BaseMetricsTestCase
         data = incident_attachment_info(self.incident, IncidentStatus.CRITICAL, 92)
         assert data["title"] == f"Critical: {self.alert_rule.name}"
         assert data["status"] == "Critical"
-        assert data["text"] == "92% users crash free rate in the last 60 minutes"
+        assert data["text"] == "92% users crash free rate in the last hour"
         assert data["ts"] == self.date_started
         assert (
             data["logo_url"]
@@ -278,7 +278,7 @@ class IncidentAttachmentInfoTestForCrashRateAlerts(TestCase, BaseMetricsTestCase
         data = incident_attachment_info(self.incident, IncidentStatus.CLOSED)
         assert data["title"] == f"Resolved: {self.alert_rule.name}"
         assert data["status"] == "Resolved"
-        assert data["text"] == "100.0% users crash free rate in the last 60 minutes"
+        assert data["text"] == "100.0% users crash free rate in the last hour"
         assert data["ts"] == self.date_started
         assert (
             data["logo_url"]
@@ -290,7 +290,7 @@ class IncidentAttachmentInfoTestForCrashRateAlerts(TestCase, BaseMetricsTestCase
         data = incident_attachment_info(self.daily_incident, IncidentStatus.CLOSED)
         assert data["title"] == f"Resolved: {self.daily_alert_rule.name}"
         assert data["status"] == "Resolved"
-        assert data["text"] == "100.0% users crash free rate in the last 1 day"
+        assert data["text"] == "100.0% users crash free rate in the last day"
         assert data["ts"] == self.date_started
         assert (
             data["logo_url"]
@@ -320,7 +320,7 @@ class IncidentAttachmentInfoTestForCrashRateAlerts(TestCase, BaseMetricsTestCase
 
         assert data["title"] == f"Critical: {alert_rule.name}"
         assert data["status"] == "Critical"
-        assert data["text"] == "No sessions crash free rate in the last 60 minutes"
+        assert data["text"] == "No sessions crash free rate in the last hour"
 
 
 @freeze_time(MOCK_NOW)


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry/issues/75048

Adds a new duration formatter function that is slightly smarter to format things like:
- "in the last hour" instead of "in the last 60 minutes" (metric alerts) or "in the last 1 hour" (general alerts)
- "in the last day" instead of "in the last 1440 minutes" (metric alerts) or "in the last 24 hours" (general alerts)
etc.