### PR TITLE
refreplay): Refactor replay preferences into its own provider

### DIFF
--- a/static/app/components/events/eventReplay/replayClipPreview.tsx
+++ b/static/app/components/events/eventReplay/replayClipPreview.tsx
@@ -1,7 +1,6 @@
 import {useMemo} from 'react';
 
 import ReplayClipPreviewPlayer from 'sentry/components/events/eventReplay/replayClipPreviewPlayer';
-import {StaticReplayPreferences} from 'sentry/components/replays/preferences/replayPreferences';
 import {Provider as ReplayContextProvider} from 'sentry/components/replays/replayContext';
 import useReplayReader from 'sentry/utils/replays/hooks/useReplayReader';
 
@@ -45,7 +44,6 @@ function ReplayClipPreview({
     <ReplayContextProvider
       analyticsContext={analyticsContext}
       isFetching={fetching}
-      prefsStrategy={StaticReplayPreferences}
       replay={replay}
     >
       <ReplayClipPreviewPlayer

--- a/static/app/components/events/eventReplay/staticReplayPreview.tsx
+++ b/static/app/components/events/eventReplay/staticReplayPreview.tsx
@@ -3,7 +3,6 @@ import styled from '@emotion/styled';
 
 import {LinkButton} from 'sentry/components/button';
 import {REPLAY_LOADING_HEIGHT} from 'sentry/components/events/eventReplay/constants';
-import {StaticReplayPreferences} from 'sentry/components/replays/preferences/replayPreferences';
 import {Provider as ReplayContextProvider} from 'sentry/components/replays/replayContext';
 import ReplayPlayer from 'sentry/components/replays/replayPlayer';
 import ReplayProcessingError from 'sentry/components/replays/replayProcessingError';
@@ -59,7 +58,6 @@ export function StaticReplayPreview({
       analyticsContext={analyticsContext}
       initialTimeOffsetMs={offset}
       isFetching={isFetching}
-      prefsStrategy={StaticReplayPreferences}
       replay={replay}
     >
       <PlayerContainer data-test-id="player-container">

--- a/static/app/components/replays/diff/replaySideBySideImageDiff.tsx
+++ b/static/app/components/replays/diff/replaySideBySideImageDiff.tsx
@@ -1,7 +1,6 @@
 import styled from '@emotion/styled';
 
 import {Flex} from 'sentry/components/container/flex';
-import {StaticReplayPreferences} from 'sentry/components/replays/preferences/replayPreferences';
 import {Provider as ReplayContextProvider} from 'sentry/components/replays/replayContext';
 import ReplayPlayer from 'sentry/components/replays/replayPlayer';
 import {t} from 'sentry/locale';
@@ -27,21 +26,21 @@ export function ReplaySideBySideImageDiff({leftOffsetMs, replay, rightOffsetMs}:
           {t('After Hydration')}
         </Flex>
       </DiffHeader>
+
       <ReplayGrid>
         <ReplayContextProvider
           analyticsContext="replay_comparison_modal_left"
           initialTimeOffsetMs={{offsetMs: leftOffsetMs}}
           isFetching={fetching}
-          prefsStrategy={StaticReplayPreferences}
           replay={replay}
         >
           <ReplayPlayer isPreview />
         </ReplayContextProvider>
+
         <ReplayContextProvider
           analyticsContext="replay_comparison_modal_right"
           initialTimeOffsetMs={{offsetMs: rightOffsetMs}}
           isFetching={fetching}
-          prefsStrategy={StaticReplayPreferences}
           replay={replay}
         >
           {rightOffsetMs > 0 ? <ReplayPlayer isPreview /> : <div />}

--- a/static/app/components/replays/diff/replaySliderDiff.tsx
+++ b/static/app/components/replays/diff/replaySliderDiff.tsx
@@ -3,7 +3,6 @@ import styled from '@emotion/styled';
 
 import NegativeSpaceContainer from 'sentry/components/container/negativeSpaceContainer';
 import ReplayIFrameRoot from 'sentry/components/replays/player/replayIFrameRoot';
-import {StaticReplayPreferences} from 'sentry/components/replays/preferences/replayPreferences';
 import {Provider as ReplayContextProvider} from 'sentry/components/replays/replayContext';
 import {Tooltip} from 'sentry/components/tooltip';
 import {t} from 'sentry/locale';
@@ -106,7 +105,6 @@ function DiffSides({leftOffsetMs, replay, rightOffsetMs, viewDimensions, width})
             analyticsContext="replay_comparison_modal_left"
             initialTimeOffsetMs={{offsetMs: leftOffsetMs}}
             isFetching={false}
-            prefsStrategy={StaticReplayPreferences}
             replay={replay}
           >
             <ReplayIFrameRoot viewDimensions={viewDimensions} />
@@ -119,7 +117,6 @@ function DiffSides({leftOffsetMs, replay, rightOffsetMs, viewDimensions, width})
             analyticsContext="replay_comparison_modal_right"
             initialTimeOffsetMs={{offsetMs: rightOffsetMs}}
             isFetching={false}
-            prefsStrategy={StaticReplayPreferences}
             replay={replay}
           >
             <ReplayIFrameRoot viewDimensions={viewDimensions} />

--- a/static/app/components/replays/preferences/replayPreferenceDropdown.stories.tsx
+++ b/static/app/components/replays/preferences/replayPreferenceDropdown.stories.tsx
@@ -1,0 +1,101 @@
+import {Fragment} from 'react';
+
+import ObjectInspector from 'sentry/components/objectInspector';
+import ReplayPreferenceDropdown from 'sentry/components/replays/preferences/replayPreferenceDropdown';
+import {
+  LocalStorageReplayPreferences,
+  StaticNoSkipReplayPreferences,
+  StaticReplayPreferences,
+} from 'sentry/components/replays/preferences/replayPreferences';
+import JSXNode from 'sentry/components/stories/jsxNode';
+import SideBySide from 'sentry/components/stories/sideBySide';
+import storyBook from 'sentry/stories/storyBook';
+import useReplayPrefs, {
+  ReplayPreferencesContextProvider,
+} from 'sentry/utils/replays/playback/providers/useReplayPrefs';
+
+export default storyBook(ReplayPreferenceDropdown, story => {
+  story('Default - LocalStorageReplayPreferences', () => {
+    return (
+      <Fragment>
+        <p>
+          Most often you'll want to save preferences into localStorage using the{' '}
+          <code>LocalStorageReplayPreferences</code> strategy.
+        </p>
+        <p>
+          Each instance of the <JSXNode name="ReplayPreferencesContextProvider" /> will
+          not communicate with the others, but the localStorage item is shared anyway.
+          Whatever instance sets the value last is the winner.
+        </p>
+        <ReplayPreferencesContextProvider prefsStrategy={LocalStorageReplayPreferences}>
+          <SideBySide>
+            <DebugReplayPrefsState />
+            <ReplayPreferenceDropdown speedOptions={[1, 2, 3]} />
+          </SideBySide>
+        </ReplayPreferencesContextProvider>
+      </Fragment>
+    );
+  });
+
+  story('No provider', () => {
+    return (
+      <Fragment>
+        <p>
+          A parent <JSXNode name="ReplayPreferencesContextProvider" /> is what allows
+          values to be changed. Without that in the tree changes will not be reflected.
+        </p>
+        <SideBySide>
+          <DebugReplayPrefsState />
+          <ReplayPreferenceDropdown speedOptions={[1, 2, 3]} />
+        </SideBySide>
+      </Fragment>
+    );
+  });
+
+  story('StaticReplayPreferences', () => {
+    return (
+      <Fragment>
+        <p>
+          If one of the Static* strategies is used, then the values can still be changed,
+          but nothing will be persisted into localStorage.
+        </p>
+        <h4>StaticReplayPreferences</h4>
+        <ReplayPreferencesContextProvider prefsStrategy={StaticReplayPreferences}>
+          <SideBySide>
+            <DebugReplayPrefsState />
+            <ReplayPreferenceDropdown speedOptions={[1, 2, 3]} />
+          </SideBySide>
+        </ReplayPreferencesContextProvider>
+        <h4>StaticNoSkipReplayPreferences</h4>
+        <ReplayPreferencesContextProvider prefsStrategy={StaticNoSkipReplayPreferences}>
+          <SideBySide>
+            <DebugReplayPrefsState />
+            <ReplayPreferenceDropdown speedOptions={[1, 2, 3]} />
+          </SideBySide>
+        </ReplayPreferencesContextProvider>
+      </Fragment>
+    );
+  });
+
+  story('hideFastForward', () => {
+    return (
+      <Fragment>
+        <p>
+          You can hide the fast-forward checkbox in case that's not supported or
+          desirable.
+        </p>
+        <ReplayPreferencesContextProvider prefsStrategy={StaticReplayPreferences}>
+          <SideBySide>
+            <DebugReplayPrefsState />
+            <ReplayPreferenceDropdown hideFastForward speedOptions={[1, 2, 3]} />
+          </SideBySide>
+        </ReplayPreferencesContextProvider>
+      </Fragment>
+    );
+  });
+});
+
+function DebugReplayPrefsState() {
+  const [prefs] = useReplayPrefs();
+  return <ObjectInspector data={prefs} expandLevel={1} />;
+}

--- a/static/app/components/replays/preferences/replayPreferenceDropdown.tsx
+++ b/static/app/components/replays/preferences/replayPreferenceDropdown.tsx
@@ -1,0 +1,55 @@
+import {Button} from 'sentry/components/button';
+import {CompositeSelect} from 'sentry/components/compactSelect/composite';
+import {IconSettings} from 'sentry/icons';
+import {t} from 'sentry/locale';
+import useReplayPrefs from 'sentry/utils/replays/playback/providers/useReplayPrefs';
+
+export default function ReplayPreferenceDropdown({
+  speedOptions,
+  hideFastForward = false,
+}: {
+  speedOptions: number[];
+  hideFastForward?: boolean;
+}) {
+  const [prefs, setPrefs] = useReplayPrefs();
+
+  const SKIP_OPTION_VALUE = 'skip';
+
+  return (
+    <CompositeSelect
+      trigger={triggerProps => (
+        <Button
+          {...triggerProps}
+          size="sm"
+          title={t('Settings')}
+          aria-label={t('Settings')}
+          icon={<IconSettings />}
+        />
+      )}
+    >
+      <CompositeSelect.Region
+        label={t('Playback Speed')}
+        value={prefs.playbackSpeed}
+        onChange={opt => setPrefs({playbackSpeed: opt.value})}
+        options={speedOptions.map(option => ({
+          label: `${option}x`,
+          value: option,
+        }))}
+      />
+      {hideFastForward ? null : (
+        <CompositeSelect.Region
+          aria-label={t('Fast-Forward Inactivity')}
+          multiple
+          value={prefs.isSkippingInactive ? [SKIP_OPTION_VALUE] : []}
+          onChange={opts => setPrefs({isSkippingInactive: opts.length > 0})}
+          options={[
+            {
+              label: t('Fast-forward inactivity'),
+              value: SKIP_OPTION_VALUE,
+            },
+          ]}
+        />
+      )}
+    </CompositeSelect>
+  );
+}

--- a/static/app/components/replays/preferences/replayPreferences.tsx
+++ b/static/app/components/replays/preferences/replayPreferences.tsx
@@ -7,26 +7,50 @@ export type ReplayPrefs = {
   playbackSpeed: number;
 };
 
-const DEFAULT_PREFS = {
+const CAN_SKIP_PREFS: ReplayPrefs = {
   isSkippingInactive: true,
   playbackSpeed: 1,
 };
 
+const NO_SKIP_PREFS: ReplayPrefs = {
+  isSkippingInactive: false,
+  playbackSpeed: 1,
+};
+
 export interface PrefsStrategy {
+  _prefs: ReplayPrefs;
   get: () => ReplayPrefs;
   set: (prefs: ReplayPrefs) => void;
 }
 
 export const StaticReplayPreferences: PrefsStrategy = {
-  get: (): ReplayPrefs => DEFAULT_PREFS,
-  set: () => {},
+  _prefs: {...CAN_SKIP_PREFS},
+  get() {
+    return this._prefs;
+  },
+  set(prefs) {
+    this._prefs = prefs;
+  },
+};
+
+export const StaticNoSkipReplayPreferences: PrefsStrategy = {
+  _prefs: {...NO_SKIP_PREFS},
+  get() {
+    return this._prefs;
+  },
+  set(prefs) {
+    this._prefs = prefs;
+  },
 };
 
 export const LocalStorageReplayPreferences: PrefsStrategy = {
-  get: (): ReplayPrefs => {
+  _prefs: {...CAN_SKIP_PREFS},
+  get() {
     const parsed = JSON.parse(localStorage.getItem(LOCAL_STORAGE_KEY) || '{}');
-    return {...DEFAULT_PREFS, ...parsed};
+    return {...CAN_SKIP_PREFS, ...parsed};
   },
-  set: (prefs: ReplayPrefs) =>
-    localStorage.setItem(LOCAL_STORAGE_KEY, JSON.stringify(prefs)),
+  set(prefs) {
+    this._prefs = prefs;
+    localStorage.setItem(LOCAL_STORAGE_KEY, JSON.stringify(prefs));
+  },
 };

--- a/static/app/components/replays/replayContext.tsx
+++ b/static/app/components/replays/replayContext.tsx
@@ -2,16 +2,13 @@ import {createContext, useCallback, useContext, useEffect, useRef, useState} fro
 import {useTheme} from '@emotion/react';
 import {Replayer, ReplayerEvents} from '@sentry-internal/rrweb';
 
-import type {
-  PrefsStrategy,
-  ReplayPrefs,
-} from 'sentry/components/replays/preferences/replayPreferences';
 import useReplayHighlighting from 'sentry/components/replays/useReplayHighlighting';
 import {VideoReplayerWithInteractions} from 'sentry/components/replays/videoReplayerWithInteractions';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import clamp from 'sentry/utils/number/clamp';
 import type useInitialOffsetMs from 'sentry/utils/replays/hooks/useInitialTimeOffsetMs';
 import {ReplayCurrentTimeContextProvider} from 'sentry/utils/replays/playback/providers/useCurrentHoverTime';
+import useReplayPrefs from 'sentry/utils/replays/playback/providers/useReplayPrefs';
 import type ReplayReader from 'sentry/utils/replays/replayReader';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePrevious from 'sentry/utils/usePrevious';
@@ -74,11 +71,6 @@ interface ReplayPlayerContextProps extends HighlightCallbacks {
   isPlaying: boolean;
 
   /**
-   * Whether fast-forward mode is enabled if RRWeb detects idle moments in the video
-   */
-  isSkippingInactive: boolean;
-
-  /**
    * Set to true while the current video is loading (this is used
    * only for video replays and in lieu of `isBuffering`)
    */
@@ -113,27 +105,11 @@ interface ReplayPlayerContextProps extends HighlightCallbacks {
   setRoot: (root: RootElem) => void;
 
   /**
-   * Set speed for normal playback
-   */
-  setSpeed: (speed: number) => void;
-
-  /**
-   * The speed for normal playback
-   */
-  speed: number;
-
-  /**
    * Start or stop playback
    *
    * @param play
    */
   togglePlayPause: (play: boolean) => void;
-  /**
-   * Allow RRWeb to use Fast-Forward mode for idle moments in the video
-   *
-   * @param skip
-   */
-  toggleSkipInactive: (skip: boolean) => void;
 }
 
 const ReplayPlayerContext = createContext<ReplayPlayerContextProps>({
@@ -149,16 +125,12 @@ const ReplayPlayerContext = createContext<ReplayPlayerContextProps>({
   isFinished: false,
   isPlaying: false,
   isVideoReplay: false,
-  isSkippingInactive: true,
   removeHighlight: () => {},
   replay: null,
   restart: () => {},
   setCurrentTime: () => {},
   setRoot: () => {},
-  setSpeed: () => {},
-  speed: 1,
   togglePlayPause: () => {},
-  toggleSkipInactive: () => {},
 });
 
 type Props = {
@@ -174,11 +146,6 @@ type Props = {
    * Is the data inside the `replay` complete, or are we waiting for more.
    */
   isFetching: boolean;
-
-  /**
-   * The strategy for saving/loading preferences, like the playback speed
-   */
-  prefsStrategy: PrefsStrategy;
 
   replay: ReplayReader | null;
 
@@ -209,7 +176,6 @@ export function Provider({
   children,
   initialTimeOffsetMs,
   isFetching,
-  prefsStrategy,
   replay,
   autoStart,
   value = {},
@@ -220,7 +186,9 @@ export function Provider({
     project_id: replay?.getReplay().project_id,
   })?.slug;
   const events = replay?.getRRWebFrames();
-  const savedReplayConfigRef = useRef<ReplayPrefs>(prefsStrategy.get());
+
+  const [prefs] = useReplayPrefs();
+  const initialPrefsRef = useRef(prefs); // don't re-mount the player when prefs change, instead there's a useEffect
 
   const theme = useTheme();
   const oldEvents = usePrevious(events);
@@ -230,10 +198,7 @@ export function Provider({
   const [dimensions, setDimensions] = useState<Dimensions>({height: 0, width: 0});
   const [isPlaying, setIsPlaying] = useState(false);
   const [finishedAtMS, setFinishedAtMS] = useState<number>(-1);
-  const [isSkippingInactive, setIsSkippingInactive] = useState(
-    savedReplayConfigRef.current.isSkippingInactive
-  );
-  const [speed, setSpeedState] = useState(savedReplayConfigRef.current.playbackSpeed);
+
   const [fastForwardSpeed, setFFSpeed] = useState(0);
   const [buffer, setBufferTime] = useState({target: -1, previous: -1});
   const [isVideoBuffering, setVideoBuffering] = useState(false);
@@ -247,18 +212,6 @@ export function Provider({
   const videoEvents = replay?.getVideoEvents();
   const startTimestampMs = replay?.getStartTimestampMs();
   const isVideoReplay = Boolean(videoEvents?.length);
-
-  const forceDimensions = (dimension: Dimensions) => {
-    setDimensions(dimension);
-  };
-  const onFastForwardStart = useCallback((e: {speed: number}) => {
-    if (savedReplayConfigRef.current.isSkippingInactive) {
-      setFFSpeed(e.speed);
-    }
-  }, []);
-  const onFastForwardEnd = () => {
-    setFFSpeed(0);
-  };
 
   const {addHighlight, clearAllHighlights, removeHighlight} = useReplayHighlighting({
     replayerRef,
@@ -400,16 +353,22 @@ export function Provider({
         plugins: organization.features.includes('session-replay-enable-canvas-replayer')
           ? [CanvasReplayerPlugin(events)]
           : [],
-        skipInactive: savedReplayConfigRef.current.isSkippingInactive,
-        speed: savedReplayConfigRef.current.playbackSpeed,
+        skipInactive: initialPrefsRef.current.isSkippingInactive,
+        speed: initialPrefsRef.current.playbackSpeed,
       });
 
       // @ts-expect-error: rrweb types event handlers with `unknown` parameters
-      inst.on(ReplayerEvents.Resize, forceDimensions);
+      inst.on(ReplayerEvents.Resize, (dimension: Dimensions) => {
+        setDimensions(dimension);
+      });
       inst.on(ReplayerEvents.Finish, setReplayFinished);
       // @ts-expect-error: rrweb types event handlers with `unknown` parameters
-      inst.on(ReplayerEvents.SkipStart, onFastForwardStart);
-      inst.on(ReplayerEvents.SkipEnd, onFastForwardEnd);
+      inst.on(ReplayerEvents.SkipStart, (e: {speed: number}) => {
+        setFFSpeed(e.speed);
+      });
+      inst.on(ReplayerEvents.SkipEnd, () => {
+        setFFSpeed(0);
+      });
 
       // `.current` is marked as readonly, but it's safe to set the value from
       // inside a `useEffect` hook.
@@ -427,7 +386,6 @@ export function Provider({
       organization.features,
       setReplayFinished,
       theme.purple200,
-      onFastForwardStart,
     ]
   );
 
@@ -467,7 +425,7 @@ export function Provider({
         },
         clipWindow,
         durationMs,
-        speed: savedReplayConfigRef.current.playbackSpeed,
+        speed: prefs.playbackSpeed,
         // rrweb specific
         theme,
         events: events ?? [],
@@ -484,46 +442,35 @@ export function Provider({
     },
     [
       applyInitialOffset,
+      clipWindow,
+      durationMs,
+      events,
       isFetching,
       isVideoReplay,
-      videoEvents,
-      events,
       organization.slug,
+      prefs.playbackSpeed,
       projectSlug,
       replay,
       setReplayFinished,
       startTimestampMs,
-      clipWindow,
-      durationMs,
       theme,
+      videoEvents,
     ]
   );
 
-  const setSpeed = useCallback(
-    (newSpeed: number) => {
-      const replayer = replayerRef.current;
-      savedReplayConfigRef.current = {
-        ...savedReplayConfigRef.current,
-        playbackSpeed: newSpeed,
-      };
-
-      prefsStrategy.set(savedReplayConfigRef.current);
-
-      if (!replayer) {
-        return;
-      }
-      if (isPlaying) {
-        replayer.pause();
-        replayer.setConfig({speed: newSpeed});
-        replayer.play(getCurrentPlayerTime());
-      } else {
-        replayer.setConfig({speed: newSpeed});
-      }
-
-      setSpeedState(newSpeed);
-    },
-    [prefsStrategy, getCurrentPlayerTime, isPlaying]
-  );
+  useEffect(() => {
+    const replayer = replayerRef.current;
+    if (!replayer) {
+      return;
+    }
+    if (isPlaying) {
+      replayer.pause();
+      replayer.setConfig({speed: prefs.playbackSpeed});
+      replayer.play(getCurrentPlayerTime());
+    } else {
+      replayer.setConfig({speed: prefs.playbackSpeed});
+    }
+  }, [getCurrentPlayerTime, isPlaying, prefs.playbackSpeed]);
 
   const togglePlayPause = useCallback(
     (play: boolean) => {
@@ -606,27 +553,15 @@ export function Provider({
     }
   }, [startTimeOffsetMs]);
 
-  const toggleSkipInactive = useCallback(
-    (skip: boolean) => {
-      const replayer = replayerRef.current;
-      savedReplayConfigRef.current = {
-        ...savedReplayConfigRef.current,
-        isSkippingInactive: skip,
-      };
-
-      prefsStrategy.set(savedReplayConfigRef.current);
-
-      if (!replayer) {
-        return;
-      }
-      if (skip !== replayer.config.skipInactive) {
-        replayer.setConfig({skipInactive: skip});
-      }
-
-      setIsSkippingInactive(skip);
-    },
-    [prefsStrategy]
-  );
+  useEffect(() => {
+    const replayer = replayerRef.current;
+    if (!replayer) {
+      return;
+    }
+    if (prefs.isSkippingInactive !== replayer.config.skipInactive) {
+      replayer.setConfig({skipInactive: prefs.isSkippingInactive});
+    }
+  }, [prefs.isSkippingInactive]);
 
   const currentPlayerTime = useCurrentTime(getCurrentPlayerTime);
 
@@ -668,15 +603,11 @@ export function Provider({
           isVideoReplay,
           isFinished,
           isPlaying,
-          isSkippingInactive,
           removeHighlight,
           replay,
           restart,
           setCurrentTime,
-          setSpeed,
-          speed,
           togglePlayPause,
-          toggleSkipInactive,
           ...value,
         }}
       >

--- a/static/app/components/replays/replayController.tsx
+++ b/static/app/components/replays/replayController.tsx
@@ -4,12 +4,12 @@ import {useResizeObserver} from '@react-aria/utils';
 
 import {Button} from 'sentry/components/button';
 import ButtonBar from 'sentry/components/buttonBar';
-import {CompositeSelect} from 'sentry/components/compactSelect/composite';
+import ReplayPreferenceDropdown from 'sentry/components/replays/preferences/replayPreferenceDropdown';
 import {useReplayContext} from 'sentry/components/replays/replayContext';
 import {ReplayFullscreenButton} from 'sentry/components/replays/replayFullscreenButton';
 import ReplayPlayPauseButton from 'sentry/components/replays/replayPlayPauseButton';
 import TimeAndScrubberGrid from 'sentry/components/replays/timeAndScrubberGrid';
-import {IconNext, IconRewind10, IconSettings} from 'sentry/icons';
+import {IconNext, IconRewind10} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {getNextReplayFrame} from 'sentry/utils/replays/getReplayEvent';
@@ -20,8 +20,7 @@ const COMPACT_WIDTH_BREAKPOINT = 500;
 
 interface Props {
   toggleFullscreen: () => void;
-  disableFastForward?: boolean;
-  isLoading?: boolean;
+  hideFastForward?: boolean;
   speedOptions?: number[];
 }
 
@@ -61,65 +60,10 @@ function ReplayPlayPauseBar() {
   );
 }
 
-function ReplayOptionsMenu({
-  speedOptions,
-  disableFastForward,
-  isLoading,
-}: {
-  disableFastForward: boolean;
-  speedOptions: number[];
-  isLoading?: boolean;
-}) {
-  const {setSpeed, speed, isSkippingInactive, toggleSkipInactive} = useReplayContext();
-  const SKIP_OPTION_VALUE = 'skip';
-
-  return (
-    <CompositeSelect
-      trigger={triggerProps => (
-        <Button
-          {...triggerProps}
-          size="sm"
-          title={t('Settings')}
-          aria-label={t('Settings')}
-          icon={<IconSettings size="sm" />}
-        />
-      )}
-      disabled={isLoading}
-    >
-      <CompositeSelect.Region
-        label={t('Playback Speed')}
-        value={speed}
-        onChange={opt => setSpeed(opt.value)}
-        options={speedOptions.map(option => ({
-          label: `${option}x`,
-          value: option,
-        }))}
-      />
-      {disableFastForward ? null : (
-        <CompositeSelect.Region
-          aria-label={t('Fast-Forward Inactivity')}
-          multiple
-          value={isSkippingInactive ? [SKIP_OPTION_VALUE] : []}
-          onChange={opts => {
-            toggleSkipInactive(opts.length > 0);
-          }}
-          options={[
-            {
-              label: t('Fast-forward inactivity'),
-              value: SKIP_OPTION_VALUE,
-            },
-          ]}
-        />
-      )}
-    </CompositeSelect>
-  );
-}
-
-function ReplayControls({
+export default function ReplayController({
   toggleFullscreen,
-  disableFastForward = false,
+  hideFastForward = false,
   speedOptions = [0.1, 0.25, 0.5, 1, 2, 4, 8, 16],
-  isLoading,
 }: Props) {
   const barRef = useRef<HTMLDivElement>(null);
   const [isCompact, setIsCompact] = useState(false);
@@ -144,10 +88,9 @@ function ReplayControls({
         <TimeAndScrubberGrid isCompact={isCompact} showZoom />
       </Container>
       <ButtonBar gap={1}>
-        <ReplayOptionsMenu
-          isLoading={isLoading}
+        <ReplayPreferenceDropdown
           speedOptions={speedOptions}
-          disableFastForward={disableFastForward}
+          hideFastForward={hideFastForward}
         />
         <ReplayFullscreenButton toggleFullscreen={toggleFullscreen} />
       </ButtonBar>
@@ -169,5 +112,3 @@ const Container = styled('div')`
   flex: 1 1;
   justify-content: center;
 `;
-
-export default ReplayControls;

--- a/static/app/components/replays/replayView.tsx
+++ b/static/app/components/replays/replayView.tsx
@@ -70,7 +70,7 @@ function ReplayView({toggleFullscreen, isLoading}: Props) {
       {isFullscreen ? (
         <ReplayController
           toggleFullscreen={toggleFullscreen}
-          disableFastForward={isVideoReplay}
+          hideFastForward={isVideoReplay}
         />
       ) : null}
     </Fragment>

--- a/static/app/utils/replays/playback/providers/useReplayPrefs.tsx
+++ b/static/app/utils/replays/playback/providers/useReplayPrefs.tsx
@@ -1,0 +1,44 @@
+import {createContext, useCallback, useContext, useState} from 'react';
+
+import type {
+  PrefsStrategy,
+  ReplayPrefs,
+} from 'sentry/components/replays/preferences/replayPreferences';
+import {StaticReplayPreferences} from 'sentry/components/replays/preferences/replayPreferences';
+
+type ContextType = [ReplayPrefs, (prefs: Partial<ReplayPrefs>) => void];
+
+const StateContext = createContext<ContextType>([
+  StaticReplayPreferences.get(),
+  () => {},
+]);
+
+export function ReplayPreferencesContextProvider({
+  children,
+  prefsStrategy,
+}: {
+  children: React.ReactNode;
+  prefsStrategy: PrefsStrategy;
+}) {
+  const [state, setState] = useState<ReplayPrefs>(() => prefsStrategy.get());
+
+  const setPrefs = useCallback(
+    (config: Partial<ReplayPrefs>) => {
+      const updated = {
+        ...prefsStrategy.get(),
+        ...config,
+      };
+      prefsStrategy.set(updated);
+      setState(updated);
+    },
+    [prefsStrategy]
+  );
+
+  return (
+    <StateContext.Provider value={[state, setPrefs]}>{children}</StateContext.Provider>
+  );
+}
+
+export default function useReplayPrefs() {
+  return useContext(StateContext);
+}

--- a/static/app/views/issueDetails/groupReplays/groupReplays.tsx
+++ b/static/app/views/issueDetails/groupReplays/groupReplays.tsx
@@ -5,7 +5,6 @@ import type {Location} from 'history';
 import {Button} from 'sentry/components/button';
 import * as Layout from 'sentry/components/layouts/thirds';
 import Placeholder from 'sentry/components/placeholder';
-import {StaticReplayPreferences} from 'sentry/components/replays/preferences/replayPreferences';
 import {Provider as ReplayContextProvider} from 'sentry/components/replays/replayContext';
 import {IconPlay, IconUser} from 'sentry/icons';
 import {t, tn} from 'sentry/locale';
@@ -141,7 +140,6 @@ function GroupReplaysTableInner({
     <ReplayContextProvider
       analyticsContext="replay_tab"
       isFetching={fetching}
-      prefsStrategy={StaticReplayPreferences}
       replay={replay}
       autoStart
     >

--- a/static/app/views/replays/detail/layout/index.tsx
+++ b/static/app/views/replays/detail/layout/index.tsx
@@ -55,9 +55,8 @@ function ReplayLayout({
   const controller = (
     <ErrorBoundary mini>
       <ReplayController
-        isLoading={isLoading}
         toggleFullscreen={toggleFullscreen}
-        disableFastForward={isVideoReplay}
+        hideFastForward={isVideoReplay}
       />
     </ErrorBoundary>
   );

--- a/static/app/views/replays/detail/tagPanel/index.spec.tsx
+++ b/static/app/views/replays/detail/tagPanel/index.spec.tsx
@@ -2,7 +2,6 @@ import {ReplayRecordFixture} from 'sentry-fixture/replayRecord';
 
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
-import {StaticReplayPreferences} from 'sentry/components/replays/preferences/replayPreferences';
 import {Provider as ReplayContextProvider} from 'sentry/components/replays/replayContext';
 import ReplayReader from 'sentry/utils/replays/replayReader';
 import TagPanel from 'sentry/views/replays/detail/tagPanel';
@@ -24,12 +23,7 @@ const mockReplay = ReplayReader.factory({
 
 const renderComponent = (replay: ReplayReader | null) => {
   return render(
-    <ReplayContextProvider
-      analyticsContext=""
-      isFetching={false}
-      prefsStrategy={StaticReplayPreferences}
-      replay={replay}
-    >
+    <ReplayContextProvider analyticsContext="" isFetching={false} replay={replay}>
       <TagPanel />
     </ReplayContextProvider>
   );

--- a/static/app/views/replays/details.tsx
+++ b/static/app/views/replays/details.tsx
@@ -20,6 +20,7 @@ import useLogReplayDataLoaded from 'sentry/utils/replays/hooks/useLogReplayDataL
 import useMarkReplayViewed from 'sentry/utils/replays/hooks/useMarkReplayViewed';
 import useReplayPageview from 'sentry/utils/replays/hooks/useReplayPageview';
 import useReplayReader from 'sentry/utils/replays/hooks/useReplayReader';
+import {ReplayPreferencesContextProvider} from 'sentry/utils/replays/playback/providers/useReplayPrefs';
 import useRouteAnalyticsEventNames from 'sentry/utils/routeAnalytics/useRouteAnalyticsEventNames';
 import useRouteAnalyticsParams from 'sentry/utils/routeAnalytics/useRouteAnalyticsParams';
 import {useLocation} from 'sentry/utils/useLocation';
@@ -180,30 +181,31 @@ function ReplayDetails({params: {replaySlug}}: Props) {
   const isVideoReplay = replay?.isVideoReplay();
 
   return (
-    <ReplayContextProvider
-      analyticsContext="replay_details"
-      initialTimeOffsetMs={initialTimeOffsetMs}
-      isFetching={fetching}
-      prefsStrategy={LocalStorageReplayPreferences}
-      replay={replay}
-    >
-      <ReplayTransactionContext replayRecord={replayRecord}>
-        <Page
-          isVideoReplay={isVideoReplay}
-          orgSlug={orgSlug}
-          replayRecord={replayRecord}
-          projectSlug={projectSlug}
-          replayErrors={replayErrors}
-          isLoading={isLoading}
-        >
-          <ReplaysLayout
+    <ReplayPreferencesContextProvider prefsStrategy={LocalStorageReplayPreferences}>
+      <ReplayContextProvider
+        analyticsContext="replay_details"
+        initialTimeOffsetMs={initialTimeOffsetMs}
+        isFetching={fetching}
+        replay={replay}
+      >
+        <ReplayTransactionContext replayRecord={replayRecord}>
+          <Page
             isVideoReplay={isVideoReplay}
+            orgSlug={orgSlug}
             replayRecord={replayRecord}
+            projectSlug={projectSlug}
+            replayErrors={replayErrors}
             isLoading={isLoading}
-          />
-        </Page>
-      </ReplayTransactionContext>
-    </ReplayContextProvider>
+          >
+            <ReplaysLayout
+              isVideoReplay={isVideoReplay}
+              replayRecord={replayRecord}
+              isLoading={isLoading}
+            />
+          </Page>
+        </ReplayTransactionContext>
+      </ReplayContextProvider>
+    </ReplayPreferencesContextProvider>
   );
 }
 

--- a/static/app/views/replays/replayTable/replayTableClipPlayer.tsx
+++ b/static/app/views/replays/replayTable/replayTableClipPlayer.tsx
@@ -1,5 +1,4 @@
 import ReplayClipPreviewPlayer from 'sentry/components/events/eventReplay/replayClipPreviewPlayer';
-import {StaticReplayPreferences} from 'sentry/components/replays/preferences/replayPreferences';
 import {Provider as ReplayContextProvider} from 'sentry/components/replays/replayContext';
 import useReplayReader from 'sentry/utils/replays/hooks/useReplayReader';
 
@@ -22,7 +21,6 @@ function ReplayTableClipPlayer({analyticsContext, orgSlug, replaySlug, ...props}
     <ReplayContextProvider
       analyticsContext={analyticsContext}
       isFetching={fetching}
-      prefsStrategy={StaticReplayPreferences}
       replay={replay}
     >
       <ReplayClipPreviewPlayer


### PR DESCRIPTION
This seems to simplify the data flow a lot, and with the default value in the Provider we don't have to set `StaticReplayPreferences` all over the place.

Tested by finding a replay with some gaps:  `/replays/c629244fee23400c96e35bea63a2657e` and playing with the speed, watching it skip through the gaps, or not.


The stories were fun and helpful to build too. I think that the CompositeSelect doesn't do the right thing with `disabled={isLoading}` set, so i removed that. But a (new) story could be used to check again.

![SCR-20240731-onot](https://github.com/user-attachments/assets/242f739a-dc21-430c-821e-adb2985c6bdc)

