### PR TITLE
fix(apidocs): improve releases docs syntax

### DIFF
--- a/src/sentry/api/endpoints/organization_sessions.py
+++ b/src/sentry/api/endpoints/organization_sessions.py
@@ -77,7 +77,7 @@ class OrganizationSessionsEndpoint(OrganizationEndpoint):
         Because of technical limitations, this endpoint returns
         at most 10000 data points. For example, if you select a 90 day window grouped by releases,
         you will see at most `floor(10k / (90 + 1)) = 109` releases. To get more results, reduce the
-        `statsPeriod`."
+        `statsPeriod`.
         """
 
         def data_fn(offset: int, limit: int) -> SessionsQueryResult:

--- a/src/sentry/apidocs/parameters.py
+++ b/src/sentry/apidocs/parameters.py
@@ -53,21 +53,21 @@ class GlobalParams:
 - `s` for seconds
 - `w` for weeks
 
-For example `24h`, to mean query data starting from 24 hours ago to now.""",
+For example, `24h`, to mean query data starting from 24 hours ago to now.""",
     )
     START = OpenApiParameter(
         name="start",
         location="query",
         required=False,
         type=OpenApiTypes.DATETIME,
-        description="The start of the period of time for the query, expected in ISO-8601 format. For example `2001-12-14T12:34:56.7890`.",
+        description="The start of the period of time for the query, expected in ISO-8601 format. For example, `2001-12-14T12:34:56.7890`.",
     )
     END = OpenApiParameter(
         name="end",
         location="query",
         required=False,
         type=OpenApiTypes.DATETIME,
-        description="The end of the period of time for the query, expected in ISO-8601 format. For example `2001-12-14T12:34:56.7890`.",
+        description="The end of the period of time for the query, expected in ISO-8601 format. For example, `2001-12-14T12:34:56.7890`.",
     )
     ENVIRONMENT = OpenApiParameter(
         name="environment",
@@ -106,7 +106,7 @@ class OrganizationParams:
         required=False,
         many=True,
         type=str,
-        description="""The project slugs to filter by. Use `$all` to include all available projects. For example the following are valid parameters:
+        description="""The project slugs to filter by. Use `$all` to include all available projects. For example, the following are valid parameters:
 - `/?projectSlug=$all`
 - `/?projectSlug=android&projectSlug=javascript-react`
 """,
@@ -118,7 +118,7 @@ class OrganizationParams:
         many=True,
         type=int,
         description="""The IDs of projects to filter by. `-1` means all available projects.
-For example the following are valid parameters:
+For example, the following are valid parameters:
 - `/?project=1234&project=56789`
 - `/?project=-1`
 """,
@@ -273,7 +273,7 @@ class VisibilityParams:
         type=str,
         description="""Filters results by using [query syntax](/product/sentry-basics/search/).
 
-example: `query=(transaction:foo AND release:abc) OR (transaction:[bar,baz] AND release:def)`
+Example: `query=(transaction:foo AND release:abc) OR (transaction:[bar,baz] AND release:def)`
 """,
     )
     FIELD = OpenApiParameter(
@@ -553,7 +553,7 @@ The available fields are
 - `sum(session)`
 - `count_unique(user)`
 - `avg`, `p50`, `p75`, `p90`, `p95`, `p99`, `max` applied to `session.duration`. For example, `p99(session.duration)`. Session duration is [no longer being recorded](https://github.com/getsentry/sentry/discussions/42716) as of on Jan 12, 2023. Returned data may be incomplete.
-- `crash_rate`, `crash_free_rate` applied to `user` or `session`. For example,`crash_free_rate(user)`
+- `crash_rate`, `crash_free_rate` applied to `user` or `session`. For example, `crash_free_rate(user)`
 """,
     )
     INTERVAL = OpenApiParameter(
@@ -576,6 +576,7 @@ The available fields are
         location="query",
         required=False,
         type=str,
+        many=True,
         description="""The list of properties to group by.\n\nThe available groupBy conditions are `project`,
         `release`, `environment` and `session.status`.""",
     )
@@ -585,7 +586,7 @@ The available fields are
         required=False,
         type=str,
         description="""An optional field to order by, which must be one of the fields provided in `field`. Use `-`
-        for descending order, for example `-sum(session)`""",
+        for descending order, for example, `-sum(session)`""",
     )
     INCLUDE_TOTALS = OpenApiParameter(
         name="includeTotals",


### PR DESCRIPTION
i was using the release docs on https://docs.sentry.io/api/releases/retrieve-release-health-session-statistics/ and found some more typos/small syntax things