### PR TITLE
chore(issue-priority): Split up priority GA changes to use a permanent flag

### DIFF
--- a/src/sentry/features/permanent.py
+++ b/src/sentry/features/permanent.py
@@ -109,6 +109,8 @@ def register_permanent_features(manager: FeatureManager):
         "organizations:org-ingest-subdomains": False,
         # Replace the footer Sentry logo with a Sentry pride logo
         "organizations:sentry-pride-logo-footer": False,
+        # Enable priority calculations using Seer's severity endpoint
+        "organizations:seer-based-priority": False,
     }
 
     permanent_project_features = {

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -365,8 +365,8 @@ def register_temporary_features(manager: FeatureManager):
     manager.add("organizations:scim-team-roles", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable detecting SDK crashes during event processing
     manager.add("organizations:sdk-crash-detection", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, api_expose=False)
-    # Enable priority alerts using the Seer calculations. This flag will move to a permanent flag before we release.
-    manager.add("organizations:seer-based-priority", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+    # Enable the GA features for priority alerts
+    manager.add("organizations:priority-ga-features", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable the Replay Details > Accessibility tab
     manager.add("organizations:session-replay-a11y-tab", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable the accessibility issues endpoint

--- a/src/sentry/receivers/rules.py
+++ b/src/sentry/receivers/rules.py
@@ -45,7 +45,7 @@ PLATFORMS_WITH_PRIORITY_ALERTS = ["python", "javascript"]
 def has_high_priority_issue_alerts(project: Project) -> bool:
     # Seer-based priority is enabled if the organization has the feature flag
     seer_based_priority_enabled = features.has(
-        "organizations:seer-based-priority", project.organization
+        "organizations:priority-ga-features", project.organization
     )
     if seer_based_priority_enabled:
         return True


### PR DESCRIPTION
The `organizations:seer-based-priority` flag was previously used to gate all changes related to priority GA. This change introduces a new flag, `organizations:priority-ga-features` which gates the GA feature set that is intended to be released to all customers. `organizations:seer-based-priority` will be converted to a permanent flag to control whether Seer's severity service should be involved in the priority calculations.

Fixes https://github.com/getsentry/sentry/issues/74756