### PR TITLE
chore(types) Improve types for File classes

### DIFF
--- a/src/sentry/models/files/abstractfile.py
+++ b/src/sentry/models/files/abstractfile.py
@@ -1,14 +1,15 @@
 from __future__ import annotations
 
-import builtins
+import abc
 import io
 import logging
 import mmap
 import os
 import tempfile
+from collections.abc import Sequence
 from concurrent.futures import ThreadPoolExecutor
 from hashlib import sha1
-from typing import Any, ClassVar
+from typing import TYPE_CHECKING, Any, Generic, TypeVar
 
 import sentry_sdk
 from django.core.files.base import ContentFile
@@ -23,7 +24,6 @@ from sentry.models.files.abstractfileblob import AbstractFileBlob
 from sentry.models.files.abstractfileblobindex import AbstractFileBlobIndex
 from sentry.models.files.utils import DEFAULT_BLOB_SIZE, AssembleChecksumMismatch, nooplogger
 from sentry.utils import metrics
-from sentry.utils.db import atomic_transaction
 
 logger = logging.getLogger(__name__)
 
@@ -197,7 +197,23 @@ class ChunkedFileBlobIndexWrapper:
         return bytes(result)
 
 
-class AbstractFile(Model):
+BlobIndexType = TypeVar("BlobIndexType", bound=AbstractFileBlobIndex)
+BlobType = TypeVar("BlobType", bound=AbstractFileBlob)
+
+if TYPE_CHECKING:
+    # Django doesn't permit models to have parent classes that are Generic
+    # this kludge lets satisfy both mypy and django
+    class _Parent(Generic[BlobIndexType, BlobType]):
+        ...
+
+else:
+
+    class _Parent:
+        def __class_getitem__(cls, _):
+            return cls
+
+
+class AbstractFile(Model, _Parent[BlobIndexType, BlobType]):
     __relocation_scope__ = RelocationScope.Excluded
 
     name = models.TextField()
@@ -210,19 +226,31 @@ class AbstractFile(Model):
     class Meta:
         abstract = True
 
-    # abstract
-    # XXX: uses `builtins.type` to avoid clash with `type` local
-    FILE_BLOB_MODEL: ClassVar[builtins.type[AbstractFileBlob]]
-    FILE_BLOB_INDEX_MODEL: ClassVar[builtins.type[AbstractFileBlobIndex]]
-    DELETE_UNREFERENCED_BLOB_TASK: ClassVar[SentryTask]
     blobs: models.ManyToManyField
+
+    @abc.abstractmethod
+    def _blob_index_records(self) -> Sequence[BlobIndexType]:
+        ...
+
+    @abc.abstractmethod
+    def _create_blob_index(self, blob: BlobType, offset: int) -> BlobIndexType:
+        ...
+
+    @abc.abstractmethod
+    def _create_blob_from_file(self, contents: ContentFile, logger: Any) -> BlobType:
+        ...
+
+    @abc.abstractmethod
+    def _get_blobs_by_id(self, blob_ids: Sequence[int]) -> models.QuerySet[BlobType]:
+        ...
+
+    @abc.abstractmethod
+    def _delete_unreferenced_blob_task(self) -> SentryTask:
+        ...
 
     def _get_chunked_blob(self, mode=None, prefetch=False, prefetch_to=None, delete=True):
         return ChunkedFileBlobIndexWrapper(
-            # TODO: file blob inheritance hierarchy is unsound
-            self.FILE_BLOB_INDEX_MODEL.objects.filter(file=self)  # type: ignore[misc]
-            .select_related("blob")
-            .order_by("offset"),
+            self._blob_index_records(),
             mode=mode,
             prefetch=prefetch,
             prefetch_to=prefetch_to,
@@ -294,11 +322,8 @@ class AbstractFile(Model):
             checksum.update(contents)
 
             blob_fileobj = ContentFile(contents)
-            blob = self.FILE_BLOB_MODEL.from_file(blob_fileobj, logger=logger)
-            results.append(
-                # TODO: file blob inheritance hierarchy is unsound
-                self.FILE_BLOB_INDEX_MODEL.objects.create(file=self, blob=blob, offset=offset)  # type: ignore[misc]
-            )
+            blob = self._create_blob_from_file(blob_fileobj, logger=logger)
+            results.append(self._create_blob_index(blob=blob, offset=offset))
             offset += blob.size
         self.size = offset
         self.checksum = checksum.hexdigest()
@@ -314,14 +339,12 @@ class AbstractFile(Model):
         contents.
         """
         tf = tempfile.NamedTemporaryFile()
-        with atomic_transaction(
-            using=(
-                router.db_for_write(self.FILE_BLOB_MODEL),
-                router.db_for_write(self.FILE_BLOB_INDEX_MODEL),
-            )
-        ):
+
+        # All file tables are on the same connection and this lets us
+        # bypass generics
+        with transaction.atomic(using=router.db_for_write(type(self))):
             try:
-                file_blobs_qs = self.FILE_BLOB_MODEL.objects.filter(id__in=file_blob_ids).all()
+                file_blobs_qs = self._get_blobs_by_id(blob_ids=file_blob_ids)
 
                 # Ensure blobs are in the order and duplication as provided
                 blobs_by_id = {blob.id: blob for blob in file_blobs_qs}
@@ -336,8 +359,7 @@ class AbstractFile(Model):
             offset = 0
             for blob in file_blobs:
                 try:
-                    # TODO: file blob inheritance hierarchy is unsound
-                    self.FILE_BLOB_INDEX_MODEL.objects.create(file=self, blob=blob, offset=offset)  # type: ignore[misc]
+                    self._create_blob_index(blob=blob, offset=offset)
                 except IntegrityError:
                     # Most likely a `ForeignKeyViolation` like `SENTRY-11P5`, because
                     # the blob we want to link does not exist anymore
@@ -372,7 +394,7 @@ class AbstractFile(Model):
         # Wait to delete blobs. This helps prevent
         # races around frequently used blobs in debug images and release files.
         transaction.on_commit(
-            lambda: self.DELETE_UNREFERENCED_BLOB_TASK.apply_async(
+            lambda: self._delete_unreferenced_blob_task().apply_async(
                 kwargs={"blob_ids": blob_ids}, countdown=60 * 5
             ),
             using=router.db_for_write(type(self)),

--- a/src/sentry/models/files/control_file.py
+++ b/src/sentry/models/files/control_file.py
@@ -1,5 +1,10 @@
+from collections.abc import Sequence
+from typing import Any
+
+from django.core.files.base import ContentFile
 from django.db import models
 
+from sentry.celery import SentryTask
 from sentry.db.models.base import control_silo_model
 from sentry.models.files.abstractfile import AbstractFile
 from sentry.models.files.control_fileblob import ControlFileBlob
@@ -8,7 +13,7 @@ from sentry.tasks.files import delete_unreferenced_blobs_control
 
 
 @control_silo_model
-class ControlFile(AbstractFile):
+class ControlFile(AbstractFile[ControlFileBlobIndex, ControlFileBlob]):
     blobs = models.ManyToManyField("sentry.ControlFileBlob", through="sentry.ControlFileBlobIndex")
     # Looking for the "blob" FK or the path attribute? These are deprecated and unavailable in the control silo
 
@@ -19,3 +24,20 @@ class ControlFile(AbstractFile):
     FILE_BLOB_MODEL = ControlFileBlob
     FILE_BLOB_INDEX_MODEL = ControlFileBlobIndex
     DELETE_UNREFERENCED_BLOB_TASK = delete_unreferenced_blobs_control
+
+    def _blob_index_records(self) -> Sequence[ControlFileBlobIndex]:
+        return list(
+            ControlFileBlobIndex.objects.filter(file=self).select_related("blob").order_by("offset")
+        )
+
+    def _create_blob_index(self, blob: ControlFileBlob, offset: int) -> ControlFileBlobIndex:
+        return ControlFileBlobIndex.objects.create(file=self, blob=blob, offset=offset)
+
+    def _create_blob_from_file(self, contents: ContentFile, logger: Any) -> ControlFileBlob:
+        return ControlFileBlob.from_file(contents, logger)
+
+    def _get_blobs_by_id(self, blob_ids: Sequence[int]) -> models.QuerySet[ControlFileBlob]:
+        return ControlFileBlob.objects.filter(id__in=blob_ids).all()
+
+    def _delete_unreferenced_blob_task(self) -> SentryTask:
+        return delete_unreferenced_blobs_control

--- a/src/sentry/models/files/file.py
+++ b/src/sentry/models/files/file.py
@@ -1,5 +1,10 @@
+from collections.abc import Sequence
+from typing import Any
+
+from django.core.files.base import ContentFile
 from django.db import models
 
+from sentry.celery import SentryTask
 from sentry.db.models import FlexibleForeignKey
 from sentry.db.models.base import region_silo_model
 from sentry.models.files.abstractfile import AbstractFile
@@ -9,9 +14,10 @@ from sentry.tasks.files import delete_unreferenced_blobs_region
 
 
 @region_silo_model
-class File(AbstractFile):
+class File(AbstractFile[FileBlobIndex, FileBlob]):
 
     blobs = models.ManyToManyField("sentry.FileBlob", through="sentry.FileBlobIndex")
+
     # <Legacy fields>
     # Remove in 8.1
     blob = FlexibleForeignKey("sentry.FileBlob", null=True, related_name="legacy_blob")
@@ -22,6 +28,19 @@ class File(AbstractFile):
         app_label = "sentry"
         db_table = "sentry_file"
 
-    FILE_BLOB_MODEL = FileBlob
-    FILE_BLOB_INDEX_MODEL = FileBlobIndex
-    DELETE_UNREFERENCED_BLOB_TASK = delete_unreferenced_blobs_region
+    def _blob_index_records(self) -> Sequence[FileBlobIndex]:
+        return list(
+            FileBlobIndex.objects.filter(file=self).select_related("blob").order_by("offset")
+        )
+
+    def _create_blob_index(self, blob: FileBlob, offset: int) -> FileBlobIndex:
+        return FileBlobIndex.objects.create(file=self, blob=blob, offset=offset)
+
+    def _create_blob_from_file(self, contents: ContentFile, logger: Any) -> FileBlob:
+        return FileBlob.from_file(contents, logger)
+
+    def _get_blobs_by_id(self, blob_ids: Sequence[int]) -> models.QuerySet[FileBlob]:
+        return FileBlob.objects.filter(id__in=blob_ids).all()
+
+    def _delete_unreferenced_blob_task(self) -> SentryTask:
+        return delete_unreferenced_blobs_region

--- a/src/sentry/models/files/fileblob.py
+++ b/src/sentry/models/files/fileblob.py
@@ -1,3 +1,4 @@
+from sentry.celery import SentryTask
 from sentry.db.models import region_silo_model
 from sentry.models.files.abstractfileblob import AbstractFileBlob
 from sentry.models.files.fileblobowner import FileBlobOwner
@@ -5,14 +6,17 @@ from sentry.tasks.files import delete_file_region
 
 
 @region_silo_model
-class FileBlob(AbstractFileBlob):
+class FileBlob(AbstractFileBlob[FileBlobOwner]):
     class Meta:
         app_label = "sentry"
         db_table = "sentry_fileblob"
 
-    FILE_BLOB_OWNER_MODEL = FileBlobOwner
-    DELETE_FILE_TASK = delete_file_region
-
     @classmethod
     def _storage_config(cls):
         return None  # Rely on get_storage defaults
+
+    def _create_blob_owner(self, organization_id: int) -> FileBlobOwner:
+        return FileBlobOwner.objects.create(organization_id=organization_id, blob=self)
+
+    def _delete_file_task(self) -> SentryTask:
+        return delete_file_region


### PR DESCRIPTION
The File classes were relying on unsound types. Extract the varying parts of the logic into abstract methods and use a Generic to tie relations together.

Django doesn't allow `Generic` to be a super class for ORM records, so I've used a `TYPE_CHECKING` guard. I also attempted a `Protocol` based solution but ran into compatibility issues with how it overlapped with Django.