### PR TITLE
chore(ui): Adjust definition of transaction duration field

### DIFF
--- a/static/app/utils/fields/index.ts
+++ b/static/app/utils/fields/index.ts
@@ -1123,7 +1123,7 @@ const EVENT_FIELD_DEFINITIONS: Record<AllEventFieldKeys, FieldDefinition> = {
     valueType: FieldValueType.STRING,
   },
   [FieldKey.TRANSACTION_DURATION]: {
-    desc: t('Duration, in milliseconds, of the transaction'),
+    desc: t('Duration of the transaction'),
     kind: FieldKind.FIELD,
     valueType: FieldValueType.DURATION,
   },


### PR DESCRIPTION
This field definition is what shows up in Discover, and other search bars that allow for querying transactions. It says specifically the duration in milliseconds, but Discover allows you to query by `ms`, `s`, `m`, `h`, so this PR changes this definition to be more general.