### PR TITLE
fix(metrics): min/max queries without data

### DIFF
--- a/static/app/utils/metrics/formatters.tsx
+++ b/static/app/utils/metrics/formatters.tsx
@@ -180,7 +180,7 @@ const METRIC_UNIT_TO_SHORT: Record<FormattingSupportedMetricUnit, string> = {
 };
 
 export function formatMetricUsingUnit(value: number | null, unit: string) {
-  if (!defined(value)) {
+  if (!defined(value) || Math.abs(value) === Infinity) {
     return '\u2014';
   }
 

--- a/static/app/views/metrics/summaryTable.tsx
+++ b/static/app/views/metrics/summaryTable.tsx
@@ -149,8 +149,6 @@ export const SummaryTable = memo(function SummaryTable({
         ...getTotals(s),
       };
     })
-    // Filter series with no data
-    .filter(s => s.min !== Infinity)
     .sort((a, b) => {
       const {name, order} = sort;
       if (!name) {
@@ -245,7 +243,7 @@ export const SummaryTable = memo(function SummaryTable({
                   <NumberCell key={aggregate}>
                     {row[aggregate]
                       ? formatMetricUsingUnit(row[aggregate], row.unit)
-                      : '–'}
+                      : '\u2014'}
                   </NumberCell>
                 ))}
 


### PR DESCRIPTION
Handles min/max aggregations when querying metrics without data
- closes #75129 

Before:
<img width="1262" alt="image" src="https://github.com/user-attachments/assets/80106083-9a8c-49db-abfc-49a25afc6fce">
After:
<img width="1262" alt="image" src="https://github.com/user-attachments/assets/3478498c-d237-4b7a-b5a6-1c8f55e4241b">
