### PR TITLE
ref: add non-null assertion after guard against query params

### DIFF
--- a/src/sentry/api/endpoints/debug_files.py
+++ b/src/sentry/api/endpoints/debug_files.py
@@ -117,6 +117,8 @@ class ProguardArtifactReleasesEndpoint(ProjectEndpoint):
             error_message = f"Missing required fields: {', '.join(missing_fields)}"
             return Response(data={"error": error_message}, status=status.HTTP_400_BAD_REQUEST)
 
+        assert release_name is not None and proguard_uuid is not None
+
         try:
             uuid.UUID(proguard_uuid)
         except ValueError:


### PR DESCRIPTION
this should probably use a serializer instead -- but this is the quickest fix once models are checked

<!-- Describe your PR here. -->