### PR TITLE
feat(discover): All performance add to discover CTAs have dataset

### DIFF
--- a/static/app/components/discover/performanceCardTable.tsx
+++ b/static/app/components/discover/performanceCardTable.tsx
@@ -18,11 +18,13 @@ import type {TableData} from 'sentry/utils/discover/discoverQuery';
 import DiscoverQuery from 'sentry/utils/discover/discoverQuery';
 import type EventView from 'sentry/utils/discover/eventView';
 import {getFieldRenderer} from 'sentry/utils/discover/fieldRenderers';
+import {SavedQueryDatasets} from 'sentry/utils/discover/types';
 import {MobileVital, WebVital} from 'sentry/utils/fields';
 import {
   MOBILE_VITAL_DETAILS,
   WEB_VITAL_DETAILS,
 } from 'sentry/utils/performance/vitals/constants';
+import {hasDatasetSelector} from 'sentry/views/dashboards/utils';
 import {ProjectPerformanceType} from 'sentry/views/performance/utils';
 
 type PerformanceCardTableProps = {
@@ -118,7 +120,15 @@ function PerformanceCardTable({
       ]);
       return (
         <SubTitle key={idx}>
-          <Link to={newView.getResultsViewUrlTarget(organization.slug)}>
+          <Link
+            to={newView.getResultsViewUrlTarget(
+              organization.slug,
+              false,
+              hasDatasetSelector(organization)
+                ? SavedQueryDatasets.TRANSACTIONS
+                : undefined
+            )}
+          >
             {WEB_VITAL_DETAILS[vital.title].name} (
             {WEB_VITAL_DETAILS[vital.title].acronym})
           </Link>
@@ -132,7 +142,15 @@ function PerformanceCardTable({
       ]);
       return (
         <SubTitle key={idx}>
-          <Link to={newView.getResultsViewUrlTarget(organization.slug)}>
+          <Link
+            to={newView.getResultsViewUrlTarget(
+              organization.slug,
+              false,
+              hasDatasetSelector(organization)
+                ? SavedQueryDatasets.TRANSACTIONS
+                : undefined
+            )}
+          >
             {span.title}
           </Link>
         </SubTitle>
@@ -310,7 +328,15 @@ function PerformanceCardTable({
       ]);
       return (
         <SubTitle key={idx}>
-          <Link to={newView.getResultsViewUrlTarget(organization.slug)}>
+          <Link
+            to={newView.getResultsViewUrlTarget(
+              organization.slug,
+              false,
+              hasDatasetSelector(organization)
+                ? SavedQueryDatasets.TRANSACTIONS
+                : undefined
+            )}
+          >
             {span.title}
           </Link>
         </SubTitle>

--- a/static/app/components/discover/transactionsList.tsx
+++ b/static/app/components/discover/transactionsList.tsx
@@ -18,9 +18,11 @@ import type {TableDataRow} from 'sentry/utils/discover/discoverQuery';
 import DiscoverQuery from 'sentry/utils/discover/discoverQuery';
 import type EventView from 'sentry/utils/discover/eventView';
 import type {Sort} from 'sentry/utils/discover/fields';
+import {SavedQueryDatasets} from 'sentry/utils/discover/types';
 import {TrendsEventsDiscoverQuery} from 'sentry/utils/performance/trends/trendsDiscoverQuery';
 import {decodeScalar} from 'sentry/utils/queryString';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
+import {hasDatasetSelector} from 'sentry/views/dashboards/utils';
 import type {Actions} from 'sentry/views/discover/table/cellAction';
 import type {TableColumn} from 'sentry/views/discover/table/types';
 import {decodeColumnOrder} from 'sentry/views/discover/utils';
@@ -329,7 +331,11 @@ class _TransactionsList extends Component<Props> {
               <DiscoverButton
                 onClick={handleOpenInDiscoverClick}
                 to={this.generateDiscoverEventView().getResultsViewUrlTarget(
-                  organization.slug
+                  organization.slug,
+                  false,
+                  hasDatasetSelector(organization)
+                    ? SavedQueryDatasets.TRANSACTIONS
+                    : undefined
                 )}
                 size="xs"
                 data-test-id="discover-open"

--- a/static/app/components/events/interfaces/spans/newTraceDetailsSpanDetails.tsx
+++ b/static/app/components/events/interfaces/spans/newTraceDetailsSpanDetails.tsx
@@ -25,11 +25,13 @@ import type {Organization} from 'sentry/types/organization';
 import {assert} from 'sentry/types/utils';
 import {defined} from 'sentry/utils';
 import EventView from 'sentry/utils/discover/eventView';
+import {SavedQueryDatasets} from 'sentry/utils/discover/types';
 import {generateEventSlug} from 'sentry/utils/discover/urls';
 import getDynamicText from 'sentry/utils/getDynamicText';
 import {safeURL} from 'sentry/utils/url/safeURL';
 import {useLocation} from 'sentry/utils/useLocation';
 import useProjects from 'sentry/utils/useProjects';
+import {hasDatasetSelector} from 'sentry/views/dashboards/utils';
 import {
   Frame,
   SpanDescription,
@@ -161,7 +163,11 @@ function NewTraceDetailsSpanDetail(props: SpanDetailProps) {
       <StyledDiscoverButton
         data-test-id="view-child-transactions"
         size="xs"
-        to={childrenEventView.getResultsViewUrlTarget(organization.slug)}
+        to={childrenEventView.getResultsViewUrlTarget(
+          organization.slug,
+          false,
+          hasDatasetSelector(organization) ? SavedQueryDatasets.TRANSACTIONS : undefined
+        )}
       >
         {t('View Children')}
       </StyledDiscoverButton>

--- a/static/app/components/events/interfaces/spans/spanDetail.tsx
+++ b/static/app/components/events/interfaces/spans/spanDetail.tsx
@@ -37,6 +37,7 @@ import {assert} from 'sentry/types/utils';
 import {defined} from 'sentry/utils';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import EventView from 'sentry/utils/discover/eventView';
+import {SavedQueryDatasets} from 'sentry/utils/discover/types';
 import {generateEventSlug} from 'sentry/utils/discover/urls';
 import getDynamicText from 'sentry/utils/getDynamicText';
 import type {
@@ -45,6 +46,7 @@ import type {
 } from 'sentry/utils/performance/quickTrace/types';
 import {useLocation} from 'sentry/utils/useLocation';
 import useProjects from 'sentry/utils/useProjects';
+import {hasDatasetSelector} from 'sentry/views/dashboards/utils';
 import {spanDetailsRouteWithQuery} from 'sentry/views/performance/transactionSummary/transactionSpans/spanDetails/utils';
 import {transactionSummaryRouteWithQuery} from 'sentry/views/performance/transactionSummary/utils';
 import {getPerformanceDuration} from 'sentry/views/performance/utils/getPerformanceDuration';
@@ -178,7 +180,11 @@ function SpanDetail(props: Props) {
       <StyledDiscoverButton
         data-test-id="view-child-transactions"
         size="xs"
-        to={childrenEventView.getResultsViewUrlTarget(organization.slug)}
+        to={childrenEventView.getResultsViewUrlTarget(
+          organization.slug,
+          false,
+          hasDatasetSelector(organization) ? SavedQueryDatasets.TRANSACTIONS : undefined
+        )}
       >
         {t('View Children')}
       </StyledDiscoverButton>

--- a/static/app/components/quickTrace/utils.tsx
+++ b/static/app/components/quickTrace/utils.tsx
@@ -6,6 +6,7 @@ import type {Event} from 'sentry/types/event';
 import type {Organization} from 'sentry/types/organization';
 import {defined} from 'sentry/utils';
 import EventView from 'sentry/utils/discover/eventView';
+import {SavedQueryDatasets} from 'sentry/utils/discover/types';
 import {
   eventDetailsRouteWithEventView,
   generateEventSlug,
@@ -18,6 +19,7 @@ import type {
 } from 'sentry/utils/performance/quickTrace/types';
 import {getTraceTimeRangeFromEvent} from 'sentry/utils/performance/quickTrace/utils';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
+import {hasDatasetSelector} from 'sentry/views/dashboards/utils';
 import {getTraceDetailsUrl} from 'sentry/views/performance/traceDetails/utils';
 
 export function isQuickTraceEvent(
@@ -109,7 +111,11 @@ export function generateMultiTransactionsTarget(
     start,
     end,
   });
-  return traceEventView.getResultsViewUrlTarget(organization.slug);
+  return traceEventView.getResultsViewUrlTarget(
+    organization.slug,
+    false,
+    hasDatasetSelector(organization) ? SavedQueryDatasets.TRANSACTIONS : undefined
+  );
 }
 
 const timestampsFieldCandidates = [
@@ -167,5 +173,9 @@ export function generateTraceTarget(
     version: 2,
     ...dateSelection,
   });
-  return eventView.getResultsViewUrlTarget(organization.slug);
+  return eventView.getResultsViewUrlTarget(
+    organization.slug,
+    false,
+    hasDatasetSelector(organization) ? SavedQueryDatasets.ERRORS : undefined
+  );
 }

--- a/static/app/views/dashboards/types.tsx
+++ b/static/app/views/dashboards/types.tsx
@@ -1,7 +1,7 @@
 import type {Layout} from 'react-grid-layout';
 
 import type {User} from 'sentry/types/user';
-import type {DatasetSource} from 'sentry/utils/discover/types';
+import {type DatasetSource, SavedQueryDatasets} from 'sentry/utils/discover/types';
 
 import type {ThresholdsConfig} from './widgetBuilder/buildSteps/thresholdsStep/thresholdsStep';
 
@@ -53,6 +53,11 @@ export enum OnDemandExtractionState {
   ENABLED_MANUAL = 'enabled:manual',
   ENABLED_CREATION = 'enabled:creation',
 }
+
+export const WIDGET_TYPE_TO_SAVED_QUERY_DATASET = {
+  [WidgetType.ERRORS]: SavedQueryDatasets.ERRORS,
+  [WidgetType.TRANSACTIONS]: SavedQueryDatasets.TRANSACTIONS,
+};
 
 interface WidgetQueryOnDemand {
   enabled: boolean;

--- a/static/app/views/dashboards/utils.tsx
+++ b/static/app/views/dashboards/utils.tsx
@@ -58,6 +58,7 @@ import type {
 import {
   DashboardFilterKeys,
   DisplayType,
+  WIDGET_TYPE_TO_SAVED_QUERY_DATASET,
   WidgetType,
 } from 'sentry/views/dashboards/types';
 
@@ -310,7 +311,13 @@ export function getWidgetDiscoverUrl(
   isMetricsData: boolean = false
 ) {
   const eventView = eventViewFromWidget(widget.title, widget.queries[index], selection);
-  const discoverLocation = eventView.getResultsViewUrlTarget(organization.slug);
+  const discoverLocation = eventView.getResultsViewUrlTarget(
+    organization.slug,
+    false,
+    hasDatasetSelector(organization) && widget.widgetType
+      ? WIDGET_TYPE_TO_SAVED_QUERY_DATASET[widget.widgetType]
+      : undefined
+  );
 
   // Pull a max of 3 valid Y-Axis from the widget
   const yAxisOptions = eventView.getYAxisOptions().map(({value}) => value);

--- a/static/app/views/discover/queryList.tsx
+++ b/static/app/views/discover/queryList.tsx
@@ -23,6 +23,7 @@ import EventView from 'sentry/utils/discover/eventView';
 import parseLinkHeader from 'sentry/utils/parseLinkHeader';
 import {decodeList} from 'sentry/utils/queryString';
 import withApi from 'sentry/utils/withApi';
+import {hasDatasetSelector} from 'sentry/views/dashboards/utils';
 
 import {
   getSavedQueryWithDataset,
@@ -166,14 +167,11 @@ class QueryList extends Component<Props> {
         ' - ' +
         moment(eventView.end).format('MMM D, YYYY h:mm A');
 
-      const to = eventView.getResultsViewUrlTarget(organization.slug);
-
-      if (organization.features.includes('performance-discover-dataset-selector')) {
-        to.query = {
-          ...to.query,
-          queryDataset: view.queryDataset,
-        };
-      }
+      const to = eventView.getResultsViewUrlTarget(
+        organization.slug,
+        false,
+        hasDatasetSelector(organization) ? view.queryDataset : undefined
+      );
 
       const menuItems = [
         {

--- a/static/app/views/performance/landing/widgets/components/widgetContainer.tsx
+++ b/static/app/views/performance/landing/widgets/components/widgetContainer.tsx
@@ -16,12 +16,13 @@ import {trackAnalytics} from 'sentry/utils/analytics';
 import {browserHistory} from 'sentry/utils/browserHistory';
 import type EventView from 'sentry/utils/discover/eventView';
 import type {Field} from 'sentry/utils/discover/fields';
-import {DisplayModes} from 'sentry/utils/discover/types';
+import {DisplayModes, SavedQueryDatasets} from 'sentry/utils/discover/types';
 import {useMEPSettingContext} from 'sentry/utils/performance/contexts/metricsEnhancedSetting';
 import {usePerformanceDisplayType} from 'sentry/utils/performance/contexts/performanceDisplayContext';
 import normalizeUrl from 'sentry/utils/url/normalizeUrl';
 import useOrganization from 'sentry/utils/useOrganization';
 import withOrganization from 'sentry/utils/withOrganization';
+import {hasDatasetSelector} from 'sentry/views/dashboards/utils';
 import MobileReleaseComparisonListWidget from 'sentry/views/performance/landing/widgets/widgets/mobileReleaseComparisonListWidget';
 import {PerformanceScoreListWidget} from 'sentry/views/performance/landing/widgets/widgets/performanceScoreListWidget';
 
@@ -344,7 +345,11 @@ const getEventViewDiscoverPath = (
   organization: Organization,
   eventView: EventView
 ): string => {
-  const discoverUrlTarget = eventView.getResultsViewUrlTarget(organization.slug);
+  const discoverUrlTarget = eventView.getResultsViewUrlTarget(
+    organization.slug,
+    false,
+    hasDatasetSelector(organization) ? SavedQueryDatasets.TRANSACTIONS : undefined
+  );
 
   // The landing page EventView has some additional conditions, but
   // `EventView#getResultsViewUrlTarget` omits those! Get them manually

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/sections/ancestry.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/sections/ancestry.tsx
@@ -21,7 +21,9 @@ import type {Organization} from 'sentry/types/organization';
 import {assert} from 'sentry/types/utils';
 import {defined} from 'sentry/utils';
 import EventView from 'sentry/utils/discover/eventView';
+import {SavedQueryDatasets} from 'sentry/utils/discover/types';
 import {generateEventSlug} from 'sentry/utils/discover/urls';
+import {hasDatasetSelector} from 'sentry/views/dashboards/utils';
 import type {
   TraceTree,
   TraceTreeNode,
@@ -146,7 +148,11 @@ function SpanChildrenTraversalButton({
     <StyledDiscoverButton
       data-test-id="view-child-transactions"
       size="xs"
-      to={childrenEventView.getResultsViewUrlTarget(organization.slug)}
+      to={childrenEventView.getResultsViewUrlTarget(
+        organization.slug,
+        false,
+        hasDatasetSelector(organization) ? SavedQueryDatasets.TRANSACTIONS : undefined
+      )}
     >
       {t('View Children')}
     </StyledDiscoverButton>

--- a/static/app/views/performance/newTraceDetails/traceDrawer/tabs/trace/tagsSummary.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/tabs/trace/tagsSummary.tsx
@@ -14,7 +14,9 @@ import type {Organization} from 'sentry/types/organization';
 import {generateQueryWithTag} from 'sentry/utils';
 import type EventView from 'sentry/utils/discover/eventView';
 import {formatTagKey} from 'sentry/utils/discover/fields';
+import {SavedQueryDatasets} from 'sentry/utils/discover/types';
 import type {UseInfiniteQueryResult} from 'sentry/utils/queryClient';
+import {hasDatasetSelector} from 'sentry/views/dashboards/utils';
 import StyledEmptyStateWarning from 'sentry/views/replays/detail/emptyState';
 
 import {TraceDrawerComponents} from '../../details/styles';
@@ -25,7 +27,11 @@ const getTagTarget = (
   eventView: EventView,
   organization: Organization
 ) => {
-  const url = eventView.getResultsViewUrlTarget(organization.slug, false);
+  const url = eventView.getResultsViewUrlTarget(
+    organization.slug,
+    false,
+    hasDatasetSelector(organization) ? SavedQueryDatasets.ERRORS : undefined
+  );
   url.query = generateQueryWithTag(url.query, {
     key: formatTagKey(tagKey),
     value: tagValue,

--- a/static/app/views/performance/newTraceDetails/traceMetadataHeader.tsx
+++ b/static/app/views/performance/newTraceDetails/traceMetadataHeader.tsx
@@ -12,8 +12,10 @@ import {t} from 'sentry/locale';
 import type {Organization} from 'sentry/types/organization';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import type EventView from 'sentry/utils/discover/eventView';
+import {SavedQueryDatasets} from 'sentry/utils/discover/types';
 import normalizeUrl from 'sentry/utils/url/normalizeUrl';
 import {useLocation} from 'sentry/utils/useLocation';
+import {hasDatasetSelector} from 'sentry/views/dashboards/utils';
 
 import Tab from '../transactionSummary/tabs';
 
@@ -366,7 +368,13 @@ export function TraceMetadataHeader(props: TraceMetadataHeaderProps) {
         <ButtonBar gap={1}>
           <DiscoverButton
             size="sm"
-            to={props.traceEventView.getResultsViewUrlTarget(props.organization.slug)}
+            to={props.traceEventView.getResultsViewUrlTarget(
+              props.organization.slug,
+              false,
+              hasDatasetSelector(props.organization)
+                ? SavedQueryDatasets.ERRORS
+                : undefined
+            )}
             onClick={trackOpenInDiscover}
           >
             {t('Open in Discover')}

--- a/static/app/views/performance/traceDetails/content.tsx
+++ b/static/app/views/performance/traceDetails/content.tsx
@@ -26,6 +26,7 @@ import {defined} from 'sentry/utils';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import type EventView from 'sentry/utils/discover/eventView';
 import type {QueryError} from 'sentry/utils/discover/genericDiscoverQuery';
+import {SavedQueryDatasets} from 'sentry/utils/discover/types';
 import getDuration from 'sentry/utils/duration/getDuration';
 import type {Fuse} from 'sentry/utils/fuzzySearch';
 import {createFuzzySearch} from 'sentry/utils/fuzzySearch';
@@ -39,6 +40,7 @@ import {filterTrace, reduceTrace} from 'sentry/utils/performance/quickTrace/util
 import {VisuallyCompleteWithData} from 'sentry/utils/performanceForSentry';
 import useDismissAlert from 'sentry/utils/useDismissAlert';
 import useProjects from 'sentry/utils/useProjects';
+import {hasDatasetSelector} from 'sentry/views/dashboards/utils';
 import Breadcrumb from 'sentry/views/performance/breadcrumb';
 import type {TraceTree} from 'sentry/views/performance/newTraceDetails/traceModels/traceTree';
 import {MetaData} from 'sentry/views/performance/transactionDetails/styles';
@@ -402,7 +404,11 @@ class TraceDetailsContent extends Component<Props, State> {
             <ButtonBar gap={1}>
               <DiscoverButton
                 size="sm"
-                to={traceEventView.getResultsViewUrlTarget(organization.slug)}
+                to={traceEventView.getResultsViewUrlTarget(
+                  organization.slug,
+                  false,
+                  hasDatasetSelector(organization) ? SavedQueryDatasets.ERRORS : undefined
+                )}
                 onClick={() => {
                   trackAnalytics('performance_views.trace_view.open_in_discover', {
                     organization,

--- a/static/app/views/performance/traceDetails/limitExceededMessage.tsx
+++ b/static/app/views/performance/traceDetails/limitExceededMessage.tsx
@@ -8,8 +8,10 @@ import {t, tct} from 'sentry/locale';
 import type {Organization} from 'sentry/types/organization';
 import {browserHistory} from 'sentry/utils/browserHistory';
 import type EventView from 'sentry/utils/discover/eventView';
+import {SavedQueryDatasets} from 'sentry/utils/discover/types';
 import type {TraceMeta} from 'sentry/utils/performance/quickTrace/types';
 import {useLocation} from 'sentry/utils/useLocation';
+import {hasDatasetSelector} from 'sentry/views/dashboards/utils';
 import type {TraceInfo} from 'sentry/views/performance/traceDetails/types';
 
 interface LimitExceededMessageProps {
@@ -42,7 +44,11 @@ function LimitExceededMessage({
     return null;
   }
 
-  const target = traceEventView.getResultsViewUrlTarget(organization.slug);
+  const target = traceEventView.getResultsViewUrlTarget(
+    organization.slug,
+    false,
+    hasDatasetSelector(organization) ? SavedQueryDatasets.ERRORS : undefined
+  );
 
   // Number of rows in the trace view. Doesnot include associated errors/issues appearing in
   // txn detail.

--- a/static/app/views/performance/transactionSummary/transactionEvents/content.tsx
+++ b/static/app/views/performance/transactionSummary/transactionEvents/content.tsx
@@ -17,10 +17,12 @@ import type {Project} from 'sentry/types/project';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {browserHistory} from 'sentry/utils/browserHistory';
 import type EventView from 'sentry/utils/discover/eventView';
+import {SavedQueryDatasets} from 'sentry/utils/discover/types';
 import type {WebVital} from 'sentry/utils/fields';
 import {decodeScalar} from 'sentry/utils/queryString';
 import projectSupportsReplay from 'sentry/utils/replays/projectSupportsReplay';
 import {useRoutes} from 'sentry/utils/useRoutes';
+import {hasDatasetSelector} from 'sentry/views/dashboards/utils';
 import {
   platformToPerformanceType,
   ProjectPerformanceType,
@@ -208,7 +210,11 @@ function Search(props: Props) {
         }))}
       />
       <Button
-        to={eventView.getResultsViewUrlTarget(organization.slug)}
+        to={eventView.getResultsViewUrlTarget(
+          organization.slug,
+          false,
+          hasDatasetSelector(organization) ? SavedQueryDatasets.TRANSACTIONS : undefined
+        )}
         onClick={handleDiscoverButtonClick}
       >
         {t('Open in Discover')}

--- a/static/app/views/performance/utils/index.tsx
+++ b/static/app/views/performance/utils/index.tsx
@@ -17,6 +17,7 @@ import {browserHistory} from 'sentry/utils/browserHistory';
 import type {EventData} from 'sentry/utils/discover/eventView';
 import EventView from 'sentry/utils/discover/eventView';
 import {TRACING_FIELDS} from 'sentry/utils/discover/fields';
+import {SavedQueryDatasets} from 'sentry/utils/discover/types';
 import {statsPeriodToDays} from 'sentry/utils/duration/statsPeriodToDays';
 import getCurrentSentryReactRootSpan from 'sentry/utils/getCurrentSentryReactRootSpan';
 import {useQuery} from 'sentry/utils/queryClient';
@@ -26,6 +27,7 @@ import normalizeUrl from 'sentry/utils/url/normalizeUrl';
 import useApi from 'sentry/utils/useApi';
 import useOrganization from 'sentry/utils/useOrganization';
 import useProjects from 'sentry/utils/useProjects';
+import {hasDatasetSelector} from 'sentry/views/dashboards/utils';
 
 import {DEFAULT_MAX_DURATION} from '../trends/utils';
 
@@ -74,7 +76,11 @@ export function createUnnamedTransactionsDiscoverTarget(props: {
     query,
     props.location
   ).withSorts([{field: 'epm', kind: 'desc'}]);
-  const target = discoverEventView.getResultsViewUrlTarget(props.organization.slug);
+  const target = discoverEventView.getResultsViewUrlTarget(
+    props.organization.slug,
+    false,
+    hasDatasetSelector(props.organization) ? SavedQueryDatasets.TRANSACTIONS : undefined
+  );
   target.query[SHOW_UNPARAM_BANNER] = 'true';
   return target;
 }


### PR DESCRIPTION
Open in Discover buttons on performance now also send
dataset. Will follow up with the rest.

This doesn't include the "open in discover" link on dashboard
widgets
