### PR TITLE
feat(query-builder): Improve filter key formatting and styles

### DIFF
--- a/static/app/components/searchQueryBuilder/index.spec.tsx
+++ b/static/app/components/searchQueryBuilder/index.spec.tsx
@@ -2072,7 +2072,7 @@ describe('SearchQueryBuilder', function () {
       it('can add an aggregate filter with default values', async function () {
         render(<SearchQueryBuilder {...aggregateDefaultProps} />);
         await userEvent.click(getLastInput());
-        await userEvent.click(screen.getByRole('option', {name: 'count_if'}));
+        await userEvent.click(screen.getByRole('option', {name: 'count_if(...)'}));
 
         expect(
           await screen.findByRole('row', {

--- a/static/app/components/searchQueryBuilder/index.stories.tsx
+++ b/static/app/components/searchQueryBuilder/index.stories.tsx
@@ -335,6 +335,11 @@ export default storyBook(SearchQueryBuilder, story => {
 
   story('Aggregate filters', () => {
     const aggregateFilterKeys: TagCollection = {
+      apdex: {
+        key: 'apdex',
+        name: 'apdex',
+        kind: FieldKind.FUNCTION,
+      },
       count: {
         key: 'count',
         name: 'count',
@@ -364,6 +369,21 @@ export default storyBook(SearchQueryBuilder, story => {
 
     const getAggregateFieldDefinition: FieldDefinitionGetter = (key: string) => {
       switch (key) {
+        case 'apdex':
+          return {
+            desc: 'Returns results with the Apdex score that you entered. Values must be between 0 and 1. Higher apdex values indicate higher user satisfaction.',
+            kind: FieldKind.FUNCTION,
+            valueType: FieldValueType.NUMBER,
+            parameters: [
+              {
+                name: 'threshold',
+                kind: 'value' as const,
+                dataType: FieldValueType.NUMBER,
+                defaultValue: '300',
+                required: true,
+              },
+            ],
+          };
         case 'count':
           return {
             desc: 'Returns results with a matching count.',

--- a/static/app/components/searchQueryBuilder/tokens/filter/functionDescription.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/functionDescription.tsx
@@ -67,11 +67,11 @@ export function FunctionDescription({token, parameterIndex}: FunctionDescription
 }
 
 const Description = styled('div')`
+  font-size: ${p => p.theme.fontSizeSmall};
   text-align: left;
 `;
 
-const Code = styled('code')`
-  display: block;
+const Code = styled('div')`
   font-size: ${p => p.theme.fontSizeMedium};
 `;
 

--- a/static/app/components/searchQueryBuilder/tokens/freeText.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/freeText.tsx
@@ -282,9 +282,9 @@ function KeyDescription({tag}: {tag: Tag}) {
 
   return (
     <DescriptionWrapper>
-      <p>
-        <strong>{getKeyLabel(tag, fieldDefinition, {includeAggregateArgs: true})}</strong>
-      </p>
+      <DescriptionKeyLabel>
+        {getKeyLabel(tag, fieldDefinition, {includeAggregateArgs: true})}
+      </DescriptionKeyLabel>
       {description ? <p>{description}</p> : null}
       <Separator />
       <DescriptionList>
@@ -721,6 +721,11 @@ const DescriptionWrapper = styled('div')`
   p + p {
     margin-top: ${space(0.5)};
   }
+`;
+
+const DescriptionKeyLabel = styled('p')`
+  font-weight: ${p => p.theme.fontWeightBold};
+  word-break: break-all;
 `;
 
 const Separator = styled('hr')`


### PR DESCRIPTION
Formats aggregate keys correctly and improves the description styles (smaller font size, more info, also shows for tag values)

![CleanShot 2024-08-01 at 15 35 02](https://github.com/user-attachments/assets/9ee577d2-b263-48b8-bba5-416752192cf2)
