### PR TITLE
ref(perf-monitoring): Change wording to "Tracing" (backend)

### DIFF
--- a/src/sentry/api/serializers/rest_framework/project_key.py
+++ b/src/sentry/api/serializers/rest_framework/project_key.py
@@ -27,7 +27,7 @@ class RateLimitSerializer(serializers.Serializer):
 class DynamicSdkLoaderOptionSerializer(serializers.Serializer):
     """
     Configures multiple options for the Javascript Loader Script.
-    - `Performance Monitoring`
+    - `Tracing`
     - `Debug Bundles & Logging`
     - `Session Replay` - Note that the loader will load the ES6 bundle instead of the ES5 bundle.
     ```json


### PR DESCRIPTION
Renaming all occurrences of "Performance Monitoring" to "Tracing"

frontend part: https://github.com/getsentry/sentry/pull/75223