### PR TITLE
feat(issue-details): Use new 'floating' tab design

### DIFF
--- a/static/app/views/issueDetails/eventNavigation.tsx
+++ b/static/app/views/issueDetails/eventNavigation.tsx
@@ -123,7 +123,7 @@ export default function EventNavigation({event, group}: EventNavigationProps) {
     <div>
       <EventNavigationWrapper>
         <Tabs>
-          <TabList hideBorder>
+          <TabList hideBorder variant="floating">
             {Object.keys(EventNavLabels).map(label => {
               return (
                 <TabList.Item


### PR DESCRIPTION
this pr uses the new tab design introduced in https://github.com/getsentry/sentry/pull/75029 for the streamlined event navigation component