### PR TITLE
ref(seer grouping): Handle Seer only sending matching groups

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -1551,13 +1551,6 @@ def _save_aggregate(
                         )
                         event.data["seer_similarity"] = seer_response_data
 
-                        # We only want to add this data to new groups, while we're testing
-                        # TODO: Remove this once we're out of the testing phase
-                        if not seer_matched_group:
-                            group_creation_kwargs["data"]["metadata"][
-                                "seer_similarity"
-                            ] = seer_response_data
-
                     # Insurance - in theory we shouldn't ever land here
                     except Exception as e:
                         sentry_sdk.capture_exception(

--- a/src/sentry/grouping/ingest/seer.py
+++ b/src/sentry/grouping/ingest/seer.py
@@ -217,9 +217,7 @@ def get_seer_similar_issues(
 
     # Similar issues are returned with the closest match first
     seer_results = get_similarity_data_from_seer(request_data)
-    similar_issues_metadata = asdict(
-        SeerSimilarIssuesMetadata(request_hash=event_hash, results=seer_results)
-    )
+    similar_issues_metadata = asdict(SeerSimilarIssuesMetadata(results=seer_results))
     parent_group = (
         Group.objects.filter(id=seer_results[0].parent_group_id).first() if seer_results else None
     )

--- a/src/sentry/grouping/ingest/seer.py
+++ b/src/sentry/grouping/ingest/seer.py
@@ -221,9 +221,7 @@ def get_seer_similar_issues(
         SeerSimilarIssuesMetadata(request_hash=event_hash, results=seer_results)
     )
     parent_group = (
-        Group.objects.filter(id=seer_results[0].parent_group_id).first()
-        if seer_results and seer_results[0].should_group
-        else None
+        Group.objects.filter(id=seer_results[0].parent_group_id).first() if seer_results else None
     )
 
     logger.info(

--- a/src/sentry/seer/similarity/types.py
+++ b/src/sentry/seer/similarity/types.py
@@ -113,6 +113,5 @@ class SeerSimilarIssueData:
 
 @dataclass
 class SeerSimilarIssuesMetadata:
-    request_hash: str
     results: list[SeerSimilarIssueData]
     similarity_model_version: str = SEER_SIMILARITY_MODEL_VERSION

--- a/tests/sentry/event_manager/grouping/test_seer_grouping.py
+++ b/tests/sentry/event_manager/grouping/test_seer_grouping.py
@@ -159,25 +159,3 @@ class SeerEventManagerGroupingTest(TestCase):
 
             assert mock_get_similarity_data.call_count == 1
             assert existing_event.group_id != new_event.group_id
-
-    @with_feature("projects:similarity-embeddings-grouping")
-    @patch("sentry.event_manager.should_call_seer_for_grouping", return_value=True)
-    def test_creates_new_group_if_too_far_neighbor_found(self, _):
-        existing_event = save_new_event({"message": "Dogs are great!"}, self.project)
-
-        no_cigar_data = SeerSimilarIssueData(
-            parent_hash=NonNone(existing_event.get_primary_hash()),
-            parent_group_id=NonNone(existing_event.group_id),
-            stacktrace_distance=0.10,
-            message_distance=0.05,
-            should_group=False,
-        )
-
-        with patch(
-            "sentry.grouping.ingest.seer.get_similarity_data_from_seer",
-            return_value=[no_cigar_data],
-        ) as mock_get_similarity_data:
-            new_event = save_new_event({"message": "Adopt don't shop"}, self.project)
-
-            assert mock_get_similarity_data.call_count == 1
-            assert existing_event.group_id != new_event.group_id

--- a/tests/sentry/event_manager/grouping/test_seer_grouping.py
+++ b/tests/sentry/event_manager/grouping/test_seer_grouping.py
@@ -25,10 +25,6 @@ class SeerEventManagerGroupingTest(TestCase):
             message_distance=0.05,
             should_group=True,
         )
-        metadata_base = {
-            "similarity_model_version": SEER_SIMILARITY_MODEL_VERSION,
-            "results": [asdict(seer_result_data)],
-        }
 
         get_seer_similar_issues_return_values: list[Any] = []
 
@@ -70,7 +66,10 @@ class SeerEventManagerGroupingTest(TestCase):
 
             with Feature({"projects:similarity-embeddings-grouping": True}):
                 new_event = save_new_event({"message": "Maisey is silly"}, self.project)
-                expected_metadata = {**metadata_base, "request_hash": new_event.get_primary_hash()}
+                expected_metadata = {
+                    "similarity_model_version": SEER_SIMILARITY_MODEL_VERSION,
+                    "results": [asdict(seer_result_data)],
+                }
 
                 # We checked whether to make the call, and then made it
                 assert should_call_seer_spy.call_count == 1
@@ -119,7 +118,6 @@ class SeerEventManagerGroupingTest(TestCase):
             new_event = save_new_event({"message": "Adopt don't shop"}, self.project)
             expected_metadata = {
                 "similarity_model_version": SEER_SIMILARITY_MODEL_VERSION,
-                "request_hash": new_event.get_primary_hash(),
                 "results": [asdict(seer_result_data)],
             }
 

--- a/tests/sentry/grouping/ingest/test_seer.py
+++ b/tests/sentry/grouping/ingest/test_seer.py
@@ -253,29 +253,6 @@ class GetSeerSimilarIssuesTest(TestCase):
                 self.existing_event.group,
             )
 
-    def test_returns_metadata_but_no_group_if_similar_group_insufficiently_close(self):
-        seer_result_data = SeerSimilarIssueData(
-            parent_hash=NonNone(self.existing_event.get_primary_hash()),
-            parent_group_id=NonNone(self.existing_event.group_id),
-            stacktrace_distance=0.08,
-            message_distance=0.12,
-            should_group=False,
-        )
-        expected_metadata = {
-            "similarity_model_version": SEER_SIMILARITY_MODEL_VERSION,
-            "request_hash": self.new_event_hashes.hashes[0],
-            "results": [asdict(seer_result_data)],
-        }
-
-        with patch(
-            "sentry.grouping.ingest.seer.get_similarity_data_from_seer",
-            return_value=[seer_result_data],
-        ):
-            assert get_seer_similar_issues(self.new_event, self.new_event_hashes) == (
-                expected_metadata,
-                None,
-            )
-
     def test_returns_no_group_and_empty_metadata_if_no_similar_group_found(self):
         expected_metadata = {
             "similarity_model_version": SEER_SIMILARITY_MODEL_VERSION,

--- a/tests/sentry/grouping/ingest/test_seer.py
+++ b/tests/sentry/grouping/ingest/test_seer.py
@@ -240,7 +240,6 @@ class GetSeerSimilarIssuesTest(TestCase):
         )
         expected_metadata = {
             "similarity_model_version": SEER_SIMILARITY_MODEL_VERSION,
-            "request_hash": self.new_event_hashes.hashes[0],
             "results": [asdict(seer_result_data)],
         }
 
@@ -256,7 +255,6 @@ class GetSeerSimilarIssuesTest(TestCase):
     def test_returns_no_group_and_empty_metadata_if_no_similar_group_found(self):
         expected_metadata = {
             "similarity_model_version": SEER_SIMILARITY_MODEL_VERSION,
-            "request_hash": self.new_event_hashes.hashes[0],
             "results": [],
         }
 


### PR DESCRIPTION
Seer no longer sends back similar but non-matching groups when called during ingest, which means on the Sentry side, we no longer need to handle that case. This PR therefore removes the `should_group` check on retrieving a parent group, since Seer will only send back results if `should_group` is true. It also stops storing the Seer results on the group, since a) the only time there's a new group on which to store the results is when a match isn't found, and b) in cases where a match isn't found, there now won't be any similar groups to store, only an empty results list. Finally, since the metadata is now only going to be stored on the event, and the event knows its own hash, `request_hash` has been removed from the metadata we store.