### PR TITLE
fix(issue-details): Swap order of last/first event buttons in event navigation

### DIFF
--- a/static/app/views/issueDetails/eventNavigation.tsx
+++ b/static/app/views/issueDetails/eventNavigation.tsx
@@ -44,8 +44,8 @@ enum EventNavOptions {
 
 const EventNavLabels = {
   [EventNavOptions.RECOMMENDED]: t('Recommended Event'),
-  [EventNavOptions.LATEST]: t('Last Event'),
   [EventNavOptions.OLDEST]: t('First Event'),
+  [EventNavOptions.LATEST]: t('Last Event'),
 };
 
 const eventDataSections: SectionDefinition[] = [


### PR DESCRIPTION
this pr swaps the order of the last/first event buttons in the updated event navigation. now "first" event will come first so the buttons are chronological 