### PR TITLE
ref(control_silo): Create forwards compatible slack task shims

### DIFF
--- a/src/sentry/integrations/slack/tasks/__init__.py
+++ b/src/sentry/integrations/slack/tasks/__init__.py
@@ -1,3 +1,14 @@
+from .find_channel_id_for_alert_rule import find_channel_id_for_alert_rule
+from .find_channel_id_for_rule import find_channel_id_for_rule
+from .link_slack_user_identities import link_slack_user_identities
+from .post_message import post_message, post_message_control
 from .send_notifications_on_activity import send_activity_notifications_to_slack_threads
 
-__all__ = ("send_activity_notifications_to_slack_threads",)
+__all__ = (
+    "send_activity_notifications_to_slack_threads",
+    "find_channel_id_for_alert_rule",
+    "find_channel_id_for_rule",
+    "link_slack_user_identities",
+    "post_message",
+    "post_message_control",
+)

--- a/src/sentry/integrations/slack/tasks/find_channel_id_for_alert_rule.py
+++ b/src/sentry/integrations/slack/tasks/find_channel_id_for_alert_rule.py
@@ -8,7 +8,7 @@ from sentry.tasks.integrations.slack.find_channel_id_for_alert_rule import (
 
 
 @instrumented_task(
-    name="sentry.integrations.slack.tasks.search_channel_id_metric_alerts",
+    name="sentry.integrations.slack.tasks.search_channel_id_for_alert_rule",
     queue="integrations",
     silo_mode=SiloMode.REGION,
 )

--- a/src/sentry/integrations/slack/tasks/find_channel_id_for_alert_rule.py
+++ b/src/sentry/integrations/slack/tasks/find_channel_id_for_alert_rule.py
@@ -1,0 +1,28 @@
+from typing import Any
+
+from sentry.silo.base import SiloMode
+from sentry.tasks.base import instrumented_task
+from sentry.tasks.integrations.slack.find_channel_id_for_alert_rule import (
+    find_channel_id_for_alert_rule as old_find_channel_id_for_alert_rule,
+)
+
+
+@instrumented_task(
+    name="sentry.integrations.slack.tasks.search_channel_id_metric_alerts",
+    queue="integrations",
+    silo_mode=SiloMode.REGION,
+)
+def find_channel_id_for_alert_rule(
+    organization_id: int,
+    uuid: str,
+    data: Any,
+    alert_rule_id: int | None = None,
+    user_id: int | None = None,
+) -> None:
+    old_find_channel_id_for_alert_rule(
+        organization_id=organization_id,
+        uuid=uuid,
+        data=data,
+        alert_rule_id=alert_rule_id,
+        user_id=user_id,
+    )

--- a/src/sentry/integrations/slack/tasks/find_channel_id_for_rule.py
+++ b/src/sentry/integrations/slack/tasks/find_channel_id_for_rule.py
@@ -1,0 +1,28 @@
+from collections.abc import Sequence
+from typing import Any
+
+from sentry.incidents.models.alert_rule import AlertRuleTriggerAction
+from sentry.models.project import Project
+from sentry.silo.base import SiloMode
+from sentry.tasks.base import instrumented_task
+from sentry.tasks.integrations.slack.find_channel_id_for_rule import (
+    find_channel_id_for_rule as old_find_channel_id_for_rule,
+)
+
+
+@instrumented_task(
+    name="sentry.integrations.slack.tasks.search_channel_id",
+    queue="integrations",
+    silo_mode=SiloMode.REGION,
+)
+def find_channel_id_for_rule(
+    project: Project,
+    actions: Sequence[AlertRuleTriggerAction],
+    uuid: str,
+    rule_id: int | None = None,
+    user_id: int | None = None,
+    **kwargs: Any,
+) -> None:
+    old_find_channel_id_for_rule(
+        project=project, actions=actions, uuid=uuid, rule_id=rule_id, user_id=user_id, **kwargs
+    )

--- a/src/sentry/integrations/slack/tasks/find_channel_id_for_rule.py
+++ b/src/sentry/integrations/slack/tasks/find_channel_id_for_rule.py
@@ -11,7 +11,7 @@ from sentry.tasks.integrations.slack.find_channel_id_for_rule import (
 
 
 @instrumented_task(
-    name="sentry.integrations.slack.tasks.search_channel_id",
+    name="sentry.integrations.slack.tasks.search_channel_id_for_rule",
     queue="integrations",
     silo_mode=SiloMode.REGION,
 )

--- a/src/sentry/integrations/slack/tasks/link_slack_user_identities.py
+++ b/src/sentry/integrations/slack/tasks/link_slack_user_identities.py
@@ -6,7 +6,7 @@ from sentry.tasks.integrations.slack.link_slack_user_identities import (
 
 
 @instrumented_task(
-    name="sentry.integrations.slack.tasks.link_users_identities",
+    name="sentry.integrations.slack.tasks.link_slack_user_identities",
     queue="integrations.control",
     silo_mode=SiloMode.CONTROL,
     max_retries=3,

--- a/src/sentry/integrations/slack/tasks/link_slack_user_identities.py
+++ b/src/sentry/integrations/slack/tasks/link_slack_user_identities.py
@@ -1,0 +1,18 @@
+from sentry.silo.base import SiloMode
+from sentry.tasks.base import instrumented_task
+from sentry.tasks.integrations.slack.link_slack_user_identities import (
+    link_slack_user_identities as old_link_slack_user_identities,
+)
+
+
+@instrumented_task(
+    name="sentry.integrations.slack.tasks.link_users_identities",
+    queue="integrations.control",
+    silo_mode=SiloMode.CONTROL,
+    max_retries=3,
+)
+def link_slack_user_identities(
+    integration_id: int,
+    organization_id: int,
+) -> None:
+    old_link_slack_user_identities(integration_id=integration_id, organization_id=organization_id)

--- a/src/sentry/integrations/slack/tasks/post_message.py
+++ b/src/sentry/integrations/slack/tasks/post_message.py
@@ -1,0 +1,49 @@
+from collections.abc import Mapping
+from typing import Any
+
+from sentry.silo.base import SiloMode
+from sentry.tasks.base import instrumented_task
+from sentry.tasks.integrations.slack.post_message import post_message as old_post_message
+from sentry.tasks.integrations.slack.post_message import (
+    post_message_control as old_post_message_control,
+)
+
+
+@instrumented_task(
+    name="sentry.integrations.slack.tasks.post_message",
+    queue="integrations",
+    max_retries=0,
+    silo_mode=SiloMode.REGION,
+)
+def post_message(
+    integration_id: int,
+    payload: Mapping[str, Any],
+    log_error_message: str,
+    log_params: Mapping[str, Any],
+) -> None:
+    old_post_message(
+        integration_id=integration_id,
+        payload=payload,
+        log_error_message=log_error_message,
+        log_params=log_params,
+    )
+
+
+@instrumented_task(
+    name="sentry.integrations.slack.tasks.post_message_control",
+    queue="integrations.control",
+    max_retries=0,
+    silo_mode=SiloMode.CONTROL,
+)
+def post_message_control(
+    integration_id: int,
+    payload: Mapping[str, Any],
+    log_error_message: str,
+    log_params: Mapping[str, Any],
+) -> None:
+    old_post_message_control(
+        integration_id=integration_id,
+        payload=payload,
+        log_error_message=log_error_message,
+        log_params=log_params,
+    )


### PR DESCRIPTION
Adds new task shims in the places where integrations tasks will be moved (in the future) for slack tasks.

ref(issue # here)
Split off of #74925