### PR TITLE
fix(metrics): focused series url

### DIFF
--- a/static/app/components/metrics/querySymbol.tsx
+++ b/static/app/components/metrics/querySymbol.tsx
@@ -47,6 +47,7 @@ export const Symbol = styled(DeprecatedSymbol)`
   border: 1px solid ${p => p.theme.purple200};
   background: ${p => p.theme.purple100};
   font-weight: 600;
+  ${p => p.isHidden && 'opacity: 0.5;'}
 `;
 
 interface QuerySymbolProps extends React.ComponentProps<typeof Symbol> {

--- a/static/app/views/metrics/summaryTable.tsx
+++ b/static/app/views/metrics/summaryTable.tsx
@@ -210,7 +210,7 @@ export const SummaryTable = memo(function SummaryTable({
               <Row
                 onClick={() => {
                   if (hasMultipleSeries) {
-                    onRowClick(row);
+                    onRowClick({id: row.id, groupBy: row.groupBy});
                   }
                 }}
                 onMouseEnter={() => {


### PR DESCRIPTION
Fixes an issue where focusing a series would result in too long url since the entire series data was passed into the url.
Also fixes #75422 

<img width="147" alt="image" src="https://github.com/user-attachments/assets/f39086c8-79d3-4dfb-81a8-df1255431a1f">
