### PR TITLE
chore(insights): Remove empty domain sample search hack

### DIFF
--- a/static/app/views/insights/http/components/httpSamplesPanel.spec.tsx
+++ b/static/app/views/insights/http/components/httpSamplesPanel.spec.tsx
@@ -245,7 +245,7 @@ describe('HTTPSamplesPanel', () => {
           query: expect.objectContaining({
             dataset: 'spansIndexed',
             query:
-              'span.module:http span.op:http.client transaction:/api/0/users span.status_code:[300,301,302,303,304,305,307,308] ( !has:span.domain OR span.domain:[""] )',
+              'span.module:http span.op:http.client !has:span.domain transaction:/api/0/users span.status_code:[300,301,302,303,304,305,307,308]',
             project: [],
             field: [
               'project',
@@ -405,7 +405,7 @@ describe('HTTPSamplesPanel', () => {
           method: 'GET',
           query: expect.objectContaining({
             query:
-              'span.module:http span.op:http.client transaction:/api/0/users span.domain:"\\*.sentry.dev"',
+              'span.module:http span.op:http.client span.domain:"\\*.sentry.dev" transaction:/api/0/users',
             project: [],
             additionalFields: [
               'trace',

--- a/static/app/views/insights/http/components/httpSamplesPanel.tsx
+++ b/static/app/views/insights/http/components/httpSamplesPanel.tsx
@@ -218,25 +218,6 @@ export function HTTPSamplesPanel() {
     referrer: Referrer.SAMPLES_PANEL_RESPONSE_CODE_CHART,
   });
 
-  // NOTE: Due to some data confusion, the `domain` column in the spans table can either be `null` or `""`. Searches like `"!has:span.domain"` are turned into the ClickHouse clause `isNull(domain)`, and do not match the empty string. We need a query that matches empty strings _and_ null_ which is `(!has:domain OR domain:[""])`. This hack can be removed in August 2024, once https://github.com/getsentry/snuba/pull/5780 has been deployed for 90 days and all `""` domains have fallen out of the data retention window. Also, `null` domains will become more rare as people upgrade the JS SDK to versions that populate the `server.address` span attribute
-  const sampleSpansSearch = MutableSearch.fromQueryObject({
-    ...filters,
-    'span.domain': undefined,
-  });
-
-  // filter by key-value filters specified in the search bar query
-  sampleSpansSearch.addStringMultiFilter(query.spanSearchQuery);
-
-  if (query.domain === '') {
-    sampleSpansSearch.addOp('(');
-    sampleSpansSearch.addFilterValue('!has', 'span.domain');
-    sampleSpansSearch.addOp('OR');
-    // HACK: Use `addOp` to add the condition `'span.domain:[""]'` and avoid escaping the double quotes. Ideally there'd be a way to specify this explicitly, but this whole thing is a hack anyway. Once a plain `!has:span.domain` condition works, this is not necessary
-    sampleSpansSearch.addOp('span.domain:[""]');
-    sampleSpansSearch.addOp(')');
-  } else {
-    sampleSpansSearch.addFilterValue('span.domain', query.domain);
-  }
   const durationAxisMax = computeAxisMax([durationData?.[`avg(span.self_time)`]]);
 
   const {
@@ -245,7 +226,7 @@ export function HTTPSamplesPanel() {
     error: durationSamplesDataError,
     refetch: refetchDurationSpanSamples,
   } = useSpanSamples({
-    search: sampleSpansSearch,
+    search,
     fields: [
       SpanIndexedField.TRACE,
       SpanIndexedField.TRANSACTION_ID,
@@ -265,7 +246,7 @@ export function HTTPSamplesPanel() {
     refetch: refetchResponseCodeSpanSamples,
   } = useSpansIndexed(
     {
-      search: sampleSpansSearch,
+      search,
       fields: [
         SpanIndexedField.PROJECT,
         SpanIndexedField.TRACE,


### PR DESCRIPTION
The hack was added in https://github.com/getsentry/sentry/pull/69129 but the data was fixed in https://github.com/getsentry/snuba/pull/5780. The hack is no longer needed because it's been over 90 days, so the old data has fallen out of retention.
