### PR TITLE
ref(am1): Collect span counts for orgs prior to migrating

### DIFF
--- a/src/sentry/ingest/consumer/processors.py
+++ b/src/sentry/ingest/consumer/processors.py
@@ -187,7 +187,11 @@ def process_event(
                 event_id=event_id,
                 project_id=project_id,
             )
-            collect_span_metrics(project, data)
+
+            try:
+                collect_span_metrics(project, data)
+            except Exception:
+                pass
 
         elif data.get("type") == "feedback":
             if features.has("organizations:user-feedback-ingest", project.organization, actor=None):

--- a/src/sentry/ingest/consumer/processors.py
+++ b/src/sentry/ingest/consumer/processors.py
@@ -1,7 +1,7 @@
 import functools
 import logging
-from collections.abc import Mapping
-from typing import Any, MutableMapping
+from collections.abc import Mapping, MutableMapping
+from typing import Any
 
 import orjson
 import sentry_sdk

--- a/src/sentry/ingest/consumer/processors.py
+++ b/src/sentry/ingest/consumer/processors.py
@@ -1,7 +1,7 @@
 import functools
 import logging
 from collections.abc import Mapping
-from typing import Any
+from typing import Any, MutableMapping
 
 import orjson
 import sentry_sdk
@@ -187,6 +187,8 @@ def process_event(
                 event_id=event_id,
                 project_id=project_id,
             )
+            collect_span_metrics(project, data)
+
         elif data.get("type") == "feedback":
             if features.has("organizations:user-feedback-ingest", project.organization, actor=None):
                 save_event_feedback.delay(
@@ -324,3 +326,16 @@ def process_userreport(message: IngestMessage, project: Project) -> bool:
         # If you want to remove this make sure to have triaged all errors in Sentry
         logger.exception("userreport.save.crash")
         return False
+
+
+def collect_span_metrics(
+    project: Project,
+    data: MutableMapping[str, Any],
+):
+    if not features.has("organizations:dynamic-sampling", project.organization):
+        amount = len(data.get("spans", []))
+        metrics.incr(
+            "event.save_event.unsampled.spans.count",
+            amount=amount,
+            tags={"organization": project.organization.slug},
+        )

--- a/src/sentry/ingest/consumer/processors.py
+++ b/src/sentry/ingest/consumer/processors.py
@@ -332,8 +332,12 @@ def collect_span_metrics(
     project: Project,
     data: MutableMapping[str, Any],
 ):
-    if not features.has("organizations:dynamic-sampling", project.organization):
-        amount = len(data.get("spans", []))
+    if not features.has(
+        "organizations:dynamic-sampling", project.organization
+    ) and not features.has("organizations:am3_tier", project.organization):
+        amount = (
+            len(data.get("spans", [])) + 1
+        )  # Segment spans also get added to the total span count.
         metrics.incr(
             "event.save_event.unsampled.spans.count",
             amount=amount,


### PR DESCRIPTION
### Summary
Some organizations are not yet on AM2, without span extraction running, which makes it hard to estimate usage for future plan changes to AM3. This allows us to collect metrics for only those specific customers who we can't estimate through outcomes.

Flag I'm using in lieu of a new option is from the subscription plan handler, should be similarly fast to an option in region mode.
