### PR TITLE
feat(uptime): Simple uptime details page

### DIFF
--- a/src/sentry/incidents/endpoints/serializers/alert_rule.py
+++ b/src/sentry/incidents/endpoints/serializers/alert_rule.py
@@ -407,7 +407,7 @@ class CombinedRuleSerializer(Serializer):
 
         for item in item_list:
             item_id = str(item.id)
-            if item_id in serialized_alert_rule_map_by_id:
+            if isinstance(item, AlertRule) and item_id in serialized_alert_rule_map_by_id:
                 # This is a metric alert rule
                 serialized_alert_rule = serialized_alert_rule_map_by_id[item_id]
                 if "latestIncident" in self.expand:
@@ -425,10 +425,13 @@ class CombinedRuleSerializer(Serializer):
                             },
                         )
                 results[item] = serialized_alert_rule
-            elif item_id in serialized_issue_rule_map_by_id:
+            elif isinstance(item, Rule) and item_id in serialized_issue_rule_map_by_id:
                 # This is an issue alert rule
                 results[item] = serialized_issue_rule_map_by_id[item_id]
-            elif item_id in serialized_uptime_monitor_map_by_id:
+            elif (
+                isinstance(item, ProjectUptimeSubscription)
+                and item_id in serialized_uptime_monitor_map_by_id
+            ):
                 # This is an uptime monitor
                 results[item] = serialized_uptime_monitor_map_by_id[item_id]
             else:

--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -1309,6 +1309,20 @@ function buildRoutes() {
     </Route>
   );
 
+  const uptimeRoutes = (
+    <Route
+      path="/uptime/"
+      component={make(() => import('sentry/views/uptime'))}
+      withOrgPath
+    >
+      <IndexRedirect to="/organizations/:orgId/" />
+      <Route
+        path=":projectId/:uptimeAlertId/"
+        component={make(() => import('sentry/views/uptime/details'))}
+      />
+    </Route>
+  );
+
   const replayRoutes = (
     <Route
       path="/replays/"
@@ -2088,6 +2102,7 @@ function buildRoutes() {
       {issueDetailsRoutes}
       {alertRoutes}
       {cronsRoutes}
+      {uptimeRoutes}
       {replayRoutes}
       {releasesRoutes}
       {statsRoutes}

--- a/static/app/views/alerts/list/rules/alertLastIncidentActivationInfo.spec.tsx
+++ b/static/app/views/alerts/list/rules/alertLastIncidentActivationInfo.spec.tsx
@@ -1,0 +1,68 @@
+import {IncidentFixture} from 'sentry-fixture/incident';
+import {MetricRuleFixture} from 'sentry-fixture/metricRule';
+import {ProjectAlertRuleFixture} from 'sentry-fixture/projectAlertRule';
+import {UptimeRuleFixture} from 'sentry-fixture/uptimeRule';
+
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import AlertLastIncidentActivationInfo from 'sentry/views/alerts/list/rules/alertLastIncidentActivationInfo';
+import {CombinedAlertType, IncidentStatus} from 'sentry/views/alerts/types';
+
+describe('AlertLastIncidentActivationInfo', function () {
+  it('Renders non-triggered issue alert correctly', function () {
+    const rule = {
+      ...ProjectAlertRuleFixture(),
+      type: CombinedAlertType.ISSUE,
+    } as const;
+
+    render(<AlertLastIncidentActivationInfo rule={rule} />);
+    expect(screen.getByText('Alert not triggered yet')).toBeInTheDocument();
+  });
+
+  it('Renders triggered issue alert correctly', function () {
+    const rule = {
+      ...ProjectAlertRuleFixture({
+        lastTriggered: '2017-10-17T00:00:00.000Z',
+      }),
+      type: CombinedAlertType.ISSUE,
+    } as const;
+
+    const {container} = render(<AlertLastIncidentActivationInfo rule={rule} />);
+    expect(container).toHaveTextContent('Triggered 3 hours ago');
+  });
+
+  it('Renders non-triggered metric alerts', function () {
+    const rule = {
+      ...MetricRuleFixture(),
+      type: CombinedAlertType.METRIC,
+    } as const;
+
+    render(<AlertLastIncidentActivationInfo rule={rule} />);
+    expect(screen.getByText('Alert not triggered yet')).toBeInTheDocument();
+  });
+
+  it('Renders triggered metric alert incidents', function () {
+    const rule = {
+      ...MetricRuleFixture({
+        latestIncident: IncidentFixture({
+          status: IncidentStatus.CRITICAL,
+          dateCreated: '2017-10-17T00:00:00.000Z',
+        }),
+      }),
+      type: CombinedAlertType.METRIC,
+    } as const;
+
+    const {container} = render(<AlertLastIncidentActivationInfo rule={rule} />);
+    expect(container).toHaveTextContent('Triggered 3 hours ago');
+  });
+
+  it('Renders uptime alerts', function () {
+    const rule = {
+      ...UptimeRuleFixture(),
+      type: CombinedAlertType.UPTIME,
+    } as const;
+
+    render(<AlertLastIncidentActivationInfo rule={rule} />);
+    expect(screen.getByText('Actively monitoring every 5 seconds')).toBeInTheDocument();
+  });
+});

--- a/static/app/views/alerts/list/rules/alertLastIncidentActivationInfo.tsx
+++ b/static/app/views/alerts/list/rules/alertLastIncidentActivationInfo.tsx
@@ -1,0 +1,92 @@
+import TimeSince from 'sentry/components/timeSince';
+import {t, tct} from 'sentry/locale';
+import {MonitorType} from 'sentry/types/alerts';
+import {hasActiveIncident} from 'sentry/views/alerts/list/rules/utils';
+import {
+  type CombinedAlerts,
+  CombinedAlertType,
+  type IssueAlert,
+  type MetricAlert,
+  type UptimeAlert,
+} from 'sentry/views/alerts/types';
+
+interface Props {
+  rule: CombinedAlerts;
+}
+
+/**
+ * Displays the time since the last uptime incident given an uptime alert rule
+ */
+function LastUptimeIncident({rule}: {rule: UptimeAlert}) {
+  // TODO(davidenwang): Once we have a lastTriggered field returned from backend, display that info here
+  return tct('Actively monitoring every [seconds] seconds', {
+    seconds: rule.intervalSeconds,
+  });
+}
+
+/**
+ * Displays the last time an issue alert was triggered
+ */
+function LastIssueTrigger({rule}: {rule: IssueAlert}) {
+  if (!rule.lastTriggered) {
+    return t('Alert not triggered yet');
+  }
+
+  return (
+    <div>
+      {t('Triggered ')}
+      <TimeSince date={rule.lastTriggered} />
+    </div>
+  );
+}
+
+/**
+ * Displays the last activation for activated alert rules or the last incident for continuous alerts
+ */
+function LastMetricAlertIncident({rule}: {rule: MetricAlert}) {
+  if (rule.monitorType === MonitorType.ACTIVATED) {
+    if (!rule.activations?.length) {
+      return t('Alert has not been activated yet');
+    }
+
+    return (
+      <div>
+        {t('Last activated ')}
+        <TimeSince date={rule.activations[0].dateCreated} />
+      </div>
+    );
+  }
+
+  if (!rule.latestIncident) {
+    return t('Alert not triggered yet');
+  }
+
+  const activeIncident = hasActiveIncident(rule);
+  if (activeIncident) {
+    return (
+      <div>
+        {t('Triggered ')}
+        <TimeSince date={rule.latestIncident.dateCreated} />
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      {t('Resolved ')}
+      <TimeSince date={rule.latestIncident.dateClosed!} />
+    </div>
+  );
+}
+
+export default function AlertLastIncidentActivationInfo({rule}: Props) {
+  // eslint-disable-next-line default-case
+  switch (rule.type) {
+    case CombinedAlertType.UPTIME:
+      return <LastUptimeIncident rule={rule} />;
+    case CombinedAlertType.ISSUE:
+      return <LastIssueTrigger rule={rule} />;
+    case CombinedAlertType.METRIC:
+      return <LastMetricAlertIncident rule={rule} />;
+  }
+}

--- a/static/app/views/alerts/list/rules/row.tsx
+++ b/static/app/views/alerts/list/rules/row.tsx
@@ -180,9 +180,11 @@ function RuleListRow({
           <AlertName>
             <Link
               to={
-                isIssueAlert(rule)
+                rule.type === CombinedAlertType.ISSUE
                   ? `/organizations/${orgId}/alerts/rules/${rule.projects[0]}/${rule.id}/details/`
-                  : `/organizations/${orgId}/alerts/rules/details/${rule.id}/`
+                  : rule.type === CombinedAlertType.METRIC
+                    ? `/organizations/${orgId}/alerts/rules/details/${rule.id}/`
+                    : `/organizations/${orgId}/uptime/${rule.projectSlug}/${rule.id}/`
               }
             >
               {rule.name}

--- a/static/app/views/alerts/types.tsx
+++ b/static/app/views/alerts/types.tsx
@@ -95,7 +95,7 @@ export enum CombinedAlertType {
   UPTIME = 'uptime',
 }
 
-interface IssueAlert extends IssueAlertRule {
+export interface IssueAlert extends IssueAlertRule {
   type: CombinedAlertType.ISSUE;
   latestIncident?: Incident | null;
 }

--- a/static/app/views/uptime/details.spec.tsx
+++ b/static/app/views/uptime/details.spec.tsx
@@ -1,0 +1,61 @@
+import {UptimeRuleFixture} from 'sentry-fixture/uptimeRule';
+
+import {initializeOrg} from 'sentry-test/initializeOrg';
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import UptimeAlertDetails from 'sentry/views/uptime/details';
+
+describe('UptimeAlertDetails', function () {
+  const {organization, project, routerProps} = initializeOrg({
+    organization: {features: ['uptime-rule-api']},
+  });
+
+  beforeEach(function () {
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/projects/`,
+      body: [project],
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/users/`,
+      body: [],
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/issues/?limit=20&project=${project.id}&query=issue.category%3Auptime&statsPeriod=14d`,
+      body: [],
+    });
+  });
+
+  it('renders', async function () {
+    MockApiClient.addMockResponse({
+      url: `/projects/${organization.slug}/${project.slug}/uptime/1/`,
+      body: UptimeRuleFixture({name: 'Uptime Test Rule'}),
+    });
+
+    render(
+      <UptimeAlertDetails
+        {...routerProps}
+        params={{...routerProps.params, uptimeAlertId: '1'}}
+      />,
+      {organization}
+    );
+    expect(await screen.findAllByText('Uptime Test Rule')).toHaveLength(2);
+  });
+
+  it('shows a message for invalid uptime alert', async function () {
+    MockApiClient.addMockResponse({
+      url: `/projects/${organization.slug}/${project.slug}/uptime/2/`,
+      statusCode: 404,
+    });
+
+    render(
+      <UptimeAlertDetails
+        {...routerProps}
+        params={{...routerProps.params, uptimeAlertId: '2'}}
+      />,
+      {organization}
+    );
+    expect(
+      await screen.findByText('The uptime alert rule you were looking for was not found.')
+    ).toBeInTheDocument();
+  });
+});

--- a/static/app/views/uptime/details.tsx
+++ b/static/app/views/uptime/details.tsx
@@ -1,0 +1,149 @@
+import type {RouteComponentProps} from 'react-router';
+import styled from '@emotion/styled';
+
+import Feature from 'sentry/components/acl/feature';
+import Alert from 'sentry/components/alert';
+import ActorAvatar from 'sentry/components/avatar/actorAvatar';
+import Breadcrumbs from 'sentry/components/breadcrumbs';
+import {Button} from 'sentry/components/button';
+import ButtonBar from 'sentry/components/buttonBar';
+import {SectionHeading} from 'sentry/components/charts/styles';
+import IdBadge from 'sentry/components/idBadge';
+import {KeyValueTable, KeyValueTableRow} from 'sentry/components/keyValueTable';
+import * as Layout from 'sentry/components/layouts/thirds';
+import LoadingError from 'sentry/components/loadingError';
+import LoadingIndicator from 'sentry/components/loadingIndicator';
+import {DatePageFilter} from 'sentry/components/organizations/datePageFilter';
+import {EnvironmentPageFilter} from 'sentry/components/organizations/environmentPageFilter';
+import PageFilterBar from 'sentry/components/organizations/pageFilterBar';
+import {IconEdit} from 'sentry/icons';
+import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
+import {type ApiQueryKey, useApiQuery} from 'sentry/utils/queryClient';
+import useOrganization from 'sentry/utils/useOrganization';
+import useProjects from 'sentry/utils/useProjects';
+import type {UptimeRule} from 'sentry/views/alerts/rules/uptime/types';
+import {UptimeIssues} from 'sentry/views/uptime/uptimeIssues';
+
+interface UptimeAlertDetailsProps
+  extends RouteComponentProps<{projectId: string; uptimeAlertId: string}, {}> {}
+
+export default function UptimeAlertDetails({params}: UptimeAlertDetailsProps) {
+  const organization = useOrganization();
+  const {projectId, uptimeAlertId} = params;
+
+  const {projects, fetching: loadingProject} = useProjects({slugs: [projectId]});
+  const project = projects.find(({slug}) => slug === projectId);
+
+  const queryKey: ApiQueryKey = [
+    `/projects/${organization.slug}/${projectId}/uptime/${uptimeAlertId}/`,
+  ];
+  const {
+    data: uptimeRule,
+    isLoading,
+    isError,
+  } = useApiQuery<UptimeRule>(queryKey, {staleTime: 0});
+  if (isError) {
+    return (
+      <LoadingError
+        message={t('The uptime alert rule you were looking for was not found.')}
+      />
+    );
+  }
+
+  if (isLoading || loadingProject) {
+    return (
+      <Layout.Body>
+        <Layout.Main fullWidth>
+          <LoadingIndicator />
+        </Layout.Main>
+      </Layout.Body>
+    );
+  }
+
+  if (!project) {
+    return (
+      <LoadingError message={t('The project you were looking for was not found.')} />
+    );
+  }
+
+  const renderDisabled = () => (
+    <Layout.Body>
+      <Layout.Main fullWidth>
+        <Alert type="warning">{t("You don't have access to this feature")}</Alert>
+      </Layout.Main>
+    </Layout.Body>
+  );
+
+  return (
+    <Feature
+      organization={organization}
+      features="uptime-rule-api"
+      renderDisabled={renderDisabled}
+    >
+      <Layout.Page>
+        <Layout.Header>
+          <Layout.HeaderContent>
+            <Breadcrumbs
+              crumbs={[
+                {
+                  label: t('Alerts'),
+                  to: `/organizations/${organization.slug}/alerts/rules/`,
+                },
+                {
+                  label: uptimeRule.name,
+                  to: null,
+                },
+              ]}
+            />
+            <Layout.Title>
+              <IdBadge
+                project={project}
+                avatarSize={28}
+                hideName
+                avatarProps={{hasTooltip: true, tooltip: project.slug}}
+              />
+              {uptimeRule.name}
+            </Layout.Title>
+          </Layout.HeaderContent>
+          <Layout.HeaderActions>
+            <ButtonBar gap={1}>
+              <Button size="sm" icon={<IconEdit />} disabled>
+                {t('Edit Rule')}
+              </Button>
+            </ButtonBar>
+          </Layout.HeaderActions>
+        </Layout.Header>
+        <Layout.Body>
+          <Layout.Main>
+            <StyledPageFilterBar condensed>
+              <DatePageFilter />
+              <EnvironmentPageFilter />
+            </StyledPageFilterBar>
+            <UptimeIssues project={project} />
+          </Layout.Main>
+          <Layout.Side>
+            <SectionHeading>{t('Uptime Alert Details')}</SectionHeading>
+            <KeyValueTable>
+              <KeyValueTableRow keyName={t('URL')} value={uptimeRule.url} />
+              <KeyValueTableRow
+                keyName={t('Owner')}
+                value={
+                  uptimeRule.owner ? (
+                    <ActorAvatar actor={uptimeRule.owner} />
+                  ) : (
+                    t('Unassigned')
+                  )
+                }
+              />
+            </KeyValueTable>
+          </Layout.Side>
+        </Layout.Body>
+      </Layout.Page>
+    </Feature>
+  );
+}
+
+const StyledPageFilterBar = styled(PageFilterBar)`
+  margin-bottom: ${space(2)};
+`;

--- a/static/app/views/uptime/index.tsx
+++ b/static/app/views/uptime/index.tsx
@@ -1,0 +1,13 @@
+import NoProjectMessage from 'sentry/components/noProjectMessage';
+import PageFiltersContainer from 'sentry/components/organizations/pageFilters/container';
+import useOrganization from 'sentry/utils/useOrganization';
+
+export default function UptimeContainer({children}: {children?: React.ReactNode}) {
+  const organization = useOrganization();
+
+  return (
+    <NoProjectMessage organization={organization}>
+      <PageFiltersContainer>{children}</PageFiltersContainer>
+    </NoProjectMessage>
+  );
+}

--- a/static/app/views/uptime/uptimeIssues.tsx
+++ b/static/app/views/uptime/uptimeIssues.tsx
@@ -1,0 +1,57 @@
+import EmptyStateWarning from 'sentry/components/emptyStateWarning';
+import GroupList from 'sentry/components/issues/groupList';
+import Panel from 'sentry/components/panels/panel';
+import PanelBody from 'sentry/components/panels/panelBody';
+import {t} from 'sentry/locale';
+import {IssueCategory} from 'sentry/types/group';
+import type {Project} from 'sentry/types/project';
+import {getUtcDateString} from 'sentry/utils/dates';
+import useOrganization from 'sentry/utils/useOrganization';
+import usePageFilters from 'sentry/utils/usePageFilters';
+
+interface Props {
+  project: Project;
+}
+
+export function UptimeIssues({project}: Props) {
+  const organization = useOrganization();
+  const {selection} = usePageFilters();
+  const {start, end, period} = selection.datetime;
+  const timeProps =
+    start && end
+      ? {
+          start: getUtcDateString(start),
+          end: getUtcDateString(end),
+        }
+      : {
+          statsPeriod: period,
+        };
+
+  // TODO(davidenwang): Replace this with an actual query for the specific uptime alert rule
+  const query = `issue.category:${IssueCategory.UPTIME}`;
+
+  const emptyMessage = () => {
+    return (
+      <Panel>
+        <PanelBody>
+          <EmptyStateWarning>
+            <p>{t('No issues relating to this uptime alert have been found.')}</p>
+          </EmptyStateWarning>
+        </PanelBody>
+      </Panel>
+    );
+  };
+
+  return (
+    <GroupList
+      orgSlug={organization.slug}
+      queryParams={{
+        query,
+        project: project.id,
+        limit: 20,
+        ...timeProps,
+      }}
+      renderEmptyMessage={emptyMessage}
+    />
+  );
+}


### PR DESCRIPTION
Simple Uptime Alert Rule Details Page:
<img width="1270" alt="Screenshot 2024-08-01 at 11 05 18 PM" src="https://github.com/user-attachments/assets/73f8447a-35c8-416b-94ab-d5a7ac3d04a7">


The uptime issues are currently not tagged with any distinguishing information so I have a placeholder query for them.
The edit page is also not built out so the button is disabled

Everything is behind the uptime-rule-api feature flag

**Dependent PRs**:
- #75514
- #75309