### PR TITLE
chore(feedback): Add deprecation notes to user report endpoint apidocs

### DIFF
--- a/api-docs/paths/projects/user-feedback.json
+++ b/api-docs/paths/projects/user-feedback.json
@@ -1,7 +1,7 @@
 {
   "get": {
     "tags": ["Projects"],
-    "description": "Return a list of user feedback items within this project.",
+    "description": "Return a list of user feedback items within this project.\n\n*This list does not include submissions from the [User Feedback Widget](https://docs.sentry.io/product/user-feedback/#user-feedback-widget). This is because it is based on an older format called User Reports - read more [here](https://develop.sentry.dev/application/feedback-architecture/#user-reports).*",
     "operationId": "List a Project's User Feedback",
     "parameters": [
       {
@@ -68,7 +68,7 @@
   },
   "post": {
     "tags": ["Projects"],
-    "description": "Submit and associate user feedback with an issue.\n\nFeedback must be received by the server no more than 30 minutes after the event was saved.\n\nAdditionally, within 5 minutes of submitting feedback it may also be overwritten. This is useful in situations where you may need to retry sending a request due to network failures.\n\nIf feedback is rejected due to a mutability threshold, a 409 status code will be returned.\n\nNote: Feedback may be submitted with DSN authentication (see auth documentation).",
+    "description": "*This endpoint is DEPRECATED. We document it here for older SDKs and users who are still migrating to the [User Feedback Widget](https://docs.sentry.io/product/user-feedback/#user-feedback-widget) or [API](https://docs.sentry.io/platforms/javascript/user-feedback/#user-feedback-api)(multi-platform). If you are a new user, do not use this endpoint - unless you don't have a JS frontend, and your platform's SDK does not offer a feedback API.*\n\nFeedback must be received by the server no more than 30 minutes after the event was saved.\n\nAdditionally, within 5 minutes of submitting feedback it may also be overwritten. This is useful in situations where you may need to retry sending a request due to network failures.\n\nIf feedback is rejected due to a mutability threshold, a 409 status code will be returned.\n\nNote: Feedback may be submitted with DSN authentication (see auth documentation).",
     "operationId": "Submit User Feedback",
     "parameters": [
       {

--- a/src/sentry/api/endpoints/project_user_reports.py
+++ b/src/sentry/api/endpoints/project_user_reports.py
@@ -45,6 +45,8 @@ class ProjectUserReportsEndpoint(ProjectEndpoint, EnvironmentMixin):
 
         Return a list of user feedback items within this project.
 
+        *This list does not include submissions from the [User Feedback Widget](https://docs.sentry.io/product/user-feedback/#user-feedback-widget). This is because it is based on an older format called User Reports - read more [here](https://develop.sentry.dev/application/feedback-architecture/#user-reports).*
+
         :pparam string organization_id_or_slug: the id or slug of the organization.
         :pparam string project_id_or_slug: the id or slug of the project.
         :auth: required
@@ -88,6 +90,8 @@ class ProjectUserReportsEndpoint(ProjectEndpoint, EnvironmentMixin):
         """
         Submit User Feedback
         ````````````````````
+
+        *This endpoint is DEPRECATED. We document it here for older SDKs and users who are still migrating to the [User Feedback Widget](https://docs.sentry.io/product/user-feedback/#user-feedback-widget) or [API](https://docs.sentry.io/platforms/javascript/user-feedback/#user-feedback-api)(multi-platform). If you are a new user, do not use this endpoint - unless you don't have a JS frontend, and your platform's SDK does not offer a feedback API.*
 
         Submit and associate user feedback with an issue.
 


### PR DESCRIPTION
Ref https://github.com/getsentry/sentry-docs/issues/10643
The replay team decided on a call to revert https://github.com/getsentry/sentry/pull/75079 because some users may still need this doc as a reference.

What it looks like:

<img width="1191" alt="Screenshot 2024-07-31 at 3 18 44 PM" src="https://github.com/user-attachments/assets/6e4b7384-d63e-43be-8ddc-95b8ea2e8833">
<img width="1175" alt="Screenshot 2024-07-31 at 3 27 25 PM" src="https://github.com/user-attachments/assets/44fe719b-2138-479a-a5cd-0fcbb48a5177">
