### PR TITLE
fix(endpoints): Fix requests with invalid statuses leading to errors

### DIFF
--- a/src/sentry/integrations/api/endpoints/organization_repositories.py
+++ b/src/sentry/integrations/api/endpoints/organization_repositories.py
@@ -85,7 +85,7 @@ class OrganizationRepositoriesEndpoint(OrganizationEndpoint):
 
             return Response(serialize(repos, request.user))
 
-        else:
+        elif status:
             queryset = queryset.none()
 
         return self.paginate(


### PR DESCRIPTION
Prev changes led to some integrations that set status to an invalid value to be an empty queryset leading to errors for certain providers (i.e terraform-provider)

See: https://github.com/jianyuan/terraform-provider-sentry/issues/470