### PR TITLE
feat(api): Make certain performance endpoints private

### DIFF
--- a/src/sentry/api/endpoints/project_create_sample_transaction.py
+++ b/src/sentry/api/endpoints/project_create_sample_transaction.py
@@ -68,7 +68,7 @@ def fix_event_data(data):
 class ProjectCreateSampleTransactionEndpoint(ProjectEndpoint):
     owner = ApiOwner.PERFORMANCE
     publish_status = {
-        "POST": ApiPublishStatus.UNKNOWN,
+        "POST": ApiPublishStatus.PRIVATE,
     }
     # Members should be able to create sample events.
     # This is the same scope that allows members to view all issues for a project.

--- a/src/sentry/api/endpoints/project_performance_issue_settings.py
+++ b/src/sentry/api/endpoints/project_performance_issue_settings.py
@@ -166,9 +166,9 @@ def get_disabled_threshold_options(payload, current_settings):
 class ProjectPerformanceIssueSettingsEndpoint(ProjectEndpoint):
     owner = ApiOwner.PERFORMANCE
     publish_status = {
-        "DELETE": ApiPublishStatus.UNKNOWN,
-        "GET": ApiPublishStatus.UNKNOWN,
-        "PUT": ApiPublishStatus.UNKNOWN,
+        "DELETE": ApiPublishStatus.PRIVATE,
+        "GET": ApiPublishStatus.PRIVATE,
+        "PUT": ApiPublishStatus.PRIVATE,
     }
     permission_classes = (ProjectSettingPermission,)
 

--- a/src/sentry/api/endpoints/project_transaction_threshold.py
+++ b/src/sentry/api/endpoints/project_transaction_threshold.py
@@ -44,9 +44,9 @@ class ProjectTransactionThresholdSerializer(serializers.Serializer):
 class ProjectTransactionThresholdEndpoint(ProjectEndpoint):
     owner = ApiOwner.PERFORMANCE
     publish_status = {
-        "DELETE": ApiPublishStatus.UNKNOWN,
-        "GET": ApiPublishStatus.UNKNOWN,
-        "POST": ApiPublishStatus.UNKNOWN,
+        "DELETE": ApiPublishStatus.PRIVATE,
+        "GET": ApiPublishStatus.PRIVATE,
+        "POST": ApiPublishStatus.PRIVATE,
     }
     permission_classes = (ProjectSettingPermission,)
 

--- a/src/sentry/data_export/endpoints/data_export.py
+++ b/src/sentry/data_export/endpoints/data_export.py
@@ -124,7 +124,7 @@ class DataExportQuerySerializer(serializers.Serializer):
 @region_silo_endpoint
 class DataExportEndpoint(OrganizationEndpoint, EnvironmentMixin):
     publish_status = {
-        "POST": ApiPublishStatus.UNKNOWN,
+        "POST": ApiPublishStatus.PRIVATE,
     }
     permission_classes = (OrganizationDataExportPermission,)
 

--- a/src/sentry/data_export/endpoints/data_export_details.py
+++ b/src/sentry/data_export/endpoints/data_export_details.py
@@ -19,7 +19,7 @@ from ..models import ExportedData
 @region_silo_endpoint
 class DataExportDetailsEndpoint(OrganizationEndpoint):
     publish_status = {
-        "GET": ApiPublishStatus.UNKNOWN,
+        "GET": ApiPublishStatus.PRIVATE,
     }
     owner = ApiOwner.PERFORMANCE
     permission_classes = (OrganizationDataExportPermission,)


### PR DESCRIPTION
1. Create sample transaction is just used for performance empty state, it's just used to power that UI, can be private
2. Unsure about the future of project/transaction thresholds with the move to spans, so going to set that as private too
3. Performance settings as private
4. Data Export:
- this endpoint isn't very well maintained and quite outdated. publicizing it will likely require re-implementation of the endpoint, since right now, it accepts free form JSON objects for the query which require different fields depending on they type of query (discover vs issues by tags). 
- the data returned by this endpoint can also be obtained through the `events/` endpoint which is public and documented, so marking this as private for now