### PR TITLE
feat(profiling): Add digest and profiles to profiles tab

### DIFF
--- a/static/app/components/profiling/profileEventsTable.tsx
+++ b/static/app/components/profiling/profileEventsTable.tsx
@@ -319,10 +319,14 @@ function getProjectForRow<F extends FieldType>(
 const FIELDS = [
   'id',
   'profile.id',
+  'profiler.id',
+  'thread.id',
   'trace.transaction',
   'trace',
   'transaction',
   'transaction.duration',
+  'precise.start_ts',
+  'precise.finish_ts',
   'profile.duration',
   'project',
   'project.id',
@@ -372,6 +376,16 @@ const COLUMN_ORDERS: Record<FieldType, GridColumnOrder<FieldType>> = {
     name: t('Profile ID'),
     width: COL_WIDTH_UNDEFINED,
   },
+  'profiler.id': {
+    key: 'profiler.id',
+    name: t('Profiler ID'),
+    width: COL_WIDTH_UNDEFINED,
+  },
+  'thread.id': {
+    key: 'thread.id',
+    name: t('Thread ID'),
+    width: COL_WIDTH_UNDEFINED,
+  },
   transaction: {
     key: 'transaction',
     name: t('Transaction'),
@@ -390,6 +404,16 @@ const COLUMN_ORDERS: Record<FieldType, GridColumnOrder<FieldType>> = {
   'trace.transaction': {
     key: 'trace.transaction',
     name: t('Transaction ID'),
+    width: COL_WIDTH_UNDEFINED,
+  },
+  'precise.start_ts': {
+    key: 'precise.start_ts',
+    name: t('Precise Start Timestamp'),
+    width: COL_WIDTH_UNDEFINED,
+  },
+  'precise.finish_ts': {
+    key: 'precise.finish_ts',
+    name: t('Precise Finish Timestamp'),
     width: COL_WIDTH_UNDEFINED,
   },
   'profile.duration': {

--- a/static/app/utils/analytics/profilingAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/profilingAnalyticsEvents.tsx
@@ -17,6 +17,7 @@ type ProfilingEventSource =
   | 'profiling_transaction.suspect_functions_table'
   | 'profiling_transaction.slowest_functions_table'
   | 'profiling_transaction.regressed_functions_table'
+  | 'profiling_transaction.profiles_table'
   | 'slowest_transaction_panel'
   | 'transaction_details'
   | 'transaction_hovercard.latest_profile'

--- a/static/app/utils/profiling/hooks/useProfileEvents.tsx
+++ b/static/app/utils/profiling/hooks/useProfileEvents.tsx
@@ -90,13 +90,21 @@ export function formatError(error: any): string | null {
 }
 
 const ALL_FIELDS = [
+  'id',
+  'trace',
   'profile.id',
+  'profiler.id',
+  'thread.id',
+  'precise.start_ts',
+  'precise.finish_ts',
+  'project.name',
   'timestamp',
   'release',
   'device.model',
   'device.classification',
   'device.arch',
   'transaction.duration',
+  'p50()',
   'p75()',
   'p95()',
   'p99()',

--- a/static/app/views/performance/newTraceDetails/traceMetadataHeader.tsx
+++ b/static/app/views/performance/newTraceDetails/traceMetadataHeader.tsx
@@ -38,6 +38,7 @@ export const enum TraceViewSources {
   CACHES_MODULE = 'caches_module',
   QUEUES_MODULE = 'queues_module',
   PERFORMANCE_TRANSACTION_SUMMARY = 'performance_transaction_summary',
+  PERFORMANCE_TRANSACTION_SUMMARY_PROFILES = 'performance_transaction_summary_profiles',
   ISSUE_DETAILS = 'issue_details',
 }
 

--- a/static/app/views/performance/transactionSummary/transactionProfiles/content.tsx
+++ b/static/app/views/performance/transactionSummary/transactionProfiles/content.tsx
@@ -1,17 +1,29 @@
-import {useCallback, useMemo} from 'react';
+import {Fragment, useCallback, useMemo, useState} from 'react';
 import styled from '@emotion/styled';
 
-import {Button} from 'sentry/components/button';
+import {Button, LinkButton} from 'sentry/components/button';
+import {SectionHeading} from 'sentry/components/charts/styles';
 import {CompactSelect} from 'sentry/components/compactSelect';
 import type {SelectOption} from 'sentry/components/compactSelect/types';
+import Count from 'sentry/components/count';
+import {DateTime} from 'sentry/components/dateTime';
+import Link from 'sentry/components/links/link';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
+import Pagination from 'sentry/components/pagination';
+import PerformanceDuration from 'sentry/components/performanceDuration';
 import {AggregateFlamegraph} from 'sentry/components/profiling/flamegraph/aggregateFlamegraph';
 import {AggregateFlamegraphTreeTable} from 'sentry/components/profiling/flamegraph/aggregateFlamegraphTreeTable';
 import {FlamegraphSearch} from 'sentry/components/profiling/flamegraph/flamegraphToolbar/flamegraphSearch';
 import {SegmentedControl} from 'sentry/components/segmentedControl';
+import {IconProfiling} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {DeepPartial} from 'sentry/types/utils';
+import {trackAnalytics} from 'sentry/utils/analytics';
+import {browserHistory} from 'sentry/utils/browserHistory';
+import {generateLinkToEventInTraceView} from 'sentry/utils/discover/urls';
+import {getShortEventId} from 'sentry/utils/events';
+import {isEmptyObject} from 'sentry/utils/object/isEmptyObject';
 import type {CanvasScheduler} from 'sentry/utils/profiling/canvasScheduler';
 import {
   CanvasPoolManager,
@@ -22,12 +34,20 @@ import {FlamegraphStateProvider} from 'sentry/utils/profiling/flamegraph/flamegr
 import {FlamegraphThemeProvider} from 'sentry/utils/profiling/flamegraph/flamegraphThemeProvider';
 import type {Frame} from 'sentry/utils/profiling/frame';
 import {useAggregateFlamegraphQuery} from 'sentry/utils/profiling/hooks/useAggregateFlamegraphQuery';
+import type {ProfilingFieldType} from 'sentry/utils/profiling/hooks/useProfileEvents';
+import {useProfileEvents} from 'sentry/utils/profiling/hooks/useProfileEvents';
+import {decodeScalar} from 'sentry/utils/queryString';
 import {useLocalStorageState} from 'sentry/utils/useLocalStorageState';
+import {useLocation} from 'sentry/utils/useLocation';
+import useOrganization from 'sentry/utils/useOrganization';
+import {TraceViewSources} from 'sentry/views/performance/newTraceDetails/traceMetadataHeader';
 import {
   FlamegraphProvider,
   useFlamegraph,
 } from 'sentry/views/profiling/flamegraphProvider';
 import {ProfileGroupProvider} from 'sentry/views/profiling/profileGroupProvider';
+
+import {generateProfileLink} from '../utils';
 
 const DEFAULT_FLAMEGRAPH_PREFERENCES: DeepPartial<FlamegraphState> = {
   preferences: {
@@ -39,9 +59,22 @@ const noop = () => void 0;
 
 interface TransactionProfilesContentProps {
   query: string;
+  transaction: string;
 }
 
-export function TransactionProfilesContent({query}: TransactionProfilesContentProps) {
+export function TransactionProfilesContent(props: TransactionProfilesContentProps) {
+  return (
+    <TransactionProfilesContentContainer>
+      <ProfileVisualization {...props} />
+      <ProfileSidebarContainer>
+        <ProfileDigest {...props} />
+        <ProfileList {...props} />
+      </ProfileSidebarContainer>
+    </TransactionProfilesContentContainer>
+  );
+}
+
+function ProfileVisualization({query}: TransactionProfilesContentProps) {
   const {data, isLoading, isError} = useAggregateFlamegraphQuery({
     query,
   });
@@ -82,7 +115,7 @@ export function TransactionProfilesContent({query}: TransactionProfilesContentPr
   const scheduler = useCanvasScheduler(canvasPoolManager);
 
   return (
-    <ProfileVisualization>
+    <ProfileVisualizationContainer>
       <ProfileGroupProvider
         traceID=""
         type="flamegraph"
@@ -131,7 +164,7 @@ export function TransactionProfilesContent({query}: TransactionProfilesContentPr
           </FlamegraphThemeProvider>
         </FlamegraphStateProvider>
       </ProfileGroupProvider>
-    </ProfileVisualization>
+    </ProfileVisualizationContainer>
   );
 }
 
@@ -204,14 +237,249 @@ function AggregateFlamegraphToolbar(props: AggregateFlamegraphToolbarProps) {
   );
 }
 
-const ProfileVisualization = styled('div')`
+const PERCENTILE_DIGESTS = [
+  'p50()',
+  'p75()',
+  'p95()',
+  'p99()',
+] satisfies ProfilingFieldType[];
+const ALL_DIGESTS = [
+  ...PERCENTILE_DIGESTS,
+  'last_seen()',
+  'count()',
+] satisfies ProfilingFieldType[];
+
+function ProfileDigest({query}: TransactionProfilesContentProps) {
+  const organization = useOrganization();
+
+  const profilesSummary = useProfileEvents<ProfilingFieldType>({
+    fields: ALL_DIGESTS,
+    query,
+    sort: {key: 'last_seen()', order: 'desc'},
+    referrer: 'api.profiling.profile-summary-table',
+    continuousProfilingCompat: organization.features.includes(
+      'continuous-profiling-compat'
+    ),
+  });
+
+  const digestData = profilesSummary.data?.data?.[0];
+
+  return (
+    <ProfileDigestContainer>
+      <ProfileDigestLabel>{t('Last Seen')}</ProfileDigestLabel>
+      <ProfileDigestValue align="right">
+        {profilesSummary.isLoading ? (
+          ''
+        ) : profilesSummary.isError ? (
+          ''
+        ) : (
+          <DateTime date={new Date(digestData?.['last_seen()'] as string)} />
+        )}
+      </ProfileDigestValue>
+      <ProfileDigestLabel>{t('Count')}</ProfileDigestLabel>
+      <ProfileDigestValue align="right">
+        {profilesSummary.isLoading ? (
+          ''
+        ) : profilesSummary.isError ? (
+          ''
+        ) : (
+          <Count value={digestData?.['count()'] as number} />
+        )}
+      </ProfileDigestValue>
+      {PERCENTILE_DIGESTS.map(percentile => (
+        <Fragment key={percentile}>
+          <ProfileDigestLabel>
+            {percentile.substring(0, percentile.length - 2)}
+          </ProfileDigestLabel>
+          <ProfileDigestValue align="right">
+            {profilesSummary.isLoading ? (
+              ''
+            ) : profilesSummary.isError ? (
+              ''
+            ) : (
+              <PerformanceDuration
+                milliseconds={digestData?.[percentile] as number}
+                abbreviation
+              />
+            )}
+          </ProfileDigestValue>
+        </Fragment>
+      ))}
+    </ProfileDigestContainer>
+  );
+}
+
+type SortOption = 'newest' | 'oldest' | 'slowest' | 'fastest';
+
+const sortOptions: SelectOption<SortOption>[] = [
+  {value: 'newest', label: t('Newest Events')},
+  {value: 'oldest', label: t('Oldest Events')},
+  {value: 'slowest', label: t('Slowest Events')},
+  {value: 'fastest', label: t('Fastest Events')},
+];
+
+const PROFILES_CURSOR = 'profilesCursor';
+
+function ProfileList({query: userQuery, transaction}: TransactionProfilesContentProps) {
+  const location = useLocation();
+  const organization = useOrganization();
+
+  const [selectedSort, setSelectedSort] = useState<SortOption>('newest');
+  const onSelectedSortChange = useCallback(
+    (value: {value: SortOption}) => {
+      setSelectedSort(value.value);
+    },
+    [setSelectedSort]
+  );
+
+  const sort = useMemo(() => {
+    if (selectedSort === 'fastest') {
+      return {key: 'transaction.duration', order: 'asc'} as const;
+    }
+
+    if (selectedSort === 'slowest') {
+      return {key: 'transaction.duration', order: 'desc'} as const;
+    }
+
+    if (selectedSort === 'oldest') {
+      return {key: 'timestamp', order: 'asc'} as const;
+    }
+
+    return {key: 'timestamp', order: 'desc'} as const;
+  }, [selectedSort]);
+
+  const profilesCursor = useMemo(
+    () => decodeScalar(location.query[PROFILES_CURSOR]),
+    [location.query]
+  );
+
+  const profilesList = useProfileEvents<ProfilingFieldType>({
+    fields: [
+      'id',
+      'project.name',
+      'trace',
+      'transaction.duration',
+      'profile.id',
+      'profiler.id',
+      'thread.id',
+      'precise.start_ts',
+      'precise.finish_ts',
+      'timestamp',
+    ],
+    query: userQuery,
+    sort,
+    referrer: 'api.profiling.profile-summary-table',
+    cursor: profilesCursor,
+    limit: 10,
+    continuousProfilingCompat: organization.features.includes(
+      'continuous-profiling-compat'
+    ),
+  });
+
+  const handleCursor = useCallback((cursor, pathname, query) => {
+    browserHistory.push({
+      pathname,
+      query: {...query, [PROFILES_CURSOR]: cursor},
+    });
+  }, []);
+
+  return (
+    <ProfileListContainer>
+      <ProfileListControls>
+        <CompactSelect
+          onChange={onSelectedSortChange}
+          value={selectedSort}
+          size="xs"
+          options={sortOptions}
+        />
+        <StyledPagination
+          pageLinks={profilesList.getResponseHeader?.('Link')}
+          onCursor={handleCursor}
+          size="xs"
+        />
+      </ProfileListControls>
+      <ProfileListResultsContainer>
+        <ProfileDigestLabel>{t('Event ID')}</ProfileDigestLabel>
+        <ProfileDigestLabel align="right">{t('Duration')}</ProfileDigestLabel>
+        <ProfileDigestLabel align="right">{t('Profile')}</ProfileDigestLabel>
+        {profilesList.data?.data?.map(row => {
+          const traceTarget = generateLinkToEventInTraceView({
+            eventId: row.id as string,
+            timestamp: row.timestamp as string,
+            traceSlug: row.trace as string,
+            projectSlug: row['project.name'] as string,
+            location,
+            organization,
+            transactionName: transaction,
+            source: TraceViewSources.PERFORMANCE_TRANSACTION_SUMMARY_PROFILES,
+          });
+
+          const profileTarget = generateProfileLink()(
+            organization,
+            {
+              id: row.id as string,
+              'project.name': row['project.name'] as string,
+              'profile.id': (row['profile.id'] as string) || '',
+              'profiler.id': (row['profiler.id'] as string) || '',
+              'thread.id': (row['thread.id'] as string) || '',
+              'precise.start_ts': row['precise.start_ts'] as number,
+              'precise.finish_ts': row['precise.finish_ts'] as number,
+              trace: row.trace as string,
+            },
+            location
+          );
+
+          return (
+            <Fragment key={row.id as string}>
+              <ProfileDigestValue align="left">
+                <Link to={traceTarget}>{getShortEventId(row.id as string)}</Link>
+              </ProfileDigestValue>
+              <ProfileDigestValue align="right">
+                <PerformanceDuration
+                  milliseconds={(row?.['transaction.duration'] as number) ?? 0}
+                  abbreviation
+                />
+              </ProfileDigestValue>
+              <ProfileDigestValue align="right">
+                <LinkButton
+                  disabled={!profileTarget || isEmptyObject(profileTarget)}
+                  to={profileTarget || {}}
+                  onClick={() => {
+                    trackAnalytics('profiling_views.go_to_flamegraph', {
+                      organization,
+                      source: 'profiling_transaction.profiles_table',
+                    });
+                  }}
+                  size="xs"
+                >
+                  <IconProfiling size="xs" />
+                </LinkButton>
+              </ProfileDigestValue>
+            </Fragment>
+          );
+        })}
+      </ProfileListResultsContainer>
+    </ProfileListContainer>
+  );
+}
+
+const TransactionProfilesContentContainer = styled('div')`
   display: grid;
-  grid-template-rows: min-content 1fr;
-  height: 100%;
+  /* false positive for grid layout */
+  /* stylelint-disable */
+  grid-template-areas: 'visualization digest';
+  grid-template-columns: 1fr 250px;
   flex: 1;
   border: 1px solid ${p => p.theme.border};
   border-radius: ${p => p.theme.borderRadius};
   overflow: hidden;
+`;
+
+const ProfileVisualizationContainer = styled('div')`
+  grid-area: visualization;
+  display: grid;
+  grid-template-rows: min-content 1fr;
+  height: 100%;
 `;
 
 const FlamegraphContainer = styled('div')`
@@ -252,4 +520,53 @@ const ViewSelectContainer = styled('div')`
 
 const AggregateFlamegraphSearch = styled(FlamegraphSearch)`
   max-width: 300px;
+`;
+
+const ProfileSidebarContainer = styled('div')`
+  grid-area: digest;
+  border-left: 1px solid ${p => p.theme.border};
+  background-color: ${p => p.theme.background};
+  position: relative;
+  overflow: hidden;
+  display: grid;
+  grid-template-rows: min-content 1fr;
+`;
+
+const ProfileDigestContainer = styled('div')`
+  display: grid;
+  grid-template-columns: min-content 1fr;
+  padding: ${space(2)};
+  gap: ${space(1)};
+`;
+
+const ProfileListContainer = styled('div')`
+  padding: ${space(2)};
+  border-top: 1px solid ${p => p.theme.border};
+`;
+
+const ProfileListControls = styled('div')`
+  display: flex;
+  justify-content: space-between;
+  margin-bottom: ${space(2)};
+`;
+
+const StyledPagination = styled(Pagination)`
+  margin: 0;
+`;
+
+const ProfileListResultsContainer = styled('div')`
+  display: grid;
+  grid-template-columns: min-content 1fr min-content;
+  gap: ${space(1)};
+`;
+
+const ProfileDigestLabel = styled(SectionHeading)<{align?: 'left' | 'right'}>`
+  margin: 0;
+  text-transform: uppercase;
+  text-wrap: nowrap;
+  text-align: ${p => p.align ?? 'left'};
+`;
+
+const ProfileDigestValue = styled('div')<{align: 'left' | 'right'}>`
+  text-align: ${p => p.align};
 `;

--- a/static/app/views/performance/transactionSummary/transactionProfiles/index.tsx
+++ b/static/app/views/performance/transactionSummary/transactionProfiles/index.tsx
@@ -199,7 +199,7 @@ function Profiles({organization, transaction}: ProfilesProps) {
                 <EnvironmentPageFilter />
                 <DatePageFilter />
               </PageFilterBar>
-              <StyledSearchBar
+              <SearchBar
                 searchSource="transaction_profiles"
                 organization={organization}
                 projectIds={projects.projects.map(p => parseInt(p.id, 10))}
@@ -208,7 +208,7 @@ function Profiles({organization, transaction}: ProfilesProps) {
                 maxQueryLength={MAX_QUERY_LENGTH}
               />
             </FilterActions>
-            <TransactionProfilesContent query={query} />
+            <TransactionProfilesContent query={query} transaction={transaction} />
           </StyledMain>
         );
       }}
@@ -221,18 +221,6 @@ const FilterActions = styled('div')`
   gap: ${space(2)};
   display: grid;
   grid-template-columns: min-content 1fr;
-`;
-
-const StyledSearchBar = styled(SearchBar)`
-  @media (min-width: ${p => p.theme.breakpoints.small}) {
-    order: 1;
-    grid-column: 1/4;
-  }
-
-  @media (min-width: ${p => p.theme.breakpoints.xlarge}) {
-    order: initial;
-    grid-column: auto;
-  }
 `;
 
 const StyledMain = styled(Layout.Main)`


### PR DESCRIPTION
This adds a sidebar to the profiles tab showing a digest of the transactions with profiles and a list of profiled events.