### PR TITLE
nit(api): Standardize list api name

### DIFF
--- a/src/sentry/api/endpoints/organization_dashboards.py
+++ b/src/sentry/api/endpoints/organization_dashboards.py
@@ -68,7 +68,7 @@ class OrganizationDashboardsEndpoint(OrganizationEndpoint):
     permission_classes = (OrganizationDashboardsPermission,)
 
     @extend_schema(
-        operation_id="Retrieve an Organization's Custom Dashboards",
+        operation_id="List an Organization's Custom Dashboards",
         parameters=[GlobalParams.ORG_ID_OR_SLUG, VisibilityParams.PER_PAGE, CursorQueryParam],
         request=None,
         responses={


### PR DESCRIPTION
The API is hard to differentiate from the single GET so changing the name to `List` like our other bulk GETs

<img width="501" alt="Screenshot 2024-07-29 at 11 46 18 AM" src="https://github.com/user-attachments/assets/5a2fec0b-0cd9-47e8-82d8-ca1aa86c32fe">
