### PR TITLE
fix(discover): Crash when event view requires trace id

### DIFF
--- a/static/app/utils/discover/eventView.tsx
+++ b/static/app/utils/discover/eventView.tsx
@@ -1446,7 +1446,7 @@ class EventView {
 
 export type ImmutableEventView = Readonly<Omit<EventView, 'additionalConditions'>>;
 
-const isFieldsSimilar = (
+export const isFieldsSimilar = (
   currentValue: Array<string>,
   otherValue: Array<string>
 ): boolean => {

--- a/static/app/views/discover/savedQuery/datasetSelector.tsx
+++ b/static/app/views/discover/savedQuery/datasetSelector.tsx
@@ -60,6 +60,9 @@ export function DatasetSelector(props: Props) {
       value={value}
       options={options}
       onChange={newValue => {
+        if (newValue.value === value) {
+          return;
+        }
         let nextEventView: EventView;
         if (eventView.id) {
           nextEventView = eventView.withDataset(

--- a/static/app/views/discover/table/tableView.tsx
+++ b/static/app/views/discover/table/tableView.tsx
@@ -216,7 +216,7 @@ function TableView(props: TableViewProps) {
           query: {...location.query, referrer: 'discover-events-table'},
         };
       } else {
-        if (dataRow && !dataRow.trace) {
+        if (!dataRow.trace) {
           throw new Error(
             'Transaction event should always have a trace associated with it.'
           );
@@ -363,7 +363,7 @@ function TableView(props: TableViewProps) {
           query: {...location.query, referrer: 'discover-events-table'},
         };
       } else {
-        if (dataRow && !dataRow.trace) {
+        if (!dataRow.trace) {
           throw new Error(
             'Transaction event should always have a trace associated with it.'
           );

--- a/static/app/views/discover/table/tableView.tsx
+++ b/static/app/views/discover/table/tableView.tsx
@@ -118,7 +118,7 @@ function TableView(props: TableViewProps) {
     columnIndex: number,
     nextColumn: TableColumn<keyof TableDataRow>
   ) {
-    const {location, eventView} = props;
+    const {location, eventView, organization, queryDataset} = props;
 
     const newWidth = nextColumn.width ? Number(nextColumn.width) : COL_WIDTH_UNDEFINED;
     const nextEventView = eventView.withResizedColumn(columnIndex, newWidth);
@@ -126,7 +126,10 @@ function TableView(props: TableViewProps) {
     pushEventViewToLocation({
       location,
       nextEventView,
-      extraQuery: pickRelevantLocationQueryStrings(location),
+      extraQuery: {
+        ...pickRelevantLocationQueryStrings(location),
+        ...appendQueryDatasetParam(organization, queryDataset),
+      },
     });
   }
 
@@ -213,7 +216,7 @@ function TableView(props: TableViewProps) {
           query: {...location.query, referrer: 'discover-events-table'},
         };
       } else {
-        if (!dataRow.trace) {
+        if (dataRow && !dataRow.trace) {
           throw new Error(
             'Transaction event should always have a trace associated with it.'
           );
@@ -360,7 +363,7 @@ function TableView(props: TableViewProps) {
           query: {...location.query, referrer: 'discover-events-table'},
         };
       } else {
-        if (!dataRow.trace) {
+        if (dataRow && !dataRow.trace) {
           throw new Error(
             'Transaction event should always have a trace associated with it.'
           );


### PR DESCRIPTION
The component hierarchy for the table in discover goes
Results > Table > TableView

Results uses `getDerivedStateFromProps` to generate `eventView`
which is passed down to `Table` and `TableView`

`Table` uses eventView to fetch table data and passes down
`tableData` and `isLoading` state down to `TableView`

`TableView` uses `eventView`, `tableData` and `isLoading` to
render the table. If no aggregates are present in eventView, we prepend
an event ID column to eventView. Rendering the event ID column requires
an event ID and a trace ID and throws an error when trace id does not exist.

When eventView switches from a state where trace id isn't required
to one where trace id is required, that prop change immediately gets
propagated down to `Table` and `TableView` causing both components
to re-render. `Table` only refetches data on `componentDidUpdate` which
happens after a render. So `TableView` has stale tableData and `isLoading`
still set to false until fetchData is called by `Table`. 
This state mismatch trips the "no trace ID" error since the new data isn't
available yet.

We're introducing `getDerivedStateFromProps` on `Table` to force `isLoading`
to true when fields or datasets change. 

fixes JAVASCRIPT-2TT6