### PR TITLE
Fix(metrics) Filter autocomplete fix

### DIFF
--- a/static/app/views/performance/utils/useSpanFieldSupportedTags.tsx
+++ b/static/app/views/performance/utils/useSpanFieldSupportedTags.tsx
@@ -1,3 +1,5 @@
+import {useMemo} from 'react';
+
 import {getHasTag} from 'sentry/components/events/searchBar';
 import type {PageFilters, TagCollection} from 'sentry/types';
 import {DiscoverDatasets} from 'sentry/utils/discover/types';
@@ -75,7 +77,7 @@ export function useSpanFieldSupportedTags(options?: {
     DiscoverDatasets.SPANS_INDEXED
   );
 
-  const dynamicTagQuery = useApiQuery<SpanFieldsResponse>(
+  const {data} = useApiQuery<SpanFieldsResponse>(
     getDynamicSpanFieldsEndpoint(
       organization.slug,
       projects ?? selection.projects,
@@ -87,15 +89,17 @@ export function useSpanFieldSupportedTags(options?: {
     }
   );
 
-  if (dynamicTagQuery.isSuccess) {
-    const dynamicTags: TagCollection = Object.fromEntries(
-      dynamicTagQuery.data.map(entry => [entry.key, entry])
-    );
+  const tags = useMemo(() => {
+    if (!data) {
+      return staticTags;
+    }
     return {
-      ...dynamicTags,
+      ...Object.fromEntries(
+        data.map(entry => [entry.key, {key: entry.key, name: entry.name}])
+      ),
       ...staticTags,
     };
-  }
+  }, [data, staticTags]);
 
-  return staticTags;
+  return tags;
 }

--- a/static/app/views/settings/projectMetrics/metricsExtractionRuleForm.tsx
+++ b/static/app/views/settings/projectMetrics/metricsExtractionRuleForm.tsx
@@ -526,6 +526,7 @@ export function MetricsExtractionRuleForm({
                               placeholder={t('Add span attributes')}
                               organization={organization}
                               supportedTags={supportedTags}
+                              excludedTags={[]}
                               dataset={DiscoverDatasets.SPANS_INDEXED}
                               projectIds={[Number(projectId)]}
                               hasRecentSearches={false}


### PR DESCRIPTION
Autocomplete wasn't showing all the data it could have because of the bug in one custom hook.
Also some fields were excluded by default (e.g. environment) which is now also fixed.

Closes https://github.com/getsentry/sentry/issues/75437

Before
![image](https://github.com/user-attachments/assets/bc8f9c08-6e64-4be4-9967-25c0139f1aba)

Now
![image](https://github.com/user-attachments/assets/0fabedb6-9730-44bd-b877-efa3ed082f32)

