### PR TITLE
feat(custom-views): Create FE hooks for group search view endpoint 

### DIFF
--- a/static/app/types/views.tsx
+++ b/static/app/types/views.tsx
@@ -1,6 +1,0 @@
-export type View = {
-  name: string;
-  query: string;
-  querySort: 'date' | 'new' | 'trend' | 'freq' | 'user' | 'inbox';
-  id?: string;
-};

--- a/static/app/types/views.tsx
+++ b/static/app/types/views.tsx
@@ -1,0 +1,6 @@
+export type View = {
+  name: string;
+  query: string;
+  querySort: 'date' | 'new' | 'trend' | 'freq' | 'user' | 'inbox';
+  id?: string;
+};

--- a/static/app/views/issueList/mutations/useUpdateGroupSearchViews.tsx
+++ b/static/app/views/issueList/mutations/useUpdateGroupSearchViews.tsx
@@ -1,6 +1,5 @@
 import {addErrorMessage} from 'sentry/actionCreators/indicator';
 import {t} from 'sentry/locale';
-import type {View} from 'sentry/types/views';
 import {
   setApiQueryData,
   useMutation,
@@ -10,14 +9,15 @@ import {
 import type RequestError from 'sentry/utils/requestError/requestError';
 import useApi from 'sentry/utils/useApi';
 import {makeFetchGroupSearchViewsKey} from 'sentry/views/issueList/queries/useFetchGroupSearchViews';
+import type {GroupSearchView} from 'sentry/views/issueList/types';
 
 type UpdateGroupSearchViewsVariables = {
   orgSlug: string;
-  views: View[];
+  views: GroupSearchView[];
 };
 
 // The PUT groupsearchviews endpoint updates the views AND returns the updated views
-type UpdateGroupSearchViewResponse = View[];
+type UpdateGroupSearchViewResponse = GroupSearchView[];
 
 export const useUpdateGroupSearchViews = (
   options: Omit<
@@ -47,7 +47,7 @@ export const useUpdateGroupSearchViews = (
       setApiQueryData<View[]>(
         queryClient,
         makeFetchGroupSearchViewsKey({orgSlug: parameters.orgSlug}),
-        () => views // Update the cache with the new views
+        views // Update the cache with the new views
       );
       options.onSuccess?.(views, parameters, context);
     },

--- a/static/app/views/issueList/mutations/useUpdateGroupSearchViews.tsx
+++ b/static/app/views/issueList/mutations/useUpdateGroupSearchViews.tsx
@@ -12,8 +12,8 @@ import {makeFetchGroupSearchViewsKey} from 'sentry/views/issueList/queries/useFe
 import type {GroupSearchView} from 'sentry/views/issueList/types';
 
 type UpdateGroupSearchViewsVariables = {
+  groupSearchViews: GroupSearchView[];
   orgSlug: string;
-  views: GroupSearchView[];
 };
 
 // The PUT groupsearchviews endpoint updates the views AND returns the updated views
@@ -38,18 +38,18 @@ export const useUpdateGroupSearchViews = (
     UpdateGroupSearchViewsVariables
   >({
     ...options,
-    mutationFn: ({orgSlug, views: data}: UpdateGroupSearchViewsVariables) =>
+    mutationFn: ({orgSlug, groupSearchViews: data}: UpdateGroupSearchViewsVariables) =>
       api.requestPromise(`/organizations/${orgSlug}/group-search-views/`, {
         method: 'PUT',
         data,
       }),
-    onSuccess: (views, parameters, context) => {
-      setApiQueryData<View[]>(
+    onSuccess: (groupSearchViews, parameters, context) => {
+      setApiQueryData<GroupSearchView[]>(
         queryClient,
         makeFetchGroupSearchViewsKey({orgSlug: parameters.orgSlug}),
-        views // Update the cache with the new views
+        groupSearchViews // Update the cache with the new groupSearchViews
       );
-      options.onSuccess?.(views, parameters, context);
+      options.onSuccess?.(groupSearchViews, parameters, context);
     },
     onError: (error, variables, context) => {
       addErrorMessage(t('Failed to update views'));

--- a/static/app/views/issueList/mutations/useUpdateGroupSearchViews.tsx
+++ b/static/app/views/issueList/mutations/useUpdateGroupSearchViews.tsx
@@ -1,0 +1,59 @@
+import {addErrorMessage} from 'sentry/actionCreators/indicator';
+import {t} from 'sentry/locale';
+import type {View} from 'sentry/types/views';
+import {
+  setApiQueryData,
+  useMutation,
+  type UseMutationOptions,
+  useQueryClient,
+} from 'sentry/utils/queryClient';
+import type RequestError from 'sentry/utils/requestError/requestError';
+import useApi from 'sentry/utils/useApi';
+import {makeFetchGroupSearchViewsKey} from 'sentry/views/issueList/queries/useFetchGroupSearchViews';
+
+type UpdateGroupSearchViewsVariables = {
+  orgSlug: string;
+  views: View[];
+};
+
+// The PUT groupsearchviews endpoint updates the views AND returns the updated views
+type UpdateGroupSearchViewResponse = View[];
+
+export const useUpdateGroupSearchViews = (
+  options: Omit<
+    UseMutationOptions<
+      UpdateGroupSearchViewResponse,
+      RequestError,
+      UpdateGroupSearchViewsVariables
+    >,
+    'mutationFn'
+  > = {}
+) => {
+  const api = useApi();
+  const queryClient = useQueryClient();
+
+  return useMutation<
+    UpdateGroupSearchViewResponse,
+    RequestError,
+    UpdateGroupSearchViewsVariables
+  >({
+    ...options,
+    mutationFn: ({orgSlug, views: data}: UpdateGroupSearchViewsVariables) =>
+      api.requestPromise(`/organizations/${orgSlug}/group-search-views/`, {
+        method: 'PUT',
+        data,
+      }),
+    onSuccess: (views, parameters, context) => {
+      setApiQueryData<View[]>(
+        queryClient,
+        makeFetchGroupSearchViewsKey({orgSlug: parameters.orgSlug}),
+        () => views // Update the cache with the new views
+      );
+      options.onSuccess?.(views, parameters, context);
+    },
+    onError: (error, variables, context) => {
+      addErrorMessage(t('Failed to update views'));
+      options.onError?.(error, variables, context);
+    },
+  });
+};

--- a/static/app/views/issueList/queries/useFetchGroupSearchViews.tsx
+++ b/static/app/views/issueList/queries/useFetchGroupSearchViews.tsx
@@ -1,0 +1,27 @@
+import type {View} from 'sentry/types/views';
+import type {UseApiQueryOptions} from 'sentry/utils/queryClient';
+import {useApiQuery} from 'sentry/utils/queryClient';
+
+type FetchGroupSearchViewsParameters = {
+  orgSlug: string;
+};
+
+type FetchGroupSearchViewsResponse = View[];
+
+export const makeFetchGroupSearchViewsKey = ({
+  orgSlug,
+}: FetchGroupSearchViewsParameters) =>
+  [`/organizations/${orgSlug}/group-search-views/`] as const;
+
+export const useFetchGroupSearchViewsForOrg = (
+  {orgSlug}: FetchGroupSearchViewsParameters,
+  options: Partial<UseApiQueryOptions<FetchGroupSearchViewsResponse>> = {}
+) => {
+  return useApiQuery<FetchGroupSearchViewsResponse>(
+    makeFetchGroupSearchViewsKey({orgSlug}),
+    {
+      staleTime: Infinity,
+      ...options,
+    }
+  );
+};

--- a/static/app/views/issueList/queries/useFetchGroupSearchViews.tsx
+++ b/static/app/views/issueList/queries/useFetchGroupSearchViews.tsx
@@ -1,12 +1,12 @@
-import type {View} from 'sentry/types/views';
 import type {UseApiQueryOptions} from 'sentry/utils/queryClient';
 import {useApiQuery} from 'sentry/utils/queryClient';
+import type {GroupSearchView} from 'sentry/views/issueList/types';
 
 type FetchGroupSearchViewsParameters = {
   orgSlug: string;
 };
 
-type FetchGroupSearchViewsResponse = View[];
+type FetchGroupSearchViewsResponse = GroupSearchView[];
 
 export const makeFetchGroupSearchViewsKey = ({
   orgSlug,

--- a/static/app/views/issueList/types.tsx
+++ b/static/app/views/issueList/types.tsx
@@ -4,6 +4,7 @@ import type {
   PriorityLevel,
   TagValue,
 } from 'sentry/types';
+import type {IssueSortOptions} from 'sentry/views/issueList/utils';
 
 export type TagValueLoader = (key: string, search: string) => Promise<TagValue[]>;
 
@@ -13,3 +14,10 @@ export type IssueUpdateData =
   | {priority: PriorityLevel}
   | MarkReviewed
   | GroupStatusResolution;
+
+export type GroupSearchView = {
+  name: string;
+  query: string;
+  querySort: IssueSortOptions;
+  id?: string;
+};


### PR DESCRIPTION
This PR creates the `useApiQuery` and `useMutation` hooks to call the GET and PUT groupsearchview endpoints, respectively. The endpoints can be found [here](https://github.com/getsentry/sentry/blob/master/src/sentry/issues/endpoints/organization_group_search_views.py)