### PR TITLE
chore(issue-priority): Switch feature flags for default alerts

### DIFF
--- a/static/app/views/alerts/rules/issue/index.tsx
+++ b/static/app/views/alerts/rules/issue/index.tsx
@@ -323,7 +323,7 @@ class IssueRuleEditor extends DeprecatedAsyncView<Props, State> {
       // now that we've loaded all the possible conditions, we can populate the
       // value of conditions for a new alert
       const hasSeerBasedPriority =
-        this.props.organization.features.includes('seer-based-priority');
+        this.props.organization.features.includes('priority-ga-features');
       const hasHighPriorityIssueAlerts =
         this.props.organization.features.includes('default-high-priority-alerts') ||
         this.props.project.features.includes('high-priority-alerts');

--- a/static/app/views/projectInstall/issueAlertOptions.tsx
+++ b/static/app/views/projectInstall/issueAlertOptions.tsx
@@ -193,7 +193,7 @@ class IssueAlertOptions extends DeprecatedAsyncComponent<Props, State> {
   }
 
   shouldUseNewDefaultSetting(): boolean {
-    if (this.props.organization.features.includes('seer-based-priority')) {
+    if (this.props.organization.features.includes('priority-ga-features')) {
       return true;
     }
 


### PR DESCRIPTION
https://github.com/getsentry/sentry/pull/75297 adds `organizations:priority-ga-features`, which gates the GA feature set that is intended to be released to all customers. Switching the flag from `organizations:seer-based-priority` to `organizations:priority-ga-features` to release these features as intended.