### PR TITLE
ref: match type in TypeDict

### DIFF
--- a/src/sentry/incidents/endpoints/serializers/alert_rule.py
+++ b/src/sentry/incidents/endpoints/serializers/alert_rule.py
@@ -85,7 +85,7 @@ class AlertRuleSerializerResponse(AlertRuleSerializerResponseOptional):
     status: int
     query: str
     aggregate: str
-    timeWindow: int
+    timeWindow: float
     resolution: float
     thresholdPeriod: int
     triggers: list[dict]


### PR DESCRIPTION
`/ 60` produces a float, discovered after mypy follows foreign keys

<!-- Describe your PR here. -->