### PR TITLE
feat(discover): Get samples works with dataset selector

### DIFF
--- a/static/app/components/dynamicSampling/investigationRule.tsx
+++ b/static/app/components/dynamicSampling/investigationRule.tsx
@@ -290,9 +290,9 @@ function InvestigationRuleCreationInternal(props: PropsInternal) {
 export function InvestigationRuleCreation(props: Props) {
   const organization = useOrganization();
 
-  // if (!organization.isDynamicallySampled) {
-  //   return null;
-  // }
+  if (!organization.isDynamicallySampled) {
+    return null;
+  }
 
   return <InvestigationRuleCreationInternal {...props} organization={organization} />;
 }

--- a/static/app/components/dynamicSampling/investigationRule.tsx
+++ b/static/app/components/dynamicSampling/investigationRule.tsx
@@ -13,6 +13,7 @@ import {space} from 'sentry/styles/space';
 import type {Organization} from 'sentry/types/organization';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import type EventView from 'sentry/utils/discover/eventView';
+import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import type {ApiQueryKey} from 'sentry/utils/queryClient';
 import {useApiQuery, useMutation, useQueryClient} from 'sentry/utils/queryClient';
 import type RequestError from 'sentry/utils/requestError/requestError';
@@ -20,6 +21,7 @@ import useApi from 'sentry/utils/useApi';
 import useOrganization from 'sentry/utils/useOrganization';
 import {Datasource} from 'sentry/views/alerts/rules/metric/types';
 import {getQueryDatasource} from 'sentry/views/alerts/utils';
+import {hasDatasetSelector} from 'sentry/views/dashboards/utils';
 
 // Number of samples under which we can trigger an investigation rule
 const INVESTIGATION_MAX_SAMPLES_TRIGGER = 5;
@@ -179,12 +181,21 @@ const InvestigationInProgressNotification = styled('span')`
 `;
 
 function InvestigationRuleCreationInternal(props: PropsInternal) {
+  const {organization, eventView} = props;
   const projects = [...props.eventView.project];
-  const organization = props.organization;
-  const period = props.eventView.statsPeriod || null;
-  const query = props.eventView.getQuery();
+  const period = eventView.statsPeriod || null;
+
+  const isTransactionsDataset =
+    hasDatasetSelector(organization) &&
+    eventView.dataset === DiscoverDatasets.TRANSACTIONS;
+
+  const query = isTransactionsDataset
+    ? appendEventTypeCondition(eventView.getQuery())
+    : eventView.getQuery();
   const isTransactionQueryMissing =
-    getQueryDatasource(query)?.source !== Datasource.TRANSACTION;
+    getQueryDatasource(query)?.source !== Datasource.TRANSACTION &&
+    !isTransactionsDataset;
+
   const createInvestigationRule = useCreateInvestigationRuleMutation();
   const {
     data: rule,
@@ -279,9 +290,9 @@ function InvestigationRuleCreationInternal(props: PropsInternal) {
 export function InvestigationRuleCreation(props: Props) {
   const organization = useOrganization();
 
-  if (!organization.isDynamicallySampled) {
-    return null;
-  }
+  // if (!organization.isDynamicallySampled) {
+  //   return null;
+  // }
 
   return <InvestigationRuleCreationInternal {...props} organization={organization} />;
 }
@@ -290,3 +301,10 @@ const StyledIconQuestion = styled(IconQuestion)`
   position: relative;
   top: 2px;
 `;
+
+function appendEventTypeCondition(query: string) {
+  if (query.length > 0) {
+    return `event.type:transaction (${query})`;
+  }
+  return 'event.type:transaction';
+}

--- a/static/app/views/discover/table/tableActions.tsx
+++ b/static/app/views/discover/table/tableActions.tsx
@@ -171,21 +171,20 @@ function TableActions(props: Props) {
   const numSamples = tableData?.data?.length ?? null;
   const totalNumSamples = numSamples === null ? null : numSamples + cursorOffset;
 
-  const isNotTransactionsView =
-    hasDatasetSelector(organization) &&
-    queryDataset &&
-    queryDataset !== SavedQueryDatasets.TRANSACTIONS;
+  const isTransactions =
+    hasDatasetSelector(organization) && queryDataset === SavedQueryDatasets.TRANSACTIONS;
 
   return (
     <Fragment>
-      {supportsInvestigationRule && !isNotTransactionsView && (
-        <InvestigationRuleCreation
-          {...props}
-          buttonProps={{size: 'sm'}}
-          numSamples={totalNumSamples}
-          key="investigationRuleCreation"
-        />
-      )}
+      {supportsInvestigationRule &&
+        (!hasDatasetSelector(organization) || isTransactions) && (
+          <InvestigationRuleCreation
+            {...props}
+            buttonProps={{size: 'sm'}}
+            numSamples={totalNumSamples}
+            key="investigationRuleCreation"
+          />
+        )}
       <FeatureWrapper {...props} key="edit">
         {renderEditButton}
       </FeatureWrapper>

--- a/static/app/views/discover/table/tableActions.tsx
+++ b/static/app/views/discover/table/tableActions.tsx
@@ -15,7 +15,10 @@ import {trackAnalytics} from 'sentry/utils/analytics';
 import {parseCursor} from 'sentry/utils/cursor';
 import type {TableData} from 'sentry/utils/discover/discoverQuery';
 import type EventView from 'sentry/utils/discover/eventView';
+import {SavedQueryDatasets} from 'sentry/utils/discover/types';
 import {useLocation} from 'sentry/utils/useLocation';
+import useOrganization from 'sentry/utils/useOrganization';
+import {hasDatasetSelector} from 'sentry/views/dashboards/utils';
 
 import {downloadAsCsv} from '../utils';
 
@@ -30,6 +33,7 @@ type Props = {
   showTags: boolean;
   tableData: TableData | null | undefined;
   title: string;
+  queryDataset?: SavedQueryDatasets;
   supportsInvestigationRule?: boolean;
 };
 
@@ -159,14 +163,22 @@ function FeatureWrapper(props: FeatureWrapperProps) {
 }
 
 function TableActions(props: Props) {
+  const {tableData, queryDataset, supportsInvestigationRule} = props;
   const location = useLocation();
+  const organization = useOrganization();
   const cursor = location?.query?.cursor;
   const cursorOffset = parseCursor(cursor)?.offset ?? 0;
-  const numSamples = props.tableData?.data?.length ?? null;
+  const numSamples = tableData?.data?.length ?? null;
   const totalNumSamples = numSamples === null ? null : numSamples + cursorOffset;
+
+  const isNotTransactionsView =
+    hasDatasetSelector(organization) &&
+    queryDataset &&
+    queryDataset !== SavedQueryDatasets.TRANSACTIONS;
+
   return (
     <Fragment>
-      {props.supportsInvestigationRule && (
+      {supportsInvestigationRule && !isNotTransactionsView && (
         <InvestigationRuleCreation
           {...props}
           buttonProps={{size: 'sm'}}

--- a/static/app/views/discover/table/tableView.tsx
+++ b/static/app/views/discover/table/tableView.tsx
@@ -652,6 +652,7 @@ function TableView(props: TableViewProps) {
       location,
       onChangeShowTags,
       showTags,
+      queryDataset,
     } = props;
 
     return (
@@ -667,6 +668,7 @@ function TableView(props: TableViewProps) {
         onChangeShowTags={onChangeShowTags}
         showTags={showTags}
         supportsInvestigationRule
+        queryDataset={queryDataset}
       />
     );
   }


### PR DESCRIPTION
Only show get samples when transactions dataset is selected
Append `event.type:transaction` to `/dynamic-sampling/custom-rules/` call
if transactions dataset is selected (since event.type:transaction condition
is redundant and we don't expect the user to add it) otherwise, it fails validation.