### PR TITLE
ref(stats): Expose org quota reason

### DIFF
--- a/static/app/views/organizationStats/getReasonGroupName.ts
+++ b/static/app/views/organizationStats/getReasonGroupName.ts
@@ -140,7 +140,7 @@ function getRateLimitedReasonGroupName(reason: RateLimitedReason | string): stri
     case RateLimitedReason.PROJECT_QUOTA:
       return 'global limit';
     case RateLimitedReason.KEY_QUOTA:
-      return 'DSN limit"';
+      return 'DSN limit';
     case RateLimitedReason.SPIKE_PROTECTION:
     case RateLimitedReason.SMART_RATE_LIMIT:
       return 'spike protection';

--- a/static/app/views/organizationStats/getReasonGroupName.ts
+++ b/static/app/views/organizationStats/getReasonGroupName.ts
@@ -72,6 +72,7 @@ enum ClientDiscardReason {
 }
 
 enum RateLimitedReason {
+  ORG_QUOTA = 'org_quota',
   KEY_QUOTA = 'key_quota',
   SPIKE_PROTECTION = 'spike_protection',
   SMART_RATE_LIMIT = 'smart_rate_limit',
@@ -130,6 +131,8 @@ function getRateLimitedReasonGroupName(reason: RateLimitedReason | string): stri
   }
 
   switch (reason) {
+    case RateLimitedReason.ORG_QUOTA:
+      return 'org quota';
     case RateLimitedReason.KEY_QUOTA:
       return 'key limit';
     case RateLimitedReason.SPIKE_PROTECTION:

--- a/static/app/views/organizationStats/getReasonGroupName.ts
+++ b/static/app/views/organizationStats/getReasonGroupName.ts
@@ -72,6 +72,7 @@ enum ClientDiscardReason {
 }
 
 enum RateLimitedReason {
+  PROJECT_QUOTA = 'project_quota',
   ORG_QUOTA = 'org_quota',
   KEY_QUOTA = 'key_quota',
   SPIKE_PROTECTION = 'spike_protection',
@@ -130,11 +131,16 @@ function getRateLimitedReasonGroupName(reason: RateLimitedReason | string): stri
     return 'quota';
   }
 
+  if (reason.endsWith('_disabled')) {
+    return 'disabled';
+  }
+
   switch (reason) {
     case RateLimitedReason.ORG_QUOTA:
-      return 'org quota';
+    case RateLimitedReason.PROJECT_QUOTA:
+      return 'global limit';
     case RateLimitedReason.KEY_QUOTA:
-      return 'key limit';
+      return 'DSN limit"';
     case RateLimitedReason.SPIKE_PROTECTION:
     case RateLimitedReason.SMART_RATE_LIMIT:
       return 'spike protection';


### PR DESCRIPTION
### Goal

On the stats chart, we currently display the 'key_quota' reason, which represents the rate limit defined for individual projects, but we do not display the 'org_quota' reason, which is the rate limit for the entire organization. Currently, the "org_quota" reason is shown as "internal," which is confusing for users. This PR addresses the issue.