### PR TITLE
nit(scopes): Remove nonexistent alert scopes

### DIFF
--- a/src/sentry/api/bases/organization.py
+++ b/src/sentry/api/bases/organization.py
@@ -203,10 +203,10 @@ class OrganizationDataExportPermission(OrganizationPermission):
 
 class OrganizationAlertRulePermission(OrganizationPermission):
     scope_map = {
-        "GET": ["org:read", "org:write", "org:admin", "alert_rule:read", "alerts:read"],
-        "POST": ["org:write", "org:admin", "alert_rule:write", "alerts:write"],
-        "PUT": ["org:write", "org:admin", "alert_rule:write", "alerts:write"],
-        "DELETE": ["org:write", "org:admin", "alert_rule:write", "alerts:write"],
+        "GET": ["org:read", "org:write", "org:admin", "alerts:read"],
+        "POST": ["org:write", "org:admin", "alerts:write"],
+        "PUT": ["org:write", "org:admin", "alerts:write"],
+        "DELETE": ["org:write", "org:admin", "alerts:write"],
     }
 
 


### PR DESCRIPTION
`alert_rule:read/write` were originally added in https://github.com/getsentry/sentry/pull/22800, but don't exist anywhere else in sentry or getsentry.

They are replaced be `alerts:read/write`