### PR TITLE
fix(ecosystems): Disables window close for integration pipeline dialog

### DIFF
--- a/src/sentry/templates/sentry/integrations/dialog-complete.html
+++ b/src/sentry/templates/sentry/integrations/dialog-complete.html
@@ -14,7 +14,6 @@
   if (window.opener) {
     window.opener.postMessage({{ payload|to_json }}, {{ document_origin|safe }});
   }
-  window.close();
 </script>
 {% endscript %}
 


### PR DESCRIPTION
Prevents the dialog window from immediately closing when the integration pipeline is finished. This currently happens, regardless of the success of the operation which results in us dropping errors messages when we should be displaying them to the customer.
