### PR TITLE
ref(seer grouping): Prepare for calling Seer in optimized grouping flow

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -1545,11 +1545,16 @@ def _save_aggregate(
                     )
                     try:
                         # If no matching group is found in Seer, we'll still get back result
-                        # metadata, but `seer_matched_group` will be None
-                        seer_response_data, seer_matched_group = get_seer_similar_issues(
+                        # metadata, but `seer_matched_grouphash` will be None
+                        seer_response_data, seer_matched_grouphash = get_seer_similar_issues(
                             event, primary_hashes
                         )
                         event.data["seer_similarity"] = seer_response_data
+                        seer_matched_group = (
+                            Group.objects.filter(id=seer_matched_grouphash.group_id).first()
+                            if seer_matched_grouphash
+                            else None
+                        )
 
                     # Insurance - in theory we shouldn't ever land here
                     except Exception as e:

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -71,7 +71,7 @@ from sentry.grouping.ingest.metrics import (
     record_hash_calculation_metrics,
     record_new_group_metrics,
 )
-from sentry.grouping.ingest.seer import get_seer_similar_issues, should_call_seer_for_grouping
+from sentry.grouping.ingest.seer import maybe_check_seer_for_matching_grouphash
 from sentry.grouping.ingest.utils import (
     add_group_id_to_grouphashes,
     check_for_category_mismatch,
@@ -1533,34 +1533,14 @@ def _save_aggregate(
             # If we still haven't found a matching grouphash, we're now safe to go ahead and talk to
             # seer and/or create the group.
             if existing_grouphash is None:
-                seer_matched_group = None
-
-                if should_call_seer_for_grouping(event, primary_hashes):
-                    metrics.incr(
-                        "grouping.similarity.did_call_seer",
-                        # TODO: Consider lowering this (in all the spots this metric is
-                        # collected) once we roll Seer grouping out more widely
-                        sample_rate=1.0,
-                        tags={"call_made": True, "blocker": "none"},
-                    )
-                    try:
-                        # If no matching group is found in Seer, we'll still get back result
-                        # metadata, but `seer_matched_grouphash` will be None
-                        seer_response_data, seer_matched_grouphash = get_seer_similar_issues(
-                            event, primary_hashes
-                        )
-                        event.data["seer_similarity"] = seer_response_data
-                        seer_matched_group = (
-                            Group.objects.filter(id=seer_matched_grouphash.group_id).first()
-                            if seer_matched_grouphash
-                            else None
-                        )
-
-                    # Insurance - in theory we shouldn't ever land here
-                    except Exception as e:
-                        sentry_sdk.capture_exception(
-                            e, tags={"event": event.event_id, "project": project.id}
-                        )
+                seer_matched_grouphash = maybe_check_seer_for_matching_grouphash(
+                    event, primary_hashes
+                )
+                seer_matched_group = (
+                    Group.objects.filter(id=seer_matched_grouphash.group_id).first()
+                    if seer_matched_grouphash
+                    else None
+                )
 
                 group = seer_matched_group or _create_group(project, event, **group_creation_kwargs)
 

--- a/tests/sentry/event_manager/grouping/test_seer_grouping.py
+++ b/tests/sentry/event_manager/grouping/test_seer_grouping.py
@@ -31,11 +31,11 @@ class SeerEventManagerGroupingTest(TestCase):
 
         with (
             patch(
-                "sentry.event_manager.should_call_seer_for_grouping",
+                "sentry.grouping.ingest.seer.should_call_seer_for_grouping",
                 wraps=should_call_seer_for_grouping,
             ) as should_call_seer_spy,
             patch(
-                "sentry.event_manager.get_seer_similar_issues",
+                "sentry.grouping.ingest.seer.get_seer_similar_issues",
                 wraps=capture_results(
                     get_seer_similar_issues, get_seer_similar_issues_return_values
                 ),
@@ -90,14 +90,14 @@ class SeerEventManagerGroupingTest(TestCase):
                 assert get_seer_similar_issues_return_values[0][1] == expected_grouphash
                 assert new_event.group_id == existing_event.group_id
 
-    @patch("sentry.event_manager.should_call_seer_for_grouping", return_value=True)
-    @patch("sentry.event_manager.get_seer_similar_issues", return_value=({}, None))
+    @patch("sentry.grouping.ingest.seer.should_call_seer_for_grouping", return_value=True)
+    @patch("sentry.grouping.ingest.seer.get_seer_similar_issues", return_value=({}, None))
     def test_calls_seer_if_no_group_found(self, mock_get_seer_similar_issues: MagicMock, _):
         save_new_event({"message": "Dogs are great!"}, self.project)
         assert mock_get_seer_similar_issues.call_count == 1
 
-    @patch("sentry.event_manager.should_call_seer_for_grouping", return_value=True)
-    @patch("sentry.event_manager.get_seer_similar_issues", return_value=({}, None))
+    @patch("sentry.grouping.ingest.seer.should_call_seer_for_grouping", return_value=True)
+    @patch("sentry.grouping.ingest.seer.get_seer_similar_issues", return_value=({}, None))
     def test_bypasses_seer_if_group_found(self, mock_get_seer_similar_issues: MagicMock, _):
         existing_event = save_new_event({"message": "Dogs are great!"}, self.project)
         assert mock_get_seer_similar_issues.call_count == 1
@@ -106,7 +106,7 @@ class SeerEventManagerGroupingTest(TestCase):
         assert existing_event.group_id == new_event.group_id
         assert mock_get_seer_similar_issues.call_count == 1  # didn't get called again
 
-    @patch("sentry.event_manager.should_call_seer_for_grouping", return_value=True)
+    @patch("sentry.grouping.ingest.seer.should_call_seer_for_grouping", return_value=True)
     def test_stores_seer_results_in_metadata(self, _):
         existing_event = save_new_event({"message": "Dogs are great!"}, self.project)
 
@@ -131,7 +131,7 @@ class SeerEventManagerGroupingTest(TestCase):
         assert new_event.data["seer_similarity"] == expected_metadata
 
     @with_feature("projects:similarity-embeddings-grouping")
-    @patch("sentry.event_manager.should_call_seer_for_grouping", return_value=True)
+    @patch("sentry.grouping.ingest.seer.should_call_seer_for_grouping", return_value=True)
     def test_assigns_event_to_neighbor_group_if_found(self, _):
         existing_event = save_new_event({"message": "Dogs are great!"}, self.project)
 
@@ -153,7 +153,7 @@ class SeerEventManagerGroupingTest(TestCase):
             assert existing_event.group_id == new_event.group_id
 
     @with_feature("projects:similarity-embeddings-grouping")
-    @patch("sentry.event_manager.should_call_seer_for_grouping", return_value=True)
+    @patch("sentry.grouping.ingest.seer.should_call_seer_for_grouping", return_value=True)
     def test_creates_new_group_if_no_neighbor_found(self, _):
         existing_event = save_new_event({"message": "Dogs are great!"}, self.project)
 


### PR DESCRIPTION
This PR makes two changes to prepare for adding a Seer call to the optimized grouping flow in ingest.

- Pull the check for whether to call Seer and the call itself into a new function, `maybe_check_seer_for_matching_grouphash`, so that the same logic can be used in both the current and optimized flows.
- Refactor `get_seer_similar_issues` so that it returns a `GroupHash` object rather than a group, to make it compatible with `handle_existing_grouphash` (which is used in the new flow).