### PR TITLE
chore(seer grouping): Update `get_seer_similar_issues` docstring given removal of metadata flag

### DIFF
--- a/src/sentry/grouping/ingest/seer.py
+++ b/src/sentry/grouping/ingest/seer.py
@@ -197,9 +197,6 @@ def get_seer_similar_issues(
     Ask Seer for the given event's nearest neighbor(s) and return the seer response data, sorted
     with the best matches first, along with the group Seer decided the event should go in, if any,
     or None if no neighbor was near enough.
-
-    Will also return `None` for the neighboring group if the `projects:similarity-embeddings-grouping`
-    feature flag is off.
     """
 
     event_hash = primary_hashes.hashes[0]


### PR DESCRIPTION
Now that the `projects:similarity-embeddings-metadata` flag is gone, we no longer make a distinction between getting Seer grouping results and using said results - we now always use the results if we've asked for them. This updates the `get_seer_similar_issues` docstring to reflect that fact.

