### PR TITLE
feat(custom-views): Add delete, duplicate, add view, save, and temp menu functionality

### DIFF
--- a/static/app/components/draggableTabs/draggableTabList.tsx
+++ b/static/app/components/draggableTabs/draggableTabList.tsx
@@ -16,10 +16,7 @@ import {type BaseTabProps, Tab} from 'sentry/components/tabs/tab';
 import {OverflowMenu, useOverflowTabs} from 'sentry/components/tabs/tabList';
 import {tabsShouldForwardProp} from 'sentry/components/tabs/utils';
 import {IconAdd} from 'sentry/icons';
-<<<<<<< HEAD
 import {t} from 'sentry/locale';
-=======
->>>>>>> f53cf6106a0 (Add new add view button and temporary tab designs)
 import {space} from 'sentry/styles/space';
 import {browserHistory} from 'sentry/utils/browserHistory';
 
@@ -159,11 +156,7 @@ function BaseDraggableTabList({
           ))}
           <AddViewButton borderless size="zero" onClick={onAddView}>
             <StyledIconAdd size="xs" />
-<<<<<<< HEAD
             {t('Add View')}
-=======
-            Add View
->>>>>>> f53cf6106a0 (Add new add view button and temporary tab designs)
           </AddViewButton>
           <TabDivider />
           {showTempTab && tempTab && (

--- a/static/app/components/draggableTabs/draggableTabList.tsx
+++ b/static/app/components/draggableTabs/draggableTabList.tsx
@@ -16,7 +16,10 @@ import {type BaseTabProps, Tab} from 'sentry/components/tabs/tab';
 import {OverflowMenu, useOverflowTabs} from 'sentry/components/tabs/tabList';
 import {tabsShouldForwardProp} from 'sentry/components/tabs/utils';
 import {IconAdd} from 'sentry/icons';
+<<<<<<< HEAD
 import {t} from 'sentry/locale';
+=======
+>>>>>>> f53cf6106a0 (Add new add view button and temporary tab designs)
 import {space} from 'sentry/styles/space';
 import {browserHistory} from 'sentry/utils/browserHistory';
 
@@ -156,7 +159,11 @@ function BaseDraggableTabList({
           ))}
           <AddViewButton borderless size="zero" onClick={onAddView}>
             <StyledIconAdd size="xs" />
+<<<<<<< HEAD
             {t('Add View')}
+=======
+            Add View
+>>>>>>> f53cf6106a0 (Add new add view button and temporary tab designs)
           </AddViewButton>
           <TabDivider />
           {showTempTab && tempTab && (

--- a/static/app/components/draggableTabs/index.stories.tsx
+++ b/static/app/components/draggableTabs/index.stories.tsx
@@ -1,6 +1,8 @@
 import {Fragment, useState} from 'react';
 import styled from '@emotion/styled';
 
+import Alert from 'sentry/components/alert';
+import {Button} from 'sentry/components/button';
 import JSXNode from 'sentry/components/stories/jsxNode';
 import SizingWindow from 'sentry/components/stories/sizingWindow';
 import storyBook from 'sentry/stories/storyBook';
@@ -11,36 +13,49 @@ const TabPanelContainer = styled('div')`
   height: 250px;
   background-color: white;
 `;
+const TABS: Tab[] = [
+  {
+    key: 'one',
+    label: 'Inbox',
+    content: <TabPanelContainer>This is the Inbox view</TabPanelContainer>,
+    queryCount: 1001,
+    hasUnsavedChanges: true,
+  },
+  {
+    key: 'two',
+    label: 'For Review',
+    content: <TabPanelContainer>This is the For Review view</TabPanelContainer>,
+    queryCount: 50,
+    hasUnsavedChanges: false,
+  },
+  {
+    key: 'three',
+    label: 'Regressed',
+    content: <TabPanelContainer>This is the Regressed view</TabPanelContainer>,
+    queryCount: 100,
+    hasUnsavedChanges: false,
+  },
+];
 
 export default storyBook(DraggableTabBar, story => {
-  const TABS: Tab[] = [
-    {
-      key: 'one',
-      label: 'Inbox',
-      content: <TabPanelContainer>This is the Inbox view</TabPanelContainer>,
-      queryCount: 1001,
-      hasUnsavedChanges: true,
-    },
-    {
-      key: 'two',
-      label: 'For Review',
-      content: <TabPanelContainer>This is the For Review view</TabPanelContainer>,
-      queryCount: 50,
-      hasUnsavedChanges: false,
-    },
-    {
-      key: 'three',
-      label: 'Regressed',
-      content: <TabPanelContainer>This is the Regressed view</TabPanelContainer>,
-      queryCount: 100,
-      hasUnsavedChanges: false,
-    },
-  ];
-
   story('Default', () => {
     const [showTempTab, setShowTempTab] = useState(false);
+    const [tabs, setTabs] = useState(TABS);
+
+    const tempTab = {
+      key: 'temporary-tab',
+      label: 'Unsaved',
+      content: <TabPanelContainer>This is the Temporary view</TabPanelContainer>,
+    };
+    const defaultNewTab = {
+      key: `view-${tabs.length + 1}`,
+      label: `New View`,
+      content: <TabPanelContainer>This is the a New View</TabPanelContainer>,
+    };
+
     return (
       <Fragment>
+        <Alert type="warning">This component is still a work in progress.</Alert>
         <p>
           You should be using all of <JSXNode name="Tabs" />, <JSXNode name="TabList" />,{' '}
           <JSXNode name="TabList.Item" />, <JSXNode name="DroppableTabPanels" /> and
@@ -50,18 +65,23 @@ export default storyBook(DraggableTabBar, story => {
           This will give you all kinds of accessibility and state tracking out of the box.
           But you will have to render all tab content, including hooks, upfront.
         </p>
-        <SizingWindow>
+        <SizingWindow style={{flexDirection: 'column', alignItems: 'flex-start'}}>
+          <StyledButton onClick={() => setShowTempTab(!showTempTab)}>
+            Toggle Temporary View
+          </StyledButton>
           <TabBarContainer>
             <DraggableTabBar
-              tabs={TABS}
+              tabs={tabs}
+              setTabs={setTabs}
               showTempTab={showTempTab}
               tempTabContent={
                 <TabPanelContainer>This is a Temporary view</TabPanelContainer>
               }
-              // The add view button should NOT toggle the temp tab normally.
-              // This is a very temporary way to show off the temp tab design to PR reviewers,
-              // and it will be removed in the very near future
-              onAddView={() => setShowTempTab(!showTempTab)}
+              defaultNewTab={defaultNewTab}
+              tempTab={tempTab}
+              onDiscardTempView={() => {
+                setShowTempTab(false);
+              }}
             />
           </TabBarContainer>
         </SizingWindow>
@@ -69,6 +89,11 @@ export default storyBook(DraggableTabBar, story => {
     );
   });
 });
+
+const StyledButton = styled(Button)`
+  justify-content: start;
+  margin-bottom: 5px;
+`;
 
 const TabBarContainer = styled('div')`
   display: flex;


### PR DESCRIPTION
closes #73339
closes #73225
closes #73229
closes #73228

This PR implements default functionality for the save changes, discard changes, duplicate, delete, add view, and discard/save temp view functionality. This does **not** include the calls made to the api, nor the debouncing logic that is planned to be included. 

Rename is the only option that has not been implemented in this PR, since that one is the most complex and requires design work. It will be coming in the subsequent PR. 