### PR TITLE
ref: move organization absolute url mixin functionality to sentry.organizations

### DIFF
--- a/src/sentry/api/base.py
+++ b/src/sentry/api/base.py
@@ -32,6 +32,7 @@ from sentry.apidocs.hooks import HTTP_METHOD_NAME
 from sentry.auth import access
 from sentry.auth.staff import has_staff_option
 from sentry.models.environment import Environment
+from sentry.organizations.absolute_url import generate_organization_url
 from sentry.ratelimits.config import DEFAULT_RATE_LIMIT_CONFIG, RateLimitConfig
 from sentry.silo.base import SiloLimit, SiloMode
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
@@ -65,7 +66,6 @@ from .permissions import (
     SuperuserOrStaffFeatureFlaggedPermission,
     SuperuserPermission,
 )
-from .utils import generate_organization_url
 
 __all__ = [
     "Endpoint",

--- a/src/sentry/api/endpoints/project_profiling_profile.py
+++ b/src/sentry/api/endpoints/project_profiling_profile.py
@@ -13,10 +13,10 @@ from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.project import ProjectEndpoint
 from sentry.api.serializers import serialize
-from sentry.api.utils import generate_organization_url
 from sentry.exceptions import InvalidSearchQuery
 from sentry.models.project import Project
 from sentry.models.release import Release
+from sentry.organizations.absolute_url import generate_organization_url
 from sentry.profiles.utils import (
     get_from_profiling_service,
     parse_profile_filters,

--- a/src/sentry/api/serializers/models/auth_provider.py
+++ b/src/sentry/api/serializers/models/auth_provider.py
@@ -8,8 +8,8 @@ from sentry.auth.services.auth import RpcAuthProvider
 from sentry.models.authprovider import AuthProvider
 from sentry.models.organization import Organization
 from sentry.models.organizationmember import OrganizationMember
+from sentry.organizations.absolute_url import organization_absolute_url
 from sentry.organizations.services.organization.model import RpcOrganization
-from sentry.types.organization import OrganizationAbsoluteUrlMixin
 
 
 @register(AuthProvider)
@@ -28,8 +28,8 @@ class AuthProviderSerializer(Serializer):
 
         login_url = Organization.get_url(organization.slug)
 
-        absolute_login_url = OrganizationAbsoluteUrlMixin.organization_absolute_url(
-            features.has("system:multi-region"),
+        absolute_login_url = organization_absolute_url(
+            has_customer_domain=features.has("system:multi-region"),
             slug=organization.slug,
             path=login_url,
         )

--- a/src/sentry/api/serializers/models/organization.py
+++ b/src/sentry/api/serializers/models/organization.py
@@ -23,7 +23,7 @@ from sentry.api.serializers.models.role import (
 )
 from sentry.api.serializers.models.team import TeamSerializerResponse
 from sentry.api.serializers.types import OrganizationSerializerResponse
-from sentry.api.utils import generate_organization_url, generate_region_url
+from sentry.api.utils import generate_region_url
 from sentry.auth.access import Access
 from sentry.auth.services.auth import RpcOrganizationAuthConfig, auth_service
 from sentry.constants import (
@@ -64,6 +64,7 @@ from sentry.models.organizationonboardingtask import OrganizationOnboardingTask
 from sentry.models.project import Project
 from sentry.models.team import Team, TeamStatus
 from sentry.models.user import User
+from sentry.organizations.absolute_url import generate_organization_url
 from sentry.organizations.services.organization import RpcOrganizationSummary
 from sentry.users.services.user.service import user_service
 

--- a/src/sentry/api/utils.py
+++ b/src/sentry/api/utils.py
@@ -2,14 +2,12 @@ from __future__ import annotations
 
 import datetime
 import logging
-import re
 import sys
 import traceback
 from collections.abc import Generator, Mapping, MutableMapping
 from contextlib import contextmanager
 from datetime import timedelta
 from typing import Any, Literal, overload
-from urllib.parse import urlparse
 
 import sentry_sdk
 from django.conf import settings
@@ -31,6 +29,10 @@ from sentry.models.apikey import is_api_key_auth
 from sentry.models.apitoken import is_api_token_auth
 from sentry.models.organization import Organization
 from sentry.models.orgauthtoken import is_org_auth_token_auth
+from sentry.organizations.absolute_url import (  # noqa: F401 # XXX: for compatibility, remove after getsentry is updated
+    customer_domain_path,
+    generate_organization_url,
+)
 from sentry.organizations.services.organization import (
     RpcOrganization,
     RpcOrganizationMember,
@@ -271,25 +273,6 @@ def is_member_disabled_from_limit(
         return member.flags.member_limit__restricted
 
 
-def generate_organization_hostname(org_slug: str) -> str:
-    url_prefix_hostname: str = urlparse(options.get("system.url-prefix")).netloc
-    org_base_hostname_template: str = options.get("system.organization-base-hostname")
-    if not org_base_hostname_template:
-        return url_prefix_hostname
-    has_org_slug_placeholder = "{slug}" in org_base_hostname_template
-    if not has_org_slug_placeholder:
-        return url_prefix_hostname
-    org_hostname = org_base_hostname_template.replace("{slug}", org_slug)
-    return org_hostname
-
-
-def generate_organization_url(org_slug: str) -> str:
-    org_url_template: str = options.get("system.organization-url-template")
-    if not org_url_template:
-        return options.get("system.url-prefix")
-    return org_url_template.replace("{hostname}", generate_organization_hostname(org_slug))
-
-
 def generate_region_url(region_name: str | None = None) -> str:
     region_url_template: str | None = options.get("system.region-api-url-template")
     if region_name is None and SiloMode.get_current_mode() == SiloMode.REGION:
@@ -303,40 +286,6 @@ def generate_region_url(region_name: str | None = None) -> str:
     if not region_url_template or not region_name:
         return options.get("system.url-prefix")
     return region_url_template.replace("{region}", region_name)
-
-
-_path_patterns: list[tuple[re.Pattern[str], str]] = [
-    # /organizations/slug/section, but not /organizations/new
-    (re.compile(r"\/?organizations\/(?!new)[^\/]+\/(.*)"), r"/\1"),
-    # For /settings/:orgId/ -> /settings/organization/
-    (
-        re.compile(r"\/settings\/(?!account\/|!billing\/|projects\/|teams)[^\/]+\/?$"),
-        "/settings/organization/",
-    ),
-    # Move /settings/:orgId/:section -> /settings/:section
-    # but not /settings/organization or /settings/projects which is a new URL
-    (
-        re.compile(r"^\/?settings\/(?!account\/|billing\/|projects\/|teams)[^\/]+\/(.*)"),
-        r"/settings/\1",
-    ),
-    (re.compile(r"^\/?join-request\/[^\/]+\/?.*"), r"/join-request/"),
-    (re.compile(r"^\/?onboarding\/[^\/]+\/(.*)"), r"/onboarding/\1"),
-    (
-        re.compile(r"^\/?(?!settings)[^\/]+\/([^\/]+)\/getting-started\/(.*)"),
-        r"/getting-started/\1/\2",
-    ),
-]
-
-
-def customer_domain_path(path: str) -> str:
-    """
-    Server side companion to path normalizations found in withDomainRequired
-    """
-    for pattern, replacement in _path_patterns:
-        updated = pattern.sub(replacement, path)
-        if updated != path:
-            return updated
-    return path
 
 
 def method_dispatch(**dispatch_mapping):

--- a/src/sentry/auth/helper.py
+++ b/src/sentry/auth/helper.py
@@ -25,7 +25,6 @@ from rest_framework.request import Request
 
 from sentry import audit_log, features
 from sentry.api.invite_helper import ApiInviteHelper, remove_invite_details_from_session
-from sentry.api.utils import generate_organization_url
 from sentry.audit_log.services.log import AuditLogEvent, log_service
 from sentry.auth.email import AmbiguousUserFromEmail, resolve_email_to_user
 from sentry.auth.exceptions import IdentityNotValid
@@ -42,6 +41,7 @@ from sentry.models.authidentity import AuthIdentity
 from sentry.models.authprovider import AuthProvider
 from sentry.models.outbox import outbox_context
 from sentry.models.user import User
+from sentry.organizations.absolute_url import generate_organization_url
 from sentry.organizations.services.organization import (
     RpcOrganization,
     RpcOrganizationFlagsUpdate,

--- a/src/sentry/integrations/github/integration.py
+++ b/src/sentry/integrations/github/integration.py
@@ -13,7 +13,6 @@ from django.utils.translation import gettext_lazy as _
 from rest_framework.request import Request
 
 from sentry import features, options
-from sentry.api.utils import generate_organization_url
 from sentry.constants import ObjectStatus
 from sentry.http import safe_urlopen, safe_urlread
 from sentry.identity.github import GitHubIdentityProvider, get_user_info
@@ -31,6 +30,7 @@ from sentry.integrations.models.organization_integration import OrganizationInte
 from sentry.integrations.services.repository import RpcRepository, repository_service
 from sentry.integrations.utils.code_mapping import RepoTree
 from sentry.models.repository import Repository
+from sentry.organizations.absolute_url import generate_organization_url
 from sentry.organizations.services.organization import RpcOrganizationSummary, organization_service
 from sentry.pipeline import Pipeline, PipelineView
 from sentry.shared_integrations.constants import ERR_INTERNAL, ERR_UNAUTHORIZED

--- a/src/sentry/integrations/pipeline.py
+++ b/src/sentry/integrations/pipeline.py
@@ -1,32 +1,29 @@
 from __future__ import annotations
 
-from django.http import HttpResponseRedirect
-
-from sentry import features
-from sentry.api.utils import generate_organization_url
-from sentry.models.organizationmapping import OrganizationMapping
-from sentry.silo.base import SiloMode
-
-__all__ = ["IntegrationPipeline"]
-
 import logging
 
 from django.db import IntegrityError
+from django.http import HttpResponseRedirect
 from django.utils import timezone
 from django.utils.translation import gettext as _
 
+from sentry import features
 from sentry.api.serializers import serialize
 from sentry.constants import ObjectStatus
+from sentry.integrations.manager import default_manager
 from sentry.integrations.models.integration import Integration
 from sentry.integrations.models.organization_integration import OrganizationIntegration
 from sentry.models.identity import Identity, IdentityProvider, IdentityStatus
+from sentry.models.organizationmapping import OrganizationMapping
+from sentry.organizations.absolute_url import generate_organization_url
 from sentry.pipeline import Pipeline, PipelineAnalyticsEntry
 from sentry.shared_integrations.exceptions import IntegrationError, IntegrationProviderError
+from sentry.silo.base import SiloMode
 from sentry.web.helpers import render_to_response
 
-logger = logging.getLogger(__name__)
+__all__ = ["IntegrationPipeline"]
 
-from sentry.integrations.manager import default_manager
+logger = logging.getLogger(__name__)
 
 
 def ensure_integration(key, data):

--- a/src/sentry/middleware/customer_domain.py
+++ b/src/sentry/middleware/customer_domain.py
@@ -11,7 +11,7 @@ from django.http.response import HttpResponseBase
 from django.urls import resolve, reverse
 
 from sentry import features
-from sentry.api.utils import generate_organization_url
+from sentry.organizations.absolute_url import generate_organization_url
 from sentry.organizations.services.organization import organization_service
 from sentry.types.region import subdomain_is_region
 from sentry.utils import auth

--- a/src/sentry/organizations/absolute_url.py
+++ b/src/sentry/organizations/absolute_url.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import re
+from urllib.parse import urlparse
+
+from sentry import features, options
+from sentry.app import env
+from sentry.utils.http import absolute_uri, is_using_customer_domain
+
+_path_patterns: list[tuple[re.Pattern[str], str]] = [
+    # /organizations/slug/section, but not /organizations/new
+    (re.compile(r"\/?organizations\/(?!new)[^\/]+\/(.*)"), r"/\1"),
+    # For /settings/:orgId/ -> /settings/organization/
+    (
+        re.compile(r"\/settings\/(?!account\/|!billing\/|projects\/|teams)[^\/]+\/?$"),
+        "/settings/organization/",
+    ),
+    # Move /settings/:orgId/:section -> /settings/:section
+    # but not /settings/organization or /settings/projects which is a new URL
+    (
+        re.compile(r"^\/?settings\/(?!account\/|billing\/|projects\/|teams)[^\/]+\/(.*)"),
+        r"/settings/\1",
+    ),
+    (re.compile(r"^\/?join-request\/[^\/]+\/?.*"), r"/join-request/"),
+    (re.compile(r"^\/?onboarding\/[^\/]+\/(.*)"), r"/onboarding/\1"),
+    (
+        re.compile(r"^\/?(?!settings)[^\/]+\/([^\/]+)\/getting-started\/(.*)"),
+        r"/getting-started/\1/\2",
+    ),
+]
+
+
+def customer_domain_path(path: str) -> str:
+    """
+    Server side companion to path normalizations found in withDomainRequired
+    """
+    for pattern, replacement in _path_patterns:
+        updated = pattern.sub(replacement, path)
+        if updated != path:
+            return updated
+    return path
+
+
+def _generate_organization_hostname(org_slug: str) -> str:
+    url_prefix_hostname: str = urlparse(options.get("system.url-prefix")).netloc
+    org_base_hostname_template: str = options.get("system.organization-base-hostname")
+    if not org_base_hostname_template:
+        return url_prefix_hostname
+    has_org_slug_placeholder = "{slug}" in org_base_hostname_template
+    if not has_org_slug_placeholder:
+        return url_prefix_hostname
+    org_hostname = org_base_hostname_template.replace("{slug}", org_slug)
+    return org_hostname
+
+
+def generate_organization_url(org_slug: str) -> str:
+    org_url_template: str = options.get("system.organization-url-template")
+    if not org_url_template:
+        return options.get("system.url-prefix")
+    return org_url_template.replace("{hostname}", _generate_organization_hostname(org_slug))
+
+
+def has_customer_domain() -> bool:
+    return (
+        # XXX: this accesses a sneaky global
+        (env.request is not None and is_using_customer_domain(env.request))
+        or features.has("system:multi-region")
+    )
+
+
+def organization_absolute_url(
+    *,
+    has_customer_domain: bool,
+    slug: str,
+    path: str,
+    query: str | None = None,
+    fragment: str | None = None,
+) -> str:
+    """
+    Get an absolute URL to `path` for this organization.
+
+    This method takes customer-domains into account and will update the path when
+    customer-domains are active.
+    """
+    url_base = None
+    if has_customer_domain:
+        path = customer_domain_path(path)
+        url_base = generate_organization_url(slug)
+    uri = absolute_uri(path, url_prefix=url_base)
+    parts = [uri]
+    if query and not query.startswith("?"):
+        query = f"?{query}"
+    if query:
+        parts.append(query)
+    if fragment and not fragment.startswith("#"):
+        fragment = f"#{fragment}"
+    if fragment:
+        parts.append(fragment)
+    return "".join(parts)

--- a/src/sentry/types/organization.py
+++ b/src/sentry/types/organization.py
@@ -4,9 +4,7 @@ from functools import cached_property
 
 from django.db import models
 
-from sentry import features
-from sentry.app import env
-from sentry.utils.http import is_using_customer_domain
+from sentry.organizations.absolute_url import has_customer_domain, organization_absolute_url
 
 
 class OrganizationAbsoluteUrlMixin:
@@ -17,12 +15,7 @@ class OrganizationAbsoluteUrlMixin:
         """
         Check if the current organization is using or has access to customer domains.
         """
-
-        request = env.request
-        if request and is_using_customer_domain(request):
-            return True
-
-        return features.has("system:multi-region")
+        return has_customer_domain()
 
     def _has_customer_domain(self) -> bool:
         # For getsentry compatibility
@@ -35,40 +28,10 @@ class OrganizationAbsoluteUrlMixin:
         This method takes customer-domains into account and will update the path when
         customer-domains are active.
         """
-        return self.organization_absolute_url(
-            self.__has_customer_domain, self.slug, path=path, query=query, fragment=fragment
+        return organization_absolute_url(
+            has_customer_domain=self.__has_customer_domain,
+            slug=self.slug,
+            path=path,
+            query=query,
+            fragment=fragment,
         )
-
-    @staticmethod
-    def organization_absolute_url(
-        has_customer_domain: bool,
-        slug: str,
-        path: str,
-        query: str | None = None,
-        fragment: str | None = None,
-    ) -> str:
-        """
-        Get an absolute URL to `path` for this organization.
-
-        This method takes customer-domains into account and will update the path when
-        customer-domains are active.
-        """
-        # Avoid cycles.
-        from sentry.api.utils import customer_domain_path, generate_organization_url
-        from sentry.utils.http import absolute_uri
-
-        url_base = None
-        if has_customer_domain:
-            path = customer_domain_path(path)
-            url_base = generate_organization_url(slug)
-        uri = absolute_uri(path, url_prefix=url_base)
-        parts = [uri]
-        if query and not query.startswith("?"):
-            query = f"?{query}"
-        if query:
-            parts.append(query)
-        if fragment and not fragment.startswith("#"):
-            fragment = f"#{fragment}"
-        if fragment:
-            parts.append(fragment)
-        return "".join(parts)

--- a/src/sentry/utils/auth.py
+++ b/src/sentry/utils/auth.py
@@ -19,6 +19,7 @@ from sentry import options
 from sentry.models.organization import Organization
 from sentry.models.outbox import outbox_context
 from sentry.models.user import User
+from sentry.organizations.absolute_url import generate_organization_url
 from sentry.organizations.services.organization import RpcOrganization
 from sentry.users.services.user import RpcUser
 from sentry.users.services.user.service import user_service
@@ -190,8 +191,6 @@ def _get_login_redirect(request: HttpRequest, default: str | None = None) -> str
 
 
 def get_login_redirect(request: HttpRequest, default: str | None = None) -> str:
-    from sentry.api.utils import generate_organization_url
-
     login_redirect = _get_login_redirect(request, default)
     url_prefix = None
     if hasattr(request, "subdomain") and request.subdomain:

--- a/src/sentry/web/client_config.py
+++ b/src/sentry/web/client_config.py
@@ -16,12 +16,13 @@ from rest_framework.request import Request
 
 import sentry
 from sentry import features, options
-from sentry.api.utils import generate_organization_url, generate_region_url
+from sentry.api.utils import generate_region_url
 from sentry.auth import superuser
 from sentry.auth.services.auth import AuthenticatedToken, AuthenticationContext
 from sentry.auth.superuser import is_active_superuser
 from sentry.models.organizationmapping import OrganizationMapping
 from sentry.models.user import User
+from sentry.organizations.absolute_url import generate_organization_url
 from sentry.organizations.services.organization import (
     RpcOrganization,
     RpcUserOrganizationContext,

--- a/src/sentry/web/frontend/auth_login.py
+++ b/src/sentry/web/frontend/auth_login.py
@@ -17,7 +17,6 @@ from rest_framework.request import Request
 
 from sentry import features
 from sentry.api.invite_helper import ApiInviteHelper, remove_invite_details_from_session
-from sentry.api.utils import generate_organization_url
 from sentry.auth.superuser import is_active_superuser
 from sentry.constants import WARN_SESSION_EXPIRED
 from sentry.http import get_server_hostname
@@ -26,6 +25,7 @@ from sentry.models.authprovider import AuthProvider
 from sentry.models.organization import OrganizationStatus
 from sentry.models.organizationmapping import OrganizationMapping
 from sentry.models.user import User
+from sentry.organizations.absolute_url import generate_organization_url
 from sentry.organizations.services.organization import RpcOrganization, organization_service
 from sentry.signals import join_request_link_viewed, user_signup
 from sentry.types.ratelimit import RateLimit, RateLimitCategory

--- a/src/sentry/web/frontend/base.py
+++ b/src/sentry/web/frontend/base.py
@@ -25,7 +25,7 @@ from django.views.generic import View
 from rest_framework.request import Request
 
 from sentry import options
-from sentry.api.utils import generate_organization_url, is_member_disabled_from_limit
+from sentry.api.utils import is_member_disabled_from_limit
 from sentry.auth import access
 from sentry.auth.superuser import is_active_superuser
 from sentry.constants import ObjectStatus
@@ -33,6 +33,7 @@ from sentry.middleware.placeholder import placeholder_get_response
 from sentry.models.avatars.base import AvatarBase
 from sentry.models.organization import Organization, OrganizationStatus
 from sentry.models.project import Project
+from sentry.organizations.absolute_url import generate_organization_url
 from sentry.organizations.services.organization import (
     RpcOrganization,
     RpcOrganizationSummary,

--- a/src/sentry/web/frontend/pipeline_advancer.py
+++ b/src/sentry/web/frontend/pipeline_advancer.py
@@ -4,9 +4,9 @@ from django.http.response import HttpResponseBase
 from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
 
-from sentry.api.utils import generate_organization_url
 from sentry.identity.pipeline import IdentityProviderPipeline
 from sentry.integrations.pipeline import IntegrationPipeline
+from sentry.organizations.absolute_url import generate_organization_url
 from sentry.utils.http import absolute_uri, create_redirect_url
 from sentry.web.frontend.base import BaseView
 

--- a/src/sentry/web/frontend/react_page.py
+++ b/src/sentry/web/frontend/react_page.py
@@ -12,7 +12,7 @@ from django.urls import resolve
 from rest_framework.request import Request
 
 from sentry import features, options
-from sentry.api.utils import customer_domain_path, generate_organization_url
+from sentry.organizations.absolute_url import customer_domain_path, generate_organization_url
 from sentry.organizations.services.organization import organization_service
 from sentry.types.region import subdomain_is_region
 from sentry.users.services.user.model import RpcUser

--- a/tests/sentry/api/test_utils.py
+++ b/tests/sentry/api/test_utils.py
@@ -9,7 +9,6 @@ from sentry_sdk import Scope
 
 from sentry.api.utils import (
     MAX_STATS_PERIOD,
-    customer_domain_path,
     get_date_range_from_params,
     handle_query_errors,
     print_and_capture_handler_exception,
@@ -162,75 +161,6 @@ class PrintAndCaptureHandlerExceptionTest(APITestCase):
             assert isinstance(capture_exception_scope_kwarg, Scope)
             assert capture_exception_scope_kwarg._contexts == expected_scope_contexts
             assert capture_exception_scope_kwarg._tags == expected_scope_tags
-
-
-def test_customer_domain_path():
-    scenarios = [
-        # Input, expected
-        ["/settings/", "/settings/"],
-        # Organization settings views.
-        ["/settings/acme/", "/settings/organization/"],
-        ["/settings/organization", "/settings/organization/"],
-        ["/settings/sentry/members/", "/settings/members/"],
-        ["/settings/sentry/members/3/", "/settings/members/3/"],
-        ["/settings/sentry/teams/peeps/", "/settings/teams/peeps/"],
-        ["/settings/sentry/billing/receipts/", "/settings/billing/receipts/"],
-        [
-            "/settings/acme/developer-settings/release-bot/",
-            "/settings/developer-settings/release-bot/",
-        ],
-        # Settings views for orgs with acccount/billing in their slugs.
-        ["/settings/account-on/", "/settings/organization/"],
-        ["/settings/billing-co/", "/settings/organization/"],
-        ["/settings/account-on/integrations/", "/settings/integrations/"],
-        [
-            "/settings/account-on/projects/billing-app/source-maps/",
-            "/settings/projects/billing-app/source-maps/",
-        ],
-        ["/settings/billing-co/integrations/", "/settings/integrations/"],
-        [
-            "/settings/billing-co/projects/billing-app/source-maps/",
-            "/settings/projects/billing-app/source-maps/",
-        ],
-        # Account settings should stay the same
-        ["/settings/account/", "/settings/account/"],
-        ["/settings/account/security/", "/settings/account/security/"],
-        ["/settings/account/details/", "/settings/account/details/"],
-        ["/join-request/acme", "/join-request/"],
-        ["/join-request/acme/", "/join-request/"],
-        ["/onboarding/acme/", "/onboarding/"],
-        ["/onboarding/acme/project/", "/onboarding/project/"],
-        ["/organizations/new/", "/organizations/new/"],
-        ["/organizations/albertos-apples/issues/", "/issues/"],
-        ["/organizations/albertos-apples/issues/?_q=all#hash", "/issues/?_q=all#hash"],
-        ["/acme/project-slug/getting-started/", "/getting-started/project-slug/"],
-        [
-            "/acme/project-slug/getting-started/python",
-            "/getting-started/project-slug/python",
-        ],
-        ["/settings/projects/python/filters/", "/settings/projects/python/filters/"],
-        ["/settings/projects/onboarding/abc123/", "/settings/projects/onboarding/abc123/"],
-        [
-            "/settings/projects/join-request/abc123/",
-            "/settings/projects/join-request/abc123/",
-        ],
-        [
-            "/settings/projects/python/filters/discarded/",
-            "/settings/projects/python/filters/discarded/",
-        ],
-        [
-            "/settings/projects/getting-started/abc123/",
-            "/settings/projects/getting-started/abc123/",
-        ],
-        ["/settings/teams/peeps/", "/settings/teams/peeps/"],
-        ["/settings/billing/checkout/?_q=all#hash", "/settings/billing/checkout/?_q=all#hash"],
-        [
-            "/settings/billing/bundle-checkout/?_q=all#hash",
-            "/settings/billing/bundle-checkout/?_q=all#hash",
-        ],
-    ]
-    for input_path, expected in scenarios:
-        assert expected == customer_domain_path(input_path)
 
 
 class FooBarError(Exception):

--- a/tests/sentry/integrations/github/test_integration.py
+++ b/tests/sentry/integrations/github/test_integration.py
@@ -14,7 +14,6 @@ from django.urls import reverse
 
 import sentry
 from fixtures.github import INSTALLATION_EVENT_EXAMPLE
-from sentry.api.utils import generate_organization_url
 from sentry.constants import ObjectStatus
 from sentry.integrations.github import (
     API_ERRORS,
@@ -29,6 +28,7 @@ from sentry.integrations.models.organization_integration import OrganizationInte
 from sentry.integrations.utils.code_mapping import Repo, RepoTree
 from sentry.models.project import Project
 from sentry.models.repository import Repository
+from sentry.organizations.absolute_url import generate_organization_url
 from sentry.plugins.base import plugins
 from sentry.plugins.bases.issue2 import IssueTrackingPlugin2
 from sentry.shared_integrations.exceptions import ApiError

--- a/tests/sentry/integrations/test_pipeline.py
+++ b/tests/sentry/integrations/test_pipeline.py
@@ -2,7 +2,6 @@ from unittest.mock import patch
 
 from django.db import router
 
-from sentry.api.utils import generate_organization_url
 from sentry.integrations.example import AliasedIntegrationProvider, ExampleIntegrationProvider
 from sentry.integrations.gitlab.integration import GitlabIntegrationProvider
 from sentry.integrations.models.integration import Integration
@@ -10,6 +9,7 @@ from sentry.integrations.models.organization_integration import OrganizationInte
 from sentry.models.identity import Identity
 from sentry.models.organizationmapping import OrganizationMapping
 from sentry.models.repository import Repository
+from sentry.organizations.absolute_url import generate_organization_url
 from sentry.plugins.base import plugins
 from sentry.plugins.bases.issue2 import IssuePlugin2
 from sentry.signals import receivers_raise_on_send

--- a/tests/sentry/organizations/test_absolute_url.py
+++ b/tests/sentry/organizations/test_absolute_url.py
@@ -1,0 +1,73 @@
+import pytest
+
+from sentry.organizations.absolute_url import customer_domain_path
+
+
+@pytest.mark.parametrize(
+    ("input", "expected"),
+    (
+        ("/settings/", "/settings/"),
+        # Organization settings views.
+        ("/settings/acme/", "/settings/organization/"),
+        ("/settings/organization", "/settings/organization/"),
+        ("/settings/sentry/members/", "/settings/members/"),
+        ("/settings/sentry/members/3/", "/settings/members/3/"),
+        ("/settings/sentry/teams/peeps/", "/settings/teams/peeps/"),
+        ("/settings/sentry/billing/receipts/", "/settings/billing/receipts/"),
+        (
+            "/settings/acme/developer-settings/release-bot/",
+            "/settings/developer-settings/release-bot/",
+        ),
+        # Settings views for orgs with acccount/billing in their slugs.
+        ("/settings/account-on/", "/settings/organization/"),
+        ("/settings/billing-co/", "/settings/organization/"),
+        ("/settings/account-on/integrations/", "/settings/integrations/"),
+        (
+            "/settings/account-on/projects/billing-app/source-maps/",
+            "/settings/projects/billing-app/source-maps/",
+        ),
+        ("/settings/billing-co/integrations/", "/settings/integrations/"),
+        (
+            "/settings/billing-co/projects/billing-app/source-maps/",
+            "/settings/projects/billing-app/source-maps/",
+        ),
+        # Account settings should stay the same
+        ("/settings/account/", "/settings/account/"),
+        ("/settings/account/security/", "/settings/account/security/"),
+        ("/settings/account/details/", "/settings/account/details/"),
+        ("/join-request/acme", "/join-request/"),
+        ("/join-request/acme/", "/join-request/"),
+        ("/onboarding/acme/", "/onboarding/"),
+        ("/onboarding/acme/project/", "/onboarding/project/"),
+        ("/organizations/new/", "/organizations/new/"),
+        ("/organizations/albertos-apples/issues/", "/issues/"),
+        ("/organizations/albertos-apples/issues/?_q=all#hash", "/issues/?_q=all#hash"),
+        ("/acme/project-slug/getting-started/", "/getting-started/project-slug/"),
+        (
+            "/acme/project-slug/getting-started/python",
+            "/getting-started/project-slug/python",
+        ),
+        ("/settings/projects/python/filters/", "/settings/projects/python/filters/"),
+        ("/settings/projects/onboarding/abc123/", "/settings/projects/onboarding/abc123/"),
+        (
+            "/settings/projects/join-request/abc123/",
+            "/settings/projects/join-request/abc123/",
+        ),
+        (
+            "/settings/projects/python/filters/discarded/",
+            "/settings/projects/python/filters/discarded/",
+        ),
+        (
+            "/settings/projects/getting-started/abc123/",
+            "/settings/projects/getting-started/abc123/",
+        ),
+        ("/settings/teams/peeps/", "/settings/teams/peeps/"),
+        ("/settings/billing/checkout/?_q=all#hash", "/settings/billing/checkout/?_q=all#hash"),
+        (
+            "/settings/billing/bundle-checkout/?_q=all#hash",
+            "/settings/billing/bundle-checkout/?_q=all#hash",
+        ),
+    ),
+)
+def test_customer_domain_path(input: str, expected: str) -> None:
+    assert expected == customer_domain_path(input)


### PR DESCRIPTION
this is step 1 -- need to do some cleanup in getsentry once these functions are available and then I can kill the organization absolute_url mixin which isn't typesafe

<!-- Describe your PR here. -->