### PR TITLE
feat(metric): Introduce an option to propagate sample rates

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1459,21 +1459,33 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 
+# Enables extrapolation on the `transactions` namespace.
 register(
     "sentry-metrics.extrapolation.enable_transactions",
     default=False,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 
+# Enables extrapolation on the `spans` namespace.
 register(
     "sentry-metrics.extrapolation.enable_spans",
     default=False,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 
+# Maximum duplication factor for ingest-time extrapolation of distribution
+# values in Relay. Obsolete once `.propagate-rates` is the default.
 register(
     "sentry-metrics.extrapolation.duplication-limit",
     default=0,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+
+# Send sample rates for metrics from Relay via the indexer into snuba rather
+# than extrapolating at ingest time.
+register(
+    "sentry-metrics.extrapolation.propagate-rates",
+    default=False,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 

--- a/src/sentry/relay/globalconfig.py
+++ b/src/sentry/relay/globalconfig.py
@@ -26,6 +26,7 @@ RELAY_OPTIONS: list[str] = [
     "relay.span-extraction.sample-rate",
     "relay.compute-metrics-summaries.sample-rate",
     "sentry-metrics.extrapolation.duplication-limit",
+    "sentry-metrics.extrapolation.propagate-rates",
 ]
 
 


### PR DESCRIPTION
Introduces a global option for Relay that stops extrapolation at ingest time and
instead sends sample rates to storage for extrapolation at query time.

The corresponding functionality in Relay and storage is WIP, and as such the
option must stay disabled.

Epic: https://github.com/getsentry/relay/issues/3724
Relay: https://github.com/getsentry/relay/pull/3884
