### PR TITLE
chore(scm): remove unused reinstall and reinstall_repositories functions

### DIFF
--- a/src/sentry/integrations/bitbucket/integration.py
+++ b/src/sentry/integrations/bitbucket/integration.py
@@ -137,9 +137,6 @@ class BitbucketIntegration(IntegrationInstallation, BitbucketIssueBasicMixin, Re
 
         return [repo for repo in repos if repo.name not in accessible_repos]
 
-    def reinstall(self):
-        self.reinstall_repositories()
-
     def source_url_matches(self, url: str) -> bool:
         return url.startswith(f'https://{self.model.metadata["domain_name"]}') or url.startswith(
             "https://bitbucket.org",

--- a/src/sentry/integrations/bitbucket_server/integration.py
+++ b/src/sentry/integrations/bitbucket_server/integration.py
@@ -295,9 +295,6 @@ class BitbucketServerIntegration(IntegrationInstallation, RepositoryMixin):
 
         return list(filter(lambda repo: repo.name not in accessible_repos, repos))
 
-    def reinstall(self):
-        self.reinstall_repositories()
-
 
 class BitbucketServerIntegrationProvider(IntegrationProvider):
     key = "bitbucket_server"

--- a/src/sentry/integrations/github/integration.py
+++ b/src/sentry/integrations/github/integration.py
@@ -254,9 +254,6 @@ class GitHubIntegration(IntegrationInstallation, GitHubIssueBasic, RepositoryMix
 
         return [repo for repo in existing_repos if repo.name not in accessible_repo_names]
 
-    def reinstall(self) -> None:
-        self.reinstall_repositories()
-
     def message_from_error(self, exc: Exception) -> str:
         if not isinstance(exc, ApiError):
             return ERR_INTERNAL

--- a/src/sentry/integrations/github_enterprise/integration.py
+++ b/src/sentry/integrations/github_enterprise/integration.py
@@ -175,13 +175,6 @@ class GitHubEnterpriseIntegration(
     def search_issues(self, query):
         return self.get_client().search_issues(query)
 
-    def reinstall(self):
-        installation_id = self.model.external_id.split(":")[1]
-        metadata = self.model.metadata
-        metadata["installation_id"] = installation_id
-        self.model.update(metadata=metadata)
-        self.reinstall_repositories()
-
     def message_from_error(self, exc):
         if isinstance(exc, ApiError):
             message = API_ERRORS.get(exc.code)

--- a/src/sentry/integrations/mixins/repositories.py
+++ b/src/sentry/integrations/mixins/repositories.py
@@ -6,8 +6,7 @@ from typing import Any
 import sentry_sdk
 
 from sentry.auth.exceptions import IdentityNotValid
-from sentry.integrations.services.integration import integration_service
-from sentry.integrations.services.repository import RpcRepository, repository_service
+from sentry.integrations.services.repository import RpcRepository
 from sentry.models.identity import Identity
 from sentry.models.repository import Repository
 from sentry.shared_integrations.exceptions import ApiError, IntegrationError
@@ -118,17 +117,6 @@ class RepositoryMixin:
         the external service is concerned.
         """
         return []
-
-    def reinstall_repositories(self) -> None:
-        """Reinstalls repositories associated with the integration."""
-        result = integration_service.organization_contexts(integration_id=self.model.id)
-
-        for install in result.organization_integrations:
-            repository_service.reinstall_repositories_for_integration(
-                organization_id=install.organization_id,
-                integration_id=self.model.id,
-                provider=f"integrations:{self.model.provider}",
-            )
 
     def has_repo_access(self, repo: RpcRepository) -> bool:
         raise NotImplementedError

--- a/src/sentry/integrations/vsts/integration.py
+++ b/src/sentry/integrations/vsts/integration.py
@@ -128,9 +128,6 @@ class VstsIntegration(IntegrationInstallation, RepositoryMixin, VstsIssueSync):
         self.org_integration: RpcOrganizationIntegration | None
         self.default_identity: RpcIdentity | None = None
 
-    def reinstall(self) -> None:
-        self.reinstall_repositories()
-
     def all_repos_migrated(self) -> bool:
         return not self.get_unmigratable_repositories()
 


### PR DESCRIPTION
The `reinstall` function is never called, and the `reinstall_repositories` function is only used in `reinstall`.

In the next PR I will remove the functions from `repository_service`.