### PR TITLE
fix(issue-priority): Re-add platform check

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -2360,14 +2360,13 @@ def _get_severity_metadata_for_group(
     if not seer_based_priority_enabled and not feature_enabled:
         return {}
 
-    if not seer_based_priority_enabled:
-        is_supported_platform = (
-            any(event.platform.startswith(platform) for platform in PLATFORMS_WITH_PRIORITY_ALERTS)
-            if event.platform
-            else False
-        )
-        if not is_supported_platform:
-            return {}
+    is_supported_platform = (
+        any(event.platform.startswith(platform) for platform in PLATFORMS_WITH_PRIORITY_ALERTS)
+        if event.platform
+        else False
+    )
+    if not is_supported_platform:
+        return {}
 
     is_error_group = group_type == ErrorGroupType.type_id if group_type else True
     if not is_error_group:


### PR DESCRIPTION
Enable the platform check regardless of feature flags when calling Seer since the service only supports severity calculation for Python and JS projects.  