### PR TITLE
Fix issue where `rules_to_fire` is not defined

### DIFF
--- a/src/sentry/rules/processing/delayed_processing.py
+++ b/src/sentry/rules/processing/delayed_processing.py
@@ -528,6 +528,7 @@ def apply_delayed(project_id: int, *args: Any, **kwargs: Any) -> None:
     for rule in alert_rules:
         rules_to_slow_conditions[rule].extend(get_slow_conditions(rule))
 
+    rules_to_fire = defaultdict(set)
     if condition_group_results:
         rules_to_fire = get_rules_to_fire(
             condition_group_results, rules_to_slow_conditions, rules_to_groups, project.id


### PR DESCRIPTION
# Description
Create a defaultdict for rules_to_fire to fix [SENTRY-3CVB](https://sentry.sentry.io/issues/5658441415/events/49852dd24100492aa24575ffc11c1320/?project=1)