### PR TITLE
fix(trace_related): Use global_views whitelist for events endpoint

### DIFF
--- a/src/sentry/api/bases/organization_events.py
+++ b/src/sentry/api/bases/organization_events.py
@@ -125,16 +125,8 @@ class OrganizationEventsEndpointBase(OrganizationEndpoint):
                     "organizations:global-views", organization, actor=request.user
                 )
                 fetching_replay_data = request.headers.get("X-Sentry-Replay-Request") == "1"
-                if not any(
-                    [
-                        has_global_views,
-                        len(params.projects) <= 1,
-                        fetching_replay_data,
-                        # If a developer can view issues of a project they do not belong to
-                        # via open membership, we will also allow the endpoint to return events for it
-                        organization.flags.allow_joinleave,
-                    ]
-                ):
+
+                if not has_global_views and len(params.projects) > 1 and not fetching_replay_data:
                     raise ParseError(detail="You cannot view events from multiple projects.")
 
             # Return both for now

--- a/src/sentry/api/bases/organization_events.py
+++ b/src/sentry/api/bases/organization_events.py
@@ -126,7 +126,9 @@ class OrganizationEventsEndpointBase(OrganizationEndpoint):
                 )
                 fetching_replay_data = request.headers.get("X-Sentry-Replay-Request") == "1"
 
-                if not has_global_views and len(params.projects) > 1 and not fetching_replay_data:
+                if not any(
+                    [has_global_views and len(params.projects) > 1 and not fetching_replay_data]
+                ):
                     raise ParseError(detail="You cannot view events from multiple projects.")
 
             # Return both for now

--- a/src/sentry/api/bases/organization_events.py
+++ b/src/sentry/api/bases/organization_events.py
@@ -119,12 +119,12 @@ class OrganizationEventsEndpointBase(OrganizationEndpoint):
                 teams=self.get_teams(request, organization),
                 organization=organization,
             )
+
             if check_global_views:
                 has_global_views = features.has(
                     "organizations:global-views", organization, actor=request.user
                 )
                 fetching_replay_data = request.headers.get("X-Sentry-Replay-Request") == "1"
-
                 if not any(
                     [
                         has_global_views,

--- a/src/sentry/api/bases/organization_events.py
+++ b/src/sentry/api/bases/organization_events.py
@@ -127,7 +127,11 @@ class OrganizationEventsEndpointBase(OrganizationEndpoint):
                 fetching_replay_data = request.headers.get("X-Sentry-Replay-Request") == "1"
 
                 if not any(
-                    [has_global_views and len(params.projects) > 1 and not fetching_replay_data]
+                    [
+                        has_global_views,
+                        len(params.projects) <= 1,
+                        fetching_replay_data,
+                    ]
                 ):
                     raise ParseError(detail="You cannot view events from multiple projects.")
 

--- a/src/sentry/api/bases/organization_events.py
+++ b/src/sentry/api/bases/organization_events.py
@@ -119,7 +119,6 @@ class OrganizationEventsEndpointBase(OrganizationEndpoint):
                 teams=self.get_teams(request, organization),
                 organization=organization,
             )
-
             if check_global_views:
                 has_global_views = features.has(
                     "organizations:global-views", organization, actor=request.user

--- a/src/sentry/api/endpoints/organization_events.py
+++ b/src/sentry/api/endpoints/organization_events.py
@@ -327,6 +327,9 @@ class OrganizationEventsEndpoint(OrganizationEventsV2EndpointBase):
             snuba_params, params = self.get_snuba_dataclass(
                 request,
                 organization,
+                # This is only temporary until we come to a decision on global views
+                # checking for referrer for an allowlist is a brittle check since referrer
+                # can easily be set by the caller
                 check_global_views=(
                     referrer in GLOBAL_VIEW_WHITELIST
                     and not bool(organization.flags.allow_joinleave)

--- a/src/sentry/api/endpoints/organization_events.py
+++ b/src/sentry/api/endpoints/organization_events.py
@@ -45,7 +45,7 @@ SAVED_QUERY_DATASET_MAP = {
 }
 # TODO: Adjust this once we make a decision in the DACI for global views restriction
 # Do not add more referres to this list as it is a temporary solution
-GLOBAL_VIEW_WHITELIST = ("api.issues.issue_events",)
+GLOBAL_VIEW_ALLOWLIST = ("api.issues.issue_events",)
 
 
 class DiscoverDatasetSplitException(Exception):
@@ -331,7 +331,7 @@ class OrganizationEventsEndpoint(OrganizationEventsV2EndpointBase):
                 # checking for referrer for an allowlist is a brittle check since referrer
                 # can easily be set by the caller
                 check_global_views=(
-                    referrer in GLOBAL_VIEW_WHITELIST
+                    referrer in GLOBAL_VIEW_ALLOWLIST
                     and not bool(organization.flags.allow_joinleave)
                 ),
             )

--- a/src/sentry/api/endpoints/organization_events.py
+++ b/src/sentry/api/endpoints/organization_events.py
@@ -316,7 +316,14 @@ class OrganizationEventsEndpoint(OrganizationEventsV2EndpointBase):
             return Response(status=404)
 
         try:
-            snuba_params, params = self.get_snuba_dataclass(request, organization)
+            # If the organization allows joining and leaving projects, it means that their
+            # developers can visit issues from any projects. In the case of trace related issues,
+            # we need the endpoint to let us see events from all projects when this flag is enabled.
+            snuba_params, params = self.get_snuba_dataclass(
+                request,
+                organization,
+                check_global_views=not bool(organization.flags.allow_joinleave),
+            )
         except NoProjects:
             return Response(
                 {

--- a/src/sentry/api/endpoints/organization_events.py
+++ b/src/sentry/api/endpoints/organization_events.py
@@ -43,7 +43,9 @@ SAVED_QUERY_DATASET_MAP = {
     DiscoverSavedQueryTypes.TRANSACTION_LIKE: get_dataset("transactions"),
     DiscoverSavedQueryTypes.ERROR_EVENTS: get_dataset("errors"),
 }
-GLOBAL_VIEW_WHITELIST = "api.issues.issue_events"
+# TODO: Adjust this once we make a decision in the DACI for global views restriction
+# Do not add more referres to this list as it is a temporary solution
+GLOBAL_VIEW_WHITELIST = ("api.issues.issue_events",)
 
 
 class DiscoverDatasetSplitException(Exception):

--- a/tests/sentry/api/test_organization_events.py
+++ b/tests/sentry/api/test_organization_events.py
@@ -93,7 +93,9 @@ class OrganizationEventsEndpointTest(APITestCase):
             },
             project_id=project2.id,
         )
-        response = self.do_request({"field": ["project"], "project": -1})
+        response = self.do_request(
+            {"field": ["project"], "project": -1, "referrer": "api.issues.issue_events"}
+        )
         assert response.status_code == 200, response.content
         assert len(response.data["data"]) == 2
 
@@ -101,7 +103,9 @@ class OrganizationEventsEndpointTest(APITestCase):
         self.organization.flags.allow_joinleave = False
         self.organization.save()
         assert bool(self.organization.flags.allow_joinleave) is False
-        response = self.do_request({"field": ["project"], "project": -1})
+        response = self.do_request(
+            {"field": ["project"], "project": -1, "referrer": "api.issues.issue_events"}
+        )
 
         assert response.status_code == 400, response.content
         assert response.data == {

--- a/tests/sentry/api/test_organization_events.py
+++ b/tests/sentry/api/test_organization_events.py
@@ -3,6 +3,7 @@ from unittest import mock
 from django.http import HttpRequest
 from django.test import override_settings
 from django.urls import reverse
+from rest_framework.exceptions import ErrorDetail
 from rest_framework.request import Request
 
 from sentry.api.endpoints.organization_events import (
@@ -74,6 +75,40 @@ class OrganizationEventsEndpointTest(APITestCase):
         assert response.status_code == 200, response.content
         assert len(response.data["data"]) == 1
         assert response.data["data"][0]["project.name"] == self.project.slug
+
+    def test_multiple_projects_open_membership(self):
+        assert bool(self.organization.flags.allow_joinleave)
+        self.store_event(
+            data={
+                "event_id": "a" * 32,
+                "timestamp": self.ten_mins_ago_iso,
+            },
+            project_id=self.project.id,
+        )
+        project2 = self.create_project()
+        self.store_event(
+            data={
+                "event_id": "b" * 32,
+                "timestamp": self.ten_mins_ago_iso,
+            },
+            project_id=project2.id,
+        )
+        response = self.do_request({"field": ["project"], "project": -1})
+        assert response.status_code == 200, response.content
+        assert len(response.data["data"]) == 2
+
+        # The test will now not work since the membership is closed
+        self.organization.flags.allow_joinleave = False
+        self.organization.save()
+        assert bool(self.organization.flags.allow_joinleave) is False
+        response = self.do_request({"field": ["project"], "project": -1})
+
+        assert response.status_code == 400, response.content
+        assert response.data == {
+            "detail": ErrorDetail(
+                string="You cannot view events from multiple projects.", code="parse_error"
+            )
+        }
 
     @mock.patch("sentry.snuba.discover.query")
     def test_api_token_referrer(self, mock):

--- a/tests/sentry/api/test_organization_events.py
+++ b/tests/sentry/api/test_organization_events.py
@@ -3,7 +3,6 @@ from unittest import mock
 from django.http import HttpRequest
 from django.test import override_settings
 from django.urls import reverse
-from rest_framework.exceptions import ErrorDetail
 from rest_framework.request import Request
 
 from sentry.api.endpoints.organization_events import (
@@ -75,39 +74,6 @@ class OrganizationEventsEndpointTest(APITestCase):
         assert response.status_code == 200, response.content
         assert len(response.data["data"]) == 1
         assert response.data["data"][0]["project.name"] == self.project.slug
-
-    def test_multiple_projects_open_membership(self):
-        assert bool(self.organization.flags.allow_joinleave)
-        self.store_event(
-            data={
-                "event_id": "a" * 32,
-                "timestamp": self.ten_mins_ago_iso,
-            },
-            project_id=self.project.id,
-        )
-        project2 = self.create_project()
-        self.store_event(
-            data={
-                "event_id": "b" * 32,
-                "timestamp": self.ten_mins_ago_iso,
-            },
-            project_id=project2.id,
-        )
-        response = self.do_request({"field": ["project"], "project": -1})
-        assert response.status_code == 200, response.content
-        assert len(response.data["data"]) == 2
-
-        self.organization.flags.allow_joinleave = False
-        self.organization.save()
-        assert bool(self.organization.flags.allow_joinleave) is False
-        response = self.do_request({"field": ["project"], "project": -1})
-
-        assert response.status_code == 400, response.content
-        assert response.data == {
-            "detail": ErrorDetail(
-                string="You cannot view events from multiple projects.", code="parse_error"
-            )
-        }
 
     @mock.patch("sentry.snuba.discover.query")
     def test_api_token_referrer(self, mock):

--- a/tests/snuba/api/endpoints/test_organization_events.py
+++ b/tests/snuba/api/endpoints/test_organization_events.py
@@ -165,6 +165,17 @@ class OrganizationEventsEndpointTest(OrganizationEventsEndpointTestBase, Perform
         assert response.status_code == 200
         assert len(response.data["data"]) == 1
 
+    def test_multi_project_feature_gate_rejection(self):
+        team = self.create_team(organization=self.organization, members=[self.user])
+
+        project = self.create_project(organization=self.organization, teams=[team])
+        project2 = self.create_project(organization=self.organization, teams=[team])
+
+        query = {"field": ["id", "project.id"], "project": [project.id, project2.id]}
+        response = self.do_request(query)
+        assert response.status_code == 400
+        assert "events from multiple projects" in response.data["detail"]
+
     def test_multi_project_feature_gate_replays(self):
         team = self.create_team(organization=self.organization, members=[self.user])
 


### PR DESCRIPTION
In #72961 I added a change to a base class which I should have not.

This PR reverts my original change and _only_ adjusts the events endpoint and requires a referrer whitelist.