### PR TITLE
chore(data-secrecy): Remove bitflag update from Org Details Endpoint

### DIFF
--- a/src/sentry/api/endpoints/organization_details.py
+++ b/src/sentry/api/endpoints/organization_details.py
@@ -512,8 +512,6 @@ class OrganizationSerializer(BaseOrganizationSerializer):
             org.flags.require_email_verification = data["requireEmailVerification"]
         if "allowMemberProjectCreation" in data:
             org.flags.disable_member_project_creation = not data["allowMemberProjectCreation"]
-        if "allowSuperuserAccess" in data:
-            org.flags.prevent_superuser_access = not data["allowSuperuserAccess"]
         if "name" in data:
             org.name = data["name"]
         if "slug" in data:
@@ -531,7 +529,6 @@ class OrganizationSerializer(BaseOrganizationSerializer):
                 "require_2fa": org.flags.require_2fa.is_set,
                 "codecov_access": org.flags.codecov_access.is_set,
                 "disable_member_project_creation": org.flags.disable_member_project_creation.is_set,
-                "prevent_superuser_access": org.flags.prevent_superuser_access.is_set,
             },
         }
 

--- a/tests/sentry/api/endpoints/test_organization_details.py
+++ b/tests/sentry/api/endpoints/test_organization_details.py
@@ -471,7 +471,6 @@ class OrganizationUpdateTest(OrganizationDetailsTestBase):
 
         assert org.flags.early_adopter
         assert org.flags.codecov_access
-        assert org.flags.prevent_superuser_access
         assert not org.flags.allow_joinleave
         assert org.flags.disable_shared_issues
         assert org.flags.enhanced_privacy
@@ -503,9 +502,6 @@ class OrganizationUpdateTest(OrganizationDetailsTestBase):
         assert "to {}".format(data["openMembership"]) in log.data["allow_joinleave"]
         assert "to {}".format(data["isEarlyAdopter"]) in log.data["early_adopter"]
         assert "to {}".format(data["codecovAccess"]) in log.data["codecov_access"]
-        assert (
-            "to {}".format(not data["allowSuperuserAccess"]) in log.data["prevent_superuser_access"]
-        )
         assert "to {}".format(data["enhancedPrivacy"]) in log.data["enhanced_privacy"]
         assert "to {}".format(not data["allowSharedIssues"]) in log.data["disable_shared_issues"]
         assert "to {}".format(data["require2FA"]) in log.data["require_2fa"]


### PR DESCRIPTION
Need to gate this behind a plan, so want to make sure noone can update their bitflag before then. checked redash and isn't the case but ill add this again once i have the permanant feature flag setup