### PR TITLE
ref(grouping): Enable optimized grouping for some transitioning non-mobile projects

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -56,7 +56,7 @@ from sentry.grouping.api import (
 from sentry.grouping.ingest.config import (
     is_in_transition,
     project_uses_optimized_grouping,
-    update_grouping_config_if_permitted,
+    update_grouping_config_if_needed,
 )
 from sentry.grouping.ingest.hashing import (
     find_existing_grouphash,
@@ -1403,7 +1403,7 @@ def _save_aggregate(
     # hashes, we're free to perform a config update if permitted. Future events will use the new
     # config, but will also be grandfathered into the current config for a month, so as not to
     # erroneously create new groups.
-    update_grouping_config_if_permitted(project, "ingest")
+    update_grouping_config_if_needed(project, "ingest")
 
     _materialize_metadata_many([job])
     metadata = dict(job["event_metadata"])
@@ -1761,7 +1761,7 @@ def _save_aggregate_new(
     # hashes, we're free to perform a config update if needed. Future events will use the new
     # config, but will also be grandfathered into the current config for a week, so as not to
     # erroneously create new groups.
-    update_grouping_config_if_permitted(project, "ingest")
+    update_grouping_config_if_needed(project, "ingest")
 
     return group_info
 

--- a/src/sentry/grouping/ingest/config.py
+++ b/src/sentry/grouping/ingest/config.py
@@ -90,7 +90,10 @@ def project_uses_optimized_grouping(project: Project) -> bool:
     secondary_grouping_config = project.get_option("sentry:secondary_grouping_config")
     has_mobile_config = "mobile:2021-02-12" in [primary_grouping_config, secondary_grouping_config]
 
-    return not has_mobile_config and features.has(
+    if has_mobile_config or options.get("grouping.config_transition.killswitch_enabled"):
+        return False
+
+    return features.has(
         "organizations:grouping-suppress-unnecessary-secondary-hash",
         project.organization,
-    )
+    ) or (is_in_transition(project) and project.id % 2 == 0)

--- a/src/sentry/grouping/ingest/config.py
+++ b/src/sentry/grouping/ingest/config.py
@@ -27,12 +27,12 @@ CONFIGS_TO_DEPRECATE = ("mobile:2021-02-12",)
 DO_NOT_UPGRADE_YET = ("legacy:2019-03-12", "newstyle:2019-10-29", "newstyle:2019-05-08")
 
 
-# Used by getsentry script. Remove it once the script has been updated to call update_grouping_config_if_permitted
-def _auto_update_grouping(project: Project) -> None:
-    update_grouping_config_if_permitted(project, "script")
+# Used by getsentry script. Remove it once the script has been updated to call update_grouping_config_if_needed
+def update_grouping_config_if_permitted(project: Project) -> None:
+    update_grouping_config_if_needed(project, "script")
 
 
-def update_grouping_config_if_permitted(project: Project, source: str) -> None:
+def update_grouping_config_if_needed(project: Project, source: str) -> None:
     current_config = project.get_option("sentry:grouping_config")
     new_config = DEFAULT_GROUPING_CONFIG
 

--- a/src/sentry/grouping/ingest/config.py
+++ b/src/sentry/grouping/ingest/config.py
@@ -21,11 +21,6 @@ Job = MutableMapping[str, Any]
 # Used to migrate projects that have no activity via getsentry scripts
 CONFIGS_TO_DEPRECATE = ("mobile:2021-02-12",)
 
-# We want to test the new optimized transition code with projects that are on
-# deprecated configs before making it the default code path.
-# Remove this once we have switched to the optimized code path.
-DO_NOT_UPGRADE_YET = ("legacy:2019-03-12", "newstyle:2019-10-29", "newstyle:2019-05-08")
-
 
 # Used by getsentry script. Remove it once the script has been updated to call update_grouping_config_if_needed
 def update_grouping_config_if_permitted(project: Project) -> None:
@@ -37,10 +32,6 @@ def update_grouping_config_if_needed(project: Project, source: str) -> None:
     new_config = DEFAULT_GROUPING_CONFIG
 
     if current_config == new_config or current_config == BETA_GROUPING_CONFIG:
-        return
-
-    # Remove this code once we have transitioned to the optimized code path
-    if current_config in DO_NOT_UPGRADE_YET:
         return
 
     # Because the way the auto grouping upgrading happening is racy, we want to

--- a/src/sentry/grouping/ingest/metrics.py
+++ b/src/sentry/grouping/ingest/metrics.py
@@ -4,9 +4,9 @@ import logging
 from collections.abc import MutableMapping
 from typing import TYPE_CHECKING, Any
 
-from sentry import features, options
+from sentry import options
 from sentry.grouping.api import GroupingConfig
-from sentry.grouping.ingest.config import is_in_transition
+from sentry.grouping.ingest.config import is_in_transition, project_uses_optimized_grouping
 from sentry.grouping.ingest.utils import extract_hashes
 from sentry.grouping.result import CalculatedHashes
 from sentry.models.project import Project
@@ -67,12 +67,7 @@ def record_calculation_metric_with_result(
     # count to get an average number of calculations per event
     tags = {
         "in_transition": str(is_in_transition(project)),
-        "using_transition_optimization": str(
-            features.has(
-                "organizations:grouping-suppress-unnecessary-secondary-hash",
-                project.organization,
-            )
-        ),
+        "using_transition_optimization": str(project_uses_optimized_grouping(project)),
         "result": result,
     }
     metrics.incr(

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -2425,6 +2425,13 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 
+register(
+    "grouping.config_transition.killswitch_enabled",
+    type=Bool,
+    default=False,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+
 # Sample rate for double writing to experimental dsn
 register(
     "store.experimental-dsn-double-write.sample-rate",

--- a/tests/sentry/event_manager/grouping/test_assign_to_group.py
+++ b/tests/sentry/event_manager/grouping/test_assign_to_group.py
@@ -19,7 +19,6 @@ from sentry.grouping.ingest.metrics import record_calculation_metric_with_result
 from sentry.models.grouphash import GroupHash
 from sentry.models.project import Project
 from sentry.testutils.helpers.eventprocessing import save_new_event
-from sentry.testutils.helpers.features import Feature
 from sentry.testutils.pytest.fixtures import django_db_all
 from sentry.testutils.pytest.mocking import capture_results
 from sentry.testutils.skips import requires_snuba
@@ -162,7 +161,9 @@ def get_results_from_saving_event(
 
     with (
         patch_grouping_helpers(return_values) as spies,
-        Feature({"organizations:grouping-suppress-unnecessary-secondary-hash": new_logic_enabled}),
+        mock.patch(
+            "sentry.event_manager.project_uses_optimized_grouping", return_value=new_logic_enabled
+        ),
     ):
         calculate_secondary_hash_spy = spies["_calculate_secondary_hash"]
         create_group_spy = spies["_create_group"]

--- a/tests/sentry/event_manager/grouping/test_assign_to_group.py
+++ b/tests/sentry/event_manager/grouping/test_assign_to_group.py
@@ -1,13 +1,15 @@
 from __future__ import annotations
 
 from contextlib import contextmanager
+from random import randint
 from time import time
 from typing import Any
 from unittest import mock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
-from sentry.event_manager import _create_group
+from sentry.event_manager import _create_group, _save_aggregate, _save_aggregate_new
 from sentry.eventstore.models import Event
 from sentry.grouping.ingest.hashing import (
     _calculate_primary_hash,
@@ -18,7 +20,10 @@ from sentry.grouping.ingest.hashing import (
 from sentry.grouping.ingest.metrics import record_calculation_metric_with_result
 from sentry.models.grouphash import GroupHash
 from sentry.models.project import Project
+from sentry.testutils.factories import Factories
 from sentry.testutils.helpers.eventprocessing import save_new_event
+from sentry.testutils.helpers.features import Feature
+from sentry.testutils.helpers.options import override_options
 from sentry.testutils.pytest.fixtures import django_db_all
 from sentry.testutils.pytest.mocking import capture_results
 from sentry.testutils.skips import requires_snuba
@@ -28,6 +33,7 @@ pytestmark = [requires_snuba]
 
 LEGACY_CONFIG = "legacy:2019-03-12"
 NEWSTYLE_CONFIG = "newstyle:2023-01-11"
+MOBILE_CONFIG = "mobile:2021-02-12"
 
 
 @contextmanager
@@ -475,3 +481,57 @@ def test_existing_group_new_hash_exists(
             "secondary_grouphash_existed_already": None,
             "secondary_grouphash_exists_now": None,
         }
+
+
+@django_db_all
+@pytest.mark.parametrize(
+    "killswitch_enabled",
+    (True, False),
+    ids=(" killswitch_enabled: True ", " killswitch_enabled: False "),
+)
+@pytest.mark.parametrize("flag_on", (True, False), ids=(" flag_on: True ", " flag_on: False "))
+@pytest.mark.parametrize(
+    "in_transition", (True, False), ids=(" in_transition: True ", " in_transition: False ")
+)
+@pytest.mark.parametrize(
+    "mobile_config", (True, False), ids=(" mobile_config: True ", " mobile_config: False ")
+)
+@pytest.mark.parametrize("id_even", (True, False), ids=(" id_even: True ", " id_even: False "))
+@patch("sentry.event_manager._save_aggregate_new", wraps=_save_aggregate_new)
+@patch("sentry.event_manager._save_aggregate", wraps=_save_aggregate)
+def test_uses_regular_or_optimized_grouping_as_appropriate(
+    mock_save_aggregate: MagicMock,
+    mock_save_aggregate_new: MagicMock,
+    id_even: bool,
+    mobile_config: bool,
+    in_transition: bool,
+    flag_on: bool,
+    killswitch_enabled: bool,
+):
+    # The snowflake id seems to sometimes get stuck generating nothing but even numbers, so replace
+    # it with something we know will generate both odds and evens
+    with patch(
+        "sentry.utils.snowflake.generate_snowflake_id", side_effect=lambda _: randint(1, 1000)
+    ):
+        # Keep making projects until we get an id of the correct parity
+        org = Factories.create_organization()
+        project = Factories.create_project(organization=org)
+        while project.id % 2 == (1 if id_even else 0):
+            project = Factories.create_project(organization=org)
+
+    with (
+        Feature({"organizations:grouping-suppress-unnecessary-secondary-hash": flag_on}),
+        patch("sentry.grouping.ingest.config.is_in_transition", return_value=in_transition),
+        override_options({"grouping.config_transition.killswitch_enabled": killswitch_enabled}),
+    ):
+        config = MOBILE_CONFIG if mobile_config else NEWSTYLE_CONFIG
+        save_event_with_grouping_config({"message": "Dogs are great!"}, project, config)
+
+    if mobile_config or killswitch_enabled:
+        assert mock_save_aggregate.call_count == 1
+    elif flag_on:
+        assert mock_save_aggregate_new.call_count == 1
+    elif in_transition and id_even:
+        assert mock_save_aggregate_new.call_count == 1
+    else:
+        assert mock_save_aggregate.call_count == 1

--- a/tests/sentry/event_manager/test_event_manager_grouping.py
+++ b/tests/sentry/event_manager/test_event_manager_grouping.py
@@ -11,7 +11,6 @@ from sentry import audit_log
 from sentry.conf.server import SENTRY_GROUPING_UPDATE_MIGRATION_PHASE
 from sentry.event_manager import _get_updated_group_title
 from sentry.eventtypes.base import DefaultEvent
-from sentry.grouping.ingest.config import DO_NOT_UPGRADE_YET
 from sentry.grouping.result import CalculatedHashes
 from sentry.models.auditlogentry import AuditLogEntry
 from sentry.models.group import Group
@@ -165,19 +164,6 @@ class EventManagerGroupingTest(TestCase):
             int(audit_log_entry.datetime.timestamp()) + SENTRY_GROUPING_UPDATE_MIGRATION_PHASE
         )
         assert actual_expiry == expected_expiry or actual_expiry == expected_expiry - 1
-
-    def test_does_not_update_project_in_exclude_list(self):
-        # It does not update the config because it is listed in DO_NOT_UPGRADE_YET
-        self.project.update_option("sentry:grouping_config", LEGACY_CONFIG)
-        assert LEGACY_CONFIG in DO_NOT_UPGRADE_YET
-        save_new_event({"message": "foo"}, self.project)
-        assert self.project.get_option("sentry:grouping_config") == LEGACY_CONFIG
-
-        # It updates the config because it is not listed in DO_NOT_UPGRADE_YET
-        self.project.update_option("sentry:grouping_config", "mobile:2021-02-12")
-        assert "mobile:2021-02-12" not in DO_NOT_UPGRADE_YET
-        save_new_event({"message": "foo"}, self.project)
-        assert self.project.get_option("sentry:grouping_config") == DEFAULT_GROUPING_CONFIG
 
 
 class PlaceholderTitleTest(TestCase):


### PR DESCRIPTION
The enables the new optimized grouping config transition flow for roughly half of non-mobile projects which are in a grouping transition, with the goal of comparing metrics between those which run through the new and old logic.

Included changes:

- Remove the `DO_NOT_UPGRADE_YET` list (and the check thereof), so that now projects on all outdated configs will get upgraded. Also remove the related test.

- Change `update_grouping_config_if_permitted` back to `update_grouping_config_if_needed` to reflect the fact that everyone now is allowed to upgrade.

- Change the logic in `project_uses_optimized_grouping` so that projects not on (or transitioning off of) the mobile config are eligible for the new flow if they are in transition and have an even id. (This should ensure that roughly 50% take the new path while the rest take the old one.) 

-  In light of the new eligibility logic, switch the way that tests turn on optimized grouping from setting the flag to just mocking the return value of `project_uses_optimized_grouping`. Make an analogous change for getting the `using_transition_optimization` tag value in `record_calculation_metric_with_result`.

- Add a killswitch for the new logic, just in case.

