### PR TITLE
ref: fix mypy ignored errors checker in CI

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -325,6 +325,7 @@ jobs:
 
       - run: |
           # mypy does not have granular codes so don't allow specific messages to regress
+          set -euo pipefail
           ! grep "'Settings' object has no attribute" .artifacts/mypy-all
           ! grep 'Cannot override class variable' .artifacts/mypy-all
           ! grep 'Exception type must be derived from BaseException' .artifacts/mypy-all

--- a/src/sentry/integrations/github/integration.py
+++ b/src/sentry/integrations/github/integration.py
@@ -6,7 +6,7 @@ from collections.abc import Collection, Mapping, Sequence
 from typing import Any
 from urllib.parse import parse_qsl
 
-from django.http import HttpResponse
+from django.http.response import HttpResponseBase
 from django.urls import reverse
 from django.utils.text import slugify
 from django.utils.translation import gettext_lazy as _
@@ -384,7 +384,7 @@ class GitHubIntegrationProvider(IntegrationProvider):
 
 
 class OAuthLoginView(PipelineView):
-    def dispatch(self, request: Request, pipeline) -> HttpResponse:
+    def dispatch(self, request: Request, pipeline) -> HttpResponseBase:
         self.determine_active_organization(request)
 
         ghip = GitHubIdentityProvider()
@@ -441,7 +441,7 @@ class GitHubInstallation(PipelineView):
         name = options.get("github-app.name")
         return f"https://github.com/apps/{slugify(name)}"
 
-    def dispatch(self, request: Request, pipeline: Pipeline) -> HttpResponse:
+    def dispatch(self, request: Request, pipeline: Pipeline) -> HttpResponseBase:
         installation_id = request.GET.get(
             "installation_id", pipeline.fetch_state("installation_id")
         )

--- a/src/sentry/tagstore/snuba/backend.py
+++ b/src/sentry/tagstore/snuba/backend.py
@@ -1176,7 +1176,7 @@ class SnubaTagStorage(TagStorage):
         key,
         start=None,
         end=None,
-        dataset: Dataset = None,
+        dataset: Dataset | None = None,
         query: str | None = None,
         order_by="-last_seen",
         include_transactions: bool = False,

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -3250,7 +3250,7 @@ class UptimeTestCase(TestCase):
         self,
         subscription_id: str | None = None,
         status: str = CHECKSTATUS_FAILURE,
-        scheduled_check_time: datetime = None,
+        scheduled_check_time: datetime | None = None,
     ) -> CheckResult:
         if subscription_id is None:
             subscription_id = uuid.uuid4().hex
@@ -3287,9 +3287,9 @@ class SpanTestCase(BaseTestCase):
     def load_data(
         self,
         platform: str = "transaction",
-        timestamp: datetime = None,
-        duration: timedelta = None,
-        **kwargs: dict[str, Any],
+        timestamp: datetime | None = None,
+        duration: timedelta | None = None,
+        **kwargs: Any,
     ) -> dict[str | int, Any]:
         if timestamp is None:
             timestamp = self.ten_mins_ago

--- a/src/sentry/web/frontend/auth_login.py
+++ b/src/sentry/web/frontend/auth_login.py
@@ -213,7 +213,7 @@ class AuthLoginView(BaseView):
         )
         return self.respond_login(request=request, context=context, **kwargs)
 
-    def post(self, request: Request, **kwargs) -> HttpResponse:
+    def post(self, request: Request, **kwargs) -> HttpResponseBase:
         op = request.POST.get("op")
         if op == "sso" and request.POST.get("organization"):
             return self.redirect_post_to_sso(request=request)
@@ -265,7 +265,7 @@ class AuthLoginView(BaseView):
 
     def handle_register_form_submit(
         self, request: Request, organization: RpcOrganization, **kwargs
-    ) -> HttpResponse:
+    ) -> HttpResponseBase:
         """
         Validates a completed register form, redirecting to the next
         step or returning the form with its errors displayed.


### PR DESCRIPTION
bash sucks, these are the errors that snuck through in ignored files that the ci check was supposed to prevent:

```
src/sentry/tagstore/snuba/backend.py:1179: error: Incompatible default for argument "dataset" (default has type "None", argument has type "Dataset")  [assignment]
src/sentry/testutils/cases.py:3253: error: Incompatible default for argument "scheduled_check_time" (default has type "None", argument has type "datetime")  [assignment]
src/sentry/testutils/cases.py:3290: error: Incompatible default for argument "timestamp" (default has type "None", argument has type "datetime")  [assignment]
src/sentry/testutils/cases.py:3291: error: Incompatible default for argument "duration" (default has type "None", argument has type "timedelta")  [assignment]
src/sentry/integrations/github/integration.py:482: error: Incompatible return value type (got "HttpResponseBase", expected "HttpResponse")  [return-value]
src/sentry/integrations/github/integration.py:507: error: Incompatible return value type (got "HttpResponseBase", expected "HttpResponse")  [return-value]
src/sentry/web/frontend/auth_login.py:280: error: Incompatible return value type (got "HttpResponseBase", expected "HttpResponse")  [return-value]
```

<!-- Describe your PR here. -->