### PR TITLE
chore(metrics) Clean up of `useMetricsTags`

### DIFF
--- a/static/app/components/metrics/mriSelect/metricListItemDetails.tsx
+++ b/static/app/components/metrics/mriSelect/metricListItemDetails.tsx
@@ -65,9 +65,7 @@ export function MetricListItemDetails({
 
   const [isQueryEnabled, setIsQueryEnabled] = useState(() => {
     // We only wnat to disable the query if there is no data in the cache
-    const queryKey = getMetricsTagsQueryKey(organization, metric.mri, {
-      projects: projectIds,
-    });
+    const queryKey = getMetricsTagsQueryKey(organization, metric.mri);
     const data = queryClient.getQueryData(queryKey);
     return !!data;
   });

--- a/static/app/utils/metrics/index.tsx
+++ b/static/app/utils/metrics/index.tsx
@@ -31,7 +31,6 @@ import type {
   UseCase,
 } from 'sentry/types/metrics';
 import {isMeasurement} from 'sentry/utils/discover/fields';
-import {statsPeriodToDays} from 'sentry/utils/duration/statsPeriodToDays';
 import {getMeasurements} from 'sentry/utils/measurements/measurements';
 import {DEFAULT_AGGREGATES} from 'sentry/utils/metrics/constants';
 import {formatMRI, formatMRIField, MRIToField, parseMRI} from 'sentry/utils/metrics/mri';
@@ -442,24 +441,6 @@ export function getAbsoluteDateTimeRange(params: PageFilters['datetime']) {
   );
 
   return {start: startObj.toISOString(), end: now.toISOString()};
-}
-
-// TODO(metrics): remove this when we switch tags to the new meta
-export function getMetaDateTimeParams(datetime?: PageFilters['datetime']) {
-  if (datetime?.period) {
-    if (statsPeriodToDays(datetime.period) < 14) {
-      return {statsPeriod: '14d'};
-    }
-    return {statsPeriod: datetime.period};
-  }
-  if (datetime?.start && datetime?.end) {
-    return {
-      start: moment(datetime.start).toISOString(),
-      end: moment(datetime.end).toISOString(),
-    };
-  }
-
-  return {statsPeriod: '14d'};
 }
 
 export function areResultsLimited(response: MetricsQueryApiResponse) {

--- a/static/app/utils/metrics/useMetricsTags.tsx
+++ b/static/app/utils/metrics/useMetricsTags.tsx
@@ -1,14 +1,12 @@
 import type {PageFilters} from 'sentry/types/core';
 import type {MRI} from 'sentry/types/metrics';
 import type {Organization} from 'sentry/types/organization';
-import {getUseCaseFromMRI, parseMRI} from 'sentry/utils/metrics/mri';
+import {parseMRI} from 'sentry/utils/metrics/mri';
 import type {MetricTag} from 'sentry/utils/metrics/types';
 import {useMetricsMeta} from 'sentry/utils/metrics/useMetricsMeta';
 import {useVirtualMetricsContext} from 'sentry/utils/metrics/virtualMetricsContext';
 import {useApiQuery} from 'sentry/utils/queryClient';
 import useOrganization from 'sentry/utils/useOrganization';
-
-import {getMetaDateTimeParams} from './index';
 
 export const SPAN_DURATION_MRI = 'd:spans/duration@millisecond';
 const ALLOWED_SPAN_DURATION_TAGS = [
@@ -21,24 +19,10 @@ const ALLOWED_SPAN_DURATION_TAGS = [
   'span.op',
 ];
 
-export function getMetricsTagsQueryKey(
-  organization: Organization,
-  mri: MRI | undefined,
-  pageFilters: Partial<PageFilters>
-) {
-  const useCase = getUseCaseFromMRI(mri) ?? 'custom';
-  const queryParams = pageFilters.projects?.length
-    ? {
-        metric: mri,
-        useCase,
-        project: pageFilters.projects,
-        ...getMetaDateTimeParams(pageFilters.datetime),
-      }
-    : {
-        metric: mri,
-        useCase,
-        ...getMetaDateTimeParams(pageFilters.datetime),
-      };
+export function getMetricsTagsQueryKey(organization: Organization, mri: MRI | undefined) {
+  const queryParams = {
+    metric: mri,
+  };
 
   return [
     `/organizations/${organization.slug}/metrics/tags/`,
@@ -60,13 +44,10 @@ export function useMetricsTags(
   const useCase = parsedMRI?.useCase ?? 'custom';
   const isVirtualMetric = parsedMRI?.type === 'v';
 
-  const tagsQuery = useApiQuery<MetricTag[]>(
-    getMetricsTagsQueryKey(organization, mri, pageFilters),
-    {
-      enabled: !!mri && !isVirtualMetric,
-      staleTime: Infinity,
-    }
-  );
+  const tagsQuery = useApiQuery<MetricTag[]>(getMetricsTagsQueryKey(organization, mri), {
+    enabled: !!mri && !isVirtualMetric,
+    staleTime: Infinity,
+  });
 
   const metricMeta = useMetricsMeta(pageFilters, [useCase], false, !blockedTags);
   const blockedTagsData =


### PR DESCRIPTION
Clean up of `useMetricsTags` since API endpoint is not even using the parameters that we are sending: https://github.com/getsentry/sentry/blob/master/src/sentry/api/endpoints/organization_metrics_tags.py
