### PR TITLE
fix(issue-search): Fix bug when searching for non-error issues

### DIFF
--- a/src/sentry/issues/search.py
+++ b/src/sentry/issues/search.py
@@ -81,14 +81,11 @@ def group_categories_from(
     for search_filter in search_filters or ():
         if search_filter.key.name in ("issue.category", "issue.type"):
             if search_filter.is_negation:
+                # get all group categories except the ones in the negation filter
                 group_categories.update(
                     get_group_type_by_type_id(value).category
-                    for value in list(
-                        filter(
-                            lambda x: x not in get_all_group_type_ids(),
-                            search_filter.value.raw_value,
-                        )
-                    )
+                    for value in get_all_group_type_ids()
+                    if value not in search_filter.value.raw_value
                 )
             else:
                 group_categories.update(

--- a/tests/sentry/issues/endpoints/test_organization_group_index.py
+++ b/tests/sentry/issues/endpoints/test_organization_group_index.py
@@ -3158,13 +3158,14 @@ class GroupListTest(APITestCase, SnubaTestCase, SearchIssueTestMixin):
         np1_group_id = group_info.group.id if group_info else None
 
         # create an error issue
-        self.store_event(
+        error_event = self.store_event(
             data={
                 "fingerprint": ["error-issue"],
                 "event_id": "e" * 32,
             },
             project_id=self.project.id,
         )
+        error_group_id = error_event.group.id
 
         self.login_as(user=self.user)
         # give time for consumers to run and propogate changes to clickhouse
@@ -3199,6 +3200,30 @@ class GroupListTest(APITestCase, SnubaTestCase, SearchIssueTestMixin):
             query="issue.category:replay issue.type:performance_n_plus_one_db_queries",
         )
         assert len(response.data) == 0
+
+        response = self.get_success_response(
+            sort="new",
+            query="issue.category:error",
+        )
+        assert len(response.data) == 1
+        assert {r["id"] for r in response.data} == {str(error_group_id)}
+
+        response = self.get_success_response(
+            sort="new",
+            query="!issue.category:performance",
+        )
+        assert len(response.data) == 1
+        assert {r["id"] for r in response.data} == {str(error_group_id)}
+
+        response = self.get_success_response(
+            sort="new",
+            query="!issue.category:error",
+        )
+        assert len(response.data) == 2
+        assert {r["id"] for r in response.data} == {
+            str(blocking_asset_group_id),
+            str(np1_group_id),
+        }
 
     def test_pagination_and_x_hits_header(self, _: MagicMock) -> None:
         # Create 30 issues

--- a/tests/sentry/issues/endpoints/test_organization_group_index.py
+++ b/tests/sentry/issues/endpoints/test_organization_group_index.py
@@ -3225,6 +3225,20 @@ class GroupListTest(APITestCase, SnubaTestCase, SearchIssueTestMixin):
             str(np1_group_id),
         }
 
+        response = self.get_success_response(
+            sort="new",
+            query="!issue.category:performance",
+        )
+        assert len(response.data) == 1
+        assert {r["id"] for r in response.data} == {str(error_group_id)}
+
+        response = self.get_success_response(
+            sort="new",
+            query="!issue.category:[performance,cron]",
+        )
+        assert len(response.data) == 1
+        assert {r["id"] for r in response.data} == {str(error_group_id)}
+
     def test_pagination_and_x_hits_header(self, _: MagicMock) -> None:
         # Create 30 issues
         for i in range(30):


### PR DESCRIPTION
There was a bug in the logic to search for group categories with a negation, specifically searches like `!issue.category:error`. This PR fixes the logic to filter out the negated issue categories and adds a test to validate that negation searches work as expected. 