### PR TITLE
ref: GroupValues.priority is nullable

### DIFF
--- a/src/sentry/issues/attributes.py
+++ b/src/sentry/issues/attributes.py
@@ -42,7 +42,7 @@ class GroupValues:
     substatus: int | None
     first_seen: datetime
     num_comments: int
-    priority: int
+    priority: int | None
     first_release_id: int | None
 
 


### PR DESCRIPTION
when models are checked mypy notices several constructions using the `priority` column which is nullable

<!-- Describe your PR here. -->