### PR TITLE
ref(metric-extraction) Timeout split from on-demand metric extraction config

### DIFF
--- a/src/sentry/relay/config/__init__.py
+++ b/src/sentry/relay/config/__init__.py
@@ -1069,7 +1069,8 @@ def _get_project_config(
             config, "metricConditionalTagging", get_metric_conditional_tagging_rules, project
         )
 
-        add_experimental_config(config, "metricExtraction", get_metric_extraction_config, project)
+        if metric_extraction := get_metric_extraction_config(project):
+            config["metricExtraction"] = metric_extraction
 
     config["sessionMetrics"] = {
         "version": (

--- a/src/sentry/relay/config/experimental.py
+++ b/src/sentry/relay/config/experimental.py
@@ -79,7 +79,7 @@ def build_safe_config(
     """
     timeout = TimeChecker(_FEATURE_BUILD_TIMEOUT)
 
-    with sentry_sdk.start_span(op=f"project_config.time_constrained_config_builder.{key}"):
+    with sentry_sdk.start_span(op=f"project_config.build_safe_config.{key}"):
         try:
             return function(timeout, *args, **kwargs)
         except TimeoutException as e:

--- a/src/sentry/relay/config/experimental.py
+++ b/src/sentry/relay/config/experimental.py
@@ -70,7 +70,7 @@ R_default = TypeVar("R_default")
 
 
 def build_safe_config(
-    key, function: Callable[..., R], *args: Any, default_return: R_default = None, **kwargs: Any
+    key: str, function: Callable[..., R], *args: Any, default_return: R_default = None, **kwargs: Any
 ) -> R | R_default:
     """
     Runs a config builder function with a timeout.

--- a/src/sentry/relay/config/experimental.py
+++ b/src/sentry/relay/config/experimental.py
@@ -55,6 +55,7 @@ def add_experimental_config(
     **kwargs: Any,
 ) -> None:
     """Try to set `config[key] = function(*args, **kwargs)`.
+    If the result of the function call is None, the key is not set.
     If the function call raises an exception, we log it to sentry and the key remains unset.
     NOTE: Only use this function if you expect Relay to behave reasonably
     if ``key`` is missing from the config.

--- a/src/sentry/relay/config/experimental.py
+++ b/src/sentry/relay/config/experimental.py
@@ -100,3 +100,5 @@ def run_experimental_config_builder(
             )
         except Exception:
             logger.exception("Exception while building Relay project config field")
+
+    return None

--- a/src/sentry/relay/config/experimental.py
+++ b/src/sentry/relay/config/experimental.py
@@ -70,7 +70,11 @@ R_default = TypeVar("R_default")
 
 
 def build_safe_config(
-    key: str, function: Callable[..., R], *args: Any, default_return: R_default = None, **kwargs: Any
+    key: str,
+    function: Callable[..., R],
+    *args: Any,
+    default_return: R_default = None,
+    **kwargs: Any,
 ) -> R | R_default:
     """
     Runs a config builder function with a timeout.

--- a/src/sentry/relay/config/experimental.py
+++ b/src/sentry/relay/config/experimental.py
@@ -73,9 +73,9 @@ def build_safe_config(
     key: str,
     function: Callable[..., R],
     *args: Any,
-    default_return: R_default = None,
+    default_return: R_default | None = None,
     **kwargs: Any,
-) -> R | R_default:
+) -> R | R_default | None:
     """
     Runs a config builder function with a timeout.
     If the function call raises an exception, we log it to sentry and return value passed as

--- a/src/sentry/relay/config/metric_extraction.py
+++ b/src/sentry/relay/config/metric_extraction.py
@@ -29,7 +29,7 @@ from sentry.models.transaction_threshold import (
     ProjectTransactionThresholdOverride,
     TransactionMetric,
 )
-from sentry.relay.config.experimental import TimeChecker, run_time_constrained_config_builder
+from sentry.relay.config.experimental import TimeChecker, build_safe_config
 from sentry.relay.types import RuleCondition
 from sentry.search.events import fields
 from sentry.search.events.builder.discover import DiscoverQueryBuilder
@@ -111,12 +111,12 @@ def get_metric_extraction_config(project: Project) -> MetricExtractionConfig | N
     sentry_sdk.set_tag("organization_id", project.organization_id)
 
     with sentry_sdk.start_span(op="get_on_demand_metric_specs"):
-        alert_specs, widget_specs = run_time_constrained_config_builder(
-            get_on_demand_metric_specs, project, default_return=([], [])
+        alert_specs, widget_specs = build_safe_config(
+            "on_demand_metric_specs", get_on_demand_metric_specs, project, default_return=([], [])
         )
     with sentry_sdk.start_span(op="generate_span_attribute_specs"):
-        span_attr_specs = run_time_constrained_config_builder(
-            _generate_span_attribute_specs, project, default_return=[]
+        span_attr_specs = build_safe_config(
+            "span_attribute_specs", _generate_span_attribute_specs, project, default_return=[]
         )
     with sentry_sdk.start_span(op="merge_metric_specs"):
         metric_specs = _merge_metric_specs(alert_specs, widget_specs, span_attr_specs)

--- a/src/sentry/relay/config/metric_extraction.py
+++ b/src/sentry/relay/config/metric_extraction.py
@@ -113,13 +113,13 @@ def get_metric_extraction_config(project: Project) -> MetricExtractionConfig | N
     with sentry_sdk.start_span(op="get_on_demand_metric_specs"):
         alert_specs, widget_specs = build_safe_config(
             "on_demand_metric_specs", get_on_demand_metric_specs, project, default_return=([], [])
-        )
+        )  # type: ignore[misc]
     with sentry_sdk.start_span(op="generate_span_attribute_specs"):
         span_attr_specs = build_safe_config(
             "span_attribute_specs", _generate_span_attribute_specs, project, default_return=[]
         )
     with sentry_sdk.start_span(op="merge_metric_specs"):
-        metric_specs = _merge_metric_specs(alert_specs, widget_specs, span_attr_specs)
+        metric_specs = _merge_metric_specs(alert_specs, widget_specs, span_attr_specs)  # type: ignore[arg-type]
     with sentry_sdk.start_span(op="get_extrapolation_config"):
         extrapolation_config = get_extrapolation_config(project)
 

--- a/tests/sentry/relay/config/test_experimental.py
+++ b/tests/sentry/relay/config/test_experimental.py
@@ -49,7 +49,7 @@ def test_add_experimental_config_catches_timeout(mock_logger):
 
 @patch("sentry.relay.config.experimental._FEATURE_BUILD_TIMEOUT", timedelta(seconds=1))
 @patch("sentry.relay.config.experimental.logger.exception")
-def test_run_experimental_config_builder_catches_timeout(mock_logger):
+def test_build_safe_config_catches_timeout(mock_logger):
     def dummy(timeout: TimeChecker, *args, **kwargs):
         sleep(1)
         timeout.check()
@@ -64,7 +64,7 @@ def test_run_experimental_config_builder_catches_timeout(mock_logger):
     assert extra == {"hard_timeout": timedelta(seconds=1)}
 
 
-def test_run_experimental_config_builder_returns_results_from_function_in_args():
+def test_build_safe_config_returns_results_from_function_in_args():
     def dummy(*args, **kwargs):
         return 1, 2, 3
 
@@ -82,7 +82,7 @@ def test_run_experimental_config_builder_returns_results_from_function_in_args()
 
 @patch("sentry.relay.config.experimental._FEATURE_BUILD_TIMEOUT", timedelta(seconds=1))
 @patch("sentry.relay.config.experimental.logger.exception")
-def test_run_experimental_config_builder_returns_default_value_on_timeout_exception(mock_logger):
+def test_build_safe_config_returns_default_value_on_timeout_exception(mock_logger):
     def dummy(timeout: TimeChecker, *args, **kwargs):
         sleep(1)
         timeout.check()
@@ -92,7 +92,7 @@ def test_run_experimental_config_builder_returns_default_value_on_timeout_except
     assert result == "bar"
 
 
-def test_run_experimental_config_builder_returns_value_passed_as_arg_on_exception():
+def test_build_safe_config_returns_value_passed_as_arg_on_exception():
     def dummy(*args, **kwargs):
         raise ValueError("foo")
 

--- a/tests/sentry/relay/config/test_metric_extraction.py
+++ b/tests/sentry/relay/config/test_metric_extraction.py
@@ -2271,7 +2271,7 @@ def test_get_metric_extrapolation_config(default_project: Project) -> None:
 @django_db_all
 def test_get_metric_extraction_config_when_on_demand_metrics_specs_timeout_exception(
     default_project: Project, default_environment: Environment
-):
+) -> None:
     with Feature(ON_DEMAND_METRICS):
         create_alert(
             "count()",


### PR DESCRIPTION
Splits timeout for on-demand metric extraction config builder from other (span-based extraction rules) metric extraction config creations by adding a new function `run_experimental_config_builder`, which runs function passed as an argument with a timeout, and catches possible `TimeoutException` from the function call.

By splitting the timeout, even if the on-demand metric extraction config generation fails, other metric extraction configs will still be generated, unlike before.

Closes https://github.com/getsentry/sentry/issues/74620
