### PR TITLE
ref: fix type errors pointed out by django-stubs 5.0.4

### DIFF
--- a/src/sentry/integrations/services/repository/impl.py
+++ b/src/sentry/integrations/services/repository/impl.py
@@ -38,7 +38,7 @@ class DatabaseBackedRepositoryService(RepositoryService):
         providers: list[str] | None = None,
         has_integration: bool | None = None,
         has_provider: bool | None = None,
-        status: ObjectStatus | None = None,
+        status: int | None = None,
     ) -> list[RpcRepository]:
         query = Repository.objects.filter(organization_id=organization_id)
         if integration_id is not None:

--- a/src/sentry/sentry_apps/services/app/model.py
+++ b/src/sentry/sentry_apps/services/app/model.py
@@ -153,5 +153,5 @@ class SentryAppInstallationFilterArgs(TypedDict, total=False):
     organization_id: int
     uuids: list[str]
     status: int
-    api_token_id: str
+    api_token_id: int
     api_installation_token_id: str


### PR DESCRIPTION
```
src/sentry/integrations/services/repository/impl.py:55: error: Incompatible type for lookup 'status': (got "ObjectStatus", expected "str | int")  [misc]
src/sentry/sentry_apps/services/app/impl.py:193: error: Incompatible type for lookup 'api_token_id': (got "str", expected "ApiToken | int | None")  [misc]
```

<!-- Describe your PR here. -->