### PR TITLE
feat(dashboards): Open in discover button for dashboard widgets

### DIFF
--- a/static/app/components/modals/widgetViewerModal.spec.tsx
+++ b/static/app/components/modals/widgetViewerModal.spec.tsx
@@ -210,6 +210,25 @@ describe('Modals -> WidgetViewerModal', function () {
         await renderModal({initialData, widget: mockWidget});
         expect(await screen.findByText('Edit Widget')).toBeInTheDocument();
         expect(screen.getByText('Open in Discover')).toBeInTheDocument();
+        expect(screen.getByRole('button', {name: 'Open in Discover'})).toBeEnabled();
+      });
+
+      it('renders Open button disabled for discover widget if dataset selector flag enabled', async function () {
+        const initData = {
+          ...initialData,
+          organization: {
+            ...initialData.organization,
+            features: [
+              ...initialData.organization.features,
+              'performance-discover-dataset-selector',
+            ],
+          },
+        };
+        mockEvents();
+        await renderModal({initialData: initData, widget: mockWidget});
+        expect(await screen.findByText('Edit Widget')).toBeInTheDocument();
+        expect(screen.getByText('Open in Discover')).toBeInTheDocument();
+        expect(screen.getByRole('button', {name: 'Open in Discover'})).toBeDisabled();
       });
 
       it('renders updated table columns and orderby', async function () {

--- a/static/app/components/modals/widgetViewerModal.tsx
+++ b/static/app/components/modals/widgetViewerModal.tsx
@@ -66,6 +66,7 @@ import {
   getWidgetIssueUrl,
   getWidgetMetricsUrl,
   getWidgetReleasesUrl,
+  hasDatasetSelector,
 } from 'sentry/views/dashboards/utils';
 import {
   SESSION_DURATION_ALERT,
@@ -74,7 +75,6 @@ import {
 import type {AugmentedEChartDataZoomHandler} from 'sentry/views/dashboards/widgetCard/chart';
 import WidgetCardChart, {SLIDER_HEIGHT} from 'sentry/views/dashboards/widgetCard/chart';
 import {
-  DashboardsMEPConsumer,
   DashboardsMEPProvider,
   useDashboardsMEPContext,
 } from 'sentry/views/dashboards/widgetCard/dashboardsMEPContext';
@@ -1022,29 +1022,6 @@ function WidgetViewerModal(props: Props) {
                           <WidgetDescription>{widget.description}</WidgetDescription>
                         </Tooltip>
                       )}
-                      <DashboardsMEPConsumer>
-                        {({}) => {
-                          // TODO(Tele-Team): Re-enable this when we have a better way to determine if the data is transaction only
-                          // if (
-                          //   widgetContentLoadingStatus === false &&
-                          //   widget.widgetType === WidgetType.DISCOVER &&
-                          //   isMetricsData === false
-                          // ) {
-                          //   return (
-                          //     <Tooltip
-                          //       containerDisplayMode="inline-flex"
-                          //       title={t(
-                          //         'Based on your search criteria, the sampled events available may be limited and may not be representative of all events.'
-                          //       )}
-                          //     >
-                          //       <IconWarning color="warningText" size="md" />
-                          //     </Tooltip>
-                          //   );
-                          // }
-
-                          return null;
-                        }}
-                      </DashboardsMEPConsumer>
                     </WidgetHeader>
                   </Header>
                   <Body>{renderWidgetViewer()}</Body>
@@ -1131,20 +1108,30 @@ function OpenButton({
       break;
   }
 
+  const optionDisabled =
+    hasDatasetSelector(organization) && widget.widgetType === WidgetType.DISCOVER;
+
   return (
-    <Button
-      to={path}
-      priority="primary"
-      onClick={() => {
-        trackAnalytics('dashboards_views.widget_viewer.open_source', {
-          organization,
-          widget_type: widget.widgetType ?? WidgetType.DISCOVER,
-          display_type: widget.displayType,
-        });
-      }}
+    <Tooltip
+      title={t(
+        'We are splitting datasets to make them easier to digest. Please confirm the dataset for this widget by clicking Edit Widget.'
+      )}
     >
-      {openLabel}
-    </Button>
+      <Button
+        to={path}
+        priority="primary"
+        disabled={optionDisabled}
+        onClick={() => {
+          trackAnalytics('dashboards_views.widget_viewer.open_source', {
+            organization,
+            widget_type: widget.widgetType ?? WidgetType.DISCOVER,
+            display_type: widget.displayType,
+          });
+        }}
+      >
+        {openLabel}
+      </Button>
+    </Tooltip>
   );
 }
 

--- a/static/app/components/modals/widgetViewerModal.tsx
+++ b/static/app/components/modals/widgetViewerModal.tsx
@@ -1108,7 +1108,7 @@ function OpenButton({
       break;
   }
 
-  const optionDisabled =
+  const buttonDisabled =
     hasDatasetSelector(organization) && widget.widgetType === WidgetType.DISCOVER;
 
   return (
@@ -1116,11 +1116,12 @@ function OpenButton({
       title={t(
         'We are splitting datasets to make them easier to digest. Please confirm the dataset for this widget by clicking Edit Widget.'
       )}
+      disabled={!buttonDisabled}
     >
       <Button
         to={path}
         priority="primary"
-        disabled={optionDisabled}
+        disabled={buttonDisabled}
         onClick={() => {
           trackAnalytics('dashboards_views.widget_viewer.open_source', {
             organization,

--- a/static/app/utils/discover/fields.tsx
+++ b/static/app/utils/discover/fields.tsx
@@ -749,6 +749,7 @@ export const ERROR_ONLY_FIELDS: (FieldKey | SpanOpBreakdown)[] = [
   FieldKey.STACK_COLNO,
   FieldKey.STACK_LINENO,
   FieldKey.STACK_STACK_LEVEL,
+  FieldKey.EVENT_TYPE,
 ];
 
 export const TRANSACTION_FIELDS = DISCOVER_FIELDS.filter(
@@ -761,7 +762,6 @@ export const ERRORS_AGGREGATION_FUNCTIONS = [
   AggregationKey.COUNT_UNIQUE,
   AggregationKey.EPS,
   AggregationKey.EPM,
-  AggregationKey.LAST_SEEN,
 ];
 
 // This list contains fields/functions that are available with profiling feature.

--- a/static/app/views/discover/results.tsx
+++ b/static/app/views/discover/results.tsx
@@ -129,16 +129,22 @@ function getYAxis(location: Location, eventView: EventView, savedQuery?: SavedQu
 
 export class Results extends Component<Props, State> {
   static getDerivedStateFromProps(nextProps: Readonly<Props>, prevState: State): State {
-    const eventView = EventView.fromSavedQueryOrLocation(
-      nextProps.savedQuery,
-      nextProps.location
-    );
     const savedQueryDataset = getSavedQueryDataset(
       nextProps.organization,
       nextProps.location,
       nextProps.savedQuery,
       undefined
     );
+    const eventViewFromQuery = EventView.fromSavedQueryOrLocation(
+      nextProps.savedQuery,
+      nextProps.location
+    );
+    const eventView =
+      hasDatasetSelector(nextProps.organization) && !eventViewFromQuery.dataset
+        ? eventViewFromQuery.withDataset(
+            getDatasetFromLocationOrSavedQueryDataset(undefined, savedQueryDataset)
+          )
+        : eventViewFromQuery;
     return {...prevState, eventView, savedQuery: nextProps.savedQuery, savedQueryDataset};
   }
 


### PR DESCRIPTION
Open in discover is disabled if dataset-selector flag is enabled
and widget is discover type. This should be a fairly short-lived state
since we plan to migrate all existing discover widgets to either errors or
transactions once this feature is GA'ed