### PR TITLE
ref(perf-monitoring): Change wording to "Tracing" (frontend)

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 # What's Sentry?
 
-Sentry is a developer-first error tracking and performance monitoring platform that helps developers see what actually matters, solve quicker, and learn continuously about their applications.
+Sentry is a developer-first error tracking and tracing platform that helps developers see what actually matters, solve quicker, and learn continuously about their applications.
 
 <p align="center">
   <img src="https://github.com/getsentry/sentry/raw/master/.github/screenshots/projects.png" width="270" />

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -65,7 +65,7 @@ function getTestsForGroup(
   // We are going to take all of our tests and split them into groups.
   // If we have a test without a known duration, we will default it to 2 second
   // This is to ensure that we still assign some weight to the tests and still attempt to somewhat balance them.
-  // The 1.5s default is selected as a p50 value of all of our JS tests in CI (as of 2022-10-26) taken from our sentry performance monitoring.
+  // The 1.5s default is selected as a p50 value of all of our JS tests in CI (as of 2022-10-26) taken from our sentry tracing.
   const tests = new Map<string, number>();
   const SUITE_P50_DURATION_MS = 1500;
 

--- a/static/app/components/metrics/metricSamplesTable.tsx
+++ b/static/app/components/metrics/metricSamplesTable.tsx
@@ -251,7 +251,7 @@ export function MetricSamplesTable({
     if (!hasPerformance) {
       return (
         <PerformanceEmptyState withIcon={false}>
-          <p>{t('You need to set up performance monitoring to collect samples.')}</p>
+          <p>{t('You need to set up tracing to collect samples.')}</p>
           <LinkButton
             priority="primary"
             external

--- a/static/app/components/onboarding/productSelection.spec.tsx
+++ b/static/app/components/onboarding/productSelection.spec.tsx
@@ -60,18 +60,18 @@ describe('Onboarding Product Selection', function () {
     await userEvent.click(screen.getByRole('checkbox', {name: 'Error Monitoring'}));
     await waitFor(() => expect(router.push).not.toHaveBeenCalled());
 
-    // Performance monitoring shall be checked and enabled by default
-    expect(screen.getByRole('checkbox', {name: 'Performance Monitoring'})).toBeChecked();
-    expect(screen.getByRole('checkbox', {name: 'Performance Monitoring'})).toBeEnabled();
+    // Tracing shall be checked and enabled by default
+    expect(screen.getByRole('checkbox', {name: 'Tracing'})).toBeChecked();
+    expect(screen.getByRole('checkbox', {name: 'Tracing'})).toBeEnabled();
 
     // Tooltip with explanation shall be displayed on hover
-    await userEvent.hover(screen.getByRole('checkbox', {name: 'Performance Monitoring'}));
+    await userEvent.hover(screen.getByRole('checkbox', {name: 'Tracing'}));
     expect(
       await screen.findByText(/Automatic performance issue detection/)
     ).toBeInTheDocument();
 
-    // Uncheck performance monitoring
-    await userEvent.click(screen.getByRole('checkbox', {name: 'Performance Monitoring'}));
+    // Uncheck tracing
+    await userEvent.click(screen.getByRole('checkbox', {name: 'Tracing'}));
     await waitFor(() =>
       expect(router.replace).toHaveBeenCalledWith({
         pathname: undefined,
@@ -172,12 +172,10 @@ describe('Onboarding Product Selection', function () {
       }
     );
 
-    // Performance Monitoring shall be unchecked and disabled by default
-    expect(screen.getByRole('checkbox', {name: 'Performance Monitoring'})).toBeDisabled();
-    expect(
-      screen.getByRole('checkbox', {name: 'Performance Monitoring'})
-    ).not.toBeChecked();
-    await userEvent.hover(screen.getByRole('checkbox', {name: 'Performance Monitoring'}));
+    // Tracing shall be unchecked and disabled by default
+    expect(screen.getByRole('checkbox', {name: 'Tracing'})).toBeDisabled();
+    expect(screen.getByRole('checkbox', {name: 'Tracing'})).not.toBeChecked();
+    await userEvent.hover(screen.getByRole('checkbox', {name: 'Tracing'}));
 
     // A tooltip with explanation why the option is disabled shall be displayed on hover
     expect(
@@ -185,9 +183,9 @@ describe('Onboarding Product Selection', function () {
         disabledProducts[ProductSolution.PERFORMANCE_MONITORING].reason
       )
     ).toBeInTheDocument();
-    await userEvent.click(screen.getByRole('checkbox', {name: 'Performance Monitoring'}));
+    await userEvent.click(screen.getByRole('checkbox', {name: 'Tracing'}));
 
-    // Try to uncheck performance monitoring
+    // Try to uncheck tracing
     await waitFor(() => expect(router.push).not.toHaveBeenCalled());
   });
 
@@ -272,7 +270,7 @@ describe('Onboarding Product Selection', function () {
 
     expect(screen.getByRole('checkbox', {name: 'Error Monitoring'})).toBeEnabled();
 
-    expect(screen.getByRole('checkbox', {name: 'Performance Monitoring'})).toBeDisabled();
+    expect(screen.getByRole('checkbox', {name: 'Tracing'})).toBeDisabled();
 
     expect(screen.getByRole('checkbox', {name: 'Session Replay'})).toBeDisabled();
   });

--- a/static/app/components/onboarding/productSelection.tsx
+++ b/static/app/components/onboarding/productSelection.tsx
@@ -69,10 +69,7 @@ function getDisabledProducts(organization: Organization): DisabledProducts {
   if (!hasPerformance) {
     disabledProducts[ProductSolution.PERFORMANCE_MONITORING] = {
       reason,
-      onClick: createClickHandler(
-        'organizations:performance-view',
-        'Performance Monitoring'
-      ),
+      onClick: createClickHandler('organizations:performance-view', 'Tracing'),
     };
   }
   if (!hasProfiling) {
@@ -351,7 +348,7 @@ export function ProductSelection({
       );
 
       if (defaultProducts?.includes(ProductSolution.PROFILING)) {
-        // Ensure that if profiling is enabled, performance monitoring is also enabled
+        // Ensure that if profiling is enabled, tracing is also enabled
         if (
           product === ProductSolution.PROFILING &&
           newProduct.has(ProductSolution.PROFILING)
@@ -427,7 +424,7 @@ export function ProductSelection({
         />
         {products.includes(ProductSolution.PERFORMANCE_MONITORING) && (
           <Product
-            label={t('Performance Monitoring')}
+            label={t('Tracing')}
             description={t(
               'Automatic performance issue detection across services and context on who is impacted, outliers, regressions, and the root cause of your slowdown.'
             )}
@@ -453,7 +450,7 @@ export function ProductSelection({
           <Product
             label={t('Profiling')}
             description={tct(
-              '[strong:Requires Performance Monitoring]\nSee the exact lines of code causing your performance bottlenecks, for faster troubleshooting and resource optimization.',
+              '[strong:Requires Tracing]\nSee the exact lines of code causing your performance bottlenecks, for faster troubleshooting and resource optimization.',
               {
                 strong: <strong />,
               }

--- a/static/app/components/slider/index.tsx
+++ b/static/app/components/slider/index.tsx
@@ -172,12 +172,16 @@ function BaseSlider(
 
   const nThumbs = state.values.length;
   const refs = useRef<Array<HTMLInputElement>>([]);
-  useImperativeHandle(forwardedRef, () => {
-    if (nThumbs > 1) {
-      return refs.current;
-    }
-    return refs.current[0];
-  }, [nThumbs]);
+  useImperativeHandle(
+    forwardedRef,
+    () => {
+      if (nThumbs > 1) {
+        return refs.current;
+      }
+      return refs.current[0];
+    },
+    [nThumbs]
+  );
 
   const getFormattedValue = useCallback(
     (val: number) => {

--- a/static/app/components/slider/index.tsx
+++ b/static/app/components/slider/index.tsx
@@ -172,16 +172,12 @@ function BaseSlider(
 
   const nThumbs = state.values.length;
   const refs = useRef<Array<HTMLInputElement>>([]);
-  useImperativeHandle(
-    forwardedRef,
-    () => {
-      if (nThumbs > 1) {
-        return refs.current;
-      }
-      return refs.current[0];
-    },
-    [nThumbs]
-  );
+  useImperativeHandle(forwardedRef, () => {
+    if (nThumbs > 1) {
+      return refs.current;
+    }
+    return refs.current[0];
+  }, [nThumbs]);
 
   const getFormattedValue = useCallback(
     (val: number) => {

--- a/static/app/constants/notAvailableMessages.tsx
+++ b/static/app/constants/notAvailableMessages.tsx
@@ -1,7 +1,7 @@
 import {t} from 'sentry/locale';
 
 export const NOT_AVAILABLE_MESSAGES = {
-  performance: t('This view is only available with Performance Monitoring.'),
+  performance: t('This view is only available with Tracing.'),
   discover: t('This view is only available with Discover.'),
   releaseHealth: t('This view is only available with Release Health.'),
 };

--- a/static/app/gettingStartedDocs/apple/ios.tsx
+++ b/static/app/gettingStartedDocs/apple/ios.tsx
@@ -69,7 +69,7 @@ func application(_ application: UIApplication,
           params.isPerformanceSelected
             ? `
 
-        // Set tracesSampleRate to 1.0 to capture 100% of transactions for performance monitoring.
+        // Set tracesSampleRate to 1.0 to capture 100% of transactions for tracing.
         // We recommend adjusting this value in production.
         options.tracesSampleRate = 1.0`
             : ''
@@ -99,7 +99,7 @@ struct SwiftUIApp: App {
               params.isPerformanceSelected
                 ? `
 
-            // Set tracesSampleRate to 1.0 to capture 100% of transactions for performance monitoring.
+            // Set tracesSampleRate to 1.0 to capture 100% of transactions for tracing.
             // We recommend adjusting this value in production.
             options.tracesSampleRate = 1.0`
                 : ''

--- a/static/app/gettingStartedDocs/apple/macos.tsx
+++ b/static/app/gettingStartedDocs/apple/macos.tsx
@@ -34,7 +34,7 @@ func applicationDidFinishLaunching(_ aNotification: Notification) {
           params.isPerformanceSelected
             ? `
 
-        // Set tracesSampleRate to 1.0 to capture 100% of transactions for performance monitoring.
+        // Set tracesSampleRate to 1.0 to capture 100% of transactions for tracing.
         // We recommend adjusting this value in production.
         options.tracesSampleRate = 1.0`
             : ''
@@ -64,7 +64,7 @@ struct SwiftUIApp: App {
               params.isPerformanceSelected
                 ? `
 
-            // Set tracesSampleRate to 1.0 to capture 100% of transactions for performance monitoring.
+            // Set tracesSampleRate to 1.0 to capture 100% of transactions for tracing.
             // We recommend adjusting this value in production.
             options.tracesSampleRate = 1.0`
                 : ''

--- a/static/app/gettingStartedDocs/bun/bun.spec.tsx
+++ b/static/app/gettingStartedDocs/bun/bun.spec.tsx
@@ -19,7 +19,7 @@ describe('bun onboarding docs', function () {
     ).toBeInTheDocument();
   });
 
-  it('renders without performance monitoring', function () {
+  it('renders without "tracing"', function () {
     renderWithOnboardingLayout(docs, {
       selectedProducts: [],
     });
@@ -30,8 +30,6 @@ describe('bun onboarding docs', function () {
     ).not.toBeInTheDocument();
 
     // Renders next steps
-    expect(
-      screen.getByRole('link', {name: 'Performance Monitoring'})
-    ).toBeInTheDocument();
+    expect(screen.getByRole('link', {name: 'Tracing'})).toBeInTheDocument();
   });
 });

--- a/static/app/gettingStartedDocs/bun/bun.tsx
+++ b/static/app/gettingStartedDocs/bun/bun.tsx
@@ -33,7 +33,7 @@ Sentry.init({
   dsn: "${params.dsn}",${
     params.isPerformanceSelected
       ? `
-  // Performance Monitoring
+  // Tracing
   tracesSampleRate: 1.0, // Capture 100% of the transactions`
       : ''
   }
@@ -98,7 +98,7 @@ const onboarding: OnboardingConfig = {
       : [
           {
             id: 'performance-monitoring',
-            name: t('Performance Monitoring'),
+            name: t('Tracing'),
             description: t(
               'Track down transactions to connect the dots between 10-second page loads and poor-performing API calls or slow database queries.'
             ),

--- a/static/app/gettingStartedDocs/capacitor/capacitor.tsx
+++ b/static/app/gettingStartedDocs/capacitor/capacitor.tsx
@@ -121,7 +121,7 @@ const getSentryInitLayout = (params: Params, siblingOption: string): string => {
   ${
     params.isPerformanceSelected
       ? `
-        // Performance Monitoring
+        // Tracing
         tracesSampleRate: 1.0, //  Capture 100% of the transactions`
       : ''
   }${
@@ -255,7 +255,7 @@ const onboarding: OnboardingConfig<PlatformOptions> = {
       ? null
       : {
           id: 'performance-monitoring',
-          name: t('Performance Monitoring'),
+          name: t('Tracing'),
           description: t(
             'Track down transactions to connect the dots between 10-second page loads and poor-performing API calls or slow database queries.'
           ),

--- a/static/app/gettingStartedDocs/dart/dart.tsx
+++ b/static/app/gettingStartedDocs/dart/dart.tsx
@@ -27,7 +27,7 @@ import 'package:sentry/sentry.dart';
 Future<void> main() async {
   await Sentry.init((options) {
     options.dsn = '${params.dsn}';
-    // Set tracesSampleRate to 1.0 to capture 100% of transactions for performance monitoring.
+    // Set tracesSampleRate to 1.0 to capture 100% of transactions for tracing.
     // We recommend adjusting this value in production.
     options.tracesSampleRate = 1.0;
   });

--- a/static/app/gettingStartedDocs/deno/deno.spec.tsx
+++ b/static/app/gettingStartedDocs/deno/deno.spec.tsx
@@ -19,7 +19,7 @@ describe('deno onboarding docs', function () {
     ).toBeInTheDocument();
   });
 
-  it('renders without performance monitoring', function () {
+  it('renders without "tracing"', function () {
     renderWithOnboardingLayout(docs, {
       selectedProducts: [],
     });
@@ -30,8 +30,6 @@ describe('deno onboarding docs', function () {
     ).not.toBeInTheDocument();
 
     // Renders next steps
-    expect(
-      screen.getByRole('link', {name: 'Performance Monitoring'})
-    ).toBeInTheDocument();
+    expect(screen.getByRole('link', {name: 'Tracing'})).toBeInTheDocument();
   });
 });

--- a/static/app/gettingStartedDocs/deno/deno.tsx
+++ b/static/app/gettingStartedDocs/deno/deno.tsx
@@ -107,7 +107,7 @@ const onboarding: OnboardingConfig = {
       : [
           {
             id: 'performance-monitoring',
-            name: t('Performance Monitoring'),
+            name: t('Tracing'),
             description: t(
               'Track down transactions to connect the dots between 10-second page loads and poor-performing API calls or slow database queries.'
             ),

--- a/static/app/gettingStartedDocs/dotnet/aspnet.tsx
+++ b/static/app/gettingStartedDocs/dotnet/aspnet.tsx
@@ -60,7 +60,7 @@ public class MvcApplication : HttpApplication
               params.isPerformanceSelected
                 ? `
             // Set TracesSampleRate to 1.0 to capture 100%
-            // of transactions for performance monitoring.
+            // of transactions for tracing.
             // We recommend adjusting this value in production
             o.TracesSampleRate = 1.0;`
                 : ''

--- a/static/app/gettingStartedDocs/dotnet/aspnetcore.spec.tsx
+++ b/static/app/gettingStartedDocs/dotnet/aspnetcore.spec.tsx
@@ -20,9 +20,7 @@ describe('aspnetcore onboarding docs', function () {
     expect(screen.getByRole('heading', {name: 'Install'})).toBeInTheDocument();
     expect(screen.getByRole('heading', {name: 'Configure SDK'})).toBeInTheDocument();
     expect(screen.getByRole('heading', {name: 'Verify'})).toBeInTheDocument();
-    expect(
-      screen.getByRole('heading', {name: 'Performance Monitoring'})
-    ).toBeInTheDocument();
+    expect(screen.getByRole('heading', {name: 'Tracing'})).toBeInTheDocument();
     expect(screen.getByRole('heading', {name: 'Samples'})).toBeInTheDocument();
 
     // Renders SDK version from registry

--- a/static/app/gettingStartedDocs/dotnet/aspnetcore.tsx
+++ b/static/app/gettingStartedDocs/dotnet/aspnetcore.tsx
@@ -63,7 +63,7 @@ public static IHostBuilder CreateHostBuilder(string[] args) =>
                 params.isPerformanceSelected
                   ? `
               // Set TracesSampleRate to 1.0 to capture 100%
-              // of transactions for performance monitoring.
+              // of transactions for tracing.
               // We recommend adjusting this value in production
               o.TracesSampleRate = 1.0;`
                   : ''
@@ -206,7 +206,7 @@ const onboarding: OnboardingConfig = {
     ...(params.isPerformanceSelected
       ? [
           {
-            title: t('Performance Monitoring'),
+            title: t('Tracing'),
             description: tct(
               'You can measure the performance of your endpoints by adding a middleware to [code:Startup.cs]:',
               {

--- a/static/app/gettingStartedDocs/dotnet/awslambda.tsx
+++ b/static/app/gettingStartedDocs/dotnet/awslambda.tsx
@@ -49,7 +49,7 @@ public class LambdaEntryPoint : Amazon.Lambda.AspNetCoreServer.APIGatewayProxyFu
               o.FlushOnCompletedRequest = true;${
                 params.isPerformanceSelected
                   ? `
-              // Set TracesSampleRate to 1.0 to capture 100% of transactions for performance monitoring.
+              // Set TracesSampleRate to 1.0 to capture 100% of transactions for tracing.
               // We recommend adjusting this value in production.
               o.TracesSampleRate = 1.0;`
                   : ''

--- a/static/app/gettingStartedDocs/dotnet/dotnet.spec.tsx
+++ b/static/app/gettingStartedDocs/dotnet/dotnet.spec.tsx
@@ -20,9 +20,7 @@ describe('dotnet onboarding docs', function () {
     expect(screen.getByRole('heading', {name: 'Install'})).toBeInTheDocument();
     expect(screen.getByRole('heading', {name: 'Configure SDK'})).toBeInTheDocument();
     expect(screen.getByRole('heading', {name: 'Verify'})).toBeInTheDocument();
-    expect(
-      screen.getByRole('heading', {name: 'Performance Monitoring'})
-    ).toBeInTheDocument();
+    expect(screen.getByRole('heading', {name: 'Tracing'})).toBeInTheDocument();
     expect(screen.getByRole('heading', {name: 'Samples'})).toBeInTheDocument();
 
     // Renders SDK version from registry

--- a/static/app/gettingStartedDocs/dotnet/dotnet.tsx
+++ b/static/app/gettingStartedDocs/dotnet/dotnet.tsx
@@ -80,7 +80,7 @@ SentrySdk.Init(options =>
         ? `
 
     // Set TracesSampleRate to 1.0 to capture 100%
-    // of transactions for performance monitoring.
+    // of transactions for tracing.
     // We recommend adjusting this value in production.
     options.TracesSampleRate = 1.0;`
         : ''
@@ -246,7 +246,7 @@ const onboarding: OnboardingConfig = {
     ...(params.isPerformanceSelected
       ? [
           {
-            title: t('Performance Monitoring'),
+            title: t('Tracing'),
             description: t(
               'You can measure the performance of your code by capturing transactions and spans.'
             ),

--- a/static/app/gettingStartedDocs/dotnet/gcpfunctions.tsx
+++ b/static/app/gettingStartedDocs/dotnet/gcpfunctions.tsx
@@ -68,7 +68,7 @@ const getConfigureJsonSnippet = (params: Params) => `
     "MaxRequestBodySize": "Always"${
       params.isPerformanceSelected
         ? `,
-    // Set TracesSampleRate to 1.0 to capture 100% of transactions for performance monitoring.
+    // Set TracesSampleRate to 1.0 to capture 100% of transactions for tracing.
     // We recommend adjusting this value in production.
     "TracesSampleRate": 1`
         : ''

--- a/static/app/gettingStartedDocs/dotnet/maui.spec.tsx
+++ b/static/app/gettingStartedDocs/dotnet/maui.spec.tsx
@@ -20,9 +20,7 @@ describe('maui onboarding docs', function () {
     expect(screen.getByRole('heading', {name: 'Install'})).toBeInTheDocument();
     expect(screen.getByRole('heading', {name: 'Configure SDK'})).toBeInTheDocument();
     expect(screen.getByRole('heading', {name: 'Verify'})).toBeInTheDocument();
-    expect(
-      screen.getByRole('heading', {name: 'Performance Monitoring'})
-    ).toBeInTheDocument();
+    expect(screen.getByRole('heading', {name: 'Tracing'})).toBeInTheDocument();
     expect(screen.getByRole('heading', {name: 'Sample Application'})).toBeInTheDocument();
 
     // Renders SDK version from registry

--- a/static/app/gettingStartedDocs/dotnet/maui.tsx
+++ b/static/app/gettingStartedDocs/dotnet/maui.tsx
@@ -74,7 +74,7 @@ public static MauiApp CreateMauiApp()
         params.isPerformanceSelected
           ? `
 
-      // Set TracesSampleRate to 1.0 to capture 100% of transactions for performance monitoring.
+      // Set TracesSampleRate to 1.0 to capture 100% of transactions for tracing.
       // We recommend adjusting this value in production.
       options.TracesSampleRate = 1.0;`
           : ''
@@ -246,7 +246,7 @@ const onboarding: OnboardingConfig = {
     ...(params.isPerformanceSelected
       ? [
           {
-            title: t('Performance Monitoring'),
+            title: t('Tracing'),
             description: (
               <Fragment>
                 {t(

--- a/static/app/gettingStartedDocs/dotnet/uwp.spec.tsx
+++ b/static/app/gettingStartedDocs/dotnet/uwp.spec.tsx
@@ -20,9 +20,7 @@ describe('uwp onboarding docs', function () {
     expect(screen.getByRole('heading', {name: 'Install'})).toBeInTheDocument();
     expect(screen.getByRole('heading', {name: 'Configure SDK'})).toBeInTheDocument();
     expect(screen.getByRole('heading', {name: 'Verify'})).toBeInTheDocument();
-    expect(
-      screen.getByRole('heading', {name: 'Performance Monitoring'})
-    ).toBeInTheDocument();
+    expect(screen.getByRole('heading', {name: 'Tracing'})).toBeInTheDocument();
     expect(screen.getByRole('heading', {name: 'Documentation'})).toBeInTheDocument();
     expect(screen.getByRole('heading', {name: 'Samples'})).toBeInTheDocument();
 

--- a/static/app/gettingStartedDocs/dotnet/uwp.tsx
+++ b/static/app/gettingStartedDocs/dotnet/uwp.tsx
@@ -44,7 +44,7 @@ sealed partial class App : Application
             o.Debug = true;${
               params.isPerformanceSelected
                 ? `
-            // Set TracesSampleRate to 1.0 to capture 100% of transactions for performance monitoring.
+            // Set TracesSampleRate to 1.0 to capture 100% of transactions for tracing.
             // We recommend adjusting this value in production.
             o.TracesSampleRate = 1.0;`
                 : ''
@@ -153,7 +153,7 @@ const onboarding: OnboardingConfig = {
       ),
     },
     {
-      title: t('Performance Monitoring'),
+      title: t('Tracing'),
       description: t(
         'You can measure the performance of your code by capturing transactions and spans.'
       ),

--- a/static/app/gettingStartedDocs/dotnet/winforms.spec.tsx
+++ b/static/app/gettingStartedDocs/dotnet/winforms.spec.tsx
@@ -20,9 +20,7 @@ describe('winforms onboarding docs', function () {
     expect(screen.getByRole('heading', {name: 'Install'})).toBeInTheDocument();
     expect(screen.getByRole('heading', {name: 'Configure SDK'})).toBeInTheDocument();
     expect(screen.getByRole('heading', {name: 'Verify'})).toBeInTheDocument();
-    expect(
-      screen.getByRole('heading', {name: 'Performance Monitoring'})
-    ).toBeInTheDocument();
+    expect(screen.getByRole('heading', {name: 'Tracing'})).toBeInTheDocument();
     expect(screen.getByRole('heading', {name: 'Documentation'})).toBeInTheDocument();
     expect(screen.getByRole('heading', {name: 'Samples'})).toBeInTheDocument();
 

--- a/static/app/gettingStartedDocs/dotnet/winforms.tsx
+++ b/static/app/gettingStartedDocs/dotnet/winforms.tsx
@@ -70,7 +70,7 @@ static class Program
             o.Debug = true;${
               params.isPerformanceSelected
                 ? `
-            // Set TracesSampleRate to 1.0 to capture 100% of transactions for performance monitoring.
+            // Set TracesSampleRate to 1.0 to capture 100% of transactions for tracing.
             // We recommend adjusting this value in production.
             o.TracesSampleRate = 1.0;`
                 : ''
@@ -212,7 +212,7 @@ const onboarding: OnboardingConfig = {
     ...(params.isPerformanceSelected
       ? [
           {
-            title: t('Performance Monitoring'),
+            title: t('Tracing'),
             description: t(
               'You can measure the performance of your code by capturing transactions and spans.'
             ),

--- a/static/app/gettingStartedDocs/dotnet/wpf.spec.tsx
+++ b/static/app/gettingStartedDocs/dotnet/wpf.spec.tsx
@@ -20,9 +20,7 @@ describe('wpf onboarding docs', function () {
     expect(screen.getByRole('heading', {name: 'Install'})).toBeInTheDocument();
     expect(screen.getByRole('heading', {name: 'Configure SDK'})).toBeInTheDocument();
     expect(screen.getByRole('heading', {name: 'Verify'})).toBeInTheDocument();
-    expect(
-      screen.getByRole('heading', {name: 'Performance Monitoring'})
-    ).toBeInTheDocument();
+    expect(screen.getByRole('heading', {name: 'Tracing'})).toBeInTheDocument();
     expect(screen.getByRole('heading', {name: 'Documentation'})).toBeInTheDocument();
     expect(screen.getByRole('heading', {name: 'Samples'})).toBeInTheDocument();
 

--- a/static/app/gettingStartedDocs/dotnet/wpf.tsx
+++ b/static/app/gettingStartedDocs/dotnet/wpf.tsx
@@ -69,7 +69,7 @@ public partial class App : Application
             o.Debug = true;${
               params.isPerformanceSelected
                 ? `
-            // Set TracesSampleRate to 1.0 to capture 100% of transactions for performance monitoring.
+            // Set TracesSampleRate to 1.0 to capture 100% of transactions for tracing.
             // We recommend adjusting this value in production.
             o.TracesSampleRate = 1.0;`
                 : ''
@@ -211,7 +211,7 @@ const onboarding: OnboardingConfig = {
     ...(params.isPerformanceSelected
       ? [
           {
-            title: t('Performance Monitoring'),
+            title: t('Tracing'),
             description: t(
               'You can measure the performance of your code by capturing transactions and spans.'
             ),

--- a/static/app/gettingStartedDocs/dotnet/xamarin.spec.tsx
+++ b/static/app/gettingStartedDocs/dotnet/xamarin.spec.tsx
@@ -18,9 +18,7 @@ describe('xamarin onboarding docs', function () {
     expect(screen.getByRole('heading', {name: 'Install'})).toBeInTheDocument();
     expect(screen.getByRole('heading', {name: 'Configure SDK'})).toBeInTheDocument();
     expect(screen.getByRole('heading', {name: 'Verify'})).toBeInTheDocument();
-    expect(
-      screen.getByRole('heading', {name: 'Performance Monitoring'})
-    ).toBeInTheDocument();
+    expect(screen.getByRole('heading', {name: 'Tracing'})).toBeInTheDocument();
     expect(screen.getByRole('heading', {name: 'Documentation'})).toBeInTheDocument();
     expect(screen.getByRole('heading', {name: 'Limitations'})).toBeInTheDocument();
     expect(screen.getByRole('heading', {name: 'Samples'})).toBeInTheDocument();

--- a/static/app/gettingStartedDocs/dotnet/xamarin.tsx
+++ b/static/app/gettingStartedDocs/dotnet/xamarin.tsx
@@ -43,7 +43,7 @@ public class MainActivity : global::Xamarin.Forms.Platform.Android.FormsAppCompa
             options.Dsn = "${params.dsn}";
             // When configuring for the first time, to see what the SDK is doing:
             options.Debug = true;
-            // Set TracesSampleRate to 1.0 to capture 100% of transactions for performance monitoring.
+            // Set TracesSampleRate to 1.0 to capture 100% of transactions for tracing.
             // We recommend adjusting this value in production.
             options.TracesSampleRate = 1.0;
             // If you installed Sentry.Xamarin.Forms:
@@ -60,7 +60,7 @@ public partial class AppDelegate : global::Xamarin.Forms.Platform.iOS.FormsAppli
             options.Dsn = "${params.dsn}";
             // When configuring for the first time, to see what the SDK is doing:
             options.Debug = true;
-            // Set TracesSampleRate to 1.0 to capture 100% of transactions for performance monitoring.
+            // Set TracesSampleRate to 1.0 to capture 100% of transactions for tracing.
             // We recommend adjusting this value in production.
             options.TracesSampleRate = 1.0;
             options.AddXamarinFormsIntegration();
@@ -76,7 +76,7 @@ sealed partial class App : Application
             options.Dsn = "${params.dsn}";
             // When configuring for the first time, to see what the SDK is doing:
             options.Debug = true;
-            // Set TracesSampleRate to 1.0 to capture 100% of transactions for performance monitoring.
+            // Set TracesSampleRate to 1.0 to capture 100% of transactions for tracing.
             // We recommend adjusting this value in production.
             options.TracesSampleRate = 1.0;
             options.AddXamarinFormsIntegration();
@@ -200,7 +200,7 @@ const onboarding: OnboardingConfig = {
       ),
     },
     {
-      title: t('Performance Monitoring'),
+      title: t('Tracing'),
       description: t(
         'You can measure the performance of your code by capturing transactions and spans.'
       ),

--- a/static/app/gettingStartedDocs/flutter/flutter.tsx
+++ b/static/app/gettingStartedDocs/flutter/flutter.tsx
@@ -28,7 +28,7 @@ Future<void> main() async {
       options.dsn = '${params.dsn}';${
         params.isPerformanceSelected
           ? `
-      // Set tracesSampleRate to 1.0 to capture 100% of transactions for performance monitoring.
+      // Set tracesSampleRate to 1.0 to capture 100% of transactions for tracing.
       // We recommend adjusting this value in production.
       options.tracesSampleRate = 1.0;`
           : ''

--- a/static/app/gettingStartedDocs/go/echo.tsx
+++ b/static/app/gettingStartedDocs/go/echo.tsx
@@ -36,7 +36,7 @@ if err := sentry.Init(sentry.ClientOptions{
     params.isPerformanceSelected
       ? `
   // Set TracesSampleRate to 1.0 to capture 100%
-  // of transactions for performance monitoring.
+  // of transactions for tracing.
   // We recommend adjusting this value in production,
   TracesSampleRate: 1.0,`
       : ''

--- a/static/app/gettingStartedDocs/go/fasthttp.tsx
+++ b/static/app/gettingStartedDocs/go/fasthttp.tsx
@@ -35,7 +35,7 @@ if err := sentry.Init(sentry.ClientOptions{
       ? `
   EnableTracing: true,
   // Set TracesSampleRate to 1.0 to capture 100%
-  // of transactions for performance monitoring.
+  // of transactions for tracing.
   // We recommend adjusting this value in production,
   TracesSampleRate: 1.0,`
       : ''

--- a/static/app/gettingStartedDocs/go/fiber.tsx
+++ b/static/app/gettingStartedDocs/go/fiber.tsx
@@ -32,7 +32,7 @@ import (
 if err := sentry.Init(sentry.ClientOptions{
   Dsn: "${params.dsn}",
   // Set TracesSampleRate to 1.0 to capture 100%
-  // of transactions for performance monitoring.
+  // of transactions for tracing.
   // We recommend adjusting this value in production,
   TracesSampleRate: 1.0,
 }); err != nil {

--- a/static/app/gettingStartedDocs/go/gin.tsx
+++ b/static/app/gettingStartedDocs/go/gin.tsx
@@ -36,7 +36,7 @@ if err := sentry.Init(sentry.ClientOptions{
       ? `
   EnableTracing: true,
   // Set TracesSampleRate to 1.0 to capture 100%
-  // of transactions for performance monitoring.
+  // of transactions for tracing.
   // We recommend adjusting this value in production,
   TracesSampleRate: 1.0,`
       : ''

--- a/static/app/gettingStartedDocs/go/go.tsx
+++ b/static/app/gettingStartedDocs/go/go.tsx
@@ -29,7 +29,7 @@ func main() {
       params.isPerformanceSelected
         ? `
     // Set TracesSampleRate to 1.0 to capture 100%
-    // of transactions for performance monitoring.
+    // of transactions for tracing.
     // We recommend adjusting this value in production,
     TracesSampleRate: 1.0,`
         : ''
@@ -56,7 +56,7 @@ func main() {
       params.isPerformanceSelected
         ? `
     // Set TracesSampleRate to 1.0 to capture 100%
-    // of transactions for performance monitoring.
+    // of transactions for tracing.
     // We recommend adjusting this value in production,
     TracesSampleRate: 1.0,`
         : ''

--- a/static/app/gettingStartedDocs/go/http.tsx
+++ b/static/app/gettingStartedDocs/go/http.tsx
@@ -34,7 +34,7 @@ if err := sentry.Init(sentry.ClientOptions{
     params.isPerformanceSelected
       ? `
   // Set TracesSampleRate to 1.0 to capture 100%
-  // of transactions for performance monitoring.
+  // of transactions for tracing.
   // We recommend adjusting this value in production,
   TracesSampleRate: 1.0,`
       : ''

--- a/static/app/gettingStartedDocs/go/iris.tsx
+++ b/static/app/gettingStartedDocs/go/iris.tsx
@@ -34,7 +34,7 @@ if err := sentry.Init(sentry.ClientOptions{
     params.isPerformanceSelected
       ? `
   // Set TracesSampleRate to 1.0 to capture 100%
-  // of transactions for performance monitoring.
+  // of transactions for tracing.
   // We recommend adjusting this value in production,
   TracesSampleRate: 1.0,`
       : ''

--- a/static/app/gettingStartedDocs/go/martini.tsx
+++ b/static/app/gettingStartedDocs/go/martini.tsx
@@ -34,7 +34,7 @@ if err := sentry.Init(sentry.ClientOptions{
     params.isPerformanceSelected
       ? `
   // Set TracesSampleRate to 1.0 to capture 100%
-  // of transactions for performance monitoring.
+  // of transactions for tracing.
   // We recommend adjusting this value in production,
   TracesSampleRate: 1.0,`
       : ''

--- a/static/app/gettingStartedDocs/go/negroni.tsx
+++ b/static/app/gettingStartedDocs/go/negroni.tsx
@@ -35,7 +35,7 @@ if err := sentry.Init(sentry.ClientOptions{
     params.isPerformanceSelected
       ? `
   // Set TracesSampleRate to 1.0 to capture 100%
-  // of transactions for performance monitoring.
+  // of transactions for tracing.
   // We recommend adjusting this value in production,
   TracesSampleRate: 1.0,`
       : ''

--- a/static/app/gettingStartedDocs/java/java.tsx
+++ b/static/app/gettingStartedDocs/java/java.tsx
@@ -124,7 +124,7 @@ Sentry.init(options -> {
   options.setDsn("${params.dsn}");${
     params.isPerformanceSelected
       ? `
-  // Set tracesSampleRate to 1.0 to capture 100% of transactions for performance monitoring.
+  // Set tracesSampleRate to 1.0 to capture 100% of transactions for tracing.
   // We recommend adjusting this value in production.
   options.setTracesSampleRate(1.0);`
       : ''
@@ -288,7 +288,7 @@ const onboarding: OnboardingConfig<PlatformOptions> = {
     },
     {
       id: 'performance-monitoring',
-      name: t('Performance Monitoring'),
+      name: t('Tracing'),
       description: t(
         'Stay ahead of latency issues and trace every slow transaction to a poor-performing API call or database query.'
       ),

--- a/static/app/gettingStartedDocs/java/spring-boot.tsx
+++ b/static/app/gettingStartedDocs/java/spring-boot.tsx
@@ -108,7 +108,7 @@ const getConfigurationPropertiesSnippet = (params: Params) => `
 sentry.dsn=${params.dsn}${
   params.isPerformanceSelected
     ? `
-# Set traces-sample-rate to 1.0 to capture 100% of transactions for performance monitoring.
+# Set traces-sample-rate to 1.0 to capture 100% of transactions for tracing.
 # We recommend adjusting this value in production.
 sentry.traces-sample-rate=1.0`
     : ''
@@ -119,7 +119,7 @@ sentry:
   dsn: ${params.dsn}${
     params.isPerformanceSelected
       ? `
-  # Set traces-sample-rate to 1.0 to capture 100% of transactions for performance monitoring.
+  # Set traces-sample-rate to 1.0 to capture 100% of transactions for tracing.
   # We recommend adjusting this value in production.
   traces-sample-rate: 1.0`
       : ''
@@ -291,7 +291,7 @@ const onboarding: OnboardingConfig<PlatformOptions> = {
     },
     {
       id: 'performance-monitoring',
-      name: t('Performance Monitoring'),
+      name: t('Tracing'),
       description: t(
         'Stay ahead of latency issues and trace every slow transaction to a poor-performing API call or database query.'
       ),

--- a/static/app/gettingStartedDocs/java/spring.tsx
+++ b/static/app/gettingStartedDocs/java/spring.tsx
@@ -363,7 +363,7 @@ const onboarding: OnboardingConfig<PlatformOptions> = {
     },
     {
       id: 'performance-monitoring',
-      name: t('Performance Monitoring'),
+      name: t('Tracing'),
       description: t(
         'Stay ahead of latency issues and trace every slow transaction to a poor-performing API call or database query.'
       ),

--- a/static/app/gettingStartedDocs/javascript/angular.tsx
+++ b/static/app/gettingStartedDocs/javascript/angular.tsx
@@ -164,7 +164,7 @@ export const nextSteps = [
   },
   {
     id: 'performance-monitoring',
-    name: t('Performance Monitoring'),
+    name: t('Tracing'),
     description: t(
       'Track down transactions to connect the dots between 10-second page loads and poor-performing API calls or slow database queries.'
     ),
@@ -212,7 +212,7 @@ ${getFeedbackConfigOptions(params.feedbackOptions)}}),`
   ],${
     params.isPerformanceSelected
       ? `
-        // Performance Monitoring
+        // Tracing
         tracesSampleRate: 1.0, //  Capture 100% of the transactions
         // Set 'tracePropagationTargets' to control for which URLs distributed tracing should be enabled
         tracePropagationTargets: ["localhost", /^https:\\/\\/yourserver\\.io\\/api/],`

--- a/static/app/gettingStartedDocs/javascript/astro.tsx
+++ b/static/app/gettingStartedDocs/javascript/astro.tsx
@@ -191,7 +191,7 @@ const onboarding: OnboardingConfig = {
     },
     {
       id: 'performance-monitoring',
-      name: t('Performance Monitoring'),
+      name: t('Tracing'),
       description: t(
         'Track down transactions to connect the dots between 10-second page loads and poor-performing API calls or slow database queries.'
       ),

--- a/static/app/gettingStartedDocs/javascript/ember.tsx
+++ b/static/app/gettingStartedDocs/javascript/ember.tsx
@@ -51,7 +51,7 @@ ${getFeedbackConfigOptions(params.feedbackOptions)}}),`
 ],${
   params.isPerformanceSelected
     ? `
-      // Performance Monitoring
+      // Tracing
       tracesSampleRate: 1.0, //  Capture 100% of the transactions
       // Set 'tracePropagationTargets' to control for which URLs distributed tracing should be enabled
       tracePropagationTargets: ["localhost", /^https:\\/\\/yourserver\\.io\\/api/],`
@@ -146,7 +146,7 @@ const onboarding: OnboardingConfig = {
   nextSteps: () => [
     {
       id: 'performance-monitoring',
-      name: t('Performance Monitoring'),
+      name: t('Tracing'),
       description: t(
         'Track down transactions to connect the dots between 10-second page loads and poor-performing API calls or slow database queries.'
       ),

--- a/static/app/gettingStartedDocs/javascript/gatsby.tsx
+++ b/static/app/gettingStartedDocs/javascript/gatsby.tsx
@@ -53,7 +53,7 @@ ${getFeedbackConfigOptions(params.feedbackOptions)}}),`
 ],${
   params.isPerformanceSelected
     ? `
-      // Performance Monitoring
+      // Tracing
       tracesSampleRate: 1.0, //  Capture 100% of the transactions
       // Set 'tracePropagationTargets' to control for which URLs distributed tracing should be enabled
       tracePropagationTargets: ["localhost", /^https:\\/\\/yourserver\\.io\\/api/],`
@@ -178,7 +178,7 @@ const onboarding: OnboardingConfig = {
   nextSteps: () => [
     {
       id: 'performance-monitoring',
-      name: t('Performance Monitoring'),
+      name: t('Tracing'),
       description: t(
         'Track down transactions to connect the dots between 10-second page loads and poor-performing API calls or slow database queries.'
       ),

--- a/static/app/gettingStartedDocs/javascript/javascript.tsx
+++ b/static/app/gettingStartedDocs/javascript/javascript.tsx
@@ -52,7 +52,7 @@ ${getFeedbackConfigOptions(params.feedbackOptions)}}),`
 ],${
   params.isPerformanceSelected
     ? `
-      // Performance Monitoring
+      // Tracing
       tracesSampleRate: 1.0, //  Capture 100% of the transactions
       // Set 'tracePropagationTargets' to control for which URLs distributed tracing should be enabled
       tracePropagationTargets: ["localhost", /^https:\\/\\/yourserver\\.io\\/api/],`
@@ -147,7 +147,7 @@ const onboarding: OnboardingConfig = {
   nextSteps: () => [
     {
       id: 'performance-monitoring',
-      name: t('Performance Monitoring'),
+      name: t('Tracing'),
       description: t(
         'Track down transactions to connect the dots between 10-second page loads and poor-performing API calls or slow database queries.'
       ),

--- a/static/app/gettingStartedDocs/javascript/react.tsx
+++ b/static/app/gettingStartedDocs/javascript/react.tsx
@@ -52,7 +52,7 @@ ${getFeedbackConfigOptions(params.feedbackOptions)}}),`
 ],${
   params.isPerformanceSelected
     ? `
-      // Performance Monitoring
+      // Tracing
       tracesSampleRate: 1.0, //  Capture 100% of the transactions
       // Set 'tracePropagationTargets' to control for which URLs distributed tracing should be enabled
       tracePropagationTargets: ["localhost", /^https:\\/\\/yourserver\\.io\\/api/],`
@@ -164,13 +164,13 @@ const onboarding: OnboardingConfig = {
       id: 'react-router',
       name: t('React Router'),
       description: t(
-        'Configure routing, so Sentry can generate parameterized transaction names for a better overview in Performance Monitoring.'
+        'Configure routing, so Sentry can generate parameterized transaction names for a better overview in Tracing.'
       ),
       link: 'https://docs.sentry.io/platforms/javascript/guides/react/configuration/integrations/react-router/',
     },
     {
       id: 'performance-monitoring',
-      name: t('Performance Monitoring'),
+      name: t('Tracing'),
       description: t(
         'Track down transactions to connect the dots between 10-second page loads and poor-performing API calls or slow database queries.'
       ),

--- a/static/app/gettingStartedDocs/javascript/remix.tsx
+++ b/static/app/gettingStartedDocs/javascript/remix.tsx
@@ -124,7 +124,7 @@ const onboarding: OnboardingConfig = {
   nextSteps: () => [
     {
       id: 'performance-monitoring',
-      name: t('Performance Monitoring'),
+      name: t('Tracing'),
       description: t(
         'Track down transactions to connect the dots between 10-second page loads and poor-performing API calls or slow database queries.'
       ),

--- a/static/app/gettingStartedDocs/javascript/solid.tsx
+++ b/static/app/gettingStartedDocs/javascript/solid.tsx
@@ -53,7 +53,7 @@ ${getFeedbackConfigOptions(params.feedbackOptions)}}),`
 ],${
   params.isPerformanceSelected
     ? `
-      // Performance Monitoring
+      // Tracing
       tracesSampleRate: 1.0, //  Capture 100% of the transactions
       // Set 'tracePropagationTargets' to control for which URLs distributed tracing should be enabled
       tracePropagationTargets: ["localhost", /^https:\\/\\/yourserver\\.io\\/api/],`
@@ -172,7 +172,7 @@ const onboarding: OnboardingConfig = {
     },
     {
       id: 'performance-monitoring',
-      name: t('Performance Monitoring'),
+      name: t('Tracing'),
       description: t(
         'Track down transactions to connect the dots between 10-second page loads and poor-performing API calls or slow database queries.'
       ),

--- a/static/app/gettingStartedDocs/javascript/svelte.tsx
+++ b/static/app/gettingStartedDocs/javascript/svelte.tsx
@@ -54,7 +54,7 @@ ${getFeedbackConfigOptions(params.feedbackOptions)}}),`
 ],${
   params.isPerformanceSelected
     ? `
-      // Performance Monitoring
+      // Tracing
       tracesSampleRate: 1.0, //  Capture 100% of the transactions
       // Set 'tracePropagationTargets' to control for which URLs distributed tracing should be enabled
       tracePropagationTargets: ["localhost", /^https:\\/\\/yourserver\\.io\\/api/],`
@@ -169,7 +169,7 @@ const onboarding: OnboardingConfig = {
     },
     {
       id: 'performance-monitoring',
-      name: t('Performance Monitoring'),
+      name: t('Tracing'),
       description: t(
         'Track down transactions to connect the dots between 10-second page loads and poor-performing API calls or slow database queries.'
       ),

--- a/static/app/gettingStartedDocs/javascript/vue.tsx
+++ b/static/app/gettingStartedDocs/javascript/vue.tsx
@@ -68,7 +68,7 @@ const getSentryInitLayout = (params: Params, siblingOption: string): string => {
   ],${
     params.isPerformanceSelected
       ? `
-        // Performance Monitoring
+        // Tracing
         tracesSampleRate: 1.0, //  Capture 100% of the transactions
         // Set 'tracePropagationTargets' to control for which URLs distributed tracing should be enabled
         tracePropagationTargets: ["localhost", /^https:\\/\\/yourserver\\.io\\/api/],`
@@ -185,7 +185,7 @@ export const nextSteps = [
   },
   {
     id: 'performance-monitoring',
-    name: t('Performance Monitoring'),
+    name: t('Tracing'),
     description: t(
       'Track down transactions to connect the dots between 10-second page loads and poor-performing API calls or slow database queries.'
     ),

--- a/static/app/gettingStartedDocs/kotlin/kotlin.tsx
+++ b/static/app/gettingStartedDocs/kotlin/kotlin.tsx
@@ -117,7 +117,7 @@ Sentry.init { options ->
   options.dsn = "${params.dsn}"${
     params.isPerformanceSelected
       ? `
-  // Set tracesSampleRate to 1.0 to capture 100% of transactions for performance monitoring.
+  // Set tracesSampleRate to 1.0 to capture 100% of transactions for tracing.
   // We recommend adjusting this value in production.
   options.tracesSampleRate = 1.0`
       : ''
@@ -266,7 +266,7 @@ const onboarding: OnboardingConfig<PlatformOptions> = {
     },
     {
       id: 'performance-monitoring',
-      name: t('Performance Monitoring'),
+      name: t('Tracing'),
       description: t(
         'Stay ahead of latency issues and trace every slow transaction to a poor-performing API call or database query.'
       ),

--- a/static/app/gettingStartedDocs/php/laravel.spec.tsx
+++ b/static/app/gettingStartedDocs/php/laravel.spec.tsx
@@ -19,7 +19,7 @@ describe('laravel onboarding docs', function () {
     ).toBeInTheDocument();
   });
 
-  it('renders without performance monitoring', function () {
+  it('renders without "tracing"', function () {
     renderWithOnboardingLayout(docs, {
       selectedProducts: [],
     });

--- a/static/app/gettingStartedDocs/php/php.spec.tsx
+++ b/static/app/gettingStartedDocs/php/php.spec.tsx
@@ -19,7 +19,7 @@ describe('php onboarding docs', function () {
     ).toBeInTheDocument();
   });
 
-  it('renders without performance monitoring', function () {
+  it('renders without "tracing"', function () {
     renderWithOnboardingLayout(docs, {
       selectedProducts: [],
     });

--- a/static/app/gettingStartedDocs/php/symfony.spec.tsx
+++ b/static/app/gettingStartedDocs/php/symfony.spec.tsx
@@ -19,7 +19,7 @@ describe('symfony onboarding docs', function () {
     ).toBeInTheDocument();
   });
 
-  it('renders without performance monitoring', function () {
+  it('renders without "tracing"', function () {
     renderWithOnboardingLayout(docs, {
       selectedProducts: [],
     });

--- a/static/app/gettingStartedDocs/powershell/powershell.spec.tsx
+++ b/static/app/gettingStartedDocs/powershell/powershell.spec.tsx
@@ -18,9 +18,7 @@ describe('powershell onboarding docs', function () {
     expect(screen.getByRole('heading', {name: 'Install'})).toBeInTheDocument();
     expect(screen.getByRole('heading', {name: 'Configure SDK'})).toBeInTheDocument();
     expect(screen.getByRole('heading', {name: 'Verify'})).toBeInTheDocument();
-    expect(
-      screen.getByRole('heading', {name: 'Performance Monitoring'})
-    ).toBeInTheDocument();
+    expect(screen.getByRole('heading', {name: 'Tracing'})).toBeInTheDocument();
     expect(screen.getByRole('heading', {name: 'Samples'})).toBeInTheDocument();
 
     // Renders SDK version from registry

--- a/static/app/gettingStartedDocs/powershell/powershell.tsx
+++ b/static/app/gettingStartedDocs/powershell/powershell.tsx
@@ -108,7 +108,7 @@ const onboarding: OnboardingConfig = {
       ],
     },
     {
-      title: t('Performance Monitoring'),
+      title: t('Tracing'),
       description: t(
         'You can measure the performance of your code by capturing transactions and spans.'
       ),

--- a/static/app/gettingStartedDocs/python/aiohttp.spec.tsx
+++ b/static/app/gettingStartedDocs/python/aiohttp.spec.tsx
@@ -19,7 +19,7 @@ describe('aiohttp onboarding docs', function () {
     ).toBeInTheDocument();
   });
 
-  it('renders without performance monitoring', function () {
+  it('renders without "tracing"', function () {
     renderWithOnboardingLayout(docs, {
       selectedProducts: [],
     });

--- a/static/app/gettingStartedDocs/python/aiohttp.tsx
+++ b/static/app/gettingStartedDocs/python/aiohttp.tsx
@@ -24,7 +24,7 @@ sentry_sdk.init(
       params.isPerformanceSelected
         ? `
     # Set traces_sample_rate to 1.0 to capture 100%
-    # of transactions for performance monitoring.
+    # of transactions for tracing.
     traces_sample_rate=1.0,`
         : ''
     }${

--- a/static/app/gettingStartedDocs/python/asgi.spec.tsx
+++ b/static/app/gettingStartedDocs/python/asgi.spec.tsx
@@ -19,7 +19,7 @@ describe('asgi onboarding docs', function () {
     ).toBeInTheDocument();
   });
 
-  it('renders without performance monitoring', function () {
+  it('renders without "tracing"', function () {
     renderWithOnboardingLayout(docs, {
       selectedProducts: [],
     });

--- a/static/app/gettingStartedDocs/python/asgi.tsx
+++ b/static/app/gettingStartedDocs/python/asgi.tsx
@@ -24,7 +24,7 @@ sentry_sdk.init(
       params.isPerformanceSelected
         ? `
     # Set traces_sample_rate to 1.0 to capture 100%
-    # of transactions for performance monitoring.
+    # of transactions for tracing.
     traces_sample_rate=1.0,`
         : ''
     }${

--- a/static/app/gettingStartedDocs/python/awslambda.spec.tsx
+++ b/static/app/gettingStartedDocs/python/awslambda.spec.tsx
@@ -19,7 +19,7 @@ describe('awslambda onboarding docs', function () {
     ).toBeInTheDocument();
   });
 
-  it('renders without performance monitoring', function () {
+  it('renders without "tracing"', function () {
     renderWithOnboardingLayout(docs, {
       selectedProducts: [],
     });

--- a/static/app/gettingStartedDocs/python/awslambda.tsx
+++ b/static/app/gettingStartedDocs/python/awslambda.tsx
@@ -27,7 +27,7 @@ sentry_sdk.init(
       params.isPerformanceSelected
         ? `
     # Set traces_sample_rate to 1.0 to capture 100%
-    # of transactions for performance monitoring.
+    # of transactions for tracing.
     traces_sample_rate=1.0,`
         : ''
     }${

--- a/static/app/gettingStartedDocs/python/bottle.spec.tsx
+++ b/static/app/gettingStartedDocs/python/bottle.spec.tsx
@@ -21,7 +21,7 @@ describe('bottle onboarding docs', function () {
     ).toBeInTheDocument();
   });
 
-  it('renders without performance monitoring', function () {
+  it('renders without "tracing"', function () {
     renderWithOnboardingLayout(docs, {
       selectedProducts: [],
     });

--- a/static/app/gettingStartedDocs/python/bottle.tsx
+++ b/static/app/gettingStartedDocs/python/bottle.tsx
@@ -22,7 +22,7 @@ sentry_sdk.init(
       params.isPerformanceSelected
         ? `
     # Set traces_sample_rate to 1.0 to capture 100%
-    # of transactions for performance monitoring.
+    # of transactions for tracing.
     traces_sample_rate=1.0,`
         : ''
     }${

--- a/static/app/gettingStartedDocs/python/celery.spec.tsx
+++ b/static/app/gettingStartedDocs/python/celery.spec.tsx
@@ -23,7 +23,7 @@ describe('celery onboarding docs', function () {
     ).toBeInTheDocument();
   });
 
-  it('renders without performance monitoring', function () {
+  it('renders without "tracing"', function () {
     renderWithOnboardingLayout(docs, {
       selectedProducts: [],
     });

--- a/static/app/gettingStartedDocs/python/celery.tsx
+++ b/static/app/gettingStartedDocs/python/celery.tsx
@@ -27,7 +27,7 @@ sentry_sdk.init(
       params.isPerformanceSelected
         ? `
     # Set traces_sample_rate to 1.0 to capture 100%
-    # of transactions for performance monitoring.
+    # of transactions for tracing.
     traces_sample_rate=1.0,`
         : ''
     }${

--- a/static/app/gettingStartedDocs/python/chalice.spec.tsx
+++ b/static/app/gettingStartedDocs/python/chalice.spec.tsx
@@ -21,7 +21,7 @@ describe('chalice onboarding docs', function () {
     ).toBeInTheDocument();
   });
 
-  it('renders without performance monitoring', function () {
+  it('renders without "tracing"', function () {
     renderWithOnboardingLayout(docs, {
       selectedProducts: [],
     });

--- a/static/app/gettingStartedDocs/python/chalice.tsx
+++ b/static/app/gettingStartedDocs/python/chalice.tsx
@@ -24,7 +24,7 @@ sentry_sdk.init(
       params.isPerformanceSelected
         ? `
     # Set traces_sample_rate to 1.0 to capture 100%
-    # of transactions for performance monitoring.
+    # of transactions for tracing.
     traces_sample_rate=1.0,`
         : ''
     }${

--- a/static/app/gettingStartedDocs/python/django.spec.tsx
+++ b/static/app/gettingStartedDocs/python/django.spec.tsx
@@ -21,7 +21,7 @@ describe('django onboarding docs', function () {
     ).toBeInTheDocument();
   });
 
-  it('renders without performance monitoring', function () {
+  it('renders without "tracing"', function () {
     renderWithOnboardingLayout(docs, {
       selectedProducts: [],
     });

--- a/static/app/gettingStartedDocs/python/django.tsx
+++ b/static/app/gettingStartedDocs/python/django.tsx
@@ -23,7 +23,7 @@ sentry_sdk.init(
       params.isPerformanceSelected
         ? `
     # Set traces_sample_rate to 1.0 to capture 100%
-    # of transactions for performance monitoring.
+    # of transactions for tracing.
     traces_sample_rate=1.0,`
         : ''
     }${

--- a/static/app/gettingStartedDocs/python/falcon.spec.tsx
+++ b/static/app/gettingStartedDocs/python/falcon.spec.tsx
@@ -21,7 +21,7 @@ describe('falcon onboarding docs', function () {
     ).toBeInTheDocument();
   });
 
-  it('renders without performance monitoring', function () {
+  it('renders without "tracing"', function () {
     renderWithOnboardingLayout(docs, {
       selectedProducts: [],
     });

--- a/static/app/gettingStartedDocs/python/falcon.tsx
+++ b/static/app/gettingStartedDocs/python/falcon.tsx
@@ -23,7 +23,7 @@ sentry_sdk.init(
       params.isPerformanceSelected
         ? `
     # Set traces_sample_rate to 1.0 to capture 100%
-    # of transactions for performance monitoring.
+    # of transactions for tracing.
     traces_sample_rate=1.0,`
         : ''
     }${

--- a/static/app/gettingStartedDocs/python/fastapi.spec.tsx
+++ b/static/app/gettingStartedDocs/python/fastapi.spec.tsx
@@ -21,7 +21,7 @@ describe('flask onboarding docs', function () {
     ).toBeInTheDocument();
   });
 
-  it('renders without performance monitoring', function () {
+  it('renders without "tracing"', function () {
     renderWithOnboardingLayout(docs, {
       selectedProducts: [],
     });

--- a/static/app/gettingStartedDocs/python/fastapi.tsx
+++ b/static/app/gettingStartedDocs/python/fastapi.tsx
@@ -23,7 +23,7 @@ sentry_sdk.init(
       params.isPerformanceSelected
         ? `
     # Set traces_sample_rate to 1.0 to capture 100%
-    # of transactions for performance monitoring.
+    # of transactions for tracing.
     traces_sample_rate=1.0,`
         : ''
     }${

--- a/static/app/gettingStartedDocs/python/flask.spec.tsx
+++ b/static/app/gettingStartedDocs/python/flask.spec.tsx
@@ -21,7 +21,7 @@ describe('flask onboarding docs', function () {
     ).toBeInTheDocument();
   });
 
-  it('renders without performance monitoring', function () {
+  it('renders without "tracing"', function () {
     renderWithOnboardingLayout(docs, {
       selectedProducts: [],
     });

--- a/static/app/gettingStartedDocs/python/flask.tsx
+++ b/static/app/gettingStartedDocs/python/flask.tsx
@@ -23,7 +23,7 @@ sentry_sdk.init(
       params.isPerformanceSelected
         ? `
     # Set traces_sample_rate to 1.0 to capture 100%
-    # of transactions for performance monitoring.
+    # of transactions for tracing.
     traces_sample_rate=1.0,`
         : ''
     }${

--- a/static/app/gettingStartedDocs/python/gcpfunctions.spec.tsx
+++ b/static/app/gettingStartedDocs/python/gcpfunctions.spec.tsx
@@ -19,7 +19,7 @@ describe('gcpfunctions onboarding docs', function () {
     ).toBeInTheDocument();
   });
 
-  it('renders without performance monitoring', function () {
+  it('renders without "tracing"', function () {
     renderWithOnboardingLayout(docs, {
       selectedProducts: [],
     });

--- a/static/app/gettingStartedDocs/python/gcpfunctions.tsx
+++ b/static/app/gettingStartedDocs/python/gcpfunctions.tsx
@@ -27,7 +27,7 @@ sentry_sdk.init(
       params.isPerformanceSelected
         ? `
     # Set traces_sample_rate to 1.0 to capture 100%
-    # of transactions for performance monitoring.
+    # of transactions for tracing.
     traces_sample_rate=1.0,`
         : ''
     }${

--- a/static/app/gettingStartedDocs/python/mongo.tsx
+++ b/static/app/gettingStartedDocs/python/mongo.tsx
@@ -23,7 +23,7 @@ sentry_sdk.init(
     ],
 
     # Set traces_sample_rate to 1.0 to capture 100%
-    # of transactions for performance monitoring.
+    # of transactions for tracing.
     # We recommend adjusting this value in production,
     traces_sample_rate=1.0,
 )`;

--- a/static/app/gettingStartedDocs/python/pyramid.spec.tsx
+++ b/static/app/gettingStartedDocs/python/pyramid.spec.tsx
@@ -19,7 +19,7 @@ describe('aiohttp onboarding docs', function () {
     ).toBeInTheDocument();
   });
 
-  it('renders without performance monitoring', function () {
+  it('renders without "tracing"', function () {
     renderWithOnboardingLayout(docs, {
       selectedProducts: [],
     });

--- a/static/app/gettingStartedDocs/python/python.spec.tsx
+++ b/static/app/gettingStartedDocs/python/python.spec.tsx
@@ -19,7 +19,7 @@ describe('python onboarding docs', function () {
     ).toBeInTheDocument();
   });
 
-  it('renders without performance monitoring', function () {
+  it('renders without "tracing"', function () {
     renderWithOnboardingLayout(docs, {
       selectedProducts: [],
     });

--- a/static/app/gettingStartedDocs/python/python.tsx
+++ b/static/app/gettingStartedDocs/python/python.tsx
@@ -24,7 +24,7 @@ sentry_sdk.init(
       params.isPerformanceSelected
         ? `
     # Set traces_sample_rate to 1.0 to capture 100%
-    # of transactions for performance monitoring.
+    # of transactions for tracing.
     traces_sample_rate=1.0,`
         : ''
     }${

--- a/static/app/gettingStartedDocs/python/quart.spec.tsx
+++ b/static/app/gettingStartedDocs/python/quart.spec.tsx
@@ -21,7 +21,7 @@ describe('quart onboarding docs', function () {
     ).toBeInTheDocument();
   });
 
-  it('renders without performance monitoring', function () {
+  it('renders without "tracing"', function () {
     renderWithOnboardingLayout(docs, {
       selectedProducts: [],
     });

--- a/static/app/gettingStartedDocs/python/quart.tsx
+++ b/static/app/gettingStartedDocs/python/quart.tsx
@@ -25,7 +25,7 @@ sentry_sdk.init(
       params.isPerformanceSelected
         ? `
     # Set traces_sample_rate to 1.0 to capture 100%
-    # of transactions for performance monitoring.
+    # of transactions for tracing.
     traces_sample_rate=1.0,`
         : ''
     }${

--- a/static/app/gettingStartedDocs/python/rq.spec.tsx
+++ b/static/app/gettingStartedDocs/python/rq.spec.tsx
@@ -24,7 +24,7 @@ describe('rq onboarding docs', function () {
     ).toBeInTheDocument();
   });
 
-  it('renders without performance monitoring', function () {
+  it('renders without "tracing"', function () {
     renderWithOnboardingLayout(docs, {
       selectedProducts: [],
     });

--- a/static/app/gettingStartedDocs/python/rq.tsx
+++ b/static/app/gettingStartedDocs/python/rq.tsx
@@ -21,7 +21,7 @@ sentry_sdk.init(
     params.isPerformanceSelected
       ? `
   # Set traces_sample_rate to 1.0 to capture 100%
-  # of transactions for performance monitoring.
+  # of transactions for tracing.
   traces_sample_rate=1.0,`
       : ''
   }${

--- a/static/app/gettingStartedDocs/python/serverless.spec.tsx
+++ b/static/app/gettingStartedDocs/python/serverless.spec.tsx
@@ -19,7 +19,7 @@ describe('serverless onboarding docs', function () {
     ).toBeInTheDocument();
   });
 
-  it('renders without performance monitoring', function () {
+  it('renders without "tracing"', function () {
     renderWithOnboardingLayout(docs, {
       selectedProducts: [],
     });

--- a/static/app/gettingStartedDocs/python/serverless.tsx
+++ b/static/app/gettingStartedDocs/python/serverless.tsx
@@ -24,7 +24,7 @@ sentry_sdk.init(
       params.isPerformanceSelected
         ? `
     # Set traces_sample_rate to 1.0 to capture 100%
-    # of transactions for performance monitoring.
+    # of transactions for tracing.
     traces_sample_rate=1.0,`
         : ''
     }${

--- a/static/app/gettingStartedDocs/python/starlette.spec.tsx
+++ b/static/app/gettingStartedDocs/python/starlette.spec.tsx
@@ -21,7 +21,7 @@ describe('starlette onboarding docs', function () {
     ).toBeInTheDocument();
   });
 
-  it('renders without performance monitoring', function () {
+  it('renders without "tracing"', function () {
     renderWithOnboardingLayout(docs, {
       selectedProducts: [],
     });

--- a/static/app/gettingStartedDocs/python/starlette.tsx
+++ b/static/app/gettingStartedDocs/python/starlette.tsx
@@ -23,7 +23,7 @@ sentry_sdk.init(
       params.isPerformanceSelected
         ? `
     # Set traces_sample_rate to 1.0 to capture 100%
-    # of transactions for performance monitoring.
+    # of transactions for tracing.
     traces_sample_rate=1.0,`
         : ''
     }${

--- a/static/app/gettingStartedDocs/python/tornado.spec.tsx
+++ b/static/app/gettingStartedDocs/python/tornado.spec.tsx
@@ -19,7 +19,7 @@ describe('tornado onboarding docs', function () {
     ).toBeInTheDocument();
   });
 
-  it('renders without performance monitoring', function () {
+  it('renders without "tracing"', function () {
     renderWithOnboardingLayout(docs, {
       selectedProducts: [],
     });

--- a/static/app/gettingStartedDocs/python/tornado.tsx
+++ b/static/app/gettingStartedDocs/python/tornado.tsx
@@ -21,7 +21,7 @@ sentry_sdk.init(
       params.isPerformanceSelected
         ? `
     # Set traces_sample_rate to 1.0 to capture 100%
-    # of transactions for performance monitoring.
+    # of transactions for tracing.
     traces_sample_rate=1.0,`
         : ''
     }${

--- a/static/app/gettingStartedDocs/python/tryton.spec.tsx
+++ b/static/app/gettingStartedDocs/python/tryton.spec.tsx
@@ -12,7 +12,7 @@ describe('django onboarding docs', function () {
     expect(screen.getByRole('heading', {name: 'Configure SDK'})).toBeInTheDocument();
   });
 
-  it('renders without performance monitoring', function () {
+  it('renders without "tracing"', function () {
     renderWithOnboardingLayout(docs, {
       selectedProducts: [],
     });

--- a/static/app/gettingStartedDocs/python/tryton.tsx
+++ b/static/app/gettingStartedDocs/python/tryton.tsx
@@ -23,7 +23,7 @@ sentry_sdk.init(
       params.isPerformanceSelected
         ? `
     # Set traces_sample_rate to 1.0 to capture 100%
-    # of transactions for performance monitoring.
+    # of transactions for tracing.
     traces_sample_rate=1.0,`
         : ''
     }${

--- a/static/app/gettingStartedDocs/python/wsgi.spec.tsx
+++ b/static/app/gettingStartedDocs/python/wsgi.spec.tsx
@@ -19,7 +19,7 @@ describe('wsgi onboarding docs', function () {
     ).toBeInTheDocument();
   });
 
-  it('renders without performance monitoring', function () {
+  it('renders without "tracing"', function () {
     renderWithOnboardingLayout(docs, {
       selectedProducts: [],
     });

--- a/static/app/gettingStartedDocs/python/wsgi.tsx
+++ b/static/app/gettingStartedDocs/python/wsgi.tsx
@@ -26,7 +26,7 @@ sentry_sdk.init(
       params.isPerformanceSelected
         ? `
     # Set traces_sample_rate to 1.0 to capture 100%
-    # of transactions for performance monitoring.
+    # of transactions for tracing.
     traces_sample_rate=1.0,`
         : ''
     }${

--- a/static/app/gettingStartedDocs/react-native/react-native.tsx
+++ b/static/app/gettingStartedDocs/react-native/react-native.tsx
@@ -25,7 +25,7 @@ Sentry.init({
   dsn: "${params.dsn}",${
     params.isPerformanceSelected
       ? `
-  // Set tracesSampleRate to 1.0 to capture 100% of transactions for performance monitoring.
+  // Set tracesSampleRate to 1.0 to capture 100% of transactions for tracing.
   // We recommend adjusting this value in production.
   tracesSampleRate: 1.0,`
       : ''
@@ -149,7 +149,7 @@ const onboarding: OnboardingConfig = {
         {
           language: 'javascript',
           description: tct(
-            'Wrap your app with Sentry to automatically instrument it with [touchEventTrakingLink:touch event tracking] and [automaticPerformanceMonitoringLink:automatic performance monitoring]:',
+            'Wrap your app with Sentry to automatically instrument it with [touchEventTrakingLink:touch event tracking] and [automaticPerformanceMonitoringLink:automatic tracing]:',
             {
               touchEventTrakingLink: (
                 <ExternalLink href="https://docs.sentry.io/platforms/react-native/touchevents/" />

--- a/static/app/gettingStartedDocs/ruby/rack.tsx
+++ b/static/app/gettingStartedDocs/ruby/rack.tsx
@@ -23,7 +23,7 @@ Sentry.init do |config|
       ? `
 
   # Set traces_sample_rate to 1.0 to capture 100%
-  # of transactions for performance monitoring.
+  # of transactions for tracing.
   # We recommend adjusting this value in production.
   config.traces_sample_rate = 1.0
   # or

--- a/static/app/gettingStartedDocs/ruby/rails.tsx
+++ b/static/app/gettingStartedDocs/ruby/rails.tsx
@@ -29,7 +29,7 @@ Sentry.init do |config|
       ? `
 
   # Set traces_sample_rate to 1.0 to capture 100%
-  # of transactions for performance monitoring.
+  # of transactions for tracing.
   # We recommend adjusting this value in production.
   config.traces_sample_rate = 1.0
   # or

--- a/static/app/gettingStartedDocs/ruby/ruby.tsx
+++ b/static/app/gettingStartedDocs/ruby/ruby.tsx
@@ -21,7 +21,7 @@ Sentry.init do |config|
       ? `
 
   # Set traces_sample_rate to 1.0 to capture 100%
-  # of transactions for performance monitoring.
+  # of transactions for tracing.
   # We recommend adjusting this value in production.
   config.traces_sample_rate = 1.0
   # or

--- a/static/app/utils/gettingStartedDocs/node.ts
+++ b/static/app/utils/gettingStartedDocs/node.ts
@@ -190,7 +190,7 @@ Sentry.init({
   }${
     params.isPerformanceSelected
       ? `
-      // Performance Monitoring
+      // Tracing
       tracesSampleRate: 1.0, //  Capture 100% of the transactions\n`
       : ''
   }${
@@ -225,7 +225,7 @@ export function getProductInitParams({
 }) {
   const params: string[] = [];
   if (productSelection['performance-monitoring']) {
-    params.push(`// Performance Monitoring`);
+    params.push(`// Tracing`);
     params.push(`tracesSampleRate: 1.0,`);
   }
 

--- a/static/app/views/insights/database/components/noDataMessage.tsx
+++ b/static/app/views/insights/database/components/noDataMessage.tsx
@@ -56,7 +56,7 @@ export function NoDataMessage({Wrapper = DivWrapper, isDataAvailable}: Props) {
     <Wrapper>
       {!isDataAvailable &&
         tct(
-          'No queries found. Try updating your filters, or learn more about performance monitoring for queries in our [documentation:documentation].',
+          'No queries found. Try updating your filters, or learn more about tracing for queries in our [documentation:documentation].',
           {
             documentation: <ExternalLink href={MODULE_DOC_LINK} />,
           }

--- a/static/app/views/metrics/layout.tsx
+++ b/static/app/views/metrics/layout.tsx
@@ -231,7 +231,7 @@ export const MetricsLayout = memo(() => {
                 <Fragment>
                   <p>
                     {t(
-                      'Create custom metrics to track and visualize the data points you care about over time, like processing time, checkout conversion rate, or user signups. See correlated trace exemplars and metrics if used together with Performance Monitoring.'
+                      'Create custom metrics to track and visualize the data points you care about over time, like processing time, checkout conversion rate, or user signups. See correlated trace exemplars and metrics if used together with Tracing.'
                     )}
                   </p>
                   <ButtonList gap={1}>

--- a/static/app/views/onboarding/components/integrations/addInstallationInstructions.tsx
+++ b/static/app/views/onboarding/components/integrations/addInstallationInstructions.tsx
@@ -9,7 +9,7 @@ export default function AddInstallationInstructions() {
     <Fragment>
       <p>
         {tct(
-          'The automated AWS Lambda setup will instrument your Lambda functions with Sentry error and performance monitoring without any code changes. We use CloudFormation Stack ([learnMore]) to create the Sentry role which gives us access to your AWS account.',
+          'The automated AWS Lambda setup will instrument your Lambda functions with Sentry error and tracing without any code changes. We use CloudFormation Stack ([learnMore]) to create the Sentry role which gives us access to your AWS account.',
           {
             learnMore: (
               <ExternalLink href="https://aws.amazon.com/cloudformation/">

--- a/static/app/views/onboarding/setupDocs.spec.tsx
+++ b/static/app/views/onboarding/setupDocs.spec.tsx
@@ -202,7 +202,7 @@ describe('Onboarding Setup Docs', function () {
       ).toBeInTheDocument();
 
       const codeBlock = await screen.findByText(/import \* as Sentry/);
-      expect(codeBlock).toHaveTextContent(/Performance Monitoring/);
+      expect(codeBlock).toHaveTextContent(/Tracing/);
       expect(codeBlock).toHaveTextContent(/Session Replay/);
     });
 
@@ -252,7 +252,7 @@ describe('Onboarding Setup Docs', function () {
       );
 
       const codeBlock = await screen.findByText(/import \* as Sentry/);
-      expect(codeBlock).toHaveTextContent(/Performance Monitoring/);
+      expect(codeBlock).toHaveTextContent(/Tracing/);
       expect(codeBlock).not.toHaveTextContent(/Session Replay/);
     });
 
@@ -303,7 +303,7 @@ describe('Onboarding Setup Docs', function () {
 
       const codeBlock = await screen.findByText(/import \* as Sentry/);
       expect(codeBlock).toHaveTextContent(/Session Replay/);
-      expect(codeBlock).not.toHaveTextContent(/Performance Monitoring/);
+      expect(codeBlock).not.toHaveTextContent(/Tracing/);
     });
 
     it('only error monitoring checked', async function () {
@@ -354,7 +354,7 @@ describe('Onboarding Setup Docs', function () {
       await waitForElementToBeRemoved(() => screen.queryByTestId('loading-indicator'));
 
       const codeBlock = await screen.findByText(/import \* as Sentry/);
-      expect(codeBlock).not.toHaveTextContent(/Performance Monitoring/);
+      expect(codeBlock).not.toHaveTextContent(/Tracing/);
       expect(codeBlock).not.toHaveTextContent(/Session Replay/);
     });
   });

--- a/static/app/views/onboarding/setupDocsLoader.tsx
+++ b/static/app/views/onboarding/setupDocsLoader.tsx
@@ -210,7 +210,7 @@ Sentry.onLoad(function() {
   }${
     hasPerformance
       ? `
-    // Performance Monitoring
+    // Tracing
     tracesSampleRate: 1.0, // Capture 100% of the transactions`
       : ''
   }${
@@ -316,7 +316,7 @@ Sentry.onLoad(function() {
           {!products.includes(ProductSolution.PERFORMANCE_MONITORING) && (
             <li>
               <ExternalLink href="https://docs.sentry.io/platforms/javascript/tracing/">
-                {t('Performance Monitoring')}
+                {t('Tracing')}
               </ExternalLink>
               {': '}
               {t(

--- a/static/app/views/performance/landing/widgets/components/selectableList.tsx
+++ b/static/app/views/performance/landing/widgets/components/selectableList.tsx
@@ -174,11 +174,7 @@ export function WidgetAddInstrumentationWarning({type}: {type: 'db' | 'http'}) {
           'No transactions with [spanCategory] spans found. You may need to add integrations to your [link] to capture these spans.',
           {
             spanCategory: type === 'db' ? t('Database') : HTTP_MODULE_TITLE,
-            link: (
-              <ExternalLink href={docsLink}>
-                {t('performance monitoring setup')}
-              </ExternalLink>
-            ),
+            link: <ExternalLink href={docsLink}>{t('tracing setup')}</ExternalLink>,
           }
         )}
       </SecondaryMessage>

--- a/static/app/views/performance/newTraceDetails/traceWarnings/performanceSetupWarning.tsx
+++ b/static/app/views/performance/newTraceDetails/traceWarnings/performanceSetupWarning.tsx
@@ -92,7 +92,7 @@ export function PerformanceSetupWarning({
     return (
       <Alert type="info" showIcon>
         {tct(
-          "Some of the projects associated with this trace don't support performance monitoring. To learn more about how to setup performance monitoring, visit our [documentation].",
+          "Some of the projects associated with this trace don't support tracing. To learn more about how to setup tracing, visit our [documentation].",
           {
             documentationLink: (
               <ExternalLink href="https://docs.sentry.io/product/performance/getting-started/">
@@ -115,7 +115,7 @@ export function PerformanceSetupWarning({
         <BannerTitle>{t('Your setup is incomplete')}</BannerTitle>
         <BannerDescription>
           {t(
-            "Want to know why this string of errors happened? Configure performance monitoring to get a full picture of what's going on."
+            "Want to know why this string of errors happened? Configure tracing to get a full picture of what's going on."
           )}
         </BannerDescription>
         <ButtonsWrapper>

--- a/static/app/views/performance/traceDetails/content.tsx
+++ b/static/app/views/performance/traceDetails/content.tsx
@@ -475,7 +475,7 @@ function OnlyOrphanErrorWarnings({orphanErrors}: OnlyOrphanErrorWarningsProps) {
         <BannerTitle>{t('Connect the Dots')}</BannerTitle>
         <BannerDescription>
           {t(
-            "If you haven't already, configure performance monitoring to learn more about how your services are interacting with each other. This will provide more clarity about how your errors are linked."
+            "If you haven't already, configure tracing to learn more about how your services are interacting with each other. This will provide more clarity about how your errors are linked."
           )}
         </BannerDescription>
         <ButtonsWrapper>

--- a/static/app/views/performance/traceDetails/newTraceDetailsContent.tsx
+++ b/static/app/views/performance/traceDetails/newTraceDetailsContent.tsx
@@ -290,7 +290,7 @@ function NewTraceDetailsContent(props: Props) {
         warning = (
           <Alert type="info" showIcon>
             {tct(
-              "The good news is we know these errors are related to each other. The bad news is that we can't tell you more than that. If you haven't already, [tracingLink: configure performance monitoring for your SDKs] to learn more about service interactions.",
+              "The good news is we know these errors are related to each other. The bad news is that we can't tell you more than that. If you haven't already, [tracingLink: configure tracing for your SDKs] to learn more about service interactions.",
               {
                 tracingLink: (
                   <ExternalLink href="https://docs.sentry.io/product/performance/getting-started/" />

--- a/static/app/views/performance/transactionDetails/quickTraceMeta.spec.tsx
+++ b/static/app/views/performance/transactionDetails/quickTraceMeta.spec.tsx
@@ -180,9 +180,7 @@ describe('QuickTraceMeta', function () {
       throw new Error('child is null');
     }
     await userEvent.hover(child as HTMLElement);
-    expect(
-      await screen.findByText('Requires performance monitoring.')
-    ).toBeInTheDocument();
+    expect(await screen.findByText('Requires tracing.')).toBeInTheDocument();
   });
 
   it('does not render when platform does not support tracing', function () {

--- a/static/app/views/performance/transactionDetails/quickTraceMeta.tsx
+++ b/static/app/views/performance/transactionDetails/quickTraceMeta.tsx
@@ -43,7 +43,7 @@ export default function QuickTraceMeta({
   const organization = useOrganization();
   const features = ['performance-view'];
 
-  const noFeatureMessage = t('Requires performance monitoring.');
+  const noFeatureMessage = t('Requires tracing.');
 
   const docsLink = getConfigurePerformanceDocsLink(project);
 

--- a/static/app/views/projectsDashboard/projectCard.tsx
+++ b/static/app/views/projectsDashboard/projectCard.tsx
@@ -165,9 +165,7 @@ class ProjectCard extends Component<Props> {
                         )}
                         {zeroTransactions && (
                           <QuestionTooltip
-                            title={t(
-                              'Click here to learn more about performance monitoring'
-                            )}
+                            title={t('Click here to learn more about tracing')}
                             position="top"
                             size="xs"
                           />

--- a/static/app/views/replays/detail/trace/index.tsx
+++ b/static/app/views/replays/detail/trace/index.tsx
@@ -11,10 +11,10 @@ const features = ['organizations:performance-view'];
 function PerfDisabled() {
   return (
     <FeatureDisabled
-      featureName={t('Performance Monitoring')}
+      featureName={t('Tracing')}
       features={features}
       hideHelpToggle
-      message={t('Requires performance monitoring.')}
+      message={t('Requires tracing.')}
     />
   );
 }

--- a/static/app/views/replays/detail/trace/trace.tsx
+++ b/static/app/views/replays/detail/trace/trace.tsx
@@ -35,7 +35,7 @@ import type {ReplayRecord} from 'sentry/views/replays/types';
 import {useReplayTraces} from './useReplayTraces';
 
 function TracesNotFound({performanceActive}: {performanceActive: boolean}) {
-  // We want to send the 'trace_status' data if the project actively uses and has access to the performance monitoring.
+  // We want to send the 'trace_status' data if the project actively uses and has access to the tracing.
   useRouteAnalyticsParams(performanceActive ? {trace_status: 'trace missing'} : {});
 
   return (
@@ -62,7 +62,7 @@ function TraceFound({
 }) {
   const location = useLocation();
 
-  // We want to send the 'trace_status' data if the project actively uses and has access to the performance monitoring.
+  // We want to send the 'trace_status' data if the project actively uses and has access to the tracing.
   useRouteAnalyticsParams(performanceActive ? {trace_status: 'success'} : {});
 
   return (

--- a/static/app/views/settings/project/loaderScript.spec.tsx
+++ b/static/app/views/settings/project/loaderScript.spec.tsx
@@ -171,12 +171,12 @@ describe('LoaderScript', function () {
 
     await waitForElementToBeRemoved(() => screen.queryByTestId('loading-indicator'));
 
-    expect(screen.getByText(t('Enable Performance Monitoring'))).toBeInTheDocument();
+    expect(screen.getByText(t('Enable Tracing'))).toBeInTheDocument();
     expect(screen.getByText(t('Enable Session Replay'))).toBeInTheDocument();
     expect(screen.getByText(t('Enable Debug Bundles & Logging'))).toBeInTheDocument();
 
     let performanceCheckbox = screen.getByRole('checkbox', {
-      name: t('Enable Performance Monitoring'),
+      name: t('Enable Tracing'),
     });
     expect(performanceCheckbox).toBeEnabled();
     expect(performanceCheckbox).not.toBeChecked();
@@ -196,12 +196,12 @@ describe('LoaderScript', function () {
     // Toggle performance option
     await userEvent.click(
       screen.getByRole('checkbox', {
-        name: t('Enable Performance Monitoring'),
+        name: t('Enable Tracing'),
       })
     );
 
     performanceCheckbox = await screen.findByRole('checkbox', {
-      name: t('Enable Performance Monitoring'),
+      name: t('Enable Tracing'),
       checked: true,
     });
     expect(performanceCheckbox).toBeEnabled();
@@ -284,7 +284,7 @@ describe('LoaderScript', function () {
 
     expect(
       screen.getAllByRole('checkbox', {
-        name: t('Enable Performance Monitoring'),
+        name: t('Enable Tracing'),
         checked: false,
       })
     ).toHaveLength(2);
@@ -304,20 +304,20 @@ describe('LoaderScript', function () {
     // Toggle performance option
     await userEvent.click(
       screen.getAllByRole('checkbox', {
-        name: t('Enable Performance Monitoring'),
+        name: t('Enable Tracing'),
       })[1]
     );
 
     expect(
       await screen.findByRole('checkbox', {
-        name: t('Enable Performance Monitoring'),
+        name: t('Enable Tracing'),
         checked: true,
       })
     ).toBeInTheDocument();
 
     expect(
       screen.getByRole('checkbox', {
-        name: t('Enable Performance Monitoring'),
+        name: t('Enable Tracing'),
         checked: false,
       })
     ).toBeInTheDocument();

--- a/static/app/views/settings/project/projectKeys/details/loaderSettings.spec.tsx
+++ b/static/app/views/settings/project/projectKeys/details/loaderSettings.spec.tsx
@@ -70,12 +70,12 @@ describe('Loader Script Settings', function () {
     // Panel title
     expect(screen.getByText('JavaScript Loader Script')).toBeInTheDocument();
 
-    expect(screen.getByText(t('Enable Performance Monitoring'))).toBeInTheDocument();
+    expect(screen.getByText(t('Enable Tracing'))).toBeInTheDocument();
     expect(screen.getByText(t('Enable Session Replay'))).toBeInTheDocument();
     expect(screen.getByText(t('Enable Debug Bundles & Logging'))).toBeInTheDocument();
 
     const performanceCheckbox = screen.getByRole('checkbox', {
-      name: t('Enable Performance Monitoring'),
+      name: t('Enable Tracing'),
     });
     expect(performanceCheckbox).toBeEnabled();
     expect(performanceCheckbox).not.toBeChecked();
@@ -126,7 +126,7 @@ describe('Loader Script Settings', function () {
     // Toggle performance option
     await userEvent.click(
       screen.getByRole('checkbox', {
-        name: t('Enable Performance Monitoring'),
+        name: t('Enable Tracing'),
       })
     );
 
@@ -235,7 +235,7 @@ describe('Loader Script Settings', function () {
     );
 
     const performanceCheckbox = screen.getByRole('checkbox', {
-      name: t('Enable Performance Monitoring'),
+      name: t('Enable Tracing'),
     });
     expect(performanceCheckbox).not.toBeChecked();
 

--- a/static/app/views/settings/project/projectKeys/details/loaderSettings.tsx
+++ b/static/app/views/settings/project/projectKeys/details/loaderSettings.tsx
@@ -178,7 +178,7 @@ export function LoaderSettings({keyId, orgSlug, project, data, updateData}: Prop
           />
 
           <BooleanField
-            label={t('Enable Performance Monitoring')}
+            label={t('Enable Tracing')}
             name={`${keyId}-has-performance`}
             value={
               sdkVersionSupportsPerformanceAndReplay(data.browserSdkVersion)


### PR DESCRIPTION
Renaming all occurrences of "Performance Monitoring" to "Tracing"

backend part: https://github.com/getsentry/sentry/pull/75224
