### PR TITLE
ref(alerts): Refactor out alert latest incident info

### DIFF
--- a/src/sentry/incidents/endpoints/serializers/alert_rule.py
+++ b/src/sentry/incidents/endpoints/serializers/alert_rule.py
@@ -413,7 +413,7 @@ class CombinedRuleSerializer(Serializer):
                 if "latestIncident" in self.expand:
                     # Eg. we _have_ an incident
                     try:
-                        serialized_alert_rule["latestIncident"] = incident_map.get(item.incident_id)
+                        serialized_alert_rule["latestIncident"] = incident_map.get(item.incident_id)  # type: ignore[attr-defined]
                     except AttributeError as e:
                         logger.exception(
                             "incident serialization error",

--- a/src/sentry/incidents/endpoints/serializers/alert_rule.py
+++ b/src/sentry/incidents/endpoints/serializers/alert_rule.py
@@ -407,7 +407,7 @@ class CombinedRuleSerializer(Serializer):
 
         for item in item_list:
             item_id = str(item.id)
-            if item_id in serialized_alert_rule_map_by_id:
+            if isinstance(item, AlertRule) and item_id in serialized_alert_rule_map_by_id:
                 # This is a metric alert rule
                 serialized_alert_rule = serialized_alert_rule_map_by_id[item_id]
                 if "latestIncident" in self.expand:
@@ -425,10 +425,13 @@ class CombinedRuleSerializer(Serializer):
                             },
                         )
                 results[item] = serialized_alert_rule
-            elif item_id in serialized_issue_rule_map_by_id:
+            elif isinstance(item, Rule) and item_id in serialized_issue_rule_map_by_id:
                 # This is an issue alert rule
                 results[item] = serialized_issue_rule_map_by_id[item_id]
-            elif item_id in serialized_uptime_monitor_map_by_id:
+            elif (
+                isinstance(item, ProjectUptimeSubscription)
+                and item_id in serialized_uptime_monitor_map_by_id
+            ):
                 # This is an uptime monitor
                 results[item] = serialized_uptime_monitor_map_by_id[item_id]
             else:

--- a/static/app/views/alerts/list/rules/alertLastIncidentActivationInfo.spec.tsx
+++ b/static/app/views/alerts/list/rules/alertLastIncidentActivationInfo.spec.tsx
@@ -1,0 +1,68 @@
+import {IncidentFixture} from 'sentry-fixture/incident';
+import {MetricRuleFixture} from 'sentry-fixture/metricRule';
+import {ProjectAlertRuleFixture} from 'sentry-fixture/projectAlertRule';
+import {UptimeRuleFixture} from 'sentry-fixture/uptimeRule';
+
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import AlertLastIncidentActivationInfo from 'sentry/views/alerts/list/rules/alertLastIncidentActivationInfo';
+import {CombinedAlertType, IncidentStatus} from 'sentry/views/alerts/types';
+
+describe('AlertLastIncidentActivationInfo', function () {
+  it('Renders non-triggered issue alert correctly', function () {
+    const rule = {
+      ...ProjectAlertRuleFixture(),
+      type: CombinedAlertType.ISSUE,
+    } as const;
+
+    render(<AlertLastIncidentActivationInfo rule={rule} />);
+    expect(screen.getByText('Alert not triggered yet')).toBeInTheDocument();
+  });
+
+  it('Renders triggered issue alert correctly', function () {
+    const rule = {
+      ...ProjectAlertRuleFixture({
+        lastTriggered: '2017-10-17T00:00:00.000Z',
+      }),
+      type: CombinedAlertType.ISSUE,
+    } as const;
+
+    const {container} = render(<AlertLastIncidentActivationInfo rule={rule} />);
+    expect(container).toHaveTextContent('Triggered 3 hours ago');
+  });
+
+  it('Renders non-triggered metric alerts', function () {
+    const rule = {
+      ...MetricRuleFixture(),
+      type: CombinedAlertType.METRIC,
+    } as const;
+
+    render(<AlertLastIncidentActivationInfo rule={rule} />);
+    expect(screen.getByText('Alert not triggered yet')).toBeInTheDocument();
+  });
+
+  it('Renders triggered metric alert incidents', function () {
+    const rule = {
+      ...MetricRuleFixture({
+        latestIncident: IncidentFixture({
+          status: IncidentStatus.CRITICAL,
+          dateCreated: '2017-10-17T00:00:00.000Z',
+        }),
+      }),
+      type: CombinedAlertType.METRIC,
+    } as const;
+
+    const {container} = render(<AlertLastIncidentActivationInfo rule={rule} />);
+    expect(container).toHaveTextContent('Triggered 3 hours ago');
+  });
+
+  it('Renders uptime alerts', function () {
+    const rule = {
+      ...UptimeRuleFixture(),
+      type: CombinedAlertType.UPTIME,
+    } as const;
+
+    render(<AlertLastIncidentActivationInfo rule={rule} />);
+    expect(screen.getByText('Actively monitoring every 5 seconds')).toBeInTheDocument();
+  });
+});

--- a/static/app/views/alerts/list/rules/alertLastIncidentActivationInfo.tsx
+++ b/static/app/views/alerts/list/rules/alertLastIncidentActivationInfo.tsx
@@ -1,0 +1,92 @@
+import TimeSince from 'sentry/components/timeSince';
+import {t, tct} from 'sentry/locale';
+import {MonitorType} from 'sentry/types/alerts';
+import {hasActiveIncident} from 'sentry/views/alerts/list/rules/utils';
+import {
+  type CombinedAlerts,
+  CombinedAlertType,
+  type IssueAlert,
+  type MetricAlert,
+  type UptimeAlert,
+} from 'sentry/views/alerts/types';
+
+interface Props {
+  rule: CombinedAlerts;
+}
+
+/**
+ * Displays the time since the last uptime incident given an uptime alert rule
+ */
+function LastUptimeIncident({rule}: {rule: UptimeAlert}) {
+  // TODO(davidenwang): Once we have a lastTriggered field returned from backend, display that info here
+  return tct('Actively monitoring every [seconds] seconds', {
+    seconds: rule.intervalSeconds,
+  });
+}
+
+/**
+ * Displays the last time an issue alert was triggered
+ */
+function LastIssueTrigger({rule}: {rule: IssueAlert}) {
+  if (!rule.lastTriggered) {
+    return t('Alert not triggered yet');
+  }
+
+  return (
+    <div>
+      {t('Triggered ')}
+      <TimeSince date={rule.lastTriggered} />
+    </div>
+  );
+}
+
+/**
+ * Displays the last activation for activated alert rules or the last incident for continuous alerts
+ */
+function LastMetricAlertIncident({rule}: {rule: MetricAlert}) {
+  if (rule.monitorType === MonitorType.ACTIVATED) {
+    if (!rule.activations?.length) {
+      return t('Alert has not been activated yet');
+    }
+
+    return (
+      <div>
+        {t('Last activated ')}
+        <TimeSince date={rule.activations[0].dateCreated} />
+      </div>
+    );
+  }
+
+  if (!rule.latestIncident) {
+    return t('Alert not triggered yet');
+  }
+
+  const activeIncident = hasActiveIncident(rule);
+  if (activeIncident) {
+    return (
+      <div>
+        {t('Triggered ')}
+        <TimeSince date={rule.latestIncident.dateCreated} />
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      {t('Resolved ')}
+      <TimeSince date={rule.latestIncident.dateClosed!} />
+    </div>
+  );
+}
+
+export default function AlertLastIncidentActivationInfo({rule}: Props) {
+  // eslint-disable-next-line default-case
+  switch (rule.type) {
+    case CombinedAlertType.UPTIME:
+      return <LastUptimeIncident rule={rule} />;
+    case CombinedAlertType.ISSUE:
+      return <LastIssueTrigger rule={rule} />;
+    case CombinedAlertType.METRIC:
+      return <LastMetricAlertIncident rule={rule} />;
+  }
+}

--- a/static/app/views/alerts/types.tsx
+++ b/static/app/views/alerts/types.tsx
@@ -95,7 +95,7 @@ export enum CombinedAlertType {
   UPTIME = 'uptime',
 }
 
-interface IssueAlert extends IssueAlertRule {
+export interface IssueAlert extends IssueAlertRule {
   type: CombinedAlertType.ISSUE;
   latestIncident?: Incident | null;
 }


### PR DESCRIPTION
Refactors out the component that renders subtext here ex: `Triggered 6 days ago`
<img width="848" alt="image" src="https://github.com/user-attachments/assets/b4aac83c-abf7-4c6a-8de3-04404a70ad78">

In my opinion the logic before was hard to follow as the alert rule type would trigger different branches of code and return statements. The new component separates each alert type's sub info into its own component with an appropriate comment and also adds tests

Depends on:
https://github.com/getsentry/sentry/pull/75308