### PR TITLE
ref: fill out TypeVars for ForeignKey

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -501,6 +501,7 @@ module = [
     "sentry.buffer.*",
     "sentry.build.*",
     "sentry.db.models.fields.citext",
+    "sentry.db.models.fields.foreignkey",
     "sentry.db.models.fields.hybrid_cloud_foreign_key",
     "sentry.db.models.fields.types",
     "sentry.db.models.manager.*",

--- a/requirements-dev-frozen.txt
+++ b/requirements-dev-frozen.txt
@@ -180,7 +180,7 @@ selenium==4.16.0
 sentry-arroyo==2.16.5
 sentry-cli==2.16.0
 sentry-devenv==1.7.0
-sentry-forked-django-stubs==5.0.2.post8
+sentry-forked-django-stubs==5.0.2.post10
 sentry-forked-djangorestframework-stubs==3.15.0.post1
 sentry-kafka-schemas==0.1.102
 sentry-ophio==0.2.7

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -35,7 +35,7 @@ pip-tools>=7.1.0
 packaging>=21.3
 
 # for type checking
-sentry-forked-django-stubs>=5.0.2.post8
+sentry-forked-django-stubs>=5.0.2.post10
 sentry-forked-djangorestframework-stubs>=3.15.0.post1
 lxml-stubs
 msgpack-types>=0.2.0

--- a/src/sentry/db/models/fields/foreignkey.py
+++ b/src/sentry/db/models/fields/foreignkey.py
@@ -5,10 +5,12 @@ from typing import Any
 from django.db import models
 from django.db.models import ForeignKey
 
+from sentry.db.models.fields.types import FieldGetType, FieldSetType
+
 __all__ = ("FlexibleForeignKey",)
 
 
-class FlexibleForeignKey(ForeignKey):
+class FlexibleForeignKey(ForeignKey[FieldSetType, FieldGetType]):
     def __init__(self, *args: Any, **kwargs: Any):
         kwargs.setdefault("on_delete", models.CASCADE)
         super().__init__(*args, **kwargs)


### PR DESCRIPTION
this fixes a class of problem when upgrading to django-stubs 5.0.4 where `_ST` becomes unbound

in order to fix this I first had to adjust the TypeVars in django-stubs itself:

- https://github.com/typeddjango/django-stubs/pull/2292

fixing that mypy now followed foreign keys which resulted in a few new errors (~30) needing fixing in sentry:

- #75233
- #75235
- #75237
- #75239
- #75240
- #75242
- #75243
- #75244
- #75246
- #75236
- #75234
- #75238
- #75241
- #75245
- #75303

fixing those left about ~5 errors that mypy was flagging code as "unreachable" but the foreign keys were marked `null=True` -- this turned out to be another bug in django-stubs related to how our "FlexibleForeignKey" was defined:

- https://github.com/typeddjango/django-stubs/pull/2294

fixing that surfaced ~220 new errors in sentry which were fixed:

- #75281
- #75282
- #75283
- #75284
- #75285
- #75286
- #75287
- #75288
- #75289
- #75290
- #75291
- #75292
- #75264
- #75263
- #75262
- #75260
- #75261
- #75258
- #75259
- #75256

<!-- Describe your PR here. -->