### PR TITLE
chore(vscode): Set Prettier config path for VSCode

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -102,8 +102,7 @@
   "python.testing.pytestEnabled": true,
   "python.testing.unittestEnabled": false,
   "python.testing.pytestPath": "${workspaceFolder}/.venv/bin/pytest",
-  "python.testing.pytestArgs": [
-    "tests"
-  ],
-  "python.analysis.autoImportCompletions": true
+  "python.testing.pytestArgs": ["tests"],
+  "python.analysis.autoImportCompletions": true,
+  "prettier.configPath": "package.json"
 }


### PR DESCRIPTION
Sets the default config path for VSCode's Prettier settings to `package.json`, where Prettier rules reside