### PR TITLE
fix(metrics): don't show empty condition in span metric alerts

### DIFF
--- a/src/sentry/snuba/metrics/naming_layer/mri.py
+++ b/src/sentry/snuba/metrics/naming_layer/mri.py
@@ -269,7 +269,7 @@ def format_mri_field(field: str) -> str:
                     condition = SpanAttributeExtractionRuleCondition.objects.get(id=condition_id)
                     config = condition.config
                     if condition.value:
-                        filter_str = ' filtered by "{condition.value}"'
+                        filter_str = f' filtered by "{condition.value}"'
                     else:
                         filter_str = ""
 

--- a/src/sentry/snuba/metrics/naming_layer/mri.py
+++ b/src/sentry/snuba/metrics/naming_layer/mri.py
@@ -268,7 +268,12 @@ def format_mri_field(field: str) -> str:
                 try:
                     condition = SpanAttributeExtractionRuleCondition.objects.get(id=condition_id)
                     config = condition.config
-                    return f'{parsed.op}({config.span_attribute}) filtered by "{condition.value}"'
+                    if condition.value:
+                        filter_str = ' filtered by "{condition.value}"'
+                    else:
+                        filter_str = ""
+
+                    return f"{parsed.op}({config.span_attribute}){filter_str}"
                 except SpanAttributeExtractionRuleCondition.DoesNotExist:
                     with sentry_sdk.new_scope() as scope:
                         scope.set_tag("field", field)

--- a/tests/snuba/metrics/naming_layer/test_mri.py
+++ b/tests/snuba/metrics/naming_layer/test_mri.py
@@ -48,6 +48,26 @@ class TestMRIUtils(TestCase):
             == 'count_unique(browser.name) filtered by "browser.name:Chrome or browser.name:Firefox"'
         )
 
+    def test_span_metric_mri_field_empty_condition(self):
+        config = {
+            "spanAttribute": "browser.name",
+            "aggregates": ["count_unique"],
+            "unit": "none",
+            "tags": [],
+            "conditions": [
+                {"value": ""},
+            ],
+        }
+        project = self.create_project(organization=self.organization, name="my new project")
+        config_object = self.create_span_attribute_extraction_config(
+            dictionary=config, user_id=self.user.id, project=project
+        )
+        condition_id = config_object.conditions.get().id
+        assert (
+            format_mri_field(f"count_unique(c:custom/span_attribute_{condition_id}@none)")
+            == "count_unique(browser.name)"
+        )
+
     def test_span_metric_mri_field_value(self):
         config = {
             "spanAttribute": "my_duration",


### PR DESCRIPTION
Before: 
sum(ddm.metrics_api.query) filtered by "" in the last hour

After:
sum(ddm.metrics_api.query) in the last hour