### PR TITLE
fix(endpoints): Fetching organisation repos regardless of status

### DIFF
--- a/src/sentry/integrations/api/endpoints/organization_repositories.py
+++ b/src/sentry/integrations/api/endpoints/organization_repositories.py
@@ -85,7 +85,7 @@ class OrganizationRepositoriesEndpoint(OrganizationEndpoint):
 
             return Response(serialize(repos, request.user))
 
-        else:
+        elif status:
             queryset = queryset.none()
 
         return self.paginate(

--- a/tests/sentry/integrations/api/endpoints/test_organization_repositories.py
+++ b/tests/sentry/integrations/api/endpoints/test_organization_repositories.py
@@ -103,6 +103,40 @@ class OrganizationRepositoriesListTest(APITestCase):
         assert first_row["provider"] == {"id": "dummy", "name": "Example"}
         assert first_row["externalSlug"] == str(repo.external_id)
 
+    def test_get_all_repos(self):
+        repo1 = Repository.objects.create(
+            name="getsentry/example",
+            organization_id=self.org.id,
+            external_id=12345,
+            provider="dummy",
+            config={"name": "getsentry/example"},
+        )
+        repo2 = Repository.objects.create(
+            name="getsentry/sentry",
+            organization_id=self.org.id,
+            external_id=54321,
+            provider="dummy",
+            config={"name": "getsentry/sentry"},
+            status=ObjectStatus.HIDDEN,
+        )
+
+        self.url = self.url + "?status="
+
+        response = self.client.get(self.url, format="json")
+
+        assert response.status_code == 200, response.content
+        assert len(response.data) == 2
+
+        first_row = response.data[0]
+        assert first_row["id"] == str(repo1.id)
+        assert first_row["provider"] == {"id": "dummy", "name": "Example"}
+        assert first_row["externalSlug"] == str(repo1.external_id)
+
+        second_row = response.data[1]
+        assert second_row["id"] == str(repo2.id)
+        assert second_row["provider"] == {"id": "dummy", "name": "Example"}
+        assert second_row["externalSlug"] == str(repo2.external_id)
+
     def test_status_unmigratable(self):
         self.url = self.url + "?status=unmigratable"
 


### PR DESCRIPTION
Previous to https://github.com/getsentry/sentry/commit/e2fa60a843ceec6c2eaf662ec706f6f0bad76242, the behaviour of the API was that sending `?status=` would return all entities regardless of their status. This restores that behaviour.

See https://github.com/getsentry/sentry/pull/75409 where the actual fix comes from. My contribution here is adding test coverage.

closes #75409 

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
