### PR TITLE
feat(metrics): remove span.group from metrics settings

### DIFF
--- a/static/app/views/performance/utils/useSpanFieldSupportedTags.tsx
+++ b/static/app/views/performance/utils/useSpanFieldSupportedTags.tsx
@@ -69,6 +69,7 @@ export function useSpanFieldSupportedTags(options?: {
     [
       SpanIndexedField.SPAN_AI_PIPELINE_GROUP,
       SpanIndexedField.SPAN_CATEGORY,
+      SpanIndexedField.SPAN_GROUP,
       ...excludedTags,
     ],
     DiscoverDatasets.SPANS_INDEXED


### PR DESCRIPTION
Closes https://github.com/getsentry/sentry/issues/75125

Trace Explorer Search Before: 
![Screenshot 2024-07-30 at 10 54 36](https://github.com/user-attachments/assets/3935803a-12f6-4671-bdf9-0deeaca4fa4b)


Trace Explorer Search After:
![Screenshot 2024-07-30 at 10 54 30](https://github.com/user-attachments/assets/90ba2d10-feb0-42d1-b90a-196dd0e7d141)

---

Metrics Settings Before:
![Screenshot 2024-07-30 at 10 59 32](https://github.com/user-attachments/assets/94a65fdb-716f-4e66-994f-36fb348276a2)


Metrics Settings After:
![Screenshot 2024-07-30 at 10 59 23](https://github.com/user-attachments/assets/07b8dbf9-4016-4105-acdf-761ed3c68fa5)
