### PR TITLE
fix(buffer): Do not propagate traces for batched incr

### DIFF
--- a/src/sentry/buffer/base.py
+++ b/src/sentry/buffer/base.py
@@ -102,7 +102,8 @@ class Buffer(Service):
                 "filters": filters,
                 "extra": extra,
                 "signal_only": signal_only,
-            }
+            },
+            headers={"sentry-propagate-traces": False},
         )
 
     def process_pending(self) -> None:

--- a/src/sentry/buffer/redis.py
+++ b/src/sentry/buffer/redis.py
@@ -391,7 +391,10 @@ class RedisBuffer(Buffer):
                 for key in keys:
                     pending_buffer.append(key)
                     if pending_buffer.full():
-                        process_incr.apply_async(kwargs={"batch_keys": pending_buffer.flush()})
+                        process_incr.apply_async(
+                            kwargs={"batch_keys": pending_buffer.flush()},
+                            headers={"sentry-propagate-traces": False},
+                        )
 
                 self.cluster.zrem(self.pending_key, *keys)
             elif is_instance_rb_cluster(self.cluster, self.is_redis_cluster):
@@ -407,7 +410,8 @@ class RedisBuffer(Buffer):
                             pending_buffer.append(keyb.decode("utf-8"))
                             if pending_buffer.full():
                                 process_incr.apply_async(
-                                    kwargs={"batch_keys": pending_buffer.flush()}
+                                    kwargs={"batch_keys": pending_buffer.flush()},
+                                    headers={"sentry-propagate-traces": False},
                                 )
                         conn.target([host_id]).zrem(self.pending_key, *keysb)
             else:
@@ -415,7 +419,10 @@ class RedisBuffer(Buffer):
 
             # queue up remainder of pending keys
             if not pending_buffer.empty():
-                process_incr.apply_async(kwargs={"batch_keys": pending_buffer.flush()})
+                process_incr.apply_async(
+                    kwargs={"batch_keys": pending_buffer.flush()},
+                    headers={"sentry-propagate-traces": False},
+                )
 
             metrics.distribution("buffer.pending-size", keycount)
         finally:

--- a/tests/sentry/buffer/test_base.py
+++ b/tests/sentry/buffer/test_base.py
@@ -27,7 +27,7 @@ class BufferTest(TestCase):
         filters: dict[str, models.Model | str | int] = {"id": 1}
         self.buf.incr(model, columns, filters)
         kwargs = dict(model=model, columns=columns, filters=filters, extra=None, signal_only=None)
-        process_incr.apply_async.assert_called_once_with(kwargs=kwargs)
+        process_incr.apply_async.assert_called_once_with(kwargs=kwargs, headers=mock.ANY)
 
     def test_process_saves_data(self):
         group = Group.objects.create(project=Project(id=1))

--- a/tests/sentry/buffer/test_redis.py
+++ b/tests/sentry/buffer/test_redis.py
@@ -53,7 +53,9 @@ class TestRedisBuffer:
         client.zadd("b:p", {"foo": 1, "bar": 2})
         self.buf.process_pending()
         assert len(process_incr.apply_async.mock_calls) == 1
-        process_incr.apply_async.assert_any_call(kwargs={"batch_keys": ["foo", "bar"]})
+        process_incr.apply_async.assert_any_call(
+            kwargs={"batch_keys": ["foo", "bar"]}, headers=mock.ANY
+        )
         client = get_cluster_routing_client(self.buf.cluster, self.buf.is_redis_cluster)
         assert client.zrange("b:p", 0, -1) == []
 
@@ -65,8 +67,10 @@ class TestRedisBuffer:
         client.zadd("b:p", {"foo": 1, "bar": 2, "baz": 3})
         self.buf.process_pending()
         assert len(process_incr.apply_async.mock_calls) == 2
-        process_incr.apply_async.assert_any_call(kwargs={"batch_keys": ["foo", "bar"]})
-        process_incr.apply_async.assert_any_call(kwargs={"batch_keys": ["baz"]})
+        process_incr.apply_async.assert_any_call(
+            kwargs={"batch_keys": ["foo", "bar"]}, headers=mock.ANY
+        )
+        process_incr.apply_async.assert_any_call(kwargs={"batch_keys": ["baz"]}, headers=mock.ANY)
         client = get_cluster_routing_client(self.buf.cluster, self.buf.is_redis_cluster)
         assert client.zrange("b:p", 0, -1) == []
 


### PR DESCRIPTION
Stops propagation of traces from `buffer.process_pending` down to
`buffer.process_incr`. The first task tends to spawn thousands of sub
tasks, which creates enormeous traces. These traces are not useful to
debug, since their connection has no meaning and they are only sent
sporadically.

In theory, direct use of `buffer.incr` should not have these issues.
However, in getsentry it is also used in hot loops in the outcomes
consumer, so we also update this instance.

SDK Documentation: https://docs.sentry.io/platforms/python/integrations/celery/#distributed-traces