### PR TITLE
fix(toolbar): release analytic name

### DIFF
--- a/static/app/components/devtoolbar/components/featureFlags/featureFlagsPanel.tsx
+++ b/static/app/components/devtoolbar/components/featureFlags/featureFlagsPanel.tsx
@@ -1,6 +1,8 @@
-import {useRef, useState} from 'react';
+import {useContext, useRef, useState} from 'react';
 
-import AnalyticsProvider from 'sentry/components/devtoolbar/components/analyticsProvider';
+import AnalyticsProvider, {
+  AnalyticsContext,
+} from 'sentry/components/devtoolbar/components/analyticsProvider';
 import useEnabledFeatureFlags from 'sentry/components/devtoolbar/components/featureFlags/useEnabledFeatureFlags';
 import {inlineLinkCss} from 'sentry/components/devtoolbar/styles/link';
 import EmptyStateWarning from 'sentry/components/emptyStateWarning';
@@ -16,7 +18,8 @@ import PanelLayout from '../panelLayout';
 
 export default function FeatureFlagsPanel() {
   const featureFlags = useEnabledFeatureFlags();
-  const {organizationSlug, featureFlagTemplateUrl} = useConfiguration();
+  const {organizationSlug, featureFlagTemplateUrl, trackAnalytics} = useConfiguration();
+  const {eventName, eventKey} = useContext(AnalyticsContext);
   const [searchTerm, setSearchTerm] = useState('');
   const searchInput = useRef<HTMLInputElement>(null);
 
@@ -63,6 +66,12 @@ export default function FeatureFlagsPanel() {
                     <ExternalLink
                       css={[smallCss, inlineLinkCss]}
                       href={featureFlagTemplateUrl(flag)}
+                      onClick={() => {
+                        trackAnalytics?.({
+                          eventKey: eventKey + '.click',
+                          eventName: eventName + ' clicked',
+                        });
+                      }}
                     >
                       {flag}
                     </ExternalLink>

--- a/static/app/components/devtoolbar/components/featureFlags/featureFlagsPanel.tsx
+++ b/static/app/components/devtoolbar/components/featureFlags/featureFlagsPanel.tsx
@@ -1,8 +1,6 @@
-import {useContext, useRef, useState} from 'react';
+import {useRef, useState} from 'react';
 
-import AnalyticsProvider, {
-  AnalyticsContext,
-} from 'sentry/components/devtoolbar/components/analyticsProvider';
+import AnalyticsProvider from 'sentry/components/devtoolbar/components/analyticsProvider';
 import useEnabledFeatureFlags from 'sentry/components/devtoolbar/components/featureFlags/useEnabledFeatureFlags';
 import {inlineLinkCss} from 'sentry/components/devtoolbar/styles/link';
 import EmptyStateWarning from 'sentry/components/emptyStateWarning';
@@ -18,8 +16,7 @@ import PanelLayout from '../panelLayout';
 
 export default function FeatureFlagsPanel() {
   const featureFlags = useEnabledFeatureFlags();
-  const {organizationSlug, featureFlagTemplateUrl, trackAnalytics} = useConfiguration();
-  const {eventName, eventKey} = useContext(AnalyticsContext);
+  const {organizationSlug, featureFlagTemplateUrl} = useConfiguration();
   const [searchTerm, setSearchTerm] = useState('');
   const searchInput = useRef<HTMLInputElement>(null);
 
@@ -66,12 +63,6 @@ export default function FeatureFlagsPanel() {
                     <ExternalLink
                       css={[smallCss, inlineLinkCss]}
                       href={featureFlagTemplateUrl(flag)}
-                      onClick={() => {
-                        trackAnalytics?.({
-                          eventKey: eventKey + '.click',
-                          eventName: eventName + ' clicked',
-                        });
-                      }}
                     >
                       {flag}
                     </ExternalLink>

--- a/static/app/components/devtoolbar/components/releases/releasesPanel.tsx
+++ b/static/app/components/devtoolbar/components/releases/releasesPanel.tsx
@@ -79,17 +79,19 @@ function ReleaseSummary({orgSlug, release}: {orgSlug: string; release: Release})
       css={{width: '100%', alignItems: 'flex-start', padding: 'var(--space150)'}}
     >
       <ReleaseInfoHeader css={infoHeaderCss}>
-        <SentryAppLink
-          to={{
-            url: `/organizations/${orgSlug}/releases/${encodeURIComponent(release.version)}/`,
-            query: {project: release.projects[0].id},
-          }}
-        >
-          <VersionWrapper>{formatVersion(release.version)}</VersionWrapper>
-        </SentryAppLink>
-        {release.commitCount > 0 && (
-          <ReleaseCardCommits release={release} withHeading={false} />
-        )}
+        <AnalyticsProvider nameVal="latest release" keyVal="latest-release">
+          <SentryAppLink
+            to={{
+              url: `/organizations/${orgSlug}/releases/${encodeURIComponent(release.version)}/`,
+              query: {project: release.projects[0].id},
+            }}
+          >
+            <VersionWrapper>{formatVersion(release.version)}</VersionWrapper>
+          </SentryAppLink>
+          {release.commitCount > 0 && (
+            <ReleaseCardCommits release={release} withHeading={false} />
+          )}
+        </AnalyticsProvider>
       </ReleaseInfoHeader>
       <ReleaseInfoSubheader
         css={[resetFlexColumnCss, subtextCss, {alignItems: 'flex-start'}]}


### PR DESCRIPTION
- renaming the releases analytic to be more specific
- i also realized that i deleted the feature flag tracking analytic in https://github.com/getsentry/sentry/pull/75194, but looks like https://github.com/getsentry/sentry/pull/75305 adds them back!