### PR TITLE
docs(api): Update API docs for issue details

### DIFF
--- a/api-docs/components/schemas/issue.json
+++ b/api-docs/components/schemas/issue.json
@@ -233,7 +233,15 @@
       "annotations": {
         "type": "array",
         "items": {
-          "type": "string"
+          "type": "object",
+          "properties": {
+            "displayName": {
+              "type": "string"
+            },
+            "url": {
+              "type": "string"
+            }
+          }
         }
       },
       "assignedTo": {


### PR DESCRIPTION
Update the `annotations` field in the schema for `GET
/api/0/organizations/{organization_id_or_slug}/issues/{issue_id}/
 ` ([link](http://localhost:3000/api/events/retrieve-an-issue/)).

 <img width="283" alt="image" src="https://github.com/user-attachments/assets/3be1ccf9-5391-4b3b-971c-330873f0b6e8">

Fixes https://github.com/getsentry/sentry/issues/75203