### PR TITLE
chore(hybrid-cloud): Resubmits Pydantic v2.7 upgrade

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,9 @@ filterwarnings = [
 
   # pytest has not yet implemented the replacement for this yet
   "ignore:The --looponfail command line argument.*",
+
+  # Temporarily disable deprecation warnings for pydantic while we upgrade it
+  "ignore::DeprecationWarning:pydantic.*",
 ]
 looponfailroots = ["src", "tests"]
 

--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -45,7 +45,7 @@ python-rapidjson>=1.4
 psutil>=5.9.2
 psycopg2-binary>=2.9.9
 PyJWT>=2.4.0
-pydantic>=1.10.17,<2
+pydantic>=2.5.0
 python-dateutil>=2.9.0
 pymemcache
 python-u2flib-server>=5.0.0

--- a/requirements-dev-frozen.txt
+++ b/requirements-dev-frozen.txt
@@ -7,6 +7,7 @@
 --index-url https://pypi.devinfra.sentry.io/simple
 
 amqp==5.2.0
+annotated-types==0.7.0
 anyio==3.7.1
 asgiref==3.7.2
 attrs==23.1.0
@@ -137,7 +138,8 @@ pyasn1-modules==0.2.4
 pycodestyle==2.11.0
 pycountry==17.5.14
 pycparser==2.21
-pydantic==1.10.17
+pydantic==2.7.4
+pydantic-core==2.18.4
 pyflakes==3.2.0
 pyjwt==2.4.0
 pymemcache==4.0.0

--- a/requirements-frozen.txt
+++ b/requirements-frozen.txt
@@ -7,6 +7,7 @@
 --index-url https://pypi.devinfra.sentry.io/simple
 
 amqp==5.2.0
+annotated-types==0.7.0
 anyio==3.7.1
 asgiref==3.7.2
 attrs==23.1.0
@@ -96,7 +97,8 @@ pyasn1==0.4.5
 pyasn1-modules==0.2.4
 pycountry==17.5.14
 pycparser==2.21
-pydantic==1.10.17
+pydantic==2.7.4
+pydantic-core==2.18.4
 pyjwt==2.4.0
 pymemcache==4.0.0
 pyparsing==3.0.9

--- a/src/sentry/autofix/utils.py
+++ b/src/sentry/autofix/utils.py
@@ -1,11 +1,11 @@
 import datetime
 import enum
-from typing import TypedDict
 
 import orjson
 import requests
 from django.conf import settings
 from pydantic import BaseModel
+from typing_extensions import TypedDict
 
 from sentry.integrations.utils.code_mapping import get_sorted_code_mapping_configs
 from sentry.models.project import Project

--- a/src/sentry/hybridcloud/rpc/__init__.py
+++ b/src/sentry/hybridcloud/rpc/__init__.py
@@ -11,6 +11,7 @@ from typing import Any, Generic, Protocol, Self, TypeVar, cast
 import pydantic
 from django.db import router, transaction
 from django.db.models import Model
+from pydantic import ConfigDict
 
 from sentry.silo.base import SiloMode
 from sentry.utils.env import in_test_environment
@@ -43,13 +44,14 @@ class ValueEqualityEnum(Enum):
 class RpcModel(pydantic.BaseModel):
     """A serializable object that may be part of an RPC schema."""
 
-    class Config:
-        orm_mode = True
-        use_enum_values = True
+    # TODO(Hybrid-Cloud): Remove number coercion after pydantic V2 stabilized
+    model_config = ConfigDict(
+        from_attributes=True, use_enum_values=True, coerce_numbers_to_str=True
+    )
 
     @classmethod
     def get_field_names(cls) -> Iterable[str]:
-        return iter(cls.__fields__.keys())
+        return iter(cls.model_fields.keys())
 
     @classmethod
     def serialize_by_field_name(

--- a/src/sentry/hybridcloud/rpc/sig.py
+++ b/src/sentry/hybridcloud/rpc/sig.py
@@ -7,6 +7,7 @@ from typing import Any
 
 import pydantic
 from django.utils.functional import LazyObject
+from pydantic import ConfigDict
 
 from sentry.hybridcloud.rpc import ArgumentDict
 
@@ -81,7 +82,10 @@ class SerializableFunctionSignature:
         if self.is_instance_method:
             parameters = parameters[1:]  # exclude `self` argument
         field_definitions = {p.name: create_field(p) for p in parameters}
-        return pydantic.create_model(model_name, **field_definitions)  # type: ignore[call-overload]
+
+        # TODO(Hybrid-Cloud): Remove number coercion after pydantic V2 stabilized
+        config = ConfigDict(coerce_numbers_to_str=True)
+        return pydantic.create_model(model_name, __config__=config, **field_definitions)  # type: ignore[call-overload]
 
     _RETURN_MODEL_ATTR = "value"
 

--- a/src/sentry/types/region.py
+++ b/src/sentry/types/region.py
@@ -8,8 +8,8 @@ from urllib.parse import urljoin
 import sentry_sdk
 from django.conf import settings
 from django.http import HttpRequest
+from pydantic import TypeAdapter
 from pydantic.dataclasses import dataclass
-from pydantic.tools import parse_obj_as
 
 from sentry import options
 from sentry.silo.base import SiloMode, SingleProcessSiloModeState, control_silo_function
@@ -151,7 +151,8 @@ class RegionDirectory:
 def _parse_raw_config(region_config: Any) -> Iterable[Region]:
     if isinstance(region_config, (str, bytes)):
         json_config_values = json.loads(region_config)
-        config_values = parse_obj_as(list[Region], json_config_values)
+        adapter = TypeAdapter(list[Region])
+        config_values = adapter.validate_python(json_config_values)
     else:
         config_values = region_config
 

--- a/src/sentry/users/services/user/serial.py
+++ b/src/sentry/users/services/user/serial.py
@@ -36,7 +36,7 @@ def serialize_generic_user(user: Any) -> RpcUser | None:
 def _serialize_from_user_fields(user: User) -> dict[str, Any]:
     args = {
         field_name: getattr(user, field_name)
-        for field_name in RpcUserProfile.__fields__
+        for field_name in RpcUserProfile.model_fields
         if hasattr(user, field_name)
     }
     args["pk"] = user.pk

--- a/tests/sentry/api/endpoints/test_organization_sdk_updates.py
+++ b/tests/sentry/api/endpoints/test_organization_sdk_updates.py
@@ -2,6 +2,7 @@ from unittest import mock
 
 import pytest
 from django.urls import reverse
+from pydantic import PydanticDeprecatedSince20
 
 from sentry.sdk_updates import SdkIndexState
 from sentry.testutils.cases import APITestCase, SnubaTestCase
@@ -188,8 +189,14 @@ class OrganizationSdkUpdates(APITestCase, SnubaTestCase):
         update_suggestions = response.data
         assert len(update_suggestions) == 0
 
+        # TODO(Gabe): Temporary kludge to allow this to pass while pydantic
+        # deprecation warnings are active.
+        filtered_warnings = [
+            info for info in warninfo if not isinstance(info.message, PydanticDeprecatedSince20)
+        ]
+
         # until it is turned into an error, we'll get a warning about parsing an invalid version
-        (warning,) = warninfo
+        (warning,) = filtered_warnings
         assert isinstance(warning.message, DeprecationWarning)
         (warn_msg,) = warning.message.args
         assert (

--- a/tests/sentry/test_dependencies.py
+++ b/tests/sentry/test_dependencies.py
@@ -1,8 +1,0 @@
-import pydantic
-
-
-def test_pydantic_1x_compiled() -> None:
-    if not pydantic.VERSION.startswith("1."):
-        raise AssertionError("delete this test, it only applies to pydantic 1.x")
-    # pydantic is horribly slow when not cythonized
-    assert pydantic.__file__.endswith(".so")


### PR DESCRIPTION
Mulligan of PR #74770

This PR upgrades pydantic and updates the model configs we use for RPC methods to conform with the new version.

This PR does not address deprecation warnings, which will be handled in a series of follow-up commits to both Sentry and GetSentry.
