### PR TITLE
feat(profiling): Generate flamegraph from latest transaction or conti…

### DIFF
--- a/src/sentry/snuba/referrer.py
+++ b/src/sentry/snuba/referrer.py
@@ -375,6 +375,9 @@ class Referrer(Enum):
     API_PROFILING_PROFILE_FLAMEGRAPH_CHUNK_CANDIDATES = (
         "api.profiling.profile-flamegraph-chunk-candidates"
     )
+    API_PROFILING_PROFILE_FLAMEGRAPH_PROFILE_CANDIDATES = (
+        "api.profiling.profile-flamegraph-profile-candidates"
+    )
     API_PROFILING_FLAMEGRAPH_SPANS_WITH_GROUP = "api.profiling.flamegraph-spans-with-group"
     API_PROFILING_FLAMEGRAPH_CHUNKS_FROM_SPANS = "api.profiling.flamegraph-chunks-with-spans"
     API_PROFILING_FUNCTION_SCOPED_FLAMEGRAPH = "api.profiling.function-scoped-flamegraph"


### PR DESCRIPTION
…nuous profiles

This adds a new flamegraph source for `profiles` where we always generate flamegraphs using the latest transaction or continuous profiles. This does not require that the user has tracing enabled, just continuous profiling.