### PR TITLE
ref(replay): rename ContextIcon to PlatformIcon

### DIFF
--- a/static/app/components/replays/platformIcon.tsx
+++ b/static/app/components/replays/platformIcon.tsx
@@ -1,5 +1,5 @@
 import styled from '@emotion/styled';
-import {PlatformIcon} from 'platformicons';
+import {PlatformIcon as BasePlatformIcon} from 'platformicons';
 
 import CountTooltipContent from 'sentry/components/replays/countTooltipContent';
 import {Tooltip} from 'sentry/components/tooltip';
@@ -21,12 +21,12 @@ const iconStyle = {
   border: '1px solid ' + commonTheme.translucentGray100,
 };
 
-const ContextIcon = styled(
+const PlatformIcon = styled(
   ({className, name, version, showVersion, showTooltip}: Props) => {
     const icon = generatePlatformIconName(name, version);
 
     if (!showTooltip) {
-      return <PlatformIcon platform={icon} size={iconSize} style={iconStyle} />;
+      return <BasePlatformIcon platform={icon} size={iconSize} style={iconStyle} />;
     }
 
     const title = (
@@ -39,7 +39,7 @@ const ContextIcon = styled(
     );
     return (
       <Tooltip title={title} className={className}>
-        <PlatformIcon platform={icon} size={iconSize} style={iconStyle} />
+        <BasePlatformIcon platform={icon} size={iconSize} style={iconStyle} />
         {showVersion ? (version ? version : null) : undefined}
       </Tooltip>
     );
@@ -51,4 +51,4 @@ const ContextIcon = styled(
   align-items: center;
 `;
 
-export default ContextIcon;
+export default PlatformIcon;

--- a/static/app/views/replays/detail/browserOSIcons.tsx
+++ b/static/app/views/replays/detail/browserOSIcons.tsx
@@ -1,7 +1,7 @@
 import {Fragment} from 'react';
 
 import Placeholder from 'sentry/components/placeholder';
-import ContextIcon from 'sentry/components/replays/contextIcon';
+import PlatformIcon from 'sentry/components/replays/platformIcon';
 import {useReplayContext} from 'sentry/components/replays/replayContext';
 import {Tooltip} from 'sentry/components/tooltip';
 
@@ -20,7 +20,7 @@ export default function BrowserOSIcons({
   ) : (
     <Fragment>
       <Tooltip title={`${replayRecord?.os.name ?? ''} ${replayRecord?.os.version ?? ''}`}>
-        <ContextIcon
+        <PlatformIcon
           name={replayRecord?.os.name ?? ''}
           version={replayRecord?.os.version ?? undefined}
           showVersion
@@ -32,7 +32,7 @@ export default function BrowserOSIcons({
             replayRecord?.browser.version ?? ''
           }`}
         >
-          <ContextIcon
+          <PlatformIcon
             name={replayRecord?.browser.name ?? ''}
             version={replayRecord?.browser.version ?? undefined}
             showVersion

--- a/static/app/views/replays/replayTable/tableCell.tsx
+++ b/static/app/views/replays/replayTable/tableCell.tsx
@@ -7,7 +7,7 @@ import UserAvatar from 'sentry/components/avatar/userAvatar';
 import {Button} from 'sentry/components/button';
 import {DropdownMenu} from 'sentry/components/dropdownMenu';
 import Link from 'sentry/components/links/link';
-import ContextIcon from 'sentry/components/replays/contextIcon';
+import PlatformIcon from 'sentry/components/replays/platformIcon';
 import ReplayPlayPauseButton from 'sentry/components/replays/replayPlayPauseButton';
 import ScoreBar from 'sentry/components/scoreBar';
 import TimeSince from 'sentry/components/timeSince';
@@ -477,7 +477,7 @@ export function OSCell({replay, showDropdownFilters}: Props) {
     <Item>
       <Container>
         <Tooltip title={`${name ?? ''} ${version ?? ''}`}>
-          <ContextIcon
+          <PlatformIcon
             name={name ?? ''}
             version={version && hasRoomForColumns ? version : undefined}
             showVersion={false}
@@ -504,7 +504,7 @@ export function BrowserCell({replay, showDropdownFilters}: Props) {
     <Item>
       <Container>
         <Tooltip title={`${name} ${version}`}>
-          <ContextIcon
+          <PlatformIcon
             name={name ?? ''}
             version={version && hasRoomForColumns ? version : undefined}
             showVersion={false}


### PR DESCRIPTION
After https://github.com/getsentry/sentry/pull/74173, I think this updated name makes the component's usage more clear