### PR TITLE
chore(profiling): Change default to left heavy flamegraph

### DIFF
--- a/static/app/views/performance/transactionSummary/transactionProfiles/content.tsx
+++ b/static/app/views/performance/transactionSummary/transactionProfiles/content.tsx
@@ -31,7 +31,7 @@ import {ProfileGroupProvider} from 'sentry/views/profiling/profileGroupProvider'
 
 const DEFAULT_FLAMEGRAPH_PREFERENCES: DeepPartial<FlamegraphState> = {
   preferences: {
-    sorting: 'alphabetical' satisfies FlamegraphState['preferences']['sorting'],
+    sorting: 'left heavy' satisfies FlamegraphState['preferences']['sorting'],
   },
 };
 

--- a/static/app/views/profiling/landingAggregateFlamegraph.tsx
+++ b/static/app/views/profiling/landingAggregateFlamegraph.tsx
@@ -33,7 +33,7 @@ import {ProfileGroupProvider} from 'sentry/views/profiling/profileGroupProvider'
 
 const DEFAULT_FLAMEGRAPH_PREFERENCES: DeepPartial<FlamegraphState> = {
   preferences: {
-    sorting: 'alphabetical' satisfies FlamegraphState['preferences']['sorting'],
+    sorting: 'left heavy' satisfies FlamegraphState['preferences']['sorting'],
   },
 };
 


### PR DESCRIPTION
Change the default to a left heavy flamegraph to make the areas of focus more obvious.