### PR TITLE
feat(profiling): Default to transaction profiles for flamegraph

### DIFF
--- a/src/sentry/profiles/flamegraph.py
+++ b/src/sentry/profiles/flamegraph.py
@@ -383,46 +383,7 @@ class FlamegraphExecutor:
         }
 
     def get_profile_candidates_from_transactions(self) -> ProfileCandidates:
-        max_profiles = options.get("profiling.flamegraph.profile-set.size")
-
-        builder = DiscoverQueryBuilder(
-            dataset=Dataset.Discover,
-            params={},
-            snuba_params=self.snuba_params,
-            selected_columns=[
-                "project.id",
-                "precise.start_ts",
-                "precise.finish_ts",
-                "profile.id",
-                "profiler.id",
-                "thread.id",
-            ],
-            query=self.query,
-            limit=max_profiles,
-            config=QueryBuilderConfig(
-                transform_alias_to_input_format=True,
-            ),
-        )
-
-        builder.add_conditions(
-            [
-                Or(
-                    conditions=[
-                        Condition(builder.resolve_column("profile.id"), Op.IS_NOT_NULL),
-                        And(
-                            conditions=[
-                                Condition(builder.resolve_column("profiler.id"), Op.IS_NOT_NULL),
-                                Condition(
-                                    Function("has", [Column("contexts.key"), "trace.thread_id"]),
-                                    Op.EQ,
-                                    1,
-                                ),
-                            ],
-                        ),
-                    ],
-                ),
-            ],
-        )
+        builder = self.get_transactions_based_candidate_query(query=self.query)
 
         results = builder.run_query(
             Referrer.API_PROFILING_PROFILE_FLAMEGRAPH_TRANSACTION_CANDIDATES.value,
@@ -458,6 +419,52 @@ class FlamegraphExecutor:
             "transaction": transaction_profile_candidates,
             "continuous": continuous_profile_candidates,
         }
+
+    def get_transactions_based_candidate_query(self, query: str | None) -> DiscoverQueryBuilder:
+        max_profiles = options.get("profiling.flamegraph.profile-set.size")
+
+        builder = DiscoverQueryBuilder(
+            dataset=Dataset.Discover,
+            params={},
+            snuba_params=self.snuba_params,
+            selected_columns=[
+                "project.id",
+                "precise.start_ts",
+                "precise.finish_ts",
+                "profile.id",
+                "profiler.id",
+                "thread.id",
+                "timestamp",
+            ],
+            query=query,
+            orderby=["-timestamp"],
+            limit=max_profiles,
+            config=QueryBuilderConfig(
+                transform_alias_to_input_format=True,
+            ),
+        )
+
+        builder.add_conditions(
+            [
+                Or(
+                    conditions=[
+                        Condition(builder.resolve_column("profile.id"), Op.IS_NOT_NULL),
+                        And(
+                            conditions=[
+                                Condition(builder.resolve_column("profiler.id"), Op.IS_NOT_NULL),
+                                Condition(
+                                    Function("has", [Column("contexts.key"), "trace.thread_id"]),
+                                    Op.EQ,
+                                    1,
+                                ),
+                            ],
+                        ),
+                    ],
+                ),
+            ],
+        )
+
+        return builder
 
     def get_chunks_for_profilers(
         self, profiler_metas: list[ProfilerMeta]
@@ -584,21 +591,7 @@ class FlamegraphExecutor:
 
         referrer = Referrer.API_PROFILING_PROFILE_FLAMEGRAPH_PROFILE_CANDIDATES.value
 
-        transaction_profiles_builder = DiscoverQueryBuilder(
-            dataset=Dataset.Discover,
-            params={},
-            snuba_params=self.snuba_params,
-            selected_columns=["project.id", "profile.id", "timestamp"],
-            query=None,  # To match the profile chunks, we only fetch the latest profiles
-            orderby=["-timestamp"],
-            limit=max_profiles,
-            config=QueryBuilderConfig(
-                transform_alias_to_input_format=True,
-            ),
-        )
-        transaction_profiles_builder.add_conditions(
-            [Condition(transaction_profiles_builder.resolve_column("profile.id"), Op.IS_NOT_NULL)]
-        )
+        transaction_profiles_builder = self.get_transactions_based_candidate_query(query=None)
 
         project_condition = Condition(
             Column("project_id"),
@@ -651,20 +644,47 @@ class FlamegraphExecutor:
         transaction_profile_results = transaction_profiles_builder.process_results(all_results[0])
         continuous_profile_results = all_results[1]
 
-        return {
-            "transaction": [
-                {
-                    "project_id": row["project.id"],
-                    "profile_id": row["profile.id"],
-                }
-                for row in transaction_profile_results["data"]
-            ],
-            "continuous": [
+        transaction_profile_candidates: list[TransactionProfileCandidate] = [
+            {
+                "project_id": row["project.id"],
+                "profile_id": row["profile.id"],
+            }
+            for row in transaction_profile_results["data"]
+            if row["profile.id"] is not None
+        ]
+
+        profiler_metas = [
+            ProfilerMeta(
+                project_id=row["project.id"],
+                profiler_id=row["profiler.id"],
+                thread_id=row["thread.id"],
+                start=row["precise.start_ts"],
+                end=row["precise.finish_ts"],
+            )
+            for row in transaction_profile_results["data"]
+            if row["profiler.id"] is not None and row["thread.id"]
+        ]
+
+        continuous_profile_candidates: list[ContinuousProfileCandidate] = []
+
+        # If there are continuous profiles attached to transactions, we prefer those as
+        # the active thread id gives us more user friendly flamegraphs than without.
+        if profiler_metas:
+            continuous_profile_candidates = self.get_chunks_for_profilers(profiler_metas)
+
+        # If we still don't have any continuous profile candidates, we'll fall back to
+        # directly using the continuous profiling data
+        if not continuous_profile_candidates:
+            continuous_profile_candidates = [
                 {
                     "project_id": row["project_id"],
                     "profiler_id": row["profiler_id"],
                     "chunk_id": row["chunk_id"],
                 }
                 for row in continuous_profile_results["data"]
-            ],
+            ]
+
+        return {
+            "transaction": transaction_profile_candidates,
+            "continuous": continuous_profile_candidates,
         }

--- a/tests/sentry/api/endpoints/test_organization_profiling_profiles.py
+++ b/tests/sentry/api/endpoints/test_organization_profiling_profiles.py
@@ -378,7 +378,21 @@ class OrganizationProfilingFlamegraphTest(ProfilesSnubaTestCase):
 
             assert transactions_snql_request.dataset == Dataset.Discover.value
             assert (
-                Condition(Column("profile_id"), Op.IS_NOT_NULL)
+                Or(
+                    conditions=[
+                        Condition(Column("profile_id"), Op.IS_NOT_NULL),
+                        And(
+                            conditions=[
+                                Condition(Column("profiler_id"), Op.IS_NOT_NULL),
+                                Condition(
+                                    Function("has", [Column("contexts.key"), "trace.thread_id"]),
+                                    Op.EQ,
+                                    1,
+                                ),
+                            ],
+                        ),
+                    ],
+                )
                 in transactions_snql_request.query.where
             )
 
@@ -567,7 +581,9 @@ class OrganizationProfilingFlamegraphTest(ProfilesSnubaTestCase):
             },
         )
 
-    def test_queries_profile_candidates_from_profiles_with_data(self):
+    def test_queries_profile_candidates_from_profiles_with_continuous_profiles_without_transactions(
+        self,
+    ):
         # this transaction has transaction profile
         profile_id = uuid4().hex
         profile_transaction = self.store_transaction(
@@ -580,6 +596,14 @@ class OrganizationProfilingFlamegraphTest(ProfilesSnubaTestCase):
             "profile.id": profile_id,
             "timestamp": iso_format(datetime.fromtimestamp(profile_transaction["timestamp"]))
             + "+00:00",
+            "profiler.id": None,
+            "thread.id": None,
+            "precise.start_ts": datetime.fromtimestamp(
+                profile_transaction["start_timestamp"]
+            ).timestamp(),
+            "precise.finish_ts": datetime.fromtimestamp(
+                profile_transaction["timestamp"]
+            ).timestamp(),
         }
 
         # this transaction has continuous profile with a matching chunk (to be mocked below)
@@ -635,7 +659,21 @@ class OrganizationProfilingFlamegraphTest(ProfilesSnubaTestCase):
 
             assert transactions_snql_request.dataset == Dataset.Discover.value
             assert (
-                Condition(Column("profile_id"), Op.IS_NOT_NULL)
+                Or(
+                    conditions=[
+                        Condition(Column("profile_id"), Op.IS_NOT_NULL),
+                        And(
+                            conditions=[
+                                Condition(Column("profiler_id"), Op.IS_NOT_NULL),
+                                Condition(
+                                    Function("has", [Column("contexts.key"), "trace.thread_id"]),
+                                    Op.EQ,
+                                    1,
+                                ),
+                            ],
+                        ),
+                    ],
+                )
                 in transactions_snql_request.query.where
             )
 
@@ -656,6 +694,157 @@ class OrganizationProfilingFlamegraphTest(ProfilesSnubaTestCase):
                             "project_id": self.project.id,
                             "profiler_id": profiler_id,
                             "chunk_id": chunk["chunk_id"],
+                        },
+                    ],
+                },
+            )
+
+    def test_queries_profile_candidates_from_profiles_with_continuous_profiles_with_transactions(
+        self,
+    ):
+        # this transaction has transaction profile
+        profile_id = uuid4().hex
+        profile_transaction = self.store_transaction(
+            transaction="foo",
+            profile_id=profile_id,
+            project=self.project,
+        )
+        transaction_1 = {
+            "project.id": self.project.id,
+            "profile.id": profile_id,
+            "timestamp": iso_format(datetime.fromtimestamp(profile_transaction["timestamp"]))
+            + "+00:00",
+            "profiler.id": None,
+            "thread.id": None,
+            "precise.start_ts": datetime.fromtimestamp(
+                profile_transaction["start_timestamp"]
+            ).timestamp(),
+            "precise.finish_ts": datetime.fromtimestamp(
+                profile_transaction["timestamp"]
+            ).timestamp(),
+        }
+
+        # this transaction has continuous profile with a matching chunk (to be mocked below)
+        profiler_id = uuid4().hex
+        thread_id = "12345"
+        profiler_transaction = self.store_transaction(
+            transaction="foo",
+            profile_id=profiler_id,
+            thread_id=thread_id,
+            project=self.project,
+        )
+        transaction_2 = {
+            "project.id": self.project.id,
+            "profile.id": None,
+            "timestamp": iso_format(datetime.fromtimestamp(profile_transaction["timestamp"]))
+            + "+00:00",
+            "profiler.id": profiler_id,
+            "thread.id": thread_id,
+            "precise.start_ts": datetime.fromtimestamp(
+                profile_transaction["start_timestamp"]
+            ).timestamp(),
+            "precise.finish_ts": datetime.fromtimestamp(
+                profile_transaction["timestamp"]
+            ).timestamp(),
+        }
+
+        start_timestamp = datetime.fromtimestamp(profile_transaction["start_timestamp"])
+        finish_timestamp = datetime.fromtimestamp(profile_transaction["timestamp"])
+        buffer = timedelta(seconds=3)
+        # not able to write profile chunks to the table yet so mock it's response here
+        # so that the profiler transaction 1 looks like it has a profile chunk within
+        # the specified time range
+        chunk_1 = {
+            "project_id": self.project.id,
+            "profiler_id": profiler_id,
+            "chunk_id": uuid4().hex,
+            "start_timestamp": (start_timestamp - buffer).isoformat(),
+            "end_timestamp": (finish_timestamp + buffer).isoformat(),
+        }
+
+        # a random chunk that could be chosen but will not because we have a chunk
+        # associated to a profile
+        chunk_2 = {
+            "project_id": self.project.id,
+            "profiler_id": uuid4().hex,
+            "chunk_id": uuid4().hex,
+            "start_timestamp": (start_timestamp - buffer).isoformat(),
+            "end_timestamp": (finish_timestamp + buffer).isoformat(),
+        }
+
+        with (
+            patch("sentry.profiles.flamegraph.bulk_snuba_queries") as mock_bulk_snuba_queries,
+            patch(
+                "sentry.api.endpoints.organization_profiling_profiles.proxy_profiling_service"
+            ) as mock_proxy_profiling_service,
+        ):
+            mock_bulk_snuba_queries.side_effect = [
+                [
+                    {"data": [transaction_1, transaction_2]},
+                    {"data": [chunk_1, chunk_2]},
+                ],
+                [{"data": [chunk_1]}],
+            ]
+            mock_proxy_profiling_service.return_value = HttpResponse(status=200)
+
+            response = self.do_request(
+                {
+                    "project": [self.project.id],
+                    "dataSource": "profiles",
+                },
+            )
+
+            assert response.status_code == 200, response.content
+
+            assert mock_bulk_snuba_queries.call_count == 2
+
+            first_call_args = mock_bulk_snuba_queries.call_args_list[0][0]
+            [transactions_snql_request, profiles_snql_request] = first_call_args[0]
+
+            assert transactions_snql_request.dataset == Dataset.Discover.value
+            assert (
+                Or(
+                    conditions=[
+                        Condition(Column("profile_id"), Op.IS_NOT_NULL),
+                        And(
+                            conditions=[
+                                Condition(Column("profiler_id"), Op.IS_NOT_NULL),
+                                Condition(
+                                    Function("has", [Column("contexts.key"), "trace.thread_id"]),
+                                    Op.EQ,
+                                    1,
+                                ),
+                            ],
+                        ),
+                    ],
+                )
+                in transactions_snql_request.query.where
+            )
+
+            assert profiles_snql_request.dataset == Dataset.Profiles.value
+
+            second_call_args = mock_bulk_snuba_queries.call_args_list[1][0]
+            [profiles_snql_request] = second_call_args[0]
+            assert profiles_snql_request.dataset == Dataset.Profiles.value
+
+            mock_proxy_profiling_service.assert_called_once_with(
+                method="POST",
+                path=f"/organizations/{self.project.organization.id}/flamegraph",
+                json_data={
+                    "transaction": [
+                        {
+                            "project_id": self.project.id,
+                            "profile_id": profile_id,
+                        },
+                    ],
+                    "continuous": [
+                        {
+                            "project_id": self.project.id,
+                            "profiler_id": profiler_id,
+                            "chunk_id": chunk_1["chunk_id"],
+                            "thread_id": thread_id,
+                            "start": str(int(profiler_transaction["start_timestamp"] * 1e9)),
+                            "end": str(int(profiler_transaction["timestamp"] * 1e9)),
                         },
                     ],
                 },


### PR DESCRIPTION
Continuous profiles without transactions means we use every thread to render the flamegraph. This means we often include a lot of idle threads that take up the bulk of the flamegraph. To give a better default experience, we prefer chunks connected to a transaction and fall back to all chunks.