### PR TITLE
feat(onboarding): refresh "perform these actions" dropdown after installation

### DIFF
--- a/static/app/views/alerts/rules/issue/addIntegrationRow.tsx
+++ b/static/app/views/alerts/rules/issue/addIntegrationRow.tsx
@@ -19,6 +19,10 @@ function AddIntegrationRow({organization, onClick}: Props) {
     return null;
   }
   const provider = integration.provider;
+  const onAddIntegration = () => {
+    integration.onAddIntegration?.();
+    onClick();
+  };
 
   const buttonProps = {
     size: 'sm',
@@ -38,7 +42,7 @@ function AddIntegrationRow({organization, onClick}: Props) {
             <StyledButton
               organization={organization}
               userHasAccess={hasAccess}
-              onAddIntegration={onClick}
+              onAddIntegration={onAddIntegration}
               onExternalClick={onClick}
               externalInstallText="Add Installation"
               buttonProps={buttonProps}

--- a/static/app/views/alerts/rules/issue/index.tsx
+++ b/static/app/views/alerts/rules/issue/index.tsx
@@ -419,8 +419,7 @@ class IssueRuleEditor extends DeprecatedAsyncView<Props, State> {
       .catch(_err => addErrorMessage(t('Unable to fetch environments')));
   }
 
-  refetchConfigs() {
-    console.log('refetching!!!!');
+  refetchConfigs = () => {
     const {organization} = this.props;
     const {project} = this.state;
 
@@ -432,7 +431,7 @@ class IssueRuleEditor extends DeprecatedAsyncView<Props, State> {
       .catch(() => {
         // No need to alert user if this fails, can use existing data
       });
-  }
+  };
 
   fetchStatus() {
     // pollHandler calls itself until it gets either a success

--- a/static/app/views/alerts/rules/issue/index.tsx
+++ b/static/app/views/alerts/rules/issue/index.tsx
@@ -1435,6 +1435,18 @@ class IssueRuleEditor extends DeprecatedAsyncView<Props, State> {
                               </StyledAlert>
                             )
                           }
+                          additionalAction={{
+                            label: 'Notify integration\u{2026}',
+                            option: {
+                              label: 'Missing an integration? Click here to refresh',
+                              value: {
+                                enabled: true,
+                                id: 'refresh_configs',
+                                label: 'Refresh Integration List',
+                              },
+                            },
+                            onClick: this.refetchConfigs,
+                          }}
                         />
                         <TestButtonWrapper>
                           <Button

--- a/static/app/views/alerts/rules/issue/index.tsx
+++ b/static/app/views/alerts/rules/issue/index.tsx
@@ -420,6 +420,7 @@ class IssueRuleEditor extends DeprecatedAsyncView<Props, State> {
   }
 
   refetchConfigs() {
+    console.log('refetching!!!!');
     const {organization} = this.props;
     const {project} = this.state;
 
@@ -1232,6 +1233,7 @@ class IssueRuleEditor extends DeprecatedAsyncView<Props, State> {
               <SetupAlertIntegrationButton
                 projectSlug={project.slug}
                 organization={organization}
+                refetchConfigs={this.refetchConfigs}
               />
             </SetConditionsListItem>
             <ContentIndent>

--- a/static/app/views/alerts/rules/issue/messagingIntegrationModal.tsx
+++ b/static/app/views/alerts/rules/issue/messagingIntegrationModal.tsx
@@ -18,6 +18,7 @@ type Props = ModalRenderProps & {
   project: Project;
   providerKeys: string[];
   bodyContent?: React.ReactElement<any, any>;
+  onAddIntegration?: () => void;
 };
 
 function MessagingIntegrationModal({
@@ -29,6 +30,7 @@ function MessagingIntegrationModal({
   providerKeys,
   organization,
   project,
+  onAddIntegration,
 }: Props) {
   const queryResults = useApiQueries<{providers: IntegrationProvider[]}>(
     providerKeys.map((providerKey: string) => [
@@ -70,6 +72,7 @@ function MessagingIntegrationModal({
                     already_installed: false,
                     view: 'onboarding',
                   },
+                  onAddIntegration: onAddIntegration,
                   modalParams: {projectId: project.id},
                 }}
               >

--- a/static/app/views/alerts/rules/issue/ruleNodeList.tsx
+++ b/static/app/views/alerts/rules/issue/ruleNodeList.tsx
@@ -306,7 +306,9 @@ class RuleNodeList extends Component<Props> {
           placeholder={placeholder}
           value={null}
           onChange={obj => {
-            additionalAction ? additionalAction.onClick() : onAddRow(obj.value);
+            additionalAction && obj === additionalAction.option
+              ? additionalAction.onClick()
+              : onAddRow(obj.value);
           }}
           options={options}
           disabled={disabled}

--- a/static/app/views/alerts/rules/issue/ruleNodeList.tsx
+++ b/static/app/views/alerts/rules/issue/ruleNodeList.tsx
@@ -268,10 +268,11 @@ class RuleNodeList extends Component<Props> {
     if (selectType === 'grouped') {
       options = groupSelectOptions(enabledNodes);
       if (additionalAction) {
-        for (const option of options) {
-          if (option.label === additionalAction.label) {
-            option.options.push(additionalAction.option);
-          }
+        const optionToModify = options.find(
+          option => option.label === additionalAction.label
+        );
+        if (optionToModify) {
+          optionToModify.options.push(additionalAction.option);
         }
       }
     } else {

--- a/static/app/views/alerts/rules/issue/ruleNodeList.tsx
+++ b/static/app/views/alerts/rules/issue/ruleNodeList.tsx
@@ -25,6 +25,7 @@ import {
 import {AlertRuleComparisonType} from '../metric/types';
 
 import RuleNode from './ruleNode';
+import {Button} from 'sentry/components/button';
 
 type Props = {
   disabled: boolean;
@@ -52,6 +53,7 @@ type Props = {
   incompatibleBanner?: number | null;
   incompatibleRules?: number[] | null;
   selectType?: 'grouped';
+  additionalStaticNode?: React.ReactNode;
 };
 
 const createSelectOptions = (
@@ -250,6 +252,7 @@ class RuleNodeList extends Component<Props> {
       selectType,
       incompatibleRules,
       incompatibleBanner,
+      additionalStaticNode,
     } = this.props;
 
     const enabledNodes = nodes ? nodes.filter(({enabled}) => enabled) : [];
@@ -281,7 +284,9 @@ class RuleNodeList extends Component<Props> {
               />
             )
           )}
+          {t('If you installed an integration but do not see it, refresh this list')}
         </RuleNodes>
+
         <StyledSelectControl
           placeholder={placeholder}
           value={null}

--- a/static/app/views/alerts/rules/issue/setupAlertIntegrationButton.spec.tsx
+++ b/static/app/views/alerts/rules/issue/setupAlertIntegrationButton.spec.tsx
@@ -27,6 +27,7 @@ describe('SetupAlertIntegrationButton', function () {
       <SetupAlertIntegrationButton
         projectSlug={project.slug}
         organization={organization}
+        refetchConfigs={jest.fn()}
       />
     );
     expect(container).toHaveTextContent('Set Up Slack Now');
@@ -43,6 +44,7 @@ describe('SetupAlertIntegrationButton', function () {
       <SetupAlertIntegrationButton
         projectSlug={project.slug}
         organization={organization}
+        refetchConfigs={jest.fn()}
       />
     );
     expect(container).not.toHaveTextContent('Set Up Slack Now');
@@ -56,7 +58,11 @@ describe('SetupAlertIntegrationButton', function () {
       },
     });
     const {container} = render(
-      <SetupAlertIntegrationButton projectSlug={project.slug} organization={featureOrg} />
+      <SetupAlertIntegrationButton
+        projectSlug={project.slug}
+        organization={featureOrg}
+        refetchConfigs={jest.fn()}
+      />
     );
     expect(container).toHaveTextContent('Connect to messaging');
   });
@@ -69,7 +75,11 @@ describe('SetupAlertIntegrationButton', function () {
       },
     });
     const {container} = render(
-      <SetupAlertIntegrationButton projectSlug={project.slug} organization={featureOrg} />
+      <SetupAlertIntegrationButton
+        projectSlug={project.slug}
+        organization={featureOrg}
+        refetchConfigs={jest.fn()}
+      />
     );
     expect(container).not.toHaveTextContent('Connect to messaging');
   });
@@ -82,7 +92,11 @@ describe('SetupAlertIntegrationButton', function () {
       },
     });
     render(
-      <SetupAlertIntegrationButton projectSlug={project.slug} organization={featureOrg} />
+      <SetupAlertIntegrationButton
+        projectSlug={project.slug}
+        organization={featureOrg}
+        refetchConfigs={jest.fn()}
+      />
     );
     await userEvent.click(screen.getByLabelText('Connect to messaging'));
 

--- a/static/app/views/alerts/rules/issue/setupAlertIntegrationButton.tsx
+++ b/static/app/views/alerts/rules/issue/setupAlertIntegrationButton.tsx
@@ -15,6 +15,7 @@ import MessagingIntegrationModal from 'sentry/views/alerts/rules/issue/messaging
 type Props = DeprecatedAsyncComponent['props'] & {
   organization: Organization;
   projectSlug: string;
+  refetchConfigs: () => void;
 };
 
 type State = DeprecatedAsyncComponent['state'] & {
@@ -56,6 +57,10 @@ export default class SetupAlertIntegrationButton extends DeprecatedAsyncComponen
     const providerKeys = ['slack', 'discord', 'msteams'];
     const {organization} = this.props;
     const {detailedProject} = this.state;
+    const onAddIntegration = () => {
+      this.reloadData();
+      this.props.refetchConfigs();
+    };
     // don't render anything if we don't have the project yet or if an alert integration
     // is installed
     if (!detailedProject || detailedProject.hasAlertIntegrationInstalled) {
@@ -87,6 +92,7 @@ export default class SetupAlertIntegrationButton extends DeprecatedAsyncComponen
                     providerKeys={providerKeys}
                     organization={organization}
                     project={detailedProject}
+                    onAddIntegration={onAddIntegration}
                   />
                 ),
                 {

--- a/static/app/views/settings/organizationIntegrations/addIntegrationButton.tsx
+++ b/static/app/views/settings/organizationIntegrations/addIntegrationButton.tsx
@@ -60,8 +60,6 @@ export function AddIntegrationButton({
                   provider: provider.metadata.noun,
                 });
               }
-              // console.log('HELPPPPPPP');
-              // onAddIntegration(IntegrationWithConfig);
               onClick();
             }}
             aria-label={t('Add integration')}

--- a/static/app/views/settings/organizationIntegrations/addIntegrationButton.tsx
+++ b/static/app/views/settings/organizationIntegrations/addIntegrationButton.tsx
@@ -60,6 +60,8 @@ export function AddIntegrationButton({
                   provider: provider.metadata.noun,
                 });
               }
+              // console.log('HELPPPPPPP');
+              // onAddIntegration(IntegrationWithConfig);
               onClick();
             }}
             aria-label={t('Add integration')}

--- a/static/app/views/settings/organizationIntegrations/integrationButton.tsx
+++ b/static/app/views/settings/organizationIntegrations/integrationButton.tsx
@@ -65,7 +65,7 @@ function IntegrationButton({
       <Button
         icon={externalInstallText ? null : <IconOpen />}
         href={metadata.aspects.externalInstall.url}
-        onClick={() => onExternalClick}
+        onClick={onExternalClick}
         external
         {...buttonProps}
       >

--- a/static/app/views/settings/organizationIntegrations/integrationContext.tsx
+++ b/static/app/views/settings/organizationIntegrations/integrationContext.tsx
@@ -14,8 +14,8 @@ export type IntegrationContextProps = {
   installStatus: string;
   provider: IntegrationProvider;
   type: IntegrationType;
-  onAddIntegration?: () => void;
   modalParams?: {[key: string]: string};
+  onAddIntegration?: () => void;
 };
 
 export const IntegrationContext = createContext<IntegrationContextProps | undefined>(

--- a/static/app/views/settings/organizationIntegrations/integrationContext.tsx
+++ b/static/app/views/settings/organizationIntegrations/integrationContext.tsx
@@ -14,6 +14,7 @@ export type IntegrationContextProps = {
   installStatus: string;
   provider: IntegrationProvider;
   type: IntegrationType;
+  onAddIntegration?: () => void;
   modalParams?: {[key: string]: string};
 };
 


### PR DESCRIPTION
once user installs integration:
- modal is closed
-  "Connect to messaging" button is hidden
-  "THEN perform these actions" dropdown is refreshed to include actions for the newly installed messaging integration

https://github.com/user-attachments/assets/06c60700-ed3c-4e8a-a987-096c50b1def5


also added a new dropdown option to manually refresh the dropdown actions, in case of external installations such as MS Teams
![Screenshot 2024-08-01 at 4 08 08 PM](https://github.com/user-attachments/assets/62af879f-1ed4-4860-af1b-9493a690861c)
