### PR TITLE
feat(relocation): Forbid forking from `de` region

### DIFF
--- a/src/sentry/api/endpoints/organization_fork.py
+++ b/src/sentry/api/endpoints/organization_fork.py
@@ -34,6 +34,12 @@ ERR_ORGANIZATION_INACTIVE = Template(
 ERR_CANNOT_FORK_INTO_SAME_REGION = Template(
     "The organization already lives in region `$region`, so it cannot be forked into that region."
 )
+ERR_CANNOT_FORK_FROM_REGION = Template(
+    "Forking an organization from region `$region` is forbidden."
+)
+
+# For legal reasons, there are certain regions from which forking is disallowed.
+CANNOT_FORK_FROM_REGION = {"de"}
 
 logger = logging.getLogger(__name__)
 
@@ -92,6 +98,15 @@ class OrganizationForkEndpoint(Endpoint):
         # Figure out which region the organization being forked lives in.
         requesting_region_name = get_local_region().name
         replying_region_name = org_mapping.region_name
+        if replying_region_name in CANNOT_FORK_FROM_REGION:
+            return Response(
+                {
+                    "detail": ERR_CANNOT_FORK_FROM_REGION.substitute(
+                        region=replying_region_name,
+                    )
+                },
+                status=status.HTTP_403_FORBIDDEN,
+            )
         if replying_region_name == requesting_region_name:
             return Response(
                 {

--- a/src/sentry/relocation/services/relocation_export/impl.py
+++ b/src/sentry/relocation/services/relocation_export/impl.py
@@ -181,7 +181,7 @@ class ProxyingRelocationExportService(ControlRelocationExportService):
             "replying_region_name": replying_region_name,
             "org_slug": org_slug,
             # TODO(azaslavsky): finish transfer from `encrypted_contents` -> `encrypted_bytes`.
-            "encrypt_with_public_key_size": len(encrypted_bytes or []),
+            "encrypted_bytes_size": len(encrypted_bytes or []),
         }
         logger.info("SaaS -> SaaS reply received on proxy", extra=logger_data)
 


### PR DESCRIPTION
This is mostly a legal safeguard: we don't want to allow easy export out of DE, and it's hard to imagine a (legal) case where this would be allowed anyway. If such a case ever does come up, we can easily modify the `CANNOT_FORK_FROM_REGION` set.
