### PR TITLE
fix(prism): Remove unnecessary vertical-align: middle style

### DIFF
--- a/static/app/styles/global.tsx
+++ b/static/app/styles/global.tsx
@@ -22,7 +22,6 @@ const prismStyles = (theme: Theme) => css`
 
     code {
       background: unset;
-      vertical-align: middle;
     }
   }
 


### PR DESCRIPTION
This style was added [here](https://github.com/getsentry/sentry/pull/50764/files#diff-6d5433cf34da1367ea13910923113fb1654aae6cc5852dc8cbe0cc31da442e0aR28) (by me), but it doesn't seem like it's needed any longer (and I can't remember why I originally added it 🤔).

The style adds unnecessary whitespace between lines and causes line highlighting to be misaligned (as attempted in https://github.com/getsentry/sentry/pull/75294). If you compare the CodeSnippet stories at `/stories/?name=app/components/codeSnippet.stories.tsx`, it looks the same but slightly more compact now.