### PR TITLE
chore(features) Remove requires_snuba tuple

### DIFF
--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -48,25 +48,11 @@ from .manager import *  # NOQA
 #
 #   NOTE: The actor kwarg should be passed when it's expected that the handler
 #         needs context of the user.
-#
-#   NOTE: Features that require Snuba to function, add to the
-#         `requires_snuba` tuple.
 
 default_manager = FeatureManager()  # NOQA
 
 register_permanent_features(default_manager)
 register_temporary_features(default_manager)
-
-# This is a gross hardcoded list, but there's no
-# other sensible way to manage this right now without augmenting
-# features themselves in the manager with detections like this.
-requires_snuba = (
-    "organizations:discover",
-    "organizations:global-views",
-    "organizations:incidents",
-    "organizations:minute-resolution-sessions",
-    "organizations:performance-view",
-)
 
 # expose public api
 add = default_manager.add

--- a/src/sentry/runner/initializer.py
+++ b/src/sentry/runner/initializer.py
@@ -656,29 +656,6 @@ def validate_snuba() -> None:
     if has_all_snuba_required_backends and eventstream_is_snuba:
         return
 
-    from sentry.features import requires_snuba as snuba_features
-
-    snuba_enabled_features = set()
-
-    for feature in snuba_features:
-        if settings.SENTRY_FEATURES.get(feature, False):
-            snuba_enabled_features.add(feature)
-
-    if snuba_enabled_features and not eventstream_is_snuba:
-        show_big_error(
-            """
-You have features enabled which require Snuba,
-but you don't have any Snuba compatible configuration.
-
-Features you have enabled:
-%s
-
-See: https://github.com/getsentry/snuba#sentry--snuba
-"""
-            % "\n".join(snuba_enabled_features)
-        )
-        raise ConfigurationError("Cannot continue without Snuba configured.")
-
     if not eventstream_is_snuba:
         show_big_error(
             """


### PR DESCRIPTION
This list came from a time when snuba was optional for local development. We are long past the point of being able to run sentry without snuba and this list is incomplete and unmaintained.