### PR TITLE
fix(metrics) Move tooltip left when tag is disabled

### DIFF
--- a/static/app/views/settings/projectMetrics/metricsExtractionRuleForm.tsx
+++ b/static/app/views/settings/projectMetrics/metricsExtractionRuleForm.tsx
@@ -294,6 +294,7 @@ export function MetricsExtractionRuleForm({
       tooltip: isHighCardinalityTag(option)
         ? t('This tag has high cardinality.')
         : undefined,
+      tooltipOptions: {position: 'left'},
     }));
   }, [allAttributeOptions]);
 


### PR DESCRIPTION
Moves tooltip left (as it is in component where we use it)

Closes https://github.com/getsentry/sentry/issues/75430

Before
![image](https://github.com/user-attachments/assets/c7f8f4fb-56bf-4611-85e0-1395340dcc56)

After
![image](https://github.com/user-attachments/assets/a844a796-4755-487b-a853-880919058604)
