### PR TITLE
ref: upgrade django-stubs

### DIFF
--- a/requirements-dev-frozen.txt
+++ b/requirements-dev-frozen.txt
@@ -43,7 +43,7 @@ django==5.0.7
 django-crispy-forms==1.14.0
 django-csp==3.8
 django-pg-zero-downtime-migrations==0.13
-django-stubs-ext==5.0.2
+django-stubs-ext==5.0.4
 djangorestframework==3.15.2
 docker==6.1.3
 drf-spectacular==0.26.3
@@ -182,7 +182,7 @@ selenium==4.16.0
 sentry-arroyo==2.16.5
 sentry-cli==2.16.0
 sentry-devenv==1.7.0
-sentry-forked-django-stubs==5.0.2.post10
+sentry-forked-django-stubs==5.0.4.post1
 sentry-forked-djangorestframework-stubs==3.15.0.post1
 sentry-kafka-schemas==0.1.102
 sentry-ophio==0.2.7

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -35,7 +35,7 @@ pip-tools>=7.1.0
 packaging>=21.3
 
 # for type checking
-sentry-forked-django-stubs>=5.0.2.post10
+sentry-forked-django-stubs>=5.0.4.post1
 sentry-forked-djangorestframework-stubs>=3.15.0.post1
 lxml-stubs
 msgpack-types>=0.2.0


### PR DESCRIPTION
<!-- Describe your PR here. -->

this had three sets of breakage addressed by other PRs:

- our foreign key subclass was not functioning, django-stubs added a default TypeVar here which started getting filled in with an unbound TypeVar resulting in thousands of errors: fixed by https://github.com/getsentry/sentry/pull/75228
- we were able to remove our fork's [descriptor patch](https://github.com/getsentry/sentry-forked-django-stubs/pull/4) (which removed the non-model overload of `__get__` for fields) as mypy [fixed this issue](https://github.com/python/mypy/pull/17381).  in doing so it pointed out an unsafe descriptor access through a mixin and so that had to go: https://github.com/getsentry/sentry/pull/75360
- django-stubs improved some field validation through QuerySets which was only checked through managers before: fixed by https://github.com/getsentry/sentry/pull/75359