### PR TITLE
fix(hybrid-cloud): Pushes a temporary fix for pydantic unpickling issues with the v2 upgrade

### DIFF
--- a/src/sentry/hybridcloud/rpc/__init__.py
+++ b/src/sentry/hybridcloud/rpc/__init__.py
@@ -49,6 +49,16 @@ class RpcModel(pydantic.BaseModel):
         from_attributes=True, use_enum_values=True, coerce_numbers_to_str=True
     )
 
+    def __setstate__(self, state: dict[Any, Any]):
+        """
+        __setstate__ override to alleviate an unpickling issue in production with the pydantic version upgrade.
+        """
+        state.setdefault("__pydantic_extra__", {})
+        state.setdefault("__pydantic_private__", {})
+
+        if "__pydantic_fields_set__" not in state:
+            state["__pydantic_fields_set__"] = state.get("__fields_set__")
+
     @classmethod
     def get_field_names(cls) -> Iterable[str]:
         return iter(cls.model_fields.keys())

--- a/src/sentry/hybridcloud/rpc/__init__.py
+++ b/src/sentry/hybridcloud/rpc/__init__.py
@@ -58,6 +58,7 @@ class RpcModel(pydantic.BaseModel):
 
         if "__pydantic_fields_set__" not in state:
             state["__pydantic_fields_set__"] = state.get("__fields_set__")
+        super().__setstate__(state)
 
     @classmethod
     def get_field_names(cls) -> Iterable[str]:

--- a/src/sentry/hybridcloud/rpc/__init__.py
+++ b/src/sentry/hybridcloud/rpc/__init__.py
@@ -49,7 +49,7 @@ class RpcModel(pydantic.BaseModel):
         from_attributes=True, use_enum_values=True, coerce_numbers_to_str=True
     )
 
-    def __setstate__(self, state: dict[Any, Any]):
+    def __setstate__(self, state: dict[Any, Any]) -> None:
         """
         __setstate__ override to alleviate an unpickling issue in production with the pydantic version upgrade.
         """


### PR DESCRIPTION
Adds a `__setstate__` override for `RpcModel` to allow it to correctly unpickle digest payloads from Redis.

This is a temporary workaround while the upgrade settles and will be removed once all digests from the previous version have been processed.
