### PR TITLE
ref(alerts): Correct metric alert tooltip text

### DIFF
--- a/static/app/views/alerts/list/rules/combinedAlertBadge.tsx
+++ b/static/app/views/alerts/list/rules/combinedAlertBadge.tsx
@@ -17,7 +17,7 @@ const IncidentStatusText: Record<IncidentStatus, string> = {
   [IncidentStatus.CRITICAL]: t('Critical'),
   [IncidentStatus.WARNING]: t('Warning'),
   [IncidentStatus.CLOSED]: t('Resolved'),
-  [IncidentStatus.OPENED]: t('Resolved'),
+  [IncidentStatus.OPENED]: t('Open'),
 };
 
 /**


### PR DESCRIPTION
Match the text in the backend here:

https://github.com/getsentry/sentry/blob/5b00015693fdc5dada4f7916853e04bf560c2139/src/sentry/incidents/models/incident.py#L168

depends on: https://github.com/getsentry/sentry/pull/75035