### PR TITLE
feat(profiling): Allow expanding metrics on flamegraph

### DIFF
--- a/src/sentry/api/endpoints/organization_profiling_profiles.py
+++ b/src/sentry/api/endpoints/organization_profiling_profiles.py
@@ -35,6 +35,7 @@ class OrganizationProfilingFlamegraphSerializer(serializers.Serializer):
     fingerprint = serializers.IntegerField(min_value=0, max_value=(1 << 32) - 1, required=False)
     dataSource = serializers.ChoiceField(["transactions", "profiles", "functions"], required=False)
     query = serializers.CharField(required=False)
+    expand = serializers.ListField(child=serializers.ChoiceField(["metrics"]), required=False)
 
     def validate(self, attrs):
         source = attrs.get("dataSource")
@@ -112,6 +113,11 @@ class OrganizationProfilingFlamegraphEndpoint(OrganizationProfilingBaseEndpoint)
                 fingerprint=serialized.get("fingerprint"),
             )
             profile_candidates = executor.get_profile_candidates()
+
+        expand = serialized.get("expand") or []
+        if expand:
+            if "metrics" in expand:
+                profile_candidates["generate_metrics"] = True
 
         return proxy_profiling_service(
             method="POST",

--- a/src/sentry/profiles/flamegraph.py
+++ b/src/sentry/profiles/flamegraph.py
@@ -285,6 +285,7 @@ class ContinuousProfileCandidate(TypedDict):
 class ProfileCandidates(TypedDict):
     transaction: list[TransactionProfileCandidate]
     continuous: list[ContinuousProfileCandidate]
+    generate_metrics: NotRequired[bool]
 
 
 @dataclass(frozen=True)

--- a/tests/sentry/api/endpoints/test_organization_profiling_profiles.py
+++ b/tests/sentry/api/endpoints/test_organization_profiling_profiles.py
@@ -7,6 +7,7 @@ from django.urls import reverse
 from rest_framework.exceptions import ErrorDetail
 from snuba_sdk import And, Column, Condition, Function, Op, Or
 
+from sentry.profiles.flamegraph import FlamegraphExecutor
 from sentry.profiles.utils import proxy_profiling_service
 from sentry.snuba.dataset import Dataset
 from sentry.testutils.cases import APITestCase, ProfilesSnubaTestCase
@@ -202,6 +203,52 @@ class OrganizationProfilingFlamegraphTest(ProfilesSnubaTestCase):
                 code="parse_error",
             ),
         }
+
+    def test_invalid_expand(self):
+        response = self.do_request(
+            {
+                "project": [self.project.id],
+                "expand": "foo",
+            },
+        )
+        assert response.status_code == 400, response.content
+        assert response.data == {
+            "expand": [ErrorDetail('"foo" is not a valid choice.', code="invalid_choice")],
+        }
+
+    def test_expands_metrics(self):
+        with (
+            patch(
+                "sentry.api.endpoints.organization_profiling_profiles.proxy_profiling_service"
+            ) as mock_proxy_profiling_service,
+            patch.object(
+                FlamegraphExecutor,
+                "get_profile_candidates",
+            ) as mock_get_profile_candidates,
+        ):
+            mock_get_profile_candidates.return_value = {
+                "continuous": [],
+                "transactions": [],
+            }
+            mock_proxy_profiling_service.return_value = HttpResponse(status=200)
+            response = self.do_request(
+                {
+                    "project": [self.project.id],
+                    "expand": "metrics",
+                },
+            )
+
+            assert response.status_code == 200, response.content
+
+        mock_proxy_profiling_service.assert_called_once_with(
+            method="POST",
+            path=f"/organizations/{self.project.organization.id}/flamegraph",
+            json_data={
+                "transactions": [],
+                "continuous": [],
+                "generate_metrics": True,
+            },
+        )
 
     def test_queries_profile_candidates_from_functions(self):
         fingerprint = int(uuid4().hex[:8], 16)
@@ -402,7 +449,7 @@ class OrganizationProfilingFlamegraphTest(ProfilesSnubaTestCase):
                         "profile_id": profile_id,
                     },
                 ],
-                "continuous": [],  # TODO: this isn't supported yet
+                "continuous": [],
             },
         )
 


### PR DESCRIPTION
Depends on getsentry/vroom#494. Allows metrics to be returned as part of the flamegraph computed via live aggregation.