### PR TITLE
feat(uptime): Implement subscription checker

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1153,6 +1153,11 @@ CELERYBEAT_SCHEDULE_REGION = {
         "schedule": crontab(minute="*/20"),
         "options": {"expires": 20 * 60},
     },
+    "uptime-subscription-checker": {
+        "task": "sentry.uptime.tasks.subscription_checker",
+        "schedule": crontab(minute="*/10"),
+        "options": {"expires": 10 * 60},
+    },
     "transaction-name-clusterer": {
         "task": "sentry.ingest.transaction_clusterer.tasks.spawn_clusterers",
         # Run every 1 hour at minute 17

--- a/src/sentry/db/models/base.py
+++ b/src/sentry/db/models/base.py
@@ -332,6 +332,8 @@ class DefaultFieldsModel(Model):
 def __model_pre_save(instance: models.Model, **kwargs: Any) -> None:
     if not isinstance(instance, DefaultFieldsModel):
         return
+    if instance.pk is not None:
+        instance.date_updated = timezone.now()
 
 
 def __model_post_save(instance: models.Model, **kwargs: Any) -> None:

--- a/src/sentry/db/models/base.py
+++ b/src/sentry/db/models/base.py
@@ -332,6 +332,7 @@ class DefaultFieldsModel(Model):
 def __model_pre_save(instance: models.Model, **kwargs: Any) -> None:
     if not isinstance(instance, DefaultFieldsModel):
         return
+    # Only update this field when we're updating the row, not on create.
     if instance.pk is not None:
         instance.date_updated = timezone.now()
 

--- a/src/sentry/db/models/base.py
+++ b/src/sentry/db/models/base.py
@@ -332,8 +332,6 @@ class DefaultFieldsModel(Model):
 def __model_pre_save(instance: models.Model, **kwargs: Any) -> None:
     if not isinstance(instance, DefaultFieldsModel):
         return
-    if instance.date_updated is None:
-        instance.date_updated = timezone.now()
 
 
 def __model_post_save(instance: models.Model, **kwargs: Any) -> None:

--- a/src/sentry/db/models/base.py
+++ b/src/sentry/db/models/base.py
@@ -332,7 +332,8 @@ class DefaultFieldsModel(Model):
 def __model_pre_save(instance: models.Model, **kwargs: Any) -> None:
     if not isinstance(instance, DefaultFieldsModel):
         return
-    instance.date_updated = timezone.now()
+    if instance.date_updated is None:
+        instance.date_updated = timezone.now()
 
 
 def __model_post_save(instance: models.Model, **kwargs: Any) -> None:

--- a/src/sentry/testutils/factories.py
+++ b/src/sentry/testutils/factories.py
@@ -1944,6 +1944,7 @@ class Factories:
         url: str,
         interval_seconds: int,
         timeout_ms: int,
+        date_updated: datetime,
     ):
         return UptimeSubscription.objects.create(
             type=type,
@@ -1952,6 +1953,7 @@ class Factories:
             url=url,
             interval_seconds=interval_seconds,
             timeout_ms=timeout_ms,
+            date_updated=date_updated,
         )
 
     @staticmethod

--- a/src/sentry/testutils/fixtures.py
+++ b/src/sentry/testutils/fixtures.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from datetime import timedelta
+from datetime import datetime, timedelta
 from typing import Any
 
 import pytest
@@ -644,7 +644,10 @@ class Fixtures:
         url="http://sentry.io/",
         interval_seconds=60,
         timeout_ms=100,
+        date_updated: None | datetime = None,
     ) -> UptimeSubscription:
+        if date_updated is None:
+            date_updated = datetime.utcnow()
         return Factories.create_uptime_subscription(
             type=type,
             subscription_id=subscription_id,
@@ -652,6 +655,7 @@ class Fixtures:
             url=url,
             interval_seconds=interval_seconds,
             timeout_ms=timeout_ms,
+            date_updated=date_updated,
         )
 
     def create_project_uptime_subscription(

--- a/src/sentry/testutils/fixtures.py
+++ b/src/sentry/testutils/fixtures.py
@@ -647,7 +647,7 @@ class Fixtures:
         date_updated: None | datetime = None,
     ) -> UptimeSubscription:
         if date_updated is None:
-            date_updated = datetime.utcnow()
+            date_updated = timezone.now()
         return Factories.create_uptime_subscription(
             type=type,
             subscription_id=subscription_id,

--- a/src/sentry/uptime/subscriptions/tasks.py
+++ b/src/sentry/uptime/subscriptions/tasks.py
@@ -101,7 +101,9 @@ def send_uptime_config_deletion(subscription_id: str) -> None:
 )
 def subscription_checker(**kwargs):
     """
-    Checks for subscriptions stuck in a transition status and attempts to repair them
+    Checks for subscriptions stuck in a transition status and attempts to repair them. This
+    typically happens when we had some kind of error running the task the first time around.
+    Usually network or configuration related.
     """
     count = 0
     for subscription in UptimeSubscription.objects.filter(

--- a/src/sentry/uptime/subscriptions/tasks.py
+++ b/src/sentry/uptime/subscriptions/tasks.py
@@ -4,6 +4,7 @@ import logging
 from datetime import timedelta
 from uuid import uuid4
 
+from django.utils import timezone
 from sentry_kafka_schemas.schema_types.uptime_configs_v1 import CheckConfig
 
 from sentry.snuba.models import QuerySubscription
@@ -92,3 +93,28 @@ def uptime_subscription_to_check_config(
 
 def send_uptime_config_deletion(subscription_id: str) -> None:
     produce_config_removal(subscription_id)
+
+
+@instrumented_task(
+    name="sentry.uptime.tasks.subscription_checker",
+    queue="uptime",
+)
+def subscription_checker(**kwargs):
+    """
+    Checks for subscriptions stuck in a transition status and attempts to repair them
+    """
+    count = 0
+    for subscription in UptimeSubscription.objects.filter(
+        status__in=(
+            UptimeSubscription.Status.CREATING.value,
+            UptimeSubscription.Status.DELETING.value,
+        ),
+        date_updated__lt=timezone.now() - SUBSCRIPTION_STATUS_MAX_AGE,
+    ):
+        count += 1
+        if subscription.status == UptimeSubscription.Status.CREATING.value:
+            create_remote_uptime_subscription.delay(uptime_subscription_id=subscription.id)
+        elif subscription.status == UptimeSubscription.Status.DELETING.value:
+            delete_remote_uptime_subscription.delay(uptime_subscription_id=subscription.id)
+
+    metrics.incr("uptime.subscriptions.repair", amount=count)


### PR DESCRIPTION
This implements the subscription checker task. This task checks for any uptime subscriptions that have been sitting in a transitory state for too long and reschedules them.

<!-- Describe your PR here. -->