### PR TITLE
Process delayed alert conditions in batches of 10,000

### DIFF
--- a/src/sentry/buffer/base.py
+++ b/src/sentry/buffer/base.py
@@ -58,7 +58,7 @@ class Buffer(Service):
     def get_hash_length(
         self, model: type[models.Model], field: dict[str, models.Model | str | int]
     ) -> int:
-        return 0
+        raise NotImplementedError
 
     def get_sorted_set(self, key: str, min: float, max: float) -> list[tuple[int, datetime]]:
         return []

--- a/src/sentry/buffer/base.py
+++ b/src/sentry/buffer/base.py
@@ -75,6 +75,14 @@ class Buffer(Service):
     ) -> None:
         return None
 
+    def push_to_hash_bulk(
+        self,
+        model: type[models.Model],
+        filters: dict[str, models.Model | str | int],
+        data: dict[str, str],
+    ) -> None:
+        raise NotImplementedError
+
     def delete_hash(
         self,
         model: type[models.Model],

--- a/src/sentry/buffer/base.py
+++ b/src/sentry/buffer/base.py
@@ -34,6 +34,7 @@ class Buffer(Service):
         "push_to_hash",
         "get_sorted_set",
         "get_hash",
+        "get_hash_length",
         "delete_hash",
         "delete_key",
     )
@@ -53,6 +54,11 @@ class Buffer(Service):
         self, model: type[models.Model], field: dict[str, models.Model | str | int]
     ) -> dict[str, str]:
         return {}
+
+    def get_hash_length(
+        self, model: type[models.Model], field: dict[str, models.Model | str | int]
+    ) -> int:
+        return 0
 
     def get_sorted_set(self, key: str, min: float, max: float) -> list[tuple[int, datetime]]:
         return []

--- a/src/sentry/buffer/redis.py
+++ b/src/sentry/buffer/redis.py
@@ -81,6 +81,7 @@ class BufferHookRegistry:
 redis_buffer_registry = BufferHookRegistry()
 
 
+# Note HMSET is not supported after redis 4.0.0, after updating we can use HSET directly.
 class RedisOperation(Enum):
     SORTED_SET_ADD = "zadd"
     SORTED_SET_GET_RANGE = "zrangebyscore"

--- a/src/sentry/buffer/redis.py
+++ b/src/sentry/buffer/redis.py
@@ -88,6 +88,7 @@ class RedisOperation(Enum):
     HASH_ADD = "hset"
     HASH_GET_ALL = "hgetall"
     HASH_DELETE = "hdel"
+    HASH_LENGTH = "hlen"
 
 
 class PendingBuffer:
@@ -310,6 +311,12 @@ class RedisBuffer(Buffer):
             decoded_hash[k] = v
 
         return decoded_hash
+
+    def get_hash_length(
+        self, model: type[models.Model], field: dict[str, models.Model | str | int]
+    ) -> int:
+        key = self._make_key(model, field)
+        return self._execute_redis_operation(key, RedisOperation.HASH_LENGTH)
 
     def process_batch(self) -> None:
         try:

--- a/src/sentry/buffer/redis.py
+++ b/src/sentry/buffer/redis.py
@@ -86,6 +86,7 @@ class RedisOperation(Enum):
     SORTED_SET_GET_RANGE = "zrangebyscore"
     SORTED_SET_DELETE_RANGE = "zremrangebyscore"
     HASH_ADD = "hset"
+    HASH_ADD_BULK = "hmset"
     HASH_GET_ALL = "hgetall"
     HASH_DELETE = "hdel"
     HASH_LENGTH = "hlen"
@@ -296,6 +297,15 @@ class RedisBuffer(Buffer):
     ) -> None:
         key = self._make_key(model, filters)
         self._execute_redis_operation(key, RedisOperation.HASH_ADD, field, value)
+
+    def push_to_hash_bulk(
+        self,
+        model: type[models.Model],
+        filters: dict[str, models.Model | str | int],
+        data: dict[str, str],
+    ) -> None:
+        key = self._make_key(model, filters)
+        self._execute_redis_operation(key, RedisOperation.HASH_ADD_BULK, data)
 
     def get_hash(
         self, model: type[models.Model], field: dict[str, models.Model | str | int]

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -2636,3 +2636,7 @@ register(
     default=1,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
+register(
+    "delayed_processing.batch_size",
+    default=10000,
+)

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -2639,4 +2639,5 @@ register(
 register(
     "delayed_processing.batch_size",
     default=10000,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
 )

--- a/src/sentry/rules/processing/delayed_processing.py
+++ b/src/sentry/rules/processing/delayed_processing.py
@@ -481,8 +481,9 @@ def process_rulegroups_in_batches(project_id: int):
     The batches are replicated into a new redis hash with a unique filter (a uuid) to identify the batch.
     We need to use a UUID because these batches can be created in multiple processes and we need to ensure
     uniqueness across all of them for the centralized redis buffer. The batches are stored in redis because
-    we shouldn't pass complex objects in the celery task arguments, and we can't send a page of data in the
-    batch becaues redis may not maintain the sort of the hash response.
+    we shouldn't pass objects that need to be pickled and 10k items could be problematic in the celery tasks
+    as arguments could be problematic. Finally, we can't use a pagination system on the data because
+    redis doesn't maintain the sort order of the hash keys.
 
     `apply_delayed` will fetch the batch from redis and process the rules.
     """

--- a/src/sentry/rules/processing/delayed_processing.py
+++ b/src/sentry/rules/processing/delayed_processing.py
@@ -549,7 +549,6 @@ def apply_delayed(project_id: int, batch_key: str | None = None, *args: Any, **k
     Grab rules, groups, and events from the Redis buffer, evaluate the "slow" conditions in a bulk snuba query, and fire them if they pass
     """
     project = fetch_project(project_id)
-
     if not project:
         return
 

--- a/src/sentry/rules/processing/delayed_processing.py
+++ b/src/sentry/rules/processing/delayed_processing.py
@@ -498,11 +498,7 @@ def process_rulegroups_in_batches(project_id: int, batch_size=CHUNK_BATCH_SIZE):
     with metrics.timer("delayed_processing.process_batch.duration"):
         items = iter(rulegroup_to_event_data.items())
 
-        while True:
-            batch = dict(islice(items, batch_size))
-            if not batch:
-                break
-
+        while batch := dict(islice(items, batch_size)):
             batch_key = str(uuid.uuid4())
 
             for field, value in batch.items():

--- a/src/sentry/rules/processing/delayed_processing.py
+++ b/src/sentry/rules/processing/delayed_processing.py
@@ -466,7 +466,9 @@ def bucket_num_groups(num_groups: int) -> str:
 
 
 def process_rulegroups_in_batches(project_id: int, batch_size=CHUNK_BATCH_SIZE):
+    # TODO REMOVE THIS
     rulegroup_to_event_data = fetch_rulegroup_to_event_data(project_id)
+
     event_count = buffer.backend.get_hash_length(Project, {"project_id": project_id})
 
     print("REHYDRAAATTE", batch_size, event_count, project_id, rulegroup_to_event_data)

--- a/src/sentry/rules/processing/delayed_processing.py
+++ b/src/sentry/rules/processing/delayed_processing.py
@@ -10,7 +10,7 @@ from typing import Any, DefaultDict, NamedTuple
 import sentry_sdk
 from django.db.models import OuterRef, Subquery
 
-from sentry import buffer, nodestore
+from sentry import buffer, nodestore, options
 from sentry.buffer.redis import BufferHookEvent, redis_buffer_registry
 from sentry.db import models
 from sentry.eventstore.models import Event, GroupEvent
@@ -47,7 +47,7 @@ from sentry.utils.safe import safe_execute
 logger = logging.getLogger("sentry.rules.delayed_processing")
 EVENT_LIMIT = 100
 COMPARISON_INTERVALS_VALUES = {k: v[1] for k, v in COMPARISON_INTERVALS.items()}
-CHUNK_BATCH_SIZE = 10000
+CHUNK_BATCH_SIZE = options.get("delayed_processing.batch_size")
 
 
 class UniqueConditionQuery(NamedTuple):

--- a/src/sentry/rules/processing/delayed_processing.py
+++ b/src/sentry/rules/processing/delayed_processing.py
@@ -485,7 +485,7 @@ def process_rulegroups_in_batches(project_id: int, batch_size=CHUNK_BATCH_SIZE):
     we shouldn't pass complex objects in the celery task arguments, and we can't send a page of data in the
     batch becaues redis may not maintain the sort of the hash response.
 
-    In `apply_delayed` will will fetch the batch from redis and process the rules.
+    `apply_delayed` will fetch the batch from redis and process the rules.
     """
     event_count = buffer.backend.get_hash_length(Project, {"project_id": project_id})
 

--- a/src/sentry/rules/processing/delayed_processing.py
+++ b/src/sentry/rules/processing/delayed_processing.py
@@ -492,6 +492,11 @@ def process_rulegroups_in_batches(project_id: int, batch_size=CHUNK_BATCH_SIZE):
     if event_count < batch_size:
         return apply_delayed.delayed(project_id)
 
+    logger.info(
+        "delayed_processing.process_large_batch",
+        extra={"project_id": project_id, "count": event_count},
+    )
+
     # if the dictionary is large, get the items and chunk them.
     rulegroup_to_event_data = fetch_rulegroup_to_event_data(project_id)
 
@@ -547,7 +552,7 @@ def apply_delayed(project_id: int, batch_key: str | None = None, *args: Any, **k
     """
     project = fetch_project(project_id)
 
-    if project is None:
+    if not project:
         return
 
     rulegroup_to_event_data = fetch_rulegroup_to_event_data(project_id, batch_key)

--- a/src/sentry/rules/processing/delayed_processing.py
+++ b/src/sentry/rules/processing/delayed_processing.py
@@ -506,13 +506,11 @@ def process_rulegroups_in_batches(project_id: int, batch_size=CHUNK_BATCH_SIZE):
         while batch := dict(islice(items, batch_size)):
             batch_key = str(uuid.uuid4())
 
-            for field, value in batch.items():
-                buffer.backend.push_to_hash(
-                    model=Project,
-                    filters={"project_id": project_id, "batch_key": batch_key},
-                    field=field,
-                    value=value,
-                )
+            buffer.backend.push_to_hash_bulk(
+                model=Project,
+                filters={"project_id": project_id, "batch_key": batch_key},
+                data=batch,
+            )
 
             # remove the batched items from the project rulegroup_to_event_data
             buffer.backend.delete_hash(

--- a/src/sentry/rules/processing/delayed_processing.py
+++ b/src/sentry/rules/processing/delayed_processing.py
@@ -47,7 +47,6 @@ from sentry.utils.safe import safe_execute
 logger = logging.getLogger("sentry.rules.delayed_processing")
 EVENT_LIMIT = 100
 COMPARISON_INTERVALS_VALUES = {k: v[1] for k, v in COMPARISON_INTERVALS.items()}
-CHUNK_BATCH_SIZE = options.get("delayed_processing.batch_size")
 
 
 class UniqueConditionQuery(NamedTuple):
@@ -473,7 +472,7 @@ def bucket_num_groups(num_groups: int) -> str:
     return "1"
 
 
-def process_rulegroups_in_batches(project_id: int, batch_size=CHUNK_BATCH_SIZE):
+def process_rulegroups_in_batches(project_id: int):
     """
     This will check the number of rulegroup_to_event_data items in the Redis buffer for a project.
 
@@ -487,6 +486,7 @@ def process_rulegroups_in_batches(project_id: int, batch_size=CHUNK_BATCH_SIZE):
 
     `apply_delayed` will fetch the batch from redis and process the rules.
     """
+    batch_size = options.get("delayed_processing.batch_size")
     event_count = buffer.backend.get_hash_length(Project, {"project_id": project_id})
 
     if event_count < batch_size:

--- a/tests/sentry/buffer/test_base.py
+++ b/tests/sentry/buffer/test_base.py
@@ -2,6 +2,7 @@ from datetime import timedelta
 from unittest import mock
 
 from django.utils import timezone
+from pytest import raises
 
 from sentry.buffer.base import Buffer
 from sentry.db import models
@@ -77,3 +78,9 @@ class BufferTest(TestCase):
         self.buf.process(Group, columns, filters, {"last_seen": the_date}, signal_only=True)
         group.refresh_from_db()
         assert group.times_seen == prev_times_seen
+
+    def test_push_to_hash_bulk(self):
+        raises(NotImplementedError, self.buf.push_to_hash_bulk, Group, {"id": 1}, {"foo": "bar"})
+
+    def test_get_hash_length(self):
+        raises(NotImplementedError, self.buf.get_hash_length, Group, {"id": 1})

--- a/tests/sentry/buffer/test_redis.py
+++ b/tests/sentry/buffer/test_redis.py
@@ -1,6 +1,7 @@
 import datetime
 import pickle
 from collections import defaultdict
+from collections.abc import Mapping
 from unittest import mock
 from unittest.mock import Mock
 
@@ -366,6 +367,36 @@ class TestRedisBuffer:
         )
         self.buf.process("foo")
         process.assert_called_once_with(mock.Mock, {"times_seen": 1}, {"pk": 1}, {}, True)
+
+    @mock.patch("sentry.buffer.redis.RedisBuffer._make_key", mock.Mock(return_value="foo"))
+    def test_get_hash_length(self):
+        client = get_cluster_routing_client(self.buf.cluster, self.buf.is_redis_cluster)
+        data: Mapping[str | bytes, bytes | float | int | str] = {
+            "f": '{"pk": ["i","1"]}',
+            "i+times_seen": "1",
+            "m": "unittest.mock.Mock",
+            "s": "1",
+        }
+
+        client.hmset("foo", data)
+        buffer_length = self.buf.get_hash_length("foo", field={"bar": 1})
+        assert buffer_length == len(data)
+
+    @mock.patch("sentry.buffer.redis.RedisBuffer._make_key", mock.Mock(return_value="foo"))
+    def test_push_to_hash_bulk(self):
+        def decode_dict(d):
+            return {k: v.decode("utf-8") if isinstance(v, bytes) else v for k, v in d.items()}
+
+        client = get_cluster_routing_client(self.buf.cluster, self.buf.is_redis_cluster)
+        data = {
+            "f": '{"pk": ["i","1"]}',
+            "i+times_seen": "1",
+            "m": "unittest.mock.Mock",
+            "s": "1",
+        }
+        self.buf.push_to_hash_bulk(model=Project, filters={"project_id": 1}, data=data)
+        result = _hgetall_decode_keys(client, "foo", self.buf.is_redis_cluster)
+        assert decode_dict(result) == data
 
 
 #    @mock.patch("sentry.buffer.redis.RedisBuffer._make_key", mock.Mock(return_value="foo"))

--- a/tests/sentry/rules/processing/test_delayed_processing.py
+++ b/tests/sentry/rules/processing/test_delayed_processing.py
@@ -40,6 +40,7 @@ from sentry.rules.processing.processor import PROJECT_ID_BUFFER_LIST_KEY
 from sentry.testutils.cases import PerformanceIssueTestCase, RuleTestCase, TestCase
 from sentry.testutils.factories import EventType
 from sentry.testutils.helpers.datetime import before_now, freeze_time, iso_format
+from sentry.testutils.helpers.options import override_options
 from sentry.testutils.helpers.redis import mock_redis_buffer
 from sentry.utils import json
 from sentry.utils.safe import safe_execute
@@ -1360,6 +1361,7 @@ class ProcessRuleGroupsInBatchesTest(CreateEventTestCase):
         process_rulegroups_in_batches(self.project.id)
         mock_delayed.assert_called_once_with(self.project.id)
 
+    @override_options({"delayed_processing.batch_size": 2})
     @patch("sentry.rules.processing.delayed_processing.apply_delayed")
     def test_batch(self, mock_apply_delayed):
         mock_delayed = Mock()
@@ -1369,7 +1371,7 @@ class ProcessRuleGroupsInBatchesTest(CreateEventTestCase):
         self.push_to_hash(self.project.id, self.rule.id, self.group_two.id)
         self.push_to_hash(self.project.id, self.rule.id, self.group_three.id)
 
-        process_rulegroups_in_batches(self.project.id, batch_size=2)
+        process_rulegroups_in_batches(self.project.id)
         assert mock_delayed.call_count == 2
 
         # Validate the batches are created correctly

--- a/tests/sentry/rules/processing/test_delayed_processing.py
+++ b/tests/sentry/rules/processing/test_delayed_processing.py
@@ -25,6 +25,7 @@ from sentry.rules.processing.delayed_processing import (
     apply_delayed,
     bucket_num_groups,
     bulk_fetch_events,
+    cleanup_redis_buffer,
     generate_unique_queries,
     get_condition_group_results,
     get_condition_query_groups,
@@ -1417,3 +1418,62 @@ class DataAndGroupsTest(TestCase):
             repr(condition)
             == "<DataAndGroups data: {'id': 'sentry.rules.conditions.event_frequency.EventFrequencyCondition', 'value': 1, 'interval': '1h'} group_ids: {1, 2}>"
         )
+
+
+class CleanupRedisBufferTest(CreateEventTestCase):
+    def setUp(self):
+        super().setUp()
+
+        self.project = self.create_project()
+        self.group = self.create_group(self.project)
+        self.rule = self.create_alert_rule()
+
+    def test_cleanup_redis(self):
+        self.push_to_hash(self.project.id, self.rule.id, self.group.id)
+        rules_to_groups: defaultdict[int, set[int]] = defaultdict(set)
+        rules_to_groups[self.rule.id].add(self.group.id)
+
+        cleanup_redis_buffer(self.project.id, rules_to_groups, None)
+        rule_group_data = buffer.backend.get_hash(Project, {"project_id": self.project.id})
+        assert rule_group_data == {}
+
+    @override_options({"delayed_processing.batch_size": 2})
+    @patch("sentry.rules.processing.delayed_processing.apply_delayed")
+    def test_batched_cleanup(self, mock_apply_delayed):
+        mock_delayed = Mock()
+        mock_apply_delayed.delayed = mock_delayed
+        group_two = self.create_group(self.project)
+        group_three = self.create_group(self.project)
+
+        self.push_to_hash(self.project.id, self.rule.id, self.group.id)
+        self.push_to_hash(self.project.id, self.rule.id, group_two.id)
+        self.push_to_hash(self.project.id, self.rule.id, group_three.id)
+
+        rules_to_groups: defaultdict[int, set[int]] = defaultdict(set)
+        rules_to_groups[self.rule.id].add(self.group.id)
+        rules_to_groups[self.rule.id].add(group_two.id)
+        rules_to_groups[self.rule.id].add(group_three.id)
+
+        process_rulegroups_in_batches(self.project.id)
+        batch_one_key = mock_delayed.call_args_list[0][0][1]
+        batch_two_key = mock_delayed.call_args_list[1][0][1]
+
+        # Verify process_rulegroups_in_batches removed the data from the buffer
+        rule_group_data = buffer.backend.get_hash(Project, {"project_id": self.project.id})
+        assert rule_group_data == {}
+
+        cleanup_redis_buffer(self.project.id, rules_to_groups, batch_one_key)
+
+        # Verify the batch we "executed" is removed
+        rule_group_data = buffer.backend.get_hash(
+            Project, {"project_id": self.project.id, "batch_key": batch_one_key}
+        )
+        assert rule_group_data == {}
+
+        # Verify the batch we didn't execute is still in redis
+        rule_group_data = buffer.backend.get_hash(
+            Project, {"project_id": self.project.id, "batch_key": batch_two_key}
+        )
+        assert rule_group_data == {
+            f"{self.rule.id}:{group_three.id}": '{"event_id":null,"occurrence_id":null}',
+        }

--- a/tests/sentry/rules/processing/test_delayed_processing.py
+++ b/tests/sentry/rules/processing/test_delayed_processing.py
@@ -750,8 +750,8 @@ class ProcessDelayedAlertConditionsTest(CreateEventTestCase, PerformanceIssueTes
     def tearDown(self):
         self.mock_redis_buffer.__exit__(None, None, None)
 
-    @patch("sentry.rules.processing.delayed_processing.apply_delayed")
-    def test_fetches_from_buffer_and_executes(self, mock_apply_delayed):
+    @patch("sentry.rules.processing.delayed_processing.process_rulegroups_in_batches")
+    def test_fetches_from_buffer_and_executes(self, mock_process_in_batches):
         self._push_base_events()
         # To get the correct mapping, we need to return the correct
         # rulegroup_event mapping based on the project_id input
@@ -761,7 +761,7 @@ class ProcessDelayedAlertConditionsTest(CreateEventTestCase, PerformanceIssueTes
             (self.project, self.rulegroup_event_mapping_one),
             (self.project_two, self.rulegroup_event_mapping_two),
         ):
-            assert mock_apply_delayed.delay.call_count == 2
+            assert mock_process_in_batches.call_count == 2
 
         project_ids = buffer.backend.get_sorted_set(
             PROJECT_ID_BUFFER_LIST_KEY, 0, self.buffer_timestamp
@@ -1324,6 +1324,20 @@ class ProcessDelayedAlertConditionsTest(CreateEventTestCase, PerformanceIssueTes
         ):
             apply_delayed(project_id)
         self._assert_count_percent_results(safe_execute_callthrough)
+
+    def test_process_in_batches(self):
+        # TODO fill this in
+        pass
+
+
+class ProcessRuleGroupsInBatchesTest(TestCase):
+    def test_basic(self):
+        # TODO write tests for processin in batches
+        pass
+
+    # todo test for no batches
+    # todo test for multiple batches
+    # verify state of redis buffers
 
 
 class UniqueConditionQueryTest(TestCase):

--- a/tests/sentry/rules/processing/test_delayed_processing.py
+++ b/tests/sentry/rules/processing/test_delayed_processing.py
@@ -1344,30 +1344,22 @@ class ProcessRuleGroupsInBatchesTest(CreateEventTestCase):
 
     @patch("sentry.rules.processing.delayed_processing.apply_delayed")
     def test_no_redis_data(self, mock_apply_delayed):
-        mock_delayed = Mock()
-        mock_apply_delayed.delayed = mock_delayed
         process_rulegroups_in_batches(self.project.id)
-
-        mock_delayed.assert_called_once_with(self.project.id)
+        mock_apply_delayed.delayed.assert_called_once_with(self.project.id)
 
     @patch("sentry.rules.processing.delayed_processing.apply_delayed")
     def test_basic(self, mock_apply_delayed):
-        mock_delayed = Mock()
-        mock_apply_delayed.delayed = mock_delayed
-
         self.push_to_hash(self.project.id, self.rule.id, self.group.id)
         self.push_to_hash(self.project.id, self.rule.id, self.group_two.id)
         self.push_to_hash(self.project.id, self.rule.id, self.group_three.id)
 
         process_rulegroups_in_batches(self.project.id)
-        mock_delayed.assert_called_once_with(self.project.id)
+        mock_apply_delayed.delayed.assert_called_once_with(self.project.id)
 
     @override_options({"delayed_processing.batch_size": 2})
     @patch("sentry.rules.processing.delayed_processing.apply_delayed")
     def test_batch(self, mock_apply_delayed):
-        mock_delayed = Mock()
-        mock_apply_delayed.delayed = mock_delayed
-
+        mock_delayed = mock_apply_delayed.delayed
         self.push_to_hash(self.project.id, self.rule.id, self.group.id)
         self.push_to_hash(self.project.id, self.rule.id, self.group_two.id)
         self.push_to_hash(self.project.id, self.rule.id, self.group_three.id)
@@ -1440,8 +1432,6 @@ class CleanupRedisBufferTest(CreateEventTestCase):
     @override_options({"delayed_processing.batch_size": 2})
     @patch("sentry.rules.processing.delayed_processing.apply_delayed")
     def test_batched_cleanup(self, mock_apply_delayed):
-        mock_delayed = Mock()
-        mock_apply_delayed.delayed = mock_delayed
         group_two = self.create_group(self.project)
         group_three = self.create_group(self.project)
 
@@ -1455,8 +1445,8 @@ class CleanupRedisBufferTest(CreateEventTestCase):
         rules_to_groups[self.rule.id].add(group_three.id)
 
         process_rulegroups_in_batches(self.project.id)
-        batch_one_key = mock_delayed.call_args_list[0][0][1]
-        batch_two_key = mock_delayed.call_args_list[1][0][1]
+        batch_one_key = mock_apply_delayed.delayed.call_args_list[0][0][1]
+        batch_two_key = mock_apply_delayed.delayed.call_args_list[1][0][1]
 
         # Verify process_rulegroups_in_batches removed the data from the buffer
         rule_group_data = buffer.backend.get_hash(Project, {"project_id": self.project.id})


### PR DESCRIPTION
# Description
Some orgs are sending 100k+ events per minute, and the processing is taking to long for a single task.

This PR will look at the size of the hash and determine if it needs to be batched.

There's some restrictions around the celery task / redis, info is outlined in a code comment here: https://github.com/getsentry/sentry/pull/75302/files#diff-f906e75a0e4419db4870fa45ca5a1608ca79beaa052c8bc50b4805607a665d27R482-R486