### PR TITLE
ref: culprit is nullable

### DIFF
--- a/src/sentry/api/endpoints/organization_events_trace.py
+++ b/src/sentry/api/endpoints/organization_events_trace.py
@@ -117,7 +117,7 @@ class TraceError(TypedDict):
 
 
 class TracePerformanceIssue(TypedDict):
-    culprit: str
+    culprit: str | None
     end: float | None
     event_id: str
     issue_id: int


### PR DESCRIPTION
when mypy checks models it notices that construction passes the `culprit` (nullable) column to this

<!-- Describe your PR here. -->