### PR TITLE
ref(alerts): Remove metric alert load shedding flag

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -182,8 +182,6 @@ def register_temporary_features(manager: FeatureManager):
     manager.add("organizations:messaging-integration-onboarding", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable metric alert charts in email/slack
     manager.add("organizations:metric-alert-chartcuterie", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, api_expose=True)
-    # Enable load shedding for newly created metric alerts
-    manager.add("organizations:metric-alert-load-shedding", OrganizationFeature, FeatureHandlerStrategy.OPTIONS, api_expose=False)
     # Enable threshold period in metric alert rule builder
     manager.add("organizations:metric-alert-threshold-period", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enables the search bar for metrics samples list

--- a/src/sentry/incidents/logic.py
+++ b/src/sentry/incidents/logic.py
@@ -491,18 +491,13 @@ query_datasets_to_type = {
 
 
 def get_alert_resolution(time_window: int, organization) -> int:
-    resolution = DEFAULT_ALERT_RULE_RESOLUTION
+    windows = sorted(DEFAULT_ALERT_RULE_WINDOW_TO_RESOLUTION.keys())
+    index = bisect.bisect_right(windows, time_window)
 
-    if features.has("organizations:metric-alert-load-shedding", organization=organization):
-        windows = sorted(DEFAULT_ALERT_RULE_WINDOW_TO_RESOLUTION.keys())
-        index = bisect.bisect_right(windows, time_window)
+    if index == 0:
+        return DEFAULT_ALERT_RULE_RESOLUTION
 
-        if index == 0:
-            return DEFAULT_ALERT_RULE_RESOLUTION
-
-        resolution = DEFAULT_ALERT_RULE_WINDOW_TO_RESOLUTION[windows[index - 1]]
-
-    return resolution
+    return DEFAULT_ALERT_RULE_WINDOW_TO_RESOLUTION[windows[index - 1]]
 
 
 def create_alert_rule(

--- a/tests/sentry/incidents/test_logic.py
+++ b/tests/sentry/incidents/test_logic.py
@@ -3157,12 +3157,7 @@ class TestCustomMetricAlertRule(TestCase):
 
 
 class TestGetAlertResolution(TestCase):
-    def test_without_feature(self):
-        time_window = 30
-        result = get_alert_resolution(time_window, self.organization)
-        assert result == DEFAULT_ALERT_RULE_RESOLUTION
-
-    def test_enabled_feature(self):
+    def test_simple(self):
         time_window = 30
         result = get_alert_resolution(time_window, self.organization)
         assert result == DEFAULT_ALERT_RULE_WINDOW_TO_RESOLUTION[time_window]

--- a/tests/sentry/incidents/test_logic.py
+++ b/tests/sentry/incidents/test_logic.py
@@ -764,25 +764,6 @@ class CreateAlertRuleTest(TestCase, BaseIncidentsTest):
 
         mocked_schedule_update_project_config.assert_called_once_with(alert_rule, [self.project])
 
-    def test_create_alert_default_resolution(self):
-        time_window = 1440
-
-        alert_rule = create_alert_rule(
-            self.organization,
-            [self.project],
-            "custom metric alert",
-            "transaction.duration:>=1000",
-            "count()",
-            time_window,
-            AlertRuleThresholdType.ABOVE,
-            1,
-            query_type=SnubaQuery.Type.PERFORMANCE,
-            dataset=Dataset.Metrics,
-        )
-
-        assert alert_rule.snuba_query.resolution == DEFAULT_ALERT_RULE_RESOLUTION * 60
-
-    @with_feature("organizations:metric-alert-load-shedding")
     def test_create_alert_resolution_load_shedding(self):
         time_window = 1440
 
@@ -804,7 +785,6 @@ class CreateAlertRuleTest(TestCase, BaseIncidentsTest):
             == DEFAULT_ALERT_RULE_WINDOW_TO_RESOLUTION[time_window] * 60
         )
 
-    @with_feature("organizations:metric-alert-load-shedding")
     def test_create_alert_load_shedding_comparison(self):
         time_window = 1440
 
@@ -1279,7 +1259,6 @@ class UpdateAlertRuleTest(TestCase, BaseIncidentsTest):
 
         mocked_schedule_update_project_config.assert_called_with(alert_rule, None)
 
-    @with_feature("organizations:metric-alert-load-shedding")
     def test_update_alert_load_shedding_on_window(self):
         time_window = 1440
         alert_rule = create_alert_rule(
@@ -1307,7 +1286,6 @@ class UpdateAlertRuleTest(TestCase, BaseIncidentsTest):
             == DEFAULT_ALERT_RULE_WINDOW_TO_RESOLUTION[time_window] * 60
         )
 
-    @with_feature("organizations:metric-alert-load-shedding")
     def test_update_alert_load_shedding_on_window_with_comparison(self):
         time_window = 1440
         comparison_delta = 60
@@ -1343,7 +1321,6 @@ class UpdateAlertRuleTest(TestCase, BaseIncidentsTest):
             * 60
         )
 
-    @with_feature("organizations:metric-alert-load-shedding")
     def test_update_alert_load_shedding_on_comparison(self):
         time_window = 1440
         comparison_delta = 60
@@ -1371,7 +1348,6 @@ class UpdateAlertRuleTest(TestCase, BaseIncidentsTest):
             * 60
         )
 
-    @with_feature("organizations:metric-alert-load-shedding")
     def test_update_alert_load_shedding_on_comparison_and_window(self):
         time_window = 1440
         comparison_delta = 60
@@ -3186,19 +3162,16 @@ class TestGetAlertResolution(TestCase):
         result = get_alert_resolution(time_window, self.organization)
         assert result == DEFAULT_ALERT_RULE_RESOLUTION
 
-    @with_feature("organizations:metric-alert-load-shedding")
     def test_enabled_feature(self):
         time_window = 30
         result = get_alert_resolution(time_window, self.organization)
         assert result == DEFAULT_ALERT_RULE_WINDOW_TO_RESOLUTION[time_window]
 
-    @with_feature("organizations:metric-alert-load-shedding")
     def test_low_range(self):
         time_window = 2
         result = get_alert_resolution(time_window, self.organization)
         assert result == DEFAULT_ALERT_RULE_RESOLUTION
 
-    @with_feature("organizations:metric-alert-load-shedding")
     def test_high_range(self):
         last_window = list(DEFAULT_ALERT_RULE_WINDOW_TO_RESOLUTION.keys())[-1]
         time_window = last_window + 1000
@@ -3206,7 +3179,6 @@ class TestGetAlertResolution(TestCase):
 
         assert result == DEFAULT_ALERT_RULE_WINDOW_TO_RESOLUTION[last_window]
 
-    @with_feature("organizations:metric-alert-load-shedding")
     def test_mid_range(self):
         time_window = 125
         result = get_alert_resolution(time_window, self.organization)
@@ -3214,7 +3186,6 @@ class TestGetAlertResolution(TestCase):
         # 125 is not part of the dict, will round down to the lower window of 120
         assert result == 3
 
-    @with_feature("organizations:metric-alert-load-shedding")
     def test_crazy_low_range(self):
         time_window = -5
         result = get_alert_resolution(time_window, self.organization)

--- a/tests/sentry/incidents/test_logic.py
+++ b/tests/sentry/incidents/test_logic.py
@@ -841,7 +841,7 @@ class CreateAlertRuleTest(TestCase, BaseIncidentsTest):
             alert_rule.snuba_query.time_window
             == self.dynamic_metric_alert_settings["time_window"] * 60
         )
-        assert alert_rule.snuba_query.resolution == DEFAULT_ALERT_RULE_RESOLUTION * 60
+        assert alert_rule.snuba_query.resolution == 120
         assert set(alert_rule.snuba_query.event_types) == set(
             self.dynamic_metric_alert_settings["event_types"]
         )


### PR DESCRIPTION
This has been GA'd for some time now and we don't need the flag anymore. Removing from options automator in https://github.com/getsentry/sentry-options-automator/pull/2051