### PR TITLE
Revert "fix(related_issues): Orgs with open membership should always show related issues (#72961)

### DIFF
--- a/src/sentry/api/bases/organization_events.py
+++ b/src/sentry/api/bases/organization_events.py
@@ -120,16 +120,8 @@ class OrganizationEventsEndpointBase(OrganizationEndpoint):
                     "organizations:global-views", organization, actor=request.user
                 )
                 fetching_replay_data = request.headers.get("X-Sentry-Replay-Request") == "1"
-                if not any(
-                    [
-                        has_global_views,
-                        len(params.projects) <= 1,
-                        fetching_replay_data,
-                        # If a developer can view issues of a project they do not belong to
-                        # via open membership, we will also allow the endpoint to return events for it
-                        organization.flags.allow_joinleave,
-                    ]
-                ):
+
+                if not has_global_views and len(params.projects) > 1 and not fetching_replay_data:
                     raise ParseError(detail="You cannot view events from multiple projects.")
 
             # Return both for now

--- a/tests/sentry/api/test_organization_events.py
+++ b/tests/sentry/api/test_organization_events.py
@@ -3,7 +3,6 @@ from unittest import mock
 from django.http import HttpRequest
 from django.test import override_settings
 from django.urls import reverse
-from rest_framework.exceptions import ErrorDetail
 from rest_framework.request import Request
 
 from sentry.api.endpoints.organization_events import (
@@ -75,39 +74,6 @@ class OrganizationEventsEndpointTest(APITestCase):
         assert response.status_code == 200, response.content
         assert len(response.data["data"]) == 1
         assert response.data["data"][0]["project.name"] == self.project.slug
-
-    def test_multiple_projects_open_membership(self):
-        assert bool(self.organization.flags.allow_joinleave)
-        self.store_event(
-            data={
-                "event_id": "a" * 32,
-                "timestamp": self.ten_mins_ago_iso,
-            },
-            project_id=self.project.id,
-        )
-        project2 = self.create_project()
-        self.store_event(
-            data={
-                "event_id": "b" * 32,
-                "timestamp": self.ten_mins_ago_iso,
-            },
-            project_id=project2.id,
-        )
-        response = self.do_request({"field": ["project"], "project": -1})
-        assert response.status_code == 200, response.content
-        assert len(response.data["data"]) == 2
-
-        self.organization.flags.allow_joinleave = False
-        self.organization.save()
-        assert bool(self.organization.flags.allow_joinleave) is False
-        response = self.do_request({"field": ["project"], "project": -1})
-
-        assert response.status_code == 400, response.content
-        assert response.data == {
-            "detail": ErrorDetail(
-                string="You cannot view events from multiple projects.", code="parse_error"
-            )
-        }
 
     @mock.patch("sentry.snuba.discover.query")
     def test_api_token_referrer(self, mock):

--- a/tests/snuba/api/endpoints/test_organization_events.py
+++ b/tests/snuba/api/endpoints/test_organization_events.py
@@ -165,6 +165,17 @@ class OrganizationEventsEndpointTest(OrganizationEventsEndpointTestBase, Perform
         assert response.status_code == 200
         assert len(response.data["data"]) == 1
 
+    def test_multi_project_feature_gate_rejection(self):
+        team = self.create_team(organization=self.organization, members=[self.user])
+
+        project = self.create_project(organization=self.organization, teams=[team])
+        project2 = self.create_project(organization=self.organization, teams=[team])
+
+        query = {"field": ["id", "project.id"], "project": [project.id, project2.id]}
+        response = self.do_request(query)
+        assert response.status_code == 400
+        assert "events from multiple projects" in response.data["detail"]
+
     def test_multi_project_feature_gate_replays(self):
         team = self.create_team(organization=self.organization, members=[self.user])
 


### PR DESCRIPTION
- This reverts commit 7a350510e73642cc34fa20f6d5a543116919550d.
- Commit 7a350510e is currently allowing anyone regardless of the global_views flag to view multiple projects as long as they have enabled the joinleave org setting
- @armenzg Does this break any critical flows in the UI?