### PR TITLE
ref(control_silo): Create forwards compatible integrations (vsts & general) task shims

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -809,6 +809,8 @@ CELERY_IMPORTS = (
     "sentry.integrations.slack.tasks",
     "sentry.uptime.detectors.tasks",
     "sentry.uptime.subscriptions.tasks",
+    "sentry.integrations.vsts.tasks",
+    "sentry.integrations.tasks",
 )
 
 default_exchange = Exchange("default", type="direct")

--- a/src/sentry/integrations/tasks/__init__.py
+++ b/src/sentry/integrations/tasks/__init__.py
@@ -1,0 +1,17 @@
+from .create_comment import create_comment
+from .kick_off_status_syncs import kick_off_status_syncs
+from .migrate_repo import migrate_repo
+from .sync_assignee_outbound import sync_assignee_outbound
+from .sync_status_inbound import sync_status_inbound
+from .sync_status_outbound import sync_status_outbound
+from .update_comment import update_comment
+
+__all__ = (
+    "create_comment",
+    "kick_off_status_syncs",
+    "migrate_repo",
+    "sync_assignee_outbound",
+    "sync_status_inbound",
+    "sync_status_outbound",
+    "update_comment",
+)

--- a/src/sentry/integrations/tasks/create_comment.py
+++ b/src/sentry/integrations/tasks/create_comment.py
@@ -1,0 +1,17 @@
+from sentry.silo.base import SiloMode, region_silo_function
+from sentry.tasks.base import instrumented_task
+from sentry.tasks.integrations.create_comment import create_comment as old_create_comment
+
+
+@region_silo_function
+@instrumented_task(
+    name="sentry.integrations.tasks.create_comment",
+    queue="integrations",
+    default_retry_delay=60 * 5,
+    max_retries=5,
+    silo_mode=SiloMode.REGION,
+)
+def create_comment(external_issue_id: int, user_id: int, group_note_id: int) -> None:
+    old_create_comment(
+        external_issue_id=external_issue_id, user_id=user_id, group_note_id=group_note_id
+    )

--- a/src/sentry/integrations/tasks/kick_off_status_syncs.py
+++ b/src/sentry/integrations/tasks/kick_off_status_syncs.py
@@ -1,0 +1,18 @@
+from sentry.silo.base import SiloMode
+from sentry.tasks.base import instrumented_task, retry, track_group_async_operation
+from sentry.tasks.integrations.kick_off_status_syncs_impl import (
+    kick_off_status_syncs as old_kick_off_status_syncs,
+)
+
+
+@instrumented_task(
+    name="sentry.integrations.tasks.kick_off_status_syncs",
+    queue="integrations",
+    default_retry_delay=60 * 5,
+    max_retries=5,
+    silo_mode=SiloMode.REGION,
+)
+@retry()
+@track_group_async_operation
+def kick_off_status_syncs(project_id: int, group_id: int) -> None:
+    old_kick_off_status_syncs(project_id=project_id, group_id=group_id)

--- a/src/sentry/integrations/tasks/migrate_repo.py
+++ b/src/sentry/integrations/tasks/migrate_repo.py
@@ -1,0 +1,20 @@
+from sentry.integrations.models.integration import Integration
+from sentry.models.organization import Organization
+from sentry.models.repository import Repository
+from sentry.silo.base import SiloMode
+from sentry.tasks.base import instrumented_task, retry
+from sentry.tasks.integrations.migrate_repo import migrate_repo as old_migrate_repo
+
+
+@instrumented_task(
+    name="sentry.integrations.tasks.migrate_repo",
+    queue="integrations.control",
+    default_retry_delay=60 * 5,
+    max_retries=5,
+    silo_mode=SiloMode.CONTROL,
+)
+@retry(exclude=(Integration.DoesNotExist, Repository.DoesNotExist, Organization.DoesNotExist))
+def migrate_repo(repo_id: int, integration_id: int, organization_id: int) -> None:
+    old_migrate_repo(
+        repo_id=repo_id, integration_id=integration_id, organization_id=organization_id
+    )

--- a/src/sentry/integrations/tasks/sync_assignee_outbound.py
+++ b/src/sentry/integrations/tasks/sync_assignee_outbound.py
@@ -1,0 +1,28 @@
+from sentry.integrations.models.external_issue import ExternalIssue
+from sentry.integrations.models.integration import Integration
+from sentry.models.organization import Organization
+from sentry.models.user import User
+from sentry.silo.base import SiloMode
+from sentry.tasks.base import instrumented_task, retry
+from sentry.tasks.integrations.sync_assignee_outbound_impl import (
+    sync_assignee_outbound as old_sync_assignee_outbound,
+)
+
+
+@instrumented_task(
+    name="sentry.integrations.tasks.sync_assignee_outbound",
+    queue="integrations",
+    default_retry_delay=60 * 5,
+    max_retries=5,
+    silo_mode=SiloMode.REGION,
+)
+@retry(
+    exclude=(
+        ExternalIssue.DoesNotExist,
+        Integration.DoesNotExist,
+        User.DoesNotExist,
+        Organization.DoesNotExist,
+    )
+)
+def sync_assignee_outbound(external_issue_id: int, user_id: int | None, assign: bool) -> None:
+    old_sync_assignee_outbound(external_issue_id=external_issue_id, user_id=user_id, assign=assign)

--- a/src/sentry/integrations/tasks/sync_status_outbound.py
+++ b/src/sentry/integrations/tasks/sync_status_outbound.py
@@ -1,0 +1,19 @@
+from sentry.integrations.models.integration import Integration
+from sentry.silo.base import SiloMode
+from sentry.tasks.base import instrumented_task, retry, track_group_async_operation
+from sentry.tasks.integrations.sync_status_outbound import (
+    sync_status_outbound as old_sync_status_outbound,
+)
+
+
+@instrumented_task(
+    name="sentry.integrations.tasks.sync_status_outbound",
+    queue="integrations",
+    default_retry_delay=60 * 5,
+    max_retries=5,
+    silo_mode=SiloMode.REGION,
+)
+@retry(exclude=(Integration.DoesNotExist,))
+@track_group_async_operation
+def sync_status_outbound(group_id: int, external_issue_id: int) -> bool | None:
+    old_sync_status_outbound(group_id=group_id, external_issue_id=external_issue_id)

--- a/src/sentry/integrations/tasks/sync_status_outbound.py
+++ b/src/sentry/integrations/tasks/sync_status_outbound.py
@@ -16,4 +16,4 @@ from sentry.tasks.integrations.sync_status_outbound import (
 @retry(exclude=(Integration.DoesNotExist,))
 @track_group_async_operation
 def sync_status_outbound(group_id: int, external_issue_id: int) -> bool | None:
-    old_sync_status_outbound(group_id=group_id, external_issue_id=external_issue_id)
+    return old_sync_status_outbound(group_id=group_id, external_issue_id=external_issue_id)

--- a/src/sentry/integrations/tasks/update_comment.py
+++ b/src/sentry/integrations/tasks/update_comment.py
@@ -1,0 +1,18 @@
+from sentry.integrations.models.integration import Integration
+from sentry.silo.base import SiloMode
+from sentry.tasks.base import instrumented_task, retry
+from sentry.tasks.integrations.update_comment import update_comment as old_update_comment
+
+
+@instrumented_task(
+    name="sentry.tasks.integrations.update_comment",
+    queue="integrations",
+    default_retry_delay=60 * 5,
+    max_retries=5,
+    silo_mode=SiloMode.REGION,
+)
+@retry(exclude=(Integration.DoesNotExist))
+def update_comment(external_issue_id: int, user_id: int, group_note_id: int) -> None:
+    old_update_comment(
+        external_issue_id=external_issue_id, user_id=user_id, group_note_id=group_note_id
+    )

--- a/src/sentry/integrations/vsts/tasks/__init__.py
+++ b/src/sentry/integrations/vsts/tasks/__init__.py
@@ -1,0 +1,4 @@
+from .kickoff_subscription_check import kickoff_vsts_subscription_check
+from .subscription_check import vsts_subscription_check
+
+__all__ = ("kickoff_vsts_subscription_check", "vsts_subscription_check")

--- a/src/sentry/integrations/vsts/tasks/kickoff_subscription_check.py
+++ b/src/sentry/integrations/vsts/tasks/kickoff_subscription_check.py
@@ -1,0 +1,17 @@
+from sentry.silo.base import SiloMode
+from sentry.tasks.base import instrumented_task, retry
+from sentry.tasks.integrations.vsts.kickoff_subscription_check import (
+    kickoff_vsts_subscription_check as old_kickoff_vsts_subscription_check,
+)
+
+
+@instrumented_task(
+    name="sentry.integrations.vsts.tasks.kickoff_vsts_subscription_check",
+    queue="integrations.control",
+    default_retry_delay=60 * 5,
+    max_retries=5,
+    silo_mode=SiloMode.CONTROL,
+)
+@retry()
+def kickoff_vsts_subscription_check() -> None:
+    old_kickoff_vsts_subscription_check()

--- a/src/sentry/integrations/vsts/tasks/subscription_check.py
+++ b/src/sentry/integrations/vsts/tasks/subscription_check.py
@@ -1,0 +1,19 @@
+from sentry.integrations.models.integration import Integration
+from sentry.shared_integrations.exceptions import ApiError, ApiUnauthorized
+from sentry.silo.base import SiloMode
+from sentry.tasks.base import instrumented_task, retry
+from sentry.tasks.integrations.vsts.subscription_check import (
+    vsts_subscription_check as old_vsts_subscription_check,
+)
+
+
+@instrumented_task(
+    name="sentry.integrations.vsts.tasks.vsts_subscription_check",
+    queue="integrations.control",
+    default_retry_delay=60 * 5,
+    max_retries=5,
+    silo_mode=SiloMode.CONTROL,
+)
+@retry(exclude=(ApiError, ApiUnauthorized, Integration.DoesNotExist))
+def vsts_subscription_check(integration_id: int, organization_id: int) -> None:
+    old_vsts_subscription_check(integration_id=integration_id, organization_id=organization_id)


### PR DESCRIPTION
Adds new task shims in the places where integrations tasks will be moved (in the future) for vsts & integrations (general) tasks.

ref(issue # here)
Split off of https://github.com/getsentry/sentry/pull/74925