### PR TITLE
fix(query-builder): Escape keys in parameter combobox

### DIFF
--- a/static/app/components/searchQueryBuilder/tokens/filter/parametersCombobox.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/parametersCombobox.tsx
@@ -3,6 +3,7 @@ import {Item} from '@react-stately/collections';
 import type {KeyboardEvent} from '@react-types/shared';
 
 import type {SelectOptionWithKey} from 'sentry/components/compactSelect/types';
+import {getEscapedKey} from 'sentry/components/compactSelect/utils';
 import {useSearchQueryBuilder} from 'sentry/components/searchQueryBuilder/context';
 import {SearchQueryBuilderCombobox} from 'sentry/components/searchQueryBuilder/tokens/combobox';
 import {replaceCommaSeparatedValue} from 'sentry/components/searchQueryBuilder/tokens/filter/utils';
@@ -153,7 +154,7 @@ function useParameterSuggestions({
   const createItem = useCallback(
     (suggestion: SuggestionItem): SelectOptionWithKey<string> => {
       return {
-        key: suggestion.value,
+        key: getEscapedKey(suggestion.value),
         label: suggestion.label ?? suggestion.value,
         value: suggestion.value,
         details: suggestion.description,


### PR DESCRIPTION
Tiny change that fixes a bug with parameter keys with special characters like `transaction.duration`