### PR TITLE
fix(query-builder): Fix selecting absolute dates

### DIFF
--- a/static/app/components/searchQueryBuilder/tokens/combobox.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/combobox.tsx
@@ -538,7 +538,6 @@ function SearchQueryBuilderComboboxInner<T extends SelectOptionOrSectionWithKey<
     // We handle closing on blur ourselves to prevent the combobox from closing
     // when the user clicks inside the tabbed menu
     shouldCloseOnBlur: false,
-    selectedKey: null,
     ...comboBoxProps,
   });
 


### PR DESCRIPTION
Adding this `selectedKey: null` in a previous PR caused a regression for selecting absolute dates. I'm not sure why, but it caused the react-aria `useListState` to go into an infinite loop which caused the page to hang. Removing it for now and will try to figure out a way to prevent this from happening later.