### PR TITLE
fix(toolbar): Fix incorrect flex direction on muted alerts

### DIFF
--- a/static/app/components/devtoolbar/components/alerts/alertsPanel.tsx
+++ b/static/app/components/devtoolbar/components/alerts/alertsPanel.tsx
@@ -138,19 +138,16 @@ function AlertListItem({item}: {item: Incident}) {
         `,
       ]}
     >
-      <div style={{gridArea: 'badge'}}>
+      <div css={{gridArea: 'badge'}}>
         <AlertBadge status={item.status} isIssue={false} />
       </div>
 
-      <div
-        css={[gridFlexEndCss, xSmallCss]}
-        style={{gridArea: 'time', color: 'var(--gray300)'}}
-      >
+      <div css={[gridFlexEndCss, xSmallCss, {gridArea: 'time', color: 'var(--gray300)'}]}>
         <TimeSince date={item.dateStarted} unitStyle="extraShort" />
       </div>
 
       <AnalyticsProvider nameVal="item" keyVal="item">
-        <TextOverflow css={smallCss} style={{gridArea: 'name'}}>
+        <TextOverflow css={[smallCss, {gridArea: 'name'}]}>
           <SentryAppLink
             to={{
               url: alertDetailsLink({slug: organizationSlug} as Organization, item),
@@ -162,7 +159,7 @@ function AlertListItem({item}: {item: Incident}) {
         </TextOverflow>
       </AnalyticsProvider>
 
-      <div css={smallCss} style={{gridArea: 'message'}}>
+      <div css={[smallCss, {gridArea: 'message', '> div': {flexDirection: 'row'}}]}>
         <ActivatedMetricAlertRuleStatus rule={rule} />
       </div>
 
@@ -173,9 +170,9 @@ function AlertListItem({item}: {item: Incident}) {
             xSmallCss,
             css`
               justify-self: flex-end;
+              grid-area: icons;
             `,
           ]}
-          style={{gridArea: 'icons'}}
         >
           <ActorAvatar actor={teamActor} size={16} hasTooltip={false} />{' '}
           <TextOverflow>{teamActor.name}</TextOverflow>


### PR DESCRIPTION
**Before**
<img width="326" alt="SCR-20240801-nvoe" src="https://github.com/user-attachments/assets/72b3df4b-1148-429b-a524-83b50d40196f">

**After**
<img width="320" alt="SCR-20240801-nvmo" src="https://github.com/user-attachments/assets/db9e7d15-388b-426f-b126-e924a6dcd24c">

I also took the chance to prefer `css={}` over `style={}`. The difference is that `style` is the inline prop that mostly just goes through react, while `css` executes `@emotion/react` magic and merges all the styles together with a classname. More like `styled()` 
