### PR TITLE
feat(profiling): Support both profile formats in transaction samples tab

### DIFF
--- a/static/app/views/performance/transactionSummary/transactionEvents/eventsTable.tsx
+++ b/static/app/views/performance/transactionSummary/transactionEvents/eventsTable.tsx
@@ -407,7 +407,7 @@ class EventsTable extends Component<Props, State> {
     totalEventsView.fields = [{field: 'count()', width: -1}];
 
     const {widths} = this.state;
-    const containsSpanOpsBreakdown = eventView
+    const containsSpanOpsBreakdown = !!eventView
       .getColumns()
       .find(
         (col: TableColumn<React.ReactText>) =>


### PR DESCRIPTION
Similar to #75099. This will render a profiling icon to link to the transaction/continuous profile automatically based on the data ingested.