### PR TITLE
ref(query-builder): Move filter value suggestion and validation logic into their own files

### DIFF
--- a/static/app/components/searchQueryBuilder/tokens/filter/valueCombobox.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/valueCombobox.tsx
@@ -1,16 +1,12 @@
-import {type ReactNode, useCallback, useEffect, useMemo, useRef, useState} from 'react';
+import {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import styled from '@emotion/styled';
 import {Item, Section} from '@react-stately/collections';
 import type {KeyboardEvent} from '@react-types/shared';
 
 import Checkbox from 'sentry/components/checkbox';
-import type {SelectOptionWithKey} from 'sentry/components/compactSelect/types';
 import {getItemsWithKeys} from 'sentry/components/compactSelect/utils';
 import {useSearchQueryBuilder} from 'sentry/components/searchQueryBuilder/context';
 import {SearchQueryBuilderCombobox} from 'sentry/components/searchQueryBuilder/tokens/combobox';
-import {parseFilterValueDate} from 'sentry/components/searchQueryBuilder/tokens/filter/parsers/date/parser';
-import {parseFilterValueDuration} from 'sentry/components/searchQueryBuilder/tokens/filter/parsers/duration/parser';
-import {parseFilterValuePercentage} from 'sentry/components/searchQueryBuilder/tokens/filter/parsers/percentage/parser';
 import SpecificDatePicker from 'sentry/components/searchQueryBuilder/tokens/filter/specificDatePicker';
 import {
   escapeTagValue,
@@ -18,6 +14,16 @@ import {
   replaceCommaSeparatedValue,
   unescapeTagValue,
 } from 'sentry/components/searchQueryBuilder/tokens/filter/utils';
+import {getDefaultAbsoluteDateValue} from 'sentry/components/searchQueryBuilder/tokens/filter/valueSuggestions/date';
+import type {
+  SuggestionItem,
+  SuggestionSection,
+  SuggestionSectionItem,
+} from 'sentry/components/searchQueryBuilder/tokens/filter/valueSuggestions/types';
+import {
+  cleanFilterValue,
+  getValueSuggestions,
+} from 'sentry/components/searchQueryBuilder/tokens/filter/valueSuggestions/utils';
 import {getDefaultFilterValue} from 'sentry/components/searchQueryBuilder/tokens/utils';
 import {
   isDateToken,
@@ -35,8 +41,7 @@ import {
   type SearchGroup,
   type SearchItem,
 } from 'sentry/components/smartSearchBar/types';
-import {IconArrow} from 'sentry/icons';
-import {t, tn} from 'sentry/locale';
+import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {Tag, TagCollection} from 'sentry/types/group';
 import {trackAnalytics} from 'sentry/utils/analytics';
@@ -54,69 +59,10 @@ type SearchQueryValueBuilderProps = {
   wrapperRef: React.RefObject<HTMLDivElement>;
 };
 
-type SuggestionItem = {
-  value: string;
-  description?: ReactNode;
-  label?: ReactNode;
-};
-
-type SuggestionSection = {
-  sectionText: string;
-  suggestions: SuggestionItem[];
-};
-
-type SuggestionSectionItem = {
-  items: SelectOptionWithKey<string>[];
-  sectionText: string;
-};
-
-const NUMERIC_REGEX = /^-?\d+(\.\d+)?$/;
-const FILTER_VALUE_NUMERIC = /^-?\d+(\.\d+)?[kmb]?$/i;
-const FILTER_VALUE_INT = /^-?\d+[kmb]?$/i;
-
-const RELATIVE_DATE_INPUT_REGEX = /^(\d+)\s*([mhdw]?)/;
-
-function isNumeric(value: string) {
-  return NUMERIC_REGEX.test(value);
-}
-
 function isStringFilterValues(
   tagValues: string[] | SearchGroup[]
 ): tagValues is string[] {
   return typeof tagValues[0] === 'string';
-}
-
-const NUMERIC_UNITS = ['k', 'm', 'b'] as const;
-const RELATIVE_DATE_UNITS = ['m', 'h', 'd', 'w'] as const;
-const DURATION_UNIT_SUGGESTIONS = ['ms', 's', 'm', 'h'] as const;
-
-const DEFAULT_NUMERIC_SUGGESTIONS: SuggestionSection[] = [
-  {
-    sectionText: '',
-    suggestions: [{value: '100'}, {value: '100k'}, {value: '100m'}, {value: '100b'}],
-  },
-];
-
-const DEFAULT_DURATION_SUGGESTIONS: SuggestionSection[] = [
-  {
-    sectionText: '',
-    suggestions: DURATION_UNIT_SUGGESTIONS.map(unit => ({value: `10${unit}`})),
-  },
-];
-
-const DEFAULT_BOOLEAN_SUGGESTIONS: SuggestionSection[] = [
-  {
-    sectionText: '',
-    suggestions: [{value: 'true'}, {value: 'false'}],
-  },
-];
-
-function getDefaultAbsoluteDateValue(token: TokenResult<Token.FILTER>) {
-  if (token.value.type === Token.VALUE_ISO_8601_DATE) {
-    return token.value.text;
-  }
-
-  return '';
 }
 
 function getMultiSelectInputValue(token: TokenResult<Token.FILTER>) {
@@ -144,7 +90,7 @@ function prepareInputValueForSaving(
   const values = uniq(
     inputValue
       .split(',')
-      .map(v => cleanFilterValue(fieldDefinition, v.trim()))
+      .map(v => cleanFilterValue(fieldDefinition?.valueType, v.trim()))
       .filter(v => v && v.length > 0)
   );
 
@@ -176,160 +122,6 @@ function getValueAtCursorPosition(text: string, cursorPosition: number | null) {
   return '';
 }
 
-function getRelativeDateSign(token: TokenResult<Token.FILTER>) {
-  if (token.value.type === Token.VALUE_ISO_8601_DATE) {
-    switch (token.operator) {
-      case TermOperator.LESS_THAN:
-      case TermOperator.LESS_THAN_EQUAL:
-        return '+';
-      default:
-        return '-';
-    }
-  }
-
-  if (token.value.type === Token.VALUE_RELATIVE_DATE) {
-    return token.value.sign;
-  }
-
-  return '-';
-}
-
-function makeRelativeDateDescription(value: number, unit: string) {
-  switch (unit) {
-    case 's':
-      return tn('%s second ago', '%s seconds ago', value);
-    case 'm':
-      return tn('%s minute ago', '%s minutes ago', value);
-    case 'h':
-      return tn('%s hour ago', '%s hours ago', value);
-    case 'd':
-      return tn('%s day ago', '%s days ago', value);
-    case 'w':
-      return tn('%s week ago', '%s weeks ago', value);
-    default:
-      return '';
-  }
-}
-
-function makeDefaultDateSuggestions(
-  token: TokenResult<Token.FILTER>
-): SuggestionSection[] {
-  const sign = getRelativeDateSign(token);
-
-  return [
-    {
-      sectionText: '',
-      suggestions: [
-        {value: `${sign}1h`, label: makeRelativeDateDescription(1, 'h')},
-        {value: `${sign}24h`, label: makeRelativeDateDescription(24, 'h')},
-        {value: `${sign}7d`, label: makeRelativeDateDescription(7, 'd')},
-        {value: `${sign}14d`, label: makeRelativeDateDescription(14, 'd')},
-        {value: `${sign}30d`, label: makeRelativeDateDescription(30, 'd')},
-        {
-          value: 'absolute_date',
-          label: (
-            <AbsoluteDateOption>
-              {t('Absolute date')}
-              <IconArrow direction="right" size="xs" />
-            </AbsoluteDateOption>
-          ),
-        },
-      ],
-    },
-  ];
-}
-
-function getNumericSuggestions(inputValue: string): SuggestionSection[] {
-  if (!inputValue) {
-    return DEFAULT_NUMERIC_SUGGESTIONS;
-  }
-
-  if (isNumeric(inputValue)) {
-    return [
-      {
-        sectionText: '',
-        suggestions: NUMERIC_UNITS.map(unit => ({
-          value: `${inputValue}${unit}`,
-        })),
-      },
-    ];
-  }
-
-  // If the value is not numeric, don't show any suggestions
-  return [];
-}
-
-function getDurationSuggestions(
-  inputValue: string,
-  token: TokenResult<Token.FILTER>
-): SuggestionSection[] {
-  if (!inputValue) {
-    const currentValue =
-      token.value.type === Token.VALUE_DURATION ? token.value.value : null;
-
-    if (!currentValue) {
-      return DEFAULT_DURATION_SUGGESTIONS;
-    }
-
-    return [
-      {
-        sectionText: '',
-        suggestions: DURATION_UNIT_SUGGESTIONS.map(unit => ({
-          value: `${currentValue}${unit}`,
-        })),
-      },
-    ];
-  }
-
-  const parsed = parseFilterValueDuration(inputValue);
-
-  if (parsed) {
-    return [
-      {
-        sectionText: '',
-        suggestions: DURATION_UNIT_SUGGESTIONS.map(unit => ({
-          value: `${parsed.value}${unit}`,
-        })),
-      },
-    ];
-  }
-
-  // If the value doesn't contain any valid number or duration, don't show any suggestions
-  return [];
-}
-
-function getRelativeDateSuggestions(
-  inputValue: string,
-  token: TokenResult<Token.FILTER>
-): SuggestionSection[] {
-  const match = inputValue.match(RELATIVE_DATE_INPUT_REGEX);
-
-  if (!match) {
-    return makeDefaultDateSuggestions(token);
-  }
-
-  const [, value] = match;
-  const intValue = parseInt(value, 10);
-
-  if (isNaN(intValue)) {
-    return makeDefaultDateSuggestions(token);
-  }
-
-  const sign = token.value.type === Token.VALUE_RELATIVE_DATE ? token.value.sign : '-';
-
-  return [
-    {
-      sectionText: '',
-      suggestions: RELATIVE_DATE_UNITS.map(unit => {
-        return {
-          value: `${sign}${intValue}${unit}`,
-          label: makeRelativeDateDescription(intValue, unit),
-        };
-      }),
-    },
-  ];
-}
-
 function getSuggestionDescription(group: SearchGroup | SearchItem) {
   const description = group.desc ?? group.documentation;
 
@@ -356,21 +148,11 @@ function getPredefinedValues({
   }
 
   if (!key.values?.length) {
-    switch (fieldDefinition?.valueType) {
-      case FieldValueType.NUMBER:
-      case FieldValueType.INTEGER:
-        return getNumericSuggestions(filterValue);
-      case FieldValueType.DURATION:
-        return getDurationSuggestions(filterValue, token);
-      case FieldValueType.PERCENTAGE:
-        return [];
-      case FieldValueType.BOOLEAN:
-        return DEFAULT_BOOLEAN_SUGGESTIONS;
-      case FieldValueType.DATE:
-        return getRelativeDateSuggestions(filterValue, token);
-      default:
-        return null;
-    }
+    return getValueSuggestions({
+      filterValue,
+      token,
+      valueType: fieldDefinition?.valueType,
+    });
   }
 
   if (isStringFilterValues(key.values)) {
@@ -432,60 +214,6 @@ function tokenSupportsMultipleValues(
       return true;
     default:
       return false;
-  }
-}
-
-function cleanFilterValue(
-  fieldDefinition: FieldDefinition | null,
-  value: string
-): string | null {
-  if (!fieldDefinition) {
-    return escapeTagValue(value);
-  }
-
-  switch (fieldDefinition.valueType) {
-    case FieldValueType.NUMBER:
-      if (FILTER_VALUE_NUMERIC.test(value)) {
-        return value;
-      }
-      return null;
-    case FieldValueType.INTEGER:
-      if (FILTER_VALUE_INT.test(value)) {
-        return value;
-      }
-      return null;
-    case FieldValueType.DURATION: {
-      const parsed = parseFilterValueDuration(value);
-      if (!parsed) {
-        return null;
-      }
-      // Default to ms if no unit is provided
-      if (!parsed.unit) {
-        return `${parsed.value}ms`;
-      }
-      return value;
-    }
-    case FieldValueType.PERCENTAGE: {
-      const parsed = parseFilterValuePercentage(value);
-      if (!parsed) {
-        return null;
-      }
-      // If the user passes "50%", convert to 0.5
-      if (parsed.unit) {
-        const numericValue = parseFloat(parsed.value);
-        return isNaN(numericValue) ? parsed.value : (numericValue / 100).toString();
-      }
-      return parsed.value;
-    }
-    case FieldValueType.DATE:
-      const parsed = parseFilterValueDate(value);
-
-      if (!parsed) {
-        return null;
-      }
-      return value;
-    default:
-      return escapeTagValue(value).trim();
   }
 }
 
@@ -781,7 +509,7 @@ export function SearchQueryBuilderValueCombobox({
 
   const updateFilterValue = useCallback(
     (value: string) => {
-      const cleanedValue = cleanFilterValue(fieldDefinition, value);
+      const cleanedValue = cleanFilterValue(fieldDefinition?.valueType, value);
 
       // TODO(malwilley): Add visual feedback for invalid values
       if (cleanedValue === null) {
@@ -1051,14 +779,4 @@ const CheckWrap = styled('div')<{visible: boolean}>`
   align-items: center;
   opacity: ${p => (p.visible ? 1 : 0)};
   padding: ${space(0.25)} 0 ${space(0.25)} ${space(0.25)};
-`;
-
-const AbsoluteDateOption = styled('div')`
-  display: flex;
-  gap: ${space(1)};
-  align-items: center;
-
-  svg {
-    color: ${p => p.theme.gray300};
-  }
 `;

--- a/static/app/components/searchQueryBuilder/tokens/filter/valueSuggestions/boolean.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/valueSuggestions/boolean.tsx
@@ -1,0 +1,8 @@
+import type {SuggestionSection} from 'sentry/components/searchQueryBuilder/tokens/filter/valueSuggestions/types';
+
+export const DEFAULT_BOOLEAN_SUGGESTIONS: SuggestionSection[] = [
+  {
+    sectionText: '',
+    suggestions: [{value: 'true'}, {value: 'false'}],
+  },
+];

--- a/static/app/components/searchQueryBuilder/tokens/filter/valueSuggestions/date.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/valueSuggestions/date.tsx
@@ -1,0 +1,127 @@
+import styled from '@emotion/styled';
+
+import type {SuggestionSection} from 'sentry/components/searchQueryBuilder/tokens/filter/valueSuggestions/types';
+import {
+  TermOperator,
+  Token,
+  type TokenResult,
+} from 'sentry/components/searchSyntax/parser';
+import {IconArrow} from 'sentry/icons';
+import {t, tn} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
+
+const RELATIVE_DATE_INPUT_REGEX = /^(\d+)\s*([mhdw]?)/;
+const RELATIVE_DATE_UNITS = ['m', 'h', 'd', 'w'] as const;
+
+export function getDefaultAbsoluteDateValue(token: TokenResult<Token.FILTER>) {
+  if (token.value.type === Token.VALUE_ISO_8601_DATE) {
+    return token.value.text;
+  }
+
+  return '';
+}
+
+function getRelativeDateSign(token: TokenResult<Token.FILTER>) {
+  if (token.value.type === Token.VALUE_ISO_8601_DATE) {
+    switch (token.operator) {
+      case TermOperator.LESS_THAN:
+      case TermOperator.LESS_THAN_EQUAL:
+        return '+';
+      default:
+        return '-';
+    }
+  }
+
+  if (token.value.type === Token.VALUE_RELATIVE_DATE) {
+    return token.value.sign;
+  }
+
+  return '-';
+}
+
+function makeRelativeDateDescription(value: number, unit: string) {
+  switch (unit) {
+    case 's':
+      return tn('%s second ago', '%s seconds ago', value);
+    case 'm':
+      return tn('%s minute ago', '%s minutes ago', value);
+    case 'h':
+      return tn('%s hour ago', '%s hours ago', value);
+    case 'd':
+      return tn('%s day ago', '%s days ago', value);
+    case 'w':
+      return tn('%s week ago', '%s weeks ago', value);
+    default:
+      return '';
+  }
+}
+
+function makeDefaultDateSuggestions(
+  token: TokenResult<Token.FILTER>
+): SuggestionSection[] {
+  const sign = getRelativeDateSign(token);
+
+  return [
+    {
+      sectionText: '',
+      suggestions: [
+        {value: `${sign}1h`, label: makeRelativeDateDescription(1, 'h')},
+        {value: `${sign}24h`, label: makeRelativeDateDescription(24, 'h')},
+        {value: `${sign}7d`, label: makeRelativeDateDescription(7, 'd')},
+        {value: `${sign}14d`, label: makeRelativeDateDescription(14, 'd')},
+        {value: `${sign}30d`, label: makeRelativeDateDescription(30, 'd')},
+        {
+          value: 'absolute_date',
+          label: (
+            <AbsoluteDateOption>
+              {t('Absolute date')}
+              <IconArrow direction="right" size="xs" />
+            </AbsoluteDateOption>
+          ),
+        },
+      ],
+    },
+  ];
+}
+
+export function getRelativeDateSuggestions(
+  inputValue: string,
+  token: TokenResult<Token.FILTER>
+): SuggestionSection[] {
+  const match = inputValue.match(RELATIVE_DATE_INPUT_REGEX);
+
+  if (!match) {
+    return makeDefaultDateSuggestions(token);
+  }
+
+  const [, value] = match;
+  const intValue = parseInt(value, 10);
+
+  if (isNaN(intValue)) {
+    return makeDefaultDateSuggestions(token);
+  }
+
+  const sign = token.value.type === Token.VALUE_RELATIVE_DATE ? token.value.sign : '-';
+
+  return [
+    {
+      sectionText: '',
+      suggestions: RELATIVE_DATE_UNITS.map(unit => {
+        return {
+          value: `${sign}${intValue}${unit}`,
+          label: makeRelativeDateDescription(intValue, unit),
+        };
+      }),
+    },
+  ];
+}
+
+const AbsoluteDateOption = styled('div')`
+  display: flex;
+  gap: ${space(1)};
+  align-items: center;
+
+  svg {
+    color: ${p => p.theme.gray300};
+  }
+`;

--- a/static/app/components/searchQueryBuilder/tokens/filter/valueSuggestions/duration.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/valueSuggestions/duration.tsx
@@ -1,0 +1,51 @@
+import {parseFilterValueDuration} from 'sentry/components/searchQueryBuilder/tokens/filter/parsers/duration/parser';
+import type {SuggestionSection} from 'sentry/components/searchQueryBuilder/tokens/filter/valueSuggestions/types';
+import {Token, type TokenResult} from 'sentry/components/searchSyntax/parser';
+
+const DURATION_UNIT_SUGGESTIONS = ['ms', 's', 'm', 'h'] as const;
+
+const DEFAULT_DURATION_SUGGESTIONS: SuggestionSection[] = [
+  {
+    sectionText: '',
+    suggestions: DURATION_UNIT_SUGGESTIONS.map(unit => ({value: `10${unit}`})),
+  },
+];
+
+export function getDurationSuggestions(
+  inputValue: string,
+  token: TokenResult<Token.FILTER>
+): SuggestionSection[] {
+  if (!inputValue) {
+    const currentValue =
+      token.value.type === Token.VALUE_DURATION ? token.value.value : null;
+
+    if (!currentValue) {
+      return DEFAULT_DURATION_SUGGESTIONS;
+    }
+
+    return [
+      {
+        sectionText: '',
+        suggestions: DURATION_UNIT_SUGGESTIONS.map(unit => ({
+          value: `${currentValue}${unit}`,
+        })),
+      },
+    ];
+  }
+
+  const parsed = parseFilterValueDuration(inputValue);
+
+  if (parsed) {
+    return [
+      {
+        sectionText: '',
+        suggestions: DURATION_UNIT_SUGGESTIONS.map(unit => ({
+          value: `${parsed.value}${unit}`,
+        })),
+      },
+    ];
+  }
+
+  // If the value doesn't contain any valid number or duration, don't show any suggestions
+  return [];
+}

--- a/static/app/components/searchQueryBuilder/tokens/filter/valueSuggestions/numeric.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/valueSuggestions/numeric.tsx
@@ -1,0 +1,34 @@
+import type {SuggestionSection} from 'sentry/components/searchQueryBuilder/tokens/filter/valueSuggestions/types';
+
+const NUMERIC_REGEX = /^-?\d+(\.\d+)?$/;
+const NUMERIC_UNITS = ['k', 'm', 'b'] as const;
+const DEFAULT_NUMERIC_SUGGESTIONS: SuggestionSection[] = [
+  {
+    sectionText: '',
+    suggestions: [{value: '100'}, {value: '100k'}, {value: '100m'}, {value: '100b'}],
+  },
+];
+
+function isNumeric(value: string) {
+  return NUMERIC_REGEX.test(value);
+}
+
+export function getNumericSuggestions(inputValue: string): SuggestionSection[] {
+  if (!inputValue) {
+    return DEFAULT_NUMERIC_SUGGESTIONS;
+  }
+
+  if (isNumeric(inputValue)) {
+    return [
+      {
+        sectionText: '',
+        suggestions: NUMERIC_UNITS.map(unit => ({
+          value: `${inputValue}${unit}`,
+        })),
+      },
+    ];
+  }
+
+  // If the value is not numeric, don't show any suggestions
+  return [];
+}

--- a/static/app/components/searchQueryBuilder/tokens/filter/valueSuggestions/types.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/valueSuggestions/types.tsx
@@ -1,0 +1,19 @@
+import type {ReactNode} from 'react';
+
+import type {SelectOptionWithKey} from 'sentry/components/compactSelect/types';
+
+export type SuggestionItem = {
+  value: string;
+  description?: ReactNode;
+  label?: ReactNode;
+};
+
+export type SuggestionSection = {
+  sectionText: string;
+  suggestions: SuggestionItem[];
+};
+
+export type SuggestionSectionItem = {
+  items: SelectOptionWithKey<string>[];
+  sectionText: string;
+};

--- a/static/app/components/searchQueryBuilder/tokens/filter/valueSuggestions/utils.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/valueSuggestions/utils.tsx
@@ -1,0 +1,98 @@
+import {parseFilterValueDate} from 'sentry/components/searchQueryBuilder/tokens/filter/parsers/date/parser';
+import {parseFilterValueDuration} from 'sentry/components/searchQueryBuilder/tokens/filter/parsers/duration/parser';
+import {parseFilterValuePercentage} from 'sentry/components/searchQueryBuilder/tokens/filter/parsers/percentage/parser';
+import {escapeTagValue} from 'sentry/components/searchQueryBuilder/tokens/filter/utils';
+import {DEFAULT_BOOLEAN_SUGGESTIONS} from 'sentry/components/searchQueryBuilder/tokens/filter/valueSuggestions/boolean';
+import {getRelativeDateSuggestions} from 'sentry/components/searchQueryBuilder/tokens/filter/valueSuggestions/date';
+import {getDurationSuggestions} from 'sentry/components/searchQueryBuilder/tokens/filter/valueSuggestions/duration';
+import {getNumericSuggestions} from 'sentry/components/searchQueryBuilder/tokens/filter/valueSuggestions/numeric';
+import type {SuggestionSection} from 'sentry/components/searchQueryBuilder/tokens/filter/valueSuggestions/types';
+import type {Token, TokenResult} from 'sentry/components/searchSyntax/parser';
+import {FieldValueType} from 'sentry/utils/fields';
+
+const FILTER_VALUE_NUMERIC = /^-?\d+(\.\d+)?[kmb]?$/i;
+const FILTER_VALUE_INT = /^-?\d+[kmb]?$/i;
+
+export function getValueSuggestions({
+  filterValue,
+  token,
+  valueType,
+}: {
+  filterValue: string;
+  token: TokenResult<Token.FILTER>;
+  valueType: FieldValueType | null | undefined;
+}): SuggestionSection[] | null {
+  switch (valueType) {
+    case FieldValueType.NUMBER:
+    case FieldValueType.INTEGER:
+      return getNumericSuggestions(filterValue);
+    case FieldValueType.DURATION:
+      return getDurationSuggestions(filterValue, token);
+    case FieldValueType.PERCENTAGE:
+      return [];
+    case FieldValueType.BOOLEAN:
+      return DEFAULT_BOOLEAN_SUGGESTIONS;
+    case FieldValueType.DATE:
+      return getRelativeDateSuggestions(filterValue, token);
+    default:
+      return null;
+  }
+}
+
+/**
+ * Given a value and a valueType, validates and cleans the value.
+ * If the value is invalid and cannot be recovered, it will return null.
+ */
+export function cleanFilterValue(
+  valueType: FieldValueType | null | undefined,
+  value: string
+): string | null {
+  if (!valueType) {
+    return escapeTagValue(value);
+  }
+
+  switch (valueType) {
+    case FieldValueType.NUMBER:
+      if (FILTER_VALUE_NUMERIC.test(value)) {
+        return value;
+      }
+      return null;
+    case FieldValueType.INTEGER:
+      if (FILTER_VALUE_INT.test(value)) {
+        return value;
+      }
+      return null;
+    case FieldValueType.DURATION: {
+      const parsed = parseFilterValueDuration(value);
+      if (!parsed) {
+        return null;
+      }
+      // Default to ms if no unit is provided
+      if (!parsed.unit) {
+        return `${parsed.value}ms`;
+      }
+      return value;
+    }
+    case FieldValueType.PERCENTAGE: {
+      const parsed = parseFilterValuePercentage(value);
+      if (!parsed) {
+        return null;
+      }
+      // If the user passes "50%", convert to 0.5
+      if (parsed.unit) {
+        const numericValue = parseFloat(parsed.value);
+        return isNaN(numericValue) ? parsed.value : (numericValue / 100).toString();
+      }
+      return parsed.value;
+    }
+    case FieldValueType.DATE:
+      const parsed = parseFilterValueDate(value);
+
+      if (!parsed) {
+        return null;
+      }
+      return value;
+    default:
+      return escapeTagValue(value).trim();
+  }
+}


### PR DESCRIPTION
`valueCombobox` contained a lot of logic to generate filter value suggestions and validate input. This will need to be shared with the aggregate filter component, so I'm extracting them to individual files. It also just makes that file a lot easier to deal with.

There should be no behavior changes, just moving functions into new files and slightly modifying them to accept more generic arguments.