### PR TITLE
feat(query-builder): Add ability to add a basic aggregate filter

### DIFF
--- a/static/app/components/searchQueryBuilder/hooks/useHandleSearch.tsx
+++ b/static/app/components/searchQueryBuilder/hooks/useHandleSearch.tsx
@@ -8,6 +8,7 @@ import {
   tokenIsInvalid,
 } from 'sentry/components/searchQueryBuilder/utils';
 import {type ParseResult, Token} from 'sentry/components/searchSyntax/parser';
+import {getKeyName} from 'sentry/components/searchSyntax/utils';
 import type {SavedSearchType} from 'sentry/types';
 import type {Organization} from 'sentry/types/organization';
 import {trackAnalytics} from 'sentry/utils/analytics';
@@ -74,7 +75,7 @@ function trackIndividualSearchFilters({
       trackAnalytics('search.searched_filter', {
         organization,
         query,
-        key: token.key.text,
+        key: getKeyName(token.key),
         values,
         search_type: searchType,
         search_source: searchSource,

--- a/static/app/components/searchQueryBuilder/hooks/useQueryBuilderState.tsx
+++ b/static/app/components/searchQueryBuilder/hooks/useQueryBuilderState.tsx
@@ -81,6 +81,12 @@ type DeleteLastMultiSelectFilterValueAction = {
   type: 'DELETE_LAST_MULTI_SELECT_FILTER_VALUE';
 };
 
+type UpdateAggregateArgsAction = {
+  token: TokenResult<Token.KEY_AGGREGATE_ARGS>;
+  type: 'UPDATE_AGGREGATE_ARGS';
+  value: string;
+};
+
 export type QueryBuilderActions =
   | ClearAction
   | UpdateQueryAction
@@ -91,6 +97,7 @@ export type QueryBuilderActions =
   | ReplaceTokensWithTextAction
   | UpdateFilterOpAction
   | UpdateTokenValueAction
+  | UpdateAggregateArgsAction
   | MultiSelectFilterValueAction
   | DeleteLastMultiSelectFilterValueAction;
 
@@ -429,6 +436,11 @@ export function useQueryBuilderState({
           return {
             ...state,
             query: modifyFilterValue(state.query, action.token, action.value),
+          };
+        case 'UPDATE_AGGREGATE_ARGS':
+          return {
+            ...state,
+            query: replaceQueryToken(state.query, action.token, action.value),
           };
         case 'TOGGLE_FILTER_VALUE':
           return multiSelectTokenValue(state, action);

--- a/static/app/components/searchQueryBuilder/index.stories.tsx
+++ b/static/app/components/searchQueryBuilder/index.stories.tsx
@@ -1,8 +1,12 @@
 import {Fragment, useState} from 'react';
 
+import Alert from 'sentry/components/alert';
 import MultipleCheckbox from 'sentry/components/forms/controls/multipleCheckbox';
 import {SearchQueryBuilder} from 'sentry/components/searchQueryBuilder';
-import type {FilterKeySection} from 'sentry/components/searchQueryBuilder/types';
+import type {
+  FieldDefinitionGetter,
+  FilterKeySection,
+} from 'sentry/components/searchQueryBuilder/types';
 import {InvalidReason} from 'sentry/components/searchSyntax/parser';
 import {ItemType} from 'sentry/components/smartSearchBar/types';
 import JSXNode from 'sentry/components/stories/jsxNode';
@@ -13,6 +17,7 @@ import {
   FieldKey,
   FieldKind,
   FieldValueType,
+  getFieldDefinition,
   MobileVital,
   WebVital,
 } from 'sentry/utils/fields';
@@ -322,6 +327,127 @@ export default storyBook(SearchQueryBuilder, story => {
               valueType: FieldValueType.BOOLEAN,
             };
           }}
+          searchSource="storybook"
+        />
+      </Fragment>
+    );
+  });
+
+  story('Aggregate filters', () => {
+    const aggregateFilterKeys: TagCollection = {
+      count: {
+        key: 'count',
+        name: 'count',
+        kind: FieldKind.FUNCTION,
+      },
+      count_if: {
+        key: 'count_if',
+        name: 'count_if',
+        kind: FieldKind.FUNCTION,
+      },
+      'transaction.duration': {
+        key: 'transaction.duration',
+        name: 'transaction.duration',
+        kind: FieldKind.FIELD,
+      },
+      timesSeen: {
+        key: 'timesSeen',
+        name: 'timesSeen',
+        kind: FieldKind.FIELD,
+      },
+      lastSeen: {
+        key: 'lastSeen',
+        name: 'lastSeen',
+        kind: FieldKind.FIELD,
+      },
+    };
+
+    const getAggregateFieldDefinition: FieldDefinitionGetter = (key: string) => {
+      switch (key) {
+        case 'count':
+          return {
+            desc: 'Returns results with a matching count.',
+            kind: FieldKind.FUNCTION,
+            valueType: FieldValueType.INTEGER,
+            parameters: [],
+          };
+        case 'count_if':
+          return {
+            desc: 'Returns results with a matching count that satisfy the condition passed to the parameters of the function.',
+            kind: FieldKind.FUNCTION,
+            valueType: FieldValueType.INTEGER,
+            parameters: [
+              {
+                name: 'column',
+                kind: 'column' as const,
+                columnTypes: [
+                  FieldValueType.STRING,
+                  FieldValueType.NUMBER,
+                  FieldValueType.DURATION,
+                ],
+                defaultValue: 'transaction.duration',
+                required: true,
+              },
+              {
+                name: 'operator',
+                kind: 'value' as const,
+                options: [
+                  {
+                    label: 'is equal to',
+                    value: 'equals',
+                  },
+                  {
+                    label: 'is not equal to',
+                    value: 'notEquals',
+                  },
+                  {
+                    label: 'is less than',
+                    value: 'less',
+                  },
+                  {
+                    label: 'is greater than',
+                    value: 'greater',
+                  },
+                  {
+                    label: 'is less than or equal to',
+                    value: 'lessOrEquals',
+                  },
+                  {
+                    label: 'is greater than or equal to',
+                    value: 'greaterOrEquals',
+                  },
+                ],
+                dataType: FieldValueType.STRING,
+                defaultValue: 'equals',
+                required: true,
+              },
+              {
+                name: 'value',
+                kind: 'value',
+                dataType: FieldValueType.STRING,
+                defaultValue: '300ms',
+                required: true,
+              },
+            ],
+          };
+        default:
+          return getFieldDefinition(key);
+      }
+    };
+
+    return (
+      <Fragment>
+        <Alert type="warning">Aggregate filter functionality is still in progress.</Alert>
+        <p>
+          Filter keys can be defined as aggregate filters, which allow for more complex
+          operations. They may accept any number of parameters, which are be defined in
+          the field definition.
+        </p>
+        <SearchQueryBuilder
+          initialQuery=""
+          filterKeys={aggregateFilterKeys}
+          getTagValues={getTagValues}
+          fieldDefinitionGetter={getAggregateFieldDefinition}
           searchSource="storybook"
         />
       </Fragment>

--- a/static/app/components/searchQueryBuilder/tokens/filter/aggregateKey.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/aggregateKey.tsx
@@ -9,6 +9,7 @@ import type {
   AggregateFilter,
   ParseResultToken,
 } from 'sentry/components/searchSyntax/parser';
+import {getKeyName} from 'sentry/components/searchSyntax/utils';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 
@@ -25,12 +26,12 @@ export function AggregateKey({item, state, token}: AggregateKeyProps) {
 
   const filterButtonProps = useFilterButtonProps({state, item});
 
-  const fnName = token.key.name.text;
+  const fnName = getKeyName(token.key);
   const fnParams = token.key.args?.text ?? '';
 
   return (
     <KeyButton
-      aria-label={t('Edit parameters for filter: %s', token.key.name.text)}
+      aria-label={t('Edit parameters for filter: %s', fnName)}
       disabled={disabled}
       {...filterButtonProps}
     >

--- a/static/app/components/searchQueryBuilder/tokens/filter/aggregateKey.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/aggregateKey.tsx
@@ -4,6 +4,7 @@ import type {Node} from '@react-types/shared';
 
 import InteractionStateLayer from 'sentry/components/interactionStateLayer';
 import {useSearchQueryBuilder} from 'sentry/components/searchQueryBuilder/context';
+import {UnstyledButton} from 'sentry/components/searchQueryBuilder/tokens/filter/unstyledButton';
 import {useFilterButtonProps} from 'sentry/components/searchQueryBuilder/tokens/filter/useFilterButtonProps';
 import type {
   AggregateFilter,
@@ -43,18 +44,6 @@ export function AggregateKey({item, state, token}: AggregateKeyProps) {
     </KeyButton>
   );
 }
-
-const UnstyledButton = styled('button')`
-  background: none;
-  border: none;
-  outline: none;
-  padding: 0;
-  user-select: none;
-
-  :focus {
-    outline: none;
-  }
-`;
 
 const KeyButton = styled(UnstyledButton)`
   padding: 0 ${space(0.25)} 0 ${space(0.5)};

--- a/static/app/components/searchQueryBuilder/tokens/filter/aggregateKey.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/aggregateKey.tsx
@@ -1,0 +1,82 @@
+import styled from '@emotion/styled';
+import type {ListState} from '@react-stately/list';
+import type {Node} from '@react-types/shared';
+
+import InteractionStateLayer from 'sentry/components/interactionStateLayer';
+import {useSearchQueryBuilder} from 'sentry/components/searchQueryBuilder/context';
+import {useFilterButtonProps} from 'sentry/components/searchQueryBuilder/tokens/filter/useFilterButtonProps';
+import type {
+  AggregateFilter,
+  ParseResultToken,
+} from 'sentry/components/searchSyntax/parser';
+import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
+
+type AggregateKeyProps = {
+  filterRef: React.RefObject<HTMLDivElement>;
+  item: Node<ParseResultToken>;
+  onActiveChange: (active: boolean) => void;
+  state: ListState<ParseResultToken>;
+  token: AggregateFilter;
+};
+
+export function AggregateKey({item, state, token}: AggregateKeyProps) {
+  const {disabled} = useSearchQueryBuilder();
+
+  const filterButtonProps = useFilterButtonProps({state, item});
+
+  const fnName = token.key.name.text;
+  const fnParams = token.key.args?.text ?? '';
+
+  return (
+    <KeyButton
+      aria-label={t('Edit parameters for filter: %s', token.key.name.text)}
+      disabled={disabled}
+      {...filterButtonProps}
+    >
+      <InteractionStateLayer />
+      <FnName>{fnName}</FnName>
+      {'('}
+      <Parameters>{fnParams}</Parameters>
+      {')'}
+    </KeyButton>
+  );
+}
+
+const UnstyledButton = styled('button')`
+  background: none;
+  border: none;
+  outline: none;
+  padding: 0;
+  user-select: none;
+
+  :focus {
+    outline: none;
+  }
+`;
+
+const KeyButton = styled(UnstyledButton)`
+  padding: 0 ${space(0.25)} 0 ${space(0.5)};
+  height: 100%;
+  border-left: 1px solid transparent;
+  border-right: 1px solid transparent;
+  border-radius: 3px 0 0 3px;
+
+  :focus {
+    background-color: ${p => p.theme.translucentGray100};
+    border-right: 1px solid ${p => p.theme.innerBorder};
+    border-left: 1px solid ${p => p.theme.innerBorder};
+  }
+`;
+
+const FnName = styled('span')`
+  color: ${p => p.theme.green400};
+`;
+
+const Parameters = styled('span')`
+  height: 100%;
+
+  &:not(:empty) {
+    padding: 0 ${space(0.25)};
+  }
+`;

--- a/static/app/components/searchQueryBuilder/tokens/filter/filter.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/filter.tsx
@@ -10,6 +10,7 @@ import InteractionStateLayer from 'sentry/components/interactionStateLayer';
 import {useSearchQueryBuilder} from 'sentry/components/searchQueryBuilder/context';
 import {useQueryBuilderGridItem} from 'sentry/components/searchQueryBuilder/hooks/useQueryBuilderGridItem';
 import {FilterKeyOperator} from 'sentry/components/searchQueryBuilder/tokens/filter/filterKeyOperator';
+import {UnstyledButton} from 'sentry/components/searchQueryBuilder/tokens/filter/unstyledButton';
 import {useFilterButtonProps} from 'sentry/components/searchQueryBuilder/tokens/filter/useFilterButtonProps';
 import {formatFilterValue} from 'sentry/components/searchQueryBuilder/tokens/filter/utils';
 import {SearchQueryBuilderValueCombobox} from 'sentry/components/searchQueryBuilder/tokens/filter/valueCombobox';
@@ -277,18 +278,6 @@ const BaseGridCell = styled('div')`
 const FilterValueGridCell = styled(BaseGridCell)`
   /* When we run out of space, shrink the value */
   min-width: 0;
-`;
-
-const UnstyledButton = styled('button')`
-  background: none;
-  border: none;
-  outline: none;
-  padding: 0;
-  user-select: none;
-
-  :focus {
-    outline: none;
-  }
 `;
 
 const ValueButton = styled(UnstyledButton)`

--- a/static/app/components/searchQueryBuilder/tokens/filter/filter.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/filter.tsx
@@ -19,6 +19,7 @@ import {
   Token,
   type TokenResult,
 } from 'sentry/components/searchSyntax/parser';
+import {getKeyName} from 'sentry/components/searchSyntax/utils';
 import {IconClose} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
@@ -137,7 +138,7 @@ function FilterValue({token, state, item, filterRef, onActiveChange}: FilterValu
 
   return (
     <ValueButton
-      aria-label={t('Edit value for filter: %s', token.key.text)}
+      aria-label={t('Edit value for filter: %s', getKeyName(token.key))}
       onClick={() => {
         setIsEditing(true);
         onActiveChange(true);
@@ -157,7 +158,7 @@ function FilterDelete({token, state, item}: SearchQueryTokenProps) {
 
   return (
     <DeleteButton
-      aria-label={t('Remove filter: %s', token.key.text)}
+      aria-label={t('Remove filter: %s', getKeyName(token.key))}
       onClick={() => dispatch({type: 'DELETE_TOKEN', token})}
       disabled={disabled}
       {...filterButtonProps}

--- a/static/app/components/searchQueryBuilder/tokens/filter/filter.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/filter.tsx
@@ -212,14 +212,14 @@ export function SearchQueryBuilderFilter({item, state, token}: SearchQueryTokenP
         containerDisplayMode="grid"
         forceVisible={filterMenuOpen ? false : undefined}
       >
-        <BaseGridCell {...gridCellProps}>
-          <FilterKeyOperator
-            token={token}
-            state={state}
-            item={item}
-            onOpenChange={setFilterMenuOpen}
-          />
-        </BaseGridCell>
+        <FilterKeyOperator
+          token={token}
+          state={state}
+          item={item}
+          onOpenChange={setFilterMenuOpen}
+          filterRef={ref}
+          gridCellProps={gridCellProps}
+        />
         <FilterValueGridCell {...gridCellProps}>
           <FilterValue
             token={token}

--- a/static/app/components/searchQueryBuilder/tokens/filter/filterKeyOperator.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/filterKeyOperator.tsx
@@ -8,6 +8,7 @@ import {CompactSelect, type SelectOption} from 'sentry/components/compactSelect'
 import InteractionStateLayer from 'sentry/components/interactionStateLayer';
 import {useSearchQueryBuilder} from 'sentry/components/searchQueryBuilder/context';
 import {AggregateKey} from 'sentry/components/searchQueryBuilder/tokens/filter/aggregateKey';
+import {UnstyledButton} from 'sentry/components/searchQueryBuilder/tokens/filter/unstyledButton';
 import {useFilterButtonProps} from 'sentry/components/searchQueryBuilder/tokens/filter/useFilterButtonProps';
 import {getValidOpsForFilter} from 'sentry/components/searchQueryBuilder/tokens/filter/utils';
 import {
@@ -393,18 +394,6 @@ export function FilterKeyOperator({
     </GridCell>
   );
 }
-
-const UnstyledButton = styled('button')`
-  background: none;
-  border: none;
-  outline: none;
-  padding: 0;
-  user-select: none;
-
-  :focus {
-    outline: none;
-  }
-`;
 
 const GridCell = styled('div')`
   display: flex;

--- a/static/app/components/searchQueryBuilder/tokens/filter/filterKeyOperator.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/filterKeyOperator.tsx
@@ -22,6 +22,7 @@ import {
   type Token,
   type TokenResult,
 } from 'sentry/components/searchSyntax/parser';
+import {getKeyName} from 'sentry/components/searchSyntax/utils';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {trackAnalytics} from 'sentry/utils/analytics';
@@ -303,7 +304,7 @@ function OperatorSelect({
           search_source: searchSource,
           new_experience: true,
           search_operator: option.value,
-          filter_key: token.key.text,
+          filter_key: getKeyName(token.key),
         });
         dispatch({
           type: 'UPDATE_FILTER_OP',

--- a/static/app/components/searchQueryBuilder/tokens/filter/unstyledButton.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/unstyledButton.tsx
@@ -1,0 +1,13 @@
+import styled from '@emotion/styled';
+
+export const UnstyledButton = styled('button')`
+  background: none;
+  border: none;
+  outline: none;
+  padding: 0;
+  user-select: none;
+
+  :focus {
+    outline: none;
+  }
+`;

--- a/static/app/components/searchQueryBuilder/tokens/filter/valueCombobox.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/valueCombobox.tsx
@@ -381,6 +381,7 @@ function getPredefinedValues({
   if (!key.values?.length) {
     switch (fieldDefinition?.valueType) {
       case FieldValueType.NUMBER:
+      case FieldValueType.INTEGER:
         return getNumericSuggestions(filterValue);
       case FieldValueType.DURATION:
         return getDurationSuggestions(filterValue, token);

--- a/static/app/components/searchQueryBuilder/tokens/filter/valueCombobox.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/valueCombobox.tsx
@@ -28,6 +28,7 @@ import {
   Token,
   type TokenResult,
 } from 'sentry/components/searchSyntax/parser';
+import {getKeyName} from 'sentry/components/searchSyntax/utils';
 import {
   ItemType,
   type SearchGroup,
@@ -435,7 +436,7 @@ function tokenSupportsMultipleValues(
     case FilterType.TEXT:
       // The search parser defaults to the text type, so we need to do further
       // checks to ensure that the filter actually supports multiple values
-      const key = keys[token.key.text];
+      const key = keys[getKeyName(token.key)];
       if (!key) {
         return true;
       }
@@ -552,9 +553,10 @@ function useFilterSuggestions({
   selectedValues: string[];
   token: TokenResult<Token.FILTER>;
 }) {
+  const keyName = getKeyName(token.key);
   const {getFieldDefinition, getTagValues, filterKeys} = useSearchQueryBuilder();
-  const key: Tag | undefined = filterKeys[token.key.text];
-  const fieldDefinition = getFieldDefinition(token.key.text);
+  const key: Tag | undefined = filterKeys[keyName];
+  const fieldDefinition = getFieldDefinition(keyName);
   const predefinedValues = useMemo(
     () =>
       getPredefinedValues({
@@ -573,8 +575,8 @@ function useFilterSuggestions({
   );
 
   const queryKey = useMemo<QueryKey>(
-    () => ['search-query-builder-tag-values', token.key.text, filterValue],
-    [filterValue, token.key]
+    () => ['search-query-builder-tag-values', keyName, filterValue],
+    [filterValue, keyName]
   );
 
   const debouncedQueryKey = useDebouncedValue(queryKey);
@@ -582,8 +584,7 @@ function useFilterSuggestions({
   // TODO(malwilley): Display error states
   const {data, isFetching} = useQuery<string[]>({
     queryKey: debouncedQueryKey,
-    queryFn: () =>
-      getTagValues(key ? key : {key: token.key.text, name: token.key.text}, filterValue),
+    queryFn: () => getTagValues(key ? key : {key: keyName, name: keyName}, filterValue),
     keepPreviousData: true,
     enabled: shouldFetchValues,
   });
@@ -727,7 +728,8 @@ export function SearchQueryBuilderValueCombobox({
   const organization = useOrganization();
   const {getFieldDefinition, filterKeys, dispatch, searchSource, recentSearches} =
     useSearchQueryBuilder();
-  const fieldDefinition = getFieldDefinition(token.key.text);
+  const keyName = getKeyName(token.key);
+  const fieldDefinition = getFieldDefinition(keyName);
   const canSelectMultipleValues = tokenSupportsMultipleValues(
     token,
     filterKeys,
@@ -784,7 +786,7 @@ export function SearchQueryBuilderValueCombobox({
       organization,
       search_type: recentSearchTypeToLabel(recentSearches),
       search_source: searchSource,
-      filter_key: token.key.text,
+      filter_key: keyName,
       filter_operator: token.operator,
       filter_value_type: fieldDefinition?.valueType ?? FieldValueType.STRING,
       new_experience: true,
@@ -794,7 +796,7 @@ export function SearchQueryBuilderValueCombobox({
       organization,
       recentSearches,
       searchSource,
-      token.key.text,
+      keyName,
       token.operator,
     ]
   );
@@ -901,7 +903,7 @@ export function SearchQueryBuilderValueCombobox({
         dispatch({
           type: 'UPDATE_TOKEN_VALUE',
           token: token,
-          value: getDefaultFilterValue({key: token.key.text, fieldDefinition}),
+          value: getDefaultFilterValue({key: keyName, fieldDefinition}),
         });
         onCommit();
         return;
@@ -941,6 +943,7 @@ export function SearchQueryBuilderValueCombobox({
       canSelectMultipleValues,
       dispatch,
       fieldDefinition,
+      keyName,
       onCommit,
       token,
       updateFilterValue,

--- a/static/app/components/searchQueryBuilder/tokens/freeText.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/freeText.tsx
@@ -32,6 +32,7 @@ import {
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {Tag, TagCollection} from 'sentry/types/group';
+import {defined} from 'sentry/utils';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {type FieldDefinition, FieldKind, FieldValueType} from 'sentry/utils/fields';
 import {useFuzzySearch} from 'sentry/utils/fuzzySearch';
@@ -95,18 +96,37 @@ function getWordAtCursorPosition(value: string, cursorPosition: number) {
   return value;
 }
 
+function getInitialFilterKeyText(key: string, fieldDefinition: FieldDefinition | null) {
+  if (fieldDefinition?.kind === FieldKind.FUNCTION) {
+    if (fieldDefinition.parameters) {
+      const parametersText = fieldDefinition.parameters
+        .filter(param => defined(param.defaultValue))
+        .map(param => param.defaultValue)
+        .join(',');
+
+      return `${key}(${parametersText})`;
+    }
+
+    return `${key}()`;
+  }
+
+  return key;
+}
+
 function getInitialFilterText(key: string, fieldDefinition: FieldDefinition | null) {
   const defaultValue = getDefaultFilterValue({key, fieldDefinition});
+
+  const keyText = getInitialFilterKeyText(key, fieldDefinition);
 
   switch (fieldDefinition?.valueType) {
     case FieldValueType.INTEGER:
     case FieldValueType.NUMBER:
     case FieldValueType.DURATION:
     case FieldValueType.PERCENTAGE:
-      return `${key}:>${defaultValue}`;
+      return `${keyText}:>${defaultValue}`;
     case FieldValueType.STRING:
     default:
-      return `${key}:${defaultValue}`;
+      return `${keyText}:${defaultValue}`;
   }
 }
 
@@ -144,7 +164,7 @@ function createItem(tag: Tag, fieldDefinition: FieldDefinition | null): KeyItem 
 
   return {
     key: getEscapedKey(tag.key),
-    label: tag.alias ?? tag.key,
+    label: tag.key,
     description: description ?? '',
     value: tag.key,
     textValue: tag.key,
@@ -247,12 +267,6 @@ function KeyDescription({tag}: {tag: Tag}) {
       <div>{fieldDefinition.desc}</div>
       <Separator />
       <DescriptionList>
-        {tag.alias ? (
-          <Fragment>
-            <Term>{t('Alias')}</Term>
-            <Details>{tag.key}</Details>
-          </Fragment>
-        ) : null}
         {fieldDefinition.valueType ? (
           <Fragment>
             <Term>{t('Type')}</Term>

--- a/static/app/components/searchQueryBuilder/types.tsx
+++ b/static/app/components/searchQueryBuilder/types.tsx
@@ -15,7 +15,7 @@ export enum QueryInterfaceType {
 
 export type FocusOverride = {
   itemKey: string;
-  part?: 'value';
+  part?: 'value' | 'key';
 };
 
 export type FieldDefinitionGetter = (key: string) => FieldDefinition | null;

--- a/static/app/components/searchSyntax/parser.tsx
+++ b/static/app/components/searchSyntax/parser.tsx
@@ -1182,6 +1182,18 @@ export type ParseResultToken =
  */
 export type ParseResult = ParseResultToken[];
 
+export type AggregateFilter = (
+  | FilterMap[FilterType.AGGREGATE_DATE]
+  | FilterMap[FilterType.AGGREGATE_DURATION]
+  | FilterMap[FilterType.AGGREGATE_NUMERIC]
+  | FilterMap[FilterType.AGGREGATE_PERCENTAGE]
+  | FilterMap[FilterType.AGGREGATE_RELATIVE_DATE]
+  | FilterMap[FilterType.AGGREGATE_SIZE]
+) & {
+  location: LocationRange;
+  text: string;
+};
+
 /**
  * Configures behavior of search parsing
  */

--- a/static/app/utils/fields/index.ts
+++ b/static/app/utils/fields/index.ts
@@ -241,6 +241,32 @@ export enum IsFieldValues {
   UNLINKED = 'unlinked',
 }
 
+export type AggregateColumnParameter = {
+  /**
+   * The types of columns that are valid for this parameter.
+   * Can pass a list of FieldValueTypes or a predicate function.
+   */
+  columnTypes:
+    | FieldValueType[]
+    | ((field: {key: string; valueType: FieldValueType}) => boolean);
+  kind: 'column';
+  name: string;
+  required: boolean;
+  defaultValue?: string;
+};
+
+export type AggregateValueParameter = {
+  dataType: FieldValueType;
+  kind: 'value';
+  name: string;
+  required: boolean;
+  defaultValue?: string;
+  options?: Array<{value: string; label?: string}>;
+  placeholder?: string;
+};
+
+export type AggregateParameter = AggregateColumnParameter | AggregateValueParameter;
+
 export interface FieldDefinition {
   kind: FieldKind;
   valueType: FieldValueType | null;
@@ -266,6 +292,11 @@ export interface FieldDefinition {
    * Additional keywords used when filtering via autocomplete
    */
   keywords?: string[];
+  /**
+   * Only valid for aggregate fields.
+   * Defines the number and type of parameters that the function accepts.
+   */
+  parameters?: AggregateParameter[];
 }
 
 export const AGGREGATION_FIELDS: Record<AggregationKey, FieldDefinition> = {


### PR DESCRIPTION
Ref https://github.com/getsentry/sentry/issues/74312

This PR adds the building blocks of aggregate filters. More functionality will be added in subsequent PRs.

- Adds `parameters` type to the field definition to allow users to define what is accepted
- Adds default parameters when an aggregate filter is selected from the key menu
- Separates the key from the operator for aggregate filters (because clicking the key will allow you to edit the parameters)

![CleanShot 2024-07-30 at 09 32 06](https://github.com/user-attachments/assets/dd72bc61-c276-4d75-9a7f-7c06d6b59b18)
