### PR TITLE
chore(azure): check if repo config instance differs from integration domain name

### DIFF
--- a/src/sentry/integrations/vsts/integration.py
+++ b/src/sentry/integrations/vsts/integration.py
@@ -136,7 +136,7 @@ class VstsIntegration(IntegrationInstallation, RepositoryMixin, VstsIssueSync):
 
     def get_repositories(self, query: str | None = None) -> Sequence[Mapping[str, str]]:
         try:
-            repos = self.get_client(base_url=self.instance).get_repos()
+            repos = self.get_client().get_repos()
         except (ApiError, IdentityNotValid) as e:
             raise IntegrationError(self.message_from_error(e))
         data = []
@@ -157,7 +157,7 @@ class VstsIntegration(IntegrationInstallation, RepositoryMixin, VstsIssueSync):
         return [repo for repo in repos if repo.external_id not in identifiers_to_exclude]
 
     def has_repo_access(self, repo: RpcRepository) -> bool:
-        client = self.get_client(base_url=self.instance)
+        client = self.get_client()
         try:
             # since we don't actually use webhooks for vsts commits,
             # just verify repo access
@@ -196,8 +196,7 @@ class VstsIntegration(IntegrationInstallation, RepositoryMixin, VstsIssueSync):
         self.model.save()
 
     def get_organization_config(self) -> Sequence[Mapping[str, Any]]:
-        instance = self.model.metadata["domain_name"]
-        client = self.get_client(base_url=instance)
+        client = self.get_client()
 
         project_selector = []
         all_states_set = set()


### PR DESCRIPTION
The `get_client` function signature for Azure DevOps differs from all the other integrations because we are passing an optional `base_url` parameter. We might not need to do this if the repository `instance` is always the same as the integration `domain_name` (both are passed as base urls). According to the code, the repository instance should always be the same as the domain name (aka `installation.instance` in the code).

https://github.com/getsentry/sentry/blob/3ba7201f3ec899add45e3478a98d93b88d1447e9/src/sentry/integrations/vsts/repository.py#L26-L37

https://github.com/getsentry/sentry/blob/3ba7201f3ec899add45e3478a98d93b88d1447e9/src/sentry/integrations/vsts/integration.py#L366-L368

This PR adds logging to check if we can remove the `base_url` parameter or if we should add an overloaded function declaration in the `IntegrationInstallation` base class. In `VstsIntegration`, we only ever pass `base_url=self.instance` to `get_client` which is already the default if we don't pass `base_url`.