### PR TITLE
feat(prevent-superuser-acces): Create Prevent Superuser Access Service

### DIFF
--- a/self-hosted/sentry.conf.py
+++ b/self-hosted/sentry.conf.py
@@ -179,6 +179,17 @@ SENTRY_BUFFER = "sentry.buffer.redis.RedisBuffer"
 
 SENTRY_QUOTAS = "sentry.quotas.redis.RedisQuota"
 
+
+##########
+# Prevent Superuser Access #
+##########
+
+# Determines if we should prevent superuser access
+
+SENTRY_PREVENT_SUPERUSER_ACCESS_BACKEND = (
+    "sentry.superuser_access.prevent_superuser_access_backend.PreventSuperuserAccess"
+)
+
 ########
 # TSDB #
 ########

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1649,6 +1649,11 @@ SENTRY_DIGESTS_OPTIONS: dict[str, Any] = {}
 SENTRY_QUOTAS = "sentry.quotas.Quota"
 SENTRY_QUOTA_OPTIONS: dict[str, str] = {}
 
+# Prevent superuser access backend
+SENTRY_PREVENT_SUPERUSER_ACCESS_BACKEND = (
+    "sentry.superuser_access.prevent_superuser_access_backend.PreventSuperuserAccess"
+)
+
 # Cache for Relay project configs
 SENTRY_RELAY_PROJECTCONFIG_CACHE = "sentry.relay.projectconfig_cache.redis.RedisProjectConfigCache"
 SENTRY_RELAY_PROJECTCONFIG_CACHE_OPTIONS: dict[str, str] = {}

--- a/src/sentry/superuser_access/__init__.py
+++ b/src/sentry/superuser_access/__init__.py
@@ -1,0 +1,10 @@
+from django.conf import settings
+
+from sentry.utils.services import LazyServiceWrapper
+
+from .prevent_superuser_access_backend import PreventSuperuserAccessBackend
+
+backend = LazyServiceWrapper(
+    PreventSuperuserAccessBackend, settings.SENTRY_PREVENT_SUPERUSER_ACCESS_BACKEND, {}
+)
+backend.expose(locals())

--- a/src/sentry/superuser_access/prevent_superuser_access_backend.py
+++ b/src/sentry/superuser_access/prevent_superuser_access_backend.py
@@ -1,0 +1,19 @@
+from sentry.models.organization import Organization
+from sentry.organizations.services.organization import RpcUserOrganizationContext
+from sentry.utils.services import Service
+
+
+class PreventSuperuserAccessBackend(Service):
+    def should_prevent_superuser_access(
+        self,
+        organization_context: Organization | RpcUserOrganizationContext,
+    ) -> bool:
+        raise NotImplementedError
+
+
+class PreventSuperuserAccess(Service):
+    def should_prevent_superuser_access(
+        self,
+        organization_context: Organization | RpcUserOrganizationContext,
+    ) -> bool:
+        return False

--- a/src/sentry/superuser_access/prevent_superuser_access_backend.py
+++ b/src/sentry/superuser_access/prevent_superuser_access_backend.py
@@ -4,7 +4,7 @@ from sentry.utils.services import Service
 
 
 class PreventSuperuserAccessBackend(Service):
-    def should_prevent_superuser_access(
+    def should_allow_superuser_access(
         self,
         organization_context: Organization | RpcUserOrganizationContext,
     ) -> bool:
@@ -12,8 +12,8 @@ class PreventSuperuserAccessBackend(Service):
 
 
 class PreventSuperuserAccess(Service):
-    def should_prevent_superuser_access(
+    def should_allow_superuser_access(
         self,
         organization_context: Organization | RpcUserOrganizationContext,
     ) -> bool:
-        return False
+        return True

--- a/src/sentry/superuser_access/prevent_superuser_access_backend.py
+++ b/src/sentry/superuser_access/prevent_superuser_access_backend.py
@@ -2,6 +2,13 @@ from sentry.models.organization import Organization
 from sentry.organizations.services.organization import RpcUserOrganizationContext
 from sentry.utils.services import Service
 
+"""
+This class defines the interface for a backend that determines whether a superuser should be allowed access to an organization.
+The backend should implement the `should_allow_superuser_access` method, which takes an organization context and returns a boolean.
+This is a SAAS-only feature, so the default implementation should always return True.
+getsentry contains buisness logic.
+"""
+
 
 class PreventSuperuserAccessBackend(Service):
     def should_allow_superuser_access(
@@ -11,7 +18,7 @@ class PreventSuperuserAccessBackend(Service):
         raise NotImplementedError
 
 
-class PreventSuperuserAccess(Service):
+class PreventSuperuserAccess(PreventSuperuserAccessBackend):
     def should_allow_superuser_access(
         self,
         organization_context: Organization | RpcUserOrganizationContext,

--- a/tests/sentry/superuser_access/test_prevent_superuser_access_backend.py
+++ b/tests/sentry/superuser_access/test_prevent_superuser_access_backend.py
@@ -29,14 +29,14 @@ class DataSecrecyTest(TestCase):
 
     def test_self_hosted(self):
         with self.settings(SENTRY_SELF_HOSTED=True):
-            assert self.backend.should_prevent_superuser_access(self.organization) is False
-            assert self.backend.should_prevent_superuser_access(self.rpc_context) is False
+            assert self.backend.should_allow_superuser_access(self.organization) is True
+            assert self.backend.should_allow_superuser_access(self.rpc_context) is True
 
     def test_bit_flag_disabled(self):
         self.organization.flags.prevent_superuser_access = False
-        assert self.backend.should_prevent_superuser_access(self.organization) is False
-        assert self.backend.should_prevent_superuser_access(self.rpc_context) is False
+        assert self.backend.should_allow_superuser_access(self.organization) is True
+        assert self.backend.should_allow_superuser_access(self.rpc_context) is True
 
     def test_returns_false(self):
-        assert self.backend.should_prevent_superuser_access(self.organization) is False
-        assert self.backend.should_prevent_superuser_access(self.rpc_context) is False
+        assert self.backend.should_allow_superuser_access(self.organization) is True
+        assert self.backend.should_allow_superuser_access(self.rpc_context) is True

--- a/tests/sentry/superuser_access/test_prevent_superuser_access_backend.py
+++ b/tests/sentry/superuser_access/test_prevent_superuser_access_backend.py
@@ -1,0 +1,42 @@
+from sentry.organizations.services.organization import (
+    RpcOrganization,
+    RpcOrganizationMember,
+    RpcUserOrganizationContext,
+)
+from sentry.superuser_access.prevent_superuser_access_backend import PreventSuperuserAccess
+from sentry.testutils.cases import TestCase
+from sentry.testutils.silo import all_silo_test, create_test_regions
+
+
+@all_silo_test(regions=create_test_regions("us"))
+class DataSecrecyTest(TestCase):
+    def setUp(self):
+        self.user = self.create_user()
+        self.organization.flags.prevent_superuser_access = True
+        self.rpc_org = RpcOrganization(id=self.organization.id)
+        self.rpc_org.flags.prevent_superuser_access = True
+
+        self.rpc_orgmember = RpcOrganizationMember(
+            organization_id=self.organization.id,
+            role="admin",
+            user_id=self.user.id,
+        )
+        self.rpc_context = RpcUserOrganizationContext(
+            user_id=self.user.id, organization=self.rpc_org, member=self.rpc_orgmember
+        )
+
+        self.backend = PreventSuperuserAccess()
+
+    def test_self_hosted(self):
+        with self.settings(SENTRY_SELF_HOSTED=True):
+            assert self.backend.should_prevent_superuser_access(self.organization) is False
+            assert self.backend.should_prevent_superuser_access(self.rpc_context) is False
+
+    def test_bit_flag_disabled(self):
+        self.organization.flags.prevent_superuser_access = False
+        assert self.backend.should_prevent_superuser_access(self.organization) is False
+        assert self.backend.should_prevent_superuser_access(self.rpc_context) is False
+
+    def test_returns_false(self):
+        assert self.backend.should_prevent_superuser_access(self.organization) is False
+        assert self.backend.should_prevent_superuser_access(self.rpc_context) is False


### PR DESCRIPTION
Made a Lazy Wrapper Service to Implement Prevent Superuser Access logic. The logic will live in `getsentry` gated by a plan, so the service will return  `True` when `should_allow_superuser_access` is called in `sentry`. 

There will be a separate PR in `getsentry` which actually implements the business logic. 

https://github.com/getsentry/getsentry/pull/14779 for more context