### PR TITLE
feat(query-builder): Add function description tooltip

### DIFF
--- a/static/app/components/searchQueryBuilder/index.spec.tsx
+++ b/static/app/components/searchQueryBuilder/index.spec.tsx
@@ -8,6 +8,7 @@ import {
   waitFor,
   within,
 } from 'sentry-test/reactTestingLibrary';
+import {textWithMarkupMatcher} from 'sentry-test/utils';
 
 import {
   SearchQueryBuilder,
@@ -2024,7 +2025,7 @@ describe('SearchQueryBuilder', function () {
             };
           case 'count_if':
             return {
-              desc: 'count_if()  description',
+              desc: 'count_if() description',
               kind: FieldKind.FUNCTION,
               valueType: FieldValueType.INTEGER,
               parameters: [
@@ -2052,7 +2053,7 @@ describe('SearchQueryBuilder', function () {
                   kind: 'value' as const,
                   dataType: FieldValueType.STRING,
                   defaultValue: '300ms',
-                  required: true,
+                  required: false,
                 },
               ],
             };
@@ -2159,6 +2160,38 @@ describe('SearchQueryBuilder', function () {
             name: 'count_if(a,b,c):>100',
           })
         ).toBeInTheDocument();
+      });
+
+      it('displays a description of the function and parameters while editing', async function () {
+        render(
+          <SearchQueryBuilder {...aggregateDefaultProps} initialQuery="count_if():>100" />
+        );
+        await userEvent.click(
+          screen.getByRole('button', {name: 'Edit parameters for filter: count_if'})
+        );
+
+        const descriptionTooltip = await screen.findByRole('tooltip');
+        expect(
+          within(descriptionTooltip).getByText('count_if() description')
+        ).toBeInTheDocument();
+        expect(
+          within(descriptionTooltip).getByText(
+            textWithMarkupMatcher(
+              'count_if(column: string, operator: string, value?: string)'
+            )
+          )
+        ).toBeInTheDocument();
+        expect(within(descriptionTooltip).getByTestId('focused-param')).toHaveTextContent(
+          'column: string'
+        );
+
+        // After moving to next parameter, should now highlight 'operator'
+        await userEvent.keyboard('a,');
+        await waitFor(() => {
+          expect(
+            within(descriptionTooltip).getByTestId('focused-param')
+          ).toHaveTextContent('operator: string');
+        });
       });
     });
   });

--- a/static/app/components/searchQueryBuilder/tokens/combobox.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/combobox.tsx
@@ -11,6 +11,7 @@ import {
   useRef,
   useState,
 } from 'react';
+import {usePopper} from 'react-popper';
 import styled from '@emotion/styled';
 import {type AriaComboBoxProps, useComboBox} from '@react-aria/combobox';
 import type {AriaListBoxOptions} from '@react-aria/listbox';
@@ -72,6 +73,11 @@ type SearchQueryBuilderComboboxProps<T extends SelectOptionOrSectionWithKey<stri
    */
   customMenu?: CustomComboboxMenu;
   /**
+   * If the combobox has additional information to display, passing JSX
+   * to this prop will display it in an overlay at the top left position.
+   */
+  description?: ReactNode;
+  /**
    * Whether to display the tabbed menu.
    */
   displayTabbedMenu?: boolean;
@@ -113,6 +119,19 @@ type CustomComboboxMenu = (props: {
   listBoxRef: React.RefObject<HTMLUListElement>;
   popoverRef: React.RefObject<HTMLDivElement>;
 }) => React.ReactNode;
+
+const DESCRIPTION_POPPER_OPTIONS = {
+  placement: 'top-start' as const,
+  strategy: 'fixed' as const,
+  modifiers: [
+    {
+      name: 'offset',
+      options: {
+        offset: [-12, 8],
+      },
+    },
+  ],
+};
 
 function itemIsSection(
   item: SelectOptionOrSectionWithKey<string>
@@ -466,6 +485,7 @@ function OverlayContent({
 function SearchQueryBuilderComboboxInner<T extends SelectOptionOrSectionWithKey<string>>(
   {
     children,
+    description,
     items,
     inputValue,
     filterValue = inputValue,
@@ -500,6 +520,7 @@ function SearchQueryBuilderComboboxInner<T extends SelectOptionOrSectionWithKey<
   const inputRef = useRef<HTMLInputElement>(null);
   const popoverRef = useRef<HTMLDivElement>(null);
   const [selectedSection, setSelectedSection] = useState<Key | null>(null);
+  const descriptionRef = useRef<HTMLDivElement>(null);
 
   const {hiddenOptions, disabledKeys} = useHiddenItems({
     items,
@@ -642,6 +663,12 @@ function SearchQueryBuilderComboboxInner<T extends SelectOptionOrSectionWithKey<
     preventOverflowOptions: {boundary: document.body, altAxis: true},
   });
 
+  const descriptionPopper = usePopper(
+    inputRef.current,
+    descriptionRef.current,
+    DESCRIPTION_POPPER_OPTIONS
+  );
+
   const handleInputClick: MouseEventHandler<HTMLInputElement> = useCallback(
     e => {
       e.stopPropagation();
@@ -666,8 +693,10 @@ function SearchQueryBuilderComboboxInner<T extends SelectOptionOrSectionWithKey<
   //
   // [1]: https://github.com/adobe/react-spectrum/blob/main/packages/%40react-aria/combobox/src/useComboBox.ts#L337C3-L341C44
   useEffect(() => {
-    if (isOpen && inputRef.current && popoverRef.current) {
-      return ariaHideOutside([inputRef.current, popoverRef.current]);
+    if (isOpen) {
+      return ariaHideOutside(
+        [inputRef.current, popoverRef.current, descriptionRef.current].filter(defined)
+      );
     }
 
     return () => {};
@@ -688,6 +717,17 @@ function SearchQueryBuilderComboboxInner<T extends SelectOptionOrSectionWithKey<
         onPaste={onPaste}
         disabled={disabled}
       />
+      {description ? (
+        <StyledPositionWrapper
+          {...descriptionPopper.attributes.popper}
+          ref={descriptionRef}
+          style={descriptionPopper.styles.popper}
+          visible
+          role="tooltip"
+        >
+          <DescriptionOverlay>{description}</DescriptionOverlay>
+        </StyledPositionWrapper>
+      ) : null}
       <StyledPositionWrapper {...overlayProps} visible={isOpen}>
         <OverlayContent
           customMenu={customMenu}
@@ -756,6 +796,13 @@ const ListBoxOverlay = styled(Overlay)`
   width: 600px;
   max-width: min-content;
   overflow-y: auto;
+`;
+
+const DescriptionOverlay = styled(Overlay)`
+  min-width: 200px;
+  max-width: 400px;
+  padding: ${space(1)} ${space(1.5)};
+  line-height: 1.2;
 `;
 
 const SectionedOverlay = styled(Overlay)`

--- a/static/app/components/searchQueryBuilder/tokens/filter/functionDescription.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/functionDescription.tsx
@@ -1,0 +1,85 @@
+import {Fragment} from 'react';
+import styled from '@emotion/styled';
+
+import {useSearchQueryBuilder} from 'sentry/components/searchQueryBuilder/context';
+import type {AggregateFilter} from 'sentry/components/searchSyntax/parser';
+import {getKeyName} from 'sentry/components/searchSyntax/utils';
+import {space} from 'sentry/styles/space';
+import type {AggregateParameter} from 'sentry/utils/fields';
+
+type FunctionDescriptionProps = {
+  parameterIndex: number;
+  token: AggregateFilter;
+};
+
+function getParameterType(param: AggregateParameter) {
+  if (param.kind === 'value') {
+    return param.dataType;
+  }
+
+  return 'string';
+}
+
+function getParameterLabel(param: AggregateParameter) {
+  return `${param.name}${param.required ? '' : '?'}: ${getParameterType(param)}`;
+}
+
+export function FunctionDescription({token, parameterIndex}: FunctionDescriptionProps) {
+  const {getFieldDefinition} = useSearchQueryBuilder();
+  const fnName = getKeyName(token.key);
+  const fieldDefinition = getFieldDefinition(fnName);
+
+  if (!fieldDefinition) {
+    return null;
+  }
+
+  const parameters = fieldDefinition.parameters ?? [];
+
+  return (
+    <Description>
+      <Code>
+        <FunctionName>
+          {fnName}
+          {'('}
+        </FunctionName>
+        {parameters.map((param, i) => (
+          <Fragment key={i}>
+            <span>{i > 0 && ', '}</span>
+            <span>
+              {i === parameterIndex ? (
+                <strong data-test-id="focused-param">{getParameterLabel(param)}</strong>
+              ) : (
+                getParameterLabel(param)
+              )}
+            </span>
+          </Fragment>
+        ))}
+        <FunctionName>{')'}</FunctionName>
+      </Code>
+      {fieldDefinition.desc && (
+        <Fragment>
+          <Separator />
+          <div>{fieldDefinition.desc}</div>
+        </Fragment>
+      )}
+    </Description>
+  );
+}
+
+const Description = styled('div')`
+  text-align: left;
+`;
+
+const Code = styled('code')`
+  display: block;
+  font-size: ${p => p.theme.fontSizeMedium};
+`;
+
+const Separator = styled('hr')`
+  border-top: 1px solid ${p => p.theme.innerBorder};
+  margin: ${space(1)} 0;
+`;
+
+const FunctionName = styled('span')`
+  color: ${p => p.theme.subText};
+`;

--- a/static/app/components/searchQueryBuilder/tokens/filter/parametersCombobox.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/parametersCombobox.tsx
@@ -5,6 +5,7 @@ import type {KeyboardEvent} from '@react-types/shared';
 import type {SelectOptionWithKey} from 'sentry/components/compactSelect/types';
 import {useSearchQueryBuilder} from 'sentry/components/searchQueryBuilder/context';
 import {SearchQueryBuilderCombobox} from 'sentry/components/searchQueryBuilder/tokens/combobox';
+import {FunctionDescription} from 'sentry/components/searchQueryBuilder/tokens/filter/functionDescription';
 import {replaceCommaSeparatedValue} from 'sentry/components/searchQueryBuilder/tokens/filter/utils';
 import type {AggregateFilter} from 'sentry/components/searchSyntax/parser';
 import {t} from 'sentry/locale';
@@ -252,6 +253,7 @@ export function SearchQueryBuilderParametersCombobox({
       autoFocus
       maxOptions={20}
       isOpen
+      description={<FunctionDescription token={token} parameterIndex={parameterIndex} />}
     >
       {item => (
         <Item {...item} key={item.key}>


### PR DESCRIPTION
Ref https://github.com/getsentry/sentry/issues/74312

Adds a description tooltip which displays above the input while editing function parameters. This tooltip displays the description, as well as the name and type of the parameters. The currently focused parameter is highlighted in bold.

![CleanShot 2024-07-31 at 14 11 03@2x](https://github.com/user-attachments/assets/152b13cb-7adb-493a-9ac0-16015cbe4fd6)
